### PR TITLE
Add `Invalid` variant for `AssetId`, `InternalAssetId` and `UntypedAssetId`

### DIFF
--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -330,6 +330,7 @@ impl<A: Asset> Assets<A> {
             AssetId::Uuid { uuid } => {
                 self.insert_with_uuid(uuid, asset);
             }
+            AssetId::Invalid => (),
         }
     }
 
@@ -352,6 +353,7 @@ impl<A: Asset> Assets<A> {
         match id.into() {
             AssetId::Index { index, .. } => self.dense_storage.get(index).is_some(),
             AssetId::Uuid { uuid } => self.hash_map.contains_key(&uuid),
+            AssetId::Invalid => false,
         }
     }
 
@@ -406,6 +408,7 @@ impl<A: Asset> Assets<A> {
         let index = match id {
             AssetId::Index { index, .. } => index.into(),
             AssetId::Uuid { uuid } => uuid.into(),
+            AssetId::Invalid => crate::InternalAssetId::Invalid,
         };
         Some(Handle::Strong(
             self.handle_provider.get_handle(index, false, None, None),
@@ -419,6 +422,7 @@ impl<A: Asset> Assets<A> {
         match id.into() {
             AssetId::Index { index, .. } => self.dense_storage.get(index),
             AssetId::Uuid { uuid } => self.hash_map.get(&uuid),
+            AssetId::Invalid => None,
         }
     }
 
@@ -430,6 +434,7 @@ impl<A: Asset> Assets<A> {
         let result = match id {
             AssetId::Index { index, .. } => self.dense_storage.get_mut(index),
             AssetId::Uuid { uuid } => self.hash_map.get_mut(&uuid),
+            AssetId::Invalid => None,
         };
         if result.is_some() {
             self.queued_events.push(AssetEvent::Modified { id });
@@ -456,6 +461,7 @@ impl<A: Asset> Assets<A> {
         match id {
             AssetId::Index { index, .. } => self.dense_storage.remove_still_alive(index),
             AssetId::Uuid { uuid } => self.hash_map.remove(&uuid),
+            AssetId::Invalid => None,
         }
     }
 
@@ -475,6 +481,7 @@ impl<A: Asset> Assets<A> {
         let existed = match id {
             AssetId::Index { index, .. } => self.dense_storage.remove_dropped(index).is_some(),
             AssetId::Uuid { uuid } => self.hash_map.remove(&uuid).is_some(),
+            AssetId::Invalid => false,
         };
 
         self.queued_events.push(AssetEvent::Unused { id });

--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -332,8 +332,18 @@ impl UntypedHandle {
     #[inline]
     pub fn type_id(&self) -> TypeId {
         match self {
-            UntypedHandle::Strong(handle) => handle.id.type_id(),
-            UntypedHandle::Weak(id) => id.type_id(),
+            UntypedHandle::Strong(handle) => {
+                let Some(type_id) = handle.id.type_id() else {
+                    unreachable!("This should never be called with an Invalid id.");
+                };
+                type_id
+            }
+            UntypedHandle::Weak(id) => {
+                let Some(type_id) = id.type_id() else {
+                    unreachable!("This should never be called with an Invalid id.");
+                };
+                type_id
+            }
         }
     }
 

--- a/crates/bevy_asset/src/id.rs
+++ b/crates/bevy_asset/src/id.rs
@@ -126,7 +126,9 @@ impl<A: Asset> Hash for AssetId<A> {
     #[inline]
     fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
         self.internal().hash(state);
-        TypeId::of::<A>().hash(state);
+        if !matches!(self, Self::Invalid) {
+            TypeId::of::<A>().hash(state);
+        }
     }
 }
 
@@ -517,6 +519,20 @@ mod tests {
             type_id: TypeId::of::<TestAsset>(),
             uuid: UUID_1,
         };
+
+        assert_eq!(
+            hash(&typed),
+            hash(&AssetId::<TestAsset>::try_from(untyped).unwrap())
+        );
+        assert_eq!(hash(&UntypedAssetId::from(typed)), hash(&untyped));
+        assert_eq!(hash(&typed), hash(&untyped));
+    }
+
+    /// Typed and Untyped `AssetIds` should be equivalently hashable to each other and themselves
+    #[test]
+    fn hashing_of_invalid() {
+        let typed = AssetId::<TestAsset>::Invalid;
+        let untyped = UntypedAssetId::Invalid;
 
         assert_eq!(
             hash(&typed),

--- a/crates/bevy_asset/src/server/info.rs
+++ b/crates/bevy_asset/src/server/info.rs
@@ -693,7 +693,9 @@ impl AssetInfos {
 
         pending_tasks.remove(&id);
 
-        let type_id = entry.key().type_id();
+        let Some(type_id) = entry.key().type_id() else {
+            unreachable!("This should never be called with an Invalid id.");
+        };
 
         let info = entry.remove();
         let Some(path) = &info.path else {

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -1634,9 +1634,12 @@ pub fn handle_internal_asset_events(world: &mut World) {
                     );
                 }
                 InternalAssetEvent::LoadedWithDependencies { id } => {
+                    let Some(type_id) = id.type_id() else {
+                        unreachable!("This should never be called with a Invalid id.");
+                    };
                     let sender = infos
                         .dependency_loaded_event_sender
-                        .get(&id.type_id())
+                        .get(&type_id)
                         .expect("Asset event sender should exist");
                     sender(world, id);
                     if let Some(info) = infos.get_mut(id) {
@@ -1655,10 +1658,13 @@ pub fn handle_internal_asset_events(world: &mut World) {
                         error: error.clone(),
                     });
 
+                    let Some(type_id) = id.type_id() else {
+                        unreachable!("This should never be called with an Invalid id.");
+                    };
                     // Send typed failure event
                     let sender = infos
                         .dependency_failed_event_sender
-                        .get(&id.type_id())
+                        .get(&type_id)
                         .expect("Asset failed event sender should exist");
                     sender(world, id, path, error);
                 }

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -415,7 +415,7 @@ where
 ///
 /// See the comments in [`RenderMaterialInstances::mesh_material`] for more
 /// information.
-static DUMMY_MESH_MATERIAL: AssetId<StandardMaterial> = AssetId::<StandardMaterial>::invalid();
+static DUMMY_MESH_MATERIAL: UntypedAssetId = UntypedAssetId::Invalid;
 
 /// A key uniquely identifying a specialized [`MaterialPipeline`].
 pub struct MaterialPipelineKey<M: Material> {
@@ -620,7 +620,7 @@ impl RenderMaterialInstances {
     pub(crate) fn mesh_material(&self, entity: MainEntity) -> UntypedAssetId {
         match self.instances.get(&entity) {
             Some(render_instance) => render_instance.asset_id,
-            None => DUMMY_MESH_MATERIAL.into(),
+            None => DUMMY_MESH_MATERIAL,
         }
     }
 }

--- a/crates/bevy_pbr/src/meshlet/instance_manager.rs
+++ b/crates/bevy_pbr/src/meshlet/instance_manager.rs
@@ -2,9 +2,8 @@ use super::{meshlet_mesh_manager::MeshletMeshManager, MeshletMesh, MeshletMesh3d
 use crate::{
     Material, MaterialBindingId, MeshFlags, MeshTransforms, MeshUniform, NotShadowCaster,
     NotShadowReceiver, PreviousGlobalTransform, RenderMaterialBindings, RenderMaterialInstances,
-    StandardMaterial,
 };
-use bevy_asset::{AssetEvent, AssetId, AssetServer, Assets, UntypedAssetId};
+use bevy_asset::{AssetEvent, AssetServer, Assets, UntypedAssetId};
 use bevy_ecs::{
     entity::{Entities, Entity, EntityHashMap},
     event::EventReader,
@@ -113,16 +112,15 @@ impl InstanceManager {
         };
 
         let mesh_material = mesh_material_ids.mesh_material(instance);
-        let mesh_material_binding_id =
-            if mesh_material != AssetId::<StandardMaterial>::invalid().untyped() {
-                render_material_bindings
-                    .get(&mesh_material)
-                    .cloned()
-                    .unwrap_or_default()
-            } else {
-                // Use a dummy binding ID if the mesh has no material
-                MaterialBindingId::default()
-            };
+        let mesh_material_binding_id = if mesh_material != UntypedAssetId::Invalid {
+            render_material_bindings
+                .get(&mesh_material)
+                .cloned()
+                .unwrap_or_default()
+        } else {
+            // Use a dummy binding ID if the mesh has no material
+            MaterialBindingId::default()
+        };
 
         let mesh_uniform = MeshUniform::new(
             &transforms,

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -1,6 +1,6 @@
 use crate::material_bind_groups::{MaterialBindGroupIndex, MaterialBindGroupSlot};
 use allocator::MeshAllocator;
-use bevy_asset::{load_internal_asset, AssetId};
+use bevy_asset::{load_internal_asset, AssetId, UntypedAssetId};
 use bevy_core_pipeline::{
     core_3d::{AlphaMask3d, Opaque3d, Transmissive3d, Transparent3d, CORE_3D_DEPTH_FORMAT},
     deferred::{AlphaMask3dDeferred, Opaque3dDeferred},
@@ -1131,19 +1131,18 @@ impl RenderMeshInstanceGpuBuilder {
         // yet loaded. In that case, add the mesh to
         // `meshes_to_reextract_next_frame` and bail.
         let mesh_material = mesh_material_ids.mesh_material(entity);
-        let mesh_material_binding_id =
-            if mesh_material != AssetId::<StandardMaterial>::invalid().untyped() {
-                match render_material_bindings.get(&mesh_material) {
-                    Some(binding_id) => *binding_id,
-                    None => {
-                        meshes_to_reextract_next_frame.insert(entity);
-                        return None;
-                    }
+        let mesh_material_binding_id = if mesh_material != UntypedAssetId::Invalid {
+            match render_material_bindings.get(&mesh_material) {
+                Some(binding_id) => *binding_id,
+                None => {
+                    meshes_to_reextract_next_frame.insert(entity);
+                    return None;
                 }
-            } else {
-                // Use a dummy material binding ID.
-                MaterialBindingId::default()
-            };
+            }
+        } else {
+            // Use a dummy material binding ID.
+            MaterialBindingId::default()
+        };
         self.shared.material_bindings_index = mesh_material_binding_id;
 
         let lightmap_slot = match render_lightmaps.render_lightmaps.get(&entity) {

--- a/examples/shader/custom_phase_item.rs
+++ b/examples/shader/custom_phase_item.rs
@@ -8,6 +8,7 @@
 //! for better reuse of parts of Bevy's built-in mesh rendering logic.
 
 use bevy::{
+    asset::UntypedAssetId,
     core_pipeline::core_3d::{Opaque3d, Opaque3dBatchSetKey, Opaque3dBinKey, CORE_3D_DEPTH_FORMAT},
     ecs::{
         component::Tick,
@@ -35,7 +36,6 @@ use bevy::{
         Render, RenderApp, RenderSet,
     },
 };
-use bevy_asset::UntypedAssetId;
 use bytemuck::{Pod, Zeroable};
 
 /// A marker component that represents an entity that is to be rendered using

--- a/examples/shader/custom_phase_item.rs
+++ b/examples/shader/custom_phase_item.rs
@@ -35,6 +35,7 @@ use bevy::{
         Render, RenderApp, RenderSet,
     },
 };
+use bevy_asset::UntypedAssetId;
 use bytemuck::{Pod, Zeroable};
 
 /// A marker component that represents an entity that is to be rendered using
@@ -275,7 +276,7 @@ fn queue_custom_phase_item(
                     index_slab: None,
                 },
                 Opaque3dBinKey {
-                    asset_id: AssetId::<Mesh>::invalid().untyped(),
+                    asset_id: UntypedAssetId::Invalid,
                 },
                 entity,
                 InputUniformIndex::default(),

--- a/examples/shader/specialized_mesh_pipeline.rs
+++ b/examples/shader/specialized_mesh_pipeline.rs
@@ -42,6 +42,7 @@ use bevy::{
         Render, RenderApp, RenderSet,
     },
 };
+use bevy_asset::UntypedAssetId;
 
 const SHADER_ASSET_PATH: &str = "shaders/specialized_mesh_pipeline.wgsl";
 
@@ -418,11 +419,8 @@ fn queue_custom_mesh_pipeline(
                     index_slab: None,
                     lightmap_slab: None,
                 },
-                // The asset ID is arbitrary; we simply use [`AssetId::invalid`],
-                // but you can use anything you like. Note that the asset ID need
-                // not be the ID of a [`Mesh`].
                 Opaque3dBinKey {
-                    asset_id: AssetId::<Mesh>::invalid().untyped(),
+                    asset_id: UntypedAssetId::Invalid,
                 },
                 (render_entity, visible_entity),
                 mesh_instance.current_uniform_index,

--- a/examples/shader/specialized_mesh_pipeline.rs
+++ b/examples/shader/specialized_mesh_pipeline.rs
@@ -7,6 +7,7 @@
 //! [`SpecializedMeshPipeline`] let's you customize the entire pipeline used when rendering a mesh.
 
 use bevy::{
+    asset::UntypedAssetId,
     core_pipeline::core_3d::{Opaque3d, Opaque3dBatchSetKey, Opaque3dBinKey, CORE_3D_DEPTH_FORMAT},
     ecs::{component::Tick, system::StaticSystemParam},
     math::{vec3, vec4},
@@ -37,12 +38,13 @@ use bevy::{
             RenderPipelineDescriptor, SpecializedMeshPipeline, SpecializedMeshPipelineError,
             SpecializedMeshPipelines, TextureFormat, VertexState,
         },
-        view::NoIndirectDrawing,
-        view::{self, ExtractedView, RenderVisibleEntities, ViewTarget, VisibilityClass},
+        view::{
+            self, ExtractedView, NoIndirectDrawing, RenderVisibleEntities, ViewTarget,
+            VisibilityClass,
+        },
         Render, RenderApp, RenderSet,
     },
 };
-use bevy_asset::UntypedAssetId;
 
 const SHADER_ASSET_PATH: &str = "shaders/specialized_mesh_pipeline.wgsl";
 


### PR DESCRIPTION
# Objective

With the restructuring of the rendering crates, some types now live in different crates, and this causes some tests for an invalid asset id to be impossible due to the missing type.

e.g. `bevy_render_3d` relies on `bevy_pbr::StandardMaterial`, but `bevy_pbr` relies on `bevy_render_3d` as a whole.

That way it is impossible to create an invalid `AssetId`.

## Solution

Create `Invalid` variant for `AssetId`, `InternalAssetId`, and `UntypedAssetId`, the `UntypedAssetId` does not store an `TypeId`.

## Testing

`cargo run -p ci` and some of the examples

## Alternative

Make locations that store an `AssetId` take an `Option` instead. Same for `UntypedAssetId`.

## TODO

- [ ] Garantee that none of the `unreachable`s are reacheable