### PR TITLE
Fixed erroneous warning for removing one-to-one Relationships

### DIFF
--- a/crates/bevy_ecs/src/relationship/relationship_source_collection.rs
+++ b/crates/bevy_ecs/src/relationship/relationship_source_collection.rs
@@ -326,7 +326,7 @@ impl<const N: usize> RelationshipSourceCollection for SmallVec<[Entity; N]> {
 }
 
 impl RelationshipSourceCollection for Entity {
-    type SourceIter<'a> = core::iter::Once<Entity>;
+    type SourceIter<'a> = core::option::IntoIter<Entity>;
 
     fn new() -> Self {
         Entity::PLACEHOLDER
@@ -355,7 +355,11 @@ impl RelationshipSourceCollection for Entity {
     }
 
     fn iter(&self) -> Self::SourceIter<'_> {
-        core::iter::once(*self)
+        if *self == Entity::PLACEHOLDER {
+            return None.into_iter();
+        }
+
+        Some(*self).into_iter()
     }
 
     fn len(&self) -> usize {


### PR DESCRIPTION
# Objective

- Fix "Tried to despawn non-existant entity PLACEHOLDER" getting raised every time a one-to-one `Relationship` is removed

## Solution

- `Entity`'s `RelationshipSourceCollection::iter` function was modified to return a `core::option::IntoIter` instead of a `core::iter::Once`, such that it returns an empty iterator when the Entity is `Entity::PLACEHOLDER`, and a single-element iterator when it is not.

## Testing

<details><summary>Minimum Reproduction</summary>
<p>

Here is a minimum reproduction `main.rs` to showcase the original bug this fixes. Press `E` to spawn a new relationship and `T` to sever it. It should print a warning `Tried to despawn non-existant entity PLACEHOLDER` for every relationship you've spawned.

```rust
use bevy::{input::common_conditions::input_just_pressed, prelude::*};

#[derive(Component)]
#[relationship(relationship_target = Bar)]
pub struct Foo(pub Entity);

#[derive(Component)]
#[relationship_target(relationship = Foo)]
pub struct Bar(Entity);

fn add_entities(
    mut commands: Commands,
) {
    info!("Spawning...");
    for _ in 0..5 {
        let bar = commands.spawn_empty().id();
        
        commands.spawn(Foo(bar));
    }
}

fn remove_entities(
    mut commands: Commands,
    query: Query<Entity, With<Foo>>,
) {
    info!("Clearing...");
    for entity in &query {
        commands.entity(entity).remove::<Foo>();
    }
}

fn main() {
    App::new()
        .add_plugins(DefaultPlugins)
        .add_systems(Update, (
            add_entities.run_if(input_just_pressed(KeyCode::KeyE)),
            remove_entities.run_if(input_just_pressed(KeyCode::KeyT)),
        ))
        .run();
}
```

</p>
</details> 

Further testing should focus on one-to-one Relationships, but ideally no regressions should appear, as the rest of `Entity`'s `RelationshipSourceCollection` implementation correctly behaves as an empty collection when the entity is `Entity::PLACEHOLDER` (i.e. `len() == 0`)

