### PR TITLE
don't disable std in bevy_dylib

### DIFF
--- a/crates/bevy_dylib/src/lib.rs
+++ b/crates/bevy_dylib/src/lib.rs
@@ -53,8 +53,6 @@
 //! use bevy_dylib;
 //! ```
 
-#![no_std]
-
 // Force linking of the main bevy crate
 #[expect(
     unused_imports,


### PR DESCRIPTION
# Objective

- `bevy_dylib` currently doesn't build independently
```
cargo build -p bevy_dylib
   Compiling bevy_dylib v0.16.0-rc.4 (/crates/bevy_dylib)
error: no global memory allocator found but one is required; link to std or add `#[global_allocator]` to a static item that implements the GlobalAlloc trait

error: `#[panic_handler]` function required, but not found

error: unwinding panics are not supported without std
  |
  = help: using nightly cargo, use -Zbuild-std with panic="abort" to avoid unwinding
  = note: since the core library is usually precompiled with panic="unwind", rebuilding your crate with panic="abort" may not be enough to fix the problem

error: could not compile `bevy_dylib` (lib) due to 3 previous errors
```

## Solution

- remove `#![no_std]` from `bevy_dylib`

## Testing

- it builds now