### PR TITLE
Derive `clone_behavior` for `Components`

### DIFF
--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -570,7 +570,7 @@ fn parse_component_attr(ast: &DeriveInput) -> Result<Attrs> {
 
     if attrs.relationship_target.is_some() && attrs.clone_behavior.is_some() {
         return Err(syn::Error::new_spanned(
-                &attrs.clone_behavior, // or any token from the attribute
+                &attrs.clone_behavior, 
                 "A Relationship Target already has it's own clone behavior, please remove `clone_behavior = ...`",
             ).into());
     }

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -569,8 +569,8 @@ fn parse_component_attr(ast: &DeriveInput) -> Result<Attrs> {
     }
 
     if attrs.relationship_target.is_some() && attrs.clone_behavior.is_some() {
-        return Err(syn::Error::new_spanned(
-                &attrs.clone_behavior,
+        return Err(syn::Error::new(
+                attrs.clone_behavior.span(),
                 "A Relationship Target already has it's own clone behavior, please remove `clone_behavior = ...`",
             ));
     }

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -568,6 +568,13 @@ fn parse_component_attr(ast: &DeriveInput) -> Result<Attrs> {
         }
     }
 
+    if attrs.relationship_target.is_some() && attrs.clone_behavior.is_some() {
+        return Err(syn::Error::new_spanned(
+                &attrs.clone_behavior, // or any token from the attribute
+                "A Relationship Target already has it's own clone behavior, please remove `clone_behavior = ...`",
+            ).into());
+    }
+
     Ok(attrs)
 }
 

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -571,7 +571,7 @@ fn parse_component_attr(ast: &DeriveInput) -> Result<Attrs> {
     if attrs.relationship_target.is_some() && attrs.clone_behavior.is_some() {
         return Err(syn::Error::new(
                 attrs.clone_behavior.span(),
-                "A Relationship Target already has it's own clone behavior, please remove `clone_behavior = ...`",
+                format!("A Relationship Target already has it's own clone behavior, please remove `clone_behavior = {}`", attrs.clone_behavior.as_ref().unwrap().to_token_stream()),
             ));
     }
 

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -571,7 +571,7 @@ fn parse_component_attr(ast: &DeriveInput) -> Result<Attrs> {
     if attrs.relationship_target.is_some() && attrs.clone_behavior.is_some() {
         return Err(syn::Error::new(
                 attrs.clone_behavior.span(),
-                format!("A Relationship Target already has it's own clone behavior, please remove `clone_behavior = {}`", attrs.clone_behavior.as_ref().unwrap().to_token_stream()),
+                "A Relationship Target already has its own clone behavior, please remove `clone_behavior = ...`",
             ));
     }
 

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -572,7 +572,7 @@ fn parse_component_attr(ast: &DeriveInput) -> Result<Attrs> {
         return Err(syn::Error::new_spanned(
                 &attrs.clone_behavior,
                 "A Relationship Target already has it's own clone behavior, please remove `clone_behavior = ...`",
-            ).into());
+            ));
     }
 
     Ok(attrs)

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -251,6 +251,8 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
 
     let clone_behavior = if relationship_target.is_some() {
         quote!(#bevy_ecs_path::component::ComponentCloneBehavior::Custom(#bevy_ecs_path::relationship::clone_relationship_target::<Self>))
+    } else if let Some(behavior) = attrs.clone_behavior {
+        quote!(#bevy_ecs_path::component::ComponentCloneBehavior::#behavior)
     } else {
         quote!(
             use #bevy_ecs_path::component::{DefaultCloneBehaviorBase, DefaultCloneBehaviorViaClone};
@@ -396,6 +398,7 @@ pub const ON_REMOVE: &str = "on_remove";
 pub const ON_DESPAWN: &str = "on_despawn";
 
 pub const IMMUTABLE: &str = "immutable";
+pub const CLONE_BEHAVIOR: &str = "clone_behavior";
 
 /// All allowed attribute value expression kinds for component hooks
 #[derive(Debug)]
@@ -458,6 +461,7 @@ struct Attrs {
     relationship: Option<Relationship>,
     relationship_target: Option<RelationshipTarget>,
     immutable: bool,
+    clone_behavior: Option<Expr>,
 }
 
 #[derive(Clone, Copy)]
@@ -496,6 +500,7 @@ fn parse_component_attr(ast: &DeriveInput) -> Result<Attrs> {
         relationship: None,
         relationship_target: None,
         immutable: false,
+        clone_behavior: None,
     };
 
     let mut require_paths = HashSet::new();
@@ -530,6 +535,9 @@ fn parse_component_attr(ast: &DeriveInput) -> Result<Attrs> {
                     Ok(())
                 } else if nested.path.is_ident(IMMUTABLE) {
                     attrs.immutable = true;
+                    Ok(())
+                } else if nested.path.is_ident(CLONE_BEHAVIOR) {
+                    attrs.clone_behavior = Some(nested.value()?.parse()?);
                     Ok(())
                 } else {
                     Err(nested.error("Unsupported attribute"))

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -570,7 +570,7 @@ fn parse_component_attr(ast: &DeriveInput) -> Result<Attrs> {
 
     if attrs.relationship_target.is_some() && attrs.clone_behavior.is_some() {
         return Err(syn::Error::new_spanned(
-                &attrs.clone_behavior, 
+                &attrs.clone_behavior,
                 "A Relationship Target already has it's own clone behavior, please remove `clone_behavior = ...`",
             ).into());
     }

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -427,9 +427,10 @@ use thiserror::Error;
 /// Your options are the functions and variants of [`ComponentCloneBehavior`]
 /// See [Handlers section of `EntityClonerBuilder`](crate::entity::EntityClonerBuilder#handlers) to understand how this affects handler priority.
 /// ```
+/// # use bevy_ecs::prelude::*;
 ///
 /// #[derive(Component)]
-/// #[Component(clone_behavior = Ignore)]
+/// #[component(clone_behavior = Ignore)]
 /// struct MyComponent;
 ///
 /// ```

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -418,6 +418,20 @@ use thiserror::Error;
 ///         println!("{message}");
 ///     }
 /// }
+///
+/// ```
+/// # Setting the clone behavior
+///
+/// You can specify how the [`Component`] is cloned when deriving it.
+///
+/// Your options are the functions and variants of [`ComponentCloneBehavior`]
+/// See [Handlers section of `EntityClonerBuilder`](crate::entity::EntityClonerBuilder#handlers) to understand how this affects handler priority.
+/// ```
+///
+/// #[derive(Component)]
+/// #[component(clone_behavior = Ignore)]
+/// struct MyComponent;
+///
 /// ```
 ///
 /// # Implementing the trait for foreign types

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -429,7 +429,7 @@ use thiserror::Error;
 /// ```
 ///
 /// #[derive(Component)]
-/// #[component(clone_behavior = Ignore)]
+/// #[Component(clone_behavior = Ignore)]
 /// struct MyComponent;
 ///
 /// ```

--- a/crates/bevy_ecs/src/entity/clone_entities.rs
+++ b/crates/bevy_ecs/src/entity/clone_entities.rs
@@ -324,16 +324,10 @@ impl<'a, 'b> ComponentCloneCtx<'a, 'b> {
 /// ```
 /// # use bevy_ecs::prelude::*;
 /// # use bevy_ecs::component::{StorageType, ComponentCloneBehavior, Mutable};
-/// #[derive(Clone)]
+/// #[derive(Clone, Component)]
+/// #[component(clone_behavior = clone::<Self>())]
 /// struct SomeComponent;
 ///
-/// impl Component for SomeComponent {
-///     const STORAGE_TYPE: StorageType = StorageType::Table;
-///     type Mutability = Mutable;
-///     fn clone_behavior() -> ComponentCloneBehavior {
-///         ComponentCloneBehavior::clone::<Self>()
-///     }
-/// }
 /// ```
 ///
 /// # Clone Behaviors

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -2846,6 +2846,7 @@ mod tests {
     #[test]
     fn clone_entities() {
         use crate::entity::{ComponentCloneCtx, SourceComponent};
+
         #[derive(Component)]
         #[component(clone_behavior = Ignore)]
         struct IgnoreClone;

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -2862,6 +2862,6 @@ mod tests {
         #[component(clone_behavior = clone::<Self>())]
         struct CloneFunction;
 
-        fn custom_clone(source: &SourceComponent, ctx: &mut ComponentCloneCtx) {}
+        fn custom_clone(_source: &SourceComponent, _ctx: &mut ComponentCloneCtx) {}
     }
 }

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -2842,4 +2842,26 @@ mod tests {
     )]
     #[derive(Component)]
     struct MyEntitiesTuple(#[entities] Vec<Entity>, #[entities] Entity, usize);
+
+    #[test]
+    fn clone_entities() {
+        use crate::entity::{ComponentCloneCtx, SourceComponent};
+        #[derive(Component)]
+        #[component(clone_behavior = Ignore)]
+        struct IgnoreClone;
+
+        #[derive(Component)]
+        #[component(clone_behavior = Default)]
+        struct DefaultClone;
+
+        #[derive(Component)]
+        #[component(clone_behavior = Custom(custom_clone))]
+        struct CustomClone;
+
+        #[derive(Component, Clone)]
+        #[component(clone_behavior = clone::<Self>())]
+        struct CloneFunction;
+
+        fn custom_clone(source: &SourceComponent, ctx: &mut ComponentCloneCtx) {}
+    }
 }

--- a/crates/bevy_render/src/sync_world.rs
+++ b/crates/bevy_render/src/sync_world.rs
@@ -1,6 +1,5 @@
 use bevy_app::Plugin;
 use bevy_derive::{Deref, DerefMut};
-use bevy_ecs::component::{ComponentCloneBehavior, Mutable, StorageType};
 use bevy_ecs::entity::EntityHash;
 use bevy_ecs::{
     component::Component,

--- a/crates/bevy_render/src/sync_world.rs
+++ b/crates/bevy_render/src/sync_world.rs
@@ -127,22 +127,13 @@ pub struct SyncToRenderWorld;
 /// Component added on the main world entities that are synced to the Render World in order to keep track of the corresponding render world entity.
 ///
 /// Can also be used as a newtype wrapper for render world entities.
-#[derive(Deref, Copy, Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Deref, Copy, Clone, Debug, Eq, Hash, PartialEq, Component)]
+#[component(clone_behavior = Ignore)]
 pub struct RenderEntity(Entity);
 impl RenderEntity {
     #[inline]
     pub fn id(&self) -> Entity {
         self.0
-    }
-}
-
-impl Component for RenderEntity {
-    const STORAGE_TYPE: StorageType = StorageType::Table;
-
-    type Mutability = Mutable;
-
-    fn clone_behavior() -> ComponentCloneBehavior {
-        ComponentCloneBehavior::Ignore
     }
 }
 


### PR DESCRIPTION
Allow Derive(Component) to specify a clone_behavior

```rust
#[derive(Component)]
#[component(clone_behavior = Ignore)]
MyComponent;
```

