### PR TITLE
Fix the extended_material example on WebGL2

### DIFF
--- a/assets/shaders/extended_material.wgsl
+++ b/assets/shaders/extended_material.wgsl
@@ -16,8 +16,9 @@
 #endif
 
 struct MyExtendedMaterial {
-    // WebGL2 structs must be 16 byte aligned. We only use the `x` field
-    quantize_steps: vec4<u32>,
+    quantize_steps: u32,
+    // Web examples WebGL2 support: structs must be 16 byte aligned.
+    _webgl2_padding: vec3<f32>
 }
 
 @group(2) @binding(100)
@@ -46,7 +47,7 @@ fn fragment(
     out.color = apply_pbr_lighting(pbr_input);
 
     // we can optionally modify the lit color before post-processing is applied
-    out.color = vec4<f32>(vec4<u32>(out.color * f32(my_extended_material.quantize_steps.x))) / f32(my_extended_material.quantize_steps.x);
+    out.color = vec4<f32>(vec4<u32>(out.color * f32(my_extended_material.quantize_steps))) / f32(my_extended_material.quantize_steps);
 
     // apply in-shader post processing (fog, alpha-premultiply, and also tonemapping, debanding if the camera is non-hdr)
     // note this does not include fullscreen postprocessing effects like bloom.

--- a/assets/shaders/extended_material.wgsl
+++ b/assets/shaders/extended_material.wgsl
@@ -16,7 +16,8 @@
 #endif
 
 struct MyExtendedMaterial {
-    quantize_steps: u32,
+    // WebGL2 structs must be 16 byte aligned. We only use the `x` field
+    quantize_steps: vec4<u32>,
 }
 
 @group(2) @binding(100)
@@ -45,7 +46,7 @@ fn fragment(
     out.color = apply_pbr_lighting(pbr_input);
 
     // we can optionally modify the lit color before post-processing is applied
-    out.color = vec4<f32>(vec4<u32>(out.color * f32(my_extended_material.quantize_steps))) / f32(my_extended_material.quantize_steps);
+    out.color = vec4<f32>(vec4<u32>(out.color * f32(my_extended_material.quantize_steps.x))) / f32(my_extended_material.quantize_steps.x);
 
     // apply in-shader post processing (fog, alpha-premultiply, and also tonemapping, debanding if the camera is non-hdr)
     // note this does not include fullscreen postprocessing effects like bloom.

--- a/assets/shaders/extended_material.wgsl
+++ b/assets/shaders/extended_material.wgsl
@@ -17,8 +17,12 @@
 
 struct MyExtendedMaterial {
     quantize_steps: u32,
+#ifdef SIXTEEN_BYTE_ALIGNMENT
     // Web examples WebGL2 support: structs must be 16 byte aligned.
-    _webgl2_padding: vec3<f32>
+    _webgl2_padding_8b: u32,
+    _webgl2_padding_12b: u32,
+    _webgl2_padding_16b: u32,
+#endif
 }
 
 @group(2) @binding(100)

--- a/examples/shader/extended_material.rs
+++ b/examples/shader/extended_material.rs
@@ -69,22 +69,22 @@ fn rotate_things(mut q: Query<&mut Transform, With<Rotate>>, time: Res<Time>) {
     }
 }
 
-#[derive(Asset, AsBindGroup, Reflect, Debug, Clone)]
+#[derive(Asset, AsBindGroup, Reflect, Debug, Clone, Default)]
 struct MyExtension {
     // We need to ensure that the bindings of the base material and the extension do not conflict,
     // so we start from binding slot 100, leaving slots 0-99 for the base material.
-    //
-    // WebGL2 structs must be 16 byte aligned. We only use the `x` field
     #[uniform(100)]
-    quantize_steps: UVec4,
+    quantize_steps: u32,
+
+    // Web examples WebGL2 support: structs must be 16 byte aligned.
+    #[uniform(100)]
+    _webgl2_padding: Vec3,
 }
 impl MyExtension {
     fn new(quantize_steps: u32) -> Self {
         Self {
-            quantize_steps: UVec4 {
-                x: quantize_steps,
-                ..default()
-            },
+            quantize_steps,
+            ..default()
         }
     }
 }

--- a/examples/shader/extended_material.rs
+++ b/examples/shader/extended_material.rs
@@ -75,10 +75,16 @@ struct MyExtension {
     // so we start from binding slot 100, leaving slots 0-99 for the base material.
     #[uniform(100)]
     quantize_steps: u32,
-
     // Web examples WebGL2 support: structs must be 16 byte aligned.
+    #[cfg(feature = "webgl2")]
     #[uniform(100)]
-    _webgl2_padding: Vec3,
+    _webgl2_padding_8b: u32,
+    #[cfg(feature = "webgl2")]
+    #[uniform(100)]
+    _webgl2_padding_12b: u32,
+    #[cfg(feature = "webgl2")]
+    #[uniform(100)]
+    _webgl2_padding_16b: u32,
 }
 impl MyExtension {
     fn new(quantize_steps: u32) -> Self {

--- a/examples/shader/extended_material.rs
+++ b/examples/shader/extended_material.rs
@@ -41,7 +41,7 @@ fn setup(
                 // change the above to `OpaqueRendererMethod::Deferred` or add the `DefaultOpaqueRendererMethod` resource.
                 ..Default::default()
             },
-            extension: MyExtension { quantize_steps: 3 },
+            extension: MyExtension::new(1),
         })),
         Transform::from_xyz(0.0, 0.5, 0.0),
     ));
@@ -69,12 +69,24 @@ fn rotate_things(mut q: Query<&mut Transform, With<Rotate>>, time: Res<Time>) {
     }
 }
 
-#[derive(Asset, AsBindGroup, Reflect, Debug, Clone)]
+#[derive(Asset, AsBindGroup, Reflect, Debug, Clone, Default)]
 struct MyExtension {
     // We need to ensure that the bindings of the base material and the extension do not conflict,
     // so we start from binding slot 100, leaving slots 0-99 for the base material.
+    //
+    // WebGL2 structs must be 16 byte aligned. We only use the `x` field
     #[uniform(100)]
-    quantize_steps: u32,
+    quantize_steps: UVec4,
+}
+impl MyExtension {
+    fn new(quantize_steps: u32) -> Self {
+        Self {
+            quantize_steps: UVec4 {
+                x: quantize_steps,
+                ..default()
+            },
+        }
+    }
 }
 
 impl MaterialExtension for MyExtension {

--- a/examples/shader/extended_material.rs
+++ b/examples/shader/extended_material.rs
@@ -69,7 +69,7 @@ fn rotate_things(mut q: Query<&mut Transform, With<Rotate>>, time: Res<Time>) {
     }
 }
 
-#[derive(Asset, AsBindGroup, Reflect, Debug, Clone, Default)]
+#[derive(Asset, AsBindGroup, Reflect, Debug, Clone)]
 struct MyExtension {
     // We need to ensure that the bindings of the base material and the extension do not conflict,
     // so we start from binding slot 100, leaving slots 0-99 for the base material.


### PR DESCRIPTION
# Objective

- Fixes #13872 (also mentioned in #17167)

## Solution

- Added conditional padding fields to the shader uniform

## Alternatives

### 1- Use a UVec4

Replace the `u32` field in `MyExtension` by a `UVec4` and only use the `x` coordinate.

(This was the original approach, but for consistency with the rest of the codebase, separate padding fields seem to be preferred)

### 2- Don't fix it, unlist it

While the fix is quite simple, it does muddy the waters a tiny bit due to `quantize_steps` now being a UVec4 instead of a simple u32. We could simply remove this example from the examples that support WebGL2.

## Testing

- Ran the example locally on WebGL2 (and native Vulkan) successfully
