### PR TITLE
Mark render assets as modified when removed from the asset server

### DIFF
--- a/crates/bevy_render/src/render_asset.rs
+++ b/crates/bevy_render/src/render_asset.rs
@@ -246,10 +246,6 @@ pub(crate) fn extract_render_asset<A: RenderAsset>(
             let mut modified = <HashSet<_>>::default();
 
             for event in events.read() {
-                #[expect(
-                    clippy::match_same_arms,
-                    reason = "LoadedWithDependencies is marked as a TODO, so it's likely this will no longer lint soon."
-                )]
                 match event {
                     AssetEvent::Added { id } => {
                         needs_extracting.insert(*id);

--- a/crates/bevy_render/src/render_asset.rs
+++ b/crates/bevy_render/src/render_asset.rs
@@ -263,7 +263,7 @@ pub(crate) fn extract_render_asset<A: RenderAsset>(
                         // when it's final handle is dropped triggering an `AssetEvent::Unused`
                         // event. However, removal without unused can happen when the asset
                         // is explicitly removed from the asset server and re-added by the user.
-                        // We mark the assset as modified in this case to ensure that
+                        // We mark the asset as modified in this case to ensure that
                         // any necessary render world bookkeeping still runs.
 
                         // TODO: consider removing this check and just emitting Unused after


### PR DESCRIPTION
# Objective

Fixes #18808

## Solution

When an asset emits a removed event, mark it as modified in the render world to ensure any appropriate bookkeeping runs as necessary.