### PR TITLE
Scoped EntityRef/Mut 🔬

### DIFF
--- a/crates/bevy_ecs/src/entity/clone_entities.rs
+++ b/crates/bevy_ecs/src/entity/clone_entities.rs
@@ -10,7 +10,7 @@ use crate::{
     entity::{hash_map::EntityHashMap, Entities, Entity, EntityMapper},
     query::DebugCheckedUnwrap,
     relationship::RelationshipHookMode,
-    world::World,
+    world::{Full, World},
 };
 
 /// Provides read access to the source component (the component being cloned) in a [`ComponentCloneFn`].
@@ -500,8 +500,11 @@ impl EntityCloner {
                 // SAFETY:
                 // - There are no other mutable references to source entity.
                 // - `component` is from `source_entity`'s archetype
-                let source_component_ptr =
-                    unsafe { source_entity.get_by_id(component).debug_checked_unwrap() };
+                let source_component_ptr = unsafe {
+                    source_entity
+                        .get_by_id(Full, component)
+                        .debug_checked_unwrap()
+                };
 
                 let source_component = SourceComponent {
                     info,

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -8,7 +8,7 @@ use crate::{
     prelude::*,
     query::DebugCheckedUnwrap,
     system::{IntoObserverSystem, ObserverSystem},
-    world::DeferredWorld,
+    world::{DeferredWorld, Only},
 };
 use bevy_ptr::PtrMut;
 
@@ -363,7 +363,7 @@ fn observer_system_runner<E: Event, B: Bundle, S: ObserverSystem<E, B>>(
     // SAFETY: Observer was triggered so must have an `ObserverState`
     let mut state = unsafe {
         observer_cell
-            .get_mut::<ObserverState>()
+            .get_mut::<ObserverState>(Only::<ObserverState>::default())
             .debug_checked_unwrap()
     };
 
@@ -377,7 +377,7 @@ fn observer_system_runner<E: Event, B: Bundle, S: ObserverSystem<E, B>>(
     // SAFETY: Observer was triggered so must have an `Observer` component.
     let error_handler = unsafe {
         observer_cell
-            .get::<Observer>()
+            .get::<Observer>(Only::<Observer>::default())
             .debug_checked_unwrap()
             .error_handler
             .debug_checked_unwrap()
@@ -393,7 +393,9 @@ fn observer_system_runner<E: Event, B: Bundle, S: ObserverSystem<E, B>>(
     // - observer was triggered so must have an `Observer` component.
     // - observer cannot be dropped or mutated until after the system pointer is already dropped.
     let system: *mut dyn ObserverSystem<E, B> = unsafe {
-        let mut observe = observer_cell.get_mut::<Observer>().debug_checked_unwrap();
+        let mut observe = observer_cell
+            .get_mut::<Observer>(Only::<Observer>::default())
+            .debug_checked_unwrap();
         let system = observe.system.downcast_mut::<S>().unwrap();
         &mut *system
     };

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -8,7 +8,7 @@ use crate::{
     storage::{ComponentSparseSet, Table, TableRow},
     world::{
         unsafe_world_cell::UnsafeWorldCell, EntityMut, EntityMutExcept, EntityRef, EntityRefExcept,
-        FilteredEntityMut, FilteredEntityRef, Mut, Ref, World,
+        Except, FilteredEntityMut, FilteredEntityRef, Full, Mut, Partial, Ref, World,
     },
 };
 use bevy_ptr::{ThinSlicePtr, UnsafeCellDeref};
@@ -547,7 +547,7 @@ unsafe impl<'a> QueryData for EntityRef<'a> {
         // SAFETY: `fetch` must be called with an entity that exists in the world
         let cell = unsafe { world.get_entity(entity).debug_checked_unwrap() };
         // SAFETY: Read-only access to every component has been registered.
-        unsafe { EntityRef::new(cell) }
+        unsafe { EntityRef::new(cell, Full) }
     }
 }
 
@@ -721,7 +721,7 @@ unsafe impl<'a> QueryData for FilteredEntityRef<'a> {
         // SAFETY: `fetch` must be called with an entity that exists in the world
         let cell = unsafe { world.get_entity(entity).debug_checked_unwrap() };
         // SAFETY: mutable access to every component has been registered.
-        unsafe { FilteredEntityRef::new(cell, access.clone()) }
+        unsafe { FilteredEntityRef::new(cell, Partial(access.clone())) }
     }
 }
 
@@ -912,7 +912,7 @@ where
         _: TableRow,
     ) -> Self::Item<'w> {
         let cell = world.get_entity(entity).unwrap();
-        EntityRefExcept::new(cell)
+        EntityRefExcept::new(cell, Except::<B>::default())
     }
 }
 

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -628,7 +628,7 @@ unsafe impl<'a> QueryData for EntityMut<'a> {
         // SAFETY: `fetch` must be called with an entity that exists in the world
         let cell = unsafe { world.get_entity(entity).debug_checked_unwrap() };
         // SAFETY: mutable access to every component has been registered.
-        unsafe { EntityMut::new(cell) }
+        unsafe { EntityMut::new(cell, Full) }
     }
 }
 
@@ -816,7 +816,7 @@ unsafe impl<'a> QueryData for FilteredEntityMut<'a> {
         // SAFETY: `fetch` must be called with an entity that exists in the world
         let cell = unsafe { world.get_entity(entity).debug_checked_unwrap() };
         // SAFETY: mutable access to every component has been registered.
-        unsafe { FilteredEntityMut::new(cell, access.clone()) }
+        unsafe { FilteredEntityMut::new(cell, Partial(access.clone())) }
     }
 }
 
@@ -1013,7 +1013,7 @@ where
         _: TableRow,
     ) -> Self::Item<'w> {
         let cell = world.get_entity(entity).unwrap();
-        EntityMutExcept::new(cell)
+        EntityMutExcept::new(cell, Except::<B>::default())
     }
 }
 

--- a/crates/bevy_ecs/src/reflect/component.rs
+++ b/crates/bevy_ecs/src/reflect/component.rs
@@ -66,7 +66,7 @@ use crate::{
     relationship::RelationshipHookMode,
     world::{
         unsafe_world_cell::UnsafeEntityCell, EntityMut, EntityWorldMut, FilteredEntityMut,
-        FilteredEntityRef, World,
+        FilteredEntityRef, Only, World,
     },
 };
 use bevy_reflect::{FromReflect, FromType, PartialReflect, Reflect, TypePath, TypeRegistry};
@@ -377,7 +377,7 @@ impl<C: Component + Reflect + TypePath> FromType<C> for ReflectComponent {
                 // SAFETY: reflect_unchecked_mut is an unsafe function pointer used by
                 // `reflect_unchecked_mut` which must be called with an UnsafeEntityCell with access to the component `C` on the `entity`
                 // guard ensures `C` is a mutable component
-                let c = unsafe { entity.get_mut_assume_mutable::<C>() };
+                let c = unsafe { entity.get_mut_assume_mutable::<C>(Only::<C>::default()) };
                 c.map(|c| c.map_unchanged(|value| value as &mut dyn Reflect))
             },
             register_component: |world: &mut World| -> ComponentId {

--- a/crates/bevy_ecs/src/world/access_scope.rs
+++ b/crates/bevy_ecs/src/world/access_scope.rs
@@ -1,5 +1,7 @@
 use core::marker::PhantomData;
 
+use derive_more::derive::{Deref, DerefMut};
+
 use crate::{
     bundle::Bundle,
     component::{ComponentId, Components},
@@ -89,7 +91,7 @@ unsafe impl AccessScope for Full {
 
 /// An [`AccessScope`] that allows reading and writing only the components allowed by
 /// the held [`Access<ComponentId>`].
-#[derive(Clone)]
+#[derive(Clone, Deref, DerefMut)]
 pub struct Partial(pub Access<ComponentId>);
 
 // SAFETY: `as_ref` refers to the same set of components as `Self`

--- a/crates/bevy_ecs/src/world/access_scope.rs
+++ b/crates/bevy_ecs/src/world/access_scope.rs
@@ -1,0 +1,209 @@
+use core::marker::PhantomData;
+
+use crate::{
+    bundle::Bundle,
+    component::{ComponentId, Components},
+    query::Access,
+};
+
+/// Access scopes define the set of [`Component`]s accessible by an entity
+/// reference type.
+///
+/// The following scopes are available:
+/// - [`Full`]: Allows reading and writing all components.
+/// - [`Partial`]: Allows reading and writing only the components allowed by the
+///   held [`Access<ComponentId>`].
+/// - [`Except`]: Allows reading and writing all components except those
+///   contained in the [`Bundle`] `B`.
+/// - [`Only`]: Allows reading and writing only the components contained in the
+///   [`Bundle`] `B`.
+///
+/// # Safety
+///
+/// Implementors must ensure that [`AccessScope::as_ref`] provides access to the same
+/// set of components as `Self`.
+///
+/// [`Component`]: crate::component::Component
+pub unsafe trait AccessScope {
+    /// Associated type to take this scope by reference.
+    ///
+    /// By using an associated type rather than `&scope` directly, we can
+    /// ensure that [`Full`] entity references always stay as [`Full`] and don't
+    /// become `&Full`, for example.
+    type AsRef<'a>: AccessScope
+    where
+        Self: 'a;
+
+    /// Takes this scope by reference.
+    fn as_ref(&self) -> Self::AsRef<'_>;
+
+    /// Returns `true` if the entity has read access to the component with the
+    /// given [`ComponentId`].
+    fn can_read(&self, components: &Components, id: ComponentId) -> bool;
+
+    /// Returns `true` if the entity has write access to the component with the
+    /// given [`ComponentId`].
+    fn can_write(&self, components: &Components, id: ComponentId) -> bool;
+}
+
+// SAFETY: `as_ref` refers to the same set of components as `Self`
+unsafe impl<S: AccessScope> AccessScope for &S {
+    type AsRef<'a>
+        = S::AsRef<'a>
+    where
+        Self: 'a;
+
+    fn as_ref(&self) -> Self::AsRef<'_> {
+        (**self).as_ref()
+    }
+
+    fn can_read(&self, components: &Components, component: ComponentId) -> bool {
+        (**self).can_read(components, component)
+    }
+
+    fn can_write(&self, components: &Components, component: ComponentId) -> bool {
+        (**self).can_write(components, component)
+    }
+}
+
+/// An [`AccessScope`] that allows reading and writing all components.
+#[derive(Clone, Copy)]
+pub struct Full;
+
+// SAFETY: `as_ref` refers to the same set of components as `Self`
+unsafe impl AccessScope for Full {
+    type AsRef<'a> = Full;
+
+    fn as_ref(&self) -> Self::AsRef<'_> {
+        *self
+    }
+
+    fn can_read(&self, _: &Components, _: ComponentId) -> bool {
+        true
+    }
+
+    fn can_write(&self, _: &Components, _: ComponentId) -> bool {
+        true
+    }
+}
+
+/// An [`AccessScope`] that allows reading and writing only the components allowed by
+/// the held [`Access<ComponentId>`].
+#[derive(Clone)]
+pub struct Partial(pub Access<ComponentId>);
+
+// SAFETY: `as_ref` refers to the same set of components as `Self`
+unsafe impl AccessScope for Partial {
+    type AsRef<'a> = &'a Partial;
+
+    fn as_ref(&self) -> Self::AsRef<'_> {
+        self
+    }
+
+    fn can_read(&self, _: &Components, id: ComponentId) -> bool {
+        self.0.has_component_read(id)
+    }
+
+    fn can_write(&self, _: &Components, id: ComponentId) -> bool {
+        self.0.has_component_write(id)
+    }
+}
+
+// SAFETY: `as_ref` refers to the same set of components as `Self`
+unsafe impl AccessScope for Access<ComponentId> {
+    type AsRef<'a> = &'a Access<ComponentId>;
+
+    fn as_ref(&self) -> Self::AsRef<'_> {
+        self
+    }
+
+    fn can_read(&self, _: &Components, id: ComponentId) -> bool {
+        self.has_component_read(id)
+    }
+
+    fn can_write(&self, _: &Components, id: ComponentId) -> bool {
+        self.has_component_write(id)
+    }
+}
+
+/// An [`AccessScope`] that allows reading and writing all components except those
+/// contained in the [`Bundle`] `B`.
+pub struct Except<B: Bundle>(PhantomData<B>);
+
+impl<B: Bundle> Clone for Except<B> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<B: Bundle> Copy for Except<B> {}
+
+impl<B: Bundle> Default for Except<B> {
+    fn default() -> Self {
+        Except(PhantomData)
+    }
+}
+
+// SAFETY: `as_ref` refers to the same set of components as `Self`
+unsafe impl<B: Bundle> AccessScope for Except<B> {
+    type AsRef<'a> = Except<B>;
+
+    fn as_ref(&self) -> Self::AsRef<'_> {
+        *self
+    }
+
+    fn can_read(&self, components: &Components, id: ComponentId) -> bool {
+        let mut found = false;
+        B::get_component_ids(components, &mut |maybe_id| {
+            if let Some(bid) = maybe_id {
+                found = found || bid == id;
+            }
+        });
+        !found
+    }
+
+    fn can_write(&self, components: &Components, id: ComponentId) -> bool {
+        self.can_read(components, id)
+    }
+}
+
+/// An [`AccessScope`] that allows reading and writing only the components contained in
+/// the [`Bundle`] `B`.
+pub struct Only<B: Bundle>(PhantomData<B>);
+
+impl<B: Bundle> Clone for Only<B> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<B: Bundle> Copy for Only<B> {}
+
+impl<B: Bundle> Default for Only<B> {
+    fn default() -> Self {
+        Only(PhantomData)
+    }
+}
+
+// SAFETY: `as_ref` refers to the same set of components as `Self`
+unsafe impl<B: Bundle> AccessScope for Only<B> {
+    type AsRef<'a> = Only<B>;
+
+    fn as_ref(&self) -> Self::AsRef<'_> {
+        *self
+    }
+
+    fn can_read(&self, components: &Components, id: ComponentId) -> bool {
+        let mut found = false;
+        B::get_component_ids(components, &mut |maybe_id| {
+            if let Some(bid) = maybe_id {
+                found = found || bid == id;
+            }
+        });
+        found
+    }
+
+    fn can_write(&self, components: &Components, id: ComponentId) -> bool {
+        self.can_read(components, id)
+    }
+}

--- a/crates/bevy_ecs/src/world/entity_fetch.rs
+++ b/crates/bevy_ecs/src/world/entity_fetch.rs
@@ -229,7 +229,7 @@ unsafe impl WorldEntityFetch for Entity {
     ) -> Result<Self::DeferredMut<'_>, EntityMutableFetchError> {
         let ecell = cell.get_entity(self)?;
         // SAFETY: caller ensures that the world cell has mutable access to the entity.
-        Ok(unsafe { EntityMut::new(ecell) })
+        Ok(unsafe { EntityMut::new(ecell, Full) })
     }
 }
 
@@ -307,7 +307,7 @@ unsafe impl<const N: usize> WorldEntityFetch for &'_ [Entity; N] {
         for (r, &id) in core::iter::zip(&mut refs, self) {
             let ecell = cell.get_entity(id)?;
             // SAFETY: caller ensures that the world cell has mutable access to the entity.
-            *r = MaybeUninit::new(unsafe { EntityMut::new(ecell) });
+            *r = MaybeUninit::new(unsafe { EntityMut::new(ecell, Full) });
         }
 
         // SAFETY: Each item was initialized in the loop above.
@@ -366,7 +366,7 @@ unsafe impl WorldEntityFetch for &'_ [Entity] {
         for &id in self {
             let ecell = cell.get_entity(id)?;
             // SAFETY: caller ensures that the world cell has mutable access to the entity.
-            refs.push(unsafe { EntityMut::new(ecell) });
+            refs.push(unsafe { EntityMut::new(ecell, Full) });
         }
 
         Ok(refs)
@@ -412,7 +412,7 @@ unsafe impl WorldEntityFetch for &'_ EntityHashSet {
         for &id in self {
             let ecell = cell.get_entity(id)?;
             // SAFETY: caller ensures that the world cell has mutable access to the entity.
-            refs.insert(id, unsafe { EntityMut::new(ecell) });
+            refs.insert(id, unsafe { EntityMut::new(ecell, Full) });
         }
         Ok(refs)
     }

--- a/crates/bevy_ecs/src/world/entity_fetch.rs
+++ b/crates/bevy_ecs/src/world/entity_fetch.rs
@@ -6,7 +6,7 @@ use crate::{
     error::Result,
     world::{
         error::EntityMutableFetchError, unsafe_world_cell::UnsafeWorldCell, EntityMut, EntityRef,
-        EntityWorldMut,
+        EntityWorldMut, Full,
     },
 };
 
@@ -206,7 +206,7 @@ unsafe impl WorldEntityFetch for Entity {
     ) -> Result<Self::Ref<'_>, EntityDoesNotExistError> {
         let ecell = cell.get_entity(self)?;
         // SAFETY: caller ensures that the world cell has read-only access to the entity.
-        Ok(unsafe { EntityRef::new(ecell) })
+        Ok(unsafe { EntityRef::new(ecell, Full) })
     }
 
     unsafe fn fetch_mut(
@@ -281,7 +281,7 @@ unsafe impl<const N: usize> WorldEntityFetch for &'_ [Entity; N] {
         for (r, &id) in core::iter::zip(&mut refs, self) {
             let ecell = cell.get_entity(id)?;
             // SAFETY: caller ensures that the world cell has read-only access to the entity.
-            *r = MaybeUninit::new(unsafe { EntityRef::new(ecell) });
+            *r = MaybeUninit::new(unsafe { EntityRef::new(ecell, Full) });
         }
 
         // SAFETY: Each item was initialized in the loop above.
@@ -343,7 +343,7 @@ unsafe impl WorldEntityFetch for &'_ [Entity] {
         for &id in self {
             let ecell = cell.get_entity(id)?;
             // SAFETY: caller ensures that the world cell has read-only access to the entity.
-            refs.push(unsafe { EntityRef::new(ecell) });
+            refs.push(unsafe { EntityRef::new(ecell, Full) });
         }
 
         Ok(refs)
@@ -399,7 +399,7 @@ unsafe impl WorldEntityFetch for &'_ EntityHashSet {
         for &id in self {
             let ecell = cell.get_entity(id)?;
             // SAFETY: caller ensures that the world cell has read-only access to the entity.
-            refs.insert(id, unsafe { EntityRef::new(ecell) });
+            refs.insert(id, unsafe { EntityRef::new(ecell, Full) });
         }
         Ok(refs)
     }

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -414,15 +414,15 @@ impl<'a> TryFrom<&'a FilteredEntityMut<'_>> for EntityRef<'a> {
     }
 }
 
-impl PartialEq for EntityRef<'_> {
+impl<S: AccessScope> PartialEq for EntityRef<'_, S> {
     fn eq(&self, other: &Self) -> bool {
         self.entity() == other.entity()
     }
 }
 
-impl Eq for EntityRef<'_> {}
+impl<S: AccessScope> Eq for EntityRef<'_, S> {}
 
-impl PartialOrd for EntityRef<'_> {
+impl<S: AccessScope> PartialOrd for EntityRef<'_, S> {
     /// [`EntityRef`]'s comparison trait implementations match the underlying [`Entity`],
     /// and cannot discern between different worlds.
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
@@ -430,26 +430,26 @@ impl PartialOrd for EntityRef<'_> {
     }
 }
 
-impl Ord for EntityRef<'_> {
+impl<S: AccessScope> Ord for EntityRef<'_, S> {
     fn cmp(&self, other: &Self) -> Ordering {
         self.entity().cmp(&other.entity())
     }
 }
 
-impl Hash for EntityRef<'_> {
+impl<S: AccessScope> Hash for EntityRef<'_, S> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.entity().hash(state);
     }
 }
 
-impl ContainsEntity for EntityRef<'_> {
+impl<S: AccessScope> ContainsEntity for EntityRef<'_, S> {
     fn entity(&self) -> Entity {
         self.id()
     }
 }
 
 // SAFETY: This type represents one Entity. We implement the comparison traits based on that Entity.
-unsafe impl EntityEquivalent for EntityRef<'_> {}
+unsafe impl<S: AccessScope> EntityEquivalent for EntityRef<'_, S> {}
 
 /// Provides mutable access to a single entity and all of its components.
 ///
@@ -1103,15 +1103,15 @@ impl<'a> TryFrom<&'a mut FilteredEntityMut<'_>> for EntityMut<'a> {
     }
 }
 
-impl PartialEq for EntityMut<'_> {
+impl<S: AccessScope> PartialEq for EntityMut<'_, S> {
     fn eq(&self, other: &Self) -> bool {
         self.entity() == other.entity()
     }
 }
 
-impl Eq for EntityMut<'_> {}
+impl<S: AccessScope> Eq for EntityMut<'_, S> {}
 
-impl PartialOrd for EntityMut<'_> {
+impl<S: AccessScope> PartialOrd for EntityMut<'_, S> {
     /// [`EntityMut`]'s comparison trait implementations match the underlying [`Entity`],
     /// and cannot discern between different worlds.
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
@@ -1119,26 +1119,26 @@ impl PartialOrd for EntityMut<'_> {
     }
 }
 
-impl Ord for EntityMut<'_> {
+impl<S: AccessScope> Ord for EntityMut<'_, S> {
     fn cmp(&self, other: &Self) -> Ordering {
         self.entity().cmp(&other.entity())
     }
 }
 
-impl Hash for EntityMut<'_> {
+impl<S: AccessScope> Hash for EntityMut<'_, S> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.entity().hash(state);
     }
 }
 
-impl ContainsEntity for EntityMut<'_> {
+impl<S: AccessScope> ContainsEntity for EntityMut<'_, S> {
     fn entity(&self) -> Entity {
         self.id()
     }
 }
 
 // SAFETY: This type represents one Entity. We implement the comparison traits based on that Entity.
-unsafe impl EntityEquivalent for EntityMut<'_> {}
+unsafe impl<S: AccessScope> EntityEquivalent for EntityMut<'_, S> {}
 
 /// A mutable reference to a particular [`Entity`], and the entire world.
 ///
@@ -3528,43 +3528,6 @@ impl<'a, B: Bundle> From<&'a EntityRefExcept<'_, B>> for FilteredEntityRef<'a> {
     }
 }
 
-impl PartialEq for FilteredEntityRef<'_> {
-    fn eq(&self, other: &Self) -> bool {
-        self.entity() == other.entity()
-    }
-}
-
-impl Eq for FilteredEntityRef<'_> {}
-
-impl PartialOrd for FilteredEntityRef<'_> {
-    /// [`FilteredEntityRef`]'s comparison trait implementations match the underlying [`Entity`],
-    /// and cannot discern between different worlds.
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for FilteredEntityRef<'_> {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.entity().cmp(&other.entity())
-    }
-}
-
-impl Hash for FilteredEntityRef<'_> {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.entity().hash(state);
-    }
-}
-
-impl ContainsEntity for FilteredEntityRef<'_> {
-    fn entity(&self) -> Entity {
-        self.id()
-    }
-}
-
-// SAFETY: This type represents one Entity. We implement the comparison traits based on that Entity.
-unsafe impl EntityEquivalent for FilteredEntityRef<'_> {}
-
 /// Provides mutable access to a single entity and some of its components defined by the contained [`Access`].
 ///
 /// To define the access when used as a [`QueryData`](crate::query::QueryData),
@@ -3677,43 +3640,6 @@ impl<'a, B: Bundle> From<&'a EntityMutExcept<'_, B>> for FilteredEntityMut<'a> {
     }
 }
 
-impl PartialEq for FilteredEntityMut<'_> {
-    fn eq(&self, other: &Self) -> bool {
-        self.entity() == other.entity()
-    }
-}
-
-impl Eq for FilteredEntityMut<'_> {}
-
-impl PartialOrd for FilteredEntityMut<'_> {
-    /// [`FilteredEntityMut`]'s comparison trait implementations match the underlying [`Entity`],
-    /// and cannot discern between different worlds.
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for FilteredEntityMut<'_> {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.entity().cmp(&other.entity())
-    }
-}
-
-impl Hash for FilteredEntityMut<'_> {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.entity().hash(state);
-    }
-}
-
-impl ContainsEntity for FilteredEntityMut<'_> {
-    fn entity(&self) -> Entity {
-        self.id()
-    }
-}
-
-// SAFETY: This type represents one Entity. We implement the comparison traits based on that Entity.
-unsafe impl EntityEquivalent for FilteredEntityMut<'_> {}
-
 /// Error type returned by [`TryFrom`] conversions from filtered entity types
 /// ([`FilteredEntityRef`]/[`FilteredEntityMut`]) to full-access entity types
 /// ([`EntityRef`]/[`EntityMut`]).
@@ -3744,43 +3670,6 @@ where
     }
 }
 
-impl<B: Bundle> PartialEq for EntityRefExcept<'_, B> {
-    fn eq(&self, other: &Self) -> bool {
-        self.entity() == other.entity()
-    }
-}
-
-impl<B: Bundle> Eq for EntityRefExcept<'_, B> {}
-
-impl<B: Bundle> PartialOrd for EntityRefExcept<'_, B> {
-    /// [`EntityRefExcept`]'s comparison trait implementations match the underlying [`Entity`],
-    /// and cannot discern between different worlds.
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl<B: Bundle> Ord for EntityRefExcept<'_, B> {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.entity().cmp(&other.entity())
-    }
-}
-
-impl<B: Bundle> Hash for EntityRefExcept<'_, B> {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.entity().hash(state);
-    }
-}
-
-impl<B: Bundle> ContainsEntity for EntityRefExcept<'_, B> {
-    fn entity(&self) -> Entity {
-        self.id()
-    }
-}
-
-// SAFETY: This type represents one Entity. We implement the comparison traits based on that Entity.
-unsafe impl<B: Bundle> EntityEquivalent for EntityRefExcept<'_, B> {}
-
 /// Provides mutable access to all components of an entity, with the exception
 /// of an explicit set.
 ///
@@ -3790,43 +3679,6 @@ unsafe impl<B: Bundle> EntityEquivalent for EntityRefExcept<'_, B> {}
 /// need access to all components, prefer a standard query with a
 /// [`crate::query::Without`] filter.
 pub type EntityMutExcept<'w, B> = EntityMut<'w, Except<B>>;
-
-impl<B: Bundle> PartialEq for EntityMutExcept<'_, B> {
-    fn eq(&self, other: &Self) -> bool {
-        self.entity() == other.entity()
-    }
-}
-
-impl<B: Bundle> Eq for EntityMutExcept<'_, B> {}
-
-impl<B: Bundle> PartialOrd for EntityMutExcept<'_, B> {
-    /// [`EntityMutExcept`]'s comparison trait implementations match the underlying [`Entity`],
-    /// and cannot discern between different worlds.
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl<B: Bundle> Ord for EntityMutExcept<'_, B> {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.entity().cmp(&other.entity())
-    }
-}
-
-impl<B: Bundle> Hash for EntityMutExcept<'_, B> {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.entity().hash(state);
-    }
-}
-
-impl<B: Bundle> ContainsEntity for EntityMutExcept<'_, B> {
-    fn entity(&self) -> Entity {
-        self.id()
-    }
-}
-
-// SAFETY: This type represents one Entity. We implement the comparison traits based on that Entity.
-unsafe impl<B: Bundle> EntityEquivalent for EntityMutExcept<'_, B> {}
 
 /// Inserts a dynamic [`Bundle`] into the entity.
 ///

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -986,7 +986,7 @@ impl World {
                         location,
                     );
                     // SAFETY: `&self` gives read access to the entire world.
-                    unsafe { EntityRef::new(cell) }
+                    unsafe { EntityRef::new(cell, Full) }
                 })
         })
     }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1012,7 +1012,7 @@ impl World {
                     let cell = UnsafeEntityCell::new(world_cell, entity, location);
                     // SAFETY: We have exclusive access to the entire world. We only create one borrow for each entity,
                     // so none will conflict with one another.
-                    unsafe { EntityMut::new(cell) }
+                    unsafe { EntityMut::new(cell, Full) }
                 })
         })
     }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1,5 +1,6 @@
 //! Defines the [`World`] and APIs for accessing it directly.
 
+mod access_scope;
 pub(crate) mod command_queue;
 mod component_constants;
 mod deferred_world;
@@ -18,6 +19,7 @@ pub use crate::{
     change_detection::{Mut, Ref, CHECK_TICK_THRESHOLD},
     world::command_queue::CommandQueue,
 };
+pub use access_scope::*;
 pub use bevy_ecs_macros::FromWorld;
 pub use component_constants::*;
 pub use deferred_world::DeferredWorld;

--- a/examples/ecs/dynamic.rs
+++ b/examples/ecs/dynamic.rs
@@ -156,7 +156,7 @@ fn main() {
                 let mut query = builder.build();
                 query.iter_mut(&mut world).for_each(|filtered_entity| {
                     let terms = filtered_entity
-                        .access()
+                        .scope()
                         .try_iter_component_access()
                         .unwrap()
                         .map(|component_access| {

--- a/examples/stress_tests/many_components.rs
+++ b/examples/stress_tests/many_components.rs
@@ -64,7 +64,7 @@ fn base_system(access_components: In<Vec<ComponentId>>, mut query: Query<Filtere
 
         // we assign this value to all the components we can write to
         for component_id in &access_components.0 {
-            if let Some(ptr) = filtered_entity.get_mut_by_id(*component_id) {
+            if let Ok(ptr) = filtered_entity.get_mut_by_id(*component_id) {
                 // SAFETY: All components have a u8 layout
                 unsafe {
                     let mut value = ptr.with_type::<u8>();


### PR DESCRIPTION
This PR is part of the [Entity API Deduplication Working Group](https://discord.com/channels/691052431525675048/1308513055000498226) on Discord, and is primarily based on [this design document](https://hackmd.io/@bevy/By4NcOYzkg). See the pinned messages in that channel for alternative designs.

# Objective

We can observe that `EntityRef`, `FilteredEntityRef`, and `EntityRefExcept` provide the same *kind* of access (reading components), but differ in *what* can be accessed: `EntityRef` allows access for all components, and `FilteredEntityRef` and `EntityRefExcept` allow runtime- and compile-time- defined access, respectively. We can reduce code duplication by unifying these three types into a single `EntityRef` which additionally has a generic parameter for determining the "scope" of access a given reference has. All of this applies to the `Mut` variants in the same manner.

- Closes #17784

## Solution

- First, we define a trait `AccessScope` with two functions for determining whether a scope can read or write a given component. Additionally we define the scopes we need:
    - `Full`: Provides read/write access to all components.
    - `Partial`: Provides runtime-configurable read/write access via `Access<ComponentId>`
    - `Except`: Provides compile-time-configurable read/write access via a type parameter. Any component *not* included in the bundle is accessible.
    - `Only`: Provides compile-time-configurable read/write access via a type parameter. Any component included in the bundle is accessible.
- Next, we add `AccessScope` parameters to component getters on `UnsafeEntityCell` so that we can exit early as soon as we know what `ComponentId` we're trying to access.
- Then we remove `FilteredEntityRef` and `EntityRefExcept`, and add an `AccessScope` type parameter to `EntityRef`. It defaults to `Full` so that we maintain backwards compatibility.
- Then we do the same for the `Mut` variants.
- Finally we cleanup the last remaining duplicate trait implementations by generalizing them.

### Notes for reviewers

- I've specifically crafted this PR to be easy to step through commit-by-commit.
- We have a new category of `unsafe`ty (access scopes) that deserve thoughtful scrutiny.
- This PR's only goal is code cleanup; no new features are intended, and attempting to minimize breaking changes.
- Should `AccessScope` be sealed? The constructors for `EntityRef`/`Mut` aren't public so they can't currently be constructed with user-defined scopes.
- Neither `EntityRefOnly` nor `EntityMutOnly` has been added, however the `Only` access scope is itself needed by the engine, so I've added just the scope at this point.

## Testing

Reusing current tests: ideally no additional features are added so no new tests should be necessary.
