### PR TITLE
Expose the output curve type in with_derivative

### DIFF
--- a/crates/bevy_math/src/common_traits.rs
+++ b/crates/bevy_math/src/common_traits.rs
@@ -80,6 +80,8 @@ impl VectorSpace for f32 {
 ///
 /// [vector spaces]: VectorSpace
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct Sum<V, W>(pub V, pub W);
 
 impl<V, W> Mul<f32> for Sum<V, W>
@@ -424,6 +426,9 @@ pub trait HasTangent {
 }
 
 /// A value with its derivative.
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct WithDerivative<T>
 where
     T: HasTangent,
@@ -436,6 +441,9 @@ where
 }
 
 /// A value together with its first and second derivatives.
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct WithTwoDerivatives<T>
 where
     T: HasTangent,

--- a/crates/bevy_math/src/curve/derivatives/mod.rs
+++ b/crates/bevy_math/src/curve/derivatives/mod.rs
@@ -37,24 +37,28 @@ use bevy_reflect::{FromReflect, Reflect};
 /// derivatives to be extracted along with values.
 ///
 /// This is implemented by implementing [`SampleDerivative`].
-pub trait CurveWithDerivative<T>: SampleDerivative<T>
+pub trait CurveWithDerivative<T>: SampleDerivative<T> + Sized
 where
     T: HasTangent,
 {
     /// This curve, but with its first derivative included in sampling.
-    fn with_derivative(self) -> impl Curve<WithDerivative<T>>;
+    ///
+    /// Notably, the output type is a `Curve<WithDerivative<T>>`.
+    fn with_derivative(self) -> SampleDerivativeWrapper<Self>;
 }
 
 /// Trait for curves that have a well-defined notion of second derivative,
 /// allowing for two derivatives to be extracted along with values.
 ///
 /// This is implemented by implementing [`SampleTwoDerivatives`].
-pub trait CurveWithTwoDerivatives<T>: SampleTwoDerivatives<T>
+pub trait CurveWithTwoDerivatives<T>: SampleTwoDerivatives<T> + Sized
 where
     T: HasTangent,
 {
     /// This curve, but with its first two derivatives included in sampling.
-    fn with_two_derivatives(self) -> impl Curve<WithTwoDerivatives<T>>;
+    ///
+    /// Notably, the output type is a `Curve<WithTwoDerivatives<T>>`.
+    fn with_two_derivatives(self) -> SampleTwoDerivativesWrapper<Self>;
 }
 
 /// A trait for curves that can sample derivatives in addition to values.
@@ -210,7 +214,7 @@ where
     T: HasTangent,
     C: SampleDerivative<T>,
 {
-    fn with_derivative(self) -> impl Curve<WithDerivative<T>> {
+    fn with_derivative(self) -> SampleDerivativeWrapper<Self> {
         SampleDerivativeWrapper(self)
     }
 }
@@ -220,7 +224,7 @@ where
     T: HasTangent,
     C: SampleTwoDerivatives<T> + CurveWithDerivative<T>,
 {
-    fn with_two_derivatives(self) -> impl Curve<WithTwoDerivatives<T>> {
+    fn with_two_derivatives(self) -> SampleTwoDerivativesWrapper<Self> {
         SampleTwoDerivativesWrapper(self)
     }
 }


### PR DESCRIPTION
# Objective

I was wrong about how RPITIT works when I wrote this stuff initially, and in order to actually give people access to all the traits implemented by the output (e.g. Debug and so on) it's important to expose the real output type, even if it makes the trait uglier and less comprehensible. (☹️)

## Solution

Expose the curve output type of the `CurveWithDerivative` trait and its double-derivative companion. I also added a bunch of trait derives to `WithDerivative<T>`, since I think that was just an oversight. 