### PR TITLE
Don't restrict the scene viewer to loading assets from approved paths.

### DIFF
--- a/examples/tools/scene_viewer/main.rs
+++ b/examples/tools/scene_viewer/main.rs
@@ -10,6 +10,7 @@
 
 use argh::FromArgs;
 use bevy::{
+    asset::UnapprovedPathMode,
     core_pipeline::prepass::{DeferredPrepass, DepthPrepass},
     pbr::DefaultOpaqueRendererMethod,
     prelude::*,
@@ -74,6 +75,9 @@ fn main() {
             })
             .set(AssetPlugin {
                 file_path: std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string()),
+                // Allow scenes to be loaded from anywhere on disk, as that's
+                // the entire point of this program.
+                unapproved_path_mode: UnapprovedPathMode::Allow,
                 ..default()
             }),
         CameraControllerPlugin,

--- a/examples/tools/scene_viewer/main.rs
+++ b/examples/tools/scene_viewer/main.rs
@@ -75,8 +75,7 @@ fn main() {
             })
             .set(AssetPlugin {
                 file_path: std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string()),
-                // Allow scenes to be loaded from anywhere on disk, as that's
-                // the entire point of this program.
+                // Allow scenes to be loaded from anywhere on disk
                 unapproved_path_mode: UnapprovedPathMode::Allow,
                 ..default()
             }),


### PR DESCRIPTION
The purpose of the scene viewer is to load arbitrary glTF scenes, so it's inconvenient if they have to be moved into the Bevy assets directory first. Thus this patch switches the scene viewer to use `UnapprovedPathMode::Allow`.