### PR TITLE
impl TriggerTargets for (ComponentId, Entity) and (Entity, ComponentId)

### DIFF
--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -194,6 +194,26 @@ impl<T: TriggerTargets + ?Sized> TriggerTargets for &T {
     }
 }
 
+impl TriggerTargets for (ComponentId, Entity) {
+    fn components(&self) -> impl Iterator<Item = ComponentId> + Clone + '_ {
+        core::iter::once(self.0)
+    }
+
+    fn entities(&self) -> impl Iterator<Item = Entity> + Clone + '_ {
+        core::iter::once(self.1)
+    }
+}
+
+impl TriggerTargets for (Entity, ComponentId) {
+    fn components(&self) -> impl Iterator<Item = ComponentId> + Clone + '_ {
+        core::iter::once(self.1)
+    }
+
+    fn entities(&self) -> impl Iterator<Item = Entity> + Clone + '_ {
+        core::iter::once(self.0)
+    }
+}
+
 impl TriggerTargets for Entity {
     fn components(&self) -> impl Iterator<Item = ComponentId> + Clone + '_ {
         [].into_iter()


### PR DESCRIPTION
Before:

```rust
struct EntityComponent(Entity, ComponentId);

impl TriggerTargets for EntityComponent {
    fn components(&self) -> impl Iterator<Item = ComponentId> + Clone + '_ {
        std::iter::once(self.1)
    }

    fn entities(&self) -> impl Iterator<Item = Entity> + Clone + '_ {
        std::iter::once(self.0)
    }
}

struct ComponentEntity(ComponentId, Entity);

impl TriggerTargets for ComponentEntity {
    fn components(&self) -> impl Iterator<Item = ComponentId> + Clone + '_ {
        std::iter::once(self.0)
    }

    fn entities(&self) -> impl Iterator<Item = Entity> + Clone + '_ {
        std::iter::once(self.1)
    }
}

commands.trigger_targets(SomeEvent, EntityComponent(entity, component_id));
commands.trigger_targets(SomeEvent, ComponentEntity(component_id, entity));
```

After:

```rust
commands.trigger_targets(SomeEvent, (entity, component_id));
commands.trigger_targets(SomeEvent, (component_id, entity));
```