### PR TITLE
Make the example android app explicitly handle some device config change events to avoid getting the activity destroyed

### DIFF
--- a/examples/mobile/android_example/app/src/main/AndroidManifest.xml
+++ b/examples/mobile/android_example/app/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:configChanges="orientation|screenSize|screenLayout"
+            android:configChanges="layoutDirection|locale|orientation|keyboardHidden|screenSize|smallestScreenSize|density|keyboard|navigation|screenLayout|uiMode"
             android:theme="@style/Theme.AppCompat.NoActionBar">
             <meta-data
                 android:name="android.app.lib_name"

--- a/examples/mobile/android_example/app/src/main/AndroidManifest.xml
+++ b/examples/mobile/android_example/app/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:configChanges="orientation|screenSize"
+            android:configChanges="orientation|screenSize|screenLayout"
             android:theme="@style/Theme.AppCompat.NoActionBar">
             <meta-data
                 android:name="android.app.lib_name"

--- a/examples/mobile/android_example/app/src/main/AndroidManifest.xml
+++ b/examples/mobile/android_example/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:configChanges="orientation|screenSize"
             android:theme="@style/Theme.AppCompat.NoActionBar">
             <meta-data
                 android:name="android.app.lib_name"

--- a/examples/mobile/android_example_native/app/src/main/AndroidManifest.xml
+++ b/examples/mobile/android_example_native/app/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:configChanges="orientation|screenSize|screenLayout"
+            android:configChanges="layoutDirection|locale|orientation|keyboardHidden|screenSize|smallestScreenSize|density|keyboard|navigation|screenLayout|uiMode"
             android:theme="@style/Theme.AppCompat.NoActionBar">
             <meta-data
                 android:name="android.app.lib_name"

--- a/examples/mobile/android_example_native/app/src/main/AndroidManifest.xml
+++ b/examples/mobile/android_example_native/app/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:configChanges="orientation|screenSize"
+            android:configChanges="orientation|screenSize|screenLayout"
             android:theme="@style/Theme.AppCompat.NoActionBar">
             <meta-data
                 android:name="android.app.lib_name"

--- a/examples/mobile/android_example_native/app/src/main/AndroidManifest.xml
+++ b/examples/mobile/android_example_native/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:configChanges="orientation|screenSize"
             android:theme="@style/Theme.AppCompat.NoActionBar">
             <meta-data
                 android:name="android.app.lib_name"


### PR DESCRIPTION
# Objective

Fixes #18316

## Solution

Add android:configChanges="orientation|screenSize" to the AndroidManifest.xml as indicated in https://stackoverflow.com/a/3329486 to avoid the GameActivity from getting destroyed, making the app stuck/crash.

## Testing

I checked the results in my phone and after adding the config change the issue went away. The change is relatively trivial, so there shouldn't be the need to make a lot more testing.
