### PR TITLE
Swap order of eviction/extraction when extracting for specialization

### DIFF
--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -822,11 +822,9 @@ pub fn extract_entities_needs_specialization<M>(
 ) where
     M: Material,
 {
-    for entity in entities_needing_specialization.iter() {
-        // Update the entity's specialization tick with this run's tick
-        entity_specialization_ticks.insert((*entity).into(), ticks.this_run());
-    }
-    // Clean up any despawned entities
+    // Clean up any despawned entities, we do this first in case the removed material was re-added
+    // the same frame, thus will appear both in the removed components list and have been added to
+    // the `EntitiesNeedingSpecialization` collection by triggering the `Changed` filter
     for entity in removed_mesh_material_components.read() {
         entity_specialization_ticks.remove(&MainEntity::from(entity));
         for view in views {
@@ -848,6 +846,11 @@ pub fn extract_entities_needs_specialization<M>(
                 cache.remove(&MainEntity::from(entity));
             }
         }
+    }
+
+    for entity in entities_needing_specialization.iter() {
+        // Update the entity's specialization tick with this run's tick
+        entity_specialization_ticks.insert((*entity).into(), ticks.this_run());
     }
 }
 

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -564,11 +564,9 @@ pub fn extract_entities_needs_specialization<M>(
 ) where
     M: Material2d,
 {
-    for entity in entities_needing_specialization.iter() {
-        // Update the entity's specialization tick with this run's tick
-        entity_specialization_ticks.insert((*entity).into(), ticks.this_run());
-    }
-    // Clean up any despawned entities
+    // Clean up any despawned entities, we do this first in case the removed material was re-added
+    // the same frame, thus will appear both in the removed components list and have been added to
+    // the `EntitiesNeedingSpecialization` collection by triggering the `Changed` filter
     for entity in removed_mesh_material_components.read() {
         entity_specialization_ticks.remove(&MainEntity::from(entity));
         for view in views {
@@ -576,6 +574,10 @@ pub fn extract_entities_needs_specialization<M>(
                 cache.remove(&MainEntity::from(entity));
             }
         }
+    }
+    for entity in entities_needing_specialization.iter() {
+        // Update the entity's specialization tick with this run's tick
+        entity_specialization_ticks.insert((*entity).into(), ticks.this_run());
     }
 }
 


### PR DESCRIPTION
# Objective

Fixes #18843 

## Solution

We need to account for the material being added and removed in the course of the same frame. We evict the caches first because the entity will be re-added if it was marked as needing specialization, which avoids another check on removed components to see if it was "really" despawned.