### PR TITLE
`FontAtlasSet` fixes

### DIFF
--- a/crates/bevy_text/src/font_atlas_set.rs
+++ b/crates/bevy_text/src/font_atlas_set.rs
@@ -53,9 +53,8 @@ pub struct FontAtlasKey(pub u32, pub FontSmoothing);
 ///
 /// Provides the interface for adding and retrieving rasterized glyphs, and manages the [`FontAtlas`]es.
 ///
-/// There is one `FontAtlasSet` for each font.
-/// `FontAtlasSet`s are created and updated during text updates by the [`queue_text`](crate::pipeline::TextPipeline::queue_text) function
-///  and then stored in the [`FontAtlasSets`] resource.
+/// There is at most one `FontAtlasSet` for each font, stored in the `FontAtlasSets` resource.
+/// `FontAtlasSet`s are added and updated by the [`queue_text`](crate::pipeline::TextPipeline::queue_text) function.
 ///
 /// A `FontAtlasSet` contains one or more [`FontAtlas`]es for each font size.
 #[derive(Debug, TypePath)]

--- a/crates/bevy_text/src/font_atlas_set.rs
+++ b/crates/bevy_text/src/font_atlas_set.rs
@@ -53,19 +53,12 @@ pub struct FontAtlasKey(pub u32, pub FontSmoothing);
 ///
 /// Provides the interface for adding and retrieving rasterized glyphs, and manages the [`FontAtlas`]es.
 ///
-/// A `FontAtlasSet` is an [`Asset`].
-///
-/// There is one `FontAtlasSet` for each font:
-/// - When a [`Font`] is loaded as an asset and then used in [`TextFont`](crate::TextFont),
-///   a `FontAtlasSet` asset is created from a weak handle to the `Font`.
-/// - ~When a font is loaded as a system font, and then used in [`TextFont`](crate::TextFont),
-///   a `FontAtlasSet` asset is created and stored with a strong handle to the `FontAtlasSet`.~
-///   (*Note that system fonts are not currently supported by the `TextPipeline`.*)
+/// There is one `FontAtlasSet` for each font.
+/// `FontAtlasSet`s are created and updated during text updates by the [`queue_text`](crate::pipeline::TextPipeline::queue_text) function
+///  and then stored in the [`FontAtlasSets`] resource.
 ///
 /// A `FontAtlasSet` contains one or more [`FontAtlas`]es for each font size.
-///
-/// It is used by [`TextPipeline::queue_text`](crate::TextPipeline::queue_text).
-#[derive(Debug, TypePath, Asset)]
+#[derive(Debug, TypePath)]
 pub struct FontAtlasSet {
     font_atlases: HashMap<FontAtlasKey, Vec<FontAtlas>>,
 }

--- a/crates/bevy_text/src/font_atlas_set.rs
+++ b/crates/bevy_text/src/font_atlas_set.rs
@@ -1,4 +1,4 @@
-use bevy_asset::{Asset, AssetEvent, AssetId, Assets};
+use bevy_asset::{AssetEvent, AssetId, Assets};
 use bevy_ecs::{event::EventReader, resource::Resource, system::ResMut};
 use bevy_image::prelude::*;
 use bevy_math::{IVec2, UVec2};


### PR DESCRIPTION
# Objective

Fix problems with  `FontAtlasSet`:

* `FontAtlasSet` derives `Asset` but `FontAtlasSet`s are not Bevy assets.
* The doc comments state that `FontAtlasSet`s are assets that are created automatically when fonts are loaded. They aren't, they are created as needed during text updates. 

## Solution
* Removed the `Asset` derive.
* Rewrote the doc comments.
