### PR TITLE
Queries as entities

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -431,9 +431,9 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
                     }
                 }
 
-                unsafe fn new_archetype(state: &mut Self::State, archetype: &#path::archetype::Archetype, system_meta: &mut #path::system::SystemMeta) {
+                unsafe fn new_archetype(state: &Self::State, archetype: &#path::archetype::Archetype, system_meta: &mut #path::system::SystemMeta, world: &#path::world::World) {
                     // SAFETY: The caller ensures that `archetype` is from the World the state was initialized from in `init_state`.
-                    unsafe { <#fields_alias::<'_, '_, #punctuated_generic_idents> as #path::system::SystemParam>::new_archetype(&mut state.state, archetype, system_meta) }
+                    unsafe { <#fields_alias::<'_, '_, #punctuated_generic_idents> as #path::system::SystemParam>::new_archetype(&state.state, archetype, system_meta, world) }
                 }
 
                 fn apply(state: &mut Self::State, system_meta: &#path::system::SystemMeta, world: &mut #path::world::World) {

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -25,7 +25,7 @@ use crate::{
     entity::{Entity, EntityLocation},
     observer::Observers,
     storage::{ImmutableSparseSet, SparseArray, SparseSet, SparseSetIndex, TableId, TableRow},
-    world::{unsafe_world_cell::UnsafeWorldCell, DeferredWorld, World},
+    world::DeferredWorld,
 };
 use alloc::{boxed::Box, vec::Vec};
 use bevy_ecs_macros::Event;
@@ -839,9 +839,7 @@ impl ArchetypeIdState {
 
     #[inline]
     pub(crate) fn trigger_if_new(&self, world: &mut DeferredWorld) {
-        std::dbg!(self.is_new);
         if self.is_new {
-            std::println!("triggering archetype created {:?}", self.id);
             world.trigger(ArchetypeCreated(self.id));
         }
     }
@@ -983,7 +981,6 @@ impl Archetypes {
             .by_components
             .entry(archetype_identity)
             .or_insert_with_key(move |identity| {
-                // std::dbg!("creating new archetype");
                 *is_new_ref = true;
                 let ArchetypeComponents {
                     table_components,

--- a/crates/bevy_ecs/src/system/builder.rs
+++ b/crates/bevy_ecs/src/system/builder.rs
@@ -3,6 +3,7 @@ use bevy_utils::synccell::SyncCell;
 use variadics_please::all_tuples;
 
 use crate::{
+    entity::Entity,
     prelude::QueryBuilder,
     query::{QueryData, QueryFilter, QueryState},
     resource::Resource,
@@ -211,10 +212,9 @@ impl ParamBuilder {
 unsafe impl<'w, 's, D: QueryData + 'static, F: QueryFilter + 'static>
     SystemParamBuilder<Query<'w, 's, D, F>> for QueryState<D, F>
 {
-    fn build(self, world: &mut World, system_meta: &mut SystemMeta) -> QueryState<D, F> {
+    fn build(self, world: &mut World, system_meta: &mut SystemMeta) -> Entity {
         self.validate_world(world.id());
-        init_query_param(world, system_meta, &self);
-        self
+        init_query_param(world, system_meta, Some(self))
     }
 }
 
@@ -290,12 +290,12 @@ unsafe impl<
         T: FnOnce(&mut QueryBuilder<D, F>),
     > SystemParamBuilder<Query<'w, 's, D, F>> for QueryParamBuilder<T>
 {
-    fn build(self, world: &mut World, system_meta: &mut SystemMeta) -> QueryState<D, F> {
+    fn build(self, world: &mut World, system_meta: &mut SystemMeta) -> Entity {
         let mut builder = QueryBuilder::new(world);
         (self.0)(&mut builder);
         let state = builder.build();
-        init_query_param(world, system_meta, &state);
-        state
+
+        init_query_param(world, system_meta, Some(state))
     }
 }
 
@@ -943,7 +943,7 @@ mod tests {
     #[derive(SystemParam)]
     #[system_param(builder)]
     struct CustomParam<'w, 's> {
-        query: Query<'w, 's, ()>,
+        query: Query<'w, 'w, ()>,
         local: Local<'s, usize>,
     }
 

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -134,16 +134,18 @@ const _: () = {
         }
 
         unsafe fn new_archetype(
-            state: &mut Self::State,
+            state: &Self::State,
             archetype: &bevy_ecs::archetype::Archetype,
             system_meta: &mut bevy_ecs::system::SystemMeta,
+            world: &World,
         ) {
             // SAFETY: Caller guarantees the archetype is from the world used in `init_state`
             unsafe {
                 <__StructFieldsAlias<'_, '_> as bevy_ecs::system::SystemParam>::new_archetype(
-                    &mut state.state,
+                    &state.state,
                     archetype,
                     system_meta,
+                    world,
                 );
             };
         }

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -479,7 +479,9 @@ impl<Param: SystemParam> SystemState<Param> {
 
         for archetype in &archetypes[old_generation..] {
             // SAFETY: The assertion above ensures that the param_state was initialized from `world`.
-            unsafe { Param::new_archetype(&mut self.param_state, archetype, &mut self.meta) };
+            unsafe {
+                Param::new_archetype(&self.param_state, archetype, &mut self.meta, world.world())
+            };
         }
     }
 
@@ -790,7 +792,14 @@ where
 
         for archetype in &archetypes[old_generation..] {
             // SAFETY: The assertion above ensures that the param_state was initialized from `world`.
-            unsafe { F::Param::new_archetype(&mut state.param, archetype, &mut self.system_meta) };
+            unsafe {
+                F::Param::new_archetype(
+                    &state.param,
+                    archetype,
+                    &mut self.system_meta,
+                    world.world(),
+                )
+            };
         }
     }
 

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -5365,7 +5365,10 @@ mod tests {
 
         world.run_system_once(system).unwrap();
 
-        fn system(_: Query<&mut TestComponent>, query: Query<EntityRefExcept<TestComponent>>) {
+        fn system(
+            _: Query<&mut TestComponent>,
+            query: Query<EntityRefExcept<TestComponent>, With<TestComponent>>,
+        ) {
             for entity_ref in query.iter() {
                 assert!(matches!(
                     entity_ref.get::<TestComponent2>(),
@@ -5447,7 +5450,10 @@ mod tests {
 
         world.run_system_once(system).unwrap();
 
-        fn system(_: Query<&mut TestComponent>, mut query: Query<EntityMutExcept<TestComponent>>) {
+        fn system(
+            _: Query<&mut TestComponent>,
+            mut query: Query<EntityMutExcept<TestComponent>, With<TestComponent>>,
+        ) {
             for mut entity_mut in query.iter_mut() {
                 assert!(entity_mut
                     .get_mut::<TestComponent2>()

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -2005,7 +2005,7 @@ impl<'w> EntityWorldMut<'w> {
             )?
         };
 
-        if new_archetype_id == old_location.archetype_id {
+        if new_archetype_id.id() == old_location.archetype_id {
             return None;
         }
 
@@ -2020,6 +2020,8 @@ impl<'w> EntityWorldMut<'w> {
                 world.into_deferred(),
             )
         };
+
+        new_archetype_id.trigger_if_new(&mut deferred_world);
 
         // SAFETY: all bundle components exist in World
         unsafe {
@@ -2074,7 +2076,7 @@ impl<'w> EntityWorldMut<'w> {
                 entities,
                 archetypes,
                 storages,
-                new_archetype_id,
+                new_archetype_id.id(),
             );
         }
         self.world.flush();
@@ -2191,7 +2193,7 @@ impl<'w> EntityWorldMut<'w> {
             )
             .expect("intersections should always return a result");
 
-        if new_archetype_id == location.archetype_id {
+        if new_archetype_id.id() == location.archetype_id {
             return location;
         }
 
@@ -2205,6 +2207,8 @@ impl<'w> EntityWorldMut<'w> {
                 world.into_deferred(),
             )
         };
+
+        new_archetype_id.trigger_if_new(&mut deferred_world);
 
         // SAFETY: all bundle components exist in World
         unsafe {
@@ -2247,7 +2251,7 @@ impl<'w> EntityWorldMut<'w> {
             &mut world.entities,
             &mut world.archetypes,
             &mut world.storages,
-            new_archetype_id,
+            new_archetype_id.id(),
         );
 
         new_location


### PR DESCRIPTION
# Objective

- Close https://github.com/bevyengine/bevy/pull/14668

## Solution

- Make `QueryState` a component and use observer to update it.
- Add `ArchetypeCreated` event. This will be emitted right after the archetype is created and before any entities are moved in.
- Only `QueryState` from `Query` system param is spawned as entity. I choose to do it to minimize the changes. We still spawn duplicated `QueryState` for now. 

## Testing

- Existing ECS tests should pass.

---
## Future work
- Maybe make `QueryState` private so we can easily dedup? How do we gonna dedup?

## TODO
- Verify safety.
