### PR TITLE
Apply a consistent padding in shader uniforms for the WebGL2 target

### DIFF
--- a/assets/shaders/post_processing.wgsl
+++ b/assets/shaders/post_processing.wgsl
@@ -26,7 +26,9 @@ struct PostProcessSettings {
     intensity: f32,
 #ifdef SIXTEEN_BYTE_ALIGNMENT
     // WebGL2 structs must be 16 byte aligned.
-    _webgl2_padding: vec3<f32>
+	_webgl2_padding_8b: u32,
+	_webgl2_padding_12b: u32,
+	_webgl2_padding_16b: u32,
 #endif
 }
 @group(0) @binding(2) var<uniform> settings: PostProcessSettings;

--- a/crates/bevy_core_pipeline/src/motion_blur/mod.rs
+++ b/crates/bevy_core_pipeline/src/motion_blur/mod.rs
@@ -111,7 +111,9 @@ impl ExtractComponent for MotionBlur {
             shutter_angle: item.shutter_angle,
             samples: item.samples,
             #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
-            _webgl2_padding: Default::default(),
+            _webgl2_padding_12b: 0,
+            #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
+            _webgl2_padding_16b: 0,
         })
     }
 }
@@ -121,9 +123,11 @@ impl ExtractComponent for MotionBlur {
 pub struct MotionBlurUniform {
     shutter_angle: f32,
     samples: u32,
-    #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
     // WebGL2 structs must be 16 byte aligned.
-    _webgl2_padding: bevy_math::Vec2,
+    #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
+    _webgl2_padding_12b: u32,
+    #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
+    _webgl2_padding_16b: u32,
 }
 
 pub const MOTION_BLUR_SHADER_HANDLE: Handle<Shader> =

--- a/crates/bevy_core_pipeline/src/motion_blur/motion_blur.wgsl
+++ b/crates/bevy_core_pipeline/src/motion_blur/motion_blur.wgsl
@@ -18,7 +18,8 @@ struct MotionBlur {
     samples: u32,
 #ifdef SIXTEEN_BYTE_ALIGNMENT
     // WebGL2 structs must be 16 byte aligned.
-    _webgl2_padding: vec2<f32>
+    _webgl2_padding_12b: u32,
+    _webgl2_padding_16b: u32,
 #endif
 }
 @group(0) @binding(4) var<uniform> settings: MotionBlur;

--- a/crates/bevy_core_pipeline/src/skybox/mod.rs
+++ b/crates/bevy_core_pipeline/src/skybox/mod.rs
@@ -132,11 +132,11 @@ impl ExtractComponent for Skybox {
                     .compute_matrix()
                     .inverse(),
                 #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
-                _wasm_padding_8b: 0,
+                _webgl2_padding_8b: 0,
                 #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
-                _wasm_padding_12b: 0,
+                _webgl2_padding_12b: 0,
                 #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
-                _wasm_padding_16b: 0,
+                _webgl2_padding_16b: 0,
             },
         ))
     }
@@ -145,14 +145,15 @@ impl ExtractComponent for Skybox {
 // TODO: Replace with a push constant once WebGPU gets support for that
 #[derive(Component, ShaderType, Clone)]
 pub struct SkyboxUniforms {
-    brightness: f32,
     transform: Mat4,
+    brightness: f32,
+    // WebGL2 structs must be 16 byte aligned.
     #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
-    _wasm_padding_8b: u32,
+    _webgl2_padding_8b: u32,
     #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
-    _wasm_padding_12b: u32,
+    _webgl2_padding_12b: u32,
     #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
-    _wasm_padding_16b: u32,
+    _webgl2_padding_16b: u32,
 }
 
 #[derive(Resource)]

--- a/crates/bevy_core_pipeline/src/skybox/skybox.wgsl
+++ b/crates/bevy_core_pipeline/src/skybox/skybox.wgsl
@@ -2,12 +2,12 @@
 #import bevy_pbr::utils::coords_to_viewport_uv
 
 struct SkyboxUniforms {
+    transform: mat4x4<f32>,
 	brightness: f32,
-	transform: mat4x4<f32>,
 #ifdef SIXTEEN_BYTE_ALIGNMENT
-	_wasm_padding_8b: u32,
-	_wasm_padding_12b: u32,
-	_wasm_padding_16b: u32,
+	_webgl2_padding_8b: u32,
+	_webgl2_padding_12b: u32,
+	_webgl2_padding_16b: u32,
 #endif
 }
 

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -471,8 +471,12 @@ fn extract_gizmo_data(
                 joints_resolution,
                 gap_scale,
                 line_scale,
-                #[cfg(feature = "webgl")]
-                _padding: Default::default(),
+                #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
+                _webgl2_padding_8b: 0,
+                #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
+                _webgl2_padding_12b: 0,
+                #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
+                _webgl2_padding_16b: 0,
             },
             #[cfg(any(feature = "bevy_pbr", feature = "bevy_sprite"))]
             GizmoMeshConfig {
@@ -502,8 +506,12 @@ struct LineGizmoUniform {
     gap_scale: f32,
     line_scale: f32,
     /// WebGL2 structs must be 16 byte aligned.
-    #[cfg(feature = "webgl")]
-    _padding: bevy_math::Vec3,
+    #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
+    _webgl2_padding_8b: u32,
+    #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
+    _webgl2_padding_12b: u32,
+    #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
+    _webgl2_padding_16b: u32,
 }
 
 /// A collection of gizmos.

--- a/crates/bevy_gizmos/src/line_joints.wgsl
+++ b/crates/bevy_gizmos/src/line_joints.wgsl
@@ -2,15 +2,18 @@
 
 @group(0) @binding(0) var<uniform> view: View;
 
-
 struct LineGizmoUniform {
     world_from_local: mat3x4<f32>,
     line_width: f32,
     depth_bias: f32,
-    resolution: u32,
+    joints_resolution: u32,
+    gap_scale: f32,
+    line_scale: f32,
 #ifdef SIXTEEN_BYTE_ALIGNMENT
     // WebGL2 structs must be 16 byte aligned.
-    _padding: f32,
+    _webgl2_padding_8b: u32,
+    _webgl2_padding_12b: u32,
+    _webgl2_padding_16b: u32,
 #endif
 }
 
@@ -188,7 +191,7 @@ fn vertex_round(vertex: VertexInput) -> VertexOutput {
     let ab_norm = vec2(-ab.y, ab.x);
     let cb_norm = vec2(cb.y, -cb.x);
 
-    // We render `joints_gizmo.resolution`triangles. The vertices in each triangle are ordered as follows:
+    // We render `joints_gizmo.joints_resolution` triangles. The vertices in each triangle are ordered as follows:
     // - 0: The 'center' vertex at `screen_b`.
     // - 1: The vertex closer to the ab line.
     // - 2: The vertex closer to the cb line. 
@@ -197,7 +200,7 @@ fn vertex_round(vertex: VertexInput) -> VertexOutput {
     var radius = sign(in_triangle_index) * 0.5 * line_width;
     var theta = acos(dot(ab_norm, cb_norm));
     let sigma = sign(dot(ab_norm, cb));
-    var angle = theta * (tri_index + in_triangle_index - 1) / f32(joints_gizmo.resolution);
+    var angle = theta * (tri_index + in_triangle_index - 1) / f32(joints_gizmo.joints_resolution);
     var position_x = sigma * radius * cos(angle);
     var position_y = radius * sin(angle);
 

--- a/crates/bevy_gizmos/src/lines.wgsl
+++ b/crates/bevy_gizmos/src/lines.wgsl
@@ -13,7 +13,9 @@ struct LineGizmoUniform {
     line_scale: f32,
 #ifdef SIXTEEN_BYTE_ALIGNMENT
     // WebGL2 structs must be 16 byte aligned.
-    _padding: vec3<f32>,
+    _webgl2_padding_8b: u32,
+    _webgl2_padding_12b: u32,
+    _webgl2_padding_16b: u32,
 #endif
 }
 

--- a/crates/bevy_gizmos/src/retained.rs
+++ b/crates/bevy_gizmos/src/retained.rs
@@ -140,8 +140,12 @@ pub(crate) fn extract_linegizmos(
                 joints_resolution,
                 gap_scale,
                 line_scale,
-                #[cfg(feature = "webgl")]
-                _padding: Default::default(),
+                #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
+                _webgl2_padding_8b: 0,
+                #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
+                _webgl2_padding_12b: 0,
+                #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
+                _webgl2_padding_16b: 0,
             },
             #[cfg(any(feature = "bevy_pbr", feature = "bevy_sprite"))]
             crate::config::GizmoMeshConfig {

--- a/crates/bevy_pbr/src/deferred/deferred_lighting.wgsl
+++ b/crates/bevy_pbr/src/deferred/deferred_lighting.wgsl
@@ -24,9 +24,9 @@ struct PbrDeferredLightingDepthId {
     depth_id: u32, // limited to u8
 #ifdef SIXTEEN_BYTE_ALIGNMENT
     // WebGL2 structs must be 16 byte aligned.
-    _webgl2_padding_0: f32,
-    _webgl2_padding_1: f32,
-    _webgl2_padding_2: f32,
+    _webgl2_padding_8b: u32,
+    _webgl2_padding_12b: u32,
+    _webgl2_padding_16b: u32,
 #endif
 }
 @group(1) @binding(0)

--- a/crates/bevy_pbr/src/deferred/mod.rs
+++ b/crates/bevy_pbr/src/deferred/mod.rs
@@ -45,13 +45,13 @@ pub const DEFAULT_PBR_DEFERRED_LIGHTING_PASS_ID: u8 = 1;
 #[derive(Component, Clone, Copy, ExtractComponent, ShaderType)]
 pub struct PbrDeferredLightingDepthId {
     depth_id: u32,
-
+    // WebGL2 structs must be 16 byte aligned.
     #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
-    _webgl2_padding_0: f32,
+    _webgl2_padding_8b: u32,
     #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
-    _webgl2_padding_1: f32,
+    _webgl2_padding_12b: u32,
     #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
-    _webgl2_padding_2: f32,
+    _webgl2_padding_16b: u32,
 }
 
 impl PbrDeferredLightingDepthId {
@@ -60,11 +60,11 @@ impl PbrDeferredLightingDepthId {
             depth_id: value as u32,
 
             #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
-            _webgl2_padding_0: 0.0,
+            _webgl2_padding_8b: 0,
             #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
-            _webgl2_padding_1: 0.0,
+            _webgl2_padding_12b: 0,
             #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
-            _webgl2_padding_2: 0.0,
+            _webgl2_padding_16b: 0,
         }
     }
 
@@ -83,11 +83,11 @@ impl Default for PbrDeferredLightingDepthId {
             depth_id: DEFAULT_PBR_DEFERRED_LIGHTING_PASS_ID as u32,
 
             #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
-            _webgl2_padding_0: 0.0,
+            _webgl2_padding_8b: 0,
             #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
-            _webgl2_padding_1: 0.0,
+            _webgl2_padding_12b: 0,
             #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
-            _webgl2_padding_2: 0.0,
+            _webgl2_padding_16b: 0,
         }
     }
 }

--- a/crates/bevy_render/src/globals.rs
+++ b/crates/bevy_render/src/globals.rs
@@ -58,7 +58,7 @@ pub struct GlobalsUniform {
     frame_count: u32,
     /// WebGL2 structs must be 16 byte aligned.
     #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
-    _wasm_padding: f32,
+    _webgl2_padding_16b: u32,
 }
 
 /// The buffer containing the [`GlobalsUniform`]

--- a/crates/bevy_render/src/globals.wgsl
+++ b/crates/bevy_render/src/globals.wgsl
@@ -11,6 +11,6 @@ struct Globals {
     frame_count: u32,
 #ifdef SIXTEEN_BYTE_ALIGNMENT
     // WebGL2 structs must be 16 byte aligned.
-    _webgl2_padding: f32
+    _webgl2_padding_16b: u32
 #endif
 };

--- a/examples/shader/custom_post_processing.rs
+++ b/examples/shader/custom_post_processing.rs
@@ -303,7 +303,11 @@ struct PostProcessSettings {
     intensity: f32,
     // WebGL2 structs must be 16 byte aligned.
     #[cfg(feature = "webgl2")]
-    _webgl2_padding: Vec3,
+    _webgl2_padding_8b: u32,
+    #[cfg(feature = "webgl2")]
+    _webgl2_padding_12b: u32,
+    #[cfg(feature = "webgl2")]
+    _webgl2_padding_16b: u32,
 }
 
 /// Set up a simple 3D scene


### PR DESCRIPTION
# Objective

Following the discussions in #18812 (and a few messages on [Discord](https://discord.com/channels/691052431525675048/743663924229963868/1362121038644772967)), paddings for the WebGL2 target in the different bevy shader uniforms are found to not always be optimal (or even correct) in size, nor consistent in style.
 
As an example, in `post_processing.wgsl`, the following uniform does not have the expected size.
```rust
struct PostProcessSettings {
    intensity: f32,
#ifdef SIXTEEN_BYTE_ALIGNMENT
    // WebGL2 structs must be 16 byte aligned.
    _webgl2_padding: vec3<f32>
#endif
}
```
```
[...] depending on how the data is prepared, either the vec3 in the shader is pointing to garbage data or the rust serialisation is 
wasting bytes (minor issue if only one value, significant if many values) and is misleading because it says an f32 followed by 12 
empty bytes, followed by the vec3 of padding bytes and then 4 more empty bytes. So it’s 32 bytes just to bind 4 and it’s confusing
because the vec3 doesn’t pack straight after the f32.
```

## Solution

- Remove usage of `vec2` & `vec3` as padding fields
- Changed all shader uniforms to use single scalar `u32` fields as padding
- Changed the naming of padding fields to be consistent (`_webgl2_padding_*b`)
- The uniform declaration in `line_joints.wgsl` seemed not up to date with the rust-side following the gizmos dashed line update. The `gap_scale` and `line_scale` fields were missing from the shader-side uniform declaration. They were only declared in `LineGizmoUniform` in `lines.wgsl`.
  - **Question to reviewers:** should/could both shaders share a common `LineGizmoUniform` declaration in `lines.wgsl` exported via a `#define_import_path bevy_gizmos::lines` ?
- In `SkyboxUniforms`, the `transform` and `brightness` fields were **swapped**. I may be wrong but I supposed that the `mat4x4<f32>` being after the `f32` could cause padding to be inserted between the brightness and transform fields (to align the mat4x4 on 16 byte).
  - **Question to reviewers:** I could not get the `skybox` example to crash on WebGL2, even by removing all the padding fields in this uniform, or by adding just 1 or 2 instead of 3. I don't know why this is the case.
  
For reference, WGSL [alignment and size](https://www.w3.org/TR/WGSL/#alignment-and-size).

## Testing

- Tested the examples locally for both Native Vulkan & WebGL2
  - 2d_gizmos
  - 3d_gizmos
  - skybox
  - post_processing
  - motion_blur
  - deferred lightning
