### PR TITLE
Add TilemapChunk rendering

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -815,6 +815,17 @@ category = "2D Rendering"
 wasm = false
 
 [[example]]
+name = "tilemap_chunk"
+path = "examples/2d/tilemap_chunk.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.tilemap_chunk]
+name = "Tilemap Chunk"
+description = "Renders a tilemap chunk"
+category = "2D Rendering"
+wasm = true
+
+[[example]]
 name = "transparency_2d"
 path = "examples/2d/transparency_2d.rs"
 doc-scrape-examples = true

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -16,6 +16,7 @@ mod picking_backend;
 mod render;
 mod sprite;
 mod texture_slice;
+mod tilemap_chunk;
 
 /// The sprite prelude.
 ///
@@ -40,6 +41,7 @@ pub use picking_backend::*;
 pub use render::*;
 pub use sprite::*;
 pub use texture_slice::*;
+pub use tilemap_chunk::*;
 
 use bevy_app::prelude::*;
 use bevy_asset::{load_internal_asset, weak_handle, AssetEvents, Assets, Handle};
@@ -96,7 +98,12 @@ impl Plugin for SpritePlugin {
             .register_type::<TextureSlicer>()
             .register_type::<Anchor>()
             .register_type::<Mesh2d>()
-            .add_plugins((Mesh2dRenderPlugin, ColorMaterialPlugin))
+            .add_plugins((
+                Mesh2dRenderPlugin,
+                ColorMaterialPlugin,
+                TilemapChunkPlugin,
+                TilemapChunkMaterialPlugin,
+            ))
             .add_systems(
                 PostUpdate,
                 (

--- a/crates/bevy_sprite/src/tilemap_chunk/mod.rs
+++ b/crates/bevy_sprite/src/tilemap_chunk/mod.rs
@@ -1,0 +1,5 @@
+mod tilemap_chunk;
+mod tilemap_chunk_material;
+
+pub use tilemap_chunk::*;
+pub use tilemap_chunk_material::*;

--- a/crates/bevy_sprite/src/tilemap_chunk/tilemap_chunk.rs
+++ b/crates/bevy_sprite/src/tilemap_chunk/tilemap_chunk.rs
@@ -1,0 +1,113 @@
+use super::TilemapChunkMaterial;
+use crate::MeshMaterial2d;
+use bevy_app::{App, Plugin, Update};
+use bevy_asset::{Assets, Handle};
+use bevy_derive::{Deref, DerefMut};
+use bevy_ecs::{
+    component::Component,
+    observer::Trigger,
+    query::Changed,
+    system::{Commands, Query, ResMut},
+    world::OnAdd,
+};
+use bevy_image::Image;
+use bevy_math::{primitives::Rectangle, UVec2};
+use bevy_render::{
+    mesh::{Mesh, Mesh2d},
+    storage::ShaderStorageBuffer,
+};
+
+/// Plugin that handles the initialization and updating of tilemap chunks.
+/// Adds systems for processing newly added tilemap chunks and updating their indices.
+pub struct TilemapChunkPlugin;
+
+impl Plugin for TilemapChunkPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_observer(on_add_tilemap_chunk)
+            .add_systems(Update, update_tilemap_chunk_indices);
+    }
+}
+
+/// A component representing a chunk of a tilemap.
+/// Each chunk is a rectangular section of tiles that is rendered as a single mesh.
+#[derive(Component, Clone, Debug, Default)]
+#[require(Mesh2d, MeshMaterial2d<TilemapChunkMaterial>, TilemapChunkIndices)]
+pub struct TilemapChunk {
+    /// The size of the chunk in tiles
+    pub chunk_size: UVec2,
+    /// The size of each tile in pixels
+    pub tile_size: UVec2,
+    /// Handle to the tileset image containing all tile textures
+    pub tileset: Handle<Image>,
+}
+
+/// Component storing the indices of tiles within a chunk.
+/// Each index corresponds to a specific tile in the tileset.
+#[derive(Component, Clone, Debug, Default, Deref, DerefMut)]
+pub struct TilemapChunkIndices(pub Vec<Option<u32>>);
+
+fn on_add_tilemap_chunk(
+    trigger: Trigger<OnAdd, TilemapChunk>,
+    mut commands: Commands,
+    mut query: Query<(&TilemapChunk, &mut TilemapChunkIndices)>,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<TilemapChunkMaterial>>,
+    mut buffers: ResMut<Assets<ShaderStorageBuffer>>,
+) {
+    let (
+        TilemapChunk {
+            chunk_size,
+            tile_size,
+            tileset,
+        },
+        mut indices,
+    ) = query.get_mut(trigger.target()).unwrap();
+
+    // Ensure the indices buffer is the same size as the chunk
+    indices.resize((chunk_size.x * chunk_size.y) as usize, None);
+
+    commands.entity(trigger.target()).insert((
+        Mesh2d(meshes.add(Rectangle::from_size(
+            chunk_size.as_vec2() * tile_size.as_vec2(),
+        ))),
+        MeshMaterial2d(
+            materials.add(TilemapChunkMaterial {
+                chunk_size: *chunk_size,
+                tile_size: *tile_size,
+                tileset: tileset.clone(),
+                indices: buffers.add(ShaderStorageBuffer::from(
+                    indices
+                        .iter()
+                        .map(|i| i.unwrap_or(u32::MAX))
+                        .collect::<Vec<u32>>(),
+                )),
+            }),
+        ),
+    ));
+}
+
+fn update_tilemap_chunk_indices(
+    mut query: Query<
+        (
+            &TilemapChunk,
+            &mut TilemapChunkIndices,
+            &MeshMaterial2d<TilemapChunkMaterial>,
+        ),
+        Changed<TilemapChunkIndices>,
+    >,
+    mut materials: ResMut<Assets<TilemapChunkMaterial>>,
+    mut buffers: ResMut<Assets<ShaderStorageBuffer>>,
+) {
+    for (chunk, mut indices, material) in &mut query {
+        indices.resize((chunk.chunk_size.x * chunk.chunk_size.y) as usize, None);
+        let material = materials.get_mut(material.id()).unwrap();
+        if let Some(buffer) = buffers.get_mut(&material.indices) {
+            buffer.set_data(
+                indices
+                    .iter()
+                    .map(|i| i.unwrap_or(u32::MAX))
+                    .collect::<Vec<u32>>(),
+            );
+        }
+    }
+}

--- a/crates/bevy_sprite/src/tilemap_chunk/tilemap_chunk_material.rs
+++ b/crates/bevy_sprite/src/tilemap_chunk/tilemap_chunk_material.rs
@@ -1,0 +1,53 @@
+use crate::{Material2d, Material2dPlugin};
+use bevy_app::{App, Plugin};
+use bevy_asset::{load_internal_asset, weak_handle, Asset, Handle};
+use bevy_image::Image;
+use bevy_math::UVec2;
+use bevy_reflect::prelude::*;
+use bevy_render::{render_resource::*, storage::ShaderStorageBuffer};
+
+pub const TILEMAP_CHUNK_MATERIAL_SHADER_HANDLE: Handle<Shader> =
+    weak_handle!("40f33e62-82f8-4578-b3fa-f22989e7c4bb");
+
+/// Plugin that adds support for tilemap chunk materials.
+#[derive(Default)]
+pub struct TilemapChunkMaterialPlugin;
+
+impl Plugin for TilemapChunkMaterialPlugin {
+    fn build(&self, app: &mut App) {
+        load_internal_asset!(
+            app,
+            TILEMAP_CHUNK_MATERIAL_SHADER_HANDLE,
+            "tilemap_chunk_material.wgsl",
+            Shader::from_wgsl
+        );
+
+        app.add_plugins(Material2dPlugin::<TilemapChunkMaterial>::default());
+    }
+}
+
+/// Material used for rendering tilemap chunks.
+///
+/// This material is used internally by the tilemap system to render chunks of tiles
+/// efficiently using a single draw call per chunk.
+#[derive(Asset, TypePath, AsBindGroup, Debug, Clone)]
+pub struct TilemapChunkMaterial {
+    #[uniform(0)]
+    pub chunk_size: UVec2,
+
+    #[uniform(0)]
+    pub tile_size: UVec2,
+
+    #[texture(1, dimension = "2d_array")]
+    #[sampler(2)]
+    pub tileset: Handle<Image>,
+
+    #[storage(3, read_only)]
+    pub indices: Handle<ShaderStorageBuffer>,
+}
+
+impl Material2d for TilemapChunkMaterial {
+    fn fragment_shader() -> ShaderRef {
+        TILEMAP_CHUNK_MATERIAL_SHADER_HANDLE.into()
+    }
+}

--- a/crates/bevy_sprite/src/tilemap_chunk/tilemap_chunk_material.wgsl
+++ b/crates/bevy_sprite/src/tilemap_chunk/tilemap_chunk_material.wgsl
@@ -1,0 +1,32 @@
+#import bevy_sprite::{
+    mesh2d_vertex_output::VertexOutput
+}
+
+struct TilemapChunkMaterial {
+    chunk_size: vec2<u32>,
+    tile_size: vec2<u32>,
+};
+
+@group(2) @binding(0) var<uniform> material: TilemapChunkMaterial;
+@group(2) @binding(1) var tileset: texture_2d_array<f32>;
+@group(2) @binding(2) var tileset_sampler: sampler;
+@group(2) @binding(3) var<storage> indices: array<u32>;
+
+@fragment
+fn fragment(mesh: VertexOutput) -> @location(0) vec4<f32> {
+    let tile_uv = mesh.uv * vec2<f32>(material.chunk_size);
+    let tile_pos = clamp(vec2<u32>(floor(tile_uv)), vec2<u32>(0), material.chunk_size - 1);
+    let index = tile_pos.y * material.chunk_size.x + tile_pos.x;
+    let tile_index = indices[index];
+
+    if tile_index == 0xffffffffu {
+        discard;
+    }
+
+    let local_uv = fract(tile_uv);
+    let color = textureSample(tileset, tileset_sampler, local_uv, tile_index);
+    if (color.a < 0.001) {
+        discard;
+    }
+    return color;
+}

--- a/examples/2d/tilemap_chunk.rs
+++ b/examples/2d/tilemap_chunk.rs
@@ -1,0 +1,78 @@
+#![allow(warnings)]
+
+use bevy::{
+    prelude::*,
+    sprite::{TilemapChunk, TilemapChunkIndices, TilemapChunkMaterial},
+};
+use bevy_asset::RenderAssetUsages;
+use bevy_image::ImageSampler;
+use bevy_render::render_resource::{Extent3d, TextureDimension, TextureFormat, TextureUsages};
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest()))
+        .add_systems(Startup, setup)
+        .run();
+}
+
+fn setup(
+    mut commands: Commands,
+    asset_server: Res<AssetServer>,
+    mut texture_atlas_layouts: ResMut<Assets<TextureAtlasLayout>>,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<TilemapChunkMaterial>>,
+    mut images: ResMut<Assets<Image>>,
+) {
+    let mut rng = ChaCha8Rng::seed_from_u64(42);
+    let chunk_size = UVec2::splat(64);
+    let tile_size = UVec2::splat(16);
+    let tileset: Handle<Image> = images.add(create_test_tileset(tile_size));
+    let indices: Vec<Option<u32>> = (0..chunk_size.x * chunk_size.y)
+        .map(|_| rng.gen_range(0..5))
+        .map(|i| if i == 0 { None } else { Some(i - 1) })
+        .collect();
+
+    commands.spawn((
+        TilemapChunk {
+            chunk_size,
+            tile_size,
+            tileset,
+        },
+        TilemapChunkIndices(indices),
+    ));
+
+    commands.spawn(Camera2d);
+}
+
+fn create_test_tileset(tile_size: UVec2) -> Image {
+    let num_tiles = 4u32;
+    let mut data = Vec::new();
+
+    let colors = [
+        [255, 0, 0, 255],
+        [0, 255, 0, 255],
+        [0, 0, 255, 255],
+        [255, 255, 0, 255],
+    ];
+
+    for tile_idx in 0..num_tiles {
+        let color = colors[tile_idx as usize];
+        for _ in 0..tile_size.element_product() {
+            data.extend_from_slice(&color);
+        }
+    }
+
+    Image::new(
+        Extent3d {
+            width: tile_size.x,
+            height: tile_size.y,
+            depth_or_array_layers: num_tiles,
+        },
+        TextureDimension::D2,
+        data,
+        TextureFormat::Rgba8UnormSrgb,
+        RenderAssetUsages::default(),
+    )
+}


### PR DESCRIPTION
# Objective

An attempt to start building a base for first-party tilemaps (#13782).

The objective was to create a very simple tilemap chunk rendering that can be used as a building block for 3rd-party tilemap crates, and eventually a first-party tilemap implementation.

## Solution

- Introduces two user-facing components, `TilemapChunk` and `TilemapChunkIndices`, and a new material `TilemapChunkMaterial`.
- `TilemapChunk` holds the chunk and tile sizes, and the tileset image
  - The tileset image is expected to be a layered image for use with `texture_2d_array`, with the assumption that atlases or multiple images would go through an asset loader/processor. Not sure if that should be part of this PR or not..
- `TilemapChunkIndices` holds a 1d representation of all of the tile's Option<u32> index into the tileset image.
  - Indices are fixed to the size of tiles in a chunk (though maybe this should just be an assertion instead?)
  - Indices are cloned and sent to the shader through a `ShaderStorageBuffer`

## Testing

- Initial testing done with the `tilemap_chunk` example, though I need to include some way to update indices as part of it.
- I'm thinking it would probably be good to do some basic perf testing.

---

## Showcase

```rust
let chunk_size = UVec2::splat(64);
let tile_size = UVec2::splat(16);
let tileset: Handle<Image> = images.add(create_test_tileset(tile_size));
let indices: Vec<Option<u32>> = (0..chunk_size.x * chunk_size.y)
    .map(|_| rng.gen_range(0..5))
    .map(|i| if i == 0 { None } else { Some(i - 1) })
    .collect();

commands.spawn((
    TilemapChunk {
        chunk_size,
        tile_size,
        tileset,
    },
    TilemapChunkIndices(indices),
));
```

![Screenshot 2025-04-17 at 1 02 08 AM](https://github.com/user-attachments/assets/ce72da04-9b89-45d6-a5eb-bf8a15603015)

