### PR TITLE
Removed conversion from pointer physical coordinates to viewport local coordinates in bevy_picking make_ray function

### DIFF
--- a/crates/bevy_picking/src/backend.rs
+++ b/crates/bevy_picking/src/backend.rs
@@ -229,11 +229,8 @@ pub mod ray {
         if !pointer_loc.is_in_viewport(camera, primary_window_entity) {
             return None;
         }
-        let mut viewport_pos = pointer_loc.position;
-        if let Some(viewport) = &camera.viewport {
-            let viewport_logical = camera.to_logical(viewport.physical_position)?;
-            viewport_pos -= viewport_logical;
-        }
-        camera.viewport_to_world(camera_tfm, viewport_pos).ok()
+        camera
+            .viewport_to_world(camera_tfm, pointer_loc.position)
+            .ok()
     }
 }


### PR DESCRIPTION
# Objective

- Fixes #18856.

## Solution

After PR #17633, `Camera::viewport_to_world` method corrects `viewport_position` passed in that input so that it's offset by camera's viewport. `Camera::viewport_to_world` is used by `make_ray` function which in turn also offsets pointer position by viewport position, which causes picking objects to be shifted by viewport position, and it wasn't removed in the aforementioned PR. This second offsetting in `make_ray` was removed.

## Testing

- I tested simple_picking example by applying some horizontal offset to camera's viewport.
- I tested my application that displayed a single rectangle with picking on two cameras arranged in a row. When using local bevy with this fix, both cameras can be used for picking correctly.
- I modified split_screen example: I added observer to ground plane that changes color on hover, and removed UI as it interfered with picking both on master and my branch. On master, only top left camera was triggering the observer, and on my branch all cameras could change plane's color on hover.
- I added viewport offset to mesh_picking, with my changes it works correctly, while on master picking ray is shifted.
- Sprite picking with viewport offset doesn't work both on master and on this branch.

These are the only scenarios I tested. I think other picking functions that use this function should be tested but I couldn't track more uses of it.
