### PR TITLE
Split `Camera.hdr` out into a new component

### DIFF
--- a/crates/bevy_core_pipeline/src/auto_exposure/settings.rs
+++ b/crates/bevy_core_pipeline/src/auto_exposure/settings.rs
@@ -5,7 +5,7 @@ use bevy_asset::Handle;
 use bevy_ecs::{prelude::Component, reflect::ReflectComponent};
 use bevy_image::Image;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
-use bevy_render::extract_component::ExtractComponent;
+use bevy_render::{extract_component::ExtractComponent, view::Hdr};
 use bevy_utils::default;
 
 /// Component that enables auto exposure for an HDR-enabled 2d or 3d camera.
@@ -25,6 +25,7 @@ use bevy_utils::default;
 /// **Auto Exposure requires compute shaders and is not compatible with WebGL2.**
 #[derive(Component, Clone, Reflect, ExtractComponent)]
 #[reflect(Component, Default, Clone)]
+#[require(Hdr)]
 pub struct AutoExposure {
     /// The range of exposure values for the histogram.
     ///

--- a/crates/bevy_core_pipeline/src/bloom/settings.rs
+++ b/crates/bevy_core_pipeline/src/bloom/settings.rs
@@ -1,8 +1,12 @@
 use super::downsampling_pipeline::BloomUniforms;
-use bevy_ecs::{prelude::Component, query::QueryItem, reflect::ReflectComponent};
+use bevy_ecs::{
+    prelude::Component,
+    query::{QueryItem, With},
+    reflect::ReflectComponent,
+};
 use bevy_math::{AspectRatio, URect, UVec4, Vec2, Vec4};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
-use bevy_render::{extract_component::ExtractComponent, prelude::Camera};
+use bevy_render::{extract_component::ExtractComponent, prelude::Camera, view::Hdr};
 
 /// Applies a bloom effect to an HDR-enabled 2d or 3d camera.
 ///
@@ -26,6 +30,7 @@ use bevy_render::{extract_component::ExtractComponent, prelude::Camera};
 /// used in Bevy as well as a visualization of the curve's respective scattering profile.
 #[derive(Component, Reflect, Clone)]
 #[reflect(Component, Default, Clone)]
+#[require(Hdr)]
 pub struct Bloom {
     /// Controls the baseline of how much the image is scattered (default: 0.15).
     ///
@@ -219,7 +224,7 @@ pub enum BloomCompositeMode {
 impl ExtractComponent for Bloom {
     type QueryData = (&'static Self, &'static Camera);
 
-    type QueryFilter = ();
+    type QueryFilter = With<Hdr>;
     type Out = (Self, BloomUniforms);
 
     fn extract_component((bloom, camera): QueryItem<'_, Self::QueryData>) -> Option<Self::Out> {
@@ -228,9 +233,8 @@ impl ExtractComponent for Bloom {
             camera.physical_viewport_size(),
             camera.physical_target_size(),
             camera.is_active,
-            camera.hdr,
         ) {
-            (Some(URect { min: origin, .. }), Some(size), Some(target_size), true, true)
+            (Some(URect { min: origin, .. }), Some(size), Some(target_size), true)
                 if size.x != 0 && size.y != 0 =>
             {
                 let threshold = bloom.prefilter.threshold;

--- a/crates/bevy_pbr/src/atmosphere/mod.rs
+++ b/crates/bevy_pbr/src/atmosphere/mod.rs
@@ -50,6 +50,7 @@ use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{
     extract_component::UniformComponentPlugin,
     render_resource::{DownlevelFlags, ShaderType, SpecializedRenderPipelines},
+    view::Hdr,
 };
 use bevy_render::{
     extract_component::{ExtractComponent, ExtractComponentPlugin},
@@ -246,7 +247,7 @@ impl Plugin for AtmospherePlugin {
 /// from the planet's surface, ozone only exists in a band centered at a fairly
 /// high altitude.
 #[derive(Clone, Component, Reflect, ShaderType)]
-#[require(AtmosphereSettings)]
+#[require(AtmosphereSettings, Hdr)]
 #[reflect(Clone, Default)]
 pub struct Atmosphere {
     /// Radius of the planet

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -13,7 +13,7 @@ use crate::{
     sync_world::{RenderEntity, SyncToRenderWorld},
     texture::GpuImage,
     view::{
-        ColorGrading, ExtractedView, ExtractedWindows, Msaa, NoIndirectDrawing, RenderLayers,
+        ColorGrading, ExtractedView, ExtractedWindows, Hdr, Msaa, NoIndirectDrawing, RenderLayers,
         RenderVisibleEntities, RetainedViewEntity, ViewUniformOffset, Visibility, VisibleEntities,
     },
     Extract,
@@ -356,9 +356,6 @@ pub struct Camera {
     pub computed: ComputedCameraValues,
     /// The "target" that this camera will render to.
     pub target: RenderTarget,
-    /// If this is set to `true`, the camera will use an intermediate "high dynamic range" render texture.
-    /// This allows rendering with a wider range of lighting values.
-    pub hdr: bool,
     // todo: reflect this when #6042 lands
     /// The [`CameraOutputMode`] for this camera.
     #[reflect(ignore, clone)]
@@ -389,7 +386,6 @@ impl Default for Camera {
             computed: Default::default(),
             target: Default::default(),
             output_mode: Default::default(),
-            hdr: false,
             msaa_writeback: true,
             clear_color: Default::default(),
             sub_camera_view: None,
@@ -1101,6 +1097,7 @@ pub fn extract_cameras(
             &GlobalTransform,
             &VisibleEntities,
             &Frustum,
+            Has<Hdr>,
             Option<&ColorGrading>,
             Option<&Exposure>,
             Option<&TemporalJitter>,
@@ -1122,6 +1119,7 @@ pub fn extract_cameras(
         transform,
         visible_entities,
         frustum,
+        hdr,
         color_grading,
         exposure,
         temporal_jitter,
@@ -1200,14 +1198,14 @@ pub fn extract_cameras(
                     exposure: exposure
                         .map(Exposure::exposure)
                         .unwrap_or_else(|| Exposure::default().exposure()),
-                    hdr: camera.hdr,
+                    hdr,
                 },
                 ExtractedView {
                     retained_view_entity: RetainedViewEntity::new(main_entity.into(), None, 0),
                     clip_from_view: camera.clip_from_view(),
                     world_from_view: *transform,
                     clip_from_world: None,
-                    hdr: camera.hdr,
+                    hdr,
                     viewport: UVec4::new(
                         viewport_origin.x,
                         viewport_origin.y,

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -114,6 +114,7 @@ impl Plugin for ViewPlugin {
             .register_type::<OcclusionCulling>()
             // NOTE: windows.is_changed() handles cases where a window was resized
             .add_plugins((
+                ExtractComponentPlugin::<Hdr>::default(),
                 ExtractComponentPlugin::<Msaa>::default(),
                 ExtractComponentPlugin::<OcclusionCulling>::default(),
                 VisibilityPlugin,
@@ -198,6 +199,14 @@ impl Msaa {
         }
     }
 }
+
+/// If this component is added to a camera, the camera will use an intermediate "high dynamic range" render texture.
+/// This allows rendering with a wider range of lighting values.
+#[derive(
+    Component, Default, Copy, Clone, ExtractComponent, Reflect, PartialEq, Eq, Hash, Debug,
+)]
+#[reflect(Component, Default, PartialEq, Hash, Debug)]
+pub struct Hdr;
 
 /// An identifier for a view that is stable across frames.
 ///

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -27,7 +27,7 @@ use bevy_render::render_phase::ViewSortedRenderPhases;
 use bevy_render::renderer::RenderContext;
 use bevy_render::sync_world::MainEntity;
 use bevy_render::texture::TRANSPARENT_IMAGE_HANDLE;
-use bevy_render::view::RetainedViewEntity;
+use bevy_render::view::{Hdr, RetainedViewEntity};
 use bevy_render::{
     camera::Camera,
     render_asset::RenderAssets,
@@ -613,6 +613,7 @@ pub fn extract_ui_camera_view(
                 Entity,
                 RenderEntity,
                 &Camera,
+                Has<Hdr>,
                 Option<&UiAntiAlias>,
                 Option<&BoxShadowSamples>,
             ),
@@ -623,7 +624,7 @@ pub fn extract_ui_camera_view(
 ) {
     live_entities.clear();
 
-    for (main_entity, render_entity, camera, ui_anti_alias, shadow_samples) in &query {
+    for (main_entity, render_entity, camera, hdr, ui_anti_alias, shadow_samples) in &query {
         // ignore inactive cameras
         if !camera.is_active {
             commands
@@ -659,7 +660,7 @@ pub fn extract_ui_camera_view(
                             UI_CAMERA_FAR + UI_CAMERA_TRANSFORM_OFFSET,
                         ),
                         clip_from_world: None,
-                        hdr: camera.hdr,
+                        hdr,
                         viewport: UVec4::from((
                             physical_viewport_rect.min,
                             physical_viewport_rect.size(),

--- a/examples/2d/bloom_2d.rs
+++ b/examples/2d/bloom_2d.rs
@@ -25,7 +25,6 @@ fn setup(
     commands.spawn((
         Camera2d,
         Camera {
-            hdr: true, // 1. HDR is required for bloom
             clear_color: ClearColorConfig::Custom(Color::BLACK),
             ..default()
         },

--- a/examples/3d/anti_aliasing.rs
+++ b/examples/3d/anti_aliasing.rs
@@ -19,6 +19,7 @@ use bevy::{
         render_resource::{Extent3d, TextureDimension, TextureFormat},
     },
 };
+use bevy_render::view::Hdr;
 
 fn main() {
     App::new()
@@ -300,10 +301,7 @@ fn setup(
     // Camera
     commands.spawn((
         Camera3d::default(),
-        Camera {
-            hdr: true,
-            ..default()
-        },
+        Hdr,
         Transform::from_xyz(0.7, 0.7, 1.0).looking_at(Vec3::new(0.0, 0.3, 0.0), Vec3::Y),
         ContrastAdaptiveSharpening {
             enabled: false,

--- a/examples/3d/atmosphere.rs
+++ b/examples/3d/atmosphere.rs
@@ -8,6 +8,7 @@ use bevy::{
     prelude::*,
     render::camera::Exposure,
 };
+use bevy_render::view::Hdr;
 
 fn main() {
     App::new()
@@ -20,11 +21,6 @@ fn main() {
 fn setup_camera_fog(mut commands: Commands) {
     commands.spawn((
         Camera3d::default(),
-        // HDR is required for atmospheric scattering to be properly applied to the scene
-        Camera {
-            hdr: true,
-            ..default()
-        },
         Transform::from_xyz(-1.2, 0.15, 0.0).looking_at(Vec3::Y * 0.1, Vec3::Y),
         // This is the component that enables atmospheric scattering for a camera
         Atmosphere::EARTH,
@@ -36,7 +32,7 @@ fn setup_camera_fog(mut commands: Commands) {
             scene_units_to_m: 1e+4,
             ..Default::default()
         },
-        // The directional light illuminance  used in this scene
+        // The directional light illuminance used in this scene
         // (the one recommended for use with this feature) is
         // quite bright, so raising the exposure compensation helps
         // bring the scene to a nicer brightness range.

--- a/examples/3d/auto_exposure.rs
+++ b/examples/3d/auto_exposure.rs
@@ -40,10 +40,6 @@ fn setup(
 
     commands.spawn((
         Camera3d::default(),
-        Camera {
-            hdr: true,
-            ..default()
-        },
         Transform::from_xyz(1.0, 0.0, 0.0).looking_at(Vec3::ZERO, Vec3::Y),
         AutoExposure {
             metering_mask: metering_mask.clone(),

--- a/examples/3d/bloom_3d.rs
+++ b/examples/3d/bloom_3d.rs
@@ -29,7 +29,6 @@ fn setup_scene(
     commands.spawn((
         Camera3d::default(),
         Camera {
-            hdr: true, // 1. HDR is required for bloom
             clear_color: ClearColorConfig::Custom(Color::BLACK),
             ..default()
         },

--- a/examples/3d/clearcoat.rs
+++ b/examples/3d/clearcoat.rs
@@ -26,6 +26,7 @@ use bevy::{
     math::vec3,
     prelude::*,
 };
+use bevy_render::view::Hdr;
 
 /// The size of each sphere.
 const SPHERE_SCALE: f32 = 0.9;
@@ -191,10 +192,7 @@ fn spawn_camera(commands: &mut Commands, asset_server: &AssetServer) {
     commands
         .spawn((
             Camera3d::default(),
-            Camera {
-                hdr: true,
-                ..default()
-            },
+            Hdr,
             Projection::Perspective(PerspectiveProjection {
                 fov: 27.0 / 180.0 * PI,
                 ..default()

--- a/examples/3d/color_grading.rs
+++ b/examples/3d/color_grading.rs
@@ -11,6 +11,7 @@ use bevy::{
     prelude::*,
     render::view::{ColorGrading, ColorGradingGlobal, ColorGradingSection},
 };
+use bevy_render::view::Hdr;
 use std::fmt::Display;
 
 static FONT_PATH: &str = "fonts/FiraMono-Medium.ttf";
@@ -334,10 +335,7 @@ fn add_text<'a>(
 fn add_camera(commands: &mut Commands, asset_server: &AssetServer, color_grading: ColorGrading) {
     commands.spawn((
         Camera3d::default(),
-        Camera {
-            hdr: true,
-            ..default()
-        },
+        Hdr,
         Transform::from_xyz(0.7, 0.7, 1.0).looking_at(Vec3::new(0.0, 0.3, 0.0), Vec3::Y),
         color_grading,
         DistanceFog {

--- a/examples/3d/deferred_rendering.rs
+++ b/examples/3d/deferred_rendering.rs
@@ -33,11 +33,6 @@ fn setup(
 ) {
     commands.spawn((
         Camera3d::default(),
-        Camera {
-            // Deferred both supports both hdr: true and hdr: false
-            hdr: false,
-            ..default()
-        },
         Transform::from_xyz(0.7, 0.7, 1.0).looking_at(Vec3::new(0.0, 0.3, 0.0), Vec3::Y),
         // MSAA needs to be off for Deferred rendering
         Msaa::Off,

--- a/examples/3d/depth_of_field.rs
+++ b/examples/3d/depth_of_field.rs
@@ -73,10 +73,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, app_settings: R
     let mut camera = commands.spawn((
         Camera3d::default(),
         Transform::from_xyz(0.0, 4.5, 8.25).looking_at(Vec3::ZERO, Vec3::Y),
-        Camera {
-            hdr: true,
-            ..default()
-        },
         Tonemapping::TonyMcMapface,
         Bloom::NATURAL,
     ));

--- a/examples/3d/fog_volumes.rs
+++ b/examples/3d/fog_volumes.rs
@@ -10,6 +10,7 @@ use bevy::{
     pbr::{FogVolume, VolumetricFog, VolumetricLight},
     prelude::*,
 };
+use bevy_render::view::Hdr;
 
 /// Entry point.
 fn main() {
@@ -58,10 +59,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn((
         Camera3d::default(),
         Transform::from_xyz(-0.75, 1.0, 2.0).looking_at(vec3(0.0, 0.0, 0.0), Vec3::Y),
-        Camera {
-            hdr: true,
-            ..default()
-        },
+        Hdr,
         VolumetricFog {
             // Make this relatively high in order to increase the fog quality.
             step_count: 64,

--- a/examples/3d/mesh_ray_cast.rs
+++ b/examples/3d/mesh_ray_cast.rs
@@ -104,10 +104,6 @@ fn setup(
     // Camera
     commands.spawn((
         Camera3d::default(),
-        Camera {
-            hdr: true,
-            ..default()
-        },
         Transform::from_xyz(1.5, 1.5, 1.5).looking_at(Vec3::ZERO, Vec3::Y),
         Tonemapping::TonyMcMapface,
         Bloom::default(),

--- a/examples/3d/post_processing.rs
+++ b/examples/3d/post_processing.rs
@@ -7,6 +7,7 @@ use std::f32::consts::PI;
 use bevy::{
     core_pipeline::post_process::ChromaticAberration, pbr::CascadeShadowConfigBuilder, prelude::*,
 };
+use bevy_render::view::Hdr;
 
 /// The number of units per frame to add to or subtract from intensity when the
 /// arrow keys are held.
@@ -60,10 +61,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, app_settings: R
 fn spawn_camera(commands: &mut Commands, asset_server: &AssetServer) {
     commands.spawn((
         Camera3d::default(),
-        Camera {
-            hdr: true,
-            ..default()
-        },
+        Hdr,
         Transform::from_xyz(0.7, 0.7, 1.0).looking_at(Vec3::new(0.0, 0.3, 0.0), Vec3::Y),
         DistanceFog {
             color: Color::srgb_u8(43, 44, 47),

--- a/examples/3d/reflection_probes.rs
+++ b/examples/3d/reflection_probes.rs
@@ -7,6 +7,7 @@
 //! Reflection probes don't work on WebGL 2 or WebGPU.
 
 use bevy::{core_pipeline::Skybox, prelude::*};
+use bevy_render::view::Hdr;
 
 use std::{
     f32::consts::PI,
@@ -105,11 +106,8 @@ fn spawn_scene(commands: &mut Commands, asset_server: &AssetServer) {
 fn spawn_camera(commands: &mut Commands) {
     commands.spawn((
         Camera3d::default(),
-        Camera {
-            hdr: true,
-            ..default()
-        },
         Transform::from_xyz(-6.483, 0.325, 4.381).looking_at(Vec3::ZERO, Vec3::Y),
+        Hdr,
     ));
 }
 

--- a/examples/3d/rotate_environment_map.rs
+++ b/examples/3d/rotate_environment_map.rs
@@ -8,6 +8,7 @@ use bevy::{
     image::ImageLoaderSettings,
     prelude::*,
 };
+use bevy_render::view::Hdr;
 
 /// Entry point.
 pub fn main() {
@@ -95,10 +96,7 @@ fn spawn_camera(commands: &mut Commands, asset_server: &AssetServer) {
     commands
         .spawn((
             Camera3d::default(),
-            Camera {
-                hdr: true,
-                ..default()
-            },
+            Hdr,
             Projection::Perspective(PerspectiveProjection {
                 fov: 27.0 / 180.0 * PI,
                 ..default()

--- a/examples/3d/scrolling_fog.rs
+++ b/examples/3d/scrolling_fog.rs
@@ -49,10 +49,6 @@ fn setup(
     commands.spawn((
         Camera3d::default(),
         Transform::from_xyz(0.0, 2.0, 0.0).looking_at(Vec3::new(-5.0, 3.5, -6.0), Vec3::Y),
-        Camera {
-            hdr: true,
-            ..default()
-        },
         Msaa::Off,
         TemporalAntiAliasing::default(),
         Bloom::default(),

--- a/examples/3d/specular_tint.rs
+++ b/examples/3d/specular_tint.rs
@@ -3,6 +3,7 @@
 use std::f32::consts::PI;
 
 use bevy::{color::palettes::css::WHITE, core_pipeline::Skybox, prelude::*};
+use bevy_render::view::Hdr;
 
 /// The camera rotation speed in radians per frame.
 const ROTATION_SPEED: f32 = 0.005;
@@ -82,10 +83,7 @@ fn setup(
     // Spawns a camera.
     commands.spawn((
         Transform::from_xyz(-2.0, 0.0, 3.5).looking_at(Vec3::ZERO, Vec3::Y),
-        Camera {
-            hdr: true,
-            ..default()
-        },
+        Hdr,
         Camera3d::default(),
         Skybox {
             image: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),

--- a/examples/3d/spotlight.rs
+++ b/examples/3d/spotlight.rs
@@ -8,6 +8,7 @@ use bevy::{
     pbr::NotShadowCaster,
     prelude::*,
 };
+use bevy_render::view::Hdr;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 
@@ -119,10 +120,7 @@ fn setup(
     // camera
     commands.spawn((
         Camera3d::default(),
-        Camera {
-            hdr: true,
-            ..default()
-        },
+        Hdr,
         Transform::from_xyz(-4.0, 5.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
     ));
 

--- a/examples/3d/ssao.rs
+++ b/examples/3d/ssao.rs
@@ -7,6 +7,7 @@ use bevy::{
     prelude::*,
     render::camera::TemporalJitter,
 };
+use bevy_render::view::Hdr;
 use std::f32::consts::PI;
 
 fn main() {
@@ -28,11 +29,8 @@ fn setup(
 ) {
     commands.spawn((
         Camera3d::default(),
-        Camera {
-            hdr: true,
-            ..default()
-        },
         Transform::from_xyz(-2.0, 2.0, -2.0).looking_at(Vec3::ZERO, Vec3::Y),
+        Hdr,
         Msaa::Off,
         ScreenSpaceAmbientOcclusion::default(),
         TemporalAntiAliasing::default(),

--- a/examples/3d/ssr.rs
+++ b/examples/3d/ssr.rs
@@ -18,6 +18,7 @@ use bevy::{
     prelude::*,
     render::render_resource::{AsBindGroup, ShaderRef, ShaderType},
 };
+use bevy_render::view::Hdr;
 
 /// This example uses a shader source file from the assets subdirectory
 const SHADER_ASSET_PATH: &str = "shaders/water_material.wgsl";
@@ -227,10 +228,7 @@ fn spawn_camera(commands: &mut Commands, asset_server: &AssetServer) {
         .spawn((
             Camera3d::default(),
             Transform::from_translation(vec3(-1.25, 2.25, 4.5)).looking_at(Vec3::ZERO, Vec3::Y),
-            Camera {
-                hdr: true,
-                ..default()
-            },
+            Hdr,
             Msaa::Off,
         ))
         .insert(EnvironmentMapLight {

--- a/examples/3d/tonemapping.rs
+++ b/examples/3d/tonemapping.rs
@@ -11,6 +11,7 @@ use bevy::{
         view::{ColorGrading, ColorGradingGlobal, ColorGradingSection},
     },
 };
+use bevy_render::view::Hdr;
 use std::f32::consts::PI;
 
 /// This example uses a shader source file from the assets subdirectory
@@ -59,10 +60,7 @@ fn setup(
     // camera
     commands.spawn((
         Camera3d::default(),
-        Camera {
-            hdr: true,
-            ..default()
-        },
+        Hdr,
         camera_transform.0,
         DistanceFog {
             color: Color::srgb_u8(43, 44, 47),

--- a/examples/3d/transmission.rs
+++ b/examples/3d/transmission.rs
@@ -303,10 +303,6 @@ fn setup(
     // Camera
     commands.spawn((
         Camera3d::default(),
-        Camera {
-            hdr: true,
-            ..default()
-        },
         Transform::from_xyz(1.0, 1.8, 7.0).looking_at(Vec3::ZERO, Vec3::Y),
         ColorGrading {
             global: ColorGradingGlobal {

--- a/examples/3d/volumetric_fog.rs
+++ b/examples/3d/volumetric_fog.rs
@@ -65,10 +65,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, app_settings: R
     commands
         .spawn((
             Camera3d::default(),
-            Camera {
-                hdr: true,
-                ..default()
-            },
             Transform::from_xyz(-1.7, 1.5, 4.5).looking_at(vec3(-1.5, 1.7, 3.5), Vec3::Y),
             Tonemapping::TonyMcMapface,
             Bloom::default(),

--- a/examples/animation/animation_events.rs
+++ b/examples/animation/animation_events.rs
@@ -5,6 +5,7 @@ use bevy::{
     core_pipeline::bloom::Bloom,
     prelude::*,
 };
+use bevy_render::view::Hdr;
 
 fn main() {
     App::new()
@@ -44,7 +45,6 @@ fn setup(
         Camera2d,
         Camera {
             clear_color: ClearColorConfig::Custom(BLACK.into()),
-            hdr: true,
             ..Default::default()
         },
         Bloom {

--- a/examples/camera/2d_top_down_camera.rs
+++ b/examples/camera/2d_top_down_camera.rs
@@ -61,14 +61,7 @@ fn setup_instructions(mut commands: Commands) {
 }
 
 fn setup_camera(mut commands: Commands) {
-    commands.spawn((
-        Camera2d,
-        Camera {
-            hdr: true, // HDR is required for the bloom effect
-            ..default()
-        },
-        Bloom::NATURAL,
-    ));
+    commands.spawn((Camera2d, Bloom::NATURAL));
 }
 
 /// Update the camera position by tracking the player.

--- a/examples/math/sampling_primitives.rs
+++ b/examples/math/sampling_primitives.rs
@@ -8,6 +8,7 @@ use bevy::{
     math::prelude::*,
     prelude::*,
 };
+use bevy_render::view::Hdr;
 use rand::{seq::SliceRandom, Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 
@@ -340,7 +341,6 @@ fn setup(
     commands.spawn((
         Camera3d::default(),
         Camera {
-            hdr: true, // HDR is required for bloom
             clear_color: ClearColorConfig::Custom(SKY_COLOR),
             ..default()
         },

--- a/examples/testbed/2d.rs
+++ b/examples/testbed/2d.rs
@@ -121,10 +121,6 @@ mod bloom {
     ) {
         commands.spawn((
             Camera2d,
-            Camera {
-                hdr: true,
-                ..default()
-            },
             Tonemapping::TonyMcMapface,
             Bloom::default(),
             StateScoped(super::Scene::Bloom),

--- a/examples/testbed/3d.rs
+++ b/examples/testbed/3d.rs
@@ -155,10 +155,6 @@ mod bloom {
     ) {
         commands.spawn((
             Camera3d::default(),
-            Camera {
-                hdr: true,
-                ..default()
-            },
             Tonemapping::TonyMcMapface,
             Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
             Bloom::NATURAL,


### PR DESCRIPTION
# Objective

- Simplify `Camera` initialization
- allow effects to require HDR

## Solution

- Split out `Camera.hdr` into a marker `Hdr` component

## Testing

- ran `bloom_3d` example

---

## Showcase

```rs
// before
commands.spawn((
  Camera3d
  Camera {
    hdr: true
    ..Default::default()
  }
))

// after
commands.spawn((Camera3d, Hdr));

// other rendering components can require that the camera enables hdr!
// currently implemented for Bloom, AutoExposure, and Atmosphere.
#[require(Hdr)]
pub struct Bloom;
```
