### PR TITLE
Add `world` and `world_mut` methods to `RelatedSpawner`

### DIFF
--- a/crates/bevy_ecs/src/relationship/related_methods.rs
+++ b/crates/bevy_ecs/src/relationship/related_methods.rs
@@ -526,7 +526,7 @@ impl<'w, R: Relationship> RelatedSpawner<'w, R> {
     }
 
     /// Returns a mutable reference to the underlying [`World`].
-    pub fn world_mut(&self) -> &mut World {
+    pub fn world_mut(&mut self) -> &mut World {
         self.world
     }
 }

--- a/crates/bevy_ecs/src/relationship/related_methods.rs
+++ b/crates/bevy_ecs/src/relationship/related_methods.rs
@@ -519,6 +519,16 @@ impl<'w, R: Relationship> RelatedSpawner<'w, R> {
     pub fn target_entity(&self) -> Entity {
         self.target
     }
+
+    /// Returns a reference to the underlying [`World`].
+    pub fn world(&self) -> &World {
+        self.world
+    }
+
+    /// Returns a mutable reference to the underlying [`World`].
+    pub fn world_mut(&self) -> &mut World {
+        self.world
+    }
 }
 
 /// Uses commands to spawn related "source" entities with the given [`Relationship`], targeting


### PR DESCRIPTION
# Objective

`RelatedSpawnerCommands` offers methods to get the underlying `Commands`.
`RelatedSpawner` does not expose the inner `World` reference so far.

I currently want to write extension traits for both of them but I need to duplicate the whole API for the latter because I cannot get it's `&mut World`.

## Solution

Add methods for immutable and mutable `World` access