### PR TITLE
Update the ecs error handler to allow being updated more than once

### DIFF
--- a/crates/bevy_ecs/src/error/command_handling.rs
+++ b/crates/bevy_ecs/src/error/command_handling.rs
@@ -7,7 +7,7 @@ use crate::{
     world::{error::EntityMutableFetchError, World},
 };
 
-use super::{default_error_handler, BevyError, ErrorContext};
+use super::{get_error_handler, BevyError, ErrorContext};
 
 /// Takes a [`Command`] that returns a Result and uses a given error handler function to convert it into
 /// a [`Command`] that internally handles an error if it occurs and returns `()`.
@@ -21,7 +21,7 @@ pub trait HandleError<Out = ()> {
     where
         Self: Sized,
     {
-        self.handle_error_with(default_error_handler())
+        self.handle_error_with(get_error_handler())
     }
 }
 

--- a/crates/bevy_ecs/src/error/mod.rs
+++ b/crates/bevy_ecs/src/error/mod.rs
@@ -8,7 +8,7 @@
 //! [`panic`] error handler function is used, resulting in a panic with the error message attached.
 //!
 //! You can change the default behavior by registering a custom error handler.
-//! Modify the [`GLOBAL_ERROR_HANDLER`] value to set a custom error handler function for your entire app.
+//! Use the [`set_error_handler`] method to set a custom error handler function for your entire app.
 //! In practice, this is generally feature-flagged: panicking or loudly logging errors in development,
 //! and quietly logging or ignoring them in production to avoid crashing the app.
 //!
@@ -36,7 +36,7 @@
 //! Remember to turn on the `configurable_error_handler` feature to set a global error handler!
 //!
 //! ```rust, ignore
-//! use bevy_ecs::error::{GLOBAL_ERROR_HANDLER, BevyError, ErrorContext};
+//! use bevy_ecs::error::{set_error_handler, BevyError, ErrorContext};
 //! use log::trace;
 //!
 //! fn my_error_handler(error: BevyError, ctx: ErrorContext) {
@@ -49,7 +49,7 @@
 //!
 //! fn main() {
 //!     // This requires the "configurable_error_handler" feature to be enabled to be in scope.
-//!     GLOBAL_ERROR_HANDLER.set(my_error_handler).expect("The error handler can only be set once.");
+//!     set_error_handler(my_error_handler);
 //!     
 //!     // Initialize your Bevy App here
 //! }

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -3,7 +3,7 @@ use core::any::Any;
 
 use crate::{
     component::{ComponentHook, ComponentId, HookContext, Mutable, StorageType},
-    error::{default_error_handler, ErrorContext},
+    error::{get_error_handler, ErrorContext},
     observer::{ObserverDescriptor, ObserverTrigger},
     prelude::*,
     query::DebugCheckedUnwrap,
@@ -458,7 +458,7 @@ fn hook_on_add<E: Event, B: Bundle, S: ObserverSystem<E, B>>(
             ..Default::default()
         };
 
-        let error_handler = default_error_handler();
+        let error_handler = get_error_handler();
 
         // Initialize System
         let system: *mut dyn ObserverSystem<E, B> =

--- a/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
@@ -14,7 +14,7 @@ use tracing::{info_span, Span};
 
 use crate::{
     archetype::ArchetypeComponentId,
-    error::{default_error_handler, BevyError, ErrorContext, Result},
+    error::{get_error_handler, BevyError, ErrorContext, Result},
     prelude::Resource,
     query::Access,
     schedule::{is_apply_deferred, BoxedCondition, ExecutorKind, SystemExecutor, SystemSchedule},
@@ -538,7 +538,7 @@ impl ExecutorState {
         world: UnsafeWorldCell,
     ) -> bool {
         let mut should_run = !self.skipped_systems.contains(system_index);
-        let error_handler = default_error_handler();
+        let error_handler = get_error_handler();
 
         for set_idx in conditions.sets_with_conditions_of_systems[system_index].ones() {
             if self.evaluated_sets.contains(set_idx) {
@@ -787,7 +787,7 @@ unsafe fn evaluate_and_fold_conditions(
     conditions: &mut [BoxedCondition],
     world: UnsafeWorldCell,
 ) -> bool {
-    let error_handler = default_error_handler();
+    let error_handler = get_error_handler();
 
     #[expect(
         clippy::unnecessary_fold,

--- a/crates/bevy_ecs/src/schedule/executor/simple.rs
+++ b/crates/bevy_ecs/src/schedule/executor/simple.rs
@@ -8,7 +8,7 @@ use tracing::info_span;
 use std::eprintln;
 
 use crate::{
-    error::{default_error_handler, BevyError, ErrorContext},
+    error::{get_error_handler, BevyError, ErrorContext},
     schedule::{
         executor::is_apply_deferred, BoxedCondition, ExecutorKind, SystemExecutor, SystemSchedule,
     },
@@ -167,7 +167,7 @@ impl SimpleExecutor {
 }
 
 fn evaluate_and_fold_conditions(conditions: &mut [BoxedCondition], world: &mut World) -> bool {
-    let error_handler = default_error_handler();
+    let error_handler = get_error_handler();
 
     #[expect(
         clippy::unnecessary_fold,

--- a/crates/bevy_ecs/src/schedule/executor/single_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/single_threaded.rs
@@ -8,7 +8,7 @@ use tracing::info_span;
 use std::eprintln;
 
 use crate::{
-    error::{default_error_handler, BevyError, ErrorContext},
+    error::{get_error_handler, BevyError, ErrorContext},
     schedule::{is_apply_deferred, BoxedCondition, ExecutorKind, SystemExecutor, SystemSchedule},
     world::World,
 };
@@ -211,7 +211,7 @@ impl SingleThreadedExecutor {
 }
 
 fn evaluate_and_fold_conditions(conditions: &mut [BoxedCondition], world: &mut World) -> bool {
-    let error_handler: fn(BevyError, ErrorContext) = default_error_handler();
+    let error_handler: fn(BevyError, ErrorContext) = get_error_handler();
 
     #[expect(
         clippy::unnecessary_fold,

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -27,7 +27,7 @@ use tracing::info_span;
 
 use crate::{
     component::{ComponentId, Components, Tick},
-    error::default_error_handler,
+    error::get_error_handler,
     prelude::Component,
     resource::Resource,
     schedule::*,
@@ -441,7 +441,7 @@ impl Schedule {
         self.initialize(world)
             .unwrap_or_else(|e| panic!("Error when initializing schedule {:?}: {e}", self.label));
 
-        let error_handler = default_error_handler();
+        let error_handler = get_error_handler();
 
         #[cfg(not(feature = "bevy_debug_stepping"))]
         self.executor

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -89,8 +89,8 @@ use crate::{
 /// A [`Command`] can return a [`Result`](crate::error::Result),
 /// which will be passed to an [error handler](crate::error) if the `Result` is an error.
 ///
-/// The [default error handler](crate::error::default_error_handler) panics.
-/// It can be configured by setting the `GLOBAL_ERROR_HANDLER`.
+/// The [default error handler](crate::error::get_error_handler) panics.
+/// It can be configured by using the [`set_error_handler`](crate::error::set_error_handler) method.
 ///
 /// Alternatively, you can customize the error handler for a specific command
 /// by calling [`Commands::queue_handled`].
@@ -509,7 +509,7 @@ impl<'w, 's> Commands<'w, 's> {
     /// Pushes a generic [`Command`] to the command queue.
     ///
     /// If the [`Command`] returns a [`Result`],
-    /// it will be handled using the [default error handler](crate::error::default_error_handler).
+    /// it will be handled using the [default error handler](crate::error::get_error_handler).
     ///
     /// To use a custom error handler, see [`Commands::queue_handled`].
     ///
@@ -695,7 +695,7 @@ impl<'w, 's> Commands<'w, 's> {
     /// This command will fail if any of the given entities do not exist.
     ///
     /// It will internally return a [`TryInsertBatchError`](crate::world::error::TryInsertBatchError),
-    /// which will be handled by the [default error handler](crate::error::default_error_handler).
+    /// which will be handled by the [default error handler](crate::error::get_error_handler).
     #[track_caller]
     pub fn insert_batch<I, B>(&mut self, batch: I)
     where
@@ -726,7 +726,7 @@ impl<'w, 's> Commands<'w, 's> {
     /// This command will fail if any of the given entities do not exist.
     ///
     /// It will internally return a [`TryInsertBatchError`](crate::world::error::TryInsertBatchError),
-    /// which will be handled by the [default error handler](crate::error::default_error_handler).
+    /// which will be handled by the [default error handler](crate::error::get_error_handler).
     #[track_caller]
     pub fn insert_batch_if_new<I, B>(&mut self, batch: I)
     where
@@ -1223,8 +1223,8 @@ impl<'w, 's> Commands<'w, 's> {
 /// An [`EntityCommand`] can return a [`Result`](crate::error::Result),
 /// which will be passed to an [error handler](crate::error) if the `Result` is an error.
 ///
-/// The [default error handler](crate::error::default_error_handler) panics.
-/// It can be configured by setting the `GLOBAL_ERROR_HANDLER`.
+/// The [default error handler](crate::error::get_error_handler) panics.
+/// It can be configured by using the [`set_error_handler`](crate::error::set_error_handler) method.
 ///
 /// Alternatively, you can customize the error handler for a specific command
 /// by calling [`EntityCommands::queue_handled`].
@@ -1767,7 +1767,7 @@ impl<'a> EntityCommands<'a> {
     /// Pushes an [`EntityCommand`] to the queue,
     /// which will get executed for the current [`Entity`].
     ///
-    /// The [default error handler](crate::error::default_error_handler)
+    /// The [default error handler](crate::error::get_error_handler)
     /// will be used to handle error cases.
     /// Every [`EntityCommand`] checks whether the entity exists at the time of execution
     /// and returns an error if it does not.

--- a/examples/ecs/error_handling.rs
+++ b/examples/ecs/error_handling.rs
@@ -5,7 +5,7 @@
 //! enabled. This feature is disabled by default, as it may introduce runtime overhead, especially for commands.
 
 use bevy::ecs::{
-    error::{warn, GLOBAL_ERROR_HANDLER},
+    error::{set_error_handler, warn},
     world::DeferredWorld,
 };
 use bevy::math::sampling::UniformMeshSampler;
@@ -22,9 +22,7 @@ fn main() {
     // Here we set the global error handler using one of the built-in
     // error handlers. Bevy provides built-in handlers for `panic`, `error`, `warn`, `info`,
     // `debug`, `trace` and `ignore`.
-    GLOBAL_ERROR_HANDLER
-        .set(warn)
-        .expect("The error handler can only be set once, globally.");
+    set_error_handler(warn);
 
     let mut app = App::new();
 

--- a/examples/ecs/fallible_params.rs
+++ b/examples/ecs/fallible_params.rs
@@ -2,7 +2,7 @@
 //! from running if their acquiry conditions aren't met.
 //!
 //! Fallible system parameters include:
-//! - [`Res<R>`], [`ResMut<R>`] - Resource has to exist, and the [`GLOBAL_ERROR_HANDLER`] will be called if it doesn't.
+//! - [`Res<R>`], [`ResMut<R>`] - Resource has to exist, and the [`global error handler`](set_error_handler) will be called if it doesn't.
 //! - [`Single<D, F>`] - There must be exactly one matching entity, but the system will be silently skipped otherwise.
 //! - [`Option<Single<D, F>>`] - There must be zero or one matching entity. The system will be silently skipped if there are more.
 //! - [`Populated<D, F>`] - There must be at least one matching entity, but the system will be silently skipped otherwise.
@@ -19,17 +19,15 @@
 //! [`SystemParamValidationError`]: bevy::ecs::system::SystemParamValidationError
 //! [`SystemParam::validate_param`]: bevy::ecs::system::SystemParam::validate_param
 
-use bevy::ecs::error::{warn, GLOBAL_ERROR_HANDLER};
+use bevy::ecs::error::{set_error_handler, warn};
 use bevy::prelude::*;
 use rand::Rng;
 
 fn main() {
     // By default, if a parameter fail to be fetched,
-    // the `GLOBAL_ERROR_HANDLER` will be used to handle the error,
+    // the `error handler` will be used to handle the error,
     // which by default is set to panic.
-    GLOBAL_ERROR_HANDLER
-        .set(warn)
-        .expect("The error handler can only be set once, globally.");
+    set_error_handler(warn);
 
     println!();
     println!("Press 'A' to add enemy ships and 'R' to remove them.");


### PR DESCRIPTION
# Objective

The application error handler can be set only once.

## Solution

Use an atomic pointer to store the error handler pointer and allow setting it at any time.

## Testing

Added 2 new tests.

---

## Showcase

The Bevy ecs error handling system has been changed to allow updating the error handler.
 
```rust
fn error_handler(error: BevyError, context: ErrorContext) {
   // ... do stuff.
}

// before
GLOBAL_ERROR_HANDLER.set(error_handler);

// after
set_error_handler(error_handler);
// do it twice, why not.
set_error_handler(error_handler);

```

