### PR TITLE
don't overflow when relations are empty

### DIFF
--- a/crates/bevy_ecs/src/relationship/relationship_source_collection.rs
+++ b/crates/bevy_ecs/src/relationship/relationship_source_collection.rs
@@ -213,7 +213,7 @@ impl OrderedRelationshipSourceCollection for Vec<Entity> {
 
     fn place_most_recent(&mut self, index: usize) {
         if let Some(entity) = self.pop() {
-            let index = index.min(self.len() - 1);
+            let index = index.min(self.len().saturating_sub(1));
             self.insert(index, entity);
         }
     }
@@ -221,7 +221,7 @@ impl OrderedRelationshipSourceCollection for Vec<Entity> {
     fn place(&mut self, entity: Entity, index: usize) {
         if let Some(current) = <[Entity]>::iter(self).position(|e| *e == entity) {
             // The len is at least 1, so the subtraction is safe.
-            let index = index.min(self.len() - 1);
+            let index = index.min(self.len().saturating_sub(1));
             Vec::remove(self, current);
             self.insert(index, entity);
         };


### PR DESCRIPTION
# Objective

- Fixes #18890 

## Solution

- Don't overflow when substracting, bound at 0

## Testing

- Reproducer from the issue now works
