### PR TITLE
feat: implement proof of concept animated gizmos

### DIFF
--- a/crates/bevy_gizmos/Cargo.toml
+++ b/crates/bevy_gizmos/Cargo.toml
@@ -34,6 +34,7 @@ bevy_time = { path = "../bevy_time", version = "0.16.0-dev" }
 # other
 bytemuck = "1.0"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
+itertools = { version = "0.14.0", default-features = false }
 
 [lints]
 workspace = true

--- a/crates/bevy_gizmos/src/config.rs
+++ b/crates/bevy_gizmos/src/config.rs
@@ -52,6 +52,8 @@ pub enum GizmoLineStyle {
         gap_scale: f32,
         /// The length of the visible line in `line_width`s
         line_scale: f32,
+        /// Whether or not the gizmo lines are animated which makes the line move from src to dst
+        animated: bool,
     },
 }
 
@@ -67,10 +69,12 @@ impl Hash for GizmoLineStyle {
             Self::Dashed {
                 gap_scale,
                 line_scale,
+                animated,
             } => {
                 2u64.hash(state);
                 gap_scale.to_bits().hash(state);
                 line_scale.to_bits().hash(state);
+                animated.hash(state);
             }
         }
     }

--- a/crates/bevy_gizmos/src/pipeline_2d.rs
+++ b/crates/bevy_gizmos/src/pipeline_2d.rs
@@ -119,7 +119,10 @@ impl SpecializedRenderPipeline for LineGizmoPipeline {
         let fragment_entry_point = match key.line_style {
             GizmoLineStyle::Solid => "fragment_solid",
             GizmoLineStyle::Dotted => "fragment_dotted",
-            GizmoLineStyle::Dashed { .. } => "fragment_dashed",
+            GizmoLineStyle::Dashed { animated: true, .. } => "fragment_dashed_animated",
+            GizmoLineStyle::Dashed {
+                animated: false, ..
+            } => "fragment_dashed",
         };
 
         RenderPipelineDescriptor {

--- a/crates/bevy_gizmos/src/retained.rs
+++ b/crates/bevy_gizmos/src/retained.rs
@@ -100,6 +100,7 @@ pub(crate) fn extract_linegizmos(
     mut commands: Commands,
     mut previous_len: Local<usize>,
     query: Extract<Query<(Entity, &Gizmo, &GlobalTransform, Option<&RenderLayers>)>>,
+    time: Extract<bevy_ecs::system::Res<bevy_time::Time>>,
 ) {
     use bevy_math::Affine3;
     use bevy_render::sync_world::{MainEntity, TemporaryRenderEntity};
@@ -119,6 +120,7 @@ pub(crate) fn extract_linegizmos(
         let (gap_scale, line_scale) = if let GizmoLineStyle::Dashed {
             gap_scale,
             line_scale,
+            ..
         } = gizmo.line_config.style
         {
             if gap_scale <= 0.0 {
@@ -140,6 +142,7 @@ pub(crate) fn extract_linegizmos(
                 joints_resolution,
                 gap_scale,
                 line_scale,
+                time: time.elapsed_secs(),
                 #[cfg(feature = "webgl")]
                 _padding: Default::default(),
             },

--- a/examples/gizmos/2d_gizmos.rs
+++ b/examples/gizmos/2d_gizmos.rs
@@ -8,6 +8,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .init_gizmo_group::<MyRoundGizmos>()
+        .init_gizmo_group::<MyAnimatedGizmos>()
         .add_systems(Startup, setup)
         .add_systems(Update, (draw_example_collection, update_config))
         .run();
@@ -17,7 +18,11 @@ fn main() {
 #[derive(Default, Reflect, GizmoConfigGroup)]
 struct MyRoundGizmos {}
 
-fn setup(mut commands: Commands) {
+// We can create our own gizmo config group!
+#[derive(Default, Reflect, GizmoConfigGroup)]
+struct MyAnimatedGizmos {}
+
+fn setup(mut commands: Commands, mut config_store: ResMut<GizmoConfigStore>) {
     commands.spawn(Camera2d);
     // text
     commands.spawn((
@@ -35,11 +40,17 @@ fn setup(mut commands: Commands) {
             ..default()
         },
     ));
+    config_store.config_mut::<MyAnimatedGizmos>().0.line.style = GizmoLineStyle::Dashed {
+        gap_scale: 10.0,
+        line_scale: 10.0,
+        animated: true,
+    };
 }
 
 fn draw_example_collection(
     mut gizmos: Gizmos,
     mut my_gizmos: Gizmos<MyRoundGizmos>,
+    mut my_animated: Gizmos<MyAnimatedGizmos>,
     time: Res<Time>,
 ) {
     let sin_t_scaled = ops::sin(time.elapsed_secs()) * 50.;
@@ -120,6 +131,8 @@ fn draw_example_collection(
         )
         .with_double_end()
         .with_tip_length(10.);
+
+    my_animated.line_2d(Vec2::ZERO, Vec2::ONE * 100.0, YELLOW_GREEN);
 }
 
 fn update_config(
@@ -145,6 +158,7 @@ fn update_config(
             GizmoLineStyle::Dotted => GizmoLineStyle::Dashed {
                 gap_scale: 3.0,
                 line_scale: 5.0,
+                animated: false,
             },
             _ => GizmoLineStyle::Solid,
         };
@@ -176,6 +190,14 @@ fn update_config(
             GizmoLineStyle::Dotted => GizmoLineStyle::Dashed {
                 gap_scale: 3.0,
                 line_scale: 5.0,
+                animated: false,
+            },
+            GizmoLineStyle::Dashed {
+                animated: false, ..
+            } => GizmoLineStyle::Dashed {
+                gap_scale: 3.0,
+                line_scale: 5.0,
+                animated: true,
             },
             _ => GizmoLineStyle::Solid,
         };


### PR DESCRIPTION
# Objective

- This is a new attempt to implement animated gizmos
- This PR is supposed to supersede my first try here https://github.com/bevyengine/bevy/pull/14645
- This is still a proof of concept of a second approach of tackling the issue. I generally would like to have a discussion here to decide whether to use the old approach from the PR mentioned above or the new approach sketched in the first commits here

## Solution

There are generally two approaches I have considered: The old one, which is CPU based and the new one which is GPU based.

### Old solution

- This old solution would basically replicate the existing API for the animated versions of it
- Lot's of code would be reused
- The implementation would happen in the rust code

### New solution

- The implementation is based on modifying the gizmo shader directly
- There are just some new variants on the gizmo line style enum
- This introduces a bit more uniform data to the shader (everything time based, we could probably make that cleaner, the current version is just a proof of concept). 
- Also the time uniforms need to be constantly updated
- Unfortunately I've noticed that the lines are rough around the edges ... literally. For curved lines the shader approach seems to be suboptimal as it will produce dashes of varying lengths. This is probably caused from the way we use small lines to draw curved lines.

## Testing

- You can try to run the new version of animated gizmos via the 2D gizmos example

---

## Showcase

<details>
  <summary>TODO</summary>

> This section is optional. If this PR does not include a visual change or does not add a new feature, you can delete this section.

- Help others understand the result of this PR by showcasing your awesome work!
- If this PR adds a new feature or public API, consider adding a brief pseudo-code snippet of it in action
- If this PR includes a visual change, consider adding a screenshot, GIF, or video
  - If you want, you could even include a before/after comparison!
- If the Migration Guide adequately covers the changes, you can delete this section

While a showcase should aim to be brief and digestible, you can use a toggleable section to save space on longer showcases:


```rust
println!("My super cool code.");
```

</details>
