### PR TITLE
Add a method to clear all related entity to `EntityCommands` and friends

### DIFF
--- a/crates/bevy_ecs/src/hierarchy.rs
+++ b/crates/bevy_ecs/src/hierarchy.rs
@@ -281,6 +281,12 @@ impl<'w> EntityWorldMut<'w> {
         self.add_related::<ChildOf>(children)
     }
 
+    /// Removes all the children from this entity.
+    /// See also [`clear_related`](Self::clear_related)
+    pub fn clear_children(&mut self) -> &mut Self {
+        self.clear_related::<ChildOf>()
+    }
+
     /// Insert children at specific index.
     /// See also [`insert_related`](Self::insert_related).
     pub fn insert_children(&mut self, index: usize, children: &[Entity]) -> &mut Self {
@@ -367,6 +373,12 @@ impl<'a> EntityCommands<'a> {
     /// Adds the given children to this entity
     pub fn add_children(&mut self, children: &[Entity]) -> &mut Self {
         self.add_related::<ChildOf>(children)
+    }
+
+    /// Removes all the children from this entity.
+    /// See also [`clear_related`](Self::clear_related)
+    pub fn clear_children(&mut self) -> &mut Self {
+        self.clear_related::<ChildOf>()
     }
 
     /// Insert children at specific index.

--- a/crates/bevy_ecs/src/relationship/related_methods.rs
+++ b/crates/bevy_ecs/src/relationship/related_methods.rs
@@ -47,6 +47,11 @@ impl<'w> EntityWorldMut<'w> {
         self
     }
 
+    /// Removes the relation `R` between this entity and all its related entities.
+    pub fn clear_related<R: Relationship>(&mut self) -> &mut Self {
+        self.remove::<R::RelationshipTarget>()
+    }
+
     /// Relates the given entities to this entity with the relation `R`, starting at this particular index.
     ///
     /// If the `related` has duplicates, a related entity will take the index of its last occurrence in `related`.
@@ -376,6 +381,13 @@ impl<'a> EntityCommands<'a> {
         })
     }
 
+    /// Removes the relation `R` between this entity and all its related entities.
+    pub fn clear_related<R: Relationship>(&mut self) -> &mut Self {
+        self.queue(|mut entity: EntityWorldMut| {
+            entity.clear_related::<R>();
+        })
+    }
+
     /// Relates the given entities to this entity with the relation `R`, starting at this particular index.
     ///
     /// If the `related` has duplicates, a related entity will take the index of its last occurrence in `related`.
@@ -612,5 +624,20 @@ mod tests {
         for entity in [a, b, c, d] {
             assert!(!world.entity(entity).contains::<TestComponent>());
         }
+    }
+
+    #[test]
+    fn remove_all_related() {
+        let mut world = World::new();
+
+        let a = world.spawn_empty().id();
+        let b = world.spawn(ChildOf(a)).id();
+        let c = world.spawn(ChildOf(a)).id();
+
+        world.entity_mut(a).clear_related::<ChildOf>();
+
+        assert_eq!(world.entity(a).get::<Children>(), None);
+        assert_eq!(world.entity(b).get::<ChildOf>(), None);
+        assert_eq!(world.entity(c).get::<ChildOf>(), None);
     }
 }


### PR DESCRIPTION
# Objective

We have methods to:
- Add related entities
- Replace related entities
- Remove specific related entities

We don't have a method the remove all related entities so.

## Solution

Add a method to remove all related entities.

## Testing

A new test case.
