### PR TITLE
Make `uuid` version less strict

### DIFF
--- a/crates/bevy_animation/Cargo.toml
+++ b/crates/bevy_animation/Cargo.toml
@@ -40,13 +40,13 @@ thiserror = { version = "2", default-features = false }
 derive_more = { version = "1", default-features = false, features = ["from"] }
 either = "1.13"
 thread_local = "1"
-uuid = { version = "1.13.1", features = ["v4"] }
+uuid = { version = "1", features = ["v4"] }
 smallvec = "1"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # TODO: Assuming all wasm builds are for the browser. Require `no_std` support to break assumption.
-uuid = { version = "1.13.1", default-features = false, features = ["js"] }
+uuid = { version = "1", default-features = false, features = ["js"] }
 
 [lints]
 workspace = true

--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -49,7 +49,7 @@ ron = "0.8"
 serde = { version = "1", features = ["derive"] }
 thiserror = { version = "2", default-features = false }
 derive_more = { version = "1", default-features = false, features = ["from"] }
-uuid = { version = "1.13.1", features = ["v4"] }
+uuid = { version = "1", features = ["v4"] }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
@@ -65,7 +65,7 @@ web-sys = { version = "0.3", features = [
 ] }
 wasm-bindgen-futures = "0.4"
 js-sys = "0.3"
-uuid = { version = "1.13.1", default-features = false, features = ["js"] }
+uuid = { version = "1", default-features = false, features = ["js"] }
 bevy_app = { path = "../bevy_app", version = "0.16.0-dev", default-features = false, features = [
   "web",
 ] }

--- a/crates/bevy_picking/Cargo.toml
+++ b/crates/bevy_picking/Cargo.toml
@@ -32,12 +32,12 @@ bevy_platform = { path = "../bevy_platform", version = "0.16.0-dev", default-fea
 
 # other
 crossbeam-channel = { version = "0.5", optional = true }
-uuid = { version = "1.13.1", features = ["v4"] }
+uuid = { version = "1", features = ["v4"] }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # TODO: Assuming all wasm builds are for the browser. Require `no_std` support to break assumption.
-uuid = { version = "1.13.1", default-features = false, features = ["js"] }
+uuid = { version = "1", default-features = false, features = ["js"] }
 
 [lints]
 workspace = true

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -106,7 +106,7 @@ petgraph = { version = "0.7", features = ["serde-1"], optional = true }
 smol_str = { version = "0.2.0", default-features = false, features = [
   "serde",
 ], optional = true }
-uuid = { version = "1.13.1", default-features = false, optional = true, features = [
+uuid = { version = "1", default-features = false, optional = true, features = [
   "v4",
   "serde",
 ] }

--- a/crates/bevy_reflect/derive/Cargo.toml
+++ b/crates/bevy_reflect/derive/Cargo.toml
@@ -23,11 +23,11 @@ bevy_macro_utils = { path = "../../bevy_macro_utils", version = "0.16.0-dev" }
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "2.0", features = ["full"] }
-uuid = { version = "1.13.1", features = ["v4"] }
+uuid = { version = "1", features = ["v4"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # TODO: Assuming all wasm builds are for the browser. Require `no_std` support to break assumption.
-uuid = { version = "1.13.1", default-features = false, features = ["js"] }
+uuid = { version = "1", default-features = false, features = ["js"] }
 
 [lints]
 workspace = true

--- a/crates/bevy_scene/Cargo.toml
+++ b/crates/bevy_scene/Cargo.toml
@@ -33,13 +33,13 @@ bevy_platform = { path = "../bevy_platform", version = "0.16.0-dev", default-fea
 
 # other
 serde = { version = "1.0", features = ["derive"], optional = true }
-uuid = { version = "1.13.1", features = ["v4"] }
+uuid = { version = "1", features = ["v4"] }
 thiserror = { version = "2", default-features = false }
 derive_more = { version = "1", default-features = false, features = ["from"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # TODO: Assuming all wasm builds are for the browser. Require `no_std` support to break assumption.
-uuid = { version = "1.13.1", default-features = false, features = ["js"] }
+uuid = { version = "1", default-features = false, features = ["js"] }
 
 [dev-dependencies]
 postcard = { version = "1.0", features = ["alloc"] }


### PR DESCRIPTION
# Objective

- Make bevy more compatible with the rest of the rust ecosystem.
- Fixes #18918.

## Solution

- Changed all dependency versions of `uuid` from `"1.13.1"` to `"1"` to only care for major version.

## Testing

I've compiled my project without any problem, but I'm not sure if there was any specific reason bevy depended on this specific version of `uuid` maybe there are some caveats I'm not aware off. Running `cargo test` in bevy repo crashes my PC by OOM, so I couldn't properly test the whole package.
