### PR TITLE
Add generic item support for `RelationshipSourceCollection`

### DIFF
--- a/crates/bevy_ecs/src/relationship/mod.rs
+++ b/crates/bevy_ecs/src/relationship/mod.rs
@@ -446,7 +446,8 @@ mod tests {
             }
         }
 
-        // SAFE: It's just a test. I promise we'll be ok!
+        // SAFETY:
+        // It's just a test. I promise we'll be ok!
         unsafe impl EntityEquivalent for E {}
 
         impl RelationshipSourceItem for E {

--- a/crates/bevy_ecs/src/relationship/mod.rs
+++ b/crates/bevy_ecs/src/relationship/mod.rs
@@ -339,7 +339,7 @@ pub enum RelationshipHookMode {
 
 #[cfg(test)]
 mod tests {
-    use crate::entity::ContainsEntity;
+    use crate::entity::{ContainsEntity, EntityEquivalent};
     use crate::prelude::RelationshipTarget;
     use crate::relationship::{Relationship, RelationshipSourceItem};
     use crate::world::World;
@@ -445,6 +445,8 @@ mod tests {
                 self.0
             }
         }
+
+        unsafe impl EntityEquivalent for E {}
 
         impl RelationshipSourceItem for E {
             fn from_entity(entity: Entity) -> Self {

--- a/crates/bevy_ecs/src/relationship/mod.rs
+++ b/crates/bevy_ecs/src/relationship/mod.rs
@@ -10,6 +10,7 @@ pub use related_methods::*;
 pub use relationship_query::*;
 pub use relationship_source_collection::*;
 
+use crate::entity::ContainsEntity;
 use crate::{
     component::{Component, HookContext, Mutable},
     entity::{ComponentCloneCtx, Entity, SourceComponent},
@@ -115,10 +116,14 @@ pub trait Relationship: Component + Sized {
             if let Some(mut relationship_target) =
                 target_entity_mut.get_mut::<Self::RelationshipTarget>()
             {
-                relationship_target.collection_mut_risky().add(entity);
+                relationship_target
+                    .collection_mut_risky()
+                    .add(RelationshipSourceItem::from_entity(entity));
             } else {
                 let mut target = <Self::RelationshipTarget as RelationshipTarget>::with_capacity(1);
-                target.collection_mut_risky().add(entity);
+                target
+                    .collection_mut_risky()
+                    .add(RelationshipSourceItem::from_entity(entity));
                 world.commands().entity(target_entity).insert(target);
             }
         } else {
@@ -156,7 +161,9 @@ pub trait Relationship: Component + Sized {
             if let Some(mut relationship_target) =
                 target_entity_mut.get_mut::<Self::RelationshipTarget>()
             {
-                relationship_target.collection_mut_risky().remove(entity);
+                relationship_target
+                    .collection_mut_risky()
+                    .remove(RelationshipSourceItem::from_entity(entity));
                 if relationship_target.len() == 0 {
                     if let Ok(mut entity) = world.commands().get_entity(target_entity) {
                         // this "remove" operation must check emptiness because in the event that an identical
@@ -224,11 +231,11 @@ pub trait RelationshipTarget: Component<Mutability = Mutable> + Sized {
     fn on_replace(mut world: DeferredWorld, HookContext { entity, caller, .. }: HookContext) {
         let (entities, mut commands) = world.entities_and_commands();
         let relationship_target = entities.get(entity).unwrap().get::<Self>().unwrap();
-        for source_entity in relationship_target.iter() {
-            if entities.get(source_entity).is_ok() {
+        for source_item in relationship_target.iter() {
+            if entities.get(source_item.entity()).is_ok() {
                 commands.queue(
                     entity_command::remove::<Self::Relationship>()
-                        .with_entity(source_entity)
+                        .with_entity(source_item.entity())
                         .handle_error_with(ignore),
                 );
             } else {
@@ -237,7 +244,7 @@ pub trait RelationshipTarget: Component<Mutability = Mutable> + Sized {
                     caller
                         .map(|location| format!("{location}: "))
                         .unwrap_or_default(),
-                    source_entity
+                    source_item.entity()
                 );
             }
         }
@@ -249,11 +256,11 @@ pub trait RelationshipTarget: Component<Mutability = Mutable> + Sized {
     fn on_despawn(mut world: DeferredWorld, HookContext { entity, caller, .. }: HookContext) {
         let (entities, mut commands) = world.entities_and_commands();
         let relationship_target = entities.get(entity).unwrap().get::<Self>().unwrap();
-        for source_entity in relationship_target.iter() {
-            if entities.get(source_entity).is_ok() {
+        for source_item in relationship_target.iter() {
+            if entities.get(source_item.entity()).is_ok() {
                 commands.queue(
                     entity_command::despawn()
-                        .with_entity(source_entity)
+                        .with_entity(source_item.entity())
                         .handle_error_with(ignore),
                 );
             } else {
@@ -262,7 +269,7 @@ pub trait RelationshipTarget: Component<Mutability = Mutable> + Sized {
                     caller
                         .map(|location| format!("{location}: "))
                         .unwrap_or_default(),
-                    source_entity
+                    source_item.entity()
                 );
             }
         }
@@ -312,7 +319,7 @@ pub fn clone_relationship_target<T: RelationshipTarget>(
             let collection = cloned.collection_mut_risky();
             for entity in component.iter() {
                 collection.add(entity);
-                context.queue_entity_clone(entity);
+                context.queue_entity_clone(entity.entity());
             }
         }
         context.write_target_component(cloned);
@@ -332,6 +339,9 @@ pub enum RelationshipHookMode {
 
 #[cfg(test)]
 mod tests {
+    use crate::entity::ContainsEntity;
+    use crate::prelude::RelationshipTarget;
+    use crate::relationship::{Relationship, RelationshipSourceItem};
     use crate::world::World;
     use crate::{component::Component, entity::Entity};
     use alloc::vec::Vec;
@@ -423,5 +433,74 @@ mod tests {
         }
 
         // No assert necessary, looking to make sure compilation works with the macros
+    }
+
+    #[test]
+    fn generic_relationship_source_collections() {
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+        struct E(Entity);
+
+        impl ContainsEntity for E {
+            fn entity(&self) -> Entity {
+                self.0
+            }
+        }
+
+        impl RelationshipSourceItem for E {
+            fn from_entity(entity: Entity) -> Self {
+                E(entity)
+            }
+        }
+
+        #[derive(Component)]
+        #[component(on_insert = <Self as Relationship>::on_insert)]
+        #[component(on_replace = <Self as Relationship>::on_replace)]
+        struct Rel(E);
+
+        impl Relationship for Rel {
+            type RelationshipTarget = RelTarget;
+
+            fn get(&self) -> Entity {
+                self.0.entity()
+            }
+
+            fn from(entity: Entity) -> Self {
+                Rel(E::from_entity(entity))
+            }
+        }
+
+        #[derive(Component)]
+        #[component(on_replace = <Self as RelationshipTarget>::on_replace)]
+        #[component(on_despawn = <Self as RelationshipTarget>::on_despawn)]
+        struct RelTarget(Vec<E>);
+
+        impl RelationshipTarget for RelTarget {
+            const LINKED_SPAWN: bool = false;
+
+            type Relationship = Rel;
+
+            type Collection = Vec<E>;
+
+            fn collection(&self) -> &Self::Collection {
+                &self.0
+            }
+
+            fn collection_mut_risky(&mut self) -> &mut Self::Collection {
+                &mut self.0
+            }
+
+            fn from_collection_risky(collection: Self::Collection) -> Self {
+                RelTarget(collection)
+            }
+        }
+
+        let mut world = World::new();
+        let a = E(world.spawn_empty().id());
+        let b = E(world.spawn(Rel(a)).id());
+        let c = E(world.spawn(Rel(a)).id());
+        assert_eq!(
+            world.entity(a.entity()).get::<RelTarget>().unwrap().0,
+            &[b, c]
+        );
     }
 }

--- a/crates/bevy_ecs/src/relationship/mod.rs
+++ b/crates/bevy_ecs/src/relationship/mod.rs
@@ -446,6 +446,7 @@ mod tests {
             }
         }
 
+        // SAFE: It's just a test. I promise we'll be ok!
         unsafe impl EntityEquivalent for E {}
 
         impl RelationshipSourceItem for E {

--- a/crates/bevy_ecs/src/relationship/relationship_source_collection.rs
+++ b/crates/bevy_ecs/src/relationship/relationship_source_collection.rs
@@ -93,13 +93,13 @@ pub trait RelationshipSourceCollection {
 pub trait OrderedRelationshipSourceCollection: RelationshipSourceCollection {
     /// Inserts the entity at a specific index.
     /// If the index is too large, the entity will be added to the end of the collection.
-    fn insert(&mut self, index: usize, entity: Self::Item);
+    fn insert(&mut self, index: usize, item: Self::Item);
     /// Removes the entity at the specified idnex if it exists.
     fn remove_at(&mut self, index: usize) -> Option<Self::Item>;
     /// Inserts the entity at a specific index.
     /// This will never reorder other entities.
     /// If the index is too large, the entity will be added to the end of the collection.
-    fn insert_stable(&mut self, index: usize, entity: Self::Item);
+    fn insert_stable(&mut self, index: usize, item: Self::Item);
     /// Removes the entity at the specified idnex if it exists.
     /// This will never reorder other entities.
     fn remove_at_stable(&mut self, index: usize) -> Option<Self::Item>;

--- a/crates/bevy_ecs/src/relationship/relationship_source_collection.rs
+++ b/crates/bevy_ecs/src/relationship/relationship_source_collection.rs
@@ -1,10 +1,10 @@
-use crate::entity::ContainsEntity;
+use crate::entity::EntityEquivalent;
 use crate::entity::{hash_set::EntityHashSet, Entity};
 use alloc::vec::Vec;
 use smallvec::SmallVec;
 
 /// Represents a single item within a [`RelationshipSourceCollection`].
-pub trait RelationshipSourceItem: 'static + ContainsEntity + Copy {
+pub trait RelationshipSourceItem: 'static + EntityEquivalent + Copy {
     /// Create a new item from an [`Entity`].
     fn from_entity(entity: Entity) -> Self;
 }
@@ -165,7 +165,7 @@ impl<T: RelationshipSourceItem> RelationshipSourceCollection for Vec<T> {
     }
 
     fn remove(&mut self, item: Self::Item) -> bool {
-        if let Some(index) = <[Self::Item]>::iter(self).position(|i| i.entity() == item.entity()) {
+        if let Some(index) = <[Self::Item]>::iter(self).position(|i| *i == item) {
             Vec::remove(self, index);
             return true;
         }
@@ -224,7 +224,7 @@ impl<T: OrderedRelationshipSourceItem> OrderedRelationshipSourceCollection for V
     }
 
     fn insert_sorted(&mut self, item: Self::Item) {
-        let index = self.partition_point(|e| e <= &item);
+        let index = self.partition_point(|i| i <= &item);
         self.insert_stable(index, item);
     }
 
@@ -236,7 +236,7 @@ impl<T: OrderedRelationshipSourceItem> OrderedRelationshipSourceCollection for V
     }
 
     fn place(&mut self, item: Self::Item, index: usize) {
-        if let Some(current) = <[Self::Item]>::iter(self).position(|e| *e == item) {
+        if let Some(current) = <[Self::Item]>::iter(self).position(|i| *i == item) {
             // The len is at least 1, so the subtraction is safe.
             let index = index.min(self.len().saturating_sub(1));
             Vec::remove(self, current);


### PR DESCRIPTION
# Objective

The current implementation of `RelationshipSourceCollection` only operates on `Entity`, some other specific entity containers. This prevents the relations to work on entity wrapper types, such as [`Instance<T>`](https://docs.rs/moonshine-kind/latest/moonshine_kind/struct.Instance.html). This PR aims to solve this.

## Solution

This changelist adds a new `RelationshipSourceItem` trait which is automatically implemented for `Entity`.

It also adds a new type entry to `RelationshipSourceCollection`:
```rust
pub trait RelationshipSourceCollection {
    /// The type of the [`Entity`]-like item stored in the collection.
    type Item: RelationshipSourceItem;
    ...
}
```

The rest of the CL is fairly straightforward as it's just conversion between "item" and entities. This allows `RelationshipSourceItem` to operate on any generic entity wrapper container.

## Testing

A simple test has been added to ensure correct behavior:
`generic_relationship_source_collections`

## Known Issues

There is currently no macro support for this; which means any component which uses non-Entity types for relations has to implement it manually. Let me know if that's a requirement for this PR to pass or if we'd like that in a separate PR.