### PR TITLE
Fix minor typo on `bevy_ecs` example

### DIFF
--- a/crates/bevy_ecs/examples/events.rs
+++ b/crates/bevy_ecs/examples/events.rs
@@ -1,5 +1,5 @@
 //! In this example a system sends a custom event with a 50/50 chance during any frame.
-//! If an event was send, it will be printed by the console in a receiving system.
+//! If an event was sent, it will be printed by the console in a receiving system.
 
 #![expect(clippy::print_stdout, reason = "Allowed in examples.")]
 


### PR DESCRIPTION
# Objective

A small typo was found on `bevy_ecs/examples/event.rs`.
I know it's very minor but I'd think fixing it would still help others in the long run.

## Solution

Fix the typo.

## Testing

I don't think this is necessary.

