### PR TITLE
bevy_ecs: forward `type_id` in `InfallibleSystemWrapper`

### DIFF
--- a/crates/bevy_ecs/src/system/schedule_system.rs
+++ b/crates/bevy_ecs/src/system/schedule_system.rs
@@ -30,6 +30,10 @@ impl<S: System<In = ()>> System for InfallibleSystemWrapper<S> {
         self.0.name()
     }
 
+    fn type_id(&self) -> core::any::TypeId {
+        self.0.type_id()
+    }
+
     #[inline]
     fn component_access(&self) -> &Access<ComponentId> {
         self.0.component_access()


### PR DESCRIPTION
similar to https://github.com/bevyengine/bevy/pull/12030

# Objective

`bevy_mod_debugdump` uses the `SystemTypeSet::system_type` to look up constrains like `(system_1, system_2.after(system_1))`. For that it needs to find the type id in `schedule.graph().systems()`

Now with systems being wrapped in an `InfallibleSystemWrapper` this association was no longer possible.

## Solution

By forwarding the type id in `InfallibleSystemWrapper`, `bevy_mod_debugdump` can resolve the dependencies as before, and the wrapper is an unnoticable implementation detail.

## Testing

- `cargo test -p bevy_ecs`
I'm not sure what exactly could break otherwise.
