### PR TITLE
Support all wgpu surface targets

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -5,6 +5,8 @@ doc-valid-idents = [
   "NVidia",
   "OpenXR",
   "VSync",
+  "AppKit",
+  "UIKit",
   "..",
 ]
 

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -236,6 +236,7 @@ bevy_render = [
   "bevy_shader",
   "bevy_color/wgpu-types",
   "bevy_color/encase",
+  "bevy_winit?/bevy_render",
 ]
 bevy_core_pipeline = ["dep:bevy_core_pipeline", "bevy_render"]
 bevy_anti_alias = ["dep:bevy_anti_alias", "bevy_core_pipeline"]

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -99,7 +99,7 @@ use bevy_ecs::{
 use bevy_image::{CompressedImageFormatSupport, CompressedImageFormats};
 use bevy_shader::{load_shader_library, Shader, ShaderLoader};
 use bevy_utils::prelude::default;
-use bevy_window::{PrimaryWindow, RawHandleWrapperHolder};
+use bevy_window::PrimaryWindow;
 use bitflags::bitflags;
 use core::ops::{Deref, DerefMut};
 use experimental::occlusion_culling::OcclusionCullingPlugin;
@@ -111,6 +111,7 @@ use render_asset::{
 use settings::RenderResources;
 use std::sync::Mutex;
 use sync_world::{despawn_temporary_render_entities, entity_sync_system, SyncWorldPlugin};
+use view::surface_target::SurfaceTargetSource;
 
 /// Contains the default Bevy rendering backend based on wgpu.
 ///
@@ -315,9 +316,9 @@ impl Plugin for RenderPlugin {
                         future_render_resources_wrapper.clone(),
                     ));
 
-                    let primary_window = app
+                    let primary_window_surface_target_source = app
                         .world_mut()
-                        .query_filtered::<&RawHandleWrapperHolder, With<PrimaryWindow>>()
+                        .query_filtered::<&SurfaceTargetSource, With<PrimaryWindow>>()
                         .single(app.world())
                         .ok()
                         .cloned();
@@ -334,7 +335,7 @@ impl Plugin for RenderPlugin {
                     let async_renderer = async move {
                         let render_resources = renderer::initialize_renderer(
                             backends,
-                            primary_window,
+                            primary_window_surface_target_source,
                             &settings,
                             #[cfg(feature = "raw_vulkan_init")]
                             raw_vulkan_init_settings,

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -116,10 +116,12 @@ impl Plugin for ViewPlugin {
                     // `TextureView`s need to be dropped before reconfiguring window surfaces.
                     clear_view_attachments
                         .in_set(RenderSystems::ManageViews)
-                        .before(create_surfaces),
+                        .before(create_send_surfaces)
+                        .before(create_non_send_surfaces),
                     cleanup_view_targets_for_resize
                         .in_set(RenderSystems::ManageViews)
-                        .before(create_surfaces),
+                        .before(create_send_surfaces)
+                        .before(create_non_send_surfaces),
                     prepare_view_attachments
                         .in_set(RenderSystems::ManageViews)
                         .before(prepare_view_targets)

--- a/crates/bevy_render/src/view/window/surface_target.rs
+++ b/crates/bevy_render/src/view/window/surface_target.rs
@@ -1,0 +1,276 @@
+#![expect(
+    unsafe_code,
+    reason = "This module interacts with wgpu's unsafe interfaces; thus, we have to use unsafe code here."
+)]
+use alloc::sync::Arc;
+use bevy_derive::Deref;
+use bevy_ecs::component::Component;
+use thiserror::Error;
+use wgpu::rwh::{DisplayHandle, HasDisplayHandle, HasWindowHandle, WindowHandle};
+
+pub use wgpu::SurfaceTarget;
+pub use wgpu::SurfaceTargetUnsafe;
+
+use crate::renderer::WgpuWrapper;
+
+pub(crate) type SurfaceTargetSourceHandle = Arc<dyn HasSurfaceTarget + Send + Sync + 'static>;
+
+/// Defines thread requirements of a [`SurfaceTargetSource`].
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum SurfaceTargetThreadConstraint {
+    /// Surfaces must only be created / updated on the main thread (e.g. UIKit, AppKit).
+    MainThread,
+    /// Surfaces can be created / updated on any thread.
+    None,
+}
+
+/// Holds a reference to a window or view that is capable of returning a surface target.
+#[derive(Clone, Component)]
+pub struct SurfaceTargetSource {
+    source: SurfaceTargetSourceHandle,
+    thread_constraint: SurfaceTargetThreadConstraint,
+}
+
+/// An error returned by [`SurfaceTargetSource::surface_target()`] when a surface target is unavailable.
+#[derive(Error, Debug, Clone)]
+pub enum SurfaceTargetError {
+    #[error("SurfaceTargetSource did not return a surface target")]
+    NoSurfaceTarget,
+    #[error("This surface target can only be accessed from the main thread")]
+    InvalidThread,
+}
+
+/// An error returned by [`SurfaceTargetSource::create_surface()`] when surface creation fails.
+#[derive(Error, Debug, Clone)]
+pub enum SurfaceCreationError {
+    #[error("The SurfaceTargetSource did not return a surface target")]
+    NoSurfaceTarget,
+    #[error("A surface on this surface target can only be created from the main thread")]
+    InvalidThread,
+    #[error("Unable to create surface: {0:?}")]
+    Failed(wgpu::CreateSurfaceError),
+}
+
+impl From<SurfaceTargetError> for SurfaceCreationError {
+    fn from(value: SurfaceTargetError) -> Self {
+        match value {
+            SurfaceTargetError::InvalidThread => Self::InvalidThread,
+            SurfaceTargetError::NoSurfaceTarget => Self::NoSurfaceTarget,
+        }
+    }
+}
+
+impl From<wgpu::CreateSurfaceError> for SurfaceCreationError {
+    fn from(value: wgpu::CreateSurfaceError) -> Self {
+        SurfaceCreationError::Failed(value)
+    }
+}
+
+/// Wraps a [`wgpu::Surface`] and holds a handle to the source window / view to ensure the surface does not outlive it.
+#[derive(Deref)]
+pub struct RenderSurface {
+    _source: SurfaceTargetSourceHandle,
+    #[deref]
+    surface: WgpuWrapper<wgpu::Surface<'static>>,
+}
+
+impl RenderSurface {
+    /// Returns the underlying [`wgpu::Surface`].
+    ///
+    /// ## Safety
+    ///
+    /// The caller must ensure the returned surface is only used when the window / view is still alive and valid.
+    pub unsafe fn into_inner(self) -> wgpu::Surface<'static> {
+        self.surface.into_inner()
+    }
+}
+
+/// An internal wrapper that allows a main-thread-only surface target to be sent across threads.
+///
+/// ## Safety
+///
+/// The wrapped surface target must only be used on the main thread.
+struct NonSendHasSurfaceTarget<T: HasSurfaceTarget + 'static>(T);
+
+// SAFETY: This is an internal type that is only used on the main thread.
+unsafe impl<T: HasSurfaceTarget + 'static> Send for NonSendHasSurfaceTarget<T> {}
+// SAFETY: This is an internal type that is only used on the main thread.
+unsafe impl<T: HasSurfaceTarget + 'static> Sync for NonSendHasSurfaceTarget<T> {}
+
+impl<T: HasSurfaceTarget + 'static> HasSurfaceTarget for NonSendHasSurfaceTarget<T> {
+    unsafe fn surface_target(&self) -> Option<SurfaceTargetWrapper<'_>> {
+        // SAFETY: We're just implementing the HasSurfaceTarget trait by calling the inner HasSurfaceTarget
+        // implementation. The caller is still expected to uphold the safety contract.
+        unsafe { self.0.surface_target() }
+    }
+}
+
+impl SurfaceTargetSource {
+    /// Creates a new surface target source that's safe to be used across threads.
+    ///
+    /// ## Safety
+    ///
+    /// If the surface target can only have surfaces created or updated on the main thread only (e.g. UIKit,
+    /// AppKit), you *must* set `thread_constraint` to [`SurfaceTargetThreadConstraint::MainThread`] or use
+    /// [`SurfaceTargetSource::new_non_send`] instead.
+    pub fn new<T: HasSurfaceTarget + Send + Sync + 'static>(
+        thread_constraint: SurfaceTargetThreadConstraint,
+        source: T,
+    ) -> Self {
+        Self {
+            source: Arc::new(source),
+            thread_constraint,
+        }
+    }
+
+    /// Creates a new surface target source that requires main-thread-only access.
+    pub fn new_non_send<T: HasSurfaceTarget + 'static>(source: T) -> Self {
+        Self {
+            source: Arc::new(NonSendHasSurfaceTarget(source)),
+            thread_constraint: SurfaceTargetThreadConstraint::MainThread,
+        }
+    }
+
+    /// Returns the thread constraint of the surface target.
+    pub fn thread_constraint(&self) -> SurfaceTargetThreadConstraint {
+        self.thread_constraint
+    }
+
+    /// Returns `true` if surfaces can only be created or updated on the main thread.
+    pub fn requires_main_thread(&self) -> bool {
+        self.thread_constraint == SurfaceTargetThreadConstraint::MainThread
+    }
+
+    /// Returns the surface target for the window or view (if available).
+    pub fn surface_target(
+        &self,
+        is_main_thread: bool,
+    ) -> Result<SurfaceTargetWrapper<'_>, SurfaceTargetError> {
+        let valid_thread = match self.thread_constraint {
+            SurfaceTargetThreadConstraint::MainThread => is_main_thread,
+            SurfaceTargetThreadConstraint::None => true,
+        };
+
+        if !valid_thread {
+            return Err(SurfaceTargetError::InvalidThread);
+        }
+
+        // SAFETY: We verify the thread above.
+        unsafe { self.source.surface_target() }.ok_or(SurfaceTargetError::NoSurfaceTarget)
+    }
+
+    /// Creates a surface.
+    pub fn create_surface(
+        &self,
+        instance: &wgpu::Instance,
+        is_main_thread: bool,
+    ) -> Result<RenderSurface, SurfaceCreationError> {
+        let surface_target = self
+            .surface_target(is_main_thread)
+            .map_err(SurfaceCreationError::from)?;
+
+        let surface = match surface_target {
+            SurfaceTargetWrapper::SurfaceTarget(surface_target) => {
+                // SAFETY: The returned surface is returned with window/view handle that ensures it lives at least as long as the surface does.
+                let static_surface_target = unsafe {
+                    core::mem::transmute::<SurfaceTarget<'_>, SurfaceTarget<'static>>(
+                        surface_target,
+                    )
+                };
+                instance
+                    .create_surface(static_surface_target)
+                    .map_err(SurfaceCreationError::from)?
+            }
+            SurfaceTargetWrapper::SurfaceTargetUnsafe(surface_target_unsafe) => {
+                // SAFETY:
+                // - The returned surface is returned with window/view handle that ensures it lives at least as long as the surface does.
+                // - The surface target source is expected to only return valid surface targets.
+                unsafe { instance.create_surface_unsafe(surface_target_unsafe) }
+                    .map_err(SurfaceCreationError::from)?
+            }
+        };
+
+        Ok(RenderSurface {
+            _source: self.source.clone(),
+            surface: WgpuWrapper::new(surface),
+        })
+    }
+}
+
+pub trait HasSurfaceTarget {
+    /// Returns the surface target for the window or view (if available).
+    ///
+    /// ## Safety
+    ///
+    /// **It's up to the caller to ensure:**
+    ///
+    /// - The returned surface is only used on an appropriate thread. Certain platforms / surface targets
+    ///   like UIKit and AppKit require access ONLY on the main thread. It is up to the caller to know
+    ///   platform conventions and abide by them.
+    ///
+    /// **It's up to the trait implementor to ensure:**
+    ///
+    /// - The returned surface is valid.
+    unsafe fn surface_target(&self) -> Option<SurfaceTargetWrapper<'_>>;
+}
+
+impl<T> HasSurfaceTarget for T
+where
+    T: wgpu::WindowHandle,
+{
+    unsafe fn surface_target(&self) -> Option<SurfaceTargetWrapper<'_>> {
+        Some(SurfaceTargetWrapper::SurfaceTarget(SurfaceTarget::from(
+            self,
+        )))
+    }
+}
+
+/// A wrapper over [`wgpu::SurfaceTarget`] and [`wgpu::SurfaceTargetUnsafe`].
+///
+/// This is inherently thread-locked due to the inner types not being `Send` nor `Sync`.
+pub enum SurfaceTargetWrapper<'a> {
+    SurfaceTarget(SurfaceTarget<'a>),
+    SurfaceTargetUnsafe(SurfaceTargetUnsafe),
+}
+
+impl HasDisplayHandle for SurfaceTargetWrapper<'_> {
+    fn display_handle(&self) -> Result<DisplayHandle<'_>, wgpu::rwh::HandleError> {
+        match self {
+            Self::SurfaceTarget(surface_target) => match &surface_target {
+                SurfaceTarget::Window(window) => window.display_handle(),
+                _ => Err(wgpu::rwh::HandleError::NotSupported),
+            },
+            Self::SurfaceTargetUnsafe(surface_target_unsafe) => match surface_target_unsafe {
+                SurfaceTargetUnsafe::RawHandle {
+                    raw_display_handle,
+                    raw_window_handle: _,
+                } => {
+                    // SAFETY: This is expected to be a valid handle for the lifetime of 'a
+                    Ok(unsafe { DisplayHandle::borrow_raw(*raw_display_handle) })
+                }
+                _ => Err(wgpu::rwh::HandleError::NotSupported),
+            },
+        }
+    }
+}
+
+impl HasWindowHandle for SurfaceTargetWrapper<'_> {
+    fn window_handle(&self) -> Result<WindowHandle<'_>, wgpu::rwh::HandleError> {
+        match self {
+            Self::SurfaceTarget(surface_target) => match &surface_target {
+                SurfaceTarget::Window(window) => window.window_handle(),
+                _ => Err(wgpu::rwh::HandleError::NotSupported),
+            },
+            Self::SurfaceTargetUnsafe(surface_target_unsafe) => match surface_target_unsafe {
+                SurfaceTargetUnsafe::RawHandle {
+                    raw_display_handle: _,
+                    raw_window_handle,
+                } => {
+                    // SAFETY: This is expected to be a valid handle for the lifetime of 'a
+                    Ok(unsafe { WindowHandle::borrow_raw(*raw_window_handle) })
+                }
+                _ => Err(wgpu::rwh::HandleError::NotSupported),
+            },
+        }
+    }
+}

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -44,9 +44,7 @@ pub mod prelude {
     };
 }
 
-use alloc::sync::Arc;
 use bevy_app::prelude::*;
-use bevy_platform::sync::Mutex;
 
 impl Default for WindowPlugin {
     fn default() -> Self {
@@ -126,10 +124,7 @@ impl Plugin for WindowPlugin {
 
         if let Some(primary_window) = &self.primary_window {
             let mut entity_commands = app.world_mut().spawn(primary_window.clone());
-            entity_commands.insert((
-                PrimaryWindow,
-                RawHandleWrapperHolder(Arc::new(Mutex::new(None))),
-            ));
+            entity_commands.insert(PrimaryWindow);
             if let Some(primary_cursor_options) = &self.primary_cursor_options {
                 entity_commands.insert(primary_cursor_options.clone());
             }

--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -52,6 +52,7 @@ bevy_platform = { path = "../bevy_platform", version = "0.18.0-dev", default-fea
 ] }
 
 # bevy optional
+bevy_render = { path = "../bevy_render", version = "0.18.0-dev", optional = true }
 ## used by custom_cursor
 bevy_asset = { path = "../bevy_asset", version = "0.18.0-dev", optional = true }
 ## used by custom_cursor

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -16,7 +16,7 @@ extern crate alloc;
 
 use bevy_derive::Deref;
 use bevy_reflect::Reflect;
-use bevy_window::{RawHandleWrapperHolder, WindowEvent};
+use bevy_window::WindowEvent;
 use core::cell::RefCell;
 use winit::{event_loop::EventLoop, window::WindowId};
 
@@ -26,6 +26,7 @@ use bevy_ecs::prelude::*;
 use bevy_window::{exit_on_all_closed, CursorOptions, Window, WindowCreated};
 use system::{changed_cursor_options, changed_windows, check_keyboard_focus_lost, despawn_windows};
 pub use system::{create_monitors, create_windows};
+pub use window_wrapper::*;
 #[cfg(all(target_family = "wasm", target_os = "unknown"))]
 pub use winit::platform::web::CustomCursorExtWebSys;
 pub use winit::{
@@ -46,6 +47,7 @@ mod converters;
 mod cursor;
 mod state;
 mod system;
+mod window_wrapper;
 mod winit_config;
 mod winit_monitors;
 mod winit_windows;
@@ -229,17 +231,7 @@ impl AppSendEvent for Vec<WindowEvent> {
 /// The parameters of the [`create_windows`] system.
 pub type CreateWindowParams<'w, 's> = (
     Commands<'w, 's>,
-    Query<
-        'w,
-        's,
-        (
-            Entity,
-            &'static mut Window,
-            &'static CursorOptions,
-            Option<&'static RawHandleWrapperHolder>,
-        ),
-        Added<Window>,
-    >,
+    Query<'w, 's, (Entity, &'static mut Window, &'static CursorOptions), Added<Window>>,
     MessageWriter<'w, WindowCreated>,
     ResMut<'w, WinitActionRequestHandlers>,
     Res<'w, AccessibilityRequested>,

--- a/crates/bevy_winit/src/window_wrapper.rs
+++ b/crates/bevy_winit/src/window_wrapper.rs
@@ -1,0 +1,39 @@
+use alloc::sync::Arc;
+use bevy_derive::Deref;
+use winit::raw_window_handle::{HasDisplayHandle, HasWindowHandle};
+
+/// A wrapper over a winit window.
+///
+/// This is cloneable, which allows us to extend the lifetime of the window, so it doesn't get eagerly
+/// dropped while a pipelined renderer still has frames in flight that need to draw to it.
+#[derive(Debug, Deref, Clone)]
+pub struct WinitWindowWrapper {
+    pub(crate) window: Arc<winit::window::Window>,
+}
+
+impl WinitWindowWrapper {
+    /// Creates a `WinitWindowWrapper` from a window.
+    pub fn new(window: winit::window::Window) -> WinitWindowWrapper {
+        WinitWindowWrapper {
+            window: Arc::new(window),
+        }
+    }
+}
+
+impl HasWindowHandle for WinitWindowWrapper {
+    fn window_handle(
+        &self,
+    ) -> Result<winit::raw_window_handle::WindowHandle<'_>, winit::raw_window_handle::HandleError>
+    {
+        self.window.window_handle()
+    }
+}
+
+impl HasDisplayHandle for WinitWindowWrapper {
+    fn display_handle(
+        &self,
+    ) -> Result<winit::raw_window_handle::DisplayHandle<'_>, winit::raw_window_handle::HandleError>
+    {
+        self.window.display_handle()
+    }
+}

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -5,7 +5,7 @@ use bevy_ecs::entity::EntityHashMap;
 use bevy_platform::collections::HashMap;
 use bevy_window::{
     CursorGrabMode, CursorOptions, MonitorSelection, VideoModeSelection, Window, WindowMode,
-    WindowPosition, WindowResolution, WindowWrapper,
+    WindowPosition, WindowResolution,
 };
 use tracing::warn;
 
@@ -17,6 +17,7 @@ use winit::{
     window::{CursorGrabMode as WinitCursorGrabMode, Fullscreen, Window as WinitWindow, WindowId},
 };
 
+use crate::WinitWindowWrapper;
 use crate::{
     accessibility::{
         prepare_accessibility_for_window, AccessKitAdapters, WinitActionRequestHandlers,
@@ -30,7 +31,7 @@ use crate::{
 #[derive(Debug, Default)]
 pub struct WinitWindows {
     /// Stores [`winit`] windows by window identifier.
-    pub windows: HashMap<WindowId, WindowWrapper<WinitWindow>>,
+    pub windows: HashMap<WindowId, WinitWindowWrapper>,
     /// Maps entities to `winit` window identifiers.
     pub entity_to_winit: EntityHashMap<WindowId>,
     /// Maps `winit` window identifiers to entities.
@@ -63,7 +64,7 @@ impl WinitWindows {
         handlers: &mut WinitActionRequestHandlers,
         accessibility_requested: &AccessibilityRequested,
         monitors: &WinitMonitors,
-    ) -> &WindowWrapper<WinitWindow> {
+    ) -> &WinitWindowWrapper {
         let mut winit_window_attributes = WinitWindow::default_attributes();
 
         // Due to a UIA limitation, winit windows need to be invisible for the
@@ -338,12 +339,12 @@ impl WinitWindows {
 
         self.windows
             .entry(winit_window.id())
-            .insert(WindowWrapper::new(winit_window))
+            .insert(WinitWindowWrapper::new(winit_window))
             .into_mut()
     }
 
     /// Get the winit window that is associated with our entity.
-    pub fn get_window(&self, entity: Entity) -> Option<&WindowWrapper<WinitWindow>> {
+    pub fn get_window(&self, entity: Entity) -> Option<&WinitWindowWrapper> {
         self.entity_to_winit
             .get(&entity)
             .and_then(|winit_id| self.windows.get(winit_id))
@@ -359,7 +360,7 @@ impl WinitWindows {
     /// Remove a window from winit.
     ///
     /// This should mostly just be called when the window is closing.
-    pub fn remove_window(&mut self, entity: Entity) -> Option<WindowWrapper<WinitWindow>> {
+    pub fn remove_window(&mut self, entity: Entity) -> Option<WinitWindowWrapper> {
         let winit_id = self.entity_to_winit.remove(&entity)?;
         self.winit_to_entity.remove(&winit_id);
         self.windows.remove(&winit_id)


### PR DESCRIPTION
# Objective
This PR refactors window handles / surface creation to support all the surface targets that wgpu supports ([defined here](https://github.com/gfx-rs/wgpu/blob/5f3f7028fca7b980707aab90d385f12fdb81bb6b/wgpu/src/api/surface.rs#L211-L375)) instead of just the subset that can be represented by [raw-window-handle](https://github.com/rust-windowing/raw-window-handle).

Although not supported out-of-the-box, the primary point for doing this is to unlock the ability to run Bevy entirely off the main thread on iOS and MacOS via wgpu’s [`SurfaceTargetUnsafe::CoreAnimationLayer`](https://github.com/gfx-rs/wgpu/blob/5f3f7028fca7b980707aab90d385f12fdb81bb6b/wgpu/src/api/surface.rs#L323-L329).

## Solution

Introduce a `SurfaceTargetSource` component on window entities that's very similar to `RawHandleWrapper`. It hands out a `wgpu::SurfaceTarget` or `wgpu::SurfaceTargetUnsafe` instead of a raw-window-handle handle.

Could this have been achieved by adding CoreAnimationLayer to raw-window-handle? Yes, but then that crate would need a new release and wgpu would need updated. The approach in this PR ensures Bevy supports all that wgpu supports without the potential for future drift.

Although it's now unused, `RawHandleWrapper` was left in place for anyone implementing custom renderers that aren't necessarily wgpu-based.

## Showcase

```rust
struct CoreAnimationLayerHandle(*mut std::ffi::c_void);

unsafe impl Send for CoreAnimationLayerHandle {}
unsafe impl Sync for CoreAnimationLayerHandle {}

impl HasSurfaceTarget for CoreAnimationLayerHandle {
    unsafe fn surface_target(&self) -> Option<SurfaceTargetWrapper> {
        Some(SurfaceTargetWrapper::SurfaceTargetUnsafe(
            SurfaceTargetUnsafe::CoreAnimationLayer(self.0),
        ))
    }
}

// The basic idea:

let ca_layer_handle = CoreAnimationLayerHandle(ptr);
std::thread::spawn(move || {
    // (Bevy initialization goes here)
    // Spawn primary window
    let thread_constraint = SurfaceTargetThreadConstraint::None;
    let surface_target_source = SurfaceTargetSource::new(thread_constraint, ca_layer_handle);
    let primary_window = app
        .world_mut()
        .spawn((Window { ... }, PrimaryWindow, surface_target_source))
        .id();
    // (Custom render loop goes here)
});
```

## Testing

* I tried to compartmentalize unsafe / minimize unsoundness, but could use another set of eyes on it.
* I tested the following configurations:
   - Run Bevy fully on a background thread on MacOS/iOS via `SurfaceTargetUnsafe::CoreAnimationLayer` (note: this isn’t supported out of the box in Bevy, but with this PR, it can be achieved with custom initialization similar to what’s shown in the Showcase section above)
   - Run on UiKit / AppKit on main thread via custom implementation
   - Run normal Bevy with `bevy_winit` on MacOS

## Migration Guide
- If you are not using `bevy_winit` but *are* using `bevy_render` (uncommon), you must insert a `SurfaceTargetSource` component on window entities. It's nearly identical to `RawHandleWrapper`, but supports additional surface targets that cannot be represented by [raw-window-handle](https://crates.io/crates/raw-window-handle).
- `RawHandleWrapperHolder` has been removed. Use `RawHandleWrapper` to get a handle instead.