### PR TITLE
Added the additional documentation to the render_layers struct

### DIFF
--- a/crates/bevy_render/src/view/visibility/render_layers.rs
+++ b/crates/bevy_render/src/view/visibility/render_layers.rs
@@ -12,6 +12,9 @@ pub type Layer = usize;
 /// Cameras with this component will only render entities with intersecting
 /// layers.
 ///
+/// Cameras without this component will only render entities belonging to the default 
+/// render layer (RenderLayers::layer(0)).
+/// 
 /// Entities may belong to one or more layers, or no layer at all.
 ///
 /// The [`Default`] instance of `RenderLayers` contains layer `0`, the first layer.


### PR DESCRIPTION
# Objective

- This is to add clarity to the documentation for RenderLayers with regards to how a camera without RenderLayers operates

## Solution

- Adding in the additional documentation
 
## Testing

- Built the solution to see the changes
---