### PR TITLE
Fully qualify crate paths in `BevyManifest`

### DIFF
--- a/crates/bevy_macro_utils/src/bevy_manifest.rs
+++ b/crates/bevy_macro_utils/src/bevy_manifest.rs
@@ -95,7 +95,7 @@ impl BevyManifest {
                 return None;
             };
 
-            let mut path = Self::parse_str::<syn::Path>(package);
+            let mut path = Self::parse_str::<syn::Path>(&format!("::{}", package));
             if let Some(module) = name.strip_prefix("bevy_") {
                 path.segments.push(Self::parse_str(module));
             }


### PR DESCRIPTION
# Objective

Subtle, very minor issue. The following code fails to compile on main:
```rs
struct bevy;
#[derive(::bevy::ecs::component::Component)]
struct MyComponent;
```
The derive proc macro is pasting in essentially:
```rs
impl bevy::ecs::component::Component for MyComponent
```
...which normally works, but I've added `struct bevy`, which makes the proc macro spit out incorrect code.

Very cursed, but to my knowledge has never been encountered in practice. All the same, it's technically incorrect and should be fixed.

## Solution

The solution is simply to prepend `::` to crate names. Specifically, all (all?) Bevy's derive macros determine the root crate name using `BevyManifest`, which does some toml-parsing witchcraft to figure out whether to qualify names using the umbrella `bevy` crate or individual `bevy_xxx` crates. I just added a `::` to the spot where we parse the `syn::Path`. The above example compiles properly after that.

## Testing

- CI should catch any errors since this change should cause compile errors if for some reason they're being used in a cursed way somewhere that would make this break something.

## Note

If this does break something for someone, this *really* needs a comment in `BevyManifest::maybe_get_path` explaining why we can't make this change.