### PR TITLE
Fix game_of_life shader relying on Naga bug

### DIFF
--- a/assets/shaders/game_of_life.wgsl
+++ b/assets/shaders/game_of_life.wgsl
@@ -12,9 +12,9 @@ fn hash(value: u32) -> u32 {
     var state = value;
     state = state ^ 2747636419u;
     state = state * 2654435769u;
-    state = state ^ state >> 16u;
+    state = state ^ (state >> 16u);
     state = state * 2654435769u;
-    state = state ^ state >> 16u;
+    state = state ^ (state >> 16u);
     state = state * 2654435769u;
     return state;
 }
@@ -27,7 +27,7 @@ fn randomFloat(value: u32) -> f32 {
 fn init(@builtin(global_invocation_id) invocation_id: vec3<u32>, @builtin(num_workgroups) num_workgroups: vec3<u32>) {
     let location = vec2<i32>(i32(invocation_id.x), i32(invocation_id.y));
 
-    let randomNumber = randomFloat(invocation_id.y << 16u | invocation_id.x);
+    let randomNumber = randomFloat((invocation_id.y << 16u) | invocation_id.x);
     let alive = randomNumber > 0.9;
     let color = vec4<f32>(f32(alive));
 


### PR DESCRIPTION
# Objective

The game of life example shader relies on a Naga bug ([6397](https://github.com/gfx-rs/wgpu/issues/6397) / [4536](https://github.com/gfx-rs/wgpu/issues/4536)). In WGSL certain arithmetic operations must be explicitly parenthesized ([reference](https://www.w3.org/TR/WGSL/#operator-precedence-associativity)). Naga doesn't enforce that (and also the precedence order is [messed up](https://github.com/gfx-rs/wgpu/issues/4536#issuecomment-1780113990)). 

So this example may break soon. This is the only sample shader having this issue.

## Solution

added parentheses

## Testing

ran the example before and after the fix with `cargo run --example compute_shader_game_of_life`
