### PR TITLE
 Expose a new function for ViewTarget and MainTargetTextures

### DIFF
--- a/crates/bevy_core_pipeline/src/upscaling/mod.rs
+++ b/crates/bevy_core_pipeline/src/upscaling/mod.rs
@@ -34,7 +34,7 @@ impl Plugin for UpscalingPlugin {
 }
 
 #[derive(Component)]
-pub struct ViewUpscalingPipeline(CachedRenderPipelineId);
+pub struct ViewUpscalingPipeline(pub CachedRenderPipelineId);
 
 fn prepare_view_upscaling_pipelines(
     mut commands: Commands,

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -723,6 +723,20 @@ pub struct NoCpuCulling;
 impl ViewTarget {
     pub const TEXTURE_FORMAT_HDR: TextureFormat = TextureFormat::Rgba16Float;
 
+    /// Creates a new `ViewTarget` with specified textures and format.
+    pub fn new(
+        main_textures: MainTargetTextures,
+        main_texture_format: TextureFormat,
+        out_texture: OutputColorAttachment,
+    ) -> Self {
+        Self {
+            main_texture: main_textures.main_texture.clone(),
+            main_textures,
+            main_texture_format,
+            out_texture,
+        }
+    }
+
     /// Retrieve this target's main texture's color attachment.
     pub fn get_color_attachment(&self) -> RenderPassColorAttachment {
         if self.main_texture.load(Ordering::SeqCst) == 0 {
@@ -964,12 +978,19 @@ pub fn prepare_view_uniforms(
 }
 
 #[derive(Clone)]
-struct MainTargetTextures {
+pub struct MainTargetTextures {
     a: ColorAttachment,
     b: ColorAttachment,
     /// 0 represents `main_textures.a`, 1 represents `main_textures.b`
     /// This is shared across view targets with the same render target
     main_texture: Arc<AtomicUsize>,
+}
+
+impl MainTargetTextures {
+    /// Creates a new `MainTargetTextures`.
+    pub fn new(a: ColorAttachment, b: ColorAttachment, main_texture: Arc<AtomicUsize>) -> Self {
+        Self { a, b, main_texture }
+    }
 }
 
 /// Prepares the view target [`OutputColorAttachment`] for each view in the current frame.


### PR DESCRIPTION
# Objective
- This PR makes the creation of `ViewTarget` public, allowing it to be used without being bound to a `Camera` entity. This enables multiple post-processing steps on a single texture, which is particularly useful when working with Render to Texture. When generating a large number of Camera entities, the FPS can drop significantly, causing lag.

## Solution
- Added a `new` function for `ViewTarget` and `MainTargetTextures`while ensuring the internal fields' accessibility remains intact.
- Exposed the pipeline cache ID field of `ViewUpscalingPipeline` .

## Testing
- The changes are minimal, and the CI should catch any issues. There were no errors when running locally.

---

## Showcase

Here is an example showcasing the result:  
![Showcase](https://raw.githubusercontent.com/aojiaoxiaolinlin/bevy_flash/main/docs/Readme/filter_effect.gif)

In the animation, the glowing effect utilizes multiple post-processing steps on a single texture, with different parameters applied to each glowing part.

