### PR TITLE
Allow entities to be added to a relationship using the new spawn api

### DIFF
--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -89,7 +89,7 @@ pub mod prelude {
             apply_deferred, common_conditions::*, ApplyDeferred, Condition, IntoScheduleConfigs,
             IntoSystemSet, Schedule, Schedules, SystemSet,
         },
-        spawn::{Spawn, SpawnRelated},
+        spawn::{Spawn, SpawnEntities, SpawnEntity, SpawnIter, SpawnRelated, SpawnWith},
         system::{
             Command, Commands, Deferred, EntityCommand, EntityCommands, In, InMut, InRef,
             IntoSystem, Local, NonSend, NonSendMut, ParamSet, Populated, Query, ReadOnlySystem,

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -89,7 +89,7 @@ pub mod prelude {
             apply_deferred, common_conditions::*, ApplyDeferred, Condition, IntoScheduleConfigs,
             IntoSystemSet, Schedule, Schedules, SystemSet,
         },
-        spawn::{Spawn, SpawnEntities, SpawnEntity, SpawnIter, SpawnRelated, SpawnWith},
+        spawn::{Spawn, SpawnIter, SpawnRelated, SpawnWith, WithOneRelated, WithRelated},
         system::{
             Command, Commands, Deferred, EntityCommand, EntityCommands, In, InMut, InRef,
             IntoSystem, Local, NonSend, NonSendMut, ParamSet, Populated, Query, ReadOnlySystem,

--- a/crates/bevy_ecs/src/spawn.rs
+++ b/crates/bevy_ecs/src/spawn.rs
@@ -137,7 +137,7 @@ impl<R: Relationship, F: FnOnce(&mut RelatedSpawner<R>) + Send + Sync + 'static>
 ///
 /// ```
 /// # use bevy_ecs::hierarchy::Children;
-/// # use bevy_ecs::spawn::{Spawn, SpawnEntities, SpawnRelated};
+/// # use bevy_ecs::spawn::{Spawn, WithRelated, SpawnRelated};
 /// # use bevy_ecs::name::Name;
 /// # use bevy_ecs::world::World;
 /// let mut world = World::new();
@@ -149,13 +149,13 @@ impl<R: Relationship, F: FnOnce(&mut RelatedSpawner<R>) + Send + Sync + 'static>
 ///     Name::new("Root"),
 ///     Children::spawn((
 ///         Spawn(Name::new("Child1")),
-///         SpawnEntities([child2, child3].into_iter()),
+///         WithRelated([child2, child3].into_iter()),
 ///     )),
 /// ));
 /// ```
-pub struct SpawnEntities<I>(pub I);
+pub struct WithRelated<I>(pub I);
 
-impl<R: Relationship, I: Iterator<Item = Entity>> SpawnableList<R> for SpawnEntities<I> {
+impl<R: Relationship, I: Iterator<Item = Entity>> SpawnableList<R> for WithRelated<I> {
     fn spawn(self, world: &mut World, entity: Entity) {
         world
             .entity_mut(entity)
@@ -174,7 +174,7 @@ impl<R: Relationship, I: Iterator<Item = Entity>> SpawnableList<R> for SpawnEnti
 ///
 /// ```
 /// # use bevy_ecs::hierarchy::Children;
-/// # use bevy_ecs::spawn::{Spawn, SpawnEntity, SpawnRelated};
+/// # use bevy_ecs::spawn::{Spawn, WithOneRelated, SpawnRelated};
 /// # use bevy_ecs::name::Name;
 /// # use bevy_ecs::world::World;
 /// let mut world = World::new();
@@ -184,13 +184,13 @@ impl<R: Relationship, I: Iterator<Item = Entity>> SpawnableList<R> for SpawnEnti
 /// world.spawn((
 ///     Name::new("Root"),
 ///     Children::spawn((
-///         SpawnEntity(child1),
+///         WithOneRelated(child1),
 ///     )),
 /// ));
 /// ```
-pub struct SpawnEntity(pub Entity);
+pub struct WithOneRelated(pub Entity);
 
-impl<R: Relationship> SpawnableList<R> for SpawnEntity {
+impl<R: Relationship> SpawnableList<R> for WithOneRelated {
     fn spawn(self, world: &mut World, entity: Entity) {
         world.entity_mut(entity).add_one_related::<R>(self.0);
     }
@@ -353,7 +353,7 @@ pub trait SpawnRelated: RelationshipTarget {
     /// Returns a [`Bundle`] containing this [`RelationshipTarget`] component. It also spawns a [`SpawnableList`] of entities, each related to the bundle's entity
     /// via [`RelationshipTarget::Relationship`]. The [`RelationshipTarget`] (when possible) will pre-allocate space for the related entities.
     ///
-    /// See [`Spawn`], [`SpawnIter`], and [`SpawnWith`] for usage examples.
+    /// See [`Spawn`], [`SpawnIter`], [`SpawnWith`], [`WithRelated`] and [`WithOneRelated`] for usage examples.
     fn spawn<L: SpawnableList<Self::Relationship>>(
         list: L,
     ) -> SpawnRelatedBundle<Self::Relationship, L>;

--- a/crates/bevy_ecs/src/spawn.rs
+++ b/crates/bevy_ecs/src/spawn.rs
@@ -142,14 +142,14 @@ impl<R: Relationship, F: FnOnce(&mut RelatedSpawner<R>) + Send + Sync + 'static>
 /// # use bevy_ecs::world::World;
 /// let mut world = World::new();
 ///
-/// let child2 = world.spawn(Name::new("Child2"));
-/// let child3 = world.spawn(Name::new("Child3"));
+/// let child2 = world.spawn(Name::new("Child2")).id();
+/// let child3 = world.spawn(Name::new("Child3")).id();
 ///
 /// world.spawn((
 ///     Name::new("Root"),
 ///     Children::spawn((
 ///         Spawn(Name::new("Child1")),
-///         SpawnEntities([child2, child3]),
+///         SpawnEntities([child2, child3].into_iter()),
 ///     )),
 /// ));
 /// ```
@@ -179,7 +179,7 @@ impl<R: Relationship, I: Iterator<Item = Entity>> SpawnableList<R> for SpawnEnti
 /// # use bevy_ecs::world::World;
 /// let mut world = World::new();
 ///
-/// let child1 = world.spawn(Name::new("Child1"));
+/// let child1 = world.spawn(Name::new("Child1")).id();
 ///
 /// world.spawn((
 ///     Name::new("Root"),

--- a/crates/bevy_ecs/src/spawn.rs
+++ b/crates/bevy_ecs/src/spawn.rs
@@ -188,7 +188,7 @@ impl<R: Relationship, I: Iterator<Item = Entity>> SpawnableList<R> for SpawnEnti
 ///     )),
 /// ));
 /// ```
-pub struct SpawnEntity(Entity);
+pub struct SpawnEntity(pub Entity);
 
 impl<R: Relationship> SpawnableList<R> for SpawnEntity {
     fn spawn(self, world: &mut World, entity: Entity) {

--- a/crates/bevy_ecs/src/spawn.rs
+++ b/crates/bevy_ecs/src/spawn.rs
@@ -137,7 +137,7 @@ impl<R: Relationship, F: FnOnce(&mut RelatedSpawner<R>) + Send + Sync + 'static>
 ///
 /// ```
 /// # use bevy_ecs::hierarchy::Children;
-/// # use bevy_ecs::spawn::{Spawn, SpawnIter, SpawnRelated};
+/// # use bevy_ecs::spawn::{Spawn, SpawnEntities, SpawnRelated};
 /// # use bevy_ecs::name::Name;
 /// # use bevy_ecs::world::World;
 /// let mut world = World::new();
@@ -174,7 +174,7 @@ impl<R: Relationship, I: Iterator<Item = Entity>> SpawnableList<R> for SpawnEnti
 ///
 /// ```
 /// # use bevy_ecs::hierarchy::Children;
-/// # use bevy_ecs::spawn::{Spawn, SpawnRelated};
+/// # use bevy_ecs::spawn::{Spawn, SpawnEntity, SpawnRelated};
 /// # use bevy_ecs::name::Name;
 /// # use bevy_ecs::world::World;
 /// let mut world = World::new();


### PR DESCRIPTION
# Objective

Fixes #18662

Useful if you want to to add something that already exists to a relationship .

## Solution

Added SpawnEntity and SpawnEntites which implement SpawnableList.

I also added SpawnIter and SpawnWith to bevy_ecs's prelude as it felt weird that they'd be missing, but maybe there's some reason why they weren't added? If you know anything about it lmk.

I'm also not entirely sold on the names so if anyone has any better ideas lmk.

## Testing

Tested by adding a child using the new methods and checking if it exists, and it worked! First try!

## Showcase

```rust
let child1 = commands.spawn(Name::new("Child1")).id();

commands.spawn((
    Name::new("Root"),
    Children::spawn((
        SpawnEntity(child1),
    )),
));
```