### PR TITLE
Audio sink seek adopted

### DIFF
--- a/crates/bevy_audio/src/sinks.rs
+++ b/crates/bevy_audio/src/sinks.rs
@@ -1,7 +1,9 @@
 use bevy_ecs::component::Component;
 use bevy_math::Vec3;
 use bevy_transform::prelude::Transform;
+use rodio::source::SeekError;
 use rodio::{Sink, SpatialSink};
+use std::time::Duration;
 
 use crate::Volume;
 
@@ -94,6 +96,9 @@ pub trait AudioSinkPlayback {
             self.mute();
         }
     }
+
+    /// Seeks to a specific position in the audio.
+    fn try_seek(&self, pos: Duration) -> Result<(), SeekError>;
 }
 
 /// Used to control audio during playback.
@@ -190,6 +195,10 @@ impl AudioSinkPlayback for AudioSink {
             self.sink.set_volume(volume.to_linear());
         }
     }
+
+    fn try_seek(&self, pos: Duration) -> Result<(), SeekError> {
+        self.sink.try_seek(pos)
+    }
 }
 
 /// Used to control spatial audio during playback.
@@ -285,6 +294,10 @@ impl AudioSinkPlayback for SpatialAudioSink {
         if let Some(volume) = self.managed_volume.take() {
             self.sink.set_volume(volume.to_linear());
         }
+    }
+
+    fn try_seek(&self, pos: Duration) -> Result<(), SeekError> {
+        self.sink.try_seek(pos)
     }
 }
 

--- a/crates/bevy_audio/src/sinks.rs
+++ b/crates/bevy_audio/src/sinks.rs
@@ -1,11 +1,10 @@
+use crate::Volume;
 use bevy_ecs::component::Component;
 use bevy_math::Vec3;
 use bevy_transform::prelude::Transform;
-use rodio::source::SeekError;
+use core::time::Duration;
+pub use rodio::source::SeekError;
 use rodio::{Sink, SpatialSink};
-use std::time::Duration;
-
-use crate::Volume;
 
 /// Common interactions with an audio sink.
 pub trait AudioSinkPlayback {
@@ -42,6 +41,26 @@ pub trait AudioSinkPlayback {
     ///
     /// No effect if not paused.
     fn play(&self);
+
+    /// Attempts to seek to a given position in the current source.
+    ///
+    /// This blocks between 0 and ~5 milliseconds.
+    ///
+    /// As long as the duration of the source is known, seek is guaranteed to saturate
+    /// at the end of the source. For example given a source that reports a total duration
+    /// of 42 seconds calling `try_seek()` with 60 seconds as argument will seek to
+    /// 42 seconds.
+    ///
+    /// # Errors
+    /// This function will return [`SeekError::NotSupported`] if one of the underlying
+    /// sources does not support seeking.
+    ///
+    /// It will return an error if an implementation ran
+    /// into one during the seek.
+    ///
+    /// When seeking beyond the end of a source this
+    /// function might return an error if the duration of the source is not known.
+    fn try_seek(&self, pos: Duration) -> Result<(), SeekError>;
 
     /// Pauses playback of this sink.
     ///
@@ -96,9 +115,6 @@ pub trait AudioSinkPlayback {
             self.mute();
         }
     }
-
-    /// Seeks to a specific position in the audio.
-    fn try_seek(&self, pos: Duration) -> Result<(), SeekError>;
 }
 
 /// Used to control audio during playback.
@@ -165,6 +181,10 @@ impl AudioSinkPlayback for AudioSink {
         self.sink.play();
     }
 
+    fn try_seek(&self, pos: Duration) -> Result<(), SeekError> {
+        self.sink.try_seek(pos)
+    }
+
     fn pause(&self) {
         self.sink.pause();
     }
@@ -194,10 +214,6 @@ impl AudioSinkPlayback for AudioSink {
         if let Some(volume) = self.managed_volume.take() {
             self.sink.set_volume(volume.to_linear());
         }
-    }
-
-    fn try_seek(&self, pos: Duration) -> Result<(), SeekError> {
-        self.sink.try_seek(pos)
     }
 }
 
@@ -265,6 +281,10 @@ impl AudioSinkPlayback for SpatialAudioSink {
         self.sink.play();
     }
 
+    fn try_seek(&self, pos: Duration) -> Result<(), SeekError> {
+        self.sink.try_seek(pos)
+    }
+
     fn pause(&self) {
         self.sink.pause();
     }
@@ -294,10 +314,6 @@ impl AudioSinkPlayback for SpatialAudioSink {
         if let Some(volume) = self.managed_volume.take() {
             self.sink.set_volume(volume.to_linear());
         }
-    }
-
-    fn try_seek(&self, pos: Duration) -> Result<(), SeekError> {
-        self.sink.try_seek(pos)
     }
 }
 

--- a/crates/bevy_audio/src/sinks.rs
+++ b/crates/bevy_audio/src/sinks.rs
@@ -58,7 +58,7 @@ pub trait AudioSinkPlayback {
     /// It will return an error if an implementation ran
     /// into one during the seek.
     ///
-    /// When seeking beyond the end of a source this
+    /// When seeking beyond the end of a source, this
     /// function might return an error if the duration of the source is not known.
     fn try_seek(&self, pos: Duration) -> Result<(), SeekError>;
 

--- a/examples/audio/audio_control.rs
+++ b/examples/audio/audio_control.rs
@@ -6,7 +6,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_systems(Startup, setup)
-        .add_systems(Update, (update_speed, pause, mute, volume))
+        .add_systems(Update, (update_speed, pause, mute, volume, seek))
         .run();
 }
 
@@ -82,5 +82,17 @@ fn volume(
     } else if keyboard_input.just_pressed(KeyCode::Minus) {
         let current_volume = sink.volume();
         sink.set_volume(current_volume - Volume::Linear(0.1));
+    }
+}
+
+fn seek(
+    keyboard_input: Res<ButtonInput<KeyCode>>,
+    music_controller: Query<&AudioSink, With<MyMusic>>,
+) {
+    if let Ok(sink) = music_controller.single() {
+        if keyboard_input.just_pressed(KeyCode::Digit0) {
+            sink.try_seek(std::time::Duration::from_secs_f64(0.0))
+                .unwrap();
+        }
     }
 }

--- a/examples/audio/audio_control.rs
+++ b/examples/audio/audio_control.rs
@@ -6,7 +6,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_systems(Startup, setup)
-        .add_systems(Update, (update_speed, pause, mute, volume, seek))
+        .add_systems(Update, (update_speed, pause, mute, volume))
         .run();
 }
 
@@ -82,17 +82,5 @@ fn volume(
     } else if keyboard_input.just_pressed(KeyCode::Minus) {
         let current_volume = sink.volume();
         sink.set_volume(current_volume - Volume::Linear(0.1));
-    }
-}
-
-fn seek(
-    keyboard_input: Res<ButtonInput<KeyCode>>,
-    music_controller: Query<&AudioSink, With<MyMusic>>,
-) {
-    if let Ok(sink) = music_controller.single() {
-        if keyboard_input.just_pressed(KeyCode::Digit0) {
-            sink.try_seek(std::time::Duration::from_secs_f64(0.0))
-                .unwrap();
-        }
     }
 }


### PR DESCRIPTION
Adopted #13869 

# Objective

Fixes #9076 

## Solution

Using `rodio`'s `try_seek`

## Testing

@ivanstepanovftw added a `seek` system using `AudioSink` to the `audio_control.rs` example. I got it working with .mp3 files, but rodio doesn't support seeking for .ogg and .flac files, so I removed it from the commit (since the assets folder only has .ogg files). Another thing to note is that `try_seek` fails when using `PlaybackMode::Loop`, as `rodio::source::buffered::Buffered` doesn't support `try_seek`. I haven't tested `SpatialAudioSink`.

## Notes

I copied the docs for `try_seek` verbatim from `rodio`, and re-exported `rodio::source::SeekError`. I'm not completely confident in those decisions, please let me know if I'm doing anything wrong.

</details>
