### PR TITLE
Fix occlusion culling not respecting device limits

### DIFF
--- a/examples/3d/occlusion_culling.rs
+++ b/examples/3d/occlusion_culling.rs
@@ -32,7 +32,7 @@ use bevy::{
         experimental::occlusion_culling::OcclusionCulling,
         render_graph::{self, NodeRunError, RenderGraphApp, RenderGraphContext, RenderLabel},
         render_resource::{Buffer, BufferDescriptor, BufferUsages, MapMode},
-        renderer::{RenderAdapter, RenderContext, RenderDevice},
+        renderer::{RenderContext, RenderDevice},
         settings::WgpuFeatures,
         Render, RenderApp, RenderDebugFlags, RenderPlugin, RenderSet,
     },
@@ -140,7 +140,7 @@ struct SavedIndirectParametersData {
 
 impl FromWorld for SavedIndirectParameters {
     fn from_world(world: &mut World) -> SavedIndirectParameters {
-        let render_adapter = world.resource::<RenderAdapter>();
+        let render_device = world.resource::<RenderDevice>();
         SavedIndirectParameters(Arc::new(Mutex::new(SavedIndirectParametersData {
             data: vec![],
             count: 0,
@@ -152,7 +152,7 @@ impl FromWorld for SavedIndirectParameters {
             // supports `multi_draw_indirect_count`. So, if we don't have that
             // feature, then we don't bother to display how many meshes were
             // culled.
-            occlusion_culling_introspection_supported: render_adapter
+            occlusion_culling_introspection_supported: render_device
                 .features()
                 .contains(WgpuFeatures::MULTI_DRAW_INDIRECT_COUNT),
         })))


### PR DESCRIPTION
The occlusion culling plugin checks for a GPU feature by looking at `RenderAdapter`. This is wrong - it should be checking `RenderDevice`. See these notes for background: https://github.com/bevyengine/bevy/discussions/18973

I don't have any evidence that this was causing any bugs, so right now it's just a precaution.

## Testing

```
cargo run --example occlusion_culling
```

Tested on Win10/Nvidia across Vulkan, WebGL/Chrome, WebGPU/Chrome.