### PR TITLE
Add 'observe_target' method to 'RelatedSpawner'

### DIFF
--- a/crates/bevy_ecs/src/relationship/related_methods.rs
+++ b/crates/bevy_ecs/src/relationship/related_methods.rs
@@ -1,10 +1,12 @@
 use crate::{
     bundle::Bundle,
     entity::{hash_set::EntityHashSet, Entity},
+    event::Event,
+    prelude::Observer,
     relationship::{
         Relationship, RelationshipHookMode, RelationshipSourceCollection, RelationshipTarget,
     },
-    system::{Commands, EntityCommands},
+    system::{Commands, EntityCommands, IntoObserverSystem},
     world::{EntityWorldMut, World},
 };
 use bevy_platform::prelude::{Box, Vec};
@@ -513,6 +515,16 @@ impl<'w, R: Relationship> RelatedSpawner<'w, R> {
     /// entity this spawner was initialized with.
     pub fn spawn_empty(&mut self) -> EntityWorldMut<'_> {
         self.world.spawn(R::from(self.target))
+    }
+
+    /// Creates an [`Observer`] listening for events of type 'E' targeting the 'target'
+    /// entity this spawner was initialized with.
+    pub fn observe_target<E: Event, B: Bundle, M>(
+        &mut self,
+        observer: impl IntoObserverSystem<E, B, M>,
+    ) -> EntityWorldMut<'_> {
+        self.world
+            .spawn(Observer::new(observer).with_entity(self.target))
     }
 
     /// Returns the "target entity" used when spawning entities with an `R` [`Relationship`].

--- a/crates/bevy_ecs/src/relationship/related_methods.rs
+++ b/crates/bevy_ecs/src/relationship/related_methods.rs
@@ -518,7 +518,7 @@ impl<'w, R: Relationship> RelatedSpawner<'w, R> {
     }
 
     /// Creates an [`Observer`] listening for events of type 'E' targeting the 'target'
-    /// entity this spawner was initialized with. No relationship is created
+    /// entity this spawner was initialized with. No relationship 'R' is created
     /// between the [`Observer`] and the 'target' entity.
     pub fn observe_target<E: Event, B: Bundle, M>(
         &mut self,

--- a/crates/bevy_ecs/src/relationship/related_methods.rs
+++ b/crates/bevy_ecs/src/relationship/related_methods.rs
@@ -518,7 +518,8 @@ impl<'w, R: Relationship> RelatedSpawner<'w, R> {
     }
 
     /// Creates an [`Observer`] listening for events of type 'E' targeting the 'target'
-    /// entity this spawner was initialized with.
+    /// entity this spawner was initialized with. No relationship is created
+    /// between the [`Observer`] and the 'target' entity.
     pub fn observe_target<E: Event, B: Bundle, M>(
         &mut self,
         observer: impl IntoObserverSystem<E, B, M>,

--- a/crates/bevy_ecs/src/relationship/related_methods.rs
+++ b/crates/bevy_ecs/src/relationship/related_methods.rs
@@ -2,7 +2,7 @@ use crate::{
     bundle::Bundle,
     entity::{hash_set::EntityHashSet, Entity},
     event::Event,
-    prelude::Observer,
+    observer::Observer,
     relationship::{
         Relationship, RelationshipHookMode, RelationshipSourceCollection, RelationshipTarget,
     },


### PR DESCRIPTION
# Objective

Add a way to spawn an observer targeting the 'target_entity()' of a 'RelatedSpawner'. This can be useful to react to Trigger's targeting a parent entity, and then making changes to children. 

This enables a pattern very similar to signals' in Godot.

## Solution

Use the 'world' field of 'RelatedSpawner' to spawn the 'Observer'.

## Showcase

Use case:

<details>
  <summary>Click to view showcase</summary>

```
fn before(world: &mut World) {
    world.spawn(Name::new("Parent")).with_children(|builder| {
        let parent_id = builder.target_entity();

        let mut child = builder.spawn(Name::new("Child"));
        let child_id = child.id();

        child.world_scope(move |world| {
            world.entity_mut(parent_id).observe(change_name(child_id));
        });
    });
}

fn after(mut commands: Commands) { // note now we can use commands instead of world
    commands.spawn(Name::new("Parent")).with_children(|builder| {
        let child_id = builder.spawn(Name::new("Child")).id();

        builder.observe_target(change_name(child_id));
    });
}

fn change_name(entity: Entity) -> impl Fn(Trigger<MyEvent>, Query<&mut Name>) {
    move |_: Trigger<MyEvent>, mut query: Query<&mut Name>| {
        if let Ok(mut name) = query.get_mut(entity) {
            name.set("New Name!");
        }
    }
}
```

</details>
