### PR TITLE
Remove upcasting methods + Cleanup interned label code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["game", "engine", "gamedev", "graphics", "bevy"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/bevyengine/bevy"
 documentation = "https://docs.rs/bevy"
-rust-version = "1.85.0"
+rust-version = "1.86.0"
 
 [workspace]
 resolver = "2"

--- a/crates/bevy_derive/src/lib.rs
+++ b/crates/bevy_derive/src/lib.rs
@@ -205,8 +205,6 @@ pub fn derive_enum_variant_meta(input: TokenStream) -> TokenStream {
 pub fn derive_app_label(input: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(input as syn::DeriveInput);
     let mut trait_path = BevyManifest::shared().get_path("bevy_app");
-    let mut dyn_eq_path = trait_path.clone();
     trait_path.segments.push(format_ident!("AppLabel").into());
-    dyn_eq_path.segments.push(format_ident!("DynEq").into());
-    derive_label(input, "AppLabel", &trait_path, &dyn_eq_path)
+    derive_label(input, "AppLabel", &trait_path)
 }

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/bevyengine/bevy"
 license = "MIT OR Apache-2.0"
 keywords = ["ecs", "game", "bevy"]
 categories = ["game-engines", "data-structures"]
-rust-version = "1.85.0"
+rust-version = "1.86.0"
 
 [features]
 default = ["std", "bevy_reflect", "async_executor", "backtrace"]

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -504,12 +504,10 @@ pub fn derive_schedule_label(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let mut trait_path = bevy_ecs_path();
     trait_path.segments.push(format_ident!("schedule").into());
-    let mut dyn_eq_path = trait_path.clone();
     trait_path
         .segments
         .push(format_ident!("ScheduleLabel").into());
-    dyn_eq_path.segments.push(format_ident!("DynEq").into());
-    derive_label(input, "ScheduleLabel", &trait_path, &dyn_eq_path)
+    derive_label(input, "ScheduleLabel", &trait_path)
 }
 
 /// Derive macro generating an impl of the trait `SystemSet`.
@@ -520,10 +518,8 @@ pub fn derive_system_set(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let mut trait_path = bevy_ecs_path();
     trait_path.segments.push(format_ident!("schedule").into());
-    let mut dyn_eq_path = trait_path.clone();
     trait_path.segments.push(format_ident!("SystemSet").into());
-    dyn_eq_path.segments.push(format_ident!("DynEq").into());
-    derive_label(input, "SystemSet", &trait_path, &dyn_eq_path)
+    derive_label(input, "SystemSet", &trait_path)
 }
 
 pub(crate) fn bevy_ecs_path() -> syn::Path {

--- a/crates/bevy_ecs/src/label.rs
+++ b/crates/bevy_ecs/src/label.rs
@@ -12,9 +12,6 @@ pub use alloc::boxed::Box;
 /// An object safe version of [`Eq`]. This trait is automatically implemented
 /// for any `'static` type that implements `Eq`.
 pub trait DynEq: Any {
-    /// Casts the type to `dyn Any`.
-    fn as_any(&self) -> &dyn Any;
-
     /// This method tests for `self` and `other` values to be equal.
     ///
     /// Implementers should avoid returning `true` when the underlying types are
@@ -29,12 +26,8 @@ impl<T> DynEq for T
 where
     T: Any + Eq,
 {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn dyn_eq(&self, other: &dyn DynEq) -> bool {
-        if let Some(other) = other.as_any().downcast_ref::<T>() {
+        if let Some(other) = (other as &dyn Any).downcast_ref::<T>() {
             return self == other;
         }
         false
@@ -44,9 +37,6 @@ where
 /// An object safe version of [`Hash`]. This trait is automatically implemented
 /// for any `'static` type that implements `Hash`.
 pub trait DynHash: DynEq {
-    /// Casts the type to `dyn Any`.
-    fn as_dyn_eq(&self) -> &dyn DynEq;
-
     /// Feeds this value into the given [`Hasher`].
     fn dyn_hash(&self, state: &mut dyn Hasher);
 }
@@ -58,10 +48,6 @@ impl<T> DynHash for T
 where
     T: DynEq + Hash,
 {
-    fn as_dyn_eq(&self) -> &dyn DynEq {
-        self
-    }
-
     fn dyn_hash(&self, mut state: &mut dyn Hasher) {
         T::hash(self, &mut state);
         self.type_id().hash(&mut state);

--- a/crates/bevy_ecs/src/label.rs
+++ b/crates/bevy_ecs/src/label.rs
@@ -106,7 +106,7 @@ macro_rules! define_label {
     ) => {
 
         $(#[$label_attr])*
-        pub trait $label_trait_name: 'static + Send + Sync + ::core::fmt::Debug + $crate::label::DynEq {
+        pub trait $label_trait_name: Send + Sync + ::core::fmt::Debug + $crate::label::DynEq + $crate::label::DynHash {
 
             $($trait_extra_methods)*
 
@@ -114,9 +114,6 @@ macro_rules! define_label {
             #[doc = stringify!($label_trait_name)]
             ///`.
             fn dyn_clone(&self) -> $crate::label::Box<dyn $label_trait_name>;
-
-            /// Feeds this value into the given [`Hasher`].
-            fn dyn_hash(&self, state: &mut dyn ::core::hash::Hasher);
 
             /// Returns an [`Interned`] value corresponding to `self`.
             fn intern(&self) -> $crate::intern::Interned<dyn $label_trait_name>
@@ -132,10 +129,6 @@ macro_rules! define_label {
 
             fn dyn_clone(&self) -> $crate::label::Box<dyn $label_trait_name> {
                 (**self).dyn_clone()
-            }
-
-            fn dyn_hash(&self, state: &mut dyn ::core::hash::Hasher) {
-                (**self).dyn_hash(state);
             }
 
             fn intern(&self) -> Self {

--- a/crates/bevy_ecs/src/schedule/set.rs
+++ b/crates/bevy_ecs/src/schedule/set.rs
@@ -116,10 +116,6 @@ impl<T> SystemSet for SystemTypeSet<T> {
         Box::new(*self)
     }
 
-    fn as_dyn_eq(&self) -> &dyn DynEq {
-        self
-    }
-
     fn dyn_hash(&self, mut state: &mut dyn Hasher) {
         TypeId::of::<Self>().hash(&mut state);
         self.hash(&mut state);
@@ -145,10 +141,6 @@ impl SystemSet for AnonymousSet {
 
     fn dyn_clone(&self) -> Box<dyn SystemSet> {
         Box::new(*self)
-    }
-
-    fn as_dyn_eq(&self) -> &dyn DynEq {
-        self
     }
 
     fn dyn_hash(&self, mut state: &mut dyn Hasher) {

--- a/crates/bevy_ecs/src/schedule/set.rs
+++ b/crates/bevy_ecs/src/schedule/set.rs
@@ -115,11 +115,6 @@ impl<T> SystemSet for SystemTypeSet<T> {
     fn dyn_clone(&self) -> Box<dyn SystemSet> {
         Box::new(*self)
     }
-
-    fn dyn_hash(&self, mut state: &mut dyn Hasher) {
-        TypeId::of::<Self>().hash(&mut state);
-        self.hash(&mut state);
-    }
 }
 
 /// A [`SystemSet`] implicitly created when using
@@ -141,11 +136,6 @@ impl SystemSet for AnonymousSet {
 
     fn dyn_clone(&self) -> Box<dyn SystemSet> {
         Box::new(*self)
-    }
-
-    fn dyn_hash(&self, mut state: &mut dyn Hasher) {
-        TypeId::of::<Self>().hash(&mut state);
-        self.hash(&mut state);
     }
 }
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -2517,9 +2517,6 @@ impl DynSystemParamState {
 
 /// Allows a [`SystemParam::State`] to be used as a trait object for implementing [`DynSystemParam`].
 trait DynParamState: Sync + Send {
-    /// Casts the underlying `ParamState<T>` to an `Any` so it can be downcast.
-    fn as_any_mut(&mut self) -> &mut dyn Any;
-
     /// For the specified [`Archetype`], registers the components accessed by this [`SystemParam`] (if applicable).a
     ///
     /// # Safety
@@ -2550,10 +2547,6 @@ trait DynParamState: Sync + Send {
 struct ParamState<T: SystemParam>(T::State);
 
 impl<T: SystemParam + 'static> DynParamState for ParamState<T> {
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
     unsafe fn new_archetype(&mut self, archetype: &Archetype, system_meta: &mut SystemMeta) {
         // SAFETY: The caller ensures that `archetype` is from the World the state was initialized from in `init_state`.
         unsafe { T::new_archetype(&mut self.0, archetype, system_meta) };
@@ -2603,13 +2596,13 @@ unsafe impl SystemParam for DynSystemParam<'_, '_> {
         change_tick: Tick,
     ) -> Self::Item<'world, 'state> {
         // SAFETY:
-        // - `state.0` is a boxed `ParamState<T>`, and its implementation of `as_any_mut` returns `self`.
+        // - `state.0` is a boxed `ParamState<T>`.
         // - The state was obtained from `SystemParamBuilder::build()`, which registers all [`World`] accesses used
         //   by [`SystemParam::get_param`] with the provided [`system_meta`](SystemMeta).
         // - The caller ensures that the provided world is the same and has the required access.
         unsafe {
             DynSystemParam::new(
-                state.0.as_any_mut(),
+                &mut state.0 as &mut dyn Any,
                 world,
                 system_meta.clone(),
                 change_tick,

--- a/crates/bevy_macro_utils/src/label.rs
+++ b/crates/bevy_macro_utils/src/label.rs
@@ -58,7 +58,6 @@ pub fn derive_label(
     input: syn::DeriveInput,
     trait_name: &str,
     trait_path: &syn::Path,
-    dyn_eq_path: &syn::Path,
 ) -> TokenStream {
     if let syn::Data::Union(_) = &input.data {
         let message = format!("Cannot derive {trait_name} for unions.");
@@ -88,10 +87,6 @@ pub fn derive_label(
             impl #impl_generics #trait_path for #ident #ty_generics #where_clause {
                 fn dyn_clone(&self) -> alloc::boxed::Box<dyn #trait_path> {
                     alloc::boxed::Box::new(::core::clone::Clone::clone(self))
-                }
-
-                fn as_dyn_eq(&self) -> &dyn #dyn_eq_path {
-                    self
                 }
 
                 fn dyn_hash(&self, mut state: &mut dyn ::core::hash::Hasher) {

--- a/crates/bevy_macro_utils/src/label.rs
+++ b/crates/bevy_macro_utils/src/label.rs
@@ -88,12 +88,6 @@ pub fn derive_label(
                 fn dyn_clone(&self) -> alloc::boxed::Box<dyn #trait_path> {
                     alloc::boxed::Box::new(::core::clone::Clone::clone(self))
                 }
-
-                fn dyn_hash(&self, mut state: &mut dyn ::core::hash::Hasher) {
-                    let ty_id = ::core::any::TypeId::of::<Self>();
-                    ::core::hash::Hash::hash(&ty_id, &mut state);
-                    ::core::hash::Hash::hash(self, &mut state);
-                }
             }
         };
     }

--- a/crates/bevy_render/macros/src/lib.rs
+++ b/crates/bevy_render/macros/src/lib.rs
@@ -80,12 +80,10 @@ pub fn derive_render_label(input: TokenStream) -> TokenStream {
     trait_path
         .segments
         .push(format_ident!("render_graph").into());
-    let mut dyn_eq_path = trait_path.clone();
     trait_path
         .segments
         .push(format_ident!("RenderLabel").into());
-    dyn_eq_path.segments.push(format_ident!("DynEq").into());
-    derive_label(input, "RenderLabel", &trait_path, &dyn_eq_path)
+    derive_label(input, "RenderLabel", &trait_path)
 }
 
 /// Derive macro generating an impl of the trait `RenderSubGraph`.
@@ -98,10 +96,8 @@ pub fn derive_render_sub_graph(input: TokenStream) -> TokenStream {
     trait_path
         .segments
         .push(format_ident!("render_graph").into());
-    let mut dyn_eq_path = trait_path.clone();
     trait_path
         .segments
         .push(format_ident!("RenderSubGraph").into());
-    dyn_eq_path.segments.push(format_ident!("DynEq").into());
-    derive_label(input, "RenderSubGraph", &trait_path, &dyn_eq_path)
+    derive_label(input, "RenderSubGraph", &trait_path)
 }


### PR DESCRIPTION
Hiya!

# Objective

- Remove upcasting methods that are no longer necessary since Rust 1.86. 
- Cleanup the interned label code.
 
## Notes
- I didn't try to remove the upcasting methods from `bevy_reflect`, as there appears to be some complexity related to remote type reflection.
- There are likely some other upcasting methods floating around.

## Testing
I ran the `breakout` example to check that the hashing/eq implementations of the labels are still correct.

## Migration Guide
- `DynEq::as_any` has been removed. Use `&value as &dyn Any` instead.
- `DynHash::as_dyn_eq` has been removed. Use `&value as &dyn DynEq` instead.
- `as_dyn_eq` has been removed from 'label' types such as `ScheduleLabel`, `SystemSet`, etc. Call `DynEq::dyn_eq` directly on the label instead.
