### PR TITLE
Improve visibility of debug picking node

### DIFF
--- a/crates/bevy_dev_tools/src/picking_debug.rs
+++ b/crates/bevy_dev_tools/src/picking_debug.rs
@@ -1,7 +1,6 @@
 //! Text and on-screen debugging tools
 
 use bevy_app::prelude::*;
-use bevy_asset::prelude::*;
 use bevy_color::prelude::*;
 use bevy_ecs::prelude::*;
 use bevy_picking::backend::HitData;
@@ -248,8 +247,7 @@ pub fn debug_draw(
     pointers: Query<(Entity, &PointerId, &PointerDebug)>,
     scale: Res<UiScale>,
 ) {
-    let font_handle: Handle<Font> = Default::default();
-    for (entity, id, debug) in pointers.iter() {
+    for (entity, id, debug) in &pointers {
         let Some(pointer_location) = &debug.location else {
             continue;
         };
@@ -278,24 +276,23 @@ pub fn debug_draw(
 
             commands
                 .entity(entity)
+                .despawn_related::<Children>()
                 .insert((
-                    Text::new(text.clone()),
-                    TextFont {
-                        font: font_handle.clone(),
-                        font_size: 12.0,
-                        ..Default::default()
-                    },
-                    TextColor(Color::WHITE),
                     Node {
                         position_type: PositionType::Absolute,
                         left: Val::Px(pointer_pos.x + 5.0) / scale.0,
                         top: Val::Px(pointer_pos.y + 5.0) / scale.0,
+                        padding: UiRect::px(10.0, 10.0, 8.0, 6.0),
                         ..Default::default()
                     },
                     BackgroundColor(Color::BLACK.with_alpha(0.75)),
                     GlobalZIndex(i32::MAX),
                     Pickable::IGNORE,
                     UiTargetCamera(camera),
+                    children![(
+                        Text::new(text.clone()),
+                        TextFont::from_font_size(12.0),
+                    )],
                 ));
         }
     }

--- a/crates/bevy_dev_tools/src/picking_debug.rs
+++ b/crates/bevy_dev_tools/src/picking_debug.rs
@@ -292,9 +292,11 @@ pub fn debug_draw(
                         top: Val::Px(pointer_pos.y + 5.0) / scale.0,
                         ..Default::default()
                     },
-                ))
-                .insert(Pickable::IGNORE)
-                .insert(UiTargetCamera(camera));
+                    BackgroundColor(Color::BLACK.with_alpha(0.75)),
+                    GlobalZIndex(i32::MAX),
+                    Pickable::IGNORE,
+                    UiTargetCamera(camera),
+                ));
         }
     }
 }

--- a/crates/bevy_dev_tools/src/picking_debug.rs
+++ b/crates/bevy_dev_tools/src/picking_debug.rs
@@ -283,7 +283,7 @@ pub fn debug_draw(
                     GlobalZIndex(i32::MAX),
                     Pickable::IGNORE,
                     UiTargetCamera(camera),
-                    children![(Text::new(text.clone()), TextFont::from_font_size(12.0),)],
+                    children![(Text::new(text.clone()), TextFont::from_font_size(12.0))],
                 ));
         }
     }

--- a/crates/bevy_dev_tools/src/picking_debug.rs
+++ b/crates/bevy_dev_tools/src/picking_debug.rs
@@ -253,18 +253,12 @@ pub fn debug_draw(
         };
         let text = format!("{id:?}\n{debug}");
 
-        for camera in camera_query
-            .iter()
-            .map(|(entity, camera)| {
-                (
-                    entity,
-                    camera.target.normalize(primary_window.single().ok()),
-                )
-            })
-            .filter_map(|(entity, target)| Some(entity).zip(target))
-            .filter(|(_entity, target)| target == &pointer_location.target)
-            .map(|(cam_entity, _target)| cam_entity)
-        {
+        for (camera, _) in camera_query.iter().filter(|(_, camera)| {
+            camera
+                .target
+                .normalize(primary_window.single().ok())
+                .is_some_and(|target| target == pointer_location.target)
+        }) {
             let mut pointer_pos = pointer_location.position;
             if let Some(viewport) = camera_query
                 .get(camera)
@@ -289,10 +283,7 @@ pub fn debug_draw(
                     GlobalZIndex(i32::MAX),
                     Pickable::IGNORE,
                     UiTargetCamera(camera),
-                    children![(
-                        Text::new(text.clone()),
-                        TextFont::from_font_size(12.0),
-                    )],
+                    children![(Text::new(text.clone()), TextFont::from_font_size(12.0),)],
                 ));
         }
     }


### PR DESCRIPTION
# Objective

Fixes https://github.com/bevyengine/bevy/issues/18989.

## Solution

Add `GlobalZIndex(i32::MAX)`, `BackgroundColor(Color::BLACK.with_alpha(0.75))`, and some padding.

## Testing

Ran `cargo run --example debug_picking`:

![2025-04-30_1745997924_1280x720](https://github.com/user-attachments/assets/4bd39897-f4ab-4d4d-850b-1b885284b072)

Before this PR:

![2025-04-29_1745972540_1280x720](https://github.com/user-attachments/assets/9c8649f4-0f06-4d4d-8fed-ac20e0d5366e)
