### PR TITLE
Remove `parking_lot` from `bevy_asset` and `bevy_macro_utils`

### DIFF
--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -44,7 +44,6 @@ either = "1.13"
 futures-io = "0.3"
 futures-lite = "2.0.1"
 blake3 = "1.5"
-parking_lot = { version = "0.12", features = ["arc_lock", "send_guard"] }
 ron = "0.8"
 serde = { version = "1", features = ["derive"] }
 thiserror = { version = "2", default-features = false }

--- a/crates/bevy_asset/src/io/embedded/embedded_watcher.rs
+++ b/crates/bevy_asset/src/io/embedded/embedded_watcher.rs
@@ -4,10 +4,12 @@ use crate::io::{
     AssetSourceEvent, AssetWatcher,
 };
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
-use bevy_platform::collections::HashMap;
+use bevy_platform::{
+    collections::HashMap,
+    sync::{PoisonError, RwLock},
+};
 use core::time::Duration;
 use notify_debouncer_full::{notify::RecommendedWatcher, Debouncer, RecommendedCache};
-use parking_lot::RwLock;
 use std::{
     fs::File,
     io::{BufReader, Read},
@@ -63,7 +65,12 @@ impl FilesystemEventHandler for EmbeddedEventHandler {
 
     fn get_path(&self, absolute_path: &Path) -> Option<(PathBuf, bool)> {
         let (local_path, is_meta) = get_asset_path(&self.root, absolute_path);
-        let final_path = self.root_paths.read().get(local_path.as_path())?.clone();
+        let final_path = self
+            .root_paths
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .get(local_path.as_path())?
+            .clone();
         if is_meta {
             warn!("Meta file asset hot-reloading is not supported yet: {final_path:?}");
         }

--- a/crates/bevy_asset/src/io/embedded/mod.rs
+++ b/crates/bevy_asset/src/io/embedded/mod.rs
@@ -10,6 +10,7 @@ use crate::io::{
 };
 use alloc::boxed::Box;
 use bevy_ecs::resource::Resource;
+use bevy_platform::sync::PoisonError;
 use std::path::{Path, PathBuf};
 
 #[cfg(feature = "embedded_watcher")]
@@ -29,7 +30,7 @@ pub struct EmbeddedAssetRegistry {
     dir: Dir,
     #[cfg(feature = "embedded_watcher")]
     root_paths: alloc::sync::Arc<
-        parking_lot::RwLock<bevy_platform::collections::HashMap<Box<Path>, PathBuf>>,
+        bevy_platform::sync::RwLock<bevy_platform::collections::HashMap<Box<Path>, PathBuf>>,
     >,
 }
 
@@ -49,6 +50,7 @@ impl EmbeddedAssetRegistry {
         #[cfg(feature = "embedded_watcher")]
         self.root_paths
             .write()
+            .unwrap_or_else(PoisonError::into_inner)
             .insert(full_path.into(), asset_path.to_owned());
         self.dir.insert_asset(asset_path, value);
     }
@@ -68,6 +70,7 @@ impl EmbeddedAssetRegistry {
         #[cfg(feature = "embedded_watcher")]
         self.root_paths
             .write()
+            .unwrap_or_else(PoisonError::into_inner)
             .insert(full_path.into(), asset_path.to_owned());
         self.dir.insert_meta(asset_path, value);
     }

--- a/crates/bevy_asset/src/io/memory.rs
+++ b/crates/bevy_asset/src/io/memory.rs
@@ -1,10 +1,12 @@
 use crate::io::{AssetReader, AssetReaderError, PathStream, Reader};
 use alloc::{borrow::ToOwned, boxed::Box, sync::Arc, vec::Vec};
-use bevy_platform::collections::HashMap;
+use bevy_platform::{
+    collections::HashMap,
+    sync::{PoisonError, RwLock},
+};
 use core::{pin::Pin, task::Poll};
 use futures_io::AsyncRead;
 use futures_lite::{ready, Stream};
-use parking_lot::RwLock;
 use std::path::{Path, PathBuf};
 
 use super::AsyncSeekForward;
@@ -44,13 +46,17 @@ impl Dir {
         if let Some(parent) = path.parent() {
             dir = self.get_or_insert_dir(parent);
         }
-        dir.0.write().assets.insert(
-            path.file_name().unwrap().to_string_lossy().into(),
-            Data {
-                value: value.into(),
-                path: path.to_owned(),
-            },
-        );
+        dir.0
+            .write()
+            .unwrap_or_else(PoisonError::into_inner)
+            .assets
+            .insert(
+                path.file_name().unwrap().to_string_lossy().into(),
+                Data {
+                    value: value.into(),
+                    path: path.to_owned(),
+                },
+            );
     }
 
     /// Removes the stored asset at `path` and returns the `Data` stored if found and otherwise `None`.
@@ -60,7 +66,11 @@ impl Dir {
             dir = self.get_or_insert_dir(parent);
         }
         let key: Box<str> = path.file_name().unwrap().to_string_lossy().into();
-        dir.0.write().assets.remove(&key)
+        dir.0
+            .write()
+            .unwrap_or_else(PoisonError::into_inner)
+            .assets
+            .remove(&key)
     }
 
     pub fn insert_meta(&self, path: &Path, value: impl Into<Value>) {
@@ -68,13 +78,17 @@ impl Dir {
         if let Some(parent) = path.parent() {
             dir = self.get_or_insert_dir(parent);
         }
-        dir.0.write().metadata.insert(
-            path.file_name().unwrap().to_string_lossy().into(),
-            Data {
-                value: value.into(),
-                path: path.to_owned(),
-            },
-        );
+        dir.0
+            .write()
+            .unwrap_or_else(PoisonError::into_inner)
+            .metadata
+            .insert(
+                path.file_name().unwrap().to_string_lossy().into(),
+                Data {
+                    value: value.into(),
+                    path: path.to_owned(),
+                },
+            );
     }
 
     pub fn get_or_insert_dir(&self, path: &Path) -> Dir {
@@ -84,7 +98,7 @@ impl Dir {
             full_path.push(c);
             let name = c.as_os_str().to_string_lossy().into();
             dir = {
-                let dirs = &mut dir.0.write().dirs;
+                let dirs = &mut dir.0.write().unwrap_or_else(PoisonError::into_inner).dirs;
                 dirs.entry(name)
                     .or_insert_with(|| Dir::new(full_path.clone()))
                     .clone()
@@ -98,7 +112,13 @@ impl Dir {
         let mut dir = self.clone();
         for p in path.components() {
             let component = p.as_os_str().to_str().unwrap();
-            let next_dir = dir.0.read().dirs.get(component)?.clone();
+            let next_dir = dir
+                .0
+                .read()
+                .unwrap_or_else(PoisonError::into_inner)
+                .dirs
+                .get(component)?
+                .clone();
             dir = next_dir;
         }
         Some(dir)
@@ -110,8 +130,14 @@ impl Dir {
             dir = dir.get_dir(parent)?;
         }
 
-        path.file_name()
-            .and_then(|f| dir.0.read().assets.get(f.to_str().unwrap()).cloned())
+        path.file_name().and_then(|f| {
+            dir.0
+                .read()
+                .unwrap_or_else(PoisonError::into_inner)
+                .assets
+                .get(f.to_str().unwrap())
+                .cloned()
+        })
     }
 
     pub fn get_metadata(&self, path: &Path) -> Option<Data> {
@@ -120,12 +146,22 @@ impl Dir {
             dir = dir.get_dir(parent)?;
         }
 
-        path.file_name()
-            .and_then(|f| dir.0.read().metadata.get(f.to_str().unwrap()).cloned())
+        path.file_name().and_then(|f| {
+            dir.0
+                .read()
+                .unwrap_or_else(PoisonError::into_inner)
+                .metadata
+                .get(f.to_str().unwrap())
+                .cloned()
+        })
     }
 
     pub fn path(&self) -> PathBuf {
-        self.0.read().path.to_owned()
+        self.0
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .path
+            .to_owned()
     }
 }
 
@@ -153,7 +189,7 @@ impl Stream for DirStream {
         _cx: &mut core::task::Context<'_>,
     ) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
-        let dir = this.dir.0.read();
+        let dir = this.dir.0.read().unwrap_or_else(PoisonError::into_inner);
 
         let dir_index = this.dir_index;
         if let Some(dir_path) = dir

--- a/crates/bevy_macro_utils/Cargo.toml
+++ b/crates/bevy_macro_utils/Cargo.toml
@@ -15,7 +15,6 @@ proc-macro2 = "1.0"
 toml_edit = { version = "0.22.7", default-features = false, features = [
   "parse",
 ] }
-parking_lot = { version = "0.12" }
 
 [lints]
 workspace = true

--- a/crates/bevy_render/macros/src/as_bind_group.rs
+++ b/crates/bevy_render/macros/src/as_bind_group.rs
@@ -58,7 +58,8 @@ struct BindlessIndexTableRangeAttr {
 }
 
 pub fn derive_as_bind_group(ast: syn::DeriveInput) -> Result<TokenStream> {
-    let manifest = BevyManifest::shared();
+    let guard = BevyManifest::shared();
+    let manifest = &*guard;
     let render_path = manifest.get_path("bevy_render");
     let image_path = manifest.get_path("bevy_image");
     let asset_path = manifest.get_path("bevy_asset");


### PR DESCRIPTION
# Objective

- Contributes to #18978 by removing a dependency that is not `no_std` compatible

## Solution

- Removed `parking_lot` from `bevy_asset` and switched to `bevy_platform::sync` internally.
- Removed `parking_lot` from `bevy_macro_utils` and switched to `std::sync` internally. Also added a simple alternative to mapped `RwLock` guards while the feature is nightly-only.

## Testing

- CI

---

## Notes

It is _possible_ there is a performance change here, but I believe it will be negligible due to [performance improvements in `std`](https://github.com/rust-lang/rust/pull/95035#issuecomment-1073966631) since Bevy adopted `parking_lot` in #210. _If_ there is a performance difference noticed, I believe the more appropriate course of action would be to move `parking_lot` into `bevy_platform` as a feature, so that _all_ parts of Bevy could benefit, not just `bevy_asset`.