### PR TITLE
Fix a few subcrate import paths in examples

### DIFF
--- a/examples/camera/custom_projection.rs
+++ b/examples/camera/custom_projection.rs
@@ -27,7 +27,7 @@ impl CameraProjection for ObliquePerspectiveProjection {
         mat
     }
 
-    fn get_clip_from_view_for_sub(&self, sub_view: &bevy_render::camera::SubCameraView) -> Mat4 {
+    fn get_clip_from_view_for_sub(&self, sub_view: &bevy::render::camera::SubCameraView) -> Mat4 {
         let mut mat = self.perspective.get_clip_from_view_for_sub(sub_view);
         mat.col_mut(2)[0] = self.horizontal_obliqueness;
         mat.col_mut(2)[1] = self.vertical_obliqueness;

--- a/examples/diagnostics/log_diagnostics.rs
+++ b/examples/diagnostics/log_diagnostics.rs
@@ -21,7 +21,7 @@ fn main() {
             bevy::diagnostic::SystemInformationDiagnosticsPlugin,
             // Forwards various diagnostics from the render app to the main app.
             // These are pretty verbose but can be useful to pinpoint performance issues.
-            bevy_render::diagnostic::RenderDiagnosticsPlugin,
+            bevy::render::diagnostic::RenderDiagnosticsPlugin,
         ))
         // No rendering diagnostics are emitted unless something is drawn to the screen,
         // so we spawn a small scene.

--- a/examples/ui/directional_navigation.rs
+++ b/examples/ui/directional_navigation.rs
@@ -388,7 +388,7 @@ fn interact_with_focused_button(
                     // This field isn't used, so we're just setting it to a placeholder value
                     pointer_location: Location {
                         target: NormalizedRenderTarget::Image(
-                            bevy_render::camera::ImageRenderTarget {
+                            bevy::render::camera::ImageRenderTarget {
                                 handle: Handle::default(),
                                 scale_factor: FloatOrd(1.0),
                             },


### PR DESCRIPTION
# Objective

Tripped over the `directional_navigation` one recently while playing around with that example.

Examples should import items from `bevy` rather than the sub-crates directly.

## Solution

Use paths re-exported by `bevy`.

## Testing

```
cargo run --example log_diagnostics
cargo run --example directional_navigation
cargo run --example custom_projection
```
