### PR TITLE
Sprite picking docs fix

### DIFF
--- a/crates/bevy_sprite/src/picking_backend.rs
+++ b/crates/bevy_sprite/src/picking_backend.rs
@@ -1,6 +1,9 @@
 //! A [`bevy_picking`] backend for sprites. Works for simple sprites and sprite atlases. Works for
-//! sprites with arbitrary transforms. Picking is done based on sprite bounds, not visible pixels.
-//! This means a partially transparent sprite is pickable even in its transparent areas.
+//! sprites with arbitrary transforms.
+//!
+//! By default, picking for sprites is based on pixel opacity.
+//! A sprite is picked only when a pointer is over an opaque pixel.
+//! Alternatively, you can configure picking to be based on sprite bounds.
 //!
 //! ## Implementation Notes
 //!
@@ -45,9 +48,10 @@ pub enum SpritePickingMode {
 #[reflect(Resource, Default)]
 pub struct SpritePickingSettings {
     /// When set to `true` sprite picking will only consider cameras marked with
-    /// [`SpritePickingCamera`].
+    /// [`SpritePickingCamera`]. Defaults to `false`.
+    /// Regardless of this setting, only sprites marked with [`Pickable`] will be considered.
     ///
-    /// This setting is provided to give you fine-grained control over which cameras and entities
+    /// This setting is provided to give you fine-grained control over which cameras
     /// should be used by the sprite picking backend at runtime.
     pub require_markers: bool,
     /// Should the backend count transparent pixels as part of the sprite for picking purposes or should it use the bounding box of the sprite alone.

--- a/examples/picking/sprite_picking.rs
+++ b/examples/picking/sprite_picking.rs
@@ -1,5 +1,5 @@
-//! Demonstrates picking for sprites and sprite atlases. The picking backend only tests against the
-//! sprite bounds, so the sprite atlas can be picked by clicking on its transparent areas.
+//! Demonstrates picking for sprites and sprite atlases.
+//! By default, the sprite picking backend considers a sprite only when a pointer is over an opaque pixel.
 
 use bevy::{prelude::*, sprite::Anchor};
 use std::fmt::Debug;


### PR DESCRIPTION
# Objective

- Docs in sprite picking plugin / example contain outdated information.

References:
- Sprite picking now always require `Picking` - #17842
- Transparency pass-through added - #16388

## Solution

- Fix the docs.
