### PR TITLE
Prevent exclusive systems from being used as observers

### DIFF
--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -562,6 +562,10 @@ impl World {
     ///     // ...
     /// });
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if the given system is an exclusive system.
     pub fn add_observer<E: Event, B: Bundle, M>(
         &mut self,
         system: impl IntoObserverSystem<E, B, M>,

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -287,7 +287,10 @@ impl Observer {
         let system = Box::new(IntoObserverSystem::into_system(system));
         assert!(
             !system.is_exclusive(),
-            "Exclusive system may not be used as observer: `{}`",
+            concat!(
+                "Exclusive system `{}` may not be used as observer.\n",
+                "Instead of `&mut World`, use either `DeferredWorld` if you do not need structural changes, or `Commands` if you do."
+            ),
             system.name()
         );
         Self {
@@ -542,7 +545,7 @@ mod tests {
 
     #[test]
     #[should_panic(
-        expected = "Exclusive system may not be used as observer: `bevy_ecs::observer::runner::tests::exclusive_system_cannot_be_observer::system`"
+        expected = "Exclusive system `bevy_ecs::observer::runner::tests::exclusive_system_cannot_be_observer::system` may not be used as observer.\nInstead of `&mut World`, use either `DeferredWorld` if you do not need structural changes, or `Commands` if you do."
     )]
     fn exclusive_system_cannot_be_observer() {
         fn system(_: Trigger<TriggerEvent>, _world: &mut World) {}

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -1123,6 +1123,10 @@ impl<'w, 's> Commands<'w, 's> {
     /// **Calling [`observe`](EntityCommands::observe) on the returned
     /// [`EntityCommands`] will observe the observer itself, which you very
     /// likely do not want.**
+    ///
+    /// # Panics
+    ///
+    /// Panics if the given system is an exclusive system.
     pub fn add_observer<E: Event, B: Bundle, M>(
         &mut self,
         observer: impl IntoObserverSystem<E, B, M>,

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -2773,6 +2773,8 @@ impl<'w> EntityWorldMut<'w> {
     /// # Panics
     ///
     /// If the entity has been despawned while this `EntityWorldMut` is still alive.
+    ///
+    /// Panics if the given system is an exclusive system.
     #[track_caller]
     pub fn observe<E: Event, B: Bundle, M>(
         &mut self,

--- a/release-content/migration-guides/observers_may_not_be_exclusive.md
+++ b/release-content/migration-guides/observers_may_not_be_exclusive.md
@@ -1,0 +1,8 @@
+---
+title: Exclusive systems may not be used as observers
+pull_requests: [19033]
+---
+
+Exclusive systems may no longer be used as observers.
+This was never sound, as the engine keeps references alive during observer invocation that would be invalidated by `&mut World` access, but was accidentally allowed.
+Instead of `&mut World`, use either `DeferredWorld` if you do not need structural changes, or `Commands` if you do.


### PR DESCRIPTION
# Objective

Prevent using exclusive systems as observers.  Allowing them is unsound, because observers are only expected to have `DeferredWorld` access, and the observer infrastructure will keep pointers that are invalidated by the creation of `&mut World`.  

See https://github.com/bevyengine/bevy/actions/runs/14778342801/job/41491517847?pr=19011 for a MIRI failure in a recent PR caused by an exclusive system being used as an observer in a test.  

## Solution

Have `Observer::new` panic if `System::is_exclusive()` is true.  Document that method, and methods that call it, as panicking.  

(It should be possible to express this in the type system so that the calls won't even compile, but I did not want to attempt that.)  

## Testing

Added a unit test that calls `World::add_observer` with an exclusive system.