### PR TITLE
Clean up phantom data for ExtcractComponentPlugin

### DIFF
--- a/crates/bevy_render/src/extract_component.rs
+++ b/crates/bevy_render/src/extract_component.rs
@@ -160,12 +160,12 @@ fn prepare_uniform_components<C>(
 /// This plugin extracts the components into the render world for synced entities.
 ///
 /// To do so, it sets up the [`ExtractSchedule`] step for the specified [`ExtractComponent`].
-pub struct ExtractComponentPlugin<C, F = ()> {
+pub struct ExtractComponentPlugin<C> {
     only_extract_visible: bool,
-    marker: PhantomData<fn() -> (C, F)>,
+    marker: PhantomData<C>,
 }
 
-impl<C, F> Default for ExtractComponentPlugin<C, F> {
+impl<C> Default for ExtractComponentPlugin<C> {
     fn default() -> Self {
         Self {
             only_extract_visible: false,
@@ -174,7 +174,7 @@ impl<C, F> Default for ExtractComponentPlugin<C, F> {
     }
 }
 
-impl<C, F> ExtractComponentPlugin<C, F> {
+impl<C> ExtractComponentPlugin<C> {
     pub fn extract_visible() -> Self {
         Self {
             only_extract_visible: true,


### PR DESCRIPTION
# Objective

I was confused by the second generic parameter in [ExtractComponentPlugin](https://docs.rs/bevy/0.16.0/bevy/render/extract_component/struct.ExtractComponentPlugin.html) documentation.
Turns out it is unused.

## Solution

Remove the unused parameter

## Testing

I checked that examples compile and run.
