### PR TITLE
Fix tonemapping example when using a local image

### DIFF
--- a/examples/3d/tonemapping.rs
+++ b/examples/3d/tonemapping.rs
@@ -1,6 +1,7 @@
 //! This examples compares Tonemapping options
 
 use bevy::{
+    asset::UnapprovedPathMode,
     core_pipeline::tonemapping::Tonemapping,
     pbr::CascadeShadowConfigBuilder,
     platform::collections::HashMap,
@@ -19,7 +20,12 @@ const SHADER_ASSET_PATH: &str = "shaders/tonemapping_test_patterns.wgsl";
 fn main() {
     App::new()
         .add_plugins((
-            DefaultPlugins,
+            DefaultPlugins.set(AssetPlugin {
+                // We enable loading assets from arbitrary filesystem paths as this example allows
+                // drag and dropping a local image for color grading
+                unapproved_path_mode: UnapprovedPathMode::Allow,
+                ..default()
+            }),
             MaterialPlugin::<ColorGradientMaterial>::default(),
         ))
         .insert_resource(CameraTransform(


### PR DESCRIPTION
# Objective

- The tonemapping example allows using a local image to try out different color grading. However, using a local file stopped working when we added the `UnapprovedPathMode` setting to the assets plugin.

## Solution

- Set `unapproved_path_mode: UnapprovedPathMode::Allow` in the example

## Testing

- I tried out the example with local images, previously it would fail saying it's an untrusted path.

