### PR TITLE
Use Component Column ids in tables to skip component maps in queries

### DIFF
--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -2484,9 +2484,9 @@ unsafe impl<T: ?Sized> ReadOnlyQueryData for PhantomData<T> {}
 /// [`StorageType`] of a given component.
 pub(super) union StorageSwitch<C: Component, T: Copy, S: Copy> {
     /// The table variant. Requires the component to be a table component.
-    table: T,
+    pub(super) table: T,
     /// The sparse set variant. Requires the component to be a sparse set component.
-    sparse_set: S,
+    pub(super) sparse_set: S,
     _marker: PhantomData<C>,
 }
 
@@ -2499,28 +2499,6 @@ impl<C: Component, T: Copy, S: Copy> StorageSwitch<C, T, S> {
             StorageType::SparseSet => Self {
                 sparse_set: sparse_set(),
             },
-        }
-    }
-
-    /// Creates a new [`StorageSwitch`] using a table variant.
-    ///
-    /// # Panics
-    ///
-    /// This will panic on debug builds if `C` is not a table component.
-    ///
-    /// # Safety
-    ///
-    /// `C` must be a table component.
-    #[inline]
-    pub unsafe fn set_table(&mut self, table: T) {
-        match C::STORAGE_TYPE {
-            StorageType::Table => self.table = table,
-            _ => {
-                #[cfg(debug_assertions)]
-                unreachable!();
-                #[cfg(not(debug_assertions))]
-                core::hint::unreachable_unchecked()
-            }
         }
     }
 

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -93,7 +93,7 @@ pub unsafe trait QueryFilter: WorldQuery {
     /// Note that this is called after already restricting the matched [`Table`]s and [`Archetype`]s to the
     /// ones that are compatible with the Filter's access.
     ///
-    /// Implementors of this method will generally either have a trivial `true` body (required for archetypal filters),
+    /// Implementers of this method will generally either have a trivial `true` body (required for archetypal filters),
     /// or access the necessary data within this function to make the final decision on filter inclusion.
     ///
     /// # Safety

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -3,7 +3,7 @@ use crate::{
     component::{Component, ComponentId, Components, StorageType, Tick},
     entity::Entity,
     query::{DebugCheckedUnwrap, FilteredAccess, StorageSwitch, WorldQuery},
-    storage::{ComponentSparseSet, Table, TableRow},
+    storage::{ComponentSparseSet, Table, TableRow, TablesComponentMeta},
     world::{unsafe_world_cell::UnsafeWorldCell, World},
 };
 use bevy_ptr::{ThinSlicePtr, UnsafeCellDeref};
@@ -626,7 +626,10 @@ pub struct AddedFetch<'w, T: Component> {
     ticks: StorageSwitch<
         T,
         // T::STORAGE_TYPE = StorageType::Table
-        Option<ThinSlicePtr<'w, UnsafeCell<Tick>>>,
+        (
+            Option<&'w TablesComponentMeta>,
+            Option<ThinSlicePtr<'w, UnsafeCell<Tick>>>,
+        ),
         // T::STORAGE_TYPE = StorageType::SparseSet
         // Can be `None` when the component has never been inserted
         Option<&'w ComponentSparseSet>,
@@ -667,7 +670,15 @@ unsafe impl<T: Component> WorldQuery for Added<T> {
     ) -> Self::Fetch<'w> {
         Self::Fetch::<'w> {
             ticks: StorageSwitch::new(
-                || None,
+                || {
+                    let tables = &world.storages().tables;
+                    (
+                        tables
+                            .get_tables_component_id(id)
+                            .map(|id| tables.get_component_storage_meta(id).debug_checked_unwrap()),
+                        None,
+                    )
+                },
                 || {
                     // SAFETY: The underlying type associated with `component_id` is `T`,
                     // which we are allowed to access since we registered it in `update_archetype_component_access`.
@@ -706,17 +717,18 @@ unsafe impl<T: Component> WorldQuery for Added<T> {
     #[inline]
     unsafe fn set_table<'w>(
         fetch: &mut Self::Fetch<'w>,
-        &component_id: &ComponentId,
+        _component_id: &ComponentId,
         table: &'w Table,
     ) {
-        let table_ticks = Some(
-            table
-                .get_added_ticks_slice_for(component_id)
-                .debug_checked_unwrap()
-                .into(),
-        );
+        let column = fetch
+            .ticks
+            .table
+            .0
+            // SAFETY: If this table didn't have this component, this would not be being called.
+            .map(|meta| meta.column_in(table.id()).debug_checked_unwrap());
+        let table_ticks = column.map(|column| table.get_added_ticks_slice_for(column).into());
         // SAFETY: set_table is only called when T::STORAGE_TYPE = StorageType::Table
-        unsafe { fetch.ticks.set_table(table_ticks) };
+        fetch.ticks.table.1 = table_ticks;
     }
 
     #[inline]
@@ -755,8 +767,8 @@ unsafe impl<T: Component> QueryFilter for Added<T> {
         // SAFETY: The invariants are upheld by the caller.
         fetch.ticks.extract(
             |table| {
-                // SAFETY: set_table was previously called
-                let table = unsafe { table.debug_checked_unwrap() };
+                // SAFETY: set_table was previously called and this entity must have this component, so it must not be none.
+                let table = unsafe { table.1.debug_checked_unwrap() };
                 // SAFETY: The caller ensures `table_row` is in range.
                 let tick = unsafe { table.get(table_row.as_usize()) };
 
@@ -854,7 +866,10 @@ pub struct Changed<T>(PhantomData<T>);
 pub struct ChangedFetch<'w, T: Component> {
     ticks: StorageSwitch<
         T,
-        Option<ThinSlicePtr<'w, UnsafeCell<Tick>>>,
+        (
+            Option<&'w TablesComponentMeta>,
+            Option<ThinSlicePtr<'w, UnsafeCell<Tick>>>,
+        ),
         // Can be `None` when the component has never been inserted
         Option<&'w ComponentSparseSet>,
     >,
@@ -894,7 +909,15 @@ unsafe impl<T: Component> WorldQuery for Changed<T> {
     ) -> Self::Fetch<'w> {
         Self::Fetch::<'w> {
             ticks: StorageSwitch::new(
-                || None,
+                || {
+                    let tables = &world.storages().tables;
+                    (
+                        tables
+                            .get_tables_component_id(id)
+                            .map(|id| tables.get_component_storage_meta(id).debug_checked_unwrap()),
+                        None,
+                    )
+                },
                 || {
                     // SAFETY: The underlying type associated with `component_id` is `T`,
                     // which we are allowed to access since we registered it in `update_archetype_component_access`.
@@ -933,17 +956,18 @@ unsafe impl<T: Component> WorldQuery for Changed<T> {
     #[inline]
     unsafe fn set_table<'w>(
         fetch: &mut Self::Fetch<'w>,
-        &component_id: &ComponentId,
+        _component_id: &ComponentId,
         table: &'w Table,
     ) {
-        let table_ticks = Some(
-            table
-                .get_changed_ticks_slice_for(component_id)
-                .debug_checked_unwrap()
-                .into(),
-        );
+        let column = fetch
+            .ticks
+            .table
+            .0
+            // SAFETY: If this table didn't have this component, this would not be being called.
+            .map(|meta| meta.column_in(table.id()).debug_checked_unwrap());
+        let table_ticks = column.map(|column| table.get_changed_ticks_slice_for(column).into());
         // SAFETY: set_table is only called when T::STORAGE_TYPE = StorageType::Table
-        unsafe { fetch.ticks.set_table(table_ticks) };
+        fetch.ticks.table.1 = table_ticks;
     }
 
     #[inline]
@@ -983,8 +1007,8 @@ unsafe impl<T: Component> QueryFilter for Changed<T> {
         // SAFETY: The invariants are upheld by the caller.
         fetch.ticks.extract(
             |table| {
-                // SAFETY: set_table was previously called
-                let table = unsafe { table.debug_checked_unwrap() };
+                // SAFETY: set_table was previously called and this entity must have this component, so it must not be none.
+                let table = unsafe { table.1.debug_checked_unwrap() };
                 // SAFETY: The caller ensures `table_row` is in range.
                 let tick = unsafe { table.get(table_row.as_usize()) };
 

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -376,6 +376,8 @@ pub(crate) struct ImmutableSparseSet<I, V: 'static> {
 
 macro_rules! impl_sparse_set {
     ($ty:ident) => {
+        #[expect(clippy::allow_attributes, reason = "Needed for macro")]
+        #[allow(unused, reason = "Not used currently, but useful utility to have.")]
         impl<I: SparseSetIndex, V> $ty<I, V> {
             /// Returns the number of elements in the sparse set.
             #[inline]

--- a/crates/bevy_ecs/src/storage/table/mod.rs
+++ b/crates/bevy_ecs/src/storage/table/mod.rs
@@ -761,7 +761,7 @@ impl TablesComponentMeta {
     pub fn column_in(&self, table: TableId) -> Option<TableColumnId> {
         self.columns
             .get(table.0 as usize)
-            .and_then(|column| (*column == TableColumnId::INVALID).then_some(*column))
+            .and_then(|column| (*column != TableColumnId::INVALID).then_some(*column))
     }
 }
 

--- a/crates/bevy_ecs/src/storage/table/mod.rs
+++ b/crates/bevy_ecs/src/storage/table/mod.rs
@@ -398,7 +398,6 @@ impl Table {
     /// Get the data of the column matching `component_id` as a slice.
     ///
     /// # Safety
-    /// `row.as_usize()` < `self.len()`
     /// - `T` must match the `TableColumnId`
     /// - The column must be for this table.
     pub unsafe fn get_data_slice_for<T>(&self, column: TableColumnId) -> &[UnsafeCell<T>] {
@@ -407,23 +406,23 @@ impl Table {
     }
 
     /// Get the added ticks of the column matching `component_id` as a slice.
-    pub fn get_added_ticks_slice_for(
-        &self,
-        component_id: ComponentId,
-    ) -> Option<&[UnsafeCell<Tick>]> {
-        self.get_column(component_id)
-            // SAFETY: `self.len()` is guaranteed to be the len of the ticks array
-            .map(|col| unsafe { col.get_added_ticks_slice(self.entity_count()) })
+    ///
+    /// # Safety
+    /// - The column must be for this table.
+    pub unsafe fn get_added_ticks_slice_for(&self, column: TableColumnId) -> &[UnsafeCell<Tick>] {
+        let column = self.get_column_by_id(column);
+        // SAFETY: `self.len()` is guaranteed to be the len of the ticks array
+        unsafe { column.get_added_ticks_slice(self.entity_count()) }
     }
 
     /// Get the changed ticks of the column matching `component_id` as a slice.
-    pub fn get_changed_ticks_slice_for(
-        &self,
-        component_id: ComponentId,
-    ) -> Option<&[UnsafeCell<Tick>]> {
-        self.get_column(component_id)
-            // SAFETY: `self.len()` is guaranteed to be the len of the ticks array
-            .map(|col| unsafe { col.get_changed_ticks_slice(self.entity_count()) })
+    ///
+    /// # Safety
+    /// - The column must be for this table.
+    pub unsafe fn get_changed_ticks_slice_for(&self, column: TableColumnId) -> &[UnsafeCell<Tick>] {
+        let column = self.get_column_by_id(column);
+        // SAFETY: `self.len()` is guaranteed to be the len of the ticks array
+        unsafe { column.get_changed_ticks_slice(self.entity_count()) }
     }
 
     /// Fetches the calling locations that last changed the each component

--- a/crates/bevy_ecs/src/storage/table/mod.rs
+++ b/crates/bevy_ecs/src/storage/table/mod.rs
@@ -899,6 +899,20 @@ impl Tables {
         }
     }
 
+    /// Gets the [`TablesComponentId`] for this component if it has been in any table.
+    pub fn get_tables_component_id(&self, component: ComponentId) -> Option<TablesComponentId> {
+        self.components.get(&component).copied()
+    }
+
+    /// Gets the [`TablesComponentMeta`] for this component if it has been in any table.
+    /// These are never removed and do not correspond to any component data access.
+    pub fn get_component_storage_meta(
+        &self,
+        component: TablesComponentId,
+    ) -> Option<&TablesComponentMeta> {
+        self.component_meta.get(component.0)
+    }
+
     /// Iterates through all of the tables stored within in [`TableId`] order.
     pub fn iter(&self) -> core::slice::Iter<'_, Table> {
         self.tables.iter()

--- a/crates/bevy_ecs/src/storage/table/mod.rs
+++ b/crates/bevy_ecs/src/storage/table/mod.rs
@@ -526,7 +526,7 @@ impl Table {
         unsafe { Some(self.get_column_mut_by_id(self.get_column_id(component_id)?)) }
     }
 
-    /// Fetches a read-only reference to the [`ThinColumn`] for a given [`Component`] within the table.
+    /// Fetches a read-only reference to the [`ThinColumn`] for a given [`Component`](crate::component::Component) within the table.
     ///
     /// # Safety
     ///
@@ -537,7 +537,7 @@ impl Table {
         unsafe { self.data.get_unchecked(column.as_usize()) }
     }
 
-    /// Fetches a mutable reference to the [`ThinColumn`] for a given [`TableColumn`] within the table.
+    /// Fetches a mutable reference to the [`ThinColumn`] for a given [`TableColumnId`] within the table.
     ///
     /// # Safety
     ///
@@ -548,7 +548,7 @@ impl Table {
         unsafe { self.data.get_unchecked_mut(column.as_usize()) }
     }
 
-    /// Fetches [`TableColumn`] for a given [`Component`] within the table.
+    /// Fetches [`TableColumnId`] for a given [`Component`] within the table.
     ///
     /// Returns `None` if the corresponding component does not belong to the table.
     ///


### PR DESCRIPTION
# Objective

In preparation for components as entities, we will need to switch `ImmutableSparseSet<ComponentId, T>` to `HashMap<ComponentId, T>`. This will be a pretty massive regression for those lookups. This PR aims to improve performance (both for components as entities and just for now) by skipping the hottest  such component map: `Table::columns`.

## Solution

I tried for longer than I'd like to admit to add per-table/storage caches to `QueryState`. (It kinda works, but justifying safety is tricky.)

Then I had an idea, and this is something that I think extends to other component maps too! Right now we have an id into something dense (table) and then from there we map a component id to a column. But what if instead we started with an id into something sparse (new table component meta) and then from there we index a dense table id to a column? This is kinda like swapping the rows and columns of a abstract table. That's the general idea here.

We can extend this in a similar way to component maps in archetypes. 

Note that we could take this a step further and physically move the columns from the `Table` to the new `TablesComponentMeta`.  That has some conveniences: A sparse set is just a one column table now (effectively), and we can save another indexing op when setting the table in a query. But it also has the big downside that moving between tables would need an extra indexing op for each component. IDK if that would be worth it, so I left it for now, instead creating column ids.

## Testing

CI

## Future Work

Currently, creating a query fetch still needs the component map. If we expand `init_state` and `get_state`'s signatures to include all world metadata, we could put the index of the component metadata directly in the query state, skipping the map entirely.

Also, right now it is still possible to get a component's data from a table directly (which does go through a component map). We should explore removing this extra data and sending everything though the new (faster) way. (And caching the column id where possible!)

## Benches

Benchmarks show roughly even with main over all. Most benches fluctuate between ±5 or 6 % compared to main. Some benches take 2.x as long as main. Some things, like change detection see 50% improvements. In general, performance is 20%-50% improved over "normal" query iteration (due to 1 less indexing op) but is much worse over specific gets (ex: `Query::get` and friends) by 100%-100% (due to one more indexing op). 

Note that `world_query_get/50000_entities_table_wide` is up 500%, a major outlier. This is because it can not cache the column id, it actually doesn't even go through a query. So the extra indexing op is responsible for the 500% regression. If it were just a query get (which has some caching now) this would only be a 33% regression. (Which should be improved with more caching and would be way worse with a hashmap.)

Interpreting these benches , I take away a few things: 1) There are *significant* performance wins to be had for caching table columns in more places, even without sparse component ids. 2) If adding one indexing op can cause 500% regression, imaging what a hashmap would do! Caching this is a must. 3) More specifically, we should look into expanding signatures of `Query::init_state` and friends to remove the current hashmap lookup in `init_fetch`.
<details>
  <summary>Benches differing by 20%</summary>

```
group                                                                                                    main                                   pr19063
-----                                                                                                    ----                                   -------
all_added_detection/50000_entities_ecs::change_detection::Table                                          1.50     44.5±0.45µs        ? ?/sec    1.00     29.7±0.27µs        ? ?/sec
all_added_detection/5000_entities_ecs::change_detection::Table                                           1.47      4.5±0.05µs        ? ?/sec    1.00      3.0±0.03µs        ? ?/sec
all_changed_detection/50000_entities_ecs::change_detection::Table                                        1.50     44.5±0.45µs        ? ?/sec    1.00     29.7±0.46µs        ? ?/sec
all_changed_detection/5000_entities_ecs::change_detection::Table                                         1.43      4.5±0.05µs        ? ?/sec    1.00      3.1±0.25µs        ? ?/sec
event_propagation/four_event_types                                                                       1.00    584.3±8.59µs        ? ?/sec    1.30    761.0±9.92µs        ? ?/sec
event_propagation/single_event_type_no_listeners                                                         1.00    247.0±2.22µs        ? ?/sec    1.70   420.0±46.15µs        ? ?/sec
events_send/size_16_events_100                                                                           1.00    123.2±3.55ns        ? ?/sec    1.21   148.7±27.05ns        ? ?/sec
events_send/size_4_events_100                                                                            1.00     81.3±0.99ns        ? ?/sec    2.06    167.1±1.54ns        ? ?/sec
few_changed_detection/50000_entities_ecs::change_detection::Table                                        1.22     57.2±0.76µs        ? ?/sec    1.00     47.0±0.62µs        ? ?/sec
few_changed_detection/5000_entities_ecs::change_detection::Sparse                                        1.00      3.9±0.39µs        ? ?/sec    1.35      5.3±0.60µs        ? ?/sec
few_changed_detection/5000_entities_ecs::change_detection::Table                                         1.27      5.1±0.25µs        ? ?/sec    1.00      4.0±0.15µs        ? ?/sec
iter_fragmented/base                                                                                     1.26    347.6±7.12ns        ? ?/sec    1.00    275.8±5.96ns        ? ?/sec
iter_fragmented/foreach_wide                                                                             1.00      2.6±0.04µs        ? ?/sec    1.37      3.6±0.05µs        ? ?/sec
iter_fragmented_sparse/foreach                                                                           1.00      5.7±0.05ns        ? ?/sec    1.39      7.9±0.27ns        ? ?/sec
iter_fragmented_sparse/foreach_wide                                                                      1.00     37.1±2.14ns        ? ?/sec    2.11     78.4±0.99ns        ? ?/sec
iter_fragmented_sparse/wide                                                                              1.00     40.2±0.34ns        ? ?/sec    1.71     68.6±0.67ns        ? ?/sec
iter_simple/foreach_wide                                                                                 1.00     16.9±0.14µs        ? ?/sec    2.82     47.8±0.32µs        ? ?/sec
multiple_archetypes_none_changed_detection/100_archetypes_10000_entities_ecs::change_detection::Table    1.54   614.2±14.55µs        ? ?/sec    1.00   397.8±26.30µs        ? ?/sec
multiple_archetypes_none_changed_detection/100_archetypes_1000_entities_ecs::change_detection::Table     1.52     63.9±5.28µs        ? ?/sec    1.00     41.9±1.65µs        ? ?/sec
multiple_archetypes_none_changed_detection/100_archetypes_100_entities_ecs::change_detection::Table      1.58      7.4±0.21µs        ? ?/sec    1.00      4.7±0.36µs        ? ?/sec
multiple_archetypes_none_changed_detection/100_archetypes_10_entities_ecs::change_detection::Table       1.38   824.8±10.56ns        ? ?/sec    1.00   595.8±11.85ns        ? ?/sec
multiple_archetypes_none_changed_detection/20_archetypes_10000_entities_ecs::change_detection::Table     1.61    120.3±1.84µs        ? ?/sec    1.00     74.9±1.39µs        ? ?/sec
multiple_archetypes_none_changed_detection/20_archetypes_1000_entities_ecs::change_detection::Table      1.54     12.3±0.29µs        ? ?/sec    1.00      8.0±0.25µs        ? ?/sec
multiple_archetypes_none_changed_detection/20_archetypes_100_entities_ecs::change_detection::Table       1.70  1418.0±15.57ns        ? ?/sec    1.00   834.5±84.47ns        ? ?/sec
multiple_archetypes_none_changed_detection/20_archetypes_10_entities_ecs::change_detection::Table        1.31    168.8±8.94ns        ? ?/sec    1.00   128.8±12.35ns        ? ?/sec
multiple_archetypes_none_changed_detection/5_archetypes_10000_entities_ecs::change_detection::Table      1.62     29.8±0.30µs        ? ?/sec    1.00     18.5±0.30µs        ? ?/sec
multiple_archetypes_none_changed_detection/5_archetypes_1000_entities_ecs::change_detection::Table       1.54      3.0±0.04µs        ? ?/sec    1.00  1971.3±66.64ns        ? ?/sec
multiple_archetypes_none_changed_detection/5_archetypes_100_entities_ecs::change_detection::Table        1.59    358.2±7.57ns        ? ?/sec    1.00   225.2±17.34ns        ? ?/sec
none_changed_detection/50000_entities_ecs::change_detection::Table                                       1.68     29.7±0.39µs        ? ?/sec    1.00     17.7±0.47µs        ? ?/sec
none_changed_detection/5000_entities_ecs::change_detection::Table                                        1.62      3.0±0.03µs        ? ?/sec    1.00  1849.6±55.64ns        ? ?/sec
query_get/50000_entities_table                                                                           1.00    198.6±1.24µs        ? ?/sec    1.33    264.8±4.04µs        ? ?/sec
query_get_many_10/50000_calls_table                                                                      1.00  1405.4±58.51µs        ? ?/sec    1.50      2.1±0.12ms        ? ?/sec
query_get_many_2/50000_calls_table                                                                       1.00    240.7±0.84µs        ? ?/sec    1.91   460.1±10.01µs        ? ?/sec
query_get_many_5/50000_calls_table                                                                       1.00    626.3±4.86µs        ? ?/sec    1.76  1101.7±61.30µs        ? ?/sec
world_query_get/50000_entities_table                                                                     1.00    125.0±0.21µs        ? ?/sec    1.66    208.0±3.80µs        ? ?/sec
world_query_get/50000_entities_table_wide                                                                1.00    124.9±0.31µs        ? ?/sec    5.20    649.2±7.31µs        ? ?/sec
```
</details>
