### PR TITLE
Fix panic when specializing materials for entities spawned in `PostUpdate`

### DIFF
--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -8,7 +8,7 @@ use crate::meshlet::{
 };
 use crate::*;
 use bevy_asset::prelude::AssetChanged;
-use bevy_asset::{Asset, AssetEvents, AssetId, AssetServer, UntypedAssetId};
+use bevy_asset::{Asset, AssetId, AssetServer, UntypedAssetId};
 use bevy_core_pipeline::deferred::{AlphaMask3dDeferred, Opaque3dDeferred};
 use bevy_core_pipeline::prepass::{AlphaMask3dPrepass, Opaque3dPrepass};
 use bevy_core_pipeline::{
@@ -286,12 +286,11 @@ where
             .add_plugins((RenderAssetPlugin::<PreparedMaterial<M>>::default(),))
             .add_systems(
                 PostUpdate,
-                (
-                    mark_meshes_as_changed_if_their_materials_changed::<M>.ambiguous_with_all(),
-                    check_entities_needing_specialization::<M>.after(AssetEvents),
-                )
+                mark_meshes_as_changed_if_their_materials_changed::<M>
+                    .ambiguous_with_all()
                     .after(mark_3d_meshes_as_changed_if_their_assets_changed),
-            );
+            )
+            .add_systems(Last, check_entities_needing_specialization::<M>);
 
         if self.shadows_enabled {
             app.add_systems(

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -2,9 +2,9 @@ use crate::{
     DrawMesh2d, Mesh2d, Mesh2dPipeline, Mesh2dPipelineKey, RenderMesh2dInstances,
     SetMesh2dBindGroup, SetMesh2dViewBindGroup, ViewKeyCache, ViewSpecializationTicks,
 };
-use bevy_app::{App, Plugin, PostUpdate};
+use bevy_app::{App, Last, Plugin};
 use bevy_asset::prelude::AssetChanged;
-use bevy_asset::{AsAssetId, Asset, AssetApp, AssetEvents, AssetId, AssetServer, Handle};
+use bevy_asset::{AsAssetId, Asset, AssetApp, AssetId, AssetServer, Handle};
 use bevy_core_pipeline::{
     core_2d::{
         AlphaMask2d, AlphaMask2dBinKey, BatchSetKey2d, Opaque2d, Opaque2dBinKey, Transparent2d,
@@ -271,10 +271,7 @@ where
             .init_resource::<EntitiesNeedingSpecialization<M>>()
             .register_type::<MeshMaterial2d<M>>()
             .add_plugins(RenderAssetPlugin::<PreparedMaterial2d<M>>::default())
-            .add_systems(
-                PostUpdate,
-                check_entities_needing_specialization::<M>.after(AssetEvents),
-            );
+            .add_systems(Last, check_entities_needing_specialization::<M>);
 
         if let Some(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app


### PR DESCRIPTION
# Objective

If an entity requiring specialization is spawned during `PostUpdate` after its material's `check_entities_needing_specialization`, but before `CheckVisibility`, a panic occurs during material specialization. This happens because the view assumes that every visible entity will be present in the specialization ticks map, but in this scenario the entity won't be added to the map until the next frame.

Fixes #19048. This may also fix the related #18980, but I wasn't able to reproduce that one and it could be unrelated.

Edit by Alice: Fixes #18980 too!

## Solution

Move `check_entities_needing_specialization` systems to `Last`. This ensures that they always runs after `CheckVisibility`.

## Testing

Confirmed the reproduction from #19048 is fixed, and ran several 3d and 2d examples with no apparent change.