### PR TITLE
Bare Minimum `no_std` support for `bevy_asset`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,7 @@ jobs:
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
       - name: Check Compile
-        run: cd examples/no_std/library && cargo check --no-default-features --features libm,critical-section --target x86_64-unknown-none
+        run: cd examples/no_std/library && RUSTFLAGS='--cfg getrandom_backend="rdrand"' cargo check --no-default-features --features libm,critical-section --target x86_64-unknown-none
 
   build-wasm:
     runs-on: ubuntu-latest

--- a/crates/bevy_animation/Cargo.toml
+++ b/crates/bevy_animation/Cargo.toml
@@ -47,6 +47,9 @@ tracing = { version = "0.1", default-features = false, features = ["std"] }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # TODO: Assuming all wasm builds are for the browser. Require `no_std` support to break assumption.
 uuid = { version = "1.13.1", default-features = false, features = ["js"] }
+bevy_asset = { path = "../bevy_asset", version = "0.16.0-dev", default-features = false, features = [
+  "web",
+] }
 
 [lints]
 workspace = true

--- a/crates/bevy_anti_aliasing/Cargo.toml
+++ b/crates/bevy_anti_aliasing/Cargo.toml
@@ -31,6 +31,12 @@ bevy_diagnostic = { path = "../bevy_diagnostic", version = "0.16.0-dev" }
 # other
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+# TODO: Assuming all wasm builds are for the browser. Require `no_std` support to break assumption.
+bevy_asset = { path = "../bevy_asset", version = "0.16.0-dev", default-features = false, features = [
+  "web",
+] }
+
 [lints]
 workspace = true
 

--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -11,12 +11,58 @@ keywords = ["bevy"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+default = ["std"]
+
+# Functionality
+
+## Watch for changes in asset files.
 file_watcher = ["notify-debouncer-full", "watch", "multi_threaded"]
+
+## Watch for changes in embedded assets.
 embedded_watcher = ["file_watcher"]
-multi_threaded = ["bevy_tasks/multi_threaded"]
-asset_processor = []
-watch = []
-trace = []
+
+## Enables multithreading support.
+multi_threaded = ["bevy_tasks/multi_threaded", "std"]
+
+## Enables asset processing.
+asset_processor = ["std"]
+
+## Sets the `watch_for_changes` default to `true`.
+watch = ["std"]
+
+# Debugging
+
+## Integrates with `tracing` to provide span information.
+trace = ["dep:tracing"]
+
+# Platform Compatibility
+
+## Integrates with the Rust standard library.
+std = [
+  "bevy_platform/std",
+  "bevy_tasks/async_executor",
+  "atomicow/std",
+  "dep:async-broadcast",
+  "dep:async-fs",
+  "dep:async-lock",
+  "dep:crossbeam-channel",
+  "crossbeam-channel?/std",
+  "dep:futures-io",
+  "dep:parking_lot",
+  "dep:ron",
+]
+
+## Integrates with the browser when run within a web context.
+web = [
+  "bevy_app/web",
+  "bevy_tasks/web",
+  "bevy_reflect/web",
+  "uuid/js",
+  "dep:js-sys",
+  "dep:wasm-bindgen-futures",
+  "dep:web-sys",
+  "dep:wasm-bindgen",
+]
 
 [dependencies]
 bevy_app = { path = "../bevy_app", version = "0.16.0-dev", default-features = false, features = [
@@ -27,34 +73,29 @@ bevy_ecs = { path = "../bevy_ecs", version = "0.16.0-dev", default-features = fa
 bevy_reflect = { path = "../bevy_reflect", version = "0.16.0-dev", default-features = false, features = [
   "uuid",
 ] }
-bevy_tasks = { path = "../bevy_tasks", version = "0.16.0-dev", default-features = false, features = [
-  "async_executor",
-] }
+bevy_tasks = { path = "../bevy_tasks", version = "0.16.0-dev", default-features = false }
 bevy_utils = { path = "../bevy_utils", version = "0.16.0-dev", default-features = false }
-bevy_platform = { path = "../bevy_platform", version = "0.16.0-dev", default-features = false, features = [
-  "std",
-] }
+bevy_platform = { path = "../bevy_platform", version = "0.16.0-dev", default-features = false }
 
 stackfuture = { version = "0.3", default-features = false }
-atomicow = { version = "1.0", default-features = false, features = ["std"] }
-async-broadcast = { version = "0.7.2", default-features = false }
-async-fs = { version = "2.0", default-features = false }
-async-lock = { version = "3.0", default-features = false }
-bitflags = { version = "2.3", default-features = false }
-crossbeam-channel = { version = "0.5", default-features = false, features = [
-  "std",
-] }
+atomicow = { version = "1.0", default-features = false }
+async-broadcast = { version = "0.7.2", default-features = false, optional = true }
+async-fs = { version = "2.0", default-features = false, optional = true }
+async-lock = { version = "3.0", default-features = false, optional = true }
+bitflags = { version = "2.3", default-features = false, features = ["serde"] }
+concurrent-queue = { version = "2.5.0", default-features = false }
+crossbeam-channel = { version = "0.5", default-features = false, optional = true }
 downcast-rs = { version = "2", default-features = false }
 disqualified = { version = "1.0", default-features = false }
 either = { version = "1.13", default-features = false }
-futures-io = { version = "0.3", default-features = false }
+futures-io = { version = "0.3", default-features = false, optional = true }
 futures-lite = { version = "2.0.1", default-features = false }
 blake3 = { version = "1.5", default-features = false }
-parking_lot = { version = "0.12", default-features = false, features = [
+parking_lot = { version = "0.12", default-features = false, optional = true, features = [
   "arc_lock",
   "send_guard",
 ] }
-ron = { version = "0.8", default-features = false }
+ron = { version = "0.8", default-features = false, optional = true }
 serde = { version = "1", default-features = false, features = ["derive"] }
 thiserror = { version = "2", default-features = false }
 derive_more = { version = "1", default-features = false, features = ["from"] }
@@ -62,34 +103,29 @@ uuid = { version = "1.13.1", default-features = false, features = [
   "v4",
   "serde",
 ] }
-tracing = { version = "0.1", default-features = false }
+tracing = { version = "0.1", default-features = false, optional = true }
+log = { version = "0.4", default-features = false }
 
 [target.'cfg(target_os = "android")'.dependencies]
 bevy_window = { path = "../bevy_window", version = "0.16.0-dev" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-# TODO: Assuming all wasm builds are for the browser. Require `no_std` support to break assumption.
-wasm-bindgen = { version = "0.2" }
+wasm-bindgen = { version = "0.2", optional = true }
 web-sys = { version = "0.3", features = [
   "Window",
   "Response",
   "WorkerGlobalScope",
-] }
-wasm-bindgen-futures = "0.4"
-js-sys = "0.3"
-uuid = { version = "1.13.1", default-features = false, features = ["js"] }
-bevy_app = { path = "../bevy_app", version = "0.16.0-dev", default-features = false, features = [
-  "web",
-] }
-bevy_tasks = { path = "../bevy_tasks", version = "0.16.0-dev", default-features = false, features = [
-  "web",
-] }
-bevy_reflect = { path = "../bevy_reflect", version = "0.16.0-dev", default-features = false, features = [
-  "web",
-] }
+], optional = true }
+wasm-bindgen-futures = { version = "0.4", optional = true }
+js-sys = { version = "0.3", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 notify-debouncer-full = { version = "0.5.0", default-features = false, optional = true }
+
+[target.'cfg(not(target_has_atomic = "ptr"))'.dependencies]
+event-listener = { version = "5.4", default-features = false, features = [
+  "portable-atomic",
+] }
 
 [lints]
 workspace = true

--- a/crates/bevy_asset/src/asset_changed.rs
+++ b/crates/bevy_asset/src/asset_changed.rs
@@ -3,7 +3,8 @@
 //! Like [`Changed`](bevy_ecs::prelude::Changed), but for [`Asset`]s,
 //! and triggers whenever the handle or the underlying asset changes.
 
-use crate::{AsAssetId, Asset, AssetId};
+use core::marker::PhantomData;
+
 use bevy_ecs::component::Components;
 use bevy_ecs::{
     archetype::Archetype,
@@ -14,9 +15,10 @@ use bevy_ecs::{
     world::unsafe_world_cell::UnsafeWorldCell,
 };
 use bevy_platform::collections::HashMap;
-use core::marker::PhantomData;
 use disqualified::ShortName;
 use log::error;
+
+use crate::{AsAssetId, Asset, AssetId};
 
 /// A resource that stores the last tick an asset was changed. This is used by
 /// the [`AssetChanged`] filter to determine if an asset has changed since the last time

--- a/crates/bevy_asset/src/asset_changed.rs
+++ b/crates/bevy_asset/src/asset_changed.rs
@@ -16,7 +16,7 @@ use bevy_ecs::{
 use bevy_platform::collections::HashMap;
 use core::marker::PhantomData;
 use disqualified::ShortName;
-use tracing::error;
+use log::error;
 
 /// A resource that stores the last tick an asset was changed. This is used by
 /// the [`AssetChanged`] filter to determine if an asset has changed since the last time
@@ -37,6 +37,7 @@ impl<A: Asset> AssetChanges<A> {
         self.last_change_tick = tick;
         self.change_ticks.insert(asset_id, tick);
     }
+
     pub(crate) fn remove(&mut self, asset_id: &AssetId<A>) {
         self.change_ticks.remove(asset_id);
     }

--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -580,10 +580,6 @@ impl<A: Asset> Assets<A> {
     /// A system that applies accumulated asset change events to the [`Events`] resource.
     ///
     /// [`Events`]: bevy_ecs::event::Events
-    #[cfg_attr(
-        not(feature = "std"),
-        expect(dead_code, reason = "only used with `std` currently")
-    )]
     pub(crate) fn asset_events(
         mut assets: ResMut<Self>,
         mut events: EventWriter<AssetEvent<A>>,
@@ -609,10 +605,6 @@ impl<A: Asset> Assets<A> {
     /// flush.
     ///
     /// [`asset_events`]: Self::asset_events
-    #[cfg_attr(
-        not(feature = "std"),
-        expect(dead_code, reason = "only used with `std` currently")
-    )]
     pub(crate) fn asset_events_condition(assets: Res<Self>) -> bool {
         !assets.queued_events.is_empty()
     }

--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -1,18 +1,28 @@
-use crate::asset_changed::AssetChanges;
-use crate::{Asset, AssetEvent, AssetHandleProvider, AssetId, AssetServer, Handle, UntypedHandle};
-use alloc::{sync::Arc, vec::Vec};
+use alloc::vec::Vec;
+use core::{any::TypeId, iter::Enumerate, marker::PhantomData};
+
 use bevy_ecs::{
     prelude::EventWriter,
     resource::Resource,
     system::{Res, ResMut, SystemChangeTick},
 };
-use bevy_platform::collections::HashMap;
+use bevy_platform::{
+    collections::HashMap,
+    sync::{atomic::AtomicU32, Arc},
+};
 use bevy_reflect::{Reflect, TypePath};
-use core::{any::TypeId, iter::Enumerate, marker::PhantomData, sync::atomic::AtomicU32};
-use crossbeam_channel::{Receiver, Sender};
+use concurrent_queue::ConcurrentQueue;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use uuid::Uuid;
+
+use crate::{
+    asset_changed::AssetChanges, Asset, AssetEvent, AssetHandleProvider, AssetId, Handle,
+    UntypedHandle,
+};
+
+#[cfg(feature = "std")]
+use crate::AssetServer;
 
 /// A generational runtime-only identifier for a specific [`Asset`] stored in [`Assets`]. This is optimized for efficient runtime
 /// usage and is not suitable for identifying assets across app runs.
@@ -45,34 +55,33 @@ impl AssetIndex {
 pub(crate) struct AssetIndexAllocator {
     /// A monotonically increasing index.
     next_index: AtomicU32,
-    recycled_queue_sender: Sender<AssetIndex>,
     /// This receives every recycled [`AssetIndex`]. It serves as a buffer/queue to store indices ready for reuse.
-    recycled_queue_receiver: Receiver<AssetIndex>,
-    recycled_sender: Sender<AssetIndex>,
-    recycled_receiver: Receiver<AssetIndex>,
+    recycled_queue: ConcurrentQueue<AssetIndex>,
+    recycled: ConcurrentQueue<AssetIndex>,
 }
 
 impl Default for AssetIndexAllocator {
     fn default() -> Self {
-        let (recycled_queue_sender, recycled_queue_receiver) = crossbeam_channel::unbounded();
-        let (recycled_sender, recycled_receiver) = crossbeam_channel::unbounded();
-        Self {
-            recycled_queue_sender,
-            recycled_queue_receiver,
-            recycled_sender,
-            recycled_receiver,
-            next_index: Default::default(),
-        }
+        Self::new()
     }
 }
 
 impl AssetIndexAllocator {
+    /// Constructs a new [`AssetIndexAllocator`].
+    pub const fn new() -> Self {
+        Self {
+            next_index: AtomicU32::new(0),
+            recycled_queue: ConcurrentQueue::unbounded(),
+            recycled: ConcurrentQueue::unbounded(),
+        }
+    }
+
     /// Reserves a new [`AssetIndex`], either by reusing a recycled index (with an incremented generation), or by creating a new index
     /// by incrementing the index counter for a given asset type `A`.
     pub fn reserve(&self) -> AssetIndex {
-        if let Ok(mut recycled) = self.recycled_queue_receiver.try_recv() {
+        if let Ok(mut recycled) = self.recycled_queue.pop() {
             recycled.generation += 1;
-            self.recycled_sender.send(recycled).unwrap();
+            self.recycled.push(recycled).unwrap();
             recycled
         } else {
             AssetIndex {
@@ -86,7 +95,7 @@ impl AssetIndexAllocator {
 
     /// Queues the given `index` for reuse. This should only be done if the `index` is no longer being used.
     pub fn recycle(&self, index: AssetIndex) {
-        self.recycled_queue_sender.send(index).unwrap();
+        self.recycled_queue.push(index).unwrap();
     }
 }
 
@@ -239,7 +248,7 @@ impl<A: Asset> DenseAssetStorage<A> {
             value: None,
             generation: 0,
         });
-        while let Ok(recycled) = self.allocator.recycled_receiver.try_recv() {
+        while let Ok(recycled) = self.allocator.recycled.pop() {
             let entry = &mut self.storage[recycled.index as usize];
             *entry = Entry::Some {
                 value: None,
@@ -460,6 +469,10 @@ impl<A: Asset> Assets<A> {
     }
 
     /// Removes the [`Asset`] with the given `id`.
+    #[cfg_attr(
+        not(feature = "std"),
+        expect(dead_code, reason = "only used with `std` currently")
+    )]
     pub(crate) fn remove_dropped(&mut self, id: AssetId<A>) {
         match self.duplicate_handles.get_mut(&id) {
             None => {}
@@ -539,6 +552,7 @@ impl<A: Asset> Assets<A> {
 
     /// A system that synchronizes the state of assets in this collection with the [`AssetServer`]. This manages
     /// [`Handle`] drop events.
+    #[cfg(feature = "std")]
     pub fn track_assets(mut assets: ResMut<Self>, asset_server: Res<AssetServer>) {
         let assets = &mut *assets;
         // note that we must hold this lock for the entire duration of this function to ensure
@@ -546,7 +560,7 @@ impl<A: Asset> Assets<A> {
         // re-loads are kicked off appropriately. This function must be "transactional" relative
         // to other asset info operations
         let mut infos = asset_server.data.infos.write();
-        while let Ok(drop_event) = assets.handle_provider.drop_receiver.try_recv() {
+        while let Ok(drop_event) = assets.handle_provider.drop.pop() {
             let id = drop_event.id.typed();
 
             if drop_event.asset_server_managed {
@@ -566,6 +580,10 @@ impl<A: Asset> Assets<A> {
     /// A system that applies accumulated asset change events to the [`Events`] resource.
     ///
     /// [`Events`]: bevy_ecs::event::Events
+    #[cfg_attr(
+        not(feature = "std"),
+        expect(dead_code, reason = "only used with `std` currently")
+    )]
     pub(crate) fn asset_events(
         mut assets: ResMut<Self>,
         mut events: EventWriter<AssetEvent<A>>,
@@ -591,6 +609,10 @@ impl<A: Asset> Assets<A> {
     /// flush.
     ///
     /// [`asset_events`]: Self::asset_events
+    #[cfg_attr(
+        not(feature = "std"),
+        expect(dead_code, reason = "only used with `std` currently")
+    )]
     pub(crate) fn asset_events_condition(assets: Res<Self>) -> bool {
         !assets.queued_events.is_empty()
     }

--- a/crates/bevy_asset/src/direct_access_ext.rs
+++ b/crates/bevy_asset/src/direct_access_ext.rs
@@ -5,8 +5,14 @@ use bevy_ecs::world::World;
 
 use crate::{Asset, Assets, Handle};
 
+#[cfg_attr(
+    not(feature = "std"),
+    expect(unused_imports, reason = "only needed with `std` feature")
+)]
+use crate::{meta::Settings, AssetPath};
+
 #[cfg(feature = "std")]
-use crate::{meta::Settings, AssetPath, AssetServer};
+use crate::AssetServer;
 
 /// An extension trait for methods for working with assets directly from a [`World`].
 pub trait DirectAssetAccessExt {

--- a/crates/bevy_asset/src/direct_access_ext.rs
+++ b/crates/bevy_asset/src/direct_access_ext.rs
@@ -3,7 +3,10 @@
 
 use bevy_ecs::world::World;
 
-use crate::{meta::Settings, Asset, AssetPath, AssetServer, Assets, Handle};
+use crate::{Asset, Assets, Handle};
+
+#[cfg(feature = "std")]
+use crate::{meta::Settings, AssetPath, AssetServer};
 
 /// An extension trait for methods for working with assets directly from a [`World`].
 pub trait DirectAssetAccessExt {
@@ -11,9 +14,11 @@ pub trait DirectAssetAccessExt {
     fn add_asset<A: Asset>(&mut self, asset: impl Into<A>) -> Handle<A>;
 
     /// Load an asset similarly to [`AssetServer::load`].
+    #[cfg(feature = "std")]
     fn load_asset<'a, A: Asset>(&self, path: impl Into<AssetPath<'a>>) -> Handle<A>;
 
     /// Load an asset with settings, similarly to [`AssetServer::load_with_settings`].
+    #[cfg(feature = "std")]
     fn load_asset_with_settings<'a, A: Asset, S: Settings>(
         &self,
         path: impl Into<AssetPath<'a>>,
@@ -33,6 +38,7 @@ impl DirectAssetAccessExt for World {
     ///
     /// # Panics
     /// If `self` doesn't have an [`AssetServer`] resource initialized yet.
+    #[cfg(feature = "std")]
     fn load_asset<'a, A: Asset>(&self, path: impl Into<AssetPath<'a>>) -> Handle<A> {
         self.resource::<AssetServer>().load(path)
     }
@@ -40,6 +46,7 @@ impl DirectAssetAccessExt for World {
     ///
     /// # Panics
     /// If `self` doesn't have an [`AssetServer`] resource initialized yet.
+    #[cfg(feature = "std")]
     fn load_asset_with_settings<'a, A: Asset, S: Settings>(
         &self,
         path: impl Into<AssetPath<'a>>,

--- a/crates/bevy_asset/src/event.rs
+++ b/crates/bevy_asset/src/event.rs
@@ -5,8 +5,14 @@ use bevy_reflect::Reflect;
 
 use crate::{Asset, AssetId};
 
+#[cfg_attr(
+    not(feature = "std"),
+    expect(unused_imports, reason = "only needed with `std` feature")
+)]
+use crate::{AssetPath, UntypedAssetId};
+
 #[cfg(feature = "std")]
-use crate::{AssetLoadError, AssetPath, UntypedAssetId};
+use crate::AssetLoadError;
 
 /// An event emitted when a specific [`Asset`] fails to load.
 ///

--- a/crates/bevy_asset/src/event.rs
+++ b/crates/bevy_asset/src/event.rs
@@ -1,11 +1,17 @@
-use crate::{Asset, AssetId, AssetLoadError, AssetPath, UntypedAssetId};
+use core::fmt::Debug;
+
 use bevy_ecs::event::Event;
 use bevy_reflect::Reflect;
-use core::fmt::Debug;
+
+use crate::{Asset, AssetId};
+
+#[cfg(feature = "std")]
+use crate::{AssetLoadError, AssetPath, UntypedAssetId};
 
 /// An event emitted when a specific [`Asset`] fails to load.
 ///
 /// For an untyped equivalent, see [`UntypedAssetLoadFailedEvent`].
+#[cfg(feature = "std")]
 #[derive(Event, Clone, Debug)]
 pub struct AssetLoadFailedEvent<A: Asset> {
     /// The stable identifier of the asset that failed to load.
@@ -16,6 +22,7 @@ pub struct AssetLoadFailedEvent<A: Asset> {
     pub error: AssetLoadError,
 }
 
+#[cfg(feature = "std")]
 impl<A: Asset> AssetLoadFailedEvent<A> {
     /// Converts this to an "untyped" / "generic-less" asset error event that stores the type information.
     pub fn untyped(&self) -> UntypedAssetLoadFailedEvent {
@@ -24,6 +31,7 @@ impl<A: Asset> AssetLoadFailedEvent<A> {
 }
 
 /// An untyped version of [`AssetLoadFailedEvent`].
+#[cfg(feature = "std")]
 #[derive(Event, Clone, Debug)]
 pub struct UntypedAssetLoadFailedEvent {
     /// The stable identifier of the asset that failed to load.
@@ -34,6 +42,7 @@ pub struct UntypedAssetLoadFailedEvent {
     pub error: AssetLoadError,
 }
 
+#[cfg(feature = "std")]
 impl<A: Asset> From<&AssetLoadFailedEvent<A>> for UntypedAssetLoadFailedEvent {
     fn from(value: &AssetLoadFailedEvent<A>) -> Self {
         UntypedAssetLoadFailedEvent {

--- a/crates/bevy_asset/src/folder.rs
+++ b/crates/bevy_asset/src/folder.rs
@@ -1,7 +1,8 @@
 use alloc::vec::Vec;
 
-use crate::{Asset, UntypedHandle};
 use bevy_reflect::TypePath;
+
+use crate::{Asset, UntypedHandle};
 
 /// A "loaded folder" containing handles for all assets stored in a given [`AssetPath`].
 ///

--- a/crates/bevy_asset/src/id.rs
+++ b/crates/bevy_asset/src/id.rs
@@ -327,6 +327,10 @@ pub(crate) enum InternalAssetId {
 }
 
 impl InternalAssetId {
+    #[cfg_attr(
+        not(feature = "std"),
+        expect(dead_code, reason = "only used with `std` currently")
+    )]
     #[inline]
     pub(crate) fn typed<A: Asset>(self) -> AssetId<A> {
         match self {

--- a/crates/bevy_asset/src/io/embedded/embedded_watcher.rs
+++ b/crates/bevy_asset/src/io/embedded/embedded_watcher.rs
@@ -3,9 +3,10 @@ use crate::io::{
     memory::Dir,
     AssetSourceEvent, AssetWatcher,
 };
-use alloc::{boxed::Box, sync::Arc, vec::Vec};
-use bevy_platform::collections::HashMap;
+use alloc::{boxed::Box, vec::Vec};
+use bevy_platform::{collections::HashMap, sync::Arc};
 use core::time::Duration;
+use log::warn;
 use notify_debouncer_full::{notify::RecommendedWatcher, Debouncer, RecommendedCache};
 use parking_lot::RwLock;
 use std::{
@@ -13,7 +14,6 @@ use std::{
     io::{BufReader, Read},
     path::{Path, PathBuf},
 };
-use tracing::warn;
 
 /// A watcher for assets stored in the `embedded` asset source. Embedded assets are assets whose
 /// bytes have been embedded into the Rust binary using the [`embedded_asset`](crate::embedded_asset) macro.

--- a/crates/bevy_asset/src/io/embedded/mod.rs
+++ b/crates/bevy_asset/src/io/embedded/mod.rs
@@ -28,7 +28,7 @@ pub const EMBEDDED: &str = "embedded";
 pub struct EmbeddedAssetRegistry {
     dir: Dir,
     #[cfg(feature = "embedded_watcher")]
-    root_paths: alloc::sync::Arc<
+    root_paths: bevy_platform::sync::Arc<
         parking_lot::RwLock<bevy_platform::collections::HashMap<Box<Path>, PathBuf>>,
     >,
 }

--- a/crates/bevy_asset/src/io/file/file_watcher.rs
+++ b/crates/bevy_asset/src/io/file/file_watcher.rs
@@ -5,6 +5,7 @@ use crate::{
 use alloc::borrow::ToOwned;
 use core::time::Duration;
 use crossbeam_channel::Sender;
+use log::error;
 use notify_debouncer_full::{
     new_debouncer,
     notify::{
@@ -15,7 +16,6 @@ use notify_debouncer_full::{
     DebounceEventResult, Debouncer, RecommendedCache,
 };
 use std::path::{Path, PathBuf};
-use tracing::error;
 
 /// An [`AssetWatcher`] that watches the filesystem for changes to asset files in a given root folder and emits [`AssetSourceEvent`]
 /// for each relevant change.

--- a/crates/bevy_asset/src/io/file/mod.rs
+++ b/crates/bevy_asset/src/io/file/mod.rs
@@ -8,13 +8,14 @@ mod sync_file_asset;
 
 #[cfg(feature = "file_watcher")]
 pub use file_watcher::*;
-use tracing::{debug, error};
 
 use alloc::borrow::ToOwned;
 use std::{
     env,
     path::{Path, PathBuf},
 };
+
+use log::{debug, error};
 
 pub(crate) fn get_base_path() -> PathBuf {
     if let Ok(manifest_dir) = env::var("BEVY_ASSET_ROOT") {

--- a/crates/bevy_asset/src/io/gated.rs
+++ b/crates/bevy_asset/src/io/gated.rs
@@ -1,6 +1,6 @@
 use crate::io::{AssetReader, AssetReaderError, PathStream, Reader};
-use alloc::{boxed::Box, sync::Arc};
-use bevy_platform::collections::HashMap;
+use alloc::boxed::Box;
+use bevy_platform::{collections::HashMap, sync::Arc};
 use crossbeam_channel::{Receiver, Sender};
 use parking_lot::RwLock;
 use std::path::Path;

--- a/crates/bevy_asset/src/io/memory.rs
+++ b/crates/bevy_asset/src/io/memory.rs
@@ -1,6 +1,6 @@
 use crate::io::{AssetReader, AssetReaderError, PathStream, Reader};
-use alloc::{borrow::ToOwned, boxed::Box, sync::Arc, vec::Vec};
-use bevy_platform::collections::HashMap;
+use alloc::{borrow::ToOwned, boxed::Box, vec::Vec};
+use bevy_platform::{collections::HashMap, sync::Arc};
 use core::{pin::Pin, task::Poll};
 use futures_io::AsyncRead;
 use futures_lite::{ready, Stream};

--- a/crates/bevy_asset/src/io/mod.rs
+++ b/crates/bevy_asset/src/io/mod.rs
@@ -21,17 +21,19 @@ mod source;
 pub use futures_lite::AsyncWriteExt;
 pub use source::*;
 
-use alloc::{boxed::Box, sync::Arc, vec::Vec};
-use bevy_tasks::{BoxedFuture, ConditionalSendFuture};
-use core::future::Future;
+use alloc::{boxed::Box, vec::Vec};
 use core::{
+    future::Future,
     mem::size_of,
     pin::Pin,
     task::{Context, Poll},
 };
+use std::path::{Path, PathBuf};
+
+use bevy_platform::sync::Arc;
+use bevy_tasks::{BoxedFuture, ConditionalSendFuture};
 use futures_io::{AsyncRead, AsyncWrite};
 use futures_lite::{ready, Stream};
-use std::path::{Path, PathBuf};
 use thiserror::Error;
 
 /// Errors that occur while loading assets.

--- a/crates/bevy_asset/src/io/processor_gated.rs
+++ b/crates/bevy_asset/src/io/processor_gated.rs
@@ -1,14 +1,15 @@
 use crate::{
-    io::{AssetReader, AssetReaderError, AssetSourceId, PathStream, Reader},
+    io::{AssetReader, AssetReaderError, PathStream, Reader},
     processor::{AssetProcessorData, ProcessStatus},
-    AssetPath,
+    AssetPath, AssetSourceId,
 };
-use alloc::{borrow::ToOwned, boxed::Box, sync::Arc, vec::Vec};
+use alloc::{borrow::ToOwned, boxed::Box, vec::Vec};
 use async_lock::RwLockReadGuardArc;
+use bevy_platform::sync::Arc;
 use core::{pin::Pin, task::Poll};
 use futures_io::AsyncRead;
+use log::trace;
 use std::path::Path;
-use tracing::trace;
 
 use super::{AsyncSeekForward, ErasedAssetReader};
 

--- a/crates/bevy_asset/src/io/wasm.rs
+++ b/crates/bevy_asset/src/io/wasm.rs
@@ -3,8 +3,8 @@ use crate::io::{
 };
 use alloc::{borrow::ToOwned, boxed::Box, format};
 use js_sys::{Uint8Array, JSON};
+use log::error;
 use std::path::{Path, PathBuf};
-use tracing::error;
 use wasm_bindgen::{prelude::wasm_bindgen, JsCast, JsValue};
 use wasm_bindgen_futures::JsFuture;
 use web_sys::Response;

--- a/crates/bevy_asset/src/loader_builders.rs
+++ b/crates/bevy_asset/src/loader_builders.rs
@@ -7,7 +7,8 @@ use crate::{
     Asset, AssetLoadError, AssetPath, ErasedAssetLoader, ErasedLoadedAsset, Handle, LoadContext,
     LoadDirectError, LoadedAsset, LoadedUntypedAsset, UntypedHandle,
 };
-use alloc::{borrow::ToOwned, boxed::Box, sync::Arc};
+use alloc::{borrow::ToOwned, boxed::Box};
+use bevy_platform::sync::Arc;
 use core::any::TypeId;
 
 // Utility type for handling the sources of reader references

--- a/crates/bevy_asset/src/meta.rs
+++ b/crates/bevy_asset/src/meta.rs
@@ -5,10 +5,15 @@ use serde::{Deserialize, Serialize};
 
 use crate::{Asset, AssetPath, VisitAssetDependencies};
 
+#[cfg_attr(
+    not(feature = "std"),
+    expect(unused_imports, reason = "only needed with `std` feature")
+)]
+use alloc::string::ToString;
+
 #[cfg(feature = "std")]
 use {
     crate::{loader::AssetLoader, processor::Process, DeserializeMetaError},
-    alloc::string::ToString,
     ron::ser::PrettyConfig,
 };
 

--- a/crates/bevy_asset/src/meta.rs
+++ b/crates/bevy_asset/src/meta.rs
@@ -1,17 +1,16 @@
-use alloc::{
-    boxed::Box,
-    string::{String, ToString},
-    vec::Vec,
-};
-
-use crate::{
-    loader::AssetLoader, processor::Process, Asset, AssetPath, DeserializeMetaError,
-    VisitAssetDependencies,
-};
+use alloc::{boxed::Box, string::String, vec::Vec};
 use downcast_rs::{impl_downcast, Downcast};
-use ron::ser::PrettyConfig;
+use log::error;
 use serde::{Deserialize, Serialize};
-use tracing::error;
+
+use crate::{Asset, AssetPath, VisitAssetDependencies};
+
+#[cfg(feature = "std")]
+use {
+    crate::{loader::AssetLoader, processor::Process, DeserializeMetaError},
+    alloc::string::ToString,
+    ron::ser::PrettyConfig,
+};
 
 pub const META_FORMAT_VERSION: &str = "1.0";
 pub type MetaTransform = Box<dyn Fn(&mut dyn AssetMetaDyn) + Send + Sync>;
@@ -20,6 +19,7 @@ pub type MetaTransform = Box<dyn Fn(&mut dyn AssetMetaDyn) + Send + Sync>;
 ///
 /// `L` is the [`AssetLoader`] (if one is configured) for the [`AssetAction`]. This can be `()` if it is not required.
 /// `P` is the [`Process`] processor, if one is configured for the [`AssetAction`]. This can be `()` if it is not required.
+#[cfg(feature = "std")]
 #[derive(Serialize, Deserialize)]
 pub struct AssetMeta<L: AssetLoader, P: Process> {
     /// The version of the meta format being used. This will change whenever a breaking change is made to
@@ -35,6 +35,7 @@ pub struct AssetMeta<L: AssetLoader, P: Process> {
     pub asset: AssetAction<L::Settings, P::Settings>,
 }
 
+#[cfg(feature = "std")]
 impl<L: AssetLoader, P: Process> AssetMeta<L, P> {
     pub fn new(asset: AssetAction<L::Settings, P::Settings>) -> Self {
         Self {
@@ -135,6 +136,7 @@ pub trait AssetMetaDyn: Downcast + Send + Sync {
     fn processed_info_mut(&mut self) -> &mut Option<ProcessedInfo>;
 }
 
+#[cfg(feature = "std")]
 impl<L: AssetLoader, P: Process> AssetMetaDyn for AssetMeta<L, P> {
     fn loader_settings(&self) -> Option<&dyn Settings> {
         if let AssetAction::Load { settings, .. } = &self.asset {
@@ -175,6 +177,7 @@ impl<T: 'static> Settings for T where T: Send + Sync {}
 impl_downcast!(Settings);
 
 /// The () processor should never be called. This implementation exists to make the meta format nicer to work with.
+#[cfg(feature = "std")]
 impl Process for () {
     type Settings = ();
     type OutputLoader = ();
@@ -198,6 +201,7 @@ impl VisitAssetDependencies for () {
 }
 
 /// The () loader should never be called. This implementation exists to make the meta format nicer to work with.
+#[cfg(feature = "std")]
 impl AssetLoader for () {
     type Asset = ();
     type Settings = ();
@@ -232,6 +236,10 @@ pub(crate) fn meta_transform_settings<S: Settings>(
     }
 }
 
+#[cfg_attr(
+    not(feature = "std"),
+    expect(dead_code, reason = "only used with `std` currently")
+)]
 pub(crate) fn loader_settings_meta_transform<S: Settings>(
     settings: impl Fn(&mut S) + Send + Sync + 'static,
 ) -> MetaTransform {
@@ -241,6 +249,10 @@ pub(crate) fn loader_settings_meta_transform<S: Settings>(
 pub type AssetHash = [u8; 32];
 
 /// NOTE: changing the hashing logic here is a _breaking change_ that requires a [`META_FORMAT_VERSION`] bump.
+#[cfg_attr(
+    not(feature = "std"),
+    expect(dead_code, reason = "only used with `std` currently")
+)]
 pub(crate) fn get_asset_hash(meta_bytes: &[u8], asset_bytes: &[u8]) -> AssetHash {
     let mut hasher = blake3::Hasher::new();
     hasher.update(meta_bytes);
@@ -249,6 +261,10 @@ pub(crate) fn get_asset_hash(meta_bytes: &[u8], asset_bytes: &[u8]) -> AssetHash
 }
 
 /// NOTE: changing the hashing logic here is a _breaking change_ that requires a [`META_FORMAT_VERSION`] bump.
+#[cfg_attr(
+    not(feature = "std"),
+    expect(dead_code, reason = "only used with `std` currently")
+)]
 pub(crate) fn get_full_asset_hash(
     asset_hash: AssetHash,
     dependency_hashes: impl Iterator<Item = AssetHash>,

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -1,18 +1,26 @@
-use crate::io::AssetSourceId;
-use alloc::{
-    borrow::ToOwned,
-    string::{String, ToString},
-};
-use atomicow::CowArc;
-use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize};
+use alloc::string::{String, ToString};
 use core::{
     fmt::{Debug, Display},
     hash::Hash,
-    ops::Deref,
 };
+
+use atomicow::CowArc;
+use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize};
 use serde::{de::Visitor, Deserialize, Serialize};
-use std::path::{Path, PathBuf};
 use thiserror::Error;
+
+#[cfg(feature = "std")]
+use {
+    alloc::borrow::ToOwned,
+    core::ops::Deref,
+    std::path::{Path, PathBuf},
+};
+
+#[cfg(feature = "std")]
+type PathInner = Path;
+
+#[cfg(not(feature = "std"))]
+type PathInner = str;
 
 /// Represents a path to an asset in a "virtual filesystem".
 ///
@@ -56,7 +64,7 @@ use thiserror::Error;
 #[reflect(Debug, PartialEq, Hash, Clone, Serialize, Deserialize)]
 pub struct AssetPath<'a> {
     source: AssetSourceId<'a>,
-    path: CowArc<'a, Path>,
+    path: CowArc<'a, PathInner>,
     label: Option<CowArc<'a, str>>,
 }
 
@@ -69,11 +77,20 @@ impl<'a> Debug for AssetPath<'a> {
 impl<'a> Display for AssetPath<'a> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         if let AssetSourceId::Name(name) = self.source() {
-            write!(f, "{name}://")?;
+            <_ as Display>::fmt(name, f)?;
+            f.write_str("://")?;
         }
-        write!(f, "{}", self.path.display())?;
+
+        let path = &self.path;
+
+        #[cfg(feature = "std")]
+        let path = path.display();
+
+        <_ as Display>::fmt(&path, f)?;
+
         if let Some(label) = &self.label {
-            write!(f, "#{label}")?;
+            f.write_str("#")?;
+            <_ as Display>::fmt(label, f)?;
         }
         Ok(())
     }
@@ -124,6 +141,10 @@ impl<'a> AssetPath<'a> {
     /// This will return a [`ParseAssetPathError`] if `asset_path` is in an invalid format.
     pub fn try_parse(asset_path: &'a str) -> Result<AssetPath<'a>, ParseAssetPathError> {
         let (source, path, label) = Self::parse_internal(asset_path)?;
+
+        #[cfg(feature = "std")]
+        let path = Path::new(path);
+
         Ok(Self {
             source: match source {
                 Some(source) => AssetSourceId::Name(CowArc::Borrowed(source)),
@@ -137,7 +158,7 @@ impl<'a> AssetPath<'a> {
     // Attempts to Parse a &str into an `AssetPath`'s `AssetPath::source`, `AssetPath::path`, and `AssetPath::label` components.
     fn parse_internal(
         asset_path: &str,
-    ) -> Result<(Option<&str>, &Path, Option<&str>), ParseAssetPathError> {
+    ) -> Result<(Option<&str>, &str, Option<&str>), ParseAssetPathError> {
         let chars = asset_path.char_indices();
         let mut source_range = None;
         let mut path_range = 0..asset_path.len();
@@ -219,11 +240,13 @@ impl<'a> AssetPath<'a> {
             None => None,
         };
 
-        let path = Path::new(&asset_path[path_range]);
+        let path = &asset_path[path_range];
+
         Ok((source, path, label))
     }
 
     /// Creates a new [`AssetPath`] from a [`Path`].
+    #[cfg(feature = "std")]
     #[inline]
     pub fn from_path(path: &'a Path) -> AssetPath<'a> {
         AssetPath {
@@ -253,6 +276,7 @@ impl<'a> AssetPath<'a> {
     }
 
     /// Gets the path to the asset in the "virtual filesystem".
+    #[cfg(feature = "std")]
     #[inline]
     pub fn path(&self) -> &Path {
         self.path.deref()
@@ -303,6 +327,7 @@ impl<'a> AssetPath<'a> {
     }
 
     /// Returns an [`AssetPath`] for the parent folder of this path, if there is a parent folder in the path.
+    #[cfg(feature = "std")]
     pub fn parent(&self) -> Option<AssetPath<'a>> {
         let path = match &self.path {
             CowArc::Borrowed(path) => CowArc::Borrowed(path.parent()?),
@@ -376,6 +401,7 @@ impl<'a> AssetPath<'a> {
     ///
     /// If there are insufficient segments in the base path to match the ".." segments,
     /// then any left-over ".." segments are left as-is.
+    #[cfg(feature = "std")]
     pub fn resolve(&self, path: &str) -> Result<AssetPath<'static>, ParseAssetPathError> {
         self.resolve_internal(path, false)
     }
@@ -402,10 +428,12 @@ impl<'a> AssetPath<'a> {
     /// assert_eq!(AssetPath::parse("a/b.png").resolve_embed("#c"), Ok(AssetPath::parse("a/b.png#c")));
     /// assert_eq!(AssetPath::parse("a/b.png#c").resolve_embed("#d"), Ok(AssetPath::parse("a/b.png#d")));
     /// ```
+    #[cfg(feature = "std")]
     pub fn resolve_embed(&self, path: &str) -> Result<AssetPath<'static>, ParseAssetPathError> {
         self.resolve_internal(path, true)
     }
 
+    #[cfg(feature = "std")]
     fn resolve_internal(
         &self,
         path: &str,
@@ -425,7 +453,7 @@ impl<'a> AssetPath<'a> {
             // Strip off leading slash
             let mut is_absolute = false;
             let rpath = match rpath.strip_prefix("/") {
-                Ok(p) => {
+                Some(p) => {
                     is_absolute = true;
                     p
                 }
@@ -455,6 +483,7 @@ impl<'a> AssetPath<'a> {
     /// Ex: Returns `"config.ron"` for `"my_asset.config.ron"`
     ///
     /// Also strips out anything following a `?` to handle query parameters in URIs
+    #[cfg(feature = "std")]
     pub fn get_full_extension(&self) -> Option<String> {
         let file_name = self.path().file_name()?.to_str()?;
         let index = file_name.find('.')?;
@@ -469,6 +498,10 @@ impl<'a> AssetPath<'a> {
         Some(extension)
     }
 
+    #[cfg_attr(
+        not(feature = "std"),
+        expect(dead_code, reason = "only used with `std` currently")
+    )]
     pub(crate) fn iter_secondary_extensions(full_extension: &str) -> impl Iterator<Item = &str> {
         full_extension.chars().enumerate().filter_map(|(i, c)| {
             if c == '.' {
@@ -505,6 +538,7 @@ impl<'a> AssetPath<'a> {
     /// let path = AssetPath::parse("/home/thingy.png");
     /// assert!(path.is_unapproved());
     /// ```
+    #[cfg(feature = "std")]
     pub fn is_unapproved(&self) -> bool {
         use std::path::Component;
         let mut simplified = PathBuf::new();
@@ -558,6 +592,9 @@ impl<'a> From<&'a str> for AssetPath<'a> {
     fn from(asset_path: &'a str) -> Self {
         let (source, path, label) = Self::parse_internal(asset_path).unwrap();
 
+        #[cfg(feature = "std")]
+        let path = Path::new(path);
+
         AssetPath {
             source: source.into(),
             path: CowArc::Borrowed(path),
@@ -580,6 +617,7 @@ impl From<String> for AssetPath<'static> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a> From<&'a Path> for AssetPath<'a> {
     #[inline]
     fn from(path: &'a Path) -> Self {
@@ -591,6 +629,7 @@ impl<'a> From<&'a Path> for AssetPath<'a> {
     }
 }
 
+#[cfg(feature = "std")]
 impl From<PathBuf> for AssetPath<'static> {
     #[inline]
     fn from(path: PathBuf) -> Self {
@@ -608,6 +647,7 @@ impl<'a, 'b> From<&'a AssetPath<'b>> for AssetPath<'b> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a> From<AssetPath<'a>> for PathBuf {
     fn from(value: AssetPath<'a>) -> Self {
         value.path().to_path_buf()
@@ -658,6 +698,7 @@ impl<'de> Visitor<'de> for AssetPathVisitor {
 
 /// Normalizes the path by collapsing all occurrences of '.' and '..' dot-segments where possible
 /// as per [RFC 1808](https://datatracker.ietf.org/doc/html/rfc1808)
+#[cfg(feature = "std")]
 pub(crate) fn normalize_path(path: &Path) -> PathBuf {
     let mut result_path = PathBuf::new();
     for elt in path.iter() {
@@ -675,39 +716,143 @@ pub(crate) fn normalize_path(path: &Path) -> PathBuf {
     result_path
 }
 
+/// * [`AssetSourceId::Default`] corresponds to "default asset paths" that don't specify a source: `/path/to/asset.png`
+/// * [`AssetSourceId::Name`] corresponds to asset paths that _do_ specify a source: `remote://path/to/asset.png`, where `remote` is the name.
+#[derive(Default, Clone, Debug, Eq)]
+pub enum AssetSourceId<'a> {
+    /// The default asset source.
+    #[default]
+    Default,
+    /// A non-default named asset source.
+    Name(CowArc<'a, str>),
+}
+
+impl<'a> Display for AssetSourceId<'a> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self.as_str() {
+            None => f.write_str("AssetSourceId::Default"),
+            Some(v) => write!(f, "AssetSourceId::Name({v})"),
+        }
+    }
+}
+
+impl<'a> AssetSourceId<'a> {
+    /// Creates a new [`AssetSourceId`]
+    pub fn new(source: Option<impl Into<CowArc<'a, str>>>) -> AssetSourceId<'a> {
+        match source {
+            Some(source) => AssetSourceId::Name(source.into()),
+            None => AssetSourceId::Default,
+        }
+    }
+
+    /// Returns [`None`] if this is [`AssetSourceId::Default`] and [`Some`] containing the
+    /// name if this is [`AssetSourceId::Name`].
+    pub fn as_str(&self) -> Option<&str> {
+        match self {
+            AssetSourceId::Default => None,
+            AssetSourceId::Name(v) => Some(v),
+        }
+    }
+
+    /// If this is not already an owned / static id, create one. Otherwise, it will return itself (with a static lifetime).
+    pub fn into_owned(self) -> AssetSourceId<'static> {
+        match self {
+            AssetSourceId::Default => AssetSourceId::Default,
+            AssetSourceId::Name(v) => AssetSourceId::Name(v.into_owned()),
+        }
+    }
+
+    /// Clones into an owned [`AssetSourceId<'static>`].
+    /// This is equivalent to `.clone().into_owned()`.
+    #[inline]
+    pub fn clone_owned(&self) -> AssetSourceId<'static> {
+        self.clone().into_owned()
+    }
+}
+
+impl AssetSourceId<'static> {
+    /// Indicates this [`AssetSourceId`] should have a static lifetime.
+    #[inline]
+    pub fn as_static(self) -> Self {
+        match self {
+            Self::Default => Self::Default,
+            Self::Name(value) => Self::Name(value.as_static()),
+        }
+    }
+
+    /// Constructs an [`AssetSourceId`] with a static lifetime.
+    #[inline]
+    pub fn from_static(value: impl Into<Self>) -> Self {
+        value.into().as_static()
+    }
+}
+
+impl<'a> From<&'a str> for AssetSourceId<'a> {
+    fn from(value: &'a str) -> Self {
+        AssetSourceId::Name(CowArc::Borrowed(value))
+    }
+}
+
+impl<'a, 'b> From<&'a AssetSourceId<'b>> for AssetSourceId<'b> {
+    fn from(value: &'a AssetSourceId<'b>) -> Self {
+        value.clone()
+    }
+}
+
+impl<'a> From<Option<&'a str>> for AssetSourceId<'a> {
+    fn from(value: Option<&'a str>) -> Self {
+        match value {
+            Some(value) => AssetSourceId::Name(CowArc::Borrowed(value)),
+            None => AssetSourceId::Default,
+        }
+    }
+}
+
+impl From<String> for AssetSourceId<'static> {
+    fn from(value: String) -> Self {
+        AssetSourceId::Name(value.into())
+    }
+}
+
+impl<'a> Hash for AssetSourceId<'a> {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.as_str().hash(state);
+    }
+}
+
+impl<'a> PartialEq for AssetSourceId<'a> {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_str().eq(&other.as_str())
+    }
+}
+
+#[cfg(feature = "std")]
 #[cfg(test)]
 mod tests {
     use crate::AssetPath;
     use alloc::string::ToString;
-    use std::path::Path;
 
     #[test]
     fn parse_asset_path() {
         let result = AssetPath::parse_internal("a/b.test");
-        assert_eq!(result, Ok((None, Path::new("a/b.test"), None)));
+        assert_eq!(result, Ok((None, "a/b.test", None)));
 
         let result = AssetPath::parse_internal("http://a/b.test");
-        assert_eq!(result, Ok((Some("http"), Path::new("a/b.test"), None)));
+        assert_eq!(result, Ok((Some("http"), "a/b.test", None)));
 
         let result = AssetPath::parse_internal("http://a/b.test#Foo");
-        assert_eq!(
-            result,
-            Ok((Some("http"), Path::new("a/b.test"), Some("Foo")))
-        );
+        assert_eq!(result, Ok((Some("http"), "a/b.test", Some("Foo"))));
 
         let result = AssetPath::parse_internal("localhost:80/b.test");
-        assert_eq!(result, Ok((None, Path::new("localhost:80/b.test"), None)));
+        assert_eq!(result, Ok((None, "localhost:80/b.test", None)));
 
         let result = AssetPath::parse_internal("http://localhost:80/b.test");
-        assert_eq!(
-            result,
-            Ok((Some("http"), Path::new("localhost:80/b.test"), None))
-        );
+        assert_eq!(result, Ok((Some("http"), "localhost:80/b.test", None)));
 
         let result = AssetPath::parse_internal("http://localhost:80/b.test#Foo");
         assert_eq!(
             result,
-            Ok((Some("http"), Path::new("localhost:80/b.test"), Some("Foo")))
+            Ok((Some("http"), "localhost:80/b.test", Some("Foo")))
         );
 
         let result = AssetPath::parse_internal("#insource://a/b.test");
@@ -723,7 +868,7 @@ mod tests {
         );
 
         let result = AssetPath::parse_internal("http://");
-        assert_eq!(result, Ok((Some("http"), Path::new(""), None)));
+        assert_eq!(result, Ok((Some("http"), "", None)));
 
         let result = AssetPath::parse_internal("://x");
         assert_eq!(result, Err(crate::ParseAssetPathError::MissingSource));

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -9,12 +9,14 @@ use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize};
 use serde::{de::Visitor, Deserialize, Serialize};
 use thiserror::Error;
 
+#[cfg_attr(
+    not(feature = "std"),
+    expect(unused_imports, reason = "only needed with `std` feature")
+)]
+use {alloc::borrow::ToOwned, core::ops::Deref};
+
 #[cfg(feature = "std")]
-use {
-    alloc::borrow::ToOwned,
-    core::ops::Deref,
-    std::path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 
 #[cfg(feature = "std")]
 type PathInner = Path;

--- a/crates/bevy_asset/src/processor/log.rs
+++ b/crates/bevy_asset/src/processor/log.rs
@@ -7,9 +7,9 @@ use alloc::{
 use async_fs::File;
 use bevy_platform::collections::HashSet;
 use futures_lite::{AsyncReadExt, AsyncWriteExt};
+use log::error;
 use std::path::PathBuf;
 use thiserror::Error;
-use tracing::error;
 
 /// An in-memory representation of a single [`ProcessorTransactionLog`] entry.
 #[derive(Debug)]

--- a/crates/bevy_asset/src/processor/mod.rs
+++ b/crates/bevy_asset/src/processor/mod.rs
@@ -45,27 +45,30 @@ pub use process::*;
 
 use crate::{
     io::{
-        AssetReaderError, AssetSource, AssetSourceBuilders, AssetSourceEvent, AssetSourceId,
-        AssetSources, AssetWriterError, ErasedAssetReader, ErasedAssetWriter,
-        MissingAssetSourceError,
+        AssetReaderError, AssetSource, AssetSourceBuilders, AssetSourceEvent, AssetSources,
+        AssetWriterError, ErasedAssetReader, ErasedAssetWriter, MissingAssetSourceError,
     },
     meta::{
         get_asset_hash, get_full_asset_hash, AssetAction, AssetActionMinimal, AssetHash, AssetMeta,
         AssetMetaDyn, AssetMetaMinimal, ProcessedInfo, ProcessedInfoMinimal,
     },
-    AssetLoadError, AssetMetaCheck, AssetPath, AssetServer, AssetServerMode, DeserializeMetaError,
-    MissingAssetLoaderForExtensionError, UnapprovedPathMode, WriteDefaultMetaError,
+    AssetLoadError, AssetMetaCheck, AssetPath, AssetServer, AssetServerMode, AssetSourceId,
+    DeserializeMetaError, MissingAssetLoaderForExtensionError, UnapprovedPathMode,
+    WriteDefaultMetaError,
 };
-use alloc::{borrow::ToOwned, boxed::Box, collections::VecDeque, sync::Arc, vec, vec::Vec};
+use ::log::{debug, error, trace, warn};
+use alloc::{borrow::ToOwned, boxed::Box, collections::VecDeque, vec, vec::Vec};
 use bevy_ecs::prelude::*;
-use bevy_platform::collections::{HashMap, HashSet};
+use bevy_platform::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 use bevy_tasks::IoTaskPool;
 use futures_io::ErrorKind;
 use futures_lite::{AsyncReadExt, AsyncWriteExt, StreamExt};
 use parking_lot::RwLock;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
-use tracing::{debug, error, trace, warn};
 
 #[cfg(feature = "trace")]
 use {

--- a/crates/bevy_asset/src/server/info.rs
+++ b/crates/bevy_asset/src/server/info.rs
@@ -4,21 +4,19 @@ use crate::{
     Handle, InternalAssetEvent, LoadState, RecursiveDependencyLoadState, StrongHandle,
     UntypedAssetId, UntypedHandle,
 };
-use alloc::{
-    borrow::ToOwned,
-    boxed::Box,
-    sync::{Arc, Weak},
-    vec::Vec,
-};
+use alloc::{borrow::ToOwned, boxed::Box, vec::Vec};
 use bevy_ecs::world::World;
-use bevy_platform::collections::{hash_map::Entry, HashMap, HashSet};
+use bevy_platform::{
+    collections::{hash_map::Entry, HashMap, HashSet},
+    sync::{Arc, Weak},
+};
 use bevy_tasks::Task;
 use bevy_utils::TypeIdMap;
 use core::{any::TypeId, task::Waker};
 use crossbeam_channel::Sender;
 use either::Either;
+use log::warn;
 use thiserror::Error;
-use tracing::warn;
 
 #[derive(Debug)]
 pub(crate) struct AssetInfo {
@@ -727,7 +725,7 @@ impl AssetInfos {
     /// [`Assets`]: crate::Assets
     pub(crate) fn consume_handle_drop_events(&mut self) {
         for provider in self.handle_providers.values() {
-            while let Ok(drop_event) = provider.drop_receiver.try_recv() {
+            while let Ok(drop_event) = provider.drop.pop() {
                 let id = drop_event.id;
                 if drop_event.asset_server_managed {
                     Self::process_handle_drop_internal(

--- a/crates/bevy_asset/src/server/loaders.rs
+++ b/crates/bevy_asset/src/server/loaders.rs
@@ -2,14 +2,14 @@ use crate::{
     loader::{AssetLoader, ErasedAssetLoader},
     path::AssetPath,
 };
-use alloc::{boxed::Box, sync::Arc, vec::Vec};
+use alloc::{boxed::Box, vec::Vec};
 use async_broadcast::RecvError;
-use bevy_platform::collections::HashMap;
+use bevy_platform::{collections::HashMap, sync::Arc};
 use bevy_tasks::IoTaskPool;
 use bevy_utils::TypeIdMap;
 use core::any::TypeId;
+use log::warn;
 use thiserror::Error;
-use tracing::warn;
 
 #[cfg(feature = "trace")]
 use {

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -4,8 +4,8 @@ mod loaders;
 use crate::{
     folder::LoadedFolder,
     io::{
-        AssetReaderError, AssetSource, AssetSourceEvent, AssetSourceId, AssetSources,
-        AssetWriterError, ErasedAssetReader, MissingAssetSourceError, MissingAssetWriterError,
+        AssetReaderError, AssetSource, AssetSourceEvent, AssetSources, AssetWriterError,
+        ErasedAssetReader, MissingAssetSourceError, MissingAssetWriterError,
         MissingProcessedAssetReaderError, Reader,
     },
     loader::{AssetLoader, ErasedAssetLoader, LoadContext, LoadedAsset},
@@ -14,19 +14,21 @@ use crate::{
         MetaTransform, Settings,
     },
     path::AssetPath,
-    Asset, AssetEvent, AssetHandleProvider, AssetId, AssetLoadFailedEvent, AssetMetaCheck, Assets,
-    DeserializeMetaError, ErasedLoadedAsset, Handle, LoadedUntypedAsset, UnapprovedPathMode,
-    UntypedAssetId, UntypedAssetLoadFailedEvent, UntypedHandle,
+    Asset, AssetEvent, AssetHandleProvider, AssetId, AssetLoadFailedEvent, AssetMetaCheck,
+    AssetSourceId, Assets, DeserializeMetaError, ErasedLoadedAsset, Handle, LoadedUntypedAsset,
+    UnapprovedPathMode, UntypedAssetId, UntypedAssetLoadFailedEvent, UntypedHandle,
 };
-use alloc::{borrow::ToOwned, boxed::Box, vec, vec::Vec};
 use alloc::{
+    borrow::ToOwned,
+    boxed::Box,
     format,
     string::{String, ToString},
-    sync::Arc,
+    vec,
+    vec::Vec,
 };
 use atomicow::CowArc;
 use bevy_ecs::prelude::*;
-use bevy_platform::collections::HashSet;
+use bevy_platform::{collections::HashSet, sync::Arc};
 use bevy_tasks::IoTaskPool;
 use core::{any::TypeId, future::Future, panic::AssertUnwindSafe, task::Poll};
 use crossbeam_channel::{Receiver, Sender};
@@ -34,10 +36,10 @@ use either::Either;
 use futures_lite::{FutureExt, StreamExt};
 use info::*;
 use loaders::*;
+use log::{error, info};
 use parking_lot::{RwLock, RwLockWriteGuard};
 use std::path::{Path, PathBuf};
 use thiserror::Error;
-use tracing::{error, info};
 
 /// Loads and tracks the state of [`Asset`] values from a configured [`AssetReader`](crate::io::AssetReader).
 /// This can be used to kick off new asset loads and retrieve their current load states.

--- a/crates/bevy_asset/src/transformer.rs
+++ b/crates/bevy_asset/src/transformer.rs
@@ -1,8 +1,4 @@
-use crate::{meta::Settings, Asset, ErasedLoadedAsset, Handle, LabeledAsset, UntypedHandle};
 use alloc::boxed::Box;
-use atomicow::CowArc;
-use bevy_platform::collections::HashMap;
-use bevy_tasks::ConditionalSendFuture;
 use core::{
     borrow::Borrow,
     convert::Infallible,
@@ -10,7 +6,13 @@ use core::{
     marker::PhantomData,
     ops::{Deref, DerefMut},
 };
+
+use atomicow::CowArc;
+use bevy_platform::collections::HashMap;
+use bevy_tasks::ConditionalSendFuture;
 use serde::{Deserialize, Serialize};
+
+use crate::{meta::Settings, Asset, ErasedLoadedAsset, Handle, LabeledAsset, UntypedHandle};
 
 /// Transforms an [`Asset`] of a given [`AssetTransformer::AssetInput`] type to an [`Asset`] of [`AssetTransformer::AssetOutput`] type.
 ///

--- a/crates/bevy_audio/Cargo.toml
+++ b/crates/bevy_audio/Cargo.toml
@@ -36,6 +36,9 @@ bevy_app = { path = "../bevy_app", version = "0.16.0-dev", default-features = fa
 bevy_reflect = { path = "../bevy_reflect", version = "0.16.0-dev", default-features = false, features = [
   "web",
 ] }
+bevy_asset = { path = "../bevy_asset", version = "0.16.0-dev", default-features = false, features = [
+  "web",
+] }
 
 [features]
 mp3 = ["rodio/mp3"]

--- a/crates/bevy_core_pipeline/Cargo.toml
+++ b/crates/bevy_core_pipeline/Cargo.toml
@@ -47,6 +47,12 @@ thiserror = { version = "2", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 bytemuck = { version = "1" }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+# TODO: Assuming all wasm builds are for the browser. Require `no_std` support to break assumption.
+bevy_asset = { path = "../bevy_asset", version = "0.16.0-dev", default-features = false, features = [
+  "web",
+] }
+
 [lints]
 workspace = true
 

--- a/crates/bevy_dev_tools/Cargo.toml
+++ b/crates/bevy_dev_tools/Cargo.toml
@@ -34,6 +34,12 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 ron = { version = "0.8.0", optional = true }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+# TODO: Assuming all wasm builds are for the browser. Require `no_std` support to break assumption.
+bevy_asset = { path = "../bevy_asset", version = "0.16.0-dev", default-features = false, features = [
+  "web",
+] }
+
 [lints]
 workspace = true
 

--- a/crates/bevy_gizmos/Cargo.toml
+++ b/crates/bevy_gizmos/Cargo.toml
@@ -35,6 +35,12 @@ bevy_time = { path = "../bevy_time", version = "0.16.0-dev" }
 bytemuck = "1.0"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+# TODO: Assuming all wasm builds are for the browser. Require `no_std` support to break assumption.
+bevy_asset = { path = "../bevy_asset", version = "0.16.0-dev", default-features = false, features = [
+  "web",
+] }
+
 [lints]
 workspace = true
 

--- a/crates/bevy_gltf/Cargo.toml
+++ b/crates/bevy_gltf/Cargo.toml
@@ -65,6 +65,12 @@ serde_json = "1"
 smallvec = "1.11"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+# TODO: Assuming all wasm builds are for the browser. Require `no_std` support to break assumption.
+bevy_asset = { path = "../bevy_asset", version = "0.16.0-dev", default-features = false, features = [
+  "web",
+] }
+
 [dev-dependencies]
 bevy_log = { path = "../bevy_log", version = "0.16.0-dev" }
 

--- a/crates/bevy_image/Cargo.toml
+++ b/crates/bevy_image/Cargo.toml
@@ -75,6 +75,12 @@ basis-universal = { version = "0.3.0", optional = true }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 half = { version = "2.4.1" }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+# TODO: Assuming all wasm builds are for the browser. Require `no_std` support to break assumption.
+bevy_asset = { path = "../bevy_asset", version = "0.16.0-dev", default-features = false, features = [
+  "web",
+] }
+
 [dev-dependencies]
 bevy_ecs = { path = "../bevy_ecs", version = "0.16.0-dev" }
 

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -288,6 +288,7 @@ configurable_error_handler = ["bevy_ecs/configurable_error_handler"]
 std = [
   "bevy_a11y?/std",
   "bevy_app/std",
+  "bevy_asset?/std",
   "bevy_color?/std",
   "bevy_diagnostic/std",
   "bevy_ecs/std",
@@ -347,6 +348,7 @@ web = [
   "bevy_platform/web",
   "bevy_reflect/web",
   "bevy_tasks/web",
+  "bevy_asset?/web",
 ]
 
 [dependencies]
@@ -393,7 +395,7 @@ bevy_a11y = { path = "../bevy_a11y", optional = true, version = "0.16.0-dev", fe
   "bevy_reflect",
 ] }
 bevy_animation = { path = "../bevy_animation", optional = true, version = "0.16.0-dev" }
-bevy_asset = { path = "../bevy_asset", optional = true, version = "0.16.0-dev" }
+bevy_asset = { path = "../bevy_asset", optional = true, version = "0.16.0-dev", default-features = false }
 bevy_audio = { path = "../bevy_audio", optional = true, version = "0.16.0-dev" }
 bevy_color = { path = "../bevy_color", optional = true, version = "0.16.0-dev", default-features = false, features = [
   "alloc",

--- a/crates/bevy_mesh/Cargo.toml
+++ b/crates/bevy_mesh/Cargo.toml
@@ -33,6 +33,12 @@ hexasphere = "15.0"
 thiserror = { version = "2", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+# TODO: Assuming all wasm builds are for the browser. Require `no_std` support to break assumption.
+bevy_asset = { path = "../bevy_asset", version = "0.16.0-dev", default-features = false, features = [
+  "web",
+] }
+
 [lints]
 workspace = true
 

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -74,6 +74,12 @@ static_assertions = "1"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 offset-allocator = "0.2"
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+# TODO: Assuming all wasm builds are for the browser. Require `no_std` support to break assumption.
+bevy_asset = { path = "../bevy_asset", version = "0.16.0-dev", default-features = false, features = [
+  "web",
+] }
+
 [lints]
 workspace = true
 

--- a/crates/bevy_picking/Cargo.toml
+++ b/crates/bevy_picking/Cargo.toml
@@ -38,6 +38,9 @@ tracing = { version = "0.1", default-features = false, features = ["std"] }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # TODO: Assuming all wasm builds are for the browser. Require `no_std` support to break assumption.
 uuid = { version = "1.13.1", default-features = false, features = ["js"] }
+bevy_asset = { path = "../bevy_asset", version = "0.16.0-dev", default-features = false, features = [
+  "web",
+] }
 
 [lints]
 workspace = true

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -150,6 +150,9 @@ bevy_platform = { path = "../bevy_platform", version = "0.16.0-dev", default-fea
 bevy_reflect = { path = "../bevy_reflect", version = "0.16.0-dev", default-features = false, features = [
   "web",
 ] }
+bevy_asset = { path = "../bevy_asset", version = "0.16.0-dev", default-features = false, features = [
+  "web",
+] }
 
 [target.'cfg(all(target_arch = "wasm32", target_feature = "atomics"))'.dependencies]
 send_wrapper = "0.6.0"

--- a/crates/bevy_scene/Cargo.toml
+++ b/crates/bevy_scene/Cargo.toml
@@ -40,6 +40,9 @@ derive_more = { version = "1", default-features = false, features = ["from"] }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # TODO: Assuming all wasm builds are for the browser. Require `no_std` support to break assumption.
 uuid = { version = "1.13.1", default-features = false, features = ["js"] }
+bevy_asset = { path = "../bevy_asset", version = "0.16.0-dev", default-features = false, features = [
+  "web",
+] }
 
 [dev-dependencies]
 postcard = { version = "1.0", features = ["alloc"] }

--- a/crates/bevy_sprite/Cargo.toml
+++ b/crates/bevy_sprite/Cargo.toml
@@ -42,6 +42,12 @@ radsort = "0.1"
 nonmax = "0.5"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+# TODO: Assuming all wasm builds are for the browser. Require `no_std` support to break assumption.
+bevy_asset = { path = "../bevy_asset", version = "0.16.0-dev", default-features = false, features = [
+  "web",
+] }
+
 [lints]
 workspace = true
 

--- a/crates/bevy_text/Cargo.toml
+++ b/crates/bevy_text/Cargo.toml
@@ -41,6 +41,12 @@ unicode-bidi = "0.3.13"
 sys-locale = "0.3.0"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+# TODO: Assuming all wasm builds are for the browser. Require `no_std` support to break assumption.
+bevy_asset = { path = "../bevy_asset", version = "0.16.0-dev", default-features = false, features = [
+  "web",
+] }
+
 [dev-dependencies]
 approx = "0.5.1"
 

--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -43,6 +43,12 @@ smallvec = "1.11"
 accesskit = "0.18"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+# TODO: Assuming all wasm builds are for the browser. Require `no_std` support to break assumption.
+bevy_asset = { path = "../bevy_asset", version = "0.16.0-dev", default-features = false, features = [
+  "web",
+] }
+
 [features]
 default = []
 serialize = [

--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -80,6 +80,9 @@ bevy_platform = { path = "../bevy_platform", version = "0.16.0-dev", default-fea
 bevy_reflect = { path = "../bevy_reflect", version = "0.16.0-dev", default-features = false, features = [
   "web",
 ] }
+bevy_asset = { path = "../bevy_asset", version = "0.16.0-dev", default-features = false, optional = true, features = [
+  "web",
+] }
 
 [lints]
 workspace = true

--- a/examples/no_std/library/.cargo/config.toml
+++ b/examples/no_std/library/.cargo/config.toml
@@ -1,2 +1,0 @@
-[target.x86_64-unknown-none]
-rustflags = ['--cfg', 'getrandom_backend="rdrand"']

--- a/examples/no_std/library/.cargo/config.toml
+++ b/examples/no_std/library/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-unknown-none]
+rustflags = ['--cfg', 'getrandom_backend="rdrand"']

--- a/examples/no_std/library/Cargo.toml
+++ b/examples/no_std/library/Cargo.toml
@@ -12,10 +12,7 @@ path = "../../../"
 default-features = false
 # We're free to enable any features our library needs.
 # Note that certain Bevy features rely on `std`.
-features = [
-  # "bevy_color",
-  # "bevy_state",
-]
+features = ["bevy_color", "bevy_state", "bevy_asset"]
 
 [features]
 # `no_std` is relatively niche, so we choose defaults to cater for the majority of our users.

--- a/release-content/release-notes/bevy_asset-no_std.md
+++ b/release-content/release-notes/bevy_asset-no_std.md
@@ -1,0 +1,22 @@
+---
+title: Support for `no_std` in `bevy_asset`
+authors: ["@bushrat011899"]
+pull_requests: [19070]
+---
+
+The `bevy_asset` crate now has initial `no_std` support.
+
+As a part of the 0.16 release cycle, there was a substantial push towards `no_std` support in Bevy, allowing its use on a wider selection of platforms.
+A particularly notable crate that missed out on that initial push was `bevy_asset`.
+Unlike many other Bevy crates, `bevy_asset` has significant interaction with the standard library for filesystem integration.
+This posed a significant design challenge, as the Rust standard library is _fantastic_, and we want users who have access to it to be able to benefit from all the functionality it provides.
+
+After careful consideration, we've isolated a subset of `bevy_asset` which should allow for critical functionality across all platforms without any compromises for more typical use cases.
+Simply disable default features to deactivate the new `std` feature:
+
+```toml
+bevy_asset = { version = "0.17", default-features = false }
+```
+
+This release allows for using the `Asset` trait, `Handle` and `AssetPath` types, and the `Assets` resources, among other supporting items.
+In the future, we hope to extend this list to include the various loading and saving traits, and the `AssetServer`.


### PR DESCRIPTION
# Objective

- Contributes to #18978

## Solution

- Added `std` and `web` features to `bevy_asset`
- Gated all non-`no_std` dependencies behind `std` feature
- Gated substantial functionality behind `std` primarily at the `lib.rs` level
- Ensured all crates depending on `bevy_asset` enable `std` and/or `web` where required
- Added simple documentation to `bevy_asset` features
- Switched from `crossbeam_channel` to `concurrent_queue` where required for `no_std` support
- Switched from `tracing` to `log` where required for `no_atomic` support
- Moved `AssetSourceId` to `bevy_asset::path`, leaving a re-export so there's no breaking change
- Refactored `AssetPath` to use `str` instead of `Path` when `std` is disabled
- Added `bevy_asset` feature to `no_std_library` example to ensure it's tested in CI

## Testing

- CI

---

## Notes

- View the release notes [here](https://github.com/bushrat011899/bevy/blob/mvp_no_std_bevy_asset/release-content/release-notes/bevy_asset-no_std.md)
- This PR is overly restrictive in what requires `std`, opting to start with some low-hanging-fruit such as the `Asset` trait and `AssetPath`. Since the `Assets`, `Handle<T>`, `Asset`, and `AssetPath` items are all available, a bare-minimum workflow where assets are added individually without the `AssetServer` is possible. It is my intention to chip away at these `std` feature gates to bring greater parity.
- Notable missing items:
  - `AssetLoader`
  - `AssetReader`
  - `AssetServer`
  - `AssetSaver`
