### PR TITLE
Bump crate-ci/typos from 1.31.1 to 1.32.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,7 +292,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Check for typos
-        uses: crate-ci/typos@v1.31.1
+        uses: crate-ci/typos@v1.32.0
       - name: Typos info
         if: failure()
         run: |

--- a/benches/benches/bevy_picking/ray_mesh_intersection.rs
+++ b/benches/benches/bevy_picking/ray_mesh_intersection.rs
@@ -37,7 +37,7 @@ fn create_mesh(vertices_per_side: u32) -> SimpleMesh {
     for p in 0..vertices_per_side.pow(2) {
         let (x, z) = p_to_xz_norm(p, vertices_per_side);
 
-        // Push a new vertice to the mesh. We translate all vertices so the final square is
+        // Push a new vertex to the mesh. We translate all vertices so the final square is
         // centered at (0, 0), instead of (0.5, 0.5).
         positions.push([x - 0.5, 0.0, z - 0.5]);
 

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -2049,7 +2049,7 @@ impl Components {
     }
 
     /// Gets the [`ComponentDescriptor`] of the component with this [`ComponentId`] if it is present.
-    /// This will return `None` only if the id is neither regisered nor queued to be registered.
+    /// This will return `None` only if the id is neither registered nor queued to be registered.
     ///
     /// Currently, the [`Cow`] will be [`Cow::Owned`] if and only if the component is queued. It will be [`Cow::Borrowed`] otherwise.
     ///
@@ -2073,7 +2073,7 @@ impl Components {
     }
 
     /// Gets the name of the component with this [`ComponentId`] if it is present.
-    /// This will return `None` only if the id is neither regisered nor queued to be registered.
+    /// This will return `None` only if the id is neither registered nor queued to be registered.
     ///
     /// This will return an incorrect result if `id` did not come from the same world as `self`. It may return `None` or a garbage value.
     #[inline]

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -349,7 +349,7 @@ pub struct ObserverTrigger {
     components: SmallVec<[ComponentId; 2]>,
     /// The entity the trigger targeted.
     pub target: Entity,
-    /// The location of the source code that triggered the obserer.
+    /// The location of the source code that triggered the observer.
     pub caller: MaybeLocation,
 }
 


### PR DESCRIPTION
Adopted #19066. Bumps [crate-ci/typos](https://github.com/crate-ci/typos) from 1.31.1 to 1.32.0.
