### PR TITLE
Upgrade `atomicow` version

### DIFF
--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -36,7 +36,7 @@ bevy_platform = { path = "../bevy_platform", version = "0.16.0-dev", default-fea
 ] }
 
 stackfuture = { version = "0.3", default-features = false }
-atomicow = { version = "1.0", default-features = false, features = ["std"] }
+atomicow = { version = "1.1", default-features = false, features = ["std"] }
 async-broadcast = { version = "0.7.2", default-features = false }
 async-fs = { version = "2.0", default-features = false }
 async-lock = { version = "3.0", default-features = false }


### PR DESCRIPTION
# Objective
`atomicow` `1.0` does not have `std` feature requested by `bevy_asset`, but `1.1` does

## Solution

Bump version
