### PR TITLE
Extract members of `PickingPlugin` and `PointerInputPlugin` into new types

### DIFF
--- a/crates/bevy_picking/src/input.rs
+++ b/crates/bevy_picking/src/input.rs
@@ -73,11 +73,15 @@ impl Default for PointerInputSettings {
 ///
 /// Toggling mouse input or touch input can be done at runtime by modifying
 /// [`PointerInputSettings`] resource.
+///
+/// [`PointerInputSettings`] can be initialized with custom values, but will be
+/// initialized with default values if it is not present at the moment this is
+/// added to the app.
 pub struct PointerInputPlugin;
 
 impl Plugin for PointerInputPlugin {
     fn build(&self, app: &mut App) {
-        app.insert_resource(PointerInputSettings::default())
+        app.init_resource::<PointerInputSettings>()
             .register_type::<PointerInputSettings>()
             .add_systems(Startup, spawn_mouse_pointer)
             .add_systems(

--- a/crates/bevy_picking/src/input.rs
+++ b/crates/bevy_picking/src/input.rs
@@ -39,24 +39,17 @@ pub mod prelude {
     pub use crate::input::PointerInputPlugin;
 }
 
-/// Adds mouse and touch inputs for picking pointers to your app. This is a default input plugin,
-/// that you can replace with your own plugin as needed.
-///
-/// [`crate::PickingPlugin::is_input_enabled`] can be used to toggle whether
-/// the core picking plugin processes the inputs sent by this, or other input plugins, in one place.
-///
-/// This plugin contains several settings, and is added to the world as a resource after initialization.
-/// You can configure pointer input settings at runtime by accessing the resource.
 #[derive(Copy, Clone, Resource, Debug, Reflect)]
 #[reflect(Resource, Default, Clone)]
-pub struct PointerInputPlugin {
+/// Settings for enabling and disabling updating mouse and touch inputs for picking
+pub struct PointerInputSettings {
     /// Should touch inputs be updated?
     pub is_touch_enabled: bool,
     /// Should mouse inputs be updated?
     pub is_mouse_enabled: bool,
 }
 
-impl PointerInputPlugin {
+impl PointerInputSettings {
     fn is_mouse_enabled(state: Res<Self>) -> bool {
         state.is_mouse_enabled
     }
@@ -66,7 +59,7 @@ impl PointerInputPlugin {
     }
 }
 
-impl Default for PointerInputPlugin {
+impl Default for PointerInputSettings {
     fn default() -> Self {
         Self {
             is_touch_enabled: true,
@@ -75,25 +68,31 @@ impl Default for PointerInputPlugin {
     }
 }
 
+/// Adds mouse and touch inputs for picking pointers to your app. This is a default input plugin,
+/// that you can replace with your own plugin as needed.
+///
+/// Toggling mouse input or touch input can be done at runtime by modifying
+/// [`PointerInputSettings`] resource.
+pub struct PointerInputPlugin;
+
 impl Plugin for PointerInputPlugin {
     fn build(&self, app: &mut App) {
-        app.insert_resource(*self)
+        app.insert_resource(PointerInputSettings::default())
+            .register_type::<PointerInputSettings>()
             .add_systems(Startup, spawn_mouse_pointer)
             .add_systems(
                 First,
                 (
-                    mouse_pick_events.run_if(PointerInputPlugin::is_mouse_enabled),
-                    touch_pick_events.run_if(PointerInputPlugin::is_touch_enabled),
+                    mouse_pick_events.run_if(PointerInputSettings::is_mouse_enabled),
+                    touch_pick_events.run_if(PointerInputSettings::is_touch_enabled),
                 )
                     .chain()
                     .in_set(PickSet::Input),
             )
             .add_systems(
                 Last,
-                deactivate_touch_pointers.run_if(PointerInputPlugin::is_touch_enabled),
-            )
-            .register_type::<Self>()
-            .register_type::<PointerInputPlugin>();
+                deactivate_touch_pointers.run_if(PointerInputSettings::is_touch_enabled),
+            );
     }
 }
 

--- a/crates/bevy_picking/src/lib.rs
+++ b/crates/bevy_picking/src/lib.rs
@@ -288,7 +288,7 @@ pub struct DefaultPickingPlugins;
 impl PluginGroup for DefaultPickingPlugins {
     fn build(self) -> PluginGroupBuilder {
         PluginGroupBuilder::start::<Self>()
-            .add(input::PointerInputPlugin::default())
+            .add(input::PointerInputPlugin)
             .add(PickingPlugin::default())
             .add(InteractionPlugin)
     }


### PR DESCRIPTION
# Objective

`PickingPlugin` and `PointerInputPlugin` were kinda weird being both a plugin and a resource.

## Solution

Extract the resource functionality of `PickingPlugin` and `PointerInputPlugin` into new resources

## Testing

`mesh_picking` and `sprite_picking`
