### PR TITLE
Cache component columns in archetypes

### DIFF
--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -811,8 +811,8 @@ pub(crate) struct ComponentRecord {
     archetypes: Vec<ArchetypeId>,
 }
 
-/// Maps a [`ComponentId`] to the list of [`Archetypes`]([`Archetype`]) that contain the [`Component`](crate::component::Component),
-/// along with an [`ArchetypeRecord`] which contains some metadata about how the component is stored in the archetype.
+/// Maps [`ComponentId`]s to [`ComponentRecord`], which contains a list of [`Archetypes`]([`Archetype`]) that contain the [`Component`](crate::component::Component),
+/// along with other metadata.
 #[derive(Default)]
 pub struct ComponentIndex {
     map: HashMap<ComponentId, ComponentRecord>,

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -814,7 +814,7 @@ pub(crate) struct ComponentRecord {
 /// Maps [`ComponentId`]s to [`ComponentRecord`], which contains a list of [`Archetypes`]([`Archetype`]) that contain the [`Component`](crate::component::Component),
 /// along with other metadata.
 #[derive(Default)]
-pub struct ComponentIndex {
+pub(crate) struct ComponentIndex {
     map: HashMap<ComponentId, ComponentRecord>,
 }
 

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -25,17 +25,13 @@ use crate::{
     entity::{Entity, EntityLocation},
     observer::Observers,
     storage::{
-        ComponentSparseSetId, ImmutableSparseSet, SparseArray, SparseSet, SparseSetIndex,
-        TableColumnId, TableId, TableRow,
+        ImmutableSparseSet, SparseArray, SparseSet, SparseSetIndex, TableColumnId, TableId,
+        TableRow,
     },
 };
 use alloc::{boxed::Box, vec::Vec};
 use bevy_platform::collections::HashMap;
-use core::{
-    hash::Hash,
-    hint::unreachable_unchecked,
-    ops::{Index, IndexMut, RangeFrom},
-};
+use core::ops::{Index, IndexMut, RangeFrom};
 
 /// An opaque location within a [`Archetype`].
 ///
@@ -791,6 +787,7 @@ impl SparseSetIndex for ArchetypeComponentId {
 }
 
 /// This maps a [`TableId`] to the column of this component in that table if it is present.
+#[repr(transparent)]
 pub(crate) struct ComponentColumns(Vec<Option<TableColumnId>>);
 
 impl ComponentColumns {
@@ -810,7 +807,7 @@ impl ComponentColumns {
 }
 
 pub(crate) struct ComponentRecord {
-    columns: ComponentColumns,
+    pub(crate) columns: ComponentColumns,
     archetypes: Vec<ArchetypeId>,
 }
 

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -845,6 +845,8 @@ impl BundleInfo {
                 table_id,
                 table_components,
                 sparse_set_components,
+                // SAFETY: All sparse set components have their sets created on bundle registration, and for a component to be in an archetype it must be in a registered bundle.
+                |id| unsafe { storages.sparse_sets.get_id(id).debug_checked_unwrap() },
             );
             // Add an edge from the old archetype to the new archetype.
             archetypes[archetype_id]
@@ -956,6 +958,8 @@ impl BundleInfo {
                 next_table_id,
                 next_table_components,
                 next_sparse_set_components,
+                // SAFETY: All sparse set components have their sets created on bundle registration, and for a component to be in an archetype it must be in a registered bundle.
+                |id| unsafe { storages.sparse_sets.get_id(id).debug_checked_unwrap() },
             );
             Some(new_archetype_id)
         };

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -838,7 +838,7 @@ impl BundleInfo {
                     new_sparse_set_components
                 };
             };
-            // SAFETY: ids in self must be valid
+            // SAFETY: ids in self must be valid, storages are correct, the tables are sorted, so the table ordering is correct.
             let new_archetype_id = archetypes.get_id_or_insert(
                 components,
                 observers,
@@ -952,6 +952,7 @@ impl BundleInfo {
                 };
             }
 
+            // SAFETY: ids in self must be valid, storages are correct, the tables are sorted, so the table ordering is correct.
             let new_archetype_id = archetypes.get_id_or_insert(
                 components,
                 observers,

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -845,8 +845,6 @@ impl BundleInfo {
                 table_id,
                 table_components,
                 sparse_set_components,
-                // SAFETY: All sparse set components have their sets created on bundle registration, and for a component to be in an archetype it must be in a registered bundle.
-                |id| unsafe { storages.sparse_sets.get_id(id).debug_checked_unwrap() },
             );
             // Add an edge from the old archetype to the new archetype.
             archetypes[archetype_id]
@@ -959,8 +957,6 @@ impl BundleInfo {
                 next_table_id,
                 next_table_components,
                 next_sparse_set_components,
-                // SAFETY: All sparse set components have their sets created on bundle registration, and for a component to be in an archetype it must be in a registered bundle.
-                |id| unsafe { storages.sparse_sets.get_id(id).debug_checked_unwrap() },
             );
             Some(new_archetype_id)
         };

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -821,17 +821,18 @@ impl World {
                     if observers.map.is_empty() && observers.entity_map.is_empty() {
                         cache.component_observers.remove(component);
                         if let Some(flag) = Observers::is_archetype_cached(event_type) {
-                            if let Some(by_component) = archetypes.by_component.get(component) {
-                                for archetype in by_component.keys() {
+                            if let Some(by_component) = archetypes
+                                .by_component
+                                .iter_archetypes_with_component(*component)
+                            {
+                                for archetype in by_component {
                                     let archetype = &mut archetypes.archetypes[archetype.index()];
-                                    if archetype.contains(*component) {
-                                        let no_longer_observed = archetype
-                                            .components()
-                                            .all(|id| !cache.component_observers.contains_key(&id));
+                                    let no_longer_observed = archetype
+                                        .components()
+                                        .all(|id| !cache.component_observers.contains_key(&id));
 
-                                        if no_longer_observed {
-                                            archetype.flags.set(flag, false);
-                                        }
+                                    if no_longer_observed {
+                                        archetype.flags.set(flag, false);
                                     }
                                 }
                             }

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -1274,12 +1274,15 @@ pub struct RefFetch<'w, T: Component> {
     components: StorageSwitch<
         T,
         // T::STORAGE_TYPE = StorageType::Table
-        Option<(
-            ThinSlicePtr<'w, UnsafeCell<T>>,
-            ThinSlicePtr<'w, UnsafeCell<Tick>>,
-            ThinSlicePtr<'w, UnsafeCell<Tick>>,
-            MaybeLocation<ThinSlicePtr<'w, UnsafeCell<&'static Location<'static>>>>,
-        )>,
+        (
+            Option<&'w ComponentColumns>,
+            Option<(
+                ThinSlicePtr<'w, UnsafeCell<T>>,
+                ThinSlicePtr<'w, UnsafeCell<Tick>>,
+                ThinSlicePtr<'w, UnsafeCell<Tick>>,
+                MaybeLocation<ThinSlicePtr<'w, UnsafeCell<&'static Location<'static>>>>,
+            )>,
+        ),
         // T::STORAGE_TYPE = StorageType::SparseSet
         // Can be `None` when the component has never been inserted
         Option<&'w ComponentSparseSet>,
@@ -1317,7 +1320,16 @@ unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
     ) -> RefFetch<'w, T> {
         RefFetch {
             components: StorageSwitch::new(
-                || None,
+                || {
+                    (
+                        world
+                            .archetypes()
+                            .component_index()
+                            .get_record(component_id)
+                            .map(|record| &record.columns),
+                        None,
+                    )
+                },
                 || {
                     // SAFETY: The underlying type associated with `component_id` is `T`,
                     // which we are allowed to access since we registered it in `update_archetype_component_access`.
@@ -1356,10 +1368,17 @@ unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
     #[inline]
     unsafe fn set_table<'w>(
         fetch: &mut RefFetch<'w, T>,
-        &component_id: &ComponentId,
+        _component_id: &ComponentId,
         table: &'w Table,
     ) {
-        let column = table.get_column(component_id).debug_checked_unwrap();
+        // SAFETY: For a table to exist, it must have an archetype.
+        let columns = fetch.components.table.0.debug_checked_unwrap();
+        // SAFETY: For this to be called, the table must be relevant to this component.
+        let column = columns
+            .get_column_in_table(table.id())
+            .debug_checked_unwrap();
+        // SAFETY: The column id is for the right table
+        let column = table.get_column_by_id(column);
         let table_data = Some((
             column.get_data_slice(table.entity_count()).into(),
             column.get_added_ticks_slice(table.entity_count()).into(),
@@ -1369,7 +1388,7 @@ unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
                 .map(Into::into),
         ));
         // SAFETY: set_table is only called when T::STORAGE_TYPE = StorageType::Table
-        unsafe { fetch.components.set_table(table_data) };
+        fetch.components.table.1 = table_data;
     }
 
     fn update_component_access(
@@ -1420,7 +1439,7 @@ unsafe impl<'__w, T: Component> QueryData for Ref<'__w, T> {
             |table| {
                 // SAFETY: set_table was previously called
                 let (table_components, added_ticks, changed_ticks, callers) =
-                    unsafe { table.debug_checked_unwrap() };
+                    unsafe { table.1.debug_checked_unwrap() };
 
                 // SAFETY: The caller ensures `table_row` is in range.
                 let component = unsafe { table_components.get(table_row.as_usize()) };
@@ -1469,12 +1488,15 @@ pub struct WriteFetch<'w, T: Component> {
     components: StorageSwitch<
         T,
         // T::STORAGE_TYPE = StorageType::Table
-        Option<(
-            ThinSlicePtr<'w, UnsafeCell<T>>,
-            ThinSlicePtr<'w, UnsafeCell<Tick>>,
-            ThinSlicePtr<'w, UnsafeCell<Tick>>,
-            MaybeLocation<ThinSlicePtr<'w, UnsafeCell<&'static Location<'static>>>>,
-        )>,
+        (
+            Option<&'w ComponentColumns>,
+            Option<(
+                ThinSlicePtr<'w, UnsafeCell<T>>,
+                ThinSlicePtr<'w, UnsafeCell<Tick>>,
+                ThinSlicePtr<'w, UnsafeCell<Tick>>,
+                MaybeLocation<ThinSlicePtr<'w, UnsafeCell<&'static Location<'static>>>>,
+            )>,
+        ),
         // T::STORAGE_TYPE = StorageType::SparseSet
         // Can be `None` when the component has never been inserted
         Option<&'w ComponentSparseSet>,
@@ -1512,7 +1534,16 @@ unsafe impl<'__w, T: Component> WorldQuery for &'__w mut T {
     ) -> WriteFetch<'w, T> {
         WriteFetch {
             components: StorageSwitch::new(
-                || None,
+                || {
+                    (
+                        world
+                            .archetypes()
+                            .component_index()
+                            .get_record(component_id)
+                            .map(|record| &record.columns),
+                        None,
+                    )
+                },
                 || {
                     // SAFETY: The underlying type associated with `component_id` is `T`,
                     // which we are allowed to access since we registered it in `update_archetype_component_access`.
@@ -1551,10 +1582,17 @@ unsafe impl<'__w, T: Component> WorldQuery for &'__w mut T {
     #[inline]
     unsafe fn set_table<'w>(
         fetch: &mut WriteFetch<'w, T>,
-        &component_id: &ComponentId,
+        _component_id: &ComponentId,
         table: &'w Table,
     ) {
-        let column = table.get_column(component_id).debug_checked_unwrap();
+        // SAFETY: For a table to exist, it must have an archetype.
+        let columns = fetch.components.table.0.debug_checked_unwrap();
+        // SAFETY: For this to be called, the table must be relevant to this component.
+        let column = columns
+            .get_column_in_table(table.id())
+            .debug_checked_unwrap();
+        // SAFETY: The column id is for the right table
+        let column = table.get_column_by_id(column);
         let table_data = Some((
             column.get_data_slice(table.entity_count()).into(),
             column.get_added_ticks_slice(table.entity_count()).into(),
@@ -1564,7 +1602,7 @@ unsafe impl<'__w, T: Component> WorldQuery for &'__w mut T {
                 .map(Into::into),
         ));
         // SAFETY: set_table is only called when T::STORAGE_TYPE = StorageType::Table
-        unsafe { fetch.components.set_table(table_data) };
+        fetch.components.table.1 = table_data;
     }
 
     fn update_component_access(
@@ -1615,7 +1653,7 @@ unsafe impl<'__w, T: Component<Mutability = Mutable>> QueryData for &'__w mut T 
             |table| {
                 // SAFETY: set_table was previously called
                 let (table_components, added_ticks, changed_ticks, callers) =
-                    unsafe { table.debug_checked_unwrap() };
+                    unsafe { table.1.debug_checked_unwrap() };
 
                 // SAFETY: The caller ensures `table_row` is in range.
                 let component = unsafe { table_components.get(table_row.as_usize()) };
@@ -2440,9 +2478,9 @@ unsafe impl<T: ?Sized> ReadOnlyQueryData for PhantomData<T> {}
 /// [`StorageType`] of a given component.
 pub(super) union StorageSwitch<C: Component, T: Copy, S: Copy> {
     /// The table variant. Requires the component to be a table component.
-    table: T,
+    pub(super) table: T,
     /// The sparse set variant. Requires the component to be a sparse set component.
-    sparse_set: S,
+    pub(super) sparse_set: S,
     _marker: PhantomData<C>,
 }
 
@@ -2455,28 +2493,6 @@ impl<C: Component, T: Copy, S: Copy> StorageSwitch<C, T, S> {
             StorageType::SparseSet => Self {
                 sparse_set: sparse_set(),
             },
-        }
-    }
-
-    /// Creates a new [`StorageSwitch`] using a table variant.
-    ///
-    /// # Panics
-    ///
-    /// This will panic on debug builds if `C` is not a table component.
-    ///
-    /// # Safety
-    ///
-    /// `C` must be a table component.
-    #[inline]
-    pub unsafe fn set_table(&mut self, table: T) {
-        match C::STORAGE_TYPE {
-            StorageType::Table => self.table = table,
-            _ => {
-                #[cfg(debug_assertions)]
-                unreachable!();
-                #[cfg(not(debug_assertions))]
-                core::hint::unreachable_unchecked()
-            }
         }
     }
 

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -1,5 +1,5 @@
 use crate::{
-    archetype::{Archetype, Archetypes},
+    archetype::{Archetype, Archetypes, ComponentColumns},
     bundle::Bundle,
     change_detection::{MaybeLocation, Ticks, TicksMut},
     component::{Component, ComponentId, Components, Mutable, StorageType, Tick},
@@ -1102,7 +1102,10 @@ pub struct ReadFetch<'w, T: Component> {
     components: StorageSwitch<
         T,
         // T::STORAGE_TYPE = StorageType::Table
-        Option<ThinSlicePtr<'w, UnsafeCell<T>>>,
+        (
+            Option<&'w ComponentColumns>,
+            Option<ThinSlicePtr<'w, UnsafeCell<T>>>,
+        ),
         // T::STORAGE_TYPE = StorageType::SparseSet
         Option<&'w ComponentSparseSet>,
     >,

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -557,19 +557,18 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
                     world
                         .archetypes()
                         .component_index()
-                        .get(&component_id)
-                        .map(|index| index.keys())
+                        .iter_archetypes_with_component(component_id)
                 })
                 // select the component with the fewest archetypes
                 .min_by_key(ExactSizeIterator::len);
             if let Some(archetypes) = potential_archetypes {
                 for archetype_id in archetypes {
                     // exclude archetypes that have already been processed
-                    if archetype_id < &self.archetype_generation.0 {
+                    if archetype_id < self.archetype_generation.0 {
                         continue;
                     }
                     // SAFETY: get_potential_archetypes only returns archetype ids that are valid for the world
-                    let archetype = &world.archetypes()[*archetype_id];
+                    let archetype = &world.archetypes()[archetype_id];
                     // SAFETY: The validate_world call ensures that the world is the same the QueryState
                     // was initialized from.
                     unsafe {
@@ -1773,7 +1772,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
     ///
     /// fn my_system(query: Query<&A>) -> Result {
     ///  let a = query.single()?;
-    ///  
+    ///
     ///  // Do something with `a`
     ///  Ok(())
     /// }

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -558,11 +558,12 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
                         .archetypes()
                         .component_index()
                         .iter_archetypes_with_component(component_id)
+                        .map(|archetypes| archetypes.iter())
                 })
                 // select the component with the fewest archetypes
                 .min_by_key(ExactSizeIterator::len);
             if let Some(archetypes) = potential_archetypes {
-                for archetype_id in archetypes {
+                for &archetype_id in archetypes {
                     // exclude archetypes that have already been processed
                     if archetype_id < self.archetype_generation.0 {
                         continue;

--- a/crates/bevy_ecs/src/query/world_query.rs
+++ b/crates/bevy_ecs/src/query/world_query.rs
@@ -101,7 +101,7 @@ pub unsafe trait WorldQuery {
     /// - `state` must be the [`State`](Self::State) that `fetch` was initialized with.
     unsafe fn set_table<'w>(fetch: &mut Self::Fetch<'w>, state: &Self::State, table: &'w Table);
 
-    /// Sets available accesses for implementors with dynamic access such as [`FilteredEntityRef`](crate::world::FilteredEntityRef)
+    /// Sets available accesses for implementers with dynamic access such as [`FilteredEntityRef`](crate::world::FilteredEntityRef)
     /// or [`FilteredEntityMut`](crate::world::FilteredEntityMut).
     ///
     /// Called when constructing a [`QueryLens`](crate::system::QueryLens) or calling [`QueryState::from_builder`](super::QueryState::from_builder)

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -383,6 +383,8 @@ pub(crate) struct ImmutableSparseSet<I, V: 'static> {
 
 macro_rules! impl_sparse_set {
     ($ty:ident) => {
+        #[expect(clippy::allow_attributes, reason = "Needed for macro")]
+        #[allow(unused, reason = "Not used currently, but useful utility to have.")]
         impl<I: SparseSetIndex, V> $ty<I, V> {
             /// Returns the number of elements in the sparse set.
             #[inline]

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -692,7 +692,7 @@ impl SparseSets {
     pub(crate) fn get_or_insert(
         &mut self,
         component_info: &ComponentInfo,
-    ) -> &mut ComponentSparseSet {
+    ) -> (&mut ComponentSparseSet, ComponentSparseSetId) {
         let Self { data, sets } = self;
 
         let id = *sets.get_or_insert_with(component_info.id(), || {
@@ -701,7 +701,7 @@ impl SparseSets {
             id
         });
         // SAFETY: The id is from self
-        unsafe { self.get_mut_by_id(id) }
+        (unsafe { self.get_mut_by_id(id) }, id)
     }
 
     /// Clear entities stored in each [`ComponentSparseSet`]

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -593,29 +593,7 @@ impl_sparse_set_index!(u8, u16, u32, u64, usize);
 /// Can be accessed via [`Storages`](crate::storage::Storages)
 #[derive(Default)]
 pub struct SparseSets {
-    data: Vec<ComponentSparseSet>,
-    // SAFETY: These ids must correspond to indices in `data`.
-    sets: SparseSet<ComponentId, ComponentSparseSetId>,
-}
-
-/// An opaque id for components in [`SparseSets`]s. Specifies a particular [`ComponentSparseSet`].
-/// Think of this as a more localized [`ComponentId`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ComponentSparseSetId(u32);
-
-impl ComponentSparseSetId {
-    /// Gets the index of the row as a [`usize`].
-    #[inline]
-    pub const fn as_usize(self) -> usize {
-        // usize is at least u32 in Bevy
-        self.0 as usize
-    }
-
-    /// Gets the index of the row as a [`usize`].
-    #[inline]
-    pub const fn as_u32(self) -> u32 {
-        self.0
-    }
+    sets: SparseSet<ComponentId, ComponentSparseSet>,
 }
 
 impl SparseSets {
@@ -634,57 +612,13 @@ impl SparseSets {
     /// An Iterator visiting all ([`ComponentId`], [`ComponentSparseSet`]) pairs.
     /// NOTE: Order is not guaranteed.
     pub fn iter(&self) -> impl Iterator<Item = (ComponentId, &ComponentSparseSet)> {
-        self.sets
-            .iter()
-            // SAFETY: Upheld by `map` safety.
-            .map(|(id, index)| (*id, unsafe { self.data.get_unchecked(index.as_usize()) }))
-    }
-
-    /// Gets a id to the [`ComponentSparseSet`] of a [`ComponentId`]. This may be `None` if the component has never been spawned.
-    #[inline]
-    pub fn get_id(&self, component_id: ComponentId) -> Option<ComponentSparseSetId> {
-        self.sets.get(component_id).copied()
-    }
-
-    /// Gets a reference to the [`ComponentSparseSet`] of a [`ComponentId`].
-    ///
-    /// # SAFETY:
-    ///
-    /// The id must be from this [`SparseSets`].
-    #[inline]
-    pub(crate) unsafe fn get_by_id(&self, id: ComponentSparseSetId) -> &ComponentSparseSet {
-        self.data.get_unchecked(id.as_usize())
-    }
-
-    /// Gets a mutable reference to the [`ComponentSparseSet`] of a [`ComponentId`].
-    ///
-    /// # SAFETY:
-    ///
-    /// The id must be from this [`SparseSets`].
-    #[inline]
-    pub(crate) unsafe fn get_mut_by_id(
-        &mut self,
-        id: ComponentSparseSetId,
-    ) -> &mut ComponentSparseSet {
-        self.data.get_unchecked_mut(id.as_usize())
+        self.sets.iter().map(|(id, data)| (*id, data))
     }
 
     /// Gets a reference to the [`ComponentSparseSet`] of a [`ComponentId`]. This may be `None` if the component has never been spawned.
     #[inline]
     pub fn get(&self, component_id: ComponentId) -> Option<&ComponentSparseSet> {
-        self.sets
-            .get(component_id)
-            // SAFETY: The id came from self.
-            .map(|id| unsafe { self.get_by_id(*id) })
-    }
-
-    /// Gets a mutable reference to the [`ComponentSparseSet`] of a [`ComponentId`]. This may be `None` if the component has never been spawned.
-    pub(crate) fn get_mut(&mut self, component_id: ComponentId) -> Option<&mut ComponentSparseSet> {
-        self.sets
-            .get(component_id)
-            .copied()
-            // SAFETY: The id came from self.
-            .map(|id| unsafe { self.get_mut_by_id(id) })
+        self.sets.get(component_id)
     }
 
     /// Gets a mutable reference of [`ComponentSparseSet`] of a [`ComponentInfo`].
@@ -692,27 +626,31 @@ impl SparseSets {
     pub(crate) fn get_or_insert(
         &mut self,
         component_info: &ComponentInfo,
-    ) -> (&mut ComponentSparseSet, ComponentSparseSetId) {
-        let Self { data, sets } = self;
+    ) -> &mut ComponentSparseSet {
+        if !self.sets.contains(component_info.id()) {
+            self.sets.insert(
+                component_info.id(),
+                ComponentSparseSet::new(component_info, 64),
+            );
+        }
 
-        let id = *sets.get_or_insert_with(component_info.id(), || {
-            let id = ComponentSparseSetId(data.len() as u32);
-            data.push(ComponentSparseSet::new(component_info, 64));
-            id
-        });
-        // SAFETY: The id is from self
-        (unsafe { self.get_mut_by_id(id) }, id)
+        self.sets.get_mut(component_info.id()).unwrap()
+    }
+
+    /// Gets a mutable reference to the [`ComponentSparseSet`] of a [`ComponentId`]. This may be `None` if the component has never been spawned.
+    pub(crate) fn get_mut(&mut self, component_id: ComponentId) -> Option<&mut ComponentSparseSet> {
+        self.sets.get_mut(component_id)
     }
 
     /// Clear entities stored in each [`ComponentSparseSet`]
     pub(crate) fn clear_entities(&mut self) {
-        for set in self.data.iter_mut() {
+        for set in self.sets.values_mut() {
             set.clear();
         }
     }
 
     pub(crate) fn check_change_ticks(&mut self, change_tick: Tick) {
-        for set in self.data.iter_mut() {
+        for set in self.sets.values_mut() {
             set.check_change_ticks(change_tick);
         }
     }

--- a/crates/bevy_ecs/src/storage/table/mod.rs
+++ b/crates/bevy_ecs/src/storage/table/mod.rs
@@ -139,9 +139,9 @@ impl TableRow {
 /// An opaque for components in [`Table`]s. Specifies a single column in a specific table.
 /// Think of this as a more localized [`ComponentId`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct TableColumn(u32);
+pub struct TableColumnId(pub(crate) u32);
 
-impl TableColumn {
+impl TableColumnId {
     /// Gets the index of the row as a [`usize`].
     #[inline]
     pub const fn as_usize(self) -> usize {
@@ -167,7 +167,7 @@ impl TableColumn {
 /// [`build`]: Self::build
 pub(crate) struct TableBuilder {
     data: Vec<ThinColumn>,
-    columns: SparseSet<ComponentId, TableColumn>,
+    columns: SparseSet<ComponentId, TableColumnId>,
     capacity: usize,
 }
 
@@ -184,7 +184,7 @@ impl TableBuilder {
     /// Add a new column to the [`Table`]. Specify the component which will be stored in the [`column`](ThinColumn) using its [`ComponentId`]
     #[must_use]
     pub fn add_column(mut self, component_info: &ComponentInfo) -> Self {
-        let column_id = TableColumn(self.data.len() as u32);
+        let column_id = TableColumnId(self.data.len() as u32);
         self.data
             .push(ThinColumn::with_capacity(component_info, self.capacity));
         self.columns.insert(component_info.id(), column_id);
@@ -216,7 +216,7 @@ impl TableBuilder {
 /// [`World`]: crate::world::World
 pub struct Table {
     data: Box<[ThinColumn]>,
-    columns: ImmutableSparseSet<ComponentId, TableColumn>,
+    columns: ImmutableSparseSet<ComponentId, TableColumnId>,
     entities: Vec<Entity>,
 }
 
@@ -525,29 +525,29 @@ impl Table {
     ///
     /// The `column` must be for *this* table.
     #[inline]
-    pub(crate) unsafe fn get_column_by_id(&self, column: TableColumn) -> &ThinColumn {
+    pub(crate) unsafe fn get_column_by_id(&self, column: TableColumnId) -> &ThinColumn {
         // SAFETY: The column map is immutable and the key came from this table.
         unsafe { self.data.get_unchecked(column.as_usize()) }
     }
 
-    /// Fetches a mutable reference to the [`ThinColumn`] for a given [`TableColumn`] within the table.
+    /// Fetches a mutable reference to the [`ThinColumn`] for a given [`TableColumnId`] within the table.
     ///
     /// # Safety
     ///
     /// The `column` must be for *this* table.
     #[inline]
-    pub(crate) unsafe fn get_column_mut_by_id(&mut self, column: TableColumn) -> &mut ThinColumn {
+    pub(crate) unsafe fn get_column_mut_by_id(&mut self, column: TableColumnId) -> &mut ThinColumn {
         // SAFETY: The column map is immutable and the key came from this table.
         unsafe { self.data.get_unchecked_mut(column.as_usize()) }
     }
 
-    /// Fetches [`TableColumn`] for a given [`Component`] within the table.
+    /// Fetches [`TableColumnId`] for a given [`Component`] within the table.
     ///
     /// Returns `None` if the corresponding component does not belong to the table.
     ///
     /// [`Component`]: crate::component::Component
     #[inline]
-    pub(crate) fn get_column_id(&self, component_id: ComponentId) -> Option<TableColumn> {
+    pub(crate) fn get_column_id(&self, component_id: ComponentId) -> Option<TableColumnId> {
         self.columns.get(component_id).copied()
     }
 

--- a/crates/bevy_ecs/src/storage/table/mod.rs
+++ b/crates/bevy_ecs/src/storage/table/mod.rs
@@ -523,7 +523,7 @@ impl Table {
         unsafe { Some(self.get_column_mut_by_id(self.get_column_id(component_id)?)) }
     }
 
-    /// Fetches a read-only reference to the [`ThinColumn`] for a given [`Component`] within the table.
+    /// Fetches a read-only reference to the [`ThinColumn`] for a given [`Component`](crate::component::Component) within the table.
     ///
     /// # Safety
     ///

--- a/crates/bevy_ecs/src/storage/table/mod.rs
+++ b/crates/bevy_ecs/src/storage/table/mod.rs
@@ -136,7 +136,7 @@ impl TableRow {
     }
 }
 
-/// An opaque for components in [`Table`]s. Specifies a single column in a specific table.
+/// An opaque id for components in [`Table`]s. Specifies a single column in a specific table.
 /// Think of this as a more localized [`ComponentId`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TableColumnId(pub(crate) u32);

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -525,7 +525,7 @@ impl World {
             .archetypes()
             .component_index()
             .iter_archetypes_with_component(requiree)
-            .is_none_or(|mut iter| iter.next().is_none())
+            .is_some_and(|archetypes| !archetypes.is_empty())
         {
             return Err(RequiredComponentsError::ArchetypeExists(requiree));
         }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -521,7 +521,12 @@ impl World {
         let requiree = self.register_component::<T>();
 
         // TODO: Remove this panic and update archetype edges accordingly when required components are added
-        if self.archetypes().component_index().contains_key(&requiree) {
+        if self
+            .archetypes()
+            .component_index()
+            .iter_archetypes_with_component(requiree)
+            .is_none_or(|mut iter| iter.next().is_none())
+        {
             return Err(RequiredComponentsError::ArchetypeExists(requiree));
         }
 


### PR DESCRIPTION
# Objective

This is an alternative to #19063 that uses the existing plan [here](https://github.com/bevyengine/bevy/blob/775fae5b626ff316f620bb4022eb1104d8f0b8d7/crates/bevy_ecs/src/archetype.rs#L812).

The goal is to reduce the lookups on component maps, maps where `ComponentId` is the key. This will be really important when these maps move from a sparse set to a hash map to support components as entities.

## Solution

Store a new `ComponentRecord` in the existing `ComponentIndex` instead of a `ArchetypeRecord`. This data structure tracks the archetypes that have a given component. Now, they also track the table columns of that component. In a query fetch, use a `HashMap` to get that `ComponentRecord` and then index the table columns. (Instead of mapping on each `set_table`.)

## Future work

We can do better than this. If we add some form of `WorldQuery::upgrade_state` that triggers when any archetype matches the query, then we can skip all component maps in `init_fetch`. 

We should also look into caching the location of the `ComponentRecord` in `ComponentInfo`. Right now, to get an arbitrary component without a query, we have to map type id to component id, table id to get column id, and then look up the entity in the column. We could just map the type id to component id and component record id. Then we'd just be indexing twice instead of hash mapping once. Although, `World::get` like this is uncommon, and a better solution may be to just force users to make a query which will be faster anyway unless they really only want one value ever. But that's blocked on #13358 (which is closed but the closing pr was later reverted IIRC). Bottom line, is we need assets as entities and I believe #18540 before we can safely turn `&mut World` there to `&World` without loosing functionality.

## Testing

CiI
---

## Performance

<details>
  <summary>Benchmarks</summary>

```
group                                                                                                    main                                     pr19096
-----                                                                                                    ----                                     -------
added_archetypes/archetype_count/1000                                                                    1.11   658.2±84.88µs        ? ?/sec      1.00  592.7±124.61µs        ? ?/sec
added_archetypes/archetype_count/500                                                                     1.37  372.6±108.77µs        ? ?/sec      1.00  272.9±138.86µs        ? ?/sec
all_added_detection/50000_entities_ecs::change_detection::Sparse                                         1.00     39.7±1.09µs        ? ?/sec      1.13     44.8±0.58µs        ? ?/sec
all_added_detection/50000_entities_ecs::change_detection::Table                                          1.50     44.5±0.45µs        ? ?/sec      1.00     29.8±0.28µs        ? ?/sec
all_added_detection/5000_entities_ecs::change_detection::Sparse                                          1.00      4.2±0.14µs        ? ?/sec      1.07      4.5±0.04µs        ? ?/sec
all_added_detection/5000_entities_ecs::change_detection::Table                                           1.48      4.5±0.05µs        ? ?/sec      1.00      3.0±0.03µs        ? ?/sec
all_changed_detection/50000_entities_ecs::change_detection::Table                                        1.50     44.5±0.45µs        ? ?/sec      1.00     29.7±0.36µs        ? ?/sec
all_changed_detection/5000_entities_ecs::change_detection::Table                                         1.48      4.5±0.05µs        ? ?/sec      1.00      3.0±0.12µs        ? ?/sec
build_schedule/100_schedule_no_constraints                                                               1.00   650.9±36.78µs        ? ?/sec      1.34   872.5±26.55µs        ? ?/sec
ecs::entity_cloning::single/clone                                                                        1.00   619.7±97.98ns 1575.9 KElem/sec    1.05   651.0±74.68ns 1500.1 KElem/sec
empty_archetypes/iter/2000                                                                               1.00      8.9±0.94µs        ? ?/sec      1.05      9.4±0.30µs        ? ?/sec
empty_archetypes/par_for_each/10                                                                         1.00      8.1±0.94µs        ? ?/sec      1.07      8.7±0.26µs        ? ?/sec
empty_archetypes/par_for_each/10000                                                                      1.00     21.1±1.26µs        ? ?/sec      1.13     23.7±0.37µs        ? ?/sec
empty_archetypes/par_for_each/2000                                                                       1.00     11.3±1.11µs        ? ?/sec      1.08     12.3±0.36µs        ? ?/sec
empty_commands/0_entities                                                                                1.08      3.8±0.02ns        ? ?/sec      1.00      3.5±0.01ns        ? ?/sec
entity_hash/entity_set_lookup_miss_gen/10000                                                             1.00     67.9±4.93µs 140.4 MElem/sec     1.10     74.9±4.08µs 127.3 MElem/sec
entity_hash/entity_set_lookup_miss_id/10000                                                              1.00     35.6±2.78µs 267.9 MElem/sec     1.11     39.7±5.60µs 240.5 MElem/sec
event_propagation/four_event_types                                                                       1.00    584.3±8.59µs        ? ?/sec      1.21    709.8±4.74µs        ? ?/sec
event_propagation/single_event_type                                                                      1.00   847.6±21.85µs        ? ?/sec      1.12   952.9±23.60µs        ? ?/sec
event_propagation/single_event_type_no_listeners                                                         1.00    247.0±2.22µs        ? ?/sec      2.33    574.9±1.82µs        ? ?/sec
events_send/size_16_events_100                                                                           1.00    123.2±3.55ns        ? ?/sec      1.30   160.3±22.16ns        ? ?/sec
events_send/size_4_events_100                                                                            1.00     81.3±0.99ns        ? ?/sec      2.05    166.6±0.78ns        ? ?/sec
events_send/size_4_events_1000                                                                           1.00    753.6±7.21ns        ? ?/sec      1.08    814.4±4.10ns        ? ?/sec
events_send/size_4_events_10000                                                                          1.00      7.7±0.11µs        ? ?/sec      1.08      8.3±0.02µs        ? ?/sec
events_send/size_4_events_50000                                                                          1.00     38.5±0.66µs        ? ?/sec      1.08     41.5±0.50µs        ? ?/sec
fake_commands/2000_commands                                                                              1.13     12.9±0.02µs        ? ?/sec      1.00     11.5±0.10µs        ? ?/sec
fake_commands/4000_commands                                                                              1.13     25.9±0.04µs        ? ?/sec      1.00     22.9±0.03µs        ? ?/sec
fake_commands/6000_commands                                                                              1.13     38.8±0.07µs        ? ?/sec      1.00     34.4±0.06µs        ? ?/sec
fake_commands/8000_commands                                                                              1.13     51.8±0.07µs        ? ?/sec      1.00     45.9±0.08µs        ? ?/sec
few_changed_detection/50000_entities_ecs::change_detection::Table                                        1.25     57.2±0.76µs        ? ?/sec      1.00     45.9±0.49µs        ? ?/sec
few_changed_detection/5000_entities_ecs::change_detection::Table                                         1.44      5.1±0.25µs        ? ?/sec      1.00      3.5±0.24µs        ? ?/sec
iter_fragmented/base                                                                                     1.16    347.6±7.12ns        ? ?/sec      1.00    299.4±5.37ns        ? ?/sec
iter_fragmented_sparse/base                                                                              1.00      6.6±0.05ns        ? ?/sec      1.13      7.4±0.25ns        ? ?/sec
iter_fragmented_sparse/foreach                                                                           1.00      5.7±0.05ns        ? ?/sec      1.42      8.2±0.28ns        ? ?/sec
iter_fragmented_sparse/foreach_wide                                                                      1.00     37.1±2.14ns        ? ?/sec      1.55     57.6±0.16ns        ? ?/sec
iter_fragmented_sparse/wide                                                                              1.00     40.2±0.34ns        ? ?/sec      1.71     68.9±0.67ns        ? ?/sec
iter_simple/base                                                                                         1.00      7.0±0.04µs        ? ?/sec      1.06      7.4±0.03µs        ? ?/sec
iter_simple/foreach_wide_sparse_set                                                                      1.00     79.8±0.45µs        ? ?/sec      1.05     84.1±0.22µs        ? ?/sec
iter_simple/system                                                                                       1.00      7.0±0.05µs        ? ?/sec      1.08      7.5±0.01µs        ? ?/sec
iter_simple/wide_sparse_set                                                                              1.00     76.9±0.41µs        ? ?/sec      1.12     86.0±0.20µs        ? ?/sec
multiple_archetypes_none_changed_detection/100_archetypes_10000_entities_ecs::change_detection::Table    1.57   614.2±14.55µs        ? ?/sec      1.00   391.5±44.78µs        ? ?/sec
multiple_archetypes_none_changed_detection/100_archetypes_1000_entities_ecs::change_detection::Table     1.59     63.9±5.28µs        ? ?/sec      1.00     40.1±1.75µs        ? ?/sec
multiple_archetypes_none_changed_detection/100_archetypes_100_entities_ecs::change_detection::Sparse     1.12      8.7±0.54µs        ? ?/sec      1.00      7.7±0.14µs        ? ?/sec
multiple_archetypes_none_changed_detection/100_archetypes_100_entities_ecs::change_detection::Table      1.58      7.4±0.21µs        ? ?/sec      1.00      4.7±0.37µs        ? ?/sec
multiple_archetypes_none_changed_detection/100_archetypes_10_entities_ecs::change_detection::Sparse      1.10  1042.4±25.56ns        ? ?/sec      1.00   947.6±16.73ns        ? ?/sec
multiple_archetypes_none_changed_detection/100_archetypes_10_entities_ecs::change_detection::Table       1.40   824.8±10.56ns        ? ?/sec      1.00   587.3±21.08ns        ? ?/sec
multiple_archetypes_none_changed_detection/20_archetypes_10000_entities_ecs::change_detection::Table     1.61    120.3±1.84µs        ? ?/sec      1.00     74.6±5.21µs        ? ?/sec
multiple_archetypes_none_changed_detection/20_archetypes_1000_entities_ecs::change_detection::Table      1.58     12.3±0.29µs        ? ?/sec      1.00      7.8±0.15µs        ? ?/sec
multiple_archetypes_none_changed_detection/20_archetypes_100_entities_ecs::change_detection::Table       1.69  1418.0±15.57ns        ? ?/sec      1.00   837.4±16.90ns        ? ?/sec
multiple_archetypes_none_changed_detection/20_archetypes_10_entities_ecs::change_detection::Table        1.33    168.8±8.94ns        ? ?/sec      1.00   127.0±10.56ns        ? ?/sec
multiple_archetypes_none_changed_detection/5_archetypes_10000_entities_ecs::change_detection::Table      1.62     29.8±0.30µs        ? ?/sec      1.00     18.5±0.51µs        ? ?/sec
multiple_archetypes_none_changed_detection/5_archetypes_1000_entities_ecs::change_detection::Table       1.58      3.0±0.04µs        ? ?/sec      1.00  1924.2±37.07ns        ? ?/sec
multiple_archetypes_none_changed_detection/5_archetypes_100_entities_ecs::change_detection::Table        1.62    358.2±7.57ns        ? ?/sec      1.00   221.7±11.89ns        ? ?/sec
multiple_archetypes_none_changed_detection/5_archetypes_10_entities_ecs::change_detection::Table         1.10     47.3±2.22ns        ? ?/sec      1.00     42.9±4.64ns        ? ?/sec
none_changed_detection/50000_entities_ecs::change_detection::Table                                       1.62     29.7±0.39µs        ? ?/sec      1.00     18.3±0.89µs        ? ?/sec
none_changed_detection/5000_entities_ecs::change_detection::Table                                        1.60      3.0±0.03µs        ? ?/sec      1.00  1867.6±40.15ns        ? ?/sec
observe/trigger_simple                                                                                   1.10    429.0±4.98µs        ? ?/sec      1.00    390.7±6.81µs        ? ?/sec
query_get/50000_entities_table                                                                           1.00    198.6±1.24µs        ? ?/sec      1.32    262.6±0.68µs        ? ?/sec
query_get_many_10/50000_calls_table                                                                      1.00  1405.4±58.51µs        ? ?/sec      1.58      2.2±0.09ms        ? ?/sec
query_get_many_2/50000_calls_table                                                                       1.00    240.7±0.84µs        ? ?/sec      1.83    440.7±2.60µs        ? ?/sec
query_get_many_5/50000_calls_table                                                                       1.00    626.3±4.86µs        ? ?/sec      1.69   1059.7±6.69µs        ? ?/sec
run_condition/yes/031_systems                                                                            1.00     26.3±0.76µs        ? ?/sec      1.07     28.1±1.55µs        ? ?/sec
run_condition/yes_using_resource/071_systems                                                             1.00     63.6±1.12µs        ? ?/sec      1.05     66.9±2.05µs        ? ?/sec
sized_commands_0_bytes/2000_commands                                                                     1.06     10.8±0.08µs        ? ?/sec      1.00     10.2±0.02µs        ? ?/sec
sized_commands_0_bytes/4000_commands                                                                     1.06     21.6±0.03µs        ? ?/sec      1.00     20.4±0.04µs        ? ?/sec
sized_commands_0_bytes/8000_commands                                                                     1.06     43.3±0.19µs        ? ?/sec      1.00     40.9±0.10µs        ? ?/sec
sized_commands_12_bytes/2000_commands                                                                    1.05     11.7±0.02µs        ? ?/sec      1.00     11.1±0.02µs        ? ?/sec
sized_commands_12_bytes/4000_commands                                                                    1.05     23.3±0.04µs        ? ?/sec      1.00     22.2±0.06µs        ? ?/sec
sized_commands_12_bytes/6000_commands                                                                    1.05     35.2±0.18µs        ? ?/sec      1.00     33.5±0.09µs        ? ?/sec
spawn_commands/6000_entities                                                                             1.00   427.3±37.60µs        ? ?/sec      1.05   449.1±30.62µs        ? ?/sec
world_get/50000_entities_table                                                                           1.00    164.9±1.82µs        ? ?/sec      1.06    175.3±0.73µs        ? ?/sec
world_query_get/50000_entities_table                                                                     1.00    125.0±0.21µs        ? ?/sec      1.73    216.0±1.49µs        ? ?/sec
world_query_get/50000_entities_table_wide                                                                1.00    124.9±0.31µs        ? ?/sec      5.70    711.6±2.87µs        ? ?/sec
```
</details>

Performance is not great. 

The only place that is significantly faster than main is change detection, which is only sped up because the column is cached. In other words, the improvement could be trivially replicated without these changes.

In general, performance is slightly worse across the board, and much worse in a few places, especially sparse table queries and `Query::get`. I want to drive home again that this is just adding an indexing op, that *caches* a sparse set lookup.  I can only imagine what would happen if the sparse set of component ids became a hash map.
