### PR TITLE
Reduce operations in `RayCast2d::circle_intersection_at` using cross product

### DIFF
--- a/crates/bevy_math/src/bounding/raycast2d.rs
+++ b/crates/bevy_math/src/bounding/raycast2d.rs
@@ -78,8 +78,8 @@ impl RayCast2d {
     pub fn circle_intersection_at(&self, circle: &BoundingCircle) -> Option<f32> {
         let offset = self.ray.origin - circle.center;
         let projected = offset.dot(*self.ray.direction);
-        let closest_point = offset - projected * *self.ray.direction;
-        let distance_squared = circle.radius().squared() - closest_point.length_squared();
+        let cross = offset.x * self.ray.direction.y - offset.y * self.ray.direction.x;
+        let distance_squared = circle.radius().squared() - cross.squared();
         if distance_squared < 0.
             || ops::copysign(projected.squared(), -projected) < -distance_squared
         {


### PR DESCRIPTION
# Objective

- Using the cross product to compute the perpendicular distance reduces one multiplication and two additions.
