### PR TITLE
Make `NonSendMarker` `!Send`

### DIFF
--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1470,7 +1470,7 @@ unsafe impl<T: SystemBuffer> SystemParam for Deferred<'_, T> {
 }
 
 /// A dummy type that is [`!Send`](Send), to force systems to run on the main thread.
-pub struct NonSendMarker;
+pub struct NonSendMarker(PhantomData<*mut ()>);
 
 // SAFETY: No world access.
 unsafe impl SystemParam for NonSendMarker {
@@ -1489,7 +1489,7 @@ unsafe impl SystemParam for NonSendMarker {
         _world: UnsafeWorldCell<'world>,
         _change_tick: Tick,
     ) -> Self::Item<'world, 'state> {
-        Self
+        Self(PhantomData)
     }
 }
 


### PR DESCRIPTION
# Objective

In #18301, `NonSendMarker` was defined in such a way that it actually implements `Send`. This isn't strictly a soundness issue, as its goal is to be used as a `SystemParam`, and it _does_ appropriately mark system access as `!Send`. It just seems odd that `NonSendMarker: Send`.

## Solution

- Made `NonSendMarker` wrap `PhantomData<*mut ()>`, which forces it to be `!Send`.

## Testing

- CI

---

## Notes

This does mean constructing a `NonSendMarker` _value_ will require using the `SystemParam` trait, but I think that's acceptable as the marker as a value should be rarely required if at all.