### PR TITLE
Deprecated Begone! 0.16 Cleanup

### DIFF
--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -149,17 +149,6 @@ impl<T: Asset> Clone for Handle<T> {
 }
 
 impl<A: Asset> Handle<A> {
-    /// Create a new [`Handle::Weak`] with the given [`u128`] encoding of a [`Uuid`].
-    #[deprecated(
-        since = "0.16.0",
-        note = "use the `weak_handle!` macro with a UUID string instead"
-    )]
-    pub const fn weak_from_u128(value: u128) -> Self {
-        Handle::Weak(AssetId::Uuid {
-            uuid: Uuid::from_u128(value),
-        })
-    }
-
     /// Returns the [`AssetId`] of this [`Asset`].
     #[inline]
     pub fn id(&self) -> AssetId<A> {

--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -11,7 +11,6 @@ use core::{
 use crossbeam_channel::{Receiver, Sender};
 use disqualified::ShortName;
 use thiserror::Error;
-use uuid::Uuid;
 
 /// Provides [`Handle`] and [`UntypedHandle`] _for a specific asset type_.
 /// This should _only_ be used for one specific asset type.
@@ -543,6 +542,7 @@ mod tests {
     use bevy_platform::hash::FixedHasher;
     use bevy_reflect::PartialReflect;
     use core::hash::BuildHasher;
+    use uuid::Uuid;
 
     use super::*;
 

--- a/crates/bevy_ecs/README.md
+++ b/crates/bevy_ecs/README.md
@@ -290,7 +290,7 @@ struct MyEvent {
 }
 
 fn writer(mut writer: EventWriter<MyEvent>) {
-    writer.send(MyEvent {
+    writer.write(MyEvent {
         message: "hello!".to_string(),
     });
 }

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -1801,12 +1801,7 @@ impl<'w> ComponentsRegistrator<'w> {
                 .debug_checked_unwrap()
         };
 
-        #[expect(
-            deprecated,
-            reason = "need to use this method until it is removed to ensure user defined components register hooks correctly"
-        )]
-        // TODO: Replace with `info.hooks.update_from_component::<T>();` once `Component::register_component_hooks` is removed
-        T::register_component_hooks(&mut info.hooks);
+        info.hooks.update_from_component::<T>();
 
         info.required_components = required_components;
     }

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -685,7 +685,7 @@ pub struct HookContext {
 /// This information is stored in the [`ComponentInfo`] of the associated component.
 ///
 /// There is two ways of configuring hooks for a component:
-/// 1. Defining the [`Component::register_component_hooks`] method (see [`Component`])
+/// 1. Defining the relevant hooks on the [`Component`] implementation
 /// 2. Using the [`World::register_component_hooks`] method
 ///
 /// # Example 2

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -509,15 +509,6 @@ pub trait Component: Send + Sync + 'static {
     /// * For a component to be immutable, this type must be [`Immutable`].
     type Mutability: ComponentMutability;
 
-    /// Called when registering this component, allowing mutable access to its [`ComponentHooks`].
-    #[deprecated(
-        since = "0.16.0",
-        note = "Use the individual hook methods instead (e.g., `Component::on_add`, etc.)"
-    )]
-    fn register_component_hooks(hooks: &mut ComponentHooks) {
-        hooks.update_from_component::<Self>();
-    }
-
     /// Gets the `on_add` [`ComponentHook`] for this [`Component`] if one is defined.
     fn on_add() -> Option<ComponentHook> {
         None

--- a/crates/bevy_ecs/src/event/writer.rs
+++ b/crates/bevy_ecs/src/event/writer.rs
@@ -98,38 +98,4 @@ impl<'w, E: Event> EventWriter<'w, E> {
     {
         self.events.send_default()
     }
-
-    /// Sends an `event`, which can later be read by [`EventReader`](super::EventReader)s.
-    /// This method returns the [ID](`EventId`) of the sent `event`.
-    ///
-    /// See [`Events`] for details.
-    #[deprecated(since = "0.16.0", note = "Use `EventWriter::write` instead.")]
-    #[track_caller]
-    pub fn send(&mut self, event: E) -> EventId<E> {
-        self.write(event)
-    }
-
-    /// Sends a list of `events` all at once, which can later be read by [`EventReader`](super::EventReader)s.
-    /// This is more efficient than sending each event individually.
-    /// This method returns the [IDs](`EventId`) of the sent `events`.
-    ///
-    /// See [`Events`] for details.
-    #[deprecated(since = "0.16.0", note = "Use `EventWriter::write_batch` instead.")]
-    #[track_caller]
-    pub fn send_batch(&mut self, events: impl IntoIterator<Item = E>) -> SendBatchIds<E> {
-        self.write_batch(events)
-    }
-
-    /// Sends the default value of the event. Useful when the event is an empty struct.
-    /// This method returns the [ID](`EventId`) of the sent `event`.
-    ///
-    /// See [`Events`] for details.
-    #[deprecated(since = "0.16.0", note = "Use `EventWriter::write_default` instead.")]
-    #[track_caller]
-    pub fn send_default(&mut self) -> EventId<E>
-    where
-        E: Default,
-    {
-        self.write_default()
-    }
 }

--- a/crates/bevy_ecs/src/hierarchy.rs
+++ b/crates/bevy_ecs/src/hierarchy.rs
@@ -106,13 +106,6 @@ impl ChildOf {
     pub fn parent(&self) -> Entity {
         self.0
     }
-
-    /// The parent entity of this child entity.
-    #[deprecated(since = "0.16.0", note = "Use child_of.parent() instead")]
-    #[inline]
-    pub fn get(&self) -> Entity {
-        self.0
-    }
 }
 
 // TODO: We need to impl either FromWorld or Default so ChildOf can be registered as Reflect.
@@ -344,20 +337,6 @@ impl<'w> EntityWorldMut<'w> {
         });
         self
     }
-
-    /// Removes the [`ChildOf`] component, if it exists.
-    #[deprecated(since = "0.16.0", note = "Use entity_mut.remove::<ChildOf>()")]
-    pub fn remove_parent(&mut self) -> &mut Self {
-        self.remove::<ChildOf>();
-        self
-    }
-
-    /// Inserts the [`ChildOf`] component with the given `parent` entity, if it exists.
-    #[deprecated(since = "0.16.0", note = "Use entity_mut.insert(ChildOf(entity))")]
-    pub fn set_parent(&mut self, parent: Entity) -> &mut Self {
-        self.insert(ChildOf(parent));
-        self
-    }
 }
 
 impl<'a> EntityCommands<'a> {
@@ -432,20 +411,6 @@ impl<'a> EntityCommands<'a> {
     /// [`with_children`]: EntityCommands::with_children
     pub fn with_child(&mut self, bundle: impl Bundle) -> &mut Self {
         self.with_related::<ChildOf>(bundle);
-        self
-    }
-
-    /// Removes the [`ChildOf`] component, if it exists.
-    #[deprecated(since = "0.16.0", note = "Use entity_commands.remove::<ChildOf>()")]
-    pub fn remove_parent(&mut self) -> &mut Self {
-        self.remove::<ChildOf>();
-        self
-    }
-
-    /// Inserts the [`ChildOf`] component with the given `parent` entity, if it exists.
-    #[deprecated(since = "0.16.0", note = "Use entity_commands.insert(ChildOf(entity))")]
-    pub fn set_parent(&mut self, parent: Entity) -> &mut Self {
-        self.insert(ChildOf(parent));
         self
     }
 }

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -64,10 +64,6 @@ pub use bevy_ptr as ptr;
 ///
 /// This includes the most common types in this crate, re-exported for your convenience.
 pub mod prelude {
-    #[expect(
-        deprecated,
-        reason = "`crate::schedule::apply_deferred` is considered deprecated; however, it may still be used by crates which consume `bevy_ecs`, so its removal here may cause confusion. It is intended to be removed in the Bevy 0.17 cycle."
-    )]
     #[doc(hidden)]
     pub use crate::{
         bundle::Bundle,
@@ -86,8 +82,8 @@ pub mod prelude {
         removal_detection::RemovedComponents,
         resource::Resource,
         schedule::{
-            apply_deferred, common_conditions::*, ApplyDeferred, Condition, IntoScheduleConfigs,
-            IntoSystemSet, Schedule, Schedules, SystemSet,
+            common_conditions::*, ApplyDeferred, Condition, IntoScheduleConfigs, IntoSystemSet,
+            Schedule, Schedules, SystemSet,
         },
         spawn::{Spawn, SpawnRelated},
         system::{

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -1800,16 +1800,6 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
         self.query(world).single_inner()
     }
 
-    /// A deprecated alias for [`QueryState::single`].
-    #[deprecated(since = "0.16.0", note = "Please use `single` instead.")]
-    #[inline]
-    pub fn get_single<'w>(
-        &mut self,
-        world: &'w World,
-    ) -> Result<ROQueryItem<'w, D>, QuerySingleError> {
-        self.single(world)
-    }
-
     /// Returns a single mutable query result when there is exactly one entity matching
     /// the query.
     ///
@@ -1825,15 +1815,6 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
         world: &'w mut World,
     ) -> Result<D::Item<'w>, QuerySingleError> {
         self.query_mut(world).single_inner()
-    }
-
-    /// A deprecated alias for [`QueryState::single_mut`].
-    #[deprecated(since = "0.16.0", note = "Please use `single` instead.")]
-    pub fn get_single_mut<'w>(
-        &mut self,
-        world: &'w mut World,
-    ) -> Result<D::Item<'w>, QuerySingleError> {
-        self.single_mut(world)
     }
 
     /// Returns a query result when there is exactly one entity matching the query.

--- a/crates/bevy_ecs/src/schedule/executor/mod.rs
+++ b/crates/bevy_ecs/src/schedule/executor/mod.rs
@@ -123,17 +123,6 @@ impl SystemSchedule {
     }
 }
 
-/// See [`ApplyDeferred`].
-#[deprecated(
-    since = "0.16.0",
-    note = "Use `ApplyDeferred` instead. This was previously a function but is now a marker struct System."
-)]
-#[expect(
-    non_upper_case_globals,
-    reason = "This item is deprecated; as such, its previous name needs to stay."
-)]
-pub const apply_deferred: ApplyDeferred = ApplyDeferred;
-
 /// A special [`System`] that instructs the executor to call
 /// [`System::apply_deferred`] on the systems that have run but not applied
 /// their [`Deferred`] system parameters (like [`Commands`]) or other system buffers.

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -1749,14 +1749,6 @@ impl<'a> EntityCommands<'a> {
     pub fn despawn(&mut self) {
         self.queue_handled(entity_command::despawn(), warn);
     }
-    /// Despawns the provided entity and its descendants.
-    #[deprecated(
-        since = "0.16.0",
-        note = "Use entity.despawn(), which now automatically despawns recursively."
-    )]
-    pub fn despawn_recursive(&mut self) {
-        self.despawn();
-    }
 
     /// Despawns the entity.
     ///

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1429,7 +1429,6 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     ///
     /// - [`get_many_mut`](Self::get_many_mut) to get mutable query items.
     /// - [`get_many_unique`](Self::get_many_unique) to only handle unique inputs.
-    /// - [`many`](Self::many) for the panicking version.
     #[inline]
     pub fn get_many<const N: usize>(
         &self,
@@ -1658,7 +1657,6 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     /// # See also
     ///
     /// - [`get_many`](Self::get_many) to get read-only query items without checking for duplicate entities.
-    /// - [`many_mut`](Self::many_mut) for the panicking version.
     #[inline]
     pub fn get_many_mut<const N: usize>(
         &mut self,

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -2330,15 +2330,6 @@ impl<'w> EntityWorldMut<'w> {
         self.despawn_with_caller(MaybeLocation::caller());
     }
 
-    /// Despawns the provided entity and its descendants.
-    #[deprecated(
-        since = "0.16.0",
-        note = "Use entity.despawn(), which now automatically despawns recursively."
-    )]
-    pub fn despawn_recursive(self) {
-        self.despawn();
-    }
-
     pub(crate) fn despawn_with_caller(self, caller: MaybeLocation) {
         self.assert_not_despawned();
         let world = self.world;

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -1243,13 +1243,6 @@ impl Segment2d {
         }
     }
 
-    /// Create a new `Segment2d` from its endpoints and compute its geometric center.
-    #[inline(always)]
-    #[deprecated(since = "0.16.0", note = "Use the `new` constructor instead")]
-    pub fn from_points(point1: Vec2, point2: Vec2) -> (Self, Vec2) {
-        (Self::new(point1, point2), (point1 + point2) / 2.)
-    }
-
     /// Create a new `Segment2d` centered at the origin with the given direction and length.
     ///
     /// The endpoints will be at `-direction * length / 2.0` and `direction * length / 2.0`.

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -381,13 +381,6 @@ impl Segment3d {
         }
     }
 
-    /// Create a new `Segment3d` from its endpoints and compute its geometric center.
-    #[inline(always)]
-    #[deprecated(since = "0.16.0", note = "Use the `new` constructor instead")]
-    pub fn from_points(point1: Vec3, point2: Vec3) -> (Self, Vec3) {
-        (Self::new(point1, point2), (point1 + point2) / 2.)
-    }
-
     /// Create a new `Segment3d` centered at the origin with the given direction and length.
     ///
     /// The endpoints will be at `-direction * length / 2.0` and `direction * length / 2.0`.

--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -68,12 +68,6 @@ pub trait Array: PartialReflect {
     /// Drain the elements of this array to get a vector of owned values.
     fn drain(self: Box<Self>) -> Vec<Box<dyn PartialReflect>>;
 
-    /// Clones the list, producing a [`DynamicArray`].
-    #[deprecated(since = "0.16.0", note = "use `to_dynamic_array` instead")]
-    fn clone_dynamic(&self) -> DynamicArray {
-        self.to_dynamic_array()
-    }
-
     /// Creates a new [`DynamicArray`] from this array.
     fn to_dynamic_array(&self) -> DynamicArray {
         DynamicArray {

--- a/crates/bevy_reflect/src/enums/dynamic_enum.rs
+++ b/crates/bevy_reflect/src/enums/dynamic_enum.rs
@@ -280,15 +280,6 @@ impl Enum for DynamicEnum {
             DynamicVariant::Struct(..) => VariantType::Struct,
         }
     }
-
-    fn clone_dynamic(&self) -> DynamicEnum {
-        Self {
-            represented_type: self.represented_type,
-            variant_index: self.variant_index,
-            variant_name: self.variant_name.clone(),
-            variant: self.variant.clone(),
-        }
-    }
 }
 
 impl PartialReflect for DynamicEnum {

--- a/crates/bevy_reflect/src/enums/enum_trait.rs
+++ b/crates/bevy_reflect/src/enums/enum_trait.rs
@@ -124,11 +124,6 @@ pub trait Enum: PartialReflect {
     fn variant_index(&self) -> usize;
     /// The type of the current variant.
     fn variant_type(&self) -> VariantType;
-    // Clones the enum into a [`DynamicEnum`].
-    #[deprecated(since = "0.16.0", note = "use `to_dynamic_enum` instead")]
-    fn clone_dynamic(&self) -> DynamicEnum {
-        self.to_dynamic_enum()
-    }
     /// Creates a new [`DynamicEnum`] from this enum.
     fn to_dynamic_enum(&self) -> DynamicEnum {
         DynamicEnum::from_ref(self)

--- a/crates/bevy_reflect/src/func/function.rs
+++ b/crates/bevy_reflect/src/func/function.rs
@@ -63,12 +63,6 @@ pub trait Function: PartialReflect + Debug {
     /// Call this function with the given arguments.
     fn reflect_call<'a>(&self, args: ArgList<'a>) -> FunctionResult<'a>;
 
-    /// Clone this function into a [`DynamicFunction`].
-    #[deprecated(since = "0.16.0", note = "use `to_dynamic_function` instead")]
-    fn clone_dynamic(&self) -> DynamicFunction<'static> {
-        self.to_dynamic_function()
-    }
-
     /// Creates a new [`DynamicFunction`] from this function.
     fn to_dynamic_function(&self) -> DynamicFunction<'static>;
 }

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -1319,21 +1319,6 @@ where
         result
     }
 
-    fn clone_dynamic(&self) -> DynamicMap {
-        let mut dynamic_map = DynamicMap::default();
-        dynamic_map.set_represented_type(self.get_represented_type_info());
-        for (k, v) in self {
-            let key = K::from_reflect(k).unwrap_or_else(|| {
-                panic!(
-                    "Attempted to clone invalid key of type {}.",
-                    k.reflect_type_path()
-                )
-            });
-            dynamic_map.insert_boxed(Box::new(key), v.to_dynamic());
-        }
-        dynamic_map
-    }
-
     fn insert_boxed(
         &mut self,
         key: Box<dyn PartialReflect>,

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -103,12 +103,6 @@ pub trait List: PartialReflect {
     /// [`Vec`] will match the order of items in `self`.
     fn drain(&mut self) -> Vec<Box<dyn PartialReflect>>;
 
-    /// Clones the list, producing a [`DynamicList`].
-    #[deprecated(since = "0.16.0", note = "use `to_dynamic_list` instead")]
-    fn clone_dynamic(&self) -> DynamicList {
-        self.to_dynamic_list()
-    }
-
     /// Creates a new [`DynamicList`] from this list.
     fn to_dynamic_list(&self) -> DynamicList {
         DynamicList {

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -81,12 +81,6 @@ pub trait Map: PartialReflect {
     /// After calling this function, `self` will be empty.
     fn drain(&mut self) -> Vec<(Box<dyn PartialReflect>, Box<dyn PartialReflect>)>;
 
-    /// Clones the map, producing a [`DynamicMap`].
-    #[deprecated(since = "0.16.0", note = "use `to_dynamic_map` instead")]
-    fn clone_dynamic(&self) -> DynamicMap {
-        self.to_dynamic_map()
-    }
-
     /// Creates a new [`DynamicMap`] from this map.
     fn to_dynamic_map(&self) -> DynamicMap {
         let mut map = DynamicMap::default();

--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -218,42 +218,6 @@ where
     /// See [`ReflectOwned`].
     fn reflect_owned(self: Box<Self>) -> ReflectOwned;
 
-    /// Clones `Self` into its dynamic representation.
-    ///
-    /// For value types or types marked with `#[reflect_value]`,
-    /// this will simply return a clone of `Self`.
-    ///
-    /// Otherwise the associated dynamic type will be returned.
-    ///
-    /// For example, a [`List`] type will invoke [`List::clone_dynamic`], returning [`DynamicList`].
-    /// A [`Struct`] type will invoke [`Struct::clone_dynamic`], returning [`DynamicStruct`].
-    /// And so on.
-    ///
-    /// If the dynamic behavior is not desired, a concrete clone can be obtained using [`PartialReflect::reflect_clone`].
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use bevy_reflect::{PartialReflect};
-    /// let value = (1, true, 3.14);
-    /// let cloned = value.clone_value();
-    /// assert!(cloned.is_dynamic())
-    /// ```
-    ///
-    /// [`List`]: crate::List
-    /// [`List::clone_dynamic`]: crate::List::clone_dynamic
-    /// [`DynamicList`]: crate::DynamicList
-    /// [`Struct`]: crate::Struct
-    /// [`Struct::clone_dynamic`]: crate::Struct::clone_dynamic
-    /// [`DynamicStruct`]: crate::DynamicStruct
-    #[deprecated(
-        since = "0.16.0",
-        note = "to clone reflected values, prefer using `reflect_clone`. To convert reflected values to dynamic ones, use `to_dynamic`."
-    )]
-    fn clone_value(&self) -> Box<dyn PartialReflect> {
-        self.to_dynamic()
-    }
-
     /// Converts this reflected value into its dynamic representation based on its [kind].
     ///
     /// For example, a [`List`] type will internally invoke [`List::to_dynamic_list`], returning [`DynamicList`].

--- a/crates/bevy_reflect/src/set.rs
+++ b/crates/bevy_reflect/src/set.rs
@@ -67,12 +67,6 @@ pub trait Set: PartialReflect {
     /// After calling this function, `self` will be empty.
     fn drain(&mut self) -> Vec<Box<dyn PartialReflect>>;
 
-    /// Clones the set, producing a [`DynamicSet`].
-    #[deprecated(since = "0.16.0", note = "use `to_dynamic_set` instead")]
-    fn clone_dynamic(&self) -> DynamicSet {
-        self.to_dynamic_set()
-    }
-
     /// Creates a new [`DynamicSet`] from this set.
     fn to_dynamic_set(&self) -> DynamicSet {
         let mut set = DynamicSet::default();

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -71,12 +71,6 @@ pub trait Struct: PartialReflect {
     /// Returns an iterator over the values of the reflectable fields for this struct.
     fn iter_fields(&self) -> FieldIter;
 
-    /// Clones the struct into a [`DynamicStruct`].
-    #[deprecated(since = "0.16.0", note = "use `to_dynamic_struct` instead")]
-    fn clone_dynamic(&self) -> DynamicStruct {
-        self.to_dynamic_struct()
-    }
-
     fn to_dynamic_struct(&self) -> DynamicStruct {
         let mut dynamic_struct = DynamicStruct::default();
         dynamic_struct.set_represented_type(self.get_represented_type_info());

--- a/crates/bevy_reflect/src/tuple.rs
+++ b/crates/bevy_reflect/src/tuple.rs
@@ -55,12 +55,6 @@ pub trait Tuple: PartialReflect {
     /// Drain the fields of this tuple to get a vector of owned values.
     fn drain(self: Box<Self>) -> Vec<Box<dyn PartialReflect>>;
 
-    /// Clones the tuple into a [`DynamicTuple`].
-    #[deprecated(since = "0.16.0", note = "use `to_dynamic_tuple` instead")]
-    fn clone_dynamic(&self) -> DynamicTuple {
-        self.to_dynamic_tuple()
-    }
-
     /// Creates a new [`DynamicTuple`] from this tuple.
     fn to_dynamic_tuple(&self) -> DynamicTuple {
         DynamicTuple {

--- a/crates/bevy_reflect/src/tuple_struct.rs
+++ b/crates/bevy_reflect/src/tuple_struct.rs
@@ -55,12 +55,6 @@ pub trait TupleStruct: PartialReflect {
     /// Returns an iterator over the values of the tuple struct's fields.
     fn iter_fields(&self) -> TupleStructFieldIter;
 
-    /// Clones the struct into a [`DynamicTupleStruct`].
-    #[deprecated(since = "0.16.0", note = "use `to_dynamic_tuple_struct` instead")]
-    fn clone_dynamic(&self) -> DynamicTupleStruct {
-        self.to_dynamic_tuple_struct()
-    }
-
     /// Creates a new [`DynamicTupleStruct`] from this tuple struct.
     fn to_dynamic_tuple_struct(&self) -> DynamicTupleStruct {
         DynamicTupleStruct {

--- a/crates/bevy_transform/src/commands.rs
+++ b/crates/bevy_transform/src/commands.rs
@@ -20,7 +20,7 @@ pub trait BuildChildrenTransformExt {
     /// Make this entity parentless while preserving this entity's [`GlobalTransform`]
     /// by updating its [`Transform`] to be equal to its current [`GlobalTransform`].
     ///
-    /// See [`EntityWorldMut::remove_parent`] or [`EntityCommands::remove_parent`] for a method that doesn't update the [`Transform`].
+    /// See [`EntityWorldMut::remove::<ChildOf>`] or [`EntityCommands::remove::<ChildOf>`] for a method that doesn't update the [`Transform`].
     ///
     /// Note that both the hierarchy and transform updates will only execute
     /// the next time commands are applied

--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -161,7 +161,7 @@ impl GlobalTransform {
     ///
     /// ```
     /// # use bevy_transform::prelude::{GlobalTransform, Transform};
-    /// # use bevy_ecs::prelude::{Entity, Query, Component, Commands};
+    /// # use bevy_ecs::prelude::{Entity, Query, Component, Commands, ChildOf};
     /// #[derive(Component)]
     /// struct ToReparent {
     ///     new_parent: Entity,
@@ -176,7 +176,7 @@ impl GlobalTransform {
     ///             *transform = initial.reparented_to(parent_transform);
     ///             commands.entity(entity)
     ///                 .remove::<ToReparent>()
-    ///                 .set_parent(to_reparent.new_parent);
+    ///                 .insert(ChildOf(to_reparent.new_parent));
     ///         }
     ///     }
     /// }


### PR DESCRIPTION
# Objective

A fair few items were deprecated in 0.16. Let's delete them now that we're in the 0.17 development cycle!

## Solution

- Deleted items marked deprecated in 0.16.

## Testing

- CI

---

## Notes

I'm making the assumption that _everything_ deprecated in 0.16 should be removed in 0.17. That may be a false assumption in certain cases. Please check the items to be removed to see if there are any exceptions we should keep around for another cycle!