### PR TITLE
Remove warning from Image::resize

### DIFF
--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -15,7 +15,6 @@ use bevy_math::{AspectRatio, UVec2, UVec3, Vec2};
 use core::hash::Hash;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tracing::warn;
 use wgpu_types::{
     AddressMode, CompareFunction, Extent3d, Features, FilterMode, SamplerBorderColor,
     SamplerDescriptor, TextureDescriptor, TextureDimension, TextureFormat, TextureUsages,

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -850,7 +850,7 @@ impl Image {
     }
 
     /// Resizes the image to the new size, by removing information or appending 0 to the `data`.
-    /// Does not properly resize the contents of the image, but only its internal `data` buffer.
+    /// Does not properly scale the contents of the image.
     pub fn resize(&mut self, size: Extent3d) {
         self.texture_descriptor.size = size;
         if let Some(ref mut data) = self.data {
@@ -858,8 +858,6 @@ impl Image {
                 size.volume() * self.texture_descriptor.format.pixel_size(),
                 0,
             );
-        } else {
-            warn!("Resized an uninitialized image. Directly modify image.texture_descriptor.size instead");
         }
     }
 


### PR DESCRIPTION
# Objective

`Image::resize` currently prints a warning when resizing an uninitialized `Image`, even though the resizing works correctly. For [code](https://github.com/bevyengine/bevy/blob/c92f14c9e7adc9f5fc02ec14b26589dd82f8b4eb/crates/bevy_ui/src/widget/viewport.rs#L175-L179) that doesn't care about whether the image is initialized CP-side, this is inconvenient and unnecessary.