### PR TITLE
Fix a `NestedLoader` code path that failed to use its meta transform

### DIFF
--- a/crates/bevy_asset/src/loader_builders.rs
+++ b/crates/bevy_asset/src/loader_builders.rs
@@ -314,7 +314,7 @@ impl NestedLoader<'_, '_, StaticTyped, Deferred> {
         } else {
             self.load_context
                 .asset_server
-                .get_or_create_path_handle(path, None)
+                .get_or_create_path_handle(path, self.meta_transform)
         };
         self.load_context.dependencies.insert(handle.id().untyped());
         handle


### PR DESCRIPTION
## Solution

While poking around `NestedLoader` I noticed that one code path fails to pass on the loader's meta transform.

```diff
- .get_or_create_path_handle(path, None)
+ .get_or_create_path_handle(path, self.meta_transform)
```

This seems like a simple oversight - all other code paths pass on the meta transform where possible - although I'm not familiar enough with the asset system to be 100% sure. It was introduced when asset loaders were changed to use the builder pattern (#13465).

Unfortunately I couldn't find an example that actually hits this code path. So I don't have a good test case, and I don't know if any users have experienced it as a bug.

## Testing

```
cargo test -p bevy_asset
```

Also tested various examples - `testbed_2d`, `testbed_3d` and everything in `examples/asset`.