### PR TITLE
Fix glTF importer wrongly ignoring sampler filters

### DIFF
--- a/crates/bevy_gltf/src/loader/gltf_ext/texture.rs
+++ b/crates/bevy_gltf/src/loader/gltf_ext/texture.rs
@@ -51,7 +51,7 @@ pub(crate) fn texture_sampler(
 
     // Shouldn't parse filters when anisotropic filtering is on, because trilinear is then required by wgpu.
     // We also trust user to have provided a valid sampler.
-    if sampler.anisotropy_clamp != 1 {
+    if sampler.anisotropy_clamp == 1 {
         if let Some(mag_filter) = gltf_sampler.mag_filter().map(|mf| match mf {
             MagFilter::Nearest => ImageFilterMode::Nearest,
             MagFilter::Linear => ImageFilterMode::Linear,


### PR DESCRIPTION
## Objective

Fix #19114.

## Solution

#17875 changed the glTF importer to make sure that sampler filters are linear when anisotropic filtering is enabled - this is required by `wgpu`. But the condition was mistakenly inverted, so it forces the filtering to linear when anisotropic filtering is _not_ enabled.

## Testing

```
cargo run --example color_grading
cargo run --example testbed_3d
```