### PR TITLE
Adjust texture filtering defaults and presets.

### DIFF
--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -166,7 +166,7 @@ pub struct GltfPlugin {
 impl Default for GltfPlugin {
     fn default() -> Self {
         GltfPlugin {
-            default_sampler: ImageSamplerDescriptor::linear(),
+            default_sampler: ImageSamplerDescriptor::anisotropic(),
             custom_vertex_attributes: HashMap::default(),
         }
     }

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -368,13 +368,37 @@ pub enum ImageSampler {
 }
 
 impl ImageSampler {
-    /// Returns an image sampler with [`ImageFilterMode::Linear`] min and mag filters
+    /// Returns an image sampler with [`Linear`](ImageFilterMode::Linear) min, mag and mipmap filters.
     #[inline]
+    #[deprecated(
+        since = "0.17.0",
+        note = "With more generators provided became misleading. For same behavior, use `trilinear()`."
+    )]
     pub fn linear() -> ImageSampler {
-        ImageSampler::Descriptor(ImageSamplerDescriptor::linear())
+        ImageSampler::Descriptor(ImageSamplerDescriptor::trilinear())
     }
 
-    /// Returns an image sampler with [`ImageFilterMode::Nearest`] min and mag filters
+    /// Returns an image sampler with [`Linear`](ImageFilterMode::Linear) min, mag and mipmap filters,
+    /// and 16x anisotropic filtering enabled.
+    #[inline]
+    pub fn anisotropic() -> ImageSampler {
+        ImageSampler::Descriptor(ImageSamplerDescriptor::anisotropic())
+    }
+
+    /// Returns an image sampler with [`Linear`](ImageFilterMode::Linear) min, mag and mipmap filters.
+    #[inline]
+    pub fn trilinear() -> ImageSampler {
+        ImageSampler::Descriptor(ImageSamplerDescriptor::trilinear())
+    }
+
+    /// Returns an image sampler with [`Linear`](ImageFilterMode::Linear) min and mag filters,
+    /// but [`Nearest`](ImageFilterMode::Nearest) mipmap filter.
+    #[inline]
+    pub fn bilinear() -> ImageSampler {
+        ImageSampler::Descriptor(ImageSamplerDescriptor::bilinear())
+    }
+
+    /// Returns an image sampler with [`ImageFilterMode::Nearest`] min, mag and mipmap filters.
     #[inline]
     pub fn nearest() -> ImageSampler {
         ImageSampler::Descriptor(ImageSamplerDescriptor::nearest())
@@ -527,43 +551,69 @@ pub struct ImageSamplerDescriptor {
 
 impl Default for ImageSamplerDescriptor {
     fn default() -> Self {
-        Self {
+        Self::anisotropic()
+    }
+}
+
+impl ImageSamplerDescriptor {
+    /// Returns a sampler descriptor with [`Linear`](ImageFilterMode::Linear) min, mag and mipmap filters.
+    #[inline]
+    #[deprecated(
+        since = "0.17.0",
+        note = "With more generators provided became misleading. For same behavior, use `trilinear()`."
+    )]
+    pub fn linear() -> ImageSamplerDescriptor {
+        Self::trilinear()
+    }
+
+    /// Returns a sampler descriptor with [`Linear`](ImageFilterMode::Linear) min, mag and mipmap filters,
+    /// and 16x anisotropic filtering enabled.
+    #[inline]
+    pub fn anisotropic() -> ImageSamplerDescriptor {
+        ImageSamplerDescriptor {
+            anisotropy_clamp: 16,
+            ..Self::trilinear()
+        }
+    }
+
+    /// Returns a sampler descriptor with [`Linear`](ImageFilterMode::Linear) min, mag and mipmap filters.
+    #[inline]
+    pub fn trilinear() -> ImageSamplerDescriptor {
+        ImageSamplerDescriptor {
+            mag_filter: ImageFilterMode::Linear,
+            min_filter: ImageFilterMode::Linear,
+            mipmap_filter: ImageFilterMode::Linear,
+            ..Self::nearest()
+        }
+    }
+
+    /// Returns a sampler descriptor with [`Linear`](ImageFilterMode::Linear) min and mag filters,
+    /// but [`Nearest`](ImageFilterMode::Nearest) mipmap filter.
+    #[inline]
+    pub fn bilinear() -> ImageSamplerDescriptor {
+        ImageSamplerDescriptor {
+            mag_filter: ImageFilterMode::Linear,
+            min_filter: ImageFilterMode::Linear,
+            ..Self::nearest()
+        }
+    }
+
+    /// Returns a sampler descriptor with [`Nearest`](ImageFilterMode::Nearest) min, mag and mipmap filters.
+    #[inline]
+    pub fn nearest() -> ImageSamplerDescriptor {
+        ImageSamplerDescriptor {
             address_mode_u: Default::default(),
             address_mode_v: Default::default(),
             address_mode_w: Default::default(),
-            mag_filter: Default::default(),
-            min_filter: Default::default(),
-            mipmap_filter: Default::default(),
+            mag_filter: ImageFilterMode::Nearest,
+            min_filter: ImageFilterMode::Nearest,
+            mipmap_filter: ImageFilterMode::Nearest,
             lod_min_clamp: 0.0,
             lod_max_clamp: 32.0,
             compare: None,
             anisotropy_clamp: 1,
             border_color: None,
             label: None,
-        }
-    }
-}
-
-impl ImageSamplerDescriptor {
-    /// Returns a sampler descriptor with [`Linear`](ImageFilterMode::Linear) min and mag filters
-    #[inline]
-    pub fn linear() -> ImageSamplerDescriptor {
-        ImageSamplerDescriptor {
-            mag_filter: ImageFilterMode::Linear,
-            min_filter: ImageFilterMode::Linear,
-            mipmap_filter: ImageFilterMode::Linear,
-            ..Default::default()
-        }
-    }
-
-    /// Returns a sampler descriptor with [`Nearest`](ImageFilterMode::Nearest) min and mag filters
-    #[inline]
-    pub fn nearest() -> ImageSamplerDescriptor {
-        ImageSamplerDescriptor {
-            mag_filter: ImageFilterMode::Nearest,
-            min_filter: ImageFilterMode::Nearest,
-            mipmap_filter: ImageFilterMode::Nearest,
-            ..Default::default()
         }
     }
 

--- a/crates/bevy_render/src/texture/mod.rs
+++ b/crates/bevy_render/src/texture/mod.rs
@@ -38,19 +38,44 @@ pub struct ImagePlugin {
 
 impl Default for ImagePlugin {
     fn default() -> Self {
-        ImagePlugin::default_linear()
+        ImagePlugin::default_anisotropic()
     }
 }
 
 impl ImagePlugin {
-    /// Creates image settings with linear sampling by default.
+    /// Creates image settings with trilinear filtering by default.
+    #[deprecated(
+        since = "0.17.0",
+        note = "With more generators provided became misleading. For same behavior, use `default_trilinear()`."
+    )]
     pub fn default_linear() -> ImagePlugin {
         ImagePlugin {
-            default_sampler: ImageSamplerDescriptor::linear(),
+            default_sampler: ImageSamplerDescriptor::trilinear(),
         }
     }
 
-    /// Creates image settings with nearest sampling by default.
+    /// Creates image settings with anisotropic filtering by default.
+    pub fn default_anisotropic() -> ImagePlugin {
+        ImagePlugin {
+            default_sampler: ImageSamplerDescriptor::anisotropic(),
+        }
+    }
+
+    /// Creates image settings with trilinear filtering by default.
+    pub fn default_trilinear() -> ImagePlugin {
+        ImagePlugin {
+            default_sampler: ImageSamplerDescriptor::trilinear(),
+        }
+    }
+
+    /// Creates image settings with bilinear filtering by default.
+    pub fn default_bilinear() -> ImagePlugin {
+        ImagePlugin {
+            default_sampler: ImageSamplerDescriptor::bilinear(),
+        }
+    }
+
+    /// Creates image settings with nearest filtering by default.
     pub fn default_nearest() -> ImagePlugin {
         ImagePlugin {
             default_sampler: ImageSamplerDescriptor::nearest(),

--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -62,7 +62,7 @@ fn setup(
     let (texture_atlas_linear, linear_sources, linear_texture) = create_texture_atlas(
         loaded_folder,
         None,
-        Some(ImageSampler::linear()),
+        Some(ImageSampler::bilinear()),
         &mut textures,
     );
     let atlas_linear_handle = texture_atlases.add(texture_atlas_linear);
@@ -79,7 +79,7 @@ fn setup(
         create_texture_atlas(
             loaded_folder,
             Some(UVec2::new(6, 6)),
-            Some(ImageSampler::linear()),
+            Some(ImageSampler::bilinear()),
             &mut textures,
         );
     let atlas_linear_padded_handle = texture_atlases.add(texture_atlas_linear_padded.clone());

--- a/examples/3d/motion_blur.rs
+++ b/examples/3d/motion_blur.rs
@@ -383,7 +383,7 @@ fn uv_debug_texture() -> Image {
         address_mode_u: ImageAddressMode::Repeat,
         address_mode_v: ImageAddressMode::MirrorRepeat,
         mag_filter: ImageFilterMode::Nearest,
-        ..ImageSamplerDescriptor::linear()
+        ..ImageSamplerDescriptor::trilinear()
     });
     img
 }


### PR DESCRIPTION
# Objective

- Do something about `ImageSamplerDescriptor::default()` not being the actual default (it's nearest instead of linear, `nearest()` doesn't trust `default()` to be nearest even though it is).
- Bring image sampler preset names to industry standard (what we're referring to as just "linear" is more precisely called "trilinear"), add bilinear and anisotropic presets.
- Make 16x anisotropic filtering an engine-wide default. The previous default is trilinear. The difference is present only with mipmapped textures, and aniso is just better looking with not that big of a performance impact.

## Solution

- Reversed `ImageSamplerDescriptor::default()`'s hierarchy. It now returns the preset we currently consider default. Everything builds upon `nearest()`.
- Added new presets, deprecated `linear()` for `trilinear()`.
- Switched the default.