### PR TITLE
Provide physical dimensions to wgpu `Device::create_texture_with_data`

### DIFF
--- a/crates/bevy_image/src/ktx2.rs
+++ b/crates/bevy_image/src/ktx2.rs
@@ -276,8 +276,7 @@ pub fn ktx2_buffer_to_image(
             depth
         }
         .max(1),
-    }
-    .physical_size(texture_format);
+    };
     image.texture_descriptor.mip_level_count = level_count;
     image.texture_descriptor.dimension = if depth > 1 {
         TextureDimension::D3


### PR DESCRIPTION
# Objective

- Make errors in #19124 #13289 clearer, and opt for option 2. of https://github.com/gfx-rs/wgpu/issues/7677

## Solution

Remove the round to block size `.physical_size(texture_format);`

Error message now becomes much clearer:
```
thread 'Compute Task Pool (5)' panicked at E:\r\wgpu\wgpu\src\backend\wgpu_core.rs:1423:26:
wgpu error: Validation Error

Caused by:
  In Device::create_texture
    Width 2050 is not a multiple of Bc7RgbaUnormSrgb's block width (4)
```

## Testing

- Tested using the repro in #19124

