### PR TITLE
Nonmax all rows

### DIFF
--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -32,6 +32,7 @@ use core::{
     hash::Hash,
     ops::{Index, IndexMut, RangeFrom},
 };
+use nonmax::NonMaxU32;
 
 /// An opaque location within a [`Archetype`].
 ///
@@ -44,23 +45,23 @@ use core::{
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 // SAFETY: Must be repr(transparent) due to the safety requirements on EntityLocation
 #[repr(transparent)]
-pub struct ArchetypeRow(u32);
+pub struct ArchetypeRow(NonMaxU32);
 
 impl ArchetypeRow {
     /// Index indicating an invalid archetype row.
     /// This is meant to be used as a placeholder.
-    pub const INVALID: ArchetypeRow = ArchetypeRow(u32::MAX);
+    pub const INVALID: ArchetypeRow = ArchetypeRow(NonMaxU32::MAX);
 
     /// Creates a `ArchetypeRow`.
     #[inline]
-    pub const fn new(index: usize) -> Self {
-        Self(index as u32)
+    pub const fn new(index: NonMaxU32) -> Self {
+        Self(index)
     }
 
     /// Gets the index of the row.
     #[inline]
     pub const fn index(self) -> usize {
-        self.0 as usize
+        self.0.get() as usize
     }
 }
 
@@ -467,6 +468,27 @@ impl Archetype {
         &self.entities
     }
 
+    /// Fetches the entities contained in this archetype.
+    #[inline]
+    pub fn entities_with_location(&self) -> impl Iterator<Item = (Entity, EntityLocation)> {
+        self.entities.iter().enumerate().map(
+            |(archetype_row, &ArchetypeEntity { entity, table_row })| {
+                (
+                    entity,
+                    EntityLocation {
+                        archetype_id: self.id,
+                        // SAFETY: The entities in the archetype must be unique and there are never more than u32::MAX entities.
+                        archetype_row: unsafe {
+                            ArchetypeRow::new(NonMaxU32::new_unchecked(archetype_row as u32))
+                        },
+                        table_id: self.table_id,
+                        table_row,
+                    },
+                )
+            },
+        )
+    }
+
     /// Gets an iterator of all of the components stored in [`Table`]s.
     ///
     /// All of the IDs are unique.
@@ -569,7 +591,8 @@ impl Archetype {
         entity: Entity,
         table_row: TableRow,
     ) -> EntityLocation {
-        let archetype_row = ArchetypeRow::new(self.entities.len());
+        // SAFETY: An entity can not have multiple archetype rows and there can not be more than u32::MAX entities.
+        let archetype_row = unsafe { ArchetypeRow::new(NonMaxU32::new_unchecked(self.len())) };
         self.entities.push(ArchetypeEntity { entity, table_row });
 
         EntityLocation {
@@ -607,6 +630,8 @@ impl Archetype {
     /// Gets the total number of entities that belong to the archetype.
     #[inline]
     pub fn len(&self) -> u32 {
+        // No entity may have more than one archetype row, so there are no duplicates,
+        // and there may only ever be u32::MAX entities, so the length never exceeds u32's cappacity.
         self.entities.len() as u32
     }
 

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -606,8 +606,8 @@ impl Archetype {
 
     /// Gets the total number of entities that belong to the archetype.
     #[inline]
-    pub fn len(&self) -> usize {
-        self.entities.len()
+    pub fn len(&self) -> u32 {
+        self.entities.len() as u32
     }
 
     /// Checks if the archetype has any entities.

--- a/crates/bevy_ecs/src/batching.rs
+++ b/crates/bevy_ecs/src/batching.rs
@@ -22,7 +22,7 @@ use core::ops::Range;
 /// [`EventReader::par_read`]: crate::event::EventReader::par_read
 #[derive(Clone, Debug)]
 pub struct BatchingStrategy {
-    /// The upper and lower limits for a batch of entities.
+    /// The upper and lower limits for a batch of items.
     ///
     /// Setting the bounds to the same value will result in a fixed
     /// batch size.

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -518,7 +518,7 @@ unsafe impl ReadOnlyQueryData for EntityLocation {}
 ///         match spawn_details.spawned_by().into_option() {
 ///             Some(location) => println!(" by {:?}", location),
 ///             None => println!()
-///         }    
+///         }
 ///     }
 /// }
 ///
@@ -1617,11 +1617,15 @@ unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
     ) {
         let column = table.get_column(component_id).debug_checked_unwrap();
         let table_data = Some((
-            column.get_data_slice(table.entity_count()).into(),
-            column.get_added_ticks_slice(table.entity_count()).into(),
-            column.get_changed_ticks_slice(table.entity_count()).into(),
+            column.get_data_slice(table.entity_count() as usize).into(),
             column
-                .get_changed_by_slice(table.entity_count())
+                .get_added_ticks_slice(table.entity_count() as usize)
+                .into(),
+            column
+                .get_changed_ticks_slice(table.entity_count() as usize)
+                .into(),
+            column
+                .get_changed_by_slice(table.entity_count() as usize)
                 .map(Into::into),
         ));
         // SAFETY: set_table is only called when T::STORAGE_TYPE = StorageType::Table
@@ -1812,11 +1816,15 @@ unsafe impl<'__w, T: Component> WorldQuery for &'__w mut T {
     ) {
         let column = table.get_column(component_id).debug_checked_unwrap();
         let table_data = Some((
-            column.get_data_slice(table.entity_count()).into(),
-            column.get_added_ticks_slice(table.entity_count()).into(),
-            column.get_changed_ticks_slice(table.entity_count()).into(),
+            column.get_data_slice(table.entity_count() as usize).into(),
             column
-                .get_changed_by_slice(table.entity_count())
+                .get_added_ticks_slice(table.entity_count() as usize)
+                .into(),
+            column
+                .get_changed_ticks_slice(table.entity_count() as usize)
+                .into(),
+            column
+                .get_changed_by_slice(table.entity_count() as usize)
                 .map(Into::into),
         ));
         // SAFETY: set_table is only called when T::STORAGE_TYPE = StorageType::Table

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -19,6 +19,7 @@ use core::{
     mem::MaybeUninit,
     ops::Range,
 };
+use nonmax::NonMaxU32;
 
 /// An [`Iterator`] over query results of a [`Query`](crate::system::Query).
 ///
@@ -136,7 +137,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIter<'w, 's, D, F> {
         mut accum: B,
         func: &mut Func,
         storage: StorageId,
-        range: Option<Range<usize>>,
+        range: Option<Range<u32>>,
     ) -> B
     where
         Func: FnMut(B, D::Item<'w>) -> B,
@@ -199,7 +200,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIter<'w, 's, D, F> {
         mut accum: B,
         func: &mut Func,
         table: &'w Table,
-        rows: Range<usize>,
+        rows: Range<u32>,
     ) -> B
     where
         Func: FnMut(B, D::Item<'w>) -> B,
@@ -207,10 +208,6 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIter<'w, 's, D, F> {
         if table.is_empty() {
             return accum;
         }
-        debug_assert!(
-            rows.end <= u32::MAX as usize,
-            "TableRow is only valid up to u32::MAX"
-        );
 
         D::set_table(&mut self.cursor.fetch, &self.query_state.fetch_state, table);
         F::set_table(
@@ -222,8 +219,9 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIter<'w, 's, D, F> {
         let entities = table.entities();
         for row in rows {
             // SAFETY: Caller assures `row` in range of the current archetype.
-            let entity = unsafe { entities.get_unchecked(row) };
-            let row = TableRow::from_usize(row);
+            let entity = unsafe { entities.get_unchecked(row as usize) };
+            // SAFETY: This is from an exclusive range, so it can't be max.
+            let row = unsafe { TableRow::from_u32(NonMaxU32::new_unchecked(row)) };
 
             // SAFETY: set_table was called prior.
             // Caller assures `row` in range of the current archetype.
@@ -254,7 +252,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIter<'w, 's, D, F> {
         mut accum: B,
         func: &mut Func,
         archetype: &'w Archetype,
-        indices: Range<usize>,
+        indices: Range<u32>,
     ) -> B
     where
         Func: FnMut(B, D::Item<'w>) -> B,
@@ -279,7 +277,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIter<'w, 's, D, F> {
         let entities = archetype.entities();
         for index in indices {
             // SAFETY: Caller assures `index` in range of the current archetype.
-            let archetype_entity = unsafe { entities.get_unchecked(index) };
+            let archetype_entity = unsafe { entities.get_unchecked(index as usize) };
 
             // SAFETY: set_archetype was called prior.
             // Caller assures `index` in range of the current archetype.
@@ -323,7 +321,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIter<'w, 's, D, F> {
         mut accum: B,
         func: &mut Func,
         archetype: &'w Archetype,
-        rows: Range<usize>,
+        rows: Range<u32>,
     ) -> B
     where
         Func: FnMut(B, D::Item<'w>) -> B,
@@ -331,10 +329,6 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIter<'w, 's, D, F> {
         if archetype.is_empty() {
             return accum;
         }
-        debug_assert!(
-            rows.end <= u32::MAX as usize,
-            "TableRow is only valid up to u32::MAX"
-        );
         let table = self.tables.get(archetype.table_id()).debug_checked_unwrap();
         debug_assert!(
             archetype.len() == table.entity_count(),
@@ -356,8 +350,9 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIter<'w, 's, D, F> {
         let entities = table.entities();
         for row in rows {
             // SAFETY: Caller assures `row` in range of the current archetype.
-            let entity = unsafe { *entities.get_unchecked(row) };
-            let row = TableRow::from_usize(row);
+            let entity = unsafe { *entities.get_unchecked(row as usize) };
+            // SAFETY: This is from an exclusive range, so it can't be max.
+            let row = unsafe { TableRow::from_u32(NonMaxU32::new_unchecked(row)) };
 
             // SAFETY: set_table was called prior.
             // Caller assures `row` in range of the current archetype.
@@ -895,7 +890,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Iterator for QueryIter<'w, 's, D, F> 
         let max_size = self.cursor.max_remaining(self.tables, self.archetypes);
         let archetype_query = F::IS_ARCHETYPAL;
         let min_size = if archetype_query { max_size } else { 0 };
-        (min_size, Some(max_size))
+        (min_size as usize, Some(max_size as usize))
     }
 
     #[inline]
@@ -2275,7 +2270,7 @@ impl<'w, 's, D: ReadOnlyQueryData, F: QueryFilter, const K: usize> Iterator
             .enumerate()
             .try_fold(0, |acc, (i, cursor)| {
                 let n = cursor.max_remaining(self.tables, self.archetypes);
-                Some(acc + choose(n, K - i)?)
+                Some(acc + choose(n as usize, K - i)?)
             });
 
         let archetype_query = F::IS_ARCHETYPAL;
@@ -2317,9 +2312,9 @@ struct QueryIterationCursor<'w, 's, D: QueryData, F: QueryFilter> {
     fetch: D::Fetch<'w>,
     filter: F::Fetch<'w>,
     // length of the table or length of the archetype, depending on whether both `D`'s and `F`'s fetches are dense
-    current_len: usize,
+    current_len: u32,
     // either table row or archetype index, depending on whether both `D`'s and `F`'s fetches are dense
-    current_row: usize,
+    current_row: u32,
 }
 
 impl<D: QueryData, F: QueryFilter> Clone for QueryIterationCursor<'_, '_, D, F> {
@@ -2400,7 +2395,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIterationCursor<'w, 's, D, F> {
             let index = self.current_row - 1;
             if self.is_dense {
                 // SAFETY: This must have been called previously in `next` as `current_row > 0`
-                let entity = unsafe { self.table_entities.get_unchecked(index) };
+                let entity = unsafe { self.table_entities.get_unchecked(index as usize) };
                 // SAFETY:
                 //  - `set_table` must have been called previously either in `next` or before it.
                 //  - `*entity` and `index` are in the current table.
@@ -2408,12 +2403,14 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIterationCursor<'w, 's, D, F> {
                     Some(D::fetch(
                         &mut self.fetch,
                         *entity,
-                        TableRow::from_usize(index),
+                        // SAFETY: This is from an exclusive range, so it can't be max.
+                        TableRow::from_u32(NonMaxU32::new_unchecked(index)),
                     ))
                 }
             } else {
                 // SAFETY: This must have been called previously in `next` as `current_row > 0`
-                let archetype_entity = unsafe { self.archetype_entities.get_unchecked(index) };
+                let archetype_entity =
+                    unsafe { self.archetype_entities.get_unchecked(index as usize) };
                 // SAFETY:
                 //  - `set_archetype` must have been called previously either in `next` or before it.
                 //  - `archetype_entity.id()` and `archetype_entity.table_row()` are in the current archetype.
@@ -2434,9 +2431,9 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIterationCursor<'w, 's, D, F> {
     ///
     /// Note that if `F::IS_ARCHETYPAL`, the return value
     /// will be **the exact count of remaining values**.
-    fn max_remaining(&self, tables: &'w Tables, archetypes: &'w Archetypes) -> usize {
+    fn max_remaining(&self, tables: &'w Tables, archetypes: &'w Archetypes) -> u32 {
         let ids = self.storage_id_iter.clone();
-        let remaining_matched: usize = if self.is_dense {
+        let remaining_matched: u32 = if self.is_dense {
             // SAFETY: The if check ensures that storage_id_iter stores TableIds
             unsafe { ids.map(|id| tables[id.table_id].entity_count()).sum() }
         } else {
@@ -2483,8 +2480,10 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIterationCursor<'w, 's, D, F> {
 
                 // SAFETY: set_table was called prior.
                 // `current_row` is a table row in range of the current table, because if it was not, then the above would have been executed.
-                let entity = unsafe { self.table_entities.get_unchecked(self.current_row) };
-                let row = TableRow::from_usize(self.current_row);
+                let entity =
+                    unsafe { self.table_entities.get_unchecked(self.current_row as usize) };
+                // SAFETY: The row is less than the u32 len, so it must not be max.
+                let row = unsafe { TableRow::from_u32(NonMaxU32::new_unchecked(self.current_row)) };
                 if !F::filter_fetch(&mut self.filter, *entity, row) {
                     self.current_row += 1;
                     continue;
@@ -2532,8 +2531,10 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIterationCursor<'w, 's, D, F> {
 
                 // SAFETY: set_archetype was called prior.
                 // `current_row` is an archetype index row in range of the current archetype, because if it was not, then the if above would have been executed.
-                let archetype_entity =
-                    unsafe { self.archetype_entities.get_unchecked(self.current_row) };
+                let archetype_entity = unsafe {
+                    self.archetype_entities
+                        .get_unchecked(self.current_row as usize)
+                };
                 if !F::filter_fetch(
                     &mut self.filter,
                     archetype_entity.id(),

--- a/crates/bevy_ecs/src/query/par_iter.rs
+++ b/crates/bevy_ecs/src/query/par_iter.rs
@@ -62,7 +62,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryParIter<'w, 's, D, F> {
     ///     query.par_iter().for_each_init(|| queue.borrow_local_mut(),|local_queue, item| {
     ///         **local_queue += 1;
     ///      });
-    ///     
+    ///
     ///     // collect value from every thread
     ///     let entity_count: usize = queue.iter_mut().map(|v| *v).sum();
     /// }
@@ -130,7 +130,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryParIter<'w, 's, D, F> {
     }
 
     #[cfg(all(not(target_arch = "wasm32"), feature = "multi_threaded"))]
-    fn get_batch_size(&self, thread_count: usize) -> usize {
+    fn get_batch_size(&self, thread_count: usize) -> u32 {
         let max_items = || {
             let id_iter = self.state.matched_storage_ids.iter();
             if self.state.is_dense {
@@ -147,10 +147,11 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryParIter<'w, 's, D, F> {
                     .map(|id| unsafe { archetypes[id.archetype_id].len() })
                     .max()
             }
+            .map(|v| v as usize)
             .unwrap_or(0)
         };
         self.batching_strategy
-            .calc_batch_size(max_items, thread_count)
+            .calc_batch_size(max_items, thread_count) as u32
     }
 }
 
@@ -232,7 +233,7 @@ impl<'w, 's, D: ReadOnlyQueryData, F: QueryFilter, E: EntityEquivalent + Sync>
     ///     query.par_iter_many(&entities).for_each_init(|| queue.borrow_local_mut(),|local_queue, item| {
     ///         **local_queue += some_expensive_operation(item);
     ///     });
-    ///     
+    ///
     ///     // collect value from every thread
     ///     let final_value: usize = queue.iter_mut().map(|v| *v).sum();
     /// }
@@ -301,9 +302,9 @@ impl<'w, 's, D: ReadOnlyQueryData, F: QueryFilter, E: EntityEquivalent + Sync>
     }
 
     #[cfg(all(not(target_arch = "wasm32"), feature = "multi_threaded"))]
-    fn get_batch_size(&self, thread_count: usize) -> usize {
+    fn get_batch_size(&self, thread_count: usize) -> u32 {
         self.batching_strategy
-            .calc_batch_size(|| self.entity_list.len(), thread_count)
+            .calc_batch_size(|| self.entity_list.len(), thread_count) as u32
     }
 }
 
@@ -387,7 +388,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter, E: EntityEquivalent + Sync>
     ///     query.par_iter_many_unique(&entities).for_each_init(|| queue.borrow_local_mut(),|local_queue, item| {
     ///         **local_queue += some_expensive_operation(item);
     ///     });
-    ///     
+    ///
     ///     // collect value from every thread
     ///     let final_value: usize = queue.iter_mut().map(|v| *v).sum();
     /// }
@@ -456,8 +457,8 @@ impl<'w, 's, D: QueryData, F: QueryFilter, E: EntityEquivalent + Sync>
     }
 
     #[cfg(all(not(target_arch = "wasm32"), feature = "multi_threaded"))]
-    fn get_batch_size(&self, thread_count: usize) -> usize {
+    fn get_batch_size(&self, thread_count: usize) -> u32 {
         self.batching_strategy
-            .calc_batch_size(|| self.entity_list.len(), thread_count)
+            .calc_batch_size(|| self.entity_list.len(), thread_count) as u32
     }
 }

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -1502,7 +1502,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
         &self,
         init_accum: INIT,
         world: UnsafeWorldCell<'w>,
-        batch_size: usize,
+        batch_size: u32,
         func: FN,
         last_run: Tick,
         this_run: Tick,
@@ -1545,7 +1545,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
 
             // submit single storage larger than batch_size
             let submit_single = |count, storage_id: StorageId| {
-                for offset in (0..count).step_by(batch_size) {
+                for offset in (0..count).step_by(batch_size as usize) {
                     let mut func = func.clone();
                     let init_accum = init_accum.clone();
                     let len = batch_size.min(count - offset);
@@ -1561,7 +1561,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
                 }
             };
 
-            let storage_entity_count = |storage_id: StorageId| -> usize {
+            let storage_entity_count = |storage_id: StorageId| -> u32 {
                 if self.is_dense {
                     tables[storage_id.table_id].entity_count()
                 } else {
@@ -1617,7 +1617,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
         init_accum: INIT,
         world: UnsafeWorldCell<'w>,
         entity_list: &UniqueEntityEquivalentSlice<E>,
-        batch_size: usize,
+        batch_size: u32,
         mut func: FN,
         last_run: Tick,
         this_run: Tick,
@@ -1631,7 +1631,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
         // QueryState::par_many_fold_init_unchecked_manual, QueryState::par_many_unique_fold_init_unchecked_manual
 
         bevy_tasks::ComputeTaskPool::get().scope(|scope| {
-            let chunks = entity_list.chunks_exact(batch_size);
+            let chunks = entity_list.chunks_exact(batch_size as usize);
             let remainder = chunks.remainder();
 
             for batch in chunks {
@@ -1680,7 +1680,7 @@ impl<D: ReadOnlyQueryData, F: QueryFilter> QueryState<D, F> {
         init_accum: INIT,
         world: UnsafeWorldCell<'w>,
         entity_list: &[E],
-        batch_size: usize,
+        batch_size: u32,
         mut func: FN,
         last_run: Tick,
         this_run: Tick,
@@ -1694,7 +1694,7 @@ impl<D: ReadOnlyQueryData, F: QueryFilter> QueryState<D, F> {
         // QueryState::par_many_fold_init_unchecked_manual, QueryState::par_many_unique_fold_init_unchecked_manual
 
         bevy_tasks::ComputeTaskPool::get().scope(|scope| {
-            let chunks = entity_list.chunks_exact(batch_size);
+            let chunks = entity_list.chunks_exact(batch_size as usize);
             let remainder = chunks.remainder();
 
             for batch in chunks {

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -31,7 +31,7 @@ pub use identifier::WorldId;
 pub use spawn_batch::*;
 
 use crate::{
-    archetype::{ArchetypeId, ArchetypeRow, Archetypes},
+    archetype::{ArchetypeId, Archetypes},
     bundle::{
         Bundle, BundleEffect, BundleInfo, BundleInserter, BundleSpawner, Bundles, InsertMode,
         NoBundleEffect,
@@ -959,18 +959,8 @@ impl World {
     pub fn iter_entities(&self) -> impl Iterator<Item = EntityRef<'_>> + '_ {
         self.archetypes.iter().flat_map(|archetype| {
             archetype
-                .entities()
-                .iter()
-                .enumerate()
-                .map(|(archetype_row, archetype_entity)| {
-                    let entity = archetype_entity.id();
-                    let location = EntityLocation {
-                        archetype_id: archetype.id(),
-                        archetype_row: ArchetypeRow::new(archetype_row),
-                        table_id: archetype.table_id(),
-                        table_row: archetype_entity.table_row(),
-                    };
-
+                .entities_with_location()
+                .map(|(entity, location)| {
                     // SAFETY: entity exists and location accurately specifies the archetype where the entity is stored.
                     let cell = UnsafeEntityCell::new(
                         self.as_unsafe_world_cell_readonly(),
@@ -992,18 +982,8 @@ impl World {
         let world_cell = self.as_unsafe_world_cell();
         world_cell.archetypes().iter().flat_map(move |archetype| {
             archetype
-                .entities()
-                .iter()
-                .enumerate()
-                .map(move |(archetype_row, archetype_entity)| {
-                    let entity = archetype_entity.id();
-                    let location = EntityLocation {
-                        archetype_id: archetype.id(),
-                        archetype_row: ArchetypeRow::new(archetype_row),
-                        table_id: archetype.table_id(),
-                        table_row: archetype_entity.table_row(),
-                    };
-
+                .entities_with_location()
+                .map(move |(entity, location)| {
                     // SAFETY: entity exists and location accurately specifies the archetype where the entity is stored.
                     let cell = UnsafeEntityCell::new(
                         world_cell,


### PR DESCRIPTION
# Objective

Since #18704  is done, we can track the length of unique entity row collections with only a `u32` and identify an index within that collection with only a `NonMaxU32`. This leaves an opportunity for performance improvements.

## Solution

- Use `EntityRow` in sparse sets.
- Change table, entity, and query lengths to be `u32` instead of `usize`.
- Keep `batching` module `usize` based since that is reused for events, which may exceed `u32::MAX`.
- Change according `Range<usize>` to `Range<u32>`. This is more efficient and helps justify safety.
- Change `ArchetypeRow` and `TableRow` to wrap `NonMaxU32` instead of `u32`.
- TODO: Write a migration guide. I'll get to this latter today probably.

Justifying `NonMaxU32::new_unchecked` everywhere is predicated on this safety comment in `Entities::set`: "`location` must be valid for the entity at `index` or immediately made valid afterwards before handing control to unknown code." This ensures no entity is in two table rows for example. That fact is used to argue uniqueness of the entity rows in each table, archetype, sparse set, query, etc. So if there's no duplicates, and a maximum total entities of `u32::MAX` none of the corresponding row ids / indexes can exceed `NonMaxU32`.

## Testing

CI
