### PR TITLE
Move away from std::Path in bevy_assets

### DIFF
--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -63,7 +63,6 @@ uuid = { version = "1.13.1", default-features = false, features = [
   "serde",
 ] }
 tracing = { version = "0.1", default-features = false }
-itertools = { version = "0.14.0", default-features = false }
 
 [target.'cfg(target_os = "android")'.dependencies]
 bevy_window = { path = "../bevy_window", version = "0.16.0-dev" }

--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -63,6 +63,7 @@ uuid = { version = "1.13.1", default-features = false, features = [
   "serde",
 ] }
 tracing = { version = "0.1", default-features = false }
+itertools = { version = "0.14.0", default-features = false }
 
 [target.'cfg(target_os = "android")'.dependencies]
 bevy_window = { path = "../bevy_window", version = "0.16.0-dev" }

--- a/crates/bevy_asset/src/io/embedded/embedded_watcher.rs
+++ b/crates/bevy_asset/src/io/embedded/embedded_watcher.rs
@@ -3,7 +3,7 @@ use crate::io::{
     memory::Dir,
     AssetSourceEvent, AssetWatcher,
 };
-use alloc::{boxed::Box, sync::Arc, vec::Vec};
+use alloc::{boxed::Box, string::ToString, sync::Arc, vec::Vec};
 use bevy_platform::collections::HashMap;
 use core::time::Duration;
 use notify_debouncer_full::{notify::RecommendedWatcher, Debouncer, RecommendedCache};
@@ -40,7 +40,9 @@ impl EmbeddedWatcher {
             last_event: None,
         };
         let watcher = new_asset_event_debouncer(
-            root.to_string_lossy().to_string(),
+            root.to_str()
+                .expect("non unicode characters found in path")
+                .to_string(),
             debounce_wait_time,
             handler,
         )

--- a/crates/bevy_asset/src/io/embedded/embedded_watcher.rs
+++ b/crates/bevy_asset/src/io/embedded/embedded_watcher.rs
@@ -41,7 +41,7 @@ impl EmbeddedWatcher {
         };
         let watcher = new_asset_event_debouncer(
             root.to_str()
-                .expect("non unicode characters found in path")
+                .expect("non UTF-8 characters found in path")
                 .to_string(),
             debounce_wait_time,
             handler,

--- a/crates/bevy_asset/src/io/embedded/embedded_watcher.rs
+++ b/crates/bevy_asset/src/io/embedded/embedded_watcher.rs
@@ -39,7 +39,12 @@ impl EmbeddedWatcher {
             root_paths,
             last_event: None,
         };
-        let watcher = new_asset_event_debouncer(root, debounce_wait_time, handler).unwrap();
+        let watcher = new_asset_event_debouncer(
+            root.to_string_lossy().to_string(),
+            debounce_wait_time,
+            handler,
+        )
+        .unwrap();
         Self { _watcher: watcher }
     }
 }

--- a/crates/bevy_asset/src/io/file/file_asset.rs
+++ b/crates/bevy_asset/src/io/file/file_asset.rs
@@ -38,7 +38,7 @@ impl AssetReader for FileAssetReader {
         let full_path = self.root_path.join(path);
         File::open(&full_path).await.map_err(|e| {
             if e.kind() == std::io::ErrorKind::NotFound {
-                AssetReaderError::NotFound(full_path)
+                AssetReaderError::NotFound(full_path.to_path_buf().to_str().unwrap().to_owned())
             } else {
                 e.into()
             }
@@ -50,7 +50,7 @@ impl AssetReader for FileAssetReader {
         let full_path = self.root_path.join(meta_path);
         File::open(&full_path).await.map_err(|e| {
             if e.kind() == std::io::ErrorKind::NotFound {
-                AssetReaderError::NotFound(full_path)
+                AssetReaderError::NotFound(full_path.to_path_buf().to_str().unwrap().to_owned())
             } else {
                 e.into()
             }
@@ -92,7 +92,9 @@ impl AssetReader for FileAssetReader {
             }
             Err(e) => {
                 if e.kind() == std::io::ErrorKind::NotFound {
-                    Err(AssetReaderError::NotFound(full_path))
+                    Err(AssetReaderError::NotFound(
+                        full_path.to_path_buf().to_str().unwrap().to_owned(),
+                    ))
                 } else {
                     Err(e.into())
                 }
@@ -102,9 +104,9 @@ impl AssetReader for FileAssetReader {
 
     async fn is_directory<'a>(&'a self, path: &'a Path) -> Result<bool, AssetReaderError> {
         let full_path = self.root_path.join(path);
-        let metadata = full_path
-            .metadata()
-            .map_err(|_e| AssetReaderError::NotFound(path.to_owned()))?;
+        let metadata = full_path.metadata().map_err(|_e| {
+            AssetReaderError::NotFound(path.to_path_buf().to_str().unwrap().to_owned())
+        })?;
         Ok(metadata.file_type().is_dir())
     }
 }

--- a/crates/bevy_asset/src/io/file/sync_file_asset.rs
+++ b/crates/bevy_asset/src/io/file/sync_file_asset.rs
@@ -105,7 +105,9 @@ impl AssetReader for FileAssetReader {
             Ok(file) => Ok(FileReader(file)),
             Err(e) => {
                 if e.kind() == std::io::ErrorKind::NotFound {
-                    Err(AssetReaderError::NotFound(full_path))
+                    Err(AssetReaderError::NotFound(
+                        full_path.to_str().unwrap().to_owned(),
+                    ))
                 } else {
                     Err(e.into())
                 }
@@ -120,7 +122,9 @@ impl AssetReader for FileAssetReader {
             Ok(file) => Ok(FileReader(file)),
             Err(e) => {
                 if e.kind() == std::io::ErrorKind::NotFound {
-                    Err(AssetReaderError::NotFound(full_path))
+                    Err(AssetReaderError::NotFound(
+                        full_path.to_str().unwrap().to_owned(),
+                    ))
                 } else {
                     Err(e.into())
                 }
@@ -164,7 +168,9 @@ impl AssetReader for FileAssetReader {
             }
             Err(e) => {
                 if e.kind() == std::io::ErrorKind::NotFound {
-                    Err(AssetReaderError::NotFound(full_path))
+                    Err(AssetReaderError::NotFound(
+                        full_path.to_str().unwrap().to_owned(),
+                    ))
                 } else {
                     Err(e.into())
                 }
@@ -176,7 +182,7 @@ impl AssetReader for FileAssetReader {
         let full_path = self.root_path.join(path);
         let metadata = full_path
             .metadata()
-            .map_err(|_e| AssetReaderError::NotFound(path.to_owned()))?;
+            .map_err(|_e| AssetReaderError::NotFound(path.to_str().unwrap().to_owned()))?;
         Ok(metadata.file_type().is_dir())
     }
 }

--- a/crates/bevy_asset/src/io/memory.rs
+++ b/crates/bevy_asset/src/io/memory.rs
@@ -294,7 +294,9 @@ impl AssetReader for MemoryAssetReader {
                 data,
                 bytes_read: 0,
             })
-            .ok_or_else(|| AssetReaderError::NotFound(path.to_path_buf()))
+            .ok_or_else(|| {
+                AssetReaderError::NotFound(path.to_path_buf().to_str().unwrap().to_owned())
+            })
     }
 
     async fn read_meta<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
@@ -304,7 +306,9 @@ impl AssetReader for MemoryAssetReader {
                 data,
                 bytes_read: 0,
             })
-            .ok_or_else(|| AssetReaderError::NotFound(path.to_path_buf()))
+            .ok_or_else(|| {
+                AssetReaderError::NotFound(path.to_path_buf().to_str().unwrap().to_owned())
+            })
     }
 
     async fn read_directory<'a>(
@@ -317,7 +321,9 @@ impl AssetReader for MemoryAssetReader {
                 let stream: Box<PathStream> = Box::new(DirStream::new(dir));
                 stream
             })
-            .ok_or_else(|| AssetReaderError::NotFound(path.to_path_buf()))
+            .ok_or_else(|| {
+                AssetReaderError::NotFound(path.to_path_buf().to_str().unwrap().to_owned())
+            })
     }
 
     async fn is_directory<'a>(&'a self, path: &'a Path) -> Result<bool, AssetReaderError> {

--- a/crates/bevy_asset/src/io/mod.rs
+++ b/crates/bevy_asset/src/io/mod.rs
@@ -38,8 +38,8 @@ use thiserror::Error;
 #[derive(Error, Debug, Clone)]
 pub enum AssetReaderError {
     /// Path not found.
-    #[error("Path not found: {}", _0.display())]
-    NotFound(PathBuf),
+    #[error("Path not found: {}", _0)]
+    NotFound(alloc::string::String),
 
     /// Encountered an I/O error while loading an asset.
     #[error("Encountered an I/O error while loading asset: {0}")]

--- a/crates/bevy_asset/src/io/processor_gated.rs
+++ b/crates/bevy_asset/src/io/processor_gated.rs
@@ -43,9 +43,9 @@ impl ProcessorGatedReader {
         path: &AssetPath<'static>,
     ) -> Result<RwLockReadGuardArc<()>, AssetReaderError> {
         let infos = self.processor_data.asset_infos.read().await;
-        let info = infos.get(path).ok_or_else(|| {
-            AssetReaderError::NotFound(PathBuf::from(path.path()).to_str().unwrap().to_owned())
-        })?;
+        let info = infos
+            .get(path)
+            .ok_or_else(|| AssetReaderError::NotFound(path.internal_path().to_owned()))?;
         Ok(info.file_transaction_lock.read_arc().await)
     }
 }

--- a/crates/bevy_asset/src/io/processor_gated.rs
+++ b/crates/bevy_asset/src/io/processor_gated.rs
@@ -7,7 +7,7 @@ use alloc::{borrow::ToOwned, boxed::Box, sync::Arc, vec::Vec};
 use async_lock::RwLockReadGuardArc;
 use core::{pin::Pin, task::Poll};
 use futures_io::AsyncRead;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use tracing::trace;
 
 use super::{AsyncSeekForward, ErasedAssetReader};

--- a/crates/bevy_asset/src/io/source.rs
+++ b/crates/bevy_asset/src/io/source.rs
@@ -545,7 +545,7 @@ impl AssetSource {
                 if path.exists() {
                     Some(Box::new(
                         super::file::FileWatcher::new(
-                            path.clone(),
+                            path.to_string_lossy().to_string(),
                             sender,
                             file_debounce_wait_time,
                         )

--- a/crates/bevy_asset/src/io/source.rs
+++ b/crates/bevy_asset/src/io/source.rs
@@ -546,7 +546,7 @@ impl AssetSource {
                     Some(Box::new(
                         super::file::FileWatcher::new(
                             path.to_str()
-                                .expect("non unicode characters found in path")
+                                .expect("non UTF-8 characters found in path")
                                 .to_string(),
                             sender,
                             file_debounce_wait_time,

--- a/crates/bevy_asset/src/io/source.rs
+++ b/crates/bevy_asset/src/io/source.rs
@@ -545,7 +545,9 @@ impl AssetSource {
                 if path.exists() {
                     Some(Box::new(
                         super::file::FileWatcher::new(
-                            path.to_string_lossy().to_string(),
+                            path.to_str()
+                                .expect("non unicode characters found in path")
+                                .to_string(),
                             sender,
                             file_debounce_wait_time,
                         )

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -357,7 +357,7 @@ impl<'a> LoadContext<'a> {
     /// # use bevy_reflect::TypePath;
     /// # #[derive(Asset, TypePath, Default)]
     /// # struct Image;
-    /// # let load_context: LoadContext = panic!();
+    /// # let mut load_context: LoadContext = panic!();
     /// let mut handles = Vec::new();
     /// for i in 0..2 {
     ///     let mut labeled = load_context.begin_labeled_asset();
@@ -459,8 +459,8 @@ impl<'a> LoadContext<'a> {
     }
 
     /// Gets the source path for this load context.
-    pub fn path(&self) -> &Path {
-        self.asset_path.path()
+    pub fn path(&self) -> &str {
+        self.asset_path.internal_path()
     }
 
     /// Gets the source asset path for this load context.

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -19,7 +19,7 @@ use core::any::{Any, TypeId};
 use downcast_rs::{impl_downcast, Downcast};
 use ron::error::SpannedError;
 use serde::{Deserialize, Serialize};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use thiserror::Error;
 
 /// Loads an [`Asset`] from a given byte [`Reader`]. This can accept [`AssetLoader::Settings`], which configure how the [`Asset`]

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -304,6 +304,10 @@ impl<'a> AssetPath<'a> {
         Path::new(self.path.as_ref())
     }
 
+    pub fn internal_path(&self) -> &str {
+        self.path.as_ref()
+    }
+
     /// Gets the path to the asset in the "virtual filesystem" without a label (if a label is currently set).
     #[inline]
     pub fn without_label(&self) -> AssetPath<'_> {
@@ -510,7 +514,14 @@ impl<'a> AssetPath<'a> {
     /// Returns the file name
     /// Ex: Returns `"a.json"` for `"a/b/c/a.json"`
     pub fn file_name(&self) -> Option<String> {
-        self.path().file_name()?.to_str().map(String::from)
+        self.path.split("/").last().map(ToString::to_string)
+    }
+
+    /// Returns a new AssetPath with the additional extension, joined by a `/`.
+    pub fn join(&self, suffix: &str) -> AssetPath<'a> {
+        let mut new_path = self.clone();
+        new_path.path = CowArc::from(alloc::format!("{new_path}/{suffix}"));
+        new_path
     }
 
     /// Returns the full extension (including multiple '.' values).

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -638,7 +638,11 @@ impl<'a> From<&'a Path> for AssetPath<'a> {
     fn from(path: &'a Path) -> Self {
         Self {
             source: AssetSourceId::Default,
-            path: CowArc::from(path.to_string_lossy().to_string()),
+            path: CowArc::from(
+                path.to_str()
+                    .expect("non unicode characters found in file path")
+                    .to_string(),
+            ),
             label: None,
         }
     }
@@ -649,7 +653,11 @@ impl From<PathBuf> for AssetPath<'static> {
     fn from(path: PathBuf) -> Self {
         Self {
             source: AssetSourceId::Default,
-            path: CowArc::from(path.to_string_lossy().to_string()),
+            path: CowArc::from(
+                path.to_str()
+                    .expect("non unicode characters found in file path")
+                    .to_string(),
+            ),
             label: None,
         }
     }
@@ -1077,5 +1085,25 @@ mod tests {
     fn test_trailing_slash_equality() {
         assert_eq!(AssetPath::from("a/b/"), AssetPath::from("a/b"));
         assert_eq!(AssetPath::from("a/b/#c"), AssetPath::from("a/b#c"));
+    }
+
+    #[test]
+    fn test_path_components() {
+        use alloc::vec;
+        use alloc::vec::Vec;
+
+        assert_eq!(
+            AssetPath::from("a/b/c")
+                .path_components()
+                .collect::<Vec<_>>(),
+            vec!["a", "b", "c"]
+        );
+
+        assert_eq!(
+            AssetPath::from("a/b/c/../d")
+                .path_components()
+                .collect::<Vec<_>>(),
+            vec!["a", "b", "c", "..", "d"]
+        );
     }
 }

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -507,12 +507,18 @@ impl<'a> AssetPath<'a> {
         }
     }
 
+    /// Returns the file name
+    /// Ex: Returns `"a.json"` for `"a/b/c/a.json"`
+    pub fn file_name(&self) -> Option<String> {
+        self.path().file_name()?.to_str().map(String::from)
+    }
+
     /// Returns the full extension (including multiple '.' values).
     /// Ex: Returns `"config.ron"` for `"my_asset.config.ron"`
     ///
     /// Also strips out anything following a `?` to handle query parameters in URIs
     pub fn get_full_extension(&self) -> Option<String> {
-        let file_name = self.path().file_name()?.to_str()?;
+        let file_name = self.file_name()?;
         let index = file_name.find('.')?;
         let mut extension = file_name[index + 1..].to_owned();
 

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -263,7 +263,7 @@ impl<'a> AssetPath<'a> {
     #[inline]
     pub fn from_path_buf(path_buf: PathBuf) -> AssetPath<'a> {
         AssetPath {
-            path: CowArc::Owned(path_buf.into()),
+            path: CowArc::Owned(path_buf.as_os_str().to_str().unwrap().into()),
             source: AssetSourceId::Default,
             label: None,
         }

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -9,9 +9,7 @@ use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize};
 use core::{
     fmt::{Debug, Display},
     hash::Hash,
-    ops::Deref,
 };
-use itertools::Itertools;
 use serde::{de::Visitor, Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use thiserror::Error;
@@ -365,7 +363,7 @@ impl<'a> AssetPath<'a> {
         if self.path.as_ref() == "/" || self.path.starts_with('#') || self.path.is_empty() {
             return None;
         }
-        let mut path: alloc::vec::Vec<_> = self.path_components().map(|s| s.to_string()).collect();
+        let mut path: Vec<_> = self.path_components().map(|s| s.to_string()).collect();
         path.pop();
         let path = path.join("/");
         Some(AssetPath {

--- a/crates/bevy_gltf/src/loader/gltf_ext/texture.rs
+++ b/crates/bevy_gltf/src/loader/gltf_ext/texture.rs
@@ -30,7 +30,7 @@ pub(crate) fn texture_handle(
             if let Ok(_data_uri) = DataUri::parse(uri) {
                 load_context.get_label_handle(texture_label(texture).to_string())
             } else {
-                let parent = load_context.path().parent().unwrap();
+                let parent = load_context.asset_path().parent().unwrap();
                 let image_path = parent.join(uri);
                 load_context.load(image_path)
             }

--- a/crates/bevy_render/src/render_resource/shader.rs
+++ b/crates/bevy_render/src/render_resource/shader.rs
@@ -341,7 +341,7 @@ impl AssetLoader for ShaderLoader {
         settings: &Self::Settings,
         load_context: &mut LoadContext<'_>,
     ) -> Result<Shader, Self::Error> {
-        let ext = load_context.path().extension().unwrap().to_str().unwrap();
+        let ext = load_context.asset_path().get_full_extension().unwrap();
         let path = load_context.asset_path().to_string();
         // On windows, the path will inconsistently use \ or /.
         // TODO: remove this once AssetPath forces cross-platform "slash" consistency. See #10511
@@ -354,8 +354,8 @@ impl AssetLoader for ShaderLoader {
                     The shader defs will be ignored."
             );
         }
-        let mut shader = match ext {
-            "spv" => Shader::from_spirv(bytes, load_context.path().to_string_lossy()),
+        let mut shader = match ext.as_str() {
+            "spv" => Shader::from_spirv(bytes, load_context.path()),
             "wgsl" => Shader::from_wgsl_with_defs(
                 String::from_utf8(bytes)?,
                 path,


### PR DESCRIPTION
# Objective


- closes #19079 

## Solution

- changes AssetPath to use `&str` internally instead of keeping a `Path`
- some external-facing methods still use either `Path` or `PathBuf`, please let me know if these should be changed as well

## Testing

- all existing tests seem to pass
- added one test for `PartialEq` implementation