### PR TITLE
fix `.insert_related` index bound

### DIFF
--- a/crates/bevy_ecs/src/hierarchy.rs
+++ b/crates/bevy_ecs/src/hierarchy.rs
@@ -614,7 +614,7 @@ mod tests {
 
         let mut entity_world_mut = world.spawn_empty();
 
-        let first_children = entity_world_mut.insert_children(0, &[child1, child2]);
+        let first_children = entity_world_mut.add_children(&[child1, child2]);
 
         let root = first_children.insert_children(1, &[child3, child4]).id();
 
@@ -628,6 +628,43 @@ mod tests {
                     Node::new(child3),
                     Node::new(child4),
                     Node::new(child2)
+                ]
+            )
+        );
+    }
+
+    // regression test for https://github.com/bevyengine/bevy/pull/19134
+    #[test]
+    fn insert_children_index_bound() {
+        let mut world = World::new();
+        let child1 = world.spawn_empty().id();
+        let child2 = world.spawn_empty().id();
+        let child3 = world.spawn_empty().id();
+        let child4 = world.spawn_empty().id();
+
+        let mut entity_world_mut = world.spawn_empty();
+
+        let first_children = entity_world_mut.add_children(&[child1, child2]).id();
+        let hierarchy = get_hierarchy(&world, first_children);
+        assert_eq!(
+            hierarchy,
+            Node::new_with(first_children, vec![Node::new(child1), Node::new(child2)])
+        );
+
+        let root = world
+            .entity_mut(first_children)
+            .insert_children(usize::MAX, &[child3, child4])
+            .id();
+        let hierarchy = get_hierarchy(&world, root);
+        assert_eq!(
+            hierarchy,
+            Node::new_with(
+                root,
+                vec![
+                    Node::new(child1),
+                    Node::new(child2),
+                    Node::new(child3),
+                    Node::new(child4),
                 ]
             )
         );

--- a/crates/bevy_ecs/src/hierarchy.rs
+++ b/crates/bevy_ecs/src/hierarchy.rs
@@ -614,7 +614,7 @@ mod tests {
 
         let mut entity_world_mut = world.spawn_empty();
 
-        let first_children = entity_world_mut.add_children(&[child1, child2]);
+        let first_children = entity_world_mut.insert_children(0, &[child1, child2]);
 
         let root = first_children.insert_children(1, &[child3, child4]).id();
 

--- a/crates/bevy_ecs/src/relationship/related_methods.rs
+++ b/crates/bevy_ecs/src/relationship/related_methods.rs
@@ -86,7 +86,7 @@ impl<'w> EntityWorldMut<'w> {
         let id = self.id();
         self.world_scope(|world| {
             for (offset, related) in related.iter().enumerate() {
-                let index = index + offset;
+                let index = index.saturating_add(offset);
                 if world
                     .get::<R>(*related)
                     .is_some_and(|relationship| relationship.get() == id)

--- a/crates/bevy_ecs/src/relationship/relationship_source_collection.rs
+++ b/crates/bevy_ecs/src/relationship/relationship_source_collection.rs
@@ -220,7 +220,7 @@ impl OrderedRelationshipSourceCollection for Vec<Entity> {
 
     fn place_most_recent(&mut self, index: usize) {
         if let Some(entity) = self.pop() {
-            let index = index.min(self.len().saturating_sub(1));
+            let index = index.min(self.len());
             self.insert(index, entity);
         }
     }
@@ -228,7 +228,7 @@ impl OrderedRelationshipSourceCollection for Vec<Entity> {
     fn place(&mut self, entity: Entity, index: usize) {
         if let Some(current) = <[Entity]>::iter(self).position(|e| *e == entity) {
             // The len is at least 1, so the subtraction is safe.
-            let index = index.min(self.len().saturating_sub(1));
+            let index = index.min(self.len());
             Vec::remove(self, current);
             self.insert(index, entity);
         };

--- a/crates/bevy_ecs/src/relationship/relationship_source_collection.rs
+++ b/crates/bevy_ecs/src/relationship/relationship_source_collection.rs
@@ -227,7 +227,6 @@ impl OrderedRelationshipSourceCollection for Vec<Entity> {
 
     fn place(&mut self, entity: Entity, index: usize) {
         if let Some(current) = <[Entity]>::iter(self).position(|e| *e == entity) {
-            // The len is at least 1, so the subtraction is safe.
             let index = index.min(self.len());
             Vec::remove(self, current);
             self.insert(index, entity);


### PR DESCRIPTION
# Objective

resolves #19092

## Solution

- remove the `.saturating_sub` from the index transformation
- add `.saturating_add` to the internal offset calculation

## Testing

- added regression test, confirming 0 index order + testing max bound