### PR TITLE
ReadOnlySystem diagnostics and type alias

### DIFF
--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -203,6 +203,10 @@ pub trait System: Send + Sync + 'static {
 ///
 /// This must only be implemented for system types which do not mutate the `World`
 /// when [`System::run_unsafe`] is called.
+#[diagnostic::on_unimplemented(
+    message = "`{Self}` is not a read-only system",
+    label = "invalid read-only system"
+)]
 pub unsafe trait ReadOnlySystem: System {
     /// Runs this system with the given input in the world.
     ///
@@ -220,6 +224,9 @@ pub unsafe trait ReadOnlySystem: System {
 
 /// A convenience type alias for a boxed [`System`] trait object.
 pub type BoxedSystem<In = (), Out = ()> = Box<dyn System<In = In, Out = Out>>;
+
+/// A convenience type alias for a boxed [`ReadOnlySystem`] trait object.
+pub type BoxedReadOnlySystem<In = (), Out = ()> = Box<dyn ReadOnlySystem<In = In, Out = Out>>;
 
 pub(crate) fn check_system_change_tick(last_run: &mut Tick, this_run: Tick, system_name: &str) {
     if last_run.check_tick(this_run) {


### PR DESCRIPTION
# Objective

- Improve usability of read-only systems.

## Solution

- Added `on_unimplemented` diagnostics for types/functions that aren't read-only systems.
- Added `BoxedReadOnlySystem` type alias, similar to `BoxedSystem`.

## Testing

Can/should we test these diagnostics?