### PR TITLE
fix windows wasm embedded assets

### DIFF
--- a/crates/bevy_asset/src/io/embedded/mod.rs
+++ b/crates/bevy_asset/src/io/embedded/mod.rs
@@ -168,6 +168,13 @@ pub fn _embedded_asset_path(
     file_path: &Path,
     asset_path: &Path,
 ) -> PathBuf {
+    let file_path = if cfg!(target_family = "wasm") {
+        // Work around bug: https://github.com/bevyengine/bevy/issues/14246
+        // Note, this will break any paths on Linux/Mac containing "\"
+        PathBuf::from(file_path.to_str().unwrap().replace("\\", "/"))
+    } else {
+        PathBuf::from(file_path)
+    };
     let mut maybe_parent = file_path.parent();
     let after_src = loop {
         let Some(parent) = maybe_parent else {

--- a/crates/bevy_asset/src/io/embedded/mod.rs
+++ b/crates/bevy_asset/src/io/embedded/mod.rs
@@ -168,7 +168,7 @@ pub fn _embedded_asset_path(
     file_path: &Path,
     asset_path: &Path,
 ) -> PathBuf {
-    let file_path = if cfg!(target_family = "wasm") {
+    let file_path = if cfg!(not(target_family = "windows")) {
         // Work around bug: https://github.com/bevyengine/bevy/issues/14246
         // Note, this will break any paths on Linux/Mac containing "\"
         PathBuf::from(file_path.to_str().unwrap().replace("\\", "/"))


### PR DESCRIPTION
# Objective

- Fix #14246

## Solution

- If building for wasm windows, add a bit of code that replaces `\\` with `/` in the `file!()` arg

## Testing

- Used MRE https://github.com/janhohenheim/asset-crash
