### PR TITLE
Added `.pop_child`, `.pop_related`, `.despawn_first_related`, `.despawn_last_related`

### DIFF
--- a/crates/bevy_ecs/src/hierarchy.rs
+++ b/crates/bevy_ecs/src/hierarchy.rs
@@ -325,6 +325,11 @@ impl<'w> EntityWorldMut<'w> {
         )
     }
 
+    /// Remove the relationship between this entity and its last child.
+    pub fn pop_child(&mut self) -> &mut Self {
+        self.pop_related::<Children>()
+    }
+
     /// Spawns the passed bundle and adds it to this entity as a child.
     ///
     /// For efficient spawning of multiple children, use [`with_children`].
@@ -374,6 +379,11 @@ impl<'a> EntityCommands<'a> {
     /// Removes the relationship between this entity and the given entities.
     pub fn remove_children(&mut self, children: &[Entity]) -> &mut Self {
         self.remove_related::<ChildOf>(children)
+    }
+
+    /// Remove the relationship between this entity and its last child.
+    pub fn pop_child(&mut self) -> &mut Self {
+        self.pop_related::<Children>()
     }
 
     /// Replaces the children on this entity with a new list of children.
@@ -650,6 +660,24 @@ mod tests {
         assert_eq!(
             hierarchy,
             Node::new_with(root, vec![Node::new(child1), Node::new(child4)])
+        );
+    }
+
+    #[test]
+    fn pop_child() {
+        let mut world = World::new();
+        let child1 = world.spawn_empty().id();
+        let child2 = world.spawn_empty().id();
+
+        let mut root = world.spawn_empty();
+        root.add_children(&[child1, child2]);
+        root.pop_child();
+        let root = root.id();
+
+        let hierarchy = get_hierarchy(&world, root);
+        assert_eq!(
+            hierarchy,
+            Node::new_with(root, vec![Node::new(child1)])
         );
     }
 


### PR DESCRIPTION
# Objective

- Remove relationship between an entity and its last child.
- Despawn last child of an entity.
- Despawn first child of an entity.

## Solution

#### Added below methods to `EntityWorldMut` and `EntityCommands`.
- `pop_child()`
- `pop_related()`
- `despawn_first_related()`
- `despawn_last_related()`

## Testing
```rust
#[test]
fn pop_child() {
    let mut world = World::new();
    let child1 = world.spawn_empty().id();
    let child2 = world.spawn_empty().id();

    let mut root = world.spawn_empty();
    root.add_children(&[child1, child2]);
    root.pop_child();
    let root = root.id();

    let hierarchy = get_hierarchy(&world, root);
    assert_eq!(
        hierarchy,
        Node::new_with(root, vec![Node::new(child1)])
    );
}

#[test]
fn test_pop_related() {
    let mut world = World::new();

    let a = world.spawn_empty().id();
    let b = world.spawn(ChildOf(a)).id();
    let c = world.spawn(ChildOf(a)).id();
    let d = world.spawn(ChildOf(a)).id();

    world.entity_mut(a).pop_related::<Children>();

    assert_eq!(world.entity(d).get::<ChildOf>(), None);
    assert!(world.entity(b).get::<ChildOf>().is_some());
    assert!(world.entity(c).get::<ChildOf>().is_some());
}

#[test]
fn test_despawn_first_and_last_related() {
    let mut world = World::new();

    let a = world.spawn_empty().id();
    let b = world.spawn(ChildOf(a)).id();
    let c = world.spawn(ChildOf(a)).id();
    let d = world.spawn(ChildOf(a)).id();

    world.entity_mut(a).despawn_first_related::<Children>();
    world.entity_mut(a).despawn_last_related::<Children>();

    assert!(world.get_entity(b).is_err());
    assert!(world.get_entity(c).is_ok());
    assert!(world.get_entity(d).is_err());
}
```
