### PR TITLE
Bump accesskit to 0.19 and accesskit_winit to 0.27

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -572,7 +572,7 @@ hyper = { version = "1", features = ["server", "http1"] }
 http-body-util = "0.1"
 anyhow = "1"
 macro_rules_attribute = "0.2"
-accesskit = "0.18"
+accesskit = "0.19"
 nonmax = "0.5"
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]

--- a/crates/bevy_a11y/Cargo.toml
+++ b/crates/bevy_a11y/Cargo.toml
@@ -46,7 +46,7 @@ bevy_ecs = { path = "../bevy_ecs", version = "0.16.0-dev", default-features = fa
 bevy_reflect = { path = "../bevy_reflect", version = "0.16.0-dev", default-features = false, optional = true }
 
 # other
-accesskit = { version = "0.18", default-features = false }
+accesskit = { version = "0.19", default-features = false }
 serde = { version = "1", default-features = false, features = [
   "alloc",
 ], optional = true }

--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -41,7 +41,7 @@ thiserror = { version = "2", default-features = false }
 derive_more = { version = "1", default-features = false, features = ["from"] }
 nonmax = "0.5"
 smallvec = "1.11"
-accesskit = "0.18"
+accesskit = "0.19"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 
 [features]

--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -51,7 +51,7 @@ bevy_image = { path = "../bevy_image", version = "0.16.0-dev", optional = true }
 # other
 # feature rwh_06 refers to window_raw_handle@v0.6
 winit = { version = "0.30", default-features = false, features = ["rwh_06"] }
-accesskit_winit = { version = "0.25", default-features = false, features = [
+accesskit_winit = { version = "0.27", default-features = false, features = [
   "rwh_06",
 ] }
 approx = { version = "0.5", default-features = false }
@@ -60,7 +60,7 @@ raw-window-handle = "0.6"
 serde = { version = "1.0", features = ["derive"], optional = true }
 bytemuck = { version = "1.5", optional = true }
 wgpu-types = { version = "24", optional = true }
-accesskit = "0.18"
+accesskit = "0.19"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]


### PR DESCRIPTION
# Objective

- Update AccessKit crates to their latest versions.
- Fixes #19040 

## Solution

- Only modifying Cargo.toml files is needed, few changes under the hood but nothing impacting Bevy.

## Testing

- I ran the tab_navigation example on Windows 11.
