### PR TITLE
Updating `GlobalVolume` now updates the volume of any playing (Spatial)AudioSinks

### DIFF
--- a/crates/bevy_audio/src/audio_output.rs
+++ b/crates/bevy_audio/src/audio_output.rs
@@ -86,6 +86,37 @@ impl<'w, 's> EarPositions<'w, 's> {
     }
 }
 
+/// Iterates "active" audio and updates their volume based on their [`PlaybackSettings`] and the updated [`GlobalVolume`]
+///
+/// "Active" audio is any entity with an [`AudioSink`]/[`SpatialAudioSink`]
+///
+/// This system triggers only on [`GlobalVolume`] updates
+pub(crate) fn update_playing_audio_volume(
+    mut query_playing_audio_sinks: Query<
+        (&mut AudioSink, &PlaybackSettings),
+        (
+            Without<PlaybackDespawnMarker>,
+            Without<PlaybackRemoveMarker>,
+        ),
+    >,
+    mut query_playing_spatial_audio_sinks: Query<
+        (&mut SpatialAudioSink, &PlaybackSettings),
+        (
+            Without<PlaybackDespawnMarker>,
+            Without<PlaybackRemoveMarker>,
+        ),
+    >,
+    global_volume: Res<GlobalVolume>,
+) {
+    for (mut sink, settings) in query_playing_audio_sinks.iter_mut() {
+        sink.set_volume(settings.volume * global_volume.volume);
+    }
+
+    for (mut sink, settings) in query_playing_spatial_audio_sinks.iter_mut() {
+        sink.set_volume(settings.volume * global_volume.volume);
+    }
+}
+
 /// Plays "queued" audio through the [`AudioOutput`] resource.
 ///
 /// "Queued" audio is any audio entity (with an [`AudioPlayer`] component) that does not have an

--- a/crates/bevy_audio/src/lib.rs
+++ b/crates/bevy_audio/src/lib.rs
@@ -118,7 +118,11 @@ impl AddAudioSource for App {
     {
         self.init_asset::<T>().add_systems(
             PostUpdate,
-            (play_queued_audio_system::<T>, cleanup_finished_audio::<T>)
+            (
+                update_playing_audio_volume.run_if(resource_changed::<GlobalVolume>),
+                play_queued_audio_system::<T>,
+                cleanup_finished_audio::<T>,
+            )
                 .in_set(AudioPlaybackSystems),
         );
         self

--- a/crates/bevy_audio/src/lib.rs
+++ b/crates/bevy_audio/src/lib.rs
@@ -96,7 +96,14 @@ impl Plugin for AudioPlugin {
             )
             .add_systems(
                 PostUpdate,
-                (update_emitter_positions, update_listener_positions).in_set(AudioPlaybackSystems),
+                (
+                    update_emitter_positions,
+                    update_listener_positions,
+                    update_playing_audio_volume
+                        .run_if(resource_changed::<GlobalVolume>)
+                        .ambiguous_with_all(),
+                )
+                    .in_set(AudioPlaybackSystems),
             )
             .init_resource::<AudioOutput>();
 
@@ -118,11 +125,7 @@ impl AddAudioSource for App {
     {
         self.init_asset::<T>().add_systems(
             PostUpdate,
-            (
-                update_playing_audio_volume.run_if(resource_changed::<GlobalVolume>),
-                play_queued_audio_system::<T>,
-                cleanup_finished_audio::<T>,
-            )
+            (play_queued_audio_system::<T>, cleanup_finished_audio::<T>)
                 .in_set(AudioPlaybackSystems),
         );
         self

--- a/crates/bevy_audio/src/volume.rs
+++ b/crates/bevy_audio/src/volume.rs
@@ -3,8 +3,6 @@ use bevy_math::ops;
 use bevy_reflect::prelude::*;
 
 /// Use this [`Resource`] to control the global volume of all audio.
-///
-/// Note: Changing [`GlobalVolume`] does not affect already playing audio.
 #[derive(Resource, Debug, Default, Clone, Copy, Reflect)]
 #[reflect(Resource, Debug, Default, Clone)]
 pub struct GlobalVolume {


### PR DESCRIPTION
# Objective

Fixes #18952

## Solution

Adds a system that iterates playing audio sinks and reconfigures the volume if `GlobalVolume` changes. Volume change is based on the initial `PlaybackSettings`.

## Testing

Adjusted game_menu example to play music in the volume screen and actually made that volume slider modify `GlobalVolume`.

---

## Showcase

[output.webm](https://github.com/user-attachments/assets/e09417b0-2403-4dbb-9535-e6ecfa84a060)
