### PR TITLE
Make sure prepass notices changes in alpha mode

### DIFF
--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -983,12 +983,18 @@ pub fn specialize_prepass_material_meshes<M>(
                 AlphaMode::Blend
                 | AlphaMode::Premultiplied
                 | AlphaMode::Add
-                | AlphaMode::Multiply => continue,
+                | AlphaMode::Multiply => {
+                    // In case this material was previously in a valid alpha_mode, remove it so
+                    // that the queue system doesn't assume its cache to be valid.
+                    view_specialized_material_pipeline_cache.remove(visible_entity);
+                    continue;
+                }
             }
 
             if material.properties.reads_view_transmission_texture {
                 // No-op: Materials reading from `ViewTransmissionTexture` are not rendered in the `Opaque3d`
                 // phase, and are therefore also excluded from the prepass much like alpha-blended materials.
+                view_specialized_material_pipeline_cache.remove(visible_entity);
                 continue;
             }
 

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -984,8 +984,8 @@ pub fn specialize_prepass_material_meshes<M>(
                 | AlphaMode::Premultiplied
                 | AlphaMode::Add
                 | AlphaMode::Multiply => {
-                    // In case this material was previously in a valid alpha_mode, remove it so
-                    // that the queue system doesn't assume its cache to be valid.
+                    // In case this material was previously in a valid alpha_mode, remove it to
+                    // stop the queue system from assuming its retained cache to be valid.
                     view_specialized_material_pipeline_cache.remove(visible_entity);
                     continue;
                 }


### PR DESCRIPTION
# Objective

Fixes #19150

## Solution

Normally the `validate_cached_entity` in 
https://github.com/bevyengine/bevy/blob/86cc02dca229662bdfb371a0e5a1716560ea7baa/crates/bevy_pbr/src/prepass/mod.rs#L1109-L1126 marks unchanged entites as clean, which makes them remain in the phase.

If a material is changed to an `alpha_mode` that isn't supposed to be added to the prepass pipeline, the specialization system just `continue`s and doesn't indicate to the cache that the entity is not clean anymore.

I made these invalid entities get removed from the pipeline cache so that they are correctly not marked clean and then removed from the phase.

## Testing

Tested with the example code from the issue.
