### PR TITLE
Add `AudioSinkPlayback::position`

### DIFF
--- a/crates/bevy_audio/src/sinks.rs
+++ b/crates/bevy_audio/src/sinks.rs
@@ -46,9 +46,9 @@ pub trait AudioSinkPlayback {
     ///
     /// This takes into account any speedup or delay applied.
     ///
-    /// Example: if you [`set_speed(2.0)`](Self::set_speed) and [`get_pos()`](Self::get_pos) returns *5s*,
+    /// Example: if you [`set_speed(2.0)`](Self::set_speed) and [`position()`](Self::position) returns *5s*,
     /// then the position in the recording is *10s* from its start.
-    fn get_pos(&self) -> Duration;
+    fn position(&self) -> Duration;
 
     /// Attempts to seek to a given position in the current source.
     ///
@@ -189,7 +189,7 @@ impl AudioSinkPlayback for AudioSink {
         self.sink.play();
     }
 
-    fn get_pos(&self) -> Duration {
+    fn position(&self) -> Duration {
         self.sink.get_pos()
     }
 
@@ -293,7 +293,7 @@ impl AudioSinkPlayback for SpatialAudioSink {
         self.sink.play();
     }
 
-    fn get_pos(&self) -> Duration {
+    fn position(&self) -> Duration {
         self.sink.get_pos()
     }
 

--- a/crates/bevy_audio/src/sinks.rs
+++ b/crates/bevy_audio/src/sinks.rs
@@ -42,6 +42,14 @@ pub trait AudioSinkPlayback {
     /// No effect if not paused.
     fn play(&self);
 
+    /// Returns the position of the sound that's being played.
+    ///
+    /// This takes into account any speedup or delay applied.
+    ///
+    /// Example: if you [`set_speed(2.0)`](Self::set_speed) and [`get_pos()`](Self::get_pos) returns *5s*,
+    /// then the position in the recording is *10s* from its start.
+    fn get_pos(&self) -> Duration;
+
     /// Attempts to seek to a given position in the current source.
     ///
     /// This blocks between 0 and ~5 milliseconds.
@@ -181,6 +189,10 @@ impl AudioSinkPlayback for AudioSink {
         self.sink.play();
     }
 
+    fn get_pos(&self) -> Duration {
+        self.sink.get_pos()
+    }
+
     fn try_seek(&self, pos: Duration) -> Result<(), SeekError> {
         self.sink.try_seek(pos)
     }
@@ -279,6 +291,10 @@ impl AudioSinkPlayback for SpatialAudioSink {
 
     fn play(&self) {
         self.sink.play();
+    }
+
+    fn get_pos(&self) -> Duration {
+        self.sink.get_pos()
     }
 
     fn try_seek(&self, pos: Duration) -> Result<(), SeekError> {

--- a/examples/audio/audio_control.rs
+++ b/examples/audio/audio_control.rs
@@ -62,6 +62,9 @@ fn update_speed(music_controller: Query<&AudioSink, With<MyMusic>>, time: Res<Ti
     let Ok(sink) = music_controller.single() else {
         return;
     };
+    if sink.is_paused() {
+        return;
+    }
 
     sink.set_speed((ops::sin(time.elapsed_secs() / 5.0) + 1.0).max(0.1));
 }

--- a/examples/audio/audio_control.rs
+++ b/examples/audio/audio_control.rs
@@ -6,7 +6,10 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_systems(Startup, setup)
-        .add_systems(Update, (update_speed, pause, mute, volume))
+        .add_systems(
+            Update,
+            (update_progress_text, update_speed, pause, mute, volume),
+        )
         .run();
 }
 
@@ -14,6 +17,17 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn((
         AudioPlayer::new(asset_server.load("sounds/Windless Slopes.ogg")),
         MyMusic,
+    ));
+
+    commands.spawn((
+        Text::new(""),
+        Node {
+            position_type: PositionType::Absolute,
+            top: Val::Px(12.0),
+            left: Val::Px(12.0),
+            ..default()
+        },
+        ProgressText,
     ));
 
     // example instructions
@@ -33,6 +47,16 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
 #[derive(Component)]
 struct MyMusic;
+
+#[derive(Component)]
+struct ProgressText;
+
+fn update_progress_text(
+    music_controller: Single<&AudioSink, With<MyMusic>>,
+    mut progress_text: Single<&mut Text, With<ProgressText>>,
+) {
+    progress_text.0 = format!("Progress: {}s", music_controller.get_pos().as_secs_f32());
+}
 
 fn update_speed(music_controller: Query<&AudioSink, With<MyMusic>>, time: Res<Time>) {
     let Ok(sink) = music_controller.single() else {

--- a/examples/audio/audio_control.rs
+++ b/examples/audio/audio_control.rs
@@ -55,7 +55,7 @@ fn update_progress_text(
     music_controller: Single<&AudioSink, With<MyMusic>>,
     mut progress_text: Single<&mut Text, With<ProgressText>>,
 ) {
-    progress_text.0 = format!("Progress: {}s", music_controller.get_pos().as_secs_f32());
+    progress_text.0 = format!("Progress: {}s", music_controller.position().as_secs_f32());
 }
 
 fn update_speed(music_controller: Query<&AudioSink, With<MyMusic>>, time: Res<Time>) {


### PR DESCRIPTION
# Objective

- Allow users to get the playback position of playing audio.

## Solution

- Add a `position` method to `AudioSinkPlayback`
- Implement it for `AudioSink` and `SpatialAudioSink`

## Testing

- Updated `audio_control` example to show playback position