### PR TITLE
Fix mismatched FogFalloff

### DIFF
--- a/examples/3d/fog.rs
+++ b/examples/3d/fog.rs
@@ -180,7 +180,7 @@ fn update_system(
         } else if let FogFalloff::ExponentialSquared { .. } = fog.falloff {
             // No change
         } else {
-            fog.falloff = FogFalloff::Exponential { density: 0.07 };
+            fog.falloff = FogFalloff::ExponentialSquared { density: 0.07 };
         };
     }
 


### PR DESCRIPTION
# Objective

When user presses <kbd>3</kbd>, the falloff mode should be changed to `ExponentialSquared` as described in the instructions, but it's not in fact.

Online Example: https://bevyengine.org/examples-webgpu/3d-rendering/fog/

## Solution

Change it to `ExponentialSquared`

## Testing

- Did you test these changes? If so, how?

Yes, by `cargo run --example fog`

- Are there any parts that need more testing?

No.

- How can other people (reviewers) test your changes? Is there anything specific they need to know?

```
cargo run --example fog
```

- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?

N/A
