### PR TITLE
don't filter dragged entity out of DragEnter events

### DIFF
--- a/crates/bevy_picking/src/events.rs
+++ b/crates/bevy_picking/src/events.rs
@@ -527,11 +527,7 @@ pub fn pointer_events(
             for button in PointerButton::iter() {
                 let state = pointer_state.get_mut(pointer_id, button);
 
-                for drag_target in state
-                    .dragging
-                    .keys()
-                    .filter(|&&drag_target| hovered_entity != drag_target)
-                {
+                for drag_target in state.dragging.keys() {
                     state.dragging_over.insert(hovered_entity, hit.clone());
                     let drag_enter_event = Pointer::new(
                         pointer_id,

--- a/release-content/migration-guides/dragenter_includes_dragged_entity.md
+++ b/release-content/migration-guides/dragenter_includes_dragged_entity.md
@@ -1,0 +1,8 @@
+---
+title: DragEnter now includes the dragged entity
+pull_requests: [19179]
+---
+
+DragEnter events are now triggered when entering any entity, even the originally dragged one. This makes the behavior more consistent.
+
+The old behavior can be achieved by checking if trigger.target != trigger.dragged


### PR DESCRIPTION
## produce a DragEnter event when reentering the dragged entity

when making a piano, i want dragging across the keys to trigger the notes of each key, but currently if i drag out of a key, then back to it, this will not work since the dragged entity gets filtered out

## Solution

- make DragEnter event work whenever there's an entry. if the user wants to ignore the dragged entity they can compare `target` and `dragged`

## Testing

- tested this with a modified version of the 2d_shapes example. i added an observer to the entities: (and added mesh picking plugin)
```rust
.observe(|t: Trigger<Pointer<DragEnter>>| {
    info!("entered {}, started from {}", t.target(), t.dragged);
}
```
- i'm not sure if other things need more testing, or if this is wrong completely and breaks other things i don't know of!

---

## Showcase

before:

https://github.com/user-attachments/assets/48de606a-e44d-4ca1-ae16-d8dcef640d6e

after:

https://github.com/user-attachments/assets/b1be231f-c826-47bc-be43-c637f22e7846
