### PR TITLE
schedule build pass are not removed, only disabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["game", "engine", "gamedev", "graphics", "bevy"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/bevyengine/bevy"
 documentation = "https://docs.rs/bevy"
-rust-version = "1.85.0"
+rust-version = "1.86.0"
 
 [workspace]
 resolver = "2"

--- a/crates/bevy_ecs/src/schedule/auto_insert_apply_deferred.rs
+++ b/crates/bevy_ecs/src/schedule/auto_insert_apply_deferred.rs
@@ -65,6 +65,10 @@ impl AutoInsertApplyDeferredPass {
 impl ScheduleBuildPass for AutoInsertApplyDeferredPass {
     type EdgeOptions = IgnoreDeferred;
 
+    fn combine(&mut self, mut other: Self) {
+        self.no_sync_edges.append(&mut other.no_sync_edges);
+    }
+
     fn add_dependency(&mut self, from: NodeId, to: NodeId, options: Option<&Self::EdgeOptions>) {
         if options.is_some() {
             self.no_sync_edges.insert((from, to));

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -2117,7 +2117,7 @@ mod tests {
     struct Resource2;
 
     #[test]
-    fn disabling_auto_sync_points_keeps_disabled_edges() {
+    fn changing_auto_sync_points_to_true_keeps_originally_disabled_edges() {
         use alloc::{vec, vec::Vec};
 
         #[derive(PartialEq, Debug)]
@@ -2147,7 +2147,7 @@ mod tests {
                     ..Default::default()
                 });
             }
-            
+
             schedule.run(&mut world);
             world.remove_resource::<Log>().unwrap().0
         }
@@ -2156,11 +2156,16 @@ mod tests {
             Entry::System(1),
             Entry::System(2),
             Entry::SyncPoint(1),
-            Entry::SyncPoint(2)
+            Entry::SyncPoint(2),
         ];
 
+        // do not change anything
         assert_eq!(get_log(vec![]), expected);
+
+        // add on enabled setting
         assert_eq!(get_log(vec![true]), expected);
+
+        // disable and enable setting
         assert_eq!(get_log(vec![false, true]), expected);
     }
 


### PR DESCRIPTION
# Objective

Fixes #18790.

## Solution

Adding schedule build setting clears all configurations regarding edges ignoring deferred parameters until then:
- If the new setting has `auto_insert_apply_deferred = true` then currently the setting gets overwritten with an empty set of ignoring edges.
- If the new setting has `auto_insert_apply_deferred = false` then currently the ignoring edges are lost even when re-enabling the build pass.

The fix is that build passes are never removed or overwritten, only combined with new values or simply disabled. I think this follows the idea of #11094.

The implementing makes use of rust's `1.86` down-casting that is properly brought into the bevy code by #18984 so it might make sense to merge that one first before this PR.

## Testing

I added a new test. I am not sure if you like that it is more like 3 tests in one but I did not want to pollute the module with the types for this "single" test. But I can split it up if wanted.

## Migration Guide

I highly highly doubt anyone so far has implemented another `ScheduleBuildPass` so I did not write a migration guide yet which notes that the trait got a new method (`combine`). Still, if wanted, I can add one as well.