### PR TITLE
Diegetic UI example

### DIFF
--- a/examples/ui/render_ui_to_texture.rs
+++ b/examples/ui/render_ui_to_texture.rs
@@ -105,9 +105,11 @@ fn setup(
                     BackgroundColor(BLUE.into()),
                 ))
                 .observe(
-                    |pointer: Trigger<Pointer<Drag>>, mut nodes: Query<(&mut Node,&ComputedNode)>| {
+                    |pointer: Trigger<Pointer<Drag>>,
+                     mut nodes: Query<(&mut Node, &ComputedNode)>| {
                         let (mut node, computed) = nodes.get_mut(pointer.target()).unwrap();
-                        node.left = Val::Px(pointer.pointer_location.position.x - computed.size.x / 2.0);
+                        node.left =
+                            Val::Px(pointer.pointer_location.position.x - computed.size.x / 2.0);
                         node.top = Val::Px(pointer.pointer_location.position.y - 50.0);
                     },
                 )
@@ -128,7 +130,7 @@ fn setup(
                             font_size: 40.0,
                             ..default()
                         },
-                        TextColor::BLACK,
+                        TextColor::WHITE,
                     ));
                 });
         });

--- a/examples/ui/render_ui_to_texture.rs
+++ b/examples/ui/render_ui_to_texture.rs
@@ -91,28 +91,23 @@ fn setup(
             UiTargetCamera(texture_camera),
         ))
         .with_children(|parent| {
-            parent.spawn((
-                Text::new("This is a cube"),
-                TextFont {
-                    font_size: 40.0,
-                    ..default()
-                },
-                TextColor::BLACK,
-            ));
             parent
                 .spawn((
                     Node {
                         position_type: PositionType::Absolute,
-                        width: Val::Px(100.),
-                        height: Val::Px(100.),
+                        width: Val::Auto,
+                        height: Val::Auto,
+                        align_items: AlignItems::Center,
+                        padding: UiRect::all(Val::Px(20.)),
                         ..default()
                     },
+                    BorderRadius::all(Val::Px(10.)),
                     BackgroundColor(BLUE.into()),
                 ))
                 .observe(
-                    |pointer: Trigger<Pointer<Drag>>, mut nodes: Query<&mut Node>| {
-                        let mut node = nodes.get_mut(pointer.target()).unwrap();
-                        node.left = Val::Px(pointer.pointer_location.position.x - 50.0);
+                    |pointer: Trigger<Pointer<Drag>>, mut nodes: Query<(&mut Node,&ComputedNode)>| {
+                        let (mut node, computed) = nodes.get_mut(pointer.target()).unwrap();
+                        node.left = Val::Px(pointer.pointer_location.position.x - computed.size.x / 2.0);
                         node.top = Val::Px(pointer.pointer_location.position.y - 50.0);
                     },
                 )
@@ -125,11 +120,21 @@ fn setup(
                     |pointer: Trigger<Pointer<Out>>, mut colors: Query<&mut BackgroundColor>| {
                         colors.get_mut(pointer.target()).unwrap().0 = BLUE.into();
                     },
-                );
+                )
+                .with_children(|parent| {
+                    parent.spawn((
+                        Text::new("Drag Me!"),
+                        TextFont {
+                            font_size: 40.0,
+                            ..default()
+                        },
+                        TextColor::BLACK,
+                    ));
+                });
         });
 
     let cube_size = 4.0;
-    let cube_handle = meshes.add(Torus::new(cube_size / 2.0, cube_size));
+    let cube_handle = meshes.add(Cuboid::new(cube_size, cube_size, cube_size));
 
     // This material has the texture that has been rendered.
     let material_handle = materials.add(StandardMaterial {

--- a/examples/ui/render_ui_to_texture.rs
+++ b/examples/ui/render_ui_to_texture.rs
@@ -2,29 +2,25 @@
 
 use std::f32::consts::PI;
 
-use bevy::color::palettes::css::BLUE;
-use bevy::input::ButtonState;
-use bevy::picking::pointer::PointerAction;
-use bevy::window::{WindowEvent, WindowRef};
 use bevy::{
-    color::{palettes::css::GOLD, palettes::css::RED},
+    asset::uuid::Uuid,
+    color::palettes::css::{BLUE, GOLD, RED},
+    input::ButtonState,
     picking::{
         backend::ray::RayMap,
-        pointer::{Location, PointerId, PointerLocation},
+        pointer::{Location, PointerAction, PointerId, PointerInput},
         PickSet,
     },
     prelude::*,
     render::{
         camera::{ManualTextureViews, RenderTarget},
+        mesh::Indices,
         mesh::VertexAttributeValues,
         render_asset::RenderAssetUsages,
         render_resource::{Extent3d, TextureDimension, TextureFormat, TextureUsages},
     },
-    window::PrimaryWindow,
+    window::{PrimaryWindow, WindowEvent},
 };
-use bevy_asset::uuid::Uuid;
-use bevy_internal::picking::pointer::PointerInput;
-use bevy_render::mesh::Indices;
 
 const CUBE_POINTER_ID: PointerId = PointerId::Custom(Uuid::from_u128(90870987));
 


### PR DESCRIPTION
https://github.com/user-attachments/assets/e7b428b9-4705-4d0a-8322-c7a80994b1a4

This is not meant to be merged as-is, I just didn't want this to get lost.

This demonstrates general-purpose world-space picking. This is not limited to bevy_ui, it works with any render target and any picking backend, e.g. this could be a viewport/portal in 3d space, it could be a custom UI system, bevy_egui, sprites, etc, etc.

Because this uses UV coordinates, it also works with anything that can be mapped to a surface, so you can display UIs on curved surfaces, etc.

https://github.com/user-attachments/assets/2926a5a1-16c9-4179-85fa-83a69fd55a96

