### PR TITLE
Move trigger_screenshots to finish()

### DIFF
--- a/crates/bevy_render/src/view/window/screenshot.rs
+++ b/crates/bevy_render/src/view/window/screenshot.rs
@@ -403,7 +403,6 @@ impl Plugin for ScreenshotPlugin {
                 .after(event_update_system)
                 .before(ApplyDeferred),
         )
-        .add_systems(Update, trigger_screenshots)
         .register_type::<Screenshot>()
         .register_type::<ScreenshotCaptured>();
 
@@ -417,7 +416,8 @@ impl Plugin for ScreenshotPlugin {
 
     fn finish(&self, app: &mut bevy_app::App) {
         let (tx, rx) = std::sync::mpsc::channel();
-        app.insert_resource(CapturedScreenshots(Arc::new(Mutex::new(rx))));
+        app.add_systems(Update, trigger_screenshots)
+            .insert_resource(CapturedScreenshots(Arc::new(Mutex::new(rx))));
 
         if let Some(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app


### PR DESCRIPTION
# Objective

- The tigger_screenshots system gets added in `.build()` but relies on a resource that is only inserted in `.finish()`
- This isn't a bug for most users, but when doing headless mode testing it can technically work without ever calling `.finish()` and did work before bevy 0.15 but while migrating my work codebase I had an issue of test failing because of this

## Solution

- Move the trigger_screenshots system to `.finish()`

## Testing

- I ran the screenshot example and it worked as expected