### PR TITLE
Add WakeUp event to App

### DIFF
--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -148,6 +148,8 @@ impl<T: Event> Plugin for WinitPlugin<T> {
 
         app.add_plugins(AccessKitPlugin);
         app.add_plugins(cursor::CursorPlugin);
+
+        app.add_event::<WakeUp>();
     }
 }
 


### PR DESCRIPTION
# Objective

- The WakeUp event is never added to the app. If you need to use that event you currently need to add it yourself.

## Solution

- Add the WakeUp event to the App in the WinitPlugin

## Testing

- I tested the window_setting example and it compiled and worked