### PR TITLE
No schedule build pass overwrite if build settings do not change `auto_insert_apply_deferred` from `true`

### DIFF
--- a/crates/bevy_ecs/src/schedule/pass.rs
+++ b/crates/bevy_ecs/src/schedule/pass.rs
@@ -34,7 +34,7 @@ pub trait ScheduleBuildPass: Send + Sync + Debug + 'static {
 }
 
 /// Object safe version of [`ScheduleBuildPass`].
-pub(super) trait ScheduleBuildPassObj: Send + Sync + Debug + Any {
+pub(super) trait ScheduleBuildPassObj: Send + Sync + Debug {
     fn build(
         &mut self,
         world: &mut World,

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -393,22 +393,6 @@ impl Schedule {
         self.graph.passes.remove(&TypeId::of::<T>());
     }
 
-    /// Returns a reference to the build pass. Returns `None` if the build pass was never added.
-    pub fn get_build_pass<T: ScheduleBuildPass>(&self) -> Option<&T> {
-        self.graph
-            .passes
-            .get(&TypeId::of::<T>())
-            .map(|pass| (pass.as_ref() as &dyn Any).downcast_ref::<T>().unwrap())
-    }
-
-    /// Returns a mutable reference to the build pass. Returns `None` if the build pass was never added.
-    pub fn get_build_pass_mut<T: ScheduleBuildPass>(&mut self) -> Option<&mut T> {
-        self.graph
-            .passes
-            .get_mut(&TypeId::of::<T>())
-            .map(|pass| (pass.as_mut() as &mut dyn Any).downcast_mut::<T>().unwrap())
-    }
-
     /// Changes miscellaneous build settings.
     ///
     /// If [`settings.auto_insert_apply_deferred`][ScheduleBuildSettings::auto_insert_apply_deferred]
@@ -418,9 +402,10 @@ impl Schedule {
     /// not after.
     pub fn set_build_settings(&mut self, settings: ScheduleBuildSettings) -> &mut Self {
         if settings.auto_insert_apply_deferred {
-            if self
-                .get_build_pass::<passes::AutoInsertApplyDeferredPass>()
-                .is_none()
+            if !self
+                .graph
+                .passes
+                .contains_key(&TypeId::of::<passes::AutoInsertApplyDeferredPass>())
             {
                 self.add_build_pass(passes::AutoInsertApplyDeferredPass::default());
             }


### PR DESCRIPTION
# Objective

Fixes #18790.
Simpler alternative to #19195.

## Solution

As suggested by @PixelDust22, simply avoid overwriting the pass if the schedule already has auto sync points enabled.
Leave pass logic untouched.

It still is probably a bad idea to add systems/set configs before changing the build settings, but that is not important as long there are no more complex build passes.

## Testing

Added a test.
