### PR TITLE
Navigate through TabGroups in order.

### DIFF
--- a/crates/bevy_input_focus/src/tab_navigation.rs
+++ b/crates/bevy_input_focus/src/tab_navigation.rs
@@ -231,6 +231,8 @@ impl TabNavigation<'_, '_> {
                     for child in children.iter() {
                         self.gather_focusable(&mut focusable, *child);
                     }
+                    // Stable sort by tabindex
+                    focusable.sort_by_key(|(_, idx)| *idx);
                 }
             }
             _ => {
@@ -246,7 +248,11 @@ impl TabNavigation<'_, '_> {
 
                 // Search group descendants
                 tab_groups.iter().for_each(|(tg_entity, _)| {
-                    self.gather_focusable(&mut focusable, *tg_entity);
+                    // Maintain group sort order before TabIndex sort order
+                    let mut focusable_group: Vec<(Entity, TabIndex)> = Vec::new();
+                    self.gather_focusable(&mut focusable_group, *tg_entity);
+                    focusable_group.sort_by_key(|(_, idx)| *idx);
+                    focusable.append(&mut focusable_group);
                 });
             }
         }


### PR DESCRIPTION
# Objective
Fixes #19156

## Solution
There was a call to sort by `TabIndex` after iterating through all the `TabGroup`s. Simply removing that line of code made the new test case pass (navigating through `TabIndex` within different `TabGroup`s and kept everything else working as expected as far as I can tell. 

I went ahead and broke the `focusable` vec down into per-group vecs that get sorted by `TabIndex` and appended to the main vec in group sorted order to maintain the sorting that was being done before, but respecting the `TabGroup` sorting that was missing in the issue that this PR addresses.

## Testing
I added a new unit test that reproduced the issue outlined above that will run in CI. This test was failing before deleting the sort, and now both unit tests are passing. 
