### PR TITLE
Adding interaction states for headless widgets.

### DIFF
--- a/crates/bevy_picking/src/events.rs
+++ b/crates/bevy_picking/src/events.rs
@@ -30,7 +30,7 @@
 //! # Events Types
 //!
 //! The events this module defines fall into a few broad categories:
-//! + Hovering and movement: [`Over`], [`Move`], and [`Out`].
+//! + Hovered and movement: [`Over`], [`Move`], and [`Out`].
 //! + Clicking and pressing: [`Pressed`], [`Released`], and [`Click`].
 //! + Dragging and dropping: [`DragStart`], [`Drag`], [`DragEnd`], [`DragEnter`], [`DragOver`], [`DragDrop`], [`DragLeave`].
 //!

--- a/crates/bevy_picking/src/events.rs
+++ b/crates/bevy_picking/src/events.rs
@@ -30,7 +30,7 @@
 //! # Events Types
 //!
 //! The events this module defines fall into a few broad categories:
-//! + Hovered and movement: [`Over`], [`Move`], and [`Out`].
+//! + Hovering and movement: [`Over`], [`Move`], and [`Out`].
 //! + Clicking and pressing: [`Pressed`], [`Released`], and [`Click`].
 //! + Dragging and dropping: [`DragStart`], [`Drag`], [`DragEnd`], [`DragEnter`], [`DragOver`], [`DragDrop`], [`DragLeave`].
 //!

--- a/crates/bevy_picking/src/hover.rs
+++ b/crates/bevy_picking/src/hover.rs
@@ -280,8 +280,8 @@ fn merge_interaction_states(
 /// enters or leaves an entity. Users should insert this component on an entity to indicate interest
 /// in knowing about hover state changes.
 ///
-/// This is similar to the old Bevy [`Interaction`] component, except that it only tracks hover
-/// state, not button presses or other interactions.
+/// This is similar to the old Bevy [`bevy_ui::Interaction`] component, except that it only tracks
+/// hover state, not button presses or other interactions.
 ///
 /// The component's boolean value will be `true` whenever the pointer is currently hovering over the
 /// entity, or any of the entity's children. This value is guaranteed to only be mutated when the
@@ -303,12 +303,13 @@ pub fn update_hovering_states(
     mut hovers: Query<(Entity, &mut Hovering)>,
     parent_query: Query<&ChildOf>,
 ) {
+    // Don't do any work if there's no hover map.
+    let Some(hover_map) = hover_map else { return };
+
     // Don't bother collecting ancestors if there are no hovers.
     if hovers.is_empty() {
         return;
     }
-
-    let Some(hover_map) = hover_map else { return };
 
     // Set which contains the hovered for the current pointer entity and its ancestors. The capacity
     // is based on the likely tree depth of the hierarchy, which is typically greater for UI (because
@@ -316,7 +317,7 @@ pub fn update_hovering_states(
     // cases.
     let mut hover_ancestors = EntityHashSet::with_capacity(32);
     if let Some(map) = hover_map.get(&PointerId::Mouse) {
-        for (hovered_entity, _) in map.iter() {
+        for hovered_entity in map.keys() {
             hover_ancestors.insert(*hovered_entity);
             hover_ancestors.extend(parent_query.iter_ancestors(*hovered_entity));
         }

--- a/crates/bevy_picking/src/hover.rs
+++ b/crates/bevy_picking/src/hover.rs
@@ -316,10 +316,16 @@ pub fn update_hovering_states(
         return;
     }
 
-    // Set which contains the hovered for the current pointer entity and its ancestors. The capacity
-    // is based on the likely tree depth of the hierarchy, which is typically greater for UI (because
-    // of layout issues) than for 3D scenes. A depth of 32 is a reasonable upper bound for most use
-    // cases.
+    // Algorithm: for each entity having a `Hovered` component, we want to know if the current entry
+    // in the hover map is "within" (that is, in the set of descenants of) that entity. Rather than
+    // doing an expensive breadth-first traversal of children, instead start with the hovermap entry
+    // and search upwards. We can make this even cheaper by building a set of ancestors for the
+    // hovermap entry, and then testing each `Hovered` entity against that set.
+
+    // A set which contains the hovered for the current pointer entity and its ancestors. The
+    // capacity is based on the likely tree depth of the hierarchy, which is typically greater for
+    // UI (because of layout issues) than for 3D scenes. A depth of 32 is a reasonable upper bound
+    // for most use cases.
     let mut hover_ancestors = EntityHashSet::with_capacity(32);
     if let Some(map) = hover_map.get(&PointerId::Mouse) {
         for hovered_entity in map.keys() {

--- a/crates/bevy_picking/src/hover.rs
+++ b/crates/bevy_picking/src/hover.rs
@@ -286,7 +286,7 @@ fn merge_interaction_states(
 /// The component's boolean value will be `true` whenever the pointer is currently hovering over the
 /// entity, or any of the entity's children. This value is guaranteed to only be mutated when the
 /// pointer enters or leaves the entity, allowing Bevy change detection to be used efficiently.
-/// This is in constrast to the [`HoverMap`] resource, which is updated every frame.
+/// This is in contrast to the [`HoverMap`] resource, which is updated every frame.
 ///
 /// Typically, a simple hoverable entity or widget will have this component added to it. More
 /// complex widgets can have this component added to each hoverable part.

--- a/crates/bevy_picking/src/hover.rs
+++ b/crates/bevy_picking/src/hover.rs
@@ -280,7 +280,7 @@ fn merge_interaction_states(
 /// enters or leaves an entity. Users should insert this component on an entity to indicate interest
 /// in knowing about hover state changes.
 ///
-/// This is similar to the old Bevy [`bevy_ui::Interaction`] component, except that it only tracks
+/// This is similar to the old Bevy [`Interaction`] component, except that it only tracks
 /// hover state, not button presses or other interactions.
 ///
 /// The component's boolean value will be `true` whenever the pointer is currently hovering over the
@@ -296,6 +296,8 @@ fn merge_interaction_states(
 ///
 /// The computational cost of keeping the `Hovering` components up to date is relatively cheap,
 /// and linear in the number of entities that have the `Hovering` component inserted.
+///
+/// [`Interaction`]: https://docs.rs/bevy/0.15.0/bevy/prelude/enum.Interaction.html
 #[derive(Component, Copy, Clone, Default, Eq, PartialEq, Debug, Reflect)]
 #[reflect(Component, Default, PartialEq, Debug, Clone)]
 pub struct Hovering(pub bool);

--- a/crates/bevy_picking/src/hover.rs
+++ b/crates/bevy_picking/src/hover.rs
@@ -37,7 +37,7 @@ type OverMap = HashMap<PointerId, LayerMap>;
 ///
 /// Maps pointers to the entities they are hovering over.
 ///
-/// "Hovering" refers to the *hover* state, which is not the same as whether or not a picking
+/// "Hovered" refers to the *hover* state, which is not the same as whether or not a picking
 /// backend is reporting hits between a pointer and an entity. A pointer is "hovering" an entity
 /// only if the pointer is hitting the entity (as reported by a picking backend) *and* no entities
 /// between it and the pointer block interactions.
@@ -294,18 +294,18 @@ fn merge_interaction_states(
 /// Typically, a simple hoverable entity or widget will have this component added to it. More
 /// complex widgets can have this component added to each hoverable part.
 ///
-/// The computational cost of keeping the `Hovering` components up to date is relatively cheap,
-/// and linear in the number of entities that have the `Hovering` component inserted.
+/// The computational cost of keeping the `Hovered` components up to date is relatively cheap,
+/// and linear in the number of entities that have the `Hovered` component inserted.
 ///
 /// [`Interaction`]: https://docs.rs/bevy/0.15.0/bevy/prelude/enum.Interaction.html
 #[derive(Component, Copy, Clone, Default, Eq, PartialEq, Debug, Reflect)]
 #[reflect(Component, Default, PartialEq, Debug, Clone)]
-pub struct Hovering(pub bool);
+pub struct Hovered(pub bool);
 
-/// Uses [`HoverMap`] changes to update [`Hovering`] components.
+/// Uses [`HoverMap`] changes to update [`Hovered`] components.
 pub fn update_hovering_states(
     hover_map: Option<Res<HoverMap>>,
-    mut hovers: Query<(Entity, &mut Hovering)>,
+    mut hovers: Query<(Entity, &mut Hovered)>,
     parent_query: Query<&ChildOf>,
 ) {
     // Don't do any work if there's no hover map.
@@ -331,7 +331,7 @@ pub fn update_hovering_states(
     // For each hovered entity, it is considered "hovering" if it's in the set of hovered ancestors.
     for (entity, mut hoverable) in hovers.iter_mut() {
         let is_hovering = hover_ancestors.contains(&entity);
-        hoverable.set_if_neq(Hovering(is_hovering));
+        hoverable.set_if_neq(Hovered(is_hovering));
     }
 }
 
@@ -348,7 +348,7 @@ mod tests {
 
         // Setup entities
         let hovered_child = world.spawn_empty().id();
-        let hovered_entity = world.spawn(Hovering(false)).add_child(hovered_child).id();
+        let hovered_entity = world.spawn(Hovered(false)).add_child(hovered_child).id();
 
         // Setup hover map with hovered_entity hovered by mouse
         let mut hover_map = HoverMap::default();
@@ -368,8 +368,8 @@ mod tests {
         // Run the system
         assert!(world.run_system_cached(update_hovering_states).is_ok());
 
-        // Check to insure that the hovered entity has the Hovering component set to true
-        let hover = world.get_mut::<Hovering>(hovered_entity).unwrap();
+        // Check to insure that the hovered entity has the Hovered component set to true
+        let hover = world.get_mut::<Hovered>(hovered_entity).unwrap();
         assert!(hover.0);
         assert!(hover.is_changed());
 
@@ -377,7 +377,7 @@ mod tests {
         world.increment_change_tick();
 
         assert!(world.run_system_cached(update_hovering_states).is_ok());
-        let hover = world.get_mut::<Hovering>(hovered_entity).unwrap();
+        let hover = world.get_mut::<Hovered>(hovered_entity).unwrap();
         assert!(hover.0);
 
         // Should not be changed
@@ -389,7 +389,7 @@ mod tests {
         world.increment_change_tick();
 
         assert!(world.run_system_cached(update_hovering_states).is_ok());
-        let hover = world.get_mut::<Hovering>(hovered_entity).unwrap();
+        let hover = world.get_mut::<Hovered>(hovered_entity).unwrap();
         assert!(!hover.0);
         assert!(hover.is_changed());
     }

--- a/crates/bevy_picking/src/hover.rs
+++ b/crates/bevy_picking/src/hover.rs
@@ -284,9 +284,12 @@ fn merge_interaction_states(
 /// hover state, not button presses or other interactions.
 ///
 /// The component's boolean value will be `true` whenever the pointer is currently hovering over the
-/// entity, or any of the entity's children. This value is guaranteed to only be mutated when the
-/// pointer enters or leaves the entity, allowing Bevy change detection to be used efficiently.
-/// This is in contrast to the [`HoverMap`] resource, which is updated every frame.
+/// entity, or any of the entity's children. This is consistent with the behavior of the CSS
+/// `:hover` pseudo-class, which applies to the element and all of its children.
+///
+/// The contained boolean value is guaranteed to only be mutated when the pointer enters or leaves
+/// the entity, allowing Bevy change detection to be used efficiently. This is in contrast to the
+/// [`HoverMap`] resource, which is updated every frame.
 ///
 /// Typically, a simple hoverable entity or widget will have this component added to it. More
 /// complex widgets can have this component added to each hoverable part.

--- a/crates/bevy_picking/src/hover.rs
+++ b/crates/bevy_picking/src/hover.rs
@@ -37,7 +37,7 @@ type OverMap = HashMap<PointerId, LayerMap>;
 ///
 /// Maps pointers to the entities they are hovering over.
 ///
-/// "Hovered" refers to the *hover* state, which is not the same as whether or not a picking
+/// "Hovering" refers to the *hover* state, which is not the same as whether or not a picking
 /// backend is reporting hits between a pointer and an entity. A pointer is "hovering" an entity
 /// only if the pointer is hitting the entity (as reported by a picking backend) *and* no entities
 /// between it and the pointer block interactions.

--- a/crates/bevy_picking/src/hover.rs
+++ b/crates/bevy_picking/src/hover.rs
@@ -291,7 +291,7 @@ fn merge_interaction_states(
 /// Typically, a simple hoverable entity or widget will have this component added to it. More
 /// complex widgets can have this component added to each hoverable part.
 ///
-/// The computational cost of keeping the `Hovering` components up to date is relatuively cheap,
+/// The computational cost of keeping the `Hovering` components up to date is relatively cheap,
 /// and linear in the number of entities that have the `Hovering` component inserted.
 #[derive(Component, Copy, Clone, Default, Eq, PartialEq, Debug, Reflect)]
 #[reflect(Component, Default, PartialEq, Debug, Clone)]

--- a/crates/bevy_picking/src/lib.rs
+++ b/crates/bevy_picking/src/lib.rs
@@ -170,6 +170,7 @@ pub mod window;
 use bevy_app::{prelude::*, PluginGroupBuilder};
 use bevy_ecs::prelude::*;
 use bevy_reflect::prelude::*;
+use hover::update_is_hovered_direct;
 
 /// The picking prelude.
 ///
@@ -392,7 +393,7 @@ impl Plugin for PickingPlugin {
             .register_type::<Self>()
             .register_type::<Pickable>()
             .register_type::<hover::PickingInteraction>()
-            .register_type::<hover::Hovered>()
+            .register_type::<hover::IsHovered>()
             .register_type::<pointer::PointerId>()
             .register_type::<pointer::PointerLocation>()
             .register_type::<pointer::PointerPress>()
@@ -408,7 +409,7 @@ pub struct InteractionPlugin;
 impl Plugin for InteractionPlugin {
     fn build(&self, app: &mut App) {
         use events::*;
-        use hover::{generate_hovermap, update_hovering_states, update_interactions};
+        use hover::{generate_hovermap, update_interactions, update_is_hovered};
 
         app.init_resource::<hover::HoverMap>()
             .init_resource::<hover::PreviousHoverMap>()
@@ -433,7 +434,7 @@ impl Plugin for InteractionPlugin {
                 (
                     generate_hovermap,
                     update_interactions,
-                    update_hovering_states,
+                    (update_is_hovered, update_is_hovered_direct),
                     pointer_events,
                 )
                     .chain()

--- a/crates/bevy_picking/src/lib.rs
+++ b/crates/bevy_picking/src/lib.rs
@@ -392,7 +392,7 @@ impl Plugin for PickingPlugin {
             .register_type::<Self>()
             .register_type::<Pickable>()
             .register_type::<hover::PickingInteraction>()
-            .register_type::<hover::Hovering>()
+            .register_type::<hover::Hovered>()
             .register_type::<pointer::PointerId>()
             .register_type::<pointer::PointerLocation>()
             .register_type::<pointer::PointerPress>()

--- a/crates/bevy_picking/src/lib.rs
+++ b/crates/bevy_picking/src/lib.rs
@@ -392,6 +392,7 @@ impl Plugin for PickingPlugin {
             .register_type::<Self>()
             .register_type::<Pickable>()
             .register_type::<hover::PickingInteraction>()
+            .register_type::<hover::Hovering>()
             .register_type::<pointer::PointerId>()
             .register_type::<pointer::PointerLocation>()
             .register_type::<pointer::PointerPress>()
@@ -407,7 +408,7 @@ pub struct InteractionPlugin;
 impl Plugin for InteractionPlugin {
     fn build(&self, app: &mut App) {
         use events::*;
-        use hover::{generate_hovermap, update_interactions};
+        use hover::{generate_hovermap, update_hovering_states, update_interactions};
 
         app.init_resource::<hover::HoverMap>()
             .init_resource::<hover::PreviousHoverMap>()
@@ -429,7 +430,12 @@ impl Plugin for InteractionPlugin {
             .add_event::<Pointer<Scroll>>()
             .add_systems(
                 PreUpdate,
-                (generate_hovermap, update_interactions, pointer_events)
+                (
+                    generate_hovermap,
+                    update_interactions,
+                    update_hovering_states,
+                    pointer_events,
+                )
                     .chain()
                     .in_set(PickingSystems::Hover),
             );

--- a/crates/bevy_picking/src/lib.rs
+++ b/crates/bevy_picking/src/lib.rs
@@ -170,7 +170,7 @@ pub mod window;
 use bevy_app::{prelude::*, PluginGroupBuilder};
 use bevy_ecs::prelude::*;
 use bevy_reflect::prelude::*;
-use hover::update_is_hovered_direct;
+use hover::update_is_directly_hovered;
 
 /// The picking prelude.
 ///
@@ -434,7 +434,7 @@ impl Plugin for InteractionPlugin {
                 (
                     generate_hovermap,
                     update_interactions,
-                    (update_is_hovered, update_is_hovered_direct),
+                    (update_is_hovered, update_is_directly_hovered),
                     pointer_events,
                 )
                     .chain()

--- a/crates/bevy_ui/src/interaction_states.rs
+++ b/crates/bevy_ui/src/interaction_states.rs
@@ -1,0 +1,95 @@
+/// This module contains components that are used to track the interaction state of UI widgets.
+///
+// Note to implementers: This uses a combination of both marker components and newtype components
+// containing a bool. Markers are used for one-way binding, "write-only" components
+// (like `InteractionDisabled`) that relay instructions from the user to the framework, whereas
+// newtype components are used to request state updates from the framework, which mutates the
+// content of those components on update.
+use bevy_a11y::AccessibilityNode;
+use bevy_ecs::{
+    component::{Component, HookContext},
+    entity::Entity,
+    hierarchy::ChildOf,
+    system::{Query, Res},
+    world::DeferredWorld,
+};
+use bevy_picking::{hover::HoverMap, pointer::PointerId};
+
+/// A marker component to indicate that a widget is disabled and should be "grayed out".
+/// This is used to prevent user interaction with the widget. It should not, however, prevent
+/// the widget from being updated or rendered, or from acquiring keyboard focus.
+///
+/// For apps which support a11y: if a widget (such as a slider) contains multiple entities,
+/// the `InteractionDisabled` component should be added to the root entity of the widget - the
+/// same entity that contains the `AccessibilityNode` component. This will ensure that
+/// the a11y tree is updated correctly.
+#[derive(Component, Debug, Clone, Copy)]
+#[component(on_add = on_add_disabled, on_remove = on_remove_disabled)]
+pub struct InteractionDisabled;
+
+// Hook to set the a11y "disabled" state when the widget is disabled.
+fn on_add_disabled(mut world: DeferredWorld, context: HookContext) {
+    let mut entt = world.entity_mut(context.entity);
+    if let Some(mut accessibility) = entt.get_mut::<AccessibilityNode>() {
+        accessibility.set_disabled();
+    }
+}
+
+// Hook to remove the a11y "disabled" state when the widget is enabled.
+fn on_remove_disabled(mut world: DeferredWorld, context: HookContext) {
+    let mut entt = world.entity_mut(context.entity);
+    if let Some(mut accessibility) = entt.get_mut::<AccessibilityNode>() {
+        accessibility.clear_disabled();
+    }
+}
+
+/// Component that indicates whether a button is currently pressed. This will be true while
+/// a drag action is in progress.
+#[derive(Component, Default, Debug)]
+pub struct ButtonPressed(pub bool);
+
+/// Component that indicates whether a checkbox or radio button is in a checked state.
+#[derive(Component, Default, Debug)]
+#[component(immutable, on_add = on_add_checked, on_replace = on_add_checked)]
+pub struct Checked(pub bool);
+
+// Hook to set the a11y "checked" state when the checkbox is added.
+fn on_add_checked(mut world: DeferredWorld, context: HookContext) {
+    let mut entt = world.entity_mut(context.entity);
+    let checked = entt.get::<Checked>().unwrap().0;
+    let mut accessibility = entt.get_mut::<AccessibilityNode>().unwrap();
+    accessibility.set_toggled(match checked {
+        true => accesskit::Toggled::True,
+        false => accesskit::Toggled::False,
+    });
+}
+
+/// Component which indicates that the entity is interested in knowing when the mouse is hovering
+/// over it or any of its children. Using this component lets users use regular Bevy change
+/// detection for hover enter and leave transitions instead of having to rely on observers or hooks.
+///
+/// TODO: This component and it's associated system isn't UI-specific, and could be moved to the
+/// bevy_picking crate.
+#[derive(Debug, Clone, Copy, Component, Default)]
+pub struct Hovering(pub bool);
+
+// TODO: This should be registered as a system after the hover map is updated.
+pub(crate) fn update_hover_states(
+    hover_map: Option<Res<HoverMap>>,
+    mut hovers: Query<(Entity, &mut Hovering)>,
+    parent_query: Query<&ChildOf>,
+) {
+    let Some(hover_map) = hover_map else { return };
+    let hover_set = hover_map.get(&PointerId::Mouse);
+    for (entity, mut hoverable) in hovers.iter_mut() {
+        let is_hovering = match hover_set {
+            Some(map) => map.iter().any(|(ha, _)| {
+                *ha == entity || parent_query.iter_ancestors(*ha).any(|e| e == entity)
+            }),
+            None => false,
+        };
+        if hoverable.0 != is_hovering {
+            hoverable.0 = is_hovering;
+        }
+    }
+}

--- a/crates/bevy_ui/src/interaction_states.rs
+++ b/crates/bevy_ui/src/interaction_states.rs
@@ -25,23 +25,23 @@ pub struct InteractionDisabled;
 
 // Hook to set the a11y "disabled" state when the widget is disabled.
 fn on_add_disabled(mut world: DeferredWorld, context: HookContext) {
-    let mut entt = world.entity_mut(context.entity);
-    if let Some(mut accessibility) = entt.get_mut::<AccessibilityNode>() {
+    let mut entity = world.entity_mut(context.entity);
+    if let Some(mut accessibility) = entity.get_mut::<AccessibilityNode>() {
         accessibility.set_disabled();
     }
 }
 
 // Hook to remove the a11y "disabled" state when the widget is enabled.
 fn on_remove_disabled(mut world: DeferredWorld, context: HookContext) {
-    let mut entt = world.entity_mut(context.entity);
-    if let Some(mut accessibility) = entt.get_mut::<AccessibilityNode>() {
+    let mut entity = world.entity_mut(context.entity);
+    if let Some(mut accessibility) = entity.get_mut::<AccessibilityNode>() {
         accessibility.clear_disabled();
     }
 }
 
-/// Component that indicates whether a button is currently pressed. This will be true while
-/// a drag action is in progress.
+/// Component that indicates whether a button is currently pressed.
 #[derive(Component, Default, Debug)]
+#[component(immutable)]
 pub struct ButtonPressed(pub bool);
 
 /// Component that indicates whether a checkbox or radio button is in a checked state.
@@ -51,9 +51,9 @@ pub struct Checked(pub bool);
 
 // Hook to set the a11y "checked" state when the checkbox is added.
 fn on_add_checked(mut world: DeferredWorld, context: HookContext) {
-    let mut entt = world.entity_mut(context.entity);
-    let checked = entt.get::<Checked>().unwrap().0;
-    let mut accessibility = entt.get_mut::<AccessibilityNode>().unwrap();
+    let mut entity = world.entity_mut(context.entity);
+    let checked = entity.get::<Checked>().unwrap().0;
+    let mut accessibility = entity.get_mut::<AccessibilityNode>().unwrap();
     accessibility.set_toggled(match checked {
         true => accesskit::Toggled::True,
         false => accesskit::Toggled::False,

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -36,6 +36,7 @@ mod ui_node;
 
 pub use focus::*;
 pub use geometry::*;
+pub use interaction_states::*;
 pub use layout::*;
 pub use measurement::*;
 pub use render::*;

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -10,6 +10,7 @@
 //! Spawn UI elements with [`widget::Button`], [`ImageNode`], [`Text`](prelude::Text) and [`Node`]
 //! This UI is laid out with the Flexbox and CSS Grid layout models (see <https://cssreference.io/flexbox/>)
 
+pub mod interaction_states;
 pub mod measurement;
 pub mod ui_material;
 pub mod update;

--- a/release-content/release-notes/headless-widgets.md
+++ b/release-content/release-notes/headless-widgets.md
@@ -15,11 +15,12 @@ in harmony with the game's overall visual theme. But writing new and unique widg
 skill and subtlety, particularly if we want first-class accessibility support. It's not a burden we
 want to put on the average indie developer.
 
-In the web development world, "headless" widget libraries, such as react-headless and reakit have
-become popular. These provide standardized widgets that implement all of the correct interactions and
-behavioral logic, including integration with screen readers, but which are unstyled. It's the
-responsibility of the game developer to provide the visual style and animation for the widgets,
-which can fit the overall style of their game.
+In the web development world, "headless" widget libraries, such as
+[headlessui](https://headlessui.com/) and [reakit](https://reakit.io/) have become popular. These
+provide standardized widgets that implement all of the correct interactions and behavioral logic,
+including integration with screen readers, but which are unstyled. It's the responsibility of the
+game developer to provide the visual style and animation for the widgets, which can fit the overall
+style of their game.
 
 With this release, Bevy introduces a collection of headless or "core" widgets. These are components
 which can be added to any UI Node to get widget-like behavior. The core widget set includes buttons,

--- a/release-content/release-notes/headless-widgets.md
+++ b/release-content/release-notes/headless-widgets.md
@@ -19,7 +19,7 @@ In the web development world, "headless" widget libraries, such as react-headles
 become popular. These provide standardized widgets that implement all of the correct interactions and
 behavioral logic, including integration with screen readers, but which are unstyled. It's the
 responsibility of the game developer to provide the visual style and animation for the widgets,
-which can fit the overall style of the game.
+which can fit the overall style of their game.
 
 With this release, Bevy introduces a collection of headless or "core" widgets. These are components
 which can be added to any UI Node to get widget-like behavior. The core widget set includes buttons,
@@ -40,7 +40,7 @@ These components include:
 - `Checked` is a boolean component that stores the checked state of a checkbox or radio button.
 - `ButtonPressed` is used for a button-like widget, and will be true while the button is held down.
 
-The combination of `Hovering` and `ButtonPressed` fulfils the same purpose as the old `Interaction`
+The combination of `Hovering` and `ButtonPressed` fulfills the same purpose as the old `Interaction`
 component, except that now we can also represent "roll-off" behavior (the state where you click
 on a button and then, while holding the mouse down, move the pointer out of the button's bounds).
 It also provides additional flexibility in cases where a widget has multiple hoverable parts,

--- a/release-content/release-notes/headless-widgets.md
+++ b/release-content/release-notes/headless-widgets.md
@@ -5,7 +5,7 @@ pull_requests: [19238]
 ---
 
 Bevy's `Button` and `Interaction` components have been around for a long time. Unfortunately
-these components have a numer of shortcomings, such as the fact that they don't use the new
+these components have a number of shortcomings, such as the fact that they don't use the new
 `bevy_picking` framework, or the fact that they are really only useful for creating buttons
 and not other kinds of widgets like sliders.
 

--- a/release-content/release-notes/headless-widgets.md
+++ b/release-content/release-notes/headless-widgets.md
@@ -1,0 +1,48 @@
+---
+title: Headless Widgets
+authors: ["@viridia"]
+pull_requests: [19238]
+---
+
+Bevy's `Button` and `Interaction` components have been around for a long time. Unfortunately
+these components have a numer of shortcomings, such as the fact that they don't use the new
+`bevy_picking` framework, or the fact that they are really only useful for creating buttons
+and not other kinds of widgets like sliders.
+
+As an art form, games thrive on novelty: the typical game doesn't have boring, standardize controls
+reminiscent of a productivity app, but instead will have beautiful, artistic widgets that are
+in harmony with the game's overall visual theme. But writing new and unique widgets requires
+skill and subtlety, particularly if we want first-class accessibility support. It's not a burden we
+want to put on the average indie developer.
+
+In the web development world, "headless" widget libraries, such as react-headless and reakit have
+become popular. These provide standardized widgets that implement all of the correct interactions and
+behavioral logic, including integration with screen readers, but which are unstyled. It's the
+responsibility of the game developer to provide the visual style and animation for the widgets,
+which can fit the overall style of the game.
+
+With this release, Bevy introduces a collection of headless or "core" widgets. These are components
+which can be added to any UI Node to get widget-like behavior. The core widget set includes buttons,
+sliders, scrollbars, checkboxes, radio buttons, and more. This set will likely be expanded in
+future releases.
+
+## Widget Interaction States
+
+Many of the core widgets will define supplementary ECS components that are used to store the widget's
+state, similar to how the old `Interaction` component worked, but in a way that is more flexible.
+These components include:
+
+- `InteractionDisabled` - a marker component used to indicate that a component should be
+  "grayed out" and non-interactive. Note that these disabled widgets are still visible and can
+  have keyboard focus (otherwise the user would have no way to discover them).
+- `Hovering` is a simple boolean component that allows detection of whether the widget is being
+  hovered using regular Bevy change detection.
+- `Checked` is a boolean component that stores the checked state of a checkbox or radio button.
+- `ButtonPressed` is used for a button-like widget, and will be true while the button is held down.
+
+The combination of `Hovering` and `ButtonPressed` fulfils the same purpose as the old `Interaction`
+component, except that now we can also represent "roll-off" behavior (the state where you click
+on a button and then, while holding the mouse down, move the pointer out of the button's bounds).
+It also provides additional flexibility in cases where a widget has multiple hoverable parts,
+or cases where a widget is hoverable but doesn't have a pressed state (such as a tree-view expansion
+toggle).


### PR DESCRIPTION
Part of #19236

This PR contains struct definitions for the low-level interaction states used by the headless widgets.