### PR TITLE
tab navigation example improvements

### DIFF
--- a/examples/ui/tab_navigation.rs
+++ b/examples/ui/tab_navigation.rs
@@ -90,9 +90,13 @@ fn setup(mut commands: Commands) {
         )
         .with_children(|parent| {
             for (label, tab_group, indices) in [
-                ("Tab Group 0", TabGroup::new(0), [0, 1, 2, 3]),
-                ("Tab Group 1", TabGroup::new(2), [0, 1, 2, 3]),
-                ("Tab Group 2", TabGroup::new(0), [3, 2, 1, 0]),
+                // In this group all the buttons have the same `TabIndex`, so they will be visited according to their order as children.
+                ("Tab Group 0", TabGroup::new(0), [0, 0, 0, 0]),
+                // In this group the `TabIndex`s are reversed, so the buttons will be visited in right-to-left order.
+                ("Tab Group 2", TabGroup::new(2), [3, 2, 1, 0]),
+                // In this group the orders of the indices and buttons match, so the buttons will be visited in left-to-right order.
+                ("Tab Group 1", TabGroup::new(1), [0, 1, 2, 3]),
+                // Visit the modal group's buttons in an arbitrary order.
                 ("Modal Tab Group", TabGroup::modal(), [0, 3, 1, 2]),
             ] {
                 parent.spawn(Text::new(label));

--- a/examples/ui/tab_navigation.rs
+++ b/examples/ui/tab_navigation.rs
@@ -10,7 +10,6 @@ use bevy::{
     winit::WinitSettings,
 };
 use bevy_ecs::spawn::{SpawnIter, SpawnWith};
-use smol::process::Child;
 
 fn main() {
     App::new()
@@ -75,7 +74,7 @@ fn focus_system(
     }
 }
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn setup(mut commands: Commands) {
     // ui camera
     commands.spawn(Camera2d);
     commands
@@ -109,7 +108,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 },
                 TabGroup::new(0),
                 // These buttons all have the same index, so they will be navigated according to their order as children.
-                Children::spawn(SpawnIter((0..4).map(|i| create_button(0)))),
+                Children::spawn(SpawnIter((0..4).map(|_| create_button(0)))),
             ));
 
             parent.spawn(Text::new("Tab Group 2"));
@@ -130,41 +129,36 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             ));
 
             parent.spawn(Text::new("Tab Group 1"));
-            parent
-                .spawn((
-                    Node {
-                        display: Display::Flex,
-                        flex_direction: FlexDirection::Row,
-                        column_gap: Val::Px(6.0),
-                        margin: UiRect {
-                            bottom: Val::Px(10.0),
-                            ..default()
-                        },
+            parent.spawn((
+                Node {
+                    display: Display::Flex,
+                    flex_direction: FlexDirection::Row,
+                    column_gap: Val::Px(6.0),
+                    margin: UiRect {
+                        bottom: Val::Px(10.0),
                         ..default()
                     },
-                    TabGroup::new(1),
-                ))
-                .with_children(|parent| {
-                    // The order of the `TabIndex`s matches the order of the buttons, so the buttons will be navigated in left-to-right order.
-                    Children::spawn(SpawnIter((0..4).rev().map(|i| create_button(i)))),
-                });
+                    ..default()
+                },
+                TabGroup::new(1),
+                // The order of the `TabIndex`s matches the order of the buttons, so the buttons will be navigated in left-to-right order.
+                Children::spawn(SpawnIter((0..4).map(|i| create_button(i)))),
+            ));
 
             parent.spawn(Text::new("Modal Tab Group"));
-            parent
-                .spawn((
-                    Node {
-                        display: Display::Flex,
-                        flex_direction: FlexDirection::Row,
-                        column_gap: Val::Px(6.0),
-                        ..default()
-                    },
-                    TabGroup::modal(),
-                ))
-                .with_children(|parent| {
-                    for i in [0, 3, 1, 2] {
-                        create_button(parent, &asset_server, i);
-                    }
-                });
+            parent.spawn((
+                Node {
+                    display: Display::Flex,
+                    flex_direction: FlexDirection::Row,
+                    column_gap: Val::Px(6.0),
+                    ..default()
+                },
+                TabGroup::modal(),
+                // The order of these `TabIndex`s doesn't match the order of the buttons.
+                Children::spawn(SpawnIter(
+                    [0, 3, 1, 2].into_iter().map(|i| create_button(i)),
+                )),
+            ));
         });
 }
 

--- a/examples/ui/tab_navigation.rs
+++ b/examples/ui/tab_navigation.rs
@@ -113,7 +113,6 @@ fn setup(mut commands: Commands) {
                             ..default()
                         },
                         tab_group,
-                        // The orders of the `TabIndex`s is the reverse of the order of the buttons, so the buttons will be navigated in right-to-left order.
                     ))
                     .with_children(|parent| {
                         for i in indices {
@@ -124,9 +123,7 @@ fn setup(mut commands: Commands) {
                                         width: Val::Px(200.0),
                                         height: Val::Px(65.0),
                                         border: UiRect::all(Val::Px(5.0)),
-                                        // horizontally center child text
                                         justify_content: JustifyContent::Center,
-                                        // vertically center child text
                                         align_items: AlignItems::Center,
                                         ..default()
                                     },


### PR DESCRIPTION
# Objective

Improve the tab navigation example.

## Solution

* Set the `TabIndex` values for each group to demonstrate different navigation orders.
* Label each button with its associated `TabIndex`.
* Replace the duplicated code using an iterator.