### PR TITLE
Make remove_reflect parameter names consistent between ReflectCommandExt and impl for EntityCommands

### DIFF
--- a/crates/bevy_ecs/src/reflect/entity_commands.rs
+++ b/crates/bevy_ecs/src/reflect/entity_commands.rs
@@ -102,7 +102,7 @@ pub trait ReflectCommandExt {
         component: Box<dyn PartialReflect>,
     ) -> &mut Self;
 
-    /// Removes from the entity the component or bundle with the given type name registered in [`AppTypeRegistry`].
+    /// Removes from the entity the component or bundle with the given type path registered in [`AppTypeRegistry`].
     ///
     /// If the type is a bundle, it will remove any components in that bundle regardless if the entity
     /// contains all the components.
@@ -263,7 +263,7 @@ impl<'w> EntityWorldMut<'w> {
         self
     }
 
-    /// Removes from the entity the component or bundle with the given type name registered in [`AppTypeRegistry`].
+    /// Removes from the entity the component or bundle with the given type path registered in [`AppTypeRegistry`].
     ///
     /// If the type is a bundle, it will remove any components in that bundle regardless if the entity
     /// contains all the components.

--- a/crates/bevy_ecs/src/reflect/entity_commands.rs
+++ b/crates/bevy_ecs/src/reflect/entity_commands.rs
@@ -159,12 +159,12 @@ pub trait ReflectCommandExt {
     ///         .remove_reflect(prefab.data.reflect_type_path().to_owned());
     /// }
     /// ```
-    fn remove_reflect(&mut self, component_type_name: impl Into<Cow<'static, str>>) -> &mut Self;
+    fn remove_reflect(&mut self, component_type_path: impl Into<Cow<'static, str>>) -> &mut Self;
     /// Same as [`remove_reflect`](ReflectCommandExt::remove_reflect), but using the `T` resource as type registry instead of
     /// `AppTypeRegistry`.
     fn remove_reflect_with_registry<T: Resource + AsRef<TypeRegistry>>(
         &mut self,
-        component_type_name: impl Into<Cow<'static, str>>,
+        component_type_path: impl Into<Cow<'static, str>>,
     ) -> &mut Self;
 }
 


### PR DESCRIPTION
# Objective

Fix https://github.com/bevyengine/bevy/issues/13390

## Solution

The second parameter of the remove_reflect function is called component_type_name in ReflectCommandExt but component_type_path in the implementation for EntityCommands. Use component_type_path in both places.

## Testing

None