### PR TITLE
Remove apostrophes in possessive its

### DIFF
--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -490,7 +490,7 @@ impl<'a> AssetPath<'a> {
     }
 
     /// Returns `true` if this [`AssetPath`] points to a file that is
-    /// outside of it's [`AssetSource`](crate::io::AssetSource) folder.
+    /// outside of its [`AssetSource`](crate::io::AssetSource) folder.
     ///
     /// ## Example
     /// ```

--- a/crates/bevy_audio/src/volume.rs
+++ b/crates/bevy_audio/src/volume.rs
@@ -144,7 +144,7 @@ impl Volume {
 
     /// Returns the volume in decibels as a float.
     ///
-    /// If the volume is silent / off / muted, i.e. it's underlying linear scale
+    /// If the volume is silent / off / muted, i.e. its underlying linear scale
     /// is `0.0`, this method returns negative infinity.
     pub fn to_decibels(&self) -> f32 {
         match self {

--- a/crates/bevy_ecs/examples/change_detection.rs
+++ b/crates/bevy_ecs/examples/change_detection.rs
@@ -84,7 +84,7 @@ fn print_changed_entities(
     entity_with_mutated_component: Query<(Entity, &Age), Changed<Age>>,
 ) {
     for entity in &entity_with_added_component {
-        println!("    {entity} has it's first birthday!");
+        println!("    {entity} has its first birthday!");
     }
     for (entity, value) in &entity_with_mutated_component {
         println!("    {entity} is now {value:?} frames old");

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -189,7 +189,7 @@ impl SparseSetIndex for EntityRow {
 /// This tracks different versions or generations of an [`EntityRow`].
 /// Importantly, this can wrap, meaning each generation is not necessarily unique per [`EntityRow`].
 ///
-/// This should be treated as a opaque identifier, and it's internal representation may be subject to change.
+/// This should be treated as a opaque identifier, and its internal representation may be subject to change.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Display)]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
 #[cfg_attr(feature = "bevy_reflect", reflect(opaque))]

--- a/crates/bevy_ecs/src/event/registry.rs
+++ b/crates/bevy_ecs/src/event/registry.rs
@@ -81,7 +81,7 @@ impl EventRegistry {
         }
     }
 
-    /// Removes an event from the world and it's associated [`EventRegistry`].
+    /// Removes an event from the world and its associated [`EventRegistry`].
     pub fn deregister_events<T: Event>(world: &mut World) {
         let component_id = world.init_resource::<Events<T>>();
         let mut registry = world.get_resource_or_init::<Self>();

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -315,7 +315,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIter<'w, 's, D, F> {
     /// # Safety
     ///  - all `indices` must be in `[0, archetype.len())`.
     ///  - `archetype` must match D and F
-    ///  - `archetype` must have the same length with it's table.
+    ///  - `archetype` must have the same length as its table.
     ///  - The query iteration must not be dense (i.e. `self.query_state.is_dense` must be false).
     #[inline]
     pub(super) unsafe fn fold_over_dense_archetype_range<B, Func>(
@@ -338,7 +338,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIter<'w, 's, D, F> {
         let table = self.tables.get(archetype.table_id()).debug_checked_unwrap();
         debug_assert!(
             archetype.len() == table.entity_count(),
-            "archetype and it's table must have the same length. "
+            "archetype and its table must have the same length. "
         );
 
         D::set_archetype(

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -123,7 +123,7 @@ pub trait System: Send + Sync + 'static {
     /// Validates that all parameters can be acquired and that system can run without panic.
     /// Built-in executors use this to prevent invalid systems from running.
     ///
-    /// However calling and respecting [`System::validate_param_unsafe`] or it's safe variant
+    /// However calling and respecting [`System::validate_param_unsafe`] or its safe variant
     /// is not a strict requirement, both [`System::run`] and [`System::run_unsafe`]
     /// should provide their own safety mechanism to prevent undefined behavior.
     ///

--- a/crates/bevy_state/src/state/sub_states.rs
+++ b/crates/bevy_state/src/state/sub_states.rs
@@ -7,7 +7,7 @@ pub use bevy_state_macros::SubStates;
 /// but unlike [`ComputedStates`](crate::state::ComputedStates) - while they exist they can be manually modified.
 ///
 /// The default approach to creating [`SubStates`] is using the derive macro, and defining a single source state
-/// and value to determine it's existence.
+/// and value to determine its existence.
 ///
 /// ```
 /// # use bevy_ecs::prelude::*;

--- a/crates/bevy_text/src/glyph.rs
+++ b/crates/bevy_text/src/glyph.rs
@@ -23,7 +23,7 @@ pub struct PositionedGlyph {
     pub span_index: usize,
     /// The index of the glyph's line.
     pub line_index: usize,
-    /// The byte index of the glyph in it's line.
+    /// The byte index of the glyph in its line.
     pub byte_index: usize,
     /// The byte length of the glyph.
     pub byte_length: usize,

--- a/crates/bevy_utils/src/parallel_queue.rs
+++ b/crates/bevy_utils/src/parallel_queue.rs
@@ -34,7 +34,7 @@ impl<T: Default + Send> Parallel<T> {
 
     /// Mutably borrows the thread-local value.
     ///
-    /// If there is no thread-local value, it will be initialized to it's default.
+    /// If there is no thread-local value, it will be initialized to its default.
     pub fn borrow_local_mut(&self) -> impl DerefMut<Target = T> + '_ {
         self.locals.get_or_default().borrow_mut()
     }

--- a/examples/app/log_layers_ecs.rs
+++ b/examples/app/log_layers_ecs.rs
@@ -59,7 +59,7 @@ fn transfer_log_events(
 }
 
 /// This is the [`Layer`] that we will use to capture log events and then send them to Bevy's
-/// ECS via it's [`mpsc::Sender`].
+/// ECS via its [`mpsc::Sender`].
 struct CaptureLayer {
     sender: mpsc::Sender<LogEvent>,
 }

--- a/examples/state/computed_states.rs
+++ b/examples/state/computed_states.rs
@@ -7,7 +7,7 @@
 //! - We can also toggle "Turbo Mode" with the `T` key - where the movement and color changes are all faster. This
 //!   is retained between pauses, but not if we exit to the main menu.
 //!
-//! In addition, we want to enable a "tutorial" mode, which will involve it's own state that is toggled in the main menu.
+//! In addition, we want to enable a "tutorial" mode, which will involve its own state that is toggled in the main menu.
 //! This will display instructions about movement and turbo mode when in game and unpaused, and instructions on how to unpause when paused.
 //!
 //! To implement this, we will create 2 root-level states: [`AppState`] and [`TutorialState`].


### PR DESCRIPTION
# Objective

Fix some grammatical errors: it's -> its

Not the most useful commit in the world, but I saw a couple of these and decided to fix the lot.

## Solution
-

## Testing
-