### PR TITLE
Allow not emitting `BundleFromComponents` with `Bundle` derive macro

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -30,6 +30,7 @@ enum BundleFieldKind {
 
 const BUNDLE_ATTRIBUTE_NAME: &str = "bundle";
 const BUNDLE_ATTRIBUTE_IGNORE_NAME: &str = "ignore";
+const BUNDLE_ATTRIBUTE_NO_EXTRACT: &str = "no_extract";
 
 #[derive(Debug, PartialEq)]
 enum BundleFlag {
@@ -44,9 +45,9 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
     let mut attributes: Vec<BundleFlag> = vec![];
 
     for attr in &ast.attrs {
-        if attr.path().is_ident("bundle") {
+        if attr.path().is_ident(BUNDLE_ATTRIBUTE_NAME) {
             let parsing = attr.parse_nested_meta(|meta| {
-                if meta.path.is_ident("no_extract") {
+                if meta.path.is_ident(BUNDLE_ATTRIBUTE_NO_EXTRACT) {
                     attributes.push(BundleFlag::NoExtract);
                     return Ok(());
                 }

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -2092,6 +2092,26 @@ mod tests {
         }
     }
 
+    #[derive(Bundle)]
+    #[bundle(no_extract)]
+    struct BundleNoExtract {
+        b: B,
+        no_from_comp: crate::spawn::SpawnRelatedBundle<ChildOf, Spawn<C>>,
+    }
+
+    #[test]
+    fn can_spawn_bundle_without_extract() {
+        let mut world = World::new();
+        let id = world
+            .spawn(BundleNoExtract {
+                b: B,
+                no_from_comp: Children::spawn(Spawn(C)),
+            })
+            .id();
+
+        assert!(world.entity(id).get::<Children>().is_some());
+    }
+
     #[test]
     fn component_hook_order_spawn_despawn() {
         let mut world = World::new();

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -30,7 +30,10 @@
 /// ```
 ///
 /// Some fields may be bundles that do not implement
-/// [`BundleFromComponents`]. In those cases you can either ignore it as above,
+/// [`BundleFromComponents`]. This happens for bundles that cannot be extracted.
+/// For example with [`SpawnRelatedBundle`](bevy_ecs::spawn::SpawnRelatedBundle), see below for an
+/// example usage.
+/// In those cases you can either ignore it as above,
 /// or you can opt out the whole Struct by marking it as ignored with
 /// `#[bundle(ignore_from_components)]`.
 ///

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -2,6 +2,54 @@
 //!
 //! This module contains the [`Bundle`] trait and some other helper types.
 
+/// Derive the [`Bundle`] trait
+///
+/// You can apply this derive macro to structs that are
+/// composed of [`Component`]s or
+/// other [`Bundle`]s.
+///
+/// ## Attributes
+///
+/// Sometimes parts of the Bundle should not be inserted.
+/// Those can be marked with `#[bundle(ignore)]`, and they will be skipped.
+/// In that case, the field needs to implement [`Default`] unless you also ignore
+/// the [`BundleFromComponents`] implementation.
+///
+/// ```rust
+/// # use bevy_ecs::prelude::{Component, Bundle};
+/// # #[derive(Component)]
+/// # struct Hitpoint;
+/// #
+/// #[derive(Bundle)]
+/// struct HitpointMarker {
+///     hitpoints: Hitpoint,
+///
+///     #[bundle(ignore)]
+///     creator: Option<String>
+/// }
+/// ```
+///
+/// Some fields may be bundles that do not implement
+/// [`BundleFromComponents`]. In those cases you can either ignore it as above,
+/// or you can opt out the whole Struct by marking it as ignored with
+/// `#[bundle(ignore_from_components)]`.
+///
+/// ```rust
+/// # use bevy_ecs::prelude::{Component, Bundle, ChildOf, Spawn};
+/// # #[derive(Component)]
+/// # struct Hitpoint;
+/// # #[derive(Component)]
+/// # struct Marker;
+/// #
+/// use bevy_ecs::spawn::SpawnRelatedBundle;
+///
+/// #[derive(Bundle)]
+/// #[bundle(ignore_from_components)]
+/// struct HitpointMarker {
+///     hitpoints: Hitpoint,
+///     related_spawner: SpawnRelatedBundle<ChildOf, Spawn<Marker>>,
+/// }
+/// ```
 pub use bevy_ecs_macros::Bundle;
 
 use crate::{

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -2093,7 +2093,7 @@ mod tests {
     }
 
     #[derive(Bundle)]
-    #[bundle(no_extract)]
+    #[bundle(ignore_from_components)]
     struct BundleNoExtract {
         b: B,
         no_from_comp: crate::spawn::SpawnRelatedBundle<ChildOf, Spawn<C>>,


### PR DESCRIPTION
# Objective

Fixes #19136

## Solution

- Add a new container attribute which when set does not emit `BundleFromComponents`

## Testing

- Did you test these changes?

Yes, a new test was added.

- Are there any parts that need more testing?

Since `BundleFromComponents` is unsafe I made extra sure that I did not misunderstand its purpose. As far as I can tell, _not_ implementing it is ok.

- How can other people (reviewers) test your changes? Is there anything specific they need to know?

Nope

- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?

I don't think the platform is relevant

---



One thing I am not sure about is how to document this? I'll gladly add it
