### PR TITLE
Clarify Resource change detection behaviour in condition docs

### DIFF
--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -605,12 +605,11 @@ pub mod common_conditions {
     }
 
     /// A [`Condition`]-satisfying system that returns `true`
-    /// if the resource of the given type has had its value changed since the condition
-    /// was last checked.
+    /// if the resource of the given type has been added or mutably dereferenced
+    /// since the condition was last checked.
     ///
-    /// The value is considered changed when it is added. The first time this condition
-    /// is checked after the resource was added, it will return `true`.
-    /// Change detection behaves like this everywhere in Bevy.
+    /// **Note** that simply *mutably dereferencing* a resource is considered a change ([`DerefMut`](std::ops::DerefMut)).
+    /// Bevy does not compare resources to their previous values.
     ///
     /// # Panics
     ///
@@ -659,14 +658,11 @@ pub mod common_conditions {
     }
 
     /// A [`Condition`]-satisfying system that returns `true`
-    /// if the resource of the given type has had its value changed since the condition
+    /// if the resource of the given type has been added or mutably dereferenced since the condition
     /// was last checked.
     ///
-    /// The value is considered changed when it is added. The first time this condition
-    /// is checked after the resource was added, it will return `true`.
-    /// Change detection behaves like this everywhere in Bevy.
-    ///
-    /// This run condition does not detect when the resource is removed.
+    /// **Note** that simply *mutably dereferencing* a resource is considered a change ([`DerefMut`](std::ops::DerefMut)).
+    /// Bevy does not compare resources to their previous values.
     ///
     /// The condition will return `false` if the resource does not exist.
     ///
@@ -719,15 +715,11 @@ pub mod common_conditions {
     }
 
     /// A [`Condition`]-satisfying system that returns `true`
-    /// if the resource of the given type has had its value changed since the condition
+    /// if the resource of the given type has been added, removed or mutably dereferenced since the condition
     /// was last checked.
     ///
-    /// The value is considered changed when it is added. The first time this condition
-    /// is checked after the resource was added, it will return `true`.
-    /// Change detection behaves like this everywhere in Bevy.
-    ///
-    /// This run condition also detects removal. It will return `true` if the resource
-    /// has been removed since the run condition was last checked.
+    /// **Note** that simply *mutably dereferencing* a resource is considered a change ([`DerefMut`](std::ops::DerefMut)).
+    /// Bevy does not compare resources to their previous values.
     ///
     /// The condition will return `false` if the resource does not exist.
     ///


### PR DESCRIPTION
# Objective

Fixes https://github.com/bevyengine/bevy/issues/17933

## Solution

Correct "value has changed'" in docs to "value has been added or mutably dereferenced", with a note for emphasis copied from the docs for Changed.

## Testing

-