### PR TITLE
Pin nightly to 14.5. due to Miri issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
   CARGO_PROFILE_TEST_DEBUG: 0
   CARGO_PROFILE_DEV_DEBUG: 0
   # If nightly is breaking CI, modify this variable to target a specific nightly version.
-  NIGHTLY_TOOLCHAIN: nightly-2025-05-16 # pinned until a fix for https://github.com/rust-lang/miri/issues/4323 is released
+  NIGHTLY_TOOLCHAIN: nightly-2025-05-14 # pinned until a fix for https://github.com/rust-lang/miri/issues/4323 is released
   RUSTFLAGS: "-D warnings"
   BINSTALL_VERSION: "v1.12.3"
 


### PR DESCRIPTION
After #19253, Miri kept failing in our pipeline. This PR goes one version further back.

See [failed run](https://github.com/bevyengine/bevy/actions/runs/15085289600/job/42407063057) on 16.5. and [green run](https://github.com/bevyengine/bevy/actions/runs/15085807284/job/42408195500) on 14.5. (no nightly on 15.5.).

Miri issue: rust-lang/miri#4325 