### PR TITLE
Add boilerplate docs for PointerHits::new and HitData::new

### DIFF
--- a/crates/bevy_picking/src/backend.rs
+++ b/crates/bevy_picking/src/backend.rs
@@ -84,7 +84,7 @@ pub struct PointerHits {
 }
 
 impl PointerHits {
-    #[expect(missing_docs, reason = "Not all docs are written yet, see #3492.")]
+    /// Construct a [`PointerHits`].
     pub fn new(pointer: prelude::PointerId, picks: Vec<(Entity, HitData)>, order: f32) -> Self {
         Self {
             pointer,
@@ -114,7 +114,7 @@ pub struct HitData {
 }
 
 impl HitData {
-    #[expect(missing_docs, reason = "Not all docs are written yet, see #3492.")]
+    /// Construct a [`HitData`].
     pub fn new(camera: Entity, depth: f32, position: Option<Vec3>, normal: Option<Vec3>) -> Self {
         Self {
             camera,

--- a/crates/bevy_picking/src/backend.rs
+++ b/crates/bevy_picking/src/backend.rs
@@ -84,7 +84,7 @@ pub struct PointerHits {
 }
 
 impl PointerHits {
-    /// Construct a [`PointerHits`].
+    /// Construct [`PointerHits`].
     pub fn new(pointer: prelude::PointerId, picks: Vec<(Entity, HitData)>, order: f32) -> Self {
         Self {
             pointer,


### PR DESCRIPTION
# Objective

Add documentation for the last two functions in bevy_picking that are missing them.

## Solution

Add boilerplate "Constructs an X" to `PointerHits::new()` and `HitData::new()`.

This form of no-information documentation of `new()` functions is used in several places in the repo, and @alice-i-cecile agreed that this is a reasonable approach - the params are already documented on the fields within the struct definition.