### PR TITLE
New selection wheel example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4371,5 +4371,5 @@ crate-type = ["lib"]
 [package.metadata.example.selection_wheel]
 name = "Selection Wheel"
 description = "Example selection wheel input menu"
-category = "Helpers"
+category = "Usage"
 wasm = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4366,7 +4366,6 @@ wasm = false
 name = "selection_wheel"
 path = "examples/usage/selection_wheel.rs"
 doc-scrape-examples = true
-crate-type = ["lib"]
 
 [package.metadata.example.selection_wheel]
 name = "Selection Wheel"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4361,3 +4361,15 @@ name = "Extended Bindless Material"
 description = "Demonstrates bindless `ExtendedMaterial`"
 category = "Shaders"
 wasm = false
+
+[[example]]
+name = "selection_wheel"
+path = "examples/usage/selection_wheel.rs"
+doc-scrape-examples = true
+crate-type = ["lib"]
+
+[package.metadata.example.selection_wheel]
+name = "Selection Wheel"
+description = "Example selection wheel input menu"
+category = "Helpers"
+wasm = true

--- a/examples/README.md
+++ b/examples/README.md
@@ -366,6 +366,7 @@ Example | Description
 Example | Description
 --- | ---
 [Camera Controller](../examples/helpers/camera_controller.rs) | Example Free-Cam Styled Camera Controller
+[Selection Wheel](../examples/usage/selection_wheel.rs) | Example selection wheel input menu
 [Widgets](../examples/helpers/widgets.rs) | Example UI Widgets
 
 ## Input

--- a/examples/README.md
+++ b/examples/README.md
@@ -67,6 +67,7 @@ git checkout v0.4.0
   - [Tools](#tools)
   - [Transforms](#transforms)
   - [UI (User Interface)](#ui-user-interface)
+  - [Usage](#usage)
   - [Window](#window)
 
 - [Tests](#tests)
@@ -366,7 +367,6 @@ Example | Description
 Example | Description
 --- | ---
 [Camera Controller](../examples/helpers/camera_controller.rs) | Example Free-Cam Styled Camera Controller
-[Selection Wheel](../examples/usage/selection_wheel.rs) | Example selection wheel input menu
 [Widgets](../examples/helpers/widgets.rs) | Example UI Widgets
 
 ## Input
@@ -571,6 +571,12 @@ Example | Description
 [Viewport Debug](../examples/ui/viewport_debug.rs) | An example for debugging viewport coordinates
 [Viewport Node](../examples/ui/viewport_node.rs) | Demonstrates how to create a viewport node with picking support
 [Window Fallthrough](../examples/ui/window_fallthrough.rs) | Illustrates how to access `winit::window::Window`'s `hittest` functionality.
+
+## Usage
+
+Example | Description
+--- | ---
+[Selection Wheel](../examples/usage/selection_wheel.rs) | Example selection wheel input menu
 
 ## Window
 

--- a/examples/usage/selection_wheel.rs
+++ b/examples/usage/selection_wheel.rs
@@ -12,21 +12,6 @@ use bevy::{
     prelude::*,
 };
 
-const NUM_BUTTONS: usize = 8;
-
-#[derive(Resource, Default)]
-struct WheelSelected {
-    selected: Option<Entity>,
-}
-
-#[derive(Component)]
-struct WheelButton {
-    label: String,
-}
-
-#[derive(Component)]
-struct WheelCenter;
-
 fn main() {
     App::new()
         .add_plugins((
@@ -47,6 +32,21 @@ fn main() {
         )
         .run();
 }
+
+const NUM_BUTTONS: usize = 8;
+
+#[derive(Resource, Default)]
+struct WheelSelected {
+    selected: Option<Entity>,
+}
+
+#[derive(Component)]
+struct WheelButton {
+    label: String,
+}
+
+#[derive(Component)]
+struct WheelCenter;
 
 fn setup(
     mut commands: Commands,

--- a/examples/usage/selection_wheel.rs
+++ b/examples/usage/selection_wheel.rs
@@ -134,7 +134,7 @@ fn update_selected_system(
 
         // Update button styling
         for (entity, _, children) in query_buttons.iter() {
-            let child = children.get(0).unwrap();
+            let child = children.first().unwrap();
             let color = if Some(entity) == selected.selected {
                 Color::BLACK
             } else {

--- a/examples/usage/selection_wheel.rs
+++ b/examples/usage/selection_wheel.rs
@@ -225,7 +225,7 @@ fn gamepad_system(
         let x = gamepad.get(GamepadAxis::LeftStickX).unwrap();
         let y = gamepad.get(GamepadAxis::LeftStickY).unwrap();
         if x.abs() + y.abs() > 0.1 {
-            // TODO: set focus based on angle
+            // TODO: set focus based on angle, I don't have a gamepad to test this
         }
     }
 }

--- a/examples/usages/selection_wheel.rs
+++ b/examples/usages/selection_wheel.rs
@@ -1,0 +1,250 @@
+//! Radial selection wheel example
+//!
+//! This example demonstrates a selection wheel with styling and as many different input methods as possible.
+use std::f32::consts::{PI, TAU};
+
+use bevy::{
+    input::{keyboard::KeyboardInput, ButtonState},
+    input_focus::{
+        tab_navigation::{NavAction, TabGroup, TabIndex, TabNavigation, TabNavigationPlugin},
+        InputDispatchPlugin, InputFocus,
+    },
+    prelude::*,
+};
+
+const NUM_BUTTONS: usize = 8;
+
+#[derive(Resource, Default)]
+struct WheelSelected {
+    selected: Option<Entity>,
+}
+
+#[derive(Component)]
+struct WheelButton {
+    label: String,
+}
+
+#[derive(Component)]
+struct WheelCenter;
+
+fn main() {
+    App::new()
+        .add_plugins((
+            DefaultPlugins,
+            MeshPickingPlugin,
+            InputDispatchPlugin,
+            TabNavigationPlugin,
+        ))
+        .init_resource::<WheelSelected>()
+        .add_systems(Startup, setup)
+        .add_systems(
+            Update,
+            (
+                (keyboard_system, gamepad_system, focus_system),
+                update_selected_system,
+            )
+                .chain(),
+        )
+        .run();
+}
+
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+) {
+    commands.spawn(Camera2d);
+
+    // TODO: This could use a ring segment primitive: https://github.com/bevyengine/bevy/issues/10572
+    // TODO: This should be a UI node instead of a Mesh2d with MeshPicking, which requires custom UI meshes or primitives: https://github.com/bevyengine/bevy/issues/14187
+    let button_mesh = meshes.add(CircularSector::new(200.0, PI / NUM_BUTTONS as f32));
+
+    let tab_group = commands
+        .spawn((
+            Transform::default(),
+            TabGroup::default(),
+            Visibility::default(),
+        ))
+        .id();
+
+    for i in 0..NUM_BUTTONS {
+        let percent = i as f32 / NUM_BUTTONS as f32;
+        let color = Color::hsl(360.0 * percent, 0.95, 0.7);
+        let button_material = materials.add(color);
+        let angle = -percent * TAU;
+        let rotation = Quat::from_rotation_z(angle);
+        let transform = Transform::from_rotation(rotation);
+
+        commands
+            .spawn((
+                ChildOf(tab_group),
+                WheelButton {
+                    label: format!("{i}"),
+                },
+                Mesh2d(button_mesh.clone()),
+                MeshMaterial2d(button_material),
+                TabIndex(i as i32),
+                transform,
+                children![(
+                    Transform::default()
+                        .with_translation(Vec3::new(0.0, 150.0, 0.0))
+                        .with_rotation(Quat::from_rotation_z(-angle)),
+                    Text2d::new(format!("{i}")),
+                )],
+            ))
+            .observe(on_click)
+            .observe(on_hover);
+    }
+
+    commands.spawn((
+        WheelCenter,
+        Pickable::IGNORE,
+        Mesh2d(meshes.add(Circle::new(100.0))),
+        MeshMaterial2d(materials.add(Color::BLACK)),
+        Transform::from_translation(Vec3::new(0.0, 0.0, 1.0)),
+        Text2d::new(""),
+    ));
+}
+
+fn on_click(trigger: Trigger<Pointer<Click>>, mut selected: ResMut<WheelSelected>) {
+    selected.selected = Some(trigger.target);
+}
+
+// TODO: add/remove styling on focus change, needs some way of reacting to focus lost?
+fn on_hover(trigger: Trigger<Pointer<Over>>, mut focus: ResMut<InputFocus>) {
+    focus.set(trigger.target);
+}
+
+/// Updates the wheel when the selected button changes
+fn update_selected_system(
+    mut query_center: Query<&mut Text2d, With<WheelCenter>>,
+    query_buttons: Query<(Entity, &WheelButton, &Children)>,
+    mut commands: Commands,
+    selected: Res<WheelSelected>,
+) -> Result {
+    if selected.is_changed() {
+        // Update center text
+        let mut text = query_center.single_mut()?;
+        if let Some(selected) = selected.selected {
+            let (_, button, _) = query_buttons.get(selected)?;
+            text.0 = button.label.clone();
+        } else {
+            text.0 = "".to_string();
+        }
+
+        // Update button styling
+        for (entity, _, children) in query_buttons.iter() {
+            let child = children.get(0).unwrap();
+            let color = if Some(entity) == selected.selected {
+                Color::BLACK
+            } else {
+                Color::WHITE
+            };
+            commands.entity(*child).insert(TextColor(color));
+        }
+    }
+
+    Ok(())
+}
+
+/// Update styling when the focus changes
+fn focus_system(
+    focus: Res<InputFocus>,
+    mut query: Query<(Entity, &mut Transform), With<WheelButton>>,
+) {
+    if focus.is_changed() {
+        for (entity, mut transform) in query.iter_mut() {
+            if Some(entity) == focus.0 {
+                transform.scale = Vec3::splat(1.2);
+            } else {
+                transform.scale = Vec3::splat(1.0);
+            }
+        }
+    }
+}
+
+/// Handle all keyboard input for the selection wheel
+///
+/// Keyboard inputs:
+/// - Left/right arrow keys to cycle focus through buttons
+/// - Number keys to select a button
+/// - Enter to select the focused button
+/// - Escape to clear selection
+/// - Tab to cycle focus through buttons (handled by the input focus system)
+/// - Shift+Tab to cycle focus through buttons in reverse (handled by the input focus system)
+fn keyboard_system(
+    mut keyboard_input_events: EventReader<KeyboardInput>,
+    mut focus: ResMut<InputFocus>,
+    tab_navigation: TabNavigation,
+    button_query: Query<(Entity, &TabIndex), With<WheelButton>>,
+    mut selected: ResMut<WheelSelected>,
+) {
+    for event in keyboard_input_events.read() {
+        if event.state == ButtonState::Pressed {
+            match event.key_code {
+                KeyCode::Escape => selected.selected = None,
+                KeyCode::Enter => {
+                    if let Some(entity) = focus.0 {
+                        if button_query.get(entity).is_ok() {
+                            selected.selected = Some(entity);
+                        }
+                    }
+                }
+                KeyCode::ArrowLeft => {
+                    if let Ok(entity) = tab_navigation.navigate(&focus, NavAction::Previous) {
+                        focus.set(entity);
+                    }
+                }
+                KeyCode::ArrowRight => {
+                    if let Ok(entity) = tab_navigation.navigate(&focus, NavAction::Next) {
+                        focus.set(entity);
+                    }
+                }
+                _ => (),
+            }
+
+            if let Some(digit) = as_digit(event.key_code) {
+                if let Some(entity) = button_query
+                    .iter()
+                    .find(|(_, TabIndex(n))| *n == digit)
+                    .map(|(entity, _)| entity)
+                {
+                    selected.selected = Some(entity);
+                }
+            }
+        }
+    }
+}
+
+fn gamepad_system(
+    gamepads: Query<&Gamepad>,
+    mut _focus: ResMut<InputFocus>,
+    _button_query: Query<Entity, With<WheelButton>>,
+) {
+    for gamepad in gamepads.iter() {
+        let x = gamepad.get(GamepadAxis::LeftStickX).unwrap();
+        let y = gamepad.get(GamepadAxis::LeftStickY).unwrap();
+        if x.abs() + y.abs() > 0.1 {
+            // TODO: set focus based on angle
+        }
+    }
+}
+
+// TODO: upstream this?
+fn as_digit(keycode: KeyCode) -> Option<i32> {
+    let digit = match keycode {
+        KeyCode::Digit0 | KeyCode::Numpad0 => 0,
+        KeyCode::Digit1 | KeyCode::Numpad1 => 1,
+        KeyCode::Digit2 | KeyCode::Numpad2 => 2,
+        KeyCode::Digit3 | KeyCode::Numpad3 => 3,
+        KeyCode::Digit4 | KeyCode::Numpad4 => 4,
+        KeyCode::Digit5 | KeyCode::Numpad5 => 5,
+        KeyCode::Digit6 | KeyCode::Numpad6 => 6,
+        KeyCode::Digit7 | KeyCode::Numpad7 => 7,
+        KeyCode::Digit8 | KeyCode::Numpad8 => 8,
+        KeyCode::Digit9 | KeyCode::Numpad9 => 9,
+        _ => return None,
+    };
+
+    Some(digit)
+}


### PR DESCRIPTION
# Objective

We want to extend our examples with a new category "usage" to demonstrate common use cases (see https://github.com/bevyengine/bevy-website/pull/2131). This PR adds an example of a radial selection wheel with support for accessibility and many different input types. 

## Solution

- New example in the "usage" directory.

![image](https://github.com/user-attachments/assets/12f4cf19-7a9c-491c-9fc1-ccdb71b76d1c)