### PR TITLE
fix(render): transitive shader imports now work consistently on web

### DIFF
--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -216,7 +216,11 @@ impl ShaderCache {
                     }
 
                     composer.add_composable_module(shader.into())?;
+                } else {
+                    Err(PipelineCacheError::ShaderImportNotYetAvailable)?;
                 }
+            } else {
+                Err(PipelineCacheError::ShaderImportNotYetAvailable)?;
             }
             // if we fail to add a module the composer will tell us what is missing
         }


### PR DESCRIPTION
# Objective

- transitive shader imports sometimes fail to load silently and return Ok
- Fixes #19226

## Solution

- Don't return Ok, return the appropriate error code which will retry the load later when the dependencies load

## Testing

- `bevy run --example=3d_scene web --open`


Note: this is was theoretically a problem before the hot reloading PR, but probably extremely unlikely to occur.
