### PR TITLE
Fix missing meta files breaking Bevy on itch

### DIFF
--- a/crates/bevy_asset/src/io/wasm.rs
+++ b/crates/bevy_asset/src/io/wasm.rs
@@ -81,7 +81,8 @@ impl HttpWasmAssetReader {
                 let reader = VecReader::new(bytes);
                 Ok(reader)
             }
-            404 => Err(AssetReaderError::NotFound(path)),
+            // Some web servers, including itch.io's CDN return 403 when a request file isn't present
+            403 | 404 => Err(AssetReaderError::NotFound(path)),
             status => Err(AssetReaderError::HttpError(status)),
         }
     }


### PR DESCRIPTION
# Objective

Fixes #19029 (also maybe sorta #18002, but we may want to handle the SPA issue I outlined there more gracefully?)

It seems that it's not *entirely* crazy for web services to return 403 for an item that was not found. Here's an example from [Amazon CloudFront docs](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/http-403-permission-denied.html#s3-origin-403-error).

## Solution

The most minimal / surgical approach I could think of, hopefully cherry-pickable for a point release.

I was previously of the opinion that any 400 level error might as well get this treatment, but I'm now thinking that's probably overkill and there are quite a few 400 level statuses that would indicate some problem that needs to be fixed, and interpreting these as "not found" might add confusion to the debugging process.

## Testing

Tested this with a web server that returns 403 for requests to meta files.

```bash
cargo run -p build-wasm-example -- --api webgl2 sprite && \
open "http://localhost:4000" && \
python3 test_403.py examples/wasm
```
`test_403.py`:
```python
from http.server import HTTPServer, SimpleHTTPRequestHandler
import os
import sys


class CustomHandler(SimpleHTTPRequestHandler):
    def do_GET(self):
        if self.path.endswith(".meta"):
            self.send_response(403)
            self.send_header("Content-type", "text/plain")
            self.end_headers()
            self.wfile.write(b"403 Forbidden: Testing.\n")
        else:
            super().do_GET()


if __name__ == "__main__":
    if len(sys.argv) != 2:
        print(f"Usage: {sys.argv[0]} <directory>")
        sys.exit(1)

    os.chdir(sys.argv[1])

    server_address = ("", 4000)
    httpd = HTTPServer(server_address, CustomHandler)
    httpd.serve_forever()
```
