### PR TITLE
19275: spawn_batch creates incorrect relationships when RelationshipTarget is initially empty

### DIFF
--- a/crates/bevy_ecs/src/relationship/mod.rs
+++ b/crates/bevy_ecs/src/relationship/mod.rs
@@ -118,7 +118,6 @@ pub trait Relationship: Component + Sized {
                 relationship_target.collection_mut_risky().add(entity);
             } else {
                 // Commands may be deferred (e.g., in batch mode), so the world should be inspected from within the command itself.
-                // Note: this may introduce small performance overhead (about 10%) due to additional commands and lookups.
                 world.commands().queue(move |world: &mut World| {
                     if let Ok(mut target_entity_mut) = world.get_entity_mut(target_entity) {
                         if let Some(mut relationship_target) =


### PR DESCRIPTION
# Objective

Fixes #19275

## Solution

Component hooks may observe an incoherent world state during `World::spawn_batch`, since commands are not flushed between entity insertions. This causing incorrect behavior when multiple entities referenced the same target entity with an initially empty `RelationshipTarget` - each hook would overwrite the previous.

This fix ensures that the on_insert hook operates on a consistent view when the `RelationshipTarget` is initially empty, by moving the logic into the command itself. It may introduce small performance overhead (about 10%) due to additional commands and lookups.

## Testing

- _Did you test these changes? If so, how?_: `cargo test --workspace`
- _Are there any parts that need more testing?_ I don't think so
- _How can other people (reviewers) test your changes? Is there anything specific they need to know?_ Test included
- _If relevant, what platforms did you test these changes on, and are there any important ones you can't test?_ irrelevant

---

