### PR TITLE
Unpin nightly in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
   CARGO_PROFILE_TEST_DEBUG: 0
   CARGO_PROFILE_DEV_DEBUG: 0
   # If nightly is breaking CI, modify this variable to target a specific nightly version.
-  NIGHTLY_TOOLCHAIN: nightly-2025-05-16 # pinned until a fix for https://github.com/rust-lang/miri/issues/4323 is released
+  NIGHTLY_TOOLCHAIN: nightly
   RUSTFLAGS: "-D warnings"
   BINSTALL_VERSION: "v1.12.3"
 


### PR DESCRIPTION
# Objective

In #19253 we pinned nightly due to a bug in Miri. That issue was resolved and the latest Miri should be usable for us again.

## Solution

- Use latest nightly again

## Testing

- I tested today's Miri locally with `RUSTUP_TOOLCHAIN=nightly-2025-05-18 MIRIFLAGS="-Zmiri-ignore-leaks -Zmiri-disable-isolation" RUSTFLAGS="-Zrandomize-layout" cargo miri test -p bevy_ecs`
- [ ] Let's see what the CI says
