### PR TITLE
Fix a few typos in bevy_ecs docs

### DIFF
--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -209,7 +209,7 @@ use core::{
 /// # #[derive(Component)]
 /// # struct ComponentB;
 /// #
-/// // A queried items must contain `ComponentA`. If they also contain `ComponentB`, its value will
+/// // Queried items must contain `ComponentA`. If they also contain `ComponentB`, its value will
 /// // be fetched as well.
 /// fn optional_component_query(query: Query<(&ComponentA, Option<&ComponentB>)>) {
 ///     // ...

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -115,7 +115,7 @@ use core::{
 /// ```
 ///
 /// Note that the filter is `With<ComponentB>`, not `With<&ComponentB>`. Unlike query data, `With`
-/// does require components to be behind a reference.
+/// does not require components to be behind a reference.
 ///
 /// ## `QueryData` or `QueryFilter` tuples
 ///

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -198,13 +198,13 @@ impl<'w> UnsafeWorldCell<'w> {
     ///
     /// # Safety
     /// - must have permission to access the whole world immutably
-    /// - there must be no live exclusive borrows on world data
+    /// - there must be no live exclusive borrows of world data
     /// - there must be no live exclusive borrow of world
     #[inline]
     pub unsafe fn world(self) -> &'w World {
         // SAFETY:
         // - caller ensures there is no `&mut World` this makes it okay to make a `&World`
-        // - caller ensures there is no mutable borrows of world data, this means the caller cannot
+        // - caller ensures there are no mutable borrows of world data, this means the caller cannot
         //   misuse the returned `&World`
         unsafe { self.unsafe_world() }
     }
@@ -233,7 +233,7 @@ impl<'w> UnsafeWorldCell<'w> {
     ///
     /// # Safety
     /// - must not be used in a way that would conflict with any
-    ///   live exclusive borrows on world data
+    ///   live exclusive borrows of world data
     #[inline]
     unsafe fn unsafe_world(self) -> &'w World {
         // SAFETY:
@@ -395,7 +395,7 @@ impl<'w> UnsafeWorldCell<'w> {
     /// Gets a reference to the resource of the given type if it exists
     ///
     /// # Safety
-    /// It is the callers responsibility to ensure that
+    /// It is the caller's responsibility to ensure that
     /// - the [`UnsafeWorldCell`] has permission to access the resource
     /// - no mutable reference to the resource exists at the same time
     #[inline]
@@ -413,7 +413,7 @@ impl<'w> UnsafeWorldCell<'w> {
     /// Gets a reference including change detection to the resource of the given type if it exists.
     ///
     /// # Safety
-    /// It is the callers responsibility to ensure that
+    /// It is the caller's responsibility to ensure that
     /// - the [`UnsafeWorldCell`] has permission to access the resource
     /// - no mutable reference to the resource exists at the same time
     #[inline]
@@ -421,7 +421,7 @@ impl<'w> UnsafeWorldCell<'w> {
         let component_id = self.components().get_resource_id(TypeId::of::<R>())?;
 
         // SAFETY: caller ensures `self` has permission to access the resource
-        // caller also ensure that no mutable reference to the resource exists
+        // caller also ensures that no mutable reference to the resource exists
         let (ptr, ticks, caller) = unsafe { self.get_resource_with_ticks(component_id)? };
 
         // SAFETY: `component_id` was obtained from the type ID of `R`
@@ -449,7 +449,7 @@ impl<'w> UnsafeWorldCell<'w> {
     /// use this in cases where the actual types are not known at compile time.**
     ///
     /// # Safety
-    /// It is the callers responsibility to ensure that
+    /// It is the caller's responsibility to ensure that
     /// - the [`UnsafeWorldCell`] has permission to access the resource
     /// - no mutable reference to the resource exists at the same time
     #[inline]
@@ -465,7 +465,7 @@ impl<'w> UnsafeWorldCell<'w> {
     /// Gets a reference to the non-send resource of the given type if it exists
     ///
     /// # Safety
-    /// It is the callers responsibility to ensure that
+    /// It is the caller's responsibility to ensure that
     /// - the [`UnsafeWorldCell`] has permission to access the resource
     /// - no mutable reference to the resource exists at the same time
     #[inline]
@@ -491,7 +491,7 @@ impl<'w> UnsafeWorldCell<'w> {
     /// This function will panic if it isn't called from the same thread that the resource was inserted from.
     ///
     /// # Safety
-    /// It is the callers responsibility to ensure that
+    /// It is the caller's responsibility to ensure that
     /// - the [`UnsafeWorldCell`] has permission to access the resource
     /// - no mutable reference to the resource exists at the same time
     #[inline]
@@ -507,7 +507,7 @@ impl<'w> UnsafeWorldCell<'w> {
     /// Gets a mutable reference to the resource of the given type if it exists
     ///
     /// # Safety
-    /// It is the callers responsibility to ensure that
+    /// It is the caller's responsibility to ensure that
     /// - the [`UnsafeWorldCell`] has permission to access the resource mutably
     /// - no other references to the resource exist at the same time
     #[inline]
@@ -532,7 +532,7 @@ impl<'w> UnsafeWorldCell<'w> {
     /// use this in cases where the actual types are not known at compile time.**
     ///
     /// # Safety
-    /// It is the callers responsibility to ensure that
+    /// It is the caller's responsibility to ensure that
     /// - the [`UnsafeWorldCell`] has permission to access the resource mutably
     /// - no other references to the resource exist at the same time
     #[inline]
@@ -571,7 +571,7 @@ impl<'w> UnsafeWorldCell<'w> {
     /// Gets a mutable reference to the non-send resource of the given type if it exists
     ///
     /// # Safety
-    /// It is the callers responsibility to ensure that
+    /// It is the caller's responsibility to ensure that
     /// - the [`UnsafeWorldCell`] has permission to access the resource mutably
     /// - no other references to the resource exist at the same time
     #[inline]
@@ -599,7 +599,7 @@ impl<'w> UnsafeWorldCell<'w> {
     /// This function will panic if it isn't called from the same thread that the resource was inserted from.
     ///
     /// # Safety
-    /// It is the callers responsibility to ensure that
+    /// It is the caller's responsibility to ensure that
     /// - the [`UnsafeWorldCell`] has permission to access the resource mutably
     /// - no other references to the resource exist at the same time
     #[inline]
@@ -633,7 +633,7 @@ impl<'w> UnsafeWorldCell<'w> {
 
     // Shorthand helper function for getting the data and change ticks for a resource.
     /// # Safety
-    /// It is the callers responsibility to ensure that
+    /// It is the caller's responsibility to ensure that
     /// - the [`UnsafeWorldCell`] has permission to access the resource mutably
     /// - no mutable references to the resource exist at the same time
     #[inline]
@@ -660,7 +660,7 @@ impl<'w> UnsafeWorldCell<'w> {
     /// This function will panic if it isn't called from the same thread that the resource was inserted from.
     ///
     /// # Safety
-    /// It is the callers responsibility to ensure that
+    /// It is the caller's responsibility to ensure that
     /// - the [`UnsafeWorldCell`] has permission to access the resource mutably
     /// - no mutable references to the resource exist at the same time
     #[inline]
@@ -684,7 +684,7 @@ impl<'w> UnsafeWorldCell<'w> {
 
     // Returns a mutable reference to the underlying world's [`CommandQueue`].
     /// # Safety
-    /// It is the callers responsibility to ensure that
+    /// It is the caller's responsibility to ensure that
     /// - the [`UnsafeWorldCell`] has permission to access the queue mutably
     /// - no mutable references to the queue exist at the same time
     pub(crate) unsafe fn get_raw_command_queue(self) -> RawCommandQueue {
@@ -696,7 +696,7 @@ impl<'w> UnsafeWorldCell<'w> {
     }
 
     /// # Safety
-    /// It is the callers responsibility to ensure that there are no outstanding
+    /// It is the caller's responsibility to ensure that there are no outstanding
     /// references to `last_trigger_id`.
     pub(crate) unsafe fn increment_trigger_id(self) {
         self.assert_allows_mutable_access();
@@ -714,7 +714,7 @@ impl Debug for UnsafeWorldCell<'_> {
     }
 }
 
-/// A interior-mutable reference to a particular [`Entity`] and all of its components
+/// An interior-mutable reference to a particular [`Entity`] and all of its components
 #[derive(Copy, Clone)]
 pub struct UnsafeEntityCell<'w> {
     world: UnsafeWorldCell<'w>,
@@ -808,7 +808,7 @@ impl<'w> UnsafeEntityCell<'w> {
     }
 
     /// # Safety
-    /// It is the callers responsibility to ensure that
+    /// It is the caller's responsibility to ensure that
     /// - the [`UnsafeEntityCell`] has permission to access the component
     /// - no other mutable references to the component exist at the same time
     #[inline]
@@ -832,7 +832,7 @@ impl<'w> UnsafeEntityCell<'w> {
     }
 
     /// # Safety
-    /// It is the callers responsibility to ensure that
+    /// It is the caller's responsibility to ensure that
     /// - the [`UnsafeEntityCell`] has permission to access the component
     /// - no other mutable references to the component exist at the same time
     #[inline]
@@ -866,7 +866,7 @@ impl<'w> UnsafeEntityCell<'w> {
     /// detection in custom runtimes.
     ///
     /// # Safety
-    /// It is the callers responsibility to ensure that
+    /// It is the caller's responsibility to ensure that
     /// - the [`UnsafeEntityCell`] has permission to access the component
     /// - no other mutable references to the component exist at the same time
     #[inline]
@@ -895,7 +895,7 @@ impl<'w> UnsafeEntityCell<'w> {
     /// compile time.**
     ///
     /// # Safety
-    /// It is the callers responsibility to ensure that
+    /// It is the caller's responsibility to ensure that
     /// - the [`UnsafeEntityCell`] has permission to access the component
     /// - no other mutable references to the component exist at the same time
     #[inline]
@@ -920,7 +920,7 @@ impl<'w> UnsafeEntityCell<'w> {
     }
 
     /// # Safety
-    /// It is the callers responsibility to ensure that
+    /// It is the caller's responsibility to ensure that
     /// - the [`UnsafeEntityCell`] has permission to access the component mutably
     /// - no other references to the component exist at the same time
     #[inline]
@@ -932,7 +932,7 @@ impl<'w> UnsafeEntityCell<'w> {
     }
 
     /// # Safety
-    /// It is the callers responsibility to ensure that
+    /// It is the caller's responsibility to ensure that
     /// - the [`UnsafeEntityCell`] has permission to access the component mutably
     /// - no other references to the component exist at the same time
     /// - the component `T` is mutable
@@ -943,7 +943,7 @@ impl<'w> UnsafeEntityCell<'w> {
     }
 
     /// # Safety
-    /// It is the callers responsibility to ensure that
+    /// It is the caller's responsibility to ensure that
     /// - the [`UnsafeEntityCell`] has permission to access the component mutably
     /// - no other references to the component exist at the same time
     /// - The component `T` is mutable
@@ -982,7 +982,7 @@ impl<'w> UnsafeEntityCell<'w> {
     /// or `None` if the entity does not have the components required by the query `Q`.
     ///
     /// # Safety
-    /// It is the callers responsibility to ensure that
+    /// It is the caller's responsibility to ensure that
     /// - the [`UnsafeEntityCell`] has permission to access the queried data immutably
     /// - no mutable references to the queried data exist at the same time
     pub(crate) unsafe fn get_components<Q: ReadOnlyQueryData>(&self) -> Option<Q::Item<'w>> {
@@ -1031,7 +1031,7 @@ impl<'w> UnsafeEntityCell<'w> {
     /// which is only valid while the `'w` borrow of the lifetime is active.
     ///
     /// # Safety
-    /// It is the callers responsibility to ensure that
+    /// It is the caller's responsibility to ensure that
     /// - the [`UnsafeEntityCell`] has permission to access the component
     /// - no other mutable references to the component exist at the same time
     #[inline]
@@ -1056,7 +1056,7 @@ impl<'w> UnsafeEntityCell<'w> {
     /// use this in cases where the actual types are not known at compile time.**
     ///
     /// # Safety
-    /// It is the callers responsibility to ensure that
+    /// It is the caller's responsibility to ensure that
     /// - the [`UnsafeEntityCell`] has permission to access the component mutably
     /// - no other references to the component exist at the same time
     #[inline]
@@ -1104,7 +1104,7 @@ impl<'w> UnsafeEntityCell<'w> {
     /// use this in cases where the actual types are not known at compile time.**
     ///
     /// # Safety
-    /// It is the callers responsibility to ensure that
+    /// It is the caller's responsibility to ensure that
     /// - the [`UnsafeEntityCell`] has permission to access the component mutably
     /// - no other references to the component exist at the same time
     /// - the component `T` is mutable

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -143,7 +143,7 @@ impl<'w> UnsafeWorldCell<'w> {
     /// below), which includes all entities, components, and resources. Notably, calling this on
     /// [`WorldQuery::init_fetch`](crate::query::WorldQuery::init_fetch) and
     /// [`SystemParam::get_param`](crate::system::SystemParam::get_param) are most likely *unsound* unless
-    /// you can prove that the underlying [`World`] is exclusive, which in normal circumstances is not.
+    /// you can prove that the underlying [`World`] is exclusive, which in normal circumstances it is not.
     ///
     /// # Safety
     /// - `self` must have been obtained from a call to [`World::as_unsafe_world_cell`]


### PR DESCRIPTION
# Objective

Fix a few minor typos that I noticed when reading the docs.