### PR TITLE
Example: projectile targeting moving object

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,29 +15,29 @@ rust-version = "1.85.0"
 [workspace]
 resolver = "2"
 members = [
-  # All of Bevy's official crates are within the `crates` folder!
-  "crates/*",
-  # Several crates with macros have "compile fail" tests nested inside them, also known as UI
-  # tests, that verify diagnostic output does not accidentally change.
-  # TODO: Use a glob pattern once they are fixed in `dependabot-core`
-  # TODO: See https://github.com/bevyengine/bevy/issues/17876 for context.
-  "crates/bevy_derive/compile_fail",
-  "crates/bevy_ecs/compile_fail",
-  "crates/bevy_reflect/compile_fail",
-  # Examples of compiling Bevy for mobile platforms.
-  "examples/mobile",
-  # Examples of using Bevy on no_std platforms.
-  "examples/no_std/*",
-  # Benchmarks
-  "benches",
-  # Internal tools that are not published.
-  "tools/*",
-  # Bevy's error codes. This is a crate so we can automatically check all of the code blocks.
-  "errors",
+    # All of Bevy's official crates are within the `crates` folder!
+    "crates/*",
+    # Several crates with macros have "compile fail" tests nested inside them, also known as UI
+    # tests, that verify diagnostic output does not accidentally change.
+    # TODO: Use a glob pattern once they are fixed in `dependabot-core`
+    # TODO: See https://github.com/bevyengine/bevy/issues/17876 for context.
+    "crates/bevy_derive/compile_fail",
+    "crates/bevy_ecs/compile_fail",
+    "crates/bevy_reflect/compile_fail",
+    # Examples of compiling Bevy for mobile platforms.
+    "examples/mobile",
+    # Examples of using Bevy on no_std platforms.
+    "examples/no_std/*",
+    # Benchmarks
+    "benches",
+    # Internal tools that are not published.
+    "tools/*",
+    # Bevy's error codes. This is a crate so we can automatically check all of the code blocks.
+    "errors",
 ]
 exclude = [
-  # Integration tests are not part of the workspace
-  "tests-integration",
+    # Integration tests are not part of the workspace
+    "tests-integration",
 ]
 
 [workspace.lints.clippy]
@@ -124,45 +124,45 @@ unused_qualifications = "warn"
 
 [features]
 default = [
-  "std",
-  "async_executor",
-  "android-game-activity",
-  "android_shared_stdcxx",
-  "animation",
-  "bevy_asset",
-  "bevy_audio",
-  "bevy_color",
-  "bevy_core_pipeline",
-  "bevy_anti_aliasing",
-  "bevy_gilrs",
-  "bevy_gizmos",
-  "bevy_gltf",
-  "bevy_input_focus",
-  "bevy_log",
-  "bevy_mesh_picking_backend",
-  "bevy_pbr",
-  "bevy_picking",
-  "bevy_render",
-  "bevy_scene",
-  "bevy_sprite",
-  "bevy_sprite_picking_backend",
-  "bevy_state",
-  "bevy_text",
-  "bevy_ui",
-  "bevy_ui_picking_backend",
-  "bevy_window",
-  "bevy_winit",
-  "custom_cursor",
-  "default_font",
-  "hdr",
-  "multi_threaded",
-  "png",
-  "smaa_luts",
-  "sysinfo_plugin",
-  "tonemapping_luts",
-  "vorbis",
-  "webgl2",
-  "x11",
+    "std",
+    "async_executor",
+    "android-game-activity",
+    "android_shared_stdcxx",
+    "animation",
+    "bevy_asset",
+    "bevy_audio",
+    "bevy_color",
+    "bevy_core_pipeline",
+    "bevy_anti_aliasing",
+    "bevy_gilrs",
+    "bevy_gizmos",
+    "bevy_gltf",
+    "bevy_input_focus",
+    "bevy_log",
+    "bevy_mesh_picking_backend",
+    "bevy_pbr",
+    "bevy_picking",
+    "bevy_render",
+    "bevy_scene",
+    "bevy_sprite",
+    "bevy_sprite_picking_backend",
+    "bevy_state",
+    "bevy_text",
+    "bevy_ui",
+    "bevy_ui_picking_backend",
+    "bevy_window",
+    "bevy_winit",
+    "custom_cursor",
+    "default_font",
+    "hdr",
+    "multi_threaded",
+    "png",
+    "smaa_luts",
+    "sysinfo_plugin",
+    "tonemapping_luts",
+    "vorbis",
+    "webgl2",
+    "x11",
 ]
 
 # Recommended defaults for no_std applications
@@ -170,20 +170,20 @@ default_no_std = ["libm", "critical-section", "bevy_color", "bevy_state"]
 
 # Provides an implementation for picking meshes
 bevy_mesh_picking_backend = [
-  "bevy_picking",
-  "bevy_internal/bevy_mesh_picking_backend",
+    "bevy_picking",
+    "bevy_internal/bevy_mesh_picking_backend",
 ]
 
 # Provides an implementation for picking sprites
 bevy_sprite_picking_backend = [
-  "bevy_picking",
-  "bevy_internal/bevy_sprite_picking_backend",
+    "bevy_picking",
+    "bevy_internal/bevy_sprite_picking_backend",
 ]
 
 # Provides an implementation for picking UI
 bevy_ui_picking_backend = [
-  "bevy_picking",
-  "bevy_internal/bevy_ui_picking_backend",
+    "bevy_picking",
+    "bevy_internal/bevy_ui_picking_backend",
 ]
 
 # Provides a debug overlay for bevy UI
@@ -209,16 +209,16 @@ bevy_color = ["bevy_internal/bevy_color"]
 
 # Provides cameras and other basic render pipeline features
 bevy_core_pipeline = [
-  "bevy_internal/bevy_core_pipeline",
-  "bevy_asset",
-  "bevy_render",
+    "bevy_internal/bevy_core_pipeline",
+    "bevy_asset",
+    "bevy_render",
 ]
 
 # Provides various anti aliasing solutions
 bevy_anti_aliasing = [
-  "bevy_internal/bevy_anti_aliasing",
-  "bevy_asset",
-  "bevy_render",
+    "bevy_internal/bevy_anti_aliasing",
+    "bevy_asset",
+    "bevy_render",
 ]
 
 # Adds gamepad support
@@ -229,11 +229,11 @@ bevy_gltf = ["bevy_internal/bevy_gltf", "bevy_asset", "bevy_scene", "bevy_pbr"]
 
 # Adds PBR rendering
 bevy_pbr = [
-  "bevy_internal/bevy_pbr",
-  "bevy_asset",
-  "bevy_render",
-  "bevy_core_pipeline",
-  "bevy_anti_aliasing",
+    "bevy_internal/bevy_pbr",
+    "bevy_asset",
+    "bevy_render",
+    "bevy_core_pipeline",
+    "bevy_anti_aliasing",
 ]
 
 # Provides picking functionality
@@ -247,11 +247,11 @@ bevy_scene = ["bevy_internal/bevy_scene", "bevy_asset"]
 
 # Provides sprite functionality
 bevy_sprite = [
-  "bevy_internal/bevy_sprite",
-  "bevy_render",
-  "bevy_core_pipeline",
-  "bevy_color",
-  "bevy_anti_aliasing",
+    "bevy_internal/bevy_sprite",
+    "bevy_render",
+    "bevy_core_pipeline",
+    "bevy_color",
+    "bevy_anti_aliasing",
 ]
 
 # Provides text functionality
@@ -259,12 +259,12 @@ bevy_text = ["bevy_internal/bevy_text", "bevy_asset", "bevy_sprite"]
 
 # A custom ECS-driven UI framework
 bevy_ui = [
-  "bevy_internal/bevy_ui",
-  "bevy_core_pipeline",
-  "bevy_text",
-  "bevy_sprite",
-  "bevy_color",
-  "bevy_anti_aliasing",
+    "bevy_internal/bevy_ui",
+    "bevy_core_pipeline",
+    "bevy_text",
+    "bevy_sprite",
+    "bevy_color",
+    "bevy_anti_aliasing",
 ]
 
 # Windowing layer
@@ -308,9 +308,9 @@ trace_tracy = ["trace", "bevy_internal/trace_tracy"]
 
 # Tracing support, with memory profiling, exposing a port for Tracy
 trace_tracy_memory = [
-  "trace",
-  "bevy_internal/trace_tracy",
-  "bevy_internal/trace_tracy_memory",
+    "trace",
+    "bevy_internal/trace_tracy",
+    "bevy_internal/trace_tracy_memory",
 ]
 
 # Tracing support
@@ -468,7 +468,7 @@ pbr_transmission_textures = ["bevy_internal/pbr_transmission_textures"]
 
 # Enable support for multi-layer material textures in the `StandardMaterial`, at the risk of blowing past the global, per-shader texture limit on older/lower-end GPUs
 pbr_multi_layer_material_textures = [
-  "bevy_internal/pbr_multi_layer_material_textures",
+    "bevy_internal/pbr_multi_layer_material_textures",
 ]
 
 # Enable support for anisotropy texture in the `StandardMaterial`, at the risk of blowing past the global, per-shader texture limit on older/lower-end GPUs
@@ -1367,17 +1367,17 @@ description = "Meshlet rendering for dense high-poly scenes (experimental)"
 category = "3D Rendering"
 wasm = false
 setup = [
-  [
-    "mkdir",
-    "-p",
-    "assets/external/models",
-  ],
-  [
-    "curl",
-    "-o",
-    "assets/external/models/bunny.meshlet_mesh",
-    "https://raw.githubusercontent.com/JMS55/bevy_meshlet_asset/7a7c14138021f63904b584d5f7b73b695c7f4bbf/bunny.meshlet_mesh",
-  ],
+    [
+        "mkdir",
+        "-p",
+        "assets/external/models",
+    ],
+    [
+        "curl",
+        "-o",
+        "assets/external/models/bunny.meshlet_mesh",
+        "https://raw.githubusercontent.com/JMS55/bevy_meshlet_asset/7a7c14138021f63904b584d5f7b73b695c7f4bbf/bunny.meshlet_mesh",
+    ],
 ]
 
 [[example]]
@@ -4198,6 +4198,17 @@ description = "Demonstrates specular tints and maps"
 category = "3D Rendering"
 wasm = true
 
+[[example]]
+name = "projectile_follow_moving"
+path = "examples/usage/projectile_follow_moving.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.projectile_follow_moving]
+name = "Projectile follow moving"
+description = "A projectile is fired on mousclick following a moving target."
+category = "usage"
+wasm = true
+
 [profile.wasm-release]
 inherits = "release"
 opt-level = "z"
@@ -4216,13 +4227,13 @@ panic = "abort"
 # with `--cfg docsrs` (and thus fail to compile) we use a different cfg.
 rustc-args = ["--cfg", "docsrs_dep"]
 rustdoc-args = [
-  "-Zunstable-options",
-  "--generate-link-to-definition",
-  # Embed tags to the top of documentation pages for common Bevy traits
-  # that are implemented by the current type, like `Component` or `Resource`.
-  # This makes it easier to see at a glance what types are used for.
-  "--html-after-content",
-  "docs-rs/trait-tags.html",
+    "-Zunstable-options",
+    "--generate-link-to-definition",
+    # Embed tags to the top of documentation pages for common Bevy traits
+    # that are implemented by the current type, like `Component` or `Resource`.
+    # This makes it easier to see at a glance what types are used for.
+    "--html-after-content",
+    "docs-rs/trait-tags.html",
 ]
 all-features = true
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]

--- a/examples/README.md
+++ b/examples/README.md
@@ -68,6 +68,7 @@ git checkout v0.4.0
   - [Transforms](#transforms)
   - [UI (User Interface)](#ui-user-interface)
   - [Window](#window)
+  - [usage](#usage)
 
 - [Tests](#tests)
 - [Platform-Specific Examples](#platform-specific-examples)
@@ -587,6 +588,12 @@ Example | Description
 [Window Drag Move](../examples/window/window_drag_move.rs) | Demonstrates drag move and drag resize without window decoration
 [Window Resizing](../examples/window/window_resizing.rs) | Demonstrates resizing and responding to resizing a window
 [Window Settings](../examples/window/window_settings.rs) | Demonstrates customizing default window settings
+
+## usage
+
+Example | Description
+--- | ---
+[Projectile follow moving](../examples/usage/projectile_follow_moving.rs) | A projectile is fired on mousclick following a moving target.
 
 # Tests
 

--- a/examples/usage/projectile_follow_moving.rs
+++ b/examples/usage/projectile_follow_moving.rs
@@ -1,0 +1,202 @@
+//! Shows how to create moving and spining objects on mouse position.
+//!
+//! Left click on with the mouse will spawn a projectile that follows the moving target.
+
+use bevy::{input::common_conditions::input_just_pressed, prelude::*};
+
+const MIN_DISTANCE: f32 = 10.0;
+
+/// Represents a movable entity with a spawn location, movement speed, and a maximum allowed distance from its spawn point.
+///
+/// This component is later used by `Follower` projectiles to select and follow a target.
+#[derive(Component, Debug)]
+struct Movable {
+    spawn: Vec3,
+    max_distance: f32,
+    speed: f32,
+}
+
+/// Utility constructor for creating a `Movable` with default speed and max distance values.
+impl Movable {
+    fn new(spawn: Vec3) -> Self {
+        Movable {
+            spawn,
+            max_distance: 300.0,
+            speed: 70.0,
+        }
+    }
+}
+
+/// Marks a projectile that follows a target entity, using a specified speed.
+///
+/// - `target`: An `Entity` identifier used to reference the target in queries.
+/// - `speed`: The speed at which the projectile moves toward the target.
+#[derive(Component)]
+struct Follower {
+    speed: f32,
+    target: Entity,
+}
+
+impl Follower {
+    /// Creates a new `Follower` with a default speed and the given target entity.
+    fn new(target: Entity) -> Self {
+        Follower {
+            speed: 110.0,
+            target,
+        }
+    }
+}
+
+/// A resource that holds the mesh and material used for rendering 2D projectiles.
+#[derive(Resource)]
+struct WorldAssets {
+    mesh: Handle<Mesh>,
+    material: Handle<ColorMaterial>,
+}
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_systems(Startup, setup)
+        .add_systems(Update, move_target)
+        .add_systems(
+            Update,
+            spawn_projectile.run_if(input_just_pressed(MouseButton::Left)),
+        )
+        .add_systems(
+            Update,
+            move_projectile.run_if(any_with_component::<Movable>),
+        )
+        .run();
+}
+
+// Startup system to setup the scene and spawn all relevant entities.
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+) {
+    // Create mesh handle and material for projectile.
+    let projectile_asset = WorldAssets {
+        mesh: meshes.add(Triangle2d::new(
+            Vec2::Y * 5.0,
+            Vec2::new(-5.0, -5.0),
+            Vec2::new(5.0, -5.0),
+        )),
+        material: materials.add(Color::from(bevy::color::palettes::basic::RED)),
+    };
+
+    // Add handler of triabgle and it's material as Resource.
+    commands.insert_resource(projectile_asset);
+
+    // Add a shape as Movable.
+    let entity_spawn = Vec3::ZERO;
+    commands.spawn((
+        Mesh2d(meshes.add(RegularPolygon::new(30.0, 8))),
+        MeshMaterial2d(materials.add(Color::WHITE)),
+        Transform::from_translation(entity_spawn),
+        Movable::new(entity_spawn),
+    ));
+
+    // Spawn a camera looking at the entities to show what's happening in this example.
+    commands.spawn((Camera2d, Transform::from_xyz(0.0, 0.0, 0.0)));
+
+    // this creates a Text comment and the Node is need as a Ui description to spawn it in the top left corner
+    commands.spawn((
+        Text::new("Mouseclick: to fire projectile from mouse position towards moving target."),
+        Node {
+            position_type: PositionType::Absolute,
+            top: Val::Px(12.0),
+            left: Val::Px(12.0),
+            ..default()
+        },
+    ));
+}
+
+/// Spawns a projectile at the current mouse cursor position and assigns the only `Movable` entity as its target.
+///
+/// The function performs the following steps:
+/// 1. Calculates the cursor position relative to the world by using the current window and camera viewport.
+/// 2. Retrieves the first and only entity with the `Movable` component to be used as the projectile's target.
+/// 3. Spawns the projectile at the computed world position using the `WorldAsset` resource created during setup.
+fn spawn_projectile(
+    mut commands: Commands,
+    world_assets: Res<WorldAssets>,
+    targets: Single<(Entity, &mut Movable)>,
+    camera_query: Single<(&Camera, &GlobalTransform)>,
+    window: Query<&Window>,
+) -> Result<(), BevyError> {
+    let (camera, camera_transform) = *camera_query;
+    let window = window.single()?;
+
+    let Some(cursor_position) = window.cursor_position() else {
+        return Ok(());
+    };
+
+    // Calculate a world position based on the cursor's position.
+    let Ok(world_pos) = camera.viewport_to_world_2d(camera_transform, cursor_position) else {
+        return Ok(());
+    };
+
+    let entity_spawn = Vec3::new(world_pos.x, world_pos.y, 0.0);
+
+    let target_entity = targets.0;
+    commands.spawn((
+        Mesh2d(world_assets.mesh.clone()),
+        MeshMaterial2d(world_assets.material.clone()),
+        Transform::from_translation(entity_spawn),
+        Follower::new(target_entity),
+    ));
+
+    Ok(())
+}
+
+/// This system will move all Movable entities with a Transform
+fn move_target(mut targets: Query<(&mut Transform, &mut Movable)>, timer: Res<Time>) {
+    for (mut transform, mut target) in &mut targets {
+        // Check if the entity moved too far from its spawn, if so invert the moving direction.
+        if (target.spawn - transform.translation).length() > target.max_distance {
+            target.speed *= -1.0;
+        }
+
+        // the direction will be horizontal to window. local_x of transform is cosntantly changing due to rotation of z-axis of transform.
+        let direction = Dir3::X;
+        transform.translation += direction * target.speed * timer.delta_secs();
+
+        // this makes the polygon look like roling.
+        transform.rotate_z(-1.2 * target.speed.signum() * timer.delta_secs());
+    }
+}
+
+/// Moves each projectile toward its target and despawns it once it gets close enough.
+///
+/// For each projectile:
+/// - Updates its position to move closer to its assigned target.
+/// - Checks the distance to the target, and if it is within a threshold, the projectile is despawned.
+fn move_projectile(
+    mut projectiles: Query<(Entity, &mut Transform, &mut Follower)>,
+    targets: Query<&Transform, Without<Follower>>,
+    mut commands: Commands,
+    timer: Res<Time>,
+) {
+    for (entity, mut transform, projectile) in &mut projectiles {
+        let target_transform = targets.get(projectile.target).unwrap();
+
+        // the direction and distance of the target.
+        let vector_to_target = target_transform.translation - transform.translation;
+
+        // if the projectile is close enough, despawn it
+        if vector_to_target.length() < MIN_DISTANCE {
+            commands.entity(entity).despawn();
+        }
+
+        // normalized vector_to_target is the direction.
+        let direction = vector_to_target.normalize();
+
+        transform.translation += direction * projectile.speed * timer.delta_secs();
+
+        // rotate to point to target
+        let rotate_to_target = Quat::from_rotation_arc(Vec3::Y, direction.xy().extend(0.));
+        transform.rotation = rotate_to_target;
+    }
+}


### PR DESCRIPTION
# Objective

This example has been writing during the RustWeek2025. In this example a projectile is spawned at cursor position on mouse click. The target is a moveable polygon that also rotates. The project will de-spawn, when close enough to it's target.



## Solution

This example goes in `/examples/usage/projectile_follow_moving.rs`.
I added the example to Cargo.toml at the bottom of the examples listed and then ran `cargo run -p build-templated-pages -- build-example-page` as [described in Creating examples
](https://bevyengine.org/learn/contribute/helping-out/creating-examples/)

It changed the Cargo.toml and added lines to /examples/README.md


## Testing

Nothing in bevy was changed. But the tests are running.
You can test the example by running the example.

---

## Showcase


```
cargo run --example projectile_follow_moving
```

## Note
Special thanks to people guiding me to use the  Api wisely. Making me understand some core concepts and constantly correcting my mistakes.
