### PR TITLE
Add a despawn_children method to EntityWorldMut and EntityCommands

### DIFF
--- a/crates/bevy_ecs/src/relationship/related_methods.rs
+++ b/crates/bevy_ecs/src/relationship/related_methods.rs
@@ -1,6 +1,7 @@
 use crate::{
     bundle::Bundle,
     entity::{hash_set::EntityHashSet, Entity},
+    prelude::Children,
     relationship::{
         Relationship, RelationshipHookMode, RelationshipSourceCollection, RelationshipTarget,
     },
@@ -302,6 +303,13 @@ impl<'w> EntityWorldMut<'w> {
         self
     }
 
+    /// Despawns the children of this entity.
+    /// This entity will not be despawned.
+    pub fn despawn_children(&mut self) -> &mut Self {
+        self.despawn_related::<Children>();
+        self
+    }
+
     /// Inserts a component or bundle of components into the entity and all related entities,
     /// traversing the relationship tracked in `S` in a breadth-first manner.
     ///
@@ -465,6 +473,12 @@ impl<'a> EntityCommands<'a> {
         self.queue(move |mut entity: EntityWorldMut| {
             entity.despawn_related::<S>();
         })
+    }
+
+    /// Despawns the children of this entity.
+    /// This entity will not be despawned.
+    pub fn despawn_children(&mut self) -> &mut Self {
+        self.despawn_related::<Children>()
     }
 
     /// Inserts a component or bundle of components into the entity and all related entities,


### PR DESCRIPTION
# Objective

At the moment, if someone wants to despawn all the children of an entity, they would need to use `despawn_related::<Children>();`.
In my opinion, this makes a very common operation less easily discoverable and require some understanding of Entity Relationships.

## Solution

Adding a `despawn_children ` makes a very simple, discoverable and readable way to despawn all the children while maintaining cohesion with other similar methods.

## Testing

The implementation itself is very simple as it simply wraps around `despawn_related` with `Children` as the generic type.
I gave it a quick try by modifying the parenting example and it worked as expected.
