### PR TITLE
Add debug cycle detection for insert_recursive and remove_recursive

### DIFF
--- a/crates/bevy_ecs/src/relationship/related_methods.rs
+++ b/crates/bevy_ecs/src/relationship/related_methods.rs
@@ -16,14 +16,17 @@ use super::OrderedRelationshipSourceCollection;
 /// Detects cycles when traversing relationships.
 #[derive(Default, Debug)]
 struct CyclicTraversalDetector {
-    visited: EntityHashSet
+    visited: EntityHashSet,
 }
 
 #[cfg(debug_assertions)]
 impl CyclicTraversalDetector {
     fn check(&mut self, node: Entity) {
         if self.visited.contains(&node) {
-            panic!("Cyclical traversal detected - have already visited entity {:?}", node);
+            panic!(
+                "Cyclical traversal detected - have already visited entity {:?}",
+                node
+            );
         }
         self.visited.insert(node);
     }
@@ -346,8 +349,7 @@ impl<'w> EntityWorldMut<'w> {
     fn insert_recursive_impl<S: RelationshipTarget>(
         &mut self,
         bundle: impl Bundle + Clone,
-        #[cfg(debug_assertions)]
-        cycle_detector: &mut CyclicTraversalDetector,
+        #[cfg(debug_assertions)] cycle_detector: &mut CyclicTraversalDetector,
     ) -> &mut Self {
         #[cfg(debug_assertions)]
         cycle_detector.check(self.id());
@@ -357,13 +359,11 @@ impl<'w> EntityWorldMut<'w> {
             let related_vec: Vec<Entity> = relationship_target.iter().collect();
             for related in related_vec {
                 self.world_scope(|world| {
-                    world
-                        .entity_mut(related)
-                        .insert_recursive_impl::<S>(
-                            bundle.clone(),
-                            #[cfg(debug_assertions)]
-                            cycle_detector
-                        );
+                    world.entity_mut(related).insert_recursive_impl::<S>(
+                        bundle.clone(),
+                        #[cfg(debug_assertions)]
+                        cycle_detector,
+                    );
                 });
             }
         }
@@ -395,8 +395,7 @@ impl<'w> EntityWorldMut<'w> {
 
     fn remove_recursive_impl<S: RelationshipTarget, B: Bundle>(
         &mut self,
-        #[cfg(debug_assertions)]
-        cycle_detector: &mut CyclicTraversalDetector,
+        #[cfg(debug_assertions)] cycle_detector: &mut CyclicTraversalDetector,
     ) -> &mut Self {
         #[cfg(debug_assertions)]
         cycle_detector.check(self.id());
@@ -408,7 +407,7 @@ impl<'w> EntityWorldMut<'w> {
                 self.world_scope(|world| {
                     world.entity_mut(related).remove_recursive_impl::<S, B>(
                         #[cfg(debug_assertions)]
-                        cycle_detector
+                        cycle_detector,
                     );
                 });
             }


### PR DESCRIPTION
# Objective

Partially fixes https://github.com/bevyengine/bevy/issues/17465.

## Solution

Add a `CyclicTraversalDetector` struct and manually thread it through calls to `insert_recursive(_impl)` and `remove_recursive(_impl)`.

All of the `cfg(debug_assertion)`s are a bit ugly, and this approach would require more wiring anywhere else we wanted to add cycle detection. We could instead use a scoped resource that gets inserted into `world` at the start of the traversal and removed at the end, but before adding complexity I wanted to check with @bushrat011899 and/or @alice-i-cecile where else they want cycle detection to be supported (and whether this "scoped resource" approach would even be sensible and/or has prior art).

## Testing

Added `should_panic` tests for a cyclical hierarchy.