### PR TITLE
Add missing words in Traversal doc comment

### DIFF
--- a/crates/bevy_ecs/src/traversal.rs
+++ b/crates/bevy_ecs/src/traversal.rs
@@ -10,7 +10,7 @@ use crate::{entity::Entity, query::ReadOnlyQueryData, relationship::Relationship
 /// Infinite loops are possible, and are not checked for. While looping can be desirable in some contexts
 /// (for example, an observer that triggers itself multiple times before stopping), following an infinite
 /// traversal loop without an eventual exit will cause your application to hang. Each implementer of `Traversal`
-/// for documenting possible looping behavior, and consumers of those implementations are responsible for
+/// is responsible for documenting possible looping behavior, and consumers of those implementations are responsible for
 /// avoiding infinite loops in their code.
 ///
 /// Traversals may be parameterized with additional data. For example, in observer event propagation, the


### PR DESCRIPTION
# Objective

Minor docs fix - add missing "is responsible".
