### PR TITLE
Pin `uuid` to prevent `getrandom` v0.3 from polluting WASM build requirements

### DIFF
--- a/crates/bevy_animation/Cargo.toml
+++ b/crates/bevy_animation/Cargo.toml
@@ -40,13 +40,13 @@ thiserror = { version = "2", default-features = false }
 derive_more = { version = "1", default-features = false, features = ["from"] }
 either = "1.13"
 thread_local = "1"
-uuid = { version = "1.13.1", features = ["v4"] }
+uuid = { version = "~1.12.1", features = ["v4"] }
 smallvec = "1"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # TODO: Assuming all wasm builds are for the browser. Require `no_std` support to break assumption.
-uuid = { version = "1.13.1", default-features = false, features = ["js"] }
+uuid = { version = "~1.12.1", default-features = false, features = ["js"] }
 
 [lints]
 workspace = true

--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -58,7 +58,7 @@ ron = { version = "0.8", default-features = false }
 serde = { version = "1", default-features = false, features = ["derive"] }
 thiserror = { version = "2", default-features = false }
 derive_more = { version = "1", default-features = false, features = ["from"] }
-uuid = { version = "1.13.1", default-features = false, features = [
+uuid = { version = "~1.12.1", default-features = false, features = [
   "v4",
   "serde",
 ] }
@@ -77,7 +77,7 @@ web-sys = { version = "0.3", features = [
 ] }
 wasm-bindgen-futures = "0.4"
 js-sys = "0.3"
-uuid = { version = "1.13.1", default-features = false, features = ["js"] }
+uuid = { version = "~1.12.1", default-features = false, features = ["js"] }
 bevy_app = { path = "../bevy_app", version = "0.16.0-dev", default-features = false, features = [
   "web",
 ] }

--- a/crates/bevy_picking/Cargo.toml
+++ b/crates/bevy_picking/Cargo.toml
@@ -32,12 +32,12 @@ bevy_platform = { path = "../bevy_platform", version = "0.16.0-dev", default-fea
 
 # other
 crossbeam-channel = { version = "0.5", optional = true }
-uuid = { version = "1.13.1", features = ["v4"] }
+uuid = { version = "~1.12.1", features = ["v4"] }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # TODO: Assuming all wasm builds are for the browser. Require `no_std` support to break assumption.
-uuid = { version = "1.13.1", default-features = false, features = ["js"] }
+uuid = { version = "~1.12.1", default-features = false, features = ["js"] }
 
 [lints]
 workspace = true

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -110,7 +110,7 @@ petgraph = { version = "0.7", features = ["serde-1"], optional = true }
 smol_str = { version = "0.2.0", default-features = false, features = [
   "serde",
 ], optional = true }
-uuid = { version = "1.13.1", default-features = false, optional = true, features = [
+uuid = { version = "~1.12.1", default-features = false, optional = true, features = [
   "v4",
   "serde",
 ] }

--- a/crates/bevy_reflect/derive/Cargo.toml
+++ b/crates/bevy_reflect/derive/Cargo.toml
@@ -23,11 +23,11 @@ bevy_macro_utils = { path = "../../bevy_macro_utils", version = "0.16.0-dev" }
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "2.0", features = ["full"] }
-uuid = { version = "1.13.1", features = ["v4"] }
+uuid = { version = "~1.12.1", features = ["v4"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # TODO: Assuming all wasm builds are for the browser. Require `no_std` support to break assumption.
-uuid = { version = "1.13.1", default-features = false, features = ["js"] }
+uuid = { version = "~1.12.1", default-features = false, features = ["js"] }
 
 [lints]
 workspace = true

--- a/crates/bevy_scene/Cargo.toml
+++ b/crates/bevy_scene/Cargo.toml
@@ -33,13 +33,13 @@ bevy_platform = { path = "../bevy_platform", version = "0.16.0-dev", default-fea
 
 # other
 serde = { version = "1.0", features = ["derive"], optional = true }
-uuid = { version = "1.13.1", features = ["v4"] }
+uuid = { version = "~1.12.1", features = ["v4"] }
 thiserror = { version = "2", default-features = false }
 derive_more = { version = "1", default-features = false, features = ["from"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # TODO: Assuming all wasm builds are for the browser. Require `no_std` support to break assumption.
-uuid = { version = "1.13.1", default-features = false, features = ["js"] }
+uuid = { version = "~1.12.1", default-features = false, features = ["js"] }
 
 [dev-dependencies]
 postcard = { version = "1.0", features = ["alloc"] }

--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -35,7 +35,7 @@ bevy_platform = { path = "../bevy_platform", version = "0.16.0-dev", default-fea
 # other
 taffy = { version = "0.7" }
 serde = { version = "1", features = ["derive"], optional = true }
-uuid = { version = "1.1", features = ["v4"], optional = true }
+uuid = { version = "~1.12.1", features = ["v4"], optional = true }
 bytemuck = { version = "1.5", features = ["derive"] }
 thiserror = { version = "2", default-features = false }
 derive_more = { version = "1", default-features = false, features = ["from"] }


### PR DESCRIPTION
# Objective

- Currently, `uuid` adds in a semver breaking change to WASM builds by including `getrandom@v0.3` and `rand@v0.9` into the dependency tree. This unfortunately adds additional build requirements in order to get Bevy to compile correctly for WASM.

## Solution

- Pin `uuid` version to one that does not have the `getrandom` update.

## Testing

- This should not be a breaking change internally, so it should compile and pass all CI tests with no regressions.
