### PR TITLE
Hot patching systems with subsecond

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -534,6 +534,9 @@ libm = ["bevy_internal/libm"]
 # Enables use of browser APIs. Note this is currently only applicable on `wasm32` architectures.
 web = ["bevy_internal/web"]
 
+# Enable hotpatching of Bevy systems
+hotpatching = ["bevy_internal/hotpatching"]
+
 [dependencies]
 bevy_internal = { path = "crates/bevy_internal", version = "0.16.0-dev", default-features = false }
 tracing = { version = "0.1", default-features = false, optional = true }
@@ -4356,4 +4359,16 @@ doc-scrape-examples = true
 name = "Extended Bindless Material"
 description = "Demonstrates bindless `ExtendedMaterial`"
 category = "Shaders"
+wasm = false
+
+[[example]]
+name = "hotpatching_systems"
+path = "examples/ecs/hotpatching_systems.rs"
+doc-scrape-examples = true
+required-features = ["hotpatching"]
+
+[package.metadata.example.hotpatching_systems]
+name = "Hotpatching Systems"
+description = "Demonstrates how to hotpatch systems"
+category = "Ecs"
 wasm = false

--- a/crates/bevy_app/Cargo.toml
+++ b/crates/bevy_app/Cargo.toml
@@ -72,6 +72,12 @@ web = [
   "dep:console_error_panic_hook",
 ]
 
+hotpatching = [
+  "bevy_ecs/hotpatching",
+  "dep:dioxus-devtools",
+  "dep:crossbeam-channel",
+]
+
 [dependencies]
 # bevy
 bevy_derive = { path = "../bevy_derive", version = "0.16.0-dev" }
@@ -90,6 +96,8 @@ variadics_please = "1.1"
 tracing = { version = "0.1", default-features = false, optional = true }
 log = { version = "0.4", default-features = false }
 cfg-if = "1.0.0"
+dioxus-devtools = { git = "https://github.com/mockersf/dioxus", branch = "typed-hotfn-pointer", optional = true }
+crossbeam-channel = { version = "0.5.0", optional = true }
 
 [target.'cfg(any(unix, windows))'.dependencies]
 ctrlc = { version = "3.4.4", optional = true }

--- a/crates/bevy_app/src/hotpatch.rs
+++ b/crates/bevy_app/src/hotpatch.rs
@@ -1,0 +1,32 @@
+use bevy_ecs::{event::EventWriter, HotPatched};
+use dioxus_devtools::{connect, subsecond::apply_patch, DevserverMsg};
+
+use crate::{Last, Plugin};
+
+/// Plugin connecting to Dioxus CLI to enable hot patching.
+#[derive(Default)]
+pub struct HotPatchPlugin;
+
+impl Plugin for HotPatchPlugin {
+    fn build(&self, app: &mut crate::App) {
+        let (sender, receiver) = crossbeam_channel::bounded::<HotPatched>(1);
+
+        connect(move |msg| {
+            if let DevserverMsg::HotReload(hot_reload_msg) = msg {
+                if let Some(jumptable) = hot_reload_msg.jump_table {
+                    unsafe { apply_patch(jumptable).unwrap() };
+                    sender.send(HotPatched).unwrap();
+                }
+            }
+        });
+
+        app.add_event::<HotPatched>().add_systems(
+            Last,
+            move |mut events: EventWriter<HotPatched>| {
+                if receiver.try_recv().is_ok() {
+                    events.write_default();
+                }
+            },
+        );
+    }
+}

--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -6,7 +6,11 @@
     )
 )]
 #![cfg_attr(any(docsrs, docsrs_dep), feature(doc_auto_cfg, rustdoc_internals))]
-#![forbid(unsafe_code)]
+#![cfg_attr(
+    feature = "hotpatching",
+    expect(unsafe_code, reason = "Unsafe code for system hotpatching.")
+)]
+#![cfg_attr(not(feature = "hotpatching"), forbid(unsafe_code))]
 #![doc(
     html_logo_url = "https://bevyengine.org/assets/icon.png",
     html_favicon_url = "https://bevyengine.org/assets/icon.png"
@@ -24,6 +28,8 @@ extern crate alloc;
 extern crate self as bevy_app;
 
 mod app;
+#[cfg(feature = "hotpatching")]
+mod hotpatch;
 mod main_schedule;
 mod panic_handler;
 mod plugin;
@@ -35,6 +41,8 @@ mod task_pool_plugin;
 mod terminal_ctrl_c_handler;
 
 pub use app::*;
+#[cfg(feature = "hotpatching")]
+pub use hotpatch::HotPatchPlugin;
 pub use main_schedule::*;
 pub use panic_handler::*;
 pub use plugin::*;

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -88,6 +88,8 @@ critical-section = [
   "bevy_reflect?/critical-section",
 ]
 
+hotpatching = ["dep:subsecond"]
+
 [dependencies]
 bevy_ptr = { path = "../bevy_ptr", version = "0.16.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.16.0-dev", features = [
@@ -124,7 +126,7 @@ variadics_please = { version = "1.1", default-features = false }
 tracing = { version = "0.1", default-features = false, optional = true }
 log = { version = "0.4", default-features = false }
 bumpalo = "3"
-subsecond = "0.7.0-alpha.0"
+subsecond = { git = "https://github.com/mockersf/dioxus", branch = "typed-hotfn-pointer", optional = true }
 
 concurrent-queue = { version = "2.5.0", default-features = false }
 [target.'cfg(not(all(target_has_atomic = "8", target_has_atomic = "16", target_has_atomic = "32", target_has_atomic = "64", target_has_atomic = "ptr")))'.dependencies]

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -124,6 +124,7 @@ variadics_please = { version = "1.1", default-features = false }
 tracing = { version = "0.1", default-features = false, optional = true }
 log = { version = "0.4", default-features = false }
 bumpalo = "3"
+subsecond = "0.7.0-alpha.0"
 
 concurrent-queue = { version = "2.5.0", default-features = false }
 [target.'cfg(not(all(target_has_atomic = "8", target_has_atomic = "16", target_has_atomic = "32", target_has_atomic = "64", target_has_atomic = "ptr")))'.dependencies]

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -59,6 +59,9 @@ pub mod world;
 
 pub use bevy_ptr as ptr;
 
+#[cfg(feature = "hotpatching")]
+use event::Event;
+
 /// The ECS prelude.
 ///
 /// This includes the most common types in this crate, re-exported for your convenience.
@@ -2768,3 +2771,10 @@ mod tests {
         fn custom_clone(_source: &SourceComponent, _ctx: &mut ComponentCloneCtx) {}
     }
 }
+
+/// Event triggered when a hotpatch happens.
+///
+/// Systems should refresh their inner pointers.
+#[cfg(feature = "hotpatching")]
+#[derive(Event, Default)]
+pub struct HotPatched;

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -366,12 +366,17 @@ fn observer_system_runner<E: Event, B: Bundle, S: ObserverSystem<E, B>>(
     };
 
     // SAFETY:
-    // - `update_archetype_component_access` is called first
+    // - `update_archetype_component_access` is called before any world access
     // - there are no outstanding references to world except a private component
     // - system is an `ObserverSystem` so won't mutate world beyond the access of a `DeferredWorld`
     //   and is never exclusive
     // - system is the same type erased system from above
     unsafe {
+        // Always refresh hotpatch pointers
+        // There's no guarantee that the `HotPatched` event would still be there once the observer is triggered.
+        #[cfg(feature = "hotpatching")]
+        (*system).refresh_hotpatch();
+
         (*system).update_archetype_component_access(world);
         match (*system).validate_param_unsafe(world) {
             Ok(()) => {

--- a/crates/bevy_ecs/src/schedule/executor/mod.rs
+++ b/crates/bevy_ecs/src/schedule/executor/mod.rs
@@ -209,6 +209,9 @@ impl System for ApplyDeferred {
         Ok(())
     }
 
+    #[inline]
+    fn refresh_hotpatch(&mut self) {}
+
     fn run(&mut self, _input: SystemIn<'_, Self>, _world: &mut World) -> Self::Out {
         // This system does nothing on its own. The executor will apply deferred
         // commands from other systems instead of running this system.

--- a/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
@@ -19,6 +19,8 @@ use crate::{
     system::ScheduleSystem,
     world::{unsafe_world_cell::UnsafeWorldCell, World},
 };
+#[cfg(feature = "hotpatching")]
+use crate::{event::Events, HotPatched};
 
 use super::__rust_begin_short_backtrace;
 
@@ -443,6 +445,14 @@ impl ExecutorState {
             return;
         }
 
+        #[cfg(feature = "hotpatching")]
+        let should_update_hotpatch = !context
+            .environment
+            .world_cell
+            .get_resource::<Events<HotPatched>>()
+            .map(|e| e.is_empty())
+            .unwrap_or(true);
+
         // can't borrow since loop mutably borrows `self`
         let mut ready_systems = core::mem::take(&mut self.ready_systems_copy);
 
@@ -459,6 +469,11 @@ impl ExecutorState {
                 // SAFETY: Caller assured that these systems are not running.
                 // Therefore, no other reference to this system exists and there is no aliasing.
                 let system = unsafe { &mut *context.environment.systems[system_index].get() };
+
+                #[cfg(feature = "hotpatching")]
+                if should_update_hotpatch {
+                    system.refresh_hotpatch();
+                }
 
                 if !self.can_run(
                     system_index,

--- a/crates/bevy_ecs/src/schedule/executor/simple.rs
+++ b/crates/bevy_ecs/src/schedule/executor/simple.rs
@@ -16,6 +16,8 @@ use crate::{
     },
     world::World,
 };
+#[cfg(feature = "hotpatching")]
+use crate::{event::Events, HotPatched};
 
 use super::__rust_begin_short_backtrace;
 
@@ -59,6 +61,12 @@ impl SystemExecutor for SimpleExecutor {
             // mark skipped systems as completed
             self.completed_systems |= skipped_systems;
         }
+
+        #[cfg(feature = "hotpatching")]
+        let should_update_hotpatch = !world
+            .get_resource::<Events<HotPatched>>()
+            .map(|e| e.is_empty())
+            .unwrap_or(true);
 
         for system_index in 0..schedule.systems.len() {
             #[cfg(feature = "trace")]
@@ -119,6 +127,11 @@ impl SystemExecutor for SimpleExecutor {
 
             #[cfg(feature = "trace")]
             should_run_span.exit();
+
+            #[cfg(feature = "hotpatching")]
+            if should_update_hotpatch {
+                system.refresh_hotpatch();
+            }
 
             // system has either been skipped or will run
             self.completed_systems.insert(system_index);
@@ -186,6 +199,12 @@ fn evaluate_and_fold_conditions(
     world: &mut World,
     error_handler: ErrorHandler,
 ) -> bool {
+    #[cfg(feature = "hotpatching")]
+    let should_update_hotpatch = !world
+        .get_resource::<Events<HotPatched>>()
+        .map(|e| e.is_empty())
+        .unwrap_or(true);
+
     #[expect(
         clippy::unnecessary_fold,
         reason = "Short-circuiting here would prevent conditions from mutating their own state as needed."
@@ -207,6 +226,10 @@ fn evaluate_and_fold_conditions(
                     }
                     return false;
                 }
+            }
+            #[cfg(feature = "hotpatching")]
+            if should_update_hotpatch {
+                condition.refresh_hotpatch();
             }
             __rust_begin_short_backtrace::readonly_run(&mut **condition, world)
         })

--- a/crates/bevy_ecs/src/system/adapter_system.rs
+++ b/crates/bevy_ecs/src/system/adapter_system.rs
@@ -169,6 +169,11 @@ where
     }
 
     #[inline]
+    fn refresh_hotpatch(&mut self) {
+        self.system.refresh_hotpatch();
+    }
+
+    #[inline]
     fn apply_deferred(&mut self, world: &mut crate::prelude::World) {
         self.system.apply_deferred(world);
     }

--- a/crates/bevy_ecs/src/system/combinator.rs
+++ b/crates/bevy_ecs/src/system/combinator.rs
@@ -192,6 +192,12 @@ where
     }
 
     #[inline]
+    fn refresh_hotpatch(&mut self) {
+        self.a.refresh_hotpatch();
+        self.b.refresh_hotpatch();
+    }
+
+    #[inline]
     fn apply_deferred(&mut self, world: &mut World) {
         self.a.apply_deferred(world);
         self.b.apply_deferred(world);
@@ -415,6 +421,12 @@ where
     ) -> Self::Out {
         let value = self.a.run_unsafe(input, world);
         self.b.run_unsafe(value, world)
+    }
+
+    #[inline]
+    fn refresh_hotpatch(&mut self) {
+        self.a.refresh_hotpatch();
+        self.b.refresh_hotpatch();
     }
 
     fn apply_deferred(&mut self, world: &mut World) {

--- a/crates/bevy_ecs/src/system/exclusive_function_system.rs
+++ b/crates/bevy_ecs/src/system/exclusive_function_system.rs
@@ -141,6 +141,11 @@ where
     }
 
     #[inline]
+    fn refresh_hotpatch(&mut self) {
+        // TODO: support exclusive systems
+    }
+
+    #[inline]
     fn apply_deferred(&mut self, _world: &mut World) {
         // "pure" exclusive systems do not have any buffers to apply.
         // Systems made by piping a normal system with an exclusive system

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -358,6 +358,9 @@ impl<Param: SystemParam> SystemState<Param> {
     ) -> FunctionSystem<Marker, F> {
         FunctionSystem {
             func,
+            #[cfg(feature = "hotpatching")]
+            current_ptr: subsecond::HotFn::current(<F as SystemParamFunction<Marker>>::run)
+                .ptr_address(),
             state: Some(FunctionSystemState {
                 param: self.param_state,
                 world_id: self.world_id,
@@ -595,6 +598,8 @@ where
     F: SystemParamFunction<Marker>,
 {
     func: F,
+    #[cfg(feature = "hotpatching")]
+    current_ptr: subsecond::HotFnPtr,
     state: Option<FunctionSystemState<F::Param>>,
     system_meta: SystemMeta,
     archetype_generation: ArchetypeGeneration,
@@ -635,6 +640,9 @@ where
     fn clone(&self) -> Self {
         Self {
             func: self.func.clone(),
+            #[cfg(feature = "hotpatching")]
+            current_ptr: subsecond::HotFn::current(<F as SystemParamFunction<Marker>>::run)
+                .ptr_address(),
             state: None,
             system_meta: SystemMeta::new::<F>(),
             archetype_generation: ArchetypeGeneration::initial(),
@@ -656,6 +664,9 @@ where
     fn into_system(func: Self) -> Self::System {
         FunctionSystem {
             func,
+            #[cfg(feature = "hotpatching")]
+            current_ptr: subsecond::HotFn::current(<F as SystemParamFunction<Marker>>::run)
+                .ptr_address(),
             state: None,
             system_meta: SystemMeta::new::<F>(),
             archetype_generation: ArchetypeGeneration::initial(),
@@ -744,15 +755,26 @@ where
         // - nu uh
         // - not even marked as unsafe, that's how unsafe this is
         // - enjoy
-        let out = subsecond::HotFn::current(<F as SystemParamFunction<Marker>>::run).call((
-            &mut self.func,
-            input,
-            params,
-        ));
+        #[cfg(feature = "hotpatching")]
+        let out = subsecond::HotFn::current(<F as SystemParamFunction<Marker>>::run)
+            .try_call_with_ptr(self.current_ptr, (&mut self.func, input, params))
+            .expect("Error calling hotpatched system. Run a full rebuild");
+        #[cfg(not(feature = "hotpatching"))]
+        let out = self.func.run(input, params);
 
         self.system_meta.last_run = change_tick;
         out
     }
+
+    #[inline]
+    #[cfg(feature = "hotpatching")]
+    fn refresh_hotpatch(&mut self) {
+        self.current_ptr =
+            subsecond::HotFn::current(<F as SystemParamFunction<Marker>>::run).ptr_address();
+    }
+    #[inline]
+    #[cfg(not(feature = "hotpatching"))]
+    fn refresh_hotpatch(&mut self) {}
 
     #[inline]
     fn apply_deferred(&mut self, world: &mut World) {

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -737,7 +737,19 @@ where
         //   will ensure that there are no data access conflicts.
         let params =
             unsafe { F::Param::get_param(param_state, &self.system_meta, world, change_tick) };
-        let out = self.func.run(input, params);
+
+        // SAFETY:
+        // - this is not safe
+        // - no way
+        // - nu uh
+        // - not even marked as unsafe, that's how unsafe this is
+        // - enjoy
+        let out = subsecond::HotFn::current(<F as SystemParamFunction<Marker>>::run).call((
+            &mut self.func,
+            input,
+            params,
+        ));
+
         self.system_meta.last_run = change_tick;
         out
     }

--- a/crates/bevy_ecs/src/system/observer_system.rs
+++ b/crates/bevy_ecs/src/system/observer_system.rs
@@ -158,6 +158,11 @@ where
     }
 
     #[inline]
+    fn refresh_hotpatch(&mut self) {
+        self.observer.refresh_hotpatch();
+    }
+
+    #[inline]
     fn apply_deferred(&mut self, world: &mut World) {
         self.observer.apply_deferred(world);
     }

--- a/crates/bevy_ecs/src/system/schedule_system.rs
+++ b/crates/bevy_ecs/src/system/schedule_system.rs
@@ -71,6 +71,11 @@ impl<S: System<In = ()>> System for InfallibleSystemWrapper<S> {
     }
 
     #[inline]
+    fn refresh_hotpatch(&mut self) {
+        self.0.refresh_hotpatch();
+    }
+
+    #[inline]
     fn apply_deferred(&mut self, world: &mut World) {
         self.0.apply_deferred(world);
     }
@@ -197,6 +202,11 @@ where
         self.system.run_unsafe(&mut self.value, world)
     }
 
+    #[inline]
+    fn refresh_hotpatch(&mut self) {
+        self.system.refresh_hotpatch();
+    }
+
     fn apply_deferred(&mut self, world: &mut World) {
         self.system.apply_deferred(world);
     }
@@ -310,6 +320,11 @@ where
             .as_mut()
             .expect("System input value was not found. Did you forget to initialize the system before running it?");
         self.system.run_unsafe(value, world)
+    }
+
+    #[inline]
+    fn refresh_hotpatch(&mut self) {
+        self.system.refresh_hotpatch();
     }
 
     fn apply_deferred(&mut self, world: &mut World) {

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -82,6 +82,9 @@ pub trait System: Send + Sync + 'static {
     unsafe fn run_unsafe(&mut self, input: SystemIn<'_, Self>, world: UnsafeWorldCell)
         -> Self::Out;
 
+    /// Refresh the inner pointer based on the latest hot patch jump table
+    fn refresh_hotpatch(&mut self);
+
     /// Runs the system with the given input in the world.
     ///
     /// For [read-only](ReadOnlySystem) systems, see [`run_readonly`], which can be called using `&World`.

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -346,6 +346,8 @@ web = [
   "bevy_tasks/web",
 ]
 
+hotpatching = ["bevy_app/hotpatching", "bevy_ecs/hotpatching"]
+
 [dependencies]
 # bevy (no_std)
 bevy_app = { path = "../bevy_app", version = "0.16.0-dev", default-features = false, features = [

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -4,6 +4,8 @@ plugin_group! {
     /// This plugin group will add all the default plugins for a *Bevy* application:
     pub struct DefaultPlugins {
         bevy_app:::PanicHandlerPlugin,
+        #[cfg(feature = "hotpatching")]
+        bevy_app:::HotPatchPlugin,
         #[cfg(feature = "bevy_log")]
         bevy_log:::LogPlugin,
         bevy_app:::TaskPoolPlugin,

--- a/examples/ecs/hotpatching_systems.rs
+++ b/examples/ecs/hotpatching_systems.rs
@@ -1,0 +1,54 @@
+//! This example demonstrates how to hotpatch systems.
+//!
+//! It needs to be run with the dioxus CLI:
+//! ```sh
+//! dx serve --hot-patch --example hotpatching_systems --features hotpatching
+//! ```
+//!
+//! You can change the text in the `update_text` system, or the color in the
+//! `on_click` system, and those changes will be hotpatched into the running
+//! application.
+
+use bevy::{color::palettes, prelude::*};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_systems(Startup, setup)
+        .add_systems(Update, update_text)
+        .run();
+}
+
+fn update_text(mut text_query: Query<&mut Text>) {
+    let mut text = text_query.single_mut().unwrap();
+    **text = "before".to_string();
+}
+
+fn on_click(_click: Trigger<Pointer<Click>>, mut color: Query<&mut TextColor>) -> Result {
+    color.single_mut()?.0 = palettes::tailwind::RED_600.into();
+    Ok(())
+}
+
+fn setup(mut commands: Commands) {
+    commands.spawn(Camera2d);
+
+    commands
+        .spawn((
+            Node {
+                width: Val::Percent(100.0),
+                height: Val::Percent(100.0),
+                align_items: AlignItems::Center,
+                justify_content: JustifyContent::Center,
+                flex_direction: FlexDirection::Column,
+                ..default()
+            },
+            children![(
+                Text::default(),
+                TextFont {
+                    font_size: 100.0,
+                    ..default()
+                },
+            )],
+        ))
+        .observe(on_click);
+}


### PR DESCRIPTION
# Objective

- Enable hot patching systems with subsecond
- Fixes #19296 

## Solution

- First commit is the naive thin layer
- Second commit only check the jump table when the code is hot patched instead of on every system execution
- Depends on https://github.com/DioxusLabs/dioxus/pull/4153 for a nicer API, but could be done without
- Everything in second commit is feature gated, it has no impact when the feature is not enabled

## Testing

- Check dependencies without the feature enabled: nothing dioxus in tree
- Run the new example: text and color can be changed
