### PR TITLE
Add debug build option to build-wasm-example 

### DIFF
--- a/docs-template/EXAMPLE_README.md.tpl
+++ b/docs-template/EXAMPLE_README.md.tpl
@@ -269,6 +269,7 @@ Bevy has a helper to build its examples:
 
 - Build for WebGL2: `cargo run -p build-wasm-example -- --api webgl2 load_gltf`
 - Build for WebGPU: `cargo run -p build-wasm-example -- --api webgpu load_gltf`
+- Debug: `cargo run -p build-wasm-example -- --debug --api webgl2 load_gltf`
 
 This helper will log the command used to build the examples.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -782,6 +782,7 @@ Bevy has a helper to build its examples:
 
 - Build for WebGL2: `cargo run -p build-wasm-example -- --api webgl2 load_gltf`
 - Build for WebGPU: `cargo run -p build-wasm-example -- --api webgpu load_gltf`
+- Debug: `cargo run -p build-wasm-example -- --debug --api webgl2 load_gltf`
 
 This helper will log the command used to build the examples.
 

--- a/tools/build-wasm-example/src/main.rs
+++ b/tools/build-wasm-example/src/main.rs
@@ -39,6 +39,10 @@ struct Args {
     #[arg(long)]
     /// Additional features to enable
     features: Vec<String>,
+
+    #[arg(long)]
+    /// Build the example in debug mode instead of release
+    debug: bool,
 }
 
 fn main() {
@@ -73,15 +77,23 @@ fn main() {
             parameters.push("--features");
             parameters.push(&features_string);
         }
+
+        let profile = if cli.debug {
+            "debug"
+        } else {
+            parameters.push("--release");
+            "release"
+        };
+
         let cmd = cmd!(
             sh,
-            "cargo build {parameters...} --profile release --target wasm32-unknown-unknown --example {example}"
+            "cargo build {parameters...} --target wasm32-unknown-unknown --example {example}"
         );
         cmd.run().expect("Error building example");
 
         cmd!(
             sh,
-            "wasm-bindgen --out-dir examples/wasm/target --out-name wasm_example --target web target/wasm32-unknown-unknown/release/examples/{example}.wasm"
+            "wasm-bindgen --out-dir examples/wasm/target/{profile} --out-name wasm_example --target web target/wasm32-unknown-unknown/{profile}/examples/{example}.wasm"
         )
         .run()
         .expect("Error creating wasm binding");

--- a/tools/build-wasm-example/src/main.rs
+++ b/tools/build-wasm-example/src/main.rs
@@ -93,7 +93,7 @@ fn main() {
 
         cmd!(
             sh,
-            "wasm-bindgen --out-dir examples/wasm/target/{profile} --out-name wasm_example --target web target/wasm32-unknown-unknown/{profile}/examples/{example}.wasm"
+            "wasm-bindgen --out-dir examples/wasm/target --out-name wasm_example --target web target/wasm32-unknown-unknown/{profile}/examples/{example}.wasm"
         )
         .run()
         .expect("Error creating wasm binding");


### PR DESCRIPTION
## Objective

- Add a `--debug` flag to `build-wasm-example` to support debug builds for WebGL2/WebGPU targets.
- Fixes #18464

## Solution
- Added `--debug` flag to build Wasm examples in debug mode.
- Default remains release mode if `--debug` is not specified.
- Updated documentation to describe the new flag and usage.

## Testing
- Verified debug and release builds for WebGL2 and WebGPU respectively.
- Confirmed wasm artifacts are placed in the correct target dir for each build profile:
  - Debug: `target/wasm32-unknown-unknown/debug/examples/`
  - Release: `target/wasm32-unknown-unknown/release/examples/`
- Confirmed wasm-bindgen output is written to: `examples/wasm/target/debug` , `examples/wasm/target/release`
- Haven't actually tested running the example

| Backend | Profile | Artifacts written | Build success    |
|---------|---------|-------------------|------------------|
| webgl2  | debug   |        ✓              |           ✓             |        
| webgl2  | release |         ✓                |         ✓             |                 
| webpgu  | debug   |       ✓             |            ✓             |                 
| webpgu  | release |        ✓              |          ✓              |         

### Examples

**Debug**
```
$ cargo run -p build-wasm-example -- --api webgl2 --debug load_gltf
```
```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 02s
wasm-bindgen --out-dir examples/wasm/target/debug --out-name wasm_example --target web target/wasm32-unknown-unknown/debug/examples/load_gltf.wasm
```

**Release**
```
$ cargo run -p build-wasm-example -- --api webgl2 load_gltf`
```
```
Finished `release` profile [optimized] target(s) in 1m 08s
wasm-bindgen --out-dir examples/wasm/target/release --out-name wasm_example --target web target/wasm32-unknown-unknown/release/examples/load_gltf.wasm
```  