### PR TITLE
doc(render): fix incorrectly transposed view matrix docs

### DIFF
--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -262,16 +262,16 @@ impl RetainedViewEntity {
 pub struct ExtractedView {
     /// The entity in the main world corresponding to this render world view.
     pub retained_view_entity: RetainedViewEntity,
-    /// Typically a right-handed projection matrix, one of either:
+    /// Typically a column-major right-handed projection matrix, one of either:
     ///
     /// Perspective (infinite reverse z)
     /// ```text
     /// f = 1 / tan(fov_y_radians / 2)
     ///
-    /// ⎡ f / aspect  0     0   0 ⎤
-    /// ⎢          0  f     0   0 ⎥
-    /// ⎢          0  0     0  -1 ⎥
-    /// ⎣          0  0  near   0 ⎦
+    /// ⎡ f / aspect  0   0     0 ⎤
+    /// ⎢          0  f   0     0 ⎥
+    /// ⎢          0  0   0  near ⎥
+    /// ⎣          0  0  -1     0 ⎦
     /// ```
     ///
     /// Orthographic
@@ -282,13 +282,15 @@ pub struct ExtractedView {
     /// cw = -right - left
     /// ch = -top - bottom
     ///
-    /// ⎡  2 / w       0         0  0 ⎤
-    /// ⎢      0   2 / h         0  0 ⎥
-    /// ⎢      0       0     1 / d  0 ⎥
-    /// ⎣ cw / w  ch / h  near / d  1 ⎦
+    /// ⎡ 2 / w      0      0    cw / w ⎤
+    /// ⎢     0  2 / h      0    ch / h ⎥
+    /// ⎢     0      0  1 / d  near / d ⎥
+    /// ⎣     0      0      0         1 ⎦
     /// ```
     ///
     /// `clip_from_view[3][3] == 1.0` is the standard way to check if a projection is orthographic
+    ///
+    /// Glam matrices are column major, so for example getting the near plane is `clip_from_view[3][2]`
     ///
     /// Custom projections are also possible however.
     pub clip_from_view: Mat4,
@@ -529,16 +531,16 @@ pub struct ViewUniform {
     pub world_from_clip: Mat4,
     pub world_from_view: Mat4,
     pub view_from_world: Mat4,
-    /// Typically a right-handed projection matrix, one of either:
+    /// Typically a column-major right-handed projection matrix, one of either:
     ///
     /// Perspective (infinite reverse z)
     /// ```text
     /// f = 1 / tan(fov_y_radians / 2)
     ///
-    /// ⎡ f / aspect  0     0   0 ⎤
-    /// ⎢          0  f     0   0 ⎥
-    /// ⎢          0  0     0  -1 ⎥
-    /// ⎣          0  0  near   0 ⎦
+    /// ⎡ f / aspect  0   0     0 ⎤
+    /// ⎢          0  f   0     0 ⎥
+    /// ⎢          0  0   0  near ⎥
+    /// ⎣          0  0  -1     0 ⎦
     /// ```
     ///
     /// Orthographic
@@ -549,13 +551,15 @@ pub struct ViewUniform {
     /// cw = -right - left
     /// ch = -top - bottom
     ///
-    /// ⎡  2 / w       0         0  0 ⎤
-    /// ⎢      0   2 / h         0  0 ⎥
-    /// ⎢      0       0     1 / d  0 ⎥
-    /// ⎣ cw / w  ch / h  near / d  1 ⎦
+    /// ⎡ 2 / w      0      0    cw / w ⎤
+    /// ⎢     0  2 / h      0    ch / h ⎥
+    /// ⎢     0      0  1 / d  near / d ⎥
+    /// ⎣     0      0      0         1 ⎦
     /// ```
     ///
     /// `clip_from_view[3][3] == 1.0` is the standard way to check if a projection is orthographic
+    ///
+    /// Glam matrices are column major, so for example getting the near plane is `clip_from_view[3][2]`
     ///
     /// Custom projections are also possible however.
     pub clip_from_view: Mat4,

--- a/crates/bevy_render/src/view/view.wgsl
+++ b/crates/bevy_render/src/view/view.wgsl
@@ -19,16 +19,16 @@ struct View {
     world_from_clip: mat4x4<f32>,
     world_from_view: mat4x4<f32>,
     view_from_world: mat4x4<f32>,
-    // Typically a right-handed projection matrix, one of either:
+    // Typically a column-major right-handed projection matrix, one of either:
     //
     // Perspective (infinite reverse z)
     // ```
     // f = 1 / tan(fov_y_radians / 2)
     //
-    // ⎡ f / aspect  0     0   0 ⎤
-    // ⎢          0  f     0   0 ⎥
-    // ⎢          0  0     0  -1 ⎥
-    // ⎣          0  0  near   0 ⎦
+    // ⎡ f / aspect  0   0     0 ⎤
+    // ⎢          0  f   0     0 ⎥
+    // ⎢          0  0   0  near ⎥
+    // ⎣          0  0  -1     0 ⎦
     // ```
     //
     // Orthographic
@@ -39,13 +39,15 @@ struct View {
     // cw = -right - left
     // ch = -top - bottom
     //
-    // ⎡  2 / w       0         0  0 ⎤
-    // ⎢      0   2 / h         0  0 ⎥
-    // ⎢      0       0     1 / d  0 ⎥
-    // ⎣ cw / w  ch / h  near / d  1 ⎦
+    // ⎡ 2 / w      0      0    cw / w ⎤
+    // ⎢     0  2 / h      0    ch / h ⎥
+    // ⎢     0      0  1 / d  near / d ⎥
+    // ⎣     0      0      0         1 ⎦
     // ```
     //
     // `clip_from_view[3][3] == 1.0` is the standard way to check if a projection is orthographic
+    //
+    // Wgsl matrices are column major, so for example getting the near plane is `clip_from_view[3][2]`
     // 
     // Custom projections are also possible however.
     clip_from_view: mat4x4<f32>,


### PR DESCRIPTION
# Objective

- Mend incorrect docs

## Solution

- Mend them
- add example use
- clarify column major

## Testing

- No code changes
