### PR TITLE
Rename `Condition` to `SystemCondition``

### DIFF
--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -81,8 +81,8 @@ pub mod prelude {
         removal_detection::RemovedComponents,
         resource::Resource,
         schedule::{
-            common_conditions::*, ApplyDeferred, SystemCondition, IntoScheduleConfigs, IntoSystemSet,
-            Schedule, Schedules, SystemSet,
+            common_conditions::*, ApplyDeferred, IntoScheduleConfigs, IntoSystemSet, Schedule,
+            Schedules, SystemCondition, SystemSet,
         },
         spawn::{Spawn, SpawnRelated},
         system::{

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -81,7 +81,7 @@ pub mod prelude {
         removal_detection::RemovedComponents,
         resource::Resource,
         schedule::{
-            common_conditions::*, ApplyDeferred, Condition, IntoScheduleConfigs, IntoSystemSet,
+            common_conditions::*, ApplyDeferred, SystemCondition, IntoScheduleConfigs, IntoSystemSet,
             Schedule, Schedules, SystemSet,
         },
         spawn::{Spawn, SpawnRelated},

--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -16,16 +16,16 @@ pub type BoxedCondition<In = ()> = Box<dyn ReadOnlySystem<In = In, Out = bool>>;
 ///
 /// # Marker type parameter
 ///
-/// `Condition` trait has `Marker` type parameter, which has no special meaning,
+/// `SystemCondition` trait has `Marker` type parameter, which has no special meaning,
 /// but exists to work around the limitation of Rust's trait system.
 ///
 /// Type parameter in return type can be set to `<()>` by calling [`IntoSystem::into_system`],
 /// but usually have to be specified when passing a condition to a function.
 ///
 /// ```
-/// # use bevy_ecs::schedule::Condition;
+/// # use bevy_ecs::schedule::SystemCondition;
 /// # use bevy_ecs::system::IntoSystem;
-/// fn not_condition<Marker>(a: impl Condition<Marker>) -> impl Condition<()> {
+/// fn not_condition<Marker>(a: impl SystemCondition<Marker>) -> impl SystemCondition<()> {
 ///    IntoSystem::into_system(a.map(|x| !x))
 /// }
 /// ```
@@ -34,7 +34,7 @@ pub type BoxedCondition<In = ()> = Box<dyn ReadOnlySystem<In = In, Out = bool>>;
 /// A condition that returns true every other time it's called.
 /// ```
 /// # use bevy_ecs::prelude::*;
-/// fn every_other_time() -> impl Condition<()> {
+/// fn every_other_time() -> impl SystemCondition<()> {
 ///     IntoSystem::into_system(|mut flag: Local<bool>| {
 ///         *flag = !*flag;
 ///         *flag
@@ -58,7 +58,7 @@ pub type BoxedCondition<In = ()> = Box<dyn ReadOnlySystem<In = In, Out = bool>>;
 ///
 /// ```
 /// # use bevy_ecs::prelude::*;
-/// fn identity() -> impl Condition<(), In<bool>> {
+/// fn identity() -> impl SystemCondition<(), In<bool>> {
 ///     IntoSystem::into_system(|In(x)| x)
 /// }
 ///
@@ -71,7 +71,7 @@ pub type BoxedCondition<In = ()> = Box<dyn ReadOnlySystem<In = In, Out = bool>>;
 /// # world.insert_resource(DidRun(false));
 /// # app.run(&mut world);
 /// # assert!(world.resource::<DidRun>().0);
-pub trait Condition<Marker, In: SystemInput = ()>: sealed::Condition<Marker, In> {
+pub trait SystemCondition<Marker, In: SystemInput = ()>: sealed::SystemCondition<Marker, In> {
     /// Returns a new run condition that only returns `true`
     /// if both this one and the passed `and` return `true`.
     ///
@@ -116,7 +116,7 @@ pub trait Condition<Marker, In: SystemInput = ()>: sealed::Condition<Marker, In>
     /// Note that in this case, it's better to just use the run condition [`resource_exists_and_equals`].
     ///
     /// [`resource_exists_and_equals`]: common_conditions::resource_exists_and_equals
-    fn and<M, C: Condition<M, In>>(self, and: C) -> And<Self::System, C::System> {
+    fn and<M, C: SystemCondition<M, In>>(self, and: C) -> And<Self::System, C::System> {
         let a = IntoSystem::into_system(self);
         let b = IntoSystem::into_system(and);
         let name = format!("{} && {}", a.name(), b.name());
@@ -168,7 +168,7 @@ pub trait Condition<Marker, In: SystemInput = ()>: sealed::Condition<Marker, In>
     ///     ),
     /// );
     /// ```
-    fn nand<M, C: Condition<M, In>>(self, nand: C) -> Nand<Self::System, C::System> {
+    fn nand<M, C: SystemCondition<M, In>>(self, nand: C) -> Nand<Self::System, C::System> {
         let a = IntoSystem::into_system(self);
         let b = IntoSystem::into_system(nand);
         let name = format!("!({} && {})", a.name(), b.name());
@@ -220,7 +220,7 @@ pub trait Condition<Marker, In: SystemInput = ()>: sealed::Condition<Marker, In>
     ///     ),
     /// );
     /// ```
-    fn nor<M, C: Condition<M, In>>(self, nor: C) -> Nor<Self::System, C::System> {
+    fn nor<M, C: SystemCondition<M, In>>(self, nor: C) -> Nor<Self::System, C::System> {
         let a = IntoSystem::into_system(self);
         let b = IntoSystem::into_system(nor);
         let name = format!("!({} || {})", a.name(), b.name());
@@ -267,7 +267,7 @@ pub trait Condition<Marker, In: SystemInput = ()>: sealed::Condition<Marker, In>
     /// # app.run(&mut world);
     /// # assert!(world.resource::<C>().0);
     /// ```
-    fn or<M, C: Condition<M, In>>(self, or: C) -> Or<Self::System, C::System> {
+    fn or<M, C: SystemCondition<M, In>>(self, or: C) -> Or<Self::System, C::System> {
         let a = IntoSystem::into_system(self);
         let b = IntoSystem::into_system(or);
         let name = format!("{} || {}", a.name(), b.name());
@@ -319,7 +319,7 @@ pub trait Condition<Marker, In: SystemInput = ()>: sealed::Condition<Marker, In>
     ///     ),
     /// );
     /// ```
-    fn xnor<M, C: Condition<M, In>>(self, xnor: C) -> Xnor<Self::System, C::System> {
+    fn xnor<M, C: SystemCondition<M, In>>(self, xnor: C) -> Xnor<Self::System, C::System> {
         let a = IntoSystem::into_system(self);
         let b = IntoSystem::into_system(xnor);
         let name = format!("!({} ^ {})", a.name(), b.name());
@@ -361,7 +361,7 @@ pub trait Condition<Marker, In: SystemInput = ()>: sealed::Condition<Marker, In>
     /// );
     /// # app.run(&mut world);
     /// ```
-    fn xor<M, C: Condition<M, In>>(self, xor: C) -> Xor<Self::System, C::System> {
+    fn xor<M, C: SystemCondition<M, In>>(self, xor: C) -> Xor<Self::System, C::System> {
         let a = IntoSystem::into_system(self);
         let b = IntoSystem::into_system(xor);
         let name = format!("({} ^ {})", a.name(), b.name());
@@ -369,12 +369,12 @@ pub trait Condition<Marker, In: SystemInput = ()>: sealed::Condition<Marker, In>
     }
 }
 
-impl<Marker, In: SystemInput, F> Condition<Marker, In> for F where F: sealed::Condition<Marker, In> {}
+impl<Marker, In: SystemInput, F> SystemCondition<Marker, In> for F where F: sealed::SystemCondition<Marker, In> {}
 
 mod sealed {
     use crate::system::{IntoSystem, ReadOnlySystem, SystemInput};
 
-    pub trait Condition<Marker, In: SystemInput>:
+    pub trait SystemCondition<Marker, In: SystemInput>:
         IntoSystem<In, bool, Marker, System = Self::ReadOnlySystem>
     {
         // This associated type is necessary to let the compiler
@@ -382,7 +382,7 @@ mod sealed {
         type ReadOnlySystem: ReadOnlySystem<In = In, Out = bool>;
     }
 
-    impl<Marker, In: SystemInput, F> Condition<Marker, In> for F
+    impl<Marker, In: SystemInput, F> SystemCondition<Marker, In> for F
     where
         F: IntoSystem<In, bool, Marker>,
         F::System: ReadOnlySystem,
@@ -391,9 +391,9 @@ mod sealed {
     }
 }
 
-/// A collection of [run conditions](Condition) that may be useful in any bevy app.
+/// A collection of [run conditions](SystemCondition) that may be useful in any bevy app.
 pub mod common_conditions {
-    use super::{Condition, NotSystem};
+    use super::{SystemCondition, NotSystem};
     use crate::{
         change_detection::DetectChanges,
         event::{Event, EventReader},
@@ -405,7 +405,7 @@ pub mod common_conditions {
     };
     use alloc::format;
 
-    /// A [`Condition`]-satisfying system that returns `true`
+    /// A [`SystemCondition`]-satisfying system that returns `true`
     /// on the first time the condition is run and false every time after.
     ///
     /// # Example
@@ -443,7 +443,7 @@ pub mod common_conditions {
         }
     }
 
-    /// A [`Condition`]-satisfying system that returns `true`
+    /// A [`SystemCondition`]-satisfying system that returns `true`
     /// if the resource exists.
     ///
     /// # Example
@@ -478,7 +478,7 @@ pub mod common_conditions {
         res.is_some()
     }
 
-    /// Generates a [`Condition`]-satisfying closure that returns `true`
+    /// Generates a [`SystemCondition`]-satisfying closure that returns `true`
     /// if the resource is equal to `value`.
     ///
     /// # Panics
@@ -518,7 +518,7 @@ pub mod common_conditions {
         move |res: Res<T>| *res == value
     }
 
-    /// Generates a [`Condition`]-satisfying closure that returns `true`
+    /// Generates a [`SystemCondition`]-satisfying closure that returns `true`
     /// if the resource exists and is equal to `value`.
     ///
     /// The condition will return `false` if the resource does not exist.
@@ -563,7 +563,7 @@ pub mod common_conditions {
         }
     }
 
-    /// A [`Condition`]-satisfying system that returns `true`
+    /// A [`SystemCondition`]-satisfying system that returns `true`
     /// if the resource of the given type has been added since the condition was last checked.
     ///
     /// # Example
@@ -604,7 +604,7 @@ pub mod common_conditions {
         }
     }
 
-    /// A [`Condition`]-satisfying system that returns `true`
+    /// A [`SystemCondition`]-satisfying system that returns `true`
     /// if the resource of the given type has had its value changed since the condition
     /// was last checked.
     ///
@@ -658,7 +658,7 @@ pub mod common_conditions {
         res.is_changed()
     }
 
-    /// A [`Condition`]-satisfying system that returns `true`
+    /// A [`SystemCondition`]-satisfying system that returns `true`
     /// if the resource of the given type has had its value changed since the condition
     /// was last checked.
     ///
@@ -718,7 +718,7 @@ pub mod common_conditions {
         }
     }
 
-    /// A [`Condition`]-satisfying system that returns `true`
+    /// A [`SystemCondition`]-satisfying system that returns `true`
     /// if the resource of the given type has had its value changed since the condition
     /// was last checked.
     ///
@@ -795,7 +795,7 @@ pub mod common_conditions {
         }
     }
 
-    /// A [`Condition`]-satisfying system that returns `true`
+    /// A [`SystemCondition`]-satisfying system that returns `true`
     /// if the resource of the given type has been removed since the condition was last checked.
     ///
     /// # Example
@@ -847,7 +847,7 @@ pub mod common_conditions {
         }
     }
 
-    /// A [`Condition`]-satisfying system that returns `true`
+    /// A [`SystemCondition`]-satisfying system that returns `true`
     /// if there are any new events of the given type since it was last called.
     ///
     /// # Example
@@ -891,7 +891,7 @@ pub mod common_conditions {
         reader.read().count() > 0
     }
 
-    /// A [`Condition`]-satisfying system that returns `true`
+    /// A [`SystemCondition`]-satisfying system that returns `true`
     /// if there are any entities with the given component type.
     ///
     /// # Example
@@ -928,7 +928,7 @@ pub mod common_conditions {
         !query.is_empty()
     }
 
-    /// A [`Condition`]-satisfying system that returns `true`
+    /// A [`SystemCondition`]-satisfying system that returns `true`
     /// if there are any entity with a component of the given type removed.
     pub fn any_component_removed<T: Component>(mut removals: RemovedComponents<T>) -> bool {
         // `RemovedComponents` based on events and therefore events need to be consumed,
@@ -939,13 +939,13 @@ pub mod common_conditions {
         removals.read().count() > 0
     }
 
-    /// A [`Condition`]-satisfying system that returns `true`
+    /// A [`SystemCondition`]-satisfying system that returns `true`
     /// if there are any entities that match the given [`QueryFilter`].
     pub fn any_match_filter<F: QueryFilter>(query: Query<(), F>) -> bool {
         !query.is_empty()
     }
 
-    /// Generates a [`Condition`] that inverses the result of passed one.
+    /// Generates a [`SystemCondition`] that inverses the result of passed one.
     ///
     /// # Example
     ///
@@ -984,7 +984,7 @@ pub mod common_conditions {
         NotSystem::new(super::NotMarker, condition, name.into())
     }
 
-    /// Generates a [`Condition`] that returns true when the passed one changes.
+    /// Generates a [`SystemCondition`] that returns true when the passed one changes.
     ///
     /// The first time this is called, the passed condition is assumed to have been previously false.
     ///
@@ -1022,10 +1022,10 @@ pub mod common_conditions {
     /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 2);
     /// ```
-    pub fn condition_changed<Marker, CIn, C>(condition: C) -> impl Condition<(), CIn>
+    pub fn condition_changed<Marker, CIn, C>(condition: C) -> impl SystemCondition<(), CIn>
     where
         CIn: SystemInput,
-        C: Condition<Marker, CIn>,
+        C: SystemCondition<Marker, CIn>,
     {
         IntoSystem::into_system(condition.pipe(|In(new): In<bool>, mut prev: Local<bool>| {
             let changed = *prev != new;
@@ -1034,7 +1034,7 @@ pub mod common_conditions {
         }))
     }
 
-    /// Generates a [`Condition`] that returns true when the result of
+    /// Generates a [`SystemCondition`] that returns true when the result of
     /// the passed one went from false to true since the last time this was called.
     ///
     /// The first time this is called, the passed condition is assumed to have been previously false.
@@ -1078,10 +1078,10 @@ pub mod common_conditions {
     /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 2);
     /// ```
-    pub fn condition_changed_to<Marker, CIn, C>(to: bool, condition: C) -> impl Condition<(), CIn>
+    pub fn condition_changed_to<Marker, CIn, C>(to: bool, condition: C) -> impl SystemCondition<(), CIn>
     where
         CIn: SystemInput,
-        C: Condition<Marker, CIn>,
+        C: SystemCondition<Marker, CIn>,
     {
         IntoSystem::into_system(condition.pipe(
             move |In(new): In<bool>, mut prev: Local<bool>| -> bool {
@@ -1262,7 +1262,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{common_conditions::*, Condition};
+    use super::{common_conditions::*, SystemCondition};
     use crate::query::With;
     use crate::{
         change_detection::ResMut,

--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -71,7 +71,9 @@ pub type BoxedCondition<In = ()> = Box<dyn ReadOnlySystem<In = In, Out = bool>>;
 /// # world.insert_resource(DidRun(false));
 /// # app.run(&mut world);
 /// # assert!(world.resource::<DidRun>().0);
-pub trait SystemCondition<Marker, In: SystemInput = ()>: sealed::SystemCondition<Marker, In> {
+pub trait SystemCondition<Marker, In: SystemInput = ()>:
+    sealed::SystemCondition<Marker, In>
+{
     /// Returns a new run condition that only returns `true`
     /// if both this one and the passed `and` return `true`.
     ///
@@ -369,7 +371,10 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>: sealed::SystemCondition
     }
 }
 
-impl<Marker, In: SystemInput, F> SystemCondition<Marker, In> for F where F: sealed::SystemCondition<Marker, In> {}
+impl<Marker, In: SystemInput, F> SystemCondition<Marker, In> for F where
+    F: sealed::SystemCondition<Marker, In>
+{
+}
 
 mod sealed {
     use crate::system::{IntoSystem, ReadOnlySystem, SystemInput};
@@ -393,7 +398,7 @@ mod sealed {
 
 /// A collection of [run conditions](SystemCondition) that may be useful in any bevy app.
 pub mod common_conditions {
-    use super::{SystemCondition, NotSystem};
+    use super::{NotSystem, SystemCondition};
     use crate::{
         change_detection::DetectChanges,
         event::{Event, EventReader},
@@ -1078,7 +1083,10 @@ pub mod common_conditions {
     /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 2);
     /// ```
-    pub fn condition_changed_to<Marker, CIn, C>(to: bool, condition: C) -> impl SystemCondition<(), CIn>
+    pub fn condition_changed_to<Marker, CIn, C>(
+        to: bool,
+        condition: C,
+    ) -> impl SystemCondition<(), CIn>
     where
         CIn: SystemInput,
         C: SystemCondition<Marker, CIn>,

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -410,7 +410,10 @@ pub trait IntoScheduleConfigs<T: Schedulable<Metadata = GraphInfo, GroupMetadata
     /// Use [`run_if`](ScheduleConfigs::run_if) on a [`SystemSet`] if you want to make sure
     /// that either all or none of the systems are run, or you don't want to evaluate the run
     /// condition for each contained system separately.
-    fn distributive_run_if<M>(self, condition: impl SystemCondition<M> + Clone) -> ScheduleConfigs<T> {
+    fn distributive_run_if<M>(
+        self,
+        condition: impl SystemCondition<M> + Clone,
+    ) -> ScheduleConfigs<T> {
         self.into_configs().distributive_run_if(condition)
     }
 

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -18,7 +18,7 @@ fn new_condition<M>(condition: impl SystemCondition<M>) -> BoxedCondition {
     let condition_system = IntoSystem::into_system(condition);
     assert!(
         condition_system.is_send(),
-        "Condition `{}` accesses `NonSend` resources. This is not currently supported.",
+        "SystemCondition `{}` accesses `NonSend` resources. This is not currently supported.",
         condition_system.name()
     );
 

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -6,7 +6,7 @@ use crate::{
     never::Never,
     schedule::{
         auto_insert_apply_deferred::IgnoreDeferred,
-        condition::{BoxedCondition, Condition},
+        condition::{BoxedCondition, SystemCondition},
         graph::{Ambiguity, Dependency, DependencyKind, GraphInfo},
         set::{InternedSystemSet, IntoSystemSet, SystemSet},
         Chain,
@@ -14,7 +14,7 @@ use crate::{
     system::{BoxedSystem, InfallibleSystemWrapper, IntoSystem, ScheduleSystem, System},
 };
 
-fn new_condition<M>(condition: impl Condition<M>) -> BoxedCondition {
+fn new_condition<M>(condition: impl SystemCondition<M>) -> BoxedCondition {
     let condition_system = IntoSystem::into_system(condition);
     assert!(
         condition_system.is_send(),
@@ -191,7 +191,7 @@ impl<T: Schedulable<Metadata = GraphInfo, GroupMetadata = Chain>> ScheduleConfig
         }
     }
 
-    fn distributive_run_if_inner<M>(&mut self, condition: impl Condition<M> + Clone) {
+    fn distributive_run_if_inner<M>(&mut self, condition: impl SystemCondition<M> + Clone) {
         match self {
             Self::ScheduleConfig(config) => {
                 config.conditions.push(new_condition(condition));
@@ -382,8 +382,8 @@ pub trait IntoScheduleConfigs<T: Schedulable<Metadata = GraphInfo, GroupMetadata
 
     /// Add a run condition to each contained system.
     ///
-    /// Each system will receive its own clone of the [`Condition`] and will only run
-    /// if the `Condition` is true.
+    /// Each system will receive its own clone of the [`SystemCondition`] and will only run
+    /// if the `SystemCondition` is true.
     ///
     /// Each individual condition will be evaluated at most once (per schedule run),
     /// right before the corresponding system prepares to run.
@@ -410,13 +410,13 @@ pub trait IntoScheduleConfigs<T: Schedulable<Metadata = GraphInfo, GroupMetadata
     /// Use [`run_if`](ScheduleConfigs::run_if) on a [`SystemSet`] if you want to make sure
     /// that either all or none of the systems are run, or you don't want to evaluate the run
     /// condition for each contained system separately.
-    fn distributive_run_if<M>(self, condition: impl Condition<M> + Clone) -> ScheduleConfigs<T> {
+    fn distributive_run_if<M>(self, condition: impl SystemCondition<M> + Clone) -> ScheduleConfigs<T> {
         self.into_configs().distributive_run_if(condition)
     }
 
-    /// Run the systems only if the [`Condition`] is `true`.
+    /// Run the systems only if the [`SystemCondition`] is `true`.
     ///
-    /// The `Condition` will be evaluated at most once (per schedule run),
+    /// The `SystemCondition` will be evaluated at most once (per schedule run),
     /// the first time a system in this set prepares to run.
     ///
     /// If this set contains more than one system, calling `run_if` is equivalent to adding each
@@ -444,7 +444,7 @@ pub trait IntoScheduleConfigs<T: Schedulable<Metadata = GraphInfo, GroupMetadata
     ///
     /// Use [`distributive_run_if`](IntoScheduleConfigs::distributive_run_if) if you want the
     /// condition to be evaluated for each individual system, right before one is run.
-    fn run_if<M>(self, condition: impl Condition<M>) -> ScheduleConfigs<T> {
+    fn run_if<M>(self, condition: impl SystemCondition<M>) -> ScheduleConfigs<T> {
         self.into_configs().run_if(condition)
     }
 
@@ -526,13 +526,13 @@ impl<T: Schedulable<Metadata = GraphInfo, GroupMetadata = Chain>> IntoScheduleCo
 
     fn distributive_run_if<M>(
         mut self,
-        condition: impl Condition<M> + Clone,
+        condition: impl SystemCondition<M> + Clone,
     ) -> ScheduleConfigs<T> {
         self.distributive_run_if_inner(condition);
         self
     }
 
-    fn run_if<M>(mut self, condition: impl Condition<M>) -> ScheduleConfigs<T> {
+    fn run_if<M>(mut self, condition: impl SystemCondition<M>) -> ScheduleConfigs<T> {
         self.run_if_dyn(new_condition(condition));
         self
     }

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -414,7 +414,7 @@ mod tests {
         removal_detection::RemovedComponents,
         resource::Resource,
         schedule::{
-            common_conditions::resource_exists, ApplyDeferred, Condition, IntoScheduleConfigs,
+            common_conditions::resource_exists, ApplyDeferred, SystemCondition, IntoScheduleConfigs,
             Schedule,
         },
         system::{

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -414,8 +414,8 @@ mod tests {
         removal_detection::RemovedComponents,
         resource::Resource,
         schedule::{
-            common_conditions::resource_exists, ApplyDeferred, SystemCondition, IntoScheduleConfigs,
-            Schedule,
+            common_conditions::resource_exists, ApplyDeferred, IntoScheduleConfigs, Schedule,
+            SystemCondition,
         },
         system::{
             Commands, In, InMut, IntoSystem, Local, NonSend, NonSendMut, ParamSet, Query, Res,

--- a/crates/bevy_input/src/button_input.rs
+++ b/crates/bevy_input/src/button_input.rs
@@ -71,7 +71,7 @@ use {
 /// Reading and checking against the current set of pressed buttons:
 /// ```no_run
 /// # use bevy_app::{App, NoopPluginGroup as DefaultPlugins, Update};
-/// # use bevy_ecs::{prelude::{IntoScheduleConfigs, Res, Resource, resource_changed}, schedule::Condition};
+/// # use bevy_ecs::{prelude::{IntoScheduleConfigs, Res, Resource, resource_changed}, schedule::SystemCondition};
 /// # use bevy_input::{ButtonInput, prelude::{KeyCode, MouseButton}};
 ///
 /// fn main() {

--- a/crates/bevy_state/src/app.rs
+++ b/crates/bevy_state/src/app.rs
@@ -25,7 +25,7 @@ pub trait AppExtStates {
     /// These schedules are triggered before [`Update`](bevy_app::Update) and at startup.
     ///
     /// If you would like to control how other systems run based on the current state, you can
-    /// emulate this behavior using the [`in_state`](crate::condition::in_state) [`Condition`](bevy_ecs::prelude::Condition).
+    /// emulate this behavior using the [`in_state`](crate::condition::in_state) [`SystemCondition`](bevy_ecs::prelude::SystemCondition).
     ///
     /// Note that you can also apply state transitions at other points in the schedule
     /// by triggering the [`StateTransition`](struct@StateTransition) schedule manually.
@@ -41,7 +41,7 @@ pub trait AppExtStates {
     /// These schedules are triggered before [`Update`](bevy_app::Update) and at startup.
     ///
     /// If you would like to control how other systems run based on the current state, you can
-    /// emulate this behavior using the [`in_state`](crate::condition::in_state) [`Condition`](bevy_ecs::prelude::Condition).
+    /// emulate this behavior using the [`in_state`](crate::condition::in_state) [`SystemCondition`](bevy_ecs::prelude::SystemCondition).
     ///
     /// Note that you can also apply state transitions at other points in the schedule
     /// by triggering the [`StateTransition`](struct@StateTransition) schedule manually.

--- a/crates/bevy_state/src/condition.rs
+++ b/crates/bevy_state/src/condition.rs
@@ -171,7 +171,7 @@ pub fn state_changed<S: States>(current_state: Option<Res<State<S>>>) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use bevy_ecs::schedule::{SystemCondition, IntoScheduleConfigs, Schedule};
+    use bevy_ecs::schedule::{IntoScheduleConfigs, Schedule, SystemCondition};
 
     use crate::prelude::*;
     use bevy_state_macros::States;

--- a/crates/bevy_state/src/condition.rs
+++ b/crates/bevy_state/src/condition.rs
@@ -1,7 +1,7 @@
 use crate::state::{State, States};
 use bevy_ecs::{change_detection::DetectChanges, system::Res};
 
-/// A [`Condition`](bevy_ecs::prelude::Condition)-satisfying system that returns `true`
+/// A [`SystemCondition`](bevy_ecs::prelude::SystemCondition)-satisfying system that returns `true`
 /// if the state machine exists.
 ///
 /// # Example
@@ -48,7 +48,7 @@ pub fn state_exists<S: States>(current_state: Option<Res<State<S>>>) -> bool {
     current_state.is_some()
 }
 
-/// Generates a [`Condition`](bevy_ecs::prelude::Condition)-satisfying closure that returns `true`
+/// Generates a [`SystemCondition`](bevy_ecs::prelude::SystemCondition)-satisfying closure that returns `true`
 /// if the state machine is currently in `state`.
 ///
 /// Will return `false` if the state does not exist or if not in `state`.
@@ -107,7 +107,7 @@ pub fn in_state<S: States>(state: S) -> impl FnMut(Option<Res<State<S>>>) -> boo
     }
 }
 
-/// A [`Condition`](bevy_ecs::prelude::Condition)-satisfying system that returns `true`
+/// A [`SystemCondition`](bevy_ecs::prelude::SystemCondition)-satisfying system that returns `true`
 /// if the state machine changed state.
 ///
 /// To do things on transitions to/from specific states, use their respective OnEnter/OnExit

--- a/crates/bevy_state/src/condition.rs
+++ b/crates/bevy_state/src/condition.rs
@@ -171,7 +171,7 @@ pub fn state_changed<S: States>(current_state: Option<Res<State<S>>>) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use bevy_ecs::schedule::{Condition, IntoScheduleConfigs, Schedule};
+    use bevy_ecs::schedule::{SystemCondition, IntoScheduleConfigs, Schedule};
 
     use crate::prelude::*;
     use bevy_state_macros::States;

--- a/release-content/migration-guides/rename_condition.md
+++ b/release-content/migration-guides/rename_condition.md
@@ -1,0 +1,8 @@
+---
+title: Renamed `Condition` to `SystemCondition`
+pull_requests: [19328]
+---
+
+`Condition` is now `SystemCondition`. Replace all references and imports.
+
+This change was made because `Condition` is an overly generic name that collides too often and is rarely used directly, despite appearing in the prelyde.

--- a/release-content/migration-guides/rename_condition.md
+++ b/release-content/migration-guides/rename_condition.md
@@ -5,4 +5,4 @@ pull_requests: [19328]
 
 `Condition` is now `SystemCondition`. Replace all references and imports.
 
-This change was made because `Condition` is an overly generic name that collides too often and is rarely used directly, despite appearing in the prelyde.
+This change was made because `Condition` is an overly generic name that collides too often and is rarely used directly, despite appearing in the prelude.


### PR DESCRIPTION
# Objective
Fixes #19120 

## Solution
Use the find and replace token feature in VSCode to replace all the `Condition`s with `SystemCondition`s. Then look through all the documentation with find and replace to replace all the `Condition`s there.

## Testing

- Did you test these changes? If so, how?
Yes, used cargo clippy, cargo build and cargo test.
- Are there any parts that need more testing?
Nope
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
By compiling and running bevy
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?
Shouldn't be, but Fedora Linux with KDE Wayland
