### PR TITLE
OkLab, Oklch color space support for UI gradients

### DIFF
--- a/crates/bevy_ui/src/gradients.rs
+++ b/crates/bevy_ui/src/gradients.rs
@@ -3,6 +3,7 @@ use bevy_color::{Color, Srgba};
 use bevy_ecs::component::Component;
 use bevy_math::Vec2;
 use bevy_reflect::prelude::*;
+use bevy_utils::default;
 use core::{f32, f32::consts::TAU};
 
 /// A color stop for a gradient
@@ -205,7 +206,7 @@ impl Default for AngularColorStop {
 /// A linear gradient
 ///
 /// <https://developer.mozilla.org/en-US/docs/Web/CSS/gradient/linear-gradient>
-#[derive(Clone, PartialEq, Debug, Reflect)]
+#[derive(Default, Clone, PartialEq, Debug, Reflect)]
 #[reflect(PartialEq)]
 #[cfg_attr(
     feature = "serialize",
@@ -213,6 +214,8 @@ impl Default for AngularColorStop {
     reflect(Serialize, Deserialize)
 )]
 pub struct LinearGradient {
+    /// The color space used for interpolation.
+    pub color_space: InterpolationColorSpace,
     /// The direction of the gradient.
     /// An angle of `0.` points upward, angles increasing clockwise.
     pub angle: f32,
@@ -240,7 +243,11 @@ impl LinearGradient {
 
     /// Create a new linear gradient
     pub fn new(angle: f32, stops: Vec<ColorStop>) -> Self {
-        Self { angle, stops }
+        Self {
+            angle,
+            stops,
+            color_space: InterpolationColorSpace::default(),
+        }
     }
 
     /// A linear gradient transitioning from bottom to top
@@ -248,6 +255,7 @@ impl LinearGradient {
         Self {
             angle: Self::TO_TOP,
             stops,
+            color_space: InterpolationColorSpace::default(),
         }
     }
 
@@ -256,6 +264,7 @@ impl LinearGradient {
         Self {
             angle: Self::TO_TOP_RIGHT,
             stops,
+            color_space: InterpolationColorSpace::default(),
         }
     }
 
@@ -264,6 +273,7 @@ impl LinearGradient {
         Self {
             angle: Self::TO_RIGHT,
             stops,
+            color_space: InterpolationColorSpace::default(),
         }
     }
 
@@ -272,6 +282,7 @@ impl LinearGradient {
         Self {
             angle: Self::TO_BOTTOM_RIGHT,
             stops,
+            color_space: InterpolationColorSpace::default(),
         }
     }
 
@@ -280,6 +291,7 @@ impl LinearGradient {
         Self {
             angle: Self::TO_BOTTOM,
             stops,
+            color_space: InterpolationColorSpace::default(),
         }
     }
 
@@ -288,6 +300,7 @@ impl LinearGradient {
         Self {
             angle: Self::TO_BOTTOM_LEFT,
             stops,
+            color_space: InterpolationColorSpace::default(),
         }
     }
 
@@ -296,6 +309,7 @@ impl LinearGradient {
         Self {
             angle: Self::TO_LEFT,
             stops,
+            color_space: InterpolationColorSpace::default(),
         }
     }
 
@@ -304,6 +318,7 @@ impl LinearGradient {
         Self {
             angle: Self::TO_TOP_LEFT,
             stops,
+            color_space: InterpolationColorSpace::default(),
         }
     }
 
@@ -312,7 +327,13 @@ impl LinearGradient {
         Self {
             angle: degrees.to_radians(),
             stops,
+            color_space: InterpolationColorSpace::default(),
         }
+    }
+
+    pub fn in_color_space(mut self, color_space: InterpolationColorSpace) -> Self {
+        self.color_space = color_space;
+        self
     }
 }
 
@@ -327,6 +348,8 @@ impl LinearGradient {
     reflect(Serialize, Deserialize)
 )]
 pub struct RadialGradient {
+    /// The color space used for interpolation.
+    pub color_space: InterpolationColorSpace,
     /// The center of the radial gradient
     pub position: Position,
     /// Defines the end shape of the radial gradient
@@ -339,16 +362,23 @@ impl RadialGradient {
     /// Create a new radial gradient
     pub fn new(position: Position, shape: RadialGradientShape, stops: Vec<ColorStop>) -> Self {
         Self {
+            color_space: default(),
             position,
             shape,
             stops,
         }
+    }
+
+    pub fn in_color_space(mut self, color_space: InterpolationColorSpace) -> Self {
+        self.color_space = color_space;
+        self
     }
 }
 
 impl Default for RadialGradient {
     fn default() -> Self {
         Self {
+            color_space: default(),
             position: Position::CENTER,
             shape: RadialGradientShape::ClosestCorner,
             stops: Vec::new(),
@@ -359,7 +389,7 @@ impl Default for RadialGradient {
 /// A conic gradient
 ///
 /// <https://developer.mozilla.org/en-US/docs/Web/CSS/gradient/conic-gradient>
-#[derive(Clone, PartialEq, Debug, Reflect)]
+#[derive(Default, Clone, PartialEq, Debug, Reflect)]
 #[reflect(PartialEq)]
 #[cfg_attr(
     feature = "serialize",
@@ -367,6 +397,8 @@ impl Default for RadialGradient {
     reflect(Serialize, Deserialize)
 )]
 pub struct ConicGradient {
+    /// The color space used for interpolation.
+    pub color_space: InterpolationColorSpace,
     /// The starting angle of the gradient in radians
     pub start: f32,
     /// The center of the conic gradient
@@ -379,6 +411,7 @@ impl ConicGradient {
     /// create a new conic gradient
     pub fn new(position: Position, stops: Vec<AngularColorStop>) -> Self {
         Self {
+            color_space: default(),
             start: 0.,
             position,
             stops,
@@ -394,6 +427,11 @@ impl ConicGradient {
     /// Sets the position of the gradient
     pub fn with_position(mut self, position: Position) -> Self {
         self.position = position;
+        self
+    }
+
+    pub fn in_color_space(mut self, color_space: InterpolationColorSpace) -> Self {
+        self.color_space = color_space;
         self
     }
 }
@@ -571,5 +609,66 @@ impl RadialGradientShape {
                     .unwrap_or(0.),
             ),
         }
+    }
+}
+
+/// The color space used for interpolation.
+#[derive(Default, Copy, Clone, Hash, Debug, PartialEq, Eq, Reflect)]
+pub enum InterpolationColorSpace {
+    /// Interpolates in OKLab space.
+    #[default]
+    OkLab,
+    /// Interpolates in OKLCH space, taking the shortest hue path.
+    OkLch,
+    /// Interpolates in OKLCH space, taking the longest hue path.
+    OkLchLong,
+    /// Interpolates in sRGB space.
+    Srgb,
+    /// Interpolates in the linear sRGB space.
+    LinearRgb,
+}
+
+pub trait InColorSpace: Sized {
+    fn in_color_space(self, color_space: InterpolationColorSpace) -> Self;
+
+    fn in_oklab(self) -> Self {
+        self.in_color_space(InterpolationColorSpace::OkLab)
+    }
+
+    fn in_oklch(self) -> Self {
+        self.in_color_space(InterpolationColorSpace::OkLch)
+    }
+
+    fn in_oklch_long(self) -> Self {
+        self.in_color_space(InterpolationColorSpace::OkLchLong)
+    }
+
+    fn in_srgb(self) -> Self {
+        self.in_color_space(InterpolationColorSpace::Srgb)
+    }
+
+    fn in_linear_rgb(self) -> Self {
+        self.in_color_space(InterpolationColorSpace::LinearRgb)
+    }
+}
+
+impl InColorSpace for LinearGradient {
+    fn in_color_space(mut self, color_space: InterpolationColorSpace) -> Self {
+        self.color_space = color_space;
+        self
+    }
+}
+
+impl InColorSpace for RadialGradient {
+    fn in_color_space(mut self, color_space: InterpolationColorSpace) -> Self {
+        self.color_space = color_space;
+        self
+    }
+}
+
+impl InColorSpace for ConicGradient {
+    fn in_color_space(mut self, color_space: InterpolationColorSpace) -> Self {
+        self.color_space = color_space;
+        self
     }
 }

--- a/crates/bevy_ui/src/render/gradient.wgsl
+++ b/crates/bevy_ui/src/render/gradient.wgsl
@@ -117,6 +117,89 @@ fn mix_linear_rgb_in_srgb_space(a: vec4<f32>, b: vec4<f32>, t: f32) -> vec4<f32>
     return vec4(pow(mixed_srgb, vec3(2.2)), mix(a.a, b.a, t));
 }
 
+fn linear_rgb_to_oklab(c: vec4<f32>) -> vec4<f32> {
+    let l = pow(0.41222146 * c.x + 0.53633255 * c.y + 0.051445995 * c.z, 1. / 3.);
+    let m = pow(0.2119035 * c.x + 0.6806995 * c.y + 0.10739696 * c.z, 1. / 3.);
+    let s = pow(0.08830246 * c.x + 0.28171885 * c.y + 0.6299787 * c.z, 1. / 3.);
+    return vec4(
+        0.21045426 * l + 0.7936178 * m - 0.004072047 * s,
+        1.9779985 * l - 2.4285922 * m + 0.4505937 * s,
+        0.025904037 * l + 0.78277177 * m  - 0.80867577 * s,
+        c.w
+    );
+}
+
+fn oklab_to_linear_rgba(c: vec4<f32>) -> vec4<f32> {
+    let l_ = c.x + 0.39633778 * c.y + 0.21580376 * c.z;
+    let m_ = c.x - 0.105561346 * c.y - 0.06385417 * c.z;
+    let s_ = c.x - 0.08948418 * c.y - 1.2914855 * c.z;
+    let l = l_ * l_ * l_;
+    let m = m_ * m_ * m_;
+    let s = s_ * s_ * s_;
+    return vec4(
+        4.0767417 * l - 3.3077116 * m + 0.23096994 * s,
+        -1.268438 * l + 2.6097574 * m - 0.34131938 * s,
+        -0.0041960863 * l - 0.7034186 * m + 1.7076147 * s,
+        c.w
+    );
+}
+
+fn mix_linear_rgb_in_oklab_space(a: vec4<f32>, b: vec4<f32>, t: f32) -> vec4<f32> { 
+    return oklab_to_linear_rgba(mix(linear_rgb_to_oklab(a), linear_rgb_to_oklab(b), t));
+}
+
+/// hue is left in radians and not converted to degrees
+fn linear_rgb_to_oklch(c: vec4<f32>) -> vec4<f32> {
+    let o = linear_rgb_to_oklab(c);
+    let chroma = sqrt(o.y * o.y + o.z * o.z);
+    let hue = atan2(o.z, o.y);
+    return vec4(o.x, chroma, select(hue + TAU, hue, hue < 0.0), o.w);
+}
+
+fn oklch_to_linear_rgb(c: vec4<f32>) -> vec4<f32> {
+    let a = c.y * cos(c.z);
+    let b = c.y * sin(c.z);
+    return oklab_to_linear_rgba(vec4(c.x, a, b, c.w));
+}
+
+fn rem_euclid(a: f32, b: f32) -> f32 {
+    return ((a % b) + b) % b;
+}
+
+fn lerp_hue(a: f32, b: f32, t: f32) -> f32 {
+    let diff = rem_euclid(b - a + PI, TAU) - PI;
+    return rem_euclid(a + diff * t, TAU);
+}
+
+fn lerp_hue_long(a: f32, b: f32, t: f32) -> f32 {
+    let diff = rem_euclid(b - a + PI, TAU) - PI;
+    return rem_euclid(a + select(diff - TAU, diff + TAU, 0. < diff) * t, TAU);
+}
+
+fn mix_oklch(a: vec4<f32>, b: vec4<f32>, t: f32) -> vec4<f32> {
+    return vec4(
+        mix(a.xy, b.xy, t),
+        lerp_hue(a.z, b.z, t),
+        mix(a.w, b.w, t)
+    );
+}
+
+fn mix_oklch_long(a: vec4<f32>, b: vec4<f32>, t: f32) -> vec4<f32> {
+    return vec4(
+        mix(a.xy, b.xy, t),
+        lerp_hue_long(a.z, b.z, t),
+        mix(a.w, b.w, t)
+    );
+}
+
+fn mix_linear_rgb_in_oklch_space(a: vec4<f32>, b: vec4<f32>, t: f32) -> vec4<f32> {
+    return oklch_to_linear_rgb(mix_oklch(linear_rgb_to_oklch(a), linear_rgb_to_oklch(b), t));
+}
+
+fn mix_linear_rgb_in_oklch_space_long(a: vec4<f32>, b: vec4<f32>, t: f32) -> vec4<f32> {
+    return oklch_to_linear_rgb(mix_oklch_long(linear_rgb_to_oklch(a), linear_rgb_to_oklch(b), t));
+}
+
 // These functions are used to calculate the distance in gradient space from the start of the gradient to the point.
 // The distance in gradient space is then used to interpolate between the start and end colors.
 
@@ -187,7 +270,16 @@ fn interpolate_gradient(
     } else {
         t = 0.5 * (1 + (t - hint) / (1.0 - hint));
     }
-
-    // Only color interpolation in SRGB space is supported atm.
+    
+#ifdef IN_SRGB
     return mix_linear_rgb_in_srgb_space(start_color, end_color, t);
+#else ifdef IN_OKLAB
+    return mix_linear_rgb_in_oklab_space(start_color, end_color, t);
+#else ifdef IN_OKLCH
+    return mix_linear_rgb_in_oklch_space(start_color, end_color, t);
+#else ifdef IN_OKLCH_LONG
+    return mix_linear_rgb_in_oklch_space_long(start_color, end_color, t);
+#else
+    return mix(start_color, end_color, t);
+#endif
 }

--- a/examples/ui/gradients.rs
+++ b/examples/ui/gradients.rs
@@ -87,6 +87,7 @@ fn setup(mut commands: Commands) {
                                                 BackgroundGradient::from(LinearGradient {
                                                     angle,
                                                     stops: stops.clone(),
+                                                    ..default()
                                                 }),
                                                 BorderGradient::from(LinearGradient {
                                                     angle: 3. * TAU / 8.,
@@ -95,6 +96,7 @@ fn setup(mut commands: Commands) {
                                                         Color::WHITE.into(),
                                                         ORANGE.into(),
                                                     ],
+                                                    ..default()
                                                 }),
                                             ));
                                         }
@@ -115,10 +117,12 @@ fn setup(mut commands: Commands) {
                             BackgroundGradient::from(LinearGradient {
                                 angle: 0.,
                                 stops: stops.clone(),
+                                ..default()
                             }),
                             BorderGradient::from(LinearGradient {
                                 angle: 3. * TAU / 8.,
                                 stops: vec![YELLOW.into(), Color::WHITE.into(), ORANGE.into()],
+                                ..default()
                             }),
                             AnimateMarker,
                         ));
@@ -136,10 +140,12 @@ fn setup(mut commands: Commands) {
                                 stops: stops.clone(),
                                 shape: RadialGradientShape::ClosestSide,
                                 position: Position::CENTER,
+                                ..default()
                             }),
                             BorderGradient::from(LinearGradient {
                                 angle: 3. * TAU / 8.,
                                 stops: vec![YELLOW.into(), Color::WHITE.into(), ORANGE.into()],
+                                ..default()
                             }),
                             AnimateMarker,
                         ));
@@ -159,10 +165,12 @@ fn setup(mut commands: Commands) {
                                     .map(|stop| AngularColorStop::auto(stop.color))
                                     .collect(),
                                 position: Position::CENTER,
+                                ..default()
                             }),
                             BorderGradient::from(LinearGradient {
                                 angle: 3. * TAU / 8.,
                                 stops: vec![YELLOW.into(), Color::WHITE.into(), ORANGE.into()],
+                                ..default()
                             }),
                             AnimateMarker,
                         ));

--- a/examples/ui/radial_gradients.rs
+++ b/examples/ui/radial_gradients.rs
@@ -88,6 +88,7 @@ fn setup_grid(mut commands: Commands) {
                                         stops: color_stops.clone(),
                                         position,
                                         shape,
+                                        ..Default::default()
                                     }),
                                 ));
                             });

--- a/examples/ui/stacked_gradients.rs
+++ b/examples/ui/stacked_gradients.rs
@@ -52,6 +52,7 @@ fn setup(mut commands: Commands) {
                             AngularColorStop::auto(YELLOW.with_alpha(0.)),
                             AngularColorStop::auto(YELLOW.with_alpha(0.)),
                         ],
+                        ..Default::default()
                     }
                     .into(),
                     RadialGradient {
@@ -63,6 +64,7 @@ fn setup(mut commands: Commands) {
                             ColorStop::auto(YELLOW.with_alpha(0.1)),
                             ColorStop::auto(YELLOW.with_alpha(0.)),
                         ],
+                        ..Default::default()
                     }
                     .into(),
                     LinearGradient {
@@ -71,6 +73,7 @@ fn setup(mut commands: Commands) {
                             ColorStop::auto(Color::BLACK),
                             ColorStop::auto(Color::BLACK.with_alpha(0.)),
                         ],
+                        ..Default::default()
                     }
                     .into(),
                     LinearGradient {
@@ -79,6 +82,7 @@ fn setup(mut commands: Commands) {
                             ColorStop::auto(Color::BLACK),
                             ColorStop::auto(Color::BLACK.with_alpha(0.)),
                         ],
+                        ..Default::default()
                     }
                     .into(),
                 ]),


### PR DESCRIPTION
* Added color space specialization to gradients pipeline.
* Added support for interpolation in OkLch and OkLab color spaces to shader.
* Added color space fields to each gradient type.
* Updated examples.

# Objective

- Describe the objective or issue this PR addresses.
- If you're fixing a specific issue, say "Fixes #X".

## Solution

- Describe the solution used to achieve the objective above.

## Testing

- Did you test these changes? If so, how?
- Are there any parts that need more testing?
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?

---

## Showcase

> This section is optional. If this PR does not include a visual change or does not add a new feature, you can delete this section.

- Help others understand the result of this PR by showcasing your awesome work!
- If this PR adds a new feature or public API, consider adding a brief pseudo-code snippet of it in action
- If this PR includes a visual change, consider adding a screenshot, GIF, or video
  - If you want, you could even include a before/after comparison!
- If the Migration Guide adequately covers the changes, you can delete this section

While a showcase should aim to be brief and digestible, you can use a toggleable section to save space on longer showcases:

<details>
  <summary>Click to view showcase</summary>

```rust
println!("My super cool code.");
```

</details>
