### PR TITLE
chore:added compiler_error!() for additional description to vague error

### DIFF
--- a/crates/bevy_tasks/src/lib.rs
+++ b/crates/bevy_tasks/src/lib.rs
@@ -6,6 +6,25 @@
 )]
 #![no_std]
 
+#[cfg(all(feature = "multi_threaded", not(feature = "async_executor")))]
+compile_error!(
+    r#"
+    The "multi_threaded" feature of `bevy_tasks` requires the "async_executor" feature
+    to be enabled alongside it.
+
+    This is because the multi-threaded task pool relies on an executor to run futures,
+    which is provided by the "async_executor" feature.
+
+    Please enable the "async_executor" feature in your `Cargo.toml` for `bevy_tasks`:
+
+    [dependencies]
+    bevy_tasks = { version = "...", default-features = false, features = ["multi_threaded", "async_executor"] }
+
+    If you are using `bevy`'s `DefaultPlugins`, the "async_executor" feature
+    for `bevy_tasks` is typically enabled automatically via Bevy's default features.
+"#
+);
+
 #[cfg(feature = "std")]
 extern crate std;
 


### PR DESCRIPTION
## Objective

This PR provides a potential fix for #19051.

---

## Solution

The `compile_error!()` is added to `bevy_tasks/src/lib.rs`. It triggers specifically when the `multi_threaded` feature is active, but `async_executor` is not.

The error message is user-friendly, detailing:
* The missing dependency.
* Why it's needed (multi-threaded pools require an executor).
* The exact `Cargo.toml` snippet for a fix.
* A note about how Bevy's `DefaultPlugins` usually handles this automatically.

---

## Testing

These changes were tested using a minimal, external project designed to specifically trigger the new `compile_error!()`.

### How it was tested:
1.  A `compile_fail_tasks` binary project was set up in an external directory.
2.  Its `Cargo.toml` was configured to depend on the local `bevy_tasks`, explicitly disabling default features and enabling only `multi_threaded`.
3.  A simple `src/main.rs` referenced a `bevy_tasks` component (`bevy_tasks::ComputeTaskPool::new();`) to ensure compilation paths were hit.
4.  The project was built using `cargo build -p compile_fail_tasks` from the Bevy root.

### Results:
The build **failed as expected**, prominently displaying the custom `compile_error!()` message. While other `Send`/`Sync` errors also appeared (confirming the underlying problem this fix addresses), the primary goal of providing a clear compile-time error was achieved.

### How to test:
Reviewers can easily verify this by:
1.  Checking out this PR.
2.  Creating `tests/compile_fail_tasks/Cargo.toml` with:
    ```toml
    # bevy/tests/compile_fail_tasks/Cargo.toml
    [package]
    name = "compile_fail_tasks"
    version = "0.1.0"
    edition = "2021"
    publish = false

    [dependencies]
    # path to bevy_tasks sub-crate to test locally
    bevy_tasks = { path = "../../bevy_tasks", default-features = false, features = ["multi_threaded"] }
    ```
4.  Running `cargo build -p compile_fail_tasks` or simply `cargo build` within the current directory.

### Platforms tested:
macOS (aarch64). As a `#[cfg]` based compile-time check, behavior should be consistent across platforms.

---