### PR TITLE
Diagnostic reset sum ema

### DIFF
--- a/crates/bevy_diagnostic/src/diagnostic.rs
+++ b/crates/bevy_diagnostic/src/diagnostic.rs
@@ -433,9 +433,7 @@ mod tests {
             Diagnostic::new(DiagnosticPath::new("test")).with_max_history_length(5);
         let mut now = Instant::now();
 
-        // Three times in a row...
         for _ in 0..3 {
-            // Fill the diagnostic with measurements...
             for _ in 0..5 {
                 diagnostic.add_measurement(DiagnosticMeasurement {
                     time: now,
@@ -444,10 +442,8 @@ mod tests {
                 // Increase time to test smoothed average.
                 now += Duration::from_secs(1);
             }
-            // Assert that the average and smoothed average are correct...
-            assert!((diagnostic.average().unwrap() - 20.0) < 0.1);
-            assert!((diagnostic.smoothed().unwrap() - 20.0) < 0.1);
-            // And clear the diagnostic history
+            assert!((diagnostic.average().unwrap() - 20.0).abs() < 0.1);
+            assert!((diagnostic.smoothed().unwrap() - 20.0).abs() < 0.1);
             diagnostic.clear_history();
         }
     }

--- a/crates/bevy_diagnostic/src/diagnostic.rs
+++ b/crates/bevy_diagnostic/src/diagnostic.rs
@@ -431,7 +431,7 @@ mod tests {
     fn test_clear_history() {
         let mut diagnostic =
             Diagnostic::new(DiagnosticPath::new("test")).with_max_history_length(5);
-        let now = Instant::now();
+        let mut now = Instant::now();
 
         // Three times in a row...
         for _ in 0..3 {
@@ -441,9 +441,12 @@ mod tests {
                     time: now,
                     value: 20.0,
                 });
+                // Increase time to test smoothed average.
+                now += Duration::from_secs(1);
             }
-            // Assert that the average is correct...
+            // Assert that the average and smoothed average are correct...
             assert!((diagnostic.average().unwrap() - 20.0) < 0.1);
+            assert!((diagnostic.smoothed().unwrap() - 20.0) < 0.1);
             // And clear the diagnostic history
             diagnostic.clear_history();
         }

--- a/crates/bevy_diagnostic/src/diagnostic.rs
+++ b/crates/bevy_diagnostic/src/diagnostic.rs
@@ -429,6 +429,8 @@ mod tests {
 
     #[test]
     fn test_clear_history() {
+        const MEASUREMENT: f64 = 20.0;
+
         let mut diagnostic =
             Diagnostic::new(DiagnosticPath::new("test")).with_max_history_length(5);
         let mut now = Instant::now();
@@ -437,13 +439,13 @@ mod tests {
             for _ in 0..5 {
                 diagnostic.add_measurement(DiagnosticMeasurement {
                     time: now,
-                    value: 20.0,
+                    value: MEASUREMENT,
                 });
                 // Increase time to test smoothed average.
                 now += Duration::from_secs(1);
             }
-            assert!((diagnostic.average().unwrap() - 20.0).abs() < 0.1);
-            assert!((diagnostic.smoothed().unwrap() - 20.0).abs() < 0.1);
+            assert!((diagnostic.average().unwrap() - MEASUREMENT).abs() < 0.1);
+            assert!((diagnostic.smoothed().unwrap() - MEASUREMENT).abs() < 0.1);
             diagnostic.clear_history();
         }
     }

--- a/crates/bevy_diagnostic/src/diagnostic.rs
+++ b/crates/bevy_diagnostic/src/diagnostic.rs
@@ -422,3 +422,30 @@ impl RegisterDiagnostic for App {
         self
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_clear_history() {
+        let mut diagnostic =
+            Diagnostic::new(DiagnosticPath::new("test")).with_max_history_length(5);
+        let now = Instant::now();
+
+        // Three times in a row...
+        for _ in 0..3 {
+            // Fill the diagnostic with measurements...
+            for _ in 0..5 {
+                diagnostic.add_measurement(DiagnosticMeasurement {
+                    time: now,
+                    value: 20.0,
+                });
+            }
+            // Assert that the average is correct...
+            assert!((diagnostic.average().unwrap() - 20.0) < 0.1);
+            // And clear the diagnostic history
+            diagnostic.clear_history();
+        }
+    }
+}

--- a/crates/bevy_diagnostic/src/diagnostic.rs
+++ b/crates/bevy_diagnostic/src/diagnostic.rs
@@ -293,6 +293,8 @@ impl Diagnostic {
     /// Clear the history of this diagnostic.
     pub fn clear_history(&mut self) {
         self.history.clear();
+        self.sum = 0.0;
+        self.ema = 0.0;
     }
 }
 


### PR DESCRIPTION
# Objective

Fix incorrect average returned by `Diagnostic` after `clear_history` is called.

## Solution

Reset sum and ema values in `Diagnostic::clear_history`.

## Testing

I have added a cargo test for `Diagnostic::clear_history` that checks average and smoothed average.  This test passes, and should not be platform dependent.