### PR TITLE
Image Node Rotation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3419,6 +3419,17 @@ category = "UI (User Interface)"
 wasm = true
 
 [[example]]
+name = "image_node_rotation"
+path = "examples/ui/image_node_rotation.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.image_node_rotation]
+name = "Image Node Rotation"
+description = "Show the use of `ImageNode::rotation`"
+category = "UI (User Interface)"
+wasm = true
+
+[[example]]
 name = "gradients"
 path = "examples/ui/gradients.rs"
 doc-scrape-examples = true

--- a/crates/bevy_ui/src/render/debug_overlay.rs
+++ b/crates/bevy_ui/src/render/debug_overlay.rs
@@ -103,7 +103,7 @@ pub fn extract_debug_overlay(
                 atlas_scaling: None,
                 transform: transform.compute_matrix(),
                 rotation: 0.,
-                flip_y: false,
+                flip_x: false,
                 border: BorderRect::all(debug_options.line_width / uinode.inverse_scale_factor()),
                 border_radius: uinode.border_radius(),
                 node_type: NodeType::Border,

--- a/crates/bevy_ui/src/render/debug_overlay.rs
+++ b/crates/bevy_ui/src/render/debug_overlay.rs
@@ -102,7 +102,7 @@ pub fn extract_debug_overlay(
             item: ExtractedUiItem::Node {
                 atlas_scaling: None,
                 transform: transform.compute_matrix(),
-                flip_x: false,
+                rotation: 0.,
                 flip_y: false,
                 border: BorderRect::all(debug_options.line_width / uinode.inverse_scale_factor()),
                 border_radius: uinode.border_radius(),

--- a/crates/bevy_ui/src/render/gradient.rs
+++ b/crates/bevy_ui/src/render/gradient.rs
@@ -412,7 +412,7 @@ pub fn extract_gradients(
                         item: ExtractedUiItem::Node {
                             atlas_scaling: None,
                             rotation: 0.,
-                            flip_y: false,
+                            flip_x: false,
                             border_radius: uinode.border_radius,
                             border: uinode.border,
                             node_type,

--- a/crates/bevy_ui/src/render/gradient.rs
+++ b/crates/bevy_ui/src/render/gradient.rs
@@ -411,7 +411,7 @@ pub fn extract_gradients(
                         extracted_camera_entity,
                         item: ExtractedUiItem::Node {
                             atlas_scaling: None,
-                            flip_x: false,
+                            rotation: 0.,
                             flip_y: false,
                             border_radius: uinode.border_radius,
                             border: uinode.border,

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -236,7 +236,7 @@ pub enum ExtractedUiItem {
     Node {
         atlas_scaling: Option<Vec2>,
         rotation: f32,
-        flip_y: bool,
+        flip_x: bool,
         /// Border radius of the UI node.
         /// Ordering: top left, top right, bottom right, bottom left.
         border_radius: ResolvedBorderRadius,
@@ -386,7 +386,7 @@ pub fn extract_uinode_background_colors(
                 atlas_scaling: None,
                 transform: transform.compute_matrix(),
                 rotation: 0.,
-                flip_y: false,
+                flip_x: false,
                 border: uinode.border(),
                 border_radius: uinode.border_radius(),
                 node_type: NodeType::Rect,
@@ -470,7 +470,7 @@ pub fn extract_uinode_images(
                 atlas_scaling,
                 transform: transform.compute_matrix(),
                 rotation: image.rotation,
-                flip_y: image.flip_y,
+                flip_x: image.flip_x,
                 border: uinode.border,
                 border_radius: uinode.border_radius,
                 node_type: NodeType::Rect,
@@ -538,7 +538,7 @@ pub fn extract_uinode_borders(
                         atlas_scaling: None,
                         transform: global_transform.compute_matrix(),
                         rotation: 0.,
-                        flip_y: false,
+                        flip_x: false,
                         border: computed_node.border(),
                         border_radius: computed_node.border_radius(),
                         node_type: NodeType::Border,
@@ -571,7 +571,7 @@ pub fn extract_uinode_borders(
                     transform: global_transform.compute_matrix(),
                     atlas_scaling: None,
                     rotation: 0.,
-                    flip_y: false,
+                    flip_x: false,
                     border: BorderRect::all(computed_node.outline_width()),
                     border_radius: computed_node.outline_radius(),
                     node_type: NodeType::Border,
@@ -761,7 +761,7 @@ pub fn extract_viewport_nodes(
                 atlas_scaling: None,
                 transform: transform.compute_matrix(),
                 rotation: 0.,
-                flip_y: false,
+                flip_x: false,
                 border: uinode.border(),
                 border_radius: uinode.border_radius(),
                 node_type: NodeType::Rect,
@@ -1011,7 +1011,7 @@ pub fn extract_text_background_colors(
                     atlas_scaling: None,
                     transform: transform * Mat4::from_translation(rect.center().extend(0.)),
                     rotation: 0.,
-                    flip_y: false,
+                    flip_x: false,
                     border: uinode.border(),
                     border_radius: uinode.border_radius(),
                     node_type: NodeType::Rect,
@@ -1270,7 +1270,7 @@ pub fn prepare_uinodes(
                         ExtractedUiItem::Node {
                             atlas_scaling,
                             rotation,
-                            flip_y,
+                            flip_x,
                             border_radius,
                             border,
                             node_type,
@@ -1362,12 +1362,12 @@ pub fn prepare_uinodes(
                                 let atlas_extent = atlas_scaling
                                     .map(|scaling| image.size_2d().as_vec2() * scaling)
                                     .unwrap_or(uinode_rect.max);
-                                if *flip_y {
-                                    core::mem::swap(&mut uinode_rect.max.y, &mut uinode_rect.min.y);
-                                    positions_diff[0].y *= -1.;
-                                    positions_diff[1].y *= -1.;
-                                    positions_diff[2].y *= -1.;
-                                    positions_diff[3].y *= -1.;
+                                if *flip_x {
+                                    core::mem::swap(&mut uinode_rect.max.x, &mut uinode_rect.min.x);
+                                    positions_diff[0].x *= -1.;
+                                    positions_diff[1].x *= -1.;
+                                    positions_diff[2].x *= -1.;
+                                    positions_diff[3].x *= -1.;
                                 }
                                 [
                                     Vec2::new(

--- a/crates/bevy_ui/src/render/ui_texture_slice_pipeline.rs
+++ b/crates/bevy_ui/src/render/ui_texture_slice_pipeline.rs
@@ -233,7 +233,7 @@ pub struct ExtractedUiTextureSlice {
     pub color: LinearRgba,
     pub image_scale_mode: SpriteImageMode,
     pub rotation: f32,
-    pub flip_y: bool,
+    pub flip_x: bool,
     pub inverse_scale_factor: f32,
     pub main_entity: MainEntity,
     pub render_entity: Entity,
@@ -324,7 +324,7 @@ pub fn extract_ui_texture_slices(
             image_scale_mode,
             atlas_rect,
             rotation: image.rotation,
-            flip_y: image.flip_y,
+            flip_x: image.flip_x,
             inverse_scale_factor: uinode.inverse_scale_factor,
             main_entity: entity.into(),
         });
@@ -609,8 +609,8 @@ pub fn prepare_ui_slices(
                         (batch_image_size, [0., 0., 1., 1.])
                     };
 
-                    if texture_slices.flip_y {
-                        atlas.swap(1, 3);
+                    if texture_slices.flip_x {
+                        atlas.swap(0, 2);
                     }
 
                     let [slices, border, repeat] = compute_texture_slices(

--- a/crates/bevy_ui/src/render/ui_texture_slice_pipeline.rs
+++ b/crates/bevy_ui/src/render/ui_texture_slice_pipeline.rs
@@ -232,7 +232,7 @@ pub struct ExtractedUiTextureSlice {
     pub extracted_camera_entity: Entity,
     pub color: LinearRgba,
     pub image_scale_mode: SpriteImageMode,
-    pub flip_x: bool,
+    pub rotation: f32,
     pub flip_y: bool,
     pub inverse_scale_factor: f32,
     pub main_entity: MainEntity,
@@ -323,7 +323,7 @@ pub fn extract_ui_texture_slices(
             extracted_camera_entity,
             image_scale_mode,
             atlas_rect,
-            flip_x: image.flip_x,
+            rotation: image.rotation,
             flip_y: image.flip_y,
             inverse_scale_factor: uinode.inverse_scale_factor,
             main_entity: entity.into(),
@@ -506,8 +506,12 @@ pub fn prepare_ui_slices(
                     let rect_size = uinode_rect.size().extend(1.0);
 
                     // Specify the corners of the node
-                    let positions = QUAD_VERTEX_POSITIONS
-                        .map(|pos| (texture_slices.transform * (pos * rect_size).extend(1.)).xyz());
+                    let positions = QUAD_VERTEX_POSITIONS.map(|pos| {
+                        (texture_slices.transform
+                            * Mat4::from_rotation_z(texture_slices.rotation)
+                            * (pos * rect_size).extend(1.))
+                        .xyz()
+                    });
 
                     // Calculate the effect of clipping
                     // Note: this won't work with rotation/scaling, but that's much more complex (may need more that 2 quads)
@@ -604,10 +608,6 @@ pub fn prepare_ui_slices(
                     } else {
                         (batch_image_size, [0., 0., 1., 1.])
                     };
-
-                    if texture_slices.flip_x {
-                        atlas.swap(0, 2);
-                    }
 
                     if texture_slices.flip_y {
                         atlas.swap(1, 3);

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -25,8 +25,8 @@ pub struct ImageNode {
     pub image: Handle<Image>,
     /// The (optional) texture atlas used to render the image.
     pub texture_atlas: Option<TextureAtlas>,
-    /// Whether the image should be flipped along its x-axis.
-    pub flip_x: bool,
+    /// Rotation of the image
+    pub rotation: f32,
     /// Whether the image should be flipped along its y-axis.
     pub flip_y: bool,
     /// An optional rectangle representing the region of the image to render, instead of rendering
@@ -55,7 +55,7 @@ impl Default for ImageNode {
             texture_atlas: None,
             // This texture needs to be transparent by default, to avoid covering the background color
             image: TRANSPARENT_IMAGE_HANDLE,
-            flip_x: false,
+            rotation: 0.,
             flip_y: false,
             rect: None,
             image_mode: NodeImageMode::Auto,
@@ -80,7 +80,7 @@ impl ImageNode {
         Self {
             image: Handle::default(),
             color,
-            flip_x: false,
+            rotation: 0.,
             flip_y: false,
             texture_atlas: None,
             rect: None,
@@ -104,10 +104,10 @@ impl ImageNode {
         self
     }
 
-    /// Flip the image along its x-axis
+    /// Rotates the image
     #[must_use]
-    pub const fn with_flip_x(mut self) -> Self {
-        self.flip_x = true;
+    pub const fn with_rotation(mut self, rotation: f32) -> Self {
+        self.rotation = rotation;
         self
     }
 

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -25,7 +25,9 @@ pub struct ImageNode {
     pub image: Handle<Image>,
     /// The (optional) texture atlas used to render the image.
     pub texture_atlas: Option<TextureAtlas>,
-    /// Clockwise rotation of the image in radians
+    /// Clockwise rotation of the image in radians.  
+    /// Rotations done through this field do not update the node's size and might cause clipping or overflow,
+    /// to rotate updating the node's size use [`Transform`](bevy_transform::prelude::Transform).
     pub rotation: f32,
     /// Whether the image should be flipped along its x-axis.
     pub flip_x: bool,

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -27,8 +27,8 @@ pub struct ImageNode {
     pub texture_atlas: Option<TextureAtlas>,
     /// Clockwise rotation of the image in radians
     pub rotation: f32,
-    /// Whether the image should be flipped along its y-axis.
-    pub flip_y: bool,
+    /// Whether the image should be flipped along its x-axis.
+    pub flip_x: bool,
     /// An optional rectangle representing the region of the image to render, instead of rendering
     /// the full image. This is an easy one-off alternative to using a [`TextureAtlas`].
     ///
@@ -56,7 +56,7 @@ impl Default for ImageNode {
             // This texture needs to be transparent by default, to avoid covering the background color
             image: TRANSPARENT_IMAGE_HANDLE,
             rotation: 0.,
-            flip_y: false,
+            flip_x: false,
             rect: None,
             image_mode: NodeImageMode::Auto,
         }
@@ -81,7 +81,7 @@ impl ImageNode {
             image: Handle::default(),
             color,
             rotation: 0.,
-            flip_y: false,
+            flip_x: false,
             texture_atlas: None,
             rect: None,
             image_mode: NodeImageMode::Auto,
@@ -111,10 +111,10 @@ impl ImageNode {
         self
     }
 
-    /// Flip the image along its y-axis
+    /// Flip the image along its x-axis
     #[must_use]
-    pub const fn with_flip_y(mut self) -> Self {
-        self.flip_y = true;
+    pub const fn with_flip_x(mut self) -> Self {
+        self.flip_x = true;
         self
     }
 

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -25,7 +25,7 @@ pub struct ImageNode {
     pub image: Handle<Image>,
     /// The (optional) texture atlas used to render the image.
     pub texture_atlas: Option<TextureAtlas>,
-    /// Rotation of the image
+    /// Clockwise rotation of the image in radians
     pub rotation: f32,
     /// Whether the image should be flipped along its y-axis.
     pub flip_y: bool,

--- a/examples/README.md
+++ b/examples/README.md
@@ -548,6 +548,7 @@ Example | Description
 [Font Atlas Debug](../examples/ui/font_atlas_debug.rs) | Illustrates how FontAtlases are populated (used to optimize text rendering internally)
 [Ghost Nodes](../examples/ui/ghost_nodes.rs) | Demonstrates the use of Ghost Nodes to skip entities in the UI layout hierarchy
 [Gradients](../examples/ui/gradients.rs) | An example demonstrating gradients
+[Image Node Rotation](../examples/ui/image_node_rotation.rs) | Show the use of `ImageNode::rotation`
 [Overflow](../examples/ui/overflow.rs) | Simple example demonstrating overflow behavior
 [Overflow Clip Margin](../examples/ui/overflow_clip_margin.rs) | Simple example demonstrating the OverflowClipMargin style property
 [Overflow and Clipping Debug](../examples/ui/overflow_debug.rs) | An example to debug overflow and clipping behavior

--- a/examples/testbed/full_ui.rs
+++ b/examples/testbed/full_ui.rs
@@ -375,7 +375,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 })
                 .insert(Pickable::IGNORE)
                 .with_children(|parent| {
-                    for (rotation, flip_y) in [
+                    for (rotation, flip_x) in [
                         (0., false),
                         (FRAC_PI_2, false),
                         (PI, false),
@@ -389,7 +389,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                             ImageNode {
                                 image: asset_server.load("branding/icon.png"),
                                 rotation,
-                                flip_y,
+                                flip_x,
                                 ..default()
                             },
                             Node {

--- a/examples/testbed/full_ui.rs
+++ b/examples/testbed/full_ui.rs
@@ -1,6 +1,6 @@
 //! This example illustrates the various features of Bevy UI.
 
-use std::f32::consts::PI;
+use std::f32::consts::{FRAC_PI_2, PI};
 
 use accesskit::{Node as Accessible, Role};
 use bevy::{
@@ -375,13 +375,20 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 })
                 .insert(Pickable::IGNORE)
                 .with_children(|parent| {
-                    for (flip_x, flip_y) in
-                        [(false, false), (false, true), (true, true), (true, false)]
-                    {
+                    for (rotation, flip_y) in [
+                        (0., false),
+                        (FRAC_PI_2, false),
+                        (PI, false),
+                        (FRAC_PI_2 + PI, false),
+                        (0., true),
+                        (FRAC_PI_2, true),
+                        (PI, true),
+                        (FRAC_PI_2 + PI, true),
+                    ] {
                         parent.spawn((
                             ImageNode {
                                 image: asset_server.load("branding/icon.png"),
-                                flip_x,
+                                rotation,
                                 flip_y,
                                 ..default()
                             },

--- a/examples/ui/image_node_rotation.rs
+++ b/examples/ui/image_node_rotation.rs
@@ -2,6 +2,7 @@
 
 use bevy::{
     app::{App, Startup, Update},
+    asset::AssetServer,
     color::Color,
     core_pipeline::core_2d::Camera2d,
     ecs::{
@@ -11,6 +12,7 @@ use bevy::{
         query::With,
         system::{Commands, Query, Res, ResMut, Single},
     },
+    image::{ImageLoaderSettings, ImageSampler},
     input::{keyboard::KeyCode, ButtonInput},
     math::ops,
     prelude::SpawnRelated,
@@ -27,8 +29,6 @@ use bevy::{
     utils::default,
     DefaultPlugins,
 };
-use bevy_asset::AssetServer;
-use bevy_image::{ImageLoaderSettings, ImageSampler};
 
 const IMAGE_NODE_SIZE: f32 = 128.;
 

--- a/examples/ui/image_node_rotation.rs
+++ b/examples/ui/image_node_rotation.rs
@@ -50,9 +50,12 @@ fn main() {
 struct UiMarker;
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, States)]
+/// Selection of modes
 enum Mode {
+    /// Uses [`ImageNode`] with [`NodeImageMode::Auto`]
     #[default]
     Image,
+    /// Uses [`ImageNode`] with [`NodeImageMode::Sliced`]
     Slices,
 }
 
@@ -65,10 +68,12 @@ impl Mode {
     }
 }
 
+/// Spawns a camera
 fn setup(mut commands: Commands) {
     commands.spawn(Camera2d);
 }
 
+/// Switching between modes on the press of the Q key
 fn switch_modes(
     keys: Res<ButtonInput<KeyCode>>,
     current_state: Res<State<Mode>>,
@@ -79,16 +84,19 @@ fn switch_modes(
     }
 }
 
+/// Rock the images back and forth
 fn rotate_image_nodes(mut image_nodes: Query<&mut ImageNode>, time: Res<Time>) {
     for mut node in image_nodes.iter_mut() {
         node.rotation = ops::sin(time.elapsed_secs());
     }
 }
 
+/// Drops the previous UI before the creation of the new one
 fn drop_previos_ui(mut commands: Commands, ui: Single<Entity, With<UiMarker>>) {
     commands.entity(*ui).despawn();
 }
 
+/// Builds the UI on entering [`Mode::Image`]
 fn image_mode(mut commands: Commands, asset_server: Res<AssetServer>) {
     let branding = asset_server.load("branding/icon.png");
     build_ui(&mut commands, |flip_y| ImageNode {
@@ -99,6 +107,7 @@ fn image_mode(mut commands: Commands, asset_server: Res<AssetServer>) {
     });
 }
 
+/// Builds the UI on entering [`Mode::Slices`]
 fn slices_mode(mut commands: Commands, asset_server: Res<AssetServer>) {
     let image = asset_server.load_with_settings(
         "textures/fantasy_ui_borders/numbered_slices.png",
@@ -127,6 +136,9 @@ fn slices_mode(mut commands: Commands, asset_server: Res<AssetServer>) {
     });
 }
 
+/// Builds the UI using a methods that generates the [`ImageNode`] with a paramenter for flipping on Y.  
+/// The UI will contain 8 [`ImageNode`] across 2 rows,
+/// the 4 on the bottom row will have their Y flipped.
 fn build_ui(commands: &mut Commands, image_node: impl Fn(bool) -> ImageNode) {
     commands.spawn((
         UiMarker,

--- a/examples/ui/image_node_rotation.rs
+++ b/examples/ui/image_node_rotation.rs
@@ -1,7 +1,5 @@
 //! Shows usage of `ImageNode::rotation`
 
-#[cfg(feature = "bevy_ui_debug")]
-use bevy::prelude::UiDebugOptions;
 use bevy::{
     app::{App, Startup, Update},
     color::Color,
@@ -35,17 +33,8 @@ use bevy_image::{ImageLoaderSettings, ImageSampler};
 const IMAGE_NODE_SIZE: f32 = 128.;
 
 fn main() {
-    let mut app = App::new();
-
-    #[cfg(feature = "bevy_ui_debug")]
-    app.insert_resource(UiDebugOptions {
-        enabled: true,
-        show_clipped: true,
-        show_hidden: true,
-        line_width: 3.,
-    });
-
-    app.add_plugins(DefaultPlugins)
+    App::new()
+        .add_plugins(DefaultPlugins)
         .init_state::<Mode>()
         .add_systems(Startup, setup)
         .add_systems(Update, (switch_modes, rotate_image_nodes))
@@ -85,7 +74,7 @@ fn switch_modes(
     mut next_state: ResMut<NextState<Mode>>,
 ) {
     if keys.just_pressed(KeyCode::KeyQ) {
-        next_state.set(dbg!(current_state.next()));
+        next_state.set(current_state.next());
     }
 }
 

--- a/examples/ui/image_node_rotation.rs
+++ b/examples/ui/image_node_rotation.rs
@@ -99,10 +99,10 @@ fn drop_previous_ui(mut commands: Commands, ui: Single<Entity, With<UiMarker>>) 
 /// Builds the UI on entering [`Mode::Image`]
 fn image_mode(mut commands: Commands, asset_server: Res<AssetServer>) {
     let branding = asset_server.load("branding/icon.png");
-    build_ui(&mut commands, |flip_y| ImageNode {
+    build_ui(&mut commands, |flip_x| ImageNode {
         color: Color::WHITE,
         image: branding.clone(),
-        flip_y,
+        flip_x,
         ..Default::default()
     });
 }
@@ -127,10 +127,10 @@ fn slices_mode(mut commands: Commands, asset_server: Res<AssetServer>) {
         ..default()
     };
 
-    build_ui(&mut commands, |flip_y| ImageNode {
+    build_ui(&mut commands, |flip_x| ImageNode {
         color: Color::WHITE,
         image: image.clone(),
-        flip_y,
+        flip_x,
         image_mode: NodeImageMode::Sliced(slicer.clone()),
         ..Default::default()
     });

--- a/examples/ui/image_node_rotation.rs
+++ b/examples/ui/image_node_rotation.rs
@@ -40,9 +40,9 @@ fn main() {
         .add_systems(Startup, setup)
         .add_systems(Update, (switch_modes, rotate_image_nodes))
         .add_systems(OnEnter(Mode::Image), image_mode)
-        .add_systems(OnExit(Mode::Image), drop_previos_ui)
+        .add_systems(OnExit(Mode::Image), drop_previous_ui)
         .add_systems(OnEnter(Mode::Slices), slices_mode)
-        .add_systems(OnExit(Mode::Slices), drop_previos_ui)
+        .add_systems(OnExit(Mode::Slices), drop_previous_ui)
         .run();
 }
 
@@ -92,7 +92,7 @@ fn rotate_image_nodes(mut image_nodes: Query<&mut ImageNode>, time: Res<Time>) {
 }
 
 /// Drops the previous UI before the creation of the new one
-fn drop_previos_ui(mut commands: Commands, ui: Single<Entity, With<UiMarker>>) {
+fn drop_previous_ui(mut commands: Commands, ui: Single<Entity, With<UiMarker>>) {
     commands.entity(*ui).despawn();
 }
 
@@ -136,7 +136,7 @@ fn slices_mode(mut commands: Commands, asset_server: Res<AssetServer>) {
     });
 }
 
-/// Builds the UI using a methods that generates the [`ImageNode`] with a paramenter for flipping on Y.  
+/// Builds the UI using a methods that generates the [`ImageNode`] with a parameter for flipping on Y.  
 /// The UI will contain 8 [`ImageNode`] across 2 rows,
 /// the 4 on the bottom row will have their Y flipped.
 fn build_ui(commands: &mut Commands, image_node: impl Fn(bool) -> ImageNode) {

--- a/examples/ui/image_node_rotation.rs
+++ b/examples/ui/image_node_rotation.rs
@@ -1,0 +1,235 @@
+//! Shows usage of `ImageNode::rotation`
+
+#[cfg(feature = "bevy_ui_debug")]
+use bevy::prelude::UiDebugOptions;
+use bevy::{
+    app::{App, Startup, Update},
+    color::Color,
+    core_pipeline::core_2d::Camera2d,
+    ecs::{
+        children,
+        component::Component,
+        entity::Entity,
+        query::With,
+        system::{Commands, Query, Res, ResMut, Single},
+    },
+    input::{keyboard::KeyCode, ButtonInput},
+    math::ops,
+    prelude::SpawnRelated,
+    state::{
+        app::AppExtStates,
+        state::{NextState, OnEnter, OnExit, State, States},
+    },
+    time::Time,
+    ui::{widget::ImageNode, FlexDirection, JustifyContent, Node, PositionType, Val},
+    DefaultPlugins,
+};
+use bevy_asset::AssetServer;
+
+const IMAGE_NODE_SIZE: f32 = 128.;
+
+fn main() {
+    let mut app = App::new();
+
+    #[cfg(feature = "bevy_ui_debug")]
+    app.insert_resource(UiDebugOptions {
+        enabled: true,
+        show_clipped: true,
+        show_hidden: true,
+        line_width: 3.,
+    });
+
+    app.add_plugins(DefaultPlugins)
+        .init_state::<Mode>()
+        .add_systems(Startup, setup)
+        .add_systems(Update, (switch_modes, rotate_image_nodes))
+        .add_systems(OnEnter(Mode::Image), image_mode)
+        .add_systems(OnExit(Mode::Image), drop_previos_ui)
+        .add_systems(OnEnter(Mode::Slices), image_mode)
+        .add_systems(OnExit(Mode::Slices), drop_previos_ui)
+        .run();
+}
+
+#[derive(Component)]
+struct UiMarker;
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, States)]
+enum Mode {
+    #[default]
+    Image,
+    Slices,
+}
+
+impl Mode {
+    fn next(&self) -> Self {
+        match self {
+            Self::Image => Self::Slices,
+            Self::Slices => Self::Image,
+        }
+    }
+}
+
+fn setup(mut commands: Commands) {
+    commands.spawn(Camera2d);
+}
+
+fn switch_modes(
+    keys: Res<ButtonInput<KeyCode>>,
+    current_state: Res<State<Mode>>,
+    mut next_state: ResMut<NextState<Mode>>,
+) {
+    if keys.just_pressed(KeyCode::KeyQ) {
+        next_state.set(dbg!(current_state.next()));
+    }
+}
+
+fn rotate_image_nodes(mut image_nodes: Query<&mut ImageNode>, time: Res<Time>) {
+    for mut node in image_nodes.iter_mut() {
+        node.rotation = ops::sin(time.elapsed_secs());
+    }
+}
+
+fn drop_previos_ui(mut commands: Commands, ui: Single<Entity, With<UiMarker>>) {
+    commands.entity(*ui).despawn();
+}
+
+fn image_mode(mut commands: Commands, asset_server: Res<AssetServer>) {
+    let branding = asset_server.load("branding/icon.png");
+    commands.spawn((
+        UiMarker,
+        Node {
+            position_type: PositionType::Absolute,
+            width: Val::Percent(100.),
+            height: Val::Percent(100.),
+            flex_direction: FlexDirection::Row,
+            justify_content: JustifyContent::Center,
+            ..Default::default()
+        },
+        children![(
+            Node {
+                height: Val::Percent(100.),
+                flex_direction: FlexDirection::Column,
+                justify_content: JustifyContent::Center,
+                ..Default::default()
+            },
+            children![
+                (
+                    Node {
+                        flex_direction: FlexDirection::Row,
+                        ..Default::default()
+                    },
+                    children![
+                        (
+                            Node {
+                                width: Val::Px(IMAGE_NODE_SIZE),
+                                height: Val::Px(IMAGE_NODE_SIZE),
+                                ..Default::default()
+                            },
+                            ImageNode {
+                                color: Color::WHITE,
+                                image: branding.clone(),
+                                ..Default::default()
+                            }
+                        ),
+                        (
+                            Node {
+                                width: Val::Px(IMAGE_NODE_SIZE),
+                                height: Val::Px(IMAGE_NODE_SIZE),
+                                ..Default::default()
+                            },
+                            ImageNode {
+                                color: Color::WHITE,
+                                image: branding.clone(),
+                                ..Default::default()
+                            }
+                        ),
+                        (
+                            Node {
+                                width: Val::Px(IMAGE_NODE_SIZE),
+                                height: Val::Px(IMAGE_NODE_SIZE),
+                                ..Default::default()
+                            },
+                            ImageNode {
+                                color: Color::WHITE,
+                                image: branding.clone(),
+                                ..Default::default()
+                            }
+                        ),
+                        (
+                            Node {
+                                width: Val::Px(IMAGE_NODE_SIZE),
+                                height: Val::Px(IMAGE_NODE_SIZE),
+                                ..Default::default()
+                            },
+                            ImageNode {
+                                color: Color::WHITE,
+                                image: branding.clone(),
+                                ..Default::default()
+                            }
+                        )
+                    ]
+                ),
+                (
+                    Node {
+                        flex_direction: FlexDirection::Row,
+                        ..Default::default()
+                    },
+                    children![
+                        (
+                            Node {
+                                width: Val::Px(IMAGE_NODE_SIZE),
+                                height: Val::Px(IMAGE_NODE_SIZE),
+                                ..Default::default()
+                            },
+                            ImageNode {
+                                color: Color::WHITE,
+                                image: branding.clone(),
+                                flip_y: true,
+                                ..Default::default()
+                            }
+                        ),
+                        (
+                            Node {
+                                width: Val::Px(IMAGE_NODE_SIZE),
+                                height: Val::Px(IMAGE_NODE_SIZE),
+                                ..Default::default()
+                            },
+                            ImageNode {
+                                color: Color::WHITE,
+                                image: branding.clone(),
+                                flip_y: true,
+                                ..Default::default()
+                            }
+                        ),
+                        (
+                            Node {
+                                width: Val::Px(IMAGE_NODE_SIZE),
+                                height: Val::Px(IMAGE_NODE_SIZE),
+                                ..Default::default()
+                            },
+                            ImageNode {
+                                color: Color::WHITE,
+                                image: branding.clone(),
+                                flip_y: true,
+                                ..Default::default()
+                            }
+                        ),
+                        (
+                            Node {
+                                width: Val::Px(IMAGE_NODE_SIZE),
+                                height: Val::Px(IMAGE_NODE_SIZE),
+                                ..Default::default()
+                            },
+                            ImageNode {
+                                color: Color::WHITE,
+                                image: branding.clone(),
+                                flip_y: true,
+                                ..Default::default()
+                            }
+                        )
+                    ]
+                )
+            ]
+        )],
+    ));
+}

--- a/examples/ui/image_node_rotation.rs
+++ b/examples/ui/image_node_rotation.rs
@@ -31,6 +31,7 @@ use bevy::{
 };
 
 const IMAGE_NODE_SIZE: f32 = 128.;
+const UI_GAPS: f32 = 16.;
 
 fn main() {
     App::new()
@@ -142,14 +143,14 @@ fn build_ui(commands: &mut Commands, image_node: impl Fn(bool) -> ImageNode) {
                 height: Val::Percent(100.),
                 flex_direction: FlexDirection::Column,
                 justify_content: JustifyContent::Center,
-                row_gap: Val::Px(16.),
+                row_gap: Val::Px(UI_GAPS),
                 ..Default::default()
             },
             children![
                 (
                     Node {
                         flex_direction: FlexDirection::Row,
-                        column_gap: Val::Px(16.),
+                        column_gap: Val::Px(UI_GAPS),
                         ..Default::default()
                     },
                     children![
@@ -190,7 +191,7 @@ fn build_ui(commands: &mut Commands, image_node: impl Fn(bool) -> ImageNode) {
                 (
                     Node {
                         flex_direction: FlexDirection::Row,
-                        column_gap: Val::Px(16.),
+                        column_gap: Val::Px(UI_GAPS),
                         ..Default::default()
                     },
                     children![

--- a/examples/ui/image_node_rotation.rs
+++ b/examples/ui/image_node_rotation.rs
@@ -110,12 +110,14 @@ fn image_mode(mut commands: Commands, asset_server: Res<AssetServer>) {
                 height: Val::Percent(100.),
                 flex_direction: FlexDirection::Column,
                 justify_content: JustifyContent::Center,
+                row_gap: Val::Px(16.),
                 ..Default::default()
             },
             children![
                 (
                     Node {
                         flex_direction: FlexDirection::Row,
+                        column_gap: Val::Px(16.),
                         ..Default::default()
                     },
                     children![
@@ -172,6 +174,7 @@ fn image_mode(mut commands: Commands, asset_server: Res<AssetServer>) {
                 (
                     Node {
                         flex_direction: FlexDirection::Row,
+                        column_gap: Val::Px(16.),
                         ..Default::default()
                     },
                     children![

--- a/examples/ui/ui_texture_slice_flip_and_tile.rs
+++ b/examples/ui/ui_texture_slice_flip_and_tile.rs
@@ -1,5 +1,7 @@
 //! This example illustrates how to how to flip and tile images with 9-slicing in the UI.
 
+use std::f32::consts::{FRAC_PI_2, PI};
+
 use bevy::{
     image::{ImageLoaderSettings, ImageSampler},
     prelude::*,
@@ -52,12 +54,20 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         })
         .with_children(|parent| {
             for [columns, rows] in [[3., 3.], [4., 4.], [5., 4.], [4., 5.], [5., 5.]] {
-                for (flip_x, flip_y) in [(false, false), (false, true), (true, false), (true, true)]
-                {
+                for (rotation, flip_y) in [
+                    (0., false),
+                    (FRAC_PI_2, false),
+                    (PI, false),
+                    (FRAC_PI_2 + PI, false),
+                    (0., true),
+                    (FRAC_PI_2, true),
+                    (PI, true),
+                    (FRAC_PI_2 + PI, true),
+                ] {
                     parent.spawn((
                         ImageNode {
                             image: image.clone(),
-                            flip_x,
+                            rotation,
                             flip_y,
                             image_mode: NodeImageMode::Sliced(slicer.clone()),
                             ..default()

--- a/examples/ui/ui_texture_slice_flip_and_tile.rs
+++ b/examples/ui/ui_texture_slice_flip_and_tile.rs
@@ -54,7 +54,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         })
         .with_children(|parent| {
             for [columns, rows] in [[3., 3.], [4., 4.], [5., 4.], [4., 5.], [5., 5.]] {
-                for (rotation, flip_y) in [
+                for (rotation, flip_x) in [
                     (0., false),
                     (FRAC_PI_2, false),
                     (PI, false),
@@ -68,7 +68,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         ImageNode {
                             image: image.clone(),
                             rotation,
-                            flip_y,
+                            flip_x,
                             image_mode: NodeImageMode::Sliced(slicer.clone()),
                             ..default()
                         },

--- a/release-content/migration-guides/image_node_flip_and_rotate.md
+++ b/release-content/migration-guides/image_node_flip_and_rotate.md
@@ -1,0 +1,6 @@
+---
+title: Remove `ImageNode::flip_y` and add `ImageNode::rotation`
+pull_requests: [19340]
+---
+
+The member `flip_y` from `ImageNode` was removed and replaced for `rotation`.

--- a/release-content/release-notes/image_node_rotation.md
+++ b/release-content/release-notes/image_node_rotation.md
@@ -1,0 +1,30 @@
+---
+title: `ImageNode` rotation
+authors: ["@hukasu"]
+pull_requests: [19340]
+---
+
+It is now possible to rotate an `ImageNode`.  
+Rotations using `ImageNode::rotation` do not update
+the `Node`'s computed size and might lead to clipping or overflow, 
+for rotations that update the `Node`'s computed size use `Transform`.
+
+```rust
+// This does not update the node's computed size 
+commands.spawn((
+    ImageNode {
+        image: handle.clone(),
+        rotation: FRAC_PI_2,
+        ..default()
+    }
+));
+
+// This does update the node's computed size 
+commands.spawn((
+    ImageNode {
+        image: handle.clone(),
+        ..default()
+    },
+    Transform::from_rotation(Quat::from_rotation_z(FRAC_PI_2))
+));
+```

--- a/release-content/release-notes/image_node_rotation.md
+++ b/release-content/release-notes/image_node_rotation.md
@@ -6,7 +6,7 @@ pull_requests: [19340]
 
 It is now possible to rotate an `ImageNode`.  
 Rotations using `ImageNode::rotation` do not update
-the `Node`'s computed size and might lead to clipping or overflow, 
+the `Node`'s computed size and might lead to clipping or overflow,
 for rotations that update the `Node`'s computed size use `Transform`.
 
 ```rust


### PR DESCRIPTION
# Objective

Adopt #6688
Allow rotation of `ImageNode`s

## Solution

Replace `ImageNode::flip_x` for `rotation`, `ImageNode::flip_y` remains intact

## Testing

`testbed_full_ui`, `ui_texture_slice_flip_and_tile` and new `image_node_rotation` examples

## Showcase

![image](https://github.com/user-attachments/assets/2be6e480-73f8-423d-94af-71598607dd33)

![image](https://github.com/user-attachments/assets/4b3846d0-7d1b-47c9-9d6e-afb8ec51cf73)

![image](https://github.com/user-attachments/assets/e725701c-4e2e-4553-94f3-4e335d0c0d08)

![image](https://github.com/user-attachments/assets/624a0ebe-aa70-4319-9463-329061b4db72)

## Deliberate Rendering change

There have been changed to the `testbed_full_iu` example

## TODO

- [x] Include ui slices on the new example
- [x] Migration Guide
