### PR TITLE
UI leaf node styling and scrollbars

### DIFF
--- a/crates/bevy_sprite/src/texture_slice/border_rect.rs
+++ b/crates/bevy_sprite/src/texture_slice/border_rect.rs
@@ -1,3 +1,4 @@
+use bevy_math::Vec2;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 
 /// Defines the extents of the border of a rectangle.
@@ -43,6 +44,27 @@ impl BorderRect {
             top: vertical,
             bottom: vertical,
         }
+    }
+
+    pub fn sum_axes(&self) -> Vec2 {
+        Vec2::new(self.left + self.right, self.top + self.bottom)
+    }
+
+    /// Expands the given border rect on all sides by a given expansion amount.
+    pub fn inflate_mut(&mut self, expansion: f32) {
+        self.left += expansion;
+        self.right += expansion;
+        self.top += expansion;
+        self.bottom += expansion;
+    }
+}
+
+impl core::ops::AddAssign for BorderRect {
+    fn add_assign(&mut self, rhs: Self) {
+        self.left += rhs.left;
+        self.right += rhs.right;
+        self.top += rhs.top;
+        self.bottom += rhs.bottom;
     }
 }
 

--- a/crates/bevy_ui/src/layout/convert.rs
+++ b/crates/bevy_ui/src/layout/convert.rs
@@ -519,7 +519,7 @@ mod tests {
             grid_row: GridPlacement::span(3),
         };
         let viewport_values = LayoutContext::new(1.0, bevy_math::Vec2::new(800., 600.));
-        let taffy_style = from_node(&node, &viewport_values, false);
+        let taffy_style = from_node(&node, &viewport_values);
         assert_eq!(taffy_style.display, taffy::style::Display::Flex);
         assert_eq!(taffy_style.box_sizing, taffy::style::BoxSizing::ContentBox);
         assert_eq!(taffy_style.position, taffy::style::Position::Absolute);

--- a/crates/bevy_ui/src/layout/convert.rs
+++ b/crates/bevy_ui/src/layout/convert.rs
@@ -4,7 +4,7 @@ use crate::{
     AlignContent, AlignItems, AlignSelf, BoxSizing, Display, FlexDirection, FlexWrap, GridAutoFlow,
     GridPlacement, GridTrack, GridTrackRepetition, JustifyContent, JustifyItems, JustifySelf,
     MaxTrackSizingFunction, MinTrackSizingFunction, Node, OverflowAxis, PositionType,
-    RepeatedGridTrack, UiRect, Val,
+    RepeatedGridTrack, UiRect, Val, SCROLLBAR_TRACK_WIDTH,
 };
 
 use super::LayoutContext;
@@ -63,7 +63,7 @@ impl UiRect {
     }
 }
 
-pub fn from_node(node: &Node, context: &LayoutContext, ignore_border: bool) -> taffy::style::Style {
+pub fn from_node(node: &Node, context: &LayoutContext) -> taffy::style::Style {
     taffy::style::Style {
         display: node.display.into(),
         box_sizing: node.box_sizing.into(),
@@ -73,7 +73,7 @@ pub fn from_node(node: &Node, context: &LayoutContext, ignore_border: bool) -> t
             x: node.overflow.x.into(),
             y: node.overflow.y.into(),
         },
-        scrollbar_width: 0.0,
+        scrollbar_width: SCROLLBAR_TRACK_WIDTH * context.scale_factor,
         position: node.position_type.into(),
         flex_direction: node.flex_direction.into(),
         flex_wrap: node.flex_wrap.into(),
@@ -95,14 +95,9 @@ pub fn from_node(node: &Node, context: &LayoutContext, ignore_border: bool) -> t
         padding: node
             .padding
             .map_to_taffy_rect(|m| m.into_length_percentage(context)),
-        // Ignore border for leaf nodes as it isn't implemented in the rendering engine.
-        // TODO: Implement rendering of border for leaf nodes
-        border: if ignore_border {
-            taffy::Rect::zero()
-        } else {
-            node.border
-                .map_to_taffy_rect(|m| m.into_length_percentage(context))
-        },
+        border: node
+            .border
+            .map_to_taffy_rect(|m| m.into_length_percentage(context)),
         flex_grow: node.flex_grow,
         flex_shrink: node.flex_shrink,
         flex_basis: node.flex_basis.into_dimension(context),

--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -81,30 +81,22 @@ impl UiSurface {
         match self.entity_to_taffy.entry(entity) {
             Entry::Occupied(entry) => {
                 let taffy_node = *entry.get();
-                let has_measure = if new_node_context.is_some() {
+
+                if new_node_context.is_some() {
                     taffy
                         .set_node_context(taffy_node.id, new_node_context)
                         .unwrap();
-                    true
-                } else {
-                    taffy.get_node_context(taffy_node.id).is_some()
-                };
+                }
 
                 taffy
-                    .set_style(
-                        taffy_node.id,
-                        convert::from_node(node, layout_context, has_measure),
-                    )
+                    .set_style(taffy_node.id, convert::from_node(node, layout_context))
                     .unwrap();
             }
             Entry::Vacant(entry) => {
                 let taffy_node = if let Some(measure) = new_node_context.take() {
-                    taffy.new_leaf_with_context(
-                        convert::from_node(node, layout_context, true),
-                        measure,
-                    )
+                    taffy.new_leaf_with_context(convert::from_node(node, layout_context), measure)
                 } else {
-                    taffy.new_leaf(convert::from_node(node, layout_context, false))
+                    taffy.new_leaf(convert::from_node(node, layout_context))
                 };
                 entry.insert(taffy_node.unwrap().into());
             }
@@ -208,10 +200,7 @@ impl UiSurface {
                     context
                         .map(|ctx| {
                             let buffer = get_text_buffer(
-                                crate::widget::TextMeasure::needs_buffer(
-                                    known_dimensions.height,
-                                    available_space.width,
-                                ),
+                                crate::widget::TextMeasure::needs_buffer(available_space.width),
                                 ctx,
                                 buffer_query,
                             );

--- a/crates/bevy_ui/src/measurement.rs
+++ b/crates/bevy_ui/src/measurement.rs
@@ -47,7 +47,6 @@ impl Measure for NodeMeasure {
     fn measure(&mut self, measure_args: MeasureArgs, style: &taffy::Style) -> Vec2 {
         match self {
             NodeMeasure::Fixed(fixed) => fixed.measure(measure_args, style),
-
             NodeMeasure::Text(text) => text.measure(measure_args, style),
             NodeMeasure::Image(image) => image.measure(measure_args, style),
             NodeMeasure::Custom(custom) => custom.measure(measure_args, style),

--- a/crates/bevy_ui/src/render/debug_overlay.rs
+++ b/crates/bevy_ui/src/render/debug_overlay.rs
@@ -100,7 +100,8 @@ pub fn extract_debug_overlay(
             image: AssetId::default(),
             extracted_camera_entity,
             item: ExtractedUiItem::Node {
-                atlas_scaling: None,
+                atlas_rect: None,
+                image_rect: None,
                 transform: transform.compute_matrix(),
                 flip_x: false,
                 flip_y: false,

--- a/crates/bevy_ui/src/render/gradient.rs
+++ b/crates/bevy_ui/src/render/gradient.rs
@@ -410,7 +410,8 @@ pub fn extract_gradients(
                         clip: clip.map(|clip| clip.clip),
                         extracted_camera_entity,
                         item: ExtractedUiItem::Node {
-                            atlas_scaling: None,
+                            atlas_rect: None,
+                            image_rect: None,
                             flip_x: false,
                             flip_y: false,
                             border_radius: uinode.border_radius,

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -1676,22 +1676,21 @@ pub fn prepare_uinodes(
                                 let mut flipped_points = points;
                                 if *flip_x {
                                     core::mem::swap(&mut rect.max.x, &mut rect.min.x);
-                                    for i in 0..4 {
-                                        flipped_points[i].x *= -1.;
+                                    for fp in &mut flipped_points {
+                                        fp.x *= -1.;
                                     }
                                 }
                                 if *flip_y {
                                     core::mem::swap(&mut rect.max.y, &mut rect.min.y);
-                                    for i in 0..4 {
-                                        flipped_points[i].y *= -1.;
+                                    for fp in &mut flipped_points {
+                                        fp.y *= -1.;
                                     }
                                 }
 
-                                let uvs = flipped_points.map(|p| {
+                                // uvs
+                                flipped_points.map(|p| {
                                     (p * scale_rect + atlas_image_rect.center()) / atlas_size
-                                });
-
-                                uvs
+                                })
                             };
 
                             let color = extracted_uinode.color.to_f32_array();

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -10,8 +10,10 @@ mod gradient;
 
 use crate::widget::{ImageNode, ViewportNode};
 use crate::{
-    BackgroundColor, BorderColor, BoxShadowSamples, CalculatedClip, ComputedNode,
-    ComputedNodeTarget, Outline, ResolvedBorderRadius, TextShadow, UiAntiAlias,
+    BackgroundColor, BorderColor, BoxShadowSamples, CalculatedClip, CalculatedContentClip,
+    ComputedNode, ComputedNodeTarget, Outline, ResolvedBorderRadius, ScrollPosition,
+    ScrollbarColor, TextShadow, UiAntiAlias, SCROLLBAR_THUMB_ROUNDING, SCROLLBAR_THUMB_WIDTH,
+    SCROLLBAR_TRACK_WIDTH,
 };
 use bevy_app::prelude::*;
 use bevy_asset::{load_internal_asset, weak_handle, AssetEvent, AssetId, Assets, Handle};
@@ -114,6 +116,7 @@ pub enum RenderUiSystems {
     ExtractTextBackgrounds,
     ExtractTextShadows,
     ExtractText,
+    ExtractScrollbars,
     ExtractDebug,
     ExtractGradient,
 }
@@ -150,6 +153,7 @@ pub fn build_ui_render(app: &mut App) {
                 RenderUiSystems::ExtractTextBackgrounds,
                 RenderUiSystems::ExtractTextShadows,
                 RenderUiSystems::ExtractText,
+                RenderUiSystems::ExtractScrollbars,
                 RenderUiSystems::ExtractDebug,
             )
                 .chain(),
@@ -165,6 +169,7 @@ pub fn build_ui_render(app: &mut App) {
                 extract_text_background_colors.in_set(RenderUiSystems::ExtractTextBackgrounds),
                 extract_text_shadows.in_set(RenderUiSystems::ExtractTextShadows),
                 extract_text_sections.in_set(RenderUiSystems::ExtractText),
+                extract_scrollbars.in_set(RenderUiSystems::ExtractScrollbars),
                 #[cfg(feature = "bevy_ui_debug")]
                 debug_overlay::extract_debug_overlay.in_set(RenderUiSystems::ExtractDebug),
             ),
@@ -234,7 +239,8 @@ pub enum NodeType {
 
 pub enum ExtractedUiItem {
     Node {
-        atlas_scaling: Option<Vec2>,
+        atlas_rect: Option<Rect>,
+        image_rect: Option<Rect>,
         flip_x: bool,
         flip_y: bool,
         /// Border radius of the UI node.
@@ -347,7 +353,7 @@ pub fn extract_uinode_background_colors(
             &ComputedNode,
             &GlobalTransform,
             &InheritedVisibility,
-            Option<&CalculatedClip>,
+            Option<&CalculatedContentClip>, // TODO perhaps overlay scrollbars atop
             &ComputedNodeTarget,
             &BackgroundColor,
         )>,
@@ -383,7 +389,8 @@ pub fn extract_uinode_background_colors(
             image: AssetId::default(),
             extracted_camera_entity,
             item: ExtractedUiItem::Node {
-                atlas_scaling: None,
+                atlas_rect: None,
+                image_rect: None,
                 transform: transform.compute_matrix(),
                 flip_x: false,
                 flip_y: false,
@@ -406,7 +413,7 @@ pub fn extract_uinode_images(
             &ComputedNode,
             &GlobalTransform,
             &InheritedVisibility,
-            Option<&CalculatedClip>,
+            Option<&CalculatedContentClip>,
             &ComputedNodeTarget,
             &ImageNode,
         )>,
@@ -429,34 +436,32 @@ pub fn extract_uinode_images(
             continue;
         };
 
+        // `content_size`, which comes from Tuffy, is `measured_size` + `padding`.
+        // We need `measured_size` as `rect` in which image will be rendered.
+        // (sampler will populate that `rect`, producing a scaled image)
+        let rect = Rect {
+            min: Vec2::ZERO,
+            max: uinode.content_size() - uinode.padding.sum_axes(),
+        };
+
+        // These two are needed in order to derive UVs.
         let atlas_rect = image
             .texture_atlas
             .as_ref()
             .and_then(|s| s.texture_rect(&texture_atlases))
             .map(|r| r.as_rect());
 
-        let mut rect = match (atlas_rect, image.rect) {
-            (None, None) => Rect {
-                min: Vec2::ZERO,
-                max: uinode.size,
-            },
-            (None, Some(image_rect)) => image_rect,
-            (Some(atlas_rect), None) => atlas_rect,
-            (Some(atlas_rect), Some(mut image_rect)) => {
-                image_rect.min += atlas_rect.min;
-                image_rect.max += atlas_rect.min;
-                image_rect
-            }
-        };
+        let image_rect = image.rect;
 
-        let atlas_scaling = if atlas_rect.is_some() || image.rect.is_some() {
-            let atlas_scaling = uinode.size() / rect.size();
-            rect.min *= atlas_scaling;
-            rect.max *= atlas_scaling;
-            Some(atlas_scaling)
-        } else {
-            None
-        };
+        let content_inset = uinode.content_inset();
+
+        let tf_content_inset_adjust = bevy_math::Affine3A::from_translation(Vec3::new(
+            (content_inset.left - content_inset.right) / 2.0,
+            (content_inset.top - content_inset.bottom) / 2.0,
+            0.0,
+        ));
+
+        let tf = transform.compute_matrix() * tf_content_inset_adjust; // * tf_scale_adjust;
 
         extracted_uinodes.uinodes.push(ExtractedUiNode {
             render_entity: commands.spawn(TemporaryRenderEntity).id(),
@@ -467,11 +472,12 @@ pub fn extract_uinode_images(
             image: image.image.id(),
             extracted_camera_entity,
             item: ExtractedUiItem::Node {
-                atlas_scaling,
-                transform: transform.compute_matrix(),
+                atlas_rect,
+                image_rect,
+                transform: tf,
                 flip_x: image.flip_x,
                 flip_y: image.flip_y,
-                border: uinode.border,
+                border: BorderRect::ZERO,
                 border_radius: uinode.border_radius,
                 node_type: NodeType::Rect,
             },
@@ -535,7 +541,8 @@ pub fn extract_uinode_borders(
                     clip: maybe_clip.map(|clip| clip.clip),
                     extracted_camera_entity,
                     item: ExtractedUiItem::Node {
-                        atlas_scaling: None,
+                        atlas_rect: None,
+                        image_rect: None,
                         transform: global_transform.compute_matrix(),
                         flip_x: false,
                         flip_y: false,
@@ -569,7 +576,8 @@ pub fn extract_uinode_borders(
                 extracted_camera_entity,
                 item: ExtractedUiItem::Node {
                     transform: global_transform.compute_matrix(),
-                    atlas_scaling: None,
+                    atlas_rect: None,
+                    image_rect: None,
                     flip_x: false,
                     flip_y: false,
                     border: BorderRect::all(computed_node.outline_width()),
@@ -718,7 +726,7 @@ pub fn extract_viewport_nodes(
             &ComputedNode,
             &GlobalTransform,
             &InheritedVisibility,
-            Option<&CalculatedClip>,
+            Option<&CalculatedContentClip>,
             &ComputedNodeTarget,
             &ViewportNode,
         )>,
@@ -758,7 +766,8 @@ pub fn extract_viewport_nodes(
             image: image.id(),
             extracted_camera_entity,
             item: ExtractedUiItem::Node {
-                atlas_scaling: None,
+                atlas_rect: None,
+                image_rect: None,
                 transform: transform.compute_matrix(),
                 flip_x: false,
                 flip_y: false,
@@ -781,10 +790,11 @@ pub fn extract_text_sections(
             &ComputedNode,
             &GlobalTransform,
             &InheritedVisibility,
-            Option<&CalculatedClip>,
+            Option<&CalculatedContentClip>,
             &ComputedNodeTarget,
             &ComputedTextBlock,
             &TextLayoutInfo,
+            Option<&ScrollPosition>,
         )>,
     >,
     text_styles: Extract<Query<&TextColor>>,
@@ -803,6 +813,7 @@ pub fn extract_text_sections(
         camera,
         computed_block,
         text_layout_info,
+        maybe_scroll_position,
     ) in &uinode_query
     {
         // Skip if not visible or if size is set to zero (e.g. when a parent is set to `Display::None`)
@@ -814,8 +825,19 @@ pub fn extract_text_sections(
             continue;
         };
 
-        let transform = global_transform.affine()
-            * bevy_math::Affine3A::from_translation((-0.5 * uinode.size()).extend(0.));
+        let content_inset = uinode.content_inset();
+
+        let xy_content_inset_adjust = Vec2::new(content_inset.left, content_inset.top);
+        let xy_center_adjust = -0.5 * uinode.size();
+        let mut xy_adjust = xy_content_inset_adjust + xy_center_adjust;
+
+        if let Some(scroll_position) = maybe_scroll_position {
+            xy_adjust.x -= scroll_position.offset_x;
+            xy_adjust.y -= scroll_position.offset_y;
+        }
+
+        let transform =
+            global_transform.affine() * bevy_math::Affine3A::from_translation(xy_adjust.extend(0.));
 
         for (
             i,
@@ -880,9 +902,10 @@ pub fn extract_text_shadows(
             &ComputedNodeTarget,
             &GlobalTransform,
             &InheritedVisibility,
-            Option<&CalculatedClip>,
+            Option<&CalculatedContentClip>,
             &TextLayoutInfo,
             &TextShadow,
+            Option<&ScrollPosition>,
         )>,
     >,
     camera_map: Extract<UiCameraMap>,
@@ -900,6 +923,7 @@ pub fn extract_text_shadows(
         clip,
         text_layout_info,
         shadow,
+        maybe_scroll_position,
     ) in &uinode_query
     {
         // Skip if not visible or if size is set to zero (e.g. when a parent is set to `Display::None`)
@@ -911,10 +935,21 @@ pub fn extract_text_shadows(
             continue;
         };
 
-        let transform = global_transform.affine()
-            * Mat4::from_translation(
-                (-0.5 * uinode.size() + shadow.offset / uinode.inverse_scale_factor()).extend(0.),
-            );
+        let content_inset = uinode.content_inset();
+
+        let xy_to_top_left_adjust = -uinode.size() / 2.0;
+        let xy_scaled_shadow_adjust = shadow.offset / uinode.inverse_scale_factor();
+        let xy_content_inset_adjust = Vec2::new(content_inset.left, content_inset.top);
+
+        let mut xy_adjust =
+            xy_to_top_left_adjust + xy_scaled_shadow_adjust + xy_content_inset_adjust;
+
+        if let Some(scroll_position) = maybe_scroll_position {
+            xy_adjust.x -= scroll_position.offset_x;
+            xy_adjust.y -= scroll_position.offset_y;
+        }
+
+        let transform = global_transform.affine() * Mat4::from_translation(xy_adjust.extend(0.));
 
         for (
             i,
@@ -967,17 +1002,26 @@ pub fn extract_text_background_colors(
             &ComputedNode,
             &GlobalTransform,
             &InheritedVisibility,
-            Option<&CalculatedClip>,
+            Option<&CalculatedContentClip>,
             &ComputedNodeTarget,
             &TextLayoutInfo,
+            Option<&ScrollPosition>,
         )>,
     >,
     text_background_colors_query: Extract<Query<&TextBackgroundColor>>,
     camera_map: Extract<UiCameraMap>,
 ) {
     let mut camera_mapper = camera_map.get_mapper();
-    for (entity, uinode, global_transform, inherited_visibility, clip, camera, text_layout_info) in
-        &uinode_query
+    for (
+        entity,
+        uinode,
+        global_transform,
+        inherited_visibility,
+        clip,
+        camera,
+        text_layout_info,
+        maybe_scroll_position,
+    ) in &uinode_query
     {
         // Skip if not visible or if size is set to zero (e.g. when a parent is set to `Display::None`)
         if !inherited_visibility.get() || uinode.is_empty() {
@@ -988,8 +1032,19 @@ pub fn extract_text_background_colors(
             continue;
         };
 
-        let transform = global_transform.affine()
-            * bevy_math::Affine3A::from_translation(-0.5 * uinode.size().extend(0.));
+        let content_inset = uinode.content_inset();
+
+        let xy_to_top_left_adjust = -uinode.size() / 2.0;
+        let xy_content_inset_adjust = Vec2::new(content_inset.left, content_inset.top);
+        let mut xy_adjust = xy_to_top_left_adjust + xy_content_inset_adjust;
+
+        if let Some(scroll_position) = maybe_scroll_position {
+            xy_adjust.x -= scroll_position.offset_x;
+            xy_adjust.y -= scroll_position.offset_y;
+        }
+
+        let transform =
+            global_transform.affine() * bevy_math::Affine3A::from_translation(xy_adjust.extend(0.));
 
         for &(section_entity, rect) in text_layout_info.section_rects.iter() {
             let Ok(text_background_color) = text_background_colors_query.get(section_entity) else {
@@ -1008,12 +1063,246 @@ pub fn extract_text_background_colors(
                 image: AssetId::default(),
                 extracted_camera_entity,
                 item: ExtractedUiItem::Node {
-                    atlas_scaling: None,
+                    atlas_rect: None,
+                    image_rect: None,
                     transform: transform * Mat4::from_translation(rect.center().extend(0.)),
                     flip_x: false,
                     flip_y: false,
-                    border: uinode.border(),
+                    border: BorderRect::ZERO,
                     border_radius: uinode.border_radius(),
+                    node_type: NodeType::Rect,
+                },
+                main_entity: entity.into(),
+            });
+        }
+    }
+}
+
+pub fn extract_scrollbars(
+    mut commands: Commands,
+    mut extracted_uinodes: ResMut<ExtractedUiNodes>,
+    uinode_query: Extract<
+        Query<(
+            Entity,
+            &Node,
+            &ComputedNode,
+            &ComputedNodeTarget,
+            Option<&CalculatedClip>,
+            &GlobalTransform,
+            &InheritedVisibility,
+            &ScrollPosition,
+            &ScrollbarColor,
+        )>,
+    >,
+    camera_map: Extract<UiCameraMap>,
+) {
+    let mut camera_mapper = camera_map.get_mapper();
+    for (
+        entity,
+        node,
+        uinode,
+        camera,
+        clip,
+        global_transform,
+        inherited_visibility,
+        scroll_position,
+        scrollbar_color,
+    ) in &uinode_query
+    {
+        // Skip if not visible or if size is set to zero (e.g. when a parent is set to `Display::None`)
+        if !inherited_visibility.get() || uinode.is_empty() {
+            continue;
+        }
+
+        let Some(extracted_camera_entity) = camera_mapper.map(camera) else {
+            continue;
+        };
+
+        // Note: `tf` is center of ui node
+        //       | -y
+        //       |
+        // -x ---+--- x
+        //       |
+        //       | y
+        // "up" is -y, "down" is +y (!)
+        let tf = global_transform.affine();
+
+        // full size, with padding+scrollbar+border
+        let psb_size = uinode.size;
+        // size with padding+scrollbar, without border size
+        let ps_size = psb_size - uinode.border.sum_axes();
+        // size with padding, without scrollbar and border sizes
+        // this is a kind of viewport of our scroll container
+        let p_size = ps_size - uinode.scrollbar_size;
+
+        let psb_half_size = psb_size / 2.0;
+
+        let track_width = SCROLLBAR_TRACK_WIDTH * camera.scale_factor;
+        let thumb_width = SCROLLBAR_THUMB_WIDTH * camera.scale_factor;
+        let thumb_offset = (track_width - thumb_width) / 2.0;
+
+        // Extract scrollbar track and thumb for Y scroll
+        if node.overflow.y.is_scroll() {
+            let track_x = psb_half_size.x - uinode.border.right - track_width;
+            // Note: ui tn origin is top _left_
+            let track_y = -psb_half_size.y + uinode.border.top;
+            let track_tn = Vec3::new(track_x, track_y, 0.0);
+            let track_tf = tf * bevy_math::Affine3A::from_translation(track_tn);
+
+            // Based on p_size, as basing on ps_size will have scrollbars overlapping
+            let track_rect = Rect {
+                min: Vec2::ZERO,
+                max: Vec2::new(track_width, p_size.y),
+            };
+
+            extracted_uinodes.uinodes.push(ExtractedUiNode {
+                render_entity: commands.spawn(TemporaryRenderEntity).id(),
+                stack_index: uinode.stack_index,
+                color: scrollbar_color.track_color.into(),
+                rect: track_rect,
+                clip: clip.map(|clip| clip.clip),
+                image: AssetId::default(),
+                extracted_camera_entity,
+                item: ExtractedUiItem::Node {
+                    atlas_rect: None,
+                    image_rect: None,
+                    transform: track_tf * Mat4::from_translation(track_rect.center().extend(0.)),
+                    flip_x: false,
+                    flip_y: false,
+                    border: BorderRect::ZERO,
+                    border_radius: ResolvedBorderRadius::ZERO,
+                    node_type: NodeType::Rect,
+                },
+                main_entity: entity.into(),
+            });
+
+            // Note: content_size = measured_size + padding.sum_axes()
+            // Viewable size, scrollbar's thumb is sized and relative to it.
+            let view_size_y = uinode.content_size.y.max(p_size.y);
+            let view_size_rel = p_size.y / view_size_y;
+
+            let thumb_height = p_size.y * view_size_rel;
+            let rect = Rect {
+                min: Vec2::ZERO,
+                max: Vec2::new(thumb_width, thumb_height),
+            };
+
+            let offset_y = scroll_position.offset_y * camera.scale_factor;
+            let view_top_rel = offset_y / view_size_y;
+
+            let thumb_tn = Vec3::new(
+                track_x + thumb_offset,
+                track_y + p_size.y * view_top_rel,
+                0.0,
+            );
+            let thumb_tf = tf * bevy_math::Affine3A::from_translation(thumb_tn);
+
+            extracted_uinodes.uinodes.push(ExtractedUiNode {
+                render_entity: commands.spawn(TemporaryRenderEntity).id(),
+                stack_index: uinode.stack_index,
+                color: scrollbar_color.thumb_color.into(),
+                rect,
+                clip: clip.map(|clip| clip.clip),
+                image: AssetId::default(),
+                extracted_camera_entity,
+                item: ExtractedUiItem::Node {
+                    atlas_rect: None,
+                    image_rect: None,
+                    transform: thumb_tf * Mat4::from_translation(rect.center().extend(0.)),
+                    flip_x: false,
+                    flip_y: false,
+                    border: BorderRect::ZERO,
+                    border_radius: ResolvedBorderRadius {
+                        top_left: SCROLLBAR_THUMB_ROUNDING,
+                        top_right: SCROLLBAR_THUMB_ROUNDING,
+                        bottom_left: SCROLLBAR_THUMB_ROUNDING,
+                        bottom_right: SCROLLBAR_THUMB_ROUNDING,
+                    },
+                    node_type: NodeType::Rect,
+                },
+                main_entity: entity.into(),
+            });
+        }
+
+        // Extract scrollbar track and thumb for X scroll
+        if node.overflow.x.is_scroll() {
+            // top of track's rect
+            let track_y = psb_half_size.y - uinode.border.bottom - track_width;
+            // left of track's rect
+            let track_x = -psb_half_size.x + uinode.border.left;
+            let track_tn = Vec3::new(track_x, track_y, 0.0);
+            let track_tf = tf * bevy_math::Affine3A::from_translation(track_tn);
+
+            // Based on p_size, as basing on ps_size will have scrollbars overlapping
+            let track_rect = Rect {
+                min: Vec2::ZERO,
+                max: Vec2::new(p_size.x, track_width),
+            };
+
+            extracted_uinodes.uinodes.push(ExtractedUiNode {
+                render_entity: commands.spawn(TemporaryRenderEntity).id(),
+                stack_index: uinode.stack_index,
+                color: scrollbar_color.track_color.into(),
+                rect: track_rect,
+                clip: clip.map(|clip| clip.clip),
+                image: AssetId::default(),
+                extracted_camera_entity,
+                item: ExtractedUiItem::Node {
+                    atlas_rect: None,
+                    image_rect: None,
+                    transform: track_tf * Mat4::from_translation(track_rect.center().extend(0.)),
+                    flip_x: false,
+                    flip_y: false,
+                    border: BorderRect::ZERO,
+                    border_radius: ResolvedBorderRadius::ZERO,
+                    node_type: NodeType::Rect,
+                },
+                main_entity: entity.into(),
+            });
+
+            // Note: content_size = measured_size + padding.sum_axes()
+            // Viewable size, scrollbar's thumb is sized and relative to it.
+            let view_size_x = uinode.content_size.x.max(p_size.x);
+            let view_size_rel = p_size.x / view_size_x;
+
+            // "main" axis is parallel to track
+            let thumb_size_main = p_size.x * view_size_rel;
+            let rect = Rect {
+                min: Vec2::ZERO,
+                max: Vec2::new(thumb_size_main, thumb_width),
+            };
+
+            let offset_x = scroll_position.offset_x * camera.scale_factor;
+            let view_left_rel = offset_x / view_size_x;
+
+            let thumb_tn = Vec3::new(
+                track_x + p_size.x * view_left_rel,
+                track_y + thumb_offset,
+                0.0,
+            );
+            let thumb_tf = tf * bevy_math::Affine3A::from_translation(thumb_tn);
+
+            extracted_uinodes.uinodes.push(ExtractedUiNode {
+                render_entity: commands.spawn(TemporaryRenderEntity).id(),
+                stack_index: uinode.stack_index,
+                color: scrollbar_color.thumb_color.into(),
+                rect,
+                clip: clip.map(|clip| clip.clip),
+                image: AssetId::default(),
+                extracted_camera_entity,
+                item: ExtractedUiItem::Node {
+                    atlas_rect: None,
+                    image_rect: None,
+                    transform: thumb_tf * Mat4::from_translation(rect.center().extend(0.)),
+                    flip_x: false,
+                    flip_y: false,
+                    border: BorderRect::ZERO,
+                    border_radius: ResolvedBorderRadius {
+                        top_left: SCROLLBAR_THUMB_ROUNDING,
+                        top_right: SCROLLBAR_THUMB_ROUNDING,
+                        bottom_left: SCROLLBAR_THUMB_ROUNDING,
+                        bottom_right: SCROLLBAR_THUMB_ROUNDING,
+                    },
                     node_type: NodeType::Rect,
                 },
                 main_entity: entity.into(),
@@ -1268,7 +1557,8 @@ pub fn prepare_uinodes(
                     }
                     match &extracted_uinode.item {
                         ExtractedUiItem::Node {
-                            atlas_scaling,
+                            atlas_rect,
+                            image_rect,
                             flip_x,
                             flip_y,
                             border_radius,
@@ -1282,9 +1572,9 @@ pub fn prepare_uinodes(
                                 shader_flags::UNTEXTURED
                             };
 
-                            let mut uinode_rect = extracted_uinode.rect;
+                            let mut rect = extracted_uinode.rect;
 
-                            let rect_size = uinode_rect.size().extend(1.0);
+                            let rect_size = rect.size().extend(1.0);
 
                             // Specify the corners of the node
                             let positions = QUAD_VERTEX_POSITIONS
@@ -1293,7 +1583,7 @@ pub fn prepare_uinodes(
 
                             // Calculate the effect of clipping
                             // Note: this won't work with rotation/scaling, but that's much more complex (may need more that 2 quads)
-                            let mut positions_diff = if let Some(clip) = extracted_uinode.clip {
+                            let positions_diff = if let Some(clip) = extracted_uinode.clip {
                                 [
                                     Vec2::new(
                                         f32::max(clip.min.x - positions[0].x, 0.),
@@ -1351,46 +1641,57 @@ pub fn prepare_uinodes(
                             let uvs = if flags == shader_flags::UNTEXTURED {
                                 [Vec2::ZERO, Vec2::X, Vec2::ONE, Vec2::Y]
                             } else {
-                                let image = gpu_images.get(extracted_uinode.image).expect(
+                                let gpu_image = gpu_images.get(extracted_uinode.image).expect(
                                     "Image was checked during batching and should still exist",
                                 );
-                                // Rescale atlases. This is done here because we need texture data that might not be available in Extract.
-                                let atlas_extent = atlas_scaling
-                                    .map(|scaling| image.size_2d().as_vec2() * scaling)
-                                    .unwrap_or(uinode_rect.max);
+
+                                let (atlas_image_rect, atlas_size) = match (atlas_rect, image_rect)
+                                {
+                                    (Some(atlas_rect), Some(image_rect)) => {
+                                        let mut atlas_image_rect = *image_rect;
+                                        atlas_image_rect.min.x += atlas_rect.min.x;
+                                        atlas_image_rect.min.y += atlas_rect.min.y;
+                                        atlas_image_rect.max.x += atlas_rect.min.x;
+                                        atlas_image_rect.max.y += atlas_rect.min.y;
+                                        (atlas_image_rect, atlas_image_rect.max)
+                                    }
+                                    (Some(atlas_rect), None) => (*atlas_rect, atlas_rect.max),
+                                    (None, Some(image_rect)) => (*image_rect, image_rect.max),
+                                    _ => (
+                                        Rect::new(
+                                            0.,
+                                            0.,
+                                            gpu_image.size.width as f32,
+                                            gpu_image.size.height as f32,
+                                        ),
+                                        Vec2::new(
+                                            gpu_image.size.width as f32,
+                                            gpu_image.size.height as f32,
+                                        ),
+                                    ),
+                                };
+
+                                let scale_rect = atlas_image_rect.size().x / rect.size().x;
+
+                                let mut flipped_points = points;
                                 if *flip_x {
-                                    core::mem::swap(&mut uinode_rect.max.x, &mut uinode_rect.min.x);
-                                    positions_diff[0].x *= -1.;
-                                    positions_diff[1].x *= -1.;
-                                    positions_diff[2].x *= -1.;
-                                    positions_diff[3].x *= -1.;
+                                    core::mem::swap(&mut rect.max.x, &mut rect.min.x);
+                                    for i in 0..4 {
+                                        flipped_points[i].x *= -1.;
+                                    }
                                 }
                                 if *flip_y {
-                                    core::mem::swap(&mut uinode_rect.max.y, &mut uinode_rect.min.y);
-                                    positions_diff[0].y *= -1.;
-                                    positions_diff[1].y *= -1.;
-                                    positions_diff[2].y *= -1.;
-                                    positions_diff[3].y *= -1.;
+                                    core::mem::swap(&mut rect.max.y, &mut rect.min.y);
+                                    for i in 0..4 {
+                                        flipped_points[i].y *= -1.;
+                                    }
                                 }
-                                [
-                                    Vec2::new(
-                                        uinode_rect.min.x + positions_diff[0].x,
-                                        uinode_rect.min.y + positions_diff[0].y,
-                                    ),
-                                    Vec2::new(
-                                        uinode_rect.max.x + positions_diff[1].x,
-                                        uinode_rect.min.y + positions_diff[1].y,
-                                    ),
-                                    Vec2::new(
-                                        uinode_rect.max.x + positions_diff[2].x,
-                                        uinode_rect.max.y + positions_diff[2].y,
-                                    ),
-                                    Vec2::new(
-                                        uinode_rect.min.x + positions_diff[3].x,
-                                        uinode_rect.max.y + positions_diff[3].y,
-                                    ),
-                                ]
-                                .map(|pos| pos / atlas_extent)
+
+                                let uvs = flipped_points.map(|p| {
+                                    (p * scale_rect + atlas_image_rect.center()) / atlas_size
+                                });
+
+                                uvs
                             };
 
                             let color = extracted_uinode.color.to_f32_array();

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -374,8 +374,7 @@ impl From<Vec2> for ScrollPosition {
     Transform,
     Visibility,
     VisibilityClass,
-    ZIndex,
-    ScrollPosition
+    ZIndex
 )]
 #[reflect(Component, Default, PartialEq, Debug, Clone)]
 #[cfg_attr(

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -283,14 +283,14 @@ impl Default for ScrollbarColor {
 /// I.e., will be width for scrollbar y, height for scrollbar x.
 // Named SCROLLBAR_TRACK_WIDTH rather than SCROLLBAL_WIDTH,
 // as scrollbar_width has different meaning in CSS:
-// https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-width
+// <https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-width>
 pub const SCROLLBAR_TRACK_WIDTH: f32 = 12.0; // px
 pub const SCROLLBAR_THUMB_WIDTH: f32 = SCROLLBAR_TRACK_WIDTH - 4.0; // px
 pub const SCROLLBAR_THUMB_ROUNDING: f32 = 10.0; // px
 
 /// The scroll position of the node.
 /// Corresponds to CSS's scrollTop:
-/// https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTop
+/// <https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTop>
 ///
 /// Updating the values of `ScrollPosition` will reposition the children of the node by the offset amount.
 /// `ScrollPosition` may be updated by the layout system when a layout change makes a previously valid `ScrollPosition` invalid.

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -1096,6 +1096,12 @@ impl Overflow {
         self.x.is_visible() && self.y.is_visible()
     }
 
+    /// Overflow is scrollable on at least 1 axis
+    pub const fn is_any_scroll(&self) -> bool {
+        // y is most commonly used for scroll, so it's first, to short-circuit
+        self.y.is_scroll() || self.x.is_scroll()
+    }
+
     pub const fn scroll() -> Self {
         Self {
             x: OverflowAxis::Scroll,
@@ -1151,6 +1157,11 @@ impl OverflowAxis {
     /// Overflow is visible on this axis
     pub const fn is_visible(&self) -> bool {
         matches!(self, Self::Visible)
+    }
+
+    /// Overflow is scroll on this axis
+    pub const fn is_scroll(&self) -> bool {
+        matches!(self, Self::Scroll)
     }
 }
 

--- a/examples/ui/borders.rs
+++ b/examples/ui/borders.rs
@@ -1,12 +1,11 @@
 //! Example demonstrating bordered UI nodes
 
+use bevy::ecs::relationship::{AncestorIter, RelationshipSourceCollection};
 use bevy::{color::palettes::css::*, ecs::spawn::SpawnIter, prelude::*};
-
 use bevy::{
     input::mouse::{MouseScrollUnit, MouseWheel},
     picking::hover::HoverMap,
 };
-use bevy_ecs::relationship::{AncestorIter, RelationshipSourceCollection};
 
 fn main() {
     App::new()

--- a/examples/ui/borders.rs
+++ b/examples/ui/borders.rs
@@ -2,14 +2,79 @@
 
 use bevy::{color::palettes::css::*, ecs::spawn::SpawnIter, prelude::*};
 
+use bevy::{
+    input::mouse::{MouseScrollUnit, MouseWheel},
+    picking::hover::HoverMap,
+};
+use bevy_ecs::relationship::{AncestorIter, RelationshipSourceCollection};
+
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_systems(Startup, setup)
+        .add_systems(Update, update_scroll_position)
         .run();
 }
 
-fn setup(mut commands: Commands) {
+const LINE_HEIGHT: f32 = 21.;
+
+/// Updates the scroll position of scrollable nodes in response to mouse input
+pub fn update_scroll_position(
+    mut mouse_wheel_events: EventReader<MouseWheel>,
+    hover_map: Res<HoverMap>,
+    mut scrolled_node_query: Query<(&mut ScrollPosition, &Node)>,
+    child_of_query: Query<&ChildOf>,
+    keyboard_input: Res<ButtonInput<KeyCode>>,
+) {
+    for mouse_wheel_event in mouse_wheel_events.read() {
+        let (mut dx, mut dy) = match mouse_wheel_event.unit {
+            MouseScrollUnit::Line => (
+                mouse_wheel_event.x * LINE_HEIGHT,
+                mouse_wheel_event.y * LINE_HEIGHT,
+            ),
+            MouseScrollUnit::Pixel => (mouse_wheel_event.x, mouse_wheel_event.y),
+        };
+        // accelerate scroll
+        // dx *= 5.0;
+        // dy *= 5.0;
+
+        if keyboard_input.pressed(KeyCode::ShiftLeft) || keyboard_input.pressed(KeyCode::ShiftRight)
+        {
+            std::mem::swap(&mut dx, &mut dy);
+        }
+
+        for (_pointer, pointer_map) in hover_map.iter() {
+            for (entity, _hit) in pointer_map.iter() {
+                let ancestors_iter = (*entity)
+                    .iter()
+                    .chain(AncestorIter::new(&child_of_query, *entity));
+
+                for ancestor_entity in ancestors_iter {
+                    // This may mut scroll position multiple times.
+                    // E.g., multiple pointers hovering over the same entity.
+                    // TODO collect _distinct_ scroll targets, then apply scroll to them.
+                    if let Ok((mut scroll_position, node)) =
+                        scrolled_node_query.get_mut(ancestor_entity)
+                    {
+                        // May be desirable to not capture scroll if there's no more room for scroll.
+                        // Although that is to be governed by CSS's overscroll-behavior, TODO.
+                        // In this version, targets without scroll axis won't capture that scroll input.
+                        // I.e., scroll_x() targets only capture x scroll, y scroll propagates further.
+                        if dy != 0.0 && node.overflow.y.is_scroll()
+                            || dx != 0.0 && node.overflow.x.is_scroll()
+                        {
+                            scroll_position.offset_y -= dy;
+                            scroll_position.offset_x -= dx;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn setup(asset_server: Res<AssetServer>, mut commands: Commands) {
     commands.spawn(Camera2d);
 
     // labels for the different border edges
@@ -92,18 +157,15 @@ fn setup(mut commands: Commands) {
     let borders_examples = (
         Node {
             margin: UiRect::all(Val::Px(25.0)),
-            align_self: AlignSelf::Stretch,
-            justify_self: JustifySelf::Stretch,
+            display: Display::Flex,
             flex_wrap: FlexWrap::Wrap,
-            justify_content: JustifyContent::FlexStart,
-            align_items: AlignItems::FlexStart,
-            align_content: AlignContent::FlexStart,
             ..default()
         },
         Children::spawn(SpawnIter(border_labels.into_iter().zip(borders).map(
             |(label, border)| {
                 (
                     Node {
+                        display: Display::Flex,
                         flex_direction: FlexDirection::Column,
                         align_items: AlignItems::Center,
                         ..default()
@@ -111,10 +173,11 @@ fn setup(mut commands: Commands) {
                     children![
                         (
                             Node {
+                                margin: UiRect::all(Val::Px(20.)),
+                                border,
                                 width: Val::Px(50.),
                                 height: Val::Px(50.),
-                                border,
-                                margin: UiRect::all(Val::Px(20.)),
+                                display: Display::Flex,
                                 align_items: AlignItems::Center,
                                 justify_content: JustifyContent::Center,
                                 ..default()
@@ -123,7 +186,7 @@ fn setup(mut commands: Commands) {
                             BorderColor(RED.into()),
                             Outline {
                                 width: Val::Px(6.),
-                                offset: Val::Px(6.),
+                                offset: Val::Px(0.),
                                 color: Color::WHITE,
                             },
                             children![(
@@ -154,18 +217,15 @@ fn setup(mut commands: Commands) {
     let borders_examples_rounded = (
         Node {
             margin: UiRect::all(Val::Px(25.0)),
-            align_self: AlignSelf::Stretch,
-            justify_self: JustifySelf::Stretch,
+            display: Display::Flex,
             flex_wrap: FlexWrap::Wrap,
-            justify_content: JustifyContent::FlexStart,
-            align_items: AlignItems::FlexStart,
-            align_content: AlignContent::FlexStart,
             ..default()
         },
         Children::spawn(SpawnIter(border_labels.into_iter().zip(borders).map(
             move |(label, border)| {
                 (
                     Node {
+                        display: Display::Flex,
                         flex_direction: FlexDirection::Column,
                         align_items: AlignItems::Center,
                         ..default()
@@ -173,10 +233,11 @@ fn setup(mut commands: Commands) {
                     children![
                         (
                             Node {
+                                margin: UiRect::all(Val::Px(20.)),
+                                border,
                                 width: Val::Px(50.),
                                 height: Val::Px(50.),
-                                border,
-                                margin: UiRect::all(Val::Px(20.)),
+                                display: Display::Flex,
                                 align_items: AlignItems::Center,
                                 justify_content: JustifyContent::Center,
                                 ..default()
@@ -191,7 +252,7 @@ fn setup(mut commands: Commands) {
                             ),
                             Outline {
                                 width: Val::Px(6.),
-                                offset: Val::Px(6.),
+                                offset: Val::Px(0.),
                                 color: Color::WHITE,
                             },
                             children![(
@@ -211,16 +272,330 @@ fn setup(mut commands: Commands) {
         ))),
     );
 
-    commands.spawn((
+    let empty_borders_examples = (
         Node {
             margin: UiRect::all(Val::Px(25.0)),
-            flex_direction: FlexDirection::Column,
-            align_self: AlignSelf::Stretch,
-            justify_self: JustifySelf::Stretch,
+            display: Display::Flex,
             flex_wrap: FlexWrap::Wrap,
-            justify_content: JustifyContent::FlexStart,
-            align_items: AlignItems::FlexStart,
-            align_content: AlignContent::FlexStart,
+            ..default()
+        },
+        Children::spawn(SpawnIter(border_labels.into_iter().zip(borders).map(
+            |(label, border)| {
+                (
+                    Node {
+                        display: Display::Flex,
+                        flex_direction: FlexDirection::Column,
+                        align_items: AlignItems::Center,
+                        ..default()
+                    },
+                    children![
+                        (
+                            Node {
+                                margin: UiRect::all(Val::Px(20.)),
+                                border,
+                                padding: UiRect::all(Val::Px(20.)),
+                                display: Display::Flex,
+                                align_items: AlignItems::Center,
+                                justify_content: JustifyContent::Center,
+                                ..default()
+                            },
+                            BackgroundColor(MAROON.into()),
+                            BorderColor(RED.into()),
+                            Outline {
+                                width: Val::Px(6.),
+                                offset: Val::Px(0.),
+                                color: Color::WHITE,
+                            },
+                        ),
+                        (Text::new(label), TextFont::from_font_size(9.0))
+                    ],
+                )
+            },
+        ))),
+    );
+
+    let text_borders_examples = (
+        Node {
+            margin: UiRect::all(Val::Px(25.0)),
+            display: Display::Flex,
+            flex_wrap: FlexWrap::Wrap,
+            ..default()
+        },
+        Children::spawn(SpawnIter(border_labels.into_iter().zip(borders).map(
+            |(label, border)| {
+                (
+                    Node {
+                        flex_direction: FlexDirection::Column,
+                        align_items: AlignItems::Center,
+                        ..default()
+                    },
+                    children![
+                        (
+                            Text::new("text\nlines"),
+                            TextBackgroundColor::from(PURPLE),
+                            TextShadow::default(),
+                            Node {
+                                margin: UiRect::all(Val::Px(20.)),
+                                border,
+                                padding: UiRect::all(Val::Px(20.)),
+                                ..default()
+                            },
+                            BackgroundColor(MAROON.into()),
+                            BorderColor(RED.into()),
+                            Outline {
+                                width: Val::Px(6.),
+                                offset: Val::Px(0.),
+                                color: Color::WHITE,
+                            },
+                        ),
+                        (Text::new(label), TextFont::from_font_size(9.0))
+                    ],
+                )
+            },
+        ))),
+    );
+
+    let scrollable_text_borders_examples = (
+        Node {
+            margin: UiRect::all(Val::Px(25.0)),
+            display: Display::Flex,
+            flex_wrap: FlexWrap::Wrap,
+            ..default()
+        },
+        Children::spawn(SpawnIter(border_labels.into_iter().zip(borders).map(
+            |(label, border)| {
+                (
+                    Node {
+                        display: Display::Flex,
+                        flex_direction: FlexDirection::Column,
+                        align_items: AlignItems::Center,
+                        ..default()
+                    },
+                    children![
+                        (
+                            Text::new(
+                                "I am a pretty long text line 1\nI am a pretty long text line 2"
+                            ),
+                            TextBackgroundColor::from(PURPLE),
+                            TextShadow::default(),
+                            Node {
+                                margin: UiRect::all(Val::Px(20.)),
+                                box_sizing: BoxSizing::ContentBox,
+                                width: Val::Px(120.),
+                                height: Val::Px(120.),
+                                border,
+                                overflow: Overflow::scroll_y(),
+                                padding: UiRect::all(Val::Px(20.)),
+                                ..default()
+                            },
+                            BackgroundColor(MAROON.into()),
+                            BorderColor(RED.into()),
+                            Outline {
+                                width: Val::Px(6.),
+                                offset: Val::Px(0.),
+                                color: Color::WHITE,
+                            },
+                        ),
+                        (Text::new(label), TextFont::from_font_size(9.0))
+                    ],
+                )
+            },
+        ))),
+    );
+
+    let image = asset_server.load("branding/icon.png");
+    let image_borders_examples = (
+        Node {
+            margin: UiRect::all(Val::Px(25.0)),
+            display: Display::Flex,
+            flex_wrap: FlexWrap::Wrap,
+            ..default()
+        },
+        Children::spawn(SpawnIter(border_labels.into_iter().zip(borders).map(
+            move |(label, border)| {
+                (
+                    Node {
+                        display: Display::Flex,
+                        flex_direction: FlexDirection::Column,
+                        align_items: AlignItems::Center,
+                        ..default()
+                    },
+                    children![
+                        (
+                            ImageNode::new(image.clone()),
+                            Node {
+                                margin: UiRect::all(Val::Px(20.)),
+                                border,
+                                padding: UiRect::all(Val::Px(20.)),
+                                width: Val::Px(80.),
+                                ..default()
+                            },
+                            BackgroundColor(MAROON.into()),
+                            BorderColor(RED.into()),
+                            Outline {
+                                width: Val::Px(6.),
+                                offset: Val::Px(0.),
+                                color: Color::WHITE,
+                            },
+                        ),
+                        (Text::new(label), TextFont::from_font_size(9.0))
+                    ],
+                )
+            },
+        ))),
+    );
+
+    let image = asset_server.load("branding/icon.png");
+    let image_content_box_borders_examples = (
+        Node {
+            margin: UiRect::all(Val::Px(25.0)),
+            display: Display::Flex,
+            flex_wrap: FlexWrap::Wrap,
+            ..default()
+        },
+        Children::spawn(SpawnIter(border_labels.into_iter().zip(borders).map(
+            move |(label, border)| {
+                (
+                    Node {
+                        display: Display::Flex,
+                        flex_direction: FlexDirection::Column,
+                        align_items: AlignItems::Center,
+                        ..default()
+                    },
+                    children![
+                        (
+                            ImageNode::new(image.clone()),
+                            Node {
+                                margin: UiRect::all(Val::Px(20.)),
+                                box_sizing: BoxSizing::ContentBox,
+                                width: Val::Px(80.),
+                                border,
+                                padding: UiRect::all(Val::Px(20.)),
+                                ..default()
+                            },
+                            BackgroundColor(MAROON.into()),
+                            BorderColor(RED.into()),
+                            Outline {
+                                width: Val::Px(6.),
+                                offset: Val::Px(0.),
+                                color: Color::WHITE,
+                            },
+                        ),
+                        (Text::new(label), TextFont::from_font_size(9.0))
+                    ],
+                )
+            },
+        ))),
+    );
+
+    let image = asset_server.load("branding/icon.png");
+    let flipped_image_content_box_borders_examples = (
+        Node {
+            margin: UiRect::all(Val::Px(25.0)),
+            display: Display::Flex,
+            flex_wrap: FlexWrap::Wrap,
+            ..default()
+        },
+        Children::spawn(SpawnIter(
+            border_labels.into_iter().zip(borders).enumerate().map(
+                move |(idx, (label, border))| {
+                    let flip_pos = idx % 4;
+                    (
+                        Node {
+                            display: Display::Flex,
+                            flex_direction: FlexDirection::Column,
+                            align_items: AlignItems::Center,
+                            ..default()
+                        },
+                        children![
+                            (
+                                ImageNode {
+                                    image: image.clone(),
+                                    // flipped: none, y, yx, x; repeat
+                                    flip_x: flip_pos == 3 || flip_pos == 2,
+                                    flip_y: flip_pos == 1 || flip_pos == 2,
+                                    ..default()
+                                },
+                                Node {
+                                    margin: UiRect::all(Val::Px(20.)),
+                                    box_sizing: BoxSizing::ContentBox,
+                                    width: Val::Px(80.),
+                                    border,
+                                    padding: UiRect::all(Val::Px(20.)),
+                                    ..default()
+                                },
+                                BackgroundColor(MAROON.into()),
+                                BorderColor(RED.into()),
+                                Outline {
+                                    width: Val::Px(6.),
+                                    offset: Val::Px(0.),
+                                    color: Color::WHITE,
+                                },
+                            ),
+                            (Text::new(label), TextFont::from_font_size(9.0))
+                        ],
+                    )
+                },
+            ),
+        )),
+    );
+
+    let image = asset_server.load("branding/banner.png");
+    let image_rounded_borders_examples = (
+        Node {
+            margin: UiRect::all(Val::Px(25.0)),
+            display: Display::Flex,
+            flex_wrap: FlexWrap::Wrap,
+            ..default()
+        },
+        Children::spawn(SpawnIter(border_labels.into_iter().zip(borders).map(
+            move |(label, border)| {
+                (
+                    Node {
+                        display: Display::Flex,
+                        flex_direction: FlexDirection::Column,
+                        align_items: AlignItems::Center,
+                        ..default()
+                    },
+                    children![
+                        (
+                            ImageNode::new(image.clone()),
+                            Node {
+                                margin: UiRect::all(Val::Px(20.)),
+                                width: Val::Px(120.),
+                                border,
+                                ..default()
+                            },
+                            BackgroundColor(MAROON.into()),
+                            BorderColor(RED.into()),
+                            BorderRadius::px(
+                                border_size(border.left, border.top),
+                                border_size(border.right, border.top),
+                                border_size(border.right, border.bottom),
+                                border_size(border.left, border.bottom),
+                            ),
+                            Outline {
+                                width: Val::Px(6.),
+                                offset: Val::Px(0.),
+                                color: Color::WHITE,
+                            },
+                        ),
+                        (Text::new(label), TextFont::from_font_size(9.0))
+                    ],
+                )
+            },
+        ))),
+    );
+
+    commands.spawn((
+        Node {
+            margin: UiRect::all(Val::Auto),
+            width: Val::Vw(95.0),
+            height: Val::Vh(95.0),
+            overflow: Overflow::scroll_y(),
+            padding: UiRect::all(Val::Px(20.)),
+            display: Display::Flex,
+            flex_direction: FlexDirection::Column,
             ..default()
         },
         BackgroundColor(Color::srgb(0.25, 0.25, 0.25)),
@@ -228,7 +603,21 @@ fn setup(mut commands: Commands) {
             label("Borders"),
             borders_examples,
             label("Borders Rounded"),
-            borders_examples_rounded
+            borders_examples_rounded,
+            label("Empty Borders"),
+            empty_borders_examples,
+            label("Text Borders"),
+            text_borders_examples,
+            label("Scrollable Text Borders"),
+            scrollable_text_borders_examples,
+            label("Image Borders"),
+            image_borders_examples,
+            label("Image Content Box Borders"),
+            image_content_box_borders_examples,
+            label("Flipped Content Box Images Borders"),
+            flipped_image_content_box_borders_examples,
+            label("Image Rounded Borders"),
+            image_rounded_borders_examples,
         ],
     ));
 }
@@ -238,8 +627,14 @@ fn setup(mut commands: Commands) {
 fn label(text: &str) -> impl Bundle {
     (
         Node {
+            display: Display::Block,
             margin: UiRect::all(Val::Px(25.0)),
             ..default()
+        },
+        Outline {
+            width: Val::Px(6.),
+            offset: Val::Px(0.),
+            color: Color::WHITE,
         },
         children![(Text::new(text), TextFont::from_font_size(20.0))],
     )

--- a/examples/ui/scroll.rs
+++ b/examples/ui/scroll.rs
@@ -22,6 +22,21 @@ fn main() {
 const FONT_SIZE: f32 = 20.;
 const LINE_HEIGHT: f32 = 21.;
 
+fn label(name: &'static str) -> impl Bundle {
+    (
+        Text::new(name),
+        TextFont {
+            font_size: FONT_SIZE,
+            ..default()
+        },
+        Label,
+        Node {
+            margin: UiRect::all(Val::Px(4.)),
+            ..default()
+        },
+    )
+}
+
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Camera
     commands.spawn((Camera2d, IsDefaultUiCamera));
@@ -31,7 +46,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         .spawn(Node {
             width: Val::Percent(100.0),
             height: Val::Percent(100.0),
-            justify_content: JustifyContent::SpaceBetween,
+            justify_content: JustifyContent::SpaceAround,
+            align_content: AlignContent::Center,
             flex_direction: FlexDirection::Column,
             ..default()
         })
@@ -46,15 +62,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 })
                 .with_children(|parent| {
                     // header
-                    parent.spawn((
-                        Text::new("Horizontally Scrolling list (Ctrl + MouseWheel)"),
-                        TextFont {
-                            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                            font_size: FONT_SIZE,
-                            ..default()
-                        },
-                        Label,
-                    ));
+                    parent.spawn(label("Horizontally Scrollable list (Ctrl + MouseWheel)"));
 
                     // horizontal scroll container
                     parent
@@ -67,6 +75,11 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                 ..default()
                             },
                             BackgroundColor(Color::srgb(0.10, 0.10, 0.10)),
+                            Outline {
+                                width: Val::Px(6.),
+                                offset: Val::Px(0.),
+                                color: Color::WHITE,
+                            },
                         ))
                         .with_children(|parent| {
                             for i in 0..100 {
@@ -106,7 +119,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     width: Val::Percent(100.),
                     height: Val::Percent(100.),
                     flex_direction: FlexDirection::Row,
-                    justify_content: JustifyContent::SpaceBetween,
+                    justify_content: JustifyContent::SpaceAround,
                     ..default()
                 })
                 .with_children(|parent| {
@@ -121,16 +134,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         })
                         .with_children(|parent| {
                             // Title
-                            parent.spawn((
-                                Text::new("Vertically Scrolling List"),
-                                TextFont {
-                                    font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                                    font_size: FONT_SIZE,
-                                    ..default()
-                                },
-                                Label,
-                            ));
-                            // Scrolling list
+                            parent.spawn(label("Vertically Scrollable List"));
+                            // Scrollable list
                             parent
                                 .spawn((
                                     Node {
@@ -141,10 +146,15 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                         ..default()
                                     },
                                     BackgroundColor(Color::srgb(0.10, 0.10, 0.10)),
+                                    Outline {
+                                        width: Val::Px(6.),
+                                        offset: Val::Px(0.),
+                                        color: Color::WHITE,
+                                    },
                                 ))
                                 .with_children(|parent| {
                                     // List items
-                                    for i in 0..25 {
+                                    for i in 0..30 {
                                         parent
                                             .spawn(Node {
                                                 min_height: Val::Px(LINE_HEIGHT),
@@ -189,16 +199,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         })
                         .with_children(|parent| {
                             // Title
-                            parent.spawn((
-                                Text::new("Bidirectionally Scrolling List"),
-                                TextFont {
-                                    font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                                    font_size: FONT_SIZE,
-                                    ..default()
-                                },
-                                Label,
-                            ));
-                            // Scrolling list
+                            parent.spawn(label("Bidirectionally Scrollable List"));
+                            // Scrollable list
                             parent
                                 .spawn((
                                     Node {
@@ -209,10 +211,15 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                         ..default()
                                     },
                                     BackgroundColor(Color::srgb(0.10, 0.10, 0.10)),
+                                    Outline {
+                                        width: Val::Px(6.),
+                                        offset: Val::Px(0.),
+                                        color: Color::WHITE,
+                                    },
                                 ))
                                 .with_children(|parent| {
                                     // Rows in each column
-                                    for oi in 0..10 {
+                                    for oi in 0..20 {
                                         parent
                                             .spawn(Node {
                                                 flex_direction: FlexDirection::Row,
@@ -257,15 +264,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         })
                         .with_children(|parent| {
                             // Title
-                            parent.spawn((
-                                Text::new("Nested Scrolling Lists"),
-                                TextFont {
-                                    font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                                    font_size: FONT_SIZE,
-                                    ..default()
-                                },
-                                Label,
-                            ));
+                            parent.spawn(label("Nested Scrollable Lists"));
                             // Outer, horizontal scrolling container
                             parent
                                 .spawn((
@@ -278,6 +277,11 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                         ..default()
                                     },
                                     BackgroundColor(Color::srgb(0.10, 0.10, 0.10)),
+                                    Outline {
+                                        width: Val::Px(6.),
+                                        offset: Val::Px(0.),
+                                        color: Color::WHITE,
+                                    },
                                 ))
                                 .with_children(|parent| {
                                     // Inner, scrolling columns


### PR DESCRIPTION
# Objective

Enable layout and rendering of padding and border on UI leaf nodes.
As presently they're being ignored.

Fixes #6879
Fixes #11557 
Fixes #17300 (duplicate of the above)

Scale-to-fit leaf node images.
As padding and border on these nodes "eat" available for image space.

Adds layout and render of scrollbars.

## Solution

1. Provide Taffy with border and scrollbar sizes. (previously, border is set to Zero for leaf nodes, scrollbar_size always 0)
2. Measure text and images with regard to available_width. (needs an eye on it)
    measure_fns make use of Taffy's available_size, which comes with borders, scrollbars and padding stripped out, so available_size for pure content.
    known_sizes are disregarded as they include those (so it's a size of border box).
    Previously they've been fine to use, as leaf nodes meant to have border_box = pure content size.
    Also, images follow CSS's object-fit: contain; and that's not a default behavior in CSS. Default is to stretch. So perhaps that's something to change?
3. Adjust clip calculation for node's content to account for scrollbar sizes.
    Cache it as ComputedContentClip (as _content's_ clip, and not inherited from parent clip is now necessary for rendering UI leaf nodes)
4. Add scrollbar rendering (of track and thumb). (eyes wanted on whether that's efficient)
    Scrollbar sizes are `const`s. (as CSS does not allow for Px val customization of scrollbar sizes, only coarse "auto" "thin" via `scrollbar-width`, so Px vals are not exposed to be configurable e.g., via a component)
    `ScrollbarColor` component, required from `Node` can be used to specify track and thumb colors for node's scrollbars.
5. Switch from Node requiring ScrollPosition to manually enabling it for nodes with overflow scroll on any axis.
6. Preliminary work on enabling scroll for a reverse-ordered flexbox, where scroll position is meant to be in negative values - clamp scroll with this in mind. Yet present version of Taffy reports content_size that = layout_size for reverse-ordered flexboxes, so that does not fixes #17129 atm.

For rendering of a scale-to-fit image I've explored two approaches:
1. Modify it's Affine transform with scale, at extraction step. Worked. Seems simple.
    But then I discovered the caveat, when clip cuts some part of an image (e.g., only top part of image is seen when scrolling), GLSL's UVs are not modified, so whole image texture is rendered on top-half rect, resulting in a "squashed" look.
2. Modify image's UV's to account for clipping. This way we have e.g., vertexes _and_ UVs for top-half of the image.
    That's the way it's done in PR. Images get clipped correctly (incl. flipped ones, as can be seen in `borders` example)
Eyes wanted on performance of the approach.

## Testing

I performed visual testing on `borders` `scroll` and `game_menu` examples.
Ubuntu 25.04, X11

---

## Showcase

Before / After

https://github.com/user-attachments/assets/e3f0723c-91cb-4e11-a556-f360e74a9a23

https://github.com/user-attachments/assets/31192ea5-75a4-461e-91ed-c0ed3cdfc744

Can be run with `cargo run --example borders` on commits:
24cc495bad15fa0fda708c2034fe9a1cef2d2408 (Extend borders example with text and images)
e976b541bb8644a725c2e5c6ed8763c5a576ae6c (UI: add support for padding...)
