### PR TITLE
bevy_render: disable GpuPreprocessingSupport for GL backend

### DIFF
--- a/crates/bevy_pbr/src/light_probe/mod.rs
+++ b/crates/bevy_pbr/src/light_probe/mod.rs
@@ -719,7 +719,7 @@ pub(crate) fn binding_arrays_are_usable(
     render_adapter: &RenderAdapter,
 ) -> bool {
     !cfg!(feature = "shader_format_glsl")
-        && bevy_render::get_adreno_model(render_adapter).is_none_or(|model| model > 610)
+        && bevy_render::get_adreno_model(&render_adapter.get_info()).is_none_or(|model| model > 610)
         && render_device.limits().max_storage_textures_per_shader_stage
             >= (STANDARD_MATERIAL_FRAGMENT_SHADER_MIN_TEXTURE_BINDINGS + MAX_VIEW_LIGHT_PROBES)
                 as u32

--- a/crates/bevy_pbr/src/light_probe/mod.rs
+++ b/crates/bevy_pbr/src/light_probe/mod.rs
@@ -23,12 +23,12 @@ use bevy_render::{
     extract_instances::ExtractInstancesPlugin,
     render_asset::RenderAssets,
     render_resource::{DynamicUniformBuffer, Sampler, ShaderType, TextureView},
-    renderer::{RenderAdapter, RenderDevice, RenderQueue},
+    renderer::{RenderAdapter, RenderAdapterInfo, RenderDevice, RenderQueue},
     settings::WgpuFeatures,
     sync_world::RenderEntity,
     texture::{FallbackImage, GpuImage},
     view::ExtractedView,
-    Extract, ExtractSchedule, Render, RenderApp, RenderSystems,
+    Extract, ExtractSchedule, Render, RenderApp, RenderSystems, WgpuWrapper,
 };
 use bevy_shader::load_shader_library;
 use bevy_transform::{components::Transform, prelude::GlobalTransform};
@@ -718,8 +718,10 @@ pub(crate) fn binding_arrays_are_usable(
     render_device: &RenderDevice,
     render_adapter: &RenderAdapter,
 ) -> bool {
+    let adapter_info = RenderAdapterInfo(WgpuWrapper::new(render_adapter.get_info()));
+
     !cfg!(feature = "shader_format_glsl")
-        && bevy_render::get_adreno_model(&render_adapter.get_info()).is_none_or(|model| model > 610)
+        && bevy_render::get_adreno_model(&adapter_info).is_none_or(|model| model > 610)
         && render_device.limits().max_storage_textures_per_shader_stage
             >= (STANDARD_MATERIAL_FRAGMENT_SHADER_MIN_TEXTURE_BINDINGS + MAX_VIEW_LIGHT_PROBES)
                 as u32

--- a/crates/bevy_render/src/diagnostic/mod.rs
+++ b/crates/bevy_render/src/diagnostic/mod.rs
@@ -17,7 +17,7 @@ use self::internal::{
     sync_diagnostics, DiagnosticsRecorder, Pass, RenderDiagnosticsMutex, WriteTimestamp,
 };
 
-use super::{RenderDevice, RenderQueue};
+use crate::renderer::{RenderDevice, RenderQueue};
 
 /// Enables collecting render diagnostics, such as CPU/GPU elapsed time per render pass,
 /// as well as pipeline statistics (number of primitives, number of shader invocations, etc).

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -78,6 +78,7 @@ pub mod prelude {
 }
 
 pub use extract_param::Extract;
+use wgpu::AdapterInfo;
 
 use crate::{
     camera::CameraPlugin,
@@ -111,7 +112,6 @@ use render_asset::{
     extract_render_asset_bytes_per_frame, reset_render_asset_bytes_per_frame,
     RenderAssetBytesPerFrame, RenderAssetBytesPerFrameLimiter,
 };
-use renderer::{RenderAdapter, RenderDevice, RenderQueue};
 use settings::RenderResources;
 use std::sync::Mutex;
 use sync_world::{despawn_temporary_render_entities, entity_sync_system, SyncWorldPlugin};
@@ -589,16 +589,15 @@ fn apply_extract_commands(render_world: &mut World) {
     });
 }
 
-/// If the [`RenderAdapter`] is a Qualcomm Adreno, returns its model number.
+/// If the [`RenderAdapter`](crate::renderer::RenderAdapter) is a Qualcomm Adreno, returns its model number.
 ///
 /// This lets us work around hardware bugs.
-pub fn get_adreno_model(adapter: &RenderAdapter) -> Option<u32> {
+pub fn get_adreno_model(adapter_info: &AdapterInfo) -> Option<u32> {
     if !cfg!(target_os = "android") {
         return None;
     }
 
-    let adapter_name = adapter.get_info().name;
-    let adreno_model = adapter_name.strip_prefix("Adreno (TM) ")?;
+    let adreno_model = adapter_info.name.strip_prefix("Adreno (TM) ")?;
 
     // Take suffixes into account (like Adreno 642L).
     Some(
@@ -610,16 +609,15 @@ pub fn get_adreno_model(adapter: &RenderAdapter) -> Option<u32> {
 }
 
 /// Get the Mali driver version if the adapter is a Mali GPU.
-pub fn get_mali_driver_version(adapter: &RenderAdapter) -> Option<u32> {
+pub fn get_mali_driver_version(adapter_info: &AdapterInfo) -> Option<u32> {
     if !cfg!(target_os = "android") {
         return None;
     }
 
-    let driver_name = adapter.get_info().name;
-    if !driver_name.contains("Mali") {
+    if !adapter_info.name.contains("Mali") {
         return None;
     }
-    let driver_info = adapter.get_info().driver_info;
+    let driver_info = &adapter_info.driver_info;
     if let Some(start_pos) = driver_info.find("v1.r")
         && let Some(end_pos) = driver_info[start_pos..].find('p')
     {

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -78,7 +78,6 @@ pub mod prelude {
 }
 
 pub use extract_param::Extract;
-use wgpu::AdapterInfo;
 
 use crate::{
     camera::CameraPlugin,
@@ -86,7 +85,7 @@ use crate::{
     mesh::{MeshPlugin, MorphPlugin, RenderMesh},
     render_asset::prepare_assets,
     render_resource::{init_empty_bind_group_layout, PipelineCache},
-    renderer::{render_system, RenderInstance},
+    renderer::{render_system, RenderAdapterInfo, RenderInstance},
     settings::RenderCreation,
     storage::StoragePlugin,
     texture::TexturePlugin,
@@ -589,10 +588,10 @@ fn apply_extract_commands(render_world: &mut World) {
     });
 }
 
-/// If the [`RenderAdapter`](crate::renderer::RenderAdapter) is a Qualcomm Adreno, returns its model number.
+/// If the [`RenderAdapterInfo`] is a Qualcomm Adreno, returns its model number.
 ///
 /// This lets us work around hardware bugs.
-pub fn get_adreno_model(adapter_info: &AdapterInfo) -> Option<u32> {
+pub fn get_adreno_model(adapter_info: &RenderAdapterInfo) -> Option<u32> {
     if !cfg!(target_os = "android") {
         return None;
     }
@@ -609,7 +608,7 @@ pub fn get_adreno_model(adapter_info: &AdapterInfo) -> Option<u32> {
 }
 
 /// Get the Mali driver version if the adapter is a Mali GPU.
-pub fn get_mali_driver_version(adapter_info: &AdapterInfo) -> Option<u32> {
+pub fn get_mali_driver_version(adapter_info: &RenderAdapterInfo) -> Option<u32> {
     if !cfg!(target_os = "android") {
         return None;
     }

--- a/crates/bevy_render/src/render_resource/bind_group_layout.rs
+++ b/crates/bevy_render/src/render_resource/bind_group_layout.rs
@@ -12,7 +12,7 @@ define_atomic_id!(BindGroupLayoutId);
 /// which can be cloned as needed to workaround lifetime management issues. It may be converted
 /// from and dereferences to wgpu's [`BindGroupLayout`](wgpu::BindGroupLayout).
 ///
-/// Can be created via [`RenderDevice::create_bind_group_layout`](crate::RenderDevice::create_bind_group_layout).
+/// Can be created via [`RenderDevice::create_bind_group_layout`](crate::renderer::RenderDevice::create_bind_group_layout).
 #[derive(Clone, Debug)]
 pub struct BindGroupLayout {
     id: BindGroupLayoutId,


### PR DESCRIPTION
# Objective

Fixes a crash when running with CPU rendered lavapipe, which could be fixed by manually setting
```rs
app.sub_app_mut(RenderApp).insert_resource(GpuPreprocessingSupport {
    max_supported_mode: GpuPreprocessingMode::None,
});
```

```rs
wgpu error: Validation Error

Caused by:
  In Device::create_compute_pipeline, label = 'downsample depth first phase pipeline'
    Internal error: WGSL `textureLoad` from depth textures is not supported in GLSL


Encountered a panic in system `bevy_render::render_resource::pipeline_cache::PipelineCache::process_pipeline_queue_system`
```

## Solution

Automatically disable gpu preprocessing when running with the GL backend.

## Testing

I ran the breakout example through `libTAS` which (among other things) forces software rendering.
Running breakout with just
```rs
        .add_plugins(DefaultPlugins.set(RenderPlugin {
            render_creation: bevy_render::settings::RenderCreation::Automatic(WgpuSettings {
                backends: Some(Backends::GL),
                ..default()
            }),
            ..default()
        }))
```
fails with `gpu_core::device::global: surface configuration failed: incompatible window kind` so gl isn't fully supported yet, but it's a step in the right direction.