### PR TITLE
enable same state transitions

### DIFF
--- a/crates/bevy_dev_tools/src/states.rs
+++ b/crates/bevy_dev_tools/src/states.rs
@@ -13,6 +13,13 @@ pub fn log_transitions<S: States>(mut transitions: EventReader<StateTransitionEv
         return;
     };
     let name = core::any::type_name::<S>();
-    let StateTransitionEvent { exited, entered } = transition;
-    info!("{} transition: {:?} => {:?}", name, exited, entered);
+    let StateTransitionEvent {
+        exited,
+        entered,
+        same_state_enforced,
+    } = transition;
+    info!(
+        "{} transition: {:?} => {:?} | same state enforced: {:?}",
+        name, exited, entered, same_state_enforced
+    );
 }

--- a/crates/bevy_state/src/app.rs
+++ b/crates/bevy_state/src/app.rs
@@ -109,6 +109,7 @@ impl AppExtStates for SubApp {
             self.world_mut().send_event(StateTransitionEvent {
                 exited: None,
                 entered: Some(state),
+                same_state_enforced: false,
             });
             if S::SCOPED_ENTITIES_ENABLED {
                 self.enable_state_scoped_entities::<S>();
@@ -134,6 +135,7 @@ impl AppExtStates for SubApp {
             self.world_mut().send_event(StateTransitionEvent {
                 exited: None,
                 entered: Some(state),
+                same_state_enforced: false,
             });
             if S::SCOPED_ENTITIES_ENABLED {
                 self.enable_state_scoped_entities::<S>();
@@ -147,6 +149,7 @@ impl AppExtStates for SubApp {
             self.world_mut().send_event(StateTransitionEvent {
                 exited: None,
                 entered: Some(state),
+                same_state_enforced: false,
             });
         }
 
@@ -171,6 +174,7 @@ impl AppExtStates for SubApp {
             self.world_mut().send_event(StateTransitionEvent {
                 exited: None,
                 entered: state,
+                same_state_enforced: false,
             });
             if S::SCOPED_ENTITIES_ENABLED {
                 self.enable_state_scoped_entities::<S>();
@@ -202,6 +206,7 @@ impl AppExtStates for SubApp {
             self.world_mut().send_event(StateTransitionEvent {
                 exited: None,
                 entered: state,
+                same_state_enforced: false,
             });
             if S::SCOPED_ENTITIES_ENABLED {
                 self.enable_state_scoped_entities::<S>();

--- a/crates/bevy_state/src/state/freely_mutable_state.rs
+++ b/crates/bevy_state/src/state/freely_mutable_state.rs
@@ -52,11 +52,17 @@ fn apply_state_transition<S: FreelyMutableState>(
     current_state: Option<ResMut<State<S>>>,
     next_state: Option<ResMut<NextState<S>>>,
 ) {
-    let Some(next_state) = take_next_state(next_state) else {
+    let Some((next_state, same_state_enforced)) = take_next_state(next_state) else {
         return;
     };
     let Some(current_state) = current_state else {
         return;
     };
-    internal_apply_state_transition(event, commands, Some(current_state), Some(next_state));
+    internal_apply_state_transition(
+        event,
+        commands,
+        Some(current_state),
+        Some(next_state),
+        same_state_enforced,
+    );
 }

--- a/crates/bevy_state/src/state/state_set.rs
+++ b/crates/bevy_state/src/state/state_set.rs
@@ -112,7 +112,7 @@ impl<S: InnerStateSet> StateSet for S {
                         None
                     };
 
-                internal_apply_state_transition(event, commands, current_state, new_state);
+                internal_apply_state_transition(event, commands, current_state, new_state, false);
             };
 
         schedule.configure_sets((
@@ -190,9 +190,26 @@ impl<S: InnerStateSet> StateSet for S {
                 } else {
                     current_state.clone()
                 };
-                let new_state = initial_state.map(|x| next_state.or(current_state).unwrap_or(x));
+                let same_state_enforced = next_state
+                    .as_ref()
+                    .map(|(_, same_state_enforced)| same_state_enforced)
+                    .cloned()
+                    .unwrap_or_default();
 
-                internal_apply_state_transition(event, commands, current_state_res, new_state);
+                let new_state = initial_state.map(|x| {
+                    next_state
+                        .map(|(next, _)| next)
+                        .or(current_state)
+                        .unwrap_or(x)
+                });
+
+                internal_apply_state_transition(
+                    event,
+                    commands,
+                    current_state_res,
+                    new_state,
+                    same_state_enforced,
+                );
             };
 
         schedule.configure_sets((
@@ -259,7 +276,7 @@ macro_rules! impl_state_set_sealed_tuples {
                             None
                         };
 
-                        internal_apply_state_transition(event, commands, current_state, new_state);
+                        internal_apply_state_transition(event, commands, current_state, new_state, false);
                     };
 
                 schedule.configure_sets((
@@ -311,9 +328,21 @@ macro_rules! impl_state_set_sealed_tuples {
                         } else {
                             current_state.clone()
                         };
-                        let new_state = initial_state.map(|x| next_state.or(current_state).unwrap_or(x));
 
-                        internal_apply_state_transition(event, commands, current_state_res, new_state);
+                        let same_state_enforced = next_state
+                            .as_ref()
+                            .map(|(_, same_state_enforced)| same_state_enforced)
+                            .cloned()
+                            .unwrap_or_default();
+
+                        let new_state = initial_state.map(|x| {
+                            next_state
+                                .map(|(next, _)| next)
+                                .or(current_state)
+                                .unwrap_or(x)
+                        });
+
+                        internal_apply_state_transition(event, commands, current_state_res, new_state, same_state_enforced);
                     };
 
                 schedule.configure_sets((


### PR DESCRIPTION
# Objective

- Same state transitions have their uses but are not currently possible

## Solution

- Add a `set_forced` method on `NextState` that will trigger `OnEnter` and `OnExit`
