### PR TITLE
Remove Shader weak_handles from bevy_pbr meshlets (with one exception).

### DIFF
--- a/crates/bevy_pbr/src/meshlet/material_pipeline_prepare.rs
+++ b/crates/bevy_pbr/src/meshlet/material_pipeline_prepare.rs
@@ -183,6 +183,9 @@ pub fn prepare_material_meshlet_meshes_main_opaque_pass<M: Material>(
             let mut shader_defs = material_fragment.shader_defs;
             shader_defs.push("MESHLET_MESH_MATERIAL_PASS".into());
 
+            let default_shader =
+                load_embedded_asset!(asset_server.as_ref(), "meshlet_mesh_material.wgsl");
+
             let pipeline_descriptor = RenderPipelineDescriptor {
                 label: material_pipeline_descriptor.label,
                 layout: vec![
@@ -192,10 +195,7 @@ pub fn prepare_material_meshlet_meshes_main_opaque_pass<M: Material>(
                 ],
                 push_constant_ranges: vec![],
                 vertex: VertexState {
-                    shader: load_embedded_asset!(
-                        asset_server.as_ref(),
-                        "meshlet_mesh_material.wgsl"
-                    ),
+                    shader: default_shader.clone(),
                     shader_defs: shader_defs.clone(),
                     entry_point: material_pipeline_descriptor.vertex.entry_point,
                     buffers: Vec::new(),
@@ -211,12 +211,7 @@ pub fn prepare_material_meshlet_meshes_main_opaque_pass<M: Material>(
                 multisample: MultisampleState::default(),
                 fragment: Some(FragmentState {
                     shader: match M::meshlet_mesh_fragment_shader() {
-                        ShaderRef::Default => {
-                            load_embedded_asset!(
-                                asset_server.as_ref(),
-                                "meshlet_mesh_material.wgsl"
-                            )
-                        }
+                        ShaderRef::Default => default_shader,
                         ShaderRef::Handle(handle) => handle,
                         ShaderRef::Path(path) => asset_server.load(path),
                     },

--- a/crates/bevy_pbr/src/meshlet/material_pipeline_prepare.rs
+++ b/crates/bevy_pbr/src/meshlet/material_pipeline_prepare.rs
@@ -1,12 +1,9 @@
-use super::{
-    instance_manager::InstanceManager, resource_manager::ResourceManager,
-    MESHLET_MESH_MATERIAL_SHADER_HANDLE,
-};
+use super::{instance_manager::InstanceManager, resource_manager::ResourceManager};
 use crate::{
     environment_map::EnvironmentMapLight, irradiance_volume::IrradianceVolume,
     material_bind_groups::MaterialBindGroupAllocator, *,
 };
-use bevy_asset::AssetServer;
+use bevy_asset::{load_embedded_asset, AssetServer};
 use bevy_core_pipeline::{
     core_3d::Camera3d,
     prepass::{DeferredPrepass, DepthPrepass, MotionVectorPrepass, NormalPrepass},
@@ -195,7 +192,10 @@ pub fn prepare_material_meshlet_meshes_main_opaque_pass<M: Material>(
                 ],
                 push_constant_ranges: vec![],
                 vertex: VertexState {
-                    shader: MESHLET_MESH_MATERIAL_SHADER_HANDLE,
+                    shader: load_embedded_asset!(
+                        asset_server.as_ref(),
+                        "meshlet_mesh_material.wgsl"
+                    ),
                     shader_defs: shader_defs.clone(),
                     entry_point: material_pipeline_descriptor.vertex.entry_point,
                     buffers: Vec::new(),
@@ -211,7 +211,12 @@ pub fn prepare_material_meshlet_meshes_main_opaque_pass<M: Material>(
                 multisample: MultisampleState::default(),
                 fragment: Some(FragmentState {
                     shader: match M::meshlet_mesh_fragment_shader() {
-                        ShaderRef::Default => MESHLET_MESH_MATERIAL_SHADER_HANDLE,
+                        ShaderRef::Default => {
+                            load_embedded_asset!(
+                                asset_server.as_ref(),
+                                "meshlet_mesh_material.wgsl"
+                            )
+                        }
                         ShaderRef::Handle(handle) => handle,
                         ShaderRef::Path(path) => asset_server.load(path),
                     },
@@ -374,7 +379,10 @@ pub fn prepare_material_meshlet_meshes_prepass<M: Material>(
                 ],
                 push_constant_ranges: vec![],
                 vertex: VertexState {
-                    shader: MESHLET_MESH_MATERIAL_SHADER_HANDLE,
+                    shader: load_embedded_asset!(
+                        asset_server.as_ref(),
+                        "meshlet_mesh_material.wgsl"
+                    ),
                     shader_defs: shader_defs.clone(),
                     entry_point: material_pipeline_descriptor.vertex.entry_point,
                     buffers: Vec::new(),
@@ -390,7 +398,12 @@ pub fn prepare_material_meshlet_meshes_prepass<M: Material>(
                 multisample: MultisampleState::default(),
                 fragment: Some(FragmentState {
                     shader: match fragment_shader {
-                        ShaderRef::Default => MESHLET_MESH_MATERIAL_SHADER_HANDLE,
+                        ShaderRef::Default => {
+                            load_embedded_asset!(
+                                asset_server.as_ref(),
+                                "meshlet_mesh_material.wgsl"
+                            )
+                        }
                         ShaderRef::Handle(handle) => handle,
                         ShaderRef::Path(path) => asset_server.load(path),
                     },

--- a/crates/bevy_pbr/src/meshlet/mod.rs
+++ b/crates/bevy_pbr/src/meshlet/mod.rs
@@ -58,7 +58,7 @@ use self::{
 };
 use crate::{graph::NodePbr, PreviousGlobalTransform};
 use bevy_app::{App, Plugin};
-use bevy_asset::{load_internal_asset, weak_handle, AssetApp, AssetId, Handle};
+use bevy_asset::{embedded_asset, load_internal_asset, AssetApp, AssetId, Handle};
 use bevy_core_pipeline::{
     core_3d::graph::{Core3d, Node3d},
     prepass::{DeferredPrepass, MotionVectorPrepass, NormalPrepass},
@@ -74,6 +74,7 @@ use bevy_ecs::{
 };
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{
+    load_shader_library,
     render_graph::{RenderGraphApp, ViewNodeRunner},
     render_resource::Shader,
     renderer::RenderDevice,
@@ -84,11 +85,6 @@ use bevy_render::{
 use bevy_transform::components::Transform;
 use derive_more::From;
 use tracing::error;
-
-const MESHLET_BINDINGS_SHADER_HANDLE: Handle<Shader> =
-    weak_handle!("d90ac78c-500f-48aa-b488-cc98eb3f6314");
-const MESHLET_MESH_MATERIAL_SHADER_HANDLE: Handle<Shader> =
-    weak_handle!("db8d9001-6ca7-4d00-968a-d5f5b96b89c3");
 
 /// Provides a plugin for rendering large amounts of high-poly 3d meshes using an efficient GPU-driven method. See also [`MeshletMesh`].
 ///
@@ -152,66 +148,22 @@ impl Plugin for MeshletPlugin {
             std::process::exit(1);
         }
 
-        load_internal_asset!(
-            app,
-            MESHLET_CLEAR_VISIBILITY_BUFFER_SHADER_HANDLE,
-            "clear_visibility_buffer.wgsl",
-            Shader::from_wgsl
-        );
-        load_internal_asset!(
-            app,
-            MESHLET_BINDINGS_SHADER_HANDLE,
-            "meshlet_bindings.wgsl",
-            Shader::from_wgsl
-        );
+        load_shader_library!(app, "meshlet_bindings.wgsl");
         load_internal_asset!(
             app,
             super::MESHLET_VISIBILITY_BUFFER_RESOLVE_SHADER_HANDLE,
             "visibility_buffer_resolve.wgsl",
             Shader::from_wgsl
         );
-        load_internal_asset!(
-            app,
-            MESHLET_FILL_CLUSTER_BUFFERS_SHADER_HANDLE,
-            "fill_cluster_buffers.wgsl",
-            Shader::from_wgsl
-        );
-        load_internal_asset!(
-            app,
-            MESHLET_CULLING_SHADER_HANDLE,
-            "cull_clusters.wgsl",
-            Shader::from_wgsl
-        );
-        load_internal_asset!(
-            app,
-            MESHLET_VISIBILITY_BUFFER_SOFTWARE_RASTER_SHADER_HANDLE,
-            "visibility_buffer_software_raster.wgsl",
-            Shader::from_wgsl
-        );
-        load_internal_asset!(
-            app,
-            MESHLET_VISIBILITY_BUFFER_HARDWARE_RASTER_SHADER_HANDLE,
-            "visibility_buffer_hardware_raster.wgsl",
-            Shader::from_wgsl
-        );
-        load_internal_asset!(
-            app,
-            MESHLET_MESH_MATERIAL_SHADER_HANDLE,
-            "meshlet_mesh_material.wgsl",
-            Shader::from_wgsl
-        );
-        load_internal_asset!(
-            app,
-            MESHLET_RESOLVE_RENDER_TARGETS_SHADER_HANDLE,
-            "resolve_render_targets.wgsl",
-            Shader::from_wgsl
-        );
-        load_internal_asset!(
-            app,
-            MESHLET_REMAP_1D_TO_2D_DISPATCH_SHADER_HANDLE,
-            "remap_1d_to_2d_dispatch.wgsl",
-            Shader::from_wgsl
-        );
+
+        embedded_asset!(app, "clear_visibility_buffer.wgsl");
+        embedded_asset!(app, "fill_cluster_buffers.wgsl");
+        embedded_asset!(app, "cull_clusters.wgsl");
+        embedded_asset!(app, "visibility_buffer_software_raster.wgsl");
+        embedded_asset!(app, "visibility_buffer_hardware_raster.wgsl");
+        embedded_asset!(app, "meshlet_mesh_material.wgsl");
+        embedded_asset!(app, "resolve_render_targets.wgsl");
+        embedded_asset!(app, "remap_1d_to_2d_dispatch.wgsl");
 
         app.init_asset::<MeshletMesh>()
             .register_asset_loader(MeshletMeshLoader);


### PR DESCRIPTION
# Objective

- Related to #19024

## Solution

- Use the new `load_shader_library` macro for the shader libraries and `embedded_asset`/`load_embedded_asset` for the "shader binaries" in `bevy_pbr` meshlets.

The last piece that I haven't handled here is `MESHLET_VISIBILITY_BUFFER_RESOLVE_SHADER_HANDLE`. This is in an awkward situation that prevents us from using the standard solutions I've been using thus far. Essentially, a shader with this import path needs to be present, but we also need to be able to replace it if meshlets really are loaded. Embedded assets don't really play nicely with that, so we will need to figure out a solution there (or maybe wait for WESL to hopefully resolve this situation).

## Testing

- `meshlet` example still works.

P.S. I don't think this needs a migration guide. Technically users could be using the `pub` weak handles, but there's no actual good use for them, so omitting it seems fine. Alternatively, we could mix this in with the migration guide notes for #19137.