### PR TITLE
ecs systems type_id renamed to system_type

### DIFF
--- a/crates/bevy_ecs/src/schedule/executor/mod.rs
+++ b/crates/bevy_ecs/src/schedule/executor/mod.rs
@@ -152,7 +152,7 @@ pub struct ApplyDeferred;
 
 /// Returns `true` if the [`System`] is an instance of [`ApplyDeferred`].
 pub(super) fn is_apply_deferred(system: &ScheduleSystem) -> bool {
-    system.type_id() == TypeId::of::<ApplyDeferred>()
+    system.system_type() == TypeId::of::<ApplyDeferred>()
 }
 
 impl System for ApplyDeferred {

--- a/crates/bevy_ecs/src/schedule/stepping.rs
+++ b/crates/bevy_ecs/src/schedule/stepping.rs
@@ -666,7 +666,7 @@ impl ScheduleState {
         // PERF: If we add a way to efficiently query schedule systems by their TypeId, we could remove the full
         // system scan here
         for (node_id, system) in schedule.systems().unwrap() {
-            let behavior = self.behavior_updates.get(&system.type_id());
+            let behavior = self.behavior_updates.get(&system.system_type());
             match behavior {
                 None => continue,
                 Some(None) => {

--- a/crates/bevy_ecs/src/schedule/stepping.rs
+++ b/crates/bevy_ecs/src/schedule/stepping.rs
@@ -246,7 +246,7 @@ impl Stepping {
         schedule: impl ScheduleLabel,
         system: impl IntoSystem<(), (), Marker>,
     ) -> &mut Self {
-        let type_id = system.system_type_id();
+        let type_id = system.system_system_type();
         self.updates.push(Update::SetBehavior(
             schedule.intern(),
             SystemIdentifier::Type(type_id),
@@ -272,7 +272,7 @@ impl Stepping {
         schedule: impl ScheduleLabel,
         system: impl IntoSystem<(), (), Marker>,
     ) -> &mut Self {
-        let type_id = system.system_type_id();
+        let type_id = system.system_system_type();
         self.updates.push(Update::SetBehavior(
             schedule.intern(),
             SystemIdentifier::Type(type_id),
@@ -298,7 +298,7 @@ impl Stepping {
         schedule: impl ScheduleLabel,
         system: impl IntoSystem<(), (), Marker>,
     ) -> &mut Self {
-        let type_id = system.system_type_id();
+        let type_id = system.system_system_type();
         self.updates.push(Update::SetBehavior(
             schedule.intern(),
             SystemIdentifier::Type(type_id),
@@ -345,7 +345,7 @@ impl Stepping {
         schedule: impl ScheduleLabel,
         system: impl IntoSystem<(), (), Marker>,
     ) -> &mut Self {
-        let type_id = system.system_type_id();
+        let type_id = system.system_system_type();
         self.updates.push(Update::ClearBehavior(
             schedule.intern(),
             SystemIdentifier::Type(type_id),

--- a/crates/bevy_ecs/src/schedule/stepping.rs
+++ b/crates/bevy_ecs/src/schedule/stepping.rs
@@ -900,7 +900,7 @@ mod tests {
             // system TypeId, and name.
             let systems: Vec<(TypeId, alloc::borrow::Cow<'static, str>)> = $schedule.systems().unwrap()
                 .map(|(_, system)| {
-                    (system.type_id(), system.name())
+                    (system.system_type(), system.name())
                 })
             .collect();
 
@@ -909,7 +909,7 @@ mod tests {
             $(
                 let sys = IntoSystem::into_system($system);
                 for (i, (type_id, _)) in systems.iter().enumerate() {
-                    if sys.type_id() == *type_id {
+                    if sys.system_type() == *type_id {
                         expected.insert(i);
                     }
                 }

--- a/crates/bevy_ecs/src/system/exclusive_function_system.rs
+++ b/crates/bevy_ecs/src/system/exclusive_function_system.rs
@@ -326,20 +326,20 @@ mod tests {
             let system = IntoSystem::into_system(function);
 
             assert_eq!(
-                system.type_id(),
-                function.system_type_id(),
-                "System::type_id should be consistent with IntoSystem::system_type_id"
+                system.system_type(),
+                function.system_system_type(),
+                "System::system_type should be consistent with IntoSystem::system_system_type"
             );
 
             assert_eq!(
-                system.type_id(),
+                system.system_type(),
                 TypeId::of::<T::System>(),
-                "System::type_id should be consistent with TypeId::of::<T::System>()"
+                "System::system_type should be consistent with TypeId::of::<T::System>()"
             );
 
             assert_ne!(
-                system.type_id(),
-                IntoSystem::into_system(reference_system).type_id(),
+                system.system_type(),
+                IntoSystem::into_system(reference_system).system_type(),
                 "Different systems should have different TypeIds"
             );
         }

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -1000,7 +1000,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn into_system_type_id_consistency() {
+    fn into_system_system_type_consistency() {
         fn test<T, In: SystemInput, Out, Marker>(function: T)
         where
             T: IntoSystem<In, Out, Marker> + Copy,
@@ -1012,20 +1012,20 @@ mod tests {
             let system = IntoSystem::into_system(function);
 
             assert_eq!(
-                system.type_id(),
-                function.system_type_id(),
-                "System::type_id should be consistent with IntoSystem::system_type_id"
+                system.system_type(),
+                function.system_system_type(),
+                "System::system_type should be consistent with IntoSystem::system_system_type"
             );
 
             assert_eq!(
-                system.type_id(),
+                system.system_type(),
                 TypeId::of::<T::System>(),
-                "System::type_id should be consistent with TypeId::of::<T::System>()"
+                "System::system_type should be consistent with TypeId::of::<T::System>()"
             );
 
             assert_ne!(
-                system.type_id(),
-                IntoSystem::into_system(reference_system).type_id(),
+                system.system_type(),
+                IntoSystem::into_system(reference_system).system_type(),
                 "Different systems should have different TypeIds"
             );
         }

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -301,7 +301,7 @@ pub trait IntoSystem<In: SystemInput, Out, Marker>: Sized {
 
     /// Get the [`TypeId`] of the [`System`] produced after calling [`into_system`](`IntoSystem::into_system`).
     #[inline]
-    fn system_type_id(&self) -> TypeId {
+    fn system_system_type(&self) -> TypeId {
         TypeId::of::<Self::System>()
     }
 }

--- a/crates/bevy_ecs/src/system/schedule_system.rs
+++ b/crates/bevy_ecs/src/system/schedule_system.rs
@@ -30,8 +30,8 @@ impl<S: System<In = ()>> System for InfallibleSystemWrapper<S> {
         self.0.name()
     }
 
-    fn type_id(&self) -> core::any::TypeId {
-        self.0.type_id()
+    fn system_type(&self) -> core::any::TypeId {
+        self.0.system_type()
     }
 
     #[inline]

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -41,7 +41,7 @@ pub trait System: Send + Sync + 'static {
     fn name(&self) -> Cow<'static, str>;
     /// Returns the [`TypeId`] of the underlying system type.
     #[inline]
-    fn type_id(&self) -> TypeId {
+    fn system_type(&self) -> TypeId {
         TypeId::of::<Self>()
     }
 

--- a/release-content/migration-guides/system-type_id-renamed-system_type.md
+++ b/release-content/migration-guides/system-type_id-renamed-system_type.md
@@ -1,0 +1,8 @@
+---
+title: ECS System type_id method renamed to system_type
+pull_requests: [19374]
+---
+
+`type_id` method on `System` trait is now `system_type`. Replace all references.
+
+This change was made so that the method names are in line with `SystemSet`.


### PR DESCRIPTION
# Objective
Fixes #19372

## Migration Guide

Users will need to use system_type() to get the type_id on ecs systems instead of type_id().