### PR TITLE
Fixed broken link in release content README.

### DIFF
--- a/release-content/README.md
+++ b/release-content/README.md
@@ -1,3 +1,3 @@
 # Release Content
 
-This directory contains drafts of documentation for the current development cycle, which will be published to the website during the next release. You can find more information in the [release notes](./release_notes.md) and [migration guide](./migration_guide.md) files.
+This directory contains drafts of documentation for the current development cycle, which will be published to the website during the next release. You can find more information in the [release notes](./release_notes.md) and [migration guide](./migration_guides.md) files.

--- a/release-content/README.md
+++ b/release-content/README.md
@@ -1,3 +1,3 @@
 # Release Content
 
-This directory contains drafts of documentation for the current development cycle, which will be published to the website during the next release. You can find more information in the [release notes](./release_notes.md) and [migration guide](./migration_guides.md) files.
+This directory contains drafts of documentation for the current development cycle, which will be published to the website during the next release. You can find more information in the [release notes](./release_notes.md) and [migration guides](./migration_guides.md) files.


### PR DESCRIPTION
The link went to a 404 page because it was missing an 's'.