### PR TITLE
Return Result from image::resize

### DIFF
--- a/crates/bevy_ui/src/widget/viewport.rs
+++ b/crates/bevy_ui/src/widget/viewport.rs
@@ -173,7 +173,7 @@ pub fn update_viewport_render_target_size(
         };
         let image = images.get_mut(image_handle).unwrap();
         if image.data.is_some() {
-            image.resize(size);
+            let _ = image.resize(size);
         } else {
             image.texture_descriptor.size = size;
         }

--- a/examples/2d/pixel_grid_snap.rs
+++ b/examples/2d/pixel_grid_snap.rs
@@ -108,7 +108,7 @@ fn setup_camera(mut commands: Commands, mut images: ResMut<Assets<Image>>) {
     };
 
     // Fill image.data with zeroes
-    canvas.resize(canvas_size);
+    let _ = canvas.resize(canvas_size);
 
     let image_handle = images.add(canvas);
 


### PR DESCRIPTION
# Objective
Return a Result when resizing an image so that we can return an Err when image.data is None.

Fixes #19376 

