### PR TITLE
Remove Shader weak_handles from bevy_anti_aliasing.

### DIFF
--- a/crates/bevy_anti_aliasing/src/contrast_adaptive_sharpening/mod.rs
+++ b/crates/bevy_anti_aliasing/src/contrast_adaptive_sharpening/mod.rs
@@ -1,5 +1,5 @@
 use bevy_app::prelude::*;
-use bevy_asset::{load_internal_asset, weak_handle, Handle};
+use bevy_asset::{embedded_asset, load_embedded_asset, Handle};
 use bevy_core_pipeline::{
     core_2d::graph::{Core2d, Node2d},
     core_3d::graph::{Core3d, Node3d},
@@ -95,20 +95,12 @@ impl ExtractComponent for ContrastAdaptiveSharpening {
     }
 }
 
-const CONTRAST_ADAPTIVE_SHARPENING_SHADER_HANDLE: Handle<Shader> =
-    weak_handle!("ef83f0a5-51df-4b51-9ab7-b5fd1ae5a397");
-
 /// Adds Support for Contrast Adaptive Sharpening (CAS).
 pub struct CasPlugin;
 
 impl Plugin for CasPlugin {
     fn build(&self, app: &mut App) {
-        load_internal_asset!(
-            app,
-            CONTRAST_ADAPTIVE_SHARPENING_SHADER_HANDLE,
-            "robust_contrast_adaptive_sharpening.wgsl",
-            Shader::from_wgsl
-        );
+        embedded_asset!(app, "robust_contrast_adaptive_sharpening.wgsl");
 
         app.register_type::<ContrastAdaptiveSharpening>();
         app.add_plugins((
@@ -171,6 +163,7 @@ impl Plugin for CasPlugin {
 pub struct CasPipeline {
     texture_bind_group: BindGroupLayout,
     sampler: Sampler,
+    shader: Handle<Shader>,
 }
 
 impl FromWorld for CasPipeline {
@@ -194,6 +187,7 @@ impl FromWorld for CasPipeline {
         CasPipeline {
             texture_bind_group,
             sampler,
+            shader: load_embedded_asset!(render_world, "robust_contrast_adaptive_sharpening.wgsl"),
         }
     }
 }
@@ -217,7 +211,7 @@ impl SpecializedRenderPipeline for CasPipeline {
             layout: vec![self.texture_bind_group.clone()],
             vertex: fullscreen_shader_vertex_state(),
             fragment: Some(FragmentState {
-                shader: CONTRAST_ADAPTIVE_SHARPENING_SHADER_HANDLE,
+                shader: self.shader.clone(),
                 shader_defs,
                 entry_point: "fragment".into(),
                 targets: vec![Some(ColorTargetState {

--- a/crates/bevy_anti_aliasing/src/fxaa/mod.rs
+++ b/crates/bevy_anti_aliasing/src/fxaa/mod.rs
@@ -1,5 +1,5 @@
 use bevy_app::prelude::*;
-use bevy_asset::{load_internal_asset, weak_handle, Handle};
+use bevy_asset::{embedded_asset, load_embedded_asset, Handle};
 use bevy_core_pipeline::{
     core_2d::graph::{Core2d, Node2d},
     core_3d::graph::{Core3d, Node3d},
@@ -80,13 +80,11 @@ impl Default for Fxaa {
     }
 }
 
-const FXAA_SHADER_HANDLE: Handle<Shader> = weak_handle!("fc58c0a8-01c0-46e9-94cc-83a794bae7b0");
-
 /// Adds support for Fast Approximate Anti-Aliasing (FXAA)
 pub struct FxaaPlugin;
 impl Plugin for FxaaPlugin {
     fn build(&self, app: &mut App) {
-        load_internal_asset!(app, FXAA_SHADER_HANDLE, "fxaa.wgsl", Shader::from_wgsl);
+        embedded_asset!(app, "fxaa.wgsl");
 
         app.register_type::<Fxaa>();
         app.add_plugins(ExtractComponentPlugin::<Fxaa>::default());
@@ -132,6 +130,7 @@ impl Plugin for FxaaPlugin {
 pub struct FxaaPipeline {
     texture_bind_group: BindGroupLayout,
     sampler: Sampler,
+    shader: Handle<Shader>,
 }
 
 impl FromWorld for FxaaPipeline {
@@ -158,6 +157,7 @@ impl FromWorld for FxaaPipeline {
         FxaaPipeline {
             texture_bind_group,
             sampler,
+            shader: load_embedded_asset!(render_world, "fxaa.wgsl"),
         }
     }
 }
@@ -183,7 +183,7 @@ impl SpecializedRenderPipeline for FxaaPipeline {
             layout: vec![self.texture_bind_group.clone()],
             vertex: fullscreen_shader_vertex_state(),
             fragment: Some(FragmentState {
-                shader: FXAA_SHADER_HANDLE,
+                shader: self.shader.clone(),
                 shader_defs: vec![
                     format!("EDGE_THRESH_{}", key.edge_threshold.get_str()).into(),
                     format!("EDGE_THRESH_MIN_{}", key.edge_threshold_min.get_str()).into(),

--- a/crates/bevy_anti_aliasing/src/smaa/mod.rs
+++ b/crates/bevy_anti_aliasing/src/smaa/mod.rs
@@ -32,7 +32,7 @@
 use bevy_app::{App, Plugin};
 #[cfg(feature = "smaa_luts")]
 use bevy_asset::load_internal_binary_asset;
-use bevy_asset::{load_internal_asset, weak_handle, Handle};
+use bevy_asset::{embedded_asset, load_embedded_asset, weak_handle, Handle};
 #[cfg(not(feature = "smaa_luts"))]
 use bevy_core_pipeline::tonemapping::lut_placeholder;
 use bevy_core_pipeline::{
@@ -80,8 +80,6 @@ use bevy_render::{
 };
 use bevy_utils::prelude::default;
 
-/// The handle of the `smaa.wgsl` shader.
-const SMAA_SHADER_HANDLE: Handle<Shader> = weak_handle!("fdd9839f-1ab4-4e0d-88a0-240b67da2ddf");
 /// The handle of the area LUT, a KTX2 format texture that SMAA uses internally.
 const SMAA_AREA_LUT_TEXTURE_HANDLE: Handle<Image> =
     weak_handle!("569c4d67-c7fa-4958-b1af-0836023603c0");
@@ -147,6 +145,8 @@ struct SmaaEdgeDetectionPipeline {
     postprocess_bind_group_layout: BindGroupLayout,
     /// The bind group layout for data specific to this pass.
     edge_detection_bind_group_layout: BindGroupLayout,
+    /// The shader asset handle.
+    shader: Handle<Shader>,
 }
 
 /// The pipeline data for phase 2 of SMAA: blending weight calculation.
@@ -155,6 +155,8 @@ struct SmaaBlendingWeightCalculationPipeline {
     postprocess_bind_group_layout: BindGroupLayout,
     /// The bind group layout for data specific to this pass.
     blending_weight_calculation_bind_group_layout: BindGroupLayout,
+    /// The shader asset handle.
+    shader: Handle<Shader>,
 }
 
 /// The pipeline data for phase 3 of SMAA: neighborhood blending.
@@ -163,6 +165,8 @@ struct SmaaNeighborhoodBlendingPipeline {
     postprocess_bind_group_layout: BindGroupLayout,
     /// The bind group layout for data specific to this pass.
     neighborhood_blending_bind_group_layout: BindGroupLayout,
+    /// The shader asset handle.
+    shader: Handle<Shader>,
 }
 
 /// A unique identifier for a set of SMAA pipelines.
@@ -287,7 +291,7 @@ pub struct SmaaSpecializedRenderPipelines {
 impl Plugin for SmaaPlugin {
     fn build(&self, app: &mut App) {
         // Load the shader.
-        load_internal_asset!(app, SMAA_SHADER_HANDLE, "smaa.wgsl", Shader::from_wgsl);
+        embedded_asset!(app, "smaa.wgsl");
 
         // Load the two lookup textures. These are compressed textures in KTX2
         // format.
@@ -431,18 +435,23 @@ impl FromWorld for SmaaPipelines {
             ),
         );
 
+        let shader = load_embedded_asset!(world, "smaa.wgsl");
+
         SmaaPipelines {
             edge_detection: SmaaEdgeDetectionPipeline {
                 postprocess_bind_group_layout: postprocess_bind_group_layout.clone(),
                 edge_detection_bind_group_layout,
+                shader: shader.clone(),
             },
             blending_weight_calculation: SmaaBlendingWeightCalculationPipeline {
                 postprocess_bind_group_layout: postprocess_bind_group_layout.clone(),
                 blending_weight_calculation_bind_group_layout,
+                shader: shader.clone(),
             },
             neighborhood_blending: SmaaNeighborhoodBlendingPipeline {
                 postprocess_bind_group_layout,
                 neighborhood_blending_bind_group_layout,
+                shader,
             },
         }
     }
@@ -472,13 +481,13 @@ impl SpecializedRenderPipeline for SmaaEdgeDetectionPipeline {
                 self.edge_detection_bind_group_layout.clone(),
             ],
             vertex: VertexState {
-                shader: SMAA_SHADER_HANDLE,
+                shader: self.shader.clone(),
                 shader_defs: shader_defs.clone(),
                 entry_point: "edge_detection_vertex_main".into(),
                 buffers: vec![],
             },
             fragment: Some(FragmentState {
-                shader: SMAA_SHADER_HANDLE,
+                shader: self.shader.clone(),
                 shader_defs,
                 entry_point: "luma_edge_detection_fragment_main".into(),
                 targets: vec![Some(ColorTargetState {
@@ -532,13 +541,13 @@ impl SpecializedRenderPipeline for SmaaBlendingWeightCalculationPipeline {
                 self.blending_weight_calculation_bind_group_layout.clone(),
             ],
             vertex: VertexState {
-                shader: SMAA_SHADER_HANDLE,
+                shader: self.shader.clone(),
                 shader_defs: shader_defs.clone(),
                 entry_point: "blending_weight_calculation_vertex_main".into(),
                 buffers: vec![],
             },
             fragment: Some(FragmentState {
-                shader: SMAA_SHADER_HANDLE,
+                shader: self.shader.clone(),
                 shader_defs,
                 entry_point: "blending_weight_calculation_fragment_main".into(),
                 targets: vec![Some(ColorTargetState {
@@ -580,13 +589,13 @@ impl SpecializedRenderPipeline for SmaaNeighborhoodBlendingPipeline {
                 self.neighborhood_blending_bind_group_layout.clone(),
             ],
             vertex: VertexState {
-                shader: SMAA_SHADER_HANDLE,
+                shader: self.shader.clone(),
                 shader_defs: shader_defs.clone(),
                 entry_point: "neighborhood_blending_vertex_main".into(),
                 buffers: vec![],
             },
             fragment: Some(FragmentState {
-                shader: SMAA_SHADER_HANDLE,
+                shader: self.shader.clone(),
                 shader_defs,
                 entry_point: "neighborhood_blending_fragment_main".into(),
                 targets: vec![Some(ColorTargetState {

--- a/crates/bevy_anti_aliasing/src/taa/mod.rs
+++ b/crates/bevy_anti_aliasing/src/taa/mod.rs
@@ -1,5 +1,5 @@
 use bevy_app::{App, Plugin};
-use bevy_asset::{load_internal_asset, weak_handle, Handle};
+use bevy_asset::{embedded_asset, load_embedded_asset, Handle};
 use bevy_core_pipeline::{
     core_3d::graph::{Core3d, Node3d},
     fullscreen_vertex_shader::fullscreen_shader_vertex_state,
@@ -40,8 +40,6 @@ use bevy_render::{
 };
 use tracing::warn;
 
-const TAA_SHADER_HANDLE: Handle<Shader> = weak_handle!("fea20d50-86b6-4069-aa32-374346aec00c");
-
 /// Plugin for temporal anti-aliasing.
 ///
 /// See [`TemporalAntiAliasing`] for more details.
@@ -49,7 +47,7 @@ pub struct TemporalAntiAliasPlugin;
 
 impl Plugin for TemporalAntiAliasPlugin {
     fn build(&self, app: &mut App) {
-        load_internal_asset!(app, TAA_SHADER_HANDLE, "taa.wgsl", Shader::from_wgsl);
+        embedded_asset!(app, "taa.wgsl");
 
         app.register_type::<TemporalAntiAliasing>();
 
@@ -243,6 +241,7 @@ struct TaaPipeline {
     taa_bind_group_layout: BindGroupLayout,
     nearest_sampler: Sampler,
     linear_sampler: Sampler,
+    shader: Handle<Shader>,
 }
 
 impl FromWorld for TaaPipeline {
@@ -287,6 +286,7 @@ impl FromWorld for TaaPipeline {
             taa_bind_group_layout,
             nearest_sampler,
             linear_sampler,
+            shader: load_embedded_asset!(world, "taa.wgsl"),
         }
     }
 }
@@ -319,7 +319,7 @@ impl SpecializedRenderPipeline for TaaPipeline {
             layout: vec![self.taa_bind_group_layout.clone()],
             vertex: fullscreen_shader_vertex_state(),
             fragment: Some(FragmentState {
-                shader: TAA_SHADER_HANDLE,
+                shader: self.shader.clone(),
                 shader_defs,
                 entry_point: "taa".into(),
                 targets: vec![


### PR DESCRIPTION
# Objective

- Related to #19024

## Solution

- Use the new `load_shader_library` macro for the shader libraries and `embedded_asset`/`load_embedded_asset` for the "shader binaries" in `bevy_anti_aliasing`.

## Testing

- `anti_aliasing` example still works.

P.S. I don't think this needs a migration guide. Technically users could be using the `pub` weak handles, but there's no actual good use for them, so omitting it seems fine. Alternatively, we could mix this in with the migration guide notes for #19137.