### PR TITLE
Remove Shader weak_handles from bevy_ui.

### DIFF
--- a/crates/bevy_ui/src/render/gradient.rs
+++ b/crates/bevy_ui/src/render/gradient.rs
@@ -34,19 +34,11 @@ use bytemuck::{Pod, Zeroable};
 
 use super::shader_flags::BORDER_ALL;
 
-pub const UI_GRADIENT_SHADER_HANDLE: Handle<Shader> =
-    weak_handle!("10116113-aac4-47fa-91c8-35cbe80dddcb");
-
 pub struct GradientPlugin;
 
 impl Plugin for GradientPlugin {
     fn build(&self, app: &mut App) {
-        load_internal_asset!(
-            app,
-            UI_GRADIENT_SHADER_HANDLE,
-            "gradient.wgsl",
-            Shader::from_wgsl
-        );
+        embedded_asset!(app, "gradient.wgsl");
 
         if let Some(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app
@@ -103,6 +95,7 @@ impl Default for GradientMeta {
 #[derive(Resource)]
 pub struct GradientPipeline {
     pub view_layout: BindGroupLayout,
+    pub shader: Handle<Shader>,
 }
 
 impl FromWorld for GradientPipeline {
@@ -117,7 +110,10 @@ impl FromWorld for GradientPipeline {
             ),
         );
 
-        GradientPipeline { view_layout }
+        GradientPipeline {
+            view_layout,
+            shader: load_embedded_asset!(world, "gradient.wgsl"),
+        }
     }
 }
 
@@ -192,13 +188,13 @@ impl SpecializedRenderPipeline for GradientPipeline {
 
         RenderPipelineDescriptor {
             vertex: VertexState {
-                shader: UI_GRADIENT_SHADER_HANDLE,
+                shader: self.shader.clone(),
                 entry_point: "vertex".into(),
                 shader_defs: shader_defs.clone(),
                 buffers: vec![vertex_layout],
             },
             fragment: Some(FragmentState {
-                shader: UI_GRADIENT_SHADER_HANDLE,
+                shader: self.shader.clone(),
                 shader_defs,
                 entry_point: "fragment".into(),
                 targets: vec![Some(ColorTargetState {

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -14,7 +14,7 @@ use crate::{
     ComputedNodeTarget, Outline, ResolvedBorderRadius, TextShadow, UiAntiAlias,
 };
 use bevy_app::prelude::*;
-use bevy_asset::{load_internal_asset, weak_handle, AssetEvent, AssetId, Assets, Handle};
+use bevy_asset::{AssetEvent, AssetId, Assets};
 use bevy_color::{Alpha, ColorToComponents, LinearRgba};
 use bevy_core_pipeline::core_2d::graph::{Core2d, Node2d};
 use bevy_core_pipeline::core_3d::graph::{Core3d, Node3d};
@@ -23,6 +23,7 @@ use bevy_ecs::prelude::*;
 use bevy_ecs::system::SystemParam;
 use bevy_image::prelude::*;
 use bevy_math::{FloatOrd, Mat4, Rect, UVec4, Vec2, Vec3, Vec3Swizzles, Vec4Swizzles};
+use bevy_render::load_shader_library;
 use bevy_render::render_graph::{NodeRunError, RenderGraphContext};
 use bevy_render::render_phase::ViewSortedRenderPhases;
 use bevy_render::renderer::RenderContext;
@@ -100,8 +101,6 @@ pub mod stack_z_offsets {
     pub const MATERIAL: f32 = 0.18267;
 }
 
-pub const UI_SHADER_HANDLE: Handle<Shader> = weak_handle!("7d190d05-545b-42f5-bd85-22a0da85b0f6");
-
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
 pub enum RenderUiSystems {
     ExtractCameraViews,
@@ -123,7 +122,7 @@ pub enum RenderUiSystems {
 pub type RenderUiSystem = RenderUiSystems;
 
 pub fn build_ui_render(app: &mut App) {
-    load_internal_asset!(app, UI_SHADER_HANDLE, "ui.wgsl", Shader::from_wgsl);
+    load_shader_library!(app, "ui.wgsl");
 
     let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
         return;

--- a/crates/bevy_ui/src/render/pipeline.rs
+++ b/crates/bevy_ui/src/render/pipeline.rs
@@ -1,3 +1,4 @@
+use bevy_asset::{load_embedded_asset, Handle};
 use bevy_ecs::prelude::*;
 use bevy_image::BevyDefault as _;
 use bevy_render::{
@@ -13,6 +14,7 @@ use bevy_render::{
 pub struct UiPipeline {
     pub view_layout: BindGroupLayout,
     pub image_layout: BindGroupLayout,
+    pub shader: Handle<Shader>,
 }
 
 impl FromWorld for UiPipeline {
@@ -41,6 +43,7 @@ impl FromWorld for UiPipeline {
         UiPipeline {
             view_layout,
             image_layout,
+            shader: load_embedded_asset!(world, "ui.wgsl"),
         }
     }
 }
@@ -84,13 +87,13 @@ impl SpecializedRenderPipeline for UiPipeline {
 
         RenderPipelineDescriptor {
             vertex: VertexState {
-                shader: super::UI_SHADER_HANDLE,
+                shader: self.shader.clone(),
                 entry_point: "vertex".into(),
                 shader_defs: shader_defs.clone(),
                 buffers: vec![vertex_layout],
             },
             fragment: Some(FragmentState {
-                shader: super::UI_SHADER_HANDLE,
+                shader: self.shader.clone(),
                 shader_defs,
                 entry_point: "fragment".into(),
                 targets: vec![Some(ColorTargetState {

--- a/crates/bevy_ui/src/render/ui_texture_slice_pipeline.rs
+++ b/crates/bevy_ui/src/render/ui_texture_slice_pipeline.rs
@@ -30,19 +30,11 @@ use binding_types::{sampler, texture_2d};
 use bytemuck::{Pod, Zeroable};
 use widget::ImageNode;
 
-pub const UI_SLICER_SHADER_HANDLE: Handle<Shader> =
-    weak_handle!("10cd61e3-bbf7-47fa-91c8-16cbe806378c");
-
 pub struct UiTextureSlicerPlugin;
 
 impl Plugin for UiTextureSlicerPlugin {
     fn build(&self, app: &mut App) {
-        load_internal_asset!(
-            app,
-            UI_SLICER_SHADER_HANDLE,
-            "ui_texture_slice.wgsl",
-            Shader::from_wgsl
-        );
+        embedded_asset!(app, "ui_texture_slice.wgsl");
 
         if let Some(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app
@@ -116,6 +108,7 @@ pub struct UiTextureSliceImageBindGroups {
 pub struct UiTextureSlicePipeline {
     pub view_layout: BindGroupLayout,
     pub image_layout: BindGroupLayout,
+    pub shader: Handle<Shader>,
 }
 
 impl FromWorld for UiTextureSlicePipeline {
@@ -144,6 +137,7 @@ impl FromWorld for UiTextureSlicePipeline {
         UiTextureSlicePipeline {
             view_layout,
             image_layout,
+            shader: load_embedded_asset!(world, "ui_texture_slice.wgsl"),
         }
     }
 }
@@ -180,13 +174,13 @@ impl SpecializedRenderPipeline for UiTextureSlicePipeline {
 
         RenderPipelineDescriptor {
             vertex: VertexState {
-                shader: UI_SLICER_SHADER_HANDLE,
+                shader: self.shader.clone(),
                 entry_point: "vertex".into(),
                 shader_defs: shader_defs.clone(),
                 buffers: vec![vertex_layout],
             },
             fragment: Some(FragmentState {
-                shader: UI_SLICER_SHADER_HANDLE,
+                shader: self.shader.clone(),
                 shader_defs,
                 entry_point: "fragment".into(),
                 targets: vec![Some(ColorTargetState {


### PR DESCRIPTION
# Objective

- Related to #19024

## Solution

- Use the new `load_shader_library` macro for the shader libraries and `embedded_asset`/`load_embedded_asset` for the "shader binaries" in `bevy_ui`.

## Testing

- `box_shadow` example still works.
- `gradient` example is broken at head (see #19384) - but otherwise gives the same result in the console.
- `ui_materials` example still works.
- `ui_texture_slice` example still works.

P.S. I don't think this needs a migration guide. Technically users could be using the `pub` weak handles, but there's no actual good use for them, so omitting it seems fine. Alternatively, we could mix this in with the migration guide notes for #19137.