### PR TITLE
More uninlined_format_args fixes

### DIFF
--- a/crates/bevy_color/src/srgba.rs
+++ b/crates/bevy_color/src/srgba.rs
@@ -177,8 +177,8 @@ impl Srgba {
     pub fn to_hex(&self) -> String {
         let [r, g, b, a] = self.to_u8_array();
         match a {
-            255 => format!("#{:02X}{:02X}{:02X}", r, g, b),
-            _ => format!("#{:02X}{:02X}{:02X}{:02X}", r, g, b, a),
+            255 => format!("#{r:02X}{g:02X}{b:02X}"),
+            _ => format!("#{r:02X}{g:02X}{b:02X}{a:02X}"),
         }
     }
 

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -38,7 +38,7 @@ pub fn derive_event(input: TokenStream) -> TokenStream {
                 traversal = meta.value()?.parse()?;
                 Ok(())
             }
-            Some(ident) => Err(meta.error(format!("unsupported attribute: {}", ident))),
+            Some(ident) => Err(meta.error(format!("unsupported attribute: {ident}"))),
             None => Err(meta.error("expected identifier")),
         }) {
             return e.to_compile_error().into();

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -242,7 +242,7 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
             .as_ref()
             .map(|f| quote! { #f })
             .unwrap_or_else(|| quote! { #i });
-        field_names.push(format!("::{}", field_value));
+        field_names.push(format!("::{field_value}"));
         fields.push(field_value);
         field_types.push(&field.ty);
         let mut field_message = None;

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -1556,22 +1556,22 @@ mod tests {
     #[test]
     fn entity_debug() {
         let entity = Entity::from_raw(EntityRow::new(NonMaxU32::new(42).unwrap()));
-        let string = format!("{:?}", entity);
+        let string = format!("{entity:?}");
         assert_eq!(string, "42v0#4294967253");
 
         let entity = Entity::PLACEHOLDER;
-        let string = format!("{:?}", entity);
+        let string = format!("{entity:?}");
         assert_eq!(string, "PLACEHOLDER");
     }
 
     #[test]
     fn entity_display() {
         let entity = Entity::from_raw(EntityRow::new(NonMaxU32::new(42).unwrap()));
-        let string = format!("{}", entity);
+        let string = format!("{entity}");
         assert_eq!(string, "42v0");
 
         let entity = Entity::PLACEHOLDER;
-        let string = format!("{}", entity);
+        let string = format!("{entity}");
         assert_eq!(string, "PLACEHOLDER");
     }
 }

--- a/crates/bevy_ecs/src/error/bevy_error.rs
+++ b/crates/bevy_ecs/src/error/bevy_error.rs
@@ -76,7 +76,7 @@ impl BevyError {
                             break;
                         }
                     }
-                    writeln!(f, "{}", line)?;
+                    writeln!(f, "{line}")?;
                 }
                 if !full_backtrace {
                     if std::thread::panicking() {

--- a/crates/bevy_ecs/src/error/handler.rs
+++ b/crates/bevy_ecs/src/error/handler.rs
@@ -39,14 +39,14 @@ impl Display for ErrorContext {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::System { name, .. } => {
-                write!(f, "System `{}` failed", name)
+                write!(f, "System `{name}` failed")
             }
-            Self::Command { name } => write!(f, "Command `{}` failed", name),
+            Self::Command { name } => write!(f, "Command `{name}` failed"),
             Self::Observer { name, .. } => {
-                write!(f, "Observer `{}` failed", name)
+                write!(f, "Observer `{name}` failed")
             }
             Self::RunCondition { name, .. } => {
-                write!(f, "Run condition `{}` failed", name)
+                write!(f, "Run condition `{name}` failed")
             }
         }
     }

--- a/crates/bevy_ecs/src/hierarchy.rs
+++ b/crates/bevy_ecs/src/hierarchy.rs
@@ -444,7 +444,7 @@ pub fn validate_parent_has_component<C: Component>(
             caller.map(|c| format!("{c}: ")).unwrap_or_default(),
             ty_name = ShortName::of::<C>(),
             name = name.map_or_else(
-                || format!("Entity {}", entity),
+                || format!("Entity {entity}"),
                 |s| format!("The {s} entity")
             ),
         );

--- a/crates/bevy_ecs/src/schedule/executor/mod.rs
+++ b/crates/bevy_ecs/src/schedule/executor/mod.rs
@@ -370,7 +370,7 @@ mod tests {
     #[expect(clippy::print_stdout, reason = "std and println are allowed in tests")]
     fn single_and_populated_skipped_and_run() {
         for executor in EXECUTORS {
-            std::println!("Testing executor: {:?}", executor);
+            std::println!("Testing executor: {executor:?}");
 
             let mut world = World::new();
             world.init_resource::<TestState>();

--- a/crates/bevy_ecs/src/schedule/stepping.rs
+++ b/crates/bevy_ecs/src/schedule/stepping.rs
@@ -125,7 +125,7 @@ impl core::fmt::Debug for Stepping {
         if self.action != Action::RunAll {
             let Cursor { schedule, system } = self.cursor;
             match self.schedule_order.get(schedule) {
-                Some(label) => write!(f, "cursor: {:?}[{}], ", label, system)?,
+                Some(label) => write!(f, "cursor: {label:?}[{system}], ")?,
                 None => write!(f, "cursor: None, ")?,
             };
         }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -299,7 +299,7 @@ impl World {
         &mut self,
         id: ComponentId,
     ) -> Option<&mut ComponentHooks> {
-        assert!(!self.archetypes.archetypes.iter().any(|a| a.contains(id)), "Components hooks cannot be modified if the component already exists in an archetype, use register_component if the component with id {:?} may already be in use", id);
+        assert!(!self.archetypes.archetypes.iter().any(|a| a.contains(id)), "Components hooks cannot be modified if the component already exists in an archetype, use register_component if the component with id {id:?} may already be in use");
         self.components.get_hooks_mut(id)
     }
 

--- a/crates/bevy_math/src/cubic_splines/mod.rs
+++ b/crates/bevy_math/src/cubic_splines/mod.rs
@@ -1788,9 +1788,7 @@ mod tests {
             for (i, (a, b)) in cubic_curve.iter().zip(rational_curve.iter()).enumerate() {
                 assert!(
                     a.distance(*b) < EPSILON,
-                    "Mismatch at {name} value {i}. CubicCurve: {} Converted RationalCurve: {}",
-                    a,
-                    b
+                    "Mismatch at {name} value {i}. CubicCurve: {a} Converted RationalCurve: {b}",
                 );
             }
         }

--- a/crates/bevy_math/src/primitives/serde.rs
+++ b/crates/bevy_math/src/primitives/serde.rs
@@ -31,7 +31,7 @@ pub(crate) mod array {
         type Value = [T; N];
 
         fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
-            formatter.write_fmt(format_args!("an array of length {}", N))
+            formatter.write_fmt(format_args!("an array of length {N}"))
         }
 
         #[inline]

--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -186,8 +186,7 @@ impl DynamicArray {
         if let Some(represented_type) = represented_type {
             assert!(
                 matches!(represented_type, TypeInfo::Array(_)),
-                "expected TypeInfo::Array but received: {:?}",
-                represented_type
+                "expected TypeInfo::Array but received: {represented_type:?}"
             );
         }
 

--- a/crates/bevy_reflect/src/attributes.rs
+++ b/crates/bevy_reflect/src/attributes.rs
@@ -213,7 +213,7 @@ mod tests {
     fn should_debug_custom_attributes() {
         let attributes = CustomAttributes::default().with_attribute("My awesome custom attribute!");
 
-        let debug = format!("{:?}", attributes);
+        let debug = format!("{attributes:?}");
 
         assert_eq!(r#"{"My awesome custom attribute!"}"#, debug);
 
@@ -224,7 +224,7 @@ mod tests {
 
         let attributes = CustomAttributes::default().with_attribute(Foo { value: 42 });
 
-        let debug = format!("{:?}", attributes);
+        let debug = format!("{attributes:?}");
 
         assert_eq!(
             r#"{bevy_reflect::attributes::tests::Foo { value: 42 }}"#,

--- a/crates/bevy_reflect/src/enums/dynamic_enum.rs
+++ b/crates/bevy_reflect/src/enums/dynamic_enum.rs
@@ -114,8 +114,7 @@ impl DynamicEnum {
         if let Some(represented_type) = represented_type {
             assert!(
                 matches!(represented_type, TypeInfo::Enum(_)),
-                "expected TypeInfo::Enum but received: {:?}",
-                represented_type
+                "expected TypeInfo::Enum but received: {represented_type:?}",
             );
         }
 

--- a/crates/bevy_reflect/src/error.rs
+++ b/crates/bevy_reflect/src/error.rs
@@ -55,7 +55,7 @@ fn full_path(
     container_type_path: &str,
 ) -> alloc::string::String {
     match variant {
-        Some(variant) => format!("{}::{}::{}", container_type_path, variant, field),
-        None => format!("{}::{}", container_type_path, field),
+        Some(variant) => format!("{container_type_path}::{variant}::{field}"),
+        None => format!("{container_type_path}::{field}"),
     }
 }

--- a/crates/bevy_reflect/src/func/dynamic_function.rs
+++ b/crates/bevy_reflect/src/func/dynamic_function.rs
@@ -550,7 +550,7 @@ mod tests {
     fn should_clone_dynamic_function() {
         let hello = String::from("Hello");
 
-        let greet = |name: &String| -> String { format!("{}, {}!", hello, name) };
+        let greet = |name: &String| -> String { format!("{hello}, {name}!") };
 
         let greet = greet.into_function().with_name("greet");
         let clone = greet.clone();
@@ -771,18 +771,18 @@ mod tests {
     #[test]
     fn should_debug_dynamic_function() {
         fn greet(name: &String) -> String {
-            format!("Hello, {}!", name)
+            format!("Hello, {name}!")
         }
 
         let function = greet.into_function();
-        let debug = format!("{:?}", function);
+        let debug = format!("{function:?}");
         assert_eq!(debug, "DynamicFunction(fn bevy_reflect::func::dynamic_function::tests::should_debug_dynamic_function::greet(_: &alloc::string::String) -> alloc::string::String)");
     }
 
     #[test]
     fn should_debug_anonymous_dynamic_function() {
         let function = (|a: i32, b: i32| a + b).into_function();
-        let debug = format!("{:?}", function);
+        let debug = format!("{function:?}");
         assert_eq!(debug, "DynamicFunction(fn _(_: i32, _: i32) -> i32)");
     }
 
@@ -792,11 +792,11 @@ mod tests {
             a + b
         }
 
-        let func = add::<i32>
+        let function = add::<i32>
             .into_function()
             .with_overload(add::<f32>)
             .with_name("add");
-        let debug = format!("{:?}", func);
+        let debug = format!("{function:?}");
         assert_eq!(
             debug,
             "DynamicFunction(fn add{(_: i32, _: i32) -> i32, (_: f32, _: f32) -> f32})"

--- a/crates/bevy_reflect/src/func/info.rs
+++ b/crates/bevy_reflect/src/func/info.rs
@@ -434,7 +434,7 @@ impl<'a> Debug for PrettyPrintFunctionInfo<'a> {
         }
 
         match (self.include_name, self.info.name()) {
-            (true, Some(name)) => write!(f, "{}", name)?,
+            (true, Some(name)) => write!(f, "{name}")?,
             (true, None) => write!(f, "_")?,
             _ => {}
         }
@@ -509,7 +509,7 @@ impl<'a> Debug for PrettyPrintSignatureInfo<'a> {
         }
 
         match (self.include_name, self.info.name()) {
-            (true, Some(name)) => write!(f, "{}", name)?,
+            (true, Some(name)) => write!(f, "{name}")?,
             (true, None) => write!(f, "_")?,
             _ => {}
         }

--- a/crates/bevy_reflect/src/func/registry.rs
+++ b/crates/bevy_reflect/src/func/registry.rs
@@ -520,7 +520,7 @@ mod tests {
         let mut registry = FunctionRegistry::default();
         registry.register_with_name("foo", foo).unwrap();
 
-        let debug = format!("{:?}", registry);
+        let debug = format!("{registry:?}");
         assert_eq!(debug, "{DynamicFunction(fn foo() -> i32)}");
     }
 }

--- a/crates/bevy_reflect/src/func/signature.rs
+++ b/crates/bevy_reflect/src/func/signature.rs
@@ -229,7 +229,7 @@ mod tests {
         );
 
         assert_eq!(
-            format!("{:?}", signature),
+            format!("{signature:?}"),
             "(&mut alloc::string::String, i32) -> ()"
         );
     }

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -2608,7 +2608,7 @@ bevy_reflect::tests::Test {
         let foo = Foo { a: 1 };
         let foo: &dyn Reflect = &foo;
 
-        assert_eq!("123", format!("{:?}", foo));
+        assert_eq!("123", format!("{foo:?}"));
     }
 
     #[test]
@@ -2861,7 +2861,7 @@ bevy_reflect::tests::Test {
         test_unknown_tuple_struct.insert(14);
         test_struct.insert("unknown_tuplestruct", test_unknown_tuple_struct);
         assert_eq!(
-            format!("{:?}", test_struct),
+            format!("{test_struct:?}"),
             "DynamicStruct(bevy_reflect::tests::TestStruct { \
                 tuple: DynamicTuple((0, 1)), \
                 tuple_struct: DynamicTupleStruct(bevy_reflect::tests::TestTupleStruct(8)), \

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -191,8 +191,7 @@ impl DynamicList {
         if let Some(represented_type) = represented_type {
             assert!(
                 matches!(represented_type, TypeInfo::List(_)),
-                "expected TypeInfo::List but received: {:?}",
-                represented_type
+                "expected TypeInfo::List but received: {represented_type:?}"
             );
         }
 

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -236,8 +236,7 @@ impl DynamicMap {
         if let Some(represented_type) = represented_type {
             assert!(
                 matches!(represented_type, TypeInfo::Map(_)),
-                "expected TypeInfo::Map but received: {:?}",
-                represented_type
+                "expected TypeInfo::Map but received: {represented_type:?}"
             );
         }
 

--- a/crates/bevy_reflect/src/serde/de/error_utils.rs
+++ b/crates/bevy_reflect/src/serde/de/error_utils.rs
@@ -23,7 +23,7 @@ thread_local! {
 pub(super) fn make_custom_error<E: Error>(msg: impl Display) -> E {
     #[cfg(feature = "debug_stack")]
     return TYPE_INFO_STACK
-        .with_borrow(|stack| E::custom(format_args!("{} (stack: {:?})", msg, stack)));
+        .with_borrow(|stack| E::custom(format_args!("{msg} (stack: {stack:?})")));
     #[cfg(not(feature = "debug_stack"))]
     return E::custom(msg);
 }

--- a/crates/bevy_reflect/src/serde/mod.rs
+++ b/crates/bevy_reflect/src/serde/mod.rs
@@ -400,7 +400,7 @@ mod tests {
             };
 
             // Poor man's comparison since we can't derive PartialEq for Arc<dyn Enemy>
-            assert_eq!(format!("{:?}", expected), format!("{:?}", output));
+            assert_eq!(format!("{expected:?}"), format!("{output:?}",));
 
             let unexpected = Level {
                 name: String::from("Level 1"),
@@ -414,7 +414,7 @@ mod tests {
             };
 
             // Poor man's comparison since we can't derive PartialEq for Arc<dyn Enemy>
-            assert_ne!(format!("{:?}", unexpected), format!("{:?}", output));
+            assert_ne!(format!("{unexpected:?}"), format!("{output:?}"));
         }
 
         #[test]

--- a/crates/bevy_reflect/src/serde/ser/error_utils.rs
+++ b/crates/bevy_reflect/src/serde/ser/error_utils.rs
@@ -23,7 +23,7 @@ thread_local! {
 pub(super) fn make_custom_error<E: Error>(msg: impl Display) -> E {
     #[cfg(feature = "debug_stack")]
     return TYPE_INFO_STACK
-        .with_borrow(|stack| E::custom(format_args!("{} (stack: {:?})", msg, stack)));
+        .with_borrow(|stack| E::custom(format_args!("{msg} (stack: {stack:?})")));
     #[cfg(not(feature = "debug_stack"))]
     return E::custom(msg);
 }

--- a/crates/bevy_reflect/src/set.rs
+++ b/crates/bevy_reflect/src/set.rs
@@ -158,8 +158,7 @@ impl DynamicSet {
         if let Some(represented_type) = represented_type {
             assert!(
                 matches!(represented_type, TypeInfo::Set(_)),
-                "expected TypeInfo::Set but received: {:?}",
-                represented_type
+                "expected TypeInfo::Set but received: {represented_type:?}"
             );
         }
 

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -292,8 +292,7 @@ impl DynamicStruct {
         if let Some(represented_type) = represented_type {
             assert!(
                 matches!(represented_type, TypeInfo::Struct(_)),
-                "expected TypeInfo::Struct but received: {:?}",
-                represented_type
+                "expected TypeInfo::Struct but received: {represented_type:?}"
             );
         }
 

--- a/crates/bevy_reflect/src/tuple.rs
+++ b/crates/bevy_reflect/src/tuple.rs
@@ -227,8 +227,7 @@ impl DynamicTuple {
         if let Some(represented_type) = represented_type {
             assert!(
                 matches!(represented_type, TypeInfo::Tuple(_)),
-                "expected TypeInfo::Tuple but received: {:?}",
-                represented_type
+                "expected TypeInfo::Tuple but received: {represented_type:?}"
             );
         }
         self.represented_type = represented_type;

--- a/crates/bevy_reflect/src/tuple_struct.rs
+++ b/crates/bevy_reflect/src/tuple_struct.rs
@@ -242,8 +242,7 @@ impl DynamicTupleStruct {
         if let Some(represented_type) = represented_type {
             assert!(
                 matches!(represented_type, TypeInfo::TupleStruct(_)),
-                "expected TypeInfo::TupleStruct but received: {:?}",
-                represented_type
+                "expected TypeInfo::TupleStruct but received: {represented_type:?}"
             );
         }
 

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -356,7 +356,7 @@ fn main() {
                                 .join(format!("{}.png", to_run.technical_name)),
                         );
                         if let Err(err) = renamed_screenshot {
-                            println!("Failed to rename screenshot: {}", err);
+                            println!("Failed to rename screenshot: {err}");
                             no_screenshot_examples.push((to_run, duration));
                         } else {
                             successful_examples.push((to_run, duration));
@@ -373,12 +373,12 @@ fn main() {
                     let stdout = String::from_utf8_lossy(&result.stdout);
                     let stderr = String::from_utf8_lossy(&result.stderr);
                     if show_logs {
-                        println!("{}", stdout);
-                        println!("{}", stderr);
+                        println!("{stdout}");
+                        println!("{stderr}");
                     }
                     if report_details {
                         let mut file =
-                            File::create(format!("{reports_path}/{}.log", example)).unwrap();
+                            File::create(format!("{reports_path}/{example}.log")).unwrap();
                         file.write_all(b"==== stdout ====\n").unwrap();
                         file.write_all(stdout.as_bytes()).unwrap();
                         file.write_all(b"\n==== stderr ====\n").unwrap();
@@ -628,7 +628,7 @@ header_message = \"Examples ({})\"
             optimize_size,
             api,
         } => {
-            let api = format!("{}", api);
+            let api = format!("{api}");
             let examples_to_build = parse_examples();
 
             let root_path = Path::new(&content_folder);


### PR DESCRIPTION
# Objective

There are several uninlined format args (seems to be in more formatting macros and in more crates) that are not detected on stable, but are on nightly.

## Solution

Fix them.