### PR TITLE
Allow playing audio from a custom start position

### DIFF
--- a/crates/bevy_audio/src/audio.rs
+++ b/crates/bevy_audio/src/audio.rs
@@ -57,8 +57,10 @@ pub struct PlaybackSettings {
     /// Optional scale factor applied to the positions of this audio source and the listener,
     /// overriding the default value configured on [`AudioPlugin::default_spatial_scale`](crate::AudioPlugin::default_spatial_scale).
     pub spatial_scale: Option<SpatialScale>,
-    /// The point in time from which to start playing the audio. If None, it will play from the
-    /// start.
+    /// The point in time in the audio clip where playback should start. If set to None, it will
+    /// play from the beginning of the clip.
+    ///
+    /// If the playback mode is set to `Loop`, each loop will start from this position.
     pub start_position: Option<std::time::Duration>,
 }
 

--- a/crates/bevy_audio/src/audio.rs
+++ b/crates/bevy_audio/src/audio.rs
@@ -142,6 +142,12 @@ impl PlaybackSettings {
         self.spatial_scale = Some(spatial_scale);
         self
     }
+
+    /// Helper to use a custom playback start position
+    pub const fn with_start_position(mut self, start_position: std::time::Duration) -> Self {
+        self.start_position = Some(start_position);
+        self
+    }
 }
 
 /// Settings for the listener for spatial audio sources.

--- a/crates/bevy_audio/src/audio.rs
+++ b/crates/bevy_audio/src/audio.rs
@@ -57,6 +57,9 @@ pub struct PlaybackSettings {
     /// Optional scale factor applied to the positions of this audio source and the listener,
     /// overriding the default value configured on [`AudioPlugin::default_spatial_scale`](crate::AudioPlugin::default_spatial_scale).
     pub spatial_scale: Option<SpatialScale>,
+    /// The point in time from which to start playing the audio. If None, it will play from the
+    /// start.
+    pub start_position: Option<std::time::Duration>,
 }
 
 impl Default for PlaybackSettings {
@@ -81,6 +84,7 @@ impl PlaybackSettings {
         muted: false,
         spatial: false,
         spatial_scale: None,
+        start_position: None,
     };
 
     /// Will play the associated audio source in a loop.

--- a/crates/bevy_audio/src/audio_output.rs
+++ b/crates/bevy_audio/src/audio_output.rs
@@ -157,9 +157,24 @@ pub(crate) fn play_queued_audio_system<Source: Asset + Decodable>(
             };
 
             match settings.mode {
-                PlaybackMode::Loop => sink.append(audio_source.decoder().repeat_infinite()),
+                PlaybackMode::Loop => {
+                    if let Some(start_position) = settings.start_position {
+                        sink.append(
+                            audio_source
+                                .decoder()
+                                .skip_duration(start_position)
+                                .repeat_infinite(),
+                        );
+                    } else {
+                        sink.append(audio_source.decoder().repeat_infinite());
+                    }
+                }
                 PlaybackMode::Once | PlaybackMode::Despawn | PlaybackMode::Remove => {
-                    sink.append(audio_source.decoder());
+                    if let Some(start_position) = settings.start_position {
+                        sink.append(audio_source.decoder().skip_duration(start_position));
+                    } else {
+                        sink.append(audio_source.decoder());
+                    }
                 }
             };
 
@@ -197,9 +212,24 @@ pub(crate) fn play_queued_audio_system<Source: Asset + Decodable>(
             };
 
             match settings.mode {
-                PlaybackMode::Loop => sink.append(audio_source.decoder().repeat_infinite()),
+                PlaybackMode::Loop => {
+                    if let Some(start_position) = settings.start_position {
+                        sink.append(
+                            audio_source
+                                .decoder()
+                                .skip_duration(start_position)
+                                .repeat_infinite(),
+                        );
+                    } else {
+                        sink.append(audio_source.decoder().repeat_infinite());
+                    }
+                }
                 PlaybackMode::Once | PlaybackMode::Despawn | PlaybackMode::Remove => {
-                    sink.append(audio_source.decoder());
+                    if let Some(start_position) = settings.start_position {
+                        sink.append(audio_source.decoder().skip_duration(start_position));
+                    } else {
+                        sink.append(audio_source.decoder());
+                    }
                 }
             };
 


### PR DESCRIPTION
# Objective

Adds the ability to play audio from a certain start position, instead of always from the beginning. This option is set via the `PlaybackSettings` component, and works on all kinds of audio sources.

## Solution

- Added a public `start_position` field to `PlaybackSettings`, of type `Option<std::time::Duration>`.
- Used rodio's `Source::skip_duration` function to skip to that position when playing an audio source. If the audio source is set to loop, each loop will start from this position. The default behaviour (when start_position is `None`) is to play the audio from the beginning, like normal.

## Testing

I tried adding a custom start position to all the existing audio examples to test a bunch of different audio sources and settings, and they all worked fine. I verified that it skips the right amount of time, and that it skips the entire audio clip if the start position is longer than the length of the clip. All my testing was done on Fedora Linux.

---

## Showcase

```rust
// Play a song on loop, but start playing each loop from 0:30.5
commands.spawn((
    AudioPlayer::new(song_handle),
    PlaybackSettings::LOOP.with_start_position(Duration::from_secs_f32(30.5))
));
```