### PR TITLE
Loosen `add_state_scoped_event` trait bound.

### DIFF
--- a/crates/bevy_state/src/state_scoped_events.rs
+++ b/crates/bevy_state/src/state_scoped_events.rs
@@ -10,7 +10,7 @@ use bevy_ecs::{
 };
 use bevy_platform::collections::HashMap;
 
-use crate::state::{FreelyMutableState, OnExit, StateTransitionEvent};
+use crate::state::{OnExit, StateTransitionEvent, States};
 
 fn clear_event_queue<E: Event>(w: &mut World) {
     if let Some(mut queue) = w.get_resource_mut::<Events<E>>() {
@@ -19,11 +19,11 @@ fn clear_event_queue<E: Event>(w: &mut World) {
 }
 
 #[derive(Resource)]
-struct StateScopedEvents<S: FreelyMutableState> {
+struct StateScopedEvents<S: States> {
     cleanup_fns: HashMap<S, Vec<fn(&mut World)>>,
 }
 
-impl<S: FreelyMutableState> StateScopedEvents<S> {
+impl<S: States> StateScopedEvents<S> {
     fn add_event<E: Event>(&mut self, state: S) {
         self.cleanup_fns
             .entry(state)
@@ -41,7 +41,7 @@ impl<S: FreelyMutableState> StateScopedEvents<S> {
     }
 }
 
-impl<S: FreelyMutableState> Default for StateScopedEvents<S> {
+impl<S: States> Default for StateScopedEvents<S> {
     fn default() -> Self {
         Self {
             cleanup_fns: HashMap::default(),
@@ -49,7 +49,7 @@ impl<S: FreelyMutableState> Default for StateScopedEvents<S> {
     }
 }
 
-fn cleanup_state_scoped_event<S: FreelyMutableState>(
+fn cleanup_state_scoped_event<S: States>(
     mut c: Commands,
     mut transitions: EventReader<StateTransitionEvent<S>>,
 ) {
@@ -70,7 +70,7 @@ fn cleanup_state_scoped_event<S: FreelyMutableState>(
     });
 }
 
-fn add_state_scoped_event_impl<E: Event, S: FreelyMutableState>(
+fn add_state_scoped_event_impl<E: Event, S: States>(
     app: &mut SubApp,
     _p: PhantomData<E>,
     state: S,
@@ -94,18 +94,18 @@ pub trait StateScopedEventsAppExt {
     /// cleanup and the [`OnExit`] schedule for the target state. All of these (state scoped
     /// entities and events cleanup, and `OnExit`) occur within schedule [`StateTransition`](crate::prelude::StateTransition)
     /// and system set `StateTransitionSystems::ExitSchedules`.
-    fn add_state_scoped_event<E: Event>(&mut self, state: impl FreelyMutableState) -> &mut Self;
+    fn add_state_scoped_event<E: Event>(&mut self, state: impl States) -> &mut Self;
 }
 
 impl StateScopedEventsAppExt for App {
-    fn add_state_scoped_event<E: Event>(&mut self, state: impl FreelyMutableState) -> &mut Self {
+    fn add_state_scoped_event<E: Event>(&mut self, state: impl States) -> &mut Self {
         add_state_scoped_event_impl(self.main_mut(), PhantomData::<E>, state);
         self
     }
 }
 
 impl StateScopedEventsAppExt for SubApp {
-    fn add_state_scoped_event<E: Event>(&mut self, state: impl FreelyMutableState) -> &mut Self {
+    fn add_state_scoped_event<E: Event>(&mut self, state: impl States) -> &mut Self {
         add_state_scoped_event_impl(self, PhantomData::<E>, state);
         self
     }


### PR DESCRIPTION
Fixes #18623, allowing `add_state_scoped_event` to work with computed states.

As a side note, should state scoped events be updated to match the recently changed [state scoped entities](https://github.com/bevyengine/bevy/blob/main/release-content/migration-guides/rename_StateScoped.md)?