### PR TITLE
Clean up several miscellaneous uses of `weak_handle`.

### DIFF
--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -492,8 +492,8 @@ impl<A: Asset> TryFrom<UntypedHandle> for Handle<A> {
 ///
 /// ```
 /// # use bevy_asset::{Handle, uuid_handle};
-/// # type Shader = ();
-/// const SHADER: Handle<Shader> = uuid_handle!("1347c9b7-c46a-48e7-b7b8-023a354b7cac");
+/// # type Image = ();
+/// const IMAGE: Handle<Image> = uuid_handle!("1347c9b7-c46a-48e7-b7b8-023a354b7cac");
 /// ```
 #[macro_export]
 macro_rules! uuid_handle {

--- a/crates/bevy_core_pipeline/src/experimental/mip_generation/mod.rs
+++ b/crates/bevy_core_pipeline/src/experimental/mip_generation/mod.rs
@@ -12,7 +12,7 @@ use crate::core_3d::{
     prepare_core_3d_depth_textures,
 };
 use bevy_app::{App, Plugin};
-use bevy_asset::{load_internal_asset, uuid_handle, Handle};
+use bevy_asset::{embedded_asset, load_embedded_asset, Handle};
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
     component::Component,
@@ -51,8 +51,8 @@ use bitflags::bitflags;
 use tracing::debug;
 
 /// Identifies the `downsample_depth.wgsl` shader.
-pub const DOWNSAMPLE_DEPTH_SHADER_HANDLE: Handle<Shader> =
-    uuid_handle!("a09a149e-5922-4fa4-9170-3c1a13065364");
+#[derive(Resource, Deref)]
+pub struct DownsampleDepthShader(Handle<Shader>);
 
 /// The maximum number of mip levels that we can produce.
 ///
@@ -69,18 +69,16 @@ pub struct MipGenerationPlugin;
 
 impl Plugin for MipGenerationPlugin {
     fn build(&self, app: &mut App) {
-        load_internal_asset!(
-            app,
-            DOWNSAMPLE_DEPTH_SHADER_HANDLE,
-            "downsample_depth.wgsl",
-            Shader::from_wgsl
-        );
+        embedded_asset!(app, "downsample_depth.wgsl");
+
+        let downsample_depth_shader = load_embedded_asset!(app, "downsample_depth.wgsl");
 
         let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
             return;
         };
 
         render_app
+            .insert_resource(DownsampleDepthShader(downsample_depth_shader))
             .init_resource::<SpecializedComputePipelines<DownsampleDepthPipeline>>()
             .add_render_graph_node::<DownsampleDepthNode>(Core3d, Node3d::EarlyDownsampleDepth)
             .add_render_graph_node::<DownsampleDepthNode>(Core3d, Node3d::LateDownsampleDepth)
@@ -294,17 +292,21 @@ pub struct DownsampleDepthPipeline {
     bind_group_layout: BindGroupLayout,
     /// A handle that identifies the compiled shader.
     pipeline_id: Option<CachedComputePipelineId>,
+    /// The shader asset handle.
+    shader: Handle<Shader>,
 }
 
 impl DownsampleDepthPipeline {
-    /// Creates a new [`DownsampleDepthPipeline`] from a bind group layout.
+    /// Creates a new [`DownsampleDepthPipeline`] from a bind group layout and the downsample
+    /// shader.
     ///
     /// This doesn't actually specialize the pipeline; that must be done
     /// afterward.
-    fn new(bind_group_layout: BindGroupLayout) -> DownsampleDepthPipeline {
+    fn new(bind_group_layout: BindGroupLayout, shader: Handle<Shader>) -> DownsampleDepthPipeline {
         DownsampleDepthPipeline {
             bind_group_layout,
             pipeline_id: None,
+            shader,
         }
     }
 }
@@ -335,6 +337,7 @@ fn create_downsample_depth_pipelines(
     pipeline_cache: Res<PipelineCache>,
     mut specialized_compute_pipelines: ResMut<SpecializedComputePipelines<DownsampleDepthPipeline>>,
     gpu_preprocessing_support: Res<GpuPreprocessingSupport>,
+    downsample_depth_shader: Res<DownsampleDepthShader>,
     mut has_run: Local<bool>,
 ) {
     // Only run once.
@@ -368,10 +371,22 @@ fn create_downsample_depth_pipelines(
 
     // Initialize the pipelines.
     let mut downsample_depth_pipelines = DownsampleDepthPipelines {
-        first: DownsampleDepthPipeline::new(standard_bind_group_layout.clone()),
-        second: DownsampleDepthPipeline::new(standard_bind_group_layout.clone()),
-        first_multisample: DownsampleDepthPipeline::new(multisampled_bind_group_layout.clone()),
-        second_multisample: DownsampleDepthPipeline::new(multisampled_bind_group_layout.clone()),
+        first: DownsampleDepthPipeline::new(
+            standard_bind_group_layout.clone(),
+            downsample_depth_shader.0.clone(),
+        ),
+        second: DownsampleDepthPipeline::new(
+            standard_bind_group_layout.clone(),
+            downsample_depth_shader.0.clone(),
+        ),
+        first_multisample: DownsampleDepthPipeline::new(
+            multisampled_bind_group_layout.clone(),
+            downsample_depth_shader.0.clone(),
+        ),
+        second_multisample: DownsampleDepthPipeline::new(
+            multisampled_bind_group_layout.clone(),
+            downsample_depth_shader.0.clone(),
+        ),
         sampler,
     };
 
@@ -491,7 +506,7 @@ impl SpecializedComputePipeline for DownsampleDepthPipeline {
                 stages: ShaderStages::COMPUTE,
                 range: 0..4,
             }],
-            shader: DOWNSAMPLE_DEPTH_SHADER_HANDLE,
+            shader: self.shader.clone(),
             shader_defs,
             entry_point: Some(if key.contains(DownsampleDepthPipelineKey::SECOND_PHASE) {
                 "downsample_depth_second".into()

--- a/crates/bevy_pbr/src/meshlet/pipelines.rs
+++ b/crates/bevy_pbr/src/meshlet/pipelines.rs
@@ -1,7 +1,7 @@
 use super::resource_manager::ResourceManager;
 use bevy_asset::{load_embedded_asset, Handle};
 use bevy_core_pipeline::{
-    core_3d::CORE_3D_DEPTH_FORMAT, experimental::mip_generation::DOWNSAMPLE_DEPTH_SHADER_HANDLE,
+    core_3d::CORE_3D_DEPTH_FORMAT, experimental::mip_generation::DownsampleDepthShader,
     FullscreenShader,
 };
 use bevy_ecs::{
@@ -84,6 +84,7 @@ impl FromWorld for MeshletPipelines {
             .remap_1d_to_2d_dispatch_bind_group_layout
             .clone();
 
+        let downsample_depth_shader = (*world.resource::<DownsampleDepthShader>()).clone();
         let vertex_state = world.resource::<FullscreenShader>().to_vertex_state();
         let fill_counts_layout = resource_manager.fill_counts_bind_group_layout.clone();
 
@@ -230,7 +231,7 @@ impl FromWorld for MeshletPipelines {
                         stages: ShaderStages::COMPUTE,
                         range: 0..4,
                     }],
-                    shader: DOWNSAMPLE_DEPTH_SHADER_HANDLE,
+                    shader: downsample_depth_shader.clone(),
                     shader_defs: vec![
                         "MESHLET_VISIBILITY_BUFFER_RASTER_PASS_OUTPUT".into(),
                         "MESHLET".into(),
@@ -248,7 +249,7 @@ impl FromWorld for MeshletPipelines {
                         stages: ShaderStages::COMPUTE,
                         range: 0..4,
                     }],
-                    shader: DOWNSAMPLE_DEPTH_SHADER_HANDLE,
+                    shader: downsample_depth_shader.clone(),
                     shader_defs: vec![
                         "MESHLET_VISIBILITY_BUFFER_RASTER_PASS_OUTPUT".into(),
                         "MESHLET".into(),
@@ -266,7 +267,7 @@ impl FromWorld for MeshletPipelines {
                         stages: ShaderStages::COMPUTE,
                         range: 0..4,
                     }],
-                    shader: DOWNSAMPLE_DEPTH_SHADER_HANDLE,
+                    shader: downsample_depth_shader.clone(),
                     shader_defs: vec!["MESHLET".into()],
                     entry_point: Some("downsample_depth_first".into()),
                     ..default()
@@ -281,7 +282,7 @@ impl FromWorld for MeshletPipelines {
                         stages: ShaderStages::COMPUTE,
                         range: 0..4,
                     }],
-                    shader: DOWNSAMPLE_DEPTH_SHADER_HANDLE,
+                    shader: downsample_depth_shader,
                     shader_defs: vec!["MESHLET".into()],
                     entry_point: Some("downsample_depth_second".into()),
                     zero_initialize_workgroup_memory: false,

--- a/release-content/migration-guides/chromatic_aberration_option.md
+++ b/release-content/migration-guides/chromatic_aberration_option.md
@@ -1,0 +1,8 @@
+---
+title: ChromaticAberration LUT is now Option
+pull_requests: [19408]
+---
+
+The `ChromaticAberration` component `color_lut` field use to be a regular `Handle<Image>`. Now, it
+is an `Option<Handle<Image>>` which falls back to the default image when `None`. For users assigning
+a custom LUT, just wrap the value in `Some`.


### PR DESCRIPTION
# Objective

- Related to #19024.

## Solution

- This is a mix of several ways to get rid of weak handles. The primary strategy is putting strong asset handles in resources that the rendering code clones into its pipelines (or whatever).
- This does not handle every remaining case, but we are slowly clearing them out.

## Testing

- `anti_aliasing` example still works.
- `fog_volumes` example still works.