### PR TITLE
Add `resize_in_place` to `Image`

### DIFF
--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -1826,14 +1826,16 @@ mod test {
         }
 
         // Grow image
-        image.resize_in_place_2d(
-            Extent3d {
-                width: 4,
-                height: 4,
-                depth_or_array_layers: 1,
-            },
-            &GROW_FILL.to_u8_array(),
-        );
+        image
+            .resize_in_place_2d(
+                Extent3d {
+                    width: 4,
+                    height: 4,
+                    depth_or_array_layers: 1,
+                },
+                &GROW_FILL.to_u8_array(),
+            )
+            .unwrap();
 
         // After growing, the test pattern should be the same.
         assert!(matches!(
@@ -1854,14 +1856,16 @@ mod test {
         ));
 
         // Shrink
-        image.resize_in_place_2d(
-            Extent3d {
-                width: 1,
-                height: 1,
-                depth_or_array_layers: 1,
-            },
-            &GROW_FILL.to_u8_array(),
-        );
+        image
+            .resize_in_place_2d(
+                Extent3d {
+                    width: 1,
+                    height: 1,
+                    depth_or_array_layers: 1,
+                },
+                &GROW_FILL.to_u8_array(),
+            )
+            .unwrap();
 
         // Images outside of the new dimensions should be clipped
         assert!(image.get_color_at(1, 1).is_err());

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -852,7 +852,7 @@ impl Image {
     /// Resizes the image to the new size, by removing information or appending 0 to the `data`.
     /// Does not properly scale the contents of the image.
     ///
-    /// If you need to keep pixel data intact, use [`Image::resize_in_place_2d`].
+    /// If you need to keep pixel data intact, use [`Image::resize_in_place`].
     pub fn resize(&mut self, size: Extent3d) {
         self.texture_descriptor.size = size;
         if let Some(ref mut data) = self.data {

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -881,7 +881,7 @@ impl Image {
     }
 
     /// Resizes the image to the new size, keeping the pixel data intact, anchored at the top-left.
-    /// When growing, the new space is filled with `fill`. When shrinking, the image is clipped.
+    /// When growing, the new space is filled with 0. When shrinking, the image is clipped.
     ///
     /// For faster resizing when keeping pixel data intact is not important, use [`Image::resize`].
     pub fn resize_in_place(&mut self, new_size: Extent3d) -> Result<(), ResizeError> {

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -1594,9 +1594,6 @@ pub enum ResizeError {
     /// Failed to resize an Image because it has no data.
     #[error("resize method requires cpu-side image data but none was present")]
     ImageWithoutData,
-    /// Failed to resize an Image because it is not 2-dimensional.
-    #[error("resize method requires a 2d image")]
-    ImageNot2d,
 }
 
 /// The type of a raw image buffer.

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -1899,7 +1899,7 @@ mod test {
             .resize_in_place(Extent3d {
                 width: 4,
                 height: 4,
-                depth_or_array_layers: LAYERS,
+                depth_or_array_layers: LAYERS + 1,
             })
             .unwrap();
 
@@ -1918,7 +1918,7 @@ mod test {
         }
 
         // Pixels in the newly added area should get filled with zeroes.
-        for z in 0..LAYERS {
+        for z in 0..(LAYERS + 1) {
             assert!(matches!(
                 image.get_color_at_3d(3, 3, z),
                 Ok(Color::LinearRgba(GROW_FILL))

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -890,7 +890,7 @@ impl Image {
         fill: &[u8],
     ) -> Result<(), ResizeError> {
         let old_size = self.texture_descriptor.size;
-        if old_size.depth_or_array_layers != 1 {
+        if old_size.depth_or_array_layers != 1 || new_size.depth_or_array_layers != 1 {
             return Err(ResizeError::ImageNot2d);
         }
 

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -884,12 +884,8 @@ impl Image {
     /// When growing, the new space is filled with `fill`. When shrinking, the image is clipped.
     ///
     /// For faster resizing when keeping pixel data intact is not important, use [`Image::resize`].
-    pub fn resize_in_place_2d(&mut self, new_size: Extent3d) -> Result<(), ResizeError> {
+    pub fn resize_in_place(&mut self, new_size: Extent3d) -> Result<(), ResizeError> {
         let old_size = self.texture_descriptor.size;
-        if old_size.depth_or_array_layers != 1 || new_size.depth_or_array_layers != 1 {
-            return Err(ResizeError::ImageNot2d);
-        }
-
         let pixel_size = self.texture_descriptor.format.pixel_size();
         let byte_len = self.texture_descriptor.format.pixel_size() * new_size.volume();
 
@@ -899,17 +895,28 @@ impl Image {
 
         let mut new: Vec<u8> = vec![0; byte_len];
 
-        let copy_width = old_size.width.min(new_size.width);
-        let copy_height = old_size.height.min(new_size.height);
+        let copy_width = old_size.width.min(new_size.width) as usize;
+        let copy_height = old_size.height.min(new_size.height) as usize;
+        let copy_depth = old_size
+            .depth_or_array_layers
+            .min(new_size.depth_or_array_layers) as usize;
 
-        for row in 0..copy_height {
-            let old_row_start = (row * old_size.width) as usize * pixel_size;
-            let old_row_end = old_row_start + copy_width as usize * pixel_size;
+        let old_row_stride = old_size.width as usize * pixel_size;
+        let old_layer_stride = old_size.height as usize * old_row_stride;
 
-            let new_row_start = (row * new_size.width) as usize * pixel_size;
-            let new_row_end = new_row_start + copy_width as usize * pixel_size;
+        let new_row_stride = new_size.width as usize * pixel_size;
+        let new_layer_stride = new_size.height as usize * new_row_stride;
 
-            new[new_row_start..new_row_end].copy_from_slice(&data[old_row_start..old_row_end]);
+        for z in 0..copy_depth {
+            for y in 0..copy_height {
+                let old_offset = z * old_layer_stride + y * old_row_stride;
+                let new_offset = z * new_layer_stride + y * new_row_stride;
+
+                let old_range = (old_offset)..(old_offset + copy_width * pixel_size);
+                let new_range = (new_offset)..(new_offset + copy_width * pixel_size);
+
+                new[new_range].copy_from_slice(&data[old_range]);
+            }
         }
 
         self.data = Some(new);
@@ -1816,7 +1823,7 @@ mod test {
 
         // Grow image
         image
-            .resize_in_place_2d(Extent3d {
+            .resize_in_place(Extent3d {
                 width: 4,
                 height: 4,
                 depth_or_array_layers: 1,
@@ -1835,7 +1842,7 @@ mod test {
             );
         }
 
-        // Pixels in the newly added area should get filled with the value provided
+        // Pixels in the newly added area should get filled with zeroes.
         assert!(matches!(
             image.get_color_at(3, 3),
             Ok(Color::LinearRgba(GROW_FILL))
@@ -1843,7 +1850,7 @@ mod test {
 
         // Shrink
         image
-            .resize_in_place_2d(Extent3d {
+            .resize_in_place(Extent3d {
                 width: 1,
                 height: 1,
                 depth_or_array_layers: 1,
@@ -1852,5 +1859,103 @@ mod test {
 
         // Images outside of the new dimensions should be clipped
         assert!(image.get_color_at(1, 1).is_err());
+    }
+
+    #[test]
+    fn resize_in_place_array_grow_and_shrink() {
+        use bevy_color::ColorToPacked;
+
+        const INITIAL_FILL: LinearRgba = LinearRgba::BLACK;
+        const GROW_FILL: LinearRgba = LinearRgba::NONE;
+        const LAYERS: u32 = 4;
+
+        let mut image = Image::new_fill(
+            Extent3d {
+                width: 2,
+                height: 2,
+                depth_or_array_layers: LAYERS,
+            },
+            TextureDimension::D2,
+            &INITIAL_FILL.to_u8_array(),
+            TextureFormat::Rgba8Unorm,
+            RenderAssetUsages::MAIN_WORLD,
+        );
+
+        // Create a test pattern
+
+        const TEST_PIXELS: [(u32, u32, LinearRgba); 3] = [
+            (0, 1, LinearRgba::RED),
+            (1, 1, LinearRgba::GREEN),
+            (1, 0, LinearRgba::BLUE),
+        ];
+
+        for z in 0..LAYERS {
+            for (x, y, color) in &TEST_PIXELS {
+                image
+                    .set_color_at_3d(*x, *y, z, Color::from(*color))
+                    .unwrap();
+            }
+        }
+
+        // Grow image
+        image
+            .resize_in_place(Extent3d {
+                width: 4,
+                height: 4,
+                depth_or_array_layers: LAYERS,
+            })
+            .unwrap();
+
+        // After growing, the test pattern should be the same.
+        assert!(matches!(
+            image.get_color_at(0, 0),
+            Ok(Color::LinearRgba(INITIAL_FILL))
+        ));
+        for z in 0..LAYERS {
+            for (x, y, color) in &TEST_PIXELS {
+                assert_eq!(
+                    image.get_color_at_3d(*x, *y, z).unwrap(),
+                    Color::LinearRgba(*color)
+                );
+            }
+        }
+
+        // Pixels in the newly added area should get filled with zeroes.
+        for z in 0..LAYERS {
+            assert!(matches!(
+                image.get_color_at_3d(3, 3, z),
+                Ok(Color::LinearRgba(GROW_FILL))
+            ));
+        }
+
+        // Shrink
+        image
+            .resize_in_place(Extent3d {
+                width: 1,
+                height: 1,
+                depth_or_array_layers: 1,
+            })
+            .unwrap();
+
+        // Images outside of the new dimensions should be clipped
+        assert!(image.get_color_at_3d(1, 1, 0).is_err());
+
+        // Higher layers should no longer be present
+        assert!(image.get_color_at_3d(0, 0, 1).is_err());
+
+        // Grow layers
+        image
+            .resize_in_place(Extent3d {
+                width: 1,
+                height: 1,
+                depth_or_array_layers: 2,
+            })
+            .unwrap();
+
+        // Pixels in the newly added layer should be zeroes.
+        assert!(matches!(
+            image.get_color_at_3d(0, 0, 1),
+            Ok(Color::LinearRgba(GROW_FILL))
+        ));
     }
 }


### PR DESCRIPTION
# Objective

Ultimately, I'd like to modify our font atlas creation systems so that they are able to resize the font atlases as more glyphs are added. At the moment, they create a new 512x512 atlas every time one fills up. With large font sizes and many glyphs, your glyphs may end up spread out across several atlases.

The goal would be to render text more efficiently, because glyphs spread across fewer textures could benefit more from batching.

`AtlasAllocator` already has support for growing atlases, but we don't currently have a way of growing a texture while keeping the pixel data intact.

## Solution

Add a new method to `Image`: `resize_in_place` and a test for it.

## Testing

Ran the new test, and also a little demo comparing this side-by-side with `resize`.

<details>
<summary>Expand Code</summary>

```rust
//! Testing ground for #19410

use bevy::prelude::*;
use bevy_render::render_resource::Extent3d;

fn main() {
    App::new()
        .add_plugins(DefaultPlugins)
        .add_systems(Startup, setup)
        .add_systems(Update, test)
        .init_resource::<Size>()
        .insert_resource(FillColor(Hsla::hsl(0.0, 1.0, 0.7)))
        .run();
}

#[derive(Resource, Default)]
struct Size(Option<UVec2>);
#[derive(Resource)]
struct FillColor(Hsla);
#[derive(Component)]
struct InPlace;

fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
    commands.spawn(Camera2d);

    commands.spawn((
        Transform::from_xyz(220.0, 0.0, 0.0),
        Sprite::from_image(asset_server.load("branding/bevy_bird_dark.png")),
    ));

    commands.spawn((
        InPlace,
        Transform::from_xyz(-220.0, 0.0, 0.0),
        Sprite::from_image(asset_server.load("branding/icon.png")),
    ));
}

fn test(
    sprites: Query<(&Sprite, Has<InPlace>)>,
    mut images: ResMut<Assets<Image>>,
    mut new_size: ResMut<Size>,
    mut dir: Local<IVec2>,
    mut color: ResMut<FillColor>,
) -> Result {
    for (sprite, in_place) in &sprites {
        let image = images.get_mut(&sprite.image).ok_or("Image not found")?;
        let size = new_size.0.get_or_insert(image.size());

        if *dir == IVec2::ZERO {
            *dir = IVec2::splat(1);
        }

        *size = size.saturating_add_signed(*dir);

        if size.x > 400 || size.x < 150 {
            *dir = *dir * -1;
        }

        color.0 = color.0.rotate_hue(1.0);

        if in_place {
            image.resize_in_place_2d(
                Extent3d {
                    width: size.x,
                    height: size.y,
                    ..default()
                },
                &Srgba::from(color.0).to_u8_array(),
            )?;
        } else {
            image.resize(Extent3d {
                width: size.x,
                height: size.y,
                ..default()
            });
        }
    }

    Ok(())
}
```
</details>

https://github.com/user-attachments/assets/6b2d0ec3-6a6e-4da1-98aa-29e7162f16fa

## Alternatives

I think that this might be useful functionality outside of the font atlas scenario, but we *could* just increase the initial font atlas size, make it configurable, and/or size font atlases according to device limits. It's not totally clear to me how to accomplish that last idea.