### PR TITLE
Updating mesh_picking doc to include RenderAssetUsages

### DIFF
--- a/crates/bevy_picking/src/mesh_picking/mod.rs
+++ b/crates/bevy_picking/src/mesh_picking/mod.rs
@@ -1,7 +1,7 @@
 //! A [mesh ray casting](ray_cast) backend for [`bevy_picking`](crate).
 //!
-//! By default, all meshes are pickable. Picking can be disabled for individual entities
-//! by adding [`Pickable::IGNORE`].
+//! By default, all meshes that have both asset_usage [`RenderAssetUsages::MAIN_WORLD`] and [`RenderAssetUsages::RENDER_WORLD`] pickable.
+//! Picking can be disabled for individual entities by adding [`Pickable::IGNORE`].
 //!
 //! To make mesh picking entirely opt-in, set [`MeshPickingSettings::require_markers`]
 //! to `true` and add [`MeshPickingCamera`] and [`Pickable`] components to the desired camera and


### PR DESCRIPTION
# Objective
Fixes #19102 

Updating mesh_picking doc stating that MAIN_WORLD and RENDER_WORLD RenderAssetUsages needs to be on the mesh to be picked.