### PR TITLE
Fix the game of life example panicking if the pipeline shader isn't ready on the first frame.

### DIFF
--- a/examples/shader/compute_shader_game_of_life.rs
+++ b/examples/shader/compute_shader_game_of_life.rs
@@ -229,6 +229,8 @@ impl render_graph::Node for GameOfLifeNode {
                     CachedPipelineState::Ok(_) => {
                         self.state = GameOfLifeState::Init;
                     }
+                    // If the shader hasn't loaded yet, just wait.
+                    CachedPipelineState::Err(PipelineCacheError::ShaderNotLoaded(_)) => {}
                     CachedPipelineState::Err(err) => {
                         panic!("Initializing assets/{SHADER_ASSET_PATH}:\n{err}")
                     }


### PR DESCRIPTION
# Objective

- Due to recent changes related to #19024, the `compute_shader_game_of_life` example panics on some machines especially on Linux.
- This is due to us switching more shaders to embedded shaders - this means the compute shader in this example takes more than one frame to load.
- The panic in the example occurs if the shader fails to load by the first frame (since the pipeline considers that an error).

## Solution

- Make the example do nothing if the shader isn't loaded yet. This has the effect of waiting for the shader to load.

## Testing

- Tested the example on my Linux laptop.