### PR TITLE
Replace (`Partial`)`Ord` for `EntityGeneration` with corrected standalone method

### DIFF
--- a/crates/bevy_ecs/src/entity/map_entities.rs
+++ b/crates/bevy_ecs/src/entity/map_entities.rs
@@ -358,7 +358,10 @@ mod tests {
         // Next allocated entity should be a further generation on the same index
         let entity = world.spawn_empty().id();
         assert_eq!(entity.index(), dead_ref.index());
-        assert!(entity.generation() > dead_ref.generation());
+        assert!(entity
+            .generation()
+            .cmp_age_approx(&dead_ref.generation())
+            .is_gt());
     }
 
     #[test]
@@ -373,7 +376,10 @@ mod tests {
         // Next allocated entity should be a further generation on the same index
         let entity = world.spawn_empty().id();
         assert_eq!(entity.index(), dead_ref.index());
-        assert!(entity.generation() > dead_ref.generation());
+        assert!(entity
+            .generation()
+            .cmp_age_approx(&dead_ref.generation())
+            .is_gt());
     }
 
     #[test]

--- a/crates/bevy_ecs/src/entity/map_entities.rs
+++ b/crates/bevy_ecs/src/entity/map_entities.rs
@@ -360,7 +360,7 @@ mod tests {
         assert_eq!(entity.index(), dead_ref.index());
         assert!(entity
             .generation()
-            .cmp_age_approx(&dead_ref.generation())
+            .cmp_approx(&dead_ref.generation())
             .is_gt());
     }
 
@@ -378,7 +378,7 @@ mod tests {
         assert_eq!(entity.index(), dead_ref.index());
         assert!(entity
             .generation()
-            .cmp_age_approx(&dead_ref.generation())
+            .cmp_approx(&dead_ref.generation())
             .is_gt());
     }
 

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -282,7 +282,7 @@ impl Ord for EntityGeneration {
         use core::cmp::Ordering;
         match self.0.wrapping_sub(other.0) {
             0 => Ordering::Equal,
-            ..Self::DIFF_MAX => Ordering::Greater,
+            1..Self::DIFF_MAX => Ordering::Greater,
             _ => Ordering::Less,
         }
     }

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -255,11 +255,11 @@ impl EntityGeneration {
     /// # use bevy_ecs::entity::EntityGeneration;
     /// # use core::cmp::Ordering;
     /// let later_generation = EntityGeneration::FIRST.after_versions(400);
-    /// assert_eq!(EntityGeneration::FIRST.cmp_age_approx(&later_generation), Ordering::Less);
+    /// assert_eq!(EntityGeneration::FIRST.cmp_approx(&later_generation), Ordering::Less);
     ///
     /// let (aliased, did_alias) = EntityGeneration::FIRST.after_versions(400).after_versions_and_could_alias(u32::MAX);
     /// assert!(did_alias);
-    /// assert_eq!(EntityGeneration::FIRST.cmp_age_approx(&aliased), Ordering::Less);
+    /// assert_eq!(EntityGeneration::FIRST.cmp_approx(&aliased), Ordering::Less);
     /// ```
     ///
     /// Ordering will be incorrect and [non-transitive](https://en.wikipedia.org/wiki/Transitive_relation)
@@ -272,16 +272,16 @@ impl EntityGeneration {
     /// let much_later_generation = later_generation.after_versions(3u32 << 31);
     ///
     /// // while these orderings are correct and pass assertions...
-    /// assert_eq!(EntityGeneration::FIRST.cmp_age_approx(&later_generation), Ordering::Less);
-    /// assert_eq!(later_generation.cmp_age_approx(&much_later_generation), Ordering::Less);
+    /// assert_eq!(EntityGeneration::FIRST.cmp_approx(&later_generation), Ordering::Less);
+    /// assert_eq!(later_generation.cmp_approx(&much_later_generation), Ordering::Less);
     ///
     /// // ... this ordering is not and the assertion fails!
-    /// assert_eq!(EntityGeneration::FIRST.cmp_age_approx(&much_later_generation), Ordering::Less);
+    /// assert_eq!(EntityGeneration::FIRST.cmp_approx(&much_later_generation), Ordering::Less);
     /// ```
     ///
     /// Because of this, `EntityGeneration` does not implement `Ord`/`PartialOrd`.
     #[inline]
-    pub const fn cmp_age_approx(self, other: &Self) -> core::cmp::Ordering {
+    pub const fn cmp_approx(self, other: &Self) -> core::cmp::Ordering {
         use core::cmp::Ordering;
         match self.0.wrapping_sub(other.0) {
             0 => Ordering::Equal,
@@ -1433,7 +1433,7 @@ mod tests {
         assert_eq!(next_entity.index(), entity.index());
         assert!(next_entity
             .generation()
-            .cmp_age_approx(&entity.generation().after_versions(GENERATIONS))
+            .cmp_approx(&entity.generation().after_versions(GENERATIONS))
             .is_gt());
     }
 
@@ -1630,14 +1630,11 @@ mod tests {
         let younger_before_ord_wrap = middle.after_versions(EntityGeneration::DIFF_MAX);
         let younger_after_ord_wrap = younger_before_ord_wrap.after_versions(1);
 
-        assert_eq!(middle.cmp_age_approx(&old), Ordering::Greater);
-        assert_eq!(middle.cmp_age_approx(&middle), Ordering::Equal);
+        assert_eq!(middle.cmp_approx(&old), Ordering::Greater);
+        assert_eq!(middle.cmp_approx(&middle), Ordering::Equal);
+        assert_eq!(middle.cmp_approx(&younger_before_ord_wrap), Ordering::Less);
         assert_eq!(
-            middle.cmp_age_approx(&younger_before_ord_wrap),
-            Ordering::Less
-        );
-        assert_eq!(
-            middle.cmp_age_approx(&younger_after_ord_wrap),
+            middle.cmp_approx(&younger_after_ord_wrap),
             Ordering::Greater
         );
     }

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -281,7 +281,7 @@ impl EntityGeneration {
     ///
     /// Because of this, `EntityGeneration` does not implement `Ord`/`PartialOrd`.
     #[inline]
-    pub const fn cmp_approx(self, other: &Self) -> core::cmp::Ordering {
+    pub const fn cmp_approx(&self, other: &Self) -> core::cmp::Ordering {
         use core::cmp::Ordering;
         match self.0.wrapping_sub(other.0) {
             0 => Ordering::Equal,

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -235,7 +235,7 @@ impl EntityGeneration {
     /// Represents the first generation of an [`EntityRow`].
     pub const FIRST: Self = Self(0);
 
-    /// Non-wrapping difference between two generations where a signed interpretation becomes negative.
+    /// Non-wrapping difference between two generations after which a signed interpretation becomes negative.
     const DIFF_MAX: u32 = 1u32 << 31;
 
     /// Gets some bits that represent this value.


### PR DESCRIPTION
# Objective

#19421 implemented `Ord` for `EntityGeneration` along the lines of [the impl from slotmap](https://docs.rs/slotmap/latest/src/slotmap/util.rs.html#8):
```rs
/// Returns if a is an older version than b, taking into account wrapping of
/// versions.
pub fn is_older_version(a: u32, b: u32) -> bool {
    let diff = a.wrapping_sub(b);
    diff >= (1 << 31)
}
```

But that PR and the slotmap impl are different:

**slotmap impl**
- if `(1u32 << 31)` is greater than `a.wrapping_sub(b)`, then `a` is older than `b`
- if `(1u32 << 31)` is equal to `a.wrapping_sub(b)`, then `a` is older than `b`
- if `(1u32 << 31)` is less than `a.wrapping_sub(b)`, then `a` is equal or newer than `b`

**previous PR impl**
- if `(1u32 << 31)` is greater than `a.wrapping_sub(b)`, then `a` is older than `b`
- if `(1u32 << 31)` is equal to `a.wrapping_sub(b)`, then `a` is equal to `b` :warning: 
- if `(1u32 << 31)` is less than `a.wrapping_sub(b)`, then `a` is newer than `b` :warning: 

This ordering is also not transitive, therefore it should not implement `PartialOrd`.

## Solution

Fix the impl in a standalone method, remove the `Partialord`/`Ord` implementation.

## Testing

Given the first impl was wrong and got past reviews, I think a new unit test is justified.