### PR TITLE
Error when `#[entities]` is on the wrong part

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -191,13 +191,15 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
 pub fn derive_map_entities(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
     let ecs_path = bevy_ecs_path();
-
-    let map_entities_impl = map_entities(
+    let map_entities_impl = match map_entities(
         &ast.data,
         Ident::new("self", Span::call_site()),
         false,
         false,
-    );
+    ) {
+        Ok(map) => map,
+        Err(err) => return err.into_compile_error().into(),
+    };
 
     let struct_name = &ast.ident;
     let (impl_generics, type_generics, where_clause) = &ast.generics.split_for_impl();


### PR DESCRIPTION
# Objective

fixes #19346

## Solution

Error when a attribute is on the variant, ideally we would want this not to error for variants with just one unnamed fied, but then we would need different functions for when doing it for components, or for doing it with the derive macro.
