### PR TITLE
Schedule build pass maintenance

### DIFF
--- a/crates/bevy_ecs/src/schedule/auto_insert_apply_deferred.rs
+++ b/crates/bevy_ecs/src/schedule/auto_insert_apply_deferred.rs
@@ -221,6 +221,8 @@ impl ScheduleBuildPass for AutoInsertApplyDeferredPass {
         &mut self,
         set: SystemSetKey,
         systems: &[SystemKey],
+        _world: &mut World,
+        _graph: &mut ScheduleGraph,
         dependency_flattening: &DiGraph<NodeId>,
     ) -> impl Iterator<Item = (NodeId, NodeId)> {
         if systems.is_empty() {

--- a/crates/bevy_ecs/src/schedule/node.rs
+++ b/crates/bevy_ecs/src/schedule/node.rs
@@ -643,7 +643,7 @@ impl SystemSets {
 
     /// Returns a reference to the system set with the given key, if it exists.
     pub fn get(&self, key: SystemSetKey) -> Option<InternedSystemSet> {
-        self.sets.get(key).map(|set| *set)
+        self.sets.get(key).copied()
     }
 
     /// Returns the key for the given system set, inserting it into this

--- a/crates/bevy_ecs/src/schedule/node.rs
+++ b/crates/bevy_ecs/src/schedule/node.rs
@@ -642,8 +642,8 @@ impl SystemSets {
     }
 
     /// Returns a reference to the system set with the given key, if it exists.
-    pub fn get(&self, key: SystemSetKey) -> Option<&dyn SystemSet> {
-        self.sets.get(key).map(|set| &**set)
+    pub fn get(&self, key: SystemSetKey) -> Option<InternedSystemSet> {
+        self.sets.get(key).map(|set| *set)
     }
 
     /// Returns the key for the given system set, inserting it into this
@@ -682,10 +682,10 @@ impl SystemSets {
     /// their conditions.
     pub fn iter(
         &self,
-    ) -> impl Iterator<Item = (SystemSetKey, &dyn SystemSet, &[ConditionWithAccess])> {
+    ) -> impl Iterator<Item = (SystemSetKey, InternedSystemSet, &[ConditionWithAccess])> {
         self.sets.iter().filter_map(|(key, set)| {
             let conditions = self.conditions.get(key)?.as_slice();
-            Some((key, &**set, conditions))
+            Some((key, *set, conditions))
         })
     }
 
@@ -739,11 +739,11 @@ impl SystemSets {
 }
 
 impl Index<SystemSetKey> for SystemSets {
-    type Output = dyn SystemSet;
+    type Output = InternedSystemSet;
 
     #[track_caller]
     fn index(&self, key: SystemSetKey) -> &Self::Output {
-        self.get(key).unwrap_or_else(|| {
+        self.sets.get(key).unwrap_or_else(|| {
             panic!(
                 "System set with key {:?} does not exist in the schedule",
                 key

--- a/crates/bevy_ecs/src/schedule/pass.rs
+++ b/crates/bevy_ecs/src/schedule/pass.rs
@@ -25,7 +25,7 @@ pub trait ScheduleBuildPass: Send + Sync + Debug + 'static {
         _world: &mut World,
         _graph: &mut ScheduleGraph,
     ) -> impl Iterator<Item = SystemKey> {
-        std::iter::empty()
+        core::iter::empty()
     }
 
     /// Called while flattening the dependency graph. For each `set`, this method is called
@@ -39,7 +39,7 @@ pub trait ScheduleBuildPass: Send + Sync + Debug + 'static {
         _graph: &mut ScheduleGraph,
         _dependency_flattening: &DiGraph<NodeId>,
     ) -> impl Iterator<Item = (NodeId, NodeId)> {
-        std::iter::empty()
+        core::iter::empty()
     }
 
     /// The implementation will be able to modify the `ScheduleGraph` here.

--- a/crates/bevy_ecs/src/schedule/pass.rs
+++ b/crates/bevy_ecs/src/schedule/pass.rs
@@ -17,25 +17,40 @@ pub trait ScheduleBuildPass: Send + Sync + Debug + 'static {
     /// Called when a dependency between sets or systems was explicitly added to the graph.
     fn add_dependency(&mut self, from: NodeId, to: NodeId, options: Option<&Self::EdgeOptions>);
 
+    /// Called when mapping system sets to systems. Implementations may return an iterator of additional systems to be
+    /// associated with the system set.
+    fn map_set_to_systems(
+        &mut self,
+        _set: SystemSetKey,
+        _world: &mut World,
+        _graph: &mut ScheduleGraph,
+    ) -> impl Iterator<Item = SystemKey> {
+        std::iter::empty()
+    }
+
     /// Called while flattening the dependency graph. For each `set`, this method is called
     /// with the `systems` associated with the set as well as an immutable reference to the current graph.
     /// Instead of modifying the graph directly, this method should return an iterator of edges to add to the graph.
     fn collapse_set(
         &mut self,
-        set: SystemSetKey,
-        systems: &[SystemKey],
-        world: &mut World,
-        graph: &mut ScheduleGraph,
-        dependency_flattening: &DiGraph<NodeId>,
-    ) -> impl Iterator<Item = (NodeId, NodeId)>;
+        _set: SystemSetKey,
+        _systems: &[SystemKey],
+        _world: &mut World,
+        _graph: &mut ScheduleGraph,
+        _dependency_flattening: &DiGraph<NodeId>,
+    ) -> impl Iterator<Item = (NodeId, NodeId)> {
+        std::iter::empty()
+    }
 
     /// The implementation will be able to modify the `ScheduleGraph` here.
     fn build(
         &mut self,
-        world: &mut World,
-        graph: &mut ScheduleGraph,
-        dependency_flattened: &mut DiGraph<SystemKey>,
-    ) -> Result<(), ScheduleBuildError>;
+        _world: &mut World,
+        _graph: &mut ScheduleGraph,
+        _dependency_flattened: &mut DiGraph<SystemKey>,
+    ) -> Result<(), ScheduleBuildError> {
+        Ok(())
+    }
 }
 
 /// Object safe version of [`ScheduleBuildPass`].
@@ -46,6 +61,14 @@ pub(super) trait ScheduleBuildPassObj: Any + Send + Sync + Debug {
         graph: &mut ScheduleGraph,
         dependency_flattened: &mut DiGraph<SystemKey>,
     ) -> Result<(), ScheduleBuildError>;
+
+    fn map_set_to_systems(
+        &mut self,
+        set: SystemSetKey,
+        systems: &mut Vec<SystemKey>,
+        world: &mut World,
+        graph: &mut ScheduleGraph,
+    );
 
     fn collapse_set(
         &mut self,
@@ -67,6 +90,15 @@ impl<T: ScheduleBuildPass> ScheduleBuildPassObj for T {
         dependency_flattened: &mut DiGraph<SystemKey>,
     ) -> Result<(), ScheduleBuildError> {
         self.build(world, graph, dependency_flattened)
+    }
+    fn map_set_to_systems(
+        &mut self,
+        set: SystemSetKey,
+        systems: &mut Vec<SystemKey>,
+        world: &mut World,
+        graph: &mut ScheduleGraph,
+    ) {
+        systems.extend(self.map_set_to_systems(set, world, graph));
     }
     fn collapse_set(
         &mut self,

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -1088,7 +1088,7 @@ impl ScheduleGraph {
                 }
             }
 
-            let mut passes = std::mem::take(&mut self.passes);
+            let mut passes = core::mem::take(&mut self.passes);
             for pass in passes.values_mut() {
                 pass.map_set_to_systems(set_key, &mut systems, world, self);
             }

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -1008,8 +1008,11 @@ impl ScheduleGraph {
 
         // map all system sets to their systems
         // go in reverse topological order (bottom-up) for efficiency
-        let (set_systems, set_system_bitsets) =
-            self.map_sets_to_systems(&self.hierarchy.topsort, &self.hierarchy.graph);
+        let set_systems = self.map_sets_to_systems(world);
+        let set_system_bitsets = set_systems
+            .iter()
+            .map(|(key, systems)| (*key, systems.iter().copied().collect()))
+            .collect();
         self.check_order_but_intersect(&dep_results.connected, &set_system_bitsets)?;
 
         // check that there are no edges to system-type sets that have multiple instances
@@ -1062,45 +1065,38 @@ impl ScheduleGraph {
     /// Return a map from system set `NodeId` to a list of system `NodeId`s that are included in the set.
     /// Also return a map from system set `NodeId` to a `FixedBitSet` of system `NodeId`s that are included in the set,
     /// where the bitset order is the same as `self.systems`
-    fn map_sets_to_systems(
-        &self,
-        hierarchy_topsort: &[NodeId],
-        hierarchy_graph: &DiGraph<NodeId>,
-    ) -> (
-        HashMap<SystemSetKey, Vec<SystemKey>>,
-        HashMap<SystemSetKey, HashSet<SystemKey>>,
-    ) {
+    fn map_sets_to_systems(&mut self, world: &mut World) -> HashMap<SystemSetKey, Vec<SystemKey>> {
         let mut set_systems: HashMap<SystemSetKey, Vec<SystemKey>> =
             HashMap::with_capacity_and_hasher(self.system_sets.len(), Default::default());
-        let mut set_system_sets: HashMap<SystemSetKey, HashSet<SystemKey>> =
-            HashMap::with_capacity_and_hasher(self.system_sets.len(), Default::default());
-        for &id in hierarchy_topsort.iter().rev() {
+        let toposort = self.hierarchy.topsort.clone();
+        for &id in toposort.iter().rev() {
             let NodeId::Set(set_key) = id else {
                 continue;
             };
 
             let mut systems = Vec::new();
-            let mut system_set = HashSet::with_capacity(self.systems.len());
 
-            for child in hierarchy_graph.neighbors_directed(id, Outgoing) {
+            for child in self.hierarchy.graph.neighbors_directed(id, Outgoing) {
                 match child {
                     NodeId::System(key) => {
                         systems.push(key);
-                        system_set.insert(key);
                     }
                     NodeId::Set(key) => {
                         let child_systems = set_systems.get(&key).unwrap();
-                        let child_system_set = set_system_sets.get(&key).unwrap();
                         systems.extend_from_slice(child_systems);
-                        system_set.extend(child_system_set.iter());
                     }
                 }
             }
 
+            let mut passes = std::mem::take(&mut self.passes);
+            for pass in passes.values_mut() {
+                pass.map_set_to_systems(set_key, &mut systems, world, self);
+            }
+            self.passes = passes;
             set_systems.insert(set_key, systems);
-            set_system_sets.insert(set_key, system_set);
         }
-        (set_systems, set_system_sets)
+
+        set_systems
     }
 
     fn get_dependency_flattened(

--- a/release-content/migration-guides/schedule-build-pass.md
+++ b/release-content/migration-guides/schedule-build-pass.md
@@ -1,0 +1,16 @@
+---
+title: Schedule Build Pass API changes
+pull_requests: [19450]
+---
+
+The schedule build pass API was improved to provide more context and flexabilities.
+
+# Summary of Changes
+
+- Breaking Change: The ScheduleBuildPass trait methods (`collapse_set` and `build`) have been updated with new parameters `(&mut World, &mut ScheduleGraph)` to provide more context.
+
+- New Feature: A new method, map_set_to_systems, has been added to the ScheduleBuildPass trait, allowing passes to dynamically add systems to a set.
+
+
+# Migration Steps
+If you have custom implementations of `ScheduleBuildPass`, you will need to update the method signatures for the `collapse_set` and `build` methods by adding the `world` and `schedule` parameters.

--- a/release-content/migration-guides/schedule-build-pass.md
+++ b/release-content/migration-guides/schedule-build-pass.md
@@ -5,12 +5,10 @@ pull_requests: [19450]
 
 The schedule build pass API was improved to provide more context and flexabilities.
 
-# Summary of Changes
-
+## Summary of Changes
 - Breaking Change: The ScheduleBuildPass trait methods (`collapse_set` and `build`) have been updated with new parameters `(&mut World, &mut ScheduleGraph)` to provide more context.
 
 - New Feature: A new method, `map_set_to_systems`, has been added to the ScheduleBuildPass trait, allowing passes to dynamically add systems to a set.
 
-
-# Migration Steps
+## Migration Steps
 If you have custom implementations of `ScheduleBuildPass`, you will need to update the method signatures for the `collapse_set` and `build` methods by adding the `world` and `schedule` parameters.

--- a/release-content/migration-guides/schedule-build-pass.md
+++ b/release-content/migration-guides/schedule-build-pass.md
@@ -6,9 +6,11 @@ pull_requests: [19450]
 The schedule build pass API was improved to provide more context and flexabilities.
 
 ## Summary of Changes
+
 - Breaking Change: The ScheduleBuildPass trait methods (`collapse_set` and `build`) have been updated with new parameters `(&mut World, &mut ScheduleGraph)` to provide more context.
 
 - New Feature: A new method, `map_set_to_systems`, has been added to the ScheduleBuildPass trait, allowing passes to dynamically add systems to a set.
 
 ## Migration Steps
+
 If you have custom implementations of `ScheduleBuildPass`, you will need to update the method signatures for the `collapse_set` and `build` methods by adding the `world` and `schedule` parameters.

--- a/release-content/migration-guides/schedule-build-pass.md
+++ b/release-content/migration-guides/schedule-build-pass.md
@@ -9,7 +9,7 @@ The schedule build pass API was improved to provide more context and flexabiliti
 
 - Breaking Change: The ScheduleBuildPass trait methods (`collapse_set` and `build`) have been updated with new parameters `(&mut World, &mut ScheduleGraph)` to provide more context.
 
-- New Feature: A new method, map_set_to_systems, has been added to the ScheduleBuildPass trait, allowing passes to dynamically add systems to a set.
+- New Feature: A new method, `map_set_to_systems`, has been added to the ScheduleBuildPass trait, allowing passes to dynamically add systems to a set.
 
 
 # Migration Steps


### PR DESCRIPTION
# Objective
- Add `get_build_pass_mut` method to `Schedule`. This requires `ScheduleBuildPassObj` to add an `Any` bound.
  In #19217 it was suggested that a `get_build_pass_mut` API be added to `Schedule`. At the time we decided against that because #18984 was still open. Now that #18984 is merged, we can finally do this.
- Pass `&mut World` and `&mut ScheduleGraph` down into `ScheduleBuildPass::collapse_set` as well. This allows the `collapse_set` method to interact with the world and the schedule.
- `get_set_at` and `set_at methods` to return an InternedSystemSet instead of `&mut dyn SystemSet`. InternedSystemSet dereferences to `&mut dyn SystemSet` so this is non-breaking, but InternedSystemSet is `'static` and `clonable`, giving users more flexibility.
- Add `map_set_to_systems` hook to schedule build passes which allows the user to specify that a system set covers additional systems.