### PR TITLE
Remove entity reserving/pending/flushing system

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1579,7 +1579,7 @@ mod tests {
         app.add_systems(EnterMainMenu, (foo, bar));
 
         app.world_mut().run_schedule(EnterMainMenu);
-        assert_eq!(app.world().entities().len(), 2);
+        assert_eq!(app.world().entities().count_active(), 2);
     }
 
     #[test]

--- a/crates/bevy_diagnostic/src/entity_count_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/entity_count_diagnostics_plugin.rs
@@ -22,6 +22,6 @@ impl EntityCountDiagnosticsPlugin {
     pub const ENTITY_COUNT: DiagnosticPath = DiagnosticPath::const_new("entity_count");
 
     pub fn diagnostic_system(mut diagnostics: Diagnostics, entities: &Entities) {
-        diagnostics.add_measurement(&Self::ENTITY_COUNT, || entities.len() as f64);
+        diagnostics.add_measurement(&Self::ENTITY_COUNT, || entities.count_active() as f64);
     }
 }

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -1737,7 +1737,7 @@ impl<'w> BundleSpawner<'w> {
                 caller,
             );
             entities.set(entity.index(), Some(location));
-            entities.mark_spawn_despawn(entity.index(), caller, self.change_tick);
+            entities.mark_construct_or_destruct(entity.index(), caller, self.change_tick);
             (location, after_effect)
         };
 

--- a/crates/bevy_ecs/src/entity/clone_entities.rs
+++ b/crates/bevy_ecs/src/entity/clone_entities.rs
@@ -540,9 +540,6 @@ impl EntityCloner {
             }
         }
 
-        world.flush();
-        world.entity_mut(target);
-
         for deferred in self.deferred_commands.drain(..) {
             (deferred)(world, mapper);
         }

--- a/crates/bevy_ecs/src/entity/clone_entities.rs
+++ b/crates/bevy_ecs/src/entity/clone_entities.rs
@@ -469,12 +469,14 @@ impl EntityCloner {
         {
             let world = world.as_unsafe_world_cell();
             let source_entity = world.get_entity(source).expect("Source entity must exist");
-            let target_archetype = (!self.filter_required.is_empty()).then(|| {
-                world
-                    .get_entity(target)
-                    .expect("Target entity must exist")
-                    .archetype()
-            });
+            let target_archetype = (!self.filter_required.is_empty())
+                .then(|| {
+                    world
+                        .get_entity(target)
+                        .expect("Target entity must exist")
+                        .archetype()
+                })
+                .flatten();
 
             #[cfg(feature = "bevy_reflect")]
             // SAFETY: we have unique access to `world`, nothing else accesses the registry at this moment, and we clone

--- a/crates/bevy_ecs/src/entity/clone_entities.rs
+++ b/crates/bevy_ecs/src/entity/clone_entities.rs
@@ -487,7 +487,10 @@ impl EntityCloner {
             #[cfg(not(feature = "bevy_reflect"))]
             let app_registry = Option::<()>::None;
 
-            let archetype = source_entity.archetype();
+            let Some(archetype) = source_entity.archetype() else {
+                // If the source has no archetype, there is nothing to clone.
+                return target;
+            };
             bundle_scratch = BundleScratch::with_capacity(archetype.component_count());
 
             for component in archetype.components() {

--- a/crates/bevy_ecs/src/entity/map_entities.rs
+++ b/crates/bevy_ecs/src/entity/map_entities.rs
@@ -53,7 +53,7 @@ use super::EntityIndexSet;
 pub trait MapEntities {
     /// Updates all [`Entity`] references stored inside using `entity_mapper`.
     ///
-    /// Implementors should look up any and all [`Entity`] values stored within `self` and
+    /// Implementers should look up any and all [`Entity`] values stored within `self` and
     /// update them to the mapped values via `entity_mapper`.
     fn map_entities<E: EntityMapper>(&mut self, entity_mapper: &mut E);
 }
@@ -152,7 +152,7 @@ impl<T: MapEntities, A: smallvec::Array<Item = T>> MapEntities for SmallVec<A> {
 ///
 /// More generally, this can be used to map [`Entity`] references between any two [`Worlds`](World).
 ///
-/// This is used by [`MapEntities`] implementors.
+/// This is used by [`MapEntities`] implementers.
 ///
 /// ## Example
 ///
@@ -286,14 +286,10 @@ impl<'m> SceneEntityMapper<'m> {
     }
 
     /// Creates a new [`SceneEntityMapper`], spawning a temporary base [`Entity`] in the provided [`World`]
-    pub fn new(map: &'m mut EntityHashMap<Entity>, world: &mut World) -> Self {
-        // We're going to be calling methods on `Entities` that require advance
-        // flushing, such as `alloc` and `free`.
-        world.flush_entities();
+    pub fn new(map: &'m mut EntityHashMap<Entity>, world: &World) -> Self {
         Self {
             map,
-            // SAFETY: Entities data is kept in a valid state via `EntityMapper::world_scope`
-            dead_start: unsafe { world.entities_mut().alloc() },
+            dead_start: world.allocator.alloc(),
             generations: 0,
         }
     }
@@ -302,10 +298,10 @@ impl<'m> SceneEntityMapper<'m> {
     /// [`Entity`] while reserving extra generations. Because this makes the [`SceneEntityMapper`] unable to
     /// safely allocate any more references, this method takes ownership of `self` in order to render it unusable.
     pub fn finish(self, world: &mut World) {
-        // SAFETY: Entities data is kept in a valid state via `EntityMap::world_scope`
-        let entities = unsafe { world.entities_mut() };
-        assert!(entities.free(self.dead_start).is_some());
-        assert!(entities.reserve_generations(self.dead_start.index(), self.generations));
+        // SAFETY: We never constructed the entity and never released it for something else to construct.
+        unsafe {
+            world.release_generations_unchecked(self.dead_start.row(), self.generations);
+        }
     }
 
     /// Creates an [`SceneEntityMapper`] from a provided [`World`] and [`EntityHashMap<Entity>`], then calls the
@@ -374,22 +370,5 @@ mod tests {
         let entity = world.spawn_empty().id();
         assert_eq!(entity.index(), dead_ref.index());
         assert!(entity.generation() > dead_ref.generation());
-    }
-
-    #[test]
-    fn entity_mapper_no_panic() {
-        let mut world = World::new();
-        // "Dirty" the `Entities`, requiring a flush afterward.
-        world.entities.reserve_entity();
-        assert!(world.entities.needs_flush());
-
-        // Create and exercise a SceneEntityMapper - should not panic because it flushes
-        // `Entities` first.
-        SceneEntityMapper::world_scope(&mut Default::default(), &mut world, |_, m| {
-            m.get_mapped(Entity::PLACEHOLDER);
-        });
-
-        // The SceneEntityMapper should leave `Entities` in a flushed state.
-        assert!(!world.entities.needs_flush());
     }
 }

--- a/crates/bevy_ecs/src/entity/map_entities.rs
+++ b/crates/bevy_ecs/src/entity/map_entities.rs
@@ -334,7 +334,7 @@ mod tests {
     fn entity_mapper() {
         let mut map = EntityHashMap::default();
         let mut world = World::new();
-        let mut mapper = SceneEntityMapper::new(&mut map, &mut world);
+        let mut mapper = SceneEntityMapper::new(&mut map, &world);
 
         let mapped_ent = Entity::from_raw_u32(1).unwrap();
         let dead_ref = mapper.get_mapped(mapped_ent);

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -782,20 +782,19 @@ impl Entities {
     }
 
     /// Returns the [`EntityLocation`] of an [`Entity`].
-    /// Note: for pending entities and entities not participating in the ECS (entities with a [`EntityIdLocation`] of `None`), returns `None`.
+    /// Note: for non-constructed entities, returns `None`.
     #[inline]
     pub fn get(&self, entity: Entity) -> Option<EntityLocation> {
         self.get_id_location(entity).flatten()
     }
 
     /// Returns the [`EntityIdLocation`] of an [`Entity`].
-    /// Note: for pending entities, returns `None`.
     #[inline]
     pub fn get_id_location(&self, entity: Entity) -> Option<EntityIdLocation> {
-        self.meta
-            .get(entity.index() as usize)
-            .filter(|meta| meta.generation == entity.generation)
-            .map(|meta| meta.location)
+        match self.meta.get(entity.index() as usize) {
+            Some(meta) => (meta.generation == entity.generation).then_some(meta.location),
+            None => (entity.generation() == EntityGeneration::FIRST).then_some(None),
+        }
     }
 
     /// Returns true if the entity exists in the world *now*:

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -658,8 +658,9 @@ impl SparseSetIndex for Entity {
     }
 }
 
+/// Allocates [`Entity`] ids uniquely.
 #[derive(Default, Debug)]
-pub(crate) struct EntitiesAllocator {
+pub struct EntitiesAllocator {
     free: Vec<Entity>,
     free_len: AtomicU32,
     next_row: AtomicU32,
@@ -761,7 +762,7 @@ impl Entities {
 
     /// Clears all entity information
     pub fn clear(&mut self) {
-        self.meta.clear()
+        self.meta.clear();
     }
 
     /// Returns the [`EntityLocation`] of an [`Entity`].
@@ -981,10 +982,13 @@ impl Entities {
 /// An error that occurs when a specified [`Entity`] can not be constructed.
 #[derive(thiserror::Error, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConstructionError {
+    /// The [`Entity`] to construct was invalid.
+    /// It probably had the wrong generation or was created erroneously.
     #[error(
         "The entity's id was invalid: either erroneously created or with the wrong generation."
     )]
     InvalidId,
+    /// The [`Entity`] to construct was already constructed.
     #[error("The entity can not be constructed as it already has a location.")]
     AlreadyConstructed,
 }

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -782,6 +782,14 @@ impl Entities {
             .map(|meta| meta.location)
     }
 
+    /// Returns true if the entity exists in the world *now*:
+    /// It has a location, etc.
+    ///
+    /// This will return false if the `entity` is reserved but has not been constructed.
+    pub fn contains(&self, entity: Entity) -> bool {
+        self.get(entity).is_some()
+    }
+
     /// Provides information regarding if `entity` may be constructed.
     #[inline]
     pub fn validate_construction(&self, entity: Entity) -> Result<(), ConstructionError> {

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -827,30 +827,40 @@ impl Entities {
 
     /// Updates the location of an [`EntityRow`].
     /// This must be called when moving the components of the existing entity around in storage.
+    /// Returns the previous location of the row.
     ///
     /// # Safety
     ///  - The current location of the `row` must already be set. If not, try [`declare`](Self::declare).
     ///  - `location` must be valid for the entity at `row` or immediately made valid afterwards
     ///    before handing control to unknown code.
     #[inline]
-    pub(crate) unsafe fn update(&mut self, row: EntityRow, location: EntityIdLocation) {
+    pub(crate) unsafe fn update(
+        &mut self,
+        row: EntityRow,
+        location: EntityIdLocation,
+    ) -> EntityIdLocation {
         // SAFETY: Caller guarantees that `row` already had a location, so `declare` must have made the index valid already.
         let meta = unsafe { self.meta.get_unchecked_mut(row.index() as usize) };
-        meta.location = location;
+        mem::replace(&mut meta.location, location)
     }
 
     /// Declares the location of an [`EntityRow`].
     /// This must be called when constructing/spawning entities.
+    /// Returns the previous location of the row.
     ///
     /// # Safety
     ///  - `location` must be valid for the entity at `index` or immediately made valid afterwards
     ///    before handing control to unknown code.
     #[inline]
-    pub(crate) unsafe fn declare(&mut self, row: EntityRow, location: EntityIdLocation) {
+    pub(crate) unsafe fn declare(
+        &mut self,
+        row: EntityRow,
+        location: EntityIdLocation,
+    ) -> EntityIdLocation {
         self.ensure_row(row);
         // SAFETY: We just did `ensure_row`
         let meta = unsafe { self.meta.get_unchecked_mut(row.index() as usize) };
-        meta.location = location;
+        mem::replace(&mut meta.location, location)
     }
 
     /// Ensures row is valid.

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -978,8 +978,14 @@ impl Entities {
     }
 }
 
+/// An error that occurs when a specified [`Entity`] can not be constructed.
+#[derive(thiserror::Error, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConstructionError {
+    #[error(
+        "The entity's id was invalid: either erroneously created or with the wrong generation."
+    )]
     InvalidId,
+    #[error("The entity can not be constructed as it already has a location.")]
     AlreadyConstructed,
 }
 

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -354,6 +354,36 @@ mod tests {
     }
 
     #[test]
+    fn construct_and_destruct() {
+        let mut world = World::new();
+        let e1 = world.spawn_null();
+        world.construct(e1, (TableStored("abc"), A(123))).unwrap();
+        let e2 = world.spawn_null();
+        assert!(world.destruct(e2).is_some());
+        assert!(world.despawn(e2));
+        let e3 = world.spawn_null();
+        let mut e3 = world.entity_mut(e3);
+        e3.destruct();
+        e3.despawn();
+        let e4 = world.spawn_null();
+        world
+            .entity_mut(e4)
+            .construct((TableStored("junk"), A(0)))
+            .unwrap()
+            .destruct()
+            .construct((TableStored("def"), A(456)))
+            .unwrap();
+
+        assert_eq!(world.entities.count_active(), 2);
+        assert!(world.despawn(e1));
+        assert_eq!(world.entities.count_active(), 1);
+        assert!(world.get::<TableStored>(e1).is_none());
+        assert!(world.get::<A>(e1).is_none());
+        assert_eq!(world.get::<TableStored>(e4).unwrap().0, "def");
+        assert_eq!(world.get::<A>(e4).unwrap().0, 456);
+    }
+
+    #[test]
     fn despawn_table_storage() {
         let mut world = World::new();
         let e = world.spawn((TableStored("abc"), A(123))).id();

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1180,16 +1180,6 @@ mod tests {
     }
 
     #[test]
-    fn reserve_and_spawn() {
-        let mut world = World::default();
-        let e = world.entities().reserve_entity();
-        world.flush_entities();
-        let mut e_mut = world.entity_mut(e);
-        e_mut.insert(A(0));
-        assert_eq!(e_mut.get::<A>().unwrap(), &A(0));
-    }
-
-    #[test]
     fn changed_query() {
         let mut world = World::default();
         let e1 = world.spawn((A(0), B(0))).id();

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -358,9 +358,9 @@ mod tests {
         let mut world = World::new();
         let e = world.spawn((TableStored("abc"), A(123))).id();
         let f = world.spawn((TableStored("def"), A(456))).id();
-        assert_eq!(world.entities.len(), 2);
+        assert_eq!(world.entities.count_active(), 2);
         assert!(world.despawn(e));
-        assert_eq!(world.entities.len(), 1);
+        assert_eq!(world.entities.count_active(), 1);
         assert!(world.get::<TableStored>(e).is_none());
         assert!(world.get::<A>(e).is_none());
         assert_eq!(world.get::<TableStored>(f).unwrap().0, "def");
@@ -373,9 +373,9 @@ mod tests {
 
         let e = world.spawn((TableStored("abc"), SparseStored(123))).id();
         let f = world.spawn((TableStored("def"), SparseStored(456))).id();
-        assert_eq!(world.entities.len(), 2);
+        assert_eq!(world.entities.count_active(), 2);
         assert!(world.despawn(e));
-        assert_eq!(world.entities.len(), 1);
+        assert_eq!(world.entities.count_active(), 1);
         assert!(world.get::<TableStored>(e).is_none());
         assert!(world.get::<SparseStored>(e).is_none());
         assert_eq!(world.get::<TableStored>(f).unwrap().0, "def");
@@ -1610,7 +1610,7 @@ mod tests {
 
         assert_eq!(q1.iter(&world).len(), 1);
         assert_eq!(q2.iter(&world).len(), 1);
-        assert_eq!(world.entities().len(), 2);
+        assert_eq!(world.entities().count_active(), 2);
 
         world.clear_entities();
 
@@ -1625,7 +1625,7 @@ mod tests {
             "world should not contain sparse set components"
         );
         assert_eq!(
-            world.entities().len(),
+            world.entities().count_active(),
             0,
             "world should not have any entities"
         );

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -1079,7 +1079,7 @@ mod tests {
         world.spawn(A).flush();
         assert_eq!(vec!["add_2", "add_1"], world.resource::<Order>().0);
         // Our A entity plus our two observers
-        assert_eq!(world.entities().len(), 3);
+        assert_eq!(world.entities().count_active(), 3);
     }
 
     #[test]

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -316,7 +316,9 @@ impl<'w, 's> Commands<'w, 's> {
             let tick = world.change_tick();
             // SAFETY: Entity has been flushed
             unsafe {
-                world.entities_mut().mark_spawn_despawn(index, caller, tick);
+                world
+                    .entities_mut()
+                    .mark_construct_or_destruct(index, caller, tick);
             }
         });
         entity_commands
@@ -382,7 +384,9 @@ impl<'w, 's> Commands<'w, 's> {
                 let tick = world.change_tick();
                 // SAFETY: Entity has been flushed
                 unsafe {
-                    world.entities_mut().mark_spawn_despawn(index, caller, tick);
+                    world
+                        .entities_mut()
+                        .mark_construct_or_destruct(index, caller, tick);
                 }
             });
 

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -2321,7 +2321,7 @@ mod tests {
             .spawn((W(1u32), W(2u64)))
             .id();
         command_queue.apply(&mut world);
-        assert_eq!(world.entities().len(), 1);
+        assert_eq!(world.entities().count_active(), 1);
         let results = world
             .query::<(&W<u32>, &W<u64>)>()
             .iter(&world)

--- a/crates/bevy_ecs/src/system/commands/parallel_scope.rs
+++ b/crates/bevy_ecs/src/system/commands/parallel_scope.rs
@@ -1,7 +1,7 @@
 use bevy_utils::Parallel;
 
 use crate::{
-    entity::EntitiesAllocator,
+    entity::{Entities, EntitiesAllocator},
     prelude::World,
     system::{Deferred, SystemBuffer, SystemMeta, SystemParam},
 };
@@ -51,7 +51,8 @@ struct ParallelCommandQueue {
 #[derive(SystemParam)]
 pub struct ParallelCommands<'w, 's> {
     state: Deferred<'s, ParallelCommandQueue>,
-    entities: &'w EntitiesAllocator,
+    allocator: &'w EntitiesAllocator,
+    entities: &'w Entities,
 }
 
 impl SystemBuffer for ParallelCommandQueue {
@@ -71,7 +72,7 @@ impl<'w, 's> ParallelCommands<'w, 's> {
     /// For an example, see the type-level documentation for [`ParallelCommands`].
     pub fn command_scope<R>(&self, f: impl FnOnce(Commands) -> R) -> R {
         self.state.thread_queues.scope(|queue| {
-            let commands = Commands::new_from_entities(queue, self.entities);
+            let commands = Commands::new_from_entities(queue, self.allocator, self.entities);
             f(commands)
         })
     }

--- a/crates/bevy_ecs/src/system/commands/parallel_scope.rs
+++ b/crates/bevy_ecs/src/system/commands/parallel_scope.rs
@@ -1,7 +1,7 @@
 use bevy_utils::Parallel;
 
 use crate::{
-    entity::Entities,
+    entity::EntitiesAllocator,
     prelude::World,
     system::{Deferred, SystemBuffer, SystemMeta, SystemParam},
 };
@@ -51,7 +51,7 @@ struct ParallelCommandQueue {
 #[derive(SystemParam)]
 pub struct ParallelCommands<'w, 's> {
     state: Deferred<'s, ParallelCommandQueue>,
-    entities: &'w Entities,
+    entities: &'w EntitiesAllocator,
 }
 
 impl SystemBuffer for ParallelCommandQueue {

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -423,9 +423,9 @@ mod tests {
     #[test]
     fn command_processing() {
         let mut world = World::new();
-        assert_eq!(world.entities.len(), 0);
+        assert_eq!(world.entities.count_active(), 0);
         world.run_system_once(spawn_entity).unwrap();
-        assert_eq!(world.entities.len(), 1);
+        assert_eq!(world.entities.count_active(), 1);
     }
 
     #[test]

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -4,7 +4,7 @@ use crate::{
     bundle::Bundles,
     change_detection::{MaybeLocation, Ticks, TicksMut},
     component::{ComponentId, ComponentTicks, Components, Tick},
-    entity::Entities,
+    entity::{Entities, EntitiesAllocator},
     query::{
         Access, FilteredAccess, FilteredAccessSet, QueryData, QueryFilter, QuerySingleError,
         QueryState, ReadOnlyQueryData,
@@ -1549,6 +1549,27 @@ unsafe impl<'a> SystemParam for &'a Entities {
         _change_tick: Tick,
     ) -> Self::Item<'w, 's> {
         world.entities()
+    }
+}
+
+// SAFETY: Only reads World entities
+unsafe impl<'a> ReadOnlySystemParam for &'a EntitiesAllocator {}
+
+// SAFETY: no component value access
+unsafe impl<'a> SystemParam for &'a EntitiesAllocator {
+    type State = ();
+    type Item<'w, 's> = &'w EntitiesAllocator;
+
+    fn init_state(_world: &mut World, _system_meta: &mut SystemMeta) -> Self::State {}
+
+    #[inline]
+    unsafe fn get_param<'w, 's>(
+        _state: &'s mut Self::State,
+        _system_meta: &SystemMeta,
+        world: UnsafeWorldCell<'w>,
+        _change_tick: Tick,
+    ) -> Self::Item<'w, 's> {
+        world.entities_allocator()
     }
 }
 

--- a/crates/bevy_ecs/src/system/system_registry.rs
+++ b/crates/bevy_ecs/src/system/system_registry.rs
@@ -657,9 +657,9 @@ mod tests {
         let exclusive_system_id = world.register_system(|world: &mut World| {
             world.spawn_empty();
         });
-        let entity_count = world.entities.len();
+        let entity_count = world.entities.count_active();
         let _ = world.run_system(exclusive_system_id);
-        assert_eq!(world.entities.len(), entity_count + 1);
+        assert_eq!(world.entities.count_active(), entity_count + 1);
     }
 
     #[test]

--- a/crates/bevy_ecs/src/world/command_queue.rs
+++ b/crates/bevy_ecs/src/world/command_queue.rs
@@ -420,12 +420,12 @@ mod test {
         let mut world = World::new();
         queue.apply(&mut world);
 
-        assert_eq!(world.entities().len(), 2);
+        assert_eq!(world.entities().count_active(), 2);
 
         // The previous call to `apply` cleared the queue.
         // This call should do nothing.
         queue.apply(&mut world);
-        assert_eq!(world.entities().len(), 2);
+        assert_eq!(world.entities().count_active(), 2);
     }
 
     #[expect(
@@ -459,7 +459,7 @@ mod test {
         queue.push(SpawnCommand);
         queue.push(SpawnCommand);
         queue.apply(&mut world);
-        assert_eq!(world.entities().len(), 3);
+        assert_eq!(world.entities().count_active(), 3);
     }
 
     #[test]

--- a/crates/bevy_ecs/src/world/command_queue.rs
+++ b/crates/bevy_ecs/src/world/command_queue.rs
@@ -83,9 +83,6 @@ impl CommandQueue {
     /// This clears the queue.
     #[inline]
     pub fn apply(&mut self, world: &mut World) {
-        // flush the previously queued entities
-        world.flush_entities();
-
         // flush the world's internal queue
         world.flush_commands();
 

--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -23,7 +23,7 @@ use super::{unsafe_world_cell::UnsafeWorldCell, Mut, World, ON_INSERT, ON_REPLAC
 ///
 /// This means that in order to add entities, for example, you will need to use commands instead of the world directly.
 pub struct DeferredWorld<'w> {
-    // SAFETY: Implementors must not use this reference to make structural changes
+    // SAFETY: Implementers must not use this reference to make structural changes
     world: UnsafeWorldCell<'w>,
 }
 
@@ -69,7 +69,7 @@ impl<'w> DeferredWorld<'w> {
         // SAFETY: &mut self ensure that there are no outstanding accesses to the queue
         let command_queue = unsafe { self.world.get_raw_command_queue() };
         // SAFETY: command_queue is stored on world and always valid while the world exists
-        unsafe { Commands::new_raw_from_entities(command_queue, self.world.entities()) }
+        unsafe { Commands::new_raw_from_entities(command_queue, self.world.entities_allocator()) }
     }
 
     /// Retrieves a mutable reference to the given `entity`'s [`Component`] of the given type.
@@ -415,7 +415,8 @@ impl<'w> DeferredWorld<'w> {
         // - Command queue access does not conflict with entity access.
         let raw_queue = unsafe { cell.get_raw_command_queue() };
         // SAFETY: `&mut self` ensures the commands does not outlive the world.
-        let commands = unsafe { Commands::new_raw_from_entities(raw_queue, cell.entities()) };
+        let commands =
+            unsafe { Commands::new_raw_from_entities(raw_queue, cell.entities_allocator()) };
 
         (fetcher, commands)
     }

--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -69,7 +69,13 @@ impl<'w> DeferredWorld<'w> {
         // SAFETY: &mut self ensure that there are no outstanding accesses to the queue
         let command_queue = unsafe { self.world.get_raw_command_queue() };
         // SAFETY: command_queue is stored on world and always valid while the world exists
-        unsafe { Commands::new_raw_from_entities(command_queue, self.world.entities_allocator()) }
+        unsafe {
+            Commands::new_raw_from_entities(
+                command_queue,
+                self.world.entities_allocator(),
+                self.world.entities(),
+            )
+        }
     }
 
     /// Retrieves a mutable reference to the given `entity`'s [`Component`] of the given type.
@@ -415,8 +421,9 @@ impl<'w> DeferredWorld<'w> {
         // - Command queue access does not conflict with entity access.
         let raw_queue = unsafe { cell.get_raw_command_queue() };
         // SAFETY: `&mut self` ensures the commands does not outlive the world.
-        let commands =
-            unsafe { Commands::new_raw_from_entities(raw_queue, cell.entities_allocator()) };
+        let commands = unsafe {
+            Commands::new_raw_from_entities(raw_queue, cell.entities_allocator(), cell.entities())
+        };
 
         (fetcher, commands)
     }

--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -8,7 +8,7 @@ use crate::{
     event::{Event, EventId, Events, SendBatchIds},
     observer::{Observers, TriggerTargets},
     prelude::{Component, QueryState},
-    query::{QueryData, QueryFilter},
+    query::{DebugCheckedUnwrap, QueryData, QueryFilter},
     relationship::RelationshipHookMode,
     resource::Resource,
     system::{Commands, Query},
@@ -144,7 +144,8 @@ impl<'w> DeferredWorld<'w> {
             return Ok(None);
         }
 
-        let archetype = &raw const *entity_cell.archetype();
+        // SAFETY: If the archetype was none, it would not have the component on it.
+        let archetype = unsafe { &raw const *entity_cell.archetype().debug_checked_unwrap() };
 
         // SAFETY:
         // - DeferredWorld ensures archetype pointer will remain valid as no

--- a/crates/bevy_ecs/src/world/entity_fetch.rs
+++ b/crates/bevy_ecs/src/world/entity_fetch.rs
@@ -215,12 +215,12 @@ unsafe impl WorldEntityFetch for Entity {
     ) -> Result<Self::Mut<'_>, EntityMutableFetchError> {
         let location = cell
             .entities()
-            .get(self)
+            .get_id_location(self)
             .ok_or(EntityDoesNotExistError::new(self, cell.entities()))?;
         // SAFETY: caller ensures that the world cell has mutable access to the entity.
         let world = unsafe { cell.world_mut() };
         // SAFETY: location was fetched from the same world's `Entities`.
-        Ok(unsafe { EntityWorldMut::new(world, self, Some(location)) })
+        Ok(unsafe { EntityWorldMut::new(world, self, location) })
     }
 
     unsafe fn fetch_deferred_mut(

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -78,13 +78,13 @@ impl<'w> EntityRef<'w> {
 
     /// Gets metadata indicating the location where the current entity is stored.
     #[inline]
-    pub fn location(&self) -> EntityLocation {
+    pub fn location(&self) -> EntityIdLocation {
         self.cell.location()
     }
 
     /// Returns the archetype that the current entity belongs to.
     #[inline]
-    pub fn archetype(&self) -> &Archetype {
+    pub fn archetype(&self) -> Option<&Archetype> {
         self.cell.archetype()
     }
 
@@ -488,13 +488,13 @@ impl<'w> EntityMut<'w> {
 
     /// Gets metadata indicating the location where the current entity is stored.
     #[inline]
-    pub fn location(&self) -> EntityLocation {
+    pub fn location(&self) -> EntityIdLocation {
         self.cell.location()
     }
 
     /// Returns the archetype that the current entity belongs to.
     #[inline]
-    pub fn archetype(&self) -> &Archetype {
+    pub fn archetype(&self) -> Option<&Archetype> {
         self.cell.archetype()
     }
 
@@ -1123,37 +1123,34 @@ impl<'w> EntityWorldMut<'w> {
     }
 
     fn as_unsafe_entity_cell_readonly(&self) -> UnsafeEntityCell<'_> {
-        let location = self.location();
         let last_change_tick = self.world.last_change_tick;
         let change_tick = self.world.read_change_tick();
         UnsafeEntityCell::new(
             self.world.as_unsafe_world_cell_readonly(),
             self.entity,
-            location,
+            self.location,
             last_change_tick,
             change_tick,
         )
     }
     fn as_unsafe_entity_cell(&mut self) -> UnsafeEntityCell<'_> {
-        let location = self.location();
         let last_change_tick = self.world.last_change_tick;
         let change_tick = self.world.change_tick();
         UnsafeEntityCell::new(
             self.world.as_unsafe_world_cell(),
             self.entity,
-            location,
+            self.location,
             last_change_tick,
             change_tick,
         )
     }
     fn into_unsafe_entity_cell(self) -> UnsafeEntityCell<'w> {
-        let location = self.location();
         let last_change_tick = self.world.last_change_tick;
         let change_tick = self.world.change_tick();
         UnsafeEntityCell::new(
             self.world.as_unsafe_world_cell(),
             self.entity,
-            location,
+            self.location,
             last_change_tick,
             change_tick,
         )
@@ -3275,13 +3272,13 @@ impl<'w> FilteredEntityRef<'w> {
 
     /// Gets metadata indicating the location where the current entity is stored.
     #[inline]
-    pub fn location(&self) -> EntityLocation {
+    pub fn location(&self) -> EntityIdLocation {
         self.entity.location()
     }
 
     /// Returns the archetype that the current entity belongs to.
     #[inline]
-    pub fn archetype(&self) -> &Archetype {
+    pub fn archetype(&self) -> Option<&Archetype> {
         self.entity.archetype()
     }
 
@@ -3617,13 +3614,13 @@ impl<'w> FilteredEntityMut<'w> {
 
     /// Gets metadata indicating the location where the current entity is stored.
     #[inline]
-    pub fn location(&self) -> EntityLocation {
+    pub fn location(&self) -> EntityIdLocation {
         self.entity.location()
     }
 
     /// Returns the archetype that the current entity belongs to.
     #[inline]
-    pub fn archetype(&self) -> &Archetype {
+    pub fn archetype(&self) -> Option<&Archetype> {
         self.entity.archetype()
     }
 
@@ -4928,7 +4925,10 @@ mod tests {
         let ent = world.spawn((Marker::<1>, Marker::<2>, Marker::<3>)).id();
 
         world.entity_mut(ent).retain::<()>();
-        assert_eq!(world.entity(ent).archetype().components().next(), None);
+        assert_eq!(
+            world.entity(ent).archetype().unwrap().components().next(),
+            None
+        );
     }
 
     // Test removing some components with `retain`, including components not on the entity.
@@ -4948,6 +4948,7 @@ mod tests {
             world
                 .entity(ent)
                 .archetype()
+                .unwrap()
                 .components()
                 .collect::<Vec<_>>()
                 .len(),

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -2784,7 +2784,7 @@ impl<'w> EntityWorldMut<'w> {
         self.assert_not_despawned();
         self.world.flush();
 
-        let entity_clone = self.world.allocator.alloc();
+        let entity_clone = self.world.spawn_empty().id();
 
         let mut builder = EntityCloner::build(self.world);
         config(&mut builder);

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -2440,7 +2440,8 @@ impl<'w> EntityWorldMut<'w> {
         }
         // SAFETY: Since we had a location, and it was valid, this is safe.
         unsafe {
-            self.world.entities.update(self.entity.row(), None);
+            let was_at = self.world.entities.update(self.entity.row(), None);
+            debug_assert_eq!(was_at, Some(location));
             self.world
                 .entities
                 .mark_construct_or_destruct(self.entity.row(), caller, change_tick);

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -2500,10 +2500,6 @@ impl<'w> EntityWorldMut<'w> {
     ///
     /// This will also despawn any [`Children`](crate::hierarchy::Children) entities, and any other [`RelationshipTarget`](crate::relationship::RelationshipTarget) that is configured
     /// to despawn descendants. This results in "recursive despawn" behavior.
-    ///
-    /// # Panics
-    ///
-    /// If the entity has been despawned while this `EntityWorldMut` is still alive.
     #[track_caller]
     pub fn despawn(self) {
         self.despawn_with_caller(MaybeLocation::caller());
@@ -2786,9 +2782,9 @@ impl<'w> EntityWorldMut<'w> {
         config: impl FnOnce(&mut EntityClonerBuilder) + Send + Sync + 'static,
     ) -> Entity {
         self.assert_not_despawned();
-
-        let entity_clone = self.world.entities.reserve_entity();
         self.world.flush();
+
+        let entity_clone = self.world.allocator.alloc();
 
         let mut builder = EntityCloner::build(self.world);
         config(&mut builder);

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -5818,7 +5818,6 @@ mod tests {
         );
         world.commands().queue(count_flush);
         let entity = world.spawn_empty().id();
-        assert_eq!(world.resource::<TestFlush>().0, 1);
         world.commands().queue(count_flush);
         let mut a = world.entity_mut(entity);
         a.trigger(TestEvent);

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -2333,6 +2333,9 @@ impl<'w> EntityWorldMut<'w> {
         self
     }
 
+    /// Constructs the entity.
+    /// If the entity has not been constructed or has been destructed, the can construct it.
+    /// See [`World::construct`] for details.
     #[track_caller]
     pub fn construct<B: Bundle>(&mut self, bundle: B) -> Result<&mut Self, ConstructionError> {
         let Self {
@@ -2340,11 +2343,26 @@ impl<'w> EntityWorldMut<'w> {
             entity,
             location,
         } = self;
-        let found = world.construct(*entity, bundle)?;
+        let found = world.construct_with_caller(*entity, bundle, MaybeLocation::caller())?;
         *location = found.location;
         Ok(self)
     }
 
+    /// A faster version of [`construct`](Self::construct) for the empty bundle.
+    #[track_caller]
+    pub fn construct_empty(&mut self) -> Result<&mut Self, ConstructionError> {
+        let Self {
+            world,
+            entity,
+            location,
+        } = self;
+        let found = world.construct_empty_with_caller(*entity, MaybeLocation::caller())?;
+        *location = found.location;
+        Ok(self)
+    }
+
+    /// Destructs the entity, without releasing it.
+    /// This may be later [`constructed`](Self::construct).
     #[track_caller]
     pub fn destruct(&mut self) -> &mut Self {
         self.destruct_with_caller(MaybeLocation::caller())

--- a/crates/bevy_ecs/src/world/error.rs
+++ b/crates/bevy_ecs/src/world/error.rs
@@ -31,8 +31,8 @@ pub struct TryInsertBatchError {
 
 /// An error that occurs when a specified [`Entity`] could not be despawned.
 #[derive(thiserror::Error, Debug, Clone, Copy)]
-#[error("Could not despawn entity: {0}")]
-pub struct EntityDespawnError(#[from] pub EntityMutableFetchError);
+#[error("Could not destruct entity: {0}")]
+pub struct EntityDestructError(#[from] pub EntityMutableFetchError);
 
 /// An error that occurs when dynamically retrieving components from an entity.
 #[derive(thiserror::Error, Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1111,7 +1111,7 @@ impl World {
         let mut bundle_spawner = BundleSpawner::new::<B>(self, change_tick);
         // SAFETY: bundle's type matches `bundle_info`, entity is allocated but non-existent
         let (entity_location, after_effect) =
-            unsafe { bundle_spawner.spawn_non_existent(entity, bundle, caller) };
+            unsafe { bundle_spawner.construct(entity, bundle, caller) };
 
         let mut entity_location = Some(entity_location);
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -267,7 +267,13 @@ impl World {
     #[inline]
     pub fn commands(&mut self) -> Commands {
         // SAFETY: command_queue is stored on world and always valid while the world exists
-        unsafe { Commands::new_raw_from_entities(self.command_queue.clone(), &self.allocator) }
+        unsafe {
+            Commands::new_raw_from_entities(
+                self.command_queue.clone(),
+                &self.allocator,
+                &self.entities,
+            )
+        }
     }
 
     /// Registers a new [`Component`] type and returns the [`ComponentId`] created for it.
@@ -1046,8 +1052,9 @@ impl World {
         // - Command queue access does not conflict with entity access.
         let raw_queue = unsafe { cell.get_raw_command_queue() };
         // SAFETY: `&mut self` ensures the commands does not outlive the world.
-        let commands =
-            unsafe { Commands::new_raw_from_entities(raw_queue, cell.entities_allocator()) };
+        let commands = unsafe {
+            Commands::new_raw_from_entities(raw_queue, cell.entities_allocator(), cell.entities())
+        };
 
         (fetcher, commands)
     }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -3645,7 +3645,7 @@ impl fmt::Debug for World {
         // Accessing any data stored in the world would be unsound.
         f.debug_struct("World")
             .field("id", &self.id)
-            .field("entity_count", &self.entities.len())
+            .field("entity_count", &self.entities.count_active())
             .field("archetype_count", &self.archetypes.len())
             .field("component_count", &self.components.len())
             .field("resource_count", &self.storages.resources.len())
@@ -4349,6 +4349,7 @@ mod tests {
             .is_ok());
 
         world.entity_mut(e1).despawn();
+        assert!(world.get_entity_mut(e2).is_ok());
 
         assert!(matches!(
             world.get_entity_mut(e1).map(|_| {}),

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -977,7 +977,7 @@ impl World {
                     let cell = UnsafeEntityCell::new(
                         self.as_unsafe_world_cell_readonly(),
                         entity,
-                        location,
+                        Some(location),
                         self.last_change_tick,
                         self.read_change_tick(),
                     );
@@ -1000,7 +1000,7 @@ impl World {
                     let cell = UnsafeEntityCell::new(
                         world_cell,
                         entity,
-                        location,
+                        Some(location),
                         last_change_tick,
                         change_tick,
                     );

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1158,7 +1158,6 @@ impl World {
         bundle: B,
         caller: MaybeLocation,
     ) -> EntityWorldMut<'_> {
-        self.flush();
         let change_tick = self.change_tick();
         let mut bundle_spawner = BundleSpawner::new::<B>(self, change_tick);
         // SAFETY: bundle's type matches `bundle_info`, entity is allocated but non-existent
@@ -2415,7 +2414,6 @@ impl World {
             archetype_id: ArchetypeId,
         }
 
-        self.flush();
         let change_tick = self.change_tick();
         // SAFETY: These come from the same world. `Self.components_registrator` can't be used since we borrow other fields too.
         let mut registrator =
@@ -2560,7 +2558,6 @@ impl World {
             archetype_id: ArchetypeId,
         }
 
-        self.flush();
         let change_tick = self.change_tick();
         // SAFETY: These come from the same world. `Self.components_registrator` can't be used since we borrow other fields too.
         let mut registrator =

--- a/crates/bevy_ecs/src/world/spawn_batch.rs
+++ b/crates/bevy_ecs/src/world/spawn_batch.rs
@@ -36,7 +36,6 @@ where
 
         let (lower, upper) = iter.size_hint();
         let length = upper.unwrap_or(lower);
-        world.entities.reserve(length as u32);
 
         let mut spawner = BundleSpawner::new::<I::Item>(world, change_tick);
         spawner.reserve_storage(length);

--- a/crates/bevy_ecs/src/world/spawn_batch.rs
+++ b/crates/bevy_ecs/src/world/spawn_batch.rs
@@ -29,10 +29,6 @@ where
     #[inline]
     #[track_caller]
     pub(crate) fn new(world: &'w mut World, iter: I, caller: MaybeLocation) -> Self {
-        // Ensure all entity allocations are accounted for so `self.entities` can realloc if
-        // necessary
-        world.flush();
-
         let change_tick = world.change_tick();
 
         let (lower, upper) = iter.size_hint();
@@ -40,10 +36,11 @@ where
 
         let mut spawner = BundleSpawner::new::<I::Item>(world, change_tick);
         spawner.reserve_storage(length);
+        let allocator = spawner.allocator().alloc_many(length as u32);
 
         Self {
             inner: iter,
-            allocator: spawner.allocator().alloc_many(length as u32),
+            allocator,
             spawner,
             caller,
         }

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -6,7 +6,10 @@ use crate::{
     bundle::Bundles,
     change_detection::{MaybeLocation, MutUntyped, Ticks, TicksMut},
     component::{ComponentId, ComponentTicks, Components, Mutable, StorageType, Tick, TickCells},
-    entity::{ContainsEntity, Entities, Entity, EntityDoesNotExistError, EntityLocation},
+    entity::{
+        ContainsEntity, Entities, EntitiesAllocator, Entity, EntityDoesNotExistError,
+        EntityLocation,
+    },
     error::{DefaultErrorHandler, ErrorHandler},
     observer::Observers,
     prelude::Component,
@@ -257,6 +260,14 @@ impl<'w> UnsafeWorldCell<'w> {
         // SAFETY:
         // - we only access world metadata
         &unsafe { self.world_metadata() }.entities
+    }
+
+    /// Retrieves this world's [`Entities`] collection.
+    #[inline]
+    pub fn entities_allocator(self) -> &'w EntitiesAllocator {
+        // SAFETY:
+        // - we only access world metadata
+        &unsafe { self.world_metadata() }.allocator
     }
 
     /// Retrieves this world's [`Archetypes`] collection.

--- a/crates/bevy_remote/src/builtin_methods.rs
+++ b/crates/bevy_remote/src/builtin_methods.rs
@@ -1125,7 +1125,11 @@ pub fn process_remote_list_request(In(params): In<Option<Value>>, world: &World)
     // If `Some`, return all components of the provided entity.
     if let Some(BrpListParams { entity }) = params.map(parse).transpose()? {
         let entity = get_entity(world, entity)?;
-        for component_id in entity.archetype().components() {
+        for component_id in entity
+            .archetype()
+            .iter()
+            .flat_map(|archetype| archetype.components())
+        {
             let Some(component_info) = world.components().get_info(component_id) else {
                 continue;
             };
@@ -1179,7 +1183,11 @@ pub fn process_remote_list_watching_request(
     let entity_ref = get_entity(world, entity)?;
     let mut response = BrpListWatchingResponse::default();
 
-    for component_id in entity_ref.archetype().components() {
+    for component_id in entity_ref
+        .archetype()
+        .iter()
+        .flat_map(|archetype| archetype.components())
+    {
         let ticks = entity_ref
             .get_change_ticks_by_id(component_id)
             .ok_or(BrpError::internal("Failed to get ticks"))?;

--- a/crates/bevy_scene/src/dynamic_scene_builder.rs
+++ b/crates/bevy_scene/src/dynamic_scene_builder.rs
@@ -283,7 +283,11 @@ impl<'w> DynamicSceneBuilder<'w> {
             };
 
             let original_entity = self.original_world.entity(entity);
-            for component_id in original_entity.archetype().components() {
+            for component_id in original_entity
+                .archetype()
+                .iter()
+                .flat_map(|archetype| archetype.components())
+            {
                 let mut extract_and_push = || {
                     let type_id = self
                         .original_world


### PR DESCRIPTION
# Objective

This is the next step for #19430 and is also convinient for #18670.

For context, the way entities work on main is as a "allocate and use" system. Entity ids are allocated, and given a location. The location can then be changed, etc. Entities that are free have an invalid location. To allocate an entity, one must also set its location. This introduced the need for pending entities, where an entity would be reserved, pending, and at some point flushed. Pending and free entities have an invalid location, and others are assumed to have a valid one.

This paradigm has a number of downsides: First, the entities metadata table is inseparable from the allocator, which makes remote reservation challenging. Second, the `World` must be flushed, even to do simple things, like allocate a temporary entity id. Third, users have little control over entity ids, only interacting with conceptual entities. This made things like `Entities::alloc_at` clunky and slow, leading to its removal, despite some users still having valid need of it.

So the goal of this PR is to:
- Decouple `Entities` from entity allocation to make room for other allocators and resolve `alloc_at` issues.
- Decouple entity allocation from spawning to make reservation a moot point.
- Introduce constructing and destructing entities, in addition to spawn/despawn.
- Change `reserve` and `flush` patterns to `alloc` and `construct` patterns.

It is possible to break this up into multiple prs, as I originally intended, but doing so would require lots of temporary scaffolding that would both hurt performance and make things harder to review.

## Solution

This solution builds on #19433, which changed the representation of invalid entity locations from a constant to `None`.

There's quite a few steps to this, each somewhat controversial:

### Entities with no location

This pr introduces the idea of entity rows both with and without locations. This corresponds to entities that are constructed (the row has a location) and not constructed (the row has no location). When a row is free or pending, it is not constructed. When a row is outside the range of the meta list, it still exists; it's just not constructed.

This extends to conceptual entities; conceptual entities may now be in one of 3 states: empty (constructed; no components), normal (constructed; 1 or more components), or null (not constructed). This extends to entity pointers (`EntityWorldMut`, etc): These now can point to "null"/not constructed entities. Depending on the privilege of the pointer, these can also construct or destruct the entity.

This also changes how `Entity` ids relate to conceptual entities. An `Entity` now exists if its generation matches that of its row. An `Entity` that has the right generation for its row will claim to exist, even if it is not constructed. This means, for example, an `Entity` manually constructed with a large index and generation of 0 *will* exist if it has not been allocated yet.

### `Entities` is separate from the allocator

This pr separates entity allocation from `Entities`. `Entities` is now only focused on tracking entity metadata, etc. The new `EntitiesAllocator` on `World` manages all allocations. This forces `Entities` to not rely on allocator state to determine if entities exist, etc, which is convinient for remote reservation and needed for custom allocators. It also paves the way for allocators not housed within the `World`, makes some unsafe code easier since the allocator and metadata live under different pointers, etc.

This separation requires thinking about interactions with `Entities` in a new way. Previously, the `Entities` set the rules for what entities are valid and what entities are not. Now, it has no way of knowing. Instead, interaction with `Entities` are more like declaring some information for it to track than changing some information it was already tracking. To reflect this, `set` has been split up into `declare` and `update`.

### Constructing and destructing

As mentioned, entities that have no location (not constructed) can be constructed at any time. This takes on exactly the same meaning as the previous `spawn_non_existent`. It creates/declares a location instead of updating an old one. As an example, this makes spawning an entity now literately just allocate a new id and construct it immediately. 

Conversely, entities that are constructed may be destructed. This removes all components and despawns related entities, just like `despawn`. The  only difference is that destructing does not free the entity id for reuse. Between constructing and destructing, all needs for `alloc_at` are resolved. If you want to keep the id for custom reuse, just destruct instead of despawn! Despawn, now just destructs the entity and frees it.

Destructing a not constructed entity will do nothing. Constructing an already constructed entity will panic. This is to guard against users constructing a manually formed `Entity` that the allocator could later hand out. However, public construction methods have proper error handling for this. Despawning a not constructed entity just frees its id.

### No more flushing

All places that once needed to reserve and flush entity ids now allocate and construct them instead. This improves performance and simplifies things.

## Testing

- CI
- Some new tests
- A few deleted (no longer applicable) tests
- If you see something you think should have a test case, I'll gladly add it.

## To do

- [ ] migration guide
- [ ] a few performance improvements
- [ ] benchmarks
- [ ] better docs
- [ ] small utilities

## Showcase

Here's an example of constructing and destructing

```rust
let e4 = world.spawn_null();
world
    .entity_mut(e4)
    .construct((TableStored("junk"), A(0)))
    .unwrap()
    .destruct()
    .construct((TableStored("def"), A(456)))
    .unwrap();
```

## Future Work

- [ ] More expansive docs. This should definitely should be done, but I'd rather do that in a future pr to separate writing review from code review. If you have more ideas for how to introduce users to these concepts, I'd like to see them. As it is, we don't do a very good job of explaining entities to users. Ex: `Entity` doesn't always correspond to a conceptual entity.
- [ ] Try to remove panics from `EntityWorldMut`. There is (and was) a lot of assuming the entity is constructed there (was assuming it was not despawned). 
- [ ] Making a centralized bundle despawner would make sense now.
- [ ] Of course, build on this for remote reservation and, potentially, for paged entities.
