### PR TITLE
Exclude `ctrlc` from `bevy_app` for the nindendo 3ds

### DIFF
--- a/crates/bevy_app/Cargo.toml
+++ b/crates/bevy_app/Cargo.toml
@@ -88,7 +88,7 @@ tracing = { version = "0.1", default-features = false, optional = true }
 log = { version = "0.4", default-features = false }
 cfg-if = "1.0.0"
 
-[target.'cfg(any(unix, windows))'.dependencies]
+[target.'cfg(any(all(unix, not(target_os = "horizon")), windows))'.dependencies]
 ctrlc = { version = "3.4.4", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -31,7 +31,7 @@ mod plugin_group;
 mod schedule_runner;
 mod sub_app;
 mod task_pool_plugin;
-#[cfg(all(any(unix, windows), feature = "std"))]
+#[cfg(all(any(all(unix, not(target_os = "horizon")), windows), feature = "std"))]
 mod terminal_ctrl_c_handler;
 
 pub use app::*;
@@ -42,7 +42,7 @@ pub use plugin_group::*;
 pub use schedule_runner::*;
 pub use sub_app::*;
 pub use task_pool_plugin::*;
-#[cfg(all(any(unix, windows), feature = "std"))]
+#[cfg(all(any(all(unix, not(target_os = "horizon")), windows), feature = "std"))]
 pub use terminal_ctrl_c_handler::*;
 
 /// The app prelude.

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -19,7 +19,7 @@ plugin_group! {
         #[cfg(feature = "bevy_window")]
         bevy_a11y:::AccessibilityPlugin,
         #[cfg(feature = "std")]
-        #[custom(cfg(any(unix, windows)))]
+        #[custom(cfg(any(all(unix, not(target_os = "horizon")), windows)))]
         bevy_app:::TerminalCtrlCHandlerPlugin,
         #[cfg(feature = "bevy_asset")]
         bevy_asset:::AssetPlugin,


### PR DESCRIPTION
The Horizon OS has std, and is a Unix target, but not an ordinary one that can use the `ctrlc` dependency in `bevy_app`. This PR simply excludes it for the os (`horizon`).

## Testing

I compiled and ran a binary with bevy along with the `std` feature on a phyisical (classic) 3ds using homebrew.