### PR TITLE
Add `ZIndex`, `YSort`, and `SortBias` 2d components

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -779,6 +779,17 @@ category = "2D Rendering"
 wasm = true
 
 [[example]]
+name = "sprite_sorting"
+path = "examples/2d/sprite_sorting.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.sprite_sorting]
+name = "Sprite Sorting"
+description = "Demonstrates how to sort sprites"
+category = "2D Rendering"
+wasm = true
+
+[[example]]
 name = "sprite_tile"
 path = "examples/2d/sprite_tile.rs"
 doc-scrape-examples = true

--- a/crates/bevy_gizmos/src/pipeline_2d.rs
+++ b/crates/bevy_gizmos/src/pipeline_2d.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use bevy_app::{App, Plugin};
 use bevy_asset::{load_embedded_asset, Handle};
-use bevy_core_pipeline::core_2d::{Transparent2d, CORE_2D_DEPTH_FORMAT};
+use bevy_core_pipeline::core_2d::{Transparent2d, Transparent2dSortKey, CORE_2D_DEPTH_FORMAT};
 
 use bevy_ecs::{
     prelude::Entity,
@@ -16,7 +16,6 @@ use bevy_ecs::{
     world::{FromWorld, World},
 };
 use bevy_image::BevyDefault as _;
-use bevy_math::FloatOrd;
 use bevy_render::sync_world::MainEntity;
 use bevy_render::{
     render_asset::{prepare_assets, RenderAssets},
@@ -343,7 +342,7 @@ fn queue_line_gizmos_2d(
                     entity: (entity, *main_entity),
                     draw_function,
                     pipeline,
-                    sort_key: FloatOrd(f32::INFINITY),
+                    sort_key: Transparent2dSortKey::new(i32::MAX, None),
                     batch_range: 0..1,
                     extra_index: PhaseItemExtraIndex::None,
                     extracted_index: usize::MAX,
@@ -365,7 +364,7 @@ fn queue_line_gizmos_2d(
                     entity: (entity, *main_entity),
                     draw_function: draw_function_strip,
                     pipeline,
-                    sort_key: FloatOrd(f32::INFINITY),
+                    sort_key: Transparent2dSortKey::new(i32::MAX, None),
                     batch_range: 0..1,
                     extra_index: PhaseItemExtraIndex::None,
                     extracted_index: usize::MAX,
@@ -425,7 +424,7 @@ fn queue_line_joint_gizmos_2d(
                 entity: (entity, *main_entity),
                 draw_function,
                 pipeline,
-                sort_key: FloatOrd(f32::INFINITY),
+                sort_key: Transparent2dSortKey::new(i32::MAX, None),
                 batch_range: 0..1,
                 extra_index: PhaseItemExtraIndex::None,
                 extracted_index: usize::MAX,

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -277,7 +277,18 @@ pub fn extract_mesh2d(
 ) {
     render_mesh_instances.clear();
 
-    for (entity, view_visibility, transform, handle, tag, z_index, y_sort, sort_bias, no_automatic_batching) in &query {
+    for (
+        entity,
+        view_visibility,
+        transform,
+        handle,
+        tag,
+        z_index,
+        y_sort,
+        sort_bias,
+        no_automatic_batching,
+    ) in &query
+    {
         if !view_visibility.get() {
             continue;
         }

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -146,7 +146,7 @@ pub struct ZIndex(pub i32);
 /// A marker component that enables Y-sorting (depth sorting) for sprites and meshes.
 ///
 /// When attached to an entity, this component indicates that the entity should be rendered
-/// in draw order based on its Y position. Entities with lower Y values (higher on screen)
+/// in draw order based on its Y position. Entities with higher Y values (higher on screen)
 /// are drawn first, creating a depth illusion where objects lower on the screen appear
 /// in front of objects higher on the screen.
 #[derive(Component, Default, Debug, Clone)]

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -248,7 +248,7 @@ pub struct RenderMesh2dInstance {
     pub material_bind_group_id: Material2dBindGroupId,
     pub automatic_batching: bool,
     pub tag: u32,
-    pub z_index: i32,
+    pub z_index: Option<i32>,
     pub y_sort: bool,
     pub sort_bias: Option<f32>,
 }
@@ -292,7 +292,7 @@ pub fn extract_mesh2d(
                 material_bind_group_id: Material2dBindGroupId::default(),
                 automatic_batching: !no_automatic_batching,
                 tag: tag.map_or(0, |i| **i),
-                z_index: z_index.map(|x| **x).unwrap_or(0),
+                z_index: z_index.cloned().map(|x| x.0),
                 y_sort,
                 sort_bias: sort_bias.cloned().map(|sb| sb.0),
             },

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -238,6 +238,9 @@ pub fn extract_text2d_sprite(
                     kind: bevy_sprite::ExtractedSpriteKind::Slices {
                         indices: start..end,
                     },
+                    z_index: 0,
+                    y_sort: false,
+                    sort_bias: None,
                 });
                 start = end;
             }

--- a/examples/2d/2d_viewport_to_world.rs
+++ b/examples/2d/2d_viewport_to_world.rs
@@ -183,6 +183,7 @@ fn setup(
     commands.spawn((
         Mesh2d(meshes.add(Rectangle::new(50000.0, 50000.0))),
         MeshMaterial2d(materials.add(Color::linear_rgb(0.01, 0.01, 0.01))),
-        Transform::from_translation(Vec3::new(0.0, 0.0, -200.0)),
+        Transform::from_translation(Vec3::new(0.0, 0.0, 0.0)),
+        bevy::sprite::ZIndex(-1),
     ));
 }

--- a/examples/2d/mesh2d_alpha_mode.rs
+++ b/examples/2d/mesh2d_alpha_mode.rs
@@ -46,7 +46,8 @@ fn setup(
             texture: Some(texture_handle.clone()),
             ..default()
         })),
-        Transform::from_xyz(-300.0, 0.0, 1.0),
+        Transform::from_xyz(-300.0, 0.0, 0.0),
+        bevy::sprite::ZIndex(1),
     ));
     commands.spawn((
         Mesh2d(mesh_handle.clone()),
@@ -56,7 +57,8 @@ fn setup(
             texture: Some(texture_handle.clone()),
             ..default()
         })),
-        Transform::from_xyz(-200.0, 0.0, -1.0),
+        Transform::from_xyz(-200.0, 0.0, 0.0),
+        bevy::sprite::ZIndex(-1),
     ));
 
     // Test the interaction between opaque/mask and transparent meshes
@@ -82,7 +84,8 @@ fn setup(
             texture: Some(texture_handle.clone()),
             ..default()
         })),
-        Transform::from_xyz(300.0, 0.0, 1.0),
+        Transform::from_xyz(300.0, 0.0, 0.0),
+        bevy::sprite::ZIndex(1),
     ));
     commands.spawn((
         Mesh2d(mesh_handle.clone()),
@@ -92,6 +95,7 @@ fn setup(
             texture: Some(texture_handle),
             ..default()
         })),
-        Transform::from_xyz(400.0, 0.0, -1.0),
+        Transform::from_xyz(400.0, 0.0, 0.0),
+        bevy::sprite::ZIndex(-1),
     ));
 }

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -10,7 +10,7 @@ use bevy::{
     asset::weak_handle,
     color::palettes::basic::YELLOW,
     core_pipeline::core_2d::{Transparent2d, CORE_2D_DEPTH_FORMAT},
-    math::{ops, FloatOrd},
+    math::ops,
     prelude::*,
     render::{
         mesh::{Indices, MeshVertexAttribute, RenderMesh},
@@ -419,7 +419,6 @@ pub fn queue_colored_mesh2d(
                 let pipeline_id =
                     pipelines.specialize(&pipeline_cache, &colored_mesh2d_pipeline, mesh2d_key);
 
-                let mesh_z = mesh2d_transforms.world_from_local.translation.z;
                 transparent_phase.add(Transparent2d {
                     entity: (*render_entity, *visible_entity),
                     draw_function: draw_colored_mesh2d,

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -5,6 +5,7 @@
 //!
 //! [`Material2d`]: bevy::sprite::Material2d
 
+use bevy::core_pipeline::core_2d::Transparent2dSortKey;
 use bevy::{
     asset::weak_handle,
     color::palettes::basic::YELLOW,
@@ -37,7 +38,6 @@ use bevy::{
     },
 };
 use std::f32::consts::PI;
-use bevy::core_pipeline::core_2d::Transparent2dSortKey;
 
 fn main() {
     App::new()

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -37,6 +37,7 @@ use bevy::{
     },
 };
 use std::f32::consts::PI;
+use bevy::core_pipeline::core_2d::Transparent2dSortKey;
 
 fn main() {
     App::new()
@@ -367,6 +368,9 @@ pub fn extract_colored_mesh2d(
                 material_bind_group_id: Material2dBindGroupId::default(),
                 automatic_batching: false,
                 tag: 0,
+                z_index: None,
+                y_sort: false,
+                sort_bias: None,
             },
         );
     }
@@ -420,9 +424,8 @@ pub fn queue_colored_mesh2d(
                     entity: (*render_entity, *visible_entity),
                     draw_function: draw_colored_mesh2d,
                     pipeline: pipeline_id,
-                    // The 2d render items are sorted according to their z value before rendering,
-                    // in order to get correct transparency
-                    sort_key: FloatOrd(mesh_z),
+                    // Transparent 2d items are sorted by a combination of z-index and sort bias
+                    sort_key: Transparent2dSortKey::new(0, None),
                     // This material is not batched
                     batch_range: 0..1,
                     extra_index: PhaseItemExtraIndex::None,

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -408,7 +408,6 @@ pub fn queue_colored_mesh2d(
         for (render_entity, visible_entity) in visible_entities.iter::<Mesh2d>() {
             if let Some(mesh_instance) = render_mesh_instances.get(visible_entity) {
                 let mesh2d_handle = mesh_instance.mesh_asset_id;
-                let mesh2d_transforms = &mesh_instance.transforms;
                 // Get our specialized pipeline
                 let mut mesh2d_key = mesh_key;
                 let Some(mesh) = render_meshes.get(mesh2d_handle) else {

--- a/examples/2d/pixel_grid_snap.rs
+++ b/examples/2d/pixel_grid_snap.rs
@@ -54,7 +54,8 @@ fn setup_sprite(mut commands: Commands, asset_server: Res<AssetServer>) {
     // The sample sprite that will be rendered to the pixel-perfect canvas
     commands.spawn((
         Sprite::from_image(asset_server.load("pixel/bevy_pixel_dark.png")),
-        Transform::from_xyz(-45., 20., 2.),
+        Transform::from_xyz(-45., 20., 0.),
+        bevy::sprite::ZIndex(2),
         Rotate,
         PIXEL_PERFECT_LAYERS,
     ));
@@ -62,7 +63,8 @@ fn setup_sprite(mut commands: Commands, asset_server: Res<AssetServer>) {
     // The sample sprite that will be rendered to the high-res "outer world"
     commands.spawn((
         Sprite::from_image(asset_server.load("pixel/bevy_pixel_light.png")),
-        Transform::from_xyz(-45., -20., 2.),
+        Transform::from_xyz(-45., -20., 0.),
+        bevy::sprite::ZIndex(2),
         Rotate,
         HIGH_RES_LAYERS,
     ));
@@ -77,7 +79,8 @@ fn setup_mesh(
     commands.spawn((
         Mesh2d(meshes.add(Capsule2d::default())),
         MeshMaterial2d(materials.add(Color::BLACK)),
-        Transform::from_xyz(25., 0., 2.).with_scale(Vec3::splat(32.)),
+        Transform::from_xyz(25., 0., 0.).with_scale(Vec3::splat(32.)),
+        bevy::sprite::ZIndex(2),
         Rotate,
         PIXEL_PERFECT_LAYERS,
     ));

--- a/examples/2d/sprite_sorting.rs
+++ b/examples/2d/sprite_sorting.rs
@@ -1,4 +1,4 @@
-//! Demonstrates sprite rendering order using ZIndex, YSort, and SortBias components.
+//! Demonstrates sprite rendering order using `ZIndex`, `YSort`, and `SortBias` components.
 //!
 //! This example shows how different sorting methods interact:
 //! - `bevy::sprite::ZIndex(i32)`: Absolute rendering order (higher = on top)

--- a/examples/2d/sprite_sorting.rs
+++ b/examples/2d/sprite_sorting.rs
@@ -1,0 +1,235 @@
+//! Demonstrates sprite rendering order using ZIndex, YSort, and SortBias components.
+//!
+//! This example shows how different sorting methods interact:
+//! - `bevy::sprite::ZIndex(i32)`: Absolute rendering order (higher = on top)
+//! - `YSort`: Automatic sorting based on Y position (lower Y = behind)
+//! - `SortBias`: Fine-tune sorting without changing actual position
+
+use bevy::sprite::YSort;
+use bevy::{prelude::*, sprite::SortBias};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_systems(Startup, setup)
+        .add_systems(Update, (move_sprites, update_info_text))
+        .run();
+}
+
+#[derive(Component)]
+struct Movable {
+    label: String,
+}
+
+#[derive(Component)]
+struct InfoText;
+
+fn setup(mut commands: Commands) {
+    commands.spawn(Camera2d);
+
+    commands.spawn((
+        Text::new(
+            "WASD: Move white sprite | Q/E: Adjust sort bias\n\
+            Hover over sprites to see their sorting properties",
+        ),
+        Node {
+            position_type: PositionType::Absolute,
+            top: Val::Px(12.0),
+            left: Val::Px(12.0),
+            ..default()
+        },
+        InfoText,
+    ));
+
+    // Left
+
+    commands.spawn((
+        Sprite {
+            color: Color::srgb(0.8, 0.2, 0.2),
+            custom_size: Some(Vec2::splat(60.0)),
+            ..default()
+        },
+        Transform::from_translation(Vec3::new(-300.0, 50.0, 0.0)),
+        bevy::sprite::ZIndex(10),
+    ));
+
+    commands.spawn((
+        Sprite {
+            color: Color::srgb(0.2, 0.2, 0.8),
+            custom_size: Some(Vec2::splat(60.0)),
+            ..default()
+        },
+        Transform::from_translation(Vec3::new(-280.0, 30.0, 0.0)),
+        bevy::sprite::ZIndex(5),
+    ));
+
+    commands.spawn((
+        Sprite {
+            color: Color::srgb(0.2, 0.8, 0.2),
+            custom_size: Some(Vec2::splat(60.0)),
+            ..default()
+        },
+        Transform::from_translation(Vec3::new(-260.0, 70.0, 0.0)),
+        bevy::sprite::ZIndex(15),
+    ));
+
+    // Center
+
+    for i in 0..3 {
+        let y = -50.0 + i as f32 * 40.0;
+        commands.spawn((
+            Sprite {
+                color: Color::srgb(0.9, 0.5, 0.1),
+                custom_size: Some(Vec2::splat(60.0)),
+                ..default()
+            },
+            Transform::from_translation(Vec3::new(-50.0 + i as f32 * 20.0, y, 0.0)),
+            YSort,
+        ));
+    }
+
+    // Right
+
+    commands.spawn((
+        Sprite {
+            color: Color::srgb(0.6, 0.2, 0.8),
+            custom_size: Some(Vec2::splat(60.0)),
+            ..default()
+        },
+        Transform::from_translation(Vec3::new(200.0, 0.0, 0.0)),
+        YSort,
+        SortBias(-20.0),
+    ));
+
+    commands.spawn((
+        Sprite {
+            color: Color::srgb(0.2, 0.8, 0.8),
+            custom_size: Some(Vec2::splat(60.0)),
+            ..default()
+        },
+        Transform::from_translation(Vec3::new(220.0, 10.0, 0.0)),
+        YSort,
+        SortBias(20.0),
+    ));
+
+    commands.spawn((
+        Sprite {
+            color: Color::srgb(0.8, 0.8, 0.2),
+            custom_size: Some(Vec2::splat(60.0)),
+            ..default()
+        },
+        Transform::from_translation(Vec3::new(240.0, 0.0, 0.0)),
+        YSort,
+    ));
+
+    // Moveable sprite
+    commands.spawn((
+        Sprite {
+            color: Color::WHITE,
+            custom_size: Some(Vec2::splat(50.0)),
+            ..default()
+        },
+        Transform::from_translation(Vec3::new(0.0, 0.0, 0.0)),
+        YSort,
+        SortBias(0.0),
+        Movable {
+            label: "Movable (YSort + Bias: 0)".to_string(),
+        },
+    ));
+
+    // Background grid
+    for x in -4..=4 {
+        for y in -3..=3 {
+            commands.spawn((
+                Sprite {
+                    color: Color::srgba(0.3, 0.3, 0.3, 0.1),
+                    custom_size: Some(Vec2::splat(30.0)),
+                    ..default()
+                },
+                Transform::from_translation(Vec3::new(x as f32 * 100.0, y as f32 * 100.0, 0.0)),
+                bevy::sprite::ZIndex(-100), // Always behind everything
+            ));
+        }
+    }
+
+    // Labels
+
+    commands.spawn((
+        Text::new("ZIndex Only"),
+        Node {
+            position_type: PositionType::Absolute,
+            left: Val::Px(300.0),
+            bottom: Val::Px(50.0),
+            ..default()
+        },
+        bevy::sprite::ZIndex(1000),
+    ));
+
+    commands.spawn((
+        Text::new("YSort Only"),
+        Node {
+            position_type: PositionType::Absolute,
+            left: Val::Px(550.0),
+            bottom: Val::Px(50.0),
+            ..default()
+        },
+        bevy::sprite::ZIndex(1000),
+    ));
+
+    commands.spawn((
+        Text::new("YSort + SortBias"),
+        Node {
+            position_type: PositionType::Absolute,
+            right: Val::Px(300.0),
+            bottom: Val::Px(50.0),
+            ..default()
+        },
+        bevy::sprite::ZIndex(1000),
+    ));
+}
+
+fn move_sprites(
+    mut query: Query<(&mut Transform, &mut SortBias, &mut Movable)>,
+    keyboard: Res<ButtonInput<KeyCode>>,
+    time: Res<Time>,
+) {
+    let speed = 150.0;
+    let bias_speed = 50.0;
+    let delta = time.delta_secs();
+
+    for (mut transform, mut sort_bias, mut movable) in &mut query {
+        if keyboard.pressed(KeyCode::KeyA) {
+            transform.translation.x -= speed * delta;
+        }
+        if keyboard.pressed(KeyCode::KeyD) {
+            transform.translation.x += speed * delta;
+        }
+        if keyboard.pressed(KeyCode::KeyW) {
+            transform.translation.y += speed * delta;
+        }
+        if keyboard.pressed(KeyCode::KeyS) {
+            transform.translation.y -= speed * delta;
+        }
+
+        // Adjust sort bias
+        if keyboard.pressed(KeyCode::KeyQ) {
+            sort_bias.0 -= bias_speed * delta;
+        }
+        if keyboard.pressed(KeyCode::KeyE) {
+            sort_bias.0 += bias_speed * delta;
+        }
+
+        // Update label
+        movable.label = format!(
+            "Movable (Y: {:.0}, Bias: {:.0})",
+            transform.translation.y, sort_bias.0
+        );
+    }
+}
+
+fn update_info_text(mut text: Single<&mut Text, With<InfoText>>, movable: Single<&Movable>) {
+    text.0 = format!(
+        "WASD: Move white sprite | Q/E: Adjust sort bias\n{}",
+        movable.label
+    );
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -126,6 +126,7 @@ Example | Description
 [Sprite Scale](../examples/2d/sprite_scale.rs) | Shows how a sprite can be scaled into a rectangle while keeping the aspect ratio
 [Sprite Sheet](../examples/2d/sprite_sheet.rs) | Renders an animated sprite
 [Sprite Slice](../examples/2d/sprite_slice.rs) | Showcases slicing sprites into sections that can be scaled independently via the 9-patch technique
+[Sprite Sorting](../examples/2d/sprite_sorting.rs) | Demonstrates how to sort sprites
 [Sprite Tile](../examples/2d/sprite_tile.rs) | Renders a sprite tiled in a grid
 [Text 2D](../examples/2d/text2d.rs) | Generates text in 2D
 [Texture Atlas](../examples/2d/texture_atlas.rs) | Generates a texture atlas (sprite sheet) from individual sprites

--- a/examples/shader/shader_defs.rs
+++ b/examples/shader/shader_defs.rs
@@ -83,6 +83,10 @@ struct CustomMaterial {
     is_red: bool,
 }
 
+// This key is used to identify a specific permutation of this material pipeline.
+// In this case, we specialize on whether or not to configure the "IS_RED" shader def.
+// Specialization keys should be kept as small / cheap to hash as possible,
+// as they will be used to look up the pipeline for each drawn entity with this material type.
 #[derive(Eq, PartialEq, Hash, Clone)]
 struct CustomMaterialKey {
     is_red: bool,

--- a/examples/shader/shader_defs.rs
+++ b/examples/shader/shader_defs.rs
@@ -83,10 +83,6 @@ struct CustomMaterial {
     is_red: bool,
 }
 
-// This key is used to identify a specific permutation of this material pipeline.
-// In this case, we specialize on whether or not to configure the "IS_RED" shader def.
-// Specialization keys should be kept as small / cheap to hash as possible,
-// as they will be used to look up the pipeline for each drawn entity with this material type.
 #[derive(Eq, PartialEq, Hash, Clone)]
 struct CustomMaterialKey {
     is_red: bool,


### PR DESCRIPTION
# Objective

Using Z transform for sprites and 2d meshes is gross! Users expect familiar sorting strategies.

## Solution

Adds 3 new sorting components for 2d:
- `ZIndex`: sorts entities into layers and always takes priority.
- `YSort`: sorts entities in each `ZIndex` layer by their Y transform.
- `SortBias`: an arbitrary bias that is either added to Y transform or used as a secondary sort value.

**TODO**:
- What should we do with the name conflict with the existing ui `ZIndex`.
- How should 2d mesh opaque behave? Right now, using any of these components opts you into transparent sorting on the CPU, but ideally we'd be able to do GPU based fragment sorting as well. This is an advantage that using the transform Z has that we should take into consideration.

## Testing

Tested a bunch of examples, might be more broken.