### PR TITLE
allow access to the source error of `AssetLoaderError` and downcasting

### DIFF
--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -1959,7 +1959,7 @@ impl AssetLoaderError {
     /// If you know the type of the error the asset loader returned, you can use
     /// [`BevyError::downcast_ref()`] to get it.
     pub fn error(&self) -> &BevyError {
-        &*self.error
+        &self.error
     }
 }
 


### PR DESCRIPTION
# Objective

I have a custom asset loader, and need access to the error it reports when failing to load (e.g. through `AssetLoadFailedEvent { error: AssetLoadError::AssetLoaderError(loader_error), .. }`). However `AssetLoaderError` doesn't expose its `<core::error::Error>::source()` (i.e. its `error` field. It only formats it when `Display`ed.

*I haven't searched for issues about it.*

## Solution

- Annotate `AssetLoaderError`'s `error` field with `#[source]`.
- Don't include the error when `AssetLoaderError` is `Display`ed (when one prints an error's source stack like a backtrace, it would now be dupplicated).
- (optional, included as a separated commit) Add a getter for the `&dyn Error` stored in the `error` field (whithin an `Arc`). This is more ergonomic than using `Error::source()` because it casts an `&Arc<dyn Error>` into an `&dyn Error`, meaning one has to downcast it twice to get the original error from the loader, including once where you have to specify the correct type of the *private* `error` field. So downcasting from `Error::source()` effectively rely on the internal implementation of `AssetLoaderError`. The getter instead return the trait object directly, which mean it will directly downcast to the expected loader error type.

I didn't included a test that checks that double-downcasting `<AssetLoaderError as Error>::source()` doesn't break user code that would rely on the private field's type.

## Testing

- Downcasting the trait objects for both `source()` and the `error()` getter work as described above.
- `cargo test -p bevy_asset --all-features` pass without errors.