### PR TITLE
Return an error when adding the same asset label multiple times.

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -677,7 +677,7 @@ mod tests {
         },
         loader::{AssetLoader, LoadContext},
         Asset, AssetApp, AssetEvent, AssetId, AssetLoadError, AssetLoadFailedEvent, AssetPath,
-        AssetPlugin, AssetServer, Assets, LoadState, UnapprovedPathMode,
+        AssetPlugin, AssetServer, Assets, LoadDirectError, LoadState, UnapprovedPathMode,
     };
     use alloc::{
         boxed::Box,
@@ -1840,7 +1840,7 @@ mod tests {
 
         impl AssetLoader for NestedLoadOfSubassetLoader {
             type Asset = TestAsset;
-            type Error = crate::loader::LoadDirectError;
+            type Error = LoadDirectError;
             type Settings = ();
 
             async fn load(
@@ -1985,6 +1985,96 @@ mod tests {
                 // TODO: Check the error message matches here.
                 Some(())
             }
+            state => panic!("Unexpected asset state: {state:?}"),
+        });
+    }
+
+    #[test]
+    fn no_error_for_diamond_duplicate_subasset_names_in_immediate_nested_assets() {
+        // While we want to ban duplicate subasset names within an asset, having two nested assets
+        // that reuse a subasset name should be supported (since these subasset names are not owned
+        // by the root asset).
+        let mut app = App::new();
+
+        let dir = Dir::default();
+        dir.insert_asset_text(Path::new("a.root"), "");
+        dir.insert_asset_text(Path::new("b.nest"), "");
+        dir.insert_asset_text(Path::new("c.nest"), "");
+
+        app.register_asset_source(
+            AssetSourceId::Default,
+            AssetSource::build()
+                .with_reader(move || Box::new(MemoryAssetReader { root: dir.clone() })),
+        )
+        .add_plugins((TaskPoolPlugin::default(), AssetPlugin::default()));
+
+        struct NestedAssetLoader;
+
+        impl AssetLoader for NestedAssetLoader {
+            type Asset = TestAsset;
+            type Error = std::io::Error;
+            type Settings = ();
+
+            async fn load(
+                &self,
+                _: &mut dyn Reader,
+                _: &Self::Settings,
+                load_context: &mut LoadContext<'_>,
+            ) -> Result<Self::Asset, Self::Error> {
+                load_context.add_labeled_asset("Duplicate".into(), TestAsset);
+                Ok(TestAsset)
+            }
+
+            fn extensions(&self) -> &[&str] {
+                &["nest"]
+            }
+        }
+
+        struct DiamondDuplicateSubassetLoader;
+
+        impl AssetLoader for DiamondDuplicateSubassetLoader {
+            type Asset = TestAsset;
+            type Error = LoadDirectError;
+            type Settings = ();
+
+            async fn load(
+                &self,
+                _: &mut dyn Reader,
+                _: &Self::Settings,
+                load_context: &mut LoadContext<'_>,
+            ) -> Result<Self::Asset, Self::Error> {
+                let b = load_context
+                    .loader()
+                    .immediate()
+                    .load::<TestAsset>("b.nest")
+                    .await?;
+                let c = load_context
+                    .loader()
+                    .immediate()
+                    .load::<TestAsset>("c.nest")
+                    .await?;
+
+                load_context.add_loaded_labeled_asset("B", b);
+                load_context.add_loaded_labeled_asset("C", c);
+                Ok(TestAsset)
+            }
+
+            fn extensions(&self) -> &[&str] {
+                &["root"]
+            }
+        }
+
+        app.init_asset::<TestAsset>()
+            .init_asset::<SubText>()
+            .register_asset_loader(NestedAssetLoader)
+            .register_asset_loader(DiamondDuplicateSubassetLoader);
+
+        let asset_server = app.world().resource::<AssetServer>().clone();
+        let handle = asset_server.load::<TestAsset>("a.root");
+
+        run_app_until(&mut app, |_world| match asset_server.load_state(&handle) {
+            LoadState::Loading => None,
+            LoadState::Loaded => Some(()),
             state => panic!("Unexpected asset state: {state:?}"),
         });
     }

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -1428,9 +1428,15 @@ impl AssetServer {
     ) -> Result<ErasedLoadedAsset, AssetLoadError> {
         // TODO: experiment with this
         let asset_path = asset_path.clone_owned();
-        let load_context =
-            LoadContext::new(self, asset_path.clone(), load_dependencies, populate_hashes);
-        AssertUnwindSafe(loader.load(reader, meta, load_context))
+        let labeled_assets = Default::default();
+        let load_context = LoadContext::new(
+            self,
+            asset_path.clone(),
+            load_dependencies,
+            populate_hashes,
+            &labeled_assets,
+        );
+        let maybe_asset = AssertUnwindSafe(loader.load(reader, meta, load_context))
             .catch_unwind()
             .await
             .map_err(|_| AssetLoadError::AssetLoaderPanic {
@@ -1443,7 +1449,12 @@ impl AssetServer {
                     loader_name: loader.type_name(),
                     error: e.into(),
                 })
-            })
+            });
+        let labeled_assets = labeled_assets.into_inner().unwrap();
+        maybe_asset.map(move |mut asset| {
+            asset.labeled_assets = labeled_assets;
+            asset
+        })
     }
 
     /// Returns a future that will suspend until the specified asset and its dependencies finish

--- a/crates/bevy_gltf/src/loader/mod.rs
+++ b/crates/bevy_gltf/src/loader/mod.rs
@@ -506,10 +506,12 @@ async fn load_gltf<'a, 'b, 'c>(
                     );
                 }
             }
-            let handle = load_context.add_labeled_asset(
-                GltfAssetLabel::Animation(animation.index()).to_string(),
-                animation_clip,
-            );
+            let handle = load_context
+                .add_labeled_asset(
+                    GltfAssetLabel::Animation(animation.index()).to_string(),
+                    animation_clip,
+                )
+                .unwrap();
             if let Some(name) = animation.name() {
                 named_animations.insert(name.into(), handle.clone());
             }
@@ -662,7 +664,8 @@ async fn load_gltf<'a, 'b, 'c>(
                         RenderAssetUsages::default(),
                     )?;
                     let handle = load_context
-                        .add_labeled_asset(morph_targets_label.to_string(), morph_target_image.0);
+                        .add_labeled_asset(morph_targets_label.to_string(), morph_target_image.0)
+                        .unwrap();
 
                     mesh.set_morph_targets(handle);
                     let extras = gltf_mesh.extras().as_ref();
@@ -715,7 +718,9 @@ async fn load_gltf<'a, 'b, 'c>(
                 });
             }
 
-            let mesh_handle = load_context.add_labeled_asset(primitive_label.to_string(), mesh);
+            let mesh_handle = load_context
+                .add_labeled_asset(primitive_label.to_string(), mesh)
+                .unwrap();
             primitives.push(super::GltfPrimitive::new(
                 &gltf_mesh,
                 &primitive,
@@ -739,7 +744,9 @@ async fn load_gltf<'a, 'b, 'c>(
             gltf_mesh.extras().as_deref().map(GltfExtras::from),
         );
 
-        let handle = load_context.add_labeled_asset(mesh.asset_label().to_string(), mesh);
+        let handle = load_context
+            .add_labeled_asset(mesh.asset_label().to_string(), mesh)
+            .unwrap();
         if let Some(name) = gltf_mesh.name() {
             named_meshes.insert(name.into(), handle.clone());
         }
@@ -757,10 +764,12 @@ async fn load_gltf<'a, 'b, 'c>(
                     core::iter::repeat_n(Mat4::IDENTITY, gltf_skin.joints().len()).collect()
                 });
 
-            load_context.add_labeled_asset(
-                GltfAssetLabel::InverseBindMatrices(gltf_skin.index()).to_string(),
-                SkinnedMeshInverseBindposes::from(local_to_bone_bind_matrices),
-            )
+            load_context
+                .add_labeled_asset(
+                    GltfAssetLabel::InverseBindMatrices(gltf_skin.index()).to_string(),
+                    SkinnedMeshInverseBindposes::from(local_to_bone_bind_matrices),
+                )
+                .unwrap()
         })
         .collect();
 
@@ -809,7 +818,8 @@ async fn load_gltf<'a, 'b, 'c>(
                     );
 
                     let handle = load_context
-                        .add_labeled_asset(gltf_skin.asset_label().to_string(), gltf_skin);
+                        .add_labeled_asset(gltf_skin.asset_label().to_string(), gltf_skin)
+                        .unwrap();
 
                     if let Some(name) = skin.name() {
                         named_skins.insert(name.into(), handle.clone());
@@ -842,7 +852,9 @@ async fn load_gltf<'a, 'b, 'c>(
         #[cfg(feature = "bevy_animation")]
         let gltf_node = gltf_node.with_animation_root(animation_roots.contains(&node.index()));
 
-        let handle = load_context.add_labeled_asset(gltf_node.asset_label().to_string(), gltf_node);
+        let handle = load_context
+            .add_labeled_asset(gltf_node.asset_label().to_string(), gltf_node)
+            .unwrap();
         nodes.insert(node.index(), handle.clone());
         if let Some(name) = node.name() {
             named_nodes.insert(name.into(), handle);
@@ -931,10 +943,12 @@ async fn load_gltf<'a, 'b, 'c>(
             });
         }
         let loaded_scene = scene_load_context.finish(Scene::new(world));
-        let scene_handle = load_context.add_loaded_labeled_asset(
-            GltfAssetLabel::Scene(scene.index()).to_string(),
-            loaded_scene,
-        );
+        let scene_handle = load_context
+            .add_loaded_labeled_asset(
+                GltfAssetLabel::Scene(scene.index()).to_string(),
+                loaded_scene,
+            )
+            .unwrap();
 
         if let Some(name) = scene.name() {
             named_scenes.insert(name.into(), scene_handle.clone());
@@ -1704,9 +1718,9 @@ impl ImageOrPath {
         handles: &mut Vec<Handle<Image>>,
     ) {
         let handle = match self {
-            ImageOrPath::Image { label, image } => {
-                load_context.add_labeled_asset(label.to_string(), image)
-            }
+            ImageOrPath::Image { label, image } => load_context
+                .add_labeled_asset(label.to_string(), image)
+                .unwrap(),
             ImageOrPath::Path {
                 path,
                 is_srgb,

--- a/release-content/migration-guides/duplicate_subasset_label_error.md
+++ b/release-content/migration-guides/duplicate_subasset_label_error.md
@@ -1,0 +1,9 @@
+---
+title: Adding duplicate subassets names now returns an error.
+pull_requests: [19485]
+---
+
+Previously, when adding a subasset in a loader through `LoadContext::add_labeled_asset` (and
+friends), adding the same subasset name multiple times would silently replace the asset (and which
+one would be used was undefined). Now these functions return an error if the subasset label was
+already present. You can use `?` to return the error from `AssetLoader`s.


### PR DESCRIPTION
# Objective

- Fixes #19026.

## Solution

- Make the labeled assets in `LoadContext` be a `&Mutex<HashMap>`.
- Make `LoadContext`s for subassets reuse the same `&Mutex<HashMap>`.
- Immediately-loaded nested assets will naturally get a separate `Mutex<HashMap>`, so their subassets will be managed separately.

## Testing

- Added tests to show the various cases working.
