### PR TITLE
Improve documentation on `Specialized*Pipeline*`.

### DIFF
--- a/crates/bevy_render/src/render_resource/pipeline_specializer.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_specializer.rs
@@ -143,7 +143,7 @@ pub struct SpecializedMeshPipelines<S: SpecializedMeshPipeline> {
     vertex_layout_cache: VertexLayoutCache<S>,
 }
 
-pub type VertexLayoutCache<S> = HashMap<
+type VertexLayoutCache<S> = HashMap<
     VertexBufferLayout,
     HashMap<<S as SpecializedMeshPipeline>::Key, CachedRenderPipelineId>,
 >;

--- a/crates/bevy_render/src/render_resource/pipeline_specializer.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_specializer.rs
@@ -20,8 +20,11 @@ use tracing::error;
 
 /// A trait that allows constructing different variants of a render pipeline from a key.
 ///
-/// Note: If your key is a ZST, you do not need to "specialize" anything. Just create the render
-/// pipeline once and store its ID.
+/// Note: This is intended for modifying your pipeline descriptor on the basis of a key. If your key
+/// contains no data then you don't need to specialize. For example, if you are using the
+/// [`AsBindGroup`](crate::render_resource::AsBindGroup) without the `#[bind_group_data]` attribute,
+/// you don't need to specialize. Instead, create the pipeline directly from [`PipelineCache`] and
+/// store its ID.
 ///
 /// See [`SpecializedRenderPipelines`] for more info.
 pub trait SpecializedRenderPipeline {
@@ -39,8 +42,11 @@ pub trait SpecializedRenderPipeline {
 /// making it easy to A) construct the necessary pipelines, and B) reuse already constructed
 /// pipelines.
 ///
-/// Note: If your key is a ZST, you do not need to "specialize" anything. Just create the render
-/// pipeline once and store its ID.
+/// Note: This is intended for modifying your pipeline descriptor on the basis of a key. If your key
+/// contains no data then you don't need to specialize. For example, if you are using the
+/// [`AsBindGroup`](crate::render_resource::AsBindGroup) without the `#[bind_group_data]` attribute,
+/// you don't need to specialize. Instead, create the pipeline directly from [`PipelineCache`] and
+/// store its ID.
 #[derive(Resource)]
 pub struct SpecializedRenderPipelines<S: SpecializedRenderPipeline> {
     cache: HashMap<S::Key, CachedRenderPipelineId>,
@@ -69,8 +75,11 @@ impl<S: SpecializedRenderPipeline> SpecializedRenderPipelines<S> {
 
 /// A trait that allows constructing different variants of a compute pipeline from a key.
 ///
-/// Note: If your key is a ZST, you do not need to "specialize" anything. Just create the compute
-/// pipeline once and store its ID.
+/// Note: This is intended for modifying your pipeline descriptor on the basis of a key. If your key
+/// contains no data then you don't need to specialize. For example, if you are using the
+/// [`AsBindGroup`](crate::render_resource::AsBindGroup) without the `#[bind_group_data]` attribute,
+/// you don't need to specialize. Instead, create the pipeline directly from [`PipelineCache`] and
+/// store its ID.
 ///
 /// See [`SpecializedComputePipelines`] for more info.
 pub trait SpecializedComputePipeline {
@@ -88,8 +97,11 @@ pub trait SpecializedComputePipeline {
 /// making it easy to A) construct the necessary pipelines, and B) reuse already constructed
 /// pipelines.
 ///
-/// Note: If your key is a ZST, you do not need to "specialize" anything. Just create the compute
-/// pipeline once and store its ID.
+/// Note: This is intended for modifying your pipeline descriptor on the basis of a key. If your key
+/// contains no data then you don't need to specialize. For example, if you are using the
+/// [`AsBindGroup`](crate::render_resource::AsBindGroup) without the `#[bind_group_data]` attribute,
+/// you don't need to specialize. Instead, create the pipeline directly from [`PipelineCache`] and
+/// store its ID.
 #[derive(Resource)]
 pub struct SpecializedComputePipelines<S: SpecializedComputePipeline> {
     cache: HashMap<S::Key, CachedComputePipelineId>,

--- a/crates/bevy_render/src/render_resource/pipeline_specializer.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_specializer.rs
@@ -57,11 +57,11 @@ impl<S: SpecializedRenderPipeline> SpecializedRenderPipelines<S> {
     pub fn specialize(
         &mut self,
         cache: &PipelineCache,
-        specialize_pipeline: &S,
+        pipeline_specializer: &S,
         key: S::Key,
     ) -> CachedRenderPipelineId {
         *self.cache.entry(key.clone()).or_insert_with(|| {
-            let descriptor = specialize_pipeline.specialize(key);
+            let descriptor = pipeline_specializer.specialize(key);
             cache.queue_render_pipeline(descriptor)
         })
     }
@@ -164,7 +164,7 @@ impl<S: SpecializedMeshPipeline> SpecializedMeshPipelines<S> {
     pub fn specialize(
         &mut self,
         cache: &PipelineCache,
-        specialize_pipeline: &S,
+        pipeline_specializer: &S,
         key: S::Key,
         layout: &MeshVertexBufferLayoutRef,
     ) -> Result<CachedRenderPipelineId, SpecializedMeshPipelineError> {
@@ -173,7 +173,7 @@ impl<S: SpecializedMeshPipeline> SpecializedMeshPipelines<S> {
             Entry::Vacant(entry) => specialize_slow(
                 &mut self.vertex_layout_cache,
                 cache,
-                specialize_pipeline,
+                pipeline_specializer,
                 key,
                 layout,
                 entry,


### PR DESCRIPTION
# Objective

- Title.

## Solution

- Add an explanation of the various traits and structs.
- Make VertexLayoutCache private - this type is not used anywhere, and it's just a type alias for a HashMap with no other utility functions.
- Rename `specialize_pipeline` argument to `pipeline_specializer` to clarify this is more like a factory than a render pipeline.

Technically making `VertexLayoutCache` private is a breaking change, but it seems highly unlikely that anyone is using this (since it's just a hashmap alias. I don't think this needs a migration guide.