### PR TITLE
Delete `System::component_access()`.

### DIFF
--- a/crates/bevy_ecs/src/schedule/executor/mod.rs
+++ b/crates/bevy_ecs/src/schedule/executor/mod.rs
@@ -18,7 +18,7 @@ use crate::{
     component::{ComponentId, Tick},
     error::{BevyError, ErrorContext, Result},
     prelude::{IntoSystemSet, SystemSet},
-    query::{Access, FilteredAccessSet},
+    query::FilteredAccessSet,
     schedule::{BoxedCondition, InternedSystemSet, NodeId, SystemTypeSet},
     system::{ScheduleSystem, System, SystemIn, SystemParamValidationError, SystemStateFlags},
     world::{unsafe_world_cell::UnsafeWorldCell, DeferredWorld, World},
@@ -162,12 +162,8 @@ impl System for ApplyDeferred {
         Cow::Borrowed("bevy_ecs::apply_deferred")
     }
 
-    fn component_access(&self) -> &Access<ComponentId> {
-        // This system accesses no components.
-        const { &Access::new() }
-    }
-
     fn component_access_set(&self) -> &FilteredAccessSet<ComponentId> {
+        // This system accesses no components.
         const { &FilteredAccessSet::new() }
     }
 

--- a/crates/bevy_ecs/src/system/adapter_system.rs
+++ b/crates/bevy_ecs/src/system/adapter_system.rs
@@ -127,10 +127,6 @@ where
         self.name.clone()
     }
 
-    fn component_access(&self) -> &crate::query::Access<crate::component::ComponentId> {
-        self.system.component_access()
-    }
-
     fn component_access_set(
         &self,
     ) -> &crate::query::FilteredAccessSet<crate::component::ComponentId> {

--- a/crates/bevy_ecs/src/system/combinator.rs
+++ b/crates/bevy_ecs/src/system/combinator.rs
@@ -4,7 +4,7 @@ use core::marker::PhantomData;
 use crate::{
     component::{ComponentId, Tick},
     prelude::World,
-    query::{Access, FilteredAccessSet},
+    query::FilteredAccessSet,
     schedule::InternedSystemSet,
     system::{input::SystemInput, SystemIn, SystemParamValidationError},
     world::unsafe_world_cell::UnsafeWorldCell,
@@ -142,10 +142,6 @@ where
 
     fn name(&self) -> Cow<'static, str> {
         self.name.clone()
-    }
-
-    fn component_access(&self) -> &Access<ComponentId> {
-        self.component_access_set.combined_access()
     }
 
     fn component_access_set(&self) -> &FilteredAccessSet<ComponentId> {
@@ -361,10 +357,6 @@ where
 
     fn name(&self) -> Cow<'static, str> {
         self.name.clone()
-    }
-
-    fn component_access(&self) -> &Access<ComponentId> {
-        self.component_access_set.combined_access()
     }
 
     fn component_access_set(&self) -> &FilteredAccessSet<ComponentId> {

--- a/crates/bevy_ecs/src/system/exclusive_function_system.rs
+++ b/crates/bevy_ecs/src/system/exclusive_function_system.rs
@@ -1,6 +1,6 @@
 use crate::{
     component::{ComponentId, Tick},
-    query::{Access, FilteredAccessSet},
+    query::FilteredAccessSet,
     schedule::{InternedSystemSet, SystemSet},
     system::{
         check_system_change_tick, ExclusiveSystemParam, ExclusiveSystemParamItem, IntoSystem,
@@ -85,11 +85,6 @@ where
     #[inline]
     fn name(&self) -> Cow<'static, str> {
         self.system_meta.name.clone()
-    }
-
-    #[inline]
-    fn component_access(&self) -> &Access<ComponentId> {
-        self.system_meta.component_access_set.combined_access()
     }
 
     #[inline]

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -1,7 +1,7 @@
 use crate::{
     component::{ComponentId, Tick},
     prelude::FromWorld,
-    query::{Access, FilteredAccessSet},
+    query::FilteredAccessSet,
     schedule::{InternedSystemSet, SystemSet},
     system::{
         check_system_change_tick, ReadOnlySystemParam, System, SystemIn, SystemInput, SystemParam,
@@ -618,11 +618,6 @@ where
     #[inline]
     fn name(&self) -> Cow<'static, str> {
         self.system_meta.name.clone()
-    }
-
-    #[inline]
-    fn component_access(&self) -> &Access<ComponentId> {
-        self.system_meta.component_access_set.combined_access()
     }
 
     #[inline]

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -1166,7 +1166,9 @@ mod tests {
         x.initialize(&mut world);
         y.initialize(&mut world);
 
-        let conflicts = x.component_access().get_conflicts(y.component_access());
+        let conflicts = x
+            .component_access_set()
+            .get_conflicts(y.component_access_set());
         let b_id = world
             .components()
             .get_resource_id(TypeId::of::<B>())

--- a/crates/bevy_ecs/src/system/observer_system.rs
+++ b/crates/bevy_ecs/src/system/observer_system.rs
@@ -6,7 +6,7 @@ use crate::{
     error::Result,
     never::Never,
     prelude::{Bundle, Trigger},
-    query::{Access, FilteredAccessSet},
+    query::FilteredAccessSet,
     schedule::{Fallible, Infallible},
     system::{input::SystemIn, System},
     world::{unsafe_world_cell::UnsafeWorldCell, DeferredWorld, World},
@@ -114,11 +114,6 @@ where
     #[inline]
     fn name(&self) -> Cow<'static, str> {
         self.observer.name()
-    }
-
-    #[inline]
-    fn component_access(&self) -> &Access<ComponentId> {
-        self.observer.component_access()
     }
 
     #[inline]

--- a/crates/bevy_ecs/src/system/schedule_system.rs
+++ b/crates/bevy_ecs/src/system/schedule_system.rs
@@ -3,7 +3,7 @@ use alloc::{borrow::Cow, vec::Vec};
 use crate::{
     component::{ComponentId, Tick},
     error::Result,
-    query::{Access, FilteredAccessSet},
+    query::FilteredAccessSet,
     system::{input::SystemIn, BoxedSystem, System, SystemInput},
     world::{unsafe_world_cell::UnsafeWorldCell, DeferredWorld, FromWorld, World},
 };
@@ -31,11 +31,6 @@ impl<S: System<In = ()>> System for InfallibleSystemWrapper<S> {
 
     fn type_id(&self) -> core::any::TypeId {
         self.0.type_id()
-    }
-
-    #[inline]
-    fn component_access(&self) -> &Access<ComponentId> {
-        self.0.component_access()
     }
 
     #[inline]
@@ -154,10 +149,6 @@ where
         self.system.name()
     }
 
-    fn component_access(&self) -> &Access<ComponentId> {
-        self.system.component_access()
-    }
-
     fn component_access_set(&self) -> &FilteredAccessSet<ComponentId> {
         self.system.component_access_set()
     }
@@ -254,10 +245,6 @@ where
 
     fn name(&self) -> Cow<'static, str> {
         self.system.name()
-    }
-
-    fn component_access(&self) -> &Access<ComponentId> {
-        self.system.component_access()
     }
 
     fn component_access_set(&self) -> &FilteredAccessSet<ComponentId> {

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 
 use crate::{
     component::{ComponentId, Tick},
-    query::{Access, FilteredAccessSet},
+    query::FilteredAccessSet,
     schedule::InternedSystemSet,
     system::{input::SystemInput, SystemIn},
     world::{unsafe_world_cell::UnsafeWorldCell, DeferredWorld, World},
@@ -56,9 +56,6 @@ pub trait System: Send + Sync + 'static {
     fn type_id(&self) -> TypeId {
         TypeId::of::<Self>()
     }
-
-    /// Returns the system's component [`Access`].
-    fn component_access(&self) -> &Access<ComponentId>;
 
     /// Returns the system's component [`FilteredAccessSet`].
     fn component_access_set(&self) -> &FilteredAccessSet<ComponentId>;

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -36,7 +36,7 @@ use thiserror::Error;
 ///
 /// This alone is not enough to implement bevy systems where multiple systems can access *disjoint* parts of the world concurrently. For this, bevy stores all values of
 /// resources and components (and [`ComponentTicks`]) in [`UnsafeCell`]s, and carefully validates disjoint access patterns using
-/// APIs like [`System::component_access`](crate::system::System::component_access).
+/// APIs like [`System::component_access_set`](crate::system::System::component_access_set).
 ///
 /// A system then can be executed using [`System::run_unsafe`](crate::system::System::run_unsafe) with a `&World` and use methods with interior mutability to access resource values.
 ///

--- a/release-content/migration-guides/delete_component_access.md
+++ b/release-content/migration-guides/delete_component_access.md
@@ -1,0 +1,10 @@
+---
+title: `System::component_access` has been deleted.
+pull_requests: [19496]
+---
+
+`System::component_access` has been deleted. If you were calling this method, you can simply use
+`my_system.component_access_set().combined_access()` to get the same result.
+
+If you were manually implementing this, it should be equivalent to `System::component_access_set`
+anyway.


### PR DESCRIPTION
# Objective

- Cleanup related to #19495.

## Solution

- Delete `System::component_access()`. It is redundant with `System::component_access_set().combined_access()`.

## Testing

- None. There are no callers of this function.