### PR TITLE
Fix iOS simulator build

### DIFF
--- a/crates/bevy_audio/Cargo.toml
+++ b/crates/bevy_audio/Cargo.toml
@@ -19,11 +19,17 @@ bevy_transform = { path = "../bevy_transform", version = "0.16.0-dev" }
 bevy_derive = { path = "../bevy_derive", version = "0.16.0-dev" }
 
 # other
+# TODO: Remove `coreaudio-sys` dep below when updating `cpal`.
 rodio = { version = "0.20", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
 cpal = { version = "0.15", optional = true }
+
+[target.'cfg(target_vendor = "apple")'.dependencies]
+# NOTE: Explicitly depend on this patch version to fix:
+# https://github.com/bevyengine/bevy/issues/18893
+coreaudio-sys = { version = "0.2.17", default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # TODO: Assuming all wasm builds are for the browser. Require `no_std` support to break assumption.

--- a/crates/bevy_log/Cargo.toml
+++ b/crates/bevy_log/Cargo.toml
@@ -45,7 +45,7 @@ bevy_app = { path = "../bevy_app", version = "0.16.0-dev", default-features = fa
 ] }
 
 [target.'cfg(target_os = "ios")'.dependencies]
-tracing-oslog = "0.2"
+tracing-oslog = "0.3"
 
 [lints]
 workspace = true


### PR DESCRIPTION
# Objective

Fixes https://github.com/bevyengine/bevy/issues/18893.

## Solution

`bindgen` currently has issues with building Xcode 16.3 and above, due to Clang being more strict about target triples. It was fixed in https://github.com/rust-lang/rust-bindgen/pull/3182, but as a breaking release, so affected dependencies have to be updated to either not depend on `bindgen`, or depend on a fixed version of it:
- `tracing-oslog`: https://github.com/Absolucy/tracing-oslog/pull/12
- `coreaudio-sys`: https://github.com/RustAudio/coreaudio-sys/pull/114

## Testing

```sh
cargo build --target aarch64-apple-ios-sim
```

With Xcode 16.3 or 16.4.