### PR TITLE
Check pipeline exists before queueing

### DIFF
--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -1145,7 +1145,7 @@ pub fn queue_material_meshes<M: Material>(
         };
 
         let Some(view_specialized_material_pipeline_cache) =
-            specialized_material_pipeline_cache.get(&view.retained_view_entity)
+            specialized_material_pipeline_cache.get_mut(&view.retained_view_entity)
         else {
             continue;
         };
@@ -1154,7 +1154,8 @@ pub fn queue_material_meshes<M: Material>(
         for (render_entity, visible_entity) in visible_entities.iter::<Mesh3d>() {
             let Some((current_change_tick, pipeline_id)) = view_specialized_material_pipeline_cache
                 .get(visible_entity)
-                .map(|(current_change_tick, pipeline_id)| (*current_change_tick, *pipeline_id))
+                .cloned()
+                .map(|(current_change_tick, pipeline_id)| (current_change_tick, pipeline_id))
             else {
                 continue;
             };
@@ -1185,9 +1186,7 @@ pub fn queue_material_meshes<M: Material>(
                     "Material {:?} for mesh {:?} has no pipeline {:?}",
                     material_asset_id, mesh_instance.mesh_asset_id, pipeline_id
                 );
-                specialized_material_pipeline_cache
-                    .get_mut(&view.retained_view_entity)
-                    .and_then(|cache| cache.remove(visible_entity));
+                view_specialized_material_pipeline_cache.remove(visible_entity);
                 continue;
             }
 

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -54,7 +54,7 @@ use bevy_render::{mesh::allocator::MeshAllocator, sync_world::MainEntityHashMap}
 use bevy_render::{texture::FallbackImage, view::RenderVisibleEntities};
 use bevy_utils::Parallel;
 use core::{hash::Hash, marker::PhantomData};
-use tracing::{error, warn};
+use tracing::error;
 
 /// Materials are used alongside [`MaterialPlugin`], [`Mesh3d`], and [`MeshMaterial3d`]
 /// to spawn entities that are rendered with a specific [`Material`] type. They serve as an easy to use high level
@@ -1154,8 +1154,7 @@ pub fn queue_material_meshes<M: Material>(
         for (render_entity, visible_entity) in visible_entities.iter::<Mesh3d>() {
             let Some((current_change_tick, pipeline_id)) = view_specialized_material_pipeline_cache
                 .get(visible_entity)
-                .cloned()
-                .map(|(current_change_tick, pipeline_id)| (current_change_tick, pipeline_id))
+                .map(|(current_change_tick, pipeline_id)| (*current_change_tick, *pipeline_id))
             else {
                 continue;
             };

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -1182,10 +1182,6 @@ pub fn queue_material_meshes<M: Material>(
                 continue;
             };
             if let None = pipeline_cache.get_render_pipeline(pipeline_id) {
-                warn!(
-                    "Material {:?} for mesh {:?} has no pipeline {:?}",
-                    material_asset_id, mesh_instance.mesh_asset_id, pipeline_id
-                );
                 view_specialized_material_pipeline_cache.remove(visible_entity);
                 continue;
             }


### PR DESCRIPTION
If a cached pipeline is removed, queueing with the invalid pipeline id may cause phase items to silently not be rendered due to changes in https://github.com/bevyengine/bevy/pull/18752.