### PR TITLE
Copy stress test settings for many_camera_lights

### DIFF
--- a/examples/stress_tests/many_cameras_lights.rs
+++ b/examples/stress_tests/many_cameras_lights.rs
@@ -6,11 +6,19 @@ use bevy::{
     math::ops::{cos, sin},
     prelude::*,
     render::camera::Viewport,
+    window::{PresentMode, WindowResolution},
 };
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugins(DefaultPlugins.set(WindowPlugin {
+            primary_window: Some(Window {
+                present_mode: PresentMode::AutoNoVsync,
+                resolution: WindowResolution::new(1920.0, 1080.0).with_scale_factor_override(1.0),
+                ..default()
+            }),
+            ..default()
+        }))
         .add_systems(Startup, setup)
         .add_systems(Update, rotate_cameras)
         .run();


### PR DESCRIPTION
# Objective

- Fixes #17183

## Solution

- Copied the stress settings from the `many_animated_sprite` example that were mentioned in the ticket

## Testing

- Run the example

