### PR TITLE
Allow new mismatched_lifetime_syntaxes lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ allow_attributes_without_reason = "warn"
 
 [workspace.lints.rust]
 missing_docs = "warn"
+mismatched_lifetime_syntaxes = "allow"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(docsrs_dep)'] }
 unsafe_code = "deny"
 unsafe_op_in_unsafe_fn = "warn"


### PR DESCRIPTION
# Objective

The new nightly lint produces [unhelpful, noisy output](http://github.com/bevyengine/bevy/actions/runs/15491867876/job/43620116435?pr=19510) that makes lifetimes more prominent in our library code than we generally find helpful.

This needs to be fixed or allowed, in order to unbreak CI for every PR in this repo.

## Solution

Blanket allow the lint at the workspace level.

## Testing

Let's see if CI passes!
