### PR TITLE
Remove re-exports of cosmic_text types

### DIFF
--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -1,8 +1,3 @@
-pub use cosmic_text::{
-    self, FamilyOwned as FontFamily, Stretch as FontStretch, Style as FontStyle,
-    Weight as FontWeight,
-};
-
 use crate::{Font, TextLayoutInfo, TextSpanAccess, TextSpanComponent};
 use bevy_asset::Handle;
 use bevy_color::Color;

--- a/release-content/migration-guides/remove_cosmic_text_reexports.md
+++ b/release-content/migration-guides/remove_cosmic_text_reexports.md
@@ -1,0 +1,18 @@
+---
+title: Removed `cosmic_text` re-exports
+pull_requests: [TODO]
+---
+
+Previously, `bevy_text` re-exported the entirety of `cosmic_text` while renaming a few of the most confusing re-exports,
+using the following code.
+
+```rust
+pub use cosmic_text::{
+    self, FamilyOwned as FontFamily, Stretch as FontStretch, Style as FontStyle, Weight as FontWeight,
+};
+```
+
+These re-exports commonly conflicted with other types (like `Query`!), leading to messy autocomplete errors.
+Ultimately, these are largely an implementation detail, and were not widely used.
+
+We've completely removed these re-exports (including the renamed types): if you need to use these types, please rely on them directly from `cosmic_text`, being sure that the version number you are using matches the version used by your version of `bevy_text`.


### PR DESCRIPTION
# Objective

As discussed in #19285, we do a poor job at keeping the namespace tidy and free of duplicates / user-conflicting names in places. `cosmic_text` re-exports were the worst offender.

## Solution

Remove the re-exports completely. While the type aliases were quite thoughtful, they weren't used in any of our code / API.