### PR TITLE
Spawn batch with relationship

### DIFF
--- a/crates/bevy_ecs/src/relationship/mod.rs
+++ b/crates/bevy_ecs/src/relationship/mod.rs
@@ -458,4 +458,31 @@ mod tests {
         assert!(world.get_entity(child).is_err());
         assert!(!world.entity(parent).contains::<RelTarget>());
     }
+
+    // Spawn a batch of entities in relationship with a target entity
+    #[test]
+    fn spawn_batch_with_relationship() {
+        use crate::relationship::{Relationship, RelationshipTarget};
+
+        #[derive(Component)]
+        #[relationship(relationship_target = RelTarget)]
+        struct Rel(Entity);
+
+        #[derive(Component)]
+        #[relationship_target(relationship = Rel)]
+        struct RelTarget(Vec<Entity>);
+
+        let mut world = World::new();
+        let target = world.spawn_empty().id();
+        let rel_entities = world
+            .spawn_batch((0..10).map(|_| Rel(target)))
+            .collect::<Vec<_>>();
+
+        for &entity in &rel_entities {
+            assert!(world.get::<Rel>(entity).is_some_and(|r| r.get() == target));
+        }
+        assert!(world
+            .get::<RelTarget>(target)
+            .is_some_and(|rt| rt.len() == 10));
+    }
 }


### PR DESCRIPTION
# Objective

Fixes #19356
Issue: Spawning a batch of entities in relationship with the same target adds the relationship between the target and only the last entity of the batch. `spawn_batch` flushes only after having spawned all entities. This means each spawned entity will have run the `on_insert` hook of its `Relationship` component. Here is the relevant part of that hook:
```Rust
            if let Some(mut relationship_target) =
                target_entity_mut.get_mut::<Self::RelationshipTarget>()
            {
                relationship_target.collection_mut_risky().add(entity);
            } else {
                let mut target = <Self::RelationshipTarget as RelationshipTarget>::with_capacity(1);
                target.collection_mut_risky().add(entity);
                world.commands().entity(target_entity).insert(target);
            }
```
Given the above snippet and since there's no flush between spawns, each entity finds the target without a `RelationshipTarget` component and defers the insertion of that component with the entity's id as the sole member of its collection. When the commands are finally flushed, each insertion after the first replaces the one before and in the process triggers the `on_replace` hook of `RelationshipTarget` which removes the `Relationship` component from the corresponding entity. That's how we end up in the invalid state.

## Solution

I see two possible solutions
1. Flush after every spawn
2. Defer the whole code snippet above

I don't know enough about bevy as a whole but 2. seems much more efficient to me. This is what I'm proposing here. I have a doubt though because I've started to look at #19348 that 1. would fix as well.

## Testing

I added a test for the issue. I've put it in `relationship/mod.rs` but I could see it in `world/spawn_batch.rs` or `lib.rs` because the test is as much about `spawn_batch` as it is about relationships.