### PR TITLE
Gradients example: Fit in initial window

### DIFF
--- a/examples/ui/gradients.rs
+++ b/examples/ui/gradients.rs
@@ -26,20 +26,20 @@ fn setup(mut commands: Commands) {
     commands
         .spawn(Node {
             flex_direction: FlexDirection::Column,
-            row_gap: Val::Px(30.),
-            margin: UiRect::all(Val::Px(30.)),
+            row_gap: Val::Px(20.),
+            margin: UiRect::all(Val::Px(20.)),
             ..Default::default()
         })
         .with_children(|commands| {
             for (b, stops) in [
                 (
-                    5.,
+                    4.,
                     vec![
                         ColorStop::new(Color::WHITE, Val::Percent(15.)),
                         ColorStop::new(Color::BLACK, Val::Percent(85.)),
                     ],
                 ),
-                (5., vec![RED.into(), BLUE.into(), LIME.into()]),
+                (4., vec![RED.into(), BLUE.into(), LIME.into()]),
                 (
                     0.,
                     vec![
@@ -64,11 +64,11 @@ fn setup(mut commands: Commands) {
                     commands
                         .spawn(Node {
                             flex_direction: FlexDirection::Column,
-                            row_gap: Val::Px(10.),
+                            row_gap: Val::Px(5.),
                             ..Default::default()
                         })
                         .with_children(|commands| {
-                            for (w, h) in [(100., 100.), (50., 100.), (100., 50.)] {
+                            for (w, h) in [(70., 70.), (35., 70.), (70., 35.)] {
                                 commands
                                     .spawn(Node {
                                         column_gap: Val::Px(10.),
@@ -108,7 +108,7 @@ fn setup(mut commands: Commands) {
                                 aspect_ratio: Some(1.),
                                 height: Val::Percent(100.),
                                 border: UiRect::all(Val::Px(b)),
-                                margin: UiRect::left(Val::Px(30.)),
+                                margin: UiRect::left(Val::Px(20.)),
                                 ..default()
                             },
                             BorderRadius::all(Val::Px(20.)),
@@ -128,7 +128,7 @@ fn setup(mut commands: Commands) {
                                 aspect_ratio: Some(1.),
                                 height: Val::Percent(100.),
                                 border: UiRect::all(Val::Px(b)),
-                                margin: UiRect::left(Val::Px(30.)),
+                                margin: UiRect::left(Val::Px(20.)),
                                 ..default()
                             },
                             BorderRadius::all(Val::Px(20.)),
@@ -148,7 +148,7 @@ fn setup(mut commands: Commands) {
                                 aspect_ratio: Some(1.),
                                 height: Val::Percent(100.),
                                 border: UiRect::all(Val::Px(b)),
-                                margin: UiRect::left(Val::Px(30.)),
+                                margin: UiRect::left(Val::Px(20.)),
                                 ..default()
                             },
                             BorderRadius::all(Val::Px(20.)),


### PR DESCRIPTION
# Objective

When running the `gradient` example, part of the content doesn't fit within the initial window:
![Screenshot from 2025-06-07 11-42-59](https://github.com/user-attachments/assets/a54223db-0223-4a6e-b8e7-adb306706b28)

The UI requires 1830×930 pixels, but the initial window size is 1280×720.

## Solution

Make ui elements smaller:
![Screenshot from 2025-06-07 11-42-13](https://github.com/user-attachments/assets/c1afc01e-51be-4295-8c0f-6a983fbb0969)

Alternative: Use a larger initial window size. I decided against this because that would make the examples less uniform, make the code less focused on gradients and not help on web.