### PR TITLE
Move `TextShadow` into `bevy_text`

### DIFF
--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -62,7 +62,7 @@ pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
         Font, JustifyText, LineBreak, Text2d, Text2dReader, Text2dWriter, TextColor, TextError,
-        TextFont, TextLayout, TextSpan,
+        TextFont, TextLayout, TextShadow, TextSpan,
     };
 }
 
@@ -106,6 +106,7 @@ impl Plugin for TextPlugin {
             .register_type::<TextSpan>()
             .register_type::<TextBounds>()
             .register_type::<TextLayout>()
+            .register_type::<TextShadow>()
             .register_type::<ComputedTextBlock>()
             .register_type::<TextEntity>()
             .init_asset_loader::<FontLoader>()

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -3,6 +3,7 @@ use bevy_asset::Handle;
 use bevy_color::Color;
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{prelude::*, reflect::ReflectComponent};
+use bevy_math::Vec2;
 use bevy_reflect::prelude::*;
 use bevy_utils::once;
 use cosmic_text::{Buffer, Metrics};
@@ -575,6 +576,28 @@ pub fn detect_text_needs_rerender<Root: Component>(
                 break;
             };
             parent = next_child_of.parent();
+        }
+    }
+}
+
+/// Adds a shadow behind text
+///
+/// Not supported by `Text2d`.
+#[derive(Component, Copy, Clone, Debug, Reflect)]
+#[reflect(Component, Default, Debug, Clone)]
+pub struct TextShadow {
+    /// Shadow displacement in logical pixels
+    /// With a value of zero the shadow will be hidden directly behind the text
+    pub offset: Vec2,
+    /// Color of the shadow
+    pub color: Color,
+}
+
+impl Default for TextShadow {
+    fn default() -> Self {
+        Self {
+            offset: Vec2::splat(4.),
+            color: Color::linear_rgba(0., 0., 0., 0.75),
         }
     }
 }

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -179,7 +179,6 @@ impl Plugin for UiPlugin {
             .register_type::<Outline>()
             .register_type::<BoxShadowSamples>()
             .register_type::<UiAntiAlias>()
-            .register_type::<TextShadow>()
             .register_type::<ColorStop>()
             .register_type::<AngularColorStop>()
             .register_type::<UiPosition>()

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -11,7 +11,7 @@ mod gradient;
 use crate::widget::{ImageNode, ViewportNode};
 use crate::{
     BackgroundColor, BorderColor, BoxShadowSamples, CalculatedClip, ComputedNode,
-    ComputedNodeTarget, Outline, ResolvedBorderRadius, TextShadow, UiAntiAlias,
+    ComputedNodeTarget, Outline, ResolvedBorderRadius, UiAntiAlias,
 };
 use bevy_app::prelude::*;
 use bevy_asset::{AssetEvent, AssetId, Assets};
@@ -55,7 +55,7 @@ use gradient::GradientPlugin;
 use crate::{Display, Node};
 use bevy_platform::collections::{HashMap, HashSet};
 use bevy_text::{
-    ComputedTextBlock, PositionedGlyph, TextBackgroundColor, TextColor, TextLayoutInfo,
+    ComputedTextBlock, PositionedGlyph, TextBackgroundColor, TextColor, TextLayoutInfo, TextShadow,
 };
 use bevy_transform::components::GlobalTransform;
 use box_shadow::BoxShadowPlugin;

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -2795,26 +2795,6 @@ impl ComputedNodeTarget {
     }
 }
 
-/// Adds a shadow behind text
-#[derive(Component, Copy, Clone, Debug, Reflect)]
-#[reflect(Component, Default, Debug, Clone)]
-pub struct TextShadow {
-    /// Shadow displacement in logical pixels
-    /// With a value of zero the shadow will be hidden directly behind the text
-    pub offset: Vec2,
-    /// Color of the shadow
-    pub color: Color,
-}
-
-impl Default for TextShadow {
-    fn default() -> Self {
-        Self {
-            offset: Vec2::splat(4.),
-            color: Color::linear_rgba(0., 0., 0., 0.75),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use crate::GridPlacement;

--- a/release-content/migration-guides/textshadow_moved_to_bevy_text.md
+++ b/release-content/migration-guides/textshadow_moved_to_bevy_text.md
@@ -9,3 +9,4 @@ This is to allow other text rendering implementations to support `TextShadow` li
 
 
 
+

--- a/release-content/migration-guides/textshadow_moved_to_bevy_text.md
+++ b/release-content/migration-guides/textshadow_moved_to_bevy_text.md
@@ -1,0 +1,11 @@
+---
+title: `TextShadow` has been moved into `bevy_text`
+pull_requests: [19532]
+---
+
+The `TextShadow` component has been moved from `bevy_ui::ui_node` to `bevy_text::text`. 
+
+This is to allow other text rendering implementations to support `TextShadow` like `Text2d` without depending `bevy_ui` to import the component.
+
+
+


### PR DESCRIPTION
# Objective

The `TextShadow` component should be in `bevy_text`. Otherwise to support `TextShadow` for other text implementations like `Text2d` we'd need the `bevy_text` crate to depend on `bevy_ui` to import the component.

## Solution

Move `TextShadow` into `bevy_text`.

Added doc comment stating `Text2d` doesn't support `TextShadow`.

Fixes #19530