### PR TITLE
Feature: 2d Point Lights.

### DIFF
--- a/crates/bevy_sprite/src/light/mod.rs
+++ b/crates/bevy_sprite/src/light/mod.rs
@@ -1,0 +1,1 @@
+pub mod point_light_2d;

--- a/crates/bevy_sprite/src/light/point_light_2d.rs
+++ b/crates/bevy_sprite/src/light/point_light_2d.rs
@@ -1,0 +1,37 @@
+use bevy_color::Color;
+use bevy_ecs::component::Component;
+use bevy_math::*;
+use bevy_reflect::Reflect;
+
+/// A 2D point light for lighting 2D sprites.
+#[derive(Component, Clone, Copy, Debug, Reflect)]
+pub struct PointLight2D {
+    // The color of this light source
+    pub color: Color,
+
+    // Amount of light in lumens emitted by this source in all directions
+    pub intensity: f32,
+
+    // Affects the size of specular highlights created by this light
+    pub radius: f32,
+
+    // This affects how light will fade with distance
+    pub falloff: FalloffType,
+}
+
+#[derive(Debug, Clone, Copy, Reflect, PartialEq)]
+pub enum FalloffType {
+    Linear,
+    Exponential,
+}
+
+impl Default for PointLight2D {
+    fn default() -> Self {
+        Self {
+            color: Color::WHITE,
+            intensity: 1.0,
+            radius: 300.0,
+            falloff: FalloffType::Linear,
+        }
+    }
+}

--- a/crates/bevy_sprite/src/render/light.rs
+++ b/crates/bevy_sprite/src/render/light.rs
@@ -1,0 +1,152 @@
+use bevy_color::Color;
+use bevy_color::ColorToComponents;
+use bevy_ecs::prelude::*;
+use bevy_math::*;
+use bevy_render::render_resource::BufferUsages;
+use bevy_render::render_resource::*;
+use bevy_render::renderer::RenderDevice;
+use bevy_render::Extract;
+use bytemuck::{Pod, Zeroable};
+
+use crate::light::point_light_2d::{FalloffType, PointLight2D};
+use crate::render::GlobalTransform;
+use crate::render::SpritePipeline;
+
+pub const MAX_POINT_LIGHTS_2D: usize = 32;
+
+#[repr(C)]
+#[derive(ShaderType, Clone, Copy, Default, Pod, Zeroable)]
+pub struct GpuPointLight2D {
+    pub color_intensity: [f32; 4],
+    pub position_radius: [f32; 4],
+}
+
+#[derive(Resource)]
+pub struct GpuLights2D {
+    pub buffer: Buffer,
+    pub bind_group: BindGroup,
+    pub length: u32,
+}
+
+// Light data transferred to the Render World
+#[derive(Clone)]
+pub struct ExtractedPointLight2D {
+    pub color: Color,
+    pub intensity: f32,
+    pub radius: f32,
+    pub falloff: FalloffType,
+    pub position: Vec2,
+}
+
+#[derive(Resource, Default)]
+pub struct ExtractedPointLights2D(pub Vec<ExtractedPointLight2D>);
+
+pub fn extract_point_lights_2d(
+    mut extracted: ResMut<ExtractedPointLights2D>,
+    query: Extract<Query<(&PointLight2D, &GlobalTransform)>>,
+) {
+    extracted.0.clear();
+    for (light, transform) in &query {
+        extracted.0.push(ExtractedPointLight2D {
+            radius: light.radius,
+            intensity: light.intensity,
+            color: light.color,
+            falloff: light.falloff,
+            position: transform.translation().truncate(),
+        });
+    }
+}
+
+pub fn prepare_point_lights_2d(
+    mut commands: Commands,
+    render_device: Res<RenderDevice>,
+    extracted_lights: Res<ExtractedPointLights2D>,
+    sprite_pipeline: Res<SpritePipeline>,
+) {
+    let mut lights = Vec::new();
+
+    for light in &extracted_lights.0 {
+        let linear = Vec4::from_array(light.color.to_srgba().to_f32_array());
+        let color_intensity = Vec4::new(
+            linear[0] * light.intensity,
+            linear[1] * light.intensity,
+            linear[2] * light.intensity,
+            linear[3],
+        );
+
+        lights.push(GpuPointLight2D {
+            color_intensity: color_intensity.to_array(),
+            position_radius: [
+                light.position.x,
+                light.position.y,
+                light.radius,
+                match light.falloff {
+                    FalloffType::Linear => 1.0,
+                    FalloffType::Exponential => 2.0,
+                },
+            ]
+            .into(),
+        });
+    }
+
+    // Pad the array to 16 lights
+    lights.resize(
+        16,
+        GpuPointLight2D {
+            color_intensity: [0.0; 4].into(),
+            position_radius: [0.0; 4].into(),
+        },
+    );
+
+    // Create GPU buffer
+    let light_bytes = bytemuck::cast_slice(&lights);
+    let buffer = render_device.create_buffer_with_data(&BufferInitDescriptor {
+        label: Some("Point Light 2D Buffer"),
+        contents: light_bytes,
+        usage: BufferUsages::UNIFORM | BufferUsages::COPY_DST,
+    });
+
+    let bind_group = render_device.create_bind_group(
+        Some("Point Light 2D BindGroup"),
+        &sprite_pipeline.point_light_layout,
+        &[BindGroupEntry {
+            binding: 0,
+            resource: buffer.as_entire_binding(),
+        }],
+    );
+
+    // Insert the resource
+    commands.insert_resource(GpuLights2D {
+        buffer,
+        bind_group,
+        length: lights.len().min(16) as u32,
+    });
+}
+
+pub fn setup_gpu_lights(
+    mut commands: Commands,
+    render_device: Res<RenderDevice>,
+    sprite_pipeline: Res<SpritePipeline>,
+) {
+    let buffer = render_device.create_buffer(&BufferDescriptor {
+        label: Some("GpuLights2D.buffer"),
+        size: (size_of::<GpuPointLight2D>() * MAX_POINT_LIGHTS_2D) as u64,
+        usage: BufferUsages::UNIFORM | BufferUsages::STORAGE | BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+
+    let bind_group = render_device.create_bind_group(
+        Some("GpuLights2D.bind_group"),
+        &sprite_pipeline.point_light_layout,
+        &[BindGroupEntry {
+            binding: 0,
+            resource: buffer.as_entire_binding(),
+        }],
+    );
+
+    commands.insert_resource(GpuLights2D {
+        buffer,
+        bind_group,
+        length: 0,
+    });
+}

--- a/crates/bevy_sprite/src/render/light.rs
+++ b/crates/bevy_sprite/src/render/light.rs
@@ -15,13 +15,12 @@ use crate::render::SpritePipeline;
 pub const MAX_POINT_LIGHTS_2D: usize = 32;
 
 /// This structure is sent to the GPU for lighting calculations.
-///
-/// - `color_intensity`: RGBA color multiplied by intensity.
-/// - `position_radius`: XY position of the light, with Z as unused and W as radius.
 #[repr(C)]
 #[derive(ShaderType, Clone, Copy, Default, Pod, Zeroable)]
 pub struct GpuPointLight2D {
+    /// RGBA color multiplied by intensity.
     pub color_intensity: [f32; 4],
+    /// XY position of the light, Z unused, W as radius.
     pub position_radius: [f32; 4],
 }
 

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -920,12 +920,22 @@ pub type DrawSprite = (
     DrawSpriteBatch,
 );
 
+/// This struct implements the `RenderCommand` trait to bind GPU light data to the render pipeline
+/// at the specified bind group index `I`.
+/// `I` - A compile-time constant that specifies the bind group index where the point light
+/// data should be bound in the render pipeline.
 pub struct SetPointLightBindGroup<const I: usize>;
 impl<const I: usize> RenderCommand<Transparent2d> for SetPointLightBindGroup<I> {
     type Param = SRes<GpuLights2D>;
     type ViewQuery = &'static ViewUniformOffset;
     type ItemQuery = ();
 
+    /// Executes the render command to bind the point light data.
+    ///  `_item` - The transparent 2D render item (unused in this implementation)
+    ///  `_view` - The view uniform offset data (unused in this implementation)
+    ///  `_item_query` - The result of the item query (unused since ItemQuery is `()`)
+    ///  `lights_resource` - The GPU lights resource containing the bind group with light data
+    ///  `pass` - The tracked render pass used to record GPU commands
     fn render<'w>(
         _item: &Transparent2d,
         _view: &ViewUniformOffset,

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -931,11 +931,12 @@ impl<const I: usize> RenderCommand<Transparent2d> for SetPointLightBindGroup<I> 
     type ItemQuery = ();
 
     /// Executes the render command to bind the point light data.
-    ///  `_item` - The transparent 2D render item (unused in this implementation)
-    ///  `_view` - The view uniform offset data (unused in this implementation)
-    ///  `_item_query` - The result of the item query (unused since  `ItemQuery` is `()`)
-    ///  `lights_resource` - The GPU lights resource containing the bind group with light data
-    ///  `pass` - The tracked render pass used to record GPU commands
+    ///
+    /// * `_item` - The transparent 2D render item (unused in this implementation)
+    /// * `_view` - The view uniform offset data (unused in this implementation)
+    /// * `_item_query` - The result of the item query (unused since `ItemQuery` is `()`)
+    /// * `lights_resource` - The GPU lights resource containing the bind group with light data
+    /// * `pass` - The tracked render pass used to record GPU commands
     fn render<'w>(
         _item: &Transparent2d,
         _view: &ViewUniformOffset,

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -933,7 +933,7 @@ impl<const I: usize> RenderCommand<Transparent2d> for SetPointLightBindGroup<I> 
     /// Executes the render command to bind the point light data.
     ///  `_item` - The transparent 2D render item (unused in this implementation)
     ///  `_view` - The view uniform offset data (unused in this implementation)
-    ///  `_item_query` - The result of the item query (unused since ItemQuery is `()`)
+    ///  `_item_query` - The result of the item query (unused since  `ItemQuery` is `()`)
     ///  `lights_resource` - The GPU lights resource containing the bind group with light data
     ///  `pass` - The tracked render pass used to record GPU commands
     fn render<'w>(

--- a/crates/bevy_sprite/src/render/sprite.wgsl
+++ b/crates/bevy_sprite/src/render/sprite.wgsl
@@ -25,6 +25,7 @@ struct VertexOutput {
     @builtin(position) clip_position: vec4<f32>,
     @location(0) uv: vec2<f32>,
     @location(1) @interpolate(flat) color: vec4<f32>,
+    @location(2) world_pos: vec2<f32>,
 };
 
 @vertex
@@ -45,19 +46,58 @@ fn vertex(in: VertexInput) -> VertexOutput {
     out.uv = vec2<f32>(vertex_position.xy) * in.i_uv_offset_scale.zw + in.i_uv_offset_scale.xy;
     out.color = in.i_color;
 
+    let model = mat3x4<f32>(
+        in.i_model_transpose_col0,
+        in.i_model_transpose_col1,
+        in.i_model_transpose_col2,
+    );
+    let world_pos_3d = transpose(model) * vec4<f32>(vertex_position, 1.0);
+    out.world_pos = world_pos_3d.xy;
+
     return out;
 }
 
 @group(1) @binding(0) var sprite_texture: texture_2d<f32>;
 @group(1) @binding(1) var sprite_sampler: sampler;
 
+struct GpuPointLight2D {
+    color_intensity: vec4<f32>,
+    position_radius: vec4<f32>, 
+};
+
+@group(2) @binding(0)
+var<uniform> point_lights: array<GpuPointLight2D, 16>;
+
+fn compute_lighting(pos: vec2<f32>) -> vec3<f32> {
+    var lighting: vec3<f32> = vec3(0.0);
+
+    for (var i = 0u; i < 16u; i = i + 1u) {
+        let light = point_lights[i];
+
+        let dist = distance(pos, light.position_radius.xy);
+        if (dist > light.position_radius.z) {
+            continue;
+        }
+
+        let attenuation = select(
+            1.0 - dist / light.position_radius.z,
+            pow(1.0 - dist / light.position_radius.z, 2.0),
+            light.position_radius.w == 2.0
+        );
+
+        lighting += light.color_intensity.rgb * light.color_intensity.a * attenuation;
+    }
+
+    return lighting;
+}
+
 @fragment
 fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
     var color = in.color * textureSample(sprite_texture, sprite_sampler, in.uv);
-
 #ifdef TONEMAP_IN_SHADER
     color = tonemapping::tone_mapping(color, view.color_grading);
 #endif
 
-    return color;
+    let lighting = compute_lighting(in.world_pos);
+    return vec4(color.rgb * lighting, color.a);
 }

--- a/examples/2d/2dscene.rs
+++ b/examples/2d/2dscene.rs
@@ -9,9 +9,6 @@
 //! `ArrowRight`: Cycle through colors
 //! N: Next scene
 //! O: Disable intensity
-
-use bevy::math::cos;
-use bevy::math::sin;
 use bevy::prelude::*;
 use bevy::sprite::{FalloffType, PointLight2D};
 use std::f32::consts::TAU;
@@ -78,8 +75,8 @@ fn setup_scene1(mut commands: Commands, asset_server: Res<AssetServer>) {
     let radius = 200.0;
     for i in 0..count {
         let angle = i as f32 / count as f32 * TAU;
-        let x = radius * cos(angle);
-        let y = radius * sin(angle);
+        let x = radius * angle.cos();
+        let y = radius * angle.sin();
         commands.spawn((
             Sprite {
                 image: sprite_handle.clone(),

--- a/examples/2dscene.rs
+++ b/examples/2dscene.rs
@@ -1,0 +1,205 @@
+//! # 2D Point Light Demo
+//!
+//! Example demonstrating 2D point lights.
+//! Features two scenes with different lighting setups and real-time parameter adjustment.
+//!
+//! Space: Change FallOffType
+//! ArrowUp: Increase intensity
+//! ArrowDown: Decrease intensity
+//! ArrowRight: Cycle through colors
+//! N: Next scene
+//! O: Disable intensity
+
+use bevy::prelude::*;
+use bevy::sprite::{FalloffType, PointLight2D};
+use std::f32::consts::TAU;
+
+#[derive(Resource)]
+struct LightControl {
+    falloff_index: usize,
+    color_index: usize,
+    last_intensity: f32,
+}
+
+#[derive(Resource, PartialEq, Eq, Clone, Copy)]
+enum SceneState {
+    Scene1,
+    Scene2,
+}
+
+#[derive(Component)]
+struct ControlledLight;
+
+#[derive(Component)]
+struct Rotating;
+
+#[derive(Component)]
+struct IntensityText;
+
+const FALLOFFS: [FalloffType; 2] = [FalloffType::Linear, FalloffType::Exponential];
+
+const COLORS: [Color; 5] = [
+    Color::srgb(1.0, 1.0, 1.0),
+    Color::srgb(1.0, 0.0, 0.0),
+    Color::srgb(0.0, 1.0, 0.0),
+    Color::srgb(0.0, 0.0, 1.0),
+    Color::srgb(1.0, 0.5, 0.0),
+];
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins.set(WindowPlugin {
+            primary_window: Some(Window {
+                title: "2D Point Light Demo".to_string(),
+                resolution: (800., 600.).into(),
+                ..default()
+            }),
+            ..default()
+        }))
+        .insert_resource(LightControl {
+            falloff_index: 0,
+            color_index: 0,
+            last_intensity: 0.0,
+        })
+        .insert_resource(SceneState::Scene1)
+        .add_systems(Startup, setup_scene1)
+        .add_systems(Update, (handle_input, switch_scene, rotate_light))
+        .run();
+}
+
+fn setup_scene1(mut commands: Commands, asset_server: Res<AssetServer>) {
+    // Camera
+    commands.spawn(Camera2d);
+
+    let sprite_handle = asset_server.load("branding/icon.png");
+    let count = 12;
+    let radius = 200.0;
+    for i in 0..count {
+        let angle = i as f32 / count as f32 * TAU;
+        let x = radius * angle.cos();
+        let y = radius * angle.sin();
+        commands.spawn((
+            Sprite {
+                image: sprite_handle.clone(),
+                ..default()
+            },
+            Transform::from_xyz(x, y, 0.0).with_scale(Vec3::splat(0.5)),
+        ));
+    }
+
+    commands.spawn((
+        PointLight2D {
+            color: COLORS[0],
+            intensity: 1.0,
+            radius: 300.0,
+            falloff: FALLOFFS[0],
+        },
+        Transform::from_xyz(0., 0., 1.),
+        ControlledLight,
+    ));
+}
+
+fn setup_scene2(mut commands: Commands, asset_server: Res<AssetServer>) {
+    let sprite_handle = asset_server.load("branding/icon.png");
+
+    // Center sprite
+    commands.spawn((
+        Sprite {
+            image: sprite_handle.clone(),
+            ..default()
+        },
+        Transform::from_xyz(0., 0., 0.).with_scale(Vec3::splat(0.5)),
+    ));
+
+    // Rotating light
+    commands.spawn((
+        PointLight2D {
+            color: COLORS[0],
+            intensity: 1.0,
+            radius: 300.0,
+            falloff: FALLOFFS[0],
+        },
+        Transform::from_xyz(250., 0., 1.),
+        ControlledLight,
+        Rotating,
+    ));
+}
+
+fn switch_scene(
+    mut commands: Commands,
+    keyboard_input: Res<ButtonInput<KeyCode>>,
+    mut scene_state: ResMut<SceneState>,
+    asset_server: Res<AssetServer>,
+    sprites: Query<Entity, (With<Sprite>, Without<Camera2d>)>,
+    lights: Query<Entity, (With<PointLight2D>, Without<Camera2d>)>,
+) {
+    if keyboard_input.just_pressed(KeyCode::KeyN) {
+        for entity in &sprites {
+            commands.entity(entity).despawn();
+        }
+
+        for entity in &lights {
+            commands.entity(entity).despawn();
+        }
+
+        *scene_state = match *scene_state {
+            SceneState::Scene1 => {
+                setup_scene2(commands, asset_server);
+                SceneState::Scene2
+            }
+            SceneState::Scene2 => {
+                setup_scene1(commands, asset_server);
+                SceneState::Scene1
+            }
+        };
+    }
+}
+
+fn handle_input(
+    keyboard_input: Res<ButtonInput<KeyCode>>,
+    mut control: ResMut<LightControl>,
+    mut query: Query<&mut PointLight2D, With<ControlledLight>>,
+) {
+    if let Ok(mut light) = query.single_mut() {
+        if keyboard_input.just_pressed(KeyCode::Space) {
+            control.falloff_index = (control.falloff_index + 1) % FALLOFFS.len();
+            light.falloff = FALLOFFS[control.falloff_index];
+            info!("Changed falloff to {:?}", light.falloff);
+        }
+
+        if keyboard_input.just_pressed(KeyCode::ArrowUp) {
+            light.intensity += 0.1;
+            info!("Increased intensity: {}", light.intensity);
+        }
+        if keyboard_input.just_pressed(KeyCode::ArrowDown) {
+            light.intensity = (light.intensity - 0.1).max(0.0);
+            info!("Decreased intensity: {}", light.intensity);
+        }
+
+        if keyboard_input.just_pressed(KeyCode::ArrowRight) {
+            control.color_index = (control.color_index + 1) % COLORS.len();
+            light.color = COLORS[control.color_index];
+            info!("Changed color to {:?}", light.color);
+        }
+
+        if keyboard_input.just_pressed(KeyCode::KeyO) {
+            if light.intensity > 0.0 {
+                control.last_intensity = light.intensity;
+                light.intensity = 0.0;
+                info!("Light turned off (intensity: 0)");
+            } else {
+                light.intensity = control.last_intensity;
+                info!("Light turned on (intensity: {})", light.intensity);
+            }
+        }
+    }
+}
+
+fn rotate_light(time: Res<Time>, mut query: Query<&mut Transform, With<Rotating>>) {
+    for mut transform in &mut query {
+        let angle = time.delta_secs() * 2.5;
+        let current_pos = transform.translation.truncate();
+        let rotated_pos = Vec2::from_angle(angle).rotate(current_pos);
+        transform.translation = Vec3::new(rotated_pos.x, rotated_pos.y, transform.translation.z);
+    }
+}

--- a/examples/2dscene.rs
+++ b/examples/2dscene.rs
@@ -3,15 +3,16 @@
 //! Example demonstrating 2D point lights.
 //! Features two scenes with different lighting setups and real-time parameter adjustment.
 //!
-//! Space: Change FallOffType
-//! ArrowUp: Increase intensity
-//! ArrowDown: Decrease intensity
-//! ArrowRight: Cycle through colors
+//! Space: Change `FallOffType`
+//! `ArrowUp`: Increase intensity
+//! `ArrowDown`: Decrease intensity
+//! `ArrowRight`: Cycle through colors
 //! N: Next scene
 //! O: Disable intensity
 
 use bevy::prelude::*;
 use bevy::sprite::{FalloffType, PointLight2D};
+use bevy_math::ops::{cos, sin};
 use std::f32::consts::TAU;
 
 #[derive(Resource)]
@@ -76,8 +77,8 @@ fn setup_scene1(mut commands: Commands, asset_server: Res<AssetServer>) {
     let radius = 200.0;
     for i in 0..count {
         let angle = i as f32 / count as f32 * TAU;
-        let x = radius * angle.cos();
-        let y = radius * angle.sin();
+        let x = radius * cos(angle);
+        let y = radius * sin(angle);
         commands.spawn((
             Sprite {
                 image: sprite_handle.clone(),

--- a/examples/2dscene.rs
+++ b/examples/2dscene.rs
@@ -10,9 +10,10 @@
 //! N: Next scene
 //! O: Disable intensity
 
+use bevy::math::cos;
+use bevy::math::sin;
 use bevy::prelude::*;
 use bevy::sprite::{FalloffType, PointLight2D};
-use bevy_math::ops::{cos, sin};
 use std::f32::consts::TAU;
 
 #[derive(Resource)]

--- a/tests/light_render.rs
+++ b/tests/light_render.rs
@@ -1,0 +1,370 @@
+//! Integration tests for the complete 2D lighting pipeline
+
+use bevy::prelude::*;
+use bevy::sprite::{FalloffType, PointLight2D};
+
+/// Container for extracted 2D point lights ready for rendering
+#[derive(Resource, Default)]
+pub struct ExtractedPointLights2D(pub Vec<ExtractedPointLight2D>);
+
+/// A 2D point light extracted from the world for rendering
+#[derive(Clone)]
+pub struct ExtractedPointLight2D {
+    /// Position of the light in the world
+    pub position: Vec2,
+    /// Color of the light
+    pub color: Color,
+    /// Intensity of the light 0 means the light is off
+    pub intensity: f32,
+    /// Radius of the light
+    pub radius: f32,
+    /// falloff type, linear or exponential
+    pub falloff: FalloffType,
+}
+
+fn extract_point_lights_2d(
+    mut extracted_lights: ResMut<ExtractedPointLights2D>,
+    light_query: Query<(&PointLight2D, &GlobalTransform)>,
+) {
+    extracted_lights.0.clear();
+
+    for (light, transform) in light_query.iter() {
+        extracted_lights.0.push(ExtractedPointLight2D {
+            position: transform.translation().truncate(),
+            color: light.color,
+            intensity: light.intensity,
+            radius: light.radius,
+            falloff: light.falloff,
+        });
+    }
+}
+
+#[cfg(test)]
+mod light_tests {
+    use super::*;
+
+    // Test that lights are properly extracted from main world to render world
+    #[test]
+    fn test_full_extraction_pipeline() {
+        let mut app = App::new();
+
+        // Add minimal plugins for testing
+        app.add_plugins(MinimalPlugins).add_plugins(TransformPlugin);
+
+        // Add our lighting systems
+        app.add_systems(ExtractSchedule, extract_point_lights_2d);
+
+        // Initialize resources
+        app.insert_resource(ExtractedPointLights2D::default());
+
+        // Spawn test entities in main world
+        let _light_entity = app
+            .world_mut()
+            .spawn((
+                PointLight2D {
+                    color: Color::srgb(1.0, 1.0, 1.0),
+                    intensity: 2.0,
+                    radius: 150.0,
+                    falloff: FalloffType::Exponential,
+                },
+                Transform::from_xyz(100.0, -50.0, 0.0),
+                GlobalTransform::default(),
+            ))
+            .id();
+
+        app.update();
+
+        app.world_mut().run_schedule(ExtractSchedule);
+
+        // Verify extraction worked
+        let extracted = app.world().resource::<ExtractedPointLights2D>();
+        assert_eq!(extracted.0.len(), 1);
+
+        let extracted_light = &extracted.0[0];
+        assert_eq!(extracted_light.position, Vec2::new(100.0, -50.0));
+        assert_eq!(extracted_light.intensity, 2.0);
+        assert_eq!(extracted_light.radius, 150.0);
+        assert!(matches!(extracted_light.falloff, FalloffType::Exponential));
+    }
+
+    // Test resource initialization
+    #[test]
+    fn test_resource_initialization() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+
+        // Resources should be properly initialized
+        app.insert_resource(ExtractedPointLights2D::default());
+
+        let extracted = app.world().resource::<ExtractedPointLights2D>();
+        assert!(extracted.0.is_empty());
+
+        app.update();
+    }
+
+    // Test component queries and filters
+    #[test]
+    fn test_light_queries() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins).add_plugins(TransformPlugin);
+
+        let _valid_light = app
+            .world_mut()
+            .spawn((
+                PointLight2D {
+                    color: Color::srgb(1.0, 0.0, 0.0),
+                    intensity: 1.0,
+                    radius: 100.0,
+                    falloff: FalloffType::Linear,
+                },
+                Transform::default(),
+                GlobalTransform::default(),
+            ))
+            .id();
+
+        let _invalid_light = app
+            .world_mut()
+            .spawn((
+                PointLight2D {
+                    color: Color::srgb(0.0, 0.0, 1.0),
+                    intensity: 1.0,
+                    radius: 100.0,
+                    falloff: FalloffType::Linear,
+                },
+                // Missing Transform/GlobalTransform
+            ))
+            .id();
+
+        let _not_a_light = app
+            .world_mut()
+            .spawn((
+                Transform::default(),
+                GlobalTransform::default(),
+                // Missing PointLight2D
+            ))
+            .id();
+
+        app.update();
+
+        // Query should only find valid lights
+        let mut query = app.world_mut().query::<(&PointLight2D, &GlobalTransform)>();
+        let results: Vec<_> = query.iter(app.world()).collect();
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0.color, Color::srgb(1.0, 0.0, 0.0));
+    }
+
+    // Test light modifications and updates
+    #[test]
+    fn test_light_updates() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins).add_plugins(TransformPlugin);
+
+        app.insert_resource(ExtractedPointLights2D::default());
+        app.add_systems(ExtractSchedule, extract_point_lights_2d);
+
+        let light_entity = app
+            .world_mut()
+            .spawn((
+                PointLight2D {
+                    color: Color::srgb(1.0, 1.0, 1.0),
+                    intensity: 1.0,
+                    radius: 100.0,
+                    falloff: FalloffType::Linear,
+                },
+                Transform::from_xyz(0.0, 0.0, 0.0),
+                GlobalTransform::default(),
+            ))
+            .id();
+
+        // Initial extraction
+        app.update();
+        app.world_mut().run_schedule(ExtractSchedule);
+
+        {
+            let extracted = app.world().resource::<ExtractedPointLights2D>();
+            assert_eq!(extracted.0.len(), 1);
+            assert_eq!(extracted.0[0].intensity, 1.0);
+            assert_eq!(extracted.0[0].position, Vec2::ZERO);
+        }
+
+        // Modify light properties
+        {
+            let mut light = app
+                .world_mut()
+                .get_mut::<PointLight2D>(light_entity)
+                .unwrap();
+            light.intensity = 2.5;
+            light.color = Color::srgb(1.0, 0.0, 0.0);
+        }
+
+        // Move the light
+        {
+            let mut transform = app.world_mut().get_mut::<Transform>(light_entity).unwrap();
+            transform.translation = Vec3::new(50.0, 100.0, 0.0);
+        }
+
+        // Re-extract and verify changes
+        app.update();
+        app.world_mut().run_schedule(ExtractSchedule);
+
+        {
+            let extracted = app.world().resource::<ExtractedPointLights2D>();
+            assert_eq!(extracted.0.len(), 1);
+            assert_eq!(extracted.0[0].intensity, 2.5);
+            assert_eq!(extracted.0[0].color, Color::srgb(1.0, 0.0, 0.0));
+            assert_eq!(extracted.0[0].position, Vec2::new(50.0, 100.0));
+        }
+    }
+
+    #[test]
+    fn test_multiple_lights() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins).add_plugins(TransformPlugin);
+
+        app.insert_resource(ExtractedPointLights2D::default());
+        app.add_systems(ExtractSchedule, extract_point_lights_2d);
+
+        // Spawn multiple lights
+        for i in 0..5 {
+            app.world_mut().spawn((
+                PointLight2D {
+                    color: Color::srgb_from_array([
+                        ((i as f32 * 72.0).to_radians().cos() + 1.0) / 2.0,
+                        ((i as f32 * 72.0 + 120.0).to_radians().cos() + 1.0) / 2.0,
+                        ((i as f32 * 72.0 + 240.0).to_radians().cos() + 1.0) / 2.0,
+                    ]), // Different colors
+                    intensity: (i + 1) as f32,
+                    radius: 100.0 + i as f32 * 50.0,
+                    falloff: if i % 2 == 0 {
+                        FalloffType::Linear
+                    } else {
+                        FalloffType::Exponential
+                    },
+                },
+                Transform::from_xyz(i as f32 * 100.0, 0.0, 0.0),
+                GlobalTransform::default(),
+            ));
+        }
+
+        app.update();
+        app.world_mut().run_schedule(ExtractSchedule);
+
+        let extracted = app.world().resource::<ExtractedPointLights2D>();
+        assert_eq!(extracted.0.len(), 5);
+
+        // Verify each light was extracted correctly
+        for (i, light) in extracted.0.iter().enumerate() {
+            assert_eq!(light.intensity, (i + 1) as f32);
+            assert_eq!(light.position.x, i as f32 * 100.0);
+            assert_eq!(light.radius, 100.0 + i as f32 * 50.0);
+            // Test falloff pattern
+            if i % 2 == 0 {
+                assert!(matches!(light.falloff, FalloffType::Linear));
+            } else {
+                assert!(matches!(light.falloff, FalloffType::Exponential));
+            }
+        }
+    }
+
+    // Test light removal
+    #[test]
+    fn test_light_removal() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins).add_plugins(TransformPlugin);
+
+        app.insert_resource(ExtractedPointLights2D::default());
+        app.add_systems(ExtractSchedule, extract_point_lights_2d);
+
+        // Spawn lights
+        let light1 = app
+            .world_mut()
+            .spawn((
+                PointLight2D {
+                    color: Color::srgb(1.0, 0.0, 0.0),
+                    intensity: 1.0,
+                    radius: 100.0,
+                    falloff: FalloffType::Linear,
+                },
+                Transform::default(),
+                GlobalTransform::default(),
+            ))
+            .id();
+
+        let _light2 = app
+            .world_mut()
+            .spawn((
+                PointLight2D {
+                    color: Color::srgb(0.0, 0.0, 1.0),
+                    intensity: 2.0,
+                    radius: 150.0,
+                    falloff: FalloffType::Exponential,
+                },
+                Transform::from_xyz(100.0, 0.0, 0.0),
+                GlobalTransform::default(),
+            ))
+            .id();
+
+        app.update();
+        app.world_mut().run_schedule(ExtractSchedule);
+
+        // Verify both lights exist
+        {
+            let extracted = app.world().resource::<ExtractedPointLights2D>();
+            assert_eq!(extracted.0.len(), 2);
+        }
+
+        // Remove one light
+        app.world_mut().despawn(light1);
+
+        app.update();
+        app.world_mut().run_schedule(ExtractSchedule);
+
+        // Verify only one light remains
+        {
+            let extracted = app.world().resource::<ExtractedPointLights2D>();
+            assert_eq!(extracted.0.len(), 1);
+            assert_eq!(extracted.0[0].color, Color::srgb(0.0, 0.0, 1.0));
+            assert_eq!(extracted.0[0].intensity, 2.0);
+        }
+    }
+
+    // Test performance with many lights
+    #[test]
+    fn test_many_lights_performance() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins).add_plugins(TransformPlugin);
+
+        app.insert_resource(ExtractedPointLights2D::default());
+        app.add_systems(ExtractSchedule, extract_point_lights_2d);
+
+        // Spawn many lights
+        const LIGHT_COUNT: usize = 1000;
+        for i in 0..LIGHT_COUNT {
+            app.world_mut().spawn((
+                PointLight2D {
+                    color: Color::WHITE,
+                    intensity: 1.0,
+                    radius: 100.0,
+                    falloff: FalloffType::Linear,
+                },
+                Transform::from_xyz((i % 100) as f32 * 10.0, (i / 100) as f32 * 10.0, 0.0),
+                GlobalTransform::default(),
+            ));
+        }
+
+        let start = std::time::Instant::now();
+        app.update();
+        app.world_mut().run_schedule(ExtractSchedule);
+        let duration = start.elapsed();
+
+        let extracted = app.world().resource::<ExtractedPointLights2D>();
+        assert_eq!(extracted.0.len(), LIGHT_COUNT);
+
+        assert!(
+            duration.as_millis() < 100,
+            "Extraction took too long: {:?}",
+            duration
+        );
+    }
+}

--- a/tests/light_render.rs
+++ b/tests/light_render.rs
@@ -2,6 +2,8 @@
 
 use bevy::prelude::*;
 use bevy::sprite::{FalloffType, PointLight2D};
+use bevy::math::cos;
+use bevy::math::sin;
 
 /// Container for extracted 2D point lights ready for rendering
 #[derive(Resource, Default)]
@@ -230,9 +232,9 @@ mod light_tests {
             app.world_mut().spawn((
                 PointLight2D {
                     color: Color::srgb_from_array([
-                        ((i as f32 * 72.0).to_radians().cos() + 1.0) / 2.0,
-                        ((i as f32 * 72.0 + 120.0).to_radians().cos() + 1.0) / 2.0,
-                        ((i as f32 * 72.0 + 240.0).to_radians().cos() + 1.0) / 2.0,
+                        (cos((i as f32 * 72.0).to_radians()) + 1.0) / 2.0,
+                        (cos((i as f32 * 72.0 + 120.0).to_radians()) + 1.0) / 2.0,
+                        (cos((i as f32 * 72.0 + 240.0).to_radians()) + 1.0) / 2.0,
                     ]), // Different colors
                     intensity: (i + 1) as f32,
                     radius: 100.0 + i as f32 * 50.0,

--- a/tests/light_render.rs
+++ b/tests/light_render.rs
@@ -1,9 +1,9 @@
 //! Integration tests for the complete 2D lighting pipeline
 
-use bevy::prelude::*;
-use bevy::sprite::{FalloffType, PointLight2D};
 use bevy::math::cos;
 use bevy::math::sin;
+use bevy::prelude::*;
+use bevy::sprite::{FalloffType, PointLight2D};
 
 /// Container for extracted 2D point lights ready for rendering
 #[derive(Resource, Default)]


### PR DESCRIPTION


# Objective

2d Point Light implementation and integration inside Sprite Plugin.

- Point lights with configurable radius, color, and intensity;
- Light falloff (linear or exponential);

## Solution

**crates/bevy_sprite/src/light/point_light_2d.rs:**
- PointLight2D component and FallOffType enum definition.

**crates/bevy_sprite/src/render/light.rs:**
- Light extraction from `PointLight2D` into `ExtractedPointLight2D`.
- Processes and store the extracted lights into `GpuLights2D` for GPU consumption.

**crates/bevy_sprite/src/render/mod.rs:**
- Create and add the light bind group to the Sprite pipeline.

**crates/bevy_sprite/src/lib.rs:**
- Add `extract_point_lights_2d` and `prepare_point_lights_2d` to the SpritePlugin.

**crates/bevy_sprite/src/render/sprite.wgsl**
- Light computation.
- Apply it to the sprite.

## Testing
- tests/light_render.rs
- examples/2dscene.rs:
  O: Set intensity to 0;
  ArrowUp: Increase intensity;
  ArrowDown: Decrease intensity;
  ArrowRight: Change color;
  N: Change scene;
  SpaceBar: Change fall off type.
- Might need performance tests.

## Showcase
https://github.com/user-attachments/assets/890e4521-150a-4910-8c79-d2e59ac2b974


