### PR TITLE
Mesh serialization

### DIFF
--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -148,8 +148,9 @@ impl<A: Asset> serde::Serialize for Handle<A> {
     {
         match self.path() {
             Some(asset_path) => asset_path.serialize(serializer),
-            // Maybe this should be an error?
-            None => AssetPath::default().serialize(serializer),
+            None => Err(serde::ser::Error::custom(
+                "only handles with asset paths can be serialized",
+            )),
         }
     }
 }

--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -138,7 +138,8 @@ pub enum Handle<A: Asset> {
     Weak(AssetId<A>),
 }
 
-/// Serialize `Handle`s as `AssetPath`s.
+/// Serialize `Handle`s as [`AssetPath`]s. This means types containing handles cannot be deserialized
+/// without special handling (see [`ReflectDeserializerProcessor`]).
 impl<A: Asset> serde::Serialize for Handle<A> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -138,6 +138,20 @@ pub enum Handle<A: Asset> {
     Weak(AssetId<A>),
 }
 
+/// Serialize `Handle`s as `AssetPath`s.
+impl<A: Asset> serde::Serialize for Handle<A> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self.path() {
+            Some(asset_path) => asset_path.serialize(serializer),
+            // Maybe this should be an error?
+            None => AssetPath::default().serialize(serializer),
+        }
+    }
+}
+
 impl<T: Asset> Clone for Handle<T> {
     fn clone(&self) -> Self {
         match self {

--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -138,8 +138,9 @@ pub enum Handle<A: Asset> {
     Weak(AssetId<A>),
 }
 
-/// Serialize `Handle`s as [`AssetPath`]s. This means types containing handles cannot be deserialized
-/// without special handling (see [`ReflectDeserializerProcessor`]).
+/// Serialize `Handle`s as [`AssetPath`]s. This means types containing handles cannot be
+/// deserialized without special handling. See
+/// [`ReflectDeserializerProcessor`](bevy_reflect::serde::ReflectDeserializerProcessor).
 impl<A: Asset> serde::Serialize for Handle<A> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/crates/bevy_mesh/Cargo.toml
+++ b/crates/bevy_mesh/Cargo.toml
@@ -8,6 +8,9 @@ repository = "https://github.com/bevyengine/bevy"
 license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
+[features]
+serialize = ["dep:serde", "wgpu-types/serde"]
+
 [dependencies]
 # bevy
 bevy_asset = { path = "../bevy_asset", version = "0.16.0-dev" }
@@ -29,8 +32,8 @@ bevy_platform = { path = "../bevy_platform", version = "0.16.0-dev", default-fea
 # other
 bitflags = { version = "2.3", features = ["serde"] }
 bytemuck = { version = "1.5" }
-wgpu-types = { version = "24", features = ["serde"], default-features = false }
-serde = { version = "1", features = ["derive"] }
+wgpu-types = { version = "24", default-features = false }
+serde = { version = "1", features = ["derive"], optional = true }
 hexasphere = "15.0"
 thiserror = { version = "2", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["std"] }

--- a/crates/bevy_mesh/Cargo.toml
+++ b/crates/bevy_mesh/Cargo.toml
@@ -38,6 +38,9 @@ hexasphere = "15.0"
 thiserror = { version = "2", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 
+[dev-dependencies]
+bevy_app = { path = "../bevy_app", version = "0.16.0-dev" }
+
 [lints]
 workspace = true
 

--- a/crates/bevy_mesh/Cargo.toml
+++ b/crates/bevy_mesh/Cargo.toml
@@ -13,7 +13,9 @@ keywords = ["bevy"]
 bevy_asset = { path = "../bevy_asset", version = "0.16.0-dev" }
 bevy_image = { path = "../bevy_image", version = "0.16.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.16.0-dev" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.16.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.16.0-dev", features = [
+  "wgpu-types",
+] }
 bevy_ecs = { path = "../bevy_ecs", version = "0.16.0-dev" }
 bevy_transform = { path = "../bevy_transform", version = "0.16.0-dev" }
 bevy_mikktspace = { path = "../bevy_mikktspace", version = "0.16.0-dev" }
@@ -27,7 +29,7 @@ bevy_platform = { path = "../bevy_platform", version = "0.16.0-dev", default-fea
 # other
 bitflags = { version = "2.3", features = ["serde"] }
 bytemuck = { version = "1.5" }
-wgpu-types = { version = "24", default-features = false }
+wgpu-types = { version = "24", features = ["serde"], default-features = false }
 serde = { version = "1", features = ["derive"] }
 hexasphere = "15.0"
 thiserror = { version = "2", default-features = false }

--- a/crates/bevy_mesh/src/index.rs
+++ b/crates/bevy_mesh/src/index.rs
@@ -1,4 +1,6 @@
 use bevy_reflect::Reflect;
+#[cfg(feature = "serialize")]
+use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 use core::iter;
 use core::iter::FusedIterator;
 use thiserror::Error;
@@ -69,8 +71,13 @@ pub enum MeshTrianglesError {
 /// An array of indices into the [`VertexAttributeValues`](super::VertexAttributeValues) for a mesh.
 ///
 /// It describes the order in which the vertex attributes should be joined into faces.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Reflect)]
-#[reflect(Clone)]
+#[derive(Debug, Clone, Reflect)]
+#[reflect(Debug, Clone)]
+#[cfg_attr(
+    feature = "serialize",
+    derive(serde::Serialize, serde::Deserialize),
+    reflect(Serialize, Deserialize)
+)]
 pub enum Indices {
     U16(Vec<u16>),
     U32(Vec<u32>),

--- a/crates/bevy_mesh/src/index.rs
+++ b/crates/bevy_mesh/src/index.rs
@@ -69,7 +69,7 @@ pub enum MeshTrianglesError {
 /// An array of indices into the [`VertexAttributeValues`](super::VertexAttributeValues) for a mesh.
 ///
 /// It describes the order in which the vertex attributes should be joined into faces.
-#[derive(Debug, Clone, Reflect)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Reflect)]
 #[reflect(Clone)]
 pub enum Indices {
     U16(Vec<u16>),

--- a/crates/bevy_mesh/src/mesh.rs
+++ b/crates/bevy_mesh/src/mesh.rs
@@ -11,7 +11,9 @@ use alloc::collections::BTreeMap;
 use bevy_asset::{Asset, Handle, RenderAssetUsages};
 use bevy_image::Image;
 use bevy_math::{primitives::Triangle3d, *};
-use bevy_reflect::{Reflect, ReflectSerialize};
+use bevy_reflect::Reflect;
+#[cfg(feature = "serialize")]
+use bevy_reflect::ReflectSerialize;
 use bytemuck::cast_slice;
 use thiserror::Error;
 use tracing::warn;
@@ -104,8 +106,14 @@ pub const VERTEX_ATTRIBUTE_BUFFER_ID: u64 = 10;
 /// - Vertex winding order: by default, `StandardMaterial.cull_mode` is `Some(Face::Back)`,
 ///   which means that Bevy would *only* render the "front" of each triangle, which
 ///   is the side of the triangle from where the vertices appear in a *counter-clockwise* order.
-#[derive(Asset, Debug, Clone, serde::Serialize, Reflect)]
-#[reflect(Clone, Serialize)]
+///
+/// Note that, when serialization is enabled, a `Mesh` cannot be deserialized without special
+/// handling of `Handle`s. See [`ReflectDeserializerProcessor`]. The serialized format should not be
+/// considered stable, and may not be compatible between versions.
+#[derive(Asset, Debug, Clone, Reflect)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[reflect(Clone)]
+#[cfg_attr(feature = "serialize", reflect(Serialize))]
 pub struct Mesh {
     primitive_topology: PrimitiveTopology,
     /// `std::collections::BTreeMap` with all defined vertex attributes (Positions, Normals, ...)

--- a/crates/bevy_mesh/src/mesh.rs
+++ b/crates/bevy_mesh/src/mesh.rs
@@ -11,7 +11,7 @@ use alloc::collections::BTreeMap;
 use bevy_asset::{Asset, Handle, RenderAssetUsages};
 use bevy_image::Image;
 use bevy_math::{primitives::Triangle3d, *};
-use bevy_reflect::Reflect;
+use bevy_reflect::{Reflect, ReflectSerialize};
 use bytemuck::cast_slice;
 use thiserror::Error;
 use tracing::warn;
@@ -104,16 +104,14 @@ pub const VERTEX_ATTRIBUTE_BUFFER_ID: u64 = 10;
 /// - Vertex winding order: by default, `StandardMaterial.cull_mode` is `Some(Face::Back)`,
 ///   which means that Bevy would *only* render the "front" of each triangle, which
 ///   is the side of the triangle from where the vertices appear in a *counter-clockwise* order.
-#[derive(Asset, Debug, Clone, Reflect)]
-#[reflect(Clone)]
+#[derive(Asset, Debug, Clone, serde::Serialize, Reflect)]
+#[reflect(Clone, Serialize)]
 pub struct Mesh {
-    #[reflect(ignore, clone)]
     primitive_topology: PrimitiveTopology,
     /// `std::collections::BTreeMap` with all defined vertex attributes (Positions, Normals, ...)
     /// for this mesh. Attribute ids to attribute values.
     /// Uses a [`BTreeMap`] because, unlike `HashMap`, it has a defined iteration order,
     /// which allows easy stable `VertexBuffers` (i.e. same buffer order)
-    #[reflect(ignore, clone)]
     attributes: BTreeMap<MeshVertexAttributeId, MeshAttributeData>,
     indices: Option<Indices>,
     morph_targets: Option<Handle<Image>>,

--- a/crates/bevy_mesh/src/mesh.rs
+++ b/crates/bevy_mesh/src/mesh.rs
@@ -107,9 +107,12 @@ pub const VERTEX_ATTRIBUTE_BUFFER_ID: u64 = 10;
 ///   which means that Bevy would *only* render the "front" of each triangle, which
 ///   is the side of the triangle from where the vertices appear in a *counter-clockwise* order.
 ///
+/// ## Serialization
+///
 /// Note that, when serialization is enabled, a `Mesh` cannot be deserialized without special
-/// handling of `Handle`s. See [`ReflectDeserializerProcessor`]. The serialized format should not be
-/// considered stable, and may not be compatible between versions.
+/// handling of `Handle`s. See
+/// [`ReflectDeserializerProcessor`](bevy_reflect::serde::ReflectDeserializerProcessor). The
+/// serialized format should not be considered stable, and may not be compatible between versions.
 #[derive(Asset, Debug, Clone, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[reflect(Clone)]

--- a/crates/bevy_mesh/src/vertex.rs
+++ b/crates/bevy_mesh/src/vertex.rs
@@ -3,14 +3,17 @@ use bevy_derive::EnumVariantMeta;
 use bevy_ecs::resource::Resource;
 use bevy_math::Vec3;
 use bevy_platform::collections::HashSet;
+use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize};
 use bytemuck::cast_slice;
 use core::hash::{Hash, Hasher};
 use thiserror::Error;
 use wgpu_types::{BufferAddress, VertexAttribute, VertexFormat, VertexStepMode};
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Reflect, serde::Serialize, serde::Deserialize)]
+#[reflect(Debug, Clone, Serialize, Deserialize)]
 pub struct MeshVertexAttribute {
     /// The friendly name of the vertex attribute
+    #[serde(skip)]
     pub name: &'static str,
 
     /// The _unique_ id of the vertex attribute. This will also determine sort ordering
@@ -36,7 +39,20 @@ impl MeshVertexAttribute {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Reflect,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+#[reflect(Debug, Clone, PartialEq, Hash, Serialize, Deserialize)]
 pub struct MeshVertexAttributeId(u64);
 
 impl From<MeshVertexAttribute> for MeshVertexAttributeId {
@@ -132,7 +148,8 @@ impl VertexAttributeDescriptor {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Reflect, serde::Serialize, serde::Deserialize)]
+#[reflect(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct MeshAttributeData {
     pub(crate) attribute: MeshVertexAttribute,
     pub(crate) values: VertexAttributeValues,
@@ -167,7 +184,8 @@ pub fn face_normal(a: [f32; 3], b: [f32; 3], c: [f32; 3]) -> [f32; 3] {
 
 /// Contains an array where each entry describes a property of a single vertex.
 /// Matches the [`VertexFormats`](VertexFormat).
-#[derive(Clone, Debug, EnumVariantMeta)]
+#[derive(Clone, Debug, EnumVariantMeta, Reflect, serde::Serialize, serde::Deserialize)]
+#[reflect(Clone, Debug, Serialize, Deserialize)]
 pub enum VertexAttributeValues {
     Float32(Vec<f32>),
     Sint32(Vec<i32>),

--- a/crates/bevy_mesh/src/vertex.rs
+++ b/crates/bevy_mesh/src/vertex.rs
@@ -3,17 +3,24 @@ use bevy_derive::EnumVariantMeta;
 use bevy_ecs::resource::Resource;
 use bevy_math::Vec3;
 use bevy_platform::collections::HashSet;
-use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize};
+use bevy_reflect::Reflect;
+#[cfg(feature = "serialize")]
+use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 use bytemuck::cast_slice;
 use core::hash::{Hash, Hasher};
 use thiserror::Error;
 use wgpu_types::{BufferAddress, VertexAttribute, VertexFormat, VertexStepMode};
 
-#[derive(Debug, Clone, Copy, Reflect, serde::Serialize, serde::Deserialize)]
-#[reflect(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Reflect)]
+#[reflect(Debug, Clone)]
+#[cfg_attr(
+    feature = "serialize",
+    derive(serde::Serialize, serde::Deserialize),
+    reflect(Serialize, Deserialize)
+)]
 pub struct MeshVertexAttribute {
     /// The friendly name of the vertex attribute
-    #[serde(skip)]
+    #[cfg_attr(feature = "serialize", serde(skip))]
     pub name: &'static str,
 
     /// The _unique_ id of the vertex attribute. This will also determine sort ordering
@@ -39,20 +46,13 @@ impl MeshVertexAttribute {
     }
 }
 
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    Ord,
-    PartialOrd,
-    Hash,
-    Reflect,
-    serde::Serialize,
-    serde::Deserialize,
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Reflect)]
+#[reflect(Debug, Clone, PartialEq, Hash)]
+#[cfg_attr(
+    feature = "serialize",
+    derive(serde::Serialize, serde::Deserialize),
+    reflect(Serialize, Deserialize)
 )]
-#[reflect(Debug, Clone, PartialEq, Hash, Serialize, Deserialize)]
 pub struct MeshVertexAttributeId(u64);
 
 impl From<MeshVertexAttribute> for MeshVertexAttributeId {
@@ -148,8 +148,13 @@ impl VertexAttributeDescriptor {
     }
 }
 
-#[derive(Debug, Clone, Reflect, serde::Serialize, serde::Deserialize)]
-#[reflect(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Reflect)]
+#[reflect(Debug, Clone)]
+#[cfg_attr(
+    feature = "serialize",
+    derive(serde::Serialize, serde::Deserialize),
+    reflect(Serialize, Deserialize)
+)]
 pub(crate) struct MeshAttributeData {
     pub(crate) attribute: MeshVertexAttribute,
     pub(crate) values: VertexAttributeValues,
@@ -184,8 +189,13 @@ pub fn face_normal(a: [f32; 3], b: [f32; 3], c: [f32; 3]) -> [f32; 3] {
 
 /// Contains an array where each entry describes a property of a single vertex.
 /// Matches the [`VertexFormats`](VertexFormat).
-#[derive(Clone, Debug, EnumVariantMeta, Reflect, serde::Serialize, serde::Deserialize)]
-#[reflect(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, EnumVariantMeta, Reflect)]
+#[reflect(Clone, Debug)]
+#[cfg_attr(
+    feature = "serialize",
+    derive(serde::Serialize, serde::Deserialize),
+    reflect(Serialize, Deserialize)
+)]
 pub enum VertexAttributeValues {
     Float32(Vec<f32>),
     Sint32(Vec<i32>),

--- a/crates/bevy_mesh/src/vertex.rs
+++ b/crates/bevy_mesh/src/vertex.rs
@@ -51,7 +51,8 @@ impl MeshVertexAttribute {
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
-    reflect(Serialize, Deserialize)
+    reflect(Serialize, Deserialize),
+    serde(transparent)
 )]
 pub struct MeshVertexAttributeId(u64);
 

--- a/crates/bevy_reflect/src/impls/wgpu_types.rs
+++ b/crates/bevy_reflect/src/impls/wgpu_types.rs
@@ -1,6 +1,26 @@
-use crate::{impl_reflect_opaque, ReflectDeserialize, ReflectSerialize};
+use crate::{std_traits::ReflectDefault, ReflectDeserialize, ReflectSerialize};
+use bevy_reflect_derive::impl_reflect_opaque;
+
+impl_reflect_opaque!(::wgpu_types::PrimitiveTopology(
+    Clone,
+    Debug,
+    Default,
+    Hash,
+    PartialEq,
+    Deserialize,
+    Serialize,
+));
 
 impl_reflect_opaque!(::wgpu_types::TextureFormat(
+    Clone,
+    Debug,
+    Hash,
+    PartialEq,
+    Deserialize,
+    Serialize,
+));
+
+impl_reflect_opaque!(::wgpu_types::VertexFormat(
     Clone,
     Debug,
     Hash,


### PR DESCRIPTION
# Objective

* Make `Mesh` serializable.

## Solution

* Implement `Serialize` for `Mesh` and `Handle` (as an `AssetPath`).
* Note `Mesh` does  not impl `Deserialize` because it contains a handle which aren't directly deserializable from asset paths. But it can be deserialized via reflection. I have an example of round-trip saving and loading meshes with an asset loader and reflect deserialization processor that I can submit in a following PR.
* This is behind a non-default feature ("serialize").

## Testing

* `cargo test -p bevy_mesh --features serialize`