### PR TITLE
Require naga_oil 0.17.1

### DIFF
--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -119,7 +119,7 @@ wesl = { version = "0.1.2", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # Omit the `glsl` feature in non-WebAssembly by default.
-naga_oil = { version = "0.17", default-features = false, features = [
+naga_oil = { version = "0.17.1", default-features = false, features = [
   "test_shader",
 ] }
 
@@ -127,7 +127,7 @@ naga_oil = { version = "0.17", default-features = false, features = [
 proptest = "1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-naga_oil = "0.17"
+naga_oil = "0.17.1"
 js-sys = "0.3"
 web-sys = { version = "0.3.67", features = [
   'Blob',


### PR DESCRIPTION
Split off from https://github.com/bevyengine/bevy/pull/19058

The patch should've been picked up anyways, but now it's required.