### PR TITLE
Object-centered text layout

### DIFF
--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -352,7 +352,7 @@ impl TextPipeline {
                     let y =
                         line_y.round() + physical_glyph.y as f32 - top + glyph_size.y as f32 / 2.0;
 
-                    let position = Vec2::new(x, y);
+                    let position = Vec2::new(x, y) - 0.5 * box_size;
 
                     let pos_glyph = PositionedGlyph {
                         position,

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -183,10 +183,16 @@ pub fn extract_text2d_sprite(
             text_bounds.height.unwrap_or(text_layout_info.size.y),
         );
 
-        let top_left = (Anchor::TOP_LEFT.0 - anchor.as_vec()) * size;
-        let transform =
-            *global_transform * GlobalTransform::from_translation(top_left.extend(0.)) * scaling;
+        // <<<<<<< HEAD
+        //         let top_left = (Anchor::TOP_LEFT.0 - anchor.as_vec()) * size;
+        //         let transform =
+        //             *global_transform * GlobalTransform::from_translation(top_left.extend(0.)) * scaling;
 
+        // =======
+        let transform = *global_transform
+            * GlobalTransform::from_translation((anchor.as_vec() * size).extend(0.))
+            * scaling;
+        //>>>>>>> 3486c46142 (Change to object centered coordinated for the text layout stored in `TextLayoutInfo`.)
         let mut color = LinearRgba::WHITE;
         let mut current_span = usize::MAX;
 

--- a/crates/bevy_ui_render/src/lib.rs
+++ b/crates/bevy_ui_render/src/lib.rs
@@ -937,7 +937,7 @@ pub fn extract_text_sections(
             continue;
         };
 
-        let transform = Affine2::from(*transform) * Affine2::from_translation(-0.5 * uinode.size());
+        let transform = Affine2::from(*transform);
 
         for (
             i,
@@ -1026,9 +1026,7 @@ pub fn extract_text_shadows(
         };
 
         let node_transform = Affine2::from(*transform)
-            * Affine2::from_translation(
-                -0.5 * uinode.size() + shadow.offset / uinode.inverse_scale_factor(),
-            );
+            * Affine2::from_translation(shadow.offset / uinode.inverse_scale_factor());
 
         for (
             i,

--- a/release-content/migration-guides/object_centered_text_layout.md
+++ b/release-content/migration-guides/object_centered_text_layout.md
@@ -1,6 +1,6 @@
 ---
 title: `TextLayoutInfo` now uses object-centered coordinates
-pull_requests: []
+pull_requests: [19559]
 ---
 
 The glyph positions stored in `TextLayoutInfo` are now object-centered.

--- a/release-content/migration-guides/object_centered_text_layout.md
+++ b/release-content/migration-guides/object_centered_text_layout.md
@@ -1,0 +1,7 @@
+---
+title: `TextLayoutInfo` now uses object-centered coordinates
+pull_requests: []
+---
+
+The glyph positions stored in `TextLayoutInfo` are now object-centered.
+


### PR DESCRIPTION
# Objective

In the text layout the glyph sprites are objected-centered but their positions are relative to the top-left corner of the text layout.
For the sake of consistancy, use object-centered coordinates for the positions as well.

## Solution

Use object-centered coordinates for the glyph positions in `TextLayoutInfo`.

## Testing

You can test the changes using the text examples: `text2d`, `text`, `text_debug`, `text_wrap_debug`.
There should be no differences to main.