### PR TITLE
Ugrade to `wgpu` version `25.0`

### DIFF
--- a/crates/bevy_color/Cargo.toml
+++ b/crates/bevy_color/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1.0", features = [
 ], default-features = false, optional = true }
 thiserror = { version = "2", default-features = false }
 derive_more = { version = "1", default-features = false, features = ["from"] }
-wgpu-types = { version = "24", default-features = false, optional = true }
+wgpu-types = { version = "25", default-features = false, optional = true }
 encase = { version = "0.10", default-features = false, optional = true }
 
 [features]

--- a/crates/bevy_gizmos/src/line_joints.wgsl
+++ b/crates/bevy_gizmos/src/line_joints.wgsl
@@ -14,7 +14,7 @@ struct LineGizmoUniform {
 #endif
 }
 
-@group(1) @binding(0) var<uniform> joints_gizmo: LineGizmoUniform;
+@group(2) @binding(0) var<uniform> joints_gizmo: LineGizmoUniform;
 
 struct VertexInput {
     @location(0) position_a: vec3<f32>,

--- a/crates/bevy_gizmos/src/lines.wgsl
+++ b/crates/bevy_gizmos/src/lines.wgsl
@@ -17,7 +17,7 @@ struct LineGizmoUniform {
 #endif
 }
 
-@group(1) @binding(0) var<uniform> line_gizmo: LineGizmoUniform;
+@group(2) @binding(0) var<uniform> line_gizmo: LineGizmoUniform;
 
 struct VertexInput {
     @location(0) position_a: vec3<f32>,

--- a/crates/bevy_gizmos/src/pipeline_3d.rs
+++ b/crates/bevy_gizmos/src/pipeline_3d.rs
@@ -124,7 +124,8 @@ impl SpecializedRenderPipeline for LineGizmoPipeline {
             .get_view_layout(key.view_key.into())
             .clone();
 
-        let layout = vec![view_layout, self.uniform_layout.clone()];
+        let mut layout = view_layout.to_vec();
+        layout.push(self.uniform_layout.clone());
 
         let fragment_entry_point = match key.line_style {
             GizmoLineStyle::Solid => "fragment_solid",
@@ -221,7 +222,8 @@ impl SpecializedRenderPipeline for LineJointGizmoPipeline {
             .get_view_layout(key.view_key.into())
             .clone();
 
-        let layout = vec![view_layout, self.uniform_layout.clone()];
+        let mut layout = view_layout.to_vec();
+        layout.push(self.uniform_layout.clone());
 
         if key.joints == GizmoLineJoint::None {
             error!("There is no entry point for line joints with GizmoLineJoints::None. Please consider aborting the drawing process before reaching this stage.");
@@ -273,20 +275,20 @@ impl SpecializedRenderPipeline for LineJointGizmoPipeline {
 
 type DrawLineGizmo3d = (
     SetItemPipeline,
-    SetMeshViewBindGroup<0>,
-    SetLineGizmoBindGroup<1>,
+    SetMeshViewBindGroup<0, 1>,
+    SetLineGizmoBindGroup<2>,
     DrawLineGizmo<false>,
 );
 type DrawLineGizmo3dStrip = (
     SetItemPipeline,
-    SetMeshViewBindGroup<0>,
-    SetLineGizmoBindGroup<1>,
+    SetMeshViewBindGroup<0, 1>,
+    SetLineGizmoBindGroup<2>,
     DrawLineGizmo<true>,
 );
 type DrawLineJointGizmo3d = (
     SetItemPipeline,
-    SetMeshViewBindGroup<0>,
-    SetLineGizmoBindGroup<1>,
+    SetMeshViewBindGroup<0, 1>,
+    SetLineGizmoBindGroup<2>,
     DrawLineJointGizmo,
 );
 

--- a/crates/bevy_image/Cargo.toml
+++ b/crates/bevy_image/Cargo.toml
@@ -60,7 +60,7 @@ image = { version = "0.25.2", default-features = false }
 # misc
 bitflags = { version = "2.3", features = ["serde"] }
 bytemuck = { version = "1.5" }
-wgpu-types = { version = "24", default-features = false }
+wgpu-types = { version = "25", default-features = false }
 serde = { version = "1", features = ["derive"] }
 thiserror = { version = "2", default-features = false }
 futures-lite = "2.0.1"

--- a/crates/bevy_mesh/Cargo.toml
+++ b/crates/bevy_mesh/Cargo.toml
@@ -27,7 +27,7 @@ bevy_platform = { path = "../bevy_platform", version = "0.16.0-dev", default-fea
 # other
 bitflags = { version = "2.3", features = ["serde"] }
 bytemuck = { version = "1.5" }
-wgpu-types = { version = "24", default-features = false }
+wgpu-types = { version = "25", default-features = false }
 serde = { version = "1", features = ["derive"] }
 hexasphere = "15.0"
 thiserror = { version = "2", default-features = false }

--- a/crates/bevy_pbr/src/deferred/mod.rs
+++ b/crates/bevy_pbr/src/deferred/mod.rs
@@ -346,12 +346,12 @@ impl SpecializedRenderPipeline for DeferredLightingLayout {
         #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
         shader_defs.push("SIXTEEN_BYTE_ALIGNMENT".into());
 
+        let mut layout = self.mesh_pipeline.get_view_layout(key.into()).to_vec();
+        layout.push(self.bind_group_layout_1.clone());
+
         RenderPipelineDescriptor {
             label: Some("deferred_lighting_pipeline".into()),
-            layout: vec![
-                self.mesh_pipeline.get_view_layout(key.into()).clone(),
-                self.bind_group_layout_1.clone(),
-            ],
+            layout,
             vertex: VertexState {
                 shader: self.deferred_lighting_shader.clone(),
                 shader_defs: shader_defs.clone(),

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -152,8 +152,8 @@ fn shader_ref(path: PathBuf) -> ShaderRef {
 const MESHLET_VISIBILITY_BUFFER_RESOLVE_SHADER_HANDLE: Handle<Shader> =
     weak_handle!("69187376-3dea-4d0f-b3f5-185bde63d6a2");
 
-pub const TONEMAPPING_LUT_TEXTURE_BINDING_INDEX: u32 = 26;
-pub const TONEMAPPING_LUT_SAMPLER_BINDING_INDEX: u32 = 27;
+pub const TONEMAPPING_LUT_TEXTURE_BINDING_INDEX: u32 = 18;
+pub const TONEMAPPING_LUT_SAMPLER_BINDING_INDEX: u32 = 19;
 
 /// Sets up the entire PBR infrastructure of bevy.
 pub struct PbrPlugin {

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -120,9 +120,9 @@ use tracing::error;
 /// In WGSL shaders, the material's binding would look like this:
 ///
 /// ```wgsl
-/// @group(2) @binding(0) var<uniform> color: vec4<f32>;
-/// @group(2) @binding(1) var color_texture: texture_2d<f32>;
-/// @group(2) @binding(2) var color_sampler: sampler;
+/// @group(3) @binding(0) var<uniform> color: vec4<f32>;
+/// @group(3) @binding(1) var color_texture: texture_2d<f32>;
+/// @group(3) @binding(2) var color_sampler: sampler;
 /// ```
 pub trait Material: Asset + AsBindGroup + Clone + Sized {
     /// Returns this material's vertex shader. If [`ShaderRef::Default`] is returned, the default mesh vertex shader
@@ -501,7 +501,7 @@ where
             descriptor.fragment.as_mut().unwrap().shader = fragment_shader.clone();
         }
 
-        descriptor.layout.insert(2, self.material_layout.clone());
+        descriptor.layout.insert(3, self.material_layout.clone());
 
         M::specialize(self, &mut descriptor, layout, key)?;
 
@@ -543,9 +543,9 @@ impl<M: Material> FromWorld for MaterialPipeline<M> {
 
 type DrawMaterial<M> = (
     SetItemPipeline,
-    SetMeshViewBindGroup<0>,
-    SetMeshBindGroup<1>,
-    SetMaterialBindGroup<M, 2>,
+    SetMeshViewBindGroup<0, 1>,
+    SetMeshBindGroup<2>,
+    SetMaterialBindGroup<M, 3>,
     DrawMesh,
 );
 

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -1864,7 +1864,7 @@ impl MeshPipeline {
         }
     }
 
-    pub fn get_view_layout(&self, layout_key: MeshPipelineViewLayoutKey) -> &BindGroupLayout {
+    pub fn get_view_layout(&self, layout_key: MeshPipelineViewLayoutKey) -> &[BindGroupLayout; 2] {
         self.view_layouts.get_view_layout(layout_key)
     }
 }
@@ -2320,7 +2320,7 @@ impl SpecializedMeshPipeline for MeshPipeline {
             shader_defs.push("PBR_SPECULAR_TEXTURES_SUPPORTED".into());
         }
 
-        let mut bind_group_layout = vec![self.get_view_layout(key.into()).clone()];
+        let mut bind_group_layout = self.get_view_layout(key.into()).to_vec();
 
         if key.msaa_samples() > 1 {
             shader_defs.push("MULTISAMPLED".into());
@@ -2847,8 +2847,8 @@ fn prepare_mesh_bind_groups_for_phase(
     groups
 }
 
-pub struct SetMeshViewBindGroup<const I: usize>;
-impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetMeshViewBindGroup<I> {
+pub struct SetMeshViewBindGroup<const I: usize, const J: usize>;
+impl<P: PhaseItem, const I: usize, const J: usize> RenderCommand<P> for SetMeshViewBindGroup<I, J> {
     type Param = ();
     type ViewQuery = (
         Read<ViewUniformOffset>,
@@ -2891,6 +2891,7 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetMeshViewBindGroup<I> 
             offsets.push(layers_count_offset.offset);
         }
         pass.set_bind_group(I, &mesh_view_bind_group.value, &offsets);
+        pass.set_bind_group(J, &mesh_view_bind_group.value_binding_array, &[]);
 
         RenderCommandResult::Success
     }

--- a/crates/bevy_pbr/src/render/mesh_bindings.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_bindings.wgsl
@@ -4,8 +4,8 @@
 
 #ifndef MESHLET_MESH_MATERIAL_PASS
 #ifdef PER_OBJECT_BUFFER_BATCH_SIZE
-@group(1) @binding(0) var<uniform> mesh: array<Mesh, #{PER_OBJECT_BUFFER_BATCH_SIZE}u>;
+@group(2) @binding(0) var<uniform> mesh: array<Mesh, #{PER_OBJECT_BUFFER_BATCH_SIZE}u>;
 #else
-@group(1) @binding(0) var<storage> mesh: array<Mesh>;
+@group(2) @binding(0) var<storage> mesh: array<Mesh>;
 #endif // PER_OBJECT_BUFFER_BATCH_SIZE
 #endif  // MESHLET_MESH_MATERIAL_PASS

--- a/crates/bevy_pbr/src/render/mesh_view_bindings.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_view_bindings.wgsl
@@ -50,70 +50,70 @@ const VISIBILITY_RANGE_UNIFORM_BUFFER_SIZE: u32 = 64u;
 
 @group(0) @binding(15) var<uniform> ssr_settings: types::ScreenSpaceReflectionsSettings;
 @group(0) @binding(16) var screen_space_ambient_occlusion_texture: texture_2d<f32>;
-
-#ifdef MULTIPLE_LIGHT_PROBES_IN_ARRAY
-@group(0) @binding(17) var diffuse_environment_maps: binding_array<texture_cube<f32>, 8u>;
-@group(0) @binding(18) var specular_environment_maps: binding_array<texture_cube<f32>, 8u>;
-#else
-@group(0) @binding(17) var diffuse_environment_map: texture_cube<f32>;
-@group(0) @binding(18) var specular_environment_map: texture_cube<f32>;
-#endif
-@group(0) @binding(19) var environment_map_sampler: sampler;
-@group(0) @binding(20) var<uniform> environment_map_uniform: types::EnvironmentMapUniform;
-
-#ifdef IRRADIANCE_VOLUMES_ARE_USABLE
-#ifdef MULTIPLE_LIGHT_PROBES_IN_ARRAY
-@group(0) @binding(21) var irradiance_volumes: binding_array<texture_3d<f32>, 8u>;
-#else
-@group(0) @binding(21) var irradiance_volume: texture_3d<f32>;
-#endif
-@group(0) @binding(22) var irradiance_volume_sampler: sampler;
-#endif
-
-#ifdef CLUSTERED_DECALS_ARE_USABLE
-@group(0) @binding(23) var<storage> clustered_decals: types::ClusteredDecals;
-@group(0) @binding(24) var clustered_decal_textures: binding_array<texture_2d<f32>, 8u>;
-@group(0) @binding(25) var clustered_decal_sampler: sampler;
-#endif  // CLUSTERED_DECALS_ARE_USABLE
+@group(0) @binding(17) var<uniform> environment_map_uniform: types::EnvironmentMapUniform;
 
 // NB: If you change these, make sure to update `tonemapping_shared.wgsl` too.
-@group(0) @binding(26) var dt_lut_texture: texture_3d<f32>;
-@group(0) @binding(27) var dt_lut_sampler: sampler;
+@group(0) @binding(18) var dt_lut_texture: texture_3d<f32>;
+@group(0) @binding(19) var dt_lut_sampler: sampler;
 
 #ifdef MULTISAMPLED
 #ifdef DEPTH_PREPASS
-@group(0) @binding(28) var depth_prepass_texture: texture_depth_multisampled_2d;
+@group(0) @binding(20) var depth_prepass_texture: texture_depth_multisampled_2d;
 #endif // DEPTH_PREPASS
 #ifdef NORMAL_PREPASS
-@group(0) @binding(29) var normal_prepass_texture: texture_multisampled_2d<f32>;
+@group(0) @binding(21) var normal_prepass_texture: texture_multisampled_2d<f32>;
 #endif // NORMAL_PREPASS
 #ifdef MOTION_VECTOR_PREPASS
-@group(0) @binding(30) var motion_vector_prepass_texture: texture_multisampled_2d<f32>;
+@group(0) @binding(22) var motion_vector_prepass_texture: texture_multisampled_2d<f32>;
 #endif // MOTION_VECTOR_PREPASS
 
 #else // MULTISAMPLED
 
 #ifdef DEPTH_PREPASS
-@group(0) @binding(28) var depth_prepass_texture: texture_depth_2d;
+@group(0) @binding(20) var depth_prepass_texture: texture_depth_2d;
 #endif // DEPTH_PREPASS
 #ifdef NORMAL_PREPASS
-@group(0) @binding(29) var normal_prepass_texture: texture_2d<f32>;
+@group(0) @binding(21) var normal_prepass_texture: texture_2d<f32>;
 #endif // NORMAL_PREPASS
 #ifdef MOTION_VECTOR_PREPASS
-@group(0) @binding(30) var motion_vector_prepass_texture: texture_2d<f32>;
+@group(0) @binding(22) var motion_vector_prepass_texture: texture_2d<f32>;
 #endif // MOTION_VECTOR_PREPASS
 
 #endif // MULTISAMPLED
 
 #ifdef DEFERRED_PREPASS
-@group(0) @binding(31) var deferred_prepass_texture: texture_2d<u32>;
+@group(0) @binding(23) var deferred_prepass_texture: texture_2d<u32>;
 #endif // DEFERRED_PREPASS
 
-@group(0) @binding(32) var view_transmission_texture: texture_2d<f32>;
-@group(0) @binding(33) var view_transmission_sampler: sampler;
+@group(0) @binding(24) var view_transmission_texture: texture_2d<f32>;
+@group(0) @binding(25) var view_transmission_sampler: sampler;
 
-#ifdef OIT_ENABLED
-@group(0) @binding(34) var<storage, read_write> oit_layers: array<vec2<u32>>;
-@group(0) @binding(35) var<storage, read_write> oit_layer_ids: array<atomic<i32>>;
-@group(0) @binding(36) var<uniform> oit_settings: types::OrderIndependentTransparencySettings;
-#endif // OIT_ENABLED
+//#ifdef OIT_ENABLED
+//@group(0) @binding(26) var<storage, read_write> oit_layers: array<vec2<u32>>;
+//@group(0) @binding(27) var<storage, read_write> oit_layer_ids: array<atomic<i32>>;
+//@group(0) @binding(28) var<uniform> oit_settings: types::OrderIndependentTransparencySettings;
+//#endif // OIT_ENABLED
+
+#ifdef MULTIPLE_LIGHT_PROBES_IN_ARRAY
+@group(1) @binding(0) var diffuse_environment_maps: binding_array<texture_cube<f32>, 8u>;
+@group(1) @binding(1) var specular_environment_maps: binding_array<texture_cube<f32>, 8u>;
+#else
+@group(1) @binding(0) var diffuse_environment_map: texture_cube<f32>;
+@group(1) @binding(1) var specular_environment_map: texture_cube<f32>;
+#endif
+@group(1) @binding(2) var environment_map_sampler: sampler;
+
+#ifdef IRRADIANCE_VOLUMES_ARE_USABLE
+#ifdef MULTIPLE_LIGHT_PROBES_IN_ARRAY
+@group(1) @binding(3) var irradiance_volumes: binding_array<texture_3d<f32>, 8u>;
+#else
+@group(1) @binding(3) var irradiance_volume: texture_3d<f32>;
+#endif
+@group(1) @binding(4) var irradiance_volume_sampler: sampler;
+#endif
+
+#ifdef CLUSTERED_DECALS_ARE_USABLE
+@group(1) @binding(5) var<storage> clustered_decals: types::ClusteredDecals;
+@group(1) @binding(6) var clustered_decal_textures: binding_array<texture_2d<f32>, 8u>;
+@group(1) @binding(7) var clustered_decal_sampler: sampler;
+#endif  // CLUSTERED_DECALS_ARE_USABLE

--- a/crates/bevy_pbr/src/render/pbr_bindings.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_bindings.wgsl
@@ -37,53 +37,53 @@ struct StandardMaterialBindings {
     specular_tint_sampler: u32,         // 30
 }
 
-@group(2) @binding(0) var<storage> material_indices: array<StandardMaterialBindings>;
-@group(2) @binding(10) var<storage> material_array: array<StandardMaterial>;
+@group(3) @binding(0) var<storage> material_indices: array<StandardMaterialBindings>;
+@group(3) @binding(10) var<storage> material_array: array<StandardMaterial>;
 
 #else   // BINDLESS
 
-@group(2) @binding(0) var<uniform> material: StandardMaterial;
-@group(2) @binding(1) var base_color_texture: texture_2d<f32>;
-@group(2) @binding(2) var base_color_sampler: sampler;
-@group(2) @binding(3) var emissive_texture: texture_2d<f32>;
-@group(2) @binding(4) var emissive_sampler: sampler;
-@group(2) @binding(5) var metallic_roughness_texture: texture_2d<f32>;
-@group(2) @binding(6) var metallic_roughness_sampler: sampler;
-@group(2) @binding(7) var occlusion_texture: texture_2d<f32>;
-@group(2) @binding(8) var occlusion_sampler: sampler;
-@group(2) @binding(9) var normal_map_texture: texture_2d<f32>;
-@group(2) @binding(10) var normal_map_sampler: sampler;
-@group(2) @binding(11) var depth_map_texture: texture_2d<f32>;
-@group(2) @binding(12) var depth_map_sampler: sampler;
+@group(3) @binding(0) var<uniform> material: StandardMaterial;
+@group(3) @binding(1) var base_color_texture: texture_2d<f32>;
+@group(3) @binding(2) var base_color_sampler: sampler;
+@group(3) @binding(3) var emissive_texture: texture_2d<f32>;
+@group(3) @binding(4) var emissive_sampler: sampler;
+@group(3) @binding(5) var metallic_roughness_texture: texture_2d<f32>;
+@group(3) @binding(6) var metallic_roughness_sampler: sampler;
+@group(3) @binding(7) var occlusion_texture: texture_2d<f32>;
+@group(3) @binding(8) var occlusion_sampler: sampler;
+@group(3) @binding(9) var normal_map_texture: texture_2d<f32>;
+@group(3) @binding(10) var normal_map_sampler: sampler;
+@group(3) @binding(11) var depth_map_texture: texture_2d<f32>;
+@group(3) @binding(12) var depth_map_sampler: sampler;
 
 #ifdef PBR_ANISOTROPY_TEXTURE_SUPPORTED
-@group(2) @binding(13) var anisotropy_texture: texture_2d<f32>;
-@group(2) @binding(14) var anisotropy_sampler: sampler;
+@group(3) @binding(13) var anisotropy_texture: texture_2d<f32>;
+@group(3) @binding(14) var anisotropy_sampler: sampler;
 #endif  // PBR_ANISOTROPY_TEXTURE_SUPPORTED
 
 #ifdef PBR_TRANSMISSION_TEXTURES_SUPPORTED
-@group(2) @binding(15) var specular_transmission_texture: texture_2d<f32>;
-@group(2) @binding(16) var specular_transmission_sampler: sampler;
-@group(2) @binding(17) var thickness_texture: texture_2d<f32>;
-@group(2) @binding(18) var thickness_sampler: sampler;
-@group(2) @binding(19) var diffuse_transmission_texture: texture_2d<f32>;
-@group(2) @binding(20) var diffuse_transmission_sampler: sampler;
+@group(3) @binding(15) var specular_transmission_texture: texture_2d<f32>;
+@group(3) @binding(16) var specular_transmission_sampler: sampler;
+@group(3) @binding(17) var thickness_texture: texture_2d<f32>;
+@group(3) @binding(18) var thickness_sampler: sampler;
+@group(3) @binding(19) var diffuse_transmission_texture: texture_2d<f32>;
+@group(3) @binding(20) var diffuse_transmission_sampler: sampler;
 #endif  // PBR_TRANSMISSION_TEXTURES_SUPPORTED
 
 #ifdef PBR_MULTI_LAYER_MATERIAL_TEXTURES_SUPPORTED
-@group(2) @binding(21) var clearcoat_texture: texture_2d<f32>;
-@group(2) @binding(22) var clearcoat_sampler: sampler;
-@group(2) @binding(23) var clearcoat_roughness_texture: texture_2d<f32>;
-@group(2) @binding(24) var clearcoat_roughness_sampler: sampler;
-@group(2) @binding(25) var clearcoat_normal_texture: texture_2d<f32>;
-@group(2) @binding(26) var clearcoat_normal_sampler: sampler;
+@group(3) @binding(21) var clearcoat_texture: texture_2d<f32>;
+@group(3) @binding(22) var clearcoat_sampler: sampler;
+@group(3) @binding(23) var clearcoat_roughness_texture: texture_2d<f32>;
+@group(3) @binding(24) var clearcoat_roughness_sampler: sampler;
+@group(3) @binding(25) var clearcoat_normal_texture: texture_2d<f32>;
+@group(3) @binding(26) var clearcoat_normal_sampler: sampler;
 #endif  // PBR_MULTI_LAYER_MATERIAL_TEXTURES_SUPPORTED
 
 #ifdef PBR_SPECULAR_TEXTURES_SUPPORTED
-@group(2) @binding(27) var specular_texture: texture_2d<f32>;
-@group(2) @binding(28) var specular_sampler: sampler;
-@group(2) @binding(29) var specular_tint_texture: texture_2d<f32>;
-@group(2) @binding(30) var specular_tint_sampler: sampler;
+@group(3) @binding(27) var specular_texture: texture_2d<f32>;
+@group(3) @binding(28) var specular_sampler: sampler;
+@group(3) @binding(29) var specular_tint_texture: texture_2d<f32>;
+@group(3) @binding(30) var specular_tint_sampler: sampler;
 #endif  // PBR_SPECULAR_TEXTURES_SUPPORTED
 
 #endif  // BINDLESS

--- a/crates/bevy_pbr/src/ssr/mod.rs
+++ b/crates/bevy_pbr/src/ssr/mod.rs
@@ -515,9 +515,11 @@ impl SpecializedRenderPipeline for ScreenSpaceReflectionsPipeline {
     type Key = ScreenSpaceReflectionsPipelineKey;
 
     fn specialize(&self, key: Self::Key) -> RenderPipelineDescriptor {
-        let mesh_view_layout = self
+        let mut layout = self
             .mesh_view_layouts
-            .get_view_layout(key.mesh_pipeline_view_key);
+            .get_view_layout(key.mesh_pipeline_view_key)
+            .to_vec();
+        layout.push(self.bind_group_layout.clone());
 
         let mut shader_defs = vec![
             "DEPTH_PREPASS".into(),
@@ -535,7 +537,7 @@ impl SpecializedRenderPipeline for ScreenSpaceReflectionsPipeline {
 
         RenderPipelineDescriptor {
             label: Some("SSR pipeline".into()),
-            layout: vec![mesh_view_layout.clone(), self.bind_group_layout.clone()],
+            layout,
             vertex: fullscreen_vertex_shader::fullscreen_shader_vertex_state(),
             fragment: Some(FragmentState {
                 shader: self.shader.clone(),

--- a/crates/bevy_pbr/src/volumetric_fog/render.rs
+++ b/crates/bevy_pbr/src/volumetric_fog/render.rs
@@ -559,9 +559,15 @@ impl SpecializedRenderPipeline for VolumetricFogPipeline {
             shader_defs.push("DENSITY_TEXTURE".into());
         }
 
+        let mut layout = self
+            .mesh_view_layouts
+            .get_view_layout(key.mesh_pipeline_view_key)
+            .to_vec();
+        layout.push(volumetric_view_bind_group_layout.clone());
+
         RenderPipelineDescriptor {
             label: Some("volumetric lighting pipeline".into()),
-            layout: vec![mesh_view_layout.clone(), volumetric_view_bind_group_layout],
+            layout,
             push_constant_ranges: vec![],
             vertex: VertexState {
                 shader: self.shader.clone(),

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -317,8 +317,8 @@ impl<P: PhaseItem> RenderCommand<P> for SetWireframe3dPushConstants {
 
 pub type DrawWireframe3d = (
     SetItemPipeline,
-    SetMeshViewBindGroup<0>,
-    SetMeshBindGroup<1>,
+    SetMeshViewBindGroup<0, 1>,
+    SetMeshBindGroup<2>,
     SetWireframe3dPushConstants,
     DrawMesh,
 );

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -109,7 +109,7 @@ uuid = { version = "1.13.1", default-features = false, optional = true, features
   "serde",
 ] }
 variadics_please = "1.1"
-wgpu-types = { version = "24", features = [
+wgpu-types = { version = "25", features = [
   "serde",
 ], optional = true, default-features = false }
 

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -85,14 +85,14 @@ codespan-reporting = "0.11.0"
 # It is enabled for now to avoid having to do a significant overhaul of the renderer just for wasm.
 # When the 'atomics' feature is enabled `fragile-send-sync-non-atomic` does nothing
 # and Bevy instead wraps `wgpu` types to verify they are not used off their origin thread.
-wgpu = { version = "24", default-features = false, features = [
+wgpu = { version = "25", default-features = false, features = [
   "wgsl",
   "dx12",
   "metal",
   "naga-ir",
   "fragile-send-sync-non-atomic-wasm",
 ] }
-naga = { version = "24", features = ["wgsl-in"] }
+naga = { version = "25", features = ["wgsl-in"] }
 serde = { version = "1", features = ["derive"] }
 bytemuck = { version = "1.5", features = ["derive", "must_cast"] }
 downcast-rs = { version = "2", default-features = false, features = ["std"] }
@@ -119,7 +119,7 @@ wesl = { version = "0.1.2", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # Omit the `glsl` feature in non-WebAssembly by default.
-naga_oil = { version = "0.17.1", default-features = false, features = [
+naga_oil = { path = "../../../naga_oil", default-features = false, features = [
   "test_shader",
 ] }
 
@@ -127,7 +127,7 @@ naga_oil = { version = "0.17.1", default-features = false, features = [
 proptest = "1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-naga_oil = "0.17.1"
+naga_oil = { path = "../../../naga_oil" }
 js-sys = "0.3"
 web-sys = { version = "0.3.67", features = [
   'Blob',

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -352,9 +352,13 @@ impl Plugin for RenderPlugin {
                             backend_options: wgpu::BackendOptions {
                                 gl: wgpu::GlBackendOptions {
                                     gles_minor_version: settings.gles3_minor_version,
+                                    fence_behavior: wgpu::GlFenceBehavior::Normal,
                                 },
                                 dx12: wgpu::Dx12BackendOptions {
                                     shader_compiler: settings.dx12_shader_compiler.clone(),
+                                },
+                                noop: wgpu::NoopBackendOptions {
+                                    enable: false,
                                 },
                             },
                         });

--- a/crates/bevy_render/src/render_phase/draw.rs
+++ b/crates/bevy_render/src/render_phase/draw.rs
@@ -167,15 +167,15 @@ impl<P: PhaseItem> DrawFunctions<P> {
 ///
 /// ```
 /// # use bevy_render::render_phase::SetItemPipeline;
-/// # struct SetMeshViewBindGroup<const N: usize>;
+/// # struct SetMeshViewBindGroup<const N: usize, const J: usize>;
 /// # struct SetMeshBindGroup<const N: usize>;
 /// # struct SetMaterialBindGroup<M, const N: usize>(std::marker::PhantomData<M>);
 /// # struct DrawMesh;
 /// pub type DrawMaterial<M> = (
 ///     SetItemPipeline,
-///     SetMeshViewBindGroup<0>,
-///     SetMeshBindGroup<1>,
-///     SetMaterialBindGroup<M, 2>,
+///     SetMeshViewBindGroup<0, 1>,
+///     SetMeshBindGroup<2>,
+///     SetMaterialBindGroup<M, 3>,
 ///     DrawMesh,
 /// );
 /// ```

--- a/crates/bevy_render/src/render_resource/bind_group.rs
+++ b/crates/bevy_render/src/render_resource/bind_group.rs
@@ -133,12 +133,12 @@ impl Deref for BindGroup {
 /// In WGSL shaders, the binding would look like this:
 ///
 /// ```wgsl
-/// @group(2) @binding(0) var<uniform> color: vec4<f32>;
-/// @group(2) @binding(1) var color_texture: texture_2d<f32>;
-/// @group(2) @binding(2) var color_sampler: sampler;
-/// @group(2) @binding(3) var<storage> storage_buffer: array<f32>;
-/// @group(2) @binding(4) var<storage> raw_buffer: array<f32>;
-/// @group(2) @binding(5) var storage_texture: texture_storage_2d<rgba8unorm, read_write>;
+/// @group(3) @binding(0) var<uniform> color: vec4<f32>;
+/// @group(3) @binding(1) var color_texture: texture_2d<f32>;
+/// @group(3) @binding(2) var color_sampler: sampler;
+/// @group(3) @binding(3) var<storage> storage_buffer: array<f32>;
+/// @group(3) @binding(4) var<storage> raw_buffer: array<f32>;
+/// @group(3) @binding(5) var storage_texture: texture_storage_2d<rgba8unorm, read_write>;
 /// ```
 /// Note that the "group" index is determined by the usage context. It is not defined in [`AsBindGroup`]. For example, in Bevy material bind groups
 /// are generally bound to group 2.
@@ -261,7 +261,7 @@ impl Deref for BindGroup {
 ///     roughness: f32,
 /// };
 ///
-/// @group(2) @binding(0) var<uniform> material: CoolMaterial;
+/// @group(3) @binding(0) var<uniform> material: CoolMaterial;
 /// ```
 ///
 /// Some less common scenarios will require "struct-level" attributes. These are the currently supported struct-level attributes:
@@ -312,7 +312,7 @@ impl Deref for BindGroup {
 /// declaration:
 ///
 /// ```wgsl
-/// @group(2) @binding(10) var<storage> material_array: binding_array<StandardMaterial>;
+/// @group(3) @binding(10) var<storage> material_array: binding_array<StandardMaterial>;
 /// ```
 ///
 /// On the other hand, if you write this declaration:
@@ -325,7 +325,7 @@ impl Deref for BindGroup {
 /// Then Bevy produces a binding that matches this WGSL declaration instead:
 ///
 /// ```wgsl
-/// @group(2) @binding(10) var<storage> material_array: array<StandardMaterial>;
+/// @group(3) @binding(10) var<storage> material_array: array<StandardMaterial>;
 /// ```
 ///
 /// * Just as with the structure-level `uniform` attribute, Bevy converts the
@@ -338,7 +338,7 @@ impl Deref for BindGroup {
 ///   this in WGSL in non-bindless mode:
 ///
 /// ```wgsl
-/// @group(2) @binding(0) var<uniform> material: StandardMaterial;
+/// @group(3) @binding(0) var<uniform> material: StandardMaterial;
 /// ```
 ///
 /// * For efficiency reasons, `data` is generally preferred over `uniform`

--- a/crates/bevy_render/src/render_resource/bind_group_entries.rs
+++ b/crates/bevy_render/src/render_resource/bind_group_entries.rs
@@ -287,6 +287,12 @@ impl<'b> DynamicBindGroupEntries<'b> {
         }
     }
 
+    pub fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+        }
+    }
+
     pub fn extend_with_indices<const N: usize>(
         mut self,
         entries: impl IntoIndexedBindingArray<'b, N>,

--- a/crates/bevy_render/src/render_resource/bind_group_layout_entries.rs
+++ b/crates/bevy_render/src/render_resource/bind_group_layout_entries.rs
@@ -334,6 +334,15 @@ impl DynamicBindGroupLayoutEntries {
         }
     }
 
+    pub fn new(
+        default_visibility: ShaderStages,
+    ) -> Self {
+        Self {
+            default_visibility,
+            entries: Vec::new(),
+        }
+    }
+
     pub fn extend_with_indices<const N: usize>(
         mut self,
         entries: impl IntoIndexedBindGroupLayoutEntryBuilderArray<N>,

--- a/crates/bevy_render/src/render_resource/bind_group_layout_entries.rs
+++ b/crates/bevy_render/src/render_resource/bind_group_layout_entries.rs
@@ -570,6 +570,14 @@ pub mod binding_types {
     }
 
     pub fn acceleration_structure() -> BindGroupLayoutEntryBuilder {
-        BindingType::AccelerationStructure.into_bind_group_layout_entry_builder()
+        BindingType::AccelerationStructure {
+            vertex_return: false,
+        }.into_bind_group_layout_entry_builder()
+    }
+
+    pub fn acceleration_structure_vertex_return() -> BindGroupLayoutEntryBuilder {
+        BindingType::AccelerationStructure {
+            vertex_return: true,
+        }.into_bind_group_layout_entry_builder()
     }
 }

--- a/crates/bevy_render/src/render_resource/mod.rs
+++ b/crates/bevy_render/src/render_resource/mod.rs
@@ -49,7 +49,7 @@ pub use wgpu::{
     ComputePassDescriptor, ComputePipelineDescriptor as RawComputePipelineDescriptor,
     CreateBlasDescriptor, CreateTlasDescriptor, DepthBiasState, DepthStencilState, DownlevelFlags,
     Extent3d, Face, Features as WgpuFeatures, FilterMode, FragmentState as RawFragmentState,
-    FrontFace, ImageSubresourceRange, IndexFormat, Limits as WgpuLimits, LoadOp, Maintain, MapMode,
+    FrontFace, ImageSubresourceRange, IndexFormat, Limits as WgpuLimits, LoadOp, MapMode,
     MultisampleState, Operations, Origin3d, PipelineCompilationOptions, PipelineLayout,
     PipelineLayoutDescriptor, PolygonMode, PrimitiveState, PrimitiveTopology, PushConstantRange,
     RenderPassColorAttachment, RenderPassDepthStencilAttachment, RenderPassDescriptor,

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -873,7 +873,7 @@ impl PipelineCache {
 
                 // TODO: Expose the rest of this somehow
                 let compilation_options = PipelineCompilationOptions {
-                    constants: &default(),
+                    constants: &[],
                     zero_initialize_workgroup_memory: descriptor.zero_initialize_workgroup_memory,
                 };
 
@@ -955,7 +955,7 @@ impl PipelineCache {
                     entry_point: Some(&descriptor.entry_point),
                     // TODO: Expose the rest of this somehow
                     compilation_options: PipelineCompilationOptions {
-                        constants: &default(),
+                        constants: &[],
                         zero_initialize_workgroup_memory: descriptor
                             .zero_initialize_workgroup_memory,
                     },
@@ -1159,8 +1159,12 @@ fn get_capabilities(features: Features, downlevel: DownlevelFlags) -> Capabiliti
         features.contains(Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING),
     );
     capabilities.set(
-        Capabilities::UNIFORM_BUFFER_AND_STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING,
-        features.contains(Features::UNIFORM_BUFFER_AND_STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING),
+        Capabilities::STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING,
+        features.contains(Features::STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING),
+    );
+    capabilities.set(
+        Capabilities::UNIFORM_BUFFER_ARRAY_NON_UNIFORM_INDEXING,
+        features.contains(Features::UNIFORM_BUFFER_BINDING_ARRAYS)
     );
     // TODO: This needs a proper wgpu feature
     capabilities.set(

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -21,10 +21,7 @@ use alloc::sync::Arc;
 use bevy_ecs::{prelude::*, system::SystemState};
 use bevy_platform::time::Instant;
 use bevy_time::TimeSender;
-use wgpu::{
-    Adapter, AdapterInfo, CommandBuffer, CommandEncoder, DeviceType, Instance, Queue,
-    RequestAdapterOptions,
-};
+use wgpu::{Adapter, AdapterInfo, CommandBuffer, CommandEncoder, DeviceType, Instance, Queue, RequestAdapterOptions, Trace};
 
 /// Updates the [`RenderGraph`] with all of its nodes and then runs it to render the entire frame.
 pub fn render_system(world: &mut World, state: &mut SystemState<Query<Entity, With<ViewTarget>>>) {
@@ -177,21 +174,21 @@ pub async fn initialize_renderer(
             // discrete GPUs due to having to transfer data across the PCI-E bus and so it
             // should not be automatically enabled in this case. It is however beneficial for
             // integrated GPUs.
-            features -= wgpu::Features::MAPPABLE_PRIMARY_BUFFERS;
+            features.remove(wgpu::Features::MAPPABLE_PRIMARY_BUFFERS);
         }
 
         // RAY_QUERY and RAY_TRACING_ACCELERATION STRUCTURE will sometimes cause DeviceLost failures on platforms
         // that report them as supported:
         // <https://github.com/gfx-rs/wgpu/issues/5488>
-        features -= wgpu::Features::EXPERIMENTAL_RAY_QUERY;
-        features -= wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE;
+        features.remove(wgpu::Features::EXPERIMENTAL_RAY_QUERY);
+        features.remove(wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE);
 
         limits = adapter.limits();
     }
 
     // Enforce the disabled features
     if let Some(disabled_features) = options.disabled_features {
-        features -= disabled_features;
+        features.remove(disabled_features);
     }
     // NOTE: |= is used here to ensure that any explicitly-enabled features are respected.
     features |= options.features;
@@ -240,6 +237,12 @@ pub async fn initialize_renderer(
             max_uniform_buffers_per_shader_stage: limits
                 .max_uniform_buffers_per_shader_stage
                 .min(constrained_limits.max_uniform_buffers_per_shader_stage),
+            max_binding_array_elements_per_shader_stage: limits
+                .max_binding_array_elements_per_shader_stage
+                .min(constrained_limits.max_binding_array_elements_per_shader_stage),
+            max_binding_array_sampler_elements_per_shader_stage: limits
+                .max_binding_array_sampler_elements_per_shader_stage
+                .min(constrained_limits.max_binding_array_sampler_elements_per_shader_stage),
             max_uniform_buffer_binding_size: limits
                 .max_uniform_buffer_binding_size
                 .min(constrained_limits.max_uniform_buffer_binding_size),
@@ -316,8 +319,9 @@ pub async fn initialize_renderer(
                 required_features: features,
                 required_limits: limits,
                 memory_hints: options.memory_hints.clone(),
+                // See https://github.com/gfx-rs/wgpu/issues/5974
+                trace: Trace::Off,
             },
-            options.trace_path.as_deref(),
         )
         .await
         .unwrap();

--- a/crates/bevy_render/src/settings.rs
+++ b/crates/bevy_render/src/settings.rs
@@ -2,12 +2,12 @@ use crate::renderer::{
     RenderAdapter, RenderAdapterInfo, RenderDevice, RenderInstance, RenderQueue,
 };
 use alloc::borrow::Cow;
-use std::path::PathBuf;
 
 pub use wgpu::{
     Backends, Dx12Compiler, Features as WgpuFeatures, Gles3MinorVersion, InstanceFlags,
     Limits as WgpuLimits, MemoryHints, PowerPreference,
 };
+use wgpu::DxcShaderModel;
 
 /// Configures the priority used when automatically configuring the features/limits of `wgpu`.
 #[derive(Clone)]
@@ -53,8 +53,6 @@ pub struct WgpuSettings {
     pub instance_flags: InstanceFlags,
     /// This hints to the WGPU device about the preferred memory allocation strategy.
     pub memory_hints: MemoryHints,
-    /// The path to pass to wgpu for API call tracing. This only has an effect if wgpu's tracing functionality is enabled.
-    pub trace_path: Option<PathBuf>,
 }
 
 impl Default for WgpuSettings {
@@ -114,6 +112,7 @@ impl Default for WgpuSettings {
                     Dx12Compiler::DynamicDxc {
                         dxc_path: String::from(dxc),
                         dxil_path: String::from(dxil),
+                        max_shader_model: DxcShaderModel::V6_7,
                     }
                 } else {
                     Dx12Compiler::Fxc
@@ -137,7 +136,6 @@ impl Default for WgpuSettings {
             gles3_minor_version,
             instance_flags,
             memory_hints: MemoryHints::default(),
-            trace_path: None,
         }
     }
 }

--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -59,7 +59,7 @@ cfg-if = "1.0"
 raw-window-handle = "0.6"
 serde = { version = "1.0", features = ["derive"], optional = true }
 bytemuck = { version = "1.5", optional = true }
-wgpu-types = { version = "24", optional = true }
+wgpu-types = { version = "25", optional = true }
 accesskit = "0.19"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 

--- a/examples/shader/custom_render_phase.rs
+++ b/examples/shader/custom_render_phase.rs
@@ -242,9 +242,9 @@ impl SpecializedMeshPipeline for StencilPipeline {
 type DrawMesh3dStencil = (
     SetItemPipeline,
     // This will set the view bindings in group 0
-    SetMeshViewBindGroup<0>,
+    SetMeshViewBindGroup<0, 1>,
     // This will set the mesh bindings in group 1
-    SetMeshBindGroup<1>,
+    SetMeshBindGroup<2>,
     // This will draw the mesh
     DrawMesh,
 );

--- a/examples/shader/custom_shader_instancing.rs
+++ b/examples/shader/custom_shader_instancing.rs
@@ -247,8 +247,8 @@ impl SpecializedMeshPipeline for CustomPipeline {
 
 type DrawCustom = (
     SetItemPipeline,
-    SetMeshViewBindGroup<0>,
-    SetMeshBindGroup<1>,
+    SetMeshViewBindGroup<0, 1>,
+    SetMeshBindGroup<2>,
     DrawMeshInstanced,
 );
 

--- a/examples/shader/specialized_mesh_pipeline.rs
+++ b/examples/shader/specialized_mesh_pipeline.rs
@@ -152,9 +152,9 @@ type DrawSpecializedPipelineCommands = (
     // Set the pipeline
     SetItemPipeline,
     // Set the view uniform at bind group 0
-    SetMeshViewBindGroup<0>,
+    SetMeshViewBindGroup<0, 1>,
     // Set the mesh uniform at bind group 1
-    SetMeshBindGroup<1>,
+    SetMeshBindGroup<2>,
     // Draw the mesh
     DrawMesh,
 );
@@ -209,16 +209,15 @@ impl SpecializedMeshPipeline for CustomMeshPipeline {
         // This will automatically generate the correct `VertexBufferLayout` based on the vertex attributes
         let vertex_buffer_layout = layout.0.get_layout(&vertex_attributes)?;
 
+        let mut layout = self.mesh_pipeline
+            .get_view_layout(MeshPipelineViewLayoutKey::from(mesh_key))
+            .clone()
+            .to_vec();
+        layout.push(self.mesh_pipeline.mesh_layouts.model_only.clone());
+
         Ok(RenderPipelineDescriptor {
             label: Some("Specialized Mesh Pipeline".into()),
-            layout: vec![
-                // Bind group 0 is the view uniform
-                self.mesh_pipeline
-                    .get_view_layout(MeshPipelineViewLayoutKey::from(mesh_key))
-                    .clone(),
-                // Bind group 1 is the mesh uniform
-                self.mesh_pipeline.mesh_layouts.model_only.clone(),
-            ],
+            layout,
             push_constant_ranges: vec![],
             vertex: VertexState {
                 shader: self.shader_handle.clone(),

--- a/examples/shader/texture_binding_array.rs
+++ b/examples/shader/texture_binding_array.rs
@@ -163,7 +163,7 @@ impl AsBindGroup for BindlessMaterial {
             (
                 // Screen texture
                 //
-                // @group(2) @binding(0) var textures: binding_array<texture_2d<f32>>;
+                // @group(3) @binding(0) var textures: binding_array<texture_2d<f32>>;
                 (
                     0,
                     texture_2d(TextureSampleType::Float { filterable: true })
@@ -171,7 +171,7 @@ impl AsBindGroup for BindlessMaterial {
                 ),
                 // Sampler
                 //
-                // @group(2) @binding(1) var nearest_sampler: sampler;
+                // @group(3) @binding(1) var nearest_sampler: sampler;
                 //
                 // Note: as with textures, multiple samplers can also be bound
                 // onto one binding slot:


### PR DESCRIPTION
# Objective

Upgrade to `wgpu` version `25.0`.

## Solution

## Problem

The biggest issue we face upgrading is the following requirement:
> To facilitate this change, there was an additional validation rule put in place: if there is a binding array in a bind group, you may not use dynamic offset buffers or uniform buffers in that bind group. This requirement comes from vulkan rules on UpdateAfterBind descriptors.

This is a major difficulty for us, as there are a number of binding arrays that are used in the view bind group. Note, this requirement does not affect merely uniform buffors that use dynamic offset but the use of *any* uniform in a bind group that also has a binding array.

## Attempted fixes

The easiest fix would be to change uniforms to be storage buffers whenever binding arrays are in use:
```wgsl
#ifdef BINDING_ARRAYS_ARE_USED
@group(0) @binding(0) var<uniform> view: View;
@group(0) @binding(1) var<uniform> lights: types::Lights;
#else
@group(0) @binding(0) var<storage> view: array<View>;
@group(0) @binding(1) var<storage> lights: array<types::Lights>;
#endif
```

This requires passing the view index to the shader so that we know where to index into the buffer:

```wgsl
struct PushConstants {
    view_index: u32,
}

var<push_constant> push_constants: PushConstants;
```

Using push constants is no problem because binding arrays are only usable on native anyway.

However, this greatly complicates the ability to access `view` in shaders. For example:
```wgsl
#ifdef BINDING_ARRAYS_ARE_USED
mesh_view_bindings::view.view_from_world[0].z
#else
mesh_view_bindings::view[mesh_view_bindings::view_index].view_from_world[0].z
#endif
```

Using this approach would work but would have the effect of polluting our shaders with ifdef spam basically *everywhere*.

Why not use a function? Unfortunately, the following is not valid wgsl as it returns a binding directly from a function in the uniform path.

```wgsl
fn get_view() -> View {
#if BINDING_ARRAYS_ARE_USED
    let view_index = push_constants.view_index;
    let view = views[view_index];
#endif
    return view;
}
```

This also poses problems for things like lights where we want to return a ptr to the light data. Returning ptrs from wgsl functions isn't allowed even if both bindings were buffers.

The next attempt was to simply use indexed buffers everywhere, in both the binding array and non binding array path. This would be viable if push constants were available everywhere to pass the view index, but unfortunately they are not available on webgpu. This means either passing the view index in a storage buffer (not ideal for such a small amount of state) or using push constants sometimes and uniform buffers only on webgpu. However, this kind of conditional layout infects absolutely everything.

Even if we were to accept just using storage buffer for the view index, there's also the additional problem that some dynamic offsets aren't actually per-view but per-use of a setting on a camera, which would require passing that uniform data on *every* camera regardless of whether that rendering feature is being used, which is also gross.

As such, although it's gross, the simplest solution just to bump binding arrays into `@group(1)` and all other bindings up one bind group. This should still bring us under the device limit of 4 for most users.

## Next steps / looking towards the future

I'd like to avoid needing split our view bind group into multiple parts. In the future, if `wgpu` were to add `@builtin(draw_index)`, we could build a list of draw state in gpu processing and avoid the need for any kind of state change at all (see https://github.com/gfx-rs/wgpu/issues/6823). This would also provide significantly more flexibility to handle things like offsets into other arrays that may not be per-view.

## Testing

Tested a number of examples, there are probably more that are still broken.