### PR TITLE
Fix `pbr` example text rotation

### DIFF
--- a/examples/3d/pbr.rs
+++ b/examples/3d/pbr.rs
@@ -85,8 +85,8 @@ fn setup(
             right: Val::ZERO,
             ..default()
         },
-        Transform {
-            rotation: Quat::from_rotation_z(std::f32::consts::PI / 2.0),
+        UiTransform {
+            rotation: Rot2::degrees(90.),
             ..default()
         },
     ));


### PR DESCRIPTION
# Objective

This example migration was missed in #16615

https://pixel-eagle.com/project/b25a040a-a980-4602-b90c-d480ab84076d/run/10633/compare/10627?screenshot=3D+Rendering/pbr.png

## Solution

Use new `UiTransform`

## Testing

`cargo run --example pbr`
