### PR TITLE
Make `GILRS` and `WINIT_WINDOWS` public

### DIFF
--- a/crates/bevy_gilrs/src/lib.rs
+++ b/crates/bevy_gilrs/src/lib.rs
@@ -39,7 +39,7 @@ thread_local! {
     /// `NonSendMut` parameter, which told Bevy that the system was `!Send`, but now with the removal of `!Send`
     /// resource/system parameter usage, there is no internal guarantee that the system will run in only one thread, so
     /// we need to rely on the platform to make such a guarantee.
-    static GILRS: RefCell<Option<gilrs::Gilrs>> = const { RefCell::new(None) };
+    pub static GILRS: RefCell<Option<gilrs::Gilrs>> = const { RefCell::new(None) };
 }
 
 #[derive(Resource)]

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -55,7 +55,9 @@ mod winit_monitors;
 mod winit_windows;
 
 thread_local! {
-    static WINIT_WINDOWS: RefCell<WinitWindows> = const { RefCell::new(WinitWindows::new()) };
+    /// Temporary storage of WinitWindows data to replace usage of `!Send` resources. This will be replaced with proper
+    /// storage of `!Send` data after issue #17667 is complete.
+    pub static WINIT_WINDOWS: RefCell<WinitWindows> = const { RefCell::new(WinitWindows::new()) };
 }
 
 /// A [`Plugin`] that uses `winit` to create and manage windows, and receive window and input

--- a/release-content/migration-guides/replace_non_send_resources.md
+++ b/release-content/migration-guides/replace_non_send_resources.md
@@ -35,3 +35,19 @@ WINIT_WINDOWS.with_borrow_mut(|winit_windows| {
 ```
 
 If a borrow is attempted while the data is borrowed elsewhere, the method will panic.
+
+Previously, the use of a `!Send` resource in a system would force the system to execute on the main thread. Since `!Send` resources are removed in Bevy, we needed to create a new way to prevent systems from running on non-main threads. To do this, you can now use `bevy_ecs::system::NonSendMarker` as a system parameter:
+
+```rust
+use bevy_ecs::system::NonSendMarker;
+
+fn my_system(
+    _non_send_marker: NonSendMarker,
+) {
+    ACCESS_KIT_ADAPTERS.with_borrow_mut(|adapters| {
+        // do things with adapters
+    });
+}
+```
+
+To prevent a panic, if any of the `!Send` resource replacements mentioned in this document are used in a system, the system should _always_ be marked as `!Send` with `bevy_ecs::system::NonSendMarker`.

--- a/release-content/migration-guides/replace_non_send_resources.md
+++ b/release-content/migration-guides/replace_non_send_resources.md
@@ -3,7 +3,10 @@ title: Replace `Gilrs`, `AccessKitAdapters`, and `WinitWindows` resources
 pull_requests: [18386, 17730, 19575]
 ---
 
+## NonSend Resources Replaced
+
 As an effort to remove `!Send` resources in Bevy, we replaced the following resources:
+
 * `Gilrs` - _For wasm32 only, other platforms are unchanged -_ Replaced with `bevy_gilrs::GILRS`
 * `WinitWindows` - Replaced with `bevy_winit::WINIT_WINDOWS`
 * `AccessKitAdapters` - Replaced with `bevy_winit::ACCESS_KIT_ADAPTERS`
@@ -12,7 +15,8 @@ Each of these are now using `thread_local`s to store the data and are temporary 
 
 Here is an example of how the data can now be accessed. This example will use `WINIT_WINDOWS` as an example, but the same technique can be applied to the others:
 
-__Immutable Access__
+### Immutable Access
+
 ```rust
 use bevy_winit::WINIT_WINDOWS;
 
@@ -23,7 +27,8 @@ WINIT_WINDOWS.with_borrow(|winit_windows| {
 });
 ```
 
-__Mutable Access__
+### Mutable Access
+
 ```rust
 use bevy_winit::WINIT_WINDOWS;
 
@@ -35,6 +40,8 @@ WINIT_WINDOWS.with_borrow_mut(|winit_windows| {
 ```
 
 If a borrow is attempted while the data is borrowed elsewhere, the method will panic.
+
+## NonSend Systems
 
 Previously, the use of a `!Send` resource in a system would force the system to execute on the main thread. Since `!Send` resources are removed in Bevy, we needed to create a new way to prevent systems from running on non-main threads. To do this, you can now use `bevy_ecs::system::NonSendMarker` as a system parameter:
 

--- a/release-content/migration-guides/replace_non_send_resources.md
+++ b/release-content/migration-guides/replace_non_send_resources.md
@@ -1,0 +1,37 @@
+---
+title: Replace `Gilrs`, `AccessKitAdapters`, and `WinitWindows` resources
+pull_requests: [18386, 17730, 19575]
+---
+
+As an effort to remove `!Send` resources in Bevy, we replaced the following resources:
+* `Gilrs` - _For wasm32 only, other platforms are unchanged -_ Replaced with `bevy_gilrs::GILRS`
+* `WinitWindows` - Replaced with `bevy_winit::WINIT_WINDOWS`
+* `AccessKitAdapters` - Replaced with `bevy_winit::ACCESS_KIT_ADAPTERS`
+
+Each of these are now using `thread_local`s to store the data and are temporary solutions to storing `!Send` data. Even though `thread_local`s are thread safe, they should not be accessed from other threads. If they are accessed from other threads, the data will be uninitialized in each non-main thread, which isn't very useful.
+
+Here is an example of how the data can now be accessed. This example will use `WINIT_WINDOWS` as an example, but the same technique can be applied to the others:
+
+__Immutable Access__
+```rust
+use bevy_winit::WINIT_WINDOWS;
+
+...
+
+WINIT_WINDOWS.with_borrow(|winit_windows| {
+    // do things with `winit_windows`
+});
+```
+
+__Mutable Access__
+```rust
+use bevy_winit::WINIT_WINDOWS;
+
+...
+
+WINIT_WINDOWS.with_borrow_mut(|winit_windows| {
+    // do things with `winit_windows`
+});
+```
+
+If a borrow is attempted while the data is borrowed elsewhere, the method will panic.


### PR DESCRIPTION
After removing `!Send` resources, `GILRS` and `WINIT_WINDOWS` were not made public, which is a breaking change. This was brought up in a [comment on that PR](https://github.com/bevyengine/bevy/pull/18386#issuecomment-2954209010). This PR makes them public.

Fixes #19540.