### PR TITLE
Update ImageMeasure to apply aspect ratio to min/max height/width

### DIFF
--- a/examples/ui/ui_scaling.rs
+++ b/examples/ui/ui_scaling.rs
@@ -67,8 +67,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             parent.spawn((
                 ImageNode::new(asset_server.load("branding/icon.png")),
                 Node {
-                    width: Val::Px(30.0),
-                    height: Val::Px(30.0),
+                    height: Val::Percent(50.0),
+                    max_width: Val::Px(50.0),
                     ..default()
                 },
             ));


### PR DESCRIPTION
# Objective

- Fixes #19576

## Solution

- Apply aspect ratio multiple times to 'draw back' the image size if it leaks outside min/max bounds after the first aspect ratio application.

## Testing

- Updated the `ui_scaling` example to demonstrate.
