### PR TITLE
Impl system condition

### DIFF
--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -14,8 +14,8 @@ use crate::{
     system::{BoxedSystem, InfallibleSystemWrapper, IntoSystem, ScheduleSystem, System},
 };
 
-fn new_condition<M>(condition: impl SystemCondition<M>) -> BoxedCondition {
-    let condition_system = IntoSystem::into_system(condition);
+fn new_condition<M, Out>(condition: impl SystemCondition<M, (), Out>) -> BoxedCondition {
+    let condition_system = condition.into_condition_system();
     assert!(
         condition_system.is_send(),
         "SystemCondition `{}` accesses `NonSend` resources. This is not currently supported.",
@@ -447,7 +447,7 @@ pub trait IntoScheduleConfigs<T: Schedulable<Metadata = GraphInfo, GroupMetadata
     ///
     /// Use [`distributive_run_if`](IntoScheduleConfigs::distributive_run_if) if you want the
     /// condition to be evaluated for each individual system, right before one is run.
-    fn run_if<M>(self, condition: impl SystemCondition<M>) -> ScheduleConfigs<T> {
+    fn run_if<M, Out>(self, condition: impl SystemCondition<M, (), Out>) -> ScheduleConfigs<T> {
         self.into_configs().run_if(condition)
     }
 
@@ -535,7 +535,7 @@ impl<T: Schedulable<Metadata = GraphInfo, GroupMetadata = Chain>> IntoScheduleCo
         self
     }
 
-    fn run_if<M>(mut self, condition: impl SystemCondition<M>) -> ScheduleConfigs<T> {
+    fn run_if<M, Out>(mut self, condition: impl SystemCondition<M, (), Out>) -> ScheduleConfigs<T> {
         self.run_if_dyn(new_condition(condition));
         self
     }

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -29,6 +29,7 @@ mod tests {
     use alloc::{string::ToString, vec, vec::Vec};
     use core::sync::atomic::{AtomicU32, Ordering};
 
+    use crate::error::BevyError;
     pub use crate::{
         prelude::World,
         resource::Resource,
@@ -49,10 +50,10 @@ mod tests {
     struct SystemOrder(Vec<u32>);
 
     #[derive(Resource, Default)]
-    struct RunConditionBool(pub bool);
+    struct RunConditionBool(bool);
 
     #[derive(Resource, Default)]
-    struct Counter(pub AtomicU32);
+    struct Counter(AtomicU32);
 
     fn make_exclusive_system(tag: u32) -> impl FnMut(&mut World) {
         move |world| world.resource_mut::<SystemOrder>().0.push(tag)
@@ -252,12 +253,13 @@ mod tests {
     }
 
     mod conditions {
+
         use crate::change_detection::DetectChanges;
 
         use super::*;
 
         #[test]
-        fn system_with_condition() {
+        fn system_with_condition_bool() {
             let mut world = World::default();
             let mut schedule = Schedule::default();
 
@@ -274,6 +276,47 @@ mod tests {
             world.resource_mut::<RunConditionBool>().0 = true;
             schedule.run(&mut world);
             assert_eq!(world.resource::<SystemOrder>().0, vec![0]);
+        }
+
+        #[test]
+        fn system_with_condition_result_unit() {
+            let mut world = World::default();
+            let mut schedule = Schedule::default();
+
+            world.init_resource::<SystemOrder>();
+
+            schedule.add_systems(
+                make_function_system(0).run_if(|| Err::<(), BevyError>(core::fmt::Error.into())),
+            );
+
+            schedule.run(&mut world);
+            assert_eq!(world.resource::<SystemOrder>().0, vec![]);
+
+            schedule.add_systems(make_function_system(1).run_if(|| Ok(())));
+
+            schedule.run(&mut world);
+            assert_eq!(world.resource::<SystemOrder>().0, vec![1]);
+        }
+
+        #[test]
+        fn system_with_condition_result_bool() {
+            let mut world = World::default();
+            let mut schedule = Schedule::default();
+
+            world.init_resource::<SystemOrder>();
+
+            schedule.add_systems((
+                make_function_system(0).run_if(|| Err::<bool, BevyError>(core::fmt::Error.into())),
+                make_function_system(1).run_if(|| Ok(false)),
+            ));
+
+            schedule.run(&mut world);
+            assert_eq!(world.resource::<SystemOrder>().0, vec![]);
+
+            schedule.add_systems(make_function_system(2).run_if(|| Ok(true)));
+
+            schedule.run(&mut world);
+            assert_eq!(world.resource::<SystemOrder>().0, vec![2]);
         }
 
         #[test]


### PR DESCRIPTION
# Objective

This is a follow-up of #19553.
I missed something. Right now the combinators (`and`, `or`, ...) only work with conditions returning `bool`. The same goes for `condition_changed`, `condition_changed_to` and `not`. The objective is to fix that to allow conditions returning `Result<(), BevyError>` and `Result<bool, BevyError>` to use these methods as well.

## Solution

It's essentially just about calling `into_condition_system()` in the methods. I just have a problem for `not` because it's implemented differently than the others. Currently `not` can accept any system whose output implement `Not`. That's a problem for systems returning `Result<(), BevyError>` or `Result<bool, BevyError>`. I see mostly two options:
1. Leave things as they are and the new conditions cannot be used with `not`.
2. Limit `not` to accept only run conditions. This way `not` could accept the new run conditions but not any system whose output implements `Not`.

I would say the second solution has more upsides than downsides because
- Use cases of `not` with `Not` feels more niche than use cases of `not` with the new conditions
- It is more coherent (being able to use the new run conditions with `run_if` but not `not` is confusing)
- To invert a system whose output implements `Not` you can still do `system.map(|x| !x)`

but I may be missing something. What do you think ?

## Testing

I also added a simple test for all the missing methods.