### PR TITLE
Thoroughly document the current state of observers

### DIFF
--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -262,10 +262,14 @@ impl<'w, E, B: Bundle> DerefMut for Trigger<'w, E, B> {
     }
 }
 
-/// Represents a collection of targets for a specific [`Trigger`] of an [`Event`]. Targets can be of type [`Entity`] or [`ComponentId`].
+/// Represents a collection of targets for a specific [`Trigger`] of an [`Event`].
 ///
 /// When a trigger occurs for a given event and [`TriggerTargets`], any [`Observer`] that watches for that specific event-target combination
 /// will run.
+///
+/// This trait is implemented for both [`Entity`] and [`ComponentId`], allowing you to target specific entities or components.
+/// It is also implemented for various collections of these types, such as [`Vec`], arrays, and tuples,
+/// allowing you to trigger events for multiple targets at once.
 pub trait TriggerTargets {
     /// The components the trigger should target.
     fn components(&self) -> impl Iterator<Item = ComponentId> + Clone + '_;

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! ## Observer targeting
 //!
-//! Observers can be "global", listening for events that are not targeted at any specific entity,
+//! Observers can be "global", listening for events that are both targeted at and not targeted at any specific entity,
 //! or they can be "entity-specific", listening for events that are targeted at specific entities.
 //!
 //! They can also be further refined by listening to events targeted at specific components

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -16,7 +16,7 @@
 //!
 //! ## Writing observers
 //!
-//! Observers are systems that implement [`IntoObserverSystem`] and listen for [`Event`]s that match their
+//! Observers are systems which implement [`IntoObserverSystem`] that listen for [`Event`]s that match their
 //! type and target(s).
 //! To write observer systems, use the [`Trigger`] system parameter as the first parameter of your system.
 //! This parameter provides access to the specific event that triggered the observer,
@@ -24,7 +24,7 @@
 //!
 //! Observers can request other data from the world,
 //! such as via a [`Query`] or [`Res`]. Commonly, you might want to verify that
-//! the entity targeted by the event has a specific component,
+//! the entity that the observable event is targeting has a specific component,
 //! or meets some other condition.
 //! [`Query::get`] or [`Query::contains`] on the [`Trigger::target`] entity
 //! is a good way to do this.
@@ -70,14 +70,14 @@
 //! This behavior is controlled via [`Event::Traversal`] and [`Event::AUTO_PROPAGATE`],
 //! with the details of the propagation path specified by the [`Traversal`](crate::traversal::Traversal) trait.
 //!
-//! When auto-propagation is enabled, propagation must be manually stopped to prevent the event from
+//! When auto-propagation is enabled, propagaion must be manually stopped to prevent the event from
 //! continuing to other targets.
 //! This can be done using the [`Trigger::propagate`] method on the [`Trigger`] system parameter inside of your observer.
 //!
 //!  ## Observer timing
 //!
 //! Observers are triggered via [`Commands`], which imply that they are evaluated at the next sync point in the ECS schedule.
-//! Accordingly, they have full access to the world, and are evaluated sequentially (and recursively), in the order that the commands were sent.
+//! Accordingly, they have full access to the world, and are evaluated sequentially, in the order that the commands were sent.
 //!
 //! To control the relative ordering of observers sent from different systems,
 //! order the systems in the schedule relative to each other.
@@ -146,7 +146,7 @@ use smallvec::SmallVec;
 /// [`Event`] data itself. If it was triggered for a specific [`Entity`], it includes that as well. It also
 /// contains event propagation information. See [`Trigger::propagate`] for more information.
 ///
-/// The generic `B: Bundle` is used to further specialize the events that this observer is interested in.
+/// The generic `B: Bundle` is used to modify the further specialize the events that this observer is interested in.
 /// The entity involved *does not* have to have these components, but the observer will only be
 /// triggered if the event matches the components in `B`.
 ///
@@ -509,7 +509,7 @@ pub struct CachedObservers {
 /// Some observer kinds (like [lifecycle](crate::lifecycle) observers) have a dedicated field,
 /// saving lookups for the most common triggers.
 ///
-/// This is stored inside of [`World::observers`].
+/// This is stored as a field of the [`World`].
 #[derive(Default, Debug)]
 pub struct Observers {
     // Cached ECS observers to save a lookup most common triggers.

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -150,18 +150,6 @@ impl<'w, E, B: Bundle> Trigger<'w, E, B> {
 
     /// Returns the [`Entity`] that was targeted by the `event` that triggered this observer. It may
     /// be [`None`] if the trigger is not for a particular entity.
-    ///
-    /// Observable events can target specific entities. When those events fire, they will trigger
-    /// any observers on the targeted entities. In this case, the `target()` and `observer()` are
-    /// the same, because the observer that was triggered is attached to the entity that was
-    /// targeted by the event.
-    ///
-    /// However, it is also possible for those events to bubble up the entity hierarchy and trigger
-    /// observers on *different* entities, or trigger a global observer. In these cases, the
-    /// observing entity is *different* from the entity being targeted by the event.
-    ///
-    /// This is an important distinction: the entity reacting to an event is not always the same as
-    /// the entity triggered by the event.
     pub fn target(&self) -> Option<Entity> {
         self.trigger.target
     }

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -476,6 +476,8 @@ impl ObserverTrigger {
 type ObserverMap = EntityHashMap<ObserverRunner>;
 
 /// Collection of [`ObserverRunner`] for [`Observer`] registered to a particular trigger targeted at a specific component.
+///
+/// This is stored inside of [`CachedObservers`].
 #[derive(Default, Debug)]
 pub struct CachedComponentObservers {
     // Observers listening to triggers targeting this component
@@ -485,6 +487,8 @@ pub struct CachedComponentObservers {
 }
 
 /// Collection of [`ObserverRunner`] for [`Observer`] registered to a particular trigger.
+///
+/// This is stored inside of [`Observers`], specialized for each kind of observer.
 #[derive(Default, Debug)]
 pub struct CachedObservers {
     // Observers listening for any time this trigger is fired
@@ -495,7 +499,13 @@ pub struct CachedObservers {
     entity_observers: EntityHashMap<ObserverMap>,
 }
 
-/// Metadata for observers. Stores a cache mapping trigger ids to the registered observers.
+/// An internal lookup table tracking all of the observers in the world.
+///
+/// Stores a cache mapping trigger ids to the registered observers.
+/// Some observer kinds (like [lifecycle](crate::lifecycle) observers) have a dedicated field,
+/// saving lookups for the most common triggers.
+///
+/// This is stored inside of [`World::observers`].
 #[derive(Default, Debug)]
 pub struct Observers {
     // Cached ECS observers to save a lookup most common triggers.
@@ -504,7 +514,7 @@ pub struct Observers {
     on_replace: CachedObservers,
     on_remove: CachedObservers,
     on_despawn: CachedObservers,
-    // Map from trigger type to set of observers
+    // Map from trigger type to set of observers listening to that trigger
     cache: HashMap<ComponentId, CachedObservers>,
 }
 

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -96,7 +96,13 @@
 //! they can be added or removed at runtime, and multiple observers
 //! can be registered for the same lifecycle event for the same component.
 //!
-//! Observers always respond to lifecycle events *after* the corresponding hooks are resolved.
+//! The ordering of hooks versus observers differs based on the lifecycle event in question:
+//!
+//! - when adding components, hooks are evaluated first, then observers
+//! - when removing components, observers are evaluated first, then hooks
+//!
+//! This allows hooks to act as constructors and destructors for components,
+//! as they always have the first and final say in the component's lifecycle.
 //!
 //! ## Cleaning up observers
 //!

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -42,16 +42,15 @@
 //! once the entity is spawned, or by manually spawning an entity with the [`Observer`] component
 //! configured with the desired targets.
 //!
-//! Observers are defined as "entities which have the [`Observer`] component"
+//! Observers are fundamentally defined as "entities which have the [`Observer`] component"
 //! allowing you to add it manually to existing entities.
-//! This pattern can be simplified by calling [`EntityCommands::observe`],
-//! which will add the [`Observer`] component to an entity, watching itself.
+//! At first, this seems convenient, but only one observer can be added to an entity at a time,
+//! regardless of the event it responds to: like always, components are unique.
 //!
-//! This is a convenient way to spawn an observer, and also ensures that the observer will be cleaned up
-//! when the entity is despawned.
-//! However, only one observer can be added to an entity at a time, regardless of the event it responds to:
-//! like always, components are unique.
-//! This can also be frustrating as observers defined in this way
+//! Instead, a better way to achieve a similar aim is to
+//! use the [`EntityWorldMut::observe`] / [`EntityCommands::observe`] method,
+//! which spawns a new observer, and configures it to watch the entity it is called on.
+//! Unfortunately, observers defined in this way
 //! [currently cannot be spawned as part of bundles](https://github.com/bevyengine/bevy/issues/14204).
 //!
 //! ## Triggering observers
@@ -98,6 +97,14 @@
 //! can be registered for the same lifecycle event for the same component.
 //!
 //! Observers always respond to lifecycle events *after* the corresponding hooks are resolved.
+//!
+//! ## Cleaning up observers
+//!
+//! Currently, observer entities are never cleaned up, even if their target entity(s) are despawned.
+//! This won't cause any runtime overhead, but is a waste of memory and can result in memory leaks.
+//!
+//! If you run into this problem, you could manually scan the world for observer entities and despawn them,
+//! by checking if the entity in [`Observer::descriptor`] still exists.
 //!
 //! ## Observers vs buffered events
 //!

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -448,7 +448,9 @@ impl ObserverDescriptor {
     }
 }
 
-/// Event trigger metadata for a given [`Observer`],
+/// Metadata about a specific [`Event`] which triggered an observer.
+///
+/// This information is exposed via methods on the [`Trigger`] system parameter.
 #[derive(Debug)]
 pub struct ObserverTrigger {
     /// The [`Entity`] of the observer handling the trigger.

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -59,8 +59,10 @@
 //! via [`Commands::trigger`] (for untargeted events) or [`Commands::trigger_targets`] (for targeted events).
 //! Like usual, equivalent methods are available on [`World`], allowing you to reduce overhead when working with exclusive world access.
 //!
-//! To trigger events for a specific set of components, pass in a [`ComponentId`] or a collection of them
-//! into [`Commands::trigger_targets`] by using the [`TriggerTargets`] trait.
+//! If your observer is configured to watch for a specific component or set of components instead,
+//! you can pass in [`ComponentId`]s into [`Commands::trigger_targets`] by using the [`TriggerTargets`] trait.
+//! As discussed in the [`Trigger`] documentation, this use case is rare, and is currently only used
+//! for [lifecycle](crate::lifecycle) events, which are automatically emitted.
 //!
 //! ## Observer bubbling
 //!

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -395,7 +395,9 @@ all_tuples!(
     T
 );
 
-/// A description of what an [`Observer`] observes.
+/// Store information about what an [`Observer`] observes.
+///
+/// This information is stored inside of the [`Observer`] component,
 #[derive(Default, Clone)]
 pub struct ObserverDescriptor {
     /// The events the observer is watching.

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -57,6 +57,7 @@
 //!
 //! Observers are most commonly triggered by [`Commands`],
 //! via [`Commands::trigger`] (for untargeted events) or [`Commands::trigger_targets`] (for targeted events).
+//! Like usual, equivalent methods are available on [`World`], allowing you to reduce overhead when working with exclusive world access.
 //!
 //! To trigger events for a specific set of components, pass in a [`ComponentId`] or a collection of them
 //! into [`Commands::trigger_targets`] by using the [`TriggerTargets`] trait.

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -8,6 +8,9 @@
 //! They can also be further refined by listening to events targeted at specific components
 //! (instead of using a generic event type), as is done with the [`OnAdd`] family of lifecycle events.
 //!
+//! When entities are observed, they will receive an [`ObservedBy`] component,
+//! which will be updated to track the observers that are currently observing them.
+//!
 //! Currently, [observers cannot be retargeted after spawning](https://github.com/bevyengine/bevy/issues/19587):
 //! despawn and respawn an observer as a workaround.
 //!

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -1,6 +1,6 @@
 //! Observers are a push-based tool for responding to [`Event`]s.
 //!
-//! //! ## Observer targeting
+//! ## Observer targeting
 //!
 //! Observers can be "global", listening for events that are not targeted at any specific entity,
 //! or they can be "entity-specific", listening for events that are targeted at specific entities.
@@ -13,7 +13,7 @@
 //!
 //! ## Writing observers
 //!
-//! Observers are systems which implement [`Observer`] that listen for [`Event`]s that match their
+//! Observers are systems which implement [`IntoObserverSystem`] that listen for [`Event`]s that match their
 //! type and target(s).
 //! To write observer systems, use the [`Trigger`] system parameter as the first parameter of your system.
 //! This parameter provides access to the specific event that triggered the observer,
@@ -28,6 +28,27 @@
 //!
 //! [`Commands`] can also be used inside of observers.
 //! This can be particularly useful for triggering other observers!
+//!
+//! ## Spawning observers
+//!
+//! Observers can be spawned via [`World::add_observer`], or the equivalent app method.
+//! This will cause an entity with the [`Observer`] component to be created,
+//! which will then run the observer system whenever the event it is watching is triggered.
+//!
+//! You can control the targets that an observer is watching by calling [`Observer::watch_entity`]
+//! once the entity is spawned, or by manually spawning an entity with the [`Observer`] component
+//! configured with the desired targets.
+//!
+//! Because observers are defined as "entities which have the [`Observer`] component",
+//! you can also add it to existing entities via [`EntityCommands::observe`],
+//! which will add the [`Observer`] component to the entity, watching that entity.
+//!
+//! This is a convenient way to spawn an observer, and also ensures that the observer will be cleaned up
+//! when the entity is despawned.
+//! However, only one observer can be added to an entity at a time, regardless of the event it responds to:
+//! like always, components are unique.
+//! This can also be frustrating as observers defined in this way
+//! [currently cannot be spawned as part of bundles](https://github.com/bevyengine/bevy/issues/14204).
 //!
 //! ## Triggering observers
 //!

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -1,5 +1,18 @@
 //! Observers are a push-based tool for responding to [`Event`]s.
 //!
+//! //! ## Observer targeting
+//!
+//! Observers can be "global", listening for events that are not targeted at any specific entity,
+//! or they can be "entity-specific", listening for events that are targeted at specific entities.
+//!
+//! They can also be further refined by listening to events targeted at specific components
+//! (instead of using a generic event type), as is done with the [`OnAdd`] family of lifecycle events.
+//!
+//! Currently, [observers cannot be retargeted after spawning](https://github.com/bevyengine/bevy/issues/19587):
+//! despawn and respawn an observer as a workaround.
+//!
+//! ## Writing observers
+//!
 //! Observers are systems which implement [`Observer`] that listen for [`Event`]s that match their
 //! type and target(s).
 //! To write observer systems, use the [`Trigger`] system parameter as the first parameter of your system.
@@ -16,16 +29,13 @@
 //! [`Commands`] can also be used inside of observers.
 //! This can be particularly useful for triggering other observers!
 //!
-//! ## Observer targeting
+//! ## Triggering observers
 //!
-//! Observers can be "global", listening for events that are not targeted at any specific entity,
-//! or they can be "entity-specific", listening for events that are targeted at specific entities.
+//! Observers are most commonly triggered by [`Commands`],
+//! via [`Commands::trigger`] (for untargeted events) or [`Commands::trigger_targets`] (for targeted events).
 //!
-//! They can also be further refined by listening to events targeted at specific components
-//! (instead of using a generic event type), as is done with the [`OnAdd`] family of lifecycle events.
-//!
-//! Currently, [observers cannot be retargeted after spawning](https://github.com/bevyengine/bevy/issues/19587):
-//! despawn and respawn an observer as a workaround.
+//! To trigger events for a specific set of components, pass in a [`ComponentId`] or a collection of them
+//! into [`Commands::trigger_targets`] by using the [`TriggerTargets`] trait.
 //!
 //! ## Observer bubbling
 //!

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -110,6 +110,17 @@ use smallvec::SmallVec;
 /// Type containing triggered [`Event`] information for a given run of an [`Observer`]. This contains the
 /// [`Event`] data itself. If it was triggered for a specific [`Entity`], it includes that as well. It also
 /// contains event propagation information. See [`Trigger::propagate`] for more information.
+///
+/// The generic `B: Bundle` is used to further specialize the events that this observer is interested in.
+/// The entity involved *does not* have to have these components, but the observer will only be
+/// triggered if the event matches the components in `B`.
+///
+/// This is used to to avoid providing a generic argument in your event, as is done for [`OnAdd`]
+/// and the other lifecycle events.
+///
+/// Providing multiple components in this bundle will cause this event to be triggered by any
+/// matching component in the bundle,
+/// [rather than requiring all of them to be present](https://github.com/bevyengine/bevy/issues/15325).
 pub struct Trigger<'w, E, B: Bundle = ()> {
     event: &'w mut E,
     propagate: &'w mut bool,

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -16,7 +16,7 @@
 //!
 //! ## Writing observers
 //!
-//! Observers are systems which implement [`IntoObserverSystem`] that listen for [`Event`]s that match their
+//! Observers are systems which implement [`IntoObserverSystem`] that listen for [`Event`]s matching their
 //! type and target(s).
 //! To write observer systems, use the [`Trigger`] system parameter as the first parameter of your system.
 //! This parameter provides access to the specific event that triggered the observer,

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -42,9 +42,10 @@
 //! once the entity is spawned, or by manually spawning an entity with the [`Observer`] component
 //! configured with the desired targets.
 //!
-//! Because observers are defined as "entities which have the [`Observer`] component",
-//! you can also add it to existing entities via [`EntityCommands::observe`],
-//! which will add the [`Observer`] component to the entity, watching that entity.
+//! Observers are defined as "entities which have the [`Observer`] component"
+//! allowing you to add it manually to existing entities.
+//! This pattern can be simplified by calling [`EntityCommands::observe`],
+//! which will add the [`Observer`] component to an entity, watching itself.
 //!
 //! This is a convenient way to spawn an observer, and also ensures that the observer will be cleaned up
 //! when the entity is despawned.

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -16,7 +16,7 @@
 //!
 //! ## Writing observers
 //!
-//! Observers are systems which implement [`IntoObserverSystem`] that listen for [`Event`]s that match their
+//! Observers are systems that implement [`IntoObserverSystem`] and listen for [`Event`]s that match their
 //! type and target(s).
 //! To write observer systems, use the [`Trigger`] system parameter as the first parameter of your system.
 //! This parameter provides access to the specific event that triggered the observer,
@@ -24,7 +24,7 @@
 //!
 //! Observers can request other data from the world,
 //! such as via a [`Query`] or [`Res`]. Commonly, you might want to verify that
-//! the entity that the observable event is targeting has a specific component,
+//! the entity targeted by the event has a specific component,
 //! or meets some other condition.
 //! [`Query::get`] or [`Query::contains`] on the [`Trigger::target`] entity
 //! is a good way to do this.
@@ -70,14 +70,14 @@
 //! This behavior is controlled via [`Event::Traversal`] and [`Event::AUTO_PROPAGATE`],
 //! with the details of the propagation path specified by the [`Traversal`](crate::traversal::Traversal) trait.
 //!
-//! When auto-propagation is enabled, propagaion must be manually stopped to prevent the event from
+//! When auto-propagation is enabled, propagation must be manually stopped to prevent the event from
 //! continuing to other targets.
 //! This can be done using the [`Trigger::propagate`] method on the [`Trigger`] system parameter inside of your observer.
 //!
 //!  ## Observer timing
 //!
 //! Observers are triggered via [`Commands`], which imply that they are evaluated at the next sync point in the ECS schedule.
-//! Accordingly, they have full access to the world, and are evaluated sequentially, in the order that the commands were sent.
+//! Accordingly, they have full access to the world, and are evaluated sequentially (and recursively), in the order that the commands were sent.
 //!
 //! To control the relative ordering of observers sent from different systems,
 //! order the systems in the schedule relative to each other.


### PR DESCRIPTION
# Objective

The documentation for observers is not very good. This poses a problem to users, but *also* causes serious problems for engine devs, as they attempt to improve assorted issues surrounding observers.

This PR:

- Fixes #14084.
- Fixes #14726.
- Fixes #16538.
- Closes #18914, by attempting to solve the same issue.

To keep this PR at all reviewable, I've opted to simply note the various limitations (some may call them bugs!) in place, rather than attempting to fix them. There is a huge amount of cleanup work to be done here: see https://github.com/orgs/bevyengine/projects/17.

## Solution

- Write good module docs for observers, offering bread crumbs to the most common methods and techniques and comparing-and-contrasting as needed.
- Fix any actively misleading documentation.
- Try to explain how the various bits of the (public?!) internals are related.