### PR TITLE
Make the `ObservedBy` component useful to public consumers

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -106,10 +106,13 @@ impl Default for App {
 
         #[cfg(feature = "bevy_reflect")]
         {
+            use bevy_ecs::observer::ObservedBy;
+
             app.init_resource::<AppTypeRegistry>();
             app.register_type::<Name>();
             app.register_type::<ChildOf>();
             app.register_type::<Children>();
+            app.register_type::<ObservedBy>();
         }
 
         #[cfg(feature = "reflect_functions")]

--- a/crates/bevy_ecs/src/observer/entity_observer.rs
+++ b/crates/bevy_ecs/src/observer/entity_observer.rs
@@ -12,6 +12,13 @@ use super::Observer;
 #[derive(Default)]
 pub struct ObservedBy(pub(crate) Vec<Entity>);
 
+impl ObservedBy {
+    /// Provides a read-only reference to the list of entities observing this entity.
+    pub fn get(&self) -> &[Entity] {
+        &self.0
+    }
+}
+
 impl Component for ObservedBy {
     const STORAGE_TYPE: StorageType = StorageType::SparseSet;
     type Mutability = Mutable;

--- a/crates/bevy_ecs/src/observer/entity_observer.rs
+++ b/crates/bevy_ecs/src/observer/entity_observer.rs
@@ -2,6 +2,7 @@ use crate::{
     component::{Component, ComponentCloneBehavior, Mutable, StorageType},
     entity::{ComponentCloneCtx, Entity, EntityClonerBuilder, EntityMapper, SourceComponent},
     lifecycle::{ComponentHook, HookContext},
+    prelude::ReflectComponent,
     world::World,
 };
 use alloc::vec::Vec;
@@ -9,7 +10,9 @@ use alloc::vec::Vec;
 use super::Observer;
 
 /// Tracks a list of entity observers for the [`Entity`] [`ObservedBy`] is added to.
-#[derive(Default)]
+#[derive(Default, Debug)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+#[cfg_attr(feature = "bevy_reflect", reflect(Component, Debug))]
 pub struct ObservedBy(pub(crate) Vec<Entity>);
 
 impl ObservedBy {


### PR DESCRIPTION
# Objective

As raised by @Jondolf, this type is `pub`, and useful for various consumers to ensure cleanup or debugging.

However, it doesn't offer any way to actually view the data.

## Solution

- Add a read-only view of the data.
- Don't add any (easy) way to mutate the data, as this presents a huge footgun.
- Implement Reflect and register the component so you can see it in inspectors nicely.
