### PR TITLE
Fix SubStates with multiple source states not reacting to all source changes

### DIFF
--- a/crates/bevy_state/src/state/state_set.rs
+++ b/crates/bevy_state/src/state/state_set.rs
@@ -293,7 +293,7 @@ macro_rules! impl_state_set_sealed_tuples {
                      current_state_res: Option<ResMut<State<T>>>,
                      next_state_res: Option<ResMut<NextState<T>>>,
                      ($($val),*,): ($(Option<Res<State<$param::RawState>>>),*,)| {
-                        let parent_changed = ($($evt.read().last().is_some())&&*);
+                        let parent_changed = ($($evt.read().last().is_some())||*);
                         let next_state = take_next_state(next_state_res);
 
                         if !parent_changed && next_state.is_none() {


### PR DESCRIPTION
# Objective

- Fix issue where `SubStates` depending on multiple source states would only react when _all_ source states changed simultaneously.
- SubStates should be created/destroyed whenever _any_ of their source states transitions, not only when all change together.

# Solution

- Changed the "did parent change" detection logic from AND to OR. We need to check if _any_ of the event readers changed, not if _all_ of them changed.
- See https://github.com/bevyengine/bevy/actions/runs/15610159742/job/43968937544?pr=19595 for failing test proof before I pushed the fix.
- The generated code we want needs `||`s not `&&`s like this:

```rust
fn register_sub_state_systems_in_schedule<T: SubStates<SourceStates = Self>>(schedule: &mut Schedule) {
  let apply_state_transition = |(mut ereader0, mut ereader1, mut ereader2): (
      EventReader<StateTransitionEvent<S0::RawState>>,
      EventReader<StateTransitionEvent<S1::RawState>>,
      EventReader<StateTransitionEvent<S2::RawState>>,
  ),
      event: EventWriter<StateTransitionEvent<T>>,
      commands: Commands,
      current_state_res: Option<ResMut<State<T>>>,
      next_state_res: Option<ResMut<NextState<T>>>,
      (s0, s1, s2): (
          Option<Res<State<S0::RawState>>>,
          Option<Res<State<S1::RawState>>>,
          Option<Res<State<S2::RawState>>>,
  )| {
    // With `||` we can correctly count parent changed if any of the sources changed.
    let parent_changed = (ereader0.read().last().is_some()
        || ereader1.read().last().is_some()
        || ereader2.read().last().is_some());
    let next_state = take_next_state(next_state_res);
    if !parent_changed && next_state.is_none() {
        return;
    }
    // ...
  }
}
```

# Testing

- Add new test.
- Check the fix worked in my game.
