### PR TITLE
Rename `Trigger` to `On`

### DIFF
--- a/benches/benches/bevy_ecs/observers/propagation.rs
+++ b/benches/benches/bevy_ecs/observers/propagation.rs
@@ -117,6 +117,6 @@ fn add_listeners_to_hierarchy<const DENSITY: usize, const N: usize>(
     }
 }
 
-fn empty_listener<const N: usize>(trigger: Trigger<TestEvent<N>>) {
+fn empty_listener<const N: usize>(trigger: On<TestEvent<N>>) {
     black_box(trigger);
 }

--- a/benches/benches/bevy_ecs/observers/simple.rs
+++ b/benches/benches/bevy_ecs/observers/simple.rs
@@ -2,7 +2,7 @@ use core::hint::black_box;
 
 use bevy_ecs::{
     event::Event,
-    observer::{Trigger, TriggerTargets},
+    observer::{On, TriggerTargets},
     world::World,
 };
 
@@ -46,7 +46,7 @@ pub fn observe_simple(criterion: &mut Criterion) {
     group.finish();
 }
 
-fn empty_listener_base(trigger: Trigger<EventBase>) {
+fn empty_listener_base(trigger: On<EventBase>) {
     black_box(trigger);
 }
 

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1306,7 +1306,7 @@ impl App {
 
     /// Spawns an [`Observer`] entity, which will watch for and respond to the given event.
     ///
-    /// `observer` can be any system whose first parameter is a [`Trigger`].
+    /// `observer` can be any system whose first parameter is [`On`].
     ///
     /// # Examples
     ///
@@ -1329,7 +1329,7 @@ impl App {
     /// # struct Friend;
     /// #
     ///
-    /// app.add_observer(|trigger: Trigger<Party>, friends: Query<Entity, With<Friend>>, mut commands: Commands| {
+    /// app.add_observer(|trigger: On<Party>, friends: Query<Entity, With<Friend>>, mut commands: Commands| {
     ///     if trigger.event().friends_allowed {
     ///         for friend in friends.iter() {
     ///             commands.trigger_targets(Invite, friend);

--- a/crates/bevy_core_widgets/src/core_button.rs
+++ b/crates/bevy_core_widgets/src/core_button.rs
@@ -6,7 +6,7 @@ use bevy_ecs::system::ResMut;
 use bevy_ecs::{
     component::Component,
     entity::Entity,
-    observer::Trigger,
+    observer::On,
     query::With,
     system::{Commands, Query, SystemId},
 };
@@ -28,7 +28,7 @@ pub struct CoreButton {
 }
 
 fn button_on_key_event(
-    mut trigger: Trigger<FocusedInput<KeyboardInput>>,
+    mut trigger: On<FocusedInput<KeyboardInput>>,
     q_state: Query<(&CoreButton, Has<InteractionDisabled>)>,
     mut commands: Commands,
 ) {
@@ -48,7 +48,7 @@ fn button_on_key_event(
 }
 
 fn button_on_pointer_click(
-    mut trigger: Trigger<Pointer<Click>>,
+    mut trigger: On<Pointer<Click>>,
     mut q_state: Query<(&CoreButton, Has<Pressed>, Has<InteractionDisabled>)>,
     mut commands: Commands,
 ) {
@@ -63,7 +63,7 @@ fn button_on_pointer_click(
 }
 
 fn button_on_pointer_down(
-    mut trigger: Trigger<Pointer<Press>>,
+    mut trigger: On<Pointer<Press>>,
     mut q_state: Query<(Entity, Has<InteractionDisabled>, Has<Pressed>), With<CoreButton>>,
     focus: Option<ResMut<InputFocus>>,
     focus_visible: Option<ResMut<InputFocusVisible>>,
@@ -88,7 +88,7 @@ fn button_on_pointer_down(
 }
 
 fn button_on_pointer_up(
-    mut trigger: Trigger<Pointer<Release>>,
+    mut trigger: On<Pointer<Release>>,
     mut q_state: Query<(Entity, Has<InteractionDisabled>, Has<Pressed>), With<CoreButton>>,
     mut commands: Commands,
 ) {
@@ -101,7 +101,7 @@ fn button_on_pointer_up(
 }
 
 fn button_on_pointer_drag_end(
-    mut trigger: Trigger<Pointer<DragEnd>>,
+    mut trigger: On<Pointer<DragEnd>>,
     mut q_state: Query<(Entity, Has<InteractionDisabled>, Has<Pressed>), With<CoreButton>>,
     mut commands: Commands,
 ) {
@@ -114,7 +114,7 @@ fn button_on_pointer_drag_end(
 }
 
 fn button_on_pointer_cancel(
-    mut trigger: Trigger<Pointer<Cancel>>,
+    mut trigger: On<Pointer<Cancel>>,
     mut q_state: Query<(Entity, Has<InteractionDisabled>, Has<Pressed>), With<CoreButton>>,
     mut commands: Commands,
 ) {

--- a/crates/bevy_ecs/README.md
+++ b/crates/bevy_ecs/README.md
@@ -315,7 +315,7 @@ struct MyEvent {
 
 let mut world = World::new();
 
-world.add_observer(|trigger: Trigger<MyEvent>| {
+world.add_observer(|trigger: On<MyEvent>| {
     println!("{}", trigger.event().message);
 });
 
@@ -339,7 +339,7 @@ struct Explode;
 let mut world = World::new();
 let entity = world.spawn_empty().id();
 
-world.add_observer(|trigger: Trigger<Explode>, mut commands: Commands| {
+world.add_observer(|trigger: On<Explode>, mut commands: Commands| {
     println!("Entity {} goes BOOM!", trigger.target().unwrap());
     commands.entity(trigger.target().unwrap()).despawn();
 });

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -691,41 +691,41 @@ impl Archetype {
         self.flags().contains(ArchetypeFlags::ON_DESPAWN_HOOK)
     }
 
-    /// Returns true if any of the components in this archetype have at least one [`OnAdd`] observer
+    /// Returns true if any of the components in this archetype have at least one [`Add`] observer
     ///
-    /// [`OnAdd`]: crate::lifecycle::OnAdd
+    /// [`Add`]: crate::lifecycle::Add
     #[inline]
     pub fn has_add_observer(&self) -> bool {
         self.flags().contains(ArchetypeFlags::ON_ADD_OBSERVER)
     }
 
-    /// Returns true if any of the components in this archetype have at least one [`OnInsert`] observer
+    /// Returns true if any of the components in this archetype have at least one [`Insert`] observer
     ///
-    /// [`OnInsert`]: crate::lifecycle::OnInsert
+    /// [`Insert`]: crate::lifecycle::Insert
     #[inline]
     pub fn has_insert_observer(&self) -> bool {
         self.flags().contains(ArchetypeFlags::ON_INSERT_OBSERVER)
     }
 
-    /// Returns true if any of the components in this archetype have at least one [`OnReplace`] observer
+    /// Returns true if any of the components in this archetype have at least one [`Replace`] observer
     ///
-    /// [`OnReplace`]: crate::lifecycle::OnReplace
+    /// [`Replace`]: crate::lifecycle::Replace
     #[inline]
     pub fn has_replace_observer(&self) -> bool {
         self.flags().contains(ArchetypeFlags::ON_REPLACE_OBSERVER)
     }
 
-    /// Returns true if any of the components in this archetype have at least one [`OnRemove`] observer
+    /// Returns true if any of the components in this archetype have at least one [`Remove`] observer
     ///
-    /// [`OnRemove`]: crate::lifecycle::OnRemove
+    /// [`Remove`]: crate::lifecycle::Remove
     #[inline]
     pub fn has_remove_observer(&self) -> bool {
         self.flags().contains(ArchetypeFlags::ON_REMOVE_OBSERVER)
     }
 
-    /// Returns true if any of the components in this archetype have at least one [`OnDespawn`] observer
+    /// Returns true if any of the components in this archetype have at least one [`Despawn`] observer
     ///
-    /// [`OnDespawn`]: crate::lifecycle::OnDespawn
+    /// [`Despawn`]: crate::lifecycle::Despawn
     #[inline]
     pub fn has_despawn_observer(&self) -> bool {
         self.flags().contains(ArchetypeFlags::ON_DESPAWN_OBSERVER)

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -2386,7 +2386,7 @@ mod tests {
         #[derive(Resource, Default)]
         struct Count(u32);
         world.init_resource::<Count>();
-        world.add_observer(|_t: Trigger<ArchetypeCreated>, mut count: ResMut<Count>| {
+        world.add_observer(|_t: On<ArchetypeCreated>, mut count: ResMut<Count>| {
             count.0 += 1;
         });
 

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -2415,7 +2415,7 @@ impl Tick {
 /// struct CustomSchedule(Schedule);
 ///
 /// # let mut world = World::new();
-/// world.add_observer(|tick: Trigger<CheckChangeTicks>, mut schedule: ResMut<CustomSchedule>| {
+/// world.add_observer(|tick: On<CheckChangeTicks>, mut schedule: ResMut<CustomSchedule>| {
 ///     schedule.0.check_change_ticks(tick.get());
 /// });
 /// ```

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -598,7 +598,7 @@ mod private {
 /// `&mut ...`, created while inserted onto an entity.
 /// In all other ways, they are identical to mutable components.
 /// This restriction allows hooks to observe all changes made to an immutable
-/// component, effectively turning the `OnInsert` and `OnReplace` hooks into a
+/// component, effectively turning the `Insert` and `Replace` hooks into a
 /// `OnMutate` hook.
 /// This is not practical for mutable components, as the runtime cost of invoking
 /// a hook for every exclusive reference created would be far too high.

--- a/crates/bevy_ecs/src/event/base.rs
+++ b/crates/bevy_ecs/src/event/base.rs
@@ -46,16 +46,17 @@ use core::{
     note = "consider annotating `{Self}` with `#[derive(Event)]`"
 )]
 pub trait Event: Send + Sync + 'static {
-    /// The component that describes which Entity to propagate this event to next, when [propagation] is enabled.
+    /// The component that describes which [`Entity`] to propagate this event to next, when [propagation] is enabled.
     ///
-    /// [propagation]: crate::observer::Trigger::propagate
+    /// [`Entity`]: crate::entity::Entity
+    /// [propagation]: crate::observer::On::propagate
     type Traversal: Traversal<Self>;
 
     /// When true, this event will always attempt to propagate when [triggered], without requiring a call
-    /// to [`Trigger::propagate`].
+    /// to [`On::propagate`].
     ///
     /// [triggered]: crate::system::Commands::trigger_targets
-    /// [`Trigger::propagate`]: crate::observer::Trigger::propagate
+    /// [`On::propagate`]: crate::observer::On::propagate
     const AUTO_PROPAGATE: bool = false;
 
     /// Generates the [`ComponentId`] for this event type.

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -76,7 +76,7 @@ pub mod prelude {
         error::{BevyError, Result},
         event::{Event, EventMutator, EventReader, EventWriter, Events},
         hierarchy::{ChildOf, ChildSpawner, ChildSpawnerCommands, Children},
-        lifecycle::{OnAdd, OnDespawn, OnInsert, OnRemove, OnReplace, RemovedComponents},
+        lifecycle::{Add, Despawn, Insert, Remove, RemovedComponents, Replace},
         name::{Name, NameOrEntity},
         observer::{Observer, On},
         query::{Added, Allows, AnyOf, Changed, Has, Or, QueryBuilder, QueryState, With, Without},

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -78,7 +78,7 @@ pub mod prelude {
         hierarchy::{ChildOf, ChildSpawner, ChildSpawnerCommands, Children},
         lifecycle::{OnAdd, OnDespawn, OnInsert, OnRemove, OnReplace, RemovedComponents},
         name::{Name, NameOrEntity},
-        observer::{Observer, Trigger},
+        observer::{Observer, On},
         query::{Added, Allows, AnyOf, Changed, Has, Or, QueryBuilder, QueryState, With, Without},
         related,
         relationship::RelationshipTarget,

--- a/crates/bevy_ecs/src/lifecycle.rs
+++ b/crates/bevy_ecs/src/lifecycle.rs
@@ -16,26 +16,26 @@
 //! There are five types of lifecycle events, split into two categories. First, we have lifecycle events that are triggered
 //! when a component is added to an entity:
 //!
-//! - [`OnAdd`]: Triggered when a component is added to an entity that did not already have it.
-//! - [`OnInsert`]: Triggered when a component is added to an entity, regardless of whether it already had it.
+//! - [`Add`]: Triggered when a component is added to an entity that did not already have it.
+//! - [`Insert`]: Triggered when a component is added to an entity, regardless of whether it already had it.
 //!
-//! When both events occur, [`OnAdd`] hooks are evaluated before [`OnInsert`].
+//! When both events occur, [`Add`] hooks are evaluated before [`Insert`].
 //!
 //! Next, we have lifecycle events that are triggered when a component is removed from an entity:
 //!
-//! - [`OnReplace`]: Triggered when a component is removed from an entity, regardless if it is then replaced with a new value.
-//! - [`OnRemove`]: Triggered when a component is removed from an entity and not replaced, before the component is removed.
-//! - [`OnDespawn`]: Triggered for each component on an entity when it is despawned.
+//! - [`Replace`]: Triggered when a component is removed from an entity, regardless if it is then replaced with a new value.
+//! - [`Remove`]: Triggered when a component is removed from an entity and not replaced, before the component is removed.
+//! - [`Despawn`]: Triggered for each component on an entity when it is despawned.
 //!
-//! [`OnReplace`] hooks are evaluated before [`OnRemove`], then finally [`OnDespawn`] hooks are evaluated.
+//! [`Replace`] hooks are evaluated before [`Remove`], then finally [`Despawn`] hooks are evaluated.
 //!
-//! [`OnAdd`] and [`OnRemove`] are counterparts: they are only triggered when a component is added or removed
+//! [`Add`] and [`Remove`] are counterparts: they are only triggered when a component is added or removed
 //! from an entity in such a way as to cause a change in the component's presence on that entity.
-//! Similarly, [`OnInsert`] and [`OnReplace`] are counterparts: they are triggered when a component is added or replaced
+//! Similarly, [`Insert`] and [`Replace`] are counterparts: they are triggered when a component is added or replaced
 //! on an entity, regardless of whether this results in a change in the component's presence on that entity.
 //!
 //! To reliably synchronize data structures using with component lifecycle events,
-//! you can combine [`OnInsert`] and [`OnReplace`] to fully capture any changes to the data.
+//! you can combine [`Insert`] and [`Replace`] to fully capture any changes to the data.
 //! This is particularly useful in combination with immutable components,
 //! to avoid any lifecycle-bypassing mutations.
 //!
@@ -47,7 +47,7 @@
 //!
 //! Each of these lifecycle events also corresponds to a fixed [`ComponentId`],
 //! which are assigned during [`World`] initialization.
-//! For example, [`OnAdd`] corresponds to [`ON_ADD`].
+//! For example, [`Add`] corresponds to [`ON_ADD`].
 //! This is used to skip [`TypeId`](core::any::TypeId) lookups in hot paths.
 use crate::{
     change_detection::MaybeLocation,
@@ -310,32 +310,32 @@ impl ComponentHooks {
     }
 }
 
-/// [`ComponentId`] for [`OnAdd`]
+/// [`ComponentId`] for [`Add`]
 pub const ON_ADD: ComponentId = ComponentId::new(0);
-/// [`ComponentId`] for [`OnInsert`]
+/// [`ComponentId`] for [`Insert`]
 pub const ON_INSERT: ComponentId = ComponentId::new(1);
-/// [`ComponentId`] for [`OnReplace`]
+/// [`ComponentId`] for [`Replace`]
 pub const ON_REPLACE: ComponentId = ComponentId::new(2);
-/// [`ComponentId`] for [`OnRemove`]
+/// [`ComponentId`] for [`Remove`]
 pub const ON_REMOVE: ComponentId = ComponentId::new(3);
-/// [`ComponentId`] for [`OnDespawn`]
+/// [`ComponentId`] for [`Despawn`]
 pub const ON_DESPAWN: ComponentId = ComponentId::new(4);
 
 /// Trigger emitted when a component is inserted onto an entity that does not already have that
-/// component. Runs before `OnInsert`.
+/// component. Runs before `Insert`.
 /// See [`crate::lifecycle::ComponentHooks::on_add`] for more information.
 #[derive(Event, Debug)]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
 #[cfg_attr(feature = "bevy_reflect", reflect(Debug))]
-pub struct OnAdd;
+pub struct Add;
 
 /// Trigger emitted when a component is inserted, regardless of whether or not the entity already
-/// had that component. Runs after `OnAdd`, if it ran.
+/// had that component. Runs after `Add`, if it ran.
 /// See [`crate::lifecycle::ComponentHooks::on_insert`] for more information.
 #[derive(Event, Debug)]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
 #[cfg_attr(feature = "bevy_reflect", reflect(Debug))]
-pub struct OnInsert;
+pub struct Insert;
 
 /// Trigger emitted when a component is removed from an entity, regardless
 /// of whether or not it is later replaced.
@@ -345,7 +345,7 @@ pub struct OnInsert;
 #[derive(Event, Debug)]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
 #[cfg_attr(feature = "bevy_reflect", reflect(Debug))]
-pub struct OnReplace;
+pub struct Replace;
 
 /// Trigger emitted when a component is removed from an entity, and runs before the component is
 /// removed, so you can still access the component data.
@@ -353,14 +353,14 @@ pub struct OnReplace;
 #[derive(Event, Debug)]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
 #[cfg_attr(feature = "bevy_reflect", reflect(Debug))]
-pub struct OnRemove;
+pub struct Remove;
 
 /// Trigger emitted for each component on an entity when it is despawned.
 /// See [`crate::lifecycle::ComponentHooks::on_despawn`] for more information.
 #[derive(Event, Debug)]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
 #[cfg_attr(feature = "bevy_reflect", reflect(Debug))]
-pub struct OnDespawn;
+pub struct Despawn;
 
 /// Wrapper around [`Entity`] for [`RemovedComponents`].
 /// Internally, `RemovedComponents` uses these as an `Events<RemovedComponentEntity>`.

--- a/crates/bevy_ecs/src/observer/entity_observer.rs
+++ b/crates/bevy_ecs/src/observer/entity_observer.rs
@@ -109,7 +109,7 @@ fn component_clone_observed_by(_source: &SourceComponent, ctx: &mut ComponentClo
 #[cfg(test)]
 mod tests {
     use crate::{
-        entity::EntityCloner, event::Event, observer::Trigger, resource::Resource, system::ResMut,
+        entity::EntityCloner, event::Event, observer::On, resource::Resource, system::ResMut,
         world::World,
     };
 
@@ -126,7 +126,7 @@ mod tests {
 
         let e = world
             .spawn_empty()
-            .observe(|_: Trigger<E>, mut res: ResMut<Num>| res.0 += 1)
+            .observe(|_: On<E>, mut res: ResMut<Num>| res.0 += 1)
             .id();
         world.flush();
 

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -6,7 +6,7 @@
 //! or they can be "entity-specific", listening for events that are targeted at specific entities.
 //!
 //! They can also be further refined by listening to events targeted at specific components
-//! (instead of using a generic event type), as is done with the [`OnAdd`] family of lifecycle events.
+//! (instead of using a generic event type), as is done with the [`Add`] family of lifecycle events.
 //!
 //! When entities are observed, they will receive an [`ObservedBy`] component,
 //! which will be updated to track the observers that are currently observing them.
@@ -164,7 +164,7 @@ use smallvec::SmallVec;
 /// The entity involved *does not* have to have these components, but the observer will only be
 /// triggered if the event matches the components in `B`.
 ///
-/// This is used to to avoid providing a generic argument in your event, as is done for [`OnAdd`]
+/// This is used to to avoid providing a generic argument in your event, as is done for [`Add`]
 /// and the other lifecycle events.
 ///
 /// Providing multiple components in this bundle will cause this event to be triggered by any
@@ -703,10 +703,10 @@ impl World {
     /// struct A;
     ///
     /// # let mut world = World::new();
-    /// world.add_observer(|_: On<OnAdd, A>| {
+    /// world.add_observer(|_: On<Add, A>| {
     ///     // ...
     /// });
-    /// world.add_observer(|_: On<OnRemove, A>| {
+    /// world.add_observer(|_: On<Remove, A>| {
     ///     // ...
     /// });
     /// ```
@@ -1000,7 +1000,7 @@ mod tests {
     use crate::component::ComponentId;
     use crate::{
         change_detection::MaybeLocation,
-        observer::{Observer, OnReplace},
+        observer::{Observer, Replace},
         prelude::*,
         traversal::Traversal,
     };
@@ -1054,12 +1054,12 @@ mod tests {
         let mut world = World::new();
         world.init_resource::<Order>();
 
-        world.add_observer(|_: On<OnAdd, A>, mut res: ResMut<Order>| res.observed("add"));
-        world.add_observer(|_: On<OnInsert, A>, mut res: ResMut<Order>| res.observed("insert"));
-        world.add_observer(|_: On<OnReplace, A>, mut res: ResMut<Order>| {
+        world.add_observer(|_: On<Add, A>, mut res: ResMut<Order>| res.observed("add"));
+        world.add_observer(|_: On<Insert, A>, mut res: ResMut<Order>| res.observed("insert"));
+        world.add_observer(|_: On<Replace, A>, mut res: ResMut<Order>| {
             res.observed("replace");
         });
-        world.add_observer(|_: On<OnRemove, A>, mut res: ResMut<Order>| res.observed("remove"));
+        world.add_observer(|_: On<Remove, A>, mut res: ResMut<Order>| res.observed("remove"));
 
         let entity = world.spawn(A).id();
         world.despawn(entity);
@@ -1074,12 +1074,12 @@ mod tests {
         let mut world = World::new();
         world.init_resource::<Order>();
 
-        world.add_observer(|_: On<OnAdd, A>, mut res: ResMut<Order>| res.observed("add"));
-        world.add_observer(|_: On<OnInsert, A>, mut res: ResMut<Order>| res.observed("insert"));
-        world.add_observer(|_: On<OnReplace, A>, mut res: ResMut<Order>| {
+        world.add_observer(|_: On<Add, A>, mut res: ResMut<Order>| res.observed("add"));
+        world.add_observer(|_: On<Insert, A>, mut res: ResMut<Order>| res.observed("insert"));
+        world.add_observer(|_: On<Replace, A>, mut res: ResMut<Order>| {
             res.observed("replace");
         });
-        world.add_observer(|_: On<OnRemove, A>, mut res: ResMut<Order>| res.observed("remove"));
+        world.add_observer(|_: On<Remove, A>, mut res: ResMut<Order>| res.observed("remove"));
 
         let mut entity = world.spawn_empty();
         entity.insert(A);
@@ -1096,12 +1096,12 @@ mod tests {
         let mut world = World::new();
         world.init_resource::<Order>();
 
-        world.add_observer(|_: On<OnAdd, S>, mut res: ResMut<Order>| res.observed("add"));
-        world.add_observer(|_: On<OnInsert, S>, mut res: ResMut<Order>| res.observed("insert"));
-        world.add_observer(|_: On<OnReplace, S>, mut res: ResMut<Order>| {
+        world.add_observer(|_: On<Add, S>, mut res: ResMut<Order>| res.observed("add"));
+        world.add_observer(|_: On<Insert, S>, mut res: ResMut<Order>| res.observed("insert"));
+        world.add_observer(|_: On<Replace, S>, mut res: ResMut<Order>| {
             res.observed("replace");
         });
-        world.add_observer(|_: On<OnRemove, S>, mut res: ResMut<Order>| res.observed("remove"));
+        world.add_observer(|_: On<Remove, S>, mut res: ResMut<Order>| res.observed("remove"));
 
         let mut entity = world.spawn_empty();
         entity.insert(S);
@@ -1120,12 +1120,12 @@ mod tests {
 
         let entity = world.spawn(A).id();
 
-        world.add_observer(|_: On<OnAdd, A>, mut res: ResMut<Order>| res.observed("add"));
-        world.add_observer(|_: On<OnInsert, A>, mut res: ResMut<Order>| res.observed("insert"));
-        world.add_observer(|_: On<OnReplace, A>, mut res: ResMut<Order>| {
+        world.add_observer(|_: On<Add, A>, mut res: ResMut<Order>| res.observed("add"));
+        world.add_observer(|_: On<Insert, A>, mut res: ResMut<Order>| res.observed("insert"));
+        world.add_observer(|_: On<Replace, A>, mut res: ResMut<Order>| {
             res.observed("replace");
         });
-        world.add_observer(|_: On<OnRemove, A>, mut res: ResMut<Order>| res.observed("remove"));
+        world.add_observer(|_: On<Remove, A>, mut res: ResMut<Order>| res.observed("remove"));
 
         // TODO: ideally this flush is not necessary, but right now observe() returns WorldEntityMut
         // and therefore does not automatically flush.
@@ -1142,25 +1142,25 @@ mod tests {
         let mut world = World::new();
         world.init_resource::<Order>();
         world.add_observer(
-            |obs: On<OnAdd, A>, mut res: ResMut<Order>, mut commands: Commands| {
+            |obs: On<Add, A>, mut res: ResMut<Order>, mut commands: Commands| {
                 res.observed("add_a");
                 commands.entity(obs.target().unwrap()).insert(B);
             },
         );
         world.add_observer(
-            |obs: On<OnRemove, A>, mut res: ResMut<Order>, mut commands: Commands| {
+            |obs: On<Remove, A>, mut res: ResMut<Order>, mut commands: Commands| {
                 res.observed("remove_a");
                 commands.entity(obs.target().unwrap()).remove::<B>();
             },
         );
 
         world.add_observer(
-            |obs: On<OnAdd, B>, mut res: ResMut<Order>, mut commands: Commands| {
+            |obs: On<Add, B>, mut res: ResMut<Order>, mut commands: Commands| {
                 res.observed("add_b");
                 commands.entity(obs.target().unwrap()).remove::<A>();
             },
         );
-        world.add_observer(|_: On<OnRemove, B>, mut res: ResMut<Order>| {
+        world.add_observer(|_: On<Remove, B>, mut res: ResMut<Order>| {
             res.observed("remove_b");
         });
 
@@ -1218,8 +1218,8 @@ mod tests {
         let mut world = World::new();
         world.init_resource::<Order>();
 
-        world.add_observer(|_: On<OnAdd, A>, mut res: ResMut<Order>| res.observed("add_1"));
-        world.add_observer(|_: On<OnAdd, A>, mut res: ResMut<Order>| res.observed("add_2"));
+        world.add_observer(|_: On<Add, A>, mut res: ResMut<Order>| res.observed("add_1"));
+        world.add_observer(|_: On<Add, A>, mut res: ResMut<Order>| res.observed("add_2"));
 
         world.spawn(A).flush();
         assert_eq!(vec!["add_2", "add_1"], world.resource::<Order>().0);
@@ -1231,11 +1231,11 @@ mod tests {
     fn observer_multiple_events() {
         let mut world = World::new();
         world.init_resource::<Order>();
-        let on_remove = OnRemove::register_component_id(&mut world);
+        let on_remove = Remove::register_component_id(&mut world);
         world.spawn(
-            // SAFETY: OnAdd and OnRemove are both unit types, so this is safe
+            // SAFETY: Add and Remove are both unit types, so this is safe
             unsafe {
-                Observer::new(|_: On<OnAdd, A>, mut res: ResMut<Order>| {
+                Observer::new(|_: On<Add, A>, mut res: ResMut<Order>| {
                     res.observed("add/remove");
                 })
                 .with_event(on_remove)
@@ -1257,7 +1257,7 @@ mod tests {
         world.register_component::<A>();
         world.register_component::<B>();
 
-        world.add_observer(|_: On<OnAdd, (A, B)>, mut res: ResMut<Order>| {
+        world.add_observer(|_: On<Add, (A, B)>, mut res: ResMut<Order>| {
             res.observed("add_ab");
         });
 
@@ -1271,7 +1271,7 @@ mod tests {
     fn observer_despawn() {
         let mut world = World::new();
 
-        let system: fn(On<OnAdd, A>) = |_| {
+        let system: fn(On<Add, A>) = |_| {
             panic!("Observer triggered after being despawned.");
         };
         let observer = world.add_observer(system).id();
@@ -1287,11 +1287,11 @@ mod tests {
 
         let entity = world.spawn((A, B)).flush();
 
-        world.add_observer(|_: On<OnRemove, A>, mut res: ResMut<Order>| {
+        world.add_observer(|_: On<Remove, A>, mut res: ResMut<Order>| {
             res.observed("remove_a");
         });
 
-        let system: fn(On<OnRemove, B>) = |_: On<OnRemove, B>| {
+        let system: fn(On<Remove, B>) = |_: On<Remove, B>| {
             panic!("Observer triggered after being despawned.");
         };
 
@@ -1308,7 +1308,7 @@ mod tests {
         let mut world = World::new();
         world.init_resource::<Order>();
 
-        world.add_observer(|_: On<OnAdd, (A, B)>, mut res: ResMut<Order>| {
+        world.add_observer(|_: On<Add, (A, B)>, mut res: ResMut<Order>| {
             res.observed("add_ab");
         });
 
@@ -1485,7 +1485,7 @@ mod tests {
 
         let component_id = world.register_component::<A>();
         world.spawn(
-            Observer::new(|_: On<OnAdd>, mut res: ResMut<Order>| res.observed("event_a"))
+            Observer::new(|_: On<Add>, mut res: ResMut<Order>| res.observed("event_a"))
                 .with_component(component_id),
         );
 
@@ -1505,7 +1505,7 @@ mod tests {
     fn observer_dynamic_trigger() {
         let mut world = World::new();
         world.init_resource::<Order>();
-        let event_a = OnRemove::register_component_id(&mut world);
+        let event_a = Remove::register_component_id(&mut world);
 
         // SAFETY: we registered `event_a` above and it matches the type of EventA
         let observe = unsafe {
@@ -1794,7 +1794,7 @@ mod tests {
     // Originally for https://github.com/bevyengine/bevy/issues/18452
     #[test]
     fn observer_modifies_relationship() {
-        fn on_add(trigger: On<OnAdd, A>, mut commands: Commands) {
+        fn on_add(trigger: On<Add, A>, mut commands: Commands) {
             commands
                 .entity(trigger.target().unwrap())
                 .with_related_entities::<crate::hierarchy::ChildOf>(|rsc| {
@@ -1815,7 +1815,7 @@ mod tests {
         let mut world = World::new();
 
         // Observe the removal of A - this will run during despawn
-        world.add_observer(|_: On<OnRemove, A>, mut cmd: Commands| {
+        world.add_observer(|_: On<Remove, A>, mut cmd: Commands| {
             // Spawn a new entity - this reserves a new ID and requires a flush
             // afterward before Entities::free can be called.
             cmd.spawn_empty();
@@ -1823,7 +1823,7 @@ mod tests {
 
         let ent = world.spawn(A).id();
 
-        // Despawn our entity, which runs the OnRemove observer and allocates a
+        // Despawn our entity, which runs the Remove observer and allocates a
         // new Entity.
         // Should not panic - if it does, then Entities was not flushed properly
         // after the observer's spawn_empty.
@@ -1889,10 +1889,10 @@ mod tests {
 
         let caller = MaybeLocation::caller();
         let mut world = World::new();
-        world.add_observer(move |trigger: On<OnAdd, Component>| {
+        world.add_observer(move |trigger: On<Add, Component>| {
             assert_eq!(trigger.caller(), caller);
         });
-        world.add_observer(move |trigger: On<OnRemove, Component>| {
+        world.add_observer(move |trigger: On<Remove, Component>| {
             assert_eq!(trigger.caller(), caller);
         });
         world.commands().spawn(Component).clear();

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -178,7 +178,7 @@ pub struct On<'w, E, B: Bundle = ()> {
 }
 
 impl<'w, E, B: Bundle> On<'w, E, B> {
-    /// Creates a new event listener for the given event and observer information.
+    /// Creates a new instance of [`On`] for the given event and observer information.
     pub fn new(event: &'w mut E, propagate: &'w mut bool, trigger: ObserverTrigger) -> Self {
         Self {
             event,
@@ -188,7 +188,7 @@ impl<'w, E, B: Bundle> On<'w, E, B> {
         }
     }
 
-    /// Returns the event type of this event listener.
+    /// Returns the event type of this [`On`] instance.
     pub fn event_type(&self) -> ComponentId {
         self.trigger.event_type
     }
@@ -301,7 +301,7 @@ impl<'w, E, B: Bundle> DerefMut for On<'w, E, B> {
     }
 }
 
-/// Represents a collection of targets for a specific [event listener](On) of an [`Event`].
+/// Represents a collection of targets for a specific [`On`] instance of an [`Event`].
 ///
 /// When an event is triggered with [`TriggerTargets`], any [`Observer`] that watches for that specific
 /// event-target combination will run.
@@ -468,7 +468,7 @@ impl ObserverDescriptor {
 
 /// Metadata about a specific [`Event`] that triggered an observer.
 ///
-/// This information is exposed via methods on the [`On`] event listener.
+/// This information is exposed via methods on [`On`].
 #[derive(Debug)]
 pub struct ObserverTrigger {
     /// The [`Entity`] of the observer handling the trigger.
@@ -689,7 +689,7 @@ impl World {
     /// Spawns a "global" [`Observer`] which will watch for the given event.
     /// Returns its [`Entity`] as a [`EntityWorldMut`].
     ///
-    /// `system` can be any system whose first parameter is an [`On`] event listener.
+    /// `system` can be any system whose first parameter is [`On`].
     ///
     /// **Calling [`observe`](EntityWorldMut::observe) on the returned
     /// [`EntityWorldMut`] will observe the observer itself, which you very

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -18,16 +18,14 @@
 //!
 //! Observers are systems which implement [`IntoObserverSystem`] that listen for [`Event`]s matching their
 //! type and target(s).
-//! To write observer systems, use the [`Trigger`] system parameter as the first parameter of your system.
+//! To write observer systems, use [`On`] as the first parameter of your system.
 //! This parameter provides access to the specific event that triggered the observer,
 //! as well as the entity that the event was targeted at, if any.
 //!
-//! Observers can request other data from the world,
-//! such as via a [`Query`] or [`Res`]. Commonly, you might want to verify that
-//! the entity that the observable event is targeting has a specific component,
-//! or meets some other condition.
-//! [`Query::get`] or [`Query::contains`] on the [`Trigger::target`] entity
-//! is a good way to do this.
+//! Observers can request other data from the world, such as via a [`Query`] or [`Res`].
+//! Commonly, you might want to verify that the entity that the observable event is targeting
+//! has a specific component, or meets some other condition. [`Query::get`] or [`Query::contains`]
+//! on the [`On::target`] entity is a good way to do this.
 //!
 //! [`Commands`] can also be used inside of observers.
 //! This can be particularly useful for triggering other observers!
@@ -61,7 +59,7 @@
 //!
 //! If your observer is configured to watch for a specific component or set of components instead,
 //! you can pass in [`ComponentId`]s into [`Commands::trigger_targets`] by using the [`TriggerTargets`] trait.
-//! As discussed in the [`Trigger`] documentation, this use case is rare, and is currently only used
+//! As discussed in the [`On`] documentation, this use case is rare, and is currently only used
 //! for [lifecycle](crate::lifecycle) events, which are automatically emitted.
 //!
 //! ## Observer bubbling
@@ -74,9 +72,9 @@
 //!
 //! When auto-propagation is enabled, propagaion must be manually stopped to prevent the event from
 //! continuing to other targets.
-//! This can be done using the [`Trigger::propagate`] method on the [`Trigger`] system parameter inside of your observer.
+//! This can be done using the [`On::propagate`] method inside of your observer.
 //!
-//!  ## Observer timing
+//! ## Observer timing
 //!
 //! Observers are triggered via [`Commands`], which imply that they are evaluated at the next sync point in the ECS schedule.
 //! Accordingly, they have full access to the world, and are evaluated sequentially, in the order that the commands were sent.
@@ -160,7 +158,7 @@ use smallvec::SmallVec;
 
 /// Type containing triggered [`Event`] information for a given run of an [`Observer`]. This contains the
 /// [`Event`] data itself. If it was triggered for a specific [`Entity`], it includes that as well. It also
-/// contains event propagation information. See [`Trigger::propagate`] for more information.
+/// contains event propagation information. See [`On::propagate`] for more information.
 ///
 /// The generic `B: Bundle` is used to modify the further specialize the events that this observer is interested in.
 /// The entity involved *does not* have to have these components, but the observer will only be
@@ -172,15 +170,15 @@ use smallvec::SmallVec;
 /// Providing multiple components in this bundle will cause this event to be triggered by any
 /// matching component in the bundle,
 /// [rather than requiring all of them to be present](https://github.com/bevyengine/bevy/issues/15325).
-pub struct Trigger<'w, E, B: Bundle = ()> {
+pub struct On<'w, E, B: Bundle = ()> {
     event: &'w mut E,
     propagate: &'w mut bool,
     trigger: ObserverTrigger,
     _marker: PhantomData<B>,
 }
 
-impl<'w, E, B: Bundle> Trigger<'w, E, B> {
-    /// Creates a new trigger for the given event and observer information.
+impl<'w, E, B: Bundle> On<'w, E, B> {
+    /// Creates a new event listener for the given event and observer information.
     pub fn new(event: &'w mut E, propagate: &'w mut bool, trigger: ObserverTrigger) -> Self {
         Self {
             event,
@@ -190,7 +188,7 @@ impl<'w, E, B: Bundle> Trigger<'w, E, B> {
         }
     }
 
-    /// Returns the event type of this trigger.
+    /// Returns the event type of this event listener.
     pub fn event_type(&self) -> ComponentId {
         self.trigger.event_type
     }
@@ -229,14 +227,14 @@ impl<'w, E, B: Bundle> Trigger<'w, E, B> {
     /// # Examples
     ///
     /// ```rust
-    /// # use bevy_ecs::prelude::{Commands, Trigger};
+    /// # use bevy_ecs::prelude::{Commands, On};
     /// #
     /// # struct MyEvent {
     /// #   done: bool,
     /// # }
     /// #
     /// /// Handle `MyEvent` and if it is done, stop observation.
-    /// fn my_observer(trigger: Trigger<MyEvent>, mut commands: Commands) {
+    /// fn my_observer(trigger: On<MyEvent>, mut commands: Commands) {
     ///     if trigger.event().done {
     ///         commands.entity(trigger.observer()).despawn();
     ///         return;
@@ -267,7 +265,7 @@ impl<'w, E, B: Bundle> Trigger<'w, E, B> {
 
     /// Returns the value of the flag that controls event propagation. See [`propagate`] for more information.
     ///
-    /// [`propagate`]: Trigger::propagate
+    /// [`propagate`]: On::propagate
     pub fn get_propagate(&self) -> bool {
         *self.propagate
     }
@@ -278,9 +276,9 @@ impl<'w, E, B: Bundle> Trigger<'w, E, B> {
     }
 }
 
-impl<'w, E: Debug, B: Bundle> Debug for Trigger<'w, E, B> {
+impl<'w, E: Debug, B: Bundle> Debug for On<'w, E, B> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Trigger")
+        f.debug_struct("On")
             .field("event", &self.event)
             .field("propagate", &self.propagate)
             .field("trigger", &self.trigger)
@@ -289,7 +287,7 @@ impl<'w, E: Debug, B: Bundle> Debug for Trigger<'w, E, B> {
     }
 }
 
-impl<'w, E, B: Bundle> Deref for Trigger<'w, E, B> {
+impl<'w, E, B: Bundle> Deref for On<'w, E, B> {
     type Target = E;
 
     fn deref(&self) -> &Self::Target {
@@ -297,16 +295,16 @@ impl<'w, E, B: Bundle> Deref for Trigger<'w, E, B> {
     }
 }
 
-impl<'w, E, B: Bundle> DerefMut for Trigger<'w, E, B> {
+impl<'w, E, B: Bundle> DerefMut for On<'w, E, B> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.event
     }
 }
 
-/// Represents a collection of targets for a specific [`Trigger`] of an [`Event`].
+/// Represents a collection of targets for a specific [event listener](On) of an [`Event`].
 ///
-/// When a trigger occurs for a given event and [`TriggerTargets`], any [`Observer`] that watches for that specific event-target combination
-/// will run.
+/// When an event is triggered with [`TriggerTargets`], any [`Observer`] that watches for that specific
+/// event-target combination will run.
 ///
 /// This trait is implemented for both [`Entity`] and [`ComponentId`], allowing you to target specific entities or components.
 /// It is also implemented for various collections of these types, such as [`Vec`], arrays, and tuples,
@@ -468,9 +466,9 @@ impl ObserverDescriptor {
     }
 }
 
-/// Metadata about a specific [`Event`] which triggered an observer.
+/// Metadata about a specific [`Event`] that triggered an observer.
 ///
-/// This information is exposed via methods on the [`Trigger`] system parameter.
+/// This information is exposed via methods on the [`On`] event listener.
 #[derive(Debug)]
 pub struct ObserverTrigger {
     /// The [`Entity`] of the observer handling the trigger.
@@ -691,7 +689,7 @@ impl World {
     /// Spawns a "global" [`Observer`] which will watch for the given event.
     /// Returns its [`Entity`] as a [`EntityWorldMut`].
     ///
-    /// `system` can be any system whose first parameter is a [`Trigger`].
+    /// `system` can be any system whose first parameter is an [`On`] event listener.
     ///
     /// **Calling [`observe`](EntityWorldMut::observe) on the returned
     /// [`EntityWorldMut`] will observe the observer itself, which you very
@@ -705,10 +703,10 @@ impl World {
     /// struct A;
     ///
     /// # let mut world = World::new();
-    /// world.add_observer(|_: Trigger<OnAdd, A>| {
+    /// world.add_observer(|_: On<OnAdd, A>| {
     ///     // ...
     /// });
-    /// world.add_observer(|_: Trigger<OnRemove, A>| {
+    /// world.add_observer(|_: On<OnRemove, A>| {
     ///     // ...
     /// });
     /// ```
@@ -1056,14 +1054,12 @@ mod tests {
         let mut world = World::new();
         world.init_resource::<Order>();
 
-        world.add_observer(|_: Trigger<OnAdd, A>, mut res: ResMut<Order>| res.observed("add"));
-        world
-            .add_observer(|_: Trigger<OnInsert, A>, mut res: ResMut<Order>| res.observed("insert"));
-        world.add_observer(|_: Trigger<OnReplace, A>, mut res: ResMut<Order>| {
+        world.add_observer(|_: On<OnAdd, A>, mut res: ResMut<Order>| res.observed("add"));
+        world.add_observer(|_: On<OnInsert, A>, mut res: ResMut<Order>| res.observed("insert"));
+        world.add_observer(|_: On<OnReplace, A>, mut res: ResMut<Order>| {
             res.observed("replace");
         });
-        world
-            .add_observer(|_: Trigger<OnRemove, A>, mut res: ResMut<Order>| res.observed("remove"));
+        world.add_observer(|_: On<OnRemove, A>, mut res: ResMut<Order>| res.observed("remove"));
 
         let entity = world.spawn(A).id();
         world.despawn(entity);
@@ -1078,14 +1074,12 @@ mod tests {
         let mut world = World::new();
         world.init_resource::<Order>();
 
-        world.add_observer(|_: Trigger<OnAdd, A>, mut res: ResMut<Order>| res.observed("add"));
-        world
-            .add_observer(|_: Trigger<OnInsert, A>, mut res: ResMut<Order>| res.observed("insert"));
-        world.add_observer(|_: Trigger<OnReplace, A>, mut res: ResMut<Order>| {
+        world.add_observer(|_: On<OnAdd, A>, mut res: ResMut<Order>| res.observed("add"));
+        world.add_observer(|_: On<OnInsert, A>, mut res: ResMut<Order>| res.observed("insert"));
+        world.add_observer(|_: On<OnReplace, A>, mut res: ResMut<Order>| {
             res.observed("replace");
         });
-        world
-            .add_observer(|_: Trigger<OnRemove, A>, mut res: ResMut<Order>| res.observed("remove"));
+        world.add_observer(|_: On<OnRemove, A>, mut res: ResMut<Order>| res.observed("remove"));
 
         let mut entity = world.spawn_empty();
         entity.insert(A);
@@ -1102,14 +1096,12 @@ mod tests {
         let mut world = World::new();
         world.init_resource::<Order>();
 
-        world.add_observer(|_: Trigger<OnAdd, S>, mut res: ResMut<Order>| res.observed("add"));
-        world
-            .add_observer(|_: Trigger<OnInsert, S>, mut res: ResMut<Order>| res.observed("insert"));
-        world.add_observer(|_: Trigger<OnReplace, S>, mut res: ResMut<Order>| {
+        world.add_observer(|_: On<OnAdd, S>, mut res: ResMut<Order>| res.observed("add"));
+        world.add_observer(|_: On<OnInsert, S>, mut res: ResMut<Order>| res.observed("insert"));
+        world.add_observer(|_: On<OnReplace, S>, mut res: ResMut<Order>| {
             res.observed("replace");
         });
-        world
-            .add_observer(|_: Trigger<OnRemove, S>, mut res: ResMut<Order>| res.observed("remove"));
+        world.add_observer(|_: On<OnRemove, S>, mut res: ResMut<Order>| res.observed("remove"));
 
         let mut entity = world.spawn_empty();
         entity.insert(S);
@@ -1128,14 +1120,12 @@ mod tests {
 
         let entity = world.spawn(A).id();
 
-        world.add_observer(|_: Trigger<OnAdd, A>, mut res: ResMut<Order>| res.observed("add"));
-        world
-            .add_observer(|_: Trigger<OnInsert, A>, mut res: ResMut<Order>| res.observed("insert"));
-        world.add_observer(|_: Trigger<OnReplace, A>, mut res: ResMut<Order>| {
+        world.add_observer(|_: On<OnAdd, A>, mut res: ResMut<Order>| res.observed("add"));
+        world.add_observer(|_: On<OnInsert, A>, mut res: ResMut<Order>| res.observed("insert"));
+        world.add_observer(|_: On<OnReplace, A>, mut res: ResMut<Order>| {
             res.observed("replace");
         });
-        world
-            .add_observer(|_: Trigger<OnRemove, A>, mut res: ResMut<Order>| res.observed("remove"));
+        world.add_observer(|_: On<OnRemove, A>, mut res: ResMut<Order>| res.observed("remove"));
 
         // TODO: ideally this flush is not necessary, but right now observe() returns WorldEntityMut
         // and therefore does not automatically flush.
@@ -1152,25 +1142,25 @@ mod tests {
         let mut world = World::new();
         world.init_resource::<Order>();
         world.add_observer(
-            |obs: Trigger<OnAdd, A>, mut res: ResMut<Order>, mut commands: Commands| {
+            |obs: On<OnAdd, A>, mut res: ResMut<Order>, mut commands: Commands| {
                 res.observed("add_a");
                 commands.entity(obs.target().unwrap()).insert(B);
             },
         );
         world.add_observer(
-            |obs: Trigger<OnRemove, A>, mut res: ResMut<Order>, mut commands: Commands| {
+            |obs: On<OnRemove, A>, mut res: ResMut<Order>, mut commands: Commands| {
                 res.observed("remove_a");
                 commands.entity(obs.target().unwrap()).remove::<B>();
             },
         );
 
         world.add_observer(
-            |obs: Trigger<OnAdd, B>, mut res: ResMut<Order>, mut commands: Commands| {
+            |obs: On<OnAdd, B>, mut res: ResMut<Order>, mut commands: Commands| {
                 res.observed("add_b");
                 commands.entity(obs.target().unwrap()).remove::<A>();
             },
         );
-        world.add_observer(|_: Trigger<OnRemove, B>, mut res: ResMut<Order>| {
+        world.add_observer(|_: On<OnRemove, B>, mut res: ResMut<Order>| {
             res.observed("remove_b");
         });
 
@@ -1188,9 +1178,9 @@ mod tests {
     fn observer_trigger_ref() {
         let mut world = World::new();
 
-        world.add_observer(|mut trigger: Trigger<EventWithData>| trigger.event_mut().counter += 1);
-        world.add_observer(|mut trigger: Trigger<EventWithData>| trigger.event_mut().counter += 2);
-        world.add_observer(|mut trigger: Trigger<EventWithData>| trigger.event_mut().counter += 4);
+        world.add_observer(|mut trigger: On<EventWithData>| trigger.event_mut().counter += 1);
+        world.add_observer(|mut trigger: On<EventWithData>| trigger.event_mut().counter += 2);
+        world.add_observer(|mut trigger: On<EventWithData>| trigger.event_mut().counter += 4);
         // This flush is required for the last observer to be called when triggering the event,
         // due to `World::add_observer` returning `WorldEntityMut`.
         world.flush();
@@ -1204,13 +1194,13 @@ mod tests {
     fn observer_trigger_targets_ref() {
         let mut world = World::new();
 
-        world.add_observer(|mut trigger: Trigger<EventWithData, A>| {
+        world.add_observer(|mut trigger: On<EventWithData, A>| {
             trigger.event_mut().counter += 1;
         });
-        world.add_observer(|mut trigger: Trigger<EventWithData, B>| {
+        world.add_observer(|mut trigger: On<EventWithData, B>| {
             trigger.event_mut().counter += 2;
         });
-        world.add_observer(|mut trigger: Trigger<EventWithData, A>| {
+        world.add_observer(|mut trigger: On<EventWithData, A>| {
             trigger.event_mut().counter += 4;
         });
         // This flush is required for the last observer to be called when triggering the event,
@@ -1228,8 +1218,8 @@ mod tests {
         let mut world = World::new();
         world.init_resource::<Order>();
 
-        world.add_observer(|_: Trigger<OnAdd, A>, mut res: ResMut<Order>| res.observed("add_1"));
-        world.add_observer(|_: Trigger<OnAdd, A>, mut res: ResMut<Order>| res.observed("add_2"));
+        world.add_observer(|_: On<OnAdd, A>, mut res: ResMut<Order>| res.observed("add_1"));
+        world.add_observer(|_: On<OnAdd, A>, mut res: ResMut<Order>| res.observed("add_2"));
 
         world.spawn(A).flush();
         assert_eq!(vec!["add_2", "add_1"], world.resource::<Order>().0);
@@ -1245,7 +1235,7 @@ mod tests {
         world.spawn(
             // SAFETY: OnAdd and OnRemove are both unit types, so this is safe
             unsafe {
-                Observer::new(|_: Trigger<OnAdd, A>, mut res: ResMut<Order>| {
+                Observer::new(|_: On<OnAdd, A>, mut res: ResMut<Order>| {
                     res.observed("add/remove");
                 })
                 .with_event(on_remove)
@@ -1267,7 +1257,7 @@ mod tests {
         world.register_component::<A>();
         world.register_component::<B>();
 
-        world.add_observer(|_: Trigger<OnAdd, (A, B)>, mut res: ResMut<Order>| {
+        world.add_observer(|_: On<OnAdd, (A, B)>, mut res: ResMut<Order>| {
             res.observed("add_ab");
         });
 
@@ -1281,7 +1271,7 @@ mod tests {
     fn observer_despawn() {
         let mut world = World::new();
 
-        let system: fn(Trigger<OnAdd, A>) = |_| {
+        let system: fn(On<OnAdd, A>) = |_| {
             panic!("Observer triggered after being despawned.");
         };
         let observer = world.add_observer(system).id();
@@ -1297,11 +1287,11 @@ mod tests {
 
         let entity = world.spawn((A, B)).flush();
 
-        world.add_observer(|_: Trigger<OnRemove, A>, mut res: ResMut<Order>| {
+        world.add_observer(|_: On<OnRemove, A>, mut res: ResMut<Order>| {
             res.observed("remove_a");
         });
 
-        let system: fn(Trigger<OnRemove, B>) = |_: Trigger<OnRemove, B>| {
+        let system: fn(On<OnRemove, B>) = |_: On<OnRemove, B>| {
             panic!("Observer triggered after being despawned.");
         };
 
@@ -1318,7 +1308,7 @@ mod tests {
         let mut world = World::new();
         world.init_resource::<Order>();
 
-        world.add_observer(|_: Trigger<OnAdd, (A, B)>, mut res: ResMut<Order>| {
+        world.add_observer(|_: On<OnAdd, (A, B)>, mut res: ResMut<Order>| {
             res.observed("add_ab");
         });
 
@@ -1331,11 +1321,11 @@ mod tests {
         let mut world = World::new();
         world.init_resource::<Order>();
 
-        let system: fn(Trigger<EventA>) = |_| {
+        let system: fn(On<EventA>) = |_| {
             panic!("Trigger routed to non-targeted entity.");
         };
         world.spawn_empty().observe(system);
-        world.add_observer(move |obs: Trigger<EventA>, mut res: ResMut<Order>| {
+        world.add_observer(move |obs: On<EventA>, mut res: ResMut<Order>| {
             assert_eq!(obs.target(), None);
             res.observed("event_a");
         });
@@ -1353,16 +1343,16 @@ mod tests {
         let mut world = World::new();
         world.init_resource::<Order>();
 
-        let system: fn(Trigger<EventA>) = |_| {
+        let system: fn(On<EventA>) = |_| {
             panic!("Trigger routed to non-targeted entity.");
         };
 
         world.spawn_empty().observe(system);
         let entity = world
             .spawn_empty()
-            .observe(|_: Trigger<EventA>, mut res: ResMut<Order>| res.observed("a_1"))
+            .observe(|_: On<EventA>, mut res: ResMut<Order>| res.observed("a_1"))
             .id();
-        world.add_observer(move |obs: Trigger<EventA>, mut res: ResMut<Order>| {
+        world.add_observer(move |obs: On<EventA>, mut res: ResMut<Order>| {
             assert_eq!(obs.target().unwrap(), entity);
             res.observed("a_2");
         });
@@ -1388,26 +1378,26 @@ mod tests {
         // targets (entity_1, A)
         let entity_1 = world
             .spawn_empty()
-            .observe(|_: Trigger<EventA, A>, mut res: ResMut<R>| res.0 += 1)
+            .observe(|_: On<EventA, A>, mut res: ResMut<R>| res.0 += 1)
             .id();
         // targets (entity_2, B)
         let entity_2 = world
             .spawn_empty()
-            .observe(|_: Trigger<EventA, B>, mut res: ResMut<R>| res.0 += 10)
+            .observe(|_: On<EventA, B>, mut res: ResMut<R>| res.0 += 10)
             .id();
         // targets any entity or component
-        world.add_observer(|_: Trigger<EventA>, mut res: ResMut<R>| res.0 += 100);
+        world.add_observer(|_: On<EventA>, mut res: ResMut<R>| res.0 += 100);
         // targets any entity, and components A or B
-        world.add_observer(|_: Trigger<EventA, (A, B)>, mut res: ResMut<R>| res.0 += 1000);
+        world.add_observer(|_: On<EventA, (A, B)>, mut res: ResMut<R>| res.0 += 1000);
         // test all tuples
-        world.add_observer(|_: Trigger<EventA, (A, B, (A, B))>, mut res: ResMut<R>| res.0 += 10000);
+        world.add_observer(|_: On<EventA, (A, B, (A, B))>, mut res: ResMut<R>| res.0 += 10000);
         world.add_observer(
-            |_: Trigger<EventA, (A, B, (A, B), ((A, B), (A, B)))>, mut res: ResMut<R>| {
+            |_: On<EventA, (A, B, (A, B), ((A, B), (A, B)))>, mut res: ResMut<R>| {
                 res.0 += 100000;
             },
         );
         world.add_observer(
-            |_: Trigger<EventA, (A, B, (A, B), (B, A), (A, B, ((A, B), (B, A))))>,
+            |_: On<EventA, (A, B, (A, B), (B, A), (A, B, ((A, B), (B, A))))>,
              mut res: ResMut<R>| res.0 += 1000000,
         );
 
@@ -1495,7 +1485,7 @@ mod tests {
 
         let component_id = world.register_component::<A>();
         world.spawn(
-            Observer::new(|_: Trigger<OnAdd>, mut res: ResMut<Order>| res.observed("event_a"))
+            Observer::new(|_: On<OnAdd>, mut res: ResMut<Order>| res.observed("event_a"))
                 .with_component(component_id),
         );
 
@@ -1541,14 +1531,14 @@ mod tests {
 
         let parent = world
             .spawn_empty()
-            .observe(|_: Trigger<EventPropagating>, mut res: ResMut<Order>| {
+            .observe(|_: On<EventPropagating>, mut res: ResMut<Order>| {
                 res.observed("parent");
             })
             .id();
 
         let child = world
             .spawn(ChildOf(parent))
-            .observe(|_: Trigger<EventPropagating>, mut res: ResMut<Order>| {
+            .observe(|_: On<EventPropagating>, mut res: ResMut<Order>| {
                 res.observed("child");
             })
             .id();
@@ -1568,14 +1558,14 @@ mod tests {
 
         let parent = world
             .spawn_empty()
-            .observe(|_: Trigger<EventPropagating>, mut res: ResMut<Order>| {
+            .observe(|_: On<EventPropagating>, mut res: ResMut<Order>| {
                 res.observed("parent");
             })
             .id();
 
         let child = world
             .spawn(ChildOf(parent))
-            .observe(|_: Trigger<EventPropagating>, mut res: ResMut<Order>| {
+            .observe(|_: On<EventPropagating>, mut res: ResMut<Order>| {
                 res.observed("child");
             })
             .id();
@@ -1598,14 +1588,14 @@ mod tests {
 
         let parent = world
             .spawn_empty()
-            .observe(|_: Trigger<EventPropagating>, mut res: ResMut<Order>| {
+            .observe(|_: On<EventPropagating>, mut res: ResMut<Order>| {
                 res.observed("parent");
             })
             .id();
 
         let child = world
             .spawn(ChildOf(parent))
-            .observe(|_: Trigger<EventPropagating>, mut res: ResMut<Order>| {
+            .observe(|_: On<EventPropagating>, mut res: ResMut<Order>| {
                 res.observed("child");
             })
             .id();
@@ -1628,7 +1618,7 @@ mod tests {
 
         let parent = world
             .spawn_empty()
-            .observe(|_: Trigger<EventPropagating>, mut res: ResMut<Order>| {
+            .observe(|_: On<EventPropagating>, mut res: ResMut<Order>| {
                 res.observed("parent");
             })
             .id();
@@ -1636,7 +1626,7 @@ mod tests {
         let child = world
             .spawn(ChildOf(parent))
             .observe(
-                |mut trigger: Trigger<EventPropagating>, mut res: ResMut<Order>| {
+                |mut trigger: On<EventPropagating>, mut res: ResMut<Order>| {
                     res.observed("child");
                     trigger.propagate(false);
                 },
@@ -1658,21 +1648,21 @@ mod tests {
 
         let parent = world
             .spawn_empty()
-            .observe(|_: Trigger<EventPropagating>, mut res: ResMut<Order>| {
+            .observe(|_: On<EventPropagating>, mut res: ResMut<Order>| {
                 res.observed("parent");
             })
             .id();
 
         let child_a = world
             .spawn(ChildOf(parent))
-            .observe(|_: Trigger<EventPropagating>, mut res: ResMut<Order>| {
+            .observe(|_: On<EventPropagating>, mut res: ResMut<Order>| {
                 res.observed("child_a");
             })
             .id();
 
         let child_b = world
             .spawn(ChildOf(parent))
-            .observe(|_: Trigger<EventPropagating>, mut res: ResMut<Order>| {
+            .observe(|_: On<EventPropagating>, mut res: ResMut<Order>| {
                 res.observed("child_b");
             })
             .id();
@@ -1695,7 +1685,7 @@ mod tests {
 
         let entity = world
             .spawn_empty()
-            .observe(|_: Trigger<EventPropagating>, mut res: ResMut<Order>| {
+            .observe(|_: On<EventPropagating>, mut res: ResMut<Order>| {
                 res.observed("event");
             })
             .id();
@@ -1715,7 +1705,7 @@ mod tests {
 
         let parent_a = world
             .spawn_empty()
-            .observe(|_: Trigger<EventPropagating>, mut res: ResMut<Order>| {
+            .observe(|_: On<EventPropagating>, mut res: ResMut<Order>| {
                 res.observed("parent_a");
             })
             .id();
@@ -1723,7 +1713,7 @@ mod tests {
         let child_a = world
             .spawn(ChildOf(parent_a))
             .observe(
-                |mut trigger: Trigger<EventPropagating>, mut res: ResMut<Order>| {
+                |mut trigger: On<EventPropagating>, mut res: ResMut<Order>| {
                     res.observed("child_a");
                     trigger.propagate(false);
                 },
@@ -1732,14 +1722,14 @@ mod tests {
 
         let parent_b = world
             .spawn_empty()
-            .observe(|_: Trigger<EventPropagating>, mut res: ResMut<Order>| {
+            .observe(|_: On<EventPropagating>, mut res: ResMut<Order>| {
                 res.observed("parent_b");
             })
             .id();
 
         let child_b = world
             .spawn(ChildOf(parent_b))
-            .observe(|_: Trigger<EventPropagating>, mut res: ResMut<Order>| {
+            .observe(|_: On<EventPropagating>, mut res: ResMut<Order>| {
                 res.observed("child_b");
             })
             .id();
@@ -1760,7 +1750,7 @@ mod tests {
         let mut world = World::new();
         world.init_resource::<Order>();
 
-        world.add_observer(|_: Trigger<EventPropagating>, mut res: ResMut<Order>| {
+        world.add_observer(|_: On<EventPropagating>, mut res: ResMut<Order>| {
             res.observed("event");
         });
 
@@ -1782,7 +1772,7 @@ mod tests {
         world.init_resource::<Order>();
 
         world.add_observer(
-            |trigger: Trigger<EventPropagating>, query: Query<&A>, mut res: ResMut<Order>| {
+            |trigger: On<EventPropagating>, query: Query<&A>, mut res: ResMut<Order>| {
                 if query.get(trigger.target().unwrap()).is_ok() {
                     res.observed("event");
                 }
@@ -1804,7 +1794,7 @@ mod tests {
     // Originally for https://github.com/bevyengine/bevy/issues/18452
     #[test]
     fn observer_modifies_relationship() {
-        fn on_add(trigger: Trigger<OnAdd, A>, mut commands: Commands) {
+        fn on_add(trigger: On<OnAdd, A>, mut commands: Commands) {
             commands
                 .entity(trigger.target().unwrap())
                 .with_related_entities::<crate::hierarchy::ChildOf>(|rsc| {
@@ -1825,7 +1815,7 @@ mod tests {
         let mut world = World::new();
 
         // Observe the removal of A - this will run during despawn
-        world.add_observer(|_: Trigger<OnRemove, A>, mut cmd: Commands| {
+        world.add_observer(|_: On<OnRemove, A>, mut cmd: Commands| {
             // Spawn a new entity - this reserves a new ID and requires a flush
             // afterward before Entities::free can be called.
             cmd.spawn_empty();
@@ -1851,7 +1841,7 @@ mod tests {
 
         let mut world = World::new();
         // This fails because `ResA` is not present in the world
-        world.add_observer(|_: Trigger<EventA>, _: Res<ResA>, mut commands: Commands| {
+        world.add_observer(|_: On<EventA>, _: Res<ResA>, mut commands: Commands| {
             commands.insert_resource(ResB);
         });
         world.trigger(EventA);
@@ -1864,7 +1854,7 @@ mod tests {
 
         let mut world = World::new();
         world.add_observer(
-            |_: Trigger<EventA>, mut params: ParamSet<(Query<Entity>, Commands)>| {
+            |_: On<EventA>, mut params: ParamSet<(Query<Entity>, Commands)>| {
                 params.p1().insert_resource(ResA);
             },
         );
@@ -1885,7 +1875,7 @@ mod tests {
 
         let caller = MaybeLocation::caller();
         let mut world = World::new();
-        world.add_observer(move |trigger: Trigger<EventA>| {
+        world.add_observer(move |trigger: On<EventA>| {
             assert_eq!(trigger.caller(), caller);
         });
         world.trigger(EventA);
@@ -1899,10 +1889,10 @@ mod tests {
 
         let caller = MaybeLocation::caller();
         let mut world = World::new();
-        world.add_observer(move |trigger: Trigger<OnAdd, Component>| {
+        world.add_observer(move |trigger: On<OnAdd, Component>| {
             assert_eq!(trigger.caller(), caller);
         });
-        world.add_observer(move |trigger: Trigger<OnRemove, Component>| {
+        world.add_observer(move |trigger: On<OnRemove, Component>| {
             assert_eq!(trigger.caller(), caller);
         });
         world.commands().spawn(Component).clear();
@@ -1920,7 +1910,7 @@ mod tests {
         let b_id = world.register_component::<B>();
 
         world.add_observer(
-            |trigger: Trigger<EventA, (A, B)>, mut counter: ResMut<Counter>| {
+            |trigger: On<EventA, (A, B)>, mut counter: ResMut<Counter>| {
                 for &component in trigger.components() {
                     *counter.0.entry(component).or_default() += 1;
                 }

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -28,8 +28,7 @@ pub type ObserverRunner = fn(DeferredWorld, ObserverTrigger, PtrMut, propagate: 
 ///
 /// # Usage
 ///
-/// The simplest usage
-/// of the observer pattern looks like this:
+/// The simplest usage of the observer pattern looks like this:
 ///
 /// ```
 /// # use bevy_ecs::prelude::*;
@@ -39,7 +38,7 @@ pub type ObserverRunner = fn(DeferredWorld, ObserverTrigger, PtrMut, propagate: 
 ///     message: String,
 /// }
 ///
-/// world.add_observer(|trigger: Trigger<Speak>| {
+/// world.add_observer(|trigger: On<Speak>| {
 ///     println!("{}", trigger.event().message);
 /// });
 ///
@@ -60,8 +59,8 @@ pub type ObserverRunner = fn(DeferredWorld, ObserverTrigger, PtrMut, propagate: 
 /// # #[derive(Event)]
 /// # struct Speak;
 /// // These are functionally the same:
-/// world.add_observer(|trigger: Trigger<Speak>| {});
-/// world.spawn(Observer::new(|trigger: Trigger<Speak>| {}));
+/// world.add_observer(|trigger: On<Speak>| {});
+/// world.spawn(Observer::new(|trigger: On<Speak>| {}));
 /// ```
 ///
 /// Observers are systems. They can access arbitrary [`World`] data by adding [`SystemParam`]s:
@@ -73,14 +72,14 @@ pub type ObserverRunner = fn(DeferredWorld, ObserverTrigger, PtrMut, propagate: 
 /// # struct PrintNames;
 /// # #[derive(Component, Debug)]
 /// # struct Name;
-/// world.add_observer(|trigger: Trigger<PrintNames>, names: Query<&Name>| {
+/// world.add_observer(|trigger: On<PrintNames>, names: Query<&Name>| {
 ///     for name in &names {
 ///         println!("{name:?}");
 ///     }
 /// });
 /// ```
 ///
-/// Note that [`Trigger`] must always be the first parameter.
+/// Note that [`On`] must always be the first parameter.
 ///
 /// You can also add [`Commands`], which means you can spawn new entities, insert new components, etc:
 ///
@@ -91,7 +90,7 @@ pub type ObserverRunner = fn(DeferredWorld, ObserverTrigger, PtrMut, propagate: 
 /// # struct SpawnThing;
 /// # #[derive(Component, Debug)]
 /// # struct Thing;
-/// world.add_observer(|trigger: Trigger<SpawnThing>, mut commands: Commands| {
+/// world.add_observer(|trigger: On<SpawnThing>, mut commands: Commands| {
 ///     commands.spawn(Thing);
 /// });
 /// ```
@@ -105,7 +104,7 @@ pub type ObserverRunner = fn(DeferredWorld, ObserverTrigger, PtrMut, propagate: 
 /// # struct A;
 /// # #[derive(Event)]
 /// # struct B;
-/// world.add_observer(|trigger: Trigger<A>, mut commands: Commands| {
+/// world.add_observer(|trigger: On<A>, mut commands: Commands| {
 ///     commands.trigger(B);
 /// });
 /// ```
@@ -123,7 +122,7 @@ pub type ObserverRunner = fn(DeferredWorld, ObserverTrigger, PtrMut, propagate: 
 /// #[derive(Event)]
 /// struct Explode;
 ///
-/// world.add_observer(|trigger: Trigger<Explode>, mut commands: Commands| {
+/// world.add_observer(|trigger: On<Explode>, mut commands: Commands| {
 ///     println!("Entity {} goes BOOM!", trigger.target().unwrap());
 ///     commands.entity(trigger.target().unwrap()).despawn();
 /// });
@@ -156,12 +155,12 @@ pub type ObserverRunner = fn(DeferredWorld, ObserverTrigger, PtrMut, propagate: 
 /// # let e2 = world.spawn_empty().id();
 /// # #[derive(Event)]
 /// # struct Explode;
-/// world.entity_mut(e1).observe(|trigger: Trigger<Explode>, mut commands: Commands| {
+/// world.entity_mut(e1).observe(|trigger: On<Explode>, mut commands: Commands| {
 ///     println!("Boom!");
 ///     commands.entity(trigger.target().unwrap()).despawn();
 /// });
 ///
-/// world.entity_mut(e2).observe(|trigger: Trigger<Explode>, mut commands: Commands| {
+/// world.entity_mut(e2).observe(|trigger: On<Explode>, mut commands: Commands| {
 ///     println!("The explosion fizzles! This entity is immune!");
 /// });
 /// ```
@@ -178,7 +177,7 @@ pub type ObserverRunner = fn(DeferredWorld, ObserverTrigger, PtrMut, propagate: 
 /// # let entity = world.spawn_empty().id();
 /// # #[derive(Event)]
 /// # struct Explode;
-/// let mut observer = Observer::new(|trigger: Trigger<Explode>| {});
+/// let mut observer = Observer::new(|trigger: On<Explode>| {});
 /// observer.watch_entity(entity);
 /// world.spawn(observer);
 /// ```
@@ -351,7 +350,7 @@ fn observer_system_runner<E: Event, B: Bundle, S: ObserverSystem<E, B>>(
     }
     state.last_trigger_id = last_trigger;
 
-    let trigger: Trigger<E, B> = Trigger::new(
+    let trigger: On<E, B> = On::new(
         // SAFETY: Caller ensures `ptr` is castable to `&mut T`
         unsafe { ptr.deref_mut() },
         propagate,
@@ -448,7 +447,7 @@ mod tests {
     use crate::{
         error::{ignore, DefaultErrorHandler},
         event::Event,
-        observer::Trigger,
+        observer::On,
     };
 
     #[derive(Event)]
@@ -457,7 +456,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "I failed!")]
     fn test_fallible_observer() {
-        fn system(_: Trigger<TriggerEvent>) -> Result {
+        fn system(_: On<TriggerEvent>) -> Result {
             Err("I failed!".into())
         }
 
@@ -472,7 +471,7 @@ mod tests {
         #[derive(Resource, Default)]
         struct Ran(bool);
 
-        fn system(_: Trigger<TriggerEvent>, mut ran: ResMut<Ran>) -> Result {
+        fn system(_: On<TriggerEvent>, mut ran: ResMut<Ran>) -> Result {
             ran.0 = true;
             Err("I failed!".into())
         }
@@ -500,7 +499,7 @@ mod tests {
         expected = "Exclusive system `bevy_ecs::observer::runner::tests::exclusive_system_cannot_be_observer::system` may not be used as observer.\nInstead of `&mut World`, use either `DeferredWorld` if you do not need structural changes, or `Commands` if you do."
     )]
     fn exclusive_system_cannot_be_observer() {
-        fn system(_: Trigger<TriggerEvent>, _world: &mut World) {}
+        fn system(_: On<TriggerEvent>, _world: &mut World) {}
         let mut world = World::default();
         world.add_observer(system);
     }

--- a/crates/bevy_ecs/src/system/commands/command.rs
+++ b/crates/bevy_ecs/src/system/commands/command.rs
@@ -208,7 +208,9 @@ pub fn run_schedule(label: impl ScheduleLabel) -> impl Command<Result> {
     }
 }
 
-/// A [`Command`] that sends a global [`Trigger`](crate::observer::Trigger) without any targets.
+/// A [`Command`] that sends a global [observer] [`Event`] without any targets.
+///
+/// [observer]: crate::observer::Observer
 #[track_caller]
 pub fn trigger(event: impl Event) -> impl Command {
     let caller = MaybeLocation::caller();
@@ -217,7 +219,9 @@ pub fn trigger(event: impl Event) -> impl Command {
     }
 }
 
-/// A [`Command`] that sends a [`Trigger`](crate::observer::Trigger) for the given targets.
+/// A [`Command`] that sends an [observer] [`Event`] for the given targets.
+///
+/// [observer]: crate::observer::Observer
 pub fn trigger_targets(
     event: impl Event,
     targets: impl TriggerTargets + Send + Sync + 'static,

--- a/crates/bevy_ecs/src/system/commands/entity_command.rs
+++ b/crates/bevy_ecs/src/system/commands/entity_command.rs
@@ -227,7 +227,7 @@ pub fn observe<E: Event, B: Bundle, M>(
     }
 }
 
-/// An [`EntityCommand`] that sends a [`Trigger`](crate::observer::Trigger) targeting an entity.
+/// An [`EntityCommand`] that sends an [observer](crate::observer::Observer) [`Event`] targeting an entity.
 ///
 /// This will run any [`Observer`](crate::observer::Observer) of the given [`Event`] watching the entity.
 #[track_caller]

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -1068,7 +1068,7 @@ impl<'w, 's> Commands<'w, 's> {
         self.queue(command::run_system_cached_with(system, input).handle_error_with(warn));
     }
 
-    /// Sends a "global" [`Trigger`](crate::observer::Trigger) without any targets.
+    /// Sends a global [observer](Observer) [`Event`] without any targets.
     ///
     /// This will run any [`Observer`] of the given [`Event`] that isn't scoped to specific targets.
     #[track_caller]
@@ -1076,7 +1076,7 @@ impl<'w, 's> Commands<'w, 's> {
         self.queue(command::trigger(event));
     }
 
-    /// Sends a [`Trigger`](crate::observer::Trigger) for the given targets.
+    /// Sends an [observer](Observer) [`Event`] for the given targets.
     ///
     /// This will run any [`Observer`] of the given [`Event`] watching those targets.
     #[track_caller]
@@ -1091,7 +1091,7 @@ impl<'w, 's> Commands<'w, 's> {
     /// Spawns an [`Observer`] and returns the [`EntityCommands`] associated
     /// with the entity that stores the observer.
     ///
-    /// `observer` can be any system whose first parameter is a [`Trigger`].
+    /// `observer` can be any system whose first parameter is [`On`].
     ///
     /// **Calling [`observe`](EntityCommands::observe) on the returned
     /// [`EntityCommands`] will observe the observer itself, which you very
@@ -1101,7 +1101,7 @@ impl<'w, 's> Commands<'w, 's> {
     ///
     /// Panics if the given system is an exclusive system.
     ///
-    /// [`Trigger`]: crate::observer::Trigger
+    /// [`On`]: crate::observer::On
     pub fn add_observer<E: Event, B: Bundle, M>(
         &mut self,
         observer: impl IntoObserverSystem<E, B, M>,
@@ -1947,7 +1947,7 @@ impl<'a> EntityCommands<'a> {
         &mut self.commands
     }
 
-    /// Sends a [`Trigger`](crate::observer::Trigger) targeting the entity.
+    /// Sends an [observer](Observer) [`Event`] targeting the entity.
     ///
     /// This will run any [`Observer`] of the given [`Event`] watching this entity.
     #[track_caller]

--- a/crates/bevy_ecs/src/system/input.rs
+++ b/crates/bevy_ecs/src/system/input.rs
@@ -2,7 +2,7 @@ use core::ops::{Deref, DerefMut};
 
 use variadics_please::all_tuples;
 
-use crate::{bundle::Bundle, prelude::Trigger, system::System};
+use crate::{bundle::Bundle, prelude::On, system::System};
 
 /// Trait for types that can be used as input to [`System`]s.
 ///
@@ -11,7 +11,7 @@ use crate::{bundle::Bundle, prelude::Trigger, system::System};
 /// - [`In<T>`]: For values
 /// - [`InRef<T>`]: For read-only references to values
 /// - [`InMut<T>`]: For mutable references to values
-/// - [`Trigger<E, B>`]: For [`ObserverSystem`]s
+/// - [`On<E, B>`]: For [`ObserverSystem`]s
 /// - [`StaticSystemInput<I>`]: For arbitrary [`SystemInput`]s in generic contexts
 /// - Tuples of [`SystemInput`]s up to 8 elements
 ///
@@ -222,9 +222,9 @@ impl<'i, T: ?Sized> DerefMut for InMut<'i, T> {
 /// Used for [`ObserverSystem`]s.
 ///
 /// [`ObserverSystem`]: crate::system::ObserverSystem
-impl<E: 'static, B: Bundle> SystemInput for Trigger<'_, E, B> {
-    type Param<'i> = Trigger<'i, E, B>;
-    type Inner<'i> = Trigger<'i, E, B>;
+impl<E: 'static, B: Bundle> SystemInput for On<'_, E, B> {
+    type Param<'i> = On<'i, E, B>;
+    type Inner<'i> = On<'i, E, B>;
 
     fn wrap(this: Self::Inner<'_>) -> Self::Param<'_> {
         this

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -410,7 +410,7 @@ mod tests {
         error::Result,
         lifecycle::RemovedComponents,
         name::Name,
-        prelude::{AnyOf, EntityRef, OnAdd, Trigger},
+        prelude::{AnyOf, EntityRef, OnAdd, On},
         query::{Added, Changed, Or, SpawnDetails, Spawned, With, Without},
         resource::Resource,
         schedule::{
@@ -1902,15 +1902,15 @@ mod tests {
         #[expect(clippy::unused_unit, reason = "this forces the () return type")]
         schedule.add_systems(|_query: Query<&Name>| -> () { todo!() });
 
-        fn obs(_trigger: Trigger<OnAdd, Name>) {
+        fn obs(_trigger: On<OnAdd, Name>) {
             todo!()
         }
 
         world.add_observer(obs);
-        world.add_observer(|_trigger: Trigger<OnAdd, Name>| {});
-        world.add_observer(|_trigger: Trigger<OnAdd, Name>| todo!());
+        world.add_observer(|_trigger: On<OnAdd, Name>| {});
+        world.add_observer(|_trigger: On<OnAdd, Name>| todo!());
         #[expect(clippy::unused_unit, reason = "this forces the () return type")]
-        world.add_observer(|_trigger: Trigger<OnAdd, Name>| -> () { todo!() });
+        world.add_observer(|_trigger: On<OnAdd, Name>| -> () { todo!() });
 
         fn my_command(_world: &mut World) {
             todo!()

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -410,7 +410,7 @@ mod tests {
         error::Result,
         lifecycle::RemovedComponents,
         name::Name,
-        prelude::{AnyOf, EntityRef, OnAdd, On},
+        prelude::{Add, AnyOf, EntityRef, On},
         query::{Added, Changed, Or, SpawnDetails, Spawned, With, Without},
         resource::Resource,
         schedule::{
@@ -1902,15 +1902,15 @@ mod tests {
         #[expect(clippy::unused_unit, reason = "this forces the () return type")]
         schedule.add_systems(|_query: Query<&Name>| -> () { todo!() });
 
-        fn obs(_trigger: On<OnAdd, Name>) {
+        fn obs(_trigger: On<Add, Name>) {
             todo!()
         }
 
         world.add_observer(obs);
-        world.add_observer(|_trigger: On<OnAdd, Name>| {});
-        world.add_observer(|_trigger: On<OnAdd, Name>| todo!());
+        world.add_observer(|_trigger: On<Add, Name>| {});
+        world.add_observer(|_trigger: On<Add, Name>| todo!());
         #[expect(clippy::unused_unit, reason = "this forces the () return type")]
-        world.add_observer(|_trigger: On<OnAdd, Name>| -> () { todo!() });
+        world.add_observer(|_trigger: On<Add, Name>| -> () { todo!() });
 
         fn my_command(_world: &mut World) {
             todo!()

--- a/crates/bevy_ecs/src/system/observer_system.rs
+++ b/crates/bevy_ecs/src/system/observer_system.rs
@@ -5,7 +5,7 @@ use crate::{
     component::{ComponentId, Tick},
     error::Result,
     never::Never,
-    prelude::{Bundle, Trigger},
+    prelude::{Bundle, On},
     query::FilteredAccessSet,
     schedule::{Fallible, Infallible},
     system::{input::SystemIn, System},
@@ -14,14 +14,14 @@ use crate::{
 
 use super::{IntoSystem, SystemParamValidationError};
 
-/// Implemented for [`System`]s that have a [`Trigger`] as the first argument.
+/// Implemented for [`System`]s that have [`On`] as the first argument.
 pub trait ObserverSystem<E: 'static, B: Bundle, Out = Result>:
-    System<In = Trigger<'static, E, B>, Out = Out> + Send + 'static
+    System<In = On<'static, E, B>, Out = Out> + Send + 'static
 {
 }
 
 impl<E: 'static, B: Bundle, Out, T> ObserverSystem<E, B, Out> for T where
-    T: System<In = Trigger<'static, E, B>, Out = Out> + Send + 'static
+    T: System<In = On<'static, E, B>, Out = Out> + Send + 'static
 {
 }
 
@@ -35,7 +35,7 @@ impl<E: 'static, B: Bundle, Out, T> ObserverSystem<E, B, Out> for T where
 #[diagnostic::on_unimplemented(
     message = "`{Self}` cannot become an `ObserverSystem`",
     label = "the trait `IntoObserverSystem` is not implemented",
-    note = "for function `ObserverSystem`s, ensure the first argument is a `Trigger<T>` and any subsequent ones are `SystemParam`"
+    note = "for function `ObserverSystem`s, ensure the first argument is `On<T>` and any subsequent ones are `SystemParam`"
 )]
 pub trait IntoObserverSystem<E: 'static, B: Bundle, M, Out = Result>: Send + 'static {
     /// The type of [`System`] that this instance converts into.
@@ -47,7 +47,7 @@ pub trait IntoObserverSystem<E: 'static, B: Bundle, M, Out = Result>: Send + 'st
 
 impl<E, B, M, S, Out> IntoObserverSystem<E, B, (Fallible, M), Out> for S
 where
-    S: IntoSystem<Trigger<'static, E, B>, Out, M> + Send + 'static,
+    S: IntoSystem<On<'static, E, B>, Out, M> + Send + 'static,
     S::System: ObserverSystem<E, B, Out>,
     E: 'static,
     B: Bundle,
@@ -61,7 +61,7 @@ where
 
 impl<E, B, M, S> IntoObserverSystem<E, B, (Infallible, M), Result> for S
 where
-    S: IntoSystem<Trigger<'static, E, B>, (), M> + Send + 'static,
+    S: IntoSystem<On<'static, E, B>, (), M> + Send + 'static,
     S::System: ObserverSystem<E, B, ()>,
     E: Send + Sync + 'static,
     B: Bundle,
@@ -74,7 +74,7 @@ where
 }
 impl<E, B, M, S> IntoObserverSystem<E, B, (Never, M), Result> for S
 where
-    S: IntoSystem<Trigger<'static, E, B>, Never, M> + Send + 'static,
+    S: IntoSystem<On<'static, E, B>, Never, M> + Send + 'static,
     E: Send + Sync + 'static,
     B: Bundle,
 {
@@ -108,7 +108,7 @@ where
     B: Bundle,
     Out: Send + Sync + 'static,
 {
-    type In = Trigger<'static, E, B>;
+    type In = On<'static, E, B>;
     type Out = Result;
 
     #[inline]
@@ -189,7 +189,7 @@ where
 mod tests {
     use crate::{
         event::Event,
-        observer::Trigger,
+        observer::On,
         system::{In, IntoSystem},
         world::World,
     };
@@ -199,7 +199,7 @@ mod tests {
 
     #[test]
     fn test_piped_observer_systems_no_input() {
-        fn a(_: Trigger<TriggerEvent>) {}
+        fn a(_: On<TriggerEvent>) {}
         fn b() {}
 
         let mut world = World::new();
@@ -208,7 +208,7 @@ mod tests {
 
     #[test]
     fn test_piped_observer_systems_with_inputs() {
-        fn a(_: Trigger<TriggerEvent>) -> u32 {
+        fn a(_: On<TriggerEvent>) -> u32 {
             3
         }
         fn b(_: In<u32>) {}

--- a/crates/bevy_ecs/src/traversal.rs
+++ b/crates/bevy_ecs/src/traversal.rs
@@ -14,11 +14,11 @@ use crate::{entity::Entity, query::ReadOnlyQueryData, relationship::Relationship
 /// avoiding infinite loops in their code.
 ///
 /// Traversals may be parameterized with additional data. For example, in observer event propagation, the
-/// parameter `D` is the event type given in `Trigger<E>`. This allows traversal to differ depending on event
+/// parameter `D` is the event type given in `On<E>`. This allows traversal to differ depending on event
 /// data.
 ///
 /// [specify the direction]: crate::event::Event::Traversal
-/// [event propagation]: crate::observer::Trigger::propagate
+/// [event propagation]: crate::observer::On::propagate
 /// [observers]: crate::observer::Observer
 pub trait Traversal<D: ?Sized>: ReadOnlyQueryData {
     /// Returns the next entity to visit.
@@ -37,7 +37,7 @@ impl<D> Traversal<D> for () {
 ///
 /// Traversing in a loop could result in infinite loops for relationship graphs with loops.
 ///
-/// [event propagation]: crate::observer::Trigger::propagate
+/// [event propagation]: crate::observer::On::propagate
 impl<R: Relationship, D> Traversal<D> for &R {
     fn traverse(item: Self::Item<'_>, _data: &D) -> Option<Entity> {
         Some(item.get())

--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -85,7 +85,7 @@ impl<'w> DeferredWorld<'w> {
 
     /// Temporarily removes a [`Component`] `T` from the provided [`Entity`] and
     /// runs the provided closure on it, returning the result if `T` was available.
-    /// This will trigger the `OnRemove` and `OnReplace` component hooks without
+    /// This will trigger the `Remove` and `Replace` component hooks without
     /// causing an archetype move.
     ///
     /// This is most useful with immutable components, where removal and reinsertion
@@ -115,7 +115,7 @@ impl<'w> DeferredWorld<'w> {
     /// Temporarily removes a [`Component`] identified by the provided
     /// [`ComponentId`] from the provided [`Entity`] and runs the provided
     /// closure on it, returning the result if the component was available.
-    /// This will trigger the `OnRemove` and `OnReplace` component hooks without
+    /// This will trigger the `Remove` and `Replace` component hooks without
     /// causing an archetype move.
     ///
     /// This is most useful with immutable components, where removal and reinsertion

--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -807,12 +807,12 @@ impl<'w> DeferredWorld<'w> {
         }
     }
 
-    /// Sends a "global" [`Trigger`](crate::observer::Trigger) without any targets.
+    /// Sends a "global" [observer](crate::observer::Observer) [`Event`] without any targets.
     pub fn trigger(&mut self, trigger: impl Event) {
         self.commands().trigger(trigger);
     }
 
-    /// Sends a [`Trigger`](crate::observer::Trigger) with the given `targets`.
+    /// Sends an [observer](crate::observer::Observer) [`Event`] with the given `targets`.
     pub fn trigger_targets(
         &mut self,
         trigger: impl Event,

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -5747,7 +5747,7 @@ mod tests {
         let mut world = World::new();
         let entity = world
             .spawn_empty()
-            .observe(|trigger: Trigger<TestEvent>, mut commands: Commands| {
+            .observe(|trigger: On<TestEvent>, mut commands: Commands| {
                 commands
                     .entity(trigger.target().unwrap())
                     .insert(TestComponent(0));
@@ -5759,7 +5759,7 @@ mod tests {
 
         let mut a = world.entity_mut(entity);
         a.trigger(TestEvent); // this adds command to change entity archetype
-        a.observe(|_: Trigger<TestEvent>| {}); // this flushes commands implicitly by spawning
+        a.observe(|_: On<TestEvent>| {}); // this flushes commands implicitly by spawning
         let location = a.location();
         assert_eq!(world.entities().get(entity), Some(location));
     }
@@ -5769,7 +5769,7 @@ mod tests {
     fn location_on_despawned_entity_panics() {
         let mut world = World::new();
         world.add_observer(
-            |trigger: Trigger<OnAdd, TestComponent>, mut commands: Commands| {
+            |trigger: On<OnAdd, TestComponent>, mut commands: Commands| {
                 commands.entity(trigger.target().unwrap()).despawn();
             },
         );
@@ -5790,11 +5790,11 @@ mod tests {
     fn archetype_modifications_trigger_flush() {
         let mut world = World::new();
         world.insert_resource(TestFlush(0));
-        world.add_observer(|_: Trigger<OnAdd, TestComponent>, mut commands: Commands| {
+        world.add_observer(|_: On<OnAdd, TestComponent>, mut commands: Commands| {
             commands.queue(count_flush);
         });
         world.add_observer(
-            |_: Trigger<OnRemove, TestComponent>, mut commands: Commands| {
+            |_: On<OnRemove, TestComponent>, mut commands: Commands| {
                 commands.queue(count_flush);
             },
         );
@@ -5862,19 +5862,19 @@ mod tests {
             .push("OrdA hook on_remove");
     }
 
-    fn ord_a_observer_on_add(_trigger: Trigger<OnAdd, OrdA>, mut res: ResMut<TestVec>) {
+    fn ord_a_observer_on_add(_trigger: On<OnAdd, OrdA>, mut res: ResMut<TestVec>) {
         res.0.push("OrdA observer on_add");
     }
 
-    fn ord_a_observer_on_insert(_trigger: Trigger<OnInsert, OrdA>, mut res: ResMut<TestVec>) {
+    fn ord_a_observer_on_insert(_trigger: On<OnInsert, OrdA>, mut res: ResMut<TestVec>) {
         res.0.push("OrdA observer on_insert");
     }
 
-    fn ord_a_observer_on_replace(_trigger: Trigger<OnReplace, OrdA>, mut res: ResMut<TestVec>) {
+    fn ord_a_observer_on_replace(_trigger: On<OnReplace, OrdA>, mut res: ResMut<TestVec>) {
         res.0.push("OrdA observer on_replace");
     }
 
-    fn ord_a_observer_on_remove(_trigger: Trigger<OnRemove, OrdA>, mut res: ResMut<TestVec>) {
+    fn ord_a_observer_on_remove(_trigger: On<OnRemove, OrdA>, mut res: ResMut<TestVec>) {
         res.0.push("OrdA observer on_remove");
     }
 
@@ -5913,19 +5913,19 @@ mod tests {
             .push("OrdB hook on_remove");
     }
 
-    fn ord_b_observer_on_add(_trigger: Trigger<OnAdd, OrdB>, mut res: ResMut<TestVec>) {
+    fn ord_b_observer_on_add(_trigger: On<OnAdd, OrdB>, mut res: ResMut<TestVec>) {
         res.0.push("OrdB observer on_add");
     }
 
-    fn ord_b_observer_on_insert(_trigger: Trigger<OnInsert, OrdB>, mut res: ResMut<TestVec>) {
+    fn ord_b_observer_on_insert(_trigger: On<OnInsert, OrdB>, mut res: ResMut<TestVec>) {
         res.0.push("OrdB observer on_insert");
     }
 
-    fn ord_b_observer_on_replace(_trigger: Trigger<OnReplace, OrdB>, mut res: ResMut<TestVec>) {
+    fn ord_b_observer_on_replace(_trigger: On<OnReplace, OrdB>, mut res: ResMut<TestVec>) {
         res.0.push("OrdB observer on_replace");
     }
 
-    fn ord_b_observer_on_remove(_trigger: Trigger<OnRemove, OrdB>, mut res: ResMut<TestVec>) {
+    fn ord_b_observer_on_remove(_trigger: On<OnRemove, OrdB>, mut res: ResMut<TestVec>) {
         res.0.push("OrdB observer on_remove");
     }
 
@@ -6201,10 +6201,10 @@ mod tests {
         world.insert_resource(Tracker { a: false, b: false });
         let entity = world.spawn(A).id();
 
-        world.add_observer(|_: Trigger<OnRemove, A>, mut tracker: ResMut<Tracker>| {
+        world.add_observer(|_: On<OnRemove, A>, mut tracker: ResMut<Tracker>| {
             tracker.a = true;
         });
-        world.add_observer(|_: Trigger<OnRemove, B>, mut tracker: ResMut<Tracker>| {
+        world.add_observer(|_: On<OnRemove, B>, mut tracker: ResMut<Tracker>| {
             tracker.b = true;
         });
 

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1377,7 +1377,7 @@ impl<'w> EntityWorldMut<'w> {
 
     /// Temporarily removes a [`Component`] `T` from this [`Entity`] and runs the
     /// provided closure on it, returning the result if `T` was available.
-    /// This will trigger the `OnRemove` and `OnReplace` component hooks without
+    /// This will trigger the `Remove` and `Replace` component hooks without
     /// causing an archetype move.
     ///
     /// This is most useful with immutable components, where removal and reinsertion
@@ -1430,7 +1430,7 @@ impl<'w> EntityWorldMut<'w> {
 
     /// Temporarily removes a [`Component`] `T` from this [`Entity`] and runs the
     /// provided closure on it, returning the result if `T` was available.
-    /// This will trigger the `OnRemove` and `OnReplace` component hooks without
+    /// This will trigger the `Remove` and `Replace` component hooks without
     /// causing an archetype move.
     ///
     /// This is most useful with immutable components, where removal and reinsertion
@@ -5768,11 +5768,9 @@ mod tests {
     #[should_panic]
     fn location_on_despawned_entity_panics() {
         let mut world = World::new();
-        world.add_observer(
-            |trigger: On<OnAdd, TestComponent>, mut commands: Commands| {
-                commands.entity(trigger.target().unwrap()).despawn();
-            },
-        );
+        world.add_observer(|trigger: On<Add, TestComponent>, mut commands: Commands| {
+            commands.entity(trigger.target().unwrap()).despawn();
+        });
         let entity = world.spawn_empty().id();
         let mut a = world.entity_mut(entity);
         a.insert(TestComponent(0));
@@ -5790,14 +5788,12 @@ mod tests {
     fn archetype_modifications_trigger_flush() {
         let mut world = World::new();
         world.insert_resource(TestFlush(0));
-        world.add_observer(|_: On<OnAdd, TestComponent>, mut commands: Commands| {
+        world.add_observer(|_: On<Add, TestComponent>, mut commands: Commands| {
             commands.queue(count_flush);
         });
-        world.add_observer(
-            |_: On<OnRemove, TestComponent>, mut commands: Commands| {
-                commands.queue(count_flush);
-            },
-        );
+        world.add_observer(|_: On<Remove, TestComponent>, mut commands: Commands| {
+            commands.queue(count_flush);
+        });
         world.commands().queue(count_flush);
         let entity = world.spawn_empty().id();
         assert_eq!(world.resource::<TestFlush>().0, 1);
@@ -5862,19 +5858,19 @@ mod tests {
             .push("OrdA hook on_remove");
     }
 
-    fn ord_a_observer_on_add(_trigger: On<OnAdd, OrdA>, mut res: ResMut<TestVec>) {
+    fn ord_a_observer_on_add(_trigger: On<Add, OrdA>, mut res: ResMut<TestVec>) {
         res.0.push("OrdA observer on_add");
     }
 
-    fn ord_a_observer_on_insert(_trigger: On<OnInsert, OrdA>, mut res: ResMut<TestVec>) {
+    fn ord_a_observer_on_insert(_trigger: On<Insert, OrdA>, mut res: ResMut<TestVec>) {
         res.0.push("OrdA observer on_insert");
     }
 
-    fn ord_a_observer_on_replace(_trigger: On<OnReplace, OrdA>, mut res: ResMut<TestVec>) {
+    fn ord_a_observer_on_replace(_trigger: On<Replace, OrdA>, mut res: ResMut<TestVec>) {
         res.0.push("OrdA observer on_replace");
     }
 
-    fn ord_a_observer_on_remove(_trigger: On<OnRemove, OrdA>, mut res: ResMut<TestVec>) {
+    fn ord_a_observer_on_remove(_trigger: On<Remove, OrdA>, mut res: ResMut<TestVec>) {
         res.0.push("OrdA observer on_remove");
     }
 
@@ -5913,19 +5909,19 @@ mod tests {
             .push("OrdB hook on_remove");
     }
 
-    fn ord_b_observer_on_add(_trigger: On<OnAdd, OrdB>, mut res: ResMut<TestVec>) {
+    fn ord_b_observer_on_add(_trigger: On<Add, OrdB>, mut res: ResMut<TestVec>) {
         res.0.push("OrdB observer on_add");
     }
 
-    fn ord_b_observer_on_insert(_trigger: On<OnInsert, OrdB>, mut res: ResMut<TestVec>) {
+    fn ord_b_observer_on_insert(_trigger: On<Insert, OrdB>, mut res: ResMut<TestVec>) {
         res.0.push("OrdB observer on_insert");
     }
 
-    fn ord_b_observer_on_replace(_trigger: On<OnReplace, OrdB>, mut res: ResMut<TestVec>) {
+    fn ord_b_observer_on_replace(_trigger: On<Replace, OrdB>, mut res: ResMut<TestVec>) {
         res.0.push("OrdB observer on_replace");
     }
 
-    fn ord_b_observer_on_remove(_trigger: On<OnRemove, OrdB>, mut res: ResMut<TestVec>) {
+    fn ord_b_observer_on_remove(_trigger: On<Remove, OrdB>, mut res: ResMut<TestVec>) {
         res.0.push("OrdB observer on_remove");
     }
 
@@ -6201,10 +6197,10 @@ mod tests {
         world.insert_resource(Tracker { a: false, b: false });
         let entity = world.spawn(A).id();
 
-        world.add_observer(|_: On<OnRemove, A>, mut tracker: ResMut<Tracker>| {
+        world.add_observer(|_: On<Remove, A>, mut tracker: ResMut<Tracker>| {
             tracker.a = true;
         });
-        world.add_observer(|_: On<OnRemove, B>, mut tracker: ResMut<Tracker>| {
+        world.add_observer(|_: On<Remove, B>, mut tracker: ResMut<Tracker>| {
             tracker.b = true;
         });
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -20,7 +20,7 @@ pub use crate::{
 use crate::{
     error::{DefaultErrorHandler, ErrorHandler},
     lifecycle::{ComponentHooks, ON_ADD, ON_DESPAWN, ON_INSERT, ON_REMOVE, ON_REPLACE},
-    prelude::{OnAdd, OnDespawn, OnInsert, OnRemove, OnReplace},
+    prelude::{Add, Despawn, Insert, Remove, Replace},
 };
 pub use bevy_ecs_macros::FromWorld;
 pub use deferred_world::DeferredWorld;
@@ -150,19 +150,19 @@ impl World {
     #[inline]
     fn bootstrap(&mut self) {
         // The order that we register these events is vital to ensure that the constants are correct!
-        let on_add = OnAdd::register_component_id(self);
+        let on_add = Add::register_component_id(self);
         assert_eq!(ON_ADD, on_add);
 
-        let on_insert = OnInsert::register_component_id(self);
+        let on_insert = Insert::register_component_id(self);
         assert_eq!(ON_INSERT, on_insert);
 
-        let on_replace = OnReplace::register_component_id(self);
+        let on_replace = Replace::register_component_id(self);
         assert_eq!(ON_REPLACE, on_replace);
 
-        let on_remove = OnRemove::register_component_id(self);
+        let on_remove = Remove::register_component_id(self);
         assert_eq!(ON_REMOVE, on_remove);
 
-        let on_despawn = OnDespawn::register_component_id(self);
+        let on_despawn = Despawn::register_component_id(self);
         assert_eq!(ON_DESPAWN, on_despawn);
 
         // This sets up `Disabled` as a disabling component, via the FromWorld impl
@@ -1273,7 +1273,7 @@ impl World {
 
     /// Temporarily removes a [`Component`] `T` from the provided [`Entity`] and
     /// runs the provided closure on it, returning the result if `T` was available.
-    /// This will trigger the `OnRemove` and `OnReplace` component hooks without
+    /// This will trigger the `Remove` and `Replace` component hooks without
     /// causing an archetype move.
     ///
     /// This is most useful with immutable components, where removal and reinsertion
@@ -1319,7 +1319,7 @@ impl World {
     /// Temporarily removes a [`Component`] identified by the provided
     /// [`ComponentId`] from the provided [`Entity`] and runs the provided
     /// closure on it, returning the result if the component was available.
-    /// This will trigger the `OnRemove` and `OnReplace` component hooks without
+    /// This will trigger the `Remove` and `Replace` component hooks without
     /// causing an archetype move.
     ///
     /// This is most useful with immutable components, where removal and reinsertion

--- a/crates/bevy_input_focus/src/lib.rs
+++ b/crates/bevy_input_focus/src/lib.rs
@@ -369,7 +369,7 @@ mod tests {
 
     use alloc::string::String;
     use bevy_ecs::{
-        lifecycle::HookContext, observer::Trigger, system::RunSystemOnce, world::DeferredWorld,
+        lifecycle::HookContext, observer::On, system::RunSystemOnce, world::DeferredWorld,
     };
     use bevy_input::{
         keyboard::{Key, KeyCode},
@@ -391,7 +391,7 @@ mod tests {
     struct GatherKeyboardEvents(String);
 
     fn gather_keyboard_events(
-        trigger: Trigger<FocusedInput<KeyboardInput>>,
+        trigger: On<FocusedInput<KeyboardInput>>,
         mut query: Query<&mut GatherKeyboardEvents>,
     ) {
         if let Ok(mut gather) = query.get_mut(trigger.target().unwrap()) {

--- a/crates/bevy_input_focus/src/tab_navigation.rs
+++ b/crates/bevy_input_focus/src/tab_navigation.rs
@@ -30,7 +30,7 @@ use bevy_ecs::{
     component::Component,
     entity::Entity,
     hierarchy::{ChildOf, Children},
-    observer::Trigger,
+    observer::On,
     query::{With, Without},
     system::{Commands, Query, Res, ResMut, SystemParam},
 };
@@ -337,7 +337,7 @@ fn setup_tab_navigation(mut commands: Commands, window: Query<Entity, With<Prima
 ///
 /// Any [`TabNavigationError`]s that occur during tab navigation are logged as warnings.
 pub fn handle_tab_navigation(
-    mut trigger: Trigger<FocusedInput<KeyboardInput>>,
+    mut trigger: On<FocusedInput<KeyboardInput>>,
     nav: TabNavigation,
     mut focus: ResMut<InputFocus>,
     mut visible: ResMut<InputFocusVisible>,

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -548,7 +548,7 @@ pub struct LightViewEntities(EntityHashMap<Vec<Entity>>);
 
 // TODO: using required component
 pub(crate) fn add_light_view_entities(
-    trigger: On<OnAdd, (ExtractedDirectionalLight, ExtractedPointLight)>,
+    trigger: On<Add, (ExtractedDirectionalLight, ExtractedPointLight)>,
     mut commands: Commands,
 ) {
     if let Ok(mut v) = commands.get_entity(trigger.target().unwrap()) {
@@ -558,7 +558,7 @@ pub(crate) fn add_light_view_entities(
 
 /// Removes [`LightViewEntities`] when light is removed. See [`add_light_view_entities`].
 pub(crate) fn extracted_light_removed(
-    trigger: On<OnRemove, (ExtractedDirectionalLight, ExtractedPointLight)>,
+    trigger: On<Remove, (ExtractedDirectionalLight, ExtractedPointLight)>,
     mut commands: Commands,
 ) {
     if let Ok(mut v) = commands.get_entity(trigger.target().unwrap()) {
@@ -567,7 +567,7 @@ pub(crate) fn extracted_light_removed(
 }
 
 pub(crate) fn remove_light_view_entities(
-    trigger: On<OnRemove, LightViewEntities>,
+    trigger: On<Remove, LightViewEntities>,
     query: Query<&LightViewEntities>,
     mut commands: Commands,
 ) {

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -548,7 +548,7 @@ pub struct LightViewEntities(EntityHashMap<Vec<Entity>>);
 
 // TODO: using required component
 pub(crate) fn add_light_view_entities(
-    trigger: Trigger<OnAdd, (ExtractedDirectionalLight, ExtractedPointLight)>,
+    trigger: On<OnAdd, (ExtractedDirectionalLight, ExtractedPointLight)>,
     mut commands: Commands,
 ) {
     if let Ok(mut v) = commands.get_entity(trigger.target().unwrap()) {
@@ -558,7 +558,7 @@ pub(crate) fn add_light_view_entities(
 
 /// Removes [`LightViewEntities`] when light is removed. See [`add_light_view_entities`].
 pub(crate) fn extracted_light_removed(
-    trigger: Trigger<OnRemove, (ExtractedDirectionalLight, ExtractedPointLight)>,
+    trigger: On<OnRemove, (ExtractedDirectionalLight, ExtractedPointLight)>,
     mut commands: Commands,
 ) {
     if let Ok(mut v) = commands.get_entity(trigger.target().unwrap()) {
@@ -567,7 +567,7 @@ pub(crate) fn extracted_light_removed(
 }
 
 pub(crate) fn remove_light_view_entities(
-    trigger: Trigger<OnRemove, LightViewEntities>,
+    trigger: On<OnRemove, LightViewEntities>,
     query: Query<&LightViewEntities>,
     mut commands: Commands,
 ) {

--- a/crates/bevy_picking/src/events.rs
+++ b/crates/bevy_picking/src/events.rs
@@ -11,7 +11,7 @@
 //! # use bevy_picking::prelude::*;
 //! # let mut world = World::default();
 //! world.spawn_empty()
-//!     .observe(|trigger: Trigger<Pointer<Over>>| {
+//!     .observe(|trigger: On<Pointer<Over>>| {
 //!         println!("I am being hovered over");
 //!     });
 //! ```

--- a/crates/bevy_picking/src/lib.rs
+++ b/crates/bevy_picking/src/lib.rs
@@ -17,7 +17,7 @@
 //! # struct MyComponent;
 //! # let mut world = World::new();
 //! world.spawn(MyComponent)
-//!     .observe(|mut trigger: Trigger<Pointer<Click>>| {
+//!     .observe(|mut trigger: On<Pointer<Click>>| {
 //!         println!("I was just clicked!");
 //!         // Get the underlying pointer event data
 //!         let click_event: &Pointer<Click> = trigger.event();
@@ -39,7 +39,7 @@
 //!
 //! When events are generated, they bubble up the entity hierarchy starting from their target, until
 //! they reach the root or bubbling is halted with a call to
-//! [`Trigger::propagate`](bevy_ecs::observer::Trigger::propagate). See [`Observer`] for details.
+//! [`On::propagate`](bevy_ecs::observer::On::propagate). See [`Observer`] for details.
 //!
 //! This allows you to run callbacks when any children of an entity are interacted with, and leads
 //! to succinct, expressive code:
@@ -52,18 +52,18 @@
 //! # struct Greeting;
 //! fn setup(mut commands: Commands) {
 //!     commands.spawn(Transform::default())
-//!         // Spawn your entity here, e.g. a Mesh.
+//!         // Spawn your entity here, e.g. a `Mesh3d`.
 //!         // When dragged, mutate the `Transform` component on the dragged target entity:
-//!         .observe(|trigger: Trigger<Pointer<Drag>>, mut transforms: Query<&mut Transform>| {
+//!         .observe(|trigger: On<Pointer<Drag>>, mut transforms: Query<&mut Transform>| {
 //!             let mut transform = transforms.get_mut(trigger.target().unwrap()).unwrap();
 //!             let drag = trigger.event();
 //!             transform.rotate_local_y(drag.delta.x / 50.0);
 //!         })
-//!         .observe(|trigger: Trigger<Pointer<Click>>, mut commands: Commands| {
+//!         .observe(|trigger: On<Pointer<Click>>, mut commands: Commands| {
 //!             println!("Entity {} goes BOOM!", trigger.target().unwrap());
 //!             commands.entity(trigger.target().unwrap()).despawn();
 //!         })
-//!         .observe(|trigger: Trigger<Pointer<Over>>, mut events: EventWriter<Greeting>| {
+//!         .observe(|trigger: On<Pointer<Over>>, mut events: EventWriter<Greeting>| {
 //!             events.write(Greeting);
 //!         });
 //! }
@@ -286,7 +286,7 @@ pub type PickSet = PickingSystems;
 ///
 /// Note: for any of these plugins to work, they require a picking backend to be active,
 /// The picking backend is responsible to turn an input, into a [`crate::backend::PointerHits`]
-/// that [`PickingPlugin`] and [`InteractionPlugin`] will refine into [`bevy_ecs::observer::Trigger`]s.
+/// that [`PickingPlugin`] and [`InteractionPlugin`] will refine into [`bevy_ecs::observer::On`]s.
 #[derive(Default)]
 pub struct DefaultPickingPlugins;
 

--- a/crates/bevy_render/src/sync_world.rs
+++ b/crates/bevy_render/src/sync_world.rs
@@ -5,7 +5,7 @@ use bevy_ecs::lifecycle::{OnAdd, OnRemove};
 use bevy_ecs::{
     component::Component,
     entity::{ContainsEntity, Entity, EntityEquivalent},
-    observer::Trigger,
+    observer::On,
     query::With,
     reflect::ReflectComponent,
     resource::Resource,
@@ -94,12 +94,12 @@ impl Plugin for SyncWorldPlugin {
     fn build(&self, app: &mut bevy_app::App) {
         app.init_resource::<PendingSyncEntity>();
         app.add_observer(
-            |trigger: Trigger<OnAdd, SyncToRenderWorld>, mut pending: ResMut<PendingSyncEntity>| {
+            |trigger: On<OnAdd, SyncToRenderWorld>, mut pending: ResMut<PendingSyncEntity>| {
                 pending.push(EntityRecord::Added(trigger.target().unwrap()));
             },
         );
         app.add_observer(
-            |trigger: Trigger<OnRemove, SyncToRenderWorld>,
+            |trigger: On<OnRemove, SyncToRenderWorld>,
              mut pending: ResMut<PendingSyncEntity>,
              query: Query<&RenderEntity>| {
                 if let Ok(e) = query.get(trigger.target().unwrap()) {
@@ -492,7 +492,7 @@ mod tests {
         component::Component,
         entity::Entity,
         lifecycle::{OnAdd, OnRemove},
-        observer::Trigger,
+        observer::On,
         query::With,
         system::{Query, ResMut},
         world::World,
@@ -513,12 +513,12 @@ mod tests {
         main_world.init_resource::<PendingSyncEntity>();
 
         main_world.add_observer(
-            |trigger: Trigger<OnAdd, SyncToRenderWorld>, mut pending: ResMut<PendingSyncEntity>| {
+            |trigger: On<OnAdd, SyncToRenderWorld>, mut pending: ResMut<PendingSyncEntity>| {
                 pending.push(EntityRecord::Added(trigger.target().unwrap()));
             },
         );
         main_world.add_observer(
-            |trigger: Trigger<OnRemove, SyncToRenderWorld>,
+            |trigger: On<OnRemove, SyncToRenderWorld>,
              mut pending: ResMut<PendingSyncEntity>,
              query: Query<&RenderEntity>| {
                 if let Ok(e) = query.get(trigger.target().unwrap()) {

--- a/crates/bevy_render/src/sync_world.rs
+++ b/crates/bevy_render/src/sync_world.rs
@@ -1,7 +1,7 @@
 use bevy_app::Plugin;
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::entity::EntityHash;
-use bevy_ecs::lifecycle::{OnAdd, OnRemove};
+use bevy_ecs::lifecycle::{Add, Remove};
 use bevy_ecs::{
     component::Component,
     entity::{ContainsEntity, Entity, EntityEquivalent},
@@ -94,12 +94,12 @@ impl Plugin for SyncWorldPlugin {
     fn build(&self, app: &mut bevy_app::App) {
         app.init_resource::<PendingSyncEntity>();
         app.add_observer(
-            |trigger: On<OnAdd, SyncToRenderWorld>, mut pending: ResMut<PendingSyncEntity>| {
+            |trigger: On<Add, SyncToRenderWorld>, mut pending: ResMut<PendingSyncEntity>| {
                 pending.push(EntityRecord::Added(trigger.target().unwrap()));
             },
         );
         app.add_observer(
-            |trigger: On<OnRemove, SyncToRenderWorld>,
+            |trigger: On<Remove, SyncToRenderWorld>,
              mut pending: ResMut<PendingSyncEntity>,
              query: Query<&RenderEntity>| {
                 if let Ok(e) = query.get(trigger.target().unwrap()) {
@@ -491,7 +491,7 @@ mod tests {
     use bevy_ecs::{
         component::Component,
         entity::Entity,
-        lifecycle::{OnAdd, OnRemove},
+        lifecycle::{Add, Remove},
         observer::On,
         query::With,
         system::{Query, ResMut},
@@ -513,12 +513,12 @@ mod tests {
         main_world.init_resource::<PendingSyncEntity>();
 
         main_world.add_observer(
-            |trigger: On<OnAdd, SyncToRenderWorld>, mut pending: ResMut<PendingSyncEntity>| {
+            |trigger: On<Add, SyncToRenderWorld>, mut pending: ResMut<PendingSyncEntity>| {
                 pending.push(EntityRecord::Added(trigger.target().unwrap()));
             },
         );
         main_world.add_observer(
-            |trigger: On<OnRemove, SyncToRenderWorld>,
+            |trigger: On<Remove, SyncToRenderWorld>,
              mut pending: ResMut<PendingSyncEntity>,
              query: Query<&RenderEntity>| {
                 if let Ok(e) = query.get(trigger.target().unwrap()) {

--- a/crates/bevy_render/src/view/window/screenshot.rs
+++ b/crates/bevy_render/src/view/window/screenshot.rs
@@ -122,7 +122,7 @@ struct RenderScreenshotsPrepared(EntityHashMap<ScreenshotPreparedState>);
 struct RenderScreenshotsSender(Sender<(Entity, Image)>);
 
 /// Saves the captured screenshot to disk at the provided path.
-pub fn save_to_disk(path: impl AsRef<Path>) -> impl FnMut(Trigger<ScreenshotCaptured>) {
+pub fn save_to_disk(path: impl AsRef<Path>) -> impl FnMut(On<ScreenshotCaptured>) {
     let path = path.as_ref().to_owned();
     move |trigger| {
         let img = trigger.event().deref().clone();

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -22,9 +22,9 @@ use bevy_ecs::{
 };
 /// Triggered on a scene's parent entity when [`crate::SceneInstance`] becomes ready to use.
 ///
-/// See also [`Trigger`], [`SceneSpawner::instance_is_ready`].
+/// See also [`On`], [`SceneSpawner::instance_is_ready`].
 ///
-/// [`Trigger`]: bevy_ecs::observer::Trigger
+/// [`On`]: bevy_ecs::observer::On
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Event, Reflect)]
 #[reflect(Debug, PartialEq, Clone)]
 pub struct SceneInstanceReady {
@@ -542,7 +542,7 @@ mod tests {
     use bevy_ecs::{
         component::Component,
         hierarchy::Children,
-        observer::Trigger,
+        observer::On,
         prelude::ReflectComponent,
         query::With,
         system::{Commands, Query, Res, ResMut, RunSystemOnce},
@@ -724,7 +724,7 @@ mod tests {
     fn observe_trigger(app: &mut App, scene_id: InstanceId, scene_entity: Option<Entity>) {
         // Add observer
         app.world_mut().add_observer(
-            move |trigger: Trigger<SceneInstanceReady>,
+            move |trigger: On<SceneInstanceReady>,
                   scene_spawner: Res<SceneSpawner>,
                   mut trigger_count: ResMut<TriggerCount>| {
                 assert_eq!(

--- a/crates/bevy_ui/src/interaction_states.rs
+++ b/crates/bevy_ui/src/interaction_states.rs
@@ -2,7 +2,7 @@
 use bevy_a11y::AccessibilityNode;
 use bevy_ecs::{
     component::Component,
-    lifecycle::{OnAdd, OnInsert, OnRemove},
+    lifecycle::{Add, Insert, Remove},
     observer::On,
     world::DeferredWorld,
 };
@@ -18,10 +18,7 @@ use bevy_ecs::{
 #[derive(Component, Debug, Clone, Copy, Default)]
 pub struct InteractionDisabled;
 
-pub(crate) fn on_add_disabled(
-    trigger: On<OnAdd, InteractionDisabled>,
-    mut world: DeferredWorld,
-) {
+pub(crate) fn on_add_disabled(trigger: On<Add, InteractionDisabled>, mut world: DeferredWorld) {
     let mut entity = world.entity_mut(trigger.target().unwrap());
     if let Some(mut accessibility) = entity.get_mut::<AccessibilityNode>() {
         accessibility.set_disabled();
@@ -29,7 +26,7 @@ pub(crate) fn on_add_disabled(
 }
 
 pub(crate) fn on_remove_disabled(
-    trigger: On<OnRemove, InteractionDisabled>,
+    trigger: On<Remove, InteractionDisabled>,
     mut world: DeferredWorld,
 ) {
     let mut entity = world.entity_mut(trigger.target().unwrap());
@@ -55,7 +52,7 @@ impl Checked {
     }
 }
 
-pub(crate) fn on_insert_is_checked(trigger: On<OnInsert, Checked>, mut world: DeferredWorld) {
+pub(crate) fn on_insert_is_checked(trigger: On<Insert, Checked>, mut world: DeferredWorld) {
     let mut entity = world.entity_mut(trigger.target().unwrap());
     let checked = entity.get::<Checked>().unwrap().get();
     if let Some(mut accessibility) = entity.get_mut::<AccessibilityNode>() {
@@ -66,7 +63,7 @@ pub(crate) fn on_insert_is_checked(trigger: On<OnInsert, Checked>, mut world: De
     }
 }
 
-pub(crate) fn on_remove_is_checked(trigger: On<OnRemove, Checked>, mut world: DeferredWorld) {
+pub(crate) fn on_remove_is_checked(trigger: On<Remove, Checked>, mut world: DeferredWorld) {
     let mut entity = world.entity_mut(trigger.target().unwrap());
     if let Some(mut accessibility) = entity.get_mut::<AccessibilityNode>() {
         accessibility.set_toggled(accesskit::Toggled::False);

--- a/crates/bevy_ui/src/interaction_states.rs
+++ b/crates/bevy_ui/src/interaction_states.rs
@@ -3,7 +3,7 @@ use bevy_a11y::AccessibilityNode;
 use bevy_ecs::{
     component::Component,
     lifecycle::{OnAdd, OnInsert, OnRemove},
-    observer::Trigger,
+    observer::On,
     world::DeferredWorld,
 };
 
@@ -19,7 +19,7 @@ use bevy_ecs::{
 pub struct InteractionDisabled;
 
 pub(crate) fn on_add_disabled(
-    trigger: Trigger<OnAdd, InteractionDisabled>,
+    trigger: On<OnAdd, InteractionDisabled>,
     mut world: DeferredWorld,
 ) {
     let mut entity = world.entity_mut(trigger.target().unwrap());
@@ -29,7 +29,7 @@ pub(crate) fn on_add_disabled(
 }
 
 pub(crate) fn on_remove_disabled(
-    trigger: Trigger<OnRemove, InteractionDisabled>,
+    trigger: On<OnRemove, InteractionDisabled>,
     mut world: DeferredWorld,
 ) {
     let mut entity = world.entity_mut(trigger.target().unwrap());
@@ -55,7 +55,7 @@ impl Checked {
     }
 }
 
-pub(crate) fn on_insert_is_checked(trigger: Trigger<OnInsert, Checked>, mut world: DeferredWorld) {
+pub(crate) fn on_insert_is_checked(trigger: On<OnInsert, Checked>, mut world: DeferredWorld) {
     let mut entity = world.entity_mut(trigger.target().unwrap());
     let checked = entity.get::<Checked>().unwrap().get();
     if let Some(mut accessibility) = entity.get_mut::<AccessibilityNode>() {
@@ -66,7 +66,7 @@ pub(crate) fn on_insert_is_checked(trigger: Trigger<OnInsert, Checked>, mut worl
     }
 }
 
-pub(crate) fn on_remove_is_checked(trigger: Trigger<OnRemove, Checked>, mut world: DeferredWorld) {
+pub(crate) fn on_remove_is_checked(trigger: On<OnRemove, Checked>, mut world: DeferredWorld) {
     let mut entity = world.entity_mut(trigger.target().unwrap());
     if let Some(mut accessibility) = entity.get_mut::<AccessibilityNode>() {
         accessibility.set_toggled(accesskit::Toggled::False);

--- a/crates/bevy_winit/src/cursor.rs
+++ b/crates/bevy_winit/src/cursor.rs
@@ -23,7 +23,7 @@ use bevy_ecs::{
     component::Component,
     entity::Entity,
     lifecycle::OnRemove,
-    observer::Trigger,
+    observer::On,
     query::With,
     reflect::ReflectComponent,
     system::{Commands, Local, Query},
@@ -192,7 +192,7 @@ fn update_cursors(
 }
 
 /// Resets the cursor to the default icon when `CursorIcon` is removed.
-fn on_remove_cursor_icon(trigger: Trigger<OnRemove, CursorIcon>, mut commands: Commands) {
+fn on_remove_cursor_icon(trigger: On<OnRemove, CursorIcon>, mut commands: Commands) {
     // Use `try_insert` to avoid panic if the window is being destroyed.
     commands
         .entity(trigger.target().unwrap())

--- a/crates/bevy_winit/src/cursor.rs
+++ b/crates/bevy_winit/src/cursor.rs
@@ -22,7 +22,7 @@ use bevy_ecs::{
     change_detection::DetectChanges,
     component::Component,
     entity::Entity,
-    lifecycle::OnRemove,
+    lifecycle::Remove,
     observer::On,
     query::With,
     reflect::ReflectComponent,
@@ -192,7 +192,7 @@ fn update_cursors(
 }
 
 /// Resets the cursor to the default icon when `CursorIcon` is removed.
-fn on_remove_cursor_icon(trigger: On<OnRemove, CursorIcon>, mut commands: Commands) {
+fn on_remove_cursor_icon(trigger: On<Remove, CursorIcon>, mut commands: Commands) {
     // Use `try_insert` to avoid panic if the window is being destroyed.
     commands
         .entity(trigger.target().unwrap())

--- a/examples/3d/edit_material_on_gltf.rs
+++ b/examples/3d/edit_material_on_gltf.rs
@@ -8,7 +8,7 @@ use bevy::{
     gltf::GltfAssetLabel,
     math::{Dir3, Vec3},
     pbr::{DirectionalLight, MeshMaterial3d, StandardMaterial},
-    prelude::{Camera3d, Children, Commands, Component, Query, Res, ResMut, Transform, Trigger},
+    prelude::{Camera3d, Children, Commands, Component, Query, Res, ResMut, Transform, On},
     scene::{SceneInstanceReady, SceneRoot},
     DefaultPlugins,
 };
@@ -57,7 +57,7 @@ fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
 }
 
 fn change_material(
-    trigger: Trigger<SceneInstanceReady>,
+    trigger: On<SceneInstanceReady>,
     mut commands: Commands,
     children: Query<&Children>,
     color_override: Query<&ColorOverride>,

--- a/examples/3d/mixed_lighting.rs
+++ b/examples/3d/mixed_lighting.rs
@@ -172,7 +172,7 @@ fn spawn_scene(commands: &mut Commands, asset_server: &AssetServer) {
             ),
         ))
         .observe(
-            |_: Trigger<SceneInstanceReady>,
+            |_: On<SceneInstanceReady>,
              mut lighting_mode_change_event_writer: EventWriter<LightingModeChanged>| {
                 // When the scene loads, send a `LightingModeChanged` event so
                 // that we set up the lightmaps.

--- a/examples/animation/animated_mesh.rs
+++ b/examples/animation/animated_mesh.rs
@@ -62,7 +62,7 @@ fn setup_mesh_and_animation(
 }
 
 fn play_animation_when_ready(
-    trigger: Trigger<SceneInstanceReady>,
+    trigger: On<SceneInstanceReady>,
     mut commands: Commands,
     children: Query<&Children>,
     animations_to_play: Query<&AnimationToPlay>,

--- a/examples/animation/animated_mesh_events.rs
+++ b/examples/animation/animated_mesh_events.rs
@@ -41,7 +41,7 @@ struct Animations {
 struct OnStep;
 
 fn observe_on_step(
-    trigger: Trigger<OnStep>,
+    trigger: On<OnStep>,
     particle: Res<ParticleAssets>,
     mut commands: Commands,
     transforms: Query<&GlobalTransform>,

--- a/examples/animation/animation_events.rs
+++ b/examples/animation/animation_events.rs
@@ -26,7 +26,7 @@ struct MessageEvent {
 }
 
 fn edit_message(
-    trigger: Trigger<MessageEvent>,
+    trigger: On<MessageEvent>,
     text: Single<(&mut Text2d, &mut TextColor), With<MessageText>>,
 ) {
     let (mut text, mut color) = text.into_inner();

--- a/examples/ecs/entity_disabling.rs
+++ b/examples/ecs/entity_disabling.rs
@@ -36,7 +36,7 @@ fn main() {
 struct DisableOnClick;
 
 fn disable_entities_on_click(
-    trigger: Trigger<Pointer<Click>>,
+    trigger: On<Pointer<Click>>,
     valid_query: Query<&DisableOnClick>,
     mut commands: Commands,
 ) {

--- a/examples/ecs/error_handling.rs
+++ b/examples/ecs/error_handling.rs
@@ -123,7 +123,7 @@ fn setup(
 
 // Observer systems can also return a `Result`.
 fn fallible_observer(
-    trigger: Trigger<Pointer<Move>>,
+    trigger: On<Pointer<Move>>,
     mut world: DeferredWorld,
     mut step: Local<f32>,
 ) -> Result {

--- a/examples/ecs/hotpatching_systems.rs
+++ b/examples/ecs/hotpatching_systems.rs
@@ -40,7 +40,7 @@ fn update_text(mut text: Single<&mut Text>) {
 }
 
 fn on_click(
-    _click: Trigger<Pointer<Click>>,
+    _click: On<Pointer<Click>>,
     mut color: Single<&mut TextColor>,
     task_sender: Res<TaskSender>,
 ) {

--- a/examples/ecs/immutable_components.rs
+++ b/examples/ecs/immutable_components.rs
@@ -76,7 +76,7 @@ impl NameIndex {
 /// inserted in the index, and its value will not change without triggering a hook.
 fn on_insert_name(mut world: DeferredWorld<'_>, HookContext { entity, .. }: HookContext) {
     let Some(&name) = world.entity(entity).get::<Name>() else {
-        unreachable!("OnInsert hook guarantees `Name` is available on entity")
+        unreachable!("Insert hook guarantees `Name` is available on entity")
     };
     let Some(mut index) = world.get_resource_mut::<NameIndex>() else {
         return;
@@ -91,7 +91,7 @@ fn on_insert_name(mut world: DeferredWorld<'_>, HookContext { entity, .. }: Hook
 /// inserted in the index.
 fn on_replace_name(mut world: DeferredWorld<'_>, HookContext { entity, .. }: HookContext) {
     let Some(&name) = world.entity(entity).get::<Name>() else {
-        unreachable!("OnReplace hook guarantees `Name` is available on entity")
+        unreachable!("Replace hook guarantees `Name` is available on entity")
     };
     let Some(mut index) = world.get_resource_mut::<NameIndex>() else {
         return;

--- a/examples/ecs/observer_propagation.rs
+++ b/examples/ecs/observer_propagation.rs
@@ -52,7 +52,7 @@ fn setup(mut commands: Commands) {
 //
 // - **auto_propagate:**
 // We can also choose whether or not this event will propagate by default when triggered. If this is
-// false, it will only propagate following a call to `Trigger::propagate(true)`.
+// false, it will only propagate following a call to `On::propagate(true)`.
 #[derive(Clone, Component, Event)]
 #[event(traversal = &'static ChildOf, auto_propagate)]
 struct Attack {
@@ -77,14 +77,14 @@ fn attack_armor(entities: Query<Entity, With<Armor>>, mut commands: Commands) {
     }
 }
 
-fn attack_hits(trigger: Trigger<Attack>, name: Query<&Name>) {
+fn attack_hits(trigger: On<Attack>, name: Query<&Name>) {
     if let Ok(name) = name.get(trigger.target().unwrap()) {
         info!("Attack hit {}", name);
     }
 }
 
 /// A callback placed on [`Armor`], checking if it absorbed all the [`Attack`] damage.
-fn block_attack(mut trigger: Trigger<Attack>, armor: Query<(&Armor, &Name)>) {
+fn block_attack(mut trigger: On<Attack>, armor: Query<(&Armor, &Name)>) {
     let (armor, name) = armor.get(trigger.target().unwrap()).unwrap();
     let attack = trigger.event_mut();
     let damage = attack.damage.saturating_sub(**armor);
@@ -104,7 +104,7 @@ fn block_attack(mut trigger: Trigger<Attack>, armor: Query<(&Armor, &Name)>) {
 /// A callback on the armor wearer, triggered when a piece of armor is not able to block an attack,
 /// or the wearer is attacked directly.
 fn take_damage(
-    trigger: Trigger<Attack>,
+    trigger: On<Attack>,
     mut hp: Query<(&mut HitPoints, &Name)>,
     mut commands: Commands,
     mut app_exit: EventWriter<AppExit>,

--- a/examples/ecs/observers.rs
+++ b/examples/ecs/observers.rs
@@ -16,7 +16,7 @@ fn main() {
         // Observers are systems that run when an event is "triggered". This observer runs whenever
         // `ExplodeMines` is triggered.
         .add_observer(
-            |trigger: Trigger<ExplodeMines>,
+            |trigger: On<ExplodeMines>,
              mines: Query<&Mine>,
              index: Res<SpatialIndex>,
              mut commands: Commands| {
@@ -113,7 +113,7 @@ fn setup(mut commands: Commands) {
 }
 
 fn on_add_mine(
-    trigger: Trigger<OnAdd, Mine>,
+    trigger: On<OnAdd, Mine>,
     query: Query<&Mine>,
     mut index: ResMut<SpatialIndex>,
 ) {
@@ -131,7 +131,7 @@ fn on_add_mine(
 
 // Remove despawned mines from our index
 fn on_remove_mine(
-    trigger: Trigger<OnRemove, Mine>,
+    trigger: On<OnRemove, Mine>,
     query: Query<&Mine>,
     mut index: ResMut<SpatialIndex>,
 ) {
@@ -145,7 +145,7 @@ fn on_remove_mine(
     });
 }
 
-fn explode_mine(trigger: Trigger<Explode>, query: Query<&Mine>, mut commands: Commands) {
+fn explode_mine(trigger: On<Explode>, query: Query<&Mine>, mut commands: Commands) {
     // If a triggered event is targeting a specific entity you can access it with `.target()`
     let id = trigger.target().unwrap();
     let Ok(mut entity) = commands.get_entity(id) else {

--- a/examples/ecs/observers.rs
+++ b/examples/ecs/observers.rs
@@ -113,7 +113,7 @@ fn setup(mut commands: Commands) {
 }
 
 fn on_add_mine(
-    trigger: On<OnAdd, Mine>,
+    trigger: On<Add, Mine>,
     query: Query<&Mine>,
     mut index: ResMut<SpatialIndex>,
 ) {
@@ -131,7 +131,7 @@ fn on_add_mine(
 
 // Remove despawned mines from our index
 fn on_remove_mine(
-    trigger: On<OnRemove, Mine>,
+    trigger: On<Remove, Mine>,
     query: Query<&Mine>,
     mut index: ResMut<SpatialIndex>,
 ) {

--- a/examples/ecs/removal_detection.rs
+++ b/examples/ecs/removal_detection.rs
@@ -1,6 +1,6 @@
 //! This example shows how you can know when a [`Component`] has been removed, so you can react to it.
 //!
-//! When a [`Component`] is removed from an [`Entity`], all [`Observer`] with an [`OnRemove`] trigger for
+//! When a [`Component`] is removed from an [`Entity`], all [`Observer`] with an [`Remove`] trigger for
 //! that [`Component`] will be notified. These observers will be called immediately after the
 //! [`Component`] is removed. For more info on observers, see the
 //! [observers example](https://github.com/bevyengine/bevy/blob/main/examples/ecs/observers.rs).
@@ -48,8 +48,8 @@ fn remove_component(
     }
 }
 
-fn react_on_removal(trigger: On<OnRemove, MyComponent>, mut query: Query<&mut Sprite>) {
-    // The `OnRemove` trigger was automatically called on the `Entity` that had its `MyComponent` removed.
+fn react_on_removal(trigger: On<Remove, MyComponent>, mut query: Query<&mut Sprite>) {
+    // The `Remove` trigger was automatically called on the `Entity` that had its `MyComponent` removed.
     let entity = trigger.target().unwrap();
     if let Ok(mut sprite) = query.get_mut(entity) {
         sprite.color = Color::srgb(0.5, 1., 1.);

--- a/examples/ecs/removal_detection.rs
+++ b/examples/ecs/removal_detection.rs
@@ -48,7 +48,7 @@ fn remove_component(
     }
 }
 
-fn react_on_removal(trigger: Trigger<OnRemove, MyComponent>, mut query: Query<&mut Sprite>) {
+fn react_on_removal(trigger: On<OnRemove, MyComponent>, mut query: Query<&mut Sprite>) {
     // The `OnRemove` trigger was automatically called on the `Entity` that had its `MyComponent` removed.
     let entity = trigger.target().unwrap();
     if let Ok(mut sprite) = query.get_mut(entity) {

--- a/examples/no_std/library/src/lib.rs
+++ b/examples/no_std/library/src/lib.rs
@@ -126,7 +126,7 @@ fn tick_timers(
     }
 }
 
-fn unwrap<B: Bundle>(trigger: Trigger<Unwrap>, world: &mut World) {
+fn unwrap<B: Bundle>(trigger: On<Unwrap>, world: &mut World) {
     if let Some(mut target) = trigger
         .target()
         .and_then(|target| world.get_entity_mut(target).ok())

--- a/examples/picking/debug_picking.rs
+++ b/examples/picking/debug_picking.rs
@@ -47,13 +47,13 @@ fn setup_scene(
         ))
         .observe(on_click_spawn_cube)
         .observe(
-            |out: Trigger<Pointer<Out>>, mut texts: Query<&mut TextColor>| {
+            |out: On<Pointer<Out>>, mut texts: Query<&mut TextColor>| {
                 let mut text_color = texts.get_mut(out.target().unwrap()).unwrap();
                 text_color.0 = Color::WHITE;
             },
         )
         .observe(
-            |over: Trigger<Pointer<Over>>, mut texts: Query<&mut TextColor>| {
+            |over: On<Pointer<Over>>, mut texts: Query<&mut TextColor>| {
                 let mut color = texts.get_mut(over.target().unwrap()).unwrap();
                 color.0 = bevy::color::palettes::tailwind::CYAN_400.into();
             },
@@ -84,7 +84,7 @@ fn setup_scene(
 }
 
 fn on_click_spawn_cube(
-    _click: Trigger<Pointer<Click>>,
+    _click: On<Pointer<Click>>,
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
@@ -101,7 +101,7 @@ fn on_click_spawn_cube(
     *num += 1;
 }
 
-fn on_drag_rotate(drag: Trigger<Pointer<Drag>>, mut transforms: Query<&mut Transform>) {
+fn on_drag_rotate(drag: On<Pointer<Drag>>, mut transforms: Query<&mut Transform>) {
     if let Ok(mut transform) = transforms.get_mut(drag.target().unwrap()) {
         transform.rotate_y(drag.delta.x * 0.02);
         transform.rotate_x(drag.delta.y * 0.02);

--- a/examples/picking/mesh_picking.rs
+++ b/examples/picking/mesh_picking.rs
@@ -159,7 +159,7 @@ fn setup_scene(
 /// Returns an observer that updates the entity's material to the one specified.
 fn update_material_on<E>(
     new_material: Handle<StandardMaterial>,
-) -> impl Fn(Trigger<E>, Query<&mut MeshMaterial3d<StandardMaterial>>) {
+) -> impl Fn(On<E>, Query<&mut MeshMaterial3d<StandardMaterial>>) {
     // An observer closure that captures `new_material`. We do this to avoid needing to write four
     // versions of this observer, each triggered by a different event and with a different hardcoded
     // material. Instead, the event type is a generic, and the material is passed in.
@@ -190,7 +190,7 @@ fn rotate(mut query: Query<&mut Transform, With<Shape>>, time: Res<Time>) {
 }
 
 /// An observer to rotate an entity when it is dragged
-fn rotate_on_drag(drag: Trigger<Pointer<Drag>>, mut transforms: Query<&mut Transform>) {
+fn rotate_on_drag(drag: On<Pointer<Drag>>, mut transforms: Query<&mut Transform>) {
     let mut transform = transforms.get_mut(drag.target().unwrap()).unwrap();
     transform.rotate_y(drag.delta.x * 0.02);
     transform.rotate_x(drag.delta.y * 0.02);

--- a/examples/picking/simple_picking.rs
+++ b/examples/picking/simple_picking.rs
@@ -26,13 +26,13 @@ fn setup_scene(
         ))
         .observe(on_click_spawn_cube)
         .observe(
-            |out: Trigger<Pointer<Out>>, mut texts: Query<&mut TextColor>| {
+            |out: On<Pointer<Out>>, mut texts: Query<&mut TextColor>| {
                 let mut text_color = texts.get_mut(out.target().unwrap()).unwrap();
                 text_color.0 = Color::WHITE;
             },
         )
         .observe(
-            |over: Trigger<Pointer<Over>>, mut texts: Query<&mut TextColor>| {
+            |over: On<Pointer<Over>>, mut texts: Query<&mut TextColor>| {
                 let mut color = texts.get_mut(over.target().unwrap()).unwrap();
                 color.0 = bevy::color::palettes::tailwind::CYAN_400.into();
             },
@@ -62,7 +62,7 @@ fn setup_scene(
 }
 
 fn on_click_spawn_cube(
-    _click: Trigger<Pointer<Click>>,
+    _click: On<Pointer<Click>>,
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
@@ -79,7 +79,7 @@ fn on_click_spawn_cube(
     *num += 1;
 }
 
-fn on_drag_rotate(drag: Trigger<Pointer<Drag>>, mut transforms: Query<&mut Transform>) {
+fn on_drag_rotate(drag: On<Pointer<Drag>>, mut transforms: Query<&mut Transform>) {
     if let Ok(mut transform) = transforms.get_mut(drag.target().unwrap()) {
         transform.rotate_y(drag.delta.x * 0.02);
         transform.rotate_x(drag.delta.y * 0.02);

--- a/examples/picking/sprite_picking.rs
+++ b/examples/picking/sprite_picking.rs
@@ -149,7 +149,7 @@ fn setup_atlas(
         .observe(recolor_on::<Pointer<Release>>(Color::srgb(0.0, 1.0, 1.0)));
 }
 
-// An observer listener that changes the target entity's color.
+// An observer that changes the target entity's color.
 fn recolor_on<E: Debug + Clone + Reflect>(color: Color) -> impl Fn(On<E>, Query<&mut Sprite>) {
     move |ev, mut sprites| {
         let Ok(mut sprite) = sprites.get_mut(ev.target().unwrap()) else {

--- a/examples/picking/sprite_picking.rs
+++ b/examples/picking/sprite_picking.rs
@@ -150,7 +150,7 @@ fn setup_atlas(
 }
 
 // An observer listener that changes the target entity's color.
-fn recolor_on<E: Debug + Clone + Reflect>(color: Color) -> impl Fn(Trigger<E>, Query<&mut Sprite>) {
+fn recolor_on<E: Debug + Clone + Reflect>(color: Color) -> impl Fn(On<E>, Query<&mut Sprite>) {
     move |ev, mut sprites| {
         let Ok(mut sprite) = sprites.get_mut(ev.target().unwrap()) else {
             return;

--- a/examples/shader/gpu_readback.rs
+++ b/examples/shader/gpu_readback.rs
@@ -103,7 +103,7 @@ fn setup(
     // asynchronously and trigger the `ReadbackComplete` event on this entity. Despawn the entity
     // to stop reading back the data.
     commands.spawn(Readback::buffer(buffer.clone())).observe(
-        |trigger: Trigger<ReadbackComplete>| {
+        |trigger: On<ReadbackComplete>| {
             // This matches the type which was used to create the `ShaderStorageBuffer` above,
             // and is a convenient way to interpret the data.
             let data: Vec<u32> = trigger.event().to_shader_type();
@@ -116,7 +116,7 @@ fn setup(
     // Textures can also be read back from the GPU. Pay careful attention to the format of the
     // texture, as it will affect how the data is interpreted.
     commands.spawn(Readback::texture(image.clone())).observe(
-        |trigger: Trigger<ReadbackComplete>| {
+        |trigger: On<ReadbackComplete>| {
             // You probably want to interpret the data as a color rather than a `ShaderType`,
             // but in this case we know the data is a single channel storage texture, so we can
             // interpret it as a `Vec<u32>`

--- a/examples/testbed/3d.rs
+++ b/examples/testbed/3d.rs
@@ -275,7 +275,7 @@ mod animation {
     }
 
     fn pause_animation_frame(
-        trigger: Trigger<SceneInstanceReady>,
+        trigger: On<SceneInstanceReady>,
         children: Query<&Children>,
         mut commands: Commands,
         animation: Res<Animation>,

--- a/examples/ui/core_widgets_observers.rs
+++ b/examples/ui/core_widgets_observers.rs
@@ -38,7 +38,7 @@ const PRESSED_BUTTON: Color = Color::srgb(0.35, 0.75, 0.35);
 struct DemoButton;
 
 fn on_add_pressed(
-    trigger: On<OnAdd, Pressed>,
+    trigger: On<Add, Pressed>,
     mut buttons: Query<
         (
             &Hovered,
@@ -67,7 +67,7 @@ fn on_add_pressed(
 }
 
 fn on_remove_pressed(
-    trigger: On<OnRemove, Pressed>,
+    trigger: On<Remove, Pressed>,
     mut buttons: Query<
         (
             &Hovered,
@@ -96,7 +96,7 @@ fn on_remove_pressed(
 }
 
 fn on_add_disabled(
-    trigger: On<OnAdd, InteractionDisabled>,
+    trigger: On<Add, InteractionDisabled>,
     mut buttons: Query<
         (
             Has<Pressed>,
@@ -125,7 +125,7 @@ fn on_add_disabled(
 }
 
 fn on_remove_disabled(
-    trigger: On<OnRemove, InteractionDisabled>,
+    trigger: On<Remove, InteractionDisabled>,
     mut buttons: Query<
         (
             Has<Pressed>,
@@ -154,7 +154,7 @@ fn on_remove_disabled(
 }
 
 fn on_change_hover(
-    trigger: On<OnInsert, Hovered>,
+    trigger: On<Insert, Hovered>,
     mut buttons: Query<
         (
             Has<Pressed>,

--- a/examples/ui/core_widgets_observers.rs
+++ b/examples/ui/core_widgets_observers.rs
@@ -38,7 +38,7 @@ const PRESSED_BUTTON: Color = Color::srgb(0.35, 0.75, 0.35);
 struct DemoButton;
 
 fn on_add_pressed(
-    trigger: Trigger<OnAdd, Pressed>,
+    trigger: On<OnAdd, Pressed>,
     mut buttons: Query<
         (
             &Hovered,
@@ -67,7 +67,7 @@ fn on_add_pressed(
 }
 
 fn on_remove_pressed(
-    trigger: Trigger<OnRemove, Pressed>,
+    trigger: On<OnRemove, Pressed>,
     mut buttons: Query<
         (
             &Hovered,
@@ -96,7 +96,7 @@ fn on_remove_pressed(
 }
 
 fn on_add_disabled(
-    trigger: Trigger<OnAdd, InteractionDisabled>,
+    trigger: On<OnAdd, InteractionDisabled>,
     mut buttons: Query<
         (
             Has<Pressed>,
@@ -125,7 +125,7 @@ fn on_add_disabled(
 }
 
 fn on_remove_disabled(
-    trigger: Trigger<OnRemove, InteractionDisabled>,
+    trigger: On<OnRemove, InteractionDisabled>,
     mut buttons: Query<
         (
             Has<Pressed>,
@@ -154,7 +154,7 @@ fn on_remove_disabled(
 }
 
 fn on_change_hover(
-    trigger: Trigger<OnInsert, Hovered>,
+    trigger: On<OnInsert, Hovered>,
     mut buttons: Query<
         (
             Has<Pressed>,

--- a/examples/ui/directional_navigation.rs
+++ b/examples/ui/directional_navigation.rs
@@ -67,7 +67,7 @@ const FOCUSED_BORDER: Srgba = bevy::color::palettes::tailwind::BLUE_50;
 // In a real project, each button would also have its own unique behavior,
 // to capture the actual intent of the user
 fn universal_button_click_behavior(
-    mut trigger: Trigger<Pointer<Click>>,
+    mut trigger: On<Pointer<Click>>,
     mut button_query: Query<(&mut BackgroundColor, &mut ResetTimer)>,
 ) {
     let button_entity = trigger.target().unwrap();

--- a/examples/ui/scroll.rs
+++ b/examples/ui/scroll.rs
@@ -89,7 +89,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                     ..default()
                                 })
                                 .observe(|
-                                    trigger: Trigger<Pointer<Press>>,
+                                    trigger: On<Pointer<Press>>,
                                     mut commands: Commands
                                 | {
                                     if trigger.event().button == PointerButton::Primary {

--- a/examples/ui/tab_navigation.rs
+++ b/examples/ui/tab_navigation.rs
@@ -83,7 +83,7 @@ fn setup(mut commands: Commands) {
             ..default()
         })
         .observe(
-            |mut trigger: Trigger<Pointer<Click>>, mut focus: ResMut<InputFocus>| {
+            |mut trigger: On<Pointer<Click>>, mut focus: ResMut<InputFocus>| {
                 focus.0 = None;
                 trigger.propagate(false);
             },
@@ -140,7 +140,7 @@ fn setup(mut commands: Commands) {
                                     )],
                                 ))
                                 .observe(
-                                    |mut trigger: Trigger<Pointer<Click>>,
+                                    |mut trigger: On<Pointer<Click>>,
                                     mut focus: ResMut<InputFocus>| {
                                         focus.0 = Some(trigger.target().unwrap());
                                         trigger.propagate(false);

--- a/examples/ui/viewport_node.rs
+++ b/examples/ui/viewport_node.rs
@@ -89,7 +89,7 @@ fn test(
         .observe(on_drag_viewport);
 }
 
-fn on_drag_viewport(drag: Trigger<Pointer<Drag>>, mut node_query: Query<&mut Node>) {
+fn on_drag_viewport(drag: On<Pointer<Drag>>, mut node_query: Query<&mut Node>) {
     if matches!(drag.button, PointerButton::Secondary) {
         let mut node = node_query.get_mut(drag.target().unwrap()).unwrap();
 
@@ -100,7 +100,7 @@ fn on_drag_viewport(drag: Trigger<Pointer<Drag>>, mut node_query: Query<&mut Nod
     }
 }
 
-fn on_drag_cuboid(drag: Trigger<Pointer<Drag>>, mut transform_query: Query<&mut Transform>) {
+fn on_drag_cuboid(drag: On<Pointer<Drag>>, mut transform_query: Query<&mut Transform>) {
     if matches!(drag.button, PointerButton::Primary) {
         let mut transform = transform_query.get_mut(drag.target().unwrap()).unwrap();
         transform.rotate_y(drag.delta.x * 0.02);

--- a/examples/usages/context_menu.rs
+++ b/examples/usages/context_menu.rs
@@ -39,8 +39,8 @@ fn main() {
 /// helper function to reduce code duplication when generating almost identical observers for the hover text color change effect
 fn text_color_on_hover<T: Debug + Clone + Reflect>(
     color: Color,
-) -> impl FnMut(Trigger<Pointer<T>>, Query<&mut TextColor>, Query<&Children>) {
-    move |mut trigger: Trigger<Pointer<T>>,
+) -> impl FnMut(On<Pointer<T>>, Query<&mut TextColor>, Query<&Children>) {
+    move |mut trigger: On<Pointer<T>>,
           mut text_color: Query<&mut TextColor>,
           children: Query<&Children>| {
         let Ok(children) = children.get(trigger.event().target) else {
@@ -62,14 +62,14 @@ fn setup(mut commands: Commands) {
 
     commands.spawn(background_and_button()).observe(
         // any click bubbling up here should lead to closing any open menu
-        |_: Trigger<Pointer<Press>>, mut commands: Commands| {
+        |_: On<Pointer<Press>>, mut commands: Commands| {
             commands.trigger(CloseContextMenus);
         },
     );
 }
 
 fn on_trigger_close_menus(
-    _trigger: Trigger<CloseContextMenus>,
+    _trigger: On<CloseContextMenus>,
     mut commands: Commands,
     menus: Query<Entity, With<ContextMenu>>,
 ) {
@@ -78,7 +78,7 @@ fn on_trigger_close_menus(
     }
 }
 
-fn on_trigger_menu(trigger: Trigger<OpenContextMenu>, mut commands: Commands) {
+fn on_trigger_menu(trigger: On<OpenContextMenu>, mut commands: Commands) {
     commands.trigger(CloseContextMenus);
 
     let pos = trigger.pos;
@@ -108,7 +108,7 @@ fn on_trigger_menu(trigger: Trigger<OpenContextMenu>, mut commands: Commands) {
             ],
         ))
         .observe(
-            |trigger: Trigger<Pointer<Press>>,
+            |trigger: On<Pointer<Press>>,
              menu_items: Query<&ContextMenuItem>,
              mut clear_col: ResMut<ClearColor>,
              mut commands: Commands| {
@@ -184,7 +184,7 @@ fn background_and_button() -> impl Bundle + use<> {
                     )],
                 ))
                 .observe(
-                    |mut trigger: Trigger<Pointer<Press>>, mut commands: Commands| {
+                    |mut trigger: On<Pointer<Press>>, mut commands: Commands| {
                         // by default this event would bubble up further leading to the `CloseContextMenus`
                         // event being triggered and undoing the opening of one here right away.
                         trigger.propagate(false);

--- a/release-content/migration-guides/component-lifecycle-module.md
+++ b/release-content/migration-guides/component-lifecycle-module.md
@@ -5,7 +5,7 @@ pull_requests: [19543]
 
 To improve documentation, discoverability and internal organization, we've gathered all of the component lifecycle-related code we could and moved it into a dedicated `lifecycle` module.
 
-The lifecycle / observer types (`OnAdd`, `OnInsert`, `OnRemove`, `OnReplace`, `OnDespawn`) have been moved from the `bevy_ecs::world` to `bevy_ecs::lifecycle`.
+The lifecycle / observer types (`Add`, `Insert`, `Remove`, `Replace`, `Despawn`) have been moved from the `bevy_ecs::world` to `bevy_ecs::lifecycle`.
 
 The same move has been done for the more internal (but public) `ComponentId` constants: `ON_ADD`, `ON_INSERT`, `ON_REMOVE`, `ON_REPLACE`, `ON_DESPAWN`.
 

--- a/release-content/migration-guides/observer_triggers.md
+++ b/release-content/migration-guides/observer_triggers.md
@@ -7,7 +7,7 @@ The `Trigger` type used inside observers has been renamed to `On` for a cleaner 
 
 ```rust
 // Old
-commands.add_observer(|trigger: Trigger<OnAdd, Player>| {
+commands.add_observer(|trigger: Trigger<Add, Player>| {
     info!("Spawned player {}", trigger.target());
 });
 

--- a/release-content/migration-guides/observer_triggers.md
+++ b/release-content/migration-guides/observer_triggers.md
@@ -3,10 +3,25 @@ title: Observer Triggers
 pull_requests: [19440]
 ---
 
+The `Trigger` type used inside observers has been renamed to `On` for a cleaner API.
+
+```rust
+// Old
+commands.add_observer(|trigger: Trigger<OnAdd, Player>| {
+    info!("Spawned player {}", trigger.target());
+});
+
+// New
+commands.add_observer(|trigger: On<Add, Player>| {
+    info!("Spawned player {}", trigger.target());
+});
+```
+
 Observers may be triggered on particular entities or globally.
 Previously, a global trigger would claim to trigger on a particular `Entity`, `Entity::PLACEHOLDER`.
 For correctness and transparency, triggers have been changed to `Option<Entity>`.
 
-`Trigger::target` now returns `Option<Entity>` and `ObserverTrigger::target` is now of type `Option<Entity>`.
-If you were checking for `Entity::PLACEHOLDER`, migrate to handling the `None` case.
-If you were not checking for `Entity::PLACEHOLDER`, migrate to unwrapping, as `Entity::PLACEHOLDER` would have caused a panic before, at a later point.
+`On::target` (previously `Trigger::target`) now returns `Option<Entity>`, and `ObserverTrigger::target`
+is now of type `Option<Entity>`. If you were checking for `Entity::PLACEHOLDER`, migrate to handling the `None` case.
+If you were not checking for `Entity::PLACEHOLDER`, migrate to unwrapping, as `Entity::PLACEHOLDER`
+would have caused a panic before, at a later point.


### PR DESCRIPTION
# Objective

Currently, the observer API looks like this:

```rust
app.add_observer(|trigger: Trigger<Explode>| {
    info!("Entity {} exploded!", trigger.target());
});
```

Future plans for observers also include "multi-event observers" with a trigger that looks like this (see [Cart's example](https://github.com/bevyengine/bevy/issues/14649#issuecomment-2960402508)):

```rust
trigger: Trigger<(
    OnAdd<Pressed>,
    OnRemove<Pressed>,
    OnAdd<InteractionDisabled>,
    OnRemove<InteractionDisabled>,
    OnInsert<Hovered>,
)>,
```

In scenarios like this, there is a lot of repetition of `On`. These are expected to be very high-traffic APIs especially in UI contexts, so ergonomics and readability are critical.

By renaming `Trigger` to `On`, we can make these APIs read more cleanly and get rid of the repetition:

```rust
app.add_observer(|trigger: On<Explode>| {
    info!("Entity {} exploded!", trigger.target());
});
```

```rust
trigger: On<(
    Add<Pressed>,
    Remove<Pressed>,
    Add<InteractionDisabled>,
    Remove<InteractionDisabled>,
    Insert<Hovered>,
)>,
```

Names like `On<Add<Pressed>>` emphasize the actual event listener nature more than `Trigger<Add<Pressed>>`, and look cleaner. This *also* frees up the `Trigger` name if we want to use it for the observer event type, splitting them out from buffered events (bikeshedding this is out of scope for this PR though).

For prior art: [`bevy_eventlistener`](https://github.com/aevyrie/bevy_eventlistener) used [`On`](https://docs.rs/bevy_eventlistener/latest/bevy_eventlistener/event_listener/struct.On.html) for its event listener type. Though in our case, the observer is the event listener, and `On` is just a type containing information about the triggered event.

## Solution

- Rename `Trigger` to `On`
- Rename `OnAdd` to `Add`
- Rename `OnInsert` to `Insert`
- Rename `OnReplace` to `Replace`
- Rename `OnRemove` to `Remove`
- Rename `OnDespawn` to `Despawn`

## Discussion

### Naming Conflicts??

Using a name like `Add` might initially feel like a very bad idea, since it risks conflict with `core::ops::Add`. However, I don't expect this to be a big problem in practice.

- You rarely need to actually implement the `Add` trait, especially in modules that would use the Bevy ECS.
- In the rare cases where you *do* get a conflict, it is very easy to fix by just disambiguating, for example using `ops::Add`.
- The `Add` event is a struct while the `Add` trait is a trait (duh), so the compiler error should be very obvious.

For the record, renaming `OnAdd` to `Add`, I got exactly *zero* errors or conflicts within Bevy itself. But this is of course not entirely representative of actual projects *using* Bevy.

You might then wonder, why not use `Added`? This would conflict with the `Added` query filter, so it wouldn't work. Additionally, the current naming convention for observer events does not use past tense.

### Documentation

This does make documentation slightly more awkward when referring to `On` or its methods. Previous docs often referred to `Trigger::target` or "sends a `Trigger`" (which is... a bit strange anyway), which would now be `On::target` and "sends an observer `Event`".

You can see the diff in this PR to see some of the effects. I think it should be fine though, we may just need to reword more documentation to read better.