### PR TITLE
Fix `headless_renderer` example and mention `Screenshot`.

### DIFF
--- a/examples/app/headless_renderer.rs
+++ b/examples/app/headless_renderer.rs
@@ -92,6 +92,7 @@ fn main() {
                 .set(WindowPlugin {
                     primary_window: None,
                     // Don’t automatically exit due to having no windows.
+                    // Instead, the code in `update()` will explicitly produce an `AppExit` event.
                     exit_condition: bevy::window::ExitCondition::DontExit,
                     ..default()
                 })


### PR DESCRIPTION
## Objective

- Makes `headless_renderer` example work instead of exiting without effect.
- Guides users who actually just need [`Screenshot`](https://docs.rs/bevy/0.16.1/bevy/render/view/window/screenshot/struct.Screenshot.html) to use that instead.

This PR was inspired by my own efforts to do headless rendering, in which the complexity of the `headless_renderer` example was a distraction, and this comment from https://github.com/bevyengine/bevy/issues/12478#issuecomment-2094925039 :

> The example added in https://github.com/bevyengine/bevy/pull/13006 would benefit from this change: be sure to clean it up when tackling this work :)

That “cleanup” was not done, and I thought to do it, but it seems to me that using `Screenshot` (in its current form) in the example would not be correct, because — if I understand correctly — the example is trying to, potentially, capture many *consecutive* frames, whereas `Screenshot` by itself gives no means to capture multiple frames without gaps or duplicates. But perhaps I am wrong (the code is complex and not clearly documented), or perhaps that feature isn’t worth preserving. In that case, let me know and I will revise this PR.

## Solution

- Added `exit_condition: bevy::window::ExitCondition::DontExit`
- Added a link to `Screenshot` in the crate documentation.

## Testing

- Ran the example and confirmed that it now writes an image file and then exits.
