### PR TITLE
Add method on `WorldQuery` to apply deferred mutations

### DIFF
--- a/crates/bevy_ecs/src/query/world_query.rs
+++ b/crates/bevy_ecs/src/query/world_query.rs
@@ -3,7 +3,8 @@ use crate::{
     component::{ComponentId, Components, Tick},
     query::FilteredAccess,
     storage::Table,
-    world::{unsafe_world_cell::UnsafeWorldCell, World},
+    system::SystemMeta,
+    world::{unsafe_world_cell::UnsafeWorldCell, DeferredWorld, World},
 };
 use variadics_please::all_tuples;
 
@@ -116,6 +117,25 @@ pub unsafe trait WorldQuery {
     /// Attempts to initialize a [`State`](WorldQuery::State) for this [`WorldQuery`] type using read-only
     /// access to [`Components`].
     fn get_state(components: &Components) -> Option<Self::State>;
+
+    /// Applies any deferred mutations stored in this [`QueryData`]'s state.
+    /// This is used to apply [`Commands`] during [`ApplyDeferred`](crate::prelude::ApplyDeferred).
+    ///
+    /// [`Commands`]: crate::prelude::Commands
+    #[inline]
+    #[expect(
+        unused_variables,
+        reason = "The parameters here are intentionally unused by the default implementation; however, putting underscores here will result in the underscores being copied by rust-analyzer's tab completion."
+    )]
+    fn apply(state: &mut Self::State, system_meta: &SystemMeta, world: &mut World) {}
+
+    /// Queues any deferred mutations to be applied at the next [`ApplyDeferred`](crate::prelude::ApplyDeferred).
+    #[inline]
+    #[expect(
+        unused_variables,
+        reason = "The parameters here are intentionally unused by the default implementation; however, putting underscores here will result in the underscores being copied by rust-analyzer's tab completion."
+    )]
+    fn queue(state: &mut Self::State, system_meta: &SystemMeta, world: DeferredWorld) {}
 
     /// Returns `true` if this query matches a set of components. Otherwise, returns `false`.
     ///

--- a/crates/bevy_ecs/src/query/world_query.rs
+++ b/crates/bevy_ecs/src/query/world_query.rs
@@ -227,6 +227,20 @@ macro_rules! impl_tuple_world_query {
                 Some(($($name::get_state(components)?,)*))
             }
 
+            #[inline]
+            fn apply(($($name,)*): &mut Self::State, system_meta: &SystemMeta, world: &mut World) {
+                $($name::apply($name, system_meta, world);)*
+            }
+
+            #[inline]
+            #[allow(
+                unused_mut,
+                reason = "The `world` parameter is unused for zero-length tuples; however, it must be mutable for other lengths of tuples."
+            )]
+            fn queue(($($name,)*): &mut Self::State, system_meta: &SystemMeta, mut world: DeferredWorld) {
+                $($name::queue($name, system_meta, world.reborrow());)*
+            }
+
             fn matches_component_set(state: &Self::State, set_contains_id: &impl Fn(ComponentId) -> bool) -> bool {
                 let ($($name,)*) = state;
                 true $(&& $name::matches_component_set($name, set_contains_id))*

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -7,7 +7,7 @@ use crate::{
     entity::Entities,
     query::{
         Access, FilteredAccess, FilteredAccessSet, QueryData, QueryFilter, QuerySingleError,
-        QueryState, ReadOnlyQueryData, WorldQuery,
+        QueryState, ReadOnlyQueryData,
     },
     resource::Resource,
     storage::ResourceData,
@@ -345,13 +345,13 @@ unsafe impl<D: QueryData + 'static, F: QueryFilter + 'static> SystemParam for Qu
     }
 
     fn apply(state: &mut Self::State, system_meta: &SystemMeta, world: &mut World) {
-        <D as WorldQuery>::apply(&mut state.fetch_state, system_meta, world);
-        <F as WorldQuery>::apply(&mut state.filter_state, system_meta, world);
+        D::apply(&mut state.fetch_state, system_meta, world);
+        F::apply(&mut state.filter_state, system_meta, world);
     }
 
     fn queue(state: &mut Self::State, system_meta: &SystemMeta, mut world: DeferredWorld) {
-        <D as WorldQuery>::queue(&mut state.fetch_state, system_meta, world.reborrow());
-        <F as WorldQuery>::queue(&mut state.filter_state, system_meta, world);
+        D::queue(&mut state.fetch_state, system_meta, world.reborrow());
+        F::queue(&mut state.filter_state, system_meta, world);
     }
 }
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -344,11 +344,13 @@ unsafe impl<D: QueryData + 'static, F: QueryFilter + 'static> SystemParam for Qu
         unsafe { state.query_unchecked_with_ticks(world, system_meta.last_run, change_tick) }
     }
 
+    #[inline]
     fn apply(state: &mut Self::State, system_meta: &SystemMeta, world: &mut World) {
         D::apply(&mut state.fetch_state, system_meta, world);
         F::apply(&mut state.filter_state, system_meta, world);
     }
 
+    #[inline]
     fn queue(state: &mut Self::State, system_meta: &SystemMeta, mut world: DeferredWorld) {
         D::queue(&mut state.fetch_state, system_meta, world.reborrow());
         F::queue(&mut state.filter_state, system_meta, world);


### PR DESCRIPTION
See discord convo: https://discord.com/channels/691052431525675048/749335865876021248/1373035857522725079

Added `apply` and `queue` methods to `WorldQuery` to mirror `SystemParam`, and piped the calls through `Query` as needed.

While manually passing `&mut Commands` around is probably sufficient for most cases, sometimes custom `QueryData` implementations would benefit from being able to directly wrap (and queue/apply) some form of deferred state. A hypothetical example would be an `Entry<T>` QueryData, but anything that needs to update external state while accessing component data would fit the bill.

I'm not sure if this is controversial or not--maybe it'd be good to enforce a strong separation between directly accessing components through queries and applying deferred mutations with commands, but IMO this opens the door to some pretty nice ergonomics.