### PR TITLE
don't deny warnings on wasm-atomics CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,7 +247,7 @@ jobs:
       - name: Check wasm
         run: cargo check --target wasm32-unknown-unknown -Z build-std=std,panic_abort
         env:
-          RUSTFLAGS: "-C target-feature=+atomics,+bulk-memory -D warnings"
+          RUSTFLAGS: "-C target-feature=+atomics,+bulk-memory"
 
   markdownlint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Objective

- CI job checking for wasm atomics fails because of an unrelated lint on nightly rust
- Fixes #19573 

## Solution

- Don't deny warning, that's not what this job is checking anyway
