### PR TITLE
feat(bevy_ecs): Allow attaching/spawning observers as a Bundle via Bundle Effects

### DIFF
--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -2128,13 +2128,13 @@ fn sorted_remove<T: Eq + Ord + Copy>(source: &mut Vec<T>, remove: &[T]) {
     });
 }
 
-/// [`Effect`] wraps a [`BundleEffect`] into a [`Bundle`] allowing
+/// [`Patch`] wraps a [`BundleEffect`] into a [`Bundle`] allowing
 /// you to leverage the power of a [`BundleEffect`] without having
 /// to implement your own unsafe implementation of the Bundle trait.
 /// [`BundleEffect`]s get access to [`EntityWorldMut`] on insert allowing for
 /// powerful modifications to the world. [`BundleEffect`]s also power other Bevy
 /// helper bundles like [`crate::spawn::SpawnIter`], [`crate::spawn::SpawnWith`], and [`crate::observer::Observer::bundle`].
-/// You can implement BundleEffect directly or use the implementation of BundleEffect
+/// You can implement [`BundleEffect`] directly or use the implementation of [`BundleEffect`]
 /// for `FnOnce(&mut EntityWorldMut)`.
 ///
 /// Note: [`crate::component::Component`] Hooks are almost as powerful as
@@ -2142,30 +2142,26 @@ fn sorted_remove<T: Eq + Ord + Copy>(source: &mut Vec<T>, remove: &[T]) {
 /// should only be used where structural ECS changes are required. For more details
 /// see [`crate::world::DeferredWorld`]
 ///
-/// Example, using a [`BundleEffect`] to add a system to the [`crate::schedule::PostUpdate`]
+/// Example, using [`Patch`] to add a [`crate::resource::Resource`] to the world
+/// this is not possible with `[crate::component::Component]` Hooks because it is
+/// a structural modification
 ///
 /// ```rust
 ///  commands.spawn((
 ///     Node::default(),
-///     Effect(|entity: &mut EntityWorldMut| {
+///     Patch(|entity: &mut EntityWorldMut| {
 ///         // SAFETY: We don't modify the entity's position so this is safe
 ///         let world = unsafe { entity.world_mut() };
 ///
-///         // This is not idempotent
-///         world
-///             .get_resource_mut::<Schedules>()
-///             .unwrap()
-///             .get_mut(PostUpdate)
-///             .unwrap()
-///             .add_systems(animate_component.in_set(UiSystem::PostLayout));
+///         world.insert_resource(SomeResource);
 ///     }),
 /// ))
 /// ```
-pub struct Effect<E>(pub E)
+pub struct Patch<E>(pub E)
 where
     E: BundleEffect;
 
-impl<E> DynamicBundle for Effect<E>
+impl<E> DynamicBundle for Patch<E>
 where
     E: BundleEffect,
 {
@@ -2176,7 +2172,7 @@ where
     }
 }
 
-unsafe impl<F> Bundle for Effect<F>
+unsafe impl<F> Bundle for Patch<F>
 where
     F: FnOnce(&mut EntityWorldMut) + Send + Sync + 'static,
 {

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -2133,7 +2133,7 @@ fn sorted_remove<T: Eq + Ord + Copy>(source: &mut Vec<T>, remove: &[T]) {
 /// to implement your own unsafe implementation of the Bundle trait.
 /// [`BundleEffect`]s get access to [`EntityWorldMut`] on insert allowing for
 /// powerful modifications to the world. [`BundleEffect`]s also power other Bevy
-/// helper bundles like [`crate::spawn::SpawnIter`], [`crate::spawn::SpawnWith`], and [`crate::observer::Observer::bundle`].
+/// helper bundles like [`crate::spawn::SpawnIter`], [`crate::spawn::SpawnWith`], and [`crate::observer::Observer::as_bundle`].
 /// You can implement [`BundleEffect`] directly or use the implementation of [`BundleEffect`]
 /// for `FnOnce(&mut EntityWorldMut)`.
 ///

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -2120,6 +2120,7 @@ fn sorted_remove<T: Eq + Ord + Copy>(source: &mut Vec<T>, remove: &[T]) {
 
 /// BundleEffectFn allows direct access to the BundleEffect trait without having
 /// to implement your own unsafe implementation of the Bundle trait.
+///
 /// Bundle Effects get access to [`EntityWorldMut`] on insert allowing for
 /// powerful modifications to the world. Bundle Effects also power other Bevy
 /// helper bundles like [`crate::spawn::SpawnIter`] and [`crate::spawn::SpawnWith`]

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -2,6 +2,7 @@ use alloc::{boxed::Box, vec};
 use core::any::Any;
 
 use crate::{
+    bundle::BundleEffectFn,
     component::{ComponentId, Mutable, StorageType},
     error::{ErrorContext, ErrorHandler},
     lifecycle::{ComponentHook, HookContext},
@@ -295,6 +296,19 @@ impl Observer {
     /// Returns the [`ObserverDescriptor`] for this [`Observer`].
     pub fn descriptor(&self) -> &ObserverDescriptor {
         &self.descriptor
+    }
+
+    /// Creates a [`Bundle`] that will spawn the given [`Observer`].
+    pub fn bundle<E, B, M, O>(observer: O) -> impl Bundle
+    where
+        E: Event,
+        B: Bundle,
+        M: Send + Sync + 'static,
+        O: IntoObserverSystem<E, B, M> + Send + Sync + 'static,
+    {
+        BundleEffectFn(move |entity| {
+            entity.observe(observer);
+        })
     }
 }
 

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -306,14 +306,14 @@ impl Observer {
     ///     commands.spawn(
     ///         Node::default(),
     ///         Text::from("Not clicked"),
-    ///         Observer::bundle(
+    ///         Observer::as_bundle(
     ///             |trigger: Trigger<Pointer<Click>>,
     ///              mut text: Query<&mut Text>| {
     ///                **text.get_mut(trigger.target).unwrap() = "Clicked!".to_string();
     ///          })
     ///     )
     /// ```
-    pub fn bundle<E, B, M, O>(observer: O) -> impl Bundle
+    pub fn as_bundle<E, B, M, O>(observer: O) -> impl Bundle
     where
         E: Event,
         B: Bundle,

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -2,7 +2,7 @@ use alloc::{boxed::Box, vec};
 use core::any::Any;
 
 use crate::{
-    bundle::Effect,
+    bundle::Patch,
     component::{ComponentId, Mutable, StorageType},
     error::{ErrorContext, ErrorHandler},
     lifecycle::{ComponentHook, HookContext},
@@ -320,7 +320,7 @@ impl Observer {
         M: Send + Sync + 'static,
         O: IntoObserverSystem<E, B, M> + Send + Sync + 'static,
     {
-        Effect(move |entity: &mut EntityWorldMut| {
+        Patch(move |entity: &mut EntityWorldMut| {
             entity.observe(observer);
         })
     }


### PR DESCRIPTION
# Objective

- This upstreams one design for the common community pattern of using Bundle Effects to spawn observers inline
- Fixes #14204
- BundleEffectFn can be used to solve #2157
- Potentially conflicts with #17607

## Solution

Introduced for `SpawnIter` and `SpawnWith`, Bundle Effects are a powerful tool for manipulating the ECS world when a bundle is inserted. This is currently used in the aforementioned children spawning helper methods and has also be extensively used by the community for spawning observers inline. This helps simplify building complex UI by allowing the use of React style components of `fn(props) -> impl Bundle`. Without it, the relevant Bundle must be spawned so its entity ID can be obtained and then the observer added. 

## Testing

- Several people including me made heavy use of this pattern during the most recent Bevy Jam 6 and it's a widely spread approach through the community with it being referenced a lot on Discord.
- I'm unclear if the unsafe impl of Bundle is correct.

---

## Showcase

<details>
  <summary>Example Usage for a tooltip bundle that can be mixed into other UI nodes</summary>

```rust
pub fn tooltip(text: impl Into<String>) -> impl Bundle {
    (
        Observer::bundle(tooltip_hover_start(text.into())),
        Observer::bundle(tooltip_hover),
        Observer::bundle(tooltip_hover_end),
        Observer::bundle(tooltip_touch_end),
    )
}

#[derive(Debug, Clone, Copy, Component)]
pub struct Tooltip;

fn tooltip_bundle(text: String, position: Vec2) -> impl Bundle {
    (
        Tooltip,
        Node {
            padding: UiRect::all(Val::Px(8.0)),
            top: Val::Px(position.y),
            left: Val::Px(position.x),
            ..default()
        },
        GlobalZIndex(100),
        Pickable::IGNORE,
        BackgroundColor(Color::BLACK.with_alpha(0.8)),
        BorderRadius::all(Val::Px(8.0)),
        children![(
            Text::new(text),
            TextFont::from_font_size(18.0),
            Pickable::IGNORE
        )],
    )
}

fn tooltip_hover_start(text: String) -> impl Fn(Trigger<Pointer<Over>>, Commands, Res<UiScale>) {
    move |trigger, mut commands, ui_scale| {
        commands.spawn(tooltip_bundle(
            text.clone(),
            trigger.pointer_location.position / **ui_scale,
        ));
    }
}

fn tooltip_hover(
    trigger: Trigger<Pointer<Move>>,
    mut tooltips: Query<&mut Node, With<Tooltip>>,
    ui_scale: Res<UiScale>,
) {
    tooltips.iter_mut().for_each(|mut tooltip| {
        tooltip.top = Val::Px(trigger.pointer_location.position.y / **ui_scale);
        tooltip.left = Val::Px(trigger.pointer_location.position.x / **ui_scale);
    });
}

fn tooltip_hover_end(
    _: Trigger<Pointer<Out>>,
    tooltips: Query<Entity, With<Tooltip>>,
    mut commands: Commands,
) {
    tooltips
        .iter()
        .for_each(|tooltip| commands.entity(tooltip).despawn());
}

fn tooltip_touch_end(
    _: Trigger<Pointer<Click>>,
    tooltips: Query<Entity, With<Tooltip>>,
    mut commands: Commands,
) {
    tooltips
        .iter()
        .for_each(|tooltip| commands.entity(tooltip).despawn());
}
```

</details>
