### PR TITLE
Prevent `AnimationGraph` from serializing `AssetId`s.

### DIFF
--- a/assets/animation_graphs/Fox.animgraph.ron
+++ b/assets/animation_graphs/Fox.animgraph.ron
@@ -9,20 +9,20 @@
             (
                 node_type: Blend,
                 mask: 0,
-                weight: 1.0,
+                weight: 0.5,
             ),
             (
-                node_type: Clip(AssetPath("models/animated/Fox.glb#Animation0")),
+                node_type: Clip("models/animated/Fox.glb#Animation0"),
                 mask: 0,
                 weight: 1.0,
             ),
             (
-                node_type: Clip(AssetPath("models/animated/Fox.glb#Animation1")),
+                node_type: Clip("models/animated/Fox.glb#Animation1"),
                 mask: 0,
                 weight: 1.0,
             ),
             (
-                node_type: Clip(AssetPath("models/animated/Fox.glb#Animation2")),
+                node_type: Clip("models/animated/Fox.glb#Animation2"),
                 mask: 0,
                 weight: 1.0,
             ),

--- a/crates/bevy_animation/src/graph.rs
+++ b/crates/bevy_animation/src/graph.rs
@@ -800,6 +800,8 @@ impl AssetLoader for AnimationGraphAssetLoader {
             serialized_animation_graph.graph.node_count(),
             serialized_animation_graph.graph.edge_count(),
         );
+
+        let mut already_warned = false;
         for serialized_node in serialized_animation_graph.graph.node_weights() {
             animation_graph.add_node(AnimationGraphNode {
                 node_type: match serialized_node.node_type {
@@ -810,12 +812,14 @@ impl AssetLoader for AnimationGraphAssetLoader {
                         MigrationSerializedAnimationClip::Legacy(
                             SerializedAnimationClip::AssetPath(path),
                         ) => {
-                            warn!(
-                                "Loaded an AnimationGraph asset which contains a \
-                                legacy-style SerializedAnimationClip. Please re-save the asset \
-                                using AnimationGraph::save to automatically migrate to the new \
-                                format"
-                            );
+                            if !already_warned {
+                                warn!(
+                                    "Loaded an AnimationGraph asset which contains a legacy-style \
+                                    SerializedAnimationClip. Please re-save the asset using \
+                                    AnimationGraph::save to automatically migrate to the new format"
+                                );
+                                already_warned = true;
+                            }
                             AnimationNodeType::Clip(load_context.load(path.clone()))
                         }
                         MigrationSerializedAnimationClip::Legacy(

--- a/crates/bevy_animation/src/graph.rs
+++ b/crates/bevy_animation/src/graph.rs
@@ -813,10 +813,12 @@ impl AssetLoader for AnimationGraphAssetLoader {
                             SerializedAnimationClip::AssetPath(path),
                         ) => {
                             if !already_warned {
+                                let path = load_context.asset_path();
                                 warn!(
-                                    "Loaded an AnimationGraph asset which contains a legacy-style \
-                                    SerializedAnimationClip. Please re-save the asset using \
-                                    AnimationGraph::save to automatically migrate to the new format"
+                                    "Loaded an AnimationGraph asset at \"{path}\" which contains a \
+                                    legacy-style SerializedAnimationClip. Please re-save the asset \
+                                    using AnimationGraph::save to automatically migrate to the new \
+                                    format"
                                 );
                                 already_warned = true;
                             }

--- a/crates/bevy_animation/src/graph.rs
+++ b/crates/bevy_animation/src/graph.rs
@@ -832,7 +832,7 @@ impl AssetLoader for AnimationGraphAssetLoader {
             });
         }
         for edge in serialized_animation_graph.graph.raw_edges() {
-            animation_graph.add_edge(edge.source(), edge.target(), edge.weight);
+            animation_graph.add_edge(edge.source(), edge.target(), ());
         }
         Ok(AnimationGraph {
             graph: animation_graph,
@@ -875,7 +875,7 @@ impl TryFrom<AnimationGraph> for SerializedAnimationGraph {
             });
         }
         for edge in animation_graph.graph.raw_edges() {
-            serialized_graph.add_edge(edge.source(), edge.target(), edge.weight);
+            serialized_graph.add_edge(edge.source(), edge.target(), ());
         }
         Ok(Self {
             graph: serialized_graph,

--- a/crates/bevy_animation/src/graph.rs
+++ b/crates/bevy_animation/src/graph.rs
@@ -260,14 +260,14 @@ pub enum AnimationGraphSaveError {
 #[derive(Error, Debug)]
 pub enum AnimationGraphLoadError {
     /// An I/O error occurred.
-    #[error("I/O")]
+    #[error(transparent)]
     Io(#[from] io::Error),
     /// An error occurred in RON deserialization.
-    #[error("RON serialization")]
+    #[error(transparent)]
     Ron(#[from] ron::Error),
     /// An error occurred in RON deserialization, and the location of the error
     /// is supplied.
-    #[error("RON serialization")]
+    #[error(transparent)]
     SpannedRon(#[from] SpannedError),
     /// The deserialized graph contained legacy data that we no longer support.
     #[error(

--- a/crates/bevy_animation/src/graph.rs
+++ b/crates/bevy_animation/src/graph.rs
@@ -242,14 +242,24 @@ pub enum AnimationNodeType {
 #[derive(Default)]
 pub struct AnimationGraphAssetLoader;
 
-/// Various errors that can occur when serializing or deserializing animation
-/// graphs to and from RON, respectively.
+/// Errors that can occur when serializing animation graphs to RON.
+#[derive(Error, Debug)]
+pub enum AnimationGraphSaveError {
+    /// An I/O error occurred.
+    #[error(transparent)]
+    Io(#[from] io::Error),
+    /// An error occurred in RON serialization.
+    #[error(transparent)]
+    Ron(#[from] ron::Error),
+}
+
+/// Errors that can occur when deserializing animation graphs from RON.
 #[derive(Error, Debug)]
 pub enum AnimationGraphLoadError {
     /// An I/O error occurred.
     #[error("I/O")]
     Io(#[from] io::Error),
-    /// An error occurred in RON serialization or deserialization.
+    /// An error occurred in RON deserialization.
     #[error("RON serialization")]
     Ron(#[from] ron::Error),
     /// An error occurred in RON deserialization, and the location of the error
@@ -648,7 +658,7 @@ impl AnimationGraph {
     ///
     /// If writing to a file, it can later be loaded with the
     /// [`AnimationGraphAssetLoader`] to reconstruct the graph.
-    pub fn save<W>(&self, writer: &mut W) -> Result<(), AnimationGraphLoadError>
+    pub fn save<W>(&self, writer: &mut W) -> Result<(), AnimationGraphSaveError>
     where
         W: Write,
     {

--- a/examples/animation/animation_graph.rs
+++ b/examples/animation/animation_graph.rs
@@ -182,6 +182,10 @@ fn setup_assets_programmatically(
             .spawn(async move {
                 use std::io::Write;
 
+                let animation_graph: SerializedAnimationGraph = animation_graph
+                    .try_into()
+                    .expect("The animation graph failed to convert to its serialized form");
+
                 let serialized_graph =
                     ron::ser::to_string_pretty(&animation_graph, PrettyConfig::default())
                         .expect("Failed to serialize the animation graph");

--- a/release-content/migration-guides/animation_graph_no_more_asset_ids.md
+++ b/release-content/migration-guides/animation_graph_no_more_asset_ids.md
@@ -1,0 +1,20 @@
+---
+title: `AnimationGraph` no longer supports raw AssetIds.
+pull_requests: []
+---
+
+In previous versions of Bevy, `AnimationGraph` would serialize `Handle<AnimationClip>` as an asset
+path, and if that wasn't available it would fallback to serializing `AssetId<AnimationClip>`. In
+practice, this was not very useful. `AssetId` is (usually) a runtime-generated ID. This means for an
+arbitrary `Handle<AnimationClip>`, it was incredibly unlikely that your handle before serialization
+would correspond to the same asset as after serialization.
+
+This confusing behavior has been removed. As a side-effect, any `AnimationGraph`s you previously
+saved (via `AnimationGraph::save`) will need to be re-saved. These legacy `AnimationGraph`s can
+still be loaded until the next Bevy version. Loading and then saving the `AnimationGraph` again will
+automatically migrate the `AnimationGraph`.
+
+If your `AnimationGraph` contained serialized `AssetId`s, you will need to manually load the bytes
+of the saved graph, deserialize it into `SerializedAnimationGraph`, and then manually decide how to
+migrate those `AssetId`s. Alternatively, you could simply rebuild the graph from scratch and save a
+new instance. We expect this to be a very rare situation.


### PR DESCRIPTION
# Objective

- A step towards #19024.
- `AnimationGraph` can serialize raw `AssetId`s. However for normal handles, this is a runtime ID. This means it is unlikely that the `AssetId` will correspond to the same asset after deserializing - effectively breaking the graph.

## Solution

- Stop allowing `AssetId` to be serialized by `AnimationGraph`. Serializing a handle with no path is now an error.
- Add `MigrationSerializedAnimationClip`. This is an untagged enum for serde, meaning that it will take the first variant that deserializes. So it will first try the "modern" version, then it will fallback to the legacy version.
- Add some logging/error messages to explain what users should do.

Note: one limitation here is that this removes the ability to serialize and deserialize UUIDs. In theory, someone could be using this to have a "default" animation. If someone inserts an empty `AnimationClip` into the `Handle::default()`, this **might** produce a T-pose. It might also do nothing though. Unclear! I think this is worth the risk for simplicity as it seems unlikely that people are sticking UUIDs in here (or that you want a default animation in **any** AnimationGraph).

## Testing

- Ran `cargo r --example animation_graph -- --save` on main, then ran `cargo r --example animation_graph` on this PR. The PR was able to load the old data (after #19631).