### PR TITLE
Fixing running `ci` locally in MacOS

### DIFF
--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -1103,10 +1103,6 @@ fn create_pipeline_task(
     target_os = "macos",
     not(feature = "multi_threaded")
 ))]
-#[expect(
-    clippy::large_enum_variant,
-    reason = "See https://github.com/bevyengine/bevy/issues/19220"
-)]
 fn create_pipeline_task(
     task: impl Future<Output = Result<Pipeline, PipelineCacheError>> + Send + 'static,
     _sync: bool,


### PR DESCRIPTION
# Objective

- Running `cargo run --package ci` in MacOS does not currently work in `main`.
- It shows a `error: this lint expectation is unfulfilled`.
- Fixes #19583

## Solution

- Remove an unnecessary `#[expect(clippy::large_enum_variant)]` on a function.

## Testing

- `cargo run --package ci`: 👍
