### PR TITLE
Remove cursor caching

### DIFF
--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -407,16 +407,12 @@ pub(crate) fn changed_windows(
                 }
             }
 
-            if window.cursor_options.grab_mode != cache.window.cursor_options.grab_mode
-                && crate::winit_windows::attempt_grab(winit_window, window.cursor_options.grab_mode)
-                    .is_err()
+            if crate::winit_windows::attempt_grab(winit_window, window.cursor_options.grab_mode).is_err()
             {
                 window.cursor_options.grab_mode = cache.window.cursor_options.grab_mode;
             }
 
-            if window.cursor_options.visible != cache.window.cursor_options.visible {
-                winit_window.set_cursor_visible(window.cursor_options.visible);
-            }
+            winit_window.set_cursor_visible(window.cursor_options.visible);
 
             if window.cursor_options.hit_test != cache.window.cursor_options.hit_test {
                 if let Err(err) = winit_window.set_cursor_hittest(window.cursor_options.hit_test) {


### PR DESCRIPTION
# Objective

- Fixes https://github.com/bevyengine/bevy/issues/19627. As described, forcing cursor locks is super awkward because you have to trick Bevy into clearing its cached cursor state

## Solution

- Disable cursor caching. 
  - Note that this will tell winit to set the cursor options on every `Changed<Window>` 
  - I think this is fine, as these events are rare and this is not an expensive operation
  - If this ends up causing unexpected trouble, we can trivially revert the PR

## Testing

I ran the window_settings.rs, changed the window settings and the cursor capturing to verify that everything still works the same.