### PR TITLE
Fix incorrect description of ClusteredDecal

### DIFF
--- a/crates/bevy_pbr/src/decal/clustered.rs
+++ b/crates/bevy_pbr/src/decal/clustered.rs
@@ -69,7 +69,7 @@ pub struct ClusteredDecalPlugin;
 /// An object that projects a decal onto surfaces within its bounds.
 ///
 /// Conceptually, a clustered decal is a 1×1×1 cube centered on its origin. It
-/// projects the given [`Self::image`] onto surfaces in the +Z direction (thus
+/// projects the given [`Self::image`] onto surfaces in the -Z direction (thus
 /// you may find [`Transform::looking_at`] useful).
 ///
 /// Clustered decals are the highest-quality types of decals that Bevy supports,


### PR DESCRIPTION
The documentation states that ClusteredDecal projects in the +Z direction, but in practice, it projects in the -Z direction, which can be confusing.

# Objective

Fixes #19612