### PR TITLE
`EntityCloner` allow/deny by `BundleId` and `allow_if_new`

### DIFF
--- a/crates/bevy_ecs/src/entity/clone_entities.rs
+++ b/crates/bevy_ecs/src/entity/clone_entities.rs
@@ -689,7 +689,7 @@ impl<'w> EntityClonerBuilder<'w> {
     }
 
     /// Adds all components of the bundle to the list of components to clone.
-    /// 
+    ///
     /// Every component the target already contains will be skipped.
     ///
     /// Note that all components are allowed by default, to clone only explicitly allowed components make sure to call
@@ -719,7 +719,7 @@ impl<'w> EntityClonerBuilder<'w> {
     }
 
     /// Adds all components of the bundle ID to the list of components to clone.
-    /// 
+    ///
     /// Every component the target already contains will be skipped.
     ///
     /// Note that all components are allowed by default, to clone only explicitly allowed components make sure to call
@@ -747,7 +747,7 @@ impl<'w> EntityClonerBuilder<'w> {
     }
 
     /// Extends the list of components to clone.
-    /// 
+    ///
     /// Every component the target already contains will be skipped.
     ///
     /// Note that all components are allowed by default, to clone only explicitly allowed components make sure to call
@@ -773,7 +773,7 @@ impl<'w> EntityClonerBuilder<'w> {
     }
 
     /// Extends the list of components to clone using [`TypeId`]s.
-    /// 
+    ///
     /// Every component the target already contains will be skipped.
     ///
     /// Note that all components are allowed by default, to clone only explicitly allowed components make sure to call


### PR DESCRIPTION
# Objective

I use the `EntityCloner` for my reversible crate and cache operations by storing the relevant `BundleId`. If I want to generate an `EntityCloner` from that I need to fetch the component ids first. (1)
Also, to only clone components the target does not know yet requires me to create a new bundle from ids and the target archetype. (2)

## Solution

1. It is more convenient to give the `BundleId` to the cloner directly so I added methods for that.
2. After #19326 `EntityCloner` becomes aware of the target archetype and with `allow_if_new` methods can itself determine which components to clone.

I renamed the internal field `filter_required` to `filter_if_new` because functionally this describes the behavior of handling required components as well.

It made no sense to me to also add `deny_if_new`. Who would want a component to not be cloned if it the target does not contain it?

## Testing

Added a new test

## Showcase

```rs
EntityCloner::build(&mut world)
    .deny_all()
    .allow_if_new::<A>() // do not clone if target already contains A
    .allow_if_new::<(B, C)>() // if target only contains B, C will be cloned
    .allow_by_bundle_id(bundle_id) // behaves like allow::<(B, C)> if this id belongs to this bundle type
    ...
```
