### PR TITLE
`EntityCloner` tracks required components only at `deny_all` mode and by the amount of requiring components

### DIFF
--- a/crates/bevy_ecs/src/entity/clone_entities.rs
+++ b/crates/bevy_ecs/src/entity/clone_entities.rs
@@ -1356,11 +1356,35 @@ mod tests {
         EntityCloner::build(&mut world)
             .deny_all()
             .allow::<A>()
-            .deny::<A>()
+            .allow::<B>()
+            .deny::<B>()
             .clone_entity(e, e_clone2);
 
-        assert_eq!(world.get::<A>(e_clone2), None);
-        assert_eq!(world.get::<C>(e_clone2), None);
+        assert_eq!(world.get::<A>(e_clone2), Some(&A));
+        assert_eq!(world.get::<C>(e_clone2), Some(&C));
+
+        let e_clone3 = world.spawn_empty().id();
+
+        EntityCloner::build(&mut world)
+            .deny_all()
+            .allow::<A>()
+            .allow::<B>()
+            .deny::<A>()
+            .clone_entity(e, e_clone3);
+
+        assert_eq!(world.get::<A>(e_clone3), None);
+        assert_eq!(world.get::<C>(e_clone3), None);
+
+        let e_clone4 = world.spawn_empty().id();
+
+        EntityCloner::build(&mut world)
+            .deny_all()
+            .allow::<A>()
+            .deny::<A>()
+            .clone_entity(e, e_clone4);
+
+        assert_eq!(world.get::<A>(e_clone4), None);
+        assert_eq!(world.get::<C>(e_clone4), None);
     }
 
     #[test]


### PR DESCRIPTION
# Objective

#19326 made the `EntityCloner` sensitive for required components and inserts it only when the target does not contain them already. However during #19632 I noticed that this concept does not work well with the `allow_all` filtering case, which is the default of `EntityCloner`. Required components are not cloned when you deny a component it is required by but still clone others requiring it too.

## Solution

In the `allow_all` mode required components are not considered at all. If you deny `A` that requires `B`, then `B` still gets cloned even without `A` because it cannot be assumed this is not wanted. This may be the case when `B` alone is useful for certain logic too. In this mode one needs to explicitly deny `B` as well if that is what is wanted.

I also track how often a required component is added to the filter by an explicit component so that denying the requiring component again will only remove the required component from the filter if this counter cannot be reduced any further.

## Testing

I did add tests asserting these cases.