### PR TITLE
deny(missing_docs) for bevy_mikktspace

### DIFF
--- a/crates/bevy_mikktspace/src/lib.rs
+++ b/crates/bevy_mikktspace/src/lib.rs
@@ -16,6 +16,10 @@
 )]
 #![no_std]
 
+//! An implementation of [Mikkelsen's algorithm] for tangent space generation.
+//!
+//! [Mikkelsen's algorithm]: http://www.mikktspace.com
+
 #[cfg(feature = "std")]
 extern crate std;
 

--- a/crates/bevy_mikktspace/src/lib.rs
+++ b/crates/bevy_mikktspace/src/lib.rs
@@ -7,7 +7,7 @@
     unsafe_op_in_unsafe_fn,
     clippy::all,
     clippy::undocumented_unsafe_blocks,
-    clippy::ptr_cast_constness,
+    clippy::ptr_cast_constness
 )]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc(

--- a/crates/bevy_mikktspace/src/lib.rs
+++ b/crates/bevy_mikktspace/src/lib.rs
@@ -8,8 +8,6 @@
     clippy::all,
     clippy::undocumented_unsafe_blocks,
     clippy::ptr_cast_constness,
-    // FIXME(15321): solve CI failures, then replace with `#![expect()]`.
-    missing_docs
 )]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc(


### PR DESCRIPTION
# Objective

Remove allow(missing_docs) from bevy_mikktspace and add a simple top-level doc comment, towards https://github.com/bevyengine/bevy/issues/3492