### PR TITLE
lighting.rs example: Improved ambient light showcase

### DIFF
--- a/examples/3d/lighting.rs
+++ b/examples/3d/lighting.rs
@@ -20,7 +20,15 @@ fn main() {
             sensor_height: 0.01866,
         }))
         .add_systems(Startup, setup)
-        .add_systems(Update, (update_exposure, toggle_ambient_light, movement, animate_light_direction))
+        .add_systems(
+            Update,
+            (
+                update_exposure,
+                toggle_ambient_light,
+                movement,
+                animate_light_direction,
+            ),
+        )
         .run();
 }
 
@@ -198,7 +206,7 @@ fn setup(
             maximum_distance: 10.0,
             ..default()
         }
-            .build(),
+        .build(),
     ));
 
     // example instructions
@@ -289,17 +297,15 @@ fn toggle_ambient_light(
     if key_input.just_pressed(KeyCode::Space) {
         if ambient_light.brightness > 1. {
             ambient_light.brightness = 0.;
-        }
-        else {
+        } else {
             ambient_light.brightness = 200.;
         }
 
         let entity = *text;
-        let ambient_light_state_text: &str =
-            match ambient_light.brightness {
-                0. => "off",
-                _ => "on",
-            };
+        let ambient_light_state_text: &str = match ambient_light.brightness {
+            0. => "off",
+            _ => "on",
+        };
         *writer.text(entity, 1) = format!("Ambient light is {}\n", ambient_light_state_text);
     }
 }

--- a/examples/3d/lighting.rs
+++ b/examples/3d/lighting.rs
@@ -20,7 +20,7 @@ fn main() {
             sensor_height: 0.01866,
         }))
         .add_systems(Startup, setup)
-        .add_systems(Update, (update_exposure, movement, animate_light_direction))
+        .add_systems(Update, (update_exposure, toggle_ambient_light, movement, animate_light_direction))
         .run();
 }
 
@@ -111,9 +111,10 @@ fn setup(
     ));
 
     // ambient light
+    // ambient lights' brightnesses are measured in candela per meter square, calculable as (color * brightness)
     commands.insert_resource(AmbientLight {
         color: ORANGE_RED.into(),
-        brightness: 0.02,
+        brightness: 200.0,
         ..default()
     });
 
@@ -197,7 +198,7 @@ fn setup(
             maximum_distance: 10.0,
             ..default()
         }
-        .build(),
+            .build(),
     ));
 
     // example instructions
@@ -211,6 +212,7 @@ fn setup(
             ..default()
         },
         children![
+            TextSpan::new("Ambient light is on\n"),
             TextSpan(format!("Aperture: f/{:.0}\n", parameters.aperture_f_stops,)),
             TextSpan(format!(
                 "Shutter speed: 1/{:.0}s\n",
@@ -224,6 +226,7 @@ fn setup(
             TextSpan::new("Controls\n"),
             TextSpan::new("---------------\n"),
             TextSpan::new("Arrow keys - Move objects\n"),
+            TextSpan::new("Space - Toggle ambient light\n"),
             TextSpan::new("1/2 - Decrease/Increase aperture\n"),
             TextSpan::new("3/4 - Decrease/Increase shutter speed\n"),
             TextSpan::new("5/6 - Decrease/Increase sensitivity\n"),
@@ -267,14 +270,38 @@ fn update_exposure(
         *parameters = Parameters::default();
     }
 
-    *writer.text(entity, 1) = format!("Aperture: f/{:.0}\n", parameters.aperture_f_stops);
-    *writer.text(entity, 2) = format!(
+    *writer.text(entity, 2) = format!("Aperture: f/{:.0}\n", parameters.aperture_f_stops);
+    *writer.text(entity, 3) = format!(
         "Shutter speed: 1/{:.0}s\n",
         1.0 / parameters.shutter_speed_s
     );
-    *writer.text(entity, 3) = format!("Sensitivity: ISO {:.0}\n", parameters.sensitivity_iso);
+    *writer.text(entity, 4) = format!("Sensitivity: ISO {:.0}\n", parameters.sensitivity_iso);
 
     **exposure = Exposure::from_physical_camera(**parameters);
+}
+
+fn toggle_ambient_light(
+    key_input: Res<ButtonInput<KeyCode>>,
+    mut ambient_light: ResMut<AmbientLight>,
+    text: Single<Entity, With<Text>>,
+    mut writer: TextUiWriter,
+) {
+    if key_input.just_pressed(KeyCode::Space) {
+        if ambient_light.brightness > 1. {
+            ambient_light.brightness = 0.;
+        }
+        else {
+            ambient_light.brightness = 200.;
+        }
+
+        let entity = *text;
+        let ambient_light_state_text: &str =
+            match ambient_light.brightness {
+                0. => "off",
+                _ => "on",
+            };
+        *writer.text(entity, 1) = format!("Ambient light is {}\n", ambient_light_state_text);
+    }
 }
 
 fn animate_light_direction(


### PR DESCRIPTION
# Objective

As someone who is currently learning Bevy, I found the implementation of the ambient light in the 3d/lighting.rs example unsatisfactory. 

## Solution

- I adjusted the brightness of the ambient light in the scene to 200 (where the default is 80). It was previously 0.02, a value so low it has no noticeable effect.
- I added a keybind (space bar) to toggle the ambient light, allowing users to see the difference it makes. I also added text showing the state of the ambient light (on, off) and text showing the keybind.

I'm very new to Bevy and Rust, so apologies if any of this code is not up to scratch.

## Testing

I checked all the text still updates correctly and all keybinds still work. In my testing, it looks to work okay.
I'd appreciate others testing too, just to make sure. 

---

## Showcase

<details>
  <summary>Click to view showcase</summary>
<img width="960" alt="Screenshot (11)" src="https://github.com/user-attachments/assets/916e569e-cd49-43fd-b81d-aae600890cd3" />
<img width="959" alt="Screenshot (12)" src="https://github.com/user-attachments/assets/0e16bb3a-c38a-4a8d-8248-edf3b820d238" />
</details>
