### PR TITLE
Fix Keyboard observer not updating SliderValue

### DIFF
--- a/crates/bevy_core_widgets/src/core_slider.rs
+++ b/crates/bevy_core_widgets/src/core_slider.rs
@@ -394,6 +394,10 @@ fn slider_on_key_input(
             trigger.propagate(false);
             if let Some(on_change) = slider.on_change {
                 commands.run_system_with(on_change, new_value);
+            } else {
+                commands
+                    .entity(trigger.target().unwrap())
+                    .insert(SliderValue(new_value));
             }
         }
     }

--- a/crates/bevy_core_widgets/src/core_slider.rs
+++ b/crates/bevy_core_widgets/src/core_slider.rs
@@ -396,7 +396,7 @@ fn slider_on_key_input(
                 commands.run_system_with(on_change, new_value);
             } else {
                 commands
-                    .entity(trigger.target().unwrap())
+                    .entity(trigger.target())
                     .insert(SliderValue(new_value));
             }
         }


### PR DESCRIPTION
# Objective

When the `CoreSlider`s `on_change` is set to None, Keyboard input, like ArrowKeys, does not update the `SliderValue`.

## Solution

Handle the missing case, like it is done for Pointer.

## Testing

- Did you test these changes?
Yes: core_widgets & core_widgets_observers
in both examples one has to remove / comment out the setting of `CoreSlider::on_change` to test the case of `on_change` being none.

- Are there any parts that need more testing?
No not that I am aware of.

- How can other people (reviewers) test your changes? Is there anything specific they need to know?
Yes: core_widgets & core_widgets_observers
in both examples one has to remove / comment out the setting of `CoreSlider::on_change` to test the case of `on_change` being none.

- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?
I tested on linux + wayland. But it is unlikely that it would effect outcomes.
