### PR TITLE
trigger `Text` & `Text2d` re-render when `Children` is removed

### DIFF
--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -131,7 +131,9 @@ impl Plugin for TextPlugin {
                     .in_set(Text2dUpdateSystems)
                     .after(AnimationSystems),
             )
-            .add_systems(Last, trim_cosmic_cache);
+            .add_systems(Last, trim_cosmic_cache)
+            .add_observer(enable_text_node_needs_rerender_detection::<TextSpan>)
+            .add_observer(enable_text_node_needs_rerender_detection::<Text2d>);
 
         if let Some(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app.add_systems(

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -578,3 +578,44 @@ pub fn detect_text_needs_rerender<Root: Component>(
         }
     }
 }
+
+/// Observer system that ensures all entities with the `Tracked` [`Component`] will be able to trigger
+/// [`detect_text_needs_rerender_on_child_removed`].
+pub fn enable_text_node_needs_rerender_detection<Tracked: Component>(
+    trigger: On<Add, Tracked>,
+    mut commands: Commands,
+) {
+    let Ok(mut entity) = commands.get_entity(trigger.target()) else {
+        return;
+    };
+
+    entity.observe(detect_text_needs_rerender_on_child_removed);
+}
+
+/// Observer system that detects when text blocks get their last child removed and sets
+/// `ComputedTextBlock::should_rerender`.
+pub fn detect_text_needs_rerender_on_child_removed(
+    trigger: On<Remove, Children>,
+    // `With<TextFont>` included to bail on non-text nodes
+    mut texts: Query<(&ChildOf, Option<&mut ComputedTextBlock>), With<TextFont>>,
+) {
+    let mut entity = trigger.target();
+    let mut computed = loop {
+        match texts.get_mut(entity) {
+            // we stop at the first computed text block encountered
+            Ok((_, Some(computed))) => break computed,
+            Ok((parent, None)) => entity = parent.0,
+            Err(_) => {
+                // This warning is less useful than the one in `detect_text_needs_rerender`,
+                // we don't know the type name of the root
+                once!(warn!(
+                    "found entity {} with a TextFont that has no ancestor with a root text \
+                    component; this warning only prints once",
+                    entity,
+                ));
+                return;
+            }
+        }
+    };
+    computed.needs_rerender = true;
+}

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -318,6 +318,7 @@ fn build_text_interop(app: &mut App) {
                 .ambiguous_with(bevy_text::calculate_bounds_text2d),
         ),
     );
+    app.add_observer(bevy_text::enable_text_node_needs_rerender_detection::<Text>);
 
     app.add_plugins(accessibility::AccessibilityPlugin);
 


### PR DESCRIPTION
# Objective

As of at least bevy 0.16.0, Removing `Children` from a `Text` Node would not be detected by `bevy_text::text::detect_text_needs_rerender`, leading to rendering glitches (#19657). After pinning down the bug, the same happens with `Text2d`, assuming its docs are correct about its use of `TextSpan` (I didn't actually went down the rabbit hole a second time to make sure).

Fixes #19657

## Solution

- Observe `On<Remove, Children>`, and query then set `ComputedTextBlock.needs_rerendering` if present.

## Testing

- The reproducer in #19657 works as intended, I did some extra logging and monitoring to be extra sure too.
