### PR TITLE
slider widget track click position `UiScale` fix

### DIFF
--- a/crates/bevy_core_widgets/src/core_slider.rs
+++ b/crates/bevy_core_widgets/src/core_slider.rs
@@ -210,6 +210,7 @@ pub(crate) fn slider_on_pointer_down(
     focus: Option<ResMut<InputFocus>>,
     focus_visible: Option<ResMut<InputFocusVisible>>,
     mut commands: Commands,
+    ui_scale: Res<UiScale>,
 ) {
     if q_thumb.contains(trigger.target().unwrap()) {
         // Thumb click, stop propagation to prevent track click.
@@ -254,7 +255,7 @@ pub(crate) fn slider_on_pointer_down(
 
         // Detect track click.
         let local_pos = transform.try_inverse().unwrap().transform_point2(
-            trigger.event().pointer_location.position * node_target.scale_factor(),
+            trigger.event().pointer_location.position * node_target.scale_factor() / ui_scale.0,
         );
         let track_width = node.size().x - thumb_size;
         // Avoid division by zero


### PR DESCRIPTION
# Objective

The position for track clicks in `core_slider` is calculated incorrectly when using `UiScale`.

## Solution

`trigger.event().pointer_location.position` uses logical window coordinates, that is:

`position = physical_position / window_scale_factor`

while `ComputedNodeTarget::scale_factor` returns the window scale factor multiplied by Ui Scale:

`target_scale_factor = window_scale_factor * ui_scale`

So to get the physical position need to divide by the `UiScale`:

```
position * target_scale_factor / ui_scale
= (physical_postion / window_scale_factor) * (window_scale_factor * ui_scale) / ui_scale
=  physical_position
```

I thought this was fixed during the slider PR review, but must have got missed somewhere or lost in a merge.

## Testing

Can test using the `core_widgets` example` with `.insert_resource(UiScale(2.))` added to the bevy app.
