### PR TITLE
Register `ReflectSerialize` for &'static str

### DIFF
--- a/crates/bevy_reflect/src/impls/core/primitives.rs
+++ b/crates/bevy_reflect/src/impls/core/primitives.rs
@@ -282,6 +282,7 @@ impl GetTypeRegistration for &'static str {
         let mut registration = TypeRegistration::of::<Self>();
         registration.insert::<ReflectFromPtr>(FromType::<Self>::from_type());
         registration.insert::<ReflectFromReflect>(FromType::<Self>::from_type());
+        registration.insert::<ReflectSerialize>(FromType::<Self>::from_type());
         registration
     }
 }


### PR DESCRIPTION
# Objective

- When trying to serialize an structure that contains `&'static str` using only Reflection, I get the following error:
```
"type `&str` did not register the `ReflectSerialize` or `ReflectSerializeWithRegistry` type data. 
For certain types, this may need to be registered manually using `register_type_data` (stack: ... -> `core::option::Option<&str>` -> `&str`)")
```
## Solution

- Register `ReflectSerialize` for `&str`

## Testing

- `cargo run -p ci`: OK


