### PR TITLE
Make `Entity::from_raw_and_generation` public

### DIFF
--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -448,7 +448,7 @@ impl Entity {
     /// Construct an [`Entity`] from a raw `row` value and a non-zero `generation` value.
     /// Ensure that the generation value is never greater than `0x7FFF_FFFF`.
     #[inline(always)]
-    pub fn from_raw_and_generation(row: EntityRow, generation: EntityGeneration) -> Entity {
+    pub const fn from_raw_and_generation(row: EntityRow, generation: EntityGeneration) -> Entity {
         Self { row, generation }
     }
 


### PR DESCRIPTION
# Objective

Constructing an entity manually with a specific index/generation is annoying to do today - change that by exposing  `Entity::from_raw_and_generation`.

## Solution

Make `Entity::from_raw_and_generation` public allowing its use outside of bevy core. 

Note that creating an entity with a specific index/generation is possible today using the already public `Entity::from_bits` api - library authors have already been using this as a workaround for internal data structures (avian previously, bevy_replicon for serialization etc.). Overall sentiment from users[ on discord](https://discord.com/channels/691052431525675048/749335865876021248/1372386052924510220) is that this would be a welcome change/ it's frustrating that this isn't public already.

## Risks

Making this easier can lead to issues for users who don't know what they're doing - a scary comment discouraging this api's use could be warranted.

## Alternatives

Make users who want to do these things continue writing their own

```rust
#[inline(always)]
pub const fn from_raw_and_generation(row: u32, generation: u32) -> Entity {
    let bits: u64 = row as u64 | ((generation as u64) << 32);
    Entity::from_bits(bits)
}
```
