### PR TITLE
Allow retrieving full asset path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1782,6 +1782,17 @@ category = "Assets"
 wasm = false
 
 [[example]]
+name = "full_asset_path"
+path = "examples/asset/full_asset_path.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.full_asset_path]
+name = "Full Asset Path"
+description = "Shows how to get the full path of an asset that was loaded from disk"
+category = "Assets"
+wasm = false
+
+[[example]]
 name = "asset_settings"
 path = "examples/asset/asset_settings.rs"
 doc-scrape-examples = true

--- a/crates/bevy_asset/src/io/mod.rs
+++ b/crates/bevy_asset/src/io/mod.rs
@@ -827,7 +827,7 @@ impl FullAssetPathProvider {
 #[cfg(not(target_arch = "wasm32"))]
 /// Error returned by [`FullAssetPathProvider::full_asset_path`].
 #[derive(Debug, thiserror::Error)]
-pub(super) enum FullAssetPathError {
+pub enum FullAssetPathError {
     #[error("Asset path is not coming from the default source: {0}")]
     NonDefaultSource(String),
 }

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -207,6 +207,8 @@ pub use server::*;
 pub use ron;
 pub use uuid;
 
+#[cfg(not(target_arch = "wasm32"))]
+use crate::io::FullAssetPathProvider;
 use crate::{
     io::{embedded::EmbeddedAssetRegistry, AssetSourceBuilder, AssetSourceBuilders, AssetSourceId},
     processor::{AssetProcessor, Process},
@@ -226,6 +228,8 @@ use bevy_ecs::{
 use bevy_platform::collections::HashSet;
 use bevy_reflect::{FromReflect, GetTypeRegistration, Reflect, TypePath};
 use core::any::TypeId;
+#[cfg(not(target_arch = "wasm32"))]
+use std::path::PathBuf;
 use tracing::error;
 
 /// Provides "asset" loading and processing functionality. An [`Asset`] is a "runtime value" that is loaded from an [`AssetSource`],
@@ -424,6 +428,13 @@ impl Plugin for AssetPlugin {
             // needs to be robust to stochastic delays anyways.
             .add_systems(PreUpdate, handle_internal_asset_events.ambiguous_with_all())
             .register_type::<AssetPath>();
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            app.insert_resource(FullAssetPathProvider {
+                relative_assets_dir: PathBuf::from(self.file_path.clone()),
+            });
+            app.register_type::<FullAssetPathProvider>();
+        }
     }
 }
 

--- a/examples/asset/full_asset_path.rs
+++ b/examples/asset/full_asset_path.rs
@@ -1,0 +1,55 @@
+//! Shows how to get the full path of an asset that was loaded from disk.
+
+use bevy::{asset::io::FullAssetPathProvider, prelude::*};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_systems(Startup, setup)
+        .add_observer(print_full_asset_path)
+        .run();
+}
+
+fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    commands.spawn(Camera2d);
+
+    commands.spawn((
+        Sprite::from_image(asset_server.load("branding/icon.png")),
+        Transform::from_xyz(-300., 0., 0.),
+    ));
+
+    commands.spawn((
+        Sprite::from_image(asset_server.load("textures/Game Icons/wrench.png")),
+        Transform::from_xyz(0., 0., 0.),
+    ));
+
+    commands.spawn((
+        Sprite::from_image(asset_server.load("textures/Game Icons/right.png")),
+        Transform::from_xyz(300., 0., 0.),
+    ));
+}
+
+/// Every time a sprite is added, we print the full asset path.
+/// We use `Sprite` here, which contains a `Handle<Image>`, but it works with any kind of `Handle<T>`.
+fn print_full_asset_path(
+    trigger: On<Add, Sprite>,
+    sprites: Query<&Sprite>,
+    full_path_provider: Res<FullAssetPathProvider>,
+) {
+    let entity = trigger.target();
+    let Ok(sprite) = sprites.get(entity) else {
+        return;
+    };
+    let Some(asset_path) = sprite.image.path() else {
+        error!("The loaded sprite has no asset path");
+        return;
+    };
+    match full_path_provider.full_asset_path(&asset_path) {
+        Ok(full_path) => info!("Full asset path: {:?}", full_path),
+        Err(e) => error!(
+            "Failed to get full asset path for {}: {}",
+            asset_path.path().display(),
+            e
+        ),
+    }
+}


### PR DESCRIPTION
# Objective

- Fixes #19695
- Getting the full path to an asset is really hard, see #19695 for why and how

## Solution

- Provide an API for it! Users can now use the `FullAssetPathProvider` resource on all platforms that support `FileAssetReader`

## Testing

- Wrote an example to validate that everything works correctly :)

---

## Showcase

You can now use the new resource `FullAssetPathProvider` to get the full path to an asset that was loaded from disk:
```rust
fn print_full_asset_path(
    trigger: On<Add, Sprite>,
    sprites: Query<&Sprite>,
    full_path_provider: Res<FullAssetPathProvider>,
) {
    let entity = trigger.target();
    let Ok(sprite) = sprites.get(entity) else {
        return;
    };
    let Some(asset_path) = sprite.image.path() else {
        error!("The loaded sprite has no asset path");
        return;
    };
    match full_path_provider.full_asset_path(&asset_path) {
        Ok(full_path) => info!("Full asset path: {:?}", full_path),
        Err(e) => error!(
            "Failed to get full asset path for {}: {}",
            asset_path.path().display(),
            e
        ),
    }
}
```

</details>
