### PR TITLE
Add entities alongside resources

### DIFF
--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -8,7 +8,7 @@ use crate::{
     lifecycle::{ComponentHook, ComponentHooks},
     query::DebugCheckedUnwrap,
     resource::Resource,
-    storage::{SparseSetIndex, SparseSets, Table, TableRow},
+    storage::{SparseSetIndex, SparseSets, Storages, Table, TableRow},
     system::{Local, SystemParam},
     world::{FromWorld, World},
 };
@@ -1734,6 +1734,9 @@ impl<'w> ComponentsRegistrator<'w> {
 pub struct Components {
     components: Vec<Option<ComponentInfo>>,
     indices: TypeIdMap<ComponentId>,
+    // Each resource corresponds to a single entity,
+    // and the resource data is stored as a component on that entity:
+    resource_entities: HashMap<ComponentId, Entity>,
     resource_indices: TypeIdMap<ComponentId>,
     // This is kept internal and local to verify that no deadlocks can occor.
     queued: bevy_platform::sync::RwLock<QueuedComponents>,
@@ -1761,6 +1764,65 @@ impl Components {
         // Caller ensures id is unique
         debug_assert!(slot.is_none());
         *slot = Some(info);
+    }
+
+    /// Store a new resource entity of type `R`.
+    ///
+    /// This doesn't register the Resource, it must first be registered via `ComponentsRegistrator`.
+    #[expect(dead_code, reason = "resources as entities work in progress")]
+    #[inline]
+    pub(crate) fn cache_resource_entity<R: Resource>(
+        &mut self,
+        _storages: &mut Storages,
+        entity: Entity,
+    ) {
+        if let Some(id) = self.resource_id::<R>() {
+            self.cache_resource_entity_by_id(entity, id);
+        }
+    }
+
+    /// Stores a new resource entity associated with the given component ID.
+    #[inline]
+    pub(crate) fn cache_resource_entity_by_id(&mut self, entity: Entity, id: ComponentId) {
+        self.resource_entities.insert(id, entity);
+    }
+
+    /// Removes the resource entity associated
+    #[inline]
+    pub(crate) fn remove_resource_entity<R: Resource>(&mut self) -> Option<Entity> {
+        let Some(id) = self.resource_id::<R>() else {
+            // If the component ID was not found, we can't have registered an entity of this type
+            return None;
+        };
+
+        self.remove_resource_entity_by_id(id)
+    }
+
+    /// Removes the resource entity associated with the given component ID.
+    #[inline]
+    pub(crate) fn remove_resource_entity_by_id(&mut self, id: ComponentId) -> Option<Entity> {
+        self.resource_entities.remove(&id)
+    }
+
+    /// Looks up the entity associated with the given resource by type.
+    ///
+    /// If no such entity exists, this will return `None`.
+    ///
+    /// Also see [`Components::get_resource_entity_by_id`].
+    #[inline]
+    pub fn get_resource_entity<R: Resource>(&self) -> Option<Entity> {
+        let id = self.resource_id::<R>()?;
+        self.get_resource_entity_by_id(id)
+    }
+
+    /// Looks up the entity associated with the given resource by [`ComponentId`].
+    ///
+    /// If no such entity exists, this will return `None`.
+    ///
+    /// Also see [`Components::get_resource_entity`].
+    #[inline]
+    pub fn get_resource_entity_by_id(&self, id: ComponentId) -> Option<Entity> {
+        self.resource_entities.get(&id).copied()
     }
 
     /// Returns the number of components registered or queued with this instance.

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -1825,6 +1825,11 @@ impl Components {
         self.resource_entities.get(&id).copied()
     }
 
+    /// Return the number of registered resources.
+    pub fn num_resources(&self) -> usize {
+        return self.resource_entities.len();
+    }
+
     /// Returns the number of components registered or queued with this instance.
     #[inline]
     pub fn len(&self) -> usize {

--- a/crates/bevy_ecs/src/entity_disabling.rs
+++ b/crates/bevy_ecs/src/entity_disabling.rs
@@ -207,6 +207,7 @@ mod tests {
     use crate::{
         prelude::World,
         query::{Has, With},
+        resource::IsResource,
     };
     use alloc::{vec, vec::Vec};
 
@@ -277,6 +278,9 @@ mod tests {
     fn multiple_disabling_components() {
         let mut world = World::new();
         world.register_disabling_component::<CustomDisabled>();
+
+        // We don't want to query resources for this test.
+        world.register_disabling_component::<IsResource>();
 
         world.spawn_empty();
         world.spawn(Disabled);

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1790,7 +1790,7 @@ mod tests {
     fn try_insert_batch() {
         let mut world = World::default();
         let e0 = world.spawn(A(0)).id();
-        let e1 = Entity::from_raw_u32(1).unwrap();
+        let e1 = Entity::from_raw_u32(2).unwrap();
 
         let values = vec![(e0, (A(1), B(0))), (e1, (A(0), B(1)))];
 
@@ -1814,7 +1814,7 @@ mod tests {
     fn try_insert_batch_if_new() {
         let mut world = World::default();
         let e0 = world.spawn(A(0)).id();
-        let e1 = Entity::from_raw_u32(1).unwrap();
+        let e1 = Entity::from_raw_u32(2).unwrap();
 
         let values = vec![(e0, (A(1), B(0))), (e1, (A(0), B(1)))];
 

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -375,11 +375,12 @@ mod tests {
     #[test]
     fn despawn_table_storage() {
         let mut world = World::new();
+        let num_resources = world.components().num_resources() as u32;
         let e = world.spawn((TableStored("abc"), A(123))).id();
         let f = world.spawn((TableStored("def"), A(456))).id();
-        assert_eq!(world.entities.len(), 2);
+        assert_eq!(world.entities.len() - num_resources, 2);
         assert!(world.despawn(e));
-        assert_eq!(world.entities.len(), 1);
+        assert_eq!(world.entities.len() - num_resources, 1);
         assert!(world.get::<TableStored>(e).is_none());
         assert!(world.get::<A>(e).is_none());
         assert_eq!(world.get::<TableStored>(f).unwrap().0, "def");
@@ -389,12 +390,13 @@ mod tests {
     #[test]
     fn despawn_mixed_storage() {
         let mut world = World::new();
+        let num_resources = world.components().num_resources() as u32;
 
         let e = world.spawn((TableStored("abc"), SparseStored(123))).id();
         let f = world.spawn((TableStored("def"), SparseStored(456))).id();
-        assert_eq!(world.entities.len(), 2);
+        assert_eq!(world.entities.len() - num_resources, 2);
         assert!(world.despawn(e));
-        assert_eq!(world.entities.len(), 1);
+        assert_eq!(world.entities.len() - num_resources, 1);
         assert!(world.get::<TableStored>(e).is_none());
         assert!(world.get::<SparseStored>(e).is_none());
         assert_eq!(world.get::<TableStored>(f).unwrap().0, "def");
@@ -1634,12 +1636,13 @@ mod tests {
         world.spawn(A(1));
         world.spawn(SparseStored(1));
 
+        let num_resources = world.components().num_resources() as u32;
         let mut q1 = world.query::<&A>();
         let mut q2 = world.query::<&SparseStored>();
 
         assert_eq!(q1.iter(&world).len(), 1);
         assert_eq!(q2.iter(&world).len(), 1);
-        assert_eq!(world.entities().len(), 2);
+        assert_eq!(world.entities().len() - num_resources, 2);
 
         world.clear_entities();
 

--- a/crates/bevy_ecs/src/name.rs
+++ b/crates/bevy_ecs/src/name.rs
@@ -275,7 +275,7 @@ mod tests {
         let mut query = world.query::<NameOrEntity>();
         let d1 = query.get(&world, e1).unwrap();
         // NameOrEntity Display for entities without a Name should be {index}v{generation}
-        assert_eq!(d1.to_string(), "0v0");
+        assert_eq!(d1.to_string(), "1v0");
         let d2 = query.get(&world, e2).unwrap();
         // NameOrEntity Display for entities with a Name should be the Name
         assert_eq!(d2.to_string(), "MyName");

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -1308,6 +1308,7 @@ mod tests {
     fn observer_multiple_listeners() {
         let mut world = World::new();
         world.init_resource::<Order>();
+        let num_resources = world.components().num_resources() as u32;
 
         world.add_observer(|_: On<Add, A>, mut res: ResMut<Order>| res.observed("add_1"));
         world.add_observer(|_: On<Add, A>, mut res: ResMut<Order>| res.observed("add_2"));
@@ -1315,7 +1316,7 @@ mod tests {
         world.spawn(A).flush();
         assert_eq!(vec!["add_2", "add_1"], world.resource::<Order>().0);
         // Our A entity plus our two observers
-        assert_eq!(world.entities().len(), 3);
+        assert_eq!(world.entities().len() - num_resources, 3);
     }
 
     #[test]

--- a/crates/bevy_ecs/src/query/builder.rs
+++ b/crates/bevy_ecs/src/query/builder.rs
@@ -275,6 +275,7 @@ impl<'w, D: QueryData, F: QueryFilter> QueryBuilder<'w, D, F> {
 mod tests {
     use crate::{
         prelude::*,
+        resource::IsResource,
         world::{EntityMutExcept, EntityRefExcept, FilteredEntityMut, FilteredEntityRef},
     };
     use std::dbg;
@@ -332,6 +333,9 @@ mod tests {
     #[test]
     fn builder_or() {
         let mut world = World::new();
+        // We don't want to query resources for this test.
+        world.register_disabling_component::<IsResource>();
+
         world.spawn((A(0), B(0)));
         world.spawn(B(0));
         world.spawn(C(0));

--- a/crates/bevy_ecs/src/query/builder.rs
+++ b/crates/bevy_ecs/src/query/builder.rs
@@ -487,7 +487,10 @@ mod tests {
         assert!(entity_ref.get::<B>().is_some());
         assert!(entity_ref.get_mut::<B>().is_none());
 
-        let mut query = QueryBuilder::<(FilteredEntityMut, EntityMutExcept<A>)>::new(&mut world)
+        let mut query =
+            QueryBuilder::<(FilteredEntityMut, EntityMutExcept<A>), Without<IsResource>>::new(
+                &mut world,
+            )
             .data::<EntityMut>()
             .build();
 
@@ -498,7 +501,10 @@ mod tests {
         assert!(entity_ref_1.get::<B>().is_none());
         assert!(entity_ref_1.get_mut::<B>().is_none());
 
-        let mut query = QueryBuilder::<(FilteredEntityMut, EntityRefExcept<A>)>::new(&mut world)
+        let mut query =
+            QueryBuilder::<(FilteredEntityMut, EntityRefExcept<A>), Without<IsResource>>::new(
+                &mut world,
+            )
             .data::<EntityMut>()
             .build();
 

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -2604,6 +2604,7 @@ mod tests {
     use crate::component::Component;
     use crate::entity::Entity;
     use crate::prelude::World;
+    use crate::resource::IsResource;
 
     #[derive(Component, Debug, PartialEq, PartialOrd, Clone, Copy)]
     struct A(f32);
@@ -2614,6 +2615,9 @@ mod tests {
     #[test]
     fn query_iter_sorts() {
         let mut world = World::new();
+        // We don't want to query resources for this test.
+        world.register_disabling_component::<IsResource>();
+
         for i in 0..100 {
             world.spawn(A(i as f32));
             world.spawn((A(i as f32), Sparse(i)));

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -1776,6 +1776,7 @@ mod tests {
         component::Component,
         entity_disabling::DefaultQueryFilters,
         prelude::*,
+        resource::IsResource,
         system::{QueryLens, RunSystemOnce},
         world::{FilteredEntityMut, FilteredEntityRef},
     };
@@ -1849,6 +1850,9 @@ mod tests {
     #[test]
     fn can_transmute_empty_tuple() {
         let mut world = World::new();
+        // We don't want to query resources for this test.
+        world.register_disabling_component::<IsResource>();
+
         world.register_component::<A>();
         let entity = world.spawn(A(10)).id();
 
@@ -2195,6 +2199,8 @@ mod tests {
         let mut df = DefaultQueryFilters::empty();
         df.register_disabling_component(world.register_component::<C>());
         world.insert_resource(df);
+        // Additionally, we want to ignore resources for this test.
+        world.register_disabling_component::<IsResource>();
 
         // Without<C> only matches the first entity
         let mut query = QueryState::<()>::new(&mut world);
@@ -2227,6 +2233,7 @@ mod tests {
     #[test]
     fn query_default_filters_updates_is_dense() {
         let mut world = World::new();
+        let num_resources = world.components().num_resources();
         world.spawn((Table, Sparse));
         world.spawn(Table);
         world.spawn(Sparse);
@@ -2234,7 +2241,7 @@ mod tests {
         let mut query = QueryState::<()>::new(&mut world);
         // There are no sparse components involved thus the query is dense
         assert!(query.is_dense);
-        assert_eq!(3, query.iter(&world).count());
+        assert_eq!(3, query.iter(&world).count() - num_resources);
 
         let mut df = DefaultQueryFilters::empty();
         df.register_disabling_component(world.register_component::<Sparse>());
@@ -2243,8 +2250,10 @@ mod tests {
         let mut query = QueryState::<()>::new(&mut world);
         // The query doesn't ask for sparse components, but the default filters adds
         // a sparse components thus it is NOT dense
+        // Moreover, we subtract the number of resources (which are also entities)
+        // They would normally be excluded, but default filters are skipped
         assert!(!query.is_dense);
-        assert_eq!(1, query.iter(&world).count());
+        assert_eq!(1, query.iter(&world).count() - num_resources);
 
         let mut df = DefaultQueryFilters::empty();
         df.register_disabling_component(world.register_component::<Table>());
@@ -2253,7 +2262,7 @@ mod tests {
         let mut query = QueryState::<()>::new(&mut world);
         // If the filter is instead a table components, the query can still be dense
         assert!(query.is_dense);
-        assert_eq!(1, query.iter(&world).count());
+        assert_eq!(1, query.iter(&world).count() - num_resources);
 
         let mut query = QueryState::<&Sparse>::new(&mut world);
         // But only if the original query was dense

--- a/crates/bevy_ecs/src/relationship/relationship_source_collection.rs
+++ b/crates/bevy_ecs/src/relationship/relationship_source_collection.rs
@@ -693,7 +693,7 @@ mod tests {
 
         #[derive(Component)]
         #[relationship_target(relationship = Rel, linked_spawn)]
-        struct RelTarget(EntityHashSet);
+        struct RelTarget(Vec<Entity>);
 
         let mut world = World::new();
         let a = world.spawn_empty().id();
@@ -708,7 +708,7 @@ mod tests {
         let collection = rel_target.collection();
 
         // Insertions should maintain ordering
-        assert!(collection.iter().eq(&[d, c, b]));
+        assert!(collection.iter().eq([b, c, d]));
 
         world.entity_mut(c).despawn();
 
@@ -716,7 +716,7 @@ mod tests {
         let collection = rel_target.collection();
 
         // Removals should maintain ordering
-        assert!(collection.iter().eq(&[d, b]));
+        assert!(collection.iter().eq([b, d]));
     }
 
     #[test]

--- a/crates/bevy_ecs/src/resource.rs
+++ b/crates/bevy_ecs/src/resource.rs
@@ -1,7 +1,9 @@
 //! Resources are unique, singleton-like data types that can be accessed from systems and stored in the [`World`](crate::world::World).
 
+use crate::prelude::Component;
 // The derive macro for the `Resource` trait
 pub use bevy_ecs_macros::Resource;
+use core::marker::PhantomData;
 
 /// A type that can be inserted into a [`World`] as a singleton.
 ///
@@ -73,3 +75,30 @@ pub use bevy_ecs_macros::Resource;
     note = "consider annotating `{Self}` with `#[derive(Resource)]`"
 )]
 pub trait Resource: Send + Sync + 'static {}
+
+/// A marker component for the entity that stores the resource of type `T`.
+///
+/// This component is automatically inserted when a resource of type `T` is inserted into the world,
+/// and can be used to find the entity that stores a particular resource.
+///
+/// By contrast, the [`IsResource`] component is used to find all entities that store resources,
+/// regardless of the type of resource they store.
+///
+/// This component comes with a hook that ensures that at most one entity has this component for any given `R`:
+/// adding this component to an entity (or spawning an entity with this component) will despawn any other entity with this component.
+#[derive(Component, Debug)]
+#[require(IsResource)]
+pub struct ResourceEntity<R: Resource>(PhantomData<R>);
+
+impl<R: Resource> Default for ResourceEntity<R> {
+    fn default() -> Self {
+        ResourceEntity(PhantomData)
+    }
+}
+
+/// A marker component for entities which store resources.
+///
+/// By contrast, the [`ResourceEntity<R>`] component is used to find the entity that stores a particular resource.
+/// This component is required by the [`ResourceEntity<R>`] component, and will automatically be added.
+#[derive(Component, Default, Debug)]
+pub struct IsResource;

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -2338,11 +2338,12 @@ mod tests {
     fn commands() {
         let mut world = World::default();
         let mut command_queue = CommandQueue::default();
+        let num_resources = world.components().num_resources() as u32;
         let entity = Commands::new(&mut command_queue, &world)
             .spawn((W(1u32), W(2u64)))
             .id();
         command_queue.apply(&mut world);
-        assert_eq!(world.entities().len(), 1);
+        assert_eq!(world.entities().len() - num_resources, 1);
         let results = world
             .query::<(&W<u32>, &W<u64>)>()
             .iter(&world)

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -412,7 +412,8 @@ mod tests {
         name::Name,
         prelude::{Add, AnyOf, EntityRef, On},
         query::{Added, Changed, Or, SpawnDetails, Spawned, With, Without},
-        resource::Resource,
+        removal_detection::RemovedComponents,
+        resource::{IsResource, Resource},
         schedule::{
             common_conditions::resource_exists, ApplyDeferred, IntoScheduleConfigs, Schedule,
             SystemCondition,
@@ -1332,8 +1333,9 @@ mod tests {
         world.spawn_empty();
         let spawn_tick = world.change_tick();
 
-        let mut system_state: SystemState<Option<Single<SpawnDetails, Spawned>>> =
-            SystemState::new(&mut world);
+        let mut system_state: SystemState<
+            Option<Single<SpawnDetails, (Spawned, Without<IsResource>)>>,
+        > = SystemState::new(&mut world);
         {
             let query = system_state.get(&world);
             assert_eq!(query.unwrap().spawned_at(), spawn_tick);

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -412,7 +412,6 @@ mod tests {
         name::Name,
         prelude::{Add, AnyOf, EntityRef, On},
         query::{Added, Changed, Or, SpawnDetails, Spawned, With, Without},
-        removal_detection::RemovedComponents,
         resource::{IsResource, Resource},
         schedule::{
             common_conditions::resource_exists, ApplyDeferred, IntoScheduleConfigs, Schedule,

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -452,9 +452,10 @@ mod tests {
     #[test]
     fn command_processing() {
         let mut world = World::new();
-        assert_eq!(world.entities.len(), 0);
+        let num_resources = world.components().num_resources() as u32;
+        assert_eq!(world.entities.len() - num_resources, 0);
         world.run_system_once(spawn_entity).unwrap();
-        assert_eq!(world.entities.len(), 1);
+        assert_eq!(world.entities.len() - num_resources, 1);
     }
 
     #[test]

--- a/crates/bevy_ecs/src/world/command_queue.rs
+++ b/crates/bevy_ecs/src/world/command_queue.rs
@@ -421,14 +421,15 @@ mod test {
         queue.push(SpawnCommand);
 
         let mut world = World::new();
+        let num_resources = world.components().num_resources() as u32;
         queue.apply(&mut world);
 
-        assert_eq!(world.entities().len(), 2);
+        assert_eq!(world.entities().len() - num_resources, 2);
 
         // The previous call to `apply` cleared the queue.
         // This call should do nothing.
         queue.apply(&mut world);
-        assert_eq!(world.entities().len(), 2);
+        assert_eq!(world.entities().len() - num_resources, 2);
     }
 
     #[expect(
@@ -452,6 +453,7 @@ mod test {
         queue.push(SpawnCommand);
 
         let mut world = World::new();
+        let num_resources = world.components().num_resources() as u32;
 
         let _ = std::panic::catch_unwind(AssertUnwindSafe(|| {
             queue.apply(&mut world);
@@ -462,7 +464,7 @@ mod test {
         queue.push(SpawnCommand);
         queue.push(SpawnCommand);
         queue.apply(&mut world);
-        assert_eq!(world.entities().len(), 3);
+        assert_eq!(world.entities().len() - num_resources, 3);
     }
 
     #[test]

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -4766,6 +4766,7 @@ mod tests {
         change_detection::{MaybeLocation, MutUntyped},
         component::ComponentId,
         prelude::*,
+        resource::IsResource,
         system::{assert_is_system, RunSystemOnce as _},
         world::{error::EntityComponentError, DeferredWorld, FilteredEntityMut, FilteredEntityRef},
     };
@@ -5152,7 +5153,8 @@ mod tests {
 
         world.spawn(TestComponent(0)).insert(TestComponent2(0));
 
-        let mut query = world.query::<EntityRefExcept<TestComponent>>();
+        let mut query =
+            world.query_filtered::<EntityRefExcept<TestComponent>, Without<IsResource>>();
 
         let mut found = false;
         for entity_ref in query.iter_mut(&mut world) {
@@ -5210,7 +5212,10 @@ mod tests {
 
         world.run_system_once(system).unwrap();
 
-        fn system(_: Query<&mut TestComponent>, query: Query<EntityRefExcept<TestComponent>>) {
+        fn system(
+            _: Query<&mut TestComponent>,
+            query: Query<EntityRefExcept<TestComponent>, Without<IsResource>>,
+        ) {
             for entity_ref in query.iter() {
                 assert!(matches!(
                     entity_ref.get::<TestComponent2>(),
@@ -5227,7 +5232,8 @@ mod tests {
         let mut world = World::new();
         world.spawn(TestComponent(0)).insert(TestComponent2(0));
 
-        let mut query = world.query::<EntityMutExcept<TestComponent>>();
+        let mut query =
+            world.query_filtered::<EntityMutExcept<TestComponent>, Without<IsResource>>();
 
         let mut found = false;
         for mut entity_mut in query.iter_mut(&mut world) {
@@ -5292,7 +5298,10 @@ mod tests {
 
         world.run_system_once(system).unwrap();
 
-        fn system(_: Query<&mut TestComponent>, mut query: Query<EntityMutExcept<TestComponent>>) {
+        fn system(
+            _: Query<&mut TestComponent>,
+            mut query: Query<EntityMutExcept<TestComponent>, Without<IsResource>>,
+        ) {
             for mut entity_mut in query.iter_mut() {
                 assert!(entity_mut
                     .get_mut::<TestComponent2>()

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -54,7 +54,8 @@ use crate::{
     observer::Observers,
     query::{DebugCheckedUnwrap, QueryData, QueryFilter, QueryState},
     relationship::RelationshipHookMode,
-    resource::Resource,
+    removal_detection::RemovedComponentEvents,
+    resource::{Resource, ResourceEntity},
     schedule::{Schedule, ScheduleLabel, Schedules},
     storage::{ResourceData, Storages},
     system::Commands,
@@ -1678,7 +1679,15 @@ impl World {
     #[track_caller]
     pub fn init_resource<R: Resource + FromWorld>(&mut self) -> ComponentId {
         let caller = MaybeLocation::caller();
+        let already_exists = self.components.resource_id::<R>().is_some();
         let component_id = self.components_registrator().register_resource::<R>();
+
+        if !already_exists {
+            let entity = self.spawn(ResourceEntity::<R>::default()).id();
+            self.components
+                .cache_resource_entity_by_id(entity, component_id);
+        }
+
         if self
             .storages
             .resources
@@ -1715,7 +1724,15 @@ impl World {
         value: R,
         caller: MaybeLocation,
     ) {
+        let already_exists = self.components.resource_id::<R>().is_some();
         let component_id = self.components_registrator().register_resource::<R>();
+
+        if !already_exists {
+            let entity = self.spawn(ResourceEntity::<R>::default()).id();
+            self.components
+                .cache_resource_entity_by_id(entity, component_id);
+        }
+
         OwningPtr::make(value, |ptr| {
             // SAFETY: component_id was just initialized and corresponds to resource of type R.
             unsafe {
@@ -1782,6 +1799,7 @@ impl World {
     /// Removes the resource of a given type and returns it, if it exists. Otherwise returns `None`.
     #[inline]
     pub fn remove_resource<R: Resource>(&mut self) -> Option<R> {
+        let _ = self.components.remove_resource_entity::<R>();
         let component_id = self.components.get_valid_resource_id(TypeId::of::<R>())?;
         let (ptr, _, _) = self.storages.resources.get_mut(component_id)?.remove()?;
         // SAFETY: `component_id` was gotten via looking up the `R` type

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -54,7 +54,6 @@ use crate::{
     observer::Observers,
     query::{DebugCheckedUnwrap, QueryData, QueryFilter, QueryState},
     relationship::RelationshipHookMode,
-    removal_detection::RemovedComponentEvents,
     resource::{Resource, ResourceEntity},
     schedule::{Schedule, ScheduleLabel, Schedules},
     storage::{ResourceData, Storages},
@@ -3639,7 +3638,7 @@ mod tests {
         entity::EntityHashSet,
         entity_disabling::{DefaultQueryFilters, Disabled},
         ptr::OwningPtr,
-        resource::Resource,
+        resource::{IsResource, Resource},
         world::{error::EntityMutableFetchError, DeferredWorld},
     };
     use alloc::{
@@ -4069,7 +4068,11 @@ mod tests {
 
         let iterate_and_count_entities = |world: &World, entity_counters: &mut HashMap<_, _>| {
             entity_counters.clear();
-            for entity in world.iter_entities() {
+            for entity in world
+                .iter_entities()
+                // exclude resources
+                .filter(|e| e.get::<IsResource>().is_none())
+            {
                 let counter = entity_counters.entry(entity.id()).or_insert(0);
                 *counter += 1;
             }
@@ -4166,7 +4169,11 @@ mod tests {
         assert_eq!(world.entity(b1).get(), Some(&B(2)));
         assert_eq!(world.entity(b2).get(), Some(&B(4)));
 
-        let mut entities = world.iter_entities_mut().collect::<Vec<_>>();
+        let mut entities = world
+            .iter_entities_mut()
+            // exclude resources
+            .filter(|e| e.get::<IsResource>().is_none())
+            .collect::<Vec<_>>();
         entities.sort_by_key(|e| e.get::<A>().map(|a| a.0).or(e.get::<B>().map(|b| b.0)));
         let (a, b) = entities.split_at_mut(2);
         core::mem::swap(


### PR DESCRIPTION
# Objective

First step towards resources as components as described in #17485.

## Solution

We add an entity alongside every Resource. We do not store any data on it yet, just to see if anything breaks. We also added a small cache that links ComponentIDs to entities for Resources.

## Testing

I should probably add a test that checks how good the cache works.

# Discussion

As outlined in [this Hackmd doc](https://hackmd.io/_uB08OiAT4GqOXPE-X76eQ#Groundwork), we want to keep the Resources conceptually separate from 'normal' entities, and as such for every single method that deals with entities we can play a fun gameshow game: "Does this method account for Resources?"

Here's a table with my **opinion** of how it should work. The third column tells you if this is how it currently works in this PR.

| Method or Code snippet | Should it account for Resources? | Is that how it works in this PR? |
| --------------------------- | ------------------------- | -------------------------- |
| `world.entities.len()` | No | Yes, but there should probably a method to count entities, that excludes resources. |
| `world.query::<()>` | Yes | No, this returns every single entity (except disabled ones) | 
| `world.clear_entities()` | Yes | No, and `world.clear_resources()` should also be changed. |
| `world.iter_entities()` and `world.iter_entities_mut()` | Yes | No |

This table can easily be expanded, but the more we add, the less of a good idea it is to tackle this in a single PR.