### PR TITLE
deny(missing_docs) for bevy_asset_macros

### DIFF
--- a/crates/bevy_asset/macros/src/lib.rs
+++ b/crates/bevy_asset/macros/src/lib.rs
@@ -1,5 +1,6 @@
-#![expect(missing_docs, reason = "Not all docs are written yet, see #3492.")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
+//! Macros for deriving asset traits.
 
 use bevy_macro_utils::BevyManifest;
 use proc_macro::{Span, TokenStream};
@@ -12,6 +13,7 @@ pub(crate) fn bevy_asset_path() -> Path {
 
 const DEPENDENCY_ATTRIBUTE: &str = "dependency";
 
+/// Implemement the `Asset` trait.
 #[proc_macro_derive(Asset, attributes(dependency))]
 pub fn derive_asset(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
@@ -30,6 +32,7 @@ pub fn derive_asset(input: TokenStream) -> TokenStream {
     })
 }
 
+/// Implement the `VisitAssetDependencies` trait.
 #[proc_macro_derive(VisitAssetDependencies, attributes(dependency))]
 pub fn derive_asset_dependency_visitor(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);

--- a/crates/bevy_asset/macros/src/lib.rs
+++ b/crates/bevy_asset/macros/src/lib.rs
@@ -13,7 +13,7 @@ pub(crate) fn bevy_asset_path() -> Path {
 
 const DEPENDENCY_ATTRIBUTE: &str = "dependency";
 
-/// Implemement the `Asset` trait.
+/// Implement the `Asset` trait.
 #[proc_macro_derive(Asset, attributes(dependency))]
 pub fn derive_asset(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);


### PR DESCRIPTION
# Objective

More boilerplate docs, towards https://github.com/bevyengine/bevy/issues/3492.

Another place where https://github.com/bevyengine/bevy/issues/19537 might be worth doing as a follow up - I've added a comment on that issue.