### PR TITLE
Reactive Systems / SystemParams and Resource impl

### DIFF
--- a/crates/bevy_ecs/src/system/adapter_system.rs
+++ b/crates/bevy_ecs/src/system/adapter_system.rs
@@ -191,6 +191,14 @@ where
     fn set_last_run(&mut self, last_run: crate::component::Tick) {
         self.system.set_last_run(last_run);
     }
+
+    unsafe fn should_react_unsafe(
+        &self,
+        world: UnsafeWorldCell,
+        this_run: crate::component::Tick,
+    ) -> bool {
+        self.system.should_react_unsafe(world, this_run)
+    }
 }
 
 // SAFETY: The inner system is read-only.

--- a/crates/bevy_ecs/src/system/combinator.rs
+++ b/crates/bevy_ecs/src/system/combinator.rs
@@ -219,6 +219,10 @@ where
         self.a.set_last_run(last_run);
         self.b.set_last_run(last_run);
     }
+
+    unsafe fn should_react_unsafe(&self, world: UnsafeWorldCell, this_run: Tick) -> bool {
+        self.a.should_react_unsafe(world, this_run) || self.b.should_react_unsafe(world, this_run)
+    }
 }
 
 /// SAFETY: Both systems are read-only, so any system created by combining them will only read from the world.
@@ -424,6 +428,10 @@ where
     fn set_last_run(&mut self, last_run: Tick) {
         self.a.set_last_run(last_run);
         self.b.set_last_run(last_run);
+    }
+
+    unsafe fn should_react_unsafe(&self, world: UnsafeWorldCell, this_run: Tick) -> bool {
+        self.a.should_react_unsafe(world, this_run) || self.b.should_react_unsafe(world, this_run)
     }
 }
 

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -729,7 +729,7 @@ where
         self.system_meta.last_run = last_run;
     }
 
-    fn should_react(&self, world: &World, this_run: Tick) -> bool {
+    unsafe fn should_react_unsafe(&self, world: UnsafeWorldCell, this_run: Tick) -> bool {
         let last_run = self.get_last_run();
         if let Some(state) = &self.state {
             <F::Param as SystemParam>::should_react(

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -728,6 +728,21 @@ where
     fn set_last_run(&mut self, last_run: Tick) {
         self.system_meta.last_run = last_run;
     }
+
+    fn should_react(&self, world: &World, this_run: Tick) -> bool {
+        let last_run = self.get_last_run();
+        if let Some(state) = &self.state {
+            <F::Param as SystemParam>::should_react(
+                &state.param,
+                &self.system_meta,
+                world,
+                last_run,
+                this_run,
+            )
+        } else {
+            false
+        }
+    }
 }
 
 /// SAFETY: `F`'s param is [`ReadOnlySystemParam`], so this system will only read from the world.

--- a/crates/bevy_ecs/src/system/observer_system.rs
+++ b/crates/bevy_ecs/src/system/observer_system.rs
@@ -178,6 +178,10 @@ where
     fn default_system_sets(&self) -> Vec<crate::schedule::InternedSystemSet> {
         self.observer.default_system_sets()
     }
+
+    unsafe fn should_react_unsafe(&self, world: UnsafeWorldCell, this_run: Tick) -> bool {
+        self.observer.should_react_unsafe(world, this_run)
+    }
 }
 
 #[cfg(test)]

--- a/crates/bevy_ecs/src/system/schedule_system.rs
+++ b/crates/bevy_ecs/src/system/schedule_system.rs
@@ -95,6 +95,10 @@ impl<S: System<In = ()>> System for InfallibleSystemWrapper<S> {
     fn default_system_sets(&self) -> Vec<crate::schedule::InternedSystemSet> {
         self.0.default_system_sets()
     }
+
+    unsafe fn should_react_unsafe(&self, world: UnsafeWorldCell, this_run: Tick) -> bool {
+        self.0.should_react_unsafe(world, this_run)
+    }
 }
 
 /// See [`IntoSystem::with_input`] for details.
@@ -191,6 +195,10 @@ where
 
     fn set_last_run(&mut self, last_run: Tick) {
         self.system.set_last_run(last_run);
+    }
+
+    unsafe fn should_react_unsafe(&self, world: UnsafeWorldCell, this_run: Tick) -> bool {
+        self.system.should_react_unsafe(world, this_run)
     }
 }
 
@@ -291,6 +299,10 @@ where
 
     fn set_last_run(&mut self, last_run: Tick) {
         self.system.set_last_run(last_run);
+    }
+
+    unsafe fn should_react_unsafe(&self, world: UnsafeWorldCell, this_run: Tick) -> bool {
+        self.system.should_react_unsafe(world, this_run)
     }
 }
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -308,6 +308,17 @@ pub unsafe trait SystemParam: Sized {
         world: UnsafeWorldCell<'world>,
         change_tick: Tick,
     ) -> Self::Item<'world, 'state>;
+
+    /// Returns true if this system param has changed since the system was last run.
+    fn should_react(
+        _state: &Self::State,
+        _system_meta: &SystemMeta,
+        _world: &World,
+        _last_run: Tick,
+        _this_run: Tick,
+    ) -> bool {
+        false
+    }
 }
 
 /// A [`SystemParam`] that only reads a given [`World`].
@@ -821,6 +832,19 @@ unsafe impl<'a, T: Resource> SystemParam for Res<'a, T> {
             changed_by: caller.map(|caller| caller.deref()),
         }
     }
+
+    fn should_react(
+        state: &Self::State,
+        _system_meta: &SystemMeta,
+        world: &World,
+        last_run: Tick,
+        this_run: Tick,
+    ) -> bool {
+        world
+            .get_resource_change_ticks_by_id(*state)
+            .unwrap()
+            .is_changed(last_run, this_run)
+    }
 }
 
 // SAFETY: Res ComponentId access is applied to SystemMeta. If this Res
@@ -898,6 +922,19 @@ unsafe impl<'a, T: Resource> SystemParam for ResMut<'a, T> {
             },
             changed_by: value.changed_by,
         }
+    }
+
+    fn should_react(
+        state: &Self::State,
+        _system_meta: &SystemMeta,
+        world: &World,
+        last_run: Tick,
+        this_run: Tick,
+    ) -> bool {
+        world
+            .get_resource_change_ticks_by_id(*state)
+            .unwrap()
+            .is_changed(last_run, this_run)
     }
 }
 
@@ -2163,6 +2200,12 @@ macro_rules! impl_system_param_tuple {
                 )]
                 ($($param::get_param($param, system_meta, world, change_tick),)*)
             }
+
+            #[inline]
+            fn should_react(state: &Self::State, system_meta: &SystemMeta, _world: &World, _last_run: Tick, _this_run: Tick) -> bool {
+                let ($($param,)*) = &state;
+                false $(|| <$param as SystemParam>::should_react($param, system_meta, _world, _last_run, _this_run))*
+            }
         }
     };
 }
@@ -2326,6 +2369,16 @@ unsafe impl<P: SystemParam + 'static> SystemParam for StaticSystemParam<'_, '_, 
     ) -> Self::Item<'world, 'state> {
         // SAFETY: Defer to the safety of P::SystemParam
         StaticSystemParam(unsafe { P::get_param(state, system_meta, world, change_tick) })
+    }
+
+    fn should_react(
+        state: &Self::State,
+        system_meta: &SystemMeta,
+        world: &World,
+        last_run: Tick,
+        this_run: Tick,
+    ) -> bool {
+        P::should_react(state, system_meta, world, last_run, this_run)
     }
 }
 


### PR DESCRIPTION
# Objective

We increasingly would like to write "reactive systems" that can detect when their inputs have been changed. This would enable things like "reactive UI" patterns.

Relates to #19712 (but does not implement a run condition ... see Next Steps)

## Solution

This is the implementation from my [Reactivity Proposal](https://github.com/bevyengine/bevy/discussions/17917) (without the other tangential bits like system entity targets or controversial bits like the reactive Com SystemParam).

- This adds `SystemParam::should_react` and `System::should_react`, making it possible to detect whether a param or system has changed since the last system run in such a way that should prompt a reactive run of a system.
- It also adds an unsafe variant `System::should_react_unsafe`, which uses UnsafeWorldCell and can be run in parallel contexts.
- It adds reactive impls for Res and FunctionSystems

This notably _does not add new traits_. Reactivity is something that SystemParams and Systems opt in to by overriding default impls that return `false` for `should_react`. It is implemented this way for a number of reasons:

1. It allows all system parameters to be used in reactive contexts, preventing the need for redundant trait impls. People will want to access arbitrary (non-reactive) data in their reactions, and we should let them! Parameters are non-reactive by default.
2. This allows us to use all existing system infrastructure in a way that works with reactions (ex: piping, adapters, combinators, anything involving boxed systems, etc).
3. This keeps our code complexity in check: we don't add more traits or redundant impls to the zoo.

Note that I do not think this is necessarily the solution to the "reactive UI" problem. It [_might_ be a piece of the puzzle](https://github.com/bevyengine/bevy/issues/19712#issuecomment-2986002574). This PR is about extending the system API to support reacting to input changes.

## Open Questions:

- How will we enable mixing and matching reactive and non-reactive inputs to system? For example `Res` and `ResMut` are currently reactive in this PR. Would we use something like `NoReact<Res<Time>>, Res<Counter>` to prevent reacting to the time parameter while reacting to the Counter parameter? Should we opt parameters _in_ to reactivity via `React<Res<Time>>, Res<Counter>`?  Should we have reactive variants (ex: `Res<Time>, ReactRes<Counter>`).
- Should we use the word "react" here (ex: `System::should_react`)? "Reactivity" intersects with the UI space, and this feature may or may not be used for the official reactive Bevy UI solution. 

## Next Steps

- I made this callable from arbitrary parallel contexts (ex: to support building a run condition wrapper system). However run conditions don't have access to the state of the system they are the condition for, so there is no way for it to know whether the system has been run. We can't just use a duplicate of the system in the run condition, as the change ticks would not update. We can't update the wrapped reactive system's change ticks when `should_react` is true (aka the ShouldReactRunCondition returns true), because we can't be sure the system will actually run (as the run condition could be combined with other run conditions). We would need to be able to somehow access the actual target system's change ticks from _within_ run condition systems, which I'm not sure is something we want to do. I'm not sure we even want/need a run condition, as most "reactive" scenarios I can imagine would be their own system execution orchestrators (ex: reactive UI running in an exclusive system that polls reactive systems for changes and runs reactions to completion).
- Make more params reactive by implementing `should_react()`
- Add "reactive queries" that track when matched entities have changed. These would likely require additional overhead and infrastructure, so it probably makes sense to make this a new system param. But thats an open question!
- Consider adding something like my Reactivity Proposal's "system entity inputs", which system params can access. This would enable writing things like:
```rust
// reactions that run for specific entities
fn reactive_entity_system(health: Com<Health>) {
  log!("new health: {}", health.0);
}
world.spawn((
  Health(10),
  reactions![reactive_entity_system]
))

// observers that can directly access entity components for the triggered entity
let e1 = world.spawn(Velocity::default())
  .observe(|trigger: On<Jump>, mut velocity: ComMut<Velocity>| {
    velocity.0 = Vec3::new(0.0, 10.0, 0.0); 
  })
  .id();

world.trigger_targets(Jump, e1);
```
- Consider upstreaming something like my Reactivity Proposal's reaction executor.