### PR TITLE
Stop inserting `RelationshipTarget` on `SpawnRelatedBundle`

### DIFF
--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -2187,7 +2187,8 @@ mod tests {
             })
             .id();
 
-        assert!(world.entity(id).get::<Children>().is_some());
+        assert!(world.entity(id).get::<B>().is_some());
+        assert!(world.entity(id).get::<Children>().is_none());
     }
 
     #[test]

--- a/crates/bevy_ecs/src/hierarchy.rs
+++ b/crates/bevy_ecs/src/hierarchy.rs
@@ -475,8 +475,8 @@ pub fn validate_parent_has_component<C: Component>(
     }
 }
 
-/// Returns a [`SpawnRelatedBundle`] that will insert the [`Children`] component, spawn a [`SpawnableList`] of entities with given bundles that
-/// relate to the [`Children`] entity via the [`ChildOf`] component, and reserve space in the [`Children`] for each spawned entity.
+/// Returns a [`SpawnRelatedBundle`] that will spawn a [`SpawnableList`] of entities with given bundles that
+/// relate to the [`Children`] entity via the [`ChildOf`] component.
 ///
 /// Any additional arguments will be interpreted as bundles to be spawned.
 ///


### PR DESCRIPTION
Fixes #19715.

### How the issue was introduced

On v0.16 [improved spawn APIs were introduced](https://bevy.org/news/bevy-0-16/#improved-spawn-api). They are presented as having vastly improved ergonomics and the following comparison is offered as an example:

```rust
commands
    .spawn(Player)
    .with_children(|p| {
        p.spawn(RightHand).with_children(|p| {
            p.spawn(Glove);
            p.spawn(Sword);
        });
        p.spawn(LeftHand).with_children(|p| {
            p.spawn(Glove);
            p.spawn(Shield);
        });
    });
```

```rust
commands.spawn((
    Player,
    children![
        (RightHand, children![Glove, Sword]),
        (LeftHand, children![Glove, Shield]),
    ],
));
```

So both APIs do more or less the same thing but one is way more ergonomic than the other, right? Well, not exactly. As written on the release notes:

> This API also allows us to optimize hierarchy construction time by cutting down on re-allocations, as we can generally (with the exception of cases like SpawnWith) statically determine how many related entities an entity will have and preallocate space for them in the RelationshipTarget component (ex: Children).

Unfortunately, this reasonable optimization requires a significant change in behavior: the `children` macro doesn't just spawn children (like `with_children` does) , it also inserts a new `Children` component beforehand.

This introduces a footgun, as users may expect to be able to bring these ergonomic improvements to a slightly different context:

```rust
commands
    .entity(entity)
    .insert(Player)
    .with_children(|p| {
        p.spawn(RightHand).with_children(|p| {
            p.spawn(Glove);
            p.spawn(Sword);
        });
        p.spawn(LeftHand).with_children(|p| {
            p.spawn(Glove);
            p.spawn(Shield);
        });
    });
```

```rust
commands
    .entity(entity)
    .insert((
        Player,
        children![
            (RightHand, children![Glove, Sword]),
            (LeftHand, children![Glove, Shield]),
        ],
    ));
```

But here the behavior is widely different. Since the `children` macro inserts a `Children` component, this means that existing children will be overriden.

Note that you can avoid the footgun by using `insert_if_new`, but it's very easy to forget and could cause issues for other components in the bundle:

```rust
commands
    .entity(entity)
    .insert_if_new((
        Player,
        children![
            (RightHand, children![Glove, Sword]),
            (LeftHand, children![Glove, Shield]),
        ],
    ));
```

### Ergonomics should be the focus

Although optimizations are always welcome, I believe that in this case the main goal of the new APIs was to improve ergonomics. I think we should drop the optimization in favor of removing a footgun that worsens ergonomics. To do that, we just need to stop inserting the `RelationshipTarget` component on `SpawnRelatedBundle`.

### Alternatives

An alternative proposed by @SkiFire13 is to make use of required components to insert the `Children` component only when it doesn't exist. This wouldn't preallocate space like the current optimization, but that is probably less impactful than avoiding the table move. Although I find this a great optimization without footgun issues, establishing a requirement relationship between `SpawnRelatedBundle` and `RelationshipTarget` would likely require complex changes since `SpawnRelatedBundle` is not a component.