### PR TITLE
New simplified "click to focus" logic for core widgets.

### DIFF
--- a/crates/bevy_core_widgets/src/core_slider.rs
+++ b/crates/bevy_core_widgets/src/core_slider.rs
@@ -3,12 +3,11 @@ use core::ops::RangeInclusive;
 use accesskit::{Orientation, Role};
 use bevy_a11y::AccessibilityNode;
 use bevy_app::{App, Plugin};
-use bevy_ecs::entity::Entity;
 use bevy_ecs::event::{EntityEvent, Event};
-use bevy_ecs::hierarchy::{ChildOf, Children};
+use bevy_ecs::hierarchy::Children;
 use bevy_ecs::lifecycle::Insert;
 use bevy_ecs::query::Has;
-use bevy_ecs::system::{In, Res, ResMut};
+use bevy_ecs::system::{In, Res};
 use bevy_ecs::world::DeferredWorld;
 use bevy_ecs::{
     component::Component,
@@ -18,7 +17,7 @@ use bevy_ecs::{
 };
 use bevy_input::keyboard::{KeyCode, KeyboardInput};
 use bevy_input::ButtonState;
-use bevy_input_focus::{FocusedInput, InputFocus, InputFocusVisible};
+use bevy_input_focus::FocusedInput;
 use bevy_log::warn_once;
 use bevy_picking::events::{Drag, DragEnd, DragStart, Pointer, Press};
 use bevy_ui::{ComputedNode, ComputedNodeTarget, InteractionDisabled, UiGlobalTransform, UiScale};
@@ -207,42 +206,17 @@ pub(crate) fn slider_on_pointer_down(
     )>,
     q_thumb: Query<&ComputedNode, With<CoreSliderThumb>>,
     q_children: Query<&Children>,
-    q_parents: Query<&ChildOf>,
-    focus: Option<ResMut<InputFocus>>,
-    focus_visible: Option<ResMut<InputFocusVisible>>,
     mut commands: Commands,
     ui_scale: Res<UiScale>,
 ) {
     if q_thumb.contains(trigger.target()) {
         // Thumb click, stop propagation to prevent track click.
         trigger.propagate(false);
-
-        // Find the slider entity that's an ancestor of the thumb
-        if let Some(slider_entity) = q_parents
-            .iter_ancestors(trigger.target())
-            .find(|entity| q_slider.contains(*entity))
-        {
-            // Set focus to slider and hide focus ring
-            if let Some(mut focus) = focus {
-                focus.0 = Some(slider_entity);
-            }
-            if let Some(mut focus_visible) = focus_visible {
-                focus_visible.0 = false;
-            }
-        }
     } else if let Ok((slider, value, range, step, node, node_target, transform, disabled)) =
         q_slider.get(trigger.target())
     {
         // Track click
         trigger.propagate(false);
-
-        // Set focus to slider and hide focus ring
-        if let Some(mut focus) = focus {
-            focus.0 = (trigger.target() != Entity::PLACEHOLDER).then_some(trigger.target());
-        }
-        if let Some(mut focus_visible) = focus_visible {
-            focus_visible.0 = false;
-        }
 
         if disabled {
             return;

--- a/crates/bevy_input_focus/Cargo.toml
+++ b/crates/bevy_input_focus/Cargo.toml
@@ -64,6 +64,7 @@ bevy_app = { path = "../bevy_app", version = "0.16.0-dev", default-features = fa
 bevy_ecs = { path = "../bevy_ecs", version = "0.16.0-dev", default-features = false }
 bevy_input = { path = "../bevy_input", version = "0.16.0-dev", default-features = false }
 bevy_math = { path = "../bevy_math", version = "0.16.0-dev", default-features = false }
+bevy_picking = { path = "../bevy_picking", version = "0.16.0-dev", default-features = false }
 bevy_window = { path = "../bevy_window", version = "0.16.0-dev", default-features = false }
 bevy_reflect = { path = "../bevy_reflect", version = "0.16.0-dev", features = [
   "glam",

--- a/crates/bevy_input_focus/src/lib.rs
+++ b/crates/bevy_input_focus/src/lib.rs
@@ -143,7 +143,7 @@ pub struct InputFocusVisible(pub bool);
 pub struct FocusedInput<E: BufferedEvent + Clone> {
     /// The underlying input event.
     pub input: E,
-    /// The window entity from which the inpu.
+    /// The primary window entity.
     window: Entity,
 }
 

--- a/crates/bevy_input_focus/src/tab_navigation.rs
+++ b/crates/bevy_input_focus/src/tab_navigation.rs
@@ -29,7 +29,6 @@ use bevy_app::{App, Plugin, Startup};
 use bevy_ecs::{
     component::Component,
     entity::Entity,
-    event::{EntityEvent, Event},
     hierarchy::{ChildOf, Children},
     observer::On,
     query::{With, Without},
@@ -40,11 +39,11 @@ use bevy_input::{
     ButtonInput, ButtonState,
 };
 use bevy_picking::events::{Pointer, Press};
-use bevy_window::PrimaryWindow;
+use bevy_window::{PrimaryWindow, Window};
 use log::warn;
 use thiserror::Error;
 
-use crate::{FocusedInput, InputFocus, InputFocusVisible};
+use crate::{AcquireFocus, FocusedInput, InputFocus, InputFocusVisible};
 
 #[cfg(feature = "bevy_reflect")]
 use {
@@ -314,16 +313,11 @@ impl TabNavigation<'_, '_> {
     }
 }
 
-/// An event which is used to set input focus. Trigger this on an entity, and it will bubble
-/// until it finds an entity with [`TabIndex`], and then set focus to it.
-#[derive(Clone, Event, EntityEvent)]
-#[entity_event(traversal = &'static ChildOf, auto_propagate)]
-pub struct AcquireFocus;
-
 /// Observer which sets focus to the nearest ancestor that has tab index, using bubbling.
-pub(crate) fn auto_focus(
+pub(crate) fn acquire_focus(
     mut ev: On<AcquireFocus>,
     focusable: Query<(), With<TabIndex>>,
+    windows: Query<(), With<Window>>,
     mut focus: ResMut<InputFocus>,
 ) {
     // If the entity has a TabIndex
@@ -333,6 +327,13 @@ pub(crate) fn auto_focus(
         // Don't mutate unless we need to, for change detection
         if focus.0 != Some(ev.target()) {
             focus.0 = Some(ev.target());
+        }
+    } else if windows.contains(ev.target()) {
+        // Stop and focus it
+        ev.propagate(false);
+        // Don't mutate unless we need to, for change detection
+        if focus.0.is_some() {
+            focus.0 = None;
         }
     }
 }
@@ -346,7 +347,8 @@ impl Plugin for TabNavigationPlugin {
 
         #[cfg(feature = "bevy_reflect")]
         app.register_type::<TabIndex>().register_type::<TabGroup>();
-        app.add_observer(auto_focus);
+        app.add_observer(acquire_focus);
+        app.add_observer(click_to_focus);
     }
 }
 
@@ -359,6 +361,7 @@ fn setup_tab_navigation(mut commands: Commands, window: Query<Entity, With<Prima
 fn click_to_focus(
     ev: On<Pointer<Press>>,
     mut focus_visible: ResMut<InputFocusVisible>,
+    windows: Query<Entity, With<PrimaryWindow>>,
     mut commands: Commands,
 ) {
     // Because `Pointer` is a bubbling event, we don't want to trigger an `AcquireFocus` event
@@ -370,18 +373,12 @@ fn click_to_focus(
         if focus_visible.0 {
             focus_visible.0 = false;
         }
-        // Search for a focusable parent entity
-        commands.entity(ev.target()).trigger(AcquireFocus);
-    }
-}
-
-/// A plugin which implements the "click to focus" behavior. This will set focus whenever an
-/// a click is detected on an entity which has a [`TabIndex`].
-pub struct ClickToFocusPlugin;
-
-impl Plugin for ClickToFocusPlugin {
-    fn build(&self, app: &mut App) {
-        app.add_observer(click_to_focus);
+        // Search for a focusable parent entity, defaulting to window if none.
+        if let Ok(window) = windows.single() {
+            commands
+                .entity(ev.target())
+                .trigger(AcquireFocus { window });
+        }
     }
 }
 

--- a/crates/bevy_input_focus/src/tab_navigation.rs
+++ b/crates/bevy_input_focus/src/tab_navigation.rs
@@ -329,11 +329,11 @@ pub(crate) fn acquire_focus(
             focus.0 = Some(ev.target());
         }
     } else if windows.contains(ev.target()) {
-        // Stop and focus it
+        // Stop and clear focus
         ev.propagate(false);
         // Don't mutate unless we need to, for change detection
         if focus.0.is_some() {
-            focus.0 = None;
+            focus.clear();
         }
     }
 }

--- a/examples/ui/core_widgets.rs
+++ b/examples/ui/core_widgets.rs
@@ -8,7 +8,7 @@ use bevy::{
     },
     ecs::system::SystemId,
     input_focus::{
-        tab_navigation::{ClickToFocusPlugin, TabGroup, TabIndex, TabNavigationPlugin},
+        tab_navigation::{TabGroup, TabIndex, TabNavigationPlugin},
         InputDispatchPlugin,
     },
     picking::hover::Hovered,
@@ -24,7 +24,6 @@ fn main() {
             CoreWidgetsPlugin,
             InputDispatchPlugin,
             TabNavigationPlugin,
-            ClickToFocusPlugin,
         ))
         // Only run the app when there is user input. This will significantly reduce CPU/GPU use.
         .insert_resource(WinitSettings::desktop_app())

--- a/examples/ui/core_widgets.rs
+++ b/examples/ui/core_widgets.rs
@@ -8,7 +8,7 @@ use bevy::{
     },
     ecs::system::SystemId,
     input_focus::{
-        tab_navigation::{TabGroup, TabIndex},
+        tab_navigation::{ClickToFocusPlugin, TabGroup, TabIndex, TabNavigationPlugin},
         InputDispatchPlugin,
     },
     picking::hover::Hovered,
@@ -19,7 +19,13 @@ use bevy::{
 
 fn main() {
     App::new()
-        .add_plugins((DefaultPlugins, CoreWidgetsPlugin, InputDispatchPlugin))
+        .add_plugins((
+            DefaultPlugins,
+            CoreWidgetsPlugin,
+            InputDispatchPlugin,
+            TabNavigationPlugin,
+            ClickToFocusPlugin,
+        ))
         // Only run the app when there is user input. This will significantly reduce CPU/GPU use.
         .insert_resource(WinitSettings::desktop_app())
         .insert_resource(DemoWidgetStates { slider_value: 50.0 })

--- a/examples/ui/core_widgets_observers.rs
+++ b/examples/ui/core_widgets_observers.rs
@@ -7,7 +7,7 @@ use bevy::{
     },
     ecs::system::SystemId,
     input_focus::{
-        tab_navigation::{ClickToFocusPlugin, TabGroup, TabIndex, TabNavigationPlugin},
+        tab_navigation::{TabGroup, TabIndex, TabNavigationPlugin},
         InputDispatchPlugin,
     },
     picking::hover::Hovered,
@@ -23,7 +23,6 @@ fn main() {
             CoreWidgetsPlugin,
             InputDispatchPlugin,
             TabNavigationPlugin,
-            ClickToFocusPlugin,
         ))
         // Only run the app when there is user input. This will significantly reduce CPU/GPU use.
         .insert_resource(WinitSettings::desktop_app())

--- a/examples/ui/core_widgets_observers.rs
+++ b/examples/ui/core_widgets_observers.rs
@@ -7,7 +7,7 @@ use bevy::{
     },
     ecs::system::SystemId,
     input_focus::{
-        tab_navigation::{TabGroup, TabIndex},
+        tab_navigation::{ClickToFocusPlugin, TabGroup, TabIndex, TabNavigationPlugin},
         InputDispatchPlugin,
     },
     picking::hover::Hovered,
@@ -18,7 +18,13 @@ use bevy::{
 
 fn main() {
     App::new()
-        .add_plugins((DefaultPlugins, CoreWidgetsPlugin, InputDispatchPlugin))
+        .add_plugins((
+            DefaultPlugins,
+            CoreWidgetsPlugin,
+            InputDispatchPlugin,
+            TabNavigationPlugin,
+            ClickToFocusPlugin,
+        ))
         // Only run the app when there is user input. This will significantly reduce CPU/GPU use.
         .insert_resource(WinitSettings::desktop_app())
         .insert_resource(DemoWidgetStates { slider_value: 50.0 })


### PR DESCRIPTION
Click to focus is now a global observer.

# Objective

Previously, the "click to focus" behavior was implemented in each individual headless widget, producing redundant logic.

## Solution

The new scheme is to have a global observer which looks for pointer down events and triggers an `AcquireFocus` event on the target. This event bubbles until it finds an entity with `TabIndex`, and then focuses it.

## Testing

Tested the changes using the various examples that have focusable widgets. (This will become easier to test when I add focus ring support to the examples, but that's for another day. For now you just have to know which keys to press.)

## Migration

This change is backwards-compatible. People who want the new behavior will need to install the new plugin.