### PR TITLE
Implement serializable mesh

### DIFF
--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -100,6 +100,7 @@ serialize = [
   "bevy_window?/serialize",
   "bevy_winit?/serialize",
   "bevy_platform/serialize",
+  "bevy_render/serialize",
 ]
 multi_threaded = [
   "std",

--- a/crates/bevy_mesh/Cargo.toml
+++ b/crates/bevy_mesh/Cargo.toml
@@ -28,10 +28,17 @@ bevy_platform = { path = "../bevy_platform", version = "0.16.0-dev", default-fea
 bitflags = { version = "2.3", features = ["serde"] }
 bytemuck = { version = "1.5" }
 wgpu-types = { version = "24", default-features = false }
-serde = { version = "1", features = ["derive"] }
+serde = { version = "1", default-features = false, features = [
+  "derive",
+], optional = true }
 hexasphere = "15.0"
 thiserror = { version = "2", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
+
+[features]
+default = []
+## Adds serialization support through `serde`.
+serialize = ["dep:serde", "wgpu-types/serde"]
 
 [lints]
 workspace = true

--- a/crates/bevy_mesh/Cargo.toml
+++ b/crates/bevy_mesh/Cargo.toml
@@ -35,6 +35,9 @@ hexasphere = "15.0"
 thiserror = { version = "2", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 
+[dev-dependencies]
+serde_json = "1.0.140"
+
 [features]
 default = []
 ## Adds serialization support through `serde`.

--- a/crates/bevy_mesh/src/index.rs
+++ b/crates/bevy_mesh/src/index.rs
@@ -1,6 +1,8 @@
 use bevy_reflect::Reflect;
 use core::iter;
 use core::iter::FusedIterator;
+#[cfg(feature = "serialize")]
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use wgpu_types::IndexFormat;
 
@@ -69,8 +71,9 @@ pub enum MeshTrianglesError {
 /// An array of indices into the [`VertexAttributeValues`](super::VertexAttributeValues) for a mesh.
 ///
 /// It describes the order in which the vertex attributes should be joined into faces.
-#[derive(Debug, Clone, Reflect)]
+#[derive(Debug, Clone, Reflect, PartialEq)]
 #[reflect(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub enum Indices {
     U16(Vec<u16>),
     U32(Vec<u32>),

--- a/crates/bevy_mesh/src/mesh.rs
+++ b/crates/bevy_mesh/src/mesh.rs
@@ -1352,15 +1352,15 @@ impl MeshDeserializer {
 
     /// Register a custom vertex attribute to the deserializer. Custom vertex attributes that were not added with this method will be ignored while deserializing.
     pub fn add_custom_vertex_attribute(
-        mut self,
+        &mut self,
         name: &str,
         attribute: MeshVertexAttribute,
-    ) -> Self {
+    ) -> &mut Self {
         self.custom_vertex_attributes.insert(name.into(), attribute);
         self
     }
 
-    /// Finalize the deserialization process and turn the [`SerializedMesh`] into a [`Mesh`].
+    /// Deserialize a [`SerializedMesh`] into a [`Mesh`].
     ///
     /// See the documentation for [`SerializedMesh`] for caveats.
     pub fn deserialize(&self, serialized_mesh: SerializedMesh) -> Mesh {

--- a/crates/bevy_mesh/src/mesh.rs
+++ b/crates/bevy_mesh/src/mesh.rs
@@ -1306,7 +1306,7 @@ impl SerializedMesh {
     }
 
     /// Create a [`Mesh`] from a [`SerializedMesh`]. See the documentation for [`SerializedMesh`] for caveats.
-    /// 
+    ///
     /// Use [`MeshDeserializer`] if you need to pass extra options to the deserialization process, such as specifying custom vertex attributes.
     pub fn into_mesh(self) -> Mesh {
         MeshDeserializer::default().deserialize(self)
@@ -1365,7 +1365,7 @@ impl MeshDeserializer {
     /// See the documentation for [`SerializedMesh`] for caveats.
     pub fn deserialize(&self, serialized_mesh: SerializedMesh) -> Mesh {
         Mesh {
-            attributes: 
+            attributes:
                 serialized_mesh
                 .attributes
                 .into_iter()
@@ -1723,7 +1723,8 @@ mod tests {
 
         let serialized_mesh = SerializedMesh::from_mesh(mesh.clone());
         let serialized_string = serde_json::to_string(&serialized_mesh).unwrap();
-        let serialized_mesh_from_string: SerializedMesh = serde_json::from_str(&serialized_string).unwrap();
+        let serialized_mesh_from_string: SerializedMesh =
+            serde_json::from_str(&serialized_string).unwrap();
         let deserialized_mesh = serialized_mesh_from_string.into_mesh();
         assert_eq!(mesh, deserialized_mesh);
     }

--- a/crates/bevy_mesh/src/mesh.rs
+++ b/crates/bevy_mesh/src/mesh.rs
@@ -1722,7 +1722,9 @@ mod tests {
         mesh.insert_indices(Indices::U16(vec![0, 1, 2, 0, 2, 3]));
 
         let serialized_mesh = SerializedMesh::from_mesh(mesh.clone());
-        let deserialized_mesh = serialized_mesh.deserialize().into_mesh();
+        let serialized_string = serde_json::to_string(&serialized_mesh).unwrap();
+        let serialized_mesh_from_string: SerializedMesh = serde_json::from_str(&serialized_string).unwrap();
+        let deserialized_mesh = serialized_mesh_from_string.into_mesh();
         assert_eq!(mesh, deserialized_mesh);
     }
 }

--- a/crates/bevy_mesh/src/mesh.rs
+++ b/crates/bevy_mesh/src/mesh.rs
@@ -1259,14 +1259,6 @@ impl core::ops::Mul<Mesh> for Transform {
 }
 
 /// A version of [`Mesh`] suitable for serializing as an asset.
-///
-/// Animation nodes can refer to external animation clips, and the [`AssetId`]
-/// is typically not sufficient to identify the clips, since the
-/// [`bevy_asset::AssetServer`] assigns IDs in unpredictable ways. That fact
-/// motivates this type, which replaces the `Handle<AnimationClip>` with an
-/// asset path.  Loading an animation graph via the [`bevy_asset::AssetServer`]
-/// actually loads a serialized instance of this type, as does serializing an
-/// [`AnimationGraph`] through `serde`.
 #[cfg(feature = "serialize")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SerializedMesh {

--- a/crates/bevy_mesh/src/mesh.rs
+++ b/crates/bevy_mesh/src/mesh.rs
@@ -213,6 +213,10 @@ impl Mesh {
     pub const ATTRIBUTE_JOINT_INDEX: MeshVertexAttribute =
         MeshVertexAttribute::new("Vertex_JointIndex", 7, VertexFormat::Uint16x4);
 
+    /// The first index that can be used for custom vertex attributes.
+    /// Only the attributes with an index below this are reserved by Bevy.
+    pub const FIRST_AVAILABLE_CUSTOM_ATTRIBUTE: u64 = 8;
+
     /// Construct a new mesh. You need to provide a [`PrimitiveTopology`] so that the
     /// renderer knows how to treat the vertex data. Most of the time this will be
     /// [`PrimitiveTopology::TriangleList`].
@@ -1317,20 +1321,24 @@ pub struct MeshDeserializer {
 #[cfg(feature = "serialize")]
 impl MeshDeserializer {
     fn new(serialized_mesh: SerializedMesh) -> Self {
+        // Written like this so that the compiler can validate that we use all the built-in attributes.
+        // If you just added a new attribute and got a compile error, please add it to this list :)
+        let builtins: [MeshVertexAttribute; Mesh::FIRST_AVAILABLE_CUSTOM_ATTRIBUTE as usize] = [
+            Mesh::ATTRIBUTE_POSITION,
+            Mesh::ATTRIBUTE_NORMAL,
+            Mesh::ATTRIBUTE_UV_0,
+            Mesh::ATTRIBUTE_UV_1,
+            Mesh::ATTRIBUTE_TANGENT,
+            Mesh::ATTRIBUTE_COLOR,
+            Mesh::ATTRIBUTE_JOINT_WEIGHT,
+            Mesh::ATTRIBUTE_JOINT_INDEX,
+        ];
         Self {
             serialized_mesh,
-            custom_vertex_attributes: [
-                Mesh::ATTRIBUTE_POSITION,
-                Mesh::ATTRIBUTE_NORMAL,
-                Mesh::ATTRIBUTE_UV_0,
-                Mesh::ATTRIBUTE_TANGENT,
-                Mesh::ATTRIBUTE_COLOR,
-                Mesh::ATTRIBUTE_JOINT_WEIGHT,
-                Mesh::ATTRIBUTE_JOINT_INDEX,
-            ]
-            .into_iter()
-            .map(|attribute| (attribute.name.into(), attribute))
-            .collect(),
+            custom_vertex_attributes: builtins
+                .into_iter()
+                .map(|attribute| (attribute.name.into(), attribute))
+                .collect(),
         }
     }
 

--- a/crates/bevy_mesh/src/mesh.rs
+++ b/crates/bevy_mesh/src/mesh.rs
@@ -214,7 +214,7 @@ impl Mesh {
         MeshVertexAttribute::new("Vertex_JointIndex", 7, VertexFormat::Uint16x4);
 
     /// The first index that can be used for custom vertex attributes.
-    /// Only the attributes with an index below this are reserved by Bevy.
+    /// Only the attributes with an index below this are used by Bevy.
     pub const FIRST_AVAILABLE_CUSTOM_ATTRIBUTE: u64 = 8;
 
     /// Construct a new mesh. You need to provide a [`PrimitiveTopology`] so that the

--- a/crates/bevy_mesh/src/vertex.rs
+++ b/crates/bevy_mesh/src/vertex.rs
@@ -26,8 +26,8 @@ pub struct MeshVertexAttribute {
     pub format: VertexFormat,
 }
 
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg(feature = "serialize")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct SerializedMeshVertexAttribute {
     pub(crate) name: String,
     pub(crate) id: MeshVertexAttributeId,
@@ -174,8 +174,8 @@ pub(crate) struct MeshAttributeData {
     pub(crate) values: VertexAttributeValues,
 }
 
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg(feature = "serialize")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct SerializedMeshAttributeData {
     pub(crate) attribute: SerializedMeshVertexAttribute,
     pub(crate) values: VertexAttributeValues,

--- a/crates/bevy_mesh/src/vertex.rs
+++ b/crates/bevy_mesh/src/vertex.rs
@@ -2,13 +2,17 @@ use alloc::sync::Arc;
 use bevy_derive::EnumVariantMeta;
 use bevy_ecs::resource::Resource;
 use bevy_math::Vec3;
+#[cfg(feature = "serialize")]
+use bevy_platform::collections::HashMap;
 use bevy_platform::collections::HashSet;
 use bytemuck::cast_slice;
 use core::hash::{Hash, Hasher};
+#[cfg(feature = "serialize")]
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use wgpu_types::{BufferAddress, VertexAttribute, VertexFormat, VertexStepMode};
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct MeshVertexAttribute {
     /// The friendly name of the vertex attribute
     pub name: &'static str,
@@ -20,6 +24,37 @@ pub struct MeshVertexAttribute {
 
     /// The format of the vertex attribute.
     pub format: VertexFormat,
+}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+pub(crate) struct SerializedMeshVertexAttribute {
+    pub(crate) name: String,
+    pub(crate) id: MeshVertexAttributeId,
+    pub(crate) format: VertexFormat,
+}
+
+#[cfg(feature = "serialize")]
+impl SerializedMeshVertexAttribute {
+    pub(crate) fn from_mesh_vertex_attribute(attribute: MeshVertexAttribute) -> Self {
+        Self {
+            name: attribute.name.to_string(),
+            id: attribute.id,
+            format: attribute.format,
+        }
+    }
+
+    pub(crate) fn try_into_mesh_vertex_attribute(
+        self,
+        possible_attributes: &HashMap<Box<str>, MeshVertexAttribute>,
+    ) -> Option<MeshVertexAttribute> {
+        let attr = possible_attributes.get(self.name.as_str())?;
+        if attr.id == self.id {
+            Some(attr.clone())
+        } else {
+            None
+        }
+    }
 }
 
 impl MeshVertexAttribute {
@@ -37,6 +72,7 @@ impl MeshVertexAttribute {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct MeshVertexAttributeId(u64);
 
 impl From<MeshVertexAttribute> for MeshVertexAttributeId {
@@ -132,10 +168,40 @@ impl VertexAttributeDescriptor {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) struct MeshAttributeData {
     pub(crate) attribute: MeshVertexAttribute,
     pub(crate) values: VertexAttributeValues,
+}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+pub(crate) struct SerializedMeshAttributeData {
+    pub(crate) attribute: SerializedMeshVertexAttribute,
+    pub(crate) values: VertexAttributeValues,
+}
+
+#[cfg(feature = "serialize")]
+impl SerializedMeshAttributeData {
+    pub(crate) fn from_mesh_attribute_data(data: MeshAttributeData) -> Self {
+        Self {
+            attribute: SerializedMeshVertexAttribute::from_mesh_vertex_attribute(data.attribute),
+            values: data.values,
+        }
+    }
+
+    pub(crate) fn try_into_mesh_attribute_data(
+        self,
+        possible_attributes: &HashMap<Box<str>, MeshVertexAttribute>,
+    ) -> Option<MeshAttributeData> {
+        let attribute = self
+            .attribute
+            .try_into_mesh_vertex_attribute(possible_attributes)?;
+        Some(MeshAttributeData {
+            attribute,
+            values: self.values,
+        })
+    }
 }
 
 /// Compute a vector whose direction is the normal of the triangle formed by
@@ -167,7 +233,8 @@ pub fn face_normal(a: [f32; 3], b: [f32; 3], c: [f32; 3]) -> [f32; 3] {
 
 /// Contains an array where each entry describes a property of a single vertex.
 /// Matches the [`VertexFormats`](VertexFormat).
-#[derive(Clone, Debug, EnumVariantMeta)]
+#[derive(Clone, Debug, EnumVariantMeta, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub enum VertexAttributeValues {
     Float32(Vec<f32>),
     Sint32(Vec<i32>),

--- a/crates/bevy_mesh/src/vertex.rs
+++ b/crates/bevy_mesh/src/vertex.rs
@@ -50,7 +50,7 @@ impl SerializedMeshVertexAttribute {
     ) -> Option<MeshVertexAttribute> {
         let attr = possible_attributes.get(self.name.as_str())?;
         if attr.id == self.id {
-            Some(attr.clone())
+            Some(attr)
         } else {
             None
         }

--- a/crates/bevy_mesh/src/vertex.rs
+++ b/crates/bevy_mesh/src/vertex.rs
@@ -50,7 +50,7 @@ impl SerializedMeshVertexAttribute {
     ) -> Option<MeshVertexAttribute> {
         let attr = possible_attributes.get(self.name.as_str())?;
         if attr.id == self.id {
-            Some(attr)
+            Some(*attr)
         } else {
             None
         }

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -46,6 +46,8 @@ ci_limits = []
 webgl = ["wgpu/webgl"]
 webgpu = ["wgpu/webgpu"]
 detailed_trace = []
+## Adds serialization support through `serde`.
+serialize = ["bevy_mesh/serialize"]
 
 [dependencies]
 # bevy

--- a/crates/bevy_scene/Cargo.toml
+++ b/crates/bevy_scene/Cargo.toml
@@ -15,6 +15,7 @@ serialize = [
   "uuid/serde",
   "bevy_ecs/serialize",
   "bevy_platform/serialize",
+  "bevy_render?/serialize",
 ]
 
 [dependencies]

--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -51,6 +51,7 @@ serialize = [
   "smallvec/serde",
   "bevy_math/serialize",
   "bevy_platform/serialize",
+  "bevy_render/serialize",
 ]
 bevy_ui_picking_backend = ["bevy_picking", "dep:uuid"]
 bevy_ui_debug = []


### PR DESCRIPTION
# Objective

- Alternative to and closes #19545  
- Resolves #9790 by providing an alternative
- `Mesh` is meant as format optimized for the renderer. There are no guarantees about how it looks, and breaking changes are expected
- This makes it not feasible to implement `Reflect` for all its fields or `Serialize` it.
- However, (de)serializing a mesh has an important use case: send a mesh over BRP to another process, like an editor!
  - In my case, I'm making a navmesh editor and need to copy the level that is running in the game into the editor process
  - Assets don't solve this because
    - They don't work over BRP #19709 and 
    - The meshes may be procedural
- So, we need a way to (de)serialize a mesh for short-term transmissions.

## Solution

- Like `SerializedAnimationGraph` before, let's make a `SerializedMesh`!
- This type's fields are all `private` because we want to keep the internals of `Mesh` hidden, and exposing them
  through this secondary struct would be counter-productive to that
- All this struct can do is be serialized, be deserialized, and be converted to and from a mesh
- It's not a lossless transmission: the handle for morph targets is ignored, and things like the render usages make no sense to be transmitted imo

## Future Work

The same song and dance needs to happen for `Image`, but I can live with completely white meshes for the moment lol

## Testing

- Added a simple test

