### PR TITLE
Add newlines before impl blocks

### DIFF
--- a/benches/benches/bevy_ecs/change_detection.rs
+++ b/benches/benches/bevy_ecs/change_detection.rs
@@ -49,6 +49,7 @@ impl BenchModify for Table {
         black_box(self.0)
     }
 }
+
 impl BenchModify for Sparse {
     fn bench_modify(&mut self) -> f32 {
         self.0 += 1f32;

--- a/crates/bevy_app/src/propagate.rs
+++ b/crates/bevy_app/src/propagate.rs
@@ -88,6 +88,7 @@ impl<C: Component + Clone + PartialEq> core::fmt::Debug for PropagateSet<C> {
 }
 
 impl<C: Component + Clone + PartialEq> Eq for PropagateSet<C> {}
+
 impl<C: Component + Clone + PartialEq> core::hash::Hash for PropagateSet<C> {
     fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
         self._p.hash(state);

--- a/crates/bevy_asset/src/direct_access_ext.rs
+++ b/crates/bevy_asset/src/direct_access_ext.rs
@@ -20,6 +20,7 @@ pub trait DirectAssetAccessExt {
         settings: impl Fn(&mut S) + Send + Sync + 'static,
     ) -> Handle<A>;
 }
+
 impl DirectAssetAccessExt for World {
     /// Insert an asset similarly to [`Assets::add`].
     ///

--- a/crates/bevy_asset/src/io/embedded/embedded_watcher.rs
+++ b/crates/bevy_asset/src/io/embedded/embedded_watcher.rs
@@ -56,6 +56,7 @@ pub(crate) struct EmbeddedEventHandler {
     dir: Dir,
     last_event: Option<AssetSourceEvent>,
 }
+
 impl FilesystemEventHandler for EmbeddedEventHandler {
     fn begin(&mut self) {
         self.last_event = None;

--- a/crates/bevy_asset/src/io/embedded/mod.rs
+++ b/crates/bevy_asset/src/io/embedded/mod.rs
@@ -141,16 +141,19 @@ impl EmbeddedAssetRegistry {
 pub trait GetAssetServer {
     fn get_asset_server(&self) -> &AssetServer;
 }
+
 impl GetAssetServer for App {
     fn get_asset_server(&self) -> &AssetServer {
         self.world().get_asset_server()
     }
 }
+
 impl GetAssetServer for World {
     fn get_asset_server(&self) -> &AssetServer {
         self.resource()
     }
 }
+
 impl GetAssetServer for AssetServer {
     fn get_asset_server(&self) -> &AssetServer {
         self

--- a/crates/bevy_asset/src/reflect.rs
+++ b/crates/bevy_asset/src/reflect.rs
@@ -223,6 +223,7 @@ pub struct ReflectHandle {
     downcast_handle_untyped: fn(&dyn Any) -> Option<UntypedHandle>,
     typed: fn(UntypedHandle) -> Box<dyn Reflect>,
 }
+
 impl ReflectHandle {
     /// The [`TypeId`] of the asset
     pub fn asset_type_id(&self) -> TypeId {

--- a/crates/bevy_audio/src/audio_output.rs
+++ b/crates/bevy_audio/src/audio_output.rs
@@ -57,6 +57,7 @@ pub struct PlaybackRemoveMarker;
 pub(crate) struct EarPositions<'w, 's> {
     pub(crate) query: Query<'w, 's, (Entity, &'static GlobalTransform, &'static SpatialListener)>,
 }
+
 impl<'w, 's> EarPositions<'w, 's> {
     /// Gets a set of transformed ear positions.
     ///

--- a/crates/bevy_core_pipeline/src/core_3d/camera_3d.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/camera_3d.rs
@@ -80,6 +80,7 @@ impl From<TextureUsages> for Camera3dDepthTextureUsage {
         Self(value.bits())
     }
 }
+
 impl From<Camera3dDepthTextureUsage> for TextureUsages {
     fn from(value: Camera3dDepthTextureUsage) -> Self {
         Self::from_bits_truncate(value.0)

--- a/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
@@ -17,11 +17,13 @@ pub struct FrameTimeDiagnosticsPlugin {
     /// The smoothing factor for the exponential moving average. Usually `2.0 / (history_length + 1.0)`.
     pub smoothing_factor: f64,
 }
+
 impl Default for FrameTimeDiagnosticsPlugin {
     fn default() -> Self {
         Self::new(DEFAULT_MAX_HISTORY_LENGTH)
     }
 }
+
 impl FrameTimeDiagnosticsPlugin {
     /// Creates a new `FrameTimeDiagnosticsPlugin` with the specified `max_history_length` and a
     /// reasonable `smoothing_factor`.

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -960,6 +960,7 @@ impl Index<RangeFrom<ArchetypeGeneration>> for Archetypes {
         &self.archetypes[index.start.0.index()..]
     }
 }
+
 impl Index<ArchetypeId> for Archetypes {
     type Output = Archetype;
 

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -623,6 +623,7 @@ pub trait ComponentMutability: private::Seal + 'static {
 pub struct Immutable;
 
 impl private::Seal for Immutable {}
+
 impl ComponentMutability for Immutable {
     const MUTABLE: bool = false;
 }
@@ -633,6 +634,7 @@ impl ComponentMutability for Immutable {
 pub struct Mutable;
 
 impl private::Seal for Mutable {}
+
 impl ComponentMutability for Mutable {
     const MUTABLE: bool = true;
 }
@@ -2968,6 +2970,7 @@ impl<T> Default for DefaultCloneBehaviorSpecialization<T> {
 pub trait DefaultCloneBehaviorBase {
     fn default_clone_behavior(&self) -> ComponentCloneBehavior;
 }
+
 impl<C> DefaultCloneBehaviorBase for DefaultCloneBehaviorSpecialization<C> {
     fn default_clone_behavior(&self) -> ComponentCloneBehavior {
         ComponentCloneBehavior::Default
@@ -2979,6 +2982,7 @@ impl<C> DefaultCloneBehaviorBase for DefaultCloneBehaviorSpecialization<C> {
 pub trait DefaultCloneBehaviorViaClone {
     fn default_clone_behavior(&self) -> ComponentCloneBehavior;
 }
+
 impl<C: Clone + Component> DefaultCloneBehaviorViaClone for &DefaultCloneBehaviorSpecialization<C> {
     fn default_clone_behavior(&self) -> ComponentCloneBehavior {
         ComponentCloneBehavior::clone::<C>()

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -718,6 +718,7 @@ impl<'a> Iterator for ReserveEntitiesIterator<'a> {
 }
 
 impl<'a> ExactSizeIterator for ReserveEntitiesIterator<'a> {}
+
 impl<'a> core::iter::FusedIterator for ReserveEntitiesIterator<'a> {}
 
 // SAFETY: Newly reserved entity values are unique.

--- a/crates/bevy_ecs/src/entity/unique_array.rs
+++ b/crates/bevy_ecs/src/entity/unique_array.rs
@@ -154,6 +154,7 @@ impl<T: EntityEquivalent, const N: usize> DerefMut for UniqueEntityEquivalentArr
         unsafe { UniqueEntityEquivalentSlice::from_slice_unchecked_mut(&mut self.0) }
     }
 }
+
 impl<T: EntityEquivalent> Default for UniqueEntityEquivalentArray<T, 0> {
     fn default() -> Self {
         Self(Default::default())
@@ -527,6 +528,7 @@ impl<T: PartialEq<U>, U: EntityEquivalent, const N: usize>
         self.eq(&other.0)
     }
 }
+
 impl<T: PartialEq<U>, U: EntityEquivalent, const N: usize>
     PartialEq<&UniqueEntityEquivalentArray<U, N>> for VecDeque<T>
 {
@@ -550,6 +552,7 @@ impl<T: PartialEq<U>, U: EntityEquivalent, const N: usize>
         self.eq(&other.0)
     }
 }
+
 impl<T: PartialEq<U>, U: EntityEquivalent, const N: usize>
     PartialEq<UniqueEntityEquivalentArray<U, N>> for VecDeque<T>
 {

--- a/crates/bevy_ecs/src/name.rs
+++ b/crates/bevy_ecs/src/name.rs
@@ -159,6 +159,7 @@ impl From<&str> for Name {
         Name::new(name.to_owned())
     }
 }
+
 impl From<String> for Name {
     #[inline(always)]
     fn from(name: String) -> Self {
@@ -174,12 +175,14 @@ impl AsRef<str> for Name {
         &self.name
     }
 }
+
 impl From<&Name> for String {
     #[inline(always)]
     fn from(val: &Name) -> String {
         val.as_str().to_owned()
     }
 }
+
 impl From<Name> for String {
     #[inline(always)]
     fn from(val: Name) -> String {

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -1489,6 +1489,7 @@ impl<T: Component> Clone for ReadFetch<'_, T> {
         *self
     }
 }
+
 impl<T: Component> Copy for ReadFetch<'_, T> {}
 
 /// SAFETY:
@@ -1665,6 +1666,7 @@ impl<T: Component> Clone for RefFetch<'_, T> {
         *self
     }
 }
+
 impl<T: Component> Copy for RefFetch<'_, T> {}
 
 /// SAFETY:
@@ -1873,6 +1875,7 @@ impl<T: Component> Clone for WriteFetch<'_, T> {
         *self
     }
 }
+
 impl<T: Component> Copy for WriteFetch<'_, T> {}
 
 /// SAFETY:

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -1240,6 +1240,7 @@ unsafe impl QueryFilter for Spawned {
 pub trait ArchetypeFilter: QueryFilter {}
 
 impl<T: Component> ArchetypeFilter for With<T> {}
+
 impl<T: Component> ArchetypeFilter for Without<T> {}
 
 macro_rules! impl_archetype_filter_tuple {

--- a/crates/bevy_ecs/src/schedule/pass.rs
+++ b/crates/bevy_ecs/src/schedule/pass.rs
@@ -51,6 +51,7 @@ pub(super) trait ScheduleBuildPassObj: Send + Sync + Debug {
     );
     fn add_dependency(&mut self, from: NodeId, to: NodeId, all_options: &TypeIdMap<Box<dyn Any>>);
 }
+
 impl<T: ScheduleBuildPass> ScheduleBuildPassObj for T {
     fn build(
         &mut self,

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -235,6 +235,7 @@ pub enum Chain {
     /// will be added between the successive elements.
     Chained(TypeIdMap<Box<dyn Any>>),
 }
+
 impl Chain {
     /// Specify that the systems must be chained.
     pub fn set_chained(&mut self) {

--- a/crates/bevy_ecs/src/spawn.rs
+++ b/crates/bevy_ecs/src/spawn.rs
@@ -210,6 +210,7 @@ unsafe impl<R: Relationship, L: SpawnableList<R> + Send + Sync + 'static> Bundle
         );
     }
 }
+
 impl<R: Relationship, L: SpawnableList<R>> DynamicBundle for SpawnRelatedBundle<R, L> {
     type Effect = Self;
 

--- a/crates/bevy_ecs/src/system/observer_system.rs
+++ b/crates/bevy_ecs/src/system/observer_system.rs
@@ -73,6 +73,7 @@ where
         InfallibleObserverWrapper::new(IntoSystem::into_system(this))
     }
 }
+
 impl<E, B, M, S> IntoObserverSystem<E, B, (Never, M), Result> for S
 where
     S: IntoSystem<On<'static, E, B>, Never, M> + Send + 'static,

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1399,6 +1399,7 @@ impl<'w, T> Deref for NonSend<'w, T> {
         self.value
     }
 }
+
 impl<'a, T> From<NonSendMut<'a, T>> for NonSend<'a, T> {
     fn from(nsm: NonSendMut<'a, T>) -> Self {
         Self {

--- a/crates/bevy_gilrs/src/lib.rs
+++ b/crates/bevy_gilrs/src/lib.rs
@@ -47,6 +47,7 @@ pub(crate) struct Gilrs {
     #[cfg(not(target_arch = "wasm32"))]
     cell: SyncCell<gilrs::Gilrs>,
 }
+
 impl Gilrs {
     #[inline]
     pub fn with(&mut self, f: impl FnOnce(&mut gilrs::Gilrs)) {

--- a/crates/bevy_gizmos/src/grid.rs
+++ b/crates/bevy_gizmos/src/grid.rs
@@ -172,6 +172,7 @@ where
         );
     }
 }
+
 impl<Config, Clear> GizmoBuffer<Config, Clear>
 where
     Config: GizmoConfigGroup,

--- a/crates/bevy_image/src/texture_atlas.rs
+++ b/crates/bevy_image/src/texture_atlas.rs
@@ -34,6 +34,7 @@ pub struct TextureAtlasSources {
     /// Maps from a specific image handle to the index in `textures` where they can be found.
     pub texture_ids: HashMap<AssetId<Image>, usize>,
 }
+
 impl TextureAtlasSources {
     /// Retrieves the texture *section* index of the given `texture` handle.
     pub fn texture_index(&self, texture: impl Into<AssetId<Image>>) -> Option<usize> {

--- a/crates/bevy_math/src/cubic_splines/mod.rs
+++ b/crates/bevy_math/src/cubic_splines/mod.rs
@@ -1347,6 +1347,7 @@ pub struct RationalSegment<P: VectorSpace> {
     /// The width of the domain of this segment.
     pub knot_span: f32,
 }
+
 impl<P: VectorSpace<Scalar = f32>> RationalSegment<P> {
     /// Instantaneous position of a point at parametric value `t` in `[0, 1]`.
     #[inline]

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -35,6 +35,7 @@ pub struct Circle {
     /// The radius of the circle
     pub radius: f32,
 }
+
 impl Primitive2d for Circle {}
 
 impl Default for Circle {
@@ -124,6 +125,7 @@ pub struct Arc2d {
     /// Half the angle defining the arc
     pub half_angle: f32,
 }
+
 impl Primitive2d for Arc2d {}
 
 impl Default for Arc2d {
@@ -290,6 +292,7 @@ pub struct CircularSector {
     #[cfg_attr(all(feature = "serialize", feature = "alloc"), serde(flatten))]
     pub arc: Arc2d,
 }
+
 impl Primitive2d for CircularSector {}
 
 impl Default for CircularSector {
@@ -433,6 +436,7 @@ pub struct CircularSegment {
     #[cfg_attr(all(feature = "serialize", feature = "alloc"), serde(flatten))]
     pub arc: Arc2d,
 }
+
 impl Primitive2d for CircularSegment {}
 
 impl Default for CircularSegment {
@@ -453,6 +457,7 @@ impl Measured2d for CircularSegment {
         self.chord_length() + self.arc_length()
     }
 }
+
 impl CircularSegment {
     /// Create a new [`CircularSegment`] from a `radius`, and an `angle`
     #[inline(always)]
@@ -788,6 +793,7 @@ pub struct Ellipse {
     /// This corresponds to the two perpendicular radii defining the ellipse.
     pub half_size: Vec2,
 }
+
 impl Primitive2d for Ellipse {}
 
 impl Default for Ellipse {
@@ -939,6 +945,7 @@ pub struct Annulus {
     /// The outer circle of the annulus
     pub outer_circle: Circle,
 }
+
 impl Primitive2d for Annulus {}
 
 impl Default for Annulus {
@@ -1036,6 +1043,7 @@ pub struct Rhombus {
     /// Size of the horizontal and vertical diagonals of the rhombus
     pub half_diagonals: Vec2,
 }
+
 impl Primitive2d for Rhombus {}
 
 impl Default for Rhombus {
@@ -1171,6 +1179,7 @@ pub struct Plane2d {
     /// The normal of the plane. The plane will be placed perpendicular to this direction
     pub normal: Dir2,
 }
+
 impl Primitive2d for Plane2d {}
 
 impl Default for Plane2d {
@@ -1213,6 +1222,7 @@ pub struct Line2d {
     /// and its opposite direction
     pub direction: Dir2,
 }
+
 impl Primitive2d for Line2d {}
 
 /// A line segment defined by two endpoints in 2D space.
@@ -1232,6 +1242,7 @@ pub struct Segment2d {
     /// The endpoints of the line segment.
     pub vertices: [Vec2; 2],
 }
+
 impl Primitive2d for Segment2d {}
 
 impl Segment2d {
@@ -1504,6 +1515,7 @@ pub struct Polyline2d<const N: usize> {
     #[cfg_attr(feature = "serialize", serde(with = "super::serde::array"))]
     pub vertices: [Vec2; N],
 }
+
 impl<const N: usize> Primitive2d for Polyline2d<N> {}
 
 impl<const N: usize> FromIterator<Vec2> for Polyline2d<N> {
@@ -1573,6 +1585,7 @@ pub struct Triangle2d {
     /// The vertices of the triangle
     pub vertices: [Vec2; 3],
 }
+
 impl Primitive2d for Triangle2d {}
 
 impl Default for Triangle2d {
@@ -1745,6 +1758,7 @@ pub struct Rectangle {
     /// Half of the width and height of the rectangle
     pub half_size: Vec2,
 }
+
 impl Primitive2d for Rectangle {}
 
 impl Default for Rectangle {
@@ -1838,6 +1852,7 @@ pub struct Polygon<const N: usize> {
     #[cfg_attr(feature = "serialize", serde(with = "super::serde::array"))]
     pub vertices: [Vec2; N],
 }
+
 impl<const N: usize> Primitive2d for Polygon<N> {}
 
 impl<const N: usize> FromIterator<Vec2> for Polygon<N> {
@@ -1892,6 +1907,7 @@ pub struct ConvexPolygon<const N: usize> {
     #[cfg_attr(feature = "serialize", serde(with = "super::serde::array"))]
     vertices: [Vec2; N],
 }
+
 impl<const N: usize> Primitive2d for ConvexPolygon<N> {}
 
 /// An error that happens when creating a [`ConvexPolygon`].
@@ -2013,6 +2029,7 @@ pub struct RegularPolygon {
     /// The number of sides
     pub sides: u32,
 }
+
 impl Primitive2d for RegularPolygon {}
 
 impl Default for RegularPolygon {
@@ -2160,6 +2177,7 @@ pub struct Capsule2d {
     /// Half the height of the capsule, excluding the semicircles
     pub half_length: f32,
 }
+
 impl Primitive2d for Capsule2d {}
 
 impl Default for Capsule2d {

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -31,6 +31,7 @@ pub struct Sphere {
     /// The radius of the sphere
     pub radius: f32,
 }
+
 impl Primitive3d for Sphere {}
 
 impl Default for Sphere {
@@ -105,6 +106,7 @@ pub struct Plane3d {
     /// Half of the width and height of the plane
     pub half_size: Vec2,
 }
+
 impl Primitive3d for Plane3d {}
 
 impl Default for Plane3d {
@@ -175,6 +177,7 @@ pub struct InfinitePlane3d {
     /// The normal of the plane. The plane will be placed perpendicular to this direction
     pub normal: Dir3,
 }
+
 impl Primitive3d for InfinitePlane3d {}
 
 impl Default for InfinitePlane3d {
@@ -351,6 +354,7 @@ pub struct Line3d {
     /// The direction of the line
     pub direction: Dir3,
 }
+
 impl Primitive3d for Line3d {}
 
 /// A line segment defined by two endpoints in 3D space.
@@ -370,6 +374,7 @@ pub struct Segment3d {
     /// The endpoints of the line segment.
     pub vertices: [Vec3; 2],
 }
+
 impl Primitive3d for Segment3d {}
 
 impl Segment3d {
@@ -578,6 +583,7 @@ pub struct Polyline3d<const N: usize> {
     #[cfg_attr(feature = "serialize", serde(with = "super::serde::array"))]
     pub vertices: [Vec3; N],
 }
+
 impl<const N: usize> Primitive3d for Polyline3d<N> {}
 
 impl<const N: usize> FromIterator<Vec3> for Polyline3d<N> {
@@ -648,6 +654,7 @@ pub struct Cuboid {
     /// Half of the width, height and depth of the cuboid
     pub half_size: Vec3,
 }
+
 impl Primitive3d for Cuboid {}
 
 impl Default for Cuboid {
@@ -742,6 +749,7 @@ pub struct Cylinder {
     /// The half height of the cylinder
     pub half_height: f32,
 }
+
 impl Primitive3d for Cylinder {}
 
 impl Default for Cylinder {
@@ -820,6 +828,7 @@ pub struct Capsule3d {
     /// Half the height of the capsule, excluding the hemispheres
     pub half_length: f32,
 }
+
 impl Primitive3d for Capsule3d {}
 
 impl Default for Capsule3d {
@@ -890,6 +899,7 @@ pub struct Cone {
     /// The height of the cone
     pub height: f32,
 }
+
 impl Primitive3d for Cone {}
 
 impl Default for Cone {
@@ -974,6 +984,7 @@ pub struct ConicalFrustum {
     /// The height of the frustum
     pub height: f32,
 }
+
 impl Primitive3d for ConicalFrustum {}
 
 impl Default for ConicalFrustum {
@@ -1030,6 +1041,7 @@ pub struct Torus {
     #[doc(alias = "radius_of_revolution")]
     pub major_radius: f32,
 }
+
 impl Primitive3d for Torus {}
 
 impl Default for Torus {
@@ -1326,6 +1338,7 @@ pub struct Tetrahedron {
     /// The vertices of the tetrahedron.
     pub vertices: [Vec3; 4],
 }
+
 impl Primitive3d for Tetrahedron {}
 
 impl Default for Tetrahedron {
@@ -1433,6 +1446,7 @@ pub struct Extrusion<T: Primitive2d> {
     /// Half of the depth of the extrusion
     pub half_depth: f32,
 }
+
 impl<T: Primitive2d> Primitive3d for Extrusion<T> {}
 
 impl<T: Primitive2d> Extrusion<T> {

--- a/crates/bevy_math/src/primitives/polygon.rs
+++ b/crates/bevy_math/src/primitives/polygon.rs
@@ -34,6 +34,7 @@ struct SweepLineEvent {
     /// Type of the vertex (left or right)
     endpoint: Endpoint,
 }
+
 impl SweepLineEvent {
     #[cfg_attr(
         not(feature = "alloc"),
@@ -46,17 +47,21 @@ impl SweepLineEvent {
         }
     }
 }
+
 impl PartialEq for SweepLineEvent {
     fn eq(&self, other: &Self) -> bool {
         self.position() == other.position()
     }
 }
+
 impl Eq for SweepLineEvent {}
+
 impl PartialOrd for SweepLineEvent {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
+
 impl Ord for SweepLineEvent {
     fn cmp(&self, other: &Self) -> Ordering {
         xy_order(self.position(), other.position())
@@ -129,11 +134,13 @@ struct Segment {
     left: Vec2,
     right: Vec2,
 }
+
 impl PartialEq for Segment {
     fn eq(&self, other: &Self) -> bool {
         self.edge_index == other.edge_index
     }
 }
+
 impl Eq for Segment {}
 
 impl PartialOrd for Segment {
@@ -141,6 +148,7 @@ impl PartialOrd for Segment {
         Some(self.cmp(other))
     }
 }
+
 impl Ord for Segment {
     fn cmp(&self, other: &Self) -> Ordering {
         self.left

--- a/crates/bevy_mesh/src/index.rs
+++ b/crates/bevy_mesh/src/index.rs
@@ -163,6 +163,7 @@ impl Iterator for IndicesIter<'_> {
 }
 
 impl<'a> ExactSizeIterator for IndicesIter<'a> {}
+
 impl<'a> FusedIterator for IndicesIter<'a> {}
 
 impl From<&Indices> for IndexFormat {

--- a/crates/bevy_mesh/src/morph.rs
+++ b/crates/bevy_mesh/src/morph.rs
@@ -117,6 +117,7 @@ pub struct MorphWeights {
     /// The first mesh primitive assigned to these weights
     first_mesh: Option<Handle<Mesh>>,
 }
+
 impl MorphWeights {
     pub fn new(
         weights: Vec<f32>,
@@ -160,6 +161,7 @@ impl MorphWeights {
 pub struct MeshMorphWeights {
     weights: Vec<f32>,
 }
+
 impl MeshMorphWeights {
     pub fn new(weights: Vec<f32>) -> Result<Self, MorphBuildError> {
         if weights.len() > MAX_MORPH_WEIGHTS {
@@ -198,6 +200,7 @@ pub struct MorphAttributes {
     /// animated, as the `w` component is the sign and cannot be animated.
     pub tangent: Vec3,
 }
+
 impl From<[Vec3; 3]> for MorphAttributes {
     fn from([position, normal, tangent]: [Vec3; 3]) -> Self {
         MorphAttributes {
@@ -207,6 +210,7 @@ impl From<[Vec3; 3]> for MorphAttributes {
         }
     }
 }
+
 impl MorphAttributes {
     /// How many components `MorphAttributes` has.
     ///

--- a/crates/bevy_pbr/src/light/ambient_light.rs
+++ b/crates/bevy_pbr/src/light/ambient_light.rs
@@ -48,6 +48,7 @@ impl Default for AmbientLight {
         }
     }
 }
+
 impl AmbientLight {
     pub const NONE: AmbientLight = AmbientLight {
         color: Color::WHITE,

--- a/crates/bevy_pbr/src/parallax.rs
+++ b/crates/bevy_pbr/src/parallax.rs
@@ -33,6 +33,7 @@ pub enum ParallaxMappingMethod {
         max_steps: u32,
     },
 }
+
 impl ParallaxMappingMethod {
     /// [`ParallaxMappingMethod::Relief`] with a 5 steps, a reasonable default.
     pub const DEFAULT_RELIEF_MAPPING: Self = ParallaxMappingMethod::Relief { max_steps: 5 };

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -27,7 +27,9 @@ pub struct Unaligned;
 /// Trait that is only implemented for [`Aligned`] and [`Unaligned`] to work around the lack of ability
 /// to have const generics of an enum.
 pub trait IsAligned: sealed::Sealed {}
+
 impl IsAligned for Aligned {}
+
 impl IsAligned for Unaligned {}
 
 mod sealed {

--- a/crates/bevy_reflect/src/func/dynamic_function.rs
+++ b/crates/bevy_reflect/src/func/dynamic_function.rs
@@ -439,6 +439,7 @@ impl PartialReflect for DynamicFunction<'static> {
 }
 
 impl MaybeTyped for DynamicFunction<'static> {}
+
 impl RegisterForReflection for DynamicFunction<'static> {}
 
 impl_type_path!((in bevy_reflect) DynamicFunction<'env>);

--- a/crates/bevy_reflect/src/func/signature.rs
+++ b/crates/bevy_reflect/src/func/signature.rs
@@ -90,6 +90,7 @@ impl<'a, 'b> ArgListSignature<'a, 'b> {
 }
 
 impl Eq for ArgListSignature<'_, '_> {}
+
 impl PartialEq for ArgListSignature<'_, '_> {
     fn eq(&self, other: &Self) -> bool {
         self.len() == other.len() && self.iter().eq(other.iter())

--- a/crates/bevy_reflect/src/impls/smallvec.rs
+++ b/crates/bevy_reflect/src/impls/smallvec.rs
@@ -77,6 +77,7 @@ where
             .collect()
     }
 }
+
 impl<T: SmallArray + TypePath + Send + Sync> PartialReflect for SmallVec<T>
 where
     T::Item: FromReflect + MaybeTyped + TypePath,

--- a/crates/bevy_reflect/src/kind.rs
+++ b/crates/bevy_reflect/src/kind.rs
@@ -220,6 +220,7 @@ pub enum ReflectRef<'a> {
     /// [opaque]: ReflectKind::Opaque
     Opaque(&'a dyn PartialReflect),
 }
+
 impl_reflect_kind_conversions!(ReflectRef<'_>);
 
 impl<'a> ReflectRef<'a> {
@@ -285,6 +286,7 @@ pub enum ReflectMut<'a> {
     /// [opaque]: ReflectKind::Opaque
     Opaque(&'a mut dyn PartialReflect),
 }
+
 impl_reflect_kind_conversions!(ReflectMut<'_>);
 
 impl<'a> ReflectMut<'a> {
@@ -350,6 +352,7 @@ pub enum ReflectOwned {
     /// [opaque]: ReflectKind::Opaque
     Opaque(Box<dyn PartialReflect>),
 }
+
 impl_reflect_kind_conversions!(ReflectOwned);
 
 impl ReflectOwned {

--- a/crates/bevy_reflect/src/path/error.rs
+++ b/crates/bevy_reflect/src/path/error.rs
@@ -74,6 +74,7 @@ impl<'a> AccessError<'a> {
         self.offset.as_ref()
     }
 }
+
 impl fmt::Display for AccessError<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let AccessError {
@@ -126,4 +127,5 @@ impl fmt::Display for AccessError<'_> {
         }
     }
 }
+
 impl core::error::Error for AccessError<'_> {}

--- a/crates/bevy_reflect/src/path/mod.rs
+++ b/crates/bevy_reflect/src/path/mod.rs
@@ -82,6 +82,7 @@ pub trait ReflectPath<'a>: Sized {
         })
     }
 }
+
 impl<'a> ReflectPath<'a> for &'a str {
     fn reflect_element(self, mut root: &dyn PartialReflect) -> PathResult<'a, &dyn PartialReflect> {
         for (access, offset) in PathParser::new(self) {
@@ -437,6 +438,7 @@ impl ParsedPath {
         Ok(Self(parts))
     }
 }
+
 impl<'a> ReflectPath<'a> for &'a ParsedPath {
     fn reflect_element(self, mut root: &dyn PartialReflect) -> PathResult<'a, &dyn PartialReflect> {
         for OffsetAccess { access, offset } in &self.0 {
@@ -454,11 +456,13 @@ impl<'a> ReflectPath<'a> for &'a ParsedPath {
         Ok(root)
     }
 }
+
 impl<const N: usize> From<[OffsetAccess; N]> for ParsedPath {
     fn from(value: [OffsetAccess; N]) -> Self {
         ParsedPath(value.to_vec())
     }
 }
+
 impl From<Vec<Access<'static>>> for ParsedPath {
     fn from(value: Vec<Access<'static>>) -> Self {
         ParsedPath(
@@ -472,6 +476,7 @@ impl From<Vec<Access<'static>>> for ParsedPath {
         )
     }
 }
+
 impl<const N: usize> From<[Access<'static>; N]> for ParsedPath {
     fn from(value: [Access<'static>; N]) -> Self {
         value.to_vec().into()
@@ -493,12 +498,14 @@ impl fmt::Display for ParsedPath {
         Ok(())
     }
 }
+
 impl core::ops::Index<usize> for ParsedPath {
     type Output = OffsetAccess;
     fn index(&self, index: usize) -> &Self::Output {
         &self.0[index]
     }
 }
+
 impl core::ops::IndexMut<usize> for ParsedPath {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]

--- a/crates/bevy_reflect/src/path/parse.rs
+++ b/crates/bevy_reflect/src/path/parse.rs
@@ -38,6 +38,7 @@ pub(super) struct PathParser<'a> {
     path: &'a str,
     remaining: &'a [u8],
 }
+
 impl<'a> PathParser<'a> {
     pub(super) fn new(path: &'a str) -> Self {
         let remaining = path.as_bytes();
@@ -103,6 +104,7 @@ impl<'a> PathParser<'a> {
         self.path.len() - self.remaining.len()
     }
 }
+
 impl<'a> Iterator for PathParser<'a> {
     type Item = (Result<Access<'a>, ReflectPathError<'a>>, usize);
 
@@ -149,6 +151,7 @@ enum Token<'a> {
     CloseBracket = b']',
     Ident(Ident<'a>),
 }
+
 impl fmt::Display for Token<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -160,6 +163,7 @@ impl fmt::Display for Token<'_> {
         }
     }
 }
+
 impl<'a> Token<'a> {
     const SYMBOLS: &'static [u8] = b".#[]";
     fn symbol_from_byte(byte: u8) -> Option<Self> {

--- a/crates/bevy_reflect/src/tuple.rs
+++ b/crates/bevy_reflect/src/tuple.rs
@@ -649,17 +649,29 @@ macro_rules! impl_reflect_tuple {
 }
 
 impl_reflect_tuple! {}
+
 impl_reflect_tuple! {0: A}
+
 impl_reflect_tuple! {0: A, 1: B}
+
 impl_reflect_tuple! {0: A, 1: B, 2: C}
+
 impl_reflect_tuple! {0: A, 1: B, 2: C, 3: D}
+
 impl_reflect_tuple! {0: A, 1: B, 2: C, 3: D, 4: E}
+
 impl_reflect_tuple! {0: A, 1: B, 2: C, 3: D, 4: E, 5: F}
+
 impl_reflect_tuple! {0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G}
+
 impl_reflect_tuple! {0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H}
+
 impl_reflect_tuple! {0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I}
+
 impl_reflect_tuple! {0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I, 9: J}
+
 impl_reflect_tuple! {0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I, 9: J, 10: K}
+
 impl_reflect_tuple! {0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I, 9: J, 10: K, 11: L}
 
 macro_rules! impl_type_path_tuple {

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -689,6 +689,7 @@ pub trait TypeData: Downcast + Send + Sync {
     /// Creates a type-erased clone of this value.
     fn clone_type_data(&self) -> Box<dyn TypeData>;
 }
+
 impl_downcast!(TypeData);
 
 impl<T: 'static + Send + Sync> TypeData for T

--- a/crates/bevy_render/src/render_resource/gpu_array_buffer.rs
+++ b/crates/bevy_render/src/render_resource/gpu_array_buffer.rs
@@ -14,6 +14,7 @@ use wgpu::{BindingResource, BufferUsages};
 
 /// Trait for types able to go in a [`GpuArrayBuffer`].
 pub trait GpuArrayBufferable: ShaderType + ShaderSize + WriteInto + Clone {}
+
 impl<T: ShaderType + ShaderSize + WriteInto + Clone> GpuArrayBufferable for T {}
 
 /// Stores an array of elements to be transferred to the GPU and made accessible to shaders as a read-only array.

--- a/crates/bevy_tasks/src/executor.rs
+++ b/crates/bevy_tasks/src/executor.rs
@@ -65,9 +65,11 @@ impl LocalExecutor<'_> {
 }
 
 impl UnwindSafe for Executor<'_> {}
+
 impl RefUnwindSafe for Executor<'_> {}
 
 impl UnwindSafe for LocalExecutor<'_> {}
+
 impl RefUnwindSafe for LocalExecutor<'_> {}
 
 impl fmt::Debug for Executor<'_> {

--- a/crates/bevy_tasks/src/lib.rs
+++ b/crates/bevy_tasks/src/lib.rs
@@ -32,6 +32,7 @@ pub use conditional_send::*;
 /// Use [`ConditionalSendFuture`] for a future with an optional Send trait bound, as on certain platforms (eg. Wasm),
 /// futures aren't Send.
 pub trait ConditionalSendFuture: Future + ConditionalSend {}
+
 impl<T: Future + ConditionalSend> ConditionalSendFuture for T {}
 
 use alloc::boxed::Box;

--- a/crates/bevy_tasks/src/thread_executor.rs
+++ b/crates/bevy_tasks/src/thread_executor.rs
@@ -24,7 +24,7 @@ use futures_lite::Future;
 ///         // we cannot get the ticker from another thread
 ///         let not_thread_ticker = thread_executor.ticker();
 ///         assert!(not_thread_ticker.is_none());
-///         
+///
 ///         // but we can spawn tasks from another thread
 ///         thread_executor.spawn(async move {
 ///             count_clone.fetch_add(1, Ordering::Relaxed);
@@ -98,6 +98,7 @@ pub struct ThreadExecutorTicker<'task, 'ticker> {
     // make type not send or sync
     _marker: PhantomData<*const ()>,
 }
+
 impl<'task, 'ticker> ThreadExecutorTicker<'task, 'ticker> {
     /// Tick the thread executor.
     pub async fn tick(&self) {

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -1043,9 +1043,11 @@ pub enum BoxSizing {
     /// Length styles like width and height refer to the "content box" size (size excluding padding and border)
     ContentBox,
 }
+
 impl BoxSizing {
     pub const DEFAULT: Self = Self::BorderBox;
 }
+
 impl Default for BoxSizing {
     fn default() -> Self {
         Self::DEFAULT

--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -570,131 +570,157 @@ impl From<AppLifecycle> for WindowEvent {
         Self::AppLifecycle(e)
     }
 }
+
 impl From<CursorEntered> for WindowEvent {
     fn from(e: CursorEntered) -> Self {
         Self::CursorEntered(e)
     }
 }
+
 impl From<CursorLeft> for WindowEvent {
     fn from(e: CursorLeft) -> Self {
         Self::CursorLeft(e)
     }
 }
+
 impl From<CursorMoved> for WindowEvent {
     fn from(e: CursorMoved) -> Self {
         Self::CursorMoved(e)
     }
 }
+
 impl From<FileDragAndDrop> for WindowEvent {
     fn from(e: FileDragAndDrop) -> Self {
         Self::FileDragAndDrop(e)
     }
 }
+
 impl From<Ime> for WindowEvent {
     fn from(e: Ime) -> Self {
         Self::Ime(e)
     }
 }
+
 impl From<RequestRedraw> for WindowEvent {
     fn from(e: RequestRedraw) -> Self {
         Self::RequestRedraw(e)
     }
 }
+
 impl From<WindowBackendScaleFactorChanged> for WindowEvent {
     fn from(e: WindowBackendScaleFactorChanged) -> Self {
         Self::WindowBackendScaleFactorChanged(e)
     }
 }
+
 impl From<WindowCloseRequested> for WindowEvent {
     fn from(e: WindowCloseRequested) -> Self {
         Self::WindowCloseRequested(e)
     }
 }
+
 impl From<WindowCreated> for WindowEvent {
     fn from(e: WindowCreated) -> Self {
         Self::WindowCreated(e)
     }
 }
+
 impl From<WindowDestroyed> for WindowEvent {
     fn from(e: WindowDestroyed) -> Self {
         Self::WindowDestroyed(e)
     }
 }
+
 impl From<WindowFocused> for WindowEvent {
     fn from(e: WindowFocused) -> Self {
         Self::WindowFocused(e)
     }
 }
+
 impl From<WindowMoved> for WindowEvent {
     fn from(e: WindowMoved) -> Self {
         Self::WindowMoved(e)
     }
 }
+
 impl From<WindowOccluded> for WindowEvent {
     fn from(e: WindowOccluded) -> Self {
         Self::WindowOccluded(e)
     }
 }
+
 impl From<WindowResized> for WindowEvent {
     fn from(e: WindowResized) -> Self {
         Self::WindowResized(e)
     }
 }
+
 impl From<WindowScaleFactorChanged> for WindowEvent {
     fn from(e: WindowScaleFactorChanged) -> Self {
         Self::WindowScaleFactorChanged(e)
     }
 }
+
 impl From<WindowThemeChanged> for WindowEvent {
     fn from(e: WindowThemeChanged) -> Self {
         Self::WindowThemeChanged(e)
     }
 }
+
 impl From<MouseButtonInput> for WindowEvent {
     fn from(e: MouseButtonInput) -> Self {
         Self::MouseButtonInput(e)
     }
 }
+
 impl From<MouseMotion> for WindowEvent {
     fn from(e: MouseMotion) -> Self {
         Self::MouseMotion(e)
     }
 }
+
 impl From<MouseWheel> for WindowEvent {
     fn from(e: MouseWheel) -> Self {
         Self::MouseWheel(e)
     }
 }
+
 impl From<PinchGesture> for WindowEvent {
     fn from(e: PinchGesture) -> Self {
         Self::PinchGesture(e)
     }
 }
+
 impl From<RotationGesture> for WindowEvent {
     fn from(e: RotationGesture) -> Self {
         Self::RotationGesture(e)
     }
 }
+
 impl From<DoubleTapGesture> for WindowEvent {
     fn from(e: DoubleTapGesture) -> Self {
         Self::DoubleTapGesture(e)
     }
 }
+
 impl From<PanGesture> for WindowEvent {
     fn from(e: PanGesture) -> Self {
         Self::PanGesture(e)
     }
 }
+
 impl From<TouchInput> for WindowEvent {
     fn from(e: TouchInput) -> Self {
         Self::TouchInput(e)
     }
 }
+
 impl From<KeyboardInput> for WindowEvent {
     fn from(e: KeyboardInput) -> Self {
         Self::KeyboardInput(e)
     }
 }
+
 impl From<KeyboardFocusLost> for WindowEvent {
     fn from(e: KeyboardFocusLost) -> Self {
         Self::KeyboardFocusLost(e)

--- a/examples/3d/meshlet.rs
+++ b/examples/3d/meshlet.rs
@@ -128,4 +128,5 @@ fn setup(
 struct MeshletDebugMaterial {
     _dummy: (),
 }
+
 impl Material for MeshletDebugMaterial {}

--- a/examples/3d/parallax_mapping.rs
+++ b/examples/3d/parallax_mapping.rs
@@ -53,6 +53,7 @@ impl Default for CurrentMethod {
         CurrentMethod(ParallaxMappingMethod::Relief { max_steps: 4 })
     }
 }
+
 impl fmt::Display for CurrentMethod {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.0 {
@@ -63,6 +64,7 @@ impl fmt::Display for CurrentMethod {
         }
     }
 }
+
 impl CurrentMethod {
     fn next_method(&mut self) {
         use ParallaxMappingMethod::*;

--- a/examples/animation/color_animation.rs
+++ b/examples/animation/color_animation.rs
@@ -4,10 +4,12 @@ use bevy::{math::VectorSpace, prelude::*};
 
 // We define this trait so we can reuse the same code for multiple color types that may be implemented using curves.
 trait CurveColor: VectorSpace<Scalar = f32> + Into<Color> + Send + Sync + 'static {}
+
 impl<T: VectorSpace<Scalar = f32> + Into<Color> + Send + Sync + 'static> CurveColor for T {}
 
 // We define this trait so we can reuse the same code for multiple color types that may be implemented using mixing.
 trait MixedColor: Mix + Into<Color> + Send + Sync + 'static {}
+
 impl<T: Mix + Into<Color> + Send + Sync + 'static> MixedColor for T {}
 
 #[derive(Debug, Component)]

--- a/examples/app/log_layers_ecs.rs
+++ b/examples/app/log_layers_ecs.rs
@@ -63,6 +63,7 @@ fn transfer_log_events(
 struct CaptureLayer {
     sender: mpsc::Sender<LogEvent>,
 }
+
 impl<S: Subscriber> Layer<S> for CaptureLayer {
     fn on_event(
         &self,

--- a/examples/shader/custom_render_phase.rs
+++ b/examples/shader/custom_render_phase.rs
@@ -165,6 +165,7 @@ struct StencilPipeline {
     /// This isn't required, it's only done like this for simplicity.
     shader_handle: Handle<Shader>,
 }
+
 impl FromWorld for StencilPipeline {
     fn from_world(world: &mut World) -> Self {
         Self {
@@ -382,6 +383,7 @@ impl GetBatchData for StencilPipeline {
         Some((mesh_uniform, None))
     }
 }
+
 impl GetFullBatchData for StencilPipeline {
     type BufferInputData = MeshInputUniform;
 

--- a/examples/shader/gpu_readback.rs
+++ b/examples/shader/gpu_readback.rs
@@ -193,6 +193,7 @@ struct ComputeNodeLabel;
 /// The node that will execute the compute shader
 #[derive(Default)]
 struct ComputeNode {}
+
 impl render_graph::Node for ComputeNode {
     fn run(
         &self,

--- a/examples/shader/specialized_mesh_pipeline.rs
+++ b/examples/shader/specialized_mesh_pipeline.rs
@@ -171,6 +171,7 @@ struct CustomMeshPipeline {
     /// This isn't required, it's only done like this for simplicity.
     shader_handle: Handle<Shader>,
 }
+
 impl FromWorld for CustomMeshPipeline {
     fn from_world(world: &mut World) -> Self {
         // Load the shader

--- a/examples/tools/gamepad_viewer.rs
+++ b/examples/tools/gamepad_viewer.rs
@@ -48,6 +48,7 @@ struct ButtonMaterials {
     normal: MeshMaterial2d<ColorMaterial>,
     active: MeshMaterial2d<ColorMaterial>,
 }
+
 impl FromWorld for ButtonMaterials {
     fn from_world(world: &mut World) -> Self {
         Self {
@@ -63,6 +64,7 @@ struct ButtonMeshes {
     start_pause: Mesh2d,
     trigger: Mesh2d,
 }
+
 impl FromWorld for ButtonMeshes {
     fn from_world(world: &mut World) -> Self {
         Self {

--- a/examples/tools/scene_viewer/animation_plugin.rs
+++ b/examples/tools/scene_viewer/animation_plugin.rs
@@ -11,6 +11,7 @@ struct Clips {
     nodes: Vec<AnimationNodeIndex>,
     current: usize,
 }
+
 impl Clips {
     fn new(clips: Vec<AnimationNodeIndex>) -> Self {
         Clips {

--- a/examples/tools/scene_viewer/morph_viewer_plugin.rs
+++ b/examples/tools/scene_viewer/morph_viewer_plugin.rs
@@ -80,6 +80,7 @@ enum WeightChange {
     Increase,
     Decrease,
 }
+
 impl WeightChange {
     fn reverse(&mut self) {
         *self = match *self {
@@ -112,6 +113,7 @@ struct Target {
     weight: f32,
     change_dir: WeightChange,
 }
+
 impl fmt::Display for Target {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match (self.name.as_ref(), self.entity_name.as_ref()) {
@@ -123,6 +125,7 @@ impl fmt::Display for Target {
         write!(f, ": {}", self.weight)
     }
 }
+
 impl Target {
     fn text_span(&self, key: &str, style: TextFont) -> (TextSpan, TextFont) {
         (TextSpan::new(format!("[{key}] {self}\n")), style)
@@ -160,6 +163,7 @@ struct MorphKey {
     modifiers: &'static [KeyCode],
     key: KeyCode,
 }
+
 impl MorphKey {
     const fn new(name: &'static str, modifiers: &'static [KeyCode], key: KeyCode) -> Self {
         MorphKey {

--- a/examples/ui/box_shadow.rs
+++ b/examples/ui/box_shadow.rs
@@ -94,6 +94,7 @@ enum SettingType {
     Shape,
     Samples,
 }
+
 impl SettingType {
     fn label(&self) -> &str {
         match self {


### PR DESCRIPTION
# Objective

Fix https://github.com/bevyengine/bevy/issues/19617 

# Solution

Add newlines before all impl blocks.

I suspect that at least some of these will be objectionable! If there's a desired Bevy style for this then I'll update the PR. If not then we can just close it - it's the work of a single find and replace.