### PR TITLE
Fix QueryData derive codegen

### DIFF
--- a/crates/bevy_ecs/macros/src/query_data.rs
+++ b/crates/bevy_ecs/macros/src/query_data.rs
@@ -83,7 +83,7 @@ pub fn derive_query_data_impl(input: TokenStream) -> TokenStream {
     let user_generics_with_world_and_state = {
         let mut generics = ast.generics;
         generics.params.insert(0, parse_quote!('__w));
-        generics.params.insert(0, parse_quote!('__s));
+        generics.params.insert(1, parse_quote!('__s));
         generics
     };
     let (


### PR DESCRIPTION
Custom derived `QueryData` impls currently generate with the order of the `Item` lifetimes swapped, which blows up the borrow checker sometimes.

See: https://discord.com/channels/691052431525675048/749335865876021248/1385509416086011914

could add a regression test, TBH I don't know the error well enough to do that minimally. Seems like it's that both lifetimes on `QueryData` need to be covariant, but I'm not sure.