### PR TITLE
don't allow nightly lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,6 @@ allow_attributes_without_reason = "warn"
 
 [workspace.lints.rust]
 missing_docs = "warn"
-mismatched_lifetime_syntaxes = "allow"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(docsrs_dep)'] }
 unsafe_code = "deny"
 unsafe_op_in_unsafe_fn = "warn"


### PR DESCRIPTION
# Objective

- A nightly only lint is allowed in cargo.toml, making all stable builds issue warning
- Fixes #19528 

## Solution

- Don't allow nightly lints
