### PR TITLE
Add benchmarks for spawning and inserting bundles

### DIFF
--- a/benches/benches/bevy_ecs/bundles/insert_many.rs
+++ b/benches/benches/bevy_ecs/bundles/insert_many.rs
@@ -1,0 +1,68 @@
+use benches::bench;
+use bevy_ecs::{component::Component, world::World};
+use criterion::Criterion;
+
+const ENTITY_COUNT: usize = 2_000;
+
+#[derive(Component)]
+struct C<const N: usize>(usize);
+
+#[derive(Component)]
+struct W<T>(T);
+
+pub fn insert_many(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group(bench!("insert_many"));
+
+    group.bench_function("all", |bencher| {
+        bencher.iter(|| {
+            let mut world = World::new();
+            for _ in 0..ENTITY_COUNT {
+                world
+                    .spawn_empty()
+                    .insert(C::<0>(1))
+                    .insert(C::<1>(1))
+                    .insert(C::<2>(1))
+                    .insert(C::<3>(1))
+                    .insert(C::<4>(1))
+                    .insert(C::<5>(1))
+                    .insert(C::<6>(1))
+                    .insert(C::<7>(1))
+                    .insert(C::<8>(1))
+                    .insert(C::<9>(1))
+                    .insert(C::<10>(1))
+                    .insert(C::<11>(1))
+                    .insert(C::<12>(1))
+                    .insert(C::<13>(1))
+                    .insert(C::<14>(1));
+            }
+        });
+    });
+
+    group.bench_function("only_last", |bencher| {
+        bencher.iter(|| {
+            let mut world = World::new();
+            for _ in 0..ENTITY_COUNT {
+                world
+                    .spawn((
+                        C::<0>(1),
+                        C::<1>(1),
+                        C::<2>(1),
+                        C::<3>(1),
+                        C::<4>(1),
+                        C::<5>(1),
+                        C::<6>(1),
+                        C::<7>(1),
+                        C::<8>(1),
+                        C::<9>(1),
+                        C::<10>(1),
+                        C::<11>(1),
+                        C::<12>(1),
+                        C::<13>(1),
+                    ))
+                    .insert(C::<14>(1));
+            }
+        });
+    });
+
+    group.finish();
+}

--- a/benches/benches/bevy_ecs/bundles/mod.rs
+++ b/benches/benches/bevy_ecs/bundles/mod.rs
@@ -1,0 +1,14 @@
+use criterion::criterion_group;
+
+mod insert_many;
+mod spawn_many;
+mod spawn_many_zst;
+mod spawn_one_zst;
+
+criterion_group!(
+    benches,
+    spawn_one_zst::spawn_one_zst,
+    spawn_many_zst::spawn_many_zst,
+    spawn_many::spawn_many,
+    insert_many::insert_many,
+);

--- a/benches/benches/bevy_ecs/bundles/spawn_many.rs
+++ b/benches/benches/bevy_ecs/bundles/spawn_many.rs
@@ -1,0 +1,44 @@
+use core::hint::black_box;
+
+use benches::bench;
+use bevy_ecs::{component::Component, world::World};
+use criterion::Criterion;
+
+const ENTITY_COUNT: usize = 2_000;
+
+#[derive(Component)]
+struct C<const N: usize>(usize);
+
+#[derive(Component)]
+struct W<T>(T);
+
+pub fn spawn_many(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group(bench!("spawn_many"));
+
+    group.bench_function("static", |bencher| {
+        bencher.iter(|| {
+            let mut world = World::new();
+            for _ in 0..ENTITY_COUNT {
+                world.spawn(black_box((
+                    C::<0>(1),
+                    C::<1>(1),
+                    C::<2>(1),
+                    C::<3>(1),
+                    C::<4>(1),
+                    C::<5>(1),
+                    C::<6>(1),
+                    C::<7>(1),
+                    C::<8>(1),
+                    C::<9>(1),
+                    C::<10>(1),
+                    C::<11>(1),
+                    C::<12>(1),
+                    C::<13>(1),
+                    C::<14>(1),
+                )));
+            }
+        });
+    });
+
+    group.finish();
+}

--- a/benches/benches/bevy_ecs/bundles/spawn_many_zst.rs
+++ b/benches/benches/bevy_ecs/bundles/spawn_many_zst.rs
@@ -1,0 +1,31 @@
+use core::hint::black_box;
+
+use benches::bench;
+use bevy_ecs::{component::Component, world::World};
+use criterion::Criterion;
+
+const ENTITY_COUNT: usize = 2_000;
+
+#[derive(Component)]
+struct C<const N: usize>;
+
+#[derive(Component)]
+struct W<T>(T);
+
+pub fn spawn_many_zst(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group(bench!("spawn_many_zst"));
+
+    group.bench_function("static", |bencher| {
+        bencher.iter(|| {
+            let mut world = World::new();
+            for _ in 0..ENTITY_COUNT {
+                world.spawn(black_box((
+                    C::<0>, C::<1>, C::<2>, C::<3>, C::<4>, C::<5>, C::<6>, C::<7>, C::<8>, C::<9>,
+                    C::<10>, C::<11>, C::<12>, C::<13>, C::<14>,
+                )));
+            }
+        });
+    });
+
+    group.finish();
+}

--- a/benches/benches/bevy_ecs/bundles/spawn_one_zst.rs
+++ b/benches/benches/bevy_ecs/bundles/spawn_one_zst.rs
@@ -1,0 +1,28 @@
+use core::hint::black_box;
+
+use benches::bench;
+use bevy_ecs::{component::Component, world::World};
+use criterion::Criterion;
+
+const ENTITY_COUNT: usize = 10_000;
+
+#[derive(Component)]
+struct A;
+
+#[derive(Component)]
+struct B;
+
+pub fn spawn_one_zst(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group(bench!("spawn_one_zst"));
+
+    group.bench_function("static", |bencher| {
+        bencher.iter(|| {
+            let mut world = World::new();
+            for _ in 0..ENTITY_COUNT {
+                world.spawn(black_box(A));
+            }
+        });
+    });
+
+    group.finish();
+}

--- a/benches/benches/bevy_ecs/main.rs
+++ b/benches/benches/bevy_ecs/main.rs
@@ -5,6 +5,7 @@
 
 use criterion::criterion_main;
 
+mod bundles;
 mod change_detection;
 mod components;
 mod empty_archetypes;
@@ -18,6 +19,7 @@ mod scheduling;
 mod world;
 
 criterion_main!(
+    bundles::benches,
     change_detection::benches,
     components::benches,
     empty_archetypes::benches,


### PR DESCRIPTION
# Objective

- Splitted off from https://github.com/bevyengine/bevy/pull/19491
- Add some benchmarks for spawning and inserting components. Right now these are pretty short, but it's expected that they will be extended when different kinds of dynamic bundles will be implemented.