### PR TITLE
Use bundle wrappers to select the insert mode

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -177,9 +177,10 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
             #[inline]
             fn get_components(
                 self,
-                func: &mut impl FnMut(#ecs_path::component::StorageType, #ecs_path::ptr::OwningPtr<'_>)
+                insert_mode: #ecs_path::bundle::InsertMode,
+                func: &mut impl FnMut(#ecs_path::component::StorageType, #ecs_path::bundle::InsertMode, #ecs_path::ptr::OwningPtr<'_>)
             ) {
-                #(<#active_field_types as #ecs_path::bundle::DynamicBundle>::get_components(self.#active_field_tokens, &mut *func);)*
+                #(<#active_field_types as #ecs_path::bundle::DynamicBundle>::get_components(self.#active_field_tokens, insert_mode, &mut *func);)*
             }
         }
     };

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -506,6 +506,37 @@ pub enum InsertMode {
     Keep,
 }
 
+pub struct IgnoreIfCollides<B: Bundle>(pub B);
+
+unsafe impl<B: Bundle> Bundle for IgnoreIfCollides<B> {
+    fn component_ids(components: &mut ComponentsRegistrator, ids: &mut impl FnMut(ComponentId)) {
+        B::component_ids(components, ids);
+    }
+
+    fn get_component_ids(components: &Components, ids: &mut impl FnMut(Option<ComponentId>)) {
+        B::get_component_ids(components, ids);
+    }
+
+    fn register_required_components(
+        components: &mut ComponentsRegistrator,
+        required_components: &mut RequiredComponents,
+    ) {
+        B::register_required_components(components, required_components);
+    }
+}
+
+impl<B: Bundle> DynamicBundle for IgnoreIfCollides<B> {
+    type Effect = ();
+
+    fn get_components(
+        self,
+        _insert_mode: InsertMode,
+        func: &mut impl FnMut(StorageType, InsertMode, OwningPtr<'_>),
+    ) {
+        self.0.get_components(InsertMode::Keep, func);
+    }
+}
+
 /// Stores metadata associated with a specific type of [`Bundle`] for a given [`World`].
 ///
 /// [`World`]: crate::world::World

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -255,7 +255,11 @@ pub trait DynamicBundle {
     /// Calls `func` on each value, in the order of this bundle's [`Component`]s. This passes
     /// ownership of the component values to `func`.
     #[doc(hidden)]
-    fn get_components(self, func: &mut impl FnMut(StorageType, OwningPtr<'_>)) -> Self::Effect;
+    fn get_components(
+        self,
+        insert_mode: InsertMode,
+        func: &mut impl FnMut(StorageType, InsertMode, OwningPtr<'_>),
+    ) -> Self::Effect;
 }
 
 /// An operation on an [`Entity`] that occurs _after_ inserting the [`Bundle`] that defined this bundle effect.
@@ -316,8 +320,12 @@ unsafe impl<C: Component> BundleFromComponents for C {
 impl<C: Component> DynamicBundle for C {
     type Effect = ();
     #[inline]
-    fn get_components(self, func: &mut impl FnMut(StorageType, OwningPtr<'_>)) -> Self::Effect {
-        OwningPtr::make(self, |ptr| func(C::STORAGE_TYPE, ptr));
+    fn get_components(
+        self,
+        insert_mode: InsertMode,
+        func: &mut impl FnMut(StorageType, InsertMode, OwningPtr<'_>),
+    ) -> Self::Effect {
+        OwningPtr::make(self, |ptr| func(C::STORAGE_TYPE, insert_mode, ptr));
     }
 }
 
@@ -408,14 +416,14 @@ macro_rules! tuple_impl {
                 reason = "Zero-length tuples will generate a function body equivalent to `()`; however, this macro is meant for all applicable tuples, and as such it makes no sense to rewrite it just for that case."
             )]
             #[inline(always)]
-            fn get_components(self, func: &mut impl FnMut(StorageType, OwningPtr<'_>)) -> Self::Effect {
+            fn get_components(self, insert_mode: InsertMode, func: &mut impl FnMut(StorageType, InsertMode, OwningPtr<'_>)) -> Self::Effect {
                 #[allow(
                     non_snake_case,
                     reason = "The names of these variables are provided by the caller, not by us."
                 )]
                 let ($(mut $name,)*) = self;
                 ($(
-                    $name.get_components(&mut *func),
+                    $name.get_components(insert_mode, &mut *func),
                 )*)
             }
         }
@@ -673,55 +681,57 @@ impl BundleInfo {
         table_row: TableRow,
         change_tick: Tick,
         bundle: T,
-        insert_mode: InsertMode,
         caller: MaybeLocation,
     ) -> T::Effect {
         // NOTE: get_components calls this closure on each component in "bundle order".
         // bundle_info.component_ids are also in "bundle order"
         let mut bundle_component = 0;
-        let after_effect = bundle.get_components(&mut |storage_type, component_ptr| {
-            let component_id = *self.component_ids.get_unchecked(bundle_component);
-            // SAFETY: bundle_component is a valid index for this bundle
-            let status = unsafe { bundle_component_status.get_status(bundle_component) };
-            match storage_type {
-                StorageType::Table => {
-                    let column =
+        let after_effect = bundle.get_components(
+            InsertMode::Replace,
+            &mut |storage_type, insert_mode, component_ptr| {
+                let component_id = *self.component_ids.get_unchecked(bundle_component);
+                // SAFETY: bundle_component is a valid index for this bundle
+                let status = unsafe { bundle_component_status.get_status(bundle_component) };
+                match storage_type {
+                    StorageType::Table => {
+                        let column =
                         // SAFETY: If component_id is in self.component_ids, BundleInfo::new ensures that
                         // the target table contains the component.
                         unsafe { table.get_column_mut(component_id).debug_checked_unwrap() };
-                    match (status, insert_mode) {
-                        (ComponentStatus::Added, _) => {
-                            column.initialize(table_row, component_ptr, change_tick, caller);
-                        }
-                        (ComponentStatus::Existing, InsertMode::Replace) => {
-                            column.replace(table_row, component_ptr, change_tick, caller);
-                        }
-                        (ComponentStatus::Existing, InsertMode::Keep) => {
-                            if let Some(drop_fn) = table.get_drop_for(component_id) {
-                                drop_fn(component_ptr);
+                        match (status, insert_mode) {
+                            (ComponentStatus::Added, _) => {
+                                column.initialize(table_row, component_ptr, change_tick, caller);
+                            }
+                            (ComponentStatus::Existing, InsertMode::Replace) => {
+                                column.replace(table_row, component_ptr, change_tick, caller);
+                            }
+                            (ComponentStatus::Existing, InsertMode::Keep) => {
+                                if let Some(drop_fn) = table.get_drop_for(component_id) {
+                                    drop_fn(component_ptr);
+                                }
                             }
                         }
                     }
-                }
-                StorageType::SparseSet => {
-                    let sparse_set =
+                    StorageType::SparseSet => {
+                        let sparse_set =
                         // SAFETY: If component_id is in self.component_ids, BundleInfo::new ensures that
                         // a sparse set exists for the component.
                         unsafe { sparse_sets.get_mut(component_id).debug_checked_unwrap() };
-                    match (status, insert_mode) {
-                        (ComponentStatus::Added, _) | (_, InsertMode::Replace) => {
-                            sparse_set.insert(entity, component_ptr, change_tick, caller);
-                        }
-                        (ComponentStatus::Existing, InsertMode::Keep) => {
-                            if let Some(drop_fn) = sparse_set.get_drop() {
-                                drop_fn(component_ptr);
+                        match (status, insert_mode) {
+                            (ComponentStatus::Added, _) | (_, InsertMode::Replace) => {
+                                sparse_set.insert(entity, component_ptr, change_tick, caller);
+                            }
+                            (ComponentStatus::Existing, InsertMode::Keep) => {
+                                if let Some(drop_fn) = sparse_set.get_drop() {
+                                    drop_fn(component_ptr);
+                                }
                             }
                         }
                     }
                 }
-            }
-            bundle_component += 1;
-        });
+                bundle_component += 1;
+            },
+        );
 
         for required_component in required_components {
             required_component.initialize(
@@ -1173,38 +1183,38 @@ impl<'w> BundleInserter<'w> {
         entity: Entity,
         location: EntityLocation,
         bundle: T,
-        insert_mode: InsertMode,
         caller: MaybeLocation,
-        relationship_hook_mode: RelationshipHookMode,
+        _relationship_hook_mode: RelationshipHookMode,
     ) -> (EntityLocation, T::Effect) {
         let bundle_info = self.bundle_info.as_ref();
         let archetype_after_insert = self.archetype_after_insert.as_ref();
-        let archetype = self.archetype.as_ref();
+        let _archetype = self.archetype.as_ref();
 
+        // TEMP: not sure what to do with this
         // SAFETY: All components in the bundle are guaranteed to exist in the World
         // as they must be initialized before creating the BundleInfo.
-        unsafe {
-            // SAFETY: Mutable references do not alias and will be dropped after this block
-            let mut deferred_world = self.world.into_deferred();
+        // unsafe {
+        //     // SAFETY: Mutable references do not alias and will be dropped after this block
+        //     let mut deferred_world = self.world.into_deferred();
 
-            if insert_mode == InsertMode::Replace {
-                if archetype.has_replace_observer() {
-                    deferred_world.trigger_observers(
-                        REPLACE,
-                        Some(entity),
-                        archetype_after_insert.iter_existing(),
-                        caller,
-                    );
-                }
-                deferred_world.trigger_on_replace(
-                    archetype,
-                    entity,
-                    archetype_after_insert.iter_existing(),
-                    caller,
-                    relationship_hook_mode,
-                );
-            }
-        }
+        //     if insert_mode == InsertMode::Replace {
+        //         if archetype.has_replace_observer() {
+        //             deferred_world.trigger_observers(
+        //                 REPLACE,
+        //                 Some(entity),
+        //                 archetype_after_insert.iter_existing(),
+        //                 caller,
+        //             );
+        //         }
+        //         deferred_world.trigger_on_replace(
+        //             archetype,
+        //             entity,
+        //             archetype_after_insert.iter_existing(),
+        //             caller,
+        //             relationship_hook_mode,
+        //         );
+        //     }
+        // }
 
         let table = self.table.as_mut();
 
@@ -1229,7 +1239,6 @@ impl<'w> BundleInserter<'w> {
                     location.table_row,
                     self.change_tick,
                     bundle,
-                    insert_mode,
                     caller,
                 );
 
@@ -1270,7 +1279,6 @@ impl<'w> BundleInserter<'w> {
                     result.table_row,
                     self.change_tick,
                     bundle,
-                    insert_mode,
                     caller,
                 );
 
@@ -1352,7 +1360,6 @@ impl<'w> BundleInserter<'w> {
                     move_result.new_row,
                     self.change_tick,
                     bundle,
-                    insert_mode,
                     caller,
                 );
 
@@ -1381,45 +1388,46 @@ impl<'w> BundleInserter<'w> {
                     caller,
                 );
             }
-            match insert_mode {
-                InsertMode::Replace => {
-                    // Insert triggers for both new and existing components if we're replacing them.
-                    deferred_world.trigger_on_insert(
-                        new_archetype,
-                        entity,
-                        archetype_after_insert.iter_inserted(),
-                        caller,
-                        relationship_hook_mode,
-                    );
-                    if new_archetype.has_insert_observer() {
-                        deferred_world.trigger_observers(
-                            INSERT,
-                            Some(entity),
-                            archetype_after_insert.iter_inserted(),
-                            caller,
-                        );
-                    }
-                }
-                InsertMode::Keep => {
-                    // Insert triggers only for new components if we're not replacing them (since
-                    // nothing is actually inserted).
-                    deferred_world.trigger_on_insert(
-                        new_archetype,
-                        entity,
-                        archetype_after_insert.iter_added(),
-                        caller,
-                        relationship_hook_mode,
-                    );
-                    if new_archetype.has_insert_observer() {
-                        deferred_world.trigger_observers(
-                            INSERT,
-                            Some(entity),
-                            archetype_after_insert.iter_added(),
-                            caller,
-                        );
-                    }
-                }
-            }
+            // TEMP: not sure what to do with this
+            // match insert_mode {
+            //     InsertMode::Replace => {
+            //         // Insert triggers for both new and existing components if we're replacing them.
+            //         deferred_world.trigger_on_insert(
+            //             new_archetype,
+            //             entity,
+            //             archetype_after_insert.iter_inserted(),
+            //             caller,
+            //             relationship_hook_mode,
+            //         );
+            //         if new_archetype.has_insert_observer() {
+            //             deferred_world.trigger_observers(
+            //                 INSERT,
+            //                 Some(entity),
+            //                 archetype_after_insert.iter_inserted(),
+            //                 caller,
+            //             );
+            //         }
+            //     }
+            //     InsertMode::Keep => {
+            //         // Insert triggers only for new components if we're not replacing them (since
+            //         // nothing is actually inserted).
+            //         deferred_world.trigger_on_insert(
+            //             new_archetype,
+            //             entity,
+            //             archetype_after_insert.iter_added(),
+            //             caller,
+            //             relationship_hook_mode,
+            //         );
+            //         if new_archetype.has_insert_observer() {
+            //             deferred_world.trigger_observers(
+            //                 INSERT,
+            //                 Some(entity),
+            //                 archetype_after_insert.iter_added(),
+            //                 caller,
+            //             );
+            //         }
+            //     }
+            // }
         }
 
         (new_location, after_effect)
@@ -1809,7 +1817,6 @@ impl<'w> BundleSpawner<'w> {
                 table_row,
                 self.change_tick,
                 bundle,
-                InsertMode::Replace,
                 caller,
             );
             entities.set(entity.index(), Some(location));

--- a/crates/bevy_ecs/src/spawn.rs
+++ b/crates/bevy_ecs/src/spawn.rs
@@ -215,10 +215,15 @@ impl<R: Relationship, L: SpawnableList<R>> DynamicBundle for SpawnRelatedBundle<
 
     fn get_components(
         self,
-        func: &mut impl FnMut(crate::component::StorageType, bevy_ptr::OwningPtr<'_>),
+        insert_mode: crate::bundle::InsertMode,
+        func: &mut impl FnMut(
+            crate::component::StorageType,
+            crate::bundle::InsertMode,
+            bevy_ptr::OwningPtr<'_>,
+        ),
     ) -> Self::Effect {
         <R::RelationshipTarget as RelationshipTarget>::with_capacity(self.list.size_hint())
-            .get_components(func);
+            .get_components(insert_mode, func);
         self
     }
 }
@@ -244,9 +249,15 @@ impl<R: Relationship, B: Bundle> DynamicBundle for SpawnOneRelated<R, B> {
 
     fn get_components(
         self,
-        func: &mut impl FnMut(crate::component::StorageType, bevy_ptr::OwningPtr<'_>),
+        insert_mode: crate::bundle::InsertMode,
+        func: &mut impl FnMut(
+            crate::component::StorageType,
+            crate::bundle::InsertMode,
+            bevy_ptr::OwningPtr<'_>,
+        ),
     ) -> Self::Effect {
-        <R::RelationshipTarget as RelationshipTarget>::with_capacity(1).get_components(func);
+        <R::RelationshipTarget as RelationshipTarget>::with_capacity(1)
+            .get_components(insert_mode, func);
         self
     }
 }

--- a/crates/bevy_ecs/src/system/commands/command.rs
+++ b/crates/bevy_ecs/src/system/commands/command.rs
@@ -5,7 +5,7 @@
 //! [`Commands`](crate::system::Commands).
 
 use crate::{
-    bundle::{Bundle, InsertMode, NoBundleEffect},
+    bundle::{Bundle, NoBundleEffect},
     change_detection::MaybeLocation,
     entity::Entity,
     error::Result,
@@ -85,14 +85,14 @@ where
 ///
 /// This is more efficient than inserting the bundles individually.
 #[track_caller]
-pub fn insert_batch<I, B>(batch: I, insert_mode: InsertMode) -> impl Command<Result>
+pub fn insert_batch<I, B>(batch: I) -> impl Command<Result>
 where
     I: IntoIterator<Item = (Entity, B)> + Send + Sync + 'static,
     B: Bundle<Effect: NoBundleEffect>,
 {
     let caller = MaybeLocation::caller();
     move |world: &mut World| -> Result {
-        world.try_insert_batch_with_caller(batch, insert_mode, caller)?;
+        world.try_insert_batch_with_caller(batch, caller)?;
         Ok(())
     }
 }

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -15,7 +15,7 @@ use core::marker::PhantomData;
 
 use crate::{
     self as bevy_ecs,
-    bundle::{Bundle, InsertMode, NoBundleEffect},
+    bundle::{Bundle, NoBundleEffect},
     change_detection::{MaybeLocation, Mut},
     component::{Component, ComponentId, Mutable},
     entity::{Entities, Entity, EntityClonerBuilder, EntityDoesNotExistError},
@@ -398,7 +398,6 @@ impl<'w, 's> Commands<'w, 's> {
 
             entity.insert_with_caller(
                 bundle,
-                InsertMode::Replace,
                 caller,
                 crate::relationship::RelationshipHookMode::Run,
             );
@@ -683,7 +682,7 @@ impl<'w, 's> Commands<'w, 's> {
         I: IntoIterator<Item = (Entity, B)> + Send + Sync + 'static,
         B: Bundle<Effect: NoBundleEffect>,
     {
-        self.queue(command::insert_batch(batch, InsertMode::Replace));
+        self.queue(command::insert_batch(batch));
     }
 
     /// Adds a series of [`Bundles`](Bundle) to each [`Entity`] they are paired with,
@@ -714,7 +713,8 @@ impl<'w, 's> Commands<'w, 's> {
         I: IntoIterator<Item = (Entity, B)> + Send + Sync + 'static,
         B: Bundle<Effect: NoBundleEffect>,
     {
-        self.queue(command::insert_batch(batch, InsertMode::Keep));
+        // TODO: keep
+        self.queue(command::insert_batch(batch));
     }
 
     /// Adds a series of [`Bundles`](Bundle) to each [`Entity`] they are paired with,
@@ -744,7 +744,7 @@ impl<'w, 's> Commands<'w, 's> {
         I: IntoIterator<Item = (Entity, B)> + Send + Sync + 'static,
         B: Bundle<Effect: NoBundleEffect>,
     {
-        self.queue(command::insert_batch(batch, InsertMode::Replace).handle_error_with(warn));
+        self.queue(command::insert_batch(batch).handle_error_with(warn));
     }
 
     /// Adds a series of [`Bundles`](Bundle) to each [`Entity`] they are paired with,
@@ -775,7 +775,8 @@ impl<'w, 's> Commands<'w, 's> {
         I: IntoIterator<Item = (Entity, B)> + Send + Sync + 'static,
         B: Bundle<Effect: NoBundleEffect>,
     {
-        self.queue(command::insert_batch(batch, InsertMode::Keep).handle_error_with(warn));
+        // TODO: keep
+        self.queue(command::insert_batch(batch).handle_error_with(warn));
     }
 
     /// Inserts a [`Resource`] into the [`World`] with an inferred value.
@@ -1353,7 +1354,7 @@ impl<'a> EntityCommands<'a> {
     /// ```
     #[track_caller]
     pub fn insert(&mut self, bundle: impl Bundle) -> &mut Self {
-        self.queue(entity_command::insert(bundle, InsertMode::Replace))
+        self.queue(entity_command::insert(bundle))
     }
 
     /// Adds a [`Bundle`] of components to the entity if the predicate returns true.
@@ -1401,7 +1402,8 @@ impl<'a> EntityCommands<'a> {
     /// as well as initialize it with a default value.
     #[track_caller]
     pub fn insert_if_new(&mut self, bundle: impl Bundle) -> &mut Self {
-        self.queue(entity_command::insert(bundle, InsertMode::Keep))
+        // TODO: keep
+        self.queue(entity_command::insert(bundle))
     }
 
     /// Adds a [`Bundle`] of components to the entity without overwriting if the
@@ -1441,7 +1443,7 @@ impl<'a> EntityCommands<'a> {
             // SAFETY:
             // - `ComponentId` safety is ensured by the caller.
             // - `T` safety is ensured by the caller.
-            unsafe { entity_command::insert_by_id(component_id, value, InsertMode::Replace) },
+            unsafe { entity_command::insert_by_id(component_id, value) },
         )
     }
 
@@ -1470,7 +1472,7 @@ impl<'a> EntityCommands<'a> {
             // SAFETY:
             // - `ComponentId` safety is ensured by the caller.
             // - `T` safety is ensured by the caller.
-            unsafe { entity_command::insert_by_id(component_id, value, InsertMode::Replace) },
+            unsafe { entity_command::insert_by_id(component_id, value) },
             ignore,
         )
     }
@@ -1523,7 +1525,7 @@ impl<'a> EntityCommands<'a> {
     /// ```
     #[track_caller]
     pub fn try_insert(&mut self, bundle: impl Bundle) -> &mut Self {
-        self.queue_handled(entity_command::insert(bundle, InsertMode::Replace), ignore)
+        self.queue_handled(entity_command::insert(bundle), ignore)
     }
 
     /// Adds a [`Bundle`] of components to the entity if the predicate returns true.
@@ -1579,7 +1581,8 @@ impl<'a> EntityCommands<'a> {
     /// the resulting error will be ignored.
     #[track_caller]
     pub fn try_insert_if_new(&mut self, bundle: impl Bundle) -> &mut Self {
-        self.queue_handled(entity_command::insert(bundle, InsertMode::Keep), ignore)
+        // TODO: keep
+        self.queue_handled(entity_command::insert(bundle), ignore)
     }
 
     /// Removes a [`Bundle`] of components from the entity.
@@ -2204,8 +2207,9 @@ impl<'a, T: Component> EntityEntryCommands<'a, T> {
     where
         T: FromWorld,
     {
+        // TODO: keep
         self.entity_commands
-            .queue(entity_command::insert_from_world::<T>(InsertMode::Keep));
+            .queue(entity_command::insert_from_world::<T>());
         self
     }
 

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -2,7 +2,7 @@ use crate::{
     archetype::Archetype,
     bundle::{
         Bundle, BundleEffect, BundleFromComponents, BundleInserter, BundleRemover, DynamicBundle,
-        InsertMode,
+        IgnoreIfCollides, InsertMode,
     },
     change_detection::{MaybeLocation, MutUntyped},
     component::{
@@ -1818,8 +1818,11 @@ impl<'w> EntityWorldMut<'w> {
     /// If the entity has been despawned while this `EntityWorldMut` is still alive.
     #[track_caller]
     pub fn insert_if_new<T: Bundle>(&mut self, bundle: T) -> &mut Self {
-        // TODO: keep
-        self.insert_with_caller(bundle, MaybeLocation::caller(), RelationshipHookMode::Run)
+        self.insert_with_caller(
+            IgnoreIfCollides(bundle),
+            MaybeLocation::caller(),
+            RelationshipHookMode::Run,
+        )
     }
 
     /// Split into a new function so we can pass the calling location into the function when using

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -39,8 +39,7 @@ pub use spawn_batch::*;
 use crate::{
     archetype::{ArchetypeId, Archetypes},
     bundle::{
-        Bundle, BundleEffect, BundleInfo, BundleInserter, BundleSpawner, Bundles, InsertMode,
-        NoBundleEffect,
+        Bundle, BundleEffect, BundleInfo, BundleInserter, BundleSpawner, Bundles, NoBundleEffect,
     },
     change_detection::{MaybeLocation, MutUntyped, TicksMut},
     component::{
@@ -2236,7 +2235,7 @@ impl World {
         I::IntoIter: Iterator<Item = (Entity, B)>,
         B: Bundle<Effect: NoBundleEffect>,
     {
-        self.insert_batch_with_caller(batch, InsertMode::Replace, MaybeLocation::caller());
+        self.insert_batch_with_caller(batch, MaybeLocation::caller());
     }
 
     /// For a given batch of ([`Entity`], [`Bundle`]) pairs,
@@ -2261,7 +2260,8 @@ impl World {
         I::IntoIter: Iterator<Item = (Entity, B)>,
         B: Bundle<Effect: NoBundleEffect>,
     {
-        self.insert_batch_with_caller(batch, InsertMode::Keep, MaybeLocation::caller());
+        // TODO: keep
+        self.insert_batch_with_caller(batch, MaybeLocation::caller());
     }
 
     /// Split into a new function so we can differentiate the calling location.
@@ -2270,12 +2270,8 @@ impl World {
     /// - [`World::insert_batch`]
     /// - [`World::insert_batch_if_new`]
     #[inline]
-    pub(crate) fn insert_batch_with_caller<I, B>(
-        &mut self,
-        batch: I,
-        insert_mode: InsertMode,
-        caller: MaybeLocation,
-    ) where
+    pub(crate) fn insert_batch_with_caller<I, B>(&mut self, batch: I, caller: MaybeLocation)
+    where
         I: IntoIterator,
         I::IntoIter: Iterator<Item = (Entity, B)>,
         B: Bundle<Effect: NoBundleEffect>,
@@ -2316,7 +2312,6 @@ impl World {
                         first_entity,
                         first_location,
                         first_bundle,
-                        insert_mode,
                         caller,
                         RelationshipHookMode::Run,
                     )
@@ -2344,7 +2339,6 @@ impl World {
                                 entity,
                                 location,
                                 bundle,
-                                insert_mode,
                                 caller,
                                 RelationshipHookMode::Run,
                             )
@@ -2379,7 +2373,7 @@ impl World {
         I::IntoIter: Iterator<Item = (Entity, B)>,
         B: Bundle<Effect: NoBundleEffect>,
     {
-        self.try_insert_batch_with_caller(batch, InsertMode::Replace, MaybeLocation::caller())
+        self.try_insert_batch_with_caller(batch, MaybeLocation::caller())
     }
     /// For a given batch of ([`Entity`], [`Bundle`]) pairs,
     /// adds the `Bundle` of components to each `Entity` without overwriting.
@@ -2401,7 +2395,8 @@ impl World {
         I::IntoIter: Iterator<Item = (Entity, B)>,
         B: Bundle<Effect: NoBundleEffect>,
     {
-        self.try_insert_batch_with_caller(batch, InsertMode::Keep, MaybeLocation::caller())
+        // TODO: keep
+        self.try_insert_batch_with_caller(batch, MaybeLocation::caller())
     }
 
     /// Split into a new function so we can differentiate the calling location.
@@ -2417,7 +2412,6 @@ impl World {
     pub(crate) fn try_insert_batch_with_caller<I, B>(
         &mut self,
         batch: I,
-        insert_mode: InsertMode,
         caller: MaybeLocation,
     ) -> Result<(), TryInsertBatchError>
     where
@@ -2466,7 +2460,6 @@ impl World {
                             first_entity,
                             first_location,
                             first_bundle,
-                            insert_mode,
                             caller,
                             RelationshipHookMode::Run,
                         )
@@ -2503,7 +2496,6 @@ impl World {
                             entity,
                             location,
                             bundle,
-                            insert_mode,
                             caller,
                             RelationshipHookMode::Run,
                         )

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -13,15 +13,16 @@ pub mod unsafe_world_cell;
 #[cfg(feature = "bevy_reflect")]
 pub mod reflect;
 
-pub use crate::{
-    change_detection::{Mut, Ref, CHECK_TICK_THRESHOLD},
-    world::command_queue::CommandQueue,
-};
 use crate::{
+    bundle::IgnoreIfCollides,
     error::{DefaultErrorHandler, ErrorHandler},
     event::BufferedEvent,
     lifecycle::{ComponentHooks, ADD, DESPAWN, INSERT, REMOVE, REPLACE},
     prelude::{Add, Despawn, Insert, Remove, Replace},
+};
+pub use crate::{
+    change_detection::{Mut, Ref, CHECK_TICK_THRESHOLD},
+    world::command_queue::CommandQueue,
 };
 pub use bevy_ecs_macros::FromWorld;
 use bevy_utils::prelude::DebugName;
@@ -2260,8 +2261,10 @@ impl World {
         I::IntoIter: Iterator<Item = (Entity, B)>,
         B: Bundle<Effect: NoBundleEffect>,
     {
-        // TODO: keep
-        self.insert_batch_with_caller(batch, MaybeLocation::caller());
+        self.insert_batch_with_caller(
+            batch.into_iter().map(|(e, b)| (e, IgnoreIfCollides(b))),
+            MaybeLocation::caller(),
+        );
     }
 
     /// Split into a new function so we can differentiate the calling location.
@@ -2395,8 +2398,10 @@ impl World {
         I::IntoIter: Iterator<Item = (Entity, B)>,
         B: Bundle<Effect: NoBundleEffect>,
     {
-        // TODO: keep
-        self.try_insert_batch_with_caller(batch, MaybeLocation::caller())
+        self.try_insert_batch_with_caller(
+            batch.into_iter().map(|(e, b)| (e, IgnoreIfCollides(b))),
+            MaybeLocation::caller(),
+        )
     }
 
     /// Split into a new function so we can differentiate the calling location.


### PR DESCRIPTION
# Objective

Allow bundles to define their insert mode in a flexible but explicit way. More specifically this is a potential solution to https://github.com/bevyengine/bevy/issues/19715 and an alternative to https://github.com/bevyengine/bevy/pull/19726 as presented [here](https://github.com/bevyengine/bevy/pull/19726#issuecomment-2990704531).

This is a first step in that direction an doesn't provide a merging solution, it focuses on aligning existing `InsertMode` APIs to the proposed direction.

## Solution

The current insert APIs use a separate parameter to control the insert mode for the whole bundle:

```rust
fn insert(bundle: impl Bundle, mode: InsertMode) { ... }
```

The proposal changes this to allow each bundle to define its own insert mode. To keep things sane and flexible most bundles wouldn't actually use that capacity and instead would simply inherit the insert mode from their outer bundle (if one exists). To support that, we update the dynamic bundle trait:

```rust
// old
pub trait DynamicBundle {
    fn get_components(self, func: &mut impl FnMut(StorageType, OwningPtr<'_>));
}
// new
pub trait DynamicBundle {
    fn get_components(
        self,
        insert_mode: InsertMode,
        func: &mut impl FnMut(StorageType, InsertMode, OwningPtr<'_>),
    );
}
```

The idea is that as `get_components` gets recursively called, the insert mode flows from outer bundles to inner bundles:

```rust
// tuples
impl<B1: Bundle, B2: Bundle> DynamicBundle for (B1, B2) {
    fn get_components(
        self,
        insert_mode: InsertMode,
        func: &mut impl FnMut(StorageType, InsertMode, OwningPtr<'_>),
    ) {
        let (b1, b2) = self;
        b1.get_components(insert_mode, &mut *func);
        b2.get_components(insert_mode, &mut *func);
    }
}
// components
impl<C: Component> DynamicBundle for C {
    fn get_components(
        self,
        insert_mode: InsertMode,
        func: &mut impl FnMut(StorageType, InsertMode, OwningPtr<'_>),
    ) {
        OwningPtr::make(self, |ptr| func(C::STORAGE_TYPE, insert_mode, ptr));
    }
}
```

Then, we can define new bundle types that wrap an inner bundle and override the insert mode:

```rust
pub struct IgnoreIfCollides<B: Bundle>(pub B);
unsafe impl<B: Bundle> Bundle for IgnoreIfCollides<B> {
    // simply call inner bundle methods
}
impl<B: Bundle> DynamicBundle for IgnoreIfCollides<B> {
    fn get_components(
        self,
        _insert_mode: InsertMode, // ignore provided insert mode
        func: &mut impl FnMut(StorageType, InsertMode, OwningPtr<'_>),
    ) {
        self.0.get_components(InsertMode::Keep, func);
    }
}
```

## Testing

- Did you test these changes? If so, how?
WIP. For now my main concern are component hooks, the current structure is not designed to support multiple insert modes in a single insert call. For now I've left the hooks always enabled as if all components used `InsertMode::Replace` but that obviously is not acceptable as a final solution.
- Are there any parts that need more testing?
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?

---

## Showcase

These changes in action would look like this:

```rust
// old
commands
    .entity(entity)
    .insert(ComponentA)
    .insert_if_new(ComponentB);
// new
commands
    .entity(entity)
    .insert((
        ComponentA,
        IgnoreIfCollides(ComponentB),
    ));
```

We could deprecate `insert_if_new(bundle)` or keep it as a shorthand for `insert(IgnoreIfCollides(bundle))`.

## Future work

These changes would pave the way for a future `MergeIfCollides`, which we would use in `SpawnRelated`:
```rust
pub trait SpawnRelated: RelationshipTarget {
    fn spawn<L: SpawnableList<Self::Relationship>>(
        list: L,
    ) -> MergeIfCollides<SpawnRelatedBundle<Self::Relationship, L>>;

    fn spawn_one<B: Bundle>(bundle: B) -> MergeIfCollides<SpawnOneRelated<Self::Relationship, B>>;
}
```