### PR TITLE
add missing `#[track_caller]`

### DIFF
--- a/crates/bevy_ecs/src/system/commands/command.rs
+++ b/crates/bevy_ecs/src/system/commands/command.rs
@@ -223,6 +223,7 @@ pub fn trigger(event: impl Event) -> impl Command {
 }
 
 /// A [`Command`] that sends an [`EntityEvent`] for the given targets.
+#[track_caller]
 pub fn trigger_targets(
     event: impl EntityEvent,
     targets: impl TriggerTargets + Send + Sync + 'static,

--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -96,6 +96,7 @@ impl<'w> DeferredWorld<'w> {
     /// If you do not need to ensure the above hooks are triggered, and your component
     /// is mutable, prefer using [`get_mut`](DeferredWorld::get_mut).
     #[inline]
+    #[track_caller]
     pub(crate) fn modify_component<T: Component, R>(
         &mut self,
         entity: Entity,
@@ -129,6 +130,7 @@ impl<'w> DeferredWorld<'w> {
     /// You should prefer the typed [`modify_component`](DeferredWorld::modify_component)
     /// whenever possible.
     #[inline]
+    #[track_caller]
     pub(crate) fn modify_component_by_id<R>(
         &mut self,
         entity: Entity,

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1311,6 +1311,7 @@ impl World {
     /// # assert_eq!(world.get::<Foo>(entity), Some(&Foo(true)));
     /// ```
     #[inline]
+    #[track_caller]
     pub fn modify_component<T: Component, R>(
         &mut self,
         entity: Entity,
@@ -1339,6 +1340,7 @@ impl World {
     /// You should prefer the typed [`modify_component`](World::modify_component)
     /// whenever possible.
     #[inline]
+    #[track_caller]
     pub fn modify_component_by_id<R>(
         &mut self,
         entity: Entity,


### PR DESCRIPTION
# Objective

I've noticed that some methods with `MaybeLocation::caller` don't have `#[track_caller]` which resulted in wrong locations reported when `track_location` is enabled.

## Solution

add `#[track_caller]` to them.