### PR TITLE
Fix intermittent drag-and-drop freezing on Windows

### DIFF
--- a/crates/bevy_winit/src/state.rs
+++ b/crates/bevy_winit/src/state.rs
@@ -529,7 +529,11 @@ impl<T: BufferedEvent> ApplicationHandler<T> for WinitAppRunnerState<T> {
                     .iter()
                     .all(|(_, w)| !w.is_visible().unwrap_or(false));
                 if !exiting
-                    && (self.startup_forced_updates > 0 || headless || all_invisible || reactive)
+                    && (self.startup_forced_updates > 0
+                        || headless
+                        || all_invisible
+                        || reactive
+                        || self.window_event_received)
                 {
                     self.redraw_requested(event_loop);
                 }


### PR DESCRIPTION
# Objective

Fixes #19030.

Since Bevy 0.15.3, there has been a bug on Windows where drag-and-drop will occasionally freeze the application where the only fix is to resize the window.

## Solution

This adds a check for any window events being received when determining if a redraw is requested—specifically on Windows.  A drag-and-drop event sets the `self.window_event_received` flag to true.

For non-Windows platforms, `self.redraw_requested(event_loop)` is always called, but the Windows-specific branch has checks that for some reason sometimes don't properly handle a drag-and-drop event (and maybe other types of events?).

I also tried replacing all of the `WINIT_WINDOWS.with_borrow(...)` with just `self.redraw_requested(event_loop)`, and that fixes the problem too (and then matches the non-Windows behavior), but I assume the Windows-specific checks are otherwise there for a reason.

**Note**: I'm not sure why the freeze only sometimes occurred.  This change fixes the specific drag-and-drop freeze problem, but there may be some sort of deeper bug/issue causing the strange behavior in the first place.

## Testing

I could replicate the intermittent freeze on Windows 11 in the drag-and-drop example, and this change seems to fully fix that problem.

---

## Showcase

Here is the existing intermittent freeze in action before the fix.  While there is nothing in the drag-and-drop example window, the whole application is completely frozen until the window is resized.

https://github.com/user-attachments/assets/0d64b21c-a843-4b4e-8b6c-8bc5d6f9dfbe
