### PR TITLE
force unclipped depth emu on webgpu

### DIFF
--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -346,7 +346,10 @@ impl<M: Material> FromWorld for PrepassPipeline<M> {
 
         let depth_clip_control_supported = render_device
             .features()
-            .contains(WgpuFeatures::DEPTH_CLIP_CONTROL);
+            .contains(WgpuFeatures::DEPTH_CLIP_CONTROL)
+            // force unclipped depth emnulation on webgpu as  unclipped depth support
+            // may be declared but is not actually supported
+            && cfg!(not(all(feature = "webgpu", target_arch = "wasm32")));
         let internal = PrepassPipelineInternal {
             view_layout_motion_vectors,
             view_layout_no_motion_vectors,

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -347,7 +347,7 @@ impl<M: Material> FromWorld for PrepassPipeline<M> {
         let depth_clip_control_supported = render_device
             .features()
             .contains(WgpuFeatures::DEPTH_CLIP_CONTROL)
-            // force unclipped depth emnulation on webgpu as  unclipped depth support
+            // force unclipped depth emulation on webgpu as unclipped depth support
             // may be declared but is not actually supported
             && cfg!(not(all(feature = "webgpu", target_arch = "wasm32")));
         let internal = PrepassPipelineInternal {


### PR DESCRIPTION
# Objective

fixes #19626

## Solution

it seems like on webgpu the render device may report DEPTH_CLIP_CONTROL without actually supporting it, so we force emulated mode for webgpu.