### PR TITLE
Split overloaded basis-universal feature into compressed_image_saver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -330,6 +330,9 @@ trace = ["bevy_internal/trace", "dep:tracing"]
 # Basis Universal compressed texture support
 basis-universal = ["bevy_internal/basis-universal"]
 
+# Enables compressed KTX2 UASTC texture output on the asset processor
+compressed_image_saver = ["bevy_internal/compressed_image_saver"]
+
 # BMP image format support
 bmp = ["bevy_internal/bmp"]
 

--- a/crates/bevy_image/Cargo.toml
+++ b/crates/bevy_image/Cargo.toml
@@ -38,6 +38,9 @@ serialize = ["bevy_reflect", "bevy_platform/serialize"]
 zlib = ["flate2"]
 zstd = ["ruzstd"]
 
+# Enables compressed KTX2 UASTC texture output on the asset processor
+compressed_image_saver = ["basis-universal"]
+
 [dependencies]
 # bevy
 bevy_app = { path = "../bevy_app", version = "0.17.0-dev" }

--- a/crates/bevy_image/src/lib.rs
+++ b/crates/bevy_image/src/lib.rs
@@ -14,7 +14,7 @@ mod image;
 pub use self::image::*;
 #[cfg(feature = "basis-universal")]
 mod basis;
-#[cfg(feature = "basis-universal")]
+#[cfg(feature = "compressed_image_saver")]
 mod compressed_image_saver;
 #[cfg(feature = "dds")]
 mod dds;
@@ -29,7 +29,7 @@ mod ktx2;
 mod texture_atlas;
 mod texture_atlas_builder;
 
-#[cfg(feature = "basis-universal")]
+#[cfg(feature = "compressed_image_saver")]
 pub use compressed_image_saver::*;
 #[cfg(feature = "dds")]
 pub use dds::*;

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -28,6 +28,12 @@ detailed_trace = ["bevy_ecs/detailed_trace", "bevy_render?/detailed_trace"]
 
 sysinfo_plugin = ["bevy_diagnostic/sysinfo_plugin"]
 
+# Enables compressed KTX2 UASTC texture output on the asset processor
+compressed_image_saver = [
+  "bevy_image/compressed_image_saver",
+  "bevy_render/compressed_image_saver",
+]
+
 # Texture formats that have specific rendering support (HDR enabled by default)
 basis-universal = ["bevy_image/basis-universal", "bevy_render/basis-universal"]
 exr = ["bevy_image/exr", "bevy_render/exr"]

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -21,6 +21,9 @@ keywords = ["bevy"]
 # wgpu-types = { git = "https://github.com/gfx-rs/wgpu", rev = "..." }
 decoupled_naga = []
 
+# Enables compressed KTX2 UASTC texture output on the asset processor
+compressed_image_saver = ["bevy_image/compressed_image_saver"]
+
 # Texture formats (require more than just image support)
 basis-universal = ["bevy_image/basis-universal"]
 exr = ["bevy_image/exr"]

--- a/crates/bevy_render/src/texture/mod.rs
+++ b/crates/bevy_render/src/texture/mod.rs
@@ -4,7 +4,7 @@ mod texture_attachment;
 mod texture_cache;
 
 pub use crate::render_resource::DefaultImageSampler;
-#[cfg(feature = "basis-universal")]
+#[cfg(feature = "compressed_image_saver")]
 use bevy_image::CompressedImageSaver;
 #[cfg(feature = "hdr")]
 use bevy_image::HdrTextureLoader;
@@ -84,7 +84,7 @@ impl Plugin for ImagePlugin {
         image_assets.insert(&Handle::default(), Image::default());
         image_assets.insert(&TRANSPARENT_IMAGE_HANDLE, Image::transparent());
 
-        #[cfg(feature = "basis-universal")]
+        #[cfg(feature = "compressed_image_saver")]
         if let Some(processor) = app
             .world()
             .get_resource::<bevy_asset::processor::AssetProcessor>()

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -73,6 +73,7 @@ The default feature set enables most of the expected features of a game engine, 
 |bevy_solari|Provides raytraced lighting (experimental)|
 |bevy_ui_debug|Provides a debug overlay for bevy UI|
 |bmp|BMP image format support|
+|compressed_image_saver|Enables compressed KTX2 UASTC texture output on the asset processor|
 |critical-section|`critical-section` provides the building blocks for synchronization primitives on all platforms, including `no_std`.|
 |dds|DDS compressed texture support|
 |debug_glam_assert|Enable assertions in debug builds to check the validity of parameters passed to glam|


### PR DESCRIPTION
# Objective

- basis-universal feature is overloaded, you might not want the compressed_image_saver but you may want basis-universal

## Solution

- split out compressed_image_saver

## Testing

- cargo clippy

