### PR TITLE
Set checkbox and radio fill color to gray when disabled in core widgets example

### DIFF
--- a/examples/ui/core_widgets.rs
+++ b/examples/ui/core_widgets.rs
@@ -55,6 +55,7 @@ const SLIDER_TRACK: Color = Color::srgb(0.05, 0.05, 0.05);
 const SLIDER_THUMB: Color = Color::srgb(0.35, 0.75, 0.35);
 const CHECKBOX_OUTLINE: Color = Color::srgb(0.45, 0.45, 0.45);
 const CHECKBOX_CHECK: Color = Color::srgb(0.35, 0.75, 0.35);
+const ELEMENT_FILL_DISABLED: Color = Color::srgb(0.5019608, 0.5019608, 0.5019608);
 
 /// Marker which identifies buttons with a particular style, in this case the "Demo style".
 #[derive(Component)]
@@ -446,7 +447,7 @@ fn update_slider_style2(
 
 fn thumb_color(disabled: bool, hovered: bool) -> Color {
     match (disabled, hovered) {
-        (true, _) => GRAY.into(),
+        (true, _) => ELEMENT_FILL_DISABLED,
 
         (false, true) => SLIDER_THUMB.lighter(0.3),
 
@@ -639,7 +640,7 @@ fn set_checkbox_or_radio_style(
     border_color.set_all(color);
 
     let mark_color: Color = match (disabled, checked) {
-        (true, true) => GRAY.into(),
+        (true, true) => ELEMENT_FILL_DISABLED,
         (false, true) => CHECKBOX_CHECK,
         (_, false) => Srgba::NONE.into(),
     };

--- a/examples/ui/core_widgets.rs
+++ b/examples/ui/core_widgets.rs
@@ -53,8 +53,8 @@ const HOVERED_BUTTON: Color = Color::srgb(0.25, 0.25, 0.25);
 const PRESSED_BUTTON: Color = Color::srgb(0.35, 0.75, 0.35);
 const SLIDER_TRACK: Color = Color::srgb(0.05, 0.05, 0.05);
 const SLIDER_THUMB: Color = Color::srgb(0.35, 0.75, 0.35);
-const CHECKBOX_OUTLINE: Color = Color::srgb(0.45, 0.45, 0.45);
-const CHECKBOX_CHECK: Color = Color::srgb(0.35, 0.75, 0.35);
+const ELEMENT_OUTLINE: Color = Color::srgb(0.45, 0.45, 0.45);
+const ELEMENT_FILL: Color = Color::srgb(0.35, 0.75, 0.35);
 const ELEMENT_FILL_DISABLED: Color = Color::srgb(0.5019608, 0.5019608, 0.5019608);
 
 /// Marker which identifies buttons with a particular style, in this case the "Demo style".
@@ -354,7 +354,7 @@ fn slider(min: f32, max: f32, value: f32, on_change: Option<SystemId<In<f32>>>) 
                     height: Val::Px(6.0),
                     ..default()
                 },
-                BackgroundColor(SLIDER_TRACK), // Border color for the checkbox
+                BackgroundColor(SLIDER_TRACK), // Border color for the slider
                 BorderRadius::all(Val::Px(3.0)),
             )),
             // Invisible track to allow absolute placement of thumb entity. This is narrower than
@@ -486,7 +486,7 @@ fn checkbox(
                     border: UiRect::all(Val::Px(2.0)),
                     ..default()
                 },
-                BorderColor::all(CHECKBOX_OUTLINE), // Border color for the checkbox
+                BorderColor::all(ELEMENT_OUTLINE), // Border color for the checkbox
                 BorderRadius::all(Val::Px(3.0)),
                 children![
                     // Checkbox inner
@@ -500,7 +500,7 @@ fn checkbox(
                             top: Val::Px(2.0),
                             ..default()
                         },
-                        BackgroundColor(CHECKBOX_CHECK),
+                        BackgroundColor(ELEMENT_FILL),
                     ),
                 ],
             )),
@@ -516,7 +516,7 @@ fn checkbox(
     )
 }
 
-// Update the checkbox's styles.
+// Update the element's styles.
 fn update_checkbox_or_radio_style(
     mut q_checkbox: Query<
         (Has<Checked>, &Hovered, Has<InteractionDisabled>, &Children),
@@ -626,27 +626,27 @@ fn set_checkbox_or_radio_style(
     mark_bg: &mut BackgroundColor,
 ) {
     let color: Color = if disabled {
-        // If the checkbox is disabled, use a lighter color
-        CHECKBOX_OUTLINE.with_alpha(0.2)
+        // If the element is disabled, use a lighter color
+        ELEMENT_OUTLINE.with_alpha(0.2)
     } else if hovering {
         // If hovering, use a lighter color
-        CHECKBOX_OUTLINE.lighter(0.2)
+        ELEMENT_OUTLINE.lighter(0.2)
     } else {
-        // Default color for the checkbox
-        CHECKBOX_OUTLINE
+        // Default color for the element
+        ELEMENT_OUTLINE
     };
 
-    // Update the background color of the check mark
+    // Update the background color of the element
     border_color.set_all(color);
 
     let mark_color: Color = match (disabled, checked) {
         (true, true) => ELEMENT_FILL_DISABLED,
-        (false, true) => CHECKBOX_CHECK,
+        (false, true) => ELEMENT_FILL,
         (_, false) => Srgba::NONE.into(),
     };
 
     if mark_bg.0 != mark_color {
-        // Update the color of the check mark
+        // Update the color of the element
         mark_bg.0 = mark_color;
     }
 }
@@ -698,7 +698,7 @@ fn radio(asset_server: &AssetServer, value: TrackClick, caption: &str) -> impl B
                     border: UiRect::all(Val::Px(2.0)),
                     ..default()
                 },
-                BorderColor::all(CHECKBOX_OUTLINE), // Border color for the checkbox
+                BorderColor::all(ELEMENT_OUTLINE), // Border color for the radio button
                 BorderRadius::MAX,
                 children![
                     // Radio inner
@@ -713,7 +713,7 @@ fn radio(asset_server: &AssetServer, value: TrackClick, caption: &str) -> impl B
                             ..default()
                         },
                         BorderRadius::MAX,
-                        BackgroundColor(CHECKBOX_CHECK),
+                        BackgroundColor(ELEMENT_FILL),
                     ),
                 ],
             )),

--- a/examples/ui/core_widgets.rs
+++ b/examples/ui/core_widgets.rs
@@ -639,7 +639,7 @@ fn set_checkbox_or_radio_style(
     border_color.set_all(color);
 
     let mark_color: Color = match (disabled, checked) {
-        (true, true) => CHECKBOX_CHECK.with_alpha(0.5),
+        (true, true) => GRAY.into(),
         (false, true) => CHECKBOX_CHECK,
         (_, false) => Srgba::NONE.into(),
     };


### PR DESCRIPTION
Simple color change to the core widgets example. This sets the fill colors of the elements to gray if they are selected but disabled. It was hard to notice if they were disabled when they were still green.

![disabled_gray](https://github.com/user-attachments/assets/299f0700-9fab-4aa4-9076-f17859a60a5e)
