### PR TITLE
Add `is_finished` method to wasm tasks

### DIFF
--- a/crates/bevy_tasks/src/wasm_task.rs
+++ b/crates/bevy_tasks/src/wasm_task.rs
@@ -31,6 +31,12 @@ impl<T: 'static> Task<T> {
     /// This is only included for feature parity with other platforms.
     pub fn detach(self) {}
 
+    /// Returns true if the current task is finished.
+    pub fn is_finished(&self) -> bool {
+        // Returns true if the result is ready or has already been accessed.
+        !self.0.is_empty() || self.0.is_terminated()
+    }
+
     /// Requests a task to be cancelled and returns a future that suspends until it completes.
     /// Returns the output of the future if it has already completed.
     ///


### PR DESCRIPTION
# Objective

Bevy mocks `async_task::Task` when building for web using ` wasm_bindgen_futures`, but it is missing a web-version of the `is_finished` method. This method should return true when the future has been polled to completion.

## Solution

We use a channel to mock tasks, and the future is complete when the channel is treated as complete when data is sent over it. Specifically, we treat the future as complete when the channel is either non-empty or terminated/complete.