### PR TITLE
CI tests can exit directly after taking a screenshot

### DIFF
--- a/crates/bevy_dev_tools/src/ci_testing/config.rs
+++ b/crates/bevy_dev_tools/src/ci_testing/config.rs
@@ -37,6 +37,9 @@ pub enum CiTestingEvent {
     /// Takes a screenshot of the entire screen, and saves the results to
     /// `screenshot-{current_frame}.png`.
     Screenshot,
+    /// Takes a screenshot of the entire screen, saves the results to
+    /// `screenshot-{current_frame}.png`, and exits once the screenshot is taken.
+    ScreenshotAndExit,
     /// Takes a screenshot of the entire screen, and saves the results to
     /// `screenshot-{name}.png`.
     NamedScreenshot(String),

--- a/crates/bevy_dev_tools/src/ci_testing/systems.rs
+++ b/crates/bevy_dev_tools/src/ci_testing/systems.rs
@@ -21,6 +21,19 @@ pub(crate) fn send_events(world: &mut World, mut current_frame: Local<u32>) {
                 world.send_event(AppExit::Success);
                 info!("Exiting after {} frames. Test successful!", *current_frame);
             }
+            CiTestingEvent::ScreenshotAndExit => {
+                let this_frame = current_frame.clone();
+                world.spawn(Screenshot::primary_window()).observe(
+                    move |captured: On<bevy_render::view::screenshot::ScreenshotCaptured>,
+                          mut exit_event: EventWriter<AppExit>| {
+                        let path = format!("./screenshot-{}.png", this_frame);
+                        save_to_disk(path)(captured);
+                        info!("Exiting. Test successful!");
+                        exit_event.write(AppExit::Success);
+                    },
+                );
+                info!("Took a screenshot at frame {}.", *current_frame);
+            }
             CiTestingEvent::Screenshot => {
                 let path = format!("./screenshot-{}.png", *current_frame);
                 world

--- a/crates/bevy_dev_tools/src/ci_testing/systems.rs
+++ b/crates/bevy_dev_tools/src/ci_testing/systems.rs
@@ -22,7 +22,7 @@ pub(crate) fn send_events(world: &mut World, mut current_frame: Local<u32>) {
                 info!("Exiting after {} frames. Test successful!", *current_frame);
             }
             CiTestingEvent::ScreenshotAndExit => {
-                let this_frame = current_frame.clone();
+                let this_frame = *current_frame;
                 world.spawn(Screenshot::primary_window()).observe(
                     move |captured: On<bevy_render::view::screenshot::ScreenshotCaptured>,
                           mut exit_event: EventWriter<AppExit>| {


### PR DESCRIPTION
# Objective

- Currently, CI tests take a screenshot at frame X and exits at frame Y with X < Y, and both number fixed
- This means tests can take longer than they actually need when taking the screenshot is fast, and can fail to take the screenshot when it's taking too long

## Solution

- Add a new event `ScreenshotAndExit` that exit directly after the screenshot is saved
