### PR TITLE
Reuse seeded rng in tilemap_chunk for more determinism

### DIFF
--- a/examples/2d/tilemap_chunk.rs
+++ b/examples/2d/tilemap_chunk.rs
@@ -22,6 +22,8 @@ struct UpdateTimer(Timer);
 struct SeededRng(ChaCha8Rng);
 
 fn setup(mut commands: Commands, assets: Res<AssetServer>) {
+    // We're seeding the PRNG here to make this example deterministic for testing purposes.
+    // This isn't strictly required in practical use unless you need your app to be deterministic.
     let mut rng = ChaCha8Rng::seed_from_u64(42);
 
     let chunk_size = UVec2::splat(64);

--- a/examples/2d/tilemap_chunk.rs
+++ b/examples/2d/tilemap_chunk.rs
@@ -9,7 +9,7 @@ use rand_chacha::ChaCha8Rng;
 
 fn main() {
     App::new()
-        .add_plugins((DefaultPlugins.set(ImagePlugin::default_nearest()),))
+        .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest()))
         .add_systems(Startup, setup)
         .add_systems(Update, (update_tileset_image, update_tilemap))
         .run();
@@ -18,8 +18,12 @@ fn main() {
 #[derive(Component, Deref, DerefMut)]
 struct UpdateTimer(Timer);
 
+#[derive(Resource, Deref, DerefMut)]
+struct SeededRng(ChaCha8Rng);
+
 fn setup(mut commands: Commands, assets: Res<AssetServer>) {
     let mut rng = ChaCha8Rng::seed_from_u64(42);
+
     let chunk_size = UVec2::splat(64);
     let tile_display_size = UVec2::splat(8);
     let indices: Vec<Option<u16>> = (0..chunk_size.element_product())
@@ -39,6 +43,8 @@ fn setup(mut commands: Commands, assets: Res<AssetServer>) {
     ));
 
     commands.spawn(Camera2d);
+
+    commands.insert_resource(SeededRng(rng));
 }
 
 fn update_tileset_image(
@@ -55,12 +61,15 @@ fn update_tileset_image(
     }
 }
 
-fn update_tilemap(time: Res<Time>, mut query: Query<(&mut TilemapChunkIndices, &mut UpdateTimer)>) {
+fn update_tilemap(
+    time: Res<Time>,
+    mut query: Query<(&mut TilemapChunkIndices, &mut UpdateTimer)>,
+    mut rng: ResMut<SeededRng>,
+) {
     for (mut indices, mut timer) in query.iter_mut() {
         timer.tick(time.delta());
 
         if timer.just_finished() {
-            let mut rng = ChaCha8Rng::from_entropy();
             for _ in 0..50 {
                 let index = rng.gen_range(0..indices.len());
                 indices[index] = Some(rng.gen_range(0..5));


### PR DESCRIPTION
# Objective

This example uses a seeded RNG for the initial setup, but new unseeded RNGs during each timed update.

This is causing the example to produce different output each time in the [example report](https://bevyengine.github.io/bevy-example-runner/).

<img width="838" alt="image" src="https://github.com/user-attachments/assets/05d78083-97d0-4bcf-aebc-f645b570d144" />

## Solution

Store and reuse the RNG, following the pattern used in other examples.

## Testing

`cargo run --example tilemap_chunk`
