### PR TITLE
Registering required component to Bundle-contributing component fails

### DIFF
--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -2625,6 +2625,9 @@ pub enum RequiredComponentsError {
     /// An archetype with the component that requires other components already exists
     #[error("An archetype with the component {0:?} that requires other components already exists")]
     ArchetypeExists(ComponentId),
+    /// A bundle with the component that requires other components already exists
+    #[error("A bundle with the component {0:?} that requires other components already exists")]
+    BundleExists(ComponentId),
 }
 
 /// A Required Component constructor. See [`Component`] for details.

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -2455,6 +2455,24 @@ mod tests {
     }
 
     #[test]
+    fn runtime_required_components_existing_bundle() {
+        #[derive(Component)]
+        struct X;
+        #[derive(Component, Default)]
+        struct Y;
+
+        let mut world = World::new();
+
+        // Registering required components after it contributed to a bundle should panic.
+        // This may change in the future.
+        world.register_bundle::<X>();
+        assert!(matches!(
+            world.try_register_required_components::<X, Y>(),
+            Err(RequiredComponentsError::BundleExists(_))
+        ));
+    }
+
+    #[test]
     fn runtime_required_components_fail_with_duplicate() {
         #[derive(Component)]
         #[require(Y)]

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -534,9 +534,14 @@ impl World {
     ) -> Result<(), RequiredComponentsError> {
         let requiree = self.register_component::<T>();
 
-        // TODO: Remove this panic and update archetype edges accordingly when required components are added
+        // TODO: Remove this error and update archetype edges accordingly when required components are added
         if self.archetypes().component_index().contains_key(&requiree) {
             return Err(RequiredComponentsError::ArchetypeExists(requiree));
+        }
+
+        // TODO: Remove this error and update bundles with requiree and constructors of required components
+        if self.bundles().component_contributes_to_any(requiree) {
+            return Err(RequiredComponentsError::BundleExists(requiree));
         }
 
         let required = self.register_component::<R>();


### PR DESCRIPTION
# Objective

Fixes #18212

## Solution

This is the most conservative dont-fix-bundles solution that just panics/returns an error.

I had ideas to do a proper fix that updates the bundles but found no good way to identify the affected bundles. I wrote more details into the linked issue.

## Testing

I added another test that asserts the error is triggered.