### PR TITLE
Use SmallVec instead of HashMap in MaterialProperties

### DIFF
--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -1330,13 +1330,8 @@ impl MaterialProperties {
             .cloned()
     }
 
-    pub fn add_shader(
-        &mut self,
-        label: impl ShaderLabel,
-        shader: Handle<Shader>,
-    ) -> Option<Handle<Shader>> {
+    pub fn add_shader(&mut self, label: impl ShaderLabel, shader: Handle<Shader>) {
         self.shaders.push((label.intern(), shader));
-        self.shaders.last().map(|(_, shader)| shader).cloned()
     }
 
     pub fn get_draw_function(&self, label: impl DrawFunctionLabel) -> Option<DrawFunctionId> {
@@ -1351,12 +1346,8 @@ impl MaterialProperties {
         &mut self,
         label: impl DrawFunctionLabel,
         draw_function: DrawFunctionId,
-    ) -> Option<DrawFunctionId> {
+    ) {
         self.draw_functions.push((label.intern(), draw_function));
-        self.draw_functions
-            .last()
-            .map(|(_, shader)| shader)
-            .cloned()
     }
 }
 
@@ -1508,7 +1499,6 @@ where
                 ShaderRef::Path(path) => Some(asset_server.load(path)),
             };
             if let Some(shader) = mayber_shader {
-                // shaders.insert(label, shader);
                 shaders.push((label, shader));
             }
         };

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -553,27 +553,18 @@ impl PrepassPipelineInternal {
             || emulate_unclipped_depth
             || (mesh_key.contains(MeshPipelineKey::MAY_DISCARD)
                 && material_properties
-                    .shaders
-                    .get(&PrepassFragmentShader.intern())
+                    .get_shader(PrepassFragmentShader)
                     .is_some());
 
         let fragment = fragment_required.then(|| {
             // Use the fragment shader from the material
             let frag_shader_handle = if mesh_key.contains(MeshPipelineKey::DEFERRED_PREPASS) {
-                match material_properties
-                    .shaders
-                    .get(&DeferredFragmentShader.intern())
-                    .cloned()
-                {
+                match material_properties.get_shader(DeferredFragmentShader) {
                     Some(frag_shader_handle) => frag_shader_handle,
                     None => self.default_prepass_shader.clone(),
                 }
             } else {
-                match material_properties
-                    .shaders
-                    .get(&PrepassFragmentShader.intern())
-                    .cloned()
-                {
+                match material_properties.get_shader(PrepassFragmentShader) {
                     Some(frag_shader_handle) => frag_shader_handle,
                     None => self.default_prepass_shader.clone(),
                 }


### PR DESCRIPTION
# Objective

- MaterialProperties uses HashMap for some data that is generally going to be really small. This is likely using more memory than necessary

## Solution

- Use a SmallVec instead
- I used the size a StandardMaterial would need for all the backing arrays

## Testing

- Tested the 3d_scene to confirm it still works

## Notes

I'm not sure if it made a measurable difference since I'm not sure how to measure this. It's a bit hard to create an artificial workflow where this would be the main bottleneck. This is very in the realm of microoptimization.