### PR TITLE
bevy_ecs: remove use of needless_return

### DIFF
--- a/crates/bevy_ecs/src/storage/resource.rs
+++ b/crates/bevy_ecs/src/storage/resource.rs
@@ -64,32 +64,23 @@ impl<const SEND: bool> ResourceData<SEND> {
     /// If `SEND` is false, this will panic if called from a different thread than the one it was inserted from.
     #[inline]
     fn validate_access(&self) {
-        if SEND {
-            #[cfg_attr(
-                not(feature = "std"),
-                expect(
-                    clippy::needless_return,
-                    reason = "needless until no_std is addressed (see below)",
-                )
-            )]
-            return;
-        }
+        if !SEND {
+            #[cfg(feature = "std")]
+            if self.origin_thread_id != Some(std::thread::current().id()) {
+                // Panic in tests, as testing for aborting is nearly impossible
+                panic!(
+                    "Attempted to access or drop non-send resource {} from thread {:?} on a thread {:?}. This is not allowed. Aborting.",
+                    self.type_name,
+                    self.origin_thread_id,
+                    std::thread::current().id()
+                );
+            }
 
-        #[cfg(feature = "std")]
-        if self.origin_thread_id != Some(std::thread::current().id()) {
-            // Panic in tests, as testing for aborting is nearly impossible
-            panic!(
-                "Attempted to access or drop non-send resource {} from thread {:?} on a thread {:?}. This is not allowed. Aborting.",
-                self.type_name,
-                self.origin_thread_id,
-                std::thread::current().id()
-            );
+            // TODO: Handle no_std non-send.
+            // Currently, no_std is single-threaded only, so this is safe to ignore.
+            // To support no_std multithreading, an alternative will be required.
+            // Remove the #[expect] attribute above when this is addressed.
         }
-
-        // TODO: Handle no_std non-send.
-        // Currently, no_std is single-threaded only, so this is safe to ignore.
-        // To support no_std multithreading, an alternative will be required.
-        // Remove the #[expect] attribute above when this is addressed.
     }
 
     /// Returns true if the resource is populated.


### PR DESCRIPTION
# Objective

- bevy_ecs has a expected lint that is both needed and unneeded

## Solution

- Change the logic so that it's always not needed

## Testing

`cargo clippy -p bevy_ecs --no-default-features --no-deps -- -D warnings`
