### PR TITLE
bevy_asset: fix clippy in wasm

### DIFF
--- a/crates/bevy_asset/src/io/wasm.rs
+++ b/crates/bevy_asset/src/io/wasm.rs
@@ -47,7 +47,7 @@ fn js_value_to_err(context: &str) -> impl FnOnce(JsValue) -> std::io::Error + '_
             }
         };
 
-        std::io::Error::new(std::io::ErrorKind::Other, message)
+        std::io::Error::other(message)
     }
 }
 
@@ -62,10 +62,7 @@ impl HttpWasmAssetReader {
             let worker: web_sys::WorkerGlobalScope = global.unchecked_into();
             worker.fetch_with_str(path.to_str().unwrap())
         } else {
-            let error = std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "Unsupported JavaScript global context",
-            );
+            let error = std::io::Error::other("Unsupported JavaScript global context");
             return Err(AssetReaderError::Io(error.into()));
         };
         let resp_value = JsFuture::from(promise)


### PR DESCRIPTION
# Objective

- bevy_asset has a clippy warning in wasm: [`clippy::io_other_error`](https://rust-lang.github.io/rust-clippy/master/index.html#io_other_error)

```
error: this can be `std::io::Error::other(_)`
  --> crates/bevy_asset/src/io/wasm.rs:50:9
   |
50 |         std::io::Error::new(std::io::ErrorKind::Other, message)
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#io_other_error
   = note: `-D clippy::io-other-error` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::io_other_error)]`
help: use `std::io::Error::other`
   |
50 -         std::io::Error::new(std::io::ErrorKind::Other, message)
50 +         std::io::Error::other(message)
```

## Solution

- Fix it

## Testing

`cargo clippy --target wasm32-unknown-unknown -p bevy_asset --no-deps -- -D warnings`