### PR TITLE
Move `ExtractInstancesPlugin<EnvironmentMapIds>` init to app.

### DIFF
--- a/crates/bevy_pbr/src/light_probe/mod.rs
+++ b/crates/bevy_pbr/src/light_probe/mod.rs
@@ -343,7 +343,8 @@ impl Plugin for LightProbePlugin {
 
         app.register_type::<LightProbe>()
             .register_type::<EnvironmentMapLight>()
-            .register_type::<IrradianceVolume>();
+            .register_type::<IrradianceVolume>()
+            .add_plugins(ExtractInstancesPlugin::<EnvironmentMapIds>::new());
     }
 
     fn finish(&self, app: &mut App) {
@@ -352,7 +353,6 @@ impl Plugin for LightProbePlugin {
         };
 
         render_app
-            .add_plugins(ExtractInstancesPlugin::<EnvironmentMapIds>::new())
             .init_resource::<LightProbesBuffer>()
             .init_resource::<EnvironmentMapUniformBuffer>()
             .add_systems(ExtractSchedule, gather_environment_map_uniform)


### PR DESCRIPTION
# Objective

- This plugin currently does nothing. That's because we add the plugin to the `RenderApp`. Inside the plugin it then looks for the `RenderApp` itself, but since it was added **to** the `RenderApp`, it will never find the `RenderApp`.

## Solution

- Move the plugin into build, and more importantly, add it to the app not the render_app.