### PR TITLE
bevy_window: fix compilation without default features

### DIFF
--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -1,4 +1,6 @@
-use alloc::{borrow::ToOwned, format, string::String};
+#[cfg(feature = "std")]
+use alloc::format;
+use alloc::{borrow::ToOwned, string::String};
 use core::num::NonZero;
 
 use bevy_ecs::{
@@ -1471,7 +1473,8 @@ pub struct ClosingWindow;
 /// - Only used on iOS.
 ///
 /// [`winit::platform::ios::ScreenEdge`]: https://docs.rs/winit/latest/x86_64-apple-darwin/winit/platform/ios/struct.ScreenEdge.html
-#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash, Reflect)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum ScreenEdge {
     #[default]


### PR DESCRIPTION
# Objective

- bevy_window fails to compile without default features

```
error: cannot find derive macro `Reflect` in this scope
    --> crates/bevy_window/src/window.rs:1474:60
     |
1474 | #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash, Reflect)]
     |                                                            ^^^^^^^

warning: unused import: `format`
 --> crates/bevy_window/src/window.rs:1:30
  |
1 | use alloc::{borrow::ToOwned, format, string::String};
  |                              ^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: `bevy_window` (lib) generated 1 warning
error: could not compile `bevy_window` (lib) due to 1 previous error; 1 warning emitted
```

## Solution

- Fix them

## Testing

`cargo build -p bevy_window --no-default-features --features bevy_math/libm`