### PR TITLE
bevy_render: fix clippy on wasm

### DIFF
--- a/crates/bevy_render/src/batching/gpu_preprocessing.rs
+++ b/crates/bevy_render/src/batching/gpu_preprocessing.rs
@@ -392,9 +392,12 @@ where
 }
 
 /// The buffer of GPU preprocessing work items for a single view.
-#[expect(
-    clippy::large_enum_variant,
-    reason = "See https://github.com/bevyengine/bevy/issues/19220"
+#[cfg_attr(
+    not(target_arch = "wasm32"),
+    expect(
+        clippy::large_enum_variant,
+        reason = "See https://github.com/bevyengine/bevy/issues/19220"
+    )
 )]
 pub enum PreprocessWorkItemBuffers {
     /// The work items we use if we aren't using indirect drawing.

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -80,9 +80,12 @@ pub struct CachedPipeline {
 }
 
 /// State of a cached pipeline inserted into a [`PipelineCache`].
-#[expect(
-    clippy::large_enum_variant,
-    reason = "See https://github.com/bevyengine/bevy/issues/19220"
+#[cfg_attr(
+    not(target_arch = "wasm32"),
+    expect(
+        clippy::large_enum_variant,
+        reason = "See https://github.com/bevyengine/bevy/issues/19220"
+    )
 )]
 #[derive(Debug)]
 pub enum CachedPipelineState {
@@ -1114,9 +1117,12 @@ fn create_pipeline_task(
 }
 
 /// Type of error returned by a [`PipelineCache`] when the creation of a GPU pipeline object failed.
-#[expect(
-    clippy::large_enum_variant,
-    reason = "See https://github.com/bevyengine/bevy/issues/19220"
+#[cfg_attr(
+    not(target_arch = "wasm32"),
+    expect(
+        clippy::large_enum_variant,
+        reason = "See https://github.com/bevyengine/bevy/issues/19220"
+    )
 )]
 #[derive(Error, Debug)]
 pub enum PipelineCacheError {


### PR DESCRIPTION
# Objective

- bevy_render has unfulfilled expected clippy lints in wasm

## Solution

- Don't expect them in wasm

## Testing

`cargo clippy --target wasm32-unknown-unknown -p bevy_render --no-deps -- -D warnings`