### PR TITLE
fix skin uniform buffer size

### DIFF
--- a/crates/bevy_pbr/src/render/skin.rs
+++ b/crates/bevy_pbr/src/render/skin.rs
@@ -220,7 +220,7 @@ pub fn prepare_skins(
         let mut new_size = uniform.current_buffer.size();
         while new_size < needed_size {
             // 1.5× growth factor.
-            new_size += new_size / 2;
+            new_size = (new_size + new_size / 2).next_multiple_of(4);
         }
 
         // Create the new buffers.


### PR DESCRIPTION
# Objective

for `BufferUsages::STORAGE` on webgpu (and maybe other contexts), buffer sizes must be a multiple of 4. the skin uniform buffer starts at 16384 then increases by 1.5x, which eventually hits a number which isn't

## Solution

`.next_multiple_of(4)`