### PR TITLE
Use `RenderStartup` in `bevy_ui`.

### DIFF
--- a/crates/bevy_ui_render/src/lib.rs
+++ b/crates/bevy_ui_render/src/lib.rs
@@ -36,7 +36,6 @@ use bevy_ecs::prelude::*;
 use bevy_ecs::system::SystemParam;
 use bevy_image::prelude::*;
 use bevy_math::{Affine2, FloatOrd, Mat4, Rect, UVec4, Vec2};
-use bevy_render::load_shader_library;
 use bevy_render::render_graph::{NodeRunError, RenderGraphContext};
 use bevy_render::render_phase::ViewSortedRenderPhases;
 use bevy_render::renderer::RenderContext;
@@ -53,6 +52,7 @@ use bevy_render::{
     view::{ExtractedView, ViewUniforms},
     Extract, RenderApp, RenderSystems,
 };
+use bevy_render::{load_shader_library, RenderStartup};
 use bevy_render::{
     render_phase::{PhaseItem, PhaseItemExtraIndex},
     sync_world::{RenderEntity, TemporaryRenderEntity},
@@ -243,6 +243,7 @@ impl Plugin for UiRenderPlugin {
                 )
                     .chain(),
             )
+            .add_systems(RenderStartup, init_ui_pipeline)
             .add_systems(
                 ExtractSchedule,
                 (
@@ -291,14 +292,6 @@ impl Plugin for UiRenderPlugin {
         app.add_plugins(UiTextureSlicerPlugin);
         app.add_plugins(GradientPlugin);
         app.add_plugins(BoxShadowPlugin);
-    }
-
-    fn finish(&self, app: &mut App) {
-        let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
-            return;
-        };
-
-        render_app.init_resource::<UiPipeline>();
     }
 }
 

--- a/crates/bevy_ui_render/src/ui_material_pipeline.rs
+++ b/crates/bevy_ui_render/src/ui_material_pipeline.rs
@@ -8,11 +8,9 @@ use bevy_ecs::{
         lifetimeless::{Read, SRes},
         *,
     },
-    world::{FromWorld, World},
 };
 use bevy_image::BevyDefault as _;
 use bevy_math::{Affine2, FloatOrd, Rect, Vec2};
-use bevy_render::RenderApp;
 use bevy_render::{
     globals::{GlobalsBuffer, GlobalsUniform},
     load_shader_library,
@@ -24,6 +22,7 @@ use bevy_render::{
     view::*,
     Extract, ExtractSchedule, Render, RenderSystems,
 };
+use bevy_render::{RenderApp, RenderStartup};
 use bevy_sprite::BorderRect;
 use bevy_utils::default;
 use bytemuck::{Pod, Zeroable};
@@ -61,6 +60,7 @@ where
                 .init_resource::<ExtractedUiMaterialNodes<M>>()
                 .init_resource::<UiMaterialMeta<M>>()
                 .init_resource::<SpecializedRenderPipelines<UiMaterialPipeline<M>>>()
+                .add_systems(RenderStartup, init_ui_material_pipeline::<M>)
                 .add_systems(
                     ExtractSchedule,
                     extract_ui_material_nodes::<M>.in_set(RenderUiSystems::ExtractBackgrounds),
@@ -72,12 +72,6 @@ where
                         prepare_uimaterial_nodes::<M>.in_set(RenderSystems::PrepareBindGroups),
                     ),
                 );
-        }
-    }
-
-    fn finish(&self, app: &mut App) {
-        if let Some(render_app) = app.get_sub_app_mut(RenderApp) {
-            render_app.init_resource::<UiMaterialPipeline<M>>();
         }
     }
 }
@@ -185,41 +179,41 @@ where
     }
 }
 
-impl<M: UiMaterial> FromWorld for UiMaterialPipeline<M> {
-    fn from_world(world: &mut World) -> Self {
-        let asset_server = world.resource::<AssetServer>();
-        let render_device = world.resource::<RenderDevice>();
-        let ui_layout = M::bind_group_layout(render_device);
+pub fn init_ui_material_pipeline<M: UiMaterial>(
+    mut commands: Commands,
+    render_device: Res<RenderDevice>,
+    asset_server: Res<AssetServer>,
+) {
+    let ui_layout = M::bind_group_layout(&render_device);
 
-        let view_layout = render_device.create_bind_group_layout(
-            "ui_view_layout",
-            &BindGroupLayoutEntries::sequential(
-                ShaderStages::VERTEX_FRAGMENT,
-                (
-                    uniform_buffer::<ViewUniform>(true),
-                    uniform_buffer::<GlobalsUniform>(false),
-                ),
+    let view_layout = render_device.create_bind_group_layout(
+        "ui_view_layout",
+        &BindGroupLayoutEntries::sequential(
+            ShaderStages::VERTEX_FRAGMENT,
+            (
+                uniform_buffer::<ViewUniform>(true),
+                uniform_buffer::<GlobalsUniform>(false),
             ),
-        );
+        ),
+    );
 
-        let load_default = || load_embedded_asset!(asset_server, "ui_material.wgsl");
+    let load_default = || load_embedded_asset!(asset_server.as_ref(), "ui_material.wgsl");
 
-        UiMaterialPipeline {
-            ui_layout,
-            view_layout,
-            vertex_shader: match M::vertex_shader() {
-                ShaderRef::Default => load_default(),
-                ShaderRef::Handle(handle) => handle,
-                ShaderRef::Path(path) => asset_server.load(path),
-            },
-            fragment_shader: match M::fragment_shader() {
-                ShaderRef::Default => load_default(),
-                ShaderRef::Handle(handle) => handle,
-                ShaderRef::Path(path) => asset_server.load(path),
-            },
-            marker: PhantomData,
-        }
-    }
+    commands.insert_resource(UiMaterialPipeline::<M> {
+        ui_layout,
+        view_layout,
+        vertex_shader: match M::vertex_shader() {
+            ShaderRef::Default => load_default(),
+            ShaderRef::Handle(handle) => handle,
+            ShaderRef::Path(path) => asset_server.load(path),
+        },
+        fragment_shader: match M::fragment_shader() {
+            ShaderRef::Default => load_default(),
+            ShaderRef::Handle(handle) => handle,
+            ShaderRef::Path(path) => asset_server.load(path),
+        },
+        marker: PhantomData,
+    });
 }
 
 pub type DrawUiMaterial<M> = (


### PR DESCRIPTION
# Objective

- Progress towards #19887.

## Solution

- Convert `FromWorld` impls into systems that run in `RenderStartup`.
- Move `UiPipeline` init to `build_ui_render` instead of doing it separately in `finish`.

Note: I am making several of these systems pub so that users could order their systems relative to them. This is to match the fact that these types previously were FromWorld so users could initialize them.

## Testing

- Ran `ui_material`, `ui_texture_slice`, `box_shadow`, and `gradients` examples and it still worked.