### PR TITLE
bevy_reflect: remove unnecessary `const _` around `TypePath` impl

### DIFF
--- a/crates/bevy_reflect/derive/src/impls/typed.rs
+++ b/crates/bevy_reflect/derive/src/impls/typed.rs
@@ -106,34 +106,27 @@ pub(crate) fn impl_type_path(meta: &ReflectMeta) -> TokenStream {
     quote! {
         #primitive_assert
 
-        // To ensure alloc is available, but also prevent its name from clashing, we place the implementation inside an anonymous constant
-        const _: () = {
-            extern crate alloc;
-
-            use alloc::string::ToString;
-
-            impl #impl_generics #bevy_reflect_path::TypePath for #type_path #ty_generics #where_reflect_clause {
-                fn type_path() -> &'static str {
-                    #long_type_path
-                }
-
-                fn short_type_path() -> &'static str {
-                    #short_type_path
-                }
-
-                fn type_ident() -> Option<&'static str> {
-                    #type_ident
-                }
-
-                fn crate_name() -> Option<&'static str> {
-                    #crate_name
-                }
-
-                fn module_path() -> Option<&'static str> {
-                    #module_path
-                }
+        impl #impl_generics #bevy_reflect_path::TypePath for #type_path #ty_generics #where_reflect_clause {
+            fn type_path() -> &'static str {
+                #long_type_path
             }
-        };
+
+            fn short_type_path() -> &'static str {
+                #short_type_path
+            }
+
+            fn type_ident() -> Option<&'static str> {
+                #type_ident
+            }
+
+            fn crate_name() -> Option<&'static str> {
+                #crate_name
+            }
+
+            fn module_path() -> Option<&'static str> {
+                #module_path
+            }
+        }
     }
 }
 


### PR DESCRIPTION
# Objective

Derived `TypePath` impls have a `const _` block in order to hold a `use alloc::string::ToString` import. But that import is useless. 

Avoiding it helps with https://github.com/bevyengine/bevy/issues/19873.

## Solution

Remove the `use` and `const _`.

## Testing

I used cargo expand to confirm the `const _ ` is no longer produced.

`-Zmacro-stats` output tells me this reduces the size of the `Reflect` code produced for `bevy_ui` from 1_880_486 bytes to 1_859_634 bytes, a 1.1% drop.
