### PR TITLE
Implement `MapEntities` for arrays, `HashMap`, `BTreeMap`, `IndexMap`

### DIFF
--- a/crates/bevy_ecs/src/entity/map_entities.rs
+++ b/crates/bevy_ecs/src/entity/map_entities.rs
@@ -11,7 +11,10 @@ use alloc::{
     vec::Vec,
 };
 use bevy_platform::collections::{HashMap, HashSet};
-use core::{hash::BuildHasher, mem};
+use core::{
+    hash::{BuildHasher, Hash},
+    mem,
+};
 use smallvec::SmallVec;
 
 use super::EntityIndexSet;
@@ -72,7 +75,7 @@ impl<T: MapEntities> MapEntities for Option<T> {
     }
 }
 
-impl<K: MapEntities + Eq + core::hash::Hash, V: MapEntities, S: BuildHasher + Default> MapEntities
+impl<K: MapEntities + Eq + Hash, V: MapEntities, S: BuildHasher + Default> MapEntities
     for HashMap<K, V, S>
 {
     fn map_entities<E: EntityMapper>(&mut self, entity_mapper: &mut E) {
@@ -87,9 +90,7 @@ impl<K: MapEntities + Eq + core::hash::Hash, V: MapEntities, S: BuildHasher + De
     }
 }
 
-impl<T: MapEntities + Eq + core::hash::Hash, S: BuildHasher + Default> MapEntities
-    for HashSet<T, S>
-{
+impl<T: MapEntities + Eq + Hash, S: BuildHasher + Default> MapEntities for HashSet<T, S> {
     fn map_entities<E: EntityMapper>(&mut self, entity_mapper: &mut E) {
         *self = self
             .drain()
@@ -101,7 +102,7 @@ impl<T: MapEntities + Eq + core::hash::Hash, S: BuildHasher + Default> MapEntiti
     }
 }
 
-impl<K: MapEntities + Eq + core::hash::Hash, V: MapEntities, S: BuildHasher + Default> MapEntities
+impl<K: MapEntities + Eq + Hash, V: MapEntities, S: BuildHasher + Default> MapEntities
     for IndexMap<K, V, S>
 {
     fn map_entities<E: EntityMapper>(&mut self, entity_mapper: &mut E) {
@@ -116,9 +117,7 @@ impl<K: MapEntities + Eq + core::hash::Hash, V: MapEntities, S: BuildHasher + De
     }
 }
 
-impl<T: MapEntities + Eq + core::hash::Hash, S: BuildHasher + Default> MapEntities
-    for IndexSet<T, S>
-{
+impl<T: MapEntities + Eq + Hash, S: BuildHasher + Default> MapEntities for IndexSet<T, S> {
     fn map_entities<E: EntityMapper>(&mut self, entity_mapper: &mut E) {
         *self = self
             .drain(..)


### PR DESCRIPTION
# Objective

- `MapEntities` is not implemented for arrays, `HashMap`, `BTreeMap`, and `IndexMap`.

## Solution

- Implement `MapEntities` for arrays, `HashMap`, `BTreeMap`, `IndexMap`

## Testing

- I didn't add a test for this as the implementations seems pretty trivial