### PR TITLE
Spawn multiple chunks in the tilemap_chunk example

### DIFF
--- a/crates/bevy_sprite/src/tilemap_chunk/mod.rs
+++ b/crates/bevy_sprite/src/tilemap_chunk/mod.rs
@@ -91,8 +91,8 @@ fn on_insert_tilemap_chunk(mut world: DeferredWorld, HookContext { entity, .. }:
             "Invalid indices length for tilemap chunk {} of size {}. Expected {}, got {}",
             entity,
             chunk_size,
+            expected_indices_length,
             indices.len(),
-            expected_indices_length
         );
         return;
     }


### PR DESCRIPTION
# Objective

The `tilemap_chunk` example is currently very basic, it's more useful if it also shows how to spawn multiple chunks.

Currently multiple chunks also seems broken, on my machine I get the following when running the example
![image](https://github.com/user-attachments/assets/9057cacf-be30-4ab1-b5d3-27669041d75b)

## Solution

Spawn multiple chunks in the example


