### PR TITLE
set required-features for example pbr_light_textures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4437,6 +4437,7 @@ wasm = false
 name = "light_textures"
 path = "examples/3d/light_textures.rs"
 doc-scrape-examples = true
+required-features = ["pbr_light_textures"]
 
 [package.metadata.example.light_textures]
 name = "Light Textures"

--- a/examples/3d/light_textures.rs
+++ b/examples/3d/light_textures.rs
@@ -155,12 +155,6 @@ fn setup(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    // Error out if the light textures feature isn't enabled
-    if !cfg!(feature = "pbr_light_textures") {
-        eprintln!("Bevy was compiled without light texture support. Run with `--features=pbr_light_textures` to enable.");
-        process::exit(1);
-    }
-
     // Error out if clustered decals (and so light textures) aren't supported on the current platform.
     if !decal::clustered::clustered_decals_are_usable(&render_device, &render_adapter) {
         eprintln!("Light textures aren't usable on this platform.");


### PR DESCRIPTION
# Objective

- Example `light_textures` exit if feature `pbr_light_textures` is not enabled. this is checked in code instead of using `required-features`

## Solution

- Use `required-features`
