### PR TITLE
Avoid unnecessary `ReflectMeta` arguments

### DIFF
--- a/crates/bevy_reflect/derive/src/derive_data.rs
+++ b/crates/bevy_reflect/derive/src/derive_data.rs
@@ -482,7 +482,6 @@ impl<'a> ReflectMeta<'a> {
         where_clause_options: &WhereClauseOptions,
     ) -> proc_macro2::TokenStream {
         crate::registration::impl_get_type_registration(
-            self,
             where_clause_options,
             None,
             Option::<core::iter::Empty<&Type>>::None,
@@ -599,7 +598,6 @@ impl<'a> ReflectStruct<'a> {
         where_clause_options: &WhereClauseOptions,
     ) -> proc_macro2::TokenStream {
         crate::registration::impl_get_type_registration(
-            self.meta(),
             where_clause_options,
             self.serialization_data(),
             Some(self.active_types().iter()),
@@ -880,7 +878,6 @@ impl<'a> ReflectEnum<'a> {
         where_clause_options: &WhereClauseOptions,
     ) -> proc_macro2::TokenStream {
         crate::registration::impl_get_type_registration(
-            self.meta(),
             where_clause_options,
             None,
             Some(self.active_fields().map(StructField::reflected_type)),

--- a/crates/bevy_reflect/derive/src/impls/common.rs
+++ b/crates/bevy_reflect/derive/src/impls/common.rs
@@ -4,10 +4,8 @@ use quote::quote;
 
 use crate::{derive_data::ReflectMeta, where_clause_options::WhereClauseOptions};
 
-pub fn impl_full_reflect(
-    meta: &ReflectMeta,
-    where_clause_options: &WhereClauseOptions,
-) -> proc_macro2::TokenStream {
+pub fn impl_full_reflect(where_clause_options: &WhereClauseOptions) -> proc_macro2::TokenStream {
+    let meta = where_clause_options.meta();
     let bevy_reflect_path = meta.bevy_reflect_path();
     let type_path = meta.type_path();
 

--- a/crates/bevy_reflect/derive/src/impls/enums.rs
+++ b/crates/bevy_reflect/derive/src/impls/enums.rs
@@ -36,8 +36,6 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
     let ref_index = Ident::new("__index_param", Span::call_site());
     let ref_value = Ident::new("__value_param", Span::call_site());
 
-    let where_clause_options = reflect_enum.where_clause_options();
-
     let EnumImpls {
         enum_field,
         enum_field_mut,
@@ -57,14 +55,11 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
         ..
     } = TryApplyVariantBuilder::new(reflect_enum).build(&ref_value);
 
-    let typed_impl = impl_typed(
-        reflect_enum.meta(),
-        &where_clause_options,
-        reflect_enum.to_info_tokens(),
-    );
+    let where_clause_options = reflect_enum.where_clause_options();
+    let typed_impl = impl_typed(&where_clause_options, reflect_enum.to_info_tokens());
 
     let type_path_impl = impl_type_path(reflect_enum.meta());
-    let full_reflect_impl = impl_full_reflect(reflect_enum.meta(), &where_clause_options);
+    let full_reflect_impl = impl_full_reflect(&where_clause_options);
     let common_methods = common_partial_reflect_methods(
         reflect_enum.meta(),
         || Some(quote!(#bevy_reflect_path::enum_partial_eq)),
@@ -75,8 +70,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
     #[cfg(not(feature = "functions"))]
     let function_impls = None::<proc_macro2::TokenStream>;
     #[cfg(feature = "functions")]
-    let function_impls =
-        crate::impls::impl_function_traits(reflect_enum.meta(), &where_clause_options);
+    let function_impls = crate::impls::impl_function_traits(&where_clause_options);
 
     let get_type_registration_impl = reflect_enum.get_type_registration(&where_clause_options);
 

--- a/crates/bevy_reflect/derive/src/impls/func/from_arg.rs
+++ b/crates/bevy_reflect/derive/src/impls/func/from_arg.rs
@@ -1,11 +1,9 @@
-use crate::{derive_data::ReflectMeta, where_clause_options::WhereClauseOptions};
+use crate::where_clause_options::WhereClauseOptions;
 use bevy_macro_utils::fq_std::FQResult;
 use quote::quote;
 
-pub(crate) fn impl_from_arg(
-    meta: &ReflectMeta,
-    where_clause_options: &WhereClauseOptions,
-) -> proc_macro2::TokenStream {
+pub(crate) fn impl_from_arg(where_clause_options: &WhereClauseOptions) -> proc_macro2::TokenStream {
+    let meta = where_clause_options.meta();
     let bevy_reflect = meta.bevy_reflect_path();
     let type_path = meta.type_path();
 

--- a/crates/bevy_reflect/derive/src/impls/func/function_impls.rs
+++ b/crates/bevy_reflect/derive/src/impls/func/function_impls.rs
@@ -1,5 +1,4 @@
 use crate::{
-    derive_data::ReflectMeta,
     impls::func::{
         from_arg::impl_from_arg, get_ownership::impl_get_ownership, into_return::impl_into_return,
     },
@@ -8,12 +7,11 @@ use crate::{
 use quote::quote;
 
 pub(crate) fn impl_function_traits(
-    meta: &ReflectMeta,
     where_clause_options: &WhereClauseOptions,
 ) -> proc_macro2::TokenStream {
-    let get_ownership = impl_get_ownership(meta, where_clause_options);
-    let from_arg = impl_from_arg(meta, where_clause_options);
-    let into_return = impl_into_return(meta, where_clause_options);
+    let get_ownership = impl_get_ownership(where_clause_options);
+    let from_arg = impl_from_arg(where_clause_options);
+    let into_return = impl_into_return(where_clause_options);
 
     quote! {
         #get_ownership

--- a/crates/bevy_reflect/derive/src/impls/func/get_ownership.rs
+++ b/crates/bevy_reflect/derive/src/impls/func/get_ownership.rs
@@ -1,10 +1,10 @@
-use crate::{derive_data::ReflectMeta, where_clause_options::WhereClauseOptions};
+use crate::where_clause_options::WhereClauseOptions;
 use quote::quote;
 
 pub(crate) fn impl_get_ownership(
-    meta: &ReflectMeta,
     where_clause_options: &WhereClauseOptions,
 ) -> proc_macro2::TokenStream {
+    let meta = where_clause_options.meta();
     let bevy_reflect = meta.bevy_reflect_path();
     let type_path = meta.type_path();
 

--- a/crates/bevy_reflect/derive/src/impls/func/into_return.rs
+++ b/crates/bevy_reflect/derive/src/impls/func/into_return.rs
@@ -1,10 +1,10 @@
-use crate::{derive_data::ReflectMeta, where_clause_options::WhereClauseOptions};
+use crate::where_clause_options::WhereClauseOptions;
 use quote::quote;
 
 pub(crate) fn impl_into_return(
-    meta: &ReflectMeta,
     where_clause_options: &WhereClauseOptions,
 ) -> proc_macro2::TokenStream {
+    let meta = where_clause_options.meta();
     let bevy_reflect = meta.bevy_reflect_path();
     let type_path = meta.type_path();
 

--- a/crates/bevy_reflect/derive/src/impls/opaque.rs
+++ b/crates/bevy_reflect/derive/src/impls/opaque.rs
@@ -21,7 +21,6 @@ pub(crate) fn impl_opaque(meta: &ReflectMeta) -> proc_macro2::TokenStream {
 
     let where_clause_options = WhereClauseOptions::new(meta);
     let typed_impl = impl_typed(
-        meta,
         &where_clause_options,
         quote! {
             let info = #bevy_reflect_path::OpaqueInfo::new::<Self>() #with_docs;
@@ -30,7 +29,7 @@ pub(crate) fn impl_opaque(meta: &ReflectMeta) -> proc_macro2::TokenStream {
     );
 
     let type_path_impl = impl_type_path(meta);
-    let full_reflect_impl = impl_full_reflect(meta, &where_clause_options);
+    let full_reflect_impl = impl_full_reflect(&where_clause_options);
     let common_methods = common_partial_reflect_methods(meta, || None, || None);
     let clone_fn = meta.attrs().get_clone_impl(bevy_reflect_path);
 
@@ -54,7 +53,7 @@ pub(crate) fn impl_opaque(meta: &ReflectMeta) -> proc_macro2::TokenStream {
     #[cfg(not(feature = "functions"))]
     let function_impls = None::<proc_macro2::TokenStream>;
     #[cfg(feature = "functions")]
-    let function_impls = crate::impls::impl_function_traits(meta, &where_clause_options);
+    let function_impls = crate::impls::impl_function_traits(&where_clause_options);
 
     let (impl_generics, ty_generics, where_clause) = type_path.generics().split_for_impl();
     let where_reflect_clause = where_clause_options.extend_where_clause(where_clause);

--- a/crates/bevy_reflect/derive/src/impls/structs.rs
+++ b/crates/bevy_reflect/derive/src/impls/structs.rs
@@ -34,14 +34,10 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> proc_macro2::TokenS
     } = FieldAccessors::new(reflect_struct);
 
     let where_clause_options = reflect_struct.where_clause_options();
-    let typed_impl = impl_typed(
-        reflect_struct.meta(),
-        &where_clause_options,
-        reflect_struct.to_info_tokens(false),
-    );
+    let typed_impl = impl_typed(&where_clause_options, reflect_struct.to_info_tokens(false));
 
     let type_path_impl = impl_type_path(reflect_struct.meta());
-    let full_reflect_impl = impl_full_reflect(reflect_struct.meta(), &where_clause_options);
+    let full_reflect_impl = impl_full_reflect(&where_clause_options);
     let common_methods = common_partial_reflect_methods(
         reflect_struct.meta(),
         || Some(quote!(#bevy_reflect_path::struct_partial_eq)),
@@ -52,8 +48,7 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> proc_macro2::TokenS
     #[cfg(not(feature = "functions"))]
     let function_impls = None::<proc_macro2::TokenStream>;
     #[cfg(feature = "functions")]
-    let function_impls =
-        crate::impls::impl_function_traits(reflect_struct.meta(), &where_clause_options);
+    let function_impls = crate::impls::impl_function_traits(&where_clause_options);
 
     let get_type_registration_impl = reflect_struct.get_type_registration(&where_clause_options);
 

--- a/crates/bevy_reflect/derive/src/impls/tuple_structs.rs
+++ b/crates/bevy_reflect/derive/src/impls/tuple_structs.rs
@@ -24,14 +24,10 @@ pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> proc_macro2::
     let where_clause_options = reflect_struct.where_clause_options();
     let get_type_registration_impl = reflect_struct.get_type_registration(&where_clause_options);
 
-    let typed_impl = impl_typed(
-        reflect_struct.meta(),
-        &where_clause_options,
-        reflect_struct.to_info_tokens(true),
-    );
+    let typed_impl = impl_typed(&where_clause_options, reflect_struct.to_info_tokens(true));
 
     let type_path_impl = impl_type_path(reflect_struct.meta());
-    let full_reflect_impl = impl_full_reflect(reflect_struct.meta(), &where_clause_options);
+    let full_reflect_impl = impl_full_reflect(&where_clause_options);
     let common_methods = common_partial_reflect_methods(
         reflect_struct.meta(),
         || Some(quote!(#bevy_reflect_path::tuple_struct_partial_eq)),
@@ -42,8 +38,7 @@ pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> proc_macro2::
     #[cfg(not(feature = "functions"))]
     let function_impls = None::<proc_macro2::TokenStream>;
     #[cfg(feature = "functions")]
-    let function_impls =
-        crate::impls::impl_function_traits(reflect_struct.meta(), &where_clause_options);
+    let function_impls = crate::impls::impl_function_traits(&where_clause_options);
 
     let (impl_generics, ty_generics, where_clause) = reflect_struct
         .meta()

--- a/crates/bevy_reflect/derive/src/impls/typed.rs
+++ b/crates/bevy_reflect/derive/src/impls/typed.rs
@@ -138,10 +138,10 @@ pub(crate) fn impl_type_path(meta: &ReflectMeta) -> TokenStream {
 }
 
 pub(crate) fn impl_typed(
-    meta: &ReflectMeta,
     where_clause_options: &WhereClauseOptions,
     type_info_generator: TokenStream,
 ) -> TokenStream {
+    let meta = where_clause_options.meta();
     let type_path = meta.type_path();
     let bevy_reflect_path = meta.bevy_reflect_path();
 

--- a/crates/bevy_reflect/derive/src/registration.rs
+++ b/crates/bevy_reflect/derive/src/registration.rs
@@ -1,19 +1,16 @@
 //! Contains code related specifically to Bevy's type registration.
 
-use crate::{
-    derive_data::ReflectMeta, serialization::SerializationDataDef,
-    where_clause_options::WhereClauseOptions,
-};
+use crate::{serialization::SerializationDataDef, where_clause_options::WhereClauseOptions};
 use quote::quote;
 use syn::Type;
 
 /// Creates the `GetTypeRegistration` impl for the given type data.
 pub(crate) fn impl_get_type_registration<'a>(
-    meta: &ReflectMeta,
     where_clause_options: &WhereClauseOptions,
     serialization_data: Option<&SerializationDataDef>,
     type_dependencies: Option<impl Iterator<Item = &'a Type>>,
 ) -> proc_macro2::TokenStream {
+    let meta = where_clause_options.meta();
     let type_path = meta.type_path();
     let bevy_reflect_path = meta.bevy_reflect_path();
     let registration_data = meta.attrs().idents();

--- a/crates/bevy_reflect/derive/src/where_clause_options.rs
+++ b/crates/bevy_reflect/derive/src/where_clause_options.rs
@@ -25,6 +25,10 @@ impl<'a, 'b> WhereClauseOptions<'a, 'b> {
         }
     }
 
+    pub fn meta(&self) -> &'a ReflectMeta<'b> {
+        self.meta
+    }
+
     /// Extends the `where` clause for a type with additional bounds needed for the reflection impls.
     ///
     /// The default bounds added are as follows:


### PR DESCRIPTION
# Objective

`WhereClauseOption` contains a reference to a `ReflectMeta`. Oddly enough, a bunch of functions that take a `WhereClauseOption` argument also take a `ReflectMeta` reference argument, which is exactly the same as the reference in the `WhereClauseOption`.

## Solution

This commit removes the redundant `ReflectMeta` argument from these functions. This requires adding a `WhereClauseOption::meta` getter method.

## Testing

`cargo run -p ci`