### PR TITLE
Add options for selecting adapter by name and forcing fallback

### DIFF
--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -399,7 +399,6 @@ impl Plugin for RenderPlugin {
                             }
                         });
 
-                        // Check env for force_fallback_adapter
                         let force_fallback_adapter = std::env::var("WGPU_FORCE_FALLBACK_ADAPTER")
                             .map_or(settings.force_fallback_adapter, |v| {
                                 !(v.is_empty() || v == "0" || v == "false")

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -117,7 +117,7 @@ use bevy_utils::WgpuWrapper;
 use bitflags::bitflags;
 use core::ops::{Deref, DerefMut};
 use std::sync::Mutex;
-use tracing::{debug, info, warn};
+use tracing::debug;
 
 /// Inline shader as an `embedded_asset` and load it permanently.
 ///
@@ -402,20 +402,12 @@ impl Plugin for RenderPlugin {
                         // Check env for force_fallback_adapter
                         let force_fallback_adapter = std::env::var("WGPU_FORCE_FALLBACK_ADAPTER")
                             .map_or(settings.force_fallback_adapter, |v| {
-                                info!(
-                                    "WGPU_FORCE_FALLBACK_ADAPTER is set to '{}'.",
-                                    v
-                                );
                                 !(v.is_empty() || v == "0" || v == "false")
                             });
 
                         let desired_adapter_name = std::env::var("WGPU_ADAPTER_NAME")
                             .as_deref()
                             .map_or(settings.adapter_name.clone(), |x| Some(x.to_lowercase()));
-
-                        if desired_adapter_name.is_some() && force_fallback_adapter {
-                            warn!("WGPU_ADAPTER_NAME is set, but WGPU_FORCE_FALLBACK_ADAPTER is also set. This will force the fallback adapter to be used, ignoring the desired adapter name.");
-                        }
 
                         let request_adapter_options = wgpu::RequestAdapterOptions {
                             power_preference: settings.power_preference,

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -154,7 +154,7 @@ pub async fn initialize_renderer(
     desired_adapter_name: Option<String>,
 ) -> (RenderDevice, RenderQueue, RenderAdapterInfo, RenderAdapter) {
     let mut selected_adapter = None;
-    if let Some(adapter_name) = &desired_adapter_name && !options.force_fallback_adapter {
+    if let Some(adapter_name) = &desired_adapter_name  {
         debug!("Searching for adapter with name: {}", adapter_name);
         for adapter in instance.enumerate_adapters(options.backends.expect("The `backends` field of `WgpuSettings` must be set to use a specific adapter.")) {
             trace!("Checking adapter: {:?}", adapter.get_info());
@@ -166,7 +166,7 @@ pub async fn initialize_renderer(
                 }
             }
 
-            if info.name.to_lowercase().contains(adapter_name) {
+            if info.name.to_lowercase().contains(&adapter_name.to_lowercase()) {
                 selected_adapter  = Some(adapter);
                 break;
             }

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -7,7 +7,7 @@ use bevy_tasks::ComputeTaskPool;
 use bevy_utils::WgpuWrapper;
 pub use graph_runner::*;
 pub use render_device::*;
-use tracing::{error, info, info_span, warn};
+use tracing::{debug, error, info, info_span, trace, warn};
 
 use crate::{
     diagnostic::{internal::DiagnosticsRecorder, RecordDiagnostics},
@@ -151,12 +151,35 @@ pub async fn initialize_renderer(
     instance: &Instance,
     options: &WgpuSettings,
     request_adapter_options: &RequestAdapterOptions<'_, '_>,
+    desired_adapter_name: Option<String>,
 ) -> (RenderDevice, RenderQueue, RenderAdapterInfo, RenderAdapter) {
-    let adapter = instance
-        .request_adapter(request_adapter_options)
-        .await
-        .expect(GPU_NOT_FOUND_ERROR_MESSAGE);
+    let mut selected_adapter = None;
+    if let Some(adapter_name) = &desired_adapter_name && !options.force_fallback_adapter {
+        debug!("Searching for adapter with name: {}", adapter_name);
+        for adapter in instance.enumerate_adapters(options.backends.expect("The `backends` field of `WgpuSettings` must be set to use a specific adapter.")) {
+            trace!("Checking adapter: {:?}", adapter.get_info());
+            let info = adapter.get_info();
+            if let Some(surface) = request_adapter_options.compatible_surface {
+                if !adapter.is_surface_supported(surface) {
+                    continue;
 
+                }
+            }
+
+            if info.name.to_lowercase().contains(adapter_name) {
+                selected_adapter  = Some(adapter);
+                break;
+            }
+        }
+    } else {
+        debug!("Searching for adapter with options: {:?}", request_adapter_options);
+        selected_adapter = instance
+            .request_adapter(request_adapter_options)
+            .await
+            .ok();
+    };
+
+    let adapter = selected_adapter.expect(GPU_NOT_FOUND_ERROR_MESSAGE);
     let adapter_info = adapter.get_info();
     info!("{:?}", adapter_info);
 

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -154,29 +154,34 @@ pub async fn initialize_renderer(
     desired_adapter_name: Option<String>,
 ) -> (RenderDevice, RenderQueue, RenderAdapterInfo, RenderAdapter) {
     let mut selected_adapter = None;
-    if let Some(adapter_name) = &desired_adapter_name  {
+    if let Some(adapter_name) = &desired_adapter_name {
         debug!("Searching for adapter with name: {}", adapter_name);
-        for adapter in instance.enumerate_adapters(options.backends.expect("The `backends` field of `WgpuSettings` must be set to use a specific adapter.")) {
+        for adapter in instance.enumerate_adapters(options.backends.expect(
+            "The `backends` field of `WgpuSettings` must be set to use a specific adapter.",
+        )) {
             trace!("Checking adapter: {:?}", adapter.get_info());
             let info = adapter.get_info();
             if let Some(surface) = request_adapter_options.compatible_surface {
                 if !adapter.is_surface_supported(surface) {
                     continue;
-
                 }
             }
 
-            if info.name.to_lowercase().contains(&adapter_name.to_lowercase()) {
-                selected_adapter  = Some(adapter);
+            if info
+                .name
+                .to_lowercase()
+                .contains(&adapter_name.to_lowercase())
+            {
+                selected_adapter = Some(adapter);
                 break;
             }
         }
     } else {
-        debug!("Searching for adapter with options: {:?}", request_adapter_options);
-        selected_adapter = instance
-            .request_adapter(request_adapter_options)
-            .await
-            .ok();
+        debug!(
+            "Searching for adapter with options: {:?}",
+            request_adapter_options
+        );
+        selected_adapter = instance.request_adapter(request_adapter_options).await.ok();
     };
 
     let adapter = selected_adapter.expect(GPU_NOT_FOUND_ERROR_MESSAGE);

--- a/crates/bevy_render/src/settings.rs
+++ b/crates/bevy_render/src/settings.rs
@@ -53,8 +53,7 @@ pub struct WgpuSettings {
     pub instance_flags: InstanceFlags,
     /// This hints to the WGPU device about the preferred memory allocation strategy.
     pub memory_hints: MemoryHints,
-    /// If true, will force wgpu to use a software renderer, if available. You probably do not
-    /// want to use this unless you are debugging or testing in CI.
+    /// If true, will force wgpu to use a software renderer, if available.
     pub force_fallback_adapter: bool,
     /// The name of the adapter to use.
     pub adapter_name: Option<String>,

--- a/crates/bevy_render/src/settings.rs
+++ b/crates/bevy_render/src/settings.rs
@@ -53,6 +53,11 @@ pub struct WgpuSettings {
     pub instance_flags: InstanceFlags,
     /// This hints to the WGPU device about the preferred memory allocation strategy.
     pub memory_hints: MemoryHints,
+    /// If true, will force wgpu to use a software renderer, if available. You probably do not
+    /// want to use this unless you are debugging or testing in CI.
+    pub force_fallback_adapter: bool,
+    /// The name of the adapter to use.
+    pub adapter_name : Option<String>,
 }
 
 impl Default for WgpuSettings {
@@ -136,6 +141,8 @@ impl Default for WgpuSettings {
             gles3_minor_version,
             instance_flags,
             memory_hints: MemoryHints::default(),
+            force_fallback_adapter: false,
+            adapter_name: None,
         }
     }
 }

--- a/crates/bevy_render/src/settings.rs
+++ b/crates/bevy_render/src/settings.rs
@@ -57,7 +57,7 @@ pub struct WgpuSettings {
     /// want to use this unless you are debugging or testing in CI.
     pub force_fallback_adapter: bool,
     /// The name of the adapter to use.
-    pub adapter_name : Option<String>,
+    pub adapter_name: Option<String>,
 }
 
 impl Default for WgpuSettings {


### PR DESCRIPTION
Adds support for:
- `WGPU_ADAPTER_NAME` which will attempt to select a specific adapter with a given name.
- `WGPU_FORCE_FALLBACK_ADAPTER` which will force fallback to a fallback (software) renderer, if available.

The first has higher specificity than the second.