### PR TITLE
Stop using `AssetId` in the `AssetServer` and use `AssetIndex` instead.

### DIFF
--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -400,10 +400,7 @@ impl<A: Asset> Assets<A> {
     pub fn add(&mut self, asset: impl Into<A>) -> Handle<A> {
         let index = self.dense_storage.allocator.reserve();
         self.insert_with_index(index, asset.into()).unwrap();
-        Handle::Strong(
-            self.handle_provider
-                .get_handle(index.into(), false, None, None),
-        )
+        Handle::Strong(self.handle_provider.get_handle(index, false, None, None))
     }
 
     /// Upgrade an `AssetId` into a strong `Handle` that will prevent asset drop.
@@ -416,7 +413,7 @@ impl<A: Asset> Assets<A> {
             return None;
         }
         let index = match id {
-            AssetId::Index { index, .. } => index.into(),
+            AssetId::Index { index, .. } => index,
             // We don't support strong handles for Uuid assets.
             AssetId::Uuid { .. } => return None,
         };

--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -291,7 +291,7 @@ pub struct Assets<A: Asset> {
     queued_events: Vec<AssetEvent<A>>,
     /// Assets managed by the `Assets` struct with live strong `Handle`s
     /// originating from `get_strong_handle`.
-    duplicate_handles: HashMap<AssetId<A>, u16>,
+    duplicate_handles: HashMap<AssetIndex, u16>,
 }
 
 impl<A: Asset> Default for Assets<A> {
@@ -415,11 +415,12 @@ impl<A: Asset> Assets<A> {
         if !self.contains(id) {
             return None;
         }
-        *self.duplicate_handles.entry(id).or_insert(0) += 1;
         let index = match id {
             AssetId::Index { index, .. } => index.into(),
-            AssetId::Uuid { uuid } => uuid.into(),
+            // We don't support strong handles for Uuid assets.
+            AssetId::Uuid { .. } => return None,
         };
+        *self.duplicate_handles.entry(index).or_insert(0) += 1;
         Some(Handle::Strong(
             self.handle_provider.get_handle(index, false, None, None),
         ))
@@ -479,19 +480,21 @@ impl<A: Asset> Assets<A> {
     /// This is the same as [`Assets::remove`] except it doesn't emit [`AssetEvent::Removed`].
     pub fn remove_untracked(&mut self, id: impl Into<AssetId<A>>) -> Option<A> {
         let id: AssetId<A> = id.into();
-        self.duplicate_handles.remove(&id);
         match id {
-            AssetId::Index { index, .. } => self.dense_storage.remove_still_alive(index),
+            AssetId::Index { index, .. } => {
+                self.duplicate_handles.remove(&index);
+                self.dense_storage.remove_still_alive(index)
+            }
             AssetId::Uuid { uuid } => self.hash_map.remove(&uuid),
         }
     }
 
     /// Removes the [`Asset`] with the given `id`.
-    pub(crate) fn remove_dropped(&mut self, id: AssetId<A>) {
-        match self.duplicate_handles.get_mut(&id) {
+    pub(crate) fn remove_dropped(&mut self, index: AssetIndex) {
+        match self.duplicate_handles.get_mut(&index) {
             None => {}
             Some(0) => {
-                self.duplicate_handles.remove(&id);
+                self.duplicate_handles.remove(&index);
             }
             Some(value) => {
                 *value -= 1;
@@ -499,14 +502,13 @@ impl<A: Asset> Assets<A> {
             }
         }
 
-        let existed = match id {
-            AssetId::Index { index, .. } => self.dense_storage.remove_dropped(index).is_some(),
-            AssetId::Uuid { uuid } => self.hash_map.remove(&uuid).is_some(),
-        };
+        let existed = self.dense_storage.remove_dropped(index).is_some();
 
-        self.queued_events.push(AssetEvent::Unused { id });
+        self.queued_events
+            .push(AssetEvent::Unused { id: index.into() });
         if existed {
-            self.queued_events.push(AssetEvent::Removed { id });
+            self.queued_events
+                .push(AssetEvent::Removed { id: index.into() });
         }
     }
 
@@ -574,19 +576,15 @@ impl<A: Asset> Assets<A> {
         // to other asset info operations
         let mut infos = asset_server.write_infos();
         while let Ok(drop_event) = assets.handle_provider.drop_receiver.try_recv() {
-            let id = drop_event.id.typed();
-
             if drop_event.asset_server_managed {
-                let untyped_id = id.untyped();
-
                 // the process_handle_drop call checks whether new handles have been created since the drop event was fired, before removing the asset
-                if !infos.process_handle_drop(untyped_id) {
+                if !infos.process_handle_drop(drop_event.index.into()) {
                     // a new handle has been created, or the asset doesn't exist
                     continue;
                 }
             }
 
-            assets.remove_dropped(id);
+            assets.remove_dropped(drop_event.index.index);
         }
     }
 

--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -578,7 +578,7 @@ impl<A: Asset> Assets<A> {
         while let Ok(drop_event) = assets.handle_provider.drop_receiver.try_recv() {
             if drop_event.asset_server_managed {
                 // the process_handle_drop call checks whether new handles have been created since the drop event was fired, before removing the asset
-                if !infos.process_handle_drop(drop_event.index.into()) {
+                if !infos.process_handle_drop(drop_event.index) {
                     // a new handle has been created, or the asset doesn't exist
                     continue;
                 }

--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -1,6 +1,6 @@
 use crate::{
-    meta::MetaTransform, Asset, AssetId, AssetIndexAllocator, AssetPath, InternalAssetId,
-    UntypedAssetId,
+    meta::MetaTransform, Asset, AssetId, AssetIndex, AssetIndexAllocator, AssetPath,
+    InternalAssetId, UntypedAssetId,
 };
 use alloc::sync::Arc;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect, TypePath};
@@ -84,7 +84,8 @@ impl AssetHandleProvider {
 /// the [`Asset`] will be freed. It also stores some asset metadata for easy access from handles.
 #[derive(TypePath)]
 pub struct StrongHandle {
-    pub(crate) id: UntypedAssetId,
+    pub(crate) index: AssetIndex,
+    pub(crate) type_id: TypeId,
     pub(crate) asset_server_managed: bool,
     pub(crate) path: Option<AssetPath<'static>>,
     /// Modifies asset meta. This is stored on the handle because it is:
@@ -106,7 +107,8 @@ impl Drop for StrongHandle {
 impl core::fmt::Debug for StrongHandle {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("StrongHandle")
-            .field("id", &self.id)
+            .field("index", &self.index)
+            .field("type_id", &self.type_id)
             .field("asset_server_managed", &self.asset_server_managed)
             .field("path", &self.path)
             .field("drop_sender", &self.drop_sender)

--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -1,6 +1,6 @@
 use crate::{
     meta::MetaTransform, Asset, AssetId, AssetIndex, AssetIndexAllocator, AssetPath,
-    InternalAssetId, UntypedAssetId,
+    ErasedAssetIndex, UntypedAssetId,
 };
 use alloc::sync::Arc;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect, TypePath};
@@ -26,7 +26,7 @@ pub struct AssetHandleProvider {
 
 #[derive(Debug)]
 pub(crate) struct DropEvent {
-    pub(crate) id: InternalAssetId,
+    pub(crate) index: ErasedAssetIndex,
     pub(crate) asset_server_managed: bool,
 }
 
@@ -45,18 +45,19 @@ impl AssetHandleProvider {
     /// [`UntypedHandle`] will match the [`Asset`] [`TypeId`] assigned to this [`AssetHandleProvider`].
     pub fn reserve_handle(&self) -> UntypedHandle {
         let index = self.allocator.reserve();
-        UntypedHandle::Strong(self.get_handle(InternalAssetId::Index(index), false, None, None))
+        UntypedHandle::Strong(self.get_handle(index, false, None, None))
     }
 
     pub(crate) fn get_handle(
         &self,
-        id: InternalAssetId,
+        index: AssetIndex,
         asset_server_managed: bool,
         path: Option<AssetPath<'static>>,
         meta_transform: Option<MetaTransform>,
     ) -> Arc<StrongHandle> {
         Arc::new(StrongHandle {
-            id: id.untyped(self.type_id),
+            index,
+            type_id: self.type_id,
             drop_sender: self.drop_sender.clone(),
             meta_transform,
             path,
@@ -71,12 +72,7 @@ impl AssetHandleProvider {
         meta_transform: Option<MetaTransform>,
     ) -> Arc<StrongHandle> {
         let index = self.allocator.reserve();
-        self.get_handle(
-            InternalAssetId::Index(index),
-            asset_server_managed,
-            path,
-            meta_transform,
-        )
+        self.get_handle(index, asset_server_managed, path, meta_transform)
     }
 }
 
@@ -98,7 +94,7 @@ pub struct StrongHandle {
 impl Drop for StrongHandle {
     fn drop(&mut self) {
         let _ = self.drop_sender.send(DropEvent {
-            id: self.id.internal(),
+            index: ErasedAssetIndex::new(self.index, self.type_id),
             asset_server_managed: self.asset_server_managed,
         });
     }
@@ -156,7 +152,10 @@ impl<A: Asset> Handle<A> {
     #[inline]
     pub fn id(&self) -> AssetId<A> {
         match self {
-            Handle::Strong(handle) => handle.id.typed_unchecked(),
+            Handle::Strong(handle) => AssetId::Index {
+                index: handle.index,
+                marker: PhantomData,
+            },
             Handle::Uuid(uuid, ..) => AssetId::Uuid { uuid: *uuid },
         }
     }
@@ -204,9 +203,8 @@ impl<A: Asset> core::fmt::Debug for Handle<A> {
             Handle::Strong(handle) => {
                 write!(
                     f,
-                    "StrongHandle<{name}>{{ id: {:?}, path: {:?} }}",
-                    handle.id.internal(),
-                    handle.path
+                    "StrongHandle<{name}>{{ index: {:?}, type_id: {:?}, path: {:?} }}",
+                    handle.index, handle.type_id, handle.path
                 )
             }
             Handle::Uuid(uuid, ..) => write!(f, "UuidHandle<{name}>({uuid:?})"),
@@ -300,7 +298,10 @@ impl UntypedHandle {
     #[inline]
     pub fn id(&self) -> UntypedAssetId {
         match self {
-            UntypedHandle::Strong(handle) => handle.id,
+            UntypedHandle::Strong(handle) => UntypedAssetId::Index {
+                type_id: handle.type_id,
+                index: handle.index,
+            },
             UntypedHandle::Uuid { type_id, uuid } => UntypedAssetId::Uuid {
                 uuid: *uuid,
                 type_id: *type_id,
@@ -321,7 +322,7 @@ impl UntypedHandle {
     #[inline]
     pub fn type_id(&self) -> TypeId {
         match self {
-            UntypedHandle::Strong(handle) => handle.id.type_id(),
+            UntypedHandle::Strong(handle) => handle.type_id,
             UntypedHandle::Uuid { type_id, .. } => *type_id,
         }
     }
@@ -402,9 +403,7 @@ impl core::fmt::Debug for UntypedHandle {
                 write!(
                     f,
                     "StrongHandle{{ type_id: {:?}, id: {:?}, path: {:?} }}",
-                    handle.id.type_id(),
-                    handle.id.internal(),
-                    handle.path
+                    handle.type_id, handle.index, handle.path
                 )
             }
             UntypedHandle::Uuid { type_id, uuid } => {

--- a/crates/bevy_asset/src/id.rs
+++ b/crates/bevy_asset/src/id.rs
@@ -68,7 +68,7 @@ impl<A: Asset> AssetId<A> {
     }
 
     #[inline]
-    pub(crate) fn internal(self) -> InternalAssetId {
+    fn internal(self) -> InternalAssetId {
         match self {
             AssetId::Index { index, .. } => InternalAssetId::Index(index),
             AssetId::Uuid { uuid } => InternalAssetId::Uuid(uuid),
@@ -255,7 +255,7 @@ impl UntypedAssetId {
     }
 
     #[inline]
-    pub(crate) fn internal(self) -> InternalAssetId {
+    fn internal(self) -> InternalAssetId {
         match self {
             UntypedAssetId::Index { index, .. } => InternalAssetId::Index(index),
             UntypedAssetId::Uuid { uuid, .. } => InternalAssetId::Uuid(uuid),
@@ -314,37 +314,11 @@ impl PartialOrd for UntypedAssetId {
 
 /// An asset id without static or dynamic types associated with it.
 ///
-/// This exist to support efficient type erased id drop tracking. We
-/// could use [`UntypedAssetId`] for this, but the [`TypeId`] is unnecessary.
-///
-/// Do not _ever_ use this across asset types for comparison.
-/// [`InternalAssetId`] contains no type information and will happily collide
-/// with indices across types.
+/// This is provided to make implementing traits easier for the many different asset ID types.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, PartialOrd, Ord, From)]
-pub(crate) enum InternalAssetId {
+enum InternalAssetId {
     Index(AssetIndex),
     Uuid(Uuid),
-}
-
-impl InternalAssetId {
-    #[inline]
-    pub(crate) fn typed<A: Asset>(self) -> AssetId<A> {
-        match self {
-            InternalAssetId::Index(index) => AssetId::Index {
-                index,
-                marker: PhantomData,
-            },
-            InternalAssetId::Uuid(uuid) => AssetId::Uuid { uuid },
-        }
-    }
-
-    #[inline]
-    pub(crate) fn untyped(self, type_id: TypeId) -> UntypedAssetId {
-        match self {
-            InternalAssetId::Index(index) => UntypedAssetId::Index { index, type_id },
-            InternalAssetId::Uuid(uuid) => UntypedAssetId::Uuid { uuid, type_id },
-        }
-    }
 }
 
 /// An asset index bundled with its (dynamic) type.

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -267,7 +267,7 @@ impl ErasedLoadedAsset {
 }
 
 /// A type erased container for an [`Asset`] value that is capable of inserting the [`Asset`] into a [`World`]'s [`Assets`] collection.
-pub trait AssetContainer: Downcast + Any + Send + Sync + 'static {
+pub(crate) trait AssetContainer: Downcast + Any + Send + Sync + 'static {
     fn insert(self: Box<Self>, id: UntypedAssetId, world: &mut World);
     fn asset_type_name(&self) -> &'static str;
 }

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -3,8 +3,8 @@ use crate::{
     loader_builders::{Deferred, NestedLoader, StaticTyped},
     meta::{AssetHash, AssetMeta, AssetMetaDyn, ProcessedInfoMinimal, Settings},
     path::AssetPath,
-    Asset, AssetLoadError, AssetServer, AssetServerMode, Assets, ErasedAssetIndex, Handle,
-    UntypedAssetId, UntypedHandle,
+    Asset, AssetIndex, AssetLoadError, AssetServer, AssetServerMode, Assets, ErasedAssetIndex,
+    Handle, UntypedHandle,
 };
 use alloc::{
     boxed::Box,
@@ -271,19 +271,19 @@ impl ErasedLoadedAsset {
 
 /// A type erased container for an [`Asset`] value that is capable of inserting the [`Asset`] into a [`World`]'s [`Assets`] collection.
 pub(crate) trait AssetContainer: Downcast + Any + Send + Sync + 'static {
-    fn insert(self: Box<Self>, id: UntypedAssetId, world: &mut World);
+    fn insert(self: Box<Self>, id: AssetIndex, world: &mut World);
     fn asset_type_name(&self) -> &'static str;
 }
 
 impl_downcast!(AssetContainer);
 
 impl<A: Asset> AssetContainer for A {
-    fn insert(self: Box<Self>, id: UntypedAssetId, world: &mut World) {
+    fn insert(self: Box<Self>, index: AssetIndex, world: &mut World) {
         // We only ever call this if we know the asset is still alive, so it is fine to unwrap here.
         world
             .resource_mut::<Assets<A>>()
-            .insert(id.typed(), *self)
-            .expect("the AssetId is still valid");
+            .insert(index, *self)
+            .expect("the AssetIndex is still valid");
     }
 
     fn asset_type_name(&self) -> &'static str {

--- a/crates/bevy_asset/src/loader_builders.rs
+++ b/crates/bevy_asset/src/loader_builders.rs
@@ -316,7 +316,10 @@ impl NestedLoader<'_, '_, StaticTyped, Deferred> {
                 .asset_server
                 .get_or_create_path_handle(path, self.meta_transform)
         };
-        self.load_context.dependencies.insert(handle.id().untyped());
+        // `load_with_meta_transform` and `get_or_create_path_handle` always returns a Strong
+        // variant, so we are safe to unwrap.
+        let index = (&handle).try_into().unwrap();
+        self.load_context.dependencies.insert(index);
         handle
     }
 }
@@ -349,7 +352,10 @@ impl NestedLoader<'_, '_, DynamicTyped, Deferred> {
                     self.meta_transform,
                 )
         };
-        self.load_context.dependencies.insert(handle.id());
+        // `load_erased_with_meta_transform` and `get_or_create_path_handle_erased` always returns a
+        // Strong variant, so we are safe to unwrap.
+        let index = (&handle).try_into().unwrap();
+        self.load_context.dependencies.insert(index);
         handle
     }
 }
@@ -370,7 +376,10 @@ impl NestedLoader<'_, '_, UnknownTyped, Deferred> {
                 .asset_server
                 .get_or_create_path_handle(path, self.meta_transform)
         };
-        self.load_context.dependencies.insert(handle.id().untyped());
+        // `load_unknown_type_with_meta_transform` and `get_or_create_path_handle` always returns a
+        // Strong variant, so we are safe to unwrap.
+        let index = (&handle).try_into().unwrap();
+        self.load_context.dependencies.insert(index);
         handle
     }
 }

--- a/crates/bevy_asset/src/server/info.rs
+++ b/crates/bevy_asset/src/server/info.rs
@@ -1,8 +1,8 @@
 use crate::{
     meta::{AssetHash, MetaTransform},
-    Asset, AssetHandleProvider, AssetLoadError, AssetPath, DependencyLoadState, ErasedLoadedAsset,
-    Handle, InternalAssetEvent, LoadState, RecursiveDependencyLoadState, StrongHandle,
-    UntypedAssetId, UntypedHandle,
+    Asset, AssetHandleProvider, AssetIndex, AssetLoadError, AssetPath, DependencyLoadState,
+    ErasedAssetIndex, ErasedLoadedAsset, Handle, InternalAssetEvent, LoadState,
+    RecursiveDependencyLoadState, StrongHandle, UntypedHandle,
 };
 use alloc::{
     borrow::ToOwned,
@@ -27,12 +27,12 @@ pub(crate) struct AssetInfo {
     pub(crate) load_state: LoadState,
     pub(crate) dep_load_state: DependencyLoadState,
     pub(crate) rec_dep_load_state: RecursiveDependencyLoadState,
-    loading_dependencies: HashSet<UntypedAssetId>,
-    failed_dependencies: HashSet<UntypedAssetId>,
-    loading_rec_dependencies: HashSet<UntypedAssetId>,
-    failed_rec_dependencies: HashSet<UntypedAssetId>,
-    dependents_waiting_on_load: HashSet<UntypedAssetId>,
-    dependents_waiting_on_recursive_dep_load: HashSet<UntypedAssetId>,
+    loading_dependencies: HashSet<ErasedAssetIndex>,
+    failed_dependencies: HashSet<ErasedAssetIndex>,
+    loading_rec_dependencies: HashSet<ErasedAssetIndex>,
+    failed_rec_dependencies: HashSet<ErasedAssetIndex>,
+    dependents_waiting_on_load: HashSet<ErasedAssetIndex>,
+    dependents_waiting_on_recursive_dep_load: HashSet<ErasedAssetIndex>,
     /// The asset paths required to load this asset. Hashes will only be set for processed assets.
     /// This is set using the value from [`LoadedAsset`].
     /// This will only be populated if [`AssetInfos::watching_for_changes`] is set to `true` to
@@ -70,8 +70,8 @@ impl AssetInfo {
 
 #[derive(Default)]
 pub(crate) struct AssetInfos {
-    path_to_id: HashMap<AssetPath<'static>, TypeIdMap<UntypedAssetId>>,
-    infos: HashMap<UntypedAssetId, AssetInfo>,
+    path_to_index: HashMap<AssetPath<'static>, TypeIdMap<AssetIndex>>,
+    infos: HashMap<ErasedAssetIndex, AssetInfo>,
     /// If set to `true`, this informs [`AssetInfos`] to track data relevant to watching for changes (such as `load_dependents`)
     /// This should only be set at startup.
     pub(crate) watching_for_changes: bool,
@@ -82,16 +82,16 @@ pub(crate) struct AssetInfos {
     /// This should only be set when watching for changes to avoid unnecessary work.
     pub(crate) living_labeled_assets: HashMap<AssetPath<'static>, HashSet<Box<str>>>,
     pub(crate) handle_providers: TypeIdMap<AssetHandleProvider>,
-    pub(crate) dependency_loaded_event_sender: TypeIdMap<fn(&mut World, UntypedAssetId)>,
+    pub(crate) dependency_loaded_event_sender: TypeIdMap<fn(&mut World, AssetIndex)>,
     pub(crate) dependency_failed_event_sender:
-        TypeIdMap<fn(&mut World, UntypedAssetId, AssetPath<'static>, AssetLoadError)>,
-    pub(crate) pending_tasks: HashMap<UntypedAssetId, Task<()>>,
+        TypeIdMap<fn(&mut World, AssetIndex, AssetPath<'static>, AssetLoadError)>,
+    pub(crate) pending_tasks: HashMap<ErasedAssetIndex, Task<()>>,
 }
 
 impl core::fmt::Debug for AssetInfos {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("AssetInfos")
-            .field("path_to_id", &self.path_to_id)
+            .field("path_to_index", &self.path_to_index)
             .field("infos", &self.infos)
             .finish()
     }
@@ -120,7 +120,7 @@ impl AssetInfos {
     }
 
     fn create_handle_internal(
-        infos: &mut HashMap<UntypedAssetId, AssetInfo>,
+        infos: &mut HashMap<ErasedAssetIndex, AssetInfo>,
         handle_providers: &TypeIdMap<AssetHandleProvider>,
         living_labeled_assets: &mut HashMap<AssetPath<'static>, HashSet<Box<str>>>,
         watching_for_changes: bool,
@@ -148,7 +148,7 @@ impl AssetInfos {
             info.dep_load_state = DependencyLoadState::Loading;
             info.rec_dep_load_state = RecursiveDependencyLoadState::Loading;
         }
-        infos.insert(handle.id, info);
+        infos.insert(ErasedAssetIndex::new(handle.index, handle.type_id), info);
 
         Ok(UntypedHandle::Strong(handle))
     }
@@ -202,7 +202,7 @@ impl AssetInfos {
         loading_mode: HandleLoadingMode,
         meta_transform: Option<MetaTransform>,
     ) -> Result<(UntypedHandle, bool), GetOrCreateHandleInternalError> {
-        let handles = self.path_to_id.entry(path.clone()).or_default();
+        let handles = self.path_to_index.entry(path.clone()).or_default();
 
         let type_id = type_id
             .or_else(|| {
@@ -217,9 +217,12 @@ impl AssetInfos {
 
         match handles.entry(type_id) {
             Entry::Occupied(entry) => {
-                let id = *entry.get();
+                let index = *entry.get();
                 // if there is a path_to_id entry, info always exists
-                let info = self.infos.get_mut(&id).unwrap();
+                let info = self
+                    .infos
+                    .get_mut(&ErasedAssetIndex::new(index, type_id))
+                    .unwrap();
                 let mut should_load = false;
                 if loading_mode == HandleLoadingMode::Force
                     || (loading_mode == HandleLoadingMode::Request
@@ -249,8 +252,7 @@ impl AssetInfos {
                         .handle_providers
                         .get(&type_id)
                         .ok_or(MissingHandleProviderError(type_id))?;
-                    let handle =
-                        provider.get_handle(id.internal(), true, Some(path), meta_transform);
+                    let handle = provider.get_handle(index, true, Some(path), meta_transform);
                     info.weak_handle = Arc::downgrade(&handle);
                     Ok((UntypedHandle::Strong(handle), should_load))
                 }
@@ -271,22 +273,27 @@ impl AssetInfos {
                     meta_transform,
                     should_load,
                 )?;
-                entry.insert(handle.id());
+                let index = match &handle {
+                    UntypedHandle::Strong(handle) => handle.index,
+                    // `create_handle_internal` always returns Strong variant.
+                    UntypedHandle::Uuid { .. } => unreachable!(),
+                };
+                entry.insert(index);
                 Ok((handle, should_load))
             }
         }
     }
 
-    pub(crate) fn get(&self, id: UntypedAssetId) -> Option<&AssetInfo> {
-        self.infos.get(&id)
+    pub(crate) fn get(&self, index: ErasedAssetIndex) -> Option<&AssetInfo> {
+        self.infos.get(&index)
     }
 
-    pub(crate) fn contains_key(&self, id: UntypedAssetId) -> bool {
-        self.infos.contains_key(&id)
+    pub(crate) fn contains_key(&self, index: ErasedAssetIndex) -> bool {
+        self.infos.contains_key(&index)
     }
 
-    pub(crate) fn get_mut(&mut self, id: UntypedAssetId) -> Option<&mut AssetInfo> {
-        self.infos.get_mut(&id)
+    pub(crate) fn get_mut(&mut self, index: ErasedAssetIndex) -> Option<&mut AssetInfo> {
+        self.infos.get_mut(&index)
     }
 
     pub(crate) fn get_path_and_type_id_handle(
@@ -294,14 +301,14 @@ impl AssetInfos {
         path: &AssetPath<'_>,
         type_id: TypeId,
     ) -> Option<UntypedHandle> {
-        let id = self.path_to_id.get(path)?.get(&type_id)?;
-        self.get_id_handle(*id)
+        let index = *self.path_to_index.get(path)?.get(&type_id)?;
+        self.get_index_handle(ErasedAssetIndex::new(index, type_id))
     }
 
-    pub(crate) fn get_path_ids<'a>(
+    pub(crate) fn get_path_indices<'a>(
         &'a self,
         path: &'a AssetPath<'_>,
-    ) -> impl Iterator<Item = UntypedAssetId> + 'a {
+    ) -> impl Iterator<Item = ErasedAssetIndex> + 'a {
         /// Concrete type to allow returning an `impl Iterator` even if `self.path_to_id.get(&path)` is `None`
         enum HandlesByPathIterator<T> {
             None,
@@ -310,9 +317,9 @@ impl AssetInfos {
 
         impl<T> Iterator for HandlesByPathIterator<T>
         where
-            T: Iterator<Item = UntypedAssetId>,
+            T: Iterator<Item = ErasedAssetIndex>,
         {
-            type Item = UntypedAssetId;
+            type Item = ErasedAssetIndex;
 
             fn next(&mut self) -> Option<Self::Item> {
                 match self {
@@ -322,8 +329,12 @@ impl AssetInfos {
             }
         }
 
-        if let Some(type_id_to_id) = self.path_to_id.get(path) {
-            HandlesByPathIterator::Some(type_id_to_id.values().copied())
+        if let Some(type_id_to_id) = self.path_to_index.get(path) {
+            HandlesByPathIterator::Some(
+                type_id_to_id
+                    .iter()
+                    .map(|(type_id, index)| ErasedAssetIndex::new(*index, *type_id)),
+            )
         } else {
             HandlesByPathIterator::None
         }
@@ -333,19 +344,19 @@ impl AssetInfos {
         &'a self,
         path: &'a AssetPath<'_>,
     ) -> impl Iterator<Item = UntypedHandle> + 'a {
-        self.get_path_ids(path)
-            .filter_map(|id| self.get_id_handle(id))
+        self.get_path_indices(path)
+            .filter_map(|id| self.get_index_handle(id))
     }
 
-    pub(crate) fn get_id_handle(&self, id: UntypedAssetId) -> Option<UntypedHandle> {
-        let info = self.infos.get(&id)?;
+    pub(crate) fn get_index_handle(&self, index: ErasedAssetIndex) -> Option<UntypedHandle> {
+        let info = self.infos.get(&index)?;
         let strong_handle = info.weak_handle.upgrade()?;
         Some(UntypedHandle::Strong(strong_handle))
     }
 
     /// Returns `true` if the asset this path points to is still alive
     pub(crate) fn is_path_alive<'a>(&self, path: impl Into<AssetPath<'a>>) -> bool {
-        self.get_path_ids(&path.into())
+        self.get_path_indices(&path.into())
             .filter_map(|id| self.infos.get(&id))
             .any(|info| info.weak_handle.strong_count() > 0)
     }
@@ -364,22 +375,22 @@ impl AssetInfos {
     }
 
     /// Returns `true` if the asset should be removed from the collection.
-    pub(crate) fn process_handle_drop(&mut self, id: UntypedAssetId) -> bool {
+    pub(crate) fn process_handle_drop(&mut self, index: ErasedAssetIndex) -> bool {
         Self::process_handle_drop_internal(
             &mut self.infos,
-            &mut self.path_to_id,
+            &mut self.path_to_index,
             &mut self.loader_dependents,
             &mut self.living_labeled_assets,
             &mut self.pending_tasks,
             self.watching_for_changes,
-            id,
+            index,
         )
     }
 
     /// Updates [`AssetInfo`] / load state for an asset that has finished loading (and relevant dependencies / dependents).
     pub(crate) fn process_asset_load(
         &mut self,
-        loaded_asset_id: UntypedAssetId,
+        loaded_asset_index: ErasedAssetIndex,
         loaded_asset: ErasedLoadedAsset,
         world: &mut World,
         sender: &Sender<InternalAssetEvent>,
@@ -387,15 +398,26 @@ impl AssetInfos {
         // Process all the labeled assets first so that they don't get skipped due to the "parent"
         // not having its handle alive.
         for (_, asset) in loaded_asset.labeled_assets {
-            self.process_asset_load(asset.handle.id(), asset.asset, world, sender);
+            let UntypedHandle::Strong(handle) = &asset.handle else {
+                unreachable!("Labeled assets are always strong handles");
+            };
+            self.process_asset_load(
+                ErasedAssetIndex {
+                    index: handle.index,
+                    type_id: handle.type_id,
+                },
+                asset.asset,
+                world,
+                sender,
+            );
         }
 
         // Check whether the handle has been dropped since the asset was loaded.
-        if !self.infos.contains_key(&loaded_asset_id) {
+        if !self.infos.contains_key(&loaded_asset_index) {
             return;
         }
 
-        loaded_asset.value.insert(loaded_asset_id, world);
+        loaded_asset.value.insert(loaded_asset_index.index, world);
         let mut loading_deps = loaded_asset.dependencies;
         let mut failed_deps = <HashSet<_>>::default();
         let mut dep_error = None;
@@ -410,7 +432,7 @@ impl AssetInfos {
                         // If dependency is loading, wait for it.
                         dep_info
                             .dependents_waiting_on_recursive_dep_load
-                            .insert(loaded_asset_id);
+                            .insert(loaded_asset_index);
                     }
                     RecursiveDependencyLoadState::Loaded => {
                         // If dependency is loaded, reduce our count by one
@@ -427,7 +449,7 @@ impl AssetInfos {
                 match dep_info.load_state {
                     LoadState::NotLoaded | LoadState::Loading => {
                         // If dependency is loading, wait for it.
-                        dep_info.dependents_waiting_on_load.insert(loaded_asset_id);
+                        dep_info.dependents_waiting_on_load.insert(loaded_asset_index);
                         true
                     }
                     LoadState::Loaded => {
@@ -446,7 +468,7 @@ impl AssetInfos {
                 // the dependency id does not exist, which implies it was manually removed or never existed in the first place
                 warn!(
                     "Dependency {} from asset {} is unknown. This asset's dependency load status will not switch to 'Loaded' until the unknown dependency is loaded.",
-                    dep_id, loaded_asset_id
+                    dep_id, loaded_asset_index
                 );
                 true
             }
@@ -462,7 +484,7 @@ impl AssetInfos {
             (0, 0) => {
                 sender
                     .send(InternalAssetEvent::LoadedWithDependencies {
-                        id: loaded_asset_id,
+                        index: loaded_asset_index,
                     })
                     .unwrap();
                 RecursiveDependencyLoadState::Loaded
@@ -477,7 +499,7 @@ impl AssetInfos {
             if watching_for_changes {
                 let info = self
                     .infos
-                    .get(&loaded_asset_id)
+                    .get(&loaded_asset_index)
                     .expect("Asset info should always exist at this point");
                 if let Some(asset_path) = &info.path {
                     for loader_dependency in loaded_asset.loader_dependencies.keys() {
@@ -490,7 +512,7 @@ impl AssetInfos {
                 }
             }
             let info = self
-                .get_mut(loaded_asset_id)
+                .get_mut(loaded_asset_index)
                 .expect("Asset info should always exist at this point");
             info.loading_dependencies = loading_deps;
             info.failed_dependencies = failed_deps;
@@ -520,7 +542,7 @@ impl AssetInfos {
 
         for id in dependents_waiting_on_load {
             if let Some(info) = self.get_mut(id) {
-                info.loading_dependencies.remove(&loaded_asset_id);
+                info.loading_dependencies.remove(&loaded_asset_index);
                 if info.loading_dependencies.is_empty() && !info.dep_load_state.is_failed() {
                     // send dependencies loaded event
                     info.dep_load_state = DependencyLoadState::Loaded;
@@ -532,12 +554,12 @@ impl AssetInfos {
             match rec_dep_load_state {
                 RecursiveDependencyLoadState::Loaded => {
                     for dep_id in dependents_waiting_on_rec_load {
-                        Self::propagate_loaded_state(self, loaded_asset_id, dep_id, sender);
+                        Self::propagate_loaded_state(self, loaded_asset_index, dep_id, sender);
                     }
                 }
                 RecursiveDependencyLoadState::Failed(ref error) => {
                     for dep_id in dependents_waiting_on_rec_load {
-                        Self::propagate_failed_state(self, loaded_asset_id, dep_id, error);
+                        Self::propagate_failed_state(self, loaded_asset_index, dep_id, error);
                     }
                 }
                 RecursiveDependencyLoadState::Loading | RecursiveDependencyLoadState::NotLoaded => {
@@ -551,8 +573,8 @@ impl AssetInfos {
     /// Recursively propagates loaded state up the dependency tree.
     fn propagate_loaded_state(
         infos: &mut AssetInfos,
-        loaded_id: UntypedAssetId,
-        waiting_id: UntypedAssetId,
+        loaded_id: ErasedAssetIndex,
+        waiting_id: ErasedAssetIndex,
         sender: &Sender<InternalAssetEvent>,
     ) {
         let dependents_waiting_on_rec_load = if let Some(info) = infos.get_mut(waiting_id) {
@@ -561,7 +583,7 @@ impl AssetInfos {
                 info.rec_dep_load_state = RecursiveDependencyLoadState::Loaded;
                 if info.load_state.is_loaded() {
                     sender
-                        .send(InternalAssetEvent::LoadedWithDependencies { id: waiting_id })
+                        .send(InternalAssetEvent::LoadedWithDependencies { index: waiting_id })
                         .unwrap();
                 }
                 Some(core::mem::take(
@@ -584,8 +606,8 @@ impl AssetInfos {
     /// Recursively propagates failed state up the dependency tree
     fn propagate_failed_state(
         infos: &mut AssetInfos,
-        failed_id: UntypedAssetId,
-        waiting_id: UntypedAssetId,
+        failed_id: ErasedAssetIndex,
+        waiting_id: ErasedAssetIndex,
         error: &Arc<AssetLoadError>,
     ) {
         let dependents_waiting_on_rec_load = if let Some(info) = infos.get_mut(waiting_id) {
@@ -606,15 +628,19 @@ impl AssetInfos {
         }
     }
 
-    pub(crate) fn process_asset_fail(&mut self, failed_id: UntypedAssetId, error: AssetLoadError) {
+    pub(crate) fn process_asset_fail(
+        &mut self,
+        failed_index: ErasedAssetIndex,
+        error: AssetLoadError,
+    ) {
         // Check whether the handle has been dropped since the asset was loaded.
-        if !self.infos.contains_key(&failed_id) {
+        if !self.infos.contains_key(&failed_index) {
             return;
         }
 
         let error = Arc::new(error);
         let (dependents_waiting_on_load, dependents_waiting_on_rec_load) = {
-            let Some(info) = self.get_mut(failed_id) else {
+            let Some(info) = self.get_mut(failed_index) else {
                 // The asset was already dropped.
                 return;
             };
@@ -632,8 +658,8 @@ impl AssetInfos {
 
         for waiting_id in dependents_waiting_on_load {
             if let Some(info) = self.get_mut(waiting_id) {
-                info.loading_dependencies.remove(&failed_id);
-                info.failed_dependencies.insert(failed_id);
+                info.loading_dependencies.remove(&failed_index);
+                info.failed_dependencies.insert(failed_index);
                 // don't overwrite DependencyLoadState if already failed to preserve first error
                 if !info.dep_load_state.is_failed() {
                     info.dep_load_state = DependencyLoadState::Failed(error.clone());
@@ -642,7 +668,7 @@ impl AssetInfos {
         }
 
         for waiting_id in dependents_waiting_on_rec_load {
-            Self::propagate_failed_state(self, failed_id, waiting_id, &error);
+            Self::propagate_failed_state(self, failed_index, waiting_id, &error);
         }
     }
 
@@ -676,15 +702,15 @@ impl AssetInfos {
     }
 
     fn process_handle_drop_internal(
-        infos: &mut HashMap<UntypedAssetId, AssetInfo>,
-        path_to_id: &mut HashMap<AssetPath<'static>, TypeIdMap<UntypedAssetId>>,
+        infos: &mut HashMap<ErasedAssetIndex, AssetInfo>,
+        path_to_id: &mut HashMap<AssetPath<'static>, TypeIdMap<AssetIndex>>,
         loader_dependents: &mut HashMap<AssetPath<'static>, HashSet<AssetPath<'static>>>,
         living_labeled_assets: &mut HashMap<AssetPath<'static>, HashSet<Box<str>>>,
-        pending_tasks: &mut HashMap<UntypedAssetId, Task<()>>,
+        pending_tasks: &mut HashMap<ErasedAssetIndex, Task<()>>,
         watching_for_changes: bool,
-        id: UntypedAssetId,
+        index: ErasedAssetIndex,
     ) -> bool {
-        let Entry::Occupied(mut entry) = infos.entry(id) else {
+        let Entry::Occupied(mut entry) = infos.entry(index) else {
             // Either the asset was already dropped, it doesn't exist, or it isn't managed by the asset server
             // None of these cases should result in a removal from the Assets collection
             return false;
@@ -695,9 +721,9 @@ impl AssetInfos {
             return false;
         }
 
-        pending_tasks.remove(&id);
+        pending_tasks.remove(&index);
 
-        let type_id = entry.key().type_id();
+        let type_id = entry.key().type_id;
 
         let info = entry.remove();
         let Some(path) = &info.path else {
@@ -736,12 +762,12 @@ impl AssetInfos {
                 if drop_event.asset_server_managed {
                     Self::process_handle_drop_internal(
                         &mut self.infos,
-                        &mut self.path_to_id,
+                        &mut self.path_to_index,
                         &mut self.loader_dependents,
                         &mut self.living_labeled_assets,
                         &mut self.pending_tasks,
                         self.watching_for_changes,
-                        id.untyped(provider.type_id),
+                        id,
                     );
                 }
             }

--- a/crates/bevy_asset/src/server/info.rs
+++ b/crates/bevy_asset/src/server/info.rs
@@ -732,7 +732,7 @@ impl AssetInfos {
     pub(crate) fn consume_handle_drop_events(&mut self) {
         for provider in self.handle_providers.values() {
             while let Ok(drop_event) = provider.drop_receiver.try_recv() {
-                let id = drop_event.id;
+                let id = drop_event.index;
                 if drop_event.asset_server_managed {
                     Self::process_handle_drop_internal(
                         &mut self.infos,

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -14,9 +14,10 @@ use crate::{
         MetaTransform, Settings,
     },
     path::AssetPath,
-    Asset, AssetEvent, AssetHandleProvider, AssetId, AssetLoadFailedEvent, AssetMetaCheck, Assets,
-    DeserializeMetaError, ErasedLoadedAsset, Handle, LoadedUntypedAsset, UnapprovedPathMode,
-    UntypedAssetId, UntypedAssetLoadFailedEvent, UntypedHandle,
+    Asset, AssetEvent, AssetHandleProvider, AssetId, AssetIndex, AssetLoadFailedEvent,
+    AssetMetaCheck, Assets, DeserializeMetaError, ErasedAssetIndex, ErasedLoadedAsset, Handle,
+    LoadedUntypedAsset, UnapprovedPathMode, UntypedAssetId, UntypedAssetLoadFailedEvent,
+    UntypedHandle,
 };
 use alloc::{borrow::ToOwned, boxed::Box, vec, vec::Vec};
 use alloc::{
@@ -194,21 +195,21 @@ impl AssetServer {
     /// Registers a new [`Asset`] type. [`Asset`] types must be registered before assets of that type can be loaded.
     pub fn register_asset<A: Asset>(&self, assets: &Assets<A>) {
         self.register_handle_provider(assets.get_handle_provider());
-        fn sender<A: Asset>(world: &mut World, id: UntypedAssetId) {
+        fn sender<A: Asset>(world: &mut World, index: AssetIndex) {
             world
                 .resource_mut::<Messages<AssetEvent<A>>>()
-                .write(AssetEvent::LoadedWithDependencies { id: id.typed() });
+                .write(AssetEvent::LoadedWithDependencies { id: index.into() });
         }
         fn failed_sender<A: Asset>(
             world: &mut World,
-            id: UntypedAssetId,
+            index: AssetIndex,
             path: AssetPath<'static>,
             error: AssetLoadError,
         ) {
             world
                 .resource_mut::<Messages<AssetLoadFailedEvent<A>>>()
                 .write(AssetLoadFailedEvent {
-                    id: id.typed(),
+                    id: index.into(),
                     path,
                     error,
                 });
@@ -568,7 +569,9 @@ impl AssetServer {
         #[cfg(not(any(target_arch = "wasm32", not(feature = "multi_threaded"))))]
         {
             let mut infos = infos;
-            infos.pending_tasks.insert(handle.id(), task);
+            infos
+                .pending_tasks
+                .insert((&handle).try_into().unwrap(), task);
         }
 
         #[cfg(any(target_arch = "wasm32", not(feature = "multi_threaded")))]
@@ -615,21 +618,21 @@ impl AssetServer {
         if !should_load {
             return handle;
         }
-        let id = handle.id().untyped();
+        let index = (&handle).try_into().unwrap();
 
         let server = self.clone();
         let task = IoTaskPool::get().spawn(async move {
             let path_clone = path.clone();
             match server.load_untyped_async(path).await {
                 Ok(handle) => server.send_asset_event(InternalAssetEvent::Loaded {
-                    id,
+                    index,
                     loaded_asset: LoadedAsset::new_with_dependencies(LoadedUntypedAsset { handle })
                         .into(),
                 }),
                 Err(err) => {
                     error!("{err}");
                     server.send_asset_event(InternalAssetEvent::Failed {
-                        id,
+                        index,
                         path: path_clone,
                         error: err,
                     });
@@ -638,7 +641,7 @@ impl AssetServer {
         });
 
         #[cfg(not(any(target_arch = "wasm32", not(feature = "multi_threaded"))))]
-        infos.pending_tasks.insert(handle.id().untyped(), task);
+        infos.pending_tasks.insert(index, task);
 
         #[cfg(any(target_arch = "wasm32", not(feature = "multi_threaded")))]
         task.detach();
@@ -701,7 +704,7 @@ impl AssetServer {
                 // we cannot find the meta and loader
                 if let Some(handle) = &input_handle {
                     self.send_asset_event(InternalAssetEvent::Failed {
-                        id: handle.id(),
+                        index: handle.try_into().unwrap(),
                         path: path.clone_owned(),
                         error: e.clone(),
                     });
@@ -712,11 +715,13 @@ impl AssetServer {
             (*meta_transform)(&mut *meta);
         }
 
-        let asset_id; // The asset ID of the asset we are trying to load.
+        let asset_id: Option<ErasedAssetIndex>; // The asset ID of the asset we are trying to load.
         let fetched_handle; // The handle if one was looked up/created.
         let should_load; // Whether we need to load the asset.
         if let Some(input_handle) = input_handle {
-            asset_id = Some(input_handle.id());
+            // This must have been created with `get_or_create_path_handle_internal` at some point,
+            // which only produces Strong variant handles, so this is safe.
+            asset_id = Some((&input_handle).try_into().unwrap());
             // In this case, we intentionally drop the input handle so we can cancel loading the
             // asset if the handle gets dropped (externally) before it finishes loading.
             fetched_handle = None;
@@ -748,14 +753,16 @@ impl AssetServer {
                     should_load = true;
                 }
                 Some((handle, result_should_load)) => {
-                    asset_id = Some(handle.id());
+                    // `get_or_create_path_handle_internal` always returns Strong variant, so this
+                    // is safe.
+                    asset_id = Some((&handle).try_into().unwrap());
                     fetched_handle = Some(handle);
                     should_load = result_should_load;
                 }
             }
         }
         // Verify that the expected type matches the loader's type.
-        if let Some(asset_type_id) = asset_id.map(|id| id.type_id()) {
+        if let Some(asset_type_id) = asset_id.map(|id| id.type_id) {
             // If we are loading a subasset, then the subasset's type almost certainly doesn't match
             // the loader's type - and that's ok.
             if path.label().is_none() && asset_type_id != loader.asset_type_id() {
@@ -792,7 +799,13 @@ impl AssetServer {
                     None,
                 )
                 .0;
-            (base_handle.id(), Some(base_handle), base_path)
+            (
+                // `get_or_create_path_handle_erased` always returns Strong variant, so this is
+                // safe.
+                (&base_handle).try_into().unwrap(),
+                Some(base_handle),
+                base_path,
+            )
         } else {
             (asset_id.unwrap(), None, path.clone())
         };
@@ -831,14 +844,14 @@ impl AssetServer {
                 };
 
                 self.send_asset_event(InternalAssetEvent::Loaded {
-                    id: base_asset_id,
+                    index: base_asset_id,
                     loaded_asset,
                 });
                 Ok(final_handle)
             }
             Err(err) => {
                 self.send_asset_event(InternalAssetEvent::Failed {
-                    id: base_asset_id,
+                    index: base_asset_id,
                     error: err.clone(),
                     path: path.into_owned(),
                 });
@@ -925,7 +938,8 @@ impl AssetServer {
             )
         };
         self.send_asset_event(InternalAssetEvent::Loaded {
-            id: handle.id(),
+            // `get_or_create_path_handle_erased` always returns Strong variant, so this is safe.
+            index: (&handle).try_into().unwrap(),
             loaded_asset,
         });
         handle
@@ -948,7 +962,8 @@ impl AssetServer {
         #[cfg(any(target_arch = "wasm32", not(feature = "multi_threaded")))]
         drop(infos);
 
-        let id = handle.id();
+        // `create_loading_handle_untyped` always returns a Strong variant, so this is safe.
+        let index = (&handle).try_into().unwrap();
 
         let event_sender = self.data.asset_event_sender.clone();
 
@@ -957,7 +972,10 @@ impl AssetServer {
                 Ok(asset) => {
                     let loaded_asset = LoadedAsset::new_with_dependencies(asset).into();
                     event_sender
-                        .send(InternalAssetEvent::Loaded { id, loaded_asset })
+                        .send(InternalAssetEvent::Loaded {
+                            index,
+                            loaded_asset,
+                        })
                         .unwrap();
                 }
                 Err(error) => {
@@ -967,7 +985,7 @@ impl AssetServer {
                     error!("{error}");
                     event_sender
                         .send(InternalAssetEvent::Failed {
-                            id,
+                            index,
                             path: Default::default(),
                             error: AssetLoadError::AddAsyncError(error),
                         })
@@ -977,7 +995,7 @@ impl AssetServer {
         });
 
         #[cfg(not(any(target_arch = "wasm32", not(feature = "multi_threaded"))))]
-        infos.pending_tasks.insert(id, task);
+        infos.pending_tasks.insert(index, task);
 
         #[cfg(any(target_arch = "wasm32", not(feature = "multi_threaded")))]
         task.detach();
@@ -1006,13 +1024,14 @@ impl AssetServer {
         if !should_load {
             return handle;
         }
-        let id = handle.id().untyped();
-        self.load_folder_internal(id, path);
+        // `get_or_create_path_handle` always returns a Strong variant, so this is safe.
+        let index = (&handle).try_into().unwrap();
+        self.load_folder_internal(index, path);
 
         handle
     }
 
-    pub(crate) fn load_folder_internal(&self, id: UntypedAssetId, path: AssetPath) {
+    pub(crate) fn load_folder_internal(&self, index: ErasedAssetIndex, path: AssetPath) {
         async fn load_folder<'a>(
             source: AssetSourceId<'static>,
             path: &'a Path,
@@ -1080,7 +1099,7 @@ impl AssetServer {
                 let mut handles = Vec::new();
                 match load_folder(source.id(), path.path(), asset_reader, &server, &mut handles).await {
                     Ok(_) => server.send_asset_event(InternalAssetEvent::Loaded {
-                        id,
+                        index,
                         loaded_asset: LoadedAsset::new_with_dependencies(
                             LoadedFolder { handles },
                         )
@@ -1088,7 +1107,7 @@ impl AssetServer {
                     }),
                     Err(err) => {
                         error!("Failed to load folder. {err}");
-                        server.send_asset_event(InternalAssetEvent::Failed { id, error: err, path });
+                        server.send_asset_event(InternalAssetEvent::Failed { index, error: err, path });
                     },
                 }
             })
@@ -1104,7 +1123,11 @@ impl AssetServer {
         &self,
         id: impl Into<UntypedAssetId>,
     ) -> Option<(LoadState, DependencyLoadState, RecursiveDependencyLoadState)> {
-        self.read_infos().get(id.into()).map(|i| {
+        let Ok(index) = id.into().try_into() else {
+            // Always say we don't have Uuid assets.
+            return None;
+        };
+        self.read_infos().get(index).map(|i| {
             (
                 i.load_state.clone(),
                 i.dep_load_state.clone(),
@@ -1119,9 +1142,11 @@ impl AssetServer {
     /// its dependencies or recursive dependencies, see [`AssetServer::get_dependency_load_state`]
     /// and [`AssetServer::get_recursive_dependency_load_state`] respectively.
     pub fn get_load_state(&self, id: impl Into<UntypedAssetId>) -> Option<LoadState> {
-        self.read_infos()
-            .get(id.into())
-            .map(|i| i.load_state.clone())
+        let Ok(index) = id.into().try_into() else {
+            // Always say we don't have Uuid assets.
+            return None;
+        };
+        self.read_infos().get(index).map(|i| i.load_state.clone())
     }
 
     /// Retrieves the [`DependencyLoadState`] of a given asset `id`'s dependencies.
@@ -1133,8 +1158,12 @@ impl AssetServer {
         &self,
         id: impl Into<UntypedAssetId>,
     ) -> Option<DependencyLoadState> {
+        let Ok(index) = id.into().try_into() else {
+            // Always say we don't have Uuid assets.
+            return None;
+        };
         self.read_infos()
-            .get(id.into())
+            .get(index)
             .map(|i| i.dep_load_state.clone())
     }
 
@@ -1147,8 +1176,12 @@ impl AssetServer {
         &self,
         id: impl Into<UntypedAssetId>,
     ) -> Option<RecursiveDependencyLoadState> {
+        let Ok(index) = id.into().try_into() else {
+            // Always say we don't have Uuid assets.
+            return None;
+        };
         self.read_infos()
-            .get(id.into())
+            .get(index)
             .map(|i| i.rec_dep_load_state.clone())
     }
 
@@ -1229,13 +1262,21 @@ impl AssetServer {
     /// Get an `UntypedHandle` from an `UntypedAssetId`.
     /// See [`AssetServer::get_id_handle`] for details.
     pub fn get_id_handle_untyped(&self, id: UntypedAssetId) -> Option<UntypedHandle> {
-        self.read_infos().get_id_handle(id)
+        let Ok(index) = id.try_into() else {
+            // Always say we don't have Uuid assets.
+            return None;
+        };
+        self.read_infos().get_index_handle(index)
     }
 
     /// Returns `true` if the given `id` corresponds to an asset that is managed by this [`AssetServer`].
     /// Otherwise, returns `false`.
     pub fn is_managed(&self, id: impl Into<UntypedAssetId>) -> bool {
-        self.read_infos().contains_key(id.into())
+        let Ok(index) = id.into().try_into() else {
+            // Always say we don't have Uuid assets.
+            return false;
+        };
+        self.read_infos().contains_key(index)
     }
 
     /// Returns an active untyped asset id for the given path, if the asset at the given path has already started loading,
@@ -1247,8 +1288,8 @@ impl AssetServer {
     pub fn get_path_id<'a>(&self, path: impl Into<AssetPath<'a>>) -> Option<UntypedAssetId> {
         let infos = self.read_infos();
         let path = path.into();
-        let mut ids = infos.get_path_ids(&path);
-        ids.next()
+        let mut ids = infos.get_path_indices(&path);
+        ids.next().map(Into::into)
     }
 
     /// Returns all active untyped asset IDs for the given path, if the assets at the given path have already started loading,
@@ -1256,7 +1297,10 @@ impl AssetServer {
     /// Multiple IDs will be returned in the event that a single path is used by multiple [`AssetLoader`]'s.
     pub fn get_path_ids<'a>(&self, path: impl Into<AssetPath<'a>>) -> Vec<UntypedAssetId> {
         let path = path.into();
-        self.read_infos().get_path_ids(&path).collect()
+        self.read_infos()
+            .get_path_indices(&path)
+            .map(Into::into)
+            .collect()
     }
 
     /// Returns an active untyped handle for the given path, if the asset at the given path has already started loading,
@@ -1292,8 +1336,12 @@ impl AssetServer {
 
     /// Returns the path for the given `id`, if it has one.
     pub fn get_path(&self, id: impl Into<UntypedAssetId>) -> Option<AssetPath<'_>> {
+        let Ok(index) = id.into().try_into() else {
+            // Always say we don't have Uuid assets.
+            return None;
+        };
         let infos = self.read_infos();
-        let info = infos.get(id.into())?;
+        let info = infos.get(index)?;
         Some(info.path.as_ref()?.clone())
     }
 
@@ -1533,19 +1581,22 @@ impl AssetServer {
         &self,
         id: impl Into<UntypedAssetId>,
     ) -> Result<(), WaitForAssetError> {
-        let id = id.into();
-        core::future::poll_fn(move |cx| self.wait_for_asset_id_poll_fn(cx, id)).await
+        let Ok(index) = id.into().try_into() else {
+            // Always say we aren't loading Uuid assets.
+            return Err(WaitForAssetError::NotLoaded);
+        };
+        core::future::poll_fn(move |cx| self.wait_for_asset_id_poll_fn(cx, index)).await
     }
 
     /// Used by [`wait_for_asset_id`](AssetServer::wait_for_asset_id) in [`poll_fn`](core::future::poll_fn).
     fn wait_for_asset_id_poll_fn(
         &self,
         cx: &mut core::task::Context<'_>,
-        id: UntypedAssetId,
+        index: ErasedAssetIndex,
     ) -> Poll<Result<(), WaitForAssetError>> {
         let infos = self.read_infos();
 
-        let Some(info) = infos.get(id) else {
+        let Some(info) = infos.get(index) else {
             return Poll::Ready(Err(WaitForAssetError::NotLoaded));
         };
 
@@ -1573,7 +1624,7 @@ impl AssetServer {
                     self.write_infos()
                 };
 
-                let Some(info) = infos.get_mut(id) else {
+                let Some(info) = infos.get_mut(index) else {
                     return Poll::Ready(Err(WaitForAssetError::NotLoaded));
                 };
 
@@ -1657,32 +1708,35 @@ pub fn handle_internal_asset_events(world: &mut World) {
         let mut untyped_failures = var_name;
         for event in server.data.asset_event_receiver.try_iter() {
             match event {
-                InternalAssetEvent::Loaded { id, loaded_asset } => {
+                InternalAssetEvent::Loaded {
+                    index,
+                    loaded_asset,
+                } => {
                     infos.process_asset_load(
-                        id,
+                        index,
                         loaded_asset,
                         world,
                         &server.data.asset_event_sender,
                     );
                 }
-                InternalAssetEvent::LoadedWithDependencies { id } => {
+                InternalAssetEvent::LoadedWithDependencies { index } => {
                     let sender = infos
                         .dependency_loaded_event_sender
-                        .get(&id.type_id())
+                        .get(&index.type_id)
                         .expect("Asset event sender should exist");
-                    sender(world, id);
-                    if let Some(info) = infos.get_mut(id) {
+                    sender(world, index.index);
+                    if let Some(info) = infos.get_mut(index) {
                         for waker in info.waiting_tasks.drain(..) {
                             waker.wake();
                         }
                     }
                 }
-                InternalAssetEvent::Failed { id, path, error } => {
-                    infos.process_asset_fail(id, error.clone());
+                InternalAssetEvent::Failed { index, path, error } => {
+                    infos.process_asset_fail(index, error.clone());
 
                     // Send untyped failure event
                     untyped_failures.push(UntypedAssetLoadFailedEvent {
-                        id,
+                        id: index.into(),
                         path: path.clone(),
                         error: error.clone(),
                     });
@@ -1690,9 +1744,9 @@ pub fn handle_internal_asset_events(world: &mut World) {
                     // Send typed failure event
                     let sender = infos
                         .dependency_failed_event_sender
-                        .get(&id.type_id())
+                        .get(&index.type_id)
                         .expect("Asset failed event sender should exist");
-                    sender(world, id, path, error);
+                    sender(world, index.index, path, error);
                 }
             }
         }
@@ -1720,7 +1774,9 @@ pub fn handle_internal_asset_events(world: &mut World) {
                     AssetPath::from(parent.to_path_buf()).with_source(source.clone());
                 for folder_handle in infos.get_path_handles(&parent_asset_path) {
                     info!("Reloading folder {parent_asset_path} because the content has changed");
-                    server.load_folder_internal(folder_handle.id(), parent_asset_path.clone());
+                    // `get_path_handles` only returns Strong variants, so this is safe.
+                    let index = (&folder_handle).try_into().unwrap();
+                    server.load_folder_internal(index, parent_asset_path.clone());
                 }
             }
         };
@@ -1794,14 +1850,14 @@ pub fn handle_internal_asset_events(world: &mut World) {
 /// Internal events for asset load results
 pub(crate) enum InternalAssetEvent {
     Loaded {
-        id: UntypedAssetId,
+        index: ErasedAssetIndex,
         loaded_asset: ErasedLoadedAsset,
     },
     LoadedWithDependencies {
-        id: UntypedAssetId,
+        index: ErasedAssetIndex,
     },
     Failed {
-        id: UntypedAssetId,
+        index: ErasedAssetIndex,
         path: AssetPath<'static>,
         error: AssetLoadError,
     },


### PR DESCRIPTION
# Objective

- This is sort of a step towards #19024.
- This is a step towards #11266.

Context: The AssetServer **never** deals with Uuid assets anyway. We always allocate asset indices, and asset UUIDs are not handled properly (dependencies on UUID assets are never loaded, so their dependents won't ever be notified).

## Solution

- Create `ErasedAssetIndex` as a replacement for `UntypedAssetId`.
- Use `ErasedAssetIndex` or `AssetIndex` where relevant within the `AssetServer`.
