### PR TITLE
bevy_reflect: Remove unnecessary `allow(unused_mut)`.

### DIFF
--- a/crates/bevy_reflect/derive/src/registration.rs
+++ b/crates/bevy_reflect/derive/src/registration.rs
@@ -43,7 +43,6 @@ pub(crate) fn impl_get_type_registration<'a>(
     });
 
     quote! {
-        #[allow(unused_mut)]
         impl #impl_generics #bevy_reflect_path::GetTypeRegistration for #type_path #ty_generics #where_reflect_clause {
             fn get_type_registration() -> #bevy_reflect_path::TypeRegistration {
                 let mut registration = #bevy_reflect_path::TypeRegistration::of::<Self>();


### PR DESCRIPTION
# Objective

The generated `GetTypeRegistration::get_type_registration` method has an unnecessary `allow(unused_mut)` attribute. It used to be necessary because it was possible for `registration` to not be modified, but now there is always at least one modification.

## Solution

Remove the attribute.

## Testing

I checked the `cargo expand` output.