### PR TITLE
Remove leftover apply deferred example metadata from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2092,12 +2092,6 @@ description = "Full guide to Bevy's ECS"
 category = "ECS (Entity Component System)"
 wasm = false
 
-[package.metadata.example.apply_deferred]
-name = "Apply System Buffers"
-description = "Show how to use `ApplyDeferred` system"
-category = "ECS (Entity Component System)"
-wasm = false
-
 [[example]]
 name = "change_detection"
 path = "examples/ecs/change_detection.rs"


### PR DESCRIPTION
I was a bit confused when searching for info about apply deferred, then I found this metadata in the manifest.