### PR TITLE
move Cubemap stuff alongside CubemapFrusta in bevy_camera::primitives

### DIFF
--- a/crates/bevy_camera/src/primitives.rs
+++ b/crates/bevy_camera/src/primitives.rs
@@ -347,6 +347,63 @@ impl Frustum {
     }
 }
 
+pub struct CubeMapFace {
+    pub target: Vec3,
+    pub up: Vec3,
+}
+
+// Cubemap faces are [+X, -X, +Y, -Y, +Z, -Z], per https://www.w3.org/TR/webgpu/#texture-view-creation
+// Note: Cubemap coordinates are left-handed y-up, unlike the rest of Bevy.
+// See https://registry.khronos.org/vulkan/specs/1.2/html/chap16.html#_cube_map_face_selection
+//
+// For each cubemap face, we take care to specify the appropriate target/up axis such that the rendered
+// texture using Bevy's right-handed y-up coordinate space matches the expected cubemap face in
+// left-handed y-up cubemap coordinates.
+pub const CUBE_MAP_FACES: [CubeMapFace; 6] = [
+    // +X
+    CubeMapFace {
+        target: Vec3::X,
+        up: Vec3::Y,
+    },
+    // -X
+    CubeMapFace {
+        target: Vec3::NEG_X,
+        up: Vec3::Y,
+    },
+    // +Y
+    CubeMapFace {
+        target: Vec3::Y,
+        up: Vec3::Z,
+    },
+    // -Y
+    CubeMapFace {
+        target: Vec3::NEG_Y,
+        up: Vec3::NEG_Z,
+    },
+    // +Z (with left-handed conventions, pointing forwards)
+    CubeMapFace {
+        target: Vec3::NEG_Z,
+        up: Vec3::Y,
+    },
+    // -Z (with left-handed conventions, pointing backwards)
+    CubeMapFace {
+        target: Vec3::Z,
+        up: Vec3::Y,
+    },
+];
+
+pub fn face_index_to_name(face_index: usize) -> &'static str {
+    match face_index {
+        0 => "+x",
+        1 => "-x",
+        2 => "+y",
+        3 => "-y",
+        4 => "+z",
+        5 => "-z",
+        _ => "invalid",
+    }
+}
+
 #[derive(Component, Clone, Debug, Default, Reflect)]
 #[reflect(Component, Default, Debug, Clone)]
 pub struct CubemapFrusta {

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -44,6 +44,7 @@ bevy_image = { path = "../bevy_image", version = "0.17.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.17.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.17.0-dev" }
 bevy_render = { path = "../bevy_render", version = "0.17.0-dev" }
+bevy_camera = { path = "../bevy_camera", version = "0.17.0-dev" }
 bevy_tasks = { path = "../bevy_tasks", version = "0.17.0-dev", optional = true }
 bevy_transform = { path = "../bevy_transform", version = "0.17.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.17.0-dev" }

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -1,6 +1,7 @@
 use self::assign::ClusterableObjectType;
 use crate::*;
 use bevy_asset::UntypedAssetId;
+pub use bevy_camera::primitives::{face_index_to_name, CubeMapFace, CUBE_MAP_FACES};
 use bevy_color::ColorToComponents;
 use bevy_core_pipeline::core_3d::{Camera3d, CORE_3D_DEPTH_FORMAT};
 use bevy_derive::{Deref, DerefMut};
@@ -581,63 +582,6 @@ pub(crate) fn remove_light_view_entities(
                 }
             }
         }
-    }
-}
-
-pub(crate) struct CubeMapFace {
-    pub(crate) target: Vec3,
-    pub(crate) up: Vec3,
-}
-
-// Cubemap faces are [+X, -X, +Y, -Y, +Z, -Z], per https://www.w3.org/TR/webgpu/#texture-view-creation
-// Note: Cubemap coordinates are left-handed y-up, unlike the rest of Bevy.
-// See https://registry.khronos.org/vulkan/specs/1.2/html/chap16.html#_cube_map_face_selection
-//
-// For each cubemap face, we take care to specify the appropriate target/up axis such that the rendered
-// texture using Bevy's right-handed y-up coordinate space matches the expected cubemap face in
-// left-handed y-up cubemap coordinates.
-pub(crate) const CUBE_MAP_FACES: [CubeMapFace; 6] = [
-    // +X
-    CubeMapFace {
-        target: Vec3::X,
-        up: Vec3::Y,
-    },
-    // -X
-    CubeMapFace {
-        target: Vec3::NEG_X,
-        up: Vec3::Y,
-    },
-    // +Y
-    CubeMapFace {
-        target: Vec3::Y,
-        up: Vec3::Z,
-    },
-    // -Y
-    CubeMapFace {
-        target: Vec3::NEG_Y,
-        up: Vec3::NEG_Z,
-    },
-    // +Z (with left-handed conventions, pointing forwards)
-    CubeMapFace {
-        target: Vec3::NEG_Z,
-        up: Vec3::Y,
-    },
-    // -Z (with left-handed conventions, pointing backwards)
-    CubeMapFace {
-        target: Vec3::Z,
-        up: Vec3::Y,
-    },
-];
-
-fn face_index_to_name(face_index: usize) -> &'static str {
-    match face_index {
-        0 => "+x",
-        1 => "-x",
-        2 => "+y",
-        3 => "-y",
-        4 => "+z",
-        5 => "-z",
-        _ => "invalid",
     }
 }
 


### PR DESCRIPTION
# Objective

- Make bevy_light possible

## Solution

- Move some stuff it needs out of somewhere it cant depend on. Plus it makes sense, cubemap stuff goes next to cubemap stuff.

## Testing

- 3d_scene runs

Note: no breaking changes thanks to re-exports