### PR TITLE
move light stuff out of decal cluster

### DIFF
--- a/crates/bevy_pbr/src/decal/clustered.rs
+++ b/crates/bevy_pbr/src/decal/clustered.rs
@@ -51,9 +51,9 @@ use bevy_transform::{components::GlobalTransform, prelude::Transform};
 use bytemuck::{Pod, Zeroable};
 
 use crate::{
-    binding_arrays_are_usable, prepare_lights, DirectionalLight, GlobalClusterableObjectMeta,
-    LightVisibilityClass, PointLight, SpotLight,
+    binding_arrays_are_usable, prepare_lights, GlobalClusterableObjectMeta, LightVisibilityClass,
 };
+pub use crate::{DirectionalLightTexture, PointLightTexture, SpotLightTexture};
 
 /// The maximum number of decals that can be present in a view.
 ///
@@ -94,44 +94,6 @@ pub struct ClusteredDecal {
     ///
     /// See the `clustered_decals` example for an example of use.
     pub tag: u32,
-}
-
-/// Add to a [`PointLight`] to add a light texture effect.
-/// A texture mask is applied to the light source to modulate its intensity,  
-/// simulating patterns like window shadows, gobo/cookie effects, or soft falloffs.
-#[derive(Clone, Component, Debug, Reflect)]
-#[reflect(Component, Debug)]
-#[require(PointLight)]
-pub struct PointLightTexture {
-    /// The texture image. Only the R channel is read.
-    pub image: Handle<Image>,
-    /// The cubemap layout. The image should be a packed cubemap in one of the formats described by the [`CubemapLayout`] enum.
-    pub cubemap_layout: CubemapLayout,
-}
-
-/// Add to a [`SpotLight`] to add a light texture effect.
-/// A texture mask is applied to the light source to modulate its intensity,  
-/// simulating patterns like window shadows, gobo/cookie effects, or soft falloffs.
-#[derive(Clone, Component, Debug, Reflect)]
-#[reflect(Component, Debug)]
-#[require(SpotLight)]
-pub struct SpotLightTexture {
-    /// The texture image. Only the R channel is read.
-    /// Note the border of the image should be entirely black to avoid leaking light.
-    pub image: Handle<Image>,
-}
-
-/// Add to a [`DirectionalLight`] to add a light texture effect.
-/// A texture mask is applied to the light source to modulate its intensity,  
-/// simulating patterns like window shadows, gobo/cookie effects, or soft falloffs.
-#[derive(Clone, Component, Debug, Reflect)]
-#[reflect(Component, Debug)]
-#[require(DirectionalLight)]
-pub struct DirectionalLightTexture {
-    /// The texture image. Only the R channel is read.
-    pub image: Handle<Image>,
-    /// Whether to tile the image infinitely, or use only a single tile centered at the light's translation
-    pub tiled: bool,
 }
 
 /// Stores information about all the clustered decals in the scene.

--- a/crates/bevy_pbr/src/light/directional_light.rs
+++ b/crates/bevy_pbr/src/light/directional_light.rs
@@ -141,3 +141,16 @@ impl DirectionalLight {
     pub const DEFAULT_SHADOW_DEPTH_BIAS: f32 = 0.02;
     pub const DEFAULT_SHADOW_NORMAL_BIAS: f32 = 1.8;
 }
+
+/// Add to a [`DirectionalLight`] to add a light texture effect.
+/// A texture mask is applied to the light source to modulate its intensity,  
+/// simulating patterns like window shadows, gobo/cookie effects, or soft falloffs.
+#[derive(Clone, Component, Debug, Reflect)]
+#[reflect(Component, Debug)]
+#[require(DirectionalLight)]
+pub struct DirectionalLightTexture {
+    /// The texture image. Only the R channel is read.
+    pub image: Handle<Image>,
+    /// Whether to tile the image infinitely, or use only a single tile centered at the light's translation
+    pub tiled: bool,
+}

--- a/crates/bevy_pbr/src/light/mod.rs
+++ b/crates/bevy_pbr/src/light/mod.rs
@@ -26,11 +26,11 @@ mod ambient_light;
 pub use ambient_light::AmbientLight;
 
 mod point_light;
-pub use point_light::PointLight;
+pub use point_light::{PointLight, PointLightTexture};
 mod spot_light;
-pub use spot_light::SpotLight;
+pub use spot_light::{SpotLight, SpotLightTexture};
 mod directional_light;
-pub use directional_light::DirectionalLight;
+pub use directional_light::{DirectionalLight, DirectionalLightTexture};
 
 /// Constants for operating with the light units: lumens, and lux.
 pub mod light_consts {

--- a/crates/bevy_pbr/src/light/point_light.rs
+++ b/crates/bevy_pbr/src/light/point_light.rs
@@ -1,5 +1,7 @@
 use bevy_render::view::{self, Visibility};
 
+use crate::decal::clustered::CubemapLayout;
+
 use super::*;
 
 /// A light that emits light in all directions from a central point.
@@ -135,4 +137,17 @@ impl PointLight {
     pub const DEFAULT_SHADOW_DEPTH_BIAS: f32 = 0.08;
     pub const DEFAULT_SHADOW_NORMAL_BIAS: f32 = 0.6;
     pub const DEFAULT_SHADOW_MAP_NEAR_Z: f32 = 0.1;
+}
+
+/// Add to a [`PointLight`] to add a light texture effect.
+/// A texture mask is applied to the light source to modulate its intensity,  
+/// simulating patterns like window shadows, gobo/cookie effects, or soft falloffs.
+#[derive(Clone, Component, Debug, Reflect)]
+#[reflect(Component, Debug)]
+#[require(PointLight)]
+pub struct PointLightTexture {
+    /// The texture image. Only the R channel is read.
+    pub image: Handle<Image>,
+    /// The cubemap layout. The image should be a packed cubemap in one of the formats described by the [`CubemapLayout`] enum.
+    pub cubemap_layout: CubemapLayout,
 }

--- a/crates/bevy_pbr/src/light/spot_light.rs
+++ b/crates/bevy_pbr/src/light/spot_light.rs
@@ -172,3 +172,15 @@ pub fn spot_light_clip_from_view(angle: f32, near_z: f32) -> Mat4 {
     // spot light projection FOV is 2x the angle from spot light center to outer edge
     Mat4::perspective_infinite_reverse_rh(angle * 2.0, 1.0, near_z)
 }
+
+/// Add to a [`SpotLight`] to add a light texture effect.
+/// A texture mask is applied to the light source to modulate its intensity,  
+/// simulating patterns like window shadows, gobo/cookie effects, or soft falloffs.
+#[derive(Clone, Component, Debug, Reflect)]
+#[reflect(Component, Debug)]
+#[require(SpotLight)]
+pub struct SpotLightTexture {
+    /// The texture image. Only the R channel is read.
+    /// Note the border of the image should be entirely black to avoid leaking light.
+    pub image: Handle<Image>,
+}


### PR DESCRIPTION
# Objective

- Make bevy_light possible

## Solution

- Move light stuff into light module

## Testing

- 3d_scene runs

Note: no breaking changes thanks to re-exports