### PR TITLE
move ShadowsEnabled to material

### DIFF
--- a/crates/bevy_pbr/src/light/mod.rs
+++ b/crates/bevy_pbr/src/light/mod.rs
@@ -17,7 +17,7 @@ use bevy_render::{
 };
 use bevy_transform::components::{GlobalTransform, Transform};
 use bevy_utils::Parallel;
-use core::{marker::PhantomData, ops::DerefMut};
+use core::ops::DerefMut;
 
 use crate::*;
 pub use light::spot_light::{spot_light_clip_from_view, spot_light_world_from_view};
@@ -88,16 +88,6 @@ pub mod light_consts {
         pub const DIRECT_SUNLIGHT: f32 = 100_000.;
         /// The amount of light (lux) of raw sunlight, not filtered by the atmosphere.
         pub const RAW_SUNLIGHT: f32 = 130_000.;
-    }
-}
-
-/// Marker resource for whether shadows are enabled for this material type
-#[derive(Resource, Debug)]
-pub struct ShadowsEnabled<M: Material>(PhantomData<M>);
-
-impl<M: Material> Default for ShadowsEnabled<M> {
-    fn default() -> Self {
-        Self(PhantomData)
     }
 }
 

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -1717,3 +1717,13 @@ pub fn write_material_bind_group_buffers(
         allocator.write_buffers(&render_device, &render_queue);
     }
 }
+
+/// Marker resource for whether shadows are enabled for this material type
+#[derive(Resource, Debug)]
+pub struct ShadowsEnabled<M: Material>(PhantomData<M>);
+
+impl<M: Material> Default for ShadowsEnabled<M> {
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}


### PR DESCRIPTION
# Objective

- Make bevy_light possible

## Solution

- Move non-light stuff out of light module (its a marker for whether a material should cast shadows: thats a material property not a light property)

## Testing

- 3d_scene runs