### PR TITLE
`spec_v2`: migrate bloom

### DIFF
--- a/crates/bevy_core_pipeline/src/bloom/mod.rs
+++ b/crates/bevy_core_pipeline/src/bloom/mod.rs
@@ -57,8 +57,6 @@ impl Plugin for BloomPlugin {
             return;
         };
         render_app
-            .init_resource::<SpecializedRenderPipelines<BloomDownsamplingPipeline>>()
-            .init_resource::<SpecializedRenderPipelines<BloomUpsamplingPipeline>>()
             .add_systems(
                 Render,
                 (


### PR DESCRIPTION
# Objective

- minimally migrate bloom to [spec_v2](https://github.com/bevyengine/bevy/pull/17373), without as many opinionated changes as the previous closed pr

## Testing

- `bloom_3d` example works

## For reviewers:

Please bikeshed! This is where we start to make patterns for using `spec_v2`. Some initial thoughts:

- I'm not sure if I'm happy with the error handling or placeholders in `upsampling_pipeline`. What should we do there?
  - @atlv24 and @tychedelia have mentioned removing custom base descriptors, and providing a single default descriptor. That would solve the issue, but I'm concerned about the consequences for composing specializers. It's still worth considering though!
- In an earlier version of this PR I implemented `Specializer<RenderPipeline>` for each `BloomXPipeline`, but this ended up making fields like `bind_group_layout` inaccessible to resource prep systems.
  - should we remove `GetBaseDescriptor` entirely and the Resource derive for `SpecializedCache`? It seems like it might be an anti-pattern.
