### PR TITLE
Fix require components depth

### DIFF
--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -240,28 +240,18 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
     if let Some(requires) = requires {
         for require in requires {
             let ident = &require.path;
-            match &require.func {
-                Some(func) => {
-                    register_required.push(quote! {
-                        components.register_required_components_manual::<Self, #ident>(
-                            required_components,
-                            || { let x: #ident = (#func)().into(); x },
-                            inheritance_depth,
-                            recursion_check_stack
-                        );
-                    });
-                }
-                None => {
-                    register_required.push(quote! {
-                        components.register_required_components_manual::<Self, #ident>(
-                            required_components,
-                            <#ident as Default>::default,
-                            inheritance_depth,
-                            recursion_check_stack
-                        );
-                    });
-                }
-            }
+            let constructor = match &require.func {
+                Some(func) => quote!(|| { let x: #ident = (#func)().into(); x }),
+                None => quote!(<#ident as Default>::default),
+            };
+            register_required.push(quote! {
+                components.register_required_components_manual::<Self, #ident>(
+                    required_components,
+                    #constructor,
+                    inheritance_depth,
+                    recursion_check_stack
+                );
+            });
         }
     }
     let struct_name = &ast.ident;

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -236,7 +236,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
         .push(parse_quote! { Self: Send + Sync + 'static });
 
     let requires = &attrs.requires;
-    let mut register_required = Vec::with_capacity(attrs.requires.iter().len());
+    let mut register_required = Vec::with_capacity(requires.as_ref().map_or(0, Punctuated::len));
     if let Some(requires) = requires {
         for require in requires {
             let ident = &require.path;

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -248,7 +248,6 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
                 components.register_required_components_manual::<Self, #ident>(
                     required_components,
                     #constructor,
-                    recursion_check_stack
                 );
             });
         }
@@ -291,7 +290,6 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
             fn register_required_components(
                 components: &mut #bevy_ecs_path::component::ComponentsRegistrator,
                 required_components: &mut #bevy_ecs_path::component::RequiredComponents,
-                recursion_check_stack: &mut #bevy_ecs_path::__macro_exports::Vec<#bevy_ecs_path::component::ComponentId>
             ) {
                 #(#register_required)*
             }

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -307,8 +307,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
                 recursion_check_stack: &mut #bevy_ecs_path::__macro_exports::Vec<#bevy_ecs_path::component::ComponentId>
             ) {
                 #bevy_ecs_path::component::enforce_no_required_components_recursion(components, recursion_check_stack);
-                let self_id = components.register_component::<Self>();
-                recursion_check_stack.push(self_id);
+                recursion_check_stack.push(requiree);
                 #(#register_required)*
                 recursion_check_stack.pop();
             }

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -248,7 +248,6 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
                 components.register_required_components_manual::<Self, #ident>(
                     required_components,
                     #constructor,
-                    inheritance_depth,
                     recursion_check_stack
                 );
             });
@@ -293,7 +292,6 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
                 requiree: #bevy_ecs_path::component::ComponentId,
                 components: &mut #bevy_ecs_path::component::ComponentsRegistrator,
                 required_components: &mut #bevy_ecs_path::component::RequiredComponents,
-                inheritance_depth: u16,
                 recursion_check_stack: &mut #bevy_ecs_path::__macro_exports::Vec<#bevy_ecs_path::component::ComponentId>
             ) {
                 #bevy_ecs_path::component::enforce_no_required_components_recursion(components, recursion_check_stack);

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -289,15 +289,11 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
             const STORAGE_TYPE: #bevy_ecs_path::component::StorageType = #storage;
             type Mutability = #mutable_type;
             fn register_required_components(
-                requiree: #bevy_ecs_path::component::ComponentId,
                 components: &mut #bevy_ecs_path::component::ComponentsRegistrator,
                 required_components: &mut #bevy_ecs_path::component::RequiredComponents,
                 recursion_check_stack: &mut #bevy_ecs_path::__macro_exports::Vec<#bevy_ecs_path::component::ComponentId>
             ) {
-                #bevy_ecs_path::component::enforce_no_required_components_recursion(components, recursion_check_stack);
-                recursion_check_stack.push(requiree);
                 #(#register_required)*
-                recursion_check_stack.pop();
             }
 
             #on_add

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -283,9 +283,7 @@ unsafe impl<C: Component> Bundle for C {
         components: &mut ComponentsRegistrator,
         required_components: &mut RequiredComponents,
     ) {
-        let component_id = components.register_component::<C>();
         <C as Component>::register_required_components(
-            component_id,
             components,
             required_components,
             &mut Vec::new(),

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -283,11 +283,7 @@ unsafe impl<C: Component> Bundle for C {
         components: &mut ComponentsRegistrator,
         required_components: &mut RequiredComponents,
     ) {
-        <C as Component>::register_required_components(
-            components,
-            required_components,
-            &mut Vec::new(),
-        );
+        <C as Component>::register_required_components(components, required_components);
     }
 
     fn get_component_ids(components: &Components, ids: &mut impl FnMut(Option<ComponentId>)) {

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -288,7 +288,6 @@ unsafe impl<C: Component> Bundle for C {
             component_id,
             components,
             required_components,
-            0,
             &mut Vec::new(),
         );
     }

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -1685,6 +1685,10 @@ impl<'w> ComponentsRegistrator<'w> {
         let requiree = self.register_component_checked::<T>(recursion_check_stack);
         let required = self.register_component_checked::<R>(recursion_check_stack);
 
+        recursion_check_stack.push(required);
+        enforce_no_required_components_recursion(self.components, &recursion_check_stack);
+        recursion_check_stack.pop();
+
         // SAFETY: We just created the components.
         unsafe {
             self.register_required_components_manual_unchecked::<R>(

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -2479,16 +2479,16 @@ mod tests {
         //
         // Requirements with `require` attribute:
         //
-        // A -> B -> C
-        //   0    1
+        // A -> B -> C -> D
+        //   0    1    2
         //
         // Runtime requirements:
         //
-        // X -> A -> B -> C
-        //   0    1    2
-        //
-        // X -> Y -> Z -> B -> C
+        // X -> A -> B -> C -> D
         //   0    1    2    3
+        //
+        // X -> Y -> Z -> B -> C -> D
+        //   0    1    2    3    4
 
         #[derive(Component, Default)]
         #[require(B)]
@@ -2499,7 +2499,11 @@ mod tests {
         struct B;
 
         #[derive(Component, Default)]
+        #[require(D)]
         struct C;
+
+        #[derive(Component, Default)]
+        struct D;
 
         #[derive(Component, Default)]
         struct X;
@@ -2515,6 +2519,7 @@ mod tests {
         let a = world.register_component::<A>();
         let b = world.register_component::<B>();
         let c = world.register_component::<C>();
+        let d = world.register_component::<D>();
         let y = world.register_component::<Y>();
         let z = world.register_component::<Z>();
 
@@ -2528,6 +2533,7 @@ mod tests {
         let required_a = world.get_required_components::<A>().unwrap();
         let required_b = world.get_required_components::<B>().unwrap();
         let required_c = world.get_required_components::<C>().unwrap();
+        let required_d = world.get_required_components::<D>().unwrap();
         let required_x = world.get_required_components::<X>().unwrap();
         let required_y = world.get_required_components::<Y>().unwrap();
         let required_z = world.get_required_components::<Z>().unwrap();
@@ -2545,15 +2551,16 @@ mod tests {
         }
 
         // Check that the inheritance depths are correct for each component.
-        assert_eq!(to_vec(required_a), vec![(b, 0), (c, 1)]);
-        assert_eq!(to_vec(required_b), vec![(c, 0)]);
-        assert_eq!(to_vec(required_c), vec![]);
+        assert_eq!(to_vec(required_a), vec![(b, 0), (c, 1), (d, 2)]);
+        assert_eq!(to_vec(required_b), vec![(c, 0), (d, 1)]);
+        assert_eq!(to_vec(required_c), vec![(d, 0)]);
+        assert_eq!(to_vec(required_d), vec![]);
         assert_eq!(
             to_vec(required_x),
-            vec![(a, 0), (b, 1), (c, 2), (y, 0), (z, 1)]
+            vec![(a, 0), (b, 1), (c, 2), (d, 3), (y, 0), (z, 1)]
         );
-        assert_eq!(to_vec(required_y), vec![(b, 1), (c, 2), (z, 0)]);
-        assert_eq!(to_vec(required_z), vec![(b, 0), (c, 1)]);
+        assert_eq!(to_vec(required_y), vec![(b, 1), (c, 2), (d, 3), (z, 0)]);
+        assert_eq!(to_vec(required_z), vec![(b, 0), (c, 1), (d, 2)]);
     }
 
     #[test]

--- a/release-content/migration-guides/component_register_required_components.md
+++ b/release-content/migration-guides/component_register_required_components.md
@@ -1,0 +1,6 @@
+---
+title: Refactor of Component::register_required_component
+pull_requests: [19972]
+---
+
+The `register_required_component` method of the `Component` trait has been refactored to no longer be aware of the recursive registration, and in particular its `requiree`, `inheritance_depth` and `recursion_check_stack` parameters have been removed.


### PR DESCRIPTION
Note: I suggest reviewing commit-by-commit

# Objective

- Fix #19863
- Clean up a bit how recursive required components registration works

## Solution

- Update required components registration to be oblivious of the recursive registration happening.
- Concretely this means removing the `requiree`, `inheritance_depth` and `recursion_check_stack` parameters from `Component::register_required_components`
  - `requiree` was effectively unused
  - `inheritance_depth` is now useless, because the depth is always either 0 (for direct requirements) or computed in `register_inherited_required_components` by bumping the depth of the inherited components
  - `recursion_check_stack` has been moved to `ComponentsRegistrator`, which also allows to make `enforce_no_required_components_recursion` private.


## Testing

- Existing tests pass
- A test has been updated to catch the issue from #19863