### PR TITLE
fix variable-termination loop gradients by sampling specific lod

### DIFF
--- a/crates/bevy_pbr/src/volumetric_fog/volumetric_fog.wgsl
+++ b/crates/bevy_pbr/src/volumetric_fog/volumetric_fog.wgsl
@@ -251,7 +251,7 @@ fn fragment(@builtin(position) position: vec4<f32>) -> @location(0) vec4<f32> {
             // case.
             let P_uvw = Ro_uvw + Rd_step_uvw * f32(step);
             if (all(P_uvw >= vec3(0.0)) && all(P_uvw <= vec3(1.0))) {
-                density *= textureSample(density_texture, density_sampler, P_uvw + density_texture_offset).r;
+                density *= textureSampleLevel(density_texture, density_sampler, P_uvw + density_texture_offset, 0.0).r;
             } else {
                 density = 0.0;
             }


### PR DESCRIPTION
# Objective

- Calculating gradients in variable-termination loop is bad, and we dont need to here

## Solution

- Sample mip 0 always

## Testing

- volumetric_fog example

