### PR TITLE
Hsl and Hsv interpolation for UI gradients

### DIFF
--- a/crates/bevy_ui/src/gradients.rs
+++ b/crates/bevy_ui/src/gradients.rs
@@ -631,6 +631,14 @@ pub enum InterpolationColorSpace {
     Srgb,
     /// Interpolates in linear sRGB space.
     LinearRgb,
+    /// Interpolates in HSL space, taking the shortest hue path.
+    Hsl,
+    /// Interpolates in HSL space, taking the longest hue path.
+    HslLong,
+    /// Interpolates in HSV space, taking the shortest hue path.
+    Hsv,
+    /// Interpolates in HSV space, taking the longest hue path.
+    HsvLong,
 }
 
 /// Set the color space used for interpolation.

--- a/crates/bevy_ui_render/src/gradient.rs
+++ b/crates/bevy_ui_render/src/gradient.rs
@@ -186,6 +186,10 @@ impl SpecializedRenderPipeline for GradientPipeline {
             InterpolationColorSpace::OkLchLong => "IN_OKLCH_LONG",
             InterpolationColorSpace::Srgb => "IN_SRGB",
             InterpolationColorSpace::LinearRgb => "IN_LINEAR_RGB",
+            InterpolationColorSpace::Hsl => "IN_HSL",
+            InterpolationColorSpace::HslLong => "IN_HSL_LONG",
+            InterpolationColorSpace::Hsv => "IN_HSV",
+            InterpolationColorSpace::HsvLong => "IN_HSV_LONG",
         };
 
         let shader_defs = if key.anti_alias {

--- a/crates/bevy_ui_render/src/gradient.wgsl
+++ b/crates/bevy_ui_render/src/gradient.wgsl
@@ -150,8 +150,8 @@ fn oklab_to_linear_rgba(c: vec4<f32>) -> vec4<f32> {
 }
 
 fn linear_rgb_to_hsl(c: vec4<f32>) -> vec4<f32> {
-    let maxc = max(max(c.r, c.g), b);
-    let minc = min(min(c.r, c.g), b);
+    let maxc = max(max(c.r, c.g), c.b);
+    let minc = min(min(c.r, c.g), c.b);
     let delta = maxc - minc;
     let l = (maxc + minc) * 0.5;
     var h: f32 = 0.0;
@@ -160,7 +160,7 @@ fn linear_rgb_to_hsl(c: vec4<f32>) -> vec4<f32> {
         s = delta / (1.0 - abs(2.0 * l - 1.0));
         if maxc == c.r {
             h = ((c.g - c.b) / delta) % 6.0;
-        } else if maxc == g {
+        } else if maxc == c.g {
             h = ((c.b - c.r) / delta) + 2.0;
         } else {
             h = ((c.r - c.g) / delta) + 4.0;
@@ -209,7 +209,7 @@ fn linear_rgba_to_hsva(c: vec4<f32>) -> vec4<f32> {
     let v: f32 = maxc;
     if delta != 0.0 {
         s = delta / maxc;
-        if maxc == r {
+        if maxc == c.r {
             h = ((c.g - c.b) / delta) % 6.0;
         } else if maxc == c.g {
             h = ((c.b - c.r) / delta) + 2.0;

--- a/examples/ui/gradients.rs
+++ b/examples/ui/gradients.rs
@@ -245,6 +245,18 @@ fn setup(mut commands: Commands) {
                                             InterpolationColorSpace::LinearRgb
                                         }
                                         InterpolationColorSpace::LinearRgb => {
+                                            InterpolationColorSpace::Hsl
+                                        }
+                                        InterpolationColorSpace::Hsl => {
+                                            InterpolationColorSpace::HslLong
+                                        }
+                                        InterpolationColorSpace::HslLong => {
+                                            InterpolationColorSpace::Hsv
+                                        }
+                                        InterpolationColorSpace::Hsv => {
+                                            InterpolationColorSpace::HsvLong
+                                        }
+                                        InterpolationColorSpace::HsvLong => {
                                             InterpolationColorSpace::OkLab
                                         }
                                     };


### PR DESCRIPTION
# Objective

Add interpolation in HSL and HSV colout spaces for UI gradients.

## Solution
Added new variants to `InterpolationColorSpace`: `Hs`l, `HslLong`, `Hsv`, and `HsvLong`, along with mix functions to the `gradients` shader for each of them.

## Testing

```cargo run --example gradients```