### PR TITLE
remove fast_sqrt in favor of sqrt

### DIFF
--- a/crates/bevy_render/src/maths.wgsl
+++ b/crates/bevy_render/src/maths.wgsl
@@ -104,17 +104,11 @@ fn project_onto(lhs: vec3<f32>, rhs: vec3<f32>) -> vec3<f32> {
 // are likely most useful when raymarching, for example, where complete numeric
 // accuracy can be sacrificed for greater sample count.
 
-fn fast_sqrt(x: f32) -> f32 {
-    let n = bitcast<f32>(0x1fbd1df5 + (bitcast<i32>(x) >> 1u));
-    // One Newton's method iteration for better precision
-    return 0.5 * (n + x / n);
-}
-
 // Slightly less accurate than fast_acos_4, but much simpler.
 fn fast_acos(in_x: f32) -> f32 {
     let x = abs(in_x);
     var res = -0.156583 * x + HALF_PI;
-    res *= fast_sqrt(1.0 - x);
+    res *= sqrt(1.0 - x);
     return select(PI - res, res, in_x >= 0.0);
 }
 
@@ -131,7 +125,7 @@ fn fast_acos_4(x: f32) -> f32 {
     s = -0.2121144 * x1 + 1.5707288;
     s = 0.0742610 * x2 + s;
     s = -0.0187293 * x3 + s;
-    s = fast_sqrt(1.0 - x1) * s;
+    s = sqrt(1.0 - x1) * s;
 
 	// acos function mirroring
     return select(PI - s, s, x >= 0.0);


### PR DESCRIPTION
# Objective

- the fast inverse sqrt trick hasnt been useful on modern hardware for over a decade now

## Solution

- just use sqrt, modern hardware has a dedicated instruction which will outperform approximations both in efficiency and accuracy

## Testing

- ran `atmosphere`