### PR TITLE
make optional crates for mesh, camera, and light

### DIFF
--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -199,6 +199,10 @@ bevy_ui = ["dep:bevy_ui", "bevy_image"]
 bevy_ui_render = ["dep:bevy_ui_render"]
 bevy_image = ["dep:bevy_image"]
 
+bevy_mesh = ["dep:bevy_mesh", "bevy_image"]
+bevy_camera = ["dep:bevy_camera", "bevy_mesh"]
+bevy_light = ["dep:bevy_light", "bevy_camera"]
+
 # Used to disable code that is unsupported when Bevy is dynamically linked
 dynamic_linking = ["bevy_diagnostic/dynamic_linking"]
 
@@ -215,7 +219,7 @@ bevy_render = [
   "dep:bevy_render",
   "bevy_scene?/bevy_render",
   "bevy_gizmos?/bevy_render",
-  "bevy_image",
+  "bevy_camera",
   "bevy_color/wgpu-types",
   "bevy_color/encase",
 ]
@@ -428,6 +432,9 @@ bevy_gizmos = { path = "../bevy_gizmos", optional = true, version = "0.17.0-dev"
 bevy_gltf = { path = "../bevy_gltf", optional = true, version = "0.17.0-dev" }
 bevy_feathers = { path = "../bevy_feathers", optional = true, version = "0.17.0-dev" }
 bevy_image = { path = "../bevy_image", optional = true, version = "0.17.0-dev" }
+bevy_mesh = { path = "../bevy_mesh", optional = true, version = "0.17.0-dev" }
+bevy_camera = { path = "../bevy_camera", optional = true, version = "0.17.0-dev" }
+bevy_light = { path = "../bevy_light", optional = true, version = "0.17.0-dev" }
 bevy_input_focus = { path = "../bevy_input_focus", optional = true, version = "0.17.0-dev", default-features = false, features = [
   "bevy_reflect",
 ] }

--- a/crates/bevy_internal/src/lib.rs
+++ b/crates/bevy_internal/src/lib.rs
@@ -25,6 +25,8 @@ pub use bevy_app as app;
 pub use bevy_asset as asset;
 #[cfg(feature = "bevy_audio")]
 pub use bevy_audio as audio;
+#[cfg(feature = "bevy_camera")]
+pub use bevy_camera as camera;
 #[cfg(feature = "bevy_color")]
 pub use bevy_color as color;
 #[cfg(feature = "bevy_core_pipeline")]
@@ -48,9 +50,13 @@ pub use bevy_image as image;
 pub use bevy_input as input;
 #[cfg(feature = "bevy_input_focus")]
 pub use bevy_input_focus as input_focus;
+#[cfg(feature = "bevy_light")]
+pub use bevy_light as light;
 #[cfg(feature = "bevy_log")]
 pub use bevy_log as log;
 pub use bevy_math as math;
+#[cfg(feature = "bevy_mesh")]
+pub use bevy_mesh as mesh;
 #[cfg(feature = "bevy_pbr")]
 pub use bevy_pbr as pbr;
 #[cfg(feature = "bevy_picking")]

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -44,7 +44,9 @@ bevy_light = { path = "../bevy_light", version = "0.17.0-dev" }
 bevy_image = { path = "../bevy_image", version = "0.17.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.17.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.17.0-dev" }
-bevy_render = { path = "../bevy_render", version = "0.17.0-dev" }
+bevy_render = { path = "../bevy_render", features = [
+  "bevy_light",
+], version = "0.17.0-dev" }
 bevy_camera = { path = "../bevy_camera", version = "0.17.0-dev" }
 bevy_tasks = { path = "../bevy_tasks", version = "0.17.0-dev", optional = true }
 bevy_transform = { path = "../bevy_transform", version = "0.17.0-dev" }

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -77,7 +77,7 @@ bevy_tasks = { path = "../bevy_tasks", version = "0.17.0-dev" }
 bevy_image = { path = "../bevy_image", version = "0.17.0-dev" }
 bevy_mesh = { path = "../bevy_mesh", version = "0.17.0-dev" }
 bevy_camera = { path = "../bevy_camera", version = "0.17.0-dev" }
-bevy_light = { path = "../bevy_light", version = "0.17.0-dev" }
+bevy_light = { path = "../bevy_light", optional = true, version = "0.17.0-dev" }
 bevy_platform = { path = "../bevy_platform", version = "0.17.0-dev", default-features = false, features = [
   "std",
   "serialize",

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -50,6 +50,7 @@ pub mod sync_world;
 pub mod texture;
 pub mod view;
 pub use bevy_camera::primitives;
+#[cfg(feature = "bevy_light")]
 mod extract_impls;
 
 /// The render prelude.


### PR DESCRIPTION
# Objective

- nice bevy::camera bevy::mesh bevy::light imports
- skip bevy_light in 2d

## Solution

- add optional crates to internal
- make light only included when building pbr

## Testing

- 3d_scene