### PR TITLE
Use `RenderStartup` for all basic cases in `bevy_core_pipeline`.

### DIFF
--- a/crates/bevy_core_pipeline/src/auto_exposure/pipeline.rs
+++ b/crates/bevy_core_pipeline/src/auto_exposure/pipeline.rs
@@ -47,31 +47,31 @@ pub enum AutoExposurePass {
 
 pub const HISTOGRAM_BIN_COUNT: u64 = 64;
 
-impl FromWorld for AutoExposurePipeline {
-    fn from_world(world: &mut World) -> Self {
-        let render_device = world.resource::<RenderDevice>();
-
-        Self {
-            histogram_layout: render_device.create_bind_group_layout(
-                "compute histogram bind group",
-                &BindGroupLayoutEntries::sequential(
-                    ShaderStages::COMPUTE,
-                    (
-                        uniform_buffer::<GlobalsUniform>(false),
-                        uniform_buffer::<AutoExposureUniform>(false),
-                        texture_2d(TextureSampleType::Float { filterable: false }),
-                        texture_2d(TextureSampleType::Float { filterable: false }),
-                        texture_1d(TextureSampleType::Float { filterable: false }),
-                        uniform_buffer::<AutoExposureCompensationCurveUniform>(false),
-                        storage_buffer_sized(false, NonZero::<u64>::new(HISTOGRAM_BIN_COUNT * 4)),
-                        storage_buffer_sized(false, NonZero::<u64>::new(4)),
-                        storage_buffer::<ViewUniform>(true),
-                    ),
+pub fn init_auto_exposure_pipeline(
+    mut commands: Commands,
+    render_device: Res<RenderDevice>,
+    asset_server: Res<AssetServer>,
+) {
+    commands.insert_resource(AutoExposurePipeline {
+        histogram_layout: render_device.create_bind_group_layout(
+            "compute histogram bind group",
+            &BindGroupLayoutEntries::sequential(
+                ShaderStages::COMPUTE,
+                (
+                    uniform_buffer::<GlobalsUniform>(false),
+                    uniform_buffer::<AutoExposureUniform>(false),
+                    texture_2d(TextureSampleType::Float { filterable: false }),
+                    texture_2d(TextureSampleType::Float { filterable: false }),
+                    texture_1d(TextureSampleType::Float { filterable: false }),
+                    uniform_buffer::<AutoExposureCompensationCurveUniform>(false),
+                    storage_buffer_sized(false, NonZero::<u64>::new(HISTOGRAM_BIN_COUNT * 4)),
+                    storage_buffer_sized(false, NonZero::<u64>::new(4)),
+                    storage_buffer::<ViewUniform>(true),
                 ),
             ),
-            histogram_shader: load_embedded_asset!(world, "auto_exposure.wgsl"),
-        }
-    }
+        ),
+        histogram_shader: load_embedded_asset!(asset_server.as_ref(), "auto_exposure.wgsl"),
+    });
 }
 
 impl SpecializedComputePipeline for AutoExposurePipeline {

--- a/crates/bevy_core_pipeline/src/blit/mod.rs
+++ b/crates/bevy_core_pipeline/src/blit/mod.rs
@@ -1,6 +1,6 @@
 use crate::FullscreenShader;
 use bevy_app::{App, Plugin};
-use bevy_asset::{embedded_asset, load_embedded_asset, Handle};
+use bevy_asset::{embedded_asset, load_embedded_asset, AssetServer, Handle};
 use bevy_ecs::prelude::*;
 use bevy_render::{
     render_resource::{
@@ -8,7 +8,7 @@ use bevy_render::{
         *,
     },
     renderer::RenderDevice,
-    RenderApp,
+    RenderApp, RenderStartup,
 };
 use bevy_utils::default;
 
@@ -19,18 +19,14 @@ impl Plugin for BlitPlugin {
     fn build(&self, app: &mut App) {
         embedded_asset!(app, "blit.wgsl");
 
-        if let Some(render_app) = app.get_sub_app_mut(RenderApp) {
-            render_app.allow_ambiguous_resource::<SpecializedRenderPipelines<BlitPipeline>>();
-        }
-    }
-
-    fn finish(&self, app: &mut App) {
         let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
             return;
         };
+
         render_app
-            .init_resource::<BlitPipeline>()
-            .init_resource::<SpecializedRenderPipelines<BlitPipeline>>();
+            .allow_ambiguous_resource::<SpecializedRenderPipelines<BlitPipeline>>()
+            .init_resource::<SpecializedRenderPipelines<BlitPipeline>>()
+            .add_systems(RenderStartup, init_blit_pipeline);
     }
 }
 
@@ -42,30 +38,31 @@ pub struct BlitPipeline {
     pub fragment_shader: Handle<Shader>,
 }
 
-impl FromWorld for BlitPipeline {
-    fn from_world(render_world: &mut World) -> Self {
-        let render_device = render_world.resource::<RenderDevice>();
-
-        let layout = render_device.create_bind_group_layout(
-            "blit_bind_group_layout",
-            &BindGroupLayoutEntries::sequential(
-                ShaderStages::FRAGMENT,
-                (
-                    texture_2d(TextureSampleType::Float { filterable: false }),
-                    sampler(SamplerBindingType::NonFiltering),
-                ),
+pub fn init_blit_pipeline(
+    mut commands: Commands,
+    render_device: Res<RenderDevice>,
+    fullscreen_shader: Res<FullscreenShader>,
+    asset_server: Res<AssetServer>,
+) {
+    let layout = render_device.create_bind_group_layout(
+        "blit_bind_group_layout",
+        &BindGroupLayoutEntries::sequential(
+            ShaderStages::FRAGMENT,
+            (
+                texture_2d(TextureSampleType::Float { filterable: false }),
+                sampler(SamplerBindingType::NonFiltering),
             ),
-        );
+        ),
+    );
 
-        let sampler = render_device.create_sampler(&SamplerDescriptor::default());
+    let sampler = render_device.create_sampler(&SamplerDescriptor::default());
 
-        BlitPipeline {
-            layout,
-            sampler,
-            fullscreen_shader: render_world.resource::<FullscreenShader>().clone(),
-            fragment_shader: load_embedded_asset!(render_world, "blit.wgsl"),
-        }
-    }
+    commands.insert_resource(BlitPipeline {
+        layout,
+        sampler,
+        fullscreen_shader: fullscreen_shader.clone(),
+        fragment_shader: load_embedded_asset!(asset_server.as_ref(), "blit.wgsl"),
+    });
 }
 
 impl BlitPipeline {

--- a/crates/bevy_core_pipeline/src/bloom/mod.rs
+++ b/crates/bevy_core_pipeline/src/bloom/mod.rs
@@ -6,6 +6,10 @@ use bevy_image::ToExtents;
 pub use settings::{Bloom, BloomCompositeMode, BloomPrefilter};
 
 use crate::{
+    bloom::{
+        downsampling_pipeline::init_bloom_downsampling_pipeline,
+        upsampling_pipeline::init_bloom_upscaling_pipeline,
+    },
     core_2d::graph::{Core2d, Node2d},
     core_3d::graph::{Core3d, Node3d},
 };
@@ -25,7 +29,7 @@ use bevy_render::{
     renderer::{RenderContext, RenderDevice},
     texture::{CachedTexture, TextureCache},
     view::ViewTarget,
-    Render, RenderApp, RenderSystems,
+    Render, RenderApp, RenderStartup, RenderSystems,
 };
 use downsampling_pipeline::{
     prepare_downsampling_pipeline, BloomDownsamplingPipeline, BloomDownsamplingPipelineIds,
@@ -60,6 +64,13 @@ impl Plugin for BloomPlugin {
             .init_resource::<SpecializedRenderPipelines<BloomDownsamplingPipeline>>()
             .init_resource::<SpecializedRenderPipelines<BloomUpsamplingPipeline>>()
             .add_systems(
+                RenderStartup,
+                (
+                    init_bloom_downsampling_pipeline,
+                    init_bloom_upscaling_pipeline,
+                ),
+            )
+            .add_systems(
                 Render,
                 (
                     prepare_downsampling_pipeline.in_set(RenderSystems::Prepare),
@@ -80,15 +91,6 @@ impl Plugin for BloomPlugin {
                 Core2d,
                 (Node2d::EndMainPass, Node2d::Bloom, Node2d::Tonemapping),
             );
-    }
-
-    fn finish(&self, app: &mut App) {
-        let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
-            return;
-        };
-        render_app
-            .init_resource::<BloomDownsamplingPipeline>()
-            .init_resource::<BloomUpsamplingPipeline>();
     }
 }
 

--- a/crates/bevy_core_pipeline/src/dof/mod.rs
+++ b/crates/bevy_core_pipeline/src/dof/mod.rs
@@ -25,7 +25,7 @@ use bevy_ecs::{
     resource::Resource,
     schedule::IntoScheduleConfigs as _,
     system::{lifetimeless::Read, Commands, Query, Res, ResMut},
-    world::{FromWorld, World},
+    world::World,
 };
 use bevy_image::BevyDefault as _;
 use bevy_math::ops;
@@ -55,7 +55,7 @@ use bevy_render::{
         prepare_view_targets, ExtractedView, Msaa, ViewDepthTexture, ViewTarget, ViewUniform,
         ViewUniformOffset, ViewUniforms,
     },
-    Extract, ExtractSchedule, Render, RenderApp, RenderSystems,
+    Extract, ExtractSchedule, Render, RenderApp, RenderStartup, RenderSystems,
 };
 use bevy_utils::{default, once};
 use smallvec::SmallVec;
@@ -219,6 +219,7 @@ impl Plugin for DepthOfFieldPlugin {
         render_app
             .init_resource::<SpecializedRenderPipelines<DepthOfFieldPipeline>>()
             .init_resource::<DepthOfFieldGlobalBindGroup>()
+            .add_systems(RenderStartup, init_dof_global_bind_group_layout)
             .add_systems(ExtractSchedule, extract_depth_of_field_settings)
             .add_systems(
                 Render,
@@ -247,14 +248,6 @@ impl Plugin for DepthOfFieldPlugin {
                 Core3d,
                 (Node3d::Bloom, Node3d::DepthOfField, Node3d::Tonemapping),
             );
-    }
-
-    fn finish(&self, app: &mut App) {
-        let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
-            return;
-        };
-
-        render_app.init_resource::<DepthOfFieldGlobalBindGroupLayout>();
     }
 }
 
@@ -504,38 +497,34 @@ impl DepthOfField {
     }
 }
 
-impl FromWorld for DepthOfFieldGlobalBindGroupLayout {
-    fn from_world(world: &mut World) -> Self {
-        let render_device = world.resource::<RenderDevice>();
-
-        // Create the bind group layout that will be shared among all instances
-        // of the depth of field shader.
-        let layout = render_device.create_bind_group_layout(
-            Some("depth of field global bind group layout"),
-            &BindGroupLayoutEntries::sequential(
-                ShaderStages::FRAGMENT,
-                (
-                    // `dof_params`
-                    uniform_buffer::<DepthOfFieldUniform>(true),
-                    // `color_texture_sampler`
-                    sampler(SamplerBindingType::Filtering),
-                ),
+pub fn init_dof_global_bind_group_layout(mut commands: Commands, render_device: Res<RenderDevice>) {
+    // Create the bind group layout that will be shared among all instances
+    // of the depth of field shader.
+    let layout = render_device.create_bind_group_layout(
+        Some("depth of field global bind group layout"),
+        &BindGroupLayoutEntries::sequential(
+            ShaderStages::FRAGMENT,
+            (
+                // `dof_params`
+                uniform_buffer::<DepthOfFieldUniform>(true),
+                // `color_texture_sampler`
+                sampler(SamplerBindingType::Filtering),
             ),
-        );
+        ),
+    );
 
-        // Create the color texture sampler.
-        let sampler = render_device.create_sampler(&SamplerDescriptor {
-            label: Some("depth of field sampler"),
-            mag_filter: FilterMode::Linear,
-            min_filter: FilterMode::Linear,
-            ..default()
-        });
+    // Create the color texture sampler.
+    let sampler = render_device.create_sampler(&SamplerDescriptor {
+        label: Some("depth of field sampler"),
+        mag_filter: FilterMode::Linear,
+        min_filter: FilterMode::Linear,
+        ..default()
+    });
 
-        DepthOfFieldGlobalBindGroupLayout {
-            color_texture_sampler: sampler,
-            layout,
-        }
-    }
+    commands.insert_resource(DepthOfFieldGlobalBindGroupLayout {
+        color_texture_sampler: sampler,
+        layout,
+    });
 }
 
 /// Creates the bind group layouts for the depth of field effect that are

--- a/crates/bevy_core_pipeline/src/lib.rs
+++ b/crates/bevy_core_pipeline/src/lib.rs
@@ -81,9 +81,6 @@ impl Plugin for CorePipelinePlugin {
                 OrderIndependentTransparencyPlugin,
                 MipGenerationPlugin,
             ));
-    }
-
-    fn finish(&self, app: &mut App) {
         let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
             return;
         };

--- a/crates/bevy_core_pipeline/src/motion_blur/mod.rs
+++ b/crates/bevy_core_pipeline/src/motion_blur/mod.rs
@@ -20,7 +20,7 @@ use bevy_render::{
     extract_component::{ExtractComponent, ExtractComponentPlugin, UniformComponentPlugin},
     render_graph::{RenderGraphExt, ViewNodeRunner},
     render_resource::{ShaderType, SpecializedRenderPipelines},
-    Render, RenderApp, RenderSystems,
+    Render, RenderApp, RenderStartup, RenderSystems,
 };
 
 pub mod node;
@@ -143,6 +143,7 @@ impl Plugin for MotionBlurPlugin {
 
         render_app
             .init_resource::<SpecializedRenderPipelines<pipeline::MotionBlurPipeline>>()
+            .add_systems(RenderStartup, pipeline::init_motion_blur_pipeline)
             .add_systems(
                 Render,
                 pipeline::prepare_motion_blur_pipelines.in_set(RenderSystems::Prepare),
@@ -161,13 +162,5 @@ impl Plugin for MotionBlurPlugin {
                     Node3d::Bloom, // we want blurred areas to bloom and tonemap properly.
                 ),
             );
-    }
-
-    fn finish(&self, app: &mut App) {
-        let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
-            return;
-        };
-
-        render_app.init_resource::<pipeline::MotionBlurPipeline>();
     }
 }

--- a/crates/bevy_core_pipeline/src/motion_blur/pipeline.rs
+++ b/crates/bevy_core_pipeline/src/motion_blur/pipeline.rs
@@ -1,12 +1,11 @@
 use crate::FullscreenShader;
-use bevy_asset::{load_embedded_asset, Handle};
+use bevy_asset::{load_embedded_asset, AssetServer, Handle};
 use bevy_ecs::{
     component::Component,
     entity::Entity,
     query::With,
     resource::Resource,
     system::{Commands, Query, Res, ResMut},
-    world::FromWorld,
 };
 use bevy_image::BevyDefault as _;
 use bevy_render::{
@@ -94,14 +93,19 @@ impl MotionBlurPipeline {
     }
 }
 
-impl FromWorld for MotionBlurPipeline {
-    fn from_world(render_world: &mut bevy_ecs::world::World) -> Self {
-        let render_device = render_world.resource::<RenderDevice>().clone();
-
-        let fullscreen_shader = render_world.resource::<FullscreenShader>().clone();
-        let fragment_shader = load_embedded_asset!(render_world, "motion_blur.wgsl");
-        MotionBlurPipeline::new(&render_device, fullscreen_shader, fragment_shader)
-    }
+pub fn init_motion_blur_pipeline(
+    mut commands: Commands,
+    render_device: Res<RenderDevice>,
+    fullscreen_shader: Res<FullscreenShader>,
+    asset_server: Res<AssetServer>,
+) {
+    let fullscreen_shader = fullscreen_shader.clone();
+    let fragment_shader = load_embedded_asset!(asset_server.as_ref(), "motion_blur.wgsl");
+    commands.insert_resource(MotionBlurPipeline::new(
+        &render_device,
+        fullscreen_shader,
+        fragment_shader,
+    ));
 }
 
 #[derive(PartialEq, Eq, Hash, Clone, Copy)]

--- a/crates/bevy_core_pipeline/src/post_process/mod.rs
+++ b/crates/bevy_core_pipeline/src/post_process/mod.rs
@@ -3,7 +3,7 @@
 //! Currently, this consists only of chromatic aberration.
 
 use bevy_app::{App, Plugin};
-use bevy_asset::{embedded_asset, load_embedded_asset, Assets, Handle};
+use bevy_asset::{embedded_asset, load_embedded_asset, AssetServer, Assets, Handle};
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
     component::Component,
@@ -13,7 +13,7 @@ use bevy_ecs::{
     resource::Resource,
     schedule::IntoScheduleConfigs as _,
     system::{lifetimeless::Read, Commands, Query, Res, ResMut},
-    world::{FromWorld, World},
+    world::World,
 };
 use bevy_image::{BevyDefault, Image};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
@@ -37,7 +37,7 @@ use bevy_render::{
     renderer::{RenderContext, RenderDevice, RenderQueue},
     texture::GpuImage,
     view::{ExtractedView, ViewTarget},
-    Render, RenderApp, RenderSystems,
+    Render, RenderApp, RenderStartup, RenderSystems,
 };
 use bevy_utils::prelude::default;
 
@@ -211,6 +211,7 @@ impl Plugin for PostProcessingPlugin {
             .insert_resource(DefaultChromaticAberrationLut(default_lut))
             .init_resource::<SpecializedRenderPipelines<PostProcessingPipeline>>()
             .init_resource::<PostProcessingUniformBuffers>()
+            .add_systems(RenderStartup, init_post_processing_pipeline)
             .add_systems(
                 Render,
                 (
@@ -240,13 +241,6 @@ impl Plugin for PostProcessingPlugin {
                 (Node2d::Bloom, Node2d::PostProcessing, Node2d::Tonemapping),
             );
     }
-
-    fn finish(&self, app: &mut App) {
-        let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
-            return;
-        };
-        render_app.init_resource::<PostProcessingPipeline>();
-    }
 }
 
 impl Default for ChromaticAberration {
@@ -259,55 +253,56 @@ impl Default for ChromaticAberration {
     }
 }
 
-impl FromWorld for PostProcessingPipeline {
-    fn from_world(world: &mut World) -> Self {
-        let render_device = world.resource::<RenderDevice>();
-
-        // Create our single bind group layout.
-        let bind_group_layout = render_device.create_bind_group_layout(
-            Some("postprocessing bind group layout"),
-            &BindGroupLayoutEntries::sequential(
-                ShaderStages::FRAGMENT,
-                (
-                    // Chromatic aberration source:
-                    texture_2d(TextureSampleType::Float { filterable: true }),
-                    // Chromatic aberration source sampler:
-                    sampler(SamplerBindingType::Filtering),
-                    // Chromatic aberration LUT:
-                    texture_2d(TextureSampleType::Float { filterable: true }),
-                    // Chromatic aberration LUT sampler:
-                    sampler(SamplerBindingType::Filtering),
-                    // Chromatic aberration settings:
-                    uniform_buffer::<ChromaticAberrationUniform>(true),
-                ),
+pub fn init_post_processing_pipeline(
+    mut commands: Commands,
+    render_device: Res<RenderDevice>,
+    fullscreen_shader: Res<FullscreenShader>,
+    asset_server: Res<AssetServer>,
+) {
+    // Create our single bind group layout.
+    let bind_group_layout = render_device.create_bind_group_layout(
+        Some("postprocessing bind group layout"),
+        &BindGroupLayoutEntries::sequential(
+            ShaderStages::FRAGMENT,
+            (
+                // Chromatic aberration source:
+                texture_2d(TextureSampleType::Float { filterable: true }),
+                // Chromatic aberration source sampler:
+                sampler(SamplerBindingType::Filtering),
+                // Chromatic aberration LUT:
+                texture_2d(TextureSampleType::Float { filterable: true }),
+                // Chromatic aberration LUT sampler:
+                sampler(SamplerBindingType::Filtering),
+                // Chromatic aberration settings:
+                uniform_buffer::<ChromaticAberrationUniform>(true),
             ),
-        );
+        ),
+    );
 
-        // Both source and chromatic aberration LUTs should be sampled
-        // bilinearly.
+    // Both source and chromatic aberration LUTs should be sampled
+    // bilinearly.
 
-        let source_sampler = render_device.create_sampler(&SamplerDescriptor {
-            mipmap_filter: FilterMode::Linear,
-            min_filter: FilterMode::Linear,
-            mag_filter: FilterMode::Linear,
-            ..default()
-        });
+    let source_sampler = render_device.create_sampler(&SamplerDescriptor {
+        mipmap_filter: FilterMode::Linear,
+        min_filter: FilterMode::Linear,
+        mag_filter: FilterMode::Linear,
+        ..default()
+    });
 
-        let chromatic_aberration_lut_sampler = render_device.create_sampler(&SamplerDescriptor {
-            mipmap_filter: FilterMode::Linear,
-            min_filter: FilterMode::Linear,
-            mag_filter: FilterMode::Linear,
-            ..default()
-        });
+    let chromatic_aberration_lut_sampler = render_device.create_sampler(&SamplerDescriptor {
+        mipmap_filter: FilterMode::Linear,
+        min_filter: FilterMode::Linear,
+        mag_filter: FilterMode::Linear,
+        ..default()
+    });
 
-        PostProcessingPipeline {
-            bind_group_layout,
-            source_sampler,
-            chromatic_aberration_lut_sampler,
-            fullscreen_shader: world.resource::<FullscreenShader>().clone(),
-            fragment_shader: load_embedded_asset!(world, "post_process.wgsl"),
-        }
-    }
+    commands.insert_resource(PostProcessingPipeline {
+        bind_group_layout,
+        source_sampler,
+        chromatic_aberration_lut_sampler,
+        fullscreen_shader: fullscreen_shader.clone(),
+        fragment_shader: load_embedded_asset!(asset_server.as_ref(), "post_process.wgsl"),
+    });
 }
 
 impl SpecializedRenderPipeline for PostProcessingPipeline {

--- a/crates/bevy_core_pipeline/src/tonemapping/mod.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/mod.rs
@@ -1,5 +1,5 @@
 use bevy_app::prelude::*;
-use bevy_asset::{embedded_asset, load_embedded_asset, Assets, Handle};
+use bevy_asset::{embedded_asset, load_embedded_asset, AssetServer, Assets, Handle};
 use bevy_ecs::prelude::*;
 use bevy_image::{CompressedImageFormats, Image, ImageSampler, ImageType};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
@@ -16,7 +16,7 @@ use bevy_render::{
     renderer::RenderDevice,
     texture::{FallbackImage, GpuImage},
     view::{ExtractedView, ViewTarget, ViewUniform},
-    Render, RenderApp, RenderSystems,
+    Render, RenderApp, RenderStartup, RenderSystems,
 };
 use bitflags::bitflags;
 #[cfg(not(feature = "tonemapping_luts"))]
@@ -95,17 +95,11 @@ impl Plugin for TonemappingPlugin {
         };
         render_app
             .init_resource::<SpecializedRenderPipelines<TonemappingPipeline>>()
+            .add_systems(RenderStartup, init_tonemapping_pipeline)
             .add_systems(
                 Render,
                 prepare_view_tonemapping_pipelines.in_set(RenderSystems::Prepare),
             );
-    }
-
-    fn finish(&self, app: &mut App) {
-        let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
-            return;
-        };
-        render_app.init_resource::<TonemappingPipeline>();
     }
 }
 
@@ -291,36 +285,37 @@ impl SpecializedRenderPipeline for TonemappingPipeline {
     }
 }
 
-impl FromWorld for TonemappingPipeline {
-    fn from_world(render_world: &mut World) -> Self {
-        let mut entries = DynamicBindGroupLayoutEntries::new_with_indices(
-            ShaderStages::FRAGMENT,
+pub fn init_tonemapping_pipeline(
+    mut commands: Commands,
+    render_device: Res<RenderDevice>,
+    fullscreen_shader: Res<FullscreenShader>,
+    asset_server: Res<AssetServer>,
+) {
+    let mut entries = DynamicBindGroupLayoutEntries::new_with_indices(
+        ShaderStages::FRAGMENT,
+        (
+            (0, uniform_buffer::<ViewUniform>(true)),
             (
-                (0, uniform_buffer::<ViewUniform>(true)),
-                (
-                    1,
-                    texture_2d(TextureSampleType::Float { filterable: false }),
-                ),
-                (2, sampler(SamplerBindingType::NonFiltering)),
+                1,
+                texture_2d(TextureSampleType::Float { filterable: false }),
             ),
-        );
-        let lut_layout_entries = get_lut_bind_group_layout_entries();
-        entries =
-            entries.extend_with_indices(((3, lut_layout_entries[0]), (4, lut_layout_entries[1])));
+            (2, sampler(SamplerBindingType::NonFiltering)),
+        ),
+    );
+    let lut_layout_entries = get_lut_bind_group_layout_entries();
+    entries = entries.extend_with_indices(((3, lut_layout_entries[0]), (4, lut_layout_entries[1])));
 
-        let render_device = render_world.resource::<RenderDevice>();
-        let tonemap_texture_bind_group = render_device
-            .create_bind_group_layout("tonemapping_hdr_texture_bind_group_layout", &entries);
+    let tonemap_texture_bind_group = render_device
+        .create_bind_group_layout("tonemapping_hdr_texture_bind_group_layout", &entries);
 
-        let sampler = render_device.create_sampler(&SamplerDescriptor::default());
+    let sampler = render_device.create_sampler(&SamplerDescriptor::default());
 
-        TonemappingPipeline {
-            texture_bind_group: tonemap_texture_bind_group,
-            sampler,
-            fullscreen_shader: render_world.resource::<FullscreenShader>().clone(),
-            fragment_shader: load_embedded_asset!(render_world, "tonemapping.wgsl"),
-        }
-    }
+    commands.insert_resource(TonemappingPipeline {
+        texture_bind_group: tonemap_texture_bind_group,
+        sampler,
+        fullscreen_shader: fullscreen_shader.clone(),
+        fragment_shader: load_embedded_asset!(asset_server.as_ref(), "tonemapping.wgsl"),
+    });
 }
 
 #[derive(Component)]

--- a/release-content/migration-guides/render_startup.md
+++ b/release-content/migration-guides/render_startup.md
@@ -1,6 +1,6 @@
 ---
 title: Many render resources now initialized in `RenderStartup`
-pull_requests: [19841, 19926, 19885, 19886, 19897, 19898, 19901, 20147]
+pull_requests: [19841, 19926, 19885, 19886, 19897, 19898, 19901, 20002, 20147]
 ---
 
 Many render resources are **no longer present** during `Plugin::finish`. Instead they are
@@ -15,6 +15,15 @@ The following are the (public) resources that are now initialized in `RenderStar
 - `FxaaPipeline`
 - `SmaaPipelines`
 - `TaaPipeline`
+- `AutoExposurePipeline`
+- `MotionBlurPipeline`
+- `SkyboxPrepassPipeline`
+- `BlitPipeline`
+- `DepthOfFieldGlobalBindGroupLayout`
+- `DepthPyramidDummyTexture`
+- `OitBuffers`
+- `PostProcessingPipeline`
+- `TonemappingPipeline`
 - `BoxShadowPipeline`
 - `GradientPipeline`
 - `UiPipeline`


### PR DESCRIPTION
# Objective

- Progress towards #19887.

## Solution

- Convert `FromWorld` impls into systems.
- Run those systems in `RenderStartup`.

## Testing

- Ran `bloom_3d`, `auto_exposure`, `depth_of_field`, `motion_blur`, `skybox`, `post_processing`, and `tonemapping` examples and they all work :)