### PR TITLE
Initialize `Window` by observer instead of by plugin fields

### DIFF
--- a/crates/bevy_render/src/view/window/mod.rs
+++ b/crates/bevy_render/src/view/window/mod.rs
@@ -101,19 +101,11 @@ impl DerefMut for ExtractedWindows {
 fn extract_windows(
     mut extracted_windows: ResMut<ExtractedWindows>,
     mut closing: Extract<EventReader<WindowClosing>>,
-    windows: Extract<
-        Query<(
-            Entity,
-            &Window,
-            &PresentMode,
-            &RawHandleWrapper,
-            Option<&PrimaryWindow>,
-        )>,
-    >,
+    windows: Extract<Query<(Entity, &Window, &RawHandleWrapper, Option<&PrimaryWindow>)>>,
     mut removed: Extract<RemovedComponents<RawHandleWrapper>>,
     mut window_surfaces: ResMut<WindowSurfaces>,
 ) {
-    for (entity, window, present_mode, handle, primary) in windows.iter() {
+    for (entity, window, handle, primary) in windows.iter() {
         if primary.is_some() {
             extracted_windows.primary = Some(entity);
         }
@@ -128,7 +120,7 @@ fn extract_windows(
             handle: handle.clone(),
             physical_width: new_width,
             physical_height: new_height,
-            present_mode: *present_mode,
+            present_mode: window.present_mode,
             desired_maximum_frame_latency: window.desired_maximum_frame_latency,
             swap_chain_texture: None,
             swap_chain_texture_view: None,
@@ -142,7 +134,8 @@ fn extract_windows(
         extracted_window.swap_chain_texture_view = None;
         extracted_window.size_changed = new_width != extracted_window.physical_width
             || new_height != extracted_window.physical_height;
-        extracted_window.present_mode_changed = *present_mode != extracted_window.present_mode;
+        extracted_window.present_mode_changed =
+            window.present_mode != extracted_window.present_mode;
 
         if extracted_window.size_changed {
             debug!(
@@ -159,9 +152,9 @@ fn extract_windows(
         if extracted_window.present_mode_changed {
             debug!(
                 "Window Present Mode changed from {:?} to {:?}",
-                extracted_window.present_mode, *present_mode
+                extracted_window.present_mode, window.present_mode
             );
-            extracted_window.present_mode = *present_mode;
+            extracted_window.present_mode = window.present_mode;
         }
     }
 

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -57,7 +57,6 @@ impl Default for WindowPlugin {
     fn default() -> Self {
         WindowPlugin {
             primary_window: Some(Window::default()),
-            primary_cursor_options: Some(CursorOptions::default()),
             exit_condition: ExitCondition::OnAllClosed,
             close_when_requested: true,
         }
@@ -76,13 +75,6 @@ pub struct WindowPlugin {
     /// Note that if there are no windows the App will exit (by default) due to
     /// [`exit_on_all_closed`].
     pub primary_window: Option<Window>,
-
-    /// Settings for the cursor on the primary window.
-    ///
-    /// Defaults to `Some(CursorOptions::default())`.
-    ///
-    /// Has no effect if [`WindowPlugin::primary_window`] is `None`.
-    pub primary_cursor_options: Option<CursorOptions>,
 
     /// Whether to exit the app when there are no open windows.
     ///
@@ -135,9 +127,6 @@ impl Plugin for WindowPlugin {
                 PrimaryWindow,
                 RawHandleWrapperHolder(Arc::new(Mutex::new(None))),
             ));
-            if let Some(primary_cursor_options) = &self.primary_cursor_options {
-                entity_commands.insert(primary_cursor_options.clone());
-            }
         }
 
         match self.exit_condition {

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -19,6 +19,7 @@ extern crate alloc;
 
 use alloc::sync::Arc;
 
+use bevy_ecs::system::Commands;
 use bevy_platform::sync::Mutex;
 
 mod event;
@@ -134,10 +135,9 @@ impl Plugin for WindowPlugin {
             .add_event::<AppLifecycle>();
 
         if self.spawn_primary_window {
-            app.world_mut().spawn((
-                PrimaryWindow,
-                RawHandleWrapperHolder(Arc::new(Mutex::new(None))),
-            ));
+            app.add_systems(PreStartup, |mut commands: Commands| {
+                commands.spawn(PrimaryWindow);
+            });
         }
 
         match self.exit_condition {

--- a/crates/bevy_window/src/raw_handle.rs
+++ b/crates/bevy_window/src/raw_handle.rs
@@ -162,5 +162,5 @@ impl HasDisplayHandle for ThreadLockedRawWindowHandleWrapper {
 }
 
 /// Holder of the [`RawHandleWrapper`] with wrappers, to allow use in asynchronous context
-#[derive(Debug, Clone, Component)]
+#[derive(Debug, Clone, Component, Default)]
 pub struct RawHandleWrapperHolder(pub Arc<Mutex<Option<RawHandleWrapper>>>);

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -161,8 +161,10 @@ impl ContainsEntity for NormalizedWindowRef {
     all(feature = "serialize", feature = "bevy_reflect"),
     reflect(Serialize, Deserialize)
 )]
-#[require(CursorOptions, PresentMode)]
+#[require(CursorOptions)]
 pub struct Window {
+    /// What presentation mode to give the window.
+    pub present_mode: PresentMode,
     /// Which fullscreen or windowing mode should be used.
     pub mode: WindowMode,
     /// Where the window should be placed.
@@ -468,6 +470,7 @@ impl Default for Window {
     fn default() -> Self {
         Self {
             title: DEFAULT_WINDOW_TITLE.to_owned(),
+            present_mode: PresentMode::default(),
             name: None,
             mode: Default::default(),
             position: Default::default(),
@@ -1205,11 +1208,11 @@ pub enum VideoModeSelection {
 /// [`AutoVsync`]: PresentMode::AutoVsync
 /// [`AutoNoVsync`]: PresentMode::AutoNoVsync
 #[repr(C)]
-#[derive(Component, Default, Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Default, Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(Reflect),
-    reflect(Component, Debug, PartialEq, Hash, Clone)
+    reflect(Debug, PartialEq, Hash, Clone)
 )]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -160,10 +160,8 @@ impl ContainsEntity for NormalizedWindowRef {
     all(feature = "serialize", feature = "bevy_reflect"),
     reflect(Serialize, Deserialize)
 )]
-#[require(CursorOptions)]
+#[require(CursorOptions, PresentMode)]
 pub struct Window {
-    /// What presentation mode to give the window.
-    pub present_mode: PresentMode,
     /// Which fullscreen or windowing mode should be used.
     pub mode: WindowMode,
     /// Where the window should be placed.
@@ -470,7 +468,6 @@ impl Default for Window {
         Self {
             title: DEFAULT_WINDOW_TITLE.to_owned(),
             name: None,
-            present_mode: Default::default(),
             mode: Default::default(),
             position: Default::default(),
             resolution: Default::default(),
@@ -1207,11 +1204,11 @@ pub enum VideoModeSelection {
 /// [`AutoVsync`]: PresentMode::AutoVsync
 /// [`AutoNoVsync`]: PresentMode::AutoNoVsync
 #[repr(C)]
-#[derive(Default, Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Component, Default, Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(Reflect),
-    reflect(Debug, PartialEq, Hash, Clone)
+    reflect(Component, Debug, PartialEq, Hash, Clone)
 )]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -20,7 +20,7 @@ use {
 #[cfg(all(feature = "serialize", feature = "bevy_reflect"))]
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 
-use crate::VideoMode;
+use crate::{RawHandleWrapperHolder, VideoMode};
 
 /// Default string used for the window title.
 ///
@@ -53,6 +53,7 @@ static DEFAULT_WINDOW_TITLE: LazyLock<String> = LazyLock::new(|| {
     derive(Reflect),
     reflect(Component, Debug, Default, PartialEq, Clone)
 )]
+#[require(Window, RawHandleWrapperHolder)]
 pub struct PrimaryWindow;
 
 /// Reference to a [`Window`], whether it be a direct link to a specific entity or

--- a/examples/3d/anisotropy.rs
+++ b/examples/3d/anisotropy.rs
@@ -81,13 +81,7 @@ impl Display for Scene {
 fn main() {
     App::new()
         .init_resource::<AppStatus>()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                title: "Bevy Anisotropy Example".into(),
-                ..default()
-            }),
-            ..default()
-        }))
+        .add_plugins(DefaultPlugins)
         .add_systems(Startup, setup)
         .add_systems(Update, create_material_variants)
         .add_systems(Update, animate_light)

--- a/examples/3d/clustered_decals.rs
+++ b/examples/3d/clustered_decals.rs
@@ -122,13 +122,7 @@ impl MaterialExtension for CustomDecalExtension {
 /// Entry point.
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                title: "Bevy Clustered Decals Example".into(),
-                ..default()
-            }),
-            ..default()
-        }))
+        .add_plugins(DefaultPlugin)
         .add_plugins(MaterialPlugin::<
             ExtendedMaterial<StandardMaterial, CustomDecalExtension>,
         >::default())

--- a/examples/3d/depth_of_field.rs
+++ b/examples/3d/depth_of_field.rs
@@ -52,13 +52,7 @@ struct AppSettings {
 fn main() {
     App::new()
         .init_resource::<AppSettings>()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                title: "Bevy Depth of Field Example".to_string(),
-                ..default()
-            }),
-            ..default()
-        }))
+        .add_plugins(DefaultPlugins)
         .add_systems(Startup, setup)
         .add_systems(Update, tweak_scene)
         .add_systems(

--- a/examples/3d/fog_volumes.rs
+++ b/examples/3d/fog_volumes.rs
@@ -15,13 +15,7 @@ use bevy::{
 /// Entry point.
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                title: "Bevy Fog Volumes Example".into(),
-                ..default()
-            }),
-            ..default()
-        }))
+        .add_plugins(DefaultPlugins)
         .insert_resource(AmbientLight::NONE)
         .add_systems(Startup, setup)
         .add_systems(Update, rotate_camera)

--- a/examples/3d/irradiance_volumes.rs
+++ b/examples/3d/irradiance_volumes.rs
@@ -147,13 +147,7 @@ struct VoxelVisualizationIrradianceVolumeInfo {
 fn main() {
     // Create the example app.
     App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                title: "Bevy Irradiance Volumes Example".into(),
-                ..default()
-            }),
-            ..default()
-        }))
+        .add_plugins(DefaultPlugins)
         .add_plugins(MaterialPlugin::<VoxelVisualizationMaterial>::default())
         .init_resource::<AppStatus>()
         .init_resource::<ExampleAssets>()

--- a/examples/3d/light_textures.rs
+++ b/examples/3d/light_textures.rs
@@ -105,13 +105,7 @@ struct HelpText;
 /// Entry point.
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                title: "Bevy Light Textures Example".into(),
-                ..default()
-            }),
-            ..default()
-        }))
+        .add_plugins(DefaultPlugins)
         .init_resource::<AppStatus>()
         .add_event::<WidgetClickEvent<Selection>>()
         .add_event::<WidgetClickEvent<Visibility>>()

--- a/examples/3d/mixed_lighting.rs
+++ b/examples/3d/mixed_lighting.rs
@@ -116,13 +116,7 @@ const INITIAL_SPHERE_POSITION: Vec3 = vec3(0.0, 0.5233223, 0.0);
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                title: "Bevy Mixed Lighting Example".into(),
-                ..default()
-            }),
-            ..default()
-        }))
+        .add_plugins(DefaultPlugins)
         .add_plugins(MeshPickingPlugin)
         .insert_resource(AmbientLight {
             color: ClearColor::default().0,

--- a/examples/3d/occlusion_culling.rs
+++ b/examples/3d/occlusion_culling.rs
@@ -182,13 +182,6 @@ fn main() {
     App::new()
         .add_plugins(
             DefaultPlugins
-                .set(WindowPlugin {
-                    primary_window: Some(Window {
-                        title: "Bevy Occlusion Culling Example".into(),
-                        ..default()
-                    }),
-                    ..default()
-                })
                 .set(RenderPlugin {
                     debug_flags: render_debug_flags,
                     ..default()

--- a/examples/3d/pcss.rs
+++ b/examples/3d/pcss.rs
@@ -113,13 +113,7 @@ enum AppSetting {
 fn main() {
     App::new()
         .init_resource::<AppStatus>()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                title: "Bevy Percentage Closer Soft Shadows Example".into(),
-                ..default()
-            }),
-            ..default()
-        }))
+        .add_plugins(DefaultPlugins)
         .add_event::<WidgetClickEvent<AppSetting>>()
         .add_systems(Startup, setup)
         .add_systems(Update, widgets::handle_ui_interactions::<AppSetting>)

--- a/examples/3d/post_processing.rs
+++ b/examples/3d/post_processing.rs
@@ -27,13 +27,7 @@ struct AppSettings {
 fn main() {
     App::new()
         .init_resource::<AppSettings>()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                title: "Bevy Chromatic Aberration Example".into(),
-                ..default()
-            }),
-            ..default()
-        }))
+        .add_plugins(DefaultPlugins)
         .add_systems(Startup, setup)
         .add_systems(Update, handle_keyboard_input)
         .add_systems(

--- a/examples/3d/scrolling_fog.rs
+++ b/examples/3d/scrolling_fog.rs
@@ -24,13 +24,7 @@ use bevy::{
 /// Initializes the example.
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                title: "Bevy Scrolling Fog".into(),
-                ..default()
-            }),
-            ..default()
-        }))
+        .add_plugins(DefaultPlugins)
         .insert_resource(DirectionalLightShadowMap { size: 4096 })
         .add_systems(Startup, setup)
         .add_systems(Update, scroll_fog)

--- a/examples/3d/specular_tint.rs
+++ b/examples/3d/specular_tint.rs
@@ -50,13 +50,7 @@ enum TintType {
 /// The entry point.
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                title: "Bevy Specular Tint Example".into(),
-                ..default()
-            }),
-            ..default()
-        }))
+        .add_plugins(DefaultPlugins)
         .init_resource::<AppAssets>()
         .init_resource::<AppStatus>()
         .insert_resource(AmbientLight {

--- a/examples/3d/ssr.rs
+++ b/examples/3d/ssr.rs
@@ -101,13 +101,7 @@ fn main() {
     App::new()
         .insert_resource(DefaultOpaqueRendererMethod::deferred())
         .init_resource::<AppSettings>()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                title: "Bevy Screen Space Reflections Example".into(),
-                ..default()
-            }),
-            ..default()
-        }))
+        .add_plugins(DefaultPlugins)
         .add_plugins(MaterialPlugin::<ExtendedMaterial<StandardMaterial, Water>>::default())
         .add_systems(Startup, setup)
         .add_systems(Update, rotate_model)

--- a/examples/3d/visibility_range.rs
+++ b/examples/3d/visibility_range.rs
@@ -71,13 +71,7 @@ struct AppStatus {
 // Sets up the app.
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                title: "Bevy Visibility Range Example".into(),
-                ..default()
-            }),
-            ..default()
-        }))
+        .add_plugins(DefaultPlugins)
         .init_resource::<AppStatus>()
         .add_systems(Startup, setup)
         .add_systems(

--- a/examples/animation/animation_graph.rs
+++ b/examples/animation/animation_graph.rs
@@ -74,13 +74,7 @@ fn main() {
     let args = Args::from_args(&[], &[]).unwrap();
 
     App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                title: "Bevy Animation Graph Example".into(),
-                ..default()
-            }),
-            ..default()
-        }))
+        .add_plugins(DefaultPlugins)
         .add_systems(Startup, (setup_assets, setup_scene, setup_ui))
         .add_systems(Update, init_animations)
         .add_systems(

--- a/examples/animation/animation_masks.rs
+++ b/examples/animation/animation_masks.rs
@@ -94,13 +94,7 @@ struct MaskGroupState {
 // The application entry point.
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                title: "Bevy Animation Masks Example".into(),
-                ..default()
-            }),
-            ..default()
-        }))
+        .add_plugins(DefaultPlugins)
         .add_systems(Startup, (setup_scene, setup_ui))
         .add_systems(Update, setup_animation_graph_once_loaded)
         .add_systems(Update, handle_button_toggles)

--- a/examples/animation/morph_targets.rs
+++ b/examples/animation/morph_targets.rs
@@ -12,13 +12,7 @@ use std::f32::consts::PI;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                title: "morph targets".to_string(),
-                ..default()
-            }),
-            ..default()
-        }))
+        .add_plugins(DefaultPlugins)
         .insert_resource(AmbientLight {
             brightness: 150.0,
             ..default()

--- a/examples/app/headless_renderer.rs
+++ b/examples/app/headless_renderer.rs
@@ -89,7 +89,7 @@ fn main() {
                 // Not strictly necessary, as the inclusion of ScheduleRunnerPlugin below
                 // replaces the bevy_winit app runner and so a window is never created.
                 .set(WindowPlugin {
-                    primary_window: None,
+                    spawn_primary_window: false,
                     // Don’t automatically exit due to having no windows.
                     // Instead, the code in `update()` will explicitly produce an `AppExit` event.
                     exit_condition: bevy::window::ExitCondition::DontExit,

--- a/examples/app/return_after_run.rs
+++ b/examples/app/return_after_run.rs
@@ -5,21 +5,21 @@
 //! - `App::run()` will never return on iOS and Web.
 //! - It is not possible to recreate a window after the event loop has been terminated.
 
-use bevy::prelude::*;
+use bevy::{prelude::*, window::PrimaryWindow};
 
 fn main() {
     println!("Running Bevy App");
     App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                title: "Close the window to return to the main function".into(),
-                ..default()
-            }),
-            ..default()
-        }))
+        .add_plugins(DefaultPlugins)
+        .add_observer(configure_window)
         .add_systems(Update, system)
         .run();
     println!("Bevy App has exited. We are back in our main function.");
+}
+
+fn configure_window(trigger: On<Add, PrimaryWindow>, mut window: Query<&mut Window>) {
+    let mut window = window.get_mut(trigger.target()).unwrap();
+    window.title = "Close the window to return to the main function".into();
 }
 
 fn system() {

--- a/examples/games/desk_toy.rs
+++ b/examples/games/desk_toy.rs
@@ -18,19 +18,11 @@ use bevy::window::CompositeAlphaMode;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                title: "Bevy Desk Toy".into(),
-                transparent: true,
-                #[cfg(target_os = "macos")]
-                composite_alpha_mode: CompositeAlphaMode::PostMultiplied,
-                ..default()
-            }),
-            ..default()
-        }))
+        .add_plugins(DefaultPlugins)
         .insert_resource(ClearColor(WINDOW_CLEAR_COLOR))
         .insert_resource(WindowTransparency(false))
         .insert_resource(CursorWorldPos(None))
+        .add_observer(configure_window)
         .add_systems(Startup, setup)
         .add_systems(
             Update,
@@ -49,6 +41,16 @@ fn main() {
                 .chain(),
         )
         .run();
+}
+
+fn configure_window(trigger: On<Add, PrimaryWindow>, mut window: Query<&mut Window>) {
+    let mut window = window.get_mut(trigger.target()).unwrap();
+    window.title = "Bevy Desk Toy".into();
+    window.transparent = true;
+    #[cfg(target_os = "macos")]
+    {
+        window.composite_alpha_mode = CompositeAlphaMode::PostMultiplied;
+    }
 }
 
 /// Whether the window is transparent

--- a/examples/mobile/src/lib.rs
+++ b/examples/mobile/src/lib.rs
@@ -15,35 +15,16 @@ use bevy::{
 /// `main.rs`.
 pub fn main() {
     let mut app = App::new();
-    app.add_plugins(
-        DefaultPlugins
-            .set(LogPlugin {
-                // This will show some log events from Bevy to the native logger.
-                level: Level::DEBUG,
-                filter: "wgpu=error,bevy_render=info,bevy_ecs=trace".to_string(),
-                ..Default::default()
-            })
-            .set(WindowPlugin {
-                primary_window: Some(Window {
-                    resizable: false,
-                    mode: WindowMode::BorderlessFullscreen(MonitorSelection::Primary),
-                    // on iOS, gestures must be enabled.
-                    // This doesn't work on Android
-                    recognize_rotation_gesture: true,
-                    // Only has an effect on iOS
-                    prefers_home_indicator_hidden: true,
-                    // Only has an effect on iOS
-                    prefers_status_bar_hidden: true,
-                    // Only has an effect on iOS
-                    preferred_screen_edges_deferring_system_gestures: ScreenEdge::Bottom,
-                    ..default()
-                }),
-                ..default()
-            }),
-    )
+    app.add_plugins(DefaultPlugins.set(LogPlugin {
+        // This will show some log events from Bevy to the native logger.
+        level: Level::DEBUG,
+        filter: "wgpu=error,bevy_render=info,bevy_ecs=trace".to_string(),
+        ..Default::default()
+    }))
     // Make the winit loop wait more aggressively when no user input is received
     // This can help reduce cpu usage on mobile devices
     .insert_resource(WinitSettings::mobile())
+    .add_observer(configure_window)
     .add_systems(Startup, (setup_scene, setup_music))
     .add_systems(
         Update,
@@ -56,6 +37,22 @@ pub fn main() {
         ),
     )
     .run();
+}
+
+fn configure_window(trigger: On<Add, PrimaryWindow>, mut window: Query<&mut Window>) {
+    let mut window = window.get_mut(trigger.target()).unwrap();
+
+    window.resizable = false;
+    window.mode = WindowMode::BorderlessFullscreen(MonitorSelection::Primary);
+    // on iOS, gestures must be enabled.
+    // This doesn't work on Android
+    window.recognize_rotation_gesture = true;
+    // Only has an effect on iOS
+    window.prefers_home_indicator_hidden = true;
+    // Only has an effect on iOS
+    window.prefers_status_bar_hidden = true;
+    // Only has an effect on iOS
+    window.preferred_screen_edges_deferring_system_gestures = ScreenEdge::Bottom;
 }
 
 fn touch_camera(

--- a/examples/shader/compute_shader_game_of_life.rs
+++ b/examples/shader/compute_shader_game_of_life.rs
@@ -14,6 +14,7 @@ use bevy::{
         texture::GpuImage,
         Render, RenderApp, RenderSystems,
     },
+    window::PrimaryWindow,
 };
 use std::borrow::Cow;
 
@@ -28,26 +29,23 @@ fn main() {
     App::new()
         .insert_resource(ClearColor(Color::BLACK))
         .add_plugins((
-            DefaultPlugins
-                .set(WindowPlugin {
-                    primary_window: Some(Window {
-                        resolution: (
-                            (SIZE.0 * DISPLAY_FACTOR) as f32,
-                            (SIZE.1 * DISPLAY_FACTOR) as f32,
-                        )
-                            .into(),
-                        // uncomment for unthrottled FPS
-                        // present_mode: bevy::window::PresentMode::AutoNoVsync,
-                        ..default()
-                    }),
-                    ..default()
-                })
-                .set(ImagePlugin::default_nearest()),
+            DefaultPlugins.set(ImagePlugin::default_nearest()),
             GameOfLifeComputePlugin,
         ))
+        .add_observer(configure_window)
         .add_systems(Startup, setup)
         .add_systems(Update, switch_textures)
         .run();
+}
+
+fn configure_window(trigger: On<Add, PrimaryWindow>, mut window: Query<&mut Window>) {
+    let mut window = window.get_mut(trigger.target()).unwrap();
+    window.resolution = (
+        (SIZE.0 * DISPLAY_FACTOR) as f32,
+        (SIZE.1 * DISPLAY_FACTOR) as f32,
+    )
+        .into();
+    // Optional: set the present mode to AutoNoVsync for unthrottled FPS
 }
 
 fn setup(mut commands: Commands, mut images: ResMut<Assets<Image>>) {

--- a/examples/stress_tests/bevymark.rs
+++ b/examples/stress_tests/bevymark.rs
@@ -15,7 +15,7 @@ use bevy::{
         render_resource::{Extent3d, TextureDimension, TextureFormat},
     },
     sprite::AlphaMode2d,
-    window::{PresentMode, WindowResolution},
+    window::{PresentMode, PrimaryWindow, WindowResolution},
     winit::{UpdateMode, WinitSettings},
 };
 use rand::{seq::SliceRandom, Rng, SeedableRng};
@@ -132,16 +132,7 @@ fn main() {
 
     App::new()
         .add_plugins((
-            DefaultPlugins.set(WindowPlugin {
-                primary_window: Some(Window {
-                    title: "BevyMark".into(),
-                    resolution: WindowResolution::new(1920.0, 1080.0)
-                        .with_scale_factor_override(1.0),
-                    present_mode: PresentMode::AutoNoVsync,
-                    ..default()
-                }),
-                ..default()
-            }),
+            DefaultPlugins,
             FrameTimeDiagnosticsPlugin::default(),
             LogDiagnosticsPlugin::default(),
         ))
@@ -154,6 +145,7 @@ fn main() {
             count: 0,
             color: Color::WHITE,
         })
+        .add_observer(configure_window)
         .add_systems(Startup, setup)
         .add_systems(FixedUpdate, scheduled_spawner)
         .add_systems(
@@ -169,6 +161,16 @@ fn main() {
             FIXED_TIMESTEP,
         )))
         .run();
+}
+
+fn configure_window(
+    trigger: On<Add, PrimaryWindow>,
+    mut window: Query<(&mut Window, &mut PresentMode)>,
+) {
+    let (mut window, mut present_mode) = window.get_mut(trigger.target()).unwrap();
+    window.title = "BevyMark".to_string();
+    window.resolution = WindowResolution::new(1920.0, 1080.0).with_scale_factor_override(1.0);
+    *present_mode = PresentMode::AutoNoVsync;
 }
 
 #[derive(Resource)]

--- a/examples/stress_tests/bevymark.rs
+++ b/examples/stress_tests/bevymark.rs
@@ -163,14 +163,11 @@ fn main() {
         .run();
 }
 
-fn configure_window(
-    trigger: On<Add, PrimaryWindow>,
-    mut window: Query<(&mut Window, &mut PresentMode)>,
-) {
-    let (mut window, mut present_mode) = window.get_mut(trigger.target()).unwrap();
+fn configure_window(trigger: On<Add, PrimaryWindow>, mut window: Query<&mut Window>) {
+    let mut window = window.get_mut(trigger.target()).unwrap();
     window.title = "BevyMark".to_string();
     window.resolution = WindowResolution::new(1920.0, 1080.0).with_scale_factor_override(1.0);
-    *present_mode = PresentMode::AutoNoVsync;
+    window.present_mode = PresentMode::AutoNoVsync;
 }
 
 #[derive(Resource)]

--- a/examples/stress_tests/many_animated_sprites.rs
+++ b/examples/stress_tests/many_animated_sprites.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     prelude::*,
-    window::{PresentMode, WindowResolution},
+    window::{PresentMode, PrimaryWindow, WindowResolution},
     winit::{UpdateMode, WinitSettings},
 };
 
@@ -22,20 +22,13 @@ fn main() {
         .add_plugins((
             LogDiagnosticsPlugin::default(),
             FrameTimeDiagnosticsPlugin::default(),
-            DefaultPlugins.set(WindowPlugin {
-                primary_window: Some(Window {
-                    present_mode: PresentMode::AutoNoVsync,
-                    resolution: WindowResolution::new(1920.0, 1080.0)
-                        .with_scale_factor_override(1.0),
-                    ..default()
-                }),
-                ..default()
-            }),
+            DefaultPlugins,
         ))
         .insert_resource(WinitSettings {
             focused_mode: UpdateMode::Continuous,
             unfocused_mode: UpdateMode::Continuous,
         })
+        .add_observer(configure_window)
         .add_systems(Startup, setup)
         .add_systems(
             Update,
@@ -46,6 +39,15 @@ fn main() {
             ),
         )
         .run();
+}
+
+fn configure_window(
+    trigger: On<Add, PrimaryWindow>,
+    mut window: Query<(&mut Window, &mut PresentMode)>,
+) {
+    let (mut window, mut present_mode) = window.get_mut(trigger.target()).unwrap();
+    window.resolution = WindowResolution::new(1920.0, 1080.0).with_scale_factor_override(1.0);
+    *present_mode = PresentMode::AutoNoVsync;
 }
 
 fn setup(

--- a/examples/stress_tests/many_animated_sprites.rs
+++ b/examples/stress_tests/many_animated_sprites.rs
@@ -41,13 +41,10 @@ fn main() {
         .run();
 }
 
-fn configure_window(
-    trigger: On<Add, PrimaryWindow>,
-    mut window: Query<(&mut Window, &mut PresentMode)>,
-) {
-    let (mut window, mut present_mode) = window.get_mut(trigger.target()).unwrap();
+fn configure_window(trigger: On<Add, PrimaryWindow>, mut window: Query<&mut Window>) {
+    let mut window = window.get_mut(trigger.target()).unwrap();
     window.resolution = WindowResolution::new(1920.0, 1080.0).with_scale_factor_override(1.0);
-    *present_mode = PresentMode::AutoNoVsync;
+    window.present_mode = PresentMode::AutoNoVsync;
 }
 
 fn setup(

--- a/examples/stress_tests/many_buttons.rs
+++ b/examples/stress_tests/many_buttons.rs
@@ -6,7 +6,7 @@ use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     prelude::*,
     text::TextColor,
-    window::{PresentMode, WindowResolution},
+    window::{PresentMode, PrimaryWindow, WindowResolution},
     winit::{UpdateMode, WinitSettings},
 };
 
@@ -73,14 +73,7 @@ fn main() {
     let mut app = App::new();
 
     app.add_plugins((
-        DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                present_mode: PresentMode::AutoNoVsync,
-                resolution: WindowResolution::new(1920.0, 1080.0).with_scale_factor_override(1.0),
-                ..default()
-            }),
-            ..default()
-        }),
+        DefaultPlugins,
         FrameTimeDiagnosticsPlugin::default(),
         LogDiagnosticsPlugin::default(),
     ))
@@ -88,6 +81,7 @@ fn main() {
         focused_mode: UpdateMode::Continuous,
         unfocused_mode: UpdateMode::Continuous,
     })
+    .add_observer(configure_window)
     .add_systems(Update, (button_system, set_text_colors_changed));
 
     if !args.no_camera {
@@ -127,6 +121,15 @@ fn main() {
     }
 
     app.insert_resource(args).run();
+}
+
+fn configure_window(
+    trigger: On<Add, PrimaryWindow>,
+    mut window: Query<(&mut Window, &mut PresentMode)>,
+) {
+    let (mut window, mut present_mode) = window.get_mut(trigger.target()).unwrap();
+    window.resolution = WindowResolution::new(1920.0, 1080.0).with_scale_factor_override(1.0);
+    *present_mode = PresentMode::AutoNoVsync;
 }
 
 fn set_text_colors_changed(mut colors: Query<&mut TextColor>) {

--- a/examples/stress_tests/many_buttons.rs
+++ b/examples/stress_tests/many_buttons.rs
@@ -123,13 +123,10 @@ fn main() {
     app.insert_resource(args).run();
 }
 
-fn configure_window(
-    trigger: On<Add, PrimaryWindow>,
-    mut window: Query<(&mut Window, &mut PresentMode)>,
-) {
-    let (mut window, mut present_mode) = window.get_mut(trigger.target()).unwrap();
+fn configure_window(trigger: On<Add, PrimaryWindow>, mut window: Query<&mut Window>) {
+    let mut window = window.get_mut(trigger.target()).unwrap();
     window.resolution = WindowResolution::new(1920.0, 1080.0).with_scale_factor_override(1.0);
-    *present_mode = PresentMode::AutoNoVsync;
+    window.present_mode = PresentMode::AutoNoVsync;
 }
 
 fn set_text_colors_changed(mut colors: Query<&mut TextColor>) {

--- a/examples/stress_tests/many_cameras_lights.rs
+++ b/examples/stress_tests/many_cameras_lights.rs
@@ -18,13 +18,10 @@ fn main() {
         .run();
 }
 
-fn configure_window(
-    trigger: On<Add, PrimaryWindow>,
-    mut window: Query<(&mut Window, &mut PresentMode)>,
-) {
-    let (mut window, mut present_mode) = window.get_mut(trigger.target()).unwrap();
+fn configure_window(trigger: On<Add, PrimaryWindow>, mut window: Query<&mut Window>) {
+    let mut window = window.get_mut(trigger.target()).unwrap();
     window.resolution = WindowResolution::new(1920.0, 1080.0).with_scale_factor_override(1.0);
-    *present_mode = PresentMode::AutoNoVsync;
+    window.present_mode = PresentMode::AutoNoVsync;
 }
 
 const CAMERA_ROWS: usize = 4;

--- a/examples/stress_tests/many_cameras_lights.rs
+++ b/examples/stress_tests/many_cameras_lights.rs
@@ -6,22 +6,25 @@ use bevy::{
     math::ops::{cos, sin},
     prelude::*,
     render::camera::Viewport,
-    window::{PresentMode, WindowResolution},
+    window::{PresentMode, PrimaryWindow, WindowResolution},
 };
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                present_mode: PresentMode::AutoNoVsync,
-                resolution: WindowResolution::new(1920.0, 1080.0).with_scale_factor_override(1.0),
-                ..default()
-            }),
-            ..default()
-        }))
+        .add_plugins(DefaultPlugins)
+        .add_observer(configure_window)
         .add_systems(Startup, setup)
         .add_systems(Update, rotate_cameras)
         .run();
+}
+
+fn configure_window(
+    trigger: On<Add, PrimaryWindow>,
+    mut window: Query<(&mut Window, &mut PresentMode)>,
+) {
+    let (mut window, mut present_mode) = window.get_mut(trigger.target()).unwrap();
+    window.resolution = WindowResolution::new(1920.0, 1080.0).with_scale_factor_override(1.0);
+    *present_mode = PresentMode::AutoNoVsync;
 }
 
 const CAMERA_ROWS: usize = 4;

--- a/examples/stress_tests/many_cubes.rs
+++ b/examples/stress_tests/many_cubes.rs
@@ -22,7 +22,7 @@ use bevy::{
         render_resource::{Extent3d, TextureDimension, TextureFormat},
         view::{NoCpuCulling, NoFrustumCulling, NoIndirectDrawing},
     },
-    window::{PresentMode, WindowResolution},
+    window::{PresentMode, PrimaryWindow, WindowResolution},
     winit::{UpdateMode, WinitSettings},
 };
 use rand::{seq::SliceRandom, Rng, SeedableRng};
@@ -106,14 +106,7 @@ fn main() {
 
     let mut app = App::new();
     app.add_plugins((
-        DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                present_mode: PresentMode::AutoNoVsync,
-                resolution: WindowResolution::new(1920.0, 1080.0).with_scale_factor_override(1.0),
-                ..default()
-            }),
-            ..default()
-        }),
+        DefaultPlugins,
         FrameTimeDiagnosticsPlugin::default(),
         LogDiagnosticsPlugin::default(),
     ))
@@ -121,6 +114,7 @@ fn main() {
         focused_mode: UpdateMode::Continuous,
         unfocused_mode: UpdateMode::Continuous,
     })
+    .add_observer(configure_window)
     .add_systems(Startup, setup)
     .add_systems(Update, (move_camera, print_mesh_count));
 
@@ -129,6 +123,15 @@ fn main() {
     }
 
     app.insert_resource(args).run();
+}
+
+fn configure_window(
+    trigger: On<Add, PrimaryWindow>,
+    mut window: Query<(&mut Window, &mut PresentMode)>,
+) {
+    let (mut window, mut present_mode) = window.get_mut(trigger.target()).unwrap();
+    window.resolution = WindowResolution::new(1920.0, 1080.0).with_scale_factor_override(1.0);
+    *present_mode = PresentMode::AutoNoVsync;
 }
 
 const WIDTH: usize = 200;

--- a/examples/stress_tests/many_cubes.rs
+++ b/examples/stress_tests/many_cubes.rs
@@ -125,13 +125,10 @@ fn main() {
     app.insert_resource(args).run();
 }
 
-fn configure_window(
-    trigger: On<Add, PrimaryWindow>,
-    mut window: Query<(&mut Window, &mut PresentMode)>,
-) {
-    let (mut window, mut present_mode) = window.get_mut(trigger.target()).unwrap();
+fn configure_window(trigger: On<Add, PrimaryWindow>, mut window: Query<&mut Window>) {
+    let mut window = window.get_mut(trigger.target()).unwrap();
     window.resolution = WindowResolution::new(1920.0, 1080.0).with_scale_factor_override(1.0);
-    *present_mode = PresentMode::AutoNoVsync;
+    window.present_mode = PresentMode::AutoNoVsync;
 }
 
 const WIDTH: usize = 200;

--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -68,14 +68,11 @@ fn main() {
         .run();
 }
 
-fn configure_window(
-    trigger: On<Add, PrimaryWindow>,
-    mut window: Query<(&mut Window, &mut PresentMode)>,
-) {
-    let (mut window, mut present_mode) = window.get_mut(trigger.target()).unwrap();
+fn configure_window(trigger: On<Add, PrimaryWindow>, mut window: Query<&mut Window>) {
+    let mut window = window.get_mut(trigger.target()).unwrap();
     window.title = "🦊🦊🦊 Many Foxes! 🦊🦊🦊".to_string();
     window.resolution = WindowResolution::new(1920.0, 1080.0).with_scale_factor_override(1.0);
-    *present_mode = PresentMode::AutoNoVsync;
+    window.present_mode = PresentMode::AutoNoVsync;
 }
 
 #[derive(Resource)]

--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -8,7 +8,7 @@ use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     pbr::CascadeShadowConfigBuilder,
     prelude::*,
-    window::{PresentMode, WindowResolution},
+    window::{PresentMode, PrimaryWindow, WindowResolution},
     winit::{UpdateMode, WinitSettings},
 };
 
@@ -41,16 +41,7 @@ fn main() {
 
     App::new()
         .add_plugins((
-            DefaultPlugins.set(WindowPlugin {
-                primary_window: Some(Window {
-                    title: "🦊🦊🦊 Many Foxes! 🦊🦊🦊".into(),
-                    present_mode: PresentMode::AutoNoVsync,
-                    resolution: WindowResolution::new(1920.0, 1080.0)
-                        .with_scale_factor_override(1.0),
-                    ..default()
-                }),
-                ..default()
-            }),
+            DefaultPlugins,
             FrameTimeDiagnosticsPlugin::default(),
             LogDiagnosticsPlugin::default(),
         ))
@@ -64,6 +55,7 @@ fn main() {
             moving: true,
             sync: args.sync,
         })
+        .add_observer(configure_window)
         .add_systems(Startup, setup)
         .add_systems(
             Update,
@@ -74,6 +66,16 @@ fn main() {
             ),
         )
         .run();
+}
+
+fn configure_window(
+    trigger: On<Add, PrimaryWindow>,
+    mut window: Query<(&mut Window, &mut PresentMode)>,
+) {
+    let (mut window, mut present_mode) = window.get_mut(trigger.target()).unwrap();
+    window.title = "🦊🦊🦊 Many Foxes! 🦊🦊🦊".to_string();
+    window.resolution = WindowResolution::new(1920.0, 1080.0).with_scale_factor_override(1.0);
+    *present_mode = PresentMode::AutoNoVsync;
 }
 
 #[derive(Resource)]

--- a/examples/stress_tests/many_gizmos.rs
+++ b/examples/stress_tests/many_gizmos.rs
@@ -5,7 +5,7 @@ use std::f32::consts::TAU;
 use bevy::{
     diagnostic::{Diagnostic, DiagnosticsStore, FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     prelude::*,
-    window::{PresentMode, WindowResolution},
+    window::{PresentMode, PrimaryWindow, WindowResolution},
     winit::{UpdateMode, WinitSettings},
 };
 
@@ -14,15 +14,7 @@ const SYSTEM_COUNT: u32 = 10;
 fn main() {
     let mut app = App::new();
     app.add_plugins((
-        DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                title: "Many Debug Lines".to_string(),
-                present_mode: PresentMode::AutoNoVsync,
-                resolution: WindowResolution::new(1920.0, 1080.0).with_scale_factor_override(1.0),
-                ..default()
-            }),
-            ..default()
-        }),
+        DefaultPlugins,
         FrameTimeDiagnosticsPlugin::default(),
         LogDiagnosticsPlugin::default(),
     ))
@@ -34,6 +26,7 @@ fn main() {
         line_count: 50_000,
         fancy: false,
     })
+    .add_observer(configure_window)
     .add_systems(Startup, setup)
     .add_systems(Update, (input, ui_system));
 
@@ -42,6 +35,16 @@ fn main() {
     }
 
     app.run();
+}
+
+fn configure_window(
+    trigger: On<Add, PrimaryWindow>,
+    mut window: Query<(&mut Window, &mut PresentMode)>,
+) {
+    let (mut window, mut present_mode) = window.get_mut(trigger.target()).unwrap();
+    window.title = "Many Debug Lines".to_string();
+    window.resolution = WindowResolution::new(1920.0, 1080.0).with_scale_factor_override(1.0);
+    *present_mode = PresentMode::AutoNoVsync;
 }
 
 #[derive(Resource, Debug)]

--- a/examples/stress_tests/many_gizmos.rs
+++ b/examples/stress_tests/many_gizmos.rs
@@ -37,14 +37,11 @@ fn main() {
     app.run();
 }
 
-fn configure_window(
-    trigger: On<Add, PrimaryWindow>,
-    mut window: Query<(&mut Window, &mut PresentMode)>,
-) {
-    let (mut window, mut present_mode) = window.get_mut(trigger.target()).unwrap();
+fn configure_window(trigger: On<Add, PrimaryWindow>, mut window: Query<&mut Window>) {
+    let mut window = window.get_mut(trigger.target()).unwrap();
     window.title = "Many Debug Lines".to_string();
     window.resolution = WindowResolution::new(1920.0, 1080.0).with_scale_factor_override(1.0);
-    *present_mode = PresentMode::AutoNoVsync;
+    window.present_mode = PresentMode::AutoNoVsync;
 }
 
 #[derive(Resource, Debug)]

--- a/examples/stress_tests/many_glyphs.rs
+++ b/examples/stress_tests/many_glyphs.rs
@@ -58,13 +58,10 @@ fn main() {
     app.insert_resource(args).run();
 }
 
-fn configure_window(
-    trigger: On<Add, PrimaryWindow>,
-    mut window: Query<(&mut Window, &mut PresentMode)>,
-) {
-    let (mut window, mut present_mode) = window.get_mut(trigger.target()).unwrap();
+fn configure_window(trigger: On<Add, PrimaryWindow>, mut window: Query<&mut Window>) {
+    let mut window = window.get_mut(trigger.target()).unwrap();
     window.resolution = WindowResolution::new(1920.0, 1080.0).with_scale_factor_override(1.0);
-    *present_mode = PresentMode::AutoNoVsync;
+    window.present_mode = PresentMode::AutoNoVsync;
 }
 
 fn setup(mut commands: Commands, args: Res<Args>) {

--- a/examples/stress_tests/many_glyphs.rs
+++ b/examples/stress_tests/many_glyphs.rs
@@ -11,7 +11,7 @@ use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     prelude::*,
     text::{LineBreak, TextBounds},
-    window::{PresentMode, WindowResolution},
+    window::{PresentMode, PrimaryWindow, WindowResolution},
     winit::{UpdateMode, WinitSettings},
 };
 
@@ -40,14 +40,7 @@ fn main() {
 
     let mut app = App::new();
     app.add_plugins((
-        DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                present_mode: PresentMode::AutoNoVsync,
-                resolution: WindowResolution::new(1920.0, 1080.0).with_scale_factor_override(1.0),
-                ..default()
-            }),
-            ..default()
-        }),
+        DefaultPlugins,
         FrameTimeDiagnosticsPlugin::default(),
         LogDiagnosticsPlugin::default(),
     ))
@@ -55,6 +48,7 @@ fn main() {
         focused_mode: UpdateMode::Continuous,
         unfocused_mode: UpdateMode::Continuous,
     })
+    .add_observer(configure_window)
     .add_systems(Startup, setup);
 
     if args.recompute_text {
@@ -62,6 +56,15 @@ fn main() {
     }
 
     app.insert_resource(args).run();
+}
+
+fn configure_window(
+    trigger: On<Add, PrimaryWindow>,
+    mut window: Query<(&mut Window, &mut PresentMode)>,
+) {
+    let (mut window, mut present_mode) = window.get_mut(trigger.target()).unwrap();
+    window.resolution = WindowResolution::new(1920.0, 1080.0).with_scale_factor_override(1.0);
+    *present_mode = PresentMode::AutoNoVsync;
 }
 
 fn setup(mut commands: Commands, args: Res<Args>) {

--- a/examples/stress_tests/many_lights.rs
+++ b/examples/stress_tests/many_lights.rs
@@ -10,7 +10,7 @@ use bevy::{
     pbr::{ExtractedPointLight, GlobalClusterableObjectMeta},
     prelude::*,
     render::{camera::ScalingMode, Render, RenderApp, RenderSystems},
-    window::{PresentMode, WindowResolution},
+    window::{PresentMode, PrimaryWindow, WindowResolution},
     winit::{UpdateMode, WinitSettings},
 };
 use rand::{thread_rng, Rng};
@@ -18,16 +18,7 @@ use rand::{thread_rng, Rng};
 fn main() {
     App::new()
         .add_plugins((
-            DefaultPlugins.set(WindowPlugin {
-                primary_window: Some(Window {
-                    resolution: WindowResolution::new(1920.0, 1080.0)
-                        .with_scale_factor_override(1.0),
-                    title: "many_lights".into(),
-                    present_mode: PresentMode::AutoNoVsync,
-                    ..default()
-                }),
-                ..default()
-            }),
+            DefaultPlugins,
             FrameTimeDiagnosticsPlugin::default(),
             LogDiagnosticsPlugin::default(),
             LogVisibleLights,
@@ -36,9 +27,20 @@ fn main() {
             focused_mode: UpdateMode::Continuous,
             unfocused_mode: UpdateMode::Continuous,
         })
+        .add_observer(configure_window)
         .add_systems(Startup, setup)
         .add_systems(Update, (move_camera, print_light_count))
         .run();
+}
+
+fn configure_window(
+    trigger: On<Add, PrimaryWindow>,
+    mut window: Query<(&mut Window, &mut PresentMode)>,
+) {
+    let (mut window, mut present_mode) = window.get_mut(trigger.target()).unwrap();
+    window.title = "many_lights".to_string();
+    window.resolution = WindowResolution::new(1920.0, 1080.0).with_scale_factor_override(1.0);
+    *present_mode = PresentMode::AutoNoVsync;
 }
 
 fn setup(

--- a/examples/stress_tests/many_lights.rs
+++ b/examples/stress_tests/many_lights.rs
@@ -33,14 +33,11 @@ fn main() {
         .run();
 }
 
-fn configure_window(
-    trigger: On<Add, PrimaryWindow>,
-    mut window: Query<(&mut Window, &mut PresentMode)>,
-) {
-    let (mut window, mut present_mode) = window.get_mut(trigger.target()).unwrap();
+fn configure_window(trigger: On<Add, PrimaryWindow>, mut window: Query<&mut Window>) {
+    let mut window = window.get_mut(trigger.target()).unwrap();
     window.title = "many_lights".to_string();
     window.resolution = WindowResolution::new(1920.0, 1080.0).with_scale_factor_override(1.0);
-    *present_mode = PresentMode::AutoNoVsync;
+    window.present_mode = PresentMode::AutoNoVsync;
 }
 
 fn setup(

--- a/examples/stress_tests/many_materials.rs
+++ b/examples/stress_tests/many_materials.rs
@@ -35,14 +35,11 @@ fn main() {
         .run();
 }
 
-fn configure_window(
-    trigger: On<Add, PrimaryWindow>,
-    mut window: Query<(&mut Window, &mut PresentMode)>,
-) {
-    let (mut window, mut present_mode) = window.get_mut(trigger.target()).unwrap();
+fn configure_window(trigger: On<Add, PrimaryWindow>, mut window: Query<&mut Window>) {
+    let mut window = window.get_mut(trigger.target()).unwrap();
     window.resolution = WindowResolution::new(1920.0, 1080.0).with_scale_factor_override(1.0);
     window.title = "many_materials".into();
-    *present_mode = PresentMode::AutoNoVsync;
+    window.present_mode = PresentMode::AutoNoVsync;
 }
 
 fn setup(

--- a/examples/stress_tests/many_materials.rs
+++ b/examples/stress_tests/many_materials.rs
@@ -3,7 +3,7 @@ use argh::FromArgs;
 use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     prelude::*,
-    window::{PresentMode, WindowPlugin, WindowResolution},
+    window::{PresentMode, PrimaryWindow, WindowResolution},
 };
 use std::f32::consts::PI;
 
@@ -24,23 +24,25 @@ fn main() {
 
     App::new()
         .add_plugins((
-            DefaultPlugins.set(WindowPlugin {
-                primary_window: Some(Window {
-                    resolution: WindowResolution::new(1920.0, 1080.0)
-                        .with_scale_factor_override(1.0),
-                    title: "many_materials".into(),
-                    present_mode: PresentMode::AutoNoVsync,
-                    ..default()
-                }),
-                ..default()
-            }),
+            DefaultPlugins,
             FrameTimeDiagnosticsPlugin::default(),
             LogDiagnosticsPlugin::default(),
         ))
         .insert_resource(args)
+        .add_observer(configure_window)
         .add_systems(Startup, setup)
         .add_systems(Update, animate_materials)
         .run();
+}
+
+fn configure_window(
+    trigger: On<Add, PrimaryWindow>,
+    mut window: Query<(&mut Window, &mut PresentMode)>,
+) {
+    let (mut window, mut present_mode) = window.get_mut(trigger.target()).unwrap();
+    window.resolution = WindowResolution::new(1920.0, 1080.0).with_scale_factor_override(1.0);
+    window.title = "many_materials".into();
+    *present_mode = PresentMode::AutoNoVsync;
 }
 
 fn setup(

--- a/examples/stress_tests/many_sprites.rs
+++ b/examples/stress_tests/many_sprites.rs
@@ -11,7 +11,7 @@ use bevy::{
     color::palettes::css::*,
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     prelude::*,
-    window::{PresentMode, WindowResolution},
+    window::{PresentMode, PrimaryWindow, WindowResolution},
     winit::{UpdateMode, WinitSettings},
 };
 
@@ -33,26 +33,28 @@ fn main() {
         .add_plugins((
             LogDiagnosticsPlugin::default(),
             FrameTimeDiagnosticsPlugin::default(),
-            DefaultPlugins.set(WindowPlugin {
-                primary_window: Some(Window {
-                    present_mode: PresentMode::AutoNoVsync,
-                    resolution: WindowResolution::new(1920.0, 1080.0)
-                        .with_scale_factor_override(1.0),
-                    ..default()
-                }),
-                ..default()
-            }),
+            DefaultPlugins,
         ))
         .insert_resource(WinitSettings {
             focused_mode: UpdateMode::Continuous,
             unfocused_mode: UpdateMode::Continuous,
         })
+        .add_observer(configure_window)
         .add_systems(Startup, setup)
         .add_systems(
             Update,
             (print_sprite_count, move_camera.after(print_sprite_count)),
         )
         .run();
+}
+
+fn configure_window(
+    trigger: On<Add, PrimaryWindow>,
+    mut window: Query<(&mut Window, &mut PresentMode)>,
+) {
+    let (mut window, mut present_mode) = window.get_mut(trigger.target()).unwrap();
+    window.resolution = WindowResolution::new(1920.0, 1080.0).with_scale_factor_override(1.0);
+    *present_mode = PresentMode::AutoNoVsync;
 }
 
 fn setup(mut commands: Commands, assets: Res<AssetServer>, color_tint: Res<ColorTint>) {

--- a/examples/stress_tests/many_sprites.rs
+++ b/examples/stress_tests/many_sprites.rs
@@ -48,13 +48,10 @@ fn main() {
         .run();
 }
 
-fn configure_window(
-    trigger: On<Add, PrimaryWindow>,
-    mut window: Query<(&mut Window, &mut PresentMode)>,
-) {
-    let (mut window, mut present_mode) = window.get_mut(trigger.target()).unwrap();
+fn configure_window(trigger: On<Add, PrimaryWindow>, mut window: Query<&mut Window>) {
+    let mut window = window.get_mut(trigger.target()).unwrap();
     window.resolution = WindowResolution::new(1920.0, 1080.0).with_scale_factor_override(1.0);
-    *present_mode = PresentMode::AutoNoVsync;
+    window.present_mode = PresentMode::AutoNoVsync;
 }
 
 fn setup(mut commands: Commands, assets: Res<AssetServer>, color_tint: Res<ColorTint>) {

--- a/examples/stress_tests/many_text2d.rs
+++ b/examples/stress_tests/many_text2d.rs
@@ -7,7 +7,7 @@ use bevy::{
     prelude::*,
     render::view::NoFrustumCulling,
     text::FontAtlasSets,
-    window::{PresentMode, WindowResolution},
+    window::{PresentMode, PrimaryWindow, WindowResolution},
 };
 
 use argh::FromArgs;
@@ -72,16 +72,10 @@ fn main() {
     app.add_plugins((
         FrameTimeDiagnosticsPlugin::default(),
         LogDiagnosticsPlugin::default(),
-        DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                present_mode: PresentMode::AutoNoVsync,
-                resolution: WindowResolution::new(1920.0, 1080.0).with_scale_factor_override(1.0),
-                ..default()
-            }),
-            ..default()
-        }),
+        DefaultPlugins,
     ))
     .init_resource::<FontHandle>()
+    .add_observer(configure_window)
     .add_systems(Startup, setup)
     .add_systems(Update, (move_camera, print_counts));
 
@@ -99,6 +93,15 @@ impl Default for PrintingTimer {
     fn default() -> Self {
         Self(Timer::from_seconds(1.0, TimerMode::Repeating))
     }
+}
+
+fn configure_window(
+    trigger: On<Add, PrimaryWindow>,
+    mut window: Query<(&mut Window, &mut PresentMode)>,
+) {
+    let (mut window, mut present_mode) = window.get_mut(trigger.target()).unwrap();
+    window.resolution = WindowResolution::new(1920.0, 1080.0).with_scale_factor_override(1.0);
+    *present_mode = PresentMode::AutoNoVsync;
 }
 
 fn setup(mut commands: Commands, font: Res<FontHandle>, args: Res<Args>) {

--- a/examples/stress_tests/many_text2d.rs
+++ b/examples/stress_tests/many_text2d.rs
@@ -95,13 +95,10 @@ impl Default for PrintingTimer {
     }
 }
 
-fn configure_window(
-    trigger: On<Add, PrimaryWindow>,
-    mut window: Query<(&mut Window, &mut PresentMode)>,
-) {
-    let (mut window, mut present_mode) = window.get_mut(trigger.target()).unwrap();
+fn configure_window(trigger: On<Add, PrimaryWindow>, mut window: Query<&mut Window>) {
+    let mut window = window.get_mut(trigger.target()).unwrap();
     window.resolution = WindowResolution::new(1920.0, 1080.0).with_scale_factor_override(1.0);
-    *present_mode = PresentMode::AutoNoVsync;
+    window.present_mode = PresentMode::AutoNoVsync;
 }
 
 fn setup(mut commands: Commands, font: Res<FontHandle>, args: Res<Args>) {

--- a/examples/stress_tests/text_pipeline.rs
+++ b/examples/stress_tests/text_pipeline.rs
@@ -28,13 +28,10 @@ fn main() {
         .run();
 }
 
-fn configure_window(
-    trigger: On<Add, PrimaryWindow>,
-    mut window: Query<(&mut Window, &mut PresentMode)>,
-) {
-    let (mut window, mut present_mode) = window.get_mut(trigger.target()).unwrap();
+fn configure_window(trigger: On<Add, PrimaryWindow>, mut window: Query<&mut Window>) {
+    let mut window = window.get_mut(trigger.target()).unwrap();
     window.resolution = WindowResolution::new(1920.0, 1080.0).with_scale_factor_override(1.0);
-    *present_mode = PresentMode::AutoNoVsync;
+    window.present_mode = PresentMode::AutoNoVsync;
 }
 
 fn spawn(mut commands: Commands, asset_server: Res<AssetServer>) {

--- a/examples/stress_tests/text_pipeline.rs
+++ b/examples/stress_tests/text_pipeline.rs
@@ -7,22 +7,14 @@ use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     prelude::*,
     text::{LineBreak, TextBounds},
-    window::{PresentMode, WindowResolution},
+    window::{PresentMode, PrimaryWindow, WindowResolution},
     winit::{UpdateMode, WinitSettings},
 };
 
 fn main() {
     App::new()
         .add_plugins((
-            DefaultPlugins.set(WindowPlugin {
-                primary_window: Some(Window {
-                    present_mode: PresentMode::AutoNoVsync,
-                    resolution: WindowResolution::new(1920.0, 1080.0)
-                        .with_scale_factor_override(1.0),
-                    ..default()
-                }),
-                ..default()
-            }),
+            DefaultPlugins,
             FrameTimeDiagnosticsPlugin::default(),
             LogDiagnosticsPlugin::default(),
         ))
@@ -30,9 +22,19 @@ fn main() {
             focused_mode: UpdateMode::Continuous,
             unfocused_mode: UpdateMode::Continuous,
         })
+        .add_observer(configure_window)
         .add_systems(Startup, spawn)
         .add_systems(Update, update_text_bounds)
         .run();
+}
+
+fn configure_window(
+    trigger: On<Add, PrimaryWindow>,
+    mut window: Query<(&mut Window, &mut PresentMode)>,
+) {
+    let (mut window, mut present_mode) = window.get_mut(trigger.target()).unwrap();
+    window.resolution = WindowResolution::new(1920.0, 1080.0).with_scale_factor_override(1.0);
+    *present_mode = PresentMode::AutoNoVsync;
 }
 
 fn spawn(mut commands: Commands, asset_server: Res<AssetServer>) {

--- a/examples/stress_tests/transform_hierarchy.rs
+++ b/examples/stress_tests/transform_hierarchy.rs
@@ -189,7 +189,7 @@ fn main() {
         .insert_resource(cfg)
         .add_plugins((
             DefaultPlugins.set(WindowPlugin {
-                primary_window: None,
+                spawn_primary_window: false,
                 exit_condition: ExitCondition::DontExit,
                 ..default()
             }),

--- a/examples/tools/scene_viewer/main.rs
+++ b/examples/tools/scene_viewer/main.rs
@@ -18,6 +18,7 @@ use bevy::{
         experimental::occlusion_culling::OcclusionCulling,
         primitives::{Aabb, Sphere},
     },
+    window::PrimaryWindow,
 };
 
 #[path = "../../helpers/camera_controller.rs"]
@@ -65,25 +66,18 @@ fn main() {
 
     let mut app = App::new();
     app.add_plugins((
-        DefaultPlugins
-            .set(WindowPlugin {
-                primary_window: Some(Window {
-                    title: "bevy scene viewer".to_string(),
-                    ..default()
-                }),
-                ..default()
-            })
-            .set(AssetPlugin {
-                file_path: std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string()),
-                // Allow scenes to be loaded from anywhere on disk
-                unapproved_path_mode: UnapprovedPathMode::Allow,
-                ..default()
-            }),
+        DefaultPlugins.set(AssetPlugin {
+            file_path: std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string()),
+            // Allow scenes to be loaded from anywhere on disk
+            unapproved_path_mode: UnapprovedPathMode::Allow,
+            ..default()
+        }),
         CameraControllerPlugin,
         SceneViewerPlugin,
         MorphViewerPlugin,
     ))
     .insert_resource(args)
+    .add_observer(configure_window)
     .add_systems(Startup, setup)
     .add_systems(PreUpdate, setup_scene_after_load);
 
@@ -96,6 +90,11 @@ fn main() {
     app.add_plugins(animation_plugin::AnimationManipulationPlugin);
 
     app.run();
+}
+
+fn configure_window(trigger: On<Add, PrimaryWindow>, mut window: Query<&mut Window>) {
+    let mut window = window.get_mut(trigger.target()).unwrap();
+    window.title = "Bevy Scene Viewer".to_string();
 }
 
 fn parse_scene(scene_path: String) -> (String, usize) {

--- a/examples/ui/flex_layout.rs
+++ b/examples/ui/flex_layout.rs
@@ -7,13 +7,7 @@ const MARGIN: Val = Val::Px(12.);
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                title: "Bevy Flex Layout Example".to_string(),
-                ..Default::default()
-            }),
-            ..Default::default()
-        }))
+        .add_plugins(DefaultPlugins)
         .add_systems(Startup, spawn_layout)
         .run();
 }

--- a/examples/ui/grid.rs
+++ b/examples/ui/grid.rs
@@ -1,18 +1,18 @@
 //! Demonstrates how CSS Grid layout can be used to lay items out in a 2D grid
-use bevy::{color::palettes::css::*, prelude::*};
+use bevy::{color::palettes::css::*, prelude::*, window::PrimaryWindow};
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                resolution: [800., 600.].into(),
-                title: "Bevy CSS Grid Layout Example".to_string(),
-                ..default()
-            }),
-            ..default()
-        }))
+        .add_plugins(DefaultPlugins)
+        .add_observer(configure_window)
         .add_systems(Startup, spawn_layout)
         .run();
+}
+
+fn configure_window(trigger: On<Add, PrimaryWindow>, mut window: Query<&mut Window>) {
+    let mut window = window.get_mut(trigger.target()).unwrap();
+    window.title = "Bevy CSS Grid Layout Example".to_string();
+    window.resolution = [800., 600.].into();
 }
 
 fn spawn_layout(mut commands: Commands, asset_server: Res<AssetServer>) {

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -7,24 +7,21 @@ use bevy::{
     diagnostic::{DiagnosticsStore, FrameTimeDiagnosticsPlugin},
     prelude::*,
     ui::widget::TextUiWriter,
-    window::PresentMode,
+    window::{PresentMode, PrimaryWindow},
 };
 
 fn main() {
     App::new()
-        .add_plugins((
-            DefaultPlugins.set(WindowPlugin {
-                primary_window: Some(Window {
-                    present_mode: PresentMode::AutoNoVsync,
-                    ..default()
-                }),
-                ..default()
-            }),
-            FrameTimeDiagnosticsPlugin::default(),
-        ))
+        .add_plugins((DefaultPlugins, FrameTimeDiagnosticsPlugin::default()))
+        .add_observer(configure_window)
         .add_systems(Startup, infotext_system)
         .add_systems(Update, change_text_system)
         .run();
+}
+
+fn configure_window(trigger: On<Add, PrimaryWindow>, mut window: Query<&mut PresentMode>) {
+    let mut present_mode = window.get_mut(trigger.target()).unwrap();
+    *present_mode = PresentMode::AutoNoVsync;
 }
 
 #[derive(Component)]

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -19,9 +19,9 @@ fn main() {
         .run();
 }
 
-fn configure_window(trigger: On<Add, PrimaryWindow>, mut window: Query<&mut PresentMode>) {
-    let mut present_mode = window.get_mut(trigger.target()).unwrap();
-    *present_mode = PresentMode::AutoNoVsync;
+fn configure_window(trigger: On<Add, PrimaryWindow>, mut window: Query<&mut Window>) {
+    let mut window = window.get_mut(trigger.target()).unwrap();
+    window.present_mode = PresentMode::AutoNoVsync;
 }
 
 #[derive(Component)]

--- a/examples/ui/text_wrap_debug.rs
+++ b/examples/ui/text_wrap_debug.rs
@@ -1,7 +1,12 @@
 //! This example demonstrates text wrapping and use of the `LineBreakOn` property.
 
 use argh::FromArgs;
-use bevy::{prelude::*, text::LineBreak, window::WindowResolution, winit::WinitSettings};
+use bevy::{
+    prelude::*,
+    text::LineBreak,
+    window::{PrimaryWindow, WindowResolution},
+    winit::WinitSettings,
+};
 
 #[derive(FromArgs, Resource)]
 /// `text_wrap_debug` demonstrates text wrapping and use of the `LineBreakOn` property
@@ -16,30 +21,30 @@ struct Args {
 }
 
 fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .insert_resource(WinitSettings::desktop_app())
+        .add_observer(configure_window)
+        .add_systems(Startup, spawn)
+        .run();
+}
+
+fn configure_window(
+    trigger: On<Add, PrimaryWindow>,
+    mut window: Query<&mut Window>,
+    mut commands: Commands,
+) {
+    let mut window = window.get_mut(trigger.target()).unwrap();
     // `from_env` panics on the web
     #[cfg(not(target_arch = "wasm32"))]
     let args: Args = argh::from_env();
     #[cfg(target_arch = "wasm32")]
     let args = Args::from_args(&[], &[]).unwrap();
 
-    let window = if let Some(scale_factor) = args.scale_factor {
-        Window {
-            resolution: WindowResolution::default().with_scale_factor_override(scale_factor),
-            ..Default::default()
-        }
-    } else {
-        Window::default()
-    };
-
-    App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(window),
-            ..Default::default()
-        }))
-        .insert_resource(WinitSettings::desktop_app())
-        .insert_resource(UiScale(args.ui_scale))
-        .add_systems(Startup, spawn)
-        .run();
+    if let Some(scale_factor) = args.scale_factor {
+        window.resolution = WindowResolution::default().with_scale_factor_override(scale_factor);
+    }
+    commands.insert_resource(UiScale(args.ui_scale));
 }
 
 fn spawn(mut commands: Commands, asset_server: Res<AssetServer>) {

--- a/examples/ui/viewport_debug.rs
+++ b/examples/ui/viewport_debug.rs
@@ -4,7 +4,7 @@
 //! and then switches between them once per second using the `Display` style property.
 //! If there are no problems both layouts should be identical, except for the color of the margin changing which is used to signal that the displayed UI node tree has changed
 //! (red for viewport, yellow for pixel).
-use bevy::{color::palettes::css::*, prelude::*};
+use bevy::{color::palettes::css::*, prelude::*, window::PrimaryWindow};
 
 const PALETTE: [Srgba; 10] = [
     RED, YELLOW, WHITE, BEIGE, AQUA, CRIMSON, NAVY, AZURE, LIME, BLACK,
@@ -20,20 +20,18 @@ enum Coords {
 fn main() {
     App::new()
         .insert_resource(UiScale(2.0))
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                title: "Viewport Coordinates Debug".to_string(),
-                // This example relies on these specific viewport dimensions, so let's explicitly
-                // define them.
-                resolution: [1280., 720.].into(),
-                resizable: false,
-                ..Default::default()
-            }),
-            ..Default::default()
-        }))
+        .add_plugins(DefaultPlugins)
+        .add_observer(configure_window)
         .add_systems(Startup, setup)
         .add_systems(Update, update)
         .run();
+}
+
+fn configure_window(trigger: On<Add, PrimaryWindow>, mut window: Query<&mut Window>) {
+    let mut window = window.get_mut(trigger.target()).unwrap();
+    window.title = "Viewport Coordinates Debug".to_string();
+    window.resolution = [1280., 720.].into();
+    window.resizable = false;
 }
 
 fn update(

--- a/examples/ui/window_fallthrough.rs
+++ b/examples/ui/window_fallthrough.rs
@@ -2,24 +2,26 @@
 //! If you build this, and hit 'P' it should toggle on/off the mouse's passthrough.
 //! Note: this example will not work on following platforms: iOS / Android / Web / X11. Window fall through is not supported there.
 
-use bevy::{prelude::*, window::CursorOptions};
+use bevy::{
+    prelude::*,
+    window::{CursorOptions, PrimaryWindow, WindowLevel},
+};
 
 fn main() {
     App::new()
         .insert_resource(ClearColor(Color::NONE)) // Use a transparent window, to make effects obvious.
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                // Set the window's parameters, note we're setting the window to always be on top.
-                transparent: true,
-                decorations: true,
-                window_level: bevy::window::WindowLevel::AlwaysOnTop,
-                ..default()
-            }),
-            ..default()
-        }))
+        .add_plugins(DefaultPlugins)
+        .add_observer(configure_window)
         .add_systems(Startup, setup)
         .add_systems(Update, toggle_mouse_passthrough) // This allows us to hit 'P' to toggle on/off the mouse's passthrough
         .run();
+}
+
+fn configure_window(trigger: On<Add, PrimaryWindow>, mut window: Query<&mut Window>) {
+    let mut window = window.get_mut(trigger.target()).unwrap();
+    window.transparent = true;
+    window.decorations = true;
+    window.window_level = WindowLevel::AlwaysOnTop;
 }
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {

--- a/examples/window/low_power.rs
+++ b/examples/window/low_power.rs
@@ -37,10 +37,10 @@ fn main() {
         .run();
 }
 
-fn configure_window(trigger: On<Add, PrimaryWindow>, mut window: Query<&mut PresentMode>) {
-    let mut present_mode = window.get_mut(trigger.target()).unwrap();
+fn configure_window(trigger: On<Add, PrimaryWindow>, mut window: Query<&mut Window>) {
+    let mut window = window.get_mut(trigger.target()).unwrap();
     // Turn off vsync to maximize CPU/GPU usage
-    *present_mode = PresentMode::AutoNoVsync;
+    window.present_mode = PresentMode::AutoNoVsync;
 }
 
 #[derive(Resource, Debug)]

--- a/examples/window/low_power.rs
+++ b/examples/window/low_power.rs
@@ -5,7 +5,7 @@
 
 use bevy::{
     prelude::*,
-    window::{PresentMode, RequestRedraw, WindowPlugin},
+    window::{PresentMode, PrimaryWindow, RequestRedraw},
     winit::{EventLoopProxyWrapper, WakeUp, WinitSettings},
 };
 use core::time::Duration;
@@ -22,14 +22,8 @@ fn main() {
             unfocused_mode: bevy::winit::UpdateMode::reactive_low_power(Duration::from_millis(10)),
         })
         .insert_resource(ExampleMode::Game)
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                // Turn off vsync to maximize CPU/GPU usage
-                present_mode: PresentMode::AutoNoVsync,
-                ..default()
-            }),
-            ..default()
-        }))
+        .add_plugins(DefaultPlugins)
+        .add_observer(configure_window)
         .add_systems(Startup, test_setup::setup)
         .add_systems(
             Update,
@@ -41,6 +35,12 @@ fn main() {
             ),
         )
         .run();
+}
+
+fn configure_window(trigger: On<Add, PrimaryWindow>, mut window: Query<&mut PresentMode>) {
+    let mut present_mode = window.get_mut(trigger.target()).unwrap();
+    // Turn off vsync to maximize CPU/GPU usage
+    *present_mode = PresentMode::AutoNoVsync;
 }
 
 #[derive(Resource, Debug)]

--- a/examples/window/monitor_info.rs
+++ b/examples/window/monitor_info.rs
@@ -9,7 +9,7 @@ use bevy::{
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: None,
+            spawn_primary_window: false,
             exit_condition: ExitCondition::DontExit,
             ..default()
         }))

--- a/examples/window/scale_factor_override.rs
+++ b/examples/window/scale_factor_override.rs
@@ -1,26 +1,29 @@
 //! This example illustrates how to override the window scale factor imposed by the
 //! operating system.
 
-use bevy::{prelude::*, window::WindowResolution};
+use bevy::{
+    prelude::*,
+    window::{PrimaryWindow, WindowResolution},
+};
 
 #[derive(Component)]
 struct CustomText;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                resolution: WindowResolution::new(500., 300.).with_scale_factor_override(1.0),
-                ..default()
-            }),
-            ..default()
-        }))
+        .add_plugins(DefaultPlugins)
+        .add_observer(configure_window)
         .add_systems(Startup, setup)
         .add_systems(
             Update,
             (display_override, toggle_override, change_scale_factor),
         )
         .run();
+}
+
+fn configure_window(trigger: On<Add, PrimaryWindow>, mut window: Query<&mut Window>) {
+    let mut window = window.get_mut(trigger.target()).unwrap();
+    window.resolution = WindowResolution::new(1920.0, 1080.0).with_scale_factor_override(1.0);
 }
 
 fn setup(mut commands: Commands) {

--- a/examples/window/transparent_window.rs
+++ b/examples/window/transparent_window.rs
@@ -4,30 +4,36 @@
 //! [documentation](https://docs.rs/bevy/latest/bevy/prelude/struct.Window.html#structfield.transparent)
 //! for more details.
 
-use bevy::prelude::*;
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 use bevy::window::CompositeAlphaMode;
+use bevy::{prelude::*, window::PrimaryWindow};
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                // Setting `transparent` allows the `ClearColor`'s alpha value to take effect
-                transparent: true,
-                // Disabling window decorations to make it feel more like a widget than a window
-                decorations: false,
-                #[cfg(target_os = "macos")]
-                composite_alpha_mode: CompositeAlphaMode::PostMultiplied,
-                #[cfg(target_os = "linux")]
-                composite_alpha_mode: CompositeAlphaMode::PreMultiplied,
-                ..default()
-            }),
-            ..default()
-        }))
+        .add_plugins(DefaultPlugins)
         // ClearColor must have 0 alpha, otherwise some color will bleed through
         .insert_resource(ClearColor(Color::NONE))
+        .add_observer(configure_window)
         .add_systems(Startup, setup)
         .run();
+}
+
+fn configure_window(trigger: On<Add, PrimaryWindow>, mut window: Query<&mut Window>) {
+    let mut window = window.get_mut(trigger.target()).unwrap();
+
+    // Setting `transparent` allows the `ClearColor`'s alpha value to take effect
+    window.transparent = true;
+    // Disabling window decorations to make it feel more like a widget than a window
+    window.decorations = false;
+
+    #[cfg(target_os = "macos")]
+    {
+        window.composite_alpha_mode = CompositeAlphaMode::PostMultiplied;
+    }
+    #[cfg(target_os = "linux")]
+    {
+        window.composite_alpha_mode = CompositeAlphaMode::PreMultiplied;
+    }
 }
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {

--- a/examples/window/window_drag_move.rs
+++ b/examples/window/window_drag_move.rs
@@ -10,7 +10,7 @@
 //!
 //! The `start_drag_resize()` function behaves similarly but permits a window to
 //! be resized.
-use bevy::{math::CompassOctant, prelude::*};
+use bevy::{math::CompassOctant, prelude::*, window::PrimaryWindow};
 
 /// Determine what do on left click.
 #[derive(Resource, Debug)]
@@ -41,18 +41,18 @@ const DIRECTIONS: [CompassOctant; 8] = [
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                decorations: false,
-                ..default()
-            }),
-            ..default()
-        }))
+        .add_plugins(DefaultPlugins)
         .insert_resource(ResizeDir(7))
         .insert_resource(LeftClickAction::Move)
+        .add_observer(configure_window)
         .add_systems(Startup, setup)
         .add_systems(Update, (handle_input, move_or_resize_windows))
         .run();
+}
+
+fn configure_window(trigger: On<Add, PrimaryWindow>, mut window: Query<&mut Window>) {
+    let mut window = window.get_mut(trigger.target()).unwrap();
+    window.decorations = false;
 }
 
 fn setup(mut commands: Commands) {

--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -38,11 +38,8 @@ fn main() {
         .run();
 }
 
-fn configure_window(
-    trigger: On<Add, PrimaryWindow>,
-    mut window: Query<(&mut Window, &mut PresentMode)>,
-) {
-    let (mut window, mut present_mode) = window.get_mut(trigger.target()).unwrap();
+fn configure_window(trigger: On<Add, PrimaryWindow>, mut window: Query<&mut Window>) {
+    let mut window = window.get_mut(trigger.target()).unwrap();
     window.title = "I am a window!".into();
     window.name = Some("bevy.app".into());
     window.resolution = (500., 300.).into();
@@ -57,7 +54,7 @@ fn configure_window(
     // This is useful when you want to avoid the white window that shows up before the GPU is ready to render the app.
     window.visible = false;
 
-    *present_mode = PresentMode::AutoNoVsync;
+    window.present_mode = PresentMode::AutoNoVsync;
 }
 
 fn make_visible(mut window: Single<&mut Window>, frames: Res<FrameCount>) {
@@ -72,14 +69,14 @@ fn make_visible(mut window: Single<&mut Window>, frames: Res<FrameCount>) {
 
 /// This system toggles the vsync mode when pressing the button V.
 /// You'll see fps increase displayed in the console.
-fn toggle_vsync(input: Res<ButtonInput<KeyCode>>, mut present_mode: Single<&mut PresentMode>) {
+fn toggle_vsync(input: Res<ButtonInput<KeyCode>>, mut window: Single<&mut Window>) {
     if input.just_pressed(KeyCode::KeyV) {
-        **present_mode = if matches!(**present_mode, PresentMode::AutoVsync) {
+        window.present_mode = if matches!(window.present_mode, PresentMode::AutoVsync) {
             PresentMode::AutoNoVsync
         } else {
             PresentMode::AutoVsync
         };
-        info!("PRESENT_MODE: {:?}", *present_mode);
+        info!("PRESENT_MODE: {:?}", window.present_mode);
     }
 }
 

--- a/tests/window/minimizing.rs
+++ b/tests/window/minimizing.rs
@@ -6,13 +6,7 @@ fn main() {
     // TODO: Combine this with `resizing` once multiple_windows is simpler than
     // it is currently.
     App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                title: "Minimizing".into(),
-                ..default()
-            }),
-            ..default()
-        }))
+        .add_plugins(DefaultPlugins)
         .add_systems(Startup, (setup_3d, setup_2d))
         .add_systems(Update, minimize_automatically)
         .run();


### PR DESCRIPTION
# Objective

- Part of #19644
- Window is biiiiig, so we want to split it
- However, to split it, we need a blessed pattern for how to initialize all these new components
- The old way was to have a field on `WindowPlugin`
- But if we split `Window` into 10 components, we'd have 10 new optional initializer fields on `WindowPlugin`
- That's just a worse version of required components

## Solution

- Use required components to build up the Window instead
- Tell users through the examples to use an observer instead of the plugin field
- While I was on it anyways, I removed the window titles of many examples, as even pre-PR they were mostly boilerplate that didn't add much didactic value

## Testing

- TODO: need to still test this some more

