### PR TITLE
Move renderer initialization from build time to `RenderStartup`

### DIFF
--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -408,7 +408,7 @@ impl Plugin for RenderPlugin {
         load_shader_library!(app, "color_operations.wgsl");
         load_shader_library!(app, "bindless.wgsl");
         if let Some(future_render_resources) =
-            app.world_mut().remove_resource::<FutureRenderResources>()
+            app.world_mut().get_resource::<FutureRenderResources>()
         {
             let RenderResources(device, queue, adapter_info, render_adapter, instance) =
                 future_render_resources.0.lock().unwrap().take().unwrap();
@@ -446,7 +446,7 @@ struct AutomaticRendererCreationSettings(WgpuSettings);
 fn initialize_renderer(
     primary_window: Option<Single<&RawHandleWrapperHolder, With<PrimaryWindow>>>,
     future_render_resources: Res<FutureRenderResources>,
-    render_creation: When<Res<AutomaticRendererCreationSettings>>,
+    render_creation: Res<AutomaticRendererCreationSettings>,
 ) {
     let primary_window = primary_window.map(|primary_window| primary_window.clone());
     let settings = render_creation.into_inner().0.clone();

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -122,7 +122,6 @@ use bevy_ecs::{prelude::*, schedule::ScheduleLabel};
 use bevy_utils::WgpuWrapper;
 use bitflags::bitflags;
 use core::ops::{Deref, DerefMut};
-use std::panic;
 use std::sync::Mutex;
 use tracing::debug;
 
@@ -394,13 +393,6 @@ impl Plugin for RenderPlugin {
             .register_type::<TemporaryRenderEntity>()
             .register_type::<MainEntity>()
             .register_type::<SyncToRenderWorld>();
-    }
-
-    fn ready(&self, app: &App) -> bool {
-        app.world()
-            .get_resource::<FutureRenderResources>()
-            .and_then(|frr| frr.0.try_lock().map(|locked| locked.is_some()).ok())
-            .unwrap_or(true)
     }
 
     fn finish(&self, app: &mut App) {


### PR DESCRIPTION
# Objective

- Transitively part of #19644
- Required for https://github.com/bevyengine/bevy/pull/20019, which is required for https://github.com/bevyengine/bevy/pull/20018
- Split off so that a bisect can find this
  - If you just bisected this PR: sorry!

I'd like to move the primary window creation into `Startup` for reasons detailed in the linked PRs, but I cannot do so, since `RenderApp` needs it in its own build

## Solution

- Move the relevant code into `RenderStartup`

## Testing

- TODO

