### PR TITLE
formatting fix in bevy_remote cargo.toml

### DIFF
--- a/crates/bevy_remote/Cargo.toml
+++ b/crates/bevy_remote/Cargo.toml
@@ -30,6 +30,7 @@ bevy_platform = { path = "../bevy_platform", version = "0.17.0-dev", default-fea
   "serialize",
 ] }
 bevy_asset = { path = "../bevy_asset", version = "0.17.0-dev", optional = true }
+bevy_log = { path = "../bevy_log", version = "0.17.0-dev" }
 
 # other
 anyhow = "1"
@@ -38,7 +39,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.140"
 http-body-util = "0.1"
 async-channel = "2"
-bevy_log = { version = "0.17.0-dev", path = "../bevy_log" }
 
 # dependencies that will not compile on wasm
 [target.'cfg(not(target_family = "wasm"))'.dependencies]


### PR DESCRIPTION
# Objective

- bevy_log is not "others". it's part of Bevy

## Solution

- Move it
- Also use the same format as other Bevy dependency (path first) as I use it in some regexes to run tests on the repo
