### PR TITLE
enable syn/full in bevy_render_macros

### DIFF
--- a/crates/bevy_render/macros/Cargo.toml
+++ b/crates/bevy_render/macros/Cargo.toml
@@ -14,7 +14,7 @@ proc-macro = true
 [dependencies]
 bevy_macro_utils = { path = "../../bevy_macro_utils", version = "0.17.0-dev" }
 
-syn = "2.0"
+syn = { version = "2.0", features = ["full"] }
 proc-macro2 = "1.0"
 quote = "1.0"
 


### PR DESCRIPTION
# Objective

- `bevy_render_macros` fails to build on its own:
```
error[E0432]: unresolved import `syn::Pat`
   --> crates/bevy_render/macros/src/specializer.rs:13:69
    |
13  |     DeriveInput, Expr, Field, Ident, Index, Member, Meta, MetaList, Pat, Path, Token, Type,
    |                                                                     ^^^
    |                                                                     |
    |                                                                     no `Pat` in the root
    |                                                                     help: a similar name exists in the module: `Path`
    |
note: found an item that was configured out
   --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/syn-2.0.104/src/lib.rs:485:15
    |
485 |     FieldPat, Pat, PatConst, PatIdent, PatLit, PatMacro, PatOr, PatParen, PatPath, PatRange,
    |               ^^^
note: the item is gated behind the `full` feature
   --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/syn-2.0.104/src/lib.rs:482:7
    |
482 | #[cfg(feature = "full")]
    |       ^^^^^^^^^^^^^^^^
```

## Solution

- Enable the `full` feature of `syn`
