### PR TITLE
StandardMaterial docs: Make clear that lighting won't look correct if `is_srgb` is `false`

### DIFF
--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -386,6 +386,17 @@ pub struct StandardMaterial {
     ///
     /// [`Mesh::generate_tangents`]: bevy_render::mesh::Mesh::generate_tangents
     /// [`Mesh::with_generated_tangents`]: bevy_render::mesh::Mesh::with_generated_tangents
+    ///
+    /// # Usage
+    ///
+    /// ```rust
+    /// let normal_handle = asset_server.load_with_settings(
+    ///     "textures/parallax_example/cube_normal.png",
+    ///     // The normal map texture is in linear color space. Lighting won't look correct
+    ///     // if `is_srgb` is `true`, which is the default.
+    ///     |settings: &mut ImageLoaderSettings| settings.is_srgb = false,
+    /// );
+    /// ```
     #[texture(9)]
     #[sampler(10)]
     #[dependency]


### PR DESCRIPTION
# Objective

- Fix https://github.com/bevyengine/bevy/issues/12123

## Solution

- Add a code example found here: https://github.com/bevyengine/bevy/blob/main/examples/3d/parallax_mapping.rs#L209 to https://docs.rs/bevy/latest/bevy/pbr/struct.StandardMaterial.html

## Testing

- This pull request if only changing docs. But I tested the formatting via ```cargo doc --no-deps --open```.