### PR TITLE
Friendlier Entity Debug impl

### DIFF
--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -615,41 +615,19 @@ impl<'de> Deserialize<'de> for Entity {
     }
 }
 
-/// Outputs the full entity identifier, including the index, generation, and the raw bits.
+/// Outputs the short entity identifier, including the index and generation.
 ///
-/// This takes the format: `{index}v{generation}#{bits}`.
+/// This takes the format: `{index}v{generation}`.
 ///
 /// For [`Entity::PLACEHOLDER`], this outputs `PLACEHOLDER`.
 ///
-/// # Usage
-///
-/// Prefer to use this format for debugging and logging purposes. Because the output contains
-/// the raw bits, it is easy to check it against serialized scene data.
-///
-/// Example serialized scene data:
-/// ```text
-/// (
-///   ...
-///   entities: {
-///     4294967297: (  <--- Raw Bits
-///       components: {
-///         ...
-///       ),
-///   ...
-/// )
-/// ```
+/// For a unique [`u64`] representation, use [`Entity::to_bits`].
 impl fmt::Debug for Entity {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self == &Self::PLACEHOLDER {
             write!(f, "PLACEHOLDER")
         } else {
-            write!(
-                f,
-                "{}v{}#{}",
-                self.index(),
-                self.generation(),
-                self.to_bits()
-            )
+            write!(f, "{}v{}", self.index(), self.generation())
         }
     }
 }


### PR DESCRIPTION
# Objective

The current Entity Debug impl prints the bit representation. This is an "overshare". Debug is in many ways the primary interface into Entity, as people derive Debug on their entity-containing types when they want to inspect them. The bits take up too much space in the console and obfuscate the useful information (entity index and generation).

## Solution

Use the Display implementation in Debug as well. Direct people interested in bits to `Entity::to_bits` in the docs.