### PR TITLE
Allow UnevenSampleCurve to infer interpolation arguments from samples

### DIFF
--- a/crates/bevy_math/src/curve/sample_curves.rs
+++ b/crates/bevy_math/src/curve/sample_curves.rs
@@ -279,7 +279,10 @@ impl<T, I> UnevenSampleCurve<T, I> {
     pub fn new(
         timed_samples: impl IntoIterator<Item = (f32, T)>,
         interpolation: I,
-    ) -> Result<Self, UnevenCoreError> {
+    ) -> Result<Self, UnevenCoreError>
+    where
+        I: Fn(&T, &T, f32) -> T,
+    {
         Ok(Self {
             core: UnevenCore::new(timed_samples)?,
             interpolation,
@@ -402,5 +405,12 @@ mod tests {
         let _: Box<dyn Reflect> = Box::new(UnevenSampleCurve::new(keyframes, foo).unwrap());
         let _: Box<dyn Reflect> = Box::new(UnevenSampleCurve::new(keyframes, bar).unwrap());
         let _: Box<dyn Reflect> = Box::new(UnevenSampleCurve::new(keyframes, baz).unwrap());
+    }
+    #[test]
+    fn test_infer_interp_arguments() {
+        // it should be possible to infer the x and y arguments of the interpolation function
+        // from the input samples. If that becomes impossible, this will fail to compile.
+        SampleCurve::new(Interval::UNIT, [0.0, 1.0], |x, y, t| x.lerp(*y, t)).ok();
+        UnevenSampleCurve::new([(0.1, 1.0), (1.0, 3.0)], |x, y, t| x.lerp(*y, t)).ok();
     }
 }


### PR DESCRIPTION
# Objective
`bevy_math::curve::UnevenSampleCurve` was lacking trait bounds on its `new` method which caused a need to manually specify interpolation function argument types, even though the types are already known from the timed_samples argument.

```rs
UnevenSampleCurve::new(
    [(0.1, 1.0), (1.0, 3.0)],
    |x: &f64, y: &f64, t| x.lerp(*y, t)
//      ^ ugly and annoying
)
```

## Solution

This adds the `Fn` trait bound to the new method, matching the behaviour of `SampleCurve`.

## Testing

I added a test which doesn't actually test for any runtime behaviour, instead writing code that would error before this PR.

---

## Showcase

It's now possible to create a `UnevenSampleCurve` without specifying the interpolation closure argument types.

```diff
UnevenSampleCurve::new(
    [(0.1, 1.0), (1.0, 3.0)],
-   |x: &f64, y: &f64, t| x.lerp(*y, t)
+   |x, y, t| x.lerp(*y, t)
)
```


### Sidenote
Seeing `x` and `y` in lerp feels wrong, I've always used `a` and `b` to avoid confusion with coordinates.
