### PR TITLE
Focus rings for feathers widgets and core widget examples.

### DIFF
--- a/crates/bevy_feathers/src/controls/button.rs
+++ b/crates/bevy_feathers/src/controls/button.rs
@@ -24,7 +24,7 @@ use crate::{
     handle_or_path::HandleOrPath,
     rounded_corners::RoundedCorners,
     theme::{ThemeBackgroundColor, ThemeFontColor},
-    tokens, VisibleFocusAnchor,
+    tokens, FocusIndicator,
 };
 
 /// Color variants for buttons. This also functions as a component used by the dynamic styling
@@ -74,7 +74,7 @@ pub fn button<C: SpawnableList<ChildOf> + Send + Sync + 'static, B: Bundle>(
         Hovered::default(),
         EntityCursor::System(bevy_window::SystemCursorIcon::Pointer),
         TabIndex(0),
-        VisibleFocusAnchor,
+        FocusIndicator,
         props.corners.to_border_radius(4.0),
         ThemeBackgroundColor(tokens::BUTTON_BG),
         ThemeFontColor(tokens::BUTTON_TEXT),

--- a/crates/bevy_feathers/src/controls/button.rs
+++ b/crates/bevy_feathers/src/controls/button.rs
@@ -24,7 +24,7 @@ use crate::{
     handle_or_path::HandleOrPath,
     rounded_corners::RoundedCorners,
     theme::{ThemeBackgroundColor, ThemeFontColor},
-    tokens,
+    tokens, VisibleFocusAnchor,
 };
 
 /// Color variants for buttons. This also functions as a component used by the dynamic styling
@@ -74,6 +74,7 @@ pub fn button<C: SpawnableList<ChildOf> + Send + Sync + 'static, B: Bundle>(
         Hovered::default(),
         EntityCursor::System(bevy_window::SystemCursorIcon::Pointer),
         TabIndex(0),
+        VisibleFocusAnchor,
         props.corners.to_border_radius(4.0),
         ThemeBackgroundColor(tokens::BUTTON_BG),
         ThemeFontColor(tokens::BUTTON_TEXT),

--- a/crates/bevy_feathers/src/controls/checkbox.rs
+++ b/crates/bevy_feathers/src/controls/checkbox.rs
@@ -29,7 +29,7 @@ use crate::{
     font_styles::InheritableFont,
     handle_or_path::HandleOrPath,
     theme::{ThemeBackgroundColor, ThemeBorderColor, ThemeFontColor},
-    tokens, VisibleFocusAnchor,
+    tokens, FocusIndicator,
 };
 
 /// Marker for the checkbox frame (contains both checkbox and label)
@@ -86,7 +86,7 @@ pub fn checkbox<C: SpawnableList<ChildOf> + Send + Sync + 'static, B: Bundle>(
                     ..Default::default()
                 },
                 CheckboxOutline,
-                VisibleFocusAnchor,
+                FocusIndicator,
                 BorderRadius::all(Val::Px(4.0)),
                 ThemeBackgroundColor(tokens::CHECKBOX_BG),
                 ThemeBorderColor(tokens::CHECKBOX_BORDER),

--- a/crates/bevy_feathers/src/controls/checkbox.rs
+++ b/crates/bevy_feathers/src/controls/checkbox.rs
@@ -29,7 +29,7 @@ use crate::{
     font_styles::InheritableFont,
     handle_or_path::HandleOrPath,
     theme::{ThemeBackgroundColor, ThemeBorderColor, ThemeFontColor},
-    tokens,
+    tokens, VisibleFocusAnchor,
 };
 
 /// Marker for the checkbox frame (contains both checkbox and label)
@@ -86,6 +86,7 @@ pub fn checkbox<C: SpawnableList<ChildOf> + Send + Sync + 'static, B: Bundle>(
                     ..Default::default()
                 },
                 CheckboxOutline,
+                VisibleFocusAnchor,
                 BorderRadius::all(Val::Px(4.0)),
                 ThemeBackgroundColor(tokens::CHECKBOX_BG),
                 ThemeBorderColor(tokens::CHECKBOX_BORDER),

--- a/crates/bevy_feathers/src/controls/color_slider.rs
+++ b/crates/bevy_feathers/src/controls/color_slider.rs
@@ -30,7 +30,7 @@ use crate::{
     cursor::EntityCursor,
     palette,
     rounded_corners::RoundedCorners,
-    VisibleFocusAnchor,
+    FocusIndicator,
 };
 
 const SLIDER_HEIGHT: f32 = 16.0;
@@ -201,7 +201,7 @@ pub fn color_slider<B: Bundle>(props: ColorSliderProps, overrides: B) -> impl Bu
         props.channel.range(),
         EntityCursor::System(bevy_window::SystemCursorIcon::Pointer),
         TabIndex(0),
-        VisibleFocusAnchor,
+        FocusIndicator,
         overrides,
         children![
             // track

--- a/crates/bevy_feathers/src/controls/color_slider.rs
+++ b/crates/bevy_feathers/src/controls/color_slider.rs
@@ -30,6 +30,7 @@ use crate::{
     cursor::EntityCursor,
     palette,
     rounded_corners::RoundedCorners,
+    VisibleFocusAnchor,
 };
 
 const SLIDER_HEIGHT: f32 = 16.0;
@@ -196,9 +197,11 @@ pub fn color_slider<B: Bundle>(props: ColorSliderProps, overrides: B) -> impl Bu
             channel: props.channel.clone(),
         },
         SliderValue(props.value),
+        SliderStep(0.01),
         props.channel.range(),
         EntityCursor::System(bevy_window::SystemCursorIcon::Pointer),
         TabIndex(0),
+        VisibleFocusAnchor,
         overrides,
         children![
             // track

--- a/crates/bevy_feathers/src/controls/color_slider.rs
+++ b/crates/bevy_feathers/src/controls/color_slider.rs
@@ -23,7 +23,7 @@ use bevy_ui::{
     UiRect, UiTransform, Val, Val2, ZIndex,
 };
 use bevy_ui_render::ui_material::MaterialNode;
-use bevy_ui_widgets::{Slider, SliderRange, SliderThumb, SliderValue, TrackClick};
+use bevy_ui_widgets::{Slider, SliderRange, SliderStep, SliderThumb, SliderValue, TrackClick};
 
 use crate::{
     alpha_pattern::{AlphaPattern, AlphaPatternMaterial},

--- a/crates/bevy_feathers/src/controls/radio.rs
+++ b/crates/bevy_feathers/src/controls/radio.rs
@@ -13,7 +13,6 @@ use bevy_ecs::{
     spawn::{Spawn, SpawnRelated, SpawnableList},
     system::{Commands, Query},
 };
-use bevy_input_focus::tab_navigation::TabIndex;
 use bevy_picking::{hover::Hovered, PickingSystems};
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_ui::{
@@ -63,7 +62,6 @@ pub fn radio<C: SpawnableList<ChildOf> + Send + Sync + 'static, B: Bundle>(
         RadioButton,
         Hovered::default(),
         EntityCursor::System(bevy_window::SystemCursorIcon::Pointer),
-        TabIndex(0),
         ThemeFontColor(tokens::RADIO_TEXT),
         InheritableFont {
             font: HandleOrPath::Path(fonts::REGULAR.to_owned()),

--- a/crates/bevy_feathers/src/controls/slider.rs
+++ b/crates/bevy_feathers/src/controls/slider.rs
@@ -32,7 +32,7 @@ use crate::{
     handle_or_path::HandleOrPath,
     rounded_corners::RoundedCorners,
     theme::{ThemeFontColor, ThemedText, UiTheme},
-    tokens,
+    tokens, VisibleFocusAnchor,
 };
 
 /// Slider template properties, passed to [`slider`] function.
@@ -90,6 +90,7 @@ pub fn slider<B: Bundle>(props: SliderProps, overrides: B) -> impl Bundle {
         SliderRange::new(props.min, props.max),
         EntityCursor::System(bevy_window::SystemCursorIcon::EwResize),
         TabIndex(0),
+        VisibleFocusAnchor,
         RoundedCorners::All.to_border_radius(6.0),
         // Use a gradient to draw the moving bar
         BackgroundGradient(vec![Gradient::Linear(LinearGradient {

--- a/crates/bevy_feathers/src/controls/slider.rs
+++ b/crates/bevy_feathers/src/controls/slider.rs
@@ -32,7 +32,7 @@ use crate::{
     handle_or_path::HandleOrPath,
     rounded_corners::RoundedCorners,
     theme::{ThemeFontColor, ThemedText, UiTheme},
-    tokens, VisibleFocusAnchor,
+    tokens, FocusIndicator,
 };
 
 /// Slider template properties, passed to [`slider`] function.
@@ -90,7 +90,7 @@ pub fn slider<B: Bundle>(props: SliderProps, overrides: B) -> impl Bundle {
         SliderRange::new(props.min, props.max),
         EntityCursor::System(bevy_window::SystemCursorIcon::EwResize),
         TabIndex(0),
-        VisibleFocusAnchor,
+        FocusIndicator,
         RoundedCorners::All.to_border_radius(6.0),
         // Use a gradient to draw the moving bar
         BackgroundGradient(vec![Gradient::Linear(LinearGradient {

--- a/crates/bevy_feathers/src/controls/toggle_switch.rs
+++ b/crates/bevy_feathers/src/controls/toggle_switch.rs
@@ -25,7 +25,7 @@ use crate::{
     constants::size,
     cursor::EntityCursor,
     theme::{ThemeBackgroundColor, ThemeBorderColor},
-    tokens, VisibleFocusAnchor,
+    tokens, FocusIndicator,
 };
 
 /// Marker for the toggle switch outline
@@ -60,7 +60,7 @@ pub fn toggle_switch<B: Bundle>(overrides: B) -> impl Bundle {
         Hovered::default(),
         EntityCursor::System(bevy_window::SystemCursorIcon::Pointer),
         TabIndex(0),
-        VisibleFocusAnchor,
+        FocusIndicator,
         overrides,
         children![(
             Node {

--- a/crates/bevy_feathers/src/controls/toggle_switch.rs
+++ b/crates/bevy_feathers/src/controls/toggle_switch.rs
@@ -25,7 +25,7 @@ use crate::{
     constants::size,
     cursor::EntityCursor,
     theme::{ThemeBackgroundColor, ThemeBorderColor},
-    tokens,
+    tokens, VisibleFocusAnchor,
 };
 
 /// Marker for the toggle switch outline
@@ -60,6 +60,7 @@ pub fn toggle_switch<B: Bundle>(overrides: B) -> impl Bundle {
         Hovered::default(),
         EntityCursor::System(bevy_window::SystemCursorIcon::Pointer),
         TabIndex(0),
+        VisibleFocusAnchor,
         overrides,
         children![(
             Node {

--- a/crates/bevy_feathers/src/dark_theme.rs
+++ b/crates/bevy_feathers/src/dark_theme.rs
@@ -10,6 +10,7 @@ pub fn create_dark_theme() -> ThemeProps {
     ThemeProps {
         color: HashMap::from([
             (tokens::WINDOW_BG, palette::GRAY_0),
+            (tokens::FOCUS_RING, palette::ACCENT.with_alpha(0.5)),
             // Button
             (tokens::BUTTON_BG, palette::GRAY_3),
             (tokens::BUTTON_BG_HOVER, palette::GRAY_3.lighter(0.05)),

--- a/crates/bevy_feathers/src/focus.rs
+++ b/crates/bevy_feathers/src/focus.rs
@@ -1,0 +1,102 @@
+//! This module contains the infrastructure needed for displaying focus outlines.
+
+use bevy_app::{Plugin, PostUpdate};
+use bevy_ecs::{
+    change_detection::DetectChanges,
+    component::Component,
+    entity::Entity,
+    hierarchy::Children,
+    query::With,
+    reflect::ReflectComponent,
+    schedule::IntoScheduleConfigs,
+    system::{Commands, Query, Res},
+};
+use bevy_input_focus::InputFocus;
+use bevy_reflect::{prelude::ReflectDefault, Reflect};
+use bevy_ui::{BorderRadius, GlobalZIndex, Node, Outline, PositionType, UiSystems, Val};
+
+use crate::{theme::UiTheme, tokens};
+
+/// A marker component which indicates that this entity should display a visible focus outline
+/// when either it, or its ancestor, are focused. Insert this into a widget on the entity that
+/// you wisth to display a focus outline.
+#[derive(Component, Default, Clone, Reflect)]
+#[reflect(Component, Clone, Default)]
+pub struct VisibleFocusAnchor;
+
+/// A marker used to identify a visible focus outline.
+#[derive(Component, Default, Clone, Reflect)]
+#[reflect(Component, Clone, Default)]
+struct FocusOutline;
+
+fn focus_system(
+    mut commands: Commands,
+    focus: Res<InputFocus>,
+    theme: Res<UiTheme>,
+    q_focus_outlines: Query<Entity, With<FocusOutline>>,
+    q_focus_anchors: Query<&BorderRadius, With<VisibleFocusAnchor>>,
+    q_children: Query<&Children>,
+) {
+    if focus.is_changed() {
+        // Start by despawning all the existing focus outlines
+        for outline in q_focus_outlines.iter() {
+            commands.entity(outline).despawn();
+        }
+
+        // Walk the descendants of the current focus element.
+        if let Some(focused) = focus.0 {
+            spawn_focus_rings(
+                &mut commands,
+                focused,
+                &q_children,
+                &q_focus_anchors,
+                theme.as_ref(),
+            );
+        }
+    }
+}
+
+fn spawn_focus_rings(
+    commands: &mut Commands,
+    parent: Entity,
+    q_children: &Query<&Children>,
+    q_anchors: &Query<&BorderRadius, With<VisibleFocusAnchor>>,
+    theme: &UiTheme,
+) {
+    if let Ok(radii) = q_anchors.get(parent) {
+        let outline = commands
+            .spawn((
+                Node {
+                    position_type: PositionType::Absolute,
+                    left: Val::Px(0.0),
+                    right: Val::Px(0.0),
+                    top: Val::Px(0.0),
+                    bottom: Val::Px(0.0),
+                    ..Default::default()
+                },
+                FocusOutline,
+                GlobalZIndex(100),
+                Outline {
+                    color: theme.color(tokens::FOCUS_RING),
+                    width: Val::Px(2.0),
+                    offset: Val::Px(2.0),
+                },
+                *radii,
+            ))
+            .id();
+        commands.entity(parent).add_child(outline);
+    } else if let Ok(children) = q_children.get(parent) {
+        for child in children {
+            spawn_focus_rings(commands, *child, q_children, q_anchors, theme);
+        }
+    }
+}
+
+/// Plugin which registers the systems for updating focus outlines.
+pub struct FocusOutlinesPlugin;
+
+impl Plugin for FocusOutlinesPlugin {
+    fn build(&self, app: &mut bevy_app::App) {
+        app.add_systems(PostUpdate, (focus_system).in_set(UiSystems::Content));
+    }
+}

--- a/crates/bevy_feathers/src/focus.rs
+++ b/crates/bevy_feathers/src/focus.rs
@@ -11,7 +11,7 @@ use bevy_ecs::{
     schedule::IntoScheduleConfigs,
     system::{Commands, Query, Res},
 };
-use bevy_input_focus::InputFocus;
+use bevy_input_focus::{InputFocus, InputFocusVisible};
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_ui::{BorderRadius, GlobalZIndex, Node, Outline, PositionType, UiSystems, Val};
 
@@ -32,6 +32,7 @@ struct FocusOutline;
 fn focus_system(
     mut commands: Commands,
     focus: Res<InputFocus>,
+    focus_visible: Res<InputFocusVisible>,
     theme: Res<UiTheme>,
     q_focus_outlines: Query<Entity, With<FocusOutline>>,
     q_focus_anchors: Query<&BorderRadius, With<VisibleFocusAnchor>>,
@@ -44,7 +45,9 @@ fn focus_system(
         }
 
         // Walk the descendants of the current focus element.
-        if let Some(focused) = focus.0 {
+        if focus_visible.0
+            && let Some(focused) = focus.0
+        {
             spawn_focus_rings(
                 &mut commands,
                 focused,

--- a/crates/bevy_feathers/src/focus.rs
+++ b/crates/bevy_feathers/src/focus.rs
@@ -22,7 +22,7 @@ use crate::{theme::UiTheme, tokens};
 /// you wisth to display a focus outline.
 #[derive(Component, Default, Clone, Reflect)]
 #[reflect(Component, Clone, Default)]
-pub struct VisibleFocusAnchor;
+pub struct FocusIndicator;
 
 /// A marker used to identify a visible focus outline.
 #[derive(Component, Default, Clone, Reflect)]
@@ -35,7 +35,7 @@ fn focus_system(
     focus_visible: Res<InputFocusVisible>,
     theme: Res<UiTheme>,
     q_focus_outlines: Query<Entity, With<FocusOutline>>,
-    q_focus_anchors: Query<&BorderRadius, With<VisibleFocusAnchor>>,
+    q_focus_anchors: Query<&BorderRadius, With<FocusIndicator>>,
     q_children: Query<&Children>,
 ) {
     if focus.is_changed() {
@@ -63,7 +63,7 @@ fn spawn_focus_rings(
     commands: &mut Commands,
     parent: Entity,
     q_children: &Query<&Children>,
-    q_anchors: &Query<&BorderRadius, With<VisibleFocusAnchor>>,
+    q_anchors: &Query<&BorderRadius, With<FocusIndicator>>,
     theme: &UiTheme,
 ) {
     if let Ok(radii) = q_anchors.get(parent) {

--- a/crates/bevy_feathers/src/focus.rs
+++ b/crates/bevy_feathers/src/focus.rs
@@ -80,7 +80,7 @@ fn spawn_focus_rings(
                 FocusOutline,
                 GlobalZIndex(100),
                 Outline {
-                    color: theme.color(tokens::FOCUS_RING),
+                    color: theme.color(&tokens::FOCUS_RING),
                     width: Val::Px(2.0),
                     offset: Val::Px(2.0),
                 },

--- a/crates/bevy_feathers/src/lib.rs
+++ b/crates/bevy_feathers/src/lib.rs
@@ -35,12 +35,14 @@ use crate::{
     cursor::{CursorIconPlugin, DefaultCursor, EntityCursor},
     theme::{ThemedText, UiTheme},
 };
+pub use focus::{FocusOutlinesPlugin, VisibleFocusAnchor};
 
 mod alpha_pattern;
 pub mod constants;
 pub mod controls;
 pub mod cursor;
 pub mod dark_theme;
+mod focus;
 pub mod font_styles;
 pub mod handle_or_path;
 pub mod palette;
@@ -68,6 +70,7 @@ impl Plugin for FeathersPlugin {
         app.add_plugins((
             ControlsPlugin,
             CursorIconPlugin,
+            FocusOutlinesPlugin,
             HierarchyPropagatePlugin::<TextColor, With<ThemedText>>::new(PostUpdate),
             HierarchyPropagatePlugin::<TextFont, With<ThemedText>>::new(PostUpdate),
             UiMaterialPlugin::<AlphaPatternMaterial>::default(),

--- a/crates/bevy_feathers/src/lib.rs
+++ b/crates/bevy_feathers/src/lib.rs
@@ -35,7 +35,7 @@ use crate::{
     cursor::{CursorIconPlugin, DefaultCursor, EntityCursor},
     theme::{ThemedText, UiTheme},
 };
-pub use focus::{FocusOutlinesPlugin, VisibleFocusAnchor};
+pub use focus::{FocusIndicator, FocusOutlinesPlugin};
 
 mod alpha_pattern;
 pub mod constants;

--- a/examples/ui/feathers.rs
+++ b/examples/ui/feathers.rs
@@ -13,7 +13,7 @@ use bevy::{
         theme::{ThemeBackgroundColor, ThemedText, UiTheme},
         tokens, FeathersPlugins, FocusIndicator,
     },
-    input_focus::tab_navigation::TabGroup,
+    input_focus::tab_navigation::{TabGroup, TabIndex},
     prelude::*,
     ui::{Checked, InteractionDisabled},
     ui_widgets::{

--- a/examples/ui/feathers.rs
+++ b/examples/ui/feathers.rs
@@ -11,7 +11,7 @@ use bevy::{
         dark_theme::create_dark_theme,
         rounded_corners::RoundedCorners,
         theme::{ThemeBackgroundColor, ThemedText, UiTheme},
-        tokens, FeathersPlugins,
+        tokens, FeathersPlugins, FocusIndicator,
     },
     input_focus::tab_navigation::TabGroup,
     prelude::*,
@@ -239,7 +239,7 @@ fn demo_root() -> impl Bundle {
                     },
                     RadioGroup,
                     TabIndex(0),
-                    VisibleFocusAnchor,
+                    FocusIndicator,
                     observe(
                         |value_change: On<ValueChange<Entity>>,
                          q_radio: Query<Entity, With<RadioButton>>,

--- a/examples/ui/feathers.rs
+++ b/examples/ui/feathers.rs
@@ -238,6 +238,8 @@ fn demo_root() -> impl Bundle {
                         ..default()
                     },
                     RadioGroup,
+                    TabIndex(0),
+                    VisibleFocusAnchor,
                     observe(
                         |value_change: On<ValueChange<Entity>>,
                          q_radio: Query<Entity, With<RadioButton>>,

--- a/examples/ui/standard_widgets.rs
+++ b/examples/ui/standard_widgets.rs
@@ -7,7 +7,7 @@
 //! and note that there are still "user experience" issues with this API.
 
 use bevy::{
-    color::palettes::basic::*,
+    color::palettes::{self, basic::*},
     input_focus::{
         tab_navigation::{TabGroup, TabIndex, TabNavigationPlugin},
         InputDispatchPlugin, InputFocus,

--- a/examples/ui/standard_widgets.rs
+++ b/examples/ui/standard_widgets.rs
@@ -10,7 +10,7 @@ use bevy::{
     color::palettes::basic::*,
     input_focus::{
         tab_navigation::{TabGroup, TabIndex, TabNavigationPlugin},
-        InputDispatchPlugin,
+        InputDispatchPlugin, InputFocus,
     },
     picking::hover::Hovered,
     prelude::*,
@@ -46,6 +46,7 @@ fn main() {
                 update_checkbox_or_radio_style.after(update_widget_values),
                 update_checkbox_or_radio_style2.after(update_widget_values),
                 toggle_disabled,
+                focus_system,
             ),
         )
         .run();
@@ -749,6 +750,26 @@ fn toggle_disabled(
             } else {
                 info!("Widget disabled");
                 commands.entity(entity).insert(InteractionDisabled);
+            }
+        }
+    }
+}
+
+fn focus_system(
+    mut commands: Commands,
+    focus: Res<InputFocus>,
+    mut query: Query<Entity, With<TabIndex>>,
+) {
+    if focus.is_changed() {
+        for button in query.iter_mut() {
+            if focus.0 == Some(button) {
+                commands.entity(button).insert(Outline {
+                    color: palettes::tailwind::BLUE_700.into(),
+                    width: Val::Px(2.0),
+                    offset: Val::Px(2.0),
+                });
+            } else {
+                commands.entity(button).remove::<Outline>();
             }
         }
     }


### PR DESCRIPTION
# Objective

Add focus rings for:

* Core widget examples
* Feathers widgets

Part of #19236 

<img width="380" alt="Screenshot 2025-07-08 at 4 23 25 PM" src="https://github.com/user-attachments/assets/f0fd75c0-be92-458d-8aef-eabe5e33eb3d" />

@alice-i-cecile 
