### PR TITLE
Factor out up-choice in shadow cubemap sampling orthonormalize

### DIFF
--- a/crates/bevy_pbr/src/render/shadow_sampling.wgsl
+++ b/crates/bevy_pbr/src/render/shadow_sampling.wgsl
@@ -422,11 +422,7 @@ fn sample_shadow_cubemap_gaussian(
 ) -> f32 {
     // Create an orthonormal basis so we can apply a 2D sampling pattern to a
     // cubemap.
-    var up = vec3(0.0, 1.0, 0.0);
-    if (dot(up, normalize(light_local)) > 0.99) {
-        up = vec3(1.0, 0.0, 0.0);   // Avoid creating a degenerate basis.
-    }
-    let basis = orthonormalize(light_local, up) * scale * distance_to_light;
+    let basis = orthonormalize(normalize(light_local)) * scale * distance_to_light;
 
     var sum: f32 = 0.0;
     sum += sample_shadow_cubemap_at_offset(
@@ -469,11 +465,7 @@ fn sample_shadow_cubemap_jittered(
 ) -> f32 {
     // Create an orthonormal basis so we can apply a 2D sampling pattern to a
     // cubemap.
-    var up = vec3(0.0, 1.0, 0.0);
-    if (dot(up, normalize(light_local)) > 0.99) {
-        up = vec3(1.0, 0.0, 0.0);   // Avoid creating a degenerate basis.
-    }
-    let basis = orthonormalize(light_local, up) * scale * distance_to_light;
+    let basis = orthonormalize(normalize(light_local)) * scale * distance_to_light;
 
     let rotation_matrix = random_rotation_matrix(vec2(1.0), temporal);
 
@@ -553,11 +545,7 @@ fn search_for_blockers_in_shadow_cubemap(
 ) -> f32 {
     // Create an orthonormal basis so we can apply a 2D sampling pattern to a
     // cubemap.
-    var up = vec3(0.0, 1.0, 0.0);
-    if (dot(up, normalize(light_local)) > 0.99) {
-        up = vec3(1.0, 0.0, 0.0);   // Avoid creating a degenerate basis.
-    }
-    let basis = orthonormalize(light_local, up) * scale * distance_to_light;
+    let basis = orthonormalize(normalize(light_local)) * scale * distance_to_light;
 
     var sum: vec2<f32> = vec2(0.0);
     sum += search_for_blockers_in_shadow_cubemap_at_offset(

--- a/crates/bevy_render/src/maths.wgsl
+++ b/crates/bevy_render/src/maths.wgsl
@@ -68,14 +68,14 @@ fn mat4x4_to_mat3x3(m: mat4x4<f32>) -> mat3x3<f32> {
 // The results are equivalent to the Gram-Schmidt process [1].
 //
 // [1]: https://math.stackexchange.com/a/1849294
-fn orthonormalize(z_basis: vec3<f32>) -> mat3x3<f32> {
+fn orthonormalize(z_normalized: vec3<f32>) -> mat3x3<f32> {
     var up = vec3(0.0, 1.0, 0.0);
-    if (abs(dot(up, z_basis)) > 0.99) {
+    if (abs(dot(up, z_normalized)) > 0.99) {
         up = vec3(1.0, 0.0, 0.0); // Avoid creating a degenerate basis.
     }
-    let x_basis = normalize(cross(z_basis, up));
-    let y_basis = cross(z_basis, x_basis);
-    return mat3x3(x_basis, y_basis, z_basis);
+    let x_basis = normalize(cross(z_normalized, up));
+    let y_basis = cross(z_normalized, x_basis);
+    return mat3x3(x_basis, y_basis, z_normalized);
 }
 
 // Returns true if any part of a sphere is on the positive side of a plane.

--- a/crates/bevy_render/src/maths.wgsl
+++ b/crates/bevy_render/src/maths.wgsl
@@ -70,7 +70,7 @@ fn mat4x4_to_mat3x3(m: mat4x4<f32>) -> mat3x3<f32> {
 // [1]: https://math.stackexchange.com/a/1849294
 fn orthonormalize(z_basis: vec3<f32>) -> mat3x3<f32> {
     var up = vec3(0.0, 1.0, 0.0);
-    if (dot(up, z_basis) > 0.99) {
+    if (abs(dot(up, z_basis)) > 0.99) {
         up = vec3(1.0, 0.0, 0.0); // Avoid creating a degenerate basis.
     }
     let x_basis = normalize(cross(z_basis, up));

--- a/crates/bevy_render/src/maths.wgsl
+++ b/crates/bevy_render/src/maths.wgsl
@@ -63,14 +63,16 @@ fn mat4x4_to_mat3x3(m: mat4x4<f32>) -> mat3x3<f32> {
     return mat3x3<f32>(m[0].xyz, m[1].xyz, m[2].xyz);
 }
 
-// Creates an orthonormal basis given a Z vector and an up vector (which becomes
-// Y after orthonormalization).
+// Creates an orthonormal basis given a normalized Z vector.
 //
 // The results are equivalent to the Gram-Schmidt process [1].
 //
 // [1]: https://math.stackexchange.com/a/1849294
-fn orthonormalize(z_unnormalized: vec3<f32>, up: vec3<f32>) -> mat3x3<f32> {
-    let z_basis = normalize(z_unnormalized);
+fn orthonormalize(z_basis: vec3<f32>) -> mat3x3<f32> {
+    var up = vec3(0.0, 1.0, 0.0);
+    if (dot(up, z_basis) > 0.99) {
+        up = vec3(1.0, 0.0, 0.0); // Avoid creating a degenerate basis.
+    }
     let x_basis = normalize(cross(z_basis, up));
     let y_basis = cross(z_basis, x_basis);
     return mat3x3(x_basis, y_basis, z_basis);


### PR DESCRIPTION
# Objective

- Another step towards unifying our orthonormal basis construction #20050
- Preserve behavior but fix a bug. Unification will be a followup after these two PRs and will need more thorough testing.

## Solution

- Make shadow cubemap sampling orthonormalize have the same function signature as the other orthonormal basis functions in bevy

## Testing

- 3d_scene + lighting examples