### PR TITLE
Add zstd release note

### DIFF
--- a/crates/bevy_image/src/ktx2.rs
+++ b/crates/bevy_image/src/ktx2.rs
@@ -58,7 +58,7 @@ pub fn ktx2_buffer_to_image(
                     })?;
                     levels.push(decompressed);
                 }
-                #[cfg(feature = "zstd_rust")]
+                #[cfg(all(feature = "zstd_rust", not(feature = "zstd_c")))]
                 SupercompressionScheme::Zstandard => {
                     let mut cursor = std::io::Cursor::new(level.data);
                     let mut decoder = ruzstd::decoding::StreamingDecoder::new(&mut cursor)
@@ -71,7 +71,7 @@ pub fn ktx2_buffer_to_image(
                     })?;
                     levels.push(decompressed);
                 }
-                #[cfg(all(feature = "zstd_c", not(feature = "zstd_rust")))]
+                #[cfg(feature = "zstd_c")]
                 SupercompressionScheme::Zstandard => {
                     levels.push(zstd::decode_all(level.data).map_err(|err| {
                         TextureError::SuperDecompressionError(format!(

--- a/release-content/release-notes/faster-zstd-option.md
+++ b/release-content/release-notes/faster-zstd-option.md
@@ -22,6 +22,6 @@ To remove this dependency, disable default-features, and manually enable any def
 ```toml
 bevy = { version = "0.17.0", default-features = false, features = [
     "zstd_c",
-    "bevy_render", // etc..
+    "bevy_render", # etc..
 ] }
 ```

--- a/release-content/release-notes/faster-zstd-option.md
+++ b/release-content/release-notes/faster-zstd-option.md
@@ -1,0 +1,27 @@
+---
+title: Faster Zstd decompression option
+authors: ["@atlv24", "@brianreavis"]
+pull_requests: [19793]
+---
+
+There is now an option to use the [zstd](https://crates.io/crates/zstd) c-bindings instead of [ruzstd](https://crates.io/crates/ruzstd).
+This is less safe and portable, but can be around 44% faster.
+
+The two features that control which one is used are `zstd_rust` and `zstd_c`.
+`zstd_rust` is enabled by default, but `zstd_c` takes precedence if both are enabled.
+
+To enable it, add the feature to the `bevy` entry of your Cargo.toml:
+
+```toml
+bevy = { version = "0.17.0", features = ["zstd_c"] }
+```
+
+Note: this will still include a dependency on `ruzstd`, because mutually exclusive features are not supported by Cargo.
+To remove this dependency, disable default-features, and manually enable any default features you need:
+
+```toml
+bevy = { version = "0.17.0", default-features = false, features = [
+    "zstd_c",
+    "bevy_render", // etc..
+] }
+```


### PR DESCRIPTION
# Objective

- Add a release note for the new zstd backend.
- Doing so, I realized it was really cumbersome to enable this feature because we default-enable ruzstd AND make it take precedence if both are enabled. We can improve ux a bit by making the optional feature take precedence when both are enabled. This still doesnt remove the unneeded dependency, but oh well.

Note: it would be nice to have a way to make zstd_c not do anything when building wasm, but im not sure theres a way to do that, as it seems like it would need negative features.