### PR TITLE
Fix core widgets unconditionally enabling bevy_ui_picking_backend

### DIFF
--- a/crates/bevy_core_widgets/Cargo.toml
+++ b/crates/bevy_core_widgets/Cargo.toml
@@ -18,9 +18,7 @@ bevy_input_focus = { path = "../bevy_input_focus", version = "0.17.0-dev" }
 bevy_log = { path = "../bevy_log", version = "0.17.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.17.0-dev" }
 bevy_picking = { path = "../bevy_picking", version = "0.17.0-dev" }
-bevy_ui = { path = "../bevy_ui", version = "0.17.0-dev", features = [
-  "bevy_ui_picking_backend",
-] }
+bevy_ui = { path = "../bevy_ui", version = "0.17.0-dev" }
 
 # other
 accesskit = "0.19"


### PR DESCRIPTION
# Objective

- Fixes #19742

## Solution

- Initially I made it an optional feature on bevy_core_widgets and piped it through to bevy_internal, but then I realized that its not actually directly reference in the crate so its safe to just remove it.