### PR TITLE
Use `ErrorContext::RunCondition` variant when reporting errors from run conditions.

### DIFF
--- a/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
@@ -849,7 +849,7 @@ unsafe fn evaluate_and_fold_conditions(
                     if let RunSystemError::Failed(err) = err {
                         error_handler(
                             err,
-                            ErrorContext::System {
+                            ErrorContext::RunCondition {
                                 name: condition.name(),
                                 last_run: condition.get_last_run(),
                             },

--- a/crates/bevy_ecs/src/schedule/executor/simple.rs
+++ b/crates/bevy_ecs/src/schedule/executor/simple.rs
@@ -207,7 +207,7 @@ fn evaluate_and_fold_conditions(
                     if let RunSystemError::Failed(err) = err {
                         error_handler(
                             err,
-                            ErrorContext::System {
+                            ErrorContext::RunCondition {
                                 name: condition.name(),
                                 last_run: condition.get_last_run(),
                             },

--- a/crates/bevy_ecs/src/schedule/executor/single_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/single_threaded.rs
@@ -223,7 +223,7 @@ fn evaluate_and_fold_conditions(
                     if let RunSystemError::Failed(err) = err {
                         error_handler(
                             err,
-                            ErrorContext::System {
+                            ErrorContext::RunCondition {
                                 name: condition.name(),
                                 last_run: condition.get_last_run(),
                             },


### PR DESCRIPTION
# Objective

The `ErrorContext::RunCondition` variant is never used.  When reporting errors from a run condition, `ErrorContext::System` is currently used instead.  

## Solution

Use `ErrorContext::RunCondition` variant when reporting errors from run conditions.