### PR TITLE
Add label `Borrow`ing

### DIFF
--- a/crates/bevy_ecs/src/label.rs
+++ b/crates/bevy_ecs/src/label.rs
@@ -150,6 +150,12 @@ macro_rules! define_label {
             }
         }
 
+        impl ::core::borrow::Borrow<dyn $label_trait_name> for $crate::intern::Interned<dyn $label_trait_name> {
+            fn borrow(&self) -> &dyn $label_trait_name {
+                &**self
+            }
+        }
+
         impl $crate::intern::Internable for dyn $label_trait_name {
             fn leak(&self) -> &'static Self {
                 $crate::label::Box::leak(self.dyn_clone())

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -841,7 +841,7 @@ impl ScheduleGraph {
 
     /// Returns `true` if the given system set is part of the graph. Otherwise, returns `false`.
     pub fn contains_set(&self, set: impl SystemSet) -> bool {
-        self.system_sets.ids.contains_key(&set.intern())
+        self.system_sets.ids.contains_key(&set as &dyn SystemSet)
     }
 
     /// Returns the system at the given [`NodeId`].


### PR DESCRIPTION
# Objective

- Require `.intern()` in fewer cases

## Solution

Implementing the [`Borrow`](https://doc.rust-lang.org/std/borrow/trait.Borrow.html) trait for `Interned<dyn MyLabel>` means data structures like `HashMap` will accept `&dyn MyLabel` for `get`, `contains`, etc.

The old way of fetching by eagerly interning still works:
```rust
struct MyStruct {
    map: HashMap<InternedMyLabel, MyThing>
}

impl MyStruct {
    pub fn get(&self, label: impl MyLabel) -> &MyThing {
        self.map.get(&label.intern())
    }
}
```

But these options are now also available:
```rust
impl MyStruct {
    pub fn get(&self, label: &dyn MyLabel) -> &MyThing {
        self.map.get(label)
    }
    
    // or
    pub fn get(&self, label: impl MyLabel) -> &MyThing {
        self.map.get(&label as &dyn MyLabel)
    }
}
```

Note: doing the following results in an error that `MyLabel` doesn't implement `Hash`:
```rust
impl MyStruct {
    pub fn get(&self, label: impl MyLabel) -> &MyThing {
        self.map.get(&label)
    }
}