### PR TITLE
Fix anisotropy not working when material is lit by environment map light

### DIFF
--- a/crates/bevy_pbr/src/render/pbr_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_functions.wgsl
@@ -604,21 +604,6 @@ fn apply_pbr_lighting(
 
     // Environment map light (indirect)
 #ifdef ENVIRONMENT_MAP
-
-#ifdef STANDARD_MATERIAL_ANISOTROPY
-    var bent_normal_lighting_input = lighting_input;
-    bend_normal_for_anisotropy(&bent_normal_lighting_input);
-    let environment_map_lighting_input = &bent_normal_lighting_input;
-#else   // STANDARD_MATERIAL_ANISOTROPY
-    let environment_map_lighting_input = &lighting_input;
-#endif  // STANDARD_MATERIAL_ANISOTROPY
-
-    let environment_light = environment_map::environment_map_light(
-        environment_map_lighting_input,
-        &clusterable_object_index_ranges,
-        found_diffuse_indirect,
-    );
-
     // If screen space reflections are going to be used for this material, don't
     // accumulate environment map light yet. The SSR shader will do it.
 #ifdef SCREEN_SPACE_REFLECTIONS
@@ -627,18 +612,25 @@ fn apply_pbr_lighting(
 #else   // SCREEN_SPACE_REFLECTIONS
     let use_ssr = false;
 #endif  // SCREEN_SPACE_REFLECTIONS
-
+    
     if (!use_ssr) {
+#ifdef STANDARD_MATERIAL_ANISOTROPY
+        var bent_normal_lighting_input = lighting_input;
+        bend_normal_for_anisotropy(&bent_normal_lighting_input);
+        let environment_map_lighting_input = &bent_normal_lighting_input;
+#else   // STANDARD_MATERIAL_ANISOTROPY
+        let environment_map_lighting_input = &lighting_input;
+#endif  // STANDARD_MATERIAL_ANISOTROPY
+
         let environment_light = environment_map::environment_map_light(
-            &lighting_input,
+            environment_map_lighting_input,
             &clusterable_object_index_ranges,
-            found_diffuse_indirect
+            found_diffuse_indirect,
         );
 
         indirect_light += environment_light.diffuse * diffuse_occlusion +
             environment_light.specular * specular_occlusion;
     }
-
 #endif  // ENVIRONMENT_MAP
 
     // Ambient light (indirect)


### PR DESCRIPTION
Fixes objects being lit by environment map light not having the anisotropy effect applied correctly. The contribution of light from the environment map with anisotropy is calculated but immediately discarded. Instead what is applied is the regular environment map contribution (calculated without anisotropy) that happen right after.

This patch fixes the logic here to what I think is the intended one. Only calculate contribution once, with or without anisotropy depending on shader specialization.

## Solution

- Properly apply normal modification if anisotropy is enabled.
- Remove duplicate environment map light calculation

## Testing
Tested this by running the anisotropy example and comparing main vs PR results. See images below.

---

## Showcase

Main:
<img width="580" height="503" alt="Main-AnisoEnabled" src="https://github.com/user-attachments/assets/47471a12-60cd-48ba-a32e-60086b6d162a" />

PR:
<img width="592" height="509" alt="WithFix-AnisoEnabled" src="https://github.com/user-attachments/assets/e1f6b82c-1bac-40e1-8925-3abece05f406" />


</details>
