### PR TITLE
Thoroughly document `UninitializedId` semantics

### DIFF
--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -752,7 +752,7 @@ new_key_type! {
     pub struct SystemSetKey;
 }
 
-/// Systems and system sets in a [`ScheduleGraph`] which have not been
+/// A node in a [`ScheduleGraph`] with a system or conditions that have not been
 /// initialized yet.
 ///
 /// We have to defer initialization of nodes in the graph until we have

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -774,11 +774,9 @@ enum UninitializedId {
         /// the same set), so we need to track which conditions in that list
         /// are newly added and not yet initialized.
         ///
-        /// Note: We don't need to do this for systems because calling
-        /// `add_systems` multiple times with the same system results in
-        /// multiple duplicates of that system in the graph, each with their own
-        /// separate list of conditions. That means all of a system's conditions
-        /// are always initialized together.
+        /// Systems don't need this tracking because each `add_systems` call
+        /// creates separate nodes in the graph with their own conditions,
+        /// so all conditions are initialized together.
         uninitialized_conditions: Range<usize>,
     },
 }

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -770,7 +770,7 @@ enum UninitializedId {
         /// still need to be initialized.
         ///
         /// Conditions might be added multiple times to a system set (e.g. when
-        /// `configure_sets` is called multiple times with the same set), So we
+        /// `configure_sets` is called multiple times with the same set), so we
         /// need to track where the newly added conditions start in the
         /// `conditions` list.
         ///


### PR DESCRIPTION
# Objective

Clean up documentation around `UninitializedId`, which has slightly confusing semantics.

## Solution

Added documentation comments on `UninitializedId`.