### PR TITLE
Fix AmbientLight::affects_lightmapped_meshes not working

### DIFF
--- a/crates/bevy_pbr/src/render/mesh_view_types.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_view_types.wgsl
@@ -66,8 +66,6 @@ struct Lights {
     cluster_factors: vec4<f32>,
     n_directional_lights: u32,
     spot_light_shadowmap_offset: i32,
-    environment_map_smallest_specular_mip_level: u32,
-    environment_map_intensity: f32,
 };
 
 struct Fog {

--- a/crates/bevy_pbr/src/render/mesh_view_types.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_view_types.wgsl
@@ -66,6 +66,7 @@ struct Lights {
     cluster_factors: vec4<f32>,
     n_directional_lights: u32,
     spot_light_shadowmap_offset: i32,
+    ambient_light_affects_lightmapped_meshes: u32
 };
 
 struct Fog {

--- a/crates/bevy_pbr/src/render/pbr_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_functions.wgsl
@@ -642,7 +642,16 @@ fn apply_pbr_lighting(
 #endif  // ENVIRONMENT_MAP
 
     // Ambient light (indirect)
-    indirect_light += ambient::ambient_light(in.world_position, in.N, in.V, NdotV, diffuse_color, F0, perceptual_roughness, diffuse_occlusion);
+    // If we are lightmapped, disable the ambient contribution if requested.
+    // This is to avoid double-counting ambient light. (It might be part of the lightmap)
+#ifdef LIGHTMAP
+    let enable_ambient = view_bindings::lights.ambient_light_affects_lightmapped_meshes != 0u;
+#else   // LIGHTMAP
+    let enable_ambient = true;
+#endif  // LIGHTMAP
+    if (enable_ambient) {
+        indirect_light += ambient::ambient_light(in.world_position, in.N, in.V, NdotV, diffuse_color, F0, perceptual_roughness, diffuse_occlusion);
+    }
 
     // we'll use the specular component of the transmitted environment
     // light in the call to `specular_transmissive_light()` below


### PR DESCRIPTION
# Objective

Fix lightmapped materials not respecting the AmbientLight::affects_lightmapped_meshes setting.

NOTE: This only makes the setting work on the forward renderer. Making it work on the deferred renderer would probably require encoding more information in the g-buffer or similar. Please advise if I missed some obvious way to get it working on deferred.

## Solution

- Make ambient light conditionally applied depending on the affects_lightmapped_meshes setting when material mesh i lightmapped
- Remove what looks to be leftover `Lights` (wgsl) members: `environment_map_smallest_specular_mip_level`, `environment_map_intensity`. (These where not present in the rust equivalent `GpuLights` and was not used in the wgsl code)

## Open Questions
- Ambient light is also blended into the transmitted light if `DIFFUSE_TRANSMISSION` is enabled on the material. Should that also be guarded by the same conditional as the indirect contribution?

## Testing

Ran a modified version of the lightmaps example, where there is a bright red ambient light added and the small cube do not have a lightmap added (To be able to see ambient light applied to meshes without lightmaps)

---

## Showcase
### Main: Lightmap example with bright red ambient, small box have no lightmap
<img width="613" height="601" alt="Main" src="https://github.com/user-attachments/assets/a3f206d7-5a1e-4590-8c40-69d5c6e06ce0" />

(All meshes get ambient light even when `affects_lightmapped_meshes = false`)

### This PR: Lightmap example with bright red ambient, small box have no lightmap
<img width="612" height="602" alt="With fix" src="https://github.com/user-attachments/assets/d1a149a5-8994-4572-909f-8788ba2c38fc" />

(Only the small box get ambient light when `affects_lightmapped_meshes = false`)

