### PR TITLE
Add `max_history_length` to `EntityCountDiagnosticsPlugin`

### DIFF
--- a/crates/bevy_diagnostic/src/entity_count_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/entity_count_diagnostics_plugin.rs
@@ -1,15 +1,32 @@
 use bevy_app::prelude::*;
 use bevy_ecs::entity::Entities;
 
-use crate::{Diagnostic, DiagnosticPath, Diagnostics, RegisterDiagnostic};
+use crate::{
+    Diagnostic, DiagnosticPath, Diagnostics, RegisterDiagnostic, DEFAULT_MAX_HISTORY_LENGTH,
+};
 
 /// Adds "entity count" diagnostic to an App.
 ///
 /// # See also
 ///
 /// [`LogDiagnosticsPlugin`](crate::LogDiagnosticsPlugin) to output diagnostics to the console.
-#[derive(Default)]
-pub struct EntityCountDiagnosticsPlugin;
+pub struct EntityCountDiagnosticsPlugin {
+    /// The total number of values to keep.
+    pub max_history_length: usize,
+}
+
+impl Default for EntityCountDiagnosticsPlugin {
+    fn default() -> Self {
+        Self::new(DEFAULT_MAX_HISTORY_LENGTH)
+    }
+}
+
+impl EntityCountDiagnosticsPlugin {
+    /// Creates a new `EntityCountDiagnosticsPlugin` with the specified `max_history_length`.
+    pub fn new(max_history_length: usize) -> Self {
+        Self { max_history_length }
+    }
+}
 
 impl Plugin for EntityCountDiagnosticsPlugin {
     fn build(&self, app: &mut App) {

--- a/examples/diagnostics/log_diagnostics.rs
+++ b/examples/diagnostics/log_diagnostics.rs
@@ -33,7 +33,7 @@ fn main() {
             // Adds frame time, FPS and frame count diagnostics.
             FrameTimeDiagnosticsPlugin::default(),
             // Adds an entity count diagnostic.
-            EntityCountDiagnosticsPlugin,
+            EntityCountDiagnosticsPlugin::default(),
             // Adds cpu and memory usage diagnostics for systems and the entire game process.
             SystemInformationDiagnosticsPlugin,
             // Forwards various diagnostics from the render app to the main app.


### PR DESCRIPTION
# Objective

I was building out a diagnostics panel in egui when I noticed that I could specify the max history length for the `FrameTimeDiagnosticsPlugin`, but not for the `EntityCountDiagnosticsPlugin`. The objective was to harmonize the two, making the diagnostic history length configurable for both.

## Solution

I added a `EntityCountDiagnosticsPlugin::new`, and a `Default` impl that matches `FrameTimeDiagnosticsPlugin`.

This is a breaking change, given the plugin had no fields previously.

## Testing

I did not test this.