### PR TITLE
Scalable primitives

### DIFF
--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -104,7 +104,9 @@ impl ScaleNonUniform2d for Circle {
     type Output = Ellipse;
 
     fn scale(&self, scale: Vec2) -> Self::Output {
-        Ellipse::from_size(scale * self.radius)
+        Ellipse {
+            half_size: scale * self.radius,
+        }
     }
 }
 

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -5,6 +5,7 @@ use thiserror::Error;
 use super::{Measured2d, Primitive2d, WindingOrder};
 use crate::{
     ops::{self, FloatPow},
+    prelude::{ScaleNonUniform2d, ScaleUniform},
     Dir2, InvalidDirectionError, Isometry2d, Ray2d, Rot2, Vec2,
 };
 
@@ -90,6 +91,20 @@ impl Measured2d for Circle {
     #[doc(alias = "circumference")]
     fn perimeter(&self) -> f32 {
         2.0 * PI * self.radius
+    }
+}
+
+impl ScaleUniform for Circle {
+    fn scale_uniform(&self, scale: f32) -> Self {
+        Self::new(scale * self.radius)
+    }
+}
+
+impl ScaleNonUniform2d for Circle {
+    type Output = Ellipse;
+
+    fn scale(&self, scale: Vec2) -> Self::Output {
+        Ellipse::from_size(scale * self.radius)
     }
 }
 
@@ -1830,6 +1845,24 @@ impl Measured2d for Rectangle {
     #[inline(always)]
     fn perimeter(&self) -> f32 {
         4.0 * (self.half_size.x + self.half_size.y)
+    }
+}
+
+impl ScaleUniform for Rectangle {
+    fn scale_uniform(&self, scale: f32) -> Self {
+        Self {
+            half_size: scale * self.half_size,
+        }
+    }
+}
+
+impl ScaleNonUniform2d for Rectangle {
+    type Output = Self;
+
+    fn scale(&self, scale: Vec2) -> Self::Output {
+        Self {
+            half_size: scale * self.half_size,
+        }
     }
 }
 

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -3,6 +3,7 @@ use core::f32::consts::{FRAC_PI_3, PI};
 use super::{Circle, Measured2d, Measured3d, Primitive2d, Primitive3d};
 use crate::{
     ops::{self, FloatPow},
+    prelude::{ScaleNonUniform3d, ScaleUniform},
     Dir3, InvalidDirectionError, Isometry3d, Mat3, Ray3d, Vec2, Vec3,
 };
 
@@ -85,6 +86,12 @@ impl Measured3d for Sphere {
     #[inline(always)]
     fn volume(&self) -> f32 {
         4.0 * FRAC_PI_3 * self.radius.cubed()
+    }
+}
+
+impl ScaleUniform for Sphere {
+    fn scale_uniform(&self, scale: f32) -> Self {
+        Self::new(scale * self.radius)
     }
 }
 
@@ -728,6 +735,24 @@ impl Measured3d for Cuboid {
     #[inline(always)]
     fn volume(&self) -> f32 {
         8.0 * self.half_size.x * self.half_size.y * self.half_size.z
+    }
+}
+
+impl ScaleUniform for Cuboid {
+    fn scale_uniform(&self, scale: f32) -> Self {
+        Self {
+            half_size: scale * self.half_size,
+        }
+    }
+}
+
+impl ScaleNonUniform3d for Cuboid {
+    type Output = Self;
+
+    fn scale(&self, scale: Vec3) -> Self::Output {
+        Self {
+            half_size: scale * self.half_size,
+        }
     }
 }
 

--- a/crates/bevy_math/src/primitives/mod.rs
+++ b/crates/bevy_math/src/primitives/mod.rs
@@ -6,6 +6,7 @@ mod dim2;
 pub use dim2::*;
 mod dim3;
 pub use dim3::*;
+use glam::{Vec2, Vec3};
 mod polygon;
 #[cfg(feature = "serialize")]
 mod serde;
@@ -47,4 +48,30 @@ pub trait Measured3d {
 
     /// Get the volume of the shape
     fn volume(&self) -> f32;
+}
+
+/// A trait for uniformly scaling shapes
+pub trait ScaleUniform {
+    /// Scale this primitive by the provided factor.
+    fn scale_uniform(&self, scale: f32) -> Self;
+}
+
+/// A trait for scaling 2D shapes non-uniformly
+pub trait ScaleNonUniform2d: ScaleUniform {
+    /// The type of the scaled primitive.
+    /// Most shapes will be the same when scaled but i.e. a [`Circle`] may become an [`Ellipse`] when scaled.
+    type Output;
+
+    /// Scale the primitive along the X- and Y-axis
+    fn scale(&self, scale: Vec2) -> Self::Output;
+}
+
+/// A trait for scaling 3D shapes non-uniformly
+pub trait ScaleNonUniform3d: ScaleUniform {
+    /// The type of the scaled primitive.
+    /// Most shapes will be the same when scaled but i.e. a [`Sphere`] may become an `Ellipsoid` when scaled.
+    type Output;
+
+    /// Scale the primitive along the X-, Y- and Z-axis
+    fn scale(&self, scale: Vec3) -> Self::Output;
 }


### PR DESCRIPTION
# Objective

- Begins fixing #19082

## Solution

- Added 3 new traits
  - `ScaleUniform` which allows scaling 2D and 3D primitives uniformly by some `scale: f32`
  - `ScaleNonUniform2d` which allows scaling 2D primitives non-uniformly by specifying a `scale: Vec2` and an additional associated `Output` type. This may be useful when scaling i.e. a circle as it will become an ellipse.
  - `ScaleNonUniform3d` - the 3D analogue of `ScaleNonUniform2d`
- Added implementations of these traits for `Circle`, `Rectangle`, `Sphere` and `Cuboid`

## Additional Information
- I am not sure whether these traits are named optimally. If you have any suggestions for better naming please do suggest them :)
- There are a lot of other implementations that would have to be added. Most of them are fairly easy however so it should not be that much of a maintenance burden.