### PR TITLE
Implement `ShapeSample for CircularSector`

### DIFF
--- a/crates/bevy_math/src/sampling/shape_sampling.rs
+++ b/crates/bevy_math/src/sampling/shape_sampling.rs
@@ -38,7 +38,7 @@
 //!
 //! In any case, the [`Rng`] used as the source of randomness must be provided explicitly.
 
-use core::f32::consts::{PI, TAU};
+use core::f32::consts::{FRAC_PI_2, PI, TAU};
 
 use crate::{ops, primitives::*, NormedVectorSpace, ScalarField, Vec2, Vec3};
 use rand::{
@@ -164,6 +164,31 @@ impl ShapeSample for Circle {
         let theta = rng.gen_range(0.0..TAU);
         let (sin, cos) = ops::sin_cos(theta);
         Vec2::new(self.radius * cos, self.radius * sin)
+    }
+}
+
+impl ShapeSample for CircularSector {
+    type Output = Vec2;
+
+    fn sample_interior<R: Rng + ?Sized>(&self, rng: &mut R) -> Vec2 {
+        let theta = rng.gen_range(-self.half_angle()..=self.half_angle());
+        let r_squared = rng.gen_range(0.0..=(self.radius() * self.radius()));
+        let r = ops::sqrt(r_squared);
+        let (sin, cos) = ops::sin_cos(theta);
+        Vec2::new(r * sin, r * cos)
+    }
+
+    fn sample_boundary<R: Rng + ?Sized>(&self, rng: &mut R) -> Vec2 {
+        if rng.gen_range(0.0..=1.0) <= self.arc_length() / self.perimeter() {
+            // Sample on the arc
+            let theta = FRAC_PI_2 + rng.gen_range(-self.half_angle()..self.half_angle());
+            Vec2::from_angle(theta) * self.radius()
+        } else {
+            // Sample on the "inner" straight lines
+            let dir = self.radius() * Vec2::from_angle(FRAC_PI_2 + self.half_angle());
+            let r: f32 = rng.gen_range(-1.0..1.0);
+            (-r).clamp(0.0, 1.0) * dir + r.clamp(0.0, 1.0) * dir * Vec2::new(-1.0, 1.0)
+        }
     }
 }
 


### PR DESCRIPTION
# Objective

- Implement `ShapeSample for CircularSector`

## Testing

- The results can be verified visually. 

---

## Showcase
### Boundary
<img width="661" height="383" alt="Circular Sector Boundary Sampling" src="https://github.com/user-attachments/assets/a08ee2eb-9b3d-4be1-8798-9317db337513" />


### Interior
<img width="665" height="386" alt="Circular Sector Interior Sampling" src="https://github.com/user-attachments/assets/bf71ce54-e73c-414c-899d-6402c0abd9e7" />
