### PR TITLE
Fix link to `bevy_solari` logo

### DIFF
--- a/crates/bevy_solari/src/lib.rs
+++ b/crates/bevy_solari/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! See [`SolariPlugins`] for more info.
 //!
-//! ![`bevy_solari` logo](https://raw.githubusercontent.com/bevyengine/bevy/assets/branding/bevy_solari.svg)
+//! ![`bevy_solari` logo](https://raw.githubusercontent.com/bevyengine/bevy/refs/heads/main/assets/branding/bevy_solari.svg)
 pub mod pathtracer;
 pub mod realtime;
 pub mod scene;


### PR DESCRIPTION
# Objective

The `bevy_solari` logo doesn't load in the [dev-docs](https://dev-docs.bevy.org/bevy/solari/index.html):

<img width="1572" height="594" alt="image" src="https://github.com/user-attachments/assets/c662402a-a729-4982-bb7f-add072742f4c" />

This is because the link to the image, <https://raw.githubusercontent.com/bevyengine/bevy/assets/branding/bevy_solari.svg>, returns a 404 not found.

## Solution

Fix the link to point to <https://raw.githubusercontent.com/bevyengine/bevy/refs/heads/main/assets/branding/bevy_solari.svg>!

![Solari Logo](https://raw.githubusercontent.com/bevyengine/bevy/refs/heads/main/assets/branding/bevy_solari.svg)

## Testing

Open up the crate page for `bevy_solari` and make sure the image loads :)

```sh
cargo doc -p bevy_solari --open --no-deps
```