### PR TITLE
FIX - RelativeCursorPosition Changed<> query filter

### DIFF
--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -268,7 +268,8 @@ pub fn ui_focus_system(
             if let Some(mut node_relative_cursor_position_component) = node.relative_cursor_position
             {
                 // Avoid triggering change detection when not necessary.
-                node_relative_cursor_position_component.set_if_neq(relative_cursor_position_component);
+                node_relative_cursor_position_component
+                    .set_if_neq(relative_cursor_position_component);
             }
 
             if contains_cursor {

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -268,9 +268,7 @@ pub fn ui_focus_system(
             if let Some(mut node_relative_cursor_position_component) = node.relative_cursor_position
             {
                 // Check that the values are different before save to enable Changed<> query filter
-                if *node_relative_cursor_position_component != relative_cursor_position_component {
-                    *node_relative_cursor_position_component = relative_cursor_position_component;
-                }
+                node_relative_cursor_position_component.set_if_neq(relative_cursor_position_component);
             }
 
             if contains_cursor {

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -267,7 +267,10 @@ pub fn ui_focus_system(
             // Save the relative cursor position to the correct component
             if let Some(mut node_relative_cursor_position_component) = node.relative_cursor_position
             {
-                *node_relative_cursor_position_component = relative_cursor_position_component;
+                // Check that the values are different before save to enable Changed<> query filter
+                if *node_relative_cursor_position_component != relative_cursor_position_component {
+                    *node_relative_cursor_position_component = relative_cursor_position_component;
+                }
             }
 
             if contains_cursor {

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -267,7 +267,7 @@ pub fn ui_focus_system(
             // Save the relative cursor position to the correct component
             if let Some(mut node_relative_cursor_position_component) = node.relative_cursor_position
             {
-                // Check that the values are different before save to enable Changed<> query filter
+                // Avoid triggering change detection when not necessary.
                 node_relative_cursor_position_component.set_if_neq(relative_cursor_position_component);
             }
 


### PR DESCRIPTION

## Problem

This pseudocode was triggering constantly, even with the Changed<> query filter.

```rust
pub fn check_mouse_movement_system(
    relative_cursor_positions: Query< &RelativeCursorPosition, (Changed<RelativeCursorPosition>, With<Button>)>,
) {}
```

## Solution

- Added a check to prevent updating the value if it hasn't changed.

