### PR TITLE
feat: implement clone for IntoPipeSystem

### DIFF
--- a/crates/bevy_ecs/src/system/combinator.rs
+++ b/crates/bevy_ecs/src/system/combinator.rs
@@ -252,6 +252,7 @@ where
 }
 
 /// An [`IntoSystem`] creating an instance of [`PipeSystem`].
+#[derive(Clone)]
 pub struct IntoPipeSystem<A, B> {
     a: A,
     b: B,
@@ -282,17 +283,6 @@ where
         let system_b = IntoSystem::into_system(this.b);
         let name = format!("Pipe({}, {})", system_a.name(), system_b.name());
         PipeSystem::new(system_a, system_b, DebugName::owned(name))
-    }
-}
-
-impl<A, B> Clone for IntoPipeSystem<A, B>
-where
-    A: Clone,
-    B: Clone,
-{
-    /// Clone the piped system. The cloned instance must be `.initialize()`d before it can run.
-    fn clone(&self) -> Self {
-        IntoPipeSystem::new(self.a.clone(), self.b.clone())
     }
 }
 

--- a/crates/bevy_ecs/src/system/combinator.rs
+++ b/crates/bevy_ecs/src/system/combinator.rs
@@ -285,6 +285,17 @@ where
     }
 }
 
+impl<A, B> Clone for IntoPipeSystem<A, B>
+where
+    A: Clone,
+    B: Clone,
+{
+    /// Clone the piped system. The cloned instance must be `.initialize()`d before it can run.
+    fn clone(&self) -> Self {
+        IntoPipeSystem::new(self.a.clone(), self.b.clone())
+    }
+}
+
 /// A [`System`] created by piping the output of the first system into the input of the second.
 ///
 /// This can be repeated indefinitely, but system pipes cannot branch: the output is consumed by the receiving system.


### PR DESCRIPTION
# Objective

Implement `Clone` for `IntoPipeSystem`, allowing for `T: IntoSystem + Clone` patterns.


## Precedence

Same clone implementation/docs as `CombinatorSystem`