### PR TITLE
Faster `FilteredEntity(Ref|Mut)` and `Entity(Ref|Mut)Except` by borrowing `Access`

### DIFF
--- a/crates/bevy_animation/src/animation_curves.rs
+++ b/crates/bevy_animation/src/animation_curves.rs
@@ -408,10 +408,7 @@ impl<A: Animatable> AnimationCurveEvaluator for AnimatableCurveEvaluator<A> {
         self.evaluator.push_blend_register(weight, graph_node)
     }
 
-    fn commit<'a>(
-        &mut self,
-        mut entity: AnimationEntityMut<'a>,
-    ) -> Result<(), AnimationEvaluationError> {
+    fn commit(&mut self, mut entity: AnimationEntityMut) -> Result<(), AnimationEvaluationError> {
         let property = self.property.get_mut(&mut entity)?;
         *property = self
             .evaluator
@@ -596,10 +593,7 @@ impl AnimationCurveEvaluator for WeightsCurveEvaluator {
         Ok(())
     }
 
-    fn commit<'a>(
-        &mut self,
-        mut entity: AnimationEntityMut<'a>,
-    ) -> Result<(), AnimationEvaluationError> {
+    fn commit(&mut self, mut entity: AnimationEntityMut) -> Result<(), AnimationEvaluationError> {
         if self.stack_morph_target_weights.is_empty() {
             return Ok(());
         }
@@ -905,10 +899,7 @@ pub trait AnimationCurveEvaluator: Downcast + Send + Sync + 'static {
     ///
     /// The property on the component must be overwritten with the value from
     /// the stack, not blended with it.
-    fn commit<'a>(
-        &mut self,
-        entity: AnimationEntityMut<'a>,
-    ) -> Result<(), AnimationEvaluationError>;
+    fn commit(&mut self, entity: AnimationEntityMut) -> Result<(), AnimationEvaluationError>;
 }
 
 impl_downcast!(AnimationCurveEvaluator);

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -1021,8 +1021,8 @@ pub fn advance_animations(
 }
 
 /// A type alias for [`EntityMutExcept`] as used in animation.
-pub type AnimationEntityMut<'w> =
-    EntityMutExcept<'w, (AnimationTarget, AnimationPlayer, AnimationGraphHandle)>;
+pub type AnimationEntityMut<'w, 's> =
+    EntityMutExcept<'w, 's, (AnimationTarget, AnimationPlayer, AnimationGraphHandle)>;
 
 /// A system that modifies animation targets (e.g. bones in a skinned mesh)
 /// according to the currently-playing animations.

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -165,6 +165,32 @@ impl<T: SparseSetIndex> Access<T> {
         }
     }
 
+    /// Creates an [`Access`] with read access to all components.
+    /// This is equivalent to calling `read_all()` on `Access::new()`,
+    /// but is available in a `const` context.
+    pub(crate) const fn new_read_all() -> Self {
+        let mut access = Self::new();
+        access.reads_all_resources = true;
+        // Note that we cannot use `read_all_components()`
+        // because `FixedBitSet::clear()` is not `const`.
+        access.component_read_and_writes_inverted = true;
+        access
+    }
+
+    /// Creates an [`Access`] with read access to all components.
+    /// This is equivalent to calling `read_all()` on `Access::new()`,
+    /// but is available in a `const` context.
+    pub(crate) const fn new_write_all() -> Self {
+        let mut access = Self::new();
+        access.reads_all_resources = true;
+        access.writes_all_resources = true;
+        // Note that we cannot use `write_all_components()`
+        // because `FixedBitSet::clear()` is not `const`.
+        access.component_read_and_writes_inverted = true;
+        access.component_writes_inverted = true;
+        access
+    }
+
     fn add_component_sparse_set_index_read(&mut self, index: usize) {
         if !self.component_read_and_writes_inverted {
             self.component_read_and_writes.grow_and_insert(index);

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -1033,7 +1033,7 @@ unsafe impl QueryData for FilteredEntityRef<'_, '_> {
                 .debug_checked_unwrap()
         };
         // SAFETY: mutable access to every component has been registered.
-        unsafe { FilteredEntityRef::new(cell, &access) }
+        unsafe { FilteredEntityRef::new(cell, access) }
     }
 }
 
@@ -1152,7 +1152,7 @@ unsafe impl<'a, 'b> QueryData for FilteredEntityMut<'a, 'b> {
                 .debug_checked_unwrap()
         };
         // SAFETY: mutable access to every component has been registered.
-        unsafe { FilteredEntityMut::new(cell, &access) }
+        unsafe { FilteredEntityMut::new(cell, access) }
     }
 }
 
@@ -1196,16 +1196,16 @@ where
     unsafe fn set_table<'w, 's>(_: &mut Self::Fetch<'w>, _: &'s Self::State, _: &'w Table) {}
 
     fn update_component_access(
-        my_access: &Self::State,
+        state: &Self::State,
         filtered_access: &mut FilteredAccess<ComponentId>,
     ) {
         let access = filtered_access.access_mut();
         assert!(
-            access.is_compatible(&my_access),
+            access.is_compatible(state),
             "`EntityRefExcept<{}>` conflicts with a previous access in this query.",
             DebugName::type_name::<B>(),
         );
-        access.extend(&my_access);
+        access.extend(state);
     }
 
     fn init_state(world: &mut World) -> Self::State {
@@ -1312,16 +1312,16 @@ where
     unsafe fn set_table<'w, 's>(_: &mut Self::Fetch<'w>, _: &'s Self::State, _: &'w Table) {}
 
     fn update_component_access(
-        my_access: &Self::State,
+        state: &Self::State,
         filtered_access: &mut FilteredAccess<ComponentId>,
     ) {
         let access = filtered_access.access_mut();
         assert!(
-            access.is_compatible(&my_access),
+            access.is_compatible(state),
             "`EntityMutExcept<{}>` conflicts with a previous access in this query.",
             DebugName::type_name::<B>()
         );
-        access.extend(&my_access);
+        access.extend(state);
     }
 
     fn init_state(world: &mut World) -> Self::State {

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -970,13 +970,13 @@ unsafe impl<'w, 's, F: QueryFilter> EntitySetIterator
 
 // SAFETY: [`QueryIter`] is guaranteed to return every matching entity once and only once.
 unsafe impl<'w, 's, F: QueryFilter, B: Bundle> EntitySetIterator
-    for QueryIter<'w, 's, EntityRefExcept<'_, B>, F>
+    for QueryIter<'w, 's, EntityRefExcept<'_, '_, B>, F>
 {
 }
 
 // SAFETY: [`QueryIter`] is guaranteed to return every matching entity once and only once.
 unsafe impl<'w, 's, F: QueryFilter, B: Bundle> EntitySetIterator
-    for QueryIter<'w, 's, EntityMutExcept<'_, B>, F>
+    for QueryIter<'w, 's, EntityMutExcept<'_, '_, B>, F>
 {
 }
 

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -958,13 +958,13 @@ unsafe impl<'w, 's, F: QueryFilter> EntitySetIterator for QueryIter<'w, 's, Enti
 
 // SAFETY: [`QueryIter`] is guaranteed to return every matching entity once and only once.
 unsafe impl<'w, 's, F: QueryFilter> EntitySetIterator
-    for QueryIter<'w, 's, FilteredEntityRef<'_>, F>
+    for QueryIter<'w, 's, FilteredEntityRef<'_, '_>, F>
 {
 }
 
 // SAFETY: [`QueryIter`] is guaranteed to return every matching entity once and only once.
 unsafe impl<'w, 's, F: QueryFilter> EntitySetIterator
-    for QueryIter<'w, 's, FilteredEntityMut<'_>, F>
+    for QueryIter<'w, 's, FilteredEntityMut<'_, '_>, F>
 {
 }
 

--- a/crates/bevy_ecs/src/reflect/component.rs
+++ b/crates/bevy_ecs/src/reflect/component.rs
@@ -118,9 +118,9 @@ pub struct ReflectComponentFns {
     /// Function pointer implementing [`ReflectComponent::contains()`].
     pub contains: fn(FilteredEntityRef) -> bool,
     /// Function pointer implementing [`ReflectComponent::reflect()`].
-    pub reflect: fn(FilteredEntityRef) -> Option<&dyn Reflect>,
+    pub reflect: for<'w> fn(FilteredEntityRef<'w, '_>) -> Option<&'w dyn Reflect>,
     /// Function pointer implementing [`ReflectComponent::reflect_mut()`].
-    pub reflect_mut: fn(FilteredEntityMut) -> Option<Mut<dyn Reflect>>,
+    pub reflect_mut: for<'w> fn(FilteredEntityMut<'w, '_>) -> Option<Mut<'w, dyn Reflect>>,
     /// Function pointer implementing [`ReflectComponent::map_entities()`].
     pub map_entities: fn(&mut dyn Reflect, &mut dyn EntityMapper),
     /// Function pointer implementing [`ReflectComponent::reflect_unchecked_mut()`].
@@ -189,12 +189,15 @@ impl ReflectComponent {
     }
 
     /// Returns whether entity contains this [`Component`]
-    pub fn contains<'a>(&self, entity: impl Into<FilteredEntityRef<'a>>) -> bool {
+    pub fn contains<'w, 's>(&self, entity: impl Into<FilteredEntityRef<'w, 's>>) -> bool {
         (self.0.contains)(entity.into())
     }
 
     /// Gets the value of this [`Component`] type from the entity as a reflected reference.
-    pub fn reflect<'a>(&self, entity: impl Into<FilteredEntityRef<'a>>) -> Option<&'a dyn Reflect> {
+    pub fn reflect<'w, 's>(
+        &self,
+        entity: impl Into<FilteredEntityRef<'w, 's>>,
+    ) -> Option<&'w dyn Reflect> {
         (self.0.reflect)(entity.into())
     }
 
@@ -203,10 +206,10 @@ impl ReflectComponent {
     /// # Panics
     ///
     /// Panics if [`Component`] is immutable.
-    pub fn reflect_mut<'a>(
+    pub fn reflect_mut<'w, 's>(
         &self,
-        entity: impl Into<FilteredEntityMut<'a>>,
-    ) -> Option<Mut<'a, dyn Reflect>> {
+        entity: impl Into<FilteredEntityMut<'w, 's>>,
+    ) -> Option<Mut<'w, dyn Reflect>> {
         (self.0.reflect_mut)(entity.into())
     }
 

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -338,10 +338,10 @@ impl<'a> From<&'a EntityMut<'_>> for EntityRef<'a> {
     }
 }
 
-impl<'a> TryFrom<FilteredEntityRef<'a>> for EntityRef<'a> {
+impl<'a> TryFrom<FilteredEntityRef<'a, '_>> for EntityRef<'a> {
     type Error = TryFromFilteredError;
 
-    fn try_from(entity: FilteredEntityRef<'a>) -> Result<Self, Self::Error> {
+    fn try_from(entity: FilteredEntityRef<'a, '_>) -> Result<Self, Self::Error> {
         if !entity.access.has_read_all() {
             Err(TryFromFilteredError::MissingReadAllAccess)
         } else {
@@ -351,10 +351,10 @@ impl<'a> TryFrom<FilteredEntityRef<'a>> for EntityRef<'a> {
     }
 }
 
-impl<'a> TryFrom<&'a FilteredEntityRef<'_>> for EntityRef<'a> {
+impl<'a> TryFrom<&'a FilteredEntityRef<'_, '_>> for EntityRef<'a> {
     type Error = TryFromFilteredError;
 
-    fn try_from(entity: &'a FilteredEntityRef<'_>) -> Result<Self, Self::Error> {
+    fn try_from(entity: &'a FilteredEntityRef<'_, '_>) -> Result<Self, Self::Error> {
         if !entity.access.has_read_all() {
             Err(TryFromFilteredError::MissingReadAllAccess)
         } else {
@@ -364,10 +364,10 @@ impl<'a> TryFrom<&'a FilteredEntityRef<'_>> for EntityRef<'a> {
     }
 }
 
-impl<'a> TryFrom<FilteredEntityMut<'a>> for EntityRef<'a> {
+impl<'a> TryFrom<FilteredEntityMut<'a, '_>> for EntityRef<'a> {
     type Error = TryFromFilteredError;
 
-    fn try_from(entity: FilteredEntityMut<'a>) -> Result<Self, Self::Error> {
+    fn try_from(entity: FilteredEntityMut<'a, '_>) -> Result<Self, Self::Error> {
         if !entity.access.has_read_all() {
             Err(TryFromFilteredError::MissingReadAllAccess)
         } else {
@@ -377,10 +377,10 @@ impl<'a> TryFrom<FilteredEntityMut<'a>> for EntityRef<'a> {
     }
 }
 
-impl<'a> TryFrom<&'a FilteredEntityMut<'_>> for EntityRef<'a> {
+impl<'a> TryFrom<&'a FilteredEntityMut<'_, '_>> for EntityRef<'a> {
     type Error = TryFromFilteredError;
 
-    fn try_from(entity: &'a FilteredEntityMut<'_>) -> Result<Self, Self::Error> {
+    fn try_from(entity: &'a FilteredEntityMut<'_, '_>) -> Result<Self, Self::Error> {
         if !entity.access.has_read_all() {
             Err(TryFromFilteredError::MissingReadAllAccess)
         } else {
@@ -1020,10 +1020,10 @@ impl<'a> From<&'a mut EntityWorldMut<'_>> for EntityMut<'a> {
     }
 }
 
-impl<'a> TryFrom<FilteredEntityMut<'a>> for EntityMut<'a> {
+impl<'a> TryFrom<FilteredEntityMut<'a, '_>> for EntityMut<'a> {
     type Error = TryFromFilteredError;
 
-    fn try_from(entity: FilteredEntityMut<'a>) -> Result<Self, Self::Error> {
+    fn try_from(entity: FilteredEntityMut<'a, '_>) -> Result<Self, Self::Error> {
         if !entity.access.has_read_all() {
             Err(TryFromFilteredError::MissingReadAllAccess)
         } else if !entity.access.has_write_all() {
@@ -1035,10 +1035,10 @@ impl<'a> TryFrom<FilteredEntityMut<'a>> for EntityMut<'a> {
     }
 }
 
-impl<'a> TryFrom<&'a mut FilteredEntityMut<'_>> for EntityMut<'a> {
+impl<'a> TryFrom<&'a mut FilteredEntityMut<'_, '_>> for EntityMut<'a> {
     type Error = TryFromFilteredError;
 
-    fn try_from(entity: &'a mut FilteredEntityMut<'_>) -> Result<Self, Self::Error> {
+    fn try_from(entity: &'a mut FilteredEntityMut<'_, '_>) -> Result<Self, Self::Error> {
         if !entity.access.has_read_all() {
             Err(TryFromFilteredError::MissingReadAllAccess)
         } else if !entity.access.has_write_all() {
@@ -3310,20 +3310,23 @@ impl<'w, 'a, T: Component> VacantComponentEntry<'w, 'a, T> {
 /// let filtered_entity: FilteredEntityRef = query.single(&mut world).unwrap();
 /// let component: &A = filtered_entity.get().unwrap();
 /// ```
-#[derive(Clone)]
-pub struct FilteredEntityRef<'w> {
+#[derive(Clone, Copy)]
+pub struct FilteredEntityRef<'w, 's> {
     entity: UnsafeEntityCell<'w>,
-    access: Access<ComponentId>,
+    access: &'s Access<ComponentId>,
 }
 
-impl<'w> FilteredEntityRef<'w> {
+impl<'w, 's> FilteredEntityRef<'w, 's> {
     /// # Safety
     /// - No `&mut World` can exist from the underlying `UnsafeWorldCell`
     /// - If `access` takes read access to a component no mutable reference to that
     ///   component can exist at the same time as the returned [`FilteredEntityMut`]
     /// - If `access` takes any access for a component `entity` must have that component.
     #[inline]
-    pub(crate) unsafe fn new(entity: UnsafeEntityCell<'w>, access: Access<ComponentId>) -> Self {
+    pub(crate) unsafe fn new(
+        entity: UnsafeEntityCell<'w>,
+        access: &'s Access<ComponentId>,
+    ) -> Self {
         Self { entity, access }
     }
 
@@ -3349,7 +3352,7 @@ impl<'w> FilteredEntityRef<'w> {
     /// Returns a reference to the underlying [`Access`].
     #[inline]
     pub fn access(&self) -> &Access<ComponentId> {
-        &self.access
+        self.access
     }
 
     /// Returns `true` if the current entity has a component of type `T`.
@@ -3482,123 +3485,91 @@ impl<'w> FilteredEntityRef<'w> {
     }
 }
 
-impl<'w> From<FilteredEntityMut<'w>> for FilteredEntityRef<'w> {
+impl<'w, 's> From<FilteredEntityMut<'w, 's>> for FilteredEntityRef<'w, 's> {
     #[inline]
-    fn from(entity: FilteredEntityMut<'w>) -> Self {
+    fn from(entity: FilteredEntityMut<'w, 's>) -> Self {
         // SAFETY:
         // - `FilteredEntityMut` guarantees exclusive access to all components in the new `FilteredEntityRef`.
         unsafe { FilteredEntityRef::new(entity.entity, entity.access) }
     }
 }
 
-impl<'a> From<&'a FilteredEntityMut<'_>> for FilteredEntityRef<'a> {
+impl<'w, 's> From<&'w FilteredEntityMut<'_, 's>> for FilteredEntityRef<'w, 's> {
     #[inline]
-    fn from(entity: &'a FilteredEntityMut<'_>) -> Self {
+    fn from(entity: &'w FilteredEntityMut<'_, 's>) -> Self {
         // SAFETY:
         // - `FilteredEntityMut` guarantees exclusive access to all components in the new `FilteredEntityRef`.
-        unsafe { FilteredEntityRef::new(entity.entity, entity.access.clone()) }
+        unsafe { FilteredEntityRef::new(entity.entity, entity.access) }
     }
 }
 
-impl<'a> From<EntityRef<'a>> for FilteredEntityRef<'a> {
+impl<'a> From<EntityRef<'a>> for FilteredEntityRef<'a, 'static> {
     fn from(entity: EntityRef<'a>) -> Self {
         // SAFETY:
         // - `EntityRef` guarantees exclusive access to all components in the new `FilteredEntityRef`.
-        unsafe {
-            let mut access = Access::default();
-            access.read_all();
-            FilteredEntityRef::new(entity.cell, access)
-        }
+        unsafe { FilteredEntityRef::new(entity.cell, const { &Access::new_read_all() }) }
     }
 }
 
-impl<'a> From<&'a EntityRef<'_>> for FilteredEntityRef<'a> {
+impl<'a> From<&'a EntityRef<'_>> for FilteredEntityRef<'a, 'static> {
     fn from(entity: &'a EntityRef<'_>) -> Self {
         // SAFETY:
         // - `EntityRef` guarantees exclusive access to all components in the new `FilteredEntityRef`.
-        unsafe {
-            let mut access = Access::default();
-            access.read_all();
-            FilteredEntityRef::new(entity.cell, access)
-        }
+        unsafe { FilteredEntityRef::new(entity.cell, const { &Access::new_read_all() }) }
     }
 }
 
-impl<'a> From<EntityMut<'a>> for FilteredEntityRef<'a> {
+impl<'a> From<EntityMut<'a>> for FilteredEntityRef<'a, 'static> {
     fn from(entity: EntityMut<'a>) -> Self {
         // SAFETY:
         // - `EntityMut` guarantees exclusive access to all components in the new `FilteredEntityRef`.
-        unsafe {
-            let mut access = Access::default();
-            access.read_all();
-            FilteredEntityRef::new(entity.cell, access)
-        }
+        unsafe { FilteredEntityRef::new(entity.cell, const { &Access::new_read_all() }) }
     }
 }
 
-impl<'a> From<&'a EntityMut<'_>> for FilteredEntityRef<'a> {
+impl<'a> From<&'a EntityMut<'_>> for FilteredEntityRef<'a, 'static> {
     fn from(entity: &'a EntityMut<'_>) -> Self {
         // SAFETY:
         // - `EntityMut` guarantees exclusive access to all components in the new `FilteredEntityRef`.
-        unsafe {
-            let mut access = Access::default();
-            access.read_all();
-            FilteredEntityRef::new(entity.cell, access)
-        }
+        unsafe { FilteredEntityRef::new(entity.cell, const { &Access::new_read_all() }) }
     }
 }
 
-impl<'a> From<EntityWorldMut<'a>> for FilteredEntityRef<'a> {
+impl<'a> From<EntityWorldMut<'a>> for FilteredEntityRef<'a, 'static> {
     fn from(entity: EntityWorldMut<'a>) -> Self {
         // SAFETY:
         // - `EntityWorldMut` guarantees exclusive access to the entire world.
         unsafe {
-            let mut access = Access::default();
-            access.read_all();
-            FilteredEntityRef::new(entity.into_unsafe_entity_cell(), access)
+            FilteredEntityRef::new(
+                entity.into_unsafe_entity_cell(),
+                const { &Access::new_read_all() },
+            )
         }
     }
 }
 
-impl<'a> From<&'a EntityWorldMut<'_>> for FilteredEntityRef<'a> {
+impl<'a> From<&'a EntityWorldMut<'_>> for FilteredEntityRef<'a, 'static> {
     fn from(entity: &'a EntityWorldMut<'_>) -> Self {
         // SAFETY:
         // - `EntityWorldMut` guarantees exclusive access to the entire world.
         unsafe {
-            let mut access = Access::default();
-            access.read_all();
-            FilteredEntityRef::new(entity.as_unsafe_entity_cell_readonly(), access)
+            FilteredEntityRef::new(
+                entity.as_unsafe_entity_cell_readonly(),
+                const { &Access::new_read_all() },
+            )
         }
     }
 }
 
-impl<'a, B: Bundle> From<&'a EntityRefExcept<'_, B>> for FilteredEntityRef<'a> {
-    fn from(value: &'a EntityRefExcept<'_, B>) -> Self {
-        // SAFETY:
-        // - The FilteredEntityRef has the same component access as the given EntityRefExcept.
-        unsafe {
-            let mut access = Access::default();
-            access.read_all();
-            let components = value.entity.world().components();
-            B::get_component_ids(components, &mut |maybe_id| {
-                if let Some(id) = maybe_id {
-                    access.remove_component_read(id);
-                }
-            });
-            FilteredEntityRef::new(value.entity, access)
-        }
-    }
-}
-
-impl PartialEq for FilteredEntityRef<'_> {
+impl PartialEq for FilteredEntityRef<'_, '_> {
     fn eq(&self, other: &Self) -> bool {
         self.entity() == other.entity()
     }
 }
 
-impl Eq for FilteredEntityRef<'_> {}
+impl Eq for FilteredEntityRef<'_, '_> {}
 
-impl PartialOrd for FilteredEntityRef<'_> {
+impl PartialOrd for FilteredEntityRef<'_, '_> {
     /// [`FilteredEntityRef`]'s comparison trait implementations match the underlying [`Entity`],
     /// and cannot discern between different worlds.
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
@@ -3606,26 +3577,26 @@ impl PartialOrd for FilteredEntityRef<'_> {
     }
 }
 
-impl Ord for FilteredEntityRef<'_> {
+impl Ord for FilteredEntityRef<'_, '_> {
     fn cmp(&self, other: &Self) -> Ordering {
         self.entity().cmp(&other.entity())
     }
 }
 
-impl Hash for FilteredEntityRef<'_> {
+impl Hash for FilteredEntityRef<'_, '_> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.entity().hash(state);
     }
 }
 
-impl ContainsEntity for FilteredEntityRef<'_> {
+impl ContainsEntity for FilteredEntityRef<'_, '_> {
     fn entity(&self) -> Entity {
         self.id()
     }
 }
 
 // SAFETY: This type represents one Entity. We implement the comparison traits based on that Entity.
-unsafe impl EntityEquivalent for FilteredEntityRef<'_> {}
+unsafe impl EntityEquivalent for FilteredEntityRef<'_, '_> {}
 
 /// Provides mutable access to a single entity and some of its components defined by the contained [`Access`].
 ///
@@ -3650,12 +3621,12 @@ unsafe impl EntityEquivalent for FilteredEntityRef<'_> {}
 /// let mut filtered_entity: FilteredEntityMut = query.single_mut(&mut world).unwrap();
 /// let component: Mut<A> = filtered_entity.get_mut().unwrap();
 /// ```
-pub struct FilteredEntityMut<'w> {
+pub struct FilteredEntityMut<'w, 's> {
     entity: UnsafeEntityCell<'w>,
-    access: Access<ComponentId>,
+    access: &'s Access<ComponentId>,
 }
 
-impl<'w> FilteredEntityMut<'w> {
+impl<'w, 's> FilteredEntityMut<'w, 's> {
     /// # Safety
     /// - No `&mut World` can exist from the underlying `UnsafeWorldCell`
     /// - If `access` takes read access to a component no mutable reference to that
@@ -3664,20 +3635,23 @@ impl<'w> FilteredEntityMut<'w> {
     ///   may exist at the same time as the returned [`FilteredEntityMut`]
     /// - If `access` takes any access for a component `entity` must have that component.
     #[inline]
-    pub(crate) unsafe fn new(entity: UnsafeEntityCell<'w>, access: Access<ComponentId>) -> Self {
+    pub(crate) unsafe fn new(
+        entity: UnsafeEntityCell<'w>,
+        access: &'s Access<ComponentId>,
+    ) -> Self {
         Self { entity, access }
     }
 
     /// Returns a new instance with a shorter lifetime.
     /// This is useful if you have `&mut FilteredEntityMut`, but you need `FilteredEntityMut`.
-    pub fn reborrow(&mut self) -> FilteredEntityMut<'_> {
+    pub fn reborrow(&mut self) -> FilteredEntityMut<'_, 's> {
         // SAFETY: We have exclusive access to the entire entity and its components.
-        unsafe { Self::new(self.entity, self.access.clone()) }
+        unsafe { Self::new(self.entity, self.access) }
     }
 
     /// Gets read-only access to all of the entity's components.
     #[inline]
-    pub fn as_readonly(&self) -> FilteredEntityRef<'_> {
+    pub fn as_readonly(&self) -> FilteredEntityRef<'_, 's> {
         FilteredEntityRef::from(self)
     }
 
@@ -3703,7 +3677,7 @@ impl<'w> FilteredEntityMut<'w> {
     /// Returns a reference to the underlying [`Access`].
     #[inline]
     pub fn access(&self) -> &Access<ComponentId> {
-        &self.access
+        self.access
     }
 
     /// Returns `true` if the current entity has a component of type `T`.
@@ -3868,85 +3842,57 @@ impl<'w> FilteredEntityMut<'w> {
     }
 }
 
-impl<'a> From<EntityMut<'a>> for FilteredEntityMut<'a> {
+impl<'a> From<EntityMut<'a>> for FilteredEntityMut<'a, 'static> {
     fn from(entity: EntityMut<'a>) -> Self {
         // SAFETY:
         // - `EntityMut` guarantees exclusive access to all components in the new `FilteredEntityMut`.
-        unsafe {
-            let mut access = Access::default();
-            access.read_all();
-            access.write_all();
-            FilteredEntityMut::new(entity.cell, access)
-        }
+        unsafe { FilteredEntityMut::new(entity.cell, const { &Access::new_write_all() }) }
     }
 }
 
-impl<'a> From<&'a mut EntityMut<'_>> for FilteredEntityMut<'a> {
+impl<'a> From<&'a mut EntityMut<'_>> for FilteredEntityMut<'a, 'static> {
     fn from(entity: &'a mut EntityMut<'_>) -> Self {
         // SAFETY:
         // - `EntityMut` guarantees exclusive access to all components in the new `FilteredEntityMut`.
-        unsafe {
-            let mut access = Access::default();
-            access.read_all();
-            access.write_all();
-            FilteredEntityMut::new(entity.cell, access)
-        }
+        unsafe { FilteredEntityMut::new(entity.cell, const { &Access::new_write_all() }) }
     }
 }
 
-impl<'a> From<EntityWorldMut<'a>> for FilteredEntityMut<'a> {
+impl<'a> From<EntityWorldMut<'a>> for FilteredEntityMut<'a, 'static> {
     fn from(entity: EntityWorldMut<'a>) -> Self {
         // SAFETY:
         // - `EntityWorldMut` guarantees exclusive access to the entire world.
         unsafe {
-            let mut access = Access::default();
-            access.read_all();
-            access.write_all();
-            FilteredEntityMut::new(entity.into_unsafe_entity_cell(), access)
+            FilteredEntityMut::new(
+                entity.into_unsafe_entity_cell(),
+                const { &Access::new_write_all() },
+            )
         }
     }
 }
 
-impl<'a> From<&'a mut EntityWorldMut<'_>> for FilteredEntityMut<'a> {
+impl<'a> From<&'a mut EntityWorldMut<'_>> for FilteredEntityMut<'a, 'static> {
     fn from(entity: &'a mut EntityWorldMut<'_>) -> Self {
         // SAFETY:
         // - `EntityWorldMut` guarantees exclusive access to the entire world.
         unsafe {
-            let mut access = Access::default();
-            access.read_all();
-            access.write_all();
-            FilteredEntityMut::new(entity.as_unsafe_entity_cell(), access)
+            FilteredEntityMut::new(
+                entity.as_unsafe_entity_cell(),
+                const { &Access::new_write_all() },
+            )
         }
     }
 }
 
-impl<'a, B: Bundle> From<&'a EntityMutExcept<'_, B>> for FilteredEntityMut<'a> {
-    fn from(value: &'a EntityMutExcept<'_, B>) -> Self {
-        // SAFETY:
-        // - The FilteredEntityMut has the same component access as the given EntityMutExcept.
-        unsafe {
-            let mut access = Access::default();
-            access.write_all();
-            let components = value.entity.world().components();
-            B::get_component_ids(components, &mut |maybe_id| {
-                if let Some(id) = maybe_id {
-                    access.remove_component_read(id);
-                }
-            });
-            FilteredEntityMut::new(value.entity, access)
-        }
-    }
-}
-
-impl PartialEq for FilteredEntityMut<'_> {
+impl PartialEq for FilteredEntityMut<'_, '_> {
     fn eq(&self, other: &Self) -> bool {
         self.entity() == other.entity()
     }
 }
 
-impl Eq for FilteredEntityMut<'_> {}
+impl Eq for FilteredEntityMut<'_, '_> {}
 
-impl PartialOrd for FilteredEntityMut<'_> {
+impl PartialOrd for FilteredEntityMut<'_, '_> {
     /// [`FilteredEntityMut`]'s comparison trait implementations match the underlying [`Entity`],
     /// and cannot discern between different worlds.
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
@@ -3954,26 +3900,26 @@ impl PartialOrd for FilteredEntityMut<'_> {
     }
 }
 
-impl Ord for FilteredEntityMut<'_> {
+impl Ord for FilteredEntityMut<'_, '_> {
     fn cmp(&self, other: &Self) -> Ordering {
         self.entity().cmp(&other.entity())
     }
 }
 
-impl Hash for FilteredEntityMut<'_> {
+impl Hash for FilteredEntityMut<'_, '_> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.entity().hash(state);
     }
 }
 
-impl ContainsEntity for FilteredEntityMut<'_> {
+impl ContainsEntity for FilteredEntityMut<'_, '_> {
     fn entity(&self) -> Entity {
         self.id()
     }
 }
 
 // SAFETY: This type represents one Entity. We implement the comparison traits based on that Entity.
-unsafe impl EntityEquivalent for FilteredEntityMut<'_> {}
+unsafe impl EntityEquivalent for FilteredEntityMut<'_, '_> {}
 
 /// Error type returned by [`TryFrom`] conversions from filtered entity types
 /// ([`FilteredEntityRef`]/[`FilteredEntityMut`]) to full-access entity types

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -5374,6 +5374,19 @@ mod tests {
         }
     }
 
+    #[test]
+    fn entity_mut_except_registers_components() {
+        // Checks for a bug where `EntityMutExcept` would not register the component and
+        // would therefore not include an exception, causing it to conflict with the later query.
+        fn system1(_query: Query<EntityMutExcept<TestComponent>>, _: Query<&mut TestComponent>) {}
+        let mut world = World::new();
+        world.run_system_once(system1).unwrap();
+
+        fn system2(_: Query<&mut TestComponent>, _query: Query<EntityMutExcept<TestComponent>>) {}
+        let mut world = World::new();
+        world.run_system_once(system2).unwrap();
+    }
+
     #[derive(Component)]
     struct A;
 

--- a/crates/bevy_remote/src/builtin_methods.rs
+++ b/crates/bevy_remote/src/builtin_methods.rs
@@ -880,7 +880,7 @@ pub fn process_remote_query_request(In(params): In<Option<Value>>, world: &mut W
 
         // The map of boolean-valued component presences:
         let has_map = build_has_map(
-            row.clone(),
+            row,
             has_paths_and_reflect_components.iter().copied(),
             &unregistered_in_has,
         );
@@ -1466,7 +1466,7 @@ fn build_has_map<'a>(
     let mut has_map = <HashMap<_, _>>::default();
 
     for (type_path, reflect_component) in paths_and_reflect_components {
-        let has = reflect_component.contains(entity_ref.clone());
+        let has = reflect_component.contains(entity_ref);
         has_map.insert(type_path.to_owned(), Value::Bool(has));
     }
     unregistered_components.iter().for_each(|component| {


### PR DESCRIPTION
# Objective

Improve the performance of queries using `FilteredEntityRef`, `FilteredEntityMut`, `EntityRefExcept`, and `EntityMutExcept`.  In particular, this appears to speed up `bevy_animation::animate_targets` by 10% in many-foxes.  

`FilteredEntity(Ref|Mut)` needs to store an `Access` to determine which components may be accessed.  Prior to #15396, this required cloning the `Access` for each instance.  Now, we can borrow the `Access` from the query state and make cheap pointer copies.  

`Entity(Ref|Mut)Except` avoided needing to clone an `Access` by calling functions on the `Bundle` trait.  Unfortunately, that meant we needed to convert from a type to a `ComponentId` for every component in the bundle on every check.  Now, we can do those conversions up front and pass references to an `Access`.  

Finally, fix a bug where `Entity(Ref|Mut)Except` would not initialize their components during `init_state`.  I noticed this while updating `init_state` and fixed it while I was there.  That was normally harmless because the components would be registered elsewhere, but a system like `fn system(_q1: Query<EntityMutExcept<C>>, _q2: Query<&mut C>) {}` would fail to find the `ComponentId` for `C` and not exclude it from the access for `q1`, and then panic with conflicting access from `q2`.  

## Solution

Change `FilteredEntityRef` and `FilteredEntityMut` to store `&'s Access` instead of `Access`, and change `EntityRefExcept` and `EntityMutExcept` to store an extra `&'s Access`.  

This adds the `'s` lifetime to those four types, and most changes are adding lifetimes as appropriate.  

Change the `WorldQuery::State` for `Entity(Ref|Mut)Except` to store an `Access` that can be borrowed from, replacing the `SmallVec<[ComponentId; 4]>` that was used only to set the query access.  

To support the conversions from `EntityRef` and `EntityMut`, we need to be able to create a `&'static Access` for read-all or write-all.  I could not change `fn read_all_components()` to be `const` because it called the non-`const` `FixedBitSet::clear()`, so I created separate constructor functions.  

## Testing

Ran `cargo run --example many_foxes --features bevy/trace_tracy --release` before and after, and compared the results of `animate_targets`, since that is the only in-engine use of `EntityMutExcept` and was the motivation for creating it.  

Yellow is this PR, red is main: 

<img width="695" height="690" alt="image" src="https://github.com/user-attachments/assets/24531a3f-65bf-46d0-baa5-29ea9e56b16a" />
