### PR TITLE
Fix visibility (re)use in Solari DI

### DIFF
--- a/crates/bevy_solari/src/realtime/restir_di.wgsl
+++ b/crates/bevy_solari/src/realtime/restir_di.wgsl
@@ -174,8 +174,8 @@ fn load_spatial_reservoir(pixel_id: vec2<u32>, depth: f32, world_position: vec3<
 }
 
 fn get_neighbor_pixel_id(center_pixel_id: vec2<u32>, rng: ptr<function, u32>) -> vec2<u32> {
-    var spatial_id = vec2<i32>(center_pixel_id) + vec2<i32>(sample_disk(SPATIAL_REUSE_RADIUS_PIXELS, rng));
-    spatial_id = clamp(spatial_id, vec2(0i), vec2<i32>(view.viewport.zw) - 1i);
+    var spatial_id = vec2<f32>(center_pixel_id) + sample_disk(SPATIAL_REUSE_RADIUS_PIXELS, rng);
+    spatial_id = clamp(spatial_id, vec2(0.0), view.viewport.zw - 1.0);
     return vec2<u32>(spatial_id);
 }
 

--- a/crates/bevy_solari/src/realtime/restir_di.wgsl
+++ b/crates/bevy_solari/src/realtime/restir_di.wgsl
@@ -112,7 +112,6 @@ fn generate_initial_reservoir(world_position: vec3<f32>, world_normal: vec3<f32>
         reservoir.unbiased_contribution_weight = reservoir.weight_sum * inverse_target_function;
 
         reservoir.visibility = trace_light_visibility(reservoir.sample, world_position);
-        reservoir.unbiased_contribution_weight *= reservoir.visibility;
     }
 
     reservoir.confidence_weight = 1.0;
@@ -288,7 +287,7 @@ fn merge_reservoirs(
 
 fn reservoir_target_function(reservoir: Reservoir, world_position: vec3<f32>, world_normal: vec3<f32>, diffuse_brdf: vec3<f32>) -> vec4<f32> {
     if !reservoir_valid(reservoir) { return vec4(0.0); }
-    let light_contribution = calculate_light_contribution(reservoir.sample, world_position, world_normal).radiance;
+    let light_contribution = calculate_light_contribution(reservoir.sample, world_position, world_normal).radiance * reservoir.visibility;
     let target_function = luminance(light_contribution * diffuse_brdf);
     return vec4(light_contribution, target_function);
 }

--- a/crates/bevy_solari/src/realtime/restir_gi.wgsl
+++ b/crates/bevy_solari/src/realtime/restir_gi.wgsl
@@ -172,8 +172,8 @@ fn load_spatial_reservoir(pixel_id: vec2<u32>, depth: f32, world_position: vec3<
 }
 
 fn get_neighbor_pixel_id(center_pixel_id: vec2<u32>, rng: ptr<function, u32>) -> vec2<u32> {
-    var spatial_id = vec2<i32>(center_pixel_id) + vec2<i32>(sample_disk(SPATIAL_REUSE_RADIUS_PIXELS, rng));
-    spatial_id = clamp(spatial_id, vec2(0i), vec2<i32>(view.viewport.zw) - 1i);
+    var spatial_id = vec2<f32>(center_pixel_id) + sample_disk(SPATIAL_REUSE_RADIUS_PIXELS, rng);
+    spatial_id = clamp(spatial_id, vec2(0.0), view.viewport.zw - 1.0);
     return vec2<u32>(spatial_id);
 }
 

--- a/release-content/release-notes/bevy_solari.md
+++ b/release-content/release-notes/bevy_solari.md
@@ -1,7 +1,7 @@
 ---
 title: Initial raytraced lighting progress (bevy_solari)
 authors: ["@JMS55"]
-pull_requests: [19058, 19620, 19790, 20020]
+pull_requests: [19058, 19620, 19790, 20020, 20113]
 ---
 
 (TODO: Embed solari example screenshot here)


### PR DESCRIPTION
# Objective
Fixes the re(use) of visibility in Solari's ReSTIR DI. 

The paper I based things off of didn't (seem) to use visibility in their resampling https://yusuketokuyoshi.com/papers/2024/Efficient_Visibility_Reuse_for_Real-time_ReSTIR_(Supplementary_Document).pdf, only shading, but factoring it into the resampling improves things a lot.

---

## Showcase
Before:
<img width="2564" height="1500" alt="image" src="https://github.com/user-attachments/assets/15fa7941-ab68-47bc-9bbc-42ca55359046" />

After: 
<img width="2564" height="1500" alt="image" src="https://github.com/user-attachments/assets/6fe52ed0-7832-41c1-b1cd-e8c8d9825e51" />
