### PR TITLE
Fix glTF light orientation

### DIFF
--- a/crates/bevy_gltf/src/convert_coordinates.rs
+++ b/crates/bevy_gltf/src/convert_coordinates.rs
@@ -24,6 +24,7 @@ pub(crate) trait ConvertCameraCoordinates {
     /// - up: Y
     /// - right: X
     ///
+    /// The same convention is used for lights.
     /// See <https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#view-matrix>
     fn convert_camera_coordinates(self) -> Self;
 }

--- a/crates/bevy_gltf/src/loader/gltf_ext/scene.rs
+++ b/crates/bevy_gltf/src/loader/gltf_ext/scene.rs
@@ -45,7 +45,7 @@ pub(crate) fn node_transform(node: &Node, convert_coordinates: bool) -> Transfor
         },
     };
     if convert_coordinates {
-        if node.camera().is_some() {
+        if node.camera().is_some() || node.light().is_some() {
             transform.convert_camera_coordinates()
         } else {
             transform.convert_coordinates()


### PR DESCRIPTION
# Objective

- Extracted from https://github.com/bevyengine/bevy/pull/20099
- Turns out glTF also uses its viewport coordinate system for lights, so let's account for that

## Solution

- Use the same branch for lights as for cameras when importing glTFs

## Testing

- Ran a dedicated Blender test scene to verify that this is the correct behavior.
