### PR TITLE
Switch most examples to use `RenderStartup` instead of `finish` and `FromWorld`.

### DIFF
--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -27,7 +27,7 @@ use bevy::{
         sync_component::SyncComponentPlugin,
         sync_world::{MainEntityHashMap, RenderEntity},
         view::{ExtractedView, RenderVisibleEntities, ViewTarget},
-        Extract, Render, RenderApp, RenderSystems,
+        Extract, Render, RenderApp, RenderStartup, RenderSystems,
     },
     sprite::{
         extract_mesh2d, DrawMesh2d, Material2dBindGroupId, Mesh2dPipeline, Mesh2dPipelineKey,
@@ -132,14 +132,16 @@ pub struct ColoredMesh2dPipeline {
     shader: Handle<Shader>,
 }
 
-impl FromWorld for ColoredMesh2dPipeline {
-    fn from_world(world: &mut World) -> Self {
-        Self {
-            mesh2d_pipeline: Mesh2dPipeline::from_world(world),
-            // Get the shader from the shader resource we inserted in the plugin.
-            shader: world.resource::<ColoredMesh2dShader>().0.clone(),
-        }
-    }
+fn init_colored_mesh_2d_pipeline(
+    mut commands: Commands,
+    mesh2d_pipeline: Res<Mesh2dPipeline>,
+    colored_mesh2d_shader: Res<ColoredMesh2dShader>,
+) {
+    commands.insert_resource(ColoredMesh2dPipeline {
+        mesh2d_pipeline: mesh2d_pipeline.clone(),
+        // Clone the shader from the shader resource we inserted in the plugin.
+        shader: colored_mesh2d_shader.0.clone(),
+    });
 }
 
 // We implement `SpecializedPipeline` to customize the default rendering from `Mesh2dPipeline`
@@ -307,6 +309,7 @@ impl Plugin for ColoredMesh2dPlugin {
             .add_render_command::<Transparent2d, DrawColoredMesh2d>()
             .init_resource::<SpecializedRenderPipelines<ColoredMesh2dPipeline>>()
             .init_resource::<RenderColoredMesh2dInstances>()
+            .add_systems(RenderStartup, init_colored_mesh_2d_pipeline)
             .add_systems(
                 ExtractSchedule,
                 extract_colored_mesh2d.after(extract_mesh2d),
@@ -315,13 +318,6 @@ impl Plugin for ColoredMesh2dPlugin {
                 Render,
                 queue_colored_mesh2d.in_set(RenderSystems::QueueMeshes),
             );
-    }
-
-    fn finish(&self, app: &mut App) {
-        // Register our custom pipeline
-        app.get_sub_app_mut(RenderApp)
-            .unwrap()
-            .init_resource::<ColoredMesh2dPipeline>();
     }
 }
 

--- a/examples/shader/compute_shader_game_of_life.rs
+++ b/examples/shader/compute_shader_game_of_life.rs
@@ -12,7 +12,7 @@ use bevy::{
         render_resource::{binding_types::texture_storage_2d, *},
         renderer::{RenderContext, RenderDevice},
         texture::GpuImage,
-        Render, RenderApp, RenderSystems,
+        Render, RenderApp, RenderStartup, RenderSystems,
     },
 };
 use std::borrow::Cow;
@@ -103,19 +103,16 @@ impl Plugin for GameOfLifeComputePlugin {
         // for operation on by the compute shader and display on the sprite.
         app.add_plugins(ExtractResourcePlugin::<GameOfLifeImages>::default());
         let render_app = app.sub_app_mut(RenderApp);
-        render_app.add_systems(
-            Render,
-            prepare_bind_group.in_set(RenderSystems::PrepareBindGroups),
-        );
+        render_app
+            .add_systems(RenderStartup, init_game_of_life_pipeline)
+            .add_systems(
+                Render,
+                prepare_bind_group.in_set(RenderSystems::PrepareBindGroups),
+            );
 
         let mut render_graph = render_app.world_mut().resource_mut::<RenderGraph>();
         render_graph.add_node(GameOfLifeLabel, GameOfLifeNode::default());
         render_graph.add_node_edge(GameOfLifeLabel, bevy::render::graph::CameraDriverLabel);
-    }
-
-    fn finish(&self, app: &mut App) {
-        let render_app = app.sub_app_mut(RenderApp);
-        render_app.init_resource::<GameOfLifePipeline>();
     }
 }
 
@@ -157,40 +154,41 @@ struct GameOfLifePipeline {
     update_pipeline: CachedComputePipelineId,
 }
 
-impl FromWorld for GameOfLifePipeline {
-    fn from_world(world: &mut World) -> Self {
-        let render_device = world.resource::<RenderDevice>();
-        let texture_bind_group_layout = render_device.create_bind_group_layout(
-            "GameOfLifeImages",
-            &BindGroupLayoutEntries::sequential(
-                ShaderStages::COMPUTE,
-                (
-                    texture_storage_2d(TextureFormat::R32Float, StorageTextureAccess::ReadOnly),
-                    texture_storage_2d(TextureFormat::R32Float, StorageTextureAccess::WriteOnly),
-                ),
+fn init_game_of_life_pipeline(
+    mut commands: Commands,
+    render_device: Res<RenderDevice>,
+    asset_server: Res<AssetServer>,
+    pipeline_cache: Res<PipelineCache>,
+) {
+    let texture_bind_group_layout = render_device.create_bind_group_layout(
+        "GameOfLifeImages",
+        &BindGroupLayoutEntries::sequential(
+            ShaderStages::COMPUTE,
+            (
+                texture_storage_2d(TextureFormat::R32Float, StorageTextureAccess::ReadOnly),
+                texture_storage_2d(TextureFormat::R32Float, StorageTextureAccess::WriteOnly),
             ),
-        );
-        let shader = world.load_asset(SHADER_ASSET_PATH);
-        let pipeline_cache = world.resource::<PipelineCache>();
-        let init_pipeline = pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
-            layout: vec![texture_bind_group_layout.clone()],
-            shader: shader.clone(),
-            entry_point: Some(Cow::from("init")),
-            ..default()
-        });
-        let update_pipeline = pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
-            layout: vec![texture_bind_group_layout.clone()],
-            shader,
-            entry_point: Some(Cow::from("update")),
-            ..default()
-        });
+        ),
+    );
+    let shader = asset_server.load(SHADER_ASSET_PATH);
+    let init_pipeline = pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
+        layout: vec![texture_bind_group_layout.clone()],
+        shader: shader.clone(),
+        entry_point: Some(Cow::from("init")),
+        ..default()
+    });
+    let update_pipeline = pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
+        layout: vec![texture_bind_group_layout.clone()],
+        shader,
+        entry_point: Some(Cow::from("update")),
+        ..default()
+    });
 
-        GameOfLifePipeline {
-            texture_bind_group_layout,
-            init_pipeline,
-            update_pipeline,
-        }
-    }
+    commands.insert_resource(GameOfLifePipeline {
+        texture_bind_group_layout,
+        init_pipeline,
+        update_pipeline,
+    });
 }
 
 enum GameOfLifeState {

--- a/examples/shader/gpu_readback.rs
+++ b/examples/shader/gpu_readback.rs
@@ -15,7 +15,7 @@ use bevy::{
         renderer::{RenderContext, RenderDevice},
         storage::{GpuShaderStorageBuffer, ShaderStorageBuffer},
         texture::GpuImage,
-        Render, RenderApp, RenderSystems,
+        Render, RenderApp, RenderStartup, RenderSystems,
     },
 };
 
@@ -41,24 +41,22 @@ fn main() {
 // We need a plugin to organize all the systems and render node required for this example
 struct GpuReadbackPlugin;
 impl Plugin for GpuReadbackPlugin {
-    fn build(&self, _app: &mut App) {}
-
-    fn finish(&self, app: &mut App) {
-        let render_app = app.sub_app_mut(RenderApp);
-        render_app.init_resource::<ComputePipeline>().add_systems(
-            Render,
-            prepare_bind_group
-                .in_set(RenderSystems::PrepareBindGroups)
-                // We don't need to recreate the bind group every frame
-                .run_if(not(resource_exists::<GpuBufferBindGroup>)),
-        );
-
-        // Add the compute node as a top level node to the render graph
-        // This means it will only execute once per frame
+    fn build(&self, app: &mut App) {
+        let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
+        };
         render_app
-            .world_mut()
-            .resource_mut::<RenderGraph>()
-            .add_node(ComputeNodeLabel, ComputeNode::default());
+            .add_systems(
+                RenderStartup,
+                (init_compute_pipeline, add_compute_render_graph_node),
+            )
+            .add_systems(
+                Render,
+                prepare_bind_group
+                    .in_set(RenderSystems::PrepareBindGroups)
+                    // We don't need to recreate the bind group every frame
+                    .run_if(not(resource_exists::<GpuBufferBindGroup>)),
+            );
     }
 }
 
@@ -127,6 +125,13 @@ fn setup(
     commands.insert_resource(ReadbackImage(image));
 }
 
+fn add_compute_render_graph_node(mut render_graph: ResMut<RenderGraph>) {
+    // Add the compute node as a top-level node to the render graph. This means it will only execute
+    // once per frame. Normally, adding a node would use the `RenderGraphApp::add_render_graph_node`
+    // method, but it does not allow adding as a top-level node.
+    render_graph.add_node(ComputeNodeLabel, ComputeNode::default());
+}
+
 #[derive(Resource)]
 struct GpuBufferBindGroup(BindGroup);
 
@@ -158,29 +163,30 @@ struct ComputePipeline {
     pipeline: CachedComputePipelineId,
 }
 
-impl FromWorld for ComputePipeline {
-    fn from_world(world: &mut World) -> Self {
-        let render_device = world.resource::<RenderDevice>();
-        let layout = render_device.create_bind_group_layout(
-            None,
-            &BindGroupLayoutEntries::sequential(
-                ShaderStages::COMPUTE,
-                (
-                    storage_buffer::<Vec<u32>>(false),
-                    texture_storage_2d(TextureFormat::R32Uint, StorageTextureAccess::WriteOnly),
-                ),
+fn init_compute_pipeline(
+    mut commands: Commands,
+    render_device: Res<RenderDevice>,
+    asset_server: Res<AssetServer>,
+    pipeline_cache: Res<PipelineCache>,
+) {
+    let layout = render_device.create_bind_group_layout(
+        None,
+        &BindGroupLayoutEntries::sequential(
+            ShaderStages::COMPUTE,
+            (
+                storage_buffer::<Vec<u32>>(false),
+                texture_storage_2d(TextureFormat::R32Uint, StorageTextureAccess::WriteOnly),
             ),
-        );
-        let shader = world.load_asset(SHADER_ASSET_PATH);
-        let pipeline_cache = world.resource::<PipelineCache>();
-        let pipeline = pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
-            label: Some("GPU readback compute shader".into()),
-            layout: vec![layout.clone()],
-            shader: shader.clone(),
-            ..default()
-        });
-        ComputePipeline { layout, pipeline }
-    }
+        ),
+    );
+    let shader = asset_server.load(SHADER_ASSET_PATH);
+    let pipeline = pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
+        label: Some("GPU readback compute shader".into()),
+        layout: vec![layout.clone()],
+        shader: shader.clone(),
+        ..default()
+    });
+    commands.insert_resource(ComputePipeline { layout, pipeline });
 }
 
 /// Label to identify the node in the render graph


### PR DESCRIPTION
# Objective

- Progress towards #19887.
- I am avoiding dealing with the `occlusion_culling` example since it is kinda annoying to resolve nicely (I will do so in another PR).

## Solution

- Rewrite these examples to replace FromWorld implementations with systems and other resource changes with systems as well.

## Testing

- All the changed examples have been tested and still work.