### PR TITLE
Rebrand glTF coordinate conversion to an alternative strategy that is biased towards glTF models

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -574,11 +574,6 @@ web = ["bevy_internal/web"]
 # Enable hotpatching of Bevy systems
 hotpatching = ["bevy_internal/hotpatching"]
 
-# Enable converting glTF coordinates to Bevy's coordinate system by default. This will be Bevy's default behavior starting in 0.18.
-gltf_convert_coordinates_default = [
-  "bevy_internal/gltf_convert_coordinates_default",
-]
-
 # Enable collecting debug information about systems and components to help with diagnostics
 debug = ["bevy_internal/debug"]
 

--- a/crates/bevy_gltf/Cargo.toml
+++ b/crates/bevy_gltf/Cargo.toml
@@ -15,7 +15,6 @@ pbr_multi_layer_material_textures = [
 ]
 pbr_anisotropy_texture = ["bevy_pbr/pbr_anisotropy_texture"]
 pbr_specular_textures = ["bevy_pbr/pbr_specular_textures"]
-gltf_convert_coordinates_default = []
 
 [dependencies]
 # bevy
@@ -64,6 +63,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.140"
 smallvec = { version = "1", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
+
+[dev-dependencies]
 bevy_log = { path = "../bevy_log", version = "0.17.0-dev" }
 
 [lints]

--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -185,7 +185,7 @@ impl Default for GltfPlugin {
         GltfPlugin {
             default_sampler: ImageSamplerDescriptor::linear(),
             custom_vertex_attributes: HashMap::default(),
-            convert_coordinates: cfg!(feature = "gltf_convert_coordinates_default"),
+            convert_coordinates: false,
         }
     }
 }

--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -159,20 +159,17 @@ pub struct GltfPlugin {
     /// Can be modified with the [`DefaultGltfImageSampler`] resource.
     pub default_sampler: ImageSamplerDescriptor,
 
-    /// Whether to convert glTF coordinates to Bevy's coordinate system by default.
-    /// If set to `true`, the loader will convert the coordinate system of loaded glTF assets to Bevy's coordinate system
-    /// such that objects looking forward in glTF will also look forward in Bevy.
+    /// How to convert glTF coordinates on import. Assuming glTF cameras, glTF lights, and glTF meshes had global unit transforms,
+    /// their Bevy [`Transform::forward`](bevy_transform::components::Transform::forward) will be pointing in the following global directions:
+    /// - When set to `false`
+    ///   - glTF cameras and glTF lights: global -Z,
+    ///   - glTF models: global +Z.
+    /// - When set to `true`
+    ///   - glTF cameras and glTF lights: global +Z,
+    ///   - glTF models: global -Z.
     ///
-    /// The exact coordinate system conversion is as follows:
-    /// - glTF:
-    ///   - forward: Z
-    ///   - up: Y
-    ///   - right: -X
-    /// - Bevy:
-    ///   - forward: -Z
-    ///   - up: Y
-    ///   - right: X
-    pub convert_coordinates: bool,
+    /// The default is `false`.
+    pub favor_model_coordinates: bool,
 
     /// Registry for custom vertex attributes.
     ///
@@ -185,7 +182,7 @@ impl Default for GltfPlugin {
         GltfPlugin {
             default_sampler: ImageSamplerDescriptor::linear(),
             custom_vertex_attributes: HashMap::default(),
-            convert_coordinates: false,
+            favor_model_coordinates: false,
         }
     }
 }
@@ -241,7 +238,7 @@ impl Plugin for GltfPlugin {
             supported_compressed_formats,
             custom_vertex_attributes: self.custom_vertex_attributes.clone(),
             default_sampler,
-            default_convert_coordinates: self.convert_coordinates,
+            default_favor_model_coordinates: self.favor_model_coordinates,
         });
     }
 }

--- a/crates/bevy_gltf/src/loader/mod.rs
+++ b/crates/bevy_gltf/src/loader/mod.rs
@@ -2,7 +2,6 @@ mod extensions;
 mod gltf_ext;
 
 use alloc::sync::Arc;
-use bevy_log::warn_once;
 use std::{
     io::Error,
     path::{Path, PathBuf},
@@ -298,18 +297,7 @@ async fn load_gltf<'a, 'b, 'c>(
 
     let convert_coordinates = match settings.convert_coordinates {
         Some(convert_coordinates) => convert_coordinates,
-        None => {
-            let convert_by_default = loader.default_convert_coordinates;
-            if !convert_by_default && !cfg!(feature = "gltf_convert_coordinates_default") {
-                warn_once!(
-                    "Starting from Bevy 0.18, by default all imported glTF models will be rotated by 180 degrees around the Y axis to align with Bevy's coordinate system. \
-                    You are currently importing glTF files using the old behavior. Consider opting-in to the new import behavior by enabling the `gltf_convert_coordinates_default` feature. \
-                    If you encounter any issues please file a bug! \
-                    If you want to continue using the old behavior going forward (even when the default changes in 0.18), manually set the corresponding option in the `GltfPlugin` or `GltfLoaderSettings`. See the migration guide for more details."
-                );
-            }
-            convert_by_default
-        }
+        None => loader.default_convert_coordinates,
     };
 
     #[cfg(feature = "bevy_animation")]

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -369,10 +369,6 @@ web = [
 
 hotpatching = ["bevy_app/hotpatching", "bevy_ecs/hotpatching"]
 
-gltf_convert_coordinates_default = [
-  "bevy_gltf?/gltf_convert_coordinates_default",
-]
-
 debug = ["bevy_utils/debug"]
 
 [dependencies]

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -91,7 +91,6 @@ The default feature set enables most of the expected features of a game engine, 
 |ghost_nodes|Experimental support for nodes that are ignored for UI layouting|
 |gif|GIF image format support|
 |glam_assert|Enable assertions to check the validity of parameters passed to glam|
-|gltf_convert_coordinates_default|Enable converting glTF coordinates to Bevy's coordinate system by default. This will be Bevy's default behavior starting in 0.18.|
 |hotpatching|Enable hotpatching of Bevy systems|
 |ico|ICO image format support|
 |jpeg|JPEG image format support|

--- a/release-content/release-notes/convert-coordinates.md
+++ b/release-content/release-notes/convert-coordinates.md
@@ -1,41 +1,44 @@
 ---
-title: Allow importing glTFs with a corrected coordinate system
+title: Allow importing glTFs with corrected model forward semantics
 authors: ["@janhohenheim"]
-pull_requests: [19633, 19685]
+pull_requests: [19633, 19685, 19816]
 ---
 
-glTF uses the following coordinate system:
-
-- forward: Z
-- up: Y
-- right: -X
-
-and Bevy uses:
+Bevy uses the following coordinate system for all worldspace entities that have a `Transform`:
 
 - forward: -Z
 - up: Y
 - right: X
 
-This means that to correctly import glTFs into Bevy, vertex data should be rotated by 180 degrees around the Y axis.  
-For the longest time, Bevy has simply ignored this distinction. That caused issues when working across programs, as most software respects the
-glTF coordinate system when importing and exporting glTFs. Your scene might have looked correct in Blender, Maya, TrenchBroom, etc. but everything would be flipped when importing it into Bevy!
+But glTF is a bit more complicated. Models in glTF scenes use the following coordinate system:
 
-Long-term, we'd like to fix our glTF imports to use the correct coordinate system by default.
-But changing the import behavior would mean that *all* imported glTFs of *all* users would suddenly look different, breaking their scenes!
-Not to mention that any bugs in the conversion code would be incredibly frustating for users.
+- forward: Z
+- up: Y
+- right: -X
 
-This is why we are now gradually rolling out support for corrected glTF imports. Starting now you can opt into the new behavior by setting `convert_coordinates` on `GltfPlugin`:
+but cameras and lights in glTF scenes use the following coordinate system:
+
+- forward: -Z
+- up: Y
+- right: X
+
+As you can see, this clashes with Bevy assumption that everything in the world uses the same coordinate system.
+In the past, we only imported glTFs using the camera / light coordinate system for everything, as that is already aligned with Bevy.
+In other words, the glTF importer simply assumed that glTF models used -Z as their forward direction, even though they use +Z.
+
+But that meant that on the Bevy side, a glTF model's `Transform::forward()` would actually point backwards from the point of view of the model,
+which is counterintuitive and very annoying when working across different art pipelines.
+
+To remedy this, users can now change the import behavior to instead favor correct `Transform::forward()` semantics for models.
+The downside is that glTF cameras and lights that have a global identity transform in glTF will now look to +Z instead of -Z in Bevy.
+This should not be a problem in many cases, as the whole scene is rotated so that the end result on your screen will be rendered the exact same way.
+
+To globally opt into the behavior that favors glTF models over glTF cameras, you can set `GltfPlugin::favor_model_coordinates`:
 
 ```rust
-// old behavior, ignores glTF's coordinate system
-App::new()
-    .add_plugins(DefaultPlugins)
-    .run();
-
-// new behavior, converts the coordinate system of all glTF assets into Bevy's coordinate system
 App::new()
     .add_plugins(DefaultPlugins.set(GltfPlugin {
-        convert_coordinates: true,
+        favor_model_coordinates: true,
         ..default()
     }))
     .run();
@@ -44,24 +47,12 @@ App::new()
 You can also control this on a per-asset-level:
 
 ```rust
-// Use the global default
-let handle = asset_server.load("fox.gltf#Scene0");
-
-// Manually opt in or out of coordinate conversion for an individual asset
 let handle = asset_server.load_with_settings(
     "fox.gltf#Scene0",
     |settings: &mut GltfLoaderSettings| {
-        settings.convert_coordinates = Some(true);
+        settings.favor_model_coordinates = Some(true);
     },
 );
 ```
 
-Afterwards, your scene will be oriented such that your modeling software's forward direction correctly corresponds to Bevy's forward direction.
-
-For example, Blender assumes -Y to be forward, so exporting the following model to glTF and loading it in Bevy with the new settings will ensure everything is
-oriented the right way across all programs in your pipeline:
-
-<!-- TODO: Add png from PR description -->
-![Blender Coordinate System](blender-coords.png)
-
-If you opt into this, please let us know how it's working out! Is your scene looking like you expected? Are the animations playing correctly? Is the camera at the right place? Are the lights shining from the right spots?
+Setting the above to `None` will fall back to the global setting taken from `GltfPlugin::favor_model_coordinates`.

--- a/release-content/release-notes/convert-coordinates.md
+++ b/release-content/release-notes/convert-coordinates.md
@@ -1,7 +1,7 @@
 ---
 title: Allow importing glTFs with a corrected coordinate system
 authors: ["@janhohenheim"]
-pull_requests: [19633, 19685, 19816]
+pull_requests: [19633, 19685]
 ---
 
 glTF uses the following coordinate system:
@@ -24,27 +24,7 @@ Long-term, we'd like to fix our glTF imports to use the correct coordinate syste
 But changing the import behavior would mean that *all* imported glTFs of *all* users would suddenly look different, breaking their scenes!
 Not to mention that any bugs in the conversion code would be incredibly frustating for users.
 
-This is why we are now gradually rolling out support for corrected glTF imports. You will now be greeted by the following warning when using the old behavior:
-
-> Starting from Bevy 0.18, by default all imported glTF models will be rotated by 180 degrees around the Y axis to align with Bevy's coordinate system.
-> You are currently importing glTF files using the old behavior. Consider opting-in to the new import behavior by enabling the `gltf_convert_coordinates_default` feature.
-> If you encounter any issues please file a bug!
-> If you want to continue using the old behavior going forward (even when the default changes in 0.18), manually set the corresponding option in the `GltfPlugin` or `GltfLoaderSettings`.
-> See the migration guide for more details.
-
-As the warning says, you can opt into the new behavior by enabling the `gltf_convert_coordinates_default` feature in your `Cargo.toml`:
-
-```toml
-# old behavior, ignores glTF's coordinate system
-[dependencies]
-bevy = "0.17.0"
-
-# new behavior, converts the coordinate system of all glTF assets into Bevy's coordinate system
-[dependencies]
-bevy = { version = "0.17.0", features = ["gltf_convert_coordinates_default"] }
-```
-
-If you prefer, you can also do this in code by setting `convert_coordinates` on `GltfPlugin`:
+This is why we are now gradually rolling out support for corrected glTF imports. Starting now you can opt into the new behavior by setting `convert_coordinates` on `GltfPlugin`:
 
 ```rust
 // old behavior, ignores glTF's coordinate system
@@ -61,9 +41,6 @@ App::new()
     .run();
 ```
 
-If you want to continue using the old behavior in the future, you can silence the warning by enabling the `gltf_convert_coordinates_default` feature
-and explicitly setting `convert_coordinates: false` on `GltfPlugin`.
-
 You can also control this on a per-asset-level:
 
 ```rust
@@ -79,7 +56,7 @@ let handle = asset_server.load_with_settings(
 );
 ```
 
-After opting into the new behavior, your scene will be oriented such that your modeling software's forward direction correctly corresponds to Bevy's forward direction.
+Afterwards, your scene will be oriented such that your modeling software's forward direction correctly corresponds to Bevy's forward direction.
 
 For example, Blender assumes -Y to be forward, so exporting the following model to glTF and loading it in Bevy with the new settings will ensure everything is
 oriented the right way across all programs in your pipeline:


### PR DESCRIPTION
# Objective

Per long discussion with @superdump, the new coordinate loading system is still wrong, just now biased in favor of having correct forward semantics for models instead of cameras. Which is what I want, but should not be the new default, as we may well change `Transform::forward` instead. 

## Solution
Since this is a bigger change, let's rebrand the coordinate conversion code and keep it opt-in so that users that don't use glTF cameras get correct semantics in the meantime.

## Testing

- Ran 3D examples and Blender test scenes.

