### PR TITLE
`GpuReadbackPlugin`: Allow reading only a part of a buffer

### DIFF
--- a/examples/shader/gpu_readback.rs
+++ b/examples/shader/gpu_readback.rs
@@ -74,7 +74,7 @@ fn setup(
     mut buffers: ResMut<Assets<ShaderStorageBuffer>>,
 ) {
     // Create a storage buffer with some data
-    let buffer = vec![0u32; BUFFER_LEN];
+    let buffer: Vec<u32> = (0..BUFFER_LEN as u32).collect();
     let mut buffer = ShaderStorageBuffer::from(buffer);
     // We need to enable the COPY_SRC usage so we can copy the buffer to the cpu
     buffer.buffer_description.usage |= BufferUsages::COPY_SRC;
@@ -110,6 +110,19 @@ fn setup(
             let data: Vec<u32> = trigger.event().to_shader_type();
             info!("Buffer {:?}", data);
         });
+
+    // It is also possible to read only a range of the buffer.
+    commands
+        .spawn(Readback::buffer_range(
+            buffer.clone(),
+            4 * u32::SHADER_SIZE.get(), // skip the first four elements
+            8 * u32::SHADER_SIZE.get(), // read eight elements
+        ))
+        .observe(|trigger: On<ReadbackComplete>| {
+            let data: Vec<u32> = trigger.event().to_shader_type();
+            info!("Buffer range {:?}", data);
+        });
+
     // This is just a simple way to pass the buffer handle to the render app for our compute node
     commands.insert_resource(ReadbackBuffer(buffer));
 


### PR DESCRIPTION
# Objective

- So far only full buffer reads were supported. This adds the ability to read a part of a buffer.

## Solution

- Allow passing in a start offset and a number of bytes to read when creating the  `Readback` component.
- I also removed the unused `src_start` and `dst_start` fields from `ReadbackSource` as they were always 0.

## Testing

- Did you test these changes? If so, how?

I extended the example to also demonstrate partial reads.

- Are there any parts that need more testing?

Can't think of any.

- How can other people (reviewers) test your changes? Is there anything specific they need to know?

Run the `gpu_readback` example. It now also reads and prints a partially read buffer.

- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?

Only tested on Linux.

---

## Showcase

Example output:

<details>
  <summary>Click to view showcase</summary>

```
2025-07-14T14:05:15.614876Z  INFO gpu_readback: Buffer [257, 258, 259, 260, 261, 262, 263, 264, 265, 266, 267, 268, 269, 270, 271, 272]
2025-07-14T14:05:15.614921Z  INFO gpu_readback: Buffer range [261, 262, 263, 264, 265, 266, 267, 268]
2025-07-14T14:05:15.614937Z  INFO gpu_readback: Image [257, 258, 259, 260, 261, 262, 263, 264, 265, 266, 267, 268, 269, 270, 271, 272, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
```

</details>
