### PR TITLE
Document repeating timer tick behavior

### DIFF
--- a/crates/bevy_time/src/timer.rs
+++ b/crates/bevy_time/src/timer.rs
@@ -5,13 +5,25 @@ use core::time::Duration;
 
 /// Tracks elapsed time. Enters the finished state once `duration` is reached.
 ///
-/// Non repeating timers will stop tracking and stay in the finished state until reset.
-/// Repeating timers will only be in the finished state on each tick `duration` is reached or
+/// Note that in order to advance the timer [`tick`](Timer::tick) **MUST** be called.
+///
+/// # Timer modes
+///
+/// There are two timer modes ([`TimerMode`]):
+///
+/// - Non repeating timers will stop tracking and stay in the finished state until reset.
+/// - Repeating timers will only be in the finished state on each tick `duration` is reached or
 /// exceeded, and can still be reset at any given point.
 ///
-/// Paused timers will not have elapsed time increased.
+/// # Pausing timers
 ///
-/// Note that in order to advance the timer [`tick`](Timer::tick) **MUST** be called.
+/// You can pause a timer using [`Timer::pause`]. Paused timers will not have elapsed time increased.
+///
+/// # Elapsing multiple times a frame
+///
+/// Repeating timers might elapse multiple times per frame if the time is advanced by more than the timer duration.
+/// You can check how many times a timer elapsed each tick with [`Timer::times_finished_this_tick`].
+/// For non-repeating timers, this will always be 0 or 1.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(


### PR DESCRIPTION
# Objective

Closes #20132 

## Solution

I found docs describing the behavior elsewhere in Bevy, which I pulled in to the main `Timer` docs: https://github.com/bevyengine/bevy/blob/b01de70bdd927bcc9cdc5d0b8c677f480e54f4b1/crates/bevy_time/src/common_conditions.rs#L27-L35

I also restructured the docs a little bit.