### PR TITLE
Rename the `InterpolationColorSpace` variants to match `Color`.

### DIFF
--- a/crates/bevy_feathers/src/controls/slider.rs
+++ b/crates/bevy_feathers/src/controls/slider.rs
@@ -99,7 +99,7 @@ pub fn slider<B: Bundle>(props: SliderProps, overrides: B) -> impl Bundle {
                 ColorStop::new(Color::NONE, Val::Percent(50.)),
                 ColorStop::new(Color::NONE, Val::Percent(100.)),
             ],
-            color_space: InterpolationColorSpace::Srgb,
+            color_space: InterpolationColorSpace::Srgba,
         })]),
         overrides,
         children![(

--- a/crates/bevy_ui/src/gradients.rs
+++ b/crates/bevy_ui/src/gradients.rs
@@ -638,25 +638,25 @@ impl RadialGradientShape {
     reflect(Serialize, Deserialize)
 )]
 pub enum InterpolationColorSpace {
-    /// Interpolates in `OKLab` space.
+    /// Interpolates in OKLABA space.
     #[default]
-    OkLab,
-    /// Interpolates in OKLCH space, taking the shortest hue path.
-    OkLch,
-    /// Interpolates in OKLCH space, taking the longest hue path.
-    OkLchLong,
-    /// Interpolates in sRGB space.
-    Srgb,
-    /// Interpolates in linear sRGB space.
-    LinearRgb,
-    /// Interpolates in HSL space, taking the shortest hue path.
-    Hsl,
-    /// Interpolates in HSL space, taking the longest hue path.
-    HslLong,
-    /// Interpolates in HSV space, taking the shortest hue path.
-    Hsv,
-    /// Interpolates in HSV space, taking the longest hue path.
-    HsvLong,
+    Oklaba,
+    /// Interpolates in OKLCHA space, taking the shortest hue path.
+    Oklcha,
+    /// Interpolates in OKLCHA space, taking the longest hue path.
+    OklchaLong,
+    /// Interpolates in sRGBA space.
+    Srgba,
+    /// Interpolates in linear sRGBA space.
+    LinearRgba,
+    /// Interpolates in HSLA space, taking the shortest hue path.
+    Hsla,
+    /// Interpolates in HSLA space, taking the longest hue path.
+    HslaLong,
+    /// Interpolates in HSVA space, taking the shortest hue path.
+    Hsva,
+    /// Interpolates in HSVA space, taking the longest hue path.
+    HsvaLong,
 }
 
 /// Set the color space used for interpolation.
@@ -665,28 +665,28 @@ pub trait InColorSpace: Sized {
     fn in_color_space(self, color_space: InterpolationColorSpace) -> Self;
 
     /// Interpolate in `OKLab` space.
-    fn in_oklab(self) -> Self {
-        self.in_color_space(InterpolationColorSpace::OkLab)
+    fn in_oklaba(self) -> Self {
+        self.in_color_space(InterpolationColorSpace::Oklaba)
     }
 
     /// Interpolate in OKLCH space (short hue path).
     fn in_oklch(self) -> Self {
-        self.in_color_space(InterpolationColorSpace::OkLch)
+        self.in_color_space(InterpolationColorSpace::Oklcha)
     }
 
     /// Interpolate in OKLCH space (long hue path).
     fn in_oklch_long(self) -> Self {
-        self.in_color_space(InterpolationColorSpace::OkLchLong)
+        self.in_color_space(InterpolationColorSpace::OklchaLong)
     }
 
     /// Interpolate in sRGB space.
     fn in_srgb(self) -> Self {
-        self.in_color_space(InterpolationColorSpace::Srgb)
+        self.in_color_space(InterpolationColorSpace::Srgba)
     }
 
     /// Interpolate in linear sRGB space.
     fn in_linear_rgb(self) -> Self {
-        self.in_color_space(InterpolationColorSpace::LinearRgb)
+        self.in_color_space(InterpolationColorSpace::LinearRgba)
     }
 }
 

--- a/crates/bevy_ui_render/src/gradient.rs
+++ b/crates/bevy_ui_render/src/gradient.rs
@@ -181,15 +181,15 @@ impl SpecializedRenderPipeline for GradientPipeline {
             ],
         );
         let color_space = match key.color_space {
-            InterpolationColorSpace::OkLab => "IN_OKLAB",
-            InterpolationColorSpace::OkLch => "IN_OKLCH",
-            InterpolationColorSpace::OkLchLong => "IN_OKLCH_LONG",
-            InterpolationColorSpace::Srgb => "IN_SRGB",
-            InterpolationColorSpace::LinearRgb => "IN_LINEAR_RGB",
-            InterpolationColorSpace::Hsl => "IN_HSL",
-            InterpolationColorSpace::HslLong => "IN_HSL_LONG",
-            InterpolationColorSpace::Hsv => "IN_HSV",
-            InterpolationColorSpace::HsvLong => "IN_HSV_LONG",
+            InterpolationColorSpace::Oklaba => "IN_OKLAB",
+            InterpolationColorSpace::Oklcha => "IN_OKLCH",
+            InterpolationColorSpace::OklchaLong => "IN_OKLCH_LONG",
+            InterpolationColorSpace::Srgba => "IN_SRGB",
+            InterpolationColorSpace::LinearRgba => "IN_LINEAR_RGB",
+            InterpolationColorSpace::Hsla => "IN_HSL",
+            InterpolationColorSpace::HslaLong => "IN_HSL_LONG",
+            InterpolationColorSpace::Hsva => "IN_HSV",
+            InterpolationColorSpace::HsvaLong => "IN_HSV_LONG",
         };
 
         let shader_defs = if key.anti_alias {

--- a/examples/testbed/ui.rs
+++ b/examples/testbed/ui.rs
@@ -597,15 +597,15 @@ mod linear_gradient {
                     ],
                 ] {
                     for color_space in [
-                        InterpolationColorSpace::LinearRgb,
-                        InterpolationColorSpace::Srgb,
-                        InterpolationColorSpace::OkLab,
-                        InterpolationColorSpace::OkLch,
-                        InterpolationColorSpace::OkLchLong,
-                        InterpolationColorSpace::Hsl,
-                        InterpolationColorSpace::HslLong,
-                        InterpolationColorSpace::Hsv,
-                        InterpolationColorSpace::HsvLong,
+                        InterpolationColorSpace::LinearRgba,
+                        InterpolationColorSpace::Srgba,
+                        InterpolationColorSpace::Oklaba,
+                        InterpolationColorSpace::Oklcha,
+                        InterpolationColorSpace::OklchaLong,
+                        InterpolationColorSpace::Hsla,
+                        InterpolationColorSpace::HslaLong,
+                        InterpolationColorSpace::Hsva,
+                        InterpolationColorSpace::HsvaLong,
                     ] {
                         commands.spawn((
                             Node {

--- a/examples/ui/gradients.rs
+++ b/examples/ui/gradients.rs
@@ -232,32 +232,32 @@ fn setup(mut commands: Commands) {
                                         }
                                     };
                                     *space = match *space {
-                                        InterpolationColorSpace::OkLab => {
-                                            InterpolationColorSpace::OkLch
+                                        InterpolationColorSpace::Oklaba => {
+                                            InterpolationColorSpace::Oklcha
                                         }
-                                        InterpolationColorSpace::OkLch => {
-                                            InterpolationColorSpace::OkLchLong
+                                        InterpolationColorSpace::Oklcha => {
+                                            InterpolationColorSpace::OklchaLong
                                         }
-                                        InterpolationColorSpace::OkLchLong => {
-                                            InterpolationColorSpace::Srgb
+                                        InterpolationColorSpace::OklchaLong => {
+                                            InterpolationColorSpace::Srgba
                                         }
-                                        InterpolationColorSpace::Srgb => {
-                                            InterpolationColorSpace::LinearRgb
+                                        InterpolationColorSpace::Srgba => {
+                                            InterpolationColorSpace::LinearRgba
                                         }
-                                        InterpolationColorSpace::LinearRgb => {
-                                            InterpolationColorSpace::Hsl
+                                        InterpolationColorSpace::LinearRgba => {
+                                            InterpolationColorSpace::Hsla
                                         }
-                                        InterpolationColorSpace::Hsl => {
-                                            InterpolationColorSpace::HslLong
+                                        InterpolationColorSpace::Hsla => {
+                                            InterpolationColorSpace::HslaLong
                                         }
-                                        InterpolationColorSpace::HslLong => {
-                                            InterpolationColorSpace::Hsv
+                                        InterpolationColorSpace::HslaLong => {
+                                            InterpolationColorSpace::Hsva
                                         }
-                                        InterpolationColorSpace::Hsv => {
-                                            InterpolationColorSpace::HsvLong
+                                        InterpolationColorSpace::Hsva => {
+                                            InterpolationColorSpace::HsvaLong
                                         }
-                                        InterpolationColorSpace::HsvLong => {
-                                            InterpolationColorSpace::OkLab
+                                        InterpolationColorSpace::HsvaLong => {
+                                            InterpolationColorSpace::Oklaba
                                         }
                                     };
                                     current_space = *space;


### PR DESCRIPTION
# Objective

The names of the variants of `InterpolationColorSpace` don't match the corresponding `Color` variants, which could be potentially confusing. For instance, `Color` has an `Oklaba` variant, in `InterpolationColorSpace` it's called `OkLab`. 

## Solution

Rename variants of `InterpolationColorSpace` to mirror the variants of Color.
