### PR TITLE
pub GraphInfo

### DIFF
--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -10,10 +10,10 @@ mod schedule;
 mod set;
 mod stepping;
 
+pub use self::graph::GraphInfo;
 use self::graph::*;
 pub use self::{condition::*, config::*, executor::*, node::*, schedule::*, set::*};
 pub use pass::ScheduleBuildPass;
-pub use self::graph::GraphInfo;
 
 /// An implementation of a graph data structure.
 pub mod graph;


### PR DESCRIPTION
IntoScheduleConfigs has the constraint `T: Schedulable<Metadata = GraphInfo, GroupMetadata = Chain>`. Making `GraphInfo` public allows external crates to implement blanket traits for any `IntoSheduleConfigs`:


```rust
pub struct ScheduleIntoMyTraitMarker;

impl<S, T, M> MyTrait<(ScheduleIntoMyTypeMarker, T, M)> for S
where
  S: 'static + Clone + IntoScheduleConfigs<T, M>,
  T: Schedulable<Metadata = GraphInfo, GroupMetadata = Chain>,
{
}

```