### PR TITLE
Split observer events

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1320,7 +1320,7 @@ impl App {
     /// #
     /// # let mut app = App::new();
     /// #
-    /// # #[derive(Event)]
+    /// # #[derive(BroadcastEvent)]
     /// # struct Party {
     /// #   friends_allowed: bool,
     /// # };

--- a/crates/bevy_ecs/README.md
+++ b/crates/bevy_ecs/README.md
@@ -306,7 +306,7 @@ Observers are systems that listen for a "trigger" of a specific `Event`:
 ```rust
 use bevy_ecs::prelude::*;
 
-#[derive(Event)]
+#[derive(BroadcastEvent)]
 struct Speak {
     message: String
 }

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -30,8 +30,9 @@ pub fn derive_broadcast_event(input: TokenStream) -> TokenStream {
     let (impl_generics, type_generics, where_clause) = &ast.generics.split_for_impl();
 
     TokenStream::from(quote! {
-        impl #impl_generics #bevy_ecs_path::event::Event for #struct_name #type_generics #where_clause {}
-        impl #impl_generics #bevy_ecs_path::event::BroadcastEvent for #struct_name #type_generics #where_clause {}
+        impl #impl_generics #bevy_ecs_path::event::Event for #struct_name #type_generics #where_clause {
+            type Kind = #bevy_ecs_path::event::BroadcastEventKind;
+        }
     })
 }
 
@@ -74,10 +75,8 @@ pub fn derive_entity_event(input: TokenStream) -> TokenStream {
     let (impl_generics, type_generics, where_clause) = &ast.generics.split_for_impl();
 
     TokenStream::from(quote! {
-        impl #impl_generics #bevy_ecs_path::event::Event for #struct_name #type_generics #where_clause {}
-        impl #impl_generics #bevy_ecs_path::event::EntityEvent for #struct_name #type_generics #where_clause {
-            type Traversal = #traversal;
-            const AUTO_PROPAGATE: bool = #auto_propagate;
+        impl #impl_generics #bevy_ecs_path::event::Event for #struct_name #type_generics #where_clause {
+            type Kind = #bevy_ecs_path::event::EntityEventKind<Self, #traversal, #auto_propagate>;
         }
     })
 }

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -17,7 +17,7 @@ pub const EVENT: &str = "entity_event";
 pub const AUTO_PROPAGATE: &str = "auto_propagate";
 pub const TRAVERSAL: &str = "traversal";
 
-pub fn derive_event(input: TokenStream) -> TokenStream {
+pub fn derive_broadcast_event(input: TokenStream) -> TokenStream {
     let mut ast = parse_macro_input!(input as DeriveInput);
     let bevy_ecs_path: Path = crate::bevy_ecs_path();
 
@@ -31,6 +31,7 @@ pub fn derive_event(input: TokenStream) -> TokenStream {
 
     TokenStream::from(quote! {
         impl #impl_generics #bevy_ecs_path::event::Event for #struct_name #type_generics #where_clause {}
+        impl #impl_generics #bevy_ecs_path::event::BroadcastEvent for #struct_name #type_generics #where_clause {}
     })
 }
 

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -30,9 +30,8 @@ pub fn derive_broadcast_event(input: TokenStream) -> TokenStream {
     let (impl_generics, type_generics, where_clause) = &ast.generics.split_for_impl();
 
     TokenStream::from(quote! {
-        impl #impl_generics #bevy_ecs_path::event::Event for #struct_name #type_generics #where_clause {
-            type Kind = #bevy_ecs_path::event::BroadcastEventKind;
-        }
+        impl #impl_generics #bevy_ecs_path::event::Event for #struct_name #type_generics #where_clause {}
+        impl #impl_generics #bevy_ecs_path::event::BroadcastEvent for #struct_name #type_generics #where_clause {}
     })
 }
 
@@ -75,8 +74,10 @@ pub fn derive_entity_event(input: TokenStream) -> TokenStream {
     let (impl_generics, type_generics, where_clause) = &ast.generics.split_for_impl();
 
     TokenStream::from(quote! {
-        impl #impl_generics #bevy_ecs_path::event::Event for #struct_name #type_generics #where_clause {
-            type Kind = #bevy_ecs_path::event::EntityEventKind<Self, #traversal, #auto_propagate>;
+        impl #impl_generics #bevy_ecs_path::event::Event for #struct_name #type_generics #where_clause {}
+        impl #impl_generics #bevy_ecs_path::event::EntityEvent for #struct_name #type_generics #where_clause {
+            type Traversal = #traversal;
+            const AUTO_PROPAGATE: bool = #auto_propagate;
         }
     })
 }

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -547,10 +547,10 @@ pub(crate) fn bevy_ecs_path() -> syn::Path {
     BevyManifest::shared().get_path("bevy_ecs")
 }
 
-/// Implement the `Event` trait.
-#[proc_macro_derive(Event)]
+/// Implement the `BroadcastEvent` trait.
+#[proc_macro_derive(BroadcastEvent)]
 pub fn derive_event(input: TokenStream) -> TokenStream {
-    component::derive_event(input)
+    component::derive_broadcast_event(input)
 }
 
 /// Cheat sheet for derive syntax,

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -549,7 +549,7 @@ pub(crate) fn bevy_ecs_path() -> syn::Path {
 
 /// Implement the `BroadcastEvent` trait.
 #[proc_macro_derive(BroadcastEvent)]
-pub fn derive_event(input: TokenStream) -> TokenStream {
+pub fn derive_broadcast_event(input: TokenStream) -> TokenStream {
     component::derive_broadcast_event(input)
 }
 

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -23,7 +23,7 @@ use crate::{
     bundle::BundleId,
     component::{ComponentId, Components, RequiredComponentConstructor, StorageType},
     entity::{Entity, EntityLocation},
-    event::Event,
+    event::BroadcastEvent,
     observer::Observers,
     storage::{ImmutableSparseSet, SparseArray, SparseSet, TableId, TableRow},
 };
@@ -35,7 +35,7 @@ use core::{
 };
 use nonmax::NonMaxU32;
 
-#[derive(Event)]
+#[derive(BroadcastEvent)]
 #[expect(dead_code, reason = "Prepare for the upcoming Query as Entities")]
 pub(crate) struct ArchetypeCreated(pub ArchetypeId);
 

--- a/crates/bevy_ecs/src/component/tick.rs
+++ b/crates/bevy_ecs/src/component/tick.rs
@@ -1,4 +1,4 @@
-use bevy_ecs_macros::Event;
+use bevy_ecs_macros::BroadcastEvent;
 use bevy_ptr::UnsafeCellDeref;
 #[cfg(feature = "bevy_reflect")]
 use bevy_reflect::Reflect;
@@ -86,7 +86,7 @@ impl Tick {
     }
 }
 
-/// An observer [`Event`] that can be used to maintain [`Tick`]s in custom data structures, enabling to make
+/// A [`BroadcastEvent`] that can be used to maintain [`Tick`]s in custom data structures, enabling to make
 /// use of bevy's periodic checks that clamps ticks to a certain range, preventing overflows and thus
 /// keeping methods like [`Tick::is_newer_than`] reliably return `false` for ticks that got too old.
 ///
@@ -111,7 +111,7 @@ impl Tick {
 ///     schedule.0.check_change_ticks(*check);
 /// });
 /// ```
-#[derive(Debug, Clone, Copy, Event)]
+#[derive(Debug, Clone, Copy, BroadcastEvent)]
 pub struct CheckChangeTicks(pub(crate) Tick);
 
 impl CheckChangeTicks {

--- a/crates/bevy_ecs/src/event/base.rs
+++ b/crates/bevy_ecs/src/event/base.rs
@@ -95,9 +95,6 @@ use core::{
     note = "consider annotating `{Self}` with `#[derive(BroadcastEvent)]` or `#[derive(EntityEvent)]`"
 )]
 pub trait Event: Send + Sync + 'static {
-    #[doc(hidden)]
-    type Kind;
-
     /// Generates the [`EventKey`] for this event type.
     ///
     /// If this type has already been registered,
@@ -133,32 +130,7 @@ pub trait Event: Send + Sync + 'static {
 }
 
 /// A global [`Event`] without an entity target.
-#[diagnostic::on_unimplemented(
-    message = "`{Self}` is not an `BroadcastEvent`",
-    label = "invalid `BroadcastEvent`",
-    note = "consider annotating `{Self}` with `#[derive(BroadcastEvent)]`"
-)]
-pub trait BroadcastEvent: Event + sealed_a::SealedA {}
-
-#[doc(hidden)]
-pub struct BroadcastEventKind;
-
-#[diagnostic::do_not_recommend]
-impl<T> BroadcastEvent for T where T: Event<Kind = BroadcastEventKind> {}
-
-pub(crate) mod sealed_a {
-    use super::*;
-
-    /// Seal for the [`BroadcastEvent`] trait.
-    #[diagnostic::on_unimplemented(
-        message = "manual implementations of `BroadcastEvent` are disallowed",
-        note = "consider annotating `{Self}` with `#[derive(BroadcastEvent)]` instead"
-    )]
-    pub trait SealedA {}
-
-    #[diagnostic::do_not_recommend]
-    impl<T> SealedA for T where T: Event<Kind = BroadcastEventKind> {}
-}
+pub trait BroadcastEvent: Event {}
 
 /// An [`Event`] that can be targeted at specific entities.
 ///
@@ -276,7 +248,7 @@ pub(crate) mod sealed_a {
     label = "invalid `EntityEvent`",
     note = "consider annotating `{Self}` with `#[derive(EntityEvent)]`"
 )]
-pub trait EntityEvent: Event + sealed_b::SealedB {
+pub trait EntityEvent: Event {
     /// The component that describes which [`Entity`] to propagate this event to next, when [propagation] is enabled.
     ///
     /// [`Entity`]: crate::entity::Entity
@@ -289,37 +261,6 @@ pub trait EntityEvent: Event + sealed_b::SealedB {
     /// [triggered]: crate::system::Commands::trigger_targets
     /// [`On::propagate`]: crate::observer::On::propagate
     const AUTO_PROPAGATE: bool = false;
-}
-
-#[doc(hidden)]
-pub struct EntityEventKind<T: ?Sized, R: Traversal<T>, const A: bool> {
-    _t: PhantomData<T>,
-    _r: PhantomData<R>,
-}
-
-// Blanket impl for EntityEvent
-#[diagnostic::do_not_recommend]
-impl<T, R: Traversal<T>, const A: bool> EntityEvent for T
-where
-    T: Event<Kind = EntityEventKind<T, R, A>>,
-{
-    type Traversal = R;
-    const AUTO_PROPAGATE: bool = A;
-}
-
-pub(crate) mod sealed_b {
-    use super::*;
-
-    /// Seal for the [`EntityEvent`] trait.
-    #[diagnostic::on_unimplemented(
-        message = "manual implementations of `EntityEvent` are disallowed",
-        note = "consider annotating `{Self}` with `#[derive(EntityEvent)]` instead"
-    )]
-    pub trait SealedB {}
-
-    #[diagnostic::do_not_recommend]
-    impl<T, R: Traversal<T>, const A: bool> SealedB for T where T: Event<Kind = EntityEventKind<T, R, A>>
-    {}
 }
 
 /// A buffered event for pull-based event handling.

--- a/crates/bevy_ecs/src/event/base.rs
+++ b/crates/bevy_ecs/src/event/base.rs
@@ -11,6 +11,7 @@ use core::{
     marker::PhantomData,
 };
 
+// TODO: Adjust these docs
 /// Something that "happens" and can be processed by app logic.
 ///
 /// Events can be triggered on a [`World`] using a method like [`trigger`](World::trigger),
@@ -89,9 +90,9 @@ use core::{
 /// [`EventReader`]: super::EventReader
 /// [`EventWriter`]: super::EventWriter
 #[diagnostic::on_unimplemented(
-    message = "`{Self}` is not an `Event`",
-    label = "invalid `Event`",
-    note = "consider annotating `{Self}` with `#[derive(Event)]`"
+    message = "`{Self}` is not an `ObserverEvent`",
+    label = "invalid `ObserverEvent`",
+    note = "consider annotating `{Self}` with `#[derive(BroadcastEvent)]` or `#[derive(EntityEvent)]`"
 )]
 pub trait Event: Send + Sync + 'static {
     /// Generates the [`EventKey`] for this event type.
@@ -127,6 +128,9 @@ pub trait Event: Send + Sync + 'static {
             .map(EventKey)
     }
 }
+
+/// A global [`Event`] without an entity target.
+pub trait BroadcastEvent: Event {}
 
 /// An [`Event`] that can be targeted at specific entities.
 ///

--- a/crates/bevy_ecs/src/event/base.rs
+++ b/crates/bevy_ecs/src/event/base.rs
@@ -95,7 +95,7 @@ use core::{
     note = "consider annotating `{Self}` with `#[derive(BroadcastEvent)]` or `#[derive(EntityEvent)]`"
 )]
 pub trait Event: Send + Sync + 'static {
-    ///
+    #[doc(hidden)]
     type Kind;
 
     /// Generates the [`EventKey`] for this event type.

--- a/crates/bevy_ecs/src/event/base.rs
+++ b/crates/bevy_ecs/src/event/base.rs
@@ -57,7 +57,7 @@ pub trait Event: Send + Sync + 'static {
 /// An [`Event`] without an entity target.
 ///
 /// [`BroadcastEvent`]s can be triggered on a [`World`] with the method [`trigger`](World::trigger),
-/// causing any [`Observer`] watching the event for those entities to run.
+/// causing any global [`Observer`]s for that event to run.
 ///
 /// # Usage
 ///
@@ -106,9 +106,6 @@ pub trait Event: Send + Sync + 'static {
 /// });
 /// ```
 ///
-/// For events that additionally need entity targeting or buffering, consider also deriving
-/// [`EntityEvent`] or [`BufferedEvent`], respectively.
-///
 /// [`Observer`]: crate::observer::Observer
 pub trait BroadcastEvent: Event {}
 
@@ -126,7 +123,7 @@ pub trait BroadcastEvent: Event {}
 ///
 /// # Usage
 ///
-/// The [`EntityEvent`] trait can be derived. The `event` attribute can be used to further configure
+/// The [`EntityEvent`] trait can be derived. The `entity_event` attribute can be used to further configure
 /// the propagation behavior: adding `auto_propagate` sets [`EntityEvent::AUTO_PROPAGATE`] to `true`,
 /// while adding `traversal = X` sets [`EntityEvent::Traversal`] to be of type `X`.
 ///

--- a/crates/bevy_ecs/src/event/mod.rs
+++ b/crates/bevy_ecs/src/event/mod.rs
@@ -11,7 +11,10 @@ mod update;
 mod writer;
 
 pub(crate) use base::EventInstance;
-pub use base::{BroadcastEvent, BufferedEvent, EntityEvent, Event, EventId, EventKey};
+pub use base::{
+    BroadcastEvent, BroadcastEventKind, BufferedEvent, EntityEvent, EntityEventKind, Event,
+    EventId, EventKey,
+};
 pub use bevy_ecs_macros::{BroadcastEvent, BufferedEvent, EntityEvent};
 #[expect(deprecated, reason = "`SendBatchIds` was renamed to `WriteBatchIds`.")]
 pub use collections::{Events, SendBatchIds, WriteBatchIds};

--- a/crates/bevy_ecs/src/event/mod.rs
+++ b/crates/bevy_ecs/src/event/mod.rs
@@ -11,10 +11,7 @@ mod update;
 mod writer;
 
 pub(crate) use base::EventInstance;
-pub use base::{
-    BroadcastEvent, BroadcastEventKind, BufferedEvent, EntityEvent, EntityEventKind, Event,
-    EventId, EventKey,
-};
+pub use base::{BroadcastEvent, BufferedEvent, EntityEvent, Event, EventId, EventKey};
 pub use bevy_ecs_macros::{BroadcastEvent, BufferedEvent, EntityEvent};
 #[expect(deprecated, reason = "`SendBatchIds` was renamed to `WriteBatchIds`.")]
 pub use collections::{Events, SendBatchIds, WriteBatchIds};

--- a/crates/bevy_ecs/src/event/mod.rs
+++ b/crates/bevy_ecs/src/event/mod.rs
@@ -1,4 +1,24 @@
-//! Event handling types.
+//! Events are that "happens" and can be processed by app logic.
+//!
+//! [Event]s can be triggered on a [`World`](bevy_ecs::world::World) using a method like [`trigger`],
+//! causing any global [`Observer`] watching that event to run. This allows for push-based
+//! event handling where observers are immediately notified of events as they happen.
+//!
+//! Event handling behavior can be enabled by implementing the [`EntityEvent`]
+//! and [`BufferedEvent`] traits:
+//!
+//! - [`Event`]: A supertrait for observer events.
+//!     - [`BroadcastEvent`]: An observer event without an entity target.
+//!     - [`EntityEvent`]s support targeting specific entities, triggering any observers watching those targets.
+//!       They are useful for entity-specific event handlers and can even be propagated from one entity to another.
+//! - [`BufferedEvent`]s support a pull-based event handling system where events are written using an [`EventWriter`]
+//!   and read later using an [`EventReader`]. This is an alternative to observers that allows efficient batch processing
+//!   of events at fixed points in a schedule.
+//!
+//! [`World`]: crate::world::World
+//! [`trigger`]: crate::world::World::trigger
+//! [`Observer`]: crate::observer::Observer
+
 mod base;
 mod collections;
 mod event_cursor;

--- a/crates/bevy_ecs/src/event/mod.rs
+++ b/crates/bevy_ecs/src/event/mod.rs
@@ -1,22 +1,22 @@
-//! Events are that "happens" and can be processed by app logic.
+//! Events are things that "happen" and can be processed by app logic.
 //!
 //! [Event]s can be triggered on a [`World`](bevy_ecs::world::World) using a method like [`trigger`],
 //! causing any global [`Observer`] watching that event to run. This allows for push-based
 //! event handling where observers are immediately notified of events as they happen.
 //!
-//! Event handling behavior can be enabled by implementing the [`EntityEvent`]
-//! and [`BufferedEvent`] traits:
-//!
-//! - [`Event`]: A supertrait for observer events.
-//!     - [`BroadcastEvent`]: An observer event without an entity target.
-//!     - [`EntityEvent`]s support targeting specific entities, triggering any observers watching those targets.
-//!       They are useful for entity-specific event handlers and can even be propagated from one entity to another.
-//! - [`BufferedEvent`]s support a pull-based event handling system where events are written using an [`EventWriter`]
+//! - [`Event`]: A supertrait for push-based events that trigger global observers added via [`add_observer`].
+//!     - [`BroadcastEvent`]: An event without an entity target. Can be used via [`trigger`]
+//!     - [`EntityEvent`]: An event targeting specific entities, triggering any observers watching those targets. Can be used via [`trigger_targets`].
+//!       They can trigger entity-specific observers added via [`observe`] and can be propagated from one entity to another.
+//! - [`BufferedEvent`]: Support a pull-based event handling system where events are written using an [`EventWriter`]
 //!   and read later using an [`EventReader`]. This is an alternative to observers that allows efficient batch processing
 //!   of events at fixed points in a schedule.
 //!
 //! [`World`]: crate::world::World
+//! [`add_observer`]: crate::world::World::add_observer
+//! [`observe`]: crate::world::EntityWorldMut::observe
 //! [`trigger`]: crate::world::World::trigger
+//! [`trigger_targets`]: crate::world::World::trigger_targets
 //! [`Observer`]: crate::observer::Observer
 
 mod base;

--- a/crates/bevy_ecs/src/event/mod.rs
+++ b/crates/bevy_ecs/src/event/mod.rs
@@ -11,8 +11,8 @@ mod update;
 mod writer;
 
 pub(crate) use base::EventInstance;
-pub use base::{BufferedEvent, EntityEvent, Event, EventId, EventKey};
-pub use bevy_ecs_macros::{BufferedEvent, EntityEvent, Event};
+pub use base::{BroadcastEvent, BufferedEvent, EntityEvent, Event, EventId, EventKey};
+pub use bevy_ecs_macros::{BroadcastEvent, BufferedEvent, EntityEvent};
 #[expect(deprecated, reason = "`SendBatchIds` was renamed to `WriteBatchIds`.")]
 pub use collections::{Events, SendBatchIds, WriteBatchIds};
 pub use event_cursor::EventCursor;

--- a/crates/bevy_ecs/src/event/mod.rs
+++ b/crates/bevy_ecs/src/event/mod.rs
@@ -1,11 +1,7 @@
 //! Events are things that "happen" and can be processed by app logic.
 //!
-//! [Event]s can be triggered on a [`World`](bevy_ecs::world::World) using a method like [`trigger`],
-//! causing any global [`Observer`] watching that event to run. This allows for push-based
-//! event handling where observers are immediately notified of events as they happen.
-//!
 //! - [`Event`]: A supertrait for push-based events that trigger global observers added via [`add_observer`].
-//!     - [`BroadcastEvent`]: An event without an entity target. Can be used via [`trigger`]
+//!     - [`BroadcastEvent`]: An event without an entity target. Can be used via [`trigger`].
 //!     - [`EntityEvent`]: An event targeting specific entities, triggering any observers watching those targets. Can be used via [`trigger_targets`].
 //!       They can trigger entity-specific observers added via [`observe`] and can be propagated from one entity to another.
 //! - [`BufferedEvent`]: Support a pull-based event handling system where events are written using an [`EventWriter`]

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -79,8 +79,8 @@ pub mod prelude {
         entity::{ContainsEntity, Entity, EntityMapper},
         error::{BevyError, Result},
         event::{
-            BufferedEvent, EntityEvent, Event, EventKey, EventMutator, EventReader, EventWriter,
-            Events,
+            BroadcastEvent, BufferedEvent, EntityEvent, Event, EventKey, EventMutator, EventReader,
+            EventWriter, Events,
         },
         hierarchy::{ChildOf, ChildSpawner, ChildSpawnerCommands, Children},
         lifecycle::{

--- a/crates/bevy_ecs/src/observer/distributed_storage.rs
+++ b/crates/bevy_ecs/src/observer/distributed_storage.rs
@@ -44,7 +44,7 @@ use crate::prelude::ReflectComponent;
 /// ```
 /// # use bevy_ecs::prelude::*;
 /// # let mut world = World::default();
-/// #[derive(Event)]
+/// #[derive(BroadcastEvent)]
 /// struct Speak {
 ///     message: String,
 /// }
@@ -67,7 +67,7 @@ use crate::prelude::ReflectComponent;
 /// ```
 /// # use bevy_ecs::prelude::*;
 /// # let mut world = World::default();
-/// # #[derive(Event)]
+/// # #[derive(BroadcastEvent)]
 /// # struct Speak;
 /// // These are functionally the same:
 /// world.add_observer(|trigger: On<Speak>| {});
@@ -79,7 +79,7 @@ use crate::prelude::ReflectComponent;
 /// ```
 /// # use bevy_ecs::prelude::*;
 /// # let mut world = World::default();
-/// # #[derive(Event)]
+/// # #[derive(BroadcastEvent)]
 /// # struct PrintNames;
 /// # #[derive(Component, Debug)]
 /// # struct Name;
@@ -97,7 +97,7 @@ use crate::prelude::ReflectComponent;
 /// ```
 /// # use bevy_ecs::prelude::*;
 /// # let mut world = World::default();
-/// # #[derive(Event)]
+/// # #[derive(BroadcastEvent)]
 /// # struct SpawnThing;
 /// # #[derive(Component, Debug)]
 /// # struct Thing;
@@ -111,9 +111,9 @@ use crate::prelude::ReflectComponent;
 /// ```
 /// # use bevy_ecs::prelude::*;
 /// # let mut world = World::default();
-/// # #[derive(Event)]
+/// # #[derive(BroadcastEvent)]
 /// # struct A;
-/// # #[derive(Event)]
+/// # #[derive(BroadcastEvent)]
 /// # struct B;
 /// world.add_observer(|trigger: On<A>, mut commands: Commands| {
 ///     commands.trigger(B);

--- a/crates/bevy_ecs/src/observer/distributed_storage.rs
+++ b/crates/bevy_ecs/src/observer/distributed_storage.rs
@@ -211,7 +211,7 @@ pub struct Observer {
 }
 
 impl Observer {
-    /// Creates a new [`Observer`], which defaults to a "global" observer. This means it will run whenever the event `E` is triggered
+    /// Creates a new [`Observer`], which defaults to a global observer. This means it will run whenever the event `E` is triggered
     /// for _any_ entity (or no entity).
     ///
     /// # Panics

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -152,7 +152,7 @@ use crate::{
 };
 
 impl World {
-    /// Spawns a "global" [`Observer`] which will watch for the given event.
+    /// Spawns a global [`Observer`] which will watch for the given event.
     /// Returns its [`Entity`] as a [`EntityWorldMut`].
     ///
     /// `system` can be any system whose first parameter is [`On`].

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -93,11 +93,11 @@ mod tests {
     use super::*;
     use crate::{
         error::{ignore, DefaultErrorHandler},
-        event::Event,
+        event::BroadcastEvent,
         observer::On,
     };
 
-    #[derive(Event)]
+    #[derive(BroadcastEvent)]
     struct TriggerEvent;
 
     #[test]

--- a/crates/bevy_ecs/src/observer/system_param.rs
+++ b/crates/bevy_ecs/src/observer/system_param.rs
@@ -110,15 +110,19 @@ impl<'w, E: EntityEvent, B: Bundle> On<'w, E, B> {
     ///
     /// Note that if event propagation is enabled, this may not be the same as the original target of the event,
     /// which can be accessed via [`On::original_target`].
+    ///
+    /// If the event is also a [`BroadcastEvent`] sent with [`trigger`](World::trigger), this will return [`Entity::PLACEHOLDER`].
     pub fn target(&self) -> Entity {
-        self.trigger.current_target.unwrap()
+        self.trigger.current_target.unwrap_or(Entity::PLACEHOLDER)
     }
 
     /// Returns the original [`Entity`] that the [`EntityEvent`] was targeted at when it was first triggered.
     ///
     /// If event propagation is not enabled, this will always return the same value as [`On::target`].
+    ///
+    /// If the event is also a [`BroadcastEvent`] sent with [`trigger`](World::trigger), this will return [`Entity::PLACEHOLDER`].
     pub fn original_target(&self) -> Entity {
-        self.trigger.original_target.unwrap()
+        self.trigger.original_target.unwrap_or(Entity::PLACEHOLDER)
     }
 
     /// Enables or disables event propagation, allowing the same event to trigger observers on a chain of different entities.
@@ -181,11 +185,13 @@ pub struct ObserverTrigger {
     pub event_key: EventKey,
     /// The [`ComponentId`]s the trigger targeted.
     pub components: SmallVec<[ComponentId; 2]>,
-    /// For [`EntityEvent`]s this is the entity that the event targeted. Always `None` for [`BroadcastEvent`].
+    /// For [`EntityEvent`]s used with `trigger_targets` this is the entity that the event targeted.
+    /// Can only be `None` for [`BroadcastEvent`]s used with `trigger`.
     ///
     /// Note that if event propagation is enabled, this may not be the same as [`ObserverTrigger::original_target`].
     pub current_target: Option<Entity>,
-    /// For [`EntityEvent`]s this is the entity that the event was originally targeted at. Always `None` for [`BroadcastEvent`].
+    /// For [`EntityEvent`]s used with `trigger_targets` this is the entity that the event was originally targeted at.
+    /// Can only be `None` for [`BroadcastEvent`]s used with `trigger`.
     ///
     /// If event propagation is enabled, this will be the first entity that the event was targeted at,
     /// even if the event was propagated to other entities.

--- a/crates/bevy_ecs/src/observer/system_param.rs
+++ b/crates/bevy_ecs/src/observer/system_param.rs
@@ -106,23 +106,19 @@ impl<'w, E, B: Bundle> On<'w, E, B> {
 }
 
 impl<'w, E: EntityEvent, B: Bundle> On<'w, E, B> {
-    /// Returns the [`Entity`] that was targeted by the `event` that triggered this observer.
+    /// Returns the [`Entity`] that was targeted by the [`EntityEvent`] that triggered this observer.
     ///
     /// Note that if event propagation is enabled, this may not be the same as the original target of the event,
     /// which can be accessed via [`On::original_target`].
-    ///
-    /// If the event was not targeted at a specific entity, this will return [`Entity::PLACEHOLDER`].
     pub fn target(&self) -> Entity {
-        self.trigger.current_target.unwrap_or(Entity::PLACEHOLDER)
+        self.trigger.current_target.unwrap()
     }
 
-    /// Returns the original [`Entity`] that the `event` was targeted at when it was first triggered.
+    /// Returns the original [`Entity`] that the [`EntityEvent`] was targeted at when it was first triggered.
     ///
     /// If event propagation is not enabled, this will always return the same value as [`On::target`].
-    ///
-    /// If the event was not targeted at a specific entity, this will return [`Entity::PLACEHOLDER`].
     pub fn original_target(&self) -> Entity {
-        self.trigger.original_target.unwrap_or(Entity::PLACEHOLDER)
+        self.trigger.original_target.unwrap()
     }
 
     /// Enables or disables event propagation, allowing the same event to trigger observers on a chain of different entities.
@@ -185,11 +181,11 @@ pub struct ObserverTrigger {
     pub event_key: EventKey,
     /// The [`ComponentId`]s the trigger targeted.
     pub components: SmallVec<[ComponentId; 2]>,
-    /// The entity that the entity-event targeted, if any.
+    /// For [`EntityEvent`]s this is the entity that the event targeted. Always `None` for [`BroadcastEvent`].
     ///
     /// Note that if event propagation is enabled, this may not be the same as [`ObserverTrigger::original_target`].
     pub current_target: Option<Entity>,
-    /// The entity that the entity-event was originally targeted at, if any.
+    /// For [`EntityEvent`]s this is the entity that the event was originally targeted at. Always `None` for [`BroadcastEvent`].
     ///
     /// If event propagation is enabled, this will be the first entity that the event was targeted at,
     /// even if the event was propagated to other entities.

--- a/crates/bevy_ecs/src/system/commands/command.rs
+++ b/crates/bevy_ecs/src/system/commands/command.rs
@@ -9,7 +9,7 @@ use crate::{
     change_detection::MaybeLocation,
     entity::Entity,
     error::Result,
-    event::{BufferedEvent, EntityEvent, Event, Events},
+    event::{BroadcastEvent, BufferedEvent, EntityEvent, Events},
     observer::TriggerTargets,
     resource::Resource,
     schedule::ScheduleLabel,
@@ -208,9 +208,9 @@ pub fn run_schedule(label: impl ScheduleLabel) -> impl Command<Result> {
     }
 }
 
-/// A [`Command`] that sends a global [`Event`] without any targets.
+/// A [`Command`] that sends a [`BroadcastEvent`].
 #[track_caller]
-pub fn trigger(event: impl Event) -> impl Command {
+pub fn trigger(event: impl BroadcastEvent) -> impl Command {
     let caller = MaybeLocation::caller();
     move |world: &mut World| {
         world.trigger_with_caller(event, caller);

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     component::{Component, ComponentId, Mutable},
     entity::{Entities, Entity, EntityClonerBuilder, EntityDoesNotExistError, OptIn, OptOut},
     error::{warn, BevyError, CommandWithEntity, ErrorContext, HandleError},
-    event::{BufferedEvent, EntityEvent, Event},
+    event::{BroadcastEvent, BufferedEvent, EntityEvent, Event},
     observer::{Observer, TriggerTargets},
     resource::Resource,
     schedule::ScheduleLabel,
@@ -1083,11 +1083,11 @@ impl<'w, 's> Commands<'w, 's> {
         self.queue(command::run_system_cached_with(system, input).handle_error_with(warn));
     }
 
-    /// Sends a global [`Event`] without any targets.
+    /// Sends a [`BroadcastEvent`].
     ///
-    /// This will run any [`Observer`] of the given [`Event`] that isn't scoped to specific targets.
+    /// This will run any [`Observer`] of the given [`BroadcastEvent`] that isn't scoped to specific targets.
     #[track_caller]
-    pub fn trigger(&mut self, event: impl Event) {
+    pub fn trigger(&mut self, event: impl BroadcastEvent) {
         self.queue(command::trigger(event));
     }
 

--- a/crates/bevy_ecs/src/system/observer_system.rs
+++ b/crates/bevy_ecs/src/system/observer_system.rs
@@ -53,13 +53,13 @@ where
 #[cfg(test)]
 mod tests {
     use crate::{
-        event::Event,
+        event::BroadcastEvent,
         observer::On,
         system::{In, IntoSystem},
         world::World,
     };
 
-    #[derive(Event)]
+    #[derive(BroadcastEvent)]
     struct TriggerEvent;
 
     #[test]

--- a/crates/bevy_ecs/src/system/system_registry.rs
+++ b/crates/bevy_ecs/src/system/system_registry.rs
@@ -526,6 +526,7 @@ impl<I: SystemInput, O> core::fmt::Debug for RegisteredSystemError<I, O> {
 mod tests {
     use core::cell::Cell;
 
+    use bevy_ecs_macros::BroadcastEvent;
     use bevy_utils::default;
 
     use crate::{prelude::*, system::SystemId};
@@ -898,7 +899,7 @@ mod tests {
 
     #[test]
     fn system_with_input_mut() {
-        #[derive(Event)]
+        #[derive(BroadcastEvent)]
         struct MyEvent {
             cancelled: bool,
         }

--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -7,7 +7,7 @@ use crate::{
     change_detection::{MaybeLocation, MutUntyped},
     component::{ComponentId, Mutable},
     entity::Entity,
-    event::{BufferedEvent, EntityEvent, Event, EventId, EventKey, Events, WriteBatchIds},
+    event::{BroadcastEvent, BufferedEvent, EntityEvent, EventId, EventKey, Events, WriteBatchIds},
     lifecycle::{HookContext, INSERT, REPLACE},
     observer::{Observers, TriggerTargets},
     prelude::{Component, QueryState},
@@ -860,12 +860,12 @@ impl<'w> DeferredWorld<'w> {
         }
     }
 
-    /// Sends a global [`Event`] without any targets.
+    /// Sends a [`BroadcastEvent`].
     ///
-    /// This will run any [`Observer`] of the given [`Event`] that isn't scoped to specific targets.
+    /// This will run any [`Observer`] of the given [`BroadcastEvent`] that isn't scoped to specific targets.
     ///
     /// [`Observer`]: crate::observer::Observer
-    pub fn trigger(&mut self, trigger: impl Event) {
+    pub fn trigger(&mut self, trigger: impl BroadcastEvent) {
         self.commands().trigger(trigger);
     }
 

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -2,7 +2,7 @@ use crate::{DynamicScene, Scene};
 use bevy_asset::{AssetEvent, AssetId, Assets, Handle};
 use bevy_ecs::{
     entity::{Entity, EntityHashMap},
-    event::{EntityEvent, EventCursor, Events},
+    event::{BroadcastEvent, EntityEvent, EventCursor, Events},
     hierarchy::ChildOf,
     reflect::AppTypeRegistry,
     resource::Resource,
@@ -33,6 +33,8 @@ pub struct SceneInstanceReady {
     /// Instance which has been spawned.
     pub instance_id: InstanceId,
 }
+
+impl BroadcastEvent for SceneInstanceReady {}
 
 /// Information about a scene instance.
 #[derive(Debug)]
@@ -421,8 +423,7 @@ impl SceneSpawner {
                     .trigger_targets(SceneInstanceReady { instance_id }, parent);
             } else {
                 // Defer via commands otherwise SceneSpawner is not available in the observer.
-                // TODO: Thinkies
-                // world.commands().trigger(SceneInstanceReady { instance_id });
+                world.commands().trigger(SceneInstanceReady { instance_id });
             }
         }
     }

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -22,11 +22,13 @@ use bevy_ecs::{
     system::{Commands, Query},
 };
 
-/// Triggered on a scene's parent entity when [`crate::SceneInstance`] becomes ready to use.
+/// This [`Event`] is triggered when the [`SceneInstance`] becomes ready to use.
+/// If the scene has a parent the event will be triggered on that entity, otherwise the event has no target.
 ///
 /// See also [`On`], [`SceneSpawner::instance_is_ready`].
 ///
 /// [`On`]: bevy_ecs::observer::On
+/// [`Event`]: bevy_ecs::event::Event
 #[derive(Clone, Copy, Debug, Eq, PartialEq, EntityEvent, Reflect)]
 #[reflect(Debug, PartialEq, Clone)]
 pub struct SceneInstanceReady {

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -421,7 +421,8 @@ impl SceneSpawner {
                     .trigger_targets(SceneInstanceReady { instance_id }, parent);
             } else {
                 // Defer via commands otherwise SceneSpawner is not available in the observer.
-                world.commands().trigger(SceneInstanceReady { instance_id });
+                // TODO: Thinkies
+                // world.commands().trigger(SceneInstanceReady { instance_id });
             }
         }
     }

--- a/examples/ecs/observers.rs
+++ b/examples/ecs/observers.rs
@@ -60,7 +60,7 @@ impl Mine {
     }
 }
 
-#[derive(Event)]
+#[derive(BroadcastEvent)]
 struct ExplodeMines {
     pos: Vec2,
     radius: f32,

--- a/examples/usage/context_menu.rs
+++ b/examples/usage/context_menu.rs
@@ -8,13 +8,13 @@ use bevy::{
 use std::fmt::Debug;
 
 /// event opening a new context menu at position `pos`
-#[derive(Event)]
+#[derive(BroadcastEvent)]
 struct OpenContextMenu {
     pos: Vec2,
 }
 
 /// event will be sent to close currently open context menus
-#[derive(Event)]
+#[derive(BroadcastEvent)]
 struct CloseContextMenus;
 
 /// marker component identifying root of a context menu

--- a/release-content/release-notes/event_split.md
+++ b/release-content/release-notes/event_split.md
@@ -24,6 +24,7 @@ All three patterns are fundamentally different in both the interface and usage. 
 APIs are typically built to support only one of them.
 
 This has led to a lot of confusion and frustration for users. Common footguns include:
+
 - Using a "buffered event" with an observer, or an observer event with `EventReader`, leaving the user wondering why the event is not being detected.
 - `On`(formerly `Trigger`) has a `target` getter which would cause confusion for events only mean to be used with `trigger` where it returns `Entity::PLACEHOLDER`. 
 

--- a/release-content/release-notes/event_split.md
+++ b/release-content/release-notes/event_split.md
@@ -26,13 +26,13 @@ APIs are typically built to support only one of them.
 This has led to a lot of confusion and frustration for users. Common footguns include:
 
 - Using a "buffered event" with an observer, or an observer event with `EventReader`, leaving the user wondering why the event is not being detected.
-- `On`(formerly `Trigger`) has a `target` getter which would cause confusion for events only mean to be used with `trigger` where it returns `Entity::PLACEHOLDER`. 
+- `On`(formerly `Trigger`) has a `target` getter which would cause confusion for events only meant to be used with `trigger` where it returns `Entity::PLACEHOLDER`.
 
 **Bevy 0.17** aims to solve this ambiguity by splitting the different kinds of events into multiple traits:
 
 - `Event`: A supertrait for observer events.
-    - `BroadcastEvent`: An observer event without an entity target.
-    - `EntityEvent`: An observer event that targets specific entities and can propagate the event from one entity to another across relationships.
+  - `BroadcastEvent`: An observer event without an entity target.
+  - `EntityEvent`: An observer event that targets specific entities and can propagate the event from one entity to another across relationships.
 - `BufferedEvent`: An event used with `EventReader` and `EventWriter` for pull-based event handling.
 
 ## Using Events

--- a/release-content/release-notes/event_split.md
+++ b/release-content/release-notes/event_split.md
@@ -25,7 +25,7 @@ APIs are typically built to support only one of them.
 
 This has led to a lot of confusion and frustration for users. Common footguns include:
 - Using a "buffered event" with an observer, or an observer event with `EventReader`, leaving the user wondering why the event is not being detected.
-- `On`(formerly `Trigger`) has a `target` getter which would return `Entity::PLACEHOLDER` for events sent via `trigger` rather than `trigger_targets`.
+- `On`(formerly `Trigger`) has a `target` getter which would cause confusion for events only mean to be used with `trigger` where it returns `Entity::PLACEHOLDER`. 
 
 **Bevy 0.17** aims to solve this ambiguity by splitting the different kinds of events into multiple traits:
 
@@ -33,8 +33,6 @@ This has led to a lot of confusion and frustration for users. Common footguns in
     - `BroadcastEvent`: An observer event without an entity target.
     - `EntityEvent`: An observer event that targets specific entities and can propagate the event from one entity to another across relationships.
 - `BufferedEvent`: An event used with `EventReader` and `EventWriter` for pull-based event handling.
-
-Note: To fully prevent the footgun of `On::target` returning `Entity::PLACEHOLDER` the `BroadcastEvent` and `EntityEvent` traits were made mutually exclusive.
 
 ## Using Events
 

--- a/release-content/release-notes/event_split.md
+++ b/release-content/release-notes/event_split.md
@@ -1,7 +1,7 @@
 ---
 title: Event Split
 authors: ["@Jondolf", "@tim-blackbird"]
-pull_requests: [19647, 20101, 20104]
+pull_requests: [19647, 20101, 20104, 20151]
 ---
 
 In past releases, all event types were defined by simply deriving the `Event` trait:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 //! [![Bevy Logo](https://bevy.org/assets/bevy_logo_docs.svg)](https://bevy.org)
 //!
 //! Bevy is an open-source modular game engine built in Rust, with a focus on developer productivity

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-
 //! [![Bevy Logo](https://bevy.org/assets/bevy_logo_docs.svg)](https://bevy.org)
 //!
 //! Bevy is an open-source modular game engine built in Rust, with a focus on developer productivity


### PR DESCRIPTION
# Objective

- Split the two types of observer usages - `trigger` and `trigger_targets` - by trait

## Solution

Check out the diff of the [release notes](https://github.com/bevyengine/bevy/pull/20151/files#diff-089b5c94d0934fc5ccc03805e1cab6b94b87d314f3f767e27b326129606f09d0).

### Notes
- It's not possible to derive `BroadcastEvent` and `EntityEvent` together, one must be implemented manually if you want both. This is probably okay as having both implemented is somewhat undesirable.
- Planned follow-up to this PR is to rename `Event` to `ObserverEvent`.

