### PR TITLE
Added finish method for timer

### DIFF
--- a/crates/bevy_time/src/timer.rs
+++ b/crates/bevy_time/src/timer.rs
@@ -220,7 +220,7 @@ impl Timer {
         self.duration = duration;
     }
 
-    /// Finishes the timer
+    /// Finishes the timer.
     ///
     /// # Examples
     /// ```

--- a/crates/bevy_time/src/timer.rs
+++ b/crates/bevy_time/src/timer.rs
@@ -227,7 +227,7 @@ impl Timer {
     /// # use bevy_time::*;
     /// let mut timer = Timer::from_seconds(1.5, TimerMode::Once);
     /// timer.finish();
-    /// assert_eq!(timer.remaining(), Duration::from_secs(0));
+    /// assert!(timer.finished());
     /// ```
     #[inline]
     pub fn finish(&mut self) {

--- a/crates/bevy_time/src/timer.rs
+++ b/crates/bevy_time/src/timer.rs
@@ -220,6 +220,21 @@ impl Timer {
         self.duration = duration;
     }
 
+    /// Finishes the timer
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_time::*;
+    /// let mut timer = Timer::from_seconds(1.5, TimerMode::Once);
+    /// timer.finish();
+    /// assert_eq!(timer.remaining(), Duration::from_secs(0));
+    
+    #[inline]
+    pub fn finish(&mut self) {
+        let remaining = self.remaining();
+        self.tick(remaining);
+    }
+
     /// Returns the mode of the timer.
     ///
     /// # Examples

--- a/crates/bevy_time/src/timer.rs
+++ b/crates/bevy_time/src/timer.rs
@@ -228,7 +228,7 @@ impl Timer {
     /// let mut timer = Timer::from_seconds(1.5, TimerMode::Once);
     /// timer.finish();
     /// assert_eq!(timer.remaining(), Duration::from_secs(0));
-    
+    /// ```
     #[inline]
     pub fn finish(&mut self) {
         let remaining = self.remaining();


### PR DESCRIPTION
# Objective

- Add an easy way to finish a Timer

## Solution

- Tick the timer by the remaining time

## Testing

I have not tested, but it should work
---

## Showcase

```rust
let mut timer = Timer::from_seconds(1.5, TimerMode::Once);
timer.finish();
assert_eq!(timer.remaining(), Duration::from_secs(0))
```