### PR TITLE
Use `RenderStartup` for `CopyDeferredLightingIdPipeline`.

### DIFF
--- a/release-content/migration-guides/render_startup.md
+++ b/release-content/migration-guides/render_startup.md
@@ -31,6 +31,7 @@ The following are the (public) resources that are now initialized in `RenderStar
 - `UiTextureSlicePipeline`
 - `VolumetricFogPipeline`
 - `DeferredLightingLayout`
+- `CopyDeferredLightingIdPipeline`
 - `RenderLightmaps`
 - `PrepassPipeline`
 - `PrepassViewBindGroup`


### PR DESCRIPTION
# Objective

- Progress towards #19887.
- This migration actually caught a segfault on Linux + Vulkan + llvmpipe software rendering driver + (maybe) `xvfb-run`
    - It seems the reason for this is that we are concurrently terminating the program (which trigger's LLVMs `atexit` handlers) while we are also compiling pipelines in parallel. It seems LLVM code is not quite multithread safe in this situation.
    - Thanks to @kristoff3r for figuring out this segfault!
    - I still have no idea why this PR triggers it and not others.

## Solution

Most of this is the same as all the other `RenderStartup` migrations.
- Convert FromWorld impls to RenderStartup systems.

In addition, I had to 1) enable synchronous pipeline compilation, 2) disable pipelined rendering in the `ambiguity_detection` test. This ensures that 1) the render thread just blocks on pipeline compilation rather than letting it run in another thread, 2) we don't leave `App::update` until the render thread finishes. So therefore, there won't be any pipeline compilation happening by the time the test ends.

## Testing

- I ran the run-examples-linux-vulkan Github action many, many times and segfaults were consistent until this PR! Now they don't seem to happen anymore.
