### PR TITLE
Adjust benches to be more robust

### DIFF
--- a/benches/benches/bevy_ecs/world/world_get.rs
+++ b/benches/benches/bevy_ecs/world/world_get.rs
@@ -1,10 +1,9 @@
 use core::hint::black_box;
-use nonmax::NonMaxU32;
 
 use bevy_ecs::{
     bundle::{Bundle, NoBundleEffect},
     component::Component,
-    entity::{Entity, EntityRow},
+    entity::Entity,
     system::{Query, SystemState},
     world::World,
 };
@@ -31,16 +30,24 @@ fn deterministic_rand() -> ChaCha8Rng {
     ChaCha8Rng::seed_from_u64(42)
 }
 
-fn setup<T: Component + Default>(entity_count: u32) -> World {
+fn setup<T: Component + Default>(entity_count: u32) -> (World, Vec<Entity>) {
     let mut world = World::default();
-    world.spawn_batch((0..entity_count).map(|_| T::default()));
-    black_box(world)
+    let entities: Vec<Entity> = world
+        .spawn_batch((0..entity_count).map(|_| T::default()))
+        .into_iter()
+        .collect();
+    black_box((world, entities))
 }
 
-fn setup_wide<T: Bundle<Effect: NoBundleEffect> + Default>(entity_count: u32) -> World {
+fn setup_wide<T: Bundle<Effect: NoBundleEffect> + Default>(
+    entity_count: u32,
+) -> (World, Vec<Entity>) {
     let mut world = World::default();
-    world.spawn_batch((0..entity_count).map(|_| T::default()));
-    black_box(world)
+    let entities: Vec<Entity> = world
+        .spawn_batch((0..entity_count).map(|_| T::default()))
+        .into_iter()
+        .collect();
+    black_box((world, entities))
 }
 
 pub fn world_entity(criterion: &mut Criterion) {
@@ -50,14 +57,11 @@ pub fn world_entity(criterion: &mut Criterion) {
 
     for entity_count in RANGE.map(|i| i * 10_000) {
         group.bench_function(format!("{entity_count}_entities"), |bencher| {
-            let world = setup::<Table>(entity_count);
+            let (world, entities) = setup::<Table>(entity_count);
 
             bencher.iter(|| {
-                for i in 0..entity_count {
-                    let entity =
-                        // SAFETY: Range is exclusive.
-                        Entity::from_raw(EntityRow::new(unsafe { NonMaxU32::new_unchecked(i) }));
-                    black_box(world.entity(entity));
+                for entity in &entities {
+                    black_box(world.entity(*entity));
                 }
             });
         });
@@ -73,26 +77,20 @@ pub fn world_get(criterion: &mut Criterion) {
 
     for entity_count in RANGE.map(|i| i * 10_000) {
         group.bench_function(format!("{entity_count}_entities_table"), |bencher| {
-            let world = setup::<Table>(entity_count);
+            let (world, entities) = setup::<Table>(entity_count);
 
             bencher.iter(|| {
-                for i in 0..entity_count {
-                    let entity =
-                        // SAFETY: Range is exclusive.
-                        Entity::from_raw(EntityRow::new(unsafe { NonMaxU32::new_unchecked(i) }));
-                    assert!(world.get::<Table>(entity).is_some());
+                for entity in &entities {
+                    assert!(world.get::<Table>(*entity).is_some());
                 }
             });
         });
         group.bench_function(format!("{entity_count}_entities_sparse"), |bencher| {
-            let world = setup::<Sparse>(entity_count);
+            let (world, entities) = setup::<Sparse>(entity_count);
 
             bencher.iter(|| {
-                for i in 0..entity_count {
-                    let entity =
-                        // SAFETY: Range is exclusive.
-                        Entity::from_raw(EntityRow::new(unsafe { NonMaxU32::new_unchecked(i) }));
-                    assert!(world.get::<Sparse>(entity).is_some());
+                for entity in &entities {
+                    assert!(world.get::<Sparse>(*entity).is_some());
                 }
             });
         });
@@ -108,20 +106,17 @@ pub fn world_query_get(criterion: &mut Criterion) {
 
     for entity_count in RANGE.map(|i| i * 10_000) {
         group.bench_function(format!("{entity_count}_entities_table"), |bencher| {
-            let mut world = setup::<Table>(entity_count);
+            let (mut world, entities) = setup::<Table>(entity_count);
             let mut query = world.query::<&Table>();
 
             bencher.iter(|| {
-                for i in 0..entity_count {
-                    let entity =
-                        // SAFETY: Range is exclusive.
-                        Entity::from_raw(EntityRow::new(unsafe { NonMaxU32::new_unchecked(i) }));
-                    assert!(query.get(&world, entity).is_ok());
+                for entity in &entities {
+                    assert!(query.get(&world, *entity).is_ok());
                 }
             });
         });
         group.bench_function(format!("{entity_count}_entities_table_wide"), |bencher| {
-            let mut world = setup_wide::<(
+            let (mut world, entities) = setup_wide::<(
                 WideTable<0>,
                 WideTable<1>,
                 WideTable<2>,
@@ -139,29 +134,23 @@ pub fn world_query_get(criterion: &mut Criterion) {
             )>();
 
             bencher.iter(|| {
-                for i in 0..entity_count {
-                    let entity =
-                        // SAFETY: Range is exclusive.
-                        Entity::from_raw(EntityRow::new(unsafe { NonMaxU32::new_unchecked(i) }));
-                    assert!(query.get(&world, entity).is_ok());
+                for entity in &entities {
+                    assert!(query.get(&world, *entity).is_ok());
                 }
             });
         });
         group.bench_function(format!("{entity_count}_entities_sparse"), |bencher| {
-            let mut world = setup::<Sparse>(entity_count);
+            let (mut world, entities) = setup::<Sparse>(entity_count);
             let mut query = world.query::<&Sparse>();
 
             bencher.iter(|| {
-                for i in 0..entity_count {
-                    let entity =
-                        // SAFETY: Range is exclusive.
-                        Entity::from_raw(EntityRow::new(unsafe { NonMaxU32::new_unchecked(i) }));
-                    assert!(query.get(&world, entity).is_ok());
+                for entity in &entities {
+                    assert!(query.get(&world, *entity).is_ok());
                 }
             });
         });
         group.bench_function(format!("{entity_count}_entities_sparse_wide"), |bencher| {
-            let mut world = setup_wide::<(
+            let (mut world, entities) = setup_wide::<(
                 WideSparse<0>,
                 WideSparse<1>,
                 WideSparse<2>,
@@ -179,11 +168,8 @@ pub fn world_query_get(criterion: &mut Criterion) {
             )>();
 
             bencher.iter(|| {
-                for i in 0..entity_count {
-                    // SAFETY: Range is exclusive.
-                    let entity =
-                        Entity::from_raw(EntityRow::new(unsafe { NonMaxU32::new_unchecked(i) }));
-                    assert!(query.get(&world, entity).is_ok());
+                for entity in &entities {
+                    assert!(query.get(&world, *entity).is_ok());
                 }
             });
         });
@@ -199,7 +185,7 @@ pub fn world_query_iter(criterion: &mut Criterion) {
 
     for entity_count in RANGE.map(|i| i * 10_000) {
         group.bench_function(format!("{entity_count}_entities_table"), |bencher| {
-            let mut world = setup::<Table>(entity_count);
+            let (mut world, _) = setup::<Table>(entity_count);
             let mut query = world.query::<&Table>();
 
             bencher.iter(|| {
@@ -213,7 +199,7 @@ pub fn world_query_iter(criterion: &mut Criterion) {
             });
         });
         group.bench_function(format!("{entity_count}_entities_sparse"), |bencher| {
-            let mut world = setup::<Sparse>(entity_count);
+            let (mut world, _) = setup::<Sparse>(entity_count);
             let mut query = world.query::<&Sparse>();
 
             bencher.iter(|| {
@@ -238,7 +224,7 @@ pub fn world_query_for_each(criterion: &mut Criterion) {
 
     for entity_count in RANGE.map(|i| i * 10_000) {
         group.bench_function(format!("{entity_count}_entities_table"), |bencher| {
-            let mut world = setup::<Table>(entity_count);
+            let (mut world, _) = setup::<Table>(entity_count);
             let mut query = world.query::<&Table>();
 
             bencher.iter(|| {
@@ -252,7 +238,7 @@ pub fn world_query_for_each(criterion: &mut Criterion) {
             });
         });
         group.bench_function(format!("{entity_count}_entities_sparse"), |bencher| {
-            let mut world = setup::<Sparse>(entity_count);
+            let (mut world, _) = setup::<Sparse>(entity_count);
             let mut query = world.query::<&Sparse>();
 
             bencher.iter(|| {


### PR DESCRIPTION
# Objective

Currently, benchmarks access the world's entities in a very unsafe way, which doesn't hold up if we add more internal entities.

## Solution

Have the setups return a `Vec<Entity>` we can iterate over.

## Testing

Not needed.
