### PR TITLE
Use `RenderStartup` for meshlets.

### DIFF
--- a/crates/bevy_pbr/src/meshlet/meshlet_mesh_manager.rs
+++ b/crates/bevy_pbr/src/meshlet/meshlet_mesh_manager.rs
@@ -5,8 +5,7 @@ use alloc::sync::Arc;
 use bevy_asset::{AssetId, Assets};
 use bevy_ecs::{
     resource::Resource,
-    system::{Res, ResMut},
-    world::{FromWorld, World},
+    system::{Commands, Res, ResMut},
 };
 use bevy_math::Vec2;
 use bevy_platform::collections::HashMap;
@@ -30,20 +29,17 @@ pub struct MeshletMeshManager {
         HashMap<AssetId<MeshletMesh>, ([Range<BufferAddress>; 7], MeshletAabb, u32)>,
 }
 
-impl FromWorld for MeshletMeshManager {
-    fn from_world(world: &mut World) -> Self {
-        let render_device = world.resource::<RenderDevice>();
-        Self {
-            vertex_positions: PersistentGpuBuffer::new("meshlet_vertex_positions", render_device),
-            vertex_normals: PersistentGpuBuffer::new("meshlet_vertex_normals", render_device),
-            vertex_uvs: PersistentGpuBuffer::new("meshlet_vertex_uvs", render_device),
-            indices: PersistentGpuBuffer::new("meshlet_indices", render_device),
-            bvh_nodes: PersistentGpuBuffer::new("meshlet_bvh_nodes", render_device),
-            meshlets: PersistentGpuBuffer::new("meshlets", render_device),
-            meshlet_cull_data: PersistentGpuBuffer::new("meshlet_cull_data", render_device),
-            meshlet_mesh_slices: HashMap::default(),
-        }
-    }
+pub fn init_meshlet_mesh_manager(mut commands: Commands, render_device: Res<RenderDevice>) {
+    commands.insert_resource(MeshletMeshManager {
+        vertex_positions: PersistentGpuBuffer::new("meshlet_vertex_positions", &render_device),
+        vertex_normals: PersistentGpuBuffer::new("meshlet_vertex_normals", &render_device),
+        vertex_uvs: PersistentGpuBuffer::new("meshlet_vertex_uvs", &render_device),
+        indices: PersistentGpuBuffer::new("meshlet_indices", &render_device),
+        bvh_nodes: PersistentGpuBuffer::new("meshlet_bvh_nodes", &render_device),
+        meshlets: PersistentGpuBuffer::new("meshlets", &render_device),
+        meshlet_cull_data: PersistentGpuBuffer::new("meshlet_cull_data", &render_device),
+        meshlet_mesh_slices: HashMap::default(),
+    });
 }
 
 impl MeshletMeshManager {

--- a/crates/bevy_pbr/src/meshlet/mod.rs
+++ b/crates/bevy_pbr/src/meshlet/mod.rs
@@ -49,14 +49,17 @@ use self::{
     material_shade_nodes::{
         MeshletDeferredGBufferPrepassNode, MeshletMainOpaquePass3dNode, MeshletPrepassNode,
     },
-    meshlet_mesh_manager::{perform_pending_meshlet_mesh_writes, MeshletMeshManager},
+    meshlet_mesh_manager::perform_pending_meshlet_mesh_writes,
     pipelines::*,
     resource_manager::{
         prepare_meshlet_per_frame_resources, prepare_meshlet_view_bind_groups, ResourceManager,
     },
     visibility_buffer_raster_node::MeshletVisibilityBufferRasterPassNode,
 };
-use crate::{graph::NodePbr, PreviousGlobalTransform};
+use crate::{
+    graph::NodePbr, meshlet::meshlet_mesh_manager::init_meshlet_mesh_manager,
+    PreviousGlobalTransform,
+};
 use bevy_app::{App, Plugin};
 use bevy_asset::{embedded_asset, AssetApp, AssetId, Handle};
 use bevy_core_pipeline::{
@@ -70,7 +73,7 @@ use bevy_ecs::{
     query::Has,
     reflect::ReflectComponent,
     schedule::IntoScheduleConfigs,
-    system::{Commands, Query},
+    system::{Commands, Query, Res},
 };
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{
@@ -79,7 +82,7 @@ use bevy_render::{
     renderer::RenderDevice,
     settings::WgpuFeatures,
     view::{self, prepare_view_targets, Msaa, Visibility, VisibilityClass},
-    ExtractSchedule, Render, RenderApp, RenderSystems,
+    ExtractSchedule, Render, RenderApp, RenderStartup, RenderSystems,
 };
 use bevy_transform::components::Transform;
 use derive_more::From;
@@ -163,22 +166,18 @@ impl Plugin for MeshletPlugin {
 
         app.init_asset::<MeshletMesh>()
             .register_asset_loader(MeshletMeshLoader);
-    }
 
-    fn finish(&self, app: &mut App) {
         let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
             return;
         };
 
-        let render_device = render_app.world().resource::<RenderDevice>().clone();
-        let features = render_device.features();
-        if !features.contains(Self::required_wgpu_features()) {
-            error!(
-                "MeshletPlugin can't be used. GPU lacks support for required features: {:?}.",
-                Self::required_wgpu_features().difference(features)
-            );
-            std::process::exit(1);
-        }
+        // Create a variable here so we can move-capture it.
+        let cluster_buffer_slots = self.cluster_buffer_slots;
+        let init_resource_manager_system =
+            move |mut commands: Commands, render_device: Res<RenderDevice>| {
+                commands
+                    .insert_resource(ResourceManager::new(cluster_buffer_slots, &render_device));
+            };
 
         render_app
             .add_render_graph_node::<MeshletVisibilityBufferRasterPassNode>(
@@ -214,13 +213,18 @@ impl Plugin for MeshletPlugin {
                     Node3d::EndMainPass,
                 ),
             )
-            .init_resource::<MeshletMeshManager>()
             .insert_resource(InstanceManager::new())
-            .insert_resource(ResourceManager::new(
-                self.cluster_buffer_slots,
-                &render_device,
-            ))
-            .init_resource::<MeshletPipelines>()
+            .add_systems(
+                RenderStartup,
+                (
+                    check_meshlet_features,
+                    (
+                        (init_resource_manager_system, init_meshlet_pipelines).chain(),
+                        init_meshlet_mesh_manager,
+                    ),
+                )
+                    .chain(),
+            )
             .add_systems(ExtractSchedule, extract_meshlet_mesh_entities)
             .add_systems(
                 Render,
@@ -237,6 +241,17 @@ impl Plugin for MeshletPlugin {
                         .before(queue_material_meshlet_meshes),
                 ),
             );
+    }
+}
+
+fn check_meshlet_features(render_device: Res<RenderDevice>) {
+    let features = render_device.features();
+    if !features.contains(MeshletPlugin::required_wgpu_features()) {
+        error!(
+            "MeshletPlugin can't be used. GPU lacks support for required features: {:?}.",
+            MeshletPlugin::required_wgpu_features().difference(features)
+        );
+        std::process::exit(1);
     }
 }
 

--- a/crates/bevy_pbr/src/meshlet/pipelines.rs
+++ b/crates/bevy_pbr/src/meshlet/pipelines.rs
@@ -1,12 +1,13 @@
 use super::resource_manager::ResourceManager;
-use bevy_asset::{load_embedded_asset, Handle};
+use bevy_asset::{load_embedded_asset, AssetServer, Handle};
 use bevy_core_pipeline::{
     core_3d::CORE_3D_DEPTH_FORMAT, experimental::mip_generation::DownsampleDepthShader,
     FullscreenShader,
 };
 use bevy_ecs::{
     resource::Resource,
-    world::{FromWorld, World},
+    system::{Commands, Res},
+    world::World,
 };
 use bevy_render::render_resource::*;
 use bevy_utils::default;
@@ -38,482 +39,480 @@ pub struct MeshletPipelines {
     pub(crate) meshlet_mesh_material: Handle<Shader>,
 }
 
-impl FromWorld for MeshletPipelines {
-    fn from_world(world: &mut World) -> Self {
-        let resource_manager = world.resource::<ResourceManager>();
-        let clear_visibility_buffer_bind_group_layout = resource_manager
-            .clear_visibility_buffer_bind_group_layout
-            .clone();
-        let clear_visibility_buffer_shadow_view_bind_group_layout = resource_manager
-            .clear_visibility_buffer_shadow_view_bind_group_layout
-            .clone();
-        let first_instance_cull_bind_group_layout = resource_manager
-            .first_instance_cull_bind_group_layout
-            .clone();
-        let second_instance_cull_bind_group_layout = resource_manager
-            .second_instance_cull_bind_group_layout
-            .clone();
-        let first_bvh_cull_bind_group_layout =
-            resource_manager.first_bvh_cull_bind_group_layout.clone();
-        let second_bvh_cull_bind_group_layout =
-            resource_manager.second_bvh_cull_bind_group_layout.clone();
-        let first_meshlet_cull_bind_group_layout = resource_manager
-            .first_meshlet_cull_bind_group_layout
-            .clone();
-        let second_meshlet_cull_bind_group_layout = resource_manager
-            .second_meshlet_cull_bind_group_layout
-            .clone();
-        let downsample_depth_layout = resource_manager.downsample_depth_bind_group_layout.clone();
-        let downsample_depth_shadow_view_layout = resource_manager
-            .downsample_depth_shadow_view_bind_group_layout
-            .clone();
-        let visibility_buffer_raster_layout = resource_manager
-            .visibility_buffer_raster_bind_group_layout
-            .clone();
-        let visibility_buffer_raster_shadow_view_layout = resource_manager
-            .visibility_buffer_raster_shadow_view_bind_group_layout
-            .clone();
-        let resolve_depth_layout = resource_manager.resolve_depth_bind_group_layout.clone();
-        let resolve_depth_shadow_view_layout = resource_manager
-            .resolve_depth_shadow_view_bind_group_layout
-            .clone();
-        let resolve_material_depth_layout = resource_manager
-            .resolve_material_depth_bind_group_layout
-            .clone();
-        let remap_1d_to_2d_dispatch_layout = resource_manager
-            .remap_1d_to_2d_dispatch_bind_group_layout
-            .clone();
+pub fn init_meshlet_pipelines(
+    mut commands: Commands,
+    resource_manager: Res<ResourceManager>,
+    fullscreen_shader: Res<FullscreenShader>,
+    downsample_depth_shader: Res<DownsampleDepthShader>,
+    pipeline_cache: Res<PipelineCache>,
+    asset_server: Res<AssetServer>,
+) {
+    let clear_visibility_buffer_bind_group_layout = resource_manager
+        .clear_visibility_buffer_bind_group_layout
+        .clone();
+    let clear_visibility_buffer_shadow_view_bind_group_layout = resource_manager
+        .clear_visibility_buffer_shadow_view_bind_group_layout
+        .clone();
+    let first_instance_cull_bind_group_layout = resource_manager
+        .first_instance_cull_bind_group_layout
+        .clone();
+    let second_instance_cull_bind_group_layout = resource_manager
+        .second_instance_cull_bind_group_layout
+        .clone();
+    let first_bvh_cull_bind_group_layout =
+        resource_manager.first_bvh_cull_bind_group_layout.clone();
+    let second_bvh_cull_bind_group_layout =
+        resource_manager.second_bvh_cull_bind_group_layout.clone();
+    let first_meshlet_cull_bind_group_layout = resource_manager
+        .first_meshlet_cull_bind_group_layout
+        .clone();
+    let second_meshlet_cull_bind_group_layout = resource_manager
+        .second_meshlet_cull_bind_group_layout
+        .clone();
+    let downsample_depth_layout = resource_manager.downsample_depth_bind_group_layout.clone();
+    let downsample_depth_shadow_view_layout = resource_manager
+        .downsample_depth_shadow_view_bind_group_layout
+        .clone();
+    let visibility_buffer_raster_layout = resource_manager
+        .visibility_buffer_raster_bind_group_layout
+        .clone();
+    let visibility_buffer_raster_shadow_view_layout = resource_manager
+        .visibility_buffer_raster_shadow_view_bind_group_layout
+        .clone();
+    let resolve_depth_layout = resource_manager.resolve_depth_bind_group_layout.clone();
+    let resolve_depth_shadow_view_layout = resource_manager
+        .resolve_depth_shadow_view_bind_group_layout
+        .clone();
+    let resolve_material_depth_layout = resource_manager
+        .resolve_material_depth_bind_group_layout
+        .clone();
+    let remap_1d_to_2d_dispatch_layout = resource_manager
+        .remap_1d_to_2d_dispatch_bind_group_layout
+        .clone();
 
-        let downsample_depth_shader = (*world.resource::<DownsampleDepthShader>()).clone();
-        let vertex_state = world.resource::<FullscreenShader>().to_vertex_state();
-        let fill_counts_layout = resource_manager.fill_counts_bind_group_layout.clone();
+    let downsample_depth_shader = (*downsample_depth_shader).clone();
+    let vertex_state = fullscreen_shader.to_vertex_state();
+    let fill_counts_layout = resource_manager.fill_counts_bind_group_layout.clone();
 
-        let clear_visibility_buffer = load_embedded_asset!(world, "clear_visibility_buffer.wgsl");
-        let cull_instances = load_embedded_asset!(world, "cull_instances.wgsl");
-        let cull_bvh = load_embedded_asset!(world, "cull_bvh.wgsl");
-        let cull_clusters = load_embedded_asset!(world, "cull_clusters.wgsl");
-        let visibility_buffer_software_raster =
-            load_embedded_asset!(world, "visibility_buffer_software_raster.wgsl");
-        let visibility_buffer_hardware_raster =
-            load_embedded_asset!(world, "visibility_buffer_hardware_raster.wgsl");
-        let resolve_render_targets = load_embedded_asset!(world, "resolve_render_targets.wgsl");
-        let remap_1d_to_2d_dispatch = load_embedded_asset!(world, "remap_1d_to_2d_dispatch.wgsl");
-        let fill_counts = load_embedded_asset!(world, "fill_counts.wgsl");
-        let meshlet_mesh_material = load_embedded_asset!(world, "meshlet_mesh_material.wgsl");
+    let clear_visibility_buffer =
+        load_embedded_asset!(asset_server.as_ref(), "clear_visibility_buffer.wgsl");
+    let cull_instances = load_embedded_asset!(asset_server.as_ref(), "cull_instances.wgsl");
+    let cull_bvh = load_embedded_asset!(asset_server.as_ref(), "cull_bvh.wgsl");
+    let cull_clusters = load_embedded_asset!(asset_server.as_ref(), "cull_clusters.wgsl");
+    let visibility_buffer_software_raster = load_embedded_asset!(
+        asset_server.as_ref(),
+        "visibility_buffer_software_raster.wgsl"
+    );
+    let visibility_buffer_hardware_raster = load_embedded_asset!(
+        asset_server.as_ref(),
+        "visibility_buffer_hardware_raster.wgsl"
+    );
+    let resolve_render_targets =
+        load_embedded_asset!(asset_server.as_ref(), "resolve_render_targets.wgsl");
+    let remap_1d_to_2d_dispatch =
+        load_embedded_asset!(asset_server.as_ref(), "remap_1d_to_2d_dispatch.wgsl");
+    let fill_counts = load_embedded_asset!(asset_server.as_ref(), "fill_counts.wgsl");
+    let meshlet_mesh_material =
+        load_embedded_asset!(asset_server.as_ref(), "meshlet_mesh_material.wgsl");
 
-        let pipeline_cache = world.resource_mut::<PipelineCache>();
+    commands.insert_resource(MeshletPipelines {
+        clear_visibility_buffer: pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
+            label: Some("meshlet_clear_visibility_buffer_pipeline".into()),
+            layout: vec![clear_visibility_buffer_bind_group_layout],
+            push_constant_ranges: vec![PushConstantRange {
+                stages: ShaderStages::COMPUTE,
+                range: 0..8,
+            }],
+            shader: clear_visibility_buffer.clone(),
+            shader_defs: vec!["MESHLET_VISIBILITY_BUFFER_RASTER_PASS_OUTPUT".into()],
+            ..default()
+        }),
 
-        Self {
-            clear_visibility_buffer: pipeline_cache.queue_compute_pipeline(
-                ComputePipelineDescriptor {
-                    label: Some("meshlet_clear_visibility_buffer_pipeline".into()),
-                    layout: vec![clear_visibility_buffer_bind_group_layout],
-                    push_constant_ranges: vec![PushConstantRange {
-                        stages: ShaderStages::COMPUTE,
-                        range: 0..8,
-                    }],
-                    shader: clear_visibility_buffer.clone(),
-                    shader_defs: vec!["MESHLET_VISIBILITY_BUFFER_RASTER_PASS_OUTPUT".into()],
-                    ..default()
-                },
-            ),
-
-            clear_visibility_buffer_shadow_view: pipeline_cache.queue_compute_pipeline(
-                ComputePipelineDescriptor {
-                    label: Some("meshlet_clear_visibility_buffer_shadow_view_pipeline".into()),
-                    layout: vec![clear_visibility_buffer_shadow_view_bind_group_layout],
-                    push_constant_ranges: vec![PushConstantRange {
-                        stages: ShaderStages::COMPUTE,
-                        range: 0..8,
-                    }],
-                    shader: clear_visibility_buffer,
-                    ..default()
-                },
-            ),
-
-            first_instance_cull: pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
-                label: Some("meshlet_first_instance_cull_pipeline".into()),
-                layout: vec![first_instance_cull_bind_group_layout.clone()],
-                push_constant_ranges: vec![PushConstantRange {
-                    stages: ShaderStages::COMPUTE,
-                    range: 0..4,
-                }],
-                shader: cull_instances.clone(),
-                shader_defs: vec![
-                    "MESHLET_INSTANCE_CULLING_PASS".into(),
-                    "MESHLET_FIRST_CULLING_PASS".into(),
-                ],
-                ..default()
-            }),
-
-            second_instance_cull: pipeline_cache.queue_compute_pipeline(
-                ComputePipelineDescriptor {
-                    label: Some("meshlet_second_instance_cull_pipeline".into()),
-                    layout: vec![second_instance_cull_bind_group_layout.clone()],
-                    push_constant_ranges: vec![PushConstantRange {
-                        stages: ShaderStages::COMPUTE,
-                        range: 0..4,
-                    }],
-                    shader: cull_instances,
-                    shader_defs: vec![
-                        "MESHLET_INSTANCE_CULLING_PASS".into(),
-                        "MESHLET_SECOND_CULLING_PASS".into(),
-                    ],
-                    ..default()
-                },
-            ),
-
-            first_bvh_cull: pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
-                label: Some("meshlet_first_bvh_cull_pipeline".into()),
-                layout: vec![first_bvh_cull_bind_group_layout.clone()],
+        clear_visibility_buffer_shadow_view: pipeline_cache.queue_compute_pipeline(
+            ComputePipelineDescriptor {
+                label: Some("meshlet_clear_visibility_buffer_shadow_view_pipeline".into()),
+                layout: vec![clear_visibility_buffer_shadow_view_bind_group_layout],
                 push_constant_ranges: vec![PushConstantRange {
                     stages: ShaderStages::COMPUTE,
                     range: 0..8,
                 }],
-                shader: cull_bvh.clone(),
-                shader_defs: vec![
-                    "MESHLET_BVH_CULLING_PASS".into(),
-                    "MESHLET_FIRST_CULLING_PASS".into(),
-                ],
+                shader: clear_visibility_buffer,
                 ..default()
-            }),
+            },
+        ),
 
-            second_bvh_cull: pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
-                label: Some("meshlet_second_bvh_cull_pipeline".into()),
-                layout: vec![second_bvh_cull_bind_group_layout.clone()],
-                push_constant_ranges: vec![PushConstantRange {
-                    stages: ShaderStages::COMPUTE,
-                    range: 0..8,
-                }],
-                shader: cull_bvh,
-                shader_defs: vec![
-                    "MESHLET_BVH_CULLING_PASS".into(),
-                    "MESHLET_SECOND_CULLING_PASS".into(),
-                ],
-                ..default()
-            }),
+        first_instance_cull: pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
+            label: Some("meshlet_first_instance_cull_pipeline".into()),
+            layout: vec![first_instance_cull_bind_group_layout.clone()],
+            push_constant_ranges: vec![PushConstantRange {
+                stages: ShaderStages::COMPUTE,
+                range: 0..4,
+            }],
+            shader: cull_instances.clone(),
+            shader_defs: vec![
+                "MESHLET_INSTANCE_CULLING_PASS".into(),
+                "MESHLET_FIRST_CULLING_PASS".into(),
+            ],
+            ..default()
+        }),
 
-            first_meshlet_cull: pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
-                label: Some("meshlet_first_meshlet_cull_pipeline".into()),
-                layout: vec![first_meshlet_cull_bind_group_layout.clone()],
+        second_instance_cull: pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
+            label: Some("meshlet_second_instance_cull_pipeline".into()),
+            layout: vec![second_instance_cull_bind_group_layout.clone()],
+            push_constant_ranges: vec![PushConstantRange {
+                stages: ShaderStages::COMPUTE,
+                range: 0..4,
+            }],
+            shader: cull_instances,
+            shader_defs: vec![
+                "MESHLET_INSTANCE_CULLING_PASS".into(),
+                "MESHLET_SECOND_CULLING_PASS".into(),
+            ],
+            ..default()
+        }),
+
+        first_bvh_cull: pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
+            label: Some("meshlet_first_bvh_cull_pipeline".into()),
+            layout: vec![first_bvh_cull_bind_group_layout.clone()],
+            push_constant_ranges: vec![PushConstantRange {
+                stages: ShaderStages::COMPUTE,
+                range: 0..8,
+            }],
+            shader: cull_bvh.clone(),
+            shader_defs: vec![
+                "MESHLET_BVH_CULLING_PASS".into(),
+                "MESHLET_FIRST_CULLING_PASS".into(),
+            ],
+            ..default()
+        }),
+
+        second_bvh_cull: pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
+            label: Some("meshlet_second_bvh_cull_pipeline".into()),
+            layout: vec![second_bvh_cull_bind_group_layout.clone()],
+            push_constant_ranges: vec![PushConstantRange {
+                stages: ShaderStages::COMPUTE,
+                range: 0..8,
+            }],
+            shader: cull_bvh,
+            shader_defs: vec![
+                "MESHLET_BVH_CULLING_PASS".into(),
+                "MESHLET_SECOND_CULLING_PASS".into(),
+            ],
+            ..default()
+        }),
+
+        first_meshlet_cull: pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
+            label: Some("meshlet_first_meshlet_cull_pipeline".into()),
+            layout: vec![first_meshlet_cull_bind_group_layout.clone()],
+            push_constant_ranges: vec![PushConstantRange {
+                stages: ShaderStages::COMPUTE,
+                range: 0..4,
+            }],
+            shader: cull_clusters.clone(),
+            shader_defs: vec![
+                "MESHLET_CLUSTER_CULLING_PASS".into(),
+                "MESHLET_FIRST_CULLING_PASS".into(),
+            ],
+            ..default()
+        }),
+
+        second_meshlet_cull: pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
+            label: Some("meshlet_second_meshlet_cull_pipeline".into()),
+            layout: vec![second_meshlet_cull_bind_group_layout.clone()],
+            push_constant_ranges: vec![PushConstantRange {
+                stages: ShaderStages::COMPUTE,
+                range: 0..4,
+            }],
+            shader: cull_clusters,
+            shader_defs: vec![
+                "MESHLET_CLUSTER_CULLING_PASS".into(),
+                "MESHLET_SECOND_CULLING_PASS".into(),
+            ],
+            ..default()
+        }),
+
+        downsample_depth_first: pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
+            label: Some("meshlet_downsample_depth_first_pipeline".into()),
+            layout: vec![downsample_depth_layout.clone()],
+            push_constant_ranges: vec![PushConstantRange {
+                stages: ShaderStages::COMPUTE,
+                range: 0..4,
+            }],
+            shader: downsample_depth_shader.clone(),
+            shader_defs: vec![
+                "MESHLET_VISIBILITY_BUFFER_RASTER_PASS_OUTPUT".into(),
+                "MESHLET".into(),
+            ],
+            entry_point: Some("downsample_depth_first".into()),
+            ..default()
+        }),
+
+        downsample_depth_second: pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
+            label: Some("meshlet_downsample_depth_second_pipeline".into()),
+            layout: vec![downsample_depth_layout.clone()],
+            push_constant_ranges: vec![PushConstantRange {
+                stages: ShaderStages::COMPUTE,
+                range: 0..4,
+            }],
+            shader: downsample_depth_shader.clone(),
+            shader_defs: vec![
+                "MESHLET_VISIBILITY_BUFFER_RASTER_PASS_OUTPUT".into(),
+                "MESHLET".into(),
+            ],
+            entry_point: Some("downsample_depth_second".into()),
+            ..default()
+        }),
+
+        downsample_depth_first_shadow_view: pipeline_cache.queue_compute_pipeline(
+            ComputePipelineDescriptor {
+                label: Some("meshlet_downsample_depth_first_pipeline".into()),
+                layout: vec![downsample_depth_shadow_view_layout.clone()],
                 push_constant_ranges: vec![PushConstantRange {
                     stages: ShaderStages::COMPUTE,
                     range: 0..4,
                 }],
-                shader: cull_clusters.clone(),
-                shader_defs: vec![
-                    "MESHLET_CLUSTER_CULLING_PASS".into(),
-                    "MESHLET_FIRST_CULLING_PASS".into(),
-                ],
+                shader: downsample_depth_shader.clone(),
+                shader_defs: vec!["MESHLET".into()],
+                entry_point: Some("downsample_depth_first".into()),
                 ..default()
-            }),
+            },
+        ),
 
-            second_meshlet_cull: pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
-                label: Some("meshlet_second_meshlet_cull_pipeline".into()),
-                layout: vec![second_meshlet_cull_bind_group_layout.clone()],
+        downsample_depth_second_shadow_view: pipeline_cache.queue_compute_pipeline(
+            ComputePipelineDescriptor {
+                label: Some("meshlet_downsample_depth_second_pipeline".into()),
+                layout: vec![downsample_depth_shadow_view_layout],
                 push_constant_ranges: vec![PushConstantRange {
                     stages: ShaderStages::COMPUTE,
                     range: 0..4,
                 }],
-                shader: cull_clusters,
+                shader: downsample_depth_shader,
+                shader_defs: vec!["MESHLET".into()],
+                entry_point: Some("downsample_depth_second".into()),
+                zero_initialize_workgroup_memory: false,
+            },
+        ),
+
+        visibility_buffer_software_raster: pipeline_cache.queue_compute_pipeline(
+            ComputePipelineDescriptor {
+                label: Some("meshlet_visibility_buffer_software_raster_pipeline".into()),
+                layout: vec![visibility_buffer_raster_layout.clone()],
+                push_constant_ranges: vec![],
+                shader: visibility_buffer_software_raster.clone(),
                 shader_defs: vec![
-                    "MESHLET_CLUSTER_CULLING_PASS".into(),
-                    "MESHLET_SECOND_CULLING_PASS".into(),
+                    "MESHLET_VISIBILITY_BUFFER_RASTER_PASS".into(),
+                    "MESHLET_VISIBILITY_BUFFER_RASTER_PASS_OUTPUT".into(),
+                    if remap_1d_to_2d_dispatch_layout.is_some() {
+                        "MESHLET_2D_DISPATCH"
+                    } else {
+                        ""
+                    }
+                    .into(),
                 ],
                 ..default()
-            }),
+            },
+        ),
 
-            downsample_depth_first: pipeline_cache.queue_compute_pipeline(
-                ComputePipelineDescriptor {
-                    label: Some("meshlet_downsample_depth_first_pipeline".into()),
-                    layout: vec![downsample_depth_layout.clone()],
-                    push_constant_ranges: vec![PushConstantRange {
-                        stages: ShaderStages::COMPUTE,
-                        range: 0..4,
-                    }],
-                    shader: downsample_depth_shader.clone(),
-                    shader_defs: vec![
-                        "MESHLET_VISIBILITY_BUFFER_RASTER_PASS_OUTPUT".into(),
-                        "MESHLET".into(),
-                    ],
-                    entry_point: Some("downsample_depth_first".into()),
-                    ..default()
-                },
-            ),
+        visibility_buffer_software_raster_shadow_view: pipeline_cache.queue_compute_pipeline(
+            ComputePipelineDescriptor {
+                label: Some(
+                    "meshlet_visibility_buffer_software_raster_shadow_view_pipeline".into(),
+                ),
+                layout: vec![visibility_buffer_raster_shadow_view_layout.clone()],
+                push_constant_ranges: vec![],
+                shader: visibility_buffer_software_raster,
+                shader_defs: vec![
+                    "MESHLET_VISIBILITY_BUFFER_RASTER_PASS".into(),
+                    if remap_1d_to_2d_dispatch_layout.is_some() {
+                        "MESHLET_2D_DISPATCH"
+                    } else {
+                        ""
+                    }
+                    .into(),
+                ],
+                ..default()
+            },
+        ),
 
-            downsample_depth_second: pipeline_cache.queue_compute_pipeline(
-                ComputePipelineDescriptor {
-                    label: Some("meshlet_downsample_depth_second_pipeline".into()),
-                    layout: vec![downsample_depth_layout.clone()],
-                    push_constant_ranges: vec![PushConstantRange {
-                        stages: ShaderStages::COMPUTE,
-                        range: 0..4,
-                    }],
-                    shader: downsample_depth_shader.clone(),
-                    shader_defs: vec![
-                        "MESHLET_VISIBILITY_BUFFER_RASTER_PASS_OUTPUT".into(),
-                        "MESHLET".into(),
-                    ],
-                    entry_point: Some("downsample_depth_second".into()),
-                    ..default()
-                },
-            ),
-
-            downsample_depth_first_shadow_view: pipeline_cache.queue_compute_pipeline(
-                ComputePipelineDescriptor {
-                    label: Some("meshlet_downsample_depth_first_pipeline".into()),
-                    layout: vec![downsample_depth_shadow_view_layout.clone()],
-                    push_constant_ranges: vec![PushConstantRange {
-                        stages: ShaderStages::COMPUTE,
-                        range: 0..4,
-                    }],
-                    shader: downsample_depth_shader.clone(),
-                    shader_defs: vec!["MESHLET".into()],
-                    entry_point: Some("downsample_depth_first".into()),
-                    ..default()
-                },
-            ),
-
-            downsample_depth_second_shadow_view: pipeline_cache.queue_compute_pipeline(
-                ComputePipelineDescriptor {
-                    label: Some("meshlet_downsample_depth_second_pipeline".into()),
-                    layout: vec![downsample_depth_shadow_view_layout],
-                    push_constant_ranges: vec![PushConstantRange {
-                        stages: ShaderStages::COMPUTE,
-                        range: 0..4,
-                    }],
-                    shader: downsample_depth_shader,
-                    shader_defs: vec!["MESHLET".into()],
-                    entry_point: Some("downsample_depth_second".into()),
-                    zero_initialize_workgroup_memory: false,
-                },
-            ),
-
-            visibility_buffer_software_raster: pipeline_cache.queue_compute_pipeline(
-                ComputePipelineDescriptor {
-                    label: Some("meshlet_visibility_buffer_software_raster_pipeline".into()),
-                    layout: vec![visibility_buffer_raster_layout.clone()],
-                    push_constant_ranges: vec![],
-                    shader: visibility_buffer_software_raster.clone(),
+        visibility_buffer_hardware_raster: pipeline_cache.queue_render_pipeline(
+            RenderPipelineDescriptor {
+                label: Some("meshlet_visibility_buffer_hardware_raster_pipeline".into()),
+                layout: vec![visibility_buffer_raster_layout.clone()],
+                push_constant_ranges: vec![PushConstantRange {
+                    stages: ShaderStages::VERTEX,
+                    range: 0..4,
+                }],
+                vertex: VertexState {
+                    shader: visibility_buffer_hardware_raster.clone(),
                     shader_defs: vec![
                         "MESHLET_VISIBILITY_BUFFER_RASTER_PASS".into(),
                         "MESHLET_VISIBILITY_BUFFER_RASTER_PASS_OUTPUT".into(),
-                        if remap_1d_to_2d_dispatch_layout.is_some() {
-                            "MESHLET_2D_DISPATCH"
-                        } else {
-                            ""
-                        }
-                        .into(),
                     ],
                     ..default()
                 },
-            ),
-
-            visibility_buffer_software_raster_shadow_view: pipeline_cache.queue_compute_pipeline(
-                ComputePipelineDescriptor {
-                    label: Some(
-                        "meshlet_visibility_buffer_software_raster_shadow_view_pipeline".into(),
-                    ),
-                    layout: vec![visibility_buffer_raster_shadow_view_layout.clone()],
-                    push_constant_ranges: vec![],
-                    shader: visibility_buffer_software_raster,
-                    shader_defs: vec![
-                        "MESHLET_VISIBILITY_BUFFER_RASTER_PASS".into(),
-                        if remap_1d_to_2d_dispatch_layout.is_some() {
-                            "MESHLET_2D_DISPATCH"
-                        } else {
-                            ""
-                        }
-                        .into(),
-                    ],
-                    ..default()
-                },
-            ),
-
-            visibility_buffer_hardware_raster: pipeline_cache.queue_render_pipeline(
-                RenderPipelineDescriptor {
-                    label: Some("meshlet_visibility_buffer_hardware_raster_pipeline".into()),
-                    layout: vec![visibility_buffer_raster_layout.clone()],
-                    push_constant_ranges: vec![PushConstantRange {
-                        stages: ShaderStages::VERTEX,
-                        range: 0..4,
-                    }],
-                    vertex: VertexState {
-                        shader: visibility_buffer_hardware_raster.clone(),
-                        shader_defs: vec![
-                            "MESHLET_VISIBILITY_BUFFER_RASTER_PASS".into(),
-                            "MESHLET_VISIBILITY_BUFFER_RASTER_PASS_OUTPUT".into(),
-                        ],
-                        ..default()
-                    },
-                    fragment: Some(FragmentState {
-                        shader: visibility_buffer_hardware_raster.clone(),
-                        shader_defs: vec![
-                            "MESHLET_VISIBILITY_BUFFER_RASTER_PASS".into(),
-                            "MESHLET_VISIBILITY_BUFFER_RASTER_PASS_OUTPUT".into(),
-                        ],
-                        targets: vec![Some(ColorTargetState {
-                            format: TextureFormat::R8Uint,
-                            blend: None,
-                            write_mask: ColorWrites::empty(),
-                        })],
-                        ..default()
-                    }),
-                    ..default()
-                },
-            ),
-
-            visibility_buffer_hardware_raster_shadow_view: pipeline_cache.queue_render_pipeline(
-                RenderPipelineDescriptor {
-                    label: Some(
-                        "meshlet_visibility_buffer_hardware_raster_shadow_view_pipeline".into(),
-                    ),
-                    layout: vec![visibility_buffer_raster_shadow_view_layout.clone()],
-                    push_constant_ranges: vec![PushConstantRange {
-                        stages: ShaderStages::VERTEX,
-                        range: 0..4,
-                    }],
-                    vertex: VertexState {
-                        shader: visibility_buffer_hardware_raster.clone(),
-                        shader_defs: vec!["MESHLET_VISIBILITY_BUFFER_RASTER_PASS".into()],
-                        ..default()
-                    },
-                    fragment: Some(FragmentState {
-                        shader: visibility_buffer_hardware_raster.clone(),
-                        shader_defs: vec!["MESHLET_VISIBILITY_BUFFER_RASTER_PASS".into()],
-                        targets: vec![Some(ColorTargetState {
-                            format: TextureFormat::R8Uint,
-                            blend: None,
-                            write_mask: ColorWrites::empty(),
-                        })],
-                        ..default()
-                    }),
-                    ..default()
-                },
-            ),
-
-            visibility_buffer_hardware_raster_shadow_view_unclipped: pipeline_cache
-                .queue_render_pipeline(RenderPipelineDescriptor {
-                    label: Some(
-                        "meshlet_visibility_buffer_hardware_raster_shadow_view_unclipped_pipeline"
-                            .into(),
-                    ),
-                    layout: vec![visibility_buffer_raster_shadow_view_layout],
-                    push_constant_ranges: vec![PushConstantRange {
-                        stages: ShaderStages::VERTEX,
-                        range: 0..4,
-                    }],
-                    vertex: VertexState {
-                        shader: visibility_buffer_hardware_raster.clone(),
-                        shader_defs: vec!["MESHLET_VISIBILITY_BUFFER_RASTER_PASS".into()],
-                        ..default()
-                    },
-                    fragment: Some(FragmentState {
-                        shader: visibility_buffer_hardware_raster,
-                        shader_defs: vec!["MESHLET_VISIBILITY_BUFFER_RASTER_PASS".into()],
-                        targets: vec![Some(ColorTargetState {
-                            format: TextureFormat::R8Uint,
-                            blend: None,
-                            write_mask: ColorWrites::empty(),
-                        })],
-                        ..default()
-                    }),
-                    ..default()
-                }),
-
-            resolve_depth: pipeline_cache.queue_render_pipeline(RenderPipelineDescriptor {
-                label: Some("meshlet_resolve_depth_pipeline".into()),
-                layout: vec![resolve_depth_layout],
-                vertex: vertex_state.clone(),
-                depth_stencil: Some(DepthStencilState {
-                    format: CORE_3D_DEPTH_FORMAT,
-                    depth_write_enabled: true,
-                    depth_compare: CompareFunction::Always,
-                    stencil: StencilState::default(),
-                    bias: DepthBiasState::default(),
-                }),
                 fragment: Some(FragmentState {
-                    shader: resolve_render_targets.clone(),
-                    shader_defs: vec!["MESHLET_VISIBILITY_BUFFER_RASTER_PASS_OUTPUT".into()],
-                    entry_point: Some("resolve_depth".into()),
+                    shader: visibility_buffer_hardware_raster.clone(),
+                    shader_defs: vec![
+                        "MESHLET_VISIBILITY_BUFFER_RASTER_PASS".into(),
+                        "MESHLET_VISIBILITY_BUFFER_RASTER_PASS_OUTPUT".into(),
+                    ],
+                    targets: vec![Some(ColorTargetState {
+                        format: TextureFormat::R8Uint,
+                        blend: None,
+                        write_mask: ColorWrites::empty(),
+                    })],
+                    ..default()
+                }),
+                ..default()
+            },
+        ),
+
+        visibility_buffer_hardware_raster_shadow_view: pipeline_cache.queue_render_pipeline(
+            RenderPipelineDescriptor {
+                label: Some(
+                    "meshlet_visibility_buffer_hardware_raster_shadow_view_pipeline".into(),
+                ),
+                layout: vec![visibility_buffer_raster_shadow_view_layout.clone()],
+                push_constant_ranges: vec![PushConstantRange {
+                    stages: ShaderStages::VERTEX,
+                    range: 0..4,
+                }],
+                vertex: VertexState {
+                    shader: visibility_buffer_hardware_raster.clone(),
+                    shader_defs: vec!["MESHLET_VISIBILITY_BUFFER_RASTER_PASS".into()],
+                    ..default()
+                },
+                fragment: Some(FragmentState {
+                    shader: visibility_buffer_hardware_raster.clone(),
+                    shader_defs: vec!["MESHLET_VISIBILITY_BUFFER_RASTER_PASS".into()],
+                    targets: vec![Some(ColorTargetState {
+                        format: TextureFormat::R8Uint,
+                        blend: None,
+                        write_mask: ColorWrites::empty(),
+                    })],
+                    ..default()
+                }),
+                ..default()
+            },
+        ),
+
+        visibility_buffer_hardware_raster_shadow_view_unclipped: pipeline_cache
+            .queue_render_pipeline(RenderPipelineDescriptor {
+                label: Some(
+                    "meshlet_visibility_buffer_hardware_raster_shadow_view_unclipped_pipeline"
+                        .into(),
+                ),
+                layout: vec![visibility_buffer_raster_shadow_view_layout],
+                push_constant_ranges: vec![PushConstantRange {
+                    stages: ShaderStages::VERTEX,
+                    range: 0..4,
+                }],
+                vertex: VertexState {
+                    shader: visibility_buffer_hardware_raster.clone(),
+                    shader_defs: vec!["MESHLET_VISIBILITY_BUFFER_RASTER_PASS".into()],
+                    ..default()
+                },
+                fragment: Some(FragmentState {
+                    shader: visibility_buffer_hardware_raster,
+                    shader_defs: vec!["MESHLET_VISIBILITY_BUFFER_RASTER_PASS".into()],
+                    targets: vec![Some(ColorTargetState {
+                        format: TextureFormat::R8Uint,
+                        blend: None,
+                        write_mask: ColorWrites::empty(),
+                    })],
                     ..default()
                 }),
                 ..default()
             }),
 
-            resolve_depth_shadow_view: pipeline_cache.queue_render_pipeline(
-                RenderPipelineDescriptor {
-                    label: Some("meshlet_resolve_depth_pipeline".into()),
-                    layout: vec![resolve_depth_shadow_view_layout],
-                    vertex: vertex_state.clone(),
-                    depth_stencil: Some(DepthStencilState {
-                        format: CORE_3D_DEPTH_FORMAT,
-                        depth_write_enabled: true,
-                        depth_compare: CompareFunction::Always,
-                        stencil: StencilState::default(),
-                        bias: DepthBiasState::default(),
-                    }),
-                    fragment: Some(FragmentState {
-                        shader: resolve_render_targets.clone(),
-                        entry_point: Some("resolve_depth".into()),
-                        ..default()
-                    }),
-                    ..default()
-                },
-            ),
-
-            resolve_material_depth: pipeline_cache.queue_render_pipeline(
-                RenderPipelineDescriptor {
-                    label: Some("meshlet_resolve_material_depth_pipeline".into()),
-                    layout: vec![resolve_material_depth_layout],
-                    vertex: vertex_state,
-                    primitive: PrimitiveState::default(),
-                    depth_stencil: Some(DepthStencilState {
-                        format: TextureFormat::Depth16Unorm,
-                        depth_write_enabled: true,
-                        depth_compare: CompareFunction::Always,
-                        stencil: StencilState::default(),
-                        bias: DepthBiasState::default(),
-                    }),
-                    fragment: Some(FragmentState {
-                        shader: resolve_render_targets,
-                        shader_defs: vec!["MESHLET_VISIBILITY_BUFFER_RASTER_PASS_OUTPUT".into()],
-                        entry_point: Some("resolve_material_depth".into()),
-                        targets: vec![],
-                    }),
-                    ..default()
-                },
-            ),
-
-            fill_counts: pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
-                label: Some("meshlet_fill_counts_pipeline".into()),
-                layout: vec![fill_counts_layout],
-                shader: fill_counts,
-                shader_defs: vec![if remap_1d_to_2d_dispatch_layout.is_some() {
-                    "MESHLET_2D_DISPATCH"
-                } else {
-                    ""
-                }
-                .into()],
+        resolve_depth: pipeline_cache.queue_render_pipeline(RenderPipelineDescriptor {
+            label: Some("meshlet_resolve_depth_pipeline".into()),
+            layout: vec![resolve_depth_layout],
+            vertex: vertex_state.clone(),
+            depth_stencil: Some(DepthStencilState {
+                format: CORE_3D_DEPTH_FORMAT,
+                depth_write_enabled: true,
+                depth_compare: CompareFunction::Always,
+                stencil: StencilState::default(),
+                bias: DepthBiasState::default(),
+            }),
+            fragment: Some(FragmentState {
+                shader: resolve_render_targets.clone(),
+                shader_defs: vec!["MESHLET_VISIBILITY_BUFFER_RASTER_PASS_OUTPUT".into()],
+                entry_point: Some("resolve_depth".into()),
                 ..default()
             }),
+            ..default()
+        }),
 
-            remap_1d_to_2d_dispatch: remap_1d_to_2d_dispatch_layout.map(|layout| {
-                pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
-                    label: Some("meshlet_remap_1d_to_2d_dispatch_pipeline".into()),
-                    layout: vec![layout],
-                    push_constant_ranges: vec![PushConstantRange {
-                        stages: ShaderStages::COMPUTE,
-                        range: 0..4,
-                    }],
-                    shader: remap_1d_to_2d_dispatch,
-                    ..default()
-                })
+        resolve_depth_shadow_view: pipeline_cache.queue_render_pipeline(RenderPipelineDescriptor {
+            label: Some("meshlet_resolve_depth_pipeline".into()),
+            layout: vec![resolve_depth_shadow_view_layout],
+            vertex: vertex_state.clone(),
+            depth_stencil: Some(DepthStencilState {
+                format: CORE_3D_DEPTH_FORMAT,
+                depth_write_enabled: true,
+                depth_compare: CompareFunction::Always,
+                stencil: StencilState::default(),
+                bias: DepthBiasState::default(),
             }),
+            fragment: Some(FragmentState {
+                shader: resolve_render_targets.clone(),
+                entry_point: Some("resolve_depth".into()),
+                ..default()
+            }),
+            ..default()
+        }),
 
-            meshlet_mesh_material,
-        }
-    }
+        resolve_material_depth: pipeline_cache.queue_render_pipeline(RenderPipelineDescriptor {
+            label: Some("meshlet_resolve_material_depth_pipeline".into()),
+            layout: vec![resolve_material_depth_layout],
+            vertex: vertex_state,
+            primitive: PrimitiveState::default(),
+            depth_stencil: Some(DepthStencilState {
+                format: TextureFormat::Depth16Unorm,
+                depth_write_enabled: true,
+                depth_compare: CompareFunction::Always,
+                stencil: StencilState::default(),
+                bias: DepthBiasState::default(),
+            }),
+            fragment: Some(FragmentState {
+                shader: resolve_render_targets,
+                shader_defs: vec!["MESHLET_VISIBILITY_BUFFER_RASTER_PASS_OUTPUT".into()],
+                entry_point: Some("resolve_material_depth".into()),
+                targets: vec![],
+            }),
+            ..default()
+        }),
+
+        fill_counts: pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
+            label: Some("meshlet_fill_counts_pipeline".into()),
+            layout: vec![fill_counts_layout],
+            shader: fill_counts,
+            shader_defs: vec![if remap_1d_to_2d_dispatch_layout.is_some() {
+                "MESHLET_2D_DISPATCH"
+            } else {
+                ""
+            }
+            .into()],
+            ..default()
+        }),
+
+        remap_1d_to_2d_dispatch: remap_1d_to_2d_dispatch_layout.map(|layout| {
+            pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
+                label: Some("meshlet_remap_1d_to_2d_dispatch_pipeline".into()),
+                layout: vec![layout],
+                push_constant_ranges: vec![PushConstantRange {
+                    stages: ShaderStages::COMPUTE,
+                    range: 0..4,
+                }],
+                shader: remap_1d_to_2d_dispatch,
+                ..default()
+            })
+        }),
+
+        meshlet_mesh_material,
+    });
 }
 
 impl MeshletPipelines {

--- a/release-content/migration-guides/render_startup.md
+++ b/release-content/migration-guides/render_startup.md
@@ -36,6 +36,9 @@ The following are the (public) resources that are now initialized in `RenderStar
 - `PrepassViewBindGroup`
 - `Wireframe3dPipeline`
 - `MaterialPipeline`
+- `MeshletPipelines`
+- `MeshletMeshManager`
+- `ResourceManager`
 - `Wireframe2dPipeline`
 - `Material2dPipeline`
 - `SpritePipeline`


### PR DESCRIPTION
# Objective

- Progress towards #19887.

## Solution

- Convert FromWorld impls to systems in `RenderStartup`.
- Use a closure system for initializing `ResourceManager` to capture the `cluster_buffer_slots`.

## Testing

- Ran the `meshlet` example and it behaves the same as main.