### PR TITLE
Fix panic when focused entity is despawned

### DIFF
--- a/crates/bevy_input_focus/src/lib.rs
+++ b/crates/bevy_input_focus/src/lib.rs
@@ -31,7 +31,7 @@ mod autofocus;
 pub use autofocus::*;
 
 use bevy_app::{App, Plugin, PostStartup, PreUpdate};
-use bevy_ecs::{prelude::*, query::QueryData, system::SystemParam, traversal::Traversal};
+use bevy_ecs::{entity::Entities, prelude::*, query::QueryData, system::SystemParam, traversal::Traversal};
 use bevy_input::{gamepad::GamepadButtonChangedEvent, keyboard::KeyboardInput, mouse::MouseWheel};
 use bevy_window::{PrimaryWindow, Window};
 use core::fmt::Debug;
@@ -254,21 +254,37 @@ pub fn set_initial_focus(
 /// if no entity has focus.
 pub fn dispatch_focused_input<E: BufferedEvent + Clone>(
     mut key_events: EventReader<E>,
-    focus: Res<InputFocus>,
+    mut focus: ResMut<InputFocus>,
     windows: Query<Entity, With<PrimaryWindow>>,
+    entities: &Entities,
     mut commands: Commands,
 ) {
     if let Ok(window) = windows.single() {
         // If an element has keyboard focus, then dispatch the input event to that element.
         if let Some(focused_entity) = focus.0 {
-            for ev in key_events.read() {
-                commands.trigger_targets(
-                    FocusedInput {
-                        input: ev.clone(),
+            // Check if the focused entity is still alive
+            if entities.contains(focused_entity) {
+                for ev in key_events.read() {
+                    commands.trigger_targets(
+                        FocusedInput {
+                            input: ev.clone(),
+                            window,
+                        },
+                        focused_entity,
+                    );
+                }
+            } else {
+                // If the focused entity no longer exists, clear focus and dispatch to window
+                focus.0 = None;
+                for ev in key_events.read() {
+                    commands.trigger_targets(
+                        FocusedInput {
+                            input: ev.clone(),
+                            window,
+                        },
                         window,
-                    },
-                    focused_entity,
-                );
+                    );
+                }
             }
         } else {
             // If no element has input focus, then dispatch the input event to the primary window.
@@ -626,5 +642,26 @@ mod tests {
                 assert!(world.is_focus_within_visible(child_of_b));
             })
             .unwrap();
+    }
+
+    #[test]
+    fn dispatch_clears_focus_when_focused_entity_despawned() {
+        let mut app = App::new();
+        app.add_plugins((InputPlugin, InputDispatchPlugin));
+
+        app.world_mut().spawn((Window::default(), PrimaryWindow));
+        app.update();
+
+        let entity = app.world_mut().spawn_empty().id();
+        app.world_mut().insert_resource(InputFocus::from_entity(entity));
+        app.world_mut().entity_mut(entity).despawn();
+
+        assert_eq!(app.world().resource::<InputFocus>().0, Some(entity));
+
+        // Send input event - this should clear focus instead of panicking
+        app.world_mut().write_event(key_a_event());
+        app.update();
+
+        assert_eq!(app.world().resource::<InputFocus>().0, None);
     }
 }

--- a/crates/bevy_input_focus/src/lib.rs
+++ b/crates/bevy_input_focus/src/lib.rs
@@ -31,7 +31,9 @@ mod autofocus;
 pub use autofocus::*;
 
 use bevy_app::{App, Plugin, PostStartup, PreUpdate};
-use bevy_ecs::{entity::Entities, prelude::*, query::QueryData, system::SystemParam, traversal::Traversal};
+use bevy_ecs::{
+    entity::Entities, prelude::*, query::QueryData, system::SystemParam, traversal::Traversal,
+};
 use bevy_input::{gamepad::GamepadButtonChangedEvent, keyboard::KeyboardInput, mouse::MouseWheel};
 use bevy_window::{PrimaryWindow, Window};
 use core::fmt::Debug;
@@ -653,7 +655,8 @@ mod tests {
         app.update();
 
         let entity = app.world_mut().spawn_empty().id();
-        app.world_mut().insert_resource(InputFocus::from_entity(entity));
+        app.world_mut()
+            .insert_resource(InputFocus::from_entity(entity));
         app.world_mut().entity_mut(entity).despawn();
 
         assert_eq!(app.world().resource::<InputFocus>().0, Some(entity));

--- a/crates/bevy_input_focus/src/lib.rs
+++ b/crates/bevy_input_focus/src/lib.rs
@@ -254,6 +254,9 @@ pub fn set_initial_focus(
 
 /// System which dispatches bubbled input events to the focused entity, or to the primary window
 /// if no entity has focus.
+///
+/// If the currently focused entity no longer exists (has been despawned), this system will
+/// automatically clear the focus and dispatch events to the primary window instead.
 pub fn dispatch_focused_input<E: BufferedEvent + Clone>(
     mut key_events: EventReader<E>,
     mut focus: ResMut<InputFocus>,


### PR DESCRIPTION
# Objective

- Fix panic when input dispatch system tries to trigger events on a despawned focused entity
- Fixes #20057

## Solution

- Added entity validity check in `dispatch_focused_input` function using `entities.contains(focused_entity)`
- If the focused entity no longer exists, the focus is cleared and the event is dispatched to the window instead

## Testing

- Added test `dispatch_clears_focus_when_focused_entity_despawned` that reproduces the issue scenario

