### PR TITLE
Add quick notes about Allows

### DIFF
--- a/crates/bevy_ecs/src/entity_disabling.rs
+++ b/crates/bevy_ecs/src/entity_disabling.rs
@@ -44,6 +44,9 @@
 //! even if they have a `Position` component,
 //! but `Query<&Position, With<Disabled>>` or `Query<(&Position, Has<Disabled>)>` will see them.
 //!
+//! The [`Allows`](crate::query::Allows) query filter is designed to be used with default query filters,
+//! and ensures that the query will include entities both with and without the specified disabling component.
+//!
 //! Entities with disabling components are still present in the [`World`] and can be accessed directly,
 //! using methods on [`World`] or [`Commands`](crate::prelude::Commands).
 //!
@@ -110,6 +113,12 @@ pub struct Disabled;
 /// If a query does not explicitly mention a given disabling component, it will not include entities with that component.
 /// To be more precise, this checks if the query's [`FilteredAccess`] contains the component,
 /// and if it does not, adds a [`Without`](crate::prelude::Without) filter for that component to the query.
+///
+/// [`Allows`](crate::query::Allows) and [`Has`](crate::prelude::Has) can be used to include entities
+/// with and without the disabling component.
+/// [`Allows`](crate::query::Allows) is a [`QueryFilter`](crate::query::QueryFilter) and will simply change
+/// the list of shown entities, while [`Has`](crate::prelude::Has) is a [`QueryData`](crate::query::QueryData)
+/// and will allow you to see if each entity has the disabling component or not.
 ///
 /// This resource is initialized in the [`World`] whenever a new world is created,
 /// with the [`Disabled`] component as a disabling component.


### PR DESCRIPTION
# Objective

- `Allows` was added as a handy tool to work with default query filters.
- It wasn't in the docs though, and I had to hunt it down while reviewing #20204.

## Solution

-  Add some breadcrumbs to the docs in the expected places.
