### PR TITLE
Remove the extra `camera2d` spawning

### DIFF
--- a/examples/2d/sprite_scale.rs
+++ b/examples/2d/sprite_scale.rs
@@ -5,10 +5,7 @@ use bevy::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_systems(
-            Startup,
-            (setup_sprites, setup_texture_atlas, setup_camera),
-        )
+        .add_systems(Startup, (setup_sprites, setup_texture_atlas, setup_camera))
         .add_systems(Update, animate_sprite)
         .run();
 }


### PR DESCRIPTION
# Objective

- Remove an unnecessary extra `Camera2d` from one of the examples. 

## Solution

- I removed the `commands.spawn(Camera2d)` where it was less explicit.
- Because the default camera brings a lot more thing, it is necessary to spawn it early (remove the `.after()` call)

## Testing

I run the test, and the result was the same as without the change - regression passed. (Win10, GTX1050TI)

Running this specific example:
```
cargo run --example sprite_scale
```

When the example starts, Gabe should run nicely.