### PR TITLE
Rework one-to-one relationships to remove existing instead of panicking

### DIFF
--- a/crates/bevy_ecs/src/relationship/mod.rs
+++ b/crates/bevy_ecs/src/relationship/mod.rs
@@ -129,19 +129,15 @@ pub trait Relationship: Component + Sized {
             return;
         }
         // For one-to-one relationships, remove existing relationship before adding new one
-        let current_source_to_remove = if let Ok(target_entity_ref) =
-            world.get_entity(target_entity)
-        {
-            if let Some(relationship_target) = target_entity_ref.get::<Self::RelationshipTarget>() {
+        let current_source_to_remove = world
+            .get_entity(target_entity)
+            .ok()
+            .and_then(|target_entity_ref| target_entity_ref.get::<Self::RelationshipTarget>())
+            .and_then(|relationship_target| {
                 relationship_target
                     .collection()
                     .source_to_remove_before_add()
-            } else {
-                None
-            }
-        } else {
-            None
-        };
+            });
 
         if let Some(current_source) = current_source_to_remove {
             world.commands().entity(current_source).try_remove::<Self>();

--- a/crates/bevy_ecs/src/relationship/mod.rs
+++ b/crates/bevy_ecs/src/relationship/mod.rs
@@ -139,9 +139,10 @@ pub trait Relationship: Component + Sized {
                 {
                     // SAFETY: We just checked that the collection type is Entity
                     let entity_collection = unsafe {
-                        &*(relationship_target.collection()
-                            as *const <Self::RelationshipTarget as RelationshipTarget>::Collection
-                            as *const Entity)
+                        &*core::ptr::from_ref::<
+                            <Self::RelationshipTarget as RelationshipTarget>::Collection,
+                        >(relationship_target.collection())
+                        .cast::<Entity>()
                     };
                     if *entity_collection != Entity::PLACEHOLDER {
                         current_source_to_remove = Some(*entity_collection);

--- a/crates/bevy_ecs/src/relationship/relationship_source_collection.rs
+++ b/crates/bevy_ecs/src/relationship/relationship_source_collection.rs
@@ -69,6 +69,12 @@ pub trait RelationshipSourceCollection {
         self.len() == 0
     }
 
+    /// For one-to-one relationships, returns the entity that should be removed before adding a new one.
+    /// Returns `None` for one-to-many relationships or when no entity needs to be removed.
+    fn source_to_remove_before_add(&self) -> Option<Entity> {
+        None
+    }
+
     /// Add multiple entities to collection at once.
     ///
     /// May be faster than repeatedly calling [`Self::add`].
@@ -383,6 +389,14 @@ impl RelationshipSourceCollection for Entity {
     fn extend_from_iter(&mut self, entities: impl IntoIterator<Item = Entity>) {
         for entity in entities {
             *self = entity;
+        }
+    }
+
+    fn source_to_remove_before_add(&self) -> Option<Entity> {
+        if *self != Entity::PLACEHOLDER {
+            Some(*self)
+        } else {
+            None
         }
     }
 }

--- a/crates/bevy_ecs/src/relationship/relationship_source_collection.rs
+++ b/crates/bevy_ecs/src/relationship/relationship_source_collection.rs
@@ -345,14 +345,7 @@ impl RelationshipSourceCollection for Entity {
     }
 
     fn add(&mut self, entity: Entity) -> bool {
-        assert_eq!(
-            *self,
-            Entity::PLACEHOLDER,
-            "Entity {entity} attempted to target an entity with a one-to-one relationship, but it is already targeted by {}. You must remove the original relationship first.",
-            *self
-        );
         *self = entity;
-
         true
     }
 
@@ -389,12 +382,6 @@ impl RelationshipSourceCollection for Entity {
 
     fn extend_from_iter(&mut self, entities: impl IntoIterator<Item = Entity>) {
         for entity in entities {
-            assert_eq!(
-                *self,
-                Entity::PLACEHOLDER,
-                "Entity {entity} attempted to target an entity with a one-to-one relationship, but it is already targeted by {}. You must remove the original relationship first.",
-                *self
-            );
             *self = entity;
         }
     }
@@ -724,7 +711,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn one_to_one_relationship_shared_target() {
         #[derive(Component)]
         #[relationship(relationship_target = Below)]
@@ -740,6 +726,22 @@ mod tests {
 
         world.entity_mut(a).insert(Above(c));
         world.entity_mut(b).insert(Above(c));
+
+        // The original relationship (a -> c) should be removed and the new relationship (b -> c) should be established
+        assert!(
+            world.get::<Above>(a).is_none(),
+            "Original relationship should be removed"
+        );
+        assert_eq!(
+            world.get::<Above>(b).unwrap().0,
+            c,
+            "New relationship should be established"
+        );
+        assert_eq!(
+            world.get::<Below>(c).unwrap().0,
+            b,
+            "Target should point to new source"
+        );
     }
 
     #[test]


### PR DESCRIPTION
# Objective

- Issue: #18847 
- Resolves panic when establishing a one-to-one relationship to an entity that already has an existing relationship from another entity.

## Solution

- Modified the `on_insert` hook in the `Relationship` trait to detect one-to-one relationships (where the target collection type is `Entity`) and automatically remove any existing relationship before establishing the new one.
- Uses runtime type checking with `TypeId` to identify one-to-one vs one-to-many relationships.
- Safely removes the existing source relationship using `try_remove()` to handle edge cases gracefully.

## Testing

- Removed panic assertions from `Entity::add()` and `Entity::extend_from_iter()` methods that would previously crash when attempting to establish overlapping one-to-one relationships
- Modified existing test `one_to_one_relationship_shared_target` by removing `#[should_panic]` and adding assertions to verify:
  - Original relationship is properly removed
  - New relationship is correctly established
  - Target entity points to the new source