### PR TITLE
fix branch name when installing rust in cache update action 

### DIFF
--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Setup Rust
         id: rust
-        uses: dtolnay/rust-toolchain@main
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
           target: ${{ matrix.target }}


### PR DESCRIPTION
# Objective

- the new cache action (#20144) is currently failing on the install rust step

## Solution

- Use the correct branch name
