### PR TITLE
Better `ScheduleBuildError` introspection and handling

### DIFF
--- a/crates/bevy_ecs/src/schedule/error.rs
+++ b/crates/bevy_ecs/src/schedule/error.rs
@@ -9,7 +9,7 @@ use crate::{
     world::World,
 };
 
-/// Category of errors encountered during schedule construction.
+/// Category of errors encountered during [`Schedule::initialize`](crate::schedule::Schedule::initialize).
 #[non_exhaustive]
 #[derive(Error, Debug)]
 pub enum ScheduleBuildError {
@@ -21,7 +21,13 @@ pub enum ScheduleBuildError {
     HierarchyCycle(Vec<Vec<NodeId>>),
     /// The hierarchy of system sets contains redundant edges.
     ///
-    /// This error is disabled by default, but can be opted-in using [`ScheduleBuildSettings`].
+    /// This error defaults to a warning, but can be upgraded to an error
+    /// by setting [`ScheduleBuildSettings::hierarchy_detection`] to [`LogLevel::Error`].
+    ///
+    /// See [`ScheduleBuildWarning::HierarchyRedundancy`] for its warning variant.
+    ///
+    /// [`ScheduleBuildSettings::hierarchy_detection`]: crate::schedule::ScheduleBuildSettings::hierarchy_detection
+    /// [`LogLevel::Error`]: crate::schedule::LogLevel::Error
     #[error("The hierarchy of system sets contains redundant edges: {0:?}")]
     HierarchyRedundancy(Vec<(NodeId, NodeId)>),
     /// A system (set) has been told to run before itself.
@@ -41,7 +47,13 @@ pub enum ScheduleBuildError {
     SystemTypeSetAmbiguity(SystemSetKey),
     /// Systems with conflicting access have indeterminate run order.
     ///
-    /// This error is disabled by default, but can be opted-in using [`ScheduleBuildSettings`].
+    /// This error is disabled by default, but can be enabled by setting
+    /// [`ScheduleBuildSettings::ambiguity_detection`] to [`LogLevel::Error`].
+    ///
+    /// See [`ScheduleBuildWarning::Ambiguity`] for its warning variant.
+    ///
+    /// [`ScheduleBuildSettings::ambiguity_detection`]: crate::schedule::ScheduleBuildSettings
+    /// [`LogLevel::Error`]: crate::schedule::LogLevel::Error
     #[error("Systems with conflicting access have indeterminate run order: {0:?}")]
     Ambiguity(Vec<(SystemKey, SystemKey, Vec<ComponentId>)>),
     /// Tried to run a schedule before all of its systems have been initialized.
@@ -49,18 +61,30 @@ pub enum ScheduleBuildError {
     Uninitialized,
 }
 
-/// Warnings encountered during schedule construction.
+/// Category of warnings encountered during [`Schedule::initialize`](crate::schedule::Schedule::initialize).
 #[non_exhaustive]
 #[derive(Error, Debug)]
 pub enum ScheduleBuildWarning {
     /// The hierarchy of system sets contains redundant edges.
     ///
-    /// This error is disabled by default, but can be opted-in using [`ScheduleBuildSettings`].
+    /// This warning is enabled by default, but can be disabled by setting
+    /// [`ScheduleBuildSettings::hierarchy_detection`] to [`LogLevel::Ignore`]
+    /// or upgraded to a [`ScheduleBuildError`] by setting it to [`LogLevel::Error`].
+    ///
+    /// [`ScheduleBuildSettings::hierarchy_detection`]: crate::schedule::ScheduleBuildSettings::hierarchy_detection
+    /// [`LogLevel::Ignore`]: crate::schedule::LogLevel::Ignore
+    /// [`LogLevel::Error`]: crate::schedule::LogLevel::Error
     #[error("The hierarchy of system sets contains redundant edges: {0:?}")]
     HierarchyRedundancy(Vec<(NodeId, NodeId)>),
     /// Systems with conflicting access have indeterminate run order.
     ///
-    /// This error is disabled by default, but can be opted-in using [`ScheduleBuildSettings`].
+    /// This warning is disabled by default, but can be enabled by setting
+    /// [`ScheduleBuildSettings::ambiguity_detection`] to [`LogLevel::Warn`]
+    /// or upgraded to a [`ScheduleBuildError`] by setting it to [`LogLevel::Error`].
+    ///
+    /// [`ScheduleBuildSettings::ambiguity_detection`]: crate::schedule::ScheduleBuildSettings::ambiguity_detection
+    /// [`LogLevel::Warn`]: crate::schedule::LogLevel::Warn
+    /// [`LogLevel::Error`]: crate::schedule::LogLevel::Error
     #[error("Systems with conflicting access have indeterminate run order: {0:?}")]
     Ambiguity(Vec<(SystemKey, SystemKey, Vec<ComponentId>)>),
 }

--- a/crates/bevy_ecs/src/schedule/error.rs
+++ b/crates/bevy_ecs/src/schedule/error.rs
@@ -92,6 +92,14 @@ pub enum ScheduleBuildWarning {
 impl ScheduleBuildError {
     /// Renders the error as a human-readable string with node identifiers
     /// replaced with their names.
+    ///
+    /// The given `graph` and `world` are used to resolve the names of the nodes
+    /// and components involved in the error. The same `graph` and `world`
+    /// should be used as those used to [`initialize`] the [`Schedule`]. Failure
+    /// to do so will result in incorrect or incomplete error messages.
+    ///
+    /// [`initialize`]: crate::schedule::Schedule::initialize
+    /// [`Schedule`]: crate::schedule::Schedule
     pub fn to_string(&self, graph: &ScheduleGraph, world: &World) -> String {
         match self {
             ScheduleBuildError::HierarchyLoop(node_id) => {

--- a/crates/bevy_ecs/src/schedule/error.rs
+++ b/crates/bevy_ecs/src/schedule/error.rs
@@ -1,0 +1,253 @@
+use alloc::{format, string::String, vec::Vec};
+use core::fmt::Write as _;
+
+use thiserror::Error;
+
+use crate::{
+    component::{ComponentId, Components},
+    schedule::{graph::GraphNodeId, NodeId, ScheduleGraph, SystemKey, SystemSetKey},
+    world::World,
+};
+
+/// Category of errors encountered during schedule construction.
+#[non_exhaustive]
+#[derive(Error, Debug)]
+pub enum ScheduleBuildError {
+    /// A system set contains itself.
+    #[error("System set `{0:?}` contains itself.")]
+    HierarchyLoop(NodeId),
+    /// The hierarchy of system sets contains a cycle.
+    #[error("The hierarchy of system sets contains a cycle: {0:?}")]
+    HierarchyCycle(Vec<Vec<NodeId>>),
+    /// The hierarchy of system sets contains redundant edges.
+    ///
+    /// This error is disabled by default, but can be opted-in using [`ScheduleBuildSettings`].
+    #[error("The hierarchy of system sets contains redundant edges: {0:?}")]
+    HierarchyRedundancy(Vec<(NodeId, NodeId)>),
+    /// A system (set) has been told to run before itself.
+    #[error("`{0:?}` has been told to run before itself.")]
+    DependencyLoop(NodeId),
+    /// The dependency graph contains a cycle.
+    #[error("The dependency graph contains a cycle: {0:?}")]
+    DependencyCycle(Vec<Vec<NodeId>>),
+    /// Tried to order a system (set) relative to a system set it belongs to.
+    #[error("`{0:?}` and `{1:?}` have both `in_set` and `before`-`after` relationships (these might be transitive). This combination is unsolvable as a system cannot run before or after a set it belongs to.")]
+    CrossDependency(NodeId, NodeId),
+    /// Tried to order system sets that share systems.
+    #[error("`{0:?}` and `{1:?}` have a `before`-`after` relationship (which may be transitive) but share systems.")]
+    SetsHaveOrderButIntersect(SystemSetKey, SystemSetKey),
+    /// Tried to order a system (set) relative to all instances of some system function.
+    #[error("Tried to order against `{0:?}` in a schedule that has more than one `{0:?}` instance. `{0:?}` is a `SystemTypeSet` and cannot be used for ordering if ambiguous. Use a different set without this restriction.")]
+    SystemTypeSetAmbiguity(SystemSetKey),
+    /// Systems with conflicting access have indeterminate run order.
+    ///
+    /// This error is disabled by default, but can be opted-in using [`ScheduleBuildSettings`].
+    #[error("Systems with conflicting access have indeterminate run order: {0:?}")]
+    Ambiguity(Vec<(SystemKey, SystemKey, Vec<ComponentId>)>),
+    /// Tried to run a schedule before all of its systems have been initialized.
+    #[error("Tried to run a schedule before all of its systems have been initialized.")]
+    Uninitialized,
+}
+
+/// Warnings encountered during schedule construction.
+#[non_exhaustive]
+#[derive(Error, Debug)]
+pub enum ScheduleBuildWarning {
+    /// The hierarchy of system sets contains redundant edges.
+    ///
+    /// This error is disabled by default, but can be opted-in using [`ScheduleBuildSettings`].
+    #[error("The hierarchy of system sets contains redundant edges: {0:?}")]
+    HierarchyRedundancy(Vec<(NodeId, NodeId)>),
+    /// Systems with conflicting access have indeterminate run order.
+    ///
+    /// This error is disabled by default, but can be opted-in using [`ScheduleBuildSettings`].
+    #[error("Systems with conflicting access have indeterminate run order: {0:?}")]
+    Ambiguity(Vec<(SystemKey, SystemKey, Vec<ComponentId>)>),
+}
+
+impl ScheduleBuildError {
+    /// Renders the error as a human-readable string with node identifiers
+    /// replaced with their names.
+    pub fn to_string(&self, graph: &ScheduleGraph, world: &World) -> String {
+        match self {
+            ScheduleBuildError::HierarchyLoop(node_id) => {
+                Self::hierarchy_loop_to_string(node_id, graph)
+            }
+            ScheduleBuildError::HierarchyCycle(cycles) => {
+                Self::hierarchy_cycle_to_string(cycles, graph)
+            }
+            ScheduleBuildError::HierarchyRedundancy(transitive_edges) => {
+                Self::hierarchy_redundancy_to_string(transitive_edges, graph)
+            }
+            ScheduleBuildError::DependencyLoop(node_id) => {
+                Self::dependency_loop_to_string(node_id, graph)
+            }
+            ScheduleBuildError::DependencyCycle(cycles) => {
+                Self::dependency_cycle_to_string(cycles, graph)
+            }
+            ScheduleBuildError::CrossDependency(a, b) => {
+                Self::cross_dependency_to_string(a, b, graph)
+            }
+            ScheduleBuildError::SetsHaveOrderButIntersect(a, b) => {
+                Self::sets_have_order_but_intersect_to_string(a, b, graph)
+            }
+            ScheduleBuildError::SystemTypeSetAmbiguity(set) => {
+                Self::system_type_set_ambiguity_to_string(set, graph)
+            }
+            ScheduleBuildError::Ambiguity(ambiguities) => {
+                Self::ambiguity_to_string(ambiguities, graph, world.components())
+            }
+            ScheduleBuildError::Uninitialized => Self::uninitialized_to_string(),
+        }
+    }
+
+    fn hierarchy_loop_to_string(node_id: &NodeId, graph: &ScheduleGraph) -> String {
+        format!(
+            "{} `{}` contains itself",
+            node_id.kind(),
+            graph.get_node_name(node_id)
+        )
+    }
+
+    fn hierarchy_cycle_to_string(cycles: &[Vec<NodeId>], graph: &ScheduleGraph) -> String {
+        let mut message = format!("schedule has {} in_set cycle(s):\n", cycles.len());
+        for (i, cycle) in cycles.iter().enumerate() {
+            let mut names = cycle.iter().map(|id| (id.kind(), graph.get_node_name(id)));
+            let (first_kind, first_name) = names.next().unwrap();
+            writeln!(
+                message,
+                "cycle {}: {first_kind} `{first_name}` contains itself",
+                i + 1,
+            )
+            .unwrap();
+            writeln!(message, "{first_kind} `{first_name}`").unwrap();
+            for (kind, name) in names.chain(core::iter::once((first_kind, first_name))) {
+                writeln!(message, " ... which contains {kind} `{name}`").unwrap();
+            }
+            writeln!(message).unwrap();
+        }
+        message
+    }
+
+    fn hierarchy_redundancy_to_string(
+        transitive_edges: &[(NodeId, NodeId)],
+        graph: &ScheduleGraph,
+    ) -> String {
+        let mut message = String::from("hierarchy contains redundant edge(s)");
+        for (parent, child) in transitive_edges {
+            writeln!(
+                message,
+                " -- {} `{}` cannot be child of {} `{}`, longer path exists",
+                child.kind(),
+                graph.get_node_name(child),
+                parent.kind(),
+                graph.get_node_name(parent),
+            )
+            .unwrap();
+        }
+        message
+    }
+
+    fn dependency_loop_to_string(node_id: &NodeId, graph: &ScheduleGraph) -> String {
+        format!(
+            "{} `{}` has been told to run before itself",
+            node_id.kind(),
+            graph.get_node_name(node_id)
+        )
+    }
+
+    fn dependency_cycle_to_string(cycles: &[Vec<NodeId>], graph: &ScheduleGraph) -> String {
+        let mut message = format!("schedule has {} before/after cycle(s):\n", cycles.len());
+        for (i, cycle) in cycles.iter().enumerate() {
+            let mut names = cycle.iter().map(|id| (id.kind(), graph.get_node_name(id)));
+            let (first_kind, first_name) = names.next().unwrap();
+            writeln!(
+                message,
+                "cycle {}: {first_kind} `{first_name}` must run before itself",
+                i + 1,
+            )
+            .unwrap();
+            writeln!(message, "{first_kind} `{first_name}`").unwrap();
+            for (kind, name) in names.chain(core::iter::once((first_kind, first_name))) {
+                writeln!(message, " ... which must run before {kind} `{name}`").unwrap();
+            }
+            writeln!(message).unwrap();
+        }
+        message
+    }
+
+    fn cross_dependency_to_string(a: &NodeId, b: &NodeId, graph: &ScheduleGraph) -> String {
+        format!(
+            "{} `{}` and {} `{}` have both `in_set` and `before`-`after` relationships (these might be transitive). \
+            This combination is unsolvable as a system cannot run before or after a set it belongs to.",
+            a.kind(),
+            graph.get_node_name(a),
+            b.kind(),
+            graph.get_node_name(b)
+        )
+    }
+
+    fn sets_have_order_but_intersect_to_string(
+        a: &SystemSetKey,
+        b: &SystemSetKey,
+        graph: &ScheduleGraph,
+    ) -> String {
+        format!(
+            "`{}` and `{}` have a `before`-`after` relationship (which may be transitive) but share systems.",
+            graph.get_node_name(&NodeId::Set(*a)),
+            graph.get_node_name(&NodeId::Set(*b)),
+        )
+    }
+
+    fn system_type_set_ambiguity_to_string(set: &SystemSetKey, graph: &ScheduleGraph) -> String {
+        let name = graph.get_node_name(&NodeId::Set(*set));
+        format!(
+            "Tried to order against `{name}` in a schedule that has more than one `{name}` instance. `{name}` is a \
+            `SystemTypeSet` and cannot be used for ordering if ambiguous. Use a different set without this restriction."
+        )
+    }
+
+    pub(crate) fn ambiguity_to_string(
+        ambiguities: &[(SystemKey, SystemKey, Vec<ComponentId>)],
+        graph: &ScheduleGraph,
+        components: &Components,
+    ) -> String {
+        let n_ambiguities = ambiguities.len();
+        let mut message = format!(
+            "{n_ambiguities} pairs of systems with conflicting data access have indeterminate execution order. \
+            Consider adding `before`, `after`, or `ambiguous_with` relationships between these:\n",
+        );
+        let ambiguities = graph.conflicts_to_string(ambiguities, components);
+        for (name_a, name_b, conflicts) in ambiguities {
+            writeln!(message, " -- {name_a} and {name_b}").unwrap();
+
+            if !conflicts.is_empty() {
+                writeln!(message, "    conflict on: {conflicts:?}").unwrap();
+            } else {
+                // one or both systems must be exclusive
+                let world = core::any::type_name::<World>();
+                writeln!(message, "    conflict on: {world}").unwrap();
+            }
+        }
+        message
+    }
+
+    fn uninitialized_to_string() -> String {
+        String::from("tried to run a schedule before all of its systems have been initialized")
+    }
+}
+
+impl ScheduleBuildWarning {
+    /// Renders the warning as a human-readable string with node identifiers
+    /// replaced with their names.
+    pub fn to_string(&self, graph: &ScheduleGraph, world: &World) -> String {
+        match self {
+            ScheduleBuildWarning::HierarchyRedundancy(transitive_edges) => {
+                ScheduleBuildError::hierarchy_redundancy_to_string(transitive_edges, graph)
+            }
+            ScheduleBuildWarning::Ambiguity(ambiguities) => {
+                ScheduleBuildError::ambiguity_to_string(ambiguities, graph, world.components())
+            }
+        }
+    }
+}

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -3,6 +3,7 @@
 mod auto_insert_apply_deferred;
 mod condition;
 mod config;
+mod error;
 mod executor;
 mod node;
 mod pass;
@@ -12,7 +13,7 @@ mod stepping;
 
 pub use self::graph::GraphInfo;
 use self::graph::*;
-pub use self::{condition::*, config::*, executor::*, node::*, schedule::*, set::*};
+pub use self::{condition::*, config::*, error::*, executor::*, node::*, schedule::*, set::*};
 pub use pass::ScheduleBuildPass;
 
 /// An implementation of a graph data structure.
@@ -1130,11 +1131,9 @@ mod tests {
             ));
 
             schedule.graph_mut().initialize(&mut world);
-            let _ = schedule.graph_mut().build_schedule(
-                &mut world,
-                TestSchedule.intern(),
-                &BTreeSet::new(),
-            );
+            let _ = schedule
+                .graph_mut()
+                .build_schedule(&mut world, &BTreeSet::new());
 
             let ambiguities: Vec<_> = schedule
                 .graph()
@@ -1190,11 +1189,9 @@ mod tests {
 
             let mut world = World::new();
             schedule.graph_mut().initialize(&mut world);
-            let _ = schedule.graph_mut().build_schedule(
-                &mut world,
-                TestSchedule.intern(),
-                &BTreeSet::new(),
-            );
+            let _ = schedule
+                .graph_mut()
+                .build_schedule(&mut world, &BTreeSet::new());
 
             let ambiguities: Vec<_> = schedule
                 .graph()

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -702,7 +702,9 @@ mod tests {
             let result = schedule.initialize(&mut world);
             assert!(matches!(
                 result,
-                Err(ScheduleBuildError::HierarchyRedundancy(_))
+                Err(ScheduleBuildError::Elevated(
+                    ScheduleBuildWarning::HierarchyRedundancy(_)
+                ))
             ));
         }
 
@@ -764,7 +766,12 @@ mod tests {
 
             schedule.add_systems((res_ref, res_mut));
             let result = schedule.initialize(&mut world);
-            assert!(matches!(result, Err(ScheduleBuildError::Ambiguity(_))));
+            assert!(matches!(
+                result,
+                Err(ScheduleBuildError::Elevated(
+                    ScheduleBuildWarning::Ambiguity(_)
+                ))
+            ));
         }
     }
 

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -332,6 +332,7 @@ pub struct Schedule {
     executable: SystemSchedule,
     executor: Box<dyn SystemExecutor>,
     executor_initialized: bool,
+    warnings: Vec<ScheduleBuildWarning>,
 }
 
 #[derive(ScheduleLabel, Hash, PartialEq, Eq, Debug, Clone)]
@@ -356,6 +357,7 @@ impl Schedule {
             executable: SystemSchedule::new(),
             executor: make_executor(ExecutorKind::default()),
             executor_initialized: false,
+            warnings: Vec::new(),
         };
         // Call `set_build_settings` to add any default build passes
         this.set_build_settings(Default::default());
@@ -476,8 +478,13 @@ impl Schedule {
         let _span = info_span!("schedule", name = ?self.label).entered();
 
         world.check_change_ticks();
-        self.initialize(world)
-            .unwrap_or_else(|e| panic!("Error when initializing schedule {:?}: {e}", self.label));
+        self.initialize(world).unwrap_or_else(|e| {
+            panic!(
+                "Error when initializing schedule {:?}: {}",
+                self.label,
+                e.to_string(self.graph(), world)
+            )
+        });
 
         let error_handler = world.default_error_handler();
 
@@ -512,12 +519,16 @@ impl Schedule {
                 .get_resource_or_init::<Schedules>()
                 .ignored_scheduling_ambiguities
                 .clone();
-            self.graph.update_schedule(
-                world,
-                &mut self.executable,
-                &ignored_ambiguities,
-                self.label,
-            )?;
+            self.warnings =
+                self.graph
+                    .update_schedule(world, &mut self.executable, &ignored_ambiguities)?;
+            for warning in &self.warnings {
+                warn!(
+                    "{:?} schedule built successfully, however: {}",
+                    self.label,
+                    warning.to_string(&self.graph, world)
+                );
+            }
             self.graph.changed = false;
             self.executor_initialized = false;
         }
@@ -611,6 +622,12 @@ impl Schedule {
         } else {
             self.executable.systems.len()
         }
+    }
+
+    /// Returns warnings that were generated during the last call to
+    /// [`Schedule::initialize`].
+    pub fn warnings(&self) -> &[ScheduleBuildWarning] {
+        &self.warnings
     }
 }
 
@@ -949,7 +966,9 @@ impl ScheduleGraph {
         self.system_sets.initialize(world);
     }
 
-    /// Build a [`SystemSchedule`] optimized for scheduler access from the [`ScheduleGraph`].
+    /// Builds an execution-optimized [`SystemSchedule`] from the current state
+    /// of the graph. Also returns any warnings that were generated during the
+    /// build process.
     ///
     /// This method also
     /// - checks for dependency or hierarchy cycles
@@ -957,15 +976,20 @@ impl ScheduleGraph {
     pub fn build_schedule(
         &mut self,
         world: &mut World,
-        schedule_label: InternedScheduleLabel,
         ignored_ambiguities: &BTreeSet<ComponentId>,
-    ) -> Result<SystemSchedule, ScheduleBuildError> {
+    ) -> Result<(SystemSchedule, Vec<ScheduleBuildWarning>), ScheduleBuildError> {
+        let mut warnings = Vec::new();
+
         // check hierarchy for cycles
         self.hierarchy.topsort =
             self.topsort_graph(&self.hierarchy.graph, ReportCycles::Hierarchy)?;
 
         let hier_results = check_graph(&self.hierarchy.graph, &self.hierarchy.topsort);
-        self.optionally_check_hierarchy_conflicts(&hier_results.transitive_edges, schedule_label)?;
+        if let Some(warning) =
+            self.optionally_check_hierarchy_conflicts(&hier_results.transitive_edges)?
+        {
+            warnings.push(warning);
+        }
 
         // remove redundant edges
         self.hierarchy.graph = hier_results.transitive_reduction;
@@ -1019,11 +1043,16 @@ impl ScheduleGraph {
             &ambiguous_with_flattened,
             ignored_ambiguities,
         );
-        self.optionally_check_conflicts(&conflicting_systems, world.components(), schedule_label)?;
+        if let Some(warning) = self.optionally_check_conflicts(&conflicting_systems)? {
+            warnings.push(warning);
+        }
         self.conflicting_systems = conflicting_systems;
 
         // build the schedule
-        Ok(self.build_schedule_inner(dependency_flattened_dag, hier_results.reachable))
+        Ok((
+            self.build_schedule_inner(dependency_flattened_dag, hier_results.reachable),
+            warnings,
+        ))
     }
 
     /// Return a map from system set `NodeId` to a list of system `NodeId`s that are included in the set.
@@ -1309,8 +1338,7 @@ impl ScheduleGraph {
         world: &mut World,
         schedule: &mut SystemSchedule,
         ignored_ambiguities: &BTreeSet<ComponentId>,
-        schedule_label: InternedScheduleLabel,
-    ) -> Result<(), ScheduleBuildError> {
+    ) -> Result<Vec<ScheduleBuildWarning>, ScheduleBuildError> {
         if !self.systems.is_initialized() || !self.system_sets.is_initialized() {
             return Err(ScheduleBuildError::Uninitialized);
         }
@@ -1334,7 +1362,8 @@ impl ScheduleGraph {
             *self.system_sets.get_conditions_mut(key).unwrap() = conditions;
         }
 
-        *schedule = self.build_schedule(world, schedule_label, ignored_ambiguities)?;
+        let (new_schedule, warnings) = self.build_schedule(world, ignored_ambiguities)?;
+        *schedule = new_schedule;
 
         // move systems into new schedule
         for &key in &schedule.system_ids {
@@ -1349,7 +1378,7 @@ impl ScheduleGraph {
             schedule.set_conditions.push(conditions);
         }
 
-        Ok(())
+        Ok(warnings)
     }
 }
 
@@ -1392,7 +1421,13 @@ pub enum ReportCycles {
 
 // methods for reporting errors
 impl ScheduleGraph {
-    fn get_node_name(&self, id: &NodeId) -> String {
+    /// Returns the name of the node with the given [`NodeId`]. Resolves
+    /// anonymous sets to a string that describes their contents.
+    ///
+    /// Also displays the set(s) the node is contained in if
+    /// [`ScheduleBuildSettings::report_sets`] is true, and shortens system names
+    /// if [`ScheduleBuildSettings::use_shortnames`] is true.
+    pub fn get_node_name(&self, id: &NodeId) -> String {
         self.get_node_name_inner(id, self.settings.report_sets)
     }
 
@@ -1448,40 +1483,19 @@ impl ScheduleGraph {
     fn optionally_check_hierarchy_conflicts(
         &self,
         transitive_edges: &[(NodeId, NodeId)],
-        schedule_label: InternedScheduleLabel,
-    ) -> Result<(), ScheduleBuildError> {
-        if self.settings.hierarchy_detection == LogLevel::Ignore || transitive_edges.is_empty() {
-            return Ok(());
+    ) -> Result<Option<ScheduleBuildWarning>, ScheduleBuildError> {
+        match (
+            self.settings.hierarchy_detection,
+            !transitive_edges.is_empty(),
+        ) {
+            (LogLevel::Warn, true) => Ok(Some(ScheduleBuildWarning::HierarchyRedundancy(
+                transitive_edges.to_vec(),
+            ))),
+            (LogLevel::Error, true) => Err(ScheduleBuildError::HierarchyRedundancy(
+                transitive_edges.to_vec(),
+            )),
+            _ => Ok(None),
         }
-
-        let message = self.get_hierarchy_conflicts_error_message(transitive_edges);
-        match self.settings.hierarchy_detection {
-            LogLevel::Ignore => unreachable!(),
-            LogLevel::Warn => {
-                error!("Schedule {schedule_label:?} has redundant edges:\n {message}");
-                Ok(())
-            }
-            LogLevel::Error => Err(ScheduleBuildError::HierarchyRedundancy(message)),
-        }
-    }
-
-    fn get_hierarchy_conflicts_error_message(
-        &self,
-        transitive_edges: &[(NodeId, NodeId)],
-    ) -> String {
-        let mut message = String::from("hierarchy contains redundant edge(s)");
-        for (parent, child) in transitive_edges {
-            writeln!(
-                message,
-                " -- {} `{}` cannot be child of set `{}`, longer path exists",
-                child.kind(),
-                self.get_node_name(child),
-                self.get_node_name(parent),
-            )
-            .unwrap();
-        }
-
-        message
     }
 
     /// Tries to topologically sort `graph`.
@@ -1501,10 +1515,9 @@ impl ScheduleGraph {
         // Check explicitly for self-edges.
         // `iter_sccs` won't report them as cycles because they still form components of one node.
         if let Some((node, _)) = graph.all_edges().find(|(left, right)| left == right) {
-            let name = self.get_node_name(&node.into());
             let error = match report {
-                ReportCycles::Hierarchy => ScheduleBuildError::HierarchyLoop(name),
-                ReportCycles::Dependency => ScheduleBuildError::DependencyLoop(name),
+                ReportCycles::Hierarchy => ScheduleBuildError::HierarchyLoop(node.into()),
+                ReportCycles::Dependency => ScheduleBuildError::DependencyLoop(node.into()),
             };
             return Err(error);
         }
@@ -1535,67 +1548,21 @@ impl ScheduleGraph {
 
             let error = match report {
                 ReportCycles::Hierarchy => ScheduleBuildError::HierarchyCycle(
-                    self.get_hierarchy_cycles_error_message(&cycles),
+                    cycles
+                        .into_iter()
+                        .map(|c| c.into_iter().map(Into::into).collect())
+                        .collect(),
                 ),
                 ReportCycles::Dependency => ScheduleBuildError::DependencyCycle(
-                    self.get_dependency_cycles_error_message(&cycles),
+                    cycles
+                        .into_iter()
+                        .map(|c| c.into_iter().map(Into::into).collect())
+                        .collect(),
                 ),
             };
 
             Err(error)
         }
-    }
-
-    /// Logs details of cycles in the hierarchy graph.
-    fn get_hierarchy_cycles_error_message<N: GraphNodeId + Into<NodeId>>(
-        &self,
-        cycles: &[Vec<N>],
-    ) -> String {
-        let mut message = format!("schedule has {} in_set cycle(s):\n", cycles.len());
-        for (i, cycle) in cycles.iter().enumerate() {
-            let mut names = cycle.iter().map(|&id| self.get_node_name(&id.into()));
-            let first_name = names.next().unwrap();
-            writeln!(
-                message,
-                "cycle {}: set `{first_name}` contains itself",
-                i + 1,
-            )
-            .unwrap();
-            writeln!(message, "set `{first_name}`").unwrap();
-            for name in names.chain(core::iter::once(first_name)) {
-                writeln!(message, " ... which contains set `{name}`").unwrap();
-            }
-            writeln!(message).unwrap();
-        }
-
-        message
-    }
-
-    /// Logs details of cycles in the dependency graph.
-    fn get_dependency_cycles_error_message<N: GraphNodeId + Into<NodeId>>(
-        &self,
-        cycles: &[Vec<N>],
-    ) -> String {
-        let mut message = format!("schedule has {} before/after cycle(s):\n", cycles.len());
-        for (i, cycle) in cycles.iter().enumerate() {
-            let mut names = cycle
-                .iter()
-                .map(|&id| (id.into().kind(), self.get_node_name(&id.into())));
-            let (first_kind, first_name) = names.next().unwrap();
-            writeln!(
-                message,
-                "cycle {}: {first_kind} `{first_name}` must run before itself",
-                i + 1,
-            )
-            .unwrap();
-            writeln!(message, "{first_kind} `{first_name}`").unwrap();
-            for (kind, name) in names.chain(core::iter::once((first_kind, first_name))) {
-                writeln!(message, " ... which must run before {kind} `{name}`").unwrap();
-            }
-            writeln!(message).unwrap();
-        }
-
-        message
     }
 
     fn check_for_cross_dependencies(
@@ -1606,9 +1573,7 @@ impl ScheduleGraph {
         for &(a, b) in &dep_results.connected {
             if hier_results_connected.contains(&(a, b)) || hier_results_connected.contains(&(b, a))
             {
-                let name_a = self.get_node_name(&a);
-                let name_b = self.get_node_name(&b);
-                return Err(ScheduleBuildError::CrossDependency(name_a, name_b));
+                return Err(ScheduleBuildError::CrossDependency(a, b));
             }
         }
 
@@ -1621,19 +1586,16 @@ impl ScheduleGraph {
         set_system_sets: &HashMap<SystemSetKey, HashSet<SystemKey>>,
     ) -> Result<(), ScheduleBuildError> {
         // check that there is no ordering between system sets that intersect
-        for (a, b) in dep_results_connected {
+        for &(a, b) in dep_results_connected {
             let (NodeId::Set(a_key), NodeId::Set(b_key)) = (a, b) else {
                 continue;
             };
 
-            let a_systems = set_system_sets.get(a_key).unwrap();
-            let b_systems = set_system_sets.get(b_key).unwrap();
+            let a_systems = set_system_sets.get(&a_key).unwrap();
+            let b_systems = set_system_sets.get(&b_key).unwrap();
 
             if !a_systems.is_disjoint(b_systems) {
-                return Err(ScheduleBuildError::SetsHaveOrderButIntersect(
-                    self.get_node_name(a),
-                    self.get_node_name(b),
-                ));
+                return Err(ScheduleBuildError::SetsHaveOrderButIntersect(a_key, b_key));
             }
         }
 
@@ -1659,9 +1621,7 @@ impl ScheduleGraph {
                     .edges_directed(NodeId::Set(key), Outgoing);
                 let relations = before.count() + after.count() + ambiguous_with.count();
                 if instances > 1 && relations > 0 {
-                    return Err(ScheduleBuildError::SystemTypeSetAmbiguity(
-                        self.get_node_name(&NodeId::Set(key)),
-                    ));
+                    return Err(ScheduleBuildError::SystemTypeSetAmbiguity(key));
                 }
             }
         }
@@ -1672,49 +1632,12 @@ impl ScheduleGraph {
     fn optionally_check_conflicts(
         &self,
         conflicts: &[(SystemKey, SystemKey, Vec<ComponentId>)],
-        components: &Components,
-        schedule_label: InternedScheduleLabel,
-    ) -> Result<(), ScheduleBuildError> {
-        if self.settings.ambiguity_detection == LogLevel::Ignore || conflicts.is_empty() {
-            return Ok(());
+    ) -> Result<Option<ScheduleBuildWarning>, ScheduleBuildError> {
+        match (self.settings.ambiguity_detection, !conflicts.is_empty()) {
+            (LogLevel::Warn, true) => Ok(Some(ScheduleBuildWarning::Ambiguity(conflicts.to_vec()))),
+            (LogLevel::Error, true) => Err(ScheduleBuildError::Ambiguity(conflicts.to_vec())),
+            _ => Ok(None),
         }
-
-        let message = self.get_conflicts_error_message(conflicts, components);
-        match self.settings.ambiguity_detection {
-            LogLevel::Ignore => Ok(()),
-            LogLevel::Warn => {
-                warn!("Schedule {schedule_label:?} has ambiguities.\n{message}");
-                Ok(())
-            }
-            LogLevel::Error => Err(ScheduleBuildError::Ambiguity(message)),
-        }
-    }
-
-    fn get_conflicts_error_message(
-        &self,
-        ambiguities: &[(SystemKey, SystemKey, Vec<ComponentId>)],
-        components: &Components,
-    ) -> String {
-        let n_ambiguities = ambiguities.len();
-
-        let mut message = format!(
-                "{n_ambiguities} pairs of systems with conflicting data access have indeterminate execution order. \
-                Consider adding `before`, `after`, or `ambiguous_with` relationships between these:\n",
-            );
-
-        for (name_a, name_b, conflicts) in self.conflicts_to_string(ambiguities, components) {
-            writeln!(message, " -- {name_a} and {name_b}").unwrap();
-
-            if !conflicts.is_empty() {
-                writeln!(message, "    conflict on: {conflicts:?}").unwrap();
-            } else {
-                // one or both systems must be exclusive
-                let world = core::any::type_name::<World>();
-                writeln!(message, "    conflict on: {world}").unwrap();
-            }
-        }
-
-        message
     }
 
     /// convert conflicts to human readable format
@@ -1763,48 +1686,8 @@ impl ScheduleGraph {
     }
 }
 
-/// Category of errors encountered during schedule construction.
-#[derive(Error, Debug)]
-#[non_exhaustive]
-pub enum ScheduleBuildError {
-    /// A system set contains itself.
-    #[error("System set `{0}` contains itself.")]
-    HierarchyLoop(String),
-    /// The hierarchy of system sets contains a cycle.
-    #[error("System set hierarchy contains cycle(s).\n{0}")]
-    HierarchyCycle(String),
-    /// The hierarchy of system sets contains redundant edges.
-    ///
-    /// This error is disabled by default, but can be opted-in using [`ScheduleBuildSettings`].
-    #[error("System set hierarchy contains redundant edges.\n{0}")]
-    HierarchyRedundancy(String),
-    /// A system (set) has been told to run before itself.
-    #[error("System set `{0}` depends on itself.")]
-    DependencyLoop(String),
-    /// The dependency graph contains a cycle.
-    #[error("System dependencies contain cycle(s).\n{0}")]
-    DependencyCycle(String),
-    /// Tried to order a system (set) relative to a system set it belongs to.
-    #[error("`{0}` and `{1}` have both `in_set` and `before`-`after` relationships (these might be transitive). This combination is unsolvable as a system cannot run before or after a set it belongs to.")]
-    CrossDependency(String, String),
-    /// Tried to order system sets that share systems.
-    #[error("`{0}` and `{1}` have a `before`-`after` relationship (which may be transitive) but share systems.")]
-    SetsHaveOrderButIntersect(String, String),
-    /// Tried to order a system (set) relative to all instances of some system function.
-    #[error("Tried to order against `{0}` in a schedule that has more than one `{0}` instance. `{0}` is a `SystemTypeSet` and cannot be used for ordering if ambiguous. Use a different set without this restriction.")]
-    SystemTypeSetAmbiguity(String),
-    /// Systems with conflicting access have indeterminate run order.
-    ///
-    /// This error is disabled by default, but can be opted-in using [`ScheduleBuildSettings`].
-    #[error("Systems with conflicting access have indeterminate run order.\n{0}")]
-    Ambiguity(String),
-    /// Tried to run a schedule before all of its systems have been initialized.
-    #[error("Systems in schedule have not been initialized.")]
-    Uninitialized,
-}
-
 /// Specifies how schedule construction should respond to detecting a certain kind of issue.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum LogLevel {
     /// Occurrences are completely ignored.
     Ignore,

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -1491,9 +1491,9 @@ impl ScheduleGraph {
             (LogLevel::Warn, true) => Ok(Some(ScheduleBuildWarning::HierarchyRedundancy(
                 transitive_edges.to_vec(),
             ))),
-            (LogLevel::Error, true) => Err(ScheduleBuildError::HierarchyRedundancy(
-                transitive_edges.to_vec(),
-            )),
+            (LogLevel::Error, true) => {
+                Err(ScheduleBuildWarning::HierarchyRedundancy(transitive_edges.to_vec()).into())
+            }
             _ => Ok(None),
         }
     }
@@ -1635,7 +1635,9 @@ impl ScheduleGraph {
     ) -> Result<Option<ScheduleBuildWarning>, ScheduleBuildError> {
         match (self.settings.ambiguity_detection, !conflicts.is_empty()) {
             (LogLevel::Warn, true) => Ok(Some(ScheduleBuildWarning::Ambiguity(conflicts.to_vec()))),
-            (LogLevel::Error, true) => Err(ScheduleBuildError::Ambiguity(conflicts.to_vec())),
+            (LogLevel::Error, true) => {
+                Err(ScheduleBuildWarning::Ambiguity(conflicts.to_vec()).into())
+            }
             _ => Ok(None),
         }
     }
@@ -1701,13 +1703,14 @@ pub enum LogLevel {
 #[derive(Clone, Debug)]
 pub struct ScheduleBuildSettings {
     /// Determines whether the presence of ambiguities (systems with conflicting access but indeterminate order)
-    /// is only logged or also results in an [`Ambiguity`](ScheduleBuildError::Ambiguity) error.
+    /// is only logged or also results in an [`Ambiguity`](ScheduleBuildWarning::Ambiguity)
+    /// warning or error.
     ///
     /// Defaults to [`LogLevel::Ignore`].
     pub ambiguity_detection: LogLevel,
     /// Determines whether the presence of redundant edges in the hierarchy of system sets is only
-    /// logged or also results in a [`HierarchyRedundancy`](ScheduleBuildError::HierarchyRedundancy)
-    /// error.
+    /// logged or also results in a [`HierarchyRedundancy`](ScheduleBuildWarning::HierarchyRedundancy)
+    /// warning or error.
     ///
     /// Defaults to [`LogLevel::Warn`].
     pub hierarchy_detection: LogLevel,

--- a/release-content/migration-guides/schedule_cleanup.md
+++ b/release-content/migration-guides/schedule_cleanup.md
@@ -37,6 +37,11 @@ take or return `SystemKey` or `SystemSetKey`. Wrap/unwrap them as necessary.
 - `ScheduleGraph::system_at`: Use `ScheduleGraph::systems` and `Systems::index` (`systems[key]`).
 - `ScheduleGraph::systems`: Use `ScheduleGraph::systems` and `Systems::iter`.
 
+The following enum variants were replaced:
+
+- `ScheduleBuildError::HierarchyRedundancy` with `ScheduleBuildError::Elevated(ScheduleBuildWarning::HierarchyRedundancy)`
+- `ScheduleBuildError::Ambiguity` with `ScheduleBuildError::Elevated(ScheduleBuildWarning::Ambiguity)`
+
 The following functions were removed:
 
 - `NodeId::index`: You should match on and use the `SystemKey` and `SystemSetKey` instead.

--- a/release-content/migration-guides/schedule_cleanup.md
+++ b/release-content/migration-guides/schedule_cleanup.md
@@ -1,6 +1,6 @@
 ---
 title: Schedule API Cleanup
-pull_requests: [19352, 20119, 20172]
+pull_requests: [19352, 20119, 20172, 20256]
 ---
 
 In order to support removing systems from schedules, `Vec`s storing `System`s and
@@ -20,6 +20,10 @@ The following signatures were changed:
 - The following functions now return the type-specific keys. Wrap them back into a `NodeId` if necessary.
   - `Schedule::systems`
   - `ScheduleGraph::conflicting_systems`
+- `ScheduleBuildError` variants now contain `NodeId` or type-specific keys, rather than `String`s.
+  Use `ScheduleBuildError::to_string` to render the nodes' names and get the old error messages.
+- `ScheduleGraph::build_schedule` now returns a `Vec<ScheduleBuildWarning>` in addition to the built
+  `SystemSchedule`. Use standard `Result` functions to grab just the `SystemSchedule`, if needed.
 
 The following functions were replaced. Those that took or returned `NodeId` now
 take or return `SystemKey` or `SystemSetKey`. Wrap/unwrap them as necessary.


### PR DESCRIPTION
# Objective

- Part of #20115

I want to pull out the ad-hoc graph manipulation and analysis functions into generalized reusable functions, but in doing so encounter some borrow-checker issues. This is because the graphs are mutably borrowed during the build process at the points where we need to render warning and error messages (which require full access to the `ScheduleGraph`).

## Solution

So, lets defer message rendering until the consumer actually needs it:
- Replaced `String`s in `ScheduleBuildError` variants with just the `NodeId`/`SystemKey`/`SystemSetKey`.
- Added `ScheduleBuildError::to_string` to render the messages as they were previously.
- Added `ScheduleBuildWarning`, a subset of the error enum of just the possible warnings.
- Collected warnings into a `Vec` and returned them from the build process, caching them in the `Schedule` and made accessible via `Schedule::warnings`. Additionally automatically `warn!()` these warnings after the schedule is built.
- Exposed `ScheduleGraph::get_node_name` so external consumers can do any special rendering themselves.
- Finally, moved `ScheduleBuildError` and `ScheduleBuildWarning` to their own files to help incrementally minimize the large `schedule.rs` module.

## Testing

Reusing current tests.