### PR TITLE
Fix observers' access to relationship data during `despawn_related`

### DIFF
--- a/crates/bevy_ecs/src/relationship/related_methods.rs
+++ b/crates/bevy_ecs/src/relationship/related_methods.rs
@@ -300,6 +300,8 @@ impl<'w> EntityWorldMut<'w> {
     /// This entity will not be despawned.
     pub fn despawn_related<S: RelationshipTarget>(&mut self) -> &mut Self {
         if let Some(sources) = self.get::<S>() {
+            // We have to collect here to defer removal, allowing observers and hooks to see this data
+            // before it is finally removed.
             let sources = sources.iter().collect::<Vec<_>>();
             self.world_scope(|world| {
                 for entity in sources {


### PR DESCRIPTION
# Objective

- Fix issue where observers cannot access relationship data during `despawn_related`
- Fixes #20106

## Solution

- Changed `despawn_related` to use `get()` instead of `take()` to preserve relationship components during the despawn process
- Collect entities into a vector before despawning to ensure the relationship data remains accessible to observers and hooks

## Testing

- Added test `despawn_related_observers_can_access_relationship_data` that reproduces the issue scenario

