### PR TITLE
Support multiple unnamed fields in relationship derive

### DIFF
--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -968,15 +968,16 @@ fn relationship_field<'a>(
             span,
             format!("{derive} derive expected named structs with a single field or with a field annotated with #[relationship].")
         )),
-        Fields::Unnamed(fields) => fields
-            .unnamed
-            .len()
-            .eq(&1)
-            .then(|| fields.unnamed.first())
-            .flatten()
+        Fields::Unnamed(fields) if fields.unnamed.len() == 1 => Ok(fields.unnamed.first().unwrap()),
+        Fields::Unnamed(fields) => fields.unnamed.iter().find(|field| {
+                field
+                    .attrs
+                    .iter()
+                    .any(|attr| attr.path().is_ident(RELATIONSHIP))
+            })
             .ok_or(syn::Error::new(
                 span,
-                format!("{derive} derive expected unnamed structs with one field."),
+                format!("{derive} derive expected unnamed structs with one field or with a field annotated with #[relationship]."),
             )),
         Fields::Unit => Err(syn::Error::new(
             span,

--- a/crates/bevy_ecs/src/relationship/mod.rs
+++ b/crates/bevy_ecs/src/relationship/mod.rs
@@ -465,6 +465,8 @@ impl RelationshipTargetCloneBehaviorHierarchy
 
 #[cfg(test)]
 mod tests {
+    use core::marker::PhantomData;
+
     use crate::prelude::{ChildOf, Children};
     use crate::world::World;
     use crate::{component::Component, entity::Entity};
@@ -555,6 +557,19 @@ mod tests {
             foo: u8,
             bar: u8,
         }
+
+        // No assert necessary, looking to make sure compilation works with the macros
+    }
+
+    #[test]
+    fn relationship_with_multiple_unnamed_non_target_fields_compiles() {
+        #[derive(Component)]
+        #[relationship(relationship_target=Target<T>)]
+        struct Source<T: Send + Sync + 'static>(#[relationship] Entity, PhantomData<T>);
+
+        #[derive(Component)]
+        #[relationship_target(relationship=Source<T>)]
+        struct Target<T: Send + Sync + 'static>(#[relationship] Vec<Entity>, PhantomData<T>);
 
         // No assert necessary, looking to make sure compilation works with the macros
     }


### PR DESCRIPTION
# Objective

- Relationship derives support structs with multiple named fields thanks to the #[relationship] attribute.
- They don't however support structs with multiple unnamed fields, so this code would fail:
```rust
#[derive(Component, Debug)]
#[relationship(relationship_target = TargetedByGeneric<T>)]
struct Targeting<T: Send + Sync + 'static>(#[relationship] Entity, PhantomData<T>);

#[derive(Component, Debug)]
#[relationship_target(relationship = TargetingGeneric<T>)]
struct TargetedBy<T: Send + Sync + 'static>(#[relationship] Vec<Entity>, PhantomData<T>);
```

## Solution

- Reuse the same logic as for named fields, but for unnamed fields

## Testing

- Trivial