### PR TITLE
Sync UI children on `Node` addition

### DIFF
--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -79,7 +79,7 @@ pub fn ui_layout_system(
         Option<&mut ContentSize>,
         Ref<ComputedNodeTarget>,
     )>,
-    computed_node_query: Query<(Entity, Option<Ref<ChildOf>>), With<ComputedNode>>,
+    computed_node_query: Query<(Entity, Ref<Node>, Option<Ref<ChildOf>>), With<ComputedNode>>,
     ui_children: UiChildren,
     mut node_update_query: Query<(
         &mut ComputedNode,
@@ -128,7 +128,7 @@ pub fn ui_layout_system(
 
     computed_node_query
         .iter()
-        .for_each(|(entity, maybe_child_of)| {
+        .for_each(|(entity, node, maybe_child_of)| {
             if let Some(child_of) = maybe_child_of {
                 // Note: This does not cover the case where a parent's Node component was removed.
                 // Users are responsible for fixing hierarchies if they do that (it is not recommended).
@@ -141,7 +141,7 @@ with UI components as a child of an entity without UI components, your UI layout
                 }
             }
 
-            if ui_children.is_changed(entity) {
+            if node.is_added() || ui_children.is_changed(entity) {
                 ui_surface.update_children(entity, ui_children.iter_ui_children(entity));
             }
         });
@@ -154,8 +154,8 @@ with UI components as a child of an entity without UI components, your UI layout
     );
 
     // Re-sync changed children: avoid layout glitches caused by removed nodes that are still set as a child of another node
-    computed_node_query.iter().for_each(|(entity, _)| {
-        if ui_children.is_changed(entity) {
+    computed_node_query.iter().for_each(|(entity, node, _)| {
+        if node.is_added() || ui_children.is_changed(entity) {
             ui_surface.update_children(entity, ui_children.iter_ui_children(entity));
         }
     });
@@ -647,6 +647,27 @@ mod tests {
         let ui_surface = world.resource::<UiSurface>();
         assert!(ui_surface.entity_to_taffy.contains_key(&ui_entity));
         assert_eq!(ui_surface.entity_to_taffy.len(), 1);
+    }
+
+    #[test]
+    fn node_addition_should_sync_children() {
+        let (mut world, mut ui_schedule) = setup_ui_test_world();
+
+        // spawn an invalid UI root node
+        let root_node = world.spawn(()).with_child(Node::default()).id();
+
+        ui_schedule.run(&mut world);
+
+        // fix the invalid root node by inserting a Node
+        world.entity_mut(root_node).insert(Node::default());
+
+        ui_schedule.run(&mut world);
+
+        let ui_surface = world.resource_mut::<UiSurface>();
+        let taffy_root = ui_surface.entity_to_taffy[&root_node];
+
+        // There should be one child of the root node after fixing it
+        assert_eq!(ui_surface.taffy.child_count(taffy_root.id), 1);
     }
 
     /// regression test for >=0.13.1 root node layouts


### PR DESCRIPTION
# Objective
For context:
> Yeah it seems like it would be a `bevy_ui` issue, which just becomes easy to hit since `spawn_scene` is deferred. You end up with an invalid (has non-Node parent) Node until the scene is resolved and spawned. And it seems like the UI systems can’t handle the parent adding Node, making the child valid
https://discord.com/channels/691052431525675048/1264881140007702558/1397443915900256338

- The UI layout systems do not take node addition into account when deciding to sync children
- Multiple people have encountered this when evaluating the BSN draft PR which involves spawning scenes asynchronously.

## Solution

- Added a check for `node.is_added()` alongside the `children.ui_children.is_changed()` check

## Testing

- Added a new test case: `node_addition_should_sync_children`
---
