### PR TITLE
Improve `bevy_a11y` docs

### DIFF
--- a/crates/bevy_a11y/src/lib.rs
+++ b/crates/bevy_a11y/src/lib.rs
@@ -6,7 +6,7 @@
 )]
 #![no_std]
 
-//! Accessibility for Bevy
+//! Reusable accessibility primitives
 //!
 //! As of Bevy version 0.15 `accesskit` is no longer re-exported from this crate.
 //!

--- a/crates/bevy_a11y/src/lib.rs
+++ b/crates/bevy_a11y/src/lib.rs
@@ -8,11 +8,55 @@
 
 //! Reusable accessibility primitives
 //!
-//! As of Bevy version 0.15 `accesskit` is no longer re-exported from this crate.
+//! This crate provides accessibility integration for the engine. It exposes the
+//! [`AccessibilityPlugin`]. This plugin integrates `AccessKit`, a Rust crate
+//! providing OS-agonstic accessibility primitives, with Bevy's ECS.
 //!
-//! If you need to use `accesskit`, you will need to add it as a separate dependency in your `Cargo.toml`.
+//! ## Some notes on utility
 //!
-//! Make sure to use the same version of `accesskit` as Bevy.
+//! While this crate defines useful types for accessibility, it does not
+//! actually power accessibility features in Bevy.
+//!
+//! Instead, it helps other interfaces coordinate their approach to
+//! accessibility. Binary authors should add the [`AccessibilityPlugin`], while
+//! library maintainers may use the [`AccessibilityRequested`] and
+//! [`ManageAccessibilityUpdates`] resources.
+//!
+//! The [`AccessibilityNode`] component is useful in both cases. It helps
+//! describe an entity in terms of its accessibility factors through an
+//! `AccessKit` "node".
+//!
+//! Typical UI concepts, like buttons, checkboxes, and textboxes, are easily
+//! described by this component, though, technically, it can represent any kind
+//! of Bevy [`Entity`].
+//!
+//! ## This crate no longer re-exports `AccessKit`
+//!
+//! As of Bevy version 0.15, [the `accesskit` crate][accesskit_crate] is no
+//! longer re-exported from this crate.[^accesskit_node_confusion] If you need
+//! to use `AccessKit` yourself, you'll have to add it as a separate dependency
+//! in your project's `Cargo.toml`.
+//!
+//! Make sure to use the same version of the `accesskit` crate as Bevy.
+//! Otherwise, you may experience errors similar to: "Perhaps two different
+//! versions of crate `accesskit` are being used?"
+//!
+//! [accesskit_crate]: https://crates.io/crates/accesskit
+//! [`Entity`]: bevy_ecs::entity::Entity
+//!
+//! <!--
+//! note: multi-line footnotes need to be indented like this!
+//!
+//! please do not remove the indentation, or the second paragraph will display
+//! at the end of the module docs, **before** the footnotes...
+//! -->
+//!
+//! [^accesskit_node_confusion]: Some users were confused about `AccessKit`'s
+//!  `Node` type, sometimes thinking it was Bevy UI's primary way to define
+//!  nodes!
+//!
+//!     For this reason, its re-export was removed by default. Users who need
+//!     its types can instead manually depend on the `accesskit` crate.
 
 #[cfg(feature = "std")]
 extern crate std;


### PR DESCRIPTION
The documentation for this crate has always been a bit scarce.

I did my best at adding some additional context and explanations to the module. 

## Changes

Here's a lil summary of what I did:

- Change the module's headline/header to say: "Reusable accessibility primitives"
    - This could help newer users understand what the crate does, particularly when seeing it in the "modules" list in the top-level `bevy` crate.
    - In the `bevy` crate's modules list, it'll appear like:
    	- `a11y`: Reusable accessibility primitives
    - If you have a better idea for it, please feel free to suggest it here!
- Add more mod-level documentation
	- I wanted to make it more clear to users when/where they'd use this module.
	- Also, it's nice to know _why_ the `accesskit` re-export was removed, so I added that in as a footnote.
- Gave a visual, ultra-clear explainer on `AccessibilityNode`, stating that `AccessKit`'s tree is NOT Bevy's ECS
- Improve clarity on ty-level docs
	- Mostly helps to say why each type exists.
- Also snuck in some basic grammar improvements... when useful.

## For Reviewers

A quick fact-check of the new docs would be really helpful. If anything is unclear, questionable, or just plain incorrect, please let me know so I can fix it. :)

Thank you!