### PR TITLE
UI material z-offset override

### DIFF
--- a/crates/bevy_ui_render/src/ui_material.rs
+++ b/crates/bevy_ui_render/src/ui_material.rs
@@ -110,6 +110,10 @@ pub trait UiMaterial: AsBindGroup + Asset + Clone + Sized {
         ShaderRef::Default
     }
 
+    fn stack_z_offset() -> f32 {
+        crate::stack_z_offsets::MATERIAL
+    }
+
     #[expect(
         unused_variables,
         reason = "The parameters here are intentionally unused by the default implementation; however, putting underscores here will result in the underscores being copied by rust-analyzer's tab completion."

--- a/crates/bevy_ui_render/src/ui_material_pipeline.rs
+++ b/crates/bevy_ui_render/src/ui_material_pipeline.rs
@@ -625,7 +625,7 @@ pub fn queue_ui_material_nodes<M: UiMaterial>(
             draw_function,
             pipeline,
             entity: (extracted_uinode.render_entity, extracted_uinode.main_entity),
-            sort_key: FloatOrd(extracted_uinode.stack_index as f32 + stack_z_offsets::MATERIAL),
+            sort_key: FloatOrd(extracted_uinode.stack_index as f32 + M::stack_z_offset()),
             batch_range: 0..0,
             extra_index: PhaseItemExtraIndex::None,
             index,


### PR DESCRIPTION
# Objective

In #20237 the swatch implementation uses a child node to display the foreground color because UI materials are drawn on top of everything else.

## Solution

Add a `stack_z_offset` function to the `UiMaterial` trait that can be overriden to set a custom z-offset.