### PR TITLE
document Spotlight shadow map sizing

### DIFF
--- a/crates/bevy_light/src/directional_light.rs
+++ b/crates/bevy_light/src/directional_light.rs
@@ -169,7 +169,7 @@ pub struct DirectionalLightTexture {
     pub tiled: bool,
 }
 
-/// Controls the resolution of [`DirectionalLight`] shadow maps.
+/// Controls the resolution of [`DirectionalLight`] and [`SpotLight`](crate::SpotLight) shadow maps.
 ///
 /// ```
 /// # use bevy_app::prelude::*;


### PR DESCRIPTION
This resource controls both, but its not documented. Document it