### PR TITLE
Add method World::run_command

### DIFF
--- a/crates/bevy_ecs/src/system/commands/command.rs
+++ b/crates/bevy_ecs/src/system/commands/command.rs
@@ -245,3 +245,10 @@ pub fn write_event<E: BufferedEvent>(event: E) -> impl Command {
 pub fn send_event<E: BufferedEvent>(event: E) -> impl Command {
     write_event(event)
 }
+
+impl World {
+    /// Runs the given [`Command`] immediately.
+    pub fn run_command<C: Command<Out>, Out>(&mut self, command: C) -> Out {
+        command.apply(self)
+    }
+}

--- a/crates/bevy_ecs/src/system/commands/entity_command.rs
+++ b/crates/bevy_ecs/src/system/commands/entity_command.rs
@@ -342,3 +342,10 @@ pub fn log_components() -> impl EntityCommand {
         info!("Entity {}: {debug_infos:?}", entity.id());
     }
 }
+
+impl EntityWorldMut<'_> {
+    /// Runs the given [`EntityCommand`] immediately.
+    pub fn run_command<C: EntityCommand<Out>, Out>(self, entity_command: C) -> Out {
+        entity_command.apply(self)
+    }
+}

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -2391,8 +2391,8 @@ mod tests {
     use crate::{
         component::Component,
         resource::Resource,
-        system::Commands,
-        world::{CommandQueue, FromWorld, World},
+        system::{command, Commands, EntityCommand},
+        world::{CommandQueue, EntityWorldMut, FromWorld, World},
     };
     use alloc::{string::String, sync::Arc, vec, vec::Vec};
     use core::{
@@ -2802,5 +2802,28 @@ mod tests {
             Some(expected),
             world.entities().entity_get_spawned_or_despawned_at(id)
         );
+    }
+
+    #[test]
+    fn world_run_command() {
+        let mut world = World::new();
+        world.run_command(command::insert_resource(W(0u32)));
+        assert!(world.get_resource::<W<u32>>().is_some());
+    }
+
+    #[test]
+    fn entity_run_command() {
+        struct InsertW(u32);
+        impl EntityCommand for InsertW {
+            fn apply(self, mut entity: EntityWorldMut) {
+                entity.insert(W(self.0));
+            }
+        }
+
+        let mut world = World::new();
+        let entity = world.spawn_empty();
+        let id = entity.id();
+        entity.run_command(InsertW(0));
+        assert!(world.get::<W<u32>>(id).is_some());
     }
 }


### PR DESCRIPTION
Applying a `Command` with `World` access is now done as
```Rust
my_command.apply(world);
```
I would say it feels more natural to think of the `World` running the `Command` instead of the `Command` being applied to the `World`. It also reads better to write
```Rust
world.run_command(my_command)
```
It might feel redundant here but in practice commands are often verbs and don't include the word command.

This PR offers that wrapper method. While we're at it, it adds a similar version for `EntityWorldMut` with respect to `EntityCommand`.

## Testing

Added two simple tests but maybe they are unnecessary.