### PR TITLE
Remove systems from schedule

### DIFF
--- a/crates/bevy_ecs/src/schedule/error.rs
+++ b/crates/bevy_ecs/src/schedule/error.rs
@@ -259,3 +259,14 @@ impl ScheduleBuildWarning {
         }
     }
 }
+
+/// Error returned from some `Schedule` methods
+#[derive(Error, Debug)]
+pub enum ScheduleError {
+    /// Operation cannot be completed because the schedule has changed and `Schedule::initialize` needs to be called
+    #[error("Operation cannot be completed because the schedule has changed and `Schedule::initialize` needs to be called")]
+    Uninitialized,
+    /// Method could not find key
+    #[error("Not Found")]
+    NotFound,
+}

--- a/crates/bevy_ecs/src/schedule/node.rs
+++ b/crates/bevy_ecs/src/schedule/node.rs
@@ -554,6 +554,24 @@ impl Systems {
         key
     }
 
+    pub fn remove(&mut self, key: SystemKey) -> bool {
+        let mut found = false;
+        if self.nodes.remove(key).is_some() {
+            found = true;
+        }
+
+        if self.conditions.remove(key).is_some() {
+            found = true;
+        }
+
+        if let Some(index) = self.uninit.iter().position(|value| *value == key) {
+            self.uninit.remove(index);
+            found = true;
+        }
+
+        found
+    }
+
     /// Returns `true` if all systems in this container have been initialized.
     pub fn is_initialized(&self) -> bool {
         self.uninit.is_empty()
@@ -719,6 +737,15 @@ impl SystemSets {
             current_conditions.extend(new_conditions.into_iter().map(ConditionWithAccess::new));
         }
         key
+    }
+
+    pub fn remove(&mut self, key: SystemSetKey) -> bool {
+        self.sets.remove(key);
+        self.conditions.remove(key);
+        if let Some(index) = self.uninit.iter().position(|uninit| uninit.key == key) {
+            self.uninit.remove(index);
+        }
+        true
     }
 
     /// Returns `true` if all system sets' conditions in this container have

--- a/crates/bevy_ecs/src/schedule/node.rs
+++ b/crates/bevy_ecs/src/schedule/node.rs
@@ -554,7 +554,8 @@ impl Systems {
         key
     }
 
-    pub fn remove(&mut self, key: SystemKey) -> bool {
+    /// Remove a system with [`SystemKey`]
+    pub(crate) fn remove(&mut self, key: SystemKey) -> bool {
         let mut found = false;
         if self.nodes.remove(key).is_some() {
             found = true;
@@ -739,7 +740,8 @@ impl SystemSets {
         key
     }
 
-    pub fn remove(&mut self, key: SystemSetKey) -> bool {
+    /// Remove a set with a [`SystemSetKey`]
+    pub(crate) fn remove(&mut self, key: SystemSetKey) -> bool {
         self.sets.remove(key);
         self.conditions.remove(key);
         if let Some(index) = self.uninit.iter().position(|uninit| uninit.key == key) {

--- a/crates/bevy_ecs/src/schedule/node.rs
+++ b/crates/bevy_ecs/src/schedule/node.rs
@@ -646,6 +646,11 @@ impl SystemSets {
         self.sets.get(key).map(|set| &**set)
     }
 
+    /// Returns the kkey for the given system set, returns None if it does not exist.
+    pub fn get_key(&self, set: InternedSystemSet) -> Option<SystemSetKey> {
+        self.ids.get(&set).copied()
+    }
+
     /// Returns the key for the given system set, inserting it into this
     /// container if it does not already exist.
     pub fn get_key_or_insert(&mut self, set: InternedSystemSet) -> SystemSetKey {

--- a/crates/bevy_ecs/src/schedule/node.rs
+++ b/crates/bevy_ecs/src/schedule/node.rs
@@ -493,8 +493,8 @@ impl Systems {
     /// # Panics
     ///
     /// If the system with the given key does not exist in this container.
-    pub(crate) fn node_mut(&mut self, key: SystemKey) -> &mut SystemNode {
-        &mut self.nodes[key]
+    pub(crate) fn node_mut(&mut self, key: SystemKey) -> Option<&mut SystemNode> {
+        self.nodes.get_mut(key)
     }
 
     /// Returns `true` if the system with the given key has conditions.

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -935,7 +935,7 @@ impl ScheduleGraph {
         AnonymousSet::new(id)
     }
 
-    /// Returns iterator over all [`SystemId`]'s in a [SystemSet]
+    /// Returns iterator over all [`SystemKey`]'s in a [`SystemSet`]
     /// Returns `ScheduleBuildError::Uninitialized` if schedule has been changed and `Self::initialize`
     /// has not been called.
     pub fn systems_in_set(

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -1421,7 +1421,6 @@ impl ScheduleGraph {
             .zip(schedule.systems.drain(..))
             .zip(schedule.system_conditions.drain(..))
         {
-            // TODO: change this code to just drop the system and conditions if the key doesn't exist
             if let Some(node) = self.systems.node_mut(key) {
                 node.inner = Some(system);
             }

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -379,11 +379,18 @@ impl Schedule {
         self
     }
 
+    /// Removes all systems in a [`SystemSet`]. This will cause the schedule to be rebuilt when
+    /// the schedule is run again. A [`ScheduleError`] is returned if the schedule needs to be
+    /// [`Schedule::initialize`]'d or the `set` is not found.
+    ///
+    /// Note that this can remove all systems of a type if you pass
+    /// the system to this function as systems implicitly create a set based
+    /// on the system type.
     pub fn remove_systems_in_set<M>(
         &mut self,
         set: impl IntoSystemSet<M>,
     ) -> Result<usize, ScheduleError> {
-        self.graph.remove_systems(set)
+        self.graph.remove_systems_in_set(set)
     }
 
     /// Suppress warnings and errors that would result from systems in these sets having ambiguities
@@ -930,10 +937,8 @@ impl ScheduleGraph {
             .ok_or(ScheduleError::NotFound)
     }
 
-    /// Remove system from schedule. This will cause the schedule to be rebuilt the next time it is run.
-    /// This also removes and dependencies on that system. Use [`systems_in_set`] to get the [`SystemKey`]
-    /// Returns count of the number of systems removed
-    pub fn remove_systems<M>(
+    /// Remove all systems in a set and any dependencies on those systems and set.
+    pub fn remove_systems_in_set<M>(
         &mut self,
         system_set: impl IntoSystemSet<M>,
     ) -> Result<usize, ScheduleError> {


### PR DESCRIPTION
# Objective

- Add ability to remove systems from a schedule.

## Solution

- add `remove_systems_in_set` method which removes all the systems by their set name. In most cases systems are added to a schedule once, so just passing the system (which is an implicit set by it's type name) will just remove the one system. If a system is added multiple times such as `apply_deferred`, then you may need to give the system a unique set, if you just want to remove just one system.
- The method also tries to remove all the configuration for the set and the systems found.
- We need to pass world to the method because user build passes are allowed to write to the world.

## Testing

- Added some unit tests.

## Future work

- In the future of systems as entities this will probably look much different. We'd probably store all the edges as relationships, so hopefully cleanup would be easier.
- It'd be better if remove_systems_in_set could take a tuple of system sets. I looked into using IntoScheduleConfigs, but that won't work since the system set version of it errors if you try to pass a system type set.
