### PR TITLE
minor gen env map cleanups

### DIFF
--- a/crates/bevy_pbr/src/light_probe/environment_map.wgsl
+++ b/crates/bevy_pbr/src/light_probe/environment_map.wgsl
@@ -32,7 +32,6 @@ fn compute_radiances(
     // Unpack.
     let N = input.N;
     let R = input.R;
-    let NdotV = input.NdotV;
     let perceptual_roughness = input.perceptual_roughness;
     let roughness = input.roughness;
 
@@ -111,7 +110,6 @@ fn compute_radiances(
     // Unpack.
     let N = input.N;
     let R = input.R;
-    let NdotV = input.NdotV;
     let perceptual_roughness = input.perceptual_roughness;
     let roughness = input.roughness;
 

--- a/crates/bevy_pbr/src/light_probe/generate.rs
+++ b/crates/bevy_pbr/src/light_probe/generate.rs
@@ -467,9 +467,9 @@ pub fn extract_generated_environment_map_entities(
     render_images: Res<RenderAssets<GpuImage>>,
 ) {
     for (entity, filtered_env_map, env_map_light) in query.iter() {
-        let env_map = render_images
-            .get(&filtered_env_map.environment_map)
-            .expect("Environment map not found");
+        let Some(env_map) = render_images.get(&filtered_env_map.environment_map) else {
+            continue;
+        };
 
         let diffuse_map = render_images.get(&env_map_light.diffuse_map);
         let specular_map = render_images.get(&env_map_light.specular_map);

--- a/examples/3d/reflection_probes.rs
+++ b/examples/3d/reflection_probes.rs
@@ -28,6 +28,8 @@ static START_ROTATION_HELP_TEXT: &str = "Press Enter to start rotation";
 
 static REFLECTION_MODE_HELP_TEXT: &str = "Press Space to switch reflection mode";
 
+const ENV_MAP_INTENSITY: f32 = 5000.0;
+
 // The mode the application is in.
 #[derive(Resource)]
 struct AppStatus {
@@ -154,7 +156,7 @@ fn spawn_reflection_probe(commands: &mut Commands, cubemaps: &Cubemaps) {
         EnvironmentMapLight {
             diffuse_map: cubemaps.diffuse_environment_map.clone(),
             specular_map: cubemaps.specular_reflection_probe.clone(),
-            intensity: 5000.0,
+            intensity: ENV_MAP_INTENSITY,
             ..default()
         },
         // 2.0 because the sphere's radius is 1.0 and we want to fully enclose it.
@@ -190,7 +192,7 @@ fn add_environment_map_to_camera(
             .insert(create_camera_environment_map_light(&cubemaps))
             .insert(Skybox {
                 image: cubemaps.specular_environment_map.clone(),
-                brightness: 5000.0,
+                brightness: ENV_MAP_INTENSITY,
                 ..default()
             });
     }
@@ -253,9 +255,7 @@ fn change_reflection_type(
                     .entity(camera)
                     .insert(GeneratedEnvironmentMapLight {
                         environment_map: cubemaps.specular_environment_map.clone(),
-                        // compensate for the energy loss of the reverse tonemapping
-                        // during filtering by using a higher intensity
-                        intensity: 5000.0,
+                        intensity: ENV_MAP_INTENSITY,
                         ..default()
                     });
             }
@@ -328,7 +328,7 @@ fn create_camera_environment_map_light(cubemaps: &Cubemaps) -> EnvironmentMapLig
     EnvironmentMapLight {
         diffuse_map: cubemaps.diffuse_environment_map.clone(),
         specular_map: cubemaps.specular_environment_map.clone(),
-        intensity: 5000.0,
+        intensity: ENV_MAP_INTENSITY,
         ..default()
     }
 }


### PR DESCRIPTION
# Objective

- remove some unused wgsl lines
- dont panic just early out to avoid ordering issues when spawning a generated envmap with a image handle that hasnt loaded/extracted yet
- factor out a constant for envmap intensity in example
- remove outdated comment

## Solution

- do stuff

## Testing

- reflection_probes example