### PR TITLE
Let `BorderColor::all` take `impl Into<Color>` 

### DIFF
--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -2116,10 +2116,17 @@ impl<T: Into<Color>> From<T> for BorderColor {
 
 impl BorderColor {
     /// Border color is transparent by default.
-    pub const DEFAULT: Self = BorderColor::all(Color::NONE);
+    pub const DEFAULT: Self = BorderColor {
+        top: Color::NONE,
+        right: Color::NONE,
+        bottom: Color::NONE,
+        left: Color::NONE,
+    };
 
     /// Helper to create a `BorderColor` struct with all borders set to the given color
-    pub const fn all(color: Color) -> Self {
+    #[inline]
+    pub fn all(color: impl Into<Color>) -> Self {
+        let color = color.into();
         Self {
             top: color,
             bottom: color,

--- a/examples/animation/animation_graph.rs
+++ b/examples/animation/animation_graph.rs
@@ -301,7 +301,7 @@ fn setup_node_rects(commands: &mut Commands) {
                     justify_content: JustifyContent::Center,
                     ..default()
                 },
-                BorderColor::all(WHITE.into()),
+                BorderColor::all(WHITE),
                 Outline::new(Val::Px(1.), Val::ZERO, Color::WHITE),
             ));
 
@@ -355,7 +355,7 @@ fn setup_node_lines(commands: &mut Commands) {
                 border: UiRect::bottom(Val::Px(1.0)),
                 ..default()
             },
-            BorderColor::all(WHITE.into()),
+            BorderColor::all(WHITE),
         ));
     }
 
@@ -370,7 +370,7 @@ fn setup_node_lines(commands: &mut Commands) {
                 border: UiRect::left(Val::Px(1.0)),
                 ..default()
             },
-            BorderColor::all(WHITE.into()),
+            BorderColor::all(WHITE),
         ));
     }
 }

--- a/examples/testbed/full_ui.rs
+++ b/examples/testbed/full_ui.rs
@@ -221,7 +221,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                 justify_content: JustifyContent::Center,
                                 ..default()
                             },
-                            BorderColor::all(LIME.into()),
+                            BorderColor::all(LIME),
                             BackgroundColor(Color::srgb(0.8, 0.8, 1.)),
                         ))
                         .with_children(|parent| {

--- a/examples/testbed/ui.rs
+++ b/examples/testbed/ui.rs
@@ -233,7 +233,7 @@ mod borders {
                             ..default()
                         },
                         BackgroundColor(MAROON.into()),
-                        BorderColor::all(RED.into()),
+                        BorderColor::all(RED),
                         Outline {
                             width: Val::Px(10.),
                             offset: Val::Px(10.),
@@ -325,7 +325,7 @@ mod box_shadow {
                             border: UiRect::all(Val::Px(2.)),
                             ..default()
                         },
-                        BorderColor::all(WHITE.into()),
+                        BorderColor::all(WHITE),
                         border_radius,
                         BackgroundColor(BLUE.into()),
                         BoxShadow::new(
@@ -423,7 +423,7 @@ mod overflow {
                                 overflow,
                                 ..default()
                             },
-                            BorderColor::all(RED.into()),
+                            BorderColor::all(RED),
                             BackgroundColor(Color::WHITE),
                         ))
                         .with_children(|parent| {
@@ -545,7 +545,7 @@ mod layout_rounding {
                                         ..Default::default()
                                     },
                                     BackgroundColor(MAROON.into()),
-                                    BorderColor::all(DARK_BLUE.into()),
+                                    BorderColor::all(DARK_BLUE),
                                 ));
                             }
                         });

--- a/examples/ui/box_shadow.rs
+++ b/examples/ui/box_shadow.rs
@@ -172,7 +172,7 @@ fn setup(
 
             (
                 node,
-                BorderColor::all(WHITE.into()),
+                BorderColor::all(WHITE),
                 radius,
                 BackgroundColor(Color::srgb(0.21, 0.21, 0.21)),
                 BoxShadow(vec![ShadowStyle {

--- a/examples/ui/button.rs
+++ b/examples/ui/button.rs
@@ -44,7 +44,7 @@ fn button_system(
                 input_focus.set(entity);
                 **text = "Press".to_string();
                 *color = PRESSED_BUTTON.into();
-                *border_color = BorderColor::all(RED.into());
+                *border_color = BorderColor::all(RED);
 
                 // The accessibility system's only update the button's state when the `Button` component is marked as changed.
                 button.set_changed();

--- a/examples/ui/directional_navigation.rs
+++ b/examples/ui/directional_navigation.rs
@@ -361,7 +361,7 @@ fn highlight_focused_element(
         if input_focus.0 == Some(entity) && input_focus_visible.0 {
             // Don't change the border size / radius here,
             // as it would result in wiggling buttons when they are focused
-            *border_color = BorderColor::all(FOCUSED_BORDER.into());
+            *border_color = BorderColor::all(FOCUSED_BORDER);
         } else {
             *border_color = BorderColor::DEFAULT;
         }

--- a/examples/ui/gradients.rs
+++ b/examples/ui/gradients.rs
@@ -202,7 +202,7 @@ fn setup(mut commands: Commands) {
                         )]
                 )).observe(
                     |_trigger: On<Pointer<Over>>, mut border_query: Query<&mut BorderColor, With<Button>>| {
-                    *border_query.single_mut().unwrap() = BorderColor::all(RED.into());
+                    *border_query.single_mut().unwrap() = BorderColor::all(RED);
 
 
                 })

--- a/examples/ui/tab_navigation.rs
+++ b/examples/ui/tab_navigation.rs
@@ -34,7 +34,7 @@ fn button_system(
         match *interaction {
             Interaction::Pressed => {
                 *color = PRESSED_BUTTON.into();
-                *border_color = BorderColor::all(RED.into());
+                *border_color = BorderColor::all(RED);
             }
             Interaction::Hovered => {
                 *color = HOVERED_BUTTON.into();

--- a/examples/ui/viewport_debug.rs
+++ b/examples/ui/viewport_debug.rs
@@ -75,7 +75,7 @@ fn spawn_with_viewport_coords(commands: &mut Commands) {
                 flex_wrap: FlexWrap::Wrap,
                 ..default()
             },
-            BorderColor::all(PALETTE[0].into()),
+            BorderColor::all(PALETTE[0]),
             Coords::Viewport,
         ))
         .with_children(|builder| {
@@ -87,7 +87,7 @@ fn spawn_with_viewport_coords(commands: &mut Commands) {
                     ..default()
                 },
                 BackgroundColor(PALETTE[2].into()),
-                BorderColor::all(PALETTE[9].into()),
+                BorderColor::all(PALETTE[9]),
             ));
 
             builder.spawn((
@@ -107,7 +107,7 @@ fn spawn_with_viewport_coords(commands: &mut Commands) {
                     ..default()
                 },
                 BackgroundColor(PALETTE[4].into()),
-                BorderColor::all(PALETTE[8].into()),
+                BorderColor::all(PALETTE[8]),
             ));
 
             builder.spawn((
@@ -118,7 +118,7 @@ fn spawn_with_viewport_coords(commands: &mut Commands) {
                     ..default()
                 },
                 BackgroundColor(PALETTE[5].into()),
-                BorderColor::all(PALETTE[8].into()),
+                BorderColor::all(PALETTE[8]),
             ));
 
             builder.spawn((
@@ -138,7 +138,7 @@ fn spawn_with_viewport_coords(commands: &mut Commands) {
                     ..default()
                 },
                 BackgroundColor(PALETTE[7].into()),
-                BorderColor::all(PALETTE[9].into()),
+                BorderColor::all(PALETTE[9]),
             ));
         });
 }
@@ -153,7 +153,7 @@ fn spawn_with_pixel_coords(commands: &mut Commands) {
                 flex_wrap: FlexWrap::Wrap,
                 ..default()
             },
-            BorderColor::all(PALETTE[1].into()),
+            BorderColor::all(PALETTE[1]),
             Coords::Pixel,
         ))
         .with_children(|builder| {
@@ -165,7 +165,7 @@ fn spawn_with_pixel_coords(commands: &mut Commands) {
                     ..default()
                 },
                 BackgroundColor(PALETTE[2].into()),
-                BorderColor::all(PALETTE[9].into()),
+                BorderColor::all(PALETTE[9]),
             ));
 
             builder.spawn((
@@ -185,7 +185,7 @@ fn spawn_with_pixel_coords(commands: &mut Commands) {
                     ..default()
                 },
                 BackgroundColor(PALETTE[4].into()),
-                BorderColor::all(PALETTE[8].into()),
+                BorderColor::all(PALETTE[8]),
             ));
 
             builder.spawn((
@@ -196,7 +196,7 @@ fn spawn_with_pixel_coords(commands: &mut Commands) {
                     ..default()
                 },
                 BackgroundColor(PALETTE[5].into()),
-                BorderColor::all(PALETTE[8].into()),
+                BorderColor::all(PALETTE[8]),
             ));
 
             builder.spawn((
@@ -216,7 +216,7 @@ fn spawn_with_pixel_coords(commands: &mut Commands) {
                     ..default()
                 },
                 BackgroundColor(PALETTE[7].into()),
-                BorderColor::all(PALETTE[9].into()),
+                BorderColor::all(PALETTE[9]),
             ));
         });
 }


### PR DESCRIPTION
# Objective

Remove some friction when building UI by changing `BorderColor::all` to accept any `impl Into<Color>` type.

