### PR TITLE
Fix audio playback for audio entities without transforms

### DIFF
--- a/crates/bevy_audio/src/audio_output.rs
+++ b/crates/bevy_audio/src/audio_output.rs
@@ -103,7 +103,7 @@ pub(crate) fn play_queued_audio_system<Source: Asset + Decodable>(
             Entity,
             &AudioPlayer<Source>,
             &PlaybackSettings,
-            &GlobalTransform,
+            Option<&GlobalTransform>,
         ),
         (Without<AudioSink>, Without<SpatialAudioSink>),
     >,
@@ -118,7 +118,7 @@ pub(crate) fn play_queued_audio_system<Source: Asset + Decodable>(
         return;
     };
 
-    for (entity, source_handle, settings, emitter_transform) in &query_nonplaying {
+    for (entity, source_handle, settings, maybe_emitter_transform) in &query_nonplaying {
         let Some(audio_source) = audio_sources.get(&source_handle.0) else {
             continue;
         };
@@ -136,7 +136,14 @@ pub(crate) fn play_queued_audio_system<Source: Asset + Decodable>(
             }
 
             let scale = settings.spatial_scale.unwrap_or(default_spatial_scale.0).0;
-            let emitter_translation = (emitter_transform.translation() * scale).into();
+
+            let emitter_translation = if let Some(emitter_transform) = maybe_emitter_transform {
+                (emitter_transform.translation() * scale).into()
+            } else {
+                warn!("Spatial AudioPlayer with no GlobalTransform component. Using zero.");
+                Vec3::ZERO.into()
+            };
+
             let sink = match SpatialSink::try_new(
                 stream_handle,
                 emitter_translation,


### PR DESCRIPTION
# Objective

Audio has been broken for audio entities without `GlobalTransform` since https://github.com/bevyengine/bevy/pull/19357

Thanks to JC Denton for reporting.

## Solution

Revert the changes to `play_queued_audio_system` in that PR while keeping the rest of it in-tact.

## Testing

`cargo run --example audio_control`
`cargo run --example spatial_audio_2d`

