### PR TITLE
Set `SCOPED_ENTITIES_ENABLED` to `true` for `ComputedStates`

### DIFF
--- a/crates/bevy_state/src/state/computed_states.rs
+++ b/crates/bevy_state/src/state/computed_states.rs
@@ -137,6 +137,6 @@ mod tests {
 
         assert!(world.query::<&TestComponent>().single(world).is_ok());
         world.run_schedule(StateTransition);
-        assert_eq!(world.query::<&TestComponent>().iter().len(), 1);
+        assert_eq!(world.query::<&TestComponent>().iter(world).len(), 0);
     }
 }


### PR DESCRIPTION
# Objective

- There is no way to enable scoped entities for `ComputedStates`.
- There is a blanket impl of `States` for `ComputedStates`, making it impossible to configure.

## Solution

- Set `SCOPED_ENTITIES_ENABLED` to `true` for `ComputedStates` by default (solution suggested by @alice-i-cecile).

## Testing

- I tested the `computed_states` example which relies on state scoped computed states.
- Added integration test.

