### PR TITLE
Update Rodio to 0.21

### DIFF
--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -80,7 +80,7 @@ jobs:
             target: aarch64-linux-android
           - os: macos-latest
             toolchain: stable
-            target: aarch64-apple-ios-sim
+            target: arm64-apple-ios-simulator
 
     steps:
       - name: Get Date

--- a/.github/workflows/validation-jobs.yml
+++ b/.github/workflows/validation-jobs.yml
@@ -33,11 +33,11 @@ jobs:
       - uses: actions/cache/restore@v4
         with:
           # key won't match, will rely on restore-keys
-          key: ${{ runner.os }}-stable-aarch64-apple-ios-sim-${{ hashFiles('**/Cargo.toml') }}-
+          key: ${{ runner.os }}-stable-arm64-apple-ios-simulator-${{ hashFiles('**/Cargo.toml') }}-
           # See .github/workflows/validation-jobs.yml for how keys are generated
           restore-keys: |
-            ${{ runner.os }}-stable-aarch64-apple-ios-sim-${{ hashFiles('**/Cargo.toml') }}-
-            ${{ runner.os }}-stable-aarch64-apple-ios-sim-
+            ${{ runner.os }}-stable-arm64-apple-ios-simulator-${{ hashFiles('**/Cargo.toml') }}-
+            ${{ runner.os }}-stable-arm64-apple-ios-simulator-
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/index/
@@ -46,7 +46,7 @@ jobs:
             target/
 
       - name: Add iOS targets
-        run: rustup target add aarch64-apple-ios-sim
+        run: rustup target add arm64-apple-ios-simulator
 
       - name: Build and install iOS app in iOS Simulator.
         run: cd examples/mobile && make install

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -396,37 +396,37 @@ zstd_rust = ["bevy_internal/zstd_rust"]
 zstd_c = ["bevy_internal/zstd_c"]
 
 # FLAC audio format support (through `claxon`)
-flac = ["bevy_internal/flac"]
+fallback-flac = ["bevy_internal/flac"]
 
 # MP3 audio format support (through `minimp3`)
-mp3 = ["bevy_internal/mp3"]
+fallback-mp3 = ["bevy_internal/mp3"]
 
 # OGG/VORBIS audio format support (through `lewton`)
-vorbis = ["bevy_internal/vorbis"]
+fallback-vorbis = ["bevy_internal/vorbis"]
 
 # WAV audio format support (through `hound`)
-wav = ["bevy_internal/wav"]
+fallback-wav = ["bevy_internal/wav"]
 
 # AAC audio format support (through `symphonia`)
-symphonia-aac = ["bevy_internal/symphonia-aac"]
+aac = ["bevy_internal/aac"]
 
 # AAC, FLAC, MP3, MP4, OGG/VORBIS, and WAV audio formats support (through `symphonia`)
-symphonia-all = ["bevy_internal/symphonia-all"]
+audio-all = ["bevy_internal/audio-all"]
 
 # FLAC audio format support (through `symphonia`)
-symphonia-flac = ["bevy_internal/symphonia-flac"]
+flac = ["bevy_internal/flac"]
 
-# MP4 audio format support (through `symphonia`)
-symphonia-isomp4 = ["bevy_internal/symphonia-isomp4"]
+# MP4 audio format support (through `symphonia`). It also enables AAC support.
+mp4 = ["bevy_internal/mp4"]
 
 # MP3 audio format support (through `symphonia`)
-symphonia-mp3 = ["bevy_internal/symphonia-mp3"]
+mp3 = ["bevy_internal/mp3"]
 
 # OGG/VORBIS audio format support (through `symphonia`)
-symphonia-vorbis = ["bevy_internal/symphonia-vorbis"]
+vorbis = ["bevy_internal/vorbis"]
 
 # WAV audio format support (through `symphonia`)
-symphonia-wav = ["bevy_internal/symphonia-wav"]
+wav = ["bevy_internal/wav"]
 
 # Enable serialization support through serde
 serialize = ["bevy_internal/serialize"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -395,34 +395,37 @@ zstd_rust = ["bevy_internal/zstd_rust"]
 # For KTX2 Zstandard decompression using [zstd](https://crates.io/crates/zstd). This is a faster backend, but uses unsafe C bindings. For the safe option, stick to the default backend with "zstd_rust".
 zstd_c = ["bevy_internal/zstd_c"]
 
-# FLAC audio format support
+# FLAC audio format support (through `claxon`)
 flac = ["bevy_internal/flac"]
 
-# MP3 audio format support
+# MP3 audio format support (through `minimp3`)
 mp3 = ["bevy_internal/mp3"]
 
-# OGG/VORBIS audio format support
+# OGG/VORBIS audio format support (through `lewton`)
 vorbis = ["bevy_internal/vorbis"]
 
-# WAV audio format support
+# WAV audio format support (through `hound`)
 wav = ["bevy_internal/wav"]
 
-# AAC audio format support (through symphonia)
+# AAC audio format support (through `symphonia`)
 symphonia-aac = ["bevy_internal/symphonia-aac"]
 
-# AAC, FLAC, MP3, MP4, OGG/VORBIS, and WAV audio formats support (through symphonia)
+# AAC, FLAC, MP3, MP4, OGG/VORBIS, and WAV audio formats support (through `symphonia`)
 symphonia-all = ["bevy_internal/symphonia-all"]
 
-# FLAC audio format support (through symphonia)
+# FLAC audio format support (through `symphonia`)
 symphonia-flac = ["bevy_internal/symphonia-flac"]
 
-# MP4 audio format support (through symphonia)
+# MP4 audio format support (through `symphonia`)
 symphonia-isomp4 = ["bevy_internal/symphonia-isomp4"]
 
-# OGG/VORBIS audio format support (through symphonia)
+# MP3 audio format support (through `symphonia`)
+symphonia-mp3 = ["bevy_internal/symphonia-mp3"]
+
+# OGG/VORBIS audio format support (through `symphonia`)
 symphonia-vorbis = ["bevy_internal/symphonia-vorbis"]
 
-# WAV audio format support (through symphonia)
+# WAV audio format support (through `symphonia`)
 symphonia-wav = ["bevy_internal/symphonia-wav"]
 
 # Enable serialization support through serde

--- a/crates/bevy_audio/Cargo.toml
+++ b/crates/bevy_audio/Cargo.toml
@@ -23,7 +23,7 @@ rodio = { version = "0.20", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
-cpal = { version = "0.15", optional = true }
+cpal = { version = "0.16", optional = true }
 
 [target.'cfg(target_vendor = "apple")'.dependencies]
 # NOTE: Explicitly depend on this patch version to fix:

--- a/crates/bevy_audio/Cargo.toml
+++ b/crates/bevy_audio/Cargo.toml
@@ -38,7 +38,6 @@ bevy_reflect = { path = "../bevy_reflect", version = "0.17.0-dev", default-featu
 ] }
 
 [features]
-default = ["mp3", "flac", "wav", "vorbis"]
 mp3 = ["rodio/minimp3"]
 flac = ["rodio/claxon"]
 wav = ["rodio/hound"]

--- a/crates/bevy_audio/Cargo.toml
+++ b/crates/bevy_audio/Cargo.toml
@@ -19,7 +19,7 @@ bevy_transform = { path = "../bevy_transform", version = "0.17.0-dev" }
 
 # other
 # TODO: Remove `coreaudio-sys` dep below when updating `cpal`.
-rodio = { version = "0.20", default-features = false }
+rodio = { version = "0.21", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
@@ -32,7 +32,7 @@ coreaudio-sys = { version = "0.2.17", default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # TODO: Assuming all wasm builds are for the browser. Require `no_std` support to break assumption.
-rodio = { version = "0.20", default-features = false, features = [
+rodio = { version = "0.21", default-features = false, features = [
   "wasm-bindgen",
 ] }
 bevy_app = { path = "../bevy_app", version = "0.17.0-dev", default-features = false, features = [

--- a/crates/bevy_audio/Cargo.toml
+++ b/crates/bevy_audio/Cargo.toml
@@ -18,7 +18,7 @@ bevy_reflect = { path = "../bevy_reflect", version = "0.17.0-dev" }
 bevy_transform = { path = "../bevy_transform", version = "0.17.0-dev" }
 
 # other
-rodio = { version = "0.21", default-features = false }
+rodio = { version = "0.21", default-features = false, features = ["playback"] }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
@@ -28,6 +28,7 @@ cpal = { version = "0.16", optional = true }
 # TODO: Assuming all wasm builds are for the browser. Require `no_std` support to break assumption.
 rodio = { version = "0.21", default-features = false, features = [
   "wasm-bindgen",
+  "playback",
 ] }
 bevy_app = { path = "../bevy_app", version = "0.17.0-dev", default-features = false, features = [
   "web",
@@ -37,16 +38,24 @@ bevy_reflect = { path = "../bevy_reflect", version = "0.17.0-dev", default-featu
 ] }
 
 [features]
-mp3 = ["rodio/mp3"]
-flac = ["rodio/flac"]
-wav = ["rodio/wav"]
-vorbis = ["rodio/vorbis"]
+default = ["mp3", "flac", "wav", "vorbis"]
+mp3 = ["rodio/minimp3"]
+flac = ["rodio/claxon"]
+wav = ["rodio/hound"]
+vorbis = ["rodio/lewton"]
 symphonia-aac = ["rodio/symphonia-aac"]
-symphonia-all = ["rodio/symphonia-all"]
-symphonia-flac = ["rodio/symphonia-flac"]
-symphonia-isomp4 = ["rodio/symphonia-isomp4"]
-symphonia-vorbis = ["rodio/symphonia-vorbis"]
-symphonia-wav = ["rodio/symphonia-wav"]
+symphonia-all = [
+  "rodio/flac",
+  "rodio/mp3",
+  "rodio/mp4",
+  "rodio/vorbis",
+  "rodio/wav",
+]
+symphonia-flac = ["rodio/flac"]
+symphonia-isomp4 = ["rodio/mp4"]
+symphonia-mp3 = ["rodio/mp3"]
+symphonia-vorbis = ["rodio/vorbis"]
+symphonia-wav = ["rodio/wav"]
 # Enable using a shared stdlib for cxx on Android.
 android_shared_stdcxx = ["cpal/oboe-shared-stdcxx"]
 

--- a/crates/bevy_audio/Cargo.toml
+++ b/crates/bevy_audio/Cargo.toml
@@ -38,23 +38,23 @@ bevy_reflect = { path = "../bevy_reflect", version = "0.17.0-dev", default-featu
 ] }
 
 [features]
-mp3 = ["rodio/minimp3"]
-flac = ["rodio/claxon"]
-wav = ["rodio/hound"]
-vorbis = ["rodio/lewton"]
-symphonia-aac = ["rodio/symphonia-aac"]
-symphonia-all = [
+fallback-mp3 = ["rodio/minimp3"]
+fallback-flac = ["rodio/claxon"]
+fallback-wav = ["rodio/hound"]
+fallback-vorbis = ["rodio/lewton"]
+mp3 = ["rodio/mp3"]
+mp4 = ["rodio/mp4"]
+flac = ["rodio/flac"]
+wav = ["rodio/wav"]
+vorbis = ["rodio/vorbis"]
+aac = ["rodio/symphonia-aac"]
+audio-all = [
   "rodio/flac",
   "rodio/mp3",
   "rodio/mp4",
   "rodio/vorbis",
   "rodio/wav",
 ]
-symphonia-flac = ["rodio/flac"]
-symphonia-isomp4 = ["rodio/mp4"]
-symphonia-mp3 = ["rodio/mp3"]
-symphonia-vorbis = ["rodio/vorbis"]
-symphonia-wav = ["rodio/wav"]
 # Enable using a shared stdlib for cxx on Android.
 android_shared_stdcxx = ["cpal/oboe-shared-stdcxx"]
 

--- a/crates/bevy_audio/Cargo.toml
+++ b/crates/bevy_audio/Cargo.toml
@@ -18,17 +18,11 @@ bevy_reflect = { path = "../bevy_reflect", version = "0.17.0-dev" }
 bevy_transform = { path = "../bevy_transform", version = "0.17.0-dev" }
 
 # other
-# TODO: Remove `coreaudio-sys` dep below when updating `cpal`.
 rodio = { version = "0.21", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
 cpal = { version = "0.16", optional = true }
-
-[target.'cfg(target_vendor = "apple")'.dependencies]
-# NOTE: Explicitly depend on this patch version to fix:
-# https://github.com/bevyengine/bevy/issues/18893
-coreaudio-sys = { version = "0.2.17", default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # TODO: Assuming all wasm builds are for the browser. Require `no_std` support to break assumption.

--- a/crates/bevy_audio/src/audio_source.rs
+++ b/crates/bevy_audio/src/audio_source.rs
@@ -58,33 +58,17 @@ impl AssetLoader for AudioLoader {
 
     fn extensions(&self) -> &[&str] {
         &[
-            #[cfg(any(feature = "mp3", feature = "symphonia-mp3", feature = "symphonia-all"))]
+            #[cfg(any(feature = "mp3", feature = "fallback-mp3", feature = "audio-all"))]
             "mp3",
-            #[cfg(any(
-                feature = "flac",
-                feature = "symphonia-flac",
-                feature = "symphonia-all"
-            ))]
+            #[cfg(any(feature = "flac", feature = "fallback-flac", feature = "audio-all"))]
             "flac",
-            #[cfg(any(feature = "wav", feature = "symphonia-wav", feature = "symphonia-all"))]
+            #[cfg(any(feature = "wav", feature = "fallback-wav", feature = "audio-all"))]
             "wav",
-            #[cfg(any(
-                feature = "vorbis",
-                feature = "symphonia-vorbis",
-                feature = "symphonia-all"
-            ))]
+            #[cfg(any(feature = "vorbis", feature = "fallback-vorbis", feature = "audio-all"))]
             "oga",
-            #[cfg(any(
-                feature = "vorbis",
-                feature = "symphonia-vorbis",
-                feature = "symphonia-all"
-            ))]
+            #[cfg(any(feature = "vorbis", feature = "fallback-vorbis", feature = "audio-all"))]
             "ogg",
-            #[cfg(any(
-                feature = "vorbis",
-                feature = "symphonia-vorbis",
-                feature = "symphonia-all"
-            ))]
+            #[cfg(any(feature = "vorbis", feature = "fallback-vorbis", feature = "audio-all"))]
             "spx",
         ]
     }

--- a/crates/bevy_audio/src/audio_source.rs
+++ b/crates/bevy_audio/src/audio_source.rs
@@ -31,9 +31,10 @@ impl AsRef<[u8]> for AudioSource {
 /// This asset loader supports different audio formats based on the enable Bevy features.
 /// The feature `bevy/vorbis` enables loading from `.ogg` files and is enabled by default.
 /// Other file endings can be loaded from with additional features:
-/// `.mp3` with `bevy/mp3`
-/// `.flac` with `bevy/flac`
-/// `.wav` with `bevy/wav`
+/// `.mp3` with `bevy/mp3` or `bevy/symphonia-mp3`
+/// `.flac` with `bevy/flac` or `bevy/symphonia-flac`
+/// `.wav` with `bevy/wav` or `bevy/symphonia-wav`
+/// The `bevy/symphonia-all` feature will enable all file endings.
 #[derive(Default)]
 pub struct AudioLoader;
 
@@ -57,17 +58,33 @@ impl AssetLoader for AudioLoader {
 
     fn extensions(&self) -> &[&str] {
         &[
-            #[cfg(feature = "mp3")]
+            #[cfg(any(feature = "mp3", feature = "symphonia-mp3", feature = "symphonia-all"))]
             "mp3",
-            #[cfg(feature = "flac")]
+            #[cfg(any(
+                feature = "flac",
+                feature = "symphonia-flac",
+                feature = "symphonia-all"
+            ))]
             "flac",
-            #[cfg(feature = "wav")]
+            #[cfg(any(feature = "wav", feature = "symphonia-wav", feature = "symphonia-all"))]
             "wav",
-            #[cfg(feature = "vorbis")]
+            #[cfg(any(
+                feature = "vorbis",
+                feature = "symphonia-vorbis",
+                feature = "symphonia-all"
+            ))]
             "oga",
-            #[cfg(feature = "vorbis")]
+            #[cfg(any(
+                feature = "vorbis",
+                feature = "symphonia-vorbis",
+                feature = "symphonia-all"
+            ))]
             "ogg",
-            #[cfg(feature = "vorbis")]
+            #[cfg(any(
+                feature = "vorbis",
+                feature = "symphonia-vorbis",
+                feature = "symphonia-all"
+            ))]
             "spx",
         ]
     }
@@ -80,22 +97,16 @@ impl AssetLoader for AudioLoader {
 /// This trait is implemented for [`AudioSource`].
 /// Check the example [`decodable`](https://github.com/bevyengine/bevy/blob/latest/examples/audio/decodable.rs) for how to implement this trait on a custom type.
 pub trait Decodable: Send + Sync + 'static {
-    /// The type of the audio samples.
-    /// Usually a [`u16`], [`i16`] or [`f32`], as those implement [`rodio::Sample`].
-    /// Other types can implement the [`rodio::Sample`] trait as well.
-    type DecoderItem: rodio::Sample + Send + Sync;
-
     /// The type of the iterator of the audio samples,
-    /// which iterates over samples of type [`Self::DecoderItem`].
+    /// which iterates over samples of type [`rodio::Sample`].
     /// Must be a [`rodio::Source`] so that it can provide information on the audio it is iterating over.
-    type Decoder: rodio::Source + Send + Iterator<Item = Self::DecoderItem>;
+    type Decoder: rodio::Source + Send + Iterator<Item = rodio::Sample>;
 
     /// Build and return a [`Self::Decoder`] of the implementing type
     fn decoder(&self) -> Self::Decoder;
 }
 
 impl Decodable for AudioSource {
-    type DecoderItem = <rodio::Decoder<Cursor<AudioSource>> as Iterator>::Item;
     type Decoder = rodio::Decoder<Cursor<AudioSource>>;
 
     fn decoder(&self) -> Self::Decoder {
@@ -115,5 +126,5 @@ pub trait AddAudioSource {
     fn add_audio_source<T>(&mut self) -> &mut Self
     where
         T: Decodable + Asset,
-        f32: rodio::cpal::FromSample<T::DecoderItem>;
+        f32: rodio::cpal::FromSample<rodio::Sample>;
 }

--- a/crates/bevy_audio/src/audio_source.rs
+++ b/crates/bevy_audio/src/audio_source.rs
@@ -30,11 +30,11 @@ impl AsRef<[u8]> for AudioSource {
 ///
 /// This asset loader supports different audio formats based on the enable Bevy features.
 /// The feature `bevy/vorbis` enables loading from `.ogg` files and is enabled by default.
-/// Other file endings can be loaded from with additional features:
-/// `.mp3` with `bevy/mp3` or `bevy/symphonia-mp3`
-/// `.flac` with `bevy/flac` or `bevy/symphonia-flac`
-/// `.wav` with `bevy/wav` or `bevy/symphonia-wav`
-/// The `bevy/symphonia-all` feature will enable all file endings.
+/// Other file extensions can be loaded from with additional features:
+/// `.mp3` with `bevy/mp3` or `bevy/fallback-mp3`
+/// `.flac` with `bevy/flac` or `bevy/fallback-flac`
+/// `.wav` with `bevy/wav` or `bevy/fallback-wav`
+/// The `bevy/audio-all` feature will enable all file extensions.
 #[derive(Default)]
 pub struct AudioLoader;
 

--- a/crates/bevy_audio/src/lib.rs
+++ b/crates/bevy_audio/src/lib.rs
@@ -114,7 +114,7 @@ impl AddAudioSource for App {
     fn add_audio_source<T>(&mut self) -> &mut Self
     where
         T: Decodable + Asset,
-        f32: rodio::cpal::FromSample<T::DecoderItem>,
+        f32: rodio::cpal::FromSample<Sample>,
     {
         self.init_asset::<T>().add_systems(
             PostUpdate,

--- a/crates/bevy_audio/src/pitch.rs
+++ b/crates/bevy_audio/src/pitch.rs
@@ -26,7 +26,6 @@ impl Pitch {
 }
 
 impl Decodable for Pitch {
-    type DecoderItem = <SineWave as Iterator>::Item;
     type Decoder = TakeDuration<SineWave>;
 
     fn decoder(&self) -> Self::Decoder {

--- a/crates/bevy_audio/src/sinks.rs
+++ b/crates/bevy_audio/src/sinks.rs
@@ -412,7 +412,7 @@ mod tests {
 
     #[test]
     fn test_audio_sink() {
-        let (sink, _queue_rx) = Sink::new_idle();
+        let (sink, _queue_rx) = Sink::new();
         let audio_sink = AudioSink::new(sink);
         test_audio_sink_playback(audio_sink);
     }

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -84,6 +84,7 @@ symphonia-aac = ["bevy_audio/symphonia-aac"]
 symphonia-all = ["bevy_audio/symphonia-all"]
 symphonia-flac = ["bevy_audio/symphonia-flac"]
 symphonia-isomp4 = ["bevy_audio/symphonia-isomp4"]
+symphonia-mp3 = ["bevy_audio/symphonia-mp3"]
 symphonia-vorbis = ["bevy_audio/symphonia-vorbis"]
 symphonia-wav = ["bevy_audio/symphonia-wav"]
 

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -78,15 +78,15 @@ smaa_luts = ["bevy_anti_aliasing/smaa_luts"]
 # Audio format support (vorbis is enabled by default)
 flac = ["bevy_audio/flac"]
 mp3 = ["bevy_audio/mp3"]
+mp4 = ["bevy_audio/mp4"]
 vorbis = ["bevy_audio/vorbis"]
 wav = ["bevy_audio/wav"]
-symphonia-aac = ["bevy_audio/symphonia-aac"]
-symphonia-all = ["bevy_audio/symphonia-all"]
-symphonia-flac = ["bevy_audio/symphonia-flac"]
-symphonia-isomp4 = ["bevy_audio/symphonia-isomp4"]
-symphonia-mp3 = ["bevy_audio/symphonia-mp3"]
-symphonia-vorbis = ["bevy_audio/symphonia-vorbis"]
-symphonia-wav = ["bevy_audio/symphonia-wav"]
+aac = ["bevy_audio/aac"]
+audio-all = ["bevy_audio/audio-all"]
+fallback-flac = ["bevy_audio/fallback-flac"]
+fallback-mp3 = ["bevy_audio/fallback-mp3"]
+fallback-vorbis = ["bevy_audio/fallback-vorbis"]
+fallback-wav = ["bevy_audio/fallback-wav"]
 
 # Shader formats
 shader_format_glsl = [

--- a/docs-template/EXAMPLE_README.md.tpl
+++ b/docs-template/EXAMPLE_README.md.tpl
@@ -160,6 +160,8 @@ In its examples, Bevy targets the minimum Android API that Play Store  <!-- mark
 [requires](https://developer.android.com/distribute/best-practices/develop/target-sdk) to upload and update apps. <!-- markdown-link-check-enable -->
 Users of older phones may want to use an older API when testing. By default, Bevy uses [`GameActivity`](https://developer.android.com/games/agdk/game-activity), which only works for Android API level 31 and higher, so if you want to use older API, you need to switch to `NativeActivity`.
 
+Keep in mind that if you are using `bevy_audio` the minimum supported Android API version is 26 (Android 8/Oreo).
+
 To use `NativeActivity`, you need to edit it in `cargo.toml` manually like this:
 
 ```toml

--- a/docs-template/EXAMPLE_README.md.tpl
+++ b/docs-template/EXAMPLE_README.md.tpl
@@ -165,7 +165,7 @@ Keep in mind that if you are using `bevy_audio` the minimum supported Android AP
 To use `NativeActivity`, you need to edit it in `cargo.toml` manually like this:
 
 ```toml
-bevy = { version = "0.14", default-features = false, features = ["android-native-activity", ...] }
+bevy = { version = "0.16", default-features = false, features = ["android-native-activity", ...] }
 ```
 
 Then build it as the [Build & Run](#build--run) section stated above.

--- a/docs-template/EXAMPLE_README.md.tpl
+++ b/docs-template/EXAMPLE_README.md.tpl
@@ -186,10 +186,10 @@ You need to install the correct rust targets:
 
 - `aarch64-apple-ios`: iOS devices
 - `x86_64-apple-ios`: iOS simulator on x86 processors
-- `aarch64-apple-ios-sim`: iOS simulator on Apple processors
+- `arm64-apple-ios-simulator`: iOS simulator on Apple processors
 
 ```sh
-rustup target add aarch64-apple-ios x86_64-apple-ios aarch64-apple-ios-sim
+rustup target add aarch64-apple-ios x86_64-apple-ios arm64-apple-ios-simulator
 ```
 
 ### Build & Run

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -52,7 +52,7 @@ The default feature set enables most of the expected features of a game engine, 
 |std|Allows access to the `std` crate.|
 |sysinfo_plugin|Enables system information diagnostic plugin|
 |tonemapping_luts|Include tonemapping Look Up Tables KTX2 files. If everything is pink, you need to enable this feature or change the `Tonemapping` method for your `Camera2d` or `Camera3d`.|
-|vorbis|OGG/VORBIS audio format support|
+|vorbis|OGG/VORBIS audio format support (through `lewton`)|
 |webgl2|Enable some limitations to be able to use WebGL2. Please refer to the [WebGL2 and WebGPU](https://github.com/bevyengine/bevy/tree/latest/examples#webgl2-and-webgpu) section of the examples README for more information on how to run Wasm builds with WebGPU.|
 |x11|X11 display server support|
 |zstd_rust|For KTX2 Zstandard decompression using pure rust [ruzstd](https://crates.io/crates/ruzstd). This is the safe default. For maximum performance, use "zstd_c".|
@@ -88,7 +88,7 @@ The default feature set enables most of the expected features of a game engine, 
 |exr|EXR image format support|
 |ff|Farbfeld image format support|
 |file_watcher|Enables watching the filesystem for Bevy Asset hot-reloading|
-|flac|FLAC audio format support|
+|flac|FLAC audio format support (through `claxon`)|
 |ghost_nodes|Experimental support for nodes that are ignored for UI layouting|
 |gif|GIF image format support|
 |glam_assert|Enable assertions to check the validity of parameters passed to glam|
@@ -99,7 +99,7 @@ The default feature set enables most of the expected features of a game engine, 
 |libm|Uses the `libm` maths library instead of the one provided in `std` and `core`.|
 |meshlet|Enables the meshlet renderer for dense high-poly scenes (experimental)|
 |meshlet_processor|Enables processing meshes into meshlet meshes for bevy_pbr|
-|mp3|MP3 audio format support|
+|mp3|MP3 audio format support (through `minimp3`)|
 |pbr_anisotropy_texture|Enable support for anisotropy texture in the `StandardMaterial`, at the risk of blowing past the global, per-shader texture limit on older/lower-end GPUs|
 |pbr_clustered_decals|Enable support for Clustered Decals|
 |pbr_light_textures|Enable support for Light Textures|
@@ -116,12 +116,13 @@ The default feature set enables most of the expected features of a game engine, 
 |shader_format_wesl|Enable support for shaders in WESL|
 |spirv_shader_passthrough|Enable passthrough loading for SPIR-V shaders (Only supported on Vulkan, shader capabilities and extensions must agree with the platform implementation)|
 |statically-linked-dxc|Statically linked DXC shader compiler for DirectX 12|
-|symphonia-aac|AAC audio format support (through symphonia)|
-|symphonia-all|AAC, FLAC, MP3, MP4, OGG/VORBIS, and WAV audio formats support (through symphonia)|
-|symphonia-flac|FLAC audio format support (through symphonia)|
-|symphonia-isomp4|MP4 audio format support (through symphonia)|
-|symphonia-vorbis|OGG/VORBIS audio format support (through symphonia)|
-|symphonia-wav|WAV audio format support (through symphonia)|
+|symphonia-aac|AAC audio format support (through `symphonia`)|
+|symphonia-all|AAC, FLAC, MP3, MP4, OGG/VORBIS, and WAV audio formats support (through `symphonia`)|
+|symphonia-flac|FLAC audio format support (through `symphonia`)|
+|symphonia-isomp4|MP4 audio format support (through `symphonia`)|
+|symphonia-mp3|MP3 audio format support (through `symphonia`)|
+|symphonia-vorbis|OGG/VORBIS audio format support (through `symphonia`)|
+|symphonia-wav|WAV audio format support (through `symphonia`)|
 |tga|TGA image format support|
 |tiff|TIFF image format support|
 |trace|Tracing support|
@@ -129,7 +130,7 @@ The default feature set enables most of the expected features of a game engine, 
 |trace_tracy|Tracing support, exposing a port for Tracy|
 |trace_tracy_memory|Tracing support, with memory profiling, exposing a port for Tracy|
 |track_location|Enables source location tracking for change detection and spawning/despawning, which can assist with debugging|
-|wav|WAV audio format support|
+|wav|WAV audio format support (through `hound`)|
 |wayland|Wayland display server support|
 |web|Enables use of browser APIs. Note this is currently only applicable on `wasm32` architectures.|
 |webgpu|Enable support for WebGPU in Wasm. When enabled, this feature will override the `webgl2` feature and you won't be able to run Wasm builds with WebGL2, only with WebGPU.|

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -52,7 +52,7 @@ The default feature set enables most of the expected features of a game engine, 
 |std|Allows access to the `std` crate.|
 |sysinfo_plugin|Enables system information diagnostic plugin|
 |tonemapping_luts|Include tonemapping Look Up Tables KTX2 files. If everything is pink, you need to enable this feature or change the `Tonemapping` method for your `Camera2d` or `Camera3d`.|
-|vorbis|OGG/VORBIS audio format support (through `lewton`)|
+|vorbis|OGG/VORBIS audio format support (through `symphonia`)|
 |webgl2|Enable some limitations to be able to use WebGL2. Please refer to the [WebGL2 and WebGPU](https://github.com/bevyengine/bevy/tree/latest/examples#webgl2-and-webgpu) section of the examples README for more information on how to run Wasm builds with WebGPU.|
 |x11|X11 display server support|
 |zstd_rust|For KTX2 Zstandard decompression using pure rust [ruzstd](https://crates.io/crates/ruzstd). This is the safe default. For maximum performance, use "zstd_c".|
@@ -61,10 +61,12 @@ The default feature set enables most of the expected features of a game engine, 
 
 |feature name|description|
 |-|-|
+|aac|AAC audio format support (through `symphonia`)|
 |accesskit_unix|Enable AccessKit on Unix backends (currently only works with experimental screen readers and forks.)|
 |android-native-activity|Android NativeActivity support. Legacy, should be avoided for most new Android games.|
 |asset_processor|Enables the built-in asset processor for processed assets.|
 |async-io|Use async-io's implementation of block_on instead of futures-lite's implementation. This is preferred if your application uses async-io.|
+|audio-all|AAC, FLAC, MP3, MP4, OGG/VORBIS, and WAV audio formats support (through `symphonia`)|
 |basis-universal|Basis Universal compressed texture support|
 |bevy_ci_testing|Enable systems that allow for automated testing on CI|
 |bevy_debug_stepping|Enable stepping-based debugging of Bevy systems|
@@ -86,9 +88,13 @@ The default feature set enables most of the expected features of a game engine, 
 |experimental_bevy_feathers|Feathers widget collection.|
 |experimental_pbr_pcss|Enable support for PCSS, at the risk of blowing past the global, per-shader sampler limit on older/lower-end GPUs|
 |exr|EXR image format support|
+|fallback-flac|FLAC audio format support (through `claxon`)|
+|fallback-mp3|MP3 audio format support (through `minimp3`)|
+|fallback-vorbis|OGG/VORBIS audio format support (through `lewton`)|
+|fallback-wav|WAV audio format support (through `hound`)|
 |ff|Farbfeld image format support|
 |file_watcher|Enables watching the filesystem for Bevy Asset hot-reloading|
-|flac|FLAC audio format support (through `claxon`)|
+|flac|FLAC audio format support (through `symphonia`)|
 |ghost_nodes|Experimental support for nodes that are ignored for UI layouting|
 |gif|GIF image format support|
 |glam_assert|Enable assertions to check the validity of parameters passed to glam|
@@ -99,7 +105,8 @@ The default feature set enables most of the expected features of a game engine, 
 |libm|Uses the `libm` maths library instead of the one provided in `std` and `core`.|
 |meshlet|Enables the meshlet renderer for dense high-poly scenes (experimental)|
 |meshlet_processor|Enables processing meshes into meshlet meshes for bevy_pbr|
-|mp3|MP3 audio format support (through `minimp3`)|
+|mp3|MP3 audio format support (through `symphonia`)|
+|mp4|MP4 audio format support (through `symphonia`). It also enables AAC support.|
 |pbr_anisotropy_texture|Enable support for anisotropy texture in the `StandardMaterial`, at the risk of blowing past the global, per-shader texture limit on older/lower-end GPUs|
 |pbr_clustered_decals|Enable support for Clustered Decals|
 |pbr_light_textures|Enable support for Light Textures|
@@ -116,13 +123,6 @@ The default feature set enables most of the expected features of a game engine, 
 |shader_format_wesl|Enable support for shaders in WESL|
 |spirv_shader_passthrough|Enable passthrough loading for SPIR-V shaders (Only supported on Vulkan, shader capabilities and extensions must agree with the platform implementation)|
 |statically-linked-dxc|Statically linked DXC shader compiler for DirectX 12|
-|symphonia-aac|AAC audio format support (through `symphonia`)|
-|symphonia-all|AAC, FLAC, MP3, MP4, OGG/VORBIS, and WAV audio formats support (through `symphonia`)|
-|symphonia-flac|FLAC audio format support (through `symphonia`)|
-|symphonia-isomp4|MP4 audio format support (through `symphonia`)|
-|symphonia-mp3|MP3 audio format support (through `symphonia`)|
-|symphonia-vorbis|OGG/VORBIS audio format support (through `symphonia`)|
-|symphonia-wav|WAV audio format support (through `symphonia`)|
 |tga|TGA image format support|
 |tiff|TIFF image format support|
 |trace|Tracing support|
@@ -130,7 +130,7 @@ The default feature set enables most of the expected features of a game engine, 
 |trace_tracy|Tracing support, exposing a port for Tracy|
 |trace_tracy_memory|Tracing support, with memory profiling, exposing a port for Tracy|
 |track_location|Enables source location tracking for change detection and spawning/despawning, which can assist with debugging|
-|wav|WAV audio format support (through `hound`)|
+|wav|WAV audio format support (through `symphonia`)|
 |wayland|Wayland display server support|
 |web|Enables use of browser APIs. Note this is currently only applicable on `wasm32` architectures.|
 |webgpu|Enable support for WebGPU in Wasm. When enabled, this feature will override the `webgl2` feature and you won't be able to run Wasm builds with WebGL2, only with WebGPU.|

--- a/examples/README.md
+++ b/examples/README.md
@@ -718,10 +718,10 @@ You need to install the correct rust targets:
 
 - `aarch64-apple-ios`: iOS devices
 - `x86_64-apple-ios`: iOS simulator on x86 processors
-- `aarch64-apple-ios-sim`: iOS simulator on Apple processors
+- `arm64-apple-ios-simulator`: iOS simulator on Apple processors
 
 ```sh
-rustup target add aarch64-apple-ios x86_64-apple-ios aarch64-apple-ios-sim
+rustup target add aarch64-apple-ios x86_64-apple-ios arm64-apple-ios-simulator
 ```
 
 ### Build & Run

--- a/examples/README.md
+++ b/examples/README.md
@@ -697,7 +697,7 @@ Keep in mind that if you are using `bevy_audio` the minimum supported Android AP
 To use `NativeActivity`, you need to edit it in `cargo.toml` manually like this:
 
 ```toml
-bevy = { version = "0.14", default-features = false, features = ["android-native-activity", ...] }
+bevy = { version = "0.16", default-features = false, features = ["android-native-activity", ...] }
 ```
 
 Then build it as the [Build & Run](#build--run) section stated above.

--- a/examples/README.md
+++ b/examples/README.md
@@ -692,6 +692,8 @@ In its examples, Bevy targets the minimum Android API that Play Store  <!-- mark
 [requires](https://developer.android.com/distribute/best-practices/develop/target-sdk) to upload and update apps. <!-- markdown-link-check-enable -->
 Users of older phones may want to use an older API when testing. By default, Bevy uses [`GameActivity`](https://developer.android.com/games/agdk/game-activity), which only works for Android API level 31 and higher, so if you want to use older API, you need to switch to `NativeActivity`.
 
+Keep in mind that if you are using `bevy_audio` the minimum supported Android API version is 26 (Android 8/Oreo).
+
 To use `NativeActivity`, you need to edit it in `cargo.toml` manually like this:
 
 ```toml

--- a/examples/audio/decodable.rs
+++ b/examples/audio/decodable.rs
@@ -54,7 +54,7 @@ impl Iterator for SineDecoder {
 // `Source` is what allows the audio source to be played by bevy.
 // This trait provides information on the audio.
 impl Source for SineDecoder {
-    fn current_frame_len(&self) -> Option<usize> {
+    fn current_span_len(&self) -> Option<usize> {
         None
     }
 
@@ -73,8 +73,6 @@ impl Source for SineDecoder {
 
 // Finally `Decodable` can be implemented for our `SineAudio`.
 impl Decodable for SineAudio {
-    type DecoderItem = <SineDecoder as Iterator>::Item;
-
     type Decoder = SineDecoder;
 
     fn decoder(&self) -> Self::Decoder {

--- a/examples/mobile/android_basic/readme.md
+++ b/examples/mobile/android_basic/readme.md
@@ -47,6 +47,8 @@ Bevy by default targets Android API level 33 in its examples which is the <!-- m
 [Play Store's minimum API to upload or update apps](https://developer.android.com/distribute/best-practices/develop/target-sdk). <!-- markdown-link-check-enable -->
 Users of older phones may want to use an older API when testing.
 
+Keep in mind that if you are using `bevy_audio` the minimum supported Android API version is 26 (Android 8/Oreo).
+
 To use a different API, the following fields must be updated in `Cargo.toml`:
 
 ```toml

--- a/examples/mobile/build_rust_deps.sh
+++ b/examples/mobile/build_rust_deps.sh
@@ -54,7 +54,7 @@ for arch in $ARCHS; do
         TARGET=aarch64-apple-ios
       else
         # M1 iOS simulator
-        TARGET=aarch64-apple-ios-sim
+        TARGET=arm64-apple-ios-simulator
       fi
   esac
 

--- a/examples/movement/physics_in_fixed_timestep.rs
+++ b/examples/movement/physics_in_fixed_timestep.rs
@@ -160,7 +160,7 @@ struct Velocity(Vec3);
 ///
 /// If you want to make sure that this component is always initialized
 /// with the same value as the `Transform`'s translation, you can
-/// use a [component lifecycle hook](https://docs.rs/bevy/0.14.0/bevy/ecs/component/struct.ComponentHooks.html)
+/// use a [component lifecycle hook](https://docs.rs/bevy/latest/bevy/ecs/component/struct.ComponentHooks.html)
 #[derive(Debug, Component, Clone, Copy, PartialEq, Default, Deref, DerefMut)]
 struct PhysicalTranslation(Vec3);
 


### PR DESCRIPTION
# Objective

- Closes #19672 

## Solution

- Updated both `cpal` and `rodio` to their latest versions.
- Updated code to address `rodio`'s breaking changes.
- Reworked audio related feature flags so `symphonia` support becomes the default.

## Testing

- Tested audio related examples.
- NOTE: `soundtrack` and spatial examples are not working in this PR yet.