### PR TITLE
Implement Serialized Image

### DIFF
--- a/crates/bevy_image/Cargo.toml
+++ b/crates/bevy_image/Cargo.toml
@@ -53,15 +53,15 @@ compressed_image_saver = ["basis-universal"]
 bevy_app = { path = "../bevy_app", version = "0.17.0-dev" }
 bevy_asset = { path = "../bevy_asset", version = "0.17.0-dev" }
 bevy_color = { path = "../bevy_color", version = "0.17.0-dev", features = [
-    "serialize",
-    "wgpu-types",
+  "serialize",
+  "wgpu-types",
 ] }
 bevy_ecs = { path = "../bevy_ecs", version = "0.17.0-dev", default-features = false }
 bevy_math = { path = "../bevy_math", version = "0.17.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.17.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.17.0-dev" }
 bevy_platform = { path = "../bevy_platform", version = "0.17.0-dev", default-features = false, features = [
-    "std",
+  "std",
 ] }
 
 # rendering

--- a/crates/bevy_image/Cargo.toml
+++ b/crates/bevy_image/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [features]
-default = ["bevy_reflect", "serialize"]
+default = ["bevy_reflect"]
 
 # bevy_reflect can't optional as it's needed for TypePath
 # this feature only control reflection in bevy_image
@@ -53,15 +53,15 @@ compressed_image_saver = ["basis-universal"]
 bevy_app = { path = "../bevy_app", version = "0.17.0-dev" }
 bevy_asset = { path = "../bevy_asset", version = "0.17.0-dev" }
 bevy_color = { path = "../bevy_color", version = "0.17.0-dev", features = [
-  "serialize",
-  "wgpu-types",
+    "serialize",
+    "wgpu-types",
 ] }
 bevy_ecs = { path = "../bevy_ecs", version = "0.17.0-dev", default-features = false }
 bevy_math = { path = "../bevy_math", version = "0.17.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.17.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.17.0-dev" }
 bevy_platform = { path = "../bevy_platform", version = "0.17.0-dev", default-features = false, features = [
-  "std",
+    "std",
 ] }
 
 # rendering

--- a/crates/bevy_image/Cargo.toml
+++ b/crates/bevy_image/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [features]
-default = ["bevy_reflect"]
+default = ["bevy_reflect", "serialize"]
 
 # bevy_reflect can't optional as it's needed for TypePath
 # this feature only control reflection in bevy_image
@@ -32,7 +32,7 @@ qoi = ["image/qoi"]
 tga = ["image/tga"]
 tiff = ["image/tiff"]
 webp = ["image/webp"]
-serialize = ["bevy_reflect", "bevy_platform/serialize"]
+serialize = ["bevy_reflect", "bevy_platform/serialize", "wgpu-types/serde"]
 
 # For ktx2 supercompression
 zlib = ["flate2"]
@@ -89,6 +89,7 @@ half = { version = "2.4.1" }
 
 [dev-dependencies]
 bevy_ecs = { path = "../bevy_ecs", version = "0.17.0-dev" }
+serde_json = "1.0.140"
 
 [lints]
 workspace = true

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -361,7 +361,7 @@ impl ToExtents for UVec3 {
 
 /// An image, optimized for usage in rendering.
 ///
-/// ## Transmission
+/// ## Remote Inspection
 ///
 /// To transmit an [`Image`] between two running Bevy apps, e.g. through BRP, use [`SerializedImage`](crate::SerializedImage).
 /// This type is only meant for short-term transmission between same versions and should not be stored anywhere.

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -383,9 +383,23 @@ pub struct Image {
     /// Use [`TextureDataOrder::default()`] for all other cases.
     pub data_order: TextureDataOrder,
     // TODO: this nesting makes accessing Image metadata verbose. Either flatten out descriptor or add accessors.
+    /// Describes the data layout of the GPU texture.\
+    /// For example, whether a texture contains 1D/2D/3D data, and what the format of the texture data is.
+    ///
+    /// ## Field Usage Notes
+    /// - [`TextureDescriptor::label`] is used for caching purposes when not using `Asset<Image>`.\
+    ///   If you use assets, the label is purely a debugging aid.
+    /// - [`TextureDescriptor::view_formats`] is currently unused by Bevy.
     pub texture_descriptor: TextureDescriptor<Option<&'static str>, &'static [TextureFormat]>,
     /// The [`ImageSampler`] to use during rendering.
     pub sampler: ImageSampler,
+    /// Describes how the GPU texture should be interpreted.\
+    /// For example, 2D image data could be read as plain 2D, an array texture of layers of 2D with the same dimensions (and the number of layers in that case),
+    /// a cube map, an array of cube maps, etc.
+    ///
+    /// ## Field Usage Notes
+    /// - [`TextureViewDescriptor::label`] is used for caching purposes when not using `Asset<Image>`.\
+    ///   If you use assets, the label is purely a debugging aid.
     pub texture_view_descriptor: Option<TextureViewDescriptor<Option<&'static str>>>,
     pub asset_usage: RenderAssetUsages,
     /// Whether this image should be copied on the GPU when resized.

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -359,7 +359,7 @@ impl ToExtents for UVec3 {
     }
 }
 
-/// A 2D image.
+/// An image, optimized for usage in rendering.
 ///
 /// ## Transmission
 ///

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -359,7 +359,7 @@ impl ToExtents for UVec3 {
     }
 }
 
-#[derive(Asset, Debug, Clone)]
+#[derive(Asset, Debug, Clone, PartialEq)]
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(Reflect),

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -359,6 +359,12 @@ impl ToExtents for UVec3 {
     }
 }
 
+/// A 2D image.
+///
+/// ## Transmission
+///
+/// To transmit an [`Image`] between two running Bevy apps, e.g. through BRP, use [`SerializedImage`](crate::SerializedImage).
+/// This type is only meant for short-term transmission between same versions and should not be stored anywhere.
 #[derive(Asset, Debug, Clone, PartialEq)]
 #[cfg_attr(
     feature = "bevy_reflect",

--- a/crates/bevy_image/src/lib.rs
+++ b/crates/bevy_image/src/lib.rs
@@ -17,6 +17,10 @@ compile_error!(
 
 mod image;
 pub use self::image::*;
+#[cfg(feature = "serialize")]
+mod serialized_image;
+#[cfg(feature = "serialize")]
+pub use self::serialized_image::*;
 #[cfg(feature = "basis-universal")]
 mod basis;
 #[cfg(feature = "compressed_image_saver")]

--- a/crates/bevy_image/src/serialized_image.rs
+++ b/crates/bevy_image/src/serialized_image.rs
@@ -1,0 +1,177 @@
+use crate::{Image, ImageSampler};
+use alloc::fmt::Debug;
+use bevy_asset::RenderAssetUsages;
+use serde::{Deserialize, Serialize};
+use wgpu_types::{
+    TextureAspect, TextureDataOrder, TextureDescriptor, TextureFormat, TextureUsages,
+    TextureViewDescriptor, TextureViewDimension,
+};
+
+/// A version of [`Image`] suitable for serializing for short-term transfer.
+///
+/// [`Image`] does not implement [`Serialize`] / [`Deserialize`] because it is made with the renderer in mind.
+/// It is not a general-purpose image implementation, and its internals are subject to frequent change.
+/// As such, storing a [`Image`] on disk is highly discouraged.
+///
+/// But there are still some valid use cases for serializing a [`Image`], namely transferring meshes between processes.
+/// To support this, you can create a [`SerializedImage`] from a [`Image`] with [`SerializedImage::from_image`],
+/// and then deserialize it with [`SerializedImage::into_mesh`].
+///
+/// The caveats are:
+/// - The image representation is not valid across different versions of Bevy.
+/// - This conversion is lossy. The following information is not preserved:
+///   - texture descriptor and texture view descriptor labels
+///   - texture descriptor view formats
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SerializedImage {
+    data: Option<Vec<u8>>,
+    data_order: SerializedTextureDataOrder,
+    texture_descriptor: TextureDescriptor<(), ()>,
+    sampler: ImageSampler,
+    texture_view_descriptor: Option<SerializedTextureViewDescriptor>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SerializedTextureViewDescriptor {
+    format: Option<TextureFormat>,
+    dimension: Option<TextureViewDimension>,
+    usage: Option<TextureUsages>,
+    aspect: TextureAspect,
+    base_mip_level: u32,
+    mip_level_count: Option<u32>,
+    base_array_layer: u32,
+    array_layer_count: Option<u32>,
+}
+
+impl SerializedTextureViewDescriptor {
+    fn from_texture_view_descriptor(
+        descriptor: TextureViewDescriptor<Option<&'static str>>,
+    ) -> Self {
+        Self {
+            format: descriptor.format,
+            dimension: descriptor.dimension,
+            usage: descriptor.usage,
+            aspect: descriptor.aspect,
+            base_mip_level: descriptor.base_mip_level,
+            mip_level_count: descriptor.mip_level_count,
+            base_array_layer: descriptor.base_array_layer,
+            array_layer_count: descriptor.array_layer_count,
+        }
+    }
+
+    fn into_texture_view_descriptor(self) -> TextureViewDescriptor<Option<&'static str>> {
+        TextureViewDescriptor {
+            // Not used for asset-based images other than debugging
+            label: None,
+            format: self.format,
+            dimension: self.dimension,
+            usage: self.usage,
+            aspect: self.aspect,
+            base_mip_level: self.base_mip_level,
+            mip_level_count: self.mip_level_count,
+            base_array_layer: self.base_array_layer,
+            array_layer_count: self.array_layer_count,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+enum SerializedTextureDataOrder {
+    LayerMajor,
+    MipMajor,
+}
+
+impl SerializedTextureDataOrder {
+    fn from_texture_data_order(order: TextureDataOrder) -> Self {
+        match order {
+            TextureDataOrder::LayerMajor => SerializedTextureDataOrder::LayerMajor,
+            TextureDataOrder::MipMajor => SerializedTextureDataOrder::MipMajor,
+        }
+    }
+
+    fn into_texture_data_order(self) -> TextureDataOrder {
+        match self {
+            SerializedTextureDataOrder::LayerMajor => TextureDataOrder::LayerMajor,
+            SerializedTextureDataOrder::MipMajor => TextureDataOrder::MipMajor,
+        }
+    }
+}
+
+impl SerializedImage {
+    /// Creates a new [`SerializedImage`] from an [`Image`].
+    pub fn from_image(image: Image) -> Self {
+        Self {
+            data: image.data,
+            data_order: SerializedTextureDataOrder::from_texture_data_order(image.data_order),
+            texture_descriptor: TextureDescriptor {
+                label: (),
+                size: image.texture_descriptor.size,
+                mip_level_count: image.texture_descriptor.mip_level_count,
+                sample_count: image.texture_descriptor.sample_count,
+                dimension: image.texture_descriptor.dimension,
+                format: image.texture_descriptor.format,
+                usage: image.texture_descriptor.usage,
+                view_formats: (),
+            },
+            sampler: image.sampler,
+            texture_view_descriptor: image.texture_view_descriptor.map(|descriptor| {
+                SerializedTextureViewDescriptor::from_texture_view_descriptor(descriptor)
+            }),
+        }
+    }
+
+    /// Create an [`Image`] from a [`SerializedImage`].
+    pub fn into_image(self) -> Image {
+        Image {
+            data: self.data,
+            data_order: self.data_order.into_texture_data_order(),
+            texture_descriptor: TextureDescriptor {
+                // Not used for asset-based images other than debugging
+                label: None,
+                size: self.texture_descriptor.size,
+                mip_level_count: self.texture_descriptor.mip_level_count,
+                sample_count: self.texture_descriptor.sample_count,
+                dimension: self.texture_descriptor.dimension,
+                format: self.texture_descriptor.format,
+                usage: self.texture_descriptor.usage,
+                // Not used for asset-based images
+                view_formats: &[],
+            },
+            sampler: self.sampler,
+            texture_view_descriptor: self
+                .texture_view_descriptor
+                .map(|descriptor| descriptor.into_texture_view_descriptor()),
+            asset_usage: RenderAssetUsages::all(),
+            copy_on_resize: false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use wgpu_types::{Extent3d, TextureDimension};
+
+    use super::*;
+
+    #[test]
+    fn serialize_deserialize_image() {
+        let image = Image::new(
+            Extent3d {
+                width: 3,
+                height: 1,
+                depth_or_array_layers: 1,
+            },
+            TextureDimension::D2,
+            vec![255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255],
+            TextureFormat::Rgba8UnormSrgb,
+            RenderAssetUsages::RENDER_WORLD,
+        );
+
+        let serialized_image = SerializedImage::from_image(image.clone());
+        let serialized_string = serde_json::to_string(&serialized_image).unwrap();
+        let serialized_image_from_string: SerializedImage =
+            serde_json::from_str(&serialized_string).unwrap();
+        let deserialized_image = serialized_image_from_string.into_image();
+        assert_eq!(image, deserialized_image);
+    }
+}

--- a/crates/bevy_image/src/serialized_image.rs
+++ b/crates/bevy_image/src/serialized_image.rs
@@ -15,7 +15,7 @@ use wgpu_types::{
 ///
 /// But there are still some valid use cases for serializing a [`Image`], namely transferring meshes between processes.
 /// To support this, you can create a [`SerializedImage`] from a [`Image`] with [`SerializedImage::from_image`],
-/// and then deserialize it with [`SerializedImage::into_mesh`].
+/// and then deserialize it with [`SerializedImage::into_image`].
 ///
 /// The caveats are:
 /// - The image representation is not valid across different versions of Bevy.

--- a/crates/bevy_image/src/serialized_image.rs
+++ b/crates/bevy_image/src/serialized_image.rs
@@ -11,11 +11,11 @@ use wgpu_types::{
 ///
 /// [`Image`] does not implement [`Serialize`] / [`Deserialize`] because it is made with the renderer in mind.
 /// It is not a general-purpose image implementation, and its internals are subject to frequent change.
-/// As such, storing a [`Image`] on disk is highly discouraged.
+/// As such, storing an [`Image`] on disk is highly discouraged.
 /// Use an existing image asset format such as `.png` instead!
 ///
-/// But there are still some valid use cases for serializing a [`Image`], namely transferring meshes between processes.
-/// To support this, you can create a [`SerializedImage`] from a [`Image`] with [`SerializedImage::from_image`],
+/// But there are still some valid use cases for serializing an [`Image`], namely transferring images between processes.
+/// To support this, you can create a [`SerializedImage`] from an [`Image`] with [`SerializedImage::from_image`],
 /// and then deserialize it with [`SerializedImage::into_image`].
 ///
 /// The caveats are:

--- a/crates/bevy_image/src/serialized_image.rs
+++ b/crates/bevy_image/src/serialized_image.rs
@@ -1,6 +1,6 @@
 use crate::{Image, ImageSampler};
-use alloc::fmt::Debug;
 use bevy_asset::RenderAssetUsages;
+use core::fmt::Debug;
 use serde::{Deserialize, Serialize};
 use wgpu_types::{
     TextureAspect, TextureDataOrder, TextureDescriptor, TextureFormat, TextureUsages,
@@ -140,7 +140,7 @@ impl SerializedImage {
             sampler: self.sampler,
             texture_view_descriptor: self
                 .texture_view_descriptor
-                .map(|descriptor| descriptor.into_texture_view_descriptor()),
+                .map(SerializedTextureViewDescriptor::into_texture_view_descriptor),
             asset_usage: RenderAssetUsages::all(),
             copy_on_resize: false,
         }

--- a/crates/bevy_image/src/serialized_image.rs
+++ b/crates/bevy_image/src/serialized_image.rs
@@ -12,6 +12,7 @@ use wgpu_types::{
 /// [`Image`] does not implement [`Serialize`] / [`Deserialize`] because it is made with the renderer in mind.
 /// It is not a general-purpose image implementation, and its internals are subject to frequent change.
 /// As such, storing a [`Image`] on disk is highly discouraged.
+/// Use an existing image asset format such as `.png` instead!
 ///
 /// But there are still some valid use cases for serializing a [`Image`], namely transferring meshes between processes.
 /// To support this, you can create a [`SerializedImage`] from a [`Image`] with [`SerializedImage::from_image`],

--- a/crates/bevy_image/src/serialized_image.rs
+++ b/crates/bevy_image/src/serialized_image.rs
@@ -141,7 +141,7 @@ impl SerializedImage {
             texture_view_descriptor: self
                 .texture_view_descriptor
                 .map(SerializedTextureViewDescriptor::into_texture_view_descriptor),
-            asset_usage: RenderAssetUsages::all(),
+            asset_usage: RenderAssetUsages::RENDER_WORLD,
             copy_on_resize: false,
         }
     }

--- a/crates/bevy_mesh/src/mesh.rs
+++ b/crates/bevy_mesh/src/mesh.rs
@@ -110,6 +110,11 @@ pub const VERTEX_ATTRIBUTE_BUFFER_ID: u64 = 10;
 /// - Vertex winding order: by default, `StandardMaterial.cull_mode` is `Some(Face::Back)`,
 ///   which means that Bevy would *only* render the "front" of each triangle, which
 ///   is the side of the triangle from where the vertices appear in a *counter-clockwise* order.
+///
+/// ## Transmission
+///
+/// To transmit a [`Mesh`] between two running Bevy apps, e.g. through BRP, use [`SerializedMesh`].
+/// This type is only meant for short-term transmission between same versions and should not be stored anywhere.
 #[derive(Asset, Debug, Clone, Reflect, PartialEq)]
 #[reflect(Clone)]
 pub struct Mesh {

--- a/crates/bevy_mesh/src/mesh.rs
+++ b/crates/bevy_mesh/src/mesh.rs
@@ -111,7 +111,7 @@ pub const VERTEX_ATTRIBUTE_BUFFER_ID: u64 = 10;
 ///   which means that Bevy would *only* render the "front" of each triangle, which
 ///   is the side of the triangle from where the vertices appear in a *counter-clockwise* order.
 ///
-/// ## Transmission
+/// ## Remote Inspection
 ///
 /// To transmit a [`Mesh`] between two running Bevy apps, e.g. through BRP, use [`SerializedMesh`].
 /// This type is only meant for short-term transmission between same versions and should not be stored anywhere.


### PR DESCRIPTION
# Objective

Following #19743, we can now send meshes over BRP to an editor, yay!

https://github.com/user-attachments/assets/84ce4fa7-c402-4738-9414-a446cd0472fe

But oh no, the editor look a bit pale! No wonder; we cannot send `StandardMaterial` over the wire yet because `Image` is not serializable!

## Solution

- Do the same as for `SerializedMesh` and `SerialzedAnimationGraph`: create a `SerializedImage` meant for transmission.
- ~~I don't think making a `SerializedStandardMaterial` is necessary for now, that part is trivial to do by hand if `Image` is serializable.~~
  - I take that back, it's about 500 LOC and a can of worms I don't want to open upstream. I'll leave serializing standard materials for userland for now :P

## Testing

- Added a roundtrip serialization
- Ported the navmesh editor:


https://github.com/user-attachments/assets/1ccbad6e-5beb-4846-8e18-c55c85709481


## Additional Info

Added it to the milestone with Alice's consent :)