### PR TITLE
Move line height into the `TextLayout` component

### DIFF
--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -133,6 +133,8 @@ impl TextPipeline {
 
             // Get max font size for use in cosmic Metrics.
             font_size = font_size.max(text_font.font_size);
+
+            // If a relative line height was chosen, base it on the largest font size in the text block.
             max_line_height = max_line_height.max(line_height.eval(text_font.font_size));
 
             // Load Bevy fonts into cosmic-text's font system.

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -359,15 +359,18 @@ impl Default for TextFont {
     }
 }
 
-/// Specifies the height of each line of text for `Text` and `Text2d`
+/// Specifies the height of each line of text for `Text` and `Text2d`.
 ///
-/// Default is 1.2x the font size
+/// LineHeight is set per text block, not per text span.
+/// If a `RelativeToFont` value is used, the resolved line height will be based on the size of the largest font in the text block.
+///
+/// Default is 1.2x the font size.
 #[derive(Debug, Clone, Copy, PartialEq, Reflect)]
 #[reflect(Debug, Clone, PartialEq)]
 pub enum LineHeight {
     /// Set line height to a specific number of pixels
     Px(f32),
-    /// Set line height to a multiple of the font size
+    /// Set line height to a multiple of the size of the largest font in the text block
     RelativeToFont(f32),
 }
 

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -119,12 +119,21 @@ pub struct TextLayout {
     pub justify: Justify,
     /// How the text should linebreak when running out of the bounds determined by `max_size`.
     pub linebreak: LineBreak,
+    /// The vertical height of a line of text, from the top of one line to the top of the
+    /// next.
+    ///
+    /// Defaults to `LineHeight::RelativeToFont(1.2)`
+    pub line_height: LineHeight,
 }
 
 impl TextLayout {
     /// Makes a new [`TextLayout`].
-    pub const fn new(justify: Justify, linebreak: LineBreak) -> Self {
-        Self { justify, linebreak }
+    pub const fn new(justify: Justify, linebreak: LineBreak, line_height: LineHeight) -> Self {
+        Self {
+            justify,
+            linebreak,
+            line_height,
+        }
     }
 
     /// Makes a new [`TextLayout`] with the specified [`Justify`].
@@ -143,6 +152,11 @@ impl TextLayout {
         Self::default().with_no_wrap()
     }
 
+    /// Makes a new [`TextLayout`] with the specified [`LineHeight`].
+    pub fn new_with_line_height(line_height: LineHeight) -> Self {
+        Self::default().with_line_height(line_height)
+    }
+
     /// Returns this [`TextLayout`] with the specified [`Justify`].
     pub const fn with_justify(mut self, justify: Justify) -> Self {
         self.justify = justify;
@@ -159,6 +173,12 @@ impl TextLayout {
     /// Hard wrapping, where text contains an explicit linebreak such as the escape sequence `\n`, will still occur.
     pub const fn with_no_wrap(mut self) -> Self {
         self.linebreak = LineBreak::NoWrap;
+        self
+    }
+
+    /// Returns this [`TextLayout`] with the specified [`LineHeight`].
+    pub const fn with_line_height(mut self, line_height: LineHeight) -> Self {
+        self.line_height = line_height;
         self
     }
 }
@@ -295,11 +315,6 @@ pub struct TextFont {
     /// A new font atlas is generated for every combination of font handle and scaled font size
     /// which can have a strong performance impact.
     pub font_size: f32,
-    /// The vertical height of a line of text, from the top of one line to the top of the
-    /// next.
-    ///
-    /// Defaults to `LineHeight::RelativeToFont(1.2)`
-    pub line_height: LineHeight,
     /// The antialiasing method to use when rendering text.
     pub font_smoothing: FontSmoothing,
 }
@@ -332,12 +347,6 @@ impl TextFont {
         self.font_smoothing = font_smoothing;
         self
     }
-
-    /// Returns this [`TextFont`] with the specified [`LineHeight`].
-    pub const fn with_line_height(mut self, line_height: LineHeight) -> Self {
-        self.line_height = line_height;
-        self
-    }
 }
 
 impl Default for TextFont {
@@ -345,7 +354,6 @@ impl Default for TextFont {
         Self {
             font: Default::default(),
             font_size: 20.0,
-            line_height: LineHeight::default(),
             font_smoothing: Default::default(),
         }
     }

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -231,6 +231,7 @@ fn create_text_measure<'a>(
         entity,
         fonts,
         spans,
+        block.line_height,
         scale_factor,
         &block,
         computed.as_mut(),


### PR DESCRIPTION
# Objective
In cosmic text all the lines in a buffer have the same height but the `TextFont` component interface implies that it is set per font.

## Solution

* Moved the `line_height` field into the `TextLayout` component.
* Updated the doc comments to explain that relative line height is based on the size of the largest font in its text block.