### PR TITLE
Add a `from_line_height` constructor function to `TextFont`.

### DIFF
--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -4,7 +4,7 @@ use bevy_color::Color;
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{prelude::*, reflect::ReflectComponent};
 use bevy_reflect::prelude::*;
-use bevy_utils::once;
+use bevy_utils::{default, once};
 use cosmic_text::{Buffer, Metrics};
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
@@ -342,6 +342,21 @@ impl TextFont {
     pub const fn with_line_height(mut self, line_height: LineHeight) -> Self {
         self.line_height = line_height;
         self
+    }
+}
+
+impl From<Handle<Font>> for TextFont {
+    fn from(font: Handle<Font>) -> Self {
+        Self { font, ..default() }
+    }
+}
+
+impl From<LineHeight> for TextFont {
+    fn from(line_height: LineHeight) -> Self {
+        Self {
+            line_height,
+            ..default()
+        }
     }
 }
 

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -315,6 +315,11 @@ impl TextFont {
         Self::default().with_font_size(font_size)
     }
 
+    /// Returns a new [`TextFont`] with the specified line height.
+    pub fn from_line_height(line_height: LineHeight) -> Self {
+        Self::default().with_line_height(line_height)
+    }
+
     /// Returns this [`TextFont`] with the specified font face handle.
     pub fn with_font(mut self, font: Handle<Font>) -> Self {
         self.font = font;


### PR DESCRIPTION
# Objective

`TextFont` has `from_font` and `from_font_size` constructors but is missing one for line height.

## Solution

* Added a `from_line_height` constructor function to `TextFont`.
* Also added `From<Handle<Font>>` and `From<LineHeight>` impls.

We could also add a `From<f32>` for font size but thought it might be confusing. At some some point we want to add responsive text size support, can do it then.