### PR TITLE
Reflect non-callback components and resources in bevy_core_widgets and bevy_feathers

### DIFF
--- a/crates/bevy_core_widgets/Cargo.toml
+++ b/crates/bevy_core_widgets/Cargo.toml
@@ -18,6 +18,7 @@ bevy_input_focus = { path = "../bevy_input_focus", version = "0.17.0-dev" }
 bevy_log = { path = "../bevy_log", version = "0.17.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.17.0-dev" }
 bevy_picking = { path = "../bevy_picking", version = "0.17.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.17.0-dev" }
 bevy_ui = { path = "../bevy_ui", version = "0.17.0-dev" }
 
 # other

--- a/crates/bevy_core_widgets/src/callback.rs
+++ b/crates/bevy_core_widgets/src/callback.rs
@@ -1,5 +1,6 @@
 use bevy_ecs::system::{Commands, SystemId, SystemInput};
 use bevy_ecs::world::{DeferredWorld, World};
+use bevy_reflect::Reflect;
 
 /// A callback defines how we want to be notified when a widget changes state. Unlike an event
 /// or observer, callbacks are intended for "point-to-point" communication that cuts across the
@@ -27,7 +28,7 @@ use bevy_ecs::world::{DeferredWorld, World};
 /// // Later, when we want to execute the callback:
 /// app.world_mut().commands().notify(&callback);
 /// ```
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Reflect)]
 pub enum Callback<I: SystemInput = ()> {
     /// Invoke a one-shot system
     System(SystemId<I>),

--- a/crates/bevy_core_widgets/src/callback.rs
+++ b/crates/bevy_core_widgets/src/callback.rs
@@ -1,6 +1,6 @@
 use bevy_ecs::system::{Commands, SystemId, SystemInput};
 use bevy_ecs::world::{DeferredWorld, World};
-use bevy_reflect::Reflect;
+use bevy_reflect::{prelude::ReflectDefault, Reflect};
 
 /// A callback defines how we want to be notified when a widget changes state. Unlike an event
 /// or observer, callbacks are intended for "point-to-point" communication that cuts across the
@@ -29,6 +29,7 @@ use bevy_reflect::Reflect;
 /// app.world_mut().commands().notify(&callback);
 /// ```
 #[derive(Default, Debug, Reflect)]
+#[reflect(Default)]
 pub enum Callback<I: SystemInput = ()> {
     /// Invoke a one-shot system
     System(SystemId<I>),

--- a/crates/bevy_core_widgets/src/core_radio.rs
+++ b/crates/bevy_core_widgets/src/core_radio.rs
@@ -8,12 +8,14 @@ use bevy_ecs::{
     component::Component,
     observer::On,
     query::With,
+    reflect::ReflectComponent,
     system::{Commands, Query},
 };
 use bevy_input::keyboard::{KeyCode, KeyboardInput};
 use bevy_input::ButtonState;
 use bevy_input_focus::FocusedInput;
 use bevy_picking::events::{Click, Pointer};
+use bevy_reflect::Reflect;
 use bevy_ui::{Checkable, Checked, InteractionDisabled};
 
 use crate::{Activate, Callback, Notify};
@@ -48,6 +50,8 @@ pub struct CoreRadioGroup {
 /// See <https://www.w3.org/WAI/ARIA/apg/patterns/radio>/
 #[derive(Component, Debug)]
 #[require(AccessibilityNode(accesskit::Node::new(Role::RadioButton)), Checkable)]
+#[derive(Reflect)]
+#[reflect(Component)]
 pub struct CoreRadio;
 
 fn radio_group_on_key_input(

--- a/crates/bevy_core_widgets/src/core_scrollbar.rs
+++ b/crates/bevy_core_widgets/src/core_scrollbar.rs
@@ -5,17 +5,20 @@ use bevy_ecs::{
     hierarchy::{ChildOf, Children},
     observer::On,
     query::{With, Without},
+    reflect::ReflectComponent,
     system::{Query, Res},
 };
 use bevy_math::Vec2;
 use bevy_picking::events::{Cancel, Drag, DragEnd, DragStart, Pointer, Press};
+use bevy_reflect::Reflect;
 use bevy_ui::{
     ComputedNode, ComputedNodeTarget, Node, ScrollPosition, UiGlobalTransform, UiScale, Val,
 };
 
 /// Used to select the orientation of a scrollbar, slider, or other oriented control.
 // TODO: Move this to a more central place.
-#[derive(Debug, Default, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Reflect)]
+#[reflect(PartialEq, Clone)]
 pub enum ControlOrientation {
     /// Horizontal orientation (stretching from left to right)
     Horizontal,
@@ -45,7 +48,8 @@ pub enum ControlOrientation {
 /// The application is free to position the scrollbars relative to the scrolling container however
 /// it wants: it can overlay them on top of the scrolling content, or use a grid layout to displace
 /// the content to make room for the scrollbars.
-#[derive(Component, Debug)]
+#[derive(Component, Debug, Reflect)]
+#[reflect(Component)]
 pub struct CoreScrollbar {
     /// Entity being scrolled.
     pub target: Entity,
@@ -62,6 +66,8 @@ pub struct CoreScrollbar {
 /// the scrollbar). This should be a child of the scrollbar entity.
 #[derive(Component, Debug)]
 #[require(CoreScrollbarDragState)]
+#[derive(Reflect)]
+#[reflect(Component)]
 pub struct CoreScrollbarThumb;
 
 impl CoreScrollbar {
@@ -83,7 +89,8 @@ impl CoreScrollbar {
 
 /// Component used to manage the state of a scrollbar during dragging. This component is
 /// inserted on the thumb entity.
-#[derive(Component, Default)]
+#[derive(Component, Default, Reflect)]
+#[reflect(Component)]
 pub struct CoreScrollbarDragState {
     /// Whether the scrollbar is currently being dragged.
     pub dragging: bool,

--- a/crates/bevy_core_widgets/src/core_scrollbar.rs
+++ b/crates/bevy_core_widgets/src/core_scrollbar.rs
@@ -10,7 +10,7 @@ use bevy_ecs::{
 };
 use bevy_math::Vec2;
 use bevy_picking::events::{Cancel, Drag, DragEnd, DragStart, Pointer, Press};
-use bevy_reflect::Reflect;
+use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_ui::{
     ComputedNode, ComputedNodeTarget, Node, ScrollPosition, UiGlobalTransform, UiScale, Val,
 };
@@ -18,7 +18,7 @@ use bevy_ui::{
 /// Used to select the orientation of a scrollbar, slider, or other oriented control.
 // TODO: Move this to a more central place.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Reflect)]
-#[reflect(PartialEq, Clone)]
+#[reflect(PartialEq, Clone, Default)]
 pub enum ControlOrientation {
     /// Horizontal orientation (stretching from left to right)
     Horizontal,
@@ -90,7 +90,7 @@ impl CoreScrollbar {
 /// Component used to manage the state of a scrollbar during dragging. This component is
 /// inserted on the thumb entity.
 #[derive(Component, Default, Reflect)]
-#[reflect(Component)]
+#[reflect(Component, Default)]
 pub struct CoreScrollbarDragState {
     /// Whether the scrollbar is currently being dragged.
     pub dragging: bool,

--- a/crates/bevy_core_widgets/src/core_slider.rs
+++ b/crates/bevy_core_widgets/src/core_slider.rs
@@ -22,14 +22,14 @@ use bevy_input_focus::FocusedInput;
 use bevy_log::warn_once;
 use bevy_math::ops;
 use bevy_picking::events::{Drag, DragEnd, DragStart, Pointer, Press};
-use bevy_reflect::Reflect;
+use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_ui::{ComputedNode, ComputedNodeTarget, InteractionDisabled, UiGlobalTransform, UiScale};
 
 use crate::{Callback, Notify, ValueChange};
 
 /// Defines how the slider should behave when you click on the track (not the thumb).
 #[derive(Debug, Default, PartialEq, Clone, Copy, Reflect)]
-#[reflect(Clone, PartialEq)]
+#[reflect(Clone, PartialEq, Default)]
 pub enum TrackClick {
     /// Clicking on the track lets you drag to edit the value, just like clicking on the thumb.
     #[default]
@@ -204,7 +204,7 @@ impl Default for SliderStep {
 /// value of 2 would round to the nearest 1/100th. A value of -3 would round to the nearest
 /// thousand.
 #[derive(Component, Debug, Default, Clone, Copy, Reflect)]
-#[reflect(Component)]
+#[reflect(Component, Default)]
 pub struct SliderPrecision(pub i32);
 
 impl SliderPrecision {

--- a/crates/bevy_core_widgets/src/core_slider.rs
+++ b/crates/bevy_core_widgets/src/core_slider.rs
@@ -13,6 +13,7 @@ use bevy_ecs::{
     component::Component,
     observer::On,
     query::With,
+    reflect::ReflectComponent,
     system::{Commands, Query},
 };
 use bevy_input::keyboard::{KeyCode, KeyboardInput};
@@ -21,12 +22,14 @@ use bevy_input_focus::FocusedInput;
 use bevy_log::warn_once;
 use bevy_math::ops;
 use bevy_picking::events::{Drag, DragEnd, DragStart, Pointer, Press};
+use bevy_reflect::Reflect;
 use bevy_ui::{ComputedNode, ComputedNodeTarget, InteractionDisabled, UiGlobalTransform, UiScale};
 
 use crate::{Callback, Notify, ValueChange};
 
 /// Defines how the slider should behave when you click on the track (not the thumb).
-#[derive(Debug, Default, PartialEq, Clone, Copy)]
+#[derive(Debug, Default, PartialEq, Clone, Copy, Reflect)]
+#[reflect(Clone, PartialEq)]
 pub enum TrackClick {
     /// Clicking on the track lets you drag to edit the value, just like clicking on the thumb.
     #[default]
@@ -181,6 +184,8 @@ impl Default for SliderRange {
 /// shortcuts. Defaults to 1.0.
 #[derive(Component, Debug, PartialEq, Clone)]
 #[component(immutable)]
+#[derive(Reflect)]
+#[reflect(Component)]
 pub struct SliderStep(pub f32);
 
 impl Default for SliderStep {
@@ -198,7 +203,8 @@ impl Default for SliderStep {
 /// The value in this component represents the number of decimal places of desired precision, so a
 /// value of 2 would round to the nearest 1/100th. A value of -3 would round to the nearest
 /// thousand.
-#[derive(Component, Debug, Default, Clone, Copy)]
+#[derive(Component, Debug, Default, Clone, Copy, Reflect)]
+#[reflect(Component)]
 pub struct SliderPrecision(pub i32);
 
 impl SliderPrecision {
@@ -209,7 +215,8 @@ impl SliderPrecision {
 }
 
 /// Component used to manage the state of a slider during dragging.
-#[derive(Component, Default)]
+#[derive(Component, Default, Reflect)]
+#[reflect(Component)]
 pub struct CoreSliderDragState {
     /// Whether the slider is currently being dragged.
     pub dragging: bool,

--- a/crates/bevy_feathers/src/alpha_pattern.rs
+++ b/crates/bevy_feathers/src/alpha_pattern.rs
@@ -4,11 +4,12 @@ use bevy_ecs::{
     component::Component,
     lifecycle::Add,
     observer::On,
+    reflect::ReflectComponent,
     resource::Resource,
     system::{Query, Res},
     world::FromWorld,
 };
-use bevy_reflect::TypePath;
+use bevy_reflect::{Reflect, TypePath};
 use bevy_render::render_resource::{AsBindGroup, ShaderRef};
 use bevy_ui_render::ui_material::{MaterialNode, UiMaterial};
 
@@ -34,7 +35,8 @@ impl FromWorld for AlphaPatternResource {
 }
 
 /// Marker that tells us we want to fill in the [`MaterialNode`] with the alpha material.
-#[derive(Component, Default, Clone)]
+#[derive(Component, Default, Clone, Reflect)]
+#[reflect(Component)]
 pub(crate) struct AlphaPattern;
 
 /// Observer to fill in the material handle (since we don't have access to the materials asset

--- a/crates/bevy_feathers/src/alpha_pattern.rs
+++ b/crates/bevy_feathers/src/alpha_pattern.rs
@@ -9,7 +9,7 @@ use bevy_ecs::{
     system::{Query, Res},
     world::FromWorld,
 };
-use bevy_reflect::{Reflect, TypePath};
+use bevy_reflect::{prelude::ReflectDefault, Reflect, TypePath};
 use bevy_render::render_resource::{AsBindGroup, ShaderRef};
 use bevy_ui_render::ui_material::{MaterialNode, UiMaterial};
 
@@ -36,7 +36,7 @@ impl FromWorld for AlphaPatternResource {
 
 /// Marker that tells us we want to fill in the [`MaterialNode`] with the alpha material.
 #[derive(Component, Default, Clone, Reflect)]
-#[reflect(Component)]
+#[reflect(Component, Default)]
 pub(crate) struct AlphaPattern;
 
 /// Observer to fill in the material handle (since we don't have access to the materials asset

--- a/crates/bevy_feathers/src/controls/button.rs
+++ b/crates/bevy_feathers/src/controls/button.rs
@@ -31,7 +31,6 @@ use crate::{
 /// system to identify which entities are buttons.
 #[derive(Component, Default, Clone, Reflect)]
 #[reflect(Component, Clone)]
-
 pub enum ButtonVariant {
     /// The standard button appearance
     #[default]

--- a/crates/bevy_feathers/src/controls/button.rs
+++ b/crates/bevy_feathers/src/controls/button.rs
@@ -7,12 +7,14 @@ use bevy_ecs::{
     hierarchy::{ChildOf, Children},
     lifecycle::RemovedComponents,
     query::{Added, Changed, Has, Or},
+    reflect::ReflectComponent,
     schedule::IntoScheduleConfigs,
     spawn::{SpawnRelated, SpawnableList},
     system::{Commands, In, Query},
 };
 use bevy_input_focus::tab_navigation::TabIndex;
 use bevy_picking::{hover::Hovered, PickingSystems};
+use bevy_reflect::Reflect;
 use bevy_ui::{AlignItems, InteractionDisabled, JustifyContent, Node, Pressed, UiRect, Val};
 
 use crate::{
@@ -27,7 +29,9 @@ use crate::{
 
 /// Color variants for buttons. This also functions as a component used by the dynamic styling
 /// system to identify which entities are buttons.
-#[derive(Component, Default, Clone)]
+#[derive(Component, Default, Clone, Reflect)]
+#[reflect(Component, Clone)]
+
 pub enum ButtonVariant {
     /// The standard button appearance
     #[default]

--- a/crates/bevy_feathers/src/controls/button.rs
+++ b/crates/bevy_feathers/src/controls/button.rs
@@ -14,7 +14,7 @@ use bevy_ecs::{
 };
 use bevy_input_focus::tab_navigation::TabIndex;
 use bevy_picking::{hover::Hovered, PickingSystems};
-use bevy_reflect::Reflect;
+use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_ui::{AlignItems, InteractionDisabled, JustifyContent, Node, Pressed, UiRect, Val};
 
 use crate::{
@@ -30,7 +30,7 @@ use crate::{
 /// Color variants for buttons. This also functions as a component used by the dynamic styling
 /// system to identify which entities are buttons.
 #[derive(Component, Default, Clone, Reflect)]
-#[reflect(Component, Clone)]
+#[reflect(Component, Clone, Default)]
 pub enum ButtonVariant {
     /// The standard button appearance
     #[default]

--- a/crates/bevy_feathers/src/controls/checkbox.rs
+++ b/crates/bevy_feathers/src/controls/checkbox.rs
@@ -42,19 +42,16 @@ pub struct CheckboxProps {
 /// Marker for the checkbox frame (contains both checkbox and label)
 #[derive(Component, Default, Clone, Reflect)]
 #[reflect(Component, Clone)]
-
 struct CheckboxFrame;
 
 /// Marker for the checkbox outline
 #[derive(Component, Default, Clone, Reflect)]
 #[reflect(Component, Clone)]
-
 struct CheckboxOutline;
 
 /// Marker for the checkbox check mark
 #[derive(Component, Default, Clone, Reflect)]
 #[reflect(Component, Clone)]
-
 struct CheckboxMark;
 
 /// Template function to spawn a checkbox.

--- a/crates/bevy_feathers/src/controls/checkbox.rs
+++ b/crates/bevy_feathers/src/controls/checkbox.rs
@@ -8,6 +8,7 @@ use bevy_ecs::{
     hierarchy::{ChildOf, Children},
     lifecycle::RemovedComponents,
     query::{Added, Changed, Has, Or, With},
+    reflect::ReflectComponent,
     schedule::IntoScheduleConfigs,
     spawn::{Spawn, SpawnRelated, SpawnableList},
     system::{Commands, In, Query},
@@ -15,6 +16,7 @@ use bevy_ecs::{
 use bevy_input_focus::tab_navigation::TabIndex;
 use bevy_math::Rot2;
 use bevy_picking::{hover::Hovered, PickingSystems};
+use bevy_reflect::Reflect;
 use bevy_render::view::Visibility;
 use bevy_ui::{
     AlignItems, BorderRadius, Checked, Display, FlexDirection, InteractionDisabled, JustifyContent,
@@ -38,15 +40,21 @@ pub struct CheckboxProps {
 }
 
 /// Marker for the checkbox frame (contains both checkbox and label)
-#[derive(Component, Default, Clone)]
+#[derive(Component, Default, Clone, Reflect)]
+#[reflect(Component, Clone)]
+
 struct CheckboxFrame;
 
 /// Marker for the checkbox outline
-#[derive(Component, Default, Clone)]
+#[derive(Component, Default, Clone, Reflect)]
+#[reflect(Component, Clone)]
+
 struct CheckboxOutline;
 
 /// Marker for the checkbox check mark
-#[derive(Component, Default, Clone)]
+#[derive(Component, Default, Clone, Reflect)]
+#[reflect(Component, Clone)]
+
 struct CheckboxMark;
 
 /// Template function to spawn a checkbox.

--- a/crates/bevy_feathers/src/controls/checkbox.rs
+++ b/crates/bevy_feathers/src/controls/checkbox.rs
@@ -16,7 +16,7 @@ use bevy_ecs::{
 use bevy_input_focus::tab_navigation::TabIndex;
 use bevy_math::Rot2;
 use bevy_picking::{hover::Hovered, PickingSystems};
-use bevy_reflect::Reflect;
+use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_render::view::Visibility;
 use bevy_ui::{
     AlignItems, BorderRadius, Checked, Display, FlexDirection, InteractionDisabled, JustifyContent,
@@ -41,17 +41,17 @@ pub struct CheckboxProps {
 
 /// Marker for the checkbox frame (contains both checkbox and label)
 #[derive(Component, Default, Clone, Reflect)]
-#[reflect(Component, Clone)]
+#[reflect(Component, Clone, Default)]
 struct CheckboxFrame;
 
 /// Marker for the checkbox outline
 #[derive(Component, Default, Clone, Reflect)]
-#[reflect(Component, Clone)]
+#[reflect(Component, Clone, Default)]
 struct CheckboxOutline;
 
 /// Marker for the checkbox check mark
 #[derive(Component, Default, Clone, Reflect)]
-#[reflect(Component, Clone)]
+#[reflect(Component, Clone, Default)]
 struct CheckboxMark;
 
 /// Template function to spawn a checkbox.

--- a/crates/bevy_feathers/src/controls/color_swatch.rs
+++ b/crates/bevy_feathers/src/controls/color_swatch.rs
@@ -1,6 +1,9 @@
 use bevy_asset::Handle;
 use bevy_color::Alpha;
-use bevy_ecs::{bundle::Bundle, children, component::Component, spawn::SpawnRelated};
+use bevy_ecs::{
+    bundle::Bundle, children, component::Component, reflect::ReflectComponent, spawn::SpawnRelated,
+};
+use bevy_reflect::Reflect;
 use bevy_ui::{BackgroundColor, BorderRadius, Node, PositionType, Val};
 use bevy_ui_render::ui_material::MaterialNode;
 
@@ -11,13 +14,17 @@ use crate::{
 };
 
 /// Marker identifying a color swatch.
-#[derive(Component, Default, Clone)]
+#[derive(Component, Default, Clone, Reflect)]
+#[reflect(Component, Clone)]
+
 pub struct ColorSwatch;
 
 /// Marker identifying the color swatch foreground, the piece that actually displays the color
 /// in front of the alpha pattern. This exists so that users can reach in and change the color
 /// dynamically.
-#[derive(Component, Default, Clone)]
+#[derive(Component, Default, Clone, Reflect)]
+#[reflect(Component, Clone)]
+
 pub struct ColorSwatchFg;
 
 /// Template function to spawn a color swatch.

--- a/crates/bevy_feathers/src/controls/color_swatch.rs
+++ b/crates/bevy_feathers/src/controls/color_swatch.rs
@@ -16,7 +16,6 @@ use crate::{
 /// Marker identifying a color swatch.
 #[derive(Component, Default, Clone, Reflect)]
 #[reflect(Component, Clone)]
-
 pub struct ColorSwatch;
 
 /// Marker identifying the color swatch foreground, the piece that actually displays the color
@@ -24,7 +23,6 @@ pub struct ColorSwatch;
 /// dynamically.
 #[derive(Component, Default, Clone, Reflect)]
 #[reflect(Component, Clone)]
-
 pub struct ColorSwatchFg;
 
 /// Template function to spawn a color swatch.

--- a/crates/bevy_feathers/src/controls/color_swatch.rs
+++ b/crates/bevy_feathers/src/controls/color_swatch.rs
@@ -3,7 +3,7 @@ use bevy_color::Alpha;
 use bevy_ecs::{
     bundle::Bundle, children, component::Component, reflect::ReflectComponent, spawn::SpawnRelated,
 };
-use bevy_reflect::Reflect;
+use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_ui::{BackgroundColor, BorderRadius, Node, PositionType, Val};
 use bevy_ui_render::ui_material::MaterialNode;
 
@@ -15,14 +15,14 @@ use crate::{
 
 /// Marker identifying a color swatch.
 #[derive(Component, Default, Clone, Reflect)]
-#[reflect(Component, Clone)]
+#[reflect(Component, Clone, Default)]
 pub struct ColorSwatch;
 
 /// Marker identifying the color swatch foreground, the piece that actually displays the color
 /// in front of the alpha pattern. This exists so that users can reach in and change the color
 /// dynamically.
 #[derive(Component, Default, Clone, Reflect)]
-#[reflect(Component, Clone)]
+#[reflect(Component, Clone, Default)]
 pub struct ColorSwatchFg;
 
 /// Template function to spawn a color swatch.

--- a/crates/bevy_feathers/src/controls/radio.rs
+++ b/crates/bevy_feathers/src/controls/radio.rs
@@ -15,7 +15,7 @@ use bevy_ecs::{
 };
 use bevy_input_focus::tab_navigation::TabIndex;
 use bevy_picking::{hover::Hovered, PickingSystems};
-use bevy_reflect::Reflect;
+use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_render::view::Visibility;
 use bevy_ui::{
     AlignItems, BorderRadius, Checked, Display, FlexDirection, InteractionDisabled, JustifyContent,
@@ -33,12 +33,12 @@ use crate::{
 
 /// Marker for the radio outline
 #[derive(Component, Default, Clone, Reflect)]
-#[reflect(Component, Clone)]
+#[reflect(Component, Clone, Default)]
 struct RadioOutline;
 
 /// Marker for the radio check mark
 #[derive(Component, Default, Clone, Reflect)]
-#[reflect(Component, Clone)]
+#[reflect(Component, Clone, Default)]
 struct RadioMark;
 
 /// Template function to spawn a radio.

--- a/crates/bevy_feathers/src/controls/radio.rs
+++ b/crates/bevy_feathers/src/controls/radio.rs
@@ -34,13 +34,11 @@ use crate::{
 /// Marker for the radio outline
 #[derive(Component, Default, Clone, Reflect)]
 #[reflect(Component, Clone)]
-
 struct RadioOutline;
 
 /// Marker for the radio check mark
 #[derive(Component, Default, Clone, Reflect)]
 #[reflect(Component, Clone)]
-
 struct RadioMark;
 
 /// Template function to spawn a radio.

--- a/crates/bevy_feathers/src/controls/radio.rs
+++ b/crates/bevy_feathers/src/controls/radio.rs
@@ -8,12 +8,14 @@ use bevy_ecs::{
     hierarchy::{ChildOf, Children},
     lifecycle::RemovedComponents,
     query::{Added, Changed, Has, Or, With},
+    reflect::ReflectComponent,
     schedule::IntoScheduleConfigs,
     spawn::{Spawn, SpawnRelated, SpawnableList},
     system::{Commands, Query},
 };
 use bevy_input_focus::tab_navigation::TabIndex;
 use bevy_picking::{hover::Hovered, PickingSystems};
+use bevy_reflect::Reflect;
 use bevy_render::view::Visibility;
 use bevy_ui::{
     AlignItems, BorderRadius, Checked, Display, FlexDirection, InteractionDisabled, JustifyContent,
@@ -30,11 +32,15 @@ use crate::{
 };
 
 /// Marker for the radio outline
-#[derive(Component, Default, Clone)]
+#[derive(Component, Default, Clone, Reflect)]
+#[reflect(Component, Clone)]
+
 struct RadioOutline;
 
 /// Marker for the radio check mark
-#[derive(Component, Default, Clone)]
+#[derive(Component, Default, Clone, Reflect)]
+#[reflect(Component, Clone)]
+
 struct RadioMark;
 
 /// Template function to spawn a radio.

--- a/crates/bevy_feathers/src/controls/slider.rs
+++ b/crates/bevy_feathers/src/controls/slider.rs
@@ -18,7 +18,7 @@ use bevy_ecs::{
 };
 use bevy_input_focus::tab_navigation::TabIndex;
 use bevy_picking::PickingSystems;
-use bevy_reflect::Reflect;
+use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_ui::{
     widget::Text, AlignItems, BackgroundGradient, ColorStop, Display, FlexDirection, Gradient,
     InteractionDisabled, InterpolationColorSpace, JustifyContent, LinearGradient, Node, UiRect,
@@ -61,12 +61,12 @@ impl Default for SliderProps {
 #[derive(Component, Default, Clone)]
 #[require(CoreSlider)]
 #[derive(Reflect)]
-#[reflect(Component, Clone)]
+#[reflect(Component, Clone, Default)]
 struct SliderStyle;
 
 /// Marker for the text
 #[derive(Component, Default, Clone, Reflect)]
-#[reflect(Component, Clone)]
+#[reflect(Component, Clone, Default)]
 struct SliderValueText;
 
 /// Spawn a new slider widget.

--- a/crates/bevy_feathers/src/controls/slider.rs
+++ b/crates/bevy_feathers/src/controls/slider.rs
@@ -62,7 +62,6 @@ impl Default for SliderProps {
 #[require(CoreSlider)]
 #[derive(Reflect)]
 #[reflect(Component, Clone)]
-
 struct SliderStyle;
 
 /// Marker for the text

--- a/crates/bevy_feathers/src/controls/slider.rs
+++ b/crates/bevy_feathers/src/controls/slider.rs
@@ -11,12 +11,14 @@ use bevy_ecs::{
     hierarchy::Children,
     lifecycle::RemovedComponents,
     query::{Added, Changed, Has, Or, Spawned, With},
+    reflect::ReflectComponent,
     schedule::IntoScheduleConfigs,
     spawn::SpawnRelated,
     system::{In, Query, Res},
 };
 use bevy_input_focus::tab_navigation::TabIndex;
 use bevy_picking::PickingSystems;
+use bevy_reflect::Reflect;
 use bevy_ui::{
     widget::Text, AlignItems, BackgroundGradient, ColorStop, Display, FlexDirection, Gradient,
     InteractionDisabled, InterpolationColorSpace, JustifyContent, LinearGradient, Node, UiRect,
@@ -58,10 +60,14 @@ impl Default for SliderProps {
 
 #[derive(Component, Default, Clone)]
 #[require(CoreSlider)]
+#[derive(Reflect)]
+#[reflect(Component, Clone)]
+
 struct SliderStyle;
 
 /// Marker for the text
-#[derive(Component, Default, Clone)]
+#[derive(Component, Default, Clone, Reflect)]
+#[reflect(Component, Clone)]
 struct SliderValueText;
 
 /// Spawn a new slider widget.

--- a/crates/bevy_feathers/src/controls/toggle_switch.rs
+++ b/crates/bevy_feathers/src/controls/toggle_switch.rs
@@ -38,13 +38,11 @@ pub struct ToggleSwitchProps {
 /// Marker for the toggle switch outline
 #[derive(Component, Default, Clone, Reflect)]
 #[reflect(Component, Clone)]
-
 struct ToggleSwitchOutline;
 
 /// Marker for the toggle switch slide
 #[derive(Component, Default, Clone, Reflect)]
 #[reflect(Component, Clone)]
-
 struct ToggleSwitchSlide;
 
 /// Template function to spawn a toggle switch.

--- a/crates/bevy_feathers/src/controls/toggle_switch.rs
+++ b/crates/bevy_feathers/src/controls/toggle_switch.rs
@@ -18,7 +18,7 @@ use bevy_ecs::{
 };
 use bevy_input_focus::tab_navigation::TabIndex;
 use bevy_picking::{hover::Hovered, PickingSystems};
-use bevy_reflect::Reflect;
+use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_ui::{BorderRadius, Checked, InteractionDisabled, Node, PositionType, UiRect, Val};
 
 use crate::{
@@ -37,12 +37,12 @@ pub struct ToggleSwitchProps {
 
 /// Marker for the toggle switch outline
 #[derive(Component, Default, Clone, Reflect)]
-#[reflect(Component, Clone)]
+#[reflect(Component, Clone, Default)]
 struct ToggleSwitchOutline;
 
 /// Marker for the toggle switch slide
 #[derive(Component, Default, Clone, Reflect)]
-#[reflect(Component, Clone)]
+#[reflect(Component, Clone, Default)]
 struct ToggleSwitchSlide;
 
 /// Template function to spawn a toggle switch.

--- a/crates/bevy_feathers/src/controls/toggle_switch.rs
+++ b/crates/bevy_feathers/src/controls/toggle_switch.rs
@@ -10,6 +10,7 @@ use bevy_ecs::{
     hierarchy::Children,
     lifecycle::RemovedComponents,
     query::{Added, Changed, Has, Or, With},
+    reflect::ReflectComponent,
     schedule::IntoScheduleConfigs,
     spawn::SpawnRelated,
     system::{Commands, In, Query},
@@ -17,6 +18,7 @@ use bevy_ecs::{
 };
 use bevy_input_focus::tab_navigation::TabIndex;
 use bevy_picking::{hover::Hovered, PickingSystems};
+use bevy_reflect::Reflect;
 use bevy_ui::{BorderRadius, Checked, InteractionDisabled, Node, PositionType, UiRect, Val};
 
 use crate::{
@@ -34,11 +36,15 @@ pub struct ToggleSwitchProps {
 }
 
 /// Marker for the toggle switch outline
-#[derive(Component, Default, Clone)]
+#[derive(Component, Default, Clone, Reflect)]
+#[reflect(Component, Clone)]
+
 struct ToggleSwitchOutline;
 
 /// Marker for the toggle switch slide
-#[derive(Component, Default, Clone)]
+#[derive(Component, Default, Clone, Reflect)]
+#[reflect(Component, Clone)]
+
 struct ToggleSwitchSlide;
 
 /// Template function to spawn a toggle switch.

--- a/crates/bevy_feathers/src/cursor.rs
+++ b/crates/bevy_feathers/src/cursor.rs
@@ -5,7 +5,7 @@ use bevy_ecs::{
     entity::Entity,
     hierarchy::ChildOf,
     query::{With, Without},
-    reflect::ReflectComponent,
+    reflect::{ReflectComponent, ReflectResource},
     resource::Resource,
     schedule::IntoScheduleConfigs,
     system::{Commands, Query, Res},
@@ -19,7 +19,8 @@ use bevy_winit::cursor::CustomCursor;
 
 /// A resource that specifies the cursor icon to be used when the mouse is not hovering over
 /// any other entity. This is used to set the default cursor icon for the window.
-#[derive(Resource, Debug, Clone, Default)]
+#[derive(Resource, Debug, Clone, Default, Reflect)]
+#[reflect(Resource, Debug, Default)]
 pub struct DefaultCursor(pub EntityCursor);
 
 /// A component that specifies the cursor shape to be used when the pointer hovers over an entity.

--- a/crates/bevy_feathers/src/font_styles.rs
+++ b/crates/bevy_feathers/src/font_styles.rs
@@ -8,7 +8,7 @@ use bevy_ecs::{
     reflect::ReflectComponent,
     system::{Commands, Query, Res},
 };
-use bevy_reflect::Reflect;
+use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_text::{Font, TextFont};
 
 use crate::handle_or_path::HandleOrPath;
@@ -16,7 +16,7 @@ use crate::handle_or_path::HandleOrPath;
 /// A component which, when inserted on an entity, will load the given font and propagate it
 /// downward to any child text entity that has the [`ThemedText`](crate::theme::ThemedText) marker.
 #[derive(Component, Default, Clone, Debug, Reflect)]
-#[reflect(Component)]
+#[reflect(Component, Default)]
 pub struct InheritableFont {
     /// The font handle or path.
     pub font: HandleOrPath<Font>,

--- a/crates/bevy_feathers/src/font_styles.rs
+++ b/crates/bevy_feathers/src/font_styles.rs
@@ -5,15 +5,18 @@ use bevy_ecs::{
     component::Component,
     lifecycle::Insert,
     observer::On,
+    reflect::ReflectComponent,
     system::{Commands, Query, Res},
 };
+use bevy_reflect::Reflect;
 use bevy_text::{Font, TextFont};
 
 use crate::handle_or_path::HandleOrPath;
 
 /// A component which, when inserted on an entity, will load the given font and propagate it
 /// downward to any child text entity that has the [`ThemedText`](crate::theme::ThemedText) marker.
-#[derive(Component, Default, Clone, Debug)]
+#[derive(Component, Default, Clone, Debug, Reflect)]
+#[reflect(Component)]
 pub struct InheritableFont {
     /// The font handle or path.
     pub font: HandleOrPath<Font>,

--- a/crates/bevy_feathers/src/handle_or_path.rs
+++ b/crates/bevy_feathers/src/handle_or_path.rs
@@ -1,11 +1,12 @@
 //! Provides a way to specify assets either by handle or by path.
 use bevy_asset::{Asset, Handle};
+use bevy_reflect::Reflect;
 
 /// Enum that represents a reference to an asset as either a [`Handle`] or a [`String`] path.
 ///
 /// This is useful for when you want to specify an asset, but don't always have convenient
 /// access to an asset server reference.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Reflect)]
 pub enum HandleOrPath<T: Asset> {
     /// Specify the asset reference as a handle.
     Handle(Handle<T>),

--- a/crates/bevy_feathers/src/theme.rs
+++ b/crates/bevy_feathers/src/theme.rs
@@ -18,7 +18,7 @@ use bevy_text::TextColor;
 use bevy_ui::{BackgroundColor, BorderColor};
 
 /// A collection of properties that make up a theme.
-#[derive(Default, Clone, Reflect)]
+#[derive(Default, Clone, Reflect, Debug)]
 pub struct ThemeProps {
     /// Map of design tokens to colors.
     pub color: HashMap<String, Color>,
@@ -26,7 +26,7 @@ pub struct ThemeProps {
 }
 
 /// The currently selected user interface theme. Overwriting this resource changes the theme.
-#[derive(Resource, Default, Reflect)]
+#[derive(Resource, Default, Reflect, Debug)]
 #[reflect(Resource)]
 pub struct UiTheme(pub ThemeProps);
 

--- a/crates/bevy_feathers/src/theme.rs
+++ b/crates/bevy_feathers/src/theme.rs
@@ -73,14 +73,12 @@ pub struct ThemeBorderColor(pub &'static str);
 #[component(immutable)]
 #[derive(Reflect)]
 #[reflect(Component, Clone)]
-
 pub struct ThemeFontColor(pub &'static str);
 
 /// A marker component that is used to indicate that the text entity wants to opt-in to using
 /// inherited text styles.
 #[derive(Component, Reflect)]
 #[reflect(Component)]
-
 pub struct ThemedText;
 
 pub(crate) fn update_theme(

--- a/crates/bevy_feathers/src/theme.rs
+++ b/crates/bevy_feathers/src/theme.rs
@@ -7,7 +7,7 @@ use bevy_ecs::{
     lifecycle::Insert,
     observer::On,
     query::Changed,
-    reflect::ReflectComponent,
+    reflect::{ReflectComponent, ReflectResource},
     resource::Resource,
     system::{Commands, Query, Res},
 };
@@ -18,7 +18,7 @@ use bevy_text::TextColor;
 use bevy_ui::{BackgroundColor, BorderColor};
 
 /// A collection of properties that make up a theme.
-#[derive(Default, Clone)]
+#[derive(Default, Clone, Reflect)]
 pub struct ThemeProps {
     /// Map of design tokens to colors.
     pub color: HashMap<String, Color>,
@@ -26,7 +26,8 @@ pub struct ThemeProps {
 }
 
 /// The currently selected user interface theme. Overwriting this resource changes the theme.
-#[derive(Resource, Default)]
+#[derive(Resource, Default, Reflect)]
+#[reflect(Resource)]
 pub struct UiTheme(pub ThemeProps);
 
 impl UiTheme {

--- a/crates/bevy_feathers/src/theme.rs
+++ b/crates/bevy_feathers/src/theme.rs
@@ -7,11 +7,13 @@ use bevy_ecs::{
     lifecycle::Insert,
     observer::On,
     query::Changed,
+    reflect::ReflectComponent,
     resource::Resource,
     system::{Commands, Query, Res},
 };
 use bevy_log::warn_once;
 use bevy_platform::collections::HashMap;
+use bevy_reflect::Reflect;
 use bevy_text::TextColor;
 use bevy_ui::{BackgroundColor, BorderColor};
 
@@ -52,6 +54,8 @@ impl UiTheme {
 #[derive(Component, Clone, Copy)]
 #[require(BackgroundColor)]
 #[component(immutable)]
+#[derive(Reflect)]
+#[reflect(Component, Clone)]
 pub struct ThemeBackgroundColor(pub &'static str);
 
 /// Component which causes the border color of an entity to be set based on a theme color.
@@ -59,16 +63,23 @@ pub struct ThemeBackgroundColor(pub &'static str);
 #[derive(Component, Clone, Copy)]
 #[require(BorderColor)]
 #[component(immutable)]
+#[derive(Reflect)]
+#[reflect(Component, Clone)]
 pub struct ThemeBorderColor(pub &'static str);
 
 /// Component which causes the inherited text color of an entity to be set based on a theme color.
 #[derive(Component, Clone, Copy)]
 #[component(immutable)]
+#[derive(Reflect)]
+#[reflect(Component, Clone)]
+
 pub struct ThemeFontColor(pub &'static str);
 
 /// A marker component that is used to indicate that the text entity wants to opt-in to using
 /// inherited text styles.
-#[derive(Component)]
+#[derive(Component, Reflect)]
+#[reflect(Component)]
+
 pub struct ThemedText;
 
 pub(crate) fn update_theme(

--- a/crates/bevy_feathers/src/theme.rs
+++ b/crates/bevy_feathers/src/theme.rs
@@ -13,12 +13,13 @@ use bevy_ecs::{
 };
 use bevy_log::warn_once;
 use bevy_platform::collections::HashMap;
-use bevy_reflect::Reflect;
+use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_text::TextColor;
 use bevy_ui::{BackgroundColor, BorderColor};
 
 /// A collection of properties that make up a theme.
 #[derive(Default, Clone, Reflect, Debug)]
+#[reflect(Default, Debug)]
 pub struct ThemeProps {
     /// Map of design tokens to colors.
     pub color: HashMap<String, Color>,
@@ -27,7 +28,7 @@ pub struct ThemeProps {
 
 /// The currently selected user interface theme. Overwriting this resource changes the theme.
 #[derive(Resource, Default, Reflect, Debug)]
-#[reflect(Resource)]
+#[reflect(Resource, Default, Debug)]
 pub struct UiTheme(pub ThemeProps);
 
 impl UiTheme {


### PR DESCRIPTION
# Objective

- Reflecting public components and resources is essential to allow them to be saved to scenes and function properly in inspectors
- Fixes #20040.

## Solution

- Derive reflect for all of the public components and resources that didn't have it
- Various components that store a `Callback`, like `CoreButton`, are a notable exception
   - Because Callbacks are not type-erased, and the reflect derive only works when all generics are reflect, I could not get this to work nicely
   - If you can get this working, please let me know and we can do this in follow-up!
- I also slapped a missing Debug derive on the theme resource because it seems extremely useful and I noticed it

## Notes to reviewers

- this is not feature-gated: see #20337 for the steps needed to meaningfully do so. Fixing that is out of scope for the 0.17 release.
- I've opted to separate the Reflect derive from the other derives wherever rustfmt would let me. While this looks dumb right now, it will reduce the diff noise when fixing #20337.
- I could add reflection to the callback-containing components with an ignore for the callback fields, but I don't think this is particularly useful