### PR TITLE
Side: Fix `ci` tool when running with `--test-threads`

### DIFF
--- a/tools/ci/src/commands/test.rs
+++ b/tools/ci/src/commands/test.rs
@@ -13,14 +13,26 @@ impl Prepare for TestCommand {
         let jobs = args.build_jobs();
         let test_threads = args.test_threads();
 
-        vec![PreparedCommand::new::<Self>(
-            cmd!(
-                sh,
-                // `--benches` runs each benchmark once in order to verify that they behave
-                // correctly and do not panic.
-                "cargo test --workspace --lib --bins --tests --benches {no_fail_fast...} {jobs...} -- {test_threads...}"
+        let jobs_ref = &jobs;
+        let test_threads_ref = &test_threads;
+
+        vec![
+            PreparedCommand::new::<Self>(
+                cmd!(
+                    sh,
+                    "cargo test --workspace --lib --bins --tests {no_fail_fast...} {jobs_ref...} -- {test_threads_ref...}"
+                ),
+                "Please fix failing tests in output above.",
             ),
-            "Please fix failing tests in output above.",
-        )]
+            PreparedCommand::new::<Self>(
+                cmd!(
+                    sh,
+                    // `--benches` runs each benchmark once in order to verify that they behave
+                    // correctly and do not panic.
+                    "cargo test --workspace --benches {no_fail_fast...} {jobs...}"
+                ),
+                "Please fix failing tests in output above.",
+            )
+        ]
     }
 }


### PR DESCRIPTION
# Objective

`ci` tool fails if you run with `--test-threads` because `cargo test --benches` does not take `--test-threads`

## Solution

Split the command that call `cargo test` into one for `--benches` and other for `--lib --bins --tests`.

## Testing

Ran `cargo run -p ci -- --build-jobs 4 --test-threads 4`

## Note

This is a cherry-pick of a commit that was added to #19011 but was unrelated to the PR