### PR TITLE
`spec_v2` style and patterns

### DIFF
--- a/crates/bevy_render/macros/src/specializer.rs
+++ b/crates/bevy_render/macros/src/specializer.rs
@@ -87,7 +87,6 @@ struct FieldInfo {
     ty: Type,
     member: Member,
     key: Key,
-    use_base_descriptor: bool,
 }
 
 impl FieldInfo {
@@ -116,15 +115,6 @@ impl FieldInfo {
         } else {
             parse_quote!(#ty: #specialize_path::Specializer<#target_path>)
         }
-    }
-
-    fn get_base_descriptor_predicate(
-        &self,
-        specialize_path: &Path,
-        target_path: &Path,
-    ) -> WherePredicate {
-        let ty = &self.ty;
-        parse_quote!(#ty: #specialize_path::GetBaseDescriptor<#target_path>)
     }
 }
 
@@ -190,7 +180,6 @@ fn get_field_info(
             ty: field_ty,
             member: field_member,
             key,
-            use_base_descriptor,
         });
     }
 
@@ -261,41 +250,18 @@ pub fn impl_specializer(input: TokenStream) -> TokenStream {
         })
         .collect();
 
-    let base_descriptor_fields = field_info
-        .iter()
-        .filter(|field| field.use_base_descriptor)
-        .collect::<Vec<_>>();
-
-    if base_descriptor_fields.len() > 1 {
-        return syn::Error::new(
-            Span::call_site(),
-            "Too many #[base_descriptor] attributes found. It must be present on exactly one field",
-        )
-        .into_compile_error()
-        .into();
-    }
-
-    let base_descriptor_field = base_descriptor_fields.first().copied();
-
     match targets {
-        SpecializeImplTargets::All => {
-            let specialize_impl = impl_specialize_all(
-                &specialize_path,
-                &ecs_path,
-                &ast,
-                &field_info,
-                &key_patterns,
-                &key_tuple_idents,
-            );
-            let get_base_descriptor_impl = base_descriptor_field
-                .map(|field_info| impl_get_base_descriptor_all(&specialize_path, &ast, field_info))
-                .unwrap_or_default();
-            [specialize_impl, get_base_descriptor_impl]
-                .into_iter()
-                .collect()
-        }
-        SpecializeImplTargets::Specific(targets) => {
-            let specialize_impls = targets.iter().map(|target| {
+        SpecializeImplTargets::All => impl_specialize_all(
+            &specialize_path,
+            &ecs_path,
+            &ast,
+            &field_info,
+            &key_patterns,
+            &key_tuple_idents,
+        ),
+        SpecializeImplTargets::Specific(targets) => targets
+            .iter()
+            .map(|target| {
                 impl_specialize_specific(
                     &specialize_path,
                     &ecs_path,
@@ -305,14 +271,8 @@ pub fn impl_specializer(input: TokenStream) -> TokenStream {
                     &key_patterns,
                     &key_tuple_idents,
                 )
-            });
-            let get_base_descriptor_impls = targets.iter().filter_map(|target| {
-                base_descriptor_field.map(|field_info| {
-                    impl_get_base_descriptor_specific(&specialize_path, &ast, field_info, target)
-                })
-            });
-            specialize_impls.chain(get_base_descriptor_impls).collect()
-        }
+            })
+            .collect(),
     }
 }
 
@@ -401,56 +361,6 @@ fn impl_specialize_specific(
             ) -> #FQResult<#specialize_path::Canonical<Self::Key>, #ecs_path::error::BevyError> {
                 #(let #key_patterns = #specialize_exprs?;)*
                 #FQResult::Ok((#(#key_tuple_idents),*))
-            }
-        }
-    })
-}
-
-fn impl_get_base_descriptor_specific(
-    specialize_path: &Path,
-    ast: &DeriveInput,
-    base_descriptor_field_info: &FieldInfo,
-    target_path: &Path,
-) -> TokenStream {
-    let struct_name = &ast.ident;
-    let (impl_generics, type_generics, where_clause) = &ast.generics.split_for_impl();
-    let field_ty = &base_descriptor_field_info.ty;
-    let field_member = &base_descriptor_field_info.member;
-    TokenStream::from(quote!(
-        impl #impl_generics #specialize_path::GetBaseDescriptor<#target_path> for #struct_name #type_generics #where_clause {
-            fn get_base_descriptor(&self) -> <#target_path as #specialize_path::Specializable>::Descriptor {
-                <#field_ty as #specialize_path::GetBaseDescriptor<#target_path>>::get_base_descriptor(&self.#field_member)
-            }
-        }
-    ))
-}
-
-fn impl_get_base_descriptor_all(
-    specialize_path: &Path,
-    ast: &DeriveInput,
-    base_descriptor_field_info: &FieldInfo,
-) -> TokenStream {
-    let target_path = Path::from(format_ident!("T"));
-    let struct_name = &ast.ident;
-    let mut generics = ast.generics.clone();
-    generics.params.insert(
-        0,
-        parse_quote!(#target_path: #specialize_path::Specializable),
-    );
-
-    let where_clause = generics.make_where_clause();
-    where_clause.predicates.push(
-        base_descriptor_field_info.get_base_descriptor_predicate(specialize_path, &target_path),
-    );
-
-    let (_, type_generics, _) = ast.generics.split_for_impl();
-    let (impl_generics, _, where_clause) = &generics.split_for_impl();
-    let field_ty = &base_descriptor_field_info.ty;
-    let field_member = &base_descriptor_field_info.member;
-    TokenStream::from(quote! {
-        impl #impl_generics #specialize_path::GetBaseDescriptor<#target_path> for #struct_name #type_generics #where_clause {
-            fn get_base_descriptor(&self) -> <#target_path as #specialize_path::Specializable>::Descriptor {
-                <#field_ty as #specialize_path::GetBaseDescriptor<#target_path>>::get_base_descriptor(&self.#field_member)
             }
         }
     })

--- a/crates/bevy_render/macros/src/specializer.rs
+++ b/crates/bevy_render/macros/src/specializer.rs
@@ -20,8 +20,6 @@ const SPECIALIZE_ALL_IDENT: &str = "all";
 const KEY_ATTR_IDENT: &str = "key";
 const KEY_DEFAULT_IDENT: &str = "default";
 
-const BASE_DESCRIPTOR_ATTR_IDENT: &str = "base_descriptor";
-
 enum SpecializeImplTargets {
     All,
     Specific(Vec<Path>),
@@ -141,12 +139,8 @@ fn get_field_info(
 
         let mut use_key_field = true;
         let mut key = Key::Index(key_index);
-        let mut use_base_descriptor = false;
         for attr in &field.attrs {
             match &attr.meta {
-                Meta::Path(path) if path.is_ident(&BASE_DESCRIPTOR_ATTR_IDENT) => {
-                    use_base_descriptor = true;
-                }
                 Meta::List(MetaList { path, tokens, .. }) if path.is_ident(&KEY_ATTR_IDENT) => {
                     let owned_tokens = tokens.clone().into();
                     let Ok(parsed_key) = syn::parse::<Key>(owned_tokens) else {

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -97,6 +97,7 @@ use render_asset::{
     extract_render_asset_bytes_per_frame, reset_render_asset_bytes_per_frame,
     RenderAssetBytesPerFrame, RenderAssetBytesPerFrameLimiter,
 };
+use render_resource::init_empty_bind_group_layout;
 use renderer::{RenderAdapter, RenderDevice, RenderQueue};
 use settings::RenderResources;
 use sync_world::{
@@ -467,6 +468,8 @@ impl Plugin for RenderPlugin {
                     Render,
                     reset_render_asset_bytes_per_frame.in_set(RenderSystems::Cleanup),
                 );
+
+            render_app.add_systems(RenderStartup, init_empty_bind_group_layout);
         }
 
         app.register_type::<alpha::AlphaMode>()

--- a/crates/bevy_render/src/render_resource/bind_group_layout.rs
+++ b/crates/bevy_render/src/render_resource/bind_group_layout.rs
@@ -1,5 +1,6 @@
-use crate::define_atomic_id;
-use crate::WgpuWrapper;
+use crate::{define_atomic_id, renderer::RenderDevice, WgpuWrapper};
+use bevy_ecs::system::Res;
+use bevy_platform::sync::OnceLock;
 use core::ops::Deref;
 
 define_atomic_id!(BindGroupLayoutId);
@@ -61,4 +62,20 @@ impl Deref for BindGroupLayout {
     fn deref(&self) -> &Self::Target {
         &self.value
     }
+}
+
+static EMPTY_BIND_GROUP_LAYOUT: OnceLock<BindGroupLayout> = OnceLock::new();
+
+pub(crate) fn init_empty_bind_group_layout(render_device: Res<RenderDevice>) {
+    let layout = render_device.create_bind_group_layout(Some("empty_bind_group_layout"), &[]);
+    EMPTY_BIND_GROUP_LAYOUT
+        .set(layout)
+        .expect("init_empty_bind_group_layout was called more than once");
+}
+
+pub fn empty_bind_group_layout() -> BindGroupLayout {
+    EMPTY_BIND_GROUP_LAYOUT
+        .get()
+        .expect("init_empty_bind_group_layout was not called")
+        .clone()
 }

--- a/crates/bevy_render/src/render_resource/pipeline.rs
+++ b/crates/bevy_render/src/render_resource/pipeline.rs
@@ -1,4 +1,4 @@
-use super::ShaderDefVal;
+use super::{empty_bind_group_layout, ShaderDefVal};
 use crate::mesh::VertexBufferLayout;
 use crate::WgpuWrapper;
 use crate::{
@@ -112,6 +112,20 @@ pub struct RenderPipelineDescriptor {
     /// Whether to zero-initialize workgroup memory by default. If you're not sure, set this to true.
     /// If this is false, reading from workgroup variables before writing to them will result in garbage values.
     pub zero_initialize_workgroup_memory: bool,
+}
+
+#[derive(Copy, Clone, Debug, Error)]
+#[error("RenderPipelineDescriptor has no FragmentState configured")]
+pub struct NoFragmentStateError;
+
+impl RenderPipelineDescriptor {
+    pub fn fragment_mut(&mut self) -> Result<&mut FragmentState, NoFragmentStateError> {
+        self.fragment.as_mut().ok_or(NoFragmentStateError)
+    }
+
+    pub fn set_layout(&mut self, index: usize, layout: BindGroupLayout) {
+        filling_set_at(&mut self.layout, index, empty_bind_group_layout(), layout);
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Default)]

--- a/crates/bevy_render/src/render_resource/pipeline.rs
+++ b/crates/bevy_render/src/render_resource/pipeline.rs
@@ -7,7 +7,9 @@ use crate::{
 };
 use alloc::borrow::Cow;
 use bevy_asset::Handle;
+use core::iter;
 use core::ops::Deref;
+use thiserror::Error;
 use wgpu::{
     ColorTargetState, DepthStencilState, MultisampleState, PrimitiveState, PushConstantRange,
 };
@@ -152,4 +154,12 @@ pub struct ComputePipelineDescriptor {
     /// Whether to zero-initialize workgroup memory by default. If you're not sure, set this to true.
     /// If this is false, reading from workgroup variables before writing to them will result in garbage values.
     pub zero_initialize_workgroup_memory: bool,
+}
+
+// utility function to set a value at the specified index, extending with
+// a filler value if the index is out of bounds.
+fn filling_set_at<T: Clone>(vec: &mut Vec<T>, index: usize, filler: T, value: T) {
+    let num_to_fill = (index + 1).saturating_sub(vec.len());
+    vec.extend(iter::repeat_n(filler, num_to_fill));
+    vec[index] = value;
 }

--- a/crates/bevy_render/src/render_resource/pipeline.rs
+++ b/crates/bevy_render/src/render_resource/pipeline.rs
@@ -153,6 +153,12 @@ pub struct FragmentState {
     pub targets: Vec<Option<ColorTargetState>>,
 }
 
+impl FragmentState {
+    pub fn set_target(&mut self, index: usize, target: ColorTargetState) {
+        filling_set_at(&mut self.targets, index, None, Some(target));
+    }
+}
+
 /// Describes a compute pipeline.
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
 pub struct ComputePipelineDescriptor {

--- a/crates/bevy_render/src/render_resource/specializer.rs
+++ b/crates/bevy_render/src/render_resource/specializer.rs
@@ -201,7 +201,7 @@ pub trait Specializer<T: Specializable>: Send + Sync + 'static {
 /// To address this, during specialization keys are processed into a [canonical]
 /// (or "standard") form that represents the actual descriptor that was produced.
 /// In the previous example, that would be the final `VertexBufferLayout` contained
-/// by the pipeline descriptor. This new key is used by [`SpecializedCache`] to
+/// by the pipeline descriptor. This new key is used by [`Variants`] to
 /// perform additional checks for duplicates, but only if required. If a key is
 /// canonical from the start, then there's no need.
 ///
@@ -256,18 +256,17 @@ macro_rules! impl_specialization_key_tuple {
 // TODO: How to we fake_variadics this?
 all_tuples!(impl_specialization_key_tuple, 0, 12, T);
 
-/// A cache for specializable resources. For a given key type the resulting
-/// resource will only be created if it is missing, retrieving it from the
-/// cache otherwise.
-pub struct SpecializedCache<T: Specializable, S: Specializer<T>> {
+/// A cache for variants of a resource type created by a specializer.
+/// At most one resource will be created for each key.
+pub struct Variants<T: Specializable, S: Specializer<T>> {
     specializer: S,
     base_descriptor: T::Descriptor,
     primary_cache: HashMap<S::Key, T::CachedId>,
     secondary_cache: HashMap<Canonical<S::Key>, T::CachedId>,
 }
 
-impl<T: Specializable, S: Specializer<T>> SpecializedCache<T, S> {
-    /// Creates a new [`SpecializedCache`] from a [`Specializer`] and a base descriptor.
+impl<T: Specializable, S: Specializer<T>> Variants<T, S> {
+    /// Creates a new [`Variants`] from a [`Specializer`] and a base descriptor.
     #[inline]
     pub fn new(specializer: S, base_descriptor: T::Descriptor) -> Self {
         Self {

--- a/examples/shader_advanced/custom_phase_item.rs
+++ b/examples/shader_advanced/custom_phase_item.rs
@@ -280,9 +280,10 @@ struct CustomPhaseSpecializer;
 
 #[derive(Resource)]
 struct CustomPhasePipeline {
-    /// Holds a reference to our shader.
-    _shader: Handle<Shader>,
     specialized_cache: SpecializedCache<RenderPipeline, CustomPhaseSpecializer>,
+    /// the base_descriptor holds onto the shader handle, this field is
+    /// unused but here for demonstration purposes.
+    _shader: Handle<Shader>,
 }
 
 impl FromWorld for CustomPhasePipeline {

--- a/examples/shader_advanced/custom_phase_item.rs
+++ b/examples/shader_advanced/custom_phase_item.rs
@@ -26,9 +26,9 @@ use bevy::{
         render_resource::{
             BufferUsages, Canonical, ColorTargetState, ColorWrites, CompareFunction,
             DepthStencilState, FragmentState, IndexFormat, PipelineCache, RawBufferVec,
-            RenderPipeline, RenderPipelineDescriptor, SpecializedCache, Specializer,
-            SpecializerKey, TextureFormat, VertexAttribute, VertexBufferLayout, VertexFormat,
-            VertexState, VertexStepMode,
+            RenderPipeline, RenderPipelineDescriptor, Specializer, SpecializerKey, TextureFormat,
+            Variants, VertexAttribute, VertexBufferLayout, VertexFormat, VertexState,
+            VertexStepMode,
         },
         renderer::{RenderDevice, RenderQueue},
         view::{self, ExtractedView, RenderVisibleEntities, VisibilityClass},
@@ -280,8 +280,8 @@ struct CustomPhaseSpecializer;
 
 #[derive(Resource)]
 struct CustomPhasePipeline {
-    /// the `specialized_cache` holds onto the shader handle through the base descriptor
-    variants: SpecializedCache<RenderPipeline, CustomPhaseSpecializer>,
+    /// the `variants` collection holds onto the shader handle through the base descriptor
+    variants: Variants<RenderPipeline, CustomPhaseSpecializer>,
 }
 
 impl FromWorld for CustomPhasePipeline {
@@ -336,7 +336,7 @@ impl FromWorld for CustomPhasePipeline {
             ..default()
         };
 
-        let variants = SpecializedCache::new(CustomPhaseSpecializer, base_descriptor);
+        let variants = Variants::new(CustomPhaseSpecializer, base_descriptor);
 
         Self { variants }
     }

--- a/examples/shader_advanced/custom_phase_item.rs
+++ b/examples/shader_advanced/custom_phase_item.rs
@@ -25,8 +25,8 @@ use bevy::{
         },
         render_resource::{
             BufferUsages, Canonical, ColorTargetState, ColorWrites, CompareFunction,
-            DepthStencilState, FragmentState, GetBaseDescriptor, IndexFormat, PipelineCache,
-            RawBufferVec, RenderPipeline, RenderPipelineDescriptor, SpecializedCache, Specializer,
+            DepthStencilState, FragmentState, IndexFormat, PipelineCache, RawBufferVec,
+            RenderPipeline, RenderPipelineDescriptor, SpecializedCache, Specializer,
             SpecializerKey, TextureFormat, VertexAttribute, VertexBufferLayout, VertexFormat,
             VertexState, VertexStepMode,
         },
@@ -165,9 +165,8 @@ fn main() {
         .add_systems(Startup, setup);
 
     // We make sure to add these to the render app, not the main app.
-    app.get_sub_app_mut(RenderApp)
-        .unwrap()
-        .init_resource::<SpecializedCache<RenderPipeline, CustomPhaseSpecializer>>()
+    app.sub_app_mut(RenderApp)
+        .init_resource::<CustomPhasePipeline>()
         .add_render_command::<Opaque3d, DrawCustomPhaseItemCommands>()
         .add_systems(
             Render,
@@ -212,9 +211,9 @@ fn prepare_custom_phase_item_buffers(mut commands: Commands) {
 /// the opaque render phases of each view.
 fn queue_custom_phase_item(
     pipeline_cache: Res<PipelineCache>,
+    mut pipeline: ResMut<CustomPhasePipeline>,
     mut opaque_render_phases: ResMut<ViewBinnedRenderPhases<Opaque3d>>,
     opaque_draw_functions: Res<DrawFunctions<Opaque3d>>,
-    mut specializer: ResMut<SpecializedCache<RenderPipeline, CustomPhaseSpecializer>>,
     views: Query<(&ExtractedView, &RenderVisibleEntities, &Msaa)>,
     mut next_tick: Local<Tick>,
 ) {
@@ -237,7 +236,9 @@ fn queue_custom_phase_item(
             // some per-view settings, such as whether the view is HDR, but for
             // simplicity's sake we simply hard-code the view's characteristics,
             // with the exception of number of MSAA samples.
-            let Ok(pipeline_id) = specializer.specialize(&pipeline_cache, CustomPhaseKey(*msaa))
+            let Ok(pipeline_id) = pipeline
+                .specialized_cache
+                .specialize(&pipeline_cache, CustomPhaseKey(*msaa))
             else {
                 continue;
             };
@@ -275,44 +276,24 @@ fn queue_custom_phase_item(
     }
 }
 
-/// Holds a reference to our shader.
-///
-/// This is loaded at app creation time.
-struct CustomPhaseSpecializer {
+struct CustomPhaseSpecializer;
+
+#[derive(Resource)]
+struct CustomPhasePipeline {
+    /// Holds a reference to our shader.
     shader: Handle<Shader>,
+    specialized_cache: SpecializedCache<RenderPipeline, CustomPhaseSpecializer>,
 }
 
-impl FromWorld for CustomPhaseSpecializer {
+impl FromWorld for CustomPhasePipeline {
     fn from_world(world: &mut World) -> Self {
         let asset_server = world.resource::<AssetServer>();
-        Self {
-            shader: asset_server.load("shaders/custom_phase_item.wgsl"),
-        }
-    }
-}
+        let shader = asset_server.load("shaders/custom_phase_item.wgsl");
 
-#[derive(Copy, Clone, PartialEq, Eq, Hash, SpecializerKey)]
-struct CustomPhaseKey(Msaa);
-
-impl Specializer<RenderPipeline> for CustomPhaseSpecializer {
-    type Key = CustomPhaseKey;
-
-    fn specialize(
-        &self,
-        key: Self::Key,
-        descriptor: &mut RenderPipelineDescriptor,
-    ) -> Result<Canonical<Self::Key>, BevyError> {
-        descriptor.multisample.count = key.0.samples();
-        Ok(key)
-    }
-}
-
-impl GetBaseDescriptor<RenderPipeline> for CustomPhaseSpecializer {
-    fn get_base_descriptor(&self) -> RenderPipelineDescriptor {
-        RenderPipelineDescriptor {
+        let base_descriptor = RenderPipelineDescriptor {
             label: Some("custom render pipeline".into()),
             vertex: VertexState {
-                shader: self.shader.clone(),
+                shader: shader.clone(),
                 buffers: vec![VertexBufferLayout {
                     array_stride: size_of::<Vertex>() as u64,
                     step_mode: VertexStepMode::Vertex,
@@ -333,7 +314,7 @@ impl GetBaseDescriptor<RenderPipeline> for CustomPhaseSpecializer {
                 ..default()
             },
             fragment: Some(FragmentState {
-                shader: self.shader.clone(),
+                shader: shader.clone(),
                 targets: vec![Some(ColorTargetState {
                     // Ordinarily, you'd want to check whether the view has the
                     // HDR format and substitute the appropriate texture format
@@ -354,7 +335,31 @@ impl GetBaseDescriptor<RenderPipeline> for CustomPhaseSpecializer {
                 bias: default(),
             }),
             ..default()
+        };
+
+        let specialized_cache =
+            SpecializedCache::new(CustomPhaseSpecializer, None, base_descriptor);
+
+        Self {
+            shader,
+            specialized_cache,
         }
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash, SpecializerKey)]
+struct CustomPhaseKey(Msaa);
+
+impl Specializer<RenderPipeline> for CustomPhaseSpecializer {
+    type Key = CustomPhaseKey;
+
+    fn specialize(
+        &self,
+        key: Self::Key,
+        descriptor: &mut RenderPipelineDescriptor,
+    ) -> Result<Canonical<Self::Key>, BevyError> {
+        descriptor.multisample.count = key.0.samples();
+        Ok(key)
     }
 }
 

--- a/examples/shader_advanced/custom_phase_item.rs
+++ b/examples/shader_advanced/custom_phase_item.rs
@@ -280,7 +280,7 @@ struct CustomPhaseSpecializer;
 
 #[derive(Resource)]
 struct CustomPhasePipeline {
-    /// the specialized_cache holds onto the shader handle through the base descriptor
+    /// the `specialized_cache` holds onto the shader handle through the base descriptor
     specialized_cache: SpecializedCache<RenderPipeline, CustomPhaseSpecializer>,
 }
 

--- a/examples/shader_advanced/custom_phase_item.rs
+++ b/examples/shader_advanced/custom_phase_item.rs
@@ -336,8 +336,7 @@ impl FromWorld for CustomPhasePipeline {
             ..default()
         };
 
-        let specialized_cache =
-            SpecializedCache::new(CustomPhaseSpecializer, None, base_descriptor);
+        let specialized_cache = SpecializedCache::new(CustomPhaseSpecializer, base_descriptor);
 
         Self { specialized_cache }
     }

--- a/examples/shader_advanced/custom_phase_item.rs
+++ b/examples/shader_advanced/custom_phase_item.rs
@@ -237,7 +237,7 @@ fn queue_custom_phase_item(
             // simplicity's sake we simply hard-code the view's characteristics,
             // with the exception of number of MSAA samples.
             let Ok(pipeline_id) = pipeline
-                .specialized_cache
+                .variants
                 .specialize(&pipeline_cache, CustomPhaseKey(*msaa))
             else {
                 continue;
@@ -281,7 +281,7 @@ struct CustomPhaseSpecializer;
 #[derive(Resource)]
 struct CustomPhasePipeline {
     /// the `specialized_cache` holds onto the shader handle through the base descriptor
-    specialized_cache: SpecializedCache<RenderPipeline, CustomPhaseSpecializer>,
+    variants: SpecializedCache<RenderPipeline, CustomPhaseSpecializer>,
 }
 
 impl FromWorld for CustomPhasePipeline {
@@ -336,9 +336,9 @@ impl FromWorld for CustomPhasePipeline {
             ..default()
         };
 
-        let specialized_cache = SpecializedCache::new(CustomPhaseSpecializer, base_descriptor);
+        let variants = SpecializedCache::new(CustomPhaseSpecializer, base_descriptor);
 
-        Self { specialized_cache }
+        Self { variants }
     }
 }
 

--- a/examples/shader_advanced/custom_phase_item.rs
+++ b/examples/shader_advanced/custom_phase_item.rs
@@ -280,10 +280,8 @@ struct CustomPhaseSpecializer;
 
 #[derive(Resource)]
 struct CustomPhasePipeline {
+    /// the specialized_cache holds onto the shader handle through the base descriptor
     specialized_cache: SpecializedCache<RenderPipeline, CustomPhaseSpecializer>,
-    /// the base_descriptor holds onto the shader handle, this field is
-    /// unused but here for demonstration purposes.
-    _shader: Handle<Shader>,
 }
 
 impl FromWorld for CustomPhasePipeline {
@@ -341,10 +339,7 @@ impl FromWorld for CustomPhasePipeline {
         let specialized_cache =
             SpecializedCache::new(CustomPhaseSpecializer, None, base_descriptor);
 
-        Self {
-            _shader: shader,
-            specialized_cache,
-        }
+        Self { specialized_cache }
     }
 }
 

--- a/examples/shader_advanced/custom_phase_item.rs
+++ b/examples/shader_advanced/custom_phase_item.rs
@@ -281,7 +281,7 @@ struct CustomPhaseSpecializer;
 #[derive(Resource)]
 struct CustomPhasePipeline {
     /// Holds a reference to our shader.
-    shader: Handle<Shader>,
+    _shader: Handle<Shader>,
     specialized_cache: SpecializedCache<RenderPipeline, CustomPhaseSpecializer>,
 }
 
@@ -341,7 +341,7 @@ impl FromWorld for CustomPhasePipeline {
             SpecializedCache::new(CustomPhaseSpecializer, None, base_descriptor);
 
         Self {
-            shader,
+            _shader: shader,
             specialized_cache,
         }
     }

--- a/release-content/migration-guides/composable_specialization.md
+++ b/release-content/migration-guides/composable_specialization.md
@@ -148,8 +148,8 @@ pub struct MyPipeline {
     // the base_descriptor and specializer each hold onto the static
     // wgpu resources (layout, shader handles), so we don't need
     // explicit fields for them here. However, real-world cases
-    // may still need to duplicate them as fields to create bind
-    // groups from, etc.
+    // may still need to expose them as fields to create bind groups
+    // from, for example.
     specialized_cache: SpecializedCache<RenderPipeline, MySpecializer>,
 }
 

--- a/release-content/migration-guides/composable_specialization.md
+++ b/release-content/migration-guides/composable_specialization.md
@@ -145,11 +145,13 @@ After:
 ```rust
 #[derive(Resource)]
 pub struct MyPipeline {
+    specialized_cache: SpecializedCache<RenderPipeline, MySpecializer>,
+
+    // these fields are unused, they're just here for demonstration purposes
     layout: BindGroupLayout,
     layout_msaa: BindGroupLayout,
     vertex: Handle<Shader>,
     fragment: Handle<Shader>,
-    specialized_cache: SpecializedCache<RenderPipeline, MySpecializer>,
 }
 
 pub struct MySpecializer {

--- a/release-content/migration-guides/composable_specialization.md
+++ b/release-content/migration-guides/composable_specialization.md
@@ -195,9 +195,7 @@ impl FromWorld for MyPipeline {
             base_descriptor,
         );
         
-        Self {
-            variants
-        }
+        Self { variants }
     }
 }
 

--- a/release-content/migration-guides/composable_specialization.md
+++ b/release-content/migration-guides/composable_specialization.md
@@ -6,7 +6,7 @@ pull_requests: [17373]
 The existing pipeline specialization APIs (`SpecializedRenderPipeline` etc.) have
 been replaced with a single `Specializer` trait and `SpecializedCache` collection:
 
-```rs
+```rust
 pub trait Specializer<T: Specializable>: Send + Sync + 'static {
     type Key: SpecializerKey;
     fn specialize(
@@ -19,20 +19,55 @@ pub trait Specializer<T: Specializable>: Send + Sync + 'static {
 pub struct SpecializedCache<T: Specializable, S: Specializer<T>>{ ... };
 ```
 
-The main difference is the change from *producing* a pipeline descriptor to
-*mutating* one based on a key. The "base descriptor" that the `SpecializedCache`
-passes to the `Specializer` can either be specified manually with `Specializer::new`
-or by implementing `GetBaseDescriptor`. There's also a new trait for specialization
-keys, `SpecializeKey`, that can be derived with the included macro in most cases.
+For more info on specialization, see the docs for `bevy_render::render_resources::Specializer`
 
-Composing multiple different specializers together with the `derive(Specializer)`
-macro can be a lot more powerful (see the `Specialize` docs), but migrating
-individual specializers is fairly simple. All static parts of the pipeline
-should be specified in the base descriptor, while the `Specializer` impl
-should mutate the key as little as necessary to match the key.
+## Mutation and Base Descriptors
 
-```rs
+The main difference between the old and new trait is that instead of
+*producing* a pipeline descriptor, `Specializer`s *mutate* existing descriptors
+based on a key. As such, `SpecializedCache::new` takes in a "base descriptor"
+to act as the template from which the specializer creates pipeline variants.
+
+When migrating, the "static" parts of the pipeline (that don't depend
+on the key) should become part of the base descriptor, while the specializer
+itself should only change the parts demanded by the key. In the full example
+below, instead of creating the entire pipeline descriptor the specializer
+only changes the msaa sample count and the bind group layout.
+
+## Composing Specializers
+
+`Specializer`s can also be *composed* with the included derive macro to combine
+their effects! This is a great way to encapsulate and reuse specialization logic,
+though the rest of this guide will focus on migrating "standalone" specializers.
+
+```rust
+pub struct MsaaSpecializer {...}
+impl Specialize<RenderPipeline> for MsaaSpecializer {...}
+
+pub struct MeshLayoutSpecializer {...}
+impl Specialize<RenderPipeline> for MeshLayoutSpecializer {...}
+
+#[derive(Specializer)]
+#[specialize(RenderPipeline)]
 pub struct MySpecializer {
+    msaa: MsaaSpecializer,
+    mesh_layout: MeshLayoutSpecializer,
+}
+```
+
+## Misc Changes
+
+The analogue of `SpecializedRenderPipelines`, `SpecializedCache`, is no longer a
+Bevy `Resource`. Instead, the cache should be stored in a user-created `Resource`
+(shown below) or even in a `Component` depending on the use case.
+
+## Full Migration Example
+
+Before:
+
+```rust
+#[derive(Resource)]
+pub struct MyPipeline {
     layout: BindGroupLayout,
     layout_msaa: BindGroupLayout,
     vertex: Handle<Shader>,
@@ -41,65 +76,134 @@ pub struct MySpecializer {
 
 // before
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
-// after
-#[derive(Clone, Copy, PartialEq, Eq, Hash, SpecializerKey)]
-
-pub struct MyKey {
-    blend_state: BlendState,
+pub struct MyPipelineKey {
     msaa: Msaa,
 }
 
-impl FromWorld for MySpecializer {
-    fn from_world(&mut World) -> Self {
-        ...
+impl FromWorld for MyPipeline {
+    fn from_world(world: &mut World) -> Self {
+        let render_device = world.resource::<RenderDevice>();
+        let asset_server = world.resource::<AssetServer>();
+
+        let layout = render_device.create_bind_group_layout(...);
+        let layout_msaa = render_device.create_bind_group_layout(...);
+
+        let vertex = asset_server.load("vertex.wgsl");
+        let fragment = asset_server.load("fragment.wgsl");
+        
+        Self {
+            layout,
+            layout_msaa,
+            vertex,
+            fragment,
+        }
     }
 }
 
-// before
-impl SpecializedRenderPipeline for MySpecializer {
-    type Key = MyKey;
+impl SpecializedRenderPipeline for MyPipeline {
+    type Key = MyPipelineKey;
 
     fn specialize(&self, key: Self::Key) -> RenderPipelineDescriptor {
         RenderPipelineDescriptor {
             label: Some("my_pipeline".into()),
             layout: vec![
-                if key.msaa.samples() > 0 {
+                if key.msaa.samples() > 1 {
                     self.layout_msaa.clone()
                 } else { 
                     self.layout.clone() 
                 }
             ],
-            push_constant_ranges: vec![],
             vertex: VertexState {
                 shader: self.vertex.clone(),
-                shader_defs: vec![],
-                entry_point: "vertex".into(),
-                buffers: vec![],
+                ..default()
             },
-            primitive: Default::default(),
-            depth_stencil: None,
             multisample: MultisampleState {
                 count: key.msaa.samples(),
-                ..Default::default()
+                ..default()
             },
             fragment: Some(FragmentState {
                 shader: self.fragment.clone(),
-                shader_defs: vec![],
-                entry_point: "fragment".into(),
                 targets: vec![Some(ColorTargetState {
                     format: TextureFormat::Rgba8Unorm,
-                    blend: Some(key.blend_state),
+                    blend: None,
                     write_mask: ColorWrites::all(),
                 })],
+                ..default()
             }),
-            zero_initialize_workgroup_memory: false,
+            ..default()
         },
     }
 }
 
-app.init_resource::<SpecializedRenderPipelines<MySpecializer>>();
+render_app
+    .init_resource::<MyPipeline>();
+    .init_resource::<SpecializedRenderPipelines<MySpecializer>>();
+```
 
-// after
+After:
+
+```rust
+#[derive(Resource)]
+pub struct MyPipeline {
+    layout: BindGroupLayout,
+    layout_msaa: BindGroupLayout,
+    vertex: Handle<Shader>,
+    fragment: Handle<Shader>,
+    specialized_cache: SpecializedCache<RenderPipeline, MySpecializer>,
+}
+
+pub struct MySpecializer {
+    layout: BindGroupLayout,
+    layout_msaa: BindGroupLayout,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, SpecializerKey)]
+pub struct MyPipelineKey {
+    msaa: Msaa,
+}
+
+impl FromWorld for MyPipeline {
+    fn from_world(world: &mut World) -> Self {
+        let render_device = world.resource::<RenderDevice>();
+        let asset_server = world.resource::<AssetServer>();
+
+        let layout = render_device.create_bind_group_layout(...);
+        let layout_msaa = render_device.create_bind_group_layout(...);
+
+        let vertex = asset_server.load("vertex.wgsl");
+        let fragment = asset_server.load("fragment.wgsl");
+
+        let base_descriptor = RenderPipelineDescriptor {
+            label: Some("my_pipeline".into()),
+            vertex: VertexState {
+                shader: vertex.clone(),
+                ..default()
+            },
+            fragment: Some(FragmentState {
+                shader: fragment.clone(),
+                ..default()
+            }),
+            ..default()
+        },
+
+        let specialized_cache = SpecializedCache::new(
+            MySpecializer {
+                layout: layout.clone(),
+                layout_msaa: layout_msaa.clone(),
+            },
+            None,
+            base_descriptor,
+        );
+        
+        Self {
+            layout,
+            layout_msaa,
+            vertex,
+            fragment,
+        }
+    }
+}
+
 impl Specializer<RenderPipeline> for MySpecializer {
     type Key = MyKey;
 
@@ -109,45 +213,19 @@ impl Specializer<RenderPipeline> for MySpecializer {
         descriptor: &mut RenderPipeline,
     ) -> Result<Canonical<Self::Key>, BevyError> {
         descriptor.multisample.count = key.msaa.samples();
-        descriptor.layout[0] = if key.msaa.samples() > 0 {
+
+        let layout = if key.msaa.samples() > 1 { 
             self.layout_msaa.clone()
         } else {
             self.layout.clone()
         };
-        descriptor.fragment.targets[0].as_mut().unwrap().blend_mode = key.blend_state;
+
+        descriptor.set_layout(0, layout);
+
         Ok(key)
     }
 }
 
-impl GetBaseDescriptor for MySpecializer {
-    fn get_base_descriptor(&self) -> RenderPipelineDescriptor {
-        RenderPipelineDescriptor {
-            label: Some("my_pipeline".into()),
-            layout: vec![self.layout.clone()],
-            push_constant_ranges: vec![],
-            vertex: VertexState {
-                shader: self.vertex.clone(),
-                shader_defs: vec![],
-                entry_point: "vertex".into(),
-                buffers: vec![],
-            },
-            primitive: Default::default(),
-            depth_stencil: None,
-            multisample: MultiSampleState::default(),
-            fragment: Some(FragmentState {
-                shader: self.fragment.clone(),
-                shader_defs: vec![],
-                entry_point: "fragment".into(),
-                targets: vec![Some(ColorTargetState {
-                    format: TextureFormat::Rgba8Unorm,
-                    blend: None,
-                    write_mask: ColorWrites::all(),
-                })],
-            }),
-            zero_initialize_workgroup_memory: false,
-        },
-    }
-}
+render_app.init_resource::<MyPipeline>();
 
-app.init_resource::<SpecializedCache<RenderPipeline, MySpecializer>>();
 ```

--- a/release-content/migration-guides/composable_specialization.md
+++ b/release-content/migration-guides/composable_specialization.md
@@ -150,7 +150,7 @@ pub struct MyPipeline {
     // explicit fields for them here. However, real-world cases
     // may still need to expose them as fields to create bind groups
     // from, for example.
-    specialized_cache: SpecializedCache<RenderPipeline, MySpecializer>,
+    variants: SpecializedCache<RenderPipeline, MySpecializer>,
 }
 
 pub struct MySpecializer {
@@ -187,20 +187,16 @@ impl FromWorld for MyPipeline {
             ..default()
         },
 
-        let specialized_cache = SpecializedCache::new(
+        let variants = SpecializedCache::new(
             MySpecializer {
                 layout: layout.clone(),
                 layout_msaa: layout_msaa.clone(),
             },
-            None,
             base_descriptor,
         );
         
         Self {
-            layout,
-            layout_msaa,
-            vertex,
-            fragment,
+            variants
         }
     }
 }

--- a/release-content/migration-guides/composable_specialization.md
+++ b/release-content/migration-guides/composable_specialization.md
@@ -145,13 +145,12 @@ After:
 ```rust
 #[derive(Resource)]
 pub struct MyPipeline {
+    // the base_descriptor and specializer each hold onto the static
+    // wgpu resources (layout, shader handles), so we don't need
+    // explicit fields for them here. However, real-world cases
+    // may still need to duplicate them as fields to create bind
+    // groups from, etc.
     specialized_cache: SpecializedCache<RenderPipeline, MySpecializer>,
-
-    // these fields are unused, they're just here for demonstration purposes
-    layout: BindGroupLayout,
-    layout_msaa: BindGroupLayout,
-    vertex: Handle<Shader>,
-    fragment: Handle<Shader>,
 }
 
 pub struct MySpecializer {

--- a/release-content/migration-guides/composable_specialization.md
+++ b/release-content/migration-guides/composable_specialization.md
@@ -4,7 +4,7 @@ pull_requests: [17373]
 ---
 
 The existing pipeline specialization APIs (`SpecializedRenderPipeline` etc.) have
-been replaced with a single `Specializer` trait and `SpecializedCache` collection:
+been replaced with a single `Specializer` trait and `Variants` collection:
 
 ```rust
 pub trait Specializer<T: Specializable>: Send + Sync + 'static {
@@ -16,7 +16,7 @@ pub trait Specializer<T: Specializable>: Send + Sync + 'static {
     ) -> Result<Canonical<Self::Key>, BevyError>;
 }
 
-pub struct SpecializedCache<T: Specializable, S: Specializer<T>>{ ... };
+pub struct Variants<T: Specializable, S: Specializer<T>>{ ... };
 ```
 
 For more info on specialization, see the docs for `bevy_render::render_resources::Specializer`
@@ -25,7 +25,7 @@ For more info on specialization, see the docs for `bevy_render::render_resources
 
 The main difference between the old and new trait is that instead of
 *producing* a pipeline descriptor, `Specializer`s *mutate* existing descriptors
-based on a key. As such, `SpecializedCache::new` takes in a "base descriptor"
+based on a key. As such, `Variants::new` takes in a "base descriptor"
 to act as the template from which the specializer creates pipeline variants.
 
 When migrating, the "static" parts of the pipeline (that don't depend
@@ -57,7 +57,7 @@ pub struct MySpecializer {
 
 ## Misc Changes
 
-The analogue of `SpecializedRenderPipelines`, `SpecializedCache`, is no longer a
+The analogue of `SpecializedRenderPipelines`, `Variants`, is no longer a
 Bevy `Resource`. Instead, the cache should be stored in a user-created `Resource`
 (shown below) or even in a `Component` depending on the use case.
 
@@ -150,7 +150,7 @@ pub struct MyPipeline {
     // explicit fields for them here. However, real-world cases
     // may still need to expose them as fields to create bind groups
     // from, for example.
-    variants: SpecializedCache<RenderPipeline, MySpecializer>,
+    variants: Variants<RenderPipeline, MySpecializer>,
 }
 
 pub struct MySpecializer {
@@ -187,7 +187,7 @@ impl FromWorld for MyPipeline {
             ..default()
         },
 
-        let variants = SpecializedCache::new(
+        let variants = Variants::new(
             MySpecializer {
                 layout: layout.clone(),
                 layout_msaa: layout_msaa.clone(),


### PR DESCRIPTION
# Objective

- Adds some util methods to remove some boilerplate from specializers. More will probably be added later but `set_target` and `set_layout` will be the most used I think.
  - Note: Specializers can't rely on their input descriptor having a certain shape, so instead of just `push`ing to each vec, the methods pad the length of the vec if necessary and set the value directly.
- After migrating a few engine `Specializer`s, `GetBaseDescriptor` & `SpecializedCache: Resource` both seem like anti-patterns, especially with dynamic materials on the horizon
- Also removes `user_specializer`s. If anyone needs that functionality they can easily make a wrapper for it.

## Solution

- Add the things
- Nuke the stuff
- update the migration guide

