### PR TITLE
Virtual keyboard widget

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3594,6 +3594,18 @@ category = "UI (User Interface)"
 wasm = true
 
 [[example]]
+name = "virtual_keyboard"
+path = "examples/ui/virtual_keyboard.rs"
+doc-scrape-examples = true
+required-features = ["experimental_bevy_feathers"]
+
+[package.metadata.example.virtual_keyboard]
+name = "Virtual Keyboard"
+description = "Example demonstrating a virtual keyboard widget"
+category = "UI (User Interface)"
+wasm = true
+
+[[example]]
 name = "ui_scaling"
 path = "examples/ui/ui_scaling.rs"
 doc-scrape-examples = true

--- a/crates/bevy_feathers/src/controls/mod.rs
+++ b/crates/bevy_feathers/src/controls/mod.rs
@@ -7,6 +7,7 @@ mod color_swatch;
 mod radio;
 mod slider;
 mod toggle_switch;
+mod virtual_keyboard;
 
 pub use button::{button, ButtonPlugin, ButtonProps, ButtonVariant};
 pub use checkbox::{checkbox, CheckboxPlugin, CheckboxProps};
@@ -14,6 +15,7 @@ pub use color_swatch::{color_swatch, ColorSwatch, ColorSwatchFg};
 pub use radio::{radio, RadioPlugin};
 pub use slider::{slider, SliderPlugin, SliderProps};
 pub use toggle_switch::{toggle_switch, ToggleSwitchPlugin, ToggleSwitchProps};
+pub use virtual_keyboard::virtual_keyboard;
 
 use crate::alpha_pattern::AlphaPatternPlugin;
 

--- a/crates/bevy_feathers/src/controls/virtual_keyboard.rs
+++ b/crates/bevy_feathers/src/controls/virtual_keyboard.rs
@@ -1,0 +1,56 @@
+use bevy_core_widgets::{Activate, Callback};
+use bevy_ecs::{
+    bundle::Bundle,
+    component::Component,
+    hierarchy::{ChildOf, Children},
+    relationship::RelatedSpawner,
+    spawn::{Spawn, SpawnRelated, SpawnWith},
+    system::{In, SystemId},
+};
+use bevy_input_focus::tab_navigation::TabGroup;
+use bevy_ui::Node;
+use bevy_ui::Val;
+use bevy_ui::{widget::Text, FlexDirection};
+
+use crate::controls::{button, ButtonProps};
+
+/// Function to spawn a virtual keyboard
+pub fn virtual_keyboard<T>(
+    keys: Vec<Vec<(String, T)>>,
+    on_key_press: SystemId<In<Activate>>,
+) -> impl Bundle
+where
+    T: Component,
+{
+    (
+        Node {
+            flex_direction: FlexDirection::Column,
+            row_gap: Val::Px(4.),
+            ..Default::default()
+        },
+        TabGroup::new(0),
+        Children::spawn((SpawnWith(move |parent: &mut RelatedSpawner<ChildOf>| {
+            for row in keys.into_iter() {
+                parent.spawn((
+                    Node {
+                        flex_direction: FlexDirection::Row,
+                        column_gap: Val::Px(4.),
+                        ..Default::default()
+                    },
+                    Children::spawn(SpawnWith(move |parent: &mut RelatedSpawner<ChildOf>| {
+                        for (label, key_id) in row.into_iter() {
+                            parent.spawn(button(
+                                ButtonProps {
+                                    on_click: Callback::System(on_key_press),
+                                    ..Default::default()
+                                },
+                                (key_id,),
+                                Spawn(Text::new(label)),
+                            ));
+                        }
+                    })),
+                ));
+            }
+        }),)),
+    )
+}

--- a/examples/ui/virtual_keyboard.rs
+++ b/examples/ui/virtual_keyboard.rs
@@ -1,0 +1,112 @@
+//! Virtual keyboard example
+
+use bevy::{
+    color::palettes::css::{NAVY, YELLOW},
+    core_widgets::{
+        Activate, Callback, CoreRadio, CoreRadioGroup, CoreWidgetsPlugins, SliderPrecision,
+        SliderStep,
+    },
+    feathers::{
+        controls::{
+            button, checkbox, color_swatch, radio, slider, toggle_switch, virtual_keyboard,
+            ButtonProps, ButtonVariant, CheckboxProps, SliderProps, ToggleSwitchProps,
+        },
+        dark_theme::create_dark_theme,
+        rounded_corners::RoundedCorners,
+        theme::{ThemeBackgroundColor, ThemedText, UiTheme},
+        tokens, FeathersPlugin,
+    },
+    input_focus::{
+        tab_navigation::{TabGroup, TabNavigationPlugin},
+        InputDispatchPlugin,
+    },
+    prelude::*,
+    ui::{Checked, InteractionDisabled},
+    winit::WinitSettings,
+};
+use bevy_ecs::relationship::{RelatedSpawner, RelatedSpawnerCommands};
+
+fn main() {
+    App::new()
+        .add_plugins((
+            DefaultPlugins,
+            CoreWidgetsPlugins,
+            InputDispatchPlugin,
+            TabNavigationPlugin,
+            FeathersPlugin,
+        ))
+        .insert_resource(UiTheme(create_dark_theme()))
+        // Only run the app when there is user input. This will significantly reduce CPU/GPU use.
+        .insert_resource(WinitSettings::desktop_app())
+        .add_systems(Startup, setup)
+        .run();
+}
+
+#[derive(Component)]
+struct VirtualKey(String);
+
+fn on_virtual_key_pressed(
+    In(Activate(virtual_key_entity)): In<Activate>,
+    virtual_key_query: Query<&VirtualKey>,
+) {
+    if let Ok(VirtualKey(label)) = virtual_key_query.get(virtual_key_entity) {
+        println!("key pressed: {label}");
+    }
+}
+
+fn setup(mut commands: Commands) {
+    // ui camera
+    commands.spawn(Camera2d);
+    let callback = commands.register_system(on_virtual_key_pressed);
+
+    let layout = vec![
+        vec!["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", ".", ","],
+        vec!["Q", "W", "E", "R", "T", "Y", "U", "I", "O", "P"],
+        vec!["A", "S", "D", "F", "G", "H", "J", "K", "L", "'"],
+        vec!["Z", "X", "C", "V", "B", "N", "M", "-", "/"],
+        vec!["space", "enter", "backspace"],
+        vec!["left", "right", "up", "down", "home", "end"],
+    ];
+
+    let keys = layout
+        .into_iter()
+        .map(|row| {
+            row.into_iter()
+                .map(|label| {
+                    let label_string = label.to_string();
+                    (label_string.clone(), VirtualKey(label_string))
+                })
+                .collect()
+        })
+        .collect();
+
+    commands
+        .spawn(Node {
+            width: Val::Percent(100.0),
+            height: Val::Percent(100.0),
+            align_items: AlignItems::End,
+            justify_content: JustifyContent::Center,
+            ..default()
+        })
+        .with_children(|parent: &mut RelatedSpawnerCommands<ChildOf>| {
+            parent
+                .spawn((
+                    Node {
+                        flex_direction: FlexDirection::Column,
+                        border: Val::Px(5.).into(),
+                        row_gap: Val::Px(5.),
+                        padding: Val::Px(5.).into(),
+                        align_items: AlignItems::Center,
+                        margin: Val::Px(25.).into(),
+                        ..Default::default()
+                    },
+                    BackgroundColor(NAVY.into()),
+                    BorderColor::all(Color::WHITE),
+                    BorderRadius::all(Val::Px(10.)),
+                ))
+                .with_children(|parent: &mut RelatedSpawnerCommands<ChildOf>| {
+                    parent.spawn(Text::new("virtual keyboard"));
+                    parent.spawn(virtual_keyboard(keys, callback));
+                });
+        });
+}


### PR DESCRIPTION
# Objective

Basic virtual keyboard widget.

## Solution

Added a `virtual_keyboard` module to `bevy_feathers::controls` with a single function also called `virtual_keyboard`.
`virtual_keyboard` takes a list of rows of keys and a system ID for the key press handler.

## Testing

```
cargo run --example virtual_keyboard --features="experimental_bevy_feathers"
```
---

## Showcase

<img width="1042" height="573" alt="virtual_keyboard" src="https://github.com/user-attachments/assets/f882cbec-ccdf-4df1-a32e-255c063454d4" />

I deliberately didn't spend even a moment thinking about the design, this is just meant to be a super basic implementation that I can hook up to the text input widget for testing. Still looks quite neat though.