### PR TITLE
Change to relationship iter method instead of looping over private vec field in relationship example

### DIFF
--- a/examples/ecs/relationships.rs
+++ b/examples/ecs/relationships.rs
@@ -87,8 +87,8 @@ fn main() {
             let targeted_by_string = if let Some(targeted_by) = maybe_targeted_by {
                 let mut vec_of_names = Vec::<&Name>::new();
 
-                for entity in &targeted_by.0 {
-                    let name = name_query.get(*entity).unwrap();
+                for entity in targeted_by.iter() {
+                    let name = name_query.get(entity).unwrap();
                     vec_of_names.push(name);
                 }
 


### PR DESCRIPTION
# Objective

- Fixes #20091 

## Solution

- Changed loop over targeted_by inner private field to use the RelationshipTarget trait's .iter() method.