### PR TITLE
bevy_window: Split `RawHandleWrapper` out into `Display` wrapper

### DIFF
--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -128,7 +128,7 @@ impl Plugin for WindowPlugin {
             let mut entity_commands = app.world_mut().spawn(primary_window.clone());
             entity_commands.insert((
                 PrimaryWindow,
-                RawHandleWrapperHolder(Arc::new(Mutex::new(None))),
+                RawWindowHandleWrapperHolder(Arc::new(Mutex::new(None))),
             ));
             if let Some(primary_cursor_options) = &self.primary_cursor_options {
                 entity_commands.insert(primary_cursor_options.clone());

--- a/crates/bevy_window/src/raw_handle.rs
+++ b/crates/bevy_window/src/raw_handle.rs
@@ -4,7 +4,7 @@
 )]
 
 use alloc::sync::Arc;
-use bevy_ecs::prelude::Component;
+use bevy_ecs::{prelude::Component, resource::Resource};
 use bevy_platform::sync::Mutex;
 use core::{any::Any, marker::PhantomData, ops::Deref};
 use raw_window_handle::{
@@ -17,7 +17,7 @@ use raw_window_handle::{
 /// This allows us to extend the lifetime of the window, so it doesn't get eagerly dropped while a
 /// pipelined renderer still has frames in flight that need to draw to it.
 ///
-/// This is achieved by storing a shared reference to the window in the [`RawHandleWrapper`],
+/// This is achieved by storing a shared reference to the window in the [`RawWindowHandleWrapper`],
 /// which gets picked up by the renderer during extraction.
 #[derive(Debug)]
 pub struct WindowWrapper<W> {
@@ -49,7 +49,7 @@ impl<W: 'static> Deref for WindowWrapper<W> {
 /// and so we cannot simply make it (or any type that has a safe operation to get a [`RawWindowHandle`] or [`RawDisplayHandle`])
 /// thread-safe.
 #[derive(Debug, Clone, Component)]
-pub struct RawHandleWrapper {
+pub struct RawWindowHandleWrapper {
     /// A shared reference to the window.
     /// This allows us to extend the lifetime of the window,
     /// so it doesn’t get eagerly dropped while a pipelined
@@ -57,19 +57,17 @@ pub struct RawHandleWrapper {
     _window: Arc<dyn Any + Send + Sync>,
     /// Raw handle to a window.
     window_handle: RawWindowHandle,
-    /// Raw handle to the display server.
-    display_handle: RawDisplayHandle,
 }
 
-impl RawHandleWrapper {
-    /// Creates a `RawHandleWrapper` from a `WindowWrapper`.
-    pub fn new<W: HasWindowHandle + HasDisplayHandle + 'static>(
+impl RawWindowHandleWrapper {
+    /// Creates a [`RawWindowHandleWrapper`] from a [`WindowWrapper`].
+    pub fn new<W: HasWindowHandle + 'static>(
         window: &WindowWrapper<W>,
-    ) -> Result<RawHandleWrapper, HandleError> {
-        Ok(RawHandleWrapper {
+    ) -> Result<Self, HandleError> {
+        Ok(Self {
             _window: window.reference.clone(),
             window_handle: window.window_handle()?.as_raw(),
-            display_handle: window.display_handle()?.as_raw(),
+            // display_handle: window.display_handle()?.as_raw(),
         })
     }
 
@@ -78,7 +76,7 @@ impl RawHandleWrapper {
     /// # Safety
     ///
     /// Some platforms have constraints on where/how this handle can be used. For example, some platforms don't support doing window
-    /// operations off of the main thread. The caller must ensure the [`RawHandleWrapper`] is only used in valid contexts.
+    /// operations off of the main thread. The caller must ensure the [`RawWindowHandleWrapper`] is only used in valid contexts.
     pub unsafe fn get_handle(&self) -> ThreadLockedRawWindowHandleWrapper {
         ThreadLockedRawWindowHandleWrapper(self.clone())
     }
@@ -101,6 +99,70 @@ impl RawHandleWrapper {
 
         self
     }
+}
+
+// SAFETY: `RawWindowHandleWrapper` is just a normal "raw pointer", which doesn't impl Send/Sync. However the pointer is only
+// exposed via an unsafe method that forces the user to make a call for a given platform. (ex: some platforms don't
+// support doing window operations off of the main thread).
+// A recommendation for this pattern (and more context) is available here:
+// https://github.com/rust-windowing/raw-window-handle/issues/59
+unsafe impl Send for RawWindowHandleWrapper {}
+// SAFETY: This is safe for the same reasons as the Send impl above.
+unsafe impl Sync for RawWindowHandleWrapper {}
+
+/// A [`RawWindowHandleWrapper`] that cannot be sent across threads.
+///
+/// This safely exposes [`RawWindowHandle`], but care must be taken to ensure that the construction itself is correct.
+///
+/// This can only be constructed via the [`RawWindowHandleWrapper::get_handle()`] method;
+/// be sure to read the safety docs there about platform-specific limitations.
+/// In many cases, this should only be constructed on the main thread.
+pub struct ThreadLockedRawWindowHandleWrapper(RawWindowHandleWrapper);
+
+impl HasWindowHandle for ThreadLockedRawWindowHandleWrapper {
+    fn window_handle(&self) -> Result<WindowHandle, HandleError> {
+        // SAFETY: the caller has validated that this is a valid context to get `RawWindowHandleWrapper`
+        // as otherwise an instance of this type could not have been constructed
+        // NOTE: we cannot simply impl HasRawWindowHandle for RawWindowHandleWrapper,
+        // as the `raw_window_handle` method is safe. We cannot guarantee that all calls
+        // of this method are correct (as it may be off the main thread on an incompatible platform),
+        // and so exposing a safe method to get a [`RawWindowHandle`] directly would be UB.
+        // XXX: ^ that note is flawed. "getting" the handle is safe - it's about how it's used. Any
+        // API **consuming** a RawWindowHandle should be adequately marked unsafe instead.
+        Ok(unsafe { WindowHandle::borrow_raw(self.0.window_handle) })
+    }
+}
+
+// XXX: Could still be implemented because `_window` provides it
+// impl HasDisplayHandle for ThreadLockedRawDisplayHandleWrapper {
+//     fn display_handle(&self) -> Result<DisplayHandle, HandleError> {
+//     }
+// }
+
+/// Holder of the [`RawHWindowandleWrapper`] with wrappers, to allow use in asynchronous context
+#[derive(Debug, Clone, Component)]
+pub struct RawWindowHandleWrapperHolder(pub Arc<Mutex<Option<RawWindowHandleWrapper>>>);
+
+/// A wrapper over [`RawDisplayHandle`] that allows us to safely pass it across threads.
+///
+/// Depending on the platform, the underlying pointer-containing handle cannot be used on all threads,
+/// and so we cannot simply make it (or any type that has a safe operation to get a [`RawWindowHandle`] or [`RawDisplayHandle`])
+/// thread-safe.
+#[derive(Debug, Clone, Resource)]
+pub struct RawDisplayHandleWrapper {
+    // XXX: Do we need to hold on to the EventLoop who owns/runs the app?
+    /// Raw handle to the display server.
+    display_handle: RawDisplayHandle,
+}
+
+impl RawDisplayHandleWrapper {
+    /// Creates a `RawDisplayHandleWrapper` from an event loop or similar.
+    // XXX: Do we need to store `display` for lifetime purposes? It should outlive App.
+    pub fn new<W: HasDisplayHandle + 'static>(display: &W) -> Result<Self, HandleError> {
+        Ok(Self {
+            display_handle: display.display_handle()?.as_raw(),
+        })
+    }
 
     /// Gets the stored display handle
     pub fn get_display_handle(&self) -> RawDisplayHandle {
@@ -119,48 +181,28 @@ impl RawHandleWrapper {
     }
 }
 
-// SAFETY: [`RawHandleWrapper`] is just a normal "raw pointer", which doesn't impl Send/Sync. However the pointer is only
+// SAFETY: `RawDisplayHandleWrapper` is just a normal "raw pointer", which doesn't impl Send/Sync. However the pointer is only
 // exposed via an unsafe method that forces the user to make a call for a given platform. (ex: some platforms don't
 // support doing window operations off of the main thread).
 // A recommendation for this pattern (and more context) is available here:
 // https://github.com/rust-windowing/raw-window-handle/issues/59
-unsafe impl Send for RawHandleWrapper {}
+unsafe impl Send for RawDisplayHandleWrapper {}
 // SAFETY: This is safe for the same reasons as the Send impl above.
-unsafe impl Sync for RawHandleWrapper {}
+unsafe impl Sync for RawDisplayHandleWrapper {}
 
-/// A [`RawHandleWrapper`] that cannot be sent across threads.
-///
-/// This safely exposes [`RawWindowHandle`] and [`RawDisplayHandle`], but care must be taken to ensure that the construction itself is correct.
-///
-/// This can only be constructed via the [`RawHandleWrapper::get_handle()`] method;
-/// be sure to read the safety docs there about platform-specific limitations.
-/// In many cases, this should only be constructed on the main thread.
-pub struct ThreadLockedRawWindowHandleWrapper(RawHandleWrapper);
+// /// A [`RawDisplayHandleWrapper`] that cannot be sent across threads.
+// ///
+// /// This safely exposes [`RawDisplayHandle`], but care must be taken to ensure that the construction itself is correct.
+// ///
+// /// This can only be constructed via the [`RawDisplayHandleWrapper::get_handle()`] method;
+// /// be sure to read the safety docs there about platform-specific limitations.
+// /// In many cases, this should only be constructed on the main thread.
+// pub struct ThreadLockedRawDisplayHandleWrapper(RawDisplayHandleWrapper);
 
-impl HasWindowHandle for ThreadLockedRawWindowHandleWrapper {
-    fn window_handle(&self) -> Result<WindowHandle, HandleError> {
-        // SAFETY: the caller has validated that this is a valid context to get [`RawHandleWrapper`]
-        // as otherwise an instance of this type could not have been constructed
-        // NOTE: we cannot simply impl HasRawWindowHandle for RawHandleWrapper,
-        // as the `raw_window_handle` method is safe. We cannot guarantee that all calls
-        // of this method are correct (as it may be off the main thread on an incompatible platform),
-        // and so exposing a safe method to get a [`RawWindowHandle`] directly would be UB.
-        Ok(unsafe { WindowHandle::borrow_raw(self.0.window_handle) })
-    }
-}
-
-impl HasDisplayHandle for ThreadLockedRawWindowHandleWrapper {
+impl HasDisplayHandle for RawDisplayHandleWrapper {
     fn display_handle(&self) -> Result<DisplayHandle, HandleError> {
-        // SAFETY: the caller has validated that this is a valid context to get [`RawDisplayHandle`]
+        // SAFETY: the caller has validated that this is a valid context to get `RawDisplayHandle`
         // as otherwise an instance of this type could not have been constructed
-        // NOTE: we cannot simply impl HasRawDisplayHandle for RawHandleWrapper,
-        // as the `raw_display_handle` method is safe. We cannot guarantee that all calls
-        // of this method are correct (as it may be off the main thread on an incompatible platform),
-        // and so exposing a safe method to get a [`RawDisplayHandle`] directly would be UB.
-        Ok(unsafe { DisplayHandle::borrow_raw(self.0.display_handle) })
+        Ok(unsafe { DisplayHandle::borrow_raw(self.display_handle) })
     }
 }
-
-/// Holder of the [`RawHandleWrapper`] with wrappers, to allow use in asynchronous context
-#[derive(Debug, Clone, Component)]
-pub struct RawHandleWrapperHolder(pub Arc<Mutex<Option<RawHandleWrapper>>>);

--- a/crates/bevy_winit/src/state.rs
+++ b/crates/bevy_winit/src/state.rs
@@ -36,7 +36,7 @@ use bevy_window::{
     WindowScaleFactorChanged, WindowThemeChanged,
 };
 #[cfg(target_os = "android")]
-use bevy_window::{CursorOptions, PrimaryWindow, RawHandleWrapper};
+use bevy_window::{CursorOptions, PrimaryWindow, RawWindowHandleWrapper};
 
 use crate::{
     accessibility::ACCESS_KIT_ADAPTERS,
@@ -529,9 +529,10 @@ impl<T: BufferedEvent> WinitAppRunnerState<T> {
             should_update = true;
             self.ran_update_since_last_redraw = false;
 
+            // XXX: Handle generically
             #[cfg(target_os = "android")]
             {
-                // Remove the `RawHandleWrapper` from the primary window.
+                // Remove the `RawWindowHandleWrapper` from the primary window.
                 // This will trigger the surface destruction.
                 let mut query = self
                     .world_mut()
@@ -539,7 +540,7 @@ impl<T: BufferedEvent> WinitAppRunnerState<T> {
                 let entity = query.single(&self.world()).unwrap();
                 self.world_mut()
                     .entity_mut(entity)
-                    .remove::<RawHandleWrapper>();
+                    .remove::<RawWindowHandleWrapper>();
             }
         }
 
@@ -550,13 +551,14 @@ impl<T: BufferedEvent> WinitAppRunnerState<T> {
             // Trigger the next redraw to refresh the screen immediately
             self.redraw_requested = true;
 
+            // XXX: Handle generically
             #[cfg(target_os = "android")]
             {
                 // Get windows that are cached but without raw handles. Those window were already created, but got their
                 // handle wrapper removed when the app was suspended.
 
                 let mut query = self.world_mut()
-                    .query_filtered::<(Entity, &Window, &CursorOptions), (With<CachedWindow>, Without<RawHandleWrapper>)>();
+                    .query_filtered::<(Entity, &Window, &CursorOptions), (With<CachedWindow>, Without<RawWindowHandleWrapper>)>();
                 if let Ok((entity, window, cursor_options)) = query.single(&self.world()) {
                     let window = window.clone();
                     let cursor_options = cursor_options.clone();
@@ -580,7 +582,7 @@ impl<T: BufferedEvent> WinitAppRunnerState<T> {
                                 &monitors,
                             );
 
-                            let wrapper = RawHandleWrapper::new(winit_window).unwrap();
+                            let wrapper = RawWindowHandleWrapper::new(winit_window).unwrap();
 
                             self.world_mut().entity_mut(entity).insert(wrapper);
                         });

--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -12,7 +12,7 @@ use bevy_ecs::{
 };
 use bevy_input::keyboard::{Key, KeyCode, KeyboardFocusLost, KeyboardInput};
 use bevy_window::{
-    ClosingWindow, CursorOptions, Monitor, PrimaryMonitor, RawHandleWrapper, VideoMode, Window,
+    ClosingWindow, CursorOptions, Monitor, PrimaryMonitor, RawWindowHandleWrapper, VideoMode, Window,
     WindowClosed, WindowClosing, WindowCreated, WindowEvent, WindowFocused, WindowMode,
     WindowResized, WindowWrapper,
 };
@@ -93,7 +93,7 @@ pub fn create_windows<F: QueryFilter + 'static>(
                     WinitWindowPressedKeys::default(),
                 ));
 
-                if let Ok(handle_wrapper) = RawHandleWrapper::new(winit_window) {
+                if let Ok(handle_wrapper) = RawWindowHandleWrapper::new(winit_window) {
                     commands.entity(entity).insert(handle_wrapper.clone());
                     if let Some(handle_holder) = handle_holder {
                         *handle_holder.0.lock().unwrap() = Some(handle_wrapper);


### PR DESCRIPTION
## Objective

- Work towards solving https://github.com/bevyengine/bevy/issues/13923 and https://github.com/bevyengine/bevy/issues/14494 by getting rid of some duplication.

## Solution

Long ago `raw-window-handle` and `winit` split out a `RawDisplayHandle` type and respective traits for dealing with the connection - or at the very least type - of a compositor, and typically implement this for a `Window` directly.

`wgpu` and `bevy` seem to have caught on to the latter and folded the two traits/types together because `Window` provides it, but miss a critical goal here: that `(Raw)DisplayHandle` is important for initialization of certain graphics APIs. In the case of Wayland all resources are unique per connection, and in general for others it's important to distinguish between Wayland and X11 if `winit` chose one over the other, even if both are available; currently that's just guesswork inside `wgpu`.

Newer APIs like Vulkan don't suffer from this, but older graphics APIs like OpenGL and specifically the EGL backend (or GLX for X11) set up their entire state based on the compositor connection (alternatives are available) even if it's ultimately "only" important for the surface that is going to be rendered into.

Note that I haven't yet checked all the safety constraints carefully in this PR; some existing messages seem flawed but I need to perform a clean audit from scratch to denote what limitations should apply to the newly proposed `RawDisplayHandleWrapper` as well.

## Testing

- `cargo r --example 3d_bloom -Fwayland` on a Wayland compositor.