### PR TITLE
Use the default directional light intensity constant

### DIFF
--- a/examples/3d/shadow_biases.rs
+++ b/examples/3d/shadow_biases.rs
@@ -160,7 +160,7 @@ fn toggle_light(
         for mut light in &mut directional_lights {
             light.illuminance = if light.illuminance == 0.0 {
                 *writer.text(*example_text, 4) = "DirectionalLight".to_string();
-                100000.0
+                light_consts::lux::AMBIENT_DAYLIGHT
             } else {
                 0.0
             };


### PR DESCRIPTION
# Objective

- Pressing L twice to cycle light type in shadow_biases ends up with a different brightness of light

## Solution

- Use the correct default so the brightness matches

## Testing

- run shadow_biases example