### PR TITLE
Add light_consts::lumens::VERY_LARGE_CINEMA_LIGHT

### DIFF
--- a/crates/bevy_light/src/lib.rs
+++ b/crates/bevy_light/src/lib.rs
@@ -65,6 +65,9 @@ pub mod light_consts {
         pub const LUMENS_PER_LED_WATTS: f32 = 90.0;
         pub const LUMENS_PER_INCANDESCENT_WATTS: f32 = 13.8;
         pub const LUMENS_PER_HALOGEN_WATTS: f32 = 19.8;
+        /// 1,000,000 lumens is a very large "cinema light" capable of registering brightly at Bevy's
+        /// default "very overcast day" exposure level. For "indoor lighting" with a lower exposure,
+        /// this would be way too bright.
         pub const VERY_LARGE_CINEMA_LIGHT: f32 = 1_000_000.0;
     }
 

--- a/crates/bevy_light/src/lib.rs
+++ b/crates/bevy_light/src/lib.rs
@@ -65,6 +65,7 @@ pub mod light_consts {
         pub const LUMENS_PER_LED_WATTS: f32 = 90.0;
         pub const LUMENS_PER_INCANDESCENT_WATTS: f32 = 13.8;
         pub const LUMENS_PER_HALOGEN_WATTS: f32 = 19.8;
+        pub const VERY_LARGE_CINEMA_LIGHT: f32 = 1_000_000.0;
     }
 
     /// Predefined for lux values in several locations.

--- a/crates/bevy_light/src/point_light.rs
+++ b/crates/bevy_light/src/point_light.rs
@@ -129,9 +129,6 @@ impl Default for PointLight {
     fn default() -> Self {
         PointLight {
             color: Color::WHITE,
-            // 1,000,000 lumens is a very large "cinema light" capable of registering brightly at Bevy's
-            // default "very overcast day" exposure level. For "indoor lighting" with a lower exposure,
-            // this would be way too bright.
             intensity: light_consts::lumens::VERY_LARGE_CINEMA_LIGHT,
             range: 20.0,
             radius: 0.0,

--- a/crates/bevy_light/src/point_light.rs
+++ b/crates/bevy_light/src/point_light.rs
@@ -10,7 +10,10 @@ use bevy_math::Mat4;
 use bevy_reflect::prelude::*;
 use bevy_transform::components::{GlobalTransform, Transform};
 
-use crate::cluster::{ClusterVisibilityClass, GlobalVisibleClusterableObjects};
+use crate::{
+    cluster::{ClusterVisibilityClass, GlobalVisibleClusterableObjects},
+    light_consts,
+};
 
 /// A light that emits light in all directions from a central point.
 ///
@@ -129,7 +132,7 @@ impl Default for PointLight {
             // 1,000,000 lumens is a very large "cinema light" capable of registering brightly at Bevy's
             // default "very overcast day" exposure level. For "indoor lighting" with a lower exposure,
             // this would be way too bright.
-            intensity: 1_000_000.0,
+            intensity: light_consts::lumens::VERY_LARGE_CINEMA_LIGHT,
             range: 20.0,
             radius: 0.0,
             shadows_enabled: false,

--- a/examples/3d/shadow_biases.rs
+++ b/examples/3d/shadow_biases.rs
@@ -152,7 +152,7 @@ fn toggle_light(
         for mut light in &mut point_lights {
             light.intensity = if light.intensity == 0.0 {
                 *writer.text(*example_text, 4) = "PointLight".to_string();
-                100000000.0
+                light_consts::lumens::VERY_LARGE_CINEMA_LIGHT
             } else {
                 0.0
             };


### PR DESCRIPTION
# Objective

- Point light default has no constant
- shadow_biases example uses some arbitrary weird lumen value

## Solution

- Add a constant inspired by the doc comment on point light default

## Testing

- run shadow_biases example and press L