### PR TITLE
Validate directional light shadow map size is power of two

### DIFF
--- a/crates/bevy_light/src/directional_light.rs
+++ b/crates/bevy_light/src/directional_light.rs
@@ -9,6 +9,7 @@ use bevy_ecs::prelude::*;
 use bevy_image::Image;
 use bevy_reflect::prelude::*;
 use bevy_transform::components::Transform;
+use tracing::warn;
 
 use super::{
     cascade::CascadeShadowConfig, cluster::ClusterVisibilityClass, light_consts, Cascades,
@@ -182,6 +183,8 @@ pub struct DirectionalLightTexture {
 pub struct DirectionalLightShadowMap {
     // The width and height of each cascade.
     ///
+    /// Must be a power of two to avoid unstable cascade positioning.
+    ///
     /// Defaults to `2048`.
     pub size: usize,
 }
@@ -189,6 +192,14 @@ pub struct DirectionalLightShadowMap {
 impl Default for DirectionalLightShadowMap {
     fn default() -> Self {
         Self { size: 2048 }
+    }
+}
+
+pub fn validate_shadow_map_size(mut shadow_map: ResMut<DirectionalLightShadowMap>) {
+    if shadow_map.is_changed() && !shadow_map.size.is_power_of_two() {
+        let new_size = shadow_map.size.next_power_of_two();
+        warn!("Non-power-of-two DirectionalLightShadowMap sizes are not supported, correcting {} to {new_size}", shadow_map.size);
+        shadow_map.size = new_size;
     }
 }
 

--- a/crates/bevy_light/src/lib.rs
+++ b/crates/bevy_light/src/lib.rs
@@ -48,6 +48,8 @@ pub use directional_light::{
     DirectionalLightTexture,
 };
 
+use crate::directional_light::validate_shadow_map_size;
+
 /// Constants for operating with the light units: lumens, and lux.
 pub mod light_consts {
     /// Approximations for converting the wattage of lamps to lumens.
@@ -145,6 +147,7 @@ impl Plugin for LightPlugin {
             .add_systems(
                 PostUpdate,
                 (
+                    validate_shadow_map_size,
                     add_clusters
                         .in_set(SimulationLightSystems::AddClusters)
                         .after(CameraUpdateSystems),


### PR DESCRIPTION
# Objective

- cascade construction code assumes shadowmap sizes are power of two
- this invariant is not enforced anywhere

## Solution

- automatically correct and warn when its not POT
- document

## Testing

- tried setting it to non-pot in shadow_biases example:
```
2025-08-02T02:30:44.379967Z  WARN bevy_light::directional_light: Non-power-of-two DirectionalLightShadowMap sizes are not supported, correcting 2442 to 4096
```