### PR TITLE
Alternative glTF coordinate conversion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -571,11 +571,6 @@ web = ["bevy_internal/web"]
 # Enable hotpatching of Bevy systems
 hotpatching = ["bevy_internal/hotpatching"]
 
-# Enable converting glTF coordinates to Bevy's coordinate system by default. This will be Bevy's default behavior starting in 0.18.
-gltf_convert_coordinates_default = [
-  "bevy_internal/gltf_convert_coordinates_default",
-]
-
 # Enable collecting debug information about systems and components to help with diagnostics
 debug = ["bevy_internal/debug"]
 

--- a/crates/bevy_gltf/Cargo.toml
+++ b/crates/bevy_gltf/Cargo.toml
@@ -15,7 +15,6 @@ pbr_multi_layer_material_textures = [
 ]
 pbr_anisotropy_texture = ["bevy_pbr/pbr_anisotropy_texture"]
 pbr_specular_textures = ["bevy_pbr/pbr_specular_textures"]
-gltf_convert_coordinates_default = []
 
 [dependencies]
 # bevy
@@ -64,6 +63,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.140"
 smallvec = { version = "1", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
+
+[dev-dependencies]
 bevy_log = { path = "../bevy_log", version = "0.17.0-dev" }
 
 [lints]

--- a/crates/bevy_gltf/src/convert_coordinates.rs
+++ b/crates/bevy_gltf/src/convert_coordinates.rs
@@ -40,12 +40,14 @@ impl ConvertCoordinates for [f32; 4] {
     }
 }
 
+// XXX TODO: Documentation.
 impl ConvertInverseCoordinates for Mat4 {
     fn convert_inverse_coordinates(self) -> Self {
         self * Mat4::from_scale(Vec3::new(-1.0, 1.0, -1.0))
     }
 }
 
+// XXX TODO: Documentation.
 #[derive(Copy, Clone, Default, Debug, Serialize, Deserialize)]
 pub struct GltfConvertCoordinates {
     pub scene: bool,

--- a/crates/bevy_gltf/src/convert_coordinates.rs
+++ b/crates/bevy_gltf/src/convert_coordinates.rs
@@ -1,4 +1,5 @@
 use core::f32::consts::PI;
+use serde::{Deserialize, Serialize};
 
 use bevy_math::{Mat4, Quat, Vec3};
 use bevy_transform::components::Transform;
@@ -78,4 +79,11 @@ impl ConvertCameraCoordinates for Transform {
         self.rotate_y(PI);
         self
     }
+}
+
+#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize)]
+pub struct GltfConvertCoordinates {
+    pub nodes: bool,
+    pub scene: bool,
+    pub meshes: bool,
 }

--- a/crates/bevy_gltf/src/convert_coordinates.rs
+++ b/crates/bevy_gltf/src/convert_coordinates.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
-use bevy_math::{Mat4, Vec3};
+use bevy_math::{Mat4, Quat, Vec3};
+use bevy_transform::components::Transform;
 
 pub(crate) trait ConvertCoordinates {
     /// Converts the glTF coordinates to Bevy's coordinate system.
@@ -52,4 +53,25 @@ impl ConvertInverseCoordinates for Mat4 {
 pub struct GltfConvertCoordinates {
     pub scene: bool,
     pub meshes: bool,
+}
+
+impl GltfConvertCoordinates {
+    const TRANSFORM_BEVY_FROM_GLTF: Transform =
+        Transform::from_rotation(Quat::from_xyzw(0.0, 1.0, 0.0, 0.0));
+
+    pub(crate) fn scene_conversion_transform(&self) -> Transform {
+        if self.scene {
+            Self::TRANSFORM_BEVY_FROM_GLTF
+        } else {
+            Transform::IDENTITY
+        }
+    }
+
+    pub(crate) fn mesh_conversion_transform(&self) -> Transform {
+        if self.meshes {
+            Self::TRANSFORM_BEVY_FROM_GLTF
+        } else {
+            Transform::IDENTITY
+        }
+    }
 }

--- a/crates/bevy_gltf/src/convert_coordinates.rs
+++ b/crates/bevy_gltf/src/convert_coordinates.rs
@@ -18,6 +18,7 @@ pub(crate) trait ConvertCoordinates {
     fn convert_coordinates(self) -> Self;
 }
 
+// XXX TODO: Documentation.
 pub(crate) trait ConvertInverseCoordinates {
     fn convert_inverse_coordinates(self) -> Self;
 }

--- a/crates/bevy_gltf/src/convert_coordinates.rs
+++ b/crates/bevy_gltf/src/convert_coordinates.rs
@@ -17,6 +17,10 @@ pub(crate) trait ConvertCoordinates {
     fn convert_coordinates(self) -> Self;
 }
 
+pub(crate) trait ConvertInverseCoordinates {
+    fn convert_inverse_coordinates(self) -> Self;
+}
+
 impl ConvertCoordinates for Vec3 {
     fn convert_coordinates(self) -> Self {
         Vec3::new(-self.x, self.y, -self.z)
@@ -36,12 +40,9 @@ impl ConvertCoordinates for [f32; 4] {
     }
 }
 
-impl ConvertCoordinates for Mat4 {
-    fn convert_coordinates(self) -> Self {
-        let m: Mat4 = Mat4::from_scale(Vec3::new(-1.0, 1.0, -1.0));
-        // Same as the original matrix
-        let m_inv = m;
-        m_inv * self * m
+impl ConvertInverseCoordinates for Mat4 {
+    fn convert_inverse_coordinates(self) -> Self {
+        self * Mat4::from_scale(Vec3::new(-1.0, 1.0, -1.0))
     }
 }
 

--- a/crates/bevy_gltf/src/convert_coordinates.rs
+++ b/crates/bevy_gltf/src/convert_coordinates.rs
@@ -1,8 +1,6 @@
-use core::f32::consts::PI;
 use serde::{Deserialize, Serialize};
 
-use bevy_math::{Mat4, Quat, Vec3};
-use bevy_transform::components::Transform;
+use bevy_math::{Mat4, Vec3};
 
 pub(crate) trait ConvertCoordinates {
     /// Converts the glTF coordinates to Bevy's coordinate system.
@@ -17,17 +15,6 @@ pub(crate) trait ConvertCoordinates {
     ///
     /// See <https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#coordinate-system-and-units>
     fn convert_coordinates(self) -> Self;
-}
-
-pub(crate) trait ConvertCameraCoordinates {
-    /// Like `convert_coordinates`, but uses the following for the lens rotation:
-    /// - forward: -Z
-    /// - up: Y
-    /// - right: X
-    ///
-    /// The same convention is used for lights.
-    /// See <https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#view-matrix>
-    fn convert_camera_coordinates(self) -> Self;
 }
 
 impl ConvertCoordinates for Vec3 {
@@ -49,35 +36,12 @@ impl ConvertCoordinates for [f32; 4] {
     }
 }
 
-impl ConvertCoordinates for Quat {
-    fn convert_coordinates(self) -> Self {
-        // Solution of q' = r q r*
-        Quat::from_array([-self.x, self.y, -self.z, self.w])
-    }
-}
-
 impl ConvertCoordinates for Mat4 {
     fn convert_coordinates(self) -> Self {
         let m: Mat4 = Mat4::from_scale(Vec3::new(-1.0, 1.0, -1.0));
         // Same as the original matrix
         let m_inv = m;
         m_inv * self * m
-    }
-}
-
-impl ConvertCoordinates for Transform {
-    fn convert_coordinates(mut self) -> Self {
-        self.translation = self.translation.convert_coordinates();
-        self.rotation = self.rotation.convert_coordinates();
-        self
-    }
-}
-
-impl ConvertCameraCoordinates for Transform {
-    fn convert_camera_coordinates(mut self) -> Self {
-        self.translation = self.translation.convert_coordinates();
-        self.rotate_y(PI);
-        self
     }
 }
 

--- a/crates/bevy_gltf/src/convert_coordinates.rs
+++ b/crates/bevy_gltf/src/convert_coordinates.rs
@@ -83,7 +83,6 @@ impl ConvertCameraCoordinates for Transform {
 
 #[derive(Copy, Clone, Default, Debug, Serialize, Deserialize)]
 pub struct GltfConvertCoordinates {
-    pub nodes: bool,
     pub scene: bool,
     pub meshes: bool,
 }

--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -185,7 +185,7 @@ impl Default for GltfPlugin {
         GltfPlugin {
             default_sampler: ImageSamplerDescriptor::linear(),
             custom_vertex_attributes: HashMap::default(),
-            convert_coordinates: cfg!(feature = "gltf_convert_coordinates_default"),
+            convert_coordinates: false,
         }
     }
 }

--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -161,6 +161,8 @@ pub struct GltfPlugin {
     /// Can be modified with the [`DefaultGltfImageSampler`] resource.
     pub default_sampler: ImageSamplerDescriptor,
 
+    /// XXX TODO: Update documentation.
+    ///
     /// Whether to convert glTF coordinates to Bevy's coordinate system by default.
     /// If set to `true`, the loader will convert the coordinate system of loaded glTF assets to Bevy's coordinate system
     /// such that objects looking forward in glTF will also look forward in Bevy.

--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -118,6 +118,8 @@ pub mod prelude {
     pub use crate::{assets::Gltf, assets::GltfExtras, label::GltfAssetLabel};
 }
 
+use crate::convert_coordinates::GltfConvertCoordinates;
+
 pub use {assets::*, label::GltfAssetLabel, loader::*};
 
 // Has to store an Arc<Mutex<...>> as there is no other way to mutate fields of asset loaders.
@@ -172,7 +174,7 @@ pub struct GltfPlugin {
     ///   - forward: -Z
     ///   - up: Y
     ///   - right: X
-    pub convert_coordinates: bool,
+    pub convert_coordinates: GltfConvertCoordinates,
 
     /// Registry for custom vertex attributes.
     ///
@@ -185,7 +187,7 @@ impl Default for GltfPlugin {
         GltfPlugin {
             default_sampler: ImageSamplerDescriptor::linear(),
             custom_vertex_attributes: HashMap::default(),
-            convert_coordinates: false,
+            convert_coordinates: GltfConvertCoordinates::default(),
         }
     }
 }

--- a/crates/bevy_gltf/src/loader/gltf_ext/scene.rs
+++ b/crates/bevy_gltf/src/loader/gltf_ext/scene.rs
@@ -10,10 +10,7 @@ use itertools::Itertools;
 #[cfg(feature = "bevy_animation")]
 use bevy_platform::collections::{HashMap, HashSet};
 
-use crate::{
-    convert_coordinates::{ConvertCameraCoordinates as _, ConvertCoordinates as _},
-    GltfError,
-};
+use crate::GltfError;
 
 pub(crate) fn node_name(node: &Node) -> Name {
     let name = node
@@ -29,8 +26,8 @@ pub(crate) fn node_name(node: &Node) -> Name {
 /// on [`Node::transform()`](gltf::Node::transform) directly because it uses optimized glam types and
 /// if `libm` feature of `bevy_math` crate is enabled also handles cross
 /// platform determinism properly.
-pub(crate) fn node_transform(node: &Node, convert_coordinates: bool) -> Transform {
-    let transform = match node.transform() {
+pub(crate) fn node_transform(node: &Node) -> Transform {
+    match node.transform() {
         gltf::scene::Transform::Matrix { matrix } => {
             Transform::from_matrix(Mat4::from_cols_array_2d(&matrix))
         }
@@ -43,15 +40,6 @@ pub(crate) fn node_transform(node: &Node, convert_coordinates: bool) -> Transfor
             rotation: bevy_math::Quat::from_array(rotation),
             scale: Vec3::from(scale),
         },
-    };
-    if convert_coordinates {
-        if node.camera().is_some() || node.light().is_some() {
-            transform.convert_camera_coordinates()
-        } else {
-            transform.convert_coordinates()
-        }
-    } else {
-        transform
     }
 }
 

--- a/crates/bevy_gltf/src/loader/mod.rs
+++ b/crates/bevy_gltf/src/loader/mod.rs
@@ -26,7 +26,7 @@ use bevy_image::{
     CompressedImageFormats, Image, ImageLoaderSettings, ImageSampler, ImageSamplerDescriptor,
     ImageType, TextureError,
 };
-use bevy_math::{Mat4, Vec3};
+use bevy_math::{Mat4, Quat, Vec3};
 use bevy_mesh::{
     morph::{MeshMorphWeights, MorphAttributes, MorphTargetImage, MorphWeights},
     skinning::{SkinnedMesh, SkinnedMeshInverseBindposes},
@@ -931,8 +931,15 @@ impl GltfLoader {
             let mut entity_to_skin_index_map = EntityHashMap::default();
             let mut scene_load_context = load_context.begin_labeled_asset();
 
+            let world_root_rotation = if convert_coordinates.scene {
+                Quat::from_xyzw(0.0, 1.0, 0.0, 0.0)
+            } else {
+                Quat::IDENTITY
+            };
+            let world_root_transform = Transform::from_rotation(world_root_rotation);
+
             let world_root_id = world
-                .spawn((Transform::default(), Visibility::default()))
+                .spawn((world_root_transform, Visibility::default()))
                 .with_children(|parent| {
                     for node in scene.nodes() {
                         let result = load_node(

--- a/crates/bevy_gltf/src/loader/mod.rs
+++ b/crates/bevy_gltf/src/loader/mod.rs
@@ -323,16 +323,7 @@ impl GltfLoader {
                         match outputs {
                             ReadOutputs::Translations(tr) => {
                                 let translation_property = animated_field!(Transform::translation);
-                                let translations: Vec<Vec3> = tr
-                                    .map(Vec3::from)
-                                    .map(|verts| {
-                                        if convert_coordinates.nodes {
-                                            Vec3::convert_coordinates(verts)
-                                        } else {
-                                            verts
-                                        }
-                                    })
-                                    .collect();
+                                let translations: Vec<Vec3> = tr.map(Vec3::from).collect();
                                 if keyframe_timestamps.len() == 1 {
                                     Some(VariableCurve::new(AnimatableCurve::new(
                                         translation_property,
@@ -388,17 +379,8 @@ impl GltfLoader {
                             }
                             ReadOutputs::Rotations(rots) => {
                                 let rotation_property = animated_field!(Transform::rotation);
-                                let rotations: Vec<Quat> = rots
-                                    .into_f32()
-                                    .map(Quat::from_array)
-                                    .map(|quat| {
-                                        if convert_coordinates.nodes {
-                                            Quat::convert_coordinates(quat)
-                                        } else {
-                                            quat
-                                        }
-                                    })
-                                    .collect();
+                                let rotations: Vec<Quat> =
+                                    rots.into_f32().map(Quat::from_array).collect();
                                 if keyframe_timestamps.len() == 1 {
                                     Some(VariableCurve::new(AnimatableCurve::new(
                                         rotation_property,
@@ -916,7 +898,7 @@ impl GltfLoader {
                 &node,
                 children,
                 mesh,
-                node_transform(&node, convert_coordinates.nodes),
+                node_transform(&node),
                 skin,
                 node.extras().as_deref().map(GltfExtras::from),
             );
@@ -968,7 +950,6 @@ impl GltfLoader {
                             #[cfg(feature = "bevy_animation")]
                             None,
                             &gltf.document,
-                            convert_coordinates,
                         );
                         if result.is_err() {
                             err = Some(result);
@@ -1410,10 +1391,9 @@ fn load_node(
     #[cfg(feature = "bevy_animation")] animation_roots: &HashSet<usize>,
     #[cfg(feature = "bevy_animation")] mut animation_context: Option<AnimationContext>,
     document: &Document,
-    convert_coordinates: GltfConvertCoordinates,
 ) -> Result<(), GltfError> {
     let mut gltf_error = None;
-    let transform = node_transform(gltf_node, convert_coordinates.nodes);
+    let transform = node_transform(gltf_node);
     let world_transform = *parent_transform * transform;
     // according to https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#instantiation,
     // if the determinant of the transform is negative we must invert the winding order of
@@ -1682,7 +1662,6 @@ fn load_node(
                 #[cfg(feature = "bevy_animation")]
                 animation_context.clone(),
                 document,
-                convert_coordinates,
             ) {
                 gltf_error = Some(err);
                 return;

--- a/crates/bevy_gltf/src/loader/mod.rs
+++ b/crates/bevy_gltf/src/loader/mod.rs
@@ -2,7 +2,6 @@ mod extensions;
 mod gltf_ext;
 
 use alloc::sync::Arc;
-use bevy_log::warn_once;
 use std::{
     io::Error,
     path::{Path, PathBuf},
@@ -278,18 +277,7 @@ impl GltfLoader {
 
         let convert_coordinates = match settings.convert_coordinates {
             Some(convert_coordinates) => convert_coordinates,
-            None => {
-                let convert_by_default = loader.default_convert_coordinates;
-                if !convert_by_default && !cfg!(feature = "gltf_convert_coordinates_default") {
-                    warn_once!(
-                    "Starting from Bevy 0.18, by default all imported glTF models will be rotated by 180 degrees around the Y axis to align with Bevy's coordinate system. \
-                    You are currently importing glTF files using the old behavior. Consider opting-in to the new import behavior by enabling the `gltf_convert_coordinates_default` feature. \
-                    If you encounter any issues please file a bug! \
-                    If you want to continue using the old behavior going forward (even when the default changes in 0.18), manually set the corresponding option in the `GltfPlugin` or `GltfLoaderSettings`. See the migration guide for more details."
-                );
-                }
-                convert_by_default
-            }
+            None => loader.default_convert_coordinates,
         };
 
         #[cfg(feature = "bevy_animation")]

--- a/crates/bevy_gltf/src/loader/mod.rs
+++ b/crates/bevy_gltf/src/loader/mod.rs
@@ -152,6 +152,8 @@ pub struct GltfLoader {
     pub custom_vertex_attributes: HashMap<Box<str>, MeshVertexAttribute>,
     /// Arc to default [`ImageSamplerDescriptor`].
     pub default_sampler: Arc<Mutex<ImageSamplerDescriptor>>,
+    /// XXX TODO: Update documentation.
+    ///
     /// Whether to convert glTF coordinates to Bevy's coordinate system by default.
     /// If set to `true`, the loader will convert the coordinate system of loaded glTF assets to Bevy's coordinate system
     /// such that objects looking forward in glTF will also look forward in Bevy.
@@ -932,6 +934,7 @@ impl GltfLoader {
             let mut entity_to_skin_index_map = EntityHashMap::default();
             let mut scene_load_context = load_context.begin_labeled_asset();
 
+            // XXX TODO: Move to utility function.
             let world_root_rotation = if convert_coordinates.scene {
                 Quat::from_xyzw(0.0, 1.0, 0.0, 0.0)
             } else {
@@ -1518,6 +1521,7 @@ fn load_node(
                     };
                     let bounds = primitive.bounding_box();
 
+                    // XXX TODO: Move to utility function.
                     let mesh_entity_transform = if convert_coordinates.meshes {
                         Transform::from_rotation(Quat::from_xyzw(0.0, 1.0, 0.0, 0.0))
                     } else {

--- a/crates/bevy_gltf/src/loader/mod.rs
+++ b/crates/bevy_gltf/src/loader/mod.rs
@@ -65,8 +65,9 @@ use thiserror::Error;
 use tracing::{error, info_span, warn};
 
 use crate::{
-    vertex_attributes::convert_attribute, Gltf, GltfAssetLabel, GltfExtras, GltfMaterialExtras,
-    GltfMaterialName, GltfMeshExtras, GltfMeshName, GltfNode, GltfSceneExtras, GltfSkin,
+    convert_coordinates::ConvertInverseCoordinates as _, vertex_attributes::convert_attribute,
+    Gltf, GltfAssetLabel, GltfExtras, GltfMaterialExtras, GltfMaterialName, GltfMeshExtras,
+    GltfMeshName, GltfNode, GltfSceneExtras, GltfSkin,
 };
 
 #[cfg(feature = "bevy_animation")]
@@ -84,7 +85,7 @@ use self::{
         texture::{texture_handle, texture_sampler, texture_transform_to_affine2},
     },
 };
-use crate::convert_coordinates::{ConvertCoordinates as _, GltfConvertCoordinates};
+use crate::convert_coordinates::GltfConvertCoordinates;
 
 /// An error that occurs when loading a glTF file.
 #[derive(Error, Debug)]
@@ -810,7 +811,7 @@ impl GltfLoader {
                         mats.map(|mat| Mat4::from_cols_array_2d(&mat))
                             .map(|mat| {
                                 if convert_coordinates.meshes {
-                                    mat.convert_coordinates()
+                                    mat.convert_inverse_coordinates()
                                 } else {
                                     mat
                                 }

--- a/crates/bevy_gltf/src/loader/mod.rs
+++ b/crates/bevy_gltf/src/loader/mod.rs
@@ -209,6 +209,8 @@ pub struct GltfLoaderSettings {
     pub default_sampler: Option<ImageSamplerDescriptor>,
     /// If true, the loader will ignore sampler data from gltf and use the default sampler.
     pub override_sampler: bool,
+    /// XXX TODO: Update documentation.
+    ///
     /// Overrides the default glTF coordinate conversion setting.
     ///
     /// If set to `Some(true)`, the loader will convert the coordinate system of loaded glTF assets to Bevy's coordinate system

--- a/crates/bevy_gltf/src/loader/mod.rs
+++ b/crates/bevy_gltf/src/loader/mod.rs
@@ -26,7 +26,7 @@ use bevy_image::{
     CompressedImageFormats, Image, ImageLoaderSettings, ImageSampler, ImageSamplerDescriptor,
     ImageType, TextureError,
 };
-use bevy_math::{Mat4, Quat, Vec3};
+use bevy_math::{Mat4, Vec3};
 use bevy_mesh::{
     morph::{MeshMorphWeights, MorphAttributes, MorphTargetImage, MorphWeights},
     skinning::{SkinnedMesh, SkinnedMeshInverseBindposes},
@@ -934,13 +934,8 @@ impl GltfLoader {
             let mut entity_to_skin_index_map = EntityHashMap::default();
             let mut scene_load_context = load_context.begin_labeled_asset();
 
-            // XXX TODO: Move to utility function.
-            let world_root_rotation = if convert_coordinates.scene {
-                Quat::from_xyzw(0.0, 1.0, 0.0, 0.0)
-            } else {
-                Quat::IDENTITY
-            };
-            let world_root_transform = Transform::from_rotation(world_root_rotation);
+            // XXX TODO: Document.
+            let world_root_transform = convert_coordinates.scene_conversion_transform();
 
             let world_root_id = world
                 .spawn((world_root_transform, Visibility::default()))
@@ -1521,12 +1516,8 @@ fn load_node(
                     };
                     let bounds = primitive.bounding_box();
 
-                    // XXX TODO: Move to utility function.
-                    let mesh_entity_transform = if convert_coordinates.meshes {
-                        Transform::from_rotation(Quat::from_xyzw(0.0, 1.0, 0.0, 0.0))
-                    } else {
-                        Transform::IDENTITY
-                    };
+                    // XXX TODO: Document.
+                    let mesh_entity_transform = convert_coordinates.mesh_conversion_transform();
 
                     let mut mesh_entity = parent.spawn((
                         // TODO: handle missing label handle errors here?

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -377,10 +377,6 @@ web = [
 
 hotpatching = ["bevy_app/hotpatching", "bevy_ecs/hotpatching"]
 
-gltf_convert_coordinates_default = [
-  "bevy_gltf?/gltf_convert_coordinates_default",
-]
-
 debug = ["bevy_utils/debug"]
 
 [dependencies]

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -92,7 +92,6 @@ The default feature set enables most of the expected features of a game engine, 
 |ghost_nodes|Experimental support for nodes that are ignored for UI layouting|
 |gif|GIF image format support|
 |glam_assert|Enable assertions to check the validity of parameters passed to glam|
-|gltf_convert_coordinates_default|Enable converting glTF coordinates to Bevy's coordinate system by default. This will be Bevy's default behavior starting in 0.18.|
 |hotpatching|Enable hotpatching of Bevy systems|
 |ico|ICO image format support|
 |jpeg|JPEG image format support|


### PR DESCRIPTION
## Objective

Try a different approach to glTF coordinate conversion. The goal is to satisfy some common use cases now while punting on the more complex and controversial parts. This is an alternative fix for https://github.com/bevyengine/bevy/issues/5670. 

#### Why A Draft?

The PR is currently a first pass intended for design discussion. It's functional, but needs more testing, clean-up, documentation, and release notes.

## Summary

The Bevy glTF loader can convert nodes and meshes from glTF's "+Z forward" to Bevy's "-Z forward". But there's been debate on whether its approach will work for all users (#19686, #20131).

This PR takes a different approach - it drops the node conversion in favour of a whole scene corrective. I think it satisfies several important use cases while keeping the behaviour simple and reliable. But it doesn't cover every case, and could be a regression for some users. (Note that the current conversion was added during 0.17, so from a 0.16 user's perspective there's no regression or changes in behaviour.)

## Background

There's been confusion over how glTF behaves and what users might want from coordinate conversion. This section recaps the basic concepts, glTF's semantics, the current loader behaviour, and some potential user stories.

### Coordinate Systems and Semantics

3D coordinate systems can have semantics assigned to their axes. These semantics are often defined as a forward axis, an up axis, and a [handedness](https://en.wikipedia.org/wiki/Right-hand_rule) - the side axis is implicit in the other choices.

Bevy's standard semantics are "-Z = forward, +Y = up, right handed". The standard is codified by the `forward` and `up` methods of `Transform` and `GlobalTransform`, and by the renderer's interpretation of camera and light transforms. There are debates about the standard and whether users should be able to choose different semantics. This PR does not account for those debates, and assumes that users want to follow the current standard.

Other engines, DCCs and file formats use different semantics. Unlike Bevy, some vary their semantics by object type (e.g. a camera's forward axis may not be the same as a light's). Some only specify an up axis, leaving the forward and side axes unspecified.

Assets might not follow the standard semantics of their file format. Static mesh hierarchies and skeletal animation rigs may even have per-node or per-joint semantics - a character rig could be +Y forward in the scene, while the head joint is +Z forward. One character rig might have both feet +X forward, while another rig might have the left foot +X forward and the right foot -X forward. This creates complexity, but also creates jobs, so no-one can say if it's good or bad.

Users may want asset loaders that convert assets to Bevy's standard semantics. This is not the only option though. The user could edit the assets themselves or run a conversion script in DCC, but that's a pain - particularly for users who rely on asset packs and don't have DCC experience. Another option is to implement an asset transform that does coordinate conversion, but having the options right there in the loader is convenient.

The conversion options of a loader can be contentious - users have different needs, and assets may have ambiguities than can only be resolved by the user. There will never be a simple "it just works" option, although there could be a least worst default that satisfies the biggest group of users.

### Loaders And User Stories

Bevy currently has a glTF loader, and I'm assuming it will get in-repo FBX and USD loaders at some point. These loaders are likely to follow a common pattern:

- The files contain meshes, which correspond to Bevy `Mesh` assets and skinned meshes.
    - Bevy meshes can only have a single material, so what the file format considers a single mesh might be multiple Bevy meshes.
- The files have a node hierarchy, where nodes roughly correspond to Bevy entities with a `Transform`.
    - Nodes can optionally be mesh instances, cameras, lights or skinned mesh joints.
- The loader outputs the assets and a `Scene` with an entity hierarchy that tries to match the file's node hierarchy.
    - Some aspects of nodes (e.g. pivot transforms) can't be represented in Bevy within a single entity.
    - So a 1:1 mapping might not be possible - instead nodes become multiple entities, or some data is lost (e.g. baking down pivot transforms).
- Users can choose to spawn the scene, or they can ignore it and use the assets directly.

For coordinate conversion in the loader, some user stories might be:

- "I want to spawn a scene on an entity with Bevy semantics and have it look right."
    - This is probably the most common case - the user wants to do `SceneRoot(load("my.gltf"))` and have it visually match the entity's `Transform::forward()`, and cameras and lights should do the right thing.
    - The user might not care about the semantics of mesh assets and nodes in the scene - they just want the scene as a whole to look right.
- "I want to spawn a scene, and convert some or all of the nodes to Bevy semantics."
    - The user might have nodes in their scene that they want to animate manually or hook up to other systems that assume Bevy semantics.
    - That becomes easier if the loader can convert the node's forward to match `Transform::forward()`.
    - Conversely, some users may want nodes to stay as they are (particularly skeletal animation rigs).
- "I want to instance a mesh on an entity with Bevy semantics. I'm not using a scene."
    - Maybe the user is doing `Mesh(load("mesh.gltf#Mesh0"))` and wants it to match the entity's forward.
    - Or it's the first stage of an asset pipeline and the remaining stages expect Bevy semantics.
- "I don't want the loader to touch anything."
    - Maybe they've already converted the file, or want to convert it post-load, or don't want to use Bevy semantics at all.
- "I want one of the other conversion stories, but the loader should convert to my chosen semantics rather than Bevy's".
    - Z-up is not a crime.

### glTF Semantics

glTF [scene semantics](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#coordinate-system-and-units) are "+Z = forward, +Y = up, right handed". This is almost the same as Bevy, except that scene forward is +Z instead of Bevy's -Z.

Some glTF assets do not follow the spec's scene semantics. The Kenney asset packs use a mix of +Z and -Z forward. At least [one of the Khronos sample assets](https://github.com/KhronosGroup/glTF-Sample-Assets/tree/main/Models/Duck) uses +X forward. That said, the majority of Kenney assets and almost all Khronos sample assets that I tested do follow the spec.

glTF [camera node](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#view-matrix) and [light node](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_lights_punctual/README.md#adding-light-instances-to-nodes) semantics are different from glTF scene semantics - they're -Z forward, same as Bevy.

The glTF spec doesn't explicitly say if non-camera/light nodes and mesh buffers have semantics. I'm guessing that some users will have nodes and meshes that follow the spec's scene semantics, and might want them converted to Bevy semantics. But as noted in the user stories, it's likely that other users will have different needs.

glTF and Bevy allow a single node/entity to be both a mesh and a camera or a light. This only makes sense if the user intends the mesh to have the same semantics as cameras and lights. I think it's very unlikely that significant numbers of users will want support for this combination - many other DCCs, file formats and engines don't support it at all.

### How The Bevy glTF Loader Works

The loader maps glTF nodes to Bevy entities. It also adds entities for two cases:

1. A single "scene root" entity is added as a parent of the glTF root nodes.
    - Note that this is not the user's entity with the `SceneRoot` component - the scene root entity is a child of that entity.
2. Mesh primitive entities are added as a child of each glTF mesh node.
    - In glTF, a single mesh node can contain multiple primitives.
    - But in Bevy a mesh component can only contain a single primitive, so one entity can't contain multiple primitives.
    - So, for each primitive, Bevy adds a child entity with a mesh component.

A single branch of the resulting scene hierarchy might look like this:

- User entity with `SceneRoot` component.
    - Scene root entity.
        - glTF root node entity.
            - glTF intermediate node entities.
                - glTF mesh node entity (does not contain `Mesh3d` component)
                    - Mesh primitive entities (does contain `Mesh3d` component).

### glTF Loader Changes In 0.17

In Bevy 0.16, the only user story supported by the glTF loader was "no conversion". During the 0.17 cycle, #19633 and some follow up PRs have implemented an option that converts the mesh buffers, nodes, and node animation tracks.

The changes do satisfy some user stories, including the common "convert scene semantics" (mostly) and "convert mesh semantics". But there's some problems:

- The conversion depends on converting both nodes and meshes.
    - Some users might want to convert the scene without converting nodes and/or meshes.
- Light and camera nodes get complicated.
    - glTF camera/light nodes already match Bevy semantics, so they need a counter-conversion (since their parent might have been converted).
    - Animation tracks for lights and cameras are not correctly converted.
        - (Counterpoint: This is fixable at the cost of some complexity)
    - Child nodes of lights and cameras are not correctly converted.
        - (Counterpoint: Also fixable, and probably a niche case?)
    - The conversion can't support a node that's a mesh instance and also a light and/or a camera.
        - (Counterpoint: As mentioned earlier, this is probably a very niche or non-existent use case.)

There was hope that the conversion option could be enabled by default in 0.18 (https://github.com/bevyengine/bevy/issues/19686). But this now looks uncertain (https://github.com/bevyengine/bevy/pull/20131).

## This PR

The big change in this PR is the removal of node conversion. Instead, the scene root entity and mesh primitive entities that Bevy adds are given corrective transforms.

So taking our example branch from the glTF explanation, the pre-PR behaviour is:

- Scene root entity. 
    - glTF root node entity. <-- CONVERTED
        - glTF intermediate node entities. <-- CONVERTED
            - glTF mesh node entity. <-- CONVERTED
                - Mesh primitive entities.

After this PR:

- Scene root entity. <-- CORRECTIVE
    - glTF root node entity. 
        - glTF intermediate node entities. 
            - glTF mesh node entity.
                - Mesh primitive entities. <-- CORRECTIVE

Mesh buffers and skinned mesh bind poses are still converted largely as before.

- Pros:
    - Simpler - there's no need to convert animations, and no need to special case cameras and lights.
    - The common user stories of "convert scene semantics" and "convert mesh assets" are still satisfied.
    - Adds support for the "don't convert nodes" story.
- Cons:
    - Regresses the "*do* convert nodes" story.

The scene and mesh conversions are exposed as separate options - I expect some users might want one without the other. They're both disabled by default.

```rust
pub struct GltfConvertCoordinates {
    pub scene: bool,
    pub meshes: bool,
}
```

The PR also removes the `gltf_convert_coordinates_default` feature and 0.18 warning message, as there's still debate on what these should do. This aligns with https://github.com/bevyengine/bevy/pull/20131, and it's fine if that PR lands first.

### Testing

I've tested various examples and glTFs with each combination of options.

```
cargo run --example animated_mesh
cargo run --example scene_viewer "assets/models/faces/faces.glb"
```

More testing is needed. In particular I want to test the Trenchbroom cases that motivated the original work.

I would have liked to add an example that spawns a separate scene for each combination of options and supports CI screenshot testing. But this is difficult due to #11111.

### What Happens After This PR?

Adding support for node conversion is the obvious next step. But getting it right will be complicated. I don't have any plans to try it.

I would like to add support for arbitrary semantic conversion. It's not that difficult to implement for glTF, and the code will be useful for other file loaders importers and asset transformers.

```rust
struct CoordinateSystem {
    forward: SignedAxis,
    up: SignedAxis,
    right: SignedAxis,
}

impl CoordinateSystem {
    const BEVY: Self = Self::forward_up(SignedAxis::NEGATIVE_Z, SignedAxis::POSITIVE_Y);
    const GLTF_SCENE: Self = Self::forward_up(SignedAxis::POSITIVE_Z, SignedAxis::POSITIVE_Y);
}

pub struct CoordinateConversion {
    pub from: CoordinateSystem,
    pub to: CoordinateSystem,
}

impl CoordinateConversion {
    const GLTF_SCENE_TO_BEVY: Self = Self::from_to(CoordinateSystem::GLTF_SCENE, CoordinateSystem::BEVY);
}
```

### What About The Forward Flag Proposal?

There's a [proposal](https://github.com/bevyengine/bevy/pull/20135) to allow per-transform semantics, aka the "forward flag". This means the axis of `Transform::forward()` and others would depend on a variable in the `Transform`. In theory the forward flag avoids the need for coordinate conversion in the loader, although how it works in practice is still to be worked out.

Even if the forward flag is implemented, I think this PR is worthwhile.

1. Implementing the forward flag would still need changes to the loader. The options and logic will be similar to what's needed for coordinate conversion, so this PR at least lays some groundwork.
2. Users may still want some form of coordinate conversion. They might be working with raw `Mesh` assets and want them converted, or they might prefer to avoid the forward flag for other reasons. So supporting both could be useful, although it would be the most complex choice.
