### PR TITLE
Added optional serde derives for rendering types.

### DIFF
--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -108,6 +108,8 @@ serialize = [
   "bevy_ui?/serialize",
   "bevy_window?/serialize",
   "bevy_winit?/serialize",
+  "bevy_sprite?/serialize",
+  "bevy_pbr?/serialize",
   "bevy_platform/serialize",
   "bevy_render/serialize",
 ]

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -31,6 +31,7 @@ meshlet_processor = [
   "dep:itertools",
   "dep:bitvec",
 ]
+serialize = ["dep:serde"]
 
 [dependencies]
 # bevy
@@ -77,6 +78,11 @@ nonmax = "0.5"
 static_assertions = "1"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 offset-allocator = "0.2"
+
+serde = { version = "1", default-features = false, features = [
+  "alloc",
+  "serde_derive",
+], optional = true }
 
 [lints]
 workspace = true

--- a/crates/bevy_pbr/src/decal/forward.rs
+++ b/crates/bevy_pbr/src/decal/forward.rs
@@ -85,7 +85,10 @@ pub type ForwardDecalMaterial<B: Material> = ExtendedMaterial<B, ForwardDecalMat
 /// the forward decal code behind an ifdef.
 #[derive(Asset, AsBindGroup, TypePath, Clone, Debug)]
 #[uniform(200, ForwardDecalMaterialExtUniform)]
-#[cfg_attr(feature = "serialize", derive(::serde::Serialize, ::serde::Deserialize))]
+#[cfg_attr(
+    feature = "serialize",
+    derive(::serde::Serialize, ::serde::Deserialize)
+)]
 pub struct ForwardDecalMaterialExt {
     /// Controls the distance threshold for decal blending with surfaces.
     ///

--- a/crates/bevy_pbr/src/decal/forward.rs
+++ b/crates/bevy_pbr/src/decal/forward.rs
@@ -85,6 +85,7 @@ pub type ForwardDecalMaterial<B: Material> = ExtendedMaterial<B, ForwardDecalMat
 /// the forward decal code behind an ifdef.
 #[derive(Asset, AsBindGroup, TypePath, Clone, Debug)]
 #[uniform(200, ForwardDecalMaterialExtUniform)]
+#[cfg_attr(feature = "serialize", derive(::serde::Serialize, ::serde::Deserialize))]
 pub struct ForwardDecalMaterialExt {
     /// Controls the distance threshold for decal blending with surfaces.
     ///

--- a/crates/bevy_pbr/src/extended_material.rs
+++ b/crates/bevy_pbr/src/extended_material.rs
@@ -128,6 +128,7 @@ pub trait MaterialExtension: Asset + AsBindGroup + Clone + Sized {
 #[derive(Asset, Clone, Debug, Reflect)]
 #[reflect(type_path = false)]
 #[reflect(Clone)]
+#[cfg_attr(feature = "serialize", derive(::serde::Serialize, ::serde::Deserialize))]
 pub struct ExtendedMaterial<B: Material, E: MaterialExtension> {
     pub base: B,
     pub extension: E,

--- a/crates/bevy_pbr/src/extended_material.rs
+++ b/crates/bevy_pbr/src/extended_material.rs
@@ -128,7 +128,10 @@ pub trait MaterialExtension: Asset + AsBindGroup + Clone + Sized {
 #[derive(Asset, Clone, Debug, Reflect)]
 #[reflect(type_path = false)]
 #[reflect(Clone)]
-#[cfg_attr(feature = "serialize", derive(::serde::Serialize, ::serde::Deserialize))]
+#[cfg_attr(
+    feature = "serialize",
+    derive(::serde::Serialize, ::serde::Deserialize)
+)]
 pub struct ExtendedMaterial<B: Material, E: MaterialExtension> {
     pub base: B,
     pub extension: E,

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -1226,6 +1226,7 @@ impl DefaultOpaqueRendererMethod {
 /// If a material indicates `OpaqueRendererMethod::Auto`, `DefaultOpaqueRendererMethod` will be used.
 #[derive(Default, Clone, Copy, Debug, PartialEq, Reflect)]
 #[reflect(Default, Clone, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(::serde::Serialize, ::serde::Deserialize))]
 pub enum OpaqueRendererMethod {
     #[default]
     Forward,

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -1226,7 +1226,10 @@ impl DefaultOpaqueRendererMethod {
 /// If a material indicates `OpaqueRendererMethod::Auto`, `DefaultOpaqueRendererMethod` will be used.
 #[derive(Default, Clone, Copy, Debug, PartialEq, Reflect)]
 #[reflect(Default, Clone, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(::serde::Serialize, ::serde::Deserialize))]
+#[cfg_attr(
+    feature = "serialize",
+    derive(::serde::Serialize, ::serde::Deserialize)
+)]
 pub enum OpaqueRendererMethod {
     #[default]
     Forward,

--- a/crates/bevy_pbr/src/parallax.rs
+++ b/crates/bevy_pbr/src/parallax.rs
@@ -1,5 +1,7 @@
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 
+#[cfg(feature = "serialize")]
+use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 /// The [parallax mapping] method to use to compute depth based on the
 /// material's [`depth_map`].
 ///
@@ -17,6 +19,7 @@ use bevy_reflect::{std_traits::ReflectDefault, Reflect};
     feature = "serialize",
     derive(::serde::Serialize, ::serde::Deserialize)
 )]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 pub enum ParallaxMappingMethod {
     /// A simple linear interpolation, using a single texture sample.
     ///

--- a/crates/bevy_pbr/src/parallax.rs
+++ b/crates/bevy_pbr/src/parallax.rs
@@ -13,6 +13,7 @@ use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 /// [parallax mapping]: https://en.wikipedia.org/wiki/Parallax_mapping
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Default, Reflect)]
 #[reflect(Default, Clone, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(::serde::Serialize, ::serde::Deserialize))]
 pub enum ParallaxMappingMethod {
     /// A simple linear interpolation, using a single texture sample.
     ///

--- a/crates/bevy_pbr/src/parallax.rs
+++ b/crates/bevy_pbr/src/parallax.rs
@@ -13,7 +13,10 @@ use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 /// [parallax mapping]: https://en.wikipedia.org/wiki/Parallax_mapping
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Default, Reflect)]
 #[reflect(Default, Clone, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(::serde::Serialize, ::serde::Deserialize))]
+#[cfg_attr(
+    feature = "serialize",
+    derive(::serde::Serialize, ::serde::Deserialize)
+)]
 pub enum ParallaxMappingMethod {
     /// A simple linear interpolation, using a single texture sample.
     ///

--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -9,6 +9,8 @@ use bevy_render::{
 use bitflags::bitflags;
 
 use crate::{deferred::DEFAULT_PBR_DEFERRED_LIGHTING_PASS_ID, *};
+#[cfg(feature = "serialize")]
+use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 
 /// An enum to define which UV attribute to use for a texture.
 ///
@@ -22,6 +24,7 @@ use crate::{deferred::DEFAULT_PBR_DEFERRED_LIGHTING_PASS_ID, *};
     feature = "serialize",
     derive(::serde::Serialize, ::serde::Deserialize)
 )]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 pub enum UvChannel {
     #[default]
     Uv0,

--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -18,6 +18,7 @@ use crate::{deferred::DEFAULT_PBR_DEFERRED_LIGHTING_PASS_ID, *};
 /// The default is [`UvChannel::Uv0`].
 #[derive(Reflect, Default, Debug, Clone, PartialEq, Eq)]
 #[reflect(Default, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(::serde::Serialize, ::serde::Deserialize))]
 pub enum UvChannel {
     #[default]
     Uv0,

--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -18,7 +18,10 @@ use crate::{deferred::DEFAULT_PBR_DEFERRED_LIGHTING_PASS_ID, *};
 /// The default is [`UvChannel::Uv0`].
 #[derive(Reflect, Default, Debug, Clone, PartialEq, Eq)]
 #[reflect(Default, Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(::serde::Serialize, ::serde::Deserialize))]
+#[cfg_attr(
+    feature = "serialize",
+    derive(::serde::Serialize, ::serde::Deserialize)
+)]
 pub enum UvChannel {
     #[default]
     Uv0,

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -50,7 +50,7 @@ webgl = ["wgpu/webgl"]
 webgpu = ["wgpu/webgpu"]
 detailed_trace = []
 ## Adds serialization support through `serde`.
-serialize = ["bevy_mesh/serialize"]
+serialize = ["dep:serde", "bevy_mesh/serialize"]
 
 [dependencies]
 # bevy
@@ -121,6 +121,10 @@ tracy-client = { version = "0.18.0", optional = true }
 indexmap = { version = "2" }
 fixedbitset = { version = "0.5" }
 bitflags = "2"
+serde = { version = "1", default-features = false, features = [
+  "alloc",
+  "serde_derive",
+], optional = true }
 
 [target.'cfg(all(target_arch = "wasm32", target_feature = "atomics"))'.dependencies]
 send_wrapper = { version = "0.6.0" }

--- a/crates/bevy_render/src/alpha.rs
+++ b/crates/bevy_render/src/alpha.rs
@@ -4,7 +4,10 @@ use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 /// Sets how a material's base color alpha channel is used for transparency.
 #[derive(Debug, Default, Reflect, Copy, Clone, PartialEq)]
 #[reflect(Default, Debug, Clone)]
-#[cfg_attr(feature = "serialize", derive(::serde::Serialize, ::serde::Deserialize))]
+#[cfg_attr(
+    feature = "serialize",
+    derive(::serde::Serialize, ::serde::Deserialize)
+)]
 pub enum AlphaMode {
     /// Base color alpha values are overridden to be fully opaque (1.0).
     #[default]

--- a/crates/bevy_render/src/alpha.rs
+++ b/crates/bevy_render/src/alpha.rs
@@ -1,4 +1,6 @@
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
+#[cfg(feature = "serialize")]
+use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 
 // TODO: add discussion about performance.
 /// Sets how a material's base color alpha channel is used for transparency.
@@ -8,6 +10,7 @@ use bevy_reflect::{std_traits::ReflectDefault, Reflect};
     feature = "serialize",
     derive(::serde::Serialize, ::serde::Deserialize)
 )]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 pub enum AlphaMode {
     /// Base color alpha values are overridden to be fully opaque (1.0).
     #[default]

--- a/crates/bevy_render/src/alpha.rs
+++ b/crates/bevy_render/src/alpha.rs
@@ -4,6 +4,7 @@ use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 /// Sets how a material's base color alpha channel is used for transparency.
 #[derive(Debug, Default, Reflect, Copy, Clone, PartialEq)]
 #[reflect(Default, Debug, Clone)]
+#[cfg_attr(feature = "serialize", derive(::serde::Serialize, ::serde::Deserialize))]
 pub enum AlphaMode {
     /// Base color alpha values are overridden to be fully opaque (1.0).
     #[default]

--- a/crates/bevy_sprite/Cargo.toml
+++ b/crates/bevy_sprite/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["bevy"]
 bevy_sprite_picking_backend = ["bevy_picking", "bevy_window"]
 webgl = []
 webgpu = []
+serialize = ["dep:serde"]
 
 [dependencies]
 # bevy
@@ -41,6 +42,10 @@ bitflags = "2.3"
 radsort = "0.1"
 nonmax = "0.5"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
+serde = { version = "1", default-features = false, features = [
+  "alloc",
+  "serde_derive",
+], optional = true }
 
 [lints]
 workspace = true

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -235,7 +235,10 @@ impl<M: Material2d> AsAssetId for MeshMaterial2d<M> {
 /// We use a separate type because 2d doesn't support all the transparency modes that 3d does.
 #[derive(Debug, Default, Reflect, Copy, Clone, PartialEq)]
 #[reflect(Default, Debug, Clone)]
-#[cfg_attr(feature = "serialize", derive(::serde::Serialize, ::serde::Deserialize))]
+#[cfg_attr(
+    feature = "serialize",
+    derive(::serde::Serialize, ::serde::Deserialize)
+)]
 pub enum AlphaMode2d {
     /// Base color alpha values are overridden to be fully opaque (1.0).
     #[default]

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -22,6 +22,8 @@ use bevy_ecs::{
 use bevy_math::FloatOrd;
 use bevy_platform::collections::HashMap;
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
+#[cfg(feature = "serialize")]
+use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 use bevy_render::camera::extract_cameras;
 use bevy_render::render_phase::{DrawFunctionId, InputUniformIndex};
 use bevy_render::render_resource::CachedRenderPipelineId;
@@ -239,6 +241,7 @@ impl<M: Material2d> AsAssetId for MeshMaterial2d<M> {
     feature = "serialize",
     derive(::serde::Serialize, ::serde::Deserialize)
 )]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 pub enum AlphaMode2d {
     /// Base color alpha values are overridden to be fully opaque (1.0).
     #[default]

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -235,6 +235,7 @@ impl<M: Material2d> AsAssetId for MeshMaterial2d<M> {
 /// We use a separate type because 2d doesn't support all the transparency modes that 3d does.
 #[derive(Debug, Default, Reflect, Copy, Clone, PartialEq)]
 #[reflect(Default, Debug, Clone)]
+#[cfg_attr(feature = "serialize", derive(::serde::Serialize, ::serde::Deserialize))]
 pub enum AlphaMode2d {
     /// Base color alpha values are overridden to be fully opaque (1.0).
     #[default]

--- a/crates/bevy_sprite/src/sprite.rs
+++ b/crates/bevy_sprite/src/sprite.rs
@@ -1,3 +1,4 @@
+use crate::TextureSlicer;
 use bevy_asset::{Assets, Handle};
 use bevy_color::Color;
 use bevy_derive::{Deref, DerefMut};
@@ -5,13 +6,13 @@ use bevy_ecs::{component::Component, reflect::ReflectComponent};
 use bevy_image::{Image, TextureAtlas, TextureAtlasLayout};
 use bevy_math::{Rect, UVec2, Vec2};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
+#[cfg(feature = "serialize")]
+use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 use bevy_render::{
     sync_world::SyncToRenderWorld,
     view::{self, Visibility, VisibilityClass},
 };
 use bevy_transform::components::Transform;
-
-use crate::TextureSlicer;
 
 /// Describes a sprite to be rendered to a 2D camera
 #[derive(Component, Debug, Default, Clone, Reflect)]
@@ -162,6 +163,7 @@ impl From<Handle<Image>> for Sprite {
     feature = "serialize",
     derive(::serde::Serialize, ::serde::Deserialize)
 )]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 pub enum SpriteImageMode {
     /// The sprite will take on the size of the image by default, and will be stretched or shrunk if [`Sprite::custom_size`] is set.
     #[default]
@@ -214,6 +216,7 @@ impl SpriteImageMode {
     feature = "serialize",
     derive(::serde::Serialize, ::serde::Deserialize)
 )]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 pub enum ScalingMode {
     /// Scale the texture uniformly (maintain the texture's aspect ratio)
     /// so that both dimensions (width and height) of the texture will be equal

--- a/crates/bevy_sprite/src/sprite.rs
+++ b/crates/bevy_sprite/src/sprite.rs
@@ -158,6 +158,10 @@ impl From<Handle<Image>> for Sprite {
 /// Controls how the image is altered when scaled.
 #[derive(Default, Debug, Clone, Reflect, PartialEq)]
 #[reflect(Debug, Default, Clone)]
+#[cfg_attr(
+    feature = "serialize",
+    derive(::serde::Serialize, ::serde::Deserialize)
+)]
 pub enum SpriteImageMode {
     /// The sprite will take on the size of the image by default, and will be stretched or shrunk if [`Sprite::custom_size`] is set.
     #[default]
@@ -206,6 +210,10 @@ impl SpriteImageMode {
 /// Can be used in [`SpriteImageMode::Scale`].
 #[derive(Debug, Clone, Copy, PartialEq, Default, Reflect)]
 #[reflect(Debug, Default, Clone)]
+#[cfg_attr(
+    feature = "serialize",
+    derive(::serde::Serialize, ::serde::Deserialize)
+)]
 pub enum ScalingMode {
     /// Scale the texture uniformly (maintain the texture's aspect ratio)
     /// so that both dimensions (width and height) of the texture will be equal

--- a/crates/bevy_sprite/src/texture_slice/border_rect.rs
+++ b/crates/bevy_sprite/src/texture_slice/border_rect.rs
@@ -1,4 +1,6 @@
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
+#[cfg(feature = "serialize")]
+use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 
 /// Defines the extents of the border of a rectangle.
 ///
@@ -10,6 +12,7 @@ use bevy_reflect::{std_traits::ReflectDefault, Reflect};
     feature = "serialize",
     derive(::serde::Serialize, ::serde::Deserialize)
 )]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 pub struct BorderRect {
     /// Extent of the border along the left edge
     pub left: f32,

--- a/crates/bevy_sprite/src/texture_slice/border_rect.rs
+++ b/crates/bevy_sprite/src/texture_slice/border_rect.rs
@@ -6,6 +6,10 @@ use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 /// of a rectangle (left, right, top, and bottom), with values increasing inwards.
 #[derive(Default, Copy, Clone, PartialEq, Debug, Reflect)]
 #[reflect(Clone, PartialEq, Default)]
+#[cfg_attr(
+    feature = "serialize",
+    derive(::serde::Serialize, ::serde::Deserialize)
+)]
 pub struct BorderRect {
     /// Extent of the border along the left edge
     pub left: f32,

--- a/crates/bevy_sprite/src/texture_slice/slicer.rs
+++ b/crates/bevy_sprite/src/texture_slice/slicer.rs
@@ -1,7 +1,8 @@
 use super::{BorderRect, TextureSlice};
 use bevy_math::{vec2, Rect, Vec2};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
-
+#[cfg(feature = "serialize")]
+use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 /// Slices a texture using the **9-slicing** technique. This allows to reuse an image at various sizes
 /// without needing to prepare multiple assets. The associated texture will be split into nine portions,
 /// so that on resize the different portions scale or tile in different ways to keep the texture in proportion.
@@ -16,6 +17,7 @@ use bevy_reflect::{std_traits::ReflectDefault, Reflect};
     feature = "serialize",
     derive(::serde::Serialize, ::serde::Deserialize)
 )]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 pub struct TextureSlicer {
     /// Inset values in pixels that define the four slicing lines dividing the texture into nine sections.
     pub border: BorderRect,
@@ -34,6 +36,7 @@ pub struct TextureSlicer {
     feature = "serialize",
     derive(::serde::Serialize, ::serde::Deserialize)
 )]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 pub enum SliceScaleMode {
     /// The slice will be stretched to fit the area
     #[default]

--- a/crates/bevy_sprite/src/texture_slice/slicer.rs
+++ b/crates/bevy_sprite/src/texture_slice/slicer.rs
@@ -12,6 +12,10 @@ use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 /// See [9-sliced](https://en.wikipedia.org/wiki/9-slice_scaling) textures.
 #[derive(Debug, Clone, Reflect, PartialEq)]
 #[reflect(Clone, PartialEq)]
+#[cfg_attr(
+    feature = "serialize",
+    derive(::serde::Serialize, ::serde::Deserialize)
+)]
 pub struct TextureSlicer {
     /// Inset values in pixels that define the four slicing lines dividing the texture into nine sections.
     pub border: BorderRect,
@@ -26,6 +30,10 @@ pub struct TextureSlicer {
 /// Defines how a texture slice scales when resized
 #[derive(Debug, Copy, Clone, Default, Reflect, PartialEq)]
 #[reflect(Clone, PartialEq, Default)]
+#[cfg_attr(
+    feature = "serialize",
+    derive(::serde::Serialize, ::serde::Deserialize)
+)]
 pub enum SliceScaleMode {
     /// The slice will be stretched to fit the area
     #[default]


### PR DESCRIPTION
# Objective

Certain types in `bevy_render`, `bevy_pbr`, and `bevy_sprite` have trivial serde implementations but currently doesn't. Adding them can benefit developers of prefab crates.

## Solution

Added serde implementations for these types.

## Testing

Cargo build with the serialize feature.
