### PR TITLE
Deduplicate Default Font Data

### DIFF
--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -67,8 +67,6 @@ pub mod prelude {
 }
 
 use bevy_app::{prelude::*, AnimationSystems};
-#[cfg(feature = "default_font")]
-use bevy_asset::{load_internal_binary_asset, Handle};
 use bevy_asset::{AssetApp, AssetEventSystems};
 use bevy_ecs::prelude::*;
 use bevy_render::{
@@ -141,11 +139,11 @@ impl Plugin for TextPlugin {
         }
 
         #[cfg(feature = "default_font")]
-        load_internal_binary_asset!(
-            app,
-            Handle::default(),
-            "FiraMono-subset.ttf",
-            |bytes: &[u8], _path: String| { Font::try_from_bytes(bytes.to_vec()).unwrap() }
-        );
+        {
+            use bevy_asset::{AssetId, Assets};
+            let mut assets = app.world_mut().resource_mut::<Assets<_>>();
+            let asset = Font::try_from_bytes(DEFAULT_FONT_DATA.to_vec()).unwrap();
+            assets.insert(AssetId::default(), asset);
+        };
     }
 }


### PR DESCRIPTION
# Objective

The data for the default font is included twice with `include_bytes!`. This is not a big problem as the data gets deduplicated at some point during optimization, so this PR only saves 50 bytes~ instead of 20kb, but we're still wasting time during compilation copying this file around twice.

# Solution

Use the `DEFAULT_FONT_DATA` constant introduced in #14406 for setting the default font instead of including the bytes a second time via `load_internal_binary_asset`.