### PR TITLE
Fix full_ui example overflowing scroll position

### DIFF
--- a/examples/testbed/full_ui.rs
+++ b/examples/testbed/full_ui.rs
@@ -9,6 +9,7 @@ use bevy::{
         basic::LIME,
         css::{DARK_GRAY, NAVY},
     },
+    core_widgets::CoreScrollbar,
     input::mouse::{MouseScrollUnit, MouseWheel},
     picking::hover::HoverMap,
     prelude::*,
@@ -437,7 +438,7 @@ fn toggle_debug_overlay(
 pub fn update_scroll_position(
     mut mouse_wheel_events: EventReader<MouseWheel>,
     hover_map: Res<HoverMap>,
-    mut scrolled_node_query: Query<&mut ScrollPosition>,
+    mut scrolled_node_query: Query<(&mut ScrollPosition, &ComputedNode), Without<CoreScrollbar>>,
     keyboard_input: Res<ButtonInput<KeyCode>>,
 ) {
     for mouse_wheel_event in mouse_wheel_events.read() {
@@ -453,9 +454,17 @@ pub fn update_scroll_position(
 
         for (_pointer, pointer_map) in hover_map.iter() {
             for (entity, _hit) in pointer_map.iter() {
-                if let Ok(mut scroll_position) = scrolled_node_query.get_mut(*entity) {
+                if let Ok((mut scroll_position, scroll_content)) =
+                    scrolled_node_query.get_mut(*entity)
+                {
+                    let visible_size = scroll_content.size() * scroll_content.inverse_scale_factor;
+                    let content_size =
+                        scroll_content.content_size() * scroll_content.inverse_scale_factor;
+
+                    let range = (content_size.y - visible_size.y).max(0.);
+
                     scroll_position.x -= dx;
-                    scroll_position.y -= dy;
+                    scroll_position.y = (scroll_position.y - dy).clamp(0., range);
                 }
             }
         }

--- a/examples/testbed/full_ui.rs
+++ b/examples/testbed/full_ui.rs
@@ -457,11 +457,10 @@ pub fn update_scroll_position(
                 if let Ok((mut scroll_position, scroll_content)) =
                     scrolled_node_query.get_mut(*entity)
                 {
-                    let visible_size = scroll_content.size() * scroll_content.inverse_scale_factor;
-                    let content_size =
-                        scroll_content.content_size() * scroll_content.inverse_scale_factor;
-
-                    let range = (content_size.y - visible_size.y).max(0.);
+                    let visible_size = scroll_content.size();
+                    let content_size = scroll_content.content_size();
+                    
+                    let range = (content_size.y - visible_size.y).max(0.)  * scroll_content.inverse_scale_factor;
 
                     scroll_position.x -= dx;
                     scroll_position.y = (scroll_position.y - dy).clamp(0., range);

--- a/examples/testbed/full_ui.rs
+++ b/examples/testbed/full_ui.rs
@@ -459,8 +459,9 @@ pub fn update_scroll_position(
                 {
                     let visible_size = scroll_content.size();
                     let content_size = scroll_content.content_size();
-                    
-                    let range = (content_size.y - visible_size.y).max(0.)  * scroll_content.inverse_scale_factor;
+
+                    let range = (content_size.y - visible_size.y).max(0.)
+                        * scroll_content.inverse_scale_factor;
 
                     scroll_position.x -= dx;
                     scroll_position.y = (scroll_position.y - dy).clamp(0., range);


### PR DESCRIPTION
# Objective
The `testbed_full_ui` example has a system listening to `MouseWheel` events and is applying the deltas to the hovered scroll position nodes.

However, this implementation does not clamp the range of the scroll position to the content size (unlike `CoreScrollBar`). If you keep scrolling you will notice that it over-/underflows despite already having hit the "visible" end.

## Solution

Clamp `scroll_position.y` to the content size using the same logic as [here](https://github.com/bevyengine/bevy/blob/197cbcb68ae1ccc8aa4e33cc3ab80afd960cf8a2/crates/bevy_core_widgets/src/core_scrollbar.rs#L209-L212).

## Testing

`cargo run --example testbed_full_ui` 