### PR TITLE
Make WgpuWrapper public again

### DIFF
--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -123,7 +123,7 @@ use bitflags::bitflags;
 use core::ops::{Deref, DerefMut};
 use std::sync::Mutex;
 use tracing::debug;
-use wgpu_wrapper::WgpuWrapper;
+pub use wgpu_wrapper::WgpuWrapper;
 
 /// Inline shader as an `embedded_asset` and load it permanently.
 ///


### PR DESCRIPTION
# Objective

- WgpuWrapper was public in 0.16 and is is needed to be able to call RenderCreation::manual.

## Solution

- Make it public again after the revert #20220

## Testing

- cargo build
