### PR TITLE
`CubicSegment::iter_uniformly` should be public

### DIFF
--- a/crates/bevy_math/src/cubic_splines/mod.rs
+++ b/crates/bevy_math/src/cubic_splines/mod.rs
@@ -1036,7 +1036,7 @@ impl<P: VectorSpace<Scalar = f32>> CubicSegment<P> {
 
     /// An iterator that returns values of `t` uniformly spaced over `0..=subdivisions`.
     #[inline]
-    fn iter_uniformly(&self, subdivisions: usize) -> impl Iterator<Item = f32> {
+    pub fn iter_uniformly(&self, subdivisions: usize) -> impl Iterator<Item = f32> {
         let step = 1.0 / subdivisions as f32;
         (0..=subdivisions).map(move |i| i as f32 * step)
     }


### PR DESCRIPTION
# Objective
`CubicSegment::iter_uniformly` should be public, as there is no harm to it being public

## Solution
made `CubicSegment::iter_uniformly` public

## Testing


