### PR TITLE
use the wasm-release profile for smaller bins and longer builds

### DIFF
--- a/tools/build-wasm-example/src/main.rs
+++ b/tools/build-wasm-example/src/main.rs
@@ -80,14 +80,15 @@ fn main() {
 
         let profile = if cli.debug {
             "debug"
+        } else if cli.optimize_size {
+            "wasm-release"
         } else {
-            parameters.push("--release");
             "release"
         };
 
         let cmd = cmd!(
             sh,
-            "cargo build {parameters...} --target wasm32-unknown-unknown --example {example}"
+            "cargo build {parameters...} --profile {profile} --target wasm32-unknown-unknown --example {example}"
         );
         cmd.run().expect("Error building example");
 


### PR DESCRIPTION
# Objective

- `cargo run -p build-wasm-example -- --api webgl2 breakout --optimize-size` produces files that are too big for the website

## Solution

- Use the `wasm-release` profile which reduce the file size at the cost of compile time

https://github.com/bevyengine/bevy/blob/e11a9e1167764235819b1803f629b40f9ac5131c/Cargo.toml#L4380-L4384