### PR TITLE
Improve `WithRelated` ergonomics

### DIFF
--- a/crates/bevy_ecs/src/spawn.rs
+++ b/crates/bevy_ecs/src/spawn.rs
@@ -153,11 +153,18 @@ impl<R: Relationship, F: FnOnce(&mut RelatedSpawner<R>) + Send + Sync + 'static>
 ///     Children::spawn((
 ///         Spawn(Name::new("Child1")),
 ///         // This adds the already existing entities as children of Root.
-///         WithRelated([child2, child3].into_iter()),
+///         WithRelated::new([child2, child3]),
 ///     )),
 /// ));
 /// ```
 pub struct WithRelated<I>(pub I);
+
+impl<I> WithRelated<I> {
+    /// Creates a new [`WithRelated`] from a collection of entities.
+    pub fn new(iter: impl IntoIterator<IntoIter = I>) -> Self {
+        Self(iter.into_iter())
+    }
+}
 
 impl<R: Relationship, I: Iterator<Item = Entity>> SpawnableList<R> for WithRelated<I> {
     fn spawn(self, world: &mut World, entity: Entity) {
@@ -653,7 +660,7 @@ mod tests {
         let parent = world
             .spawn((
                 Name::new("Parent"),
-                Children::spawn(WithRelated([child1, child2].into_iter())),
+                Children::spawn(WithRelated::new([child1, child2])),
             ))
             .id();
 


### PR DESCRIPTION
# Objective

Recommending users to use `WithRelated([child2, child3].into_iter())` feels a bit weird.

## Solution

Add `WithRelated::new`, which uses `IntoIterator` to do the conversion more cleanly and succinctly. The old way is still left as an option for those wanting it.

## Testing

Updated the test to use the `new` function.