### PR TITLE
Implement field_at[_mut] for Struct DynamicVariant

### DIFF
--- a/crates/bevy_reflect/src/enums/dynamic_enum.rs
+++ b/crates/bevy_reflect/src/enums/dynamic_enum.rs
@@ -216,10 +216,10 @@ impl Enum for DynamicEnum {
     }
 
     fn field_at(&self, index: usize) -> Option<&dyn PartialReflect> {
-        if let DynamicVariant::Tuple(data) = &self.variant {
-            data.field(index)
-        } else {
-            None
+        match &self.variant {
+            DynamicVariant::Tuple(data) => data.field(index),
+            DynamicVariant::Struct(data) => data.field_at(index),
+            DynamicVariant::Unit => None,
         }
     }
 
@@ -232,10 +232,10 @@ impl Enum for DynamicEnum {
     }
 
     fn field_at_mut(&mut self, index: usize) -> Option<&mut dyn PartialReflect> {
-        if let DynamicVariant::Tuple(data) = &mut self.variant {
-            data.field_mut(index)
-        } else {
-            None
+        match &mut self.variant {
+            DynamicVariant::Tuple(data) => data.field_mut(index),
+            DynamicVariant::Struct(data) => data.field_at_mut(index),
+            DynamicVariant::Unit => None,
         }
     }
 


### PR DESCRIPTION
# Objective

This implements the field_at methods for Struct DynamicEnum Variants instead of only the Tuple variants. This brings it inline with DynamicStructs and the docs for the Enum trait.

Fixes #20402 

## Solution

Instead of only matching on the Tuple variant, it matches on the Struct variant as well

## Testing

Let me know if there's some place where unit tests should be added. I couldn't see any existing ones, but I can add them if needed.
