### PR TITLE
try to fix GitHub Actions permissions

### DIFF
--- a/.github/workflows/example-run-report.yml
+++ b/.github/workflows/example-run-report.yml
@@ -6,6 +6,7 @@ name: Example Run - PR Comments
 # Also requesting write permissions on PR to be able to comment
 permissions:
   pull-requests: "write"
+  contents: "read"
 
 on:
   workflow_run:


### PR DESCRIPTION
# Objective

- since #20416 GitHub Actions complains that:
```
Invalid workflow file
The workflow is not valid. .github/workflows/example-run-report.yml (Line: 71, Col: 3): Error calling workflow 'bevyengine/bevy/.github/workflows/send-screenshots-to-pixeleagle.yml@caafa03d21b722d79b9537b70e647fef32df37a5'. The workflow is requesting 'contents: read', but is only allowed 'contents: none'.
```

## Solution

- I couldn't find it in the documentation, but I suppose that permissions are inherited through workflow calls so I'm adding the permission to the parent workflow

🤞 