### PR TITLE
Use the hierachy plugin to propagate `ComputedNodeContext`

### DIFF
--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -70,7 +70,7 @@ pub mod prelude {
     };
 }
 
-use bevy_app::{prelude::*, AnimationSystems};
+use bevy_app::{prelude::*, AnimationSystems, HierarchyPropagatePlugin};
 use bevy_ecs::prelude::*;
 use bevy_input::InputSystems;
 use bevy_render::camera::CameraUpdateSystems;
@@ -182,6 +182,8 @@ impl Plugin for UiPlugin {
                 )
                     .chain(),
             )
+            .add_plugins(HierarchyPropagatePlugin::<ComputedNodeTarget>::default())
+            .add_systems(Update, update_ui_context_system)
             .add_systems(
                 PreUpdate,
                 ui_focus_system.in_set(UiSystems::Focus).after(InputSystems),
@@ -206,7 +208,6 @@ impl Plugin for UiPlugin {
         app.add_systems(
             PostUpdate,
             (
-                update_ui_context_system.in_set(UiSystems::Prepare),
                 ui_layout_system_config,
                 ui_stack_system
                     .in_set(UiSystems::Stack)

--- a/crates/bevy_ui/src/update.rs
+++ b/crates/bevy_ui/src/update.rs
@@ -142,9 +142,6 @@ pub fn update_ui_context_system(
     camera_query: Query<&Camera>,
     target_camera_query: Query<&UiTargetCamera>,
     ui_root_nodes: UiRootNodes,
-    // mut computed_target_query: Query<&mut ComputedNodeTarget>,
-    // ui_children: UiChildren,
-    // reparented_nodes: Query<(Entity, &ChildOf), (Changed<ChildOf>, With<ComputedNodeTarget>)>,
 ) {
     let default_camera_entity = default_ui_camera.get();
 
@@ -167,16 +164,6 @@ pub fn update_ui_context_system(
             })
             .unwrap_or((1., UVec2::ZERO));
 
-        // update_contexts_recursively(
-        //     root_entity,
-        //     ComputedNodeTarget {
-        //         camera,
-        //         scale_factor,
-        //         physical_size,
-        //     },
-        //     &ui_children,
-        //     &mut computed_target_query,
-        // );
         commands
             .entity(root_entity)
             .insert(Propagate(ComputedNodeTarget {
@@ -185,37 +172,7 @@ pub fn update_ui_context_system(
                 physical_size,
             }));
     }
-
-    // for (entity, child_of) in reparented_nodes.iter() {
-    //     let Ok(computed_target) = computed_target_query.get(child_of.parent()) else {
-    //         continue;
-    //     };
-
-    //     update_contexts_recursively(
-    //         entity,
-    //         *computed_target,
-    //         &ui_children,
-    //         &mut computed_target_query,
-    //     );
-    // }
 }
-
-// fn update_contexts_recursively(
-//     entity: Entity,
-//     inherited_computed_target: ComputedNodeTarget,
-//     ui_children: &UiChildren,
-//     query: &mut Query<&mut ComputedNodeTarget>,
-// ) {
-//     if query
-//         .get_mut(entity)
-//         .map(|mut computed_target| computed_target.set_if_neq(inherited_computed_target))
-//         .unwrap_or(false)
-//     {
-//         for child in ui_children.iter_ui_children(entity) {
-//             update_contexts_recursively(child, inherited_computed_target, ui_children, query);
-//         }
-//     }
-// }
 
 #[cfg(test)]
 mod tests {

--- a/crates/bevy_ui/src/update.rs
+++ b/crates/bevy_ui/src/update.rs
@@ -10,10 +10,8 @@ use crate::{
 use super::ComputedNode;
 use bevy_app::Propagate;
 use bevy_ecs::{
-    change_detection::DetectChangesMut,
     entity::Entity,
-    hierarchy::ChildOf,
-    query::{Changed, Has, With},
+    query::Has,
     system::{Commands, Query, Res},
 };
 use bevy_math::{Rect, UVec2};


### PR DESCRIPTION
# Objective
```
@Villor @ickshonpe I know you two have submitted some fixes for this already, but here is a smol repro on main for another issue.
Spawning an entity (without Node) as a child of a parent Node and then adding a Node component to that child a frame later causes the child not to appear (same for Text as in the given example).
Setting the system to run at the first frame (FrameCount(0)) makes it function as expected 
use bevy::{diagnostic::FrameCount, prelude::*};

fn main() {
    App::new()
    .add_plugins(DefaultPlugins)
    .add_systems(Startup, setup)
    .add_systems(Update, insert_text.run_if(resource_equals(FrameCount(1))))
    .run();
}

fn setup(mut commands: Commands) {
    commands.spawn((Node::default(), children![Text::new("Gamer"), Marker]));
    commands.spawn(Camera3d::default());
}

fn insert_text(entity: Single<Entity, With<Marker>>, mut commands: Commands) {
    commands.entity(*entity).insert(Text::new("remaG"));
}

#[derive(Component)]
struct Marker;
```

## Solution

Use the hierarchy plugin to propagate `ComputedNodeContext`.

The problem was that the `ComputedNodeContext` isn't updated immediately and so the text isn't rendered because the extraction function can't find a render target.

## Testing

Run the example above.

