### PR TITLE
Add winit phase to MouseWheel event, allowing users to detect if Mousewheel events are scroll wheel or touchpad origin

### DIFF
--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -1,6 +1,6 @@
 //! The mouse input functionality.
 
-use crate::{ButtonInput, ButtonState};
+use crate::{touch::TouchPhase, ButtonInput, ButtonState};
 use bevy_ecs::{
     change_detection::DetectChangesMut,
     entity::Entity,
@@ -160,6 +160,8 @@ pub struct MouseWheel {
     pub y: f32,
     /// Window that received the input.
     pub window: Entity,
+    /// Phase of the wheel event.
+    pub phase: TouchPhase,
 }
 
 /// Updates the [`ButtonInput<MouseButton>`] resource with the latest [`MouseButtonInput`] events.

--- a/crates/bevy_input/src/touch.rs
+++ b/crates/bevy_input/src/touch.rs
@@ -127,11 +127,14 @@ pub enum ForceTouch {
     reflect(Serialize, Deserialize)
 )]
 pub enum TouchPhase {
-    /// A finger started to touch the touchscreen.
+    /// A finger started to touch the touchscreen or a wheel scroll started.
     Started,
-    /// A finger moved over the touchscreen.
+    /// A finger moved over the touchscreen or touchpad scroll is in progress.
+    ///
+    /// This can be used to detect whether a scroll action is taking place on a
+    /// mouse wheel or touchpad, because mouse wheel scrolls do not emit this event.
     Moved,
-    /// A finger stopped touching the touchscreen.
+    /// A finger stopped touching the touchscreen or a wheel scroll finished.
     Ended,
     /// The system canceled the tracking of the finger.
     ///

--- a/crates/bevy_picking/src/events.rs
+++ b/crates/bevy_picking/src/events.rs
@@ -40,7 +40,7 @@
 use core::{fmt::Debug, time::Duration};
 
 use bevy_ecs::{prelude::*, query::QueryData, system::SystemParam, traversal::Traversal};
-use bevy_input::mouse::MouseScrollUnit;
+use bevy_input::{mouse::MouseScrollUnit, touch::TouchPhase};
 use bevy_math::Vec2;
 use bevy_platform::collections::HashMap;
 use bevy_platform::time::Instant;
@@ -334,6 +334,8 @@ pub struct Scroll {
     pub y: f32,
     /// Information about the picking intersection.
     pub hit: HitData,
+    /// `TouchPhase` of the scroll.
+    pub phase: TouchPhase,
 }
 
 /// An entry in the cache that drives the `pointer_events` system, storing additional data
@@ -776,7 +778,7 @@ pub fn pointer_events(
                     event_writers.move_events.write(move_event);
                 }
             }
-            PointerAction::Scroll { x, y, unit } => {
+            PointerAction::Scroll { x, y, unit, phase } => {
                 for (hovered_entity, hit) in hover_map
                     .get(&pointer_id)
                     .iter()
@@ -791,6 +793,7 @@ pub fn pointer_events(
                             x,
                             y,
                             hit: hit.clone(),
+                            phase,
                         },
                     );
                     commands.trigger_targets(scroll_event.clone(), hovered_entity);

--- a/crates/bevy_picking/src/input.rs
+++ b/crates/bevy_picking/src/input.rs
@@ -174,7 +174,13 @@ pub fn mouse_pick_events(
                 pointer_events.write(PointerInput::new(PointerId::Mouse, location, action));
             }
             WindowEvent::MouseWheel(event) => {
-                let MouseWheel { unit, x, y, window } = *event;
+                let MouseWheel {
+                    unit,
+                    x,
+                    y,
+                    window,
+                    phase,
+                } = *event;
 
                 let location = Location {
                     target: match RenderTarget::Window(WindowRef::Entity(window))
@@ -186,7 +192,7 @@ pub fn mouse_pick_events(
                     position: *cursor_last,
                 };
 
-                let action = PointerAction::Scroll { x, y, unit };
+                let action = PointerAction::Scroll { x, y, unit, phase };
 
                 pointer_events.write(PointerInput::new(PointerId::Mouse, location, action));
             }

--- a/crates/bevy_picking/src/pointer.rs
+++ b/crates/bevy_picking/src/pointer.rs
@@ -9,7 +9,7 @@
 //! driven by lower-level input devices and consumed by higher-level interaction systems.
 
 use bevy_ecs::prelude::*;
-use bevy_input::mouse::MouseScrollUnit;
+use bevy_input::{mouse::MouseScrollUnit, touch::TouchPhase};
 use bevy_math::Vec2;
 use bevy_platform::collections::HashMap;
 use bevy_reflect::prelude::*;
@@ -263,6 +263,8 @@ pub enum PointerAction {
         x: f32,
         /// The vertical scroll value.
         y: f32,
+        /// The phase of the scroll.
+        phase: TouchPhase,
     },
     /// Cancel the pointer. Often used for touch events.
     Cancel,

--- a/crates/bevy_winit/src/converters.rs
+++ b/crates/bevy_winit/src/converters.rs
@@ -45,18 +45,22 @@ pub fn convert_mouse_button(mouse_button: winit::event::MouseButton) -> MouseBut
     }
 }
 
+pub fn convert_touch_input_phase(phase: winit::event::TouchPhase) -> TouchPhase {
+    match phase {
+        winit::event::TouchPhase::Started => TouchPhase::Started,
+        winit::event::TouchPhase::Moved => TouchPhase::Moved,
+        winit::event::TouchPhase::Ended => TouchPhase::Ended,
+        winit::event::TouchPhase::Cancelled => TouchPhase::Canceled,
+    }
+}
+
 pub fn convert_touch_input(
     touch_input: winit::event::Touch,
     location: winit::dpi::LogicalPosition<f64>,
     window_entity: Entity,
 ) -> TouchInput {
     TouchInput {
-        phase: match touch_input.phase {
-            winit::event::TouchPhase::Started => TouchPhase::Started,
-            winit::event::TouchPhase::Moved => TouchPhase::Moved,
-            winit::event::TouchPhase::Ended => TouchPhase::Ended,
-            winit::event::TouchPhase::Cancelled => TouchPhase::Canceled,
-        },
+        phase: convert_touch_input_phase(touch_input.phase),
         position: Vec2::new(location.x as f32, location.y as f32),
         window: window_entity,
         force: touch_input.force.map(|f| match f {

--- a/crates/bevy_winit/src/state.rs
+++ b/crates/bevy_winit/src/state.rs
@@ -40,7 +40,8 @@ use bevy_window::{CursorOptions, PrimaryWindow, RawHandleWrapper};
 
 use crate::{
     accessibility::ACCESS_KIT_ADAPTERS,
-    converters, create_windows,
+    converters::{self, convert_touch_input_phase},
+    create_windows,
     system::{create_monitors, CachedWindow, WinitWindowPressedKeys},
     AppSendEvent, CreateMonitorParams, CreateWindowParams, EventLoopProxyWrapper,
     RawWinitWindowEvent, UpdateMode, WinitSettings, WINIT_WINDOWS,
@@ -320,13 +321,14 @@ impl<T: BufferedEvent> ApplicationHandler<T> for WinitAppRunnerState<T> {
                             y: delta.y,
                         }));
                     }
-                    WindowEvent::MouseWheel { delta, .. } => match delta {
+                    WindowEvent::MouseWheel { delta, phase, .. } => match delta {
                         event::MouseScrollDelta::LineDelta(x, y) => {
                             self.bevy_window_events.send(MouseWheel {
                                 unit: MouseScrollUnit::Line,
                                 x,
                                 y,
                                 window,
+                                phase: convert_touch_input_phase(phase),
                             });
                         }
                         event::MouseScrollDelta::PixelDelta(p) => {
@@ -335,6 +337,7 @@ impl<T: BufferedEvent> ApplicationHandler<T> for WinitAppRunnerState<T> {
                                 x: p.x as f32,
                                 y: p.y as f32,
                                 window,
+                                phase: convert_touch_input_phase(phase),
                             });
                         }
                     },


### PR DESCRIPTION
# Objective

Allow detecting whether MouseWheel events originate from a mouse scroll wheel or trackpad.

See https://github.com/johanhelsing/bevy_pancam/pull/81#issuecomment-3138826639 for use case. 

## Solution

Propagate the `TouchPhase` from `winit`, which allows distinguishing mouse wheel scroll from touchpad scroll: https://github.com/rust-windowing/winit/issues/4315#issuecomment-3149253226 

## Testing

I'm currently only able to test on a MacOS, it would be great if I could get help testing with a mouse and also a Windows & Linux trackpad.