### PR TITLE
Update toml_edit requirement from 0.22.7 to 0.23.2

### DIFF
--- a/crates/bevy_macro_utils/Cargo.toml
+++ b/crates/bevy_macro_utils/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["bevy"]
 syn = "2.0"
 quote = "1.0"
 proc-macro2 = "1.0"
-toml_edit = { version = "0.22.7", default-features = false, features = [
+toml_edit = { version = "0.23.2", default-features = false, features = [
   "parse",
 ] }
 parking_lot = { version = "0.12" }

--- a/crates/bevy_macro_utils/src/bevy_manifest.rs
+++ b/crates/bevy_macro_utils/src/bevy_manifest.rs
@@ -8,12 +8,12 @@ use std::{
     path::{Path, PathBuf},
     time::SystemTime,
 };
-use toml_edit::{ImDocument, Item};
+use toml_edit::{Document, Item};
 
 /// The path to the `Cargo.toml` file for the Bevy project.
 #[derive(Debug)]
 pub struct BevyManifest {
-    manifest: ImDocument<Box<str>>,
+    manifest: Document<Box<str>>,
     modified_time: SystemTime,
 }
 
@@ -70,11 +70,11 @@ impl BevyManifest {
         std::fs::metadata(cargo_manifest_path).and_then(|metadata| metadata.modified())
     }
 
-    fn read_manifest(path: &Path) -> ImDocument<Box<str>> {
+    fn read_manifest(path: &Path) -> Document<Box<str>> {
         let manifest = std::fs::read_to_string(path)
             .unwrap_or_else(|_| panic!("Unable to read cargo manifest: {}", path.display()))
             .into_boxed_str();
-        ImDocument::parse(manifest)
+        Document::parse(manifest)
             .unwrap_or_else(|_| panic!("Failed to parse cargo manifest: {}", path.display()))
     }
 

--- a/tools/build-templated-pages/Cargo.toml
+++ b/tools/build-templated-pages/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-toml_edit = { version = "0.22.7", default-features = false, features = [
+toml_edit = { version = "0.23.2", default-features = false, features = [
   "parse",
 ] }
 tera = "1.15"

--- a/tools/example-showcase/Cargo.toml
+++ b/tools/example-showcase/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 xshell = "0.2"
 clap = { version = "4.0", features = ["derive"] }
 ron = "0.10"
-toml_edit = { version = "0.22.7", default-features = false, features = [
+toml_edit = { version = "0.23.2", default-features = false, features = [
   "parse",
 ] }
 pbr = "1.1"


### PR DESCRIPTION
# Objective

- Closes #20410

## Solution

- Updated a deprecated type alias name (`ImDocument` -> `Document`).

## Testing

- CI checks