### PR TITLE
Add a test to check that we're only launching one load task when loading subassets.

### DIFF
--- a/crates/bevy_asset/src/server/info.rs
+++ b/crates/bevy_asset/src/server/info.rs
@@ -85,6 +85,7 @@ pub(crate) struct AssetInfos {
     pub(crate) dependency_loaded_event_sender: TypeIdMap<fn(&mut World, UntypedAssetId)>,
     pub(crate) dependency_failed_event_sender:
         TypeIdMap<fn(&mut World, UntypedAssetId, AssetPath<'static>, AssetLoadError)>,
+    pub(crate) root_asset_to_loading_count: HashMap<(TypeId, AssetPath<'static>), u32>,
     pub(crate) pending_tasks: HashMap<UntypedAssetId, Task<()>>,
 }
 


### PR DESCRIPTION
# Objective

- Fixes #20383.
- Fixes #12756.

## Solution

- Count the number of loads for a root asset that are currently happening. Note this needs to count assets by path and type ID, since you could be loading an asset path multiple times with different types.
- Don't launch a new load for a root asset if its number of loads is positive.
- Add some special handling for `load_untyped_async` to allow it to load even if the number of loads is already positive (since we need the handle, which means awaiting the async task which needs to perform the actual load).

## Testing

- Added a test to check that we only launch one task.
    - This test is brittle. We don't have any way to count how many tasks are currently running, so the best we can do is just hope the tasks finish quickly and stall until they are done.
- Ran the `many_foxes` example and it now works correctly!
