### PR TITLE
Replace `from_` constructors on `TextFont` with `From` impls 

### DIFF
--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -305,19 +305,9 @@ pub struct TextFont {
 }
 
 impl TextFont {
-    /// Returns a new [`TextFont`] with the specified font face handle.
-    pub fn from_font(font: Handle<Font>) -> Self {
-        Self::default().with_font(font)
-    }
-
     /// Returns a new [`TextFont`] with the specified font size.
     pub fn from_font_size(font_size: f32) -> Self {
         Self::default().with_font_size(font_size)
-    }
-
-    /// Returns a new [`TextFont`] with the specified line height.
-    pub fn from_line_height(line_height: LineHeight) -> Self {
-        Self::default().with_line_height(line_height)
     }
 
     /// Returns this [`TextFont`] with the specified font face handle.

--- a/examples/testbed/2d.rs
+++ b/examples/testbed/2d.rs
@@ -169,7 +169,7 @@ mod text {
             );
         }
 
-        let sans_serif = TextFont::from_font(asset_server.load("fonts/FiraSans-Bold.ttf"));
+        let sans_serif = TextFont::from(asset_server.load("fonts/FiraSans-Bold.ttf"));
 
         const NUM_ITERATIONS: usize = 10;
         for i in 0..NUM_ITERATIONS {

--- a/release-content/migration-guides/remove_text_font_from_constructor_methods.md
+++ b/release-content/migration-guides/remove_text_font_from_constructor_methods.md
@@ -1,0 +1,16 @@
+---
+title: `TextFont` constructor methods replaced with `From` impls
+pull_requests: [20335]
+---
+
+The `TextFont::from_font` and `TextFont::from_line_height` constructor methods have been removed in favor of `From` trait implementations.
+
+```rust
+// 0.16
+let text_font = TextFont::from_font(font_handle);
+let text_font = TextFont::from_line_height(line_height);
+
+// 0.17
+let text_font = TextFont::from(font_handle);
+let text_font = TextFont::from(line_height);
+```

--- a/release-content/migration-guides/remove_text_font_from_constructor_methods.md
+++ b/release-content/migration-guides/remove_text_font_from_constructor_methods.md
@@ -1,6 +1,6 @@
 ---
 title: `TextFont` constructor methods replaced with `From` impls
-pull_requests: [20335]
+pull_requests: [20335, 20450]
 ---
 
 The `TextFont::from_font` and `TextFont::from_line_height` constructor methods have been removed in favor of `From` trait implementations.


### PR DESCRIPTION
# Objective

- Closes #20353

## Solution

- Removed `TextFont::from_font` and `TextFont::from_line_height`.
- Updated `examples/testbed/2d.rs` to use the `Form` impl.
- Added migration guide.
