### PR TITLE
Fix panic in `FpsOverlay` with disabled `FrameTimeGraph`

### DIFF
--- a/crates/bevy_dev_tools/src/fps_overlay.rs
+++ b/crates/bevy_dev_tools/src/fps_overlay.rs
@@ -188,7 +188,10 @@ fn setup(
                     ..Default::default()
                 },
                 MaterialNode::from(frame_time_graph_materials.add(FrametimeGraphMaterial {
-                    values: buffers.add(ShaderStorageBuffer::default()),
+                    values: buffers.add(ShaderStorageBuffer {
+                        data: Some(vec![0, 0, 0, 0]),
+                        ..Default::default()
+                    }),
                     config: FrameTimeGraphConfigUniform::new(
                         overlay_config.frame_time_graph_config.target_fps,
                         overlay_config.frame_time_graph_config.min_fps,

--- a/crates/bevy_dev_tools/src/fps_overlay.rs
+++ b/crates/bevy_dev_tools/src/fps_overlay.rs
@@ -189,6 +189,9 @@ fn setup(
                 },
                 MaterialNode::from(frame_time_graph_materials.add(FrametimeGraphMaterial {
                     values: buffers.add(ShaderStorageBuffer {
+                        // Initialize with dummy data because the default (`data: None`) will
+                        // cause a panic in the shader if the frame time graph is constructed
+                        // with `enabled: false`.
                         data: Some(vec![0, 0, 0, 0]),
                         ..Default::default()
                     }),


### PR DESCRIPTION
# Objective

I am getting the following panic on start:

```
thread 'main' panicked at /home/User/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/wgpu-26.0.1/src/backend/wgpu_core.rs:1195:26:
wgpu error: Validation Error

Caused by:
  In Device::create_bind_group, label = 'FrametimeGraphMaterial'
    Buffer with '' label binding size is zero


note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Encountered a panic in system `bevy_render::render_asset::prepare_assets<bevy_ui_render::ui_material_pipeline::PreparedUiMaterial<bevy_dev_tools::frame_time_graph::FrametimeGraphMaterial>>`!
```

when registering the `FpsOverlayPlugin` with the frame time graph disabled by default:

```rust
app.add_plugins(FpsOverlayPlugin {
    config: FpsOverlayConfig {
        text_config: TextFont {
            font_size: 18.0,
            ..Default::default()
        },
        frame_time_graph_config: FrameTimeGraphConfig {
            enabled: false, // causes panic above
            ..Default::default()
        },
        enabled: false,
        ..Default::default()
    },
})
```


## Solution

I went with the most pragmatic fix I could find, since I am no render/shader expert but I can imagine there is a better way to fix this, please let me know. My reasoning being:

It does not panic after `update_frame_time_values` called `buffer.set_data(frame_times.clone().as_slice())`. So I ended up logging the buffer inside the system, and the first time it is called with empty `frame_times` it writes it into the `ShaderStorageBuffer` as `[0, 0, 0, 0]`. Doing the same when initializing the storage buffer fixes the panic on start.

