### PR TITLE
CI fixes for Rust 1.89

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,8 @@ allow_attributes = "warn"
 allow_attributes_without_reason = "warn"
 
 [workspace.lints.rust]
+# Strictly temporary until encase fixes dead code generation from ShaderType macros
+dead_code = "allow"
 missing_docs = "warn"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(docsrs_dep)'] }
 unsafe_code = "deny"
@@ -118,6 +120,8 @@ allow_attributes = "warn"
 allow_attributes_without_reason = "warn"
 
 [lints.rust]
+# Strictly temporary until encase fixes dead code generation from ShaderType macros
+dead_code = "allow"
 missing_docs = "warn"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(docsrs_dep)'] }
 unsafe_code = "deny"

--- a/crates/bevy_animation/src/animation_curves.rs
+++ b/crates/bevy_animation/src/animation_curves.rs
@@ -199,7 +199,7 @@ pub trait AnimatableProperty: Send + Sync + 'static {
 
     /// The [`EvaluatorId`] used to look up the [`AnimationCurveEvaluator`] for this [`AnimatableProperty`].
     /// For a given animated property, this ID should always be the same to allow things like animation blending to occur.
-    fn evaluator_id(&self) -> EvaluatorId;
+    fn evaluator_id(&self) -> EvaluatorId<'_>;
 }
 
 /// A [`Component`] field that can be animated, defined by a function that reads the component and returns
@@ -236,7 +236,7 @@ where
         Ok((self.func)(c.into_inner()))
     }
 
-    fn evaluator_id(&self) -> EvaluatorId {
+    fn evaluator_id(&self) -> EvaluatorId<'_> {
         EvaluatorId::ComponentField(&self.evaluator_id)
     }
 }
@@ -357,7 +357,7 @@ where
         self.curve.domain()
     }
 
-    fn evaluator_id(&self) -> EvaluatorId {
+    fn evaluator_id(&self) -> EvaluatorId<'_> {
         self.property.evaluator_id()
     }
 
@@ -476,7 +476,7 @@ where
         self.0.domain()
     }
 
-    fn evaluator_id(&self) -> EvaluatorId {
+    fn evaluator_id(&self) -> EvaluatorId<'_> {
         EvaluatorId::Type(TypeId::of::<WeightsCurveEvaluator>())
     }
 
@@ -768,7 +768,7 @@ pub trait AnimationCurve: Debug + Send + Sync + 'static {
     ///
     /// This must match the type returned by [`Self::create_evaluator`]. It must
     /// be a single type that doesn't depend on the type of the curve.
-    fn evaluator_id(&self) -> EvaluatorId;
+    fn evaluator_id(&self) -> EvaluatorId<'_>;
 
     /// Returns a newly-instantiated [`AnimationCurveEvaluator`] for use with
     /// this curve.

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -772,7 +772,7 @@ struct CurrentEvaluators {
 }
 
 impl CurrentEvaluators {
-    pub(crate) fn keys(&self) -> impl Iterator<Item = EvaluatorId> {
+    pub(crate) fn keys(&self) -> impl Iterator<Item = EvaluatorId<'_>> {
         self.component_properties
             .keys()
             .map(EvaluatorId::ComponentField)
@@ -1462,7 +1462,7 @@ impl<'a> TriggeredEvents<'a> {
         self.lower.is_empty() && self.upper.is_empty()
     }
 
-    fn iter(&self) -> TriggeredEventsIter {
+    fn iter(&self) -> TriggeredEventsIter<'_> {
         match self.direction {
             TriggeredEventsDir::Forward => TriggeredEventsIter::Forward(self.lower.iter()),
             TriggeredEventsDir::Reverse => TriggeredEventsIter::Reverse(self.lower.iter().rev()),

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -1007,12 +1007,11 @@ pub fn advance_animations(
 
                 if let Some(active_animation) = active_animations.get_mut(&node_index) {
                     // Tick the animation if necessary.
-                    if !active_animation.paused {
-                        if let AnimationNodeType::Clip(ref clip_handle) = node.node_type {
-                            if let Some(clip) = animation_clips.get(clip_handle) {
-                                active_animation.update(delta_seconds, clip.duration);
-                            }
-                        }
+                    if !active_animation.paused
+                        && let AnimationNodeType::Clip(ref clip_handle) = node.node_type
+                        && let Some(clip) = animation_clips.get(clip_handle)
+                    {
+                        active_animation.update(delta_seconds, clip.duration);
                     }
                 }
             }
@@ -1158,21 +1157,20 @@ pub fn animate_targets(
                                 AnimationEventTarget::Node(target_id),
                                 clip,
                                 active_animation,
-                            ) {
-                                if !triggered_events.is_empty() {
-                                    par_commands.command_scope(move |mut commands| {
-                                        for TimedAnimationEvent { time, event } in
-                                            triggered_events.iter()
-                                        {
-                                            event.trigger(
-                                                &mut commands,
-                                                entity,
-                                                *time,
-                                                active_animation.weight,
-                                            );
-                                        }
-                                    });
-                                }
+                            ) && !triggered_events.is_empty()
+                            {
+                                par_commands.command_scope(move |mut commands| {
+                                    for TimedAnimationEvent { time, event } in
+                                        triggered_events.iter()
+                                    {
+                                        event.trigger(
+                                            &mut commands,
+                                            entity,
+                                            *time,
+                                            active_animation.weight,
+                                        );
+                                    }
+                                });
                             }
                         }
 

--- a/crates/bevy_animation/src/transition.rs
+++ b/crates/bevy_animation/src/transition.rs
@@ -81,16 +81,15 @@ impl AnimationTransitions {
         new_animation: AnimationNodeIndex,
         transition_duration: Duration,
     ) -> &'p mut ActiveAnimation {
-        if let Some(old_animation_index) = self.main_animation.replace(new_animation) {
-            if let Some(old_animation) = player.animation_mut(old_animation_index) {
-                if !old_animation.is_paused() {
-                    self.transitions.push(AnimationTransition {
-                        current_weight: old_animation.weight,
-                        weight_decline_per_sec: 1.0 / transition_duration.as_secs_f32(),
-                        animation: old_animation_index,
-                    });
-                }
-            }
+        if let Some(old_animation_index) = self.main_animation.replace(new_animation)
+            && let Some(old_animation) = player.animation_mut(old_animation_index)
+            && !old_animation.is_paused()
+        {
+            self.transitions.push(AnimationTransition {
+                current_weight: old_animation.weight,
+                weight_decline_per_sec: 1.0 / transition_duration.as_secs_f32(),
+                animation: old_animation_index,
+            });
         }
 
         // If already transitioning away from this animation, cancel the transition.
@@ -135,10 +134,10 @@ pub fn advance_transitions(
             remaining_weight -= animation.weight;
         }
 
-        if let Some(main_animation_index) = animation_transitions.main_animation {
-            if let Some(ref mut animation) = player.animation_mut(main_animation_index) {
-                animation.weight = remaining_weight;
-            }
+        if let Some(main_animation_index) = animation_transitions.main_animation
+            && let Some(ref mut animation) = player.animation_mut(main_animation_index)
+        {
+            animation.weight = remaining_weight;
         }
     }
 }

--- a/crates/bevy_anti_aliasing/src/taa/mod.rs
+++ b/crates/bevy_anti_aliasing/src/taa/mod.rs
@@ -350,16 +350,17 @@ fn extract_taa_settings(mut commands: Commands, mut main_world: ResMut<MainWorld
         Option<&mut TemporalAntiAliasing>,
     )>();
 
-    for (entity, camera, camera_projection, mut taa_settings) in
-        cameras_3d.iter_mut(&mut main_world)
-    {
+    for (entity, camera, camera_projection, taa_settings) in cameras_3d.iter_mut(&mut main_world) {
         let has_perspective_projection = matches!(camera_projection, Projection::Perspective(_));
         let mut entity_commands = commands
             .get_entity(entity)
             .expect("Camera entity wasn't synced.");
-        if taa_settings.is_some() && camera.is_active && has_perspective_projection {
-            entity_commands.insert(taa_settings.as_deref().unwrap().clone());
-            taa_settings.as_mut().unwrap().reset = false;
+        if let Some(mut taa_settings) = taa_settings
+            && camera.is_active
+            && has_perspective_projection
+        {
+            entity_commands.insert(taa_settings.clone());
+            taa_settings.reset = false;
         } else {
             entity_commands.remove::<(
                 TemporalAntiAliasing,

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1611,9 +1611,11 @@ mod tests {
             b: u32,
         }
 
+        #[expect(dead_code, reason = "type is never constructed")]
         #[derive(AppLabel, Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
         struct EmptyTupleLabel();
 
+        #[expect(dead_code, reason = "type is never constructed")]
         #[derive(AppLabel, Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
         struct EmptyStructLabel {}
 

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1611,11 +1611,9 @@ mod tests {
             b: u32,
         }
 
-        #[expect(dead_code, reason = "type is never constructed")]
         #[derive(AppLabel, Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
         struct EmptyTupleLabel();
 
-        #[expect(dead_code, reason = "type is never constructed")]
         #[derive(AppLabel, Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
         struct EmptyStructLabel {}
 

--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -517,18 +517,18 @@ impl PluginGroupBuilder {
     #[track_caller]
     pub fn finish(mut self, app: &mut App) {
         for ty in &self.order {
-            if let Some(entry) = self.plugins.remove(ty) {
-                if entry.enabled {
-                    debug!("added plugin: {}", entry.plugin.name());
-                    if let Err(AppError::DuplicatePlugin { plugin_name }) =
-                        app.add_boxed_plugin(entry.plugin)
-                    {
-                        panic!(
-                            "Error adding plugin {} in group {}: plugin was already added in application",
-                            plugin_name,
-                            self.group_name
-                        );
-                    }
+            if let Some(entry) = self.plugins.remove(ty)
+                && entry.enabled
+            {
+                debug!("added plugin: {}", entry.plugin.name());
+                if let Err(AppError::DuplicatePlugin { plugin_name }) =
+                    app.add_boxed_plugin(entry.plugin)
+                {
+                    panic!(
+                        "Error adding plugin {} in group {}: plugin was already added in application",
+                        plugin_name,
+                        self.group_name
+                    );
                 }
             }
         }

--- a/crates/bevy_asset/src/io/embedded/embedded_watcher.rs
+++ b/crates/bevy_asset/src/io/embedded/embedded_watcher.rs
@@ -73,15 +73,15 @@ impl FilesystemEventHandler for EmbeddedEventHandler {
 
     fn handle(&mut self, absolute_paths: &[PathBuf], event: AssetSourceEvent) {
         if self.last_event.as_ref() != Some(&event) {
-            if let AssetSourceEvent::ModifiedAsset(path) = &event {
-                if let Ok(file) = File::open(&absolute_paths[0]) {
-                    let mut reader = BufReader::new(file);
-                    let mut buffer = Vec::new();
+            if let AssetSourceEvent::ModifiedAsset(path) = &event
+                && let Ok(file) = File::open(&absolute_paths[0])
+            {
+                let mut reader = BufReader::new(file);
+                let mut buffer = Vec::new();
 
-                    // Read file into vector.
-                    if reader.read_to_end(&mut buffer).is_ok() {
-                        self.dir.insert_asset(path, buffer);
-                    }
+                // Read file into vector.
+                if reader.read_to_end(&mut buffer).is_ok() {
+                    self.dir.insert_asset(path, buffer);
                 }
             }
             self.last_event = Some(event.clone());

--- a/crates/bevy_asset/src/io/file/file_asset.rs
+++ b/crates/bevy_asset/src/io/file/file_asset.rs
@@ -69,10 +69,10 @@ impl AssetReader for FileAssetReader {
                     f.ok().and_then(|dir_entry| {
                         let path = dir_entry.path();
                         // filter out meta files as they are not considered assets
-                        if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
-                            if ext.eq_ignore_ascii_case("meta") {
-                                return None;
-                            }
+                        if let Some(ext) = path.extension().and_then(|e| e.to_str())
+                            && ext.eq_ignore_ascii_case("meta")
+                        {
+                            return None;
                         }
                         // filter out hidden files. they are not listed by default but are directly targetable
                         if path

--- a/crates/bevy_asset/src/io/file/mod.rs
+++ b/crates/bevy_asset/src/io/file/mod.rs
@@ -75,14 +75,12 @@ impl FileAssetWriter {
     /// watching for changes.
     pub fn new<P: AsRef<Path> + core::fmt::Debug>(path: P, create_root: bool) -> Self {
         let root_path = get_base_path().join(path.as_ref());
-        if create_root {
-            if let Err(e) = std::fs::create_dir_all(&root_path) {
-                error!(
-                    "Failed to create root directory {} for file asset writer: {}",
-                    root_path.display(),
-                    e
-                );
-            }
+        if create_root && let Err(e) = std::fs::create_dir_all(&root_path) {
+            error!(
+                "Failed to create root directory {} for file asset writer: {}",
+                root_path.display(),
+                e
+            );
         }
         Self { root_path }
     }

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -1629,37 +1629,37 @@ mod tests {
             let loaded_folders = world.resource::<Assets<LoadedFolder>>();
             let cool_texts = world.resource::<Assets<CoolText>>();
             for event in reader.read(events) {
-                if let AssetEvent::LoadedWithDependencies { id } = event {
-                    if *id == handle.id() {
-                        let loaded_folder = loaded_folders.get(&handle).unwrap();
-                        let a_handle: Handle<CoolText> =
-                            asset_server.get_handle("text/a.cool.ron").unwrap();
-                        let c_handle: Handle<CoolText> =
-                            asset_server.get_handle("text/c.cool.ron").unwrap();
+                if let AssetEvent::LoadedWithDependencies { id } = event
+                    && *id == handle.id()
+                {
+                    let loaded_folder = loaded_folders.get(&handle).unwrap();
+                    let a_handle: Handle<CoolText> =
+                        asset_server.get_handle("text/a.cool.ron").unwrap();
+                    let c_handle: Handle<CoolText> =
+                        asset_server.get_handle("text/c.cool.ron").unwrap();
 
-                        let mut found_a = false;
-                        let mut found_c = false;
-                        for asset_handle in &loaded_folder.handles {
-                            if asset_handle.id() == a_handle.id().untyped() {
-                                found_a = true;
-                            } else if asset_handle.id() == c_handle.id().untyped() {
-                                found_c = true;
-                            }
+                    let mut found_a = false;
+                    let mut found_c = false;
+                    for asset_handle in &loaded_folder.handles {
+                        if asset_handle.id() == a_handle.id().untyped() {
+                            found_a = true;
+                        } else if asset_handle.id() == c_handle.id().untyped() {
+                            found_c = true;
                         }
-                        assert!(found_a);
-                        assert!(found_c);
-                        assert_eq!(loaded_folder.handles.len(), 2);
-
-                        let a_text = cool_texts.get(&a_handle).unwrap();
-                        let b_text = cool_texts.get(&a_text.dependencies[0]).unwrap();
-                        let c_text = cool_texts.get(&c_handle).unwrap();
-
-                        assert_eq!("a", a_text.text);
-                        assert_eq!("b", b_text.text);
-                        assert_eq!("c", c_text.text);
-
-                        return Some(());
                     }
+                    assert!(found_a);
+                    assert!(found_c);
+                    assert_eq!(loaded_folder.handles.len(), 2);
+
+                    let a_text = cool_texts.get(&a_handle).unwrap();
+                    let b_text = cool_texts.get(&a_text.dependencies[0]).unwrap();
+                    let c_text = cool_texts.get(&c_handle).unwrap();
+
+                    assert_eq!("a", a_text.text);
+                    assert_eq!("b", b_text.text);
+                    assert_eq!("c", c_text.text);
+
+                    return Some(());
                 }
             }
             None

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -371,7 +371,7 @@ impl<'a> LoadContext<'a> {
     ///     load_context.add_loaded_labeled_asset(label, loaded_asset);
     /// }
     /// ```
-    pub fn begin_labeled_asset(&self) -> LoadContext {
+    pub fn begin_labeled_asset(&self) -> LoadContext<'_> {
         LoadContext::new(
             self.asset_server,
             self.asset_path.clone(),

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -246,7 +246,7 @@ impl<'a> AssetPath<'a> {
     /// Gets the "asset source", if one was defined. If none was defined, the default source
     /// will be used.
     #[inline]
-    pub fn source(&self) -> &AssetSourceId {
+    pub fn source(&self) -> &AssetSourceId<'_> {
         &self.source
     }
 

--- a/crates/bevy_asset/src/saver.rs
+++ b/crates/bevy_asset/src/saver.rs
@@ -114,7 +114,7 @@ impl<'a, A: Asset> SavedAsset<'a, A> {
     }
 
     /// Returns the labeled asset, if it exists and matches this type.
-    pub fn get_labeled<B: Asset, Q>(&self, label: &Q) -> Option<SavedAsset<B>>
+    pub fn get_labeled<B: Asset, Q>(&self, label: &Q) -> Option<SavedAsset<'_, B>>
     where
         CowArc<'static, str>: Borrow<Q>,
         Q: ?Sized + Hash + Eq,

--- a/crates/bevy_asset/src/server/info.rs
+++ b/crates/bevy_asset/src/server/info.rs
@@ -133,13 +133,11 @@ impl AssetInfos {
             .get(&type_id)
             .ok_or(MissingHandleProviderError(type_id))?;
 
-        if watching_for_changes {
-            if let Some(path) = &path {
-                let mut without_label = path.to_owned();
-                if let Some(label) = without_label.take_label() {
-                    let labels = living_labeled_assets.entry(without_label).or_default();
-                    labels.insert(label.as_ref().into());
-                }
+        if watching_for_changes && let Some(path) = &path {
+            let mut without_label = path.to_owned();
+            if let Some(label) = without_label.take_label() {
+                let labels = living_labeled_assets.entry(without_label).or_default();
+                labels.insert(label.as_ref().into());
             }
         }
 

--- a/crates/bevy_asset/src/server/loaders.rs
+++ b/crates/bevy_asset/src/server/loaders.rs
@@ -59,15 +59,13 @@ impl AssetLoaders {
                     .entry((*extension).into())
                     .or_default();
 
-                if !list.is_empty() {
-                    if let Some(existing_loaders_for_type_id) = existing_loaders_for_type_id {
-                        if list
-                            .iter()
-                            .any(|index| existing_loaders_for_type_id.contains(index))
-                        {
-                            duplicate_extensions.push(extension);
-                        }
-                    }
+                if !list.is_empty()
+                    && let Some(existing_loaders_for_type_id) = existing_loaders_for_type_id
+                    && list
+                        .iter()
+                        .any(|index| existing_loaders_for_type_id.contains(index))
+                {
+                    duplicate_extensions.push(extension);
                 }
 
                 list.push(loader_index);
@@ -125,15 +123,13 @@ impl AssetLoaders {
                 .entry((*extension).into())
                 .or_default();
 
-            if !list.is_empty() {
-                if let Some(existing_loaders_for_type_id) = existing_loaders_for_type_id {
-                    if list
-                        .iter()
-                        .any(|index| existing_loaders_for_type_id.contains(index))
-                    {
-                        duplicate_extensions.push(extension);
-                    }
-                }
+            if !list.is_empty()
+                && let Some(existing_loaders_for_type_id) = existing_loaders_for_type_id
+                && list
+                    .iter()
+                    .any(|index| existing_loaders_for_type_id.contains(index))
+            {
+                duplicate_extensions.push(extension);
             }
 
             list.push(loader_index);
@@ -218,10 +214,10 @@ impl AssetLoaders {
         };
 
         // Try the provided extension
-        if let Some(extension) = extension {
-            if let Some(&index) = try_extension(extension) {
-                return self.get_by_index(index);
-            }
+        if let Some(extension) = extension
+            && let Some(&index) = try_extension(extension)
+        {
+            return self.get_by_index(index);
         }
 
         // Try extracting the extension from the path

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -846,10 +846,11 @@ impl AssetServer {
                     }
                 }
 
-                if !reloaded && server.data.infos.read().should_reload(&path) {
-                    if let Err(err) = server.load_internal(None, path, true, None).await {
-                        error!("{}", err);
-                    }
+                if !reloaded
+                    && server.data.infos.read().should_reload(&path)
+                    && let Err(err) = server.load_internal(None, path, true, None).await
+                {
+                    error!("{}", err);
                 }
             })
             .detach();

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -1272,7 +1272,7 @@ impl AssetServer {
     }
 
     /// Returns the path for the given `id`, if it has one.
-    pub fn get_path(&self, id: impl Into<UntypedAssetId>) -> Option<AssetPath> {
+    pub fn get_path(&self, id: impl Into<UntypedAssetId>) -> Option<AssetPath<'_>> {
         let infos = self.data.infos.read();
         let info = infos.get(id.into())?;
         Some(info.path.as_ref()?.clone())

--- a/crates/bevy_asset/src/transformer.rs
+++ b/crates/bevy_asset/src/transformer.rs
@@ -87,7 +87,7 @@ impl<A: Asset> TransformedAsset<A> {
         &mut self.value
     }
     /// Returns the labeled asset, if it exists and matches this type.
-    pub fn get_labeled<B: Asset, Q>(&mut self, label: &Q) -> Option<TransformedSubAsset<B>>
+    pub fn get_labeled<B: Asset, Q>(&mut self, label: &Q) -> Option<TransformedSubAsset<'_, B>>
     where
         CowArc<'static, str>: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
@@ -187,7 +187,7 @@ impl<'a, A: Asset> TransformedSubAsset<'a, A> {
         self.value
     }
     /// Returns the labeled asset, if it exists and matches this type.
-    pub fn get_labeled<B: Asset, Q>(&mut self, label: &Q) -> Option<TransformedSubAsset<B>>
+    pub fn get_labeled<B: Asset, Q>(&mut self, label: &Q) -> Option<TransformedSubAsset<'_, B>>
     where
         CowArc<'static, str>: Borrow<Q>,
         Q: ?Sized + Hash + Eq,

--- a/crates/bevy_camera/src/visibility/mod.rs
+++ b/crates/bevy_camera/src/visibility/mod.rs
@@ -384,10 +384,10 @@ pub fn calculate_bounds(
     without_aabb: Query<(Entity, &Mesh3d), (Without<Aabb>, Without<NoFrustumCulling>)>,
 ) {
     for (entity, mesh_handle) in &without_aabb {
-        if let Some(mesh) = meshes.get(mesh_handle) {
-            if let Some(aabb) = mesh.compute_aabb() {
-                commands.entity(entity).try_insert(aabb);
-            }
+        if let Some(mesh) = meshes.get(mesh_handle)
+            && let Some(aabb) = mesh.compute_aabb()
+        {
+            commands.entity(entity).try_insert(aabb);
         }
     }
 }
@@ -580,21 +580,22 @@ pub fn check_visibility(
                 }
 
                 // If we have an aabb, do frustum culling
-                if !no_frustum_culling && !no_cpu_culling {
-                    if let Some(model_aabb) = maybe_model_aabb {
-                        let world_from_local = transform.affine();
-                        let model_sphere = Sphere {
-                            center: world_from_local.transform_point3a(model_aabb.center),
-                            radius: transform.radius_vec3a(model_aabb.half_extents),
-                        };
-                        // Do quick sphere-based frustum culling
-                        if !frustum.intersects_sphere(&model_sphere, false) {
-                            return;
-                        }
-                        // Do aabb-based frustum culling
-                        if !frustum.intersects_obb(model_aabb, &world_from_local, true, false) {
-                            return;
-                        }
+                if !no_frustum_culling
+                    && !no_cpu_culling
+                    && let Some(model_aabb) = maybe_model_aabb
+                {
+                    let world_from_local = transform.affine();
+                    let model_sphere = Sphere {
+                        center: world_from_local.transform_point3a(model_aabb.center),
+                        radius: transform.radius_vec3a(model_aabb.half_extents),
+                    };
+                    // Do quick sphere-based frustum culling
+                    if !frustum.intersects_sphere(&model_sphere, false) {
+                        return;
+                    }
+                    // Do aabb-based frustum culling
+                    if !frustum.intersects_obb(model_aabb, &world_from_local, true, false) {
+                        return;
                     }
                 }
 

--- a/crates/bevy_core_pipeline/src/oit/mod.rs
+++ b/crates/bevy_core_pipeline/src/oit/mod.rs
@@ -67,13 +67,13 @@ impl Component for OrderIndependentTransparencySettings {
 
     fn on_add() -> Option<ComponentHook> {
         Some(|world, context| {
-            if let Some(value) = world.get::<OrderIndependentTransparencySettings>(context.entity) {
-                if value.layer_count > 32 {
-                    warn!("{}OrderIndependentTransparencySettings layer_count set to {} might be too high.",
+            if let Some(value) = world.get::<OrderIndependentTransparencySettings>(context.entity)
+                && value.layer_count > 32
+            {
+                warn!("{}OrderIndependentTransparencySettings layer_count set to {} might be too high.",
                         context.caller.map(|location|format!("{location}: ")).unwrap_or_default(),
                         value.layer_count
                     );
-                }
             }
         })
     }

--- a/crates/bevy_core_pipeline/src/oit/resolve/mod.rs
+++ b/crates/bevy_core_pipeline/src/oit/resolve/mod.rs
@@ -167,11 +167,11 @@ pub fn queue_oit_resolve_pipeline(
             layer_count: oit_settings.layer_count,
         };
 
-        if let Some((cached_key, id)) = cached_pipeline_id.get(&e) {
-            if *cached_key == key {
-                commands.entity(e).insert(OitResolvePipelineId(*id));
-                continue;
-            }
+        if let Some((cached_key, id)) = cached_pipeline_id.get(&e)
+            && *cached_key == key
+        {
+            commands.entity(e).insert(OitResolvePipelineId(*id));
+            continue;
         }
 
         let desc = specialize_oit_resolve_pipeline(

--- a/crates/bevy_core_pipeline/src/prepass/node.rs
+++ b/crates/bevy_core_pipeline/src/prepass/node.rs
@@ -238,14 +238,14 @@ fn run_prepass<'w>(
         drop(render_pass);
 
         // After rendering to the view depth texture, copy it to the prepass depth texture if deferred isn't going to
-        if deferred_prepass.is_none() {
-            if let Some(prepass_depth_texture) = &view_prepass_textures.depth {
-                command_encoder.copy_texture_to_texture(
-                    view_depth_texture.texture.as_image_copy(),
-                    prepass_depth_texture.texture.texture.as_image_copy(),
-                    view_prepass_textures.size,
-                );
-            }
+        if deferred_prepass.is_none()
+            && let Some(prepass_depth_texture) = &view_prepass_textures.depth
+        {
+            command_encoder.copy_texture_to_texture(
+                view_depth_texture.texture.as_image_copy(),
+                prepass_depth_texture.texture.texture.as_image_copy(),
+                view_prepass_textures.size,
+            );
         }
 
         command_encoder.finish()

--- a/crates/bevy_core_pipeline/src/upscaling/node.rs
+++ b/crates/bevy_core_pipeline/src/upscaling/node.rs
@@ -84,12 +84,12 @@ impl ViewNode for UpscalingNode {
             .begin_render_pass(&pass_descriptor);
         let pass_span = diagnostics.pass_span(&mut render_pass, "upscaling");
 
-        if let Some(camera) = camera {
-            if let Some(viewport) = &camera.viewport {
-                let size = viewport.physical_size;
-                let position = viewport.physical_position;
-                render_pass.set_scissor_rect(position.x, position.y, size.x, size.y);
-            }
+        if let Some(camera) = camera
+            && let Some(viewport) = &camera.viewport
+        {
+            let size = viewport.physical_size;
+            let position = viewport.physical_position;
+            render_pass.set_scissor_rect(position.x, position.y, size.x, size.y);
         }
 
         render_pass.set_pipeline(pipeline);

--- a/crates/bevy_core_widgets/src/core_button.rs
+++ b/crates/bevy_core_widgets/src/core_button.rs
@@ -34,16 +34,16 @@ fn button_on_key_event(
     q_state: Query<(&CoreButton, Has<InteractionDisabled>)>,
     mut commands: Commands,
 ) {
-    if let Ok((bstate, disabled)) = q_state.get(trigger.target()) {
-        if !disabled {
-            let event = &trigger.event().input;
-            if !event.repeat
-                && event.state == ButtonState::Pressed
-                && (event.key_code == KeyCode::Enter || event.key_code == KeyCode::Space)
-            {
-                trigger.propagate(false);
-                commands.notify_with(&bstate.on_activate, Activate(trigger.target()));
-            }
+    if let Ok((bstate, disabled)) = q_state.get(trigger.target())
+        && !disabled
+    {
+        let event = &trigger.event().input;
+        if !event.repeat
+            && event.state == ButtonState::Pressed
+            && (event.key_code == KeyCode::Enter || event.key_code == KeyCode::Space)
+        {
+            trigger.propagate(false);
+            commands.notify_with(&bstate.on_activate, Activate(trigger.target()));
         }
     }
 }

--- a/crates/bevy_core_widgets/src/core_scrollbar.rs
+++ b/crates/bevy_core_widgets/src/core_scrollbar.rs
@@ -164,14 +164,14 @@ fn scrollbar_on_drag_start(
 ) {
     if let Ok((ChildOf(thumb_parent), mut drag)) = q_thumb.get_mut(ev.target()) {
         ev.propagate(false);
-        if let Ok(scrollbar) = q_scrollbar.get(*thumb_parent) {
-            if let Ok(scroll_area) = q_scroll_area.get(scrollbar.target) {
-                drag.dragging = true;
-                drag.drag_origin = match scrollbar.orientation {
-                    ControlOrientation::Horizontal => scroll_area.x,
-                    ControlOrientation::Vertical => scroll_area.y,
-                };
-            }
+        if let Ok(scrollbar) = q_scrollbar.get(*thumb_parent)
+            && let Ok(scroll_area) = q_scroll_area.get(scrollbar.target)
+        {
+            drag.dragging = true;
+            drag.drag_origin = match scrollbar.orientation {
+                ControlOrientation::Horizontal => scroll_area.x,
+                ControlOrientation::Vertical => scroll_area.y,
+            };
         }
     }
 }
@@ -183,36 +183,34 @@ fn scrollbar_on_drag(
     mut q_scroll_pos: Query<(&mut ScrollPosition, &ComputedNode), Without<CoreScrollbar>>,
     ui_scale: Res<UiScale>,
 ) {
-    if let Ok((ChildOf(thumb_parent), drag)) = q_thumb.get_mut(ev.target()) {
-        if let Ok((node, scrollbar)) = q_scrollbar.get_mut(*thumb_parent) {
-            ev.propagate(false);
-            let Ok((mut scroll_pos, scroll_content)) = q_scroll_pos.get_mut(scrollbar.target)
-            else {
-                return;
+    if let Ok((ChildOf(thumb_parent), drag)) = q_thumb.get_mut(ev.target())
+        && let Ok((node, scrollbar)) = q_scrollbar.get_mut(*thumb_parent)
+    {
+        ev.propagate(false);
+        let Ok((mut scroll_pos, scroll_content)) = q_scroll_pos.get_mut(scrollbar.target) else {
+            return;
+        };
+
+        if drag.dragging {
+            let distance = ev.event().distance / ui_scale.0;
+            let visible_size = scroll_content.size() * scroll_content.inverse_scale_factor;
+            let content_size = scroll_content.content_size() * scroll_content.inverse_scale_factor;
+            let scrollbar_size = (node.size() * node.inverse_scale_factor).max(Vec2::ONE);
+
+            match scrollbar.orientation {
+                ControlOrientation::Horizontal => {
+                    let range = (content_size.x - visible_size.x).max(0.);
+                    scroll_pos.x = (drag.drag_origin
+                        + (distance.x * content_size.x) / scrollbar_size.x)
+                        .clamp(0., range);
+                }
+                ControlOrientation::Vertical => {
+                    let range = (content_size.y - visible_size.y).max(0.);
+                    scroll_pos.y = (drag.drag_origin
+                        + (distance.y * content_size.y) / scrollbar_size.y)
+                        .clamp(0., range);
+                }
             };
-
-            if drag.dragging {
-                let distance = ev.event().distance / ui_scale.0;
-                let visible_size = scroll_content.size() * scroll_content.inverse_scale_factor;
-                let content_size =
-                    scroll_content.content_size() * scroll_content.inverse_scale_factor;
-                let scrollbar_size = (node.size() * node.inverse_scale_factor).max(Vec2::ONE);
-
-                match scrollbar.orientation {
-                    ControlOrientation::Horizontal => {
-                        let range = (content_size.x - visible_size.x).max(0.);
-                        scroll_pos.x = (drag.drag_origin
-                            + (distance.x * content_size.x) / scrollbar_size.x)
-                            .clamp(0., range);
-                    }
-                    ControlOrientation::Vertical => {
-                        let range = (content_size.y - visible_size.y).max(0.);
-                        scroll_pos.y = (drag.drag_origin
-                            + (distance.y * content_size.y) / scrollbar_size.y)
-                            .clamp(0., range);
-                    }
-                };
-            }
         }
     }
 }

--- a/crates/bevy_dev_tools/src/fps_overlay.rs
+++ b/crates/bevy_dev_tools/src/fps_overlay.rs
@@ -212,10 +212,10 @@ fn update_text(
     if *time_since_rerender >= config.refresh_interval {
         *time_since_rerender = Duration::ZERO;
         for entity in &query {
-            if let Some(fps) = diagnostic.get(&FrameTimeDiagnosticsPlugin::FPS) {
-                if let Some(value) = fps.smoothed() {
-                    *writer.text(entity, 1) = format!("{value:.2}");
-                }
+            if let Some(fps) = diagnostic.get(&FrameTimeDiagnosticsPlugin::FPS)
+                && let Some(value) = fps.smoothed()
+            {
+                *writer.text(entity, 1) = format!("{value:.2}");
             }
         }
     }

--- a/crates/bevy_diagnostic/src/diagnostic.rs
+++ b/crates/bevy_diagnostic/src/diagnostic.rs
@@ -149,12 +149,11 @@ impl Diagnostic {
         }
 
         if self.max_history_length > 1 {
-            if self.history.len() >= self.max_history_length {
-                if let Some(removed_diagnostic) = self.history.pop_front() {
-                    if !removed_diagnostic.value.is_nan() {
-                        self.sum -= removed_diagnostic.value;
-                    }
-                }
+            if self.history.len() >= self.max_history_length
+                && let Some(removed_diagnostic) = self.history.pop_front()
+                && !removed_diagnostic.value.is_nan()
+            {
+                self.sum -= removed_diagnostic.value;
             }
 
             if measurement.value.is_finite() {
@@ -273,13 +272,9 @@ impl Diagnostic {
             return None;
         }
 
-        if let Some(newest) = self.history.back() {
-            if let Some(oldest) = self.history.front() {
-                return Some(newest.time.duration_since(oldest.time));
-            }
-        }
-
-        None
+        let newest = self.history.back()?;
+        let oldest = self.history.front()?;
+        Some(newest.time.duration_since(oldest.time))
     }
 
     /// Return the maximum number of elements for this diagnostic.

--- a/crates/bevy_diagnostic/src/log_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/log_diagnostics_plugin.rs
@@ -128,10 +128,10 @@ impl LogDiagnosticsPlugin {
     ) {
         if let Some(filter) = &state.filter {
             for path in filter.iter() {
-                if let Some(diagnostic) = diagnostics.get(path) {
-                    if diagnostic.is_enabled {
-                        callback(diagnostic);
-                    }
+                if let Some(diagnostic) = diagnostics.get(path)
+                    && diagnostic.is_enabled
+                {
+                    callback(diagnostic);
                 }
             }
         } else {

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -1051,7 +1051,7 @@ impl<'w> MutUntyped<'w> {
     /// Returns a [`MutUntyped`] with a smaller lifetime.
     /// This is useful if you have `&mut MutUntyped`, but you need a `MutUntyped`.
     #[inline]
-    pub fn reborrow(&mut self) -> MutUntyped {
+    pub fn reborrow(&mut self) -> MutUntyped<'_> {
         MutUntyped {
             value: self.value.reborrow(),
             ticks: TicksMut {

--- a/crates/bevy_ecs/src/component/clone.rs
+++ b/crates/bevy_ecs/src/component/clone.rs
@@ -7,7 +7,7 @@ use crate::entity::{ComponentCloneCtx, SourceComponent};
 pub type ComponentCloneFn = fn(&SourceComponent, &mut ComponentCloneCtx);
 
 /// The clone behavior to use when cloning or moving a [`Component`].
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default)]
 pub enum ComponentCloneBehavior {
     /// Uses the default behavior (which is passed to [`ComponentCloneBehavior::resolve`])
     #[default]

--- a/crates/bevy_ecs/src/entity/clone_entities.rs
+++ b/crates/bevy_ecs/src/entity/clone_entities.rs
@@ -445,7 +445,7 @@ impl EntityCloner {
     /// explicitly denied, for example by using the [`deny`](EntityClonerBuilder<OptOut>::deny) method.
     ///
     /// Required components are not considered by denied components and must be explicitly denied as well if desired.
-    pub fn build_opt_out(world: &mut World) -> EntityClonerBuilder<OptOut> {
+    pub fn build_opt_out(world: &mut World) -> EntityClonerBuilder<'_, OptOut> {
         EntityClonerBuilder {
             world,
             filter: Default::default(),
@@ -461,7 +461,7 @@ impl EntityCloner {
     /// Components allowed to be cloned through this builder would also allow their required components,
     /// which will be cloned from the source entity only if the target entity does not contain them already.
     /// To skip adding required components see [`without_required_components`](EntityClonerBuilder<OptIn>::without_required_components).
-    pub fn build_opt_in(world: &mut World) -> EntityClonerBuilder<OptIn> {
+    pub fn build_opt_in(world: &mut World) -> EntityClonerBuilder<'_, OptIn> {
         EntityClonerBuilder {
             world,
             filter: Default::default(),

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -774,7 +774,7 @@ impl Entities {
         clippy::unnecessary_fallible_conversions,
         reason = "`IdCursor::try_from` may fail on 32-bit platforms."
     )]
-    pub fn reserve_entities(&self, count: u32) -> ReserveEntitiesIterator {
+    pub fn reserve_entities(&self, count: u32) -> ReserveEntitiesIterator<'_> {
         // Use one atomic subtract to grab a range of new IDs. The range might be
         // entirely nonnegative, meaning all IDs come from the freelist, or entirely
         // negative, meaning they are all new IDs to allocate, or a mix of both.

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1929,17 +1929,9 @@ mod tests {
         assert_eq!(&mapper.0, &[e1, e2, e3]);
     }
 
-    #[expect(
-        dead_code,
-        reason = "This struct is used as a compilation test to test the derive macros, and as such is intentionally never constructed."
-    )]
     #[derive(Component)]
     struct ComponentA(u32);
 
-    #[expect(
-        dead_code,
-        reason = "This struct is used as a compilation test to test the derive macros, and as such is intentionally never constructed."
-    )]
     #[derive(Component)]
     struct ComponentB(u32);
 
@@ -1963,17 +1955,9 @@ mod tests {
         another_one: Entity,
         #[entities]
         maybe_entity: Option<Entity>,
-        #[expect(
-            dead_code,
-            reason = "This struct is used as a compilation test to test the derive macros, and as such this field is intentionally never used."
-        )]
         something_else: String,
     }
 
-    #[expect(
-        dead_code,
-        reason = "This struct is used as a compilation test to test the derive macros, and as such is intentionally never constructed."
-    )]
     #[derive(Component)]
     struct MyEntitiesTuple(#[entities] Vec<Entity>, #[entities] Entity, usize);
 

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -516,9 +516,6 @@ mod tests {
     struct B;
 
     #[derive(Component)]
-    struct C;
-
-    #[derive(Component)]
     #[component(storage = "SparseSet")]
     struct S;
 

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -182,7 +182,7 @@ impl World {
     pub fn add_observer<E: Event, B: Bundle, M>(
         &mut self,
         system: impl IntoObserverSystem<E, B, M>,
-    ) -> EntityWorldMut {
+    ) -> EntityWorldMut<'_> {
         self.spawn(Observer::new(system))
     }
 

--- a/crates/bevy_ecs/src/observer/system_param.rs
+++ b/crates/bevy_ecs/src/observer/system_param.rs
@@ -64,7 +64,7 @@ impl<'w, E, B: Bundle> On<'w, E, B> {
     }
 
     /// Returns a pointer to the triggered event.
-    pub fn event_ptr(&self) -> Ptr {
+    pub fn event_ptr(&self) -> Ptr<'_> {
         Ptr::from(&self.event)
     }
 

--- a/crates/bevy_ecs/src/relationship/related_methods.rs
+++ b/crates/bevy_ecs/src/relationship/related_methods.rs
@@ -642,7 +642,7 @@ impl<'w, R: Relationship> RelatedSpawnerCommands<'w, R> {
     }
 
     /// Returns the underlying [`Commands`].
-    pub fn commands(&mut self) -> Commands {
+    pub fn commands(&mut self) -> Commands<'_, '_> {
         self.commands.reborrow()
     }
 

--- a/crates/bevy_ecs/src/schedule/set.rs
+++ b/crates/bevy_ecs/src/schedule/set.rs
@@ -373,9 +373,11 @@ mod tests {
             b: u32,
         }
 
+        #[expect(dead_code, reason = "this is never constructed")]
         #[derive(ScheduleLabel, Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
         struct EmptyTupleLabel();
 
+        #[expect(dead_code, reason = "this is never constructed")]
         #[derive(ScheduleLabel, Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
         struct EmptyStructLabel {}
 

--- a/crates/bevy_ecs/src/schedule/set.rs
+++ b/crates/bevy_ecs/src/schedule/set.rs
@@ -373,11 +373,9 @@ mod tests {
             b: u32,
         }
 
-        #[expect(dead_code, reason = "this is never constructed")]
         #[derive(ScheduleLabel, Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
         struct EmptyTupleLabel();
 
-        #[expect(dead_code, reason = "this is never constructed")]
         #[derive(ScheduleLabel, Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
         struct EmptyStructLabel {}
 

--- a/crates/bevy_ecs/src/schedule/stepping.rs
+++ b/crates/bevy_ecs/src/schedule/stepping.rs
@@ -365,13 +365,11 @@ impl Stepping {
 
     /// lookup the first system for the supplied schedule index
     fn first_system_index_for_schedule(&self, index: usize) -> usize {
-        let label = match self.schedule_order.get(index) {
-            None => return 0,
-            Some(label) => label,
+        let Some(label) = self.schedule_order.get(index) else {
+            return 0;
         };
-        let state = match self.schedule_states.get(label) {
-            None => return 0,
-            Some(state) => state,
+        let Some(state) = self.schedule_states.get(label) else {
+            return 0;
         };
         state.first.unwrap_or(0)
     }

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -313,7 +313,7 @@ impl<'w, 's> Commands<'w, 's> {
     /// - [`spawn_batch`](Self::spawn_batch) to spawn many entities
     ///   with the same combination of components.
     #[track_caller]
-    pub fn spawn_empty(&mut self) -> EntityCommands {
+    pub fn spawn_empty(&mut self) -> EntityCommands<'_> {
         let entity = self.entities.reserve_entity();
         let mut entity_commands = EntityCommands {
             entity,
@@ -375,7 +375,7 @@ impl<'w, 's> Commands<'w, 's> {
     /// - [`spawn_batch`](Self::spawn_batch) to spawn many entities
     ///   with the same combination of components.
     #[track_caller]
-    pub fn spawn<T: Bundle>(&mut self, bundle: T) -> EntityCommands {
+    pub fn spawn<T: Bundle>(&mut self, bundle: T) -> EntityCommands<'_> {
         let entity = self.entities.reserve_entity();
         let mut entity_commands = EntityCommands {
             entity,
@@ -436,7 +436,7 @@ impl<'w, 's> Commands<'w, 's> {
     /// - [`get_entity`](Self::get_entity) for the fallible version.
     #[inline]
     #[track_caller]
-    pub fn entity(&mut self, entity: Entity) -> EntityCommands {
+    pub fn entity(&mut self, entity: Entity) -> EntityCommands<'_> {
         EntityCommands {
             entity,
             commands: self.reborrow(),
@@ -487,7 +487,7 @@ impl<'w, 's> Commands<'w, 's> {
     pub fn get_entity(
         &mut self,
         entity: Entity,
-    ) -> Result<EntityCommands, EntityDoesNotExistError> {
+    ) -> Result<EntityCommands<'_>, EntityDoesNotExistError> {
         if self.entities.contains(entity) {
             Ok(EntityCommands {
                 entity,
@@ -1120,7 +1120,7 @@ impl<'w, 's> Commands<'w, 's> {
     pub fn add_observer<E: Event, B: Bundle, M>(
         &mut self,
         observer: impl IntoObserverSystem<E, B, M>,
-    ) -> EntityCommands {
+    ) -> EntityCommands<'_> {
         self.spawn(Observer::new(observer))
     }
 
@@ -1269,7 +1269,7 @@ impl<'a> EntityCommands<'a> {
     /// Returns an [`EntityCommands`] with a smaller lifetime.
     ///
     /// This is useful if you have `&mut EntityCommands` but you need `EntityCommands`.
-    pub fn reborrow(&mut self) -> EntityCommands {
+    pub fn reborrow(&mut self) -> EntityCommands<'_> {
         EntityCommands {
             entity: self.entity,
             commands: self.commands.reborrow(),
@@ -1319,7 +1319,7 @@ impl<'a> EntityCommands<'a> {
     ///
     /// # bevy_ecs::system::assert_is_system(level_up_system);
     /// ```
-    pub fn entry<T: Component>(&mut self) -> EntityEntryCommands<T> {
+    pub fn entry<T: Component>(&mut self) -> EntityEntryCommands<'_, T> {
         EntityEntryCommands {
             entity_commands: self.reborrow(),
             marker: PhantomData,
@@ -1982,7 +1982,7 @@ impl<'a> EntityCommands<'a> {
     }
 
     /// Returns the underlying [`Commands`].
-    pub fn commands(&mut self) -> Commands {
+    pub fn commands(&mut self) -> Commands<'_, '_> {
         self.commands.reborrow()
     }
 
@@ -2381,7 +2381,7 @@ impl<'a, T: Component> EntityEntryCommands<'a, T> {
     /// }
     /// # bevy_ecs::system::assert_is_system(level_up_system);
     /// ```
-    pub fn entity(&mut self) -> EntityCommands {
+    pub fn entity(&mut self) -> EntityCommands<'_> {
         self.entity_commands.reborrow()
     }
 }

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1270,7 +1270,7 @@ impl<'a, T: SystemBuffer> DerefMut for Deferred<'a, T> {
 impl<T: SystemBuffer> Deferred<'_, T> {
     /// Returns a [`Deferred<T>`] with a smaller lifetime.
     /// This is useful if you have `&mut Deferred<T>` but need `Deferred<T>`.
-    pub fn reborrow(&mut self) -> Deferred<T> {
+    pub fn reborrow(&mut self) -> Deferred<'_, T> {
         Deferred(self.0)
     }
 }

--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -62,13 +62,13 @@ impl<'w> From<&'w mut World> for DeferredWorld<'w> {
 impl<'w> DeferredWorld<'w> {
     /// Reborrow self as a new instance of [`DeferredWorld`]
     #[inline]
-    pub fn reborrow(&mut self) -> DeferredWorld {
+    pub fn reborrow(&mut self) -> DeferredWorld<'_> {
         DeferredWorld { world: self.world }
     }
 
     /// Creates a [`Commands`] instance that pushes to the world's command queue
     #[inline]
-    pub fn commands(&mut self) -> Commands {
+    pub fn commands(&mut self) -> Commands<'_, '_> {
         // SAFETY: &mut self ensure that there are no outstanding accesses to the queue
         let command_queue = unsafe { self.world.get_raw_command_queue() };
         // SAFETY: command_queue is stored on world and always valid while the world exists
@@ -81,7 +81,7 @@ impl<'w> DeferredWorld<'w> {
     pub fn get_mut<T: Component<Mutability = Mutable>>(
         &mut self,
         entity: Entity,
-    ) -> Option<Mut<T>> {
+    ) -> Option<Mut<'_, T>> {
         self.get_entity_mut(entity).ok()?.into_mut()
     }
 
@@ -418,7 +418,7 @@ impl<'w> DeferredWorld<'w> {
     /// # assert_eq!(_world.get::<TargetedBy>(e1).unwrap().0, eid);
     /// # assert_eq!(_world.get::<TargetedBy>(e2).unwrap().0, eid);
     /// ```
-    pub fn entities_and_commands(&mut self) -> (EntityFetcher, Commands) {
+    pub fn entities_and_commands(&mut self) -> (EntityFetcher<'_>, Commands<'_, '_>) {
         let cell = self.as_unsafe_world_cell();
         // SAFETY: `&mut self` gives mutable access to the entire world, and prevents simultaneous access.
         let fetcher = unsafe { EntityFetcher::new(cell) };
@@ -887,7 +887,7 @@ impl<'w> DeferredWorld<'w> {
     /// # Safety
     /// - must only be used to make non-structural ECS changes
     #[inline]
-    pub(crate) fn as_unsafe_world_cell(&mut self) -> UnsafeWorldCell {
+    pub(crate) fn as_unsafe_world_cell(&mut self) -> UnsafeWorldCell<'_> {
         self.world
     }
 }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -232,14 +232,14 @@ impl World {
     /// **NOTE:** [`ComponentsQueuedRegistrator`] is easily misused.
     /// See its docs for important notes on when and how it should be used.
     #[inline]
-    pub fn components_queue(&self) -> ComponentsQueuedRegistrator {
+    pub fn components_queue(&self) -> ComponentsQueuedRegistrator<'_> {
         // SAFETY: These are from the same world.
         unsafe { ComponentsQueuedRegistrator::new(&self.components, &self.component_ids) }
     }
 
     /// Prepares a [`ComponentsRegistrator`] for the world.
     #[inline]
-    pub fn components_registrator(&mut self) -> ComponentsRegistrator {
+    pub fn components_registrator(&mut self) -> ComponentsRegistrator<'_> {
         // SAFETY: These are from the same world.
         unsafe { ComponentsRegistrator::new(&mut self.components, &mut self.component_ids) }
     }
@@ -271,7 +271,7 @@ impl World {
     /// Creates a new [`Commands`] instance that writes to the world's command queue
     /// Use [`World::flush`] to apply all queued commands
     #[inline]
-    pub fn commands(&mut self) -> Commands {
+    pub fn commands(&mut self) -> Commands<'_, '_> {
         // SAFETY: command_queue is stored on world and always valid while the world exists
         unsafe { Commands::new_raw_from_entities(self.command_queue.clone(), &self.entities) }
     }
@@ -1047,7 +1047,7 @@ impl World {
     /// # assert_eq!(world.get::<TargetedBy>(e1).unwrap().0, eid);
     /// # assert_eq!(world.get::<TargetedBy>(e2).unwrap().0, eid);
     /// ```
-    pub fn entities_and_commands(&mut self) -> (EntityFetcher, Commands) {
+    pub fn entities_and_commands(&mut self) -> (EntityFetcher<'_>, Commands<'_, '_>) {
         let cell = self.as_unsafe_world_cell();
         // SAFETY: `&mut self` gives mutable access to the entire world, and prevents simultaneous access.
         let fetcher = unsafe { EntityFetcher::new(cell) };
@@ -1087,7 +1087,7 @@ impl World {
     /// assert_eq!(position.x, 0.0);
     /// ```
     #[track_caller]
-    pub fn spawn_empty(&mut self) -> EntityWorldMut {
+    pub fn spawn_empty(&mut self) -> EntityWorldMut<'_> {
         self.flush();
         let entity = self.entities.alloc();
         // SAFETY: entity was just allocated
@@ -1155,7 +1155,7 @@ impl World {
     /// assert_eq!(position.x, 2.0);
     /// ```
     #[track_caller]
-    pub fn spawn<B: Bundle>(&mut self, bundle: B) -> EntityWorldMut {
+    pub fn spawn<B: Bundle>(&mut self, bundle: B) -> EntityWorldMut<'_> {
         self.spawn_with_caller(bundle, MaybeLocation::caller())
     }
 
@@ -1163,7 +1163,7 @@ impl World {
         &mut self,
         bundle: B,
         caller: MaybeLocation,
-    ) -> EntityWorldMut {
+    ) -> EntityWorldMut<'_> {
         self.flush();
         let change_tick = self.change_tick();
         let entity = self.entities.alloc();
@@ -1192,7 +1192,7 @@ impl World {
         &mut self,
         entity: Entity,
         caller: MaybeLocation,
-    ) -> EntityWorldMut {
+    ) -> EntityWorldMut<'_> {
         let archetype = self.archetypes.empty_mut();
         // PERF: consider avoiding allocating entities in the empty archetype unless needed
         let table_row = self.storages.tables[archetype.table_id()].allocate(entity);
@@ -1279,7 +1279,7 @@ impl World {
     pub fn get_mut<T: Component<Mutability = Mutable>>(
         &mut self,
         entity: Entity,
-    ) -> Option<Mut<T>> {
+    ) -> Option<Mut<'_, T>> {
         self.get_entity_mut(entity).ok()?.into_mut()
     }
 
@@ -1980,7 +1980,7 @@ impl World {
     /// use [`get_resource_or_insert_with`](World::get_resource_or_insert_with).
     #[inline]
     #[track_caller]
-    pub fn resource_ref<R: Resource>(&self) -> Ref<R> {
+    pub fn resource_ref<R: Resource>(&self) -> Ref<'_, R> {
         match self.get_resource_ref() {
             Some(x) => x,
             None => panic!(
@@ -2028,7 +2028,7 @@ impl World {
 
     /// Gets a reference including change detection to the resource of the given type if it exists.
     #[inline]
-    pub fn get_resource_ref<R: Resource>(&self) -> Option<Ref<R>> {
+    pub fn get_resource_ref<R: Resource>(&self) -> Option<Ref<'_, R>> {
         // SAFETY:
         // - `as_unsafe_world_cell_readonly` gives permission to access everything immutably
         // - `&self` ensures nothing in world is borrowed mutably

--- a/crates/bevy_feathers/src/controls/color_slider.rs
+++ b/crates/bevy_feathers/src/controls/color_slider.rs
@@ -328,34 +328,31 @@ fn update_track_color(
                 cap_bg.0 = start;
             }
 
-            if let Ok(mut gradient) = q_gradient.get_mut(track_children[1]) {
-                if let [Gradient::Linear(linear_gradient)] = &mut gradient.0[..] {
-                    linear_gradient.stops[0].color = start;
-                    linear_gradient.stops[1].color = middle;
-                    linear_gradient.stops[2].color = end;
-                    linear_gradient.color_space = match slider.channel {
-                        ColorChannel::Red | ColorChannel::Green | ColorChannel::Blue => {
+            if let Ok(mut gradient) = q_gradient.get_mut(track_children[1])
+                && let [Gradient::Linear(linear_gradient)] = &mut gradient.0[..]
+            {
+                linear_gradient.stops[0].color = start;
+                linear_gradient.stops[1].color = middle;
+                linear_gradient.stops[2].color = end;
+                linear_gradient.color_space = match slider.channel {
+                    ColorChannel::Red | ColorChannel::Green | ColorChannel::Blue => {
+                        InterpolationColorSpace::Srgba
+                    }
+                    ColorChannel::HslHue
+                    | ColorChannel::HslLightness
+                    | ColorChannel::HslSaturation => InterpolationColorSpace::Hsla,
+                    ColorChannel::Alpha => match base_color {
+                        Color::Srgba(_) => InterpolationColorSpace::Srgba,
+                        Color::LinearRgba(_) => InterpolationColorSpace::LinearRgba,
+                        Color::Oklaba(_) => InterpolationColorSpace::Oklaba,
+                        Color::Oklcha(_) => InterpolationColorSpace::OklchaLong,
+                        Color::Hsla(_) | Color::Hsva(_) => InterpolationColorSpace::Hsla,
+                        _ => {
+                            warn_once!("Unsupported color space for ColorSlider: {:?}", base_color);
                             InterpolationColorSpace::Srgba
                         }
-                        ColorChannel::HslHue
-                        | ColorChannel::HslLightness
-                        | ColorChannel::HslSaturation => InterpolationColorSpace::Hsla,
-                        ColorChannel::Alpha => match base_color {
-                            Color::Srgba(_) => InterpolationColorSpace::Srgba,
-                            Color::LinearRgba(_) => InterpolationColorSpace::LinearRgba,
-                            Color::Oklaba(_) => InterpolationColorSpace::Oklaba,
-                            Color::Oklcha(_) => InterpolationColorSpace::OklchaLong,
-                            Color::Hsla(_) | Color::Hsva(_) => InterpolationColorSpace::Hsla,
-                            _ => {
-                                warn_once!(
-                                    "Unsupported color space for ColorSlider: {:?}",
-                                    base_color
-                                );
-                                InterpolationColorSpace::Srgba
-                            }
-                        },
-                    };
-                }
+                    },
+                };
             }
 
             if let Ok(mut cap_bg) = q_background.get_mut(track_children[2]) {

--- a/crates/bevy_feathers/src/cursor.rs
+++ b/crates/bevy_feathers/src/cursor.rs
@@ -93,10 +93,10 @@ pub(crate) fn update_cursor(
         .unwrap_or(&r_default_cursor.0);
 
     for (entity, prev_cursor) in q_windows.iter() {
-        if let Some(prev_cursor) = prev_cursor {
-            if cursor.eq_cursor_icon(prev_cursor) {
-                continue;
-            }
+        if let Some(prev_cursor) = prev_cursor
+            && cursor.eq_cursor_icon(prev_cursor)
+        {
+            continue;
         }
         commands.entity(entity).insert(cursor.to_cursor_icon());
     }

--- a/crates/bevy_feathers/src/font_styles.rs
+++ b/crates/bevy_feathers/src/font_styles.rs
@@ -50,16 +50,16 @@ pub(crate) fn on_changed_font(
     assets: Res<AssetServer>,
     mut commands: Commands,
 ) {
-    if let Ok(style) = font_style.get(ev.target()) {
-        if let Some(font) = match style.font {
+    if let Ok(style) = font_style.get(ev.target())
+        && let Some(font) = match style.font {
             HandleOrPath::Handle(ref h) => Some(h.clone()),
             HandleOrPath::Path(ref p) => Some(assets.load::<Font>(p)),
-        } {
-            commands.entity(ev.target()).insert(Propagate(TextFont {
-                font,
-                font_size: style.font_size,
-                ..Default::default()
-            }));
         }
+    {
+        commands.entity(ev.target()).insert(Propagate(TextFont {
+            font,
+            font_size: style.font_size,
+            ..Default::default()
+        }));
     }
 }

--- a/crates/bevy_gizmos/src/gizmos.rs
+++ b/crates/bevy_gizmos/src/gizmos.rs
@@ -355,7 +355,7 @@ where
     }
 
     /// Read-only view into the buffers data.
-    pub fn buffer(&self) -> GizmoBufferView {
+    pub fn buffer(&self) -> GizmoBufferView<'_> {
         let GizmoBuffer {
             list_positions,
             list_colors,

--- a/crates/bevy_gltf/src/loader/mod.rs
+++ b/crates/bevy_gltf/src/loader/mod.rs
@@ -1462,49 +1462,49 @@ fn load_node(
     }
 
     // create camera node
-    if settings.load_cameras {
-        if let Some(camera) = gltf_node.camera() {
-            let projection = match camera.projection() {
-                gltf::camera::Projection::Orthographic(orthographic) => {
-                    let xmag = orthographic.xmag();
-                    let orthographic_projection = OrthographicProjection {
-                        near: orthographic.znear(),
-                        far: orthographic.zfar(),
-                        scaling_mode: ScalingMode::FixedHorizontal {
-                            viewport_width: xmag,
-                        },
-                        ..OrthographicProjection::default_3d()
-                    };
-                    Projection::Orthographic(orthographic_projection)
-                }
-                gltf::camera::Projection::Perspective(perspective) => {
-                    let mut perspective_projection: PerspectiveProjection = PerspectiveProjection {
-                        fov: perspective.yfov(),
-                        near: perspective.znear(),
-                        ..Default::default()
-                    };
-                    if let Some(zfar) = perspective.zfar() {
-                        perspective_projection.far = zfar;
-                    }
-                    if let Some(aspect_ratio) = perspective.aspect_ratio() {
-                        perspective_projection.aspect_ratio = aspect_ratio;
-                    }
-                    Projection::Perspective(perspective_projection)
-                }
-            };
-
-            node.insert((
-                Camera3d::default(),
-                projection,
-                transform,
-                Camera {
-                    is_active: !*active_camera_found,
+    if settings.load_cameras
+        && let Some(camera) = gltf_node.camera()
+    {
+        let projection = match camera.projection() {
+            gltf::camera::Projection::Orthographic(orthographic) => {
+                let xmag = orthographic.xmag();
+                let orthographic_projection = OrthographicProjection {
+                    near: orthographic.znear(),
+                    far: orthographic.zfar(),
+                    scaling_mode: ScalingMode::FixedHorizontal {
+                        viewport_width: xmag,
+                    },
+                    ..OrthographicProjection::default_3d()
+                };
+                Projection::Orthographic(orthographic_projection)
+            }
+            gltf::camera::Projection::Perspective(perspective) => {
+                let mut perspective_projection: PerspectiveProjection = PerspectiveProjection {
+                    fov: perspective.yfov(),
+                    near: perspective.znear(),
                     ..Default::default()
-                },
-            ));
+                };
+                if let Some(zfar) = perspective.zfar() {
+                    perspective_projection.far = zfar;
+                }
+                if let Some(aspect_ratio) = perspective.aspect_ratio() {
+                    perspective_projection.aspect_ratio = aspect_ratio;
+                }
+                Projection::Perspective(perspective_projection)
+            }
+        };
 
-            *active_camera_found = true;
-        }
+        node.insert((
+            Camera3d::default(),
+            projection,
+            transform,
+            Camera {
+                is_active: !*active_camera_found,
+                ..Default::default()
+            },
+        ));
+
+        *active_camera_found = true;
     }
 
     // Map node index to entity
@@ -1514,161 +1514,161 @@ fn load_node(
 
     node.with_children(|parent| {
         // Only include meshes in the output if they're set to be retained in the MAIN_WORLD and/or RENDER_WORLD by the load_meshes flag
-        if !settings.load_meshes.is_empty() {
-            if let Some(mesh) = gltf_node.mesh() {
-                // append primitives
-                for primitive in mesh.primitives() {
-                    let material = primitive.material();
-                    let material_label = material_label(&material, is_scale_inverted).to_string();
+        if !settings.load_meshes.is_empty()
+            && let Some(mesh) = gltf_node.mesh()
+        {
+            // append primitives
+            for primitive in mesh.primitives() {
+                let material = primitive.material();
+                let material_label = material_label(&material, is_scale_inverted).to_string();
 
-                    // This will make sure we load the default material now since it would not have been
-                    // added when iterating over all the gltf materials (since the default material is
-                    // not explicitly listed in the gltf).
-                    // It also ensures an inverted scale copy is instantiated if required.
-                    if !root_load_context.has_labeled_asset(&material_label)
-                        && !load_context.has_labeled_asset(&material_label)
-                    {
-                        load_material(&material, load_context, document, is_scale_inverted);
-                    }
+                // This will make sure we load the default material now since it would not have been
+                // added when iterating over all the gltf materials (since the default material is
+                // not explicitly listed in the gltf).
+                // It also ensures an inverted scale copy is instantiated if required.
+                if !root_load_context.has_labeled_asset(&material_label)
+                    && !load_context.has_labeled_asset(&material_label)
+                {
+                    load_material(&material, load_context, document, is_scale_inverted);
+                }
 
-                    let primitive_label = GltfAssetLabel::Primitive {
-                        mesh: mesh.index(),
-                        primitive: primitive.index(),
+                let primitive_label = GltfAssetLabel::Primitive {
+                    mesh: mesh.index(),
+                    primitive: primitive.index(),
+                };
+                let bounds = primitive.bounding_box();
+
+                let mut mesh_entity = parent.spawn((
+                    // TODO: handle missing label handle errors here?
+                    Mesh3d(load_context.get_label_handle(primitive_label.to_string())),
+                    MeshMaterial3d::<StandardMaterial>(
+                        load_context.get_label_handle(&material_label),
+                    ),
+                ));
+
+                let target_count = primitive.morph_targets().len();
+                if target_count != 0 {
+                    let weights = match mesh.weights() {
+                        Some(weights) => weights.to_vec(),
+                        None => vec![0.0; target_count],
                     };
-                    let bounds = primitive.bounding_box();
 
-                    let mut mesh_entity = parent.spawn((
-                        // TODO: handle missing label handle errors here?
-                        Mesh3d(load_context.get_label_handle(primitive_label.to_string())),
-                        MeshMaterial3d::<StandardMaterial>(
-                            load_context.get_label_handle(&material_label),
-                        ),
-                    ));
-
-                    let target_count = primitive.morph_targets().len();
-                    if target_count != 0 {
-                        let weights = match mesh.weights() {
-                            Some(weights) => weights.to_vec(),
-                            None => vec![0.0; target_count],
-                        };
-
-                        if morph_weights.is_none() {
-                            morph_weights = Some(weights.clone());
-                        }
-
-                        // unwrap: the parent's call to `MeshMorphWeights::new`
-                        // means this code doesn't run if it returns an `Err`.
-                        // According to https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#morph-targets
-                        // they should all have the same length.
-                        // > All morph target accessors MUST have the same count as
-                        // > the accessors of the original primitive.
-                        mesh_entity.insert(MeshMorphWeights::new(weights).unwrap());
-                    }
-                    mesh_entity.insert(Aabb::from_min_max(
-                        Vec3::from_slice(&bounds.min),
-                        Vec3::from_slice(&bounds.max),
-                    ));
-
-                    if let Some(extras) = primitive.extras() {
-                        mesh_entity.insert(GltfExtras {
-                            value: extras.get().to_string(),
-                        });
+                    if morph_weights.is_none() {
+                        morph_weights = Some(weights.clone());
                     }
 
-                    if let Some(extras) = mesh.extras() {
-                        mesh_entity.insert(GltfMeshExtras {
-                            value: extras.get().to_string(),
-                        });
-                    }
+                    // unwrap: the parent's call to `MeshMorphWeights::new`
+                    // means this code doesn't run if it returns an `Err`.
+                    // According to https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#morph-targets
+                    // they should all have the same length.
+                    // > All morph target accessors MUST have the same count as
+                    // > the accessors of the original primitive.
+                    mesh_entity.insert(MeshMorphWeights::new(weights).unwrap());
+                }
+                mesh_entity.insert(Aabb::from_min_max(
+                    Vec3::from_slice(&bounds.min),
+                    Vec3::from_slice(&bounds.max),
+                ));
 
-                    if let Some(extras) = material.extras() {
-                        mesh_entity.insert(GltfMaterialExtras {
-                            value: extras.get().to_string(),
-                        });
-                    }
+                if let Some(extras) = primitive.extras() {
+                    mesh_entity.insert(GltfExtras {
+                        value: extras.get().to_string(),
+                    });
+                }
 
-                    if let Some(name) = mesh.name() {
-                        mesh_entity.insert(GltfMeshName(name.to_string()));
-                    }
+                if let Some(extras) = mesh.extras() {
+                    mesh_entity.insert(GltfMeshExtras {
+                        value: extras.get().to_string(),
+                    });
+                }
 
-                    if let Some(name) = material.name() {
-                        mesh_entity.insert(GltfMaterialName(name.to_string()));
-                    }
+                if let Some(extras) = material.extras() {
+                    mesh_entity.insert(GltfMaterialExtras {
+                        value: extras.get().to_string(),
+                    });
+                }
 
-                    mesh_entity.insert(Name::new(primitive_name(&mesh, &material)));
+                if let Some(name) = mesh.name() {
+                    mesh_entity.insert(GltfMeshName(name.to_string()));
+                }
 
-                    // Mark for adding skinned mesh
-                    if let Some(skin) = gltf_node.skin() {
-                        entity_to_skin_index_map.insert(mesh_entity.id(), skin.index());
-                    }
+                if let Some(name) = material.name() {
+                    mesh_entity.insert(GltfMaterialName(name.to_string()));
+                }
+
+                mesh_entity.insert(Name::new(primitive_name(&mesh, &material)));
+
+                // Mark for adding skinned mesh
+                if let Some(skin) = gltf_node.skin() {
+                    entity_to_skin_index_map.insert(mesh_entity.id(), skin.index());
                 }
             }
         }
 
-        if settings.load_lights {
-            if let Some(light) = gltf_node.light() {
-                match light.kind() {
-                    gltf::khr_lights_punctual::Kind::Directional => {
-                        let mut entity = parent.spawn(DirectionalLight {
-                            color: Color::srgb_from_array(light.color()),
-                            // NOTE: KHR_punctual_lights defines the intensity units for directional
-                            // lights in lux (lm/m^2) which is what we need.
-                            illuminance: light.intensity(),
-                            ..Default::default()
-                        });
-                        if let Some(name) = light.name() {
-                            entity.insert(Name::new(name.to_string()));
-                        }
-                        if let Some(extras) = light.extras() {
-                            entity.insert(GltfExtras {
-                                value: extras.get().to_string(),
-                            });
-                        }
+        if settings.load_lights
+            && let Some(light) = gltf_node.light()
+        {
+            match light.kind() {
+                gltf::khr_lights_punctual::Kind::Directional => {
+                    let mut entity = parent.spawn(DirectionalLight {
+                        color: Color::srgb_from_array(light.color()),
+                        // NOTE: KHR_punctual_lights defines the intensity units for directional
+                        // lights in lux (lm/m^2) which is what we need.
+                        illuminance: light.intensity(),
+                        ..Default::default()
+                    });
+                    if let Some(name) = light.name() {
+                        entity.insert(Name::new(name.to_string()));
                     }
-                    gltf::khr_lights_punctual::Kind::Point => {
-                        let mut entity = parent.spawn(PointLight {
-                            color: Color::srgb_from_array(light.color()),
-                            // NOTE: KHR_punctual_lights defines the intensity units for point lights in
-                            // candela (lm/sr) which is luminous intensity and we need luminous power.
-                            // For a point light, luminous power = 4 * pi * luminous intensity
-                            intensity: light.intensity() * core::f32::consts::PI * 4.0,
-                            range: light.range().unwrap_or(20.0),
-                            radius: 0.0,
-                            ..Default::default()
+                    if let Some(extras) = light.extras() {
+                        entity.insert(GltfExtras {
+                            value: extras.get().to_string(),
                         });
-                        if let Some(name) = light.name() {
-                            entity.insert(Name::new(name.to_string()));
-                        }
-                        if let Some(extras) = light.extras() {
-                            entity.insert(GltfExtras {
-                                value: extras.get().to_string(),
-                            });
-                        }
                     }
-                    gltf::khr_lights_punctual::Kind::Spot {
-                        inner_cone_angle,
-                        outer_cone_angle,
-                    } => {
-                        let mut entity = parent.spawn(SpotLight {
-                            color: Color::srgb_from_array(light.color()),
-                            // NOTE: KHR_punctual_lights defines the intensity units for spot lights in
-                            // candela (lm/sr) which is luminous intensity and we need luminous power.
-                            // For a spot light, we map luminous power = 4 * pi * luminous intensity
-                            intensity: light.intensity() * core::f32::consts::PI * 4.0,
-                            range: light.range().unwrap_or(20.0),
-                            radius: light.range().unwrap_or(0.0),
-                            inner_angle: inner_cone_angle,
-                            outer_angle: outer_cone_angle,
-                            ..Default::default()
+                }
+                gltf::khr_lights_punctual::Kind::Point => {
+                    let mut entity = parent.spawn(PointLight {
+                        color: Color::srgb_from_array(light.color()),
+                        // NOTE: KHR_punctual_lights defines the intensity units for point lights in
+                        // candela (lm/sr) which is luminous intensity and we need luminous power.
+                        // For a point light, luminous power = 4 * pi * luminous intensity
+                        intensity: light.intensity() * core::f32::consts::PI * 4.0,
+                        range: light.range().unwrap_or(20.0),
+                        radius: 0.0,
+                        ..Default::default()
+                    });
+                    if let Some(name) = light.name() {
+                        entity.insert(Name::new(name.to_string()));
+                    }
+                    if let Some(extras) = light.extras() {
+                        entity.insert(GltfExtras {
+                            value: extras.get().to_string(),
                         });
-                        if let Some(name) = light.name() {
-                            entity.insert(Name::new(name.to_string()));
-                        }
-                        if let Some(extras) = light.extras() {
-                            entity.insert(GltfExtras {
-                                value: extras.get().to_string(),
-                            });
-                        }
+                    }
+                }
+                gltf::khr_lights_punctual::Kind::Spot {
+                    inner_cone_angle,
+                    outer_cone_angle,
+                } => {
+                    let mut entity = parent.spawn(SpotLight {
+                        color: Color::srgb_from_array(light.color()),
+                        // NOTE: KHR_punctual_lights defines the intensity units for spot lights in
+                        // candela (lm/sr) which is luminous intensity and we need luminous power.
+                        // For a spot light, we map luminous power = 4 * pi * luminous intensity
+                        intensity: light.intensity() * core::f32::consts::PI * 4.0,
+                        range: light.range().unwrap_or(20.0),
+                        radius: light.range().unwrap_or(0.0),
+                        inner_angle: inner_cone_angle,
+                        outer_angle: outer_cone_angle,
+                        ..Default::default()
+                    });
+                    if let Some(name) = light.name() {
+                        entity.insert(Name::new(name.to_string()));
+                    }
+                    if let Some(extras) = light.extras() {
+                        entity.insert(GltfExtras {
+                            value: extras.get().to_string(),
+                        });
                     }
                 }
             }
@@ -1700,16 +1700,16 @@ fn load_node(
     });
 
     // Only include meshes in the output if they're set to be retained in the MAIN_WORLD and/or RENDER_WORLD by the load_meshes flag
-    if !settings.load_meshes.is_empty() {
-        if let (Some(mesh), Some(weights)) = (gltf_node.mesh(), morph_weights) {
-            let primitive_label = mesh.primitives().next().map(|p| GltfAssetLabel::Primitive {
-                mesh: mesh.index(),
-                primitive: p.index(),
-            });
-            let first_mesh =
-                primitive_label.map(|label| load_context.get_label_handle(label.to_string()));
-            node.insert(MorphWeights::new(weights, first_mesh)?);
-        }
+    if !settings.load_meshes.is_empty()
+        && let (Some(mesh), Some(weights)) = (gltf_node.mesh(), morph_weights)
+    {
+        let primitive_label = mesh.primitives().next().map(|p| GltfAssetLabel::Primitive {
+            mesh: mesh.index(),
+            primitive: p.index(),
+        });
+        let first_mesh =
+            primitive_label.map(|label| load_context.get_label_handle(label.to_string()));
+        node.insert(MorphWeights::new(weights, first_mesh)?);
     }
 
     if let Some(err) = gltf_error {

--- a/crates/bevy_image/src/basis.rs
+++ b/crates/bevy_image/src/basis.rs
@@ -53,12 +53,12 @@ pub fn basis_buffer_to_image(
 
     let image0_mip_level_count = transcoder.image_level_count(buffer, 0);
     for image_index in 0..image_count {
-        if let Some(image_info) = transcoder.image_info(buffer, image_index) {
-            if texture_type == BasisTextureType::TextureType2D
-                && (image_info.m_orig_width != image0_info.m_orig_width
-                    || image_info.m_orig_height != image0_info.m_orig_height)
-            {
-                return Err(TextureError::UnsupportedTextureFormat(format!(
+        if let Some(image_info) = transcoder.image_info(buffer, image_index)
+            && texture_type == BasisTextureType::TextureType2D
+            && (image_info.m_orig_width != image0_info.m_orig_width
+                || image_info.m_orig_height != image0_info.m_orig_height)
+        {
+            return Err(TextureError::UnsupportedTextureFormat(format!(
                     "Basis file with multiple 2D textures with different sizes not supported. Image {} {}x{}, image 0 {}x{}",
                     image_index,
                     image_info.m_orig_width,
@@ -66,7 +66,6 @@ pub fn basis_buffer_to_image(
                     image0_info.m_orig_width,
                     image0_info.m_orig_height,
                 )));
-            }
         }
         let mip_level_count = transcoder.image_level_count(buffer, image_index);
         if mip_level_count != image0_mip_level_count {

--- a/crates/bevy_macro_utils/src/bevy_manifest.rs
+++ b/crates/bevy_macro_utils/src/bevy_manifest.rs
@@ -29,10 +29,9 @@ impl BevyManifest {
 
         if let Ok(manifest) =
             RwLockReadGuard::try_map(MANIFESTS.read(), |manifests| manifests.get(&manifest_path))
+            && manifest.modified_time == modified_time
         {
-            if manifest.modified_time == modified_time {
-                return manifest;
-            }
+            return manifest;
         }
 
         let manifest = BevyManifest {

--- a/crates/bevy_math/src/cubic_splines/mod.rs
+++ b/crates/bevy_math/src/cubic_splines/mod.rs
@@ -1605,7 +1605,7 @@ impl<P: VectorSpace<Scalar = f32>> RationalCurve<P> {
                 }
                 t -= segment.knot_span;
             }
-            return (self.segments.last().unwrap(), 1.0);
+            (self.segments.last().unwrap(), 1.0)
         }
     }
 

--- a/crates/bevy_mesh/src/conversions.rs
+++ b/crates/bevy_mesh/src/conversions.rs
@@ -445,9 +445,8 @@ mod tests {
         let buffer = vec![[0_u32; 4]; 3];
         let values = VertexAttributeValues::from(buffer);
         let error_result: Result<Vec<u32>, _> = values.try_into();
-        let error = match error_result {
-            Ok(..) => unreachable!(),
-            Err(error) => error,
+        let Err(error) = error_result else {
+            unreachable!()
         };
         assert_eq!(
             error.to_string(),

--- a/crates/bevy_pbr/src/cluster.rs
+++ b/crates/bevy_pbr/src/cluster.rs
@@ -216,7 +216,7 @@ impl GpuClusterableObjects {
         }
     }
 
-    pub fn binding(&self) -> Option<BindingResource> {
+    pub fn binding(&self) -> Option<BindingResource<'_>> {
         match self {
             GpuClusterableObjects::Uniform(buffer) => buffer.binding(),
             GpuClusterableObjects::Storage(buffer) => buffer.binding(),
@@ -456,7 +456,7 @@ impl ViewClusterBindings {
         }
     }
 
-    pub fn clusterable_object_index_lists_binding(&self) -> Option<BindingResource> {
+    pub fn clusterable_object_index_lists_binding(&self) -> Option<BindingResource<'_>> {
         match &self.buffers {
             ViewClusterBuffers::Uniform {
                 clusterable_object_index_lists,
@@ -469,7 +469,7 @@ impl ViewClusterBindings {
         }
     }
 
-    pub fn offsets_and_counts_binding(&self) -> Option<BindingResource> {
+    pub fn offsets_and_counts_binding(&self) -> Option<BindingResource<'_>> {
         match &self.buffers {
             ViewClusterBuffers::Uniform {
                 cluster_offsets_and_counts,

--- a/crates/bevy_pbr/src/light_probe/environment_map.rs
+++ b/crates/bevy_pbr/src/light_probe/environment_map.rs
@@ -215,18 +215,16 @@ impl<'a> RenderViewEnvironmentMapBindGroupEntries<'a> {
             };
         }
 
-        if let Some(environment_maps) = render_view_environment_maps {
-            if let Some(cubemap) = environment_maps.binding_index_to_textures.first() {
-                if let (Some(diffuse_image), Some(specular_image)) =
-                    (images.get(cubemap.diffuse), images.get(cubemap.specular))
-                {
-                    return RenderViewEnvironmentMapBindGroupEntries::Single {
-                        diffuse_texture_view: &diffuse_image.texture_view,
-                        specular_texture_view: &specular_image.texture_view,
-                        sampler: &diffuse_image.sampler,
-                    };
-                }
-            }
+        if let Some(environment_maps) = render_view_environment_maps
+            && let Some(cubemap) = environment_maps.binding_index_to_textures.first()
+            && let (Some(diffuse_image), Some(specular_image)) =
+                (images.get(cubemap.diffuse), images.get(cubemap.specular))
+        {
+            return RenderViewEnvironmentMapBindGroupEntries::Single {
+                diffuse_texture_view: &diffuse_image.texture_view,
+                specular_texture_view: &specular_image.texture_view,
+                sampler: &diffuse_image.sampler,
+            };
         }
 
         RenderViewEnvironmentMapBindGroupEntries::Single {
@@ -280,23 +278,20 @@ impl LightProbeComponent for EnvironmentMapLight {
             affects_lightmapped_mesh_diffuse,
             ..
         }) = view_component
-        {
-            if let (Some(_), Some(specular_map)) = (
+            && let (Some(_), Some(specular_map)) = (
                 image_assets.get(diffuse_map_handle),
                 image_assets.get(specular_map_handle),
-            ) {
-                render_view_light_probes.view_light_probe_info = EnvironmentMapViewLightProbeInfo {
-                    cubemap_index: render_view_light_probes.get_or_insert_cubemap(
-                        &EnvironmentMapIds {
-                            diffuse: diffuse_map_handle.id(),
-                            specular: specular_map_handle.id(),
-                        },
-                    ) as i32,
-                    smallest_specular_mip_level: specular_map.mip_level_count - 1,
-                    intensity: *intensity,
-                    affects_lightmapped_mesh_diffuse: *affects_lightmapped_mesh_diffuse,
-                };
-            }
+            )
+        {
+            render_view_light_probes.view_light_probe_info = EnvironmentMapViewLightProbeInfo {
+                cubemap_index: render_view_light_probes.get_or_insert_cubemap(&EnvironmentMapIds {
+                    diffuse: diffuse_map_handle.id(),
+                    specular: specular_map_handle.id(),
+                }) as i32,
+                smallest_specular_mip_level: specular_map.mip_level_count - 1,
+                intensity: *intensity,
+                affects_lightmapped_mesh_diffuse: *affects_lightmapped_mesh_diffuse,
+            };
         };
 
         render_view_light_probes

--- a/crates/bevy_pbr/src/light_probe/irradiance_volume.rs
+++ b/crates/bevy_pbr/src/light_probe/irradiance_volume.rs
@@ -253,22 +253,18 @@ impl<'a> RenderViewIrradianceVolumeBindGroupEntries<'a> {
         images: &'a RenderAssets<GpuImage>,
         fallback_image: &'a FallbackImage,
     ) -> RenderViewIrradianceVolumeBindGroupEntries<'a> {
-        if let Some(irradiance_volumes) = render_view_irradiance_volumes {
-            if let Some(irradiance_volume) = irradiance_volumes.render_light_probes.first() {
-                if irradiance_volume.texture_index >= 0 {
-                    if let Some(image_id) = irradiance_volumes
-                        .binding_index_to_textures
-                        .get(irradiance_volume.texture_index as usize)
-                    {
-                        if let Some(image) = images.get(*image_id) {
-                            return RenderViewIrradianceVolumeBindGroupEntries::Single {
-                                texture_view: &image.texture_view,
-                                sampler: &image.sampler,
-                            };
-                        }
-                    }
-                }
-            }
+        if let Some(irradiance_volumes) = render_view_irradiance_volumes
+            && let Some(irradiance_volume) = irradiance_volumes.render_light_probes.first()
+            && irradiance_volume.texture_index >= 0
+            && let Some(image_id) = irradiance_volumes
+                .binding_index_to_textures
+                .get(irradiance_volume.texture_index as usize)
+            && let Some(image) = images.get(*image_id)
+        {
+            return RenderViewIrradianceVolumeBindGroupEntries::Single {
+                texture_view: &image.texture_view,
+                sampler: &image.sampler,
+            };
         }
 
         RenderViewIrradianceVolumeBindGroupEntries::Single {

--- a/crates/bevy_pbr/src/material_bind_groups.rs
+++ b/crates/bevy_pbr/src/material_bind_groups.rs
@@ -478,7 +478,7 @@ impl MaterialBindGroupAllocator {
     }
 
     /// Returns the slab with the given index, if one exists.
-    pub fn get(&self, group: MaterialBindGroupIndex) -> Option<MaterialSlab> {
+    pub fn get(&self, group: MaterialBindGroupIndex) -> Option<MaterialSlab<'_>> {
         match *self {
             MaterialBindGroupAllocator::Bindless(ref bindless_allocator) => bindless_allocator
                 .get(group)
@@ -673,7 +673,7 @@ impl MaterialBindlessIndexTable {
     }
 
     /// Returns the [`BindGroupEntry`] for the index table itself.
-    fn bind_group_entry(&self) -> BindGroupEntry {
+    fn bind_group_entry(&self) -> BindGroupEntry<'_> {
         BindGroupEntry {
             binding: *self.binding_number,
             resource: self
@@ -1837,7 +1837,7 @@ impl MaterialBindGroupNonBindlessAllocator {
     }
 
     /// Returns a wrapper around the bind group with the given index.
-    fn get(&self, group: MaterialBindGroupIndex) -> Option<MaterialNonBindlessSlab> {
+    fn get(&self, group: MaterialBindGroupIndex) -> Option<MaterialNonBindlessSlab<'_>> {
         self.bind_groups[group.0 as usize]
             .as_ref()
             .map(|bind_group| match bind_group {

--- a/crates/bevy_pbr/src/meshlet/instance_manager.rs
+++ b/crates/bevy_pbr/src/meshlet/instance_manager.rs
@@ -282,16 +282,15 @@ pub fn queue_material_meshlet_meshes(
     let instance_manager = instance_manager.deref_mut();
 
     for (i, (instance, _, _)) in instance_manager.instances.iter().enumerate() {
-        if let Some(material_instance) = render_material_instances.instances.get(instance) {
-            if let Some(material_id) = instance_manager
+        if let Some(material_instance) = render_material_instances.instances.get(instance)
+            && let Some(material_id) = instance_manager
                 .material_id_lookup
                 .get(&material_instance.asset_id)
-            {
-                instance_manager
-                    .material_ids_present_in_scene
-                    .insert(*material_id);
-                instance_manager.instance_material_ids.get_mut()[i] = *material_id;
-            }
+        {
+            instance_manager
+                .material_ids_present_in_scene
+                .insert(*material_id);
+            instance_manager.instance_material_ids.get_mut()[i] = *material_id;
         }
     }
 }

--- a/crates/bevy_pbr/src/meshlet/material_shade_nodes.rs
+++ b/crates/bevy_pbr/src/meshlet/material_shade_nodes.rs
@@ -132,15 +132,14 @@ impl ViewNode for MeshletMainOpaquePass3dNode {
         for (material_id, material_pipeline_id, material_bind_group) in
             meshlet_view_materials.iter()
         {
-            if instance_manager.material_present_in_scene(material_id) {
-                if let Some(material_pipeline) =
+            if instance_manager.material_present_in_scene(material_id)
+                && let Some(material_pipeline) =
                     pipeline_cache.get_render_pipeline(*material_pipeline_id)
-                {
-                    let x = *material_id * 3;
-                    render_pass.set_render_pipeline(material_pipeline);
-                    render_pass.set_bind_group(3, material_bind_group, &[]);
-                    render_pass.draw(x..(x + 3), 0..1);
-                }
+            {
+                let x = *material_id * 3;
+                render_pass.set_render_pipeline(material_pipeline);
+                render_pass.set_bind_group(3, material_bind_group, &[]);
+                render_pass.draw(x..(x + 3), 0..1);
             }
         }
 
@@ -265,15 +264,14 @@ impl ViewNode for MeshletPrepassNode {
         for (material_id, material_pipeline_id, material_bind_group) in
             meshlet_view_materials.iter()
         {
-            if instance_manager.material_present_in_scene(material_id) {
-                if let Some(material_pipeline) =
+            if instance_manager.material_present_in_scene(material_id)
+                && let Some(material_pipeline) =
                     pipeline_cache.get_render_pipeline(*material_pipeline_id)
-                {
-                    let x = *material_id * 3;
-                    render_pass.set_render_pipeline(material_pipeline);
-                    render_pass.set_bind_group(2, material_bind_group, &[]);
-                    render_pass.draw(x..(x + 3), 0..1);
-                }
+            {
+                let x = *material_id * 3;
+                render_pass.set_render_pipeline(material_pipeline);
+                render_pass.set_bind_group(2, material_bind_group, &[]);
+                render_pass.draw(x..(x + 3), 0..1);
             }
         }
 
@@ -404,15 +402,14 @@ impl ViewNode for MeshletDeferredGBufferPrepassNode {
         for (material_id, material_pipeline_id, material_bind_group) in
             meshlet_view_materials.iter()
         {
-            if instance_manager.material_present_in_scene(material_id) {
-                if let Some(material_pipeline) =
+            if instance_manager.material_present_in_scene(material_id)
+                && let Some(material_pipeline) =
                     pipeline_cache.get_render_pipeline(*material_pipeline_id)
-                {
-                    let x = *material_id * 3;
-                    render_pass.set_render_pipeline(material_pipeline);
-                    render_pass.set_bind_group(2, material_bind_group, &[]);
-                    render_pass.draw(x..(x + 3), 0..1);
-                }
+            {
+                let x = *material_id * 3;
+                render_pass.set_render_pipeline(material_pipeline);
+                render_pass.set_bind_group(2, material_bind_group, &[]);
+                render_pass.draw(x..(x + 3), 0..1);
             }
         }
 

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -903,7 +903,7 @@ impl RenderMeshInstances {
 
     /// Constructs [`RenderMeshQueueData`] for the given entity, if it has a
     /// mesh attached.
-    pub fn render_mesh_queue_data(&self, entity: MainEntity) -> Option<RenderMeshQueueData> {
+    pub fn render_mesh_queue_data(&self, entity: MainEntity) -> Option<RenderMeshQueueData<'_>> {
         match *self {
             RenderMeshInstances::CpuBuilding(ref instances) => {
                 instances.render_mesh_queue_data(entity)
@@ -934,7 +934,7 @@ impl RenderMeshInstancesCpu {
             .map(|render_mesh_instance| render_mesh_instance.mesh_asset_id)
     }
 
-    fn render_mesh_queue_data(&self, entity: MainEntity) -> Option<RenderMeshQueueData> {
+    fn render_mesh_queue_data(&self, entity: MainEntity) -> Option<RenderMeshQueueData<'_>> {
         self.get(&entity)
             .map(|render_mesh_instance| RenderMeshQueueData {
                 shared: &render_mesh_instance.shared,
@@ -958,7 +958,7 @@ impl RenderMeshInstancesGpu {
             .map(|render_mesh_instance| render_mesh_instance.mesh_asset_id)
     }
 
-    fn render_mesh_queue_data(&self, entity: MainEntity) -> Option<RenderMeshQueueData> {
+    fn render_mesh_queue_data(&self, entity: MainEntity) -> Option<RenderMeshQueueData<'_>> {
         self.get(&entity)
             .map(|render_mesh_instance| RenderMeshQueueData {
                 shared: &render_mesh_instance.shared,

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -2712,27 +2712,26 @@ pub fn prepare_mesh_bind_groups(
     mut render_lightmaps: ResMut<RenderLightmaps>,
 ) {
     // CPU mesh preprocessing path.
-    if let Some(cpu_batched_instance_buffer) = cpu_batched_instance_buffer {
-        if let Some(instance_data_binding) = cpu_batched_instance_buffer
+    if let Some(cpu_batched_instance_buffer) = cpu_batched_instance_buffer
+        && let Some(instance_data_binding) = cpu_batched_instance_buffer
             .into_inner()
             .instance_data_binding()
-        {
-            // In this path, we only have a single set of bind groups for all phases.
-            let cpu_preprocessing_mesh_bind_groups = prepare_mesh_bind_groups_for_phase(
-                instance_data_binding,
-                &meshes,
-                &mesh_pipeline,
-                &render_device,
-                &skins_uniform,
-                &weights_uniform,
-                &mut render_lightmaps,
-            );
+    {
+        // In this path, we only have a single set of bind groups for all phases.
+        let cpu_preprocessing_mesh_bind_groups = prepare_mesh_bind_groups_for_phase(
+            instance_data_binding,
+            &meshes,
+            &mesh_pipeline,
+            &render_device,
+            &skins_uniform,
+            &weights_uniform,
+            &mut render_lightmaps,
+        );
 
-            commands.insert_resource(MeshBindGroups::CpuPreprocessing(
-                cpu_preprocessing_mesh_bind_groups,
-            ));
-            return;
-        }
+        commands.insert_resource(MeshBindGroups::CpuPreprocessing(
+            cpu_preprocessing_mesh_bind_groups,
+        ));
+        return;
     }
 
     // GPU mesh preprocessing path.
@@ -3022,11 +3021,11 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetMeshBindGroup<I> {
             dynamic_offsets[offset_count] = dynamic_offset;
             offset_count += 1;
         }
-        if let Some(current_skin_index) = current_skin_byte_offset {
-            if skins_use_uniform_buffers(&render_device) {
-                dynamic_offsets[offset_count] = current_skin_index.byte_offset;
-                offset_count += 1;
-            }
+        if let Some(current_skin_index) = current_skin_byte_offset
+            && skins_use_uniform_buffers(&render_device)
+        {
+            dynamic_offsets[offset_count] = current_skin_index.byte_offset;
+            offset_count += 1;
         }
         if let Some(current_morph_index) = current_morph_index {
             dynamic_offsets[offset_count] = current_morph_index.index;
@@ -3036,11 +3035,11 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetMeshBindGroup<I> {
         // Attach motion vectors if needed.
         if has_motion_vector_prepass {
             // Attach the previous skin index for motion vector computation.
-            if skins_use_uniform_buffers(&render_device) {
-                if let Some(current_skin_byte_offset) = current_skin_byte_offset {
-                    dynamic_offsets[offset_count] = current_skin_byte_offset.byte_offset;
-                    offset_count += 1;
-                }
+            if skins_use_uniform_buffers(&render_device)
+                && let Some(current_skin_byte_offset) = current_skin_byte_offset
+            {
+                dynamic_offsets[offset_count] = current_skin_byte_offset.byte_offset;
+                offset_count += 1;
             }
 
             // Attach the previous morph index for motion vector computation. If
@@ -3094,13 +3093,12 @@ impl<P: PhaseItem> RenderCommand<P> for DrawMesh {
         // If we're using GPU preprocessing, then we're dependent on that
         // compute shader having been run, which of course can only happen if
         // it's compiled. Otherwise, our mesh instance data won't be present.
-        if let Some(preprocess_pipelines) = preprocess_pipelines {
-            if !has_preprocess_bind_group
+        if let Some(preprocess_pipelines) = preprocess_pipelines
+            && (!has_preprocess_bind_group
                 || !preprocess_pipelines
-                    .pipelines_are_loaded(&pipeline_cache, &preprocessing_support)
-            {
-                return RenderCommandResult::Skip;
-            }
+                    .pipelines_are_loaded(&pipeline_cache, &preprocessing_support))
+        {
+            return RenderCommandResult::Skip;
         }
 
         let meshes = meshes.into_inner();

--- a/crates/bevy_pbr/src/render/mesh_bindings.rs
+++ b/crates/bevy_pbr/src/render/mesh_bindings.rs
@@ -91,7 +91,7 @@ mod entry {
         renderer::RenderDevice,
     };
 
-    fn entry(binding: u32, size: Option<u64>, buffer: &Buffer) -> BindGroupEntry {
+    fn entry(binding: u32, size: Option<u64>, buffer: &Buffer) -> BindGroupEntry<'_> {
         BindGroupEntry {
             binding,
             resource: BindingResource::Buffer(BufferBinding {
@@ -116,22 +116,25 @@ mod entry {
         };
         entry(binding, size, buffer)
     }
-    pub(super) fn weights(binding: u32, buffer: &Buffer) -> BindGroupEntry {
+    pub(super) fn weights(binding: u32, buffer: &Buffer) -> BindGroupEntry<'_> {
         entry(binding, Some(MORPH_BUFFER_SIZE as u64), buffer)
     }
-    pub(super) fn targets(binding: u32, texture: &TextureView) -> BindGroupEntry {
+    pub(super) fn targets(binding: u32, texture: &TextureView) -> BindGroupEntry<'_> {
         BindGroupEntry {
             binding,
             resource: BindingResource::TextureView(texture),
         }
     }
-    pub(super) fn lightmaps_texture_view(binding: u32, texture: &TextureView) -> BindGroupEntry {
+    pub(super) fn lightmaps_texture_view(
+        binding: u32,
+        texture: &TextureView,
+    ) -> BindGroupEntry<'_> {
         BindGroupEntry {
             binding,
             resource: BindingResource::TextureView(texture),
         }
     }
-    pub(super) fn lightmaps_sampler(binding: u32, sampler: &Sampler) -> BindGroupEntry {
+    pub(super) fn lightmaps_sampler(binding: u32, sampler: &Sampler) -> BindGroupEntry<'_> {
         BindGroupEntry {
             binding,
             resource: BindingResource::Sampler(sampler),

--- a/crates/bevy_pbr/src/render/mesh_view_bindings.rs
+++ b/crates/bevy_pbr/src/render/mesh_view_bindings.rs
@@ -684,8 +684,8 @@ pub fn prepare_mesh_view_bind_groups(
             entries =
                 entries.extend_with_indices(((24, transmission_view), (25, transmission_sampler)));
 
-            if has_oit {
-                if let (
+            if has_oit
+                && let (
                     Some(oit_layers_binding),
                     Some(oit_layer_ids_binding),
                     Some(oit_settings_binding),
@@ -693,13 +693,13 @@ pub fn prepare_mesh_view_bind_groups(
                     oit_buffers.layers.binding(),
                     oit_buffers.layer_ids.binding(),
                     oit_buffers.settings.binding(),
-                ) {
-                    entries = entries.extend_with_indices((
-                        (26, oit_layers_binding.clone()),
-                        (27, oit_layer_ids_binding.clone()),
-                        (28, oit_settings_binding.clone()),
-                    ));
-                }
+                )
+            {
+                entries = entries.extend_with_indices((
+                    (26, oit_layers_binding.clone()),
+                    (27, oit_layer_ids_binding.clone()),
+                    (28, oit_settings_binding.clone()),
+                ));
             }
 
             let mut entries_binding_array = DynamicBindGroupEntries::new();

--- a/crates/bevy_picking/src/events.rs
+++ b/crates/bevy_picking/src/events.rs
@@ -95,10 +95,10 @@ where
         };
 
         // Otherwise, send it to the window entity (unless this is a window entity).
-        if window.is_none() {
-            if let NormalizedRenderTarget::Window(window_ref) = pointer.pointer_location.target {
-                return Some(window_ref.entity());
-            }
+        if window.is_none()
+            && let NormalizedRenderTarget::Window(window_ref) = pointer.pointer_location.target
+        {
+            return Some(window_ref.entity());
         }
 
         None

--- a/crates/bevy_picking/src/hover.rs
+++ b/crates/bevy_picking/src/hover.rs
@@ -243,10 +243,10 @@ pub fn update_interactions(
         };
 
         for entity in previously_hovered_entities.keys() {
-            if !new_interaction_state.contains_key(entity) {
-                if let Ok(mut interaction) = interact.get_mut(*entity) {
-                    interaction.set_if_neq(PickingInteraction::None);
-                }
+            if !new_interaction_state.contains_key(entity)
+                && let Ok(mut interaction) = interact.get_mut(*entity)
+            {
+                interaction.set_if_neq(PickingInteraction::None);
             }
         }
     }

--- a/crates/bevy_picking/src/mesh_picking/ray_cast/mod.rs
+++ b/crates/bevy_picking/src/mesh_picking/ray_cast/mod.rs
@@ -229,14 +229,14 @@ impl<'w, 's> MeshRayCast<'w, 's> {
                     RayCastVisibility::Visible => inherited_visibility.get(),
                     RayCastVisibility::VisibleInView => view_visibility.get(),
                 };
-                if should_ray_cast {
-                    if let Some(distance) = ray_aabb_intersection_3d(
+                if should_ray_cast
+                    && let Some(distance) = ray_aabb_intersection_3d(
                         ray,
                         &Aabb3d::new(aabb.center, aabb.half_extents),
                         &transform.to_matrix(),
-                    ) {
-                        aabb_hits_tx.send((FloatOrd(distance), entity)).ok();
-                    }
+                    )
+                {
+                    aabb_hits_tx.send((FloatOrd(distance), entity)).ok();
                 }
             },
         );

--- a/crates/bevy_reflect/derive/src/derive_data.rs
+++ b/crates/bevy_reflect/derive/src/derive_data.rs
@@ -332,7 +332,7 @@ impl<'a> ReflectDerive<'a> {
     }
 
     /// Get the remote type path, if any.
-    pub fn remote_ty(&self) -> Option<RemoteType> {
+    pub fn remote_ty(&self) -> Option<RemoteType<'_>> {
         match self {
             Self::Struct(data) | Self::TupleStruct(data) | Self::UnitStruct(data) => {
                 data.meta.remote_ty()
@@ -343,7 +343,7 @@ impl<'a> ReflectDerive<'a> {
     }
 
     /// Get the [`ReflectMeta`] for this derived type.
-    pub fn meta(&self) -> &ReflectMeta {
+    pub fn meta(&self) -> &ReflectMeta<'_> {
         match self {
             Self::Struct(data) | Self::TupleStruct(data) | Self::UnitStruct(data) => data.meta(),
             Self::Enum(data) => data.meta(),
@@ -351,7 +351,7 @@ impl<'a> ReflectDerive<'a> {
         }
     }
 
-    pub fn where_clause_options(&self) -> WhereClauseOptions {
+    pub fn where_clause_options(&self) -> WhereClauseOptions<'_, '_> {
         match self {
             Self::Struct(data) | Self::TupleStruct(data) | Self::UnitStruct(data) => {
                 data.where_clause_options()
@@ -462,7 +462,7 @@ impl<'a> ReflectMeta<'a> {
     }
 
     /// Get the remote type path, if any.
-    pub fn remote_ty(&self) -> Option<RemoteType> {
+    pub fn remote_ty(&self) -> Option<RemoteType<'_>> {
         self.remote_ty
     }
 
@@ -631,7 +631,7 @@ impl<'a> ReflectStruct<'a> {
         &self.fields
     }
 
-    pub fn where_clause_options(&self) -> WhereClauseOptions {
+    pub fn where_clause_options(&self) -> WhereClauseOptions<'_, '_> {
         WhereClauseOptions::new_with_types(self.meta(), self.active_types())
     }
 
@@ -851,7 +851,7 @@ impl<'a> ReflectEnum<'a> {
         self.variants.iter().flat_map(EnumVariant::active_fields)
     }
 
-    pub fn where_clause_options(&self) -> WhereClauseOptions {
+    pub fn where_clause_options(&self) -> WhereClauseOptions<'_, '_> {
         WhereClauseOptions::new_with_types(self.meta(), self.active_types())
     }
 

--- a/crates/bevy_reflect/derive/src/enum_utility.rs
+++ b/crates/bevy_reflect/derive/src/enum_utility.rs
@@ -37,7 +37,7 @@ pub(crate) struct VariantField<'a, 'b> {
 /// Trait used to control how enum variants are built.
 pub(crate) trait VariantBuilder: Sized {
     /// Returns the enum data.
-    fn reflect_enum(&self) -> &ReflectEnum;
+    fn reflect_enum(&self) -> &ReflectEnum<'_>;
 
     /// Returns a token stream that accesses a field of a variant as an `Option<dyn Reflect>`.
     ///
@@ -212,7 +212,7 @@ impl<'a> FromReflectVariantBuilder<'a> {
 }
 
 impl<'a> VariantBuilder for FromReflectVariantBuilder<'a> {
-    fn reflect_enum(&self) -> &ReflectEnum {
+    fn reflect_enum(&self) -> &ReflectEnum<'_> {
         self.reflect_enum
     }
 
@@ -244,7 +244,7 @@ impl<'a> TryApplyVariantBuilder<'a> {
 }
 
 impl<'a> VariantBuilder for TryApplyVariantBuilder<'a> {
-    fn reflect_enum(&self) -> &ReflectEnum {
+    fn reflect_enum(&self) -> &ReflectEnum<'_> {
         self.reflect_enum
     }
 
@@ -300,7 +300,7 @@ impl<'a> ReflectCloneVariantBuilder<'a> {
 }
 
 impl<'a> VariantBuilder for ReflectCloneVariantBuilder<'a> {
-    fn reflect_enum(&self) -> &ReflectEnum {
+    fn reflect_enum(&self) -> &ReflectEnum<'_> {
         self.reflect_enum
     }
 

--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -63,7 +63,7 @@ pub trait Array: PartialReflect {
     }
 
     /// Returns an iterator over the array.
-    fn iter(&self) -> ArrayIter;
+    fn iter(&self) -> ArrayIter<'_>;
 
     /// Drain the elements of this array to get a vector of owned values.
     fn drain(self: Box<Self>) -> Vec<Box<dyn PartialReflect>>;
@@ -242,12 +242,12 @@ impl PartialReflect for DynamicArray {
     }
 
     #[inline]
-    fn reflect_ref(&self) -> ReflectRef {
+    fn reflect_ref(&self) -> ReflectRef<'_> {
         ReflectRef::Array(self)
     }
 
     #[inline]
-    fn reflect_mut(&mut self) -> ReflectMut {
+    fn reflect_mut(&mut self) -> ReflectMut<'_> {
         ReflectMut::Array(self)
     }
 
@@ -294,7 +294,7 @@ impl Array for DynamicArray {
     }
 
     #[inline]
-    fn iter(&self) -> ArrayIter {
+    fn iter(&self) -> ArrayIter<'_> {
         ArrayIter::new(self)
     }
 
@@ -351,7 +351,7 @@ pub struct ArrayIter<'a> {
 impl ArrayIter<'_> {
     /// Creates a new [`ArrayIter`].
     #[inline]
-    pub const fn new(array: &dyn Array) -> ArrayIter {
+    pub const fn new(array: &dyn Array) -> ArrayIter<'_> {
         ArrayIter { array, index: 0 }
     }
 }

--- a/crates/bevy_reflect/src/enums/dynamic_enum.rs
+++ b/crates/bevy_reflect/src/enums/dynamic_enum.rs
@@ -255,7 +255,7 @@ impl Enum for DynamicEnum {
         }
     }
 
-    fn iter_fields(&self) -> VariantFieldIter {
+    fn iter_fields(&self) -> VariantFieldIter<'_> {
         VariantFieldIter::new(self)
     }
 
@@ -372,12 +372,12 @@ impl PartialReflect for DynamicEnum {
     }
 
     #[inline]
-    fn reflect_ref(&self) -> ReflectRef {
+    fn reflect_ref(&self) -> ReflectRef<'_> {
         ReflectRef::Enum(self)
     }
 
     #[inline]
-    fn reflect_mut(&mut self) -> ReflectMut {
+    fn reflect_mut(&mut self) -> ReflectMut<'_> {
         ReflectMut::Enum(self)
     }
 

--- a/crates/bevy_reflect/src/enums/enum_trait.rs
+++ b/crates/bevy_reflect/src/enums/enum_trait.rs
@@ -115,7 +115,7 @@ pub trait Enum: PartialReflect {
     /// For non-[`VariantType::Struct`] variants, this should return `None`.
     fn name_at(&self, index: usize) -> Option<&str>;
     /// Returns an iterator over the values of the current variant's fields.
-    fn iter_fields(&self) -> VariantFieldIter;
+    fn iter_fields(&self) -> VariantFieldIter<'_>;
     /// Returns the number of fields in the current variant.
     fn field_len(&self) -> usize;
     /// The name of the current variant.

--- a/crates/bevy_reflect/src/func/args/from_arg.rs
+++ b/crates/bevy_reflect/src/func/args/from_arg.rs
@@ -1,3 +1,7 @@
+#![expect(
+    mismatched_lifetime_syntaxes,
+    reason = "I can't figure out how to fix this."
+)]
 use crate::func::args::{Arg, ArgError};
 use crate::{Reflect, TypePath};
 
@@ -77,6 +81,10 @@ macro_rules! impl_from_arg {
         )?
         {
             type This<'from_arg> = $ty;
+            #[expect(
+                mismatched_lifetime_syntaxes,
+                reason = "I can't figure out how to fix this."
+            )]
             fn from_arg(arg: $crate::func::args::Arg) ->
                 Result<Self::This<'_>, $crate::func::args::ArgError>
             {

--- a/crates/bevy_reflect/src/func/dynamic_function.rs
+++ b/crates/bevy_reflect/src/func/dynamic_function.rs
@@ -409,11 +409,11 @@ impl PartialReflect for DynamicFunction<'static> {
         ReflectKind::Function
     }
 
-    fn reflect_ref(&self) -> ReflectRef {
+    fn reflect_ref(&self) -> ReflectRef<'_> {
         ReflectRef::Function(self)
     }
 
-    fn reflect_mut(&mut self) -> ReflectMut {
+    fn reflect_mut(&mut self) -> ReflectMut<'_> {
         ReflectMut::Function(self)
     }
 

--- a/crates/bevy_reflect/src/func/info.rs
+++ b/crates/bevy_reflect/src/func/info.rs
@@ -177,7 +177,7 @@ impl FunctionInfo {
     /// let pretty = info.pretty_printer();
     /// assert_eq!(format!("{:?}", pretty), "(_: i32, _: i32) -> i32");
     /// ```
-    pub fn pretty_printer(&self) -> PrettyPrintFunctionInfo {
+    pub fn pretty_printer(&self) -> PrettyPrintFunctionInfo<'_> {
         PrettyPrintFunctionInfo::new(self)
     }
 

--- a/crates/bevy_reflect/src/impls/alloc/borrow.rs
+++ b/crates/bevy_reflect/src/impls/alloc/borrow.rs
@@ -55,11 +55,11 @@ impl PartialReflect for Cow<'static, str> {
         ReflectKind::Opaque
     }
 
-    fn reflect_ref(&self) -> ReflectRef {
+    fn reflect_ref(&self) -> ReflectRef<'_> {
         ReflectRef::Opaque(self)
     }
 
-    fn reflect_mut(&mut self) -> ReflectMut {
+    fn reflect_mut(&mut self) -> ReflectMut<'_> {
         ReflectMut::Opaque(self)
     }
 
@@ -180,7 +180,7 @@ impl<T: FromReflect + MaybeTyped + Clone + TypePath + GetTypeRegistration> List
         self.as_ref().len()
     }
 
-    fn iter(&self) -> ListIter {
+    fn iter(&self) -> ListIter<'_> {
         ListIter::new(self)
     }
 
@@ -228,11 +228,11 @@ impl<T: FromReflect + MaybeTyped + Clone + TypePath + GetTypeRegistration> Parti
         ReflectKind::List
     }
 
-    fn reflect_ref(&self) -> ReflectRef {
+    fn reflect_ref(&self) -> ReflectRef<'_> {
         ReflectRef::List(self)
     }
 
-    fn reflect_mut(&mut self) -> ReflectMut {
+    fn reflect_mut(&mut self) -> ReflectMut<'_> {
         ReflectMut::List(self)
     }
 

--- a/crates/bevy_reflect/src/impls/alloc/collections/btree/map.rs
+++ b/crates/bevy_reflect/src/impls/alloc/collections/btree/map.rs
@@ -128,11 +128,11 @@ where
         ReflectKind::Map
     }
 
-    fn reflect_ref(&self) -> ReflectRef {
+    fn reflect_ref(&self) -> ReflectRef<'_> {
         ReflectRef::Map(self)
     }
 
-    fn reflect_mut(&mut self) -> ReflectMut {
+    fn reflect_mut(&mut self) -> ReflectMut<'_> {
         ReflectMut::Map(self)
     }
 

--- a/crates/bevy_reflect/src/impls/core/panic.rs
+++ b/crates/bevy_reflect/src/impls/core/panic.rs
@@ -57,11 +57,11 @@ impl PartialReflect for &'static Location<'static> {
         ReflectKind::Opaque
     }
 
-    fn reflect_ref(&self) -> ReflectRef {
+    fn reflect_ref(&self) -> ReflectRef<'_> {
         ReflectRef::Opaque(self)
     }
 
-    fn reflect_mut(&mut self) -> ReflectMut {
+    fn reflect_mut(&mut self) -> ReflectMut<'_> {
         ReflectMut::Opaque(self)
     }
 

--- a/crates/bevy_reflect/src/impls/core/primitives.rs
+++ b/crates/bevy_reflect/src/impls/core/primitives.rs
@@ -191,11 +191,11 @@ impl PartialReflect for &'static str {
         Some(self)
     }
 
-    fn reflect_ref(&self) -> ReflectRef {
+    fn reflect_ref(&self) -> ReflectRef<'_> {
         ReflectRef::Opaque(self)
     }
 
-    fn reflect_mut(&mut self) -> ReflectMut {
+    fn reflect_mut(&mut self) -> ReflectMut<'_> {
         ReflectMut::Opaque(self)
     }
 
@@ -310,7 +310,7 @@ impl<T: Reflect + MaybeTyped + TypePath + GetTypeRegistration, const N: usize> A
     }
 
     #[inline]
-    fn iter(&self) -> ArrayIter {
+    fn iter(&self) -> ArrayIter<'_> {
         ArrayIter::new(self)
     }
 
@@ -360,12 +360,12 @@ impl<T: Reflect + MaybeTyped + TypePath + GetTypeRegistration, const N: usize> P
     }
 
     #[inline]
-    fn reflect_ref(&self) -> ReflectRef {
+    fn reflect_ref(&self) -> ReflectRef<'_> {
         ReflectRef::Array(self)
     }
 
     #[inline]
-    fn reflect_mut(&mut self) -> ReflectMut {
+    fn reflect_mut(&mut self) -> ReflectMut<'_> {
         ReflectMut::Array(self)
     }
 

--- a/crates/bevy_reflect/src/impls/core/sync.rs
+++ b/crates/bevy_reflect/src/impls/core/sync.rs
@@ -102,11 +102,11 @@ macro_rules! impl_reflect_for_atomic {
                     ReflectKind::Opaque
                 }
                 #[inline]
-                fn reflect_ref(&self) -> ReflectRef {
+                fn reflect_ref(&self) -> ReflectRef <'_> {
                     ReflectRef::Opaque(self)
                 }
                 #[inline]
-                fn reflect_mut(&mut self) -> ReflectMut {
+                fn reflect_mut(&mut self) -> ReflectMut <'_> {
                     ReflectMut::Opaque(self)
                 }
                 #[inline]

--- a/crates/bevy_reflect/src/impls/macros/list.rs
+++ b/crates/bevy_reflect/src/impls/macros/list.rs
@@ -48,7 +48,7 @@ macro_rules! impl_reflect_for_veclike {
                 }
 
                 #[inline]
-                fn iter(&self) -> $crate::list::ListIter {
+                fn iter(&self) -> $crate::list::ListIter<'_>  {
                     $crate::list::ListIter::new(self)
                 }
 
@@ -98,11 +98,11 @@ macro_rules! impl_reflect_for_veclike {
                     $crate::kind::ReflectKind::List
                 }
 
-                fn reflect_ref(&self) -> $crate::kind::ReflectRef {
+                fn reflect_ref(&self) -> $crate::kind::ReflectRef<'_> {
                     $crate::kind::ReflectRef::List(self)
                 }
 
-                fn reflect_mut(&mut self) -> $crate::kind::ReflectMut {
+                fn reflect_mut(&mut self) -> $crate::kind::ReflectMut<'_> {
                     $crate::kind::ReflectMut::List(self)
                 }
 

--- a/crates/bevy_reflect/src/impls/macros/map.rs
+++ b/crates/bevy_reflect/src/impls/macros/map.rs
@@ -131,11 +131,11 @@ macro_rules! impl_reflect_for_hashmap {
                     $crate::kind::ReflectKind::Map
                 }
 
-                fn reflect_ref(&self) -> $crate::kind::ReflectRef {
+                fn reflect_ref(&self) -> $crate::kind::ReflectRef<'_> {
                     $crate::kind::ReflectRef::Map(self)
                 }
 
-                fn reflect_mut(&mut self) -> $crate::kind::ReflectMut {
+                fn reflect_mut(&mut self) -> $crate::kind::ReflectMut<'_> {
                     $crate::kind::ReflectMut::Map(self)
                 }
 

--- a/crates/bevy_reflect/src/impls/macros/set.rs
+++ b/crates/bevy_reflect/src/impls/macros/set.rs
@@ -114,11 +114,11 @@ macro_rules! impl_reflect_for_hashset {
                     $crate::kind::ReflectKind::Set
                 }
 
-                fn reflect_ref(&self) -> $crate::kind::ReflectRef {
+                fn reflect_ref(&self) -> $crate::kind::ReflectRef<'_>  {
                     $crate::kind::ReflectRef::Set(self)
                 }
 
-                fn reflect_mut(&mut self) -> $crate::kind::ReflectMut {
+                fn reflect_mut(&mut self) -> $crate::kind::ReflectMut<'_>  {
                     $crate::kind::ReflectMut::Set(self)
                 }
 

--- a/crates/bevy_reflect/src/impls/smallvec.rs
+++ b/crates/bevy_reflect/src/impls/smallvec.rs
@@ -67,7 +67,7 @@ where
         <SmallVec<T>>::len(self)
     }
 
-    fn iter(&self) -> ListIter {
+    fn iter(&self) -> ListIter<'_> {
         ListIter::new(self)
     }
 
@@ -123,11 +123,11 @@ where
         ReflectKind::List
     }
 
-    fn reflect_ref(&self) -> ReflectRef {
+    fn reflect_ref(&self) -> ReflectRef<'_> {
         ReflectRef::List(self)
     }
 
-    fn reflect_mut(&mut self) -> ReflectMut {
+    fn reflect_mut(&mut self) -> ReflectMut<'_> {
         ReflectMut::List(self)
     }
 

--- a/crates/bevy_reflect/src/impls/std/path.rs
+++ b/crates/bevy_reflect/src/impls/std/path.rs
@@ -63,11 +63,11 @@ impl PartialReflect for &'static Path {
         ReflectKind::Opaque
     }
 
-    fn reflect_ref(&self) -> ReflectRef <'_> {
+    fn reflect_ref(&self) -> ReflectRef<'_> {
         ReflectRef::Opaque(self)
     }
 
-    fn reflect_mut(&mut self) -> ReflectMut <'_> {
+    fn reflect_mut(&mut self) -> ReflectMut<'_> {
         ReflectMut::Opaque(self)
     }
 
@@ -194,11 +194,11 @@ impl PartialReflect for Cow<'static, Path> {
         ReflectKind::Opaque
     }
 
-    fn reflect_ref(&self) -> ReflectRef <'_> {
+    fn reflect_ref(&self) -> ReflectRef<'_> {
         ReflectRef::Opaque(self)
     }
 
-    fn reflect_mut(&mut self) -> ReflectMut <'_> {
+    fn reflect_mut(&mut self) -> ReflectMut<'_> {
         ReflectMut::Opaque(self)
     }
 

--- a/crates/bevy_reflect/src/impls/std/path.rs
+++ b/crates/bevy_reflect/src/impls/std/path.rs
@@ -63,11 +63,11 @@ impl PartialReflect for &'static Path {
         ReflectKind::Opaque
     }
 
-    fn reflect_ref(&self) -> ReflectRef {
+    fn reflect_ref(&self) -> ReflectRef <'_> {
         ReflectRef::Opaque(self)
     }
 
-    fn reflect_mut(&mut self) -> ReflectMut {
+    fn reflect_mut(&mut self) -> ReflectMut <'_> {
         ReflectMut::Opaque(self)
     }
 
@@ -194,11 +194,11 @@ impl PartialReflect for Cow<'static, Path> {
         ReflectKind::Opaque
     }
 
-    fn reflect_ref(&self) -> ReflectRef {
+    fn reflect_ref(&self) -> ReflectRef <'_> {
         ReflectRef::Opaque(self)
     }
 
-    fn reflect_mut(&mut self) -> ReflectMut {
+    fn reflect_mut(&mut self) -> ReflectMut <'_> {
         ReflectMut::Opaque(self)
     }
 

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -2711,11 +2711,9 @@ bevy_reflect::tests::Test {
         #[reflect(where T: Default)]
         struct Foo<T>(String, #[reflect(ignore)] PhantomData<T>);
 
-        #[expect(dead_code, reason = "Bar is never constructed")]
         #[derive(Default, TypePath)]
         struct Bar;
 
-        #[expect(dead_code, reason = "Baz is never constructed")]
         #[derive(TypePath)]
         struct Baz;
 
@@ -2729,7 +2727,6 @@ bevy_reflect::tests::Test {
         #[reflect(where)]
         struct Foo<T>(String, #[reflect(ignore)] PhantomData<T>);
 
-        #[expect(dead_code, reason = "Bar is never constructed")]
         #[derive(TypePath)]
         struct Bar;
 
@@ -2764,7 +2761,6 @@ bevy_reflect::tests::Test {
         #[reflect(where T::Assoc: core::fmt::Display)]
         struct Foo<T: Trait>(T::Assoc);
 
-        #[expect(dead_code, reason = "Bar is never constructed")]
         #[derive(TypePath)]
         struct Bar;
 
@@ -2772,7 +2768,6 @@ bevy_reflect::tests::Test {
             type Assoc = usize;
         }
 
-        #[expect(dead_code, reason = "Baz is never constructed")]
         #[derive(TypePath)]
         struct Baz;
 

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -95,7 +95,7 @@ pub trait List: PartialReflect {
     }
 
     /// Returns an iterator over the list.
-    fn iter(&self) -> ListIter;
+    fn iter(&self) -> ListIter<'_>;
 
     /// Drain the elements of this list to get a vector of owned values.
     ///
@@ -238,7 +238,7 @@ impl List for DynamicList {
         self.values.len()
     }
 
-    fn iter(&self) -> ListIter {
+    fn iter(&self) -> ListIter<'_> {
         ListIter::new(self)
     }
 
@@ -294,12 +294,12 @@ impl PartialReflect for DynamicList {
     }
 
     #[inline]
-    fn reflect_ref(&self) -> ReflectRef {
+    fn reflect_ref(&self) -> ReflectRef<'_> {
         ReflectRef::List(self)
     }
 
     #[inline]
-    fn reflect_mut(&mut self) -> ReflectMut {
+    fn reflect_mut(&mut self) -> ReflectMut<'_> {
         ReflectMut::List(self)
     }
 
@@ -382,7 +382,7 @@ pub struct ListIter<'a> {
 impl ListIter<'_> {
     /// Creates a new [`ListIter`].
     #[inline]
-    pub const fn new(list: &dyn List) -> ListIter {
+    pub const fn new(list: &dyn List) -> ListIter<'_> {
         ListIter { list, index: 0 }
     }
 }

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -375,11 +375,11 @@ impl PartialReflect for DynamicMap {
         ReflectKind::Map
     }
 
-    fn reflect_ref(&self) -> ReflectRef {
+    fn reflect_ref(&self) -> ReflectRef<'_> {
         ReflectRef::Map(self)
     }
 
-    fn reflect_mut(&mut self) -> ReflectMut {
+    fn reflect_mut(&mut self) -> ReflectMut<'_> {
         ReflectMut::Map(self)
     }
 

--- a/crates/bevy_reflect/src/path/error.rs
+++ b/crates/bevy_reflect/src/path/error.rs
@@ -64,7 +64,7 @@ impl<'a> AccessError<'a> {
     }
 
     /// The returns the [`Access`] that this [`AccessError`] occurred in.
-    pub const fn access(&self) -> &Access {
+    pub const fn access(&self) -> &Access<'_> {
         &self.access
     }
 

--- a/crates/bevy_reflect/src/path/mod.rs
+++ b/crates/bevy_reflect/src/path/mod.rs
@@ -414,7 +414,7 @@ impl ParsedPath {
     ///
     /// assert_eq!(parsed_path.element::<u32>(&foo).unwrap(), &123);
     /// ```
-    pub fn parse(string: &str) -> PathResult<Self> {
+    pub fn parse(string: &str) -> PathResult<'_, Self> {
         let mut parts = Vec::new();
         for (access, offset) in PathParser::new(string) {
             parts.push(OffsetAccess {

--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -226,12 +226,12 @@ where
     /// Returns an immutable enumeration of "kinds" of type.
     ///
     /// See [`ReflectRef`].
-    fn reflect_ref(&self) -> ReflectRef;
+    fn reflect_ref(&self) -> ReflectRef<'_>;
 
     /// Returns a mutable enumeration of "kinds" of type.
     ///
     /// See [`ReflectMut`].
-    fn reflect_mut(&mut self) -> ReflectMut;
+    fn reflect_mut(&mut self) -> ReflectMut<'_>;
 
     /// Returns an owned enumeration of "kinds" of type.
     ///

--- a/crates/bevy_reflect/src/set.rs
+++ b/crates/bevy_reflect/src/set.rs
@@ -301,11 +301,11 @@ impl PartialReflect for DynamicSet {
         ReflectKind::Set
     }
 
-    fn reflect_ref(&self) -> ReflectRef {
+    fn reflect_ref(&self) -> ReflectRef<'_> {
         ReflectRef::Set(self)
     }
 
-    fn reflect_mut(&mut self) -> ReflectMut {
+    fn reflect_mut(&mut self) -> ReflectMut<'_> {
         ReflectMut::Set(self)
     }
 

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -69,7 +69,7 @@ pub trait Struct: PartialReflect {
     fn field_len(&self) -> usize;
 
     /// Returns an iterator over the values of the reflectable fields for this struct.
-    fn iter_fields(&self) -> FieldIter;
+    fn iter_fields(&self) -> FieldIter<'_>;
 
     /// Creates a new [`DynamicStruct`] from this struct.
     fn to_dynamic_struct(&self) -> DynamicStruct {
@@ -371,7 +371,7 @@ impl Struct for DynamicStruct {
     }
 
     #[inline]
-    fn iter_fields(&self) -> FieldIter {
+    fn iter_fields(&self) -> FieldIter<'_> {
         FieldIter {
             struct_val: self,
             index: 0,
@@ -429,12 +429,12 @@ impl PartialReflect for DynamicStruct {
     }
 
     #[inline]
-    fn reflect_ref(&self) -> ReflectRef {
+    fn reflect_ref(&self) -> ReflectRef<'_> {
         ReflectRef::Struct(self)
     }
 
     #[inline]
-    fn reflect_mut(&mut self) -> ReflectMut {
+    fn reflect_mut(&mut self) -> ReflectMut<'_> {
         ReflectMut::Struct(self)
     }
 

--- a/crates/bevy_reflect/src/tuple.rs
+++ b/crates/bevy_reflect/src/tuple.rs
@@ -50,7 +50,7 @@ pub trait Tuple: PartialReflect {
     fn field_len(&self) -> usize;
 
     /// Returns an iterator over the values of the tuple's fields.
-    fn iter_fields(&self) -> TupleFieldIter;
+    fn iter_fields(&self) -> TupleFieldIter<'_>;
 
     /// Drain the fields of this tuple to get a vector of owned values.
     fn drain(self: Box<Self>) -> Vec<Box<dyn PartialReflect>>;
@@ -264,7 +264,7 @@ impl Tuple for DynamicTuple {
     }
 
     #[inline]
-    fn iter_fields(&self) -> TupleFieldIter {
+    fn iter_fields(&self) -> TupleFieldIter<'_> {
         TupleFieldIter {
             tuple: self,
             index: 0,
@@ -318,12 +318,12 @@ impl PartialReflect for DynamicTuple {
     }
 
     #[inline]
-    fn reflect_ref(&self) -> ReflectRef {
+    fn reflect_ref(&self) -> ReflectRef<'_> {
         ReflectRef::Tuple(self)
     }
 
     #[inline]
-    fn reflect_mut(&mut self) -> ReflectMut {
+    fn reflect_mut(&mut self) -> ReflectMut<'_> {
         ReflectMut::Tuple(self)
     }
 
@@ -493,7 +493,7 @@ macro_rules! impl_reflect_tuple {
             }
 
             #[inline]
-            fn iter_fields(&self) -> TupleFieldIter {
+            fn iter_fields(&self) -> TupleFieldIter<'_> {
                 TupleFieldIter {
                     tuple: self,
                     index: 0,
@@ -542,11 +542,11 @@ macro_rules! impl_reflect_tuple {
                 ReflectKind::Tuple
             }
 
-            fn reflect_ref(&self) -> ReflectRef {
+            fn reflect_ref(&self) -> ReflectRef <'_> {
                 ReflectRef::Tuple(self)
             }
 
-            fn reflect_mut(&mut self) -> ReflectMut {
+            fn reflect_mut(&mut self) -> ReflectMut <'_> {
                 ReflectMut::Tuple(self)
             }
 

--- a/crates/bevy_reflect/src/tuple_struct.rs
+++ b/crates/bevy_reflect/src/tuple_struct.rs
@@ -53,7 +53,7 @@ pub trait TupleStruct: PartialReflect {
     fn field_len(&self) -> usize;
 
     /// Returns an iterator over the values of the tuple struct's fields.
-    fn iter_fields(&self) -> TupleStructFieldIter;
+    fn iter_fields(&self) -> TupleStructFieldIter<'_>;
 
     /// Creates a new [`DynamicTupleStruct`] from this tuple struct.
     fn to_dynamic_tuple_struct(&self) -> DynamicTupleStruct {
@@ -278,7 +278,7 @@ impl TupleStruct for DynamicTupleStruct {
     }
 
     #[inline]
-    fn iter_fields(&self) -> TupleStructFieldIter {
+    fn iter_fields(&self) -> TupleStructFieldIter<'_> {
         TupleStructFieldIter {
             tuple_struct: self,
             index: 0,
@@ -337,12 +337,12 @@ impl PartialReflect for DynamicTupleStruct {
     }
 
     #[inline]
-    fn reflect_ref(&self) -> ReflectRef {
+    fn reflect_ref(&self) -> ReflectRef<'_> {
         ReflectRef::TupleStruct(self)
     }
 
     #[inline]
-    fn reflect_mut(&mut self) -> ReflectMut {
+    fn reflect_mut(&mut self) -> ReflectMut<'_> {
         ReflectMut::TupleStruct(self)
     }
 

--- a/crates/bevy_reflect/src/type_info.rs
+++ b/crates/bevy_reflect/src/type_info.rs
@@ -69,8 +69,8 @@ use thiserror::Error;
 /// #     fn try_as_reflect(&self) -> Option<&dyn Reflect> { todo!() }
 /// #     fn try_as_reflect_mut(&mut self) -> Option<&mut dyn Reflect> { todo!() }
 /// #     fn try_apply(&mut self, value: &dyn PartialReflect) -> Result<(), ApplyError> { todo!() }
-/// #     fn reflect_ref(&self) -> ReflectRef { todo!() }
-/// #     fn reflect_mut(&mut self) -> ReflectMut { todo!() }
+/// #     fn reflect_ref(&self) -> ReflectRef <'_> { todo!() }
+/// #     fn reflect_mut(&mut self) -> ReflectMut <'_> { todo!() }
 /// #     fn reflect_owned(self: Box<Self>) -> ReflectOwned { todo!() }
 /// # }
 /// # impl Reflect for MyStruct {

--- a/crates/bevy_reflect/src/type_info.rs
+++ b/crates/bevy_reflect/src/type_info.rs
@@ -69,8 +69,8 @@ use thiserror::Error;
 /// #     fn try_as_reflect(&self) -> Option<&dyn Reflect> { todo!() }
 /// #     fn try_as_reflect_mut(&mut self) -> Option<&mut dyn Reflect> { todo!() }
 /// #     fn try_apply(&mut self, value: &dyn PartialReflect) -> Result<(), ApplyError> { todo!() }
-/// #     fn reflect_ref(&self) -> ReflectRef <'_> { todo!() }
-/// #     fn reflect_mut(&mut self) -> ReflectMut <'_> { todo!() }
+/// #     fn reflect_ref(&self) -> ReflectRef<'_> { todo!() }
+/// #     fn reflect_mut(&mut self) -> ReflectMut<'_> { todo!() }
 /// #     fn reflect_owned(self: Box<Self>) -> ReflectOwned { todo!() }
 /// # }
 /// # impl Reflect for MyStruct {

--- a/crates/bevy_reflect/src/type_info_stack.rs
+++ b/crates/bevy_reflect/src/type_info_stack.rs
@@ -30,7 +30,7 @@ impl TypeInfoStack {
     }
 
     /// Get an iterator over the stack in the order they were pushed.
-    pub fn iter(&self) -> Iter<&'static TypeInfo> {
+    pub fn iter(&self) -> Iter<'_, &'static TypeInfo> {
         self.stack.iter()
     }
 }

--- a/crates/bevy_reflect/src/utility.rs
+++ b/crates/bevy_reflect/src/utility.rs
@@ -86,8 +86,8 @@ mod sealed {
 /// #     fn try_as_reflect(&self) -> Option<&dyn Reflect> { todo!() }
 /// #     fn try_as_reflect_mut(&mut self) -> Option<&mut dyn Reflect> { todo!() }
 /// #     fn try_apply(&mut self, value: &dyn PartialReflect) -> Result<(), ApplyError> { todo!() }
-/// #     fn reflect_ref(&self) -> ReflectRef { todo!() }
-/// #     fn reflect_mut(&mut self) -> ReflectMut { todo!() }
+/// #     fn reflect_ref(&self) -> ReflectRef <'_> { todo!() }
+/// #     fn reflect_mut(&mut self) -> ReflectMut <'_> { todo!() }
 /// #     fn reflect_owned(self: Box<Self>) -> ReflectOwned { todo!() }
 /// # }
 /// # impl Reflect for Foo {
@@ -173,8 +173,8 @@ impl<T: TypedProperty> Default for NonGenericTypeCell<T> {
 /// #     fn try_as_reflect(&self) -> Option<&dyn Reflect> { todo!() }
 /// #     fn try_as_reflect_mut(&mut self) -> Option<&mut dyn Reflect> { todo!() }
 /// #     fn try_apply(&mut self, value: &dyn PartialReflect) -> Result<(), ApplyError> { todo!() }
-/// #     fn reflect_ref(&self) -> ReflectRef { todo!() }
-/// #     fn reflect_mut(&mut self) -> ReflectMut { todo!() }
+/// #     fn reflect_ref(&self) -> ReflectRef <'_> { todo!() }
+/// #     fn reflect_mut(&mut self) -> ReflectMut <'_> { todo!() }
 /// #     fn reflect_owned(self: Box<Self>) -> ReflectOwned { todo!() }
 /// # }
 /// # impl<T: Reflect + Typed + TypePath> Reflect for Foo<T> {

--- a/crates/bevy_remote/src/builtin_methods.rs
+++ b/crates/bevy_remote/src/builtin_methods.rs
@@ -590,11 +590,11 @@ pub fn process_remote_get_components_watching_request(
             continue;
         };
 
-        if let Some(ticks) = entity_ref.get_change_ticks_by_id(component_id) {
-            if ticks.is_changed(world.last_change_tick(), world.read_change_tick()) {
-                changed.push(component_path);
-                continue;
-            }
+        if let Some(ticks) = entity_ref.get_change_ticks_by_id(component_id)
+            && ticks.is_changed(world.last_change_tick(), world.read_change_tick())
+        {
+            changed.push(component_path);
+            continue;
         };
 
         let Some(events) = world.removed_components().get(component_id) else {
@@ -914,10 +914,10 @@ fn serialize_components(
         };
         if let Some(reflect_component) = type_registration.data::<ReflectComponent>() {
             // If a component_id is provided, check if the entity has it
-            if let Some(component_id) = component_id_opt {
-                if !entity_ref.contains_id(component_id) {
-                    continue;
-                }
+            if let Some(component_id) = component_id_opt
+                && !entity_ref.contains_id(component_id)
+            {
+                continue;
             }
             if let Some(reflected) = reflect_component.reflect(entity_ref) {
                 let reflect_serializer =

--- a/crates/bevy_render/macros/src/specializer.rs
+++ b/crates/bevy_render/macros/src/specializer.rs
@@ -189,10 +189,10 @@ fn get_specialize_targets(
     derive_name: &str,
 ) -> syn::Result<SpecializeImplTargets> {
     let specialize_attr = ast.attrs.iter().find_map(|attr| {
-        if attr.path().is_ident(SPECIALIZE_ATTR_IDENT) {
-            if let Meta::List(meta_list) = &attr.meta {
-                return Some(meta_list);
-            }
+        if attr.path().is_ident(SPECIALIZE_ATTR_IDENT)
+            && let Meta::List(meta_list) = &attr.meta
+        {
+            return Some(meta_list);
         }
         None
     });

--- a/crates/bevy_render/src/batching/gpu_preprocessing.rs
+++ b/crates/bevy_render/src/batching/gpu_preprocessing.rs
@@ -1185,7 +1185,7 @@ where
     /// Returns the binding of the buffer that contains the per-instance data.
     ///
     /// This buffer needs to be filled in via a compute shader.
-    pub fn instance_data_binding(&self) -> Option<BindingResource> {
+    pub fn instance_data_binding(&self) -> Option<BindingResource<'_>> {
         self.data_buffer
             .buffer()
             .map(|buffer| buffer.as_entire_binding())

--- a/crates/bevy_render/src/batching/no_gpu_preprocessing.rs
+++ b/crates/bevy_render/src/batching/no_gpu_preprocessing.rs
@@ -42,7 +42,7 @@ where
     ///
     /// If we're in the GPU instance buffer building mode, this buffer needs to
     /// be filled in via a compute shader.
-    pub fn instance_data_binding(&self) -> Option<BindingResource> {
+    pub fn instance_data_binding(&self) -> Option<BindingResource<'_>> {
         self.binding()
     }
 }

--- a/crates/bevy_render/src/extract_instances.rs
+++ b/crates/bevy_render/src/extract_instances.rs
@@ -128,10 +128,10 @@ fn extract_visible<EI>(
 {
     extracted_instances.clear();
     for (entity, view_visibility, other) in &query {
-        if view_visibility.get() {
-            if let Some(extract_instance) = EI::extract(other) {
-                extracted_instances.insert(entity.into(), extract_instance);
-            }
+        if view_visibility.get()
+            && let Some(extract_instance) = EI::extract(other)
+        {
+            extracted_instances.insert(entity.into(), extract_instance);
         }
     }
 }

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -642,13 +642,13 @@ pub fn get_mali_driver_version(adapter: &RenderAdapter) -> Option<u32> {
         return None;
     }
     let driver_info = adapter.get_info().driver_info;
-    if let Some(start_pos) = driver_info.find("v1.r") {
-        if let Some(end_pos) = driver_info[start_pos..].find('p') {
-            let start_idx = start_pos + 4; // Skip "v1.r"
-            let end_idx = start_pos + end_pos;
+    if let Some(start_pos) = driver_info.find("v1.r")
+        && let Some(end_pos) = driver_info[start_pos..].find('p')
+    {
+        let start_idx = start_pos + 4; // Skip "v1.r"
+        let end_idx = start_pos + end_pos;
 
-            return driver_info[start_idx..end_idx].parse::<u32>().ok();
-        }
+        return driver_info[start_idx..end_idx].parse::<u32>().ok();
     }
 
     None

--- a/crates/bevy_render/src/mesh/allocator.rs
+++ b/crates/bevy_render/src/mesh/allocator.rs
@@ -384,7 +384,7 @@ impl MeshAllocator {
     /// the mesh with the given ID.
     ///
     /// If the mesh wasn't allocated, returns None.
-    pub fn mesh_vertex_slice(&self, mesh_id: &AssetId<Mesh>) -> Option<MeshBufferSlice> {
+    pub fn mesh_vertex_slice(&self, mesh_id: &AssetId<Mesh>) -> Option<MeshBufferSlice<'_>> {
         self.mesh_slice_in_slab(mesh_id, *self.mesh_id_to_vertex_slab.get(mesh_id)?)
     }
 
@@ -392,7 +392,7 @@ impl MeshAllocator {
     /// the mesh with the given ID.
     ///
     /// If the mesh has no index data or wasn't allocated, returns None.
-    pub fn mesh_index_slice(&self, mesh_id: &AssetId<Mesh>) -> Option<MeshBufferSlice> {
+    pub fn mesh_index_slice(&self, mesh_id: &AssetId<Mesh>) -> Option<MeshBufferSlice<'_>> {
         self.mesh_slice_in_slab(mesh_id, *self.mesh_id_to_index_slab.get(mesh_id)?)
     }
 
@@ -415,7 +415,7 @@ impl MeshAllocator {
         &self,
         mesh_id: &AssetId<Mesh>,
         slab_id: SlabId,
-    ) -> Option<MeshBufferSlice> {
+    ) -> Option<MeshBufferSlice<'_>> {
         match self.slabs.get(&slab_id)? {
             Slab::General(general_slab) => {
                 let slab_allocation = general_slab.resident_allocations.get(mesh_id)?;

--- a/crates/bevy_render/src/render_graph/graph.rs
+++ b/crates/bevy_render/src/render_graph/graph.rs
@@ -478,14 +478,13 @@ impl RenderGraph {
                     } else {
                         false
                     }
-                }) {
-                    if should_exist == EdgeExistence::DoesNotExist {
-                        return Err(RenderGraphError::NodeInputSlotAlreadyOccupied {
-                            node: input_node,
-                            input_slot: input_index,
-                            occupied_by_node: *current_output_node,
-                        });
-                    }
+                }) && should_exist == EdgeExistence::DoesNotExist
+                {
+                    return Err(RenderGraphError::NodeInputSlotAlreadyOccupied {
+                        node: input_node,
+                        input_slot: input_index,
+                        occupied_by_node: *current_output_node,
+                    });
                 }
 
                 if output_slot.slot_type != input_slot.slot_type {
@@ -507,14 +506,12 @@ impl RenderGraph {
     pub fn has_edge(&self, edge: &Edge) -> bool {
         let output_node_state = self.get_node_state(edge.get_output_node());
         let input_node_state = self.get_node_state(edge.get_input_node());
-        if let Ok(output_node_state) = output_node_state {
-            if output_node_state.edges.output_edges().contains(edge) {
-                if let Ok(input_node_state) = input_node_state {
-                    if input_node_state.edges.input_edges().contains(edge) {
-                        return true;
-                    }
-                }
-            }
+        if let Ok(output_node_state) = output_node_state
+            && output_node_state.edges.output_edges().contains(edge)
+            && let Ok(input_node_state) = input_node_state
+            && input_node_state.edges.input_edges().contains(edge)
+        {
+            return true;
         }
 
         false

--- a/crates/bevy_render/src/render_phase/mod.rs
+++ b/crates/bevy_render/src/render_phase/mod.rs
@@ -612,13 +612,13 @@ where
 
         // If the entity changed bins, record its old bin so that we can remove
         // the entity from it.
-        if let Some(old_cached_binned_entity) = old_cached_binned_entity {
-            if old_cached_binned_entity.cached_bin_key != new_cached_binned_entity.cached_bin_key {
-                self.entities_that_changed_bins.push(EntityThatChangedBins {
-                    main_entity,
-                    old_cached_binned_entity,
-                });
-            }
+        if let Some(old_cached_binned_entity) = old_cached_binned_entity
+            && old_cached_binned_entity.cached_bin_key != new_cached_binned_entity.cached_bin_key
+        {
+            self.entities_that_changed_bins.push(EntityThatChangedBins {
+                main_entity,
+                old_cached_binned_entity,
+            });
         }
 
         // Mark the entity as valid.
@@ -904,11 +904,10 @@ where
     ) -> bool {
         if let indexmap::map::Entry::Occupied(entry) =
             self.cached_entity_bin_keys.entry(visible_entity)
+            && entry.get().change_tick == current_change_tick
         {
-            if entry.get().change_tick == current_change_tick {
-                self.valid_cached_entity_bin_keys.insert(entry.index());
-                return true;
-            }
+            self.valid_cached_entity_bin_keys.insert(entry.index());
+            return true;
         }
 
         false

--- a/crates/bevy_render/src/render_resource/batched_uniform_buffer.rs
+++ b/crates/bevy_render/src/render_resource/batched_uniform_buffer.rs
@@ -109,7 +109,7 @@ impl<T: GpuArrayBufferable> BatchedUniformBuffer<T> {
     }
 
     #[inline]
-    pub fn binding(&self) -> Option<BindingResource> {
+    pub fn binding(&self) -> Option<BindingResource<'_>> {
         let mut binding = self.uniforms.binding();
         if let Some(BindingResource::Buffer(binding)) = &mut binding {
             // MaxCapacityArray is runtime-sized so can't use T::min_size()

--- a/crates/bevy_render/src/render_resource/bind_group.rs
+++ b/crates/bevy_render/src/render_resource/bind_group.rs
@@ -659,7 +659,7 @@ impl OwnedBindingResource {
     /// [`OwnedBindingResource::Data`], because [`OwnedData`] doesn't itself
     /// correspond to any binding and instead requires the
     /// `MaterialBindGroupAllocator` to pack it into a buffer.
-    pub fn get_binding(&self) -> BindingResource {
+    pub fn get_binding(&self) -> BindingResource<'_> {
         match self {
             OwnedBindingResource::Buffer(buffer) => buffer.as_entire_binding(),
             OwnedBindingResource::TextureView(_, view) => BindingResource::TextureView(view),

--- a/crates/bevy_render/src/render_resource/buffer.rs
+++ b/crates/bevy_render/src/render_resource/buffer.rs
@@ -16,7 +16,7 @@ impl Buffer {
         self.id
     }
 
-    pub fn slice(&self, bounds: impl RangeBounds<wgpu::BufferAddress>) -> BufferSlice {
+    pub fn slice(&self, bounds: impl RangeBounds<wgpu::BufferAddress>) -> BufferSlice<'_> {
         // need to compute and store this manually because wgpu doesn't export offset and size on wgpu::BufferSlice
         let offset = match bounds.start_bound() {
             Bound::Included(&bound) => bound,

--- a/crates/bevy_render/src/render_resource/buffer_vec.rs
+++ b/crates/bevy_render/src/render_resource/buffer_vec.rs
@@ -68,7 +68,7 @@ impl<T: NoUninit> RawBufferVec<T> {
 
     /// Returns the binding for the buffer if the data has been uploaded.
     #[inline]
-    pub fn binding(&self) -> Option<BindingResource> {
+    pub fn binding(&self) -> Option<BindingResource<'_>> {
         Some(BindingResource::Buffer(
             self.buffer()?.as_entire_buffer_binding(),
         ))
@@ -310,7 +310,7 @@ where
 
     /// Returns the binding for the buffer if the data has been uploaded.
     #[inline]
-    pub fn binding(&self) -> Option<BindingResource> {
+    pub fn binding(&self) -> Option<BindingResource<'_>> {
         Some(BindingResource::Buffer(
             self.buffer()?.as_entire_buffer_binding(),
         ))
@@ -498,7 +498,7 @@ where
 
     /// Returns the binding for the buffer if the data has been uploaded.
     #[inline]
-    pub fn binding(&self) -> Option<BindingResource> {
+    pub fn binding(&self) -> Option<BindingResource<'_>> {
         Some(BindingResource::Buffer(
             self.buffer()?.as_entire_buffer_binding(),
         ))

--- a/crates/bevy_render/src/render_resource/gpu_array_buffer.rs
+++ b/crates/bevy_render/src/render_resource/gpu_array_buffer.rs
@@ -89,7 +89,7 @@ impl<T: GpuArrayBufferable> GpuArrayBuffer<T> {
         }
     }
 
-    pub fn binding(&self) -> Option<BindingResource> {
+    pub fn binding(&self) -> Option<BindingResource<'_>> {
         match self {
             GpuArrayBuffer::Uniform(buffer) => buffer.binding(),
             GpuArrayBuffer::Storage(buffer) => buffer.binding(),

--- a/crates/bevy_render/src/render_resource/storage_buffer.rs
+++ b/crates/bevy_render/src/render_resource/storage_buffer.rs
@@ -76,7 +76,7 @@ impl<T: ShaderType + WriteInto> StorageBuffer<T> {
     }
 
     #[inline]
-    pub fn binding(&self) -> Option<BindingResource> {
+    pub fn binding(&self) -> Option<BindingResource<'_>> {
         Some(BindingResource::Buffer(BufferBinding {
             buffer: self.buffer()?,
             offset: 0,
@@ -209,7 +209,7 @@ impl<T: ShaderType + WriteInto> DynamicStorageBuffer<T> {
     }
 
     #[inline]
-    pub fn binding(&self) -> Option<BindingResource> {
+    pub fn binding(&self) -> Option<BindingResource<'_>> {
         Some(BindingResource::Buffer(BufferBinding {
             buffer: self.buffer()?,
             offset: 0,

--- a/crates/bevy_render/src/render_resource/uniform_buffer.rs
+++ b/crates/bevy_render/src/render_resource/uniform_buffer.rs
@@ -78,7 +78,7 @@ impl<T: ShaderType + WriteInto> UniformBuffer<T> {
     }
 
     #[inline]
-    pub fn binding(&self) -> Option<BindingResource> {
+    pub fn binding(&self) -> Option<BindingResource<'_>> {
         Some(BindingResource::Buffer(
             self.buffer()?.as_entire_buffer_binding(),
         ))
@@ -213,7 +213,7 @@ impl<T: ShaderType + WriteInto> DynamicUniformBuffer<T> {
     }
 
     #[inline]
-    pub fn binding(&self) -> Option<BindingResource> {
+    pub fn binding(&self) -> Option<BindingResource<'_>> {
         Some(BindingResource::Buffer(BufferBinding {
             buffer: self.buffer()?,
             offset: 0,

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -155,10 +155,10 @@ fn find_adapter_by_name(
     {
         tracing::trace!("Checking adapter: {:?}", adapter.get_info());
         let info = adapter.get_info();
-        if let Some(surface) = compatible_surface {
-            if !adapter.is_surface_supported(surface) {
-                continue;
-            }
+        if let Some(surface) = compatible_surface
+            && !adapter.is_surface_supported(surface)
+        {
+            continue;
         }
 
         if info.name.eq_ignore_ascii_case(adapter_name) {

--- a/crates/bevy_render/src/renderer/render_device.rs
+++ b/crates/bevy_render/src/renderer/render_device.rs
@@ -139,7 +139,7 @@ impl RenderDevice {
     pub fn create_render_bundle_encoder(
         &self,
         desc: &wgpu::RenderBundleEncoderDescriptor,
-    ) -> wgpu::RenderBundleEncoder {
+    ) -> wgpu::RenderBundleEncoder<'_> {
         self.device.create_render_bundle_encoder(desc)
     }
 

--- a/crates/bevy_render/src/texture/texture_attachment.rs
+++ b/crates/bevy_render/src/texture/texture_attachment.rs
@@ -34,7 +34,7 @@ impl ColorAttachment {
     /// `clear_color` if this is the first time calling this function, otherwise it will be loaded.
     ///
     /// The returned attachment will always have writing enabled (`store: StoreOp::Load`).
-    pub fn get_attachment(&self) -> RenderPassColorAttachment {
+    pub fn get_attachment(&self) -> RenderPassColorAttachment<'_> {
         if let Some(resolve_target) = self.resolve_target.as_ref() {
             let first_call = self.is_first_call.fetch_and(false, Ordering::SeqCst);
 
@@ -59,7 +59,7 @@ impl ColorAttachment {
     /// a value of `clear_color` if this is the first time calling this function, otherwise it will be loaded.
     ///
     /// The returned attachment will always have writing enabled (`store: StoreOp::Load`).
-    pub fn get_unsampled_attachment(&self) -> RenderPassColorAttachment {
+    pub fn get_unsampled_attachment(&self) -> RenderPassColorAttachment<'_> {
         let first_call = self.is_first_call.fetch_and(false, Ordering::SeqCst);
 
         RenderPassColorAttachment {
@@ -101,7 +101,7 @@ impl DepthAttachment {
     /// Get this texture view as an attachment. The attachment will be cleared with a value of
     /// `clear_value` if this is the first time calling this function with `store` == [`StoreOp::Store`],
     /// and a clear value was provided, otherwise it will be loaded.
-    pub fn get_attachment(&self, store: StoreOp) -> RenderPassDepthStencilAttachment {
+    pub fn get_attachment(&self, store: StoreOp) -> RenderPassDepthStencilAttachment<'_> {
         let first_call = self
             .is_first_call
             .fetch_and(store != StoreOp::Store, Ordering::SeqCst);
@@ -143,7 +143,7 @@ impl OutputColorAttachment {
     /// Get this texture view as an attachment. The attachment will be cleared with a value of
     /// the provided `clear_color` if this is the first time calling this function, otherwise it
     /// will be loaded.
-    pub fn get_attachment(&self, clear_color: Option<LinearRgba>) -> RenderPassColorAttachment {
+    pub fn get_attachment(&self, clear_color: Option<LinearRgba>) -> RenderPassColorAttachment<'_> {
         let first_call = self.is_first_call.fetch_and(false, Ordering::SeqCst);
 
         RenderPassColorAttachment {

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -725,7 +725,7 @@ impl ViewTarget {
     pub const TEXTURE_FORMAT_HDR: TextureFormat = TextureFormat::Rgba16Float;
 
     /// Retrieve this target's main texture's color attachment.
-    pub fn get_color_attachment(&self) -> RenderPassColorAttachment {
+    pub fn get_color_attachment(&self) -> RenderPassColorAttachment<'_> {
         if self.main_texture.load(Ordering::SeqCst) == 0 {
             self.main_textures.a.get_attachment()
         } else {
@@ -734,7 +734,7 @@ impl ViewTarget {
     }
 
     /// Retrieve this target's "unsampled" main texture's color attachment.
-    pub fn get_unsampled_color_attachment(&self) -> RenderPassColorAttachment {
+    pub fn get_unsampled_color_attachment(&self) -> RenderPassColorAttachment<'_> {
         if self.main_texture.load(Ordering::SeqCst) == 0 {
             self.main_textures.a.get_unsampled_attachment()
         } else {
@@ -826,7 +826,7 @@ impl ViewTarget {
     pub fn out_texture_color_attachment(
         &self,
         clear_color: Option<LinearRgba>,
-    ) -> RenderPassColorAttachment {
+    ) -> RenderPassColorAttachment<'_> {
         self.out_texture.get_attachment(clear_color)
     }
 
@@ -843,7 +843,7 @@ impl ViewTarget {
     /// [`ViewTarget`]'s main texture to the `destination` texture, so the caller
     /// _must_ ensure `source` is copied to `destination`, with or without modifications.
     /// Failing to do so will cause the current main texture information to be lost.
-    pub fn post_process_write(&self) -> PostProcessWrite {
+    pub fn post_process_write(&self) -> PostProcessWrite<'_> {
         let old_is_a_main_texture = self.main_texture.fetch_xor(1, Ordering::SeqCst);
         // if the old main texture is a, then the post processing must write from a to b
         if old_is_a_main_texture == 0 {
@@ -880,7 +880,7 @@ impl ViewDepthTexture {
         }
     }
 
-    pub fn get_attachment(&self, store: StoreOp) -> RenderPassDepthStencilAttachment {
+    pub fn get_attachment(&self, store: StoreOp) -> RenderPassDepthStencilAttachment<'_> {
         self.attachment.get_attachment(store)
     }
 

--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -122,7 +122,10 @@ impl DynamicScene {
                     #[expect(unsafe_code, reason = "this is faster")]
                     let component_info =
                         unsafe { world.components().get_info_unchecked(component_id) };
-                    if *component_info.clone_behavior() == ComponentCloneBehavior::Ignore {
+                    if matches!(
+                        *component_info.clone_behavior(),
+                        ComponentCloneBehavior::Ignore
+                    ) {
                         continue;
                     }
                 }

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -126,7 +126,10 @@ impl Scene {
                         .get_info(component_id)
                         .expect("component_ids in archetypes should have ComponentInfo");
 
-                    if *component_info.clone_behavior() == ComponentCloneBehavior::Ignore {
+                    if matches!(
+                        *component_info.clone_behavior(),
+                        ComponentCloneBehavior::Ignore
+                    ) {
                         continue;
                     }
 

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -552,10 +552,10 @@ pub fn scene_spawner_system(world: &mut World) {
             .scene_asset_event_reader
             .read(scene_asset_events)
         {
-            if let AssetEvent::Modified { id } = event {
-                if scene_spawner.spawned_scenes.contains_key(id) {
-                    updated_spawned_scenes.push(*id);
-                }
+            if let AssetEvent::Modified { id } = event
+                && scene_spawner.spawned_scenes.contains_key(id)
+            {
+                updated_spawned_scenes.push(*id);
             }
         }
         let mut updated_spawned_dynamic_scenes = Vec::new();
@@ -563,10 +563,10 @@ pub fn scene_spawner_system(world: &mut World) {
             .dynamic_scene_asset_event_reader
             .read(dynamic_scene_asset_events)
         {
-            if let AssetEvent::Modified { id } = event {
-                if scene_spawner.spawned_dynamic_scenes.contains_key(id) {
-                    updated_spawned_dynamic_scenes.push(*id);
-                }
+            if let AssetEvent::Modified { id } = event
+                && scene_spawner.spawned_dynamic_scenes.contains_key(id)
+            {
+                updated_spawned_dynamic_scenes.push(*id);
             }
         }
 

--- a/crates/bevy_shader/src/shader_cache.rs
+++ b/crates/bevy_shader/src/shader_cache.rs
@@ -401,7 +401,7 @@ impl<'a> wesl::Resolver for ShaderResolver<'a> {
     fn resolve_source(
         &self,
         module_path: &wesl::syntax::ModulePath,
-    ) -> Result<alloc::borrow::Cow<str>, wesl::ResolveError> {
+    ) -> Result<alloc::borrow::Cow<'_, str>, wesl::ResolveError> {
         let asset_id = self.asset_paths.get(module_path).ok_or_else(|| {
             wesl::ResolveError::ModuleNotFound(module_path.clone(), "Invalid asset id".to_string())
         })?;

--- a/crates/bevy_shader/src/shader_cache.rs
+++ b/crates/bevy_shader/src/shader_cache.rs
@@ -357,11 +357,11 @@ impl<ShaderModule, RenderDevice> ShaderCache<ShaderModule, RenderDevice> {
         }
 
         #[cfg(feature = "shader_format_wesl")]
-        if let Source::Wesl(_) = shader.source {
-            if let ShaderImport::AssetPath(path) = shader.import_path() {
-                self.asset_paths
-                    .insert(wesl::syntax::ModulePath::from_path(path), id);
-            }
+        if let Source::Wesl(_) = shader.source
+            && let ShaderImport::AssetPath(path) = shader.import_path()
+        {
+            self.asset_paths
+                .insert(wesl::syntax::ModulePath::from_path(path), id);
         }
         self.shaders.insert(id, shader);
         pipelines_to_queue

--- a/crates/bevy_solari/src/pathtracer/extract.rs
+++ b/crates/bevy_solari/src/pathtracer/extract.rs
@@ -22,8 +22,10 @@ pub fn extract_pathtracer(
         let mut entity_commands = commands
             .get_entity(entity)
             .expect("Camera entity wasn't synced.");
-        if pathtracer.is_some() && camera.is_active {
-            let mut pathtracer = pathtracer.unwrap().clone();
+        if let Some(pathtracer) = pathtracer
+            && camera.is_active
+        {
+            let mut pathtracer = pathtracer.clone();
             pathtracer.reset |= global_transform.is_changed();
             entity_commands.insert(pathtracer);
         } else {

--- a/crates/bevy_solari/src/realtime/extract.rs
+++ b/crates/bevy_solari/src/realtime/extract.rs
@@ -6,16 +6,15 @@ use bevy_render::{camera::Camera, sync_world::RenderEntity, MainWorld};
 pub fn extract_solari_lighting(mut main_world: ResMut<MainWorld>, mut commands: Commands) {
     let mut cameras_3d = main_world.query::<(RenderEntity, &Camera, Option<&mut SolariLighting>)>();
 
-    for (entity, camera, mut solari_lighting) in cameras_3d.iter_mut(&mut main_world) {
+    for (entity, camera, solari_lighting) in cameras_3d.iter_mut(&mut main_world) {
         let mut entity_commands = commands
             .get_entity(entity)
             .expect("Camera entity wasn't synced.");
-        if solari_lighting.is_some() && camera.is_active {
-            entity_commands.insert((
-                solari_lighting.as_deref().unwrap().clone(),
-                SkipDeferredLighting,
-            ));
-            solari_lighting.as_mut().unwrap().reset = false;
+        if let Some(mut solari_lighting) = solari_lighting
+            && camera.is_active
+        {
+            entity_commands.insert((solari_lighting.clone(), SkipDeferredLighting));
+            solari_lighting.reset = false;
         } else {
             entity_commands.remove::<(
                 SolariLighting,

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -160,10 +160,10 @@ pub fn calculate_bounds_2d(
     >,
 ) {
     for (entity, mesh_handle) in &meshes_without_aabb {
-        if let Some(mesh) = meshes.get(&mesh_handle.0) {
-            if let Some(aabb) = mesh.compute_aabb() {
-                commands.entity(entity).try_insert(aabb);
-            }
+        if let Some(mesh) = meshes.get(&mesh_handle.0)
+            && let Some(aabb) = mesh.compute_aabb()
+        {
+            commands.entity(entity).try_insert(aabb);
         }
     }
     for (entity, sprite, anchor) in &sprites_to_recalculate_aabb {

--- a/crates/bevy_sprite/src/picking_backend.rs
+++ b/crates/bevy_sprite/src/picking_backend.rs
@@ -143,11 +143,11 @@ fn sprite_picking(
         };
 
         let viewport_pos = location.position;
-        if let Some(viewport) = camera.logical_viewport_rect() {
-            if !viewport.contains(viewport_pos) {
-                // The pointer is outside the viewport, skip it
-                continue;
-            }
+        if let Some(viewport) = camera.logical_viewport_rect()
+            && !viewport.contains(viewport_pos)
+        {
+            // The pointer is outside the viewport, skip it
+            continue;
         }
 
         let Ok(cursor_ray_world) = camera.viewport_to_world(cam_transform, viewport_pos) else {

--- a/crates/bevy_state/src/commands.rs
+++ b/crates/bevy_state/src/commands.rs
@@ -19,10 +19,10 @@ impl CommandsStatesExt for Commands<'_, '_> {
     fn set_state<S: FreelyMutableState>(&mut self, state: S) {
         self.queue(move |w: &mut World| {
             let mut next = w.resource_mut::<NextState<S>>();
-            if let NextState::Pending(prev) = &*next {
-                if *prev != state {
-                    debug!("overwriting next state {prev:?} with {state:?}");
-                }
+            if let NextState::Pending(prev) = &*next
+                && *prev != state
+            {
+                debug!("overwriting next state {prev:?} with {state:?}");
             }
             next.set(state);
         });

--- a/crates/bevy_text/src/text_access.rs
+++ b/crates/bevy_text/src/text_access.rs
@@ -74,7 +74,7 @@ pub struct TextReader<'w, 's, R: TextRoot> {
 
 impl<'w, 's, R: TextRoot> TextReader<'w, 's, R> {
     /// Returns an iterator over text spans in a text block, starting with the root entity.
-    pub fn iter(&mut self, root_entity: Entity) -> TextSpanIter<R> {
+    pub fn iter(&mut self, root_entity: Entity) -> TextSpanIter<'_, R> {
         let stack = self.scratch.take();
 
         TextSpanIter {
@@ -254,7 +254,13 @@ impl<'w, 's, R: TextRoot> TextWriter<'w, 's, R> {
         &mut self,
         root_entity: Entity,
         index: usize,
-    ) -> Option<(Entity, usize, Mut<String>, Mut<TextFont>, Mut<TextColor>)> {
+    ) -> Option<(
+        Entity,
+        usize,
+        Mut<'_, String>,
+        Mut<'_, TextFont>,
+        Mut<'_, TextColor>,
+    )> {
         // Root
         if index == 0 {
             let (text, font, color) = self.roots.get_mut(root_entity).ok()?;
@@ -321,17 +327,17 @@ impl<'w, 's, R: TextRoot> TextWriter<'w, 's, R> {
     }
 
     /// Gets the text value of a text span within a text block at a specific index in the flattened span list.
-    pub fn get_text(&mut self, root_entity: Entity, index: usize) -> Option<Mut<String>> {
+    pub fn get_text(&mut self, root_entity: Entity, index: usize) -> Option<Mut<'_, String>> {
         self.get(root_entity, index).map(|(_, _, text, ..)| text)
     }
 
     /// Gets the [`TextFont`] of a text span within a text block at a specific index in the flattened span list.
-    pub fn get_font(&mut self, root_entity: Entity, index: usize) -> Option<Mut<TextFont>> {
+    pub fn get_font(&mut self, root_entity: Entity, index: usize) -> Option<Mut<'_, TextFont>> {
         self.get(root_entity, index).map(|(_, _, _, font, _)| font)
     }
 
     /// Gets the [`TextColor`] of a text span within a text block at a specific index in the flattened span list.
-    pub fn get_color(&mut self, root_entity: Entity, index: usize) -> Option<Mut<TextColor>> {
+    pub fn get_color(&mut self, root_entity: Entity, index: usize) -> Option<Mut<'_, TextColor>> {
         self.get(root_entity, index)
             .map(|(_, _, _, _, color)| color)
     }
@@ -339,21 +345,21 @@ impl<'w, 's, R: TextRoot> TextWriter<'w, 's, R> {
     /// Gets the text value of a text span within a text block at a specific index in the flattened span list.
     ///
     /// Panics if there is no span at the requested index.
-    pub fn text(&mut self, root_entity: Entity, index: usize) -> Mut<String> {
+    pub fn text(&mut self, root_entity: Entity, index: usize) -> Mut<'_, String> {
         self.get_text(root_entity, index).unwrap()
     }
 
     /// Gets the [`TextFont`] of a text span within a text block at a specific index in the flattened span list.
     ///
     /// Panics if there is no span at the requested index.
-    pub fn font(&mut self, root_entity: Entity, index: usize) -> Mut<TextFont> {
+    pub fn font(&mut self, root_entity: Entity, index: usize) -> Mut<'_, TextFont> {
         self.get_font(root_entity, index).unwrap()
     }
 
     /// Gets the [`TextColor`] of a text span within a text block at a specific index in the flattened span list.
     ///
     /// Panics if there is no span at the requested index.
-    pub fn color(&mut self, root_entity: Entity, index: usize) -> Mut<TextColor> {
+    pub fn color(&mut self, root_entity: Entity, index: usize) -> Mut<'_, TextColor> {
         self.get_color(root_entity, index).unwrap()
     }
 

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -178,10 +178,10 @@ pub fn ui_focus_system(
         mouse_button_input.just_released(MouseButton::Left) || touches_input.any_just_released();
     if mouse_released {
         for node in &mut node_query {
-            if let Some(mut interaction) = node.interaction {
-                if *interaction == Interaction::Pressed {
-                    *interaction = Interaction::None;
-                }
+            if let Some(mut interaction) = node.interaction
+                && *interaction == Interaction::Pressed
+            {
+                *interaction = Interaction::None;
             }
         }
     }
@@ -275,12 +275,11 @@ pub fn ui_focus_system(
             if contains_cursor {
                 Some(*entity)
             } else {
-                if let Some(mut interaction) = node.interaction {
-                    if *interaction == Interaction::Hovered
-                        || (normalized_cursor_position.is_none())
-                    {
-                        interaction.set_if_neq(Interaction::None);
-                    }
+                if let Some(mut interaction) = node.interaction
+                    && (*interaction == Interaction::Hovered
+                        || (normalized_cursor_position.is_none()))
+                {
+                    interaction.set_if_neq(Interaction::None);
                 }
                 None
             }
@@ -338,14 +337,13 @@ pub fn clip_check_recursive(
 ) -> bool {
     if let Ok(child_of) = child_of_query.get(entity) {
         let parent = child_of.0;
-        if let Ok((computed_node, transform, node)) = clipping_query.get(parent) {
-            if !computed_node
+        if let Ok((computed_node, transform, node)) = clipping_query.get(parent)
+            && !computed_node
                 .resolve_clip_rect(node.overflow, node.overflow_clip_margin)
                 .contains(transform.inverse().transform_point2(point))
-            {
-                // The point is clipped and should be ignored by picking
-                return false;
-            }
+        {
+            // The point is clipped and should be ignored by picking
+            return false;
         }
         return clip_check_recursive(point, parent, clipping_query, child_of_query);
     }

--- a/crates/bevy_ui_render/src/lib.rs
+++ b/crates/bevy_ui_render/src/lib.rs
@@ -1365,9 +1365,11 @@ pub fn prepare_uinodes(
                     } else if batch_image_handle == AssetId::default()
                         && extracted_uinode.image != AssetId::default()
                     {
-                        if let Some(gpu_image) = gpu_images.get(extracted_uinode.image) {
+                        if let Some(ref mut existing_batch) = existing_batch
+                            && let Some(gpu_image) = gpu_images.get(extracted_uinode.image)
+                        {
                             batch_image_handle = extracted_uinode.image;
-                            existing_batch.as_mut().unwrap().1.image = extracted_uinode.image;
+                            existing_batch.1.image = extracted_uinode.image;
 
                             image_bind_groups
                                 .values

--- a/crates/bevy_ui_render/src/lib.rs
+++ b/crates/bevy_ui_render/src/lib.rs
@@ -610,64 +610,64 @@ pub fn extract_uinode_borders(
         };
 
         // Don't extract borders with zero width along all edges
-        if computed_node.border() != BorderRect::ZERO {
-            if let Some(border_color) = maybe_border_color {
-                let border_colors = [
-                    border_color.left.to_linear(),
-                    border_color.top.to_linear(),
-                    border_color.right.to_linear(),
-                    border_color.bottom.to_linear(),
-                ];
+        if computed_node.border() != BorderRect::ZERO
+            && let Some(border_color) = maybe_border_color
+        {
+            let border_colors = [
+                border_color.left.to_linear(),
+                border_color.top.to_linear(),
+                border_color.right.to_linear(),
+                border_color.bottom.to_linear(),
+            ];
 
-                const BORDER_FLAGS: [u32; 4] = [
-                    shader_flags::BORDER_LEFT,
-                    shader_flags::BORDER_TOP,
-                    shader_flags::BORDER_RIGHT,
-                    shader_flags::BORDER_BOTTOM,
-                ];
-                let mut completed_flags = 0;
+            const BORDER_FLAGS: [u32; 4] = [
+                shader_flags::BORDER_LEFT,
+                shader_flags::BORDER_TOP,
+                shader_flags::BORDER_RIGHT,
+                shader_flags::BORDER_BOTTOM,
+            ];
+            let mut completed_flags = 0;
 
-                for (i, &color) in border_colors.iter().enumerate() {
-                    if color.is_fully_transparent() {
-                        continue;
-                    }
-
-                    let mut border_flags = BORDER_FLAGS[i];
-
-                    if completed_flags & border_flags != 0 {
-                        continue;
-                    }
-
-                    for j in i + 1..4 {
-                        if color == border_colors[j] {
-                            border_flags |= BORDER_FLAGS[j];
-                        }
-                    }
-                    completed_flags |= border_flags;
-
-                    extracted_uinodes.uinodes.push(ExtractedUiNode {
-                        z_order: computed_node.stack_index as f32 + stack_z_offsets::BORDER,
-                        color,
-                        rect: Rect {
-                            max: computed_node.size(),
-                            ..Default::default()
-                        },
-                        image,
-                        clip: maybe_clip.map(|clip| clip.clip),
-                        extracted_camera_entity,
-                        item: ExtractedUiItem::Node {
-                            atlas_scaling: None,
-                            transform: transform.into(),
-                            flip_x: false,
-                            flip_y: false,
-                            border: computed_node.border(),
-                            border_radius: computed_node.border_radius(),
-                            node_type: NodeType::Border(border_flags),
-                        },
-                        main_entity: entity.into(),
-                        render_entity: commands.spawn(TemporaryRenderEntity).id(),
-                    });
+            for (i, &color) in border_colors.iter().enumerate() {
+                if color.is_fully_transparent() {
+                    continue;
                 }
+
+                let mut border_flags = BORDER_FLAGS[i];
+
+                if completed_flags & border_flags != 0 {
+                    continue;
+                }
+
+                for j in i + 1..4 {
+                    if color == border_colors[j] {
+                        border_flags |= BORDER_FLAGS[j];
+                    }
+                }
+                completed_flags |= border_flags;
+
+                extracted_uinodes.uinodes.push(ExtractedUiNode {
+                    z_order: computed_node.stack_index as f32 + stack_z_offsets::BORDER,
+                    color,
+                    rect: Rect {
+                        max: computed_node.size(),
+                        ..Default::default()
+                    },
+                    image,
+                    clip: maybe_clip.map(|clip| clip.clip),
+                    extracted_camera_entity,
+                    item: ExtractedUiItem::Node {
+                        atlas_scaling: None,
+                        transform: transform.into(),
+                        flip_x: false,
+                        flip_y: false,
+                        border: computed_node.border(),
+                        border_radius: computed_node.border_radius(),
+                        node_type: NodeType::Border(border_flags),
+                    },
+                    main_entity: entity.into(),
+                    render_entity: commands.spawn(TemporaryRenderEntity).id(),
+                });
             }
         }
 

--- a/crates/bevy_ui_render/src/ui_texture_slice_pipeline.rs
+++ b/crates/bevy_ui_render/src/ui_texture_slice_pipeline.rs
@@ -445,13 +445,14 @@ pub fn prepare_ui_slices(
                         } else {
                             continue;
                         }
-                    } else if batch_image_handle == AssetId::default()
+                    } else if let Some(ref mut existing_batch) = existing_batch
+                        && batch_image_handle == AssetId::default()
                         && texture_slices.image != AssetId::default()
                     {
                         if let Some(gpu_image) = gpu_images.get(texture_slices.image) {
                             batch_image_handle = texture_slices.image;
                             batch_image_size = gpu_image.size_2d().as_vec2();
-                            existing_batch.as_mut().unwrap().1.image = texture_slices.image;
+                            existing_batch.1.image = texture_slices.image;
 
                             image_bind_groups
                                 .values

--- a/crates/bevy_utils/src/debug_info.rs
+++ b/crates/bevy_utils/src/debug_info.rs
@@ -82,7 +82,7 @@ impl DebugName {
     /// Get the [`ShortName`] corresponding to this debug name
     ///
     /// The value will be a static string if the `debug` feature is not enabled
-    pub fn shortname(&self) -> ShortName {
+    pub fn shortname(&self) -> ShortName<'_> {
         #[cfg(feature = "debug")]
         return ShortName(self.name.as_ref());
         #[cfg(not(feature = "debug"))]

--- a/crates/bevy_window/src/raw_handle.rs
+++ b/crates/bevy_window/src/raw_handle.rs
@@ -138,7 +138,7 @@ unsafe impl Sync for RawHandleWrapper {}
 pub struct ThreadLockedRawWindowHandleWrapper(RawHandleWrapper);
 
 impl HasWindowHandle for ThreadLockedRawWindowHandleWrapper {
-    fn window_handle(&self) -> Result<WindowHandle, HandleError> {
+    fn window_handle(&self) -> Result<WindowHandle<'_>, HandleError> {
         // SAFETY: the caller has validated that this is a valid context to get [`RawHandleWrapper`]
         // as otherwise an instance of this type could not have been constructed
         // NOTE: we cannot simply impl HasRawWindowHandle for RawHandleWrapper,
@@ -150,7 +150,7 @@ impl HasWindowHandle for ThreadLockedRawWindowHandleWrapper {
 }
 
 impl HasDisplayHandle for ThreadLockedRawWindowHandleWrapper {
-    fn display_handle(&self) -> Result<DisplayHandle, HandleError> {
+    fn display_handle(&self) -> Result<DisplayHandle<'_>, HandleError> {
         // SAFETY: the caller has validated that this is a valid context to get [`RawDisplayHandle`]
         // as otherwise an instance of this type could not have been constructed
         // NOTE: we cannot simply impl HasRawDisplayHandle for RawHandleWrapper,

--- a/crates/bevy_winit/src/accessibility.rs
+++ b/crates/bevy_winit/src/accessibility.rs
@@ -214,10 +214,10 @@ fn update_accessibility_nodes(
         if focus.is_changed() || !nodes.is_empty() {
             // Don't panic if the focused entity does not currently exist
             // It's probably waiting to be spawned
-            if let Some(focused_entity) = focus.0 {
-                if !node_entities.contains(focused_entity) {
-                    return;
-                }
+            if let Some(focused_entity) = focus.0
+                && !node_entities.contains(focused_entity)
+            {
+                return;
             }
 
             adapter.update_if_active(|| {

--- a/crates/bevy_winit/src/state.rs
+++ b/crates/bevy_winit/src/state.rs
@@ -232,10 +232,10 @@ impl<T: BufferedEvent> ApplicationHandler<T> for WinitAppRunnerState<T> {
 
                 // Allow AccessKit to respond to `WindowEvent`s before they reach
                 // the engine.
-                if let Some(adapter) = access_kit_adapters.get_mut(&window) {
-                    if let Some(winit_window) = winit_windows.get_window(window) {
-                        adapter.process_event(winit_window, &event);
-                    }
+                if let Some(adapter) = access_kit_adapters.get_mut(&window)
+                    && let Some(winit_window) = winit_windows.get_window(window)
+                {
+                    adapter.process_event(winit_window, &event);
                 }
 
                 match event {
@@ -417,10 +417,9 @@ impl<T: BufferedEvent> ApplicationHandler<T> for WinitAppRunnerState<T> {
 
                 let mut windows = self.world_mut().query::<(&mut Window, &mut CachedWindow)>();
                 if let Ok((window_component, mut cache)) = windows.get_mut(self.world_mut(), window)
+                    && window_component.is_changed()
                 {
-                    if window_component.is_changed() {
-                        **cache = window_component.clone();
-                    }
+                    **cache = window_component.clone();
                 }
             });
         });
@@ -505,10 +504,10 @@ impl<T: BufferedEvent> WinitAppRunnerState<T> {
         let mut focused_windows_state: SystemState<(Res<WinitSettings>, Query<(Entity, &Window)>)> =
             SystemState::new(self.world_mut());
 
-        if let Some(app_redraw_events) = self.world().get_resource::<Events<RequestRedraw>>() {
-            if redraw_event_reader.read(app_redraw_events).last().is_some() {
-                self.redraw_requested = true;
-            }
+        if let Some(app_redraw_events) = self.world().get_resource::<Events<RequestRedraw>>()
+            && redraw_event_reader.read(app_redraw_events).last().is_some()
+        {
+            self.redraw_requested = true;
         }
 
         let (config, windows) = focused_windows_state.get(self.world());
@@ -673,10 +672,10 @@ impl<T: BufferedEvent> WinitAppRunnerState<T> {
             }
             UpdateMode::Reactive { wait, .. } => {
                 // Set the next timeout, starting from the instant before running app.update() to avoid frame delays
-                if let Some(next) = begin_frame_time.checked_add(wait) {
-                    if self.wait_elapsed {
-                        event_loop.set_control_flow(ControlFlow::WaitUntil(next));
-                    }
+                if let Some(next) = begin_frame_time.checked_add(wait)
+                    && self.wait_elapsed
+                {
+                    event_loop.set_control_flow(ControlFlow::WaitUntil(next));
                 }
             }
         }

--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -349,11 +349,10 @@ pub(crate) fn changed_windows(
                     WindowMode::Windowed => Some(None),
                 };
 
-                if let Some(new_mode) = new_mode {
-                    if winit_window.fullscreen() != new_mode {
+                if let Some(new_mode) = new_mode
+                    && winit_window.fullscreen() != new_mode {
                         winit_window.set_fullscreen(new_mode);
                     }
-                }
             }
 
             if window.resolution != cache.resolution {
@@ -394,22 +393,20 @@ pub(crate) fn changed_windows(
                     }
                 }
 
-                if physical_size != cached_physical_size {
-                    if let Some(new_physical_size) = winit_window.request_inner_size(physical_size) {
+                if physical_size != cached_physical_size
+                    && let Some(new_physical_size) = winit_window.request_inner_size(physical_size) {
                         react_to_resize(entity, &mut window, new_physical_size, &mut window_resized);
                     }
-                }
             }
 
-            if window.physical_cursor_position() != cache.physical_cursor_position() {
-                if let Some(physical_position) = window.physical_cursor_position() {
+            if window.physical_cursor_position() != cache.physical_cursor_position()
+                && let Some(physical_position) = window.physical_cursor_position() {
                     let position = PhysicalPosition::new(physical_position.x, physical_position.y);
 
                     if let Err(err) = winit_window.set_cursor_position(position) {
                         error!("could not set cursor position: {}", err);
                     }
                 }
-            }
 
             if window.decorations != cache.decorations
                 && window.decorations != winit_window.is_decorated()
@@ -444,8 +441,8 @@ pub(crate) fn changed_windows(
                 }
             }
 
-            if window.position != cache.position {
-                if let Some(position) = crate::winit_window_position(
+            if window.position != cache.position
+                && let Some(position) = crate::winit_window_position(
                     &window.position,
                     &window.resolution,
                     &monitors,
@@ -461,7 +458,6 @@ pub(crate) fn changed_windows(
                         winit_window.set_outer_position(position);
                     }
                 }
-            }
 
             if let Some(maximized) = window.internal.take_maximize_request() {
                 winit_window.set_maximized(maximized);
@@ -471,19 +467,17 @@ pub(crate) fn changed_windows(
                 winit_window.set_minimized(minimized);
             }
 
-            if window.internal.take_move_request() {
-                if let Err(e) = winit_window.drag_window() {
+            if window.internal.take_move_request()
+                && let Err(e) = winit_window.drag_window() {
                     warn!("Winit returned an error while attempting to drag the window: {e}");
                 }
-            }
 
-            if let Some(resize_direction) = window.internal.take_resize_request() {
-                if let Err(e) =
+            if let Some(resize_direction) = window.internal.take_resize_request()
+                && let Err(e) =
                     winit_window.drag_resize_window(convert_resize_direction(resize_direction))
                 {
                     warn!("Winit returned an error while attempting to drag resize the window: {e}");
                 }
-            }
 
             if window.focused != cache.focused && window.focused {
                 winit_window.focus_window();

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -324,13 +324,13 @@ impl WinitWindows {
 
         // Do not set the cursor hittest on window creation if it's false, as it will always fail on
         // some platforms and log an unfixable warning.
-        if !cursor_options.hit_test {
-            if let Err(err) = winit_window.set_cursor_hittest(cursor_options.hit_test) {
-                warn!(
-                    "Could not set cursor hit test for window {}: {}",
-                    window.title, err
-                );
-            }
+        if !cursor_options.hit_test
+            && let Err(err) = winit_window.set_cursor_hittest(cursor_options.hit_test)
+        {
+            warn!(
+                "Could not set cursor hit test for window {}: {}",
+                window.title, err
+            );
         }
 
         self.entity_to_winit.insert(entity, winit_window.id());

--- a/examples/2d/sprite_animation.rs
+++ b/examples/2d/sprite_animation.rs
@@ -60,17 +60,17 @@ fn execute_animations(time: Res<Time>, mut query: Query<(&mut AnimationConfig, &
         config.frame_timer.tick(time.delta());
 
         // If it has been displayed for the user-defined amount of time (fps)...
-        if config.frame_timer.just_finished() {
-            if let Some(atlas) = &mut sprite.texture_atlas {
-                if atlas.index == config.last_sprite_index {
-                    // ...and it IS the last frame, then we move back to the first frame and stop.
-                    atlas.index = config.first_sprite_index;
-                } else {
-                    // ...and it is NOT the last frame, then we move to the next frame...
-                    atlas.index += 1;
-                    // ...and reset the frame timer to start counting all over again
-                    config.frame_timer = AnimationConfig::timer_from_fps(config.fps);
-                }
+        if config.frame_timer.just_finished()
+            && let Some(atlas) = &mut sprite.texture_atlas
+        {
+            if atlas.index == config.last_sprite_index {
+                // ...and it IS the last frame, then we move back to the first frame and stop.
+                atlas.index = config.first_sprite_index;
+            } else {
+                // ...and it is NOT the last frame, then we move to the next frame...
+                atlas.index += 1;
+                // ...and reset the frame timer to start counting all over again
+                config.frame_timer = AnimationConfig::timer_from_fps(config.fps);
             }
         }
     }

--- a/examples/2d/sprite_scale.rs
+++ b/examples/2d/sprite_scale.rs
@@ -315,14 +315,14 @@ fn animate_sprite(
     for (indices, mut timer, mut sprite) in &mut query {
         timer.tick(time.delta());
 
-        if timer.just_finished() {
-            if let Some(atlas) = &mut sprite.texture_atlas {
-                atlas.index = if atlas.index == indices.last {
-                    indices.first
-                } else {
-                    atlas.index + 1
-                };
-            }
+        if timer.just_finished()
+            && let Some(atlas) = &mut sprite.texture_atlas
+        {
+            atlas.index = if atlas.index == indices.last {
+                indices.first
+            } else {
+                atlas.index + 1
+            };
         }
     }
 }

--- a/examples/2d/sprite_sheet.rs
+++ b/examples/2d/sprite_sheet.rs
@@ -27,14 +27,14 @@ fn animate_sprite(
     for (indices, mut timer, mut sprite) in &mut query {
         timer.tick(time.delta());
 
-        if timer.just_finished() {
-            if let Some(atlas) = &mut sprite.texture_atlas {
-                atlas.index = if atlas.index == indices.last {
-                    indices.first
-                } else {
-                    atlas.index + 1
-                };
-            }
+        if timer.just_finished()
+            && let Some(atlas) = &mut sprite.texture_atlas
+        {
+            atlas.index = if atlas.index == indices.last {
+                indices.first
+            } else {
+                atlas.index + 1
+            };
         }
     }
 }

--- a/examples/3d/animated_material.rs
+++ b/examples/3d/animated_material.rs
@@ -50,10 +50,10 @@ fn animate_materials(
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
     for material_handle in material_handles.iter() {
-        if let Some(material) = materials.get_mut(material_handle) {
-            if let Color::Hsla(ref mut hsla) = material.base_color {
-                *hsla = hsla.rotate_hue(time.delta_secs() * 100.0);
-            }
+        if let Some(material) = materials.get_mut(material_handle)
+            && let Color::Hsla(ref mut hsla) = material.base_color
+        {
+            *hsla = hsla.rotate_hue(time.delta_secs() * 100.0);
         }
     }
 }

--- a/examples/3d/light_textures.rs
+++ b/examples/3d/light_textures.rs
@@ -365,17 +365,17 @@ fn spawn_help_text(commands: &mut Commands, app_status: &AppStatus) {
 
 /// Draws the outlines that show the bounds of the spotlight.
 fn draw_gizmos(mut gizmos: Gizmos, spotlight: Query<(&GlobalTransform, &SpotLight, &Visibility)>) {
-    if let Ok((global_transform, spotlight, visibility)) = spotlight.single() {
-        if visibility != Visibility::Hidden {
-            gizmos.primitive_3d(
-                &Cone::new(7.0 * spotlight.outer_angle, 7.0),
-                Isometry3d {
-                    rotation: global_transform.rotation() * Quat::from_rotation_x(FRAC_PI_2),
-                    translation: global_transform.translation_vec3a() * 0.5,
-                },
-                YELLOW,
-            );
-        }
+    if let Ok((global_transform, spotlight, visibility)) = spotlight.single()
+        && visibility != Visibility::Hidden
+    {
+        gizmos.primitive_3d(
+            &Cone::new(7.0 * spotlight.outer_angle, 7.0),
+            Isometry3d {
+                rotation: global_transform.rotation() * Quat::from_rotation_x(FRAC_PI_2),
+                translation: global_transform.translation_vec3a() * 0.5,
+            },
+            YELLOW,
+        );
     }
 }
 

--- a/examples/3d/query_gltf_primitives.rs
+++ b/examples/3d/query_gltf_primitives.rs
@@ -34,18 +34,17 @@ fn find_top_material_and_mesh(
                 }
             }
 
-            if let Some(mesh) = meshes.get_mut(mesh_handle) {
-                if let Some(VertexAttributeValues::Float32x3(positions)) =
+            if let Some(mesh) = meshes.get_mut(mesh_handle)
+                && let Some(VertexAttributeValues::Float32x3(positions)) =
                     mesh.attribute_mut(Mesh::ATTRIBUTE_POSITION)
-                {
-                    for position in positions {
-                        *position = (
-                            position[0],
-                            1.5 + 0.5 * ops::sin(time.elapsed_secs() / 2.0),
-                            position[2],
-                        )
-                            .into();
-                    }
+            {
+                for position in positions {
+                    *position = (
+                        position[0],
+                        1.5 + 0.5 * ops::sin(time.elapsed_secs() / 2.0),
+                        position[2],
+                    )
+                        .into();
                 }
             }
         }

--- a/examples/3d/reflection_probes.rs
+++ b/examples/3d/reflection_probes.rs
@@ -367,14 +367,13 @@ impl FromWorld for Cubemaps {
 }
 
 fn setup_environment_map_usage(cubemaps: Res<Cubemaps>, mut images: ResMut<Assets<Image>>) {
-    if let Some(image) = images.get_mut(&cubemaps.specular_environment_map) {
-        if !image
+    if let Some(image) = images.get_mut(&cubemaps.specular_environment_map)
+        && !image
             .texture_descriptor
             .usage
             .contains(TextureUsages::COPY_SRC)
-        {
-            image.texture_descriptor.usage |= TextureUsages::COPY_SRC;
-        }
+    {
+        image.texture_descriptor.usage |= TextureUsages::COPY_SRC;
     }
 }
 

--- a/examples/3d/solari.rs
+++ b/examples/3d/solari.rs
@@ -93,10 +93,10 @@ fn add_raytracing_meshes_on_scene_load(
         mesh.remove_attribute(Mesh::ATTRIBUTE_COLOR.id);
         mesh.generate_tangents().unwrap();
 
-        if let Some(indices) = mesh.indices_mut() {
-            if let Indices::U16(u16_indices) = indices {
-                *indices = Indices::U32(u16_indices.iter().map(|i| *i as u32).collect());
-            }
+        if let Some(indices) = mesh.indices_mut()
+            && let Indices::U16(u16_indices) = indices
+        {
+            *indices = Indices::U32(u16_indices.iter().map(|i| *i as u32).collect());
         }
     }
 

--- a/examples/animation/animated_ui.rs
+++ b/examples/animation/animated_ui.rs
@@ -171,7 +171,7 @@ struct TextColorProperty;
 impl AnimatableProperty for TextColorProperty {
     type Property = Srgba;
 
-    fn evaluator_id(&self) -> EvaluatorId {
+    fn evaluator_id(&self) -> EvaluatorId<'_> {
         EvaluatorId::Type(TypeId::of::<Self>())
     }
 

--- a/examples/ecs/dynamic.rs
+++ b/examples/ecs/dynamic.rs
@@ -231,11 +231,11 @@ fn parse_term<Q: QueryData>(
             let mut parts = str.split_whitespace();
             let first = parts.next().unwrap();
             if first == "&mut" {
-                if let Some(str) = parts.next() {
-                    if let Some(&id) = components.get(str) {
-                        builder.mut_id(id);
-                        matched = true;
-                    }
+                if let Some(str) = parts.next()
+                    && let Some(&id) = components.get(str)
+                {
+                    builder.mut_id(id);
+                    matched = true;
                 };
             } else if let Some(&id) = components.get(&first[1..]) {
                 builder.ref_id(id);

--- a/examples/ecs/dynamic.rs
+++ b/examples/ecs/dynamic.rs
@@ -197,7 +197,7 @@ fn main() {
 
 // Constructs `OwningPtr` for each item in `components`
 // By sharing the lifetime of `components` with the resulting ptrs we ensure we don't drop the data before use
-fn to_owning_ptrs(components: &mut [Vec<u64>]) -> Vec<OwningPtr<Aligned>> {
+fn to_owning_ptrs(components: &mut [Vec<u64>]) -> Vec<OwningPtr<'_, Aligned>> {
     components
         .iter_mut()
         .map(|data| {

--- a/examples/ecs/fallible_params.rs
+++ b/examples/ecs/fallible_params.rs
@@ -110,10 +110,10 @@ fn user_input(
         ));
     }
 
-    if keyboard_input.just_pressed(KeyCode::KeyR) {
-        if let Some(entity) = enemies.iter().next() {
-            commands.entity(entity).despawn();
-        }
+    if keyboard_input.just_pressed(KeyCode::KeyR)
+        && let Some(entity) = enemies.iter().next()
+    {
+        commands.entity(entity).despawn();
     }
 }
 

--- a/examples/ecs/observers.rs
+++ b/examples/ecs/observers.rs
@@ -176,10 +176,9 @@ fn handle_click(
         .cursor_position()
         .and_then(|cursor| camera.viewport_to_world(camera_transform, cursor).ok())
         .map(|ray| ray.origin.truncate())
+        && mouse_button_input.just_pressed(MouseButton::Left)
     {
-        if mouse_button_input.just_pressed(MouseButton::Left) {
-            commands.trigger(ExplodeMines { pos, radius: 1.0 });
-        }
+        commands.trigger(ExplodeMines { pos, radius: 1.0 });
     }
 }
 

--- a/examples/ecs/removal_detection.rs
+++ b/examples/ecs/removal_detection.rs
@@ -41,10 +41,10 @@ fn remove_component(
     query: Query<Entity, With<MyComponent>>,
 ) {
     // After two seconds have passed the `Component` is removed.
-    if time.elapsed_secs() > 2.0 {
-        if let Some(entity) = query.iter().next() {
-            commands.entity(entity).remove::<MyComponent>();
-        }
+    if time.elapsed_secs() > 2.0
+        && let Some(entity) = query.iter().next()
+    {
+        commands.entity(entity).remove::<MyComponent>();
     }
 }
 

--- a/examples/games/alien_cake_addict.rs
+++ b/examples/games/alien_cake_addict.rs
@@ -252,13 +252,14 @@ fn move_player(
     }
 
     // eat the cake!
-    if let Some(entity) = game.bonus.entity {
-        if game.player.i == game.bonus.i && game.player.j == game.bonus.j {
-            game.score += 2;
-            game.cake_eaten += 1;
-            commands.entity(entity).despawn();
-            game.bonus.entity = None;
-        }
+    if let Some(entity) = game.bonus.entity
+        && game.player.i == game.bonus.i
+        && game.player.j == game.bonus.j
+    {
+        game.score += 2;
+        game.cake_eaten += 1;
+        commands.entity(entity).despawn();
+        game.bonus.entity = None;
     }
 }
 
@@ -362,12 +363,12 @@ fn spawn_bonus(
 
 // let the cake turn on itself
 fn rotate_bonus(game: Res<Game>, time: Res<Time>, mut transforms: Query<&mut Transform>) {
-    if let Some(entity) = game.bonus.entity {
-        if let Ok(mut cake_transform) = transforms.get_mut(entity) {
-            cake_transform.rotate_y(time.delta_secs());
-            cake_transform.scale =
-                Vec3::splat(1.0 + (game.score as f32 / 10.0 * ops::sin(time.elapsed_secs())).abs());
-        }
+    if let Some(entity) = game.bonus.entity
+        && let Ok(mut cake_transform) = transforms.get_mut(entity)
+    {
+        cake_transform.rotate_y(time.delta_secs());
+        cake_transform.scale =
+            Vec3::splat(1.0 + (game.score as f32 / 10.0 * ops::sin(time.elapsed_secs())).abs());
     }
 }
 

--- a/examples/games/stepping.rs
+++ b/examples/games/stepping.rs
@@ -260,10 +260,9 @@ fn update_ui(
         return;
     }
 
-    let (cursor_schedule, cursor_system) = match stepping.cursor() {
-        // no cursor means stepping isn't enabled, so we're done here
-        None => return,
-        Some(c) => c,
+    // no cursor means stepping isn't enabled, so we're done here
+    let Some((cursor_schedule, cursor_system)) = stepping.cursor() else {
+        return;
     };
 
     for (schedule, system, text_index) in &state.systems {

--- a/examples/no_std/library/src/lib.rs
+++ b/examples/no_std/library/src/lib.rs
@@ -126,10 +126,10 @@ fn tick_timers(
 }
 
 fn unwrap<B: Bundle>(trigger: On<Unwrap>, world: &mut World) {
-    if let Ok(mut target) = world.get_entity_mut(trigger.target()) {
-        if let Some(DelayedComponent(bundle)) = target.take::<DelayedComponent<B>>() {
-            target.insert(bundle);
-        }
+    if let Ok(mut target) = world.get_entity_mut(trigger.target())
+        && let Some(DelayedComponent(bundle)) = target.take::<DelayedComponent<B>>()
+    {
+        target.insert(bundle);
     }
 
     world.despawn(trigger.observer());

--- a/examples/scene/scene.rs
+++ b/examples/scene/scene.rs
@@ -141,10 +141,10 @@ fn log_system(
             component_a.x, component_a.y
         );
     }
-    if let Some(res) = res {
-        if res.is_added() {
-            info!("  New ResourceA: {{ score: {} }}\n", res.score);
-        }
+    if let Some(res) = res
+        && res.is_added()
+    {
+        info!("  New ResourceA: {{ score: {} }}\n", res.score);
     }
 }
 

--- a/examples/state/computed_states.rs
+++ b/examples/state/computed_states.rs
@@ -271,13 +271,13 @@ fn toggle_pause(
     current_state: Res<State<AppState>>,
     mut next_state: ResMut<NextState<AppState>>,
 ) {
-    if input.just_pressed(KeyCode::Space) {
-        if let AppState::InGame { paused, turbo } = current_state.get() {
-            next_state.set(AppState::InGame {
-                paused: !*paused,
-                turbo: *turbo,
-            });
-        }
+    if input.just_pressed(KeyCode::Space)
+        && let AppState::InGame { paused, turbo } = current_state.get()
+    {
+        next_state.set(AppState::InGame {
+            paused: !*paused,
+            turbo: *turbo,
+        });
     }
 }
 
@@ -286,13 +286,13 @@ fn toggle_turbo(
     current_state: Res<State<AppState>>,
     mut next_state: ResMut<NextState<AppState>>,
 ) {
-    if input.just_pressed(KeyCode::KeyT) {
-        if let AppState::InGame { paused, turbo } = current_state.get() {
-            next_state.set(AppState::InGame {
-                paused: *paused,
-                turbo: !*turbo,
-            });
-        }
+    if input.just_pressed(KeyCode::KeyT)
+        && let AppState::InGame { paused, turbo } = current_state.get()
+    {
+        next_state.set(AppState::InGame {
+            paused: *paused,
+            turbo: !*turbo,
+        });
     }
 }
 

--- a/examples/tools/scene_viewer/main.rs
+++ b/examples/tools/scene_viewer/main.rs
@@ -101,13 +101,12 @@ fn main() {
 fn parse_scene(scene_path: String) -> (String, usize) {
     if scene_path.contains('#') {
         let gltf_and_scene = scene_path.split('#').collect::<Vec<_>>();
-        if let Some((last, path)) = gltf_and_scene.split_last() {
-            if let Some(index) = last
+        if let Some((last, path)) = gltf_and_scene.split_last()
+            && let Some(index) = last
                 .strip_prefix("Scene")
                 .and_then(|index| index.parse::<usize>().ok())
-            {
-                return (path.join("#"), index);
-            }
+        {
+            return (path.join("#"), index);
         }
     }
     (scene_path, 0)

--- a/examples/tools/scene_viewer/scene_viewer_plugin.rs
+++ b/examples/tools/scene_viewer/scene_viewer_plugin.rs
@@ -218,17 +218,17 @@ fn camera_tracker(
 
     if keyboard_input.just_pressed(KeyCode::KeyC) {
         // disable currently active camera
-        if let Some(e) = camera_tracker.active_camera() {
-            if let Ok(mut camera) = queries.p2().get_mut(e) {
-                camera.is_active = false;
-            }
+        if let Some(e) = camera_tracker.active_camera()
+            && let Ok(mut camera) = queries.p2().get_mut(e)
+        {
+            camera.is_active = false;
         }
 
         // enable next active camera
-        if let Some(e) = camera_tracker.set_next_active() {
-            if let Ok(mut camera) = queries.p2().get_mut(e) {
-                camera.is_active = true;
-            }
+        if let Some(e) = camera_tracker.set_next_active()
+            && let Ok(mut camera) = queries.p2().get_mut(e)
+        {
+            camera.is_active = true;
         }
     }
 }

--- a/examples/ui/core_widgets.rs
+++ b/examples/ui/core_widgets.rs
@@ -423,11 +423,11 @@ fn update_slider_style(
 ) {
     for (slider_ent, value, range, hovered, drag_state, disabled) in sliders.iter() {
         for child in children.iter_descendants(slider_ent) {
-            if let Ok((mut thumb_node, mut thumb_bg, is_thumb)) = thumbs.get_mut(child) {
-                if is_thumb {
-                    thumb_node.left = Val::Percent(range.thumb_position(value.0) * 100.0);
-                    thumb_bg.0 = thumb_color(disabled, hovered.0 | drag_state.dragging);
-                }
+            if let Ok((mut thumb_node, mut thumb_bg, is_thumb)) = thumbs.get_mut(child)
+                && is_thumb
+            {
+                thumb_node.left = Val::Percent(range.thumb_position(value.0) * 100.0);
+                thumb_bg.0 = thumb_color(disabled, hovered.0 | drag_state.dragging);
             }
         }
     }
@@ -450,10 +450,10 @@ fn update_slider_style2(
     removed_disabled.read().for_each(|entity| {
         if let Ok((slider_ent, hovered, drag_state, disabled)) = sliders.get(entity) {
             for child in children.iter_descendants(slider_ent) {
-                if let Ok((mut thumb_bg, is_thumb)) = thumbs.get_mut(child) {
-                    if is_thumb {
-                        thumb_bg.0 = thumb_color(disabled, hovered.0 | drag_state.dragging);
-                    }
+                if let Ok((mut thumb_bg, is_thumb)) = thumbs.get_mut(child)
+                    && is_thumb
+                {
+                    thumb_bg.0 = thumb_color(disabled, hovered.0 | drag_state.dragging);
                 }
             }
         }

--- a/examples/ui/core_widgets_observers.rs
+++ b/examples/ui/core_widgets_observers.rs
@@ -431,10 +431,10 @@ fn slider_on_add_disabled(
 ) {
     if let Ok((slider_ent, hovered)) = sliders.get(trigger.target()) {
         for child in children.iter_descendants(slider_ent) {
-            if let Ok((mut thumb_bg, is_thumb)) = thumbs.get_mut(child) {
-                if is_thumb {
-                    thumb_bg.0 = thumb_color(true, hovered.0);
-                }
+            if let Ok((mut thumb_bg, is_thumb)) = thumbs.get_mut(child)
+                && is_thumb
+            {
+                thumb_bg.0 = thumb_color(true, hovered.0);
             }
         }
     }
@@ -448,10 +448,10 @@ fn slider_on_remove_disabled(
 ) {
     if let Ok((slider_ent, hovered)) = sliders.get(trigger.target()) {
         for child in children.iter_descendants(slider_ent) {
-            if let Ok((mut thumb_bg, is_thumb)) = thumbs.get_mut(child) {
-                if is_thumb {
-                    thumb_bg.0 = thumb_color(false, hovered.0);
-                }
+            if let Ok((mut thumb_bg, is_thumb)) = thumbs.get_mut(child)
+                && is_thumb
+            {
+                thumb_bg.0 = thumb_color(false, hovered.0);
             }
         }
     }
@@ -465,10 +465,10 @@ fn slider_on_change_hover(
 ) {
     if let Ok((slider_ent, hovered, disabled)) = sliders.get(trigger.target()) {
         for child in children.iter_descendants(slider_ent) {
-            if let Ok((mut thumb_bg, is_thumb)) = thumbs.get_mut(child) {
-                if is_thumb {
-                    thumb_bg.0 = thumb_color(disabled, hovered.0);
-                }
+            if let Ok((mut thumb_bg, is_thumb)) = thumbs.get_mut(child)
+                && is_thumb
+            {
+                thumb_bg.0 = thumb_color(disabled, hovered.0);
             }
         }
     }
@@ -482,10 +482,10 @@ fn slider_on_change_value(
 ) {
     if let Ok((slider_ent, value, range)) = sliders.get(trigger.target()) {
         for child in children.iter_descendants(slider_ent) {
-            if let Ok((mut thumb_node, is_thumb)) = thumbs.get_mut(child) {
-                if is_thumb {
-                    thumb_node.left = Val::Percent(range.thumb_position(value.0) * 100.0);
-                }
+            if let Ok((mut thumb_node, is_thumb)) = thumbs.get_mut(child)
+                && is_thumb
+            {
+                thumb_node.left = Val::Percent(range.thumb_position(value.0) * 100.0);
             }
         }
     }
@@ -499,10 +499,10 @@ fn slider_on_change_range(
 ) {
     if let Ok((slider_ent, value, range)) = sliders.get(trigger.target()) {
         for child in children.iter_descendants(slider_ent) {
-            if let Ok((mut thumb_node, is_thumb)) = thumbs.get_mut(child) {
-                if is_thumb {
-                    thumb_node.left = Val::Percent(range.thumb_position(value.0) * 100.0);
-                }
+            if let Ok((mut thumb_node, is_thumb)) = thumbs.get_mut(child)
+                && is_thumb
+            {
+                thumb_node.left = Val::Percent(range.thumb_position(value.0) * 100.0);
             }
         }
     }

--- a/examples/ui/directional_navigation.rs
+++ b/examples/ui/directional_navigation.rs
@@ -378,36 +378,35 @@ fn interact_with_focused_button(
     if action_state
         .pressed_actions
         .contains(&DirectionalNavigationAction::Select)
+        && let Some(focused_entity) = input_focus.0
     {
-        if let Some(focused_entity) = input_focus.0 {
-            commands.trigger_targets(
-                Pointer::<Click> {
-                    // We're pretending that we're a mouse
-                    pointer_id: PointerId::Mouse,
-                    // This field isn't used, so we're just setting it to a placeholder value
-                    pointer_location: Location {
-                        target: NormalizedRenderTarget::Image(
-                            bevy::render::camera::ImageRenderTarget {
-                                handle: Handle::default(),
-                                scale_factor: FloatOrd(1.0),
-                            },
-                        ),
-                        position: Vec2::ZERO,
-                    },
-                    event: Click {
-                        button: PointerButton::Primary,
-                        // This field isn't used, so we're just setting it to a placeholder value
-                        hit: HitData {
-                            camera: Entity::PLACEHOLDER,
-                            depth: 0.0,
-                            position: None,
-                            normal: None,
+        commands.trigger_targets(
+            Pointer::<Click> {
+                // We're pretending that we're a mouse
+                pointer_id: PointerId::Mouse,
+                // This field isn't used, so we're just setting it to a placeholder value
+                pointer_location: Location {
+                    target: NormalizedRenderTarget::Image(
+                        bevy::render::camera::ImageRenderTarget {
+                            handle: Handle::default(),
+                            scale_factor: FloatOrd(1.0),
                         },
-                        duration: Duration::from_secs_f32(0.1),
-                    },
+                    ),
+                    position: Vec2::ZERO,
                 },
-                focused_entity,
-            );
-        }
+                event: Click {
+                    button: PointerButton::Primary,
+                    // This field isn't used, so we're just setting it to a placeholder value
+                    hit: HitData {
+                        camera: Entity::PLACEHOLDER,
+                        depth: 0.0,
+                        position: None,
+                        normal: None,
+                    },
+                    duration: Duration::from_secs_f32(0.1),
+                },
+            },
+            focused_entity,
+        );
     }
 }

--- a/examples/ui/font_atlas_debug.rs
+++ b/examples/ui/font_atlas_debug.rs
@@ -41,25 +41,25 @@ fn atlas_render_system(
     font_atlas_sets: Res<FontAtlasSets>,
     images: Res<Assets<Image>>,
 ) {
-    if let Some(set) = font_atlas_sets.get(&state.handle) {
-        if let Some((_size, font_atlases)) = set.iter().next() {
-            let x_offset = state.atlas_count as f32;
-            if state.atlas_count == font_atlases.len() as u32 {
-                return;
-            }
-            let font_atlas = &font_atlases[state.atlas_count as usize];
-            let image = images.get(&font_atlas.texture).unwrap();
-            state.atlas_count += 1;
-            commands.spawn((
-                ImageNode::new(font_atlas.texture.clone()),
-                Node {
-                    position_type: PositionType::Absolute,
-                    top: Val::ZERO,
-                    left: Val::Px(image.width() as f32 * x_offset),
-                    ..default()
-                },
-            ));
+    if let Some(set) = font_atlas_sets.get(&state.handle)
+        && let Some((_size, font_atlases)) = set.iter().next()
+    {
+        let x_offset = state.atlas_count as f32;
+        if state.atlas_count == font_atlases.len() as u32 {
+            return;
         }
+        let font_atlas = &font_atlases[state.atlas_count as usize];
+        let image = images.get(&font_atlas.texture).unwrap();
+        state.atlas_count += 1;
+        commands.spawn((
+            ImageNode::new(font_atlas.texture.clone()),
+            Node {
+                position_type: PositionType::Absolute,
+                top: Val::ZERO,
+                left: Val::Px(image.width() as f32 * x_offset),
+                ..default()
+            },
+        ));
     }
 }
 

--- a/examples/ui/size_constraints.rs
+++ b/examples/ui/size_constraints.rs
@@ -290,10 +290,10 @@ fn update_buttons(
                     for &child in children {
                         if let Ok(grand_children) = children_query.get(child) {
                             for &grandchild in grand_children {
-                                if let Ok(mut text_color) = text_query.get_mut(grandchild) {
-                                    if text_color.0 != ACTIVE_TEXT_COLOR {
-                                        text_color.0 = HOVERED_TEXT_COLOR;
-                                    }
+                                if let Ok(mut text_color) = text_query.get_mut(grandchild)
+                                    && text_color.0 != ACTIVE_TEXT_COLOR
+                                {
+                                    text_color.0 = HOVERED_TEXT_COLOR;
                                 }
                             }
                         }
@@ -305,10 +305,10 @@ fn update_buttons(
                     for &child in children {
                         if let Ok(grand_children) = children_query.get(child) {
                             for &grandchild in grand_children {
-                                if let Ok(mut text_color) = text_query.get_mut(grandchild) {
-                                    if text_color.0 != ACTIVE_TEXT_COLOR {
-                                        text_color.0 = UNHOVERED_TEXT_COLOR;
-                                    }
+                                if let Ok(mut text_color) = text_query.get_mut(grandchild)
+                                    && text_color.0 != ACTIVE_TEXT_COLOR
+                                {
+                                    text_color.0 = UNHOVERED_TEXT_COLOR;
                                 }
                             }
                         }

--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -135,11 +135,11 @@ fn text_update_system(
     mut query: Query<&mut TextSpan, With<FpsText>>,
 ) {
     for mut span in &mut query {
-        if let Some(fps) = diagnostics.get(&FrameTimeDiagnosticsPlugin::FPS) {
-            if let Some(value) = fps.smoothed() {
-                // Update the value of the second section
-                **span = format!("{value:.2}");
-            }
+        if let Some(fps) = diagnostics.get(&FrameTimeDiagnosticsPlugin::FPS)
+            && let Some(value) = fps.smoothed()
+        {
+            // Update the value of the second section
+            **span = format!("{value:.2}");
         }
     }
 }

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -266,19 +266,18 @@ fn change_text_system(
 
     for entity in &query {
         let mut fps = 0.0;
-        if let Some(fps_diagnostic) = diagnostics.get(&FrameTimeDiagnosticsPlugin::FPS) {
-            if let Some(fps_smoothed) = fps_diagnostic.smoothed() {
-                fps = fps_smoothed;
-            }
+        if let Some(fps_diagnostic) = diagnostics.get(&FrameTimeDiagnosticsPlugin::FPS)
+            && let Some(fps_smoothed) = fps_diagnostic.smoothed()
+        {
+            fps = fps_smoothed;
         }
 
         let mut frame_time = time.delta_secs_f64();
         if let Some(frame_time_diagnostic) =
             diagnostics.get(&FrameTimeDiagnosticsPlugin::FRAME_TIME)
+            && let Some(frame_time_smoothed) = frame_time_diagnostic.smoothed()
         {
-            if let Some(frame_time_smoothed) = frame_time_diagnostic.smoothed() {
-                frame_time = frame_time_smoothed;
-            }
+            frame_time = frame_time_smoothed;
         }
 
         *writer.text(entity, 0) =

--- a/examples/window/custom_cursor_image.rs
+++ b/examples/window/custom_cursor_image.rs
@@ -117,16 +117,16 @@ fn execute_animation(time: Res<Time>, mut query: Query<(&mut AnimationConfig, &m
         if let CursorIcon::Custom(CustomCursor::Image(ref mut image)) = *cursor_icon {
             config.frame_timer.tick(time.delta());
 
-            if config.frame_timer.is_finished() {
-                if let Some(atlas) = image.texture_atlas.as_mut() {
-                    atlas.index += config.increment;
+            if config.frame_timer.is_finished()
+                && let Some(atlas) = image.texture_atlas.as_mut()
+            {
+                atlas.index += config.increment;
 
-                    if atlas.index > config.last_sprite_index {
-                        atlas.index = config.first_sprite_index;
-                    }
-
-                    config.frame_timer = AnimationConfig::timer_from_fps(config.fps);
+                if atlas.index > config.last_sprite_index {
+                    atlas.index = config.first_sprite_index;
                 }
+
+                config.frame_timer = AnimationConfig::timer_from_fps(config.fps);
             }
         }
     }

--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -142,13 +142,13 @@ fn toggle_cursor(mut cursor_options: Single<&mut CursorOptions>, input: Res<Butt
 
 // This system will toggle the color theme used by the window
 fn toggle_theme(mut window: Single<&mut Window>, input: Res<ButtonInput<KeyCode>>) {
-    if input.just_pressed(KeyCode::KeyF) {
-        if let Some(current_theme) = window.window_theme {
-            window.window_theme = match current_theme {
-                WindowTheme::Light => Some(WindowTheme::Dark),
-                WindowTheme::Dark => Some(WindowTheme::Light),
-            };
-        }
+    if input.just_pressed(KeyCode::KeyF)
+        && let Some(current_theme) = window.window_theme
+    {
+        window.window_theme = match current_theme {
+            WindowTheme::Light => Some(WindowTheme::Dark),
+            WindowTheme::Dark => Some(WindowTheme::Light),
+        };
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-
+#![expect(
+    clippy::doc_markdown,
+    reason = "Android GameActivity does not need to be code-formatted."
+)]
 //! [![Bevy Logo](https://bevy.org/assets/bevy_logo_docs.svg)](https://bevy.org)
 //!
 //! Bevy is an open-source modular game engine built in Rust, with a focus on developer productivity


### PR DESCRIPTION
Adopted from #20456

Original PR Description:
># Objective
>
>Unbreak CI.
>
> ## Solution
>
> Fix the lints.
>
>I've opted for anonymous lifetimes in every revealed case so far; please let me know if you think I should used named lifetimes in specific cases and why.
>
>## Testing
>
>Is CI green?
>
>## Context
>
> This lint originally had a much larger splash damage, with fairly negative effects on Bevy. See https://github.com/rust-lang/rust/issues/131725.
>
> The more restricted former is much more helpful, despite the large diff in this PR. Bevy is a large code base!
>
>## TODO
>
>- [x] discuss proposed lifetime lint fixes
>,- [x] use cargo clippy --fix to fix newly uncovered docs misformatting
>- [x] fix newly revealed dead code issues
>- [x] ensure CI is green