### PR TITLE
`Text2d` `TextBackgroundColor` support

### DIFF
--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -47,6 +47,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         Text2d::new("translation"),
         text_font.clone(),
         TextLayout::new_with_justify(text_justification),
+        TextBackgroundColor(Color::BLACK.with_alpha(0.5)),
         AnimateTranslation,
     ));
     // Demonstrate changing rotation
@@ -54,6 +55,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         Text2d::new("rotation"),
         text_font.clone(),
         TextLayout::new_with_justify(text_justification),
+        TextBackgroundColor(Color::BLACK.with_alpha(0.5)),
         AnimateRotation,
     ));
     // Demonstrate changing scale
@@ -62,6 +64,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         text_font,
         TextLayout::new_with_justify(text_justification),
         Transform::from_translation(Vec3::new(400.0, 0.0, 0.0)),
+        TextBackgroundColor(Color::BLACK.with_alpha(0.5)),
         AnimateScale,
     ));
     // Demonstrate text wrapping
@@ -133,16 +136,20 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         Text2d::new(" Anchor".to_string()),
                         slightly_smaller_text_font.clone(),
                         text_anchor,
+                        TextBackgroundColor(Color::WHITE.darker(0.8)),
+                        Transform::from_translation(-1. * Vec3::Z),
                     ))
                     .with_child((
                         TextSpan("::".to_string()),
                         slightly_smaller_text_font.clone(),
                         TextColor(LIGHT_GREY.into()),
+                        TextBackgroundColor(DARK_BLUE.into()),
                     ))
                     .with_child((
                         TextSpan(format!("{text_anchor:?} ")),
                         slightly_smaller_text_font.clone(),
                         TextColor(color),
+                        TextBackgroundColor(color.darker(0.3)),
                     ));
             }
         });

--- a/release-content/release-notes/text2d_textbackgroundcolor.md
+++ b/release-content/release-notes/text2d_textbackgroundcolor.md
@@ -1,0 +1,9 @@
+---
+title: `TextBackgroundColor` support for `Text2d`
+authors: ["@ickshonpe"]
+pull_requests: []
+---
+
+`Text2d` now supports the `TextBackgroundColor` component.
+
+Add a `TextBackgroundColor` to `Text2d` entity or its child `TextSection` entities to draw a background color for that section of text.


### PR DESCRIPTION
# Objective

Add support for `TextBackgroundColor` to `Text2d`.

## Solution

Add a `TextBackgroundColor` query to `extract_text2d_sprite` and queue a background sprite for each text section with a `TextBackgroundColor`.

## Testing

Added `TextBackgroundColor`s to some of the text in the `text2d` example:

```cargo run --example text2d```

---

## Showcase

<img width="1924" height="1127" alt="text2d-background" src="https://github.com/user-attachments/assets/faa64dbe-cf80-4aca-b749-d24bb4399db3" />
