### PR TITLE
Update documentation of HitData coordinates range in ui::picking_backend

### DIFF
--- a/crates/bevy_ui/src/picking_backend.rs
+++ b/crates/bevy_ui/src/picking_backend.rs
@@ -18,9 +18,9 @@
 //! - `bevy_ui` can render on any camera with a flag, it is special, and is not tied to a particular
 //!   camera.
 //! - To correctly sort picks, the order of `bevy_ui` is set to be the camera order plus 0.5.
-//! - The `position` reported in `HitData` is normalized relative to the node, with `(0.,0.,0.)` at
-//!   the top left and `(1., 1., 0.)` in the bottom right. Coordinates are relative to the entire
-//!   node, not just the visible region. This backend does not provide a `normal`.
+//! - The `position` reported in `HitData` is normalized relative to the node, with
+//!   `(-0.5, -0.5, 0.)` at the top left and `(0.5, 0.5, 0.)` in the bottom right. Coordinates are
+//!   relative to the entire node, not just the visible region. This backend does not provide a `normal`.
 
 #![deny(missing_docs)]
 


### PR DESCRIPTION
`HitData` coordinates now lie between `-0.5` and `0.5`. The documentation of the `ui::picking_backend` module still documents the old values of `0.0` and `1.0`.