### PR TITLE
Remove `offset` argument from `TrackedRenderPass::set_index_buffer`

### DIFF
--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -3154,7 +3154,7 @@ impl<P: PhaseItem> RenderCommand<P> for DrawMesh {
                     return RenderCommandResult::Skip;
                 };
 
-                pass.set_index_buffer(index_buffer_slice.buffer.slice(..), 0, *index_format);
+                pass.set_index_buffer(index_buffer_slice.buffer.slice(..), *index_format);
 
                 match item.extra_index() {
                     PhaseItemExtraIndex::None | PhaseItemExtraIndex::DynamicOffset(_) => {

--- a/crates/bevy_render/src/render_phase/draw_state.rs
+++ b/crates/bevy_render/src/render_phase/draw_state.rs
@@ -254,17 +254,18 @@ impl<'a> TrackedRenderPass<'a> {
     /// Subsequent calls to [`TrackedRenderPass::draw_indexed`] will use the buffer referenced by
     /// `buffer_slice` as the source index buffer.
     pub fn set_index_buffer(&mut self, buffer_slice: BufferSlice<'a>, index_format: IndexFormat) {
-        if self.state.is_index_buffer_set(&buffer_slice, index_format) {
-            #[cfg(feature = "detailed_trace")]
-            trace!(
-                "set index buffer (already set): {:?} ({})",
-                buffer_slice.id(),
-                offset
-            );
+        let already_set = self.state.is_index_buffer_set(&buffer_slice, index_format);
+        #[cfg(feature = "detailed_trace")]
+        trace!(
+            "set index buffer{}: {:?} (offset = {}, size = {})",
+            if already_set { " (already set)" } else { "" },
+            buffer_slice.id(),
+            buffer_slice.offset(),
+            buffer_slice.size(),
+        );
+        if already_set {
             return;
         }
-        #[cfg(feature = "detailed_trace")]
-        trace!("set index buffer: {:?} ({})", buffer_slice.id(), offset);
         self.pass.set_index_buffer(*buffer_slice, index_format);
         self.state.set_index_buffer(&buffer_slice, index_format);
     }

--- a/crates/bevy_sprite_render/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite_render/src/mesh2d/mesh.rs
@@ -862,7 +862,7 @@ impl<P: PhaseItem> RenderCommand<P> for DrawMesh2d {
                     return RenderCommandResult::Skip;
                 };
 
-                pass.set_index_buffer(index_buffer_slice.buffer.slice(..), 0, *index_format);
+                pass.set_index_buffer(index_buffer_slice.buffer.slice(..), *index_format);
 
                 pass.draw_indexed(
                     index_buffer_slice.range.start..(index_buffer_slice.range.start + count),

--- a/crates/bevy_sprite_render/src/render/mod.rs
+++ b/crates/bevy_sprite_render/src/render/mod.rs
@@ -947,7 +947,6 @@ impl<P: PhaseItem> RenderCommand<P> for DrawSpriteBatch {
 
         pass.set_index_buffer(
             sprite_meta.sprite_index_buffer.buffer().unwrap().slice(..),
-            0,
             IndexFormat::Uint32,
         );
         pass.set_vertex_buffer(

--- a/crates/bevy_ui_render/src/box_shadow.rs
+++ b/crates/bevy_ui_render/src/box_shadow.rs
@@ -559,7 +559,7 @@ impl<P: PhaseItem> RenderCommand<P> for DrawBoxShadow {
         // Store the vertices
         pass.set_vertex_buffer(0, vertices.slice(..));
         // Define how to "connect" the vertices
-        pass.set_index_buffer(indices.slice(..), 0, IndexFormat::Uint32);
+        pass.set_index_buffer(indices.slice(..), IndexFormat::Uint32);
         // Draw the vertices
         pass.draw_indexed(batch.range.clone(), 0, 0..1);
         RenderCommandResult::Success

--- a/crates/bevy_ui_render/src/gradient.rs
+++ b/crates/bevy_ui_render/src/gradient.rs
@@ -966,7 +966,7 @@ impl<P: PhaseItem> RenderCommand<P> for DrawGradient {
         // Store the vertices
         pass.set_vertex_buffer(0, vertices.slice(..));
         // Define how to "connect" the vertices
-        pass.set_index_buffer(indices.slice(..), 0, IndexFormat::Uint32);
+        pass.set_index_buffer(indices.slice(..), IndexFormat::Uint32);
         // Draw the vertices
         pass.draw_indexed(batch.range.clone(), 0, 0..1);
         RenderCommandResult::Success

--- a/crates/bevy_ui_render/src/render_pass.rs
+++ b/crates/bevy_ui_render/src/render_pass.rs
@@ -267,7 +267,6 @@ impl<P: PhaseItem> RenderCommand<P> for DrawUiNode {
         // Define how to "connect" the vertices
         pass.set_index_buffer(
             indices.slice(..),
-            0,
             bevy_render::render_resource::IndexFormat::Uint32,
         );
         // Draw the vertices

--- a/crates/bevy_ui_render/src/ui_texture_slice_pipeline.rs
+++ b/crates/bevy_ui_render/src/ui_texture_slice_pipeline.rs
@@ -706,7 +706,7 @@ impl<P: PhaseItem> RenderCommand<P> for DrawSlicer {
         // Store the vertices
         pass.set_vertex_buffer(0, vertices.slice(..));
         // Define how to "connect" the vertices
-        pass.set_index_buffer(indices.slice(..), 0, IndexFormat::Uint32);
+        pass.set_index_buffer(indices.slice(..), IndexFormat::Uint32);
         // Draw the vertices
         pass.draw_indexed(batch.range.clone(), 0, 0..1);
         RenderCommandResult::Success

--- a/examples/shader_advanced/custom_phase_item.rs
+++ b/examples/shader_advanced/custom_phase_item.rs
@@ -93,7 +93,6 @@ where
                 .buffer()
                 .unwrap()
                 .slice(..),
-            0,
             IndexFormat::Uint32,
         );
 

--- a/examples/shader_advanced/custom_shader_instancing.rs
+++ b/examples/shader_advanced/custom_shader_instancing.rs
@@ -303,7 +303,7 @@ impl<P: PhaseItem> RenderCommand<P> for DrawMeshInstanced {
                     return RenderCommandResult::Skip;
                 };
 
-                pass.set_index_buffer(index_buffer_slice.buffer.slice(..), 0, *index_format);
+                pass.set_index_buffer(index_buffer_slice.buffer.slice(..), *index_format);
                 pass.draw_indexed(
                     index_buffer_slice.range.start..(index_buffer_slice.range.start + count),
                     vertex_buffer_slice.range.start as i32,

--- a/release-content/migration-guides/set_index_buffer.md
+++ b/release-content/migration-guides/set_index_buffer.md
@@ -1,5 +1,5 @@
 ---
-title: `TrackedRenderPass::set_index_buffer` no longer takes buffer offset
+title: "`TrackedRenderPass::set_index_buffer` no longer takes buffer offset"
 pull_requests: [20468]
 ---
 

--- a/release-content/migration-guides/set_index_buffer.md
+++ b/release-content/migration-guides/set_index_buffer.md
@@ -1,0 +1,13 @@
+---
+title: `TrackedRenderPass::set_index_buffer` no longer takes buffer offset
+pull_requests: [20468]
+---
+
+`TrackedRenderPass::set_index_buffer` no longer takes a separate buffer offset argument, which wasn't actually forwarded to wgpu. You have already needed to pass a `BufferSlice` that is sliced to the desired offset/size.
+
+```rust
+// Before:
+pass.set_index_buffer(indices.slice(1..), 1, IndexFormat::Uint32);
+// After:
+pass.set_index_buffer(indices.slice(1..), IndexFormat::Uint32);
+```


### PR DESCRIPTION
# Objective

- `offset` argument is misleading as the argument is not actually passed to wgpu (used only for memoization and logging). `BufferSlice` already contains an offset.
    - wgpu's `set_index_buffer` [sets the offset according to BufferSlice::offset](https://github.com/gfx-rs/wgpu/blob/e990388af98e4b4dff9f7fcc09a4eb5d2f71d227/wgpu/src/api/render_pass.rs#L98-L105)
- `TrackedRenderPass::set_vertex_buffer` was made aware of slice size (#14916) but missed `set_index_buffer` counterpart

## Solution

- Removed `offset` argument from `TrackedRenderPass::set_index_buffer`
- Apply fix from #14916 to `TrackedRenderPass::is_index_buffer_set`
- ~~Cleanup code by using the newly added `BufferSlice` getters~~  split out to https://github.com/bevyengine/bevy/pull/21289

## Testing

- Ran a few examples
