### PR TITLE
add module doc to bevy_render

### DIFF
--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -3,13 +3,13 @@
 //! Both `bevy_render` and `wgpu` have a number of environment variable options for changing the runtime behavior
 //! of both crates. Many of these may be useful in development or release environments. 
 //!
-//! - `WGPU_DEBUG=1` enables debug labels in release builds
-//! - `WGPU_VALIDATION=0` disables validation layers
-//! - `WGPU_FORCE_FALLBACK_ADAPTER=1` attempts to force software rendering
-//! - `WGPU_ADAPTER_NAME`: select a specific adapter by name
-//! - `WGPU_SETTINGS_PRIO=webgl2` uses webgl2 limits
-//! - `WGPU_SETTINGS_PRIO=compatibility` uses webgpu limits
-//! - `VERBOSE_SHADER_ERROR=1` prints more detailed information about WGSL compilation errors
+//! - `WGPU_DEBUG=1` enables debug labels, which can be useful in release builds.
+//! - `WGPU_VALIDATION=0` disables validation layers. This can help with particularly spammy errors.
+//! - `WGPU_FORCE_FALLBACK_ADAPTER=1` attempts to force software rendering. This typically matches what is used in CI.
+//! - `WGPU_ADAPTER_NAME` allows selecting a specific adapter by name.
+//! - `WGPU_SETTINGS_PRIO=webgl2` uses webgl2 limits.
+//! - `WGPU_SETTINGS_PRIO=compatibility` uses webgpu limits.
+//! - `VERBOSE_SHADER_ERROR=1` prints more detailed information about WGSL compilation errors, such as shader defs and shader entrypoint.
 
 #![expect(missing_docs, reason = "Not all docs are written yet, see #3492.")]
 #![expect(unsafe_code, reason = "Unsafe code is used to improve performance.")]

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -1,3 +1,13 @@
+//! # Useful Environment Variables
+//!
+//! `WGPU_DEBUG=1` enables debug labels in release builds\
+//! `WGPU_VALIDATION=0` disables validation layers\
+//! `WGPU_FORCE_FALLBACK_ADAPTER=1` attempts to force softare rendering\
+//! `WGPU_ADAPTER_NAME`: select a specific adapter by name\
+//! `WGPU_SETTINGS_PRIO=webgl2` uses webgl2 limits\
+//! `WGPU_SETTINGS_PRIO=compatibility` uses webgpu limits\
+//! `VERBOSE_SHADER_ERROR=1` prints shader defs and entrypoint shaders on wgsl compilation error
+
 #![expect(missing_docs, reason = "Not all docs are written yet, see #3492.")]
 #![expect(unsafe_code, reason = "Unsafe code is used to improve performance.")]
 #![cfg_attr(

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -1,4 +1,5 @@
 //! # Useful Environment Variables
+//!
 //! Both `bevy_render` and `wgpu` have a number of environment variable options for changing the runtime behavior
 //! of both crates. Many of these may be useful in development or release environments. 
 //!

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -1,7 +1,7 @@
 //! # Useful Environment Variables
 //!
 //! Both `bevy_render` and `wgpu` have a number of environment variable options for changing the runtime behavior
-//! of both crates. Many of these may be useful in development or release environments. 
+//! of both crates. Many of these may be useful in development or release environments.
 //!
 //! - `WGPU_DEBUG=1` enables debug labels, which can be useful in release builds.
 //! - `WGPU_VALIDATION=0` disables validation layers. This can help with particularly spammy errors.

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -1,12 +1,14 @@
 //! # Useful Environment Variables
+//! Both `bevy_render` and `wgpu` have a number of environment variable options for changing the runtime behavior
+//! of both crates. Many of these may be useful in development or release environments. 
 //!
-//! `WGPU_DEBUG=1` enables debug labels in release builds\
-//! `WGPU_VALIDATION=0` disables validation layers\
-//! `WGPU_FORCE_FALLBACK_ADAPTER=1` attempts to force software rendering\
-//! `WGPU_ADAPTER_NAME`: select a specific adapter by name\
-//! `WGPU_SETTINGS_PRIO=webgl2` uses webgl2 limits\
-//! `WGPU_SETTINGS_PRIO=compatibility` uses webgpu limits\
-//! `VERBOSE_SHADER_ERROR=1` prints shader defs and entrypoint shaders on wgsl compilation error
+//! -  `WGPU_DEBUG=1` enables debug labels in release builds
+//! - `WGPU_VALIDATION=0` disables validation layers
+//! - `WGPU_FORCE_FALLBACK_ADAPTER=1` attempts to force software rendering
+//! - `WGPU_ADAPTER_NAME`: select a specific adapter by name
+//! - `WGPU_SETTINGS_PRIO=webgl2` uses webgl2 limits
+//! - `WGPU_SETTINGS_PRIO=compatibility` uses webgpu limits
+//! - `VERBOSE_SHADER_ERROR=1` prints more detailed information about WGSL compilation errors
 
 #![expect(missing_docs, reason = "Not all docs are written yet, see #3492.")]
 #![expect(unsafe_code, reason = "Unsafe code is used to improve performance.")]

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -2,7 +2,7 @@
 //! Both `bevy_render` and `wgpu` have a number of environment variable options for changing the runtime behavior
 //! of both crates. Many of these may be useful in development or release environments. 
 //!
-//! -  `WGPU_DEBUG=1` enables debug labels in release builds
+//! - `WGPU_DEBUG=1` enables debug labels in release builds
 //! - `WGPU_VALIDATION=0` disables validation layers
 //! - `WGPU_FORCE_FALLBACK_ADAPTER=1` attempts to force software rendering
 //! - `WGPU_ADAPTER_NAME`: select a specific adapter by name

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! `WGPU_DEBUG=1` enables debug labels in release builds\
 //! `WGPU_VALIDATION=0` disables validation layers\
-//! `WGPU_FORCE_FALLBACK_ADAPTER=1` attempts to force softare rendering\
+//! `WGPU_FORCE_FALLBACK_ADAPTER=1` attempts to force software rendering\
 //! `WGPU_ADAPTER_NAME`: select a specific adapter by name\
 //! `WGPU_SETTINGS_PRIO=webgl2` uses webgl2 limits\
 //! `WGPU_SETTINGS_PRIO=compatibility` uses webgpu limits\


### PR DESCRIPTION
# Objective

- theres no docs regarding our env vars

## Solution

- document them in bevy_render module docs (currently nonexistent)

## Testing

- 