### PR TITLE
stop re-exporting RenderAssetUsages from bevy_render

### DIFF
--- a/crates/bevy_render/src/erased_render_asset.rs
+++ b/crates/bevy_render/src/erased_render_asset.rs
@@ -3,7 +3,7 @@ use crate::{
     RenderSystems, Res,
 };
 use bevy_app::{App, Plugin, SubApp};
-pub use bevy_asset::RenderAssetUsages;
+use bevy_asset::RenderAssetUsages;
 use bevy_asset::{Asset, AssetEvent, AssetId, Assets, UntypedAssetId};
 use bevy_ecs::{
     prelude::{Commands, EventReader, IntoScheduleConfigs, ResMut, Resource},

--- a/release-content/migration-guides/bevy_render_reorganization.md
+++ b/release-content/migration-guides/bevy_render_reorganization.md
@@ -20,3 +20,5 @@ Import them directly or from `bevy::mesh` now, as the re-exports will be removed
 
 Image types have been moved to a new crate, `bevy_image`, but continue to be re-exported by `bevy_render` for now.
 Import them directly or from `bevy::image` now, as the re-exports will be removed.
+
+RenderAssetUsages is no longer re-exported by `bevy_render`. Import it from `bevy_asset` instead.


### PR DESCRIPTION
# Objective

- I believe I left this here to ease migration in the previous release, but shouldn't be re-exported long-term.

## Solution

- yeet

## Testing

- ci