### PR TITLE
Make bevy_animation not depend on bevy_render

### DIFF
--- a/crates/bevy_animation/Cargo.toml
+++ b/crates/bevy_animation/Cargo.toml
@@ -19,7 +19,6 @@ bevy_mesh = { path = "../bevy_mesh", version = "0.17.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.17.0-dev", features = [
   "petgraph",
 ] }
-bevy_render = { path = "../bevy_render", version = "0.17.0-dev" }
 bevy_time = { path = "../bevy_time", version = "0.17.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.17.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.17.0-dev" }

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -1245,7 +1245,7 @@ impl Plugin for AnimationPlugin {
                     // `PostUpdate`. For now, we just disable ambiguity testing
                     // for this system.
                     animate_targets
-                        .before(bevy_render::mesh::inherit_weights)
+                        .before(bevy_mesh::InheritWeights)
                         .ambiguous_with_all(),
                     trigger_untargeted_animation_events,
                     expire_completed_transitions,

--- a/crates/bevy_mesh/src/lib.rs
+++ b/crates/bevy_mesh/src/lib.rs
@@ -12,6 +12,7 @@ pub mod morph;
 pub mod primitives;
 pub mod skinning;
 mod vertex;
+use bevy_ecs::schedule::SystemSet;
 use bitflags::bitflags;
 pub use components::*;
 pub use index::*;
@@ -57,3 +58,7 @@ impl BaseMeshPipelineKey {
         }
     }
 }
+
+/// `bevy_render::mesh::inherit_weights` runs in this `SystemSet`
+#[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
+pub struct InheritWeights;

--- a/crates/bevy_render/src/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mod.rs
@@ -52,7 +52,7 @@ impl Plugin for MeshPlugin {
 pub struct MorphPlugin;
 impl Plugin for MorphPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(PostUpdate, inherit_weights);
+        app.add_systems(PostUpdate, inherit_weights.in_set(InheritWeights));
     }
 }
 


### PR DESCRIPTION
# Objective

- recognize this holy gift and celebrate this chance to be alive and breathing 30% more this fall by not waiting for bevy_render to compile when you use bevy_animation

## Solution

- use a SystemSet to decouple a system ordering dependency

## Testing

- cargo check --examples
