### PR TITLE
Add a prelude to bevy_camera

### DIFF
--- a/crates/bevy_camera/src/lib.rs
+++ b/crates/bevy_camera/src/lib.rs
@@ -25,3 +25,15 @@ impl Plugin for CameraPlugin {
         ));
     }
 }
+
+/// The mesh prelude.
+///
+/// This includes the most common types in this crate, re-exported for your convenience.
+pub mod prelude {
+    #[doc(hidden)]
+    pub use crate::{
+        visibility::{InheritedVisibility, ViewVisibility, Visibility},
+        Camera, Camera2d, Camera3d, ClearColor, ClearColorConfig, OrthographicProjection,
+        PerspectiveProjection, Projection,
+    };
+}

--- a/crates/bevy_camera/src/lib.rs
+++ b/crates/bevy_camera/src/lib.rs
@@ -26,7 +26,7 @@ impl Plugin for CameraPlugin {
     }
 }
 
-/// The mesh prelude.
+/// The camera prelude.
 ///
 /// This includes the most common types in this crate, re-exported for your convenience.
 pub mod prelude {

--- a/crates/bevy_internal/src/prelude.rs
+++ b/crates/bevy_internal/src/prelude.rs
@@ -44,10 +44,6 @@ pub use crate::animation::prelude::*;
 pub use crate::color::prelude::*;
 
 #[doc(hidden)]
-#[cfg(feature = "bevy_core_pipeline")]
-pub use crate::core_pipeline::prelude::*;
-
-#[doc(hidden)]
 #[cfg(feature = "bevy_pbr")]
 pub use crate::pbr::prelude::*;
 

--- a/crates/bevy_internal/src/prelude.rs
+++ b/crates/bevy_internal/src/prelude.rs
@@ -18,8 +18,12 @@ pub use crate::window::prelude::*;
 pub use crate::image::prelude::*;
 
 #[doc(hidden)]
-#[cfg(feature = "bevy_image")]
+#[cfg(feature = "bevy_mesh")]
 pub use crate::mesh::prelude::*;
+
+#[doc(hidden)]
+#[cfg(feature = "bevy_camera")]
+pub use crate::camera::prelude::*;
 
 pub use bevy_derive::{bevy_main, Deref, DerefMut};
 


### PR DESCRIPTION
# Objective

- title. this is the exact set of prelude re-exports bevy_render provides of bevy_mesh. We will soon be ready to yeet the re-exports.
- also fix an oversight with bevy mesh prelude

## Solution

- do it

## Testing

- cargo check --examples