### PR TITLE
Add bevy_shader prelude and move load_shader_library

### DIFF
--- a/crates/bevy_internal/src/prelude.rs
+++ b/crates/bevy_internal/src/prelude.rs
@@ -29,6 +29,10 @@ pub use crate::light::prelude::*;
 #[cfg(feature = "bevy_camera")]
 pub use crate::camera::prelude::*;
 
+#[doc(hidden)]
+#[cfg(feature = "bevy_shader")]
+pub use crate::shader::prelude::*;
+
 pub use bevy_derive::{bevy_main, Deref, DerefMut};
 
 #[doc(hidden)]

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -92,11 +92,7 @@ pub mod prelude {
     };
 }
 
-#[doc(hidden)]
-pub mod _macro {
-    pub use bevy_asset;
-}
-
+pub use bevy_shader::load_shader_library;
 pub use extract_param::Extract;
 
 use crate::{
@@ -104,7 +100,7 @@ use crate::{
     gpu_readback::GpuReadbackPlugin,
     mesh::{MeshPlugin, MorphPlugin, RenderMesh},
     render_asset::prepare_assets,
-    render_resource::{init_empty_bind_group_layout, PipelineCache, Shader, ShaderLoader},
+    render_resource::{init_empty_bind_group_layout, PipelineCache},
     renderer::{render_system, RenderInstance},
     settings::RenderCreation,
     storage::StoragePlugin,
@@ -119,6 +115,7 @@ use bevy_ecs::{
     schedule::{ScheduleBuildSettings, ScheduleLabel},
 };
 use bevy_image::{CompressedImageFormatSupport, CompressedImageFormats};
+use bevy_shader::{Shader, ShaderLoader};
 use bevy_utils::prelude::default;
 use bevy_window::{PrimaryWindow, RawHandleWrapperHolder};
 use bitflags::bitflags;
@@ -135,24 +132,6 @@ use std::sync::Mutex;
 use sync_world::{despawn_temporary_render_entities, entity_sync_system, SyncWorldPlugin};
 use tracing::debug;
 pub use wgpu_wrapper::WgpuWrapper;
-
-/// Inline shader as an `embedded_asset` and load it permanently.
-///
-/// This works around a limitation of the shader loader not properly loading
-/// dependencies of shaders.
-#[macro_export]
-macro_rules! load_shader_library {
-    ($asset_server_provider: expr, $path: literal $(, $settings: expr)?) => {
-        $crate::_macro::bevy_asset::embedded_asset!($asset_server_provider, $path);
-        let handle: $crate::_macro::bevy_asset::prelude::Handle<$crate::prelude::Shader> =
-            $crate::_macro::bevy_asset::load_embedded_asset!(
-                $asset_server_provider,
-                $path
-                $(,$settings)?
-            );
-        core::mem::forget(handle);
-    }
-}
 
 /// Contains the default Bevy rendering backend based on wgpu.
 ///

--- a/crates/bevy_shader/src/lib.rs
+++ b/crates/bevy_shader/src/lib.rs
@@ -6,3 +6,34 @@ mod shader;
 mod shader_cache;
 pub use shader::*;
 pub use shader_cache::*;
+
+/// The shader prelude.
+///
+/// This includes the most common types in this crate, re-exported for your convenience.
+pub mod prelude {
+    #[doc(hidden)]
+    pub use crate::Shader;
+}
+
+#[doc(hidden)]
+pub mod _macro {
+    pub use bevy_asset;
+}
+
+/// Inline shader as an `embedded_asset` and load it permanently.
+///
+/// This works around a limitation of the shader loader not properly loading
+/// dependencies of shaders.
+#[macro_export]
+macro_rules! load_shader_library {
+    ($asset_server_provider: expr, $path: literal $(, $settings: expr)?) => {
+        $crate::_macro::bevy_asset::embedded_asset!($asset_server_provider, $path);
+        let handle: $crate::_macro::bevy_asset::prelude::Handle<$crate::prelude::Shader> =
+            $crate::_macro::bevy_asset::load_embedded_asset!(
+                $asset_server_provider,
+                $path
+                $(,$settings)?
+            );
+        core::mem::forget(handle);
+    }
+}


### PR DESCRIPTION
# Objective

- Prepare for removing re-exports
- We want to use load_shader_library without bevy_render, so put it in bevy_shader

## Solution

- title

## Testing

- cargo check --examples --all-features