### PR TITLE
Use bevy::shader in examples instead of bevy::render::shader re-export

### DIFF
--- a/examples/2d/custom_gltf_vertex_attribute.rs
+++ b/examples/2d/custom_gltf_vertex_attribute.rs
@@ -6,6 +6,7 @@ use bevy::{
     prelude::*,
     reflect::TypePath,
     render::render_resource::*,
+    shader::ShaderRef,
     sprite::{Material2d, Material2dKey, Material2dPlugin},
 };
 

--- a/examples/3d/clustered_decals.rs
+++ b/examples/3d/clustered_decals.rs
@@ -10,9 +10,10 @@ use bevy::{
     pbr::{decal, ExtendedMaterial, MaterialExtension},
     prelude::*,
     render::{
-        render_resource::{AsBindGroup, ShaderRef},
+        render_resource::AsBindGroup,
         renderer::{RenderAdapter, RenderDevice},
     },
+    shader::ShaderRef,
     window::{CursorIcon, SystemCursorIcon},
 };
 use ops::{acos, cos, sin};

--- a/examples/3d/irradiance_volumes.rs
+++ b/examples/3d/irradiance_volumes.rs
@@ -20,7 +20,8 @@ use bevy::{
     math::{uvec3, vec3},
     pbr::{ExtendedMaterial, MaterialExtension},
     prelude::*,
-    render::render_resource::{AsBindGroup, ShaderRef, ShaderType},
+    render::render_resource::{AsBindGroup, ShaderType},
+    shader::ShaderRef,
     window::PrimaryWindow,
 };
 

--- a/examples/3d/lines.rs
+++ b/examples/3d/lines.rs
@@ -8,10 +8,10 @@ use bevy::{
     render::{
         render_asset::RenderAssetUsages,
         render_resource::{
-            AsBindGroup, PolygonMode, RenderPipelineDescriptor, ShaderRef,
-            SpecializedMeshPipelineError,
+            AsBindGroup, PolygonMode, RenderPipelineDescriptor, SpecializedMeshPipelineError,
         },
     },
+    shader::ShaderRef,
 };
 
 /// This example uses a shader source file from the assets subdirectory

--- a/examples/3d/solari.rs
+++ b/examples/3d/solari.rs
@@ -6,8 +6,9 @@ mod camera_controller;
 use argh::FromArgs;
 use bevy::{
     camera::CameraMainTextureUsages,
+    mesh::Indices,
     prelude::*,
-    render::{mesh::Indices, render_resource::TextureUsages},
+    render::render_resource::TextureUsages,
     scene::SceneInstanceReady,
     solari::{
         pathtracer::{Pathtracer, PathtracingPlugin},

--- a/examples/3d/ssr.rs
+++ b/examples/3d/ssr.rs
@@ -17,9 +17,10 @@ use bevy::{
     },
     prelude::*,
     render::{
-        render_resource::{AsBindGroup, ShaderRef, ShaderType},
+        render_resource::{AsBindGroup, ShaderType},
         view::Hdr,
     },
+    shader::ShaderRef,
 };
 
 /// This example uses a shader source file from the assets subdirectory

--- a/examples/3d/tonemapping.rs
+++ b/examples/3d/tonemapping.rs
@@ -8,9 +8,10 @@ use bevy::{
     prelude::*,
     reflect::TypePath,
     render::{
-        render_resource::{AsBindGroup, ShaderRef},
+        render_resource::AsBindGroup,
         view::{ColorGrading, ColorGradingGlobal, ColorGradingSection, Hdr},
     },
+    shader::ShaderRef,
 };
 use std::f32::consts::PI;
 

--- a/examples/shader/animate_shader.rs
+++ b/examples/shader/animate_shader.rs
@@ -2,9 +2,7 @@
 //! The time data is in the globals binding which is part of the `mesh_view_bindings` shader import.
 
 use bevy::{
-    prelude::*,
-    reflect::TypePath,
-    render::render_resource::{AsBindGroup, ShaderRef},
+    prelude::*, reflect::TypePath, render::render_resource::AsBindGroup, shader::ShaderRef,
 };
 
 /// This example uses a shader source file from the assets subdirectory

--- a/examples/shader/array_texture.rs
+++ b/examples/shader/array_texture.rs
@@ -2,9 +2,7 @@
 //! uniform variable.
 
 use bevy::{
-    prelude::*,
-    reflect::TypePath,
-    render::render_resource::{AsBindGroup, ShaderRef},
+    prelude::*, reflect::TypePath, render::render_resource::AsBindGroup, shader::ShaderRef,
 };
 
 /// This example uses a shader source file from the assets subdirectory

--- a/examples/shader/automatic_instancing.rs
+++ b/examples/shader/automatic_instancing.rs
@@ -3,10 +3,8 @@
 //! Also demonstrates how to use `MeshTag` to use external data in a custom material.
 
 use bevy::{
-    mesh::MeshTag,
-    prelude::*,
-    reflect::TypePath,
-    render::render_resource::{AsBindGroup, ShaderRef},
+    mesh::MeshTag, prelude::*, reflect::TypePath, render::render_resource::AsBindGroup,
+    shader::ShaderRef,
 };
 
 const SHADER_ASSET_PATH: &str = "shaders/automatic_instancing.wgsl";

--- a/examples/shader/compute_shader_game_of_life.rs
+++ b/examples/shader/compute_shader_game_of_life.rs
@@ -14,6 +14,7 @@ use bevy::{
         texture::GpuImage,
         Render, RenderApp, RenderStartup, RenderSystems,
     },
+    shader::PipelineCacheError,
 };
 use std::borrow::Cow;
 

--- a/examples/shader/extended_material.rs
+++ b/examples/shader/extended_material.rs
@@ -5,6 +5,7 @@ use bevy::{
     pbr::{ExtendedMaterial, MaterialExtension, OpaqueRendererMethod},
     prelude::*,
     render::render_resource::*,
+    shader::ShaderRef,
 };
 
 /// This example uses a shader source file from the assets subdirectory

--- a/examples/shader/extended_material_bindless.rs
+++ b/examples/shader/extended_material_bindless.rs
@@ -7,7 +7,8 @@ use bevy::{
     mesh::{SphereKind, SphereMeshBuilder},
     pbr::{ExtendedMaterial, MaterialExtension, MeshMaterial3d},
     prelude::*,
-    render::render_resource::{AsBindGroup, ShaderRef, ShaderType},
+    render::render_resource::{AsBindGroup, ShaderType},
+    shader::ShaderRef,
     utils::default,
 };
 

--- a/examples/shader/fallback_image.rs
+++ b/examples/shader/fallback_image.rs
@@ -6,9 +6,7 @@
 //! only tests that the images are initialized and bound so that the app does
 //! not panic.
 use bevy::{
-    prelude::*,
-    reflect::TypePath,
-    render::render_resource::{AsBindGroup, ShaderRef},
+    prelude::*, reflect::TypePath, render::render_resource::AsBindGroup, shader::ShaderRef,
 };
 
 /// This example uses a shader source file from the assets subdirectory

--- a/examples/shader/shader_defs.rs
+++ b/examples/shader/shader_defs.rs
@@ -6,8 +6,9 @@ use bevy::{
     prelude::*,
     reflect::TypePath,
     render::render_resource::{
-        AsBindGroup, RenderPipelineDescriptor, ShaderRef, SpecializedMeshPipelineError,
+        AsBindGroup, RenderPipelineDescriptor, SpecializedMeshPipelineError,
     },
+    shader::ShaderRef,
 };
 
 /// This example uses a shader source file from the assets subdirectory

--- a/examples/shader/shader_material.rs
+++ b/examples/shader/shader_material.rs
@@ -1,9 +1,7 @@
 //! A shader and a material that uses it.
 
 use bevy::{
-    prelude::*,
-    reflect::TypePath,
-    render::render_resource::{AsBindGroup, ShaderRef},
+    prelude::*, reflect::TypePath, render::render_resource::AsBindGroup, shader::ShaderRef,
 };
 
 /// This example uses a shader source file from the assets subdirectory

--- a/examples/shader/shader_material_2d.rs
+++ b/examples/shader/shader_material_2d.rs
@@ -3,7 +3,8 @@
 use bevy::{
     prelude::*,
     reflect::TypePath,
-    render::render_resource::{AsBindGroup, ShaderRef},
+    render::render_resource::AsBindGroup,
+    shader::ShaderRef,
     sprite::{AlphaMode2d, Material2d, Material2dPlugin},
 };
 

--- a/examples/shader/shader_material_bindless.rs
+++ b/examples/shader/shader_material_bindless.rs
@@ -1,7 +1,8 @@
 //! A material that uses bindless textures.
 
 use bevy::prelude::*;
-use bevy::render::render_resource::{AsBindGroup, ShaderRef, ShaderType};
+use bevy::render::render_resource::{AsBindGroup, ShaderType};
+use bevy::shader::ShaderRef;
 
 const SHADER_ASSET_PATH: &str = "shaders/bindless_material.wgsl";
 

--- a/examples/shader/shader_material_glsl.rs
+++ b/examples/shader/shader_material_glsl.rs
@@ -1,9 +1,7 @@
 //! A shader that uses the GLSL shading language.
 
 use bevy::{
-    prelude::*,
-    reflect::TypePath,
-    render::render_resource::{AsBindGroup, ShaderRef},
+    prelude::*, reflect::TypePath, render::render_resource::AsBindGroup, shader::ShaderRef,
 };
 
 /// This example uses shader source files from the assets subdirectory

--- a/examples/shader/shader_material_screenspace_texture.rs
+++ b/examples/shader/shader_material_screenspace_texture.rs
@@ -1,9 +1,7 @@
 //! A shader that samples a texture with view-independent UV coordinates.
 
 use bevy::{
-    prelude::*,
-    reflect::TypePath,
-    render::render_resource::{AsBindGroup, ShaderRef},
+    prelude::*, reflect::TypePath, render::render_resource::AsBindGroup, shader::ShaderRef,
 };
 
 /// This example uses a shader source file from the assets subdirectory

--- a/examples/shader/shader_material_wesl.rs
+++ b/examples/shader/shader_material_wesl.rs
@@ -1,16 +1,14 @@
 //! A shader that uses the WESL shading language.
 
 use bevy::{
+    mesh::MeshVertexBufferLayoutRef,
     pbr::{MaterialPipeline, MaterialPipelineKey},
     prelude::*,
     reflect::TypePath,
-    render::{
-        mesh::MeshVertexBufferLayoutRef,
-        render_resource::{
-            AsBindGroup, RenderPipelineDescriptor, ShaderDefVal, ShaderRef,
-            SpecializedMeshPipelineError,
-        },
+    render::render_resource::{
+        AsBindGroup, RenderPipelineDescriptor, SpecializedMeshPipelineError,
     },
+    shader::{ShaderDefVal, ShaderRef},
 };
 
 /// This example uses shader source files from the assets subdirectory

--- a/examples/shader/shader_prepass.rs
+++ b/examples/shader/shader_prepass.rs
@@ -8,7 +8,8 @@ use bevy::{
     pbr::PbrPlugin,
     prelude::*,
     reflect::TypePath,
-    render::render_resource::{AsBindGroup, ShaderRef, ShaderType},
+    render::render_resource::{AsBindGroup, ShaderType},
+    shader::ShaderRef,
 };
 
 /// This example uses a shader source file from the assets subdirectory

--- a/examples/shader/storage_buffer.rs
+++ b/examples/shader/storage_buffer.rs
@@ -3,10 +3,8 @@ use bevy::{
     mesh::MeshTag,
     prelude::*,
     reflect::TypePath,
-    render::{
-        render_resource::{AsBindGroup, ShaderRef},
-        storage::ShaderStorageBuffer,
-    },
+    render::{render_resource::AsBindGroup, storage::ShaderStorageBuffer},
+    shader::ShaderRef,
 };
 
 const SHADER_ASSET_PATH: &str = "shaders/storage_buffer.wgsl";

--- a/examples/shader_advanced/custom_vertex_attribute.rs
+++ b/examples/shader_advanced/custom_vertex_attribute.rs
@@ -6,9 +6,9 @@ use bevy::{
     prelude::*,
     reflect::TypePath,
     render::render_resource::{
-        AsBindGroup, RenderPipelineDescriptor, ShaderRef, SpecializedMeshPipelineError,
-        VertexFormat,
+        AsBindGroup, RenderPipelineDescriptor, SpecializedMeshPipelineError, VertexFormat,
     },
+    shader::ShaderRef,
 };
 
 /// This example uses a shader source file from the assets subdirectory

--- a/examples/shader_advanced/texture_binding_array.rs
+++ b/examples/shader_advanced/texture_binding_array.rs
@@ -15,6 +15,7 @@ use bevy::{
         texture::{FallbackImage, GpuImage},
         RenderApp, RenderStartup,
     },
+    shader::ShaderRef,
 };
 use std::{num::NonZero, process::exit};
 

--- a/examples/ui/ui_material.rs
+++ b/examples/ui/ui_material.rs
@@ -2,6 +2,7 @@
 
 use bevy::{
     color::palettes::css::DARK_BLUE, prelude::*, reflect::TypePath, render::render_resource::*,
+    shader::ShaderRef,
 };
 
 /// This example uses a shader source file from the assets subdirectory


### PR DESCRIPTION
# Objective

- Prepare for removing re-exports
- Probably depends on #20491 merging first

## Solution

- title

## Testing

- cargo check --examples --all-features
