### PR TITLE
Use bevy_shader in pbr, core pipelines, sprite, aa, gizmos, feathers, solari, dev_tools instead of bevy_render::shader re-export

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -22,6 +22,8 @@ bevy_picking = { path = "../crates/bevy_picking", features = [
 ] }
 bevy_reflect = { path = "../crates/bevy_reflect", features = ["functions"] }
 bevy_camera = { path = "../crates/bevy_camera" }
+bevy_mesh = { path = "../crates/bevy_mesh" }
+bevy_asset = { path = "../crates/bevy_asset" }
 bevy_render = { path = "../crates/bevy_render" }
 bevy_tasks = { path = "../crates/bevy_tasks" }
 bevy_platform = { path = "../crates/bevy_platform", default-features = false, features = [

--- a/benches/benches/bevy_render/compute_normals.rs
+++ b/benches/benches/bevy_render/compute_normals.rs
@@ -4,10 +4,8 @@ use criterion::{criterion_group, Criterion};
 use rand::random;
 use std::time::{Duration, Instant};
 
-use bevy_render::{
-    mesh::{Indices, Mesh, PrimitiveTopology},
-    render_asset::RenderAssetUsages,
-};
+use bevy_asset::RenderAssetUsages;
+use bevy_mesh::{Indices, Mesh, PrimitiveTopology};
 
 const GRID_SIZE: usize = 256;
 

--- a/benches/benches/bevy_render/torus.rs
+++ b/benches/benches/bevy_render/torus.rs
@@ -2,7 +2,7 @@ use core::hint::black_box;
 
 use criterion::{criterion_group, Criterion};
 
-use bevy_render::mesh::TorusMeshBuilder;
+use bevy_mesh::TorusMeshBuilder;
 
 fn torus(c: &mut Criterion) {
     c.bench_function("build_torus", |b| {

--- a/crates/bevy_anti_aliasing/Cargo.toml
+++ b/crates/bevy_anti_aliasing/Cargo.toml
@@ -25,6 +25,7 @@ bevy_utils = { path = "../bevy_utils", version = "0.17.0-dev" }
 bevy_app = { path = "../bevy_app", version = "0.17.0-dev" }
 bevy_image = { path = "../bevy_image", version = "0.17.0-dev" }
 bevy_derive = { path = "../bevy_derive", version = "0.17.0-dev" }
+bevy_shader = { path = "../bevy_shader", version = "0.17.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.17.0-dev" }
 bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.17.0-dev" }
 bevy_diagnostic = { path = "../bevy_diagnostic", version = "0.17.0-dev" }

--- a/crates/bevy_anti_aliasing/src/contrast_adaptive_sharpening/mod.rs
+++ b/crates/bevy_anti_aliasing/src/contrast_adaptive_sharpening/mod.rs
@@ -20,6 +20,7 @@ use bevy_render::{
     view::{ExtractedView, ViewTarget},
     Render, RenderApp, RenderStartup, RenderSystems,
 };
+use bevy_shader::Shader;
 use bevy_utils::default;
 
 mod node;

--- a/crates/bevy_anti_aliasing/src/fxaa/mod.rs
+++ b/crates/bevy_anti_aliasing/src/fxaa/mod.rs
@@ -20,6 +20,7 @@ use bevy_render::{
     view::{ExtractedView, ViewTarget},
     Render, RenderApp, RenderStartup, RenderSystems,
 };
+use bevy_shader::Shader;
 use bevy_utils::default;
 
 mod node;

--- a/crates/bevy_anti_aliasing/src/smaa/mod.rs
+++ b/crates/bevy_anti_aliasing/src/smaa/mod.rs
@@ -65,17 +65,18 @@ use bevy_render::{
         CachedRenderPipelineId, ColorTargetState, ColorWrites, CompareFunction, DepthStencilState,
         DynamicUniformBuffer, FilterMode, FragmentState, LoadOp, Operations, PipelineCache,
         RenderPassColorAttachment, RenderPassDepthStencilAttachment, RenderPassDescriptor,
-        RenderPipeline, RenderPipelineDescriptor, SamplerBindingType, SamplerDescriptor, Shader,
-        ShaderDefVal, ShaderStages, ShaderType, SpecializedRenderPipeline,
-        SpecializedRenderPipelines, StencilFaceState, StencilOperation, StencilState, StoreOp,
-        TextureDescriptor, TextureDimension, TextureFormat, TextureSampleType, TextureUsages,
-        TextureView, VertexState,
+        RenderPipeline, RenderPipelineDescriptor, SamplerBindingType, SamplerDescriptor,
+        ShaderStages, ShaderType, SpecializedRenderPipeline, SpecializedRenderPipelines,
+        StencilFaceState, StencilOperation, StencilState, StoreOp, TextureDescriptor,
+        TextureDimension, TextureFormat, TextureSampleType, TextureUsages, TextureView,
+        VertexState,
     },
     renderer::{RenderContext, RenderDevice, RenderQueue},
     texture::{CachedTexture, GpuImage, TextureCache},
     view::{ExtractedView, ViewTarget},
     Render, RenderApp, RenderStartup, RenderSystems,
 };
+use bevy_shader::{Shader, ShaderDefVal};
 use bevy_utils::prelude::default;
 
 /// Adds support for subpixel morphological antialiasing, or SMAA.

--- a/crates/bevy_anti_aliasing/src/taa/mod.rs
+++ b/crates/bevy_anti_aliasing/src/taa/mod.rs
@@ -27,7 +27,7 @@ use bevy_render::{
         BindGroupEntries, BindGroupLayout, BindGroupLayoutEntries, CachedRenderPipelineId,
         ColorTargetState, ColorWrites, FilterMode, FragmentState, Operations, PipelineCache,
         RenderPassColorAttachment, RenderPassDescriptor, RenderPipelineDescriptor, Sampler,
-        SamplerBindingType, SamplerDescriptor, Shader, ShaderStages, SpecializedRenderPipeline,
+        SamplerBindingType, SamplerDescriptor, ShaderStages, SpecializedRenderPipeline,
         SpecializedRenderPipelines, TextureDescriptor, TextureDimension, TextureFormat,
         TextureSampleType, TextureUsages,
     },
@@ -38,6 +38,7 @@ use bevy_render::{
     view::{ExtractedView, Msaa, ViewTarget},
     ExtractSchedule, MainWorld, Render, RenderApp, RenderStartup, RenderSystems,
 };
+use bevy_shader::Shader;
 use bevy_utils::default;
 use tracing::warn;
 

--- a/crates/bevy_core_pipeline/Cargo.toml
+++ b/crates/bevy_core_pipeline/Cargo.toml
@@ -28,6 +28,7 @@ bevy_ecs = { path = "../bevy_ecs", version = "0.17.0-dev" }
 bevy_image = { path = "../bevy_image", version = "0.17.0-dev" }
 bevy_camera = { path = "../bevy_camera", version = "0.17.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.17.0-dev" }
+bevy_shader = { path = "../bevy_shader", version = "0.17.0-dev" }
 bevy_render = { path = "../bevy_render", version = "0.17.0-dev" }
 bevy_transform = { path = "../bevy_transform", version = "0.17.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.17.0-dev" }

--- a/crates/bevy_core_pipeline/src/auto_exposure/pipeline.rs
+++ b/crates/bevy_core_pipeline/src/auto_exposure/pipeline.rs
@@ -10,6 +10,7 @@ use bevy_render::{
     renderer::RenderDevice,
     view::ViewUniform,
 };
+use bevy_shader::Shader;
 use bevy_utils::default;
 use core::num::NonZero;
 

--- a/crates/bevy_core_pipeline/src/blit/mod.rs
+++ b/crates/bevy_core_pipeline/src/blit/mod.rs
@@ -10,6 +10,7 @@ use bevy_render::{
     renderer::RenderDevice,
     RenderApp, RenderStartup,
 };
+use bevy_shader::Shader;
 use bevy_utils::default;
 
 /// Adds support for specialized "blit pipelines", which can be used to write one texture to another.

--- a/crates/bevy_core_pipeline/src/bloom/downsampling_pipeline.rs
+++ b/crates/bevy_core_pipeline/src/bloom/downsampling_pipeline.rs
@@ -15,6 +15,7 @@ use bevy_render::{
     },
     renderer::RenderDevice,
 };
+use bevy_shader::Shader;
 use bevy_utils::default;
 
 #[derive(Component)]

--- a/crates/bevy_core_pipeline/src/bloom/upsampling_pipeline.rs
+++ b/crates/bevy_core_pipeline/src/bloom/upsampling_pipeline.rs
@@ -17,6 +17,7 @@ use bevy_render::{
     renderer::RenderDevice,
     view::ViewTarget,
 };
+use bevy_shader::Shader;
 use bevy_utils::default;
 
 #[derive(Component)]

--- a/crates/bevy_core_pipeline/src/dof/mod.rs
+++ b/crates/bevy_core_pipeline/src/dof/mod.rs
@@ -44,8 +44,8 @@ use bevy_render::{
         BindGroup, BindGroupEntries, BindGroupLayout, BindGroupLayoutEntries,
         CachedRenderPipelineId, ColorTargetState, ColorWrites, FilterMode, FragmentState, LoadOp,
         Operations, PipelineCache, RenderPassColorAttachment, RenderPassDescriptor,
-        RenderPipelineDescriptor, Sampler, SamplerBindingType, SamplerDescriptor, Shader,
-        ShaderStages, ShaderType, SpecializedRenderPipeline, SpecializedRenderPipelines, StoreOp,
+        RenderPipelineDescriptor, Sampler, SamplerBindingType, SamplerDescriptor, ShaderStages,
+        ShaderType, SpecializedRenderPipeline, SpecializedRenderPipelines, StoreOp,
         TextureDescriptor, TextureDimension, TextureFormat, TextureSampleType, TextureUsages,
     },
     renderer::{RenderContext, RenderDevice},
@@ -58,6 +58,7 @@ use bevy_render::{
     },
     Extract, ExtractSchedule, Render, RenderApp, RenderStartup, RenderSystems,
 };
+use bevy_shader::Shader;
 use bevy_utils::{default, once};
 use smallvec::SmallVec;
 use tracing::{info, warn};

--- a/crates/bevy_core_pipeline/src/experimental/mip_generation/mod.rs
+++ b/crates/bevy_core_pipeline/src/experimental/mip_generation/mod.rs
@@ -36,16 +36,16 @@ use bevy_render::{
         BindGroup, BindGroupEntries, BindGroupLayout, BindGroupLayoutEntries,
         CachedComputePipelineId, ComputePassDescriptor, ComputePipeline, ComputePipelineDescriptor,
         Extent3d, IntoBinding, PipelineCache, PushConstantRange, Sampler, SamplerBindingType,
-        SamplerDescriptor, Shader, ShaderStages, SpecializedComputePipeline,
-        SpecializedComputePipelines, StorageTextureAccess, TextureAspect, TextureDescriptor,
-        TextureDimension, TextureFormat, TextureSampleType, TextureUsages, TextureView,
-        TextureViewDescriptor, TextureViewDimension,
+        SamplerDescriptor, ShaderStages, SpecializedComputePipeline, SpecializedComputePipelines,
+        StorageTextureAccess, TextureAspect, TextureDescriptor, TextureDimension, TextureFormat,
+        TextureSampleType, TextureUsages, TextureView, TextureViewDescriptor, TextureViewDimension,
     },
     renderer::{RenderContext, RenderDevice},
     texture::TextureCache,
     view::{ExtractedView, NoIndirectDrawing, ViewDepthTexture},
     Render, RenderApp, RenderSystems,
 };
+use bevy_shader::Shader;
 use bevy_utils::default;
 use bitflags::bitflags;
 use tracing::debug;

--- a/crates/bevy_core_pipeline/src/fullscreen_vertex_shader/mod.rs
+++ b/crates/bevy_core_pipeline/src/fullscreen_vertex_shader/mod.rs
@@ -1,6 +1,7 @@
 use bevy_asset::{load_embedded_asset, Handle};
 use bevy_ecs::{resource::Resource, world::FromWorld};
-use bevy_render::{prelude::Shader, render_resource::VertexState};
+use bevy_render::render_resource::VertexState;
+use bevy_shader::Shader;
 
 /// A shader that renders to the whole screen. Useful for post-processing.
 #[derive(Resource, Clone)]

--- a/crates/bevy_core_pipeline/src/motion_blur/pipeline.rs
+++ b/crates/bevy_core_pipeline/src/motion_blur/pipeline.rs
@@ -17,12 +17,13 @@ use bevy_render::{
         },
         BindGroupLayout, BindGroupLayoutEntries, CachedRenderPipelineId, ColorTargetState,
         ColorWrites, FragmentState, PipelineCache, RenderPipelineDescriptor, Sampler,
-        SamplerBindingType, SamplerDescriptor, Shader, ShaderDefVal, ShaderStages, ShaderType,
-        SpecializedRenderPipeline, SpecializedRenderPipelines, TextureFormat, TextureSampleType,
+        SamplerBindingType, SamplerDescriptor, ShaderStages, ShaderType, SpecializedRenderPipeline,
+        SpecializedRenderPipelines, TextureFormat, TextureSampleType,
     },
     renderer::RenderDevice,
     view::{ExtractedView, Msaa, ViewTarget},
 };
+use bevy_shader::{Shader, ShaderDefVal};
 use bevy_utils::default;
 
 use super::MotionBlurUniform;

--- a/crates/bevy_core_pipeline/src/oit/mod.rs
+++ b/crates/bevy_core_pipeline/src/oit/mod.rs
@@ -10,13 +10,13 @@ use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{
     camera::ExtractedCamera,
     extract_component::{ExtractComponent, ExtractComponentPlugin},
-    load_shader_library,
     render_graph::{RenderGraphExt, ViewNodeRunner},
     render_resource::{BufferUsages, BufferVec, DynamicUniformBuffer, ShaderType, TextureUsages},
     renderer::{RenderDevice, RenderQueue},
     view::Msaa,
     Render, RenderApp, RenderStartup, RenderSystems,
 };
+use bevy_shader::load_shader_library;
 use bevy_window::PrimaryWindow;
 use resolve::{
     node::{OitResolveNode, OitResolvePass},

--- a/crates/bevy_core_pipeline/src/oit/resolve/mod.rs
+++ b/crates/bevy_core_pipeline/src/oit/resolve/mod.rs
@@ -13,13 +13,13 @@ use bevy_render::{
         binding_types::{storage_buffer_sized, texture_depth_2d, uniform_buffer},
         BindGroup, BindGroupEntries, BindGroupLayout, BindGroupLayoutEntries, BlendComponent,
         BlendState, CachedRenderPipelineId, ColorTargetState, ColorWrites, DownlevelFlags,
-        FragmentState, PipelineCache, RenderPipelineDescriptor, ShaderDefVal, ShaderStages,
-        TextureFormat,
+        FragmentState, PipelineCache, RenderPipelineDescriptor, ShaderStages, TextureFormat,
     },
     renderer::{RenderAdapter, RenderDevice},
     view::{ExtractedView, ViewTarget, ViewUniform, ViewUniforms},
     Render, RenderApp, RenderSystems,
 };
+use bevy_shader::ShaderDefVal;
 use bevy_utils::default;
 use tracing::warn;
 

--- a/crates/bevy_core_pipeline/src/post_process/mod.rs
+++ b/crates/bevy_core_pipeline/src/post_process/mod.rs
@@ -21,7 +21,6 @@ use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{
     diagnostic::RecordDiagnostics,
     extract_component::{ExtractComponent, ExtractComponentPlugin},
-    load_shader_library,
     render_asset::{RenderAssetUsages, RenderAssets},
     render_graph::{
         NodeRunError, RenderGraphContext, RenderGraphExt as _, ViewNode, ViewNodeRunner,
@@ -31,15 +30,16 @@ use bevy_render::{
         BindGroupEntries, BindGroupLayout, BindGroupLayoutEntries, CachedRenderPipelineId,
         ColorTargetState, ColorWrites, DynamicUniformBuffer, Extent3d, FilterMode, FragmentState,
         Operations, PipelineCache, RenderPassColorAttachment, RenderPassDescriptor,
-        RenderPipelineDescriptor, Sampler, SamplerBindingType, SamplerDescriptor, Shader,
-        ShaderStages, ShaderType, SpecializedRenderPipeline, SpecializedRenderPipelines,
-        TextureDimension, TextureFormat, TextureSampleType,
+        RenderPipelineDescriptor, Sampler, SamplerBindingType, SamplerDescriptor, ShaderStages,
+        ShaderType, SpecializedRenderPipeline, SpecializedRenderPipelines, TextureDimension,
+        TextureFormat, TextureSampleType,
     },
     renderer::{RenderContext, RenderDevice, RenderQueue},
     texture::GpuImage,
     view::{ExtractedView, ViewTarget},
     Render, RenderApp, RenderStartup, RenderSystems,
 };
+use bevy_shader::{load_shader_library, Shader};
 use bevy_utils::prelude::default;
 
 use crate::{

--- a/crates/bevy_core_pipeline/src/skybox/mod.rs
+++ b/crates/bevy_core_pipeline/src/skybox/mod.rs
@@ -27,6 +27,7 @@ use bevy_render::{
     view::{ExtractedView, Msaa, ViewTarget, ViewUniform, ViewUniforms},
     Render, RenderApp, RenderStartup, RenderSystems,
 };
+use bevy_shader::Shader;
 use bevy_transform::components::Transform;
 use bevy_utils::default;
 use prepass::SkyboxPrepassPipeline;

--- a/crates/bevy_core_pipeline/src/skybox/prepass.rs
+++ b/crates/bevy_core_pipeline/src/skybox/prepass.rs
@@ -12,12 +12,13 @@ use bevy_render::{
     render_resource::{
         binding_types::uniform_buffer, BindGroup, BindGroupEntries, BindGroupLayout,
         BindGroupLayoutEntries, CachedRenderPipelineId, CompareFunction, DepthStencilState,
-        FragmentState, MultisampleState, PipelineCache, RenderPipelineDescriptor, Shader,
-        ShaderStages, SpecializedRenderPipeline, SpecializedRenderPipelines,
+        FragmentState, MultisampleState, PipelineCache, RenderPipelineDescriptor, ShaderStages,
+        SpecializedRenderPipeline, SpecializedRenderPipelines,
     },
     renderer::RenderDevice,
     view::{Msaa, ViewUniform, ViewUniforms},
 };
+use bevy_shader::Shader;
 use bevy_utils::prelude::default;
 
 use crate::{

--- a/crates/bevy_core_pipeline/src/tonemapping/mod.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/mod.rs
@@ -7,7 +7,6 @@ use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{
     extract_component::{ExtractComponent, ExtractComponentPlugin},
     extract_resource::{ExtractResource, ExtractResourcePlugin},
-    load_shader_library,
     render_asset::{RenderAssetUsages, RenderAssets},
     render_resource::{
         binding_types::{sampler, texture_2d, texture_3d, uniform_buffer},
@@ -18,6 +17,7 @@ use bevy_render::{
     view::{ExtractedView, ViewTarget, ViewUniform},
     Render, RenderApp, RenderStartup, RenderSystems,
 };
+use bevy_shader::{load_shader_library, Shader, ShaderDefVal};
 use bitflags::bitflags;
 #[cfg(not(feature = "tonemapping_luts"))]
 use tracing::error;

--- a/crates/bevy_dev_tools/Cargo.toml
+++ b/crates/bevy_dev_tools/Cargo.toml
@@ -25,6 +25,7 @@ bevy_render = { path = "../bevy_render", version = "0.17.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.17.0-dev" }
 bevy_time = { path = "../bevy_time", version = "0.17.0-dev" }
 bevy_text = { path = "../bevy_text", version = "0.17.0-dev" }
+bevy_shader = { path = "../bevy_shader", version = "0.17.0-dev" }
 bevy_ui = { path = "../bevy_ui", version = "0.17.0-dev" }
 bevy_ui_render = { path = "../bevy_ui_render", version = "0.17.0-dev" }
 bevy_window = { path = "../bevy_window", version = "0.17.0-dev" }

--- a/crates/bevy_dev_tools/src/frame_time_graph/mod.rs
+++ b/crates/bevy_dev_tools/src/frame_time_graph/mod.rs
@@ -7,9 +7,10 @@ use bevy_ecs::system::{Res, ResMut};
 use bevy_math::ops::log2;
 use bevy_reflect::TypePath;
 use bevy_render::{
-    render_resource::{AsBindGroup, Shader, ShaderRef, ShaderType},
+    render_resource::{AsBindGroup, ShaderType},
     storage::ShaderStorageBuffer,
 };
+use bevy_shader::{Shader, ShaderRef};
 use bevy_ui_render::prelude::{UiMaterial, UiMaterialPlugin};
 
 use crate::fps_overlay::FpsOverlayConfig;

--- a/crates/bevy_feathers/Cargo.toml
+++ b/crates/bevy_feathers/Cargo.toml
@@ -21,6 +21,7 @@ bevy_input_focus = { path = "../bevy_input_focus", version = "0.17.0-dev" }
 bevy_log = { path = "../bevy_log", version = "0.17.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.17.0-dev" }
 bevy_picking = { path = "../bevy_picking", version = "0.17.0-dev" }
+bevy_shader = { path = "../bevy_shader", version = "0.17.0-dev" }
 bevy_platform = { path = "../bevy_platform", version = "0.17.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.17.0-dev" }
 bevy_render = { path = "../bevy_render", version = "0.17.0-dev" }

--- a/crates/bevy_feathers/src/alpha_pattern.rs
+++ b/crates/bevy_feathers/src/alpha_pattern.rs
@@ -10,7 +10,8 @@ use bevy_ecs::{
     world::FromWorld,
 };
 use bevy_reflect::{prelude::ReflectDefault, Reflect, TypePath};
-use bevy_render::render_resource::{AsBindGroup, ShaderRef};
+use bevy_render::render_resource::AsBindGroup;
+use bevy_shader::ShaderRef;
 use bevy_ui_render::ui_material::{MaterialNode, UiMaterial};
 
 #[derive(AsBindGroup, Asset, TypePath, Default, Debug, Clone)]

--- a/crates/bevy_gizmos/Cargo.toml
+++ b/crates/bevy_gizmos/Cargo.toml
@@ -26,6 +26,7 @@ bevy_image = { path = "../bevy_image", version = "0.17.0-dev" }
 bevy_mesh = { path = "../bevy_mesh", version = "0.17.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.17.0-dev" }
 bevy_asset = { path = "../bevy_asset", version = "0.17.0-dev" }
+bevy_shader = { path = "../bevy_shader", version = "0.17.0-dev" }
 bevy_render = { path = "../bevy_render", version = "0.17.0-dev", optional = true }
 bevy_utils = { path = "../bevy_utils", version = "0.17.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.17.0-dev" }

--- a/crates/bevy_gizmos/src/pipeline_2d.rs
+++ b/crates/bevy_gizmos/src/pipeline_2d.rs
@@ -28,6 +28,7 @@ use bevy_render::{
     Render, RenderApp, RenderSystems,
 };
 use bevy_render::{sync_world::MainEntity, RenderStartup};
+use bevy_shader::Shader;
 use bevy_sprite::{
     init_mesh_2d_pipeline, Mesh2dPipeline, Mesh2dPipelineKey, SetMesh2dViewBindGroup,
 };

--- a/crates/bevy_gizmos/src/pipeline_3d.rs
+++ b/crates/bevy_gizmos/src/pipeline_3d.rs
@@ -33,6 +33,7 @@ use bevy_render::{
     Render, RenderApp, RenderSystems,
 };
 use bevy_render::{sync_world::MainEntity, RenderStartup};
+use bevy_shader::Shader;
 use bevy_utils::default;
 use tracing::error;
 

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -44,6 +44,7 @@ bevy_ecs = { path = "../bevy_ecs", version = "0.17.0-dev" }
 bevy_light = { path = "../bevy_light", version = "0.17.0-dev" }
 bevy_image = { path = "../bevy_image", version = "0.17.0-dev" }
 bevy_mesh = { path = "../bevy_mesh", version = "0.17.0-dev" }
+bevy_shader = { path = "../bevy_shader", version = "0.17.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.17.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.17.0-dev" }
 bevy_render = { path = "../bevy_render", features = [

--- a/crates/bevy_pbr/src/atmosphere/mod.rs
+++ b/crates/bevy_pbr/src/atmosphere/mod.rs
@@ -50,7 +50,6 @@ use bevy_math::{UVec2, UVec3, Vec3};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{
     extract_component::UniformComponentPlugin,
-    load_shader_library,
     render_resource::{DownlevelFlags, ShaderType, SpecializedRenderPipelines},
     view::Hdr,
 };
@@ -63,6 +62,7 @@ use bevy_render::{
 };
 
 use bevy_core_pipeline::core_3d::graph::Core3d;
+use bevy_shader::load_shader_library;
 use resources::{
     prepare_atmosphere_transforms, queue_render_sky_pipelines, AtmosphereTransforms,
     RenderSkyBindGroupLayouts,

--- a/crates/bevy_pbr/src/atmosphere/resources.rs
+++ b/crates/bevy_pbr/src/atmosphere/resources.rs
@@ -19,6 +19,7 @@ use bevy_render::{
     texture::{CachedTexture, TextureCache},
     view::{ExtractedView, Msaa, ViewDepthTexture, ViewUniform, ViewUniforms},
 };
+use bevy_shader::Shader;
 use bevy_utils::default;
 
 use super::{Atmosphere, AtmosphereSettings};

--- a/crates/bevy_pbr/src/decal/clustered.rs
+++ b/crates/bevy_pbr/src/decal/clustered.rs
@@ -35,7 +35,6 @@ use bevy_platform::collections::HashMap;
 pub use bevy_render::primitives::CubemapLayout;
 use bevy_render::{
     extract_component::ExtractComponentPlugin,
-    load_shader_library,
     render_asset::RenderAssets,
     render_resource::{
         binding_types, BindGroupLayoutEntryBuilder, Buffer, BufferUsages, RawBufferVec, Sampler,
@@ -46,6 +45,7 @@ use bevy_render::{
     texture::{FallbackImage, GpuImage},
     Extract, ExtractSchedule, Render, RenderApp, RenderSystems,
 };
+use bevy_shader::load_shader_library;
 use bevy_transform::components::GlobalTransform;
 use bytemuck::{Pod, Zeroable};
 

--- a/crates/bevy_pbr/src/decal/forward.rs
+++ b/crates/bevy_pbr/src/decal/forward.rs
@@ -12,7 +12,6 @@ use bevy_mesh::{Mesh, Mesh3d, MeshBuilder, MeshVertexBufferLayoutRef, Meshable};
 use bevy_reflect::{Reflect, TypePath};
 use bevy_render::{
     alpha::AlphaMode,
-    load_shader_library,
     render_asset::RenderAssets,
     render_resource::{
         AsBindGroup, AsBindGroupShaderType, CompareFunction, RenderPipelineDescriptor, ShaderType,
@@ -21,6 +20,7 @@ use bevy_render::{
     texture::GpuImage,
     RenderDebugFlags,
 };
+use bevy_shader::load_shader_library;
 
 /// Plugin to render [`ForwardDecal`]s.
 pub struct ForwardDecalPlugin;

--- a/crates/bevy_pbr/src/deferred/mod.rs
+++ b/crates/bevy_pbr/src/deferred/mod.rs
@@ -30,6 +30,7 @@ use bevy_render::{
     view::{ExtractedView, ViewTarget, ViewUniformOffset},
     Render, RenderApp, RenderSystems,
 };
+use bevy_shader::{Shader, ShaderDefVal};
 use bevy_utils::default;
 
 pub struct DeferredPbrLightingPlugin;

--- a/crates/bevy_pbr/src/extended_material.rs
+++ b/crates/bevy_pbr/src/extended_material.rs
@@ -9,11 +9,12 @@ use bevy_render::{
     alpha::AlphaMode,
     render_resource::{
         AsBindGroup, AsBindGroupError, BindGroupLayout, BindGroupLayoutEntry, BindlessDescriptor,
-        BindlessResourceType, BindlessSlabResourceLimit, RenderPipelineDescriptor, ShaderRef,
+        BindlessResourceType, BindlessSlabResourceLimit, RenderPipelineDescriptor,
         SpecializedMeshPipelineError, UnpreparedBindGroup,
     },
     renderer::RenderDevice,
 };
+use bevy_shader::ShaderRef;
 
 use crate::{Material, MaterialPipeline, MaterialPipelineKey, MeshPipeline, MeshPipelineKey};
 

--- a/crates/bevy_pbr/src/fog.rs
+++ b/crates/bevy_pbr/src/fog.rs
@@ -24,7 +24,7 @@ use bevy_render::extract_component::ExtractComponent;
 /// ```
 /// # use bevy_ecs::prelude::*;
 /// # use bevy_render::prelude::*;
-/// # use bevy_core_pipeline::prelude::*;
+/// # use bevy_camera::prelude::*;
 /// # use bevy_pbr::prelude::*;
 /// # use bevy_color::Color;
 /// # fn system(mut commands: Commands) {

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -55,6 +55,7 @@ pub use bevy_light::{
     PointLight, PointLightShadowMap, PointLightTexture, ShadowFilteringMethod, SpotLight,
     SpotLightTexture, TransmittedShadowReceiver, VolumetricFog, VolumetricLight,
 };
+use bevy_shader::{load_shader_library, ShaderRef};
 pub use cluster::*;
 pub use components::*;
 pub use decal::clustered::ClusteredDecalPlugin;
@@ -144,10 +145,9 @@ use bevy_render::{
     camera::sort_cameras,
     extract_component::ExtractComponentPlugin,
     extract_resource::ExtractResourcePlugin,
-    load_shader_library,
     render_graph::RenderGraph,
     render_resource::{
-        Extent3d, ShaderRef, TextureDataOrder, TextureDescriptor, TextureDimension, TextureFormat,
+        Extent3d, TextureDataOrder, TextureDescriptor, TextureDimension, TextureFormat,
         TextureUsages,
     },
     sync_component::SyncComponentPlugin,

--- a/crates/bevy_pbr/src/light_probe/generate.rs
+++ b/crates/bevy_pbr/src/light_probe/generate.rs
@@ -33,9 +33,9 @@ use bevy_render::{
         binding_types::*, AddressMode, BindGroup, BindGroupEntries, BindGroupLayout,
         BindGroupLayoutEntries, CachedComputePipelineId, ComputePassDescriptor,
         ComputePipelineDescriptor, DownlevelFlags, Extent3d, FilterMode, PipelineCache, Sampler,
-        SamplerBindingType, SamplerDescriptor, ShaderDefVal, ShaderStages, ShaderType,
-        StorageTextureAccess, Texture, TextureAspect, TextureDescriptor, TextureDimension,
-        TextureFormat, TextureFormatFeatureFlags, TextureSampleType, TextureUsages, TextureView,
+        SamplerBindingType, SamplerDescriptor, ShaderStages, ShaderType, StorageTextureAccess,
+        Texture, TextureAspect, TextureDescriptor, TextureDimension, TextureFormat,
+        TextureFormatFeatureFlags, TextureSampleType, TextureUsages, TextureView,
         TextureViewDescriptor, TextureViewDimension, UniformBuffer,
     },
     renderer::{RenderAdapter, RenderContext, RenderDevice, RenderQueue},
@@ -61,6 +61,7 @@ use bevy_render::{
 // [GGX convolution]: https://gpuopen.com/download/Bounded_VNDF_Sampling_for_Smith-GGX_Reflections.pdf
 
 use bevy_light::{EnvironmentMapLight, GeneratedEnvironmentMapLight};
+use bevy_shader::ShaderDefVal;
 use core::cmp::min;
 use tracing::info;
 

--- a/crates/bevy_pbr/src/light_probe/mod.rs
+++ b/crates/bevy_pbr/src/light_probe/mod.rs
@@ -21,7 +21,6 @@ use bevy_math::{Affine3A, FloatOrd, Mat4, Vec3A, Vec4};
 use bevy_platform::collections::HashMap;
 use bevy_render::{
     extract_instances::ExtractInstancesPlugin,
-    load_shader_library,
     render_asset::RenderAssets,
     render_resource::{DynamicUniformBuffer, Sampler, ShaderType, TextureView},
     renderer::{RenderAdapter, RenderDevice, RenderQueue},
@@ -31,6 +30,7 @@ use bevy_render::{
     view::ExtractedView,
     Extract, ExtractSchedule, Render, RenderApp, RenderSystems,
 };
+use bevy_shader::load_shader_library;
 use bevy_transform::{components::Transform, prelude::GlobalTransform};
 use tracing::error;
 

--- a/crates/bevy_pbr/src/lightmap/mod.rs
+++ b/crates/bevy_pbr/src/lightmap/mod.rs
@@ -50,7 +50,6 @@ use bevy_math::{uvec2, vec4, Rect, UVec2};
 use bevy_platform::collections::HashSet;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{
-    load_shader_library,
     render_asset::RenderAssets,
     render_resource::{Sampler, TextureView, WgpuSampler, WgpuTextureView},
     renderer::RenderAdapter,
@@ -59,6 +58,7 @@ use bevy_render::{
     Extract, ExtractSchedule, RenderApp, RenderStartup,
 };
 use bevy_render::{renderer::RenderDevice, sync_world::MainEntityHashMap};
+use bevy_shader::load_shader_library;
 use bevy_utils::default;
 use fixedbitset::FixedBitSet;
 use nonmax::{NonMaxU16, NonMaxU32};

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -55,6 +55,7 @@ use bevy_render::{
 };
 use bevy_render::{mesh::allocator::MeshAllocator, sync_world::MainEntityHashMap};
 use bevy_render::{texture::FallbackImage, view::RenderVisibleEntities};
+use bevy_shader::{Shader, ShaderDefVal};
 use bevy_utils::Parallel;
 use core::any::TypeId;
 use core::{hash::Hash, marker::PhantomData};

--- a/crates/bevy_pbr/src/meshlet/from_mesh.rs
+++ b/crates/bevy_pbr/src/meshlet/from_mesh.rs
@@ -7,11 +7,9 @@ use bevy_math::{
     ops::log2,
     IVec3, Isometry3d, Vec2, Vec3, Vec3A, Vec3Swizzles,
 };
+use bevy_mesh::{Indices, Mesh};
 use bevy_platform::collections::HashMap;
-use bevy_render::{
-    mesh::{Indices, Mesh},
-    render_resource::PrimitiveTopology,
-};
+use bevy_render::render_resource::PrimitiveTopology;
 use bevy_tasks::{AsyncComputeTaskPool, ParallelSlice};
 use bitvec::{order::Lsb0, vec::BitVec, view::BitView};
 use core::{f32, ops::Range};

--- a/crates/bevy_pbr/src/meshlet/material_pipeline_prepare.rs
+++ b/crates/bevy_pbr/src/meshlet/material_pipeline_prepare.rs
@@ -11,14 +11,10 @@ use bevy_core_pipeline::{
 use bevy_derive::{Deref, DerefMut};
 use bevy_light::{EnvironmentMapLight, IrradianceVolume, ShadowFilteringMethod};
 use bevy_mesh::VertexBufferLayout;
+use bevy_mesh::{Mesh, MeshVertexBufferLayout, MeshVertexBufferLayoutRef, MeshVertexBufferLayouts};
 use bevy_platform::collections::{HashMap, HashSet};
 use bevy_render::erased_render_asset::ErasedRenderAssets;
-use bevy_render::{
-    camera::TemporalJitter,
-    mesh::{Mesh, MeshVertexBufferLayout, MeshVertexBufferLayoutRef, MeshVertexBufferLayouts},
-    render_resource::*,
-    view::ExtractedView,
-};
+use bevy_render::{camera::TemporalJitter, render_resource::*, view::ExtractedView};
 use bevy_utils::default;
 use core::any::{Any, TypeId};
 

--- a/crates/bevy_pbr/src/meshlet/mod.rs
+++ b/crates/bevy_pbr/src/meshlet/mod.rs
@@ -78,13 +78,13 @@ use bevy_ecs::{
 };
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{
-    load_shader_library,
     render_graph::{RenderGraphExt, ViewNodeRunner},
     renderer::RenderDevice,
     settings::WgpuFeatures,
     view::{prepare_view_targets, Msaa},
     ExtractSchedule, Render, RenderApp, RenderStartup, RenderSystems,
 };
+use bevy_shader::load_shader_library;
 use bevy_transform::components::Transform;
 use derive_more::From;
 use tracing::error;

--- a/crates/bevy_pbr/src/meshlet/pipelines.rs
+++ b/crates/bevy_pbr/src/meshlet/pipelines.rs
@@ -10,6 +10,7 @@ use bevy_ecs::{
     world::World,
 };
 use bevy_render::render_resource::*;
+use bevy_shader::Shader;
 use bevy_utils::default;
 
 #[derive(Resource)]

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -27,7 +27,6 @@ use bevy_render::{
     alpha::AlphaMode,
     batching::gpu_preprocessing::GpuPreprocessingSupport,
     globals::{GlobalsBuffer, GlobalsUniform},
-    load_shader_library,
     mesh::{allocator::MeshAllocator, RenderMesh},
     render_asset::{prepare_assets, RenderAssets},
     render_phase::*,
@@ -40,6 +39,7 @@ use bevy_render::{
     },
     Extract, ExtractSchedule, Render, RenderApp, RenderDebugFlags, RenderStartup, RenderSystems,
 };
+use bevy_shader::{load_shader_library, Shader, ShaderDefVal};
 use bevy_transform::prelude::GlobalTransform;
 pub use prepass_bindings::*;
 use tracing::{error, warn};

--- a/crates/bevy_pbr/src/render/fog.rs
+++ b/crates/bevy_pbr/src/render/fog.rs
@@ -4,12 +4,12 @@ use bevy_ecs::prelude::*;
 use bevy_math::{Vec3, Vec4};
 use bevy_render::{
     extract_component::ExtractComponentPlugin,
-    load_shader_library,
     render_resource::{DynamicUniformBuffer, ShaderType},
     renderer::{RenderDevice, RenderQueue},
     view::ExtractedView,
     Render, RenderApp, RenderSystems,
 };
+use bevy_shader::load_shader_library;
 
 use crate::{DistanceFog, FogFalloff};
 

--- a/crates/bevy_pbr/src/render/gpu_preprocess.rs
+++ b/crates/bevy_pbr/src/render/gpu_preprocess.rs
@@ -42,7 +42,7 @@ use bevy_render::{
         binding_types::{storage_buffer, storage_buffer_read_only, texture_2d, uniform_buffer},
         BindGroup, BindGroupEntries, BindGroupLayout, BindingResource, Buffer, BufferBinding,
         CachedComputePipelineId, ComputePassDescriptor, ComputePipelineDescriptor,
-        DynamicBindGroupLayoutEntries, PipelineCache, PushConstantRange, RawBufferVec, Shader,
+        DynamicBindGroupLayoutEntries, PipelineCache, PushConstantRange, RawBufferVec,
         ShaderStages, ShaderType, SpecializedComputePipeline, SpecializedComputePipelines,
         TextureSampleType, UninitBufferVec,
     },
@@ -51,6 +51,7 @@ use bevy_render::{
     view::{ExtractedView, NoIndirectDrawing, ViewUniform, ViewUniformOffset, ViewUniforms},
     Render, RenderApp, RenderSystems,
 };
+use bevy_shader::Shader;
 use bevy_utils::{default, TypeIdMap};
 use bitflags::bitflags;
 use smallvec::{smallvec, SmallVec};

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -54,6 +54,7 @@ use bevy_render::{
     },
     Extract,
 };
+use bevy_shader::{load_shader_library, Shader, ShaderDefVal, ShaderSettings};
 use bevy_transform::components::GlobalTransform;
 use bevy_utils::{default, Parallel, TypeIdMap};
 use core::any::TypeId;

--- a/crates/bevy_pbr/src/ssao/mod.rs
+++ b/crates/bevy_pbr/src/ssao/mod.rs
@@ -22,7 +22,6 @@ use bevy_render::{
     diagnostic::RecordDiagnostics,
     extract_component::ExtractComponent,
     globals::{GlobalsBuffer, GlobalsUniform},
-    load_shader_library,
     render_graph::{NodeRunError, RenderGraphContext, RenderGraphExt, ViewNode, ViewNodeRunner},
     render_resource::{
         binding_types::{
@@ -37,6 +36,7 @@ use bevy_render::{
     view::{Msaa, ViewUniform, ViewUniformOffset, ViewUniforms},
     Extract, ExtractSchedule, Render, RenderApp, RenderSystems,
 };
+use bevy_shader::{load_shader_library, Shader, ShaderDefVal};
 use bevy_utils::prelude::default;
 use core::mem;
 use tracing::{error, warn};

--- a/crates/bevy_pbr/src/ssr/mod.rs
+++ b/crates/bevy_pbr/src/ssr/mod.rs
@@ -27,7 +27,6 @@ use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{
     diagnostic::RecordDiagnostics,
     extract_component::{ExtractComponent, ExtractComponentPlugin},
-    load_shader_library,
     render_graph::{
         NodeRunError, RenderGraph, RenderGraphContext, RenderGraphExt, ViewNode, ViewNodeRunner,
     },
@@ -35,14 +34,15 @@ use bevy_render::{
         binding_types, AddressMode, BindGroupEntries, BindGroupLayout, BindGroupLayoutEntries,
         CachedRenderPipelineId, ColorTargetState, ColorWrites, DynamicUniformBuffer, FilterMode,
         FragmentState, Operations, PipelineCache, RenderPassColorAttachment, RenderPassDescriptor,
-        RenderPipelineDescriptor, Sampler, SamplerBindingType, SamplerDescriptor, Shader,
-        ShaderStages, ShaderType, SpecializedRenderPipeline, SpecializedRenderPipelines,
-        TextureFormat, TextureSampleType,
+        RenderPipelineDescriptor, Sampler, SamplerBindingType, SamplerDescriptor, ShaderStages,
+        ShaderType, SpecializedRenderPipeline, SpecializedRenderPipelines, TextureFormat,
+        TextureSampleType,
     },
     renderer::{RenderAdapter, RenderContext, RenderDevice, RenderQueue},
     view::{ExtractedView, Msaa, ViewTarget, ViewUniformOffset},
     Render, RenderApp, RenderStartup, RenderSystems,
 };
+use bevy_shader::{load_shader_library, Shader};
 use bevy_utils::{once, prelude::default};
 use tracing::info;
 

--- a/crates/bevy_pbr/src/volumetric_fog/render.rs
+++ b/crates/bevy_pbr/src/volumetric_fog/render.rs
@@ -34,7 +34,7 @@ use bevy_render::{
         BlendOperation, BlendState, CachedRenderPipelineId, ColorTargetState, ColorWrites,
         DynamicBindGroupEntries, DynamicUniformBuffer, Face, FragmentState, LoadOp, Operations,
         PipelineCache, PrimitiveState, RenderPassColorAttachment, RenderPassDescriptor,
-        RenderPipelineDescriptor, SamplerBindingType, Shader, ShaderStages, ShaderType,
+        RenderPipelineDescriptor, SamplerBindingType, ShaderStages, ShaderType,
         SpecializedRenderPipeline, SpecializedRenderPipelines, StoreOp, TextureFormat,
         TextureSampleType, TextureUsages, VertexState,
     },
@@ -44,6 +44,7 @@ use bevy_render::{
     view::{ExtractedView, Msaa, ViewDepthTexture, ViewTarget, ViewUniformOffset},
     Extract,
 };
+use bevy_shader::Shader;
 use bevy_transform::components::GlobalTransform;
 use bevy_utils::prelude::default;
 use bitflags::bitflags;

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -53,6 +53,7 @@ use bevy_render::{
     },
     Extract, Render, RenderApp, RenderDebugFlags, RenderStartup, RenderSystems,
 };
+use bevy_shader::Shader;
 use core::{hash::Hash, ops::Range};
 use tracing::error;
 

--- a/crates/bevy_render/src/render_resource/pipeline.rs
+++ b/crates/bevy_render/src/render_resource/pipeline.rs
@@ -1,12 +1,10 @@
-use super::{empty_bind_group_layout, ShaderDefVal};
+use super::empty_bind_group_layout;
 use crate::WgpuWrapper;
-use crate::{
-    define_atomic_id,
-    render_resource::{BindGroupLayout, Shader},
-};
+use crate::{define_atomic_id, render_resource::BindGroupLayout};
 use alloc::borrow::Cow;
 use bevy_asset::Handle;
 use bevy_mesh::VertexBufferLayout;
+use bevy_shader::{Shader, ShaderDefVal};
 use core::iter;
 use core::ops::Deref;
 use thiserror::Error;

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -12,6 +12,10 @@ use bevy_ecs::{
     system::{Res, ResMut},
 };
 use bevy_platform::collections::{HashMap, HashSet};
+use bevy_shader::{
+    CachedPipelineId, PipelineCacheError, Shader, ShaderCache, ShaderCacheSource, ShaderDefVal,
+    ValidateShader,
+};
 use bevy_tasks::Task;
 use bevy_utils::default;
 use core::{future::Future, hash::Hash, mem};

--- a/crates/bevy_render/src/view/window/screenshot.rs
+++ b/crates/bevy_render/src/view/window/screenshot.rs
@@ -1,7 +1,6 @@
 use super::ExtractedWindows;
 use crate::{
     gpu_readback,
-    prelude::Shader,
     render_asset::{RenderAssetUsages, RenderAssets},
     render_resource::{
         binding_types::texture_2d, BindGroup, BindGroupEntries, BindGroupLayout,
@@ -25,6 +24,7 @@ use bevy_ecs::{
 use bevy_image::{Image, TextureFormatPixelInfo, ToExtents};
 use bevy_platform::collections::HashSet;
 use bevy_reflect::Reflect;
+use bevy_shader::Shader;
 use bevy_tasks::AsyncComputeTaskPool;
 use bevy_utils::default;
 use bevy_window::{PrimaryWindow, WindowRef};

--- a/crates/bevy_solari/Cargo.toml
+++ b/crates/bevy_solari/Cargo.toml
@@ -18,6 +18,7 @@ bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.17.0-dev" }
 bevy_derive = { path = "../bevy_derive", version = "0.17.0-dev" }
 bevy_diagnostic = { path = "../bevy_diagnostic", version = "0.17.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.17.0-dev" }
+bevy_shader = { path = "../bevy_shader", version = "0.17.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.17.0-dev" }
 bevy_mesh = { path = "../bevy_mesh", version = "0.17.0-dev" }
 bevy_pbr = { path = "../bevy_pbr", version = "0.17.0-dev" }

--- a/crates/bevy_solari/src/realtime/mod.rs
+++ b/crates/bevy_solari/src/realtime/mod.rs
@@ -13,12 +13,12 @@ use bevy_ecs::{component::Component, reflect::ReflectComponent, schedule::IntoSc
 use bevy_pbr::DefaultOpaqueRendererMethod;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{
-    load_shader_library,
     render_graph::{RenderGraphExt, ViewNodeRunner},
     renderer::RenderDevice,
     view::Hdr,
     ExtractSchedule, Render, RenderApp, RenderSystems,
 };
+use bevy_shader::load_shader_library;
 use extract::extract_solari_lighting;
 use node::SolariLightingNode;
 use prepare::prepare_solari_lighting_resources;

--- a/crates/bevy_solari/src/realtime/node.rs
+++ b/crates/bevy_solari/src/realtime/node.rs
@@ -21,12 +21,13 @@ use bevy_render::{
             storage_buffer_sized, texture_2d, texture_depth_2d, texture_storage_2d, uniform_buffer,
         },
         BindGroupEntries, BindGroupLayout, BindGroupLayoutEntries, CachedComputePipelineId,
-        ComputePassDescriptor, ComputePipelineDescriptor, PipelineCache, PushConstantRange, Shader,
-        ShaderDefVal, ShaderStages, StorageTextureAccess, TextureSampleType,
+        ComputePassDescriptor, ComputePipelineDescriptor, PipelineCache, PushConstantRange,
+        ShaderStages, StorageTextureAccess, TextureSampleType,
     },
     renderer::{RenderContext, RenderDevice},
     view::{ViewTarget, ViewUniform, ViewUniformOffset, ViewUniforms},
 };
+use bevy_shader::{Shader, ShaderDefVal};
 use bevy_utils::default;
 
 pub mod graph {

--- a/crates/bevy_solari/src/scene/mod.rs
+++ b/crates/bevy_solari/src/scene/mod.rs
@@ -3,6 +3,7 @@ mod blas;
 mod extract;
 mod types;
 
+use bevy_shader::load_shader_library;
 pub use binder::RaytracingSceneBindings;
 pub use types::RaytracingMesh3d;
 
@@ -11,7 +12,6 @@ use bevy_app::{App, Plugin};
 use bevy_ecs::schedule::IntoScheduleConfigs;
 use bevy_render::{
     extract_resource::ExtractResourcePlugin,
-    load_shader_library,
     mesh::{
         allocator::{allocate_and_free_meshes, MeshAllocator},
         RenderMesh,

--- a/crates/bevy_sprite/Cargo.toml
+++ b/crates/bevy_sprite/Cargo.toml
@@ -24,6 +24,7 @@ bevy_image = { path = "../bevy_image", version = "0.17.0-dev" }
 bevy_camera = { path = "../bevy_camera", version = "0.17.0-dev" }
 bevy_mesh = { path = "../bevy_mesh", version = "0.17.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.17.0-dev" }
+bevy_shader = { path = "../bevy_shader", version = "0.17.0-dev" }
 bevy_picking = { path = "../bevy_picking", version = "0.17.0-dev", optional = true }
 bevy_reflect = { path = "../bevy_reflect", version = "0.17.0-dev" }
 bevy_render = { path = "../bevy_render", version = "0.17.0-dev" }

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -39,6 +39,7 @@ use bevy_camera::{
     primitives::{Aabb, MeshAabb as _},
     visibility::{NoFrustumCulling, VisibilitySystems},
 };
+use bevy_shader::load_shader_library;
 pub use mesh2d::*;
 #[cfg(feature = "bevy_sprite_picking_backend")]
 pub use picking_backend::*;
@@ -54,7 +55,7 @@ use bevy_ecs::prelude::*;
 use bevy_image::{prelude::*, TextureAtlasPlugin};
 use bevy_mesh::{Mesh, Mesh2d};
 use bevy_render::{
-    batching::sort_binned_render_phase, load_shader_library, render_phase::AddRenderCommand,
+    batching::sort_binned_render_phase, render_phase::AddRenderCommand,
     render_resource::SpecializedRenderPipelines, ExtractSchedule, Render, RenderApp, RenderStartup,
     RenderSystems,
 };

--- a/crates/bevy_sprite/src/mesh2d/color_material.rs
+++ b/crates/bevy_sprite/src/mesh2d/color_material.rs
@@ -6,6 +6,7 @@ use bevy_image::Image;
 use bevy_math::{Affine2, Mat3, Vec4};
 use bevy_reflect::prelude::*;
 use bevy_render::{render_asset::RenderAssets, render_resource::*, texture::GpuImage};
+use bevy_shader::ShaderRef;
 
 #[derive(Default)]
 pub struct ColorMaterialPlugin;

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -37,14 +37,15 @@ use bevy_render::{
     },
     render_resource::{
         AsBindGroup, AsBindGroupError, BindGroup, BindGroupId, BindGroupLayout, BindingResources,
-        CachedRenderPipelineId, PipelineCache, RenderPipelineDescriptor, Shader, ShaderDefVal,
-        ShaderRef, SpecializedMeshPipeline, SpecializedMeshPipelineError, SpecializedMeshPipelines,
+        CachedRenderPipelineId, PipelineCache, RenderPipelineDescriptor, SpecializedMeshPipeline,
+        SpecializedMeshPipelineError, SpecializedMeshPipelines,
     },
     renderer::RenderDevice,
     sync_world::{MainEntity, MainEntityHashMap},
     view::{ExtractedView, RenderVisibleEntities},
     Extract, ExtractSchedule, Render, RenderApp, RenderStartup, RenderSystems,
 };
+use bevy_shader::{Shader, ShaderDefVal, ShaderRef};
 use bevy_utils::Parallel;
 use core::{hash::Hash, marker::PhantomData};
 use derive_more::derive::From;

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -1,7 +1,8 @@
 use bevy_app::Plugin;
 use bevy_asset::{embedded_asset, load_embedded_asset, AssetId, AssetServer, Handle};
 use bevy_camera::{visibility::ViewVisibility, Camera2d};
-use bevy_render::{load_shader_library, RenderStartup};
+use bevy_render::RenderStartup;
+use bevy_shader::{load_shader_library, Shader, ShaderDefVal, ShaderSettings};
 
 use crate::{tonemapping_pipeline_key, Material2dBindGroupId};
 use bevy_core_pipeline::{

--- a/crates/bevy_sprite/src/mesh2d/wireframe2d.rs
+++ b/crates/bevy_sprite/src/mesh2d/wireframe2d.rs
@@ -51,6 +51,7 @@ use bevy_render::{
     },
     Extract, Render, RenderApp, RenderDebugFlags, RenderStartup, RenderSystems,
 };
+use bevy_shader::Shader;
 use core::{hash::Hash, ops::Range};
 use tracing::error;
 

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -38,6 +38,7 @@ use bevy_render::{
     view::{ExtractedView, Msaa, ViewTarget, ViewUniform, ViewUniformOffset, ViewUniforms},
     Extract,
 };
+use bevy_shader::{Shader, ShaderDefVal};
 use bevy_transform::components::GlobalTransform;
 use bevy_utils::default;
 use bytemuck::{Pod, Zeroable};

--- a/crates/bevy_sprite/src/tilemap_chunk/tilemap_chunk_material.rs
+++ b/crates/bevy_sprite/src/tilemap_chunk/tilemap_chunk_material.rs
@@ -6,6 +6,7 @@ use bevy_image::{Image, ImageSampler, ToExtents};
 use bevy_math::UVec2;
 use bevy_reflect::prelude::*;
 use bevy_render::render_resource::*;
+use bevy_shader::ShaderRef;
 use bytemuck::{Pod, Zeroable};
 
 /// Plugin that adds support for tilemap chunk materials.

--- a/crates/bevy_ui_render/Cargo.toml
+++ b/crates/bevy_ui_render/Cargo.toml
@@ -21,6 +21,7 @@ bevy_image = { path = "../bevy_image", version = "0.17.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.17.0-dev" }
 bevy_mesh = { path = "../bevy_mesh", version = "0.17.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.17.0-dev" }
+bevy_shader = { path = "../bevy_shader", version = "0.17.0-dev" }
 bevy_render = { path = "../bevy_render", version = "0.17.0-dev" }
 bevy_sprite = { path = "../bevy_sprite", version = "0.17.0-dev" }
 bevy_picking = { path = "../bevy_picking", version = "0.17.0-dev", optional = true }

--- a/crates/bevy_ui_render/src/box_shadow.rs
+++ b/crates/bevy_ui_render/src/box_shadow.rs
@@ -26,6 +26,7 @@ use bevy_render::{
     Extract, ExtractSchedule, Render, RenderSystems,
 };
 use bevy_render::{RenderApp, RenderStartup};
+use bevy_shader::{Shader, ShaderDefVal};
 use bevy_ui::{
     BoxShadow, CalculatedClip, ComputedNode, ComputedNodeTarget, ResolvedBorderRadius,
     UiGlobalTransform, Val,

--- a/crates/bevy_ui_render/src/gradient.rs
+++ b/crates/bevy_ui_render/src/gradient.rs
@@ -31,6 +31,7 @@ use bevy_render::{
     Extract, ExtractSchedule, Render, RenderSystems,
 };
 use bevy_render::{sync_world::MainEntity, RenderStartup};
+use bevy_shader::Shader;
 use bevy_sprite::BorderRect;
 use bevy_ui::{
     BackgroundGradient, BorderGradient, ColorStop, ConicGradient, Gradient,

--- a/crates/bevy_ui_render/src/lib.rs
+++ b/crates/bevy_ui_render/src/lib.rs
@@ -22,6 +22,7 @@ use bevy_camera::visibility::InheritedVisibility;
 use bevy_camera::{Camera, Camera2d, Camera3d};
 use bevy_reflect::prelude::ReflectDefault;
 use bevy_reflect::Reflect;
+use bevy_shader::load_shader_library;
 use bevy_ui::widget::{ImageNode, TextShadow, ViewportNode};
 use bevy_ui::{
     BackgroundColor, BorderColor, CalculatedClip, ComputedNode, ComputedNodeTarget, Display, Node,
@@ -43,7 +44,7 @@ use bevy_render::renderer::RenderContext;
 use bevy_render::sync_world::MainEntity;
 use bevy_render::texture::TRANSPARENT_IMAGE_HANDLE;
 use bevy_render::view::{Hdr, RetainedViewEntity};
-use bevy_render::{load_shader_library, RenderStartup};
+use bevy_render::RenderStartup;
 use bevy_render::{
     render_asset::RenderAssets,
     render_graph::{Node as RenderGraphNode, RenderGraph},
@@ -147,7 +148,7 @@ pub enum RenderUiSystems {
 /// **Note:** This does not affect text anti-aliasing. For that, use the `font_smoothing` property of the [`TextFont`](bevy_text::TextFont) component.
 ///
 /// ```
-/// use bevy_core_pipeline::prelude::*;
+/// use bevy_camera::prelude::*;
 /// use bevy_ecs::prelude::*;
 /// use bevy_ui::prelude::*;
 /// use bevy_ui_render::prelude::*;
@@ -176,7 +177,7 @@ pub enum UiAntiAlias {
 /// Default is 4, values higher than ~10 offer diminishing returns.
 ///
 /// ```
-/// use bevy_core_pipeline::prelude::*;
+/// use bevy_camera::prelude::*;
 /// use bevy_ecs::prelude::*;
 /// use bevy_ui::prelude::*;
 /// use bevy_ui_render::prelude::*;

--- a/crates/bevy_ui_render/src/pipeline.rs
+++ b/crates/bevy_ui_render/src/pipeline.rs
@@ -10,6 +10,7 @@ use bevy_render::{
     renderer::RenderDevice,
     view::{ViewTarget, ViewUniform},
 };
+use bevy_shader::Shader;
 use bevy_utils::default;
 
 #[derive(Resource)]

--- a/crates/bevy_ui_render/src/ui_material.rs
+++ b/crates/bevy_ui_render/src/ui_material.rs
@@ -5,8 +5,9 @@ use bevy_ecs::{component::Component, reflect::ReflectComponent};
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_render::{
     extract_component::ExtractComponent,
-    render_resource::{AsBindGroup, RenderPipelineDescriptor, ShaderRef},
+    render_resource::{AsBindGroup, RenderPipelineDescriptor},
 };
+use bevy_shader::ShaderRef;
 use derive_more::derive::From;
 
 /// Materials are used alongside [`UiMaterialPlugin`](crate::UiMaterialPlugin) and [`MaterialNode`]
@@ -31,8 +32,9 @@ use derive_more::derive::From;
 /// # use bevy_ecs::prelude::*;
 /// # use bevy_image::Image;
 /// # use bevy_reflect::TypePath;
-/// # use bevy_render::render_resource::{AsBindGroup, ShaderRef};
+/// # use bevy_render::render_resource::AsBindGroup;
 /// # use bevy_color::LinearRgba;
+/// # use bevy_shader::ShaderDef;
 /// # use bevy_asset::{Handle, AssetServer, Assets, Asset};
 /// # use bevy_ui_render::prelude::*;
 ///

--- a/crates/bevy_ui_render/src/ui_material.rs
+++ b/crates/bevy_ui_render/src/ui_material.rs
@@ -34,7 +34,7 @@ use derive_more::derive::From;
 /// # use bevy_reflect::TypePath;
 /// # use bevy_render::render_resource::AsBindGroup;
 /// # use bevy_color::LinearRgba;
-/// # use bevy_shader::ShaderDef;
+/// # use bevy_shader::ShaderRef;
 /// # use bevy_asset::{Handle, AssetServer, Assets, Asset};
 /// # use bevy_ui_render::prelude::*;
 ///

--- a/crates/bevy_ui_render/src/ui_material_pipeline.rs
+++ b/crates/bevy_ui_render/src/ui_material_pipeline.rs
@@ -14,7 +14,6 @@ use bevy_math::{Affine2, FloatOrd, Rect, Vec2};
 use bevy_mesh::VertexBufferLayout;
 use bevy_render::{
     globals::{GlobalsBuffer, GlobalsUniform},
-    load_shader_library,
     render_asset::{PrepareAssetError, RenderAsset, RenderAssetPlugin, RenderAssets},
     render_phase::*,
     render_resource::{binding_types::uniform_buffer, *},
@@ -24,6 +23,7 @@ use bevy_render::{
     Extract, ExtractSchedule, Render, RenderSystems,
 };
 use bevy_render::{RenderApp, RenderStartup};
+use bevy_shader::{load_shader_library, Shader, ShaderRef};
 use bevy_sprite::BorderRect;
 use bevy_utils::default;
 use bytemuck::{Pod, Zeroable};

--- a/crates/bevy_ui_render/src/ui_texture_slice_pipeline.rs
+++ b/crates/bevy_ui_render/src/ui_texture_slice_pipeline.rs
@@ -24,6 +24,7 @@ use bevy_render::{
     Extract, ExtractSchedule, Render, RenderSystems,
 };
 use bevy_render::{sync_world::MainEntity, RenderStartup};
+use bevy_shader::Shader;
 use bevy_sprite::{SliceScaleMode, SpriteAssetEvents, SpriteImageMode, TextureSlicer};
 use bevy_ui::widget;
 use bevy_utils::default;


### PR DESCRIPTION
# Objective

- Prepare for removing re-exports
- Probably depends on #20491 merging first

## Solution

- title

## Testing

- cargo check --examples --all-features
