### PR TITLE
Depend on bevy_tasks::block_on instead of futures_lite::block_on

### DIFF
--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -105,7 +105,6 @@ bytemuck = { version = "1.5", features = ["derive", "must_cast"] }
 downcast-rs = { version = "2", default-features = false, features = ["std"] }
 thiserror = { version = "2", default-features = false }
 derive_more = { version = "2", default-features = false, features = ["from"] }
-futures-lite = "2.0.1"
 encase = { version = "0.10", features = ["glam"] }
 # For wgpu profiling using tracing. Use `RUST_LOG=info` to also capture the wgpu spans.
 profiling = { version = "1", features = [

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -432,7 +432,7 @@ impl Plugin for RenderPlugin {
                         .detach();
                     // Otherwise, just block for it to complete
                     #[cfg(not(target_arch = "wasm32"))]
-                    futures_lite::future::block_on(async_renderer);
+                    bevy_tasks::block_on(async_renderer);
 
                     // SAFETY: Plugins should be set up on the main thread.
                     unsafe { initialize_render_app(app) };

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -759,7 +759,7 @@ fn create_pipeline_task(
         return CachedPipelineState::Creating(bevy_tasks::AsyncComputeTaskPool::get().spawn(task));
     }
 
-    match futures_lite::future::block_on(task) {
+    match bevy_tasks::block_on(task) {
         Ok(pipeline) => CachedPipelineState::Ok(pipeline),
         Err(err) => CachedPipelineState::Err(err),
     }
@@ -774,7 +774,7 @@ fn create_pipeline_task(
     task: impl Future<Output = Result<Pipeline, PipelineCacheError>> + Send + 'static,
     _sync: bool,
 ) -> CachedPipelineState {
-    match futures_lite::future::block_on(task) {
+    match bevy_tasks::block_on(task) {
         Ok(pipeline) => CachedPipelineState::Ok(pipeline),
         Err(err) => CachedPipelineState::Err(err),
     }

--- a/crates/bevy_tasks/src/edge_executor.rs
+++ b/crates/bevy_tasks/src/edge_executor.rs
@@ -481,7 +481,7 @@ impl<const C: usize> State<C> {
 mod different_executor_tests {
     use core::cell::Cell;
 
-    use futures_lite::future::{block_on, pending, poll_once};
+    use bevy_tasks::{block_on, futures_lite::{pending, poll_once}};
     use futures_lite::pin;
 
     use super::LocalExecutor;


### PR DESCRIPTION
# Objective
`bevy_tasks::block_on` is aliased depending on the features enabled on the crate. If a Bevy-specific version of a `block_on` is implemented, it should be using it as well. The rest of the engine should use the version bevy_tasks exposes.

## Solution
Remove the indirect dependencies on `futures_lite::block_on` and use `bevy_tasks::block_on` instead.

## Testing
CI should pass.