### PR TITLE
Fix App::get_added_plugins not working inside finish and cleanup

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -256,12 +256,14 @@ impl App {
     /// plugins are ready, but can be useful for situations where you want to use [`App::update`].
     pub fn finish(&mut self) {
         // plugins installed to main should see all sub-apps
-        let plugins = core::mem::take(&mut self.main_mut().plugin_registry);
-        for plugin in &plugins {
+        let len = self.main().plugin_registry.len();
+        for i in 0..len {
+            let plugin = self.main_mut().plugin_registry.swap_remove(i);
             plugin.finish(self);
+            self.main_mut().plugin_registry.push(plugin);
+            self.main_mut().plugin_registry.swap(i, len - 1);
         }
         let main = self.main_mut();
-        main.plugin_registry = plugins;
         main.plugins_state = PluginsState::Finished;
         self.sub_apps.iter_mut().skip(1).for_each(SubApp::finish);
     }
@@ -270,12 +272,14 @@ impl App {
     /// [`App::finish`], but can be useful for situations where you want to use [`App::update`].
     pub fn cleanup(&mut self) {
         // plugins installed to main should see all sub-apps
-        let plugins = core::mem::take(&mut self.main_mut().plugin_registry);
-        for plugin in &plugins {
+        let len = self.main().plugin_registry.len();
+        for i in 0..len {
+            let plugin = self.main_mut().plugin_registry.swap_remove(i);
             plugin.cleanup(self);
+            self.main_mut().plugin_registry.push(plugin);
+            self.main_mut().plugin_registry.swap(i, len - 1);
         }
         let main = self.main_mut();
-        main.plugin_registry = plugins;
         main.plugins_state = PluginsState::Cleaned;
         self.sub_apps.iter_mut().skip(1).for_each(SubApp::cleanup);
     }

--- a/crates/bevy_app/src/sub_app.rs
+++ b/crates/bevy_app/src/sub_app.rs
@@ -401,25 +401,29 @@ impl SubApp {
 
     /// Runs [`Plugin::finish`] for each plugin.
     pub fn finish(&mut self) {
-        let plugins = core::mem::take(&mut self.plugin_registry);
-        self.run_as_app(|app| {
-            for plugin in &plugins {
+        let len = self.plugin_registry.len();
+        for i in 0..len {
+            let plugin = self.plugin_registry.swap_remove(i);
+            self.run_as_app(|app| {
                 plugin.finish(app);
-            }
-        });
-        self.plugin_registry = plugins;
+            });
+            self.plugin_registry.push(plugin);
+            self.plugin_registry.swap(i, len - 1);
+        }
         self.plugins_state = PluginsState::Finished;
     }
 
     /// Runs [`Plugin::cleanup`] for each plugin.
     pub fn cleanup(&mut self) {
-        let plugins = core::mem::take(&mut self.plugin_registry);
-        self.run_as_app(|app| {
-            for plugin in &plugins {
+        let len = self.plugin_registry.len();
+        for i in 0..len {
+            let plugin = self.plugin_registry.swap_remove(i);
+            self.run_as_app(|app| {
                 plugin.cleanup(app);
-            }
-        });
-        self.plugin_registry = plugins;
+            });
+            self.plugin_registry.push(plugin);
+            self.plugin_registry.swap(i, len - 1);
+        }
         self.plugins_state = PluginsState::Cleaned;
     }
 


### PR DESCRIPTION
# Objective

This assertion fails when called inside finish or cleanup:
```rs
assert_eq!(
    app.is_plugin_added::<ImagePlugin>(),
    app.get_added_plugins::<ImagePlugin>().len() > 0
);
```

## Solution

- Do the hokey pokey one plugin at a time
- swap_remove to stay O(1), then push and swap back to preserve plugin order

## Testing

- Someone should write unit tests for this and probably document that it hokey pokeys, although i dont think anyone will get_added_plugins<Self> because you have a `self` param in finish and cleanup anyways.