### PR TITLE
Fix rotation matrix construction from `Rot2`

### DIFF
--- a/crates/bevy_math/src/rotation2d.rs
+++ b/crates/bevy_math/src/rotation2d.rs
@@ -729,7 +729,7 @@ mod tests {
 
         // Check that the matrix is correct.
         assert_relative_eq!(matrix.x_axis, Vec2::Y);
-        assert_relative_eq!(matrix.y_axis, -Vec2::X);
+        assert_relative_eq!(matrix.y_axis, Vec2::NEG_X);
 
         // Check that the matrix rotates vectors correctly.
         assert_relative_eq!(matrix * Vec2::X, Vec2::Y);

--- a/crates/bevy_math/src/rotation2d.rs
+++ b/crates/bevy_math/src/rotation2d.rs
@@ -446,7 +446,7 @@ impl From<f32> for Rot2 {
 impl From<Rot2> for Mat2 {
     /// Creates a [`Mat2`] rotation matrix from a [`Rot2`].
     fn from(rot: Rot2) -> Self {
-        Mat2::from_cols_array(&[rot.cos, -rot.sin, rot.sin, rot.cos])
+        Mat2::from_cols_array(&[rot.cos, rot.sin, -rot.sin, rot.cos])
     }
 }
 
@@ -518,7 +518,7 @@ mod tests {
 
     use approx::assert_relative_eq;
 
-    use crate::{ops, Dir2, Rot2, Vec2};
+    use crate::{ops, Dir2, Mat2, Rot2, Vec2};
 
     #[test]
     fn creation() {
@@ -720,5 +720,21 @@ mod tests {
         assert!(rot1.slerp(rot2, 0.0).is_near_identity());
         assert_eq!(rot1.slerp(rot2, 0.5).as_degrees(), 90.0);
         assert_eq!(ops::abs(rot1.slerp(rot2, 1.0).as_degrees()), 180.0);
+    }
+
+    #[test]
+    fn rotation_matrix() {
+        let rotation = Rot2::degrees(90.0);
+        let matrix: Mat2 = rotation.into();
+
+        // Check that the matrix is correct.
+        assert_relative_eq!(matrix.x_axis, Vec2::Y);
+        assert_relative_eq!(matrix.y_axis, -Vec2::X);
+
+        // Check that the matrix rotates vectors correctly.
+        assert_relative_eq!(matrix * Vec2::X, Vec2::Y);
+        assert_relative_eq!(matrix * Vec2::Y, Vec2::NEG_X);
+        assert_relative_eq!(matrix * Vec2::NEG_X, Vec2::NEG_Y);
+        assert_relative_eq!(matrix * Vec2::NEG_Y, Vec2::X);
     }
 }


### PR DESCRIPTION
# Objective

Our `From<Rot2>` implementation for `Mat2` looks like this:

```rust
impl From<Rot2> for Mat2 {
    /// Creates a [`Mat2`] rotation matrix from a [`Rot2`].
    fn from(rot: Rot2) -> Self {
        Mat2::from_cols_array(&[rot.cos, -rot.sin, rot.sin, rot.cos])
    }
}
```

The resulting matrix looks like this:

```text
[  cos, sin ]
[ -sin, cos ]
```

Cool! Oh wait -- *checks [notes](https://en.wikipedia.org/wiki/Rotation_matrix)* -- the correct matrix is this?

```text
[ cos, -sin ]
[ sin,  cos ]
```

Oops!

## Solution

Fix the matrix signs. Now my joint's axes are oriented correctly :)

## Testing

Added a simple regression test. Fails before the change, passes after.