### PR TITLE
Use the capacity from the entities Vec to initialize Table columns

### DIFF
--- a/crates/bevy_ecs/src/storage/table/mod.rs
+++ b/crates/bevy_ecs/src/storage/table/mod.rs
@@ -134,7 +134,7 @@ impl TableRow {
 /// [`build`]: Self::build
 pub(crate) struct TableBuilder {
     columns: SparseSet<ComponentId, ThinColumn>,
-    capacity: usize,
+    entities: Vec<Entity>,
 }
 
 impl TableBuilder {
@@ -142,7 +142,7 @@ impl TableBuilder {
     pub fn with_capacity(capacity: usize, column_capacity: usize) -> Self {
         Self {
             columns: SparseSet::with_capacity(column_capacity),
-            capacity,
+            entities: Vec::with_capacity(capacity),
         }
     }
 
@@ -151,7 +151,7 @@ impl TableBuilder {
     pub fn add_column(mut self, component_info: &ComponentInfo) -> Self {
         self.columns.insert(
             component_info.id(),
-            ThinColumn::with_capacity(component_info, self.capacity),
+            ThinColumn::with_capacity(component_info, self.entities.capacity()),
         );
         self
     }
@@ -161,7 +161,7 @@ impl TableBuilder {
     pub fn build(self) -> Table {
         Table {
             columns: self.columns.into_immutable(),
-            entities: Vec::with_capacity(self.capacity),
+            entities: self.entities,
         }
     }
 }


### PR DESCRIPTION
# Objective
When working with `realloc`, it's a safety invariant to pass in the existing layout of the allocation that is being reallocated. This may not be the case with newly created `Table`s.  `Vec::with_capacity`'s documentation states that it will return an allocation with enough space for *at least* `capacity` elements, not exactly `capacity`. This means that `entities.capacity()` may be greater than the provided capacity. As the `ThinColumn`s use this as their capacity, the new Layout fed to `realloc` will not match the allocation originally provided to `alloc`. This is unsound.

## Solution
Begin `Table` construction by allocating the `entities` Vec, and use it's capacity to allocate the columns instead of directly feeding the provided capacity into `ThinColumn::with_capacity`.

## Testing
Tested this locally against existing unit tests and miri.