### PR TITLE
Atmosphere generated environment map lighting

### DIFF
--- a/crates/bevy_light/src/lib.rs
+++ b/crates/bevy_light/src/lib.rs
@@ -27,7 +27,10 @@ use cluster::{
 mod ambient_light;
 pub use ambient_light::AmbientLight;
 mod probe;
-pub use probe::{EnvironmentMapLight, GeneratedEnvironmentMapLight, IrradianceVolume, LightProbe};
+pub use probe::{
+    AtmosphereEnvironmentMapLight, EnvironmentMapLight, GeneratedEnvironmentMapLight,
+    IrradianceVolume, LightProbe,
+};
 mod volumetric;
 pub use volumetric::{FogVolume, VolumetricFog, VolumetricLight};
 pub mod cascade;

--- a/crates/bevy_light/src/probe.rs
+++ b/crates/bevy_light/src/probe.rs
@@ -2,7 +2,7 @@ use bevy_asset::Handle;
 use bevy_camera::visibility::Visibility;
 use bevy_ecs::prelude::*;
 use bevy_image::Image;
-use bevy_math::Quat;
+use bevy_math::{Quat, UVec2};
 use bevy_reflect::prelude::*;
 use bevy_transform::components::Transform;
 
@@ -136,6 +136,29 @@ impl Default for GeneratedEnvironmentMapLight {
             intensity: 0.0,
             rotation: Quat::IDENTITY,
             affects_lightmapped_mesh_diffuse: true,
+        }
+    }
+}
+
+/// Generates a cubemap of the sky produced by the atmosphere shader.
+///
+/// Attach to a `LightProbe` to capture reflections inside its volume.
+#[derive(Component, Clone)]
+pub struct AtmosphereEnvironmentMapLight {
+    /// Luminance multiplier in cd/m².
+    pub intensity: f32,
+    /// Whether the diffuse contribution should affect meshes that already have lightmaps.
+    pub affects_lightmapped_mesh_diffuse: bool,
+    /// Cubemap resolution in pixels (must be a power-of-two).
+    pub size: UVec2,
+}
+
+impl Default for AtmosphereEnvironmentMapLight {
+    fn default() -> Self {
+        Self {
+            intensity: 1.0,
+            affects_lightmapped_mesh_diffuse: true,
+            size: UVec2::new(512, 512),
         }
     }
 }

--- a/crates/bevy_pbr/src/atmosphere/environment.rs
+++ b/crates/bevy_pbr/src/atmosphere/environment.rs
@@ -1,0 +1,315 @@
+use crate::{
+    resources::{
+        AtmosphereSamplers, AtmosphereTextures, AtmosphereTransform, AtmosphereTransforms,
+        AtmosphereTransformsOffset,
+    },
+    AtmosphereSettings, GpuLights, LightMeta, ViewLightsUniformOffset,
+};
+use bevy_asset::{load_embedded_asset, AssetServer, Assets, Handle, RenderAssetUsages};
+use bevy_ecs::{
+    component::Component,
+    entity::Entity,
+    query::{QueryState, With, Without},
+    resource::Resource,
+    system::{lifetimeless::Read, Commands, Query, Res, ResMut},
+    world::{FromWorld, World},
+};
+use bevy_image::Image;
+use bevy_light::{AtmosphereEnvironmentMapLight, GeneratedEnvironmentMapLight};
+use bevy_math::{Quat, UVec2};
+use bevy_render::{
+    extract_component::{ComponentUniforms, DynamicUniformIndex, ExtractComponent},
+    render_asset::RenderAssets,
+    render_graph::{Node, NodeRunError, RenderGraphContext},
+    render_resource::{binding_types::*, *},
+    renderer::{RenderContext, RenderDevice},
+    texture::{CachedTexture, GpuImage},
+    view::{ViewUniform, ViewUniformOffset, ViewUniforms},
+};
+use bevy_utils::default;
+
+use super::Atmosphere;
+
+// Render world representation of an environment map light for the atmosphere
+#[derive(Component, ExtractComponent, Clone)]
+pub struct AtmosphereEnvironmentMap {
+    pub environment_map: Handle<Image>,
+    pub size: UVec2,
+}
+
+#[derive(Component)]
+pub struct AtmosphereProbeTextures {
+    pub environment: TextureView,
+    pub transmittance_lut: CachedTexture,
+    pub multiscattering_lut: CachedTexture,
+    pub sky_view_lut: CachedTexture,
+    pub aerial_view_lut: CachedTexture,
+}
+
+#[derive(Component)]
+pub(crate) struct AtmosphereProbeBindGroups {
+    pub environment: BindGroup,
+}
+
+#[derive(Resource)]
+pub struct AtmosphereProbeLayouts {
+    pub environment: BindGroupLayout,
+}
+
+#[derive(Resource)]
+pub struct AtmosphereProbePipelines {
+    pub environment: CachedComputePipelineId,
+}
+
+pub fn prepare_atmosphere_probe_layout(mut commands: Commands, render_device: Res<RenderDevice>) {
+    let environment = render_device.create_bind_group_layout(
+        "environment_bind_group_layout",
+        &BindGroupLayoutEntries::sequential(
+            ShaderStages::COMPUTE,
+            (
+                uniform_buffer::<Atmosphere>(true),
+                uniform_buffer::<AtmosphereSettings>(true),
+                uniform_buffer::<AtmosphereTransform>(true),
+                uniform_buffer::<ViewUniform>(true),
+                uniform_buffer::<GpuLights>(true),
+                texture_2d(TextureSampleType::Float { filterable: true }), //transmittance lut and sampler
+                sampler(SamplerBindingType::Filtering),
+                texture_2d(TextureSampleType::Float { filterable: true }), //multiscattering lut and sampler
+                sampler(SamplerBindingType::Filtering),
+                texture_2d(TextureSampleType::Float { filterable: true }), //sky view lut and sampler
+                sampler(SamplerBindingType::Filtering),
+                texture_3d(TextureSampleType::Float { filterable: true }), //aerial view lut ans sampler
+                sampler(SamplerBindingType::Filtering),
+                texture_storage_2d_array(
+                    // output 2D array texture
+                    TextureFormat::Rgba16Float,
+                    StorageTextureAccess::WriteOnly,
+                ),
+            ),
+        ),
+    );
+
+    commands.insert_resource(AtmosphereProbeLayouts { environment });
+}
+
+pub(super) fn prepare_atmosphere_probe_bind_groups(
+    probes: Query<(Entity, &AtmosphereProbeTextures), With<AtmosphereEnvironmentMap>>,
+    render_device: Res<RenderDevice>,
+    layouts: Res<AtmosphereProbeLayouts>,
+    samplers: Res<AtmosphereSamplers>,
+    view_uniforms: Res<ViewUniforms>,
+    lights_uniforms: Res<LightMeta>,
+    atmosphere_transforms: Res<AtmosphereTransforms>,
+    atmosphere_uniforms: Res<ComponentUniforms<Atmosphere>>,
+    settings_uniforms: Res<ComponentUniforms<AtmosphereSettings>>,
+    mut commands: Commands,
+) {
+    for (entity, textures) in &probes {
+        let environment = render_device.create_bind_group(
+            "environment_bind_group",
+            &layouts.environment,
+            &BindGroupEntries::sequential((
+                atmosphere_uniforms.binding().unwrap(),
+                settings_uniforms.binding().unwrap(),
+                atmosphere_transforms.uniforms().binding().unwrap(),
+                view_uniforms.uniforms.binding().unwrap(),
+                lights_uniforms.view_gpu_lights.binding().unwrap(),
+                &textures.transmittance_lut.default_view,
+                &samplers.transmittance_lut,
+                &textures.multiscattering_lut.default_view,
+                &samplers.multiscattering_lut,
+                &textures.sky_view_lut.default_view,
+                &samplers.sky_view_lut,
+                &textures.aerial_view_lut.default_view,
+                &samplers.aerial_view_lut,
+                &textures.environment,
+            )),
+        );
+
+        commands
+            .entity(entity)
+            .insert(AtmosphereProbeBindGroups { environment });
+    }
+}
+
+pub(super) fn prepare_probe_textures(
+    view_textures: Query<&AtmosphereTextures, With<Atmosphere>>,
+    probes: Query<
+        (Entity, &AtmosphereEnvironmentMap),
+        (
+            With<AtmosphereEnvironmentMap>,
+            Without<AtmosphereProbeTextures>,
+        ),
+    >,
+    gpu_images: Res<RenderAssets<GpuImage>>,
+    mut commands: Commands,
+) {
+    for (probe, render_env_map) in &probes {
+        let environment = gpu_images.get(&render_env_map.environment_map).unwrap();
+        // create a cube view
+        let environment_view = environment.texture.create_view(&TextureViewDescriptor {
+            dimension: Some(TextureViewDimension::D2Array),
+            ..Default::default()
+        });
+        // Get the first view entity's textures to borrow
+        if let Some(view_textures) = view_textures.iter().next() {
+            commands.entity(probe).insert(AtmosphereProbeTextures {
+                environment: environment_view,
+                transmittance_lut: view_textures.transmittance_lut.clone(),
+                multiscattering_lut: view_textures.multiscattering_lut.clone(),
+                sky_view_lut: view_textures.sky_view_lut.clone(),
+                aerial_view_lut: view_textures.aerial_view_lut.clone(),
+            });
+        }
+    }
+}
+
+pub fn prepare_atmosphere_probe_pipeline(
+    pipeline_cache: Res<PipelineCache>,
+    layouts: Res<AtmosphereProbeLayouts>,
+    asset_server: Res<AssetServer>,
+    mut commands: Commands,
+) {
+    let environment = pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
+        label: Some("environment_pipeline".into()),
+        layout: vec![layouts.environment.clone()],
+        shader: load_embedded_asset!(asset_server.as_ref(), "environment.wgsl"),
+        ..default()
+    });
+    commands.insert_resource(AtmosphereProbePipelines { environment });
+}
+
+pub fn prepare_atmosphere_probe_components(
+    probes: Query<(Entity, &AtmosphereEnvironmentMapLight), (Without<AtmosphereEnvironmentMap>,)>,
+    mut commands: Commands,
+    mut images: ResMut<Assets<Image>>,
+) {
+    for (entity, env_map_light) in &probes {
+        // Create a cubemap image in the main world that we can reference
+        let mut environment_image = Image::new_fill(
+            Extent3d {
+                width: env_map_light.size.x,
+                height: env_map_light.size.y,
+                depth_or_array_layers: 6,
+            },
+            TextureDimension::D2,
+            &[0; 8],
+            TextureFormat::Rgba16Float,
+            RenderAssetUsages::all(),
+        );
+
+        environment_image.texture_view_descriptor = Some(TextureViewDescriptor {
+            dimension: Some(TextureViewDimension::Cube),
+            ..Default::default()
+        });
+
+        environment_image.texture_descriptor.usage = TextureUsages::TEXTURE_BINDING
+            | TextureUsages::STORAGE_BINDING
+            | TextureUsages::COPY_SRC;
+
+        // Add the image to assets to get a handle
+        let environment_handle = images.add(environment_image);
+
+        commands.entity(entity).insert(AtmosphereEnvironmentMap {
+            environment_map: environment_handle.clone(),
+            size: env_map_light.size,
+        });
+
+        commands
+            .entity(entity)
+            .insert(GeneratedEnvironmentMapLight {
+                environment_map: environment_handle,
+                intensity: env_map_light.intensity,
+                rotation: Quat::IDENTITY,
+                affects_lightmapped_mesh_diffuse: env_map_light.affects_lightmapped_mesh_diffuse,
+            });
+    }
+}
+
+pub(super) struct EnvironmentNode {
+    main_view_query: QueryState<(
+        Read<DynamicUniformIndex<Atmosphere>>,
+        Read<DynamicUniformIndex<AtmosphereSettings>>,
+        Read<AtmosphereTransformsOffset>,
+        Read<ViewUniformOffset>,
+        Read<ViewLightsUniformOffset>,
+    )>,
+    probe_query: QueryState<(
+        Read<AtmosphereProbeBindGroups>,
+        Read<AtmosphereEnvironmentMap>,
+    )>,
+}
+
+impl FromWorld for EnvironmentNode {
+    fn from_world(world: &mut World) -> Self {
+        Self {
+            main_view_query: QueryState::new(world),
+            probe_query: QueryState::new(world),
+        }
+    }
+}
+
+impl Node for EnvironmentNode {
+    fn update(&mut self, world: &mut World) {
+        self.main_view_query.update_archetypes(world);
+        self.probe_query.update_archetypes(world);
+    }
+
+    fn run(
+        &self,
+        graph: &mut RenderGraphContext,
+        render_context: &mut RenderContext,
+        world: &World,
+    ) -> Result<(), NodeRunError> {
+        let pipeline_cache = world.resource::<PipelineCache>();
+        let pipelines = world.resource::<AtmosphereProbePipelines>();
+        let view_entity = graph.view_entity();
+
+        let Some(environment_pipeline) = pipeline_cache.get_compute_pipeline(pipelines.environment)
+        else {
+            return Ok(());
+        };
+
+        let (Ok((
+            atmosphere_uniforms_offset,
+            settings_uniforms_offset,
+            atmosphere_transforms_offset,
+            view_uniforms_offset,
+            lights_uniforms_offset,
+        )),) = (self.main_view_query.get_manual(world, view_entity),)
+        else {
+            return Ok(());
+        };
+
+        for (bind_groups, env_map_light) in self.probe_query.iter_manual(world) {
+            let mut pass =
+                render_context
+                    .command_encoder()
+                    .begin_compute_pass(&ComputePassDescriptor {
+                        label: Some("environment_pass"),
+                        timestamp_writes: None,
+                    });
+
+            pass.set_pipeline(environment_pipeline);
+            pass.set_bind_group(
+                0,
+                &bind_groups.environment,
+                &[
+                    atmosphere_uniforms_offset.index(),
+                    settings_uniforms_offset.index(),
+                    atmosphere_transforms_offset.index(),
+                    view_uniforms_offset.offset,
+                    lights_uniforms_offset.offset,
+                ],
+            );
+
+            pass.dispatch_workgroups(
+                env_map_light.size.x / 8,
+                env_map_light.size.y / 8,
+                6, // 6 cubemap faces
+            );
+        }
+
+        Ok(())
+    }
+}

--- a/crates/bevy_pbr/src/atmosphere/environment.wgsl
+++ b/crates/bevy_pbr/src/atmosphere/environment.wgsl
@@ -1,0 +1,37 @@
+#import bevy_pbr::{
+    atmosphere::{
+        functions::{direction_world_to_atmosphere, sample_sky_view_lut, view_radius},
+    },
+    utils::sample_cube_dir
+}
+
+@group(0) @binding(13) var output: texture_storage_2d_array<rgba16float, write>;
+
+@compute @workgroup_size(8, 8, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let dimensions = textureDimensions(output);
+    let slice_index = global_id.z;
+    
+    if (global_id.x >= dimensions.x || global_id.y >= dimensions.y || slice_index >= 6u) {
+        return;
+    }
+    
+    // Calculate normalized UV coordinates for this pixel
+    let uv = vec2<f32>(
+        (f32(global_id.x) + 0.5) / f32(dimensions.x),
+        (f32(global_id.y) + 0.5) / f32(dimensions.y)
+    );
+
+    let r = view_radius();
+
+    var ray_dir_ws = sample_cube_dir(uv, slice_index);
+    
+    // invert the z direction to match
+    ray_dir_ws = vec3(ray_dir_ws.x, ray_dir_ws.y, ray_dir_ws.z * -1.0);
+
+    let ray_dir_as = direction_world_to_atmosphere(ray_dir_ws.xyz);
+    let inscattering = sample_sky_view_lut(r, ray_dir_as);
+    let color = vec4<f32>(inscattering, 1.0);
+
+    textureStore(output, vec2<i32>(global_id.xy), i32(slice_index), color);
+}

--- a/crates/bevy_pbr/src/atmosphere/functions.wgsl
+++ b/crates/bevy_pbr/src/atmosphere/functions.wgsl
@@ -272,7 +272,7 @@ fn sample_local_inscattering(local_atmosphere: AtmosphereSample, ray_dir: vec3<f
 
         inscattering += (*light).color.rgb * (scattering_factor + multiscattering_factor);
     }
-    return inscattering * view.exposure;
+    return inscattering;
 }
 
 const SUN_ANGULAR_SIZE: f32 = 0.0174533; // angular diameter of sun in radians

--- a/crates/bevy_pbr/src/atmosphere/mod.rs
+++ b/crates/bevy_pbr/src/atmosphere/mod.rs
@@ -33,10 +33,11 @@
 //!
 //! [Unreal Engine Implementation]: https://github.com/sebh/UnrealEngineSkyAtmosphere
 
+mod environment;
 mod node;
 pub mod resources;
 
-use bevy_app::{App, Plugin};
+use bevy_app::{App, Plugin, Update};
 use bevy_asset::embedded_asset;
 use bevy_camera::Camera3d;
 use bevy_core_pipeline::core_3d::graph::Node3d;
@@ -63,6 +64,11 @@ use bevy_render::{
 
 use bevy_core_pipeline::core_3d::graph::Core3d;
 use bevy_shader::load_shader_library;
+use environment::{
+    prepare_atmosphere_probe_bind_groups, prepare_atmosphere_probe_components,
+    prepare_atmosphere_probe_layout, prepare_atmosphere_probe_pipeline, prepare_probe_textures,
+    AtmosphereEnvironmentMap, EnvironmentNode,
+};
 use resources::{
     prepare_atmosphere_transforms, queue_render_sky_pipelines, AtmosphereTransforms,
     RenderSkyBindGroupLayouts,
@@ -92,13 +98,16 @@ impl Plugin for AtmospherePlugin {
         embedded_asset!(app, "sky_view_lut.wgsl");
         embedded_asset!(app, "aerial_view_lut.wgsl");
         embedded_asset!(app, "render_sky.wgsl");
+        embedded_asset!(app, "environment.wgsl");
 
         app.add_plugins((
             ExtractComponentPlugin::<Atmosphere>::default(),
             ExtractComponentPlugin::<AtmosphereSettings>::default(),
+            ExtractComponentPlugin::<AtmosphereEnvironmentMap>::default(),
             UniformComponentPlugin::<Atmosphere>::default(),
             UniformComponentPlugin::<AtmosphereSettings>::default(),
-        ));
+        ))
+        .add_systems(Update, prepare_atmosphere_probe_components);
     }
 
     fn finish(&self, app: &mut App) {
@@ -139,6 +148,14 @@ impl Plugin for AtmospherePlugin {
                     configure_camera_depth_usages.in_set(RenderSystems::ManageViews),
                     queue_render_sky_pipelines.in_set(RenderSystems::Queue),
                     prepare_atmosphere_textures.in_set(RenderSystems::PrepareResources),
+                    prepare_atmosphere_probe_layout.in_set(RenderSystems::PrepareResources),
+                    prepare_probe_textures
+                        .in_set(RenderSystems::PrepareResources)
+                        .after(prepare_atmosphere_textures),
+                    prepare_atmosphere_probe_bind_groups.in_set(RenderSystems::PrepareBindGroups),
+                    prepare_atmosphere_probe_pipeline
+                        .in_set(RenderSystems::PrepareResources)
+                        .after(prepare_atmosphere_probe_layout),
                     prepare_atmosphere_transforms.in_set(RenderSystems::PrepareResources),
                     prepare_atmosphere_bind_groups.in_set(RenderSystems::PrepareBindGroups),
                 ),
@@ -160,6 +177,7 @@ impl Plugin for AtmospherePlugin {
                 Core3d,
                 AtmosphereNode::RenderSky,
             )
+            .add_render_graph_node::<EnvironmentNode>(Core3d, AtmosphereNode::Environment)
             .add_render_graph_edges(
                 Core3d,
                 (

--- a/crates/bevy_pbr/src/atmosphere/node.rs
+++ b/crates/bevy_pbr/src/atmosphere/node.rs
@@ -23,6 +23,7 @@ use super::{
 pub enum AtmosphereNode {
     RenderLuts,
     RenderSky,
+    Environment,
 }
 
 #[derive(Default)]

--- a/crates/bevy_pbr/src/atmosphere/render_sky.wgsl
+++ b/crates/bevy_pbr/src/atmosphere/render_sky.wgsl
@@ -46,12 +46,16 @@ fn main(in: FullscreenVertexOutput) -> RenderSkyOutput {
         let ray_dir_as = direction_world_to_atmosphere(ray_dir_ws.xyz);
         transmittance = sample_transmittance_lut(r, mu);
         inscattering += sample_sky_view_lut(r, ray_dir_as);
-        inscattering += sun_radiance * transmittance * view.exposure;
+        inscattering += sun_radiance * transmittance;
     } else {
         let t = ndc_to_camera_dist(vec3(uv_to_ndc(in.uv), depth));
         inscattering = sample_aerial_view_lut(in.uv, t);
         transmittance = sample_transmittance_lut_segment(r, mu, t);
     }
+
+    // exposure compensation
+    inscattering *= view.exposure;
+    
 #ifdef DUAL_SOURCE_BLENDING
     return RenderSkyOutput(vec4(inscattering, 0.0), vec4(transmittance, 1.0));
 #else

--- a/examples/3d/atmosphere.rs
+++ b/examples/3d/atmosphere.rs
@@ -5,7 +5,7 @@ use std::f32::consts::PI;
 use bevy::{
     camera::Exposure,
     core_pipeline::{bloom::Bloom, tonemapping::Tonemapping},
-    light::{light_consts::lux, CascadeShadowConfigBuilder},
+    light::{light_consts::lux, AtmosphereEnvironmentMapLight, CascadeShadowConfigBuilder},
     pbr::{Atmosphere, AtmosphereSettings},
     prelude::*,
 };
@@ -42,6 +42,8 @@ fn setup_camera_fog(mut commands: Commands) {
         Tonemapping::AcesFitted,
         // Bloom gives the sun a much more natural look.
         Bloom::NATURAL,
+        // Renders the atmosphere to the environment map from the perspective of the camera
+        AtmosphereEnvironmentMapLight::default(),
     ));
 }
 


### PR DESCRIPTION
# Objective

- Add generated environment lighting to the atmosphere for reflections and diffuse
- Tracking issue: #20374

## Solution

- created a new atmosphere node type called environment
- up-sampling the existing sky-view lookup texture and tied to the current view only. this atmosphere cube map pass has negligible performance impact, however the filtering pipeline does have a small performance impact to the example. 
- using the new filtering pipeline, creates mip chain for different roughness levels as well as diffuse

## Testing

- ran the atmosphere example

---

## Showcase

<img width="1281" height="752" alt="Screenshot 2025-08-12 at 12 19 08 PM" src="https://github.com/user-attachments/assets/8f00ff25-5f48-4c51-b67e-abcbf421abc4" />

```rs
commands.spawn((
    Camera3d::default(),
    // ...
    // Renders the atmosphere to the environment map from the perspective of the camera
    AtmosphereEnvironmentMapLight::default(),
));
```

## Limitations, out of scope

- The generation does not support light probes (yet). This allows to render the atmosphere as a light probe from any "location" within the scene and within the overall atmosphere. 
- therefore we assume that the relative scale of the scene to the atmosphere are orders of magnitude different , this is a safe assumption now with the current impl not officially supporting space views, yet
- the PBR directional light is still unaffected by the atmosphere (not tinted by it) out of scope for this PR
- unrelated issue to this PR: small black pixels around the fully reflective sphere. narrowed it down, this is a problem in the inscattering calculation based on the depth value in the render sky shader. however the addition of the env map light makes this problem more "apparent". to be addressed separately.
- past work staged for further PRs, up next: https://github.com/mate-h/bevy/pull/10 
