### PR TITLE
Split `ComputedUiTargetCamera`

### DIFF
--- a/crates/bevy_core_widgets/src/core_scrollbar.rs
+++ b/crates/bevy_core_widgets/src/core_scrollbar.rs
@@ -12,7 +12,7 @@ use bevy_math::Vec2;
 use bevy_picking::events::{Cancel, Drag, DragEnd, DragStart, Pointer, Press};
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_ui::{
-    ComputedNode, ComputedUiTargetCamera, Node, ScrollPosition, UiGlobalTransform, UiScale, Val,
+    ComputedNode, ComputedUiRenderTargetInfo, Node, ScrollPosition, UiGlobalTransform, UiScale, Val,
 };
 
 /// Used to select the orientation of a scrollbar, slider, or other oriented control.
@@ -104,7 +104,7 @@ fn scrollbar_on_pointer_down(
     mut q_scrollbar: Query<(
         &CoreScrollbar,
         &ComputedNode,
-        &ComputedUiTargetCamera,
+        &ComputedUiRenderTargetInfo,
         &UiGlobalTransform,
     )>,
     mut q_scroll_pos: Query<(&mut ScrollPosition, &ComputedNode), Without<CoreScrollbar>>,

--- a/crates/bevy_core_widgets/src/core_slider.rs
+++ b/crates/bevy_core_widgets/src/core_slider.rs
@@ -24,7 +24,7 @@ use bevy_math::ops;
 use bevy_picking::events::{Drag, DragEnd, DragStart, Pointer, Press};
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_ui::{
-    ComputedNode, ComputedUiTargetCamera, InteractionDisabled, UiGlobalTransform, UiScale,
+    ComputedNode, ComputedUiRenderTargetInfo, InteractionDisabled, UiGlobalTransform, UiScale,
 };
 
 use crate::{Callback, Notify, ValueChange};
@@ -236,7 +236,7 @@ pub(crate) fn slider_on_pointer_down(
         &SliderStep,
         Option<&SliderPrecision>,
         &ComputedNode,
-        &ComputedUiTargetCamera,
+        &ComputedUiRenderTargetInfo,
         &UiGlobalTransform,
         Has<InteractionDisabled>,
     )>,

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -373,7 +373,7 @@ mod tests {
 
     use crate::{
         layout::ui_surface::UiSurface, prelude::*, ui_layout_system,
-        update::update_ui_context_system, ContentSize, LayoutContext,
+        update::propagate_ui_target_camera_system, ContentSize, LayoutContext,
     };
 
     // these window dimensions are easy to convert to and from percentage values
@@ -404,7 +404,7 @@ mod tests {
             (
                 // UI is driven by calculated camera target info, so we need to run the camera system first
                 bevy_render::camera::camera_system,
-                update_ui_context_system,
+                propagate_ui_target_camera_system,
                 ApplyDeferred,
                 ui_layout_system,
                 mark_dirty_trees,
@@ -417,7 +417,7 @@ mod tests {
         app.configure_sets(
             PostUpdate,
             PropagateSet::<ComputedUiTargetCamera>::default()
-                .after(update_ui_context_system)
+                .after(propagate_ui_target_camera_system)
                 .before(ui_layout_system),
         );
 
@@ -1067,7 +1067,7 @@ mod tests {
             (
                 // UI is driven by calculated camera target info, so we need to run the camera system first
                 bevy_render::camera::camera_system,
-                update_ui_context_system,
+                propagate_ui_target_camera_system,
                 ApplyDeferred,
                 ui_layout_system,
             )
@@ -1081,7 +1081,7 @@ mod tests {
         app.configure_sets(
             PostUpdate,
             PropagateSet::<ComputedUiTargetCamera>::default()
-                .after(update_ui_context_system)
+                .after(propagate_ui_target_camera_system)
                 .before(ui_layout_system),
         );
 

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -1,8 +1,8 @@
 use crate::{
     experimental::{UiChildren, UiRootNodes},
     ui_transform::{UiGlobalTransform, UiTransform},
-    BorderRadius, ComputedNode, ComputedUiTargetCamera, ContentSize, Display, LayoutConfig, Node,
-    Outline, OverflowAxis, ScrollPosition,
+    BorderRadius, ComputedNode, ComputedUiRenderTargetInfo, ContentSize, Display, LayoutConfig,
+    Node, Outline, OverflowAxis, ScrollPosition,
 };
 use bevy_ecs::{
     change_detection::{DetectChanges, DetectChangesMut},
@@ -77,7 +77,7 @@ pub fn ui_layout_system(
         Entity,
         Ref<Node>,
         Option<&mut ContentSize>,
-        Ref<ComputedUiTargetCamera>,
+        Ref<ComputedUiRenderTargetInfo>,
     )>,
     added_node_query: Query<(), Added<Node>>,
     mut node_update_query: Query<(
@@ -373,7 +373,7 @@ mod tests {
 
     use crate::{
         layout::ui_surface::UiSurface, prelude::*, ui_layout_system,
-        update::propagate_ui_target_camera_system, ContentSize, LayoutContext,
+        update::update_ui_context_system, ContentSize, LayoutContext,
     };
 
     // these window dimensions are easy to convert to and from percentage values
@@ -404,7 +404,7 @@ mod tests {
             (
                 // UI is driven by calculated camera target info, so we need to run the camera system first
                 bevy_render::camera::camera_system,
-                propagate_ui_target_camera_system,
+                update_ui_context_system,
                 ApplyDeferred,
                 ui_layout_system,
                 mark_dirty_trees,
@@ -417,7 +417,7 @@ mod tests {
         app.configure_sets(
             PostUpdate,
             PropagateSet::<ComputedUiTargetCamera>::default()
-                .after(propagate_ui_target_camera_system)
+                .after(update_ui_context_system)
                 .before(ui_layout_system),
         );
 
@@ -1067,7 +1067,7 @@ mod tests {
             (
                 // UI is driven by calculated camera target info, so we need to run the camera system first
                 bevy_render::camera::camera_system,
-                propagate_ui_target_camera_system,
+                update_ui_context_system,
                 ApplyDeferred,
                 ui_layout_system,
             )
@@ -1081,7 +1081,7 @@ mod tests {
         app.configure_sets(
             PostUpdate,
             PropagateSet::<ComputedUiTargetCamera>::default()
-                .after(propagate_ui_target_camera_system)
+                .after(update_ui_context_system)
                 .before(ui_layout_system),
         );
 

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -159,6 +159,13 @@ impl Plugin for UiPlugin {
             .add_plugins(HierarchyPropagatePlugin::<ComputedUiTargetCamera>::new(
                 PostUpdate,
             ))
+            .configure_sets(
+                PostUpdate,
+                PropagateSet::<ComputedUiRenderTargetInfo>::default().in_set(UiSystems::Propagate),
+            )
+            .add_plugins(HierarchyPropagatePlugin::<ComputedUiRenderTargetInfo>::new(
+                PostUpdate,
+            ))
             .add_systems(
                 PreUpdate,
                 ui_focus_system.in_set(UiSystems::Focus).after(InputSystems),

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -76,7 +76,7 @@ use bevy_transform::TransformSystems;
 use layout::ui_surface::UiSurface;
 use stack::ui_stack_system;
 pub use stack::UiStack;
-use update::{propagate_ui_target_camera_system, update_clipping_system};
+use update::{update_clipping_system, update_ui_context_system};
 
 /// The basic plugin for Bevy UI
 #[derive(Default)]
@@ -183,7 +183,7 @@ impl Plugin for UiPlugin {
         app.add_systems(
             PostUpdate,
             (
-                propagate_ui_target_camera_system.in_set(UiSystems::Prepare),
+                update_ui_context_system.in_set(UiSystems::Prepare),
                 ui_layout_system_config,
                 ui_stack_system
                     .in_set(UiSystems::Stack)

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -76,7 +76,7 @@ use bevy_transform::TransformSystems;
 use layout::ui_surface::UiSurface;
 use stack::ui_stack_system;
 pub use stack::UiStack;
-use update::{update_clipping_system, update_ui_context_system};
+use update::{propagate_ui_target_camera_system, update_clipping_system};
 
 /// The basic plugin for Bevy UI
 #[derive(Default)]
@@ -183,7 +183,7 @@ impl Plugin for UiPlugin {
         app.add_systems(
             PostUpdate,
             (
-                update_ui_context_system.in_set(UiSystems::Prepare),
+                propagate_ui_target_camera_system.in_set(UiSystems::Prepare),
                 ui_layout_system_config,
                 ui_stack_system
                     .in_set(UiSystems::Stack)

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -381,6 +381,7 @@ impl From<Vec2> for ScrollPosition {
 #[require(
     ComputedNode,
     ComputedUiTargetCamera,
+    ComputedUiRenderTargetInfo,
     UiTransform,
     BackgroundColor,
     BorderColor,

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -2804,16 +2804,12 @@ impl<'w, 's> DefaultUiCamera<'w, 's> {
 #[reflect(Component, Default, PartialEq, Clone)]
 pub struct ComputedUiTargetCamera {
     pub(crate) camera: Entity,
-    pub(crate) scale_factor: f32,
-    pub(crate) physical_size: UVec2,
 }
 
 impl Default for ComputedUiTargetCamera {
     fn default() -> Self {
         Self {
             camera: Entity::PLACEHOLDER,
-            scale_factor: 1.,
-            physical_size: UVec2::ZERO,
         }
     }
 }
@@ -2822,7 +2818,26 @@ impl ComputedUiTargetCamera {
     pub fn camera(&self) -> Option<Entity> {
         Some(self.camera).filter(|&entity| entity != Entity::PLACEHOLDER)
     }
+}
 
+/// Derived information about the render target for this UI node.
+#[derive(Component, Clone, Copy, Debug, Reflect, PartialEq)]
+#[reflect(Component, Default, PartialEq, Clone)]
+pub struct ComputedUiRenderTargetInfo {
+    pub(crate) scale_factor: f32,
+    pub(crate) physical_size: UVec2,
+}
+
+impl Default for ComputedUiRenderTargetInfo {
+    fn default() -> Self {
+        Self {
+            scale_factor: 1.,
+            physical_size: UVec2::ZERO,
+        }
+    }
+}
+
+impl ComputedUiRenderTargetInfo {
     pub const fn scale_factor(&self) -> f32 {
         self.scale_factor
     }

--- a/crates/bevy_ui/src/update.rs
+++ b/crates/bevy_ui/src/update.rs
@@ -133,7 +133,7 @@ fn update_clipping(
     }
 }
 
-pub fn update_ui_context_system(
+pub fn propagate_ui_target_camera_system(
     mut commands: Commands,
     default_ui_camera: DefaultUiCamera,
     ui_scale: Res<UiScale>,
@@ -198,7 +198,7 @@ mod tests {
     use bevy_window::WindowResolution;
     use bevy_window::WindowScaleFactorChanged;
 
-    use crate::update::update_ui_context_system;
+    use crate::update::propagate_ui_target_camera_system;
     use crate::ComputedUiTargetCamera;
     use crate::IsDefaultUiCamera;
     use crate::Node;
@@ -228,7 +228,11 @@ mod tests {
 
         app.add_systems(
             bevy_app::Update,
-            (bevy_render::camera::camera_system, update_ui_context_system).chain(),
+            (
+                bevy_render::camera::camera_system,
+                propagate_ui_target_camera_system,
+            )
+                .chain(),
         );
 
         app

--- a/crates/bevy_ui/src/update.rs
+++ b/crates/bevy_ui/src/update.rs
@@ -3,8 +3,8 @@
 use crate::{
     experimental::{UiChildren, UiRootNodes},
     ui_transform::UiGlobalTransform,
-    CalculatedClip, ComputedUiTargetCamera, DefaultUiCamera, Display, Node, OverflowAxis,
-    OverrideClip, UiScale, UiTargetCamera,
+    CalculatedClip, ComputedUiRenderTargetInfo, ComputedUiTargetCamera, DefaultUiCamera, Display,
+    Node, OverflowAxis, OverrideClip, UiScale, UiTargetCamera,
 };
 
 use super::ComputedNode;
@@ -133,7 +133,7 @@ fn update_clipping(
     }
 }
 
-pub fn propagate_ui_target_camera_system(
+pub fn update_ui_context_system(
     mut commands: Commands,
     default_ui_camera: DefaultUiCamera,
     ui_scale: Res<UiScale>,
@@ -151,6 +151,10 @@ pub fn propagate_ui_target_camera_system(
             .or(default_camera_entity)
             .unwrap_or(Entity::PLACEHOLDER);
 
+        commands
+            .entity(root_entity)
+            .insert(Propagate(ComputedUiTargetCamera { camera }));
+
         let (scale_factor, physical_size) = camera_query
             .get(camera)
             .ok()
@@ -164,8 +168,7 @@ pub fn propagate_ui_target_camera_system(
 
         commands
             .entity(root_entity)
-            .insert(Propagate(ComputedUiTargetCamera {
-                camera,
+            .insert(Propagate(ComputedUiRenderTargetInfo {
                 scale_factor,
                 physical_size,
             }));

--- a/crates/bevy_ui/src/update.rs
+++ b/crates/bevy_ui/src/update.rs
@@ -201,7 +201,7 @@ mod tests {
     use bevy_window::WindowResolution;
     use bevy_window::WindowScaleFactorChanged;
 
-    use crate::update::propagate_ui_target_camera_system;
+    use crate::update::update_ui_context_system;
     use crate::ComputedUiTargetCamera;
     use crate::IsDefaultUiCamera;
     use crate::Node;
@@ -231,11 +231,7 @@ mod tests {
 
         app.add_systems(
             bevy_app::Update,
-            (
-                bevy_render::camera::camera_system,
-                propagate_ui_target_camera_system,
-            )
-                .chain(),
+            (bevy_render::camera::camera_system, update_ui_context_system).chain(),
         );
 
         app

--- a/crates/bevy_ui/src/update.rs
+++ b/crates/bevy_ui/src/update.rs
@@ -267,8 +267,12 @@ mod tests {
 
         assert_eq!(
             *world.get::<ComputedUiTargetCamera>(uinode).unwrap(),
-            ComputedUiTargetCamera {
-                camera,
+            ComputedUiTargetCamera { camera }
+        );
+
+        assert_eq!(
+            *world.get::<ComputedUiRenderTargetInfo>(uinode).unwrap(),
+            ComputedUiRenderTargetInfo {
                 physical_size,
                 scale_factor,
             }
@@ -331,10 +335,14 @@ mod tests {
         ] {
             assert_eq!(
                 *world.get::<ComputedUiTargetCamera>(uinode).unwrap(),
-                ComputedUiTargetCamera {
-                    camera,
-                    scale_factor,
+                ComputedUiTargetCamera { camera }
+            );
+
+            assert_eq!(
+                *world.get::<ComputedUiRenderTargetInfo>(uinode).unwrap(),
+                ComputedUiRenderTargetInfo {
                     physical_size,
+                    scale_factor,
                 }
             );
         }

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -1,4 +1,4 @@
-use crate::{ComputedUiTargetCamera, ContentSize, Measure, MeasureArgs, Node, NodeMeasure};
+use crate::{ComputedUiRenderTargetInfo, ContentSize, Measure, MeasureArgs, Node, NodeMeasure};
 use bevy_asset::{Assets, Handle};
 use bevy_color::Color;
 use bevy_ecs::prelude::*;
@@ -260,7 +260,7 @@ pub fn update_image_content_size_system(
             &mut ContentSize,
             Ref<ImageNode>,
             &mut ImageNodeSize,
-            Ref<ComputedUiTargetCamera>,
+            Ref<ComputedUiRenderTargetInfo>,
         ),
         UpdateImageFilter,
     >,

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -1,6 +1,6 @@
 use crate::{
-    ComputedNode, ComputedUiTargetCamera, ContentSize, FixedMeasure, Measure, MeasureArgs, Node,
-    NodeMeasure,
+    ComputedNode, ComputedUiRenderTargetInfo, ContentSize, FixedMeasure, Measure, MeasureArgs,
+    Node, NodeMeasure,
 };
 use bevy_asset::Assets;
 use bevy_color::Color;
@@ -276,7 +276,7 @@ pub fn measure_text_system(
             &mut ContentSize,
             &mut TextNodeFlags,
             &mut ComputedTextBlock,
-            Ref<ComputedUiTargetCamera>,
+            Ref<ComputedUiRenderTargetInfo>,
         ),
         With<Node>,
     >,

--- a/crates/bevy_ui_render/src/box_shadow.rs
+++ b/crates/bevy_ui_render/src/box_shadow.rs
@@ -28,8 +28,8 @@ use bevy_render::{
 use bevy_render::{RenderApp, RenderStartup};
 use bevy_shader::{Shader, ShaderDefVal};
 use bevy_ui::{
-    BoxShadow, CalculatedClip, ComputedNode, ComputedUiTargetCamera, ResolvedBorderRadius,
-    UiGlobalTransform, Val,
+    BoxShadow, CalculatedClip, ComputedNode, ComputedUiRenderTargetInfo, ComputedUiTargetCamera,
+    ResolvedBorderRadius, UiGlobalTransform, Val,
 };
 use bevy_utils::default;
 use bytemuck::{Pod, Zeroable};
@@ -224,13 +224,16 @@ pub fn extract_shadows(
             &BoxShadow,
             Option<&CalculatedClip>,
             &ComputedUiTargetCamera,
+            &ComputedUiRenderTargetInfo,
         )>,
     >,
     camera_map: Extract<UiCameraMap>,
 ) {
     let mut mapping = camera_map.get_mapper();
 
-    for (entity, uinode, transform, visibility, box_shadow, clip, camera) in &box_shadow_query {
+    for (entity, uinode, transform, visibility, box_shadow, clip, camera, target) in
+        &box_shadow_query
+    {
         // Skip if no visible shadows
         if !visibility.get() || box_shadow.is_empty() || uinode.is_empty() {
             continue;
@@ -240,8 +243,8 @@ pub fn extract_shadows(
             continue;
         };
 
-        let ui_physical_viewport_size = camera.physical_size().as_vec2();
-        let scale_factor = uinode.inverse_scale_factor.recip();
+        let ui_physical_viewport_size = target.physical_size().as_vec2();
+        let scale_factor = target.scale_factor();
 
         for drop_shadow in box_shadow.iter() {
             if drop_shadow.color.is_fully_transparent() {

--- a/crates/bevy_ui_render/src/gradient.rs
+++ b/crates/bevy_ui_render/src/gradient.rs
@@ -34,8 +34,8 @@ use bevy_render::{sync_world::MainEntity, RenderStartup};
 use bevy_shader::Shader;
 use bevy_sprite::BorderRect;
 use bevy_ui::{
-    BackgroundGradient, BorderGradient, ColorStop, ConicGradient, Gradient,
-    InterpolationColorSpace, LinearGradient, RadialGradient, ResolvedBorderRadius, Val,
+    BackgroundGradient, BorderGradient, ColorStop, ComputedUiRenderTargetInfo, ConicGradient,
+    Gradient, InterpolationColorSpace, LinearGradient, RadialGradient, ResolvedBorderRadius, Val,
 };
 use bevy_utils::default;
 use bytemuck::{Pod, Zeroable};
@@ -353,6 +353,7 @@ pub fn extract_gradients(
             Entity,
             &ComputedNode,
             &ComputedUiTargetCamera,
+            &ComputedUiRenderTargetInfo,
             &UiGlobalTransform,
             &InheritedVisibility,
             Option<&CalculatedClip>,
@@ -367,6 +368,7 @@ pub fn extract_gradients(
     for (
         entity,
         uinode,
+        camera,
         target,
         transform,
         inherited_visibility,
@@ -379,7 +381,7 @@ pub fn extract_gradients(
             continue;
         }
 
-        let Some(extracted_camera_entity) = camera_mapper.map(target) else {
+        let Some(extracted_camera_entity) = camera_mapper.map(camera) else {
             continue;
         };
 


### PR DESCRIPTION
# Objective

Remove the render target info from `ComputedUiTargetCamera` so it just holds the camera id that is only needed for rendering and picking.


## Solution

Remove the render target info from `ComputedUiTargetCamera`.
Create a new component `ComputedUiRenderTargetInfo` and move the render target info (physical size and scale factor) into it.
Update the systems to use the `ComputedUiRenderTargetInfo` as needed.

## Testing

The output from the UI examples should be unchanged.
