### PR TITLE
Add new ImageLoaderSettings member for loading as stacked 2d array

### DIFF
--- a/crates/bevy_image/src/compressed_image_saver.rs
+++ b/crates/bevy_image/src/compressed_image_saver.rs
@@ -1,6 +1,7 @@
 use crate::{Image, ImageFormat, ImageFormatSetting, ImageLoader, ImageLoaderSettings};
 
 use bevy_asset::saver::{AssetSaver, SavedAsset};
+use core::num::NonZero;
 use futures_lite::AsyncWriteExt;
 use thiserror::Error;
 
@@ -64,11 +65,14 @@ impl AssetSaver for CompressedImageSaver {
         };
 
         writer.write_all(&compressed_basis_data).await?;
+
+        let layers = NonZero::new(image.texture_descriptor.size.depth_or_array_layers);
         Ok(ImageLoaderSettings {
             format: ImageFormatSetting::Format(ImageFormat::Basis),
             is_srgb,
             sampler: image.sampler.clone(),
             asset_usage: image.asset_usage,
+            layers,
         })
     }
 }

--- a/examples/shader/array_texture.rs
+++ b/examples/shader/array_texture.rs
@@ -1,9 +1,12 @@
 //! This example illustrates how to create a texture for use with a `texture_2d_array<f32>` shader
 //! uniform variable.
 
+use core::num::NonZero;
+
 use bevy::{
     prelude::*, reflect::TypePath, render::render_resource::AsBindGroup, shader::ShaderRef,
 };
+use bevy_image::ImageLoaderSettings;
 
 /// This example uses a shader source file from the assets subdirectory
 const SHADER_ASSET_PATH: &str = "shaders/array_texture.wgsl";
@@ -15,23 +18,15 @@ fn main() {
             MaterialPlugin::<ArrayTextureMaterial>::default(),
         ))
         .add_systems(Startup, setup)
-        .add_systems(Update, create_array_texture)
         .run();
 }
 
-#[derive(Resource)]
-struct LoadingTexture {
-    is_loaded: bool,
-    handle: Handle<Image>,
-}
-
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    // Start loading the texture.
-    commands.insert_resource(LoadingTexture {
-        is_loaded: false,
-        handle: asset_server.load("textures/array_texture.png"),
-    });
-
+fn setup(
+    mut commands: Commands,
+    asset_server: Res<AssetServer>,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<ArrayTextureMaterial>>,
+) {
     // light
     commands.spawn((
         DirectionalLight::default(),
@@ -43,34 +38,17 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         Camera3d::default(),
         Transform::from_xyz(5.0, 5.0, 5.0).looking_at(Vec3::new(1.5, 0.0, 0.0), Vec3::Y),
     ));
-}
-
-fn create_array_texture(
-    mut commands: Commands,
-    asset_server: Res<AssetServer>,
-    mut loading_texture: ResMut<LoadingTexture>,
-    mut images: ResMut<Assets<Image>>,
-    mut meshes: ResMut<Assets<Mesh>>,
-    mut materials: ResMut<Assets<ArrayTextureMaterial>>,
-) {
-    if loading_texture.is_loaded
-        || !asset_server
-            .load_state(loading_texture.handle.id())
-            .is_loaded()
-    {
-        return;
-    }
-    loading_texture.is_loaded = true;
-    let image = images.get_mut(&loading_texture.handle).unwrap();
-
-    // Create a new array texture asset from the loaded texture.
-    let array_layers = 4;
-    image.reinterpret_stacked_2d_as_array(array_layers);
 
     // Spawn some cubes using the array texture
+    let array_layers = 4;
     let mesh_handle = meshes.add(Cuboid::default());
     let material_handle = materials.add(ArrayTextureMaterial {
-        array_texture: loading_texture.handle.clone(),
+        array_texture: asset_server.load_with_settings(
+            "textures/array_texture.png",
+            move |settings: &mut ImageLoaderSettings| {
+                settings.layers = NonZero::new(array_layers);
+            },
+        ),
     });
     for x in -5..=5 {
         commands.spawn((


### PR DESCRIPTION
# Objective

Loading images for use as texture 2d array is tedious and should be supported in the in the context of loading the asset.

## Solution

Add a new `layer` member to `ImageLoaderSettings` which determines if and how we call `reinterpret_stacked_2d_as_array` during asset loading.

## Testing

- Did you test these changes? If so, how?
  - I ran ci locally and simplified and ran the current texture 2d array example
- Are there any parts that need more testing?
  - I do not think so
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
  - Run `array_texture` example
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?
  - linux, amd cpu, amd gpu

---

## Showcase

I believe the changes in `examples/shader/array_texture.rs` show quite well how this is nicer to work with.
