### PR TITLE
Only regenerate text measure funcs on changes to the scale factor, not the camera or target size

### DIFF
--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -78,8 +78,6 @@ use stack::ui_stack_system;
 pub use stack::UiStack;
 use update::{update_clipping_system, update_ui_context_system};
 
-use crate::widget::measure_text_system;
-
 /// The basic plugin for Bevy UI
 #[derive(Default)]
 pub struct UiPlugin;
@@ -190,7 +188,7 @@ impl Plugin for UiPlugin {
                 ui_stack_system
                     .in_set(UiSystems::Stack)
                     // These systems don't care about stack index
-                    .ambiguous_with(measure_text_system)
+                    .ambiguous_with(widget::measure_text_system)
                     .ambiguous_with(update_clipping_system)
                     .ambiguous_with(ui_layout_system)
                     .ambiguous_with(widget::update_viewport_render_target_size)

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -78,6 +78,8 @@ use stack::ui_stack_system;
 pub use stack::UiStack;
 use update::{update_clipping_system, update_ui_context_system};
 
+use crate::widget::measure_text_system;
+
 /// The basic plugin for Bevy UI
 #[derive(Default)]
 pub struct UiPlugin;
@@ -188,6 +190,7 @@ impl Plugin for UiPlugin {
                 ui_stack_system
                     .in_set(UiSystems::Stack)
                     // These systems don't care about stack index
+                    .ambiguous_with(measure_text_system)
                     .ambiguous_with(update_clipping_system)
                     .ambiguous_with(ui_layout_system)
                     .ambiguous_with(widget::update_viewport_render_target_size)

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -276,7 +276,8 @@ pub fn measure_text_system(
             &mut ContentSize,
             &mut TextNodeFlags,
             &mut ComputedTextBlock,
-            Ref<ComputedUiTargetCamera>,
+            &ComputedUiTargetCamera,
+            &ComputedNode,
         ),
         With<Node>,
     >,
@@ -284,9 +285,13 @@ pub fn measure_text_system(
     mut text_pipeline: ResMut<TextPipeline>,
     mut font_system: ResMut<CosmicFontSystem>,
 ) {
-    for (entity, block, content_size, text_flags, computed, computed_target) in &mut text_query {
+    for (entity, block, content_size, text_flags, computed, computed_target, computed_node) in
+        &mut text_query
+    {
         // Note: the ComputedTextBlock::needs_rerender bool is cleared in create_text_measure().
-        if computed_target.is_changed()
+        // 1e-5 epsilon to ignore tiny scale factor float errors
+        if (computed_target.scale_factor() - computed_node.inverse_scale_factor.recip()).abs()
+            < 1e-5
             || computed.needs_rerender()
             || text_flags.needs_measure_fn
             || content_size.is_added()

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -290,8 +290,8 @@ pub fn measure_text_system(
     {
         // Note: the ComputedTextBlock::needs_rerender bool is cleared in create_text_measure().
         // 1e-5 epsilon to ignore tiny scale factor float errors
-        if (computed_target.scale_factor() - computed_node.inverse_scale_factor.recip()).abs()
-            < 1e-5
+        if 1e-5
+            < (computed_target.scale_factor() - computed_node.inverse_scale_factor.recip()).abs()
             || computed.needs_rerender()
             || text_flags.needs_measure_fn
             || content_size.is_added()


### PR DESCRIPTION
# Objective

`measure_text_system` should only remeasure text nodes on changes to scale factor and their text, not the target camera or target size.

## Solution

Instead of checking if the `ComputedUiTargetCamera` component has changed, compare the computed target scale factor to the scale factor from the previous frame stored in `ComputedNode`.