### PR TITLE
Don't serialize `PhantomData` in adaptor curves

### DIFF
--- a/crates/bevy_math/src/curve/adaptors.rs
+++ b/crates/bevy_math/src/curve/adaptors.rs
@@ -91,6 +91,7 @@ pub struct FunctionCurve<T, F> {
     pub(crate) domain: Interval,
     #[cfg_attr(feature = "bevy_reflect", reflect(ignore))]
     pub(crate) f: F,
+    #[cfg_attr(feature = "serialize", serde(skip))]
     #[cfg_attr(feature = "bevy_reflect", reflect(ignore, clone))]
     pub(crate) _phantom: PhantomData<fn() -> T>,
 }
@@ -192,6 +193,7 @@ pub struct MapCurve<S, T, C, F> {
     pub(crate) preimage: C,
     #[cfg_attr(feature = "bevy_reflect", reflect(ignore))]
     pub(crate) f: F,
+    #[cfg_attr(feature = "serialize", serde(skip))]
     #[cfg_attr(feature = "bevy_reflect", reflect(ignore, clone))]
     pub(crate) _phantom: PhantomData<(fn() -> S, fn(S) -> T)>,
 }
@@ -289,6 +291,7 @@ pub struct ReparamCurve<T, C, F> {
     pub(crate) base: C,
     #[cfg_attr(feature = "bevy_reflect", reflect(ignore))]
     pub(crate) f: F,
+    #[cfg_attr(feature = "serialize", serde(skip))]
     #[cfg_attr(feature = "bevy_reflect", reflect(ignore, clone))]
     pub(crate) _phantom: PhantomData<fn() -> T>,
 }
@@ -383,6 +386,7 @@ pub struct LinearReparamCurve<T, C> {
     pub(crate) base: C,
     /// Invariants: This interval must always be bounded.
     pub(crate) new_domain: Interval,
+    #[cfg_attr(feature = "serialize", serde(skip))]
     #[cfg_attr(feature = "bevy_reflect", reflect(ignore, clone))]
     pub(crate) _phantom: PhantomData<fn() -> T>,
 }
@@ -416,6 +420,7 @@ where
 pub struct CurveReparamCurve<T, C, D> {
     pub(crate) base: C,
     pub(crate) reparam_curve: D,
+    #[cfg_attr(feature = "serialize", serde(skip))]
     #[cfg_attr(feature = "bevy_reflect", reflect(ignore, clone))]
     pub(crate) _phantom: PhantomData<fn() -> T>,
 }
@@ -448,6 +453,7 @@ where
 )]
 pub struct GraphCurve<T, C> {
     pub(crate) base: C,
+    #[cfg_attr(feature = "serialize", serde(skip))]
     #[cfg_attr(feature = "bevy_reflect", reflect(ignore, clone))]
     pub(crate) _phantom: PhantomData<fn() -> T>,
 }
@@ -480,6 +486,7 @@ pub struct ZipCurve<S, T, C, D> {
     pub(crate) domain: Interval,
     pub(crate) first: C,
     pub(crate) second: D,
+    #[cfg_attr(feature = "serialize", serde(skip))]
     #[cfg_attr(feature = "bevy_reflect", reflect(ignore, clone))]
     pub(crate) _phantom: PhantomData<fn() -> (S, T)>,
 }
@@ -520,6 +527,7 @@ where
 pub struct ChainCurve<T, C, D> {
     pub(crate) first: C,
     pub(crate) second: D,
+    #[cfg_attr(feature = "serialize", serde(skip))]
     #[cfg_attr(feature = "bevy_reflect", reflect(ignore, clone))]
     pub(crate) _phantom: PhantomData<fn() -> T>,
 }
@@ -569,6 +577,7 @@ where
 )]
 pub struct ReverseCurve<T, C> {
     pub(crate) curve: C,
+    #[cfg_attr(feature = "serialize", serde(skip))]
     #[cfg_attr(feature = "bevy_reflect", reflect(ignore, clone))]
     pub(crate) _phantom: PhantomData<fn() -> T>,
 }
@@ -611,6 +620,7 @@ where
 pub struct RepeatCurve<T, C> {
     pub(crate) domain: Interval,
     pub(crate) curve: C,
+    #[cfg_attr(feature = "serialize", serde(skip))]
     #[cfg_attr(feature = "bevy_reflect", reflect(ignore, clone))]
     pub(crate) _phantom: PhantomData<fn() -> T>,
 }
@@ -669,6 +679,7 @@ where
 )]
 pub struct ForeverCurve<T, C> {
     pub(crate) curve: C,
+    #[cfg_attr(feature = "serialize", serde(skip))]
     #[cfg_attr(feature = "bevy_reflect", reflect(ignore, clone))]
     pub(crate) _phantom: PhantomData<fn() -> T>,
 }
@@ -723,6 +734,7 @@ where
 )]
 pub struct PingPongCurve<T, C> {
     pub(crate) curve: C,
+    #[cfg_attr(feature = "serialize", serde(skip))]
     #[cfg_attr(feature = "bevy_reflect", reflect(ignore, clone))]
     pub(crate) _phantom: PhantomData<fn() -> T>,
 }
@@ -780,6 +792,7 @@ pub struct ContinuationCurve<T, C, D> {
     pub(crate) second: D,
     // cache the offset in the curve directly to prevent triple sampling for every sample we make
     pub(crate) offset: T,
+    #[cfg_attr(feature = "serialize", serde(skip))]
     #[cfg_attr(feature = "bevy_reflect", reflect(ignore, clone))]
     pub(crate) _phantom: PhantomData<fn() -> T>,
 }


### PR DESCRIPTION
# Objective

Adaptor curves have `PhantomData` fields that are included when serializing.

## Solution

Add `serde(skip)` to `PhantomData` fields.

## Testing

Everything still compiles, the curves still work, and the `_phantom: ()` fields are no longer emitted.