### PR TITLE
Rename the `Allows` query filter to `Allow`

### DIFF
--- a/crates/bevy_ecs/src/entity_disabling.rs
+++ b/crates/bevy_ecs/src/entity_disabling.rs
@@ -44,7 +44,7 @@
 //! even if they have a `Position` component,
 //! but `Query<&Position, With<Disabled>>` or `Query<(&Position, Has<Disabled>)>` will see them.
 //!
-//! The [`Allows`](crate::query::Allows) query filter is designed to be used with default query filters,
+//! The [`Allow`](crate::query::Allow) query filter is designed to be used with default query filters,
 //! and ensures that the query will include entities both with and without the specified disabling component.
 //!
 //! Entities with disabling components are still present in the [`World`] and can be accessed directly,
@@ -161,9 +161,9 @@ pub struct Internal;
 /// To be more precise, this checks if the query's [`FilteredAccess`] contains the component,
 /// and if it does not, adds a [`Without`](crate::prelude::Without) filter for that component to the query.
 ///
-/// [`Allows`](crate::query::Allows) and [`Has`](crate::prelude::Has) can be used to include entities
+/// [`Allow`](crate::query::Allow) and [`Has`](crate::prelude::Has) can be used to include entities
 /// with and without the disabling component.
-/// [`Allows`](crate::query::Allows) is a [`QueryFilter`](crate::query::QueryFilter) and will simply change
+/// [`Allow`](crate::query::Allow) is a [`QueryFilter`](crate::query::QueryFilter) and will simply change
 /// the list of shown entities, while [`Has`](crate::prelude::Has) is a [`QueryData`](crate::query::QueryData)
 /// and will allow you to see if each entity has the disabling component or not.
 ///

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -89,7 +89,7 @@ pub mod prelude {
         },
         name::{Name, NameOrEntity},
         observer::{Observer, On, Trigger},
-        query::{Added, Allows, AnyOf, Changed, Has, Or, QueryBuilder, QueryState, With, Without},
+        query::{Added, Allow, AnyOf, Changed, Has, Or, QueryBuilder, QueryState, With, Without},
         related,
         relationship::RelationshipTarget,
         resource::Resource,

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -718,7 +718,7 @@ mod tests {
         assert_eq!(world.query::<&A>().query(&world).count(), 1);
         assert_eq!(
             world
-                .query_filtered::<&Observer, Allows<Internal>>()
+                .query_filtered::<&Observer, Allow<Internal>>()
                 .query(&world)
                 .count(),
             2

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -263,10 +263,10 @@ impl Access {
     /// This is for components whose values are not accessed (and thus will never cause conflicts),
     /// but whose presence in an archetype may affect query results.
     ///
-    /// Currently, this is only used for [`Has<T>`] and [`Allows<T>`].
+    /// Currently, this is only used for [`Has<T>`] and [`Allow<T>`].
     ///
     /// [`Has<T>`]: crate::query::Has
-    /// [`Allows<T>`]: crate::query::filter::Allows
+    /// [`Allow<T>`]: crate::query::filter::Allow
     pub fn add_archetypal(&mut self, index: ComponentId) {
         self.archetypal.grow_and_insert(index.index());
     }

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -569,14 +569,14 @@ all_tuples!(
 /// Allows a query to contain entities with the component `T`, bypassing [`DefaultQueryFilters`].
 ///
 /// [`DefaultQueryFilters`]: crate::entity_disabling::DefaultQueryFilters
-pub struct Allows<T>(PhantomData<T>);
+pub struct Allow<T>(PhantomData<T>);
 
 /// SAFETY:
 /// `update_component_access` does not add any accesses.
 /// This is sound because [`QueryFilter::filter_fetch`] does not access any components.
 /// `update_component_access` adds an archetypal filter for `T`.
 /// This is sound because it doesn't affect the query
-unsafe impl<T: Component> WorldQuery for Allows<T> {
+unsafe impl<T: Component> WorldQuery for Allow<T> {
     type Fetch<'w> = ();
     type State = ComponentId;
 
@@ -608,13 +608,13 @@ unsafe impl<T: Component> WorldQuery for Allows<T> {
     }
 
     fn matches_component_set(_: &ComponentId, _: &impl Fn(ComponentId) -> bool) -> bool {
-        // Allows<T> always matches
+        // Allow<T> always matches
         true
     }
 }
 
 // SAFETY: WorldQuery impl performs no access at all
-unsafe impl<T: Component> QueryFilter for Allows<T> {
+unsafe impl<T: Component> QueryFilter for Allow<T> {
     const IS_ARCHETYPAL: bool = true;
 
     #[inline(always)]

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -2186,8 +2186,8 @@ mod tests {
         let mut query = QueryState::<Has<C>>::new(&mut world);
         assert_eq!(3, query.iter(&world).count());
 
-        // Allows should bypass the filter entirely
-        let mut query = QueryState::<(), Allows<C>>::new(&mut world);
+        // Allow should bypass the filter entirely
+        let mut query = QueryState::<(), Allow<C>>::new(&mut world);
         assert_eq!(3, query.iter(&world).count());
 
         // Other filters should still be respected

--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -56,7 +56,7 @@ impl DynamicScene {
         DynamicSceneBuilder::from_world(world)
             .extract_entities(
                 // we do this instead of a query, in order to completely sidestep default query filters.
-                // while we could use `Allows<_>`, this wouldn't account for custom disabled components
+                // while we could use `Allow<_>`, this wouldn't account for custom disabled components
                 world
                     .archetypes()
                     .iter()

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -122,7 +122,7 @@ mod tests {
         entity::Entity,
         entity_disabling::Internal,
         hierarchy::{ChildOf, Children},
-        query::Allows,
+        query::Allow,
         reflect::{AppTypeRegistry, ReflectComponent},
         world::World,
     };
@@ -307,7 +307,7 @@ mod tests {
                 .insert_resource(world.resource::<AppTypeRegistry>().clone());
             let entities: Vec<Entity> = scene
                 .world
-                .query_filtered::<Entity, Allows<Internal>>()
+                .query_filtered::<Entity, Allow<Internal>>()
                 .iter(&scene.world)
                 .collect();
             DynamicSceneBuilder::from_world(&scene.world)

--- a/release-content/migration-guides/deprecate_iter_entities.md
+++ b/release-content/migration-guides/deprecate_iter_entities.md
@@ -6,4 +6,4 @@ pull_requests: [20260]
 In Bevy 0.17.0 we deprecate `world.iter_entities()` and `world.iter_entities_mut()`.
 Use `world.query::<EntityMut>().iter(&world)` and `world.query::<EntityRef>().iter(&mut world)` instead.
 
-This may not return every single entity, because of [default filter queries](https://docs.rs/bevy/latest/bevy/ecs/entity_disabling/index.html). If you really intend to query disabled entities too, consider removing the `DefaultQueryFilters` resource from the world before querying the elements. You can also add an `Allows<Component>` filter to allow a specific disabled `Component`, to show up in the query.
+This may not return every single entity, because of [default filter queries](https://docs.rs/bevy/latest/bevy/ecs/entity_disabling/index.html). If you really intend to query disabled entities too, consider removing the `DefaultQueryFilters` resource from the world before querying the elements. You can also add an `Allow<Component>` filter to allow a specific disabled `Component`, to show up in the query.

--- a/release-content/migration-guides/internal_entities.md
+++ b/release-content/migration-guides/internal_entities.md
@@ -7,4 +7,4 @@ Bevy 0.17 introduces internal entities. Entities tagged by the `Internal` compon
 
 Currently, both [`Observer`s](https://docs.rs/bevy/latest/bevy/ecs/observer/struct.Observer.html) and systems that are registered through [`World::register_system`](https://docs.rs/bevy/latest/bevy/prelude/struct.World.html#method.register_system) are considered internal entities.
 
-If you queried them before, add the `Allows<Internal>` filter to the query to bypass the default filter.
+If you queried them before, add the `Allow<Internal>` filter to the query to bypass the default filter.


### PR DESCRIPTION
This is the bikeshed of all time, but I needed to bring this up before it became a breaking change.

In my opinion, `Allow<Disabled>` sounds better than `Allows<Disabled>`.

I don't think there's a 1-to-1 comparison in other query keywords yet, but there's the hypothetical `Expect` in [the discussion on #19489](https://github.com/bevyengine/bevy/pull/19489#issuecomment-3132926829), as opposed to `Expects`.

`Allows` hasn't been in a release yet, so it's free to change until 0.17 comes out.