### PR TITLE
Premultiplied alpha.

### DIFF
--- a/crates/bevy_camera/src/camera.rs
+++ b/crates/bevy_camera/src/camera.rs
@@ -809,6 +809,14 @@ impl RenderTarget {
     }
 }
 
+/// Marker component indicating that the render target should be treated as using premultiplied alpha,
+/// which affects how the output is blended when rendering to a target that already has content.
+///
+/// Note, using this in combination with materials using [`AlphaMode::Premultiplied`](crate::render_phase::AlphaMode::Premultiplied)
+/// may lead to unexpected results, as both the material and the render target will apply premultiplied alpha blending.
+#[derive(Debug, Clone, Component, Reflect)]
+pub struct RenderTargetPremultipliedAlpha;
+
 /// A unique id that corresponds to a specific `ManualTextureView` in the `ManualTextureViews` collection.
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Component, Reflect)]
 #[reflect(Component, Default, Debug, PartialEq, Hash, Clone)]

--- a/crates/bevy_core_pipeline/src/blit/blit.wgsl
+++ b/crates/bevy_core_pipeline/src/blit/blit.wgsl
@@ -5,5 +5,9 @@
 
 @fragment
 fn fs_main(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
-    return textureSample(in_texture, in_sampler, in.uv);
+    var color = textureSample(in_texture, in_sampler, in.uv);
+#ifdef PREMULTIPLY_ALPHA
+    color = vec4<f32>(color.rgb * color.a, color.a);
+#endif // PREMULTIPLY_ALPHA
+    return color;
 }

--- a/crates/bevy_core_pipeline/src/blit/mod.rs
+++ b/crates/bevy_core_pipeline/src/blit/mod.rs
@@ -84,12 +84,19 @@ pub struct BlitPipelineKey {
     pub texture_format: TextureFormat,
     pub blend_state: Option<BlendState>,
     pub samples: u32,
+    pub premultiplied_alpha: bool,
 }
 
 impl SpecializedRenderPipeline for BlitPipeline {
     type Key = BlitPipelineKey;
 
     fn specialize(&self, key: Self::Key) -> RenderPipelineDescriptor {
+        let shader_defs = if key.premultiplied_alpha {
+            vec!["PREMULTIPLY_ALPHA".into()]
+        } else {
+            vec![]
+        };
+
         RenderPipelineDescriptor {
             label: Some("blit pipeline".into()),
             layout: vec![self.layout.clone()],
@@ -101,6 +108,7 @@ impl SpecializedRenderPipeline for BlitPipeline {
                     blend: key.blend_state,
                     write_mask: ColorWrites::ALL,
                 })],
+                shader_defs,
                 ..default()
             }),
             multisample: MultisampleState {

--- a/crates/bevy_core_pipeline/src/msaa_writeback.rs
+++ b/crates/bevy_core_pipeline/src/msaa_writeback.rs
@@ -139,6 +139,7 @@ fn prepare_msaa_writeback_pipelines(
                 texture_format: view_target.main_texture_format(),
                 samples: msaa.samples(),
                 blend_state: None,
+                premultiplied_alpha: false,
             };
 
             let pipeline = pipelines.specialize(&pipeline_cache, &blit_pipeline, key);

--- a/crates/bevy_core_pipeline/src/upscaling/mod.rs
+++ b/crates/bevy_core_pipeline/src/upscaling/mod.rs
@@ -46,6 +46,7 @@ fn prepare_view_upscaling_pipelines(
     let mut output_textures = <HashSet<_>>::default();
     for (entity, view_target, camera) in view_targets.iter() {
         let out_texture_id = view_target.out_texture().id();
+        let premultiplied_alpha = view_target.out_texture_is_premultiplied();
         let blend_state = if let Some(extracted_camera) = camera {
             match extracted_camera.output_mode {
                 CameraOutputMode::Skip => None,
@@ -59,7 +60,11 @@ fn prepare_view_upscaling_pipelines(
                             // mode configured, default to alpha blend so that we don't accidentally overwrite
                             // the output texture
                             if already_seen {
-                                Some(BlendState::ALPHA_BLENDING)
+                                if premultiplied_alpha {
+                                    Some(BlendState::PREMULTIPLIED_ALPHA_BLENDING)
+                                } else {
+                                    Some(BlendState::ALPHA_BLENDING)
+                                }
                             } else {
                                 None
                             }
@@ -77,6 +82,7 @@ fn prepare_view_upscaling_pipelines(
             texture_format: view_target.out_texture_format(),
             blend_state,
             samples: 1,
+            premultiplied_alpha,
         };
         let pipeline = pipelines.specialize(&pipeline_cache, &blit_pipeline, key);
 

--- a/crates/bevy_render/src/camera.rs
+++ b/crates/bevy_render/src/camera.rs
@@ -405,6 +405,7 @@ pub struct ExtractedCamera {
     pub sorted_camera_index_for_target: usize,
     pub exposure: f32,
     pub hdr: bool,
+    pub premultiply_alpha: bool,
 }
 
 pub fn extract_cameras(
@@ -425,7 +426,7 @@ pub fn extract_cameras(
             Option<&MipBias>,
             Option<&RenderLayers>,
             Option<&Projection>,
-            Has<NoIndirectDrawing>,
+            (Has<NoIndirectDrawing>, Has<RenderTargetPremultipliedAlpha>),
         )>,
     >,
     primary_window: Extract<Query<Entity, With<PrimaryWindow>>>,
@@ -459,7 +460,7 @@ pub fn extract_cameras(
         mip_bias,
         render_layers,
         projection,
-        no_indirect_drawing,
+        (no_indirect_drawing, premultiply_alpha),
     ) in query.iter()
     {
         if !camera.is_active {
@@ -529,6 +530,7 @@ pub fn extract_cameras(
                         .map(Exposure::exposure)
                         .unwrap_or_else(|| Exposure::default().exposure()),
                     hdr,
+                    premultiply_alpha,
                 },
                 ExtractedView {
                     retained_view_entity: RetainedViewEntity::new(main_entity.into(), None, 0),

--- a/crates/bevy_render/src/texture/texture_attachment.rs
+++ b/crates/bevy_render/src/texture/texture_attachment.rs
@@ -128,14 +128,16 @@ impl DepthAttachment {
 pub struct OutputColorAttachment {
     pub view: TextureView,
     pub format: TextureFormat,
+    pub premultiply_alpha: bool,
     is_first_call: Arc<AtomicBool>,
 }
 
 impl OutputColorAttachment {
-    pub fn new(view: TextureView, format: TextureFormat) -> Self {
+    pub fn new(view: TextureView, format: TextureFormat, premultiply_alpha: bool) -> Self {
         Self {
             view,
             format,
+            premultiply_alpha,
             is_first_call: Arc::new(AtomicBool::new(true)),
         }
     }

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -838,6 +838,11 @@ impl ViewTarget {
         self.out_texture.format
     }
 
+    /// Returns `true` if the output texture is using premultiplied alpha.
+    pub fn out_texture_is_premultiplied(&self) -> bool {
+        self.out_texture.premultiply_alpha
+    }
+
     /// This will start a new "post process write", which assumes that the caller
     /// will write the [`PostProcessWrite`]'s `source` to the `destination`.
     ///
@@ -1013,7 +1018,11 @@ pub fn prepare_view_attachments(
                     .cloned()
                     .zip(target.get_texture_format(&windows, &images, &manual_texture_views))
                     .map(|(view, format)| {
-                        OutputColorAttachment::new(view.clone(), format.add_srgb_suffix())
+                        OutputColorAttachment::new(
+                            view.clone(),
+                            format.add_srgb_suffix(),
+                            camera.premultiply_alpha,
+                        )
                     })
                 else {
                     continue;

--- a/crates/bevy_render/src/view/window/screenshot.rs
+++ b/crates/bevy_render/src/view/window/screenshot.rs
@@ -290,7 +290,11 @@ fn prepare_screenshots(
                 prepared.insert(*entity, state);
                 view_target_attachments.insert(
                     target.clone(),
-                    OutputColorAttachment::new(texture_view.clone(), format.add_srgb_suffix()),
+                    OutputColorAttachment::new(
+                        texture_view.clone(),
+                        format.add_srgb_suffix(),
+                        false,
+                    ),
                 );
             }
             NormalizedRenderTarget::Image(image) => {
@@ -310,7 +314,11 @@ fn prepare_screenshots(
                 prepared.insert(*entity, state);
                 view_target_attachments.insert(
                     target.clone(),
-                    OutputColorAttachment::new(texture_view.clone(), format.add_srgb_suffix()),
+                    OutputColorAttachment::new(
+                        texture_view.clone(),
+                        format.add_srgb_suffix(),
+                        false,
+                    ),
                 );
             }
             NormalizedRenderTarget::TextureView(texture_view) => {
@@ -334,7 +342,11 @@ fn prepare_screenshots(
                 prepared.insert(*entity, state);
                 view_target_attachments.insert(
                     target.clone(),
-                    OutputColorAttachment::new(texture_view.clone(), format.add_srgb_suffix()),
+                    OutputColorAttachment::new(
+                        texture_view.clone(),
+                        format.add_srgb_suffix(),
+                        false,
+                    ),
                 );
             }
         }

--- a/examples/window/transparent_window.rs
+++ b/examples/window/transparent_window.rs
@@ -4,6 +4,7 @@
 //! [documentation](https://docs.rs/bevy/latest/bevy/prelude/struct.Window.html#structfield.transparent)
 //! for more details.
 
+use bevy::camera::RenderTargetPremultipliedAlpha;
 use bevy::prelude::*;
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 use bevy::window::CompositeAlphaMode;
@@ -30,7 +31,50 @@ fn main() {
         .run();
 }
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn(Camera2d);
-    commands.spawn(Sprite::from_image(asset_server.load("branding/icon.png")));
+fn setup(mut commands: Commands) {
+    let camera = commands.spawn(Camera2d).id();
+
+    if cfg!(target_os = "linux") {
+        commands
+            .entity(camera)
+            .insert(RenderTargetPremultipliedAlpha);
+    }
+
+    for y in 0..10 {
+        for x in 0..10 {
+            let alpha = 0.1 + (x as f32 / 10.0) * 0.8; // Alpha from 0.1 to 0.9
+            let brightness = y as f32 / 10.0; // Brightness from 0.0 to 1.0
+
+            commands.spawn((
+                Sprite {
+                    color: Color::srgba(brightness, brightness, brightness, alpha),
+                    custom_size: Some(Vec2::new(40.0, 40.0)),
+                    ..default()
+                },
+                Transform::from_translation(Vec3::new(
+                    (x as f32 - 5.0) * 45.0,
+                    (y as f32 - 5.0) * 45.0,
+                    0.0,
+                )),
+            ));
+        }
+    }
+
+    commands.spawn((
+        Sprite {
+            color: Color::srgba(1.0, 0.0, 0.0, 0.5), // Semi-transparent red
+            custom_size: Some(Vec2::new(200.0, 200.0)),
+            ..default()
+        },
+        Transform::from_translation(Vec3::new(-100.0, 0.0, 1.0)),
+    ));
+
+    commands.spawn((
+        Sprite {
+            color: Color::srgba(0.0, 0.0, 1.0, 0.5), // Semi-transparent blue
+            custom_size: Some(Vec2::new(200.0, 200.0)),
+            ..default()
+        },
+        Transform::from_translation(Vec3::new(100.0, 0.0, 1.0)),
+    ));
 }


### PR DESCRIPTION
# Objective

Partially address #14711 

## Solution

Allow specifying that a render target expects pre-multiplied alpha. So we render in straight alpha and then pre-multiply during the upscale blit. Not 100% sure this addresses the need of the user who requested it, so should be tested first.

## Testing

Tried updating the transparent window example and verified that the shader def is applied, but it's a bit hard to tell.