### PR TITLE
Change cursor shape for disabled widgets

### DIFF
--- a/crates/bevy_feathers/src/controls/button.rs
+++ b/crates/bevy_feathers/src/controls/button.rs
@@ -183,6 +183,11 @@ fn set_button_colors(
         (ButtonVariant::Primary, false) => tokens::BUTTON_PRIMARY_TEXT,
     };
 
+    let cursor_shape = match disabled {
+        true => bevy_window::SystemCursorIcon::NotAllowed,
+        false => bevy_window::SystemCursorIcon::Pointer,
+    };
+
     // Change background color
     if bg_color.0 != bg_token {
         commands
@@ -196,6 +201,11 @@ fn set_button_colors(
             .entity(button_ent)
             .insert(ThemeFontColor(font_color_token));
     }
+
+    // Change cursor shape
+    commands
+        .entity(button_ent)
+        .insert(EntityCursor::System(cursor_shape));
 }
 
 /// Plugin which registers the systems for updating the button styles.

--- a/crates/bevy_feathers/src/controls/button.rs
+++ b/crates/bevy_feathers/src/controls/button.rs
@@ -107,7 +107,7 @@ fn update_button_styles(
 ) {
     for (button_ent, variant, disabled, pressed, hovered, bg_color, font_color) in q_buttons.iter()
     {
-        set_button_colors(
+        set_button_styles(
             button_ent,
             variant,
             disabled,
@@ -141,7 +141,7 @@ fn update_button_styles_remove(
             if let Ok((button_ent, variant, disabled, pressed, hovered, bg_color, font_color)) =
                 q_buttons.get(ent)
             {
-                set_button_colors(
+                set_button_styles(
                     button_ent,
                     variant,
                     disabled,
@@ -155,7 +155,7 @@ fn update_button_styles_remove(
         });
 }
 
-fn set_button_colors(
+fn set_button_styles(
     button_ent: Entity,
     variant: &ButtonVariant,
     disabled: bool,

--- a/crates/bevy_feathers/src/controls/checkbox.rs
+++ b/crates/bevy_feathers/src/controls/checkbox.rs
@@ -266,6 +266,11 @@ fn set_checkbox_colors(
         false => tokens::CHECKBOX_TEXT,
     };
 
+    let cursor_shape = match disabled {
+        true => bevy_window::SystemCursorIcon::NotAllowed,
+        false => bevy_window::SystemCursorIcon::Pointer,
+    };
+
     // Change outline background
     if outline_bg.0 != outline_bg_token {
         commands
@@ -299,6 +304,11 @@ fn set_checkbox_colors(
             .entity(checkbox_ent)
             .insert(ThemeFontColor(font_color_token));
     }
+
+    // Change cursor shape
+    commands
+        .entity(checkbox_ent)
+        .insert(EntityCursor::System(cursor_shape));
 }
 
 /// Plugin which registers the systems for updating the checkbox styles.

--- a/crates/bevy_feathers/src/controls/checkbox.rs
+++ b/crates/bevy_feathers/src/controls/checkbox.rs
@@ -158,7 +158,7 @@ fn update_checkbox_styles(
         };
         let (outline_bg, outline_border) = q_outline.get_mut(outline_ent).unwrap();
         let mark_color = q_mark.get_mut(mark_ent).unwrap();
-        set_checkbox_colors(
+        set_checkbox_styles(
             checkbox_ent,
             outline_ent,
             mark_ent,
@@ -213,7 +213,7 @@ fn update_checkbox_styles_remove(
                 };
                 let (outline_bg, outline_border) = q_outline.get_mut(outline_ent).unwrap();
                 let mark_color = q_mark.get_mut(mark_ent).unwrap();
-                set_checkbox_colors(
+                set_checkbox_styles(
                     checkbox_ent,
                     outline_ent,
                     mark_ent,
@@ -230,7 +230,7 @@ fn update_checkbox_styles_remove(
         });
 }
 
-fn set_checkbox_colors(
+fn set_checkbox_styles(
     checkbox_ent: Entity,
     outline_ent: Entity,
     mark_ent: Entity,

--- a/crates/bevy_feathers/src/controls/radio.rs
+++ b/crates/bevy_feathers/src/controls/radio.rs
@@ -231,6 +231,11 @@ fn set_radio_colors(
         false => tokens::RADIO_TEXT,
     };
 
+    let cursor_shape = match disabled {
+        true => bevy_window::SystemCursorIcon::NotAllowed,
+        false => bevy_window::SystemCursorIcon::Pointer,
+    };
+
     // Change outline border
     if outline_border.0 != outline_border_token {
         commands
@@ -257,6 +262,11 @@ fn set_radio_colors(
             .entity(radio_ent)
             .insert(ThemeFontColor(font_color_token));
     }
+
+    // Change cursor shape
+    commands
+        .entity(radio_ent)
+        .insert(EntityCursor::System(cursor_shape));
 }
 
 /// Plugin which registers the systems for updating the radio styles.

--- a/crates/bevy_feathers/src/controls/radio.rs
+++ b/crates/bevy_feathers/src/controls/radio.rs
@@ -135,7 +135,7 @@ fn update_radio_styles(
         };
         let outline_border = q_outline.get_mut(outline_ent).unwrap();
         let mark_color = q_mark.get_mut(mark_ent).unwrap();
-        set_radio_colors(
+        set_radio_styles(
             radio_ent,
             outline_ent,
             mark_ent,
@@ -187,7 +187,7 @@ fn update_radio_styles_remove(
                 };
                 let outline_border = q_outline.get_mut(outline_ent).unwrap();
                 let mark_color = q_mark.get_mut(mark_ent).unwrap();
-                set_radio_colors(
+                set_radio_styles(
                     radio_ent,
                     outline_ent,
                     mark_ent,
@@ -203,7 +203,7 @@ fn update_radio_styles_remove(
         });
 }
 
-fn set_radio_colors(
+fn set_radio_styles(
     radio_ent: Entity,
     outline_ent: Entity,
     mark_ent: Entity,

--- a/crates/bevy_feathers/src/controls/slider.rs
+++ b/crates/bevy_feathers/src/controls/slider.rs
@@ -14,7 +14,7 @@ use bevy_ecs::{
     reflect::ReflectComponent,
     schedule::IntoScheduleConfigs,
     spawn::SpawnRelated,
-    system::{In, Query, Res},
+    system::{Commands, In, Query, Res},
 };
 use bevy_input_focus::tab_navigation::TabIndex;
 use bevy_picking::PickingSystems;
@@ -128,40 +128,72 @@ pub fn slider<B: Bundle>(props: SliderProps, overrides: B) -> impl Bundle {
 
 fn update_slider_colors(
     mut q_sliders: Query<
-        (Has<InteractionDisabled>, &mut BackgroundGradient),
+        (Entity, Has<InteractionDisabled>, &mut BackgroundGradient),
         (With<SliderStyle>, Or<(Spawned, Added<InteractionDisabled>)>),
     >,
     theme: Res<UiTheme>,
+    mut commands: Commands,
 ) {
-    for (disabled, mut gradient) in q_sliders.iter_mut() {
-        set_slider_colors(&theme, disabled, gradient.as_mut());
+    for (slider_ent, disabled, mut gradient) in q_sliders.iter_mut() {
+        set_slider_colors(
+            slider_ent,
+            &theme,
+            disabled,
+            gradient.as_mut(),
+            &mut commands,
+        );
     }
 }
 
 fn update_slider_colors_remove(
-    mut q_sliders: Query<(Has<InteractionDisabled>, &mut BackgroundGradient)>,
+    mut q_sliders: Query<(Entity, Has<InteractionDisabled>, &mut BackgroundGradient)>,
     mut removed_disabled: RemovedComponents<InteractionDisabled>,
     theme: Res<UiTheme>,
+    mut commands: Commands,
 ) {
     removed_disabled.read().for_each(|ent| {
-        if let Ok((disabled, mut gradient)) = q_sliders.get_mut(ent) {
-            set_slider_colors(&theme, disabled, gradient.as_mut());
+        if let Ok((slider_ent, disabled, mut gradient)) = q_sliders.get_mut(ent) {
+            set_slider_colors(
+                slider_ent,
+                &theme,
+                disabled,
+                gradient.as_mut(),
+                &mut commands,
+            );
         }
     });
 }
 
-fn set_slider_colors(theme: &Res<'_, UiTheme>, disabled: bool, gradient: &mut BackgroundGradient) {
+fn set_slider_colors(
+    slider_ent: Entity,
+    theme: &Res<'_, UiTheme>,
+    disabled: bool,
+    gradient: &mut BackgroundGradient,
+    commands: &mut Commands,
+) {
     let bar_color = theme.color(match disabled {
         true => tokens::SLIDER_BAR_DISABLED,
         false => tokens::SLIDER_BAR,
     });
+
     let bg_color = theme.color(tokens::SLIDER_BG);
+
+    let cursor_shape = match disabled {
+        true => bevy_window::SystemCursorIcon::NotAllowed,
+        false => bevy_window::SystemCursorIcon::Pointer,
+    };
+
     if let [Gradient::Linear(linear_gradient)] = &mut gradient.0[..] {
         linear_gradient.stops[0].color = bar_color;
         linear_gradient.stops[1].color = bar_color;
         linear_gradient.stops[2].color = bg_color;
         linear_gradient.stops[3].color = bg_color;
     }
+
+    // Change cursor shape
+    commands
+        .entity(slider_ent)
+        .insert(EntityCursor::System(cursor_shape));
 }
 
 fn update_slider_pos(

--- a/crates/bevy_feathers/src/controls/slider.rs
+++ b/crates/bevy_feathers/src/controls/slider.rs
@@ -126,7 +126,7 @@ pub fn slider<B: Bundle>(props: SliderProps, overrides: B) -> impl Bundle {
     )
 }
 
-fn update_slider_colors(
+fn update_slider_styles(
     mut q_sliders: Query<
         (Entity, Has<InteractionDisabled>, &mut BackgroundGradient),
         (With<SliderStyle>, Or<(Spawned, Added<InteractionDisabled>)>),
@@ -135,7 +135,7 @@ fn update_slider_colors(
     mut commands: Commands,
 ) {
     for (slider_ent, disabled, mut gradient) in q_sliders.iter_mut() {
-        set_slider_colors(
+        set_slider_styles(
             slider_ent,
             &theme,
             disabled,
@@ -145,7 +145,7 @@ fn update_slider_colors(
     }
 }
 
-fn update_slider_colors_remove(
+fn update_slider_styles_remove(
     mut q_sliders: Query<(Entity, Has<InteractionDisabled>, &mut BackgroundGradient)>,
     mut removed_disabled: RemovedComponents<InteractionDisabled>,
     theme: Res<UiTheme>,
@@ -153,7 +153,7 @@ fn update_slider_colors_remove(
 ) {
     removed_disabled.read().for_each(|ent| {
         if let Ok((slider_ent, disabled, mut gradient)) = q_sliders.get_mut(ent) {
-            set_slider_colors(
+            set_slider_styles(
                 slider_ent,
                 &theme,
                 disabled,
@@ -164,7 +164,7 @@ fn update_slider_colors_remove(
     });
 }
 
-fn set_slider_colors(
+fn set_slider_styles(
     slider_ent: Entity,
     theme: &Res<'_, UiTheme>,
     disabled: bool,
@@ -235,8 +235,8 @@ impl Plugin for SliderPlugin {
         app.add_systems(
             PreUpdate,
             (
-                update_slider_colors,
-                update_slider_colors_remove,
+                update_slider_styles,
+                update_slider_styles_remove,
                 update_slider_pos,
             )
                 .in_set(PickingSystems::Last),

--- a/crates/bevy_feathers/src/controls/slider.rs
+++ b/crates/bevy_feathers/src/controls/slider.rs
@@ -180,7 +180,7 @@ fn set_slider_colors(
 
     let cursor_shape = match disabled {
         true => bevy_window::SystemCursorIcon::NotAllowed,
-        false => bevy_window::SystemCursorIcon::Pointer,
+        false => bevy_window::SystemCursorIcon::EwResize,
     };
 
     if let [Gradient::Linear(linear_gradient)] = &mut gradient.0[..] {

--- a/crates/bevy_feathers/src/controls/toggle_switch.rs
+++ b/crates/bevy_feathers/src/controls/toggle_switch.rs
@@ -114,7 +114,7 @@ fn update_switch_styles(
         };
         // Safety: since we just checked the query, should always work.
         let (ref mut slide_style, slide_color) = q_slide.get_mut(slide_ent).unwrap();
-        set_switch_colors(
+        set_switch_styles(
             switch_ent,
             slide_ent,
             disabled,
@@ -162,7 +162,7 @@ fn update_switch_styles_remove(
                 };
                 // Safety: since we just checked the query, should always work.
                 let (ref mut slide_style, slide_color) = q_slide.get_mut(slide_ent).unwrap();
-                set_switch_colors(
+                set_switch_styles(
                     switch_ent,
                     slide_ent,
                     disabled,
@@ -178,7 +178,7 @@ fn update_switch_styles_remove(
         });
 }
 
-fn set_switch_colors(
+fn set_switch_styles(
     switch_ent: Entity,
     slide_ent: Entity,
     disabled: bool,

--- a/crates/bevy_feathers/src/controls/toggle_switch.rs
+++ b/crates/bevy_feathers/src/controls/toggle_switch.rs
@@ -213,6 +213,11 @@ fn set_switch_colors(
         false => Val::Percent(0.),
     };
 
+    let cursor_shape = match disabled {
+        true => bevy_window::SystemCursorIcon::NotAllowed,
+        false => bevy_window::SystemCursorIcon::Pointer,
+    };
+
     // Change outline background
     if outline_bg.0 != outline_bg_token {
         commands
@@ -238,6 +243,11 @@ fn set_switch_colors(
     if slide_pos != slide_style.left {
         slide_style.left = slide_pos;
     }
+
+    // Change cursor shape
+    commands
+        .entity(switch_ent)
+        .insert(EntityCursor::System(cursor_shape));
 }
 
 /// Plugin which registers the systems for updating the toggle switch styles.

--- a/release-content/release-notes/feathers.md
+++ b/release-content/release-notes/feathers.md
@@ -1,7 +1,7 @@
 ---
 title: Bevy Feathers
-authors: ["@viridia", "@Atlas16A", "@ickshonpe"]
-pull_requests: [19730, 19900, 19928, 20237, 20169, 20422, 20350]
+authors: ["@viridia", "@Atlas16A", "@ickshonpe", "@amedoeyes"]
+pull_requests: [19730, 19900, 19928, 20237, 20169, 20422, 20350, 20548]
 ---
 
 To make it easier for Bevy engine developers and third-party tool creators to make comfortable, visually cohesive tooling,


### PR DESCRIPTION
# Objective

- Fixes #20499

## Solution

- Added `EntityCursor` re-insertion in `set_*_colors` functions with corresponding cursor shape depending on whether the widget is disabled or not.

## Testing

- Tested the changes in the `feathers` example.