### PR TITLE
Add `zero()` helper function for `Val::ZERO`

### DIFF
--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -288,6 +288,11 @@ pub const fn auto() -> Val {
     Val::Auto
 }
 
+/// Returns [`Val::ZERO`] representing a zero value.
+pub const fn zero() -> Val {
+    Val::ZERO
+}
+
 /// Returns a [`Val::Px`] representing a value in logical pixels.
 pub const fn px(value: f32) -> Val {
     Val::Px(value)


### PR DESCRIPTION
# Objective

- Helper functions exist for all other `Val` variants, only zero is missing

## Solution

- Add a function called `zero()` that just returns `Val::ZERO` (`Val::Px(0.0)`)

---

## Showcase

```rust
zero() // the same as Val::ZERO
```

## Still controversial?

Should a function called `zero()` really be included in the prelude?

On the one hand, it should be done for the sake of consistency (`auto()` instead of `Val::Auto()`, `px(10.0)` instead of `Val::Px(10.0)`), but `zero()` might be a bit too unspecific to include it in the prelude.