### PR TITLE
add example of using system state with an exclusive system

### DIFF
--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -194,6 +194,22 @@ impl SystemMeta {
 ///     }
 /// });
 /// ```
+/// Exclusive System:
+/// ```
+/// # use bevy_ecs::prelude::*;
+/// # use bevy_ecs::system::SystemState;
+/// #
+/// # #[derive(BufferedEvent)]
+/// # struct MyEvent;
+/// #
+/// fn exclusive_system(world: &mut World, system_state: &mut SystemState<EventReader<MyEvent>>) {
+///     let mut event_reader = system_state.get_mut(world);
+///
+///     for events in event_reader.read() {
+///         println!("Hello World!");
+///     }
+/// }
+/// ```
 pub struct SystemState<Param: SystemParam + 'static> {
     meta: SystemMeta,
     param_state: Param::State,


### PR DESCRIPTION
# Objective

- Make using SystemState as a ExclusiveSystemParam more discoverable

## Solution

- add an example of using it with an exclusive system to the SystemState docs.

<img width="1225" height="375" alt="image" src="https://github.com/user-attachments/assets/031d458a-f67c-448e-9ad9-57501f5b2531" />
