### PR TITLE
Fix bevy_tasks catch_unwind compilation error with --all-features

### DIFF
--- a/crates/bevy_tasks/Cargo.toml
+++ b/crates/bevy_tasks/Cargo.toml
@@ -22,7 +22,7 @@ multi_threaded = [
 
 # Uses `async-executor` as a task execution backend.
 # This backend is incompatible with `no_std` targets.
-async_executor = ["bevy_platform/std", "dep:async-executor"]
+async_executor = ["bevy_platform/std", "dep:async-executor", "futures-lite"]
 
 # Provide an implementation of `block_on` from  `futures-lite`.
 futures-lite = ["bevy_platform/std", "futures-lite/std"]


### PR DESCRIPTION
Fixes the 'catch_unwind' compilation errors in bevy_tasks when building with --all-features

After file change,

Re-ran cargo test --package bevy_ecs --all-features and the 'catch_unwind' errors were gone

Part of #20542.