### PR TITLE
Adjust SolariLightingNode ordering

### DIFF
--- a/crates/bevy_solari/src/lib.rs
+++ b/crates/bevy_solari/src/lib.rs
@@ -47,7 +47,7 @@ impl PluginGroup for SolariPlugins {
 }
 
 impl SolariPlugins {
-    /// [`WgpuFeatures`] required for this plugin to function.
+    /// [`WgpuFeatures`] required for these plugins to function.
     pub fn required_wgpu_features() -> WgpuFeatures {
         WgpuFeatures::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE
             | WgpuFeatures::EXPERIMENTAL_RAY_QUERY

--- a/crates/bevy_solari/src/realtime/mod.rs
+++ b/crates/bevy_solari/src/realtime/mod.rs
@@ -66,7 +66,11 @@ impl Plugin for SolariLightingPlugin {
             )
             .add_render_graph_edges(
                 Core3d,
-                (Node3d::EndMainPass, node::graph::SolariLightingNode),
+                (
+                    Node3d::EndPrepasses,
+                    node::graph::SolariLightingNode,
+                    Node3d::EndMainPass,
+                ),
             );
     }
 }


### PR DESCRIPTION
Tiny PR to better place the SolariLightingNode.

This allows denoisers like DLSS-RR, which orders itself after EndMainPass, to run before SolariLightingNode.