### PR TITLE
UI Node Decorations

### DIFF
--- a/crates/bevy_ui/src/experimental/ghost_hierarchy.rs
+++ b/crates/bevy_ui/src/experimental/ghost_hierarchy.rs
@@ -2,6 +2,8 @@
 
 #[cfg(feature = "ghost_nodes")]
 use crate::ui_node::ComputedUiTargetCamera;
+#[cfg(not(feature = "ghost_nodes"))]
+use crate::Decoration;
 use crate::Node;
 #[cfg(feature = "ghost_nodes")]
 use bevy_camera::visibility::Visibility;
@@ -37,7 +39,8 @@ pub struct UiRootNodes<'w, 's> {
 }
 
 #[cfg(not(feature = "ghost_nodes"))]
-pub type UiRootNodes<'w, 's> = Query<'w, 's, Entity, (With<Node>, Without<ChildOf>)>;
+pub type UiRootNodes<'w, 's> =
+    Query<'w, 's, Entity, (Or<(With<Node>, With<Decoration>)>, Without<ChildOf>)>;
 
 #[cfg(feature = "ghost_nodes")]
 impl<'w, 's> UiRootNodes<'w, 's> {
@@ -59,7 +62,7 @@ pub struct UiChildren<'w, 's> {
         'w,
         's,
         (Option<&'static Children>, Has<GhostNode>),
-        Or<(With<Node>, With<GhostNode>)>,
+        Or<(With<Node>, With<Decoration>, With<GhostNode>)>,
     >,
     changed_children_query: Query<'w, 's, Entity, Changed<Children>>,
     children_query: Query<'w, 's, &'static Children>,
@@ -71,7 +74,7 @@ pub struct UiChildren<'w, 's> {
 /// System param that gives access to UI children utilities.
 #[derive(SystemParam)]
 pub struct UiChildren<'w, 's> {
-    ui_children_query: Query<'w, 's, Option<&'static Children>, With<Node>>,
+    ui_children_query: Query<'w, 's, Option<&'static Children>, Or<(With<Node>, With<Decoration>)>>,
     changed_children_query: Query<'w, 's, Entity, Changed<Children>>,
     parents_query: Query<'w, 's, &'static ChildOf>,
 }
@@ -171,7 +174,7 @@ pub struct UiChildrenIter<'w, 's> {
         'w,
         's,
         (Option<&'static Children>, Has<GhostNode>),
-        Or<(With<Node>, With<GhostNode>)>,
+        Or<(With<Node>, With<Decoration>, With<GhostNode>)>,
     >,
 }
 

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -1,15 +1,15 @@
 use crate::{
     experimental::{UiChildren, UiRootNodes},
     ui_transform::{UiGlobalTransform, UiTransform},
-    BorderRadius, ComputedNode, ComputedUiTargetCamera, ContentSize, Display, LayoutConfig, Node,
-    Outline, OverflowAxis, ScrollPosition,
+    BorderRadius, ComputedNode, ComputedUiTargetCamera, ContentSize, Decoration, Display,
+    LayoutConfig, Node, Outline, OverflowAxis, ScrollPosition,
 };
 use bevy_ecs::{
     change_detection::{DetectChanges, DetectChangesMut},
     entity::Entity,
     hierarchy::Children,
     lifecycle::RemovedComponents,
-    query::Added,
+    query::{Added, AnyOf},
     system::{Query, ResMut},
     world::Ref,
 };
@@ -84,7 +84,7 @@ pub fn ui_layout_system(
         &mut ComputedNode,
         &UiTransform,
         &mut UiGlobalTransform,
-        &Node,
+        AnyOf<(&Node, &Decoration)>,
         Option<&LayoutConfig>,
         Option<&BorderRadius>,
         Option<&Outline>,
@@ -172,6 +172,7 @@ pub fn ui_layout_system(
 
         update_uinode_geometry_recursive(
             ui_root_entity,
+            Entity::PLACEHOLDER,
             &mut ui_surface,
             true,
             computed_target.physical_size().as_vec2(),
@@ -187,6 +188,7 @@ pub fn ui_layout_system(
     // Returns the combined bounding box of the node and any of its overflowing children.
     fn update_uinode_geometry_recursive(
         entity: Entity,
+        parent: Entity,
         ui_surface: &mut UiSurface,
         inherited_use_rounding: bool,
         target_size: Vec2,
@@ -195,7 +197,7 @@ pub fn ui_layout_system(
             &mut ComputedNode,
             &UiTransform,
             &mut UiGlobalTransform,
-            &Node,
+            AnyOf<(&Node, &Decoration)>,
             Option<&LayoutConfig>,
             Option<&BorderRadius>,
             Option<&Outline>,
@@ -210,13 +212,36 @@ pub fn ui_layout_system(
             mut node,
             transform,
             mut global_transform,
-            style,
+            (style, _),
             maybe_layout_config,
             maybe_border_radius,
             maybe_outline,
             maybe_scroll_position,
         )) = node_update_query.get_mut(entity)
         {
+            let Some(style) = style else {
+                let Ok((parent_node, _, _, (Some(parent_style), None), ..)) =
+                    node_update_query.get(parent)
+                else {
+                    return;
+                };
+                let parent_node = parent_node.clone();
+                let parent_style = parent_style.clone();
+                return update_decoration_geometry_recursive(
+                    entity,
+                    ui_surface,
+                    inherited_use_rounding,
+                    target_size,
+                    inherited_transform,
+                    node_update_query,
+                    ui_children,
+                    inverse_target_scale_factor,
+                    parent_size,
+                    &parent_node,
+                    &parent_style,
+                );
+            };
+
             let use_rounding = maybe_layout_config
                 .map(|layout_config| layout_config.use_rounding)
                 .unwrap_or(inherited_use_rounding);
@@ -335,6 +360,7 @@ pub fn ui_layout_system(
             for child_uinode in ui_children.iter_ui_children(entity) {
                 update_uinode_geometry_recursive(
                     child_uinode,
+                    entity,
                     ui_surface,
                     use_rounding,
                     target_size,
@@ -344,6 +370,134 @@ pub fn ui_layout_system(
                     inverse_target_scale_factor,
                     layout_size,
                     physical_scroll_position,
+                );
+            }
+        }
+    }
+
+    fn update_decoration_geometry_recursive(
+        entity: Entity,
+        ui_surface: &mut UiSurface,
+        inherited_use_rounding: bool,
+        target_size: Vec2,
+        mut inherited_transform: Affine2,
+        node_update_query: &mut Query<(
+            &mut ComputedNode,
+            &UiTransform,
+            &mut UiGlobalTransform,
+            AnyOf<(&Node, &Decoration)>,
+            Option<&LayoutConfig>,
+            Option<&BorderRadius>,
+            Option<&Outline>,
+            Option<&ScrollPosition>,
+        )>,
+        ui_children: &UiChildren,
+        inverse_target_scale_factor: f32,
+        parent_size: Vec2,
+        base_computed_node: &ComputedNode,
+        style: &Node,
+    ) {
+        if let Ok((
+            mut node,
+            transform,
+            mut global_transform,
+            (None, Some(_decoration)),
+            _,
+            maybe_border_radius,
+            maybe_outline,
+            maybe_scroll_position,
+        )) = node_update_query.get_mut(entity)
+        {
+            // only trigger change detection when the new values are different
+            if *node != *base_computed_node {
+                *node = *base_computed_node;
+            }
+
+            // Computer the node's new global transform
+            let local_transform =
+                transform.compute_affine(inverse_target_scale_factor, node.size, target_size);
+
+            inherited_transform *= local_transform;
+
+            if inherited_transform != **global_transform {
+                *global_transform = inherited_transform.into();
+            }
+
+            if let Some(border_radius) = maybe_border_radius {
+                // We don't trigger change detection for changes to border radius
+                node.bypass_change_detection().border_radius = border_radius.resolve(
+                    inverse_target_scale_factor.recip(),
+                    node.size,
+                    target_size,
+                );
+            }
+
+            if let Some(outline) = maybe_outline {
+                // don't trigger change detection when only outlines are changed
+                let node = node.bypass_change_detection();
+                node.outline_width = if style.display != Display::None {
+                    outline
+                        .width
+                        .resolve(
+                            inverse_target_scale_factor.recip(),
+                            node.size().x,
+                            target_size,
+                        )
+                        .unwrap_or(0.)
+                        .max(0.)
+                } else {
+                    0.
+                };
+
+                node.outline_offset = outline
+                    .offset
+                    .resolve(
+                        inverse_target_scale_factor.recip(),
+                        node.size().x,
+                        target_size,
+                    )
+                    .unwrap_or(0.)
+                    .max(0.);
+            }
+
+            let scroll_position: Vec2 = maybe_scroll_position
+                .map(|scroll_pos| {
+                    Vec2::new(
+                        if style.overflow.x == OverflowAxis::Scroll {
+                            scroll_pos.x * inverse_target_scale_factor.recip()
+                        } else {
+                            0.0
+                        },
+                        if style.overflow.y == OverflowAxis::Scroll {
+                            scroll_pos.y * inverse_target_scale_factor.recip()
+                        } else {
+                            0.0
+                        },
+                    )
+                })
+                .unwrap_or_default();
+
+            let max_possible_offset =
+                (node.content_size - node.size + node.scrollbar_size).max(Vec2::ZERO);
+            let clamped_scroll_position = scroll_position.clamp(Vec2::ZERO, max_possible_offset);
+
+            let physical_scroll_position = clamped_scroll_position.floor();
+
+            node.bypass_change_detection().scroll_position = physical_scroll_position;
+
+            for child_uinode in ui_children.iter_ui_children(entity) {
+                update_decoration_geometry_recursive(
+                    child_uinode,
+                    ui_surface,
+                    inherited_use_rounding,
+                    target_size,
+                    inherited_transform,
+                    node_update_query,
+                    ui_children,
+                    inverse_target_scale_factor,
+                    parent_size,
+                    base_computed_node,
+                    style,
                 );
             }
         }

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -732,6 +732,27 @@ impl Default for Node {
     }
 }
 
+#[derive(Default, Component, Clone, PartialEq, Debug, Reflect)]
+#[require(
+    ComputedNode,
+    ComputedUiTargetCamera,
+    UiTransform,
+    BackgroundColor,
+    BorderColor,
+    BorderRadius,
+    FocusPolicy,
+    ScrollPosition,
+    Visibility,
+    ZIndex
+)]
+#[reflect(Component, Default, PartialEq, Debug, Clone)]
+#[cfg_attr(
+    feature = "serialize",
+    derive(serde::Serialize, serde::Deserialize),
+    reflect(Serialize, Deserialize)
+)]
+pub struct Decoration;
+
 /// Used to control how each individual item is aligned by default within the space they're given.
 /// - For Flexbox containers, sets default cross axis alignment of the child items.
 /// - For CSS Grid containers, controls block (vertical) axis alignment of children of this grid container within their grid areas.

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -732,6 +732,7 @@ impl Default for Node {
     }
 }
 
+/// Component that represents visual UI nodes that don't occupy space in the layout.
 #[derive(Default, Component, Clone, PartialEq, Debug, Reflect)]
 #[require(
     ComputedNode,
@@ -751,7 +752,13 @@ impl Default for Node {
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-pub struct Decoration;
+pub struct Decoration {
+    pub width: Val,
+    /// Logical height
+    pub height: Val,
+    /// Border
+    pub border: UiRect,
+}
 
 /// Used to control how each individual item is aligned by default within the space they're given.
 /// - For Flexbox containers, sets default cross axis alignment of the child items.

--- a/crates/bevy_ui_render/src/lib.rs
+++ b/crates/bevy_ui_render/src/lib.rs
@@ -575,7 +575,7 @@ pub fn extract_uinode_borders(
     uinode_query: Extract<
         Query<(
             Entity,
-            &Node,
+            Option<&Node>,
             &ComputedNode,
             &UiGlobalTransform,
             &InheritedVisibility,
@@ -601,7 +601,7 @@ pub fn extract_uinode_borders(
     ) in &uinode_query
     {
         // Skip invisible borders and removed nodes
-        if !inherited_visibility.get() || node.display == Display::None {
+        if !inherited_visibility.get() || node.is_some_and(|node| node.display == Display::None) {
             continue;
         }
 

--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -28,6 +28,7 @@ struct AnimatedText;
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // UI camera
     commands.spawn(Camera2d);
+
     // Text with one section
     commands.spawn((
         // Accepts a `String` or any type that converts into a `String`, such as `&str`
@@ -50,13 +51,27 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         },
         AnimatedText,
         children![(
-            Decoration,
+            Decoration::default(),
             Outline {
                 width: px(2.),
                 offset: px(2.),
                 color: Color::WHITE
             },
         )],
+    ));
+
+    // Text Decoration
+    commands.spawn((
+        Text::new("Decoration"),
+        TextFont {
+            // This font is loaded and will be used instead of the default font.
+            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+            font_size: 67.0,
+            ..default()
+        },
+        TextShadow::default(),
+        Decoration::default(),
+        UiTransform::from_translation(Val2::new(vw(25.), vh(25.))),
     ));
 
     // Text with multiple sections

--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -49,6 +49,14 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             ..default()
         },
         AnimatedText,
+        children![(
+            Decoration,
+            Outline {
+                width: px(2.),
+                offset: px(2.),
+                color: Color::WHITE
+            },
+        )],
     ));
 
     // Text with multiple sections

--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -71,7 +71,11 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         },
         TextShadow::default(),
         Decoration::default(),
-        UiTransform::from_translation(Val2::new(vw(25.), vh(25.))),
+        UiTransform {
+            translation: Val2::new(vw(25.), vh(25.)),
+            rotation: Rot2::degrees(-30.),
+            ..Default::default()
+        },
     ));
 
     // Text with multiple sections

--- a/release-content/release-notes/ui_node_decorations.md
+++ b/release-content/release-notes/ui_node_decorations.md
@@ -1,0 +1,7 @@
+---
+title: UI `Decoration`s
+authors: ["@ickshonpe"]
+pull_requests: [17253]
+---
+
+New `Decoration` component, which lets you create UI nodes that don't occupy space in the layout.


### PR DESCRIPTION
# Objective

Rough implementation of #20103.
Doesn't use relations atm, `Decoration`s are just entities in the tree.

## Solution

* New component `Decoration` which has `size` and `border` fields. If these fields are set to `Auto` the size of the parent node is used or if no parent, the render target size. 
* If a UI node entity has both a `Node` and a `Decoration` component, the `Decoration` component is ignored.
* Use the `UiTransform` to position `Decorations`.
* Doesn't use relations, instead the `Decoration` nodes are just nodes in the tree.
* Allows drawing outlines around text nodes.
* A `Decoration` entity can be a root node, a child of a `Node` entity, or a child of another `Decoration` entity.
* `Node` entities can't be children of `Decoration`s.
* `Text` and scrolling support needs more changes.
* Will support all visual UI elements, some may not work atm not updated everything yet.

## Testing

Added some text and an outline using decorations to the `text` example.
```
cargo run --example text
```

## Showcase

<img width="1339" height="782" alt="decor" src="https://github.com/user-attachments/assets/79562cc0-7de0-4835-a8ed-e73cea4594a5" />
