### PR TITLE
Fix glTF coordinate conversion not converting tangents

### DIFF
--- a/crates/bevy_gltf/src/loader/mod.rs
+++ b/crates/bevy_gltf/src/loader/mod.rs
@@ -35,7 +35,7 @@ use bevy_math::{Mat4, Vec3};
 use bevy_mesh::{
     morph::{MeshMorphWeights, MorphAttributes, MorphTargetImage, MorphWeights},
     skinning::{SkinnedMesh, SkinnedMeshInverseBindposes},
-    Indices, Mesh, Mesh3d, MeshVertexAttribute, PrimitiveTopology, VertexAttributeValues,
+    Indices, Mesh, Mesh3d, MeshVertexAttribute, PrimitiveTopology,
 };
 #[cfg(feature = "pbr_transmission_textures")]
 use bevy_pbr::UvChannel;
@@ -771,26 +771,22 @@ impl GltfLoader {
                     }
                 }
 
-                if let Some(vertex_attribute) = reader
-                    .read_tangents()
-                    .map(|v| VertexAttributeValues::Float32x4(v.collect()))
-                {
-                    mesh.insert_attribute(Mesh::ATTRIBUTE_TANGENT, vertex_attribute);
-                } else if mesh.attribute(Mesh::ATTRIBUTE_NORMAL).is_some()
+                if !mesh.contains_attribute(Mesh::ATTRIBUTE_TANGENT)
+                    && mesh.contains_attribute(Mesh::ATTRIBUTE_NORMAL)
                     && needs_tangents(&primitive.material())
                 {
                     tracing::debug!(
-                    "Missing vertex tangents for {}, computing them using the mikktspace algorithm. Consider using a tool such as Blender to pre-compute the tangents.", file_name
-                );
+                        "Missing vertex tangents for {}, computing them using the mikktspace algorithm. Consider using a tool such as Blender to pre-compute the tangents.", file_name
+                    );
 
                     let generate_tangents_span = info_span!("generate_tangents", name = file_name);
 
                     generate_tangents_span.in_scope(|| {
                         if let Err(err) = mesh.generate_tangents() {
                             warn!(
-                            "Failed to generate vertex tangents using the mikktspace algorithm: {}",
-                            err
-                        );
+                                "Failed to generate vertex tangents using the mikktspace algorithm: {}",
+                                err
+                            );
                         }
                     });
                 }


### PR DESCRIPTION
# Objective

Fix glTF coordinate conversion not converting tangents.

<img width="995" height="565" alt="image" src="https://github.com/user-attachments/assets/20aada7a-39fe-4527-b257-c5efb4555aaf" />

Report: https://discord.com/channels/691052431525675048/692572690833473578/1405362252617355335
Thread: https://discord.com/channels/691052431525675048/1405451520836898848

## Solution

Fixed by removing a redundant copy of the tangent attributes.

In #5370 attribute copying was moved to a more generic function (see `convert_attribute`). But one code path was left behind, so the tangents are actually copied twice. This is technically a bug, but a harmless one since both copies are the same.

Later on, #19633 added the option to convert attribute coordinates. But only the first tangent copy (in `convert_attribute`) applies the conversion - the second copy will overwrite them with unconverted values. This PR removes the second copy.

There's also some minor code quality tweaks - prefer `contains_attribute()` to `attribute().is_some()`, and fixed some bad indentation in log macros. I can revert these if we want to play it safe.

## Testing

Tested a modified version of example `load_gltf` with and without feature `gltf_convert_coordinates_default`. Also tested after hacking the loader to use the code path where tangents are recalculated.