### PR TITLE
remove panic in TextureFormatPixelInfo::pixel_info

### DIFF
--- a/crates/bevy_image/src/dynamic_texture_atlas_builder.rs
+++ b/crates/bevy_image/src/dynamic_texture_atlas_builder.rs
@@ -1,4 +1,4 @@
-use crate::{Image, TextureAtlasLayout, TextureFormatPixelInfo as _};
+use crate::{Image, TextureAccessError, TextureAtlasLayout, TextureFormatPixelInfo as _};
 use bevy_asset::RenderAssetUsages;
 use bevy_math::{URect, UVec2};
 use guillotiere::{size2, Allocation, AtlasAllocator};
@@ -18,6 +18,9 @@ pub enum DynamicTextureAtlasBuilderError {
     /// Attempted to add an uninitialized texture to an atlas
     #[error("cannot add uninitialized texture to atlas")]
     UninitializedSourceTexture,
+    /// A texture access error occurred
+    #[error("texture access error: {0}")]
+    TextureAccess(#[from] TextureAccessError),
 }
 
 /// Helper utility to update [`TextureAtlasLayout`] on the fly.
@@ -90,7 +93,7 @@ impl DynamicTextureAtlasBuilder {
         rect.max.y -= self.padding as i32;
         let atlas_width = atlas_texture.width() as usize;
         let rect_width = rect.width() as usize;
-        let format_size = atlas_texture.texture_descriptor.format.pixel_size();
+        let format_size = atlas_texture.texture_descriptor.format.pixel_size()?;
 
         let Some(ref mut atlas_data) = atlas_texture.data else {
             return Err(DynamicTextureAtlasBuilderError::UninitializedAtlas);

--- a/crates/bevy_image/src/exr_texture_loader.rs
+++ b/crates/bevy_image/src/exr_texture_loader.rs
@@ -1,4 +1,4 @@
-use crate::{Image, TextureFormatPixelInfo};
+use crate::{Image, TextureAccessError, TextureFormatPixelInfo};
 use bevy_asset::{io::Reader, AssetLoader, LoadContext, RenderAssetUsages};
 use image::ImageDecoder;
 use serde::{Deserialize, Serialize};
@@ -25,6 +25,8 @@ pub enum ExrTextureLoaderError {
     Io(#[from] std::io::Error),
     #[error(transparent)]
     ImageError(#[from] image::ImageError),
+    #[error("Texture access error: {0}")]
+    TextureAccess(#[from] TextureAccessError),
 }
 
 impl AssetLoader for ExrTextureLoader {
@@ -40,7 +42,7 @@ impl AssetLoader for ExrTextureLoader {
     ) -> Result<Image, Self::Error> {
         let format = TextureFormat::Rgba32Float;
         debug_assert_eq!(
-            format.pixel_size(),
+            format.pixel_size()?,
             4 * 4,
             "Format should have 32bit x 4 size"
         );

--- a/crates/bevy_image/src/hdr_texture_loader.rs
+++ b/crates/bevy_image/src/hdr_texture_loader.rs
@@ -1,4 +1,4 @@
-use crate::{Image, TextureFormatPixelInfo};
+use crate::{Image, TextureAccessError, TextureFormatPixelInfo};
 use bevy_asset::RenderAssetUsages;
 use bevy_asset::{io::Reader, AssetLoader, LoadContext};
 use image::DynamicImage;
@@ -22,6 +22,8 @@ pub enum HdrTextureLoaderError {
     Io(#[from] std::io::Error),
     #[error("Could not extract image: {0}")]
     Image(#[from] image::ImageError),
+    #[error("Texture access error: {0}")]
+    TextureAccess(#[from] TextureAccessError),
 }
 
 impl AssetLoader for HdrTextureLoader {
@@ -35,11 +37,8 @@ impl AssetLoader for HdrTextureLoader {
         _load_context: &mut LoadContext<'_>,
     ) -> Result<Image, Self::Error> {
         let format = TextureFormat::Rgba32Float;
-        debug_assert_eq!(
-            format.pixel_size(),
-            4 * 4,
-            "Format should have 32bit x 4 size"
-        );
+        let pixel_size = format.pixel_size()?;
+        debug_assert_eq!(pixel_size, 4 * 4, "Format should have 32bit x 4 size");
 
         let mut bytes = Vec::new();
         reader.read_to_end(&mut bytes).await?;
@@ -49,7 +48,7 @@ impl AssetLoader for HdrTextureLoader {
         let image_buffer = dynamic_image
             .as_rgb32f()
             .expect("HDR Image format should be Rgb32F");
-        let mut rgba_data = Vec::with_capacity(image_buffer.pixels().len() * format.pixel_size());
+        let mut rgba_data = Vec::with_capacity(image_buffer.pixels().len() * pixel_size);
 
         for rgb in image_buffer.pixels() {
             let alpha = 1.0f32;

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -941,22 +941,22 @@ impl Image {
         asset_usage: RenderAssetUsages,
     ) -> Self {
         let mut image = Image::new_uninit(size, dimension, format, asset_usage);
-        if let Ok(pixel_size) = image.texture_descriptor.format.pixel_size() {
-            if pixel_size > 0 {
-                let byte_len = pixel_size * size.volume();
-                debug_assert_eq!(
-                    pixel.len() % pixel_size,
-                    0,
-                    "Must not have incomplete pixel data (pixel size is {}B).",
-                    pixel_size,
-                );
-                debug_assert!(
-                    pixel.len() <= byte_len,
-                    "Fill data must fit within pixel buffer (expected {byte_len}B).",
-                );
-                let data = pixel.iter().copied().cycle().take(byte_len).collect();
-                image.data = Some(data);
-            }
+        if let Ok(pixel_size) = image.texture_descriptor.format.pixel_size()
+            && pixel_size > 0
+        {
+            let byte_len = pixel_size * size.volume();
+            debug_assert_eq!(
+                pixel.len() % pixel_size,
+                0,
+                "Must not have incomplete pixel data (pixel size is {}B).",
+                pixel_size,
+            );
+            debug_assert!(
+                pixel.len() <= byte_len,
+                "Fill data must fit within pixel buffer (expected {byte_len}B).",
+            );
+            let data = pixel.iter().copied().cycle().take(byte_len).collect();
+            image.data = Some(data);
         }
         image
     }
@@ -1051,10 +1051,10 @@ impl Image {
     /// If you need to keep pixel data intact, use [`Image::resize_in_place`].
     pub fn resize(&mut self, size: Extent3d) {
         self.texture_descriptor.size = size;
-        if let Some(ref mut data) = self.data {
-            if let Ok(pixel_size) = self.texture_descriptor.format.pixel_size() {
-                data.resize(size.volume() * pixel_size, 0);
-            }
+        if let Some(ref mut data) = self.data
+            && let Ok(pixel_size) = self.texture_descriptor.format.pixel_size()
+        {
+            data.resize(size.volume() * pixel_size, 0);
         }
     }
 
@@ -1820,7 +1820,7 @@ impl Volume for Extent3d {
 /// Extends the wgpu [`TextureFormat`] with information about the pixel.
 pub trait TextureFormatPixelInfo {
     /// Returns the size of a pixel in bytes of the format.
-    /// error with TextureAccessError::UnsupportedTextureFormat if the format is compressed.
+    /// error with `TextureAccessError::UnsupportedTextureFormat` if the format is compressed.
     fn pixel_size(&self) -> Result<usize, TextureAccessError>;
 }
 

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -832,7 +832,14 @@ impl Default for Image {
     /// default is a 1x1x1 all '1.0' texture
     fn default() -> Self {
         let mut image = Image::default_uninit();
-        image.data = Some(vec![255; image.texture_descriptor.format.pixel_size()]);
+        image.data = Some(vec![
+            255;
+            image
+                .texture_descriptor
+                .format
+                .pixel_size()
+                .unwrap_or(0)
+        ]);
         image
     }
 }
@@ -850,11 +857,13 @@ impl Image {
         format: TextureFormat,
         asset_usage: RenderAssetUsages,
     ) -> Self {
-        debug_assert_eq!(
-            size.volume() * format.pixel_size(),
-            data.len(),
-            "Pixel data, size and format have to match",
-        );
+        if let Ok(pixel_size) = format.pixel_size() {
+            debug_assert_eq!(
+                size.volume() * pixel_size,
+                data.len(),
+                "Pixel data, size and format have to match",
+            );
+        }
         let mut image = Image::new_uninit(size, dimension, format, asset_usage);
         image.data = Some(data);
         image
@@ -897,7 +906,9 @@ impl Image {
         // when constructing a transparent color from bytes.
         // If this changes, this function will need to be updated.
         let format = TextureFormat::bevy_default();
-        debug_assert!(format.pixel_size() == 4);
+        if let Ok(pixel_size) = format.pixel_size() {
+            debug_assert!(pixel_size == 4);
+        }
         let data = vec![255, 255, 255, 0];
         Image::new(
             Extent3d::default(),
@@ -929,19 +940,25 @@ impl Image {
         format: TextureFormat,
         asset_usage: RenderAssetUsages,
     ) -> Self {
-        let byte_len = format.pixel_size() * size.volume();
-        debug_assert_eq!(
-            pixel.len() % format.pixel_size(),
-            0,
-            "Must not have incomplete pixel data (pixel size is {}B).",
-            format.pixel_size(),
-        );
-        debug_assert!(
-            pixel.len() <= byte_len,
-            "Fill data must fit within pixel buffer (expected {byte_len}B).",
-        );
-        let data = pixel.iter().copied().cycle().take(byte_len).collect();
-        Image::new(size, dimension, data, format, asset_usage)
+        let mut image = Image::new_uninit(size, dimension, format, asset_usage);
+        if let Ok(pixel_size) = image.texture_descriptor.format.pixel_size() {
+            if pixel_size > 0 {
+                let byte_len = pixel_size * size.volume();
+                debug_assert_eq!(
+                    pixel.len() % pixel_size,
+                    0,
+                    "Must not have incomplete pixel data (pixel size is {}B).",
+                    pixel_size,
+                );
+                debug_assert!(
+                    pixel.len() <= byte_len,
+                    "Fill data must fit within pixel buffer (expected {byte_len}B).",
+                );
+                let data = pixel.iter().copied().cycle().take(byte_len).collect();
+                image.data = Some(data);
+            }
+        }
+        image
     }
 
     /// Create a new zero-filled image with a given size, which can be rendered to.
@@ -974,7 +991,7 @@ impl Image {
             | TextureUsages::COPY_DST
             | TextureUsages::RENDER_ATTACHMENT;
         // Fill with zeroes
-        let data = vec![0; format.pixel_size() * size.volume()];
+        let data = vec![0; format.pixel_size().unwrap_or(0) * size.volume()];
 
         Image {
             data: Some(data),
@@ -1035,10 +1052,9 @@ impl Image {
     pub fn resize(&mut self, size: Extent3d) {
         self.texture_descriptor.size = size;
         if let Some(ref mut data) = self.data {
-            data.resize(
-                size.volume() * self.texture_descriptor.format.pixel_size(),
-                0,
-            );
+            if let Ok(pixel_size) = self.texture_descriptor.format.pixel_size() {
+                data.resize(size.volume() * pixel_size, 0);
+            }
         }
     }
 
@@ -1064,43 +1080,44 @@ impl Image {
     ///
     /// For faster resizing when keeping pixel data intact is not important, use [`Image::resize`].
     pub fn resize_in_place(&mut self, new_size: Extent3d) {
-        let old_size = self.texture_descriptor.size;
-        let pixel_size = self.texture_descriptor.format.pixel_size();
-        let byte_len = self.texture_descriptor.format.pixel_size() * new_size.volume();
-        self.texture_descriptor.size = new_size;
+        if let Ok(pixel_size) = self.texture_descriptor.format.pixel_size() {
+            let old_size = self.texture_descriptor.size;
+            let byte_len = pixel_size * new_size.volume();
+            self.texture_descriptor.size = new_size;
 
-        let Some(ref mut data) = self.data else {
-            self.copy_on_resize = true;
-            return;
-        };
+            let Some(ref mut data) = self.data else {
+                self.copy_on_resize = true;
+                return;
+            };
 
-        let mut new: Vec<u8> = vec![0; byte_len];
+            let mut new: Vec<u8> = vec![0; byte_len];
 
-        let copy_width = old_size.width.min(new_size.width) as usize;
-        let copy_height = old_size.height.min(new_size.height) as usize;
-        let copy_depth = old_size
-            .depth_or_array_layers
-            .min(new_size.depth_or_array_layers) as usize;
+            let copy_width = old_size.width.min(new_size.width) as usize;
+            let copy_height = old_size.height.min(new_size.height) as usize;
+            let copy_depth = old_size
+                .depth_or_array_layers
+                .min(new_size.depth_or_array_layers) as usize;
 
-        let old_row_stride = old_size.width as usize * pixel_size;
-        let old_layer_stride = old_size.height as usize * old_row_stride;
+            let old_row_stride = old_size.width as usize * pixel_size;
+            let old_layer_stride = old_size.height as usize * old_row_stride;
 
-        let new_row_stride = new_size.width as usize * pixel_size;
-        let new_layer_stride = new_size.height as usize * new_row_stride;
+            let new_row_stride = new_size.width as usize * pixel_size;
+            let new_layer_stride = new_size.height as usize * new_row_stride;
 
-        for z in 0..copy_depth {
-            for y in 0..copy_height {
-                let old_offset = z * old_layer_stride + y * old_row_stride;
-                let new_offset = z * new_layer_stride + y * new_row_stride;
+            for z in 0..copy_depth {
+                for y in 0..copy_height {
+                    let old_offset = z * old_layer_stride + y * old_row_stride;
+                    let new_offset = z * new_layer_stride + y * new_row_stride;
 
-                let old_range = (old_offset)..(old_offset + copy_width * pixel_size);
-                let new_range = (new_offset)..(new_offset + copy_width * pixel_size);
+                    let old_range = (old_offset)..(old_offset + copy_width * pixel_size);
+                    let new_range = (new_offset)..(new_offset + copy_width * pixel_size);
 
-                new[new_range].copy_from_slice(&data[old_range]);
+                    new[new_range].copy_from_slice(&data[old_range]);
+                }
             }
-        }
 
-        self.data = Some(new);
+            self.data = Some(new);
+        }
     }
 
     /// Takes a 2D image containing vertically stacked images of the same size, and reinterprets
@@ -1232,7 +1249,7 @@ impl Image {
         let height = self.texture_descriptor.size.height;
         let depth = self.texture_descriptor.size.depth_or_array_layers;
 
-        let pixel_size = self.texture_descriptor.format.pixel_size();
+        let pixel_size = self.texture_descriptor.format.pixel_size().ok()?;
         let pixel_offset = match self.texture_descriptor.dimension {
             TextureDimension::D3 | TextureDimension::D2 => {
                 if coords.x >= width || coords.y >= height || coords.z >= depth {
@@ -1254,7 +1271,7 @@ impl Image {
     /// Get a reference to the data bytes where a specific pixel's value is stored
     #[inline(always)]
     pub fn pixel_bytes(&self, coords: UVec3) -> Option<&[u8]> {
-        let len = self.texture_descriptor.format.pixel_size();
+        let len = self.texture_descriptor.format.pixel_size().ok()?;
         let data = self.data.as_ref()?;
         self.pixel_data_offset(coords)
             .map(|start| &data[start..(start + len)])
@@ -1263,7 +1280,7 @@ impl Image {
     /// Get a mutable reference to the data bytes where a specific pixel's value is stored
     #[inline(always)]
     pub fn pixel_bytes_mut(&mut self, coords: UVec3) -> Option<&mut [u8]> {
-        let len = self.texture_descriptor.format.pixel_size();
+        let len = self.texture_descriptor.format.pixel_size().ok()?;
         let offset = self.pixel_data_offset(coords);
         let data = self.data.as_mut()?;
         offset.map(|start| &mut data[start..(start + len)])
@@ -1803,15 +1820,16 @@ impl Volume for Extent3d {
 /// Extends the wgpu [`TextureFormat`] with information about the pixel.
 pub trait TextureFormatPixelInfo {
     /// Returns the size of a pixel in bytes of the format.
-    fn pixel_size(&self) -> usize;
+    /// error with TextureAccessError::UnsupportedTextureFormat if the format is compressed.
+    fn pixel_size(&self) -> Result<usize, TextureAccessError>;
 }
 
 impl TextureFormatPixelInfo for TextureFormat {
-    fn pixel_size(&self) -> usize {
+    fn pixel_size(&self) -> Result<usize, TextureAccessError> {
         let info = self;
         match info.block_dimensions() {
-            (1, 1) => info.block_copy_size(None).unwrap() as usize,
-            _ => panic!("Using pixel_size for compressed textures is invalid"),
+            (1, 1) => Ok(info.block_copy_size(None).unwrap() as usize),
+            _ => Err(TextureAccessError::UnsupportedTextureFormat(*self)),
         }
     }
 }

--- a/crates/bevy_image/src/image_texture_conversion.rs
+++ b/crates/bevy_image/src/image_texture_conversion.rs
@@ -108,8 +108,9 @@ impl Image {
                 height = image.height();
                 format = TextureFormat::Rgba32Float;
 
-                let mut local_data =
-                    Vec::with_capacity(width as usize * height as usize * format.pixel_size());
+                let mut local_data = Vec::with_capacity(
+                    width as usize * height as usize * format.pixel_size().unwrap_or(0),
+                );
 
                 for pixel in image.into_raw().chunks_exact(3) {
                     // TODO: use the array_chunks method once stabilized

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -1822,17 +1822,18 @@ impl FromWorld for MeshPipeline {
                 }
             };
 
-            let format_size = image.texture_descriptor.format.pixel_size();
-            render_queue.write_texture(
-                texture.as_image_copy(),
-                image.data.as_ref().expect("Image was created without data"),
-                TexelCopyBufferLayout {
-                    offset: 0,
-                    bytes_per_row: Some(image.width() * format_size as u32),
-                    rows_per_image: None,
-                },
-                image.texture_descriptor.size,
-            );
+            if let Ok(format_size) = image.texture_descriptor.format.pixel_size() {
+                render_queue.write_texture(
+                    texture.as_image_copy(),
+                    image.data.as_ref().expect("Image was created without data"),
+                    TexelCopyBufferLayout {
+                        offset: 0,
+                        bytes_per_row: Some(image.width() * format_size as u32),
+                        rows_per_image: None,
+                    },
+                    image.texture_descriptor.size,
+                );
+            }
 
             let texture_view = texture.create_view(&TextureViewDescriptor::default());
             GpuImage {

--- a/crates/bevy_render/src/gpu_readback.rs
+++ b/crates/bevy_render/src/gpu_readback.rs
@@ -257,26 +257,26 @@ fn prepare_buffers(
     for (entity, readback) in handles.iter() {
         match readback {
             Readback::Texture(image) => {
-                if let Some(gpu_image) = gpu_images.get(image) {
-                    if let Ok(pixel_size) = gpu_image.texture_format.pixel_size() {
-                        let layout = layout_data(gpu_image.size, gpu_image.texture_format);
-                        let buffer = buffer_pool.get(
-                            &render_device,
-                            get_aligned_size(gpu_image.size, pixel_size as u32) as u64,
-                        );
-                        let (tx, rx) = async_channel::bounded(1);
-                        readbacks.requested.push(GpuReadback {
-                            entity: entity.id(),
-                            src: ReadbackSource::Texture {
-                                texture: gpu_image.texture.clone(),
-                                layout,
-                                size: gpu_image.size,
-                            },
-                            buffer,
-                            rx,
-                            tx,
-                        });
-                    }
+                if let Some(gpu_image) = gpu_images.get(image)
+                    && let Ok(pixel_size) = gpu_image.texture_format.pixel_size()
+                {
+                    let layout = layout_data(gpu_image.size, gpu_image.texture_format);
+                    let buffer = buffer_pool.get(
+                        &render_device,
+                        get_aligned_size(gpu_image.size, pixel_size as u32) as u64,
+                    );
+                    let (tx, rx) = async_channel::bounded(1);
+                    readbacks.requested.push(GpuReadback {
+                        entity: entity.id(),
+                        src: ReadbackSource::Texture {
+                            texture: gpu_image.texture.clone(),
+                            layout,
+                            size: gpu_image.size,
+                        },
+                        buffer,
+                        rx,
+                        tx,
+                    });
                 }
             }
             Readback::Buffer {

--- a/crates/bevy_render/src/gpu_readback.rs
+++ b/crates/bevy_render/src/gpu_readback.rs
@@ -258,26 +258,25 @@ fn prepare_buffers(
         match readback {
             Readback::Texture(image) => {
                 if let Some(gpu_image) = gpu_images.get(image) {
-                    let layout = layout_data(gpu_image.size, gpu_image.texture_format);
-                    let buffer = buffer_pool.get(
-                        &render_device,
-                        get_aligned_size(
-                            gpu_image.size,
-                            gpu_image.texture_format.pixel_size() as u32,
-                        ) as u64,
-                    );
-                    let (tx, rx) = async_channel::bounded(1);
-                    readbacks.requested.push(GpuReadback {
-                        entity: entity.id(),
-                        src: ReadbackSource::Texture {
-                            texture: gpu_image.texture.clone(),
-                            layout,
-                            size: gpu_image.size,
-                        },
-                        buffer,
-                        rx,
-                        tx,
-                    });
+                    if let Ok(pixel_size) = gpu_image.texture_format.pixel_size() {
+                        let layout = layout_data(gpu_image.size, gpu_image.texture_format);
+                        let buffer = buffer_pool.get(
+                            &render_device,
+                            get_aligned_size(gpu_image.size, pixel_size as u32) as u64,
+                        );
+                        let (tx, rx) = async_channel::bounded(1);
+                        readbacks.requested.push(GpuReadback {
+                            entity: entity.id(),
+                            src: ReadbackSource::Texture {
+                                texture: gpu_image.texture.clone(),
+                                layout,
+                                size: gpu_image.size,
+                            },
+                            buffer,
+                            rx,
+                            tx,
+                        });
+                    }
                 }
             }
             Readback::Buffer {
@@ -384,15 +383,19 @@ pub(crate) const fn get_aligned_size(extent: Extent3d, pixel_size: u32) -> u32 {
 pub(crate) fn layout_data(extent: Extent3d, format: TextureFormat) -> TexelCopyBufferLayout {
     TexelCopyBufferLayout {
         bytes_per_row: if extent.height > 1 || extent.depth_or_array_layers > 1 {
-            // 1 = 1 row
-            Some(get_aligned_size(
-                Extent3d {
-                    width: extent.width,
-                    height: 1,
-                    depth_or_array_layers: 1,
-                },
-                format.pixel_size() as u32,
-            ))
+            if let Ok(pixel_size) = format.pixel_size() {
+                // 1 = 1 row
+                Some(get_aligned_size(
+                    Extent3d {
+                        width: extent.width,
+                        height: 1,
+                        depth_or_array_layers: 1,
+                    },
+                    pixel_size as u32,
+                ))
+            } else {
+                None
+            }
         } else {
             None
         },

--- a/crates/bevy_render/src/texture/fallback_image.rs
+++ b/crates/bevy_render/src/texture/fallback_image.rs
@@ -89,7 +89,7 @@ fn fallback_image_new(
 
     let image_dimension = dimension.compatible_texture_dimension();
     let mut image = if create_texture_with_data {
-        let data = vec![value; format.pixel_size()];
+        let data = vec![value; format.pixel_size().unwrap_or(0)];
         Image::new_fill(
             extents,
             image_dimension,

--- a/crates/bevy_render/src/view/window/screenshot.rs
+++ b/crates/bevy_render/src/view/window/screenshot.rs
@@ -363,7 +363,7 @@ fn prepare_screenshot_state(
     let texture_view = texture.create_view(&Default::default());
     let buffer = render_device.create_buffer(&wgpu::BufferDescriptor {
         label: Some("screenshot-transfer-buffer"),
-        size: gpu_readback::get_aligned_size(size, format.pixel_size() as u32) as u64,
+        size: gpu_readback::get_aligned_size(size, format.pixel_size().unwrap_or(0) as u32) as u64,
         usage: BufferUsages::MAP_READ | BufferUsages::COPY_DST,
         mapped_at_creation: false,
     });
@@ -623,7 +623,9 @@ pub(crate) fn collect_screenshots(world: &mut World) {
         let width = prepared.size.width;
         let height = prepared.size.height;
         let texture_format = prepared.texture.format();
-        let pixel_size = texture_format.pixel_size();
+        let Ok(pixel_size) = texture_format.pixel_size() else {
+            continue;
+        };
         let buffer = prepared.buffer.clone();
 
         let finish = async move {

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -328,17 +328,18 @@ pub fn init_mesh_2d_pipeline(
             }
         };
 
-        let format_size = image.texture_descriptor.format.pixel_size();
-        render_queue.write_texture(
-            texture.as_image_copy(),
-            image.data.as_ref().expect("Image has no data"),
-            TexelCopyBufferLayout {
-                offset: 0,
-                bytes_per_row: Some(image.width() * format_size as u32),
-                rows_per_image: None,
-            },
-            image.texture_descriptor.size,
-        );
+        if let Ok(format_size) = image.texture_descriptor.format.pixel_size() {
+            render_queue.write_texture(
+                texture.as_image_copy(),
+                image.data.as_ref().expect("Image has no data"),
+                TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(image.width() * format_size as u32),
+                    rows_per_image: None,
+                },
+                image.texture_descriptor.size,
+            );
+        }
 
         let texture_view = texture.create_view(&TextureViewDescriptor::default());
         GpuImage {

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -92,17 +92,18 @@ pub fn init_sprite_pipeline(
             }
         };
 
-        let format_size = image.texture_descriptor.format.pixel_size();
-        render_queue.write_texture(
-            texture.as_image_copy(),
-            image.data.as_ref().expect("Image has no data"),
-            TexelCopyBufferLayout {
-                offset: 0,
-                bytes_per_row: Some(image.width() * format_size as u32),
-                rows_per_image: None,
-            },
-            image.texture_descriptor.size,
-        );
+        if let Ok(format_size) = image.texture_descriptor.format.pixel_size() {
+            render_queue.write_texture(
+                texture.as_image_copy(),
+                image.data.as_ref().expect("Image has no data"),
+                TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(image.width() * format_size as u32),
+                    rows_per_image: None,
+                },
+                image.texture_descriptor.size,
+            );
+        }
         let texture_view = texture.create_view(&TextureViewDescriptor::default());
         GpuImage {
             texture,

--- a/examples/app/headless_renderer.rs
+++ b/examples/app/headless_renderer.rs
@@ -497,7 +497,7 @@ fn update(
                     // If the image became wider when copying from the texture to the buffer,
                     // then the data is reduced to its original size when copying from the buffer to the image.
                     let row_bytes = img_bytes.width() as usize
-                        * img_bytes.texture_descriptor.format.pixel_size();
+                        * img_bytes.texture_descriptor.format.pixel_size().unwrap();
                     let aligned_row_bytes = RenderDevice::align_copy_bytes_per_row(row_bytes);
                     if row_bytes == aligned_row_bytes {
                         img_bytes.data.as_mut().unwrap().clone_from(&image_data);


### PR DESCRIPTION
# Objective

fixes #20365 

## Solution

TextureFormatPixelInfo::pixel_info now return a Result instead of panic

## Testing

ran my game on it, using mesh, sprite, ui everything seems good.

**BUT** its my first time contributing this type of code, dont much about rendering and its integration in bevy. **REVIEW THIS LIKE I DON'T KNOW ANYTHING** especially i dont know if there is some unwanted consequence of these changes in other places.

what remains, is maybe we should add some `warn!` ? at least in picking.
Currently in sprite picking backend if the pixel data couldn't be accessed (to determine if the alpha is greater than the threshold), the entity is skipped. maybe a `warn!` here at least ?

(imo it shouldn't be skipped, instead be taken as if it was valid: id rather have a sprite where the whole size of it is picked than having it not working at all. maybe a SpritePickingSettings per entity ?)