### PR TITLE
Modifying an Assets dependencies should mark the Asset as modified

### DIFF
--- a/crates/bevy_asset/macros/src/lib.rs
+++ b/crates/bevy_asset/macros/src/lib.rs
@@ -50,7 +50,7 @@ fn derive_dependency_visitor_internal(
     let struct_name = &ast.ident;
     let (impl_generics, type_generics, where_clause) = &ast.generics.split_for_impl();
 
-    let visit_dep = |to_read| quote!(#bevy_asset_path::VisitAssetDependencies::visit_dependencies(#to_read, visit););
+    let visit_dep = |to_read| quote!(#bevy_asset_path::VisitAssetDependencies::visit_dependencies(#to_read, visit)?;);
     let is_dep_attribute = |a: &syn::Attribute| a.path().is_ident(DEPENDENCY_ATTRIBUTE);
     let field_has_dep = |f: &syn::Field| f.attrs.iter().any(is_dep_attribute);
 
@@ -119,8 +119,9 @@ fn derive_dependency_visitor_internal(
 
     Ok(quote! {
         impl #impl_generics #bevy_asset_path::VisitAssetDependencies for #struct_name #type_generics #where_clause {
-            fn visit_dependencies(&self, #visit: &mut impl FnMut(#bevy_asset_path::UntypedAssetId)) {
+            fn visit_dependencies(&self, #visit: &mut impl FnMut(#bevy_asset_path::UntypedAssetId)-> core::ops::ControlFlow<#bevy_asset_path::UntypedAssetId>)-> core::ops::ControlFlow<#bevy_asset_path::UntypedAssetId> {
                 #body
+                core::ops::ControlFlow::Continue(())
             }
         }
     })

--- a/crates/bevy_asset/src/event.rs
+++ b/crates/bevy_asset/src/event.rs
@@ -127,3 +127,8 @@ impl<A: Asset> PartialEq for AssetEvent<A> {
 }
 
 impl<A: Asset> Eq for AssetEvent<A> {}
+
+#[derive(BufferedEvent)]
+pub struct UntypedAssetModifiedEvent {
+    pub id: UntypedAssetId,
+}

--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -531,7 +531,7 @@ mod tests {
     use alloc::boxed::Box;
     use bevy_platform::hash::FixedHasher;
     use bevy_reflect::PartialReflect;
-    use core::hash::BuildHasher;
+    use core::{hash::BuildHasher, ops::ControlFlow};
     use uuid::Uuid;
 
     use super::*;
@@ -639,7 +639,12 @@ mod tests {
         }
         impl Asset for MyAsset {}
         impl VisitAssetDependencies for MyAsset {
-            fn visit_dependencies(&self, _visit: &mut impl FnMut(UntypedAssetId)) {}
+            fn visit_dependencies(
+                &self,
+                _visit: &mut impl FnMut(UntypedAssetId) -> ControlFlow<UntypedAssetId>,
+            ) -> ControlFlow<UntypedAssetId> {
+                ControlFlow::Continue(())
+            }
         }
 
         let mut app = App::new();

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -15,7 +15,10 @@ use atomicow::CowArc;
 use bevy_ecs::{error::BevyError, world::World};
 use bevy_platform::collections::{HashMap, HashSet};
 use bevy_tasks::{BoxedFuture, ConditionalSendFuture};
-use core::any::{Any, TypeId};
+use core::{
+    any::{Any, TypeId},
+    ops::ControlFlow,
+};
 use downcast_rs::{impl_downcast, Downcast};
 use ron::error::SpannedError;
 use serde::{Deserialize, Serialize};
@@ -153,8 +156,9 @@ impl<A: Asset> LoadedAsset<A> {
     /// Create a new loaded asset. This will use [`VisitAssetDependencies`](crate::VisitAssetDependencies) to populate `dependencies`.
     pub fn new_with_dependencies(value: A) -> Self {
         let mut dependencies = <HashSet<_>>::default();
-        value.visit_dependencies(&mut |id| {
+        let _ = value.visit_dependencies(&mut |id| -> ControlFlow<UntypedAssetId> {
             dependencies.insert(id);
+            ControlFlow::Continue(())
         });
         LoadedAsset {
             value,

--- a/crates/bevy_asset/src/meta.rs
+++ b/crates/bevy_asset/src/meta.rs
@@ -1,3 +1,5 @@
+use core::ops::ControlFlow;
+
 use alloc::{
     boxed::Box,
     string::{String, ToString},
@@ -192,7 +194,10 @@ impl Process for () {
 impl Asset for () {}
 
 impl VisitAssetDependencies for () {
-    fn visit_dependencies(&self, _visit: &mut impl FnMut(bevy_asset::UntypedAssetId)) {
+    fn visit_dependencies(
+        &self,
+        _visit: &mut impl FnMut(bevy_asset::UntypedAssetId) -> ControlFlow<bevy_asset::UntypedAssetId>,
+    ) -> ControlFlow<bevy_asset::UntypedAssetId> {
         unreachable!()
     }
 }

--- a/crates/bevy_sprite/src/mesh2d/color_material.rs
+++ b/crates/bevy_sprite/src/mesh2d/color_material.rs
@@ -42,6 +42,7 @@ pub struct ColorMaterial {
     pub uv_transform: Affine2,
     #[texture(1)]
     #[sampler(2)]
+    #[dependency]
     pub texture: Option<Handle<Image>>,
 }
 


### PR DESCRIPTION
# Objective

Fixes #20269 and #16159

The issue is when an `Asset` is modified and it is a dependency of another `Asset`, that "parent" `Asset` is not marked as modified. Specifically in the 2 issues above, an `Image` asset is modified and it is a dependency of `StandardMaterial` (`base_color_texture`) or a `ColorMaterial` (`texture`) asset. When the `Image` is modified, neither material is marked modified and so they do not rebuild their cached `BindGroup` and so the image rendered does not change.

## Solution

First, modify `VisitAssetDependencies::visit_dependencies` to allow early termination via `ControlFlow`.

Then, for every `Assets<A>` modification, also queue an `UntypedAssetModifiedEvent` with the `UntypedAssetId`. So we have an event queue of modified assets across all asset types. Then for each asset we check if any of its dependency assets are in that set of modified assets, and if so mark the asset itself as modified.

This does mean that any time an asset in `Assets<A>` is modified, we will iterate all assets in `Assets<A>` and visit each of their dependencies which is perhaps suboptimal.

## Testing

Here is some sample code that demonstrates the issue with both `StandardMaterial` and `ColorMaterial` and an `Image`.

<details>
  <summary>Click to expand sample code</summary>

```rust
use std::f32::consts::FRAC_PI_4;

use bevy::{
    asset::RenderAssetUsages,
    prelude::*,
    render::render_resource::{Extent3d, TextureDimension, TextureFormat},
};
use rand::Rng;

fn main() {
    let mut app = App::new();
    app.add_plugins(DefaultPlugins)
        .init_resource::<ImageAssetId>()
        .add_systems(Startup, setup)
        .add_systems(Update, update);

    app.run();
}

#[derive(Resource, Default)]
struct ImageAssetId(AssetId<Image>);

fn setup(
    mut commands: Commands,
    mut meshes: ResMut<Assets<Mesh>>,
    mut standard_materials: ResMut<Assets<StandardMaterial>>,
    mut color_materials: ResMut<Assets<ColorMaterial>>,
    mut images: ResMut<Assets<Image>>,
    mut image_id: ResMut<ImageAssetId>,
) {
    commands.spawn((PointLight::default(), Transform::from_xyz(2.0, 2.0, 3.0)));
    commands.spawn((
        Camera {
            order: 0,
            ..default()
        },
        Camera3d::default(),
        Transform::from_xyz(0.0, 0.0, 2.0),
    ));
    commands.spawn((
        Camera {
            order: 1,
            ..default()
        },
        Camera2d,
    ));
    let image_handle = images.add(random_image());
    image_id.0 = image_handle.id();
    commands.spawn((
        Mesh3d(meshes.add(Cuboid::new(1.0, 1.0, 1.0))),
        MeshMaterial3d(standard_materials.add(StandardMaterial {
            base_color_texture: Some(image_handle.clone()),
            ..default()
        })),
        Transform::from_rotation(Quat::from_axis_angle(Vec3::X, FRAC_PI_4)),
    ));

    commands.spawn((
        MeshMaterial2d(color_materials.add(ColorMaterial {
            texture: Some(image_handle),
            ..default()
        })),
        Mesh2d(meshes.add(Rectangle::new(512.0, 512.0))),
        Transform::from_scale(Vec3::splat(0.3)),
    ));
}

fn update(image_id: Res<ImageAssetId>, mut images: ResMut<Assets<Image>>) {
    if let Some(image) = images.get_mut(image_id.0) {
        *image = random_image();
    }
}

fn random_image() -> Image {
    let mut rng = rand::rng();
    let color = [
        rng.random_range(0..=255u8),
        rng.random_range(0..=255u8),
        rng.random_range(0..=255u8),
        255u8,
    ];
    let mut pixels = [0u8; 512 * 512 * 4];
    for chunk in pixels.chunks_exact_mut(4) {
        chunk.copy_from_slice(&color);
    }
    Image::new_fill(
        Extent3d {
            width: 512,
            height: 512,
            ..default()
        },
        TextureDimension::D2,
        &pixels,
        TextureFormat::Rgba8UnormSrgb,
        RenderAssetUsages::default(),
    )
}
```
</details>


