### PR TITLE
Fix code indentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ To draw a window with standard functionality enabled, use:
 use bevy::prelude::*;
 
 fn main() {
-  App::new()
-    .add_plugins(DefaultPlugins)
-    .run();
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .run();
 }
 ```
 


### PR DESCRIPTION
# Objective

Somehow the README's code example still uses a non-standard indentation level of 2 spaces (the [style guide](https://github.com/rust-lang/rust/tree/HEAD/src/doc/style-guide/src) recommends 4, and it is what rustfmt uses by default).

## Solution

Fix the indentation level!
