### PR TITLE
Fix typo in release-notes directory link in GitHub workflow

### DIFF
--- a/.github/workflows/action-on-PR-labeled.yml
+++ b/.github/workflows/action-on-PR-labeled.yml
@@ -70,5 +70,5 @@ jobs:
               repo: context.repo.repo,
               body: `It looks like your PR has been selected for a highlight in the next release blog post, but **you didn't provide a release note**.
 
-              Please review the [instructions for writing release notes](https://github.com/bevyengine/bevy/tree/main/release-content/release_notes.md), then expand or revise the content in the [release notes directory](https://github.com/bevyengine/bevy/tree/main/release-content/release_notes) to showcase your changes.`
+              Please review the [instructions for writing release notes](https://github.com/bevyengine/bevy/tree/main/release-content/release_notes.md), then expand or revise the content in the [release notes directory](https://github.com/bevyengine/bevy/tree/main/release-content/release-notes) to showcase your changes.`
             })


### PR DESCRIPTION
# Objective

For example, in:

- https://github.com/bevyengine/bevy/pull/19864#issuecomment-3016970396

The link to the directory containing the release notes is broken.

## Solution

Fix the link.

## Testing

Copy pasted the new link in URL bar.
