### PR TITLE
Split up ComputedUiTargetCamera (#20534)

### DIFF
--- a/crates/bevy_core_widgets/src/core_scrollbar.rs
+++ b/crates/bevy_core_widgets/src/core_scrollbar.rs
@@ -12,7 +12,7 @@ use bevy_math::Vec2;
 use bevy_picking::events::{Cancel, Drag, DragEnd, DragStart, Pointer, Press};
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_ui::{
-    ComputedNode, ComputedUiTargetCamera, Node, ScrollPosition, UiGlobalTransform, UiScale, Val,
+    ComputedNode, ComputedUiRenderTargetInfo, Node, ScrollPosition, UiGlobalTransform, UiScale, Val,
 };
 
 /// Used to select the orientation of a scrollbar, slider, or other oriented control.
@@ -104,7 +104,7 @@ fn scrollbar_on_pointer_down(
     mut q_scrollbar: Query<(
         &CoreScrollbar,
         &ComputedNode,
-        &ComputedUiTargetCamera,
+        &ComputedUiRenderTargetInfo,
         &UiGlobalTransform,
     )>,
     mut q_scroll_pos: Query<(&mut ScrollPosition, &ComputedNode), Without<CoreScrollbar>>,

--- a/crates/bevy_core_widgets/src/core_slider.rs
+++ b/crates/bevy_core_widgets/src/core_slider.rs
@@ -24,7 +24,7 @@ use bevy_math::ops;
 use bevy_picking::events::{Drag, DragEnd, DragStart, Pointer, Press};
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_ui::{
-    ComputedNode, ComputedUiTargetCamera, InteractionDisabled, UiGlobalTransform, UiScale,
+    ComputedNode, ComputedUiRenderTargetInfo, InteractionDisabled, UiGlobalTransform, UiScale,
 };
 
 use crate::{Callback, Notify, ValueChange};
@@ -236,7 +236,7 @@ pub(crate) fn slider_on_pointer_down(
         &SliderStep,
         Option<&SliderPrecision>,
         &ComputedNode,
-        &ComputedUiTargetCamera,
+        &ComputedUiRenderTargetInfo,
         &UiGlobalTransform,
         Has<InteractionDisabled>,
     )>,
@@ -255,7 +255,7 @@ pub(crate) fn slider_on_pointer_down(
         step,
         precision,
         node,
-        node_target,
+        node_info,
         transform,
         disabled,
     )) = q_slider.get(trigger.target())
@@ -275,7 +275,7 @@ pub(crate) fn slider_on_pointer_down(
 
         // Detect track click.
         let local_pos = transform.try_inverse().unwrap().transform_point2(
-            trigger.event().pointer_location.position * node_target.scale_factor() / ui_scale.0,
+            trigger.event().pointer_location.position * node_info.scale_factor() / ui_scale.0,
         );
         let track_width = node.size().x - thumb_size;
         // Avoid division by zero

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -379,6 +379,9 @@ mod tests {
         app.add_plugins(HierarchyPropagatePlugin::<ComputedUiTargetCamera>::new(
             PostUpdate,
         ));
+        app.add_plugins(HierarchyPropagatePlugin::<ComputedUiRenderTargetInfo>::new(
+            PostUpdate,
+        ));
         app.init_resource::<UiScale>();
         app.init_resource::<UiSurface>();
         app.init_resource::<bevy_text::TextPipeline>();
@@ -402,6 +405,13 @@ mod tests {
         app.configure_sets(
             PostUpdate,
             PropagateSet::<ComputedUiTargetCamera>::default()
+                .after(propagate_ui_target_cameras)
+                .before(ui_layout_system),
+        );
+
+        app.configure_sets(
+            PostUpdate,
+            PropagateSet::<ComputedUiRenderTargetInfo>::default()
                 .after(propagate_ui_target_cameras)
                 .before(ui_layout_system),
         );
@@ -1056,9 +1066,20 @@ mod tests {
             PostUpdate,
         ));
 
+        app.add_plugins(HierarchyPropagatePlugin::<ComputedUiRenderTargetInfo>::new(
+            PostUpdate,
+        ));
+
         app.configure_sets(
             PostUpdate,
             PropagateSet::<ComputedUiTargetCamera>::default()
+                .after(propagate_ui_target_cameras)
+                .before(ui_layout_system),
+        );
+
+        app.configure_sets(
+            PostUpdate,
+            PropagateSet::<ComputedUiRenderTargetInfo>::default()
                 .after(propagate_ui_target_cameras)
                 .before(ui_layout_system),
         );

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -156,7 +156,14 @@ impl Plugin for UiPlugin {
                 PostUpdate,
                 PropagateSet::<ComputedUiTargetCamera>::default().in_set(UiSystems::Propagate),
             )
+            .configure_sets(
+                PostUpdate,
+                PropagateSet::<ComputedUiRenderTargetInfo>::default().in_set(UiSystems::Propagate),
+            )
             .add_plugins(HierarchyPropagatePlugin::<ComputedUiTargetCamera>::new(
+                PostUpdate,
+            ))
+            .add_plugins(HierarchyPropagatePlugin::<ComputedUiRenderTargetInfo>::new(
                 PostUpdate,
             ))
             .add_systems(

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -2804,30 +2804,23 @@ impl<'w, 's> DefaultUiCamera<'w, 's> {
 /// Updated in [`UiSystems::Prepare`](crate::UiSystems::Prepare) by [`propagate_ui_target_cameras`](crate::update::propagate_ui_target_cameras)
 #[derive(Component, Clone, Copy, Debug, Reflect, PartialEq)]
 #[reflect(Component, Default, PartialEq, Clone)]
-pub struct ComputedUiTargetCamera {
-    pub(crate) camera: Entity,
+pub struct ComputedUiRenderTargetInfo {
     /// The scale factor of the target camera's render target.
     pub(crate) scale_factor: f32,
     /// The size of the target camera's viewport in physical pixels.
     pub(crate) physical_size: UVec2,
 }
 
-impl Default for ComputedUiTargetCamera {
+impl Default for ComputedUiRenderTargetInfo {
     fn default() -> Self {
         Self {
-            camera: Entity::PLACEHOLDER,
             scale_factor: 1.,
             physical_size: UVec2::ZERO,
         }
     }
 }
 
-impl ComputedUiTargetCamera {
-    /// Returns the id of the target camera for this UI node.
-    pub fn camera(&self) -> Option<Entity> {
-        Some(self.camera).filter(|&entity| entity != Entity::PLACEHOLDER)
-    }
-
+impl ComputedUiRenderTargetInfo {
     /// Returns the scale factor of the target camera's render target.
     pub const fn scale_factor(&self) -> f32 {
         self.scale_factor
@@ -2841,6 +2834,30 @@ impl ComputedUiTargetCamera {
     /// Returns the size of the target camera's viewport in logical pixels.
     pub fn logical_size(&self) -> Vec2 {
         self.physical_size.as_vec2() / self.scale_factor
+    }
+}
+
+/// Derived information about the camera target for this UI node.
+///
+/// Updated in [`UiSystems::Prepare`](crate::UiSystems::Prepare) by [`propagate_ui_target_cameras`](crate::update::propagate_ui_target_cameras)
+#[derive(Component, Clone, Copy, Debug, Reflect, PartialEq)]
+#[reflect(Component, Default, PartialEq, Clone)]
+pub struct ComputedUiTargetCamera {
+    pub(crate) camera: Entity,
+}
+
+impl Default for ComputedUiTargetCamera {
+    fn default() -> Self {
+        Self {
+            camera: Entity::PLACEHOLDER,
+        }
+    }
+}
+
+impl ComputedUiTargetCamera {
+    /// Returns the id of the target camera for this UI node.
+    pub fn camera(&self) -> Option<Entity> {
+        Some(self.camera).filter(|&entity| entity != Entity::PLACEHOLDER)
     }
 }
 

--- a/crates/bevy_ui/src/update.rs
+++ b/crates/bevy_ui/src/update.rs
@@ -235,9 +235,18 @@ mod tests {
             PostUpdate,
         ));
 
+        app.add_plugins(HierarchyPropagatePlugin::<ComputedUiRenderTargetInfo>::new(
+            PostUpdate,
+        ));
+
         app.configure_sets(
             PostUpdate,
             PropagateSet::<ComputedUiTargetCamera>::default(),
+        );
+
+        app.configure_sets(
+            PostUpdate,
+            PropagateSet::<ComputedUiRenderTargetInfo>::default(),
         );
 
         app.add_systems(

--- a/crates/bevy_ui/src/update.rs
+++ b/crates/bevy_ui/src/update.rs
@@ -3,8 +3,8 @@
 use crate::{
     experimental::{UiChildren, UiRootNodes},
     ui_transform::UiGlobalTransform,
-    CalculatedClip, ComputedUiTargetCamera, DefaultUiCamera, Display, Node, OverflowAxis,
-    OverrideClip, UiScale, UiTargetCamera,
+    CalculatedClip, ComputedUiRenderTargetInfo, ComputedUiTargetCamera, DefaultUiCamera, Display,
+    Node, OverflowAxis, OverrideClip, UiScale, UiTargetCamera,
 };
 
 use super::ComputedNode;
@@ -164,8 +164,8 @@ pub fn propagate_ui_target_cameras(
 
         commands
             .entity(root_entity)
-            .insert(Propagate(ComputedUiTargetCamera {
-                camera,
+            .insert(Propagate(ComputedUiTargetCamera { camera }))
+            .insert(Propagate(ComputedUiRenderTargetInfo {
                 scale_factor,
                 physical_size,
             }));
@@ -204,6 +204,7 @@ pub(crate) fn update_cameras_test_system(
 #[cfg(test)]
 mod tests {
     use crate::update::propagate_ui_target_cameras;
+    use crate::ComputedUiRenderTargetInfo;
     use crate::ComputedUiTargetCamera;
     use crate::IsDefaultUiCamera;
     use crate::Node;
@@ -268,7 +269,7 @@ mod tests {
             PrimaryWindow,
         ));
 
-        let camera = world.spawn(Camera2d).id();
+        // let camera = world.spawn(Camera2d).id();
 
         let uinode = world.spawn(Node::default()).id();
 
@@ -276,9 +277,8 @@ mod tests {
         let world = app.world_mut();
 
         assert_eq!(
-            *world.get::<ComputedUiTargetCamera>(uinode).unwrap(),
-            ComputedUiTargetCamera {
-                camera,
+            *world.get::<ComputedUiRenderTargetInfo>(uinode).unwrap(),
+            ComputedUiRenderTargetInfo {
                 physical_size,
                 scale_factor,
             }
@@ -341,8 +341,11 @@ mod tests {
         ] {
             assert_eq!(
                 *world.get::<ComputedUiTargetCamera>(uinode).unwrap(),
-                ComputedUiTargetCamera {
-                    camera,
+                ComputedUiTargetCamera { camera }
+            );
+            assert_eq!(
+                *world.get::<ComputedUiRenderTargetInfo>(uinode).unwrap(),
+                ComputedUiRenderTargetInfo {
                     scale_factor,
                     physical_size,
                 }
@@ -395,7 +398,7 @@ mod tests {
 
         assert_eq!(
             world
-                .get::<ComputedUiTargetCamera>(uinode)
+                .get::<ComputedUiRenderTargetInfo>(uinode)
                 .unwrap()
                 .scale_factor,
             scale1
@@ -403,7 +406,7 @@ mod tests {
 
         assert_eq!(
             world
-                .get::<ComputedUiTargetCamera>(uinode)
+                .get::<ComputedUiRenderTargetInfo>(uinode)
                 .unwrap()
                 .physical_size,
             size1
@@ -425,7 +428,7 @@ mod tests {
 
         assert_eq!(
             world
-                .get::<ComputedUiTargetCamera>(uinode)
+                .get::<ComputedUiRenderTargetInfo>(uinode)
                 .unwrap()
                 .scale_factor,
             scale2
@@ -433,7 +436,7 @@ mod tests {
 
         assert_eq!(
             world
-                .get::<ComputedUiTargetCamera>(uinode)
+                .get::<ComputedUiRenderTargetInfo>(uinode)
                 .unwrap()
                 .physical_size,
             size2
@@ -496,7 +499,7 @@ mod tests {
 
         assert_eq!(
             world
-                .get::<ComputedUiTargetCamera>(uinode1)
+                .get::<ComputedUiRenderTargetInfo>(uinode1)
                 .unwrap()
                 .scale_factor(),
             scale1
@@ -504,7 +507,7 @@ mod tests {
 
         assert_eq!(
             world
-                .get::<ComputedUiTargetCamera>(uinode1)
+                .get::<ComputedUiRenderTargetInfo>(uinode1)
                 .unwrap()
                 .physical_size(),
             size1
@@ -536,7 +539,7 @@ mod tests {
 
         assert_eq!(
             world
-                .get::<ComputedUiTargetCamera>(uinode1)
+                .get::<ComputedUiRenderTargetInfo>(uinode1)
                 .unwrap()
                 .scale_factor(),
             scale2
@@ -544,7 +547,7 @@ mod tests {
 
         assert_eq!(
             world
-                .get::<ComputedUiTargetCamera>(uinode1)
+                .get::<ComputedUiRenderTargetInfo>(uinode1)
                 .unwrap()
                 .physical_size(),
             size2
@@ -600,7 +603,7 @@ mod tests {
 
         assert_eq!(
             world
-                .get::<ComputedUiTargetCamera>(uinode)
+                .get::<ComputedUiRenderTargetInfo>(uinode)
                 .unwrap()
                 .scale_factor,
             scale
@@ -608,7 +611,7 @@ mod tests {
 
         assert_eq!(
             world
-                .get::<ComputedUiTargetCamera>(uinode)
+                .get::<ComputedUiRenderTargetInfo>(uinode)
                 .unwrap()
                 .physical_size,
             size
@@ -630,7 +633,7 @@ mod tests {
 
         assert_eq!(
             world
-                .get::<ComputedUiTargetCamera>(uinode)
+                .get::<ComputedUiRenderTargetInfo>(uinode)
                 .unwrap()
                 .scale_factor(),
             2.

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -1,4 +1,7 @@
-use crate::{ComputedUiTargetCamera, ContentSize, Measure, MeasureArgs, Node, NodeMeasure};
+use crate::{
+    ComputedUiRenderTargetInfo, ComputedUiTargetCamera, ContentSize, Measure, MeasureArgs, Node,
+    NodeMeasure,
+};
 use bevy_asset::{Assets, Handle};
 use bevy_color::Color;
 use bevy_ecs::prelude::*;
@@ -261,11 +264,14 @@ pub fn update_image_content_size_system(
             Ref<ImageNode>,
             &mut ImageNodeSize,
             Ref<ComputedUiTargetCamera>,
+            Ref<ComputedUiRenderTargetInfo>,
         ),
         UpdateImageFilter,
     >,
 ) {
-    for (mut content_size, image, mut image_size, computed_target) in &mut query {
+    for (mut content_size, image, mut image_size, computed_target, computed_target_info) in
+        &mut query
+    {
         if !matches!(image.image_mode, NodeImageMode::Auto)
             || image.image.id() == TRANSPARENT_IMAGE_HANDLE.id()
         {
@@ -290,7 +296,7 @@ pub fn update_image_content_size_system(
                 image_size.size = size;
                 content_size.set(NodeMeasure::Image(ImageMeasure {
                     // multiply the image size by the scale factor to get the physical size
-                    size: size.as_vec2() * computed_target.scale_factor(),
+                    size: size.as_vec2() * computed_target_info.scale_factor(),
                 }));
             }
         }

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -1,6 +1,6 @@
 use crate::{
-    ComputedNode, ComputedUiTargetCamera, ContentSize, FixedMeasure, Measure, MeasureArgs, Node,
-    NodeMeasure,
+    ComputedNode, ComputedUiRenderTargetInfo, ContentSize, FixedMeasure, Measure, MeasureArgs,
+    Node, NodeMeasure,
 };
 use bevy_asset::Assets;
 use bevy_color::Color;
@@ -276,7 +276,7 @@ pub fn measure_text_system(
             &mut ContentSize,
             &mut TextNodeFlags,
             &mut ComputedTextBlock,
-            &ComputedUiTargetCamera,
+            &ComputedUiRenderTargetInfo,
             &ComputedNode,
         ),
         With<Node>,
@@ -285,13 +285,14 @@ pub fn measure_text_system(
     mut text_pipeline: ResMut<TextPipeline>,
     mut font_system: ResMut<CosmicFontSystem>,
 ) {
-    for (entity, block, content_size, text_flags, computed, computed_target, computed_node) in
+    for (entity, block, content_size, text_flags, computed, computed_target_info, computed_node) in
         &mut text_query
     {
         // Note: the ComputedTextBlock::needs_rerender bool is cleared in create_text_measure().
         // 1e-5 epsilon to ignore tiny scale factor float errors
         if 1e-5
-            < (computed_target.scale_factor() - computed_node.inverse_scale_factor.recip()).abs()
+            < (computed_target_info.scale_factor() - computed_node.inverse_scale_factor.recip())
+                .abs()
             || computed.needs_rerender()
             || text_flags.needs_measure_fn
             || content_size.is_added()
@@ -299,7 +300,7 @@ pub fn measure_text_system(
             create_text_measure(
                 entity,
                 &fonts,
-                computed_target.scale_factor.into(),
+                computed_target_info.scale_factor.into(),
                 text_reader.iter(entity),
                 block,
                 &mut text_pipeline,

--- a/crates/bevy_ui_render/src/box_shadow.rs
+++ b/crates/bevy_ui_render/src/box_shadow.rs
@@ -28,8 +28,8 @@ use bevy_render::{
 use bevy_render::{RenderApp, RenderStartup};
 use bevy_shader::{Shader, ShaderDefVal};
 use bevy_ui::{
-    BoxShadow, CalculatedClip, ComputedNode, ComputedUiTargetCamera, ResolvedBorderRadius,
-    UiGlobalTransform, Val,
+    BoxShadow, CalculatedClip, ComputedNode, ComputedUiRenderTargetInfo, ComputedUiTargetCamera,
+    ResolvedBorderRadius, UiGlobalTransform, Val,
 };
 use bevy_utils::default;
 use bytemuck::{Pod, Zeroable};
@@ -224,13 +224,16 @@ pub fn extract_shadows(
             &BoxShadow,
             Option<&CalculatedClip>,
             &ComputedUiTargetCamera,
+            &ComputedUiRenderTargetInfo,
         )>,
     >,
     camera_map: Extract<UiCameraMap>,
 ) {
     let mut mapping = camera_map.get_mapper();
 
-    for (entity, uinode, transform, visibility, box_shadow, clip, camera) in &box_shadow_query {
+    for (entity, uinode, transform, visibility, box_shadow, clip, camera, render_target_info) in
+        &box_shadow_query
+    {
         // Skip if no visible shadows
         if !visibility.get() || box_shadow.is_empty() || uinode.is_empty() {
             continue;
@@ -240,7 +243,7 @@ pub fn extract_shadows(
             continue;
         };
 
-        let ui_physical_viewport_size = camera.physical_size().as_vec2();
+        let ui_physical_viewport_size = render_target_info.physical_size().as_vec2();
         let scale_factor = uinode.inverse_scale_factor.recip();
 
         for drop_shadow in box_shadow.iter() {

--- a/crates/bevy_ui_render/src/gradient.rs
+++ b/crates/bevy_ui_render/src/gradient.rs
@@ -34,8 +34,8 @@ use bevy_render::{sync_world::MainEntity, RenderStartup};
 use bevy_shader::Shader;
 use bevy_sprite::BorderRect;
 use bevy_ui::{
-    BackgroundGradient, BorderGradient, ColorStop, ConicGradient, Gradient,
-    InterpolationColorSpace, LinearGradient, RadialGradient, ResolvedBorderRadius, Val,
+    BackgroundGradient, BorderGradient, ColorStop, ComputedUiRenderTargetInfo, ConicGradient,
+    Gradient, InterpolationColorSpace, LinearGradient, RadialGradient, ResolvedBorderRadius, Val,
 };
 use bevy_utils::default;
 use bytemuck::{Pod, Zeroable};
@@ -353,6 +353,7 @@ pub fn extract_gradients(
             Entity,
             &ComputedNode,
             &ComputedUiTargetCamera,
+            &ComputedUiRenderTargetInfo,
             &UiGlobalTransform,
             &InheritedVisibility,
             Option<&CalculatedClip>,
@@ -368,6 +369,7 @@ pub fn extract_gradients(
         entity,
         uinode,
         target,
+        target_render_info,
         transform,
         inherited_visibility,
         clip,
@@ -436,9 +438,9 @@ pub fn extract_gradients(
 
                         compute_color_stops(
                             stops,
-                            target.scale_factor(),
+                            target_render_info.scale_factor(),
                             length,
-                            target.physical_size().as_vec2(),
+                            target_render_info.physical_size().as_vec2(),
                             &mut sorted_stops,
                             &mut extracted_color_stops.0,
                         );
@@ -469,16 +471,16 @@ pub fn extract_gradients(
                         stops,
                     }) => {
                         let c = center.resolve(
-                            target.scale_factor(),
+                            target_render_info.scale_factor(),
                             uinode.size,
-                            target.physical_size().as_vec2(),
+                            target_render_info.physical_size().as_vec2(),
                         );
 
                         let size = shape.resolve(
                             c,
-                            target.scale_factor(),
+                            target_render_info.scale_factor(),
                             uinode.size,
-                            target.physical_size().as_vec2(),
+                            target_render_info.physical_size().as_vec2(),
                         );
 
                         let length = size.x;
@@ -486,9 +488,9 @@ pub fn extract_gradients(
                         let range_start = extracted_color_stops.0.len();
                         compute_color_stops(
                             stops,
-                            target.scale_factor(),
+                            target_render_info.scale_factor(),
                             length,
-                            target.physical_size().as_vec2(),
+                            target_render_info.physical_size().as_vec2(),
                             &mut sorted_stops,
                             &mut extracted_color_stops.0,
                         );
@@ -519,9 +521,9 @@ pub fn extract_gradients(
                         stops,
                     }) => {
                         let g_start = center.resolve(
-                            target.scale_factor(),
+                            target_render_info.scale_factor(),
                             uinode.size,
-                            target.physical_size().as_vec2(),
+                            target_render_info.physical_size().as_vec2(),
                         );
                         let range_start = extracted_color_stops.0.len();
 


### PR DESCRIPTION
# Objective

The UI layout, text and widget systems don't need to know anything about camera targets and having to deal with cameras makes setting up tests a lot more complicated and fragile that it should be.

Fixes #20534.

## Solution

- Split off render target info from ComputedUiTargetCamera into a separate component ComputedUiRenderTargetInfo.
