### PR TITLE
Introduce Command::apply_raw

### DIFF
--- a/crates/bevy_ecs/src/system/commands/command.rs
+++ b/crates/bevy_ecs/src/system/commands/command.rs
@@ -4,6 +4,8 @@
 //! It also contains functions that return closures for use with
 //! [`Commands`](crate::system::Commands).
 
+use bevy_ptr::OwningPtr;
+
 use crate::{
     bundle::{Bundle, InsertMode, NoBundleEffect},
     change_detection::MaybeLocation,
@@ -16,6 +18,7 @@ use crate::{
     system::{IntoSystem, SystemId, SystemInput},
     world::{FromWorld, SpawnBatchIter, World},
 };
+use core::{mem, ptr::NonNull};
 
 /// A [`World`] mutation.
 ///
@@ -45,13 +48,31 @@ use crate::{
 ///     commands.queue(AddToCounter(42));
 /// }
 /// ```
-pub trait Command<Out = ()>: Send + 'static {
+pub trait Command<Out = ()>: Send + Sized + 'static {
     /// Applies this command, causing it to mutate the provided `world`.
     ///
     /// This method is used to define what a command "does" when it is ultimately applied.
     /// Because this method takes `self`, you can store data or settings on the type that implements this trait.
     /// This data is set by the system or other source of the command, and then ultimately read in this method.
     fn apply(self, world: &mut World) -> Out;
+
+    /// Applies this command, causing it to mutate the provided `world`.
+    ///
+    /// Identical to `Command::apply`, except it's only given a raw pointer to
+    /// a valid, but potentially unaligned, instance of `Self`.
+    ///
+    /// This function is reponsible for dropping the value pointed to by `ptr`.
+    ///
+    /// Implementing this function is optional and strictly an optimization.
+    ///
+    /// # Safety
+    /// `ptr` must point to a valid, but potentially unaligned instance of `Self`.
+    unsafe fn apply_raw(ptr: *mut Self, world: &mut World) -> Out {
+        // SAFETY: The safety invariants on this function require `ptr` to point to a valid
+        // but potentially unaligned instance of `Self`.
+        let command = unsafe { ptr.read_unaligned() };
+        command.apply(world)
+    }
 }
 
 impl<F, Out> Command<Out> for F
@@ -109,9 +130,41 @@ pub fn init_resource<R: Resource + FromWorld>() -> impl Command {
 /// A [`Command`] that inserts a [`Resource`] into the world.
 #[track_caller]
 pub fn insert_resource<R: Resource>(resource: R) -> impl Command {
-    let caller = MaybeLocation::caller();
-    move |world: &mut World| {
-        world.insert_resource_with_caller(resource, caller);
+    InsertResource {
+        resource,
+        caller: MaybeLocation::caller(),
+    }
+}
+
+struct InsertResource<T: Resource> {
+    resource: T,
+    caller: MaybeLocation,
+}
+
+impl<T: Resource> Command for InsertResource<T> {
+    fn apply(mut self, world: &mut World) {
+        // SAFETY: This is being called with a mutable borrow, which must be a valid pointer.
+        unsafe { Self::apply_raw(&mut self, world) }
+    }
+
+    unsafe fn apply_raw(ptr: *mut Self, world: &mut World) {
+        let id = world.components_registrator().register_resource::<T>();
+        // SAFETY: The caller must ensure that `ptr` is a valid instance of `Self`, so getting the
+        // pointer to the provided resource should be valid and non-null.
+        let value_ptr = unsafe {
+            NonNull::new_unchecked(
+                ptr.byte_add(mem::offset_of!(InsertResource<T>, resource))
+                    .cast::<u8>(),
+            )
+        };
+        // SAFETY: The caller must ensure that `ptr` is a valid instance of `Self`, so getting the
+        // pointer to the provided caller location should be valid.
+        let caller = unsafe {
+            ptr.byte_add(mem::offset_of!(InsertResource<T>, caller))
+                .cast::<MaybeLocation>()
+                .read_unaligned()
+        };
+        unsafe { world.insert_resource_by_id(id, OwningPtr::new(value_ptr), caller) }
     }
 }
 

--- a/crates/bevy_ecs/src/system/commands/entity_command.rs
+++ b/crates/bevy_ecs/src/system/commands/entity_command.rs
@@ -78,7 +78,7 @@ use bevy_ptr::OwningPtr;
 ///     assert_eq!(names, HashSet::from_iter(["Entity #0", "Entity #1"]));
 /// }
 /// ```
-pub trait EntityCommand<Out = ()>: Send + 'static {
+pub trait EntityCommand<Out = ()>: Send + Sized + 'static {
     /// Executes this command for the given [`Entity`].
     fn apply(self, entity: EntityWorldMut) -> Out;
 }

--- a/crates/bevy_ecs/src/world/command_queue.rs
+++ b/crates/bevy_ecs/src/world/command_queue.rs
@@ -8,7 +8,7 @@ use core::{
     fmt::Debug,
     mem::{size_of, MaybeUninit},
     panic::AssertUnwindSafe,
-    ptr::{addr_of_mut, NonNull},
+    ptr::{self, addr_of_mut, NonNull},
 };
 use log::warn;
 
@@ -164,20 +164,29 @@ impl RawCommandQueue {
 
                 // SAFETY: According to the invariants of `CommandMeta.consume_command_and_get_size`,
                 // `command` must point to a value of type `C`.
-                let command: C = unsafe { command.read_unaligned() };
+                let command: *mut C = command.as_ptr().cast();
                 match world {
                     // Apply command to the provided world...
                     Some(mut world) => {
                         // SAFETY: Caller ensures pointer is not null
                         let world = unsafe { world.as_mut() };
-                        command.apply(world);
+                        // SAFETY: According to the invariants of `CommandMeta.consume_command_and_get_size`,
+                        // `command` must point to a value of type `C`, and thus cannot be null. It is also OK for `command`
+                        // to be unaligned.
+                        C::apply_raw(command, world);
                         // The command may have queued up world commands, which we flush here to ensure they are also picked up.
                         // If the current command queue already the World Command queue, this will still behave appropriately because the global cursor
                         // is still at the current `stop`, ensuring only the newly queued Commands will be applied.
                         world.flush();
                     }
                     // ...or discard it.
-                    None => drop(command),
+                    None => {
+                        if command.is_aligned() {
+                            ptr::drop_in_place(command);
+                        } else {
+                            drop(command.read_unaligned())
+                        }
+                    }
                 }
             },
         };


### PR DESCRIPTION
# Objective
Partially address #20420. Command application currently requires a `ptr::read_unaligned` call ,which read a complete copy of the command onto the stack before applying it to the World. This require quite a bit of extra memory read and written when the bundle or resource is otherwise very large, particularly if that memory is just going to be moved into the `World` anyway.

## Solution
Add a new function to `Command` called `apply_raw` that takes the unaligned pointer provided by `CommandQueue`. Provide a default implementation for it using `Command::apply`. Rework `(Raw)CommandQueue::push` to work in terms of `apply_raw`. 

This is an optional optimization and does not always need to be implemented by all `Command` types, just those likely to move a large amount of memory around.

An example of how to evade this extra copy was implemented for `insert_resource`, where the relevant metadata was pulled via `read_unaligned`, but the unaligned resource stored in the command was directly fed to `World::insert_resource_by_id` to skip the stack copy. 

This unfortunately means we cannot use closure based Commands for these command types, but thankfully the number of performance sensitive commands like these is fairly low, and the concrete types do not need to be exposed as a public part of the interface.

TODO:

 - [ ] Implement this extension for `EntityCommands`, specifically `EntityCommands::insert` and friends.
 - [ ] Benchmark

## Testing
Ran bevy_ecs tests and miri.