### PR TITLE
Make sure we submit work even if we visited a camera.

### DIFF
--- a/crates/bevy_render/src/render_graph/camera_driver_node.rs
+++ b/crates/bevy_render/src/render_graph/camera_driver_node.rs
@@ -63,7 +63,7 @@ impl Node for CameraDriverNode {
         // wgpu (and some backends) require doing work for swap chains if you call `get_current_texture()` and `present()`
         // This ensures that Bevy doesn't crash, even when there are no cameras (and therefore no work submitted).
         for (id, window) in world.resource::<ExtractedWindows>().iter() {
-            if camera_windows.contains(id) {
+            if camera_windows.contains(id) && render_context.has_commands() {
                 continue;
             }
 

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -509,8 +509,8 @@ impl<'w> RenderContext<'w> {
         })
     }
 
-    pub fn has_commands(&mut self) -> bool {
-        self.command_encoder.is_some()
+    pub(crate) fn has_commands(&mut self) -> bool {
+        self.command_encoder.is_some() && !self.command_buffer_queue.is_empty()
     }
 
     /// Creates a new [`TrackedRenderPass`] for the context,

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -509,6 +509,10 @@ impl<'w> RenderContext<'w> {
         })
     }
 
+    pub fn has_commands(&mut self) -> bool {
+        self.command_encoder.is_some()
+    }
+
     /// Creates a new [`TrackedRenderPass`] for the context,
     /// configured using the provided `descriptor`.
     pub fn begin_tracked_render_pass<'a>(

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -510,7 +510,7 @@ impl<'w> RenderContext<'w> {
     }
 
     pub(crate) fn has_commands(&mut self) -> bool {
-        self.command_encoder.is_some() && !self.command_buffer_queue.is_empty()
+        self.command_encoder.is_some() || !self.command_buffer_queue.is_empty()
     }
 
     /// Creates a new [`TrackedRenderPass`] for the context,


### PR DESCRIPTION
Alternative fix to #20318. We have existing code making sure that we do work on a swapchain in `CameraDriverNode`. However, it's only protecting against the case where we have no cameras spawned. We also need to check that we actually did any rendering work, even if we have cameras in the scene.

Tested on macOS.