### PR TITLE
Update the list of `RenderStartup` PRs in the release notes.

### DIFF
--- a/release-content/migration-guides/render_startup.md
+++ b/release-content/migration-guides/render_startup.md
@@ -1,6 +1,6 @@
 ---
 title: Many render resources now initialized in `RenderStartup`
-pull_requests: [19841, 19926, 19885, 19886, 19897, 19898, 19901, 20002, 20147]
+pull_requests: [19841, 19885, 19886, 19897, 19898, 19901, 19912, 19926, 19999, 20002, 20024, 20124, 20147, 20184, 20194, 20195, 20208, 20209, 20210]
 ---
 
 Many render resources are **no longer present** during `Plugin::finish`. Instead they are

--- a/release-content/release-notes/render_startup.md
+++ b/release-content/release-notes/render_startup.md
@@ -1,7 +1,7 @@
 ---
 title: "`RenderStartup` and making the renderer my ECS-y"
 authors: ["@IceSentry", "@andriyDev"]
-pull_requests: [19841, 19926, 19885, 19886, 19897, 19898, 19901]
+pull_requests: [19841, 19885, 19886, 19897, 19898, 19901, 19912, 19926, 19999, 20002, 20024, 20124, 20147, 20184, 20194, 20195, 20208, 20209, 20210]
 ---
 
 Previous rendering code looked quite different from other Bevy code. In general, resources were


### PR DESCRIPTION
I stopped updating it since it was causing merge conflicts, but now everything's frozen so it's a good time.