### PR TITLE
Remove unnecessary sqrt ops

### DIFF
--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -1297,14 +1297,16 @@ impl Triangle3d {
         let ca = a - c;
 
         let mut largest_side_points = (a, b);
-        let mut largest_side_length = ab.length();
+        let mut largest_side_length = ab.length_squared();
 
-        if bc.length() > largest_side_length {
+        let bc_length = bc.length_squared();
+        if bc_length > largest_side_length {
             largest_side_points = (b, c);
-            largest_side_length = bc.length();
+            largest_side_length = bc_length;
         }
 
-        if ca.length() > largest_side_length {
+        let ca_length = ca.length_squared();
+        if ca_length > largest_side_length {
             largest_side_points = (a, c);
         }
 


### PR DESCRIPTION
# Objective

Remove unnecessary use of `Vec3::length` in favour of `Vec3::length_squared` where the precise length isn't needed in `Triangle3d::largest_side`.

## Testing

Ran `cargo test -p bevy_math`.

## Showcase

Benching showed a -18% change.

```rust
c.bench_function(bench!("Triangle3d::largest_side"), |b| {
    b.iter(|| black_box(Triangle3d::default()).largest_side())
});
```
Before
```
math::dim3::Triangle3d::largest_side
                        time:   [3.2933 ns 3.2965 ns 3.3002 ns]
```
After
```
math::dim3::Triangle3d::largest_side
                        time:   [2.7029 ns 2.7087 ns 2.7157 ns]
                        change: [−18.158% −17.981% −17.801%] (p = 0.00 < 0.05)
                        Performance has improved.
```
