### PR TITLE
Fix glTF coordinate conversion not converting mesh bounds

### DIFF
--- a/crates/bevy_gltf/src/loader/mod.rs
+++ b/crates/bevy_gltf/src/loader/mod.rs
@@ -1539,10 +1539,19 @@ fn load_node(
                     // > the accessors of the original primitive.
                     mesh_entity.insert(MeshMorphWeights::new(weights).unwrap());
                 }
-                mesh_entity.insert(Aabb::from_min_max(
-                    Vec3::from_slice(&bounds.min),
-                    Vec3::from_slice(&bounds.max),
-                ));
+
+                let mut bounds_min = Vec3::from_slice(&bounds.min);
+                let mut bounds_max = Vec3::from_slice(&bounds.max);
+
+                if convert_coordinates {
+                    let converted_min = bounds_min.convert_coordinates();
+                    let converted_max = bounds_max.convert_coordinates();
+
+                    bounds_min = converted_min.min(converted_max);
+                    bounds_max = converted_min.max(converted_max);
+                }
+
+                mesh_entity.insert(Aabb::from_min_max(bounds_min, bounds_max));
 
                 if let Some(extras) = primitive.extras() {
                     mesh_entity.insert(GltfExtras {


### PR DESCRIPTION
glTF coordinate conversion is applied to mesh assets, but not their bounds:

<img width="1602" height="939" alt="image" src="https://github.com/user-attachments/assets/8eb82e38-309c-446b-8999-4edc1e98b193" />

After the fix:

<img width="1602" height="939" alt="image" src="https://github.com/user-attachments/assets/966344ac-bca5-4020-95d2-878ed141601d" />

## Testing

Tested using a new `scene_viewer` option that I'll file in a separate PR.

```sh
cargo run --example scene_viewer -- "assets/models/faces/faces.glb" --use-model-forward-direction
```
