### PR TITLE
Fix some more lints

### DIFF
--- a/crates/bevy_feathers/src/cursor.rs
+++ b/crates/bevy_feathers/src/cursor.rs
@@ -51,12 +51,14 @@ impl EntityCursor {
     /// Compare the [`EntityCursor`] to a [`CursorIcon`] so that we can see whether or not
     /// the window cursor needs to be changed.
     pub fn eq_cursor_icon(&self, cursor_icon: &CursorIcon) -> bool {
-        match (self, cursor_icon) {
+        // If feature custom_cursor is not enabled in bevy_features, we can't know if it is or not
+        // in bevy_window. So we use the wrapper function `as_system` to let bevy_window check its own feature.
+        // Otherwise it is not possible to have a match that both covers all cases and doesn't have unreachable
+        // branches under all feature combinations.
+        match (self, cursor_icon, cursor_icon.as_system()) {
             #[cfg(feature = "custom_cursor")]
-            (EntityCursor::Custom(custom), CursorIcon::Custom(other)) => custom == other,
-            (EntityCursor::System(system), CursorIcon::System(cursor_icon)) => {
-                *system == *cursor_icon
-            }
+            (EntityCursor::Custom(custom), CursorIcon::Custom(other), _) => custom == other,
+            (EntityCursor::System(system), _, Some(cursor_icon)) => *system == *cursor_icon,
             _ => false,
         }
     }

--- a/crates/bevy_window/src/cursor/mod.rs
+++ b/crates/bevy_window/src/cursor/mod.rs
@@ -36,3 +36,22 @@ impl From<SystemCursorIcon> for CursorIcon {
         CursorIcon::System(icon)
     }
 }
+
+impl CursorIcon {
+    /// Returns the system cursor icon if this is a system cursor.
+    pub fn as_system(&self) -> Option<&SystemCursorIcon> {
+        #[cfg(feature = "custom_cursor")]
+        {
+            return if let CursorIcon::System(icon) = self {
+                Some(icon)
+            } else {
+                None
+            };
+        }
+        #[cfg(not(feature = "custom_cursor"))]
+        {
+            let CursorIcon::System(icon) = self;
+            return Some(icon);
+        }
+    }
+}


### PR DESCRIPTION
# Objective

- Fix some more lints
- run `cargo build --no-default-features --features bluenoise_texture` without triggering a lint for unused variables
- build bevy_feathers with all combinations of feature flag on cursor without complaints about the match:
  - `cargo check -p bevy_feathers`
  - `cargo check -p bevy_feathers --features custom_cursor`
  - `cargo check -p bevy_feathers --features bevy_window/custom_cursor`

## Solution

- fix the lints
