### PR TITLE
Add caution to glTF coordinate conversion docs and release notes

### DIFF
--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -159,6 +159,8 @@ pub struct GltfPlugin {
     /// Can be modified with the [`DefaultGltfImageSampler`] resource.
     pub default_sampler: ImageSamplerDescriptor,
 
+    /// _CAUTION: This is an experimental feature with [known issues](https://github.com/bevyengine/bevy/issues/20621). Behavior may change in future versions._
+    ///
     /// How to convert glTF coordinates on import. Assuming glTF cameras, glTF lights, and glTF meshes had global identity transforms,
     /// their Bevy [`Transform::forward`](bevy_transform::components::Transform::forward) will be pointing in the following global directions:
     /// - When set to `false`

--- a/crates/bevy_gltf/src/loader/mod.rs
+++ b/crates/bevy_gltf/src/loader/mod.rs
@@ -199,6 +199,8 @@ pub struct GltfLoaderSettings {
     pub default_sampler: Option<ImageSamplerDescriptor>,
     /// If true, the loader will ignore sampler data from gltf and use the default sampler.
     pub override_sampler: bool,
+    /// _CAUTION: This is an experimental feature with [known issues](https://github.com/bevyengine/bevy/issues/20621). Behavior may change in future versions._
+    ///
     /// How to convert glTF coordinates on import. Assuming glTF cameras, glTF lights, and glTF meshes had global unit transforms,
     /// their Bevy [`Transform::forward`](bevy_transform::components::Transform::forward) will be pointing in the following global directions:
     /// - When set to `false`

--- a/release-content/release-notes/convert-coordinates.md
+++ b/release-content/release-notes/convert-coordinates.md
@@ -4,6 +4,8 @@ authors: ["@janhohenheim"]
 pull_requests: [19633, 19685, 19816, 20131, 20122]
 ---
 
+_CAUTION: This is an experimental feature with [known issues](https://github.com/bevyengine/bevy/issues/20621). Behavior may change in future versions._
+
 Bevy uses the following coordinate system for all worldspace entities that have a `Transform`:
 
 - forward: -Z


### PR DESCRIPTION
glTF coordinate conversion is new in 0.17 and desirable for some users. But it has known issues (#20621), and future versions might have breaking changes. This PR adds some cautionary notes.

> _CAUTION: This is an experimental feature with [known issues](https://github.com/bevyengine/bevy/issues/20621). Behavior may change in future versions._