### PR TITLE
bevy_reflect gating / better compile error message

### DIFF
--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -740,6 +740,14 @@ pub mod __macro_exports {
     pub mod auto_register {
         pub use super::*;
 
+        #[cfg(all(
+            not(feature = "auto_register_inventory"),
+            not(feature = "auto_register_static")
+        ))]
+        compile_error!(
+            "Choosing a backend is required for automatic reflect registration. Please enable either the \"auto_register_inventory\" or the \"auto_register_static\" feature."
+        );
+
         /// inventory impl
         #[cfg(all(
             not(feature = "auto_register_static"),

--- a/crates/bevy_window/src/cursor/custom_cursor.rs
+++ b/crates/bevy_window/src/cursor/custom_cursor.rs
@@ -3,11 +3,17 @@ use alloc::string::String;
 use bevy_asset::Handle;
 use bevy_image::{Image, TextureAtlas};
 use bevy_math::URect;
+
+#[cfg(feature = "bevy_reflect")]
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 
 /// A custom cursor created from an image.
-#[derive(Debug, Clone, Default, Reflect, PartialEq, Eq, Hash)]
-#[reflect(Debug, Default, Hash, PartialEq, Clone)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "bevy_reflect",
+    derive(Reflect),
+    reflect(Debug, Default, Hash, PartialEq, Clone)
+)]
 pub struct CustomCursorImage {
     /// Handle to the image to use as the cursor. The image must be in 8 bit int
     /// or 32 bit float rgba. PNG images work well for this.
@@ -41,8 +47,12 @@ pub struct CustomCursorImage {
 }
 
 /// A custom cursor created from a URL. Note that this currently only works on the web.
-#[derive(Debug, Clone, Default, Reflect, PartialEq, Eq, Hash)]
-#[reflect(Debug, Default, Hash, PartialEq, Clone)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "bevy_reflect",
+    derive(Reflect),
+    reflect(Debug, Default, Hash, PartialEq, Clone)
+)]
 pub struct CustomCursorUrl {
     /// Web URL to an image to use as the cursor. PNGs are preferred. Cursor
     /// creation can fail if the image is invalid or not reachable.
@@ -53,8 +63,12 @@ pub struct CustomCursorUrl {
 }
 
 /// Custom cursor image data.
-#[derive(Debug, Clone, Reflect, PartialEq, Eq, Hash)]
-#[reflect(Clone, PartialEq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "bevy_reflect",
+    derive(Reflect),
+    reflect(Clone, PartialEq, Hash)
+)]
 pub enum CustomCursor {
     /// Use an image as the cursor.
     Image(CustomCursorImage),

--- a/crates/bevy_window/src/cursor/mod.rs
+++ b/crates/bevy_window/src/cursor/mod.rs
@@ -9,14 +9,20 @@ pub use custom_cursor::*;
 pub use system_cursor::*;
 
 use bevy_ecs::{component::Component, reflect::ReflectComponent};
+#[cfg(feature = "bevy_reflect")]
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 
 #[cfg(feature = "custom_cursor")]
 pub use crate::cursor::{CustomCursor, CustomCursorImage};
 
 /// Insert into a window entity to set the cursor for that window.
-#[derive(Component, Debug, Clone, Reflect, PartialEq, Eq)]
-#[reflect(Component, Debug, Default, PartialEq, Clone)]
+#[derive(Component, Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "bevy_reflect",
+    derive(Reflect),
+    reflect(Component, Debug, Default, PartialEq, Clone)
+)]
+
 pub enum CursorIcon {
     #[cfg(feature = "custom_cursor")]
     /// Custom cursor image.


### PR DESCRIPTION
# Objective

- next batch of compile issues
- I think that's the last for now... until we add more

## Solution

- gate bevy_reflect properly in bevy_window
- improve compile error when auto_register is enabled but not "*_inventory" or "*_static" is. Error is currently:
```
error[E0425]: cannot find function `register_types` in module `crate::__macro_exports::auto_register`
   --> crates/bevy_reflect/src/type_registry.rs:158:48
    |
158 |         crate::__macro_exports::auto_register::register_types(self);
    |                                                ^^^^^^^^^^^^^^ not found in `crate::__macro_exports::auto_register`
```

