### PR TITLE
Make failing `invalid_params` tests less fragile

### DIFF
--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -533,7 +533,15 @@ mod tests {
         let result = world.run_system_once(system);
 
         assert!(matches!(result, Err(RunSystemError::Failed { .. })));
-        let expected = "Parameter `Res<T>` failed validation: Resource does not exist\n";
-        assert!(result.unwrap_err().to_string().contains(expected));
+
+        let expected = "Resource does not exist";
+        let actual = result.unwrap_err().to_string();
+
+        assert!(
+            actual.contains(expected),
+            "Expected error message to contain `{}` but got `{}`",
+            expected,
+            actual
+        );
     }
 }

--- a/crates/bevy_ecs/src/system/system_registry.rs
+++ b/crates/bevy_ecs/src/system/system_registry.rs
@@ -1005,8 +1005,15 @@ mod tests {
         let result = world.run_system(id);
 
         assert!(matches!(result, Err(RegisteredSystemError::Failed { .. })));
-        let expected = "System returned error: Parameter `Res<T>` failed validation: Resource does not exist\n";
-        assert!(result.unwrap_err().to_string().contains(expected));
+        let expected = "Resource does not exist";
+        let actual = result.unwrap_err().to_string();
+
+        assert!(
+            actual.contains(expected),
+            "Expected error message to contain `{}` but got `{}`",
+            expected,
+            actual
+        );
     }
 
     #[test]


### PR DESCRIPTION
# Objective

- These tests [were failing](https://github.com/bevyengine/bevy/actions/runs/17029621247/job/48269977564?pr=20628) in #20628 by @atlv24.
- They seem pointlessly fragile.

## Solution

- Made sure nothing freaky was going on: the failure mode was as expected.
- Make the tests less fragile.

## Testing

I've ran both tests locally and they failed before and now pass.


## Notes to reviewers

I am not sure why this is suddenly failing in CI, but this is a better way to write the tests anyways so 🤷🏽 