### PR TITLE
Regression tests for observers whose Observer component is removed.

### DIFF
--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -1396,4 +1396,48 @@ mod tests {
         world.trigger_targets(EventA, [entities[2], entities[3]]);
         assert_eq!(vec!["a", "a"], world.resource::<Order>().0);
     }
+
+    #[test]
+    fn unregister_global_observer() {
+        let mut world = World::new();
+        let mut observer = world.add_observer(|_: On<EventA>| {});
+        observer.remove::<Observer>();
+        let id = observer.id();
+        let event_key = EventA::event_key(&world).unwrap();
+        assert!(!world
+            .observers
+            .get_observers_mut(event_key)
+            .global_observers
+            .contains_key(&id));
+    }
+
+    #[test]
+    fn unregister_entity_observer() {
+        let mut world = World::new();
+        let entity = world.spawn_empty().id();
+        let observer = Observer::new(|_: On<EventA>| {}).with_entity(entity);
+        let mut observer = world.spawn(observer);
+        observer.remove::<Observer>();
+        let event_key = EventA::event_key(&world).unwrap();
+        assert!(!world
+            .observers
+            .get_observers_mut(event_key)
+            .entity_observers
+            .contains_key(&entity));
+    }
+
+    #[test]
+    fn unregister_component_observer() {
+        let mut world = World::new();
+        let a = world.register_component::<A>();
+        let observer = Observer::new(|_: On<EventA>| {}).with_component(a);
+        let mut observer = world.spawn(observer);
+        observer.remove::<Observer>();
+        let event_key = EventA::event_key(&world).unwrap();
+        assert!(!world
+            .observers
+            .get_observers_mut(event_key)
+            .get_component_observers()
+            .contains_key(&a));
+    }
 }


### PR DESCRIPTION
Regression test of #19673 .

The issue above has been fixed by the observer overhaul. This PR adds the regression tests.