### PR TITLE
Prevent infinite loop during BLAS compaction

### DIFF
--- a/crates/bevy_solari/src/scene/blas.rs
+++ b/crates/bevy_solari/src/scene/blas.rs
@@ -105,16 +105,18 @@ pub fn compact_raytracing_blas(
     mut blas_manager: ResMut<BlasManager>,
     render_queue: Res<RenderQueue>,
 ) {
-    let mut i = 0;
-    let queue_len = blas_manager.compaction_queue.len();
-
+    let queue_size = blas_manager.compaction_queue.len();
+    let mut meshes_processed = 0;
     let mut vertices_compacted = 0;
-    while let Some((mesh, vertex_count, compaction_started)) =
-        blas_manager.compaction_queue.pop_front()
+
+    while !blas_manager.compaction_queue.is_empty()
         && vertices_compacted < MAX_COMPACTION_VERTICES_PER_FRAME
-        && i < queue_len
+        && meshes_processed < queue_size
     {
-        i += 1;
+        meshes_processed += 1;
+
+        let (mesh, vertex_count, compaction_started) =
+            blas_manager.compaction_queue.pop_front().unwrap();
 
         let Some(blas) = blas_manager.get(&mesh) else {
             continue;

--- a/crates/bevy_solari/src/scene/blas.rs
+++ b/crates/bevy_solari/src/scene/blas.rs
@@ -105,20 +105,16 @@ pub fn compact_raytracing_blas(
     mut blas_manager: ResMut<BlasManager>,
     render_queue: Res<RenderQueue>,
 ) {
-    let mut first_mesh_processed = None;
+    let mut i = 0;
+    let queue_len = blas_manager.compaction_queue.len();
 
     let mut vertices_compacted = 0;
-    while vertices_compacted < MAX_COMPACTION_VERTICES_PER_FRAME
-        && let Some((mesh, vertex_count, compaction_started)) =
-            blas_manager.compaction_queue.pop_front()
+    while let Some((mesh, vertex_count, compaction_started)) =
+        blas_manager.compaction_queue.pop_front()
+        && vertices_compacted < MAX_COMPACTION_VERTICES_PER_FRAME
+        && i < queue_len
     {
-        // Stop iterating once we loop back around to the start of the list
-        if Some(mesh) == first_mesh_processed {
-            break;
-        }
-        if first_mesh_processed.is_none() {
-            first_mesh_processed = Some(mesh);
-        }
+        i += 1;
 
         let Some(blas) = blas_manager.get(&mesh) else {
             continue;

--- a/release-content/release-notes/bevy_solari.md
+++ b/release-content/release-notes/bevy_solari.md
@@ -1,7 +1,7 @@
 ---
 title: Initial raytraced lighting progress (bevy_solari)
 authors: ["@JMS55", "@SparkyPotato"]
-pull_requests: [19058, 19620, 19790, 20020, 20113, 20156, 20213, 20242, 20259, 20406, 20457, 20580, 20596, 20622]
+pull_requests: [19058, 19620, 19790, 20020, 20113, 20156, 20213, 20242, 20259, 20406, 20457, 20580, 20596, 20622, 20659]
 ---
 
 ## Overview


### PR DESCRIPTION
Not sure why exactly this was happening, but the old logic I was using to prevent checking BLAS compaction status more than once per system run wasn't working. This fixes that.