### PR TITLE
Fix a comment error in example system_stepping.rs

### DIFF
--- a/examples/ecs/system_stepping.rs
+++ b/examples/ecs/system_stepping.rs
@@ -151,7 +151,7 @@ fn main() {
              they form a chained dependency on update_system_one() and run
              in order of one, two, three.  Stepping stops system execution in
              the Update schedule when it encounters the breakpoint for
-             update_system_three().
+             update_system_two().
              During the step we run update_system_two() along with the
              pre_update_system().
              During the final continue pre_update_system() and


### PR DESCRIPTION
# Objective

Examples ECS system_stepping.rs :

```rust
  println!(
      r#"
           ....................................
           in order of one, two, three.  Stepping stops system execution in
           the Update schedule when it encounters the breakpoint for
           update_system_three(). // <------
           ................."#
  );
  let mut stepping = app.world_mut().resource_mut::<Stepping>();
  stepping.set_breakpoint(Update, update_system_two); // <------
  stepping.continue_frame();
  app.update();
  ....................
```

I think this should be "breakpoint for update_system_two()." instead of "breakpoint for update_system_three().".

## Solution

Change `update_system_three` to `update_system_two` in `println!` .

## Testing

Only modified one comment, not tested.
