### PR TITLE
casted -> cast and downcasted -> downcast spelling.

### DIFF
--- a/crates/bevy_ecs/src/entity/unique_slice.rs
+++ b/crates/bevy_ecs/src/entity/unique_slice.rs
@@ -913,7 +913,7 @@ pub const unsafe fn from_raw_parts_mut<'a, T: EntityEquivalent>(
 ///
 /// # Safety
 ///
-/// All elements in each of the casted slices must be unique.
+/// All elements in each of the cast slices must be unique.
 pub unsafe fn cast_slice_of_unique_entity_slice<'a, 'b, T: EntityEquivalent + 'a>(
     slice: &'b [&'a [T]],
 ) -> &'b [&'a UniqueEntityEquivalentSlice<T>] {
@@ -925,7 +925,7 @@ pub unsafe fn cast_slice_of_unique_entity_slice<'a, 'b, T: EntityEquivalent + 'a
 ///
 /// # Safety
 ///
-/// All elements in each of the casted slices must be unique.
+/// All elements in each of the cast slices must be unique.
 pub unsafe fn cast_slice_of_unique_entity_slice_mut<'a, 'b, T: EntityEquivalent + 'a>(
     slice: &'b mut [&'a [T]],
 ) -> &'b mut [&'a UniqueEntityEquivalentSlice<T>] {
@@ -937,7 +937,7 @@ pub unsafe fn cast_slice_of_unique_entity_slice_mut<'a, 'b, T: EntityEquivalent 
 ///
 /// # Safety
 ///
-/// All elements in each of the casted slices must be unique.
+/// All elements in each of the cast slices must be unique.
 pub unsafe fn cast_slice_of_mut_unique_entity_slice_mut<'a, 'b, T: EntityEquivalent + 'a>(
     slice: &'b mut [&'a mut [T]],
 ) -> &'b mut [&'a mut UniqueEntityEquivalentSlice<T>] {

--- a/crates/bevy_picking/src/backend.rs
+++ b/crates/bevy_picking/src/backend.rs
@@ -99,7 +99,7 @@ impl PointerHits {
 #[reflect(Clone, PartialEq)]
 pub struct HitData {
     /// The camera entity used to detect this hit. Useful when you need to find the ray that was
-    /// casted for this hit when using a raycasting backend.
+    /// cast for this hit when using a raycasting backend.
     pub camera: Entity,
     /// `depth` only needs to be self-consistent with other [`PointerHits`]s using the same
     /// [`RenderTarget`](bevy_camera::RenderTarget). However, it is recommended to use the

--- a/crates/bevy_picking/src/mesh_picking/ray_cast/mod.rs
+++ b/crates/bevy_picking/src/mesh_picking/ray_cast/mod.rs
@@ -27,7 +27,7 @@ use tracing::*;
 #[derive(Clone, Copy, Reflect)]
 #[reflect(Clone)]
 pub enum RayCastVisibility {
-    /// Completely ignore visibility checks. Hidden items can still be ray casted against.
+    /// Completely ignore visibility checks. Hidden items can still be ray cast against.
     Any,
     /// Only cast rays against entities that are visible in the hierarchy. See [`Visibility`](bevy_camera::visibility::Visibility).
     Visible,

--- a/crates/bevy_reflect/README.md
+++ b/crates/bevy_reflect/README.md
@@ -160,7 +160,7 @@ println!("{}", my_trait.do_thing());
 
 // This works because the #[reflect(MyTrait)] we put on MyType informed the Reflect derive to insert a new instance
 // of ReflectDoThing into MyType's registration. The instance knows how to cast &dyn Reflect to &dyn DoThing, because it
-// knows that &dyn Reflect should first be downcasted to &MyType, which can then be safely casted to &dyn DoThing
+// knows that &dyn Reflect should first be downcast to &MyType, which can then be safely cast to &dyn DoThing
 ```
 
 ## Why make this?

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -59,7 +59,7 @@
 //!   This means values implementing `PartialReflect` can be dynamically constructed and introspected.
 //! * The `Reflect` trait, however, ensures that the interface exposed by `PartialReflect`
 //!   on types which additionally implement `Reflect` mirrors the structure of a single Rust type.
-//! * This means `dyn Reflect` trait objects can be directly downcasted to concrete types,
+//! * This means `dyn Reflect` trait objects can be directly downcast to concrete types,
 //!   where `dyn PartialReflect` trait object cannot.
 //! * `Reflect`, since it provides a stronger type-correctness guarantee,
 //!   is the trait used to interact with [the type registry].

--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -546,9 +546,9 @@ impl dyn Reflect {
     /// otherwise.
     ///
     /// The underlying value is the concrete type that is stored in this `dyn` object;
-    /// it can be downcasted to. In the case that this underlying value "represents"
+    /// it can be downcast to. In the case that this underlying value "represents"
     /// a different type, like the Dynamic\*\*\* types do, you can call `represents`
-    /// to determine what type they represent. Represented types cannot be downcasted
+    /// to determine what type they represent. Represented types cannot be downcast
     /// to, but you can use [`FromReflect`] to create a value of the represented type from them.
     ///
     /// For remote types, `T` should be the type itself rather than the wrapper type.


### PR DESCRIPTION
# Objective

correct spelling of `cast` and `downcast` (past tense).
the incorrect spelling `casted` and `downcasted` appears a few times in comments and doc, notably 
https://dev-docs.bevy.org/bevy/prelude/trait.Reflect.html#method.is
https://dev-docs.bevy.org/bevy/picking/backend/struct.HitData.html#structfield.camera
https://dev-docs.bevy.org/bevy/picking/mesh_picking/ray_cast/enum.RayCastVisibility.html#variant.Any

## Solution

`rg 'casted'` in project root
`s/casted/cast/g`

## Testing

This affects comments and doc-comments only.
