### PR TITLE
Fix world_to_ndc

### DIFF
--- a/crates/bevy_camera/src/camera.rs
+++ b/crates/bevy_camera/src/camera.rs
@@ -704,11 +704,8 @@ impl Camera {
         camera_transform: &GlobalTransform,
         world_point: V,
     ) -> Option<V> {
-        // Build a transformation matrix to convert from world space to NDC using camera data
-        let view_point = camera_transform
-            .affine()
-            .inverse()
-            .transform_point3a(world_point.into());
+        let view_from_world = camera_transform.affine().inverse();
+        let view_point = view_from_world.transform_point3a(world_point.into());
         let ndc_point = self.computed.clip_from_view.project_point3a(view_point);
 
         (!ndc_point.is_nan()).then_some(ndc_point.into())


### PR DESCRIPTION
# Objective

- world_to_ndc inverts a mat4 that is an affine matrix. this doesnt actually work, the translation needs special treatment to be correct. also it unnecessarily does a mat4 x mat4 mul, its cheaper and more precise to mul the point by each in sequence

## Solution

- dont write broken code
- use traits to allow avoiding vec3a -> vec3 -> vec3a casts (if this is controversial i'll undo that commit)

## Testing

- found this bug at my job, fixed it at my job. it works now