### PR TITLE
Fix aabb area calculation

### DIFF
--- a/crates/bevy_math/src/bounding/bounded2d/mod.rs
+++ b/crates/bevy_math/src/bounding/bounded2d/mod.rs
@@ -127,7 +127,7 @@ impl BoundingVolume for Aabb2d {
 
     #[inline(always)]
     fn visible_area(&self) -> f32 {
-        let b = self.max - self.min;
+        let b = (self.max - self.min).max(Vec2::ZERO);
         b.x * b.y
     }
 

--- a/crates/bevy_math/src/bounding/bounded3d/mod.rs
+++ b/crates/bevy_math/src/bounding/bounded3d/mod.rs
@@ -136,7 +136,7 @@ impl BoundingVolume for Aabb3d {
 
     #[inline(always)]
     fn visible_area(&self) -> f32 {
-        let b = self.max - self.min;
+        let b = (self.max - self.min).max(Vec3A::ZERO);
         b.x * (b.y + b.z) + b.y * b.z
     }
 


### PR DESCRIPTION
# Objective

- positive area can be reported for inverted Aabb2d, and negative area too in some cases. Invalid Aabbs (any(min > max)) should have zero area.

## Solution

- max 0

## Testing

- found at work, fixed at work, tested at work, works at work