### PR TITLE
fix(mesh2d): replace unwrap by error log in specialize system

### DIFF
--- a/crates/bevy_sprite_render/src/mesh2d/material.rs
+++ b/crates/bevy_sprite_render/src/mesh2d/material.rs
@@ -737,7 +737,10 @@ pub fn specialize_material2d_meshes<M: Material2d>(
             let Some(mesh_instance) = render_mesh_instances.get_mut(visible_entity) else {
                 continue;
             };
-            let entity_tick = entity_specialization_ticks.get(visible_entity).unwrap();
+            let Some(entity_tick) = entity_specialization_ticks.get(visible_entity) else {
+                error!("Entity {} is missing specialization tick. spawning Mesh2d in PostUpdate and later is currently not properly implemented. please see PR #19064 for details.", visible_entity.id());
+                continue;
+            };
             let last_specialized_tick = view_specialized_material_pipeline_cache
                 .get(visible_entity)
                 .map(|(tick, _)| *tick);

--- a/crates/bevy_sprite_render/src/mesh2d/material.rs
+++ b/crates/bevy_sprite_render/src/mesh2d/material.rs
@@ -738,7 +738,7 @@ pub fn specialize_material2d_meshes<M: Material2d>(
                 continue;
             };
             let Some(entity_tick) = entity_specialization_ticks.get(visible_entity) else {
-                error!("Entity {} is missing specialization tick. spawning Mesh2d in PostUpdate and later is currently not properly implemented. please see PR #19064 for details.", visible_entity.id());
+                error!("{} is missing specialization tick. Spawning Mesh2d in PostUpdate or later is currently not fully supported. Please see PR #19064 for details.", visible_entity);
                 continue;
             };
             let last_specialized_tick = view_specialized_material_pipeline_cache

--- a/crates/bevy_sprite_render/src/mesh2d/material.rs
+++ b/crates/bevy_sprite_render/src/mesh2d/material.rs
@@ -738,7 +738,7 @@ pub fn specialize_material2d_meshes<M: Material2d>(
                 continue;
             };
             let Some(entity_tick) = entity_specialization_ticks.get(visible_entity) else {
-                error!("{} is missing specialization tick. Spawning Mesh2d in PostUpdate or later is currently not fully supported. Please see PR #19064 for details.", visible_entity);
+                error!("{visible_entity:?} is missing specialization tick. Spawning Meshes in PostUpdate or later is currently not fully supported.");
                 continue;
             };
             let last_specialized_tick = view_specialized_material_pipeline_cache


### PR DESCRIPTION
# Objective

prevent panics talked about in #19064
this a “temporary” fix to get in 0.17, until the above PR is finalized, and the source problem is fixed.

## Solution

remove the unwrap

## Testing

- anything is better than panic
- been using this patch in my own games for months without any apparent issue

## Note

please improve the actual error missing if needed, i doubt its perfect
