### PR TITLE
Color::srgb requires values in range 0..1 and the ui/relative_cursor_position example used misleading 0..255 range

### DIFF
--- a/examples/ui/relative_cursor_position.rs
+++ b/examples/ui/relative_cursor_position.rs
@@ -44,7 +44,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         margin: UiRect::bottom(Val::Px(15.)),
                         ..default()
                     },
-                    BackgroundColor(Color::srgb(235., 35., 12.)),
+                    BackgroundColor(Color::srgb(0.92, 0.14, 0.05)),
                 ))
                 .insert(RelativeCursorPosition::default());
 


### PR DESCRIPTION
`Color::srgb` requires values in range `0..1` and the `ui/relative_cursor_position` example uses misleading `0..255` range

# Objective

- To remove misleading range error in UI example (it actually caught me off-guard when I was learning about Bevy UI)

## Solution

- Scaled data to (approx.) `0..1` range of values via dividing by `255` with 2 digits precision. This will change the example look, as previously the example node rendered 100% white.

## Testing

- Run the isolated example, screenshots below

---

## Showcase

- Comparison below:

### Previous version

<img width="671" height="518" alt="image" src="https://github.com/user-attachments/assets/4825072f-40fe-43d0-a4da-aed2a07b7f15" />

### New version

<img width="405" height="410" alt="image" src="https://github.com/user-attachments/assets/67b97b08-d86f-4d04-871f-845b66bbe3c3" />
