### PR TITLE
Ensure systems passed to `Combine` cannot be called re-entrantly either

### DIFF
--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -1147,12 +1147,13 @@ where
     type In = In;
     type Out = bool;
 
-    fn combine(
+    fn combine<T>(
         input: <Self::In as SystemInput>::Inner<'_>,
-        a: impl FnOnce(SystemIn<'_, A>) -> Result<A::Out, RunSystemError>,
-        b: impl FnOnce(SystemIn<'_, A>) -> Result<B::Out, RunSystemError>,
+        mut data: T,
+        a: impl FnOnce(SystemIn<'_, A>, &mut T) -> Result<A::Out, RunSystemError>,
+        b: impl FnOnce(SystemIn<'_, A>, &mut T) -> Result<B::Out, RunSystemError>,
     ) -> Result<Self::Out, RunSystemError> {
-        Ok(a(input)? && b(input)?)
+        Ok(a(input, &mut data)? && b(input, &mut data)?)
     }
 }
 
@@ -1168,12 +1169,13 @@ where
     type In = In;
     type Out = bool;
 
-    fn combine(
+    fn combine<T>(
         input: <Self::In as SystemInput>::Inner<'_>,
-        a: impl FnOnce(SystemIn<'_, A>) -> Result<A::Out, RunSystemError>,
-        b: impl FnOnce(SystemIn<'_, A>) -> Result<B::Out, RunSystemError>,
+        mut data: T,
+        a: impl FnOnce(SystemIn<'_, A>, &mut T) -> Result<A::Out, RunSystemError>,
+        b: impl FnOnce(SystemIn<'_, A>, &mut T) -> Result<B::Out, RunSystemError>,
     ) -> Result<Self::Out, RunSystemError> {
-        Ok(!(a(input)? && b(input)?))
+        Ok(!(a(input, &mut data)? && b(input, &mut data)?))
     }
 }
 
@@ -1189,12 +1191,13 @@ where
     type In = In;
     type Out = bool;
 
-    fn combine(
+    fn combine<T>(
         input: <Self::In as SystemInput>::Inner<'_>,
-        a: impl FnOnce(SystemIn<'_, A>) -> Result<A::Out, RunSystemError>,
-        b: impl FnOnce(SystemIn<'_, A>) -> Result<B::Out, RunSystemError>,
+        mut data: T,
+        a: impl FnOnce(SystemIn<'_, A>, &mut T) -> Result<A::Out, RunSystemError>,
+        b: impl FnOnce(SystemIn<'_, A>, &mut T) -> Result<B::Out, RunSystemError>,
     ) -> Result<Self::Out, RunSystemError> {
-        Ok(!(a(input)? || b(input)?))
+        Ok(!(a(input, &mut data)? || b(input, &mut data)?))
     }
 }
 
@@ -1210,12 +1213,13 @@ where
     type In = In;
     type Out = bool;
 
-    fn combine(
+    fn combine<T>(
         input: <Self::In as SystemInput>::Inner<'_>,
-        a: impl FnOnce(SystemIn<'_, A>) -> Result<A::Out, RunSystemError>,
-        b: impl FnOnce(SystemIn<'_, A>) -> Result<B::Out, RunSystemError>,
+        mut data: T,
+        a: impl FnOnce(SystemIn<'_, A>, &mut T) -> Result<A::Out, RunSystemError>,
+        b: impl FnOnce(SystemIn<'_, A>, &mut T) -> Result<B::Out, RunSystemError>,
     ) -> Result<Self::Out, RunSystemError> {
-        Ok(a(input)? || b(input)?)
+        Ok(a(input, &mut data)? || b(input, &mut data)?)
     }
 }
 
@@ -1231,12 +1235,13 @@ where
     type In = In;
     type Out = bool;
 
-    fn combine(
+    fn combine<T>(
         input: <Self::In as SystemInput>::Inner<'_>,
-        a: impl FnOnce(SystemIn<'_, A>) -> Result<A::Out, RunSystemError>,
-        b: impl FnOnce(SystemIn<'_, A>) -> Result<B::Out, RunSystemError>,
+        mut data: T,
+        a: impl FnOnce(SystemIn<'_, A>, &mut T) -> Result<A::Out, RunSystemError>,
+        b: impl FnOnce(SystemIn<'_, A>, &mut T) -> Result<B::Out, RunSystemError>,
     ) -> Result<Self::Out, RunSystemError> {
-        Ok(!(a(input)? ^ b(input)?))
+        Ok(!(a(input, &mut data)? ^ b(input, &mut data)?))
     }
 }
 
@@ -1252,12 +1257,13 @@ where
     type In = In;
     type Out = bool;
 
-    fn combine(
+    fn combine<T>(
         input: <Self::In as SystemInput>::Inner<'_>,
-        a: impl FnOnce(SystemIn<'_, A>) -> Result<A::Out, RunSystemError>,
-        b: impl FnOnce(SystemIn<'_, A>) -> Result<B::Out, RunSystemError>,
+        mut data: T,
+        a: impl FnOnce(SystemIn<'_, A>, &mut T) -> Result<A::Out, RunSystemError>,
+        b: impl FnOnce(SystemIn<'_, A>, &mut T) -> Result<B::Out, RunSystemError>,
     ) -> Result<Self::Out, RunSystemError> {
-        Ok(a(input)? ^ b(input)?)
+        Ok(a(input, &mut data)? ^ b(input, &mut data)?)
     }
 }
 

--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -1149,11 +1149,11 @@ where
 
     fn combine<T>(
         input: <Self::In as SystemInput>::Inner<'_>,
-        mut data: T,
+        data: &mut T,
         a: impl FnOnce(SystemIn<'_, A>, &mut T) -> Result<A::Out, RunSystemError>,
         b: impl FnOnce(SystemIn<'_, A>, &mut T) -> Result<B::Out, RunSystemError>,
     ) -> Result<Self::Out, RunSystemError> {
-        Ok(a(input, &mut data)? && b(input, &mut data)?)
+        Ok(a(input, data)? && b(input, data)?)
     }
 }
 
@@ -1171,11 +1171,11 @@ where
 
     fn combine<T>(
         input: <Self::In as SystemInput>::Inner<'_>,
-        mut data: T,
+        data: &mut T,
         a: impl FnOnce(SystemIn<'_, A>, &mut T) -> Result<A::Out, RunSystemError>,
         b: impl FnOnce(SystemIn<'_, A>, &mut T) -> Result<B::Out, RunSystemError>,
     ) -> Result<Self::Out, RunSystemError> {
-        Ok(!(a(input, &mut data)? && b(input, &mut data)?))
+        Ok(!(a(input, data)? && b(input, data)?))
     }
 }
 
@@ -1193,11 +1193,11 @@ where
 
     fn combine<T>(
         input: <Self::In as SystemInput>::Inner<'_>,
-        mut data: T,
+        data: &mut T,
         a: impl FnOnce(SystemIn<'_, A>, &mut T) -> Result<A::Out, RunSystemError>,
         b: impl FnOnce(SystemIn<'_, A>, &mut T) -> Result<B::Out, RunSystemError>,
     ) -> Result<Self::Out, RunSystemError> {
-        Ok(!(a(input, &mut data)? || b(input, &mut data)?))
+        Ok(!(a(input, data)? || b(input, data)?))
     }
 }
 
@@ -1215,11 +1215,11 @@ where
 
     fn combine<T>(
         input: <Self::In as SystemInput>::Inner<'_>,
-        mut data: T,
+        data: &mut T,
         a: impl FnOnce(SystemIn<'_, A>, &mut T) -> Result<A::Out, RunSystemError>,
         b: impl FnOnce(SystemIn<'_, A>, &mut T) -> Result<B::Out, RunSystemError>,
     ) -> Result<Self::Out, RunSystemError> {
-        Ok(a(input, &mut data)? || b(input, &mut data)?)
+        Ok(a(input, data)? || b(input, data)?)
     }
 }
 
@@ -1237,11 +1237,11 @@ where
 
     fn combine<T>(
         input: <Self::In as SystemInput>::Inner<'_>,
-        mut data: T,
+        data: &mut T,
         a: impl FnOnce(SystemIn<'_, A>, &mut T) -> Result<A::Out, RunSystemError>,
         b: impl FnOnce(SystemIn<'_, A>, &mut T) -> Result<B::Out, RunSystemError>,
     ) -> Result<Self::Out, RunSystemError> {
-        Ok(!(a(input, &mut data)? ^ b(input, &mut data)?))
+        Ok(!(a(input, data)? ^ b(input, data)?))
     }
 }
 
@@ -1259,11 +1259,11 @@ where
 
     fn combine<T>(
         input: <Self::In as SystemInput>::Inner<'_>,
-        mut data: T,
+        data: &mut T,
         a: impl FnOnce(SystemIn<'_, A>, &mut T) -> Result<A::Out, RunSystemError>,
         b: impl FnOnce(SystemIn<'_, A>, &mut T) -> Result<B::Out, RunSystemError>,
     ) -> Result<Self::Out, RunSystemError> {
-        Ok(a(input, &mut data)? ^ b(input, &mut data)?)
+        Ok(a(input, data)? ^ b(input, data)?)
     }
 }
 

--- a/crates/bevy_ecs/src/system/combinator.rs
+++ b/crates/bevy_ecs/src/system/combinator.rs
@@ -36,12 +36,13 @@ use super::{IntoSystem, ReadOnlySystem, RunSystemError, System};
 ///     type In = ();
 ///     type Out = bool;
 ///
-///     fn combine(
+///     fn combine<T>(
 ///         _input: Self::In,
-///         a: impl FnOnce(A::In) -> Result<A::Out, RunSystemError>,
-///         b: impl FnOnce(B::In) -> Result<B::Out, RunSystemError>,
+///         mut data: T,
+///         a: impl FnOnce(A::In, &mut T) -> Result<A::Out, RunSystemError>,
+///         b: impl FnOnce(B::In, &mut T) -> Result<B::Out, RunSystemError>,
 ///     ) -> Result<Self::Out, RunSystemError> {
-///         Ok(a(())? ^ b(())?)
+///         Ok(a((), &mut data)? ^ b((), &mut data)?)
 ///     }
 /// }
 ///

--- a/release-content/migration-guides/combine_soundness_fix.md
+++ b/release-content/migration-guides/combine_soundness_fix.md
@@ -1,0 +1,6 @@
+---
+title: Combine now takes an extra parameter
+pull_requests: [20689]
+---
+
+The `Combine::combine` method now takes an extra parameter that needs to be passed mutably to the two given closures. This allows fixing a soundness issue which manifested when the two closures were called re-entrantly.


### PR DESCRIPTION
# Objective

- Fix #14709

## Solution

- Add an extra parameter to `Combine::combine` of a generic type `T`, which ensures only one of the two closures can be called at any given time, including re-entrantly.