### PR TITLE
Change breakout example from fixed time updates to virtual time updates

### DIFF
--- a/examples/games/breakout.rs
+++ b/examples/games/breakout.rs
@@ -66,17 +66,17 @@ fn main() {
         // Add our gameplay simulation systems to the fixed timestep schedule
         // which runs at 64 Hz by default
         .add_systems(
-            FixedUpdate,
+            Update,
             (
                 apply_velocity,
                 move_paddle,
                 check_for_collisions,
                 play_collision_sound,
+                update_scoreboard,
             )
                 // `chain`ing systems together runs them in order
                 .chain(),
         )
-        .add_systems(Update, update_scoreboard)
         .run();
 }
 


### PR DESCRIPTION
# Objective
Addresses #14239 
Move breakout example to use virtual time instead of fixed time updates

## Solution
- The example already used `time.delta().as_secs()` so it wasn't very dependent on fixed time; comments on the issue suggested using `StableInterpolate` so I did
- I changed the paddle entity to also use a velocity to be more similar to the ball and moved its clamping behavior to a separate system (This could possibly be treated as a collision and handled in `check_for_collisions`? )

## Testing

- I tested the example before and after the changes and verified the same behavior on a macbook m2 pro. I did not test it on other platforms.
- The changes can be tested with
```
cargo run --example breakout
```

---

## Showcase
Visually identical to the existing breakout example
<img width="1392" height="860" alt="Screenshot 2025-08-20 at 9 10 39 PM" src="https://github.com/user-attachments/assets/7f329e53-1c67-4c4e-9086-35f087eb544b" />

