### PR TITLE
Comment fix for `ui_picking` function

### DIFF
--- a/crates/bevy_ui/src/picking_backend.rs
+++ b/crates/bevy_ui/src/picking_backend.rs
@@ -110,7 +110,7 @@ pub fn ui_picking(
     clipping_query: Query<(&ComputedNode, &UiGlobalTransform, &Node)>,
     child_of_query: Query<&ChildOf, Without<OverrideClip>>,
 ) {
-    // For each camera, the pointer and its position
+    // Map from each camera to its active pointers and their positions in viewport space
     let mut pointer_pos_by_camera = HashMap::<Entity, HashMap<PointerId, Vec2>>::default();
 
     for (pointer_id, pointer_location) in


### PR DESCRIPTION
# Objective
This comment in `ui_picking`:
```
    // For each camera, the pointer and its position
```
implies each camera has a single unique pointer, when they can have many.

## Solution

Change it to:
```
    // Map from each camera to its active pointers and their positions in viewport space
```