### PR TITLE
Emit the `WindowScaleFactorChanged` event

### DIFF
--- a/crates/bevy_winit/src/state.rs
+++ b/crates/bevy_winit/src/state.rs
@@ -895,6 +895,7 @@ pub(crate) fn react_to_scale_factor_change(
     window_backend_scale_factor_changed: &mut EventWriter<WindowBackendScaleFactorChanged>,
     window_scale_factor_changed: &mut EventWriter<WindowScaleFactorChanged>,
 ) {
+    let prior_factor = window.resolution.scale_factor();
     window.resolution.set_scale_factor(scale_factor as f32);
 
     window_backend_scale_factor_changed.write(WindowBackendScaleFactorChanged {
@@ -902,7 +903,6 @@ pub(crate) fn react_to_scale_factor_change(
         scale_factor,
     });
 
-    let prior_factor = window.resolution.scale_factor();
     let scale_factor_override = window.resolution.scale_factor_override();
 
     if scale_factor_override.is_none() && !relative_eq!(scale_factor as f32, prior_factor) {


### PR DESCRIPTION
# Objective

Obvious bug here in `react_to_scale_factor_change`:

```rust
pub(crate) fn react_to_scale_factor_change(
    window_entity: Entity,
    window: &mut Mut<'_, Window>,
    scale_factor: f64,
    window_backend_scale_factor_changed: &mut EventWriter<WindowBackendScaleFactorChanged>,
    window_scale_factor_changed: &mut EventWriter<WindowScaleFactorChanged>,
) {
    window.resolution.set_scale_factor(scale_factor as f32);

    window_backend_scale_factor_changed.write(WindowBackendScaleFactorChanged {
        window: window_entity,
        scale_factor,
    });

    let prior_factor = window.resolution.scale_factor();
    let scale_factor_override = window.resolution.scale_factor_override();

    if scale_factor_override.is_none() && !relative_eq!(scale_factor as f32, prior_factor) {
        window_scale_factor_changed.write(WindowScaleFactorChanged {
            window: window_entity,
            scale_factor,
        });
    }
}
```

The previous scale factor is meant to be stored in `prior_factor` but it's overwritten in the first line of the function so `WindowScaleFactorChanged` events are only emitted when `!relative_eq!(scale_factor, scale_factor)`, which is never true.

Fixes #20670

## Solution

Store the previous scale factor in `prior_factor` at the start of the function, before setting the new value.

#

These scale factor events seem a bit confusing, I think probably it would make more intuitive sense if `WindowScaleFactorChanged` was also emitted when the window's scale factor override is changed. I want to fix any existing bugs before considering any other changes though.

## Testing

Can add this system to check it works now: 
```rust
fn print_scale_factor_changes(
    mut events: EventReader<WindowScaleFactorChanged>,
) {
    for e in events.read() {
        println!("scale factor changed: {}", e.scale_factor);
    }
}
```