### PR TITLE
Don't invert an affine matrix as if it was a mat4

### DIFF
--- a/crates/bevy_camera/src/projection.rs
+++ b/crates/bevy_camera/src/projection.rs
@@ -68,7 +68,7 @@ pub trait CameraProjection {
     /// This code is called by [`update_frusta`](crate::visibility::update_frusta) system
     /// for each camera to update its frustum.
     fn compute_frustum(&self, camera_transform: &GlobalTransform) -> Frustum {
-        let clip_from_world = self.get_clip_from_view() * camera_transform.to_matrix().inverse();
+        let clip_from_world = self.get_clip_from_view() * camera_transform.affine().inverse();
         Frustum::from_clip_from_world_custom_far(
             &clip_from_world,
             &camera_transform.translation(),


### PR DESCRIPTION
# Objective

- Don't invert an affine matrix as if it was a mat4

## Solution

- keep it affine

## Testing

shadow biases example