### PR TITLE
invert affine not mat4 in point_light

### DIFF
--- a/crates/bevy_light/src/point_light.rs
+++ b/crates/bevy_light/src/point_light.rs
@@ -232,7 +232,7 @@ pub fn update_point_light_frusta(
 
         for (view_rotation, frustum) in view_rotations.iter().zip(cubemap_frusta.iter_mut()) {
             let world_from_view = view_translation * *view_rotation;
-            let clip_from_world = clip_from_view * world_from_view.to_matrix().inverse();
+            let clip_from_world = clip_from_view * world_from_view.compute_affine().inverse();
 
             *frustum = Frustum::from_clip_from_world_custom_far(
                 &clip_from_world,


### PR DESCRIPTION
# Objective

- dont do a full mat4 inverse when you have an affine matrix

## Solution

- do an affine inverse when you have an affine matrix

## Testing

- lighting example