### PR TITLE
rename animation feature to bevy_animation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ default = [
   "async_executor",
   "android-game-activity",
   "android_shared_stdcxx",
-  "animation",
+  "bevy_animation",
   "bevy_asset",
   "bevy_audio",
   "bevy_color",
@@ -201,7 +201,7 @@ dynamic_linking = ["dep:bevy_dylib", "bevy_internal/dynamic_linking"]
 # Enables system information diagnostic plugin
 sysinfo_plugin = ["bevy_internal/sysinfo_plugin"]
 
-# Provides animation functionality
+# Enable animation support, and glTF animation loading
 bevy_animation = ["bevy_internal/bevy_animation"]
 
 # Provides asset functionality
@@ -431,9 +431,6 @@ android-game-activity = ["bevy_internal/android-game-activity"]
 
 # Enable systems that allow for automated testing on CI
 bevy_ci_testing = ["bevy_internal/bevy_ci_testing"]
-
-# Enable animation support, and glTF animation loading
-animation = ["bevy_internal/animation", "bevy_animation"]
 
 # Enable using a shared stdlib for cxx on Android
 android_shared_stdcxx = ["bevy_internal/android_shared_stdcxx"]

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -202,8 +202,8 @@ webgpu = [
 bevy_ci_testing = ["bevy_dev_tools/bevy_ci_testing", "bevy_render?/ci_limits"]
 
 # Enable animation support, and glTF animation loading
-animation = [
-  "bevy_animation",
+bevy_animation = [
+  "dep:bevy_animation",
   "bevy_mesh",
   "bevy_color",
   "bevy_gltf?/bevy_animation",

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -13,9 +13,8 @@ The default feature set enables most of the expected features of a game engine, 
 |-|-|
 |android-game-activity|Android GameActivity support. Default, choose between this and `android-native-activity`.|
 |android_shared_stdcxx|Enable using a shared stdlib for cxx on Android|
-|animation|Enable animation support, and glTF animation loading|
 |async_executor|Uses `async-executor` as a task execution backend.|
-|bevy_animation|Provides animation functionality|
+|bevy_animation|Enable animation support, and glTF animation loading|
 |bevy_anti_aliasing|Provides various anti aliasing solutions|
 |bevy_asset|Provides asset functionality|
 |bevy_audio|Provides audio functionality|

--- a/examples/mobile/android_basic/Cargo.toml
+++ b/examples/mobile/android_basic/Cargo.toml
@@ -15,7 +15,6 @@ crate-type = ["staticlib", "cdylib"]
 bevy = { path = "../../", default-features = false, features = [
   "android-native-activity",
   "android_shared_stdcxx",
-  "animation",
   "bevy_animation",
   "bevy_asset",
   "bevy_audio",

--- a/examples/tools/scene_viewer/main.rs
+++ b/examples/tools/scene_viewer/main.rs
@@ -22,7 +22,7 @@ use bevy::{
 #[path = "../../helpers/camera_controller.rs"]
 mod camera_controller;
 
-#[cfg(feature = "animation")]
+#[cfg(feature = "bevy_animation")]
 mod animation_plugin;
 mod morph_viewer_plugin;
 mod scene_viewer_plugin;
@@ -111,7 +111,7 @@ fn main() {
         app.insert_resource(DefaultOpaqueRendererMethod::deferred());
     }
 
-    #[cfg(feature = "animation")]
+    #[cfg(feature = "bevy_animation")]
     app.add_plugins(animation_plugin::AnimationManipulationPlugin);
 
     app.run();

--- a/examples/tools/scene_viewer/scene_viewer_plugin.rs
+++ b/examples/tools/scene_viewer/scene_viewer_plugin.rs
@@ -32,7 +32,7 @@ impl SceneHandle {
     }
 }
 
-#[cfg(not(feature = "animation"))]
+#[cfg(not(feature = "bevy_animation"))]
 const INSTRUCTIONS: &str = r#"
 Scene Controls:
     L           - animate light direction
@@ -42,7 +42,7 @@ Scene Controls:
     compile with "--features animation" for animation controls.
 "#;
 
-#[cfg(feature = "animation")]
+#[cfg(feature = "bevy_animation")]
 const INSTRUCTIONS: &str = "
 Scene Controls:
     L           - animate light direction

--- a/release-content/migration-guides/animation-feature.md
+++ b/release-content/migration-guides/animation-feature.md
@@ -1,0 +1,6 @@
+---
+title: "`animation` feature rename"
+pull_requests: [20714]
+---
+
+The `animation` feature has become `bevy_animation` for consistency.


### PR DESCRIPTION
# Objective

- feature name consistency
- for some reason there were two features to control one thing?

## Solution

- rename/merge animation feature with bevy_animation

## Testing

- animated_mesh example