### PR TITLE
rename SpriteRenderingPlugin to SpriteRenderPlugin

### DIFF
--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -45,7 +45,7 @@ plugin_group! {
         #[cfg(feature = "bevy_sprite")]
         bevy_sprite:::SpritePlugin,
         #[cfg(feature = "bevy_sprite_render")]
-        bevy_sprite_render:::SpriteRenderingPlugin,
+        bevy_sprite_render:::SpriteRenderPlugin,
         #[cfg(feature = "bevy_text")]
         bevy_text:::TextPlugin,
         #[cfg(feature = "bevy_ui")]

--- a/crates/bevy_sprite_render/src/lib.rs
+++ b/crates/bevy_sprite_render/src/lib.rs
@@ -49,7 +49,7 @@ use crate::text2d::extract_text2d_sprite;
 
 /// Adds support for 2D sprite rendering.
 #[derive(Default)]
-pub struct SpriteRenderingPlugin;
+pub struct SpriteRenderPlugin;
 
 /// System set for sprite rendering.
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
@@ -62,7 +62,7 @@ pub enum SpriteSystems {
 #[deprecated(since = "0.17.0", note = "Renamed to `SpriteSystems`.")]
 pub type SpriteSystem = SpriteSystems;
 
-impl Plugin for SpriteRenderingPlugin {
+impl Plugin for SpriteRenderPlugin {
     fn build(&self, app: &mut App) {
         load_shader_library!(app, "render/sprite_view_bindings.wgsl");
 


### PR DESCRIPTION
# Objective

-  consistency

## Solution

- rename SpriteRenderingPlugin to SpriteRenderPlugin

## Testing

Not breaking, this didnt exist last cycle.