### PR TITLE
make smaa_luts and tonemap_luts not unconditionally bring in rendering crates

### DIFF
--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -66,12 +66,12 @@ statically-linked-dxc = ["bevy_render/statically-linked-dxc"]
 raw_vulkan_init = ["bevy_render/raw_vulkan_init"]
 
 # Include tonemapping LUT KTX2 files.
-tonemapping_luts = ["bevy_core_pipeline/tonemapping_luts"]
+tonemapping_luts = ["bevy_core_pipeline?/tonemapping_luts"]
 # Include Bluenoise texture for environment map generation.
 bluenoise_texture = ["bevy_pbr?/bluenoise_texture"]
 
 # Include SMAA LUT KTX2 Files
-smaa_luts = ["bevy_anti_aliasing/smaa_luts"]
+smaa_luts = ["bevy_anti_aliasing?/smaa_luts"]
 
 # NVIDIA Deep Learning Super Sampling
 dlss = ["bevy_anti_aliasing/dlss", "bevy_solari?/dlss"]


### PR DESCRIPTION
# Objective

- i dont actually know if this is desirable, but i think i'd prefer this. its also consistent with how bluenoise texture is set up. i feel that these are "addon" features that should only really do anything if the base crate they apply to is in use.

## Solution

- i really have no idea how to use this pr template a lot of the time

## Testing

- 