### PR TITLE
implement Reflect for indexmap and adjust docs accordingly

### DIFF
--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -88,6 +88,7 @@ hotpatching = ["dep:subsecond"]
 bevy_ptr = { path = "../bevy_ptr", version = "0.17.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.17.0-dev", features = [
   "smallvec",
+  "indexmap",
 ], default-features = false, optional = true }
 bevy_tasks = { path = "../bevy_tasks", version = "0.17.0-dev", default-features = false }
 bevy_utils = { path = "../bevy_utils", version = "0.17.0-dev", default-features = false }

--- a/crates/bevy_ecs/src/entity/index_set.rs
+++ b/crates/bevy_ecs/src/entity/index_set.rs
@@ -21,8 +21,10 @@ use indexmap::set::{self, IndexSet};
 use super::{Entity, EntityHash, EntitySetIterator};
 
 use bevy_platform::prelude::Box;
+use bevy_reflect::Reflect;
 
 /// An [`IndexSet`] pre-configured to use [`EntityHash`] hashing.
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
 #[cfg_attr(feature = "serialize", derive(serde::Deserialize, serde::Serialize))]
 #[derive(Debug, Clone, Default)]
 pub struct EntityIndexSet(pub(crate) IndexSet<Entity, EntityHash>);

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["bevy"]
 rust-version = "1.85.0"
 
 [features]
-default = ["std", "smallvec", "debug", "auto_register_inventory"]
+default = ["std", "smallvec", "indexmap", "debug", "auto_register_inventory"]
 
 # Features
 
@@ -35,6 +35,9 @@ glam = ["dep:glam"]
 
 ## Adds reflection support to `hashbrown` types.
 hashbrown = ["dep:hashbrown"]
+
+## Adds reflection support to `indexmap` types.
+indexmap = ["dep:indexmap"]
 
 ## Adds reflection support to `petgraph` types.
 petgraph = ["dep:petgraph", "std"]
@@ -68,7 +71,7 @@ std = [
 ## on all platforms, including `no_std`.
 critical-section = ["bevy_platform/critical-section"]
 
-# Enables automatic reflect registration. Does nothing by itself, 
+# Enables automatic reflect registration. Does nothing by itself,
 # must select `auto_register_inventory` or `auto_register_static` to make it work.
 auto_register = []
 ## Enables automatic reflect registration using inventory. Not supported on all platforms.
@@ -116,6 +119,7 @@ smallvec = { version = "1", default-features = false, optional = true }
 glam = { version = "0.30.1", default-features = false, features = [
   "serde",
 ], optional = true }
+indexmap = { version = "2.5.0", default-features = false, optional = true }
 petgraph = { version = "0.8", features = ["serde-1"], optional = true }
 smol_str = { version = "0.2.0", default-features = false, features = [
   "serde",

--- a/crates/bevy_reflect/src/impls/indexmap.rs
+++ b/crates/bevy_reflect/src/impls/indexmap.rs
@@ -1,0 +1,492 @@
+use crate::{
+    utility::GenericTypeInfoCell, FromReflect, FromType, Generics, GetTypeRegistration,
+    PartialReflect, Reflect, ReflectCloneError, ReflectFromPtr, ReflectMut, ReflectOwned,
+    ReflectRef, Set, SetInfo, TypeInfo, TypeParamInfo, TypePath, TypeRegistration,
+};
+use bevy_platform::prelude::{Box, Vec};
+use bevy_reflect::{DynamicMap, Map, MapInfo, MaybeTyped, ReflectFromReflect, ReflectKind, TypeRegistry, Typed};
+use bevy_reflect_derive::impl_type_path;
+use core::{any::Any, hash::BuildHasher, hash::Hash};
+use indexmap::{IndexMap, IndexSet};
+
+impl<K, V, S> Map for IndexMap<K, V, S>
+where
+    K: FromReflect + MaybeTyped + TypePath + GetTypeRegistration + Eq + Hash,
+    V: FromReflect + MaybeTyped + TypePath + GetTypeRegistration,
+    S: TypePath + BuildHasher + Default + Send + Sync,
+{
+    fn get(&self, key: &dyn PartialReflect) -> Option<&dyn PartialReflect> {
+        key.try_downcast_ref::<K>()
+            .and_then(|key| Self::get(self, key))
+            .map(|value| value as &dyn PartialReflect)
+    }
+
+    fn get_mut(&mut self, key: &dyn PartialReflect) -> Option<&mut dyn PartialReflect> {
+        key.try_downcast_ref::<K>()
+            .and_then(move |key| Self::get_mut(self, key))
+            .map(|value| value as &mut dyn PartialReflect)
+    }
+
+    fn len(&self) -> usize {
+        Self::len(self)
+    }
+
+    fn iter(&self) -> Box<dyn Iterator<Item = (&dyn PartialReflect, &dyn PartialReflect)> + '_> {
+        Box::new(self.iter().map(|(k, v)| (k as &dyn PartialReflect, v as &dyn PartialReflect)))
+    }
+
+    fn drain(&mut self) -> Vec<(Box<dyn PartialReflect>, Box<dyn PartialReflect>)> {
+    self.drain(..)
+            .map(|(key, value)| {
+                (
+                    Box::new(key) as Box<dyn PartialReflect>,
+                    Box::new(value) as Box<dyn PartialReflect>,
+                )
+            })
+            .collect()
+    }
+
+    fn retain(&mut self, f: &mut dyn FnMut(&dyn PartialReflect, &mut dyn PartialReflect) -> bool) {
+    self.retain(move |key, value| f(key, value));
+    }
+
+    fn to_dynamic_map(&self) -> DynamicMap {
+        let mut dynamic_map = DynamicMap::default();
+        dynamic_map.set_represented_type(PartialReflect::get_represented_type_info(self));
+        for (k, v) in self {
+            let key = K::from_reflect(k).unwrap_or_else(|| {
+                panic!(
+                "Attempted to clone invalid key of type {}.",
+                k.reflect_type_path()
+                )
+            });
+    dynamic_map.insert_boxed(Box::new(key), v.to_dynamic());
+        }
+        dynamic_map
+    }
+
+    fn insert_boxed(
+        &mut self,
+        key: Box<dyn PartialReflect>,
+        value: Box<dyn PartialReflect>,
+    ) -> Option<Box<dyn PartialReflect>> {
+        let key = K::take_from_reflect(key).unwrap_or_else(|key| {
+            panic!(
+                "Attempted to insert invalid key of type {}.",
+                key.reflect_type_path()
+            )
+        });
+        let value = V::take_from_reflect(value).unwrap_or_else(|value| {
+            panic!(
+            "Attempted to insert invalid value of type {}.",
+            value.reflect_type_path()
+            )
+        });
+        self.insert(key, value)
+            .map(|old_value| Box::new(old_value) as Box<dyn PartialReflect>)
+    }
+
+    fn remove(&mut self, key: &dyn PartialReflect) -> Option<Box<dyn PartialReflect>> {
+        let mut from_reflect = None;
+        key.try_downcast_ref::<K>()
+            .or_else(|| {
+                from_reflect = K::from_reflect(key);
+                from_reflect.as_ref()
+            })
+            .and_then(|key| self.shift_remove(key))
+            .map(|value| Box::new(value) as Box<dyn PartialReflect>)
+    }
+}
+
+impl<K, V, S> PartialReflect for IndexMap<K, V, S>
+where
+    K: FromReflect + MaybeTyped + TypePath + GetTypeRegistration + Eq + Hash,
+    V: FromReflect + MaybeTyped + TypePath + GetTypeRegistration,
+    S: TypePath + BuildHasher + Default + Send + Sync,
+{
+    fn get_represented_type_info(&self) -> Option<&'static TypeInfo> {
+        Some(<Self as Typed>::type_info())
+    }
+
+    #[inline]
+    fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> {
+        self
+    }
+
+    fn as_partial_reflect(&self) -> &dyn PartialReflect {
+        self
+    }
+
+    fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
+        self
+    }
+
+    #[inline]
+    fn try_into_reflect(self: Box<Self>) -> Result<Box<dyn Reflect>, Box<dyn PartialReflect>> {
+        Ok(self)
+    }
+
+    fn try_as_reflect(&self) -> Option<&dyn Reflect> {
+        Some(self)
+    }
+
+    fn try_as_reflect_mut(&mut self) -> Option<&mut dyn Reflect> {
+        Some(self)
+    }
+
+    fn apply(&mut self, value: &dyn PartialReflect) {
+        crate::map_apply(self, value);
+    }
+
+    fn try_apply(&mut self, value: &dyn PartialReflect) -> Result<(), crate::ApplyError> {
+        crate::map_try_apply(self, value)
+    }
+
+    fn reflect_kind(&self) -> ReflectKind {
+        ReflectKind::Map
+    }
+
+    fn reflect_ref(&self) -> ReflectRef<'_> {
+        ReflectRef::Map(self)
+    }
+
+    fn reflect_mut(&mut self) -> ReflectMut<'_> {
+        ReflectMut::Map(self)
+    }
+
+    fn reflect_owned(self: Box<Self>) -> ReflectOwned {
+        ReflectOwned::Map(self)
+    }
+
+    fn reflect_clone(&self) -> Result<Box<dyn Reflect>, ReflectCloneError> {
+        let mut map = Self::with_capacity_and_hasher(self.len(), S::default());
+        for (key, value) in self.iter() {
+            let key = key.reflect_clone_and_take()?;
+            let value = value.reflect_clone_and_take()?;
+            map.insert(key, value);
+        }
+
+        Ok(Box::new(map))
+    }
+
+    fn reflect_partial_eq(&self, value: &dyn PartialReflect) -> Option<bool> {
+        crate::map_partial_eq(self, value)
+    }
+}
+
+
+impl<K, V, S> Reflect for IndexMap<K, V, S>
+where
+    K: FromReflect + MaybeTyped + TypePath + GetTypeRegistration + Eq + Hash,
+    V: FromReflect + MaybeTyped + TypePath + GetTypeRegistration,
+    S: TypePath + BuildHasher + Default + Send + Sync,
+{
+    fn into_any(self: Box<Self>) -> Box<dyn Any> {
+        self
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
+        self
+    }
+
+    fn as_reflect(&self) -> &dyn Reflect {
+        self
+    }
+
+    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
+        self
+    }
+
+    fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
+        *self = value.take()?;
+        Ok(())
+    }
+}
+
+
+impl<K, V, S> Typed for IndexMap<K, V, S>
+where
+    K: FromReflect + MaybeTyped + TypePath + GetTypeRegistration + Eq + Hash,
+    V: FromReflect + MaybeTyped + TypePath + GetTypeRegistration,
+    S: TypePath + BuildHasher + Default + Send + Sync,
+{
+    fn type_info() -> &'static TypeInfo {
+        static CELL: GenericTypeInfoCell = GenericTypeInfoCell::new();
+        CELL.get_or_insert::<Self, _>(|| {
+            TypeInfo::Map(
+                MapInfo::new::<Self, K, V>().with_generics(Generics::from_iter([
+                    TypeParamInfo::new::<K>("K"),
+                    TypeParamInfo::new::<V>("V")
+                ])),
+            )
+        })
+    }
+}
+
+impl<K, V, S> FromReflect for IndexMap<K, V, S>
+where
+    K: FromReflect + MaybeTyped + TypePath + GetTypeRegistration + Eq + Hash,
+    V: FromReflect + MaybeTyped + TypePath + GetTypeRegistration,
+    S: TypePath + BuildHasher + Default + Send + Sync,
+{
+    fn from_reflect(reflect: &dyn PartialReflect) -> Option<Self> {
+        let ref_map = reflect.reflect_ref().as_map().ok()?;
+
+        let mut new_map = Self::with_capacity_and_hasher(ref_map.len(), S::default());
+
+        for (key, value) in ref_map.iter() {
+            let new_key = K::from_reflect(key)?;
+            let new_value = V::from_reflect(value)?;
+            new_map.insert(new_key, new_value);
+        }
+
+        Some(new_map)
+    }
+}
+
+impl<K, V, S> GetTypeRegistration for IndexMap<K, V, S>
+where
+    K: Hash + Eq + FromReflect + MaybeTyped + TypePath + GetTypeRegistration,
+    V: FromReflect + MaybeTyped + TypePath + GetTypeRegistration,
+    S: TypePath + BuildHasher + Send + Sync + Default,
+{
+    fn get_type_registration() -> TypeRegistration {
+        let mut registration = TypeRegistration::of::<Self>();
+        registration.insert::<ReflectFromPtr>(FromType::<Self>::from_type());
+        registration.insert::<ReflectFromReflect>(FromType::<Self>::from_type());
+        registration
+    }
+
+    fn register_type_dependencies(registry: &mut TypeRegistry) {
+        registry.register::<K>();
+        registry.register::<V>();
+    }
+}
+
+impl_type_path!(::indexmap::IndexMap<K, V, S>);
+
+impl<T, S> Set for IndexSet<T, S>
+where
+    T: FromReflect + TypePath + GetTypeRegistration + Eq + Hash,
+    S: TypePath + BuildHasher + Default + Send + Sync,
+{
+    fn get(&self, value: &dyn PartialReflect) -> Option<&dyn PartialReflect> {
+        value
+            .try_downcast_ref::<T>()
+            .and_then(|value| Self::get(self, value))
+            .map(|value| value as &dyn PartialReflect)
+    }
+
+    fn len(&self) -> usize {
+        self.len()
+    }
+
+    fn iter(&self) -> Box<dyn Iterator<Item = &dyn PartialReflect> + '_> {
+        let iter = self.iter().map(|v| v as &dyn PartialReflect);
+        Box::new(iter)
+    }
+
+    fn drain(&mut self) -> Vec<Box<dyn PartialReflect>> {
+        self.drain(..)
+            .map(|value| Box::new(value) as Box<dyn PartialReflect>)
+            .collect()
+    }
+
+    fn retain(&mut self, f: &mut dyn FnMut(&dyn PartialReflect) -> bool) {
+        self.retain(move |value| f(value))
+    }
+
+    fn insert_boxed(&mut self, value: Box<dyn PartialReflect>) -> bool {
+        let value = T::take_from_reflect(value).unwrap_or_else(|value| {
+            panic!(
+                "Attempted to insert invalid value of type {}.",
+                value.reflect_type_path()
+            )
+        });
+        self.insert(value)
+    }
+
+    fn remove(&mut self, value: &dyn PartialReflect) -> bool {
+        let mut from_reflect = None;
+        value.try_downcast_ref::<T>()
+            .or_else(|| {
+                from_reflect = T::from_reflect(value);
+                from_reflect.as_ref()
+            })
+            .is_some_and(|value| self.shift_remove(value))
+    }
+
+    fn contains(&self, value: &dyn PartialReflect) -> bool {
+        let mut from_reflect = None;
+        value.try_downcast_ref::<T>()
+            .or_else(|| {
+                from_reflect = T::from_reflect(value);
+                from_reflect.as_ref()
+            })
+            .is_some_and(|value| self.contains(value))
+    }
+}
+
+impl<T, S> PartialReflect for IndexSet<T, S>
+where
+    T: FromReflect + TypePath + GetTypeRegistration + Eq + Hash,
+    S: TypePath + BuildHasher + Default + Send + Sync,
+{
+    fn get_represented_type_info(&self) -> Option<&'static TypeInfo> {
+        Some(<Self as Typed>::type_info())
+    }
+
+    #[inline]
+    fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> {
+        self
+    }
+
+    fn as_partial_reflect(&self) -> &dyn PartialReflect {
+        self
+    }
+
+    fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
+        self
+    }
+    
+    #[inline]
+    fn try_into_reflect(self: Box<Self>) -> Result<Box<dyn Reflect>, Box<dyn PartialReflect>> {
+        Ok(self)
+    }
+
+    fn try_as_reflect(&self) -> Option<&dyn Reflect> {
+        Some(self)
+    }
+
+    fn try_as_reflect_mut(&mut self) -> Option<&mut dyn Reflect> {
+        Some(self)
+    }
+
+    fn apply(&mut self, value: &dyn PartialReflect) {
+        crate::set_apply(self, value);
+    }
+
+    fn try_apply(&mut self, value: &dyn PartialReflect) -> Result<(), crate::ApplyError> {
+        crate::set_try_apply(self, value)
+    }
+
+    fn reflect_kind(&self) -> ReflectKind {
+        ReflectKind::Set
+    }
+
+    fn reflect_ref(&self) -> ReflectRef<'_> {
+        ReflectRef::Set(self)
+    }
+
+    fn reflect_mut(&mut self) -> ReflectMut<'_> {
+        ReflectMut::Set(self)
+    }
+
+    fn reflect_owned(self: Box<Self>) -> ReflectOwned {
+        ReflectOwned::Set(self)
+    }
+
+    fn reflect_clone(&self) -> Result<Box<dyn Reflect>, ReflectCloneError> {
+        Ok(Box::new(
+            self.iter()
+                .map(PartialReflect::reflect_clone_and_take)
+                .collect::<Result<Self, ReflectCloneError>>()?,
+        ))
+    }
+
+    fn reflect_partial_eq(&self, value: &dyn PartialReflect) -> Option<bool> {
+        crate::set_partial_eq(self, value)
+    }
+}
+
+impl<T, S> Reflect for IndexSet<T, S>
+where
+    T: FromReflect + TypePath + GetTypeRegistration + Eq + Hash,
+    S: TypePath + BuildHasher + Default + Send + Sync,
+{
+    fn into_any(self: Box<Self>) -> Box<dyn Any> {
+        self
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
+        self
+    }
+
+    fn as_reflect(&self) -> &dyn Reflect {
+        self
+    }
+
+    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
+        self
+    }
+
+    fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
+        *self = value.take()?;
+        Ok(())
+    }
+}
+
+impl<T, S> Typed for IndexSet<T, S>
+where
+    T: FromReflect + TypePath + GetTypeRegistration + Eq + Hash,
+    S: TypePath + BuildHasher + Default + Send + Sync,
+{
+    fn type_info() -> &'static TypeInfo {
+        static CELL: GenericTypeInfoCell = GenericTypeInfoCell::new();
+        CELL.get_or_insert::<Self, _>(|| {
+            TypeInfo::Set(
+                SetInfo::new::<Self, T>().with_generics(Generics::from_iter([
+                    TypeParamInfo::new::<T>("T")
+                ])),
+            )
+        })
+    }
+}
+
+impl<T, S> FromReflect for IndexSet<T, S>
+where
+    T: FromReflect + TypePath + GetTypeRegistration + Eq + Hash,
+    S: TypePath + BuildHasher + Default + Send + Sync,
+{
+    fn from_reflect(reflect: &dyn PartialReflect) -> Option<Self> {
+        let ref_set = reflect.reflect_ref().as_set().ok()?;
+
+        let mut new_set = Self::with_capacity_and_hasher(ref_set.len(), S::default());
+
+        for field in ref_set.iter() {
+            new_set.insert(T::from_reflect(field)?);
+        }
+
+        Some(new_set)
+    }
+}
+
+impl<T, S> GetTypeRegistration for IndexSet<T, S>
+where
+    T: FromReflect + TypePath + GetTypeRegistration + Eq + Hash,
+    S: TypePath + BuildHasher + Default + Send + Sync,
+{
+    fn get_type_registration() -> TypeRegistration {
+        let mut registration = TypeRegistration::of::<Self>();
+        registration.insert::<ReflectFromPtr>(FromType::<Self>::from_type());
+        registration
+    }
+}
+
+impl_type_path!(::indexmap::IndexSet<T, S>);

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -467,13 +467,13 @@
 //!
 //! ## `bevy`
 //!
-//! | Default | Dependencies                              |
-//! | :-----: | :---------------------------------------: |
-//! | ❌      | [`bevy_math`], [`glam`], [`smallvec`]     |
+//! | Default | Dependencies                                        |
+//! | :-----: | :-------------------------------------------------: |
+//! | ❌      | [`bevy_math`], [`glam`], [`indexmap`], [`smallvec`] |
 //!
 //! This feature makes it so that the appropriate reflection traits are implemented on all the types
 //! necessary for the [Bevy] game engine.
-//! enables the optional dependencies: [`bevy_math`], [`glam`], and [`smallvec`].
+//! enables the optional dependencies: [`bevy_math`], [`glam`], [`indexmap`], and [`smallvec`].
 //! These dependencies are used by the [Bevy] game engine and must define their reflection implementations
 //! within this crate due to Rust's [orphan rule].
 //!
@@ -559,6 +559,7 @@
 //! [`bevy_math`]: https://docs.rs/bevy_math/latest/bevy_math/
 //! [`glam`]: https://docs.rs/glam/latest/glam/
 //! [`smallvec`]: https://docs.rs/smallvec/latest/smallvec/
+//! [`indexmap`]: https://docs.rs/indexmap/latest/indexmap/
 //! [orphan rule]: https://doc.rust-lang.org/book/ch10-02-traits.html#implementing-a-trait-on-a-type:~:text=But%20we%20can%E2%80%99t,implementation%20to%20use.
 //! [`bevy_reflect_derive/documentation`]: bevy_reflect_derive
 //! [`bevy_reflect_derive/functions`]: bevy_reflect_derive
@@ -611,6 +612,8 @@ mod impls {
 
     #[cfg(feature = "glam")]
     mod glam;
+    #[cfg(feature = "indexmap")]
+    mod indexmap;
     #[cfg(feature = "petgraph")]
     mod petgraph;
     #[cfg(feature = "smallvec")]
@@ -2324,6 +2327,31 @@ mod tests {
         let value: &dyn Reflect = &MyMap::default();
         let info = value.reflect_type_info();
         assert!(info.is::<MyMap>());
+
+        // Map (IndexMap)
+        #[cfg(feature = "indexmap")]
+        {
+            use std::hash::RandomState;
+
+            type MyIndexMap = indexmap::IndexMap<String, u32, RandomState>;
+
+            let info = MyIndexMap::type_info().as_map().unwrap();
+            assert!(info.is::<MyIndexMap>());
+            assert_eq!(MyIndexMap::type_path(), info.type_path());
+
+            assert!(info.key_ty().is::<String>());
+            assert!(info.key_info().unwrap().is::<String>());
+            assert_eq!(String::type_path(), info.key_ty().path());
+
+            assert!(info.value_ty().is::<u32>());
+            assert!(info.value_info().unwrap().is::<u32>());
+            assert_eq!(u32::type_path(), info.value_ty().path());
+
+            let value: MyIndexMap = MyIndexMap::with_capacity_and_hasher(10, RandomState::new());
+            let value: &dyn Reflect = &value;
+            let info = value.reflect_type_info();
+            assert!(info.is::<MyIndexMap>());
+        }
 
         // Value
         type MyValue = String;


### PR DESCRIPTION
# Objective
- Fixes #19681

## Solution
- Implement Map, PartialReflect, Reflect, Typed, FromReflect, GetTypeRegistration for `indexmap::IndexMap` and `indexmap::IndexSet`
- Add `#[derive(Reflect)]` to `EntityIndexMap`, `EntityIndexSet`
- Add indexmap feature to `bevy_reflect` and Update docs accordingly

## Testing
- Added test on indexmap::IndexMap

---
I initially tried using `impl_reflect_for_hashmap`, but ran into two issues:
1. `IndexMap::drain` requires a range parameter, unlike `HashMap::drain`.
2. `IndexMap::remove` defaults to `swap_remove`, and is now deprecated.

I went with `shift_remove`, since I think it matches user expectations.  
That said, it’s `O(n)`, while `swap_remove` is `O(1)`.  
Would love feedback on which behavior we should prefer.