### PR TITLE
impl `VisitAssetDependencies` for `HashSet`

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -501,6 +501,22 @@ impl VisitAssetDependencies for Vec<UntypedHandle> {
     }
 }
 
+impl<A: Asset> VisitAssetDependencies for HashSet<Handle<A>> {
+    fn visit_dependencies(&self, visit: &mut impl FnMut(UntypedAssetId)) {
+        for dependency in self {
+            visit(dependency.id().untyped());
+        }
+    }
+}
+
+impl VisitAssetDependencies for HashSet<UntypedHandle> {
+    fn visit_dependencies(&self, visit: &mut impl FnMut(UntypedAssetId)) {
+        for dependency in self {
+            visit(dependency.id());
+        }
+    }
+}
+
 /// Adds asset-related builder methods to [`App`].
 pub trait AssetApp {
     /// Registers the given `loader` in the [`App`]'s [`AssetServer`].


### PR DESCRIPTION
# Objective

I want to use `HashSet<Handle<T>>` over `Vec<Handle<T>>` for fast contains checking. Partially adopts #14162: I only need the `HashSet` implementation at the moment.

## Solution

Implement `VisitAssetDependencies` for `HashSet`.

## Testing

We don't have tests for these currently, and I'm not sure how best to test this.