### PR TITLE
make `Bundles::register_info` and `Bundles::register_contributed_bundle_info` unsafe + `deny(unsafe_op_in_unsafe_fn)`

### DIFF
--- a/crates/bevy_ecs/src/bundle/info.rs
+++ b/crates/bevy_ecs/src/bundle/info.rs
@@ -418,7 +418,14 @@ impl Bundles {
     /// Registers a new [`BundleInfo`] for a statically known type.
     ///
     /// Also registers all the components in the bundle.
-    pub(crate) fn register_info<T: Bundle>(
+    ///
+    /// # Safety
+    ///
+    /// `components` and `storages` must be from the same [`World`] as `self`.
+    ///
+    /// [`World`]: crate::world::World
+    #[deny(unsafe_op_in_unsafe_fn)]
+    pub(crate) unsafe fn register_info<T: Bundle>(
         &mut self,
         components: &mut ComponentsRegistrator,
         storages: &mut Storages,
@@ -442,7 +449,14 @@ impl Bundles {
     /// Registers a new [`BundleInfo`], which contains both explicit and required components for a statically known type.
     ///
     /// Also registers all the components in the bundle.
-    pub(crate) fn register_contributed_bundle_info<T: Bundle>(
+    ///
+    /// # Safety
+    ///
+    /// `components` and `storages` must be from the same [`World`] as `self`.
+    ///
+    /// [`World`]: crate::world::World
+    #[deny(unsafe_op_in_unsafe_fn)]
+    pub(crate) unsafe fn register_contributed_bundle_info<T: Bundle>(
         &mut self,
         components: &mut ComponentsRegistrator,
         storages: &mut Storages,
@@ -450,7 +464,10 @@ impl Bundles {
         if let Some(id) = self.contributed_bundle_ids.get(&TypeId::of::<T>()).cloned() {
             id
         } else {
-            let explicit_bundle_id = self.register_info::<T>(components, storages);
+            // SAFETY: as per the guarantees of this function, components and
+            // storages are from the same world as self
+            let explicit_bundle_id = unsafe { self.register_info::<T>(components, storages) };
+
             // SAFETY: reading from `explicit_bundle_id` and creating new bundle in same time. Its valid because bundle hashmap allow this
             let id = unsafe {
                 let (ptr, len) = {

--- a/crates/bevy_ecs/src/bundle/insert.rs
+++ b/crates/bevy_ecs/src/bundle/insert.rs
@@ -40,9 +40,13 @@ impl<'w> BundleInserter<'w> {
         // SAFETY: These come from the same world. `world.components_registrator` can't be used since we borrow other fields too.
         let mut registrator =
             unsafe { ComponentsRegistrator::new(&mut world.components, &mut world.component_ids) };
-        let bundle_id = world
-            .bundles
-            .register_info::<T>(&mut registrator, &mut world.storages);
+
+        // SAFETY: `registrator`, `world.bundles`, and `world.storages` all come from the same world
+        let bundle_id = unsafe {
+            world
+                .bundles
+                .register_info::<T>(&mut registrator, &mut world.storages)
+        };
         // SAFETY: We just ensured this bundle exists
         unsafe { Self::new_with_id(world, archetype_id, bundle_id, change_tick) }
     }

--- a/crates/bevy_ecs/src/bundle/insert.rs
+++ b/crates/bevy_ecs/src/bundle/insert.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     bundle::{ArchetypeMoveType, Bundle, BundleId, BundleInfo, DynamicBundle, InsertMode},
     change_detection::MaybeLocation,
-    component::{Components, ComponentsRegistrator, StorageType, Tick},
+    component::{Components, StorageType, Tick},
     entity::{Entities, Entity, EntityLocation},
     lifecycle::{ADD, INSERT, REPLACE},
     observer::Observers,
@@ -37,16 +37,8 @@ impl<'w> BundleInserter<'w> {
         archetype_id: ArchetypeId,
         change_tick: Tick,
     ) -> Self {
-        // SAFETY: These come from the same world. `world.components_registrator` can't be used since we borrow other fields too.
-        let mut registrator =
-            unsafe { ComponentsRegistrator::new(&mut world.components, &mut world.component_ids) };
+        let bundle_id = world.register_bundle_info::<T>();
 
-        // SAFETY: `registrator`, `world.bundles`, and `world.storages` all come from the same world
-        let bundle_id = unsafe {
-            world
-                .bundles
-                .register_info::<T>(&mut registrator, &mut world.storages)
-        };
         // SAFETY: We just ensured this bundle exists
         unsafe { Self::new_with_id(world, archetype_id, bundle_id, change_tick) }
     }

--- a/crates/bevy_ecs/src/bundle/remove.rs
+++ b/crates/bevy_ecs/src/bundle/remove.rs
@@ -6,7 +6,7 @@ use crate::{
     archetype::{Archetype, ArchetypeCreated, ArchetypeId, Archetypes},
     bundle::{Bundle, BundleId, BundleInfo},
     change_detection::MaybeLocation,
-    component::{ComponentId, Components, ComponentsRegistrator, StorageType},
+    component::{ComponentId, Components, StorageType},
     entity::{Entity, EntityLocation},
     lifecycle::{REMOVE, REPLACE},
     observer::Observers,
@@ -39,16 +39,8 @@ impl<'w> BundleRemover<'w> {
         archetype_id: ArchetypeId,
         require_all: bool,
     ) -> Option<Self> {
-        // SAFETY: These come from the same world. `world.components_registrator` can't be used since we borrow other fields too.
-        let mut registrator =
-            unsafe { ComponentsRegistrator::new(&mut world.components, &mut world.component_ids) };
+        let bundle_id = world.register_bundle_info::<T>();
 
-        // SAFETY: `registrator`, `world.storages`, and `world.bundles` all come from the same world.
-        let bundle_id = unsafe {
-            world
-                .bundles
-                .register_info::<T>(&mut registrator, &mut world.storages)
-        };
         // SAFETY: we initialized this bundle_id in `init_info`, and caller ensures archetype is valid.
         unsafe { Self::new_with_id(world, archetype_id, bundle_id, require_all) }
     }

--- a/crates/bevy_ecs/src/bundle/spawner.rs
+++ b/crates/bevy_ecs/src/bundle/spawner.rs
@@ -29,9 +29,13 @@ impl<'w> BundleSpawner<'w> {
         // SAFETY: These come from the same world. `world.components_registrator` can't be used since we borrow other fields too.
         let mut registrator =
             unsafe { ComponentsRegistrator::new(&mut world.components, &mut world.component_ids) };
-        let bundle_id = world
-            .bundles
-            .register_info::<T>(&mut registrator, &mut world.storages);
+
+        // SAFETY: `registrator`, `world.bundles`, and `world.storages` all come from the same world.
+        let bundle_id = unsafe {
+            world
+                .bundles
+                .register_info::<T>(&mut registrator, &mut world.storages)
+        };
         // SAFETY: we initialized this bundle_id in `init_info`
         unsafe { Self::new_with_id(world, bundle_id, change_tick) }
     }

--- a/crates/bevy_ecs/src/bundle/spawner.rs
+++ b/crates/bevy_ecs/src/bundle/spawner.rs
@@ -6,7 +6,7 @@ use crate::{
     archetype::{Archetype, ArchetypeCreated, ArchetypeId, SpawnBundleStatus},
     bundle::{Bundle, BundleId, BundleInfo, DynamicBundle, InsertMode},
     change_detection::MaybeLocation,
-    component::{ComponentsRegistrator, Tick},
+    component::Tick,
     entity::{Entities, Entity, EntityLocation},
     lifecycle::{ADD, INSERT},
     relationship::RelationshipHookMode,
@@ -26,16 +26,8 @@ pub(crate) struct BundleSpawner<'w> {
 impl<'w> BundleSpawner<'w> {
     #[inline]
     pub fn new<T: Bundle>(world: &'w mut World, change_tick: Tick) -> Self {
-        // SAFETY: These come from the same world. `world.components_registrator` can't be used since we borrow other fields too.
-        let mut registrator =
-            unsafe { ComponentsRegistrator::new(&mut world.components, &mut world.component_ids) };
+        let bundle_id = world.register_bundle_info::<T>();
 
-        // SAFETY: `registrator`, `world.bundles`, and `world.storages` all come from the same world.
-        let bundle_id = unsafe {
-            world
-                .bundles
-                .register_info::<T>(&mut registrator, &mut world.storages)
-        };
         // SAFETY: we initialized this bundle_id in `init_info`
         unsafe { Self::new_with_id(world, bundle_id, change_tick) }
     }

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -2304,7 +2304,10 @@ impl<'w> EntityWorldMut<'w> {
         let mut registrator = unsafe {
             ComponentsRegistrator::new(&mut self.world.components, &mut self.world.component_ids)
         };
-        let bundle_id = bundles.register_contributed_bundle_info::<T>(&mut registrator, storages);
+
+        // SAFETY: `storages`, `bundles` and `registrator` come from the same world.
+        let bundle_id =
+            unsafe { bundles.register_contributed_bundle_info::<T>(&mut registrator, storages) };
 
         // SAFETY: We just created the bundle, and the archetype is valid, since we are in it.
         let Some(mut remover) = (unsafe {
@@ -2351,10 +2354,13 @@ impl<'w> EntityWorldMut<'w> {
             ComponentsRegistrator::new(&mut self.world.components, &mut self.world.component_ids)
         };
 
-        let retained_bundle = self
-            .world
-            .bundles
-            .register_info::<T>(&mut registrator, storages);
+        // SAFETY: `storages`, `bundles` and `registrator` come from the same world.
+        let retained_bundle = unsafe {
+            self.world
+                .bundles
+                .register_info::<T>(&mut registrator, storages)
+        };
+
         // SAFETY: `retained_bundle` exists as we just initialized it.
         let retained_bundle_info = unsafe { self.world.bundles.get_unchecked(retained_bundle) };
         let old_archetype = &mut archetypes[old_location.archetype_id];

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -2347,7 +2347,10 @@ impl<'w> EntityWorldMut<'w> {
             .components()
             .filter(|c| !retained_bundle_info.contributed_components().contains(c))
             .collect::<Vec<_>>();
-        let remove_bundle = self.world.init_dynamic_bundle_info(to_remove);
+        let remove_bundle =
+            self.world
+                .bundles
+                .init_dynamic_info(&mut self.world.storages, &registrator, to_remove);
 
         // SAFETY: We just created the bundle, and the archetype is valid, since we are in it.
         let Some(mut remover) = (unsafe {

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -2347,10 +2347,11 @@ impl<'w> EntityWorldMut<'w> {
             .components()
             .filter(|c| !retained_bundle_info.contributed_components().contains(c))
             .collect::<Vec<_>>();
-        let remove_bundle =
-            self.world
-                .bundles
-                .init_dynamic_info(&mut self.world.storages, &registrator, to_remove);
+        let remove_bundle = self.world.bundles.init_dynamic_info(
+            &mut self.world.storages,
+            &self.world.components,
+            to_remove,
+        );
 
         // SAFETY: We just created the bundle, and the archetype is valid, since we are in it.
         let Some(mut remover) = (unsafe {

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -5,10 +5,7 @@ use crate::{
         InsertMode,
     },
     change_detection::{MaybeLocation, MutUntyped},
-    component::{
-        Component, ComponentId, ComponentTicks, Components, ComponentsRegistrator, Mutable,
-        StorageType, Tick,
-    },
+    component::{Component, ComponentId, ComponentTicks, Components, Mutable, StorageType, Tick},
     entity::{
         ContainsEntity, Entity, EntityCloner, EntityClonerBuilder, EntityEquivalent,
         EntityIdLocation, EntityLocation, OptIn, OptOut,
@@ -2298,16 +2295,7 @@ impl<'w> EntityWorldMut<'w> {
         caller: MaybeLocation,
     ) -> &mut Self {
         let location = self.location();
-        let storages = &mut self.world.storages;
-        let bundles = &mut self.world.bundles;
-        // SAFETY: These come from the same world.
-        let mut registrator = unsafe {
-            ComponentsRegistrator::new(&mut self.world.components, &mut self.world.component_ids)
-        };
-
-        // SAFETY: `storages`, `bundles` and `registrator` come from the same world.
-        let bundle_id =
-            unsafe { bundles.register_contributed_bundle_info::<T>(&mut registrator, storages) };
+        let bundle_id = self.world.register_contributed_bundle_info::<T>();
 
         // SAFETY: We just created the bundle, and the archetype is valid, since we are in it.
         let Some(mut remover) = (unsafe {
@@ -2347,21 +2335,10 @@ impl<'w> EntityWorldMut<'w> {
     #[inline]
     pub(crate) fn retain_with_caller<T: Bundle>(&mut self, caller: MaybeLocation) -> &mut Self {
         let old_location = self.location();
+        let retained_bundle = self.world.register_bundle_info::<T>();
         let archetypes = &mut self.world.archetypes;
-        let storages = &mut self.world.storages;
-        // SAFETY: These come from the same world.
-        let mut registrator = unsafe {
-            ComponentsRegistrator::new(&mut self.world.components, &mut self.world.component_ids)
-        };
 
-        // SAFETY: `storages`, `bundles` and `registrator` come from the same world.
-        let retained_bundle = unsafe {
-            self.world
-                .bundles
-                .register_info::<T>(&mut registrator, storages)
-        };
-
-        // SAFETY: `retained_bundle` exists as we just initialized it.
+        // SAFETY: `retained_bundle` exists as we just registered it.
         let retained_bundle_info = unsafe { self.world.bundles.get_unchecked(retained_bundle) };
         let old_archetype = &mut archetypes[old_location.archetype_id];
 
@@ -2370,10 +2347,7 @@ impl<'w> EntityWorldMut<'w> {
             .components()
             .filter(|c| !retained_bundle_info.contributed_components().contains(c))
             .collect::<Vec<_>>();
-        let remove_bundle =
-            self.world
-                .bundles
-                .init_dynamic_info(&mut self.world.storages, &registrator, to_remove);
+        let remove_bundle = self.world.init_dynamic_bundle_info(to_remove);
 
         // SAFETY: We just created the bundle, and the archetype is valid, since we are in it.
         let Some(mut remover) = (unsafe {

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -2305,9 +2305,12 @@ impl World {
         // SAFETY: These come from the same world. `Self.components_registrator` can't be used since we borrow other fields too.
         let mut registrator =
             unsafe { ComponentsRegistrator::new(&mut self.components, &mut self.component_ids) };
-        let bundle_id = self
-            .bundles
-            .register_info::<B>(&mut registrator, &mut self.storages);
+
+        // SAFETY: `registrator`, `self.bundles`, and `self.storages` all come from this world.
+        let bundle_id = unsafe {
+            self.bundles
+                .register_info::<B>(&mut registrator, &mut self.storages)
+        };
 
         let mut batch_iter = batch.into_iter();
 
@@ -2450,9 +2453,12 @@ impl World {
         // SAFETY: These come from the same world. `Self.components_registrator` can't be used since we borrow other fields too.
         let mut registrator =
             unsafe { ComponentsRegistrator::new(&mut self.components, &mut self.component_ids) };
-        let bundle_id = self
-            .bundles
-            .register_info::<B>(&mut registrator, &mut self.storages);
+
+        // SAFETY: `registrator`, `self.bundles`, and `self.storages` all come from this world.
+        let bundle_id = unsafe {
+            self.bundles
+                .register_info::<B>(&mut registrator, &mut self.storages)
+        };
 
         let mut invalid_entities = Vec::<Entity>::new();
         let mut batch_iter = batch.into_iter();
@@ -3072,9 +3078,13 @@ impl World {
         // SAFETY: These come from the same world. `Self.components_registrator` can't be used since we borrow other fields too.
         let mut registrator =
             unsafe { ComponentsRegistrator::new(&mut self.components, &mut self.component_ids) };
-        let id = self
-            .bundles
-            .register_info::<B>(&mut registrator, &mut self.storages);
+
+        // SAFETY: `registrator`, `self.storages` and `self.bundles` all come from this world.
+        let id = unsafe {
+            self.bundles
+                .register_info::<B>(&mut registrator, &mut self.storages)
+        };
+
         // SAFETY: We just initialized the bundle so its id should definitely be valid.
         unsafe { self.bundles.get(id).debug_checked_unwrap() }
     }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -3102,21 +3102,11 @@ impl World {
     /// This function will panic if any of the provided component ids do not belong to a component known to this [`World`].
     #[inline]
     pub fn register_dynamic_bundle(&mut self, component_ids: &[ComponentId]) -> &BundleInfo {
-        let id = self.init_dynamic_bundle_info(component_ids);
-
+        let id =
+            self.bundles
+                .init_dynamic_info(&mut self.storages, &self.components, component_ids);
         // SAFETY: We just initialized the bundle so its id should definitely be valid.
         unsafe { self.bundles.get(id).debug_checked_unwrap() }
-    }
-
-    /// Initializes a new [`BundleInfo`] for a dynamic [`Bundle`].
-    ///
-    /// # Panics
-    ///
-    /// Panics if any of the provided [`ComponentId`]s do not exist in this
-    /// [`World`]'s components.
-    pub(crate) fn init_dynamic_bundle_info(&mut self, component_ids: &[ComponentId]) -> BundleId {
-        self.bundles
-            .init_dynamic_info(&mut self.storages, &self.components, component_ids)
     }
 
     /// Convenience method for accessing the world's default error handler,

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -13,15 +13,16 @@ pub mod unsafe_world_cell;
 #[cfg(feature = "bevy_reflect")]
 pub mod reflect;
 
-pub use crate::{
-    change_detection::{Mut, Ref, CHECK_TICK_THRESHOLD},
-    world::command_queue::CommandQueue,
-};
 use crate::{
+    bundle::BundleId,
     error::{DefaultErrorHandler, ErrorHandler},
     event::BufferedEvent,
     lifecycle::{ComponentHooks, ADD, DESPAWN, INSERT, REMOVE, REPLACE},
     prelude::{Add, Despawn, Insert, Remove, Replace},
+};
+pub use crate::{
+    change_detection::{Mut, Ref, CHECK_TICK_THRESHOLD},
+    world::command_queue::CommandQueue,
 };
 pub use bevy_ecs_macros::FromWorld;
 use bevy_utils::prelude::DebugName;
@@ -2302,15 +2303,7 @@ impl World {
 
         self.flush();
         let change_tick = self.change_tick();
-        // SAFETY: These come from the same world. `Self.components_registrator` can't be used since we borrow other fields too.
-        let mut registrator =
-            unsafe { ComponentsRegistrator::new(&mut self.components, &mut self.component_ids) };
-
-        // SAFETY: `registrator`, `self.bundles`, and `self.storages` all come from this world.
-        let bundle_id = unsafe {
-            self.bundles
-                .register_info::<B>(&mut registrator, &mut self.storages)
-        };
+        let bundle_id = self.register_bundle_info::<B>();
 
         let mut batch_iter = batch.into_iter();
 
@@ -2450,15 +2443,7 @@ impl World {
 
         self.flush();
         let change_tick = self.change_tick();
-        // SAFETY: These come from the same world. `Self.components_registrator` can't be used since we borrow other fields too.
-        let mut registrator =
-            unsafe { ComponentsRegistrator::new(&mut self.components, &mut self.component_ids) };
-
-        // SAFETY: `registrator`, `self.bundles`, and `self.storages` all come from this world.
-        let bundle_id = unsafe {
-            self.bundles
-                .register_info::<B>(&mut registrator, &mut self.storages)
-        };
+        let bundle_id = self.register_bundle_info::<B>();
 
         let mut invalid_entities = Vec::<Entity>::new();
         let mut batch_iter = batch.into_iter();
@@ -2470,7 +2455,7 @@ impl World {
             if let Some((first_entity, first_bundle)) = batch_iter.next() {
                 if let Some(first_location) = self.entities().get(first_entity) {
                     let mut cache = InserterArchetypeCache {
-                        // SAFETY: we initialized this bundle_id in `register_info`
+                        // SAFETY: we initialized this bundle_id in `register_bundle_info`
                         inserter: unsafe {
                             BundleInserter::new_with_id(
                                 self,
@@ -3075,18 +3060,34 @@ impl World {
     /// component in the bundle.
     #[inline]
     pub fn register_bundle<B: Bundle>(&mut self) -> &BundleInfo {
+        let id = self.register_bundle_info::<B>();
+
+        // SAFETY: We just initialized the bundle so its id should definitely be valid.
+        unsafe { self.bundles.get(id).debug_checked_unwrap() }
+    }
+
+    pub(crate) fn register_bundle_info<B: Bundle>(&mut self) -> BundleId {
         // SAFETY: These come from the same world. `Self.components_registrator` can't be used since we borrow other fields too.
         let mut registrator =
             unsafe { ComponentsRegistrator::new(&mut self.components, &mut self.component_ids) };
 
         // SAFETY: `registrator`, `self.storages` and `self.bundles` all come from this world.
-        let id = unsafe {
+        unsafe {
             self.bundles
                 .register_info::<B>(&mut registrator, &mut self.storages)
-        };
+        }
+    }
 
-        // SAFETY: We just initialized the bundle so its id should definitely be valid.
-        unsafe { self.bundles.get(id).debug_checked_unwrap() }
+    pub(crate) fn register_contributed_bundle_info<B: Bundle>(&mut self) -> BundleId {
+        // SAFETY: These come from the same world. `Self.components_registrator` can't be used since we borrow other fields too.
+        let mut registrator =
+            unsafe { ComponentsRegistrator::new(&mut self.components, &mut self.component_ids) };
+
+        // SAFETY: `registrator`, `self.bundles` and `self.storages` are all from this world.
+        unsafe {
+            self.bundles
+                .register_contributed_bundle_info::<B>(&mut registrator, &mut self.storages)
+        }
     }
 
     /// Registers the given [`ComponentId`]s as a dynamic bundle and returns both the required component ids and the bundle id.
@@ -3101,11 +3102,21 @@ impl World {
     /// This function will panic if any of the provided component ids do not belong to a component known to this [`World`].
     #[inline]
     pub fn register_dynamic_bundle(&mut self, component_ids: &[ComponentId]) -> &BundleInfo {
-        let id =
-            self.bundles
-                .init_dynamic_info(&mut self.storages, &self.components, component_ids);
+        let id = self.init_dynamic_bundle_info(component_ids);
+
         // SAFETY: We just initialized the bundle so its id should definitely be valid.
         unsafe { self.bundles.get(id).debug_checked_unwrap() }
+    }
+
+    /// Initializes a new [`BundleInfo`] for a dynamic [`Bundle`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if any of the provided [`ComponentId`]s do not exist in this
+    /// [`World`]'s components.
+    pub(crate) fn init_dynamic_bundle_info(&mut self, component_ids: &[ComponentId]) -> BundleId {
+        self.bundles
+            .init_dynamic_info(&mut self.storages, &self.components, component_ids)
     }
 
     /// Convenience method for accessing the world's default error handler,


### PR DESCRIPTION
# Objective

calling `register_info` and `register_contributed_bundle_info` with incorrect arguments results in panics in 100% safe code

## Solution

Mark `register_info` and `register_contributed_bundle_info` as unsafe.
Also optionally add a helper function on `World` that sidesteps any ambiguity regarding safety.

## Testing

no

---

This PR (hopefully, idk how github prs work) contains multiple commits, it probably makes sense to break it up into two PRs too?
The first commit makes the existing functions `unsafe` and adds `deny(unsafe_op_in_unsafe_fn)` to them to make new unsafe changes easier to notice, with the long term goal of being able to have `unsafe_op_in_unsafe_fn` on for the entire crate.

The second commit adds a function to `World` that hides the unsafe bits and encapsulates them to the world to which they belong. There are no calls to `register_info` that don't have direct access to a `&mut World` or reuse the `ComponentRegistrator`. (there's 2 more commits there reverting and fixing some other stuff I touched which I can squash (again, I'm not sure how github prs work)).

It's pretty obvious why this is unsafe, but the function doesn't explicitly forbid it:
```rust
fn safe_bundle_register_world_unsafety() {
    #![forbid(unsafe_code)]
    let mut world = World::new();
    let mut antiworld = World::new();

    #[derive(crate::prelude::Component, Debug, PartialEq, Eq)]
    struct A(u32);

    let mut world_components = world.components_registrator();

    let _ = antiworld
        .bundles
        .register_info::<(A,)>(&mut world_components, &mut antiworld.storages);
    // unsound beyond this point

    let e = antiworld.spawn((A(3),));
    let a = e.get::<A>().unwrap();
    assert_eq!(a, &A(3));
}
```
