### PR TITLE
make bevy_mesh optional for bevy_animate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,6 +167,7 @@ default = [
   "hdr",
   "ktx2",
   "morph",
+  "morph_animation",
   "multi_threaded",
   "png",
   "reflect_auto_register",
@@ -444,6 +445,9 @@ animation = ["bevy_internal/animation", "bevy_animation"]
 
 # Enables support for morph target weights in bevy_mesh
 morph = ["bevy_internal/morph"]
+
+# Enables bevy_mesh and bevy_animation morph weight support
+morph_animation = ["bevy_internal/morph_animation"]
 
 # Enable using a shared stdlib for cxx on Android
 android_shared_stdcxx = ["bevy_internal/android_shared_stdcxx"]

--- a/crates/bevy_animation/Cargo.toml
+++ b/crates/bevy_animation/Cargo.toml
@@ -16,7 +16,7 @@ bevy_asset = { path = "../bevy_asset", version = "0.18.0-dev" }
 bevy_color = { path = "../bevy_color", version = "0.18.0-dev" }
 bevy_derive = { path = "../bevy_derive", version = "0.18.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.18.0-dev" }
-bevy_mesh = { path = "../bevy_mesh", version = "0.18.0-dev", features = [
+bevy_mesh = { path = "../bevy_mesh", version = "0.18.0-dev", optional = true, features = [
   "morph",
 ] }
 bevy_reflect = { path = "../bevy_reflect", version = "0.18.0-dev", features = [

--- a/crates/bevy_animation/src/animation_curves.rs
+++ b/crates/bevy_animation/src/animation_curves.rs
@@ -89,6 +89,8 @@ use core::{
     marker::PhantomData,
 };
 
+#[cfg(feature = "bevy_mesh")]
+pub use crate::morph::*;
 use crate::{
     graph::AnimationNodeIndex,
     prelude::{Animatable, BlendInput},
@@ -97,10 +99,8 @@ use crate::{
 use bevy_ecs::component::{Component, Mutable};
 use bevy_math::curve::{
     cores::{UnevenCore, UnevenCoreError},
-    iterable::IterableCurve,
     Curve, Interval,
 };
-use bevy_mesh::morph::MorphWeights;
 use bevy_platform::hash::Hashed;
 use bevy_reflect::{FromReflect, Reflect, Reflectable, TypeInfo, Typed};
 use downcast_rs::{impl_downcast, Downcast};
@@ -420,206 +420,6 @@ impl<A: Animatable> AnimationCurveEvaluator for AnimatableCurveEvaluator<A> {
     }
 }
 
-/// This type allows an [`IterableCurve`] valued in `f32` to be used as an [`AnimationCurve`]
-/// that animates [morph weights].
-///
-/// [morph weights]: MorphWeights
-#[derive(Debug, Clone, Reflect, FromReflect)]
-#[reflect(from_reflect = false)]
-pub struct WeightsCurve<C>(pub C);
-
-#[derive(Reflect)]
-struct WeightsCurveEvaluator {
-    /// The values of the stack, in which each element is a list of morph target
-    /// weights.
-    ///
-    /// The stack elements are concatenated and tightly packed together.
-    ///
-    /// The number of elements in this stack will always be a multiple of
-    /// [`Self::morph_target_count`].
-    stack_morph_target_weights: Vec<f32>,
-
-    /// The blend weights and graph node indices for each element of the stack.
-    ///
-    /// This should have as many elements as there are stack nodes. In other
-    /// words, `Self::stack_morph_target_weights.len() *
-    /// Self::morph_target_counts as usize ==
-    /// Self::stack_blend_weights_and_graph_nodes`.
-    stack_blend_weights_and_graph_nodes: Vec<(f32, AnimationNodeIndex)>,
-
-    /// The morph target weights in the blend register, if any.
-    ///
-    /// This field should be ignored if [`Self::blend_register_blend_weight`] is
-    /// `None`. If non-empty, it will always have [`Self::morph_target_count`]
-    /// elements in it.
-    blend_register_morph_target_weights: Vec<f32>,
-
-    /// The weight in the blend register.
-    ///
-    /// This will be `None` if the blend register is empty. In that case,
-    /// [`Self::blend_register_morph_target_weights`] will be empty.
-    blend_register_blend_weight: Option<f32>,
-
-    /// The number of morph targets that are to be animated.
-    morph_target_count: Option<u32>,
-}
-
-impl<C> AnimationCurve for WeightsCurve<C>
-where
-    C: IterableCurve<f32> + Debug + Clone + Reflectable,
-{
-    fn clone_value(&self) -> Box<dyn AnimationCurve> {
-        Box::new(self.clone())
-    }
-
-    fn domain(&self) -> Interval {
-        self.0.domain()
-    }
-
-    fn evaluator_id(&self) -> EvaluatorId<'_> {
-        EvaluatorId::Type(TypeId::of::<WeightsCurveEvaluator>())
-    }
-
-    fn create_evaluator(&self) -> Box<dyn AnimationCurveEvaluator> {
-        Box::new(WeightsCurveEvaluator {
-            stack_morph_target_weights: vec![],
-            stack_blend_weights_and_graph_nodes: vec![],
-            blend_register_morph_target_weights: vec![],
-            blend_register_blend_weight: None,
-            morph_target_count: None,
-        })
-    }
-
-    fn apply(
-        &self,
-        curve_evaluator: &mut dyn AnimationCurveEvaluator,
-        t: f32,
-        weight: f32,
-        graph_node: AnimationNodeIndex,
-    ) -> Result<(), AnimationEvaluationError> {
-        let curve_evaluator = curve_evaluator
-            .downcast_mut::<WeightsCurveEvaluator>()
-            .unwrap();
-
-        let prev_morph_target_weights_len = curve_evaluator.stack_morph_target_weights.len();
-        curve_evaluator
-            .stack_morph_target_weights
-            .extend(self.0.sample_iter_clamped(t));
-        curve_evaluator.morph_target_count = Some(
-            (curve_evaluator.stack_morph_target_weights.len() - prev_morph_target_weights_len)
-                as u32,
-        );
-
-        curve_evaluator
-            .stack_blend_weights_and_graph_nodes
-            .push((weight, graph_node));
-        Ok(())
-    }
-}
-
-impl WeightsCurveEvaluator {
-    fn combine(
-        &mut self,
-        graph_node: AnimationNodeIndex,
-        additive: bool,
-    ) -> Result<(), AnimationEvaluationError> {
-        let Some(&(_, top_graph_node)) = self.stack_blend_weights_and_graph_nodes.last() else {
-            return Ok(());
-        };
-        if top_graph_node != graph_node {
-            return Ok(());
-        }
-
-        let (weight_to_blend, _) = self.stack_blend_weights_and_graph_nodes.pop().unwrap();
-        let stack_iter = self.stack_morph_target_weights.drain(
-            (self.stack_morph_target_weights.len() - self.morph_target_count.unwrap() as usize)..,
-        );
-
-        match self.blend_register_blend_weight {
-            None => {
-                self.blend_register_blend_weight = Some(weight_to_blend);
-                self.blend_register_morph_target_weights.clear();
-
-                // In the additive case, the values pushed onto the blend register need
-                // to be scaled by the weight.
-                if additive {
-                    self.blend_register_morph_target_weights
-                        .extend(stack_iter.map(|m| m * weight_to_blend));
-                } else {
-                    self.blend_register_morph_target_weights.extend(stack_iter);
-                }
-            }
-
-            Some(ref mut current_weight) => {
-                *current_weight += weight_to_blend;
-                for (dest, src) in self
-                    .blend_register_morph_target_weights
-                    .iter_mut()
-                    .zip(stack_iter)
-                {
-                    if additive {
-                        *dest += src * weight_to_blend;
-                    } else {
-                        *dest = f32::interpolate(dest, &src, weight_to_blend / *current_weight);
-                    }
-                }
-            }
-        }
-
-        Ok(())
-    }
-}
-
-impl AnimationCurveEvaluator for WeightsCurveEvaluator {
-    fn blend(&mut self, graph_node: AnimationNodeIndex) -> Result<(), AnimationEvaluationError> {
-        self.combine(graph_node, /*additive=*/ false)
-    }
-
-    fn add(&mut self, graph_node: AnimationNodeIndex) -> Result<(), AnimationEvaluationError> {
-        self.combine(graph_node, /*additive=*/ true)
-    }
-
-    fn push_blend_register(
-        &mut self,
-        weight: f32,
-        graph_node: AnimationNodeIndex,
-    ) -> Result<(), AnimationEvaluationError> {
-        if self.blend_register_blend_weight.take().is_some() {
-            self.stack_morph_target_weights
-                .append(&mut self.blend_register_morph_target_weights);
-            self.stack_blend_weights_and_graph_nodes
-                .push((weight, graph_node));
-        }
-        Ok(())
-    }
-
-    fn commit(&mut self, mut entity: AnimationEntityMut) -> Result<(), AnimationEvaluationError> {
-        if self.stack_morph_target_weights.is_empty() {
-            return Ok(());
-        }
-
-        // Compute the index of the first morph target in the last element of
-        // the stack.
-        let index_of_first_morph_target =
-            self.stack_morph_target_weights.len() - self.morph_target_count.unwrap() as usize;
-
-        for (dest, src) in entity
-            .get_mut::<MorphWeights>()
-            .ok_or_else(|| {
-                AnimationEvaluationError::ComponentNotPresent(TypeId::of::<MorphWeights>())
-            })?
-            .weights_mut()
-            .iter_mut()
-            .zip(self.stack_morph_target_weights[index_of_first_morph_target..].iter())
-        {
-            *dest = *src;
-        }
-        self.stack_morph_target_weights.clear();
-        self.stack_blend_weights_and_graph_nodes.clear();
-        Ok(())
-    }
-}
-
 #[derive(Reflect)]
 struct BasicAnimationCurveEvaluator<A>
 where
@@ -821,7 +621,7 @@ pub enum EvaluatorId<'a> {
 /// control over how animations are evaluated.
 ///
 /// You can implement this trait when the generic [`AnimatableCurveEvaluator`]
-/// isn't sufficiently-expressive for your needs. For example, [`MorphWeights`]
+/// isn't sufficiently-expressive for your needs. For example, `MorphWeights`
 /// implements this trait instead of using [`AnimatableCurveEvaluator`] because
 /// it needs to animate arbitrarily many weights at once, which can't be done
 /// with [`Animatable`] as that works on fixed-size values only.

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -13,6 +13,8 @@ pub mod animatable;
 pub mod animation_curves;
 pub mod gltf_curves;
 pub mod graph;
+#[cfg(feature = "bevy_mesh")]
+mod morph;
 pub mod transition;
 
 mod animation_event;
@@ -1249,9 +1251,12 @@ impl Plugin for AnimationPlugin {
                     // it to its own system set after `Update` but before
                     // `PostUpdate`. For now, we just disable ambiguity testing
                     // for this system.
+                    #[cfg(feature = "bevy_mesh")]
                     animate_targets
                         .before(bevy_mesh::InheritWeightSystems)
                         .ambiguous_with_all(),
+                    #[cfg(not(feature = "bevy_mesh"))]
+                    animate_targets.ambiguous_with_all(),
                     trigger_untargeted_animation_events,
                     expire_completed_transitions,
                 )

--- a/crates/bevy_animation/src/morph.rs
+++ b/crates/bevy_animation/src/morph.rs
@@ -1,0 +1,210 @@
+use crate::{
+    animatable::Animatable,
+    animation_curves::{AnimationCurve, AnimationCurveEvaluator, EvaluatorId},
+    graph::AnimationNodeIndex,
+    AnimationEntityMut, AnimationEvaluationError,
+};
+use bevy_math::curve::{iterable::IterableCurve, Interval};
+use bevy_mesh::morph::MorphWeights;
+use bevy_reflect::{FromReflect, Reflect, Reflectable};
+use core::{any::TypeId, fmt::Debug};
+
+/// This type allows an [`IterableCurve`] valued in `f32` to be used as an [`AnimationCurve`]
+/// that animates [morph weights].
+///
+/// [morph weights]: MorphWeights
+#[derive(Debug, Clone, Reflect, FromReflect)]
+#[reflect(from_reflect = false)]
+pub struct WeightsCurve<C>(pub C);
+
+#[derive(Reflect)]
+struct WeightsCurveEvaluator {
+    /// The values of the stack, in which each element is a list of morph target
+    /// weights.
+    ///
+    /// The stack elements are concatenated and tightly packed together.
+    ///
+    /// The number of elements in this stack will always be a multiple of
+    /// [`Self::morph_target_count`].
+    stack_morph_target_weights: Vec<f32>,
+
+    /// The blend weights and graph node indices for each element of the stack.
+    ///
+    /// This should have as many elements as there are stack nodes. In other
+    /// words, `Self::stack_morph_target_weights.len() *
+    /// Self::morph_target_counts as usize ==
+    /// Self::stack_blend_weights_and_graph_nodes`.
+    stack_blend_weights_and_graph_nodes: Vec<(f32, AnimationNodeIndex)>,
+
+    /// The morph target weights in the blend register, if any.
+    ///
+    /// This field should be ignored if [`Self::blend_register_blend_weight`] is
+    /// `None`. If non-empty, it will always have [`Self::morph_target_count`]
+    /// elements in it.
+    blend_register_morph_target_weights: Vec<f32>,
+
+    /// The weight in the blend register.
+    ///
+    /// This will be `None` if the blend register is empty. In that case,
+    /// [`Self::blend_register_morph_target_weights`] will be empty.
+    blend_register_blend_weight: Option<f32>,
+
+    /// The number of morph targets that are to be animated.
+    morph_target_count: Option<u32>,
+}
+
+impl<C> AnimationCurve for WeightsCurve<C>
+where
+    C: IterableCurve<f32> + Debug + Clone + Reflectable,
+{
+    fn clone_value(&self) -> Box<dyn AnimationCurve> {
+        Box::new(self.clone())
+    }
+
+    fn domain(&self) -> Interval {
+        self.0.domain()
+    }
+
+    fn evaluator_id(&self) -> EvaluatorId<'_> {
+        EvaluatorId::Type(TypeId::of::<WeightsCurveEvaluator>())
+    }
+
+    fn create_evaluator(&self) -> Box<dyn AnimationCurveEvaluator> {
+        Box::new(WeightsCurveEvaluator {
+            stack_morph_target_weights: vec![],
+            stack_blend_weights_and_graph_nodes: vec![],
+            blend_register_morph_target_weights: vec![],
+            blend_register_blend_weight: None,
+            morph_target_count: None,
+        })
+    }
+
+    fn apply(
+        &self,
+        curve_evaluator: &mut dyn AnimationCurveEvaluator,
+        t: f32,
+        weight: f32,
+        graph_node: AnimationNodeIndex,
+    ) -> Result<(), AnimationEvaluationError> {
+        let curve_evaluator = curve_evaluator
+            .downcast_mut::<WeightsCurveEvaluator>()
+            .unwrap();
+
+        let prev_morph_target_weights_len = curve_evaluator.stack_morph_target_weights.len();
+        curve_evaluator
+            .stack_morph_target_weights
+            .extend(self.0.sample_iter_clamped(t));
+        curve_evaluator.morph_target_count = Some(
+            (curve_evaluator.stack_morph_target_weights.len() - prev_morph_target_weights_len)
+                as u32,
+        );
+
+        curve_evaluator
+            .stack_blend_weights_and_graph_nodes
+            .push((weight, graph_node));
+        Ok(())
+    }
+}
+
+impl WeightsCurveEvaluator {
+    fn combine(
+        &mut self,
+        graph_node: AnimationNodeIndex,
+        additive: bool,
+    ) -> Result<(), AnimationEvaluationError> {
+        let Some(&(_, top_graph_node)) = self.stack_blend_weights_and_graph_nodes.last() else {
+            return Ok(());
+        };
+        if top_graph_node != graph_node {
+            return Ok(());
+        }
+
+        let (weight_to_blend, _) = self.stack_blend_weights_and_graph_nodes.pop().unwrap();
+        let stack_iter = self.stack_morph_target_weights.drain(
+            (self.stack_morph_target_weights.len() - self.morph_target_count.unwrap() as usize)..,
+        );
+
+        match self.blend_register_blend_weight {
+            None => {
+                self.blend_register_blend_weight = Some(weight_to_blend);
+                self.blend_register_morph_target_weights.clear();
+
+                // In the additive case, the values pushed onto the blend register need
+                // to be scaled by the weight.
+                if additive {
+                    self.blend_register_morph_target_weights
+                        .extend(stack_iter.map(|m| m * weight_to_blend));
+                } else {
+                    self.blend_register_morph_target_weights.extend(stack_iter);
+                }
+            }
+
+            Some(ref mut current_weight) => {
+                *current_weight += weight_to_blend;
+                for (dest, src) in self
+                    .blend_register_morph_target_weights
+                    .iter_mut()
+                    .zip(stack_iter)
+                {
+                    if additive {
+                        *dest += src * weight_to_blend;
+                    } else {
+                        *dest = f32::interpolate(dest, &src, weight_to_blend / *current_weight);
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl AnimationCurveEvaluator for WeightsCurveEvaluator {
+    fn blend(&mut self, graph_node: AnimationNodeIndex) -> Result<(), AnimationEvaluationError> {
+        self.combine(graph_node, /*additive=*/ false)
+    }
+
+    fn add(&mut self, graph_node: AnimationNodeIndex) -> Result<(), AnimationEvaluationError> {
+        self.combine(graph_node, /*additive=*/ true)
+    }
+
+    fn push_blend_register(
+        &mut self,
+        weight: f32,
+        graph_node: AnimationNodeIndex,
+    ) -> Result<(), AnimationEvaluationError> {
+        if self.blend_register_blend_weight.take().is_some() {
+            self.stack_morph_target_weights
+                .append(&mut self.blend_register_morph_target_weights);
+            self.stack_blend_weights_and_graph_nodes
+                .push((weight, graph_node));
+        }
+        Ok(())
+    }
+
+    fn commit(&mut self, mut entity: AnimationEntityMut) -> Result<(), AnimationEvaluationError> {
+        if self.stack_morph_target_weights.is_empty() {
+            return Ok(());
+        }
+
+        // Compute the index of the first morph target in the last element of
+        // the stack.
+        let index_of_first_morph_target =
+            self.stack_morph_target_weights.len() - self.morph_target_count.unwrap() as usize;
+
+        for (dest, src) in entity
+            .get_mut::<MorphWeights>()
+            .ok_or_else(|| {
+                AnimationEvaluationError::ComponentNotPresent(TypeId::of::<MorphWeights>())
+            })?
+            .weights_mut()
+            .iter_mut()
+            .zip(self.stack_morph_target_weights[index_of_first_morph_target..].iter())
+        {
+            *dest = *src;
+        }
+        self.stack_morph_target_weights.clear();
+        self.stack_blend_weights_and_graph_nodes.clear();
+        Ok(())
+    }
+}

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -212,6 +212,9 @@ animation = [
 # Enables support for morph target weights in bevy_mesh
 morph = ["bevy_mesh?/morph", "bevy_render?/morph"]
 
+# Enables bevy_mesh and bevy_animation morph weight support
+morph_animation = ["morph", "bevy_animation?/bevy_mesh"]
+
 bevy_shader = ["dep:bevy_shader"]
 bevy_image = ["dep:bevy_image", "bevy_color", "bevy_asset"]
 bevy_sprite = ["dep:bevy_sprite", "bevy_camera"]

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -53,6 +53,7 @@ The default feature set enables most of the expected features of a game engine, 
 |hdr|HDR image format support|
 |ktx2|KTX2 compressed texture support|
 |morph|Enables support for morph target weights in bevy_mesh|
+|morph_animation|Enables bevy_mesh and bevy_animation morph weight support|
 |multi_threaded|Enables multithreaded parallelism in the engine. Disabling it forces all engine tasks to run on a single thread.|
 |png|PNG image format support|
 |reflect_auto_register|Enable automatic reflect registration|


### PR DESCRIPTION
# Objective

- make bevy_mesh optional for bevy_animate as mentioned in https://github.com/bevyengine/bevy/pull/20714#issuecomment-3218581329

## Solution

- copy paste the morph weights stuff out into a module, gate it, then add the optional dep