### PR TITLE
Cleanup bevy_tasks::future module

### DIFF
--- a/crates/bevy_tasks/src/futures.rs
+++ b/crates/bevy_tasks/src/futures.rs
@@ -1,24 +1,17 @@
-#![expect(unsafe_code, reason = "Futures require unsafe code.")]
-
 //! Utilities for working with [`Future`]s.
 use core::{
     future::Future,
-    pin::Pin,
-    task::{Context, Poll, RawWaker, RawWakerVTable, Waker},
+    pin::{pin, Pin},
+    task::{Context, Poll, Waker},
 };
 
 /// Consumes a future, polls it once, and immediately returns the output
 /// or returns `None` if it wasn't ready yet.
 ///
 /// This will cancel the future if it's not ready.
-pub fn now_or_never<F: Future>(mut future: F) -> Option<F::Output> {
-    let noop_waker = noop_waker();
-    let mut cx = Context::from_waker(&noop_waker);
-
-    // SAFETY: `future` is not moved and the original value is shadowed
-    let future = unsafe { Pin::new_unchecked(&mut future) };
-
-    match future.poll(&mut cx) {
+pub fn now_or_never<F: Future>(future: F) -> Option<F::Output> {
+    let mut cx = Context::from_waker(Waker::noop());
+    match pin!(future).poll(&mut cx) {
         Poll::Ready(x) => Some(x),
         _ => None,
     }
@@ -27,30 +20,9 @@ pub fn now_or_never<F: Future>(mut future: F) -> Option<F::Output> {
 /// Polls a future once, and returns the output if ready
 /// or returns `None` if it wasn't ready yet.
 pub fn check_ready<F: Future + Unpin>(future: &mut F) -> Option<F::Output> {
-    let noop_waker = noop_waker();
-    let mut cx = Context::from_waker(&noop_waker);
-
-    let future = Pin::new(future);
-
-    match future.poll(&mut cx) {
+    let mut cx = Context::from_waker(Waker::noop());
+    match Pin::new(future).poll(&mut cx) {
         Poll::Ready(x) => Some(x),
         _ => None,
     }
-}
-
-fn noop_clone(_data: *const ()) -> RawWaker {
-    noop_raw_waker()
-}
-fn noop(_data: *const ()) {}
-
-const NOOP_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(noop_clone, noop, noop, noop);
-
-fn noop_raw_waker() -> RawWaker {
-    RawWaker::new(core::ptr::null(), &NOOP_WAKER_VTABLE)
-}
-
-pub(crate) fn noop_waker() -> Waker {
-    // SAFETY: the `RawWakerVTable` is just a big noop and doesn't violate any of the rules in `RawWakerVTable`s documentation
-    // (which talks about retaining and releasing any "resources", of which there are none in this case)
-    unsafe { Waker::from_raw(noop_raw_waker()) }
 }

--- a/crates/bevy_tasks/src/futures.rs
+++ b/crates/bevy_tasks/src/futures.rs
@@ -1,7 +1,7 @@
 //! Utilities for working with [`Future`]s.
 use core::{
     future::Future,
-    pin::{pin, Pin},
+    pin::pin,
     task::{Context, Poll, Waker},
 };
 
@@ -20,9 +20,5 @@ pub fn now_or_never<F: Future>(future: F) -> Option<F::Output> {
 /// Polls a future once, and returns the output if ready
 /// or returns `None` if it wasn't ready yet.
 pub fn check_ready<F: Future + Unpin>(future: &mut F) -> Option<F::Output> {
-    let mut cx = Context::from_waker(Waker::noop());
-    match Pin::new(future).poll(&mut cx) {
-        Poll::Ready(x) => Some(x),
-        _ => None,
-    }
+    now_or_never(future)
 }

--- a/crates/bevy_tasks/src/lib.rs
+++ b/crates/bevy_tasks/src/lib.rs
@@ -132,7 +132,7 @@ cfg::switch! {
             let mut future = core::pin::pin!(future);
 
             // We don't care about the waker as we're just going to poll as fast as possible.
-            let cx = &mut Context::from_waker(Waker::noop());
+            let cx = &mut Context::from_waker(core::task::Waker::noop());
 
             // Keep polling until the future is ready.
             loop {

--- a/crates/bevy_tasks/src/lib.rs
+++ b/crates/bevy_tasks/src/lib.rs
@@ -132,8 +132,7 @@ cfg::switch! {
             let mut future = core::pin::pin!(future);
 
             // We don't care about the waker as we're just going to poll as fast as possible.
-            let waker = futures::noop_waker();
-            let cx = &mut Context::from_waker(&waker);
+            let cx = &mut Context::from_waker(Waker::noop());
 
             // Keep polling until the future is ready.
             loop {


### PR DESCRIPTION
# Objective
`Waker::noop` was stabilized in Rust 1.85, and we have a vendored version in tree.

## Solution
Remove it and clean up related code.

## Testing
CI