### PR TITLE
Make loading GLTF animations optional

### DIFF
--- a/crates/bevy_gltf/src/loader/mod.rs
+++ b/crates/bevy_gltf/src/loader/mod.rs
@@ -191,6 +191,8 @@ pub struct GltfLoaderSettings {
     pub load_cameras: bool,
     /// If true, the loader will spawn lights for gltf light nodes.
     pub load_lights: bool,
+    /// If true, the loader will load animations. Requires `bevy_animation` feature.
+    pub load_animations: bool,
     /// If true, the loader will include the root of the gltf root node.
     pub include_source: bool,
     /// Overrides the default sampler. Data from sampler node is added on top of that.
@@ -221,6 +223,7 @@ impl Default for GltfLoaderSettings {
             load_materials: RenderAssetUsages::default(),
             load_cameras: true,
             load_lights: true,
+            load_animations: true,
             include_source: false,
             default_sampler: None,
             override_sampler: false,
@@ -253,7 +256,7 @@ impl GltfLoader {
         let linear_textures = get_linear_textures(&gltf.document);
 
         #[cfg(feature = "bevy_animation")]
-        let paths = {
+        let paths = if settings.load_animations {
             let mut paths = HashMap::<usize, (usize, Vec<Name>)>::default();
             for scene in gltf.scenes() {
                 for node in scene.nodes() {
@@ -262,6 +265,8 @@ impl GltfLoader {
                 }
             }
             paths
+        } else {
+            Default::default()
         };
 
         let convert_coordinates = match settings.use_model_forward_direction {
@@ -270,7 +275,7 @@ impl GltfLoader {
         };
 
         #[cfg(feature = "bevy_animation")]
-        let (animations, named_animations, animation_roots) = {
+        let (animations, named_animations, animation_roots) = if settings.load_animations {
             use bevy_animation::{
                 animated_field, animation_curves::*, gltf_curves::*, VariableCurve,
             };
@@ -571,6 +576,8 @@ impl GltfLoader {
                 animations.push(handle);
             }
             (animations, named_animations, animation_roots)
+        } else {
+            Default::default()
         };
 
         let default_sampler = match settings.default_sampler.as_ref() {


### PR DESCRIPTION
# Objective

- There was a mistaken belief in #20714 that it is possible to use bevy_gltf and bevy_animation without loading the animations of a gltf. This is not the case, the animation loading is gated by the presence of the bevy_animation crate. (And I believe this is how it should be.)
- We want to be able to control gltf animation loading though, and I think it should be at the asset granularity. You may want some loaded with animation and some without, or maybe even load the same asset sometimes with animation and sometimes without.

## Solution

- Just add a flag to the load settings

## Testing

- many_foxes works, and setting the flag to false makes the foxes not animate