### PR TITLE
update some stress tests to use the common setup

### DIFF
--- a/examples/stress_tests/many_gradients.rs
+++ b/examples/stress_tests/many_gradients.rs
@@ -61,7 +61,7 @@ fn main() {
             DefaultPlugins.set(WindowPlugin {
                 primary_window: Some(Window {
                     title: "Gradient Stress Test".to_string(),
-                    resolution: WindowResolution::new(1920, 1080),
+                    resolution: WindowResolution::new(1920, 1080).with_scale_factor_override(1.0),
                     present_mode: PresentMode::AutoNoVsync,
                     ..default()
                 }),

--- a/examples/stress_tests/many_gradients.rs
+++ b/examples/stress_tests/many_gradients.rs
@@ -14,6 +14,7 @@ use bevy::{
         RepeatedGridTrack,
     },
     window::{PresentMode, WindowResolution},
+    winit::{UpdateMode, WinitSettings},
 };
 
 const COLS: usize = 30;
@@ -68,6 +69,10 @@ fn main() {
                 ..default()
             }),
         ))
+        .insert_resource(WinitSettings {
+            focused_mode: UpdateMode::Continuous,
+            unfocused_mode: UpdateMode::Continuous,
+        })
         .insert_resource(args)
         .add_systems(Startup, setup)
         .add_systems(Update, animate_gradients)

--- a/examples/stress_tests/many_materials.rs
+++ b/examples/stress_tests/many_materials.rs
@@ -3,7 +3,8 @@ use argh::FromArgs;
 use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     prelude::*,
-    window::{PresentMode, WindowPlugin, WindowResolution},
+    window::{PresentMode, WindowResolution},
+    winit::{UpdateMode, WinitSettings},
 };
 use std::f32::consts::PI;
 
@@ -36,6 +37,10 @@ fn main() {
             FrameTimeDiagnosticsPlugin::default(),
             LogDiagnosticsPlugin::default(),
         ))
+        .insert_resource(WinitSettings {
+            focused_mode: UpdateMode::Continuous,
+            unfocused_mode: UpdateMode::Continuous,
+        })
         .insert_resource(args)
         .add_systems(Startup, setup)
         .add_systems(Update, animate_materials)

--- a/examples/stress_tests/many_text2d.rs
+++ b/examples/stress_tests/many_text2d.rs
@@ -8,6 +8,7 @@ use bevy::{
     prelude::*,
     text::FontAtlasSets,
     window::{PresentMode, WindowResolution},
+    winit::{UpdateMode, WinitSettings},
 };
 
 use argh::FromArgs;
@@ -81,6 +82,10 @@ fn main() {
             ..default()
         }),
     ))
+    .insert_resource(WinitSettings {
+        focused_mode: UpdateMode::Continuous,
+        unfocused_mode: UpdateMode::Continuous,
+    })
     .init_resource::<FontHandle>()
     .add_systems(Startup, setup)
     .add_systems(Update, (move_camera, print_counts));


### PR DESCRIPTION
# Objective

- `many_gradients`, `many_materials` and `many_text2d` don't always run at their full potential

## Solution

- Use the same scale factor as other stress tests.
- Use the same winit settings as other stress tests.
