### PR TITLE
Remove generic Components functions

### DIFF
--- a/crates/bevy_asset/src/asset_changed.rs
+++ b/crates/bevy_asset/src/asset_changed.rs
@@ -246,7 +246,7 @@ unsafe impl<A: AsAssetId> WorldQuery for AssetChanged<A> {
     }
 
     fn get_state(components: &Components) -> Option<Self::State> {
-        let resource_id = components.resource_id::<AssetChanges<A::Asset>>()?;
+        let resource_id = components.get_resource_id(TypeId::of::<AssetChanges<A::Asset>>())?;
         let asset_id = components.get_id(TypeId::of::<A>())?;
         Some(AssetChangedState {
             asset_id,

--- a/crates/bevy_asset/src/asset_changed.rs
+++ b/crates/bevy_asset/src/asset_changed.rs
@@ -13,6 +13,7 @@ use bevy_ecs::{
     storage::{Table, TableRow},
     world::unsafe_world_cell::UnsafeWorldCell,
 };
+use core::any::TypeId;
 use bevy_platform::collections::HashMap;
 use core::marker::PhantomData;
 use disqualified::ShortName;
@@ -246,7 +247,7 @@ unsafe impl<A: AsAssetId> WorldQuery for AssetChanged<A> {
 
     fn get_state(components: &Components) -> Option<Self::State> {
         let resource_id = components.resource_id::<AssetChanges<A::Asset>>()?;
-        let asset_id = components.component_id::<A>()?;
+        let asset_id = components.get_id(TypeId::of::<A>())?;
         Some(AssetChangedState {
             asset_id,
             resource_id,

--- a/crates/bevy_asset/src/asset_changed.rs
+++ b/crates/bevy_asset/src/asset_changed.rs
@@ -13,8 +13,8 @@ use bevy_ecs::{
     storage::{Table, TableRow},
     world::unsafe_world_cell::UnsafeWorldCell,
 };
-use core::any::TypeId;
 use bevy_platform::collections::HashMap;
+use core::any::TypeId;
 use core::marker::PhantomData;
 use disqualified::ShortName;
 use tracing::error;

--- a/crates/bevy_ecs/src/component/info.rs
+++ b/crates/bevy_ecs/src/component/info.rs
@@ -616,19 +616,6 @@ impl Components {
         self.get_valid_resource_id(TypeId::of::<T>())
     }
 
-    /// Type-erased equivalent of [`Components::component_id()`].
-    #[inline]
-    pub fn get_id(&self, type_id: TypeId) -> Option<ComponentId> {
-        self.indices.get(&type_id).copied().or_else(|| {
-            self.queued
-                .read()
-                .unwrap_or_else(PoisonError::into_inner)
-                .components
-                .get(&type_id)
-                .map(|queued| queued.id)
-        })
-    }
-
     /// Returns the [`ComponentId`] of the given [`Component`] type `T`.
     ///
     /// The returned `ComponentId` is specific to the `Components` instance
@@ -659,8 +646,15 @@ impl Components {
     /// * [`Components::resource_id()`]
     /// * [`World::component_id()`](crate::world::World::component_id)
     #[inline]
-    pub fn component_id<T: Component>(&self) -> Option<ComponentId> {
-        self.get_id(TypeId::of::<T>())
+    pub fn get_id(&self, type_id: TypeId) -> Option<ComponentId> {
+        self.indices.get(&type_id).copied().or_else(|| {
+            self.queued
+                .read()
+                .unwrap_or_else(PoisonError::into_inner)
+                .components
+                .get(&type_id)
+                .map(|queued| queued.id)
+        })
     }
 
     /// Type-erased equivalent of [`Components::resource_id()`].

--- a/crates/bevy_ecs/src/component/info.rs
+++ b/crates/bevy_ecs/src/component/info.rs
@@ -642,7 +642,6 @@ impl Components {
     /// # See also
     ///
     /// * [`ComponentIdFor`](super::ComponentIdFor)
-    /// * [`Components::get_id()`]
     /// * [`Components::resource_id()`]
     /// * [`World::component_id()`](crate::world::World::component_id)
     #[inline]
@@ -652,19 +651,6 @@ impl Components {
                 .read()
                 .unwrap_or_else(PoisonError::into_inner)
                 .components
-                .get(&type_id)
-                .map(|queued| queued.id)
-        })
-    }
-
-    /// Type-erased equivalent of [`Components::resource_id()`].
-    #[inline]
-    pub fn get_resource_id(&self, type_id: TypeId) -> Option<ComponentId> {
-        self.resource_indices.get(&type_id).copied().or_else(|| {
-            self.queued
-                .read()
-                .unwrap_or_else(PoisonError::into_inner)
-                .resources
                 .get(&type_id)
                 .map(|queued| queued.id)
         })
@@ -695,11 +681,17 @@ impl Components {
     ///
     /// # See also
     ///
-    /// * [`Components::component_id()`]
     /// * [`Components::get_resource_id()`]
     #[inline]
-    pub fn resource_id<T: Resource>(&self) -> Option<ComponentId> {
-        self.get_resource_id(TypeId::of::<T>())
+    pub fn get_resource_id(&self, type_id: TypeId) -> Option<ComponentId> {
+        self.resource_indices.get(&type_id).copied().or_else(|| {
+            self.queued
+                .read()
+                .unwrap_or_else(PoisonError::into_inner)
+                .resources
+                .get(&type_id)
+                .map(|queued| queued.id)
+        })
     }
 
     /// # Safety

--- a/crates/bevy_ecs/src/component/info.rs
+++ b/crates/bevy_ecs/src/component/info.rs
@@ -553,12 +553,6 @@ impl Components {
         self.components.get(id.0).is_some_and(Option::is_some)
     }
 
-    /// Type-erased equivalent of [`Components::valid_component_id()`].
-    #[inline]
-    pub fn get_valid_id(&self, type_id: TypeId) -> Option<ComponentId> {
-        self.indices.get(&type_id).copied()
-    }
-
     /// Returns the [`ComponentId`] of the given [`Component`] type `T` if it is fully registered.
     /// If you want to include queued registration, see [`Components::component_id()`].
     ///
@@ -581,14 +575,8 @@ impl Components {
     /// * [`Components::valid_resource_id()`]
     /// * [`World::component_id()`](crate::world::World::component_id)
     #[inline]
-    pub fn valid_component_id<T: Component>(&self) -> Option<ComponentId> {
-        self.get_valid_id(TypeId::of::<T>())
-    }
-
-    /// Type-erased equivalent of [`Components::valid_resource_id()`].
-    #[inline]
-    pub fn get_valid_resource_id(&self, type_id: TypeId) -> Option<ComponentId> {
-        self.resource_indices.get(&type_id).copied()
+    pub fn get_valid_id(&self, type_id: TypeId) -> Option<ComponentId> {
+        self.indices.get(&type_id).copied()
     }
 
     /// Returns the [`ComponentId`] of the given [`Resource`] type `T` if it is fully registered.
@@ -612,8 +600,8 @@ impl Components {
     /// * [`Components::valid_component_id()`]
     /// * [`Components::get_resource_id()`]
     #[inline]
-    pub fn valid_resource_id<T: Resource>(&self) -> Option<ComponentId> {
-        self.get_valid_resource_id(TypeId::of::<T>())
+    pub fn get_valid_resource_id(&self, type_id: TypeId) -> Option<ComponentId> {
+        self.resource_indices.get(&type_id).copied()
     }
 
     /// Returns the [`ComponentId`] of the given [`Component`] type `T`.

--- a/crates/bevy_ecs/src/entity/clone_entities.rs
+++ b/crates/bevy_ecs/src/entity/clone_entities.rs
@@ -831,7 +831,7 @@ impl<'w, Filter: CloneByFilter> EntityClonerBuilder<'w, Filter> {
         &mut self,
         clone_behavior: ComponentCloneBehavior,
     ) -> &mut Self {
-        if let Some(id) = self.world.components().valid_component_id::<T>() {
+        if let Some(id) = self.world.components().get_valid_id(TypeId::of::<T>()) {
             self.state
                 .clone_behavior_overrides
                 .insert(id, clone_behavior);
@@ -856,7 +856,7 @@ impl<'w, Filter: CloneByFilter> EntityClonerBuilder<'w, Filter> {
 
     /// Removes a previously set override of [`ComponentCloneBehavior`] for a component in this builder.
     pub fn remove_clone_behavior_override<T: Component>(&mut self) -> &mut Self {
-        if let Some(id) = self.world.components().valid_component_id::<T>() {
+        if let Some(id) = self.world.components().get_valid_id(TypeId::of::<T>()) {
             self.state.clone_behavior_overrides.remove(&id);
         }
         self

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -11,9 +11,9 @@ use crate::{
         FilteredEntityMut, FilteredEntityRef, Mut, Ref, World,
     },
 };
-use core::any::TypeId;
 use bevy_ptr::{ThinSlicePtr, UnsafeCellDeref};
 use bevy_utils::prelude::DebugName;
+use core::any::TypeId;
 use core::{cell::UnsafeCell, marker::PhantomData, panic::Location};
 use variadics_please::all_tuples;
 

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -11,6 +11,7 @@ use crate::{
         FilteredEntityMut, FilteredEntityRef, Mut, Ref, World,
     },
 };
+use core::any::TypeId;
 use bevy_ptr::{ThinSlicePtr, UnsafeCellDeref};
 use bevy_utils::prelude::DebugName;
 use core::{cell::UnsafeCell, marker::PhantomData, panic::Location};
@@ -1571,7 +1572,7 @@ unsafe impl<T: Component> WorldQuery for &T {
     }
 
     fn get_state(components: &Components) -> Option<Self::State> {
-        components.component_id::<T>()
+        components.get_id(TypeId::of::<T>())
     }
 
     fn matches_component_set(
@@ -1754,7 +1755,7 @@ unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
     }
 
     fn get_state(components: &Components) -> Option<Self::State> {
-        components.component_id::<T>()
+        components.get_id(TypeId::of::<T>())
     }
 
     fn matches_component_set(
@@ -1960,7 +1961,7 @@ unsafe impl<'__w, T: Component> WorldQuery for &'__w mut T {
     }
 
     fn get_state(components: &Components) -> Option<Self::State> {
-        components.component_id::<T>()
+        components.get_id(TypeId::of::<T>())
     }
 
     fn matches_component_set(
@@ -2423,7 +2424,7 @@ unsafe impl<T: Component> WorldQuery for Has<T> {
     }
 
     fn get_state(components: &Components) -> Option<Self::State> {
-        components.component_id::<T>()
+        components.get_id(TypeId::of::<T>())
     }
 
     fn matches_component_set(

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -6,6 +6,7 @@ use crate::{
     storage::{ComponentSparseSet, Table, TableRow},
     world::{unsafe_world_cell::UnsafeWorldCell, World},
 };
+use core::any::TypeId;
 use bevy_ptr::{ThinSlicePtr, UnsafeCellDeref};
 use bevy_utils::prelude::DebugName;
 use core::{cell::UnsafeCell, marker::PhantomData};
@@ -189,7 +190,7 @@ unsafe impl<T: Component> WorldQuery for With<T> {
     }
 
     fn get_state(components: &Components) -> Option<Self::State> {
-        components.component_id::<T>()
+        components.get_id(TypeId::of::<T>())
     }
 
     fn matches_component_set(
@@ -290,7 +291,7 @@ unsafe impl<T: Component> WorldQuery for Without<T> {
     }
 
     fn get_state(components: &Components) -> Option<Self::State> {
-        components.component_id::<T>()
+        components.get_id(TypeId::of::<T>())
     }
 
     fn matches_component_set(
@@ -604,7 +605,7 @@ unsafe impl<T: Component> WorldQuery for Allow<T> {
     }
 
     fn get_state(components: &Components) -> Option<Self::State> {
-        components.component_id::<T>()
+        components.get_id(TypeId::of::<T>())
     }
 
     fn matches_component_set(_: &ComponentId, _: &impl Fn(ComponentId) -> bool) -> bool {
@@ -805,7 +806,7 @@ unsafe impl<T: Component> WorldQuery for Added<T> {
     }
 
     fn get_state(components: &Components) -> Option<ComponentId> {
-        components.component_id::<T>()
+        components.get_id(TypeId::of::<T>())
     }
 
     fn matches_component_set(
@@ -1032,7 +1033,7 @@ unsafe impl<T: Component> WorldQuery for Changed<T> {
     }
 
     fn get_state(components: &Components) -> Option<ComponentId> {
-        components.component_id::<T>()
+        components.get_id(TypeId::of::<T>())
     }
 
     fn matches_component_set(

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -6,9 +6,9 @@ use crate::{
     storage::{ComponentSparseSet, Table, TableRow},
     world::{unsafe_world_cell::UnsafeWorldCell, World},
 };
-use core::any::TypeId;
 use bevy_ptr::{ThinSlicePtr, UnsafeCellDeref};
 use bevy_utils::prelude::DebugName;
+use core::any::TypeId;
 use core::{cell::UnsafeCell, marker::PhantomData};
 use variadics_please::all_tuples;
 

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -4190,7 +4190,7 @@ where
         C: Component,
     {
         let components = self.entity.world().components();
-        let id = components.valid_component_id::<C>()?;
+        let id = components.get_valid_id(TypeId::of::<C>())?;
         if bundle_contains_component::<B>(components, id) {
             None
         } else {
@@ -4210,7 +4210,7 @@ where
         C: Component,
     {
         let components = self.entity.world().components();
-        let id = components.valid_component_id::<C>()?;
+        let id = components.get_valid_id(TypeId::of::<C>())?;
         if bundle_contains_component::<B>(components, id) {
             None
         } else {
@@ -4465,7 +4465,7 @@ where
         C: Component<Mutability = Mutable>,
     {
         let components = self.entity.world().components();
-        let id = components.valid_component_id::<C>()?;
+        let id = components.get_valid_id(TypeId::of::<C>())?;
         if bundle_contains_component::<B>(components, id) {
             None
         } else {

--- a/crates/bevy_ecs/src/world/filtered_resource.rs
+++ b/crates/bevy_ecs/src/world/filtered_resource.rs
@@ -5,6 +5,7 @@ use crate::{
     resource::Resource,
     world::{unsafe_world_cell::UnsafeWorldCell, World},
 };
+use core::any::TypeId;
 use bevy_ptr::{Ptr, UnsafeCellDeref};
 
 use super::error::ResourceFetchError;
@@ -148,7 +149,7 @@ impl<'w, 's> FilteredResources<'w, 's> {
     /// Returns `true` if the `FilteredResources` has access to the given resource.
     /// Note that [`Self::get()`] may still return `Err` if the resource does not exist.
     pub fn has_read<R: Resource>(&self) -> bool {
-        let component_id = self.world.components().resource_id::<R>();
+        let component_id = self.world.components().get_resource_id(TypeId::of::<R>());
         component_id.is_some_and(|component_id| self.access.has_resource_read(component_id))
     }
 
@@ -416,14 +417,14 @@ impl<'w, 's> FilteredResourcesMut<'w, 's> {
     /// Returns `true` if the `FilteredResources` has read access to the given resource.
     /// Note that [`Self::get()`] may still return `Err` if the resource does not exist.
     pub fn has_read<R: Resource>(&self) -> bool {
-        let component_id = self.world.components().resource_id::<R>();
+        let component_id = self.world.components().get_resource_id(TypeId::of::<R>());
         component_id.is_some_and(|component_id| self.access.has_resource_read(component_id))
     }
 
     /// Returns `true` if the `FilteredResources` has write access to the given resource.
     /// Note that [`Self::get_mut()`] may still return `Err` if the resource does not exist.
     pub fn has_write<R: Resource>(&self) -> bool {
-        let component_id = self.world.components().resource_id::<R>();
+        let component_id = self.world.components().get_resource_id(TypeId::of::<R>());
         component_id.is_some_and(|component_id| self.access.has_resource_write(component_id))
     }
 

--- a/crates/bevy_ecs/src/world/filtered_resource.rs
+++ b/crates/bevy_ecs/src/world/filtered_resource.rs
@@ -5,8 +5,8 @@ use crate::{
     resource::Resource,
     world::{unsafe_world_cell::UnsafeWorldCell, World},
 };
-use core::any::TypeId;
 use bevy_ptr::{Ptr, UnsafeCellDeref};
+use core::any::TypeId;
 
 use super::error::ResourceFetchError;
 
@@ -158,7 +158,7 @@ impl<'w, 's> FilteredResources<'w, 's> {
         let component_id = self
             .world
             .components()
-            .valid_resource_id::<R>()
+            .get_valid_resource_id(TypeId::of::<R>())
             .ok_or(ResourceFetchError::NotRegistered)?;
         if !self.access.has_resource_read(component_id) {
             return Err(ResourceFetchError::NoResourceAccess(component_id));
@@ -475,7 +475,7 @@ impl<'w, 's> FilteredResourcesMut<'w, 's> {
         let component_id = self
             .world
             .components()
-            .valid_resource_id::<R>()
+            .get_valid_resource_id(TypeId::of::<R>())
             .ok_or(ResourceFetchError::NotRegistered)?;
         // SAFETY: THe caller ensures that there are no conflicting borrows.
         unsafe { self.get_mut_by_id_unchecked(component_id) }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -599,7 +599,7 @@ impl World {
     /// * [`Components::get_id()`]
     #[inline]
     pub fn component_id<T: Component>(&self) -> Option<ComponentId> {
-        self.components.component_id::<T>()
+        self.components.get_id(TypeId::of::<T>())
     }
 
     /// Registers a new [`Resource`] type and returns the [`ComponentId`] created for it.

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -543,7 +543,7 @@ impl World {
 
     /// Retrieves the [required components](RequiredComponents) for the given component type, if it exists.
     pub fn get_required_components<C: Component>(&self) -> Option<&RequiredComponents> {
-        let id = self.components().valid_component_id::<C>()?;
+        let id = self.components().get_valid_id(TypeId::of::<C>())?;
         let component_info = self.components().get_info(id)?;
         Some(component_info.required_components())
     }


### PR DESCRIPTION
# Objective
`Components` has a few functions that are generic but only use with `TypeId::of`. This forces monomorphization of the TypeId map lookups. Even if it's inlined, this still has a compile time cost.

## Solution
Remove unnecessary generic functions that only use `TypeId::of` in internal ECS metadata types., use the type erased versions instead.

## Testing
CI