### PR TITLE
force parenthesis for elements in the children! macro list

### DIFF
--- a/crates/bevy_ecs/src/hierarchy.rs
+++ b/crates/bevy_ecs/src/hierarchy.rs
@@ -476,7 +476,9 @@ pub fn validate_parent_has_component<C: Component>(
 /// Returns a [`SpawnRelatedBundle`] that will insert the [`Children`] component, spawn a [`SpawnableList`] of entities with given bundles that
 /// relate to the [`Children`] entity via the [`ChildOf`] component, and reserve space in the [`Children`] for each spawned entity.
 ///
-/// Any additional arguments will be interpreted as bundles to be spawned.
+/// Any additional arguments will be interpreted as bundles to be spawned. Note that even single
+/// component bundles MUST be wrapped in parentheses. This is to prevent you from accidentally
+/// spawning many seperate single components instead of a single bundle.
 ///
 /// Also see [`related`](crate::related) for a version of this that works with any [`RelationshipTarget`] type.
 ///
@@ -490,7 +492,7 @@ pub fn validate_parent_has_component<C: Component>(
 /// world.spawn((
 ///     Name::new("Root"),
 ///     children![
-///         Name::new("Child1"),
+///         (Name::new("Child1")),
 ///         (
 ///             Name::new("Child2"),
 ///             children![Name::new("Grandchild")]
@@ -504,10 +506,16 @@ pub fn validate_parent_has_component<C: Component>(
 /// [`SpawnableList`]: crate::spawn::SpawnableList
 #[macro_export]
 macro_rules! children {
-    [$($child:expr),*$(,)?] => {
-       $crate::hierarchy::Children::spawn($crate::recursive_spawn!($($child),*))
+    [$(($($child:expr),*$(,)?)),*$(,)?] => {
+       $crate::hierarchy::Children::spawn($crate::recursive_spawn!($(($($child),*)),*))
     };
 }
+
+//macro_rules! children {
+//    [$($child:expr),*$(,)?] => {
+//       $crate::hierarchy::Children::spawn($crate::recursive_spawn!($($child),*))
+//    };
+//}
 
 #[cfg(test)]
 mod tests {

--- a/examples/3d/lighting.rs
+++ b/examples/3d/lighting.rs
@@ -220,25 +220,25 @@ fn setup(
             ..default()
         },
         children![
-            TextSpan::new("Ambient light is on\n"),
-            TextSpan(format!("Aperture: f/{:.0}\n", parameters.aperture_f_stops,)),
-            TextSpan(format!(
+            (TextSpan::new("Ambient light is on\n")),
+            (TextSpan(format!("Aperture: f/{:.0}\n", parameters.aperture_f_stops,))),
+            (TextSpan(format!(
                 "Shutter speed: 1/{:.0}s\n",
                 1.0 / parameters.shutter_speed_s
-            )),
-            TextSpan(format!(
+            ))),
+            (TextSpan(format!(
                 "Sensitivity: ISO {:.0}\n",
                 parameters.sensitivity_iso
-            )),
-            TextSpan::new("\n\n"),
-            TextSpan::new("Controls\n"),
-            TextSpan::new("---------------\n"),
-            TextSpan::new("Arrow keys - Move objects\n"),
-            TextSpan::new("Space - Toggle ambient light\n"),
-            TextSpan::new("1/2 - Decrease/Increase aperture\n"),
-            TextSpan::new("3/4 - Decrease/Increase shutter speed\n"),
-            TextSpan::new("5/6 - Decrease/Increase sensitivity\n"),
-            TextSpan::new("R - Reset exposure"),
+            ))),
+            (TextSpan::new("\n\n")),
+            (TextSpan::new("Controls\n")),
+            (TextSpan::new("---------------\n")),
+            (TextSpan::new("Arrow keys - Move objects\n")),
+            (TextSpan::new("Space - Toggle ambient light\n")),
+            (TextSpan::new("1/2 - Decrease/Increase aperture\n")),
+            (TextSpan::new("3/4 - Decrease/Increase shutter speed\n")),
+            (TextSpan::new("5/6 - Decrease/Increase sensitivity\n")),
+            (TextSpan::new("R - Reset exposure")),
         ],
     ));
 

--- a/examples/app/log_layers_ecs.rs
+++ b/examples/app/log_layers_ecs.rs
@@ -157,7 +157,7 @@ fn print_logs(
                         TextSpan::new(format!("{:5} ", event.level)),
                         TextColor(level_color(&event.level)),
                     ),
-                    TextSpan::new(&event.message),
+                    (TextSpan::new(&event.message)),
                 ],
             ));
         }

--- a/examples/diagnostics/log_diagnostics.rs
+++ b/examples/diagnostics/log_diagnostics.rs
@@ -203,7 +203,7 @@ fn update_commands(
                     ..default()
                 },
                 children![
-                    Text::new("[Q] Toggle filtering:"),
+                    (Text::new("[Q] Toggle filtering:")),
                     (
                         Text::new(format!("{:?}", *status)),
                         TextColor(enabled_color(enabled))

--- a/examples/input/text_input.rs
+++ b/examples/input/text_input.rs
@@ -43,12 +43,12 @@ fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
             ..default()
         },
         children![
-            TextSpan::new("Click to toggle IME. Press return to start a new line.\n\n",),
-            TextSpan::new("IME Enabled: "),
-            TextSpan::new("false\n"),
-            TextSpan::new("IME Active:  "),
-            TextSpan::new("false\n"),
-            TextSpan::new("IME Buffer:  "),
+            (TextSpan::new("Click to toggle IME. Press return to start a new line.\n\n",)),
+            (TextSpan::new("IME Enabled: ")),
+            (TextSpan::new("false\n")),
+            (TextSpan::new("IME Active:  ")),
+            (TextSpan::new("false\n")),
+            (TextSpan::new("IME Buffer:  ")),
             (
                 TextSpan::new("\n"),
                 TextFont {

--- a/examples/math/render_primitives.rs
+++ b/examples/math/render_primitives.rs
@@ -354,15 +354,15 @@ fn setup_text(mut commands: Commands, cameras: Query<(Entity, &Camera)>) {
             HeaderText,
             TextLayout::new_with_justify(Justify::Center),
             children![
-                TextSpan::new("Primitive: "),
-                TextSpan(format!("{text}", text = PrimitiveSelected::default())),
-                TextSpan::new("\n\n"),
-                TextSpan::new(
+                (TextSpan::new("Primitive: ")),
+                (TextSpan(format!("{text}", text = PrimitiveSelected::default()))),
+                (TextSpan::new("\n\n")),
+                (TextSpan::new(
                     "Press 'C' to switch between 2D and 3D mode\n\
                     Press 'Up' or 'Down' to switch to the next/previous primitive",
-                ),
-                TextSpan::new("\n\n"),
-                TextSpan::new("(If nothing is displayed, there's no rendering support yet)",),
+                )),
+                (TextSpan::new("\n\n")),
+                (TextSpan::new("(If nothing is displayed, there's no rendering support yet)",)),
             ]
         )],
     ));

--- a/examples/shader/shader_prepass.rs
+++ b/examples/shader/shader_prepass.rs
@@ -134,11 +134,11 @@ fn setup(
             ..default()
         },
         children![
-            TextSpan::new("Prepass Output: transparent\n"),
-            TextSpan::new("\n\n"),
-            TextSpan::new("Controls\n"),
-            TextSpan::new("---------------\n"),
-            TextSpan::new("Space - Change output\n"),
+            (TextSpan::new("Prepass Output: transparent\n")),
+            (TextSpan::new("\n\n")),
+            (TextSpan::new("Controls\n")),
+            (TextSpan::new("---------------\n")),
+            (TextSpan::new("Space - Change output\n")),
         ],
     ));
 }

--- a/examples/testbed/ui.rs
+++ b/examples/testbed/ui.rs
@@ -666,12 +666,12 @@ mod linear_gradient {
                                             stops: stops.clone(),
                                         }),
                                         children![
-                                            Node {
+                                            (Node {
                                                 position_type: PositionType::Absolute,
                                                 ..default()
-                                            },
-                                            TextFont::from_font_size(10.),
-                                            bevy::ui::widget::Text(format!("{color_space:?}")),
+                                            }),
+                                            (TextFont::from_font_size(10.)),
+                                            (bevy::ui::widget::Text(format!("{color_space:?}"))),
                                         ]
                                     )],
                                 ));

--- a/examples/tools/gamepad_viewer.rs
+++ b/examples/tools/gamepad_viewer.rs
@@ -138,34 +138,34 @@ fn setup(mut commands: Commands, meshes: Res<ButtonMeshes>, materials: Res<Butto
         Transform::from_xyz(BUTTONS_X, BUTTONS_Y, 0.),
         Visibility::default(),
         children![
-            GamepadButtonBundle::new(
+            (GamepadButtonBundle::new(
                 GamepadButton::North,
                 meshes.circle.clone(),
                 materials.normal.clone(),
                 0.,
                 BUTTON_CLUSTER_RADIUS,
-            ),
-            GamepadButtonBundle::new(
+            )),
+            (GamepadButtonBundle::new(
                 GamepadButton::South,
                 meshes.circle.clone(),
                 materials.normal.clone(),
                 0.,
                 -BUTTON_CLUSTER_RADIUS,
-            ),
-            GamepadButtonBundle::new(
+            )),
+            (GamepadButtonBundle::new(
                 GamepadButton::West,
                 meshes.circle.clone(),
                 materials.normal.clone(),
                 -BUTTON_CLUSTER_RADIUS,
                 0.,
-            ),
-            GamepadButtonBundle::new(
+            )),
+            (GamepadButtonBundle::new(
                 GamepadButton::East,
                 meshes.circle.clone(),
                 materials.normal.clone(),
                 BUTTON_CLUSTER_RADIUS,
                 0.,
-            ),
+            )),
         ],
     ));
 
@@ -193,37 +193,37 @@ fn setup(mut commands: Commands, meshes: Res<ButtonMeshes>, materials: Res<Butto
         Transform::from_xyz(-BUTTONS_X, BUTTONS_Y, 0.),
         Visibility::default(),
         children![
-            GamepadButtonBundle::new(
+            (GamepadButtonBundle::new(
                 GamepadButton::DPadUp,
                 meshes.triangle.clone(),
                 materials.normal.clone(),
                 0.,
                 BUTTON_CLUSTER_RADIUS,
-            ),
-            GamepadButtonBundle::new(
+            )),
+            (GamepadButtonBundle::new(
                 GamepadButton::DPadDown,
                 meshes.triangle.clone(),
                 materials.normal.clone(),
                 0.,
                 -BUTTON_CLUSTER_RADIUS,
             )
-            .with_rotation(PI),
-            GamepadButtonBundle::new(
+            .with_rotation(PI)),
+            (GamepadButtonBundle::new(
                 GamepadButton::DPadLeft,
                 meshes.triangle.clone(),
                 materials.normal.clone(),
                 -BUTTON_CLUSTER_RADIUS,
                 0.,
             )
-            .with_rotation(PI / 2.),
-            GamepadButtonBundle::new(
+            .with_rotation(PI / 2.)),
+            (GamepadButtonBundle::new(
                 GamepadButton::DPadRight,
                 meshes.triangle.clone(),
                 materials.normal.clone(),
                 BUTTON_CLUSTER_RADIUS,
                 0.,
             )
-            .with_rotation(-PI / 2.),
+            .with_rotation(-PI / 2.)),
         ],
     ));
 
@@ -277,7 +277,7 @@ fn setup_sticks(
             Transform::from_xyz(x_pos, y_pos, 0.),
             Visibility::default(),
             children![
-                Sprite::from_color(DEAD_COLOR, Vec2::splat(STICK_BOUNDS_SIZE * 2.),),
+                (Sprite::from_color(DEAD_COLOR, Vec2::splat(STICK_BOUNDS_SIZE * 2.),)),
                 (
                     Sprite::from_color(LIVE_COLOR, Vec2::splat(live_size)),
                     Transform::from_xyz(live_mid, live_mid, 2.),
@@ -369,7 +369,7 @@ fn setup_connected(mut commands: Commands) {
             ..default()
         },
         ConnectedGamepadsText,
-        children![TextSpan::new("None")],
+        children![(TextSpan::new("None"))],
     ));
 }
 

--- a/examples/ui/borders.rs
+++ b/examples/ui/borders.rs
@@ -235,10 +235,10 @@ fn setup(mut commands: Commands) {
         },
         BackgroundColor(Color::srgb(0.25, 0.25, 0.25)),
         children![
-            label("Borders"),
-            borders_examples,
-            label("Borders Rounded"),
-            borders_examples_rounded
+            (label("Borders")),
+            (borders_examples),
+            (label("Borders Rounded")),
+            (borders_examples_rounded)
         ],
     ));
 }

--- a/examples/ui/box_shadow.rs
+++ b/examples/ui/box_shadow.rs
@@ -158,33 +158,35 @@ fn setup(
             },
             BackgroundColor(GRAY.into()),
         ))
-        .insert(children![{
-            let mut node = Node {
-                width: Val::Px(164.),
-                height: Val::Px(164.),
-                border: UiRect::all(Val::Px(1.)),
-                align_items: AlignItems::Center,
-                justify_content: JustifyContent::Center,
-                ..default()
-            };
-            let mut radius = BorderRadius::ZERO;
-            SHAPES[shape.index % SHAPES.len()].1(&mut node, &mut radius);
+        .insert(children![
+            ({
+                let mut node = Node {
+                    width: Val::Px(164.),
+                    height: Val::Px(164.),
+                    border: UiRect::all(Val::Px(1.)),
+                    align_items: AlignItems::Center,
+                    justify_content: JustifyContent::Center,
+                    ..default()
+                };
+                let mut radius = BorderRadius::ZERO;
+                SHAPES[shape.index % SHAPES.len()].1(&mut node, &mut radius);
 
-            (
-                node,
-                BorderColor::all(WHITE),
-                radius,
-                BackgroundColor(Color::srgb(0.21, 0.21, 0.21)),
-                BoxShadow(vec![ShadowStyle {
-                    color: Color::BLACK.with_alpha(0.8),
-                    x_offset: Val::Px(shadow.x_offset),
-                    y_offset: Val::Px(shadow.y_offset),
-                    spread_radius: Val::Px(shadow.spread),
-                    blur_radius: Val::Px(shadow.blur),
-                }]),
-                ShadowNode,
-            )
-        }]);
+                (
+                    node,
+                    BorderColor::all(WHITE),
+                    radius,
+                    BackgroundColor(Color::srgb(0.21, 0.21, 0.21)),
+                    BoxShadow(vec![ShadowStyle {
+                        color: Color::BLACK.with_alpha(0.8),
+                        x_offset: Val::Px(shadow.x_offset),
+                        y_offset: Val::Px(shadow.y_offset),
+                        spread_radius: Val::Px(shadow.spread),
+                        blur_radius: Val::Px(shadow.blur),
+                    }]),
+                    ShadowNode,
+                )
+            })
+        ]);
 
     // Settings Panel
     commands
@@ -204,56 +206,56 @@ fn setup(
             ZIndex(10),
         ))
         .insert(children![
-            build_setting_row(
+            (build_setting_row(
                 SettingType::Shape,
                 SettingsButton::ShapePrev,
                 SettingsButton::ShapeNext,
                 shape.index as f32,
                 &asset_server,
-            ),
-            build_setting_row(
+            )),
+            (build_setting_row(
                 SettingType::XOffset,
                 SettingsButton::XOffsetDec,
                 SettingsButton::XOffsetInc,
                 shadow.x_offset,
                 &asset_server,
-            ),
-            build_setting_row(
+            )),
+            (build_setting_row(
                 SettingType::YOffset,
                 SettingsButton::YOffsetDec,
                 SettingsButton::YOffsetInc,
                 shadow.y_offset,
                 &asset_server,
-            ),
-            build_setting_row(
+            )),
+            (build_setting_row(
                 SettingType::Blur,
                 SettingsButton::BlurDec,
                 SettingsButton::BlurInc,
                 shadow.blur,
                 &asset_server,
-            ),
-            build_setting_row(
+            )),
+            (build_setting_row(
                 SettingType::Spread,
                 SettingsButton::SpreadDec,
                 SettingsButton::SpreadInc,
                 shadow.spread,
                 &asset_server,
-            ),
-            build_setting_row(
+            )),
+            (build_setting_row(
                 SettingType::Count,
                 SettingsButton::CountDec,
                 SettingsButton::CountInc,
                 shadow.count as f32,
                 &asset_server,
-            ),
+            )),
             // Add BoxShadowSamples as a setting row
-            build_setting_row(
+            (build_setting_row(
                 SettingType::Samples,
                 SettingsButton::SamplesDec,
                 SettingsButton::SamplesInc,
                 shadow.samples as f32,
                 &asset_server,
-            ),
+            )),
             // Reset button
             (
                 Node {
@@ -365,17 +367,15 @@ fn build_setting_row(
                     ..default()
                 },
                 BorderRadius::all(Val::Px(6.)),
-                children![{
-                    (
-                        Text::new(value_text),
-                        TextFont {
-                            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                            font_size: 16.0,
-                            ..default()
-                        },
-                        setting_type,
-                    )
-                }],
+                children![(
+                    Text::new(value_text),
+                    TextFont {
+                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                        font_size: 16.0,
+                        ..default()
+                    },
+                    setting_type,
+                )],
             ),
             (
                 Button,

--- a/examples/ui/core_widgets.rs
+++ b/examples/ui/core_widgets.rs
@@ -172,11 +172,11 @@ fn demo_root(
         },
         TabGroup::default(),
         children![
-            button(asset_server, on_click),
-            slider(0.0, 100.0, 50.0, on_change_value),
-            checkbox(asset_server, "Checkbox", Callback::Ignore),
-            radio_group(asset_server, on_change_radio),
-            Text::new("Press 'D' to toggle widget disabled states"),
+            (button(asset_server, on_click)),
+            (slider(0.0, 100.0, 50.0, on_change_value)),
+            (checkbox(asset_server, "Checkbox", Callback::Ignore)),
+            (radio_group(asset_server, on_change_radio)),
+            (Text::new("Press 'D' to toggle widget disabled states")),
         ],
     )
 }

--- a/examples/ui/core_widgets_observers.rs
+++ b/examples/ui/core_widgets_observers.rs
@@ -120,10 +120,10 @@ fn demo_root(
         },
         TabGroup::default(),
         children![
-            button(asset_server, Callback::System(on_click)),
-            slider(0.0, 100.0, 50.0, Callback::System(on_change_value)),
-            checkbox(asset_server, "Checkbox", Callback::Ignore),
-            Text::new("Press 'D' to toggle widget disabled states"),
+            (button(asset_server, Callback::System(on_click))),
+            (slider(0.0, 100.0, 50.0, Callback::System(on_change_value))),
+            (checkbox(asset_server, "Checkbox", Callback::Ignore)),
+            (Text::new("Press 'D' to toggle widget disabled states")),
         ],
     )
 }

--- a/examples/ui/scroll.rs
+++ b/examples/ui/scroll.rs
@@ -194,9 +194,9 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     ..default()
                 },
                 children![
-                    vertically_scrolling_list(asset_server.load("fonts/FiraSans-Bold.ttf")),
-                    bidirectional_scrolling_list(asset_server.load("fonts/FiraSans-Bold.ttf")),
-                    nested_scrolling_list(asset_server.load("fonts/FiraSans-Bold.ttf")),
+                    (vertically_scrolling_list(asset_server.load("fonts/FiraSans-Bold.ttf"))),
+                    (bidirectional_scrolling_list(asset_server.load("fonts/FiraSans-Bold.ttf"))),
+                    (nested_scrolling_list(asset_server.load("fonts/FiraSans-Bold.ttf"))),
                 ],
             ));
         });

--- a/examples/usage/context_menu.rs
+++ b/examples/usage/context_menu.rs
@@ -100,11 +100,11 @@ fn on_trigger_menu(event: On<OpenContextMenu>, mut commands: Commands) {
             BorderRadius::all(Val::Px(4.)),
             BackgroundColor(Color::linear_rgb(0.1, 0.1, 0.1)),
             children![
-                context_item("fuchsia", basic::FUCHSIA),
-                context_item("gray", basic::GRAY),
-                context_item("maroon", basic::MAROON),
-                context_item("purple", basic::PURPLE),
-                context_item("teal", basic::TEAL),
+                (context_item("fuchsia", basic::FUCHSIA)),
+                (context_item("gray", basic::GRAY)),
+                (context_item("maroon", basic::MAROON)),
+                (context_item("purple", basic::PURPLE)),
+                (context_item("teal", basic::TEAL)),
             ],
         ))
         .observe(


### PR DESCRIPTION
# Objective

- Fixes https://github.com/bevyengine/bevy/issues/20429
- Shoutout to @SkiFire13 for helping <3

## Solution

- Always parse the child expression within parenthesis to prevent spawning many single component children by accident.

## Testing

- There are no behavioral changes

## Open questions

- When violating this new requirement you get a pretty unhelpful error message. It was suggested in [ecs-dev](https://discord.com/channels/691052431525675048/749335865876021248/1409842983959920640) that this requires a proc-macro. I didn't feel like I should go ahead with that before gathering some more input from other contributors.