### PR TITLE
Split `AnimationTarget` into two components

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -213,7 +213,7 @@ impl Hash for AnimationTargetId {
 /// runtime to change which player is responsible for animating the entity.
 #[derive(Clone, Copy, Component, Reflect)]
 #[reflect(Component, Clone)]
-pub struct AnimationTargetPlayer(#[entities] pub Entity);
+pub struct AnimationPlayerTarget(#[entities] pub Entity);
 
 impl AnimationClip {
     #[inline]
@@ -1019,7 +1019,7 @@ pub type AnimationEntityMut<'w, 's> = EntityMutExcept<
     's,
     (
         AnimationTargetId,
-        AnimationTargetPlayer,
+        AnimationPlayerTarget,
         AnimationPlayer,
         AnimationGraphHandle,
     ),
@@ -1036,14 +1036,14 @@ pub fn animate_targets(
     mut targets: Query<(
         Entity,
         &AnimationTargetId,
-        &AnimationTargetPlayer,
+        &AnimationPlayerTarget,
         AnimationEntityMut,
     )>,
     animation_evaluation_state: Local<ThreadLocal<RefCell<AnimationEvaluationState>>>,
 ) {
     // Evaluate all animation targets in parallel.
     targets.par_iter_mut().for_each(
-        |(entity, &target_id, &AnimationTargetPlayer(player_id), entity_mut)| {
+        |(entity, &target_id, &AnimationPlayerTarget(player_id), entity_mut)| {
             let (animation_player, animation_graph_id) =
                 if let Ok((player, graph_handle)) = players.get(player_id) {
                     (player, graph_handle.id())

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -211,7 +211,7 @@ impl Hash for AnimationTargetId {
 /// Note that each entity can only be animated by one animation player at a
 /// time. However, you can change [`AnimationTarget`]'s `player` property at
 /// runtime to change which player is responsible for animating the entity.
-#[derive(Clone, Copy, Component, Reflect)]
+#[derive(Clone, Copy, Component, Reflect, Debug)]
 #[reflect(Component, Clone)]
 pub struct AnimationPlayerTarget(#[entities] pub Entity);
 

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -154,21 +154,19 @@ type AnimationEvents = HashMap<AnimationEventTarget, Vec<TimedAnimationEvent>>;
 /// animation curves.
 pub type AnimationCurves = HashMap<AnimationTargetId, Vec<VariableCurve>, NoOpHash>;
 
-/// A unique [UUID] for an animation target (e.g. bone in a skinned mesh).
+/// A component used to identify an animation target entity (e.g. a bone in a
+/// skinned mesh). The [`AnimationClip`] asset uses this to identify which
+/// curves in the clip will affect the target entity.
 ///
-/// XXX TODO
-/// The [`AnimationClip`] asset and the [`AnimationTarget`] component both use
-/// this to refer to targets (e.g. bones in a skinned mesh) to be animated.
-///
-/// When importing an armature or an animation clip, asset loaders typically use
-/// the full path name from the armature to the bone to generate these UUIDs.
-/// The ID is unique to the full path name and based only on the names. So, for
-/// example, any imported armature with a bone at the root named `Hips` will
-/// assign the same [`AnimationTargetId`] to its root bone. Likewise, any
-/// imported animation clip that animates a root bone named `Hips` will
-/// reference the same [`AnimationTargetId`]. Any animation is playable on any
-/// armature as long as the bone names match, which allows for easy animation
-/// retargeting.
+/// `AnimationTargetId` is implemented as a [UUID]. When importing an armature
+/// or an animation clip, asset loaders typically use the full path name from
+/// the armature to the bone to generate these UUIDs. The ID is unique to the
+/// full path name and based only on the names. So, for example, any imported
+/// armature with a bone at the root named `Hips` will assign the same
+/// [`AnimationTargetId`] to its root bone. Likewise, any imported animation
+/// clip that animates a root bone named `Hips` will reference the same
+/// [`AnimationTargetId`]. Any animation is playable on any armature as long as
+/// the bone names match, which allows for easy animation retargeting.
 ///
 /// Note that asset loaders generally use the *full* path name to generate the
 /// [`AnimationTargetId`]. Thus a bone named `Chest` directly connected to a
@@ -189,28 +187,23 @@ impl Hash for AnimationTargetId {
     }
 }
 
-/// XXX TODO
-/// An entity that can be animated by an [`AnimationPlayer`].
+/// A component that links an animated entity to an entity containing an
+/// [`AnimationPlayer`]. Typically used alongside the [`AnimationTargetId`]
+/// component - the linked `AnimationPlayer` plays [`AnimationClip`] assets, and
+/// the `AnimationTargetId` identifies which curves in the `AnimationClip` will
+/// affect the target entity.
 ///
-/// These are frequently referred to as *bones* or *joints*, because they often
-/// refer to individually-animatable parts of an armature.
-///
-/// Asset loaders for armatures are responsible for adding these as necessary.
-/// Typically, they're generated from hashed versions of the entire name path
-/// from the root of the armature to the bone. See the [`AnimationTargetId`]
-/// documentation for more details.
-///
-/// By convention, asset loaders add [`AnimationTarget`] components to the
+/// By convention, asset loaders add [`AnimationTargetId`] components to the
 /// descendants of an [`AnimationPlayer`], as well as to the [`AnimationPlayer`]
 /// entity itself, but Bevy doesn't require this in any way. So, for example,
 /// it's entirely possible for an [`AnimationPlayer`] to animate a target that
 /// it isn't an ancestor of. If you add a new bone to or delete a bone from an
-/// armature at runtime, you may want to update the [`AnimationTarget`]
+/// armature at runtime, you may want to update the [`AnimationTargetId`]
 /// component as appropriate, as Bevy won't do this automatically.
 ///
 /// Note that each entity can only be animated by one animation player at a
-/// time. However, you can change [`AnimationTarget`]'s `player` property at
-/// runtime to change which player is responsible for animating the entity.
+/// time. However, you can change [`AnimationPlayerTargets`]'s at runtime to
+/// change which player is responsible for animating the entity.
 #[derive(Clone, Copy, Component, Reflect, Debug)]
 #[reflect(Component, Clone)]
 pub struct AnimationPlayerTarget(#[entities] pub Entity);

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -93,7 +93,7 @@ impl VariableCurve {
 /// apply.
 ///
 /// Because animation clips refer to targets by UUID, they can target any
-/// [`AnimationTarget`] with that ID.
+/// entity with that ID.
 #[derive(Asset, Reflect, Clone, Debug, Default)]
 #[reflect(Clone, Default)]
 pub struct AnimationClip {
@@ -202,8 +202,8 @@ impl Hash for AnimationTargetId {
 /// component as appropriate, as Bevy won't do this automatically.
 ///
 /// Note that each entity can only be animated by one animation player at a
-/// time. However, you can change [`AnimationPlayerTargets`]'s at runtime to
-/// change which player is responsible for animating the entity.
+/// time. However, you can change [`AnimationPlayerTarget`]s at runtime and
+/// link them to a different player.
 #[derive(Clone, Copy, Component, Reflect, Debug)]
 #[reflect(Component, Clone)]
 pub struct AnimationPlayerTarget(#[entities] pub Entity);
@@ -255,8 +255,8 @@ impl AnimationClip {
         self.duration = duration_sec;
     }
 
-    /// Adds an [`AnimationCurve`] to an [`AnimationTarget`] named by an
-    /// [`AnimationTargetId`].
+    /// Adds an [`AnimationCurve`] that can target an entity with the given
+    /// [`AnimationTargetId`] component.
     ///
     /// If the curve extends beyond the current duration of this clip, this
     /// method lengthens this clip to include the entire time span that the
@@ -311,7 +311,7 @@ impl AnimationClip {
             .push(variable_curve);
     }
 
-    /// Add an [`EntityEvent`] with no [`AnimationTarget`] to this [`AnimationClip`].
+    /// Add an [`EntityEvent`] with no [`AnimationTargetId`].
     ///
     /// The `event` will be cloned and triggered on the [`AnimationPlayer`] entity once the `time` (in seconds)
     /// is reached in the animation.
@@ -326,7 +326,7 @@ impl AnimationClip {
         );
     }
 
-    /// Add an [`EntityEvent`] to an [`AnimationTarget`] named by an [`AnimationTargetId`].
+    /// Add an [`EntityEvent`] with an [`AnimationTargetId`].
     ///
     /// The `event` will be cloned and triggered on the entity matching the target once the `time` (in seconds)
     /// is reached in the animation.
@@ -347,7 +347,7 @@ impl AnimationClip {
         );
     }
 
-    /// Add an event function with no [`AnimationTarget`] to this [`AnimationClip`].
+    /// Add an event function with no [`AnimationTargetId`] to this [`AnimationClip`].
     ///
     /// The `func` will trigger on the [`AnimationPlayer`] entity once the `time` (in seconds)
     /// is reached in the animation.
@@ -370,7 +370,7 @@ impl AnimationClip {
         self.add_event_internal(AnimationEventTarget::Root, time, func);
     }
 
-    /// Add an event function to an [`AnimationTarget`] named by an [`AnimationTargetId`].
+    /// Add an event function with an [`AnimationTargetId`].
     ///
     /// The `func` will trigger on the entity matching the target once the `time` (in seconds)
     /// is reached in the animation.

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -154,9 +154,9 @@ type AnimationEvents = HashMap<AnimationEventTarget, Vec<TimedAnimationEvent>>;
 /// animation curves.
 pub type AnimationCurves = HashMap<AnimationTargetId, Vec<VariableCurve>, NoOpHash>;
 
-/// A component used to identify an animation target entity (e.g. a bone in a
-/// skinned mesh). The [`AnimationClip`] asset uses this to identify which
-/// curves in the clip will affect the target entity.
+/// A component that identifies which parts of an [`AnimationClip`] asset can
+/// be applied to an entity. Typically used alongside the
+/// [`AnimationPlayerTarget`] component.
 ///
 /// `AnimationTargetId` is implemented as a [UUID]. When importing an armature
 /// or an animation clip, asset loaders typically use the full path name from

--- a/crates/bevy_gltf/src/loader/mod.rs
+++ b/crates/bevy_gltf/src/loader/mod.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 #[cfg(feature = "bevy_animation")]
-use bevy_animation::{prelude::*, AnimationTargetId, AnimationTargetPlayer};
+use bevy_animation::{prelude::*, AnimationPlayerTarget, AnimationTargetId};
 use bevy_asset::{
     io::Reader, AssetLoadError, AssetLoader, Handle, LoadContext, ReadAssetBytesError,
     RenderAssetUsages,
@@ -1432,7 +1432,7 @@ fn load_node(
 
         node.insert((
             AnimationTargetId::from_names(animation_context.path.iter()),
-            AnimationTargetPlayer(animation_context.root),
+            AnimationPlayerTarget(animation_context.root),
         ));
     }
 

--- a/crates/bevy_gltf/src/loader/mod.rs
+++ b/crates/bevy_gltf/src/loader/mod.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 #[cfg(feature = "bevy_animation")]
-use bevy_animation::{prelude::*, AnimationTarget, AnimationTargetId};
+use bevy_animation::{prelude::*, AnimationTargetId, AnimationTargetPlayer};
 use bevy_asset::{
     io::Reader, AssetLoadError, AssetLoader, Handle, LoadContext, ReadAssetBytesError,
     RenderAssetUsages,
@@ -1430,10 +1430,10 @@ fn load_node(
     if let Some(ref mut animation_context) = animation_context {
         animation_context.path.push(name);
 
-        node.insert(AnimationTarget {
-            id: AnimationTargetId::from_names(animation_context.path.iter()),
-            player: animation_context.root,
-        });
+        node.insert((
+            AnimationTargetId::from_names(animation_context.path.iter()),
+            AnimationTargetPlayer(animation_context.root),
+        ));
     }
 
     if let Some(extras) = gltf_node.extras() {

--- a/examples/animation/animated_transform.rs
+++ b/examples/animation/animated_transform.rs
@@ -3,7 +3,7 @@
 use std::f32::consts::PI;
 
 use bevy::{
-    animation::{animated_field, AnimationTargetId, AnimationTargetPlayer},
+    animation::{animated_field, AnimationTargetId, AnimationPlayerTarget},
     prelude::*,
 };
 
@@ -155,7 +155,7 @@ fn setup(
         .entity(planet_entity)
         .insert((
             planet_animation_target_id,
-            AnimationTargetPlayer(planet_entity),
+            AnimationPlayerTarget(planet_entity),
         ))
         .with_children(|p| {
             // This entity is just used for animation, but doesn't display anything
@@ -164,7 +164,7 @@ fn setup(
                 Visibility::default(),
                 orbit_controller,
                 orbit_controller_animation_target_id,
-                AnimationTargetPlayer(planet_entity),
+                AnimationPlayerTarget(planet_entity),
             ))
             .with_children(|p| {
                 // The satellite, placed at a distance of the planet
@@ -173,7 +173,7 @@ fn setup(
                     MeshMaterial3d(materials.add(Color::srgb(0.3, 0.9, 0.3))),
                     Transform::from_xyz(1.5, 0.0, 0.0),
                     satellite_animation_target_id,
-                    AnimationTargetPlayer(planet_entity),
+                    AnimationPlayerTarget(planet_entity),
                     satellite,
                 ));
             });

--- a/examples/animation/animated_transform.rs
+++ b/examples/animation/animated_transform.rs
@@ -3,7 +3,7 @@
 use std::f32::consts::PI;
 
 use bevy::{
-    animation::{animated_field, AnimationTarget, AnimationTargetId},
+    animation::{animated_field, AnimationTargetId, AnimationTargetPlayer},
     prelude::*,
 };
 
@@ -153,20 +153,18 @@ fn setup(
         .id();
     commands
         .entity(planet_entity)
-        .insert(AnimationTarget {
-            id: planet_animation_target_id,
-            player: planet_entity,
-        })
+        .insert((
+            planet_animation_target_id,
+            AnimationTargetPlayer(planet_entity),
+        ))
         .with_children(|p| {
             // This entity is just used for animation, but doesn't display anything
             p.spawn((
                 Transform::default(),
                 Visibility::default(),
                 orbit_controller,
-                AnimationTarget {
-                    id: orbit_controller_animation_target_id,
-                    player: planet_entity,
-                },
+                orbit_controller_animation_target_id,
+                AnimationTargetPlayer(planet_entity),
             ))
             .with_children(|p| {
                 // The satellite, placed at a distance of the planet
@@ -174,10 +172,8 @@ fn setup(
                     Mesh3d(meshes.add(Cuboid::new(0.5, 0.5, 0.5))),
                     MeshMaterial3d(materials.add(Color::srgb(0.3, 0.9, 0.3))),
                     Transform::from_xyz(1.5, 0.0, 0.0),
-                    AnimationTarget {
-                        id: satellite_animation_target_id,
-                        player: planet_entity,
-                    },
+                    satellite_animation_target_id,
+                    AnimationTargetPlayer(planet_entity),
                     satellite,
                 ));
             });

--- a/examples/animation/animated_transform.rs
+++ b/examples/animation/animated_transform.rs
@@ -3,7 +3,7 @@
 use std::f32::consts::PI;
 
 use bevy::{
-    animation::{animated_field, AnimationTargetId, AnimationPlayerTarget},
+    animation::{animated_field, AnimationPlayerTarget, AnimationTargetId},
     prelude::*,
 };
 

--- a/examples/animation/animated_ui.rs
+++ b/examples/animation/animated_ui.rs
@@ -3,7 +3,7 @@
 use bevy::{
     animation::{
         animated_field, AnimationEntityMut, AnimationEvaluationError, AnimationTargetId,
-        AnimationTargetPlayer,
+        AnimationPlayerTarget,
     },
     prelude::*,
 };
@@ -154,7 +154,7 @@ fn setup(
                     TextLayout::new_with_justify(Justify::Center),
                 ))
                 // Mark as an animation target.
-                .insert((animation_target_id, AnimationTargetPlayer(player)))
+                .insert((animation_target_id, AnimationPlayerTarget(player)))
                 .insert(animation_target_name);
         });
 }

--- a/examples/animation/animated_ui.rs
+++ b/examples/animation/animated_ui.rs
@@ -2,8 +2,8 @@
 
 use bevy::{
     animation::{
-        animated_field, AnimationEntityMut, AnimationEvaluationError, AnimationTarget,
-        AnimationTargetId,
+        animated_field, AnimationEntityMut, AnimationEvaluationError, AnimationTargetId,
+        AnimationTargetPlayer,
     },
     prelude::*,
 };
@@ -154,10 +154,7 @@ fn setup(
                     TextLayout::new_with_justify(Justify::Center),
                 ))
                 // Mark as an animation target.
-                .insert(AnimationTarget {
-                    id: animation_target_id,
-                    player,
-                })
+                .insert((animation_target_id, AnimationTargetPlayer(player)))
                 .insert(animation_target_name);
         });
 }

--- a/examples/animation/animated_ui.rs
+++ b/examples/animation/animated_ui.rs
@@ -2,8 +2,8 @@
 
 use bevy::{
     animation::{
-        animated_field, AnimationEntityMut, AnimationEvaluationError, AnimationTargetId,
-        AnimationPlayerTarget,
+        animated_field, AnimationEntityMut, AnimationEvaluationError, AnimationPlayerTarget,
+        AnimationTargetId,
     },
     prelude::*,
 };

--- a/examples/animation/animation_masks.rs
+++ b/examples/animation/animation_masks.rs
@@ -1,7 +1,7 @@
 //! Demonstrates how to use masks to limit the scope of animations.
 
 use bevy::{
-    animation::{AnimationTargetId, AnimationTargetPlayer},
+    animation::{AnimationTargetId, AnimationPlayerTarget},
     color::palettes::css::{LIGHT_GRAY, WHITE},
     prelude::*,
 };
@@ -404,7 +404,7 @@ fn setup_animation_graph_once_loaded(
                 commands.entity(target_entity).remove::<AnimationTargetId>();
                 commands
                     .entity(target_entity)
-                    .remove::<AnimationTargetPlayer>();
+                    .remove::<AnimationPlayerTarget>();
             }
         }
 

--- a/examples/animation/animation_masks.rs
+++ b/examples/animation/animation_masks.rs
@@ -1,7 +1,7 @@
 //! Demonstrates how to use masks to limit the scope of animations.
 
 use bevy::{
-    animation::{AnimationTarget, AnimationTargetId},
+    animation::{AnimationTargetId, AnimationTargetPlayer},
     color::palettes::css::{LIGHT_GRAY, WHITE},
     prelude::*,
 };
@@ -353,7 +353,7 @@ fn setup_animation_graph_once_loaded(
     asset_server: Res<AssetServer>,
     mut animation_graphs: ResMut<Assets<AnimationGraph>>,
     mut players: Query<(Entity, &mut AnimationPlayer), Added<AnimationPlayer>>,
-    targets: Query<(Entity, &AnimationTarget)>,
+    targets: Query<(Entity, &AnimationTargetId)>,
 ) {
     for (entity, mut player) in &mut players {
         // Load the animation clip from the glTF file.
@@ -400,8 +400,11 @@ fn setup_animation_graph_once_loaded(
         // don't do that, those bones will play all animations at once, which is
         // ugly.
         for (target_entity, target) in &targets {
-            if !all_animation_target_ids.contains(&target.id) {
-                commands.entity(target_entity).remove::<AnimationTarget>();
+            if !all_animation_target_ids.contains(target) {
+                commands.entity(target_entity).remove::<AnimationTargetId>();
+                commands
+                    .entity(target_entity)
+                    .remove::<AnimationTargetPlayer>();
             }
         }
 

--- a/examples/animation/animation_masks.rs
+++ b/examples/animation/animation_masks.rs
@@ -1,7 +1,7 @@
 //! Demonstrates how to use masks to limit the scope of animations.
 
 use bevy::{
-    animation::{AnimationTargetId, AnimationPlayerTarget},
+    animation::{AnimationPlayerTarget, AnimationTargetId},
     color::palettes::css::{LIGHT_GRAY, WHITE},
     prelude::*,
 };

--- a/examples/animation/eased_motion.rs
+++ b/examples/animation/eased_motion.rs
@@ -3,7 +3,7 @@
 use std::f32::consts::FRAC_PI_2;
 
 use bevy::{
-    animation::{animated_field, AnimationTarget, AnimationTargetId},
+    animation::{animated_field, AnimationTargetId, AnimationTargetPlayer},
     color::palettes::css::{ORANGE, SILVER},
     math::vec3,
     prelude::*,
@@ -47,10 +47,9 @@ fn setup(
         ))
         .id();
 
-    commands.entity(cube_entity).insert(AnimationTarget {
-        id: animation_target_id,
-        player: cube_entity,
-    });
+    commands
+        .entity(cube_entity)
+        .insert((animation_target_id, AnimationTargetPlayer(cube_entity)));
 
     // Some light to see something
     commands.spawn((

--- a/examples/animation/eased_motion.rs
+++ b/examples/animation/eased_motion.rs
@@ -3,7 +3,7 @@
 use std::f32::consts::FRAC_PI_2;
 
 use bevy::{
-    animation::{animated_field, AnimationTargetId, AnimationTargetPlayer},
+    animation::{animated_field, AnimationPlayerTarget, AnimationTargetId},
     color::palettes::css::{ORANGE, SILVER},
     math::vec3,
     prelude::*,
@@ -49,7 +49,7 @@ fn setup(
 
     commands
         .entity(cube_entity)
-        .insert((animation_target_id, AnimationTargetPlayer(cube_entity)));
+        .insert((animation_target_id, AnimationPlayerTarget(cube_entity)));
 
     // Some light to see something
     commands.spawn((

--- a/examples/tools/scene_viewer/animation_plugin.rs
+++ b/examples/tools/scene_viewer/animation_plugin.rs
@@ -1,7 +1,7 @@
 //! Control animations of entities in the loaded scene.
 use std::collections::HashMap;
 
-use bevy::{animation::AnimationTarget, ecs::entity::EntityHashMap, gltf::Gltf, prelude::*};
+use bevy::{animation::AnimationTargetId, ecs::entity::EntityHashMap, gltf::Gltf, prelude::*};
 
 use crate::scene_viewer_plugin::SceneHandle;
 
@@ -35,7 +35,7 @@ impl Clips {
 /// the common case).
 fn assign_clips(
     mut players: Query<&mut AnimationPlayer>,
-    targets: Query<(Entity, &AnimationTarget)>,
+    targets: Query<(Entity, &AnimationTargetId)>,
     children: Query<&ChildOf>,
     scene_handle: Res<SceneHandle>,
     clips: Res<Assets<AnimationClip>>,
@@ -66,7 +66,7 @@ fn assign_clips(
     // Map animation target IDs to entities.
     let animation_target_id_to_entity: HashMap<_, _> = targets
         .iter()
-        .map(|(entity, target)| (target.id, entity))
+        .map(|(entity, target)| (target, entity))
         .collect();
 
     // Build up a list of all animation clips that belong to each player. A clip


### PR DESCRIPTION
## Objective

Add flexibility by refactoring `AnimationTarget` into two separate components. This will smooth the path for future animation features.

## Background

`bevy_animation` animates entities by assigning them `AnimationTarget` components:

```rust
struct AnimationTarget {
    player: Entity,
    id: AnimationTargetId,
}
```

- `player: Entity` links to an entity that contains an `AnimationPlayer` component. An `AnimationPlayer` plays `AnimationClip` assets.
- `id: AnimationTargetId` identifies which tracks in an `AnimationClip` apply to the target entity.

When loading a glTF these components are automatically created. They can also be created manually.

## Problem

The two parts of `AnimationTarget` often go together but sometimes would be better separated:

1. I might want to calculate the `AnimationTargetId` first, but not link it up to an `AnimationPlayer` until later (see #18262 for an example).
2. I might want to use `AnimationTargetId` but not use `AnimationPlayer` - maybe I've got a different component that plays `AnimationClip`s.

In theory `player` could be left as `Entity::PLACEHOLDER`, but that's messy and will trigger a warning in `animate_targets`.

## Solution

This PR splits `AnimationTarget` into two components:

1. `AnimationTargetId` is just the original struct with a component derive.
2. `AnimationPlayerTarget` is a new unit struct `(Entity)`.

I'm not convinced `AnimationPlayerTarget` is a good name, but it does fit the usual source/target naming. `AnimationPlayerRef` was another candidate.

`AnimationPlayerTarget` could be a relationship target, but there would be a performance cost from making `AnimationPlayer` a relationship source. Maybe it's still a good idea, but that's probably best left to another PR.

### Performance

Profiled on `many_foxes` - difference was negligible.

### Testing

Examples `animated_mesh`, `animated_transform`, `animated_ui`, `animation_masks`, `eased_motion`, `scene_viewer`.

## Future

If this PR lands then I'll probably file a follow up that adds more flexibility to the the glTF loader creation of `AnimationTargetId` and `AnimationPlayer`. This will help #18262 and enable some other features.