### PR TITLE
Fixing crash when minimizing a window with custom viewport for 0.16. (#16704)

### DIFF
--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -1114,6 +1114,16 @@ pub fn extract_cameras(
     mapper: Extract<Query<&RenderEntity>>,
 ) {
     let primary_window = primary_window.iter().next();
+    type ExtractedCameraComponents = (
+        ExtractedCamera,
+        ExtractedView,
+        RenderVisibleEntities,
+        TemporalJitter,
+        RenderLayers,
+        Projection,
+        NoIndirectDrawing,
+        ViewUniformOffset,
+    );
     for (
         main_entity,
         render_entity,
@@ -1131,16 +1141,9 @@ pub fn extract_cameras(
     ) in query.iter()
     {
         if !camera.is_active {
-            commands.entity(render_entity).remove::<(
-                ExtractedCamera,
-                ExtractedView,
-                RenderVisibleEntities,
-                TemporalJitter,
-                RenderLayers,
-                Projection,
-                NoIndirectDrawing,
-                ViewUniformOffset,
-            )>();
+            commands
+                .entity(render_entity)
+                .remove::<ExtractedCameraComponents>();
             continue;
         }
 
@@ -1159,6 +1162,9 @@ pub fn extract_cameras(
             camera.physical_target_size(),
         ) {
             if target_size.x == 0 || target_size.y == 0 {
+                commands
+                    .entity(render_entity)
+                    .remove::<ExtractedCameraComponents>();
                 continue;
             }
 


### PR DESCRIPTION
# Objective

Fix a crash on minimizing a window when the window contains Camera with a custom Viewport (#16704). This is the same as #18916, but targeting the 0.16.2 branch so that developers won't have to wait until the 0.17 release for the fix.

## Solution

Remove ExtractedCamera when the corresponding camera in main world has zero target size. It indicates that the window is minimized.

## Testing

Tested in Windows 10, the original PR was tested on Windows 11. Previously the split_screen example crashes when the window is minimized; and with this change, it would not crash. Other behaviors remain unchanged.