### PR TITLE
set uv_transform in pbr_input_from_standard_material

### DIFF
--- a/crates/bevy_pbr/src/render/pbr_fragment.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_fragment.wgsl
@@ -120,6 +120,8 @@ fn pbr_input_from_standard_material(
     let uv_transform = pbr_bindings::material.uv_transform;
 #endif  // BINDLESS
 
+pbr_input.material.uv_transform = uv_transform;
+
 #ifdef VERTEX_UVS_A
     var uv = (uv_transform * vec3(in.uv, 1.0)).xy;
 #endif


### PR DESCRIPTION
Previously, even though the `uv_transform` was being accessed correctly from the material bindings; that information was not being passed on in the constructed `pbr_input` from `pbr_input_from_standard_material`. This led to a situation where the `StandardMaterial` textures would properly have the `StandardMaterial::uv_transform` applied, but the `pbr_input.material.uv_transform` value was the default instead of the material's. In turn this leads to any textures in a material extension using the wrong uvs, unless the value was accessed from the bindings directly instead of the pbr_input struct.


## Testing

Given an Affine2 supplied to a StandardMaterial in an extension, such as this one from the bevy examples

```rust
MeshMaterial3d(materials.add(ExtendedMaterial {
    base: StandardMaterial {
        uv_transform: Affine2::from_scale(
            Vec2::splat(4.),
        ),
        ..Default::default()
    },
    extension: MyExtension::new(1),
})),
```

Previously, accessing the uv_transform from the pbr_input would result in the default being used, which fills one full cube face.
Accessing from the bindings correctly uses the uv_transform and shows 4 boxes.

```
    // correct
    // let uv = (bevy_pbr::pbr_bindings::material.uv_transform * vec3(in.uv, 1.0)).xy;
    // incorrect
    let uv = (pbr_input.material.uv_transform * vec3(in.uv, 1.0)).xy;

    pbr_input.material.base_color = vec4(uv % 1., 0., 1.);
```

<img width="2560" height="1496" alt="screenshot-2025-08-28-at-06 29 33@2x" src="https://github.com/user-attachments/assets/e6d843a6-f83b-43a4-aea1-53574f3855a0" />

<img width="2560" height="1496" alt="screenshot-2025-08-28-at-06 29 41@2x" src="https://github.com/user-attachments/assets/e331747c-316a-48ad-be90-e649ca1ca7bf" />


