### PR TITLE
Reduce memory usage from Edges

### DIFF
--- a/crates/bevy_ecs/src/bundle/spawner.rs
+++ b/crates/bevy_ecs/src/bundle/spawner.rs
@@ -49,6 +49,7 @@ impl<'w> BundleSpawner<'w> {
         let bundle_info = world.bundles.get_unchecked(bundle_id);
         let (new_archetype_id, is_new_created) = bundle_info.insert_bundle_into_archetype(
             &mut world.archetypes,
+            &mut world.edges,
             &mut world.storages,
             &world.components,
             &world.observers,

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -37,7 +37,7 @@ pub use identifier::WorldId;
 pub use spawn_batch::*;
 
 use crate::{
-    archetype::{ArchetypeId, Archetypes},
+    archetype::{ArchetypeId, Archetypes, Edges},
     bundle::{
         Bundle, BundleEffect, BundleInfo, BundleInserter, BundleSpawner, Bundles, InsertMode,
         NoBundleEffect,
@@ -97,6 +97,7 @@ pub struct World {
     pub(crate) components: Components,
     pub(crate) component_ids: ComponentIds,
     pub(crate) archetypes: Archetypes,
+    pub(crate) edges: Edges,
     pub(crate) storages: Storages,
     pub(crate) bundles: Bundles,
     pub(crate) observers: Observers,
@@ -115,6 +116,7 @@ impl Default for World {
             entities: Entities::new(),
             components: Default::default(),
             archetypes: Archetypes::new(),
+            edges: Default::default(),
             storages: Default::default(),
             bundles: Default::default(),
             observers: Observers::default(),
@@ -220,6 +222,13 @@ impl World {
     #[inline]
     pub fn archetypes(&self) -> &Archetypes {
         &self.archetypes
+    }
+
+    /// Fetches an immutable reference to the [`Edges`], a cache of
+    /// archetypal relationships.
+    #[inline]
+    pub fn edges(&self) -> &Edges {
+        &self.edges
     }
 
     /// Retrieves this world's [`Components`] collection.


### PR DESCRIPTION
# Objective
The `SparseArray` in `Edges` uses a lot of memory for

## Solution

* Change `Edges` to use `HashMap` instead. 
* Key the `HashMap`s on a combination of the source archetype and the bundle.
* Move `Edges` to the top level of `World` instead of individual `Archetypes`

This should result in the memory usage in `Edges` across a world scaling linearly with the number of observed `Archetype` moves instead of scaling quadratically with the number of archetypes.

TODO: Benchmark

## Testing
CI

## Future Work
If desirable, we may want to move the TypeId lookup into Edges, keying on `(ArchetypeId, TypeId)` instead. It'd return the associated BundleId and skip the Bundles typemap lookup.