### PR TITLE
Fix broken json documentation

### DIFF
--- a/crates/bevy_remote/src/lib.rs
+++ b/crates/bevy_remote/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! ```json
 //! {
-//!     "method": world.get_components",
+//!     "method": "world.get_components",
 //!     "id": 0,
 //!     "params": {
 //!         "entity": 4294967298,


### PR DESCRIPTION
It's pretty self-explanatory. There was simply a missing ' " '
