### PR TITLE
mark `register_info`, `register_contributed_bundle_info` unsafe

### DIFF
--- a/crates/bevy_ecs/src/bundle/info.rs
+++ b/crates/bevy_ecs/src/bundle/info.rs
@@ -418,7 +418,14 @@ impl Bundles {
     /// Registers a new [`BundleInfo`] for a statically known type.
     ///
     /// Also registers all the components in the bundle.
-    pub(crate) fn register_info<T: Bundle>(
+    ///
+    /// # Safety
+    ///
+    /// `components` and `storages` must be from the same [`World`] as `self`.
+    ///
+    /// [`World`]: crate::world::World
+    #[deny(unsafe_op_in_unsafe_fn)]
+    pub(crate) unsafe fn register_info<T: Bundle>(
         &mut self,
         components: &mut ComponentsRegistrator,
         storages: &mut Storages,
@@ -442,7 +449,14 @@ impl Bundles {
     /// Registers a new [`BundleInfo`], which contains both explicit and required components for a statically known type.
     ///
     /// Also registers all the components in the bundle.
-    pub(crate) fn register_contributed_bundle_info<T: Bundle>(
+    ///
+    /// # Safety
+    ///
+    /// `components` and `storages` must be from the same [`World`] as `self`.
+    ///
+    /// [`World`]: crate::world::World
+    #[deny(unsafe_op_in_unsafe_fn)]
+    pub(crate) unsafe fn register_contributed_bundle_info<T: Bundle>(
         &mut self,
         components: &mut ComponentsRegistrator,
         storages: &mut Storages,
@@ -450,7 +464,10 @@ impl Bundles {
         if let Some(id) = self.contributed_bundle_ids.get(&TypeId::of::<T>()).cloned() {
             id
         } else {
-            let explicit_bundle_id = self.register_info::<T>(components, storages);
+            // SAFETY: as per the guarantees of this function, components and
+            // storages are from the same world as self
+            let explicit_bundle_id = unsafe { self.register_info::<T>(components, storages) };
+
             // SAFETY: reading from `explicit_bundle_id` and creating new bundle in same time. Its valid because bundle hashmap allow this
             let id = unsafe {
                 let (ptr, len) = {

--- a/crates/bevy_ecs/src/bundle/insert.rs
+++ b/crates/bevy_ecs/src/bundle/insert.rs
@@ -40,9 +40,13 @@ impl<'w> BundleInserter<'w> {
         // SAFETY: These come from the same world. `world.components_registrator` can't be used since we borrow other fields too.
         let mut registrator =
             unsafe { ComponentsRegistrator::new(&mut world.components, &mut world.component_ids) };
-        let bundle_id = world
-            .bundles
-            .register_info::<T>(&mut registrator, &mut world.storages);
+
+        // SAFETY: `registrator`, `world.bundles`, and `world.storages` all come from the same world
+        let bundle_id = unsafe {
+            world
+                .bundles
+                .register_info::<T>(&mut registrator, &mut world.storages)
+        };
         // SAFETY: We just ensured this bundle exists
         unsafe { Self::new_with_id(world, archetype_id, bundle_id, change_tick) }
     }

--- a/crates/bevy_ecs/src/bundle/spawner.rs
+++ b/crates/bevy_ecs/src/bundle/spawner.rs
@@ -29,9 +29,13 @@ impl<'w> BundleSpawner<'w> {
         // SAFETY: These come from the same world. `world.components_registrator` can't be used since we borrow other fields too.
         let mut registrator =
             unsafe { ComponentsRegistrator::new(&mut world.components, &mut world.component_ids) };
-        let bundle_id = world
-            .bundles
-            .register_info::<T>(&mut registrator, &mut world.storages);
+
+        // SAFETY: `registrator`, `world.bundles`, and `world.storages` all come from the same world.
+        let bundle_id = unsafe {
+            world
+                .bundles
+                .register_info::<T>(&mut registrator, &mut world.storages)
+        };
         // SAFETY: we initialized this bundle_id in `init_info`
         unsafe { Self::new_with_id(world, bundle_id, change_tick) }
     }

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -2304,7 +2304,10 @@ impl<'w> EntityWorldMut<'w> {
         let mut registrator = unsafe {
             ComponentsRegistrator::new(&mut self.world.components, &mut self.world.component_ids)
         };
-        let bundle_id = bundles.register_contributed_bundle_info::<T>(&mut registrator, storages);
+
+        // SAFETY: `storages`, `bundles` and `registrator` come from the same world.
+        let bundle_id =
+            unsafe { bundles.register_contributed_bundle_info::<T>(&mut registrator, storages) };
 
         // SAFETY: We just created the bundle, and the archetype is valid, since we are in it.
         let Some(mut remover) = (unsafe {
@@ -2351,10 +2354,13 @@ impl<'w> EntityWorldMut<'w> {
             ComponentsRegistrator::new(&mut self.world.components, &mut self.world.component_ids)
         };
 
-        let retained_bundle = self
-            .world
-            .bundles
-            .register_info::<T>(&mut registrator, storages);
+        // SAFETY: `storages`, `bundles` and `registrator` come from the same world.
+        let retained_bundle = unsafe {
+            self.world
+                .bundles
+                .register_info::<T>(&mut registrator, storages)
+        };
+
         // SAFETY: `retained_bundle` exists as we just initialized it.
         let retained_bundle_info = unsafe { self.world.bundles.get_unchecked(retained_bundle) };
         let old_archetype = &mut archetypes[old_location.archetype_id];

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -2305,9 +2305,12 @@ impl World {
         // SAFETY: These come from the same world. `Self.components_registrator` can't be used since we borrow other fields too.
         let mut registrator =
             unsafe { ComponentsRegistrator::new(&mut self.components, &mut self.component_ids) };
-        let bundle_id = self
-            .bundles
-            .register_info::<B>(&mut registrator, &mut self.storages);
+
+        // SAFETY: `registrator`, `self.bundles`, and `self.storages` all come from this world.
+        let bundle_id = unsafe {
+            self.bundles
+                .register_info::<B>(&mut registrator, &mut self.storages)
+        };
 
         let mut batch_iter = batch.into_iter();
 
@@ -2450,9 +2453,12 @@ impl World {
         // SAFETY: These come from the same world. `Self.components_registrator` can't be used since we borrow other fields too.
         let mut registrator =
             unsafe { ComponentsRegistrator::new(&mut self.components, &mut self.component_ids) };
-        let bundle_id = self
-            .bundles
-            .register_info::<B>(&mut registrator, &mut self.storages);
+
+        // SAFETY: `registrator`, `self.bundles`, and `self.storages` all come from this world.
+        let bundle_id = unsafe {
+            self.bundles
+                .register_info::<B>(&mut registrator, &mut self.storages)
+        };
 
         let mut invalid_entities = Vec::<Entity>::new();
         let mut batch_iter = batch.into_iter();
@@ -3072,9 +3078,13 @@ impl World {
         // SAFETY: These come from the same world. `Self.components_registrator` can't be used since we borrow other fields too.
         let mut registrator =
             unsafe { ComponentsRegistrator::new(&mut self.components, &mut self.component_ids) };
-        let id = self
-            .bundles
-            .register_info::<B>(&mut registrator, &mut self.storages);
+
+        // SAFETY: `registrator`, `self.storages` and `self.bundles` all come from this world.
+        let id = unsafe {
+            self.bundles
+                .register_info::<B>(&mut registrator, &mut self.storages)
+        };
+
         // SAFETY: We just initialized the bundle so its id should definitely be valid.
         unsafe { self.bundles.get(id).debug_checked_unwrap() }
     }


### PR DESCRIPTION
# Objective
calling `register_info` and `register_contributed_bundle_info` with incorrect arguments results in panics in 100% safe code
part of breaking up #20739 

## Solution

Mark `register_info` and `register_contributed_bundle_info` as unsafe.


## Testing

cargo test in crates/bevy_ecs

---

It's pretty obvious why this is unsafe, but the function doesn't explicitly forbid it:
```rust
fn safe_bundle_register_world_unsafety() {
    #![forbid(unsafe_code)]
    let mut world = World::new();
    let mut antiworld = World::new();

    #[derive(crate::prelude::Component, Debug, PartialEq, Eq)]
    struct A(u32);

    let mut world_components = world.components_registrator();

    let _ = antiworld
        .bundles
        .register_info::<(A,)>(&mut world_components, &mut antiworld.storages);
    // unsound beyond this point

    let e = antiworld.spawn((A(3),));
    let a = e.get::<A>().unwrap();
    assert_eq!(a, &A(3));
}
```
