### PR TITLE
Demote OpenGL to optional feature

### DIFF
--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -40,6 +40,7 @@ tracing-tracy = ["dep:tracy-client"]
 ci_limits = []
 webgl = ["wgpu/webgl"]
 webgpu = ["wgpu/webgpu"]
+gles = ["wgpu/gles"]
 detailed_trace = []
 ## Adds serialization support through `serde`.
 serialize = ["bevy_mesh/serialize"]
@@ -86,7 +87,6 @@ wgpu = { version = "26", default-features = false, features = [
   "dx12",
   "metal",
   "vulkan",
-  "gles",
   "naga-ir",
   "fragile-send-sync-non-atomic-wasm",
 ] }

--- a/crates/bevy_render/src/settings.rs
+++ b/crates/bevy_render/src/settings.rs
@@ -27,8 +27,8 @@ pub enum WgpuSettingsPriority {
 /// [`Backends::VULKAN`](Backends::VULKAN) are enabled by default for non-web and the best choice
 /// is automatically selected. Web using the `webgl` feature uses [`Backends::GL`](Backends::GL).
 /// NOTE: If you want to use [`Backends::GL`](Backends::GL) in a native app on `Windows` and/or `macOS`, you must
-/// use [`ANGLE`](https://github.com/gfx-rs/wgpu#angle). This is because wgpu requires EGL to
-/// create a GL context without a window and only ANGLE supports that.
+/// use [`ANGLE`](https://github.com/gfx-rs/wgpu#angle) and enable the `gles` feature. This is
+/// because wgpu requires EGL to create a GL context without a window and only ANGLE supports that.
 #[derive(Clone)]
 pub struct WgpuSettings {
     pub device_label: Option<Cow<'static, str>>,

--- a/crates/bevy_render/src/view/window/mod.rs
+++ b/crates/bevy_render/src/view/window/mod.rs
@@ -208,7 +208,7 @@ impl WindowSurfaces {
 ///   output during renderer initialization.
 ///   Another alternative is to try to use [`ANGLE`](https://github.com/gfx-rs/wgpu#angle) and
 ///   [`Backends::GL`](crate::settings::Backends::GL) with the `gles` feature enabled if your
-///    GPU/drivers support `OpenGL 4.3` / `OpenGL ES 3.0` or later.
+///   GPU/drivers support `OpenGL 4.3` / `OpenGL ES 3.0` or later.
 pub fn prepare_windows(
     mut windows: ResMut<ExtractedWindows>,
     mut window_surfaces: ResMut<WindowSurfaces>,

--- a/crates/bevy_render/src/view/window/mod.rs
+++ b/crates/bevy_render/src/view/window/mod.rs
@@ -205,10 +205,10 @@ impl WindowSurfaces {
 ///   `DirectX 11` is not supported by wgpu 0.12 and so if your GPU/drivers do not support Vulkan,
 ///   it may be that a software renderer called "Microsoft Basic Render Driver" using `DirectX 12`
 ///   will be chosen and performance will be very poor. This is visible in a log message that is
-///   output during renderer initialization. Future versions of wgpu will support `DirectX 11`, but
-///   another alternative is to try to use [`ANGLE`](https://github.com/gfx-rs/wgpu#angle) and
-///   [`Backends::GL`](crate::settings::Backends::GL) if your GPU/drivers support `OpenGL 4.3` / `OpenGL ES 3.0` or
-///   later.
+///   output during renderer initialization.
+///   Another alternative is to try to use [`ANGLE`](https://github.com/gfx-rs/wgpu#angle) and
+///   [`Backends::GL`](crate::settings::Backends::GL) with the `gles` feature enabled if your
+///    GPU/drivers support `OpenGL 4.3` / `OpenGL ES 3.0` or later.
 pub fn prepare_windows(
     mut windows: ResMut<ExtractedWindows>,
     mut window_surfaces: ResMut<WindowSurfaces>,

--- a/release-content/migration-guides/gles_optional.md
+++ b/release-content/migration-guides/gles_optional.md
@@ -1,0 +1,9 @@
+---
+title: "OpenGL ES `wgpu` backend is no longer supported by default"
+pull_requests: []
+---
+
+The `gles` backend for `wgpu` is no longer included as a default feature of `bevy_render`. OpenGL support is still 
+available, but must be explicitly enabled by adding the `bevy_render/gles` feature to your app. This change reflects the 
+fact that OpenGL support is not tested and that some features may not work as expected or at all. We welcome 
+contributions to improve OpenGL support in the future.

--- a/release-content/migration-guides/gles_optional.md
+++ b/release-content/migration-guides/gles_optional.md
@@ -1,6 +1,6 @@
 ---
 title: "OpenGL ES `wgpu` backend is no longer supported by default"
-pull_requests: []
+pull_requests: [ 20793 ]
 ---
 
 The `gles` backend for `wgpu` is no longer included as a default feature of `bevy_render`. OpenGL support is still 

--- a/release-content/migration-guides/gles_optional.md
+++ b/release-content/migration-guides/gles_optional.md
@@ -3,7 +3,7 @@ title: "OpenGL ES `wgpu` backend is no longer supported by default"
 pull_requests: [ 20793 ]
 ---
 
-The `gles` backend for `wgpu` is no longer included as a default feature of `bevy_render`. OpenGL support is still 
+The `gles` backend for `wgpu` is no longer included as a default feature of `bevy_render`. OpenGL support is still
 available, but must be explicitly enabled by adding the `bevy_render/gles` feature to your app. This change reflects the 
-fact that OpenGL support is not tested and that some features may not work as expected or at all. We welcome 
+fact that OpenGL support is not tested and that some features may not work as expected or at all. We welcome
 contributions to improve OpenGL support in the future.

--- a/release-content/migration-guides/gles_optional.md
+++ b/release-content/migration-guides/gles_optional.md
@@ -4,6 +4,6 @@ pull_requests: [ 20793 ]
 ---
 
 The `gles` backend for `wgpu` is no longer included as a default feature of `bevy_render`. OpenGL support is still
-available, but must be explicitly enabled by adding the `bevy_render/gles` feature to your app. This change reflects the 
+available, but must be explicitly enabled by adding the `bevy_render/gles` feature to your app. This change reflects the
 fact that OpenGL support is not tested and that some features may not work as expected or at all. We welcome
 contributions to improve OpenGL support in the future.


### PR DESCRIPTION
# Objective

In practice, we don't test OpenGL support and it's been reported broken for several releases.

## Solution

Make the `gles` feature for `wgpu` optional, reflecting our level of support.