### PR TITLE
Add `vulkan-portability` to fix compiling with `--all-features`

### DIFF
--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -40,6 +40,7 @@ tracing-tracy = ["dep:tracy-client"]
 ci_limits = []
 webgl = ["wgpu/webgl"]
 webgpu = ["wgpu/webgpu"]
+vulkan-portability = ["wgpu/vulkan-portability"]
 detailed_trace = []
 ## Adds serialization support through `serde`.
 serialize = ["bevy_mesh/serialize"]


### PR DESCRIPTION
#20565 broke compiling with `--all-features` on macos. Add the `vulkan-portability` feature to `bevy_render` required to make vulkan compile with wgpu on mac.