### PR TITLE
Image reinterpretation methods no longer panic

### DIFF
--- a/examples/2d/tilemap_chunk.rs
+++ b/examples/2d/tilemap_chunk.rs
@@ -64,7 +64,7 @@ fn update_tileset_image(
     for event in events.read() {
         if event.is_loaded_with_dependencies(chunk.tileset.id()) {
             let image = images.get_mut(&chunk.tileset).unwrap();
-            image.reinterpret_stacked_2d_as_array(4);
+            image.reinterpret_stacked_2d_as_array(4).unwrap();
         }
     }
 }

--- a/examples/3d/skybox.rs
+++ b/examples/3d/skybox.rs
@@ -157,7 +157,9 @@ fn asset_loaded(
         // NOTE: PNGs do not have any metadata that could indicate they contain a cubemap texture,
         // so they appear as one texture. The following code reconfigures the texture as necessary.
         if image.texture_descriptor.array_layer_count() == 1 {
-            image.reinterpret_stacked_2d_as_array(image.height() / image.width());
+            image
+                .reinterpret_stacked_2d_as_array(image.height() / image.width())
+                .unwrap();
             image.texture_view_descriptor = Some(TextureViewDescriptor {
                 dimension: Some(TextureViewDimension::Cube),
                 ..default()

--- a/examples/shader/array_texture.rs
+++ b/examples/shader/array_texture.rs
@@ -65,7 +65,7 @@ fn create_array_texture(
 
     // Create a new array texture asset from the loaded texture.
     let array_layers = 4;
-    image.reinterpret_stacked_2d_as_array(array_layers);
+    image.reinterpret_stacked_2d_as_array(array_layers).unwrap();
 
     // Spawn some cubes using the array texture
     let mesh_handle = meshes.add(Cuboid::default());


### PR DESCRIPTION
# Objective

Remove panics from image reinterpretation methods.

## Solution

Introduce new errors and emit those instead of panicking.

## Testing

- Did you test these changes? If so, how?
  - CI + changed examples
- Are there any parts that need more testing?
  - No
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
  - examples, no
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?
  - linux, amd cpu, amd gpu

---

Moved out of #20536