### PR TITLE
Feature/image loader setting view dim

### DIFF
--- a/crates/bevy_image/src/compressed_image_saver.rs
+++ b/crates/bevy_image/src/compressed_image_saver.rs
@@ -69,6 +69,7 @@ impl AssetSaver for CompressedImageSaver {
             is_srgb,
             sampler: image.sampler.clone(),
             asset_usage: image.asset_usage,
+            view_dimension: None,
         })
     }
 }

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -22,7 +22,7 @@ use thiserror::Error;
 use wgpu_types::{
     AddressMode, CompareFunction, Extent3d, Features, FilterMode, SamplerBorderColor,
     SamplerDescriptor, TextureDataOrder, TextureDescriptor, TextureDimension, TextureFormat,
-    TextureUsages, TextureViewDescriptor,
+    TextureUsages, TextureViewDescriptor, TextureViewDimension,
 };
 
 /// Trait used to provide default values for Bevy-external types that
@@ -713,6 +713,39 @@ impl ImageSamplerDescriptor {
             compare: self.compare.map(Into::into),
             anisotropy_clamp: self.anisotropy_clamp,
             border_color: self.border_color.map(Into::into),
+        }
+    }
+}
+
+/// Dimensions of a particular texture view.
+///
+/// This type mirrors [`TextureViewDimension`].
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub enum ImageTextureViewDimension {
+    /// A one dimensional texture. `texture_1d` in WGSL and `texture1D` in GLSL.
+    D1,
+    /// A two dimensional texture. `texture_2d` in WGSL and `texture2D` in GLSL.
+    #[default]
+    D2,
+    /// A two dimensional array texture. `texture_2d_array` in WGSL and `texture2DArray` in GLSL.
+    D2Array(u32),
+    /// A cubemap texture. `texture_cube` in WGSL and `textureCube` in GLSL.
+    Cube,
+    /// A cubemap array texture. `texture_cube_array` in WGSL and `textureCubeArray` in GLSL.
+    CubeArray(u32),
+    /// A three dimensional texture. `texture_3d` in WGSL and `texture3D` in GLSL.
+    D3,
+}
+
+impl From<ImageTextureViewDimension> for TextureViewDimension {
+    fn from(value: ImageTextureViewDimension) -> Self {
+        match value {
+            ImageTextureViewDimension::D1 => TextureViewDimension::D1,
+            ImageTextureViewDimension::D2 => TextureViewDimension::D2,
+            ImageTextureViewDimension::D2Array(_) => TextureViewDimension::D2Array,
+            ImageTextureViewDimension::Cube => TextureViewDimension::Cube,
+            ImageTextureViewDimension::CubeArray(_) => TextureViewDimension::CubeArray,
+            ImageTextureViewDimension::D3 => TextureViewDimension::D3,
         }
     }
 }

--- a/crates/bevy_image/src/image_loader.rs
+++ b/crates/bevy_image/src/image_loader.rs
@@ -194,29 +194,21 @@ impl AssetLoader for ImageLoader {
         })?;
 
         if let Some(view_dimension) = &settings.view_dimension {
-            // TODO: Let use handle this instead based on what their asset actually supports?
-            let image_view_dimension = image
-                .texture_view_descriptor
-                .clone()
-                .and_then(|texture_view_descriptor| texture_view_descriptor.dimension);
-            let new_image_view_dimension = Some(view_dimension.clone().into());
-            if image_view_dimension != new_image_view_dimension {
-                match view_dimension {
-                    ImageTextureViewDimension::D2Array(layers)
-                    | ImageTextureViewDimension::CubeArray(layers) => {
-                        image.reinterpret_stacked_2d_as_array(*layers)?;
-                    }
-                    ImageTextureViewDimension::Cube => {
-                        image.reinterpret_stacked_2d_as_array(image.height() / image.width())?;
-                    }
-                    _ => {}
+            match view_dimension {
+                ImageTextureViewDimension::D2Array(layers)
+                | ImageTextureViewDimension::CubeArray(layers) => {
+                    image.reinterpret_stacked_2d_as_array(*layers)?;
                 }
-
-                image.texture_view_descriptor = Some(TextureViewDescriptor {
-                    dimension: new_image_view_dimension,
-                    ..default()
-                });
+                ImageTextureViewDimension::Cube => {
+                    image.reinterpret_stacked_2d_as_array(image.height() / image.width())?;
+                }
+                _ => {}
             }
+
+            image.texture_view_descriptor = Some(TextureViewDescriptor {
+                dimension: Some(view_dimension.clone().into()),
+                ..default()
+            });
         }
 
         Ok(image)

--- a/crates/bevy_image/src/image_loader.rs
+++ b/crates/bevy_image/src/image_loader.rs
@@ -195,12 +195,16 @@ impl AssetLoader for ImageLoader {
 
         if let Some(view_dimension) = &settings.view_dimension {
             match view_dimension {
-                ImageTextureViewDimension::D2Array(layers)
-                | ImageTextureViewDimension::CubeArray(layers) => {
+                ImageTextureViewDimension::D2Array(layers) => {
                     image.reinterpret_stacked_2d_as_array(*layers)?;
                 }
                 ImageTextureViewDimension::Cube => {
                     image.reinterpret_stacked_2d_as_array(image.height() / image.width())?;
+                }
+                ImageTextureViewDimension::CubeArray(layers) => {
+                    image.reinterpret_stacked_2d_as_array(
+                        image.height() / image.width() * *layers,
+                    )?;
                 }
                 _ => {}
             }

--- a/examples/2d/tilemap_chunk.rs
+++ b/examples/2d/tilemap_chunk.rs
@@ -4,7 +4,7 @@ use bevy::{
     prelude::*,
     sprite_render::{TileData, TilemapChunk, TilemapChunkTileData},
 };
-use bevy_image::ImageLoaderSettings;
+use bevy_image::{ImageLoaderSettings, ImageTextureViewDimension};
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 
@@ -47,7 +47,7 @@ fn setup(mut commands: Commands, assets: Res<AssetServer>) {
             tileset: assets.load_with_settings(
                 "textures/array_texture.png",
                 |settings: &mut ImageLoaderSettings| {
-                    settings.view_dimension = bevy_image::ImageTextureViewDimension::D2Array(4);
+                    settings.view_dimension = Some(ImageTextureViewDimension::D2Array(4));
                 },
             ),
             ..default()

--- a/examples/2d/tilemap_chunk.rs
+++ b/examples/2d/tilemap_chunk.rs
@@ -64,7 +64,7 @@ fn update_tileset_image(
     for event in events.read() {
         if event.is_loaded_with_dependencies(chunk.tileset.id()) {
             let image = images.get_mut(&chunk.tileset).unwrap();
-            image.reinterpret_stacked_2d_as_array(4);
+            image.reinterpret_stacked_2d_as_array(4).unwrap();
         }
     }
 }

--- a/examples/3d/skybox.rs
+++ b/examples/3d/skybox.rs
@@ -157,7 +157,9 @@ fn asset_loaded(
         // NOTE: PNGs do not have any metadata that could indicate they contain a cubemap texture,
         // so they appear as one texture. The following code reconfigures the texture as necessary.
         if image.texture_descriptor.array_layer_count() == 1 {
-            image.reinterpret_stacked_2d_as_array(image.height() / image.width());
+            image
+                .reinterpret_stacked_2d_as_array(image.height() / image.width())
+                .unwrap();
             image.texture_view_descriptor = Some(TextureViewDescriptor {
                 dimension: Some(TextureViewDimension::Cube),
                 ..default()

--- a/examples/3d/skybox.rs
+++ b/examples/3d/skybox.rs
@@ -11,22 +11,32 @@ use bevy_image::{ImageLoaderSettings, ImageTextureViewDimension};
 use camera_controller::{CameraController, CameraControllerPlugin};
 use std::f32::consts::PI;
 
-const CUBEMAPS: &[(&str, CompressedImageFormats)] = &[
+const CUBEMAPS: &[(
+    &str,
+    CompressedImageFormats,
+    Option<ImageTextureViewDimension>,
+)] = &[
     (
         "textures/Ryfjallet_cubemap.png",
         CompressedImageFormats::NONE,
+        // NOTE: PNGs do not have any metadata that could indicate they contain a cubemap texture,
+        // so they appear as one texture. This is passed to ImageLoaderSettings to reconfigure the texture as necessary during load.
+        Some(ImageTextureViewDimension::Cube),
     ),
     (
         "textures/Ryfjallet_cubemap_astc4x4.ktx2",
         CompressedImageFormats::ASTC_LDR,
+        None,
     ),
     (
         "textures/Ryfjallet_cubemap_bc7.ktx2",
         CompressedImageFormats::BC,
+        None,
     ),
     (
         "textures/Ryfjallet_cubemap_etc2.ktx2",
         CompressedImageFormats::ETC2,
+        None,
     ),
 ];
 
@@ -122,10 +132,11 @@ fn cycle_cubemap_asset(
     *index = new_index;
 
     for mut skybox in &mut skyboxes {
+        let view_dimension = &CUBEMAPS[*index].2;
         skybox.image = asset_server.load_with_settings(
             CUBEMAPS[*index].0,
             |settings: &mut ImageLoaderSettings| {
-                settings.view_dimension = Some(ImageTextureViewDimension::Cube);
+                settings.view_dimension = view_dimension.clone();
             },
         );
     }

--- a/examples/3d/skybox.rs
+++ b/examples/3d/skybox.rs
@@ -51,7 +51,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     let skybox_handle =
         asset_server.load_with_settings(CUBEMAPS[0].0, |settings: &mut ImageLoaderSettings| {
-            settings.view_dimension = ImageTextureViewDimension::Cube;
+            settings.view_dimension = Some(ImageTextureViewDimension::Cube);
         });
 
     // camera
@@ -125,7 +125,7 @@ fn cycle_cubemap_asset(
         skybox.image = asset_server.load_with_settings(
             CUBEMAPS[*index].0,
             |settings: &mut ImageLoaderSettings| {
-                settings.view_dimension = ImageTextureViewDimension::Cube;
+                settings.view_dimension = Some(ImageTextureViewDimension::Cube);
             },
         );
     }

--- a/examples/shader/array_texture.rs
+++ b/examples/shader/array_texture.rs
@@ -29,7 +29,7 @@ fn setup(
     let array_texture = asset_server.load_with_settings(
         "textures/array_texture.png",
         |settings: &mut ImageLoaderSettings| {
-            settings.view_dimension = ImageTextureViewDimension::D2Array(4);
+            settings.view_dimension = Some(ImageTextureViewDimension::D2Array(4));
         },
     );
 

--- a/examples/shader/array_texture.rs
+++ b/examples/shader/array_texture.rs
@@ -4,6 +4,7 @@
 use bevy::{
     prelude::*, reflect::TypePath, render::render_resource::AsBindGroup, shader::ShaderRef,
 };
+use bevy_image::{ImageLoaderSettings, ImageTextureViewDimension};
 
 /// This example uses a shader source file from the assets subdirectory
 const SHADER_ASSET_PATH: &str = "shaders/array_texture.wgsl";
@@ -15,22 +16,33 @@ fn main() {
             MaterialPlugin::<ArrayTextureMaterial>::default(),
         ))
         .add_systems(Startup, setup)
-        .add_systems(Update, create_array_texture)
         .run();
 }
 
-#[derive(Resource)]
-struct LoadingTexture {
-    is_loaded: bool,
-    handle: Handle<Image>,
-}
+fn setup(
+    mut commands: Commands,
+    asset_server: Res<AssetServer>,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<ArrayTextureMaterial>>,
+) {
+    // Load the array texture
+    let array_texture = asset_server.load_with_settings(
+        "textures/array_texture.png",
+        |settings: &mut ImageLoaderSettings| {
+            settings.view_dimension = ImageTextureViewDimension::D2Array(4);
+        },
+    );
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    // Start loading the texture.
-    commands.insert_resource(LoadingTexture {
-        is_loaded: false,
-        handle: asset_server.load("textures/array_texture.png"),
-    });
+    // Spawn some cubes using the array texture
+    let mesh_handle = meshes.add(Cuboid::default());
+    let material_handle = materials.add(ArrayTextureMaterial { array_texture });
+    for x in -5..=5 {
+        commands.spawn((
+            Mesh3d(mesh_handle.clone()),
+            MeshMaterial3d(material_handle.clone()),
+            Transform::from_xyz(x as f32 + 0.5, 0.0, 0.0),
+        ));
+    }
 
     // light
     commands.spawn((
@@ -43,42 +55,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         Camera3d::default(),
         Transform::from_xyz(5.0, 5.0, 5.0).looking_at(Vec3::new(1.5, 0.0, 0.0), Vec3::Y),
     ));
-}
-
-fn create_array_texture(
-    mut commands: Commands,
-    asset_server: Res<AssetServer>,
-    mut loading_texture: ResMut<LoadingTexture>,
-    mut images: ResMut<Assets<Image>>,
-    mut meshes: ResMut<Assets<Mesh>>,
-    mut materials: ResMut<Assets<ArrayTextureMaterial>>,
-) {
-    if loading_texture.is_loaded
-        || !asset_server
-            .load_state(loading_texture.handle.id())
-            .is_loaded()
-    {
-        return;
-    }
-    loading_texture.is_loaded = true;
-    let image = images.get_mut(&loading_texture.handle).unwrap();
-
-    // Create a new array texture asset from the loaded texture.
-    let array_layers = 4;
-    image.reinterpret_stacked_2d_as_array(array_layers).unwrap();
-
-    // Spawn some cubes using the array texture
-    let mesh_handle = meshes.add(Cuboid::default());
-    let material_handle = materials.add(ArrayTextureMaterial {
-        array_texture: loading_texture.handle.clone(),
-    });
-    for x in -5..=5 {
-        commands.spawn((
-            Mesh3d(mesh_handle.clone()),
-            MeshMaterial3d(material_handle.clone()),
-            Transform::from_xyz(x as f32 + 0.5, 0.0, 0.0),
-        ));
-    }
 }
 
 #[derive(Asset, TypePath, AsBindGroup, Debug, Clone)]

--- a/examples/shader/array_texture.rs
+++ b/examples/shader/array_texture.rs
@@ -65,7 +65,7 @@ fn create_array_texture(
 
     // Create a new array texture asset from the loaded texture.
     let array_layers = 4;
-    image.reinterpret_stacked_2d_as_array(array_layers);
+    image.reinterpret_stacked_2d_as_array(array_layers).unwrap();
 
     // Spawn some cubes using the array texture
     let mesh_handle = meshes.add(Cuboid::default());


### PR DESCRIPTION
# Objective

Make loading images with specific TextureViewDimension easier where the image does not contain the meta data.
e.g. loading a png as a texture_2d_array

## Solution

Add new optional TextureViewDimension member to ImageLoaderSettings.
If Some will override the TextureViewDescriptor with the provided TextureViewDimension.

## Testing

- Did you test these changes? If so, how?
  - CI + changed examples
- Are there any parts that need more testing?
  - My hardware seems to support only the png skybox. So someone might want to run the example.
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
  - Run the examples. No.
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?
  - linux, amd cpu, amd gpu

---

## Showcase

Check out the changes examples.

---

depends on #20797
alternative to #20536