### PR TITLE
Implement ```VisitAssetDependencies``` for Arrays

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -693,6 +693,7 @@ mod tests {
         loader::{AssetLoader, LoadContext},
         Asset, AssetApp, AssetEvent, AssetId, AssetLoadError, AssetLoadFailedEvent, AssetPath,
         AssetPlugin, AssetServer, Assets, InvalidGenerationError, LoadState, UnapprovedPathMode,
+        UntypedHandle,
     };
     use alloc::{
         boxed::Box,
@@ -1908,6 +1909,10 @@ mod tests {
         handle: Handle<TestAsset>,
         #[dependency]
         embedded: TestAsset,
+        #[dependency]
+        array_handles: [Handle<TestAsset>; 5],
+        #[dependency]
+        untyped_array_handles: [UntypedHandle; 5],
     }
 
     #[expect(

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -485,6 +485,22 @@ impl VisitAssetDependencies for Option<UntypedHandle> {
     }
 }
 
+impl<A: Asset, const N: usize> VisitAssetDependencies for [Handle<A>; N] {
+    fn visit_dependencies(&self, visit: &mut impl FnMut(UntypedAssetId)) {
+        for dependency in self {
+            visit(dependency.id().untyped());
+        }
+    }
+}
+
+impl<const N: usize> VisitAssetDependencies for [UntypedHandle; N] {
+    fn visit_dependencies(&self, visit: &mut impl FnMut(UntypedAssetId)) {
+        for dependency in self {
+            visit(dependency.id());
+        }
+    }
+}
+
 impl<A: Asset> VisitAssetDependencies for Vec<Handle<A>> {
     fn visit_dependencies(&self, visit: &mut impl FnMut(UntypedAssetId)) {
         for dependency in self {


### PR DESCRIPTION
# Objective

- Since ```Vec<Handle<A>>``` and ```Vec<UntypedHandle>``` implement ```VisitAssetDependencies``` users might expect ```[Handle<A>; N]``` and ```[UntypedHandle; N]``` to also implement ```VisitAssetDependencies```, but this is currently not the case.
- The ```#[dependency]``` attribute from the ```Asset``` derive macro should work with an implementation.

## Solution

Implement ```VisitAssetDependencies``` for ```[Handle<A>; N]``` and ```[UntypedHandle; N]```. The implementations are based on the corresponding ones for Vec. 

## Testing

A test for compatibility with the derive macros was added for ```[Handle<A>; N]``` and ```[UntypedHandle; N]```.

---

## Showcase

The following is now made possible:
```rust
#[derive(Asset)]
struct MyAsset {

}
```