### PR TITLE
Bump hashbrown to 0.16.0

### DIFF
--- a/crates/bevy_platform/Cargo.toml
+++ b/crates/bevy_platform/Cargo.toml
@@ -66,8 +66,8 @@ spin = { version = "0.10.0", default-features = false, features = [
   "lazy",
   "barrier",
 ] }
-foldhash = { version = "0.1.3", default-features = false }
-hashbrown = { version = "0.15.1", features = [
+foldhash = { version = "0.2.0", default-features = false }
+hashbrown = { version = "0.16.0", features = [
   "equivalent",
   "raw-entry",
 ], optional = true, default-features = false }

--- a/crates/bevy_platform/src/hash.rs
+++ b/crates/bevy_platform/src/hash.rs
@@ -22,7 +22,7 @@ const FIXED_HASHER: FixedState =
 #[derive(Copy, Clone, Default, Debug)]
 pub struct FixedHasher;
 impl BuildHasher for FixedHasher {
-    type Hasher = DefaultHasher;
+    type Hasher = DefaultHasher<'static>;
 
     #[inline]
     fn build_hasher(&self) -> Self::Hasher {

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -99,8 +99,8 @@ bevy_platform = { path = "../bevy_platform", version = "0.17.0-dev", default-fea
 ] }
 
 # used by bevy-utils, but it also needs reflect impls
-foldhash = { version = "0.1.3", default-features = false }
-hashbrown = { version = "0.15.1", optional = true, default-features = false }
+foldhash = { version = "0.2.0", default-features = false }
+hashbrown = { version = "0.16.0", optional = true, default-features = false }
 
 # other
 erased-serde = { version = "0.4", default-features = false, features = [

--- a/crates/bevy_reflect/src/impls/foldhash.rs
+++ b/crates/bevy_reflect/src/impls/foldhash.rs
@@ -1,8 +1,8 @@
 use crate::impl_type_path;
 
-impl_type_path!(::foldhash::fast::FoldHasher);
+impl_type_path!(::foldhash::fast::FoldHasher<'a>);
 impl_type_path!(::foldhash::fast::FixedState);
 impl_type_path!(::foldhash::fast::RandomState);
-impl_type_path!(::foldhash::quality::FoldHasher);
+impl_type_path!(::foldhash::quality::FoldHasher<'a>);
 impl_type_path!(::foldhash::quality::FixedState);
 impl_type_path!(::foldhash::quality::RandomState);

--- a/crates/bevy_reflect/src/utility.rs
+++ b/crates/bevy_reflect/src/utility.rs
@@ -303,6 +303,6 @@ impl<T: TypedProperty> Default for GenericTypeCell<T> {
 ///
 /// [`Reflect::reflect_hash`]: crate::Reflect
 #[inline]
-pub fn reflect_hasher() -> DefaultHasher {
+pub fn reflect_hasher() -> DefaultHasher<'static> {
     FixedHasher.build_hasher()
 }

--- a/tools/build-templated-pages/Cargo.toml
+++ b/tools/build-templated-pages/Cargo.toml
@@ -12,7 +12,7 @@ toml_edit = { version = "0.23.2", default-features = false, features = [
 tera = "1.15"
 serde = { version = "1.0", features = ["derive"] }
 bitflags = "2.3"
-hashbrown = { version = "0.15", features = ["serde"] }
+hashbrown = { version = "0.16.0", features = ["serde"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
# Objective

use the latest hashbrown, and foldhash version (foldhash went from 0.1.5 to 0.2.0)
small performance improvement in foldhash.

# Notes

`FoldHasher` now takes a lifetime, had to specify it.
