### PR TITLE
bump tracing-subscriber to fix dependabot alert

### DIFF
--- a/crates/bevy_log/Cargo.toml
+++ b/crates/bevy_log/Cargo.toml
@@ -20,7 +20,7 @@ bevy_platform = { path = "../bevy_platform", version = "0.17.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.17.0-dev" }
 
 # other
-tracing-subscriber = { version = "0.3.1", features = [
+tracing-subscriber = { version = "0.3.20", features = [
   "registry",
   "env-filter",
 ] }


### PR DESCRIPTION
Cheers!

This mini-PR fixes a security advisory by updating the minimum tracing-subscriber version to 0.3.20: https://github.com/advisories/GHSA-xwfj-jgwm-7wp5

# Objective

The security advisory linked above reports a low-impact vulnerability in tracing-subscriber versions <0.3.20.

Dependabot will alert downstream users of bevy that are using tracing-subscriber locked to an older version.

## Solution

Update the minimum supported version of tracing-subscriber to 0.3.20.

## Open Questions/Alternatives

If somebody (for some reason) is pinned to tracing-subscriber <0.3.20, this will cause a conflict for them.
Instead, we could leave resolving this alert up to downstream users, who could also choose to ignore it, based on their usage of the library.
However, by upping the version requirement for tracing-subscriber in bevy, we increase "security by default" for downstream projects, which is the better trade-off imo.
But in the end this is up to maintainers/project policy.

## Testing

Leaving testing up to CI.