### PR TITLE
`ui_target_camera` example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3705,6 +3705,17 @@ category = "UI (User Interface)"
 wasm = true
 
 [[example]]
+name = "ui_target_camera"
+path = "examples/ui/ui_target_camera.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.ui_target_camera]
+name = "UI Target Camera"
+description = "Demonstrates how to use `UiTargetCamera` and camera ordering."
+category = "UI (User Interface)"
+wasm = true
+
+[[example]]
 name = "viewport_debug"
 path = "examples/ui/viewport_debug.rs"
 doc-scrape-examples = true

--- a/examples/README.md
+++ b/examples/README.md
@@ -580,6 +580,7 @@ Example | Description
 [UI Drag and Drop](../examples/ui/ui_drag_and_drop.rs) | Demonstrates dragging and dropping UI nodes
 [UI Material](../examples/ui/ui_material.rs) | Demonstrates creating and using custom Ui materials
 [UI Scaling](../examples/ui/ui_scaling.rs) | Illustrates how to scale the UI
+[UI Target Camera](../examples/ui/ui_target_camera.rs) | Demonstrates how to use `UiTargetCamera` and camera ordering.
 [UI Texture Atlas](../examples/ui/ui_texture_atlas.rs) | Illustrates how to use TextureAtlases in UI
 [UI Texture Atlas Slice](../examples/ui/ui_texture_atlas_slice.rs) | Illustrates how to use 9 Slicing for TextureAtlases in UI
 [UI Texture Slice](../examples/ui/ui_texture_slice.rs) | Illustrates how to use 9 Slicing in UI

--- a/examples/ui/ui_target_camera.rs
+++ b/examples/ui/ui_target_camera.rs
@@ -1,0 +1,102 @@
+//! Demonstrates how to use `UiTargetCamera` and camera ordering.
+
+use bevy::color::palettes::css::BLUE;
+use bevy::color::palettes::css::GREEN;
+use bevy::color::palettes::css::RED;
+use bevy::color::palettes::css::YELLOW;
+use bevy::log::LogPlugin;
+use bevy::log::DEFAULT_FILTER;
+use bevy::prelude::*;
+use bevy::winit::WinitSettings;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins.set(LogPlugin {
+            // Disable camera order ambiguity warnings
+            filter: format!("{DEFAULT_FILTER},bevy_render::camera=off"),
+            ..Default::default()
+        }))
+        .insert_resource(WinitSettings::desktop_app())
+        .add_systems(Startup, setup)
+        .run();
+}
+
+const BOX_SIZE: f32 = 100.;
+
+fn setup(mut commands: Commands) {
+    // Root UI node displaying instructions.
+    // Has no `UiTargetCamera`; the highest-order camera rendering to the primary window will be chosen automatically.
+    commands.spawn((
+        Node {
+                align_self: AlignSelf::Center,
+                justify_self: JustifySelf::Center,
+                justify_content: JustifyContent::Center,
+                bottom: px(2. * BOX_SIZE),
+                ..default()
+            },
+            Text::new("Each box is rendered by a different camera\n* left-click: increase the camera's order\n* right-click: decrease the camera's order")
+        ));
+
+    for (i, color) in [RED, GREEN, BLUE].into_iter().enumerate() {
+        let camera_entity = commands
+            .spawn((
+                // Ordering behaviour is the same using `Camera3d`.
+                Camera2d,
+                Camera {
+                    // The viewport will be cleared according to the `ClearColorConfig` of the camera with the lowest order, skipping cameras set to `ClearColorConfig::NONE`.
+                    // If all are set to `ClearColorConfig::NONE`, no clear color is used.
+                    clear_color: ClearColorConfig::Custom(color.into()),
+                    order: i as isize,
+                    ..Default::default()
+                },
+            ))
+            .id();
+
+        // Label each box with the order of its camera target
+        let label_entity = commands
+            .spawn((
+                Text(format!("{i}")),
+                TextFont::from_font_size(50.),
+                TextColor(color.into()),
+            ))
+            .id();
+
+        commands
+            .spawn((
+                Node {
+                    align_self: AlignSelf::Center,
+                    justify_self: JustifySelf::Center,
+                    justify_content: JustifyContent::Center,
+                    align_items: AlignItems::Center,
+                    left: px(0.5 * BOX_SIZE * (i as f32 - 1.)),
+                    top: px(0.5 * BOX_SIZE * (i as f32 - 1.)),
+                    width: px(BOX_SIZE),
+                    height: px(BOX_SIZE),
+                    border: px(0.1 * BOX_SIZE).into(),
+                    ..default()
+                },
+                // Bevy UI doesn't support `RenderLayers`. Each UI layout can only have one render target, selected using `UiTargetCamera`.
+                UiTargetCamera(camera_entity),
+                BackgroundColor(Color::BLACK),
+                BorderColor::all(YELLOW),
+            ))
+            .observe(
+                move |on_pressed: On<Pointer<Press>>,
+                      mut label_query: Query<&mut Text>,
+                      mut camera_query: Query<&mut Camera>| {
+                    let Ok(mut label_text) = label_query.get_mut(label_entity) else {
+                        return;
+                    };
+                    let Ok(mut camera) = camera_query.get_mut(camera_entity) else {
+                        return;
+                    };
+                    camera.order += match on_pressed.button {
+                        PointerButton::Primary => 1,
+                        _ => -1,
+                    };
+                    label_text.0 = format!("{}", camera.order);
+                },
+            )
+            .add_child(label_entity);
+    }
+}

--- a/examples/ui/ui_target_camera.rs
+++ b/examples/ui/ui_target_camera.rs
@@ -40,7 +40,7 @@ fn setup(mut commands: Commands) {
     for (i, color) in [RED, GREEN, BLUE].into_iter().enumerate() {
         let camera_entity = commands
             .spawn((
-                // Ordering behaviour is the same using `Camera3d`.
+                // Ordering behavior is the same using `Camera3d`.
                 Camera2d,
                 Camera {
                     // The viewport will be cleared according to the `ClearColorConfig` of the camera with the lowest order, skipping cameras set to `ClearColorConfig::NONE`.
@@ -68,8 +68,8 @@ fn setup(mut commands: Commands) {
                     justify_self: JustifySelf::Center,
                     justify_content: JustifyContent::Center,
                     align_items: AlignItems::Center,
-                    left: px(0.5 * BOX_SIZE * (i as f32 - 1.)),
-                    top: px(0.5 * BOX_SIZE * (i as f32 - 1.)),
+                    left: px(0.67 * BOX_SIZE * (i as f32 - 1.)),
+                    top: px(0.67 * BOX_SIZE * (i as f32 - 1.)),
                     width: px(BOX_SIZE),
                     height: px(BOX_SIZE),
                     border: px(0.1 * BOX_SIZE).into(),


### PR DESCRIPTION
# Objective

Add a basic example demonstrating `UiTargetCamera` and camera ordering.

## Showcase

<img width="500" alt="image" src="https://github.com/user-attachments/assets/6532600b-3e54-4835-85da-31dc4ecdc883" />


