### PR TITLE
re-enable wasm32 atomics CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,6 @@ jobs:
         run: cargo check --target wasm32-unknown-unknown
 
   build-wasm-atomics:
-    if: ${{ false }} # Disabled temporarily due to https://github.com/rust-lang/rust/issues/145101
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: build


### PR DESCRIPTION
# Objective

- It was disabled in #20462 due to https://github.com/rust-lang/rust/issues/145101
- Rust issue was fixed by https://github.com/rust-lang/rust/pull/145096

## Solution

- Re-enable the job in CI
