### PR TITLE
Fix text span colors

### DIFF
--- a/crates/bevy_ui_render/src/lib.rs
+++ b/crates/bevy_ui_render/src/lib.rs
@@ -973,7 +973,7 @@ pub fn extract_text_sections(
                     .get(
                         computed_block
                             .entities()
-                            .get(*span_index)
+                            .get(*span_index + 1)
                             .map(|t| t.entity)
                             .unwrap_or(Entity::PLACEHOLDER),
                     )


### PR DESCRIPTION
# Objective

Fixes #20834

## Solution

The previous span index was being used to look up the `TextSpan` entity with the color of the next span. Just increment it by one.
