### PR TITLE
Ensure only one bevy diagnostics task exists

### DIFF
--- a/crates/bevy_diagnostic/Cargo.toml
+++ b/crates/bevy_diagnostic/Cargo.toml
@@ -61,6 +61,7 @@ bevy_platform = { path = "../bevy_platform", version = "0.17.0-dev", default-fea
 
 # other
 const-fnv1a-hash = "1.1.0"
+crossbeam-channel = "0.5.0"
 serde = { version = "1.0", default-features = false, features = [
   "alloc",
 ], optional = true }


### PR DESCRIPTION
# Objective

Fixes #20802.

## Solution

Implemented the suggested approach (using a future that reschedules itself).

## Testing

I tried to test it with the `log_diagnostics` example, but ran into #20844.


