### PR TITLE
Add `#[doc(fake_variadic)]` to some places where it's missing

### DIFF
--- a/crates/bevy_ecs/src/bundle/impls.rs
+++ b/crates/bevy_ecs/src/bundle/impls.rs
@@ -148,11 +148,12 @@ all_tuples!(
 );
 
 macro_rules! after_effect_impl {
-    ($($after_effect: ident),*) => {
+    ($(#[$meta:meta])* $($after_effect: ident),*) => {
         #[expect(
             clippy::allow_attributes,
             reason = "This is a tuple-related macro; as such, the lints below may not always apply."
         )]
+        $(#[$meta])*
         impl<$($after_effect: BundleEffect),*> BundleEffect for ($($after_effect,)*) {
             #[allow(
                 clippy::unused_unit,
@@ -168,8 +169,15 @@ macro_rules! after_effect_impl {
             }
         }
 
+        $(#[$meta])*
         impl<$($after_effect: NoBundleEffect),*> NoBundleEffect for ($($after_effect,)*) { }
     }
 }
 
-all_tuples!(after_effect_impl, 0, 15, P);
+all_tuples!(
+    #[doc(fake_variadic)]
+    after_effect_impl,
+    0,
+    15,
+    P
+);

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -2530,6 +2530,7 @@ macro_rules! impl_tuple_query_data {
             }
         }
 
+        $(#[$meta])*
         /// SAFETY: each item in the tuple is read only
         unsafe impl<$($name: ReadOnlyQueryData),*> ReadOnlyQueryData for ($($name,)*) {}
 
@@ -2541,6 +2542,7 @@ macro_rules! impl_tuple_query_data {
             clippy::unused_unit,
             reason = "Zero-length tuples will generate some function bodies equivalent to `()`; however, this macro is meant for all applicable tuples, and as such it makes no sense to rewrite it just for that case."
         )]
+        $(#[$meta])*
         impl<$($name: ReleaseStateQueryData),*> ReleaseStateQueryData for ($($name,)*) {
             fn release_state<'w>(($($item,)*): Self::Item<'w, '_>) -> Self::Item<'w, 'static> {
                 ($($name::release_state($item),)*)

--- a/crates/bevy_ecs/src/spawn.rs
+++ b/crates/bevy_ecs/src/spawn.rs
@@ -215,11 +215,12 @@ impl<R: Relationship> SpawnableList<R> for WithOneRelated {
 }
 
 macro_rules! spawnable_list_impl {
-    ($($list: ident),*) => {
+    ($(#[$meta:meta])* $($list: ident),*) => {
         #[expect(
             clippy::allow_attributes,
             reason = "This is a tuple-related macro; as such, the lints below may not always apply."
         )]
+        $(#[$meta])*
         impl<R: Relationship, $($list: SpawnableList<R>),*> SpawnableList<R> for ($($list,)*) {
             fn spawn(self, _world: &mut World, _entity: Entity) {
                 #[allow(
@@ -242,7 +243,13 @@ macro_rules! spawnable_list_impl {
     }
 }
 
-all_tuples!(spawnable_list_impl, 0, 12, P);
+all_tuples!(
+    #[doc(fake_variadic)]
+    spawnable_list_impl,
+    0,
+    12,
+    P
+);
 
 /// A [`Bundle`] that:
 /// 1. Contains a [`RelationshipTarget`] component (associated with the given [`Relationship`]). This reserves space for the [`SpawnableList`].

--- a/crates/bevy_render/src/render_resource/specializer.rs
+++ b/crates/bevy_render/src/render_resource/specializer.rs
@@ -245,7 +245,8 @@ impl<T: Specializable, V: Send + Sync + 'static> Specializer<T> for PhantomData<
 }
 
 macro_rules! impl_specialization_key_tuple {
-    ($($T:ident),*) => {
+    ($(#[$meta:meta])* $($T:ident),*) => {
+        $(#[$meta])*
         impl <$($T: SpecializerKey),*> SpecializerKey for ($($T,)*) {
             const IS_CANONICAL: bool = true $(&& <$T as SpecializerKey>::IS_CANONICAL)*;
             type Canonical = ($(Canonical<$T>,)*);
@@ -253,8 +254,13 @@ macro_rules! impl_specialization_key_tuple {
     };
 }
 
-// TODO: How to we fake_variadics this?
-all_tuples!(impl_specialization_key_tuple, 0, 12, T);
+all_tuples!(
+    #[doc(fake_variadic)]
+    impl_specialization_key_tuple,
+    0,
+    12,
+    T
+);
 
 /// A cache for variants of a resource type created by a specializer.
 /// At most one resource will be created for each key.


### PR DESCRIPTION
# Objective

See #14697.  We use `#[doc(fake_variadic)]` for most of our trait impls for tuples, but it's missing for a few, mostly traits that were added after #14703: 

* `BundleEffect`
* `NoBundleEffect`
* `ReadOnlyQueryData`
* `ReleaseStateQueryData`
* `SpawnableList`
* `SpecializerKey`

## Solution

Pass `#[doc(fake_variadic)]` through `all_tuples!` for those trait impls.  

## Testing

Ran `RUSTFLAGS='--cfg docsrs_dep' RUSTDOCFLAGS='--cfg=docsrs' cargo +nightly doc`

<img width="649" height="143" alt="image" src="https://github.com/user-attachments/assets/4ef0c53d-fe22-4f39-b9c7-c6df9a48e791" />

<img width="910" height="218" alt="image" src="https://github.com/user-attachments/assets/2eaf8c0e-48fe-4dfe-8691-a23ca6f2d1f0" />

<img width="696" height="153" alt="image" src="https://github.com/user-attachments/assets/0909a663-7c32-45ce-af12-ef789941ef5b" />
