### PR TITLE
Disable vsync in the feathers example to remove mouse input lag

### DIFF
--- a/examples/ui/feathers.rs
+++ b/examples/ui/feathers.rs
@@ -23,6 +23,7 @@ use bevy::{
     },
     prelude::*,
     ui::{Checked, InteractionDisabled},
+    window::PresentMode,
     winit::WinitSettings,
 };
 
@@ -42,7 +43,14 @@ enum SwatchType {
 fn main() {
     App::new()
         .add_plugins((
-            DefaultPlugins,
+            DefaultPlugins.set(WindowPlugin {
+                primary_window: Some(Window {
+                    // Disable VSync to make the UI respond to fast input (like mouse movement) properly
+                    present_mode: PresentMode::AutoNoVsync,
+                    ..default()
+                }),
+                ..default()
+            }),
             CoreWidgetsPlugins,
             InputDispatchPlugin,
             TabNavigationPlugin,


### PR DESCRIPTION
# Objective

Fix the sliders and progress bars having considerable input lag when being moved with the mouse in the Feathers example

## Solution

- Disable vsync in the feathers example

---

## Showcase

Comparison of running the example with and without vsync enabled:

https://github.com/user-attachments/assets/23e57e8a-80e2-4c70-b07f-19434c189bd8

