### PR TITLE
rename variable

### DIFF
--- a/crates/bevy_ui_render/src/lib.rs
+++ b/crates/bevy_ui_render/src/lib.rs
@@ -419,12 +419,12 @@ impl RenderGraphNode for RunUiSubgraphOnUiViewNode {
         let Some(mut render_views) = world.try_query::<&UiCameraView>() else {
             return Ok(());
         };
-        let Ok(default_camera_view) = render_views.get(world, graph.view_entity()) else {
+        let Ok(ui_camera_view) = render_views.get(world, graph.view_entity()) else {
             return Ok(());
         };
 
         // Run the subgraph on the UI view.
-        graph.run_sub_graph(SubGraphUi, vec![], Some(default_camera_view.0))?;
+        graph.run_sub_graph(SubGraphUi, vec![], Some(ui_camera_view.0))?;
         Ok(())
     }
 }


### PR DESCRIPTION
# Objective

Naming of this `default_camera_view` variable in the `bevy_ui_render::lib` module is misleading. It's not a default anything, I think it was named this way because iirc `UiCameraView` was called `DefaultCameraView` (or something like that) a few versions ago.

## Solution

Rename `default_camera_view` to `ui_camera_view`.
