### PR TITLE
Remove `desktop_app` setting from `feathers` example

### DIFF
--- a/examples/ui/feathers.rs
+++ b/examples/ui/feathers.rs
@@ -23,7 +23,6 @@ use bevy::{
     },
     prelude::*,
     ui::{Checked, InteractionDisabled},
-    winit::WinitSettings,
 };
 
 /// A struct to hold the state of various widgets shown in the demo.
@@ -53,8 +52,6 @@ fn main() {
             rgb_color: palettes::tailwind::EMERALD_800.with_alpha(0.7),
             hsl_color: palettes::tailwind::AMBER_800.into(),
         })
-        // Only run the app when there is user input. This will significantly reduce CPU/GPU use.
-        .insert_resource(WinitSettings::desktop_app())
         .add_systems(Startup, setup)
         .add_systems(Update, update_colors)
         .run();


### PR DESCRIPTION
# Objective

While `desktop_app` is arguably correct for a UI focused example, in practice, it doesn't work well currently. The intermittent updates lead to "buggy" behavior: partial loads, stutters and so on.

We should fix those problems, and make the desktop_app setting more useful! But "last minute before release" is not a good time to do so. And simply leaving these apparent bugs in our showcase of the new UI toolkit will both mislead users about the quality and trick them into doing bad things for their own project.

Closes #20796. Fixes (kind of) the problem that motivated #20849.

## Solution

Remove the `desktop_app` setting from this example.

This will cause problems for `accesskit` users (at least on Mac) unfortunately, but that problem is *another* bug: #20515. Telling visually impaired users that they can only use screen readers on low CPU utilization apps in our game framework is not acceptable either.

## Testing

I've run the `feathers` example locally: the bad behavior is no longer observed.
