### PR TITLE
Change edit_gltf_material to use GltfMaterialName

### DIFF
--- a/examples/3d/edit_material_on_gltf.rs
+++ b/examples/3d/edit_material_on_gltf.rs
@@ -74,7 +74,7 @@ fn change_material(
                 info!("editing LeatherPartsMat to use ColorOverride tint");
                 // Get the `ColorOverride` of the entity, if it does not have a color override, skip
                 let Ok(color_override) = color_override.get(event.entity()) else {
-                    return;
+                    continue;
                 };
                 // Create a copy of the material and override base color
                 // If you intend on creating multiple models with the same tint, it


### PR DESCRIPTION
# Objective

The intention is to make it more obvious how to replace and edit materials from glTF files in a way that is capable of targeting specific materials like a real application would.

Partial documentation for #12209 

## Solution

Use GltfMaterialName so that it is more obvious how to target specific materials.

## Testing

```
cargo run --example edit_material_on_gltf
```

## Showcase

The tinting is now only applied to the leather materials.

<img width="2560" height="1496" alt="screenshot-2025-09-03-at-11 21 25@2x" src="https://github.com/user-attachments/assets/c5010397-00e7-41cf-864c-bf4632bd1975" />

## Notes

- It could be useful to have an extended material that uses the base replacing one of the options, or other material modification examples. I tried to use the existing material extension shader example but it really didn't look like it fit (and appeared buggy visually, although I don't believe it was actually buggy).
- I used the prelude in the example instead of separating out every item like it had previously
- This is a small improvement, but there are multiple concepts in this example. "Scene-specific overrides" and "editing materials".
- This example *could* have material caches (`struct LeatherPartsMat(Handle<..>)`) but right now the example has three separate materials that are all used in the scene so it felt like overkill until the problem is actually present.
