### PR TITLE
added anti-aliasing support for Custom Projection

### DIFF
--- a/crates/bevy_anti_alias/src/dlss/extract.rs
+++ b/crates/bevy_anti_alias/src/dlss/extract.rs
@@ -15,11 +15,10 @@ pub fn extract_dlss<F: DlssFeature>(
         .query_filtered::<(RenderEntity, &Camera, &Projection, Option<&mut Dlss<F>>), With<Hdr>>();
 
     for (entity, camera, camera_projection, mut dlss) in cameras_3d.iter_mut(&mut main_world) {
-        let has_perspective_projection = matches!(camera_projection, Projection::Perspective(_));
         let mut entity_commands = commands
             .get_entity(entity)
             .expect("Camera entity wasn't synced.");
-        if dlss.is_some() && camera.is_active && has_perspective_projection {
+        if dlss.is_some() && camera.is_active && camera_projection.is_perspective() {
             entity_commands.insert(dlss.as_deref().unwrap().clone());
             dlss.as_mut().unwrap().reset = false;
         } else if cleanup_query.get(entity) == Ok(true) {

--- a/crates/bevy_anti_alias/src/taa/mod.rs
+++ b/crates/bevy_anti_alias/src/taa/mod.rs
@@ -351,13 +351,12 @@ fn extract_taa_settings(mut commands: Commands, mut main_world: ResMut<MainWorld
     )>();
 
     for (entity, camera, camera_projection, taa_settings) in cameras_3d.iter_mut(&mut main_world) {
-        let has_perspective_projection = matches!(camera_projection, Projection::Perspective(_));
         let mut entity_commands = commands
             .get_entity(entity)
             .expect("Camera entity wasn't synced.");
         if let Some(mut taa_settings) = taa_settings
             && camera.is_active
-            && has_perspective_projection
+            && camera_projection.is_perspective()
         {
             entity_commands.insert(taa_settings.clone());
             taa_settings.reset = false;

--- a/crates/bevy_camera/src/projection.rs
+++ b/crates/bevy_camera/src/projection.rs
@@ -238,6 +238,8 @@ impl Projection {
         })
     }
 
+    /// Check if the projection is perspective.
+    /// For [`CustomProjection`], this checks if the projection matrix's w-axis's w is 0.0.
     pub fn is_perspective(&self) -> bool {
         match self {
             Projection::Perspective(_) => true,

--- a/crates/bevy_camera/src/projection.rs
+++ b/crates/bevy_camera/src/projection.rs
@@ -237,6 +237,14 @@ impl Projection {
             dyn_projection: Box::new(projection),
         })
     }
+
+    pub fn is_perspective(&self) -> bool {
+        match self {
+            Projection::Perspective(_) => true,
+            Projection::Orthographic(_) => false,
+            Projection::Custom(projection) => projection.get_clip_from_view().w_axis.w == 0.0,
+        }
+    }
 }
 
 impl Deref for Projection {


### PR DESCRIPTION
# Objective
Support anti-aliasing for Custom Projection. 

## Solution
function is_perspective() is added to Projection, it checks the matrix to determine if the Custom Projection is perspective.

## Testing

- Did you test these changes? If so, how?
 yes, we have an internal project that uses Custom Projection, I tested taa, but not the dlss, but the logic is the same.

- Are there any parts that need more testing? 
  N/A
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
here is the detail: https://metashapes.com/blog/opengl-metal-projection-matrix-problem/
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?
N/A
