### PR TITLE
another text color fix

### DIFF
--- a/examples/testbed/ui.rs
+++ b/examples/testbed/ui.rs
@@ -130,6 +130,44 @@ mod text {
                 ),
             ],
         ));
+
+        commands.spawn((
+            Node {
+                left: px(100.),
+                top: px(300.),
+                ..Default::default()
+            },
+            Text::new(""),
+            TextFont {
+                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                ..default()
+            },
+            DespawnOnExitState(super::Scene::Text),
+            children![
+                (TextSpan::new(""), TextColor(YELLOW.into()),),
+                TextSpan::new(""),
+                TextSpan::new("white "),
+                TextSpan::new(""),
+                (TextSpan::new("red "), TextColor(RED.into()),),
+                TextSpan::new(""),
+                TextSpan::new(""),
+                (TextSpan::new("green "), TextColor(GREEN.into()),),
+                (TextSpan::new(""), TextColor(YELLOW.into()),),
+                (TextSpan::new("blue "), TextColor(BLUE.into()),),
+                TextSpan::new(""),
+                (TextSpan::new(""), TextColor(YELLOW.into()),),
+                (
+                    TextSpan::new("black"),
+                    TextColor(Color::BLACK),
+                    TextFont {
+                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                        ..default()
+                    },
+                    TextBackgroundColor(Color::WHITE)
+                ),
+                TextSpan::new(""),
+            ],
+        ));
     }
 }
 

--- a/examples/testbed/ui.rs
+++ b/examples/testbed/ui.rs
@@ -144,9 +144,50 @@ mod text {
             },
             DespawnOnExitState(super::Scene::Text),
             children![
+                (
+                    TextSpan::new("white "),
+                    TextFont {
+                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                        ..default()
+                    }
+                ),
+                (TextSpan::new("red "), TextColor(RED.into()),),
+                (TextSpan::new("green "), TextColor(GREEN.into()),),
+                (TextSpan::new("blue "), TextColor(BLUE.into()),),
+                (
+                    TextSpan::new("black"),
+                    TextColor(Color::BLACK),
+                    TextFont {
+                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                        ..default()
+                    },
+                    TextBackgroundColor(Color::WHITE)
+                ),
+            ],
+        ));
+
+        commands.spawn((
+            Node {
+                left: px(100.),
+                top: px(350.),
+                ..Default::default()
+            },
+            Text::new(""),
+            TextFont {
+                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                ..default()
+            },
+            DespawnOnExitState(super::Scene::Text),
+            children![
                 (TextSpan::new(""), TextColor(YELLOW.into()),),
                 TextSpan::new(""),
-                TextSpan::new("white "),
+                (
+                    TextSpan::new("white "),
+                    TextFont {
+                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                        ..default()
+                    }
+                ),
                 TextSpan::new(""),
                 (TextSpan::new("red "), TextColor(RED.into()),),
                 TextSpan::new(""),


### PR DESCRIPTION
# Objective

Fixes #20854

## Solution

Query for the next color on span changes before queuing the next glyph.

## Testing

Added two more cases to `testbed_ui`'s text example, the three lines of coloured text should all look identical.

