### PR TITLE
Rename DespawnOnExitState to DespawnOnExit

### DIFF
--- a/crates/bevy_state/src/lib.rs
+++ b/crates/bevy_state/src/lib.rs
@@ -91,7 +91,7 @@ pub mod prelude {
             OnExit, OnTransition, State, StateSet, StateTransition, StateTransitionEvent, States,
             SubStates, TransitionSchedules,
         },
-        state_scoped::{DespawnOnEnterState, DespawnOnExitState},
+        state_scoped::{DespawnOnEnter, DespawnOnExit},
     };
 }
 

--- a/crates/bevy_state/src/state/computed_states.rs
+++ b/crates/bevy_state/src/state/computed_states.rs
@@ -99,7 +99,7 @@ impl<S: ComputedStates> States for S {
 mod tests {
     use crate::{
         app::{AppExtStates, StatesPlugin},
-        prelude::DespawnOnEnterState,
+        prelude::DespawnOnEnter,
         state::{ComputedStates, StateTransition},
     };
     use bevy_app::App;
@@ -132,7 +132,7 @@ mod tests {
 
         let world = app.world_mut();
 
-        world.spawn((DespawnOnEnterState(TestComputedState), TestComponent));
+        world.spawn((DespawnOnEnter(TestComputedState), TestComponent));
 
         assert!(world.query::<&TestComponent>().single(world).is_ok());
         world.run_schedule(StateTransition);

--- a/crates/bevy_state/src/state/states.rs
+++ b/crates/bevy_state/src/state/states.rs
@@ -69,8 +69,8 @@ pub trait States: 'static + Send + Sync + Clone + PartialEq + Eq + Hash + Debug 
 
     /// Should [state scoping](crate::state_scoped) be enabled for this state?
     /// If set to `true`, the
-    /// [`DespawnOnEnterState`](crate::state_scoped::DespawnOnEnterState) and
-    /// [`DespawnOnExitState`](crate::state_scoped::DespawnOnEnterState)
+    /// [`DespawnOnEnter`](crate::state_scoped::DespawnOnEnter) and
+    /// [`DespawnOnExit`](crate::state_scoped::DespawnOnExit)
     /// components are used to remove entities when entering or exiting the
     /// state.
     const SCOPED_ENTITIES_ENABLED: bool = false;

--- a/crates/bevy_state/src/state_scoped.rs
+++ b/crates/bevy_state/src/state_scoped.rs
@@ -34,7 +34,7 @@ use crate::state::{StateTransitionEvent, States};
 ///
 /// fn spawn_player(mut commands: Commands) {
 ///     commands.spawn((
-///         DespawnOnExitState(GameState::InGame),
+///         DespawnOnExit(GameState::InGame),
 ///         Player
 ///     ));
 /// }
@@ -52,9 +52,9 @@ use crate::state::{StateTransitionEvent, States};
 /// ```
 #[derive(Component, Clone)]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Component, Clone))]
-pub struct DespawnOnExitState<S: States>(pub S);
+pub struct DespawnOnExit<S: States>(pub S);
 
-impl<S> Default for DespawnOnExitState<S>
+impl<S> Default for DespawnOnExit<S>
 where
     S: States + Default,
 {
@@ -63,12 +63,12 @@ where
     }
 }
 
-/// Despawns entities marked with [`DespawnOnExitState<S>`] when their state no
+/// Despawns entities marked with [`DespawnOnExit<S>`] when their state no
 /// longer matches the world state.
 pub fn despawn_entities_on_exit_state<S: States>(
     mut commands: Commands,
     mut transitions: EventReader<StateTransitionEvent<S>>,
-    query: Query<(Entity, &DespawnOnExitState<S>)>,
+    query: Query<(Entity, &DespawnOnExit<S>)>,
 ) {
     // We use the latest event, because state machine internals generate at most 1
     // transition event (per type) each frame. No event means no change happened
@@ -112,7 +112,7 @@ pub fn despawn_entities_on_exit_state<S: States>(
 ///
 /// fn spawn_player(mut commands: Commands) {
 ///     commands.spawn((
-///         DespawnOnEnterState(GameState::MainMenu),
+///         DespawnOnEnter(GameState::MainMenu),
 ///         Player
 ///     ));
 /// }
@@ -130,14 +130,14 @@ pub fn despawn_entities_on_exit_state<S: States>(
 /// ```
 #[derive(Component, Clone)]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Component))]
-pub struct DespawnOnEnterState<S: States>(pub S);
+pub struct DespawnOnEnter<S: States>(pub S);
 
-/// Despawns entities marked with [`DespawnOnEnterState<S>`] when their state
+/// Despawns entities marked with [`DespawnOnEnter<S>`] when their state
 /// matches the world state.
 pub fn despawn_entities_on_enter_state<S: States>(
     mut commands: Commands,
     mut transitions: EventReader<StateTransitionEvent<S>>,
-    query: Query<(Entity, &DespawnOnEnterState<S>)>,
+    query: Query<(Entity, &DespawnOnEnter<S>)>,
 ) {
     // We use the latest event, because state machine internals generate at most 1
     // transition event (per type) each frame. No event means no change happened

--- a/crates/bevy_state/src/state_scoped_events.rs
+++ b/crates/bevy_state/src/state_scoped_events.rs
@@ -130,8 +130,8 @@ fn clear_events_on_state_transition<E: BufferedEvent, S: States>(
 pub trait StateScopedEventsAppExt {
     /// Clears an [`BufferedEvent`] when exiting the specified `state`.
     ///
-    /// Note that event cleanup is ambiguously ordered relative to  
-    /// [`DespawnOnExitState`](crate::prelude::DespawnOnExitState) entity cleanup,
+    /// Note that event cleanup is ambiguously ordered relative to
+    /// [`DespawnOnExit`](crate::prelude::DespawnOnExit) entity cleanup,
     /// and the [`OnExit`] schedule for the target state.
     /// All of these (state scoped entities and events cleanup, and `OnExit`)
     /// occur within schedule [`StateTransition`](crate::prelude::StateTransition)
@@ -141,7 +141,7 @@ pub trait StateScopedEventsAppExt {
     /// Clears an [`BufferedEvent`] when entering the specified `state`.
     ///
     /// Note that event cleanup is ambiguously ordered relative to
-    /// [`DespawnOnEnterState`](crate::prelude::DespawnOnEnterState) entity cleanup,
+    /// [`DespawnOnEnter`](crate::prelude::DespawnOnEnter) entity cleanup,
     /// and the [`OnEnter`] schedule for the target state.
     /// All of these (state scoped entities and events cleanup, and `OnEnter`)
     /// occur within schedule [`StateTransition`](crate::prelude::StateTransition)

--- a/examples/ecs/state_scoped.rs
+++ b/examples/ecs/state_scoped.rs
@@ -33,7 +33,7 @@ struct TickTock(Timer);
 fn on_a_enter(mut commands: Commands) {
     info!("on_a_enter");
     commands.spawn((
-        DespawnOnExitState(GameState::A),
+        DespawnOnExit(GameState::A),
         Text::new("Game is in state 'A'"),
         TextFont {
             font_size: 33.0,
@@ -52,7 +52,7 @@ fn on_a_enter(mut commands: Commands) {
 fn on_a_exit(mut commands: Commands) {
     info!("on_a_exit");
     commands.spawn((
-        DespawnOnEnterState(GameState::A),
+        DespawnOnEnter(GameState::A),
         Text::new("Game state 'A' will be back in 1 second"),
         TextFont {
             font_size: 33.0,
@@ -71,7 +71,7 @@ fn on_a_exit(mut commands: Commands) {
 fn on_b_enter(mut commands: Commands) {
     info!("on_b_enter");
     commands.spawn((
-        DespawnOnExitState(GameState::B),
+        DespawnOnExit(GameState::B),
         Text::new("Game is in state 'B'"),
         TextFont {
             font_size: 33.0,
@@ -90,7 +90,7 @@ fn on_b_enter(mut commands: Commands) {
 fn on_b_exit(mut commands: Commands) {
     info!("on_b_exit");
     commands.spawn((
-        DespawnOnEnterState(GameState::B),
+        DespawnOnEnter(GameState::B),
         Text::new("Game state 'B' will be back in 1 second"),
         TextFont {
             font_size: 33.0,

--- a/examples/games/alien_cake_addict.rs
+++ b/examples/games/alien_cake_addict.rs
@@ -120,7 +120,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut game: ResMu
     game.player.move_cooldown = Timer::from_seconds(0.3, TimerMode::Once);
 
     commands.spawn((
-        DespawnOnExitState(GameState::Playing),
+        DespawnOnExit(GameState::Playing),
         PointLight {
             intensity: 2_000_000.0,
             shadows_enabled: true,
@@ -139,7 +139,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut game: ResMu
                 .map(|i| {
                     let height = rng.random_range(-0.1..0.1);
                     commands.spawn((
-                        DespawnOnExitState(GameState::Playing),
+                        DespawnOnExit(GameState::Playing),
                         Transform::from_xyz(i as f32, height - 0.2, j as f32),
                         SceneRoot(cell_scene.clone()),
                     ));
@@ -153,7 +153,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut game: ResMu
     game.player.entity = Some(
         commands
             .spawn((
-                DespawnOnExitState(GameState::Playing),
+                DespawnOnExit(GameState::Playing),
                 Transform {
                     translation: Vec3::new(
                         game.player.i as f32,
@@ -177,7 +177,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut game: ResMu
 
     // scoreboard
     commands.spawn((
-        DespawnOnExitState(GameState::Playing),
+        DespawnOnExit(GameState::Playing),
         Text::new("Score:"),
         TextFont {
             font_size: 33.0,
@@ -340,7 +340,7 @@ fn spawn_bonus(
     game.bonus.entity = Some(
         commands
             .spawn((
-                DespawnOnExitState(GameState::Playing),
+                DespawnOnExit(GameState::Playing),
                 Transform::from_xyz(
                     game.bonus.i as f32,
                     game.board[game.bonus.j][game.bonus.i].height + 0.2,
@@ -390,7 +390,7 @@ fn game_over_keyboard(
 // display the number of cake eaten before losing
 fn display_score(mut commands: Commands, game: Res<Game>) {
     commands.spawn((
-        DespawnOnExitState(GameState::GameOver),
+        DespawnOnExit(GameState::GameOver),
         Node {
             width: percent(100),
             align_items: AlignItems::Center,

--- a/examples/state/computed_states.rs
+++ b/examples/state/computed_states.rs
@@ -403,7 +403,7 @@ mod ui {
 
     pub fn setup_game(mut commands: Commands, asset_server: Res<AssetServer>) {
         commands.spawn((
-            DespawnOnExitState(InGame),
+            DespawnOnExit(InGame),
             Sprite::from_image(asset_server.load("branding/icon.png")),
         ));
     }
@@ -443,7 +443,7 @@ mod ui {
     pub fn setup_paused_screen(mut commands: Commands) {
         info!("Printing Pause");
         commands.spawn((
-            DespawnOnExitState(IsPaused::Paused),
+            DespawnOnExit(IsPaused::Paused),
             Node {
                 // center button
                 width: percent(100),
@@ -481,7 +481,7 @@ mod ui {
 
     pub fn setup_turbo_text(mut commands: Commands) {
         commands.spawn((
-            DespawnOnExitState(TurboMode),
+            DespawnOnExit(TurboMode),
             Node {
                 // center button
                 width: percent(100),
@@ -517,7 +517,7 @@ mod ui {
 
     pub fn movement_instructions(mut commands: Commands) {
         commands.spawn((
-            DespawnOnExitState(Tutorial::MovementInstructions),
+            DespawnOnExit(Tutorial::MovementInstructions),
             Node {
                 // center button
                 width: percent(100),
@@ -568,7 +568,7 @@ mod ui {
 
     pub fn pause_instructions(mut commands: Commands) {
         commands.spawn((
-            DespawnOnExitState(Tutorial::PauseInstructions),
+            DespawnOnExit(Tutorial::PauseInstructions),
             Node {
                 // center button
                 width: percent(100),

--- a/examples/state/sub_states.rs
+++ b/examples/state/sub_states.rs
@@ -197,7 +197,7 @@ mod ui {
 
     pub fn setup_paused_screen(mut commands: Commands) {
         commands.spawn((
-            DespawnOnExitState(IsPaused::Paused),
+            DespawnOnExit(IsPaused::Paused),
             Node {
                 // center button
                 width: percent(100),

--- a/examples/testbed/2d.rs
+++ b/examples/testbed/2d.rs
@@ -68,7 +68,7 @@ mod shapes {
         mut meshes: ResMut<Assets<Mesh>>,
         mut materials: ResMut<Assets<ColorMaterial>>,
     ) {
-        commands.spawn((Camera2d, DespawnOnExitState(super::Scene::Shapes)));
+        commands.spawn((Camera2d, DespawnOnExit(super::Scene::Shapes)));
 
         let shapes = [
             meshes.add(Circle::new(50.0)),
@@ -101,7 +101,7 @@ mod shapes {
                     0.0,
                     0.0,
                 ),
-                DespawnOnExitState(super::Scene::Shapes),
+                DespawnOnExit(super::Scene::Shapes),
             ));
         }
     }
@@ -122,21 +122,21 @@ mod bloom {
             Camera2d,
             Tonemapping::TonyMcMapface,
             Bloom::default(),
-            DespawnOnExitState(super::Scene::Bloom),
+            DespawnOnExit(super::Scene::Bloom),
         ));
 
         commands.spawn((
             Mesh2d(meshes.add(Circle::new(100.))),
             MeshMaterial2d(materials.add(Color::srgb(7.5, 0.0, 7.5))),
             Transform::from_translation(Vec3::new(-200., 0., 0.)),
-            DespawnOnExitState(super::Scene::Bloom),
+            DespawnOnExit(super::Scene::Bloom),
         ));
 
         commands.spawn((
             Mesh2d(meshes.add(RegularPolygon::new(100., 6))),
             MeshMaterial2d(materials.add(Color::srgb(6.25, 9.4, 9.1))),
             Transform::from_translation(Vec3::new(200., 0., 0.)),
-            DespawnOnExitState(super::Scene::Bloom),
+            DespawnOnExit(super::Scene::Bloom),
         ));
     }
 }
@@ -148,7 +148,7 @@ mod text {
     use bevy::text::TextBounds;
 
     pub fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-        commands.spawn((Camera2d, DespawnOnExitState(super::Scene::Text)));
+        commands.spawn((Camera2d, DespawnOnExit(super::Scene::Text)));
 
         for (i, justify) in [
             Justify::Left,
@@ -182,14 +182,14 @@ mod text {
                     .with_scale(1.0 + Vec2::splat(fraction).extend(1.))
                     .with_rotation(Quat::from_rotation_z(fraction * core::f32::consts::PI)),
                 TextColor(Color::hsla(fraction * 360.0, 0.8, 0.8, 0.8)),
-                DespawnOnExitState(super::Scene::Text),
+                DespawnOnExit(super::Scene::Text),
             ));
         }
 
         commands.spawn((
             Text2d::new("This text is invisible."),
             Visibility::Hidden,
-            DespawnOnExitState(super::Scene::Text),
+            DespawnOnExit(super::Scene::Text),
         ));
     }
 
@@ -206,7 +206,7 @@ mod text {
                 ..Default::default()
             },
             Transform::from_translation(dest),
-            DespawnOnExitState(super::Scene::Text),
+            DespawnOnExit(super::Scene::Text),
         ));
 
         for anchor in [
@@ -220,7 +220,7 @@ mod text {
                 TextLayout::new_with_justify(justify),
                 Transform::from_translation(dest + Vec3::Z),
                 anchor,
-                DespawnOnExitState(super::Scene::Text),
+                DespawnOnExit(super::Scene::Text),
                 ShowAabbGizmo {
                     color: Some(palettes::tailwind::AMBER_400.into()),
                 },
@@ -248,7 +248,7 @@ mod text {
                     },
                     Transform::from_translation(dest - Vec3::Z),
                     anchor,
-                    DespawnOnExitState(super::Scene::Text),
+                    DespawnOnExit(super::Scene::Text),
                 ));
             }
         }
@@ -261,7 +261,7 @@ mod sprite {
     use bevy::sprite::Anchor;
 
     pub fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-        commands.spawn((Camera2d, DespawnOnExitState(super::Scene::Sprite)));
+        commands.spawn((Camera2d, DespawnOnExit(super::Scene::Sprite)));
         for (anchor, flip_x, flip_y, color) in [
             (Anchor::BOTTOM_LEFT, false, false, Color::WHITE),
             (Anchor::BOTTOM_RIGHT, true, false, RED.into()),
@@ -277,7 +277,7 @@ mod sprite {
                     ..default()
                 },
                 anchor,
-                DespawnOnExitState(super::Scene::Sprite),
+                DespawnOnExit(super::Scene::Sprite),
             ));
         }
     }
@@ -287,7 +287,7 @@ mod gizmos {
     use bevy::{color::palettes::css::*, prelude::*};
 
     pub fn setup(mut commands: Commands) {
-        commands.spawn((Camera2d, DespawnOnExitState(super::Scene::Gizmos)));
+        commands.spawn((Camera2d, DespawnOnExit(super::Scene::Gizmos)));
     }
 
     pub fn draw_gizmos(mut gizmos: Gizmos) {

--- a/examples/testbed/3d.rs
+++ b/examples/testbed/3d.rs
@@ -91,7 +91,7 @@ mod light {
                 perceptual_roughness: 1.0,
                 ..default()
             })),
-            DespawnOnExitState(CURRENT_SCENE),
+            DespawnOnExit(CURRENT_SCENE),
         ));
 
         commands.spawn((
@@ -101,7 +101,7 @@ mod light {
                 ..default()
             })),
             Transform::from_xyz(0.0, 1.0, 0.0),
-            DespawnOnExitState(CURRENT_SCENE),
+            DespawnOnExit(CURRENT_SCENE),
         ));
 
         commands.spawn((
@@ -112,7 +112,7 @@ mod light {
                 ..default()
             },
             Transform::from_xyz(1.0, 2.0, 0.0),
-            DespawnOnExitState(CURRENT_SCENE),
+            DespawnOnExit(CURRENT_SCENE),
         ));
 
         commands.spawn((
@@ -125,7 +125,7 @@ mod light {
                 ..default()
             },
             Transform::from_xyz(-1.0, 2.0, 0.0).looking_at(Vec3::new(-1.0, 0.0, 0.0), Vec3::Z),
-            DespawnOnExitState(CURRENT_SCENE),
+            DespawnOnExit(CURRENT_SCENE),
         ));
 
         commands.spawn((
@@ -139,13 +139,13 @@ mod light {
                 rotation: Quat::from_rotation_x(-PI / 4.),
                 ..default()
             },
-            DespawnOnExitState(CURRENT_SCENE),
+            DespawnOnExit(CURRENT_SCENE),
         ));
 
         commands.spawn((
             Camera3d::default(),
             Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-            DespawnOnExitState(CURRENT_SCENE),
+            DespawnOnExit(CURRENT_SCENE),
         ));
     }
 }
@@ -168,7 +168,7 @@ mod bloom {
             Tonemapping::TonyMcMapface,
             Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
             Bloom::NATURAL,
-            DespawnOnExitState(CURRENT_SCENE),
+            DespawnOnExit(CURRENT_SCENE),
         ));
 
         let material_emissive1 = materials.add(StandardMaterial {
@@ -193,7 +193,7 @@ mod bloom {
                 Mesh3d(mesh.clone()),
                 MeshMaterial3d(material),
                 Transform::from_xyz(z as f32 * 2.0, 0.0, 0.0),
-                DespawnOnExitState(CURRENT_SCENE),
+                DespawnOnExit(CURRENT_SCENE),
             ));
         }
     }
@@ -214,7 +214,7 @@ mod gltf {
                 intensity: 250.0,
                 ..default()
             },
-            DespawnOnExitState(CURRENT_SCENE),
+            DespawnOnExit(CURRENT_SCENE),
         ));
 
         commands.spawn((
@@ -222,13 +222,13 @@ mod gltf {
                 shadows_enabled: true,
                 ..default()
             },
-            DespawnOnExitState(CURRENT_SCENE),
+            DespawnOnExit(CURRENT_SCENE),
         ));
         commands.spawn((
             SceneRoot(asset_server.load(
                 GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"),
             )),
-            DespawnOnExitState(CURRENT_SCENE),
+            DespawnOnExit(CURRENT_SCENE),
         ));
     }
 }
@@ -265,7 +265,7 @@ mod animation {
         commands.spawn((
             Camera3d::default(),
             Transform::from_xyz(100.0, 100.0, 150.0).looking_at(Vec3::new(0.0, 20.0, 0.0), Vec3::Y),
-            DespawnOnExitState(CURRENT_SCENE),
+            DespawnOnExit(CURRENT_SCENE),
         ));
 
         commands.spawn((
@@ -274,13 +274,13 @@ mod animation {
                 shadows_enabled: true,
                 ..default()
             },
-            DespawnOnExitState(CURRENT_SCENE),
+            DespawnOnExit(CURRENT_SCENE),
         ));
 
         commands
             .spawn((
                 SceneRoot(asset_server.load(GltfAssetLabel::Scene(0).from_asset(FOX_PATH))),
-                DespawnOnExitState(CURRENT_SCENE),
+                DespawnOnExit(CURRENT_SCENE),
             ))
             .observe(pause_animation_frame);
     }
@@ -316,7 +316,7 @@ mod gizmos {
         commands.spawn((
             Camera3d::default(),
             Transform::from_xyz(-1.0, 2.5, 6.5).looking_at(Vec3::ZERO, Vec3::Y),
-            DespawnOnExitState(super::Scene::Gizmos),
+            DespawnOnExit(super::Scene::Gizmos),
         ));
     }
 
@@ -363,7 +363,7 @@ mod gltf_coordinate_conversion {
         commands.spawn((
             Camera3d::default(),
             Transform::from_xyz(-4.0, 4.0, -5.0).looking_at(Vec3::ZERO, Vec3::Y),
-            DespawnOnExitState(CURRENT_SCENE),
+            DespawnOnExit(CURRENT_SCENE),
         ));
 
         commands.spawn((
@@ -372,7 +372,7 @@ mod gltf_coordinate_conversion {
                 ..default()
             },
             Transform::IDENTITY.looking_to(Dir3::Z, Dir3::Y),
-            DespawnOnExitState(CURRENT_SCENE),
+            DespawnOnExit(CURRENT_SCENE),
         ));
 
         commands.spawn((
@@ -381,7 +381,7 @@ mod gltf_coordinate_conversion {
                 ..default()
             },
             Transform::IDENTITY.looking_to(Dir3::X, Dir3::Y),
-            DespawnOnExitState(CURRENT_SCENE),
+            DespawnOnExit(CURRENT_SCENE),
         ));
 
         commands.spawn((
@@ -390,7 +390,7 @@ mod gltf_coordinate_conversion {
                 ..default()
             },
             Transform::IDENTITY.looking_to(Dir3::NEG_Y, Dir3::X),
-            DespawnOnExitState(CURRENT_SCENE),
+            DespawnOnExit(CURRENT_SCENE),
         ));
 
         commands
@@ -401,7 +401,7 @@ mod gltf_coordinate_conversion {
                         s.use_model_forward_direction = Some(true);
                     },
                 )),
-                DespawnOnExitState(CURRENT_SCENE),
+                DespawnOnExit(CURRENT_SCENE),
             ))
             .observe(show_aabbs);
     }

--- a/examples/testbed/ui.rs
+++ b/examples/testbed/ui.rs
@@ -80,10 +80,10 @@ mod image {
     use bevy::prelude::*;
 
     pub fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-        commands.spawn((Camera2d, DespawnOnExitState(super::Scene::Image)));
+        commands.spawn((Camera2d, DespawnOnExit(super::Scene::Image)));
         commands.spawn((
             ImageNode::new(asset_server.load("branding/bevy_logo_dark.png")),
-            DespawnOnExitState(super::Scene::Image),
+            DespawnOnExit(super::Scene::Image),
         ));
     }
 }
@@ -92,7 +92,7 @@ mod text {
     use bevy::{color::palettes::css::*, prelude::*};
 
     pub fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-        commands.spawn((Camera2d, DespawnOnExitState(super::Scene::Text)));
+        commands.spawn((Camera2d, DespawnOnExit(super::Scene::Text)));
         commands.spawn((
             Text::new("Hello World."),
             TextFont {
@@ -100,7 +100,7 @@ mod text {
                 font_size: 200.,
                 ..default()
             },
-            DespawnOnExitState(super::Scene::Text),
+            DespawnOnExit(super::Scene::Text),
         ));
 
         commands.spawn((
@@ -114,7 +114,7 @@ mod text {
                 font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                 ..default()
             },
-            DespawnOnExitState(super::Scene::Text),
+            DespawnOnExit(super::Scene::Text),
             children![
                 (TextSpan::new("red "), TextColor(RED.into()),),
                 (TextSpan::new("green "), TextColor(GREEN.into()),),
@@ -142,7 +142,7 @@ mod text {
                 font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                 ..default()
             },
-            DespawnOnExitState(super::Scene::Text),
+            DespawnOnExit(super::Scene::Text),
             children![
                 (
                     TextSpan::new("white "),
@@ -177,7 +177,7 @@ mod text {
                 font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                 ..default()
             },
-            DespawnOnExitState(super::Scene::Text),
+            DespawnOnExit(super::Scene::Text),
             children![
                 (TextSpan::new(""), TextColor(YELLOW.into()),),
                 TextSpan::new(""),
@@ -216,7 +216,7 @@ mod grid {
     use bevy::{color::palettes::css::*, prelude::*};
 
     pub fn setup(mut commands: Commands) {
-        commands.spawn((Camera2d, DespawnOnExitState(super::Scene::Grid)));
+        commands.spawn((Camera2d, DespawnOnExit(super::Scene::Grid)));
         // Top-level grid (app frame)
         commands.spawn((
             Node {
@@ -232,7 +232,7 @@ mod grid {
                 ..default()
             },
             BackgroundColor(Color::WHITE),
-            DespawnOnExitState(super::Scene::Grid),
+            DespawnOnExit(super::Scene::Grid),
             children![
                 // Header
                 (
@@ -276,14 +276,14 @@ mod borders {
     use bevy::{color::palettes::css::*, prelude::*};
 
     pub fn setup(mut commands: Commands) {
-        commands.spawn((Camera2d, DespawnOnExitState(super::Scene::Borders)));
+        commands.spawn((Camera2d, DespawnOnExit(super::Scene::Borders)));
         let root = commands
             .spawn((
                 Node {
                     flex_wrap: FlexWrap::Wrap,
                     ..default()
                 },
-                DespawnOnExitState(super::Scene::Borders),
+                DespawnOnExit(super::Scene::Borders),
             ))
             .id();
 
@@ -369,7 +369,7 @@ mod box_shadow {
     use bevy::{color::palettes::css::*, prelude::*};
 
     pub fn setup(mut commands: Commands) {
-        commands.spawn((Camera2d, DespawnOnExitState(super::Scene::BoxShadow)));
+        commands.spawn((Camera2d, DespawnOnExit(super::Scene::BoxShadow)));
 
         commands
             .spawn((
@@ -382,7 +382,7 @@ mod box_shadow {
                     ..default()
                 },
                 BackgroundColor(GREEN.into()),
-                DespawnOnExitState(super::Scene::BoxShadow),
+                DespawnOnExit(super::Scene::BoxShadow),
             ))
             .with_children(|commands| {
                 let example_nodes = [
@@ -452,7 +452,7 @@ mod text_wrap {
     use bevy::prelude::*;
 
     pub fn setup(mut commands: Commands) {
-        commands.spawn((Camera2d, DespawnOnExitState(super::Scene::TextWrap)));
+        commands.spawn((Camera2d, DespawnOnExit(super::Scene::TextWrap)));
 
         let root = commands
             .spawn((
@@ -464,7 +464,7 @@ mod text_wrap {
                     ..default()
                 },
                 BackgroundColor(Color::BLACK),
-                DespawnOnExitState(super::Scene::TextWrap),
+                DespawnOnExit(super::Scene::TextWrap),
             ))
             .id();
 
@@ -494,7 +494,7 @@ mod overflow {
     use bevy::{color::palettes::css::*, prelude::*};
 
     pub fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-        commands.spawn((Camera2d, DespawnOnExitState(super::Scene::Overflow)));
+        commands.spawn((Camera2d, DespawnOnExit(super::Scene::Overflow)));
         let image = asset_server.load("branding/icon.png");
 
         commands
@@ -507,7 +507,7 @@ mod overflow {
                     ..Default::default()
                 },
                 BackgroundColor(BLUE.into()),
-                DespawnOnExitState(super::Scene::Overflow),
+                DespawnOnExit(super::Scene::Overflow),
             ))
             .with_children(|parent| {
                 for overflow in [
@@ -558,7 +558,7 @@ mod slice {
     use bevy::prelude::*;
 
     pub fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-        commands.spawn((Camera2d, DespawnOnExitState(super::Scene::Slice)));
+        commands.spawn((Camera2d, DespawnOnExit(super::Scene::Slice)));
         let image = asset_server.load("textures/fantasy_ui_borders/numbered_slices.png");
 
         let slicer = TextureSlicer {
@@ -576,7 +576,7 @@ mod slice {
                     justify_content: JustifyContent::SpaceAround,
                     ..default()
                 },
-                DespawnOnExitState(super::Scene::Slice),
+                DespawnOnExit(super::Scene::Slice),
             ))
             .with_children(|parent| {
                 for [w, h] in [[150.0, 150.0], [300.0, 150.0], [150.0, 300.0]] {
@@ -622,7 +622,7 @@ mod layout_rounding {
     use bevy::{color::palettes::css::*, prelude::*};
 
     pub fn setup(mut commands: Commands) {
-        commands.spawn((Camera2d, DespawnOnExitState(super::Scene::LayoutRounding)));
+        commands.spawn((Camera2d, DespawnOnExit(super::Scene::LayoutRounding)));
 
         commands
             .spawn((
@@ -634,7 +634,7 @@ mod layout_rounding {
                     ..Default::default()
                 },
                 BackgroundColor(Color::WHITE),
-                DespawnOnExitState(super::Scene::LayoutRounding),
+                DespawnOnExit(super::Scene::LayoutRounding),
             ))
             .with_children(|commands| {
                 for i in 2..12 {
@@ -669,7 +669,7 @@ mod linear_gradient {
     use bevy::color::palettes::css::YELLOW;
     use bevy::color::Color;
     use bevy::ecs::prelude::*;
-    use bevy::state::state_scoped::DespawnOnExitState;
+    use bevy::state::state_scoped::DespawnOnExit;
     use bevy::text::TextFont;
     use bevy::ui::AlignItems;
     use bevy::ui::BackgroundGradient;
@@ -683,7 +683,7 @@ mod linear_gradient {
     use bevy::utils::default;
 
     pub fn setup(mut commands: Commands) {
-        commands.spawn((Camera2d, DespawnOnExitState(super::Scene::LinearGradient)));
+        commands.spawn((Camera2d, DespawnOnExit(super::Scene::LinearGradient)));
         commands
             .spawn((
                 Node {
@@ -695,7 +695,7 @@ mod linear_gradient {
                     row_gap: bevy::ui::px(5),
                     ..default()
                 },
-                DespawnOnExitState(super::Scene::LinearGradient),
+                DespawnOnExit(super::Scene::LinearGradient),
             ))
             .with_children(|commands| {
                 let mut i = 0;
@@ -805,7 +805,7 @@ mod radial_gradient {
             ColorStop::auto(RED),
         ];
 
-        commands.spawn((Camera2d, DespawnOnExitState(super::Scene::RadialGradient)));
+        commands.spawn((Camera2d, DespawnOnExit(super::Scene::RadialGradient)));
         commands
             .spawn((
                 Node {
@@ -823,7 +823,7 @@ mod radial_gradient {
                     padding: UiRect::all(px(GAP)),
                     ..default()
                 },
-                DespawnOnExitState(super::Scene::RadialGradient),
+                DespawnOnExit(super::Scene::RadialGradient),
             ))
             .with_children(|commands| {
                 for (shape, shape_label) in [

--- a/release-content/migration-guides/rename_state_scoped.md
+++ b/release-content/migration-guides/rename_state_scoped.md
@@ -8,13 +8,13 @@ as a way to remove entities/events when **exiting** a state.
 
 However, it can also be useful to have the opposite behavior,
 where entities/events are removed when **entering** a state.
-This is now possible with the new `DespawnOnEnterState` component and `clear_events_on_enter_state` method.
+This is now possible with the new `DespawnOnEnter` component and `clear_events_on_enter_state` method.
 
 To support this addition, the previous method and component have been renamed.
 Also, `clear_event_on_exit_state` no longer adds the event automatically, so you must call `App::add_event` manually.
 
 | Before                        | After                                      |
 |-------------------------------|--------------------------------------------|
-| `StateScoped`                 | `DespawnOnExitState`                       |
+| `StateScoped`                 | `DespawnOnExit`                       |
 | `clear_state_scoped_entities` | `despawn_entities_on_exit_state`           |
 | `add_state_scoped_event`      | `add_event` + `clear_events_on_exit_state` |


### PR DESCRIPTION
# Objective

- `StateScoped` was renamed to `DespawnOnExitState`, and we introduced `DespawnOnEnterState`
- This is redundant: the type it wraps is already a state
- Often, state enums have `State` in their names, leading to stutter: `DespawnOnExitState(GameState::Gameplay)`
- This component is *very* common in games. The longer name makes it clunkier to use, so we should be careful when expanding it. I think the added clarity is good, but we can do better.

## Solution

- Compromise to `DespawnOnExit`

## Testing

- CI
