### PR TITLE
unifying `Asset<A>` / `AssetServer` handles (#20651, #20776)

### DIFF
--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -563,9 +563,11 @@ impl<A: Asset> Assets<A> {
             // handle being dropped and this system running; only try dropping
             // if that isn't the case.
             if !assets.get_handle_provider().is_live(id.internal()) {
-                if drop_event.asset_server_managed {
-                    let untyped_id = id.untyped();
-
+                // the server should only decide whether to skip dropping the
+                // asset if it manages the asset: this is the case if the asset
+                // has an info entry with the server.
+                let untyped_id = id.untyped();
+                if infos.contains_key(untyped_id) {
                     if !infos.process_handle_drop(untyped_id) {
                         // the asset doesn't exist
                         continue;

--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -411,13 +411,16 @@ impl<A: Asset> Assets<A> {
         if !self.contains(id) {
             return None;
         }
-        let index = match id {
-            AssetId::Index { index, .. } => index.into(),
-            AssetId::Uuid { uuid } => uuid.into(),
-        };
-        Some(Handle::Strong(
-            self.handle_provider.get_handle(index, false, None, None),
-        ))
+
+        match id {
+            AssetId::Index { index, .. } => Some(Handle::Strong(self.handle_provider.get_handle(
+                index.into(),
+                false,
+                None,
+                None,
+            ))),
+            AssetId::Uuid { uuid } => Some(Handle::Uuid(uuid, PhantomData)),
+        }
     }
 
     /// Retrieves a reference to the [`Asset`] with the given `id`, if it exists.

--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -570,11 +570,9 @@ impl<A: Asset> Assets<A> {
                 // asset if it manages the asset: this is the case if the asset
                 // has an info entry with the server.
                 let untyped_id = id.untyped();
-                if infos.contains_key(untyped_id) {
-                    if !infos.process_handle_drop(untyped_id) {
-                        // the asset doesn't exist
-                        continue;
-                    }
+                if infos.contains_key(untyped_id) && !infos.process_handle_drop(untyped_id) {
+                    // the asset doesn't exist
+                    continue;
                 }
 
                 assets.remove_dropped(id);

--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -54,7 +54,7 @@ impl AssetHandleProvider {
 
     pub(crate) fn try_get_handle(&self, id: InternalAssetId) -> Option<Arc<StrongHandle>> {
         let id_to_handle = self.id_to_handle.lock();
-        id_to_handle.get(&id).and_then(|weak| weak.upgrade())
+        id_to_handle.get(&id).and_then(Weak::upgrade)
     }
 
     /// Creates a new handle for the given `id`. If a handle was previously
@@ -71,7 +71,7 @@ impl AssetHandleProvider {
     ) -> Arc<StrongHandle> {
         let mut id_to_handle = self.id_to_handle.lock();
 
-        if let Some(strong) = id_to_handle.get(&id).and_then(|weak| weak.upgrade()) {
+        if let Some(strong) = id_to_handle.get(&id).and_then(Weak::upgrade) {
             return strong;
         }
 

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -1609,7 +1609,7 @@ mod tests {
     }
 
     #[test]
-    fn uuid_asset_strong_handle() {
+    fn get_strong_handle_for_uuid_asset() {
         let dir = Dir::default();
         let dep_path = "dep.cool.ron";
 


### PR DESCRIPTION
# Objective

fixes #20651, #20776

## Solution

the AssetHandleProvider gets a mutex'd hashmap of all handles it has given out and the Assets<A> and AssetServer use this to synchronise their respective assets and asset state.
Even though this introduces a lock to an otherwise lockless type, after trying to share the handle between AssetServer and Assets<A> via the asset events I believe that this is the better and simpler approach.
Opening this as a draft though because I think it's controversial.

calling get_strong_handle() with a UUID asset now also returns a UUID handle so that track_assets doesn't get a drop even for UUID assets which don't have automatic dropping behaviour.

## Testing

ci doesn't work on my machine, so I did `cargo test --workspace --lib --tests`

