### PR TITLE
convert more examples to new spawn api

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -267,6 +267,8 @@ pub struct AssetPlugin {
 /// app will include scripts or modding support, as it could allow arbitrary file
 /// access for malicious code.
 ///
+/// The default value is [`Forbid`](UnapprovedPathMode::Forbid).
+///
 /// See [`AssetPath::is_unapproved`](crate::AssetPath::is_unapproved)
 #[derive(Clone, Default)]
 pub enum UnapprovedPathMode {

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -1906,7 +1906,7 @@ pub enum AssetLoadError {
         actual_asset_name: &'static str,
         loader_name: &'static str,
     },
-    #[error("Could not find an asset loader matching: Loader Name: {loader_name:?}; Asset Type: {loader_name:?}; Extension: {extension:?}; Path: {asset_path:?};")]
+    #[error("Could not find an asset loader matching: Loader Name: {loader_name:?}; Asset Type: {asset_type_id:?}; Extension: {extension:?}; Path: {asset_path:?};")]
     MissingAssetLoader {
         loader_name: Option<String>,
         asset_type_id: Option<TypeId>,

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -325,7 +325,7 @@ impl AssetServer {
         self.load_with_meta_transform(path, None, (), false)
     }
 
-    /// Same as [`load`](AssetServer::load), but you can load assets from unaproved paths
+    /// Same as [`load`](AssetServer::load), but you can load assets from unapproved paths
     /// if [`AssetPlugin::unapproved_path_mode`](super::AssetPlugin::unapproved_path_mode)
     /// is [`Deny`](UnapprovedPathMode::Deny).
     ///
@@ -358,7 +358,7 @@ impl AssetServer {
         self.load_with_meta_transform(path, None, guard, false)
     }
 
-    /// Same as [`load`](AssetServer::load_acquire), but you can load assets from unaproved paths
+    /// Same as [`load`](AssetServer::load_acquire), but you can load assets from unapproved paths
     /// if [`AssetPlugin::unapproved_path_mode`](super::AssetPlugin::unapproved_path_mode)
     /// is [`Deny`](UnapprovedPathMode::Deny).
     ///
@@ -388,7 +388,7 @@ impl AssetServer {
         )
     }
 
-    /// Same as [`load`](AssetServer::load_with_settings), but you can load assets from unaproved paths
+    /// Same as [`load`](AssetServer::load_with_settings), but you can load assets from unapproved paths
     /// if [`AssetPlugin::unapproved_path_mode`](super::AssetPlugin::unapproved_path_mode)
     /// is [`Deny`](UnapprovedPathMode::Deny).
     ///
@@ -430,7 +430,7 @@ impl AssetServer {
         )
     }
 
-    /// Same as [`load`](AssetServer::load_acquire_with_settings), but you can load assets from unaproved paths
+    /// Same as [`load`](AssetServer::load_acquire_with_settings), but you can load assets from unapproved paths
     /// if [`AssetPlugin::unapproved_path_mode`](super::AssetPlugin::unapproved_path_mode)
     /// is [`Deny`](UnapprovedPathMode::Deny).
     ///

--- a/crates/bevy_ecs/src/bundle/impls.rs
+++ b/crates/bevy_ecs/src/bundle/impls.rs
@@ -148,11 +148,12 @@ all_tuples!(
 );
 
 macro_rules! after_effect_impl {
-    ($($after_effect: ident),*) => {
+    ($(#[$meta:meta])* $($after_effect: ident),*) => {
         #[expect(
             clippy::allow_attributes,
             reason = "This is a tuple-related macro; as such, the lints below may not always apply."
         )]
+        $(#[$meta])*
         impl<$($after_effect: BundleEffect),*> BundleEffect for ($($after_effect,)*) {
             #[allow(
                 clippy::unused_unit,
@@ -168,8 +169,15 @@ macro_rules! after_effect_impl {
             }
         }
 
+        $(#[$meta])*
         impl<$($after_effect: NoBundleEffect),*> NoBundleEffect for ($($after_effect,)*) { }
     }
 }
 
-all_tuples!(after_effect_impl, 0, 15, P);
+all_tuples!(
+    #[doc(fake_variadic)]
+    after_effect_impl,
+    0,
+    15,
+    P
+);

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -2530,6 +2530,7 @@ macro_rules! impl_tuple_query_data {
             }
         }
 
+        $(#[$meta])*
         /// SAFETY: each item in the tuple is read only
         unsafe impl<$($name: ReadOnlyQueryData),*> ReadOnlyQueryData for ($($name,)*) {}
 
@@ -2541,6 +2542,7 @@ macro_rules! impl_tuple_query_data {
             clippy::unused_unit,
             reason = "Zero-length tuples will generate some function bodies equivalent to `()`; however, this macro is meant for all applicable tuples, and as such it makes no sense to rewrite it just for that case."
         )]
+        $(#[$meta])*
         impl<$($name: ReleaseStateQueryData),*> ReleaseStateQueryData for ($($name,)*) {
             fn release_state<'w>(($($item,)*): Self::Item<'w, '_>) -> Self::Item<'w, 'static> {
                 ($($name::release_state($item),)*)

--- a/crates/bevy_ecs/src/spawn.rs
+++ b/crates/bevy_ecs/src/spawn.rs
@@ -215,11 +215,12 @@ impl<R: Relationship> SpawnableList<R> for WithOneRelated {
 }
 
 macro_rules! spawnable_list_impl {
-    ($($list: ident),*) => {
+    ($(#[$meta:meta])* $($list: ident),*) => {
         #[expect(
             clippy::allow_attributes,
             reason = "This is a tuple-related macro; as such, the lints below may not always apply."
         )]
+        $(#[$meta])*
         impl<R: Relationship, $($list: SpawnableList<R>),*> SpawnableList<R> for ($($list,)*) {
             fn spawn(self, _world: &mut World, _entity: Entity) {
                 #[allow(
@@ -242,7 +243,13 @@ macro_rules! spawnable_list_impl {
     }
 }
 
-all_tuples!(spawnable_list_impl, 0, 12, P);
+all_tuples!(
+    #[doc(fake_variadic)]
+    spawnable_list_impl,
+    0,
+    12,
+    P
+);
 
 /// A [`Bundle`] that:
 /// 1. Contains a [`RelationshipTarget`] component (associated with the given [`Relationship`]). This reserves space for the [`SpawnableList`].

--- a/crates/bevy_render/src/render_resource/specializer.rs
+++ b/crates/bevy_render/src/render_resource/specializer.rs
@@ -245,7 +245,8 @@ impl<T: Specializable, V: Send + Sync + 'static> Specializer<T> for PhantomData<
 }
 
 macro_rules! impl_specialization_key_tuple {
-    ($($T:ident),*) => {
+    ($(#[$meta:meta])* $($T:ident),*) => {
+        $(#[$meta])*
         impl <$($T: SpecializerKey),*> SpecializerKey for ($($T,)*) {
             const IS_CANONICAL: bool = true $(&& <$T as SpecializerKey>::IS_CANONICAL)*;
             type Canonical = ($(Canonical<$T>,)*);
@@ -253,8 +254,13 @@ macro_rules! impl_specialization_key_tuple {
     };
 }
 
-// TODO: How to we fake_variadics this?
-all_tuples!(impl_specialization_key_tuple, 0, 12, T);
+all_tuples!(
+    #[doc(fake_variadic)]
+    impl_specialization_key_tuple,
+    0,
+    12,
+    T
+);
 
 /// A cache for variants of a resource type created by a specializer.
 /// At most one resource will be created for each key.

--- a/crates/bevy_ui_render/src/lib.rs
+++ b/crates/bevy_ui_render/src/lib.rs
@@ -1331,105 +1331,253 @@ pub fn prepare_uinodes(
 
             for item_index in 0..ui_phase.items.len() {
                 let item = &mut ui_phase.items[item_index];
-                if let Some(extracted_uinode) = extracted_uinodes
+                let Some(extracted_uinode) = extracted_uinodes
                     .uinodes
                     .get(item.index)
                     .filter(|n| item.entity() == n.render_entity)
-                {
-                    let mut existing_batch = batches.last_mut();
+                else {
+                    batch_image_handle = AssetId::invalid();
+                    continue;
+                };
 
-                    if batch_image_handle == AssetId::invalid()
-                        || existing_batch.is_none()
-                        || (batch_image_handle != AssetId::default()
-                            && extracted_uinode.image != AssetId::default()
-                            && batch_image_handle != extracted_uinode.image)
-                    {
-                        if let Some(gpu_image) = gpu_images.get(extracted_uinode.image) {
-                            batch_item_index = item_index;
-                            batch_image_handle = extracted_uinode.image;
+                let mut existing_batch = batches.last_mut();
 
-                            let new_batch = UiBatch {
-                                range: vertices_index..vertices_index,
-                                image: extracted_uinode.image,
-                            };
-
-                            batches.push((item.entity(), new_batch));
-
-                            image_bind_groups
-                                .values
-                                .entry(batch_image_handle)
-                                .or_insert_with(|| {
-                                    render_device.create_bind_group(
-                                        "ui_material_bind_group",
-                                        &ui_pipeline.image_layout,
-                                        &BindGroupEntries::sequential((
-                                            &gpu_image.texture_view,
-                                            &gpu_image.sampler,
-                                        )),
-                                    )
-                                });
-
-                            existing_batch = batches.last_mut();
-                        } else {
-                            continue;
-                        }
-                    } else if batch_image_handle == AssetId::default()
+                if batch_image_handle == AssetId::invalid()
+                    || existing_batch.is_none()
+                    || (batch_image_handle != AssetId::default()
                         && extracted_uinode.image != AssetId::default()
-                    {
-                        if let Some(ref mut existing_batch) = existing_batch
-                            && let Some(gpu_image) = gpu_images.get(extracted_uinode.image)
-                        {
-                            batch_image_handle = extracted_uinode.image;
-                            existing_batch.1.image = extracted_uinode.image;
+                        && batch_image_handle != extracted_uinode.image)
+                {
+                    if let Some(gpu_image) = gpu_images.get(extracted_uinode.image) {
+                        batch_item_index = item_index;
+                        batch_image_handle = extracted_uinode.image;
 
-                            image_bind_groups
-                                .values
-                                .entry(batch_image_handle)
-                                .or_insert_with(|| {
-                                    render_device.create_bind_group(
-                                        "ui_material_bind_group",
-                                        &ui_pipeline.image_layout,
-                                        &BindGroupEntries::sequential((
-                                            &gpu_image.texture_view,
-                                            &gpu_image.sampler,
-                                        )),
-                                    )
-                                });
-                        } else {
-                            continue;
-                        }
+                        let new_batch = UiBatch {
+                            range: vertices_index..vertices_index,
+                            image: extracted_uinode.image,
+                        };
+
+                        batches.push((item.entity(), new_batch));
+
+                        image_bind_groups
+                            .values
+                            .entry(batch_image_handle)
+                            .or_insert_with(|| {
+                                render_device.create_bind_group(
+                                    "ui_material_bind_group",
+                                    &ui_pipeline.image_layout,
+                                    &BindGroupEntries::sequential((
+                                        &gpu_image.texture_view,
+                                        &gpu_image.sampler,
+                                    )),
+                                )
+                            });
+
+                        existing_batch = batches.last_mut();
+                    } else {
+                        continue;
                     }
-                    match &extracted_uinode.item {
-                        ExtractedUiItem::Node {
-                            atlas_scaling,
-                            flip_x,
-                            flip_y,
-                            border_radius,
-                            border,
-                            node_type,
-                            rect,
-                            color,
-                        } => {
-                            let mut flags = if extracted_uinode.image != AssetId::default() {
-                                shader_flags::TEXTURED
-                            } else {
-                                shader_flags::UNTEXTURED
-                            };
+                } else if batch_image_handle == AssetId::default()
+                    && extracted_uinode.image != AssetId::default()
+                {
+                    if let Some(ref mut existing_batch) = existing_batch
+                        && let Some(gpu_image) = gpu_images.get(extracted_uinode.image)
+                    {
+                        batch_image_handle = extracted_uinode.image;
+                        existing_batch.1.image = extracted_uinode.image;
 
-                            let mut uinode_rect = *rect;
+                        image_bind_groups
+                            .values
+                            .entry(batch_image_handle)
+                            .or_insert_with(|| {
+                                render_device.create_bind_group(
+                                    "ui_material_bind_group",
+                                    &ui_pipeline.image_layout,
+                                    &BindGroupEntries::sequential((
+                                        &gpu_image.texture_view,
+                                        &gpu_image.sampler,
+                                    )),
+                                )
+                            });
+                    } else {
+                        continue;
+                    }
+                }
+                match &extracted_uinode.item {
+                    ExtractedUiItem::Node {
+                        atlas_scaling,
+                        flip_x,
+                        flip_y,
+                        border_radius,
+                        border,
+                        node_type,
+                        rect,
+                        color,
+                    } => {
+                        let mut flags = if extracted_uinode.image != AssetId::default() {
+                            shader_flags::TEXTURED
+                        } else {
+                            shader_flags::UNTEXTURED
+                        };
 
-                            let rect_size = uinode_rect.size();
+                        let mut uinode_rect = *rect;
 
-                            let transform = extracted_uinode.transform;
+                        let rect_size = uinode_rect.size();
 
-                            // Specify the corners of the node
-                            let positions = QUAD_VERTEX_POSITIONS
-                                .map(|pos| transform.transform_point2(pos * rect_size).extend(0.));
-                            let points = QUAD_VERTEX_POSITIONS.map(|pos| pos * rect_size);
+                        let transform = extracted_uinode.transform;
 
-                            // Calculate the effect of clipping
-                            // Note: this won't work with rotation/scaling, but that's much more complex (may need more that 2 quads)
-                            let mut positions_diff = if let Some(clip) = extracted_uinode.clip {
+                        // Specify the corners of the node
+                        let positions = QUAD_VERTEX_POSITIONS
+                            .map(|pos| transform.transform_point2(pos * rect_size).extend(0.));
+                        let points = QUAD_VERTEX_POSITIONS.map(|pos| pos * rect_size);
+
+                        // Calculate the effect of clipping
+                        // Note: this won't work with rotation/scaling, but that's much more complex (may need more that 2 quads)
+                        let mut positions_diff = if let Some(clip) = extracted_uinode.clip {
+                            [
+                                Vec2::new(
+                                    f32::max(clip.min.x - positions[0].x, 0.),
+                                    f32::max(clip.min.y - positions[0].y, 0.),
+                                ),
+                                Vec2::new(
+                                    f32::min(clip.max.x - positions[1].x, 0.),
+                                    f32::max(clip.min.y - positions[1].y, 0.),
+                                ),
+                                Vec2::new(
+                                    f32::min(clip.max.x - positions[2].x, 0.),
+                                    f32::min(clip.max.y - positions[2].y, 0.),
+                                ),
+                                Vec2::new(
+                                    f32::max(clip.min.x - positions[3].x, 0.),
+                                    f32::min(clip.max.y - positions[3].y, 0.),
+                                ),
+                            ]
+                        } else {
+                            [Vec2::ZERO; 4]
+                        };
+
+                        let positions_clipped = [
+                            positions[0] + positions_diff[0].extend(0.),
+                            positions[1] + positions_diff[1].extend(0.),
+                            positions[2] + positions_diff[2].extend(0.),
+                            positions[3] + positions_diff[3].extend(0.),
+                        ];
+
+                        let points = [
+                            points[0] + positions_diff[0],
+                            points[1] + positions_diff[1],
+                            points[2] + positions_diff[2],
+                            points[3] + positions_diff[3],
+                        ];
+
+                        let transformed_rect_size = transform.transform_vector2(rect_size);
+
+                        // Don't try to cull nodes that have a rotation
+                        // In a rotation around the Z-axis, this value is 0.0 for an angle of 0.0 or π
+                        // In those two cases, the culling check can proceed normally as corners will be on
+                        // horizontal / vertical lines
+                        // For all other angles, bypass the culling check
+                        // This does not properly handles all rotations on all axis
+                        if transform.x_axis[1] == 0.0 {
+                            // Cull nodes that are completely clipped
+                            if positions_diff[0].x - positions_diff[1].x >= transformed_rect_size.x
+                                || positions_diff[1].y - positions_diff[2].y
+                                    >= transformed_rect_size.y
+                            {
+                                continue;
+                            }
+                        }
+                        let uvs = if flags == shader_flags::UNTEXTURED {
+                            [Vec2::ZERO, Vec2::X, Vec2::ONE, Vec2::Y]
+                        } else {
+                            let image = gpu_images
+                                .get(extracted_uinode.image)
+                                .expect("Image was checked during batching and should still exist");
+                            // Rescale atlases. This is done here because we need texture data that might not be available in Extract.
+                            let atlas_extent = atlas_scaling
+                                .map(|scaling| image.size_2d().as_vec2() * scaling)
+                                .unwrap_or(uinode_rect.max);
+                            if *flip_x {
+                                core::mem::swap(&mut uinode_rect.max.x, &mut uinode_rect.min.x);
+                                positions_diff[0].x *= -1.;
+                                positions_diff[1].x *= -1.;
+                                positions_diff[2].x *= -1.;
+                                positions_diff[3].x *= -1.;
+                            }
+                            if *flip_y {
+                                core::mem::swap(&mut uinode_rect.max.y, &mut uinode_rect.min.y);
+                                positions_diff[0].y *= -1.;
+                                positions_diff[1].y *= -1.;
+                                positions_diff[2].y *= -1.;
+                                positions_diff[3].y *= -1.;
+                            }
+                            [
+                                Vec2::new(
+                                    uinode_rect.min.x + positions_diff[0].x,
+                                    uinode_rect.min.y + positions_diff[0].y,
+                                ),
+                                Vec2::new(
+                                    uinode_rect.max.x + positions_diff[1].x,
+                                    uinode_rect.min.y + positions_diff[1].y,
+                                ),
+                                Vec2::new(
+                                    uinode_rect.max.x + positions_diff[2].x,
+                                    uinode_rect.max.y + positions_diff[2].y,
+                                ),
+                                Vec2::new(
+                                    uinode_rect.min.x + positions_diff[3].x,
+                                    uinode_rect.max.y + positions_diff[3].y,
+                                ),
+                            ]
+                            .map(|pos| pos / atlas_extent)
+                        };
+
+                        let color = color.to_f32_array();
+                        if let NodeType::Border(border_flags) = *node_type {
+                            flags |= border_flags;
+                        }
+
+                        for i in 0..4 {
+                            ui_meta.vertices.push(UiVertex {
+                                position: positions_clipped[i].into(),
+                                uv: uvs[i].into(),
+                                color,
+                                flags: flags | shader_flags::CORNERS[i],
+                                radius: (*border_radius).into(),
+                                border: [border.left, border.top, border.right, border.bottom],
+                                size: rect_size.into(),
+                                point: points[i].into(),
+                            });
+                        }
+
+                        for &i in &QUAD_INDICES {
+                            ui_meta.indices.push(indices_index + i as u32);
+                        }
+
+                        vertices_index += 6;
+                        indices_index += 4;
+                    }
+                    ExtractedUiItem::Glyphs { range } => {
+                        let image = gpu_images
+                            .get(extracted_uinode.image)
+                            .expect("Image was checked during batching and should still exist");
+
+                        let atlas_extent = image.size_2d().as_vec2();
+
+                        for glyph in &extracted_uinodes.glyphs[range.clone()] {
+                            let color = glyph.color.to_f32_array();
+                            let glyph_rect = glyph.rect;
+                            let rect_size = glyph_rect.size();
+
+                            // Specify the corners of the glyph
+                            let positions = QUAD_VERTEX_POSITIONS.map(|pos| {
+                                extracted_uinode
+                                    .transform
+                                    .transform_point2(glyph.translation + pos * glyph_rect.size())
+                                    .extend(0.)
+                            });
+
+                            let positions_diff = if let Some(clip) = extracted_uinode.clip {
                                 [
                                     Vec2::new(
                                         f32::max(clip.min.x - positions[0].x, 0.),
@@ -1459,91 +1607,47 @@ pub fn prepare_uinodes(
                                 positions[3] + positions_diff[3].extend(0.),
                             ];
 
-                            let points = [
-                                points[0] + positions_diff[0],
-                                points[1] + positions_diff[1],
-                                points[2] + positions_diff[2],
-                                points[3] + positions_diff[3],
-                            ];
-
-                            let transformed_rect_size = transform.transform_vector2(rect_size);
-
-                            // Don't try to cull nodes that have a rotation
-                            // In a rotation around the Z-axis, this value is 0.0 for an angle of 0.0 or π
-                            // In those two cases, the culling check can proceed normally as corners will be on
-                            // horizontal / vertical lines
-                            // For all other angles, bypass the culling check
-                            // This does not properly handles all rotations on all axis
-                            if transform.x_axis[1] == 0.0 {
-                                // Cull nodes that are completely clipped
-                                if positions_diff[0].x - positions_diff[1].x
-                                    >= transformed_rect_size.x
-                                    || positions_diff[1].y - positions_diff[2].y
-                                        >= transformed_rect_size.y
-                                {
-                                    continue;
-                                }
+                            // cull nodes that are completely clipped
+                            let transformed_rect_size =
+                                extracted_uinode.transform.transform_vector2(rect_size);
+                            if positions_diff[0].x - positions_diff[1].x
+                                >= transformed_rect_size.x.abs()
+                                || positions_diff[1].y - positions_diff[2].y
+                                    >= transformed_rect_size.y.abs()
+                            {
+                                continue;
                             }
-                            let uvs = if flags == shader_flags::UNTEXTURED {
-                                [Vec2::ZERO, Vec2::X, Vec2::ONE, Vec2::Y]
-                            } else {
-                                let image = gpu_images.get(extracted_uinode.image).expect(
-                                    "Image was checked during batching and should still exist",
-                                );
-                                // Rescale atlases. This is done here because we need texture data that might not be available in Extract.
-                                let atlas_extent = atlas_scaling
-                                    .map(|scaling| image.size_2d().as_vec2() * scaling)
-                                    .unwrap_or(uinode_rect.max);
-                                if *flip_x {
-                                    core::mem::swap(&mut uinode_rect.max.x, &mut uinode_rect.min.x);
-                                    positions_diff[0].x *= -1.;
-                                    positions_diff[1].x *= -1.;
-                                    positions_diff[2].x *= -1.;
-                                    positions_diff[3].x *= -1.;
-                                }
-                                if *flip_y {
-                                    core::mem::swap(&mut uinode_rect.max.y, &mut uinode_rect.min.y);
-                                    positions_diff[0].y *= -1.;
-                                    positions_diff[1].y *= -1.;
-                                    positions_diff[2].y *= -1.;
-                                    positions_diff[3].y *= -1.;
-                                }
-                                [
-                                    Vec2::new(
-                                        uinode_rect.min.x + positions_diff[0].x,
-                                        uinode_rect.min.y + positions_diff[0].y,
-                                    ),
-                                    Vec2::new(
-                                        uinode_rect.max.x + positions_diff[1].x,
-                                        uinode_rect.min.y + positions_diff[1].y,
-                                    ),
-                                    Vec2::new(
-                                        uinode_rect.max.x + positions_diff[2].x,
-                                        uinode_rect.max.y + positions_diff[2].y,
-                                    ),
-                                    Vec2::new(
-                                        uinode_rect.min.x + positions_diff[3].x,
-                                        uinode_rect.max.y + positions_diff[3].y,
-                                    ),
-                                ]
-                                .map(|pos| pos / atlas_extent)
-                            };
 
-                            let color = color.to_f32_array();
-                            if let NodeType::Border(border_flags) = *node_type {
-                                flags |= border_flags;
-                            }
+                            let uvs = [
+                                Vec2::new(
+                                    glyph.rect.min.x + positions_diff[0].x,
+                                    glyph.rect.min.y + positions_diff[0].y,
+                                ),
+                                Vec2::new(
+                                    glyph.rect.max.x + positions_diff[1].x,
+                                    glyph.rect.min.y + positions_diff[1].y,
+                                ),
+                                Vec2::new(
+                                    glyph.rect.max.x + positions_diff[2].x,
+                                    glyph.rect.max.y + positions_diff[2].y,
+                                ),
+                                Vec2::new(
+                                    glyph.rect.min.x + positions_diff[3].x,
+                                    glyph.rect.max.y + positions_diff[3].y,
+                                ),
+                            ]
+                            .map(|pos| pos / atlas_extent);
 
                             for i in 0..4 {
                                 ui_meta.vertices.push(UiVertex {
                                     position: positions_clipped[i].into(),
                                     uv: uvs[i].into(),
                                     color,
-                                    flags: flags | shader_flags::CORNERS[i],
-                                    radius: (*border_radius).into(),
-                                    border: [border.left, border.top, border.right, border.bottom],
+                                    flags: shader_flags::TEXTURED | shader_flags::CORNERS[i],
+                                    radius: [0.0; 4],
+                                    border: [0.0; 4],
                                     size: rect_size.into(),
-                                    point: points[i].into(),
+                                    point: [0.0; 2],
                                 });
                             }
 
@@ -1554,116 +1658,10 @@ pub fn prepare_uinodes(
                             vertices_index += 6;
                             indices_index += 4;
                         }
-                        ExtractedUiItem::Glyphs { range } => {
-                            let image = gpu_images
-                                .get(extracted_uinode.image)
-                                .expect("Image was checked during batching and should still exist");
-
-                            let atlas_extent = image.size_2d().as_vec2();
-
-                            for glyph in &extracted_uinodes.glyphs[range.clone()] {
-                                let color = glyph.color.to_f32_array();
-                                let glyph_rect = glyph.rect;
-                                let rect_size = glyph_rect.size();
-
-                                // Specify the corners of the glyph
-                                let positions = QUAD_VERTEX_POSITIONS.map(|pos| {
-                                    extracted_uinode
-                                        .transform
-                                        .transform_point2(
-                                            glyph.translation + pos * glyph_rect.size(),
-                                        )
-                                        .extend(0.)
-                                });
-
-                                let positions_diff = if let Some(clip) = extracted_uinode.clip {
-                                    [
-                                        Vec2::new(
-                                            f32::max(clip.min.x - positions[0].x, 0.),
-                                            f32::max(clip.min.y - positions[0].y, 0.),
-                                        ),
-                                        Vec2::new(
-                                            f32::min(clip.max.x - positions[1].x, 0.),
-                                            f32::max(clip.min.y - positions[1].y, 0.),
-                                        ),
-                                        Vec2::new(
-                                            f32::min(clip.max.x - positions[2].x, 0.),
-                                            f32::min(clip.max.y - positions[2].y, 0.),
-                                        ),
-                                        Vec2::new(
-                                            f32::max(clip.min.x - positions[3].x, 0.),
-                                            f32::min(clip.max.y - positions[3].y, 0.),
-                                        ),
-                                    ]
-                                } else {
-                                    [Vec2::ZERO; 4]
-                                };
-
-                                let positions_clipped = [
-                                    positions[0] + positions_diff[0].extend(0.),
-                                    positions[1] + positions_diff[1].extend(0.),
-                                    positions[2] + positions_diff[2].extend(0.),
-                                    positions[3] + positions_diff[3].extend(0.),
-                                ];
-
-                                // cull nodes that are completely clipped
-                                let transformed_rect_size =
-                                    extracted_uinode.transform.transform_vector2(rect_size);
-                                if positions_diff[0].x - positions_diff[1].x
-                                    >= transformed_rect_size.x.abs()
-                                    || positions_diff[1].y - positions_diff[2].y
-                                        >= transformed_rect_size.y.abs()
-                                {
-                                    continue;
-                                }
-
-                                let uvs = [
-                                    Vec2::new(
-                                        glyph.rect.min.x + positions_diff[0].x,
-                                        glyph.rect.min.y + positions_diff[0].y,
-                                    ),
-                                    Vec2::new(
-                                        glyph.rect.max.x + positions_diff[1].x,
-                                        glyph.rect.min.y + positions_diff[1].y,
-                                    ),
-                                    Vec2::new(
-                                        glyph.rect.max.x + positions_diff[2].x,
-                                        glyph.rect.max.y + positions_diff[2].y,
-                                    ),
-                                    Vec2::new(
-                                        glyph.rect.min.x + positions_diff[3].x,
-                                        glyph.rect.max.y + positions_diff[3].y,
-                                    ),
-                                ]
-                                .map(|pos| pos / atlas_extent);
-
-                                for i in 0..4 {
-                                    ui_meta.vertices.push(UiVertex {
-                                        position: positions_clipped[i].into(),
-                                        uv: uvs[i].into(),
-                                        color,
-                                        flags: shader_flags::TEXTURED | shader_flags::CORNERS[i],
-                                        radius: [0.0; 4],
-                                        border: [0.0; 4],
-                                        size: rect_size.into(),
-                                        point: [0.0; 2],
-                                    });
-                                }
-
-                                for &i in &QUAD_INDICES {
-                                    ui_meta.indices.push(indices_index + i as u32);
-                                }
-
-                                vertices_index += 6;
-                                indices_index += 4;
-                            }
-                        }
                     }
-                    existing_batch.unwrap().1.range.end = vertices_index;
-                    ui_phase.items[batch_item_index].batch_range_mut().end += 1;
-                } else {
-                    batch_image_handle = AssetId::invalid();
                 }
+                existing_batch.unwrap().1.range.end = vertices_index;
+                ui_phase.items[batch_item_index].batch_range_mut().end += 1;
             }
         }
 

--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -132,6 +132,30 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         Text2dShadow::default(),
     ));
 
+    let make_child = move |(text_anchor, color): (Anchor, Color)| {
+        (
+            Text2d::new(" Anchor".to_string()),
+            slightly_smaller_text_font.clone(),
+            text_anchor,
+            TextBackgroundColor(Color::WHITE.darker(0.8)),
+            Transform::from_translation(-1. * Vec3::Z),
+            children![
+                (
+                    TextSpan("::".to_string()),
+                    slightly_smaller_text_font.clone(),
+                    TextColor(LIGHT_GREY.into()),
+                    TextBackgroundColor(DARK_BLUE.into()),
+                ),
+                (
+                    TextSpan(format!("{text_anchor:?} ")),
+                    slightly_smaller_text_font.clone(),
+                    TextColor(color),
+                    TextBackgroundColor(color.darker(0.3)),
+                )
+            ],
+        )
+    };
+
     commands.spawn((
         Sprite {
             color: Color::Srgba(LIGHT_CYAN),
@@ -139,38 +163,12 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             ..Default::default()
         },
         Transform::from_translation(250. * Vec3::Y),
-        Children::spawn(SpawnIter(
-            [
-                (Anchor::TOP_LEFT, Color::Srgba(LIGHT_SALMON)),
-                (Anchor::TOP_RIGHT, Color::Srgba(LIGHT_GREEN)),
-                (Anchor::BOTTOM_RIGHT, Color::Srgba(LIGHT_BLUE)),
-                (Anchor::BOTTOM_LEFT, Color::Srgba(LIGHT_YELLOW)),
-            ]
-            .into_iter()
-            .map(move |(text_anchor, color)| {
-                (
-                    Text2d::new(" Anchor".to_string()),
-                    slightly_smaller_text_font.clone(),
-                    text_anchor,
-                    TextBackgroundColor(Color::WHITE.darker(0.8)),
-                    Transform::from_translation(-1. * Vec3::Z),
-                    children![
-                        (
-                            TextSpan("::".to_string()),
-                            slightly_smaller_text_font.clone(),
-                            TextColor(LIGHT_GREY.into()),
-                            TextBackgroundColor(DARK_BLUE.into()),
-                        ),
-                        (
-                            TextSpan(format!("{text_anchor:?} ")),
-                            slightly_smaller_text_font.clone(),
-                            TextColor(color),
-                            TextBackgroundColor(color.darker(0.3)),
-                        )
-                    ],
-                )
-            }),
-        )),
+        children![
+            make_child((Anchor::TOP_LEFT, Color::Srgba(LIGHT_SALMON))),
+            make_child((Anchor::TOP_RIGHT, Color::Srgba(LIGHT_GREEN))),
+            make_child((Anchor::BOTTOM_RIGHT, Color::Srgba(LIGHT_BLUE))),
+            make_child((Anchor::BOTTOM_LEFT, Color::Srgba(LIGHT_YELLOW))),
+        ],
     ));
 }
 

--- a/examples/animation/animated_transform.rs
+++ b/examples/animation/animated_transform.rs
@@ -156,7 +156,7 @@ fn setup(
             id: planet_animation_target_id,
             player: planet_entity,
         },
-        Children::spawn_one((
+        children![(
             Transform::default(),
             Visibility::default(),
             orbit_controller,
@@ -164,7 +164,7 @@ fn setup(
                 id: orbit_controller_animation_target_id,
                 player: planet_entity,
             },
-            Children::spawn_one((
+            children![(
                 Mesh3d(meshes.add(Cuboid::new(0.5, 0.5, 0.5))),
                 MeshMaterial3d(materials.add(Color::srgb(0.3, 0.9, 0.3))),
                 Transform::from_xyz(1.5, 0.0, 0.0),
@@ -173,7 +173,7 @@ fn setup(
                     player: planet_entity,
                 },
                 satellite,
-            )),
-        )),
+            )],
+        )],
     ));
 }

--- a/examples/animation/animated_ui.rs
+++ b/examples/animation/animated_ui.rs
@@ -140,7 +140,7 @@ fn setup(
     ));
 
     let player = entity.id();
-    entity.insert(Children::spawn_one((
+    entity.insert(children![(
         Text::new("Bevy"),
         TextFont {
             font: asset_server.load("fonts/FiraSans-Bold.ttf"),
@@ -154,7 +154,7 @@ fn setup(
             player,
         },
         animation_target_name,
-    )));
+    )]);
 }
 
 // A type that represents the color of the first text section.

--- a/examples/animation/animation_masks.rs
+++ b/examples/animation/animation_masks.rs
@@ -266,14 +266,14 @@ fn new_mask_group_control(label: &str, width: Val, mask_group_id: u32) -> impl B
                     ..default()
                 },
                 BackgroundColor(Color::BLACK),
-                Children::spawn_one((
+                children![(
                     Text::new(label),
                     label_text_style.clone(),
                     Node {
                         margin: UiRect::vertical(px(3)),
                         ..default()
                     },
-                ))
+                )]
             ),
             (
                 Node {
@@ -319,7 +319,7 @@ fn new_mask_group_control(label: &str, width: Val, mask_group_id: u32) -> impl B
                                     group_id: mask_group_id,
                                     label,
                                 },
-                                Children::spawn_one((
+                                children![(
                                     Text(format!("{label:?}")),
                                     if index > 0 {
                                         button_text_style.clone()
@@ -332,7 +332,7 @@ fn new_mask_group_control(label: &str, width: Val, mask_group_id: u32) -> impl B
                                         margin: UiRect::vertical(px(3)),
                                         ..default()
                                     },
-                                )),
+                                )],
                             )
                         }
                     })

--- a/examples/animation/animation_masks.rs
+++ b/examples/animation/animation_masks.rs
@@ -240,6 +240,45 @@ fn new_mask_group_control(label: &str, width: Val, mask_group_id: u32) -> impl B
         TextColor(Color::Srgba(LIGHT_GRAY)),
     );
 
+    let make_animation_label = {
+        let button_text_style = button_text_style.clone();
+        let selected_button_text_style = selected_button_text_style.clone();
+        move |first: bool, label: AnimationLabel| {
+            (
+                Button,
+                BackgroundColor(if !first { Color::BLACK } else { Color::WHITE }),
+                Node {
+                    flex_grow: 1.0,
+                    border: if !first {
+                        UiRect::left(px(1))
+                    } else {
+                        UiRect::ZERO
+                    },
+                    ..default()
+                },
+                BorderColor::all(Color::WHITE),
+                AnimationControl {
+                    group_id: mask_group_id,
+                    label,
+                },
+                children![(
+                    Text(format!("{label:?}")),
+                    if !first {
+                        button_text_style.clone()
+                    } else {
+                        selected_button_text_style.clone()
+                    },
+                    TextLayout::new_with_justify(Justify::Center),
+                    Node {
+                        flex_grow: 1.0,
+                        margin: UiRect::vertical(px(3)),
+                        ..default()
+                    },
+                )],
+            )
+        }
+    };
+
     (
         Node {
             border: UiRect::all(px(1)),
@@ -285,58 +324,12 @@ fn new_mask_group_control(label: &str, width: Val, mask_group_id: u32) -> impl B
                     ..default()
                 },
                 BorderColor::all(Color::WHITE),
-                Children::spawn(SpawnIter(
-                    [
-                        AnimationLabel::Run,
-                        AnimationLabel::Walk,
-                        AnimationLabel::Idle,
-                        AnimationLabel::Off,
-                    ]
-                    .into_iter()
-                    .enumerate()
-                    .map({
-                        let button_text_style = button_text_style.clone();
-                        let selected_button_text_style = selected_button_text_style.clone();
-                        move |(index, label)| {
-                            (
-                                Button,
-                                BackgroundColor(if index > 0 {
-                                    Color::BLACK
-                                } else {
-                                    Color::WHITE
-                                }),
-                                Node {
-                                    flex_grow: 1.0,
-                                    border: if index > 0 {
-                                        UiRect::left(px(1))
-                                    } else {
-                                        UiRect::ZERO
-                                    },
-                                    ..default()
-                                },
-                                BorderColor::all(Color::WHITE),
-                                AnimationControl {
-                                    group_id: mask_group_id,
-                                    label,
-                                },
-                                children![(
-                                    Text(format!("{label:?}")),
-                                    if index > 0 {
-                                        button_text_style.clone()
-                                    } else {
-                                        selected_button_text_style.clone()
-                                    },
-                                    TextLayout::new_with_justify(Justify::Center),
-                                    Node {
-                                        flex_grow: 1.0,
-                                        margin: UiRect::vertical(px(3)),
-                                        ..default()
-                                    },
-                                )],
-                            )
-                        }
-                    })
-                ))
+                children![
+                    make_animation_label(true, AnimationLabel::Run),
+                    make_animation_label(false, AnimationLabel::Walk),
+                    make_animation_label(false, AnimationLabel::Idle),
+                    make_animation_label(false, AnimationLabel::Off),
+                ]
             )
         ],
     )


### PR DESCRIPTION
# Objective
works on #18238

## Solution

convert  calls to `.with_children` to use the `Children::spawn` or `Children::spawn_one` types or `children!` macro.
This touches the `window`, `2d`, `animation` folders, as well as `ecs/one_shot_systems.rs`.
`observer_propagation.rs` looks like exactly what `with_children` is useful for, so I deliberately haven't touched it.
I can break this up into more PRs or squash if desired.

## Testing

I've run the examples before and after this patch and verified visually that nothing has changed
