### PR TITLE
Fix plugin_group macro with multiple nested plugin groups

### DIFF
--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -561,16 +561,19 @@ mod tests {
     use super::PluginGroupBuilder;
     use crate::{App, NoopPluginGroup, Plugin, PluginGroup};
 
+    #[derive(Default)]
     struct PluginA;
     impl Plugin for PluginA {
         fn build(&self, _: &mut App) {}
     }
 
+    #[derive(Default)]
     struct PluginB;
     impl Plugin for PluginB {
         fn build(&self, _: &mut App) {}
     }
 
+    #[derive(Default)]
     struct PluginC;
     impl Plugin for PluginC {
         fn build(&self, _: &mut App) {}
@@ -877,15 +880,18 @@ mod tests {
     plugin_group! {
         #[derive(Default)]
         struct PluginGroupA {
+            :PluginA
         }
     }
     plugin_group! {
         #[derive(Default)]
         struct PluginGroupB {
+            :PluginB
         }
     }
     plugin_group! {
         struct PluginGroupC {
+            :PluginC
             #[plugin_group]
             :PluginGroupA,
             #[plugin_group]

--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -559,7 +559,7 @@ mod tests {
     use core::{any::TypeId, fmt::Debug};
 
     use super::PluginGroupBuilder;
-    use crate::{App, NoopPluginGroup, Plugin};
+    use crate::{App, NoopPluginGroup, Plugin, PluginGroup};
 
     struct PluginA;
     impl Plugin for PluginA {
@@ -872,5 +872,28 @@ mod tests {
                 TypeId::of::<PluginC>(),
             ]
         );
+    }
+
+    plugin_group! {
+        #[derive(Default)]
+        struct PluginGroupA {
+        }
+    }
+    plugin_group! {
+        #[derive(Default)]
+        struct PluginGroupB {
+        }
+    }
+    plugin_group! {
+        struct PluginGroupC {
+            #[plugin_group]
+            :PluginGroupA,
+            #[plugin_group]
+            :PluginGroupB,
+        }
+    }
+    #[test]
+    fn construct_nested_plugin_groups() {
+        PluginGroupC {}.build();
     }
 }

--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -143,7 +143,7 @@ macro_rules! plugin_group {
        $($(#[doc = concat!(
             " - [`", stringify!($plugin_group_name), "`](" $(, stringify!($plugin_group_path), "::")*, stringify!($plugin_group_name), ")"
             $(, " - with feature `", $plugin_group_feature, "`")?
-        )]),+)?
+        )])+)?
         $(
             ///
             $(#[doc = $post_doc])+


### PR DESCRIPTION
# Objective

- Putting multiple plugin groups inside a plugin group results in a compile error

## Solution

- remove spurious comma in doc gen

## Testing

- Found when trying to use multiple plugin groups in DefaultPlugins for #20778, fixed for that.