### PR TITLE
Rename scoped functions

### DIFF
--- a/release-content/migration-guides/rename_state_scoped.md
+++ b/release-content/migration-guides/rename_state_scoped.md
@@ -8,7 +8,7 @@ as a way to remove entities/events when **exiting** a state.
 
 However, it can also be useful to have the opposite behavior,
 where entities/events are removed when **entering** a state.
-This is now possible with the new `DespawnOnEnter` component and `clear_events_on_enter_state` method.
+This is now possible with the new `DespawnOnEnter` component and `clear_events_on_enter` method.
 
 To support this addition, the previous method and component have been renamed.
 Also, `clear_event_on_exit_state` no longer adds the event automatically, so you must call `App::add_event` manually.
@@ -17,4 +17,4 @@ Also, `clear_event_on_exit_state` no longer adds the event automatically, so you
 |-------------------------------|--------------------------------------------|
 | `StateScoped`                 | `DespawnOnExit`                       |
 | `clear_state_scoped_entities` | `despawn_entities_on_exit_state`           |
-| `add_state_scoped_event`      | `add_event` + `clear_events_on_exit_state` |
+| `add_state_scoped_event`      | `add_event` + `clear_events_on_exit` |


### PR DESCRIPTION
# Objective

- Followup to https://github.com/bevyengine/bevy/pull/20872#issuecomment-3256973683
- `clear_events_on_exit_state` is now inconsistent with `DespawnOnExit`

## Solution

- remove the suffix

## Testing

- CI
