### PR TITLE
Fix gizmos for real this time

### DIFF
--- a/crates/bevy_gizmos/src/lines.wgsl
+++ b/crates/bevy_gizmos/src/lines.wgsl
@@ -136,8 +136,9 @@ fn vertex(vertex: VertexInput) -> VertexOutput {
 }
 
 fn clip_near_plane(a: vec4<f32>, b: vec4<f32>) -> vec4<f32> {
-    // Move a if a is behind the near plane and b is in front. 
-    if a.z > a.w && b.z <= b.w {
+    // Move a if a is behind the near plane and b is in front.
+    // equivalent to `a.z / a.w > 1.0 && b.z / b.w <= 1.0` but avoids divs
+    if a.z * sign(a.w) > abs(a.w) && b.z * sign(b.w) <= abs(b.w) {
         // Interpolate a towards b until it's at the near plane.
         let distance_a = a.z - a.w;
         let distance_b = b.z - b.w;


### PR DESCRIPTION
# Objective

- Fixes #19205

## Solution

- so it turns out a wrong optimization got made at some point, where a division by w was avoided by multiplying both sides of an inequality by w. This is wrong, because w can be negative, which should flip the inequality.
- So instead, we document what it should be doing, which is computing the depth values and comparing to near plane, and then avoid the divison in a sign-aware way using sign and abs.

## Testing

- slightly tweaked repro by anthony in #20773
- 3d_gizmos works as expected