### PR TITLE
Put order parameter back in render_to_texture example's camera

### DIFF
--- a/examples/3d/render_to_texture.rs
+++ b/examples/3d/render_to_texture.rs
@@ -64,6 +64,8 @@ fn setup(
     commands.spawn((
         Camera3d::default(),
         Camera {
+            // render before the "main pass" camera
+            order: -1,
             target: image_handle.clone().into(),
             clear_color: Color::WHITE.into(),
             ..default()

--- a/examples/ui/render_ui_to_texture.rs
+++ b/examples/ui/render_ui_to_texture.rs
@@ -65,6 +65,8 @@ fn setup(
         .spawn((
             Camera2d,
             Camera {
+                // render before the "main pass" camera
+                order: -1,
                 target: RenderTarget::Image(image_handle.clone().into()),
                 ..default()
             },


### PR DESCRIPTION
# Objective

The "order" parameter for the render_to_texture example's camera went missing in https://github.com/bevyengine/bevy/commit/d46a05e387234116c12754fde5f8a7c07a057cf6 .
Without the order parameter, the RT texture lags a frame behind, which is rarely what developers want. This PR puts it back.

## Solution

The order parameter is added to the camera.

## Testing

Tested and works. The render_ui_to_texture camera feels less laggy now!
