### PR TITLE
Add `register_type` for `MaterialNode`

### DIFF
--- a/crates/bevy_ui_render/src/ui_material_pipeline.rs
+++ b/crates/bevy_ui_render/src/ui_material_pipeline.rs
@@ -49,11 +49,8 @@ where
         embedded_asset!(app, "ui_material.wgsl");
 
         app.init_asset::<M>()
-            //.register_type::<MaterialNode<M>>()
-            .add_plugins((
-                //ExtractComponentPlugin::<MaterialNode<M>>::extract_visible(),
-                RenderAssetPlugin::<PreparedUiMaterial<M>>::default(),
-            ));
+            .register_type::<MaterialNode<M>>()
+            .add_plugins(RenderAssetPlugin::<PreparedUiMaterial<M>>::default());
 
         if let Some(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app


### PR DESCRIPTION
# Objective

Add a `register_type` for `MaterialNode` to the `UiMaterialPlugin`. Removed this temporarily when moving everything to the `bevy_ui_render` crate and forgot to put it back.