### PR TITLE
Update the 3D examples to use `children!`

### DIFF
--- a/examples/3d/blend_modes.rs
+++ b/examples/3d/blend_modes.rs
@@ -190,26 +190,23 @@ fn setup(
     ));
 
     let mut label = |entity: Entity, label: &str| {
-        commands
-            .spawn((
+        commands.spawn((
+            Node {
+                position_type: PositionType::Absolute,
+                ..default()
+            },
+            ExampleLabel { entity },
+            children![(
+                Text::new(label),
+                label_text_style.clone(),
                 Node {
                     position_type: PositionType::Absolute,
+                    bottom: Val::ZERO,
                     ..default()
                 },
-                ExampleLabel { entity },
-            ))
-            .with_children(|parent| {
-                parent.spawn((
-                    Text::new(label),
-                    label_text_style.clone(),
-                    Node {
-                        position_type: PositionType::Absolute,
-                        bottom: Val::ZERO,
-                        ..default()
-                    },
-                    TextLayout::default().with_no_wrap(),
-                ));
-            });
+                TextLayout::default().with_no_wrap(),
+            )],
+        ));
     };
 
     label(opaque, "┌─ Opaque\n│\n│\n│\n│");

--- a/examples/3d/clustered_decals.rs
+++ b/examples/3d/clustered_decals.rs
@@ -257,43 +257,38 @@ fn spawn_buttons(commands: &mut Commands) {
 
     // Spawn the drag buttons that allow the user to control the scale and roll
     // of the selected object.
-    commands
-        .spawn(Node {
+    commands.spawn((
+        Node {
             flex_direction: FlexDirection::Row,
             position_type: PositionType::Absolute,
             right: px(10),
             bottom: px(10),
             column_gap: px(6),
             ..default()
-        })
-        .with_children(|parent| {
-            spawn_drag_button(parent, "Scale").insert(DragMode::Scale);
-            spawn_drag_button(parent, "Roll").insert(DragMode::Roll);
-        });
+        },
+        children![
+            (drag_button("Scale"), DragMode::Scale),
+            (drag_button("Roll"), DragMode::Roll),
+        ],
+    ));
 }
 
 /// Spawns a button that the user can drag to change a parameter.
-fn spawn_drag_button<'a>(
-    commands: &'a mut ChildSpawnerCommands,
-    label: &str,
-) -> EntityCommands<'a> {
-    let mut kid = commands.spawn(Node {
-        border: BUTTON_BORDER,
-        justify_content: JustifyContent::Center,
-        align_items: AlignItems::Center,
-        padding: BUTTON_PADDING,
-        ..default()
-    });
-    kid.insert((
+fn drag_button<'a>(label: &str) -> impl Bundle {
+    (
+        Node {
+            border: BUTTON_BORDER,
+            justify_content: JustifyContent::Center,
+            align_items: AlignItems::Center,
+            padding: BUTTON_PADDING,
+            ..default()
+        },
         Button,
         BackgroundColor(Color::BLACK),
         BorderRadius::all(BUTTON_BORDER_RADIUS_SIZE),
         BUTTON_BORDER_COLOR,
-    ))
-    .with_children(|parent| {
-        widgets::spawn_ui_text(parent, label, Color::WHITE);
-    });
-    kid
+        children![widgets::ui_text(label, Color::WHITE)],
+    )
 }
 
 /// Spawns the help text at the top of the screen.

--- a/examples/3d/clustered_decals.rs
+++ b/examples/3d/clustered_decals.rs
@@ -274,7 +274,7 @@ fn spawn_buttons(commands: &mut Commands) {
 }
 
 /// Spawns a button that the user can drag to change a parameter.
-fn drag_button<'a>(label: &str) -> impl Bundle {
+fn drag_button(label: &str) -> impl Bundle {
     (
         Node {
             border: BUTTON_BORDER,

--- a/examples/3d/clustered_decals.rs
+++ b/examples/3d/clustered_decals.rs
@@ -243,19 +243,17 @@ fn spawn_decals(commands: &mut Commands, asset_server: &AssetServer) {
 fn spawn_buttons(commands: &mut Commands) {
     // Spawn the radio buttons that allow the user to select an object to
     // control.
-    commands
-        .spawn(widgets::main_ui_node())
-        .with_children(|parent| {
-            widgets::spawn_option_buttons(
-                parent,
-                "Drag to Move",
-                &[
-                    (Selection::Camera, "Camera"),
-                    (Selection::DecalA, "Decal A"),
-                    (Selection::DecalB, "Decal B"),
-                ],
-            );
-        });
+    commands.spawn((
+        widgets::main_ui_node(),
+        children![widgets::option_buttons(
+            "Drag to Move",
+            &[
+                (Selection::Camera, "Camera"),
+                (Selection::DecalA, "Decal A"),
+                (Selection::DecalB, "Decal B"),
+            ],
+        )],
+    ));
 
     // Spawn the drag buttons that allow the user to control the scale and roll
     // of the selected object.

--- a/examples/3d/color_grading.rs
+++ b/examples/3d/color_grading.rs
@@ -6,7 +6,6 @@ use std::{
 };
 
 use bevy::{
-    ecs::system::EntityCommands,
     light::CascadeShadowConfigBuilder,
     prelude::*,
     render::view::{ColorGrading, ColorGradingGlobal, ColorGradingSection, Hdr},

--- a/examples/3d/color_grading.rs
+++ b/examples/3d/color_grading.rs
@@ -306,7 +306,7 @@ fn add_help_text(
 }
 
 /// Adds some text to the scene.
-fn text(label: &str, font: &Handle<Font>, color: Color) -> (Text, TextFont, TextColor) {
+fn text(label: &str, font: &Handle<Font>, color: Color) -> impl Bundle + use<> {
     (
         Text::new(label),
         TextFont {

--- a/examples/3d/color_grading.rs
+++ b/examples/3d/color_grading.rs
@@ -136,159 +136,152 @@ fn setup(
 
 /// Adds all the buttons on the bottom of the scene.
 fn add_buttons(commands: &mut Commands, font: &Handle<Font>, color_grading: &ColorGrading) {
-    // Spawn the parent node that contains all the buttons.
-    commands
-        .spawn(Node {
+    commands.spawn((
+        // Spawn the parent node that contains all the buttons.
+        Node {
             flex_direction: FlexDirection::Column,
             position_type: PositionType::Absolute,
             row_gap: px(6),
             left: px(12),
             bottom: px(12),
             ..default()
-        })
-        .with_children(|parent| {
+        },
+        children![
             // Create the first row, which contains the global controls.
-            add_buttons_for_global_controls(parent, color_grading, font);
-
+            buttons_for_global_controls(color_grading, font),
             // Create the rows for individual controls.
-            for section in [
-                SelectedColorGradingSection::Highlights,
-                SelectedColorGradingSection::Midtones,
-                SelectedColorGradingSection::Shadows,
-            ] {
-                add_buttons_for_section(parent, section, color_grading, font);
-            }
-        });
+            buttons_for_section(SelectedColorGradingSection::Highlights, color_grading, font),
+            buttons_for_section(SelectedColorGradingSection::Midtones, color_grading, font),
+            buttons_for_section(SelectedColorGradingSection::Shadows, color_grading, font),
+        ],
+    ));
 }
 
 /// Adds the buttons for the global controls (those that control the scene as a
 /// whole as opposed to shadows, midtones, or highlights).
-fn add_buttons_for_global_controls(
-    parent: &mut ChildSpawnerCommands,
-    color_grading: &ColorGrading,
-    font: &Handle<Font>,
-) {
-    // Add the parent node for the row.
-    parent.spawn(Node::default()).with_children(|parent| {
-        // Add some placeholder text to fill this column.
-        parent.spawn(Node {
-            width: px(125),
-            ..default()
-        });
+fn buttons_for_global_controls(color_grading: &ColorGrading, font: &Handle<Font>) -> impl Bundle {
+    let make_button = |option: SelectedGlobalColorGradingOption| {
+        button_for_value(
+            SelectedColorGradingOption::Global(option),
+            color_grading,
+            font,
+        )
+    };
 
-        // Add each global color grading option button.
-        for option in [
-            SelectedGlobalColorGradingOption::Exposure,
-            SelectedGlobalColorGradingOption::Temperature,
-            SelectedGlobalColorGradingOption::Tint,
-            SelectedGlobalColorGradingOption::Hue,
-        ] {
-            add_button_for_value(
-                parent,
-                SelectedColorGradingOption::Global(option),
-                color_grading,
-                font,
-            );
-        }
-    });
+    // Add the parent node for the row.
+    (
+        Node::default(),
+        children![
+            Node {
+                width: px(125),
+                ..default()
+            },
+            make_button(SelectedGlobalColorGradingOption::Exposure),
+            make_button(SelectedGlobalColorGradingOption::Temperature),
+            make_button(SelectedGlobalColorGradingOption::Tint),
+            make_button(SelectedGlobalColorGradingOption::Hue),
+        ],
+    )
 }
 
 /// Adds the buttons that control color grading for individual sections
 /// (highlights, midtones, shadows).
-fn add_buttons_for_section(
-    parent: &mut ChildSpawnerCommands,
+fn buttons_for_section(
     section: SelectedColorGradingSection,
     color_grading: &ColorGrading,
     font: &Handle<Font>,
-) {
+) -> impl Bundle {
+    let make_button = |option| {
+        button_for_value(
+            SelectedColorGradingOption::Section(section, option),
+            color_grading,
+            font,
+        )
+    };
+
     // Spawn the row container.
-    parent
-        .spawn(Node {
+    (
+        Node {
             align_items: AlignItems::Center,
             ..default()
-        })
-        .with_children(|parent| {
+        },
+        children![
             // Spawn the label ("Highlights", etc.)
-            add_text(parent, &section.to_string(), font, Color::WHITE).insert(Node {
-                width: px(125),
-                ..default()
-            });
-
+            (
+                text(&section.to_string(), font, Color::WHITE),
+                Node {
+                    width: px(125),
+                    ..default()
+                }
+            ),
             // Spawn the buttons.
-            for option in [
-                SelectedSectionColorGradingOption::Saturation,
-                SelectedSectionColorGradingOption::Contrast,
-                SelectedSectionColorGradingOption::Gamma,
-                SelectedSectionColorGradingOption::Gain,
-                SelectedSectionColorGradingOption::Lift,
-            ] {
-                add_button_for_value(
-                    parent,
-                    SelectedColorGradingOption::Section(section, option),
-                    color_grading,
-                    font,
-                );
-            }
-        });
+            make_button(SelectedSectionColorGradingOption::Saturation),
+            make_button(SelectedSectionColorGradingOption::Contrast),
+            make_button(SelectedSectionColorGradingOption::Gamma),
+            make_button(SelectedSectionColorGradingOption::Gain),
+            make_button(SelectedSectionColorGradingOption::Lift),
+        ],
+    )
 }
 
 /// Adds a button that controls one of the color grading values.
-fn add_button_for_value(
-    parent: &mut ChildSpawnerCommands,
+fn button_for_value(
     option: SelectedColorGradingOption,
     color_grading: &ColorGrading,
     font: &Handle<Font>,
-) {
+) -> impl Bundle {
+    let label = match option {
+        SelectedColorGradingOption::Global(option) => option.to_string(),
+        SelectedColorGradingOption::Section(_, option) => option.to_string(),
+    };
+
     // Add the button node.
-    parent
-        .spawn((
-            Button,
-            Node {
-                border: UiRect::all(px(1)),
-                width: px(200),
-                justify_content: JustifyContent::Center,
-                align_items: AlignItems::Center,
-                padding: UiRect::axes(px(12), px(6)),
-                margin: UiRect::right(px(12)),
-                ..default()
-            },
-            BorderColor::all(Color::WHITE),
-            BorderRadius::MAX,
-            BackgroundColor(Color::BLACK),
-        ))
-        .insert(ColorGradingOptionWidget {
+    (
+        Button,
+        Node {
+            border: UiRect::all(px(1)),
+            width: px(200),
+            justify_content: JustifyContent::Center,
+            align_items: AlignItems::Center,
+            padding: UiRect::axes(px(12), px(6)),
+            margin: UiRect::right(px(12)),
+            ..default()
+        },
+        BorderColor::all(Color::WHITE),
+        BorderRadius::MAX,
+        BackgroundColor(Color::BLACK),
+        ColorGradingOptionWidget {
             widget_type: ColorGradingOptionWidgetType::Button,
             option,
-        })
-        .with_children(|parent| {
+        },
+        children![
             // Add the button label.
-            let label = match option {
-                SelectedColorGradingOption::Global(option) => option.to_string(),
-                SelectedColorGradingOption::Section(_, option) => option.to_string(),
-            };
-            add_text(parent, &label, font, Color::WHITE).insert(ColorGradingOptionWidget {
-                widget_type: ColorGradingOptionWidgetType::Label,
-                option,
-            });
-
+            (
+                text(&label, font, Color::WHITE),
+                ColorGradingOptionWidget {
+                    widget_type: ColorGradingOptionWidgetType::Label,
+                    option,
+                },
+            ),
             // Add a spacer.
-            parent.spawn(Node {
+            Node {
                 flex_grow: 1.0,
                 ..default()
-            });
-
+            },
             // Add the value text.
-            add_text(
-                parent,
-                &format!("{:.3}", option.get(color_grading)),
-                font,
-                Color::WHITE,
-            )
-            .insert(ColorGradingOptionWidget {
-                widget_type: ColorGradingOptionWidgetType::Value,
-                option,
-            });
-        });
+            (
+                text(
+                    &format!("{:.3}", option.get(color_grading)),
+                    font,
+                    Color::WHITE,
+                ),
+                ColorGradingOptionWidget {
+                    widget_type: ColorGradingOptionWidgetType::Value,
+                    option,
+                },
+            ),
+        ],
+    )
 }
 
 /// Creates the help text at the top of the screen.
@@ -314,13 +307,8 @@ fn add_help_text(
 }
 
 /// Adds some text to the scene.
-fn add_text<'a>(
-    parent: &'a mut ChildSpawnerCommands,
-    label: &str,
-    font: &Handle<Font>,
-    color: Color,
-) -> EntityCommands<'a> {
-    parent.spawn((
+fn text(label: &str, font: &Handle<Font>, color: Color) -> (Text, TextFont, TextColor) {
+    (
         Text::new(label),
         TextFont {
             font: font.clone(),
@@ -328,7 +316,7 @@ fn add_text<'a>(
             ..default()
         },
         TextColor(color),
-    ))
+    )
 }
 
 fn add_camera(commands: &mut Commands, asset_server: &AssetServer, color_grading: ColorGrading) {

--- a/examples/3d/light_textures.rs
+++ b/examples/3d/light_textures.rs
@@ -283,19 +283,18 @@ fn spawn_light_textures(
 fn spawn_buttons(commands: &mut Commands) {
     // Spawn the radio buttons that allow the user to select an object to
     // control.
-    commands
-        .spawn((widgets::main_ui_node(),))
-        .with_children(|parent| {
-            widgets::option_buttons(
-                "Drag to Move",
-                &[
-                    (Selection::Camera, "Camera"),
-                    (Selection::SpotLight, "Spotlight"),
-                    (Selection::PointLight, "Point Light"),
-                    (Selection::DirectionalLight, "Directional Light"),
-                ],
-            );
-        });
+    commands.spawn((
+        widgets::main_ui_node(),
+        children![widgets::option_buttons(
+            "Drag to Move",
+            &[
+                (Selection::Camera, "Camera"),
+                (Selection::SpotLight, "Spotlight"),
+                (Selection::PointLight, "Point Light"),
+                (Selection::DirectionalLight, "Directional Light"),
+            ],
+        )],
+    ));
 
     // Spawn the drag buttons that allow the user to control the scale and roll
     // of the selected object.

--- a/examples/3d/light_textures.rs
+++ b/examples/3d/light_textures.rs
@@ -198,13 +198,11 @@ fn spawn_cubes(
 
 /// Spawns the directional light.
 fn spawn_light(commands: &mut Commands, asset_server: &AssetServer) {
-    commands
-        .spawn((
-            Visibility::Hidden,
-            Transform::from_xyz(8.0, 8.0, 4.0).looking_at(Vec3::ZERO, Vec3::Y),
-            Selection::DirectionalLight,
-        ))
-        .with_child((
+    commands.spawn((
+        Visibility::Hidden,
+        Transform::from_xyz(8.0, 8.0, 4.0).looking_at(Vec3::ZERO, Vec3::Y),
+        Selection::DirectionalLight,
+        children![(
             DirectionalLight {
                 illuminance: AMBIENT_DAYLIGHT,
                 ..default()
@@ -214,7 +212,8 @@ fn spawn_light(commands: &mut Commands, asset_server: &AssetServer) {
                 tiled: true,
             },
             Visibility::Visible,
-        ));
+        )],
+    ));
 }
 
 /// Spawns the camera.
@@ -249,26 +248,22 @@ fn spawn_light_textures(
         Selection::SpotLight,
     ));
 
-    commands
-        .spawn((
-            Visibility::Hidden,
-            Transform::from_translation(Vec3::new(0.0, 1.8, 0.01)).with_scale(Vec3::splat(0.1)),
-            Selection::PointLight,
-        ))
-        .with_children(|parent| {
-            parent.spawn(SceneRoot(
+    commands.spawn((
+        Visibility::Hidden,
+        Transform::from_translation(Vec3::new(0.0, 1.8, 0.01)).with_scale(Vec3::splat(0.1)),
+        Selection::PointLight,
+        children![
+            SceneRoot(
                 asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/Faces/faces.glb")),
-            ));
-
-            parent.spawn((
+            ),
+            (
                 Mesh3d(meshes.add(Sphere::new(1.0))),
                 MeshMaterial3d(materials.add(StandardMaterial {
                     emissive: Color::srgb(0.0, 0.0, 300.0).to_linear(),
                     ..default()
                 })),
-            ));
-
-            parent.spawn((
+            ),
+            (
                 PointLight {
                     color: Color::srgb(0.0, 0.0, 1.0),
                     intensity: 1e6,
@@ -279,8 +274,9 @@ fn spawn_light_textures(
                     image: asset_server.load("lightmaps/faces_pointlight_texture_blurred.png"),
                     cubemap_layout: CubemapLayout::CrossVertical,
                 },
-            ));
-        });
+            )
+        ],
+    ));
 }
 
 /// Spawns the buttons at the bottom of the screen.
@@ -288,10 +284,9 @@ fn spawn_buttons(commands: &mut Commands) {
     // Spawn the radio buttons that allow the user to select an object to
     // control.
     commands
-        .spawn(widgets::main_ui_node())
+        .spawn((widgets::main_ui_node(),))
         .with_children(|parent| {
-            widgets::spawn_option_buttons(
-                parent,
+            widgets::option_buttons(
                 "Drag to Move",
                 &[
                     (Selection::Camera, "Camera"),
@@ -304,51 +299,45 @@ fn spawn_buttons(commands: &mut Commands) {
 
     // Spawn the drag buttons that allow the user to control the scale and roll
     // of the selected object.
-    commands
-        .spawn(Node {
+    commands.spawn((
+        Node {
             flex_direction: FlexDirection::Row,
             position_type: PositionType::Absolute,
             right: px(10),
             bottom: px(10),
             column_gap: px(6),
             ..default()
-        })
-        .with_children(|parent| {
-            widgets::spawn_option_buttons(
-                parent,
+        },
+        children![
+            widgets::option_buttons(
                 "",
                 &[
                     (Visibility::Inherited, "Show"),
                     (Visibility::Hidden, "Hide"),
                 ],
-            );
-            spawn_drag_button(parent, "Scale").insert(DragMode::Scale);
-            spawn_drag_button(parent, "Roll").insert(DragMode::Roll);
-        });
+            ),
+            (drag_button("Scale"), DragMode::Scale),
+            (drag_button("Roll"), DragMode::Roll),
+        ],
+    ));
 }
 
 /// Spawns a button that the user can drag to change a parameter.
-fn spawn_drag_button<'a>(
-    commands: &'a mut ChildSpawnerCommands,
-    label: &str,
-) -> EntityCommands<'a> {
-    let mut kid = commands.spawn(Node {
-        border: BUTTON_BORDER,
-        justify_content: JustifyContent::Center,
-        align_items: AlignItems::Center,
-        padding: BUTTON_PADDING,
-        ..default()
-    });
-    kid.insert((
+fn drag_button<'a>(label: &str) -> impl Bundle {
+    (
+        Node {
+            border: BUTTON_BORDER,
+            justify_content: JustifyContent::Center,
+            align_items: AlignItems::Center,
+            padding: BUTTON_PADDING,
+            ..default()
+        },
         Button,
         BackgroundColor(Color::BLACK),
         BorderRadius::all(BUTTON_BORDER_RADIUS_SIZE),
         BUTTON_BORDER_COLOR,
-    ))
-    .with_children(|parent| {
-        widgets::spawn_ui_text(parent, label, Color::WHITE);
-    });
-    kid
+        children![widgets::ui_text(label, Color::WHITE),],
+    )
 }
 
 /// Spawns the help text at the top of the screen.

--- a/examples/3d/light_textures.rs
+++ b/examples/3d/light_textures.rs
@@ -322,7 +322,7 @@ fn spawn_buttons(commands: &mut Commands) {
 }
 
 /// Spawns a button that the user can drag to change a parameter.
-fn drag_button<'a>(label: &str) -> impl Bundle {
+fn drag_button(label: &str) -> impl Bundle {
     (
         Node {
             border: BUTTON_BORDER,

--- a/examples/3d/mixed_lighting.rs
+++ b/examples/3d/mixed_lighting.rs
@@ -183,20 +183,18 @@ fn spawn_scene(commands: &mut Commands, asset_server: &AssetServer) {
 
 /// Spawns the buttons that allow the user to change the lighting mode.
 fn spawn_buttons(commands: &mut Commands) {
-    commands
-        .spawn(widgets::main_ui_node())
-        .with_children(|parent| {
-            widgets::spawn_option_buttons(
-                parent,
-                "Lighting",
-                &[
-                    (LightingMode::Baked, "Baked"),
-                    (LightingMode::MixedDirect, "Mixed (Direct)"),
-                    (LightingMode::MixedIndirect, "Mixed (Indirect)"),
-                    (LightingMode::RealTime, "Real-Time"),
-                ],
-            );
-        });
+    commands.spawn((
+        widgets::main_ui_node(),
+        children![widgets::option_buttons(
+            "Lighting",
+            &[
+                (LightingMode::Baked, "Baked"),
+                (LightingMode::MixedDirect, "Mixed (Direct)"),
+                (LightingMode::MixedIndirect, "Mixed (Indirect)"),
+                (LightingMode::RealTime, "Real-Time"),
+            ],
+        )],
+    ));
 }
 
 /// Spawns the help text at the top of the window.

--- a/examples/3d/motion_blur.rs
+++ b/examples/3d/motion_blur.rs
@@ -136,6 +136,17 @@ fn spawn_cars(
         matl(Color::linear_rgb(1.0, 0.5, 0.0)),
     ];
 
+    let make_wheel = |x: f32, z: f32| {
+        (
+            Mesh3d(cylinder.clone()),
+            MeshMaterial3d(wheel_matl.clone()),
+            Transform::from_xyz(0.14 * x, -0.045, 0.15 * z)
+                .with_scale(Vec3::new(0.15, 0.04, 0.15))
+                .with_rotation(Quat::from_rotation_z(std::f32::consts::FRAC_PI_2)),
+            Rotates,
+        )
+    };
+
     for i in 0..N_CARS {
         let color = colors[i % colors.len()].clone();
         commands
@@ -144,29 +155,19 @@ fn spawn_cars(
                 MeshMaterial3d(color.clone()),
                 Transform::from_scale(Vec3::splat(0.5)),
                 Moves(i as f32 * 2.0),
+                children![
+                    (
+                        Mesh3d(box_mesh.clone()),
+                        MeshMaterial3d(color),
+                        Transform::from_xyz(0.0, 0.08, 0.03).with_scale(Vec3::new(1.0, 1.0, 0.5)),
+                    ),
+                    make_wheel(1.0, 1.0),
+                    make_wheel(1.0, -1.0),
+                    make_wheel(-1.0, 1.0),
+                    make_wheel(-1.0, -1.0)
+                ],
             ))
-            .insert_if(CameraTracked, || i == 0)
-            .with_children(|parent| {
-                parent.spawn((
-                    Mesh3d(box_mesh.clone()),
-                    MeshMaterial3d(color),
-                    Transform::from_xyz(0.0, 0.08, 0.03).with_scale(Vec3::new(1.0, 1.0, 0.5)),
-                ));
-                let mut spawn_wheel = |x: f32, z: f32| {
-                    parent.spawn((
-                        Mesh3d(cylinder.clone()),
-                        MeshMaterial3d(wheel_matl.clone()),
-                        Transform::from_xyz(0.14 * x, -0.045, 0.15 * z)
-                            .with_scale(Vec3::new(0.15, 0.04, 0.15))
-                            .with_rotation(Quat::from_rotation_z(std::f32::consts::FRAC_PI_2)),
-                        Rotates,
-                    ));
-                };
-                spawn_wheel(1.0, 1.0);
-                spawn_wheel(1.0, -1.0);
-                spawn_wheel(-1.0, 1.0);
-                spawn_wheel(-1.0, -1.0);
-            });
+            .insert_if(CameraTracked, || i == 0);
     }
 }
 
@@ -234,23 +235,22 @@ fn spawn_trees(
 }
 
 fn setup_ui(mut commands: Commands) {
-    commands
-        .spawn((
-            Text::default(),
-            Node {
-                position_type: PositionType::Absolute,
-                top: px(12),
-                left: px(12),
-                ..default()
-            },
-        ))
-        .with_children(|p| {
-            p.spawn(TextSpan::default());
-            p.spawn(TextSpan::default());
-            p.spawn(TextSpan::new("1/2: -/+ shutter angle (blur amount)\n"));
-            p.spawn(TextSpan::new("3/4: -/+ sample count (blur quality)\n"));
-            p.spawn(TextSpan::new("Spacebar: cycle camera\n"));
-        });
+    commands.spawn((
+        Text::default(),
+        Node {
+            position_type: PositionType::Absolute,
+            top: px(12),
+            left: px(12),
+            ..default()
+        },
+        children![
+            TextSpan::default(),
+            TextSpan::default(),
+            TextSpan::new("1/2: -/+ shutter angle (blur amount)\n"),
+            TextSpan::new("3/4: -/+ sample count (blur quality)\n"),
+            TextSpan::new("Spacebar: cycle camera\n"),
+        ],
+    ));
 }
 
 fn keyboard_inputs(

--- a/examples/3d/order_independent_transparency.rs
+++ b/examples/3d/order_independent_transparency.rs
@@ -46,22 +46,21 @@ fn setup(
     ));
 
     // spawn help text
-    commands
-        .spawn((
-            Text::default(),
-            Node {
-                position_type: PositionType::Absolute,
-                top: px(12),
-                left: px(12),
-                ..default()
-            },
-            RenderLayers::layer(1),
-        ))
-        .with_children(|p| {
-            p.spawn(TextSpan::new("Press T to toggle OIT\n"));
-            p.spawn(TextSpan::new("OIT Enabled"));
-            p.spawn(TextSpan::new("\nPress C to cycle test scenes"));
-        });
+    commands.spawn((
+        Text::default(),
+        Node {
+            position_type: PositionType::Absolute,
+            top: px(12),
+            left: px(12),
+            ..default()
+        },
+        RenderLayers::layer(1),
+        children![
+            TextSpan::new("Press T to toggle OIT\n"),
+            TextSpan::new("OIT Enabled"),
+            TextSpan::new("\nPress C to cycle test scenes"),
+        ],
+    ));
 
     // spawn default scene
     spawn_spheres(&mut commands, &mut meshes, &mut materials);

--- a/examples/3d/parallax_mapping.rs
+++ b/examples/3d/parallax_mapping.rs
@@ -220,11 +220,10 @@ fn setup(
         CameraController,
     ));
 
-    // light
-
     // represent the light source as a sphere
     let mesh = meshes.add(Sphere::new(0.05).mesh().ico(3).unwrap());
 
+    // light
     commands.spawn((
         PointLight {
             shadows_enabled: true,

--- a/examples/3d/parallax_mapping.rs
+++ b/examples/3d/parallax_mapping.rs
@@ -221,19 +221,18 @@ fn setup(
     ));
 
     // light
-    commands
-        .spawn((
-            PointLight {
-                shadows_enabled: true,
-                ..default()
-            },
-            Transform::from_xyz(2.0, 1.0, -1.1),
-        ))
-        .with_children(|commands| {
-            // represent the light source as a sphere
-            let mesh = meshes.add(Sphere::new(0.05).mesh().ico(3).unwrap());
-            commands.spawn((Mesh3d(mesh), MeshMaterial3d(materials.add(Color::WHITE))));
-        });
+
+    // represent the light source as a sphere
+    let mesh = meshes.add(Sphere::new(0.05).mesh().ico(3).unwrap());
+
+    commands.spawn((
+        PointLight {
+            shadows_enabled: true,
+            ..default()
+        },
+        Transform::from_xyz(2.0, 1.0, -1.1),
+        children![(Mesh3d(mesh), MeshMaterial3d(materials.add(Color::WHITE)))],
+    ));
 
     // Plane
     commands.spawn((
@@ -297,29 +296,24 @@ fn setup(
     commands.spawn(background_cube_bundle(Vec3::new(0., 0., -45.)));
 
     // example instructions
-    commands
-        .spawn((
-            Text::default(),
-            Node {
-                position_type: PositionType::Absolute,
-                top: px(12),
-                left: px(12),
-                ..default()
-            },
-        ))
-        .with_children(|p| {
-            p.spawn(TextSpan(format!(
-                "Parallax depth scale: {parallax_depth_scale:.5}\n"
-            )));
-            p.spawn(TextSpan(format!("Layers: {max_parallax_layer_count:.0}\n")));
-            p.spawn(TextSpan(format!("{parallax_mapping_method}\n")));
-            p.spawn(TextSpan::new("\n\n"));
-            p.spawn(TextSpan::new("Controls:\n"));
-            p.spawn(TextSpan::new("Left click - Change view angle\n"));
-            p.spawn(TextSpan::new(
-                "1/2 - Decrease/Increase parallax depth scale\n",
-            ));
-            p.spawn(TextSpan::new("3/4 - Decrease/Increase layer count\n"));
-            p.spawn(TextSpan::new("Space - Switch parallaxing algorithm\n"));
-        });
+    commands.spawn((
+        Text::default(),
+        Node {
+            position_type: PositionType::Absolute,
+            top: px(12),
+            left: px(12),
+            ..default()
+        },
+        children![
+            (TextSpan(format!("Parallax depth scale: {parallax_depth_scale:.5}\n"))),
+            (TextSpan(format!("Layers: {max_parallax_layer_count:.0}\n"))),
+            (TextSpan(format!("{parallax_mapping_method}\n"))),
+            (TextSpan::new("\n\n")),
+            (TextSpan::new("Controls:\n")),
+            (TextSpan::new("Left click - Change view angle\n")),
+            (TextSpan::new("1/2 - Decrease/Increase parallax depth scale\n",)),
+            (TextSpan::new("3/4 - Decrease/Increase layer count\n")),
+            (TextSpan::new("Space - Switch parallaxing algorithm\n")),
+        ],
+    ));
 }

--- a/examples/3d/parenting.rs
+++ b/examples/3d/parenting.rs
@@ -35,21 +35,18 @@ fn setup(
     });
 
     // parent cube
-    commands
-        .spawn((
-            Mesh3d(cube_handle.clone()),
-            MeshMaterial3d(cube_material_handle.clone()),
-            Transform::from_xyz(0.0, 0.0, 1.0),
-            Rotator,
-        ))
-        .with_children(|parent| {
+    commands.spawn((
+        Mesh3d(cube_handle.clone()),
+        MeshMaterial3d(cube_material_handle.clone()),
+        Transform::from_xyz(0.0, 0.0, 1.0),
+        Rotator,
+        children![(
             // child cube
-            parent.spawn((
-                Mesh3d(cube_handle),
-                MeshMaterial3d(cube_material_handle),
-                Transform::from_xyz(0.0, 0.0, 3.0),
-            ));
-        });
+            Mesh3d(cube_handle),
+            MeshMaterial3d(cube_material_handle),
+            Transform::from_xyz(0.0, 0.0, 3.0),
+        )],
+    ));
     // light
     commands.spawn((PointLight::default(), Transform::from_xyz(4.0, 5.0, -4.0)));
     // camera

--- a/examples/3d/pcss.rs
+++ b/examples/3d/pcss.rs
@@ -208,20 +208,18 @@ fn spawn_gltf_scene(commands: &mut Commands, asset_server: &AssetServer) {
 
 /// Spawns all the buttons at the bottom of the screen.
 fn spawn_buttons(commands: &mut Commands) {
-    commands
-        .spawn(widgets::main_ui_node())
-        .with_children(|parent| {
-            widgets::spawn_option_buttons(
-                parent,
+    commands.spawn((
+        widgets::main_ui_node(),
+        children![
+            widgets::option_buttons(
                 "Light Type",
                 &[
                     (AppSetting::LightType(LightType::Directional), "Directional"),
                     (AppSetting::LightType(LightType::Point), "Point"),
                     (AppSetting::LightType(LightType::Spot), "Spot"),
                 ],
-            );
-            widgets::spawn_option_buttons(
-                parent,
+            ),
+            widgets::option_buttons(
                 "Shadow Filter",
                 &[
                     (AppSetting::ShadowFilter(ShadowFilter::Temporal), "Temporal"),
@@ -230,16 +228,16 @@ fn spawn_buttons(commands: &mut Commands) {
                         "Non-Temporal",
                     ),
                 ],
-            );
-            widgets::spawn_option_buttons(
-                parent,
+            ),
+            widgets::option_buttons(
                 "Soft Shadows",
                 &[
                     (AppSetting::SoftShadows(true), "On"),
                     (AppSetting::SoftShadows(false), "Off"),
                 ],
-            );
-        });
+            ),
+        ],
+    ));
 }
 
 /// Updates the style of the radio buttons that enable and disable soft shadows

--- a/examples/3d/shadow_biases.rs
+++ b/examples/3d/shadow_biases.rs
@@ -45,21 +45,24 @@ fn setup(
     let sphere_handle = meshes.add(Sphere::new(sphere_radius));
 
     let light_transform = Transform::from_xyz(5.0, 5.0, 0.0).looking_at(Vec3::ZERO, Vec3::Y);
-    commands
-        .spawn((light_transform, Visibility::default(), Lights))
-        .with_children(|builder| {
-            builder.spawn(PointLight {
+    commands.spawn((
+        light_transform,
+        Visibility::default(),
+        Lights,
+        children![
+            (PointLight {
                 intensity: 0.0,
                 range: spawn_plane_depth,
                 color: Color::WHITE,
                 shadows_enabled: true,
                 ..default()
-            });
-            builder.spawn(DirectionalLight {
+            }),
+            (DirectionalLight {
                 shadows_enabled: true,
                 ..default()
-            });
-        });
+            })
+        ],
+    ));
 
     // camera
     commands.spawn((
@@ -92,53 +95,47 @@ fn setup(
         MeshMaterial3d(white_handle),
     ));
 
-    commands
-        .spawn((
-            Node {
-                position_type: PositionType::Absolute,
-                padding: UiRect::all(px(5)),
-                ..default()
-            },
-            BackgroundColor(Color::BLACK.with_alpha(0.75)),
-            GlobalZIndex(i32::MAX),
-        ))
-        .with_children(|p| {
-            p.spawn(Text::default()).with_children(|p| {
-                p.spawn(TextSpan::new("Controls:\n"));
-                p.spawn(TextSpan::new("R / Z - reset biases to default / zero\n"));
-                p.spawn(TextSpan::new(
-                    "L     - switch between directional and point lights [",
-                ));
-                p.spawn(TextSpan::new("DirectionalLight"));
-                p.spawn(TextSpan::new("]\n"));
-                p.spawn(TextSpan::new(
-                    "F     - switch directional light filter methods [",
-                ));
-                p.spawn(TextSpan::new("Hardware2x2"));
-                p.spawn(TextSpan::new("]\n"));
-                p.spawn(TextSpan::new("1/2   - change point light depth bias ["));
-                p.spawn(TextSpan::new("0.00"));
-                p.spawn(TextSpan::new("]\n"));
-                p.spawn(TextSpan::new("3/4   - change point light normal bias ["));
-                p.spawn(TextSpan::new("0.0"));
-                p.spawn(TextSpan::new("]\n"));
-                p.spawn(TextSpan::new("5/6   - change direction light depth bias ["));
-                p.spawn(TextSpan::new("0.00"));
-                p.spawn(TextSpan::new("]\n"));
-                p.spawn(TextSpan::new(
-                    "7/8   - change direction light normal bias [",
-                ));
-                p.spawn(TextSpan::new("0.0"));
-                p.spawn(TextSpan::new("]\n"));
-                p.spawn(TextSpan::new(
+    commands.spawn((
+        Node {
+            position_type: PositionType::Absolute,
+            padding: UiRect::all(px(5)),
+            ..default()
+        },
+        BackgroundColor(Color::BLACK.with_alpha(0.75)),
+        GlobalZIndex(i32::MAX),
+        children![(
+            Text::default(),
+            children![
+                (TextSpan::new("Controls:\n")),
+                (TextSpan::new("R / Z - reset biases to default / zero\n")),
+                (TextSpan::new("L     - switch between directional and point lights [",)),
+                (TextSpan::new("DirectionalLight")),
+                (TextSpan::new("]\n")),
+                (TextSpan::new("F     - switch directional light filter methods [",)),
+                (TextSpan::new("Hardware2x2")),
+                (TextSpan::new("]\n")),
+                (TextSpan::new("1/2   - change point light depth bias [")),
+                (TextSpan::new("0.00")),
+                (TextSpan::new("]\n")),
+                (TextSpan::new("3/4   - change point light normal bias [")),
+                (TextSpan::new("0.0")),
+                (TextSpan::new("]\n")),
+                (TextSpan::new("5/6   - change direction light depth bias [")),
+                (TextSpan::new("0.00")),
+                (TextSpan::new("]\n")),
+                (TextSpan::new("7/8   - change direction light normal bias [",)),
+                (TextSpan::new("0.0")),
+                (TextSpan::new("]\n")),
+                (TextSpan::new(
                     "left/right/up/down/pgup/pgdown - adjust light position (looking at 0,0,0) [",
-                ));
-                p.spawn(TextSpan(format!("{:.1},", light_transform.translation.x)));
-                p.spawn(TextSpan(format!(" {:.1},", light_transform.translation.y)));
-                p.spawn(TextSpan(format!(" {:.1}", light_transform.translation.z)));
-                p.spawn(TextSpan::new("]\n"));
-            });
-        });
+                )),
+                (TextSpan(format!("{:.1},", light_transform.translation.x))),
+                (TextSpan(format!(" {:.1},", light_transform.translation.y))),
+                (TextSpan(format!(" {:.1}", light_transform.translation.z))),
+                (TextSpan::new("]\n")),
+            ]
+        )],
+    ));
 }
 
 fn toggle_light(

--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -82,17 +82,15 @@ fn setup(
             .id();
 
         // Set up UI
-        commands
-            .spawn((
-                UiTargetCamera(camera),
-                Node {
-                    width: percent(100),
-                    height: percent(100),
-                    ..default()
-                },
-            ))
-            .with_children(|parent| {
-                parent.spawn((
+        commands.spawn((
+            UiTargetCamera(camera),
+            Node {
+                width: percent(100),
+                height: percent(100),
+                ..default()
+            },
+            children![
+                (
                     Text::new(*camera_name),
                     Node {
                         position_type: PositionType::Absolute,
@@ -100,14 +98,15 @@ fn setup(
                         left: px(12),
                         ..default()
                     },
-                ));
-                buttons_panel(parent);
-            });
+                ),
+                buttons_panel(),
+            ],
+        ));
     }
 
-    fn buttons_panel(parent: &mut ChildSpawnerCommands) {
-        parent
-            .spawn(Node {
+    fn buttons_panel() -> impl Bundle {
+        (
+            Node {
                 position_type: PositionType::Absolute,
                 width: percent(100),
                 height: percent(100),
@@ -117,32 +116,30 @@ fn setup(
                 align_items: AlignItems::Center,
                 padding: UiRect::all(px(20)),
                 ..default()
-            })
-            .with_children(|parent| {
-                rotate_button(parent, "<", Direction::Left);
-                rotate_button(parent, ">", Direction::Right);
-            });
+            },
+            children![
+                rotate_button("<", Direction::Left),
+                rotate_button(">", Direction::Right),
+            ],
+        )
     }
 
-    fn rotate_button(parent: &mut ChildSpawnerCommands, caption: &str, direction: Direction) {
-        parent
-            .spawn((
-                RotateCamera(direction),
-                Button,
-                Node {
-                    width: px(40),
-                    height: px(40),
-                    border: UiRect::all(px(2)),
-                    justify_content: JustifyContent::Center,
-                    align_items: AlignItems::Center,
-                    ..default()
-                },
-                BorderColor::all(Color::WHITE),
-                BackgroundColor(Color::srgb(0.25, 0.25, 0.25)),
-            ))
-            .with_children(|parent| {
-                parent.spawn(Text::new(caption));
-            });
+    fn rotate_button(caption: &str, direction: Direction) -> impl Bundle {
+        (
+            RotateCamera(direction),
+            Button,
+            Node {
+                width: px(40),
+                height: px(40),
+                border: UiRect::all(px(2)),
+                justify_content: JustifyContent::Center,
+                align_items: AlignItems::Center,
+                ..default()
+            },
+            BorderColor::all(Color::WHITE),
+            BackgroundColor(Color::srgb(0.25, 0.25, 0.25)),
+            children![Text::new(caption)],
+        )
     }
 }
 

--- a/examples/3d/spotlight.rs
+++ b/examples/3d/spotlight.rs
@@ -89,31 +89,30 @@ fn setup(
             let x = x as f32 - 2.0;
             let z = z as f32 - 2.0;
             // red spot_light
-            commands
-                .spawn((
-                    SpotLight {
-                        intensity: 40_000.0, // lumens
-                        color: Color::WHITE,
-                        shadows_enabled: true,
-                        inner_angle: PI / 4.0 * 0.85,
-                        outer_angle: PI / 4.0,
-                        ..default()
-                    },
-                    Transform::from_xyz(1.0 + x, 2.0, z)
-                        .looking_at(Vec3::new(1.0 + x, 0.0, z), Vec3::X),
-                ))
-                .with_children(|builder| {
-                    builder.spawn((
+            commands.spawn((
+                SpotLight {
+                    intensity: 40_000.0, // lumens
+                    color: Color::WHITE,
+                    shadows_enabled: true,
+                    inner_angle: PI / 4.0 * 0.85,
+                    outer_angle: PI / 4.0,
+                    ..default()
+                },
+                Transform::from_xyz(1.0 + x, 2.0, z)
+                    .looking_at(Vec3::new(1.0 + x, 0.0, z), Vec3::X),
+                children![
+                    (
                         Mesh3d(sphere_mesh.clone()),
                         MeshMaterial3d(red_emissive.clone()),
-                    ));
-                    builder.spawn((
+                    ),
+                    (
                         Mesh3d(sphere_mesh_direction.clone()),
                         MeshMaterial3d(maroon_emissive.clone()),
                         Transform::from_translation(Vec3::Z * -0.1),
                         NotShadowCaster,
-                    ));
-                });
+                    )
+                ],
+            ));
         }
     }
 

--- a/examples/helpers/widgets.rs
+++ b/examples/helpers/widgets.rs
@@ -2,7 +2,7 @@
 //!
 //! Unlike other examples, which demonstrate an application, this demonstrates a plugin library.
 
-use bevy::{ecs::system::EntityCommands, prelude::*};
+use bevy::prelude::*;
 
 /// An event that's sent whenever the user changes one of the settings by
 /// clicking a radio button.
@@ -150,20 +150,8 @@ where
     )
 }
 
-/// Spawns text for the UI.
-///
-/// Returns the `EntityCommands`, which allow further customization of the text
-/// style.
-pub fn spawn_ui_text<'a>(
-    parent: &'a mut ChildSpawnerCommands,
-    label: &str,
-    color: Color,
-) -> EntityCommands<'a> {
-    parent.spawn(ui_text(label, color))
-}
-
 /// Creates a text bundle for the UI.
-pub fn ui_text<'a>(label: &str, color: Color) -> (Text, TextFont, TextColor) {
+pub fn ui_text(label: &str, color: Color) -> (Text, TextFont, TextColor) {
     (
         Text::new(label),
         TextFont {

--- a/examples/helpers/widgets.rs
+++ b/examples/helpers/widgets.rs
@@ -151,7 +151,7 @@ where
 }
 
 /// Creates a text bundle for the UI.
-pub fn ui_text(label: &str, color: Color) -> (Text, TextFont, TextColor) {
+pub fn ui_text(label: &str, color: Color) -> impl Bundle + use<> {
     (
         Text::new(label),
         TextFont {

--- a/examples/helpers/widgets.rs
+++ b/examples/helpers/widgets.rs
@@ -59,14 +59,14 @@ pub fn main_ui_node() -> Node {
 ///
 /// The type parameter specifies the value that will be packaged up and sent in
 /// a [`WidgetClickEvent`] when the radio button is clicked.
-pub fn spawn_option_button<T>(
-    parent: &mut ChildSpawnerCommands,
+pub fn option_button<T>(
     option_value: T,
     option_name: &str,
     is_selected: bool,
     is_first: bool,
     is_last: bool,
-) where
+) -> impl Bundle
+where
     T: Clone + Send + Sync + 'static,
 {
     let (bg_color, fg_color) = if is_selected {
@@ -76,37 +76,36 @@ pub fn spawn_option_button<T>(
     };
 
     // Add the button node.
-    parent
-        .spawn((
-            Button,
-            Node {
-                border: BUTTON_BORDER.with_left(if is_first { px(1) } else { px(0) }),
-                justify_content: JustifyContent::Center,
-                align_items: AlignItems::Center,
-                padding: BUTTON_PADDING,
-                ..default()
-            },
-            BUTTON_BORDER_COLOR,
-            BorderRadius::ZERO
-                .with_left(if is_first {
-                    BUTTON_BORDER_RADIUS_SIZE
-                } else {
-                    px(0)
-                })
-                .with_right(if is_last {
-                    BUTTON_BORDER_RADIUS_SIZE
-                } else {
-                    px(0)
-                }),
-            BackgroundColor(bg_color),
-        ))
-        .insert(RadioButton)
-        .insert(WidgetClickSender(option_value.clone()))
-        .with_children(|parent| {
-            spawn_ui_text(parent, option_name, fg_color)
-                .insert(RadioButtonText)
-                .insert(WidgetClickSender(option_value));
-        });
+    (
+        Button,
+        Node {
+            border: BUTTON_BORDER.with_left(if is_first { px(1) } else { px(0) }),
+            justify_content: JustifyContent::Center,
+            align_items: AlignItems::Center,
+            padding: BUTTON_PADDING,
+            ..default()
+        },
+        BUTTON_BORDER_COLOR,
+        BorderRadius::ZERO
+            .with_left(if is_first {
+                BUTTON_BORDER_RADIUS_SIZE
+            } else {
+                px(0)
+            })
+            .with_right(if is_last {
+                BUTTON_BORDER_RADIUS_SIZE
+            } else {
+                px(0)
+            }),
+        BackgroundColor(bg_color),
+        RadioButton,
+        WidgetClickSender(option_value.clone()),
+        children![(
+            ui_text(option_name, fg_color),
+            RadioButtonText,
+            WidgetClickSender(option_value),
+        )],
+    )
 }
 
 /// Spawns the buttons that allow configuration of a setting.
@@ -114,36 +113,41 @@ pub fn spawn_option_button<T>(
 /// The user may change the setting to any one of the labeled `options`. The
 /// value of the given type parameter will be packaged up and sent as a
 /// [`WidgetClickEvent`] when one of the radio buttons is clicked.
-pub fn spawn_option_buttons<T>(
-    parent: &mut ChildSpawnerCommands,
-    title: &str,
-    options: &[(T, &str)],
-) where
+pub fn option_buttons<T>(title: &str, options: &[(T, &str)]) -> impl Bundle
+where
     T: Clone + Send + Sync + 'static,
 {
+    let buttons = options
+        .iter()
+        .cloned()
+        .enumerate()
+        .map(|(option_index, (option_value, option_name))| {
+            option_button(
+                option_value,
+                option_name,
+                option_index == 0,
+                option_index == 0,
+                option_index == options.len() - 1,
+            )
+        })
+        .collect::<Vec<_>>();
     // Add the parent node for the row.
-    parent
-        .spawn(Node {
+    (
+        Node {
             align_items: AlignItems::Center,
             ..default()
-        })
-        .with_children(|parent| {
-            spawn_ui_text(parent, title, Color::BLACK).insert(Node {
-                width: px(125),
-                ..default()
-            });
-
-            for (option_index, (option_value, option_name)) in options.iter().cloned().enumerate() {
-                spawn_option_button(
-                    parent,
-                    option_value,
-                    option_name,
-                    option_index == 0,
-                    option_index == 0,
-                    option_index == options.len() - 1,
-                );
-            }
-        });
+        },
+        Children::spawn((
+            Spawn((
+                ui_text(title, Color::BLACK),
+                Node {
+                    width: px(125),
+                    ..default()
+                },
+            )),
+            SpawnIter(buttons.into_iter()),
+        )),
+    )
 }
 
 /// Spawns text for the UI.
@@ -155,14 +159,19 @@ pub fn spawn_ui_text<'a>(
     label: &str,
     color: Color,
 ) -> EntityCommands<'a> {
-    parent.spawn((
+    parent.spawn(ui_text(label, color))
+}
+
+/// Creates a text bundle for the UI.
+pub fn ui_text<'a>(label: &str, color: Color) -> (Text, TextFont, TextColor) {
+    (
         Text::new(label),
         TextFont {
             font_size: 18.0,
             ..default()
         },
         TextColor(color),
-    ))
+    )
 }
 
 /// Checks for clicks on the radio buttons and sends `RadioButtonChangeEvent`s


### PR DESCRIPTION
# Objective
works on #18238

## Solution

convert  calls to `.with_children` to use the `Children::spawn` or `Children::spawn_one` types or `children!` macro.
This touches the `3d` folder.
I can break this up into more PRs or squash if desired.

## Testing

I've run the examples before and after this patch and verified visually that nothing has changed.

I have noticed some strange inconsistencies in the the mixed_lighting example where switching from real-time to mixed(indirect) will break shadows (including switching between any except real-time after) that is unaffected by my changes. I haven't investigated this yet.
