### PR TITLE
Hide `super` from more doc-links

### DIFF
--- a/crates/bevy_asset/src/event.rs
+++ b/crates/bevy_asset/src/event.rs
@@ -54,7 +54,7 @@ pub enum AssetEvent<A: Asset> {
     Modified { id: AssetId<A> },
     /// Emitted whenever an [`Asset`] is removed.
     Removed { id: AssetId<A> },
-    /// Emitted when the last [`super::Handle::Strong`] of an [`Asset`] is dropped.
+    /// Emitted when the last [`Handle::Strong`](`super::Handle::Strong`) of an [`Asset`] is dropped.
     Unused { id: AssetId<A> },
     /// Emitted whenever an [`Asset`] has been fully loaded (including its dependencies and all "recursive dependencies").
     LoadedWithDependencies { id: AssetId<A> },

--- a/crates/bevy_camera/src/projection.rs
+++ b/crates/bevy_camera/src/projection.rs
@@ -81,7 +81,7 @@ pub trait CameraProjection {
 mod sealed {
     use super::CameraProjection;
 
-    /// A wrapper trait to make it possible to implement Clone for boxed [`super::CameraProjection`]
+    /// A wrapper trait to make it possible to implement Clone for boxed [`CameraProjection`][`super::CameraProjection`]
     /// trait objects, without breaking object safety rules by making it `Sized`. Additional bounds
     /// are included for downcasting, and fulfilling the trait bounds on `Projection`.
     pub trait DynCameraProjection:

--- a/crates/bevy_camera/src/visibility/range.rs
+++ b/crates/bevy_camera/src/visibility/range.rs
@@ -173,7 +173,7 @@ impl VisibilityRange {
 /// Stores which entities are in within the [`VisibilityRange`]s of views.
 ///
 /// This doesn't store the results of frustum or occlusion culling; use
-/// [`super::ViewVisibility`] for that. Thus entities in this list may not
+/// [`ViewVisibility`](`super::ViewVisibility`) for that. Thus entities in this list may not
 /// actually be visible.
 ///
 /// For efficiency, these tables only store entities that have

--- a/crates/bevy_ecs/src/reflect/bundle.rs
+++ b/crates/bevy_ecs/src/reflect/bundle.rs
@@ -3,7 +3,7 @@
 //!
 //! This module exports two types: [`ReflectBundleFns`] and [`ReflectBundle`].
 //!
-//! Same as [`super::component`], but for bundles.
+//! Same as [`component`](`super::component`), but for bundles.
 use alloc::boxed::Box;
 use bevy_utils::prelude::DebugName;
 use core::any::{Any, TypeId};
@@ -30,7 +30,7 @@ pub struct ReflectBundle(ReflectBundleFns);
 
 /// The raw function pointers needed to make up a [`ReflectBundle`].
 ///
-/// The also [`super::component::ReflectComponentFns`].
+/// The also [`ReflectComponentFns`](`super::component::ReflectComponentFns`).
 #[derive(Clone)]
 pub struct ReflectBundleFns {
     /// Function pointer implementing [`ReflectBundle::insert`].

--- a/crates/bevy_ecs/src/reflect/from_world.rs
+++ b/crates/bevy_ecs/src/reflect/from_world.rs
@@ -4,7 +4,7 @@
 //!
 //! This module exports two types: [`ReflectFromWorldFns`] and [`ReflectFromWorld`].
 //!
-//! Same as [`super::component`], but for [`FromWorld`].
+//! Same as [`component`](`super::component`), but for [`FromWorld`].
 
 use alloc::boxed::Box;
 use bevy_reflect::{FromType, Reflect};

--- a/crates/bevy_math/src/aspect_ratio.rs
+++ b/crates/bevy_math/src/aspect_ratio.rs
@@ -88,7 +88,7 @@ impl TryFrom<Vec2> for AspectRatio {
     }
 }
 
-/// An Error type for when [`super::AspectRatio`] is provided invalid width or height values
+/// An Error type for when [`AspectRatio`](`super::AspectRatio`) is provided invalid width or height values
 #[derive(Error, Debug, PartialEq, Eq, Clone, Copy)]
 pub enum AspectRatioError {
     /// Error due to width or height having zero as a value.


### PR DESCRIPTION
# Objective

Hide `super` from more doc-links