### PR TITLE
beta ci fix

### DIFF
--- a/crates/bevy_ecs/src/relationship/mod.rs
+++ b/crates/bevy_ecs/src/relationship/mod.rs
@@ -541,9 +541,12 @@ mod tests {
 
     #[test]
     fn relationship_with_multiple_non_target_fields_compiles() {
+        #[expect(
+            dead_code,
+            reason = "This struct is used as a compilation test to test the derive macros, and as such is intentionally never constructed."
+        )]
         #[derive(Component)]
         #[relationship(relationship_target=Target)]
-        #[expect(dead_code, reason = "test struct")]
         struct Source {
             #[relationship]
             target: Entity,
@@ -551,6 +554,10 @@ mod tests {
             bar: u8,
         }
 
+        #[expect(
+            dead_code,
+            reason = "This struct is used as a compilation test to test the derive macros, and as such is intentionally never constructed."
+        )]
         #[derive(Component)]
         #[relationship_target(relationship=Source)]
         struct Target(Vec<Entity>);
@@ -559,13 +566,20 @@ mod tests {
     }
     #[test]
     fn relationship_target_with_multiple_non_target_fields_compiles() {
+        #[expect(
+            dead_code,
+            reason = "This struct is used as a compilation test to test the derive macros, and as such is intentionally never constructed."
+        )]
         #[derive(Component)]
         #[relationship(relationship_target=Target)]
         struct Source(Entity);
 
+        #[expect(
+            dead_code,
+            reason = "This struct is used as a compilation test to test the derive macros, and as such is intentionally never constructed."
+        )]
         #[derive(Component)]
         #[relationship_target(relationship=Source)]
-        #[expect(dead_code, reason = "test struct")]
         struct Target {
             #[relationship]
             target: Vec<Entity>,
@@ -578,10 +592,18 @@ mod tests {
 
     #[test]
     fn relationship_with_multiple_unnamed_non_target_fields_compiles() {
+        #[expect(
+            dead_code,
+            reason = "This struct is used as a compilation test to test the derive macros, and as such is intentionally never constructed."
+        )]
         #[derive(Component)]
         #[relationship(relationship_target=Target<T>)]
         struct Source<T: Send + Sync + 'static>(#[relationship] Entity, PhantomData<T>);
 
+        #[expect(
+            dead_code,
+            reason = "This struct is used as a compilation test to test the derive macros, and as such is intentionally never constructed."
+        )]
         #[derive(Component)]
         #[relationship_target(relationship=Source<T>)]
         struct Target<T: Send + Sync + 'static>(#[relationship] Vec<Entity>, PhantomData<T>);

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -1067,6 +1067,10 @@ mod tests {
         expected = "the dynamic type `bevy_reflect::DynamicStruct` does not support hashing"
     )]
     fn reflect_map_no_hash_dynamic() {
+        #[expect(
+            dead_code,
+            reason = "This struct is used as a compilation test to test the derive macros, and as such is intentionally never constructed."
+        )]
         #[derive(Reflect, Hash)]
         #[reflect(Hash)]
         struct Foo {
@@ -1124,12 +1128,24 @@ mod tests {
             }
         }
 
+        #[expect(
+            dead_code,
+            reason = "This struct is used as a compilation test to test the derive macros, and as such is intentionally never constructed."
+        )]
         #[derive(Reflect)]
         struct Foo<A>(A);
 
+        #[expect(
+            dead_code,
+            reason = "This struct is used as a compilation test to test the derive macros, and as such is intentionally never constructed."
+        )]
         #[derive(Reflect)]
         struct Bar<A, B>(A, B);
 
+        #[expect(
+            dead_code,
+            reason = "This struct is used as a compilation test to test the derive macros, and as such is intentionally never constructed."
+        )]
         #[derive(Reflect)]
         struct Baz<A, B, C>(A, B, C);
     }
@@ -2749,6 +2765,10 @@ bevy_reflect::tests::Test {
         #[reflect(where U: core::ops::Add<T>)]
         struct Foo<T, U>(T, U);
 
+        #[expect(
+            dead_code,
+            reason = "This struct is used as a compilation test to test the derive macros, and as such is intentionally never constructed."
+        )]
         #[derive(Reflect)]
         struct Baz {
             a: Foo<i32, i32>,
@@ -3182,6 +3202,10 @@ bevy_reflect::tests::Test {
             pub mod external_crate {
                 use alloc::string::String;
 
+                #[expect(
+                    dead_code,
+                    reason = "This struct is used as a compilation test to test the derive macros, and as such is intentionally never constructed."
+                )]
                 pub struct TheirType {
                     pub value: String,
                 }
@@ -3193,6 +3217,10 @@ bevy_reflect::tests::Test {
             }
         }
 
+        #[expect(
+            dead_code,
+            reason = "This struct is used as a compilation test to test the derive macros, and as such is intentionally never constructed."
+        )]
         #[derive(Reflect)]
         struct ContainerStruct {
             #[reflect(remote = wrapper::MyType)]

--- a/examples/reflection/auto_register_static/src/lib.rs
+++ b/examples/reflection/auto_register_static/src/lib.rs
@@ -14,6 +14,10 @@ mod private {
         use bevy::prelude::*;
 
         // Works with private types too!
+        #[expect(
+            dead_code,
+            reason = "This private struct demonstrates the use of a derive macro only, and as such is intentionally never constructed."
+        )]
         #[derive(Reflect)]
         struct PrivateStruct {
             a: i32,

--- a/examples/reflection/reflection_types.rs
+++ b/examples/reflection/reflection_types.rs
@@ -140,4 +140,8 @@ fn setup() {
     let mut value: A = value.take::<A>().unwrap();
     value.y.apply(&dynamic_list);
     assert_eq!(value.y, vec![3u32, 4u32, 5u32]);
+
+    // reference types defined above that are only used to demonstrate reflect
+    // derive functionality:
+    _ = || -> (A, B, C, D, E, F) { unreachable!() };
 }


### PR DESCRIPTION
# Objective
fixes #20748

## Solution
add `dead_code` to a bunch of test and example structs.

## Testing

`cargo run -p ci` works on beta (but not nightly)
There's a handful of `unfulfilled_lint_expectations` on these `dead_code`s that I'm not sure how to suppress in some compilation runs but not in others.