### PR TITLE
Lint against the use of unwrap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ unwrap_or_default = "warn"
 needless_lifetimes = "allow"
 too_many_arguments = "allow"
 nonstandard_macro_braces = "warn"
+unwrap_used = "warn"
 
 ptr_as_ptr = "warn"
 ptr_cast_constness = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ too_many_arguments = "allow"
 nonstandard_macro_braces = "warn"
 print_stdout = "warn"
 print_stderr = "warn"
+unwrap_used = "warn"
 
 ptr_as_ptr = "warn"
 ptr_cast_constness = "warn"

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -49,6 +49,8 @@ unwrap_or_default = "warn"
 needless_lifetimes = "allow"
 too_many_arguments = "allow"
 nonstandard_macro_braces = "warn"
+# explicitly allow uwnraps in benchmarks
+unwrap_used = "allow"
 
 ptr_as_ptr = "warn"
 ptr_cast_constness = "warn"

--- a/clippy.toml
+++ b/clippy.toml
@@ -13,6 +13,8 @@ doc-valid-idents = [
 
 check-private-items = true
 
+allow-unwrap-in-tests = true
+
 disallowed-methods = [
   { path = "f32::powi", reason = "use bevy_math::ops::FloatPow::squared, bevy_math::ops::FloatPow::cubed, or bevy_math::ops::powf instead for libm determinism" },
   { path = "f32::log", reason = "use bevy_math::ops::ln, bevy_math::ops::log2, or bevy_math::ops::log10 instead for libm determinism" },

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -4,6 +4,11 @@
     html_logo_url = "https://bevy.org/assets/icon.png",
     html_favicon_url = "https://bevy.org/assets/icon.png"
 )]
+// FIXME: Address the unwraps used in this crate. See https://github.com/bevyengine/bevy/issues/12660.
+#![expect(
+    clippy::unwrap_used,
+    reason = "Temporary hold until all unwraps in this crate can be addressed."
+)]
 
 //! Animation for the game engine Bevy
 

--- a/crates/bevy_anti_alias/src/fxaa/node.rs
+++ b/crates/bevy_anti_alias/src/fxaa/node.rs
@@ -1,4 +1,4 @@
-use std::sync::Mutex;
+use std::sync::{Mutex, PoisonError};
 
 use crate::fxaa::{CameraFxaaPipeline, Fxaa, FxaaPipeline};
 use bevy_ecs::{prelude::*, query::QueryItem};
@@ -48,7 +48,10 @@ impl ViewNode for FxaaNode {
         let post_process = target.post_process_write();
         let source = post_process.source;
         let destination = post_process.destination;
-        let mut cached_bind_group = self.cached_texture_bind_group.lock().unwrap();
+        let mut cached_bind_group = self
+            .cached_texture_bind_group
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
         let bind_group = match &mut *cached_bind_group {
             Some((id, bind_group)) if source.id() == *id => bind_group,
             cached_bind_group => {

--- a/crates/bevy_anti_alias/src/lib.rs
+++ b/crates/bevy_anti_alias/src/lib.rs
@@ -4,11 +4,6 @@
     html_logo_url = "https://bevy.org/assets/icon.png",
     html_favicon_url = "https://bevy.org/assets/icon.png"
 )]
-// FIXME: Address the unwraps used in this crate. See https://github.com/bevyengine/bevy/issues/12660.
-#![expect(
-    clippy::unwrap_used,
-    reason = "Temporary hold until all unwraps in this crate can be addressed."
-)]
 
 use bevy_app::Plugin;
 use contrast_adaptive_sharpening::CasPlugin;

--- a/crates/bevy_anti_alias/src/lib.rs
+++ b/crates/bevy_anti_alias/src/lib.rs
@@ -4,6 +4,11 @@
     html_logo_url = "https://bevy.org/assets/icon.png",
     html_favicon_url = "https://bevy.org/assets/icon.png"
 )]
+// FIXME: Address the unwraps used in this crate. See https://github.com/bevyengine/bevy/issues/12660.
+#![expect(
+    clippy::unwrap_used,
+    reason = "Temporary hold until all unwraps in this crate can be addressed."
+)]
 
 use bevy_app::Plugin;
 use contrast_adaptive_sharpening::CasPlugin;

--- a/crates/bevy_app/src/hotpatch.rs
+++ b/crates/bevy_app/src/hotpatch.rs
@@ -23,7 +23,7 @@ pub struct HotPatchPlugin;
 
 impl Plugin for HotPatchPlugin {
     fn build(&self, app: &mut crate::App) {
-        let (sender, receiver) = crossbeam_channel::bounded::<HotPatched>(1);
+        let (sender, receiver) = crossbeam_channel::unbounded::<HotPatched>();
 
         // Connects to the dioxus CLI that will handle rebuilds
         // This will open a connection to the dioxus CLI to receive updated jump tables
@@ -31,7 +31,7 @@ impl Plugin for HotPatchPlugin {
         #[cfg(not(target_family = "wasm"))]
         connect_subsecond();
         subsecond::register_handler(Arc::new(move || {
-            sender.send(HotPatched).unwrap();
+            sender.send(HotPatched);
         }));
 
         // Adds a system that will read the channel for new `HotPatched` messages, send the event, and update change detection.

--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -368,7 +368,9 @@ impl PluginGroupBuilder {
         for plugin_id in order {
             self.upsert_plugin_entry_state(
                 plugin_id,
-                plugins.remove(&plugin_id).unwrap(),
+                plugins
+                    .remove(&plugin_id)
+                    .expect("order contains plugins that don't exist"),
                 self.order.len(),
             );
 

--- a/crates/bevy_app/src/sub_app.rs
+++ b/crates/bevy_app/src/sub_app.rs
@@ -282,12 +282,13 @@ impl SubApp {
     ) -> &mut Self {
         let label = label.intern();
         let mut schedules = self.world.resource_mut::<Schedules>();
-        if !schedules.contains(label) {
-            schedules.insert(Schedule::new(label));
+        if let Some(schedule) = schedules.get_mut(label) {
+            f(schedule);
+        } else {
+            let mut schedule = Schedule::new(label);
+            f(&mut schedule);
+            schedules.insert(schedule);
         }
-
-        let schedule = schedules.get_mut(label).unwrap();
-        f(schedule);
 
         self
     }

--- a/crates/bevy_app/src/sub_app.rs
+++ b/crates/bevy_app/src/sub_app.rs
@@ -457,6 +457,10 @@ impl SubApp {
 
     /// See [`App::register_function`].
     #[cfg(feature = "reflect_functions")]
+    #[expect(
+        clippy::unwrap_used,
+        reason = "no way to return a function, and the Debug feature here is useful"
+    )]
     pub fn register_function<F, Marker>(&mut self, function: F) -> &mut Self
     where
         F: bevy_reflect::func::IntoFunction<'static, Marker> + 'static,
@@ -468,6 +472,10 @@ impl SubApp {
 
     /// See [`App::register_function_with_name`].
     #[cfg(feature = "reflect_functions")]
+    #[expect(
+        clippy::unwrap_used,
+        reason = "no way to return a function, and the Debug feature here is useful"
+    )]
     pub fn register_function_with_name<F, Marker>(
         &mut self,
         name: impl Into<alloc::borrow::Cow<'static, str>>,

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -1,3 +1,9 @@
+// FIXME: Address the unwraps used in this crate. See https://github.com/bevyengine/bevy/issues/12660.
+#![expect(
+    clippy::unwrap_used,
+    reason = "Temporary hold until all unwraps in this crate can be addressed."
+)]
+
 //! In the context of game development, an "asset" is a piece of content that is loaded from disk and displayed in the game.
 //! Typically, these are authored by artists and designers (in contrast to code),
 //! are relatively large in size, and include everything from textures and models to sounds and music to levels and scripts.

--- a/crates/bevy_audio/src/lib.rs
+++ b/crates/bevy_audio/src/lib.rs
@@ -4,6 +4,11 @@
     html_logo_url = "https://bevy.org/assets/icon.png",
     html_favicon_url = "https://bevy.org/assets/icon.png"
 )]
+// FIXME: Address the unwraps used in this crate. See https://github.com/bevyengine/bevy/issues/12660.
+#![expect(
+    clippy::unwrap_used,
+    reason = "Temporary hold until all unwraps in this crate can be addressed."
+)]
 
 //! Audio support for the game engine Bevy
 //!

--- a/crates/bevy_camera/src/lib.rs
+++ b/crates/bevy_camera/src/lib.rs
@@ -1,4 +1,10 @@
 #![expect(missing_docs, reason = "Not all docs are written yet, see #3492.")]
+// FIXME: Address the unwraps used in this crate. See https://github.com/bevyengine/bevy/issues/12660.
+#![expect(
+    clippy::unwrap_used,
+    reason = "Temporary hold until all unwraps in this crate can be addressed."
+)]
+
 mod camera;
 mod clear_color;
 mod components;

--- a/crates/bevy_core_pipeline/src/lib.rs
+++ b/crates/bevy_core_pipeline/src/lib.rs
@@ -5,6 +5,11 @@
     html_logo_url = "https://bevy.org/assets/icon.png",
     html_favicon_url = "https://bevy.org/assets/icon.png"
 )]
+// FIXME: Address the unwraps used in this crate. See https://github.com/bevyengine/bevy/issues/12660.
+#![expect(
+    clippy::unwrap_used,
+    reason = "Temporary hold until all unwraps in this crate can be addressed."
+)]
 
 pub mod blit;
 pub mod core_2d;

--- a/crates/bevy_core_widgets/src/lib.rs
+++ b/crates/bevy_core_widgets/src/lib.rs
@@ -1,3 +1,9 @@
+// FIXME: Address the unwraps used in this crate. See https://github.com/bevyengine/bevy/issues/12660.
+#![expect(
+    clippy::unwrap_used,
+    reason = "Temporary hold until all unwraps in this crate can be addressed."
+)]
+
 //! This crate provides a set of core widgets for Bevy UI, such as buttons, checkboxes, and sliders.
 //! These widgets have no inherent styling, it's the responsibility of the user to add styling
 //! appropriate for their game or application.

--- a/crates/bevy_dev_tools/src/frame_time_graph/mod.rs
+++ b/crates/bevy_dev_tools/src/frame_time_graph/mod.rs
@@ -108,8 +108,8 @@ fn update_frame_time_values(
         .map(|x| *x as f32 / 1000.0)
         .collect::<Vec<_>>();
     for (_, material) in frame_time_graph_materials.iter_mut() {
-        let buffer = buffers.get_mut(&material.values).unwrap();
-
-        buffer.set_data(frame_times.clone());
+        if let Some(buffer) = buffers.get_mut(&material.values) {
+            buffer.set_data(frame_times.clone());
+        }
     }
 }

--- a/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
@@ -182,7 +182,7 @@ mod internal {
         receiver: SyncCell<Receiver<SysinfoRefreshData>>,
         waker: Arc<AtomicWaker>,
     }
-  
+
     struct DiagnosticTask {
         system: System,
         last_refresh: Instant,

--- a/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
@@ -74,9 +74,7 @@ mod internal {
         pin::Pin,
         task::{Context, Poll},
     };
-    use std::sync::{
-        mpsc::{self, Receiver, Sender},
-    };
+    use std::sync::mpsc::{self, Receiver, Sender};
 
     use alloc::{
         format,
@@ -86,7 +84,7 @@ mod internal {
     use bevy_app::{App, First, Startup, Update};
     use bevy_ecs::resource::Resource;
     use bevy_ecs::{prelude::ResMut, system::Commands};
-    use bevy_platform::{cell::SyncCell, time::Instant, sync::Arc};
+    use bevy_platform::{cell::SyncCell, sync::Arc, time::Instant};
     use bevy_tasks::{AsyncComputeTaskPool, Task};
     use log::info;
     use sysinfo::{CpuRefreshKind, MemoryRefreshKind, RefreshKind, System};
@@ -216,7 +214,7 @@ mod internal {
 
                 let sysinfo_refresh_data = SysinfoRefreshData::new(&mut self.system);
                 if self.sender.send(sysinfo_refresh_data).is_err() {
-                    // The reciever has been dropped. Kill the tas
+                    // The receiver has been dropped. Kill the task.
                     return Poll::Ready(());
                 }
             }

--- a/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
@@ -76,7 +76,6 @@ mod internal {
     };
     use std::sync::{
         mpsc::{self, Receiver, Sender},
-        Arc,
     };
 
     use alloc::{
@@ -87,7 +86,7 @@ mod internal {
     use bevy_app::{App, First, Startup, Update};
     use bevy_ecs::resource::Resource;
     use bevy_ecs::{prelude::ResMut, system::Commands};
-    use bevy_platform::{cell::SyncCell, time::Instant};
+    use bevy_platform::{cell::SyncCell, time::Instant, sync::Arc};
     use bevy_tasks::{AsyncComputeTaskPool, Task};
     use log::info;
     use sysinfo::{CpuRefreshKind, MemoryRefreshKind, RefreshKind, System};
@@ -216,7 +215,10 @@ mod internal {
                 self.last_refresh = Instant::now();
 
                 let sysinfo_refresh_data = SysinfoRefreshData::new(&mut self.system);
-                self.sender.send(sysinfo_refresh_data).unwrap();
+                if self.sender.send(sysinfo_refresh_data).is_err() {
+                    // The reciever has been dropped. Kill the tas
+                    return Poll::Ready(());
+                }
             }
 
             // Always reschedules

--- a/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
@@ -82,7 +82,7 @@ pub mod internal {
     use bevy_platform::time::Instant;
     use bevy_tasks::{available_parallelism, block_on, poll_once, AsyncComputeTaskPool, Task};
     use log::info;
-    use std::sync::Mutex;
+    use std::sync::{Mutex, PoisonError};
     use sysinfo::{CpuRefreshKind, MemoryRefreshKind, RefreshKind, System};
 
     use crate::{Diagnostic, Diagnostics, DiagnosticsStore};
@@ -154,7 +154,7 @@ pub mod internal {
         {
             let sys = Arc::clone(sysinfo);
             let task = thread_pool.spawn(async move {
-                let mut sys = sys.lock().unwrap();
+                let mut sys = sys.lock().unwrap_or_else(PoisonError::into_inner);
                 let pid = sysinfo::get_current_pid().expect("Failed to get current process ID");
                 sys.refresh_processes(sysinfo::ProcessesToUpdate::Some(&[pid]), true);
 

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -917,6 +917,7 @@ fn derive_relationship_target(
     }))
 }
 
+#[expect(clippy::unwrap_used, reason = "The invariant is already being checked")]
 /// Returns the field with the `#[relationship]` attribute, the only field if unnamed,
 /// or the only field in a [`Fields::Named`] with one field, otherwise `Err`.
 fn relationship_field<'a>(

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -17,6 +17,11 @@
     html_favicon_url = "https://bevy.org/assets/icon.png"
 )]
 #![no_std]
+// FIXME: Address the unwraps used in this crate. See https://github.com/bevyengine/bevy/issues/12660.
+#![expect(
+    clippy::unwrap_used,
+    reason = "Temporary hold until all unwraps in this crate can be addressed."
+)]
 
 #[cfg(feature = "std")]
 extern crate std;

--- a/crates/bevy_feathers/src/alpha_pattern.rs
+++ b/crates/bevy_feathers/src/alpha_pattern.rs
@@ -30,7 +30,7 @@ impl FromWorld for AlphaPatternResource {
     fn from_world(world: &mut bevy_ecs::world::World) -> Self {
         let mut ui_materials = world
             .get_resource_mut::<Assets<AlphaPatternMaterial>>()
-            .unwrap();
+            .expect("AlphaPatternMaterial assets missing!");
         Self(ui_materials.add(AlphaPatternMaterial::default()))
     }
 }

--- a/crates/bevy_feathers/src/controls/checkbox.rs
+++ b/crates/bevy_feathers/src/controls/checkbox.rs
@@ -156,8 +156,12 @@ fn update_checkbox_styles(
         else {
             continue;
         };
-        let (outline_bg, outline_border) = q_outline.get_mut(outline_ent).unwrap();
-        let mark_color = q_mark.get_mut(mark_ent).unwrap();
+        let Ok((outline_bg, outline_border)) = q_outline.get_mut(outline_ent) else {
+            continue;
+        };
+        let Ok(mark_color) = q_mark.get_mut(mark_ent) else {
+            continue;
+        };
         set_checkbox_styles(
             checkbox_ent,
             outline_ent,
@@ -211,8 +215,12 @@ fn update_checkbox_styles_remove(
                 else {
                     return;
                 };
-                let (outline_bg, outline_border) = q_outline.get_mut(outline_ent).unwrap();
-                let mark_color = q_mark.get_mut(mark_ent).unwrap();
+                let Ok((outline_bg, outline_border)) = q_outline.get_mut(outline_ent) else {
+                    return;
+                };
+                let Ok(mark_color) = q_mark.get_mut(mark_ent) else {
+                    return;
+                };
                 set_checkbox_styles(
                     checkbox_ent,
                     outline_ent,

--- a/crates/bevy_feathers/src/controls/radio.rs
+++ b/crates/bevy_feathers/src/controls/radio.rs
@@ -133,8 +133,12 @@ fn update_radio_styles(
         else {
             continue;
         };
-        let outline_border = q_outline.get_mut(outline_ent).unwrap();
-        let mark_color = q_mark.get_mut(mark_ent).unwrap();
+        let Ok(outline_border) = q_outline.get_mut(outline_ent) else {
+            continue;
+        };
+        let Ok(mark_color) = q_mark.get_mut(mark_ent) else {
+            continue;
+        };
         set_radio_styles(
             radio_ent,
             outline_ent,
@@ -185,8 +189,12 @@ fn update_radio_styles_remove(
                 else {
                     return;
                 };
-                let outline_border = q_outline.get_mut(outline_ent).unwrap();
-                let mark_color = q_mark.get_mut(mark_ent).unwrap();
+                let Ok(outline_border) = q_outline.get_mut(outline_ent) else {
+                    return;
+                };
+                let Ok(mark_color) = q_mark.get_mut(mark_ent) else {
+                    return;
+                };
                 set_radio_styles(
                     radio_ent,
                     outline_ent,

--- a/crates/bevy_feathers/src/controls/toggle_switch.rs
+++ b/crates/bevy_feathers/src/controls/toggle_switch.rs
@@ -113,7 +113,9 @@ fn update_switch_styles(
             continue;
         };
         // Safety: since we just checked the query, should always work.
-        let (ref mut slide_style, slide_color) = q_slide.get_mut(slide_ent).unwrap();
+        let Ok((ref mut slide_style, slide_color)) = q_slide.get_mut(slide_ent) else {
+            continue;
+        };
         set_switch_styles(
             switch_ent,
             slide_ent,
@@ -161,7 +163,9 @@ fn update_switch_styles_remove(
                     return;
                 };
                 // Safety: since we just checked the query, should always work.
-                let (ref mut slide_style, slide_color) = q_slide.get_mut(slide_ent).unwrap();
+                let Ok((ref mut slide_style, slide_color)) = q_slide.get_mut(slide_ent) else {
+                    return;
+                };
                 set_switch_styles(
                     switch_ent,
                     slide_ent,

--- a/crates/bevy_gilrs/src/rumble.rs
+++ b/crates/bevy_gilrs/src/rumble.rs
@@ -86,11 +86,13 @@ fn handle_rumble_request(
     rumble: GamepadRumbleRequest,
     current_time: Duration,
 ) -> Result<(), RumbleError> {
-    let gamepad = rumble.gamepad();
+    let gamepad_id = gamepads
+        .get_gamepad_id(rumble.gamepad())
+        .ok_or(RumbleError::GamepadNotFound)?;
 
     let (gamepad_id, _) = gilrs
         .gamepads()
-        .find(|(pad_id, _)| *pad_id == gamepads.get_gamepad_id(gamepad).unwrap())
+        .find(|(pad_id, _)| *pad_id == gamepad_id)
         .ok_or(RumbleError::GamepadNotFound)?;
 
     match rumble {

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -3,6 +3,11 @@
     html_logo_url = "https://bevy.org/assets/icon.png",
     html_favicon_url = "https://bevy.org/assets/icon.png"
 )]
+// FIXME: Address the unwraps used in this crate. See https://github.com/bevyengine/bevy/issues/12660.
+#![expect(
+    clippy::unwrap_used,
+    reason = "Temporary hold until all unwraps in this crate can be addressed."
+)]
 
 //! This crate adds an immediate mode drawing api to Bevy for visual debugging.
 //!

--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -4,6 +4,11 @@
     html_logo_url = "https://bevy.org/assets/icon.png",
     html_favicon_url = "https://bevy.org/assets/icon.png"
 )]
+// FIXME: Address the unwraps used in this crate. See https://github.com/bevyengine/bevy/issues/12660.
+#![expect(
+    clippy::unwrap_used,
+    reason = "Temporary hold until all unwraps in this crate can be addressed."
+)]
 
 //! Plugin providing an [`AssetLoader`](bevy_asset::AssetLoader) and type definitions
 //! for loading glTF 2.0 (a standard 3D scene definition format) files in Bevy.

--- a/crates/bevy_image/src/lib.rs
+++ b/crates/bevy_image/src/lib.rs
@@ -1,4 +1,9 @@
 #![expect(missing_docs, reason = "Not all docs are written yet, see #3492.")]
+// FIXME: Address the unwraps used in this crate. See https://github.com/bevyengine/bevy/issues/12660.
+#![expect(
+    clippy::unwrap_used,
+    reason = "Temporary hold until all unwraps in this crate can be addressed."
+)]
 
 extern crate alloc;
 

--- a/crates/bevy_input_focus/src/lib.rs
+++ b/crates/bevy_input_focus/src/lib.rs
@@ -5,11 +5,6 @@
     html_favicon_url = "https://bevy.org/assets/icon.png"
 )]
 #![no_std]
-// FIXME: Address the unwraps used in this crate. See https://github.com/bevyengine/bevy/issues/12660.
-#![expect(
-    clippy::unwrap_used,
-    reason = "Temporary hold until all unwraps in this crate can be addressed."
-)]
 
 //! A UI-centric focus system for Bevy.
 //!

--- a/crates/bevy_input_focus/src/lib.rs
+++ b/crates/bevy_input_focus/src/lib.rs
@@ -5,6 +5,11 @@
     html_favicon_url = "https://bevy.org/assets/icon.png"
 )]
 #![no_std]
+// FIXME: Address the unwraps used in this crate. See https://github.com/bevyengine/bevy/issues/12660.
+#![expect(
+    clippy::unwrap_used,
+    reason = "Temporary hold until all unwraps in this crate can be addressed."
+)]
 
 //! A UI-centric focus system for Bevy.
 //!

--- a/crates/bevy_input_focus/src/tab_navigation.rs
+++ b/crates/bevy_input_focus/src/tab_navigation.rs
@@ -203,7 +203,9 @@ impl TabNavigation<'_, '_> {
 
         match navigation_result {
             Ok(entity) => {
-                if let Some(previous_focus) = focus.0 && tabgroup.is_none() {
+                if let Some(previous_focus) = focus.0
+                    && tabgroup.is_none()
+                {
                     Err(TabNavigationError::NoTabGroupForCurrentFocus {
                         previous_focus,
                         new_focus: entity,

--- a/crates/bevy_input_focus/src/tab_navigation.rs
+++ b/crates/bevy_input_focus/src/tab_navigation.rs
@@ -203,9 +203,9 @@ impl TabNavigation<'_, '_> {
 
         match navigation_result {
             Ok(entity) => {
-                if focus.0.is_some() && tabgroup.is_none() {
+                if let Some(previous_focus) = focus.0 && tabgroup.is_none() {
                     Err(TabNavigationError::NoTabGroupForCurrentFocus {
-                        previous_focus: focus.0.unwrap(),
+                        previous_focus,
                         new_focus: entity,
                     })
                 } else {

--- a/crates/bevy_light/src/lib.rs
+++ b/crates/bevy_light/src/lib.rs
@@ -1,9 +1,4 @@
 #![expect(missing_docs, reason = "Not all docs are written yet, see #3492.")]
-// FIXME: Address the unwraps used in this crate. See https://github.com/bevyengine/bevy/issues/12660.
-#![expect(
-    clippy::unwrap_used,
-    reason = "Temporary hold until all unwraps in this crate can be addressed."
-)]
 
 use bevy_app::{App, Plugin, PostUpdate};
 use bevy_camera::{
@@ -430,16 +425,14 @@ pub fn check_dir_light_mesh_visibility(
                 },
             );
             // collect entities from parallel queue
+            let view_entities = visible_entities
+                .entities
+                .get_mut(view)
+                .expect("view not present in visible_entities");
             for entities in view_visible_entities_queue.iter_mut() {
-                visible_entities
-                    .entities
-                    .get_mut(view)
-                    .unwrap()
-                    .iter_mut()
-                    .zip(entities.iter_mut())
-                    .for_each(|(dst, source)| {
-                        dst.append(source);
-                    });
+                for (dst, source) in view_entities.iter_mut().zip(entities.iter_mut()) {
+                    dst.append(source);
+                }
             }
         }
 

--- a/crates/bevy_light/src/lib.rs
+++ b/crates/bevy_light/src/lib.rs
@@ -1,4 +1,9 @@
 #![expect(missing_docs, reason = "Not all docs are written yet, see #3492.")]
+// FIXME: Address the unwraps used in this crate. See https://github.com/bevyengine/bevy/issues/12660.
+#![expect(
+    clippy::unwrap_used,
+    reason = "Temporary hold until all unwraps in this crate can be addressed."
+)]
 
 use bevy_app::{App, Plugin, PostUpdate};
 use bevy_camera::{

--- a/crates/bevy_log/src/android_tracing.rs
+++ b/crates/bevy_log/src/android_tracing.rs
@@ -28,12 +28,13 @@ impl Visit for StringRecorder {
         } else {
             if self.1 {
                 // following args
-                write!(self.0, " ").unwrap();
+                // writing can never fail
+                write!(self.0, " ").ok();
             } else {
                 // first arg
                 self.1 = true;
             }
-            write!(self.0, "{} = {:?};", field.name(), value).unwrap();
+            write!(self.0, "{} = {:?};", field.name(), value).ok();
         }
     }
 }
@@ -71,9 +72,9 @@ impl<S: Subscriber + for<'a> LookupSpan<'a>> Layer<S> for AndroidLayer {
                 .as_bytes()
                 .into_iter()
                 .copied()
-                .filter(|byte| *byte != 0)
+                .flat_map(NonZeroU8::new)
                 .collect();
-            CString::new(bytes).unwrap()
+            CString::from(bytes)
         }
 
         let mut recorder = StringRecorder::new();

--- a/crates/bevy_macro_utils/src/bevy_manifest.rs
+++ b/crates/bevy_macro_utils/src/bevy_manifest.rs
@@ -43,6 +43,10 @@ impl BevyManifest {
         let mut manifests = MANIFESTS.write();
         manifests.insert(key, manifest);
 
+        #[expect(
+            clippy::unwrap_used,
+            reason = "The manifest should have been populated in the `read_manifest` call above."
+        )]
         RwLockReadGuard::map(RwLockWriteGuard::downgrade(manifests), |manifests| {
             manifests.get(&manifest_path).unwrap()
         })
@@ -127,6 +131,6 @@ impl BevyManifest {
     ///
     /// [`try_parse_str`]: Self::try_parse_str
     pub fn parse_str<T: syn::parse::Parse>(path: &str) -> T {
-        Self::try_parse_str(path).unwrap()
+        Self::try_parse_str(path).expect("invalid parse")
     }
 }

--- a/crates/bevy_macro_utils/src/label.rs
+++ b/crates/bevy_macro_utils/src/label.rs
@@ -77,7 +77,7 @@ pub fn derive_label(
         syn::parse2(quote! {
             Self: 'static + Send + Sync + Clone + Eq + ::core::fmt::Debug + ::core::hash::Hash
         })
-        .unwrap(),
+        .expect("invalid WherePredicate"),
     );
     quote! {
         // To ensure alloc is available, but also prevent its name from clashing, we place the implementation inside an anonymous constant

--- a/crates/bevy_math/src/lib.rs
+++ b/crates/bevy_math/src/lib.rs
@@ -13,6 +13,11 @@
     html_favicon_url = "https://bevy.org/assets/icon.png"
 )]
 #![no_std]
+// FIXME: Address the unwraps used in this crate. See https://github.com/bevyengine/bevy/issues/12660.
+#![expect(
+    clippy::unwrap_used,
+    reason = "Temporary hold until all unwraps in this crate can be addressed."
+)]
 
 //! Provides math types and functionality for the Bevy game engine.
 //!

--- a/crates/bevy_mesh/src/lib.rs
+++ b/crates/bevy_mesh/src/lib.rs
@@ -1,4 +1,9 @@
 #![expect(missing_docs, reason = "Not all docs are written yet, see #3492.")]
+// FIXME: Address the unwraps used in this crate. See https://github.com/bevyengine/bevy/issues/12660.
+#![expect(
+    clippy::unwrap_used,
+    reason = "Temporary hold until all unwraps in this crate can be addressed."
+)]
 
 extern crate alloc;
 extern crate core;

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -5,6 +5,11 @@
     html_logo_url = "https://bevy.org/assets/icon.png",
     html_favicon_url = "https://bevy.org/assets/icon.png"
 )]
+// FIXME: Address the unwraps used in this crate. See https://github.com/bevyengine/bevy/issues/12660.
+#![expect(
+    clippy::unwrap_used,
+    reason = "Temporary hold until all unwraps in this crate can be addressed."
+)]
 
 extern crate alloc;
 

--- a/crates/bevy_post_process/src/auto_exposure/mod.rs
+++ b/crates/bevy_post_process/src/auto_exposure/mod.rs
@@ -46,10 +46,11 @@ impl Plugin for AutoExposurePlugin {
         app.add_plugins(RenderAssetPlugin::<GpuAutoExposureCompensationCurve>::default())
             .init_asset::<AutoExposureCompensationCurve>()
             .register_asset_reflect::<AutoExposureCompensationCurve>();
-        app.world_mut()
+        // The default handle is always valid.
+        let _ = app
+            .world_mut()
             .resource_mut::<Assets<AutoExposureCompensationCurve>>()
-            .insert(&Handle::default(), AutoExposureCompensationCurve::default())
-            .unwrap();
+            .insert(&Handle::default(), AutoExposureCompensationCurve::default());
 
         app.add_plugins(ExtractComponentPlugin::<AutoExposure>::default());
 

--- a/crates/bevy_post_process/src/auto_exposure/node.rs
+++ b/crates/bevy_post_process/src/auto_exposure/node.rs
@@ -14,6 +14,7 @@ use bevy_render::{
     globals::GlobalsBuffer,
     render_asset::RenderAssets,
     render_graph::*,
+    render_phase::DrawError,
     render_resource::*,
     renderer::RenderContext,
     texture::{FallbackImage, GpuImage},
@@ -58,7 +59,9 @@ impl Node for AutoExposureNode {
 
         let view_uniforms_resource = world.resource::<ViewUniforms>();
         let view_uniforms = &view_uniforms_resource.uniforms;
-        let view_uniforms_buffer = view_uniforms.buffer().unwrap();
+        let view_uniforms_buffer = view_uniforms
+            .buffer()
+            .ok_or(DrawError::ViewUniformsBufferNotFound)?;
 
         let globals_buffer = world.resource::<GlobalsBuffer>();
 

--- a/crates/bevy_post_process/src/bloom/mod.rs
+++ b/crates/bevy_post_process/src/bloom/mod.rs
@@ -423,6 +423,10 @@ fn prepare_bloom_bind_groups(
 ) {
     let sampler = &downsampling_pipeline.sampler;
 
+    let Some(uniforms_binding) = uniforms.binding() else {
+        return;
+    };
+
     for (entity, bloom_texture) in &views {
         let bind_group_count = bloom_texture.mip_count as usize - 1;
 
@@ -434,7 +438,7 @@ fn prepare_bloom_bind_groups(
                 &BindGroupEntries::sequential((
                     &bloom_texture.view(mip - 1),
                     sampler,
-                    uniforms.binding().unwrap(),
+                    uniforms_binding.clone(),
                 )),
             ));
         }
@@ -447,7 +451,7 @@ fn prepare_bloom_bind_groups(
                 &BindGroupEntries::sequential((
                     &bloom_texture.view(mip),
                     sampler,
-                    uniforms.binding().unwrap(),
+                    uniforms_binding.clone(),
                 )),
             ));
         }

--- a/crates/bevy_post_process/src/lib.rs
+++ b/crates/bevy_post_process/src/lib.rs
@@ -5,6 +5,11 @@
     html_logo_url = "https://bevy.org/assets/icon.png",
     html_favicon_url = "https://bevy.org/assets/icon.png"
 )]
+// FIXME: Address the unwraps used in this crate. See https://github.com/bevyengine/bevy/issues/12660.
+#![expect(
+    clippy::unwrap_used,
+    reason = "Temporary hold until all unwraps in this crate can be addressed."
+)]
 
 pub mod auto_exposure;
 pub mod bloom;

--- a/crates/bevy_post_process/src/lib.rs
+++ b/crates/bevy_post_process/src/lib.rs
@@ -5,11 +5,6 @@
     html_logo_url = "https://bevy.org/assets/icon.png",
     html_favicon_url = "https://bevy.org/assets/icon.png"
 )]
-// FIXME: Address the unwraps used in this crate. See https://github.com/bevyengine/bevy/issues/12660.
-#![expect(
-    clippy::unwrap_used,
-    reason = "Temporary hold until all unwraps in this crate can be addressed."
-)]
 
 pub mod auto_exposure;
 pub mod bloom;

--- a/crates/bevy_post_process/src/msaa_writeback.rs
+++ b/crates/bevy_post_process/src/msaa_writeback.rs
@@ -89,7 +89,10 @@ impl ViewNode for MsaaWritebackNode {
             // We will indirectly write the results to the "destination" using
             // the MSAA resolve step.
             color_attachments: &[Some(RenderPassColorAttachment {
-                // If MSAA is enabled, then the sampled texture will always exist
+                #[expect(
+                    clippy::unwrap_used,
+                    reason = "If MSAA is enabled, then the sampled texture will always exist"
+                )]
                 view: target.sampled_main_texture_view().unwrap(),
                 depth_slice: None,
                 resolve_target: Some(post_process.destination),

--- a/crates/bevy_reflect/derive/src/lib.rs
+++ b/crates/bevy_reflect/derive/src/lib.rs
@@ -1,4 +1,9 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+// FIXME: Address the unwraps used in this crate. See https://github.com/bevyengine/bevy/issues/12660.
+#![expect(
+    clippy::unwrap_used,
+    reason = "Temporary hold until all unwraps in this crate can be addressed."
+)]
 
 //! This crate contains macros used by Bevy's `Reflect` API.
 //!

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -10,6 +10,11 @@
     html_logo_url = "https://bevy.org/assets/icon.png",
     html_favicon_url = "https://bevy.org/assets/icon.png"
 )]
+// FIXME: Address the unwraps used in this crate. See https://github.com/bevyengine/bevy/issues/12660.
+#![expect(
+    clippy::unwrap_used,
+    reason = "Temporary hold until all unwraps in this crate can be addressed."
+)]
 
 //! Reflection in Rust.
 //!

--- a/crates/bevy_remote/src/http.rs
+++ b/crates/bevy_remote/src/http.rs
@@ -451,10 +451,7 @@ impl Body for BrpHttpBody {
     ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
         match &mut *self.get_mut() {
             BrpHttpBody::Complete(body) =>
-            {
-                #[expect(clippy::unwrap_used, reason = "this poll is infallible")]
-                Body::poll_frame(Pin::new(body), cx).map(|poll| poll.map(|res| Ok(res.unwrap())))
-            }
+                Body::poll_frame(Pin::new(body), cx).map(|poll| poll.map(|res| Ok(res.unwrap()))),
             BrpHttpBody::Stream(body) => Body::poll_frame(Pin::new(body), cx),
         }
     }

--- a/crates/bevy_remote/src/http.rs
+++ b/crates/bevy_remote/src/http.rs
@@ -450,8 +450,9 @@ impl Body for BrpHttpBody {
         cx: &mut Context<'_>,
     ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
         match &mut *self.get_mut() {
-            BrpHttpBody::Complete(body) =>
-                Body::poll_frame(Pin::new(body), cx).map(|poll| poll.map(|res| Ok(res.unwrap()))),
+            BrpHttpBody::Complete(body) => {
+                Body::poll_frame(Pin::new(body), cx).map(|poll| poll.map(|res| Ok(res.unwrap())))
+            }
             BrpHttpBody::Stream(body) => Body::poll_frame(Pin::new(body), cx),
         }
     }

--- a/crates/bevy_render/macros/src/lib.rs
+++ b/crates/bevy_render/macros/src/lib.rs
@@ -1,5 +1,10 @@
 #![expect(missing_docs, reason = "Not all docs are written yet, see #3492.")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+// FIXME: Address the unwraps used in this crate. See https://github.com/bevyengine/bevy/issues/12660.
+#![expect(
+    clippy::unwrap_used,
+    reason = "Temporary hold until all unwraps in this crate can be addressed."
+)]
 
 mod as_bind_group;
 mod extract_component;

--- a/crates/bevy_render/macros/src/lib.rs
+++ b/crates/bevy_render/macros/src/lib.rs
@@ -1,10 +1,5 @@
 #![expect(missing_docs, reason = "Not all docs are written yet, see #3492.")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-// FIXME: Address the unwraps used in this crate. See https://github.com/bevyengine/bevy/issues/12660.
-#![expect(
-    clippy::unwrap_used,
-    reason = "Temporary hold until all unwraps in this crate can be addressed."
-)]
 
 mod as_bind_group;
 mod extract_component;

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -1,3 +1,9 @@
+// FIXME: Address the unwraps used in this crate. See https://github.com/bevyengine/bevy/issues/12660.
+#![expect(
+    clippy::unwrap_used,
+    reason = "Temporary hold until all unwraps in this crate can be addressed."
+)]
+
 //! # Useful Environment Variables
 //!
 //! Both `bevy_render` and `wgpu` have a number of environment variable options for changing the runtime behavior

--- a/crates/bevy_render/src/render_phase/draw.rs
+++ b/crates/bevy_render/src/render_phase/draw.rs
@@ -47,6 +47,8 @@ pub enum DrawError {
     InvalidViewQuery,
     #[error("View entity not found")]
     ViewEntityNotFound,
+    #[error("View uniforms buffer not found")]
+    ViewUniformsBufferNotFound,
 }
 
 // TODO: make this generic?

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -3,6 +3,11 @@
     html_logo_url = "https://bevy.org/assets/icon.png",
     html_favicon_url = "https://bevy.org/assets/icon.png"
 )]
+// FIXME: Address the unwraps used in this crate. See https://github.com/bevyengine/bevy/issues/12660.
+#![expect(
+    clippy::unwrap_used,
+    reason = "Temporary hold until all unwraps in this crate can be addressed."
+)]
 
 //! Provides scene definition, instantiation and serialization/deserialization.
 //!

--- a/crates/bevy_shader/src/lib.rs
+++ b/crates/bevy_shader/src/lib.rs
@@ -1,4 +1,9 @@
 #![expect(missing_docs, reason = "Not all docs are written yet, see #3492.")]
+// FIXME: Address the unwraps used in this crate. See https://github.com/bevyengine/bevy/issues/12660.
+#![expect(
+    clippy::unwrap_used,
+    reason = "Temporary hold until all unwraps in this crate can be addressed."
+)]
 
 extern crate alloc;
 

--- a/crates/bevy_solari/src/lib.rs
+++ b/crates/bevy_solari/src/lib.rs
@@ -1,4 +1,9 @@
 #![expect(missing_docs, reason = "Not all docs are written yet, see #3492.")]
+// FIXME: Address the unwraps used in this crate. See https://github.com/bevyengine/bevy/issues/12660.
+#![expect(
+    clippy::unwrap_used,
+    reason = "Temporary hold until all unwraps in this crate can be addressed."
+)]
 
 //! Provides raytraced lighting.
 //!

--- a/crates/bevy_sprite_render/src/lib.rs
+++ b/crates/bevy_sprite_render/src/lib.rs
@@ -5,6 +5,11 @@
     html_logo_url = "https://bevy.org/assets/icon.png",
     html_favicon_url = "https://bevy.org/assets/icon.png"
 )]
+// FIXME: Address the unwraps used in this crate. See https://github.com/bevyengine/bevy/issues/12660.
+#![expect(
+    clippy::unwrap_used,
+    reason = "Temporary hold until all unwraps in this crate can be addressed."
+)]
 
 //! Provides 2D sprite rendering functionality.
 

--- a/crates/bevy_tasks/src/lib.rs
+++ b/crates/bevy_tasks/src/lib.rs
@@ -5,6 +5,11 @@
     html_favicon_url = "https://bevy.org/assets/icon.png"
 )]
 #![no_std]
+// FIXME: Address the unwraps used in this crate. See https://github.com/bevyengine/bevy/issues/12660.
+#![expect(
+    clippy::unwrap_used,
+    reason = "Temporary hold until all unwraps in this crate can be addressed."
+)]
 
 /// Configuration information for this crate.
 pub mod cfg {

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -1,3 +1,9 @@
+// FIXME: Address the unwraps used in this crate. See https://github.com/bevyengine/bevy/issues/12660.
+#![expect(
+    clippy::unwrap_used,
+    reason = "Temporary hold until all unwraps in this crate can be addressed."
+)]
+
 //! This crate provides the tools for positioning and rendering text in Bevy.
 //!
 //! # `Font`

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -5,6 +5,11 @@
     html_favicon_url = "https://bevy.org/assets/icon.png"
 )]
 #![no_std]
+// FIXME: Address the unwraps used in this crate. See https://github.com/bevyengine/bevy/issues/12660.
+#![expect(
+    clippy::unwrap_used,
+    reason = "Temporary hold until all unwraps in this crate can be addressed."
+)]
 
 #[cfg(feature = "std")]
 extern crate std;

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -4,6 +4,11 @@
     html_logo_url = "https://bevy.org/assets/icon.png",
     html_favicon_url = "https://bevy.org/assets/icon.png"
 )]
+// FIXME: Address the unwraps used in this crate. See https://github.com/bevyengine/bevy/issues/12660.
+#![expect(
+    clippy::unwrap_used,
+    reason = "Temporary hold until all unwraps in this crate can be addressed."
+)]
 
 //! This crate contains Bevy's UI system, which can be used to create UI for both 2D and 3D games
 //! # Basic usage

--- a/crates/bevy_ui_render/src/lib.rs
+++ b/crates/bevy_ui_render/src/lib.rs
@@ -4,6 +4,11 @@
     html_logo_url = "https://bevyengine.org/assets/icon.png",
     html_favicon_url = "https://bevyengine.org/assets/icon.png"
 )]
+// FIXME: Address the unwraps used in this crate. See https://github.com/bevyengine/bevy/issues/12660.
+#![expect(
+    clippy::unwrap_used,
+    reason = "Temporary hold until all unwraps in this crate can be addressed."
+)]
 
 //! Provides rendering functionality for `bevy_ui`.
 

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -4,6 +4,11 @@
     html_favicon_url = "https://bevy.org/assets/icon.png"
 )]
 #![no_std]
+// FIXME: Address the unwraps used in this crate. See https://github.com/bevyengine/bevy/issues/12660.
+#![expect(
+    clippy::unwrap_used,
+    reason = "Temporary hold until all unwraps in this crate can be addressed."
+)]
 
 //! `bevy_window` provides a platform-agnostic interface for windowing in Bevy.
 //!

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -4,11 +4,6 @@
     html_favicon_url = "https://bevy.org/assets/icon.png"
 )]
 #![no_std]
-// FIXME: Address the unwraps used in this crate. See https://github.com/bevyengine/bevy/issues/12660.
-#![expect(
-    clippy::unwrap_used,
-    reason = "Temporary hold until all unwraps in this crate can be addressed."
-)]
 
 //! `bevy_window` provides a platform-agnostic interface for windowing in Bevy.
 //!

--- a/crates/bevy_window/src/raw_handle.rs
+++ b/crates/bevy_window/src/raw_handle.rs
@@ -39,6 +39,10 @@ impl<W: 'static> Deref for WindowWrapper<W> {
     type Target = W;
 
     fn deref(&self) -> &Self::Target {
+        #[expect(
+            clippy::unwrap_used,
+            reason = "This can only ever be W and thus cannot fail"
+        )]
         self.reference.downcast_ref::<W>().unwrap()
     }
 }

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -4,6 +4,11 @@
     html_logo_url = "https://bevy.org/assets/icon.png",
     html_favicon_url = "https://bevy.org/assets/icon.png"
 )]
+// FIXME: Address the unwraps used in this crate. See https://github.com/bevyengine/bevy/issues/12660.
+#![expect(
+    clippy::unwrap_used,
+    reason = "Temporary hold until all unwraps in this crate can be addressed."
+)]
 
 //! `bevy_winit` provides utilities to handle window creation and the eventloop through [`winit`]
 //!

--- a/examples/no_std/library/Cargo.toml
+++ b/examples/no_std/library/Cargo.toml
@@ -43,3 +43,4 @@ web = ["bevy/web"]
 std_instead_of_core = "warn"
 std_instead_of_alloc = "warn"
 alloc_instead_of_core = "warn"
+unwrap_used = "warn"


### PR DESCRIPTION
# Objective
Begin addressing #12660. 

## Solution
Follow the example of the existing efforts to enable `deny(missing_docs)` and `deny(unsafe_code)`:

 * Set `clippy::unwrap_used` to `warn` workspace wide.
 * Set `allow-unwrap-in-tests` to true in Clippy.toml.
 * Add `expect` annotations for every non-trivial crate in the workspace
 * Directly address a few crates with only a few cases.

## Testing
Ran clippy locally.