### PR TITLE
Limit float output in some examples to two decimal places.

### DIFF
--- a/examples/3d/depth_of_field.rs
+++ b/examples/3d/depth_of_field.rs
@@ -242,10 +242,10 @@ impl AppSettings {
         let fov = PerspectiveProjection::default().fov;
 
         format!(
-            "Focal distance: {} m (Press Up/Down to change)
-Aperture F-stops: f/{} (Press Left/Right to change)
-Sensor height: {}mm
-Focal length: {}mm
+            "Focal distance: {:.2} m (Press Up/Down to change)
+Aperture F-stops: f/{:.2} (Press Left/Right to change)
+Sensor height: {:.2}mm
+Focal length: {:.2}mm
 Mode: {} (Press Space to change)",
             self.focal_distance,
             self.aperture_f_stops,

--- a/examples/3d/post_processing.rs
+++ b/examples/3d/post_processing.rs
@@ -142,7 +142,7 @@ impl Default for AppSettings {
 /// Creates help text at the bottom of the screen.
 fn create_help_text(app_settings: &AppSettings) -> Text {
     format!(
-        "Chromatic aberration intensity: {} (Press Left or Right to change)",
+        "Chromatic aberration intensity: {:.2} (Press Left or Right to change)",
         app_settings.chromatic_aberration_intensity
     )
     .into()

--- a/examples/3d/tonemapping.rs
+++ b/examples/3d/tonemapping.rs
@@ -502,23 +502,23 @@ fn update_ui(
     if selected_parameter.value == 0 {
         text.push_str("> ");
     }
-    text.push_str(&format!("Exposure: {}\n", color_grading.global.exposure));
+    text.push_str(&format!("Exposure: {:.2}\n", color_grading.global.exposure));
     if selected_parameter.value == 1 {
         text.push_str("> ");
     }
-    text.push_str(&format!("Gamma: {}\n", color_grading.shadows.gamma));
+    text.push_str(&format!("Gamma: {:.2}\n", color_grading.shadows.gamma));
     if selected_parameter.value == 2 {
         text.push_str("> ");
     }
     text.push_str(&format!(
-        "PreSaturation: {}\n",
+        "PreSaturation: {:.2}\n",
         color_grading.shadows.saturation
     ));
     if selected_parameter.value == 3 {
         text.push_str("> ");
     }
     text.push_str(&format!(
-        "PostSaturation: {}\n",
+        "PostSaturation: {:.2}\n",
         color_grading.global.post_saturation
     ));
     text.push_str("(Space) Reset all to default\n");


### PR DESCRIPTION
# Objective

- Improve the readability of float output in the depth_of_field, post_processing, and tonemapping examples by limiting it to two decimal places
- This makes the output cleaner and more consistent.

## Solution

- Use Rust’s formatting syntax (e.g., {:.2}) to ensure floats are displayed with exactly two decimal places.
- Apply this to all relevant print and debug output lines in these examples.
