### PR TITLE
feathers: ensure buttons can change variant dynamically

### DIFF
--- a/crates/bevy_feathers/src/controls/button.rs
+++ b/crates/bevy_feathers/src/controls/button.rs
@@ -29,7 +29,7 @@ use crate::{
 
 /// Color variants for buttons. This also functions as a component used by the dynamic styling
 /// system to identify which entities are buttons.
-#[derive(Component, Default, Clone, Reflect)]
+#[derive(Component, Default, Clone, Reflect, Debug, PartialEq, Eq)]
 #[reflect(Component, Clone, Default)]
 pub enum ButtonVariant {
     /// The standard button appearance
@@ -101,7 +101,12 @@ fn update_button_styles(
             &ThemeBackgroundColor,
             &ThemeFontColor,
         ),
-        Or<(Changed<Hovered>, Added<Pressed>, Added<InteractionDisabled>)>,
+        Or<(
+            Changed<Hovered>,
+            Changed<ButtonVariant>,
+            Added<Pressed>,
+            Added<InteractionDisabled>,
+        )>,
     >,
     mut commands: Commands,
 ) {


### PR DESCRIPTION
Problem: `ButtonVariant` changes do not trigger an update to the button style:

https://github.com/user-attachments/assets/b3eb93bf-c3f9-4f5d-ba76-fdde24d45358


The above video shows that hover is necessary.

As a small bonus add some derives which make `ButtonVariant` more dev friendly (`Debug`) and allow doing variant comparisons.

## Solution

Add `Changed<ButtonVariant>` to the system which updates button styles.

Also add some derives to allow debug printing button variants as well as comparing them for equality.

## Testing

Tested in my local project, works well.
