### PR TITLE
Change defaults for `Tonemapping` based on `tonemapping_luts` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -445,7 +445,7 @@ android_shared_stdcxx = ["bevy_internal/android_shared_stdcxx"]
 # Enable detailed trace event logging. These trace events are expensive even when off, thus they require compile time opt-in
 detailed_trace = ["bevy_internal/detailed_trace"]
 
-# Include tonemapping Look Up Tables KTX2 files. If everything is pink, you need to enable this feature or change the `Tonemapping` method for your `Camera2d` or `Camera3d`.
+# Include tonemapping Look Up Tables KTX2 files.
 tonemapping_luts = ["bevy_internal/tonemapping_luts"]
 
 # Include SMAA Look Up Tables KTX2 Files

--- a/crates/bevy_core_pipeline/src/tonemapping/mod.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/mod.rs
@@ -110,7 +110,8 @@ pub struct TonemappingPipeline {
 
 /// Optionally enables a tonemapping shader that attempts to map linear input stimulus into a perceptually uniform image for a given [`Camera`] entity.
 ///
-/// The default when `tonemapping_luts` is enabled is `TonyMcMapface`, otherwise it is `None`.
+/// The default when `tonemapping_luts` is enabled is [`TonyMcMapface`](Tonemapping::TonyMcMapface),
+/// otherwise it is [`None`](Tonemapping::None).
 #[derive(
     Component, Debug, Hash, Clone, Copy, Reflect, Default, ExtractComponent, PartialEq, Eq,
 )]

--- a/crates/bevy_core_pipeline/src/tonemapping/mod.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/mod.rs
@@ -109,6 +109,15 @@ pub struct TonemappingPipeline {
 }
 
 /// Optionally enables a tonemapping shader that attempts to map linear input stimulus into a perceptually uniform image for a given [`Camera`] entity.
+///
+#[cfg_attr(
+    feature = "tonemapping_luts",
+    doc = "The default tonemapping is [`TonyMcMapface`](Tonemapping::TonyMcMapface)."
+)]
+#[cfg_attr(
+    not(feature = "tonemapping_luts"),
+    doc = "The default tonemapping is [`None`](Tonemapping::None)."
+)]
 #[derive(
     Component, Debug, Hash, Clone, Copy, Reflect, Default, ExtractComponent, PartialEq, Eq,
 )]
@@ -116,6 +125,8 @@ pub struct TonemappingPipeline {
 #[reflect(Component, Debug, Hash, Default, PartialEq)]
 pub enum Tonemapping {
     /// Bypass tonemapping.
+    ///
+    /// Default when `tonemapping_luts` is disabled.
     #[cfg_attr(not(feature = "tonemapping_luts"), default)]
     None,
     /// Suffers from lots hue shifting, brights don't desaturate naturally.
@@ -152,6 +163,8 @@ pub enum Tonemapping {
     /// Brightness-equivalent luminance of the input stimulus is compressed. The non-linearity resembles Reinhard.
     /// Color hues are preserved during compression, except for a deliberate [Bezold–Brücke shift](https://en.wikipedia.org/wiki/Bezold%E2%80%93Br%C3%BCcke_shift).
     /// To avoid posterization, selective desaturation is employed, with care to avoid the [Abney effect](https://en.wikipedia.org/wiki/Abney_effect).
+    ///
+    /// Default when `tonemapping_luts` is enabled.
     #[cfg_attr(feature = "tonemapping_luts", default)]
     #[cfg(feature = "tonemapping_luts")]
     TonyMcMapface,

--- a/crates/bevy_core_pipeline/src/tonemapping/mod.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/mod.rs
@@ -110,14 +110,7 @@ pub struct TonemappingPipeline {
 
 /// Optionally enables a tonemapping shader that attempts to map linear input stimulus into a perceptually uniform image for a given [`Camera`] entity.
 ///
-#[cfg_attr(
-    feature = "tonemapping_luts",
-    doc = "The default tonemapping is [`TonyMcMapface`](Tonemapping::TonyMcMapface)."
-)]
-#[cfg_attr(
-    not(feature = "tonemapping_luts"),
-    doc = "The default tonemapping is [`None`](Tonemapping::None)."
-)]
+/// The default when `tonemapping_luts` is enabled is `TonyMcMapface`, otherwise it is `None`.
 #[derive(
     Component, Debug, Hash, Clone, Copy, Reflect, Default, ExtractComponent, PartialEq, Eq,
 )]

--- a/crates/bevy_core_pipeline/src/tonemapping/node.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/node.rs
@@ -1,6 +1,8 @@
 use std::sync::Mutex;
 
-use crate::tonemapping::{TonemappingLuts, TonemappingPipeline, ViewTonemappingPipeline};
+#[cfg(feature = "tonemapping_luts")]
+use crate::tonemapping::TonemappingLuts;
+use crate::tonemapping::{TonemappingPipeline, ViewTonemappingPipeline};
 
 use bevy_ecs::{prelude::*, query::QueryItem};
 use bevy_render::{
@@ -89,10 +91,16 @@ impl ViewNode for TonemappingNode {
                 bind_group
             }
             cached_bind_group => {
+                #[cfg(feature = "tonemapping_luts")]
                 let tonemapping_luts = world.resource::<TonemappingLuts>();
 
-                let lut_bindings =
-                    get_lut_bindings(gpu_images, tonemapping_luts, tonemapping, fallback_image);
+                let lut_bindings = get_lut_bindings(
+                    gpu_images,
+                    #[cfg(feature = "tonemapping_luts")]
+                    tonemapping_luts,
+                    tonemapping,
+                    fallback_image,
+                );
 
                 let bind_group = render_context.render_device().create_bind_group(
                     None,

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -68,6 +68,7 @@ raw_vulkan_init = ["bevy_render/raw_vulkan_init"]
 # Include tonemapping LUT KTX2 files.
 tonemapping_luts = [
   "bevy_core_pipeline?/tonemapping_luts",
+  "bevy_pbr?/tonemapping_luts",
   "ktx2",
   "bevy_image/zstd",
 ]

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -69,6 +69,7 @@ raw_vulkan_init = ["bevy_render/raw_vulkan_init"]
 tonemapping_luts = [
   "bevy_core_pipeline?/tonemapping_luts",
   "bevy_pbr?/tonemapping_luts",
+  "bevy_sprite_render?/tonemapping_luts",
   "ktx2",
   "bevy_image/zstd",
 ]

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -31,6 +31,7 @@ meshlet_processor = [
   "dep:itertools",
   "dep:bitvec",
 ]
+tonemapping_luts = ["bevy_core_pipeline/tonemapping_luts"]
 
 [dependencies]
 # bevy

--- a/crates/bevy_pbr/src/deferred/mod.rs
+++ b/crates/bevy_pbr/src/deferred/mod.rs
@@ -503,11 +503,14 @@ pub fn prepare_deferred_lighting_pipelines(
                         MeshPipelineKey::TONEMAP_METHOD_REINHARD_LUMINANCE
                     }
                     Tonemapping::AcesFitted => MeshPipelineKey::TONEMAP_METHOD_ACES_FITTED,
+                    #[cfg(feature = "tonemapping_luts")]
                     Tonemapping::AgX => MeshPipelineKey::TONEMAP_METHOD_AGX,
                     Tonemapping::SomewhatBoringDisplayTransform => {
                         MeshPipelineKey::TONEMAP_METHOD_SOMEWHAT_BORING_DISPLAY_TRANSFORM
                     }
+                    #[cfg(feature = "tonemapping_luts")]
                     Tonemapping::TonyMcMapface => MeshPipelineKey::TONEMAP_METHOD_TONY_MC_MAPFACE,
+                    #[cfg(feature = "tonemapping_luts")]
                     Tonemapping::BlenderFilmic => MeshPipelineKey::TONEMAP_METHOD_BLENDER_FILMIC,
                 };
             }

--- a/crates/bevy_pbr/src/deferred/mod.rs
+++ b/crates/bevy_pbr/src/deferred/mod.rs
@@ -270,14 +270,17 @@ impl SpecializedRenderPipeline for DeferredLightingLayout {
                 shader_defs.push("TONEMAP_METHOD_REINHARD_LUMINANCE".into());
             } else if method == MeshPipelineKey::TONEMAP_METHOD_ACES_FITTED {
                 shader_defs.push("TONEMAP_METHOD_ACES_FITTED".into());
-            } else if method == MeshPipelineKey::TONEMAP_METHOD_AGX {
-                shader_defs.push("TONEMAP_METHOD_AGX".into());
             } else if method == MeshPipelineKey::TONEMAP_METHOD_SOMEWHAT_BORING_DISPLAY_TRANSFORM {
                 shader_defs.push("TONEMAP_METHOD_SOMEWHAT_BORING_DISPLAY_TRANSFORM".into());
-            } else if method == MeshPipelineKey::TONEMAP_METHOD_BLENDER_FILMIC {
-                shader_defs.push("TONEMAP_METHOD_BLENDER_FILMIC".into());
-            } else if method == MeshPipelineKey::TONEMAP_METHOD_TONY_MC_MAPFACE {
-                shader_defs.push("TONEMAP_METHOD_TONY_MC_MAPFACE".into());
+            } else {
+                #[cfg(feature = "tonemapping_luts")]
+                if method == MeshPipelineKey::TONEMAP_METHOD_AGX {
+                    shader_defs.push("TONEMAP_METHOD_AGX".into());
+                } else if method == MeshPipelineKey::TONEMAP_METHOD_BLENDER_FILMIC {
+                    shader_defs.push("TONEMAP_METHOD_BLENDER_FILMIC".into());
+                } else if method == MeshPipelineKey::TONEMAP_METHOD_TONY_MC_MAPFACE {
+                    shader_defs.push("TONEMAP_METHOD_TONY_MC_MAPFACE".into());
+                }
             }
 
             // Debanding is tied to tonemapping in the shader, cannot run without it.

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -632,11 +632,14 @@ pub const fn tonemapping_pipeline_key(tonemapping: Tonemapping) -> MeshPipelineK
         Tonemapping::Reinhard => MeshPipelineKey::TONEMAP_METHOD_REINHARD,
         Tonemapping::ReinhardLuminance => MeshPipelineKey::TONEMAP_METHOD_REINHARD_LUMINANCE,
         Tonemapping::AcesFitted => MeshPipelineKey::TONEMAP_METHOD_ACES_FITTED,
+        #[cfg(feature = "tonemapping_luts")]
         Tonemapping::AgX => MeshPipelineKey::TONEMAP_METHOD_AGX,
         Tonemapping::SomewhatBoringDisplayTransform => {
             MeshPipelineKey::TONEMAP_METHOD_SOMEWHAT_BORING_DISPLAY_TRANSFORM
         }
+        #[cfg(feature = "tonemapping_luts")]
         Tonemapping::TonyMcMapface => MeshPipelineKey::TONEMAP_METHOD_TONY_MC_MAPFACE,
+        #[cfg(feature = "tonemapping_luts")]
         Tonemapping::BlenderFilmic => MeshPipelineKey::TONEMAP_METHOD_BLENDER_FILMIC,
     }
 }

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -2107,9 +2107,12 @@ bitflags::bitflags! {
         const TONEMAP_METHOD_REINHARD           = 1 << Self::TONEMAP_METHOD_SHIFT_BITS;
         const TONEMAP_METHOD_REINHARD_LUMINANCE = 2 << Self::TONEMAP_METHOD_SHIFT_BITS;
         const TONEMAP_METHOD_ACES_FITTED        = 3 << Self::TONEMAP_METHOD_SHIFT_BITS;
+        #[cfg(feature = "tonemapping_luts")]
         const TONEMAP_METHOD_AGX                = 4 << Self::TONEMAP_METHOD_SHIFT_BITS;
         const TONEMAP_METHOD_SOMEWHAT_BORING_DISPLAY_TRANSFORM = 5 << Self::TONEMAP_METHOD_SHIFT_BITS;
+        #[cfg(feature = "tonemapping_luts")]
         const TONEMAP_METHOD_TONY_MC_MAPFACE    = 6 << Self::TONEMAP_METHOD_SHIFT_BITS;
+        #[cfg(feature = "tonemapping_luts")]
         const TONEMAP_METHOD_BLENDER_FILMIC     = 7 << Self::TONEMAP_METHOD_SHIFT_BITS;
         const SHADOW_FILTER_METHOD_RESERVED_BITS = Self::SHADOW_FILTER_METHOD_MASK_BITS << Self::SHADOW_FILTER_METHOD_SHIFT_BITS;
         const SHADOW_FILTER_METHOD_HARDWARE_2X2  = 0 << Self::SHADOW_FILTER_METHOD_SHIFT_BITS;

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -2494,14 +2494,17 @@ impl SpecializedMeshPipeline for MeshPipeline {
                 shader_defs.push("TONEMAP_METHOD_REINHARD_LUMINANCE".into());
             } else if method == MeshPipelineKey::TONEMAP_METHOD_ACES_FITTED {
                 shader_defs.push("TONEMAP_METHOD_ACES_FITTED".into());
-            } else if method == MeshPipelineKey::TONEMAP_METHOD_AGX {
-                shader_defs.push("TONEMAP_METHOD_AGX".into());
             } else if method == MeshPipelineKey::TONEMAP_METHOD_SOMEWHAT_BORING_DISPLAY_TRANSFORM {
                 shader_defs.push("TONEMAP_METHOD_SOMEWHAT_BORING_DISPLAY_TRANSFORM".into());
-            } else if method == MeshPipelineKey::TONEMAP_METHOD_BLENDER_FILMIC {
-                shader_defs.push("TONEMAP_METHOD_BLENDER_FILMIC".into());
-            } else if method == MeshPipelineKey::TONEMAP_METHOD_TONY_MC_MAPFACE {
-                shader_defs.push("TONEMAP_METHOD_TONY_MC_MAPFACE".into());
+            } else {
+                #[cfg(feature = "tonemapping_luts")]
+                if method == MeshPipelineKey::TONEMAP_METHOD_AGX {
+                    shader_defs.push("TONEMAP_METHOD_AGX".into());
+                } else if method == MeshPipelineKey::TONEMAP_METHOD_BLENDER_FILMIC {
+                    shader_defs.push("TONEMAP_METHOD_BLENDER_FILMIC".into());
+                } else if method == MeshPipelineKey::TONEMAP_METHOD_TONY_MC_MAPFACE {
+                    shader_defs.push("TONEMAP_METHOD_TONY_MC_MAPFACE".into());
+                }
             }
 
             // Debanding is tied to tonemapping in the shader, cannot run without it.

--- a/crates/bevy_pbr/src/render/mesh_view_bindings.rs
+++ b/crates/bevy_pbr/src/render/mesh_view_bindings.rs
@@ -1,12 +1,13 @@
 use alloc::sync::Arc;
+#[cfg(feature = "tonemapping_luts")]
+use bevy_core_pipeline::tonemapping::TonemappingLuts;
 use bevy_core_pipeline::{
     core_3d::ViewTransmissionTexture,
     oit::{resolve::is_oit_supported, OitBuffers, OrderIndependentTransparencySettings},
     prepass::ViewPrepassTextures,
-    tonemapping::{
-        get_lut_bind_group_layout_entries, get_lut_bindings, Tonemapping, TonemappingLuts,
-    },
+    tonemapping::{get_lut_bind_group_layout_entries, get_lut_bindings, Tonemapping},
 };
+
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
     component::Component,
@@ -566,7 +567,7 @@ pub fn prepare_mesh_view_bind_groups(
         Res<FallbackImageZero>,
     ),
     globals_buffer: Res<GlobalsBuffer>,
-    tonemapping_luts: Res<TonemappingLuts>,
+    #[cfg(feature = "tonemapping_luts")] tonemapping_luts: Res<TonemappingLuts>,
     light_probes_buffer: Res<LightProbesBuffer>,
     visibility_ranges: Res<RenderVisibilityRanges>,
     ssr_buffer: Res<ScreenSpaceReflectionsBuffer>,
@@ -653,8 +654,13 @@ pub fn prepare_mesh_view_bind_groups(
 
             entries = entries.extend_with_indices(((17, environment_map_binding.clone()),));
 
-            let lut_bindings =
-                get_lut_bindings(&images, &tonemapping_luts, tonemapping, &fallback_image);
+            let lut_bindings = get_lut_bindings(
+                &images,
+                #[cfg(feature = "tonemapping_luts")]
+                &tonemapping_luts,
+                tonemapping,
+                &fallback_image,
+            );
             entries = entries.extend_with_indices(((18, lut_bindings.0), (19, lut_bindings.1)));
 
             // When using WebGL, we can't have a depth texture with multisampling

--- a/crates/bevy_sprite_render/Cargo.toml
+++ b/crates/bevy_sprite_render/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["bevy"]
 webgl = []
 webgpu = []
 bevy_text = ["dep:bevy_text", "bevy_sprite/bevy_text"]
+tonemapping_luts = ["bevy_core_pipeline/tonemapping_luts"]
 
 [dependencies]
 # bevy

--- a/crates/bevy_sprite_render/src/mesh2d/material.rs
+++ b/crates/bevy_sprite_render/src/mesh2d/material.rs
@@ -555,11 +555,14 @@ pub const fn tonemapping_pipeline_key(tonemapping: Tonemapping) -> Mesh2dPipelin
         Tonemapping::Reinhard => Mesh2dPipelineKey::TONEMAP_METHOD_REINHARD,
         Tonemapping::ReinhardLuminance => Mesh2dPipelineKey::TONEMAP_METHOD_REINHARD_LUMINANCE,
         Tonemapping::AcesFitted => Mesh2dPipelineKey::TONEMAP_METHOD_ACES_FITTED,
+        #[cfg(feature = "tonemapping_luts")]
         Tonemapping::AgX => Mesh2dPipelineKey::TONEMAP_METHOD_AGX,
         Tonemapping::SomewhatBoringDisplayTransform => {
             Mesh2dPipelineKey::TONEMAP_METHOD_SOMEWHAT_BORING_DISPLAY_TRANSFORM
         }
+        #[cfg(feature = "tonemapping_luts")]
         Tonemapping::TonyMcMapface => Mesh2dPipelineKey::TONEMAP_METHOD_TONY_MC_MAPFACE,
+        #[cfg(feature = "tonemapping_luts")]
         Tonemapping::BlenderFilmic => Mesh2dPipelineKey::TONEMAP_METHOD_BLENDER_FILMIC,
     }
 }

--- a/crates/bevy_sprite_render/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite_render/src/mesh2d/mesh.rs
@@ -5,12 +5,11 @@ use bevy_render::RenderStartup;
 use bevy_shader::{load_shader_library, Shader, ShaderDefVal, ShaderSettings};
 
 use crate::{tonemapping_pipeline_key, Material2dBindGroupId};
+#[cfg(feature = "tonemapping_luts")]
+use bevy_core_pipeline::tonemapping::TonemappingLuts;
 use bevy_core_pipeline::{
     core_2d::{AlphaMask2d, Opaque2d, Transparent2d, CORE_2D_DEPTH_FORMAT},
-    tonemapping::{
-        get_lut_bind_group_layout_entries, get_lut_bindings, DebandDither, Tonemapping,
-        TonemappingLuts,
-    },
+    tonemapping::{get_lut_bind_group_layout_entries, get_lut_bindings, DebandDither, Tonemapping},
 };
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::component::Tick;
@@ -741,7 +740,7 @@ pub fn prepare_mesh2d_view_bind_groups(
     view_uniforms: Res<ViewUniforms>,
     views: Query<(Entity, &Tonemapping), (With<ExtractedView>, With<Camera2d>)>,
     globals_buffer: Res<GlobalsBuffer>,
-    tonemapping_luts: Res<TonemappingLuts>,
+    #[cfg(feature = "tonemapping_luts")] tonemapping_luts: Res<TonemappingLuts>,
     images: Res<RenderAssets<GpuImage>>,
     fallback_image: Res<FallbackImage>,
 ) {
@@ -753,8 +752,13 @@ pub fn prepare_mesh2d_view_bind_groups(
     };
 
     for (entity, tonemapping) in &views {
-        let lut_bindings =
-            get_lut_bindings(&images, &tonemapping_luts, tonemapping, &fallback_image);
+        let lut_bindings = get_lut_bindings(
+            &images,
+            #[cfg(feature = "tonemapping_luts")]
+            &tonemapping_luts,
+            tonemapping,
+            &fallback_image,
+        );
         let view_bind_group = render_device.create_bind_group(
             "mesh2d_view_bind_group",
             &mesh2d_pipeline.view_layout,

--- a/crates/bevy_sprite_render/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite_render/src/mesh2d/mesh.rs
@@ -488,9 +488,12 @@ bitflags::bitflags! {
         const TONEMAP_METHOD_REINHARD           = 1 << Self::TONEMAP_METHOD_SHIFT_BITS;
         const TONEMAP_METHOD_REINHARD_LUMINANCE = 2 << Self::TONEMAP_METHOD_SHIFT_BITS;
         const TONEMAP_METHOD_ACES_FITTED        = 3 << Self::TONEMAP_METHOD_SHIFT_BITS;
+        #[cfg(feature = "tonemapping_luts")]
         const TONEMAP_METHOD_AGX                = 4 << Self::TONEMAP_METHOD_SHIFT_BITS;
         const TONEMAP_METHOD_SOMEWHAT_BORING_DISPLAY_TRANSFORM = 5 << Self::TONEMAP_METHOD_SHIFT_BITS;
+        #[cfg(feature = "tonemapping_luts")]
         const TONEMAP_METHOD_TONY_MC_MAPFACE    = 6 << Self::TONEMAP_METHOD_SHIFT_BITS;
+        #[cfg(feature = "tonemapping_luts")]
         const TONEMAP_METHOD_BLENDER_FILMIC     = 7 << Self::TONEMAP_METHOD_SHIFT_BITS;
     }
 }
@@ -605,15 +608,18 @@ impl SpecializedMeshPipeline for Mesh2dPipeline {
                 Mesh2dPipelineKey::TONEMAP_METHOD_ACES_FITTED => {
                     shader_defs.push("TONEMAP_METHOD_ACES_FITTED".into());
                 }
+                #[cfg(feature = "tonemapping_luts")]
                 Mesh2dPipelineKey::TONEMAP_METHOD_AGX => {
                     shader_defs.push("TONEMAP_METHOD_AGX".into());
                 }
                 Mesh2dPipelineKey::TONEMAP_METHOD_SOMEWHAT_BORING_DISPLAY_TRANSFORM => {
                     shader_defs.push("TONEMAP_METHOD_SOMEWHAT_BORING_DISPLAY_TRANSFORM".into());
                 }
+                #[cfg(feature = "tonemapping_luts")]
                 Mesh2dPipelineKey::TONEMAP_METHOD_BLENDER_FILMIC => {
                     shader_defs.push("TONEMAP_METHOD_BLENDER_FILMIC".into());
                 }
+                #[cfg(feature = "tonemapping_luts")]
                 Mesh2dPipelineKey::TONEMAP_METHOD_TONY_MC_MAPFACE => {
                     shader_defs.push("TONEMAP_METHOD_TONY_MC_MAPFACE".into());
                 }

--- a/crates/bevy_sprite_render/src/render/mod.rs
+++ b/crates/bevy_sprite_render/src/render/mod.rs
@@ -4,12 +4,11 @@ use crate::ComputedTextureSlices;
 use bevy_asset::{load_embedded_asset, AssetEvent, AssetId, AssetServer, Assets, Handle};
 use bevy_camera::visibility::ViewVisibility;
 use bevy_color::{ColorToComponents, LinearRgba};
+#[cfg(feature = "tonemapping_luts")]
+use bevy_core_pipeline::tonemapping::TonemappingLuts;
 use bevy_core_pipeline::{
     core_2d::{Transparent2d, CORE_2D_DEPTH_FORMAT},
-    tonemapping::{
-        get_lut_bind_group_layout_entries, get_lut_bindings, DebandDither, Tonemapping,
-        TonemappingLuts,
-    },
+    tonemapping::{get_lut_bind_group_layout_entries, get_lut_bindings, DebandDither, Tonemapping},
 };
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
@@ -609,7 +608,7 @@ pub fn prepare_sprite_view_bind_groups(
     sprite_pipeline: Res<SpritePipeline>,
     view_uniforms: Res<ViewUniforms>,
     views: Query<(Entity, &Tonemapping), With<ExtractedView>>,
-    tonemapping_luts: Res<TonemappingLuts>,
+    #[cfg(feature = "tonemapping_luts")] tonemapping_luts: Res<TonemappingLuts>,
     images: Res<RenderAssets<GpuImage>>,
     fallback_image: Res<FallbackImage>,
 ) {
@@ -618,8 +617,13 @@ pub fn prepare_sprite_view_bind_groups(
     };
 
     for (entity, tonemapping) in &views {
-        let lut_bindings =
-            get_lut_bindings(&images, &tonemapping_luts, tonemapping, &fallback_image);
+        let lut_bindings = get_lut_bindings(
+            &images,
+            #[cfg(feature = "tonemapping_luts")]
+            &tonemapping_luts,
+            tonemapping,
+            &fallback_image,
+        );
         let view_bind_group = render_device.create_bind_group(
             "mesh2d_view_bind_group",
             &sprite_pipeline.view_layout,

--- a/crates/bevy_sprite_render/src/render/mod.rs
+++ b/crates/bevy_sprite_render/src/render/mod.rs
@@ -545,11 +545,14 @@ pub fn queue_sprites(
                         SpritePipelineKey::TONEMAP_METHOD_REINHARD_LUMINANCE
                     }
                     Tonemapping::AcesFitted => SpritePipelineKey::TONEMAP_METHOD_ACES_FITTED,
+                    #[cfg(feature = "tonemapping_luts")]
                     Tonemapping::AgX => SpritePipelineKey::TONEMAP_METHOD_AGX,
                     Tonemapping::SomewhatBoringDisplayTransform => {
                         SpritePipelineKey::TONEMAP_METHOD_SOMEWHAT_BORING_DISPLAY_TRANSFORM
                     }
+                    #[cfg(feature = "tonemapping_luts")]
                     Tonemapping::TonyMcMapface => SpritePipelineKey::TONEMAP_METHOD_TONY_MC_MAPFACE,
+                    #[cfg(feature = "tonemapping_luts")]
                     Tonemapping::BlenderFilmic => SpritePipelineKey::TONEMAP_METHOD_BLENDER_FILMIC,
                 };
             }

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -59,7 +59,7 @@ The default feature set enables most of the expected features of a game engine, 
 |smaa_luts|Include SMAA Look Up Tables KTX2 Files|
 |std|Allows access to the `std` crate.|
 |sysinfo_plugin|Enables system information diagnostic plugin|
-|tonemapping_luts|Include tonemapping Look Up Tables KTX2 files. If everything is pink, you need to enable this feature or change the `Tonemapping` method for your `Camera2d` or `Camera3d`.|
+|tonemapping_luts|Include tonemapping Look Up Tables KTX2 files.|
 |vorbis|OGG/VORBIS audio format support|
 |wayland|Wayland display server support|
 |webgl2|Enable some limitations to be able to use WebGL2. Please refer to the [WebGL2 and WebGPU](https://github.com/bevyengine/bevy/tree/latest/examples#webgl2-and-webgpu) section of the examples README for more information on how to run Wasm builds with WebGPU.|

--- a/examples/3d/tonemapping.rs
+++ b/examples/3d/tonemapping.rs
@@ -1,5 +1,7 @@
 //! This examples compares Tonemapping options
 
+#[cfg(feature = "tonemapping_luts")]
+use bevy::render::view::ColorGradingSection;
 use bevy::{
     asset::UnapprovedPathMode,
     core_pipeline::tonemapping::Tonemapping,
@@ -9,7 +11,7 @@ use bevy::{
     reflect::TypePath,
     render::{
         render_resource::AsBindGroup,
-        view::{ColorGrading, ColorGradingGlobal, ColorGradingSection, Hdr},
+        view::{ColorGrading, ColorGradingGlobal, Hdr},
     },
     shader::ShaderRef,
 };

--- a/examples/3d/tonemapping.rs
+++ b/examples/3d/tonemapping.rs
@@ -301,14 +301,17 @@ fn toggle_tonemapping_method(
         **tonemapping = Tonemapping::ReinhardLuminance;
     } else if keys.just_pressed(KeyCode::Digit4) {
         **tonemapping = Tonemapping::AcesFitted;
-    } else if keys.just_pressed(KeyCode::Digit5) {
-        **tonemapping = Tonemapping::AgX;
     } else if keys.just_pressed(KeyCode::Digit6) {
         **tonemapping = Tonemapping::SomewhatBoringDisplayTransform;
-    } else if keys.just_pressed(KeyCode::Digit7) {
-        **tonemapping = Tonemapping::TonyMcMapface;
-    } else if keys.just_pressed(KeyCode::Digit8) {
-        **tonemapping = Tonemapping::BlenderFilmic;
+    } else {
+        #[cfg(feature = "tonemapping_luts")]
+        if keys.just_pressed(KeyCode::Digit5) {
+            **tonemapping = Tonemapping::AgX;
+        } else if keys.just_pressed(KeyCode::Digit7) {
+            **tonemapping = Tonemapping::TonyMcMapface;
+        } else if keys.just_pressed(KeyCode::Digit8) {
+            **tonemapping = Tonemapping::BlenderFilmic;
+        }
     }
 
     **color_grading = (*per_method_settings
@@ -464,6 +467,7 @@ fn update_ui(
             ""
         }
     ));
+    #[cfg(feature = "tonemapping_luts")]
     text.push_str(&format!(
         "(5) {} AgX\n",
         if tonemapping == Tonemapping::AgX {
@@ -480,6 +484,7 @@ fn update_ui(
             ""
         }
     ));
+    #[cfg(feature = "tonemapping_luts")]
     text.push_str(&format!(
         "(7) {} TonyMcMapface\n",
         if tonemapping == Tonemapping::TonyMcMapface {
@@ -488,6 +493,7 @@ fn update_ui(
             ""
         }
     ));
+    #[cfg(feature = "tonemapping_luts")]
     text.push_str(&format!(
         "(8) {} Blender Filmic\n",
         if tonemapping == Tonemapping::BlenderFilmic {
@@ -558,6 +564,7 @@ impl PerMethodSettings {
                 },
                 ..default()
             },
+            #[cfg(feature = "tonemapping_luts")]
             Tonemapping::AgX => ColorGrading::with_identical_sections(
                 ColorGradingGlobal {
                     exposure: -0.2,
@@ -583,9 +590,12 @@ impl Default for PerMethodSettings {
             Tonemapping::Reinhard,
             Tonemapping::ReinhardLuminance,
             Tonemapping::AcesFitted,
+            #[cfg(feature = "tonemapping_luts")]
             Tonemapping::AgX,
             Tonemapping::SomewhatBoringDisplayTransform,
+            #[cfg(feature = "tonemapping_luts")]
             Tonemapping::TonyMcMapface,
+            #[cfg(feature = "tonemapping_luts")]
             Tonemapping::BlenderFilmic,
         ] {
             settings.insert(

--- a/release-content/migration-guides/gated-tonemapping.md
+++ b/release-content/migration-guides/gated-tonemapping.md
@@ -1,7 +1,7 @@
 ---
-title: `Tonemapping` modes `ToneMcMapface`, `BlenderFilmic`, and `AgX` are now gated behind `tonemapping_luts`
+title: `Tonemapping` modes `TonyMcMapface`, `BlenderFilmic`, and `AgX` are now gated behind `tonemapping_luts`
 pull_requests: [20924]
 ---
 
-`Tonemapping` mode `ToneMcMapface`, `BlenderFilmic`, and `AgX` are now only present with the `tonemapping_luts`
+`Tonemapping` mode `TonyMcMapface`, `BlenderFilmic`, and `AgX` are now only present with the `tonemapping_luts`
 instead of having a notice on the documentation and logging an error during runtime.

--- a/release-content/migration-guides/gated-tonemapping.md
+++ b/release-content/migration-guides/gated-tonemapping.md
@@ -1,0 +1,7 @@
+---
+title: `Tonemapping` modes `ToneMcMapface`, `BlenderFilmic`, and `AgX` are now gated behind `tonemapping_luts`
+pull_requests: [20924]
+---
+
+`Tonemapping` mode `ToneMcMapface`, `BlenderFilmic`, and `AgX` are now only present with the `tonemapping_luts`
+instead of having a notice on the documentation and logging an error during runtime.

--- a/release-content/migration-guides/tonemapping-defaults.md
+++ b/release-content/migration-guides/tonemapping-defaults.md
@@ -4,5 +4,5 @@ pull_requests: [20924]
 ---
 
 `Tonemapping` component now has a different defaults based on `tonemappint_luts` feature.
-When `tonemapping_luts` is present the default remains `ToneMcMapface`, but when it is off
+When `tonemapping_luts` is present the default remains `TonyMcMapface`, but when it is off
 the default is now `None`.

--- a/release-content/migration-guides/tonemapping-defaults.md
+++ b/release-content/migration-guides/tonemapping-defaults.md
@@ -1,0 +1,8 @@
+---
+title: Different defaults for `Tonemapping` based on `tonemapping_luts` feature
+pull_requests: [20924]
+---
+
+`Tonemapping` component now has a different defaults based on `tonemappint_luts` feature.
+When `tonemapping_luts` is present the default remains `ToneMcMapface`, but when it is off
+the default is now `None`.


### PR DESCRIPTION
# Objective

Fixes #20690

## Solution

Have a different default for `Tonemapping` when `tonemapping_luts` is on and when it is off, and lock `TonyMcMapface`, `BlenderFilmic` and `AgX` behind feature

## Testing

`cargo run -p ci`
