### PR TITLE
Prevent typos from "fixing" `ratatui`

### DIFF
--- a/typos.toml
+++ b/typos.toml
@@ -14,6 +14,7 @@ reparametrization = "reparametrization" # Mathematical term in curve context (re
 reparametrize = "reparametrize"
 reparametrized = "reparametrized"
 mis = "mis"                             # mis - multiple importance sampling
+ratatui = "ratatui"                     # TUI crate
 
 # Match a Whole Word - Case Sensitive
 [default.extend-identifiers]


### PR DESCRIPTION
# Objective

Prevent `typos` from changing `ratatui` crate name

## Solution

Add `ratatui` to `typos`'s exclude

## Testing

Ran `typos -w` before and after change