### PR TITLE
Non-Sync Plugin types

### DIFF
--- a/crates/bevy_app/src/plugin.rs
+++ b/crates/bevy_app/src/plugin.rs
@@ -54,7 +54,7 @@ use downcast_rs::{impl_downcast, Downcast};
 /// }
 /// # fn damp_flickering() {}
 /// ```
-pub trait Plugin: Downcast + Any + Send + Sync {
+pub trait Plugin: Downcast + Any + Send {
     /// Configures the [`App`] to which this plugin is added.
     fn build(&self, app: &mut App);
 

--- a/crates/bevy_remote/src/lib.rs
+++ b/crates/bevy_remote/src/lib.rs
@@ -516,7 +516,6 @@ use bevy_platform::collections::HashMap;
 use bevy_utils::prelude::default;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::sync::RwLock;
 
 pub mod builtin_methods;
 #[cfg(feature = "http")]


### PR DESCRIPTION
# Objective
When going over #20901, it came across to me that the `Sync` bound on `Plugin` might be too strong. There are currently zero uses in first-party crates where we currently rely on `Plugin: Sync`, or in other words ,we never rely on plugins being simultaneously accessible from multiple threads. Given that most of the plugins we have are ZSTs, this might be too tight of a restriction on plugins that require more configuration (e.g. `RemotePlugin`).

## Solution
Remove the bound on the trait. Utilize that to use `Cell` instead of `RwLock` in `RemotePlugin`.

Given this loosens the restrictions on a core trait, I expect this PR to be, at least, a bit contentious. I currently cannot think of a common use case inside the core App framework for plugins (and Apps that contain them) to be accessed simultaneously from multiple threads.

## Testing
Local tests.