### PR TITLE
add helper functions for registering bundles to world

### DIFF
--- a/crates/bevy_ecs/src/bundle/insert.rs
+++ b/crates/bevy_ecs/src/bundle/insert.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     bundle::{ArchetypeMoveType, Bundle, BundleId, BundleInfo, DynamicBundle, InsertMode},
     change_detection::MaybeLocation,
-    component::{Components, ComponentsRegistrator, StorageType, Tick},
+    component::{Components, StorageType, Tick},
     entity::{Entities, Entity, EntityLocation},
     lifecycle::{ADD, INSERT, REPLACE},
     observer::Observers,
@@ -37,16 +37,8 @@ impl<'w> BundleInserter<'w> {
         archetype_id: ArchetypeId,
         change_tick: Tick,
     ) -> Self {
-        // SAFETY: These come from the same world. `world.components_registrator` can't be used since we borrow other fields too.
-        let mut registrator =
-            unsafe { ComponentsRegistrator::new(&mut world.components, &mut world.component_ids) };
+        let bundle_id = world.register_bundle_info::<T>();
 
-        // SAFETY: `registrator`, `world.bundles`, and `world.storages` all come from the same world
-        let bundle_id = unsafe {
-            world
-                .bundles
-                .register_info::<T>(&mut registrator, &mut world.storages)
-        };
         // SAFETY: We just ensured this bundle exists
         unsafe { Self::new_with_id(world, archetype_id, bundle_id, change_tick) }
     }

--- a/crates/bevy_ecs/src/bundle/remove.rs
+++ b/crates/bevy_ecs/src/bundle/remove.rs
@@ -6,7 +6,7 @@ use crate::{
     archetype::{Archetype, ArchetypeCreated, ArchetypeId, Archetypes},
     bundle::{Bundle, BundleId, BundleInfo},
     change_detection::MaybeLocation,
-    component::{ComponentId, Components, ComponentsRegistrator, StorageType},
+    component::{ComponentId, Components, StorageType},
     entity::{Entity, EntityLocation},
     lifecycle::{REMOVE, REPLACE},
     observer::Observers,
@@ -39,16 +39,8 @@ impl<'w> BundleRemover<'w> {
         archetype_id: ArchetypeId,
         require_all: bool,
     ) -> Option<Self> {
-        // SAFETY: These come from the same world. `world.components_registrator` can't be used since we borrow other fields too.
-        let mut registrator =
-            unsafe { ComponentsRegistrator::new(&mut world.components, &mut world.component_ids) };
+        let bundle_id = world.register_bundle_info::<T>();
 
-        // SAFETY: `registrator`, `world.storages`, and `world.bundles` all come from the same world.
-        let bundle_id = unsafe {
-            world
-                .bundles
-                .register_info::<T>(&mut registrator, &mut world.storages)
-        };
         // SAFETY: we initialized this bundle_id in `init_info`, and caller ensures archetype is valid.
         unsafe { Self::new_with_id(world, archetype_id, bundle_id, require_all) }
     }

--- a/crates/bevy_ecs/src/bundle/spawner.rs
+++ b/crates/bevy_ecs/src/bundle/spawner.rs
@@ -6,7 +6,7 @@ use crate::{
     archetype::{Archetype, ArchetypeCreated, ArchetypeId, SpawnBundleStatus},
     bundle::{Bundle, BundleId, BundleInfo, DynamicBundle, InsertMode},
     change_detection::MaybeLocation,
-    component::{ComponentsRegistrator, Tick},
+    component::Tick,
     entity::{Entities, Entity, EntityLocation},
     lifecycle::{ADD, INSERT},
     relationship::RelationshipHookMode,
@@ -26,16 +26,8 @@ pub(crate) struct BundleSpawner<'w> {
 impl<'w> BundleSpawner<'w> {
     #[inline]
     pub fn new<T: Bundle>(world: &'w mut World, change_tick: Tick) -> Self {
-        // SAFETY: These come from the same world. `world.components_registrator` can't be used since we borrow other fields too.
-        let mut registrator =
-            unsafe { ComponentsRegistrator::new(&mut world.components, &mut world.component_ids) };
+        let bundle_id = world.register_bundle_info::<T>();
 
-        // SAFETY: `registrator`, `world.bundles`, and `world.storages` all come from the same world.
-        let bundle_id = unsafe {
-            world
-                .bundles
-                .register_info::<T>(&mut registrator, &mut world.storages)
-        };
         // SAFETY: we initialized this bundle_id in `init_info`
         unsafe { Self::new_with_id(world, bundle_id, change_tick) }
     }


### PR DESCRIPTION
This avoids having to create a `ComponentRegistrator` and passing it to Bundles::register_info everywhere it's called, reducing unsafe blocks. There aren't any calls to `register_info` and related functions that don't have access to a `&mut World` where it wouldn't be possible to do this.

(part 2 to #20790),  #20739

# Objective
calling `Bundles::register_info` involves creating a `ComponentRegistrator` from world `components` and `component_ids`, requiring a `&mut World` and a safety comment ensuring the `ComponentRegistrator` belongs to the same world as the `Bundles`.

## Solution
create a helper function to the world that calls `register_info` with the correct `ComponentRegistrator`, removing the need for unsafe blocks.
