### PR TITLE
handle panics in required component constructors

### DIFF
--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -142,6 +142,8 @@ pub(crate) struct ArchetypeAfterBundleInsert {
     ///
     /// The initial values are determined based on the provided constructor, falling back to the `Default` trait if none is given.
     pub required_components: Box<[RequiredComponentConstructor]>,
+    /// The Ids of the required components that were added by this bundle.
+    pub required_component_ids: Box<[ComponentId]>,
     /// The components added by this bundle. This includes any Required Components that are inserted when adding this bundle.
     added: Box<[ComponentId]>,
     /// The components that were explicitly contributed by this bundle, but already existed in the archetype. This _does not_ include any
@@ -244,6 +246,7 @@ impl Edges {
         archetype_id: ArchetypeId,
         bundle_status: impl Into<Box<[ComponentStatus]>>,
         required_components: impl Into<Box<[RequiredComponentConstructor]>>,
+        required_component_ids: impl Into<Box<[ComponentId]>>,
         added: impl Into<Box<[ComponentId]>>,
         existing: impl Into<Box<[ComponentId]>>,
     ) {
@@ -253,6 +256,7 @@ impl Edges {
                 archetype_id,
                 bundle_status: bundle_status.into(),
                 required_components: required_components.into(),
+                required_component_ids: required_component_ids.into(),
                 added: added.into(),
                 existing: existing.into(),
             },

--- a/crates/bevy_ecs/src/bundle/insert.rs
+++ b/crates/bevy_ecs/src/bundle/insert.rs
@@ -494,13 +494,17 @@ impl<'w> BundleInserter<'w> {
             let (_row, location) = if table_id == remove_table_id {
                 move_archetype(entities, archetype, entity, new_location, remove_archetype)
             } else {
+                let (old_table, new_table) = storages
+                    .tables
+                    .get_2_mut(new_location.table_id, remove_table_id);
+
                 move_archetype_new_table(
                     entities,
                     archetypes_ptr,
                     archetype,
-                    table,
+                    old_table,
                     remove_archetype,
-                    &mut storages.tables[remove_table_id],
+                    new_table,
                     entity,
                     new_location,
                     Table::move_to_and_forget_missing_unchecked,

--- a/crates/bevy_ecs/src/bundle/spawner.rs
+++ b/crates/bevy_ecs/src/bundle/spawner.rs
@@ -108,11 +108,12 @@ impl<'w> BundleSpawner<'w> {
             };
             let table_row = table.allocate(entity);
             let location = archetype.allocate(entity, table_row);
-            let after_effect = bundle_info.write_components(
+            let (after_effect, _failed_components) = bundle_info.write_components(
                 table,
                 sparse_sets,
                 &SpawnBundleStatus,
                 bundle_info.required_component_constructors.iter(),
+                bundle_info.required_component_ids.iter(),
                 entity,
                 table_row,
                 self.change_tick,


### PR DESCRIPTION
# Objective

fix #20368

## Solution

catch panics in required component constructors, then move archetypes if necessary.
this is a PoC kind of PR because I want to know if this is even the right approach to the issue.

## Testing
skifire's example works for inserting components and passes miri. still need to fix `spawn_non_existent` and consider hooks/observers, clean up code, double check safety.
