### PR TITLE
add reflection serialization example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2720,6 +2720,17 @@ category = "Reflection"
 wasm = false
 
 [[example]]
+name = "serialization"
+path = "examples/reflection/serialization.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.serialization]
+name = "Serialization"
+description = "Demonstrates serialization and deserialization using reflection without serde's Serialize/Deserialize traits"
+category = "Reflection"
+wasm = false
+
+[[example]]
 name = "custom_attributes"
 path = "examples/reflection/custom_attributes.rs"
 doc-scrape-examples = true

--- a/examples/README.md
+++ b/examples/README.md
@@ -433,6 +433,7 @@ Example | Description
 [Generic Reflection](../examples/reflection/generic_reflection.rs) | Registers concrete instances of generic types that may be used with reflection
 [Reflection](../examples/reflection/reflection.rs) | Demonstrates how reflection in Bevy provides a way to dynamically interact with Rust types
 [Reflection Types](../examples/reflection/reflection_types.rs) | Illustrates the various reflection types available
+[Serialization](../examples/reflection/serialization.rs) | Demonstrates serialization and deserialization using reflection without serde's Serialize/Deserialize traits
 [Type Data](../examples/reflection/type_data.rs) | Demonstrates how to create and use type data
 
 ### Remote Protocol

--- a/examples/reflection/serialization.rs
+++ b/examples/reflection/serialization.rs
@@ -1,0 +1,76 @@
+//! Illustrates how "reflection" serialization works in Bevy.
+//!
+//! Deriving `Reflect` will also register `SerializationData`,
+//! which powers reflect (de)serialization.
+//! Serializing reflected data *does not* require deriving serde's
+//! Serialize and Deserialize implementations.
+
+use bevy::{
+    prelude::*,
+    reflect::{serde::ReflectDeserializer, PartialReflect},
+};
+use bevy_reflect::serde::ReflectSerializer;
+use serde::de::DeserializeSeed;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_systems(Startup, (deserialize, serialize).chain())
+        .run();
+}
+
+/// Deriving `Reflect` includes reflecting `SerializationData`
+#[derive(Reflect)]
+pub struct Player {
+    name: String,
+    health: u32,
+}
+
+const PLAYER_JSON: &str = r#"{
+    "serialization::Player": {
+        "name": "BevyPlayerOne",
+        "health": 50
+    }
+}"#;
+
+fn deserialize(type_registry: Res<AppTypeRegistry>) {
+    let type_registry = type_registry.read();
+
+    // a serde_json::Value that might have come from an API
+    let value: serde_json::Value = serde_json::from_str(PLAYER_JSON).unwrap();
+
+    // alternatively, `TypedReflectDeserializer` can be used if the type
+    // is known.
+    let deserializer = ReflectDeserializer::new(&type_registry);
+    // deserialize
+    let reflect_value = deserializer.deserialize(value).unwrap();
+    // If Player implemented additional functionality, like Component,
+    // this reflect_value could be used with commands.insert_reflect
+    info!(?reflect_value);
+
+    // `FromReflect` and `ReflectFromReflect` can yield a concrete value.
+    let type_id = reflect_value.get_represented_type_info().unwrap().type_id();
+    let reflect_from_reflect = type_registry
+        .get_type_data::<ReflectFromReflect>(type_id)
+        .unwrap();
+    let player: Box<dyn Reflect> = reflect_from_reflect
+        .from_reflect(reflect_value.as_partial_reflect())
+        .unwrap();
+    info!(?player);
+}
+
+fn serialize(type_registry: Res<AppTypeRegistry>) {
+    let type_registry = type_registry.read();
+
+    // a concrete value
+    let value = Player {
+        name: "BevyPlayerSerialize".to_string(),
+        health: 80,
+    };
+
+    // By default, all derived `Reflect` types can be serialized using serde. No need to derive
+    // Serialize!
+    let serializer = ReflectSerializer::new(&value, &type_registry);
+    let json = serde_json::to_string(&serializer).unwrap();
+    info!(?json);
+}

--- a/examples/reflection/serialization.rs
+++ b/examples/reflection/serialization.rs
@@ -7,9 +7,11 @@
 
 use bevy::{
     prelude::*,
-    reflect::{serde::ReflectDeserializer, PartialReflect},
+    reflect::{
+        serde::{ReflectDeserializer, ReflectSerializer},
+        PartialReflect,
+    },
 };
-use bevy_reflect::serde::ReflectSerializer;
 use serde::de::DeserializeSeed;
 
 fn main() {

--- a/examples/reflection/serialization.rs
+++ b/examples/reflection/serialization.rs
@@ -7,10 +7,7 @@
 
 use bevy::{
     prelude::*,
-    reflect::{
-        serde::{ReflectDeserializer, ReflectSerializer},
-        PartialReflect,
-    },
+    reflect::serde::{ReflectDeserializer, ReflectSerializer},
 };
 use serde::de::DeserializeSeed;
 


### PR DESCRIPTION
# Objective

It is a very common[0] misconception that serde's Serialize/Deserialize derives are required for reflection (de)serialization. This is not true, and can lead to unexpectedly changing the serialization behavior in a way that doesn't get exposed via reflection information. Having an example to point to would be a useful resource when talking about this.

[0]: This is why Avian has Serialize/Deserialize on all types, including marker types; This also cropped up in PRs to new BRP functionality.

## Solution

Implement an example showing deserialization and serialization for a type that only implements `Reflect`, and not serde's `Serialize` or `Deserialize`.

## Testing

```
cargo run --example serialization
2025-09-09T19:08:28.258523Z  INFO serialization: reflect_value=DynamicStruct(serialization::Player { health: 50, name: "BevyPlayerOne" })
2025-09-09T19:08:28.258770Z  INFO serialization: player=serialization::Player { name: "BevyPlayerOne", health: 50 }
2025-09-09T19:08:28.259382Z  INFO serialization: json="{\"serialization::Player\":{\"name\":\"BevyPlayerSerialize\",\"health\":80}}"
```
