### PR TITLE
Set thumb color to lighter in core_widgets_observers when dragging with pointer not over

### DIFF
--- a/examples/ui/core_widgets_observers.rs
+++ b/examples/ui/core_widgets_observers.rs
@@ -46,7 +46,7 @@ fn main() {
             (
                 update_widget_values,
                 toggle_disabled,
-                set_thumb_color_when_drag_ends,
+                update_thumb_color_when_drag_ends,
             ),
         )
         .run();
@@ -486,7 +486,7 @@ fn slider_on_change_hover(
     }
 }
 
-fn set_thumb_color_when_drag_ends(
+fn update_thumb_color_when_drag_ends(
     sliders: Query<
         (
             Entity,

--- a/examples/ui/core_widgets_observers.rs
+++ b/examples/ui/core_widgets_observers.rs
@@ -3,8 +3,8 @@
 use bevy::{
     color::palettes::basic::*,
     core_widgets::{
-        Activate, Callback, CoreButton, CoreCheckbox, CoreSlider, CoreSliderThumb,
-        CoreWidgetsPlugins, SliderRange, SliderValue, ValueChange,
+        Activate, Callback, CoreButton, CoreCheckbox, CoreSlider, CoreSliderDragState,
+        CoreSliderThumb, CoreWidgetsPlugins, SliderRange, SliderValue, ValueChange,
     },
     ecs::system::SystemId,
     input_focus::{
@@ -41,7 +41,14 @@ fn main() {
         .add_observer(checkbox_on_change_hover)
         .add_observer(checkbox_on_add_checked)
         .add_observer(checkbox_on_remove_checked)
-        .add_systems(Update, (update_widget_values, toggle_disabled))
+        .add_systems(
+            Update,
+            (
+                update_widget_values,
+                toggle_disabled,
+                set_thumb_color_when_drag_ends,
+            ),
+        )
         .run();
 }
 
@@ -456,16 +463,50 @@ fn slider_on_remove_disabled(
 
 fn slider_on_change_hover(
     insert: On<Insert, Hovered>,
-    sliders: Query<(Entity, &Hovered, Has<InteractionDisabled>), With<DemoSlider>>,
+    sliders: Query<
+        (
+            Entity,
+            &Hovered,
+            Has<InteractionDisabled>,
+            &CoreSliderDragState,
+        ),
+        With<DemoSlider>,
+    >,
     children: Query<&Children>,
     mut thumbs: Query<(&mut BackgroundColor, Has<DemoSliderThumb>), Without<DemoSlider>>,
 ) {
-    if let Ok((slider_ent, hovered, disabled)) = sliders.get(insert.entity) {
+    if let Ok((slider_ent, hovered, disabled, drag_state)) = sliders.get(insert.entity) {
         for child in children.iter_descendants(slider_ent) {
             if let Ok((mut thumb_bg, is_thumb)) = thumbs.get_mut(child)
                 && is_thumb
             {
-                thumb_bg.0 = thumb_color(disabled, hovered.0);
+                thumb_bg.0 = thumb_color(disabled, hovered.0 | drag_state.dragging);
+            }
+        }
+    }
+}
+
+fn set_thumb_color_when_drag_ends(
+    sliders: Query<
+        (
+            Entity,
+            &Hovered,
+            Has<InteractionDisabled>,
+            &CoreSliderDragState,
+        ),
+        (Changed<CoreSliderDragState>, With<DemoSlider>),
+    >,
+    children: Query<&Children>,
+    mut thumbs: Query<(&mut BackgroundColor, Has<DemoSliderThumb>), Without<DemoSlider>>,
+) {
+    for (slider_ent, hovered, disabled, drag_state) in sliders.iter() {
+        if !drag_state.dragging {
+            for child in children.iter_descendants(slider_ent) {
+                if let Ok((mut thumb_bg, is_thumb)) = thumbs.get_mut(child)
+                    && is_thumb
+                {
+                    thumb_bg.0 = thumb_color(disabled, hovered.0);
+                }
             }
         }
     }


### PR DESCRIPTION
# Objective

In `core_widgets_observers` the thumb should stay the active color during drags when the pointer is not hovering the slider.

## Solution

* In `slider_on_change_hover`, query for  `CoreSliderDragState` and set the thumb color lighter if the slider is hovered or dragged.
* Add a system `update_thumb_color_when_drag_ends` to update the thumb color when dragging ends.

Not ideal implementation, would be better with some way to observe the drag state.