### PR TITLE
Fix `MeshTag` changes having no effect

### DIFF
--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -1458,6 +1458,7 @@ pub fn extract_meshes_for_gpu_building(
                 Changed<Lightmap>,
                 Changed<Aabb>,
                 Changed<Mesh3d>,
+                Changed<MeshTag>,
                 Changed<NoFrustumCulling>,
                 Changed<NotShadowReceiver>,
                 Changed<TransmittedShadowReceiver>,


### PR DESCRIPTION
# Objective

Changing only the mesh tag on a mesh did not have an effect.

## Solution

Check if the mesh tag has changed when extracting the mesh.

## Testing

Can be tested with a modified `storage_buffer`  example:

<details>
  <summary>Click to view the code</summary>

```rust
//! This example demonstrates how to use a storage buffer with `AsBindGroup` in a custom material.
use bevy::{
    mesh::MeshTag,
    prelude::*,
    reflect::TypePath,
    render::{render_resource::AsBindGroup, storage::ShaderStorageBuffer},
    shader::ShaderRef,
};

const SHADER_ASSET_PATH: &str = "shaders/storage_buffer.wgsl";

fn main() {
    App::new()
        .add_plugins((DefaultPlugins, MaterialPlugin::<CustomMaterial>::default()))
        .add_systems(Startup, setup)
        .add_systems(Update, update)
        .run();
}

/// set up a simple 3D scene
fn setup(
    mut commands: Commands,
    mut meshes: ResMut<Assets<Mesh>>,
    mut buffers: ResMut<Assets<ShaderStorageBuffer>>,
    mut materials: ResMut<Assets<CustomMaterial>>,
) {
    // Example data for the storage buffer
    let color_data: Vec<[f32; 4]> = (0..13)
        .map(|i| {
            [
                ops::sin(i as f32) / 2.0 + 0.5,
                ops::sin(i as f32 + 2.0) / 2.0 + 0.5,
                ops::sin(i as f32 + 4.0) / 2.0 + 0.5,
                1.0,
            ]
        })
        .collect::<Vec<[f32; 4]>>();

    let colors = buffers.add(ShaderStorageBuffer::from(color_data));

    let mesh_handle = meshes.add(Cuboid::from_size(Vec3::splat(0.3)));
    // Create the custom material with the storage buffer
    let material_handle = materials.add(CustomMaterial {
        colors: colors.clone(),
    });

    // Spawn cubes with the custom material
    for col in -6..=6 {
        for row in -3..=3 {
            commands.spawn((
                Mesh3d(mesh_handle.clone()),
                MeshMaterial3d(material_handle.clone()),
                MeshTag(5),
                Transform::from_xyz(col as f32, row as f32, 0.0),
            ));
        }
    }

    // Camera
    commands.spawn((
        Camera3d::default(),
        Transform::from_xyz(0.0, 0.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
    ));
}

// Update the mesh tags.
fn update(time: Res<Time>, mut cubes: Query<&mut MeshTag, With<Mesh3d>>) {
    cubes.iter_mut().for_each(|mut tag| {
        let new_tag = time.elapsed_secs() as u32 % 13;
        dbg!(new_tag);
        **tag = new_tag;
    });
}

// This struct defines the data that will be passed to your shader
#[derive(Asset, TypePath, AsBindGroup, Debug, Clone)]
struct CustomMaterial {
    #[storage(0, read_only)]
    colors: Handle<ShaderStorageBuffer>,
}

impl Material for CustomMaterial {
    fn vertex_shader() -> ShaderRef {
        SHADER_ASSET_PATH.into()
    }

    fn fragment_shader() -> ShaderRef {
        SHADER_ASSET_PATH.into()
    }
}
```

</details>
