### PR TITLE
Added SSAO support on WebGPU, with R32Float fallback.

### DIFF
--- a/crates/bevy_pbr/src/ssao/mod.rs
+++ b/crates/bevy_pbr/src/ssao/mod.rs
@@ -405,9 +405,7 @@ impl FromWorld for SsaoPipelines {
 
         let mut shader_defs = Vec::new();
         if depth_format == TextureFormat::R16Float {
-            shader_defs.push(ShaderDefVal::UInt("SSAO_DEPTH_FORMAT".into(), 16));
-        } else {
-            shader_defs.push(ShaderDefVal::UInt("SSAO_DEPTH_FORMAT".into(), 32));
+            shader_defs.push("USE_R16FLOAT".into());
         }
 
         let preprocess_depth_pipeline =
@@ -478,9 +476,7 @@ impl SpecializedComputePipeline for SsaoPipelines {
         }
 
         if self.depth_format == TextureFormat::R16Float {
-            shader_defs.push(ShaderDefVal::UInt("SSAO_DEPTH_FORMAT".into(), 16));
-        } else {
-            shader_defs.push(ShaderDefVal::UInt("SSAO_DEPTH_FORMAT".into(), 32));
+            shader_defs.push("USE_R16FLOAT".into());
         }
 
         ComputePipelineDescriptor {

--- a/crates/bevy_pbr/src/ssao/preprocess_depth.wgsl
+++ b/crates/bevy_pbr/src/ssao/preprocess_depth.wgsl
@@ -8,11 +8,19 @@
 #import bevy_render::view::View
 
 @group(0) @binding(0) var input_depth: texture_depth_2d;
-@group(0) @binding(1) var preprocessed_depth_mip0: texture_storage_2d<r#{SSAO_DEPTH_FORMAT}float, write>;
-@group(0) @binding(2) var preprocessed_depth_mip1: texture_storage_2d<r#{SSAO_DEPTH_FORMAT}float, write>;
-@group(0) @binding(3) var preprocessed_depth_mip2: texture_storage_2d<r#{SSAO_DEPTH_FORMAT}float, write>;
-@group(0) @binding(4) var preprocessed_depth_mip3: texture_storage_2d<r#{SSAO_DEPTH_FORMAT}float, write>;
-@group(0) @binding(5) var preprocessed_depth_mip4: texture_storage_2d<r#{SSAO_DEPTH_FORMAT}float, write>;
+#ifdef USE_R16FLOAT
+@group(0) @binding(1) var preprocessed_depth_mip0: texture_storage_2d<r16float, write>;
+@group(0) @binding(2) var preprocessed_depth_mip1: texture_storage_2d<r16float, write>;
+@group(0) @binding(3) var preprocessed_depth_mip2: texture_storage_2d<r16float, write>;
+@group(0) @binding(4) var preprocessed_depth_mip3: texture_storage_2d<r16float, write>;
+@group(0) @binding(5) var preprocessed_depth_mip4: texture_storage_2d<r16float, write>;
+#else
+@group(0) @binding(1) var preprocessed_depth_mip0: texture_storage_2d<r32float, write>;
+@group(0) @binding(2) var preprocessed_depth_mip1: texture_storage_2d<r32float, write>;
+@group(0) @binding(3) var preprocessed_depth_mip2: texture_storage_2d<r32float, write>;
+@group(0) @binding(4) var preprocessed_depth_mip3: texture_storage_2d<r32float, write>;
+@group(0) @binding(5) var preprocessed_depth_mip4: texture_storage_2d<r32float, write>;
+#endif
 @group(1) @binding(0) var point_clamp_sampler: sampler;
 @group(1) @binding(1) var linear_clamp_sampler: sampler;
 @group(1) @binding(2) var<uniform> view: View;

--- a/crates/bevy_pbr/src/ssao/spatial_denoise.wgsl
+++ b/crates/bevy_pbr/src/ssao/spatial_denoise.wgsl
@@ -13,7 +13,11 @@
 
 @group(0) @binding(0) var ambient_occlusion_noisy: texture_2d<f32>;
 @group(0) @binding(1) var depth_differences: texture_2d<u32>;
-@group(0) @binding(2) var ambient_occlusion: texture_storage_2d<r#{SSAO_DEPTH_FORMAT}float, write>;
+#ifdef USE_R16FLOAT
+@group(0) @binding(2) var ambient_occlusion: texture_storage_2d<r16float, write>;
+#else
+@group(0) @binding(2) var ambient_occlusion: texture_storage_2d<r32float, write>;
+#endif
 @group(1) @binding(0) var point_clamp_sampler: sampler;
 @group(1) @binding(1) var linear_clamp_sampler: sampler;
 @group(1) @binding(2) var<uniform> view: View;

--- a/crates/bevy_pbr/src/ssao/ssao.wgsl
+++ b/crates/bevy_pbr/src/ssao/ssao.wgsl
@@ -21,7 +21,11 @@
 @group(0) @binding(0) var preprocessed_depth: texture_2d<f32>;
 @group(0) @binding(1) var normals: texture_2d<f32>;
 @group(0) @binding(2) var hilbert_index_lut: texture_2d<u32>;
-@group(0) @binding(3) var ambient_occlusion: texture_storage_2d<r#{SSAO_DEPTH_FORMAT}float, write>;
+#ifdef USE_R16FLOAT
+@group(0) @binding(3) var ambient_occlusion: texture_storage_2d<r16float, write>;
+#else
+@group(0) @binding(3) var ambient_occlusion: texture_storage_2d<r32float, write>;
+#endif
 @group(0) @binding(4) var depth_differences: texture_storage_2d<r32uint, write>;
 @group(0) @binding(5) var<uniform> globals: Globals;
 @group(0) @binding(6) var<uniform> thickness: f32;


### PR DESCRIPTION
# Objective

This PR is to add SSAO support on WebGPU.

## Solution
Add r16float detect and fallback to r32float if not supported. FYI the initial ssao PR [here](https://github.com/bevyengine/bevy/pull/7402). 

## Testing

- Did you test these changes? If so, how?
     Yes, here is the command to test the ssao example 
`RUSTFLAGS="--cfg getrandom_backend=\"wasm_js\"" cargo run --example ssao --target wasm32-unknown-unknown --features webgpu`
and then http://localhost:1334, make sure it supports [WebGPU](https://caniuse.com/webgpu) 

- Are there any parts that need more testing?
 N/A
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
     1. For the R32Float fallback, only the 1st commit is needed. However, I ran into some strange flickering issue on Chrome (and   Chrome canary too), so I added a "detect_r16float_support" flag and a temp fix in the 2nd and 3rd commit, which are intended to be reverted when merging.
     2. with the 1st commit, Safari works fine, but Chrome has the flickering, and I fixed it by partially reverting a shader change from https://github.com/bevyengine/bevy/pull/20313, which is very strange. It is probably caused by some shader optimization issue in Chrome, and I have no clue why, as the change is just moving the calculation to a different function.   
Here is the flickering on Mac Chrome(140.0.7339.133 (Official Build) (arm64))
<img width="353" height="327" alt="chrome_ssao" src="https://github.com/user-attachments/assets/0666673f-508e-4b57-a152-19327ffdb6f3" />


- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?
     Tested on native(mac) and WebGPU. To test on native,  set "detect_r16float_support"  to false to force R32Float.
     I couldn't make the WebGPU ssao example running on Windows 11 Chrome or Firefox, there is some error in 'taa_pipeline' .
 
---


