### PR TITLE
Rename `WidgetBehaviorPlugins` to `UIWidgetsPlugins`

### DIFF
--- a/crates/bevy_ui_widgets/src/lib.rs
+++ b/crates/bevy_ui_widgets/src/lib.rs
@@ -29,9 +29,9 @@ use bevy_ecs::entity::Entity;
 
 /// A plugin group that registers the observers for all of the widgets in this crate. If you don't want to
 /// use all of the widgets, you can import the individual widget plugins instead.
-pub struct WidgetBehaviorPlugins;
+pub struct UiWidgetsPlugins;
 
-impl PluginGroup for WidgetBehaviorPlugins {
+impl PluginGroup for UiWidgetsPlugins {
     fn build(self) -> PluginGroupBuilder {
         PluginGroupBuilder::start::<Self>()
             .add(ButtonPlugin)

--- a/examples/ui/feathers.rs
+++ b/examples/ui/feathers.rs
@@ -21,7 +21,7 @@ use bevy::{
     ui::{Checked, InteractionDisabled},
     ui_widgets::{
         Activate, Callback, RadioButton, RadioGroup, SliderPrecision, SliderStep, SliderValue,
-        ValueChange, WidgetBehaviorPlugins,
+        UiWidgetsPlugins, ValueChange,
     },
 };
 
@@ -42,7 +42,7 @@ fn main() {
     App::new()
         .add_plugins((
             DefaultPlugins,
-            WidgetBehaviorPlugins,
+            UiWidgetsPlugins,
             InputDispatchPlugin,
             TabNavigationPlugin,
             FeathersPlugin,

--- a/examples/ui/standard_widgets.rs
+++ b/examples/ui/standard_widgets.rs
@@ -11,7 +11,7 @@ use bevy::{
     ui::{Checked, InteractionDisabled, Pressed},
     ui_widgets::{
         Activate, Button, Callback, Checkbox, CoreSliderDragState, RadioButton, RadioGroup, Slider,
-        SliderRange, SliderThumb, SliderValue, TrackClick, ValueChange, WidgetBehaviorPlugins,
+        SliderRange, SliderThumb, SliderValue, TrackClick, UiWidgetsPlugins, ValueChange,
     },
 };
 
@@ -19,7 +19,7 @@ fn main() {
     App::new()
         .add_plugins((
             DefaultPlugins,
-            WidgetBehaviorPlugins,
+            UiWidgetsPlugins,
             InputDispatchPlugin,
             TabNavigationPlugin,
         ))

--- a/examples/ui/standard_widgets_observers.rs
+++ b/examples/ui/standard_widgets_observers.rs
@@ -12,7 +12,7 @@ use bevy::{
     ui::{Checked, InteractionDisabled, Pressed},
     ui_widgets::{
         Activate, Button, Callback, Checkbox, Slider, SliderRange, SliderThumb, SliderValue,
-        ValueChange, WidgetBehaviorPlugins,
+        UiWidgetsPlugins, ValueChange,
     },
 };
 
@@ -20,7 +20,7 @@ fn main() {
     App::new()
         .add_plugins((
             DefaultPlugins,
-            WidgetBehaviorPlugins,
+            UiWidgetsPlugins,
             InputDispatchPlugin,
             TabNavigationPlugin,
         ))

--- a/examples/ui/virtual_keyboard.rs
+++ b/examples/ui/virtual_keyboard.rs
@@ -8,14 +8,14 @@ use bevy::{
     },
     input_focus::{tab_navigation::TabNavigationPlugin, InputDispatchPlugin},
     prelude::*,
-    ui_widgets::{Activate, WidgetBehaviorPlugins},
+    ui_widgets::{Activate, UiWidgetsPlugins},
 };
 
 fn main() {
     App::new()
         .add_plugins((
             DefaultPlugins,
-            WidgetBehaviorPlugins,
+            UiWidgetsPlugins,
             InputDispatchPlugin,
             TabNavigationPlugin,
             FeathersPlugin,


### PR DESCRIPTION
# Objective

- Fixes #20962

## Testing

- `feathers`, `virtual_keyboard`, `standard_widgets`, `standard_widgets_observers` examples
