### PR TITLE
`MovingPtr<'_,B: Bundle>` impls Bundle

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -150,20 +150,20 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
         // - `Bundle::get_components` is exactly once for each member. Rely's on the Component -> Bundle implementation to properly pass
         //   the correct `StorageType` into the callback.
         #[allow(deprecated)]
-        unsafe impl #impl_generics #ecs_path::bundle::Bundle for #struct_name #ty_generics #where_clause {
-            type Name = (#(<#active_field_types as #ecs_path::bundle::Bundle>::Name,)*);
+        unsafe impl #impl_generics #ecs_path::bundle::BundleImpl for #struct_name #ty_generics #where_clause {
+            type Name = (#(<#active_field_types as #ecs_path::bundle::BundleImpl>::Name,)*);
             fn component_ids(
                 components: &mut #ecs_path::component::ComponentsRegistrator,
                 ids: &mut impl FnMut(#ecs_path::component::ComponentId)
             ) {
-                #(<#active_field_types as #ecs_path::bundle::Bundle>::component_ids(components, ids);)*
+                #(<#active_field_types as #ecs_path::bundle::BundleImpl>::component_ids(components, ids);)*
             }
 
             fn get_component_ids(
                 components: &#ecs_path::component::Components,
                 ids: &mut impl FnMut(Option<#ecs_path::component::ComponentId>)
             ) {
-                #(<#active_field_types as #ecs_path::bundle::Bundle>::get_component_ids(components, &mut *ids);)*
+                #(<#active_field_types as #ecs_path::bundle::BundleImpl>::get_component_ids(components, &mut *ids);)*
             }
         }
     };

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -151,6 +151,7 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
         //   the correct `StorageType` into the callback.
         #[allow(deprecated)]
         unsafe impl #impl_generics #ecs_path::bundle::Bundle for #struct_name #ty_generics #where_clause {
+            type Name = (#(<#active_field_types as #ecs_path::bundle::Bundle>::Name,)*);
             fn component_ids(
                 components: &mut #ecs_path::component::ComponentsRegistrator,
                 ids: &mut impl FnMut(#ecs_path::component::ComponentId)

--- a/crates/bevy_ecs/src/bundle/impls.rs
+++ b/crates/bevy_ecs/src/bundle/impls.rs
@@ -5,16 +5,19 @@ use core::mem::MaybeUninit;
 use variadics_please::all_tuples_enumerated;
 
 use crate::{
-    bundle::{Bundle, BundleFromComponents, DynamicBundle, NoBundleEffect},
+    bundle::{BundleFromComponents, DynamicBundle, NoBundleEffect},
     component::{Component, ComponentId, Components, ComponentsRegistrator, StorageType},
     query::DebugCheckedUnwrap,
     world::EntityWorldMut,
 };
 
+use super::BundleImpl;
+
+// note: `Component: 'static`, so `C: Bundle`.
 // SAFETY:
 // - `Bundle::component_ids` calls `ids` for C's component id (and nothing else)
 // - `Bundle::get_components` is called exactly once for C and passes the component's storage type based on its associated constant.
-unsafe impl<C: Component> Bundle for C {
+unsafe impl<C: Component> BundleImpl for C {
     type Name = C;
 
     fn component_ids(components: &mut ComponentsRegistrator, ids: &mut impl FnMut(ComponentId)) {
@@ -55,8 +58,8 @@ impl<C: Component> DynamicBundle for C {
     unsafe fn apply_effect(_ptr: MovingPtr<'_, MaybeUninit<Self>>, _entity: &mut EntityWorldMut) {}
 }
 
-unsafe impl<T: Bundle + 'static> Bundle for MovingPtr<'_, T> {
-    type Name = <T as Bundle>::Name;
+unsafe impl<T: BundleImpl> BundleImpl for MovingPtr<'_, T> {
+    type Name = <T as BundleImpl>::Name;
 
     fn component_ids(components: &mut ComponentsRegistrator, ids: &mut impl FnMut(ComponentId)) {
         T::component_ids(components, ids);
@@ -67,7 +70,7 @@ unsafe impl<T: Bundle + 'static> Bundle for MovingPtr<'_, T> {
     }
 }
 
-impl<T: Bundle> DynamicBundle for MovingPtr<'_, T> {
+impl<T: DynamicBundle> DynamicBundle for MovingPtr<'_, T> {
     type Effect = T::Effect;
 
     unsafe fn get_components(
@@ -107,14 +110,14 @@ macro_rules! tuple_impl {
         // - `Bundle::from_components` calls `func` exactly once for each `ComponentId` returned by `Bundle::component_ids`.
         // - `Bundle::get_components` is called exactly once for each member. Relies on the above implementation to pass the correct
         //   `StorageType` into the callback.
-        unsafe impl<$($name: Bundle),*> Bundle for ($($name,)*) {
-            type Name = ($(<$name as Bundle>::Name,)*);
+        unsafe impl<$($name: BundleImpl),*> BundleImpl for ($($name,)*) {
+            type Name = ($(<$name as BundleImpl>::Name,)*);
             fn component_ids(components: &mut ComponentsRegistrator,  ids: &mut impl FnMut(ComponentId)){
-                $(<$name as Bundle>::component_ids(components, ids);)*
+                $(<$name as BundleImpl>::component_ids(components, ids);)*
             }
 
             fn get_component_ids(components: &Components, ids: &mut impl FnMut(Option<ComponentId>)){
-                $(<$name as Bundle>::get_component_ids(components, ids);)*
+                $(<$name as BundleImpl>::get_component_ids(components, ids);)*
             }
         }
 
@@ -163,7 +166,7 @@ macro_rules! tuple_impl {
             reason = "Zero-length tuples won't use any of the parameters."
         )]
         $(#[$meta])*
-        impl<$($name: Bundle),*> DynamicBundle for ($($name,)*) {
+        impl<$($name: DynamicBundle),*> DynamicBundle for ($($name,)*) {
             type Effect = ($($name::Effect,)*);
             #[allow(
                 clippy::unused_unit,

--- a/crates/bevy_ecs/src/bundle/info.rs
+++ b/crates/bevy_ecs/src/bundle/info.rs
@@ -21,6 +21,8 @@ use crate::{
     storage::{SparseSetIndex, SparseSets, Storages, Table, TableRow},
 };
 
+use super::BundleImpl;
+
 /// For a specific [`World`], this stores a unique value identifying a type of a registered [`Bundle`].
 ///
 /// [`World`]: crate::world::World
@@ -430,7 +432,7 @@ impl Bundles {
     ///
     /// [`World`]: crate::world::World
     #[deny(unsafe_op_in_unsafe_fn)]
-    pub(crate) unsafe fn register_info<T: Bundle>(
+    pub(crate) unsafe fn register_info<T: BundleImpl>(
         &mut self,
         components: &mut ComponentsRegistrator,
         storages: &mut Storages,

--- a/crates/bevy_ecs/src/bundle/mod.rs
+++ b/crates/bevy_ecs/src/bundle/mod.rs
@@ -15,7 +15,7 @@ pub(crate) use remove::BundleRemover;
 pub(crate) use spawner::BundleSpawner;
 
 use bevy_ptr::MovingPtr;
-use core::mem::MaybeUninit;
+use core::{any::TypeId, mem::MaybeUninit};
 pub use info::*;
 
 /// Derive the [`Bundle`] trait
@@ -197,7 +197,8 @@ use bevy_ptr::OwningPtr;
     label = "invalid `Bundle`",
     note = "consider annotating `{Self}` with `#[derive(Component)]` or `#[derive(Bundle)]`"
 )]
-pub unsafe trait Bundle: DynamicBundle + Send + Sync + 'static {
+pub unsafe trait Bundle: DynamicBundle + Send {
+    type Name: 'static;
     /// Gets this [`Bundle`]'s component ids, in the order of this bundle's [`Component`]s
     #[doc(hidden)]
     fn component_ids(components: &mut ComponentsRegistrator, ids: &mut impl FnMut(ComponentId));
@@ -205,6 +206,16 @@ pub unsafe trait Bundle: DynamicBundle + Send + Sync + 'static {
     /// Gets this [`Bundle`]'s component ids. This will be [`None`] if the component has not been registered.
     fn get_component_ids(components: &Components, ids: &mut impl FnMut(Option<ComponentId>));
 }
+
+pub const fn bundle_id_of<T: Bundle>() -> TypeId {
+    TypeId::of::<T::Name>()
+}
+pub const fn bundle_id_of_val<T: Bundle>(_: &T) -> TypeId {
+    TypeId::of::<T::Name>()
+}
+
+pub trait StaticBundle: Bundle + 'static {}
+impl<T: Bundle + 'static> StaticBundle for T {}
 
 /// Creates a [`Bundle`] by taking it from internal storage.
 ///

--- a/crates/bevy_ecs/src/bundle/mod.rs
+++ b/crates/bevy_ecs/src/bundle/mod.rs
@@ -197,7 +197,7 @@ use bevy_ptr::OwningPtr;
     label = "invalid `Bundle`",
     note = "consider annotating `{Self}` with `#[derive(Component)]` or `#[derive(Bundle)]`"
 )]
-pub unsafe trait Bundle: DynamicBundle + Send {
+pub unsafe trait BundleImpl: DynamicBundle + Send + Sync {
     type Name: 'static;
     /// Gets this [`Bundle`]'s component ids, in the order of this bundle's [`Component`]s
     #[doc(hidden)]
@@ -207,15 +207,15 @@ pub unsafe trait Bundle: DynamicBundle + Send {
     fn get_component_ids(components: &Components, ids: &mut impl FnMut(Option<ComponentId>));
 }
 
-pub const fn bundle_id_of<T: Bundle>() -> TypeId {
+pub const fn bundle_id_of<T: BundleImpl>() -> TypeId {
     TypeId::of::<T::Name>()
 }
-pub const fn bundle_id_of_val<T: Bundle>(_: &T) -> TypeId {
+pub const fn bundle_id_of_val<T: BundleImpl>(_: &T) -> TypeId {
     TypeId::of::<T::Name>()
 }
 
-pub trait StaticBundle: Bundle + 'static {}
-impl<T: Bundle + 'static> StaticBundle for T {}
+pub trait Bundle: BundleImpl + 'static {}
+impl<T: BundleImpl + 'static> Bundle for T {}
 
 /// Creates a [`Bundle`] by taking it from internal storage.
 ///

--- a/crates/bevy_ecs/src/bundle/spawner.rs
+++ b/crates/bevy_ecs/src/bundle/spawner.rs
@@ -15,6 +15,8 @@ use crate::{
     world::{unsafe_world_cell::UnsafeWorldCell, World},
 };
 
+use super::BundleImpl;
+
 // SAFETY: We have exclusive world access so our pointers can't be invalidated externally
 pub(crate) struct BundleSpawner<'w> {
     world: UnsafeWorldCell<'w>,
@@ -26,7 +28,7 @@ pub(crate) struct BundleSpawner<'w> {
 
 impl<'w> BundleSpawner<'w> {
     #[inline]
-    pub fn new<T: Bundle>(world: &'w mut World, change_tick: Tick) -> Self {
+    pub fn new<T: BundleImpl>(world: &'w mut World, change_tick: Tick) -> Self {
         let bundle_id = world.register_bundle_info::<T>();
 
         // SAFETY: we initialized this bundle_id in `init_info`

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -158,7 +158,7 @@ pub struct HotPatchChanges;
 #[cfg(test)]
 mod tests {
     use crate::{
-        bundle::Bundle,
+        bundle::{Bundle, BundleImpl},
         change_detection::Ref,
         component::Component,
         entity::{Entity, EntityMapper},
@@ -250,7 +250,7 @@ mod tests {
             y: SparseStored,
         }
         let mut ids = Vec::new();
-        <FooBundle as Bundle>::component_ids(&mut world.components_registrator(), &mut |id| {
+        <FooBundle as BundleImpl>::component_ids(&mut world.components_registrator(), &mut |id| {
             ids.push(id);
         });
 
@@ -300,9 +300,12 @@ mod tests {
         }
 
         let mut ids = Vec::new();
-        <NestedBundle as Bundle>::component_ids(&mut world.components_registrator(), &mut |id| {
-            ids.push(id);
-        });
+        <NestedBundle as BundleImpl>::component_ids(
+            &mut world.components_registrator(),
+            &mut |id| {
+                ids.push(id);
+            },
+        );
 
         assert_eq!(
             ids,
@@ -352,7 +355,7 @@ mod tests {
         }
 
         let mut ids = Vec::new();
-        <BundleWithIgnored as Bundle>::component_ids(
+        <BundleWithIgnored as BundleImpl>::component_ids(
             &mut world.components_registrator(),
             &mut |id| {
                 ids.push(id);

--- a/crates/bevy_ecs/src/spawn.rs
+++ b/crates/bevy_ecs/src/spawn.rs
@@ -309,6 +309,7 @@ pub struct SpawnRelatedBundle<R: Relationship, L: SpawnableList<R>> {
 unsafe impl<R: Relationship, L: SpawnableList<R> + Send + Sync + 'static> Bundle
     for SpawnRelatedBundle<R, L>
 {
+    type Name = <R::RelationshipTarget as Bundle>::Name;
     fn component_ids(
         components: &mut crate::component::ComponentsRegistrator,
         ids: &mut impl FnMut(crate::component::ComponentId),
@@ -402,6 +403,7 @@ impl<R: Relationship, B: Bundle> DynamicBundle for SpawnOneRelated<R, B> {
 
 // SAFETY: This internally relies on the RelationshipTarget's Bundle implementation, which is sound.
 unsafe impl<R: Relationship, B: Bundle> Bundle for SpawnOneRelated<R, B> {
+    type Name = <R::RelationshipTarget as Bundle>::Name;
     fn component_ids(
         components: &mut crate::component::ComponentsRegistrator,
         ids: &mut impl FnMut(crate::component::ComponentId),

--- a/crates/bevy_ecs/src/spawn.rs
+++ b/crates/bevy_ecs/src/spawn.rs
@@ -2,7 +2,7 @@
 //! for the best entry points into these APIs and examples of how to use them.
 
 use crate::{
-    bundle::{Bundle, DynamicBundle, InsertMode, NoBundleEffect},
+    bundle::{Bundle, BundleImpl, DynamicBundle, InsertMode, NoBundleEffect},
     change_detection::MaybeLocation,
     entity::Entity,
     query::DebugCheckedUnwrap,
@@ -80,23 +80,23 @@ impl<R: Relationship, B: Bundle> SpawnableList<R> for Spawn<B> {
             // SAFETY:
             //  - `Spawn<B>` has one field at index 0.
             //  - if `this` is aligned, then its inner bundle must be as well.
-            let bundle = unsafe {
+            let bundle: MovingPtr<'_, B, _> = unsafe {
                 bevy_ptr::deconstruct_moving_ptr!(this => (
                     0 => bundle,
                 ));
                 bundle.try_into().debug_checked_unwrap()
             };
 
-            let r = R::from(entity);
+            let r = (R::from(entity), bundle);
             move_as_ptr!(r);
-            let mut entity = world.spawn_with_caller(r, caller);
+            world.spawn_with_caller(r, caller);
 
-            entity.insert_with_caller(
-                bundle,
-                InsertMode::Replace,
-                caller,
-                RelationshipHookMode::Run,
-            );
+            // entity.insert_with_caller(
+            //     bundle,
+            //     InsertMode::Replace,
+            //     caller,
+            //     RelationshipHookMode::Run,
+            // );
         }
 
         spawn::<B, R>(this, world, entity);
@@ -306,22 +306,22 @@ pub struct SpawnRelatedBundle<R: Relationship, L: SpawnableList<R>> {
 }
 
 // SAFETY: This internally relies on the RelationshipTarget's Bundle implementation, which is sound.
-unsafe impl<R: Relationship, L: SpawnableList<R> + Send + Sync + 'static> Bundle
+unsafe impl<R: Relationship, L: SpawnableList<R> + Send + Sync + 'static> BundleImpl
     for SpawnRelatedBundle<R, L>
 {
-    type Name = <R::RelationshipTarget as Bundle>::Name;
+    type Name = <R::RelationshipTarget as BundleImpl>::Name;
     fn component_ids(
         components: &mut crate::component::ComponentsRegistrator,
         ids: &mut impl FnMut(crate::component::ComponentId),
     ) {
-        <R::RelationshipTarget as Bundle>::component_ids(components, ids);
+        <R::RelationshipTarget as BundleImpl>::component_ids(components, ids);
     }
 
     fn get_component_ids(
         components: &crate::component::Components,
         ids: &mut impl FnMut(Option<crate::component::ComponentId>),
     ) {
-        <R::RelationshipTarget as Bundle>::get_component_ids(components, ids);
+        <R::RelationshipTarget as BundleImpl>::get_component_ids(components, ids);
     }
 }
 
@@ -402,20 +402,20 @@ impl<R: Relationship, B: Bundle> DynamicBundle for SpawnOneRelated<R, B> {
 }
 
 // SAFETY: This internally relies on the RelationshipTarget's Bundle implementation, which is sound.
-unsafe impl<R: Relationship, B: Bundle> Bundle for SpawnOneRelated<R, B> {
-    type Name = <R::RelationshipTarget as Bundle>::Name;
+unsafe impl<R: Relationship, B: Bundle> BundleImpl for SpawnOneRelated<R, B> {
+    type Name = <R::RelationshipTarget as BundleImpl>::Name;
     fn component_ids(
         components: &mut crate::component::ComponentsRegistrator,
         ids: &mut impl FnMut(crate::component::ComponentId),
     ) {
-        <R::RelationshipTarget as Bundle>::component_ids(components, ids);
+        <R::RelationshipTarget as BundleImpl>::component_ids(components, ids);
     }
 
     fn get_component_ids(
         components: &crate::component::Components,
         ids: &mut impl FnMut(Option<crate::component::ComponentId>),
     ) {
-        <R::RelationshipTarget as Bundle>::get_component_ids(components, ids);
+        <R::RelationshipTarget as BundleImpl>::get_component_ids(components, ids);
     }
 }
 

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -1129,7 +1129,9 @@ mod tests {
                 let archetype = archetypes.get(location.archetype_id).unwrap();
                 let archetype_components = archetype.components();
                 let bundle_id = bundles
-                    .get_id(TypeId::of::<(W<i32>, W<bool>)>())
+                    .get_id(TypeId::of::<
+                        <(W<i32>, W<bool>) as crate::bundle::Bundle>::Name,
+                    >())
                     .expect("Bundle used to spawn entity should exist");
                 let bundle_info = bundles.get(bundle_id).unwrap();
                 let mut bundle_components = bundle_info.contributed_components().to_vec();

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -403,7 +403,7 @@ mod tests {
 
     use crate::{
         archetype::Archetypes,
-        bundle::Bundles,
+        bundle::{bundle_id_of, Bundles},
         change_detection::DetectChanges,
         component::{Component, Components},
         entity::{Entities, Entity},
@@ -1129,9 +1129,7 @@ mod tests {
                 let archetype = archetypes.get(location.archetype_id).unwrap();
                 let archetype_components = archetype.components();
                 let bundle_id = bundles
-                    .get_id(TypeId::of::<
-                        <(W<i32>, W<bool>) as crate::bundle::Bundle>::Name,
-                    >())
+                    .get_id(bundle_id_of::<(W<i32>, W<bool>)>())
                     .expect("Bundle used to spawn entity should exist");
                 let bundle_info = bundles.get(bundle_id).unwrap();
                 let mut bundle_components = bundle_info.contributed_components().to_vec();

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -32,8 +32,8 @@ pub use spawn_batch::*;
 use crate::{
     archetype::{ArchetypeId, Archetypes},
     bundle::{
-        Bundle, BundleId, BundleInfo, BundleInserter, BundleSpawner, Bundles, InsertMode,
-        NoBundleEffect,
+        Bundle, BundleId, BundleImpl, BundleInfo, BundleInserter, BundleSpawner, Bundles,
+        InsertMode, NoBundleEffect,
     },
     change_detection::{MaybeLocation, MutUntyped, TicksMut},
     component::{
@@ -1156,7 +1156,7 @@ impl World {
         self.spawn_with_caller(bundle, MaybeLocation::caller())
     }
 
-    pub(crate) fn spawn_with_caller<B: Bundle>(
+    pub(crate) fn spawn_with_caller<B: BundleImpl>(
         &mut self,
         bundle: MovingPtr<'_, B>,
         caller: MaybeLocation,
@@ -3085,14 +3085,14 @@ impl World {
     /// This is largely equivalent to calling [`register_component`](Self::register_component) on each
     /// component in the bundle.
     #[inline]
-    pub fn register_bundle<B: Bundle>(&mut self) -> &BundleInfo {
+    pub fn register_bundle<B: BundleImpl>(&mut self) -> &BundleInfo {
         let id = self.register_bundle_info::<B>();
 
         // SAFETY: We just initialized the bundle so its id should definitely be valid.
         unsafe { self.bundles.get(id).debug_checked_unwrap() }
     }
 
-    pub(crate) fn register_bundle_info<B: Bundle>(&mut self) -> BundleId {
+    pub(crate) fn register_bundle_info<B: BundleImpl>(&mut self) -> BundleId {
         // SAFETY: These come from the same world. `Self.components_registrator` can't be used since we borrow other fields too.
         let mut registrator =
             unsafe { ComponentsRegistrator::new(&mut self.components, &mut self.component_ids) };

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -805,6 +805,9 @@ impl<T, A: IsAligned> Drop for MovingPtr<'_, T, A> {
     }
 }
 
+unsafe impl<T: Send, A: IsAligned> Send for MovingPtr<'_, T, A> {}
+unsafe impl<T: Sync, A: IsAligned> Sync for MovingPtr<'_, T, A> {}
+
 impl<'a, A: IsAligned> Ptr<'a, A> {
     /// Creates a new instance from a raw pointer.
     ///


### PR DESCRIPTION
relevant issue: #20976

## Solution
In order to spawn bundles inside `MovingPtr`s alongside other bundles, we need to be able to name `MovingPtr` as a bundle, which the new associated type `Name` on `Bundle` allows. This type is basically a canonicalized bundle name-type that allows types like `SpawnRelatedBundle` to appear to the `Bundles` as if they were the bundle they are wrapping: `R::RelationshipTarget`. (I need to write tests for this).

Other parts of the engine, like observers, rely on `Bundle` being `'static` in order to pass around the type without being constrained by lifetimes, which is why I've renamed `Bundle` to `BundleImpl` and made `trait Bundle: BundleImpl + 'static`.
Not sure how much I like this personally. 
Observers only use the associated trait functions of `Bundle` which shouldn't be affected by the lifetime of the type implementing `Bundle` (I think).
An alternative would be to enforce `Bundle::Name` to impl Bundle itself (which it does, since it's just a tuple of bundles) and have the same components/component order as `Self` so that `Bundle`s methods are available `'static` (though using `DynamicBundle` this way would certainly be unsafe). That could allow types carrying `Bundles` in phantom datas to use the associated functions for component order and ids.

