### PR TITLE
Warn when schedule set is empty

### DIFF
--- a/crates/bevy_ecs/src/schedule/error.rs
+++ b/crates/bevy_ecs/src/schedule/error.rs
@@ -70,8 +70,8 @@ pub enum ScheduleBuildWarning {
     Ambiguity(Vec<(SystemKey, SystemKey, Vec<ComponentId>)>),
     /// The system set contains no systems.
     ///
-    /// This warning is **enabled** by default, but can be disabled by setting
-    /// [`ScheduleBuildSettings::empty_set_detection`] to `false`].
+    /// This warning is **disabled** by default, but can be enabled by setting
+    /// [`ScheduleBuildSettings::empty_set_detection`] to `true`].
     ///
     /// [`ScheduleBuildSettings::empty_set_detection`]: crate::schedule::ScheduleBuildSettings::empty_set_detection
     #[error("The system set contains no systems: {0:?}")]

--- a/crates/bevy_ecs/src/schedule/error.rs
+++ b/crates/bevy_ecs/src/schedule/error.rs
@@ -71,12 +71,9 @@ pub enum ScheduleBuildWarning {
     /// The system set contains no systems.
     ///
     /// This warning is **enabled** by default, but can be disabled by setting
-    /// [`ScheduleBuildSettings::hierarchy_detection`] to [`LogLevel::Ignore`]
-    /// or upgraded to a [`ScheduleBuildError`] by setting it to [`LogLevel::Error`].
+    /// [`ScheduleBuildSettings::empty_set_detection`] to `false`].
     ///
-    /// [`ScheduleBuildSettings::hierarchy_detection`]: crate::schedule::ScheduleBuildSettings::hierarchy_detection
-    /// [`LogLevel::Ignore`]: crate::schedule::LogLevel::Ignore
-    /// [`LogLevel::Error`]: crate::schedule::LogLevel::Error
+    /// [`ScheduleBuildSettings::empty_set_detection`]: crate::schedule::ScheduleBuildSettings::empty_set_detection
     #[error("The system set contains no systems: {0:?}")]
     EmptySet(NodeId),
 }

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -710,7 +710,7 @@ mod tests {
         }
 
         #[test]
-        fn empty_set_check() {
+        fn empty_set() {
             let mut world = World::new();
             let mut schedule = Schedule::default();
 
@@ -722,7 +722,47 @@ mod tests {
             // Add `A`.
             schedule.configure_sets(TestSystems::A);
 
-            // schedule.configure_sets((TestSystems::B,TestSystems::C).chain());
+            _ = schedule.initialize(&mut world);
+            let warnings = schedule.warnings();
+
+            assert!(matches!(warnings[0], ScheduleBuildWarning::EmptySet(_)));
+        }
+
+        #[test]
+        fn empty_set_with_edges() {
+            let mut world = World::new();
+            let mut schedule = Schedule::default();
+
+            schedule.set_build_settings(ScheduleBuildSettings {
+                empty_set_detection: true,
+                ..Default::default()
+            });
+
+            // Add `A`.
+            schedule.configure_sets(TestSystems::A.after(TestSystems::B));
+
+            _ = schedule.initialize(&mut world);
+            let warnings = schedule.warnings();
+
+            assert!(matches!(warnings[0], ScheduleBuildWarning::EmptySet(_)));
+        }
+
+        #[test]
+        fn empty_set_with_condition() {
+            let mut world = World::new();
+            let mut schedule = Schedule::default();
+
+            schedule.set_build_settings(ScheduleBuildSettings {
+                empty_set_detection: true,
+                ..Default::default()
+            });
+
+            fn true_condition() -> bool {
+                true
+            }
+
+            // Add `A`.
+            schedule.configure_sets(TestSystems::A.run_if(true_condition));
 
             _ = schedule.initialize(&mut world);
             let warnings = schedule.warnings();

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -771,6 +771,27 @@ mod tests {
         }
 
         #[test]
+        fn empty_set_with_system() {
+            let mut world = World::new();
+            let mut schedule = Schedule::default();
+
+            schedule.set_build_settings(ScheduleBuildSettings {
+                empty_set_detection: true,
+                ..Default::default()
+            });
+
+            fn system() {}
+
+            // Add `A`.
+            schedule.add_systems(system.in_set(TestSystems::A));
+
+            _ = schedule.initialize(&mut world);
+            let warnings = schedule.warnings();
+
+            assert!(warnings.is_empty());
+        }
+
+        #[test]
         fn cross_dependency() {
             let mut world = World::new();
             let mut schedule = Schedule::default();

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -710,6 +710,27 @@ mod tests {
         }
 
         #[test]
+        fn empty_set_check() {
+            let mut world = World::new();
+            let mut schedule = Schedule::default();
+
+            schedule.set_build_settings(ScheduleBuildSettings {
+                empty_set_detection: true,
+                ..Default::default()
+            });
+
+            // Add `A`.
+            schedule.configure_sets(TestSystems::A);
+
+            // schedule.configure_sets((TestSystems::B,TestSystems::C).chain());
+
+            _ = schedule.initialize(&mut world);
+            let warnings = schedule.warnings();
+
+            assert!(matches!(warnings[0], ScheduleBuildWarning::EmptySet(_)));
+        }
+
+        #[test]
         fn cross_dependency() {
             let mut world = World::new();
             let mut schedule = Schedule::default();

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -1764,7 +1764,7 @@ impl ScheduleBuildSettings {
         Self {
             ambiguity_detection: LogLevel::Ignore,
             hierarchy_detection: LogLevel::Warn,
-            empty_set_detection: true,
+            empty_set_detection: false,
             auto_insert_apply_deferred: true,
             use_shortnames: true,
             report_sets: true,

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -1000,8 +1000,11 @@ impl ScheduleGraph {
 
         // map all system sets to their systems
         // go in reverse topological order (bottom-up) for efficiency
-        let (set_systems, set_system_bitsets) =
-            self.map_sets_to_systems(&self.hierarchy.topsort, &self.hierarchy.graph);
+        let (set_systems, set_system_bitsets) = self.map_sets_to_systems(
+            &self.hierarchy.topsort,
+            &self.hierarchy.graph,
+            &mut warnings,
+        );
         self.check_order_but_intersect(&dep_results.connected, &set_system_bitsets)?;
 
         // check that there are no edges to system-type sets that have multiple instances
@@ -1058,6 +1061,7 @@ impl ScheduleGraph {
         &self,
         hierarchy_topsort: &[NodeId],
         hierarchy_graph: &DiGraph<NodeId>,
+        warnings: &mut Vec<ScheduleBuildWarning>,
     ) -> (
         HashMap<SystemSetKey, Vec<SystemKey>>,
         HashMap<SystemSetKey, HashSet<SystemKey>>,
@@ -1087,6 +1091,10 @@ impl ScheduleGraph {
                         system_set.extend(child_system_set.iter());
                     }
                 }
+            }
+
+            if self.settings.empty_set_detection && systems.is_empty() {
+                warnings.push(ScheduleBuildWarning::EmptySet(id));
             }
 
             set_systems.insert(set_key, systems);
@@ -1719,6 +1727,10 @@ pub struct ScheduleBuildSettings {
     ///
     /// Defaults to [`LogLevel::Warn`].
     pub hierarchy_detection: LogLevel,
+    /// If set to `true`, warnings will be emitted if any system set contains no systems.
+    ///
+    /// Defaults to `true`.
+    pub empty_set_detection: bool,
     /// Auto insert [`ApplyDeferred`] systems into the schedule,
     /// when there are [`Deferred`](crate::prelude::Deferred)
     /// in one system and there are ordering dependencies on that system. [`Commands`](crate::system::Commands) is one
@@ -1752,6 +1764,7 @@ impl ScheduleBuildSettings {
         Self {
             ambiguity_detection: LogLevel::Ignore,
             hierarchy_detection: LogLevel::Warn,
+            empty_set_detection: true,
             auto_insert_apply_deferred: true,
             use_shortnames: true,
             report_sets: true,


### PR DESCRIPTION
# Objective
addresses #19979


## Solution
- Add `ScheduleBuildWarning` for empty sets
- When updating schedules, check that each set contains at least one system, and emit a warning if not.

## Testing

I've added 4 tests testing different configurations of system sets.

## Open Questions
Should this be a boolean configuration or a `LogLevel` like the other `ScheduleBuildWarnings`?