### PR TITLE
Make specialization cache cleanup respect material swaps

### DIFF
--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -804,9 +804,12 @@ pub fn extract_entities_needs_specialization<M>(
     // so that the `RenderMaterialInstances` bookkeeping has already been done, and we can check if the entity
     // still has a valid material instance.
     for entity in removed_mesh_material_components.read() {
-       if material_instances.instances.contains_key(&MainEntity::from(entity)) {
+        if material_instances
+            .instances
+            .contains_key(&MainEntity::from(entity))
+        {
             continue;
-       }
+        }
 
         entity_specialization_ticks.remove(&MainEntity::from(entity));
         for view in views {

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -34,7 +34,6 @@ use bevy_platform::collections::{HashMap, HashSet};
 use bevy_platform::hash::FixedHasher;
 use bevy_reflect::std_traits::ReflectDefault;
 use bevy_reflect::Reflect;
-use bevy_render::camera::extract_cameras;
 use bevy_render::erased_render_asset::{
     ErasedRenderAsset, ErasedRenderAssetPlugin, ErasedRenderAssets, PrepareAssetError,
 };

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -34,6 +34,7 @@ use bevy_platform::collections::{HashMap, HashSet};
 use bevy_platform::hash::FixedHasher;
 use bevy_reflect::std_traits::ReflectDefault;
 use bevy_reflect::Reflect;
+use bevy_render::camera::extract_cameras;
 use bevy_render::erased_render_asset::{
     ErasedRenderAsset, ErasedRenderAssetPlugin, ErasedRenderAssets, PrepareAssetError,
 };
@@ -390,7 +391,9 @@ where
                         early_sweep_material_instances::<M>
                             .after(MaterialExtractionSystems)
                             .before(late_sweep_material_instances),
-                        extract_entities_needs_specialization::<M>.after(MaterialExtractionSystems),
+                        extract_entities_needs_specialization::<M>
+                            .after(extract_cameras)
+                            .after(MaterialExtractionSystems),
                     ),
                 );
         }

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -391,7 +391,7 @@ where
                         early_sweep_material_instances::<M>
                             .after(MaterialExtractionSystems)
                             .before(late_sweep_material_instances),
-                        extract_entities_needs_specialization::<M>.after(extract_cameras),
+                        extract_entities_needs_specialization::<M>.after(MaterialExtractionSystems),
                     ),
                 );
         }
@@ -779,6 +779,7 @@ pub(crate) fn late_sweep_material_instances(
 
 pub fn extract_entities_needs_specialization<M>(
     entities_needing_specialization: Extract<Res<EntitiesNeedingSpecialization<M>>>,
+    material_instances: Res<RenderMaterialInstances>,
     mut entity_specialization_ticks: ResMut<EntitySpecializationTicks>,
     mut removed_mesh_material_components: Extract<RemovedComponents<MeshMaterial3d<M>>>,
     mut specialized_material_pipeline_cache: ResMut<SpecializedMaterialPipelineCache>,
@@ -796,7 +797,17 @@ pub fn extract_entities_needs_specialization<M>(
     // Clean up any despawned entities, we do this first in case the removed material was re-added
     // the same frame, thus will appear both in the removed components list and have been added to
     // the `EntitiesNeedingSpecialization` collection by triggering the `Changed` filter
+    //
+    // Additionally, we need to make sure that we are careful about materials that could have changed
+    // type, e.g. from a `StandardMaterial` to a `CustomMaterial`, as this will also appear in the
+    // removed components list. As such, we make sure that this system runs after `MaterialExtractionSystems`
+    // so that the `RenderMaterialInstances` bookkeeping has already been done, and we can check if the entity
+    // still has a valid material instance.
     for entity in removed_mesh_material_components.read() {
+       if material_instances.instances.contains_key(&MainEntity::from(entity)) {
+            continue;
+       }
+
         entity_specialization_ticks.remove(&MainEntity::from(entity));
         for view in views {
             if let Some(cache) =


### PR DESCRIPTION
# Objective

Swapping material types can break specialization caches.

Fixes #20992.

## Solution

Make sure that type erased bookkeeping (i.e. `RenderMaterialInstances`) runs first so that we can know whether the material was actually removed or just swapped.

## Testing

Example in #20992. Tested also with 2d and didn't seem to be an issue there.