### PR TITLE
Add deprecated EntityCommands::trigger and EntityWorldMut::trigger

### DIFF
--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -2258,6 +2258,21 @@ impl<'a> EntityCommands<'a> {
     pub fn move_components<B: Bundle>(&mut self, target: Entity) -> &mut Self {
         self.queue(entity_command::move_components::<B>(target))
     }
+
+    /// Deprecated. Use [`Commands::trigger`] instead.
+    #[track_caller]
+    #[deprecated(
+        since = "0.17.0",
+        note = "Use Commands::trigger with an EntityEvent instead."
+    )]
+    pub fn trigger<'t, E: EntityEvent>(
+        &mut self,
+        event: impl EntityEvent<Trigger<'t>: Default>,
+    ) -> &mut Self {
+        log::warn!("EntityCommands::trigger is deprecated and no longer triggers the event for the current EntityCommands entity. Use Commands::trigger instead with an EntityEvent.");
+        self.commands.trigger(event);
+        self
+    }
 }
 
 /// A wrapper around [`EntityCommands`] with convenience methods for working with a specified component type.

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -3159,6 +3159,20 @@ impl<'w> EntityWorldMut<'w> {
             })
         })
     }
+
+    /// Deprecated. Use [`World::trigger`] instead.
+    #[track_caller]
+    #[deprecated(
+        since = "0.17.0",
+        note = "Use World::trigger with an EntityEvent instead."
+    )]
+    pub fn trigger<'t>(&mut self, event: impl EntityEvent<Trigger<'t>: Default>) -> &mut Self {
+        log::warn!("EntityWorldMut::trigger is deprecated and no longer triggers the event for the current EntityWorldMut entity. Use World::trigger instead with an EntityEvent.");
+        self.world_scope(|world| {
+            world.trigger(event);
+        });
+        self
+    }
 }
 
 /// A view into a single entity and component in a world, which may either be vacant or occupied.


### PR DESCRIPTION
# Objective

These methods were removed in #20731. It is more helpful to deprecate them.

## Solution

- Re-add them, and print a warning that they no longer fire for the current entity.