### PR TITLE
Gave bevy::app::App the must_use attribute

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -77,6 +77,7 @@ pub(crate) enum AppError {
 ///    println!("hello world");
 /// }
 /// ```
+#[must_use]
 pub struct App {
     pub(crate) sub_apps: SubApps,
     /// The function that will manage the app's lifecycle.


### PR DESCRIPTION
# Objective

Attempts #5386

## Solution

Added the `must_use` attribute to `bevy::app::App` 

## Testing

I tested it by linking the library to another cargo package and calling App::new() without using the return value.

(this is my first pr, so i just chose something very easy.)
