### PR TITLE
Automatically add Send + Sync + 'static bounds to Event / EntityEvent derives

### DIFF
--- a/crates/bevy_ecs/macros/src/event.rs
+++ b/crates/bevy_ecs/macros/src/event.rs
@@ -15,8 +15,13 @@ pub const TRIGGER: &str = "trigger";
 pub const EVENT_TARGET: &str = "event_target";
 
 pub fn derive_event(input: TokenStream) -> TokenStream {
-    let ast = parse_macro_input!(input as DeriveInput);
+    let mut ast = parse_macro_input!(input as DeriveInput);
     let bevy_ecs_path: Path = crate::bevy_ecs_path();
+
+    ast.generics
+        .make_where_clause()
+        .predicates
+        .push(parse_quote! { Self: Send + Sync + 'static });
 
     let mut processed_attrs = Vec::new();
     let mut trigger: Option<Type> = None;
@@ -55,7 +60,13 @@ pub fn derive_event(input: TokenStream) -> TokenStream {
 }
 
 pub fn derive_entity_event(input: TokenStream) -> TokenStream {
-    let ast = parse_macro_input!(input as DeriveInput);
+    let mut ast = parse_macro_input!(input as DeriveInput);
+
+    ast.generics
+        .make_where_clause()
+        .predicates
+        .push(parse_quote! { Self: Send + Sync + 'static });
+
     let mut auto_propagate = false;
     let mut propagate = false;
     let mut traversal: Option<Type> = None;


### PR DESCRIPTION
# Objective

The Event derive used to add these bounds on behalf of developers, but the new macros in #20731 don't do that. This removed the need for developers to specify the bounds themselves for Events that use generics.

## Solution

Automatically add `Self: Send + Sync + 'static` bounds to the `Event` and `EntityEvent` derives
