### PR TITLE
SpawnDetails::spawned_at -> spawn_tick

### DIFF
--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -555,7 +555,7 @@ impl ReleaseStateQueryData for EntityLocation {
 ///         print!(
 ///             "entity {:?} spawned at {:?}",
 ///             entity,
-///             spawn_details.spawned_at()
+///             spawn_details.spawn_tick()
 ///         );
 ///         match spawn_details.spawned_by().into_option() {
 ///             Some(location) => println!(" by {:?}", location),
@@ -569,7 +569,7 @@ impl ReleaseStateQueryData for EntityLocation {
 #[derive(Clone, Copy, Debug)]
 pub struct SpawnDetails {
     spawned_by: MaybeLocation,
-    spawned_at: Tick,
+    spawn_tick: Tick,
     last_run: Tick,
     this_run: Tick,
 }
@@ -578,12 +578,12 @@ impl SpawnDetails {
     /// Returns `true` if the entity spawned since the last time this system ran.
     /// Otherwise, returns `false`.
     pub fn is_spawned(self) -> bool {
-        self.spawned_at.is_newer_than(self.last_run, self.this_run)
+        self.spawn_tick.is_newer_than(self.last_run, self.this_run)
     }
 
     /// Returns the `Tick` this entity spawned at.
-    pub fn spawned_at(self) -> Tick {
-        self.spawned_at
+    pub fn spawn_tick(self) -> Tick {
+        self.spawn_tick
     }
 
     /// Returns the source code location from which this entity has been spawned.
@@ -680,14 +680,14 @@ unsafe impl QueryData for SpawnDetails {
         _table_row: TableRow,
     ) -> Self::Item<'w, 's> {
         // SAFETY: only living entities are queried
-        let (spawned_by, spawned_at) = unsafe {
+        let (spawned_by, spawn_tick) = unsafe {
             fetch
                 .entities
                 .entity_get_spawned_or_despawned_unchecked(entity)
         };
         Self {
             spawned_by,
-            spawned_at,
+            spawn_tick,
             last_run: fetch.last_run,
             this_run: fetch.this_run,
         }

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -2807,7 +2807,7 @@ mod tests {
         world.flush();
         assert_eq!(
             Some(expected),
-            world.entities().entity_get_spawned_or_despawned_at(id)
+            world.entities().entity_get_spawn_or_despawn_tick(id)
         );
     }
 }

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -1336,7 +1336,7 @@ mod tests {
             SystemState::new(&mut world);
         {
             let query = system_state.get(&world);
-            assert_eq!(query.unwrap().spawned_at(), spawn_tick);
+            assert_eq!(query.unwrap().spawn_tick(), spawn_tick);
         }
 
         {

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -298,8 +298,8 @@ impl<'w> EntityRef<'w> {
     }
 
     /// Returns the [`Tick`] at which this entity has been spawned.
-    pub fn spawned_at(&self) -> Tick {
-        self.cell.spawned_at()
+    pub fn spawn_tick(&self) -> Tick {
+        self.cell.spawn_tick()
     }
 }
 
@@ -1065,8 +1065,8 @@ impl<'w> EntityMut<'w> {
     }
 
     /// Returns the [`Tick`] at which this entity has been spawned.
-    pub fn spawned_at(&self) -> Tick {
-        self.cell.spawned_at()
+    pub fn spawn_tick(&self) -> Tick {
+        self.cell.spawn_tick()
     }
 }
 
@@ -3132,7 +3132,7 @@ impl<'w> EntityWorldMut<'w> {
     }
 
     /// Returns the [`Tick`] at which this entity has last been spawned.
-    pub fn spawned_at(&self) -> Tick {
+    pub fn spawn_tick(&self) -> Tick {
         self.assert_not_despawned();
 
         // SAFETY: entity being alive was asserted
@@ -3679,8 +3679,8 @@ impl<'w, 's> FilteredEntityRef<'w, 's> {
     }
 
     /// Returns the [`Tick`] at which this entity has been spawned.
-    pub fn spawned_at(&self) -> Tick {
-        self.entity.spawned_at()
+    pub fn spawn_tick(&self) -> Tick {
+        self.entity.spawn_tick()
     }
 }
 
@@ -4041,8 +4041,8 @@ impl<'w, 's> FilteredEntityMut<'w, 's> {
     }
 
     /// Returns the [`Tick`] at which this entity has been spawned.
-    pub fn spawned_at(&self) -> Tick {
-        self.entity.spawned_at()
+    pub fn spawn_tick(&self) -> Tick {
+        self.entity.spawn_tick()
     }
 }
 
@@ -4225,8 +4225,8 @@ where
     }
 
     /// Returns the [`Tick`] at which this entity has been spawned.
-    pub fn spawned_at(&self) -> Tick {
-        self.entity.spawned_at()
+    pub fn spawn_tick(&self) -> Tick {
+        self.entity.spawn_tick()
     }
 
     /// Gets the component of the given [`ComponentId`] from the entity.
@@ -4480,8 +4480,8 @@ where
     }
 
     /// Returns the [`Tick`] at which this entity has been spawned.
-    pub fn spawned_at(&self) -> Tick {
-        self.entity.spawned_at()
+    pub fn spawn_tick(&self) -> Tick {
+        self.entity.spawn_tick()
     }
 
     /// Returns `true` if the current entity has a component of type `T`.
@@ -6399,7 +6399,7 @@ mod tests {
                     .map(|l| l.unwrap());
                 let at = world
                     .entities
-                    .entity_get_spawned_or_despawned_at(entity)
+                    .entity_get_spawn_or_despawn_tick(entity)
                     .unwrap();
                 (by, at)
             });
@@ -6439,7 +6439,7 @@ mod tests {
             despawn_tick,
             world
                 .entities()
-                .entity_get_spawned_or_despawned_at(entity)
+                .entity_get_spawn_or_despawn_tick(entity)
                 .unwrap()
         );
     }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -4381,7 +4381,7 @@ mod tests {
             MaybeLocation::new(Some(Location::caller()))
         );
         assert_eq!(
-            world.entities.entity_get_spawned_or_despawned_at(entity),
+            world.entities.entity_get_spawn_or_despawn_tick(entity),
             Some(world.change_tick())
         );
         world.despawn(entity);
@@ -4390,7 +4390,7 @@ mod tests {
             MaybeLocation::new(Some(Location::caller()))
         );
         assert_eq!(
-            world.entities.entity_get_spawned_or_despawned_at(entity),
+            world.entities.entity_get_spawn_or_despawn_tick(entity),
             Some(world.change_tick())
         );
         let new = world.spawn_empty().id();
@@ -4400,7 +4400,7 @@ mod tests {
             MaybeLocation::new(None)
         );
         assert_eq!(
-            world.entities.entity_get_spawned_or_despawned_at(entity),
+            world.entities.entity_get_spawn_or_despawn_tick(entity),
             None
         );
         world.despawn(new);
@@ -4409,7 +4409,7 @@ mod tests {
             MaybeLocation::new(None)
         );
         assert_eq!(
-            world.entities.entity_get_spawned_or_despawned_at(entity),
+            world.entities.entity_get_spawn_or_despawn_tick(entity),
             None
         );
     }

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -1166,7 +1166,7 @@ impl<'w> UnsafeEntityCell<'w> {
     }
 
     /// Returns the [`Tick`] at which this entity has been spawned.
-    pub fn spawned_at(self) -> Tick {
+    pub fn spawn_tick(self) -> Tick {
         // SAFETY: UnsafeEntityCell is only constructed for living entities and offers no despawn method
         unsafe {
             self.world()


### PR DESCRIPTION
# Objective

We don't normally use the `spawned_at` naming convention in Bevy  (with `spawned_at_TICK` being implied). `spawned_at` violates that convention.

## Solution

Rename `spawned_at` to `spawn_tick`, and all associated getter + internals. I've done the release notes update in my current editorial pass.
