### PR TITLE
Mark meshes as changed *after* AssetEvents are processed.

### DIFF
--- a/crates/bevy_mesh/src/lib.rs
+++ b/crates/bevy_mesh/src/lib.rs
@@ -54,7 +54,7 @@ impl Plugin for MeshPlugin {
             .register_asset_reflect::<Mesh>()
             .add_systems(
                 PostUpdate,
-                mark_3d_meshes_as_changed_if_their_assets_changed.before(AssetEventSystems),
+                mark_3d_meshes_as_changed_if_their_assets_changed.after(AssetEventSystems),
             );
     }
 }


### PR DESCRIPTION
Whenever a Mesh asset is modified, bevy needs to mark entities which include a matching `Mesh3D` component as Changed.  The need for this is explained on the comment for system `mark_3d_meshes_as_changed_if_their_assets_changed`, which performs this action:

> This is needed because the systems that extract meshes, such as
> `extract_meshes_for_gpu_building`, write some metadata about the mesh (like
> the location within each slab) into the GPU structures that they build that
> needs to be kept up to date if the contents of the mesh change.

However, this system use EventReader<AssetEvent<Mesh>> to detect this, but was scheduled *before* AssetEvents are processed for the frame. This created a one-frame delay in the update, which was causing the "mesh flickering" in #19409 - a result of using the previous model's vertex and index offsets against the newly updated mesh buffers.


# Objective

- Fixes #19409

## Solution

- Fix is to schedule this system *after* AssetEvents are processed for the frame.

## Testing

- Had a perfectly consistent graphical reproduction of the situation: Updating a mesh which is being displayed by an entity, and making it significantly *larger* in vertex count, triggers this reliably - the mesh will be significantly *underdrawn* for one frame.
