### PR TITLE
Update documentation to reflect four cameras in split screen

### DIFF
--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -1,4 +1,4 @@
-//! Renders two cameras to the same window to accomplish "split screen".
+//! Renders four cameras to the same window to accomplish "split screen".
 
 use std::f32::consts::PI;
 


### PR DESCRIPTION
Doc comment at the top of the file states that the example renders two cameras but the code renders four cameras.

# Objective

- Update doc comment to reflect the actual implementation

## Solution

- Update doc comment to reflect the actual implementation

## Testing
- cargo run --example split_screen
- cargo doc --examples --open
