### PR TITLE
Document missing brp methods

### DIFF
--- a/crates/bevy_remote/src/lib.rs
+++ b/crates/bevy_remote/src/lib.rs
@@ -153,7 +153,7 @@
 //! - `has`: A map associating each type name from `has` to a boolean value indicating whether or not the
 //!   entity has that component. If `has` was empty or omitted, this key will be omitted in the response.
 //!
-//! ### Example
+//! #### Example
 //! To use the query API and retrieve Transform data for all entities that have a Transform
 //! use this query:
 //!
@@ -454,6 +454,32 @@
 //! List all reflectable registered resource types. This method has no parameters.
 //!
 //! `result`: An array of [fully-qualified type names] of registered resource types.
+//!
+//! ### `registry.schema`
+//!
+//! Retrieve schema information about registered types in the Bevy app's type registry.
+//!
+//! `params` (optional):
+//! - `with_crates`: An array of crate names to include in the results. If non-empty, only types from these crates will be included.
+//! - `without_crates`: An array of crate names to exclude from the results. If non-empty, types from these crates will be excluded.
+//! - `type_limit`: Additional type constraints:
+//!   - `with`: An array of reflect type names that must be present for a type to be included
+//!   - `without`: An array of reflect type names that must not be present for a type to be excluded
+//!
+//! `result`: A map associating each type's [fully-qualified type names] with [JsonSchemaBevyType](crate::schemas::json_schema::JsonSchemaBevyType)
+//! which contains schema information about that type, including field definitions, type information, reflect type information, and other metadata
+//! helpful for understanding the structure of the type.
+//!
+//! ### `rpc.discover`
+//!
+//! Discover available remote methods and server information. This follows the OpenRPC specification for service discovery.
+//!
+//! This method takes no parameters.
+//!
+//! `result`: An OpenRPC document containing:
+//! - Information about all available remote methods
+//! - Server connection information (when using HTTP transport)
+//! - OpenRPC specification version
 //!
 //! ## Custom methods
 //!


### PR DESCRIPTION
# Objective

Document missing brp methods:
- `registry.schema`
- `rpc.discover`

## Solution

- Update crate-level documentation

## Testing

- `cargo doc -p bevy_remote`