### PR TITLE
Make `On` documentation more friendly

### DIFF
--- a/crates/bevy_ecs/src/observer/system_param.rs
+++ b/crates/bevy_ecs/src/observer/system_param.rs
@@ -14,11 +14,13 @@ use core::{
     ops::{Deref, DerefMut},
 };
 
-/// Type containing triggered [`Event`] information for a given run of an [`Observer`]. This contains the
-/// [`Event`] data itself. It also provides access to the [`Trigger`](crate::event::Trigger), which for things like
-/// [`EntityEvent`] with a [`PropagateEntityTrigger`], includes control over event propagation.
+/// A [system parameter] used by an observer to process events. See [`Observer`] and [`Event`] for examples.
 ///
-/// The generic `B: Bundle` is used to modify the further specialize the events that this observer is interested in.
+/// `On` contains the triggered [`Event`] data for a given run of an `Observer`. It also provides access to the
+/// [`Trigger`](crate::event::Trigger), which for things like [`EntityEvent`] with a [`PropagateEntityTrigger`],
+/// includes control over event propagation.
+///
+/// The generic `B: Bundle` is used to further specialize the events that this observer is interested in.
 /// The entity involved *does not* have to have these components, but the observer will only be
 /// triggered if the event matches the components in `B`.
 ///
@@ -28,6 +30,8 @@ use core::{
 /// Providing multiple components in this bundle will cause this event to be triggered by any
 /// matching component in the bundle,
 /// [rather than requiring all of them to be present](https://github.com/bevyengine/bevy/issues/15325).
+///
+/// [system parameter]: crate::system::SystemParam
 // SAFETY WARNING!
 // this type must _never_ expose anything with the 'w lifetime
 // See the safety discussion on `Trigger` for more details.


### PR DESCRIPTION
## Objective

While updating a crate to Bevy 0.17 I found myself confused about how to use the `On` system parameter - the documentation seemed a bit low-level, and I didn't realise that there were examples behind some links.

## Solution

This PR adds a brief description and explicitly links to examples. It also fixes what looks like an editing error:

```diff
-/// The generic `B: Bundle` is used to modify the further specialize the events that this observer is interested in.
+/// The generic `B: Bundle` is used to further specialize the events that this observer is interested in.
```

<img width="1246" height="538" alt="image" src="https://github.com/user-attachments/assets/200183fc-f0b2-4f1e-835b-eb6ab1a47b78" />

