### PR TITLE
enable bevy_sprite_render when enabling bevy_sprite for bevy_gizmos

### DIFF
--- a/crates/bevy_gizmos/Cargo.toml
+++ b/crates/bevy_gizmos/Cargo.toml
@@ -12,6 +12,8 @@ keywords = ["bevy"]
 webgl = []
 webgpu = []
 bevy_render = ["dep:bevy_render", "bevy_core_pipeline"]
+bevy_sprite = ["dep:bevy_sprite", "bevy_sprite_render"]
+bevy_sprite_render = ["dep:bevy_sprite_render"]
 
 [dependencies]
 # Bevy


### PR DESCRIPTION
# Objective
fixes #21008

## Solution
`bevy_gizmos` enables the `pipeline_2d` mod and plugin when `bevy_sprite` and `bevy_render` features are enabled, but `pipeline_2d` also imports `bevy_sprite_render`. Since `bevy_sprite_render` is only used together with `bevy_sprite` and `bevy_sprite` isn't otherwise used, I think it makes sense to automatically enable `bevy_sprite_render` together with `bevy_sprite`

## Alternative Solutions
`bevy_sprite_render` could be enabled by `bevy_render`, which already enables `bevy_core_pipeline`