### PR TITLE
fps overlay: text node display none if disable

### DIFF
--- a/crates/bevy_dev_tools/src/fps_overlay.rs
+++ b/crates/bevy_dev_tools/src/fps_overlay.rs
@@ -2,18 +2,16 @@
 
 use bevy_app::{Plugin, Startup, Update};
 use bevy_asset::{Assets, Handle};
-use bevy_camera::visibility::Visibility;
 use bevy_color::Color;
 use bevy_diagnostic::{DiagnosticsStore, FrameTimeDiagnosticsPlugin};
 use bevy_ecs::{
-    change_detection::DetectChangesMut,
     component::Component,
     entity::Entity,
     prelude::Local,
-    query::With,
+    query::{With, Without},
     resource::Resource,
     schedule::{common_conditions::resource_changed, IntoScheduleConfigs},
-    system::{Commands, Query, Res, ResMut},
+    system::{Commands, Query, Res, ResMut, Single},
 };
 use bevy_render::storage::ShaderStorageBuffer;
 use bevy_text::{Font, TextColor, TextFont, TextSpan};
@@ -243,26 +241,23 @@ fn customize_overlay(
 
 fn toggle_display(
     overlay_config: Res<FpsOverlayConfig>,
-    mut query: Query<&mut Visibility, With<FpsText>>,
-    mut graph_style: Query<&mut Node, With<FrameTimeGraph>>,
+    mut text_node: Single<&mut Node, (With<FpsText>, Without<FrameTimeGraph>)>,
+    mut graph_node: Single<&mut Node, (With<FrameTimeGraph>, Without<FpsText>)>,
 ) {
-    for mut visibility in &mut query {
-        visibility.set_if_neq(match overlay_config.enabled {
-            true => Visibility::Visible,
-            false => Visibility::Hidden,
-        });
+    if overlay_config.enabled {
+        text_node.display = bevy_ui::Display::DEFAULT;
+    } else {
+        text_node.display = bevy_ui::Display::None;
     }
 
-    if let Ok(mut graph_style) = graph_style.single_mut() {
-        if overlay_config.frame_time_graph_config.enabled {
-            // Scale the frame time graph based on the font size of the overlay
-            let font_size = overlay_config.text_config.font_size;
-            graph_style.width = Val::Px(font_size * FRAME_TIME_GRAPH_WIDTH_SCALE);
-            graph_style.height = Val::Px(font_size * FRAME_TIME_GRAPH_HEIGHT_SCALE);
+    if overlay_config.frame_time_graph_config.enabled {
+        // Scale the frame time graph based on the font size of the overlay
+        let font_size = overlay_config.text_config.font_size;
+        graph_node.width = Val::Px(font_size * FRAME_TIME_GRAPH_WIDTH_SCALE);
+        graph_node.height = Val::Px(font_size * FRAME_TIME_GRAPH_HEIGHT_SCALE);
 
-            graph_style.display = bevy_ui::Display::DEFAULT;
-        } else {
-            graph_style.display = bevy_ui::Display::None;
-        }
+        graph_node.display = bevy_ui::Display::DEFAULT;
+    } else {
+        graph_node.display = bevy_ui::Display::None;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/bevyengine/bevy/issues/21003

# Objective

Make sure the FPS overlay properly removes node footprint when not enabled.

## Solution

Hide the text node like the graph node does. The text node was currently using visibility, which doesn't change the node footprint.

## Testing

My project works as expected now, buttons no longer exhibit strange picking bugs.

## Showcase


https://github.com/user-attachments/assets/8562af43-c12d-42e0-a2db-19ae49b85d24


Notice unlike the linked issue the outline of the FPS overlay completely disappears now when disabled.