### PR TITLE
fps overlay: allow picking through

### DIFF
--- a/crates/bevy_dev_tools/src/fps_overlay.rs
+++ b/crates/bevy_dev_tools/src/fps_overlay.rs
@@ -15,6 +15,7 @@ use bevy_ecs::{
     schedule::{common_conditions::resource_changed, IntoScheduleConfigs},
     system::{Commands, Query, Res, ResMut},
 };
+use bevy_picking::Pickable;
 use bevy_render::storage::ShaderStorageBuffer;
 use bevy_text::{Font, TextColor, TextFont, TextSpan};
 use bevy_time::Time;
@@ -166,6 +167,7 @@ fn setup(
             },
             // Render overlay on top of everything
             GlobalZIndex(FPS_OVERLAY_ZINDEX),
+            Pickable::IGNORE,
         ))
         .with_children(|p| {
             p.spawn((
@@ -173,6 +175,7 @@ fn setup(
                 overlay_config.text_config.clone(),
                 TextColor(overlay_config.text_color),
                 FpsText,
+                Pickable::IGNORE,
             ))
             .with_child((TextSpan::default(), overlay_config.text_config.clone()));
 
@@ -188,6 +191,7 @@ fn setup(
                     },
                     ..Default::default()
                 },
+                Pickable::IGNORE,
                 MaterialNode::from(frame_time_graph_materials.add(FrametimeGraphMaterial {
                     values: buffers.add(ShaderStorageBuffer {
                         // Initialize with dummy data because the default (`data: None`) will


### PR DESCRIPTION
# Objective

The current FPS overlay does not allow users to pick through it.
Since the FPS overlay is absolutely positioned it's likely it will be on top of other UI, which can create problems.

## Solution

Ignore picking for the FPS overlay on the assumption it's more likely users want to click things _under_ it.

## Testing

See showcase.

## Showcase


https://github.com/user-attachments/assets/87b3a6b2-4745-4fb7-a846-2edb96ff97d7

