### PR TITLE
Add `$crate` in weak_handle macro

### DIFF
--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -506,7 +506,7 @@ macro_rules! uuid_handle {
 #[macro_export]
 macro_rules! weak_handle {
     ($uuid:expr) => {
-        uuid_handle!($uuid)
+        $crate::uuid_handle!($uuid)
     };
 }
 


### PR DESCRIPTION
# Objective

- `weak_handle` macro causes ``error: cannot find macro `uuid_handle` in this scope``.

## Solution

- Add `$crate::` prefix to `uuid_handle!`.

## Testing

- Compiling usage of `weak_handle` with this change