### PR TITLE
Impl Debug for triggers

### DIFF
--- a/crates/bevy_ecs/src/event/trigger.rs
+++ b/crates/bevy_ecs/src/event/trigger.rs
@@ -7,7 +7,7 @@ use crate::{
     world::DeferredWorld,
 };
 use bevy_ptr::PtrMut;
-use core::marker::PhantomData;
+use core::{fmt, marker::PhantomData};
 
 /// [`Trigger`] determines _how_ an [`Event`] is triggered when [`World::trigger`](crate::world::World::trigger) is called.
 /// This decides which [`Observer`](crate::observer::Observer)s will run, what data gets passed to them, and the order they will
@@ -57,7 +57,7 @@ pub unsafe trait Trigger<E: Event> {
 /// that matches the given [`Event`].
 ///
 /// The [`Event`] derive defaults to using this [`Trigger`], and it is usable for any [`Event`] type.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct GlobalTrigger;
 
 // SAFETY:
@@ -127,7 +127,7 @@ impl GlobalTrigger {
 /// The [`EntityEvent`] derive defaults to using this [`Trigger`], and it is usable for any [`EntityEvent`] type.
 ///
 /// [`Observer`]: crate::observer::Observer
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct EntityTrigger;
 
 // SAFETY:
@@ -248,6 +248,17 @@ impl<const AUTO_PROPAGATE: bool, E: EntityEvent, T: Traversal<E>> Default
             propagate: AUTO_PROPAGATE,
             _marker: Default::default(),
         }
+    }
+}
+
+impl<const AUTO_PROPAGATE: bool, E: EntityEvent, T: Traversal<E>> fmt::Debug
+    for PropagateEntityTrigger<AUTO_PROPAGATE, E, T>
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PropagateEntityTrigger")
+            .field("original_event_target", &self.original_event_target)
+            .field("propagate", &self.propagate)
+            .finish()
     }
 }
 

--- a/crates/bevy_ecs/src/event/trigger.rs
+++ b/crates/bevy_ecs/src/event/trigger.rs
@@ -258,6 +258,7 @@ impl<const AUTO_PROPAGATE: bool, E: EntityEvent, T: Traversal<E>> fmt::Debug
         f.debug_struct("PropagateEntityTrigger")
             .field("original_event_target", &self.original_event_target)
             .field("propagate", &self.propagate)
+            .field("_marker", &self._marker)
             .finish()
     }
 }


### PR DESCRIPTION
# Objective

- Debug-printing `Trigger` (now `On`) was handy for debugging events. It becomes an error in 0.17-rc due to triggers not implementing `Debug`.

## Solution

- Impl `Debug` for triggers
