### PR TITLE
Fix `On::target` not being implemented for an `EntityEvent` without propagation

### DIFF
--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -1119,4 +1119,17 @@ mod tests {
             .component_observers()
             .contains_key(&a));
     }
+
+    #[test]
+    #[expect(deprecated, reason = "We still need to test `On::target`")]
+    fn observer_target() {
+        let mut world = World::new();
+        let entity = world
+            .spawn_empty()
+            .observe(|event: On<EntityEventA>| {
+                assert_eq!(event.target(), event.event_target());
+            })
+            .id();
+        world.trigger(EntityEventA(entity));
+    }
 }

--- a/crates/bevy_ecs/src/observer/system_param.rs
+++ b/crates/bevy_ecs/src/observer/system_param.rs
@@ -129,15 +129,7 @@ impl<'w, 't, E: Event, B: Bundle> On<'w, 't, E, B> {
     }
 }
 
-impl<
-        'w,
-        't,
-        const AUTO_PROPAGATE: bool,
-        E: EntityEvent + for<'a> Event<Trigger<'a> = PropagateEntityTrigger<AUTO_PROPAGATE, E, T>>,
-        B: Bundle,
-        T: Traversal<E>,
-    > On<'w, 't, E, B>
-{
+impl<'w, 't, E: EntityEvent, B: Bundle> On<'w, 't, E, B> {
     /// A deprecated way to retrieve the entity that this [`EntityEvent`] targeted at.
     ///
     /// Access the event via [`On::event`], then read the entity that the event was targeting.
@@ -150,7 +142,17 @@ impl<
     pub fn target(&self) -> Entity {
         self.event.event_target()
     }
+}
 
+impl<
+        'w,
+        't,
+        const AUTO_PROPAGATE: bool,
+        E: EntityEvent + for<'a> Event<Trigger<'a> = PropagateEntityTrigger<AUTO_PROPAGATE, E, T>>,
+        B: Bundle,
+        T: Traversal<E>,
+    > On<'w, 't, E, B>
+{
     /// Returns the original [`Entity`] that this [`EntityEvent`] targeted via [`EntityEvent::event_target`] when it was _first_ triggered,
     /// prior to any propagation logic.
     pub fn original_event_target(&self) -> Entity {


### PR DESCRIPTION
Before #20731, `On::target` was implemented for any `EntityEvent`. After that PR, it's only implemented for events with `#[entity_event(propagate)]`.

```rust
entity.observe(|scene_ready: On<SceneInstanceReady>| {
    // Error: "the method `target` exists but its trait bounds were not satisfied".
    info!("Scene entity {} is ready", scene_ready.target()); 
})
```

I suspect the change wasn't intentional. This PR restores the old behaviour and adds a regression test.

Note that `On::target` is deprecated, but without the fix users will get an error instead of a deprecation warning.

<details>
<summary>Full error message:</summary>

```
error[E0599]: the method `target` exists for struct `observer::system_param::On<'_, '_, EntityEventA>`, but its trait bounds were not satisfied
    --> crates\bevy_ecs\src\observer\mod.rs:1129:34
     |
285  |     struct EntityEventA(Entity);
     |     ------------------- doesn't satisfy `<_ as Event>::Trigger<'a> = PropagateEntityTrigger<_, EntityEventA, _>`
...
1129 |                 assert_eq!(event.target(), event.event_target());
     |                                  ^^^^^^
     |
    ::: crates\bevy_ecs\src\observer\system_param.rs:38:1
     |
38   | pub struct On<'w, 't, E: Event, B: Bundle = ()> {
     | ----------------------------------------------- method `target` not found for this struct
     |
note: trait bound `<EntityEventA as event::Event>::Trigger<'a> = trigger::PropagateEntityTrigger<_, EntityEventA, _>` was not satisfied
    --> crates\bevy_ecs\src\observer\system_param.rs:153:40
     |
153  |         E: EntityEvent + for<'a> Event<Trigger<'a> = PropagateEntityTrigger<AUTO_PROPAGATE, E, T>>,
     |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound introduced here
...
156  |     > On<'w, 't, E, B>
     |       ----------------
```

</code>
</details>

## Testing

Hacked `animated_mesh` example to use `On::target`, confirming it worked and reported the deprecation warning.