### PR TITLE
Change `ImageRenderTarget`'s `scale_factor` to an `f32`

### DIFF
--- a/crates/bevy_camera/src/camera.rs
+++ b/crates/bevy_camera/src/camera.rs
@@ -910,7 +910,7 @@ impl PartialOrd for ImageRenderTarget {
 }
 
 impl Ord for ImageRenderTarget {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         self.handle
             .cmp(&other.handle)
             .then_with(|| FloatOrd(self.scale_factor).cmp(&FloatOrd(other.scale_factor)))

--- a/crates/bevy_camera/src/camera.rs
+++ b/crates/bevy_camera/src/camera.rs
@@ -878,14 +878,43 @@ pub enum NormalizedRenderTarget {
 pub struct ManualTextureViewHandle(pub u32);
 
 /// A render target that renders to an [`Image`].
-#[derive(Debug, Clone, Reflect, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, Reflect)]
 #[reflect(Clone, PartialEq, Hash)]
 pub struct ImageRenderTarget {
     /// The image to render to.
     pub handle: Handle<Image>,
     /// The scale factor of the render target image, corresponding to the scale
     /// factor for a window target. This should almost always be 1.0.
-    pub scale_factor: FloatOrd,
+    pub scale_factor: f32,
+}
+
+impl Eq for ImageRenderTarget {}
+
+impl PartialEq for ImageRenderTarget {
+    fn eq(&self, other: &Self) -> bool {
+        self.handle == other.handle && FloatOrd(self.scale_factor) == FloatOrd(other.scale_factor)
+    }
+}
+
+impl core::hash::Hash for ImageRenderTarget {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.handle.hash(state);
+        FloatOrd(self.scale_factor).hash(state);
+    }
+}
+
+impl PartialOrd for ImageRenderTarget {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for ImageRenderTarget {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.handle
+            .cmp(&other.handle)
+            .then_with(|| FloatOrd(self.scale_factor).cmp(&FloatOrd(other.scale_factor)))
+    }
 }
 
 impl From<Handle<Image>> for RenderTarget {
@@ -898,7 +927,7 @@ impl From<Handle<Image>> for ImageRenderTarget {
     fn from(handle: Handle<Image>) -> Self {
         Self {
             handle,
-            scale_factor: FloatOrd(1.0),
+            scale_factor: 1.0,
         }
     }
 }

--- a/crates/bevy_render/src/camera.rs
+++ b/crates/bevy_render/src/camera.rs
@@ -240,7 +240,7 @@ impl NormalizedRenderTargetExt for NormalizedRenderTarget {
                 .get(&image_target.handle)
                 .map(|image| RenderTargetInfo {
                     physical_size: image.size(),
-                    scale_factor: image_target.scale_factor.0,
+                    scale_factor: image_target.scale_factor,
                 })
                 .ok_or(MissingRenderTargetInfoError::Image {
                     image: image_target.handle.id(),

--- a/examples/ui/directional_navigation.rs
+++ b/examples/ui/directional_navigation.rs
@@ -388,7 +388,7 @@ fn interact_with_focused_button(
             pointer_location: Location {
                 target: NormalizedRenderTarget::Image(bevy::camera::ImageRenderTarget {
                     handle: Handle::default(),
-                    scale_factor: FloatOrd(1.0),
+                    scale_factor: 1.0,
                 }),
                 position: Vec2::ZERO,
             },

--- a/examples/ui/directional_navigation.rs
+++ b/examples/ui/directional_navigation.rs
@@ -15,7 +15,7 @@ use bevy::{
         },
         InputDispatchPlugin, InputFocus, InputFocusVisible,
     },
-    math::{CompassOctant, FloatOrd},
+    math::CompassOctant,
     picking::{
         backend::HitData,
         pointer::{Location, PointerId},

--- a/release-content/migration-guides/image_render_target_scale_factor_is_now_f32.md
+++ b/release-content/migration-guides/image_render_target_scale_factor_is_now_f32.md
@@ -1,0 +1,6 @@
+---
+title: "`ImageRenderTarget`s `scale_factor` field is now an `f32`"
+pull_requests: [ 21054 ]
+---
+
+The `scale_factor` field on `ImageRenderTarget` is now an `f32` and no longer requires wrapping in `FloatOrd`.


### PR DESCRIPTION
# Objective

`ImageRenderTarget`'s `scale_factor` field is a `FloatOrd`, which seems weird from a user POV. All the other scale factor fields are `f32`, this one shouldn't be any different.

## Solution

Change it to an `f32`, add impls for the traits that can no longer be derived.