### PR TITLE
Improve suggestion when old name for `Justify` is used

### DIFF
--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -214,6 +214,7 @@ impl From<String> for TextSpan {
 /// [`TextBounds`](super::bounds::TextBounds) component with an explicit `width` value.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Reflect, Serialize, Deserialize)]
 #[reflect(Serialize, Deserialize, Clone, PartialEq, Hash)]
+#[doc(alias = "JustifyText")]
 pub enum Justify {
     /// Leftmost character is immediately to the right of the render position.
     /// Bounds start from the render position and advance rightwards.


### PR DESCRIPTION
# Objective

Rust currently suggests that users try `JustifySelf` when `JustifyText` (which has been renamed to `Justify`) is used.

## Solution

Add an alias for the old name

## Before

```
warning: `bevy-alt-ui-navigation-lite` (lib) generated 2 warnings
error[E0433]: failed to resolve: use of undeclared type `JustifyText`
   --> examples/infinite_upgrades.rs:526:46
    |
526 |                 TextLayout::new_with_justify(JustifyText::Center),
    |                                              ^^^^^^^^^^^
    |                                              |
    |                                              use of undeclared type `JustifyText`
    |                                              help: an enum with a similar name exists: `JustifySelf`
```

## After

```
warning: `bevy-alt-ui-navigation-lite` (lib) generated 2 warnings
error[E0433]: failed to resolve: use of undeclared type `JustifyText`
   --> examples/infinite_upgrades.rs:526:46
    |
526 |                 TextLayout::new_with_justify(JustifyText::Center),
    |                                              ^^^^^^^^^^^ use of undeclared type `JustifyText`
    |
help: `Justify` has a name defined in the doc alias attribute as `JustifyText`
    |
526 -                 TextLayout::new_with_justify(JustifyText::Center),
526 +                 TextLayout::new_with_justify(Justify::Center),
```

## Testing

Testing with local bevy dependency in a library I am migrating

## Alternatives

Add deprecated type alias