### PR TITLE
Add note about `z` translation value which is no longer present

### DIFF
--- a/release-content/migration-guides/specialized_ui_transform.md
+++ b/release-content/migration-guides/specialized_ui_transform.md
@@ -26,7 +26,9 @@ UiTransform {
     translation: Val2::px(x, y),
     rotation: Rot2::from_rotation(radians),
     scale: scale.xy(),
-} 
+}
 ```
 
 In previous versions of Bevy `ui_layout_system` would overwrite UI node's `Transform::translation` each frame. `UiTransform`s aren't overwritten and there is no longer any need for systems that cache and rewrite the transform for translated UI elements.
+
+If you were relying on the `z` value of the `GlobalTransform`, this can be derived from `UiStack` instead.


### PR DESCRIPTION
# Objective

While migrating a [library](https://github.com/rparrett/bevy-alt-ui-navigation-lite) that does some custom UI "picking" / navigation, I stumbled on some code that was sorting UI nodes by the `GlobalTransform`'s z value.

It seems that the only way to obtain an ordering of UI nodes is now through `UiStack`

## Solution

Add a small note

## Alternatives

I would imagine that users doing this sort of thing should probably be using bevy's built-in picking instead. But I would sooner abandon maintenance of this thing than attempt such a migration. It does some things that bevy's built-in navigation can't do, but nothing that I am making use of personally.