### PR TITLE
fix: migration guide starting with backtick

### DIFF
--- a/release-content/migration-guides/remove_text_font_from_constructor_methods.md
+++ b/release-content/migration-guides/remove_text_font_from_constructor_methods.md
@@ -1,5 +1,5 @@
 ---
-title: `TextFont` constructor methods replaced with `From` impls
+title: Replaced `TextFont` constructor methods with `From` impls
 pull_requests: [20335, 20450]
 ---
 


### PR DESCRIPTION
# Objective

Fix the broken migration guide.

## Solution

Restructure the sentence so it does not start with a backtick.

## Testing

I ran `cargo run -p export-content` and it produced no errors.