### PR TITLE
readme: use a logo url available from everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [![Bevy](assets/branding/bevy_logo_light_dark_and_dimmed.svg)](https://bevy.org)
+# [![Bevy](https://bevy.org/assets/bevy_logo_light_dark_and_dimmed.svg)](https://bevy.org)
 
 [![License](https://img.shields.io/badge/license-MIT%2FApache-blue.svg)](https://github.com/bevyengine/bevy#license)
 [![Crates.io](https://img.shields.io/crates/v/bevy.svg)](https://crates.io/crates/bevy)


### PR DESCRIPTION
# Objective

- Logo in the readme is only available with the full repo and parsing markdown links
- For example, doesn't work on https://docs.rs/crate/bevy/0.16.1

## Solution

- Use an url on the website
