### PR TITLE
Add StateScoped as deprecated type alias

### DIFF
--- a/crates/bevy_state/src/lib.rs
+++ b/crates/bevy_state/src/lib.rs
@@ -83,6 +83,13 @@ pub mod prelude {
     pub use crate::reflect::{ReflectFreelyMutableState, ReflectState};
 
     #[doc(hidden)]
+    #[expect(
+        deprecated,
+        reason = "Temporarily re-exporting deprecated type for transition"
+    )]
+    pub use crate::state_scoped::StateScoped;
+
+    #[doc(hidden)]
     pub use crate::{
         commands::CommandsStatesExt,
         condition::*,

--- a/crates/bevy_state/src/state_scoped.rs
+++ b/crates/bevy_state/src/state_scoped.rs
@@ -63,6 +63,10 @@ where
     }
 }
 
+/// A deprecated alias for [`DespawnOnExit`].
+#[deprecated(since = "0.17.0", note = "use DespawnOnExit instead")]
+pub type StateScoped<S> = DespawnOnExit<S>;
+
 /// Despawns entities marked with [`DespawnOnExit<S>`] when their state no
 /// longer matches the world state.
 pub fn despawn_entities_on_exit_state<S: States>(


### PR DESCRIPTION
# Objective

- Make migration easier.
- Fixes #21035.

## Solution

- Add a deprecated type alias to help with the rename, rather than immediately renaming.
- Remember to re-export it in the prelude too to reduce compiler errors.