### PR TITLE
Improve migration guide for changes to the default error handler

### DIFF
--- a/release-content/migration-guides/per-world-error-handler.md
+++ b/release-content/migration-guides/per-world-error-handler.md
@@ -3,8 +3,12 @@ title: Changes to the default error handler mechanism
 pull_requests: [18810]
 ---
 
-Worlds can now have different default error handlers, so there no longer is a global handler.
+We've improved the implementation of Bevy's default error handling.
+The performance overhead has been reduced, and as a result it is always enabled.
+The `configurable_error_handler` feature no longer exists: simply remove it from your list of enabled features.
 
-Replace uses of `GLOBAL_ERROR_HANDLER` with `App`'s `.set_error_handler(handler)`.
+Additionally, worlds can now have different default error handlers, so there is no longer a truly global handler.
+
+Replace uses of `GLOBAL_ERROR_HANDLER` with `App::set_error_handler(handler)`.
 For worlds that do not directly belong to an `App`/`SubApp`,
 insert the `DefaultErrorHandler(handler)` resource.


### PR DESCRIPTION
# Objective

- The removed feature was not mention
- The writing was a bit wonky otherwise
- Fixes #21042

## Solution

- Mention the feature and rationale explicitly, to aid in lazy CTRL+F migration
- Improve the wording on the rest of the note.
