### PR TITLE
fix `wasm32v1-none` compiling with --no-default-features

### DIFF
--- a/crates/bevy_tasks/Cargo.toml
+++ b/crates/bevy_tasks/Cargo.toml
@@ -55,7 +55,7 @@ crossbeam-queue = { version = "0.3", default-features = false, features = [
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 pin-project = "1"
-async-channel = "2.3.0"
+async-channel = { version = "2.3.0", default-features = false }
 
 [target.'cfg(not(all(target_has_atomic = "8", target_has_atomic = "16", target_has_atomic = "32", target_has_atomic = "64", target_has_atomic = "ptr")))'.dependencies]
 async-task = { version = "4.4.0", default-features = false, features = [


### PR DESCRIPTION
# Objective

Fixes #21006

## Solution
disable default features for wasm32 arch dependency on `async-channel`