### PR TITLE
Remove unneeded migration guide

### DIFF
--- a/release-content/migration-guides/border_color_all_takes_impl_into_color.md
+++ b/release-content/migration-guides/border_color_all_takes_impl_into_color.md
@@ -1,6 +1,0 @@
----
-title: "`BorderColor::all` now accepts any `impl Into<Color>` type"
-pull_requests: [20311]
----
-
-`BorderColor`'s `all` constructor function is no longer const and its `color` parameter now accepts any `impl Into<Color>` type, not only `Color`.


### PR DESCRIPTION
# Objective

- This migration guide is for a method that didn't exist in Bevy 0.16.
- Fixes #21012

## Solution

- Yeet!
