### PR TITLE
Change the default for `RenderTargetInfo::scale_factor` to `1.`

### DIFF
--- a/crates/bevy_camera/src/camera.rs
+++ b/crates/bevy_camera/src/camera.rs
@@ -162,7 +162,7 @@ impl Default for SubCameraView {
 }
 
 /// Information about the current [`RenderTarget`].
-#[derive(Default, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub struct RenderTargetInfo {
     /// The physical size of this render target (in physical pixels, ignoring scale factor).
     pub physical_size: UVec2,
@@ -171,6 +171,15 @@ pub struct RenderTargetInfo {
     /// When rendering to a window, typically it is a value greater or equal than 1.0,
     /// representing the ratio between the size of the window in physical pixels and the logical size of the window.
     pub scale_factor: f32,
+}
+
+impl Default for RenderTargetInfo {
+    fn default() -> Self {
+        Self {
+            physical_size: Default::default(),
+            scale_factor: 1.,
+        }
+    }
 }
 
 /// Holds internally computed [`Camera`] values.

--- a/release-content/migration-guides/RenderTargetInfo_default.md
+++ b/release-content/migration-guides/RenderTargetInfo_default.md
@@ -1,0 +1,6 @@
+---
+title: "RenderTargetInfo's default `scale_factor` has been changed to `1.`"
+pull_requests: [21802]
+---
+
+The default for `RenderTargetInfo`'s `scale_factor` field is now `1.`.


### PR DESCRIPTION
# Objective

The default for `RenderTargetInfo`'s `scale_factor` field is `0.` but it's much more natural to assume that it would be `1.`.
A scale factor of `0.` is degenerate, and could potentially cause a panic.

## Solution

Set it to `1.` by default.


