### PR TITLE
Commandqueue uses source tracing.

### DIFF
--- a/crates/bevy_ecs/src/world/command_queue.rs
+++ b/crates/bevy_ecs/src/world/command_queue.rs
@@ -39,6 +39,7 @@ pub struct CommandQueue {
     pub(crate) bytes: Vec<MaybeUninit<u8>>,
     pub(crate) cursor: usize,
     pub(crate) panic_recovery: Vec<MaybeUninit<u8>>,
+    #[cfg(feature = "track_location")]
     pub(crate) caller: MaybeLocation,
 }
 
@@ -49,6 +50,7 @@ impl Default for CommandQueue {
             bytes: Default::default(),
             cursor: Default::default(),
             panic_recovery: Default::default(),
+            #[cfg(feature = "track_location")]
             caller: MaybeLocation::caller(),
         }
     }

--- a/crates/bevy_ecs/src/world/command_queue.rs
+++ b/crates/bevy_ecs/src/world/command_queue.rs
@@ -1,8 +1,10 @@
 use crate::{
-    change_detection::MaybeLocation,
     system::{Command, SystemBuffer, SystemMeta},
     world::{DeferredWorld, World},
 };
+#[cfg(feature = "track_location")]
+use crate::change_detection::MaybeLocation;
+
 use alloc::{boxed::Box, vec::Vec};
 use bevy_ptr::{OwningPtr, Unaligned};
 use core::{
@@ -363,7 +365,6 @@ mod test {
         panic::AssertUnwindSafe,
         sync::atomic::{AtomicU32, Ordering},
     };
-    use std::println;
 
     #[cfg(miri)]
     use alloc::format;
@@ -554,11 +555,15 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "track_location")]
     fn test_caller() {
+        use std::println;
+
         let queue = CommandQueue::default();
         println!("queue:{:?}", queue);
+
+        #[cfg(feature = "track_location")]
         println!("caller:{:?}", queue.caller);
+        
         let mut queue = CommandQueue::default();
         queue.push(|world: &mut World| {
             world.spawn(A);

--- a/crates/bevy_ecs/src/world/command_queue.rs
+++ b/crates/bevy_ecs/src/world/command_queue.rs
@@ -1,9 +1,9 @@
+#[cfg(feature = "track_location")]
+use crate::change_detection::MaybeLocation;
 use crate::{
     system::{Command, SystemBuffer, SystemMeta},
     world::{DeferredWorld, World},
 };
-#[cfg(feature = "track_location")]
-use crate::change_detection::MaybeLocation;
 
 use alloc::{boxed::Box, vec::Vec};
 use bevy_ptr::{OwningPtr, Unaligned};
@@ -563,7 +563,7 @@ mod test {
 
         #[cfg(feature = "track_location")]
         println!("caller:{:?}", queue.caller);
-        
+
         let mut queue = CommandQueue::default();
         queue.push(|world: &mut World| {
             world.spawn(A);

--- a/crates/bevy_ecs/src/world/command_queue.rs
+++ b/crates/bevy_ecs/src/world/command_queue.rs
@@ -553,23 +553,4 @@ mod test {
         queue.push(CommandWithPadding(0, 0));
         let _ = format!("{:?}", queue.bytes);
     }
-
-    #[test]
-    fn test_caller() {
-        use std::println;
-
-        let queue = CommandQueue::default();
-        println!("queue:{:?}", queue);
-
-        #[cfg(feature = "track_location")]
-        println!("caller:{:?}", queue.caller);
-
-        let mut queue = CommandQueue::default();
-        queue.push(|world: &mut World| {
-            world.spawn(A);
-        });
-
-        // Printing errors and source path
-        drop(queue);
-    }
 }


### PR DESCRIPTION
Add a caller to track the source of the command queue. Add a command queue source for printing tests.

# Objective
Fixes #21046

## Solution

Commandqueue uses source tracing

## Testing

Only one MaybeLocation has been added for tracking sources, and it only works when track-location is enabled.
