### PR TITLE
`UiGlobalTransform` helper methods

### DIFF
--- a/crates/bevy_ui/src/ui_transform.rs
+++ b/crates/bevy_ui/src/ui_transform.rs
@@ -3,6 +3,7 @@ use bevy_derive::Deref;
 use bevy_ecs::component::Component;
 use bevy_ecs::prelude::ReflectComponent;
 use bevy_math::Affine2;
+use bevy_math::Mat2;
 use bevy_math::Rot2;
 use bevy_math::Vec2;
 use bevy_reflect::prelude::*;
@@ -130,9 +131,8 @@ impl UiTransform {
     /// Resolves the translation from the given `scale_factor`, `base_value`, and `target_size`
     /// and returns a 2d affine transform from the resolved translation, and the `UiTransform`'s rotation, and scale.
     pub fn compute_affine(&self, scale_factor: f32, base_size: Vec2, target_size: Vec2) -> Affine2 {
-        Affine2::from_scale_angle_translation(
-            self.scale,
-            self.rotation.as_radians(),
+        Affine2::from_mat2_translation(
+            Mat2::from(self.rotation) * Mat2::from_diagonal(self.scale),
             self.translation
                 .resolve(scale_factor, base_size, target_size),
         )
@@ -187,7 +187,7 @@ impl UiGlobalTransform {
     /// Creates a `UiGlobalTransform` from the given rotation.
     #[inline]
     pub fn from_rotation(rotation: Rot2) -> Self {
-        Self(Affine2::from_angle(rotation.as_radians()))
+        Self(Affine2::from_mat2(rotation.into()))
     }
 
     /// Creates a `UiGlobalTransform` from the given scaling.

--- a/crates/bevy_ui/src/ui_transform.rs
+++ b/crates/bevy_ui/src/ui_transform.rs
@@ -229,11 +229,11 @@ impl From<&UiGlobalTransform> for Affine2 {
 }
 
 impl Mul for UiGlobalTransform {
-    type Output = Affine2;
+    type Output = Self;
 
     #[inline]
     fn mul(self, value: Self) -> Self::Output {
-        self.0 * value.0
+        Self(self.0 * value.0)
     }
 }
 

--- a/crates/bevy_ui/src/ui_transform.rs
+++ b/crates/bevy_ui/src/ui_transform.rs
@@ -6,7 +6,6 @@ use bevy_math::Affine2;
 use bevy_math::Rot2;
 use bevy_math::Vec2;
 use bevy_reflect::prelude::*;
-use bevy_transform::components::GlobalTransform;
 use core::ops::Mul;
 
 /// A pair of [`Val`]s used to represent a 2-dimensional size or offset.

--- a/crates/bevy_ui/src/ui_transform.rs
+++ b/crates/bevy_ui/src/ui_transform.rs
@@ -228,11 +228,11 @@ impl From<&UiGlobalTransform> for Affine2 {
     }
 }
 
-impl Mul<UiGlobalTransform> for UiGlobalTransform {
+impl Mul for UiGlobalTransform {
     type Output = Affine2;
 
     #[inline]
-    fn mul(self, value: UiGlobalTransform) -> Self::Output {
+    fn mul(self, value: Self) -> Self::Output {
         self.0 * value.0
     }
 }
@@ -243,6 +243,15 @@ impl Mul<Affine2> for UiGlobalTransform {
     #[inline]
     fn mul(self, affine2: Affine2) -> Self::Output {
         self.0 * affine2
+    }
+}
+
+impl Mul<UiGlobalTransform> for Affine2 {
+    type Output = Affine2;
+
+    #[inline]
+    fn mul(self, transform: UiGlobalTransform) -> Self::Output {
+        self * transform.0
     }
 }
 


### PR DESCRIPTION
# Objective

Realised when reviewing the migration PR for the text input crate, that `UiGlobalTransform` could do with a few helper functions. 

## Solution

* Add some constructor functions, similar to those on `GlobalTransform`.
* Add a `to_scale_angle_translation` method.
* Add some `Mul` impls.