### PR TITLE
Remove the "bevy_ui_debug" feature gate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,9 +192,6 @@ bevy_sprite_picking_backend = ["bevy_internal/bevy_sprite_picking_backend"]
 # Provides an implementation for picking UI
 bevy_ui_picking_backend = ["bevy_internal/bevy_ui_picking_backend"]
 
-# Provides a debug overlay for bevy UI
-bevy_ui_debug = ["bevy_internal/bevy_ui_debug"]
-
 # Force dynamic linking, which improves iterative compile times
 dynamic_linking = ["dep:bevy_dylib", "bevy_internal/dynamic_linking"]
 

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -325,9 +325,6 @@ bevy_sprite_picking_backend = [
 # Provides a UI picking backend
 bevy_ui_picking_backend = ["bevy_picking", "bevy_ui/bevy_ui_picking_backend"]
 
-# Provides a UI debug overlay
-bevy_ui_debug = ["bevy_ui_render?/bevy_ui_debug"]
-
 # Enable built in global state machines
 bevy_state = ["dep:bevy_state"]
 

--- a/crates/bevy_ui_render/Cargo.toml
+++ b/crates/bevy_ui_render/Cargo.toml
@@ -43,7 +43,6 @@ tracing = { version = "0.1", default-features = false, features = ["std"] }
 [features]
 default = []
 serialize = ["bevy_math/serialize", "bevy_platform/serialize"]
-bevy_ui_debug = []
 
 [lints]
 workspace = true

--- a/crates/bevy_ui_render/src/debug_overlay.rs
+++ b/crates/bevy_ui_render/src/debug_overlay.rs
@@ -56,7 +56,7 @@ impl Default for UiDebugOptions {
 
 pub fn extract_debug_overlay(
     mut commands: Commands,
-    debug_options: Extract<Res<UiDebugOptions>>,
+    maybe_debug_options: Extract<Option<Res<UiDebugOptions>>>,
     mut extracted_uinodes: ResMut<ExtractedUiNodes>,
     uinode_query: Extract<
         Query<(
@@ -71,6 +71,10 @@ pub fn extract_debug_overlay(
     ui_stack: Extract<Res<UiStack>>,
     camera_map: Extract<UiCameraMap>,
 ) {
+    let Some(debug_options) = maybe_debug_options else {
+        return;
+    };
+
     if !debug_options.enabled {
         return;
     }

--- a/crates/bevy_ui_render/src/debug_overlay.rs
+++ b/crates/bevy_ui_render/src/debug_overlay.rs
@@ -71,7 +71,7 @@ pub fn extract_debug_overlay(
     ui_stack: Extract<Res<UiStack>>,
     camera_map: Extract<UiCameraMap>,
 ) {
-    let Some(debug_options) = maybe_debug_options else {
+    let Some(debug_options) = maybe_debug_options.as_ref() else {
         return;
     };
 

--- a/crates/bevy_ui_render/src/lib.rs
+++ b/crates/bevy_ui_render/src/lib.rs
@@ -8,15 +8,13 @@
 //! Provides rendering functionality for `bevy_ui`.
 
 pub mod box_shadow;
+pub mod debug_overlay;
 mod gradient;
 mod pipeline;
 mod render_pass;
 pub mod ui_material;
 mod ui_material_pipeline;
 pub mod ui_texture_slice_pipeline;
-
-#[cfg(feature = "bevy_ui_debug")]
-mod debug_overlay;
 
 use bevy_camera::visibility::InheritedVisibility;
 use bevy_camera::{Camera, Camera2d, Camera3d};
@@ -86,7 +84,6 @@ pub mod graph {
 }
 
 pub mod prelude {
-    #[cfg(feature = "bevy_ui_debug")]
     pub use crate::debug_overlay::UiDebugOptions;
 
     pub use crate::{
@@ -203,9 +200,6 @@ impl Plugin for UiRenderPlugin {
     fn build(&self, app: &mut App) {
         load_shader_library!(app, "ui.wgsl");
 
-        #[cfg(feature = "bevy_ui_debug")]
-        app.init_resource::<UiDebugOptions>();
-
         let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
             return;
         };
@@ -247,7 +241,6 @@ impl Plugin for UiRenderPlugin {
                     extract_text_background_colors.in_set(RenderUiSystems::ExtractTextBackgrounds),
                     extract_text_shadows.in_set(RenderUiSystems::ExtractTextShadows),
                     extract_text_sections.in_set(RenderUiSystems::ExtractText),
-                    #[cfg(feature = "bevy_ui_debug")]
                     debug_overlay::extract_debug_overlay.in_set(RenderUiSystems::ExtractDebug),
                 ),
             )

--- a/crates/bevy_ui_render/src/lib.rs
+++ b/crates/bevy_ui_render/src/lib.rs
@@ -52,7 +52,7 @@ use bevy_render::{
     Extract, ExtractSchedule, Render, RenderApp, RenderStartup, RenderSystems,
 };
 use bevy_sprite::BorderRect;
-#[cfg(feature = "bevy_ui_debug")]
+
 pub use debug_overlay::UiDebugOptions;
 use gradient::GradientPlugin;
 

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -79,7 +79,6 @@ The default feature set enables most of the expected features of a game engine, 
 |bevy_dev_tools|Provides a collection of developer tools|
 |bevy_remote|Enable the Bevy Remote Protocol|
 |bevy_solari|Provides raytraced lighting (experimental)|
-|bevy_ui_debug|Provides a debug overlay for bevy UI|
 |bluenoise_texture|Include spatio-temporal blue noise KTX2 file used by generated environment maps, Solari and atmosphere|
 |bmp|BMP image format support|
 |compressed_image_saver|Enables compressed KTX2 UASTC texture output on the asset processor|

--- a/examples/testbed/full_ui.rs
+++ b/examples/testbed/full_ui.rs
@@ -22,7 +22,7 @@ fn main() {
         .add_systems(Startup, setup)
         .add_systems(Update, update_scroll_position);
     app.add_systems(Update, toggle_debug_overlay);
-
+    app.init_resource::<UiDebugOptions>();
     app.run();
 }
 

--- a/examples/testbed/full_ui.rs
+++ b/examples/testbed/full_ui.rs
@@ -21,8 +21,6 @@ fn main() {
     app.add_plugins(DefaultPlugins)
         .add_systems(Startup, setup)
         .add_systems(Update, update_scroll_position);
-
-    #[cfg(feature = "bevy_ui_debug")]
     app.add_systems(Update, toggle_debug_overlay);
 
     app.run();
@@ -81,52 +79,40 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                 Label,
                             ));
 
-                            #[cfg(feature = "bevy_ui_debug")]
-                            {
-                                // Debug overlay text
-                                parent.spawn((
-                                    Text::new("Press Space to toggle debug outlines."),
-                                    TextFont {
-                                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                                        ..default()
-                                    },
-                                    Label,
-                                ));
-
-                                parent.spawn((
-                                    Text::new("V: toggle UI root's visibility"),
-                                    TextFont {
-                                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                                        font_size: 12.,
-                                        ..default()
-                                    },
-                                    Label,
-                                ));
-
-                                parent.spawn((
-                                    Text::new("S: toggle outlines for hidden nodes"),
-                                    TextFont {
-                                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                                        font_size: 12.,
-                                        ..default()
-                                    },
-                                    Label,
-                                ));
-                                parent.spawn((
-                                    Text::new("C: toggle outlines for clipped nodes"),
-                                    TextFont {
-                                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                                        font_size: 12.,
-                                        ..default()
-                                    },
-                                    Label,
-                                ));
-                            }
-                            #[cfg(not(feature = "bevy_ui_debug"))]
+                            // Debug overlay text
                             parent.spawn((
-                                Text::new("Try enabling feature \"bevy_ui_debug\"."),
+                                Text::new("Press Space to toggle debug outlines."),
                                 TextFont {
                                     font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                                    ..default()
+                                },
+                                Label,
+                            ));
+
+                            parent.spawn((
+                                Text::new("V: toggle UI root's visibility"),
+                                TextFont {
+                                    font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                                    font_size: 12.,
+                                    ..default()
+                                },
+                                Label,
+                            ));
+
+                            parent.spawn((
+                                Text::new("S: toggle outlines for hidden nodes"),
+                                TextFont {
+                                    font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                                    font_size: 12.,
+                                    ..default()
+                                },
+                                Label,
+                            ));
+                            parent.spawn((
+                                Text::new("C: toggle outlines for clipped nodes"),
+                                TextFont {
+                                    font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                                    font_size: 12.,
                                     ..default()
                                 },
                                 Label,
@@ -403,7 +389,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         });
 }
 
-#[cfg(feature = "bevy_ui_debug")]
 // The system that will enable/disable the debug outlines around the nodes
 fn toggle_debug_overlay(
     input: Res<ButtonInput<KeyCode>>,

--- a/release-content/migration-guides/remove_the_bevy_ui_debug_feature_gate.md
+++ b/release-content/migration-guides/remove_the_bevy_ui_debug_feature_gate.md
@@ -1,9 +1,9 @@
 ---
-title: The `bevy_ui_debug` feature gate has been removed
+title: The `bevy_ui_debug` feature has been removed
 pull_requests: [ 21091 ]
 ---
 
-The `bevy_ui_debug` feature gate has been removed.
+The "bevy_ui_debug" feature has been removed.
 To use the debug overlay, add the `UiDebugOptions` resource to your Bevy app with its `enabled` field set to true:
 
 ```rust

--- a/release-content/migration-guides/remove_the_bevy_ui_debug_feature_gate.md
+++ b/release-content/migration-guides/remove_the_bevy_ui_debug_feature_gate.md
@@ -1,0 +1,15 @@
+---
+title: The `bevy_ui_debug` feature gate has been removed
+pull_requests: [ 21091 ]
+---
+
+The `bevy_ui_debug` feature gate has been removed.
+To use the debug overlay, add the `UiDebugOptions` resource to your Bevy app with its `enabled` field set to true:
+
+```rust
+    app.insert_resource(UiDebugOptions {
+        enabled: true, 
+        ..default()
+    });
+
+```

--- a/release-content/migration-guides/remove_the_bevy_ui_debug_feature_gate.md
+++ b/release-content/migration-guides/remove_the_bevy_ui_debug_feature_gate.md
@@ -1,15 +1,13 @@
 ---
-title: The `bevy_ui_debug` feature has been removed
+title: The "bevy_ui_debug" feature has been removed
 pull_requests: [ 21091 ]
 ---
 
-The "bevy_ui_debug" feature has been removed.
-To use the debug overlay, add the `UiDebugOptions` resource to your Bevy app with its `enabled` field set to true:
+The "bevy_ui_debug" feature has been removed. To use the debug overlay, add the `UiDebugOptions` resource to your Bevy app with its `enabled` field set to true:
 
 ```rust
     app.insert_resource(UiDebugOptions {
         enabled: true, 
         ..default()
     });
-
 ```


### PR DESCRIPTION
# Objective

The "bevy_ui_debug" feature gate doesn't achieve much, the UI debug overlay implementation consists of just a resource and an extraction system that early returns if the overlay is disabled. But it does make the debug overlay harder to discover and use, and it's often broken by changes to the UI rendering systems that forget to update it.

## Solution

Remove the "bevy_ui_debug" feature gate.