### PR TITLE
Fix tasks on wasm

### DIFF
--- a/crates/bevy_tasks/src/task.rs
+++ b/crates/bevy_tasks/src/task.rs
@@ -39,7 +39,7 @@ cfg::web! {
                     // Catch any panics that occur when polling the future so they can
                     // be propagated back to the task handle.
                     let value = CatchUnwind(AssertUnwindSafe(future)).await;
-                    let _ = sender.send(value);
+                    let _ = sender.send(value).await;
                 });
                 Self(receiver)
             }


### PR DESCRIPTION
# Objective

Fix #21079. This was caused by incorrectly dropping a future.

## Solution

Await the future instead of dropping it.

## Testing

See https://github.com/bevyengine/bevy/issues/21079#issuecomment-3295174637. @rparrett has indicated this resolves the issue. I have not personally tested it.

We need to figure out a better solution to unit test the web. This would be very easy to test, except that it requires `web_bindgen_futures` and has to run in a browser environment.