### PR TITLE
Fix empty children regression

### DIFF
--- a/crates/bevy_ecs/src/hierarchy.rs
+++ b/crates/bevy_ecs/src/hierarchy.rs
@@ -808,6 +808,9 @@ mod tests {
     fn spawn_many_children() {
         let mut world = World::new();
 
+        // ensure an empty set can be mentioned
+        world.spawn(children![]);
+
         // 12 children should result in a flat tuple
         let id = world
             .spawn(children![(), (), (), (), (), (), (), (), (), (), (), ()])

--- a/crates/bevy_ecs/src/spawn.rs
+++ b/crates/bevy_ecs/src/spawn.rs
@@ -513,6 +513,7 @@ macro_rules! related {
 #[doc(hidden)]
 macro_rules! recursive_spawn {
     // direct expansion
+    () => { () };
     ($a:expr) => {
         $crate::spawn::Spawn($a)
     };


### PR DESCRIPTION
## Objective

#18865 introduced a regression for an empty invocation of `children!` and `related!`. The `recursive_spawn` macro has no case for zero inputs, so the compiler rejects `children![]`. Whether this is particularly meaningful isn't important; there are a number of situations in which you might want your code to compile even with an empty set of children.

## Solution

A case has been added to `recursive_spawn` for no inputs, returning a unit. This matches the previous behavior for `children!` and `related!` exactly.
