### PR TITLE
Combine added and existing `ComponentId`s in a single allocation

### DIFF
--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -25,6 +25,7 @@ use crate::{
     entity::{Entity, EntityLocation},
     event::Event,
     observer::Observers,
+    query::DebugCheckedUnwrap,
     storage::{ImmutableSparseSet, SparseArray, SparseSet, TableId, TableRow},
 };
 use alloc::{boxed::Box, vec::Vec};
@@ -156,11 +157,13 @@ impl ArchetypeAfterBundleInsert {
     }
 
     pub(crate) fn added(&self) -> &[ComponentId] {
-        &self.inserted[..self.added_len]
+        // SAFETY: `added_len` is always in range `0..=inserted.len()`
+        unsafe { self.inserted.get(..self.added_len).debug_checked_unwrap() }
     }
 
     pub(crate) fn existing(&self) -> &[ComponentId] {
-        &self.inserted[self.added_len..]
+        // SAFETY: `added_len` is always in range `0..=inserted.len()`
+        unsafe { self.inserted.get(self.added_len..).debug_checked_unwrap() }
     }
 }
 

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -248,17 +248,21 @@ impl Edges {
         archetype_id: ArchetypeId,
         bundle_status: impl Into<Box<[ComponentStatus]>>,
         required_components: impl Into<Box<[RequiredComponentConstructor]>>,
-        added: Vec<ComponentId>,
-        existing: impl IntoIterator<Item = ComponentId>,
+        mut added: Vec<ComponentId>,
+        existing: Vec<ComponentId>,
     ) {
+        let added_len = added.len();
+        // Make sure `extend` doesn't over-reserve, since the conversion to `Box<[_]>` would reallocate to shrink.
+        added.reserve_exact(existing.len());
+        added.extend(existing);
         self.insert_bundle.insert(
             bundle_id,
             ArchetypeAfterBundleInsert {
                 archetype_id,
                 bundle_status: bundle_status.into(),
                 required_components: required_components.into(),
-                added_len: added.len(),
-                inserted: added.into_iter().chain(existing).collect(),
+                added_len,
+                inserted: added.into(),
             },
         );
     }

--- a/crates/bevy_ecs/src/bundle/insert.rs
+++ b/crates/bevy_ecs/src/bundle/insert.rs
@@ -167,7 +167,7 @@ impl<'w> BundleInserter<'w> {
                         REPLACE,
                         &mut Replace { entity },
                         &mut EntityComponentsTrigger {
-                            components: &archetype_after_insert.existing,
+                            components: archetype_after_insert.existing(),
                         },
                         caller,
                     );
@@ -175,7 +175,7 @@ impl<'w> BundleInserter<'w> {
                 deferred_world.trigger_on_replace(
                     archetype,
                     entity,
-                    archetype_after_insert.iter_existing(),
+                    archetype_after_insert.existing().iter().copied(),
                     caller,
                     relationship_hook_mode,
                 );
@@ -346,7 +346,7 @@ impl<'w> BundleInserter<'w> {
             deferred_world.trigger_on_add(
                 new_archetype,
                 entity,
-                archetype_after_insert.iter_added(),
+                archetype_after_insert.added().iter().copied(),
                 caller,
             );
             if new_archetype.has_add_observer() {
@@ -355,7 +355,7 @@ impl<'w> BundleInserter<'w> {
                     ADD,
                     &mut Add { entity },
                     &mut EntityComponentsTrigger {
-                        components: &archetype_after_insert.added,
+                        components: archetype_after_insert.added(),
                     },
                     caller,
                 );
@@ -366,7 +366,7 @@ impl<'w> BundleInserter<'w> {
                     deferred_world.trigger_on_insert(
                         new_archetype,
                         entity,
-                        archetype_after_insert.iter_inserted(),
+                        archetype_after_insert.inserted().iter().copied(),
                         caller,
                         relationship_hook_mode,
                     );
@@ -375,12 +375,8 @@ impl<'w> BundleInserter<'w> {
                         deferred_world.trigger_raw(
                             INSERT,
                             &mut Insert { entity },
-                            // PERF: this is not a regression from what we were doing before, but ideally we don't
-                            // need to collect here
                             &mut EntityComponentsTrigger {
-                                components: &archetype_after_insert
-                                    .iter_inserted()
-                                    .collect::<Vec<_>>(),
+                                components: archetype_after_insert.inserted(),
                             },
                             caller,
                         );
@@ -392,7 +388,7 @@ impl<'w> BundleInserter<'w> {
                     deferred_world.trigger_on_insert(
                         new_archetype,
                         entity,
-                        archetype_after_insert.iter_added(),
+                        archetype_after_insert.added().iter().copied(),
                         caller,
                         relationship_hook_mode,
                     );
@@ -402,7 +398,7 @@ impl<'w> BundleInserter<'w> {
                             INSERT,
                             &mut Insert { entity },
                             &mut EntityComponentsTrigger {
-                                components: &archetype_after_insert.added,
+                                components: archetype_after_insert.added(),
                             },
                             caller,
                         );


### PR DESCRIPTION
# Objective

Further shrink `ArchetypeAfterBundleInsert`, following #20626.  

Remove the need for a `collect()` when triggering `Insert` observers.  

## Solution

Combine the `added` and `existing` component id lists into a single boxed slice.  We need to store an additional length to recover the slices, but this means we store **one** pointer and two lengths instead of **two** pointers and two lengths, shrinking the size of `ArchetypeAfterBundleInsert` by one pointer.  

This also means we have a slice available for the full list of `inserted` components without having to copy them into a new `Vec`.  