### PR TITLE
Make `extract_text2d_sprite` public

### DIFF
--- a/crates/bevy_sprite_render/src/lib.rs
+++ b/crates/bevy_sprite_render/src/lib.rs
@@ -45,7 +45,7 @@ use bevy_render::{
 use bevy_sprite::Sprite;
 
 #[cfg(feature = "bevy_text")]
-use crate::text2d::extract_text2d_sprite;
+pub use crate::text2d::extract_text2d_sprite;
 
 /// Adds support for 2D sprite rendering.
 #[derive(Default)]


### PR DESCRIPTION
# Objective

This was public before the `bevy_sprite_render` migration, don't think the change to make it private was intentional.


