### PR TITLE
Use `$crate` instead of `bevy_ptr` in `move_as_ptr` macro

### DIFF
--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -1212,7 +1212,7 @@ macro_rules! move_as_ptr {
         //   it is impossible to refer to the original value, preventing further access after
         //   the `MovingPtr` has been used. `MaybeUninit` also prevents the compiler from
         //   dropping the original value.
-        let $value = unsafe { bevy_ptr::MovingPtr::from_value(&mut $value) };
+        let $value = unsafe { $crate::MovingPtr::from_value(&mut $value) };
     };
 }
 


### PR DESCRIPTION
# Objective

Fixes #21050

## Solution

Use the `$crate` metavariable in the `move_as_ptr` macro so that it always resolves the `bevy_ptr` crate correctly.  
