### PR TITLE
Bevy Feathers no longer depends on `Propagate`

### DIFF
--- a/crates/bevy_feathers/src/lib.rs
+++ b/crates/bevy_feathers/src/lib.rs
@@ -18,14 +18,9 @@
 //! Please report issues, submit fixes and propose changes.
 //! Thanks for stress-testing; let's build something better together.
 
-use bevy_app::{
-    HierarchyPropagatePlugin, Plugin, PluginGroup, PluginGroupBuilder, PostUpdate, PropagateSet,
-};
+use bevy_app::{Plugin, PluginGroup, PluginGroupBuilder, PostUpdate};
 use bevy_asset::embedded_asset;
-use bevy_ecs::{query::With, schedule::IntoScheduleConfigs};
 use bevy_input_focus::{tab_navigation::TabNavigationPlugin, InputDispatchPlugin};
-use bevy_text::{TextColor, TextFont};
-use bevy_ui::UiSystems;
 use bevy_ui_render::UiMaterialPlugin;
 use bevy_ui_widgets::UiWidgetsPlugins;
 
@@ -33,7 +28,7 @@ use crate::{
     alpha_pattern::{AlphaPatternMaterial, AlphaPatternResource},
     controls::ControlsPlugin,
     cursor::{CursorIconPlugin, DefaultCursor, EntityCursor},
-    theme::{ThemedText, UiTheme},
+    theme::UiTheme,
 };
 
 mod alpha_pattern;
@@ -68,17 +63,8 @@ impl Plugin for FeathersPlugin {
         app.add_plugins((
             ControlsPlugin,
             CursorIconPlugin,
-            HierarchyPropagatePlugin::<TextColor, With<ThemedText>>::new(PostUpdate),
-            HierarchyPropagatePlugin::<TextFont, With<ThemedText>>::new(PostUpdate),
             UiMaterialPlugin::<AlphaPatternMaterial>::default(),
         ));
-
-        // This needs to run in UiSystems::Propagate so the fonts are up-to-date for `measure_text_system`
-        // and `detect_text_needs_rerender` in UiSystems::Content
-        app.configure_sets(
-            PostUpdate,
-            PropagateSet::<TextFont>::default().in_set(UiSystems::Propagate),
-        );
 
         app.insert_resource(DefaultCursor(EntityCursor::System(
             bevy_window::SystemCursorIcon::Default,
@@ -88,6 +74,7 @@ impl Plugin for FeathersPlugin {
             .add_observer(theme::on_changed_background)
             .add_observer(theme::on_changed_border)
             .add_observer(theme::on_changed_font_color)
+            .add_observer(theme::on_changed_text)
             .add_observer(font_styles::on_changed_font);
 
         app.init_resource::<AlphaPatternResource>();

--- a/examples/ui/feathers.rs
+++ b/examples/ui/feathers.rs
@@ -35,6 +35,9 @@ enum SwatchType {
     Hsl,
 }
 
+#[derive(Component, Clone, Copy)]
+struct DemoDisabledButton;
+
 fn main() {
     App::new()
         .add_plugins((DefaultPlugins, FeathersPlugins))
@@ -168,7 +171,7 @@ fn demo_root(commands: &mut Commands) -> impl Bundle {
                                 )),
                                 ..default()
                             },
-                            InteractionDisabled,
+                            (InteractionDisabled, DemoDisabledButton),
                             Spawn((Text::new("Disabled"), ThemedText))
                         ),
                         button(
@@ -249,7 +252,25 @@ fn demo_root(commands: &mut Commands) -> impl Bundle {
                 ),
                 checkbox(
                     CheckboxProps {
-                        on_change: Callback::Ignore,
+                        on_change: Callback::System(commands.register_system(
+                            |change: In<ValueChange<bool>>,
+                             query: Query<Entity, With<DemoDisabledButton>>,
+                             mut commands: Commands| {
+                                info!("Checkbox clicked!");
+                                let mut button = commands.entity(query.single().unwrap());
+                                if change.value {
+                                    button.insert(InteractionDisabled);
+                                } else {
+                                    button.remove::<InteractionDisabled>();
+                                }
+                                let mut checkbox = commands.entity(change.source);
+                                if change.value {
+                                    checkbox.insert(Checked);
+                                } else {
+                                    checkbox.remove::<Checked>();
+                                }
+                            }
+                        )),
                     },
                     Checked,
                     Spawn((Text::new("Checkbox"), ThemedText))


### PR DESCRIPTION
...but instead uses observers and hierarchy iteration to manually implement inherited text styles.

Fixes: #21110
