### PR TITLE
Borders example cleanup

### DIFF
--- a/examples/ui/borders.rs
+++ b/examples/ui/borders.rs
@@ -93,9 +93,6 @@ fn setup(mut commands: Commands) {
         Node {
             margin: px(25).all(),
             flex_wrap: FlexWrap::Wrap,
-            justify_content: JustifyContent::FlexStart,
-            align_items: AlignItems::FlexStart,
-            align_content: AlignContent::FlexStart,
             ..default()
         },
         Children::spawn(SpawnIter(border_labels.into_iter().zip(borders).map(
@@ -158,9 +155,6 @@ fn setup(mut commands: Commands) {
         Node {
             margin: px(25).all(),
             flex_wrap: FlexWrap::Wrap,
-            justify_content: JustifyContent::FlexStart,
-            align_items: AlignItems::FlexStart,
-            align_content: AlignContent::FlexStart,
             ..default()
         },
         Children::spawn(SpawnIter(border_labels.into_iter().zip(borders).map(

--- a/examples/ui/borders.rs
+++ b/examples/ui/borders.rs
@@ -221,9 +221,8 @@ fn setup(mut commands: Commands) {
         Node {
             margin: px(25).all(),
             flex_direction: FlexDirection::Column,
+            align_self: AlignSelf::Stretch,
             justify_self: JustifySelf::Stretch,
-            justify_content: JustifyContent::FlexStart,
-            align_items: AlignItems::FlexStart,
             ..default()
         },
         BackgroundColor(Color::srgb(0.25, 0.25, 0.25)),

--- a/examples/ui/borders.rs
+++ b/examples/ui/borders.rs
@@ -223,10 +223,8 @@ fn setup(mut commands: Commands) {
             flex_direction: FlexDirection::Column,
             align_self: AlignSelf::Stretch,
             justify_self: JustifySelf::Stretch,
-            flex_wrap: FlexWrap::Wrap,
             justify_content: JustifyContent::FlexStart,
             align_items: AlignItems::FlexStart,
-            align_content: AlignContent::FlexStart,
             ..default()
         },
         BackgroundColor(Color::srgb(0.25, 0.25, 0.25)),

--- a/examples/ui/borders.rs
+++ b/examples/ui/borders.rs
@@ -92,8 +92,6 @@ fn setup(mut commands: Commands) {
     let borders_examples = (
         Node {
             margin: px(25).all(),
-            align_self: AlignSelf::Stretch,
-            justify_self: JustifySelf::Stretch,
             flex_wrap: FlexWrap::Wrap,
             justify_content: JustifyContent::FlexStart,
             align_items: AlignItems::FlexStart,
@@ -159,8 +157,6 @@ fn setup(mut commands: Commands) {
     let borders_examples_rounded = (
         Node {
             margin: px(25).all(),
-            align_self: AlignSelf::Stretch,
-            justify_self: JustifySelf::Stretch,
             flex_wrap: FlexWrap::Wrap,
             justify_content: JustifyContent::FlexStart,
             align_items: AlignItems::FlexStart,

--- a/examples/ui/borders.rs
+++ b/examples/ui/borders.rs
@@ -91,7 +91,7 @@ fn setup(mut commands: Commands) {
 
     let borders_examples = (
         Node {
-            margin: UiRect::all(px(25)),
+            margin: px(25).all(),
             align_self: AlignSelf::Stretch,
             justify_self: JustifySelf::Stretch,
             flex_wrap: FlexWrap::Wrap,
@@ -114,7 +114,7 @@ fn setup(mut commands: Commands) {
                                 width: px(50),
                                 height: px(50),
                                 border,
-                                margin: UiRect::all(px(20)),
+                                margin: px(20).all(),
                                 align_items: AlignItems::Center,
                                 justify_content: JustifyContent::Center,
                                 ..default()
@@ -158,7 +158,7 @@ fn setup(mut commands: Commands) {
 
     let borders_examples_rounded = (
         Node {
-            margin: UiRect::all(px(25)),
+            margin: px(25).all(),
             align_self: AlignSelf::Stretch,
             justify_self: JustifySelf::Stretch,
             flex_wrap: FlexWrap::Wrap,
@@ -181,7 +181,7 @@ fn setup(mut commands: Commands) {
                                 width: px(50),
                                 height: px(50),
                                 border,
-                                margin: UiRect::all(px(20)),
+                                margin: px(20).all(),
                                 align_items: AlignItems::Center,
                                 justify_content: JustifyContent::Center,
                                 ..default()
@@ -223,7 +223,7 @@ fn setup(mut commands: Commands) {
 
     commands.spawn((
         Node {
-            margin: UiRect::all(px(25)),
+            margin: px(25).all(),
             flex_direction: FlexDirection::Column,
             align_self: AlignSelf::Stretch,
             justify_self: JustifySelf::Stretch,
@@ -248,7 +248,7 @@ fn setup(mut commands: Commands) {
 fn label(text: &str) -> impl Bundle {
     (
         Node {
-            margin: UiRect::all(px(25)),
+            margin: px(25).all(),
             ..default()
         },
         children![(Text::new(text), TextFont::from_font_size(20.0))],

--- a/examples/ui/borders.rs
+++ b/examples/ui/borders.rs
@@ -221,7 +221,6 @@ fn setup(mut commands: Commands) {
         Node {
             margin: px(25).all(),
             flex_direction: FlexDirection::Column,
-            align_self: AlignSelf::Stretch,
             justify_self: JustifySelf::Stretch,
             justify_content: JustifyContent::FlexStart,
             align_items: AlignItems::FlexStart,


### PR DESCRIPTION
# Objective

Cleanup the `borders` example

## Solution

Remove lots of unneeded constraints  and use the new uirect constructors.

## Testing

```cargo run --example borders```

Output should be unchanged.

