### PR TITLE
`JustifySelf` doc comment edit

### DIFF
--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -857,7 +857,7 @@ impl Default for AlignSelf {
 }
 
 /// Used to control how the specified item is aligned within the space it's given.
-/// - For Flexbox items, this property has no effect. See `justify_content` for main axis alignment of flex items.
+/// - For children of flex nodes, this property has no effect. See `justify_content` for main axis alignment of flex items.
 /// - For CSS Grid items, controls inline (horizontal) axis alignment of a grid item within its grid area.
 ///
 /// <https://developer.mozilla.org/en-US/docs/Web/CSS/justify-self>


### PR DESCRIPTION
# Objective

Changed the doc comment for `JustifySelf` as it's a bit misleading, flex nodes are affected by `JustifySelf` if they have a parent grid node.

A lot of the doc comments need some de-css

