### PR TITLE
Add `Event` option to `Callback`.

### DIFF
--- a/crates/bevy_ui_widgets/src/callback.rs
+++ b/crates/bevy_ui_widgets/src/callback.rs
@@ -1,3 +1,4 @@
+use bevy_ecs::event::Event;
 use bevy_ecs::system::{Commands, SystemId, SystemInput};
 use bevy_ecs::world::{DeferredWorld, World};
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
@@ -33,6 +34,8 @@ use bevy_reflect::{prelude::ReflectDefault, Reflect};
 pub enum Callback<I: SystemInput = ()> {
     /// Invoke a one-shot system
     System(SystemId<I>),
+    /// Emit an event
+    Event,
     /// Ignore this notification
     #[default]
     Ignore,
@@ -40,75 +43,50 @@ pub enum Callback<I: SystemInput = ()> {
 
 /// Trait used to invoke a [`Callback`], unifying the API across callers.
 pub trait Notify {
-    /// Invoke the callback with no arguments.
-    fn notify(&mut self, callback: &Callback<()>);
-
     /// Invoke the callback with one argument.
     fn notify_with<I>(&mut self, callback: &Callback<I>, input: I::Inner<'static>)
     where
-        I: SystemInput<Inner<'static>: Send> + 'static;
+        I: SystemInput<Inner<'static>: Send + Event<Trigger<'static>: Default>> + 'static;
 }
 
 impl<'w, 's> Notify for Commands<'w, 's> {
-    fn notify(&mut self, callback: &Callback<()>) {
-        match callback {
-            Callback::System(system_id) => self.run_system(*system_id),
-            Callback::Ignore => (),
-        }
-    }
-
     fn notify_with<I>(&mut self, callback: &Callback<I>, input: I::Inner<'static>)
     where
-        I: SystemInput<Inner<'static>: Send> + 'static,
+        I: SystemInput<Inner<'static>: Send + Event<Trigger<'static>: Default>> + 'static,
     {
         match callback {
             Callback::System(system_id) => self.run_system_with(*system_id, input),
+            Callback::Event => self.trigger(input),
             Callback::Ignore => (),
         }
     }
 }
 
 impl Notify for World {
-    fn notify(&mut self, callback: &Callback<()>) {
-        match callback {
-            Callback::System(system_id) => {
-                let _ = self.run_system(*system_id);
-            }
-            Callback::Ignore => (),
-        }
-    }
-
     fn notify_with<I>(&mut self, callback: &Callback<I>, input: I::Inner<'static>)
     where
-        I: SystemInput<Inner<'static>: Send> + 'static,
+        I: SystemInput<Inner<'static>: Send + Event<Trigger<'static>: Default>> + 'static,
     {
         match callback {
             Callback::System(system_id) => {
                 let _ = self.run_system_with(*system_id, input);
             }
+            Callback::Event => self.trigger(input),
             Callback::Ignore => (),
         }
     }
 }
 
 impl Notify for DeferredWorld<'_> {
-    fn notify(&mut self, callback: &Callback<()>) {
-        match callback {
-            Callback::System(system_id) => {
-                self.commands().run_system(*system_id);
-            }
-            Callback::Ignore => (),
-        }
-    }
-
     fn notify_with<I>(&mut self, callback: &Callback<I>, input: I::Inner<'static>)
     where
-        I: SystemInput<Inner<'static>: Send> + 'static,
+        I: SystemInput<Inner<'static>: Send + Event<Trigger<'static>: Default>> + 'static,
     {
         match callback {
             Callback::System(system_id) => {
                 self.commands().run_system_with(*system_id, input);
             }
+            Callback::Event => self.trigger(input),
             Callback::Ignore => (),
         }
     }

--- a/crates/bevy_ui_widgets/src/lib.rs
+++ b/crates/bevy_ui_widgets/src/lib.rs
@@ -33,7 +33,7 @@ pub use scrollbar::*;
 pub use slider::*;
 
 use bevy_app::{PluginGroup, PluginGroupBuilder};
-use bevy_ecs::entity::Entity;
+use bevy_ecs::{entity::Entity, event::EntityEvent};
 
 /// A plugin group that registers the observers for all of the widgets in this crate. If you don't want to
 /// use all of the widgets, you can import the individual widget plugins instead.
@@ -51,13 +51,14 @@ impl PluginGroup for UiWidgetsPlugins {
 }
 
 /// Notification sent by a button or menu item.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, EntityEvent)]
 pub struct Activate(pub Entity);
 
 /// Notification sent by a widget that edits a scalar value.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, EntityEvent)]
 pub struct ValueChange<T> {
     /// The id of the widget that produced this value.
+    #[event_target]
     pub source: Entity,
     /// The new value.
     pub value: T,


### PR DESCRIPTION
This adds a new variant `Callback::Event` which causes the widget to emit an `EntityEvent` rather than run a one-shot system. The same notification types can be used either as `In` parameters or events (nice how that worked out).

This compiles, but is untested; I had planned to update the examples, but that's hard to do without support for adding observers declaratively, an option which is currently not present in Bevy main.

In particular, I wanted to explore the idea of a "standard uncontrolled observer" - that is, a generic function such as `.observe(uncontrolled_slider)` which would transform a widget from a controlled to uncontrolled mode - that is, the observer would be responsible for updating the state of the widget in response to events. This would significantly mitigate some of the pain of dealing with controlled widgets for novice users.

This PR isn't meant to be a final solution; having to specify `Callback::Event` everywhere would be cumbersome. The main motivation here is to provide a basis for experimenting with other API choices.

@cart @alice-i-cecile @ickshonpe 