### PR TITLE
Normalize `path` component in `AssetPath` constructors and `From` impls

### DIFF
--- a/crates/bevy_asset/src/io/processor_gated.rs
+++ b/crates/bevy_asset/src/io/processor_gated.rs
@@ -74,7 +74,8 @@ impl AssetReader for ProcessorGatedReader {
     }
 
     async fn read_meta<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
-        let asset_path = AssetPath::from(path.to_path_buf()).with_source(self.source.clone());
+        let normalized_path = normalize_path(path);
+        let asset_path = AssetPath::from(normalized_path).with_source(self.source.clone());
         trace!("Waiting for processing to finish before reading meta for {asset_path}",);
         let process_result = self
             .processor_data

--- a/crates/bevy_asset/src/io/processor_gated.rs
+++ b/crates/bevy_asset/src/io/processor_gated.rs
@@ -1,5 +1,6 @@
 use crate::{
     io::{AssetReader, AssetReaderError, AssetSourceId, PathStream, Reader},
+    normalize_path,
     processor::{AssetProcessorData, ProcessStatus},
     AssetPath,
 };
@@ -52,7 +53,8 @@ impl ProcessorGatedReader {
 
 impl AssetReader for ProcessorGatedReader {
     async fn read<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
-        let asset_path = AssetPath::from(path.to_path_buf()).with_source(self.source.clone());
+        let normalized_path = normalize_path(path);
+        let asset_path = AssetPath::from(normalized_path).with_source(self.source.clone());
         trace!("Waiting for processing to finish before reading {asset_path}");
         let process_result = self
             .processor_data

--- a/crates/bevy_asset/src/io/processor_gated.rs
+++ b/crates/bevy_asset/src/io/processor_gated.rs
@@ -1,6 +1,5 @@
 use crate::{
     io::{AssetReader, AssetReaderError, AssetSourceId, PathStream, Reader},
-    normalize_path,
     processor::{AssetProcessorData, ProcessStatus},
     AssetPath,
 };
@@ -53,8 +52,7 @@ impl ProcessorGatedReader {
 
 impl AssetReader for ProcessorGatedReader {
     async fn read<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
-        let normalized_path = normalize_path(path);
-        let asset_path = AssetPath::from(normalized_path).with_source(self.source.clone());
+        let asset_path = AssetPath::from(path.to_path_buf()).with_source(self.source.clone());
         trace!("Waiting for processing to finish before reading {asset_path}");
         let process_result = self
             .processor_data
@@ -74,8 +72,7 @@ impl AssetReader for ProcessorGatedReader {
     }
 
     async fn read_meta<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
-        let normalized_path = normalize_path(path);
-        let asset_path = AssetPath::from(normalized_path).with_source(self.source.clone());
+        let asset_path = AssetPath::from(path.to_path_buf()).with_source(self.source.clone());
         trace!("Waiting for processing to finish before reading meta for {asset_path}",);
         let process_result = self
             .processor_data

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -927,6 +927,35 @@ mod tests {
     }
 
     #[test]
+    fn load_relative_path() {
+        let dir = Dir::default();
+        let d_path = "a/b/c/d.cool.ron";
+        let d_ron = r#"
+(
+    text: "hello",
+    dependencies: [],
+    embedded_dependencies: [],
+    sub_texts: [],
+)"#;
+        dir.insert_asset_text(Path::new(d_path), d_ron);
+
+        let (mut app, gate_opener) = test_app(dir);
+        gate_opener.open(d_path);
+        app.init_asset::<CoolText>()
+            .register_asset_loader(CoolTextLoader);
+        let asset_server = app.world().resource::<AssetServer>().clone();
+        let handle: Handle<CoolText> = asset_server.load("a/b/c/../c/d.cool.ron");
+        let d_id = handle.id();
+        app.update();
+
+        let handle2: Handle<CoolText> = asset_server.load("a/b/../b/c/d.cool.ron");
+        let handle3: Handle<CoolText> = asset_server.load("a/b/c/./d.cool.ron");
+
+        assert_eq!(handle2.id(), d_id);
+        assert_eq!(handle3.id(), d_id);
+    }
+
+    #[test]
     fn load_dependencies() {
         let dir = Dir::default();
 

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -339,8 +339,10 @@ impl<'a> AssetPath<'a> {
         }
     }
 
-    /// Normalizes the path by collapsing all occurrences of '.' and '..' dot-segments where possible.
-    /// See [`normalize_cow_path`] for more details.
+    /// Normalizes the path component of the `AssetPath` by collapsing all
+    /// occurrences of '.' and '..' dot-segments where possible as per [RFC
+    /// 1808](https://datatracker.ietf.org/doc/html/rfc1808).
+    /// If the path is already normalized, this will return `self` unchanged.
     pub fn normalized(self) -> AssetPath<'a> {
         AssetPath {
             source: self.source,

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -664,6 +664,10 @@ impl<'de> Visitor<'de> for AssetPathVisitor {
 
 /// Normalizes the path by collapsing all occurrences of '.' and '..' dot-segments where possible
 /// as per [RFC 1808](https://datatracker.ietf.org/doc/html/rfc1808)
+#[cfg_attr(
+    not(feature = "file_watcher"),
+    expect(dead_code, reason = "used in file_watcher feature")
+)]
 pub(crate) fn normalize_path(path: &Path) -> Cow<'_, Path> {
     match maybe_normalize_path(path) {
         Some(pathbuf) => Cow::Owned(pathbuf),

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -11,10 +11,7 @@ use core::{
     ops::Deref,
 };
 use serde::{de::Visitor, Deserialize, Serialize};
-use std::{
-    borrow::Cow,
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 use thiserror::Error;
 
 /// Represents a path to an asset in a "virtual filesystem".
@@ -668,10 +665,10 @@ impl<'de> Visitor<'de> for AssetPathVisitor {
     not(feature = "file_watcher"),
     expect(dead_code, reason = "used in file_watcher feature")
 )]
-pub(crate) fn normalize_path(path: &Path) -> Cow<'_, Path> {
+pub(crate) fn normalize_path(path: &Path) -> alloc::borrow::Cow<'_, Path> {
     match maybe_normalize_path(path) {
-        Some(pathbuf) => Cow::Owned(pathbuf),
-        None => Cow::Borrowed(path),
+        Some(pathbuf) => alloc::borrow::Cow::Owned(pathbuf),
+        None => alloc::borrow::Cow::Borrowed(path),
     }
 }
 


### PR DESCRIPTION
# Objective

Fixes #21131

The `ProcessorGatedReader` tries to look up assets by path in the processor's `AssetInfos` so it can wait for the processor to be finished processing, and doesn't find an asset for a relative path, and so it errors, even though the asset exists, and is being processed.

## Solution

Since the gated reader tries to look up processed assets by their path, the path
should be normalized for this operation.
## Testing

`cd crates/bevy_asset; cargo test`

-----
because of lifetimes, I'm not sure it's possible to read the processed asset with the same normalized path here.
I would expect both the path and the normalized path to resolve to the same file on the file system, ofc because filesystems are the worst enemy of the programmer, this isn't guaranteed to be the case, but I think it's a reasonable expectation here. Notably, this doesn't fix potential issues with symlinks.