### PR TITLE
bevy_reflect: Add `serialize` function in `ReflectSerialize`

### DIFF
--- a/crates/bevy_reflect/src/serde/ser/custom_serialization.rs
+++ b/crates/bevy_reflect/src/serde/ser/custom_serialization.rs
@@ -3,8 +3,7 @@ use crate::serde::ser::error_utils::make_custom_error;
 use crate::serde::ser::error_utils::TYPE_INFO_STACK;
 use crate::serde::ReflectSerializeWithRegistry;
 use crate::{PartialReflect, ReflectSerialize, TypeRegistry};
-use core::borrow::Borrow;
-use serde::{Serialize, Serializer};
+use serde::Serializer;
 
 /// Attempts to serialize a [`PartialReflect`] value with custom [`ReflectSerialize`]
 /// or [`ReflectSerializeWithRegistry`] type data.
@@ -42,10 +41,7 @@ pub(super) fn try_custom_serialize<S: Serializer>(
         #[cfg(feature = "debug_stack")]
         TYPE_INFO_STACK.with_borrow_mut(crate::type_info_stack::TypeInfoStack::pop);
 
-        Ok(reflect_serialize
-            .get_serializable(value)
-            .borrow()
-            .serialize(serializer))
+        Ok(reflect_serialize.serialize(value, serializer))
     } else if let Some(reflect_serialize_with_registry) =
         registration.data::<ReflectSerializeWithRegistry>()
     {


### PR DESCRIPTION
# Objective

1. The `ReflectDeserialize` struct provides a `deserialize` function that inputs a `Deserializer` and returns a `dyn Reflect`, completing the full deserialization process. However, `ReflectSerialize` only offers `get_serializable`, which converts a `dyn Reflect` into a `dyn erased_serde::Serialize`, without providing a complete serialization function. This confuses the reader.

2. The `pub` on the `func` field of `ReflectDeserialize` appears to be redundant.

## Solution

- Add `serialize` function for `ReflectSerialize` struct. Allowing the use of `.serialize(value, serializer)` instead of the original `.get_serializable(value).serialize(serializer)`.

- The `get_serializable` function is temporarily kept as it is used in tests in `bevy_reflect/src/impls/core/time.rs`.

- Removed `pub` from the `func` field in `ReflectDeserialize`.

## Testing
 
- `cd crates/bevy_reflect; cargo test`
- `cd crates/bevy_ecs; cargo test`
- `cd crates/bevy_asset; cargo test`
---

## Showcase

<details>
  <summary>Click to view showcase</summary>

```rust
// bevy_reflect  type_registry.rs
pub struct ReflectSerialize {
    func: fn(value: &dyn Reflect) -> Serializable,
}

impl ReflectSerialize {
    pub fn get_serializable<'a>(&self, value: &'a dyn Reflect) -> Serializable<'a> {
        (self.func)(value)
    }

    // ↓↓↓ Added
    /// Serializes a reflected value.
    pub fn serialize<S>(&self, value: &dyn Reflect, serializer: S) -> Result<S::Ok, S::Error>
    where
        S: serde::Serializer,
    {
        (self.func)(value).serialize(serializer)
    }
}

// ....

pub struct ReflectDeserialize {
    // removed `pub`
    func: fn(
        deserializer: &mut dyn erased_serde::Deserializer,
    ) -> Result<Box<dyn Reflect>, erased_serde::Error>,
}

// bevy_reflect  custom_serialization.rs
/*
Ok(reflect_serialize
    .get_serializable(value)
    .borrow()
    .serialize(serializer))
*/
Ok(reflect_serialize.serialize(value, serializer))
```

</details>
