### PR TITLE
add helper to get tile_data_from_tile_pos from tilemapchunktiledata

### DIFF
--- a/crates/bevy_sprite_render/src/tilemap_chunk/mod.rs
+++ b/crates/bevy_sprite_render/src/tilemap_chunk/mod.rs
@@ -210,3 +210,15 @@ fn update_tilemap_chunk_indices(
         data.extend_from_slice(bytemuck::cast_slice(&packed_tile_data));
     }
 }
+
+impl TilemapChunkTileData {
+    pub fn tile_data_from_tile_pos(
+        &self,
+        tilemap_size: UVec2,
+        position: UVec2,
+    ) -> Option<&TileData> {
+        self.0
+            .get(tilemap_size.x as usize * position.y as usize + position.x as usize)
+            .and_then(|opt| opt.as_ref())
+    }
+}

--- a/examples/2d/tilemap_chunk.rs
+++ b/examples/2d/tilemap_chunk.rs
@@ -87,8 +87,14 @@ fn update_tilemap(
 }
 
 // find the data for an arbitrary tile in the chunk and log its data
-fn log_tile(tilemap: Single<(&TilemapChunk, &TilemapChunkTileData)>) {
+fn log_tile(tilemap: Single<(&TilemapChunk, &TilemapChunkTileData)>, mut local: Local<u16>) {
     let (chunk, data) = tilemap.into_inner();
-    let tile_data = data.tile_data_from_tile_pos(chunk.chunk_size, UVec2::new(3, 4));
-    info!(?tile_data);
+    let Some(tile_data) = data.tile_data_from_tile_pos(chunk.chunk_size, UVec2::new(3, 4)) else {
+        return;
+    };
+    // log when the tile changes
+    if tile_data.tileset_index != *local {
+        info!(?tile_data, "tile_data changed");
+        *local = tile_data.tileset_index;
+    }
 }

--- a/examples/2d/tilemap_chunk.rs
+++ b/examples/2d/tilemap_chunk.rs
@@ -11,7 +11,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest()))
         .add_systems(Startup, setup)
-        .add_systems(Update, (update_tileset_image, update_tilemap))
+        .add_systems(Update, (update_tileset_image, update_tilemap, log_tile))
         .run();
 }
 
@@ -84,4 +84,11 @@ fn update_tilemap(
             }
         }
     }
+}
+
+// find the data for an arbitrary tile in the chunk and log its data
+fn log_tile(tilemap: Single<(&TilemapChunk, &TilemapChunkTileData)>) {
+    let (chunk, data) = tilemap.into_inner();
+    let tile_data = data.tile_data_from_tile_pos(chunk.chunk_size, UVec2::new(3, 4));
+    info!(?tile_data);
 }


### PR DESCRIPTION
# Objective

When using the new tilemap chunk facilities, getting the data associated with a specific tile is not currently exposed via API, making users do the math themselves.

## Solution

Add a helper function to calculate the index position of `TileData` given a chunk size and a position

## Testing

This example now includes a log that logs out when a specific tile's index changes

```
cargo run --example tilemap_chunk
```

```
2025-09-21T07:36:23.489006Z  INFO tilemap_chunk: tile_data changed tile_data=TileData { tileset_index: 2, color: LinearRgba(LinearRgba { red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0 }), visible: true }
2025-09-21T07:36:32.514408Z  INFO tilemap_chunk: tile_data changed tile_data=TileData { tileset_index: 3, color: LinearRgba(LinearRgba { red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0 }), visible: true }
2025-09-21T07:36:37.040941Z  INFO tilemap_chunk: tile_data changed tile_data=TileData { tileset_index: 2, color: LinearRgba(LinearRgba { red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0 }), visible: true }
```

---

## Showcase

```rust
fn log_tile(tilemap: Single<(&TilemapChunk, &TilemapChunkTileData)>) {
    let (chunk, data) = tilemap.into_inner();
    let Some(tile_data) = data.tile_data_from_tile_pos(chunk.chunk_size, UVec2::new(3, 4)) else {
        return;
    };
    // do something with tile_data
}
```

---

I alternatively considered storing the chunk size in the `TilemapChunkTileData` as a private field, since the component hooks guarantee the chunk_size needs to match between TilemapChunk and the data. This would eliminate the chunk_size argument from the function but also require re-setting the chunk size to reuse the same data with a different chunk_size with the same length.

We could take this alternative approach, but I figured the simpler helper would have a higher chance of making it into 0.17.

The function could also be named something like `data.at(chunk_size, position)` instead of the longer name here.

prior art for storage helpers on arrays that are stored like this: https://github.com/StarArawn/bevy_ecs_tilemap/blob/c2c1d076bd70d132edb6410e835a2ba6bdbaab5c/src/tiles/storage.rs#L43