### PR TITLE
enable calculating the Transform of a tile

### DIFF
--- a/crates/bevy_sprite_render/src/tilemap_chunk/mod.rs
+++ b/crates/bevy_sprite_render/src/tilemap_chunk/mod.rs
@@ -1,3 +1,5 @@
+use std::ops::Neg;
+
 use crate::{AlphaMode2d, MeshMaterial2d};
 use bevy_app::{App, Plugin, Update};
 use bevy_asset::{Assets, Handle};
@@ -18,6 +20,7 @@ use bevy_math::{primitives::Rectangle, UVec2};
 use bevy_mesh::{Mesh, Mesh2d};
 use bevy_platform::collections::HashMap;
 use bevy_reflect::{prelude::*, Reflect};
+use bevy_transform::components::Transform;
 use bevy_utils::default;
 use tracing::warn;
 
@@ -56,6 +59,33 @@ pub struct TilemapChunk {
     pub tileset: Handle<Image>,
     /// The alpha mode to use for the tilemap chunk.
     pub alpha_mode: AlphaMode2d,
+}
+
+impl TilemapChunk {
+    pub fn calculate_tile_transform(&self, position: UVec2) -> Transform {
+        Transform::from_xyz(
+            // tile position
+            position.x as f32 
+            // times display size for a tile
+            * self.tile_display_size.x as f32
+               // plus 1/2 the tile_display_size
+            + self.tile_display_size.x as f32 / 2.
+            // minus 1/2 the tilechunk size, in terms of the tile_display_size,
+            // to place the 0,0 at top_left
+            - self.tile_display_size.x as f32 * self.chunk_size.y as f32 / 2.
+            ,
+            // tile position
+            position.y as f32 
+            // times display size for a tile
+            * (self.tile_display_size.y as f32).neg()
+            // plus 1/2 the tile_display_size
+            - self.tile_display_size.y as f32 / 2.
+            // minus 1/2 the tilechunk size, in terms of the tile_display_size,
+            // to place the 0,0 at top_left
+            + self.tile_display_size.y as f32 * self.chunk_size.y as f32 / 2.,
+            0.,
+        )
+    }
 }
 
 /// Data for a single tile in the tilemap chunk.

--- a/examples/2d/tilemap_chunk.rs
+++ b/examples/2d/tilemap_chunk.rs
@@ -1,6 +1,7 @@
 //! Shows a tilemap chunk rendered with a single draw call.
 
 use bevy::{
+    color::palettes::tailwind::RED_400,
     prelude::*,
     sprite_render::{TileData, TilemapChunk, TilemapChunkTileData},
 };
@@ -10,8 +11,8 @@ use rand_chacha::ChaCha8Rng;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest()))
-        .add_systems(Startup, setup)
-        .add_systems(Update, (update_tileset_image, update_tilemap))
+        .add_systems(Startup, (setup, spawn_fake_player).chain())
+        .add_systems(Update, (update_tileset_image, update_tilemap, move_player))
         .run();
 }
 
@@ -53,6 +54,55 @@ fn setup(mut commands: Commands, assets: Res<AssetServer>) {
     commands.spawn(Camera2d);
 
     commands.insert_resource(SeededRng(rng));
+}
+
+#[derive(Component)]
+struct MovePlayer;
+
+fn spawn_fake_player(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+    chunk: Single<&TilemapChunk>,
+) {
+    let mut transform = chunk.calculate_tile_transform(UVec2::new(0, 0));
+    transform.translation.z = 1.;
+
+    commands.spawn((
+        Mesh2d(meshes.add(Rectangle::new(8., 8.))),
+        MeshMaterial2d(materials.add(Color::from(RED_400))),
+        transform,
+        MovePlayer,
+    ));
+
+    let mut transform = chunk.calculate_tile_transform(UVec2::new(5, 6));
+    transform.translation.z = 1.;
+
+    // second "player" to visually test a non-zero position
+    commands.spawn((
+        Mesh2d(meshes.add(Rectangle::new(8., 8.))),
+        MeshMaterial2d(materials.add(Color::from(RED_400))),
+        transform,
+    ));
+}
+
+fn move_player(
+    mut player: Single<&mut Transform, With<MovePlayer>>,
+    time: Res<Time>,
+    chunk: Single<&TilemapChunk>,
+) {
+    let t = (time.elapsed_secs().sin() + 1.) / 2.;
+
+    let origin = chunk
+        .calculate_tile_transform(UVec2::new(0, 0))
+        .translation
+        .x;
+    let destination = chunk
+        .calculate_tile_transform(UVec2::new(63, 0))
+        .translation
+        .x;
+
+    player.translation.x = origin.lerp(destination, t);
 }
 
 fn update_tileset_image(


### PR DESCRIPTION
# Objective

Placing a player relative to a `TilemapChunk` but not in the tilemap itself (for example, Pokemon's Trainer) requires calculating the Transform of the relevant tile.
Animating these values (ex: Pokemon Trainer walking across tiles) also requires Transforms

## Solution

Add a helper to calculate the transforms of tiles.

## Testing

```
cargo run --example tilemap_chunk
```

```rust
let mut transform = chunk.calculate_tile_transform(UVec2::new(5, 6));
transform.translation.z = 1.;

commands.spawn((
    Mesh2d(meshes.add(Rectangle::new(8., 8.))),
    MeshMaterial2d(materials.add(Color::from(RED_400))),
    transform,
));
```

## Showcase


https://github.com/user-attachments/assets/97efeba0-fb09-4b77-9907-17710272d601

---

## Other

Maybe the function should return a z-index of 1 by default? I found myself "raising" the z-index basically immediately... or Transform should have a `with_z` function like the underlying Translation does.