### PR TITLE
Remove X11 as a default feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ ref_as_ptr = "warn"
 
 too_long_first_doc_paragraph = "allow"
 
+
 std_instead_of_core = "allow"
 std_instead_of_alloc = "allow"
 alloc_instead_of_core = "allow"
@@ -174,7 +175,6 @@ default = [
   "tonemapping_luts",
   "vorbis",
   "webgl2",
-  "x11",
   "wayland",
   "debug",
   "zstd_rust",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,6 @@ ref_as_ptr = "warn"
 
 too_long_first_doc_paragraph = "allow"
 
-
 std_instead_of_core = "allow"
 std_instead_of_alloc = "allow"
 alloc_instead_of_core = "allow"

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -135,7 +135,7 @@ multi_threaded = [
 ]
 async-io = ["std", "bevy_tasks/async-io"]
 
-# Display server protocol support (X11 is enabled by default)
+# Display server protocol support (Wayland is enabled by default)
 wayland = ["bevy_winit/wayland"]
 x11 = ["bevy_winit/x11"]
 

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -62,7 +62,6 @@ The default feature set enables most of the expected features of a game engine, 
 |vorbis|OGG/VORBIS audio format support|
 |wayland|Wayland display server support|
 |webgl2|Enable some limitations to be able to use WebGL2. Please refer to the [WebGL2 and WebGPU](https://github.com/bevyengine/bevy/tree/latest/examples#webgl2-and-webgpu) section of the examples README for more information on how to run Wasm builds with WebGPU.|
-|x11|X11 display server support|
 |zstd_rust|For KTX2 Zstandard decompression using pure rust [ruzstd](https://crates.io/crates/ruzstd). This is the safe default. For maximum performance, use "zstd_c".|
 
 ### Optional Features
@@ -147,5 +146,6 @@ The default feature set enables most of the expected features of a game engine, 
 |web_asset_cache|Enable caching downloaded assets on the filesystem. NOTE: this cache currently never invalidates entries!|
 |webgpu|Enable support for WebGPU in Wasm. When enabled, this feature will override the `webgl2` feature and you won't be able to run Wasm builds with WebGL2, only with WebGPU.|
 |webp|WebP image format support|
+|x11|X11 display server support|
 |zlib|For KTX2 supercompression|
 |zstd_c|For KTX2 Zstandard decompression using [zstd](https://crates.io/crates/zstd). This is a faster backend, but uses unsafe C bindings. For the safe option, stick to the default backend with "zstd_rust".|

--- a/release-content/migration-guides/x11-no-longer-default.md
+++ b/release-content/migration-guides/x11-no-longer-default.md
@@ -1,5 +1,5 @@
 ---
-title: "X11 no longer enabled by default."
+title: "X11 is no longer enabled by default"
 pull_requests: [21158]
 ---
 

--- a/release-content/migration-guides/x11-no-longer-default.md
+++ b/release-content/migration-guides/x11-no-longer-default.md
@@ -1,0 +1,26 @@
+---
+title: "X11 no longer enabled by default."
+pull_requests: [21158]
+---
+
+X11 support is on the downturn, with other players like GTK announcing that
+they're considering deprecating X11 support in the next major release and
+Fedora 43 later this year is going to be Wayland only. With this in mind,
+the `x11` top level feature on the Bevy crate is no longer a default
+feature when building for Linux targets.
+
+If your project was already targetting Wayland-only systems, this is
+effectively a no-op and can safely be ignored.
+
+If you still require X.Org support, you can manually reenable the `x11`
+feature:
+
+```toml
+# 0.17
+[dependencies]
+bevy = { version = 0.17 }
+
+# 0.17
+[dependencies]
+bevy = { version = 0.17, features = ["x11"] }
+```

--- a/release-content/migration-guides/x11-no-longer-default.md
+++ b/release-content/migration-guides/x11-no-longer-default.md
@@ -9,7 +9,7 @@ Fedora 43 later this year is going to be Wayland only. With this in mind,
 the `x11` top level feature on the Bevy crate is no longer a default
 feature when building for Linux targets.
 
-If your project was already targetting Wayland-only systems, this is
+If your project was already targeting Wayland-only systems, this is
 effectively a no-op and can safely be ignored.
 
 If you still require X.Org support, you can manually reenable the `x11`


### PR DESCRIPTION
# Objective
Follow-up to #19232. X11 support is on the downturn, with other players like GTK announcing that they're considering deprecating X11 support in the next major release and Fedora 43 later this year is going to be Wayland only.

## Solution
Remove x11 as a default feature from the top level `bevy` crate.

## Testing
Local build run of `3d_example`. This doesn't seem to impact compile times significantly. Release builds shave off about 1MB.