### PR TITLE
Change default for `ExecutorKind` when `std` feature is off

### DIFF
--- a/crates/bevy_ecs/src/schedule/executor/mod.rs
+++ b/crates/bevy_ecs/src/schedule/executor/mod.rs
@@ -53,7 +53,14 @@ pub enum ExecutorKind {
     ///
     /// Useful if you're dealing with a single-threaded environment, saving your threads for
     /// other things, or just trying minimize overhead.
-    #[cfg_attr(any(target_arch = "wasm32", not(feature = "multi_threaded")), default)]
+    #[cfg_attr(
+        any(
+            target_arch = "wasm32",
+            not(feature = "std"),
+            not(feature = "multi_threaded")
+        ),
+        default
+    )]
     SingleThreaded,
     /// Like [`SingleThreaded`](ExecutorKind::SingleThreaded) but calls [`apply_deferred`](crate::system::System::apply_deferred)
     /// immediately after running each system.


### PR DESCRIPTION
# Objective

There is no default for `ExecutorKind` if `multi_threaded` is enabled but `std` is not.
Closes #21144 

## Solution

Add `SingleThreaded` as default for that case

## Testing

`cargo clippy -p bevy_ecs --no-default-features --features="multi_threaded"`

## Alternatives

Make `multi_threaded` require `std`
