### PR TITLE
Adds migration instructions for old zstd feature.

### DIFF
--- a/release-content/migration-guides/zstd.md
+++ b/release-content/migration-guides/zstd.md
@@ -5,3 +5,22 @@ pull_requests: [19793]
 
 A more performant zstd backend has been added for texture decompression. To enable it, disable default-features and enable feature "zstd_c".
 If you have default-features disabled and use functionality that requires zstd decompression ("tonemapping_luts" or "ktx2"), you must choose a zstd implementation with one of the following feature flags: "zstd_c" (faster) or "zstd_rust" (safer)
+
+## Migration Guide
+
+If you previously used the `zstd` feature explicitly:
+```toml
+# 0.16
+[dependencies]
+bevy = { version = "0.16", features = ["zstd"] }
+
+# 0.17 - Use the safe Rust implementation:
+[dependencies]
+bevy = { version = "0.17", features = ["zstd_rust"] }
+
+# 0.17 - Or use the faster C implementation:
+[dependencies]
+bevy = { version = "0.17", features = ["zstd_c"] }
+```
+
+If you have default-features disabled and use functionality that requires zstd decompression ("tonemapping_luts" or "ktx2"), you must choose a zstd implementation with one of the following feature flags: "zstd_c" (faster) or "zstd_rust" (safer).

--- a/release-content/migration-guides/zstd.md
+++ b/release-content/migration-guides/zstd.md
@@ -9,6 +9,7 @@ If you have default-features disabled and use functionality that requires zstd d
 ## Migration Guide
 
 If you previously used the `zstd` feature explicitly, it has been renamed to `zstd_rust`:
+
 ```toml
 # 0.16
 [dependencies]

--- a/release-content/migration-guides/zstd.md
+++ b/release-content/migration-guides/zstd.md
@@ -8,7 +8,7 @@ If you have default-features disabled and use functionality that requires zstd d
 
 ## Migration Guide
 
-If you previously used the `zstd` feature explicitly:
+If you previously used the `zstd` feature explicitly, it has been renamed to `zstd_rust`:
 ```toml
 # 0.16
 [dependencies]


### PR DESCRIPTION
# Objective

Fixes #21089 

The migration guide for the `zstd` feature changes didn't explain how to migrate from the old `zstd` feature to the new split features.

## Solution

Added migration instructions showing that the old `zstd` feature should be replaced with either `zstd_rust` (safe default) or `zstd_c` (faster but unsafe).

## Testing

- Documentation change only, no code to test
- Verified the feature change in git history (PR #19793)

##
Link to the issue: [https://github.com/bevyengine/bevy/issues/21089](https://github.com/bevyengine/bevy/issues/21089)