### PR TITLE
Add `serialize` method to `ReflectSerialize` (bevy_reflect)

### DIFF
--- a/crates/bevy_reflect/src/serde/ser/custom_serialization.rs
+++ b/crates/bevy_reflect/src/serde/ser/custom_serialization.rs
@@ -3,8 +3,7 @@ use crate::serde::ser::error_utils::make_custom_error;
 use crate::serde::ser::error_utils::TYPE_INFO_STACK;
 use crate::serde::ReflectSerializeWithRegistry;
 use crate::{PartialReflect, ReflectSerialize, TypeRegistry};
-use core::borrow::Borrow;
-use serde::{Serialize, Serializer};
+use serde::Serializer;
 
 /// Attempts to serialize a [`PartialReflect`] value with custom [`ReflectSerialize`]
 /// or [`ReflectSerializeWithRegistry`] type data.
@@ -42,10 +41,7 @@ pub(super) fn try_custom_serialize<S: Serializer>(
         #[cfg(feature = "debug_stack")]
         TYPE_INFO_STACK.with_borrow_mut(crate::type_info_stack::TypeInfoStack::pop);
 
-        Ok(reflect_serialize
-            .get_serializable(value)
-            .borrow()
-            .serialize(serializer))
+        Ok(reflect_serialize.serialize(value, serializer))
     } else if let Some(reflect_serialize_with_registry) =
         registration.data::<ReflectSerializeWithRegistry>()
     {

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -12,7 +12,7 @@ use core::{
     ops::{Deref, DerefMut},
 };
 use downcast_rs::{impl_downcast, Downcast};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// A registry of [reflected] types.
 ///
@@ -780,6 +780,14 @@ impl ReflectSerialize {
     /// Turn the value into a serializable representation
     pub fn get_serializable<'a>(&self, value: &'a dyn Reflect) -> Serializable<'a> {
         (self.get_serializable)(value)
+    }
+
+    /// Serializes a reflected value.
+    pub fn serialize<S>(&self, value: &dyn Reflect, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        (self.get_serializable)(value).serialize(serializer)
     }
 }
 


### PR DESCRIPTION
# Objective

This change allows direct use of `.serialize(value, serializer)` instead of the more verbose `.get_serializable(value).serialize(serializer)`.

Currently, `ReflectDeserialize`, `ReflectDeserializeWithRegistry`, and `ReflectSerializeWithRegistry` all provide a `deserialize`/`serialize` method directly. It is inconsistent and somewhat odd that `ReflectSerialize` only provides `get_serializable`.

While the returned `Serializable` object does expose a `serialize` method, I believe `ReflectSerialize` should offer a direct `serialize` method for better ergonomics.

The existing `get_serializable` method can still be used to obtain the `Serializable` struct for testing or other specialized use cases. However, for typical serialization tasks, the direct `.serialize(...)` approach is clearer and more concise.

## Solution

Add `serialize` function for `ReflectSerialize`.


## Testing
 
- `cd crates/bevy_reflect; cargo test`
- `cd crates/bevy_ecs; cargo test`
- `cd crates/bevy_asset; cargo test`
- `cargo run --example serialization`
---

## Showcase

<details>
  <summary>Click to view showcase</summary>

```rust
// bevy_reflect  type_registry.rs
#[derive(Clone)]
pub struct ReflectSerialize {
    get_serializable: fn(value: &dyn Reflect) -> Serializable,
}

impl ReflectSerialize {
    // keep function `get_serializable()` unchanged .

    /// Serializes a reflected value.
    pub fn serialize<S>(&self, value: &dyn Reflect, serializer: S) -> Result<S::Ok, S::Error>
    where
        S: serde::Serializer,
    {
        (self.get_serializable)(value).serialize(serializer)
    }
}

// bevy_reflect  custom_serialization.rs
/*
Ok(reflect_serialize
    .get_serializable(value)
    .borrow()
    .serialize(serializer))
*/
Ok(reflect_serialize.serialize(value, serializer))
```

</details>
