### PR TITLE
Fix docs on `Query::single_inner()` saying it panics

### DIFF
--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1952,7 +1952,6 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     ///
     /// - [`single`](Self::single) to get the read-only query item.
     /// - [`single_mut`](Self::single_mut) to get the mutable query item.
-    /// - [`single_inner`](Self::single_inner) for the panicking version.
     #[inline]
     pub fn single_inner(self) -> Result<D::Item<'w, 's>, QuerySingleError> {
         let mut query = self.into_iter();


### PR DESCRIPTION
# Objective

- While reviewing https://github.com/TheBevyFlock/bevy_cli/pull/577, I was looking to see if any of `Query`'s methods still have complementary panicking / non-panicking versions
- Turns out, `Query::single_inner()` mistakenly links to itself as a "panicking version", which isn't true

## Solution

- Remove the entry about panicking versions, they don't exist anymore

## Testing

None :)