### PR TITLE
Replace `#[expect(dead_code)]` with `#[allow(dead_code)]` in some tests

### DIFF
--- a/crates/bevy_ecs/src/relationship/mod.rs
+++ b/crates/bevy_ecs/src/relationship/mod.rs
@@ -554,7 +554,7 @@ mod tests {
             bar: u8,
         }
 
-        #[expect(
+        #[allow(
             dead_code,
             reason = "This struct is used as a compilation test to test the derive macros, and as such is intentionally never constructed."
         )]
@@ -566,7 +566,7 @@ mod tests {
     }
     #[test]
     fn relationship_target_with_multiple_non_target_fields_compiles() {
-        #[expect(
+        #[allow(
             dead_code,
             reason = "This struct is used as a compilation test to test the derive macros, and as such is intentionally never constructed."
         )]
@@ -592,7 +592,7 @@ mod tests {
 
     #[test]
     fn relationship_with_multiple_unnamed_non_target_fields_compiles() {
-        #[expect(
+        #[allow(
             dead_code,
             reason = "This struct is used as a compilation test to test the derive macros, and as such is intentionally never constructed."
         )]
@@ -600,7 +600,7 @@ mod tests {
         #[relationship(relationship_target=Target<T>)]
         struct Source<T: Send + Sync + 'static>(#[relationship] Entity, PhantomData<T>);
 
-        #[expect(
+        #[allow(
             dead_code,
             reason = "This struct is used as a compilation test to test the derive macros, and as such is intentionally never constructed."
         )]

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -1131,21 +1131,21 @@ mod tests {
             }
         }
 
-        #[expect(
+        #[allow(
             dead_code,
             reason = "This struct is used as a compilation test to test the derive macros, and as such is intentionally never constructed."
         )]
         #[derive(Reflect)]
         struct Foo<A>(A);
 
-        #[expect(
+        #[allow(
             dead_code,
             reason = "This struct is used as a compilation test to test the derive macros, and as such is intentionally never constructed."
         )]
         #[derive(Reflect)]
         struct Bar<A, B>(A, B);
 
-        #[expect(
+        #[allow(
             dead_code,
             reason = "This struct is used as a compilation test to test the derive macros, and as such is intentionally never constructed."
         )]


### PR DESCRIPTION
# Objective

#20913 Used `#[expect(dead_code)]` in some scenarios to fix test compilation failures. However, some structs may not be entirely considered `dead_code` due to  `#[derive(Reflect)]` macro. This caused rust-analyzer to report `unfulfilled_lint_expectations` warnings.

This PR replaces some `#[expect(dead_code)]` with `#[allow(dead_code)]` to eliminate these warnings.

## Solution

Replaced `#[expect(dead_code)]` with `#[allow(dead_code)]`

