### PR TITLE
`ComputedTextStyle`

### DIFF
--- a/crates/bevy_feathers/src/font_styles.rs
+++ b/crates/bevy_feathers/src/font_styles.rs
@@ -1,5 +1,4 @@
 //! A framework for inheritable font styles.
-use bevy_app::{Propagate, PropagateOver};
 use bevy_asset::{AssetServer, Handle};
 use bevy_ecs::{
     component::Component,
@@ -17,7 +16,7 @@ use crate::{handle_or_path::HandleOrPath, theme::ThemedText};
 /// downward to any child text entity that has the [`ThemedText`] marker.
 #[derive(Component, Default, Clone, Debug, Reflect)]
 #[reflect(Component, Default)]
-#[require(ThemedText, PropagateOver::<TextFont>::default())]
+#[require(ThemedText)]
 pub struct InheritableFont {
     /// The font handle or path.
     pub font: HandleOrPath<Font>,
@@ -57,10 +56,10 @@ pub(crate) fn on_changed_font(
             HandleOrPath::Path(ref p) => Some(assets.load::<Font>(p)),
         }
     {
-        commands.entity(insert.entity).insert(Propagate(TextFont {
+        commands.entity(insert.entity).insert(TextFont {
             font,
             font_size: style.font_size,
             ..Default::default()
-        }));
+        });
     }
 }

--- a/crates/bevy_feathers/src/lib.rs
+++ b/crates/bevy_feathers/src/lib.rs
@@ -18,14 +18,9 @@
 //! Please report issues, submit fixes and propose changes.
 //! Thanks for stress-testing; let's build something better together.
 
-use bevy_app::{
-    HierarchyPropagatePlugin, Plugin, PluginGroup, PluginGroupBuilder, PostUpdate, PropagateSet,
-};
+use bevy_app::{Plugin, PluginGroup, PluginGroupBuilder, PostUpdate};
 use bevy_asset::embedded_asset;
-use bevy_ecs::{query::With, schedule::IntoScheduleConfigs};
 use bevy_input_focus::{tab_navigation::TabNavigationPlugin, InputDispatchPlugin};
-use bevy_text::{TextColor, TextFont};
-use bevy_ui::UiSystems;
 use bevy_ui_render::UiMaterialPlugin;
 use bevy_ui_widgets::UiWidgetsPlugins;
 
@@ -33,7 +28,7 @@ use crate::{
     alpha_pattern::{AlphaPatternMaterial, AlphaPatternResource},
     controls::ControlsPlugin,
     cursor::{CursorIconPlugin, DefaultCursor, EntityCursor},
-    theme::{ThemedText, UiTheme},
+    theme::UiTheme,
 };
 
 mod alpha_pattern;
@@ -68,17 +63,8 @@ impl Plugin for FeathersPlugin {
         app.add_plugins((
             ControlsPlugin,
             CursorIconPlugin,
-            HierarchyPropagatePlugin::<TextColor, With<ThemedText>>::new(PostUpdate),
-            HierarchyPropagatePlugin::<TextFont, With<ThemedText>>::new(PostUpdate),
             UiMaterialPlugin::<AlphaPatternMaterial>::default(),
         ));
-
-        // This needs to run in UiSystems::Propagate so the fonts are up-to-date for `measure_text_system`
-        // and `detect_text_needs_rerender` in UiSystems::Content
-        app.configure_sets(
-            PostUpdate,
-            PropagateSet::<TextFont>::default().in_set(UiSystems::Propagate),
-        );
 
         app.insert_resource(DefaultCursor(EntityCursor::System(
             bevy_window::SystemCursorIcon::Default,

--- a/crates/bevy_feathers/src/theme.rs
+++ b/crates/bevy_feathers/src/theme.rs
@@ -1,5 +1,4 @@
 //! A framework for theming.
-use bevy_app::{Propagate, PropagateOver};
 use bevy_color::{palettes, Color};
 use bevy_ecs::{
     change_detection::DetectChanges,
@@ -105,7 +104,7 @@ pub struct ThemeBorderColor(pub ThemeToken);
 #[component(immutable)]
 #[derive(Reflect)]
 #[reflect(Component, Clone)]
-#[require(ThemedText, PropagateOver::<TextColor>::default())]
+#[require(ThemedText)]
 pub struct ThemeFontColor(pub ThemeToken);
 
 /// A marker component that is used to indicate that the text entity wants to opt-in to using
@@ -167,8 +166,6 @@ pub(crate) fn on_changed_font_color(
 ) {
     if let Ok(token) = font_color.get(insert.entity) {
         let color = theme.color(&token.0);
-        commands
-            .entity(insert.entity)
-            .insert(Propagate(TextColor(color)));
+        commands.entity(insert.entity).insert(TextColor(color));
     }
 }

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -44,6 +44,8 @@ use bevy_camera::{
     visibility::VisibilitySystems,
 };
 use bevy_mesh::{Mesh, Mesh2d};
+#[cfg(feature = "bevy_text")]
+use bevy_text::update_text_styles;
 #[cfg(feature = "bevy_sprite_picking_backend")]
 pub use picking_backend::*;
 pub use sprite::*;
@@ -87,6 +89,7 @@ impl Plugin for SpritePlugin {
                 bevy_text::detect_text_needs_rerender::<Text2d>,
                 update_text2d_layout
                     .after(bevy_camera::CameraUpdateSystems)
+                    .after(update_text_styles)
                     .after(bevy_text::remove_dropped_font_atlas_sets),
                 calculate_bounds_text2d.in_set(VisibilitySystems::CalculateBounds),
             )

--- a/crates/bevy_sprite/src/text2d.rs
+++ b/crates/bevy_sprite/src/text2d.rs
@@ -309,7 +309,9 @@ mod tests {
     use bevy_camera::{ComputedCameraValues, RenderTargetInfo};
     use bevy_ecs::schedule::IntoScheduleConfigs;
     use bevy_math::UVec2;
-    use bevy_text::{detect_text_needs_rerender, update_text_styles, TextIterScratch};
+    use bevy_text::{
+        detect_text_needs_rerender, update_text_styles, DefaultTextStyle, TextIterScratch,
+    };
 
     use super::*;
 
@@ -326,6 +328,7 @@ mod tests {
             .init_resource::<CosmicFontSystem>()
             .init_resource::<SwashCache>()
             .init_resource::<TextIterScratch>()
+            .init_resource::<DefaultTextStyle>()
             .add_systems(
                 Update,
                 (

--- a/crates/bevy_sprite/src/text2d.rs
+++ b/crates/bevy_sprite/src/text2d.rs
@@ -309,7 +309,7 @@ mod tests {
     use bevy_camera::{ComputedCameraValues, RenderTargetInfo};
     use bevy_ecs::schedule::IntoScheduleConfigs;
     use bevy_math::UVec2;
-    use bevy_text::{detect_text_needs_rerender, TextIterScratch};
+    use bevy_text::{detect_text_needs_rerender, update_text_styles, TextIterScratch};
 
     use super::*;
 
@@ -329,6 +329,7 @@ mod tests {
             .add_systems(
                 Update,
                 (
+                    update_text_styles,
                     detect_text_needs_rerender::<Text2d>,
                     update_text2d_layout,
                     calculate_bounds_text2d,

--- a/crates/bevy_sprite/src/text2d.rs
+++ b/crates/bevy_sprite/src/text2d.rs
@@ -19,10 +19,11 @@ use bevy_ecs::{
 use bevy_image::prelude::*;
 use bevy_math::{FloatOrd, Vec2, Vec3};
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
+use bevy_text::ComputedTextStyle;
 use bevy_text::{
     ComputedTextBlock, CosmicFontSystem, Font, FontAtlasSets, LineBreak, SwashCache, TextBounds,
-    TextColor, TextError, TextFont, TextLayout, TextLayoutInfo, TextPipeline, TextReader, TextRoot,
-    TextSpanAccess, TextWriter,
+    TextError, TextLayout, TextLayoutInfo, TextPipeline, TextReader, TextRoot, TextSpanAccess,
+    TextWriter,
 };
 use bevy_transform::components::Transform;
 use core::any::TypeId;
@@ -81,12 +82,11 @@ use core::any::TypeId;
 #[reflect(Component, Default, Debug, Clone)]
 #[require(
     TextLayout,
-    TextFont,
-    TextColor,
     TextBounds,
     Anchor,
     Visibility,
     VisibilityClass,
+    ComputedTextStyle,
     Transform
 )]
 #[component(on_add = visibility::add_visibility_class::<Sprite>)]

--- a/crates/bevy_sprite_render/src/text2d/mod.rs
+++ b/crates/bevy_sprite_render/src/text2d/mod.rs
@@ -14,7 +14,8 @@ use bevy_render::sync_world::TemporaryRenderEntity;
 use bevy_render::Extract;
 use bevy_sprite::{Anchor, Text2dShadow};
 use bevy_text::{
-    ComputedTextBlock, PositionedGlyph, TextBackgroundColor, TextBounds, TextColor, TextLayoutInfo,
+    ComputedTextBlock, ComputedTextStyle, PositionedGlyph, TextBackgroundColor, TextBounds,
+    TextLayoutInfo,
 };
 use bevy_transform::prelude::GlobalTransform;
 
@@ -37,7 +38,7 @@ pub fn extract_text2d_sprite(
             &GlobalTransform,
         )>,
     >,
-    text_colors: Extract<Query<&TextColor>>,
+    text_colors: Extract<Query<&ComputedTextStyle>>,
     text_background_colors_query: Extract<Query<&TextBackgroundColor>>,
 ) {
     let mut start = extracted_slices.slices.len();
@@ -170,7 +171,7 @@ pub fn extract_text2d_sprite(
                             .map(|t| t.entity)
                             .unwrap_or(Entity::PLACEHOLDER),
                     )
-                    .map(|text_color| LinearRgba::from(text_color.0))
+                    .map(|style| LinearRgba::from(style.color()))
                     .unwrap_or_default();
                 current_span = *span_index;
             }

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -39,7 +39,7 @@ mod font_atlas_set;
 mod font_loader;
 mod glyph;
 mod pipeline;
-pub mod style;
+mod style;
 mod text;
 mod text_access;
 
@@ -51,6 +51,7 @@ pub use font_atlas_set::*;
 pub use font_loader::*;
 pub use glyph::*;
 pub use pipeline::*;
+pub use style::*;
 pub use text::*;
 pub use text_access::*;
 
@@ -60,7 +61,8 @@ pub use text_access::*;
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
-        Font, Justify, LineBreak, TextColor, TextError, TextFont, TextLayout, TextSpan,
+        ComputedTextStyle, Font, Justify, LineBreak, TextColor, TextError, TextFont, TextLayout,
+        TextSpan,
     };
 }
 
@@ -96,9 +98,13 @@ impl Plugin for TextPlugin {
             .init_resource::<CosmicFontSystem>()
             .init_resource::<SwashCache>()
             .init_resource::<TextIterScratch>()
+            .init_resource::<DefaultTextStyle>()
             .add_systems(
                 PostUpdate,
-                remove_dropped_font_atlas_sets.before(AssetEventSystems),
+                (
+                    update_text_styles,
+                    remove_dropped_font_atlas_sets.before(AssetEventSystems),
+                ),
             )
             .add_systems(Last, trim_cosmic_cache);
 

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -39,6 +39,7 @@ mod font_atlas_set;
 mod font_loader;
 mod glyph;
 mod pipeline;
+pub mod style;
 mod text;
 mod text_access;
 

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -1,7 +1,6 @@
 use alloc::sync::Arc;
 
 use bevy_asset::{AssetId, Assets};
-use bevy_color::Color;
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
     component::Component, entity::Entity, reflect::ReflectComponent, resource::Resource,
@@ -16,8 +15,9 @@ use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use cosmic_text::{Attrs, Buffer, Family, Metrics, Shaping, Wrap};
 
 use crate::{
-    error::TextError, ComputedTextBlock, Font, FontAtlasSets, FontSmoothing, Justify, LineBreak,
-    PositionedGlyph, TextBounds, TextEntity, TextFont, TextLayout,
+    error::TextError, style::ComputedTextStyle, ComputedTextBlock, Font, FontAtlasSets,
+    FontSmoothing, Justify, LineBreak, PositionedGlyph, TextBounds, TextEntity, TextFont,
+    TextLayout,
 };
 
 /// A wrapper resource around a [`cosmic_text::FontSystem`]
@@ -86,7 +86,7 @@ impl TextPipeline {
     pub fn update_buffer<'a>(
         &mut self,
         fonts: &Assets<Font>,
-        text_spans: impl Iterator<Item = (Entity, usize, &'a str, &'a TextFont, Color)>,
+        text_spans: impl Iterator<Item = (Entity, usize, &'a str, &'a ComputedTextStyle)>,
         linebreak: LineBreak,
         justify: Justify,
         bounds: TextBounds,
@@ -100,15 +100,15 @@ impl TextPipeline {
         // to FontSystem, which the cosmic-text Buffer also needs.
         let mut max_font_size: f32 = 0.;
         let mut max_line_height: f32 = 0.0;
-        let mut spans: Vec<(usize, &str, &TextFont, FontFaceInfo, Color)> =
+        let mut spans: Vec<(usize, &str, &ComputedTextStyle, FontFaceInfo)> =
             core::mem::take(&mut self.spans_buffer)
                 .into_iter()
-                .map(|_| -> (usize, &str, &TextFont, FontFaceInfo, Color) { unreachable!() })
+                .map(|_| -> (usize, &str, &ComputedTextStyle, FontFaceInfo) { unreachable!() })
                 .collect();
 
         computed.entities.clear();
 
-        for (span_index, (entity, depth, span, text_font, color)) in text_spans.enumerate() {
+        for (span_index, (entity, depth, span, style)) in text_spans.enumerate() {
             // Save this span entity in the computed text block.
             computed.entities.push(TextEntity { entity, depth });
 
@@ -116,7 +116,7 @@ impl TextPipeline {
                 continue;
             }
             // Return early if a font is not loaded yet.
-            if !fonts.contains(text_font.font.id()) {
+            if !fonts.contains(style.font.font.id()) {
                 spans.clear();
                 self.spans_buffer = spans
                     .into_iter()
@@ -131,26 +131,27 @@ impl TextPipeline {
             }
 
             // Get max font size for use in cosmic Metrics.
-            max_font_size = max_font_size.max(text_font.font_size);
-            max_line_height = max_line_height.max(text_font.line_height.eval(text_font.font_size));
+            max_font_size = max_font_size.max(style.font.font_size);
+            max_line_height =
+                max_line_height.max(style.font.line_height.eval(style.font.font_size));
 
             // Load Bevy fonts into cosmic-text's font system.
             let face_info = load_font_to_fontdb(
-                text_font,
+                &style.font,
                 font_system,
                 &mut self.map_handle_to_font_id,
                 fonts,
             );
 
             // Save spans that aren't zero-sized.
-            if scale_factor <= 0.0 || text_font.font_size <= 0.0 {
+            if scale_factor <= 0.0 || style.font.font_size <= 0.0 {
                 once!(warn!(
                     "Text span {entity} has a font size <= 0.0. Nothing will be displayed.",
                 ));
 
                 continue;
             }
-            spans.push((span_index, span, text_font, face_info, color));
+            spans.push((span_index, span, style, face_info));
         }
 
         let mut metrics = Metrics::new(max_font_size, max_line_height).scale(scale_factor as f32);
@@ -166,14 +167,12 @@ impl TextPipeline {
         // The section index is stored in the metadata of the spans, and could be used
         // to look up the section the span came from and is not used internally
         // in cosmic-text.
-        let spans_iter = spans
-            .iter()
-            .map(|(span_index, span, text_font, font_info, color)| {
-                (
-                    *span,
-                    get_attrs(*span_index, text_font, *color, font_info, scale_factor),
-                )
-            });
+        let spans_iter = spans.iter().map(|(span_index, span, style, font_info)| {
+            (
+                *span,
+                get_attrs(*span_index, style, font_info, scale_factor),
+            )
+        });
 
         // Update the buffer.
         let buffer = &mut computed.buffer;
@@ -225,7 +224,7 @@ impl TextPipeline {
         &mut self,
         layout_info: &mut TextLayoutInfo,
         fonts: &Assets<Font>,
-        text_spans: impl Iterator<Item = (Entity, usize, &'a str, &'a TextFont, Color)>,
+        text_spans: impl Iterator<Item = (Entity, usize, &'a str, &'a ComputedTextStyle)>,
         scale_factor: f64,
         layout: &TextLayout,
         bounds: TextBounds,
@@ -246,8 +245,8 @@ impl TextPipeline {
         // Extract font ids from the iterator while traversing it.
         let mut glyph_info = core::mem::take(&mut self.glyph_info);
         glyph_info.clear();
-        let text_spans = text_spans.inspect(|(_, _, _, text_font, _)| {
-            glyph_info.push((text_font.font.id(), text_font.font_smoothing));
+        let text_spans = text_spans.inspect(|(_, _, _, text_style)| {
+            glyph_info.push((text_style.font.font.id(), text_style.font.font_smoothing));
         });
 
         let update_result = self.update_buffer(
@@ -394,7 +393,7 @@ impl TextPipeline {
         &mut self,
         entity: Entity,
         fonts: &Assets<Font>,
-        text_spans: impl Iterator<Item = (Entity, usize, &'a str, &'a TextFont, Color)>,
+        text_spans: impl Iterator<Item = (Entity, usize, &'a str, &'a ComputedTextStyle)>,
         scale_factor: f64,
         layout: &TextLayout,
         computed: &mut ComputedTextBlock,
@@ -529,8 +528,7 @@ pub fn load_font_to_fontdb(
 /// Translates [`TextFont`] to [`Attrs`].
 fn get_attrs<'a>(
     span_index: usize,
-    text_font: &TextFont,
-    color: Color,
+    style: &'a ComputedTextStyle,
     face_info: &'a FontFaceInfo,
     scale_factor: f64,
 ) -> Attrs<'a> {
@@ -542,12 +540,12 @@ fn get_attrs<'a>(
         .weight(face_info.weight)
         .metrics(
             Metrics {
-                font_size: text_font.font_size,
-                line_height: text_font.line_height.eval(text_font.font_size),
+                font_size: style.font.font_size,
+                line_height: style.font.line_height.eval(style.font.font_size),
             }
             .scale(scale_factor as f32),
         )
-        .color(cosmic_text::Color(color.to_linear().as_u32()))
+        .color(cosmic_text::Color(style.color.to_linear().as_u32()))
 }
 
 /// Calculate the size of the text area for the given buffer.

--- a/crates/bevy_text/src/style.rs
+++ b/crates/bevy_text/src/style.rs
@@ -1,0 +1,18 @@
+use crate::*;
+use bevy_app::Propagate;
+use bevy_color::Color;
+use bevy_ecs::component::Component;
+use bevy_ecs::prelude::*;
+use bevy_ecs::query::AnyOf;
+
+#[derive(Resource)]
+pub struct DefaultTextStyle {
+    font: TextFont,
+    color: Color,
+}
+
+#[derive(Component)]
+pub struct ComputedTextStyle {
+    font: TextFont,
+    color: Color,
+}

--- a/crates/bevy_text/src/style.rs
+++ b/crates/bevy_text/src/style.rs
@@ -42,7 +42,8 @@ impl ComputedTextStyle {
     }
 }
 
-/// update text styles
+/// Update the `ComputedTextStyle` for each text node from the
+/// `TextFont`s and `TextColor`s of its nearest ancestors.
 pub fn update_text_styles(
     default_text_style: Res<DefaultTextStyle>,
     mut computed_text_query: Query<(Entity, &mut ComputedTextStyle)>,

--- a/crates/bevy_text/src/style.rs
+++ b/crates/bevy_text/src/style.rs
@@ -3,12 +3,12 @@ use bevy_color::Color;
 use bevy_ecs::component::Component;
 use bevy_ecs::prelude::*;
 
-/// Default text style
+/// Fallback text style used if a text entity and all its ancestors lack text styling components.
 #[derive(Resource)]
 pub struct DefaultTextStyle {
-    /// default font
-    pub font: TextFont,
-    /// default color
+    /// The font used by a text entity when neither it nor any ancestor has a [`TextFont`] component.
+    font: TextFont,
+    /// The color used by a text entity when neither it nor any ancestor has a [`TextColor`] component.
     pub color: Color,
 }
 
@@ -21,29 +21,35 @@ impl Default for DefaultTextStyle {
     }
 }
 
-/// Computed text style
+/// The resolved text style for a text entity.
+///
+/// Updated by [`update_text_styles`]
 #[derive(Component, PartialEq, Default)]
 pub struct ComputedTextStyle {
-    /// From nearest ancestor with a `TextFont`
+    /// The resolved font, taken from the nearest ancestor (including self) with a [`TextFont`],
+    /// or from [`DefaultTextStyle`] if none is found.
     pub(crate) font: TextFont,
-    /// From nearest ancestor with a `TextColor`
+    /// The resolved text color, taken from the nearest ancestor (including self) with a [`TextColor`],
+    /// or from [`DefaultTextStyle`] if none is found.
     pub(crate) color: Color,
 }
 
 impl ComputedTextStyle {
-    /// Computed text font
+    /// The resolved font, taken from the nearest ancestor (including self) with a [`TextFont`],
+    /// or from [`DefaultTextStyle`] if none is found.
     pub const fn font(&self) -> &TextFont {
         &self.font
     }
 
-    /// Computed text color
+    /// The resolved text color, taken from the nearest ancestor (including self) with a [`TextColor`],
+    /// or from [`DefaultTextStyle`] if none is found.
     pub const fn color(&self) -> Color {
         self.color
     }
 }
 
 /// Update the `ComputedTextStyle` for each text node from the
-/// `TextFont`s and `TextColor`s of its nearest ancestors.
+/// `TextFont`s and `TextColor`s of its nearest ancestors, or from [`DefaultTextStyle`] if none are found.
 pub fn update_text_styles(
     default_text_style: Res<DefaultTextStyle>,
     mut computed_text_query: Query<(Entity, &mut ComputedTextStyle)>,
@@ -70,7 +76,8 @@ pub fn update_text_styles(
         if new_style.font != style.font {
             *style = new_style;
         } else {
-            style.color = new_style.color;
+            // bypass change detection, we don't need to do any updates if only the text color has changed
+            style.bypass_change_detection().color = new_style.color;
         }
     }
 }

--- a/crates/bevy_text/src/style.rs
+++ b/crates/bevy_text/src/style.rs
@@ -1,18 +1,75 @@
 use crate::*;
-use bevy_app::Propagate;
 use bevy_color::Color;
 use bevy_ecs::component::Component;
 use bevy_ecs::prelude::*;
-use bevy_ecs::query::AnyOf;
 
+/// Default text style
 #[derive(Resource)]
 pub struct DefaultTextStyle {
-    font: TextFont,
-    color: Color,
+    /// default font
+    pub font: TextFont,
+    /// default color
+    pub color: Color,
 }
 
-#[derive(Component)]
+impl Default for DefaultTextStyle {
+    fn default() -> Self {
+        Self {
+            font: Default::default(),
+            color: Color::WHITE,
+        }
+    }
+}
+
+/// Computed text style
+#[derive(Component, PartialEq, Default)]
 pub struct ComputedTextStyle {
-    font: TextFont,
-    color: Color,
+    /// From nearest ancestor with a `TextFont`
+    pub(crate) font: TextFont,
+    /// From nearest ancestor with a `TextColor`
+    pub(crate) color: Color,
+}
+
+impl ComputedTextStyle {
+    /// Computed text font
+    pub const fn font(&self) -> &TextFont {
+        &self.font
+    }
+
+    /// Computed text color
+    pub const fn color(&self) -> Color {
+        self.color
+    }
+}
+
+/// update text styles
+pub fn update_text_styles(
+    default_text_style: Res<DefaultTextStyle>,
+    mut computed_text_query: Query<(Entity, &mut ComputedTextStyle)>,
+    parent_query: Query<&ChildOf>,
+    font_query: Query<(Option<&TextFont>, Option<&TextColor>)>,
+) {
+    for (start, mut style) in computed_text_query.iter_mut() {
+        let (mut font, mut color) = font_query.get(start).unwrap();
+        let mut ancestors = parent_query.iter_ancestors(start);
+
+        while (font.is_none() || color.is_none())
+            && let Some(ancestor) = ancestors.next()
+        {
+            let (next_font, next_color) = font_query.get(ancestor).unwrap();
+            font = font.or(next_font);
+            color = color.or(next_color);
+        }
+
+        let new_style = ComputedTextStyle {
+            font: font.unwrap_or(&default_text_style.font).clone(),
+            color: color.map(|t| t.0).unwrap_or(default_text_style.color),
+        };
+
+        if new_style.font != style.font {
+            *style = new_style;
+        } else {
+            style.color = new_style.color;
+        }
+    }
 }

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -459,12 +459,12 @@ pub fn detect_text_needs_rerender<Root: Component>(
         (
             Or<(
                 Changed<Root>,
-                Changed<TextFont>,
+                Changed<ComputedTextStyle>,
                 Changed<TextLayout>,
                 Changed<Children>,
             )>,
             With<Root>,
-            With<TextFont>,
+            With<ComputedTextStyle>,
             With<TextLayout>,
         ),
     >,
@@ -473,13 +473,13 @@ pub fn detect_text_needs_rerender<Root: Component>(
         (
             Or<(
                 Changed<TextSpan>,
-                Changed<TextFont>,
+                Changed<ComputedTextStyle>,
                 Changed<Children>,
                 Changed<ChildOf>, // Included to detect broken text block hierarchies.
                 Added<TextLayout>,
             )>,
             With<TextSpan>,
-            With<TextFont>,
+            With<ComputedTextStyle>,
         ),
     >,
     mut computed: Query<(

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -1,4 +1,4 @@
-use crate::{Font, TextLayoutInfo, TextSpanAccess, TextSpanComponent};
+use crate::{style::ComputedTextStyle, Font, TextLayoutInfo, TextSpanAccess, TextSpanComponent};
 use bevy_asset::Handle;
 use bevy_color::Color;
 use bevy_derive::{Deref, DerefMut};
@@ -172,7 +172,7 @@ impl TextLayout {
 /// but each node has its own [`TextFont`] and [`TextColor`].
 #[derive(Component, Debug, Default, Clone, Deref, DerefMut, Reflect)]
 #[reflect(Component, Default, Debug, Clone)]
-#[require(TextFont, TextColor)]
+#[require(ComputedTextStyle)]
 pub struct TextSpan(pub String);
 
 impl TextSpan {

--- a/crates/bevy_ui/src/accessibility.rs
+++ b/crates/bevy_ui/src/accessibility.rs
@@ -17,6 +17,7 @@ use bevy_ecs::{
 
 use accesskit::{Node, Rect, Role};
 use bevy_camera::CameraUpdateSystems;
+use bevy_text::update_text_styles;
 
 fn calc_label(
     text_reader: &mut TextUiReader,
@@ -154,9 +155,7 @@ impl Plugin for AccessibilityPlugin {
                     .after(CameraUpdateSystems)
                     // the listed systems do not affect calculated size
                     .ambiguous_with(crate::ui_stack_system),
-                button_changed,
-                image_changed,
-                label_changed,
+                (button_changed, image_changed, label_changed).before(update_text_styles),
             ),
         );
     }

--- a/crates/bevy_ui/src/accessibility.rs
+++ b/crates/bevy_ui/src/accessibility.rs
@@ -26,7 +26,7 @@ fn calc_label(
     for child in children {
         let values = text_reader
             .iter(child)
-            .map(|(_, _, text, _, _)| text.into())
+            .map(|(_, _, text, _)| text.into())
             .collect::<Vec<String>>();
         if !values.is_empty() {
             name = Some(values.join(" "));
@@ -119,7 +119,7 @@ fn label_changed(
     for (entity, accessible) in &mut query {
         let values = text_reader
             .iter(entity)
-            .map(|(_, _, text, _, _)| text.into())
+            .map(|(_, _, text, _)| text.into())
             .collect::<Vec<String>>();
         let label = Some(values.join(" ").into_boxed_str());
         if let Some(mut accessible) = accessible {

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -236,7 +236,6 @@ fn build_text_interop(app: &mut App) {
             )
                 .chain()
                 .in_set(UiSystems::Content)
-                .after(update_text_styles)
                 // Text and Text2d are independent.
                 .ambiguous_with(bevy_text::detect_text_needs_rerender::<bevy_sprite::Text2d>)
                 // Potential conflict: `Assets<Image>`
@@ -247,7 +246,6 @@ fn build_text_interop(app: &mut App) {
                 // FIXME: Add an archetype invariant for this https://github.com/bevyengine/bevy/issues/1481.
                 .ambiguous_with(widget::update_image_content_size_system),
             widget::text_system
-                .after(update_text_styles)
                 .in_set(UiSystems::PostLayout)
                 .after(bevy_text::remove_dropped_font_atlas_sets)
                 .before(bevy_asset::AssetEventSystems)
@@ -255,7 +253,8 @@ fn build_text_interop(app: &mut App) {
                 .ambiguous_with(bevy_text::detect_text_needs_rerender::<bevy_sprite::Text2d>)
                 .ambiguous_with(bevy_sprite::update_text2d_layout)
                 .ambiguous_with(bevy_sprite::calculate_bounds_text2d),
-        ),
+        )
+            .after(update_text_styles),
     );
 
     app.add_plugins(accessibility::AccessibilityPlugin);

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -34,6 +34,7 @@ mod layout;
 mod stack;
 mod ui_node;
 
+use bevy_text::update_text_styles;
 pub use focus::*;
 pub use geometry::*;
 pub use gradients::*;
@@ -235,6 +236,7 @@ fn build_text_interop(app: &mut App) {
             )
                 .chain()
                 .in_set(UiSystems::Content)
+                .after(update_text_styles)
                 // Text and Text2d are independent.
                 .ambiguous_with(bevy_text::detect_text_needs_rerender::<bevy_sprite::Text2d>)
                 // Potential conflict: `Assets<Image>`
@@ -245,6 +247,7 @@ fn build_text_interop(app: &mut App) {
                 // FIXME: Add an archetype invariant for this https://github.com/bevyengine/bevy/issues/1481.
                 .ambiguous_with(widget::update_image_content_size_system),
             widget::text_system
+                .after(update_text_styles)
                 .in_set(UiSystems::PostLayout)
                 .after(bevy_text::remove_dropped_font_atlas_sets)
                 .before(bevy_asset::AssetEventSystems)

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -18,8 +18,8 @@ use bevy_image::prelude::*;
 use bevy_math::Vec2;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_text::{
-    ComputedTextBlock, CosmicFontSystem, Font, FontAtlasSets, LineBreak, SwashCache, TextBounds,
-    TextColor, TextError, TextFont, TextLayout, TextLayoutInfo, TextMeasureInfo, TextPipeline,
+    ComputedTextBlock, ComputedTextStyle, CosmicFontSystem, Font, FontAtlasSets, LineBreak,
+    SwashCache, TextBounds, TextError, TextLayout, TextLayoutInfo, TextMeasureInfo, TextPipeline,
     TextReader, TextRoot, TextSpanAccess, TextWriter,
 };
 use taffy::style::AvailableSpace;
@@ -95,7 +95,7 @@ impl Default for TextNodeFlags {
 /// ```
 #[derive(Component, Debug, Default, Clone, Deref, DerefMut, Reflect, PartialEq)]
 #[reflect(Component, Default, Debug, PartialEq, Clone)]
-#[require(Node, TextLayout, TextFont, TextColor, TextNodeFlags, ContentSize)]
+#[require(Node, TextLayout, ComputedTextStyle, TextNodeFlags, ContentSize)]
 pub struct Text(pub String);
 
 impl Text {
@@ -220,7 +220,7 @@ fn create_text_measure<'a>(
     entity: Entity,
     fonts: &Assets<Font>,
     scale_factor: f64,
-    spans: impl Iterator<Item = (Entity, usize, &'a str, &'a TextFont, Color)>,
+    spans: impl Iterator<Item = (Entity, usize, &'a str, &'a ComputedTextStyle)>,
     block: Ref<TextLayout>,
     text_pipeline: &mut TextPipeline,
     mut content_size: Mut<ContentSize>,

--- a/crates/bevy_ui_render/src/lib.rs
+++ b/crates/bevy_ui_render/src/lib.rs
@@ -24,6 +24,7 @@ use bevy_reflect::prelude::ReflectDefault;
 use bevy_reflect::Reflect;
 use bevy_shader::load_shader_library;
 use bevy_sprite_render::SpriteAssetEvents;
+use bevy_text::ComputedTextStyle;
 use bevy_ui::widget::{ImageNode, TextShadow, ViewportNode};
 use bevy_ui::{
     BackgroundColor, BorderColor, CalculatedClip, ComputedNode, ComputedUiTargetCamera, Display,
@@ -59,9 +60,7 @@ pub use debug_overlay::UiDebugOptions;
 use gradient::GradientPlugin;
 
 use bevy_platform::collections::{HashMap, HashSet};
-use bevy_text::{
-    ComputedTextBlock, PositionedGlyph, TextBackgroundColor, TextColor, TextLayoutInfo,
-};
+use bevy_text::{ComputedTextBlock, PositionedGlyph, TextBackgroundColor, TextLayoutInfo};
 use bevy_transform::components::GlobalTransform;
 use box_shadow::BoxShadowPlugin;
 use bytemuck::{Pod, Zeroable};
@@ -909,11 +908,11 @@ pub fn extract_text_sections(
             Option<&CalculatedClip>,
             &ComputedUiTargetCamera,
             &ComputedTextBlock,
-            &TextColor,
+            &ComputedTextStyle,
             &TextLayoutInfo,
         )>,
     >,
-    text_styles: Extract<Query<&TextColor>>,
+    text_styles: Extract<Query<&ComputedTextStyle>>,
     camera_map: Extract<UiCameraMap>,
 ) {
     let mut start = extracted_uinodes.glyphs.len();
@@ -928,7 +927,7 @@ pub fn extract_text_sections(
         clip,
         camera,
         computed_block,
-        text_color,
+        text_style,
         text_layout_info,
     ) in &uinode_query
     {
@@ -943,7 +942,7 @@ pub fn extract_text_sections(
 
         let transform = Affine2::from(*transform) * Affine2::from_translation(-0.5 * uinode.size());
 
-        let mut color = text_color.0.to_linear();
+        let mut color = text_style.color().to_linear();
 
         let mut current_span_index = 0;
 
@@ -963,7 +962,7 @@ pub fn extract_text_sections(
             {
                 color = text_styles
                     .get(span_entity)
-                    .map(|text_color| LinearRgba::from(text_color.0))
+                    .map(|style| LinearRgba::from(style.color()))
                     .unwrap_or_default();
                 current_span_index = *span_index;
             }

--- a/examples/testbed/ui.rs
+++ b/examples/testbed/ui.rs
@@ -116,9 +116,21 @@ mod text {
             },
             DespawnOnExit(super::Scene::Text),
             children![
-                (TextSpan::new("red "), TextColor(RED.into()),),
-                (TextSpan::new("green "), TextColor(GREEN.into()),),
-                (TextSpan::new("blue "), TextColor(BLUE.into()),),
+                (
+                    TextSpan::new("red "),
+                    TextColor(RED.into()),
+                    TextFont::default()
+                ),
+                (
+                    TextSpan::new("green "),
+                    TextColor(GREEN.into()),
+                    TextFont::default()
+                ),
+                (
+                    TextSpan::new("blue "),
+                    TextColor(BLUE.into()),
+                    TextFont::default()
+                ),
                 (
                     TextSpan::new("black"),
                     TextColor(Color::BLACK),
@@ -151,9 +163,21 @@ mod text {
                         ..default()
                     }
                 ),
-                (TextSpan::new("red "), TextColor(RED.into()),),
-                (TextSpan::new("green "), TextColor(GREEN.into()),),
-                (TextSpan::new("blue "), TextColor(BLUE.into()),),
+                (
+                    TextSpan::new("red "),
+                    TextColor(RED.into()),
+                    TextFont::default()
+                ),
+                (
+                    TextSpan::new("green "),
+                    TextColor(GREEN.into()),
+                    TextFont::default()
+                ),
+                (
+                    TextSpan::new("blue "),
+                    TextColor(BLUE.into()),
+                    TextFont::default()
+                ),
                 (
                     TextSpan::new("black"),
                     TextColor(Color::BLACK),
@@ -189,14 +213,30 @@ mod text {
                     }
                 ),
                 TextSpan::new(""),
-                (TextSpan::new("red "), TextColor(RED.into()),),
+                (
+                    TextSpan::new("red "),
+                    TextColor(RED.into()),
+                    TextFont::default()
+                ),
                 TextSpan::new(""),
                 TextSpan::new(""),
-                (TextSpan::new("green "), TextColor(GREEN.into()),),
+                (
+                    TextSpan::new("green "),
+                    TextColor(GREEN.into()),
+                    TextFont::default()
+                ),
                 (TextSpan::new(""), TextColor(YELLOW.into()),),
-                (TextSpan::new("blue "), TextColor(BLUE.into()),),
+                (
+                    TextSpan::new("blue "),
+                    TextColor(BLUE.into()),
+                    TextFont::default()
+                ),
                 TextSpan::new(""),
-                (TextSpan::new(""), TextColor(YELLOW.into()),),
+                (
+                    TextSpan::new(""),
+                    TextColor(YELLOW.into()),
+                    TextFont::default()
+                ),
                 (
                     TextSpan::new("black"),
                     TextColor(Color::BLACK),

--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -48,6 +48,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             right: px(5),
             ..default()
         },
+        TextColor::WHITE,
         AnimatedText,
     ));
 


### PR DESCRIPTION
# Objective

Propagate text styles down the tree, instead of setting them per node.

Work towards #21175

## Solution

* New component `ComputedTextStyle`, required on `Text`, `Text2d`, and `TextSpan`.
* Unrequire `TextFont` and `TextColor` from `Text`, `Text2d`, and `TextSpan`. 
* New system `update_text_styles`. It updates each `ComputedTextStyle`, from either the current entity or the nearest ancestor with a `TextFont` or `TextColor`.
* New resource `DefaultTextStyle`, used if `update_text_styles` can't find any ancestor with a `TextColor` or `TextFont`.
---

`update_text_styles` isn't optimised at all yet. Every frame (there's no change detection), from every text entity, it walks up the tree until it finds a `TextColor` and `TextFont` to use. It's okay as a reference implementation though, more concerned with synchronisation errors at this stage.

Most existing code should work without changes. Because they are no longer required, `TextFont` and `TextColor` aren't automatically inserted on text entities when ellided, so instead of the default font, they will use the font and color they inherit from their ancestors instead. And queries for `TextFont` and `TextColor` that assume the components presence may also fail now.

## Testing

The `text2d`, `feathers` and `testbed_ui` examples all seem to be working correctly with only minor changes.

