### PR TITLE
`NonSendMut` alias

### DIFF
--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1515,11 +1515,11 @@ unsafe impl<'a, T: 'static> SystemParam for NonSendMut<'a, T> {
         system_meta.set_non_send();
 
         let combined_access = component_access_set.combined_access();
-        if combined_access.has_component_write(component_id) {
+        if combined_access.has_resource_write(component_id) {
             panic!(
                 "error[B0002]: NonSendMut<{}> in system {} conflicts with a previous mutable resource access ({0}). Consider removing the duplicate access. See: https://bevy.org/learn/errors/b0002",
                 DebugName::type_name::<T>(), system_meta.name);
-        } else if combined_access.has_component_read(component_id) {
+        } else if combined_access.has_resource_read(component_id) {
             panic!(
                 "error[B0002]: NonSendMut<{}> in system {} conflicts with a previous immutable resource access ({0}). Consider removing the duplicate access. See: https://bevy.org/learn/errors/b0002",
                 DebugName::type_name::<T>(), system_meta.name);

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -2860,6 +2860,22 @@ mod tests {
     use crate::system::assert_is_system;
     use core::cell::RefCell;
 
+    #[test]
+    #[should_panic]
+    fn non_send_alias() {
+        #[derive(Resource)]
+        struct A(usize);
+        fn my_system(mut res0: NonSendMut<A>, mut res1: NonSendMut<A>) {
+            res0.0 += 1;
+            res1.0 += 1;
+        }
+        let mut world = World::new();
+        world.insert_non_send_resource(A(42));
+        let mut schedule = crate::schedule::Schedule::default();
+        schedule.add_systems(my_system);
+        schedule.run(&mut world);
+    }
+
     // Compile test for https://github.com/bevyengine/bevy/pull/2838.
     #[test]
     fn system_param_generic_bounds() {


### PR DESCRIPTION
# Objective
disallow multiple mutable references to the same non-send resource in the same system.

## Solution

init_access for `NonSendMut` should check resource references (I think there should be a separate set for nonsend resources since they are distinct from resources?), not components when checking for conflicting system access.

## Testing

I've added a new test that panics when two conflicting NonSendMut system params are present in one system.