### PR TITLE
Fix animation crate typo from resume to pause

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -884,7 +884,7 @@ impl AnimationPlayer {
             .all(ActiveAnimation::is_paused)
     }
 
-    /// Resume all playing animations.
+    /// Pause all playing animations.
     #[doc(alias = "pause")]
     pub fn pause_all(&mut self) -> &mut Self {
         for (_, playing_animation) in self.playing_animations_mut() {


### PR DESCRIPTION
# Objective

The API "pause_all" on AnimationPlayer had docs stating it would resume all.

## Solution

Fix typo