### PR TITLE
Add UiDebugOptions to type registry

### DIFF
--- a/crates/bevy_ui_render/src/lib.rs
+++ b/crates/bevy_ui_render/src/lib.rs
@@ -204,8 +204,7 @@ impl Plugin for UiRenderPlugin {
         load_shader_library!(app, "ui.wgsl");
 
         #[cfg(feature = "bevy_ui_debug")]
-        app.init_resource::<UiDebugOptions>()
-            .register_type::<UiDebugOptions>();
+        app.init_resource::<UiDebugOptions>();
 
         let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
             return;


### PR DESCRIPTION
# Objective

add reflect to UiDebugOptions, to for example allow using it bevy-inspector-egui.
this allow for example easily modifying the ui debug options at runtime, and toggling it.

# Solution

bevy-inspector-egui need the resource to reflect Resource, and the type to be in type registry.
