### PR TITLE
Send the entire loaded asset instead of decomposing it on the loader task.

### DIFF
--- a/crates/bevy_asset/src/server/info.rs
+++ b/crates/bevy_asset/src/server/info.rs
@@ -384,6 +384,12 @@ impl AssetInfos {
         world: &mut World,
         sender: &Sender<InternalAssetEvent>,
     ) {
+        // Process all the labeled assets first so that they don't get skipped due to the "parent"
+        // not having its handle alive.
+        for (_, asset) in loaded_asset.labeled_assets {
+            self.process_asset_load(asset.handle.id(), asset.asset, world, sender);
+        }
+
         // Check whether the handle has been dropped since the asset was loaded.
         if !self.infos.contains_key(&loaded_asset_id) {
             return;

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -799,7 +799,10 @@ impl AssetServer {
                     fetched_handle
                 };
 
-                self.send_loaded_asset(base_asset_id, loaded_asset);
+                self.send_asset_event(InternalAssetEvent::Loaded {
+                    id: base_asset_id,
+                    loaded_asset,
+                });
                 Ok(final_handle)
             }
             Err(err) => {
@@ -811,16 +814,6 @@ impl AssetServer {
                 Err(err)
             }
         }
-    }
-
-    /// Sends a load event for the given `loaded_asset` and does the same recursively for all
-    /// labeled assets.
-    fn send_loaded_asset(&self, id: UntypedAssetId, mut loaded_asset: ErasedLoadedAsset) {
-        for (_, labeled_asset) in loaded_asset.labeled_assets.drain() {
-            self.send_loaded_asset(labeled_asset.handle.id(), labeled_asset.asset);
-        }
-
-        self.send_asset_event(InternalAssetEvent::Loaded { id, loaded_asset });
     }
 
     /// Kicks off a reload of the asset stored at the given path. This will only reload the asset if it currently loaded.


### PR DESCRIPTION
# Objective

- The previous state had the loader task send a single `InternalAssetEvent::Loaded` for every root asset **and** each of its subassets. The `handle_internal_asset_events` system reads these events one at a time. This means these two threads are racing. So it's possible to see some of the subassets loaded without the root asset being loaded in a frame, and then have to wait an additional frame to see the remaining subassets and root asset loaded.

## Solution

- Instead of recursively sending the subassets inside the loader task, just send the `LoadedAsset` in its entirety.
- Do the recursion when processing the loaded asset. Since we're doing this in the system, the entire loaded asset will be processed in a single frame.
- This also reduces contention of the channel.

## Testing

- None. This is kinda a "fake issue". In order to see it, handling a loaded asset in `handle_internal_asset_events` needs to finish the last received subasset before the loader task sends the root asset. This is probably pretty unlikely, but could in theory cause flaky tests.