### PR TITLE
enable bevy_dev_tools by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,6 +178,7 @@ default = [
   "wayland",
   "debug",
   "zstd_rust",
+  "bevy_dev_tools",
 ]
 
 # Recommended defaults for no_std applications


### PR DESCRIPTION
# Objective

- Default features are mostly useful to new users of Bevy, or when running examples in the repo
- Those two cases are mostly developers, but they need to take an extra step to enable `bevy_dev_tools`

## Solution

- Enable `bevy_dev_tools` by default
