### PR TITLE
Fix crash with RenderDiagnosticsPlugin on mac

### DIFF
--- a/crates/bevy_anti_alias/src/contrast_adaptive_sharpening/node.rs
+++ b/crates/bevy_anti_alias/src/contrast_adaptive_sharpening/node.rs
@@ -113,7 +113,7 @@ impl Node for CasNode {
         let mut render_pass = render_context
             .command_encoder()
             .begin_render_pass(&pass_descriptor);
-        let pass_span = diagnostics.time_span(&mut render_pass, "contrast_adaptive_sharpening");
+        let pass_span = diagnostics.pass_span(&mut render_pass, "contrast_adaptive_sharpening");
 
         render_pass.set_pipeline(pipeline);
         render_pass.set_bind_group(0, bind_group, &[uniform_index.index()]);

--- a/crates/bevy_pbr/src/atmosphere/node.rs
+++ b/crates/bevy_pbr/src/atmosphere/node.rs
@@ -80,7 +80,7 @@ impl ViewNode for AtmosphereLutsNode {
             label: Some("atmosphere_luts"),
             timestamp_writes: None,
         });
-        let pass_span = diagnostics.time_span(&mut luts_pass, "atmosphere_luts");
+        let pass_span = diagnostics.pass_span(&mut luts_pass, "atmosphere_luts");
 
         fn dispatch_2d(compute_pass: &mut ComputePass, size: UVec2) {
             const WORKGROUP_SIZE: u32 = 16;

--- a/crates/bevy_pbr/src/meshlet/visibility_buffer_raster_node.rs
+++ b/crates/bevy_pbr/src/meshlet/visibility_buffer_raster_node.rs
@@ -246,7 +246,7 @@ impl Node for MeshletVisibilityBufferRasterPassNode {
                 "meshlet_visibility_buffer_raster: {}",
                 shadow_view.pass_name
             ));
-            let pass_span = diagnostics.time_span(
+            let time_span_shadow = diagnostics.time_span(
                 render_context.command_encoder(),
                 shadow_view.pass_name.clone(),
             );
@@ -342,7 +342,7 @@ impl Node for MeshletVisibilityBufferRasterPassNode {
                 downsample_depth_second_shadow_view_pipeline,
             );
             render_context.command_encoder().pop_debug_group();
-            pass_span.end(render_context.command_encoder());
+            time_span_shadow.end(render_context.command_encoder());
         }
 
         time_span.end(render_context.command_encoder());

--- a/crates/bevy_pbr/src/render/gpu_preprocess.rs
+++ b/crates/bevy_pbr/src/render/gpu_preprocess.rs
@@ -598,7 +598,7 @@ impl Node for EarlyGpuPreprocessNode {
                     label: Some("early_mesh_preprocessing"),
                     timestamp_writes: None,
                 });
-        let pass_span = diagnostics.time_span(&mut compute_pass, "early_mesh_preprocessing");
+        let pass_span = diagnostics.pass_span(&mut compute_pass, "early_mesh_preprocessing");
 
         let mut all_views: SmallVec<[_; 8]> = SmallVec::new();
         all_views.push(graph.view_entity());
@@ -839,7 +839,7 @@ impl Node for LateGpuPreprocessNode {
                     label: Some("late_mesh_preprocessing"),
                     timestamp_writes: None,
                 });
-        let pass_span = diagnostics.time_span(&mut compute_pass, "late_mesh_preprocessing");
+        let pass_span = diagnostics.pass_span(&mut compute_pass, "late_mesh_preprocessing");
 
         // Run the compute passes.
         for (view, bind_groups, view_uniform_offset) in self.view_query.iter_manual(world) {
@@ -1056,7 +1056,7 @@ fn run_build_indirect_parameters_node(
                 label: Some(label),
                 timestamp_writes: None,
             });
-    let pass_span = diagnostics.time_span(&mut compute_pass, label);
+    let pass_span = diagnostics.pass_span(&mut compute_pass, label);
 
     // Fetch the pipeline.
     let (

--- a/crates/bevy_post_process/src/auto_exposure/node.rs
+++ b/crates/bevy_post_process/src/auto_exposure/node.rs
@@ -128,7 +128,7 @@ impl Node for AutoExposureNode {
                     label: Some("auto_exposure"),
                     timestamp_writes: None,
                 });
-        let pass_span = diagnostics.time_span(&mut compute_pass, "auto_exposure");
+        let pass_span = diagnostics.pass_span(&mut compute_pass, "auto_exposure");
 
         compute_pass.set_bind_group(0, &compute_bind_group, &[view_uniform_offset.offset]);
         compute_pass.set_pipeline(histogram_pipeline);


### PR DESCRIPTION
# Objective

- Fixes #21167 
  (happens with `trace_tracy` feature too, as it adds the plugin automatically)
- There are some uses of `time_span` inside passes, which go around [the check](https://github.com/bevyengine/bevy/blob/10325593d5bae88e1089bdf1fa1395f232d5248b/crates/bevy_render/src/diagnostic/internal.rs#L289) for [TIMESTAMP_QUERY_INSIDE_PASSES](https://docs.rs/wgpu-types/latest/wgpu_types/struct.FeaturesWGPU.html#associatedconstant.TIMESTAMP_QUERY_INSIDE_PASSES) feature (unsupported on Apple GPU).
introduced in  #19191

## Solution

- They look like just typos (all in `let pass_span = time_span` form), so replaced with `pass_span`.

There's an occurence of this pattern in `meshlet/visibility_buffer_raster_node.rs`, but it's the variable name that is  incorrect in this case. I renamed it instead.

## Testing

- Running `log_diagnostics` example no longer crashes on Mac.
