### PR TITLE
Add Custom SubApp example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -605,6 +605,7 @@ serde_json = "1.0.140"
 bytemuck = "1"
 # The following explicit dependencies are needed for proc macros to work inside of examples as they are part of the bevy crate itself.
 bevy_animation = { path = "crates/bevy_animation", version = "0.18.0-dev", default-features = false }
+bevy_app = { path = "crates/bevy_app", version = "0.18.0-dev", default-features = false }
 bevy_asset = { path = "crates/bevy_asset", version = "0.18.0-dev", default-features = false }
 bevy_ecs = { path = "crates/bevy_ecs", version = "0.18.0-dev", default-features = false }
 bevy_gizmos = { path = "crates/bevy_gizmos", version = "0.18.0-dev", default-features = false }
@@ -1576,6 +1577,18 @@ doc-scrape-examples = true
 [package.metadata.example.custom_loop]
 name = "Custom Loop"
 description = "Demonstrates how to create a custom runner (to update an app manually)"
+category = "Application"
+# Doesn't render anything, doesn't create a canvas
+wasm = false
+
+[[example]]
+name = "custom_subapp"
+path = "examples/app/custom_subapp.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.custom_subapp]
+name = "Custom SubApp"
+description = "Demonstratres how to create a custom subapp with its own extract fn"
 category = "Application"
 # Doesn't render anything, doesn't create a canvas
 wasm = false

--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -56,7 +56,7 @@ pub use terminal_ctrl_c_handler::*;
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
-        app::{App, AppExit},
+        app::{App, AppExit, AppLabel},
         main_schedule::{
             First, FixedFirst, FixedLast, FixedPostUpdate, FixedPreUpdate, FixedUpdate, Last, Main,
             PostStartup, PostUpdate, PreStartup, PreUpdate, RunFixedMainLoop,

--- a/examples/README.md
+++ b/examples/README.md
@@ -224,6 +224,7 @@ Example | Description
 --- | ---
 [Advanced log layers](../examples/app/log_layers_ecs.rs) | Illustrate how to transfer data between log layers and Bevy's ECS
 [Custom Loop](../examples/app/custom_loop.rs) | Demonstrates how to create a custom runner (to update an app manually)
+[Custom SubApp](../examples/app/custom_subapp.rs) | Demonstratres how to create a custom subapp with its own extract fn
 [Drag and Drop](../examples/app/drag_and_drop.rs) | An example that shows how to handle drag and drop in an app
 [Empty](../examples/app/empty.rs) | An empty application (does nothing)
 [Empty with Defaults](../examples/app/empty_defaults.rs) | An empty application with default plugins

--- a/examples/app/custom_subapp.rs
+++ b/examples/app/custom_subapp.rs
@@ -1,0 +1,51 @@
+//! This example demonstrates how you could create your own custom subapps to run tasks based off of the main app.
+
+use bevy::{ecs::schedule::ScheduleLabel, prelude::*};
+
+#[derive(Clone, Copy, AppLabel, Hash, PartialEq, Eq, Debug, Default)]
+struct OurCustomSubApp;
+
+/// A ref to which main world entity our subapp entity refers to.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, Component)]
+struct MainWorldEntity(pub Entity);
+
+fn extract(main_world: &mut World, our_world: &mut World) {
+    let mut query_state_existing_entities = our_world.query::<&MainWorldEntity>();
+    let existing_entities = query_state_existing_entities
+        .iter(our_world)
+        .map(|x| x.0)
+        .collect::<Vec<_>>();
+    // For each currently non existing entity in main world, create a variant for our own world
+    let mut query_state = main_world.query::<(Entity, &Name)>();
+    for (e, name) in query_state.iter(main_world) {
+        if !existing_entities.contains(&e) {
+            our_world.spawn((MainWorldEntity(e), name.clone()));
+        }
+    }
+}
+
+fn exists_hi_system(query: Populated<&Name, With<MainWorldEntity>>, mut found: Local<bool>) {
+    if *found {
+        return;
+    }
+    for i in query.iter() {
+        if i.as_str() == "hello there" {
+            *found = true;
+            println!("{i}");
+        }
+    }
+}
+
+fn main() {
+    let mut sub_app = SubApp::new();
+    sub_app.set_extract(extract);
+    // Sets the default schedule to run whenever sub_app.update() gets called.
+    sub_app.update_schedule = Some(Main.intern());
+    sub_app.add_systems(Main, exists_hi_system);
+
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins)
+        .insert_sub_app(OurCustomSubApp, sub_app);
+    app.world_mut().spawn(Name::new("hello there"));
+    app.run();
+}


### PR DESCRIPTION
# Objective

Fixes some issues related to #20975
```rs
error[E0433]: failed to resolve: use of unresolved module or unlinked crate `bevy_app`
 --> examples/app/custom_subapp.rs:3:17
  |
3 | #[derive(Clone, AppLabel)]
  |                 ^^^^^^^^ use of unresolved module or unlinked crate `bevy_app`
  |
  = help: if you wanted to use a crate named `bevy_app`, use `cargo add bevy_app` to add it to your `Cargo.toml`
  = note: this error originates in the derive macro `AppLabel` (in Nightly builds, run with -Z macro-backtrace for more info)
```

## Solution

Modify Cargo.toml and also add a new example.

## Testing

`cargo run --example custom_subapp`

Works as intended.