### PR TITLE
Implementation of Dynamic Plugins

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -605,6 +605,7 @@ serde_json = "1.0.140"
 bytemuck = "1"
 # The following explicit dependencies are needed for proc macros to work inside of examples as they are part of the bevy crate itself.
 bevy_animation = { path = "crates/bevy_animation", version = "0.18.0-dev", default-features = false }
+bevy_app = { path = "crates/bevy_app", version = "0.18.0-dev", default-features = false }
 bevy_asset = { path = "crates/bevy_asset", version = "0.18.0-dev", default-features = false }
 bevy_ecs = { path = "crates/bevy_ecs", version = "0.18.0-dev", default-features = false }
 bevy_gizmos = { path = "crates/bevy_gizmos", version = "0.18.0-dev", default-features = false }
@@ -1576,6 +1577,18 @@ doc-scrape-examples = true
 [package.metadata.example.custom_loop]
 name = "Custom Loop"
 description = "Demonstrates how to create a custom runner (to update an app manually)"
+category = "Application"
+# Doesn't render anything, doesn't create a canvas
+wasm = false
+
+[[example]]
+name = "custom_subapp"
+path = "examples/app/custom_subapp.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.custom_subapp]
+name = "Custom SubApp"
+description = "Demonstratres how to create a custom subapp with its own extract fn"
 category = "Application"
 # Doesn't render anything, doesn't create a canvas
 wasm = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1629,6 +1629,17 @@ category = "Application"
 wasm = true
 
 [[example]]
+name = "exclusive_hook"
+path = "examples/app/exclusive_hook.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.exclusive_hook]
+name = "Exclusive App Hooks"
+description = "A plugin that allows to access subapps during runtime."
+category = "Application"
+wasm = true
+
+[[example]]
 name = "headless"
 path = "examples/app/headless.rs"
 doc-scrape-examples = true

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -88,6 +88,9 @@ pub struct App {
     /// [`WinitPlugin`]: https://docs.rs/bevy/latest/bevy/winit/struct.WinitPlugin.html
     /// [`ScheduleRunnerPlugin`]: https://docs.rs/bevy/latest/bevy/app/struct.ScheduleRunnerPlugin.html
     pub(crate) runner: RunnerFn,
+    /// The list of hooks to run distributing exclusive app access to outside code.
+    pub(crate) hooks: HashMap<usize, RunnerHookFn>,
+    pub(crate) hook_id_count: usize,
     default_error_handler: Option<ErrorHandler>,
 }
 
@@ -148,17 +151,48 @@ impl App {
                 sub_apps: HashMap::default(),
             },
             runner: Box::new(run_once),
+            hooks: HashMap::new(),
+            hook_id_count: 0,
             default_error_handler: None,
         }
     }
 
     /// Runs the default schedules of all sub-apps (starting with the "main" app) once.
+    ///
+    /// Also runs exclusive app hooks, see also [`App::add_exclusive_hook()`]
     pub fn update(&mut self) {
         if self.is_building_plugins() {
             panic!("App::update() was called while a plugin was building.");
         }
-
+        let mut hooks = core::mem::take(&mut self.hooks);
+        for hook in hooks.values_mut() {
+            hook(self);
+        }
+        self.hooks = hooks;
         self.sub_apps.update();
+    }
+
+    /// Adds a new exclusive hook to the App
+    ///
+    /// These hooks will get called on every [`App::update()`] call, but will not get called if its updated via subapps.
+    ///
+    /// The ID returned can be later used with [`App::remove_exclusive_hook()`]
+    ///
+    /// See also [`App::update()`]
+    pub fn add_exclusive_hook(&mut self, func: impl FnMut(&mut App) + 'static) -> usize {
+        let hook_id_count = self.hook_id_count;
+        self.hook_id_count += 1;
+
+        self.hooks.insert(hook_id_count, Box::new(func));
+
+        hook_id_count
+    }
+
+    /// Removes an already existing exclusive hook from the App, returning the hook
+    ///
+    /// See also [`App::add_exclusive_hook()`] and [`App::update()`]
+    pub fn remove_exclusive_hook(&mut self, id: usize) -> Option<RunnerHookFn> {
+        self.hooks.remove(&id)
     }
 
     /// Runs the [`App`] by calling its [runner](Self::set_runner).
@@ -1438,6 +1472,7 @@ impl Plugin for HokeyPokey {
 }
 
 type RunnerFn = Box<dyn FnOnce(App) -> AppExit>;
+type RunnerHookFn = Box<dyn FnMut(&mut App)>;
 
 fn run_once(mut app: App) -> AppExit {
     while app.plugins_state() == PluginsState::Adding {

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -46,9 +46,12 @@ pub use bevy_ecs::label::DynEq;
 pub type InternedAppLabel = Interned<dyn AppLabel>;
 
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub(crate) enum AppError {
     #[error("duplicate plugin {plugin_name:?}")]
     DuplicatePlugin { plugin_name: String },
+    #[error("expected dynamic plugin, got non-dynamic {plugin_name:?}")]
+    ExpectedDynamicPlugin { plugin_name: String },
 }
 
 /// [`App`] is the primary API for writing user applications. It automates the setup of a
@@ -306,6 +309,20 @@ impl App {
             hokeypokey.finish(self);
             core::mem::swap(&mut self.main_mut().plugin_registry[i], &mut hokeypokey);
         }
+        for i in 0..self.main().dynamic_plugin_registry.len() {
+            core::mem::swap(
+                &mut self.main_mut().dynamic_plugin_registry[i],
+                &mut hokeypokey,
+            );
+            #[cfg(feature = "trace")]
+            let _plugin_finish_span =
+                info_span!("plugin finish", plugin = hokeypokey.name()).entered();
+            hokeypokey.finish(self);
+            core::mem::swap(
+                &mut self.main_mut().dynamic_plugin_registry[i],
+                &mut hokeypokey,
+            );
+        }
         self.main_mut().plugins_state = PluginsState::Finished;
         self.sub_apps.iter_mut().skip(1).for_each(SubApp::finish);
     }
@@ -325,6 +342,20 @@ impl App {
                 info_span!("plugin cleanup", plugin = hokeypokey.name()).entered();
             hokeypokey.cleanup(self);
             core::mem::swap(&mut self.main_mut().plugin_registry[i], &mut hokeypokey);
+        }
+        for i in 0..self.main().dynamic_plugin_registry.len() {
+            core::mem::swap(
+                &mut self.main_mut().dynamic_plugin_registry[i],
+                &mut hokeypokey,
+            );
+            #[cfg(feature = "trace")]
+            let _plugin_finish_span =
+                info_span!("plugin finish", plugin = hokeypokey.name()).entered();
+            hokeypokey.cleanup(self);
+            core::mem::swap(
+                &mut self.main_mut().dynamic_plugin_registry[i],
+                &mut hokeypokey,
+            );
         }
         self.main_mut().plugins_state = PluginsState::Cleaned;
         self.sub_apps.iter_mut().skip(1).for_each(SubApp::cleanup);
@@ -576,6 +607,66 @@ impl App {
         Ok(self)
     }
 
+    pub(crate) fn add_boxed_dynamic_plugin(
+        &mut self,
+        plugin: Box<dyn Plugin>,
+    ) -> Result<&mut Self, AppError> {
+        debug!("added dynamic plugin: {}", plugin.name());
+
+        if !plugin.is_dynamic() {
+            Err(AppError::ExpectedDynamicPlugin {
+                plugin_name: plugin.name().to_string(),
+            })?;
+        }
+
+        if plugin.is_unique() && self.main_mut().plugin_names.contains(plugin.name()) {
+            Err(AppError::DuplicatePlugin {
+                plugin_name: plugin.name().to_string(),
+            })?;
+        }
+
+        let index = self.main().dynamic_plugin_registry.len();
+
+        self.main_mut()
+            .dynamic_plugin_registry
+            .push(Box::new(PlaceholderPlugin));
+
+        self.main_mut().plugin_build_depth += 1;
+
+        #[cfg(feature = "trace")]
+        let _plugin_build_span = info_span!("plugin build", plugin = plugin.name()).entered();
+
+        let f = AssertUnwindSafe(|| plugin.build(self));
+
+        #[cfg(feature = "std")]
+        let result = catch_unwind(f);
+
+        #[cfg(not(feature = "std"))]
+        f();
+
+        self.main_mut()
+            .plugin_names
+            .insert(plugin.name().to_string());
+        self.main_mut().plugin_build_depth -= 1;
+
+        #[cfg(feature = "std")]
+        if let Err(payload) = result {
+            resume_unwind(payload);
+        }
+
+        match self.plugins_state() {
+            PluginsState::Finished => plugin.finish(self),
+            PluginsState::Cleaned => {
+                plugin.finish(self);
+                plugin.cleanup(self);
+            }
+            _ => (),
+        }
+
+        self.main_mut().plugin_registry[index] = plugin;
+        Ok(self)
+    }
+
     /// Returns `true` if the [`Plugin`] has already been added.
     pub fn is_plugin_added<T>(&self) -> bool
     where
@@ -648,6 +739,8 @@ impl App {
     /// Panics if one of the plugins had already been added to the application.
     ///
     /// [`PluginGroup`]:super::PluginGroup
+    ///
+    /// See also [`App::add_dynamic_plugins()`]
     #[track_caller]
     pub fn add_plugins<M>(&mut self, plugins: impl Plugins<M>) -> &mut Self {
         if matches!(
@@ -660,6 +753,43 @@ impl App {
         }
         plugins.add_to_app(self);
         self
+    }
+    /// Installs a [`Plugin`] collection dynamically.
+    ///
+    /// # Panics
+    ///
+    /// Panics if one of the plugins had already been added to the application
+    ///
+    /// See also [`App::add_plugins()`]
+    #[track_caller]
+    pub fn add_dynamic_plugins<M>(&mut self, plugins: impl Plugins<M>) -> &mut Self {
+        plugins.add_to_app_dynamic(self);
+        self
+    }
+
+    /// Uninstalls a [`Plugin`] dynamically
+    ///
+    /// # Panics
+    ///
+    /// Panics if the plugin was not registered as dynamic.
+    ///
+    /// See also [`App::add_dynamic_plugins()`]
+    #[track_caller]
+    pub fn remove_dynamic_plugin<P: Plugin>(&mut self) {
+        let index = self
+            .main()
+            .dynamic_plugin_registry
+            .iter()
+            .enumerate()
+            .filter_map(|(i, p)| p.downcast_ref::<P>().map(|_| i))
+            .next_back();
+        if let Some(idx) = index {
+            let plugin = self.main_mut().dynamic_plugin_registry.remove(idx);
+            plugin.remove(self);
+            // drop plugin
+        } else {
+            panic!("dynamic plugin {:?} not found", core::any::type_name::<P>());
+        }
     }
 
     /// Registers the type `T` in the [`AppTypeRegistry`] resource,

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -90,6 +90,8 @@ pub struct App {
     pub(crate) runner: RunnerFn,
     /// The list of hooks to run distributing exclusive app access to outside code.
     pub(crate) hooks: HashMap<usize, RunnerHookFn>,
+    /// The next id that will be used for a newly registered hook.
+    /// This value does not track the currently active hook amount as it is never decremented.
     pub(crate) hook_id_count: usize,
     default_error_handler: Option<ErrorHandler>,
 }

--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -56,7 +56,7 @@ pub use terminal_ctrl_c_handler::*;
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
-        app::{App, AppExit},
+        app::{App, AppExit, AppLabel},
         main_schedule::{
             First, FixedFirst, FixedLast, FixedPostUpdate, FixedPreUpdate, FixedUpdate, Last, Main,
             PostStartup, PostUpdate, PreStartup, PreUpdate, RunFixedMainLoop,

--- a/crates/bevy_app/src/sub_app.rs
+++ b/crates/bevy_app/src/sub_app.rs
@@ -63,6 +63,8 @@ pub struct SubApp {
     world: World,
     /// List of plugins that have been added.
     pub(crate) plugin_registry: Vec<Box<dyn Plugin>>,
+    /// List of dynamic plugins that have been added.
+    pub(crate) dynamic_plugin_registry: Vec<Box<dyn Plugin>>,
     /// The names of plugins that have been added to this app. (used to track duplicates and
     /// already-registered plugins)
     pub(crate) plugin_names: HashSet<String>,
@@ -89,6 +91,7 @@ impl Default for SubApp {
         Self {
             world,
             plugin_registry: Vec::default(),
+            dynamic_plugin_registry: Vec::default(),
             plugin_names: HashSet::default(),
             plugin_build_depth: 0,
             plugins_state: PluginsState::Adding,
@@ -362,6 +365,18 @@ impl SubApp {
         self
     }
 
+    /// See [`App::add_dynamic_plugins`].
+    pub fn add_dynamic_plugins<M>(&mut self, plugins: impl Plugins<M>) -> &mut Self {
+        self.run_as_app(|app| plugins.add_to_app_dynamic(app));
+        self
+    }
+
+    /// See [`App::remove_dynamic_plugin`].
+    pub fn remove_dynamic_plugin<P: Plugin>(&mut self) -> &mut Self {
+        self.run_as_app(|app| app.remove_dynamic_plugin::<P>());
+        self
+    }
+
     /// See [`App::is_plugin_added`].
     pub fn is_plugin_added<T>(&self) -> bool
     where
@@ -377,6 +392,7 @@ impl SubApp {
     {
         self.plugin_registry
             .iter()
+            .chain(self.dynamic_plugin_registry.iter())
             .filter_map(|p| p.downcast_ref())
             .collect()
     }

--- a/examples/README.md
+++ b/examples/README.md
@@ -228,6 +228,7 @@ Example | Description
 [Drag and Drop](../examples/app/drag_and_drop.rs) | An example that shows how to handle drag and drop in an app
 [Empty](../examples/app/empty.rs) | An empty application (does nothing)
 [Empty with Defaults](../examples/app/empty_defaults.rs) | An empty application with default plugins
+[Exclusive App Hooks](../examples/app/exclusive_hook.rs) | A plugin that allows to access subapps during runtime.
 [Headless](../examples/app/headless.rs) | An application that runs without default plugins
 [Headless Renderer](../examples/app/headless_renderer.rs) | An application that runs with no window, but renders into image file
 [Log layers](../examples/app/log_layers.rs) | Illustrate how to add custom log layers

--- a/examples/README.md
+++ b/examples/README.md
@@ -224,6 +224,7 @@ Example | Description
 --- | ---
 [Advanced log layers](../examples/app/log_layers_ecs.rs) | Illustrate how to transfer data between log layers and Bevy's ECS
 [Custom Loop](../examples/app/custom_loop.rs) | Demonstrates how to create a custom runner (to update an app manually)
+[Custom SubApp](../examples/app/custom_subapp.rs) | Demonstratres how to create a custom subapp with its own extract fn
 [Drag and Drop](../examples/app/drag_and_drop.rs) | An example that shows how to handle drag and drop in an app
 [Empty](../examples/app/empty.rs) | An empty application (does nothing)
 [Empty with Defaults](../examples/app/empty_defaults.rs) | An empty application with default plugins

--- a/examples/app/custom_subapp.rs
+++ b/examples/app/custom_subapp.rs
@@ -1,0 +1,51 @@
+//! This example demonstrates how you could create your own custom subapps to run tasks based off of the main app.
+
+use bevy::{ecs::schedule::ScheduleLabel, prelude::*};
+
+#[derive(Clone, Copy, AppLabel, Hash, PartialEq, Eq, Debug, Default)]
+struct OurCustomSubApp;
+
+/// A ref to which main world entity our subapp entity refers to.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, Component)]
+struct MainWorldEntity(pub Entity);
+
+fn extract(main_world: &mut World, our_world: &mut World) {
+    let mut query_state_existing_entities = our_world.query::<&MainWorldEntity>();
+    let existing_entities = query_state_existing_entities
+        .iter(our_world)
+        .map(|x| x.0)
+        .collect::<Vec<_>>();
+    // For each currently non existing entity in main world, create a variant for our own world
+    let mut query_state = main_world.query::<(Entity, &Name)>();
+    for (e, name) in query_state.iter(main_world) {
+        if !existing_entities.contains(&e) {
+            our_world.spawn((MainWorldEntity(e), name.clone()));
+        }
+    }
+}
+
+fn exists_hi_system(query: Populated<&Name, With<MainWorldEntity>>, mut found: Local<bool>) {
+    if *found {
+        return;
+    }
+    for i in query.iter() {
+        if i.as_str() == "hello there" {
+            *found = true;
+            println!("{i}");
+        }
+    }
+}
+
+fn main() {
+    let mut sub_app = SubApp::new();
+    sub_app.set_extract(extract);
+    // Sets the default schedule to run whenever sub_app.update() gets called.
+    sub_app.update_schedule = Some(Main.intern());
+    sub_app.add_systems(Main, exists_hi_system);
+
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins)
+        .insert_sub_app(OurCustomSubApp, sub_app);
+    app.world_mut().spawn(Name::new("hello there"));
+    app.run();
+}

--- a/examples/app/exclusive_hook.rs
+++ b/examples/app/exclusive_hook.rs
@@ -1,0 +1,70 @@
+//! Shows how exclusive app hooks work for modifying subapps at runtime. This example only allows access from the main app to specific sub apps.
+
+use bevy::{
+    ecs::{intern::Interned, system::SystemId},
+    prelude::*,
+};
+
+#[derive(Resource, Default)]
+struct CallWithSubAppList(Vec<CallWithSubApp>);
+struct CallWithSubApp(SystemId<InMut<'static, SubApp>, ()>, Interned<dyn AppLabel>);
+impl Command for CallWithSubApp {
+    fn apply(self, w: &mut World) {
+        w.resource_mut::<CallWithSubAppList>().0.push(self);
+    }
+}
+struct SubAppAccessPlugin;
+impl Plugin for SubAppAccessPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<CallWithSubAppList>()
+            .add_exclusive_hook(hook);
+    }
+}
+
+#[derive(AppLabel, Clone, Copy, Hash, Default, Debug, PartialEq, Eq)]
+struct OurSubAppLabel;
+
+fn print_hi() {
+    println!("Hello from sub app");
+}
+
+fn subapp_access(mut sub_app: InMut<SubApp>) {
+    sub_app.world_mut().spawn(Name::new("Hello from sub app"));
+    let id = sub_app.register_system(print_hi);
+    sub_app.world_mut().run_system(id).unwrap();
+}
+
+fn main() {
+    let mut app = App::new();
+    app.add_plugins(SubAppAccessPlugin)
+        .add_plugins(MinimalPlugins)
+        .add_systems(Startup, init)
+        .insert_sub_app(OurSubAppLabel, SubApp::default());
+    app.run();
+}
+
+fn init(mut commands: Commands) {
+    let id = commands.register_system(subapp_access);
+    commands.queue(CallWithSubApp(id, OurSubAppLabel.intern()));
+}
+
+fn hook(app: &mut App) {
+    let list = std::mem::take(&mut app.world_mut().resource_mut::<CallWithSubAppList>().0);
+    for command in list {
+        #[expect(unsafe_code, reason = "App is guaranteed to outlive the subapp")]
+        // SAFETY: The app is guaranteed to outlive the SubApp
+        let sub_app = unsafe {
+            core::ptr::from_mut(
+                app.sub_apps_mut()
+                    .sub_apps
+                    .get_mut(&command.1)
+                    .expect("Failed to get sub app"),
+            )
+            .as_mut()
+            .unwrap_unchecked()
+        };
+        app.world_mut()
+            .run_system_with(command.0, sub_app)
+            .expect("Failed to run system on sub app");
+    }
+}


### PR DESCRIPTION
Depends on #20975, #21239 and #20298 

# Objective

- Implements a way to have dynamically installable and removable plugins for Bevy

## Solution

- Implements two new functions on the `Plugin` trait: `fn is_dynamic(&self) -> bool` and `fn remove(&self, app: &mut App)`

## Testing

- Not tested at the moment