### PR TITLE
Re-export disqualified::ShortName from bevy_utils

### DIFF
--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -45,6 +45,7 @@ cfg::parallel! {
 pub mod prelude {
     pub use crate::debug_info::DebugName;
     pub use crate::default;
+    pub use disqualified::ShortName;
 }
 
 mod debug_info;


### PR DESCRIPTION
To migrate to 0.17, I tried switching to using `DebugName::type_name::<C>()` from bevy_utils.

In some cases I wanted to use the `ShortName` type that I saw in bevy_utils, but to my surprise it was not exported.

Is it possible to include this in 0.17?
