### PR TITLE
Allow users to configure the maximum number of joints and morph weights used in models

### DIFF
--- a/crates/bevy_gltf/src/loader/mod.rs
+++ b/crates/bevy_gltf/src/loader/mod.rs
@@ -38,7 +38,7 @@ use bevy_mesh::{
 };
 #[cfg(feature = "pbr_transmission_textures")]
 use bevy_pbr::UvChannel;
-use bevy_pbr::{MeshMaterial3d, StandardMaterial, MAX_JOINTS};
+use bevy_pbr::{MeshMaterial3d, StandardMaterial};
 use bevy_platform::collections::{HashMap, HashSet};
 use bevy_render::render_resource::Face;
 use bevy_scene::Scene;
@@ -870,17 +870,6 @@ impl GltfLoader {
                             .joints()
                             .map(|joint| nodes.get(&joint.index()).unwrap().clone())
                             .collect();
-
-                        if joints.len() > MAX_JOINTS {
-                            warn!(
-                                "The glTF skin {} has {} joints, but the maximum supported is {}",
-                                skin.name()
-                                    .map(ToString::to_string)
-                                    .unwrap_or_else(|| skin.index().to_string()),
-                                joints.len(),
-                                MAX_JOINTS
-                            );
-                        }
 
                         let gltf_skin = GltfSkin::new(
                             &skin,

--- a/crates/bevy_mesh/src/morph.rs
+++ b/crates/bevy_mesh/src/morph.rs
@@ -13,9 +13,6 @@ const MAX_TEXTURE_WIDTH: u32 = 2048;
 // Vec3 has 3 components, Mat2 has 4 components.
 const MAX_COMPONENTS: u32 = MAX_TEXTURE_WIDTH * MAX_TEXTURE_WIDTH;
 
-/// Max target count available for [morph targets](MorphWeights).
-pub const MAX_MORPH_WEIGHTS: usize = 64;
-
 #[derive(Error, Clone, Debug)]
 pub enum MorphBuildError {
     #[error(
@@ -27,12 +24,6 @@ pub enum MorphBuildError {
         vertex_count: usize,
         component_count: u32,
     },
-    #[error(
-        "Bevy only supports up to {} morph targets (individual poses), tried to \
-        create a model with {target_count} morph targets",
-        MAX_MORPH_WEIGHTS
-    )]
-    TooManyTargets { target_count: usize },
 }
 
 /// An image formatted for use with [`MorphWeights`] for rendering the morph target.
@@ -55,9 +46,6 @@ impl MorphTargetImage {
     ) -> Result<Self, MorphBuildError> {
         let max = MAX_TEXTURE_WIDTH;
         let target_count = targets.len();
-        if target_count > MAX_MORPH_WEIGHTS {
-            return Err(MorphBuildError::TooManyTargets { target_count });
-        }
         let component_count = (vertex_count * MorphAttributes::COMPONENT_COUNT) as u32;
         let Some((Rect(width, height), padding)) = lowest_2d(component_count, max) else {
             return Err(MorphBuildError::TooManyAttributes {
@@ -123,10 +111,6 @@ impl MorphWeights {
         weights: Vec<f32>,
         first_mesh: Option<Handle<Mesh>>,
     ) -> Result<Self, MorphBuildError> {
-        if weights.len() > MAX_MORPH_WEIGHTS {
-            let target_count = weights.len();
-            return Err(MorphBuildError::TooManyTargets { target_count });
-        }
         Ok(MorphWeights {
             weights,
             first_mesh,
@@ -164,10 +148,6 @@ pub struct MeshMorphWeights {
 
 impl MeshMorphWeights {
     pub fn new(weights: Vec<f32>) -> Result<Self, MorphBuildError> {
-        if weights.len() > MAX_MORPH_WEIGHTS {
-            let target_count = weights.len();
-            return Err(MorphBuildError::TooManyTargets { target_count });
-        }
         Ok(MeshMorphWeights { weights })
     }
     pub fn weights(&self) -> &[f32] {

--- a/crates/bevy_pbr/src/render/mod.rs
+++ b/crates/bevy_pbr/src/render/mod.rs
@@ -14,4 +14,4 @@ pub use mesh::*;
 pub use mesh_bindings::MeshLayouts;
 pub use mesh_view_bindings::*;
 pub use morph::*;
-pub use skin::{extract_skins, prepare_skins, skins_use_uniform_buffers, SkinUniforms, MAX_JOINTS};
+pub use skin::{extract_skins, prepare_skins, skins_use_uniform_buffers, SkinUniforms, GlobalSkinnedMeshSettings};

--- a/crates/bevy_pbr/src/render/morph.rs
+++ b/crates/bevy_pbr/src/render/morph.rs
@@ -2,7 +2,7 @@ use core::{iter, mem};
 
 use bevy_camera::visibility::ViewVisibility;
 use bevy_ecs::prelude::*;
-use bevy_mesh::morph::{MeshMorphWeights, MAX_MORPH_WEIGHTS};
+use bevy_mesh::morph::{MeshMorphWeights};
 use bevy_render::sync_world::MainEntityHashMap;
 use bevy_render::{
     batching::NoAutomaticBatching,
@@ -11,6 +11,7 @@ use bevy_render::{
     Extract,
 };
 use bytemuck::NoUninit;
+use crate::GlobalSkinnedMeshSettings;
 
 #[derive(Component)]
 pub struct MorphIndex {
@@ -109,6 +110,7 @@ fn add_to_alignment<T: NoUninit + Default>(buffer: &mut RawBufferVec<T>) {
 pub fn extract_morphs(
     morph_indices: ResMut<MorphIndices>,
     uniform: ResMut<MorphUniforms>,
+    skinned_mesh_settings: Res<GlobalSkinnedMeshSettings>,
     query: Extract<Query<(Entity, &ViewVisibility, &MeshMorphWeights)>>,
 ) {
     // Borrow check workaround.
@@ -127,7 +129,7 @@ pub fn extract_morphs(
         }
         let start = uniform.current_buffer.len();
         let weights = morph_weights.weights();
-        let legal_weights = weights.iter().take(MAX_MORPH_WEIGHTS).copied();
+        let legal_weights = weights.iter().take(skinned_mesh_settings.max_morph_weights).copied();
         uniform.current_buffer.extend(legal_weights);
         add_to_alignment::<f32>(&mut uniform.current_buffer);
 


### PR DESCRIPTION
# Objective

- We want to allow editing the `MAX_JOINTS` and `MAX_MORPH_WEIGHTS` values (currently constants), so we can use models with high joint/morph weight count.
- Fixes #17128.

## Solution

Replaces the constants `MAX_JOINTS` and `MAX_MORPH_WEIGHTS` with `GlobalSkinnedMeshSettings` so those values can be customized.

## Testing

I included a model made with Ready Player Me and rigged with Blender's Rigify, and updated the `gltf_skinned_mesh` example in a seaparete branch [here](https://github.com/doceazedo/bevy/blob/max-morph-targets-example/examples/gltf/gltf_skinned_mesh.rs) for testing.

If you run `cargo run --example gltf_skinned_mesh`, you can see the model is rendered just fine:

<img width="1280" height="748" alt="CleanShot 2025-09-28 at 12 40 28" src="https://github.com/user-attachments/assets/c59ec142-cde5-46c0-ad9f-ea11c271ec56" />

While previously it would throw this error:

```
Bevy only supports up to 64 morph targets (individual poses), tried to create a model with 72 morph targets
```