### PR TITLE
Add conversion from DebugName to Cow<'static, str>

### DIFF
--- a/crates/bevy_utils/src/debug_info.rs
+++ b/crates/bevy_utils/src/debug_info.rs
@@ -143,7 +143,13 @@ cfg::alloc! {
         )]
         fn from(value: DebugName) -> Self {
             #[cfg(feature = "debug")]
-            value.name
+            {
+                value.name
+            }
+            #[cfg(not(feature = "debug"))]
+            {
+                Cow::Borrowed(FEATURE_DISABLED)
+            }
         }
     }
 }

--- a/crates/bevy_utils/src/debug_info.rs
+++ b/crates/bevy_utils/src/debug_info.rs
@@ -132,6 +132,20 @@ cfg::alloc! {
             Self::owned(value)
         }
     }
+
+    impl From<DebugName> for Cow<'static, str> {
+        #[cfg_attr(
+            not(feature = "debug"),
+            expect(
+                unused_variables,
+                reason = "The value will be ignored if the `debug` feature is not enabled"
+            )
+        )]
+        fn from(value: DebugName) -> Self {
+            #[cfg(feature = "debug")]
+            value.name
+        }
+    }
 }
 
 impl From<&'static str> for DebugName {


### PR DESCRIPTION
# Objective

There seems to be no way to get the underlying `Cow<'static, str>` from the `DebugName`.

This is useful for me to be able to use `DebugName` and have it interop seamlessly with the `metrics` crate: https://docs.rs/metrics/latest/metrics/type.SharedString.html

which is the standard why to register/record metrics in rust.

Is it possible to include this in 0.17?