### PR TITLE
Add Srgba color construction from u32 literal

### DIFF
--- a/crates/bevy_color/src/srgba.rs
+++ b/crates/bevy_color/src/srgba.rs
@@ -172,6 +172,20 @@ impl Srgba {
         }
     }
 
+    /// New `Srgba` from a u32 literal.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bevy_color::Srgba;
+    /// let color = Srgba::literal(0xFF00FFFF); // fuchsia
+    /// let color = Srgba::literal(0xFF00FF7F); // partially transparent fuchsia
+    /// ```
+    pub fn literal(hex: u32) -> Self {
+        let rgba = hex.to_be_bytes();
+        Self::rgba_u8(rgba[0], rgba[1], rgba[2], rgba[3])
+    }
+
     /// Convert this color to CSS-style hexadecimal notation.
     #[cfg(feature = "alloc")]
     pub fn to_hex(&self) -> String {
@@ -517,5 +531,17 @@ mod tests {
 
         assert!(matches!(Srgba::hex("yyy"), Err(HexColorError::Parse(_))));
         assert!(matches!(Srgba::hex("##fff"), Err(HexColorError::Parse(_))));
+    }
+
+    #[test]
+    fn literal_color() {
+        assert_eq!(Srgba::literal(0xFFFFFFFF), Srgba::WHITE);
+        assert_eq!(Srgba::literal(0x000000FF), Srgba::BLACK);
+        assert_eq!(Srgba::literal(0x03a9f4FF), Srgba::rgb_u8(3, 169, 244));
+        assert_eq!(Srgba::literal(0xFF22AAFF), Srgba::rgb_u8(255, 34, 170));
+        assert_eq!(Srgba::literal(0xE23030FF), Srgba::rgb_u8(226, 48, 48));
+        assert_eq!(Srgba::literal(0x11223344), Srgba::rgba_u8(17, 34, 51, 68));
+        assert_eq!(Srgba::literal(0x12345678), Srgba::rgba_u8(18, 52, 86, 120));
+        assert_eq!(Srgba::literal(0x44332211), Srgba::rgba_u8(68, 51, 34, 17));
     }
 }

--- a/crates/bevy_color/src/srgba.rs
+++ b/crates/bevy_color/src/srgba.rs
@@ -537,7 +537,7 @@ mod tests {
     fn literal_color() {
         assert_eq!(Srgba::literal(0xFFFFFFFF), Srgba::WHITE);
         assert_eq!(Srgba::literal(0x000000FF), Srgba::BLACK);
-        assert_eq!(Srgba::literal(0x03a9f4FF), Srgba::rgb_u8(3, 169, 244));
+        assert_eq!(Srgba::literal(0x03A9F4FF), Srgba::rgb_u8(3, 169, 244));
         assert_eq!(Srgba::literal(0xFF22AAFF), Srgba::rgb_u8(255, 34, 170));
         assert_eq!(Srgba::literal(0xE23030FF), Srgba::rgb_u8(226, 48, 48));
         assert_eq!(Srgba::literal(0x11223344), Srgba::rgba_u8(17, 34, 51, 68));


### PR DESCRIPTION
# Objective

As I was working with colors, I found that we can use `Srgba::hex` to get a color from a hex code with CSS Style. But since we are using Rust, and we have the capabilities to use the literal hex notation `0x00000000` Why not have the capabilities of using that?

## Solution

I didn't want to create a PR with breaking changes, my initial thought was to change the `hex` function to be `css_hex` and call this one as hex.

Currently, I'm calling it Literal as I wasn't sure what to call it by replacing the other name, another way we could do it is by implementing `From<u32> for Srgba` which does basically the same thing. Only problem is, then we can't get to control if we can split it into two functions, one with alpha and one without.

Benefits:

- We get the compiler to help us not make a mistake in our Hex literal, instead of returning a Result like the current implementation of Hex.
- Speed, but I wouldn't say it's going to be that big of a boost.
- It's more precise for those who work with Hex and not familiar with the way CSS does it. For example, using this function with `0xFF` it sets Red to 255, while everything else to 0s, while CSS `0xFFF` means everything is 255

One problem with this is that Alpha should always be provided, we could spawn 2 functions, one with alpha always set to 1.0 and another that takes alpha from the Hex Literal provided.

## Testing
Test cases are included in the PR