### PR TITLE
Add additional FixedHasher details in HashSet and HashMap docs

### DIFF
--- a/crates/bevy_platform/src/collections/hash_map.rs
+++ b/crates/bevy_platform/src/collections/hash_map.rs
@@ -40,6 +40,11 @@ pub type Entry<'a, K, V, S = FixedHasher> = hb::Entry<'a, K, V, S>;
 ///
 /// A new-type is used instead of a type alias due to critical methods like [`new`](hb::HashMap::new)
 /// being incompatible with Bevy's choice of default hasher.
+///
+/// Unlike [`hashbrown::HashMap`], [`HashMap`] defaults to [`FixedHasher`]
+/// instead of [`RandomState`].
+/// This provides determinism by default with an acceptable compromise to denial
+/// of service resistance in the context of a game engine.
 #[repr(transparent)]
 pub struct HashMap<K, V, S = FixedHasher>(hb::HashMap<K, V, S>);
 

--- a/crates/bevy_platform/src/collections/hash_set.rs
+++ b/crates/bevy_platform/src/collections/hash_set.rs
@@ -34,6 +34,11 @@ pub type Entry<'a, T, S = FixedHasher> = hb::Entry<'a, T, S>;
 ///
 /// A new-type is used instead of a type alias due to critical methods like [`new`](hb::HashSet::new)
 /// being incompatible with Bevy's choice of default hasher.
+///
+/// Unlike [`hashbrown::HashSet`], [`HashSet`] defaults to [`FixedHasher`]
+/// instead of [`RandomState`](crate::hash::RandomState).
+/// This provides determinism by default with an acceptable compromise to denial
+/// of service resistance in the context of a game engine.
 #[repr(transparent)]
 pub struct HashSet<T, S = FixedHasher>(hb::HashSet<T, S>);
 


### PR DESCRIPTION
# Objective

- Make information about why to use bevy's `HashMap` and `HashSet` types more accessible.

## Solution

- Copy part of the module docs of `hash_set` and `hash_map` into the struct docs as it is where people will be looking for this info.