### PR TITLE
Make `DirectionalLight` `Copy`

### DIFF
--- a/crates/bevy_light/src/directional_light.rs
+++ b/crates/bevy_light/src/directional_light.rs
@@ -55,7 +55,7 @@ use super::{
 /// change the [`CascadeShadowConfig`] component of the entity with the [`DirectionalLight`].
 ///
 /// To control the resolution of the shadow maps, use the [`DirectionalLightShadowMap`] resource.
-#[derive(Component, Debug, Clone, Reflect)]
+#[derive(Component, Debug, Clone, Copy, Reflect)]
 #[reflect(Component, Default, Debug, Clone)]
 #[require(
     Cascades,


### PR DESCRIPTION
# Objective

- `PointLight` and `SpotLight` are both `Copy`, but `DirectionalLight` isn't.

## Solution

- Make it `Copy`. It's also a light, and the struct is comparable in size to the others

## Testing

- CI

## Additional info

Noticed this while implementing a CPU estimate of Bevy's lighting for the visibility calculations in a stealth system