### PR TITLE
Make run_fixed_main_schedule public

### DIFF
--- a/crates/bevy_time/src/fixed.rs
+++ b/crates/bevy_time/src/fixed.rs
@@ -236,7 +236,7 @@ impl Default for Fixed {
 /// [`Time<Virtual>`](Virtual) and [`Time::overstep`].
 /// You can order your systems relative to this by using
 /// [`RunFixedMainLoopSystems`](bevy_app::prelude::RunFixedMainLoopSystems).
-pub(super) fn run_fixed_main_schedule(world: &mut World) {
+pub fn run_fixed_main_schedule(world: &mut World) {
     let delta = world.resource::<Time<Virtual>>().delta();
     world.resource_mut::<Time<Fixed>>().accumulate(delta);
 


### PR DESCRIPTION
Those wanting to customize `TimePlugin` cannot do so because `run_fixed_main_schedule` is not public, so make it public.

## Testing

1. Copy/paste `TimePlugin` to consumer application
2. build now succeeds where previously it failed