### PR TITLE
Support for customized `RenderPlugin` implementations.

### DIFF
--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -290,7 +290,7 @@ pub mod graph {
 }
 
 #[derive(Resource)]
-struct FutureRenderResources(Arc<Mutex<Option<RenderResources>>>);
+pub struct FutureRenderResources(Arc<Mutex<Option<RenderResources>>>);
 
 /// A label for the rendering sub-app.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, AppLabel)]
@@ -450,11 +450,11 @@ impl Plugin for RenderPlugin {
 /// A "scratch" world used to avoid allocating new worlds every frame when
 /// swapping out the [`MainWorld`] for [`ExtractSchedule`].
 #[derive(Resource, Default)]
-struct ScratchMainWorld(World);
+pub struct ScratchMainWorld(World);
 
 /// Executes the [`ExtractSchedule`] step of the renderer.
 /// This updates the render world with the extracted ECS data of the current frame.
-fn extract(main_world: &mut World, render_world: &mut World) {
+pub fn extract(main_world: &mut World, render_world: &mut World) {
     // temporarily add the app world to the render world as a resource
     let scratch_world = main_world.remove_resource::<ScratchMainWorld>().unwrap();
     let inserted_world = core::mem::replace(main_world, scratch_world.0);

--- a/crates/bevy_render/src/render_resource/bind_group_layout.rs
+++ b/crates/bevy_render/src/render_resource/bind_group_layout.rs
@@ -66,7 +66,7 @@ impl Deref for BindGroupLayout {
 
 static EMPTY_BIND_GROUP_LAYOUT: OnceLock<BindGroupLayout> = OnceLock::new();
 
-pub(crate) fn init_empty_bind_group_layout(render_device: Res<RenderDevice>) {
+pub fn init_empty_bind_group_layout(render_device: Res<RenderDevice>) {
     let layout = render_device.create_bind_group_layout(Some("empty_bind_group_layout"), &[]);
     EMPTY_BIND_GROUP_LAYOUT
         .set(layout)

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -720,11 +720,11 @@ impl PipelineCache {
         self.waiting_pipelines.insert(id);
     }
 
-    pub(crate) fn process_pipeline_queue_system(mut cache: ResMut<Self>) {
+    pub fn process_pipeline_queue_system(mut cache: ResMut<Self>) {
         cache.process_queue();
     }
 
-    pub(crate) fn extract_shaders(
+    pub fn extract_shaders(
         mut cache: ResMut<Self>,
         shaders: Extract<Res<Assets<Shader>>>,
         mut events: Extract<MessageReader<AssetEvent<Shader>>>,

--- a/crates/bevy_render/src/sync_world.rs
+++ b/crates/bevy_render/src/sync_world.rs
@@ -211,7 +211,7 @@ pub(crate) struct PendingSyncEntity {
     records: Vec<EntityRecord>,
 }
 
-pub(crate) fn entity_sync_system(main_world: &mut World, render_world: &mut World) {
+pub fn entity_sync_system(main_world: &mut World, render_world: &mut World) {
     main_world.resource_scope(|world, mut pending: Mut<PendingSyncEntity>| {
         // TODO : batching record
         for record in pending.drain(..) {
@@ -253,7 +253,7 @@ pub(crate) fn entity_sync_system(main_world: &mut World, render_world: &mut Worl
     });
 }
 
-pub(crate) fn despawn_temporary_render_entities(
+pub fn despawn_temporary_render_entities(
     world: &mut World,
     state: &mut SystemState<Query<Entity, With<TemporaryRenderEntity>>>,
     mut local: Local<Vec<Entity>>,


### PR DESCRIPTION
# Objective

- Export internalized methods for to allow for custom render worlds by exposing the few remaining internal pieces of `RenderPlugin`.

## Solution

I am building a Monte Carlo simulation engine with Bevy and using ECS for simulation management and the render world to run pipelined compute shaders with render graphs. This exposes a few internal methods so I can build a custom render world that doesn't have camera, mesh, texture, or other plugins for pure headless environments (re: testing, server-side, etc.)

I assumed if I need it to, someone else might later!

## Testing

- Did you test these changes? If so, how?
  - No, they are just identifiers.
- Are there any parts that need more testing?
  - No
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
  - 🤷🏼‍♀️ 
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?
  - I can test on MacOS, but not any others.
