### PR TITLE
BufferSlice cleanup

### DIFF
--- a/crates/bevy_render/src/render_phase/draw_state.rs
+++ b/crates/bevy_render/src/render_phase/draw_state.rs
@@ -25,7 +25,7 @@ struct DrawState {
     pipeline: Option<RenderPipelineId>,
     bind_groups: Vec<(Option<BindGroupId>, Vec<u32>)>,
     /// List of vertex buffers by [`BufferId`], offset, and size. See [`DrawState::buffer_slice_key`]
-    vertex_buffers: Vec<Option<(BufferId, u64, u64)>>,
+    vertex_buffers: Vec<Option<(BufferId, wgpu::BufferAddress, wgpu::BufferSize)>>,
     index_buffer: Option<(BufferId, u64, IndexFormat)>,
 
     /// Stores whether this state is populated or empty for quick state invalidation
@@ -87,7 +87,10 @@ impl DrawState {
     }
 
     /// Returns the value used for checking whether `BufferSlice`s are equivalent.
-    fn buffer_slice_key(&self, buffer_slice: &BufferSlice) -> (BufferId, u64, u64) {
+    fn buffer_slice_key(
+        &self,
+        buffer_slice: &BufferSlice,
+    ) -> (BufferId, wgpu::BufferAddress, wgpu::BufferSize) {
         (
             buffer_slice.id(),
             buffer_slice.offset(),

--- a/crates/bevy_render/src/render_resource/buffer.rs
+++ b/crates/bevy_render/src/render_resource/buffer.rs
@@ -58,16 +58,6 @@ impl<'a> BufferSlice<'a> {
     pub fn id(&self) -> BufferId {
         self.id
     }
-
-    #[inline]
-    pub fn offset(&self) -> wgpu::BufferAddress {
-        self.value.offset()
-    }
-
-    #[inline]
-    pub fn size(&self) -> wgpu::BufferSize {
-        self.value.size()
-    }
 }
 
 impl<'a> Deref for BufferSlice<'a> {

--- a/crates/bevy_render/src/render_resource/buffer.rs
+++ b/crates/bevy_render/src/render_resource/buffer.rs
@@ -1,6 +1,6 @@
 use crate::define_atomic_id;
 use crate::renderer::WgpuWrapper;
-use core::ops::{Bound, Deref, RangeBounds};
+use core::ops::{Deref, RangeBounds};
 
 define_atomic_id!(BufferId);
 
@@ -17,21 +17,8 @@ impl Buffer {
     }
 
     pub fn slice(&self, bounds: impl RangeBounds<wgpu::BufferAddress>) -> BufferSlice<'_> {
-        // need to compute and store this manually because wgpu doesn't export offset and size on wgpu::BufferSlice
-        let offset = match bounds.start_bound() {
-            Bound::Included(&bound) => bound,
-            Bound::Excluded(&bound) => bound + 1,
-            Bound::Unbounded => 0,
-        };
-        let size = match bounds.end_bound() {
-            Bound::Included(&bound) => bound + 1,
-            Bound::Excluded(&bound) => bound,
-            Bound::Unbounded => self.value.size(),
-        } - offset;
         BufferSlice {
             id: self.id,
-            offset,
-            size,
             value: self.value.slice(bounds),
         }
     }
@@ -63,9 +50,7 @@ impl Deref for Buffer {
 #[derive(Clone, Debug)]
 pub struct BufferSlice<'a> {
     id: BufferId,
-    offset: wgpu::BufferAddress,
     value: wgpu::BufferSlice<'a>,
-    size: wgpu::BufferAddress,
 }
 
 impl<'a> BufferSlice<'a> {
@@ -76,12 +61,12 @@ impl<'a> BufferSlice<'a> {
 
     #[inline]
     pub fn offset(&self) -> wgpu::BufferAddress {
-        self.offset
+        self.value.offset()
     }
 
     #[inline]
-    pub fn size(&self) -> wgpu::BufferAddress {
-        self.size
+    pub fn size(&self) -> wgpu::BufferSize {
+        self.value.size()
     }
 }
 


### PR DESCRIPTION
# Objective

- Cleanup code by utilizing `wgpu::BufferSlice::offset`/`size` (added in wpgu 25).

This is technically a breaking change. `bevy::BufferSlice::offset`/`size` no longer exists, and `.size()` now returns `wgpu::BufferSize = NonZeroU64` instead of `wgpu::BufferAddress = u64`.

Originally in PR https://github.com/bevyengine/bevy/pull/20468. I thought this is conflated and should be separated
