### PR TITLE
Add cautionary docs to light textures

### DIFF
--- a/crates/bevy_light/src/directional_light.rs
+++ b/crates/bevy_light/src/directional_light.rs
@@ -158,8 +158,10 @@ impl DirectionalLight {
 }
 
 /// Add to a [`DirectionalLight`] to add a light texture effect.
-/// A texture mask is applied to the light source to modulate its intensity,  
+/// A texture mask is applied to the light source to modulate its intensity,
 /// simulating patterns like window shadows, gobo/cookie effects, or soft falloffs.
+///
+/// Light textures require bindless textures. This means that they presently can’t be used on WebGL 2, WebGPU, macOS, or iOS.
 #[derive(Clone, Component, Debug, Reflect)]
 #[reflect(Component, Debug)]
 #[require(DirectionalLight)]

--- a/crates/bevy_light/src/point_light.rs
+++ b/crates/bevy_light/src/point_light.rs
@@ -150,8 +150,10 @@ impl PointLight {
 }
 
 /// Add to a [`PointLight`] to add a light texture effect.
-/// A texture mask is applied to the light source to modulate its intensity,  
+/// A texture mask is applied to the light source to modulate its intensity,
 /// simulating patterns like window shadows, gobo/cookie effects, or soft falloffs.
+///
+/// Light textures require bindless textures. This means that they presently can’t be used on WebGL 2, WebGPU, macOS, or iOS.
 #[derive(Clone, Component, Debug, Reflect)]
 #[reflect(Component, Debug)]
 #[require(PointLight)]

--- a/crates/bevy_light/src/spot_light.rs
+++ b/crates/bevy_light/src/spot_light.rs
@@ -190,8 +190,10 @@ pub fn spot_light_clip_from_view(angle: f32, near_z: f32) -> Mat4 {
 }
 
 /// Add to a [`SpotLight`] to add a light texture effect.
-/// A texture mask is applied to the light source to modulate its intensity,  
+/// A texture mask is applied to the light source to modulate its intensity,
 /// simulating patterns like window shadows, gobo/cookie effects, or soft falloffs.
+///
+/// Light textures require bindless textures. This means that they presently can’t be used on WebGL 2, WebGPU, macOS, or iOS.
 #[derive(Clone, Component, Debug, Reflect)]
 #[reflect(Component, Debug)]
 #[require(SpotLight)]


### PR DESCRIPTION
Suggested originally by @ChristopherBiscardi, confirmed by @robtfm
Since most of Bevy's features at least work on all native platforms and usually also WebGPU, I think we should be very explicit that this feature doesn't follow suit.

These limitations are inherited from clustered decals, but there it's not that big of a deal since users can just pick forward decals for platform compatibility. For light textures, there's not really an alternative API right now.
