### PR TITLE
Register unit type alongside the other primitives

### DIFF
--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -100,6 +100,7 @@ impl TypeRegistry {
     /// Create a type registry with default registrations for primitive types.
     pub fn new() -> Self {
         let mut registry = Self::empty();
+        registry.register::<()>();
         registry.register::<bool>();
         registry.register::<char>();
         registry.register::<u8>();


### PR DESCRIPTION
# Objective

Primitive types are automatically registered when a `TypeRegistry` is created, except for unit type `()`.

## Solution

Register `()` alongside other primitives.

## Testing

Run tests in `bevy_reflect`, tested with my code that `()` is being registered.