### PR TITLE
Virtual geometry: Upgrade deps, allow 256 vertices

### DIFF
--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -65,9 +65,9 @@ derive_more = { version = "2", default-features = false, features = ["from"] }
 lz4_flex = { version = "0.11", default-features = false, features = [
   "frame",
 ], optional = true }
-range-alloc = { version = "0.1.3", optional = true }
-meshopt = { version = "0.4.1", optional = true }
-metis = { version = "0.2", optional = true }
+range-alloc = { version = "0.1", optional = true }
+meshopt = { version = "0.6.1", optional = true }
+metis = { version = "0.2.2", optional = true }
 itertools = { version = "0.14", optional = true }
 bitvec = { version = "1", optional = true }
 # direct dependency required for derive macro

--- a/crates/bevy_pbr/src/meshlet/asset.rs
+++ b/crates/bevy_pbr/src/meshlet/asset.rs
@@ -17,7 +17,7 @@ use thiserror::Error;
 const MESHLET_MESH_ASSET_MAGIC: u64 = 1717551717668;
 
 /// The current version of the [`MeshletMesh`] asset format.
-pub const MESHLET_MESH_ASSET_VERSION: u64 = 2;
+pub const MESHLET_MESH_ASSET_VERSION: u64 = 3;
 
 /// A mesh that has been pre-processed into multiple small clusters of triangles called meshlets.
 ///
@@ -86,8 +86,8 @@ pub struct Meshlet {
     pub start_vertex_attribute_id: u32,
     /// The offset within the parent mesh's [`MeshletMesh::indices`] buffer where the indices for this meshlet begin.
     pub start_index_id: u32,
-    /// The amount of vertices in this meshlet.
-    pub vertex_count: u8,
+    /// The amount of vertices in this meshlet (minus one to fit 256 in a u8).
+    pub vertex_count_minus_one: u8,
     /// The amount of triangles in this meshlet.
     pub triangle_count: u8,
     /// Unused.

--- a/crates/bevy_pbr/src/meshlet/from_mesh.rs
+++ b/crates/bevy_pbr/src/meshlet/from_mesh.rs
@@ -383,7 +383,7 @@ fn compute_meshlets(
         )
     };
     for meshlet_indices in &indices_per_meshlet {
-        let meshlet = build_meshlets(meshlet_indices, vertices, 255, 128, 0.0);
+        let meshlet = build_meshlets(meshlet_indices, vertices, 256, 128, 0.0);
         for meshlet in meshlet.iter() {
             let (lod_group_sphere, error) = prev_lod_data.unwrap_or_else(|| {
                 let bounds = meshopt::compute_meshlet_bounds(meshlet, vertices);
@@ -617,7 +617,7 @@ fn build_and_compress_per_meshlet_vertex_data(
     let mut max_quantized_position_channels = IVec3::MIN;
 
     // Lossy vertex compression
-    let mut quantized_positions = [IVec3::ZERO; 255];
+    let mut quantized_positions = [IVec3::ZERO; 256];
     for (i, vertex_id) in meshlet_vertex_ids.iter().enumerate() {
         // Load source vertex attributes
         let vertex_id_byte = *vertex_id as usize * vertex_stride;
@@ -668,7 +668,7 @@ fn build_and_compress_per_meshlet_vertex_data(
         start_vertex_position_bit,
         start_vertex_attribute_id,
         start_index_id: meshlet.triangle_offset,
-        vertex_count: meshlet.vertex_count as u8,
+        vertex_count_minus_one: (meshlet.vertex_count - 1) as u8,
         triangle_count: meshlet.triangle_count as u8,
         padding: 0,
         bits_per_vertex_position_channel_x,

--- a/crates/bevy_pbr/src/meshlet/meshlet_bindings.wgsl
+++ b/crates/bevy_pbr/src/meshlet/meshlet_bindings.wgsl
@@ -24,7 +24,7 @@ struct Meshlet {
 }
 
 fn get_meshlet_vertex_count(meshlet: ptr<function, Meshlet>) -> u32 {
-    return extractBits((*meshlet).packed_a, 0u, 8u);
+    return extractBits((*meshlet).packed_a, 0u, 8u) + 1u;
 }
 
 fn get_meshlet_triangle_count(meshlet: ptr<function, Meshlet>) -> u32 {

--- a/crates/bevy_pbr/src/meshlet/visibility_buffer_software_raster.wgsl
+++ b/crates/bevy_pbr/src/meshlet/visibility_buffer_software_raster.wgsl
@@ -23,7 +23,7 @@
 
 // TODO: Fixed-point math and top-left rule
 
-var<workgroup> viewport_vertices: array<vec3f, 255>;
+var<workgroup> viewport_vertices: array<vec3f, 256>;
 
 @compute
 @workgroup_size(128, 1, 1) // 128 threads per workgroup, 1-2 vertices per thread, 1 triangle per thread, 1 cluster per workgroup


### PR DESCRIPTION
Some small work on virtual geometry.

Some other improvements we should do in the future for the builder code:

* meshopt_computeSphereBounds instead of merge_spheres
* Use meshopt_generatePositionRemap instead of generate_vertex_remap_multi (https://github.com/gwihlidal/meshopt-rs/issues/70)
* Permissive simplification
* Faster vertex locking, copying https://github.com/zeux/meshoptimizer/pull/961