### PR TITLE
`font_count` method

### DIFF
--- a/crates/bevy_text/src/font_atlas_set.rs
+++ b/crates/bevy_text/src/font_atlas_set.rs
@@ -21,10 +21,18 @@ impl FontAtlasSets {
         let id: AssetId<Font> = id.into();
         self.sets.get(&id)
     }
+
     /// Get a mutable reference to the [`FontAtlasSet`] with the given font asset id.
     pub fn get_mut(&mut self, id: impl Into<AssetId<Font>>) -> Option<&mut FontAtlasSet> {
         let id: AssetId<Font> = id.into();
         self.sets.get_mut(&id)
+    }
+
+    /// Returns the total number of fonts in all sets
+    pub fn font_count(&self) -> usize {
+        self.sets
+            .iter()
+            .fold(0, |count, (_, set)| count + set.len())
     }
 }
 

--- a/crates/bevy_text/src/font_atlas_set.rs
+++ b/crates/bevy_text/src/font_atlas_set.rs
@@ -28,7 +28,7 @@ impl FontAtlasSets {
         self.sets.get_mut(&id)
     }
 
-    /// Returns the total number of fonts in all sets
+    /// Returns the total number of rasterized fonts across all sets.
     pub fn font_count(&self) -> usize {
         self.sets
             .iter()

--- a/crates/bevy_text/src/font_atlas_set.rs
+++ b/crates/bevy_text/src/font_atlas_set.rs
@@ -30,9 +30,7 @@ impl FontAtlasSets {
 
     /// Returns the total number of rasterized fonts across all sets.
     pub fn font_count(&self) -> usize {
-        self.sets
-            .iter()
-            .fold(0, |count, (_, set)| count + set.len())
+        self.sets.values().map(FontAtlasSet::len).sum()
     }
 }
 


### PR DESCRIPTION
# Objective

Splitting off some trivial changes from the text rework.

This adds a method that counts the number of rasterized fonts stored in `FontAtlasSets`.

# Solution

Return the sum of the lengths of all the sets.