### PR TITLE
Add Ease trait to Transform

### DIFF
--- a/crates/bevy_math/src/curve/easing.rs
+++ b/crates/bevy_math/src/curve/easing.rs
@@ -74,6 +74,9 @@ use crate::{
 #[cfg(feature = "bevy_reflect")]
 use bevy_reflect::std_traits::ReflectDefault;
 
+#[cfg(feature = "bevy_transform")]
+use bevy_transform::components::Transform;
+
 use variadics_please::all_tuples_enumerated;
 
 // TODO: Think about merging `Ease` with `StableInterpolate`
@@ -172,6 +175,14 @@ impl Ease for Isometry2d {
                 )
                 .sample_unchecked(t),
             }
+        })
+    }
+}
+
+impl Ease for Transform {
+    fn interpolating_curve_unbounded(start: Self, end: Self) -> impl Curve<Self> {
+        FunctionCurve::new(Interval::EVERYWHERE, move |t| {
+            Transform::interpolate(&start, &end, t)
         })
     }
 }

--- a/crates/bevy_transform/Cargo.toml
+++ b/crates/bevy_transform/Cargo.toml
@@ -15,6 +15,7 @@ bevy_ecs = { path = "../bevy_ecs", version = "0.18.0-dev", default-features = fa
 bevy_log = { path = "../bevy_log", version = "0.18.0-dev", default-features = false, optional = true }
 bevy_math = { path = "../bevy_math", version = "0.18.0-dev", default-features = false }
 bevy_reflect = { path = "../bevy_reflect", version = "0.18.0-dev", default-features = false, optional = true }
+bevy_transform = { path = "../bevy_transform", version = "0.18.0-dev", default-features = false, optional = true }
 bevy_tasks = { path = "../bevy_tasks", version = "0.18.0-dev", default-features = false }
 bevy_utils = { path = "../bevy_utils", version = "0.18.0-dev", default-features = false, optional = true }
 serde = { version = "1", default-features = false, features = [


### PR DESCRIPTION
# Objective

Fixes #21316

## Solution

Adds a new optional dependency on `bevy_transform` to `bevy_math` to use `Transform::interpolate` with easing

## Testing

I did not test these changes

---
