### PR TITLE
bevy_render: improve panic message when render graph node doesn't exist

### DIFF
--- a/crates/bevy_render/src/render_graph/app.rs
+++ b/crates/bevy_render/src/render_graph/app.rs
@@ -53,6 +53,7 @@ impl RenderGraphExt for World {
         self
     }
 
+    #[track_caller]
     fn add_render_graph_edges<const N: usize>(
         &mut self,
         sub_graph: impl RenderSubGraph,
@@ -121,6 +122,7 @@ impl RenderGraphExt for SubApp {
         self
     }
 
+    #[track_caller]
     fn add_render_graph_edges<const N: usize>(
         &mut self,
         sub_graph: impl RenderSubGraph,

--- a/crates/bevy_render/src/render_graph/graph.rs
+++ b/crates/bevy_render/src/render_graph/graph.rs
@@ -145,6 +145,7 @@ impl RenderGraph {
     ///
     /// Defining an edge that already exists is not considered an error with this api.
     /// It simply won't create a new edge.
+    #[track_caller]
     pub fn add_node_edges<const N: usize>(&mut self, edges: impl IntoRenderNodeArray<N>) {
         for window in edges.into_array().windows(2) {
             let [a, b] = window else {
@@ -155,7 +156,7 @@ impl RenderGraph {
                     // Already existing edges are very easy to produce with this api
                     // and shouldn't cause a panic
                     RenderGraphError::EdgeAlreadyExists(_) => {}
-                    _ => panic!("{err:?}"),
+                    _ => panic!("{err}"),
                 }
             }
         }


### PR DESCRIPTION
# Objective

It should be possible to enable minimal bevy features by disabling all and then progressively enabling them until everything works.
This however requires, that bevy has good error reporting and gracefully supports different featuresets.

I ran my code with minimal features and got this unhelpful error:
```
thread 'main' (993068) panicked at /home/jakob/dev/rust/bevy/crates/bevy_render/src/render_graph/graph.rs:158:26:
InvalidNode(PostProcessing)
```

## Solution

With this PR it looks like this:
```
thread 'main' (989393) panicked at /home/jakob/dev/rust/bevy/crates/bevy_pbr/src/wireframe.rs:136:14:
node PostProcessing does not exist
```

Which immediately helps me figure out that I need some feature for the `WireframePlugin` I added.
