### PR TITLE
Update cargo-binstall action to 1.15.6, for real this time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ env:
   # If nightly is breaking CI, modify this variable to target a specific nightly version.
   NIGHTLY_TOOLCHAIN: nightly
   RUSTFLAGS: "-D warnings"
-  BINSTALL_VERSION: "v1.14.1"
+  BINSTALL_VERSION: "v1.15.6"
 
 concurrency:
   group: ${{github.workflow}}-${{github.ref}}
@@ -318,7 +318,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       # Update in sync with BINSTALL_VERSION
-      - uses: cargo-bins/cargo-binstall@v1.15.4
+      - uses: cargo-bins/cargo-binstall@v1.15.6
       - name: Install taplo
         run: cargo binstall taplo-cli@0.9.3 --locked
       - name: Run Taplo


### PR DESCRIPTION
Like the many @dependabot PRs that have updated the cargo-binstall version - except this one *actually* updates the version, because the `BINSTALL_VERSION` environment variable is what actually determines the version, rather than the version attached to the action.

To be honest, I really think we should just use `cargo-bins/cargo-binstall@main`. Yeah, we don't get to review updates as they come in, but if we're forgetting to update the environment variable despite there being a note right above this line, I don't think it's worth pinning to a specific version.