### PR TITLE
Update `cargo-binstall` to v1.15.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,7 +318,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       # Update in sync with BINSTALL_VERSION
-      - uses: cargo-bins/cargo-binstall@v1.15.4
+      - uses: cargo-bins/cargo-binstall@v1.15.6
       - name: Install taplo
         run: cargo binstall taplo-cli@0.9.3 --locked
       - name: Run Taplo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ env:
   # If nightly is breaking CI, modify this variable to target a specific nightly version.
   NIGHTLY_TOOLCHAIN: nightly
   RUSTFLAGS: "-D warnings"
-  BINSTALL_VERSION: "v1.14.1"
+  BINSTALL_VERSION: "v1.15.6"
 
 concurrency:
   group: ${{github.workflow}}-${{github.ref}}


### PR DESCRIPTION
# Objective

- Adopted from #21271.
- `cargo-binstall` in CI is outdated, let's update!

## Solution

- Update to v1.15.6 from v1.14.1.

## Testing

- As it's run in CI, the best way to test is to run CI! :)

## Notable Changes

- [v1.14.2](https://github.com/cargo-bins/cargo-binstall/releases/tag/v1.14.2) - Dependency updates
- [v1.14.3](https://github.com/cargo-bins/cargo-binstall/releases/tag/v1.14.3) - Fixes race condition
- [v1.14.4](https://github.com/cargo-bins/cargo-binstall/releases/tag/v1.14.4) - Switch from `fs4` to `std` for file locking
- [v1.15.0](https://github.com/cargo-bins/cargo-binstall/releases/tag/v1.15.0) - Prompt when using Quickinstall. ~~This may cause some issues in CI, I need to investigate it further.~~
- [v1.15.1](https://github.com/cargo-bins/cargo-binstall/releases/tag/v1.15.1) - Fix issues with manifest file and Quickinstall prompt
- [v1.15.2](https://github.com/cargo-bins/cargo-binstall/releases/tag/v1.15.2) - Fix updating telemetry config file
- [v1.15.3](https://github.com/cargo-bins/cargo-binstall/releases/tag/v1.15.3) - Stop building for x86 MacOS
- [v1.15.4](https://github.com/cargo-bins/cargo-binstall/releases/tag/v1.15.4) - Docs and dependencies
- [v1.15.5](https://github.com/cargo-bins/cargo-binstall/releases/tag/v1.15.5) - Support Socks5 proxy
- [v1.15.6](https://github.com/cargo-bins/cargo-binstall/releases/tag/v1.15.6) - Update dependencies