### PR TITLE
Use slider precision to format feathers slider label

### DIFF
--- a/crates/bevy_feathers/src/controls/slider.rs
+++ b/crates/bevy_feathers/src/controls/slider.rs
@@ -226,7 +226,6 @@ fn update_slider_pos(
             if let Ok(mut text) = q_slider_text.get_mut(child) {
                 let label = format!("{}", value.0);
                 let decimals_len = label
-                    .as_str()
                     .split_once('.')
                     .map(|(_, decimals)| decimals.len() as i32)
                     .unwrap_or(precision.0);

--- a/crates/bevy_feathers/src/controls/slider.rs
+++ b/crates/bevy_feathers/src/controls/slider.rs
@@ -224,10 +224,18 @@ fn update_slider_pos(
         // Find slider text child entity and update its text with the formatted value
         q_children.iter_descendants(slider_ent).for_each(|child| {
             if let Ok(mut text) = q_slider_text.get_mut(child) {
-                text.0 = if precision.0 >= 0 {
+                let label = format!("{}", value.0);
+                let decimals_len = label
+                    .as_str()
+                    .split_once('.')
+                    .map(|(_, decimals)| decimals.len() as i32)
+                    .unwrap_or(precision.0);
+
+                // Don't format with precision if the value has more decimals than the precision
+                text.0 = if precision.0 >= 0 && decimals_len <= precision.0 {
                     format!("{:.precision$}", value.0, precision = precision.0 as usize)
                 } else {
-                    format!("{}", value.0)
+                    label
                 };
             }
         });


### PR DESCRIPTION
# Objective

The slider label doesn't format consistently. For example, for precision `2` it might jump between: `20`, `20.01`, `20.02` ... `20.1`, `20.11`… which is noisy and ugly.

## Solution

Format the label using the precision.

## Testing

Checked the feathers example with `2`, `0` and `-1` precision.

## Showcase

https://github.com/user-attachments/assets/9f30200a-a832-43df-937a-123c8d3168cf
