### PR TITLE
update taplo to 0.10.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ env:
   # If nightly is breaking CI, modify this variable to target a specific nightly version.
   NIGHTLY_TOOLCHAIN: nightly
   RUSTFLAGS: "-D warnings"
-  BINSTALL_VERSION: "v1.15.6"
 
 concurrency:
   group: ${{github.workflow}}-${{github.ref}}
@@ -317,10 +316,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
-      # Update in sync with BINSTALL_VERSION
-      - uses: cargo-bins/cargo-binstall@v1.15.6
       - name: Install taplo
-        run: cargo binstall taplo-cli@0.9.3 --locked
+        run: curl -fsSL https://github.com/tamasfe/taplo/releases/download/0.10.0/taplo-linux-x86_64.gz | gzip -d - | install -m 755 /dev/stdin /usr/local/bin/taplo
       - name: Run Taplo
         id: taplo
         run: taplo fmt --check --diff


### PR DESCRIPTION
# Objective

- Taplo 0.10.0 is out since may, let's update!

## Solution

- Stop using cargo-binstall. it's a pain to maintain and break updates for the tools it installs anyway
<img width="827" height="749" alt="Screenshot 2025-10-01 at 21 54 58" src="https://github.com/user-attachments/assets/f86ba2e9-767f-4a0d-b87c-9222d2b804ff" />

- All that just for the tool installing the tool
- Do the curl as recommended in taplo docs

## Testing

- CI
