### PR TITLE
clustered decals docs: macOS and iOS are no longer restricted

### DIFF
--- a/crates/bevy_pbr/src/decal/clustered.rs
+++ b/crates/bevy_pbr/src/decal/clustered.rs
@@ -6,7 +6,7 @@
 //!
 //! Clustered decals are the highest-quality types of decals that Bevy supports,
 //! but they require bindless textures. This means that they presently can't be
-//! used on WebGL 2, WebGPU, macOS, or iOS. Bevy's clustered decals can be used
+//! used on WebGL 2 or WebGPU. Bevy's clustered decals can be used
 //! with forward or deferred rendering and don't require a prepass.
 //!
 //! On their own, clustered decals only project the base color of a texture. You


### PR DESCRIPTION
# Objective

https://github.com/bevyengine/bevy/pull/21297 removed the restriction that prevented macos/ios from using clustered decals

## Solution

Remove them from the list of "unsupported" targets.