### PR TITLE
Avoid a "RefCell already borrowed" error with WINIT_WINDOWS

### DIFF
--- a/crates/bevy_winit/src/state.rs
+++ b/crates/bevy_winit/src/state.rs
@@ -466,7 +466,7 @@ impl<M: Message> ApplicationHandler<M> for WinitAppRunnerState<M> {
         // invisible window creation. https://github.com/bevyengine/bevy/issues/18027
         #[cfg(target_os = "windows")]
         {
-            WINIT_WINDOWS.with_borrow(|winit_windows| {
+            if WINIT_WINDOWS.with_borrow(|winit_windows| {
                 let headless = winit_windows.windows.is_empty();
                 let exiting = self.app_exit.is_some();
                 let reactive = matches!(self.update_mode, UpdateMode::Reactive { .. });
@@ -474,16 +474,15 @@ impl<M: Message> ApplicationHandler<M> for WinitAppRunnerState<M> {
                     .windows
                     .iter()
                     .all(|(_, w)| !w.is_visible().unwrap_or(false));
-                if !exiting
+                !exiting
                     && (self.startup_forced_updates > 0
                         || headless
                         || all_invisible
                         || reactive
                         || self.window_event_received)
-                {
-                    self.redraw_requested(event_loop);
-                }
-            });
+            }) {
+                self.redraw_requested(event_loop);
+            }
         }
     }
 
@@ -1023,10 +1022,10 @@ mod tests {
         app.add_systems(
             Update,
             move |mut window: Single<(Entity, &mut Window)>,
-             mut window_backend_scale_factor_changed: MessageWriter<
-                WindowBackendScaleFactorChanged,
-            >,
-             mut window_scale_factor_changed: MessageWriter<WindowScaleFactorChanged>| {
+                  mut window_backend_scale_factor_changed: MessageWriter<
+                      WindowBackendScaleFactorChanged,
+                  >,
+                  mut window_scale_factor_changed: MessageWriter<WindowScaleFactorChanged>| {
                 react_to_scale_factor_change(
                     window.0,
                     &mut window.1,


### PR DESCRIPTION
# Objective

Fixes #21319.

## Solution

In the "about_to_wait" state of Bevy's winit event loop, we borrow WINIT_WINDOWS only to check the conditions for a redraw, and perform the call after that check is concluded.

## Testing

Tested by confirming that the RefCell error no longer occurs in my application.  In my application, the error occurred when the `bevy-egui-inspector` crate was used.

I do not know whether the original reporter of #21319 was also using third-party Bevy plugins that might have caused the issue.  It would be good if they could check whether this change fixes it for them.

Tested on Windows 11, where the bug is known to occur.  The code that was changed is only included in Windows builds so there is little need to test on other platforms.
