### PR TITLE
`TextPipeline::queue_text` refactor

### DIFF
--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -244,6 +244,7 @@ impl TextPipeline {
         computed.needs_rerender = false;
 
         // Extract font ids from the iterator while traversing it.
+
         let mut glyph_info = core::mem::take(&mut self.glyph_info);
         glyph_info.clear();
         let text_spans = text_spans.inspect(|(_, _, _, text_font, _)| {
@@ -260,10 +261,10 @@ impl TextPipeline {
             computed,
             font_system,
         );
-        if let Err(err) = update_result {
-            self.glyph_info = glyph_info;
-            return Err(err);
-        }
+
+        self.glyph_info = glyph_info;
+
+        update_result?;
 
         let buffer = &mut computed.buffer;
         let box_size = buffer_dimensions(buffer);
@@ -303,8 +304,8 @@ impl TextPipeline {
 
                     let mut temp_glyph;
                     let span_index = layout_glyph.metadata;
-                    let font_id = glyph_info[span_index].0;
-                    let font_smoothing = glyph_info[span_index].1;
+                    let font_id = self.glyph_info[span_index].0;
+                    let font_smoothing = self.glyph_info[span_index].1;
 
                     let layout_glyph = if font_smoothing == FontSmoothing::None {
                         // If font smoothing is disabled, round the glyph positions and sizes,
@@ -375,9 +376,6 @@ impl TextPipeline {
 
             result
         });
-
-        // Return the scratch vec.
-        self.glyph_info = glyph_info;
 
         // Check result.
         result?;

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -244,7 +244,6 @@ impl TextPipeline {
         computed.needs_rerender = false;
 
         // Extract font ids from the iterator while traversing it.
-
         let mut glyph_info = core::mem::take(&mut self.glyph_info);
         glyph_info.clear();
         let text_spans = text_spans.inspect(|(_, _, _, text_font, _)| {


### PR DESCRIPTION
# Objective

 `TextPipeline::queue_text` temporarily `take`s the buffer from its `glyph_info` field, so that it can be used in a call to `TextPipeline::update_buffer`. It then replaces it when the function exits. This is a bit fragile, as the function has two exit points.

## Solution

Replace it immediately after calling `update_buffer`, and then access it with `self` for the rest of the function.
