### PR TITLE
Implement `Reflect` for `CameraOutputMode`

### DIFF
--- a/crates/bevy_camera/Cargo.toml
+++ b/crates/bevy_camera/Cargo.toml
@@ -15,7 +15,9 @@ bevy_asset = { path = "../bevy_asset", version = "0.18.0-dev" }
 bevy_image = { path = "../bevy_image", version = "0.18.0-dev" }
 bevy_mesh = { path = "../bevy_mesh", version = "0.18.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.18.0-dev" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.18.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.18.0-dev", features = [
+  "wgpu-types",
+] }
 bevy_ecs = { path = "../bevy_ecs", version = "0.18.0-dev" }
 bevy_transform = { path = "../bevy_transform", version = "0.18.0-dev" }
 bevy_derive = { path = "../bevy_derive", version = "0.18.0-dev" }

--- a/crates/bevy_camera/src/camera.rs
+++ b/crates/bevy_camera/src/camera.rs
@@ -362,9 +362,7 @@ pub struct Camera {
     pub computed: ComputedCameraValues,
     /// The "target" that this camera will render to.
     pub target: RenderTarget,
-    // todo: reflect this when #6042 lands
     /// The [`CameraOutputMode`] for this camera.
-    #[reflect(ignore, clone)]
     pub output_mode: CameraOutputMode,
     /// If this is enabled, a previous camera exists that shares this camera's render target, and this camera has MSAA enabled, then the previous camera's
     /// outputs will be written to the intermediate multi-sampled render target textures for this camera. This enables cameras with MSAA enabled to
@@ -777,7 +775,7 @@ impl Camera {
 }
 
 /// Control how this [`Camera`] outputs once rendering is completed.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Reflect)]
 pub enum CameraOutputMode {
     /// Writes the camera output to configured render target.
     Write {

--- a/crates/bevy_reflect/src/impls/wgpu_types.rs
+++ b/crates/bevy_reflect/src/impls/wgpu_types.rs
@@ -8,3 +8,11 @@ impl_reflect_opaque!(::wgpu_types::TextureFormat(
     Deserialize,
     Serialize,
 ));
+impl_reflect_opaque!(::wgpu_types::BlendState(
+    Clone,
+    Debug,
+    Hash,
+    PartialEq,
+    Deserialize,
+    Serialize,
+));


### PR DESCRIPTION
# Objective

`CameraOutputMode` doesn't Implement `Reflect` and is ignored in `Camera`.

## Solution

Like #15355, this Implements opaque `Reflect` for `wgpu::BlendState` thus we can add `#derive(Reflect)` for `CameraOutputMode`.

As the commnent says, it can also implement `Reflect` througth `reflect_remote` (#6042),  but I'm not sure if we should do this for wgpu types.

## Testing

ci