### PR TITLE
Solari: Fix world cache update using last frame's light tiles due to incorrect pass ordering

### DIFF
--- a/crates/bevy_solari/src/realtime/node.rs
+++ b/crates/bevy_solari/src/realtime/node.rs
@@ -238,6 +238,13 @@ impl ViewNode for SolariLightingNode {
             pass.dispatch_workgroups(dx, dy, 1);
         }
 
+        pass.set_pipeline(presample_light_tiles_pipeline);
+        pass.set_push_constants(
+            0,
+            bytemuck::cast_slice(&[frame_index, solari_lighting.reset as u32]),
+        );
+        pass.dispatch_workgroups(LIGHT_TILE_BLOCKS as u32, 1, 1);
+
         pass.set_bind_group(2, &bind_group_world_cache_active_cells_dispatch, &[]);
 
         pass.set_pipeline(decay_world_cache_pipeline);
@@ -269,13 +276,6 @@ impl ViewNode for SolariLightingNode {
             &solari_lighting_resources.world_cache_active_cells_dispatch,
             0,
         );
-
-        pass.set_pipeline(presample_light_tiles_pipeline);
-        pass.set_push_constants(
-            0,
-            bytemuck::cast_slice(&[frame_index, solari_lighting.reset as u32]),
-        );
-        pass.dispatch_workgroups(LIGHT_TILE_BLOCKS as u32, 1, 1);
 
         pass.set_pipeline(di_initial_and_temporal_pipeline);
         pass.set_push_constants(


### PR DESCRIPTION
Light tiles used to be generated _after_ the world cache update, despite the world cache update relying on them. This means that the world cache update used last frame's light tiles, which is fine for static lights, but completely wrong for dynamic lights and lead to missing GI contributions from dynamic lights.

Moving the presample light tile step to before the world cache update fixes this.

Can be tested by running the solari example, turning off the directional light so there's only the emissive robot light, enabling VISUALIZE_WORLD_CACHE, and then comparing before/after this PR.