### PR TITLE
Aabb gizmo api

### DIFF
--- a/crates/bevy_gizmos/src/aabb.rs
+++ b/crates/bevy_gizmos/src/aabb.rs
@@ -12,10 +12,7 @@ use bevy_ecs::{
     system::{Query, Res},
 };
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
-use bevy_transform::{
-    components::{GlobalTransform, Transform},
-    TransformSystems,
-};
+use bevy_transform::{components::GlobalTransform, TransformSystems};
 
 use crate::{
     config::{GizmoConfigGroup, GizmoConfigStore},
@@ -78,7 +75,7 @@ fn draw_aabbs(
             .color
             .or(gizmos.config_ext.default_color)
             .unwrap_or_else(|| color_from_entity(entity));
-        gizmos.cuboid(aabb_transform(aabb, transform), color);
+        gizmos.cuboid(aabb, transform, color);
     }
 }
 
@@ -91,18 +88,10 @@ fn draw_all_aabbs(
             .config_ext
             .default_color
             .unwrap_or_else(|| color_from_entity(entity));
-        gizmos.cuboid(aabb_transform(aabb, transform), color);
+        gizmos.cuboid(aabb, transform, color);
     }
 }
 
 fn color_from_entity(entity: Entity) -> Color {
     Oklcha::sequential_dispersed(entity.index()).into()
-}
-
-fn aabb_transform(aabb: Aabb, transform: GlobalTransform) -> GlobalTransform {
-    transform
-        * GlobalTransform::from(
-            Transform::from_translation(aabb.center.into())
-                .with_scale((aabb.half_extents * 2.).into()),
-        )
 }

--- a/crates/bevy_gizmos/src/gizmos.rs
+++ b/crates/bevy_gizmos/src/gizmos.rs
@@ -18,7 +18,7 @@ use bevy_ecs::{
     },
     world::{unsafe_world_cell::UnsafeWorldCell, World},
 };
-use bevy_math::{Isometry2d, Isometry3d, Vec2, Vec3};
+use bevy_math::{bounding::Aabb3d, Isometry2d, Isometry3d, Vec2, Vec3};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_transform::TransformPoint;
 use bevy_utils::default;
@@ -588,12 +588,12 @@ where
     /// # use bevy_transform::prelude::*;
     /// # use bevy_color::palettes::basic::GREEN;
     /// fn system(mut gizmos: Gizmos) {
-    ///     gizmos.cuboid(Transform::IDENTITY, GREEN);
+    ///     gizmos.cube(Transform::IDENTITY, GREEN);
     /// }
     /// # bevy_ecs::system::assert_is_system(system);
     /// ```
     #[inline]
-    pub fn cuboid(&mut self, transform: impl TransformPoint, color: impl Into<Color>) {
+    pub fn cube(&mut self, transform: impl TransformPoint, color: impl Into<Color>) {
         let polymorphic_color: Color = color.into();
         if !self.enabled {
             return;
@@ -603,6 +603,58 @@ where
         let [tlf, trf, brf, blf] = rect.map(|vec2| transform.transform_point(vec2.extend(0.5)));
         // Back
         let [tlb, trb, brb, blb] = rect.map(|vec2| transform.transform_point(vec2.extend(-0.5)));
+
+        let strip_positions = [
+            tlf, trf, brf, blf, tlf, // Front
+            tlb, trb, brb, blb, tlb, // Back
+        ];
+        self.linestrip(strip_positions, polymorphic_color);
+
+        let list_positions = [
+            trf, trb, brf, brb, blf, blb, // Front to back
+        ];
+        self.extend_list_positions(list_positions);
+
+        self.add_list_color(polymorphic_color, 6);
+    }
+
+    /// Draw a wireframe cuboid in 3D.
+    ///
+    /// This should be called for each frame the cuboid needs to be rendered.
+    ///
+    /// # Example
+    /// ```
+    /// # use bevy_gizmos::prelude::*;
+    /// # use bevy_transform::prelude::*;
+    /// # use bevy_color::palettes::basic::GREEN;
+    /// fn system(mut gizmos: Gizmos) {
+    ///     gizmos.cuboid(Transform::IDENTITY, GREEN);
+    /// }
+    /// # bevy_ecs::system::assert_is_system(system);
+    /// ```
+    #[inline]
+    pub fn cuboid(
+        &mut self,
+        aabb: impl Into<Aabb3d>,
+        transform: impl TransformPoint,
+        color: impl Into<Color>,
+    ) {
+        let polymorphic_color: Color = color.into();
+        if !self.enabled {
+            return;
+        }
+        let aabb = aabb.into();
+        let [tlf, trf, brf, blf, tlb, trb, brb, blb] = [
+            Vec3::new(aabb.min.x, aabb.max.y, aabb.max.z),
+            Vec3::new(aabb.max.x, aabb.max.y, aabb.max.z),
+            Vec3::new(aabb.max.x, aabb.min.y, aabb.max.z),
+            Vec3::new(aabb.min.x, aabb.min.y, aabb.max.z),
+            Vec3::new(aabb.min.x, aabb.max.y, aabb.min.z),
+            Vec3::new(aabb.max.x, aabb.max.y, aabb.min.z),
+            Vec3::new(aabb.max.x, aabb.min.y, aabb.min.z),
+            Vec3::new(aabb.min.x, aabb.min.y, aabb.min.z),
+        ]
+        .map(|v| transform.transform_point(v));
 
         let strip_positions = [
             tlf, trf, brf, blf, tlf, // Front

--- a/crates/bevy_gizmos/src/rounded_box.rs
+++ b/crates/bevy_gizmos/src/rounded_box.rs
@@ -185,7 +185,7 @@ where
             let transform = Transform::from_translation(config.isometry.translation.into())
                 .with_rotation(config.isometry.rotation)
                 .with_scale(self.size);
-            self.gizmos.cuboid(transform, config.color);
+            self.gizmos.cube(transform, config.color);
             return;
         }
 

--- a/examples/3d/irradiance_volumes.rs
+++ b/examples/3d/irradiance_volumes.rs
@@ -601,7 +601,7 @@ fn draw_gizmo(
 ) {
     if app_status.voxels_visible {
         for transform in irradiance_volume_query.iter() {
-            gizmos.cuboid(*transform, GIZMO_COLOR);
+            gizmos.cube(*transform, GIZMO_COLOR);
         }
     }
 }

--- a/examples/gizmos/3d_gizmos.rs
+++ b/examples/gizmos/3d_gizmos.rs
@@ -130,7 +130,7 @@ fn draw_example_collection(
         .cell_count(UVec2::new(5, 10))
         .spacing(Vec2::new(0.2, 0.1));
 
-    gizmos.cuboid(
+    gizmos.cube(
         Transform::from_translation(Vec3::Y * 0.5).with_scale(Vec3::splat(1.25)),
         BLACK,
     );

--- a/examples/testbed/3d.rs
+++ b/examples/testbed/3d.rs
@@ -318,7 +318,7 @@ mod gizmos {
     }
 
     pub fn draw_gizmos(mut gizmos: Gizmos) {
-        gizmos.cuboid(
+        gizmos.cube(
             Transform::from_translation(Vec3::X * -1.75).with_scale(Vec3::splat(1.25)),
             RED,
         );


### PR DESCRIPTION
# Objective

- a way to draw aabbs that doesnt hurt my soul every time i use gizmos

## Solution

- Gizmos::cuboid actually draws a cube, so name it that to free up the name for an actual cuboid drawing function
- Add a real Gizmos::cuboid which takes Into<Aabb3d> now that #21307 merged, so we can also draw bevy_camera Aabb.

## Testing

- Existing gizmo tests and also tried making 3d_scene turn on AabbGizmoConfigGroup.draw_all and it looked good:
<img width="774" height="393" alt="{ADFB1568-0B6F-48C8-86C7-F81A73E7B409}" src="https://github.com/user-attachments/assets/2bbcb638-c1d0-41fe-b942-08d21d64fa95" />
