### PR TITLE
Enable `track_location` tests

### DIFF
--- a/tools/ci/src/commands/test.rs
+++ b/tools/ci/src/commands/test.rs
@@ -20,7 +20,7 @@ impl Prepare for TestCommand {
             PreparedCommand::new::<Self>(
                 cmd!(
                     sh,
-                    "cargo test --workspace --lib --bins --tests {no_fail_fast...} {jobs_ref...} -- {test_threads_ref...}"
+                    "cargo test --workspace --lib --bins --tests --features bevy_ecs/track_location {no_fail_fast...} {jobs_ref...} -- {test_threads_ref...}"
                 ),
                 "Please fix failing tests in output above.",
             ),


### PR DESCRIPTION
# Objective

Fixes #17314 

## Solution

Enable the `track_location` feature for `bevy_ecs` tests (but not benchmarks)

## Testing

I verified it by running the `cargo test` command before and after the modification locally
