### PR TITLE
Relax deferred UnsafeWorldCell visibility

### DIFF
--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -831,7 +831,7 @@ impl<'w> DeferredWorld<'w> {
     /// # Safety
     /// - must only be used to make non-structural ECS changes
     #[inline]
-    pub(crate) fn as_unsafe_world_cell(&mut self) -> UnsafeWorldCell<'_> {
+    pub fn as_unsafe_world_cell(&mut self) -> UnsafeWorldCell<'_> {
         self.world
     }
 }


### PR DESCRIPTION
# Objective

Addresses the immediate blocker in #21354 by relaxing the `(crate)` visibility restriction on `DeferredWorld::as_unsafe_world_cell`.

This method already has documentation, including a safety comment. While sparse, I think they communicate the function clearly.