### PR TITLE
set spawn_despawn on the correct entity when despawning

### DIFF
--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -6752,11 +6752,14 @@ mod tests {
         let _id2 = world.spawn(Marker).id();
         let id3 = world.spawn(Marker).id();
 
+        #[cfg(feature = "track_location")]
         let e1_spawned = world.entity(id1).spawned_by();
 
         let spawn = world.entity(id3).spawned_by();
         world.entity_mut(id1).despawn();
+        #[cfg(feature = "track_location")]
         let e1_despawned = world.entities().entity_get_spawned_or_despawned_by(id1);
+        #[cfg(feature = "track_location")]
         assert_ne!(e1_spawned.map(Some), e1_despawned);
 
         let spawn_after = world.entity(id3).spawned_by();

--- a/tools/ci/src/commands/test.rs
+++ b/tools/ci/src/commands/test.rs
@@ -20,7 +20,7 @@ impl Prepare for TestCommand {
             PreparedCommand::new::<Self>(
                 cmd!(
                     sh,
-                    "cargo test --workspace --lib --bins --tests {no_fail_fast...} {jobs_ref...} -- {test_threads_ref...}"
+                    "cargo test --workspace --lib --bins --tests --features bevy_ecs/track_location {no_fail_fast...} {jobs_ref...} -- {test_threads_ref...}"
                 ),
                 "Please fix failing tests in output above.",
             ),


### PR DESCRIPTION
# Objective

Fixes #21293
Fixes #17314 to ensure that this is tested correctly.

## Solution
when despawning an entity, previously the swapped in (archetype) or moved in entity (table) (which both require extra bookkeeping to update archetype or table rows) were marked as `spawned_or_despawned` by the location and tick that the to-be-removed entity was meant to be marked, while the to-be-removed entity wasn't marked.
As pointed out by @akimakinai in [#19047](https://github.com/bevyengine/bevy/pull/19047), I've re-added the correct `mark_spawn_despawn` call to `despawn_with_caller`.

## Testing

I've added a test `spawned_after_swap_remove` that ensures that despawning an entity by swapping doesn't effect other entities `spawned_or_despawned` location, and that it does effect the despawned entity's index's `spawned_or_despawned` location.

Co-Authored By: waterwhisperer24@qq.com