### PR TITLE
Fix u32 overflow when window is resize

### DIFF
--- a/examples/2d/2d_viewport_to_world.rs
+++ b/examples/2d/2d_viewport_to_world.rs
@@ -77,6 +77,11 @@ fn controls(
     }
 
     if let Some(viewport) = camera.viewport.as_mut() {
+        // Reset viewport when widnow is resize
+        if viewport.physical_size.x > window_size.x || viewport.physical_size.y > window_size.y {
+            viewport.physical_size = (window_size.as_vec2() * 0.75).as_uvec2();
+        }
+
         // Viewport movement controls
         if input.pressed(KeyCode::KeyW) {
             viewport.physical_position.y = viewport.physical_position.y.saturating_sub(uspeed);

--- a/examples/2d/2d_viewport_to_world.rs
+++ b/examples/2d/2d_viewport_to_world.rs
@@ -77,7 +77,7 @@ fn controls(
     }
 
     if let Some(viewport) = camera.viewport.as_mut() {
-        // Reset viewport when widnow is resize
+        // Reset viewport size on window resize
         if viewport.physical_size.x > window_size.x || viewport.physical_size.y > window_size.y {
             viewport.physical_size = (window_size.as_vec2() * 0.75).as_uvec2();
         }


### PR DESCRIPTION
# Objective

bevy v0.17.1, archlinux + i3wm.

`cargo run --example 2d_viewport_to_world`

```
thread 'Compute Task Pool (1)' (470531) panicked at /home/go/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/glam-0.30.8/src/u32/uvec2.rs:1071:23:
attempt to subtract with overflow
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Encountered a panic in system `2d_viewport_to_world::controls`!
Encountered a panic in system `bevy_app::main_schedule::FixedMain::run_fixed_main`!
Encountered a panic in system `bevy_time::fixed::run_fixed_main_schedule`!
Encountered a panic in system `bevy_app::main_schedule::Main::run_main`!
```

## Solution

Consider window resize。

## Testing

no panic.

---
