### PR TITLE
Reexport `Entry` from `indexmap` crate

### DIFF
--- a/crates/bevy_ecs/src/entity/index_map.rs
+++ b/crates/bevy_ecs/src/entity/index_map.rs
@@ -17,6 +17,7 @@ use core::{
 
 #[cfg(feature = "bevy_reflect")]
 use bevy_reflect::Reflect;
+pub use indexmap::map::Entry;
 use indexmap::map::{self, IndexMap, IntoValues, ValuesMut};
 
 use super::{Entity, EntityEquivalent, EntityHash, EntitySetIterator};


### PR DESCRIPTION
# Objective

Fixes #21275 

Pasting the content of the Issue to provide context,

> bevy_ecs::entity::EntityIndexMap has the entry() method because it derefs to indexmap::IndexMap, but it doesn't re-export IndexMap::Entry so I have to import the indexmap crate manually.

> It would be convenient to re-export indexmap::Entry in bevy_ecs::entity::index_map