### PR TITLE
Remove unnecessary calls to `world.flush()`

### DIFF
--- a/crates/bevy_ecs/src/observer/entity_cloning.rs
+++ b/crates/bevy_ecs/src/observer/entity_cloning.rs
@@ -95,7 +95,6 @@ mod tests {
             .spawn_empty()
             .observe(|_: On<E>, mut res: ResMut<Num>| res.0 += 1)
             .id();
-        world.flush();
 
         world.trigger(E(e));
 


### PR DESCRIPTION
# Objective

Fixes #20177 

## Solution

Remove unnecessary calls to `world.flush()` in observer tests 

## Testing

Ran `cargo test --package bevy_ecs --lib observer` and all tests passed
<img width="1569" height="718" alt="image" src="https://github.com/user-attachments/assets/7fdb1959-3d4a-49f6-832a-15650e8ee94a" />
