### PR TITLE
`Interaction::Hovered` fix

### DIFF
--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -302,7 +302,8 @@ pub fn ui_focus_system(
 
     // set Pressed or Hovered on top nodes. as soon as a node with a `Block` focus policy is detected,
     // the iteration will stop on it because it "captures" the interaction.
-    let mut iter = node_query.iter_many_mut(hovered_nodes.iter());
+    let mut hovered_nodes = hovered_nodes.iter();
+    let mut iter = node_query.iter_many_mut(hovered_nodes.by_ref());
     while let Some(node) = iter.fetch_next() {
         if let Some(mut interaction) = node.interaction {
             if mouse_clicked {
@@ -329,7 +330,7 @@ pub fn ui_focus_system(
     }
     // reset `Interaction` for the remaining lower nodes to `None`. those are the nodes that remain in
     // `moused_over_nodes` after the previous loop is exited.
-    let mut iter = node_query.iter_many_mut(hovered_nodes.iter());
+    let mut iter = node_query.iter_many_mut(hovered_nodes);
     while let Some(node) = iter.fetch_next() {
         if let Some(mut interaction) = node.interaction {
             // don't reset pressed nodes because they're handled separately


### PR DESCRIPTION
# Objective

The `Interaction` component only gets set to `None` and `Pressed` atm.

fixes #21374

## Solution

The second while loop through `hovered_nodes` needs to reuse the iterator from the first while loop. Instead it creates a new iterator and sets `Interaction::None` for all hovered nodes, not just the ones that are blocked.