### PR TITLE
fix typo in viewport_node example

### DIFF
--- a/examples/ui/viewport_node.rs
+++ b/examples/ui/viewport_node.rs
@@ -65,7 +65,7 @@ fn test(
             Shape,
         ))
         // We can observe pointer events on our objects as normal, the
-        // `bevy::ui::widgets::viewport_picking` system will take care of ensuring our viewport
+        // `bevy::ui::widget::viewport_picking` system will take care of ensuring our viewport
         // clicks pass through
         .observe(on_drag_cuboid);
 


### PR DESCRIPTION
# Objective
Fix typo in viewport_node example 
## Solution
- the comment should point to [widget](https://docs.rs/bevy/latest/bevy/ui/widget/fn.viewport_picking.html) not widgets.