### PR TITLE
Fix clippy lint for importing `Arc` from `std` instead of `alloc`

### DIFF
--- a/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
@@ -74,14 +74,12 @@ mod internal {
         pin::Pin,
         task::{Context, Poll},
     };
-    use std::sync::{
-        mpsc::{self, Receiver, Sender},
-        Arc,
-    };
+    use std::sync::mpsc::{self, Receiver, Sender};
 
     use alloc::{
         format,
         string::{String, ToString},
+        sync::Arc,
     };
     use atomic_waker::AtomicWaker;
     use bevy_app::{App, First, Startup, Update};


### PR DESCRIPTION
# Objective

Currently, when running `cargo clippy`, we get a warning from `bevy_diagnostic` that `Arc` is imported from `std::sync` instead of `alloc::sync`. That's the only clippy warning in the project.

## Solution

Change the offending file to import `Arc` from `alloc::sync` instead of `std::sync`.

## Testing

Since `alloc::sync::Arc` is the same as `std::sync::Arc`, there should be no differences in behavior.