### PR TITLE
Fixed fog contribution for point and spotlights

### DIFF
--- a/crates/bevy_pbr/src/volumetric_fog/volumetric_fog.wgsl
+++ b/crates/bevy_pbr/src/volumetric_fog/volumetric_fog.wgsl
@@ -17,14 +17,14 @@
 #import bevy_pbr::mesh_functions::{get_world_from_local, mesh_position_local_to_clip}
 #import bevy_pbr::mesh_view_bindings::{globals, lights, view, clusterable_objects}
 #import bevy_pbr::mesh_view_types::{
-    DIRECTIONAL_LIGHT_FLAGS_VOLUMETRIC_BIT, 
-    POINT_LIGHT_FLAGS_SHADOWS_ENABLED_BIT, 
+    DIRECTIONAL_LIGHT_FLAGS_VOLUMETRIC_BIT,
+    POINT_LIGHT_FLAGS_SHADOWS_ENABLED_BIT,
     POINT_LIGHT_FLAGS_VOLUMETRIC_BIT,
     POINT_LIGHT_FLAGS_SPOT_LIGHT_Y_NEGATIVE,
     ClusterableObject
 }
 #import bevy_pbr::shadow_sampling::{
-    sample_shadow_map_hardware, 
+    sample_shadow_map_hardware,
     sample_shadow_cubemap,
     sample_shadow_map,
     SPOT_SHADOW_TEXEL_SIZE
@@ -371,7 +371,7 @@ fn fragment(@builtin(position) position: vec4<f32>) -> @location(0) vec4<f32> {
                 }
                 local_light_attenuation *= spot_attenuation * shadow;
             }
-            
+
             // Calculate absorption (amount of light absorbed by the fog) and
             // out-scattering (amount of light the fog scattered away).
             let sample_attenuation = exp(-step_size_world * density * (absorption + scattering));
@@ -381,7 +381,7 @@ fn fragment(@builtin(position) position: vec4<f32>) -> @location(0) vec4<f32> {
 
             let light_attenuation = exp(-density * bounding_radius * (absorption + scattering));
             let light_factors_per_step = fog_color * light_tint * light_attenuation *
-                scattering * density * step_size_world * light_intensity * 0.1;
+                scattering * density * step_size_world * light_intensity * exposure;
 
             // Modulate the factor we calculated above by the phase, fog color,
             // light color, light tint.

--- a/examples/3d/volumetric_fog.rs
+++ b/examples/3d/volumetric_fog.rs
@@ -89,7 +89,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, app_settings: R
             shadows_enabled: true,
             range: 150.0,
             color: RED.into(),
-            intensity: 1000.0,
+            intensity: 10_000.0,
             ..default()
         },
         VolumetricLight,
@@ -104,7 +104,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, app_settings: R
     commands.spawn((
         Transform::from_xyz(-1.8, 3.9, -2.7).looking_at(Vec3::ZERO, Vec3::Y),
         SpotLight {
-            intensity: 5000.0, // lumens
+            intensity: 50_000.0, // lumens
             color: Color::WHITE,
             shadows_enabled: true,
             inner_angle: 0.76,


### PR DESCRIPTION
# Objective

Fixes #21327 
Volumetric fog contribution was not proportional to the light intensity for point and spotlights.

## Solution

Take into account `exposure` value for Point and Spotlights to match the Directional light implementation.

## Testing

- Run the updated `volumetric_fog` example. You can see the volumetric effect of point and spotlights now match the intensity of this light on the surfaces of the room. 

---

## Showcase

Point and spotlight intensities in the original `volumetric_fog` example were too low to light up the room despite having a very strong volumetric contribution. This update boosts the light intensity and lowers the volumetric contribution of point and spotlights

Before this change `volumetric_fog` example with 10x light intensity for point and spotlights:
<img width="1922" height="1126" alt="brightness_10x_on" src="https://github.com/user-attachments/assets/7562585c-bc1b-4cbf-9d52-4ffb083d65f4" />

After change:
<img width="1922" height="1126" alt="brightness_10x_on_fix" src="https://github.com/user-attachments/assets/2a17fec8-0272-4c4e-9d88-d0916027a7c5" />


