### PR TITLE
Make bevy_mikktspace optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,6 +149,7 @@ default = [
   "bevy_scene",
   "bevy_image",
   "bevy_mesh",
+  "bevy_mikktspace",
   "bevy_camera",
   "bevy_light",
   "bevy_shader",
@@ -271,6 +272,9 @@ bevy_image = ["bevy_internal/bevy_image"]
 
 # Provides a mesh format and some primitive meshing routines.
 bevy_mesh = ["bevy_internal/bevy_mesh"]
+
+# Provides Mikkelsen Tangent Space generation for use with bevy_mesh.
+bevy_mikktspace = ["bevy_internal/bevy_mikktspace"]
 
 # Provides camera and visibility types, as well as culling primitives.
 bevy_camera = ["bevy_internal/bevy_camera"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -273,7 +273,7 @@ bevy_image = ["bevy_internal/bevy_image"]
 # Provides a mesh format and some primitive meshing routines.
 bevy_mesh = ["bevy_internal/bevy_mesh"]
 
-# Provides Mikkelsen Tangent Space generation for use with bevy_mesh.
+# Provides vertex tangent generation for use with bevy_mesh.
 bevy_mikktspace = ["bevy_internal/bevy_mikktspace"]
 
 # Provides camera and visibility types, as well as culling primitives.

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -222,6 +222,7 @@ bevy_text = [
 bevy_ui = ["dep:bevy_ui", "bevy_text", "bevy_sprite"]
 bevy_mesh = ["dep:bevy_mesh", "bevy_image"]
 bevy_animation = ["dep:bevy_animation", "bevy_mesh"]
+bevy_mikktspace = ["bevy_mesh?/bevy_mikktspace"]
 bevy_window = ["dep:bevy_window", "dep:bevy_a11y", "bevy_image"]
 bevy_winit = ["dep:bevy_winit", "bevy_window"]
 bevy_camera = ["dep:bevy_camera", "bevy_mesh", "bevy_window"]

--- a/crates/bevy_mesh/Cargo.toml
+++ b/crates/bevy_mesh/Cargo.toml
@@ -17,7 +17,7 @@ bevy_math = { path = "../bevy_math", version = "0.18.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.18.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.18.0-dev" }
 bevy_transform = { path = "../bevy_transform", version = "0.18.0-dev" }
-bevy_mikktspace = { version = "0.17.0-dev" }
+bevy_mikktspace = { version = "0.17.0-dev", optional = true }
 bevy_derive = { path = "../bevy_derive", version = "0.18.0-dev" }
 bevy_platform = { path = "../bevy_platform", version = "0.18.0-dev", default-features = false, features = [
   "std",

--- a/crates/bevy_mesh/src/lib.rs
+++ b/crates/bevy_mesh/src/lib.rs
@@ -7,6 +7,7 @@ mod components;
 mod conversions;
 mod index;
 mod mesh;
+#[cfg(feature = "bevy_mikktspace")]
 mod mikktspace;
 #[cfg(feature = "morph")]
 pub mod morph;
@@ -20,6 +21,7 @@ use bitflags::bitflags;
 pub use components::*;
 pub use index::*;
 pub use mesh::*;
+#[cfg(feature = "bevy_mikktspace")]
 pub use mikktspace::*;
 pub use primitives::*;
 pub use vertex::*;

--- a/crates/bevy_mesh/src/mikktspace.rs
+++ b/crates/bevy_mesh/src/mikktspace.rs
@@ -1,5 +1,4 @@
 use super::{Indices, Mesh, VertexAttributeValues};
-use bevy_math::Vec3;
 use thiserror::Error;
 use wgpu_types::{PrimitiveTopology, VertexFormat};
 
@@ -126,19 +125,4 @@ pub(crate) fn generate_tangents_for_mesh(
     }
 
     Ok(mikktspace_mesh.tangents)
-}
-
-/// Correctly scales and renormalizes an already normalized `normal` by the scale determined by its reciprocal `scale_recip`
-pub(crate) fn scale_normal(normal: Vec3, scale_recip: Vec3) -> Vec3 {
-    // This is basically just `normal * scale_recip` but with the added rule that `0. * anything == 0.`
-    // This is necessary because components of `scale_recip` may be infinities, which do not multiply to zero
-    let n = Vec3::select(normal.cmpeq(Vec3::ZERO), Vec3::ZERO, normal * scale_recip);
-
-    // If n is finite, no component of `scale_recip` was infinite or the normal was perpendicular to the scale
-    // else the scale had at least one zero-component and the normal needs to point along the direction of that component
-    if n.is_finite() {
-        n.normalize_or_zero()
-    } else {
-        Vec3::select(n.abs().cmpeq(Vec3::INFINITY), n.signum(), Vec3::ZERO).normalize()
-    }
 }

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -29,6 +29,7 @@ The default feature set enables most of the expected features of a game engine, 
 |bevy_log|Enable integration with `tracing` and `log`|
 |bevy_mesh|Provides a mesh format and some primitive meshing routines.|
 |bevy_mesh_picking_backend|Provides an implementation for picking meshes|
+|bevy_mikktspace|Provides Mikkelsen Tangent Space generation for use with bevy_mesh.|
 |bevy_pbr|Adds PBR rendering|
 |bevy_picking|Provides picking functionality|
 |bevy_post_process|Provides post process effects such as depth of field, bloom, chromatic aberration.|

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -29,7 +29,7 @@ The default feature set enables most of the expected features of a game engine, 
 |bevy_log|Enable integration with `tracing` and `log`|
 |bevy_mesh|Provides a mesh format and some primitive meshing routines.|
 |bevy_mesh_picking_backend|Provides an implementation for picking meshes|
-|bevy_mikktspace|Provides Mikkelsen Tangent Space generation for use with bevy_mesh.|
+|bevy_mikktspace|Provides vertex tangent generation for use with bevy_mesh.|
 |bevy_pbr|Adds PBR rendering|
 |bevy_picking|Provides picking functionality|
 |bevy_post_process|Provides post process effects such as depth of field, bloom, chromatic aberration.|


### PR DESCRIPTION
# Objective

- allow users to cut unneeded deps

## Solution

- feature gate

## Testing

- clearcoat example uses generated tangents, still works.