### PR TITLE
Rename cuboid to cube

### DIFF
--- a/crates/bevy_gizmos/src/gizmos.rs
+++ b/crates/bevy_gizmos/src/gizmos.rs
@@ -588,12 +588,12 @@ where
     /// # use bevy_transform::prelude::*;
     /// # use bevy_color::palettes::basic::GREEN;
     /// fn system(mut gizmos: Gizmos) {
-    ///     gizmos.cuboid(Transform::IDENTITY, GREEN);
+    ///     gizmos.cube(Transform::IDENTITY, GREEN);
     /// }
     /// # bevy_ecs::system::assert_is_system(system);
     /// ```
     #[inline]
-    pub fn cuboid(&mut self, transform: impl TransformPoint, color: impl Into<Color>) {
+    pub fn cube(&mut self, transform: impl TransformPoint, color: impl Into<Color>) {
         let polymorphic_color: Color = color.into();
         if !self.enabled {
             return;

--- a/crates/bevy_gizmos/src/rounded_box.rs
+++ b/crates/bevy_gizmos/src/rounded_box.rs
@@ -185,7 +185,7 @@ where
             let transform = Transform::from_translation(config.isometry.translation.into())
                 .with_rotation(config.isometry.rotation)
                 .with_scale(self.size);
-            self.gizmos.cuboid(transform, config.color);
+            self.gizmos.cube(transform, config.color);
             return;
         }
 

--- a/examples/3d/irradiance_volumes.rs
+++ b/examples/3d/irradiance_volumes.rs
@@ -601,7 +601,7 @@ fn draw_gizmo(
 ) {
     if app_status.voxels_visible {
         for transform in irradiance_volume_query.iter() {
-            gizmos.cuboid(*transform, GIZMO_COLOR);
+            gizmos.cube(*transform, GIZMO_COLOR);
         }
     }
 }

--- a/examples/gizmos/3d_gizmos.rs
+++ b/examples/gizmos/3d_gizmos.rs
@@ -130,7 +130,7 @@ fn draw_example_collection(
         .cell_count(UVec2::new(5, 10))
         .spacing(Vec2::new(0.2, 0.1));
 
-    gizmos.cuboid(
+    gizmos.cube(
         Transform::from_translation(Vec3::Y * 0.5).with_scale(Vec3::splat(1.25)),
         BLACK,
     );

--- a/examples/testbed/3d.rs
+++ b/examples/testbed/3d.rs
@@ -318,7 +318,7 @@ mod gizmos {
     }
 
     pub fn draw_gizmos(mut gizmos: Gizmos) {
-        gizmos.cuboid(
+        gizmos.cube(
             Transform::from_translation(Vec3::X * -1.75).with_scale(Vec3::splat(1.25)),
             RED,
         );

--- a/release-content/migration-guides/gizmos-cuboid.md
+++ b/release-content/migration-guides/gizmos-cuboid.md
@@ -1,0 +1,6 @@
+---
+title: "`Gizmos::cuboid` has been renamed to `Gizmos::cube`"
+pull_requests: [21393]
+---
+
+`Gizmos::cuboid` was renamed to `Gizmos::cube`.


### PR DESCRIPTION
# Objective

- Gizmos::cuboid is for drawing cubes, even the docs say so. A cuboid drawing function should take Cuboid as input.

## Solution

- Rename ::cuboid to ::cube, making way for an actual cuboid drawing function.

## Testing

- ci