### PR TITLE
Remove uses of `#[cfg(feature = "track_location")]` outside of the implementation of `MaybeLocation`

### DIFF
--- a/crates/bevy_ecs/src/world/command_queue.rs
+++ b/crates/bevy_ecs/src/world/command_queue.rs
@@ -1,6 +1,5 @@
-#[cfg(feature = "track_location")]
-use crate::change_detection::MaybeLocation;
 use crate::{
+    change_detection::MaybeLocation,
     system::{Command, SystemBuffer, SystemMeta},
     world::{DeferredWorld, World},
 };
@@ -41,7 +40,6 @@ pub struct CommandQueue {
     pub(crate) bytes: Vec<MaybeUninit<u8>>,
     pub(crate) cursor: usize,
     pub(crate) panic_recovery: Vec<MaybeUninit<u8>>,
-    #[cfg(feature = "track_location")]
     pub(crate) caller: MaybeLocation,
 }
 
@@ -52,7 +50,6 @@ impl Default for CommandQueue {
             bytes: Default::default(),
             cursor: Default::default(),
             panic_recovery: Default::default(),
-            #[cfg(feature = "track_location")]
             caller: MaybeLocation::caller(),
         }
     }
@@ -74,13 +71,10 @@ pub(crate) struct RawCommandQueue {
 // So instead, the manual impl just prints the length of vec.
 impl Debug for CommandQueue {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let mut binding = f.debug_struct("CommandQueue");
-        binding.field("len_bytes", &self.bytes.len());
-
-        #[cfg(feature = "track_location")]
-        binding.field("caller", &self.caller.into_option());
-
-        binding.finish_non_exhaustive()
+        f.debug_struct("CommandQueue")
+            .field("len_bytes", &self.bytes.len())
+            .field("caller", &self.caller)
+            .finish_non_exhaustive()
     }
 }
 
@@ -332,10 +326,11 @@ impl RawCommandQueue {
 impl Drop for CommandQueue {
     fn drop(&mut self) {
         if !self.bytes.is_empty() {
-            #[cfg(feature = "track_location")]
-            warn!("CommandQueue has un-applied commands being dropped. Did you forget to call SystemState::apply? caller:{:?}",self.caller.into_option());
-            #[cfg(not(feature = "track_location"))]
-            warn!("CommandQueue has un-applied commands being dropped. Did you forget to call SystemState::apply?");
+            if let Some(caller) = self.caller.into_option() {
+                warn!("CommandQueue has un-applied commands being dropped. Did you forget to call SystemState::apply? caller:{caller:?}");
+            } else {
+                warn!("CommandQueue has un-applied commands being dropped. Did you forget to call SystemState::apply?");
+            }
         }
         // SAFETY: A reference is always a valid pointer
         unsafe { self.get_raw().apply_or_drop_queued(None) };

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -6752,15 +6752,19 @@ mod tests {
         let _id2 = world.spawn(Marker).id();
         let id3 = world.spawn(Marker).id();
 
-        #[cfg(feature = "track_location")]
         let e1_spawned = world.entity(id1).spawned_by();
 
         let spawn = world.entity(id3).spawned_by();
         world.entity_mut(id1).despawn();
-        #[cfg(feature = "track_location")]
         let e1_despawned = world.entities().entity_get_spawned_or_despawned_by(id1);
-        #[cfg(feature = "track_location")]
-        assert_ne!(e1_spawned.map(Some), e1_despawned);
+
+        // These assertions are only possible if the `track_location` feature is enabled
+        if let (Some(e1_spawned), Some(e1_despawned)) =
+            (e1_spawned.into_option(), e1_despawned.into_option())
+        {
+            assert!(e1_despawned.is_some());
+            assert_ne!(Some(e1_spawned), e1_despawned);
+        }
 
         let spawn_after = world.entity(id3).spawned_by();
         assert_eq!(spawn, spawn_after);


### PR DESCRIPTION
# Objective

Remove uses of `#[cfg(feature = "track_location")]` outside of the implementation of `MaybeLocation`.  

Reducing the amount of conditional compilation makes the code less brittle, since compilation errors will be found regardless of whether the feature is enabled.  

We also want to ensure that uses of `MaybeLocation` outside of `bevy_ecs` don't need their *own* feature flags.  Avoiding the flags even within `bevy_ecs` helps ensure that all use cases are covered, and makes it easier to move or copy implementations from `bevy_ecs` into other crates.  

## Solution

Remove `#[cfg(feature = "track_location")]` annotations.  Use `.into_option()` in the cases where we want the behavior to depend on whether the feature is enabled.  