### PR TITLE
Allow only parentheses in #[reflect(...)]

### DIFF
--- a/crates/bevy_render/src/sync_world.rs
+++ b/crates/bevy_render/src/sync_world.rs
@@ -119,7 +119,7 @@ impl Plugin for SyncWorldPlugin {
 /// [`ExtractComponentPlugin`]: crate::extract_component::ExtractComponentPlugin
 /// [`SyncComponentPlugin`]: crate::sync_component::SyncComponentPlugin
 #[derive(Component, Copy, Clone, Debug, Default, Reflect)]
-#[reflect[Component, Default, Clone]]
+#[reflect(Component, Default, Clone)]
 #[component(storage = "SparseSet")]
 pub struct SyncToRenderWorld;
 

--- a/release-content/migration-guides/reflect_parentheses.md
+++ b/release-content/migration-guides/reflect_parentheses.md
@@ -1,0 +1,26 @@
+---
+title: "`#[reflect(...)]` now supports only parentheses" 
+pull_requests: [21400]
+---
+
+Previously, the `#[reflect(...)]` attribute of the `Reflect` derive macro
+supported parentheses, braces, or brackets, to standardize the syntax going
+forward, it now supports only parentheses.
+
+```rust
+/// before
+#[derive(Clone, Reflect)]
+#[reflect[Clone]]
+
+/// after
+#[derive(Clone, Reflect)]
+#[reflect(Clone)]
+
+/// before
+#[derive(Clone, Reflect)]
+#[reflect{Clone}]
+
+/// after
+#[derive(Clone, Reflect)]
+#[reflect(Clone)]
+```


### PR DESCRIPTION
# Objective

Fixes #8906

#8906 reports that the `reflect` attribute silently fails when using the `#[reflect[...]]` syntax. I wasn't able to reproduce that issue, so it was likely resolved in a prior change. This pull request addresses only the syntax issue.

## Solution

Validate the `Meta::List` delimiter in reflect macro to allow only `MacroDelimiter::Paren`

## Testing

- Did you test these changes? If so, how?
I run `cargo check --example reflection_types`
- Are there any parts that need more testing?
No
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
Run `cargo check --example reflection_types`

Then modify the reflection_types example by changing:
```
#[reflect(Hash, PartialEq, Clone)]
pub struct E {
    x: usize,
}
```
to
```
#[reflect[Hash, PartialEq, Clone]]
pub struct E {
    x: usize,
}
```
then run `cargo check --example reflection_types`  again it should now fail with this error:
```
error: `#[reflect = "..."]` must use parenthesis `(` and `)`
```