### PR TITLE
Fix entity reservation on 32-bit platforms

### DIFF
--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -841,8 +841,8 @@ impl Entities {
             // As `self.free_cursor` goes more and more negative, we return IDs farther
             // and farther beyond `meta.len()`.
             let raw = self.meta.len() as IdCursor - n;
-            if raw >= u32::MAX as IdCursor {
-                panic!("too many entities");
+            if raw == IdCursor::MAX {
+                panic!("number of entities exceeds {}", IdCursor::MAX);
             }
             // SAFETY: We just checked the bounds
             let row = unsafe { EntityRow::new(NonMaxU32::new_unchecked(raw as u32)) };

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -842,7 +842,7 @@ impl Entities {
             // and farther beyond `meta.len()`.
             let raw = self.meta.len() as IdCursor - n;
             if raw == IdCursor::MAX {
-                panic!("number of entities exceeds {}", IdCursor::MAX);
+                panic!("number of entities can't exceed {}", IdCursor::MAX);
             }
             // SAFETY: We just checked the bounds
             let row = unsafe { EntityRow::new(NonMaxU32::new_unchecked(raw as u32)) };


### PR DESCRIPTION
# Objective

- Casting `u32::MAX` to `IdCursor` on platforms such as GBA results in -1. 

## Solution

- I replaced with `IdCursor::MAX` and made the panic less cryptic.

## Testing

- I porting https://github.com/bushrat011899/bevy_mod_gba to 0.17 and this change fixes the breakout example.