### PR TITLE
Emit slider drag value change only when value changes

### DIFF
--- a/crates/bevy_ui_widgets/src/slider.rs
+++ b/crates/bevy_ui_widgets/src/slider.rs
@@ -330,6 +330,7 @@ pub(crate) fn slider_on_drag(
     mut event: On<Pointer<Drag>>,
     mut q_slider: Query<
         (
+            &SliderValue,
             &ComputedNode,
             &SliderRange,
             Option<&SliderPrecision>,
@@ -344,7 +345,8 @@ pub(crate) fn slider_on_drag(
     mut commands: Commands,
     ui_scale: Res<UiScale>,
 ) {
-    if let Ok((node, range, precision, transform, drag, disabled)) = q_slider.get_mut(event.entity)
+    if let Ok((value, node, range, precision, transform, drag, disabled)) =
+        q_slider.get_mut(event.entity)
     {
         event.propagate(false);
         if drag.dragging && !disabled {
@@ -369,10 +371,12 @@ pub(crate) fn slider_on_drag(
                     .unwrap_or(new_value),
             );
 
-            commands.trigger(ValueChange {
-                source: event.entity,
-                value: rounded_value,
-            });
+            if rounded_value != value.0 {
+                commands.trigger(ValueChange {
+                    source: event.entity,
+                    value: rounded_value,
+                });
+            }
         }
     }
 }


### PR DESCRIPTION
# Objective

Fixes #21376

## Solution

Just check if the value has changed with an `if`.  The issue mentions `.set_if_neq` but I'm not sure if it's relevant as `slider_on_drag` doesn't directly change the component value but emits an event.

## Testing

Checked on the feathers example:

https://github.com/user-attachments/assets/ac5bb2fa-9054-4eed-985f-846ac15f310d
