### PR TITLE
Fix slider value indicator bar when value is out of range

### DIFF
--- a/crates/bevy_feathers/src/controls/slider.rs
+++ b/crates/bevy_feathers/src/controls/slider.rs
@@ -216,7 +216,7 @@ fn update_slider_pos(
 ) {
     for (slider_ent, value, range, precision, mut gradient) in q_sliders.iter_mut() {
         if let [Gradient::Linear(linear_gradient)] = &mut gradient.0[..] {
-            let percent_value = range.thumb_position(value.0) * 100.0;
+            let percent_value = (range.thumb_position(value.0) * 100.0).clamp(0.0, 100.0);
             linear_gradient.stops[1].point = Val::Percent(percent_value);
             linear_gradient.stops[2].point = Val::Percent(percent_value);
         }


### PR DESCRIPTION
# Objective

When the slider value is out of range the indicator bar renders incorrectly. For example:

```rs
SliderProps {
    max: 10.0,
    value: 100.0, // or -100.0,
    ..default()
},
```

<img width="370" alt="image" src="https://github.com/user-attachments/assets/77ebd9ae-1988-4cb1-9f79-994bb467993c" />

<img width="370" alt="image" src="https://github.com/user-attachments/assets/6db1d063-69fa-4478-997c-1bc8e76d40dd" />

## Solution

Clamp slider gradient to 0-100 range.

## Testing

Tried different values in feathers example.

<img width="370" alt="image" src="https://github.com/user-attachments/assets/828381f8-7212-4be2-9d44-8b0d774600cc" />

<img width="370" alt="image" src="https://github.com/user-attachments/assets/ad0d0f38-13dc-4fb1-86c0-6053d0782263" />

