### PR TITLE
Modifying the readme in example to address the wayland default

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,10 @@ To run an example, use the command `cargo run --example <Example>`, and add the 
 ```sh
 cargo run --features wayland --example hello_world
 ```
-
+Because the engine builds with wayland by default, if your system uses x11, you need to add `--no-default-features` flag. Run using this command:
+```sh
+cargo run --no-default-features --features x11 --example hello_world
+```
 **⚠️ Note: for users of releases on crates.io!**
 
 There are often large differences and incompatible API changes between the latest [crates.io](https://crates.io/crates/bevy) release and the development version of Bevy in the git main branch!


### PR DESCRIPTION
I am new to bevy, so I just cloned the repository and did a cargo build. That gave me the error: 
```
/home/einfochips/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/wayland-sys-0.31.7/build.rs:10:47:
  called `Result::unwrap()` on an `Err` value: Failed to run command `PKG_CONFIG_ALLOW_SYSTEM_LIBS=1 PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1 pkg-config --libs --cflags wayland-client`, because: Not a directory (os error 20)
```
then I discovered that my system runs on x11, but when i ran the example:
```
cargo run --features x11 --example hello_world
```
I still got the error.
This PR is trying to fix this.

# Objective

Since engine runs on wayland by default, the defaults need to be disabled for running on x11. 

## Solution

The first example of `cargo run` in example/README.md needs to specify how to do this. Hence a new example is added.

## Testing

I did run the cargo my self and the newly added example works on my system, the command being:
```sh
cargo run --no-default-features --features x11 --example hello_world
```