### PR TITLE
Fix clippy when `target_os = "windows"`

### DIFF
--- a/crates/bevy_winit/src/state.rs
+++ b/crates/bevy_winit/src/state.rs
@@ -478,7 +478,7 @@ impl<M: Message> ApplicationHandler<M> for WinitAppRunnerState<M> {
                 })
             }
 
-            if !self.app_exit.is_some()
+            if self.app_exit.is_none()
                 && (self.startup_forced_updates > 0
                     || matches!(self.update_mode, UpdateMode::Reactive { .. })
                     || self.window_event_received


### PR DESCRIPTION
Fixes a clippy error introduced by #21338. Issue was inside a `#[cfg(target_os = "windows")]` block so it wasn't caught by CI.

```rust
error: this boolean expression can be simplified
   --> crates\bevy_winit\src\state.rs:481:16
    |
481 |             if !self.app_exit.is_some()
    |                ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `self.app_exit.is_none()`
```

Tested with Rust 1.90.0, Win10, `cargo run -p ci -- lints`, `cargo run --example window_settings`.