### PR TITLE
Entity scope v1: component scope

### DIFF
--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -488,10 +488,10 @@ impl Archetype {
         &self.entities
     }
 
-    /// Fetches the disabled entities contained in this archetype.
+    /// Fetches the enabled entities contained in this archetype.
     #[inline]
-    pub fn disabled_entities(&self) -> &[ArchetypeEntity] {
-        &self.entities[..self.disabled_entities as usize]
+    pub fn enabled_entities(&self) -> &[ArchetypeEntity] {
+        &self.entities[self.disabled_entities as usize..]
     }
 
     /// Get the valid table rows (i.e. non-disabled entities).
@@ -507,8 +507,7 @@ impl Archetype {
     #[inline]
     pub fn entities_with_location(
         &self,
-    ) -> impl Iterator<Item = (Entity, EntityLocation)> + DoubleEndedIterator + ExactSizeIterator
-    {
+    ) -> impl DoubleEndedIterator<Item = (Entity, EntityLocation)> + ExactSizeIterator {
         self.entities.iter().enumerate().map(
             |(archetype_row, &ArchetypeEntity { entity, table_row })| {
                 (

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -1318,6 +1318,13 @@ pub struct EntityLocation {
 /// It is also useful for reserving an id; commands will often allocate an `Entity` but not provide it a location until the command is applied.
 pub type EntityIdLocation = Option<EntityLocation>;
 
+/// An [`Entity`] that has been disabled. This entity will not be found by queries or accessible via other ECS operations, but it's components are still stored in the ECS.
+/// This is useful for temporarily disabling an entity without fully despawning it or invoking archetype moves. This entity keeps track of its location, so it can be re-enabled later.
+pub struct DisabledEntity {
+    pub entity: Entity,
+    pub location: EntityLocation,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -1321,7 +1321,10 @@ pub type EntityIdLocation = Option<EntityLocation>;
 /// An [`Entity`] that has been disabled. This entity will not be found by queries or accessible via other ECS operations, but it's components are still stored in the ECS.
 /// This is useful for temporarily disabling an entity without fully despawning it or invoking archetype moves. This entity keeps track of its location, so it can be re-enabled later.
 pub struct DisabledEntity {
+    /// The disabled entity.
     pub entity: Entity,
+    /// The location of the entity after it was disabled.
+    /// This may not necessarily be it's location when it is re-enabled.
     pub location: EntityLocation,
 }
 

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -1323,9 +1323,9 @@ pub type EntityIdLocation = Option<EntityLocation>;
 pub struct DisabledEntity {
     /// The disabled entity.
     pub entity: Entity,
-    /// The location of the entity after it was disabled.
-    /// This may not necessarily be it's location when it is re-enabled.
-    pub location: EntityLocation,
+    /// The archetype this entity belongs to. This is used to look up the entity
+    /// for re-enabling.
+    pub archetype_id: ArchetypeId,
 }
 
 #[cfg(test)]

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -1725,15 +1725,11 @@ unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
     ) {
         let column = table.get_column(component_id).debug_checked_unwrap();
         let table_data = Some((
-            column.get_data_slice(table.entity_count() as usize).into(),
+            column.get_data_slice(table.len() as usize).into(),
+            column.get_added_ticks_slice(table.len() as usize).into(),
+            column.get_changed_ticks_slice(table.len() as usize).into(),
             column
-                .get_added_ticks_slice(table.entity_count() as usize)
-                .into(),
-            column
-                .get_changed_ticks_slice(table.entity_count() as usize)
-                .into(),
-            column
-                .get_changed_by_slice(table.entity_count() as usize)
+                .get_changed_by_slice(table.len() as usize)
                 .map(Into::into),
         ));
         // SAFETY: set_table is only called when T::STORAGE_TYPE = StorageType::Table
@@ -1931,15 +1927,11 @@ unsafe impl<'__w, T: Component> WorldQuery for &'__w mut T {
     ) {
         let column = table.get_column(component_id).debug_checked_unwrap();
         let table_data = Some((
-            column.get_data_slice(table.entity_count() as usize).into(),
+            column.get_data_slice(table.len() as usize).into(),
+            column.get_added_ticks_slice(table.len() as usize).into(),
+            column.get_changed_ticks_slice(table.len() as usize).into(),
             column
-                .get_added_ticks_slice(table.entity_count() as usize)
-                .into(),
-            column
-                .get_changed_ticks_slice(table.entity_count() as usize)
-                .into(),
-            column
-                .get_changed_by_slice(table.entity_count() as usize)
+                .get_changed_by_slice(table.len() as usize)
                 .map(Into::into),
         ));
         // SAFETY: set_table is only called when T::STORAGE_TYPE = StorageType::Table

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -2746,19 +2746,17 @@ mod tests {
             let mut query = world.query::<&A>();
             let mut iter = query.iter(&world);
             println!(
-                "archetype_entities: {} table_entities: {} current_len: {} current_row: {}",
+                "archetype_entities: {} table_entities: {} current_range: {:?}",
                 iter.cursor.archetype_entities.len(),
                 iter.cursor.table_entities.len(),
-                iter.cursor.current_len,
-                iter.cursor.current_row
+                iter.cursor.current_range,
             );
             _ = iter.next();
             println!(
-                "archetype_entities: {} table_entities: {} current_len: {} current_row: {}",
+                "archetype_entities: {} table_entities: {} current_range: {:?}",
                 iter.cursor.archetype_entities.len(),
                 iter.cursor.table_entities.len(),
-                iter.cursor.current_len,
-                iter.cursor.current_row
+                iter.cursor.current_range,
             );
             println!("{}", iter.sort::<Entity>().len());
         }
@@ -2776,19 +2774,17 @@ mod tests {
             let mut query = world.query::<&Sparse>();
             let mut iter = query.iter(&world);
             println!(
-                "before_next_call: archetype_entities: {} table_entities: {} current_len: {} current_row: {}",
+                "before_next_call: archetype_entities: {} table_entities: {} current_range: {:?}",
                 iter.cursor.archetype_entities.len(),
                 iter.cursor.table_entities.len(),
-                iter.cursor.current_len,
-                iter.cursor.current_row
+                iter.cursor.current_range,
             );
             _ = iter.next();
             println!(
-                "after_next_call: archetype_entities: {} table_entities: {} current_len: {} current_row: {}",
+                "after_next_call: archetype_entities: {} table_entities: {} current_range: {:?}",
                 iter.cursor.archetype_entities.len(),
                 iter.cursor.table_entities.len(),
-                iter.cursor.current_len,
-                iter.cursor.current_row
+                iter.cursor.current_range,
             );
             println!("{}", iter.sort::<Entity>().len());
         }
@@ -2801,19 +2797,17 @@ mod tests {
             let mut query = world.query::<(&A, &Sparse)>();
             let mut iter = query.iter(&world);
             println!(
-                "before_next_call: archetype_entities: {} table_entities: {} current_len: {} current_row: {}",
+                "before_next_call: archetype_entities: {} table_entities: {} current_range: {:?}",
                 iter.cursor.archetype_entities.len(),
                 iter.cursor.table_entities.len(),
-                iter.cursor.current_len,
-                iter.cursor.current_row
+                iter.cursor.current_range,
             );
             _ = iter.next();
             println!(
-                "after_next_call: archetype_entities: {} table_entities: {} current_len: {} current_row: {}",
+                "before_next_call: archetype_entities: {} table_entities: {} current_range: {:?}",
                 iter.cursor.archetype_entities.len(),
                 iter.cursor.table_entities.len(),
-                iter.cursor.current_len,
-                iter.cursor.current_row
+                iter.cursor.current_range,
             );
             println!("{}", iter.sort::<Entity>().len());
         }
@@ -2829,20 +2823,18 @@ mod tests {
             let mut query = world.query::<(&A, &Sparse)>();
             let mut iter = query.iter(&world);
             println!(
-                "before_next_call: archetype_entities: {} table_entities: {} current_len: {} current_row: {}",
+                "before_next_call: archetype_entities: {} table_entities: {} current_range: {:?}",
                 iter.cursor.archetype_entities.len(),
                 iter.cursor.table_entities.len(),
-                iter.cursor.current_len,
-                iter.cursor.current_row
+                iter.cursor.current_range,
             );
             assert!(iter.cursor.table_entities.len() | iter.cursor.archetype_entities.len() == 0);
             _ = iter.next();
             println!(
-                "after_next_call: archetype_entities: {} table_entities: {} current_len: {} current_row: {}",
+                "before_next_call: archetype_entities: {} table_entities: {} current_range: {:?}",
                 iter.cursor.archetype_entities.len(),
                 iter.cursor.table_entities.len(),
-                iter.cursor.current_len,
-                iter.cursor.current_row
+                iter.cursor.current_range,
             );
             assert!(
                 (

--- a/crates/bevy_ecs/src/query/par_iter.rs
+++ b/crates/bevy_ecs/src/query/par_iter.rs
@@ -144,7 +144,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryParIter<'w, 's, D, F> {
                 let archetypes = &self.world.archetypes();
                 id_iter
                     // SAFETY: The if check ensures that matched_storage_ids stores ArchetypeIds
-                    .map(|id| unsafe { archetypes[id.archetype_id].len() })
+                    .map(|id| unsafe { archetypes[id.archetype_id].entity_count() })
                     .max()
             }
             .map(|v| v as usize)

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -1416,9 +1416,9 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
         use arrayvec::ArrayVec;
 
         bevy_tasks::ComputeTaskPool::get().scope(|scope| {
-            // SAFETY: We only access table data that has been registered in `self.component_access`.
-
             use core::ops::Range;
+
+            // SAFETY: We only access table data that has been registered in `self.component_access`.
             let tables = unsafe { &world.storages().tables };
             let archetypes = world.archetypes();
             let mut batch_queue = ArrayVec::new();

--- a/crates/bevy_ecs/src/storage/blob_array.rs
+++ b/crates/bevy_ecs/src/storage/blob_array.rs
@@ -174,10 +174,9 @@ impl BlobArray {
     /// [`Vec::drain`]: alloc::vec::Vec::drain
     pub unsafe fn clear_range(&mut self, range: impl RangeBounds<usize>) {
         let map_bound_or = |bounds: Bound<&usize>, or: usize, start: bool| match (bounds, start) {
-            (Bound::Included(&b), true) => b,
+            (Bound::Included(&b), true) | (Bound::Excluded(&b), false) => b,
             (Bound::Included(&b), false) => b.checked_add(1).expect("range end overflowed"),
             (Bound::Excluded(&b), true) => b.checked_add(1).expect("range start overflowed"),
-            (Bound::Excluded(&b), false) => b,
             (Bound::Unbounded, _) => or,
         };
 

--- a/crates/bevy_ecs/src/storage/resource.rs
+++ b/crates/bevy_ecs/src/storage/resource.rs
@@ -51,7 +51,8 @@ impl<const SEND: bool> Drop for ResourceData<SEND> {
         // been dropped. The validate_access call above will check that the
         // data is dropped on the thread it was inserted from.
         unsafe {
-            self.data.drop(1, self.is_present().into());
+            let len: usize = self.is_present().into();
+            self.data.drop(1, ..len);
         }
     }
 }

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -245,6 +245,11 @@ impl ComponentSparseSet {
                 TableRow::new(unsafe { NonMaxU32::new_unchecked(self.disabled_entities) })
             };
 
+            if dense_row == disabled_row {
+                // nothing to do, the entity is already in the correct section
+                return;
+            }
+
             // SAFETY: TODO
             unsafe {
                 self.dense.swap_unchecked(dense_row, disabled_row);

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -250,7 +250,7 @@ impl ComponentSparseSet {
                 return;
             }
 
-            // SAFETY: TODO
+            // SAFETY: both dense_row and disabled_row are guaranteed to be valid indices
             unsafe {
                 self.dense.swap_unchecked(dense_row, disabled_row);
                 self.entities.swap(dense_row.index(), disabled_row.index());
@@ -261,6 +261,7 @@ impl ComponentSparseSet {
                 #[cfg(not(debug_assertions))]
                 let row_index = *row_index;
 
+                // row_index exists in the sparse array.
                 *self.sparse.get_mut(row_index).debug_checked_unwrap() = dense_row;
 
                 let disabled_row_index = self.entities.get_unchecked(dense_row.index());
@@ -269,6 +270,7 @@ impl ComponentSparseSet {
                 #[cfg(not(debug_assertions))]
                 let disabled_row_index = *disabled_row_index;
 
+                // disabled_row_index exists in the sparse array.
                 *self
                     .sparse
                     .get_mut(disabled_row_index)

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -447,7 +447,7 @@ impl Drop for ComponentSparseSet {
         self.entities.clear();
         // SAFETY: `cap` and `len` are correct. `dense` is never accessed again after this call.
         unsafe {
-            self.dense.drop(self.entities.capacity(), len);
+            self.dense.drop(self.entities.capacity(), len, ..len);
         }
     }
 }

--- a/crates/bevy_ecs/src/storage/table/column.rs
+++ b/crates/bevy_ecs/src/storage/table/column.rs
@@ -309,10 +309,10 @@ impl Column {
     /// # Safety
     /// - `len` must match the actual length of the column
     /// -   The caller must not use the elements this column's data until [`initializing`](Self::initialize) it again (set `len` to 0).
-    pub(crate) unsafe fn clear(&mut self, len: usize) {
+    pub(crate) unsafe fn clear(&mut self, len: usize, range: impl RangeBounds<usize>) {
         self.added_ticks.clear_elements(len);
         self.changed_ticks.clear_elements(len);
-        self.data.clear_range(..len);
+        self.data.clear_range(range);
         self.changed_by
             .as_mut()
             .map(|changed_by| changed_by.clear_elements(len));

--- a/crates/bevy_ecs/src/storage/table/column.rs
+++ b/crates/bevy_ecs/src/storage/table/column.rs
@@ -43,6 +43,23 @@ impl Column {
         }
     }
 
+    /// Swap the two elements.
+    ///
+    /// # Safety
+    /// - `a.as_usize()` < `len`
+    /// - `b.as_usize()` < `len`
+    /// - `a` != `b`
+    pub(crate) unsafe fn swap_unchecked(&mut self, a: TableRow, b: TableRow) {
+        let a = a.index();
+        let b = b.index();
+        self.data.swap_unchecked_nonoverlapping(a, b);
+        self.added_ticks.swap_unchecked_nonoverlapping(a, b);
+        self.changed_ticks.swap_unchecked_nonoverlapping(a, b);
+        self.changed_by.as_mut().map(|changed_by| {
+            changed_by.swap_unchecked_nonoverlapping(a, b);
+        });
+    }
+
     /// Swap-remove and drop the removed element, but the component at `row` must not be the last element.
     ///
     /// # Safety

--- a/crates/bevy_ecs/src/storage/table/column.rs
+++ b/crates/bevy_ecs/src/storage/table/column.rs
@@ -3,8 +3,6 @@ use crate::{
     change_detection::MaybeLocation,
     storage::{blob_array::BlobArray, thin_array_ptr::ThinArrayPtr},
 };
-use alloc::vec::Vec;
-use bevy_ptr::PtrMut;
 use core::{mem::needs_drop, ops::RangeBounds, panic::Location};
 
 /// A type-erased contiguous container for data of a homogeneous type.

--- a/crates/bevy_ecs/src/storage/table/mod.rs
+++ b/crates/bevy_ecs/src/storage/table/mod.rs
@@ -253,7 +253,7 @@ impl Table {
         if row == disabled_row {
             // the entity is already in the correct position, no swap needed
 
-            // SAFETY: TODO
+            // SAFETY: row index is guaranteed to be valid by the caller.
             ((*self.entities.get_unchecked(row.index()), row), None)
         } else {
             for col in self.columns.values_mut() {

--- a/crates/bevy_ecs/src/storage/table/mod.rs
+++ b/crates/bevy_ecs/src/storage/table/mod.rs
@@ -933,7 +933,7 @@ impl Drop for Table {
             // SAFETY: `cap` and `len` are correct. `col` is never accessed again after this call.
             unsafe {
                 // TODO: don't drop disabled entities components
-                col.drop(cap, len);
+                col.drop(cap, len, self.disabled_entities as usize..len);
             }
         }
     }

--- a/crates/bevy_ecs/src/storage/table/mod.rs
+++ b/crates/bevy_ecs/src/storage/table/mod.rs
@@ -758,7 +758,7 @@ impl Table {
         for column in self.columns.values_mut() {
             // SAFETY: we defer `self.entities.clear()` until after clearing the columns,
             // so `self.len()` should match the columns' len
-            unsafe { column.clear(len) };
+            unsafe { column.clear(len, self.disabled_entities as usize..len) };
         }
     }
 

--- a/crates/bevy_ecs/src/storage/thin_array_ptr.rs
+++ b/crates/bevy_ecs/src/storage/thin_array_ptr.rs
@@ -170,6 +170,24 @@ impl<T> ThinArrayPtr<T> {
         }
     }
 
+    /// Perform a [`swap`](https://doc.rust-lang.org/std/primitive.slice.html#method.swap).
+    ///
+    /// # Safety
+    /// - `a` must be safe to access (within the bounds of the length of the array).
+    /// - `b` must be safe to access (within the bounds of the length of the array).
+    /// - `a` != `b`
+    #[inline]
+    pub unsafe fn swap_unchecked_nonoverlapping(&mut self, a: usize, b: usize) {
+        #[cfg(debug_assertions)]
+        {
+            debug_assert!(self.capacity > a);
+            debug_assert!(self.capacity > b);
+            debug_assert_ne!(a, b);
+        }
+        let base_ptr = self.data.as_ptr();
+        ptr::copy_nonoverlapping(base_ptr.add(a), base_ptr.add(b), 1);
+    }
+
     /// Perform a [`swap-remove`](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.swap_remove) and return the removed value.
     ///
     /// # Safety

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -2566,7 +2566,7 @@ impl<'w> EntityWorldMut<'w> {
         let location = self.location();
         let Self { world, entity, .. } = self;
 
-        let _location = {
+        let location = {
             let archetype = &mut world.archetypes[location.archetype_id];
             let ((disabled_arch, archetype_row), swapped_archetype) =
                 archetype.swap_disable(location.archetype_row);
@@ -2631,7 +2631,7 @@ impl<'w> EntityWorldMut<'w> {
         Self {
             world,
             entity,
-            location: None,
+            location: Some(location),
         }
     }
 
@@ -2661,12 +2661,21 @@ impl<'w> EntityWorldMut<'w> {
             .find(|(e, _)| *e == entity)
             .map(|(_, location)| location);
 
-        Self {
+        let entity_mut = Self {
             world,
             entity,
             location,
         }
-        .swap_disable()
+        .swap_disable();
+
+        // SAFETY: TODO
+        unsafe {
+            entity_mut
+                .world
+                .entities
+                .set(entity_mut.entity.index(), entity_mut.location);
+        }
+        entity_mut
     }
 
     /// Disable the current entity.

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -2600,6 +2600,8 @@ impl<'w> EntityWorldMut<'w> {
                     .swap_disable_unchecked(disabled_arch.table_row())
             };
 
+            archetype.set_entity_table_row(archetype_row, table_row);
+
             if let Some((entity, table_row)) = swapped_table {
                 let swapped_location = world.entities.get(entity).unwrap();
 
@@ -2613,6 +2615,7 @@ impl<'w> EntityWorldMut<'w> {
                         }),
                     );
                 }
+                archetype.set_entity_table_row(swapped_location.archetype_row, table_row);
             }
 
             assert_eq!(disabled_table, disabled_arch.id());

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -2615,7 +2615,8 @@ impl<'w> EntityWorldMut<'w> {
                         }),
                     );
                 }
-                archetype.set_entity_table_row(swapped_location.archetype_row, table_row);
+                world.archetypes[swapped_location.archetype_id]
+                    .set_entity_table_row(swapped_location.archetype_row, table_row);
             }
 
             assert_eq!(disabled_table, disabled_arch.id());

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -6,8 +6,8 @@ use crate::{
     change_detection::{MaybeLocation, MutUntyped},
     component::{Component, ComponentId, ComponentTicks, Components, Mutable, StorageType, Tick},
     entity::{
-        ContainsEntity, Entity, EntityCloner, EntityClonerBuilder, EntityEquivalent,
-        EntityIdLocation, EntityLocation, OptIn, OptOut,
+        ContainsEntity, DisabledEntity, Entity, EntityCloner, EntityClonerBuilder,
+        EntityEquivalent, EntityIdLocation, EntityLocation, OptIn, OptOut,
     },
     event::{EntityComponentsTrigger, EntityEvent},
     lifecycle::{Despawn, Remove, Replace, DESPAWN, REMOVE, REPLACE},
@@ -2564,7 +2564,7 @@ impl<'w> EntityWorldMut<'w> {
 
     /// Disable the current entity.
     ///
-    pub fn disable(self) -> EntityLocation {
+    pub fn disable(self) -> DisabledEntity {
         let world = self.world;
 
         let location = world
@@ -2629,7 +2629,10 @@ impl<'w> EntityWorldMut<'w> {
             world.entities.set(self.entity.index(), None);
         }
 
-        location
+        DisabledEntity {
+            entity: self.entity,
+            location,
+        }
     }
 
     pub(crate) fn despawn_with_caller(self, caller: MaybeLocation) {

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -2576,7 +2576,7 @@ impl<'w> EntityWorldMut<'w> {
                 let entity = entity.id();
                 let swapped_location = world.entities.get(entity).unwrap();
 
-                // SAFETY: TODO
+                // SAFETY: `entity` is a valid entity, whose archetype row was just swapped
                 unsafe {
                     world.entities.set(
                         entity.index(),
@@ -2594,7 +2594,7 @@ impl<'w> EntityWorldMut<'w> {
                 sparse_set.swap_disable(self.entity);
             }
 
-            // SAFETY: TODO
+            // SAFETY: `disabled_arch.table_row()` is an in-bounds row as provided by the archetype
             let ((disabled_table, table_row), swapped_table) = unsafe {
                 world.storages.tables[archetype.table_id()]
                     .swap_disable_unchecked(disabled_arch.table_row())
@@ -2605,7 +2605,7 @@ impl<'w> EntityWorldMut<'w> {
             if let Some((entity, table_row)) = swapped_table {
                 let swapped_location = world.entities.get(entity).unwrap();
 
-                // SAFETY: TODO
+                // SAFETY: `entity` is a valid entity, whose table row was just swapped
                 unsafe {
                     world.entities.set(
                         entity.index(),
@@ -2668,7 +2668,8 @@ impl<'w> EntityWorldMut<'w> {
         }
         .swap_disable();
 
-        // SAFETY: TODO
+        // SAFETY: `entity` is a valid entity, and the entity was either just
+        // swapped into this location or was already in it.
         unsafe {
             entity_mut
                 .world
@@ -2691,7 +2692,8 @@ impl<'w> EntityWorldMut<'w> {
 
         self = self.swap_disable();
 
-        // SAFETY: TODO
+        // SAFETY: entity is a valid entity, that has no location anymore due to
+        // being disabled.
         unsafe {
             self.world.entities.set(self.entity.index(), None);
         }

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -2594,6 +2594,12 @@ impl<'w> EntityWorldMut<'w> {
                 }
             }
 
+            for component_id in archetype.sparse_set_components() {
+                // set must have existed for the component to be added.
+                let sparse_set = world.storages.sparse_sets.get_mut(component_id).unwrap();
+                sparse_set.swap_disable(self.entity);
+            }
+
             // SAFETY: TODO
             let ((disabled_table, table_row), swapped_table) = unsafe {
                 world.storages.tables[archetype.table_id()]

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -41,7 +41,7 @@ use crate::{
         ComponentTicks, Components, ComponentsQueuedRegistrator, ComponentsRegistrator, Mutable,
         RequiredComponents, RequiredComponentsError, Tick,
     },
-    entity::{Entities, Entity, EntityDoesNotExistError},
+    entity::{Entities, Entity, EntityDoesNotExistError, EntityLocation},
     entity_disabling::DefaultQueryFilters,
     error::{DefaultErrorHandler, ErrorHandler},
     lifecycle::{ComponentHooks, RemovedComponentMessages, ADD, DESPAWN, INSERT, REMOVE, REPLACE},
@@ -1437,6 +1437,13 @@ impl World {
         let entity = self.get_entity_mut(entity)?;
         entity.despawn_with_caller(caller);
         Ok(())
+    }
+
+    pub fn disable(&mut self, entity: Entity) -> Result<EntityLocation, EntityMutableFetchError> {
+        self.flush();
+
+        let entity = self.get_entity_mut(entity)?;
+        Ok(entity.disable())
     }
 
     /// Clears the internal component tracker state.

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1453,25 +1453,7 @@ impl World {
     pub fn enable(&mut self, disabled: DisabledEntity) -> EntityWorldMut<'_> {
         self.flush();
 
-        let archetype = &self.archetypes[disabled.location.archetype_id];
-        // Find the location of the disabled entity in the archetype by
-        // searching backwards through the disabled entities.
-        // The disabled entity is most likely the last disabled entity, as
-        // is the case when disabled for `entity_scope`.
-        let location = archetype
-            .entities_with_location()
-            .take(archetype.disabled_entities as usize)
-            .rev()
-            .find(|(e, _)| *e == disabled.entity)
-            .map(|(_, location)| location);
-
-        // SAFETY: disabled entity existed when it was disabled, and wasn't
-        // despawned in the meantime.
-        unsafe {
-            self.entities.set(disabled.entity.index(), location);
-        }
-
-        self.entity_mut(disabled.entity)
+        EntityWorldMut::enable(self, disabled)
     }
 
     /// Temporarily disables the requested entity from this [`World`], runs

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1527,7 +1527,8 @@ impl World {
         let mut entity_mut = self.get_entity_mut(entity).ok()?;
         let mut component = {
             let component = entity_mut.get_mut::<C>()?;
-            // SAFETY: TODO
+            // SAFETY: component contains a &mut reference, so it must be
+            // aligned and valid for reads
             unsafe { core::ptr::read::<C>(&raw const *component) }
         };
 
@@ -1544,7 +1545,8 @@ impl World {
         let mut entity_mut = self.enable(disabled);
 
         let mut component_mut = entity_mut.get_mut::<C>().unwrap();
-        // SAFETY: TODO
+        // SAFETY: component contains a &mut reference, so it must be
+        // aligned and valid for writes
         unsafe {
             core::ptr::write::<C>(&raw mut *component_mut, component);
         }

--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -60,7 +60,7 @@ impl DynamicScene {
                 world
                     .archetypes()
                     .iter()
-                    .flat_map(bevy_ecs::archetype::Archetype::entities)
+                    .flat_map(bevy_ecs::archetype::Archetype::enabled_entities)
                     .map(bevy_ecs::archetype::ArchetypeEntity::id),
             )
             .extract_resources()

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -106,7 +106,7 @@ impl Scene {
         // Ensure that all scene entities have been allocated in the destination
         // world before handling components that may contain references that need mapping.
         for archetype in self.world.archetypes().iter() {
-            for scene_entity in archetype.entities() {
+            for scene_entity in archetype.enabled_entities() {
                 entity_map
                     .entry(scene_entity.id())
                     .or_insert_with(|| world.spawn_empty().id());
@@ -114,7 +114,7 @@ impl Scene {
         }
 
         for archetype in self.world.archetypes().iter() {
-            for scene_entity in archetype.entities() {
+            for scene_entity in archetype.enabled_entities() {
                 let entity = *entity_map
                     .get(&scene_entity.id())
                     .expect("should have previously spawned an entity");


### PR DESCRIPTION
# Objective

related: #13128
With Resources-as-Entities, and possibly more *-as-Entities on the horizon, simultaneous mutable access to an entity and the world has and will come up more often: `resource_scope`, for example, needs mutable access to the resource component on the resource entity, and doesn't want the entity to be available for it's scope.

## Solution
I propose the following solution:
Entities can be 'hard' disabled by swapping them into a region at the beginning of their archetype/table and their meta is updated to contain no location.
These regions are skipped by queries and not dropped when the table is removed.
A `component_scope` `ptr::read`s a component onto the stack, then disables the entity and calls the closure with a mutable reference to the stack copy of the component.
After the closure finishes, the stack component is `ptr::write`n back into storage and the entity is enabled: during the scope the component in storage must not be dropped because the scope closure may decide to drop it itself.

A `component_scope` limited to a single component is the simplest and easiest functionality to build here, because we cannot ensure that the table doesn't move the disabled components around or that the table even remains live for the duration of the scope, so we can't give out references to the ECS storage, and can't use `WorldQuery` and related traits to easily retrieve multiple components: this will require some more trait magic ontop of `WorldQuery`, but I think it shouldn't be excessively complicated or unsound.

## Remaining Questions
- Relationships: the relationship hooks unwrap the target entity, which isn't available when disabled, causing a panic.
The `component_scope` closure could be passed `Commands` of some shape onto which to record operations related to the disabled entity.
- Is this actually worth it/cheaper than an archetype move? This still moves components around in the tables, which is most of what an archetype move is. I haven't benchmarked this (and I would need some help properly benchmarking it). Nested `component_scopes` *should* not require a swap when re-enabling the entity, but different functionality build with disabling/enabling *might*.
- Things I've forgotten or overlooked.

## Testing

there are still lots of TODOs in this PR:
- Tests
- Safety comments
- some polishing, probably
- actually implementing the logic that forgets the disabled components

## Alternatives
- Removing components (and possibly despawning the entity), re+inserting/spawning them after the scope.
- I'm spit-balling here but:
Tables might be made up of chunks in which rows are stable across table growth; an entity could be moved to a dedicated chunk, which can be owned by the `entity_scope` to be moved back into the table afterwards. This would probably have a significant performance impact, not to mention the architectural impact.
- Instead of moving components around in tables, keep a bitset indicating enabled-ness
---

## Showcase

```rust
use bevy_ecs::prelude::*;
#[derive(Component)]
struct A(u32);
#[derive(Component)]
struct B(u32);
let mut world = World::new();
let scoped_entity = world.spawn(A(1)).id();
let entity = world.spawn(B(1)).id();

world.component_scope(scoped_entity, |world, _, a: &mut A| {
    assert!(world.get_mut::<A>(scoped_entity).is_none());
    let b = world.get_mut::<B>(entity).unwrap();
    a.0 += b.0;
});
assert_eq!(world.get::<A>(scoped_entity).unwrap().0, 2);
```
