### PR TITLE
Rename bevy_mesh_picking_backend to mesh_picking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,6 @@ default = [
   "bevy_gltf",
   "bevy_input_focus",
   "bevy_log",
-  "bevy_mesh_picking_backend",
   "bevy_pbr",
   "bevy_picking",
   "bevy_render",
@@ -165,6 +164,7 @@ default = [
   "default_font",
   "hdr",
   "ktx2",
+  "mesh_picking",
   "morph",
   "morph_animation",
   "multi_threaded",
@@ -187,7 +187,7 @@ default = [
 default_no_std = ["libm", "critical-section", "bevy_color", "bevy_state"]
 
 # Provides an implementation for picking meshes
-bevy_mesh_picking_backend = ["bevy_internal/bevy_mesh_picking_backend"]
+mesh_picking = ["bevy_internal/mesh_picking"]
 
 # Provides an implementation for picking sprites
 sprite_picking = ["bevy_internal/sprite_picking"]
@@ -2276,7 +2276,7 @@ wasm = false
 name = "error_handling"
 path = "examples/ecs/error_handling.rs"
 doc-scrape-examples = true
-required-features = ["bevy_mesh_picking_backend"]
+required-features = ["mesh_picking"]
 
 [package.metadata.example.error_handling]
 name = "Error handling"
@@ -4351,7 +4351,7 @@ wasm = false
 name = "mesh_picking"
 path = "examples/picking/mesh_picking.rs"
 doc-scrape-examples = true
-required-features = ["bevy_mesh_picking_backend"]
+required-features = ["mesh_picking"]
 
 [package.metadata.example.mesh_picking]
 name = "Mesh Picking"

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -17,9 +17,7 @@ criterion = { version = "0.6.0", features = ["html_reports"] }
 bevy_app = { path = "../crates/bevy_app" }
 bevy_ecs = { path = "../crates/bevy_ecs", features = ["multi_threaded"] }
 bevy_math = { path = "../crates/bevy_math" }
-bevy_picking = { path = "../crates/bevy_picking", features = [
-  "bevy_mesh_picking_backend",
-] }
+bevy_picking = { path = "../crates/bevy_picking", features = ["mesh_picking"] }
 bevy_reflect = { path = "../crates/bevy_reflect", features = ["functions"] }
 bevy_camera = { path = "../crates/bevy_camera" }
 bevy_mesh = { path = "../crates/bevy_mesh" }

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -314,10 +314,7 @@ bevy_remote = ["dep:bevy_remote", "serialize"]
 bevy_picking = ["dep:bevy_picking"]
 
 # Provides a mesh picking backend
-bevy_mesh_picking_backend = [
-  "bevy_picking",
-  "bevy_picking/bevy_mesh_picking_backend",
-]
+mesh_picking = ["bevy_picking", "bevy_picking/mesh_picking"]
 
 # Provides a sprite picking backend
 sprite_picking = ["bevy_picking", "bevy_sprite/bevy_picking"]

--- a/crates/bevy_picking/Cargo.toml
+++ b/crates/bevy_picking/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 
 [features]
 # Provides a mesh picking backend
-bevy_mesh_picking_backend = ["dep:bevy_mesh", "dep:crossbeam-channel"]
+mesh_picking = ["dep:bevy_mesh", "dep:crossbeam-channel"]
 
 [dependencies]
 # bevy

--- a/crates/bevy_picking/src/lib.rs
+++ b/crates/bevy_picking/src/lib.rs
@@ -160,7 +160,7 @@ pub mod backend;
 pub mod events;
 pub mod hover;
 pub mod input;
-#[cfg(feature = "bevy_mesh_picking_backend")]
+#[cfg(feature = "mesh_picking")]
 pub mod mesh_picking;
 pub mod pointer;
 pub mod window;
@@ -174,7 +174,7 @@ use hover::{update_is_directly_hovered, update_is_hovered};
 ///
 /// This includes the most common types in this crate, re-exported for your convenience.
 pub mod prelude {
-    #[cfg(feature = "bevy_mesh_picking_backend")]
+    #[cfg(feature = "mesh_picking")]
     #[doc(hidden)]
     pub use crate::mesh_picking::{
         ray_cast::{MeshRayCast, MeshRayCastSettings, RayCastBackfaces, RayCastVisibility},

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -29,7 +29,6 @@ The default feature set enables most of the expected features of a game engine, 
 |bevy_light|Provides light types such as point lights, directional lights, spotlights.|
 |bevy_log|Enable integration with `tracing` and `log`|
 |bevy_mesh|Provides a mesh format and some primitive meshing routines.|
-|bevy_mesh_picking_backend|Provides an implementation for picking meshes|
 |bevy_mikktspace|Provides vertex tangent generation for use with bevy_mesh.|
 |bevy_pbr|Adds PBR rendering|
 |bevy_picking|Provides picking functionality|
@@ -51,6 +50,7 @@ The default feature set enables most of the expected features of a game engine, 
 |gltf_animation|Enable glTF animation loading|
 |hdr|HDR image format support|
 |ktx2|KTX2 compressed texture support|
+|mesh_picking|Provides an implementation for picking meshes|
 |morph|Enables support for morph target weights in bevy_mesh|
 |morph_animation|Enables bevy_mesh and bevy_animation morph weight support|
 |multi_threaded|Enables multithreaded parallelism in the engine. Disabling it forces all engine tasks to run on a single thread.|

--- a/examples/ecs/error_handling.rs
+++ b/examples/ecs/error_handling.rs
@@ -22,7 +22,7 @@ fn main() {
 
     app.add_plugins(DefaultPlugins);
 
-    #[cfg(feature = "bevy_mesh_picking_backend")]
+    #[cfg(feature = "mesh_picking")]
     app.add_plugins(MeshPickingPlugin);
 
     // Fallible systems can be used the same way as regular systems. The only difference is they

--- a/release-content/migration-guides/feature-cleanup.md
+++ b/release-content/migration-guides/feature-cleanup.md
@@ -1,8 +1,9 @@
 ---
 title: Feature cleanup
-pull_requests: [21388, 21435, 21437]
+pull_requests: [21388, 21435, 21436, 21437]
 ---
 
 `animation` has been renamed to `gltf_animation`.
 `bevy_sprite_picking_backend` has been renamed to `sprite_picking`.
 `bevy_ui_picking_backend` has been renamed to `ui_picking`.
+`bevy_mesh_picking_backend` has been renamed to `mesh_picking`.


### PR DESCRIPTION
# Objective

- Only prefix features bevy_ if they correspond to a crate
- Another step towards #20867

## Solution

- rename it

## Testing

- ci