### PR TITLE
rename bevy_sprite_picking_backend to sprite_picking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,7 +154,6 @@ default = [
   "bevy_light",
   "bevy_shader",
   "bevy_sprite",
-  "bevy_sprite_picking_backend",
   "bevy_sprite_render",
   "bevy_state",
   "bevy_text",
@@ -173,6 +172,7 @@ default = [
   "png",
   "reflect_auto_register",
   "smaa_luts",
+  "sprite_picking",
   "sysinfo_plugin",
   "tonemapping_luts",
   "vorbis",
@@ -190,7 +190,7 @@ default_no_std = ["libm", "critical-section", "bevy_color", "bevy_state"]
 bevy_mesh_picking_backend = ["bevy_internal/bevy_mesh_picking_backend"]
 
 # Provides an implementation for picking sprites
-bevy_sprite_picking_backend = ["bevy_internal/bevy_sprite_picking_backend"]
+sprite_picking = ["bevy_internal/sprite_picking"]
 
 # Provides an implementation for picking UI
 bevy_ui_picking_backend = ["bevy_internal/bevy_ui_picking_backend"]
@@ -4375,7 +4375,7 @@ wasm = true
 name = "sprite_picking"
 path = "examples/picking/sprite_picking.rs"
 doc-scrape-examples = true
-required-features = ["bevy_sprite_picking_backend"]
+required-features = ["sprite_picking"]
 
 [package.metadata.example.sprite_picking]
 name = "Sprite Picking"

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -320,10 +320,7 @@ bevy_mesh_picking_backend = [
 ]
 
 # Provides a sprite picking backend
-bevy_sprite_picking_backend = [
-  "bevy_picking",
-  "bevy_sprite/bevy_sprite_picking_backend",
-]
+sprite_picking = ["bevy_picking", "bevy_sprite/bevy_picking"]
 
 # Provides a UI picking backend
 bevy_ui_picking_backend = ["bevy_picking", "bevy_ui/bevy_ui_picking_backend"]

--- a/crates/bevy_sprite/Cargo.toml
+++ b/crates/bevy_sprite/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [features]
-bevy_sprite_picking_backend = ["bevy_picking", "bevy_window"]
+bevy_picking = ["dep:bevy_picking", "bevy_window"]
 bevy_text = ["dep:bevy_text", "bevy_window"]
 
 [dependencies]

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -10,7 +10,7 @@
 
 extern crate alloc;
 
-#[cfg(feature = "bevy_sprite_picking_backend")]
+#[cfg(feature = "bevy_picking")]
 mod picking_backend;
 mod sprite;
 #[cfg(feature = "bevy_text")]
@@ -21,7 +21,7 @@ mod texture_slice;
 ///
 /// This includes the most common types in this crate, re-exported for your convenience.
 pub mod prelude {
-    #[cfg(feature = "bevy_sprite_picking_backend")]
+    #[cfg(feature = "bevy_picking")]
     #[doc(hidden)]
     pub use crate::picking_backend::{
         SpritePickingCamera, SpritePickingMode, SpritePickingPlugin, SpritePickingSettings,
@@ -44,7 +44,7 @@ use bevy_camera::{
     visibility::VisibilitySystems,
 };
 use bevy_mesh::{Mesh, Mesh2d};
-#[cfg(feature = "bevy_sprite_picking_backend")]
+#[cfg(feature = "bevy_picking")]
 pub use picking_backend::*;
 pub use sprite::*;
 #[cfg(feature = "bevy_text")]
@@ -95,7 +95,7 @@ impl Plugin for SpritePlugin {
                 .after(bevy_app::AnimationSystems),
         );
 
-        #[cfg(feature = "bevy_sprite_picking_backend")]
+        #[cfg(feature = "bevy_picking")]
         app.add_plugins(SpritePickingPlugin);
     }
 }

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -37,7 +37,6 @@ The default feature set enables most of the expected features of a game engine, 
 |bevy_scene|Provides scene functionality|
 |bevy_shader|Provides shaders usable through asset handles.|
 |bevy_sprite|Provides sprite functionality|
-|bevy_sprite_picking_backend|Provides an implementation for picking sprites|
 |bevy_sprite_render|Provides sprite rendering functionality|
 |bevy_state|Enable built in global state machines|
 |bevy_text|Provides text functionality|
@@ -58,6 +57,7 @@ The default feature set enables most of the expected features of a game engine, 
 |png|PNG image format support|
 |reflect_auto_register|Enable automatic reflect registration|
 |smaa_luts|Include SMAA Look Up Tables KTX2 Files|
+|sprite_picking|Provides an implementation for picking sprites|
 |std|Allows access to the `std` crate.|
 |sysinfo_plugin|Enables system information diagnostic plugin|
 |tonemapping_luts|Include tonemapping Look Up Tables KTX2 files. If everything is pink, you need to enable this feature or change the `Tonemapping` method for your `Camera2d` or `Camera3d`.|

--- a/release-content/migration-guides/feature-cleanup.md
+++ b/release-content/migration-guides/feature-cleanup.md
@@ -1,6 +1,7 @@
 ---
 title: Feature cleanup
-pull_requests: [21388]
+pull_requests: [21388, 21437]
 ---
 
 `animation` has been renamed to `gltf_animation`.
+`bevy_sprite_picking_backend` has been renamed to `sprite_picking`.


### PR DESCRIPTION
# Objective

- Only prefix features bevy_ if they correspond to a crate
- Another step towards #20867

## Solution

- rename it

## Testing

- ci