### PR TITLE
`MovingPtr<'_,B: Bundle>` impls Bundle

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -150,20 +150,20 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
         // - `Bundle::get_components` is exactly once for each member. Rely's on the Component -> Bundle implementation to properly pass
         //   the correct `StorageType` into the callback.
         #[allow(deprecated)]
-        unsafe impl #impl_generics #ecs_path::bundle::Bundle for #struct_name #ty_generics #where_clause {
-            type Name = (#(<#active_field_types as #ecs_path::bundle::Bundle>::Name,)*);
+        unsafe impl #impl_generics #ecs_path::bundle::BundleImpl for #struct_name #ty_generics #where_clause {
+            type Name = (#(<#active_field_types as #ecs_path::bundle::BundleImpl>::Name,)*);
             fn component_ids(
                 components: &mut #ecs_path::component::ComponentsRegistrator,
                 ids: &mut impl FnMut(#ecs_path::component::ComponentId)
             ) {
-                #(<#active_field_types as #ecs_path::bundle::Bundle>::component_ids(components, ids);)*
+                #(<#active_field_types as #ecs_path::bundle::BundleImpl>::component_ids(components, ids);)*
             }
 
             fn get_component_ids(
                 components: &#ecs_path::component::Components,
                 ids: &mut impl FnMut(Option<#ecs_path::component::ComponentId>)
             ) {
-                #(<#active_field_types as #ecs_path::bundle::Bundle>::get_component_ids(components, &mut *ids);)*
+                #(<#active_field_types as #ecs_path::bundle::BundleImpl>::get_component_ids(components, &mut *ids);)*
             }
         }
     };

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -151,6 +151,7 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
         //   the correct `StorageType` into the callback.
         #[allow(deprecated)]
         unsafe impl #impl_generics #ecs_path::bundle::Bundle for #struct_name #ty_generics #where_clause {
+            type Name = (#(<#active_field_types as #ecs_path::bundle::Bundle>::Name,)*);
             fn component_ids(
                 components: &mut #ecs_path::component::ComponentsRegistrator,
                 ids: &mut impl FnMut(#ecs_path::component::ComponentId)

--- a/crates/bevy_ecs/src/bundle/impls.rs
+++ b/crates/bevy_ecs/src/bundle/impls.rs
@@ -57,6 +57,8 @@ impl<C: Component> DynamicBundle for C {
     unsafe fn apply_effect(_ptr: MovingPtr<'_, MaybeUninit<Self>>, _entity: &mut EntityWorldMut) {}
 }
 
+// SAFETY: `MovingPtr` forwards its implementation of `Bundle` to another
+// `Bundle`, so it is correct if that impl is correct
 unsafe impl<T: BundleImpl> BundleImpl for MovingPtr<'_, T> {
     type Name = <T as BundleImpl>::Name;
 
@@ -81,7 +83,11 @@ impl<T: DynamicBundle> DynamicBundle for MovingPtr<'_, T> {
         T::get_components(this, func);
     }
 
+    // SAFETY: `MovingPtr` forwards its implementation of `apply_effect` to another
+    // `DynamicBundle`, so it is correct if that impl is correct
     unsafe fn apply_effect(ptr: MovingPtr<'_, MaybeUninit<Self>>, entity: &mut EntityWorldMut) {
+        // SAFETY: the `MovingPtr` is still init, but it's inner value may no
+        // longer be fully init
         let this = unsafe {
             core::mem::transmute::<MaybeUninit<MovingPtr<'_, T>>, MovingPtr<'_, MaybeUninit<T>>>(
                 ptr.read(),

--- a/crates/bevy_ecs/src/bundle/impls.rs
+++ b/crates/bevy_ecs/src/bundle/impls.rs
@@ -14,6 +14,8 @@ use crate::{
 // - `Bundle::component_ids` calls `ids` for C's component id (and nothing else)
 // - `Bundle::get_components` is called exactly once for C and passes the component's storage type based on its associated constant.
 unsafe impl<C: Component> Bundle for C {
+    type Name = C;
+
     fn component_ids(components: &mut ComponentsRegistrator, ids: &mut impl FnMut(ComponentId)) {
         ids(components.register_component::<C>());
     }
@@ -52,6 +54,40 @@ impl<C: Component> DynamicBundle for C {
     unsafe fn apply_effect(_ptr: MovingPtr<'_, MaybeUninit<Self>>, _entity: &mut EntityWorldMut) {}
 }
 
+unsafe impl<T: Bundle + 'static> Bundle for MovingPtr<'_, T> {
+    type Name = <T as Bundle>::Name;
+
+    fn component_ids(components: &mut ComponentsRegistrator, ids: &mut impl FnMut(ComponentId)) {
+        T::component_ids(components, ids);
+    }
+
+    fn get_component_ids(components: &Components, ids: &mut impl FnMut(Option<ComponentId>)) {
+        T::get_component_ids(components, ids);
+    }
+}
+
+impl<T: Bundle> DynamicBundle for MovingPtr<'_, T> {
+    type Effect = T::Effect;
+
+    unsafe fn get_components(
+        ptr: MovingPtr<'_, Self>,
+        func: &mut impl FnMut(StorageType, OwningPtr<'_>),
+    ) {
+        let this = ptr.read();
+
+        T::get_components(this, func);
+    }
+
+    unsafe fn apply_effect(ptr: MovingPtr<'_, MaybeUninit<Self>>, entity: &mut EntityWorldMut) {
+        let this = unsafe {
+            core::mem::transmute::<MaybeUninit<MovingPtr<'_, T>>, MovingPtr<'_, MaybeUninit<T>>>(
+                ptr.read(),
+            )
+        };
+        T::apply_effect(this, entity);
+    }
+}
+
 macro_rules! tuple_impl {
     ($(#[$meta:meta])* $(($index:tt, $name: ident, $alias: ident)),*) => {
         #[expect(
@@ -71,6 +107,7 @@ macro_rules! tuple_impl {
         // - `Bundle::get_components` is called exactly once for each member. Relies on the above implementation to pass the correct
         //   `StorageType` into the callback.
         unsafe impl<$($name: Bundle),*> Bundle for ($($name,)*) {
+            type Name = ($(<$name as Bundle>::Name,)*);
             fn component_ids(components: &mut ComponentsRegistrator,  ids: &mut impl FnMut(ComponentId)){
                 $(<$name as Bundle>::component_ids(components, ids);)*
             }

--- a/crates/bevy_ecs/src/bundle/info.rs
+++ b/crates/bevy_ecs/src/bundle/info.rs
@@ -21,6 +21,8 @@ use crate::{
     storage::{SparseSetIndex, SparseSets, Storages, Table, TableRow},
 };
 
+use super::BundleImpl;
+
 /// For a specific [`World`], this stores a unique value identifying a type of a registered [`Bundle`].
 ///
 /// [`World`]: crate::world::World
@@ -430,7 +432,7 @@ impl Bundles {
     ///
     /// [`World`]: crate::world::World
     #[deny(unsafe_op_in_unsafe_fn)]
-    pub(crate) unsafe fn register_info<T: Bundle>(
+    pub(crate) unsafe fn register_info<T: BundleImpl>(
         &mut self,
         components: &mut ComponentsRegistrator,
         storages: &mut Storages,

--- a/crates/bevy_ecs/src/bundle/info.rs
+++ b/crates/bevy_ecs/src/bundle/info.rs
@@ -414,7 +414,9 @@ impl Bundles {
     }
 
     /// Gets the value identifying a specific bundle.
-    /// You can use [`bundle_id_of`] or [`bundle_id_of_val`](super::bundle_id_of_val) to easily get a bundle's `TypeId`.
+    /// You can use [`bundle_id_of`] or
+    /// [`bundle_id_of_val`](super::bundle_id_of_val) to easily get a bundle's
+    /// [`TypeId`].
     /// Returns `None` if the bundle does not exist in the world,
     /// or if `type_id` does not correspond to a bundle.
     #[inline]

--- a/crates/bevy_ecs/src/bundle/mod.rs
+++ b/crates/bevy_ecs/src/bundle/mod.rs
@@ -15,7 +15,7 @@ pub(crate) use remove::BundleRemover;
 pub(crate) use spawner::BundleSpawner;
 
 use bevy_ptr::MovingPtr;
-use core::mem::MaybeUninit;
+use core::{any::TypeId, mem::MaybeUninit};
 pub use info::*;
 
 /// Derive the [`Bundle`] trait
@@ -197,7 +197,8 @@ use bevy_ptr::OwningPtr;
     label = "invalid `Bundle`",
     note = "consider annotating `{Self}` with `#[derive(Component)]` or `#[derive(Bundle)]`"
 )]
-pub unsafe trait Bundle: DynamicBundle + Send + Sync + 'static {
+pub unsafe trait Bundle: DynamicBundle + Send {
+    type Name: 'static;
     /// Gets this [`Bundle`]'s component ids, in the order of this bundle's [`Component`]s
     #[doc(hidden)]
     fn component_ids(components: &mut ComponentsRegistrator, ids: &mut impl FnMut(ComponentId));
@@ -205,6 +206,16 @@ pub unsafe trait Bundle: DynamicBundle + Send + Sync + 'static {
     /// Gets this [`Bundle`]'s component ids. This will be [`None`] if the component has not been registered.
     fn get_component_ids(components: &Components, ids: &mut impl FnMut(Option<ComponentId>));
 }
+
+pub const fn bundle_id_of<T: Bundle>() -> TypeId {
+    TypeId::of::<T::Name>()
+}
+pub const fn bundle_id_of_val<T: Bundle>(_: &T) -> TypeId {
+    TypeId::of::<T::Name>()
+}
+
+pub trait StaticBundle: Bundle + 'static {}
+impl<T: Bundle + 'static> StaticBundle for T {}
 
 /// Creates a [`Bundle`] by taking it from internal storage.
 ///

--- a/crates/bevy_ecs/src/bundle/mod.rs
+++ b/crates/bevy_ecs/src/bundle/mod.rs
@@ -211,7 +211,7 @@ pub unsafe trait BundleImpl: DynamicBundle + Send + Sync {
 
 /// Retrieves the `TypeId` of the bundle type. Used for registering bundles.
 ///
-/// See also [`Bundle::type_id_of_val`] for retrieving the bundle id without naming the type.
+/// See also [`bundle_id_of_val`] for retrieving the bundle id without naming the type.
 // TODO: make this const in rust 1.92
 pub fn bundle_id_of<T: BundleImpl>() -> TypeId {
     TypeId::of::<T::Name>()
@@ -219,7 +219,7 @@ pub fn bundle_id_of<T: BundleImpl>() -> TypeId {
 
 /// Retrieves the `TypeId` of a bundle when the type may not be easily named. Used for registering bundles.
 ///
-/// See also [`Bundle::type_id`] for retrieving the bundle id without an instance of the bundle.
+/// See also [`bundle_id_of`] for retrieving the bundle id without an instance of the bundle.
 // TODO: make this const in rust 1.92
 pub fn bundle_id_of_val<T: BundleImpl>(_: &T) -> TypeId {
     TypeId::of::<T::Name>()
@@ -388,7 +388,7 @@ pub trait DynamicBundle: Sized {
     ///
     /// For implementors:
     ///  - Implementors of this function must convert `ptr` into pointers to individual components stored within
-    ///    `Self` and call `func` on each of them in exactly the same order as [`Bundle::get_component_ids`] and
+    ///    `Self` and call `func` on each of them in exactly the same order as [`BundleImpl::get_component_ids`] and
     ///    [`BundleFromComponents::from_components`].
     ///  - If any part of `ptr` is to be accessed in `apply_effect`, it must *not* be dropped at any point in this
     ///    function. Calling [`bevy_ptr::deconstruct_moving_ptr`] in this function automatically ensures this.

--- a/crates/bevy_ecs/src/bundle/mod.rs
+++ b/crates/bevy_ecs/src/bundle/mod.rs
@@ -198,6 +198,8 @@ use bevy_ptr::OwningPtr;
     note = "consider annotating `{Self}` with `#[derive(Component)]` or `#[derive(Bundle)]`"
 )]
 pub unsafe trait BundleImpl: DynamicBundle + Send + Sync {
+    /// This type is used to track the identity of this bundle.
+    /// Bundles with an equal `Name` must have equal components.
     type Name: 'static;
     /// Gets this [`Bundle`]'s component ids, in the order of this bundle's [`Component`]s
     #[doc(hidden)]
@@ -207,10 +209,19 @@ pub unsafe trait BundleImpl: DynamicBundle + Send + Sync {
     fn get_component_ids(components: &Components, ids: &mut impl FnMut(Option<ComponentId>));
 }
 
-pub const fn bundle_id_of<T: BundleImpl>() -> TypeId {
+/// Retrieves the `TypeId` of the bundle type. Used for registering bundles.
+///
+/// See also [`Bundle::type_id_of_val`] for retrieving the bundle id without naming the type.
+// TODO: make this const in rust 1.92
+pub fn bundle_id_of<T: BundleImpl>() -> TypeId {
     TypeId::of::<T::Name>()
 }
-pub const fn bundle_id_of_val<T: BundleImpl>(_: &T) -> TypeId {
+
+/// Retrieves the `TypeId` of a bundle when the type may not be easily named. Used for registering bundles.
+///
+/// See also [`Bundle::type_id`] for retrieving the bundle id without an instance of the bundle.
+// TODO: make this const in rust 1.92
+pub fn bundle_id_of_val<T: BundleImpl>(_: &T) -> TypeId {
     TypeId::of::<T::Name>()
 }
 

--- a/crates/bevy_ecs/src/bundle/mod.rs
+++ b/crates/bevy_ecs/src/bundle/mod.rs
@@ -197,7 +197,7 @@ use bevy_ptr::OwningPtr;
     label = "invalid `Bundle`",
     note = "consider annotating `{Self}` with `#[derive(Component)]` or `#[derive(Bundle)]`"
 )]
-pub unsafe trait Bundle: DynamicBundle + Send {
+pub unsafe trait BundleImpl: DynamicBundle + Send + Sync {
     type Name: 'static;
     /// Gets this [`Bundle`]'s component ids, in the order of this bundle's [`Component`]s
     #[doc(hidden)]
@@ -207,15 +207,15 @@ pub unsafe trait Bundle: DynamicBundle + Send {
     fn get_component_ids(components: &Components, ids: &mut impl FnMut(Option<ComponentId>));
 }
 
-pub const fn bundle_id_of<T: Bundle>() -> TypeId {
+pub const fn bundle_id_of<T: BundleImpl>() -> TypeId {
     TypeId::of::<T::Name>()
 }
-pub const fn bundle_id_of_val<T: Bundle>(_: &T) -> TypeId {
+pub const fn bundle_id_of_val<T: BundleImpl>(_: &T) -> TypeId {
     TypeId::of::<T::Name>()
 }
 
-pub trait StaticBundle: Bundle + 'static {}
-impl<T: Bundle + 'static> StaticBundle for T {}
+pub trait Bundle: BundleImpl + 'static {}
+impl<T: BundleImpl + 'static> Bundle for T {}
 
 /// Creates a [`Bundle`] by taking it from internal storage.
 ///

--- a/crates/bevy_ecs/src/bundle/mod.rs
+++ b/crates/bevy_ecs/src/bundle/mod.rs
@@ -77,9 +77,9 @@ use crate::{
 };
 use bevy_ptr::OwningPtr;
 
-/// The `Bundle` trait enables insertion and removal of [`Component`]s from an entity.
+/// The `BundleImpl` trait enables insertion and removal of [`Component`]s from an entity.
 ///
-/// Implementers of the `Bundle` trait are called 'bundles'.
+/// Implementers of the `BundleImpl` trait are called 'bundles'.
 ///
 /// Each bundle represents a static set of [`Component`] types.
 /// Currently, bundles can only contain one of each [`Component`], and will
@@ -225,7 +225,123 @@ pub fn bundle_id_of_val<T: BundleImpl>(_: &T) -> TypeId {
     TypeId::of::<T::Name>()
 }
 
+/// The `Bundle` trait enables insertion and removal of [`Component`]s from an entity.
+///
+/// Implementers of the `Bundle` trait are called 'bundles'.
+///
+/// Each bundle represents a static set of [`Component`] types.
+/// Currently, bundles can only contain one of each [`Component`], and will
+/// panic once initialized if this is not met.
+///
+/// See also: [`BundleImpl`].
+///
+/// ## Insertion
+///
+/// The primary use for bundles is to add a useful collection of components to an entity.
+///
+/// Adding a value of bundle to an entity will add the components from the set it
+/// represents to the entity.
+/// The values of these components are taken from the bundle.
+/// If an entity already had one of these components, the entity's original component value
+/// will be overwritten.
+///
+/// Importantly, bundles are only their constituent set of components.
+/// You **should not** use bundles as a unit of behavior.
+/// The behavior of your app can only be considered in terms of components, as systems,
+/// which drive the behavior of a `bevy` application, operate on combinations of
+/// components.
+///
+/// This rule is also important because multiple bundles may contain the same component type,
+/// calculated in different ways &mdash; adding both of these bundles to one entity
+/// would create incoherent behavior.
+/// This would be unexpected if bundles were treated as an abstraction boundary, as
+/// the abstraction would be unmaintainable for these cases.
+///
+/// For this reason, there is intentionally no [`Query`] to match whether an entity
+/// contains the components of a bundle.
+/// Queries should instead only select the components they logically operate on.
+///
+/// ## Removal
+///
+/// Bundles are also used when removing components from an entity.
+///
+/// Removing a bundle from an entity will remove any of its components attached
+/// to the entity from the entity.
+/// That is, if the entity does not have all the components of the bundle, those
+/// which are present will be removed.
+///
+/// # Implementers
+///
+/// Every type which implements [`Component`] also implements `Bundle`, since
+/// [`Component`] types can be added to or removed from an entity.
+///
+/// Additionally, [Tuples](`tuple`) of bundles are also [`Bundle`] (with up to 15 bundles).
+/// These bundles contain the items of the 'inner' bundles.
+/// This is a convenient shorthand which is primarily used when spawning entities.
+///
+/// [`unit`], otherwise known as [`()`](`unit`), is a [`Bundle`] containing no components (since it
+/// can also be considered as the empty tuple).
+/// This can be useful for spawning large numbers of empty entities using
+/// [`World::spawn_batch`](crate::world::World::spawn_batch).
+///
+/// Tuple bundles can be nested, which can be used to create an anonymous bundle with more than
+/// 15 items.
+/// However, in most cases where this is required, the derive macro [`derive@Bundle`] should be
+/// used instead.
+/// The derived `Bundle` implementation contains the items of its fields, which all must
+/// implement `Bundle`.
+/// As explained above, this includes any [`Component`] type, and other derived bundles.
+///
+/// If you want to add `PhantomData` to your `Bundle` you have to mark it with `#[bundle(ignore)]`.
+/// ```
+/// # use std::marker::PhantomData;
+/// use bevy_ecs::{component::Component, bundle::Bundle};
+///
+/// #[derive(Component)]
+/// struct XPosition(i32);
+/// #[derive(Component)]
+/// struct YPosition(i32);
+///
+/// #[derive(Bundle)]
+/// struct PositionBundle {
+///     // A bundle can contain components
+///     x: XPosition,
+///     y: YPosition,
+/// }
+///
+/// // You have to implement `Default` for ignored field types in bundle structs.
+/// #[derive(Default)]
+/// struct Other(f32);
+///
+/// #[derive(Bundle)]
+/// struct NamedPointBundle<T: Send + Sync + 'static> {
+///     // Or other bundles
+///     a: PositionBundle,
+///     // In addition to more components
+///     z: PointName,
+///
+///     // when you need to use `PhantomData` you have to mark it as ignored
+///     #[bundle(ignore)]
+///     _phantom_data: PhantomData<T>
+/// }
+///
+/// #[derive(Component)]
+/// struct PointName(String);
+/// ```
+///
+/// # Safety
+///
+/// Manual implementations of this trait are unsupported.
+/// That is, there is no safe way to implement this trait, and you must not do so.
+/// If you want a type to implement [`Bundle`], you must use [`derive@Bundle`](derive@Bundle).
+///
+/// [`Component`]: crate::component::Component
+/// [`Query`]: crate::system::Query
 pub trait Bundle: BundleImpl + 'static {}
+
+// Automatically derive `Bundle` for any `'static BundleImpl`; most users don't
+// care for non-'static bundles, and will want to use `Bundle` to benefit
+// from not having to worry about lifetime bounds.
 impl<T: BundleImpl + 'static> Bundle for T {}
 
 /// Creates a [`Bundle`] by taking it from internal storage.

--- a/crates/bevy_ecs/src/bundle/spawner.rs
+++ b/crates/bevy_ecs/src/bundle/spawner.rs
@@ -15,6 +15,8 @@ use crate::{
     world::{unsafe_world_cell::UnsafeWorldCell, World},
 };
 
+use super::BundleImpl;
+
 // SAFETY: We have exclusive world access so our pointers can't be invalidated externally
 pub(crate) struct BundleSpawner<'w> {
     world: UnsafeWorldCell<'w>,
@@ -26,7 +28,7 @@ pub(crate) struct BundleSpawner<'w> {
 
 impl<'w> BundleSpawner<'w> {
     #[inline]
-    pub fn new<T: Bundle>(world: &'w mut World, change_tick: Tick) -> Self {
+    pub fn new<T: BundleImpl>(world: &'w mut World, change_tick: Tick) -> Self {
         let bundle_id = world.register_bundle_info::<T>();
 
         // SAFETY: we initialized this bundle_id in `init_info`

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -158,7 +158,7 @@ pub struct HotPatchChanges;
 #[cfg(test)]
 mod tests {
     use crate::{
-        bundle::Bundle,
+        bundle::{Bundle, BundleImpl},
         change_detection::Ref,
         component::Component,
         entity::{Entity, EntityMapper},
@@ -250,7 +250,7 @@ mod tests {
             y: SparseStored,
         }
         let mut ids = Vec::new();
-        <FooBundle as Bundle>::component_ids(&mut world.components_registrator(), &mut |id| {
+        <FooBundle as BundleImpl>::component_ids(&mut world.components_registrator(), &mut |id| {
             ids.push(id);
         });
 
@@ -300,9 +300,12 @@ mod tests {
         }
 
         let mut ids = Vec::new();
-        <NestedBundle as Bundle>::component_ids(&mut world.components_registrator(), &mut |id| {
-            ids.push(id);
-        });
+        <NestedBundle as BundleImpl>::component_ids(
+            &mut world.components_registrator(),
+            &mut |id| {
+                ids.push(id);
+            },
+        );
 
         assert_eq!(
             ids,
@@ -352,7 +355,7 @@ mod tests {
         }
 
         let mut ids = Vec::new();
-        <BundleWithIgnored as Bundle>::component_ids(
+        <BundleWithIgnored as BundleImpl>::component_ids(
             &mut world.components_registrator(),
             &mut |id| {
                 ids.push(id);

--- a/crates/bevy_ecs/src/spawn.rs
+++ b/crates/bevy_ecs/src/spawn.rs
@@ -298,6 +298,7 @@ pub struct SpawnRelatedBundle<R: Relationship, L: SpawnableList<R>> {
 unsafe impl<R: Relationship, L: SpawnableList<R> + Send + Sync + 'static> Bundle
     for SpawnRelatedBundle<R, L>
 {
+    type Name = <R::RelationshipTarget as Bundle>::Name;
     fn component_ids(
         components: &mut crate::component::ComponentsRegistrator,
         ids: &mut impl FnMut(crate::component::ComponentId),
@@ -390,6 +391,7 @@ impl<R: Relationship, B: Bundle> DynamicBundle for SpawnOneRelated<R, B> {
 
 // SAFETY: This internally relies on the RelationshipTarget's Bundle implementation, which is sound.
 unsafe impl<R: Relationship, B: Bundle> Bundle for SpawnOneRelated<R, B> {
+    type Name = <R::RelationshipTarget as Bundle>::Name;
     fn component_ids(
         components: &mut crate::component::ComponentsRegistrator,
         ids: &mut impl FnMut(crate::component::ComponentId),

--- a/crates/bevy_ecs/src/spawn.rs
+++ b/crates/bevy_ecs/src/spawn.rs
@@ -2,10 +2,10 @@
 //! for the best entry points into these APIs and examples of how to use them.
 
 use crate::{
-    bundle::{Bundle, BundleImpl, DynamicBundle, InsertMode, NoBundleEffect},
+    bundle::{Bundle, BundleImpl, DynamicBundle, NoBundleEffect},
     change_detection::MaybeLocation,
     entity::Entity,
-    relationship::{RelatedSpawner, Relationship, RelationshipHookMode, RelationshipTarget},
+    relationship::{RelatedSpawner, Relationship, RelationshipTarget},
     world::{EntityWorldMut, World},
 };
 use alloc::vec::Vec;

--- a/crates/bevy_ecs/src/spawn.rs
+++ b/crates/bevy_ecs/src/spawn.rs
@@ -2,7 +2,7 @@
 //! for the best entry points into these APIs and examples of how to use them.
 
 use crate::{
-    bundle::{Bundle, DynamicBundle, InsertMode, NoBundleEffect},
+    bundle::{Bundle, BundleImpl, DynamicBundle, InsertMode, NoBundleEffect},
     change_detection::MaybeLocation,
     entity::Entity,
     relationship::{RelatedSpawner, Relationship, RelationshipHookMode, RelationshipTarget},
@@ -80,16 +80,16 @@ impl<R: Relationship, B: Bundle> SpawnableList<R> for Spawn<B> {
                 let Spawn { 0: bundle } = this;
             });
 
-            let r = R::from(entity);
+            let r = (R::from(entity), bundle);
             move_as_ptr!(r);
-            let mut entity = world.spawn_with_caller(r, caller);
+            world.spawn_with_caller(r, caller);
 
-            entity.insert_with_caller(
-                bundle,
-                InsertMode::Replace,
-                caller,
-                RelationshipHookMode::Run,
-            );
+            // entity.insert_with_caller(
+            //     bundle,
+            //     InsertMode::Replace,
+            //     caller,
+            //     RelationshipHookMode::Run,
+            // );
         }
 
         spawn::<B, R>(this, world, entity);
@@ -295,22 +295,22 @@ pub struct SpawnRelatedBundle<R: Relationship, L: SpawnableList<R>> {
 }
 
 // SAFETY: This internally relies on the RelationshipTarget's Bundle implementation, which is sound.
-unsafe impl<R: Relationship, L: SpawnableList<R> + Send + Sync + 'static> Bundle
+unsafe impl<R: Relationship, L: SpawnableList<R> + Send + Sync + 'static> BundleImpl
     for SpawnRelatedBundle<R, L>
 {
-    type Name = <R::RelationshipTarget as Bundle>::Name;
+    type Name = <R::RelationshipTarget as BundleImpl>::Name;
     fn component_ids(
         components: &mut crate::component::ComponentsRegistrator,
         ids: &mut impl FnMut(crate::component::ComponentId),
     ) {
-        <R::RelationshipTarget as Bundle>::component_ids(components, ids);
+        <R::RelationshipTarget as BundleImpl>::component_ids(components, ids);
     }
 
     fn get_component_ids(
         components: &crate::component::Components,
         ids: &mut impl FnMut(Option<crate::component::ComponentId>),
     ) {
-        <R::RelationshipTarget as Bundle>::get_component_ids(components, ids);
+        <R::RelationshipTarget as BundleImpl>::get_component_ids(components, ids);
     }
 }
 
@@ -390,20 +390,20 @@ impl<R: Relationship, B: Bundle> DynamicBundle for SpawnOneRelated<R, B> {
 }
 
 // SAFETY: This internally relies on the RelationshipTarget's Bundle implementation, which is sound.
-unsafe impl<R: Relationship, B: Bundle> Bundle for SpawnOneRelated<R, B> {
-    type Name = <R::RelationshipTarget as Bundle>::Name;
+unsafe impl<R: Relationship, B: Bundle> BundleImpl for SpawnOneRelated<R, B> {
+    type Name = <R::RelationshipTarget as BundleImpl>::Name;
     fn component_ids(
         components: &mut crate::component::ComponentsRegistrator,
         ids: &mut impl FnMut(crate::component::ComponentId),
     ) {
-        <R::RelationshipTarget as Bundle>::component_ids(components, ids);
+        <R::RelationshipTarget as BundleImpl>::component_ids(components, ids);
     }
 
     fn get_component_ids(
         components: &crate::component::Components,
         ids: &mut impl FnMut(Option<crate::component::ComponentId>),
     ) {
-        <R::RelationshipTarget as Bundle>::get_component_ids(components, ids);
+        <R::RelationshipTarget as BundleImpl>::get_component_ids(components, ids);
     }
 }
 

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -1129,7 +1129,9 @@ mod tests {
                 let archetype = archetypes.get(location.archetype_id).unwrap();
                 let archetype_components = archetype.components();
                 let bundle_id = bundles
-                    .get_id(TypeId::of::<(W<i32>, W<bool>)>())
+                    .get_id(TypeId::of::<
+                        <(W<i32>, W<bool>) as crate::bundle::Bundle>::Name,
+                    >())
                     .expect("Bundle used to spawn entity should exist");
                 let bundle_info = bundles.get(bundle_id).unwrap();
                 let mut bundle_components = bundle_info.contributed_components().to_vec();

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -403,7 +403,7 @@ mod tests {
 
     use crate::{
         archetype::Archetypes,
-        bundle::Bundles,
+        bundle::{bundle_id_of, Bundles},
         change_detection::DetectChanges,
         component::{Component, Components},
         entity::{Entities, Entity},
@@ -1129,9 +1129,7 @@ mod tests {
                 let archetype = archetypes.get(location.archetype_id).unwrap();
                 let archetype_components = archetype.components();
                 let bundle_id = bundles
-                    .get_id(TypeId::of::<
-                        <(W<i32>, W<bool>) as crate::bundle::Bundle>::Name,
-                    >())
+                    .get_id(bundle_id_of::<(W<i32>, W<bool>)>())
                     .expect("Bundle used to spawn entity should exist");
                 let bundle_info = bundles.get(bundle_id).unwrap();
                 let mut bundle_components = bundle_info.contributed_components().to_vec();

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -32,8 +32,8 @@ pub use spawn_batch::*;
 use crate::{
     archetype::{ArchetypeId, Archetypes},
     bundle::{
-        Bundle, BundleId, BundleInfo, BundleInserter, BundleSpawner, Bundles, InsertMode,
-        NoBundleEffect,
+        Bundle, BundleId, BundleImpl, BundleInfo, BundleInserter, BundleSpawner, Bundles,
+        InsertMode, NoBundleEffect,
     },
     change_detection::{MaybeLocation, MutUntyped, TicksMut},
     component::{
@@ -1156,7 +1156,7 @@ impl World {
         self.spawn_with_caller(bundle, MaybeLocation::caller())
     }
 
-    pub(crate) fn spawn_with_caller<B: Bundle>(
+    pub(crate) fn spawn_with_caller<B: BundleImpl>(
         &mut self,
         bundle: MovingPtr<'_, B>,
         caller: MaybeLocation,
@@ -3085,14 +3085,14 @@ impl World {
     /// This is largely equivalent to calling [`register_component`](Self::register_component) on each
     /// component in the bundle.
     #[inline]
-    pub fn register_bundle<B: Bundle>(&mut self) -> &BundleInfo {
+    pub fn register_bundle<B: BundleImpl>(&mut self) -> &BundleInfo {
         let id = self.register_bundle_info::<B>();
 
         // SAFETY: We just initialized the bundle so its id should definitely be valid.
         unsafe { self.bundles.get(id).debug_checked_unwrap() }
     }
 
-    pub(crate) fn register_bundle_info<B: Bundle>(&mut self) -> BundleId {
+    pub(crate) fn register_bundle_info<B: BundleImpl>(&mut self) -> BundleId {
         // SAFETY: These come from the same world. `Self.components_registrator` can't be used since we borrow other fields too.
         let mut registrator =
             unsafe { ComponentsRegistrator::new(&mut self.components, &mut self.component_ids) };

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -807,7 +807,10 @@ impl<T, A: IsAligned> Drop for MovingPtr<'_, T, A> {
     }
 }
 
+// These traits aren't auto-implemented as `MovingPtr` contains a raw pointer:
+// SAFETY: MovingPtr<T> owns the value it points to and so it is `Send` if `T` is `Send`.
 unsafe impl<T: Send, A: IsAligned> Send for MovingPtr<'_, T, A> {}
+// SAFETY: MovingPtr<T> owns the value it points to and so it is `Sync` if `T` is `Sync`.
 unsafe impl<T: Sync, A: IsAligned> Sync for MovingPtr<'_, T, A> {}
 
 impl<'a, A: IsAligned> Ptr<'a, A> {

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -807,6 +807,9 @@ impl<T, A: IsAligned> Drop for MovingPtr<'_, T, A> {
     }
 }
 
+unsafe impl<T: Send, A: IsAligned> Send for MovingPtr<'_, T, A> {}
+unsafe impl<T: Sync, A: IsAligned> Sync for MovingPtr<'_, T, A> {}
+
 impl<'a, A: IsAligned> Ptr<'a, A> {
     /// Creates a new instance from a raw pointer.
     ///

--- a/crates/bevy_ui_widgets/src/observe.rs
+++ b/crates/bevy_ui_widgets/src/observe.rs
@@ -5,7 +5,7 @@
 use core::marker::PhantomData;
 
 use bevy_ecs::{
-    bundle::{Bundle, DynamicBundle},
+    bundle::{Bundle, BundleImpl, DynamicBundle},
     event::EntityEvent,
     system::IntoObserverSystem,
 };
@@ -22,8 +22,9 @@ unsafe impl<
         B: Bundle,
         M: Send + Sync + 'static,
         I: IntoObserverSystem<E, B, M> + Send + Sync,
-    > Bundle for AddObserver<E, B, M, I>
+    > BundleImpl for AddObserver<E, B, M, I>
 {
+    type Name = Self;
     #[inline]
     fn component_ids(
         _components: &mut bevy_ecs::component::ComponentsRegistrator,


### PR DESCRIPTION
(I messed up by renaming the branch and I couldn't figure out how to change the branch and reopen #20984)
relevant issue: #20976

## Solution
In order to spawn bundles inside `MovingPtr`s alongside other bundles, we need to be able to name `MovingPtr` as a bundle, which the new associated type `Name` on `Bundle` allows. This type is basically a canonicalized bundle name-type that allows types like `SpawnRelatedBundle` to appear to the `Bundles` as if they were the bundle they are wrapping: `R::RelationshipTarget`. (I need to write tests for this).

Other parts of the engine, like observers, rely on `Bundle` being `'static` in order to pass around the type without being constrained by lifetimes, which is why I've renamed `Bundle` to `BundleImpl` and made `trait Bundle: BundleImpl + 'static`.
Not sure how much I like this personally. 
Observers only use the associated trait functions of `Bundle` which shouldn't be affected by the lifetime of the type implementing `Bundle` (I think).
An alternative would be to enforce `Bundle::Name` to impl Bundle itself (which it does, since it's just a tuple of bundles) and have the same components/component order as `Self` so that `Bundle`s methods are available `'static` (though using `DynamicBundle` this way would certainly be unsafe). That could allow types carrying `Bundles` in phantom datas to use the associated functions for component order and ids.

## Alternative Solutions
@james7132 pointed out the [typeid](https://docs.rs/typeid/1.0.3/typeid/) crate, which is already in the dependency graph, and which allows getting `TypeId`s from non-static types, notably at the cost of [dynamic dispatch](https://docs.rs/typeid/1.0.3/src/typeid/lib.rs.html#220). This could allow for a simple trait method that returns the type id rather than using the associated type `Name`.
Note:
As far as I can tell, rustc can inline the dynamic dispatch here into a static call to `core::any::TypeId::of`, meaning there is potentially no added cost to using `typeid`.
<details>
  <summary>Click to expand</summary>
  
```rust
fn main() {
    struct X {
        a: u32,
        b: u64,
    }
    let x = X { a: 1, b: 2 };
    move_as_ptr!(x);
    let _x = black_box(get_typeid_of(x));
    assert_eq!(TypeId::of::<X>(), _x);
}

fn get_typeid_of<T: Debug>(_: T) -> TypeId {
    typeid::of::<T>()
}
```
disassembly:
```asm
playground::main:
	.cfi_startproc
	sub rsp, 88
	.cfi_def_cfa_offset 96
	movups xmm0, xmmword ptr [rip + .Lanon.e23240f1cfa1af806bfe11aec7d94188.5]
	movaps xmmword ptr [rsp], xmm0
	mov rax, rsp
	#APP
	#NO_APP
	movups xmm0, xmmword ptr [rip + .Lanon.e23240f1cfa1af806bfe11aec7d94188.0]
	movaps xmmword ptr [rsp + 16], xmm0
	movdqa xmm0, xmmword ptr [rsp]
	pcmpeqb xmm0, xmmword ptr [rip + .LCPI0_0]
	pmovmskb eax, xmm0
	cmp eax, 65535
	jne .LBB0_2
	add rsp, 88
	.cfi_def_cfa_offset 8
	ret
```
</details>

