### PR TITLE
Add a conversion factor for MouseScrollUnit and use in camera controller

### DIFF
--- a/crates/bevy_camera_controller/src/free_cam.rs
+++ b/crates/bevy_camera_controller/src/free_cam.rs
@@ -118,7 +118,7 @@ impl Default for FreeCam {
             keyboard_key_toggle_cursor_grab: KeyCode::KeyM,
             walk_speed: 5.0,
             run_speed: 15.0,
-            scroll_factor: 0.1,
+            scroll_factor: 0.5,
             friction: 0.5,
             pitch: 0.0,
             yaw: 0.0,

--- a/crates/bevy_camera_controller/src/free_cam.rs
+++ b/crates/bevy_camera_controller/src/free_cam.rs
@@ -190,7 +190,9 @@ pub fn run_freecam_controller(
 
     let amount = match accumulated_mouse_scroll.unit {
         MouseScrollUnit::Line => accumulated_mouse_scroll.delta.y,
-        MouseScrollUnit::Pixel => accumulated_mouse_scroll.delta.y / 16.0,
+        MouseScrollUnit::Pixel => {
+            accumulated_mouse_scroll.delta.y / MouseScrollUnit::SCROLL_UNIT_CONVERSION_FACTOR
+        }
     };
     scroll += amount;
     controller.walk_speed += scroll * controller.scroll_factor * controller.walk_speed;

--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -137,6 +137,18 @@ pub enum MouseScrollUnit {
     Pixel,
 }
 
+impl MouseScrollUnit {
+    /// An approximate conversion factor to account for the difference between
+    /// [`MouseScrollUnit::Line`] and [`MouseScrollUnit::Pixel`].
+    ///
+    /// Each line corresponds to many pixels; this must be corrected for in order to ensure that
+    /// mouse wheel controls are scaled properly regardless of the provided input events for the end user.
+    ///
+    /// This value is correct for Microsoft Edge, but its validity has not been broadly tested.
+    /// Please file an issue if you find that this differs on certain platforms or hardware!
+    pub const SCROLL_UNIT_CONVERSION_FACTOR: f32 = 100.;
+}
+
 /// A mouse wheel event.
 ///
 /// This event is the translated version of the `WindowEvent::MouseWheel` from the `winit` crate.


### PR DESCRIPTION
# Objective

As noted in https://github.com/bevyengine/bevy/pull/20215#issuecomment-3099068564 by @BigWingBeat, the conversion factor used in the free cam camera controller code that was added in #11921 arbitrary and untested.

This is a problem that users have stumbled across elsewhere, including in #21140 and myself when writing leafwing-input-manager!

## Solution

1. Define a constant with the correct conversion factor, at least as reported in #21140. This goes in `bevy_input` as it's broadly useful.
2. Use that constant in bevy_camera_controller::free_cam.
3. Approximately scale the default value on the camera controller to compensate.

## Testing

We use this controller in a number of our examples. I chose `3d_gizmos`, which worked just about the same before and after. The scroll wheel controls your "walking speed".
