### PR TITLE
Reduce default sensitivity for free_cam controller

### DIFF
--- a/crates/bevy_camera_controller/src/free_cam.rs
+++ b/crates/bevy_camera_controller/src/free_cam.rs
@@ -106,7 +106,7 @@ impl Default for FreeCam {
         Self {
             enabled: true,
             initialized: false,
-            sensitivity: 1.0,
+            sensitivity: 0.2,
             key_forward: KeyCode::KeyW,
             key_back: KeyCode::KeyS,
             key_left: KeyCode::KeyA,


### PR DESCRIPTION
# Objective

As pointed out by @BigWingBeat in 
https://github.com/bevyengine/bevy/pull/20215#issuecomment-3099726369 the default mouse sensitivity of the free_cam controller is crazy high.

## Solution

Divide the sensitivity value by 5. 10 was too much, but 5 feels about right for a "careful and controlled scene editor".

## Testing

`cargo run --example 3d_gizmos --features="free_cam"`