### PR TITLE
MovingPtr<'_,B: Bundle> impls Bundle but with `typeid`

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1392,7 +1392,7 @@ impl App {
     ///     }
     /// });
     /// ```
-    pub fn add_observer<E: Event, B: Bundle, M>(
+    pub fn add_observer<E: Event, B: Bundle + 'static, M>(
         &mut self,
         observer: impl IntoObserverSystem<E, B, M>,
     ) -> &mut Self {

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -100,6 +100,7 @@ bevy_platform = { path = "../bevy_platform", version = "0.19.0-dev", default-fea
   "alloc",
 ] }
 
+typeid = { version = "1" }
 bitflags = { version = "2.3", default-features = false }
 fixedbitset = { version = "0.5", default-features = false }
 serde = { version = "1", default-features = false, features = [

--- a/crates/bevy_ecs/src/bundle/impls.rs
+++ b/crates/bevy_ecs/src/bundle/impls.rs
@@ -11,13 +11,15 @@ use crate::{
 };
 
 // SAFETY: `MovingPtr` forwards its implementation of `Bundle` to another `Bundle`, so it is correct if that impl is correct
-unsafe impl<B: Bundle> Bundle for MovingPtr<'_, B> {
-    fn component_ids(components: &mut ComponentsRegistrator, ids: &mut impl FnMut(ComponentId)) {
-        B::component_ids(components, ids);
+unsafe impl<'a, B: Bundle> Bundle for MovingPtr<'a, B> {
+    fn component_ids(
+        components: &mut ComponentsRegistrator,
+    ) -> impl Iterator<Item = ComponentId> + use<'a, B> {
+        B::component_ids(components)
     }
 
-    fn get_component_ids(components: &Components, ids: &mut impl FnMut(Option<ComponentId>)) {
-        B::get_component_ids(components, ids);
+    fn get_component_ids(components: &Components) -> impl Iterator<Item = Option<ComponentId>> {
+        B::get_component_ids(components)
     }
 }
 

--- a/crates/bevy_ecs/src/bundle/info.rs
+++ b/crates/bevy_ecs/src/bundle/info.rs
@@ -10,7 +10,7 @@ use indexmap::{IndexMap, IndexSet};
 
 use crate::{
     archetype::{Archetype, BundleComponentStatus, ComponentStatus},
-    bundle::{Bundle, DynamicBundle},
+    bundle::{bundle_id_of, Bundle, DynamicBundle},
     change_detection::{MaybeLocation, Tick},
     component::{
         ComponentId, Components, ComponentsRegistrator, RequiredComponentConstructor, StorageType,
@@ -434,7 +434,7 @@ impl Bundles {
         storages: &mut Storages,
     ) -> BundleId {
         let bundle_infos = &mut self.bundle_infos;
-        *self.bundle_ids.entry(TypeId::of::<T>()).or_insert_with(|| {
+        *self.bundle_ids.entry(bundle_id_of::<T>()).or_insert_with(|| {
             let component_ids = T::component_ids(components).collect::<Vec<_>>();
             let id = BundleId(bundle_infos.len());
             let bundle_info =
@@ -463,7 +463,11 @@ impl Bundles {
         components: &mut ComponentsRegistrator,
         storages: &mut Storages,
     ) -> BundleId {
-        if let Some(id) = self.contributed_bundle_ids.get(&TypeId::of::<T>()).cloned() {
+        if let Some(id) = self
+            .contributed_bundle_ids
+            .get(&bundle_id_of::<T>())
+            .cloned()
+        {
             id
         } else {
             // SAFETY: as per the guarantees of this function, components and
@@ -483,7 +487,7 @@ impl Bundles {
                 // part of init_dynamic_info. No mutable references will be created and the allocation will remain valid.
                 self.init_dynamic_info(storages, components, core::slice::from_raw_parts(ptr, len))
             };
-            self.contributed_bundle_ids.insert(TypeId::of::<T>(), id);
+            self.contributed_bundle_ids.insert(bundle_id_of::<T>(), id);
             id
         }
     }

--- a/crates/bevy_ecs/src/bundle/mod.rs
+++ b/crates/bevy_ecs/src/bundle/mod.rs
@@ -214,12 +214,16 @@ pub unsafe trait Bundle: DynamicBundle + Send + Sync {
     fn get_component_ids(components: &Components) -> impl Iterator<Item = Option<ComponentId>>;
 }
 
-/// Returns the `TypeId` of the bundle `T`.
+/// Retrieves the `TypeId` of the bundle type. Used for registering bundles.
+///
+/// See also [`bundle_id_of_val`] for retrieving the bundle id without naming the type.
 pub fn bundle_id_of<T: Bundle>() -> TypeId {
     typeid::of::<T>()
 }
 
-/// Returns the `TypeId` of the bundle type of the value `val`.
+/// Retrieves the `TypeId` of a bundle when the type may not be easily named. Used for registering bundles.
+///
+/// See also [`bundle_id_of`] for retrieving the bundle id without an instance of the bundle.
 pub fn bundle_id_of_val<T: Bundle>(val: T) -> TypeId {
     _ = val;
     typeid::of::<T>()

--- a/crates/bevy_ecs/src/bundle/mod.rs
+++ b/crates/bevy_ecs/src/bundle/mod.rs
@@ -217,14 +217,14 @@ pub unsafe trait Bundle: DynamicBundle + Send + Sync {
 /// Retrieves the `TypeId` of the bundle type. Used for registering bundles.
 ///
 /// See also [`bundle_id_of_val`] for retrieving the bundle id without naming the type.
-pub fn bundle_id_of<T: Bundle>() -> TypeId {
+pub fn bundle_id_of<T: DynamicBundle>() -> TypeId {
     typeid::of::<T>()
 }
 
 /// Retrieves the `TypeId` of a bundle when the type may not be easily named. Used for registering bundles.
 ///
 /// See also [`bundle_id_of`] for retrieving the bundle id without an instance of the bundle.
-pub fn bundle_id_of_val<T: Bundle>(val: T) -> TypeId {
+pub fn bundle_id_of_val<T: DynamicBundle>(val: T) -> TypeId {
     _ = val;
     typeid::of::<T>()
 }

--- a/crates/bevy_ecs/src/bundle/mod.rs
+++ b/crates/bevy_ecs/src/bundle/mod.rs
@@ -20,7 +20,7 @@ pub(crate) use remove::BundleRemover;
 pub(crate) use spawner::BundleSpawner;
 
 use bevy_ptr::MovingPtr;
-use core::mem::MaybeUninit;
+use core::{any::TypeId, mem::MaybeUninit};
 pub use info::*;
 
 /// Derive the [`Bundle`] trait
@@ -202,7 +202,7 @@ use bevy_ptr::OwningPtr;
     label = "invalid `Bundle`",
     note = "consider annotating `{Self}` with `#[derive(Component)]` or `#[derive(Bundle)]`"
 )]
-pub unsafe trait Bundle: DynamicBundle + Send + Sync + 'static {
+pub unsafe trait Bundle: DynamicBundle + Send + Sync {
     /// Gets this [`Bundle`]'s component ids, in the order of this bundle's [`Component`]s
     /// This will register the component if it doesn't exist.
     #[doc(hidden)]
@@ -212,6 +212,17 @@ pub unsafe trait Bundle: DynamicBundle + Send + Sync + 'static {
 
     /// Return a iterator over this [`Bundle`]'s component ids. This will be [`None`] if the component has not been registered.
     fn get_component_ids(components: &Components) -> impl Iterator<Item = Option<ComponentId>>;
+}
+
+/// Returns the `TypeId` of the bundle `T`.
+pub fn bundle_id_of<T: Bundle>() -> TypeId {
+    typeid::of::<T>()
+}
+
+/// Returns the `TypeId` of the bundle type of the value `val`.
+pub fn bundle_id_of_val<T: Bundle>(val: T) -> TypeId {
+    _ = val;
+    typeid::of::<T>()
 }
 
 /// Creates a [`Bundle`] by taking it from internal storage.

--- a/crates/bevy_ecs/src/bundle/tests.rs
+++ b/crates/bevy_ecs/src/bundle/tests.rs
@@ -1,3 +1,5 @@
+use bevy_ptr::move_as_ptr;
+
 use crate::{
     archetype::ArchetypeCreated, lifecycle::HookContext, prelude::*, world::DeferredWorld,
 };
@@ -262,4 +264,14 @@ struct Ignore {
     foo: i32,
     #[bundle(ignore)]
     bar: i32,
+}
+
+#[test]
+fn moving_ptr_bundle() {
+    let mut world = World::new();
+    let v = V("yogurt");
+    move_as_ptr!(v);
+
+    let e1 = world.spawn((v, B)).id();
+    assert_eq!(world.entity(e1).get::<V>(), Some(&V("yogurt")));
 }

--- a/crates/bevy_ecs/src/hierarchy.rs
+++ b/crates/bevy_ecs/src/hierarchy.rs
@@ -484,7 +484,7 @@ impl<'a> EntityCommands<'a> {
     /// For efficient spawning of multiple children, use [`with_children`].
     ///
     /// [`with_children`]: EntityCommands::with_children
-    pub fn with_child(&mut self, bundle: impl Bundle) -> &mut Self {
+    pub fn with_child(&mut self, bundle: impl Bundle + 'static) -> &mut Self {
         self.with_related::<ChildOf>(bundle);
         self
     }

--- a/crates/bevy_ecs/src/observer/distributed_storage.rs
+++ b/crates/bevy_ecs/src/observer/distributed_storage.rs
@@ -216,7 +216,9 @@ impl Observer {
     /// # Panics
     ///
     /// Panics if the given system is an exclusive system.
-    pub fn new<E: Event, B: Bundle, M, I: IntoObserverSystem<E, B, M>>(system: I) -> Self {
+    pub fn new<E: Event, B: Bundle + 'static, M, I: IntoObserverSystem<E, B, M>>(
+        system: I,
+    ) -> Self {
         let system = Box::new(IntoObserverSystem::into_system(system));
         assert!(
             !system.is_exclusive(),
@@ -427,7 +429,7 @@ impl ObserverDescriptor {
 /// The type parameters of this function _must_ match those used to create the [`Observer`].
 /// As such, it is recommended to only use this function within the [`Observer::new`] method to
 /// ensure type parameters match.
-fn hook_on_add<E: Event, B: Bundle, S: ObserverSystem<E, B>>(
+fn hook_on_add<E: Event, B: Bundle + 'static, S: ObserverSystem<E, B>>(
     mut world: DeferredWorld<'_>,
     HookContext { entity, .. }: HookContext,
 ) {

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -51,7 +51,7 @@ impl World {
     /// # Panics
     ///
     /// Panics if the given system is an exclusive system.
-    pub fn add_observer<E: Event, B: Bundle, M>(
+    pub fn add_observer<E: Event, B: Bundle + 'static, M>(
         &mut self,
         system: impl IntoObserverSystem<E, B, M>,
     ) -> EntityWorldMut<'_> {

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -32,7 +32,11 @@ pub type ObserverRunner =
 // NOTE: The way `Trigger` and `On` interact in this implementation is _subtle_ and _easily invalidated_
 // from a soundness perspective. Please read and understand the safety comments before making any changes,
 // either here or in `On`.
-pub(super) unsafe fn observer_system_runner<E: Event, B: Bundle, S: ObserverSystem<E, B>>(
+pub(super) unsafe fn observer_system_runner<
+    E: Event,
+    B: Bundle + 'static,
+    S: ObserverSystem<E, B>,
+>(
     mut world: DeferredWorld,
     observer: Entity,
     trigger_context: &TriggerContext,

--- a/crates/bevy_ecs/src/relationship/related_methods.rs
+++ b/crates/bevy_ecs/src/relationship/related_methods.rs
@@ -409,7 +409,7 @@ impl<'w> EntityWorldMut<'w> {
 
 impl<'a> EntityCommands<'a> {
     /// Spawns a entity related to this entity (with the `R` relationship) by taking a bundle
-    pub fn with_related<R: Relationship>(&mut self, bundle: impl Bundle) -> &mut Self {
+    pub fn with_related<R: Relationship>(&mut self, bundle: impl Bundle + 'static) -> &mut Self {
         let parent = self.id();
         self.commands.spawn((bundle, R::from(parent)));
         self
@@ -539,7 +539,7 @@ impl<'a> EntityCommands<'a> {
     /// Any cycles will cause this method to loop infinitely.
     pub fn insert_recursive<S: RelationshipTarget>(
         &mut self,
-        bundle: impl Bundle + Clone,
+        bundle: impl Bundle + Clone + 'static,
     ) -> &mut Self {
         self.queue(move |mut entity: EntityWorldMut| {
             entity.insert_recursive::<S>(bundle);
@@ -626,7 +626,7 @@ impl<'w, R: Relationship> RelatedSpawnerCommands<'w, R> {
 
     /// Spawns an entity with the given `bundle` and an `R` relationship targeting the `target`
     /// entity this spawner was initialized with.
-    pub fn spawn(&mut self, bundle: impl Bundle) -> EntityCommands<'_> {
+    pub fn spawn(&mut self, bundle: impl Bundle + 'static) -> EntityCommands<'_> {
         self.commands.spawn((R::from(self.target), bundle))
     }
 

--- a/crates/bevy_ecs/src/system/commands/entity_command.rs
+++ b/crates/bevy_ecs/src/system/commands/entity_command.rs
@@ -109,7 +109,7 @@ where
 
 /// An [`EntityCommand`] that adds the components in a [`Bundle`] to an entity.
 #[track_caller]
-pub fn insert(bundle: impl Bundle, mode: InsertMode) -> impl EntityCommand {
+pub fn insert(bundle: impl Bundle + 'static, mode: InsertMode) -> impl EntityCommand {
     let caller = MaybeLocation::caller();
     move |mut entity: EntityWorldMut| {
         move_as_ptr!(bundle);
@@ -252,7 +252,7 @@ pub fn despawn() -> impl EntityCommand {
 /// watching for an [`EntityEvent`] of type `E` whose [`EntityEvent::event_target`]
 /// targets this entity.
 #[track_caller]
-pub fn observe<E: EntityEvent, B: Bundle, M>(
+pub fn observe<E: EntityEvent, B: Bundle + 'static, M>(
     observer: impl IntoObserverSystem<E, B, M>,
 ) -> impl EntityCommand {
     let caller = MaybeLocation::caller();

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -397,7 +397,7 @@ impl<'w, 's> Commands<'w, 's> {
     /// - [`spawn_batch`](Self::spawn_batch) to spawn many entities
     ///   with the same combination of components.
     #[track_caller]
-    pub fn spawn<T: Bundle>(&mut self, bundle: T) -> EntityCommands<'_> {
+    pub fn spawn<T: Bundle + 'static>(&mut self, bundle: T) -> EntityCommands<'_> {
         let entity = self.allocator.alloc();
         let caller = MaybeLocation::caller();
         self.queue(move |world: &mut World| {
@@ -1174,7 +1174,7 @@ impl<'w, 's> Commands<'w, 's> {
     /// Panics if the given system is an exclusive system.
     ///
     /// [`On`]: crate::observer::On
-    pub fn add_observer<E: Event, B: Bundle, M>(
+    pub fn add_observer<E: Event, B: Bundle + 'static, M>(
         &mut self,
         observer: impl IntoObserverSystem<E, B, M>,
     ) -> EntityCommands<'_> {
@@ -1412,7 +1412,7 @@ impl<'a> EntityCommands<'a> {
     /// # bevy_ecs::system::assert_is_system(add_combat_stats_system);
     /// ```
     #[track_caller]
-    pub fn insert(&mut self, bundle: impl Bundle) -> &mut Self {
+    pub fn insert(&mut self, bundle: impl Bundle + 'static) -> &mut Self {
         self.queue(entity_command::insert(bundle, InsertMode::Replace))
     }
 
@@ -1441,7 +1441,7 @@ impl<'a> EntityCommands<'a> {
     /// # bevy_ecs::system::assert_is_system(add_health_system);
     /// ```
     #[track_caller]
-    pub fn insert_if<F>(&mut self, bundle: impl Bundle, condition: F) -> &mut Self
+    pub fn insert_if<F>(&mut self, bundle: impl Bundle + 'static, condition: F) -> &mut Self
     where
         F: FnOnce() -> bool,
     {
@@ -1460,7 +1460,7 @@ impl<'a> EntityCommands<'a> {
     /// See also [`entry`](Self::entry), which lets you modify a [`Component`] if it's present,
     /// as well as initialize it with a default value.
     #[track_caller]
-    pub fn insert_if_new(&mut self, bundle: impl Bundle) -> &mut Self {
+    pub fn insert_if_new(&mut self, bundle: impl Bundle + 'static) -> &mut Self {
         self.queue(entity_command::insert(bundle, InsertMode::Keep))
     }
 
@@ -1470,7 +1470,7 @@ impl<'a> EntityCommands<'a> {
     /// This is the same as [`EntityCommands::insert_if`], but in case of duplicate
     /// components will leave the old values instead of replacing them with new ones.
     #[track_caller]
-    pub fn insert_if_new_and<F>(&mut self, bundle: impl Bundle, condition: F) -> &mut Self
+    pub fn insert_if_new_and<F>(&mut self, bundle: impl Bundle + 'static, condition: F) -> &mut Self
     where
         F: FnOnce() -> bool,
     {
@@ -1581,7 +1581,7 @@ impl<'a> EntityCommands<'a> {
     /// # bevy_ecs::system::assert_is_system(add_combat_stats_system);
     /// ```
     #[track_caller]
-    pub fn try_insert(&mut self, bundle: impl Bundle) -> &mut Self {
+    pub fn try_insert(&mut self, bundle: impl Bundle + 'static) -> &mut Self {
         self.queue_silenced(entity_command::insert(bundle, InsertMode::Replace))
     }
 
@@ -1594,7 +1594,7 @@ impl<'a> EntityCommands<'a> {
     /// If the entity does not exist when this command is executed,
     /// the resulting error will be ignored.
     #[track_caller]
-    pub fn try_insert_if<F>(&mut self, bundle: impl Bundle, condition: F) -> &mut Self
+    pub fn try_insert_if<F>(&mut self, bundle: impl Bundle + 'static, condition: F) -> &mut Self
     where
         F: FnOnce() -> bool,
     {
@@ -1616,7 +1616,11 @@ impl<'a> EntityCommands<'a> {
     /// If the entity does not exist when this command is executed,
     /// the resulting error will be ignored.
     #[track_caller]
-    pub fn try_insert_if_new_and<F>(&mut self, bundle: impl Bundle, condition: F) -> &mut Self
+    pub fn try_insert_if_new_and<F>(
+        &mut self,
+        bundle: impl Bundle + 'static,
+        condition: F,
+    ) -> &mut Self
     where
         F: FnOnce() -> bool,
     {
@@ -1637,7 +1641,7 @@ impl<'a> EntityCommands<'a> {
     /// If the entity does not exist when this command is executed,
     /// the resulting error will be ignored.
     #[track_caller]
-    pub fn try_insert_if_new(&mut self, bundle: impl Bundle) -> &mut Self {
+    pub fn try_insert_if_new(&mut self, bundle: impl Bundle + 'static) -> &mut Self {
         self.queue_silenced(entity_command::insert(bundle, InsertMode::Keep))
     }
 
@@ -2032,7 +2036,7 @@ impl<'a> EntityCommands<'a> {
 
     /// Creates an [`Observer`] watching for an [`EntityEvent`] of type `E` whose [`EntityEvent::event_target`]
     /// targets this entity.
-    pub fn observe<E: EntityEvent, B: Bundle, M>(
+    pub fn observe<E: EntityEvent, B: Bundle + 'static, M>(
         &mut self,
         observer: impl IntoObserverSystem<E, B, M>,
     ) -> &mut Self {

--- a/crates/bevy_ecs/src/world/entity_access/world_mut.rs
+++ b/crates/bevy_ecs/src/world/entity_access/world_mut.rs
@@ -1200,7 +1200,7 @@ impl<'w> EntityWorldMut<'w> {
     /// If the entity has been despawned while this `EntityWorldMut` is still alive.
     #[must_use]
     #[track_caller]
-    pub fn take<T: Bundle + BundleFromComponents>(&mut self) -> Option<T> {
+    pub fn take<T: Bundle + BundleFromComponents + 'static>(&mut self) -> Option<T> {
         let location = self.location();
         let entity = self.entity;
 
@@ -1878,14 +1878,14 @@ impl<'w> EntityWorldMut<'w> {
     ///
     /// Panics if the given system is an exclusive system.
     #[track_caller]
-    pub fn observe<E: EntityEvent, B: Bundle, M>(
+    pub fn observe<E: EntityEvent, B: Bundle + 'static, M>(
         &mut self,
         observer: impl IntoObserverSystem<E, B, M>,
     ) -> &mut Self {
         self.observe_with_caller(observer, MaybeLocation::caller())
     }
 
-    pub(crate) fn observe_with_caller<E: EntityEvent, B: Bundle, M>(
+    pub(crate) fn observe_with_caller<E: EntityEvent, B: Bundle + 'static, M>(
         &mut self,
         observer: impl IntoObserverSystem<E, B, M>,
         caller: MaybeLocation,

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -807,7 +807,10 @@ impl<T, A: IsAligned> Drop for MovingPtr<'_, T, A> {
     }
 }
 
+// These traits aren't auto-implemented as `MovingPtr` contains a raw pointer:
+// SAFETY: MovingPtr<T> owns the value it points to and so it is `Send` if `T` is `Send`.
 unsafe impl<T: Send, A: IsAligned> Send for MovingPtr<'_, T, A> {}
+// SAFETY: MovingPtr<T> owns the value it points to and so it is `Sync` if `T` is `Sync`.
 unsafe impl<T: Sync, A: IsAligned> Sync for MovingPtr<'_, T, A> {}
 
 impl<'a, A: IsAligned> Ptr<'a, A> {

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -807,6 +807,9 @@ impl<T, A: IsAligned> Drop for MovingPtr<'_, T, A> {
     }
 }
 
+unsafe impl<T: Send, A: IsAligned> Send for MovingPtr<'_, T, A> {}
+unsafe impl<T: Sync, A: IsAligned> Sync for MovingPtr<'_, T, A> {}
+
 impl<'a, A: IsAligned> Ptr<'a, A> {
     /// Creates a new instance from a raw pointer.
     ///

--- a/crates/bevy_ui_widgets/src/observe.rs
+++ b/crates/bevy_ui_widgets/src/observe.rs
@@ -11,7 +11,7 @@ use bevy_ecs::{
 };
 
 /// Helper struct that adds an observer when inserted as a [`Bundle`].
-pub struct AddObserver<E: EntityEvent, B: Bundle, M, I: IntoObserverSystem<E, B, M>> {
+pub struct AddObserver<E: EntityEvent, B: Bundle + 'static, M, I: IntoObserverSystem<E, B, M>> {
     observer: I,
     marker: PhantomData<(E, B, M)>,
 }
@@ -19,7 +19,7 @@ pub struct AddObserver<E: EntityEvent, B: Bundle, M, I: IntoObserverSystem<E, B,
 // SAFETY: Empty method bodies.
 unsafe impl<
         E: EntityEvent,
-        B: Bundle,
+        B: Bundle + 'static,
         M: Send + Sync + 'static,
         I: IntoObserverSystem<E, B, M> + Send + Sync,
     > Bundle for AddObserver<E, B, M, I>
@@ -41,7 +41,7 @@ unsafe impl<
     }
 }
 
-impl<E: EntityEvent, B: Bundle, M, I: IntoObserverSystem<E, B, M>> DynamicBundle
+impl<E: EntityEvent, B: Bundle + 'static, M, I: IntoObserverSystem<E, B, M>> DynamicBundle
     for AddObserver<E, B, M, I>
 {
     type Effect = Self;
@@ -70,7 +70,7 @@ impl<E: EntityEvent, B: Bundle, M, I: IntoObserverSystem<E, B, M>> DynamicBundle
 }
 
 /// Adds an observer as a bundle effect.
-pub fn observe<E: EntityEvent, B: Bundle, M, I: IntoObserverSystem<E, B, M>>(
+pub fn observe<E: EntityEvent, B: Bundle + 'static, M, I: IntoObserverSystem<E, B, M>>(
     observer: I,
 ) -> AddObserver<E, B, M, I> {
     AddObserver {

--- a/examples/3d/color_grading.rs
+++ b/examples/3d/color_grading.rs
@@ -159,7 +159,10 @@ fn add_buttons(commands: &mut Commands, font: &Handle<Font>, color_grading: &Col
 
 /// Adds the buttons for the global controls (those that control the scene as a
 /// whole as opposed to shadows, midtones, or highlights).
-fn buttons_for_global_controls(color_grading: &ColorGrading, font: &Handle<Font>) -> impl Bundle {
+fn buttons_for_global_controls(
+    color_grading: &ColorGrading,
+    font: &Handle<Font>,
+) -> impl Bundle + use<> + 'static {
     let make_button = |option: SelectedGlobalColorGradingOption| {
         button_for_value(
             SelectedColorGradingOption::Global(option),
@@ -190,7 +193,7 @@ fn buttons_for_section(
     section: SelectedColorGradingSection,
     color_grading: &ColorGrading,
     font: &Handle<Font>,
-) -> impl Bundle {
+) -> impl Bundle + 'static {
     let make_button = |option| {
         button_for_value(
             SelectedColorGradingOption::Section(section, option),
@@ -229,7 +232,7 @@ fn button_for_value(
     option: SelectedColorGradingOption,
     color_grading: &ColorGrading,
     font: &Handle<Font>,
-) -> impl Bundle {
+) -> impl Bundle + use<> + 'static {
     let label = match option {
         SelectedColorGradingOption::Global(option) => option.to_string(),
         SelectedColorGradingOption::Section(_, option) => option.to_string(),

--- a/examples/helpers/widgets.rs
+++ b/examples/helpers/widgets.rs
@@ -65,7 +65,7 @@ pub fn option_button<T>(
     is_selected: bool,
     is_first: bool,
     is_last: bool,
-) -> impl Bundle
+) -> impl Bundle + use<T>
 where
     T: Clone + Send + Sync + 'static,
 {
@@ -113,7 +113,7 @@ where
 /// The user may change the setting to any one of the labeled `options`. The
 /// value of the given type parameter will be packaged up and sent as a
 /// [`WidgetClickEvent`] when one of the radio buttons is clicked.
-pub fn option_buttons<T>(title: &str, options: &[(T, &str)]) -> impl Bundle
+pub fn option_buttons<T>(title: &str, options: &[(T, &str)]) -> impl Bundle + use<T>
 where
     T: Clone + Send + Sync + 'static,
 {

--- a/examples/no_std/library/src/lib.rs
+++ b/examples/no_std/library/src/lib.rs
@@ -74,11 +74,11 @@ impl Plugin for DelayedComponentPlugin {
 /// Extension trait providing [`insert_delayed`](EntityCommandsExt::insert_delayed).
 pub trait EntityCommandsExt {
     /// Insert the provided [`Bundle`] `B` with a provided `delay`.
-    fn insert_delayed<B: Bundle>(&mut self, bundle: B, delay: Duration) -> &mut Self;
+    fn insert_delayed<B: Bundle + 'static>(&mut self, bundle: B, delay: Duration) -> &mut Self;
 }
 
 impl EntityCommandsExt for EntityCommands<'_> {
-    fn insert_delayed<B: Bundle>(&mut self, bundle: B, delay: Duration) -> &mut Self {
+    fn insert_delayed<B: Bundle + 'static>(&mut self, bundle: B, delay: Duration) -> &mut Self {
         self.insert((
             DelayedComponentTimer(Timer::new(delay, TimerMode::Once)),
             DelayedComponent(bundle),
@@ -88,7 +88,7 @@ impl EntityCommandsExt for EntityCommands<'_> {
 }
 
 impl EntityCommandsExt for EntityWorldMut<'_> {
-    fn insert_delayed<B: Bundle>(&mut self, bundle: B, delay: Duration) -> &mut Self {
+    fn insert_delayed<B: Bundle + 'static>(&mut self, bundle: B, delay: Duration) -> &mut Self {
         self.insert((
             DelayedComponentTimer(Timer::new(delay, TimerMode::Once)),
             DelayedComponent(bundle),
@@ -125,7 +125,7 @@ fn tick_timers(
     }
 }
 
-fn unwrap<B: Bundle>(event: On<Unwrap>, world: &mut World) {
+fn unwrap<B: Bundle + 'static>(event: On<Unwrap>, world: &mut World) {
     if let Ok(mut target) = world.get_entity_mut(event.event_target())
         && let Some(DelayedComponent(bundle)) = target.take::<DelayedComponent<B>>()
     {

--- a/examples/ui/box_shadow.rs
+++ b/examples/ui/box_shadow.rs
@@ -293,7 +293,7 @@ fn build_setting_row(
     inc: SettingsButton,
     value: f32,
     asset_server: &Res<AssetServer>,
-) -> impl Bundle {
+) -> impl Bundle + use<> {
     let value_text = match setting_type {
         SettingType::Shape => SHAPES[value as usize % SHAPES.len()].0.to_string(),
         SettingType::Count => format!("{}", value as usize),

--- a/examples/ui/button.rs
+++ b/examples/ui/button.rs
@@ -70,7 +70,7 @@ fn setup(mut commands: Commands, assets: Res<AssetServer>) {
     commands.spawn(button(&assets));
 }
 
-fn button(asset_server: &AssetServer) -> impl Bundle {
+fn button(asset_server: &AssetServer) -> impl Bundle + use<> {
     (
         Node {
             width: percent(100),

--- a/examples/ui/standard_widgets.rs
+++ b/examples/ui/standard_widgets.rs
@@ -224,7 +224,7 @@ fn button(asset_server: &AssetServer) -> impl Bundle + use<> + 'static {
     )
 }
 
-fn menu_button(asset_server: &AssetServer) -> impl Bundle {
+fn menu_button(asset_server: &AssetServer) -> impl Bundle + use<> + 'static {
     (
         Node { ..default() },
         DemoMenuAnchor,
@@ -879,7 +879,7 @@ fn spawn_menu(anchor: Entity, assets: Res<AssetServer>, mut commands: Commands) 
     commands.entity(anchor).add_child(menu);
 }
 
-fn menu_item(asset_server: &AssetServer) -> impl Bundle {
+fn menu_item(asset_server: &AssetServer) -> impl Bundle + use<> + 'static {
     (
         Node {
             padding: UiRect::axes(px(8), px(2)),

--- a/examples/ui/standard_widgets.rs
+++ b/examples/ui/standard_widgets.rs
@@ -143,7 +143,7 @@ fn setup(mut commands: Commands, assets: Res<AssetServer>) {
     commands.spawn(demo_root(&assets));
 }
 
-fn demo_root(asset_server: &AssetServer) -> impl Bundle {
+fn demo_root(asset_server: &AssetServer) -> impl Bundle + use<> + 'static {
     (
         Node {
             width: percent(100),
@@ -194,7 +194,7 @@ fn demo_root(asset_server: &AssetServer) -> impl Bundle {
     )
 }
 
-fn button(asset_server: &AssetServer) -> impl Bundle {
+fn button(asset_server: &AssetServer) -> impl Bundle + use<> + 'static {
     (
         Node {
             width: px(150),
@@ -523,7 +523,7 @@ fn thumb_color(disabled: bool, hovered: bool) -> Color {
 }
 
 /// Create a demo checkbox
-fn checkbox(asset_server: &AssetServer, caption: &str) -> impl Bundle {
+fn checkbox(asset_server: &AssetServer, caption: &str) -> impl Bundle + use<> + 'static {
     (
         Node {
             display: Display::Flex,
@@ -715,7 +715,7 @@ fn set_checkbox_or_radio_style(
 }
 
 /// Create a demo radio group
-fn radio_group(asset_server: &AssetServer) -> impl Bundle {
+fn radio_group(asset_server: &AssetServer) -> impl Bundle + use<> + 'static {
     (
         Node {
             display: Display::Flex,
@@ -736,7 +736,11 @@ fn radio_group(asset_server: &AssetServer) -> impl Bundle {
 }
 
 /// Create a demo radio button
-fn radio(asset_server: &AssetServer, value: TrackClick, caption: &str) -> impl Bundle {
+fn radio(
+    asset_server: &AssetServer,
+    value: TrackClick,
+    caption: &str,
+) -> impl Bundle + use<> + 'static {
     (
         Node {
             display: Display::Flex,

--- a/examples/ui/standard_widgets_observers.rs
+++ b/examples/ui/standard_widgets_observers.rs
@@ -90,7 +90,7 @@ fn setup(mut commands: Commands, assets: Res<AssetServer>) {
     commands.spawn(demo_root(&assets));
 }
 
-fn demo_root(asset_server: &AssetServer) -> impl Bundle {
+fn demo_root(asset_server: &AssetServer) -> impl Bundle + use<> + 'static {
     (
         Node {
             width: percent(100),
@@ -128,7 +128,7 @@ fn demo_root(asset_server: &AssetServer) -> impl Bundle {
     )
 }
 
-fn button(asset_server: &AssetServer) -> impl Bundle {
+fn button(asset_server: &AssetServer) -> impl Bundle + use<> + 'static {
     (
         Node {
             width: px(150),
@@ -332,7 +332,7 @@ fn thumb_color(disabled: bool, hovered: bool) -> Color {
 }
 
 /// Create a demo checkbox
-fn checkbox(asset_server: &AssetServer, caption: &str) -> impl Bundle {
+fn checkbox(asset_server: &AssetServer, caption: &str) -> impl Bundle + use<> + 'static {
     (
         Node {
             display: Display::Flex,

--- a/release-content/migration-guides/movingptr_bundle.md
+++ b/release-content/migration-guides/movingptr_bundle.md
@@ -1,0 +1,39 @@
+---
+title: Implement `Bundle` for `MovingPtr<'_, B: Bundle>`
+pull_requests: [21454]
+---
+
+`MovingPtr<'_, B: Bundle>` now implements the `Bundle` trait.
+`MovingPtr<'_, B: Bundle>` can also be part of another bundle, such as a tuple bundle:
+
+```rust
+fn assert_bundle<B: Bundle>() {}
+assert_bundle::<Transform>();
+assert_bundle::<MovingPtr<'_, Transform>>();
+assert_bundle::<(Name, MovingPtr<'_, Transform>)>();
+```
+
+Implementers of traits such as `SpawnableList`, which work with `MovingPtr`s, can now spawn bundles directly from a `MovingPtr<'_, B: Bundle>` rather than having to copy the bundle to the stack first.
+
+```rust
+struct MyList<B: Bundle> {
+    bundle: B
+}
+
+// Previously
+fn spawn(this: MovingPtr<'_, Self>, world: &mut World, entity: Entity) {
+    deconstruct_moving_ptr!({
+        let MyList { bundle } = this;
+    });
+    let bundle = bundle.read();
+    world.spawn((bundle, R::from(entity)));
+}
+
+// Now
+fn spawn(this: MovingPtr<'_, Self>, world: &mut World, entity: Entity) {
+    deconstruct_moving_ptr!({
+        let MyList { bundle } = this;
+    });
+    world.spawn((bundle, R::from(entity)));
+}
+```

--- a/release-content/migration-guides/movingptr_bundle.md
+++ b/release-content/migration-guides/movingptr_bundle.md
@@ -1,5 +1,5 @@
 ---
-title: Implement `Bundle` for `MovingPtr<'_, B: Bundle>`
+title: Implement `Bundle` for `MovingPtr`
 pull_requests: [21454]
 ---
 


### PR DESCRIPTION
This is an alternative solution to #20976

# Objective
Users using `MovingPtr` bundles, or implementing bundle-related types that have to deal with `MovingPtr`s of bundles currently have to copy the bundle onto the stack before they can spawn or insert it, mostly negating the benefits from #20772.

## Solution
By implementing `Bundle` for `MovingPtr<B: Bundle>`, bundles can be spawned with the existing API, including as parts of other bundles, like `(R::from(entity), bundle_ptr)`.
In order to implement `Bundle` for any `MovingPtr<'_, B: Bundle>` we have to remove the `'static` bound on `Bundle`, which is possible when using `typeid` to get the bundle's unique identifier, as suggested by @james7132.
Internally, `typeid` uses dynamic dispatch to go from a `T: 'a` to a `T: 'static` to call `TypeId::of` on, but it appears as if rustc is able to de-virtualise this call. This should, however, **definitely be benchmarked** before this PR is merged.

A number of users of `Bundle` require `Bundle + 'static` now, which means a surprisingly wide diff, including for upgrading users of bevy_ecs. Some of the examples have also revealed that could lead to confusing error messages and requires frequent use of `use<>` when using the `fn() -> impl Bundle` pattern to prevent rustc from pulling in unrelated lifetimes.
This could be simplified by renaming the bundle trait and providing a trait alias `trait Bundle: BikeshedBundleName + 'static` which retains the previous bounds on `Bundle`; in this case, only implementers of the Bundle trait would be directly impacted (see  #21443 and #19491, which factors out some of `Bundle` into another trait, as a reference).

## Alternatives
 #21443