### PR TITLE
Trait tag for Message

### DIFF
--- a/docs-rs/trait-tags.html
+++ b/docs-rs/trait-tags.html
@@ -13,6 +13,7 @@
         'Resource',
         'Asset',
         'Event',
+        'Message',
         'ScheduleLabel',
         'SystemSet',
         'SystemParam',
@@ -136,7 +137,7 @@
 
     .component-tag,
     .immutable-component-tag {
-        --tag-color: oklch(50% 27% 95);
+        --tag-color: oklch(50% 27% 80);
     }
 
     .resource-tag {
@@ -151,6 +152,10 @@
         --tag-color: oklch(50% 27% 310);
     }
 
+    .message-tag {
+        --tag-color: oklch(50% 27% 190);
+    }
+
     .plugin-tag,
     .plugingroup-tag {
         --tag-color: oklch(50% 27% 50);
@@ -162,7 +167,7 @@
     }
 
     .systemparam-tag {
-        --tag-color: oklch(50% 27% 200);
+        --tag-color: oklch(50% 27% 240);
     }
 
     .relationship-tag,


### PR DESCRIPTION
Found by JMS55:
> Hey, I think we regressed the doc labels
The tags that we have for events, components, resources, etc
They don't account for the message/event split

## Showcase

<img width="610" height="109" alt="Screenshot from 2025-10-08 18-50-30" src="https://github.com/user-attachments/assets/1e605c09-575e-49a5-a92f-4024d82852be" />
<img width="613" height="106" alt="Screenshot from 2025-10-08 18-50-17" src="https://github.com/user-attachments/assets/dc64d745-a3b8-4e29-bf0c-508ee829ec77" />
<img width="606" height="108" alt="Screenshot from 2025-10-08 18-48-58" src="https://github.com/user-attachments/assets/dde2af49-9b54-4bbb-9ab3-fa66d699a28f" />
