### PR TITLE
Change friction behavior in freecam to use smooth nudge #21455 

### DIFF
--- a/crates/bevy_camera_controller/src/free_cam.rs
+++ b/crates/bevy_camera_controller/src/free_cam.rs
@@ -23,7 +23,7 @@ use bevy_input::mouse::{
 };
 use bevy_input::ButtonInput;
 use bevy_log::info;
-use bevy_math::{ops, EulerRot, Quat, StableInterpolate, Vec2, Vec3};
+use bevy_math::{EulerRot, Quat, StableInterpolate, Vec2, Vec3};
 use bevy_time::{Real, Time};
 use bevy_transform::prelude::Transform;
 use bevy_window::{CursorGrabMode, CursorOptions, Window};
@@ -119,7 +119,7 @@ impl Default for FreeCam {
             walk_speed: 5.0,
             run_speed: 15.0,
             scroll_factor: 0.5,
-            friction: 10.0,
+            friction: 40.0,
             pitch: 0.0,
             yaw: 0.0,
             velocity: Vec3::ZERO,


### PR DESCRIPTION
# Objective
- Fixes #21455 
- Change the behavior of freecam to use smooth nudge instead of an exponential, per-frame fall off

## Solution
- As written, the freecam's velocity decays by half every loop.  
- Instead, I used smooth_nudge, which takes the time difference into account so that its behavior isn't depended on the fixed main loop's hz. 
- The freecam plugin took a f32 that defaulted to 0.5, and was written so lower numbers would have faster decay. In smooth nudge terms, you could describe this as 64 log 2 at the fixed time step of 64 hz, which is a decay rate of around 44.3. 
- I used 40.0 as this seems like an easily understandable default. 
- This is a breaking change because now higher numbers (instead of lower numbers) supplied to `friction`, will increase the decay rate. However, all of the examples that use freecamplugin relied on the default() friction value, and it was only recently added, so I think this is okay.

## Testing

- I tested this change in the examples that use freecam; 
---