### PR TITLE
Fix feature flags for solari and meshlets examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1427,7 +1427,7 @@ wasm = false
 name = "meshlet"
 path = "examples/3d/meshlet.rs"
 doc-scrape-examples = true
-required-features = ["meshlet", "https"]
+required-features = ["meshlet", "https", "free_cam"]
 
 [package.metadata.example.meshlet]
 name = "Meshlet"


### PR DESCRIPTION
# Objective

The `solari` example does not compile when run with the required-features following #20215.

## Solution

Require the new free_cam feature.

## Testing

`cargo build --example solari --features="bevy_solari https free_cam"`