### PR TITLE
`FreeCam`: stop cursor from remaining grabbed when camera controller is disabled

### DIFF
--- a/crates/bevy_camera_controller/src/free_cam.rs
+++ b/crates/bevy_camera_controller/src/free_cam.rs
@@ -182,7 +182,18 @@ pub fn run_freecam_controller(
         controller.initialized = true;
         info!("{}", *controller);
     }
+
     if !controller.enabled {
+        // don't keep the cursor grabbed if the controller was disabled.
+        if *toggle_cursor_grab || *mouse_cursor_grab {
+            *toggle_cursor_grab = false;
+            *mouse_cursor_grab = false;
+
+            for (_, mut cursor_options) in &mut windows {
+                cursor_options.grab_mode = CursorGrabMode::None;
+                cursor_options.visible = true;
+            }
+        }
         return;
     }
 


### PR DESCRIPTION
# Objective
Fixes #21482

## Solution
Before exiting the system when the controller is disabled, check if either of the cursor grab flags are set and ungrab any windows if so.
Note: I think it's a bit strange that the camera un-grabs every window, not just the one with focus, but I've just copied this behaviour from further down in the function. In this case, it might be more correct to do this anyway, since the controller might be disabled when the respective window isn't focused.

## Testing

I used #21477 to test this
