### PR TITLE
Clarify `from_viewport_and_override` logic

### DIFF
--- a/crates/bevy_camera/src/camera.rs
+++ b/crates/bevy_camera/src/camera.rs
@@ -85,7 +85,7 @@ impl Viewport {
         main_pass_resolution_override: Option<&MainPassResolutionOverride>,
     ) -> Option<Self> {
         if let Some(override_size) = main_pass_resolution_override {
-            let mut vp = viewport.map_or_else(|| Self::default(), |v| v.clone());
+            let mut vp = viewport.map_or_else(Self::default, Self::clone);
             vp.physical_size = **override_size;
             Some(vp)
         } else {


### PR DESCRIPTION
# Objective

- This commit refactors the `from_viewport_and_override` function to improve readability and safety.

## Solution

- Replaces the initial `cloned()` and subsequent `if/else` logic with a clearer `if let` structure.
- Removes the need for `unwrap()` by handling both `Some` and `None` cases

## Testing

- I don't know how to make sure there is no probelm, but I run some examples and I don't see the errors. 
