### PR TITLE
Add optional wordvec feature for RelationshipSourceCollection

### DIFF
--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -22,6 +22,9 @@ multi_threaded = ["bevy_tasks/multi_threaded", "dep:arrayvec"]
 ## Adds serialization support through `serde`.
 serialize = ["dep:serde", "bevy_platform/serialize", "indexmap/serde"]
 
+## Supports relationship collections through `wordvec`.
+wordvec = ["dep:wordvec"]
+
 ## Adds runtime reflection support using `bevy_reflect`.
 bevy_reflect = ["dep:bevy_reflect"]
 
@@ -115,6 +118,7 @@ smallvec = { version = "1", default-features = false, features = [
   "union",
   "const_generics",
 ] }
+wordvec = { version = "0.1.0", optional = true }
 indexmap = { version = "2.5.0", default-features = false }
 variadics_please = { version = "1.1", default-features = false }
 tracing = { version = "0.1", default-features = false, optional = true }

--- a/crates/bevy_ecs/src/entity/map_entities.rs
+++ b/crates/bevy_ecs/src/entity/map_entities.rs
@@ -1,5 +1,7 @@
 pub use bevy_ecs_macros::MapEntities;
 use indexmap::{IndexMap, IndexSet};
+#[cfg(feature = "wordvec")]
+use wordvec::WordVec;
 
 use crate::{
     entity::{hash_map::EntityHashMap, Entity},
@@ -188,6 +190,15 @@ impl<T: MapEntities> MapEntities for VecDeque<T> {
 }
 
 impl<T: MapEntities, A: smallvec::Array<Item = T>> MapEntities for SmallVec<A> {
+    fn map_entities<E: EntityMapper>(&mut self, entity_mapper: &mut E) {
+        for entities in self.iter_mut() {
+            entities.map_entities(entity_mapper);
+        }
+    }
+}
+
+#[cfg(feature = "wordvec")]
+impl<T: MapEntities, const N: usize> MapEntities for WordVec<T, N> {
     fn map_entities<E: EntityMapper>(&mut self, entity_mapper: &mut E) {
         for entities in self.iter_mut() {
             entities.map_entities(entity_mapper);


### PR DESCRIPTION
# Objective

- Describe the objective or issue this PR addresses.
- If you're fixing a specific issue, say "Fixes #X".

Add a more memory-efficient relationship source collection data structure for relationships with up to one child most of the time.

## Solution

- Describe the solution used to achieve the objective above.

Introduces a new optional dependency `wordvec`, under the feature `wordvec`, such that

```rs
WordVec<Entity, 1>
```

can be used to substitute

```rs
SmallVec<[Entity; 1]>
```

where the former only takes 16 bytes instead of 24 bytes with [comparable performance](https://sof3.github.io/wordvec/report/index.html) to SmallVec, particularly 20%-40% when used as `Vec<WordVec<Entity, 1>>` to index other entities, but 40% slower during single-item pushing.

Accessing `Vec<X<usize>>` for `X = Vec/ThinVec/SmallVec/WordVec` (with `N = 1`) where `vec.len() == 1000 && vec[i].len() == 1` for `i` in 0 to 1000 (effectively `Query<&Children>.iter().flatten().for_each(|e| *u64_query.get_mut(e).unwrap() += 1)`):
<img width="1008" height="243" alt="image" src="https://github.com/user-attachments/assets/55709835-3a66-4f7b-82dc-41ae33013f49" />

Pushing 1, 2, 3 in order to `X<u16>` with `N = 3`:
<img width="1008" height="243" alt="image" src="https://github.com/user-attachments/assets/a1660f17-55be-4fd0-a07f-70d9a18adf8d" />


## Testing

- Did you test these changes? If so, how?
- Are there any parts that need more testing?
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?

The tests for SmallVec implementation in `relationship_source_collection.rs` are duplicated for WordVec as-is.
