### PR TITLE
Switch to try_insert in UICameraPropagate

### DIFF
--- a/crates/bevy_ui/src/update.rs
+++ b/crates/bevy_ui/src/update.rs
@@ -153,7 +153,7 @@ pub fn propagate_ui_target_cameras(
 
         commands
             .entity(root_entity)
-            .insert(Propagate(ComputedUiTargetCamera { camera }));
+            .try_insert(Propagate(ComputedUiTargetCamera { camera }));
 
         let (scale_factor, physical_size) = camera_query
             .get(camera)
@@ -168,7 +168,7 @@ pub fn propagate_ui_target_cameras(
 
         commands
             .entity(root_entity)
-            .insert(Propagate(ComputedUiRenderTargetInfo {
+            .try_insert(Propagate(ComputedUiRenderTargetInfo {
                 scale_factor,
                 physical_size,
             }));


### PR DESCRIPTION
# Objective

I've been having panics in situations where:
- I despawn a UI Root Node in PostUpdate
- I don't have any system order dependency between my PostUpdate system and `UiSystems::Prepare`, so there was no sync point between the two

Therefore the order of operations was:
- My system runs and queues a command to despawn a root node
- The UI system runs and tries to insert `Propagate` on my root node
- CommandExecutions:
  - my command to despawn the root node is executed
  - the command to insert Propagate is executed, causing a panics

This means that any attempt to despawn a Root node in PostUpdate will probably cause these kinds of panics.

## Solution

Replace the command with `try_insert` so that if the Root Node is despawned we don't try to add a Propagate component on it.

## Testing

This fixed the issue in my repo
