### PR TITLE
add note about hdr to custom post process. 

### DIFF
--- a/examples/shader_advanced/custom_post_processing.rs
+++ b/examples/shader_advanced/custom_post_processing.rs
@@ -12,7 +12,6 @@ use bevy::{
         FullscreenShader,
     },
     ecs::query::QueryItem,
-    pbr::MeshPipelineKey,
     prelude::*,
     render::{
         extract_component::{


### PR DESCRIPTION
# Objective

A user was confused about a crash when modifying the custom_post_processing example.
They added an Hdr feature, Bloom, and were confused about the crash.
The issue is that when using Hdr cameras, the custom_post_processing pipeline must use Hdr textures.

Fixes #21516

## Solution

Add note about using Hdr textures if Hdr features are enabled.
Note is added to two locations since most users will be looking at the camera when adding hdr components; not looking at the colortargetstate.


