### PR TITLE
Add dependencies on morph feature for bevy_pbr, fixes #21528

### DIFF
--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -43,11 +43,16 @@ bevy_diagnostic = { path = "../bevy_diagnostic", version = "0.18.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.18.0-dev" }
 bevy_light = { path = "../bevy_light", version = "0.18.0-dev" }
 bevy_image = { path = "../bevy_image", version = "0.18.0-dev" }
-bevy_mesh = { path = "../bevy_mesh", version = "0.18.0-dev", features=["morph", "bevy_mikktspace"] }
+bevy_mesh = { path = "../bevy_mesh", version = "0.18.0-dev", features = [
+  "morph",
+  "bevy_mikktspace",
+] }
 bevy_shader = { path = "../bevy_shader", version = "0.18.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.18.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.18.0-dev" }
-bevy_render = { path = "../bevy_render", version = "0.18.0-dev", features=["morph"] }
+bevy_render = { path = "../bevy_render", version = "0.18.0-dev", features = [
+  "morph",
+] }
 bevy_camera = { path = "../bevy_camera", version = "0.18.0-dev" }
 bevy_tasks = { path = "../bevy_tasks", version = "0.18.0-dev", optional = true }
 bevy_transform = { path = "../bevy_transform", version = "0.18.0-dev" }


### PR DESCRIPTION
# Objective

Fixes #21528 causing the main branch to not build when not using default features

## Solution

Added explicit dependencies on morph feature for bevy_mesh and bevy_render for bevy_pbr

## Testing

Now builds successfully on my machine using 

> cargo build --no-default-features --features std,x11,bevy_winit,bevy_state,bevy_window,bevy_pbr,bevy_sprite,bevy_text,bevy_core_pipeline,bevy_picking,bevy_animation,png,zstd_rust,tonemapping_luts,ktx2
