### PR TITLE
(Partially) fix specialization memory leak

### DIFF
--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -389,6 +389,7 @@ where
                             .before(late_sweep_material_instances),
                         extract_entities_needs_specialization::<M>
                             .after(extract_cameras)
+                            // Make sure that material instances are cleared first.
                             .after(early_sweep_material_instances::<M>)
                             .after(MaterialExtractionSystems),
                     ),


### PR DESCRIPTION
# Objective

Plugs one of the holes responsible for leaking memory in #21526. 

## Solution

- Explicit ordering so that instances are cleaned up and the subsequent `SpecializedMaterialViewPipelineCache` cleanup step can happen.

## Testing

Tested with the first example in the issue while printing the size of the maps in `specialize_material_meshes`, i.e.

```rust
        dbg!(entity_specialization_ticks.len());
        dbg!(view_specialized_material_pipeline_cache.len());
```

