### PR TITLE
Update desk_toy.rs

### DIFF
--- a/examples/games/desk_toy.rs
+++ b/examples/games/desk_toy.rs
@@ -20,7 +20,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
-                // MacOS does not let you set the title of transparent windows. Do not add
+                // MacOS cfg does not let you set the title of transparent windows on Windows. Do not add
                 // title: "Bevy Desk Toy".into(),
                 transparent: true,
                 #[cfg(target_os = "macos")]


### PR DESCRIPTION
Fixes #21138 
Tested and reproduced errors. 
ERROR logs were ALL OK and UNRELATED.
Real problem:
adding title with macos has problems. 

My ChatGPT friend says macOS does have stricter behavior around transparent windows and window configuration, and it's very likely that the issue you're seeing—like the window closing and reopening or unexpected behavior—is related to:

Using transparent: true in combination with:
composite_alpha_mode
decorations: false
window_level: AlwaysOnTop
Setting the title
and 
Reconfiguring the window at runtime
Might introduce errors 

Example closes window and opens window and deleting title makes example desk_toy work.

# Objective

- Describe the objective or issue this PR addresses. it would crash example 
- If you're fixing a specific issue, say "Fixes #X".

## Solution

- Describe the solution used to achieve the objective above.
Another solution was adding assets/branding/icon.png next to games/desk_toy.rs and asset load("branding/icon.png".  However, I think no window title and strict macos rules were the real culprit.
## Testing
There were ERRORS 
However,  those were other ERRORS UNRELATED
OP described them. I witnessed them. I had Vulkan errors too.  Totally unrelated.   macOS strict rules were the culprit
- Did you test these changes? If so, how? I cargo clean build and run.  It wokeed and didn't work at times.  
- Are there any parts that need more testing? allowing title in strict macos Window rules cfg to avoid title errors would be logical step
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test? I tested on Windows 11 Vulkan 12

---

## Showcase

> This section is optional. If this PR does not include a visual change or does not add a new feature, you can delete this section.

Example has a Startup and Update component opening and closing Window WITH macOS cfg and Windows has problems acknowledging macOS cfg inside Window and one of those problems is the title.

- Help others understand the result of this PR by showcasing your awesome work!
<details>
  <summary>Click to view showcase</summary>

```rust
println!("My super cool code.");
```

</details>
