### PR TITLE
Match input common_conditions bounds with ButtonInput

### DIFF
--- a/crates/bevy_input/src/common_conditions.rs
+++ b/crates/bevy_input/src/common_conditions.rs
@@ -53,11 +53,11 @@ pub fn input_toggle_active<T>(
     input: T,
 ) -> impl FnMut(Res<ButtonInput<T>>) -> bool + Clone
 where
-    T: Copy + Eq + Hash + Send + Sync + 'static,
+    T: Clone + Eq + Hash + Send + Sync + 'static,
 {
     let mut active = default;
     move |inputs: Res<ButtonInput<T>>| {
-        active ^= inputs.just_pressed(input);
+        active ^= inputs.just_pressed(input.clone());
         active
     }
 }
@@ -65,9 +65,9 @@ where
 /// Run condition that is active if [`ButtonInput::pressed`] is true for the given input.
 pub fn input_pressed<T>(input: T) -> impl FnMut(Res<ButtonInput<T>>) -> bool + Clone
 where
-    T: Copy + Eq + Hash + Send + Sync + 'static,
+    T: Clone + Eq + Hash + Send + Sync + 'static,
 {
-    move |inputs: Res<ButtonInput<T>>| inputs.pressed(input)
+    move |inputs: Res<ButtonInput<T>>| inputs.pressed(input.clone())
 }
 
 /// Run condition that is active if [`ButtonInput::just_pressed`] is true for the given input.
@@ -87,17 +87,17 @@ where
 /// ```
 pub fn input_just_pressed<T>(input: T) -> impl FnMut(Res<ButtonInput<T>>) -> bool + Clone
 where
-    T: Copy + Eq + Hash + Send + Sync + 'static,
+    T: Clone + Eq + Hash + Send + Sync + 'static,
 {
-    move |inputs: Res<ButtonInput<T>>| inputs.just_pressed(input)
+    move |inputs: Res<ButtonInput<T>>| inputs.just_pressed(input.clone())
 }
 
 /// Run condition that is active if [`ButtonInput::just_released`] is true for the given input.
 pub fn input_just_released<T>(input: T) -> impl FnMut(Res<ButtonInput<T>>) -> bool + Clone
 where
-    T: Copy + Eq + Hash + Send + Sync + 'static,
+    T: Clone + Eq + Hash + Send + Sync + 'static,
 {
-    move |inputs: Res<ButtonInput<T>>| inputs.just_released(input)
+    move |inputs: Res<ButtonInput<T>>| inputs.just_released(input.clone())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Objective

- `ButtonInput` has `T: Clone + Eq + Hash + Send + Sync + 'static` bounds,
  but functions in `bevy_input::common_conditions` has `T: Copy + Eq + Hash + Send + Sync + 'static` bounds.
  This prevents use of `!Copy` inputs like `Key` for the latter.

## Solution

- Replace `Copy` -> `Clone` in `bevy_input::common_conditions`
