### PR TITLE
Feature/glam cross constants

### DIFF
--- a/crates/bevy_math/src/direction.rs
+++ b/crates/bevy_math/src/direction.rs
@@ -428,10 +428,6 @@ impl Dir3 {
 
     // Adding this allow here to make sure that the precision in FRAC_1_SQRT_2
     // and here is the same
-    #[expect(
-        clippy::excessive_precision,
-        reason = "compatibility with the unstable rust definition"
-    )]
     /// Approximation of 1/sqrt(3) needed for the diagonals in 3D space
     const FRAC_1_SQRT_3: f32 = 0.577350269189625764509148780501957456_f32;
     /// The directions pointing towards the vertices of a cube centered at the origin.


### PR DESCRIPTION
# Objective

Fixes #21333 

## Solution

This PR introduces several new constants for Dir2 and Dir3,
providing convenient shorthands for popular directions on a grid, such as:
- All the cardinal directions
- All diagonals
- All neighboring directions (cardinals + diagonals)


## Testing

Changes were not tested via autotests, but I did check my math to make sure I didn't mess up.

You can look at the changed files and make sure that the constants contain the directions they are supposed to

## Showcase

For example. if you have a grid and wish to get all neighboring cells on it,
you don't have to define the directions yourself and can do the following

```rust
let valid_positions = Dir2::ALL_NEIGHBORS.iter().filter_map(|offset| {
    grid.get(current_position + offset)
}.collect();
```
