### PR TITLE
Fix lightmaps freeing the wrong slab on removal.

### DIFF
--- a/crates/bevy_pbr/src/lightmap/mod.rs
+++ b/crates/bevy_pbr/src/lightmap/mod.rs
@@ -388,7 +388,7 @@ impl RenderLightmaps {
         slab.remove(fallback_images, slot_index);
 
         if !slab.is_full() {
-            self.free_slabs.grow_and_insert(slot_index.into());
+            self.free_slabs.grow_and_insert(slab_index.into());
         }
     }
 }


### PR DESCRIPTION
# Objective

- Fixes #21551.
- Fixes #20688.

## Solution

- Insert slab_index instead of slot_index into free_slabs.

## Testing

Ran the repro in #20688 and it works!