### PR TITLE
Improve Tracy profiling docs (quickstart, split into sections)

### DIFF
--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -79,7 +79,7 @@ The [Tracy profiling tool](https://github.com/wolfpld/tracy) is:
    - Starting the Tracy UI first and letting it wait for connection ensures it doesn't have to catch up
 4. Run your bevy app with `--features bevy/trace_tracy --release`
    - `--release` as theres little point to profiling unoptimized code
-    - You can capture memory usage as well with `--features bevy/trace_tracy_memory`, at the cost of increased overhead.
+   - You can capture memory usage as well with `--features bevy/trace_tracy_memory`, at the cost of increased overhead.
 
 #### Finding the correct Tracy version
 
@@ -93,7 +93,7 @@ To determine which Tracy version to install
 Tracy has a command line capture tool that can record the execution of graphical applications, saving it as a profile file. This reduces potential inaccuracies, as running the live capture on the same machine will be a competing graphical application. Pre-recording the profile data through the CLI tool, while other applications are closed, is recommended for more accurate traces.
 
 > [!NOTE]
-> The name and location of the Tracy command line tool will vary depending on how you installed it - the default executable name for the prebuilt binaries is `tracy-capture`. 
+> The name and location of the Tracy command line tool will vary depending on how you installed it - the default executable name for the prebuilt binaries is `tracy-capture`.
 
 In a terminal, run:
 `./tracy-capture -o my_capture.tracy`


### PR DESCRIPTION
# Objective

The Tracy profiling docs were confusing and overwhelming to some for a number of reasons:
- only mentioning that you can capture through the UI in a single sentence quite a bit down
- interspersed installation, version-matching and usage instructions
- lack of clear steps
- lack of separation between topics

## Solution

I've added a Quickstart which guides people through using the Tracy UI to capture, including some more installation instructions for various platforms (unofficial macos/linux binary builds, link to repology packages list).

Additionally, I've created the following sub-titles (sub-headers?)
- `Finding the correct tracy version`
- `Commandline capture (less overhead)`, which is where most of the previous instructions ended up
- `Using the Tracy UI`, for the basic usage guide with screenshots

Rendered version: https://github.com/laundmo/bevy/blob/improve-tracy-profiling-docs/docs/profiling.md#tracy-profiler