### PR TITLE
docs(camera): clarify ndc_to_world method documentation

### DIFF
--- a/crates/bevy_camera/src/camera.rs
+++ b/crates/bevy_camera/src/camera.rs
@@ -727,12 +727,13 @@ impl Camera {
     /// Given a position in Normalized Device Coordinates,
     /// use the camera's viewport to compute the world space position.
     ///
-    /// When the position is within the viewport the values returned will be between -1.0 and 1.0 on the X and Y axes,
-    /// and between 0.0 and 1.0 on the Z axis.
-    /// To get the world space coordinates with the viewport position, you should use
-    /// [`world_to_viewport`](Self::world_to_viewport).
+    /// The input is expected to be in NDC: `x` and `y` in the range `[-1.0, 1.0]`, and `z` in `[0.0, 1.0]`
+    /// (with `z = 0.0` at the far plane and `z = 1.0` at the near plane).
+    /// The returned value is a position in world space (your game's world units) and is not limited to `[-1.0, 1.0]`.
+    /// To convert from a viewport position to world space, you should use
+    /// [`viewport_to_world`](Self::viewport_to_world).
     ///
-    /// Returns `None` if the `camera_transform`, the `world_position`, or the projection matrix defined by
+    /// Returns `None` if the `camera_transform`, the `ndc_point`, or the projection matrix defined by
     /// [`Projection`](super::projection::Projection) contain `NAN`.
     ///
     /// # Panics


### PR DESCRIPTION
# Objective

Fixes #16809 

## Solution

- Correct NDC coordinate ranges and depth interpretation
- Fix method reference from world_to_viewport to viewport_to_world
- Update parameter name in error condition from world_position to ndc_point
- Clarify that returned world position is not limited to NDC
