### PR TITLE
Rename `bevy_reflect`'s `documentation` feature to `reflect_documentation`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -661,7 +661,7 @@ track_location = ["bevy_internal/track_location"]
 # Enable function reflection
 reflect_functions = ["bevy_internal/reflect_functions"]
 
-# Enable documentation reflection
+# Enables bevy_reflect to access documentation comments of rust code at runtime
 reflect_documentation = ["bevy_internal/reflect_documentation"]
 
 # Enable automatic reflect registration

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -357,8 +357,8 @@ reflect_auto_register_static = [
   "bevy_ecs/reflect_auto_register",
 ]
 
-# Enable documentation reflection
-reflect_documentation = ["bevy_reflect/documentation"]
+# Enables bevy_reflect to access documentation comments of rust code at runtime
+reflect_documentation = ["bevy_reflect/reflect_documentation"]
 
 # Enable custom cursor support
 custom_cursor = ["bevy_window/custom_cursor", "bevy_winit/custom_cursor"]

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -15,7 +15,7 @@ default = ["std", "smallvec", "debug", "auto_register_inventory"]
 # Features
 
 ## When enabled, allows documentation comments to be accessed via reflection
-documentation = ["bevy_reflect_derive/documentation"]
+reflect_documentation = ["bevy_reflect_derive/reflect_documentation"]
 
 ## Enables function reflection
 functions = ["bevy_reflect_derive/functions"]
@@ -143,7 +143,7 @@ static_assertions = "1.1.0"
 [[example]]
 name = "reflect_docs"
 path = "examples/reflect_docs.rs"
-required-features = ["documentation"]
+required-features = ["reflect_documentation"]
 
 [lints]
 workspace = true

--- a/crates/bevy_reflect/derive/Cargo.toml
+++ b/crates/bevy_reflect/derive/Cargo.toml
@@ -14,7 +14,7 @@ proc-macro = true
 [features]
 default = []
 # When enabled, allows documentation comments to be processed by the reflection macros
-documentation = []
+reflect_documentation = []
 # Enables macro logic related to function reflection
 functions = []
 # Enables automatic reflect registration. Does nothing by itself, 

--- a/crates/bevy_reflect/derive/src/derive_data.rs
+++ b/crates/bevy_reflect/derive/src/derive_data.rs
@@ -57,7 +57,7 @@ pub(crate) struct ReflectMeta<'a> {
     /// A cached instance of the path to the `bevy_reflect` crate.
     bevy_reflect_path: Path,
     /// The documentation for this type, if any
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     docs: crate::documentation::Documentation,
 }
 
@@ -115,7 +115,7 @@ pub(crate) struct StructField<'a> {
     /// [ignored]: crate::field_attributes::ReflectIgnoreBehavior::IgnoreAlways
     pub reflection_index: Option<usize>,
     /// The documentation for this field, if any
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     pub doc: crate::documentation::Documentation,
 }
 
@@ -128,7 +128,7 @@ pub(crate) struct EnumVariant<'a> {
     /// The reflection-based attributes on the variant.
     pub attrs: FieldAttributes,
     /// The documentation for this variant, if any
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     pub doc: crate::documentation::Documentation,
 }
 
@@ -191,7 +191,7 @@ impl<'a> ReflectDerive<'a> {
         // Should indicate whether `#[type_name = "..."]` was used.
         let mut custom_type_name: Option<Ident> = None;
 
-        #[cfg(feature = "documentation")]
+        #[cfg(feature = "reflect_documentation")]
         let mut doc = crate::documentation::Documentation::default();
 
         for attribute in &input.attrs {
@@ -239,7 +239,7 @@ impl<'a> ReflectDerive<'a> {
 
                     custom_type_name = Some(parse_str(&lit.value())?);
                 }
-                #[cfg(feature = "documentation")]
+                #[cfg(feature = "reflect_documentation")]
                 Meta::NameValue(pair) if pair.path.is_ident("doc") => {
                     if let syn::Expr::Lit(syn::ExprLit {
                         lit: syn::Lit::Str(lit),
@@ -284,7 +284,7 @@ impl<'a> ReflectDerive<'a> {
             ));
         }
 
-        #[cfg(feature = "documentation")]
+        #[cfg(feature = "reflect_documentation")]
         let meta = meta.with_docs(doc);
 
         if meta.attrs().is_opaque() {
@@ -391,7 +391,7 @@ impl<'a> ReflectDerive<'a> {
                         reflection_index,
                         attrs,
                         data: field,
-                        #[cfg(feature = "documentation")]
+                        #[cfg(feature = "reflect_documentation")]
                         doc: crate::documentation::Documentation::from_attributes(&field.attrs),
                     })
                 },
@@ -418,7 +418,7 @@ impl<'a> ReflectDerive<'a> {
                     fields,
                     attrs: FieldAttributes::parse_attributes(&variant.attrs)?,
                     data: variant,
-                    #[cfg(feature = "documentation")]
+                    #[cfg(feature = "reflect_documentation")]
                     doc: crate::documentation::Documentation::from_attributes(&variant.attrs),
                 })
             })
@@ -435,13 +435,13 @@ impl<'a> ReflectMeta<'a> {
             type_path,
             remote_ty: None,
             bevy_reflect_path: crate::meta::get_bevy_reflect_path(),
-            #[cfg(feature = "documentation")]
+            #[cfg(feature = "reflect_documentation")]
             docs: Default::default(),
         }
     }
 
     /// Sets the documentation for this type.
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     pub fn with_docs(self, docs: crate::documentation::Documentation) -> Self {
         Self { docs, ..self }
     }
@@ -498,7 +498,7 @@ impl<'a> ReflectMeta<'a> {
     }
 
     /// The collection of docstrings for this type, if any.
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     pub fn doc(&self) -> &crate::documentation::Documentation {
         &self.docs
     }
@@ -536,7 +536,7 @@ impl<'a> StructField<'a> {
             });
         }
 
-        #[cfg(feature = "documentation")]
+        #[cfg(feature = "reflect_documentation")]
         {
             let docs = &self.doc;
             if !docs.is_empty() {
@@ -684,7 +684,7 @@ impl<'a> ReflectStruct<'a> {
             });
         }
 
-        #[cfg(feature = "documentation")]
+        #[cfg(feature = "reflect_documentation")]
         {
             let docs = self.meta().doc();
             if !docs.is_empty() {
@@ -907,7 +907,7 @@ impl<'a> ReflectEnum<'a> {
             });
         }
 
-        #[cfg(feature = "documentation")]
+        #[cfg(feature = "reflect_documentation")]
         {
             let docs = self.meta().doc();
             if !docs.is_empty() {
@@ -1026,7 +1026,7 @@ impl<'a> EnumVariant<'a> {
             });
         }
 
-        #[cfg(feature = "documentation")]
+        #[cfg(feature = "reflect_documentation")]
         {
             let docs = &self.doc;
             if !docs.is_empty() {

--- a/crates/bevy_reflect/derive/src/impls/opaque.rs
+++ b/crates/bevy_reflect/derive/src/impls/opaque.rs
@@ -11,12 +11,12 @@ pub(crate) fn impl_opaque(meta: &ReflectMeta) -> proc_macro2::TokenStream {
     let bevy_reflect_path = meta.bevy_reflect_path();
     let type_path = meta.type_path();
 
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     let with_docs = {
         let doc = quote::ToTokens::to_token_stream(meta.doc());
         Some(quote!(.with_docs(#doc)))
     };
-    #[cfg(not(feature = "documentation"))]
+    #[cfg(not(feature = "reflect_documentation"))]
     let with_docs: Option<proc_macro2::TokenStream> = None;
 
     let where_clause_options = WhereClauseOptions::new(meta);

--- a/crates/bevy_reflect/derive/src/lib.rs
+++ b/crates/bevy_reflect/derive/src/lib.rs
@@ -19,7 +19,7 @@ extern crate proc_macro;
 mod container_attributes;
 mod custom_attributes;
 mod derive_data;
-#[cfg(feature = "documentation")]
+#[cfg(feature = "reflect_documentation")]
 mod documentation;
 mod enum_utility;
 mod field_attributes;
@@ -680,7 +680,7 @@ pub fn impl_reflect_opaque(input: TokenStream) -> TokenStream {
 
     let meta = ReflectMeta::new(type_path, def.traits.unwrap_or_default());
 
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     let meta = meta.with_docs(documentation::Documentation::from_attributes(&def.attrs));
 
     let reflect_impls = impls::impl_opaque(&meta);

--- a/crates/bevy_reflect/derive/src/reflect_opaque.rs
+++ b/crates/bevy_reflect/derive/src/reflect_opaque.rs
@@ -23,7 +23,7 @@ use syn::{parenthesized, parse::ParseStream, token::Paren, Attribute, Generics, 
 /// ```
 pub(crate) struct ReflectOpaqueDef {
     #[cfg_attr(
-        not(feature = "documentation"),
+        not(feature = "reflect_documentation"),
         expect(
             dead_code,
             reason = "The is used when the `documentation` feature is enabled.",

--- a/crates/bevy_reflect/examples/reflect_docs.rs
+++ b/crates/bevy_reflect/examples/reflect_docs.rs
@@ -4,7 +4,7 @@
 //! For example, you may want to generate schemas or other external documentation for scripting.
 //! Or perhaps you want your custom editor to display tooltips for certain properties that match the documentation.
 //!
-//! These scenarios can readily be achieved by using `bevy_reflect` with the `documentation` feature.
+//! These scenarios can readily be achieved by using `bevy_reflect` with the `reflect_documentation` feature.
 
 #![expect(clippy::print_stdout, reason = "Allowed in examples.")]
 

--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -90,7 +90,7 @@ pub struct ArrayInfo {
     item_info: fn() -> Option<&'static TypeInfo>,
     item_ty: Type,
     capacity: usize,
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     docs: Option<&'static str>,
 }
 
@@ -109,13 +109,13 @@ impl ArrayInfo {
             item_info: TItem::maybe_type_info,
             item_ty: Type::of::<TItem>(),
             capacity,
-            #[cfg(feature = "documentation")]
+            #[cfg(feature = "reflect_documentation")]
             docs: None,
         }
     }
 
     /// Sets the docstring for this array.
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     pub fn with_docs(self, docs: Option<&'static str>) -> Self {
         Self { docs, ..self }
     }
@@ -143,7 +143,7 @@ impl ArrayInfo {
     }
 
     /// The docstring of this array, if any.
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     pub fn docs(&self) -> Option<&'static str> {
         self.docs
     }

--- a/crates/bevy_reflect/src/enums/enum_trait.rs
+++ b/crates/bevy_reflect/src/enums/enum_trait.rs
@@ -154,7 +154,7 @@ pub struct EnumInfo {
     variant_names: Box<[&'static str]>,
     variant_indices: HashMap<&'static str, usize>,
     custom_attributes: Arc<CustomAttributes>,
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     docs: Option<&'static str>,
 }
 
@@ -180,13 +180,13 @@ impl EnumInfo {
             variant_names,
             variant_indices,
             custom_attributes: Arc::new(CustomAttributes::default()),
-            #[cfg(feature = "documentation")]
+            #[cfg(feature = "reflect_documentation")]
             docs: None,
         }
     }
 
     /// Sets the docstring for this enum.
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     pub fn with_docs(self, docs: Option<&'static str>) -> Self {
         Self { docs, ..self }
     }
@@ -246,7 +246,7 @@ impl EnumInfo {
     impl_type_methods!(ty);
 
     /// The docstring of this enum, if any.
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     pub fn docs(&self) -> Option<&'static str> {
         self.docs
     }

--- a/crates/bevy_reflect/src/enums/variants.rs
+++ b/crates/bevy_reflect/src/enums/variants.rs
@@ -96,7 +96,7 @@ impl VariantInfo {
     }
 
     /// The docstring of the underlying variant, if any.
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     pub fn docs(&self) -> Option<&str> {
         match self {
             Self::Struct(info) => info.docs(),
@@ -158,7 +158,7 @@ pub struct StructVariantInfo {
     field_names: Box<[&'static str]>,
     field_indices: HashMap<&'static str, usize>,
     custom_attributes: Arc<CustomAttributes>,
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     docs: Option<&'static str>,
 }
 
@@ -173,13 +173,13 @@ impl StructVariantInfo {
             field_names,
             field_indices,
             custom_attributes: Arc::new(CustomAttributes::default()),
-            #[cfg(feature = "documentation")]
+            #[cfg(feature = "reflect_documentation")]
             docs: None,
         }
     }
 
     /// Sets the docstring for this variant.
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     pub fn with_docs(self, docs: Option<&'static str>) -> Self {
         Self { docs, ..self }
     }
@@ -238,7 +238,7 @@ impl StructVariantInfo {
     }
 
     /// The docstring of this variant, if any.
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     pub fn docs(&self) -> Option<&'static str> {
         self.docs
     }
@@ -252,7 +252,7 @@ pub struct TupleVariantInfo {
     name: &'static str,
     fields: Box<[UnnamedField]>,
     custom_attributes: Arc<CustomAttributes>,
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     docs: Option<&'static str>,
 }
 
@@ -263,13 +263,13 @@ impl TupleVariantInfo {
             name,
             fields: fields.to_vec().into_boxed_slice(),
             custom_attributes: Arc::new(CustomAttributes::default()),
-            #[cfg(feature = "documentation")]
+            #[cfg(feature = "reflect_documentation")]
             docs: None,
         }
     }
 
     /// Sets the docstring for this variant.
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     pub fn with_docs(self, docs: Option<&'static str>) -> Self {
         Self { docs, ..self }
     }
@@ -303,7 +303,7 @@ impl TupleVariantInfo {
     }
 
     /// The docstring of this variant, if any.
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     pub fn docs(&self) -> Option<&'static str> {
         self.docs
     }
@@ -316,7 +316,7 @@ impl TupleVariantInfo {
 pub struct UnitVariantInfo {
     name: &'static str,
     custom_attributes: Arc<CustomAttributes>,
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     docs: Option<&'static str>,
 }
 
@@ -326,13 +326,13 @@ impl UnitVariantInfo {
         Self {
             name,
             custom_attributes: Arc::new(CustomAttributes::default()),
-            #[cfg(feature = "documentation")]
+            #[cfg(feature = "reflect_documentation")]
             docs: None,
         }
     }
 
     /// Sets the docstring for this variant.
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     pub fn with_docs(self, docs: Option<&'static str>) -> Self {
         Self { docs, ..self }
     }
@@ -351,7 +351,7 @@ impl UnitVariantInfo {
     }
 
     /// The docstring of this variant, if any.
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     pub fn docs(&self) -> Option<&'static str> {
         self.docs
     }

--- a/crates/bevy_reflect/src/fields.rs
+++ b/crates/bevy_reflect/src/fields.rs
@@ -14,7 +14,7 @@ pub struct NamedField {
     type_info: fn() -> Option<&'static TypeInfo>,
     ty: Type,
     custom_attributes: Arc<CustomAttributes>,
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     docs: Option<&'static str>,
 }
 
@@ -26,13 +26,13 @@ impl NamedField {
             type_info: T::maybe_type_info,
             ty: Type::of::<T>(),
             custom_attributes: Arc::new(CustomAttributes::default()),
-            #[cfg(feature = "documentation")]
+            #[cfg(feature = "reflect_documentation")]
             docs: None,
         }
     }
 
     /// Sets the docstring for this field.
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     pub fn with_docs(self, docs: Option<&'static str>) -> Self {
         Self { docs, ..self }
     }
@@ -62,7 +62,7 @@ impl NamedField {
     impl_type_methods!(ty);
 
     /// The docstring of this field, if any.
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     pub fn docs(&self) -> Option<&'static str> {
         self.docs
     }
@@ -77,7 +77,7 @@ pub struct UnnamedField {
     type_info: fn() -> Option<&'static TypeInfo>,
     ty: Type,
     custom_attributes: Arc<CustomAttributes>,
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     docs: Option<&'static str>,
 }
 
@@ -89,13 +89,13 @@ impl UnnamedField {
             type_info: T::maybe_type_info,
             ty: Type::of::<T>(),
             custom_attributes: Arc::new(CustomAttributes::default()),
-            #[cfg(feature = "documentation")]
+            #[cfg(feature = "reflect_documentation")]
             docs: None,
         }
     }
 
     /// Sets the docstring for this field.
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     pub fn with_docs(self, docs: Option<&'static str>) -> Self {
         Self { docs, ..self }
     }
@@ -125,7 +125,7 @@ impl UnnamedField {
     impl_type_methods!(ty);
 
     /// The docstring of this field, if any.
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     pub fn docs(&self) -> Option<&'static str> {
         self.docs
     }

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -2428,7 +2428,7 @@ mod tests {
         dynamic_array.set_represented_type(Some(type_info));
     }
 
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     mod docstrings {
         use super::*;
 

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -124,7 +124,7 @@ pub struct ListInfo {
     generics: Generics,
     item_info: fn() -> Option<&'static TypeInfo>,
     item_ty: Type,
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     docs: Option<&'static str>,
 }
 
@@ -136,13 +136,13 @@ impl ListInfo {
             generics: Generics::new(),
             item_info: TItem::maybe_type_info,
             item_ty: Type::of::<TItem>(),
-            #[cfg(feature = "documentation")]
+            #[cfg(feature = "reflect_documentation")]
             docs: None,
         }
     }
 
     /// Sets the docstring for this list.
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     pub fn with_docs(self, docs: Option<&'static str>) -> Self {
         Self { docs, ..self }
     }
@@ -165,7 +165,7 @@ impl ListInfo {
     }
 
     /// The docstring of this list, if any.
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     pub fn docs(&self) -> Option<&'static str> {
         self.docs
     }

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -118,7 +118,7 @@ pub struct MapInfo {
     key_ty: Type,
     value_info: fn() -> Option<&'static TypeInfo>,
     value_ty: Type,
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     docs: Option<&'static str>,
 }
 
@@ -136,13 +136,13 @@ impl MapInfo {
             key_ty: Type::of::<TKey>(),
             value_info: TValue::maybe_type_info,
             value_ty: Type::of::<TValue>(),
-            #[cfg(feature = "documentation")]
+            #[cfg(feature = "reflect_documentation")]
             docs: None,
         }
     }
 
     /// Sets the docstring for this map.
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     pub fn with_docs(self, docs: Option<&'static str>) -> Self {
         Self { docs, ..self }
     }
@@ -180,7 +180,7 @@ impl MapInfo {
     }
 
     /// The docstring of this map, if any.
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     pub fn docs(&self) -> Option<&'static str> {
         self.docs
     }

--- a/crates/bevy_reflect/src/set.rs
+++ b/crates/bevy_reflect/src/set.rs
@@ -104,7 +104,7 @@ pub struct SetInfo {
     ty: Type,
     generics: Generics,
     value_ty: Type,
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     docs: Option<&'static str>,
 }
 
@@ -115,13 +115,13 @@ impl SetInfo {
             ty: Type::of::<TSet>(),
             generics: Generics::new(),
             value_ty: Type::of::<TValue>(),
-            #[cfg(feature = "documentation")]
+            #[cfg(feature = "reflect_documentation")]
             docs: None,
         }
     }
 
     /// Sets the docstring for this set.
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     pub fn with_docs(self, docs: Option<&'static str>) -> Self {
         Self { docs, ..self }
     }
@@ -136,7 +136,7 @@ impl SetInfo {
     }
 
     /// The docstring of this set, if any.
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     pub fn docs(&self) -> Option<&'static str> {
         self.docs
     }

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -96,7 +96,7 @@ pub struct StructInfo {
     field_names: Box<[&'static str]>,
     field_indices: HashMap<&'static str, usize>,
     custom_attributes: Arc<CustomAttributes>,
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     docs: Option<&'static str>,
 }
 
@@ -122,13 +122,13 @@ impl StructInfo {
             field_names,
             field_indices,
             custom_attributes: Arc::new(CustomAttributes::default()),
-            #[cfg(feature = "documentation")]
+            #[cfg(feature = "reflect_documentation")]
             docs: None,
         }
     }
 
     /// Sets the docstring for this struct.
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     pub fn with_docs(self, docs: Option<&'static str>) -> Self {
         Self { docs, ..self }
     }
@@ -176,7 +176,7 @@ impl StructInfo {
     impl_type_methods!(ty);
 
     /// The docstring of this struct, if any.
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     pub fn docs(&self) -> Option<&'static str> {
         self.docs
     }

--- a/crates/bevy_reflect/src/tuple.rs
+++ b/crates/bevy_reflect/src/tuple.rs
@@ -157,7 +157,7 @@ pub struct TupleInfo {
     ty: Type,
     generics: Generics,
     fields: Box<[UnnamedField]>,
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     docs: Option<&'static str>,
 }
 
@@ -172,13 +172,13 @@ impl TupleInfo {
             ty: Type::of::<T>(),
             generics: Generics::new(),
             fields: fields.to_vec().into_boxed_slice(),
-            #[cfg(feature = "documentation")]
+            #[cfg(feature = "reflect_documentation")]
             docs: None,
         }
     }
 
     /// Sets the docstring for this tuple.
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     pub fn with_docs(self, docs: Option<&'static str>) -> Self {
         Self { docs, ..self }
     }
@@ -201,7 +201,7 @@ impl TupleInfo {
     impl_type_methods!(ty);
 
     /// The docstring of this tuple, if any.
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     pub fn docs(&self) -> Option<&'static str> {
         self.docs
     }

--- a/crates/bevy_reflect/src/tuple_struct.rs
+++ b/crates/bevy_reflect/src/tuple_struct.rs
@@ -76,7 +76,7 @@ pub struct TupleStructInfo {
     generics: Generics,
     fields: Box<[UnnamedField]>,
     custom_attributes: Arc<CustomAttributes>,
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     docs: Option<&'static str>,
 }
 
@@ -92,13 +92,13 @@ impl TupleStructInfo {
             generics: Generics::new(),
             fields: fields.to_vec().into_boxed_slice(),
             custom_attributes: Arc::new(CustomAttributes::default()),
-            #[cfg(feature = "documentation")]
+            #[cfg(feature = "reflect_documentation")]
             docs: None,
         }
     }
 
     /// Sets the docstring for this struct.
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     pub fn with_docs(self, docs: Option<&'static str>) -> Self {
         Self { docs, ..self }
     }
@@ -129,7 +129,7 @@ impl TupleStructInfo {
     impl_type_methods!(ty);
 
     /// The docstring of this struct, if any.
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     pub fn docs(&self) -> Option<&'static str> {
         self.docs
     }

--- a/crates/bevy_reflect/src/type_info.rs
+++ b/crates/bevy_reflect/src/type_info.rs
@@ -289,7 +289,7 @@ impl TypeInfo {
     }
 
     /// The docstring of the underlying type, if any.
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     pub fn docs(&self) -> Option<&str> {
         match self {
             Self::Struct(info) => info.docs(),
@@ -580,7 +580,7 @@ pub(crate) use impl_type_methods;
 pub struct OpaqueInfo {
     ty: Type,
     generics: Generics,
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     docs: Option<&'static str>,
 }
 
@@ -590,13 +590,13 @@ impl OpaqueInfo {
         Self {
             ty: Type::of::<T>(),
             generics: Generics::new(),
-            #[cfg(feature = "documentation")]
+            #[cfg(feature = "reflect_documentation")]
             docs: None,
         }
     }
 
     /// Sets the docstring for this type.
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     pub fn with_docs(self, doc: Option<&'static str>) -> Self {
         Self { docs: doc, ..self }
     }
@@ -604,7 +604,7 @@ impl OpaqueInfo {
     impl_type_methods!(ty);
 
     /// The docstring of this dynamic type, if any.
-    #[cfg(feature = "documentation")]
+    #[cfg(feature = "reflect_documentation")]
     pub fn docs(&self) -> Option<&'static str> {
         self.docs
     }

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -157,7 +157,7 @@ This is the complete `bevy` cargo feature list, without "profiles" or "collectio
 |raw_vulkan_init|Forces the wgpu instance to be initialized using the raw Vulkan HAL, enabling additional configuration|
 |reflect_auto_register|Enable automatic reflect registration|
 |reflect_auto_register_static|Enable automatic reflect registration without inventory. See `reflect::load_type_registrations` for more info.|
-|reflect_documentation|Enable documentation reflection|
+|reflect_documentation|Enables bevy_reflect to access documentation comments of rust code at runtime|
 |reflect_functions|Enable function reflection|
 |serialize|Enable serialization support through serde|
 |shader_format_glsl|Enable support for shaders in GLSL|

--- a/release-content/migration-guides/rename-reflect-documentation-feature.md
+++ b/release-content/migration-guides/rename-reflect-documentation-feature.md
@@ -1,0 +1,6 @@
+---
+title: Renamed `bevy_reflect` feature `documentation` to `reflect_documentation`
+pull_requests: [21577]
+---
+
+The `documentation` feature in `bevy_reflect` has been renamed to `reflect_documentation` to clarify that it allows reflecting documentation of rust code at runtime.


### PR DESCRIPTION
# Objective

Fixes #14309 

## Solution

Renamed the `bevy_reflect` feature from `documentation` to `reflect_documentation` to follow the naming convention where features are prefixed with their module name.

## Changes

- Renamed feature `documentation` to `reflect_documentation` in:
  - `bevy_reflect/Cargo.toml`
  - `bevy_reflect/derive/Cargo.toml`
  - `bevy_internal/Cargo.toml`
- Updated all conditional compilation attributes from `#[cfg(feature = "documentation")]` to `#[cfg(feature = "reflect_documentation")]`
- Updated example documentation in `reflect_docs.rs`

## Testing

<img width="1414" height="688" alt="截图 2025-10-17 18-52-14" src="https://github.com/user-attachments/assets/461d827a-c958-4c0d-862d-aae25598f2f7" />
