### PR TITLE
Add `try_get_*` component accessors to filtered entity references and mutators

### DIFF
--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -6239,7 +6239,7 @@ mod tests {
             ComponentFetchError::ComponentNotFound(id) if id == missing_id
         ));
 
-        assert_eq!(world.entity(e).get::<M>().unwrap().0, 3);
+        assert_eq!(world.entity(e).get::<M>().unwrap().0, 2);
     }
 
     #[test]

--- a/crates/bevy_ecs/src/world/error.rs
+++ b/crates/bevy_ecs/src/world/error.rs
@@ -75,6 +75,18 @@ pub enum ResourceFetchError {
     NoResourceAccess(ComponentId),
 }
 
+/// An error that occurs when fetching a component for an entity via filtered access.
+#[derive(thiserror::Error, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ComponentFetchError {
+    /// The component with the given [`ComponentId`] exists in the world but cannot be accessed
+    /// through the current [`Access`](crate::query::access::Access) of the filtered reference.
+    #[error("Cannot access component with ID {0:?} due to insufficient access permissions.")]
+    InsufficientAccess(ComponentId),
+    /// The component with the given [`ComponentId`] does not exist on the entity.
+    #[error("The component with ID {0:?} does not exist on the entity.")]
+    ComponentNotFound(ComponentId),
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{

--- a/crates/bevy_ecs/src/world/error.rs
+++ b/crates/bevy_ecs/src/world/error.rs
@@ -79,7 +79,7 @@ pub enum ResourceFetchError {
 #[derive(thiserror::Error, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ComponentFetchError {
     /// The component with the given [`ComponentId`] exists in the world but cannot be accessed
-    /// through the current [`Access`](crate::query::access::Access) of the filtered reference.
+    /// through the current [`Access`](crate::query::Access) of the filtered reference.
     #[error("Cannot access component with ID {0:?} due to insufficient access permissions.")]
     InsufficientAccess(ComponentId),
     /// The component with the given [`ComponentId`] does not exist on the entity.


### PR DESCRIPTION
# Objective

Fixes https://github.com/bevyengine/bevy/issues/21403

## Solution

- Add `try_get_*` APIs to filtered entity refs/muts to return `Result`, distinguishing missing components from insufficient access.
- Introduce `ComponentFetchError` with `InsufficientAccess` and `ComponentNotFound`.
- Clarify docs for existing `get`/`get_ref` that `None` can also mean no read access under filtering.

## Testing

- Added unit tests covering success paths and both error cases.
- Run: `cargo test -p bevy_ecs`.
