### PR TITLE
Rewrite the reason for the `clippy::doc_markdown` expectation in the `bevy` main crate to be more accurate

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,13 +1,10 @@
 doc-valid-idents = [
+  "GameActivity",
   "GilRs",
   "glTF",
-  "macOS",
   "NVidia",
   "OpenXR",
-  "sRGB",
   "VSync",
-  "WebGL2",
-  "WebGPU",
   "..",
 ]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![expect(
     clippy::doc_markdown,
-    reason = "Android GameActivity does not need to be code-formatted."
+    reason = "Clippy lints for un-backticked identifiers within the cargo features list, which we don't want."
 )]
 //! [![Bevy Logo](https://bevy.org/assets/bevy_logo_docs.svg)](https://bevy.org)
 //!


### PR DESCRIPTION
# Objective
The `bevy` main crate's `lib.rs` file contains an expectation for the `clippy::doc_markdown` lint. However, it only references one of the many times that `clippy::doc_markdown` lints on that file. Many of the other `clippy::doc_markdown` instances are within the cargo features list.

## Solution
Rewrite the reason for this expectation to be more clear. Additionally, mark `GameActivity` as an allowed doc ident for Clippy.

## Testing
`cargo clippy` returned no errors.