### PR TITLE
Create a config file for cargo aliases, so tool commands aren't so painful to type

### DIFF
--- a/.cargo/config_aliases.toml
+++ b/.cargo/config_aliases.toml
@@ -1,0 +1,41 @@
+# Copy this file to `config.toml` to enable several aliases to commonly-used tools.
+
+[alias]
+### Alias for the `build-easefunction-graphs` tool
+build-easefunction-graphs = "run --package build-easefunction-graphs --"
+
+### Aliases for the `build-templated-pages` tool
+build-templated-pages = "run --package build-templated-pages --"
+
+# Checks for missing data
+check-missing-templated-pages = "build-templated-pages check-missing"
+check-missing-example-metadata = "check-missing-templated-pages examples"
+check-missing-feature-docs = "check-missing-templated-pages features"
+
+# Updates certain templated data
+update-templated-pages = "build-templated-pages update"
+update-examples-readme = "update-templated-pages examples"
+update-feature-docs = "update-templated-pages features"
+
+### Alias for the `build-wasm-example` tool
+build-wasm-example = "run --package build-wasm-example --"
+
+### Aliases for the `ci` tool
+ci = "run --package ci --"
+
+# Check each file under `tools/ci/src/commands/` to see what each individual command does
+ci-bench-check = "ci bench-check"
+ci-clippy = "ci clippy"
+ci-compile = "ci compile"
+ci-compile-check = "ci compile-check"
+ci-compile-fail = "ci compile-fail"
+ci-doc = "ci doc"
+ci-doc-check = "ci doc-check"
+ci-doc-test = "ci doc-test"
+ci-example-check = "ci example-check"
+ci-format = "ci format"
+ci-integration-test-check = "ci integration-test-check"
+ci-integration-test-clean = "ci integration-test-clean"
+ci-integration-test-run = "ci integration-test"
+ci-lints = "ci lints"
+ci-test = "ci test"

--- a/.cargo/config_fast_builds.toml
+++ b/.cargo/config_fast_builds.toml
@@ -142,8 +142,3 @@ rustflags = [
 # In most cases the gains are negligible, but if you are on macOS and have slow compile times you should see significant gains.
 # [profile.dev]
 # debug = 1
-
-# This enables you to run the CI tool using `cargo ci`.
-# This is not enabled by default, you need to copy this file to `config.toml`.
-[alias]
-ci = "run --package ci --"


### PR DESCRIPTION
# Objective
To be honest, typing tool commands suck due to just how long the commands are.

Also, what is a `ci` alias doing in a config file meant for fast builds...?

## Solution
Create a config file for cargo aliases, under `.cargo/config_aliases.toml`, with many short aliases to useful commands.

Now instead of typing `cargo run -p build-templated-pages -- update features`, you can just run `cargo update-feature-docs`. :D

## Testing
This change was tested by copying `.cargo/config_aliases.toml` to `.cargo/config.toml`, and running `cargo --list` to confirm that they showed up.

I also ran a few (but not all) of these aliases to ensure they work.