### PR TITLE
Remove `ron` re-export from `bevy_scene` and `bevy_asset`

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -204,8 +204,6 @@ pub use reflect::*;
 pub use render_asset::*;
 pub use server::*;
 
-/// Rusty Object Notation, a crate used to serialize and deserialize bevy assets.
-pub use ron;
 pub use uuid;
 
 use crate::{

--- a/crates/bevy_scene/Cargo.toml
+++ b/crates/bevy_scene/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["bevy"]
 [features]
 default = ["serialize"]
 serialize = [
+  "dep:ron",
   "dep:serde",
   "uuid/serde",
   "bevy_ecs/serialize",
@@ -32,6 +33,7 @@ bevy_platform = { path = "../bevy_platform", version = "0.18.0-dev", default-fea
 ] }
 
 # other
+ron = { version = "0.11", default-features = false, optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 uuid = { version = "1.13.1", features = ["v4"] }
 thiserror = { version = "2", default-features = false }

--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -13,11 +13,7 @@ use bevy_ecs::component::ComponentCloneBehavior;
 use bevy_ecs::relationship::RelationshipHookMode;
 
 #[cfg(feature = "serialize")]
-use {
-    crate::{ron, serde::SceneSerializer},
-    bevy_reflect::TypeRegistry,
-    serde::Serialize,
-};
+use {crate::serde::SceneSerializer, bevy_reflect::TypeRegistry, serde::Serialize};
 
 /// A collection of serializable resources and dynamic entities.
 ///

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -24,9 +24,6 @@ mod scene_spawner;
 #[cfg(feature = "serialize")]
 pub mod serde;
 
-/// Rusty Object Notation, a crate used to serialize and deserialize bevy scenes.
-pub use bevy_asset::ron;
-
 pub use components::*;
 pub use dynamic_scene::*;
 pub use dynamic_scene_builder::*;

--- a/crates/bevy_scene/src/scene_loader.rs
+++ b/crates/bevy_scene/src/scene_loader.rs
@@ -1,4 +1,3 @@
-use crate::ron;
 use bevy_ecs::{
     reflect::AppTypeRegistry,
     world::{FromWorld, World},

--- a/crates/bevy_scene/src/serde.rs
+++ b/crates/bevy_scene/src/serde.rs
@@ -52,7 +52,7 @@ pub const ENTITY_FIELD_COMPONENTS: &str = "components";
 /// let scene_serializer = SceneSerializer::new(&scene, &registry);
 ///
 /// // Serialize through any serde-compatible Serializer
-/// let ron_string = bevy_scene::ron::ser::to_string(&scene_serializer);
+/// let ron_string = ron::ser::to_string(&scene_serializer);
 /// ```
 pub struct SceneSerializer<'a> {
     /// The scene to serialize.
@@ -510,7 +510,6 @@ impl<'a, 'de> Visitor<'de> for SceneMapVisitor<'a> {
 #[cfg(test)]
 mod tests {
     use crate::{
-        ron,
         serde::{SceneDeserializer, SceneSerializer},
         DynamicScene, DynamicSceneBuilder,
     };
@@ -522,6 +521,7 @@ mod tests {
         world::FromWorld,
     };
     use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize};
+    use ron;
     use serde::{de::DeserializeSeed, Deserialize, Serialize};
     use std::io::BufReader;
 

--- a/release-content/migration-guides/remove_ron_reexport.md
+++ b/release-content/migration-guides/remove_ron_reexport.md
@@ -1,0 +1,10 @@
+---
+title: Remove ron re-export from bevy_scene and bevy_asset
+pull_requests: [21611]
+---
+
+The `ron` crate is no longer re-exported from `bevy_scene` or `bevy_asset`. This was done to reduce naming conflicts and improve API clarity.
+
+If you were importing `ron` through `bevy_scene` or `bevy_asset`, you should now add `ron` as a direct dependency to your project.
+
+This change only affects code that was explicitly importing the `ron` module. All internal scene serialization and deserialization functionality remains unchanged.


### PR DESCRIPTION
# Objective

As discussed in #19285, Bevy has reused the same conceptual names for multiple types across different crates, creating confusion for autocomplete tooling and users. This PR addresses one of those conflicts by removing the `ron` re-export from `bevy_scene` and `bevy_asset`

## Solution

- Removed `pub use bevy_asset::ron;` from `bevy_scene::lib` and `pub use ron;` from `bevy_asset::lib`
- Updated `crates/bevy_scene/Cargo.toml`
- Updated all internal references to use `ron` directly:
  - `crates/bevy_scene/src/dynamic_scene.rs`
  - `crates/bevy_scene/src/scene_loader.rs`
  - `crates/bevy_scene/src/serde.rs` (including doc examples and tests)

## Testing

- `cargo check --workspace` - all checks pass
- `cargo test -p bevy_scene` - tests pass (4 pre-existing test failures unrelated to this change)
-  `cargo test -p bevy_asset` - tests pass
- `cargo clippy` - no new warnings
