### PR TITLE
Rename M-Needs- labels

### DIFF
--- a/.github/workflows/action-on-PR-labeled.yml
+++ b/.github/workflows/action-on-PR-labeled.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   comment-on-migration-guide-label:
     runs-on: ubuntu-latest
-    if: github.event.label.name == 'M-Needs-Migration-Guide'
+    if: github.event.label.name == 'M-Migration-Guide'
     steps:
       - uses: actions/checkout@v5
         with:
@@ -44,7 +44,7 @@ jobs:
             })
   comment-on-release-note-label:
     runs-on: ubuntu-latest
-    if: github.event.label.name == 'M-Needs-Release-Note'
+    if: github.event.label.name == 'M-Release-Note'
     steps:
       - uses: actions/checkout@v5
         with:

--- a/release-content/migration_guides.md
+++ b/release-content/migration_guides.md
@@ -1,6 +1,6 @@
 # Bevy's Migration Guide Process
 
-Hi! Did someone add `M-Needs-Migration-Guide` to your PR? If so, you're in the right place.
+Hi! Did someone add `M-Migration-Guide` to your PR? If so, you're in the right place.
 Let's talk about how this process works.
 
 When we make breaking changes to Bevy, we need to communicate them to users so their libraries and applications can be moved to the new Bevy version.
@@ -97,6 +97,6 @@ Keep it short and sweet:
   
   **Relocations**
   
-  |Item|0.15 Path|0.16 Path|
-  |-|-|-|
-  |`Foo`|`bar::foo`|`baz`|
+  | Item  | 0.15 Path  | 0.16 Path |
+  | ----- | ---------- | --------- |
+  | `Foo` | `bar::foo` | `baz`     |

--- a/release-content/release_notes.md
+++ b/release-content/release_notes.md
@@ -1,6 +1,6 @@
 # Bevy's Release Notes Process
 
-Hi! Did someone add `M-Needs-Release-Note` to your PR? If so, you're in the right place.
+Hi! Did someone add `M-Release-Note` to your PR? If so, you're in the right place.
 Let's talk about how this process works.
 
 When we make high-impact changes to Bevy, we need to communicate them to users (and potential users!).


### PR DESCRIPTION
# Objective

https://github.com/bevyengine/bevy-website/pull/2293 proposed a rename of our `M-Needs-Release-Note` and `M-Needs-Migration-Guide` labels for improved clarity.

This has been approved, so I'm merging that PR.

This repo lists these labels in a few places for automation / contributor help, and they need to be updated.

## Solution

Grep for these like @bd103 told me to in https://github.com/bevyengine/bevy-website/pull/2293#issuecomment-3422121003

## Follow-up work

Once this PR is merged I'll actually rename the label.