### PR TITLE
order rhombus vertices in "hull-order"

### DIFF
--- a/crates/bevy_mesh/src/primitives/dim2.rs
+++ b/crates/bevy_mesh/src/primitives/dim2.rs
@@ -906,7 +906,7 @@ impl MeshBuilder for RhombusMeshBuilder {
         ];
         let normals = vec![[0.0, 0.0, 1.0]; 4];
         let uvs = vec![[1.0, 0.5], [0.5, 0.0], [0.0, 0.5], [0.5, 1.0]];
-        let indices = Indices::U32(vec![0, 1, 2, 2, 3, 0]);
+        let indices = Indices::U32(vec![2, 0, 1, 2, 3, 0]);
 
         Mesh::new(
             PrimitiveTopology::TriangleList,


### PR DESCRIPTION
# Objective

Most Mesh2d primitives order their vertices in what I'll call "hull order", which is to say, in an sequential outline of the shape.
A Rectangle, for example, is:

```rust
let positions = vec![
  [hw, hh, 0.0],
  [-hw, hh, 0.0],
  [-hw, -hh, 0.0],
  [hw, -hh, 0.0],
];
```

The Rhombus does not follow this pattern, instead using "right, left, top, bottom" order for the vertex buffer.

This isn't a general issue, but there is definitely a pattern to the way the shapes are laid out, and Rhombus doesn't follow it.
This means you can use the vertex buffer alone to define a hull for most 2d shapes (regular polygons, lines, circles, capsules, etc), except the rhombus (also not valid for annulus/ring afaik)

## Solution

Re-order the indices and vertices for Rhombus, resulting in the same output, but enabling the vertex buffer to be used to define a "hull" directly, without the index buffer.

## Testing

Run the 2d_shapes demo, see wireframe is as expected.

<img width="2432" height="910" alt="screenshot-2025-10-21-at-09 03 12@2x" src="https://github.com/user-attachments/assets/d95237a0-5fe1-4cd8-a4a5-0b8849557427" />

---

## Showcase

In a 2d visibility mesh demo I was building, this caused an issue when trying to directly use the vertex buffer to define the outer "hull" shape.

old rhombus on left, new rhombus on right.

<img width="334" height="238" alt="screenshot-2025-10-21-at-08 40 14@2x" src="https://github.com/user-attachments/assets/22cb2ff2-7070-4c46-bc7f-d6d18372af79" />

