### PR TITLE
Include SpawnScene in docs for Main schedule

### DIFF
--- a/crates/bevy_app/src/main_schedule.rs
+++ b/crates/bevy_app/src/main_schedule.rs
@@ -174,7 +174,7 @@ pub struct Update;
 
 /// The schedule that contains scene spawning.
 ///
-/// See the [`Main`] schedule for some details about how schedules are run.
+/// This runs after [`Update`] and before [`PostUpdate`]. See the [`Main`] schedule for more details about how schedules are run.
 #[derive(ScheduleLabel, Clone, Debug, PartialEq, Eq, Hash, Default)]
 pub struct SpawnScene;
 


### PR DESCRIPTION
# Objective

Currently the docs for [`SpawnScene`](https://docs.rs/bevy/latest/bevy/app/struct.SpawnScene.html) link to the [`Main`](https://docs.rs/bevy/latest/bevy/prelude/struct.Main.html) schedule, but those docs don't mention when it runs.

## Solution

Updates docs to include this information, based on the schedule ordering defined here:

https://github.com/bevyengine/bevy/blob/78d940cbfe177e3585fe19145e73c76172f4085e/crates/bevy_app/src/main_schedule.rs#L222-L224
