### PR TITLE
fix dead links in Mesh2d doc comment

### DIFF
--- a/crates/bevy_mesh/src/components.rs
+++ b/crates/bevy_mesh/src/components.rs
@@ -12,8 +12,8 @@ use derive_more::derive::From;
 
 /// A component for 2D meshes. Requires a [`MeshMaterial2d`] to be rendered, commonly using a [`ColorMaterial`].
 ///
-/// [`MeshMaterial2d`]: <https://docs.rs/bevy/latest/bevy/sprite/struct.MeshMaterial2d.html>
-/// [`ColorMaterial`]: <https://docs.rs/bevy/latest/bevy/sprite/struct.ColorMaterial.html>
+/// [`MeshMaterial2d`]: <https://docs.rs/bevy/latest/bevy/prelude/struct.MeshMaterial2d.html>
+/// [`ColorMaterial`]: <https://docs.rs/bevy/latest/bevy/prelude/struct.ColorMaterial.html>
 ///
 /// # Example
 ///


### PR DESCRIPTION
at some point, the things it was pointing to were moved from bevy/sprite to bevy/prelude, so fix the link to point there
