### PR TITLE
Fix GLTF files being broken when loaded from custom asset sources.

### DIFF
--- a/crates/bevy_gltf/src/loader/gltf_ext/texture.rs
+++ b/crates/bevy_gltf/src/loader/gltf_ext/texture.rs
@@ -30,8 +30,10 @@ pub(crate) fn texture_handle(
             if let Ok(_data_uri) = DataUri::parse(uri) {
                 load_context.get_label_handle(texture_label(texture).to_string())
             } else {
-                let parent = load_context.path().parent().unwrap();
-                let image_path = parent.join(uri);
+                let image_path = load_context
+                    .asset_path()
+                    .resolve_embed(uri)
+                    .expect("all URIs were already validated when we initially loaded textures");
                 load_context.load(image_path)
             }
         }

--- a/crates/bevy_gltf/src/loader/mod.rs
+++ b/crates/bevy_gltf/src/loader/mod.rs
@@ -1917,6 +1917,7 @@ mod test {
     use bevy_log::LogPlugin;
     use bevy_mesh::skinning::SkinnedMeshInverseBindposes;
     use bevy_mesh::MeshPlugin;
+    use bevy_pbr::StandardMaterial;
     use bevy_scene::ScenePlugin;
 
     fn test_app(dir: Dir) -> App {
@@ -2407,6 +2408,11 @@ mod test {
     fn reads_images_in_custom_asset_source() {
         let (mut app, dir) = test_app_custom_asset_source();
 
+        app.init_asset::<StandardMaterial>();
+
+        // Note: We need the material here since otherwise we don't store the texture handle, which
+        // can result in the image getting dropped leading to the gltf never being loaded with
+        // dependencies.
         dir.insert_asset_text(
             Path::new("abc.gltf"),
             r#"
@@ -2429,6 +2435,16 @@ mod test {
         {
             "magFilter": 9729,
             "minFilter": 9729
+        }
+    ],
+    "materials": [
+        {
+            "pbrMetallicRoughness": {
+                "baseColorTexture": {
+                    "index": 0,
+                    "texCoord": 0
+                }
+            }
         }
     ]
 }


### PR DESCRIPTION
# Objective

- Fixes #10903

## Solution

- Stop using `Path::join` for joining asset paths and instead use `AssetPath::resolve_embed`.

## Testing

- Added 2 tests!
