### PR TITLE
Add sticky ui nodes

### DIFF
--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -347,15 +347,16 @@ impl From<Vec2> for ScrollPosition {
     }
 }
 
-/// Determines which axes of a node are *sticky* during scrolling.
+/// Controls whether a UI element ignores its parent's [`ScrollPosition`] along specific axes.
 ///
-/// A **sticky** node maintains its position along the specified axes
-/// instead of moving with its scrolled parent content when [`ScrollPosition`] is applied.
+/// When an axis is set to `true`, the node will not have the parent’s scroll position applied
+/// on that axis. This can be used to keep an element visually fixed along one or both axes
+/// even when its parent UI element is scrolled.
 #[derive(Component, Debug, Clone, Default, Deref, DerefMut, Reflect)]
 #[reflect(Component, Default, Clone)]
-pub struct ScrollSticky(pub BVec2);
+pub struct IgnoreScroll(pub BVec2);
 
-impl From<BVec2> for ScrollSticky {
+impl From<BVec2> for IgnoreScroll {
     fn from(value: BVec2) -> Self {
         Self(value)
     }

--- a/examples/ui/scroll.rs
+++ b/examples/ui/scroll.rs
@@ -344,11 +344,10 @@ fn bidirectional_scrolling_list_with_sticky(font_handle: Handle<Font>) -> impl B
                         .flat_map(|y| (0..30).map(move |x| (y, x)))
                         .map(move |(y, x)| {
                             let value = font_handle.clone();
-                            // Sticky elements are not affected by scrolling
-                            // Some cells can be made sticky and drawn on top
-                            // of other cells with background to
-                            // create effects like sticky headers.
-                            let sticky = BVec2 {
+                            // Simple sticky nodes at top and left sides of UI node
+                            // can be achieved by combining such effects as
+                            // IgnoreScroll, ZIndex, BackgroundColor for child UI nodes.
+                            let ignore_scroll = BVec2 {
                                 x: x == 0,
                                 y: y == 0,
                             };
@@ -370,7 +369,7 @@ fn bidirectional_scrolling_list_with_sticky(font_handle: Handle<Font>) -> impl B
                                 },
                                 Label,
                                 AccessibilityNode(Accessible::new(role)),
-                                ScrollSticky(sticky),
+                                IgnoreScroll(ignore_scroll),
                                 ZIndex(z_index),
                                 BackgroundColor(Color::Srgba(background_color)),
                             )

--- a/release-content/release-notes/ignore-scroll.md
+++ b/release-content/release-notes/ignore-scroll.md
@@ -1,0 +1,9 @@
+---
+title: Support for Ui nodes that ignore parent scroll position.
+authors: ["@PPakalns"]
+pull_requests: [21648]
+---
+
+Adds the `IgnoreScroll` component, which controls whether a UI element ignores its parent’s `ScrollPosition` along specific axes.
+
+This can be used to achieve basic sticky row and column headers in scrollable UI layouts. See `scroll` example.

--- a/release-content/release-notes/scroll-sticky-ui-node.md
+++ b/release-content/release-notes/scroll-sticky-ui-node.md
@@ -1,8 +1,0 @@
----
-title: Scroll sticky ui nodes
-authors: ["@PPakalns"]
-pull_requests: [21648]
----
-
-Adds the `ScrollSticky` component to control sticky behavior in scrollable UI containers.
-Nodes with stickiness enabled on specific axes remain pinned along those axes while other content scrolls, making it possible to build simple variants of fixed column and row headers.


### PR DESCRIPTION
# Objective

Add UI nodes that can be used as sticky row, column headers.

## Solution

Add ui nodes that ignore parent node scroll position. This approach only allows for row, column headers that are located at the top and at the left side of the parent node.  Multiple rows, columns can be used as headers.

## Testing

Extended scroll example.

## Prior art

Used the same approach to implement sticky elements in [egui taffy (sticky)](https://github.com/PPakalns/egui_taffy?tab=readme-ov-file#sticky-elements-sticky-row-and-column-in-scrollable-grid)

---

## Showcase


https://github.com/user-attachments/assets/1c5bcc5a-81c8-4ccb-9eda-6f0decbd0b79


