### PR TITLE
Doc - Link directly to DespawnOnEnter/Exit

### DIFF
--- a/crates/bevy_state/src/lib.rs
+++ b/crates/bevy_state/src/lib.rs
@@ -29,7 +29,7 @@
 //! - The [`in_state<S>`](crate::condition::in_state) and [`state_changed<S>`](crate::condition::state_changed) run conditions - which are used
 //!   to determine whether a system should run based on the current state.
 //!
-//! Bevy also provides ("state-scoped entities")\ [`state_scoped`](crate::state_scoped) functionality for managing the lifetime of entities in the context of game states.
+//! Bevy also provides functionality for managing the lifetime of entities in the context of game states, using the [`state_scoped`] module.
 //! Specifically, the marker components [`DespawnOnEnter<S>`](crate::state_scoped::DespawnOnEnter) and [`DespawnOnExit<S>`](crate::state_scoped::DespawnOnExit) are provided for despawning entities on state transition.
 //! This, especially in combination with system scheduling, enables a flexible and expressive way to manage spawning and despawning entities.
 


### PR DESCRIPTION
# Objective

* Make DespawnOnExit more discoverable.
* Fix broken link text - the parenthetical before it seems to mess it up.

## Solution

* Link directly to DespawnOnExit from the module documentation instead of just the containing module.

## Testing

None. Somebody should build the docs to make sure the links actually work (I'm 99% sure they do) and that the `\` added actually fixes the link on line 32 (I'm only 80% sure it does)

## Further Questions

I'm wondering if this functionality should be listed in the bulleted list that precedes this paragraph.