### PR TITLE
fix docs for `Entity::from_row`

### DIFF
--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -496,7 +496,7 @@ impl Entity {
     /// ```
     pub const PLACEHOLDER: Self = Self::from_row(EntityRow::PLACEHOLDER);
 
-    /// Creates a new entity ID with the specified `row` and a generation of 1.
+    /// Creates a new entity ID with the specified `row` and an unspecified generation.
     ///
     /// # Note
     ///


### PR DESCRIPTION
# Objective

The docs state that `Entity::from_row` creates an entity with a generation of `1`, which was the case previously. With `Entity` internals being reworked in `0.17` however, this is no longer the case, as the generation used is now `EntityGeneration::FIRST`, currently equivalent to `0`.

## Solution

This PR changes the docs to state an "unspecified" generation to allow further changes to implementation without needing another rewrite, as the docs rather consistently refer to `Entity`, `EntityRow`, and `EntityGeneration` as being opaque identifiers.