### PR TITLE
Don't use `[!Default; 0]: Default` impl

### DIFF
--- a/crates/bevy_camera/src/primitives.rs
+++ b/crates/bevy_camera/src/primitives.rs
@@ -652,7 +652,7 @@ mod tests {
 
     #[test]
     fn aabb_enclosing() {
-        assert_eq!(Aabb::enclosing(<[Vec3; 0]>::default()), None);
+        assert_eq!(Aabb::enclosing([] as [Vec3; 0]), None);
         assert_eq!(
             Aabb::enclosing(vec![Vec3::ONE]).unwrap(),
             Aabb::from_min_max(Vec3::ONE, Vec3::ONE)

--- a/crates/bevy_ecs/src/entity/unique_array.rs
+++ b/crates/bevy_ecs/src/entity/unique_array.rs
@@ -157,7 +157,7 @@ impl<T: EntityEquivalent, const N: usize> DerefMut for UniqueEntityEquivalentArr
 
 impl<T: EntityEquivalent> Default for UniqueEntityEquivalentArray<T, 0> {
     fn default() -> Self {
-        Self(Default::default())
+        Self([])
     }
 }
 


### PR DESCRIPTION
# Objective

- See https://github.com/rust-lang/rust/pull/145457, we want to remove unconditional `[T; 0]: Default` impl. That would be a breaking change breaking `bevy_ecs` and (a test of) `bevy_camera`.

## Solution

- Replace `<[T; 0]>::default()` calls with `[]`

## Testing

- It compiles, the `<[T; 0]>::default()` is equivalent to `[]`, no additional testing required