### PR TITLE
fix path when sending screenshots to pixeleagle

### DIFF
--- a/.github/workflows/send-screenshots-to-pixeleagle.yml
+++ b/.github/workflows/send-screenshots-to-pixeleagle.yml
@@ -56,8 +56,6 @@ jobs:
 
           SAVEIFS=$IFS
 
-          cd ${{ inputs.artifact }}
-
           # Read the hashes of the screenshot for fast comparison when they are equal
           IFS=$'\n'
           # Build a json array of screenshots and their hashes


### PR DESCRIPTION
# Objective

- #21664 broke CI. Failures wasn't triggered by this PR as it's the CI that runs from the main branch

## Solution

- download-artifact v5 changed how artefacts are handled. we met a case not documented in their breaking change
