### PR TITLE
Add viewport_to_ndc

### DIFF
--- a/crates/bevy_camera/src/camera.rs
+++ b/crates/bevy_camera/src/camera.rs
@@ -768,11 +768,11 @@ impl Camera {
         let target_rect = self
             .logical_viewport_rect()
             .ok_or(ViewportConversionError::NoViewportSize)?;
-        let mut rect_relative = (viewport_position - target_rect.min) / target_rect.size();
-        let mut ndc_xy = rect_relative * 2. - Vec2::ONE;
+        let rect_relative = (viewport_position - target_rect.min) / target_rect.size();
+        let mut ndc = rect_relative * 2. - Vec2::ONE;
         // Flip the Y co-ordinate from the top to the bottom to enter NDC.
-        ndc_xy.y = -ndc_xy.y;
-        Ok(ndc_xy)
+        ndc.y = -ndc.y;
+        Ok(ndc)
     }
 }
 


### PR DESCRIPTION
# Objective

- Computing the ndc from a viewport coordinates is already done in a few places.
- It's can be useful for users, not just internally.

## Solution

- Extract it to a function

## Testing

- I'm using it in a currently unfinished PR for gpu picking and things worked as expected
- I also tested 3d_viewport_to_world and 2d_viewport_to_world
