### PR TITLE
Rename the `strikethrough` example to `strikethrough_and_underline`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3561,13 +3561,13 @@ category = "UI (User Interface)"
 wasm = true
 
 [[example]]
-name = "strikethrough"
-path = "examples/ui/strikethrough.rs"
+name = "strikethrough_and_underline"
+path = "examples/ui/strikethrough_and_underline.rs"
 doc-scrape-examples = true
 
-[package.metadata.example.strikethrough]
-name = "Strikethrough"
-description = "Demonstrates how to display text with strikethrough."
+[package.metadata.example.strikethrough_and_underline]
+name = "Strikethrough and Underline"
+description = "Demonstrates how to display text with strikethrough and underline."
 category = "UI (User Interface)"
 wasm = true
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -570,7 +570,7 @@ Example | Description
 [Stacked Gradients](../examples/ui/stacked_gradients.rs) | An example demonstrating stacked gradients
 [Standard Widgets](../examples/ui/standard_widgets.rs) | Demonstrates use of core (headless) widgets in Bevy UI
 [Standard Widgets (w/Observers)](../examples/ui/standard_widgets_observers.rs) | Demonstrates use of core (headless) widgets in Bevy UI, with Observers
-[Strikethrough](../examples/ui/strikethrough.rs) | Demonstrates how to display text with strikethrough.
+[Strikethrough and Underline](../examples/ui/strikethrough_and_underline.rs) | Demonstrates how to display text with strikethrough and underline.
 [Tab Navigation](../examples/ui/tab_navigation.rs) | Demonstration of Tab Navigation between UI elements
 [Text](../examples/ui/text.rs) | Illustrates creating and updating text
 [Text Background Colors](../examples/ui/text_background_colors.rs) | Demonstrates text background colors

--- a/examples/ui/strikethrough_and_underline.rs
+++ b/examples/ui/strikethrough_and_underline.rs
@@ -1,4 +1,4 @@
-//! This example illustrates UI text with strikethrough
+//! This example illustrates UI text with strikethrough and underline decorations
 
 use bevy::{
     color::palettes::css::{GREEN, NAVY, RED, YELLOW},
@@ -16,7 +16,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2d);
     commands.spawn((
         Text::new("struck\nstruck"),
-        // Just add the `Strikethrough` component to any `Text`, `Text2d` or `TextSpan` and it's text will be struck through.
+        // Just add the `Strikethrough` component to any `Text`, `Text2d` or `TextSpan` and its text will be struck through
         Strikethrough,
         TextFont {
             font: asset_server.load("fonts/FiraSans-Bold.ttf"),
@@ -49,6 +49,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 StrikethroughColor(RED.into()),
                 TextBackgroundColor(GREEN.into()),
             ),
+            // Text entities with the `Underline` component will drawn with underline
             (Text::new("underline"), Underline),
             (
                 Text::new("struck"),


### PR DESCRIPTION
# Objective

Rename the example, fix a typo in its ("it's") comments.

