### PR TITLE
Text2d underline shadows fix

### DIFF
--- a/crates/bevy_sprite_render/src/text2d/mod.rs
+++ b/crates/bevy_sprite_render/src/text2d/mod.rs
@@ -189,7 +189,7 @@ pub fn extract_text2d_sprite(
 
                 if has_underline {
                     let render_entity = commands.spawn(TemporaryRenderEntity).id();
-                    let offset = run.strikethrough_position() * Vec2::new(1., -1.);
+                    let offset = run.underline_position() * Vec2::new(1., -1.);
                     let transform =
                         shadow_transform * GlobalTransform::from_translation(offset.extend(0.));
                     extracted_sprites.sprites.push(ExtractedSprite {
@@ -204,7 +204,7 @@ pub fn extract_text2d_sprite(
                             anchor: Vec2::ZERO,
                             rect: None,
                             scaling_mode: None,
-                            custom_size: Some(run.strikethrough_size()),
+                            custom_size: Some(run.underline_size()),
                         },
                     });
                 }


### PR DESCRIPTION
# Objective

Text2d underline shadow is being drawn using the strikethrough position and size values.  Draw it with the correct geometry.

## Solution

Use the underline values.