### PR TITLE
Document `SystemState` + exclusive system patterns

### DIFF
--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -91,6 +91,25 @@ impl SystemMeta {
     #[inline]
     pub fn set_non_send(&mut self) {
         self.flags |= SystemStateFlags::NON_SEND;
+    /// Alternatively, for exclusive systems the ECS can automatically cache a
+    /// `SystemState` for you. The trait [`ExclusiveSystemParam`] is implemented for
+    /// `&'a mut SystemState<P>`, so if your function is an exclusive system
+    /// (takes `&mut World` as its first parameter) you can accept
+    /// `&mut SystemState<...>` directly and the ECS will initialize and persist it
+    /// across invocations. Example:
+    /// ```
+    /// # use bevy_ecs::prelude::*;
+    /// # use bevy_ecs::system::SystemState;
+    /// #
+    /// # #[derive(Message)]
+    /// # struct MyMessage;
+    /// fn exclusive_system(world: &mut World, system_state: &mut SystemState<MessageReader<MyMessage>>) {
+    ///     let mut message_reader = system_state.get_mut(world);
+    ///     for message in message_reader.read() {
+    ///         println!("Hello World!");
+    ///     }
+    /// }
+    /// ```
     }
 
     /// Returns true if the system has deferred [`SystemParam`]'s

--- a/crates/bevy_ecs/src/system/system_registry.rs
+++ b/crates/bevy_ecs/src/system/system_registry.rs
@@ -500,6 +500,16 @@ impl World {
 
     /// Runs a cached system, registering it if necessary.
     ///
+    /// # Type Inference Note
+    /// If the system returns `()`, you may need to explicitly constrain the output
+    /// type for error handling:
+    ///
+    /// ```rust
+    /// () = world.run_system_cached(my_system)?;
+    /// ```
+    ///
+    /// Without this, Rust may fail to infer the system’s output type and produce
+    /// a `IntoResult<!>` inference error.
     /// See [`World::register_system_cached`] for more information.
     pub fn run_system_cached<O: 'static, M, S: IntoSystem<(), O, M> + 'static>(
         &mut self,
@@ -509,7 +519,18 @@ impl World {
     }
 
     /// Runs a cached system with an input, registering it if necessary.
+    /// Runs a cached system, registering it if necessary.
     ///
+    /// # Type Inference Note
+    /// If the system returns `()`, you may need to explicitly constrain the output
+    /// type for error handling:
+    ///
+    /// ```rust
+    /// () = world.run_system_cached(my_system)?;
+    /// ```
+    ///
+    /// Without this, Rust may fail to infer the system’s output type and produce
+    /// a `IntoResult<!>` inference error.
     /// See [`World::register_system_cached`] for more information.
     pub fn run_system_cached_with<I, O, M, S>(
         &mut self,


### PR DESCRIPTION
# Objective

fixes #12587

This issue is a more specific form of https://github.com/bevyengine/bevy/issues/8770, which has been open for over nine months with no apparent resolution.

The [caching example](https://docs.rs/bevy/latest/bevy/ecs/system/struct.SystemState.html#example) for SystemState in the documentation shows the use of a function-local struct to cache a SystemState object. However, caching a SystemState has gotten easier since this documentation was written - with the addition of ExclusiveSystemParam and its implementation on &'a mut SystemState<P>, we can have the ECS handle caching for us.

The documentation should be updated to reflect this.

## Solution

- Updated doccumentation to reach the goal state above

## Testing

No testing was needed; however, review should ensure I actually achieved the goal state above. I believe, to the best of my abilities, I have but I have never interacted with rust of a codebase as large as this before. 

---