### PR TITLE
Deduplicate world_to_view logic

### DIFF
--- a/crates/bevy_camera/src/camera.rs
+++ b/crates/bevy_camera/src/camera.rs
@@ -494,7 +494,7 @@ impl Camera {
     /// This function is shared by `world_to_viewport` and `world_to_viewport_with_depth`
     /// to avoid code duplication.
     ///
-    /// Returns a tuple `(viewport_position, ndc_depth)`.
+    /// Returns a tuple `(viewport_position, ndc_space_coords.z)`.
     fn world_to_viewport_core(
         &self,
         camera_transform: &GlobalTransform,

--- a/crates/bevy_camera/src/camera.rs
+++ b/crates/bevy_camera/src/camera.rs
@@ -513,7 +513,7 @@ impl Camera {
         if ndc_space_coords.z > 1.0 {
             return Err(ViewportConversionError::PastNearPlane);
         }
-        
+
         let depth = ndc_space_coords.z;
 
         // Flip the Y co-ordinate origin from the bottom to the top.

--- a/crates/bevy_camera/src/camera.rs
+++ b/crates/bevy_camera/src/camera.rs
@@ -489,7 +489,7 @@ impl Camera {
         self.computed.clip_from_view
     }
 
-    /// Core conversion logic to compute viewport coordinates and NDC depth from a world position.
+    /// Core conversion logic to compute viewport coordinates
     ///
     /// This function is shared by `world_to_viewport` and `world_to_viewport_with_depth`
     /// to avoid code duplication.


### PR DESCRIPTION
# Objective

- The functions logical_viewport_size and physical_viewport_size in camera.rs share a very similar pattern.
- Refactor code to reduce duplication.

## Solution

- extract to a shared function.

## Testing

- Ran `cargo test` and all the tests pass.
