### PR TITLE
Remove "should be called each frame" in `GizmoBuffer` document.

### DIFF
--- a/crates/bevy_gizmos/src/arcs.rs
+++ b/crates/bevy_gizmos/src/arcs.rs
@@ -17,8 +17,6 @@ where
 {
     /// Draw an arc, which is a part of the circumference of a circle, in 2D.
     ///
-    /// This should be called for each frame the arc needs to be rendered.
-    ///
     /// # Arguments
     /// - `isometry` defines the translation and rotation of the arc.
     ///   - the translation specifies the center of the arc
@@ -131,8 +129,6 @@ where
     /// - starting at `Vec3::X`
     /// - embedded in the XZ plane
     /// - rotates counterclockwise
-    ///
-    /// This should be called for each frame the arc needs to be rendered.
     ///
     /// # Arguments
     /// - `angle`: sets how much of a circle circumference is passed, e.g. PI is half a circle. This

--- a/crates/bevy_gizmos/src/arrows.rs
+++ b/crates/bevy_gizmos/src/arrows.rs
@@ -108,8 +108,6 @@ where
 {
     /// Draw an arrow in 3D, from `start` to `end`. Has four tips for convenient viewing from any direction.
     ///
-    /// This should be called for each frame the arrow needs to be rendered.
-    ///
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
@@ -139,8 +137,6 @@ where
 
     /// Draw an arrow in 2D (on the xy plane), from `start` to `end`.
     ///
-    /// This should be called for each frame the arrow needs to be rendered.
-    ///
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
@@ -168,8 +164,6 @@ where
 {
     /// Draw a set of axes local to the given transform (`transform`), with length scaled by a factor
     /// of `base_length`.
-    ///
-    /// This should be called for each frame the axes need to be rendered.
     ///
     /// # Example
     /// ```
@@ -201,8 +195,6 @@ where
 
     /// Draw a set of axes local to the given transform (`transform`), with length scaled by a factor
     /// of `base_length`.
-    ///
-    /// This should be called for each frame the axes need to be rendered.
     ///
     /// # Example
     /// ```

--- a/crates/bevy_gizmos/src/circles.rs
+++ b/crates/bevy_gizmos/src/circles.rs
@@ -30,8 +30,6 @@ where
     /// - the center is at `Vec3::ZERO`
     /// - the `half_sizes` are aligned with the `Vec3::X` and `Vec3::Y` axes.
     ///
-    /// This should be called for each frame the ellipse needs to be rendered.
-    ///
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
@@ -70,8 +68,6 @@ where
     ///
     /// - the center is at `Vec2::ZERO`
     /// - the `half_sizes` are aligned with the `Vec2::X` and `Vec2::Y` axes.
-    ///
-    /// This should be called for each frame the ellipse needs to be rendered.
     ///
     /// # Example
     /// ```
@@ -151,8 +147,6 @@ where
     /// - the center is at `Vec2::ZERO`
     /// - the radius is aligned with the `Vec2::X` and `Vec2::Y` axes.
     ///
-    /// This should be called for each frame the circle needs to be rendered.
-    ///
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
@@ -192,8 +186,6 @@ where
     ///
     /// - the center is at `Vec3::ZERO`
     /// - the 3 circles are in the XY, YZ and XZ planes.
-    ///
-    /// This should be called for each frame the sphere needs to be rendered.
     ///
     /// # Example
     /// ```

--- a/crates/bevy_gizmos/src/cross.rs
+++ b/crates/bevy_gizmos/src/cross.rs
@@ -19,8 +19,6 @@ where
     /// - the center is at `Vec3::ZERO`
     /// - the `half_size`s are aligned with the `Vec3::X`, `Vec3::Y` and `Vec3::Z` axes.
     ///
-    /// This should be called for each frame the cross needs to be rendered.
-    ///
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
@@ -53,8 +51,6 @@ where
     ///
     /// - the center is at `Vec3::ZERO`
     /// - the `half_size`s are aligned with the `Vec3::X` and `Vec3::Y` axes.
-    ///
-    /// This should be called for each frame the cross needs to be rendered.
     ///
     /// # Example
     /// ```

--- a/crates/bevy_gizmos/src/curves.rs
+++ b/crates/bevy_gizmos/src/curves.rs
@@ -18,8 +18,6 @@ where
 {
     /// Draw a curve, at the given time points, sampling in 2D.
     ///
-    /// This should be called for each frame the curve needs to be rendered.
-    ///
     /// Samples of time points outside of the curve's domain will be filtered out and won't
     /// contribute to the rendering. If you wish to render the curve outside of its domain you need
     /// to create a new curve with an extended domain.
@@ -51,8 +49,6 @@ where
     }
 
     /// Draw a curve, at the given time points, sampling in 3D.
-    ///
-    /// This should be called for each frame the curve needs to be rendered.
     ///
     /// Samples of time points outside of the curve's domain will be filtered out and won't
     /// contribute to the rendering. If you wish to render the curve outside of its domain you need
@@ -88,8 +84,6 @@ where
     }
 
     /// Draw a curve, at the given time points, sampling in 2D, with a color gradient.
-    ///
-    /// This should be called for each frame the curve needs to be rendered.
     ///
     /// Samples of time points outside of the curve's domain will be filtered out and won't
     /// contribute to the rendering. If you wish to render the curve outside of its domain you need
@@ -131,8 +125,6 @@ where
     }
 
     /// Draw a curve, at the given time points, sampling in 3D, with a color gradient.
-    ///
-    /// This should be called for each frame the curve needs to be rendered.
     ///
     /// Samples of time points outside of the curve's domain will be filtered out and won't
     /// contribute to the rendering. If you wish to render the curve outside of its domain you need

--- a/crates/bevy_gizmos/src/gizmos.rs
+++ b/crates/bevy_gizmos/src/gizmos.rs
@@ -376,8 +376,6 @@ where
     }
     /// Draw a line in 3D from `start` to `end`.
     ///
-    /// This should be called for each frame the line needs to be rendered.
-    ///
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
@@ -398,8 +396,6 @@ where
     }
 
     /// Draw a line in 3D with a color gradient from `start` to `end`.
-    ///
-    /// This should be called for each frame the line needs to be rendered.
     ///
     /// # Example
     /// ```
@@ -428,8 +424,6 @@ where
 
     /// Draw a line in 3D from `start` to `start + vector`.
     ///
-    /// This should be called for each frame the line needs to be rendered.
-    ///
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
@@ -449,8 +443,6 @@ where
     }
 
     /// Draw a line in 3D with a color gradient from `start` to `start + vector`.
-    ///
-    /// This should be called for each frame the line needs to be rendered.
     ///
     /// # Example
     /// ```
@@ -477,8 +469,6 @@ where
     }
 
     /// Draw a line in 3D made of straight segments between the points.
-    ///
-    /// This should be called for each frame the line needs to be rendered.
     ///
     /// # Example
     /// ```
@@ -507,8 +497,6 @@ where
     }
 
     /// Draw a line in 3D made of straight segments between the points, with a color gradient.
-    ///
-    /// This should be called for each frame the lines need to be rendered.
     ///
     /// # Example
     /// ```
@@ -560,8 +548,6 @@ where
     /// - the center is at `Vec3::ZERO`
     /// - the sizes are aligned with the `Vec3::X` and `Vec3::Y` axes.
     ///
-    /// This should be called for each frame the rectangle needs to be rendered.
-    ///
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
@@ -583,8 +569,6 @@ where
     }
 
     /// Draw a wireframe cube in 3D.
-    ///
-    /// This should be called for each frame the cube needs to be rendered.
     ///
     /// # Example
     /// ```
@@ -623,8 +607,6 @@ where
     }
 
     /// Draw a wireframe aabb in 3D.
-    ///
-    /// This should be called for each frame the aabb needs to be rendered.
     ///
     /// # Example
     /// ```
@@ -677,8 +659,6 @@ where
 
     /// Draw a line in 2D from `start` to `end`.
     ///
-    /// This should be called for each frame the line needs to be rendered.
-    ///
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
@@ -698,8 +678,6 @@ where
     }
 
     /// Draw a line in 2D with a color gradient from `start` to `end`.
-    ///
-    /// This should be called for each frame the line needs to be rendered.
     ///
     /// # Example
     /// ```
@@ -727,8 +705,6 @@ where
 
     /// Draw a line in 2D made of straight segments between the points.
     ///
-    /// This should be called for each frame the line needs to be rendered.
-    ///
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
@@ -752,8 +728,6 @@ where
     }
 
     /// Draw a line in 2D made of straight segments between the points, with a color gradient.
-    ///
-    /// This should be called for each frame the line needs to be rendered.
     ///
     /// # Example
     /// ```
@@ -786,8 +760,6 @@ where
 
     /// Draw a line in 2D from `start` to `start + vector`.
     ///
-    /// This should be called for each frame the line needs to be rendered.
-    ///
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
@@ -807,8 +779,6 @@ where
     }
 
     /// Draw a line in 2D with a color gradient from `start` to `start + vector`.
-    ///
-    /// This should be called for each frame the line needs to be rendered.
     ///
     /// # Example
     /// ```
@@ -840,8 +810,6 @@ where
     ///
     /// - the center is at `Vec2::ZERO`
     /// - the sizes are aligned with the `Vec2::X` and `Vec2::Y` axes.
-    ///
-    /// This should be called for each frame the rectangle needs to be rendered.
     ///
     /// # Example
     /// ```

--- a/crates/bevy_gizmos/src/grid.rs
+++ b/crates/bevy_gizmos/src/grid.rs
@@ -180,8 +180,6 @@ where
 {
     /// Draw a 2D grid in 3D.
     ///
-    /// This should be called for each frame the grid needs to be rendered.
-    ///
     /// The grid's default orientation aligns with the XY-plane.
     ///
     /// # Arguments
@@ -236,8 +234,6 @@ where
 
     /// Draw a 3D grid of voxel-like cells.
     ///
-    /// This should be called for each frame the grid needs to be rendered.
-    ///
     /// # Arguments
     ///
     /// - `isometry` defines the translation and rotation of the grid.
@@ -288,8 +284,6 @@ where
     }
 
     /// Draw a grid in 2D.
-    ///
-    /// This should be called for each frame the grid needs to be rendered.
     ///
     /// # Arguments
     ///

--- a/crates/bevy_gizmos/src/rounded_box.rs
+++ b/crates/bevy_gizmos/src/rounded_box.rs
@@ -233,8 +233,6 @@ where
 {
     /// Draw a wireframe rectangle with rounded corners in 3D.
     ///
-    /// This should be called for each frame the rectangle needs to be rendered.
-    ///
     /// # Arguments
     ///
     /// - `isometry` defines the translation and rotation of the rectangle.
@@ -286,8 +284,6 @@ where
     }
 
     /// Draw a wireframe rectangle with rounded corners in 2D.
-    ///
-    /// This should be called for each frame the rectangle needs to be rendered.
     ///
     /// # Arguments
     ///
@@ -343,8 +339,6 @@ where
     }
 
     /// Draw a wireframe cuboid with rounded corners in 3D.
-    ///
-    /// This should be called for each frame the cuboid needs to be rendered.
     ///
     /// # Arguments
     ///


### PR DESCRIPTION
`GizmoBuffer` is used by both `GizmoAsset` and `Gizmos`, and the former doesn't require these methods to be calle each frame.

# Objective

Fixes #21711

## Solution

- Remove those lines in the document.

## Testing

- Run `cargo doc` and no longer see those lines in the document of `GizmoAsset`.
