### PR TITLE
Fix gizmos_render feature typo

### DIFF
--- a/crates/bevy_internal/src/lib.rs
+++ b/crates/bevy_internal/src/lib.rs
@@ -45,7 +45,7 @@ pub use bevy_feathers as feathers;
 pub use bevy_gilrs as gilrs;
 #[cfg(feature = "bevy_gizmos")]
 pub use bevy_gizmos as gizmos;
-#[cfg(feature = "bevy_gizmos")]
+#[cfg(feature = "bevy_gizmos_render")]
 pub use bevy_gizmos_render as gizmos_render;
 #[cfg(feature = "bevy_gltf")]
 pub use bevy_gltf as gltf;


### PR DESCRIPTION
# Objective

Fix gizmos_render feature typo

## Solution

Use bevy_gizmos_render instead of bevy_gizmos feature
