### PR TITLE
Add an optional request URL mapping function to WASM asset io

### DIFF
--- a/crates/bevy_asset/src/io/wasm.rs
+++ b/crates/bevy_asset/src/io/wasm.rs
@@ -106,7 +106,7 @@ impl HttpWasmAssetReader {
             // Some web servers, including itch.io's CDN, return 403 when a requested file isn't present.
             // TODO: remove handling of 403 as not found when it's easier to configure
             // see https://github.com/bevyengine/bevy/pull/19268#pullrequestreview-2882410105
-            403 | 404 => Err(AssetReaderError::NotFound(path.into())),
+            403 | 404 => Err(AssetReaderError::NotFound((*fetch_path).into())),
             status => Err(AssetReaderError::HttpError(status)),
         }
     }


### PR DESCRIPTION
# Objective

Allow post processing wasm asset request URLs to make it possible to add query strings.

## Solution

The first steps to fixing #21730 

Add a new property `request_mapper` to `HttpWasmAssetReader`. I made it `dyn` to not add needless generics, but I guess static dispatch might work too.

Some mapping could be added to the default asset loader too, but I figured there is no consensus on what to do there. I just wanted to add this to allow motivated users to implement some kind of cache busting manually.

## Testing

Added this to the `custom_asset_reader` example and ran it on a web browser.

```rust
impl Plugin for CustomAssetReaderPlugin {
    fn build(&self, app: &mut App) {
        let mut file_hashes = HashMap::new();
        file_hashes.insert("assets/branding/icon.png", "c09n2309jv");
        let file_hashes = Arc::new(file_hashes);
        app.register_asset_source(
            AssetSourceId::Default,
            AssetSource::build().with_reader(move || {
                Box::new(HttpWasmAssetReader::new("assets").with_request_mapper({
                    let file_hashes = file_hashes.clone();
                    move |path| {
                        let mapped = file_hashes.get(path).map_or_else(
                            || Cow::Borrowed(path),
                            |hash| Cow::Owned([path, "?", hash].concat()),
                        );
                        info!("Mapped asset path '{}' to '{}'", path, mapped);
                        mapped
                    }
                }))
            }),
        );
    }
}
```

The alternative, more straight forward, and slightly less efficient way to do cache busting would be to just add the current game version to the query string. Maybe we could add a premade helper function for that.

## Showcase
