### PR TITLE
Removed invalid ECS archetype constants

### DIFF
--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -54,11 +54,6 @@ pub(crate) struct ArchetypeCreated(pub ArchetypeId);
 pub struct ArchetypeRow(NonMaxU32);
 
 impl ArchetypeRow {
-    /// Index indicating an invalid archetype row.
-    /// This is meant to be used as a placeholder.
-    // TODO: Deprecate in favor of options, since `INVALID` is, technically, valid.
-    pub const INVALID: ArchetypeRow = ArchetypeRow(NonMaxU32::MAX);
-
     /// Creates a `ArchetypeRow`.
     #[inline]
     pub const fn new(index: NonMaxU32) -> Self {
@@ -95,10 +90,6 @@ pub struct ArchetypeId(u32);
 impl ArchetypeId {
     /// The ID for the [`Archetype`] without any components.
     pub const EMPTY: ArchetypeId = ArchetypeId(0);
-    /// # Safety:
-    ///
-    /// This must always have an all-1s bit pattern to ensure soundness in fast entity id space allocation.
-    pub const INVALID: ArchetypeId = ArchetypeId(u32::MAX);
 
     /// Create an `ArchetypeId` from a plain value.
     ///

--- a/release-content/migration-guides/entities_apis.md
+++ b/release-content/migration-guides/entities_apis.md
@@ -62,6 +62,9 @@ If you only want spawned entities, use `Commands::get_spawned_entity`.
 
 ### Other entity interactions
 
+The `ArchetypeRow::INVALID` and `ArchetypeId::INVALID` constants have been removed, since they are no longer needed for flushing.
+If you depended on these, use options instead.
+
 `BundleSpawner::spawn_non_existent` is now `BundleSpawner::construct`.
 `World::inspect_entity` now errors with `EntityNotSpawnedError` instead of `EntityDoesNotExistError`.
 `QueryEntityError::EntityDoesNotExist` is now `QueryEntityError::NotSpawned`.


### PR DESCRIPTION
# Objective

This is a tiny clean up to #19451 that removes some now completely unneeded public constants.
I mean, they aren't wrong, but there's no point to their existence.

## Solution

Removed `ArchetypeRow::INVALID` and `ArchetypeId::INVALID` and extend migration guide.
