### PR TITLE
Add a dense layout to the `many_cubes` stress test

### DIFF
--- a/examples/stress_tests/many_cubes.rs
+++ b/examples/stress_tests/many_cubes.rs
@@ -547,9 +547,9 @@ fn rotate_cubes(
     mut query: Query<&mut Transform, (With<Mesh3d>, Without<NotShadowCaster>)>,
     time: Res<Time>,
 ) {
-    for mut transform in query.iter_mut() {
+    query.par_iter_mut().for_each(|mut transform| {
         transform.rotate_y(10.0 * time.delta_secs());
-    }
+    });
 }
 
 #[inline]


### PR DESCRIPTION
# Objective

- Test the impact that many overlapping cubes, all within the camera frustum, have on visibility/occlusion calculations, especially with continuous rotation and shadows enabled.

## Solution

- Add a dense cube layout using a static camera, and a toggle for individual cube rotation.

## Testing

- I ran the test in several stages, each causing a considerable performance drop.
  - Stage 1: using just the dense layout.
  - Stage 2: using the dense layout with rotation or shadows enabled.
  - Stage 3: using the dense layout with both rotation and shadows enabled.

```
cargo run --release --example many_cubes -- --layout dense --rotate-cubes --shadows
```

---

## Showcase
<img width="1904" height="940" alt="image" src="https://github.com/user-attachments/assets/6fc811aa-81fa-4130-a6e0-0a017bc99f19" />
