### PR TITLE
Shortcircuit `SceneInstanceReady` on models that do not have `ColorOverride`

### DIFF
--- a/examples/gltf/edit_material_on_gltf.rs
+++ b/examples/gltf/edit_material_on_gltf.rs
@@ -14,7 +14,7 @@ fn main() {
 }
 
 /// This is added to a [`SceneRoot`] and will cause the [`StandardMaterial::base_color`]
-/// of materials with [`GltfMaterialName`] equal to `LeatherPartsMat.
+/// of materials with [`GltfMaterialName`] equal to `LeatherPartsMat`.
 #[derive(Component)]
 struct ColorOverride(Color);
 


### PR DESCRIPTION
# Objective

The `edit_material_on_gltf` example was iterating over all materials of a Gltf even when it did not have `ColorOverride`.

## Solution

Shortcircuit observer if scene does not have `ColorOverride`

## Testing

Ran the example