### PR TITLE
Fix dragging bug in drag_to_scroll example

### DIFF
--- a/examples/ui/drag_to_scroll.rs
+++ b/examples/ui/drag_to_scroll.rs
@@ -58,7 +58,7 @@ fn setup(mut commands: Commands) {
             >| {
                 if let Ok((computed_node, mut start)) = scroll_position_query.single_mut() {
                     start.0 = computed_node.scroll_position * computed_node.inverse_scale_factor;
-                };
+                }
             },
         )
         .with_children(|commands| {


### PR DESCRIPTION
# Objective

Fixes #21675. The issue was that the position the drag started on was never saved so new drags always forced the grid to its initial position.

The original entity hierarchy consists of a `ScrollableNode`, with a child node (grid parent), which itself has a bunch of nodes as children (grid tiles). Only the grid node has a `Pickable` component.

There are a few issues in the original code:

* Since grid tiles have `should_block_lower = false` and `is_hoverable = true`, they will allow drag events to propagate to the grid parent. Since the grid parent does not have `Pickable`, it blocks further propagation but does ding a scroll event. This creates two scroll events observed by the `ScrollableNode`.
* However, neither of these are the same entity as the `ScrollableNode`, so both events fail the check originally on line 59 (`drag_start.entity != drag_start.original_event_target()`).

## Solution

I tried to fix both issues.

* Add `Pickable` to the grid parent with `should_block_lower = true` and `is_hoverable = false`. This way it does not ding an event nor does it propagate further. This ensures there is only one scroll event ever going through.
* Remove the line 59 entity check as it is no longer necessary.

## Testing

Tested on macOS, seems to work fine.