### PR TITLE
Optimized `BindGroupLayoutCache` to reduce unnecessary cloning

### DIFF
--- a/crates/bevy_anti_alias/src/contrast_adaptive_sharpening/node.rs
+++ b/crates/bevy_anti_alias/src/contrast_adaptive_sharpening/node.rs
@@ -83,7 +83,7 @@ impl Node for CasNode {
             cached_bind_group => {
                 let bind_group = render_context.render_device().create_bind_group(
                     "cas_bind_group",
-                    &pipeline_cache.get_bind_group_layout(&sharpening_pipeline.layout),
+                    pipeline_cache.get_bind_group_layout(&sharpening_pipeline.layout),
                     &BindGroupEntries::sequential((
                         view_target.source,
                         &sharpening_pipeline.sampler,

--- a/crates/bevy_anti_alias/src/fxaa/node.rs
+++ b/crates/bevy_anti_alias/src/fxaa/node.rs
@@ -54,7 +54,7 @@ impl ViewNode for FxaaNode {
             cached_bind_group => {
                 let bind_group = render_context.render_device().create_bind_group(
                     None,
-                    &pipeline_cache.get_bind_group_layout(&fxaa_pipeline.texture_bind_group),
+                    pipeline_cache.get_bind_group_layout(&fxaa_pipeline.texture_bind_group),
                     &BindGroupEntries::sequential((source, &fxaa_pipeline.sampler)),
                 );
 

--- a/crates/bevy_anti_alias/src/smaa/mod.rs
+++ b/crates/bevy_anti_alias/src/smaa/mod.rs
@@ -768,7 +768,7 @@ fn prepare_smaa_bind_groups(
         commands.entity(entity).insert(SmaaBindGroups {
             edge_detection_bind_group: render_device.create_bind_group(
                 Some("SMAA edge detection bind group"),
-                &pipeline_cache.get_bind_group_layout(
+                pipeline_cache.get_bind_group_layout(
                     &smaa_pipelines
                         .edge_detection
                         .edge_detection_bind_group_layout,
@@ -777,7 +777,7 @@ fn prepare_smaa_bind_groups(
             ),
             blending_weight_calculation_bind_group: render_device.create_bind_group(
                 Some("SMAA blending weight calculation bind group"),
-                &pipeline_cache.get_bind_group_layout(
+                pipeline_cache.get_bind_group_layout(
                     &smaa_pipelines
                         .blending_weight_calculation
                         .blending_weight_calculation_bind_group_layout,
@@ -791,7 +791,7 @@ fn prepare_smaa_bind_groups(
             ),
             neighborhood_blending_bind_group: render_device.create_bind_group(
                 Some("SMAA neighborhood blending bind group"),
-                &pipeline_cache.get_bind_group_layout(
+                pipeline_cache.get_bind_group_layout(
                     &smaa_pipelines
                         .neighborhood_blending
                         .neighborhood_blending_bind_group_layout,
@@ -920,7 +920,7 @@ fn perform_edge_detection(
     // Create the edge detection bind group.
     let postprocess_bind_group = render_context.render_device().create_bind_group(
         None,
-        &pipeline_cache
+        pipeline_cache
             .get_bind_group_layout(&smaa_pipelines.edge_detection.postprocess_bind_group_layout),
         &BindGroupEntries::sequential((source, &**smaa_info_uniform_buffer)),
     );
@@ -976,7 +976,7 @@ fn perform_blending_weight_calculation(
     // Create the blending weight calculation bind group.
     let postprocess_bind_group = render_context.render_device().create_bind_group(
         None,
-        &pipeline_cache.get_bind_group_layout(
+        pipeline_cache.get_bind_group_layout(
             &smaa_pipelines
                 .blending_weight_calculation
                 .postprocess_bind_group_layout,
@@ -1037,7 +1037,7 @@ fn perform_neighborhood_blending(
 ) {
     let postprocess_bind_group = render_context.render_device().create_bind_group(
         None,
-        &pipeline_cache.get_bind_group_layout(
+        pipeline_cache.get_bind_group_layout(
             &smaa_pipelines
                 .neighborhood_blending
                 .postprocess_bind_group_layout,

--- a/crates/bevy_anti_alias/src/taa/mod.rs
+++ b/crates/bevy_anti_alias/src/taa/mod.rs
@@ -185,7 +185,7 @@ impl ViewNode for TemporalAntiAliasNode {
 
         let taa_bind_group = render_context.render_device().create_bind_group(
             "taa_bind_group",
-            &pipeline_cache.get_bind_group_layout(&pipelines.taa_bind_group_layout),
+            pipeline_cache.get_bind_group_layout(&pipelines.taa_bind_group_layout),
             &BindGroupEntries::sequential((
                 view_target.source,
                 &taa_history_textures.read.default_view,

--- a/crates/bevy_core_pipeline/src/blit/mod.rs
+++ b/crates/bevy_core_pipeline/src/blit/mod.rs
@@ -75,7 +75,7 @@ impl BlitPipeline {
     ) -> BindGroup {
         render_device.create_bind_group(
             None,
-            &pipeline_cache.get_bind_group_layout(&self.layout),
+            pipeline_cache.get_bind_group_layout(&self.layout),
             &BindGroupEntries::sequential((src_texture, &self.sampler)),
         )
     }

--- a/crates/bevy_core_pipeline/src/deferred/copy_lighting_id.rs
+++ b/crates/bevy_core_pipeline/src/deferred/copy_lighting_id.rs
@@ -82,7 +82,7 @@ impl ViewNode for CopyDeferredLightingIdNode {
 
         let bind_group = render_context.render_device().create_bind_group(
             "copy_deferred_lighting_id_bind_group",
-            &pipeline_cache.get_bind_group_layout(&copy_deferred_lighting_id_pipeline.layout),
+            pipeline_cache.get_bind_group_layout(&copy_deferred_lighting_id_pipeline.layout),
             &BindGroupEntries::single(&deferred_lighting_pass_id_texture.texture.default_view),
         );
 

--- a/crates/bevy_core_pipeline/src/experimental/mip_generation/mod.rs
+++ b/crates/bevy_core_pipeline/src/experimental/mip_generation/mod.rs
@@ -764,7 +764,7 @@ fn prepare_downsample_depth_view_bind_groups(
                     } else {
                         "downsample depth bind group"
                     },
-                    &pipeline_cache.get_bind_group_layout(if is_multisampled {
+                    pipeline_cache.get_bind_group_layout(if is_multisampled {
                         &downsample_depth_pipelines
                             .first_multisample
                             .bind_group_layout

--- a/crates/bevy_core_pipeline/src/fullscreen_material.rs
+++ b/crates/bevy_core_pipeline/src/fullscreen_material.rs
@@ -299,7 +299,7 @@ impl<T: FullscreenMaterial> ViewNode for FullscreenMaterialNode<T> {
 
         let bind_group = render_context.render_device().create_bind_group(
             "post_process_bind_group",
-            &pipeline_cache.get_bind_group_layout(&fullscreen_pipeline.layout),
+            pipeline_cache.get_bind_group_layout(&fullscreen_pipeline.layout),
             &BindGroupEntries::sequential((
                 post_process.source,
                 &fullscreen_pipeline.sampler,

--- a/crates/bevy_core_pipeline/src/oit/resolve/mod.rs
+++ b/crates/bevy_core_pipeline/src/oit/resolve/mod.rs
@@ -247,7 +247,7 @@ pub fn prepare_oit_resolve_bind_group(
     ) {
         let bind_group = render_device.create_bind_group(
             "oit_resolve_bind_group",
-            &pipeline_cache.get_bind_group_layout(&resolve_pipeline.view_bind_group_layout),
+            pipeline_cache.get_bind_group_layout(&resolve_pipeline.view_bind_group_layout),
             &BindGroupEntries::sequential((binding.clone(), layers_binding, layer_ids_binding)),
         );
         commands.insert_resource(OitResolveBindGroup(bind_group));

--- a/crates/bevy_core_pipeline/src/oit/resolve/node.rs
+++ b/crates/bevy_core_pipeline/src/oit/resolve/node.rs
@@ -55,8 +55,7 @@ impl ViewNode for OitResolveNode {
 
             let depth_bind_group = render_context.render_device().create_bind_group(
                 "oit_resolve_depth_bind_group",
-                &pipeline_cache
-                    .get_bind_group_layout(&resolve_pipeline.oit_depth_bind_group_layout),
+                pipeline_cache.get_bind_group_layout(&resolve_pipeline.oit_depth_bind_group_layout),
                 &BindGroupEntries::single(depth.view()),
             );
 

--- a/crates/bevy_core_pipeline/src/skybox/mod.rs
+++ b/crates/bevy_core_pipeline/src/skybox/mod.rs
@@ -285,7 +285,7 @@ fn prepare_skybox_bind_groups(
         ) {
             let bind_group = render_device.create_bind_group(
                 "skybox_bind_group",
-                &pipeline_cache.get_bind_group_layout(&pipeline.bind_group_layout),
+                pipeline_cache.get_bind_group_layout(&pipeline.bind_group_layout),
                 &BindGroupEntries::sequential((
                     &skybox.texture_view,
                     &skybox.sampler,

--- a/crates/bevy_core_pipeline/src/skybox/prepass.rs
+++ b/crates/bevy_core_pipeline/src/skybox/prepass.rs
@@ -153,7 +153,7 @@ pub fn prepare_skybox_prepass_bind_groups(
         };
         let bind_group = render_device.create_bind_group(
             "skybox_prepass_bind_group",
-            &pipeline_cache.get_bind_group_layout(&pipeline.bind_group_layout),
+            pipeline_cache.get_bind_group_layout(&pipeline.bind_group_layout),
             &BindGroupEntries::sequential((view_uniforms, prev_view_uniforms)),
         );
 

--- a/crates/bevy_core_pipeline/src/tonemapping/node.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/node.rs
@@ -96,7 +96,7 @@ impl ViewNode for TonemappingNode {
 
                 let bind_group = render_context.render_device().create_bind_group(
                     None,
-                    &pipeline_cache.get_bind_group_layout(&tonemapping_pipeline.texture_bind_group),
+                    pipeline_cache.get_bind_group_layout(&tonemapping_pipeline.texture_bind_group),
                     &BindGroupEntries::sequential((
                         view_uniforms,
                         source,

--- a/crates/bevy_gizmos_render/src/lib.rs
+++ b/crates/bevy_gizmos_render/src/lib.rs
@@ -313,7 +313,7 @@ fn prepare_line_gizmo_bind_group(
         commands.insert_resource(LineGizmoUniformBindgroup {
             bindgroup: render_device.create_bind_group(
                 "LineGizmoUniform bindgroup",
-                &pipeline_cache.get_bind_group_layout(&line_gizmo_uniform_layout.layout),
+                pipeline_cache.get_bind_group_layout(&line_gizmo_uniform_layout.layout),
                 &BindGroupEntries::single(binding),
             ),
         });

--- a/crates/bevy_pbr/src/atmosphere/environment.rs
+++ b/crates/bevy_pbr/src/atmosphere/environment.rs
@@ -109,7 +109,7 @@ pub(super) fn prepare_atmosphere_probe_bind_groups(
     for (entity, textures) in &probes {
         let environment = render_device.create_bind_group(
             "environment_bind_group",
-            &pipeline_cache.get_bind_group_layout(&layouts.environment),
+            pipeline_cache.get_bind_group_layout(&layouts.environment),
             &BindGroupEntries::with_indices((
                 // uniforms
                 (0, atmosphere_uniforms.binding().unwrap()),

--- a/crates/bevy_pbr/src/atmosphere/resources.rs
+++ b/crates/bevy_pbr/src/atmosphere/resources.rs
@@ -647,7 +647,7 @@ pub(super) fn prepare_atmosphere_bind_groups(
 
         let transmittance_lut = render_device.create_bind_group(
             "transmittance_lut_bind_group",
-            &pipeline_cache.get_bind_group_layout(&layouts.transmittance_lut),
+            pipeline_cache.get_bind_group_layout(&layouts.transmittance_lut),
             &BindGroupEntries::with_indices((
                 // uniforms
                 (0, atmosphere_binding.clone()),
@@ -663,7 +663,7 @@ pub(super) fn prepare_atmosphere_bind_groups(
 
         let multiscattering_lut = render_device.create_bind_group(
             "multiscattering_lut_bind_group",
-            &pipeline_cache.get_bind_group_layout(&layouts.multiscattering_lut),
+            pipeline_cache.get_bind_group_layout(&layouts.multiscattering_lut),
             &BindGroupEntries::with_indices((
                 // uniforms
                 (0, atmosphere_binding.clone()),
@@ -682,7 +682,7 @@ pub(super) fn prepare_atmosphere_bind_groups(
 
         let sky_view_lut = render_device.create_bind_group(
             "sky_view_lut_bind_group",
-            &pipeline_cache.get_bind_group_layout(&layouts.sky_view_lut),
+            pipeline_cache.get_bind_group_layout(&layouts.sky_view_lut),
             &BindGroupEntries::with_indices((
                 // uniforms
                 (0, atmosphere_binding.clone()),
@@ -705,7 +705,7 @@ pub(super) fn prepare_atmosphere_bind_groups(
 
         let aerial_view_lut = render_device.create_bind_group(
             "sky_view_lut_bind_group",
-            &pipeline_cache.get_bind_group_layout(&layouts.aerial_view_lut),
+            pipeline_cache.get_bind_group_layout(&layouts.aerial_view_lut),
             &BindGroupEntries::with_indices((
                 // uniforms
                 (0, atmosphere_binding.clone()),
@@ -727,7 +727,7 @@ pub(super) fn prepare_atmosphere_bind_groups(
 
         let render_sky = render_device.create_bind_group(
             "render_sky_bind_group",
-            &pipeline_cache.get_bind_group_layout(if *msaa == Msaa::Off {
+            pipeline_cache.get_bind_group_layout(if *msaa == Msaa::Off {
                 &render_sky_layouts.render_sky
             } else {
                 &render_sky_layouts.render_sky_msaa

--- a/crates/bevy_pbr/src/deferred/mod.rs
+++ b/crates/bevy_pbr/src/deferred/mod.rs
@@ -185,7 +185,7 @@ impl ViewNode for DeferredOpaquePass3dPbrLightingNode {
 
         let bind_group_2 = render_context.render_device().create_bind_group(
             "deferred_lighting_layout_group_2",
-            &pipeline_cache.get_bind_group_layout(&deferred_lighting_layout.bind_group_layout_2),
+            pipeline_cache.get_bind_group_layout(&deferred_lighting_layout.bind_group_layout_2),
             &BindGroupEntries::single(deferred_lighting_pass_id_binding),
         );
 

--- a/crates/bevy_pbr/src/light_probe/generate.rs
+++ b/crates/bevy_pbr/src/light_probe/generate.rs
@@ -655,7 +655,7 @@ pub fn prepare_generated_environment_map_bind_groups(
                 // Combined layout expects destinations 1–12 in both bind groups
                 let bind_group = render_device.create_bind_group(
                     "downsampling_bind_group_combined_first",
-                    &pipeline_cache.get_bind_group_layout(&layouts.downsampling_first),
+                    pipeline_cache.get_bind_group_layout(&layouts.downsampling_first),
                     &BindGroupEntries::sequential((
                         &samplers.linear,
                         &downsampling_constants_buffer,
@@ -692,7 +692,7 @@ pub fn prepare_generated_environment_map_bind_groups(
                 // Split layout (current behavior)
                 let first = render_device.create_bind_group(
                     "downsampling_first_bind_group",
-                    &pipeline_cache.get_bind_group_layout(&layouts.downsampling_first),
+                    pipeline_cache.get_bind_group_layout(&layouts.downsampling_first),
                     &BindGroupEntries::sequential((
                         &samplers.linear,
                         &downsampling_constants_buffer,
@@ -708,7 +708,7 @@ pub fn prepare_generated_environment_map_bind_groups(
 
                 let second = render_device.create_bind_group(
                     "downsampling_second_bind_group",
-                    &pipeline_cache.get_bind_group_layout(&layouts.downsampling_second),
+                    pipeline_cache.get_bind_group_layout(&layouts.downsampling_second),
                     &BindGroupEntries::sequential((
                         &samplers.linear,
                         &downsampling_constants_buffer,
@@ -761,7 +761,7 @@ pub fn prepare_generated_environment_map_bind_groups(
             );
             let bind_group = render_device.create_bind_group(
                 Some(format!("radiance_bind_group_mip_{mip}").as_str()),
-                &pipeline_cache.get_bind_group_layout(&layouts.radiance),
+                pipeline_cache.get_bind_group_layout(&layouts.radiance),
                 &BindGroupEntries::sequential((
                     &textures.environment_map.default_view,
                     &samplers.linear,
@@ -798,7 +798,7 @@ pub fn prepare_generated_environment_map_bind_groups(
 
         let irradiance_bind_group = render_device.create_bind_group(
             "irradiance_bind_group",
-            &pipeline_cache.get_bind_group_layout(&layouts.irradiance),
+            pipeline_cache.get_bind_group_layout(&layouts.irradiance),
             &BindGroupEntries::sequential((
                 &textures.environment_map.default_view,
                 &samplers.linear,
@@ -821,7 +821,7 @@ pub fn prepare_generated_environment_map_bind_groups(
 
         let copy_bind_group = render_device.create_bind_group(
             "copy_bind_group",
-            &pipeline_cache.get_bind_group_layout(&layouts.copy),
+            pipeline_cache.get_bind_group_layout(&layouts.copy),
             &BindGroupEntries::with_indices(((0, &src_view), (1, &dst_view))),
         );
 

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -1784,7 +1784,7 @@ where
         let actual_material_layout = pipeline_cache.get_bind_group_layout(&material_layout);
 
         match material.unprepared_bind_group(
-            &actual_material_layout,
+            actual_material_layout,
             render_device,
             material_param,
             false,

--- a/crates/bevy_pbr/src/material_bind_groups.rs
+++ b/crates/bevy_pbr/src/material_bind_groups.rs
@@ -1312,7 +1312,7 @@ impl MaterialBindlessSlab {
 
         self.bind_group = Some(render_device.create_bind_group(
             Some(label),
-            &pipeline_cache.get_bind_group_layout(bind_group_layout),
+            pipeline_cache.get_bind_group_layout(bind_group_layout),
             &bind_group_entries,
         ));
     }
@@ -1959,7 +1959,7 @@ impl MaterialBindGroupNonBindlessAllocator {
             // Create the bind group.
             let bind_group = render_device.create_bind_group(
                 self.label,
-                &pipeline_cache.get_bind_group_layout(&bind_group_layout),
+                pipeline_cache.get_bind_group_layout(&bind_group_layout),
                 &bind_group_entries,
             );
 

--- a/crates/bevy_pbr/src/meshlet/resource_manager.rs
+++ b/crates/bevy_pbr/src/meshlet/resource_manager.rs
@@ -814,7 +814,7 @@ pub fn prepare_meshlet_view_bind_groups(
     for (view_entity, view_resources) in &views {
         let clear_visibility_buffer = render_device.create_bind_group(
             "meshlet_clear_visibility_buffer_bind_group",
-            &pipeline_cache.get_bind_group_layout(if view_resources.not_shadow_view {
+            pipeline_cache.get_bind_group_layout(if view_resources.not_shadow_view {
                 &resource_manager.clear_visibility_buffer_bind_group_layout
             } else {
                 &resource_manager.clear_visibility_buffer_shadow_view_bind_group_layout
@@ -824,7 +824,7 @@ pub fn prepare_meshlet_view_bind_groups(
 
         let first_instance_cull = render_device.create_bind_group(
             "meshlet_first_instance_cull_bind_group",
-            &pipeline_cache
+            pipeline_cache
                 .get_bind_group_layout(&resource_manager.first_instance_cull_bind_group_layout),
             &BindGroupEntries::sequential((
                 &view_resources.previous_depth_pyramid,
@@ -849,7 +849,7 @@ pub fn prepare_meshlet_view_bind_groups(
 
         let second_instance_cull = render_device.create_bind_group(
             "meshlet_second_instance_cull_bind_group",
-            &pipeline_cache
+            pipeline_cache
                 .get_bind_group_layout(&resource_manager.second_instance_cull_bind_group_layout),
             &BindGroupEntries::sequential((
                 &view_resources.previous_depth_pyramid,
@@ -873,7 +873,7 @@ pub fn prepare_meshlet_view_bind_groups(
 
         let first_bvh_cull_ping = render_device.create_bind_group(
             "meshlet_first_bvh_cull_ping_bind_group",
-            &pipeline_cache
+            pipeline_cache
                 .get_bind_group_layout(&resource_manager.first_bvh_cull_bind_group_layout),
             &BindGroupEntries::sequential((
                 &view_resources.previous_depth_pyramid,
@@ -947,7 +947,7 @@ pub fn prepare_meshlet_view_bind_groups(
 
         let second_bvh_cull_ping = render_device.create_bind_group(
             "meshlet_second_bvh_cull_ping_bind_group",
-            &pipeline_cache
+            pipeline_cache
                 .get_bind_group_layout(&resource_manager.second_bvh_cull_bind_group_layout),
             &BindGroupEntries::sequential((
                 &view_resources.previous_depth_pyramid,
@@ -979,7 +979,7 @@ pub fn prepare_meshlet_view_bind_groups(
 
         let second_bvh_cull_pong = render_device.create_bind_group(
             "meshlet_second_bvh_cull_pong_bind_group",
-            &pipeline_cache
+            pipeline_cache
                 .get_bind_group_layout(&resource_manager.second_bvh_cull_bind_group_layout),
             &BindGroupEntries::sequential((
                 &view_resources.previous_depth_pyramid,
@@ -1070,7 +1070,7 @@ pub fn prepare_meshlet_view_bind_groups(
         let downsample_depth = view_resources.depth_pyramid.create_bind_group(
             &render_device,
             "meshlet_downsample_depth_bind_group",
-            &pipeline_cache.get_bind_group_layout(if view_resources.not_shadow_view {
+            pipeline_cache.get_bind_group_layout(if view_resources.not_shadow_view {
                 &resource_manager.downsample_depth_bind_group_layout
             } else {
                 &resource_manager.downsample_depth_shadow_view_bind_group_layout
@@ -1081,7 +1081,7 @@ pub fn prepare_meshlet_view_bind_groups(
 
         let visibility_buffer_raster = render_device.create_bind_group(
             "meshlet_visibility_raster_buffer_bind_group",
-            &pipeline_cache.get_bind_group_layout(if view_resources.not_shadow_view {
+            pipeline_cache.get_bind_group_layout(if view_resources.not_shadow_view {
                 &resource_manager.visibility_buffer_raster_bind_group_layout
             } else {
                 &resource_manager.visibility_buffer_raster_shadow_view_bind_group_layout
@@ -1107,7 +1107,7 @@ pub fn prepare_meshlet_view_bind_groups(
 
         let resolve_depth = render_device.create_bind_group(
             "meshlet_resolve_depth_bind_group",
-            &pipeline_cache.get_bind_group_layout(if view_resources.not_shadow_view {
+            pipeline_cache.get_bind_group_layout(if view_resources.not_shadow_view {
                 &resource_manager.resolve_depth_bind_group_layout
             } else {
                 &resource_manager.resolve_depth_shadow_view_bind_group_layout
@@ -1118,7 +1118,7 @@ pub fn prepare_meshlet_view_bind_groups(
         let resolve_material_depth = view_resources.material_depth.as_ref().map(|_| {
             render_device.create_bind_group(
                 "meshlet_resolve_material_depth_bind_group",
-                &pipeline_cache.get_bind_group_layout(
+                pipeline_cache.get_bind_group_layout(
                     &resource_manager.resolve_material_depth_bind_group_layout,
                 ),
                 &BindGroupEntries::sequential((
@@ -1134,7 +1134,7 @@ pub fn prepare_meshlet_view_bind_groups(
         let material_shade = view_resources.material_depth.as_ref().map(|_| {
             render_device.create_bind_group(
                 "meshlet_mesh_material_shade_bind_group",
-                &pipeline_cache
+                pipeline_cache
                     .get_bind_group_layout(&resource_manager.material_shade_bind_group_layout),
                 &BindGroupEntries::sequential((
                     &view_resources.visibility_buffer.default_view,
@@ -1157,7 +1157,7 @@ pub fn prepare_meshlet_view_bind_groups(
             .map(|layout| {
                 render_device.create_bind_group(
                     "meshlet_remap_1d_to_2d_dispatch_bind_group",
-                    &pipeline_cache.get_bind_group_layout(layout),
+                    pipeline_cache.get_bind_group_layout(layout),
                     &BindGroupEntries::sequential((
                         view_resources
                             .visibility_buffer_software_raster_indirect_args
@@ -1175,7 +1175,7 @@ pub fn prepare_meshlet_view_bind_groups(
         {
             render_device.create_bind_group(
                 "meshlet_fill_counts_bind_group",
-                &pipeline_cache
+                pipeline_cache
                     .get_bind_group_layout(&resource_manager.fill_counts_bind_group_layout),
                 &BindGroupEntries::sequential((
                     view_resources
@@ -1195,7 +1195,7 @@ pub fn prepare_meshlet_view_bind_groups(
         } else {
             render_device.create_bind_group(
                 "meshlet_fill_counts_bind_group",
-                &pipeline_cache
+                pipeline_cache
                     .get_bind_group_layout(&resource_manager.fill_counts_bind_group_layout),
                 &BindGroupEntries::sequential((
                     view_resources

--- a/crates/bevy_pbr/src/meshlet/resource_manager.rs
+++ b/crates/bevy_pbr/src/meshlet/resource_manager.rs
@@ -910,7 +910,7 @@ pub fn prepare_meshlet_view_bind_groups(
 
         let first_bvh_cull_pong = render_device.create_bind_group(
             "meshlet_first_bvh_cull_pong_bind_group",
-            &pipeline_cache
+            pipeline_cache
                 .get_bind_group_layout(&resource_manager.first_bvh_cull_bind_group_layout),
             &BindGroupEntries::sequential((
                 &view_resources.previous_depth_pyramid,
@@ -1011,7 +1011,7 @@ pub fn prepare_meshlet_view_bind_groups(
 
         let first_meshlet_cull = render_device.create_bind_group(
             "meshlet_first_meshlet_cull_bind_group",
-            &pipeline_cache
+            pipeline_cache
                 .get_bind_group_layout(&resource_manager.first_meshlet_cull_bind_group_layout),
             &BindGroupEntries::sequential((
                 &view_resources.previous_depth_pyramid,
@@ -1042,7 +1042,7 @@ pub fn prepare_meshlet_view_bind_groups(
 
         let second_meshlet_cull = render_device.create_bind_group(
             "meshlet_second_meshlet_cull_bind_group",
-            &pipeline_cache
+            pipeline_cache
                 .get_bind_group_layout(&resource_manager.second_meshlet_cull_bind_group_layout),
             &BindGroupEntries::sequential((
                 &view_resources.previous_depth_pyramid,

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -697,7 +697,7 @@ pub fn init_prepass_view_bind_group(
 ) {
     let empty_bind_group = render_device.create_bind_group(
         "prepass_view_empty_bind_group",
-        &pipeline_cache.get_bind_group_layout(&pipeline.empty_layout),
+        pipeline_cache.get_bind_group_layout(&pipeline.empty_layout),
         &[],
     );
     commands.insert_resource(PrepassViewBindGroup {
@@ -724,7 +724,7 @@ pub fn prepare_prepass_view_bind_group(
     ) {
         prepass_view_bind_group.no_motion_vectors = Some(render_device.create_bind_group(
             "prepass_view_no_motion_vectors_bind_group",
-            &pipeline_cache.get_bind_group_layout(&prepass_pipeline.view_layout_no_motion_vectors),
+            pipeline_cache.get_bind_group_layout(&prepass_pipeline.view_layout_no_motion_vectors),
             &BindGroupEntries::with_indices((
                 (0, view_binding.clone()),
                 (1, globals_binding.clone()),
@@ -735,7 +735,7 @@ pub fn prepare_prepass_view_bind_group(
         if let Some(previous_view_uniforms_binding) = previous_view_uniforms.uniforms.binding() {
             prepass_view_bind_group.motion_vectors = Some(render_device.create_bind_group(
                 "prepass_view_motion_vectors_bind_group",
-                &pipeline_cache.get_bind_group_layout(&prepass_pipeline.view_layout_motion_vectors),
+                pipeline_cache.get_bind_group_layout(&prepass_pipeline.view_layout_motion_vectors),
                 &BindGroupEntries::with_indices((
                     (0, view_binding),
                     (1, globals_binding),

--- a/crates/bevy_pbr/src/render/gpu_preprocess.rs
+++ b/crates/bevy_pbr/src/render/gpu_preprocess.rs
@@ -2440,7 +2440,7 @@ impl<'a> PreprocessBindGroupBuilder<'a> {
                 Some(
                     self.render_device.create_bind_group(
                         "preprocess_gpu_indexed_frustum_culling_bind_group",
-                        &self.pipeline_cache.get_bind_group_layout(
+                        self.pipeline_cache.get_bind_group_layout(
                             &self
                                 .pipelines
                                 .gpu_frustum_culling_preprocess

--- a/crates/bevy_pbr/src/render/gpu_preprocess.rs
+++ b/crates/bevy_pbr/src/render/gpu_preprocess.rs
@@ -1944,8 +1944,7 @@ impl<'a> PreprocessBindGroupBuilder<'a> {
         Some(PhasePreprocessBindGroups::Direct(
             self.render_device.create_bind_group(
                 "preprocess_direct_bind_group",
-                &self
-                    .pipeline_cache
+                self.pipeline_cache
                     .get_bind_group_layout(&self.pipelines.direct_preprocess.bind_group_layout),
                 &BindGroupEntries::with_indices((
                     (0, self.view_uniforms.uniforms.binding()?),
@@ -2055,7 +2054,7 @@ impl<'a> PreprocessBindGroupBuilder<'a> {
                 Some(
                     self.render_device.create_bind_group(
                         "preprocess_early_indexed_gpu_occlusion_culling_bind_group",
-                        &self.pipeline_cache.get_bind_group_layout(
+                        self.pipeline_cache.get_bind_group_layout(
                             &self
                                 .pipelines
                                 .early_gpu_occlusion_culling_preprocess
@@ -2155,7 +2154,7 @@ impl<'a> PreprocessBindGroupBuilder<'a> {
                 Some(
                     self.render_device.create_bind_group(
                         "preprocess_early_non_indexed_gpu_occlusion_culling_bind_group",
-                        &self.pipeline_cache.get_bind_group_layout(
+                        self.pipeline_cache.get_bind_group_layout(
                             &self
                                 .pipelines
                                 .early_gpu_occlusion_culling_preprocess
@@ -2252,7 +2251,7 @@ impl<'a> PreprocessBindGroupBuilder<'a> {
                 Some(
                     self.render_device.create_bind_group(
                         "preprocess_late_indexed_gpu_occlusion_culling_bind_group",
-                        &self.pipeline_cache.get_bind_group_layout(
+                        self.pipeline_cache.get_bind_group_layout(
                             &self
                                 .pipelines
                                 .late_gpu_occlusion_culling_preprocess
@@ -2341,7 +2340,7 @@ impl<'a> PreprocessBindGroupBuilder<'a> {
                 Some(
                     self.render_device.create_bind_group(
                         "preprocess_late_non_indexed_gpu_occlusion_culling_bind_group",
-                        &self.pipeline_cache.get_bind_group_layout(
+                        self.pipeline_cache.get_bind_group_layout(
                             &self
                                 .pipelines
                                 .late_gpu_occlusion_culling_preprocess
@@ -2506,7 +2505,7 @@ impl<'a> PreprocessBindGroupBuilder<'a> {
                 Some(
                     self.render_device.create_bind_group(
                         "preprocess_gpu_non_indexed_frustum_culling_bind_group",
-                        &self.pipeline_cache.get_bind_group_layout(
+                        self.pipeline_cache.get_bind_group_layout(
                             &self
                                 .pipelines
                                 .gpu_frustum_culling_preprocess
@@ -2563,7 +2562,7 @@ fn create_build_indirect_parameters_bind_groups(
                             "reset_indexed_indirect_batch_sets_bind_group",
                             // The early bind group is good for the main phase and late
                             // phase too. They bind the same buffers.
-                            &pipeline_cache.get_bind_group_layout(
+                            pipeline_cache.get_bind_group_layout(
                                 &pipelines
                                     .early_phase
                                     .reset_indirect_batch_sets
@@ -2586,7 +2585,7 @@ fn create_build_indirect_parameters_bind_groups(
                             "reset_non_indexed_indirect_batch_sets_bind_group",
                             // The early bind group is good for the main phase and late
                             // phase too. They bind the same buffers.
-                            &pipeline_cache.get_bind_group_layout(
+                            pipeline_cache.get_bind_group_layout(
                                 &pipelines
                                     .early_phase
                                     .reset_indirect_batch_sets
@@ -2620,7 +2619,7 @@ fn create_build_indirect_parameters_bind_groups(
                             "build_indexed_indirect_parameters_bind_group",
                             // The frustum culling bind group is good for occlusion culling
                             // too. They bind the same buffers.
-                            &pipeline_cache.get_bind_group_layout(
+                            pipeline_cache.get_bind_group_layout(
                                 &pipelines
                                     .gpu_frustum_culling_build_indexed_indirect_params
                                     .bind_group_layout,
@@ -2677,7 +2676,7 @@ fn create_build_indirect_parameters_bind_groups(
                             "build_non_indexed_indirect_parameters_bind_group",
                             // The frustum culling bind group is good for occlusion culling
                             // too. They bind the same buffers.
-                            &pipeline_cache.get_bind_group_layout(
+                            pipeline_cache.get_bind_group_layout(
                                 &pipelines
                                     .gpu_frustum_culling_build_non_indexed_indirect_params
                                     .bind_group_layout,

--- a/crates/bevy_pbr/src/render/mesh_bindings.rs
+++ b/crates/bevy_pbr/src/render/mesh_bindings.rs
@@ -377,7 +377,7 @@ impl MeshLayouts {
     ) -> BindGroup {
         render_device.create_bind_group(
             "model_only_mesh_bind_group",
-            &pipeline_cache.get_bind_group_layout(&self.model_only),
+            pipeline_cache.get_bind_group_layout(&self.model_only),
             &[entry::model(0, model.clone())],
         )
     }
@@ -394,7 +394,7 @@ impl MeshLayouts {
             let (texture_views, samplers) = lightmap_slab.build_binding_arrays();
             render_device.create_bind_group(
                 "lightmapped_mesh_bind_group",
-                &pipeline_cache.get_bind_group_layout(&self.lightmapped),
+                pipeline_cache.get_bind_group_layout(&self.lightmapped),
                 &[
                     entry::model(0, model.clone()),
                     entry::lightmaps_texture_view_array(4, &texture_views),
@@ -405,7 +405,7 @@ impl MeshLayouts {
             let (texture_view, sampler) = lightmap_slab.bindings_for_first_lightmap();
             render_device.create_bind_group(
                 "lightmapped_mesh_bind_group",
-                &pipeline_cache.get_bind_group_layout(&self.lightmapped),
+                pipeline_cache.get_bind_group_layout(&self.lightmapped),
                 &[
                     entry::model(0, model.clone()),
                     entry::lightmaps_texture_view(4, texture_view),
@@ -425,7 +425,7 @@ impl MeshLayouts {
     ) -> BindGroup {
         render_device.create_bind_group(
             "skinned_mesh_bind_group",
-            &pipeline_cache.get_bind_group_layout(&self.skinned),
+            pipeline_cache.get_bind_group_layout(&self.skinned),
             &[
                 entry::model(0, model.clone()),
                 entry::skinning(render_device, 1, current_skin),
@@ -450,7 +450,7 @@ impl MeshLayouts {
     ) -> BindGroup {
         render_device.create_bind_group(
             "skinned_motion_mesh_bind_group",
-            &pipeline_cache.get_bind_group_layout(&self.skinned_motion),
+            pipeline_cache.get_bind_group_layout(&self.skinned_motion),
             &[
                 entry::model(0, model.clone()),
                 entry::skinning(render_device, 1, current_skin),
@@ -470,7 +470,7 @@ impl MeshLayouts {
     ) -> BindGroup {
         render_device.create_bind_group(
             "morphed_mesh_bind_group",
-            &pipeline_cache.get_bind_group_layout(&self.morphed),
+            pipeline_cache.get_bind_group_layout(&self.morphed),
             &[
                 entry::model(0, model.clone()),
                 entry::weights(2, current_weights),
@@ -497,7 +497,7 @@ impl MeshLayouts {
     ) -> BindGroup {
         render_device.create_bind_group(
             "morphed_motion_mesh_bind_group",
-            &pipeline_cache.get_bind_group_layout(&self.morphed_motion),
+            pipeline_cache.get_bind_group_layout(&self.morphed_motion),
             &[
                 entry::model(0, model.clone()),
                 entry::weights(2, current_weights),
@@ -519,7 +519,7 @@ impl MeshLayouts {
     ) -> BindGroup {
         render_device.create_bind_group(
             "morphed_skinned_mesh_bind_group",
-            &pipeline_cache.get_bind_group_layout(&self.morphed_skinned),
+            pipeline_cache.get_bind_group_layout(&self.morphed_skinned),
             &[
                 entry::model(0, model.clone()),
                 entry::skinning(render_device, 1, current_skin),
@@ -549,7 +549,7 @@ impl MeshLayouts {
     ) -> BindGroup {
         render_device.create_bind_group(
             "morphed_skinned_motion_mesh_bind_group",
-            &pipeline_cache.get_bind_group_layout(&self.morphed_skinned_motion),
+            pipeline_cache.get_bind_group_layout(&self.morphed_skinned_motion),
             &[
                 entry::model(0, model.clone()),
                 entry::skinning(render_device, 1, current_skin),

--- a/crates/bevy_pbr/src/render/mesh_view_bindings.rs
+++ b/crates/bevy_pbr/src/render/mesh_view_bindings.rs
@@ -850,17 +850,17 @@ pub fn prepare_mesh_view_bind_groups(
             commands.entity(entity).insert(MeshViewBindGroup {
                 main: render_device.create_bind_group(
                     "mesh_view_bind_group",
-                    &pipeline_cache.get_bind_group_layout(&layout.main_layout),
+                    pipeline_cache.get_bind_group_layout(&layout.main_layout),
                     &entries,
                 ),
                 binding_array: render_device.create_bind_group(
                     "mesh_view_bind_group_binding_array",
-                    &pipeline_cache.get_bind_group_layout(&layout.binding_array_layout),
+                    pipeline_cache.get_bind_group_layout(&layout.binding_array_layout),
                     &entries_binding_array,
                 ),
                 empty: render_device.create_bind_group(
                     "mesh_view_bind_group_empty",
-                    &pipeline_cache.get_bind_group_layout(&layout.empty_layout),
+                    pipeline_cache.get_bind_group_layout(&layout.empty_layout),
                     &[],
                 ),
             });

--- a/crates/bevy_pbr/src/ssao/mod.rs
+++ b/crates/bevy_pbr/src/ssao/mod.rs
@@ -671,7 +671,7 @@ fn prepare_ssao_bind_groups(
     for (entity, ssao_resources, prepass_textures) in &views {
         let common_bind_group = render_device.create_bind_group(
             "ssao_common_bind_group",
-            &pipeline_cache.get_bind_group_layout(&pipelines.common_bind_group_layout),
+            pipeline_cache.get_bind_group_layout(&pipelines.common_bind_group_layout),
             &BindGroupEntries::sequential((
                 &pipelines.point_clamp_sampler,
                 &pipelines.linear_clamp_sampler,
@@ -695,7 +695,7 @@ fn prepare_ssao_bind_groups(
 
         let preprocess_depth_bind_group = render_device.create_bind_group(
             "ssao_preprocess_depth_bind_group",
-            &pipeline_cache.get_bind_group_layout(&pipelines.preprocess_depth_bind_group_layout),
+            pipeline_cache.get_bind_group_layout(&pipelines.preprocess_depth_bind_group_layout),
             &BindGroupEntries::sequential((
                 prepass_textures.depth_view().unwrap(),
                 &create_depth_view(0),
@@ -708,7 +708,7 @@ fn prepare_ssao_bind_groups(
 
         let ssao_bind_group = render_device.create_bind_group(
             "ssao_ssao_bind_group",
-            &pipeline_cache.get_bind_group_layout(&pipelines.ssao_bind_group_layout),
+            pipeline_cache.get_bind_group_layout(&pipelines.ssao_bind_group_layout),
             &BindGroupEntries::sequential((
                 &ssao_resources.preprocessed_depth_texture.default_view,
                 prepass_textures.normal_view().unwrap(),
@@ -722,7 +722,7 @@ fn prepare_ssao_bind_groups(
 
         let spatial_denoise_bind_group = render_device.create_bind_group(
             "ssao_spatial_denoise_bind_group",
-            &pipeline_cache.get_bind_group_layout(&pipelines.spatial_denoise_bind_group_layout),
+            pipeline_cache.get_bind_group_layout(&pipelines.spatial_denoise_bind_group_layout),
             &BindGroupEntries::sequential((
                 &ssao_resources.ssao_noisy_texture.default_view,
                 &ssao_resources.depth_differences_texture.default_view,

--- a/crates/bevy_pbr/src/ssr/mod.rs
+++ b/crates/bevy_pbr/src/ssr/mod.rs
@@ -295,7 +295,7 @@ impl ViewNode for ScreenSpaceReflectionsNode {
         let ssr_pipeline = world.resource::<ScreenSpaceReflectionsPipeline>();
         let ssr_bind_group = render_context.render_device().create_bind_group(
             "SSR bind group",
-            &pipeline_cache.get_bind_group_layout(&ssr_pipeline.bind_group_layout),
+            pipeline_cache.get_bind_group_layout(&ssr_pipeline.bind_group_layout),
             &BindGroupEntries::sequential((
                 postprocess.source,
                 &ssr_pipeline.color_sampler,

--- a/crates/bevy_pbr/src/volumetric_fog/render.rs
+++ b/crates/bevy_pbr/src/volumetric_fog/render.rs
@@ -431,7 +431,7 @@ impl ViewNode for VolumetricFogNode {
 
             let volumetric_view_bind_group = render_context.render_device().create_bind_group(
                 None,
-                &pipeline_cache.get_bind_group_layout(volumetric_view_bind_group_layout),
+                pipeline_cache.get_bind_group_layout(volumetric_view_bind_group_layout),
                 &bind_group_entries,
             );
 

--- a/crates/bevy_post_process/src/auto_exposure/node.rs
+++ b/crates/bevy_post_process/src/auto_exposure/node.rs
@@ -103,7 +103,7 @@ impl Node for AutoExposureNode {
 
         let compute_bind_group = render_context.render_device().create_bind_group(
             None,
-            &pipeline_cache.get_bind_group_layout(&pipeline.histogram_layout),
+            pipeline_cache.get_bind_group_layout(&pipeline.histogram_layout),
             &BindGroupEntries::sequential((
                 &globals_buffer.buffer,
                 &auto_exposure_buffers.settings,

--- a/crates/bevy_post_process/src/bloom/mod.rs
+++ b/crates/bevy_post_process/src/bloom/mod.rs
@@ -177,7 +177,7 @@ impl ViewNode for BloomNode {
             {
                 let downsampling_first_bind_group = render_device.create_bind_group(
                     "bloom_downsampling_first_bind_group",
-                    &pipeline_cache
+                    pipeline_cache
                         .get_bind_group_layout(&downsampling_pipeline_res.bind_group_layout),
                     &BindGroupEntries::sequential((
                         // Read from main texture directly
@@ -451,7 +451,7 @@ fn prepare_bloom_bind_groups(
         for mip in 1..bloom_texture.mip_count {
             downsampling_bind_groups.push(render_device.create_bind_group(
                 "bloom_downsampling_bind_group",
-                &pipeline_cache.get_bind_group_layout(&downsampling_pipeline.bind_group_layout),
+                pipeline_cache.get_bind_group_layout(&downsampling_pipeline.bind_group_layout),
                 &BindGroupEntries::sequential((
                     &bloom_texture.view(mip - 1),
                     sampler,
@@ -464,7 +464,7 @@ fn prepare_bloom_bind_groups(
         for mip in (0..bloom_texture.mip_count).rev() {
             upsampling_bind_groups.push(render_device.create_bind_group(
                 "bloom_upsampling_bind_group",
-                &pipeline_cache.get_bind_group_layout(&upsampling_pipeline.bind_group_layout),
+                pipeline_cache.get_bind_group_layout(&upsampling_pipeline.bind_group_layout),
                 &BindGroupEntries::sequential((
                     &bloom_texture.view(mip),
                     sampler,

--- a/crates/bevy_post_process/src/dof/mod.rs
+++ b/crates/bevy_post_process/src/dof/mod.rs
@@ -388,7 +388,7 @@ impl ViewNode for DepthOfFieldNode {
                 };
                 render_context.render_device().create_bind_group(
                     Some(pipeline_render_info.view_bind_group_label),
-                    &pipeline_cache.get_bind_group_layout(dual_input_bind_group_layout),
+                    pipeline_cache.get_bind_group_layout(dual_input_bind_group_layout),
                     &BindGroupEntries::sequential((
                         view_uniforms_binding,
                         view_depth_texture.view(),
@@ -399,7 +399,7 @@ impl ViewNode for DepthOfFieldNode {
             } else {
                 render_context.render_device().create_bind_group(
                     Some(pipeline_render_info.view_bind_group_label),
-                    &pipeline_cache.get_bind_group_layout(&view_bind_group_layouts.single_input),
+                    pipeline_cache.get_bind_group_layout(&view_bind_group_layouts.single_input),
                     &BindGroupEntries::sequential((
                         view_uniforms_binding,
                         view_depth_texture.view(),
@@ -624,7 +624,7 @@ pub fn prepare_depth_of_field_global_bind_group(
 
     **dof_bind_group = Some(render_device.create_bind_group(
         Some("depth of field global bind group"),
-        &pipeline_cache.get_bind_group_layout(&global_bind_group_layout.layout),
+        pipeline_cache.get_bind_group_layout(&global_bind_group_layout.layout),
         &BindGroupEntries::sequential((
             depth_of_field_uniforms,                         // `dof_params`
             &global_bind_group_layout.color_texture_sampler, // `color_texture_sampler`

--- a/crates/bevy_post_process/src/effect_stack/mod.rs
+++ b/crates/bevy_post_process/src/effect_stack/mod.rs
@@ -395,7 +395,7 @@ impl ViewNode for PostProcessingNode {
 
         let bind_group = render_context.render_device().create_bind_group(
             Some("postprocessing bind group"),
-            &pipeline_cache.get_bind_group_layout(&post_processing_pipeline.bind_group_layout),
+            pipeline_cache.get_bind_group_layout(&post_processing_pipeline.bind_group_layout),
             &BindGroupEntries::sequential((
                 post_process.source,
                 &post_processing_pipeline.source_sampler,

--- a/crates/bevy_post_process/src/motion_blur/node.rs
+++ b/crates/bevy_post_process/src/motion_blur/node.rs
@@ -72,7 +72,7 @@ impl ViewNode for MotionBlurNode {
 
         let bind_group = render_context.render_device().create_bind_group(
             Some("motion_blur_bind_group"),
-            &pipeline_cache.get_bind_group_layout(layout),
+            pipeline_cache.get_bind_group_layout(layout),
             &BindGroupEntries::sequential((
                 post_process.source,
                 &prepass_motion_vectors_texture.texture.default_view,

--- a/crates/bevy_render/src/render_resource/bind_group.rs
+++ b/crates/bevy_render/src/render_resource/bind_group.rs
@@ -534,7 +534,7 @@ pub trait AsBindGroup {
         pipeline_cache: &PipelineCache,
         param: &mut SystemParamItem<'_, '_, Self::Param>,
     ) -> Result<PreparedBindGroup, AsBindGroupError> {
-        let layout = &pipeline_cache.get_bind_group_layout(layout_descriptor);
+        let layout = pipeline_cache.get_bind_group_layout(layout_descriptor);
 
         let UnpreparedBindGroup { bindings } =
             Self::unprepared_bind_group(self, layout, render_device, param, false)?;

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -17,6 +17,7 @@ use bevy_shader::{
 };
 use bevy_tasks::Task;
 use bevy_utils::default;
+use core::pin::Pin;
 use core::{future::Future, hash::Hash, mem};
 use std::sync::{Mutex, PoisonError};
 use tracing::error;
@@ -209,22 +210,25 @@ fn load_module(
 
 #[derive(Default)]
 struct BindGroupLayoutCache {
-    bgls: HashMap<BindGroupLayoutDescriptor, BindGroupLayout>,
+    bgls: HashMap<BindGroupLayoutDescriptor, Pin<Box<BindGroupLayout>>>,
 }
 
 impl BindGroupLayoutCache {
     fn get(
         &mut self,
         render_device: &RenderDevice,
-        descriptor: BindGroupLayoutDescriptor,
-    ) -> BindGroupLayout {
-        self.bgls
-            .entry(descriptor)
-            .or_insert_with_key(|descriptor| {
-                render_device
-                    .create_bind_group_layout(descriptor.label.as_ref(), &descriptor.entries)
-            })
-            .clone()
+        descriptor: &BindGroupLayoutDescriptor,
+    ) -> &Pin<Box<BindGroupLayout>> {
+        use bevy_platform::collections::hash_map::RawEntryMut;
+        // SAFETY: PipelineCache::get_bind_group_layout() requires that items are never removed or modified. See the SAFETY comment in that method for more details.
+        match self.bgls.raw_entry_mut().from_key(descriptor) {
+            RawEntryMut::Occupied(entry) => entry.into_mut(),
+            RawEntryMut::Vacant(slot) => {
+                let created = render_device
+                    .create_bind_group_layout(descriptor.label.as_ref(), &descriptor.entries);
+                slot.insert(descriptor.clone(), Box::pin(created)).1
+            }
+        }
     }
 }
 
@@ -475,11 +479,16 @@ impl PipelineCache {
     pub fn get_bind_group_layout(
         &self,
         bind_group_layout_descriptor: &BindGroupLayoutDescriptor,
-    ) -> BindGroupLayout {
-        self.bindgroup_layout_cache
-            .lock()
-            .unwrap()
-            .get(&self.device, bind_group_layout_descriptor.clone())
+    ) -> &BindGroupLayout {
+        let mut mutex_guard = self.bindgroup_layout_cache.lock().unwrap();
+        let boxed_layout = mutex_guard.get(&self.device, bind_group_layout_descriptor);
+        let boxed_layout_ptr = Pin::as_ref(boxed_layout).get_ref() as *const BindGroupLayout;
+
+        // SAFETY:
+        // - Cached `BindGroupLayout` entries are immutable: they're never replaced, modified, or evicted from the hashmap.
+        // - Cached `BindGroupLayout` entries are Pin<Box<...>>, so the memory address will be stable (i.e. hashmap resizes will not move the `BindGroupLayout`).
+        // - The returned reference's lifetime matches the lifetime of the `BindGroupLayoutCache`.
+        unsafe { &*boxed_layout_ptr }
     }
 
     fn set_shader(&mut self, id: AssetId<Shader>, shader: Shader) {
@@ -513,9 +522,14 @@ impl PipelineCache {
             .layout
             .iter()
             .map(|bind_group_layout_descriptor| {
-                bindgroup_layout_cache.get(&self.device, bind_group_layout_descriptor.clone())
+                bindgroup_layout_cache
+                    .get(&self.device, bind_group_layout_descriptor)
+                    .as_ref()
+                    .get_ref()
+                    .clone()
             })
             .collect::<Vec<_>>();
+        drop(bindgroup_layout_cache);
 
         create_pipeline_task(
             async move {
@@ -632,9 +646,14 @@ impl PipelineCache {
             .layout
             .iter()
             .map(|bind_group_layout_descriptor| {
-                bindgroup_layout_cache.get(&self.device, bind_group_layout_descriptor.clone())
+                bindgroup_layout_cache
+                    .get(&self.device, bind_group_layout_descriptor)
+                    .as_ref()
+                    .get_ref()
+                    .clone()
             })
             .collect::<Vec<_>>();
+        drop(bindgroup_layout_cache);
 
         create_pipeline_task(
             async move {

--- a/crates/bevy_render/src/view/window/screenshot.rs
+++ b/crates/bevy_render/src/view/window/screenshot.rs
@@ -382,7 +382,7 @@ fn prepare_screenshot_state(
     });
     let bind_group = render_device.create_bind_group(
         "screenshot-to-screen-bind-group",
-        &pipeline_cache.get_bind_group_layout(&pipeline.bind_group_layout),
+        pipeline_cache.get_bind_group_layout(&pipeline.bind_group_layout),
         &BindGroupEntries::single(&texture_view),
     );
     let pipeline_id = pipelines.specialize(pipeline_cache, pipeline, format);

--- a/crates/bevy_solari/src/pathtracer/node.rs
+++ b/crates/bevy_solari/src/pathtracer/node.rs
@@ -63,7 +63,7 @@ impl ViewNode for PathtracerNode {
 
         let bind_group = render_context.render_device().create_bind_group(
             "pathtracer_bind_group",
-            &pipeline_cache.get_bind_group_layout(&self.bind_group_layout),
+            pipeline_cache.get_bind_group_layout(&self.bind_group_layout),
             &BindGroupEntries::sequential((
                 &accumulation_texture.0.default_view,
                 view_target.get_unsampled_color_attachment().view,

--- a/crates/bevy_solari/src/realtime/node.rs
+++ b/crates/bevy_solari/src/realtime/node.rs
@@ -168,7 +168,7 @@ impl ViewNode for SolariLightingNode {
         let s = solari_lighting_resources;
         let bind_group = render_context.render_device().create_bind_group(
             "solari_lighting_bind_group",
-            &pipeline_cache.get_bind_group_layout(&self.bind_group_layout),
+            pipeline_cache.get_bind_group_layout(&self.bind_group_layout),
             &BindGroupEntries::sequential((
                 view_target.view,
                 s.light_tile_samples.as_entire_binding(),
@@ -199,7 +199,7 @@ impl ViewNode for SolariLightingNode {
         let bind_group_world_cache_active_cells_dispatch =
             render_context.render_device().create_bind_group(
                 "solari_lighting_bind_group_world_cache_active_cells_dispatch",
-                &pipeline_cache.get_bind_group_layout(
+                pipeline_cache.get_bind_group_layout(
                     &self.bind_group_layout_world_cache_active_cells_dispatch,
                 ),
                 &BindGroupEntries::single(s.world_cache_active_cells_dispatch.as_entire_binding()),
@@ -208,7 +208,7 @@ impl ViewNode for SolariLightingNode {
         let bind_group_resolve_dlss_rr_textures = view_dlss_rr_textures.map(|d| {
             render_context.render_device().create_bind_group(
                 "solari_lighting_bind_group_resolve_dlss_rr_textures",
-                &pipeline_cache
+                pipeline_cache
                     .get_bind_group_layout(&self.bind_group_layout_resolve_dlss_rr_textures),
                 &BindGroupEntries::sequential((
                     &d.diffuse_albedo.default_view,

--- a/crates/bevy_solari/src/scene/binder.rs
+++ b/crates/bevy_solari/src/scene/binder.rs
@@ -258,7 +258,7 @@ pub fn prepare_raytracing_scene_bindings(
 
     raytracing_scene_bindings.bind_group = Some(render_device.create_bind_group(
         "raytracing_scene_bind_group",
-        &pipeline_cache.get_bind_group_layout(&raytracing_scene_bindings.bind_group_layout),
+        pipeline_cache.get_bind_group_layout(&raytracing_scene_bindings.bind_group_layout),
         &BindGroupEntries::sequential((
             vertex_buffers.as_slice(),
             index_buffers.as_slice(),

--- a/crates/bevy_sprite_render/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite_render/src/mesh2d/mesh.rs
@@ -665,7 +665,7 @@ pub fn prepare_mesh2d_bind_group(
         commands.insert_resource(Mesh2dBindGroup {
             value: render_device.create_bind_group(
                 "mesh2d_bind_group",
-                &pipeline_cache.get_bind_group_layout(&mesh2d_pipeline.mesh_layout),
+                pipeline_cache.get_bind_group_layout(&mesh2d_pipeline.mesh_layout),
                 &BindGroupEntries::single(binding),
             ),
         });
@@ -701,7 +701,7 @@ pub fn prepare_mesh2d_view_bind_groups(
             get_lut_bindings(&images, &tonemapping_luts, tonemapping, &fallback_image);
         let view_bind_group = render_device.create_bind_group(
             "mesh2d_view_bind_group",
-            &pipeline_cache.get_bind_group_layout(&mesh2d_pipeline.view_layout),
+            pipeline_cache.get_bind_group_layout(&mesh2d_pipeline.view_layout),
             &BindGroupEntries::sequential((
                 view_binding.clone(),
                 globals.clone(),

--- a/crates/bevy_sprite_render/src/render/mod.rs
+++ b/crates/bevy_sprite_render/src/render/mod.rs
@@ -580,7 +580,7 @@ pub fn prepare_sprite_view_bind_groups(
             get_lut_bindings(&images, &tonemapping_luts, tonemapping, &fallback_image);
         let view_bind_group = render_device.create_bind_group(
             "mesh2d_view_bind_group",
-            &pipeline_cache.get_bind_group_layout(&sprite_pipeline.view_layout),
+            pipeline_cache.get_bind_group_layout(&sprite_pipeline.view_layout),
             &BindGroupEntries::sequential((view_binding.clone(), lut_bindings.0, lut_bindings.1)),
         );
 
@@ -663,7 +663,7 @@ pub fn prepare_sprite_image_bind_groups(
                     .or_insert_with(|| {
                         render_device.create_bind_group(
                             "sprite_material_bind_group",
-                            &pipeline_cache.get_bind_group_layout(&sprite_pipeline.material_layout),
+                            pipeline_cache.get_bind_group_layout(&sprite_pipeline.material_layout),
                             &BindGroupEntries::sequential((
                                 &gpu_image.texture_view,
                                 &gpu_image.sampler,

--- a/crates/bevy_ui_render/src/box_shadow.rs
+++ b/crates/bevy_ui_render/src/box_shadow.rs
@@ -371,7 +371,7 @@ pub fn prepare_shadows(
         ui_meta.indices.clear();
         ui_meta.view_bind_group = Some(render_device.create_bind_group(
             "box_shadow_view_bind_group",
-            &pipeline_cache.get_bind_group_layout(&box_shadow_pipeline.view_layout),
+            pipeline_cache.get_bind_group_layout(&box_shadow_pipeline.view_layout),
             &BindGroupEntries::single(view_binding),
         ));
 

--- a/crates/bevy_ui_render/src/gradient.rs
+++ b/crates/bevy_ui_render/src/gradient.rs
@@ -708,7 +708,7 @@ pub fn prepare_gradient(
         ui_meta.indices.clear();
         ui_meta.view_bind_group = Some(render_device.create_bind_group(
             "gradient_view_bind_group",
-            &pipeline_cache.get_bind_group_layout(&gradients_pipeline.view_layout),
+            pipeline_cache.get_bind_group_layout(&gradients_pipeline.view_layout),
             &BindGroupEntries::single(view_binding),
         ));
 

--- a/crates/bevy_ui_render/src/lib.rs
+++ b/crates/bevy_ui_render/src/lib.rs
@@ -1476,7 +1476,7 @@ pub fn prepare_uinodes(
         ui_meta.indices.clear();
         ui_meta.view_bind_group = Some(render_device.create_bind_group(
             "ui_view_bind_group",
-            &pipeline_cache.get_bind_group_layout(&ui_pipeline.view_layout),
+            pipeline_cache.get_bind_group_layout(&ui_pipeline.view_layout),
             &BindGroupEntries::single(view_binding),
         ));
 
@@ -1524,8 +1524,7 @@ pub fn prepare_uinodes(
                             .or_insert_with(|| {
                                 render_device.create_bind_group(
                                     "ui_material_bind_group",
-                                    &pipeline_cache
-                                        .get_bind_group_layout(&ui_pipeline.image_layout),
+                                    pipeline_cache.get_bind_group_layout(&ui_pipeline.image_layout),
                                     &BindGroupEntries::sequential((
                                         &gpu_image.texture_view,
                                         &gpu_image.sampler,
@@ -1552,8 +1551,7 @@ pub fn prepare_uinodes(
                             .or_insert_with(|| {
                                 render_device.create_bind_group(
                                     "ui_material_bind_group",
-                                    &pipeline_cache
-                                        .get_bind_group_layout(&ui_pipeline.image_layout),
+                                    pipeline_cache.get_bind_group_layout(&ui_pipeline.image_layout),
                                     &BindGroupEntries::sequential((
                                         &gpu_image.texture_view,
                                         &gpu_image.sampler,

--- a/crates/bevy_ui_render/src/ui_material_pipeline.rs
+++ b/crates/bevy_ui_render/src/ui_material_pipeline.rs
@@ -398,7 +398,7 @@ pub fn prepare_uimaterial_nodes<M: UiMaterial>(
         ui_meta.vertices.clear();
         ui_meta.view_bind_group = Some(render_device.create_bind_group(
             "ui_material_view_bind_group",
-            &pipeline_cache.get_bind_group_layout(&ui_material_pipeline.view_layout),
+            pipeline_cache.get_bind_group_layout(&ui_material_pipeline.view_layout),
             &BindGroupEntries::sequential((view_binding, globals_binding)),
         ));
         let mut index = 0;

--- a/crates/bevy_ui_render/src/ui_texture_slice_pipeline.rs
+++ b/crates/bevy_ui_render/src/ui_texture_slice_pipeline.rs
@@ -387,7 +387,7 @@ pub fn prepare_ui_slices(
         ui_meta.indices.clear();
         ui_meta.view_bind_group = Some(render_device.create_bind_group(
             "ui_texture_slice_view_bind_group",
-            &pipeline_cache.get_bind_group_layout(&texture_slicer_pipeline.view_layout),
+            pipeline_cache.get_bind_group_layout(&texture_slicer_pipeline.view_layout),
             &BindGroupEntries::single(view_binding),
         ));
 
@@ -433,7 +433,7 @@ pub fn prepare_ui_slices(
                                 .or_insert_with(|| {
                                     render_device.create_bind_group(
                                         "ui_texture_slice_image_layout",
-                                        &pipeline_cache.get_bind_group_layout(
+                                        pipeline_cache.get_bind_group_layout(
                                             &texture_slicer_pipeline.image_layout,
                                         ),
                                         &BindGroupEntries::sequential((
@@ -462,7 +462,7 @@ pub fn prepare_ui_slices(
                                 .or_insert_with(|| {
                                     render_device.create_bind_group(
                                         "ui_texture_slice_image_layout",
-                                        &pipeline_cache.get_bind_group_layout(
+                                        pipeline_cache.get_bind_group_layout(
                                             &texture_slicer_pipeline.image_layout,
                                         ),
                                         &BindGroupEntries::sequential((

--- a/examples/shader/compute_shader_game_of_life.rs
+++ b/examples/shader/compute_shader_game_of_life.rs
@@ -149,7 +149,7 @@ fn prepare_bind_group(
 
     let bind_group_0 = render_device.create_bind_group(
         None,
-        &pipeline_cache.get_bind_group_layout(&pipeline.texture_bind_group_layout),
+        pipeline_cache.get_bind_group_layout(&pipeline.texture_bind_group_layout),
         &BindGroupEntries::sequential((
             &view_a.texture_view,
             &view_b.texture_view,
@@ -158,7 +158,7 @@ fn prepare_bind_group(
     );
     let bind_group_1 = render_device.create_bind_group(
         None,
-        &pipeline_cache.get_bind_group_layout(&pipeline.texture_bind_group_layout),
+        pipeline_cache.get_bind_group_layout(&pipeline.texture_bind_group_layout),
         &BindGroupEntries::sequential((
             &view_b.texture_view,
             &view_a.texture_view,

--- a/examples/shader/gpu_readback.rs
+++ b/examples/shader/gpu_readback.rs
@@ -163,7 +163,7 @@ fn prepare_bind_group(
     let image = images.get(&image.0).unwrap();
     let bind_group = render_device.create_bind_group(
         None,
-        &pipeline_cache.get_bind_group_layout(&pipeline.layout),
+        pipeline_cache.get_bind_group_layout(&pipeline.layout),
         &BindGroupEntries::sequential((
             buffer.buffer.as_entire_buffer_binding(),
             image.texture_view.into_binding(),

--- a/examples/shader_advanced/custom_post_processing.rs
+++ b/examples/shader_advanced/custom_post_processing.rs
@@ -178,7 +178,7 @@ impl ViewNode for PostProcessNode {
         // is to make sure you get it during the node execution.
         let bind_group = render_context.render_device().create_bind_group(
             "post_process_bind_group",
-            &pipeline_cache.get_bind_group_layout(&post_process_pipeline.layout),
+            pipeline_cache.get_bind_group_layout(&post_process_pipeline.layout),
             // It's important for this to match the BindGroupLayout defined in the PostProcessPipeline
             &BindGroupEntries::sequential((
                 // Make sure to use the source view

--- a/examples/shader_advanced/texture_binding_array.rs
+++ b/examples/shader_advanced/texture_binding_array.rs
@@ -130,7 +130,7 @@ impl AsBindGroup for BindlessMaterial {
 
         let bind_group = render_device.create_bind_group(
             Self::label(),
-            &pipeline_cache.get_bind_group_layout(layout),
+            pipeline_cache.get_bind_group_layout(layout),
             &BindGroupEntries::sequential((&textures[..], &fallback_image.sampler)),
         );
 

--- a/release-content/migration-guides/bind-group-layout-descriptors.md
+++ b/release-content/migration-guides/bind-group-layout-descriptors.md
@@ -35,7 +35,7 @@ commands.insert_resource(MyPipeline {
 // ...
 let bind_group = render_context.render_device().create_bind_group(
     None
-    &pipeline_cache.get_bind_group_layout(&my_pipeline.bind_group),
+    pipeline_cache.get_bind_group_layout(&my_pipeline.bind_group),
     // ...
 );
 ```


### PR DESCRIPTION
# Objective

Currently, `BindGroupLayoutCache` ends up cloning the `BindGroupLayoutDescriptor` and `BindGroupLayout` for every get. This PR removes unnecessary cloning.

- https://github.com/bevyengine/bevy/pull/21205

## Solution

- Pin `BindGroupLayoutCache` values to a stable memory location and have `pipeline_cache.get_bind_group_layout(...)` return a reference to the `BindGroupLayout` instead of a clone. 
- In `BindGroupLayoutCache::get()`, operate on the hashmap using `raw_entry_mut` instead of `entry` so that we don't need to unnecessarily need to clone the `BindGroupLayoutDescriptor` when the `BindGroupLayout` is already in the cache. 

## Testing

- I tested these changes on a local project.
- When reviewing, jump to [pipeline_cache.rs](https://github.com/bevyengine/bevy/pull/21757/files#diff-cc220cd7b30bdab53f07cc69085af49c438247ef41ebd0d0921d87013d74271c). Some `unsafe` is required in order to get a reference that outlives the mutex guard.