### PR TITLE
enable tracy subscriber layer on android

### DIFF
--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -336,13 +336,9 @@ impl Plugin for LogPlugin {
         #[cfg(feature = "trace")]
         let subscriber = subscriber.with(tracing_error::ErrorLayer::default());
 
-        #[cfg(all(
-            not(target_arch = "wasm32"),
-            not(target_os = "android"),
-            not(target_os = "ios")
-        ))]
+        #[cfg(all(not(target_arch = "wasm32"), not(target_os = "ios")))]
         {
-            #[cfg(feature = "tracing-chrome")]
+            #[cfg(all(feature = "tracing-chrome", not(target_os = "android")))]
             let chrome_layer = {
                 let mut layer = tracing_chrome::ChromeLayerBuilder::new();
                 if let Ok(path) = std::env::var("TRACE_CHROME") {
@@ -386,10 +382,12 @@ impl Plugin for LogPlugin {
 
             let subscriber = subscriber.with(fmt_layer);
 
-            #[cfg(feature = "tracing-chrome")]
+            #[cfg(all(feature = "tracing-chrome", not(target_os = "android")))]
             let subscriber = subscriber.with(chrome_layer);
             #[cfg(feature = "tracing-tracy")]
             let subscriber = subscriber.with(tracy_layer);
+            #[cfg(target_os = "android")]
+            let subscriber = subscriber.with(android_tracing::AndroidLayer::default());
             finished_subscriber = subscriber;
         }
 
@@ -398,11 +396,6 @@ impl Plugin for LogPlugin {
             finished_subscriber = subscriber.with(tracing_wasm::WASMLayer::new(
                 tracing_wasm::WASMLayerConfig::default(),
             ));
-        }
-
-        #[cfg(target_os = "android")]
-        {
-            finished_subscriber = subscriber.with(android_tracing::AndroidLayer::default());
         }
 
         #[cfg(target_os = "ios")]


### PR DESCRIPTION
# Objective

I really need tracing on android right now as I'm attempting to profile bevy running on a quest 3.

## Solution

I saw [this issue](https://github.com/bevyengine/bevy/issues/21612) already opened about it around 2 weeks ago, and I was able to use it to figure out how to enable tracy to run on android. However I did not enable it for IOS and made sure to retain the same behavior for other flags such as chrome style profiling. 

## Testing

I've tested that the engine still builds on both windows and to android. Additionally the flame graph will now show complete frames of info, instead of one single mono-frame with 4 different render events.

Android also requires: `android.permission.INTERNET` and possibly `android.permission.NEARBY_WIFI_DEVICES` to be able to host the debug server.

## Showcase
Tracy running for an apk deployed to a quest 3. 
<img width="2090" height="687" alt="image" src="https://github.com/user-attachments/assets/16e249c4-48db-46fd-baa0-604ec9a12856" />
