### PR TITLE
Share `AssetSources` between the `AssetServer`, the asset processor, and the asset processor's internal asset server.

### DIFF
--- a/crates/bevy_asset/src/io/processor_gated.rs
+++ b/crates/bevy_asset/src/io/processor_gated.rs
@@ -17,7 +17,7 @@ use super::{AsyncSeekForward, ErasedAssetReader};
 ///
 /// [`AssetProcessor`]: crate::processor::AssetProcessor
 pub(crate) struct ProcessorGatedReader {
-    reader: Box<dyn ErasedAssetReader>,
+    reader: Arc<dyn ErasedAssetReader>,
     source: AssetSourceId<'static>,
     processing_state: Arc<ProcessingState>,
 }
@@ -26,7 +26,7 @@ impl ProcessorGatedReader {
     /// Creates a new [`ProcessorGatedReader`].
     pub(crate) fn new(
         source: AssetSourceId<'static>,
-        reader: Box<dyn ErasedAssetReader>,
+        reader: Arc<dyn ErasedAssetReader>,
         processing_state: Arc<ProcessingState>,
     ) -> Self {
         Self {

--- a/crates/bevy_asset/src/io/source.rs
+++ b/crates/bevy_asset/src/io/source.rs
@@ -1,6 +1,6 @@
 use crate::{
     io::{processor_gated::ProcessorGatedReader, AssetSourceEvent, AssetWatcher},
-    processor::AssetProcessorData,
+    processor::ProcessingState,
 };
 use alloc::{
     boxed::Box,
@@ -560,12 +560,12 @@ impl AssetSource {
 
     /// This will cause processed [`AssetReader`](crate::io::AssetReader) futures (such as [`AssetReader::read`](crate::io::AssetReader::read)) to wait until
     /// the [`AssetProcessor`](crate::AssetProcessor) has finished processing the requested asset.
-    pub fn gate_on_processor(&mut self, processor_data: Arc<AssetProcessorData>) {
+    pub(crate) fn gate_on_processor(&mut self, processing_state: Arc<ProcessingState>) {
         if let Some(reader) = self.processed_reader.take() {
             self.processed_reader = Some(Box::new(ProcessorGatedReader::new(
                 self.id(),
                 reader,
-                processor_data,
+                processing_state,
             )));
         }
     }
@@ -622,9 +622,9 @@ impl AssetSources {
 
     /// This will cause processed [`AssetReader`](crate::io::AssetReader) futures (such as [`AssetReader::read`](crate::io::AssetReader::read)) to wait until
     /// the [`AssetProcessor`](crate::AssetProcessor) has finished processing the requested asset.
-    pub fn gate_on_processor(&mut self, processor_data: Arc<AssetProcessorData>) {
+    pub(crate) fn gate_on_processor(&mut self, processing_state: Arc<ProcessingState>) {
         for source in self.iter_processed_mut() {
-            source.gate_on_processor(processor_data.clone());
+            source.gate_on_processor(processing_state.clone());
         }
     }
 }

--- a/crates/bevy_asset/src/io/source.rs
+++ b/crates/bevy_asset/src/io/source.rs
@@ -431,6 +431,13 @@ impl AssetSource {
             .ok_or_else(|| MissingProcessedAssetReaderError(self.id.clone_owned()))
     }
 
+    /// Return's this source's ungated processed [`AssetReader`](crate::io::AssetReader), if it
+    /// exists.
+    #[inline]
+    pub(crate) fn ungated_processed_reader(&self) -> Option<&dyn ErasedAssetReader> {
+        self.ungated_processed_reader.as_deref()
+    }
+
     /// Return's this source's processed [`AssetWriter`](crate::io::AssetWriter), if it exists.
     #[inline]
     pub fn processed_writer(

--- a/crates/bevy_asset/src/io/source.rs
+++ b/crates/bevy_asset/src/io/source.rs
@@ -392,6 +392,10 @@ pub struct AssetSource {
     reader: Box<dyn ErasedAssetReader>,
     writer: Option<Box<dyn ErasedAssetWriter>>,
     processed_reader: Option<Arc<dyn ErasedAssetReader>>,
+    /// The ungated version of `processed_reader`.
+    ///
+    /// This allows the processor to read all the processed assets to initialize itself without
+    /// being gated on itself (causing a deadlock).
     ungated_processed_reader: Option<Arc<dyn ErasedAssetReader>>,
     processed_writer: Option<Box<dyn ErasedAssetWriter>>,
     watcher: Option<Box<dyn AssetWatcher>>,

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -375,7 +375,7 @@ impl Plugin for AssetPlugin {
                     let sources = builders.build_sources(watch, false);
 
                     app.insert_resource(AssetServer::new_with_meta_check(
-                        sources,
+                        Arc::new(sources),
                         AssetServerMode::Unprocessed,
                         self.meta_check.clone(),
                         watch,
@@ -388,9 +388,7 @@ impl Plugin for AssetPlugin {
                         .unwrap_or(cfg!(feature = "asset_processor"));
                     if use_asset_processor {
                         let mut builders = app.world_mut().resource_mut::<AssetSourceBuilders>();
-                        let processor = AssetProcessor::new(&mut builders);
-                        let mut sources = builders.build_sources(false, watch);
-                        sources.gate_on_processor(processor.data.processing_state.clone());
+                        let (processor, sources) = AssetProcessor::new(&mut builders, watch);
                         // the main asset server shares loaders with the processor asset server
                         app.insert_resource(AssetServer::new_with_loaders(
                             sources,
@@ -406,7 +404,7 @@ impl Plugin for AssetPlugin {
                         let mut builders = app.world_mut().resource_mut::<AssetSourceBuilders>();
                         let sources = builders.build_sources(false, watch);
                         app.insert_resource(AssetServer::new_with_meta_check(
-                            sources,
+                            Arc::new(sources),
                             AssetServerMode::Processed,
                             AssetMetaCheck::Always,
                             watch,

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -390,7 +390,7 @@ impl Plugin for AssetPlugin {
                         let mut builders = app.world_mut().resource_mut::<AssetSourceBuilders>();
                         let processor = AssetProcessor::new(&mut builders);
                         let mut sources = builders.build_sources(false, watch);
-                        sources.gate_on_processor(processor.data.clone());
+                        sources.gate_on_processor(processor.data.processing_state.clone());
                         // the main asset server shares loaders with the processor asset server
                         app.insert_resource(AssetServer::new_with_loaders(
                             sources,

--- a/crates/bevy_asset/src/processor/mod.rs
+++ b/crates/bevy_asset/src/processor/mod.rs
@@ -105,7 +105,7 @@ pub struct AssetProcessor {
 /// Internal data stored inside an [`AssetProcessor`].
 pub struct AssetProcessorData {
     /// The state of processing.
-    pub(crate) processing_state: ProcessingState,
+    pub(crate) processing_state: Arc<ProcessingState>,
     /// The factory that creates the transaction log.
     ///
     /// Note: we use a regular Mutex instead of an async mutex since we expect users to only set
@@ -139,7 +139,7 @@ impl AssetProcessor {
         let data = Arc::new(AssetProcessorData::new(source.build_sources(true, false)));
         // The asset processor uses its own asset server with its own id space
         let mut sources = source.build_sources(false, false);
-        sources.gate_on_processor(data.clone());
+        sources.gate_on_processor(data.processing_state.clone());
         let server = AssetServer::new_with_meta_check(
             sources,
             AssetServerMode::Processed,
@@ -1212,7 +1212,7 @@ impl AssetProcessorData {
     /// Initializes a new [`AssetProcessorData`] using the given [`AssetSources`].
     pub fn new(source: AssetSources) -> Self {
         AssetProcessorData {
-            processing_state: ProcessingState::new(),
+            processing_state: Arc::new(ProcessingState::new()),
             sources: source,
             log_factory: Mutex::new(Some(Box::new(FileTransactionLogFactory::default()))),
             log: Default::default(),

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -1775,6 +1775,12 @@ pub fn handle_internal_asset_events(world: &mut World) {
             world.write_message_batch(untyped_failures);
         }
 
+        // The following code all deals with hot-reloading, which we can skip if the server isn't
+        // watching for changes.
+        if !infos.watching_for_changes {
+            return;
+        }
+
         fn queue_ancestors(
             asset_path: &AssetPath,
             infos: &AssetInfos,

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -69,7 +69,7 @@ pub(crate) struct AssetServerData {
     pub(crate) loaders: Arc<RwLock<AssetLoaders>>,
     asset_event_sender: Sender<InternalAssetEvent>,
     asset_event_receiver: Receiver<InternalAssetEvent>,
-    sources: AssetSources,
+    sources: Arc<AssetSources>,
     mode: AssetServerMode,
     meta_check: AssetMetaCheck,
     unapproved_path_mode: UnapprovedPathMode,
@@ -91,7 +91,7 @@ impl AssetServer {
     /// Create a new instance of [`AssetServer`]. If `watch_for_changes` is true, the [`AssetReader`](crate::io::AssetReader) storage will watch for changes to
     /// asset sources and hot-reload them.
     pub fn new(
-        sources: AssetSources,
+        sources: Arc<AssetSources>,
         mode: AssetServerMode,
         watching_for_changes: bool,
         unapproved_path_mode: UnapprovedPathMode,
@@ -109,7 +109,7 @@ impl AssetServer {
     /// Create a new instance of [`AssetServer`]. If `watch_for_changes` is true, the [`AssetReader`](crate::io::AssetReader) storage will watch for changes to
     /// asset sources and hot-reload them.
     pub fn new_with_meta_check(
-        sources: AssetSources,
+        sources: Arc<AssetSources>,
         mode: AssetServerMode,
         meta_check: AssetMetaCheck,
         watching_for_changes: bool,
@@ -126,7 +126,7 @@ impl AssetServer {
     }
 
     pub(crate) fn new_with_loaders(
-        sources: AssetSources,
+        sources: Arc<AssetSources>,
         loaders: Arc<RwLock<AssetLoaders>>,
         mode: AssetServerMode,
         meta_check: AssetMetaCheck,

--- a/release-content/migration-guides/changed_asset_server_init.md
+++ b/release-content/migration-guides/changed_asset_server_init.md
@@ -1,0 +1,62 @@
+---
+title: Changes to `AssetServer` and `AssetProcessor` creation.
+pull_requests: [21763]
+---
+
+Previously `AssetServer`s `new` methods would take `AssetSources`. Now, these methods take
+`Arc<AssetSources>`. So if you previously had:
+
+```rust
+AssetServer::new(
+    sources,
+    mode,
+    watching_for_changes,
+    unapproved_path_mode,
+)
+
+// OR:
+AssetServer::new_with_meta_check(
+    sources,
+    mode,
+    meta_check,
+    watching_for_changes,
+    unapproved_path_mode,
+)
+```
+
+Now you need to do:
+
+```rust
+AssetServer::new(
+    Arc::new(sources),
+    mode,
+    watching_for_changes,
+    unapproved_path_mode,
+)
+
+// OR:
+AssetServer::new_with_meta_check(
+    Arc::new(sources),
+    mode,
+    meta_check,
+    watching_for_changes,
+    unapproved_path_mode,
+)
+```
+
+`AssetProcessor::new` has also changed. It now returns to you the `Arc<AssetSources>` which can (and
+should) be shared with the `AssetServer`. So if you previously had:
+
+```rust
+let processor = AssetProcessor::new(sources);
+```
+
+Now you need:
+
+```rust
+let (processor, sources_arc) = AssetProcessor::new(
+    sources,
+    // A bool whether the returned sources should listen for changes as asset processing completes.
+    false,
+);
+```


### PR DESCRIPTION
# Objective

- Previously, we would build the sources up to 3 times with different options: once for the regular asset server, once for the asset processor, and once for the asset processor's internal asset server.
- This is a step towards #21758 (since now adding a source to this shared `AssetSources` will be reflected in all the uses.

## Solution

1) Skip all the hot-reloading polling if `watch_for_changes` is false. If we don't do this, sharing the sources between the asset server and the processor-internal asset server will result in two tasks consuming asset events, so the regular asset server will miss asset events.
2) Move the state of the asset processor into a separate struct that we then Arc. We need to be able to gate the processed asset reader, but we can't create an asset processor without the sources. So instead we allow ourselves to create the state first, so that we can gate on that state, and then create the processor with that state.
3) Split the processed reader into a gated and an ungated form. The gate first blocks on the processor being done initialized, followed by gating on the per-asset lock. However the asset processor needs to iterate through all the directories in order to finish initializing. So just unconditionally gating doesn't work - we hit a deadlock. So we provide access to the ungated processed reader, so that the processor can use that to initialize its state.
4) Finally do the sharing!

One thing I'm starting in this PR is making things more private. For example, it's not clear why `ProcessorGatedReader` was `pub`. I've also made `AssetSources::gate_on_processor` no longer `pub`. This does mean that users can no longer initialize their own `AssetServer` properly (e.g., gated on the processor), but I don't think we should really support this - our focus should be on the `AssetServer` initialized by `AssetPlugin`, not hypothetical uses where someone wants to insert their own `AssetServer`.

## Testing

- CI