### PR TITLE
Relayout text on changes to `LineHeight`

### DIFF
--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -674,6 +674,7 @@ pub fn detect_text_needs_rerender<Root: Component>(
                 Changed<Root>,
                 Changed<TextFont>,
                 Changed<TextLayout>,
+                Changed<LineHeight>,
                 Changed<Children>,
             )>,
             With<Root>,
@@ -687,6 +688,7 @@ pub fn detect_text_needs_rerender<Root: Component>(
             Or<(
                 Changed<TextSpan>,
                 Changed<TextFont>,
+                Changed<LineHeight>,
                 Changed<Children>,
                 Changed<ChildOf>, // Included to detect broken text block hierarchies.
                 Added<TextLayout>,


### PR DESCRIPTION
# Objective

`LineHeight` was removed from `TextFont` and made into a component, but change detection on the `LineHeight` component to trigger a relayout wasn't added.

## Solution

Add `Changed<LineHeight>` query filters to `detect_text_needs_rerender`.