### PR TITLE
Make `WinitMonitors` public

### DIFF
--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -35,12 +35,12 @@ pub use winit::{
     window::{CustomCursor as WinitCustomCursor, CustomCursorSource},
 };
 pub use winit_config::*;
+pub use winit_monitors::*;
 pub use winit_windows::*;
 
 use crate::{
     accessibility::{AccessKitPlugin, WinitActionRequestHandlers},
     state::winit_runner,
-    winit_monitors::WinitMonitors,
 };
 
 pub mod accessibility;

--- a/crates/bevy_winit/src/winit_monitors.rs
+++ b/crates/bevy_winit/src/winit_monitors.rs
@@ -21,10 +21,12 @@ pub struct WinitMonitors {
 }
 
 impl WinitMonitors {
+    /// Gets the [`MonitorHandle`] at index `n`.
     pub fn nth(&self, n: usize) -> Option<MonitorHandle> {
         self.monitors.get(n).map(|(monitor, _)| monitor.clone())
     }
 
+    /// Gets the [`MonitorHandle`] associated with a `Monitor` entity.
     pub fn find_entity(&self, entity: Entity) -> Option<MonitorHandle> {
         self.monitors
             .iter()


### PR DESCRIPTION
# Objective

- Allow third-party code to integrate with winit `MonitorHandle`s represented by bevy `Monitor` entities.

## Solution

- Reexport this resource type, just like `WinitWindows`.
- It was already part of the public API through the system types.