### PR TITLE
Don't automatically compute `Aabb` components for skinned meshes.

### DIFF
--- a/crates/bevy_camera/src/primitives.rs
+++ b/crates/bevy_camera/src/primitives.rs
@@ -43,13 +43,23 @@ impl MeshAabb for Mesh {
 /// It will be added automatically by the systems in [`CalculateBounds`] to entities that:
 /// - could be subject to frustum culling, for example with a [`Mesh3d`]
 ///   or `Sprite` component,
-/// - don't have the [`NoFrustumCulling`] component.
+/// - don't have the [`NoFrustumCulling`] component,
+/// - and don't have the [`SkinnedMesh`] component.
 ///
 /// It won't be updated automatically if the space occupied by the entity changes,
 /// for example if the vertex positions of a [`Mesh3d`] are updated.
 ///
+/// Bevy doesn't add the [`Aabb`] component to skinned meshes automatically,
+/// because skins can deform meshes arbitrarily and therefore there's no
+/// [`Aabb`] that can be automatically determined for them. You can, however,
+/// add an [`Aabb`] component yourself if you can guarantee to Bevy that no
+/// vertex in your skinned mesh will ever be positioned outside the boundaries
+/// of that AABB. This will allow your skinned meshes to participate in frustum
+/// and occlusion culling.
+///
 /// [`Camera`]: crate::Camera
 /// [`NoFrustumCulling`]: crate::visibility::NoFrustumCulling
+/// [`SkinnedMesh`]: bevy_mesh::skinning::SkinnedMesh
 /// [`CalculateBounds`]: crate::visibility::VisibilitySystems::CalculateBounds
 /// [`Mesh3d`]: bevy_mesh::Mesh
 #[derive(Component, Clone, Copy, Debug, Default, Reflect, PartialEq)]


### PR DESCRIPTION
Currently, Bevy automatically computes AABBs for all meshes, even those that have skins or morph targets. This is incorrect, as each skin and/or morph target can deform the mesh arbitrarily. This is not a theoretical problem, as Maya relies on rest poses to position and rotate meshes that are children of skins.

Right now, the only way to disable this Bevy feature is to add the `NoFrustumCulling` component, or to overwrite the generated `Aabb` with a different one. Neither are a particularly good experience:

1. Adding `NoFrustumCulling` is impossible when loading a glTF scene, and it's also not obvious that `NoFrustumCulling` is needed to correctly render skinned meshes sometimes.

2. Overwriting the `Aabb` is cumbersome.

This commit changes Bevy's behavior to not generate `Aabb` components for skinned meshes, fixing the issue. Note that, to keep this patch small, morph targets aren't handled yet. The documentation has been updated to inform developers that they may wish to add `Aabb` components manually to skinned meshes in order to opt in to frustum culling.

Fixes #4971.