### PR TITLE
Change feather's radio control's visibility from visible to inherited

### DIFF
--- a/crates/bevy_feathers/src/controls/radio.rs
+++ b/crates/bevy_feathers/src/controls/radio.rs
@@ -258,7 +258,7 @@ fn set_radio_styles(
 
     // Change mark visibility
     commands.entity(mark_ent).insert(match checked {
-        true => Visibility::Visible,
+        true => Visibility::Inherited,
         false => Visibility::Hidden,
     });
 


### PR DESCRIPTION
# Objective

Setting a feather radio button's visibility to `Visibility::Hidden` (bottom row of the below image) should hide the radio button entirely. Instead, the mark stays visible.

My use case for this is a settings panel, in which the radio buttons are in a collapsible section that makes them hidden.

## Solution

Changing the visibility of the mark from `Visibility::Visible` to `Visibility::Inherited` appears to me to be the cleanest solution, as it does minimal work and has no downsides. 

I considered adding a system to my project that would override the visibility each time, but the mark's marker component is not exported. 
I also considered adding a system to my project which removed the `Checked` component from the radio button when making it hidden, and re-adds it when making it visible.

## Testing

I tested this change by editing the source file in `~/.cargo/registry/`, running `cargo clean`, then doing a full rebuild of my app, and it worked as expected.

## Showcase

<img width="405" height="408" src="https://github.com/user-attachments/assets/3b45e538-996a-4e84-b867-e9d89cd43b98" />
