### PR TITLE
Replace unwrap() calls with proper error handling in font_altas

### DIFF
--- a/crates/bevy_sprite/src/text2d.rs
+++ b/crates/bevy_sprite/src/text2d.rs
@@ -253,7 +253,13 @@ pub fn update_text2d_layout(
                     // queue for further processing
                     queue.insert(entity);
                 }
-                Err(e @ (TextError::FailedToAddGlyph(_) | TextError::FailedToGetGlyphImage(_))) => {
+                Err(
+                    e @ (TextError::FailedToAddGlyph(_)
+                    | TextError::FailedToGetGlyphImage(_)
+                    | TextError::MissingAtlasLayout
+                    | TextError::MissingAtlasTexture
+                    | TextError::InconsistentAtlasState),
+                ) => {
                     panic!("Fatal error when processing text: {e}.");
                 }
                 Ok(()) => {

--- a/crates/bevy_text/src/error.rs
+++ b/crates/bevy_text/src/error.rs
@@ -14,4 +14,13 @@ pub enum TextError {
     /// Failed to get scaled glyph image for cache key
     #[error("failed to get scaled glyph image for cache key: {0:?}")]
     FailedToGetGlyphImage(CacheKey),
+    /// Missing texture atlas layout for the font
+    #[error("missing texture atlas layout for the font")]
+    MissingAtlasLayout,
+    /// Missing texture for the font atlas
+    #[error("missing texture for the font atlas")]
+    MissingAtlasTexture,
+    /// Failed to find glyph in atlas after it was added
+    #[error("failed to find glyph in atlas after it was added")]
+    InconsistentAtlasState,
 }

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -260,7 +260,13 @@ fn create_text_measure<'a>(
             // Try again next frame
             text_flags.needs_measure_fn = true;
         }
-        Err(e @ (TextError::FailedToAddGlyph(_) | TextError::FailedToGetGlyphImage(_))) => {
+        Err(
+            e @ (TextError::FailedToAddGlyph(_)
+            | TextError::FailedToGetGlyphImage(_)
+            | TextError::MissingAtlasLayout
+            | TextError::MissingAtlasTexture
+            | TextError::InconsistentAtlasState),
+        ) => {
             panic!("Fatal error when processing text: {e}.");
         }
     };
@@ -372,7 +378,13 @@ fn queue_text(
             // There was an error processing the text layout, try again next frame
             text_flags.needs_recompute = true;
         }
-        Err(e @ (TextError::FailedToAddGlyph(_) | TextError::FailedToGetGlyphImage(_))) => {
+        Err(
+            e @ (TextError::FailedToAddGlyph(_)
+            | TextError::FailedToGetGlyphImage(_)
+            | TextError::MissingAtlasLayout
+            | TextError::MissingAtlasTexture
+            | TextError::InconsistentAtlasState),
+        ) => {
             panic!("Fatal error when processing text: {e}.");
         }
         Ok(()) => {


### PR DESCRIPTION
# Objective

- Replace unwrap() calls with proper error handling in `font_atlas.rs`'s `add_glyph()` and `add_glyph_to_atlas()` to prevent panics and provide clear information.

## Solution

- Add new variants to the TextError enum to provide more specific error messages.
