### PR TITLE
Fix binding in generated environment map downsampling pipeline

### DIFF
--- a/crates/bevy_pbr/src/light_probe/generate.rs
+++ b/crates/bevy_pbr/src/light_probe/generate.rs
@@ -678,12 +678,16 @@ pub fn prepare_generated_environment_map_bind_groups(
                 (bind_group.clone(), bind_group)
             } else {
                 // Split path requires a separate view for mip6 input
-                let input_env_map_second = env_map_texture.create_view(&TextureViewDescriptor {
-                    dimension: Some(TextureViewDimension::D2Array),
-                    base_mip_level: min(6, last_mip),
-                    mip_level_count: Some(1),
-                    ..Default::default()
-                });
+                let input_env_map_second =
+                    textures
+                        .environment_map
+                        .texture
+                        .create_view(&TextureViewDescriptor {
+                            dimension: Some(TextureViewDimension::D2Array),
+                            base_mip_level: min(6, last_mip),
+                            mip_level_count: Some(1),
+                            ..Default::default()
+                        });
 
                 // Split layout (current behavior)
                 let first = render_device.create_bind_group(


### PR DESCRIPTION
# Objective

When Bevy splits mip generation for environment maps into two passes due to limits, the second pass binds a view to the the original texture when it's supposed to be the 6th mip level of an intermediate one. This causes an error on WebGPU in browsers if that original texture doesn't already have mipmaps.

This affects the atmosphere example on WebGPU, but there are other issues there too so it still won't work after this.

## Solution

Create texture view from the texture in the `IntermediateTextures` component instead of in `RenderEnvironmentMap`

## Testing

<details>

<summary>Example that doesn't work on WebGPU before this (replace square.png with any power of 2 square image that doesn't store mipmaps)</summary>

```rust
use bevy::prelude::*;

fn main() {
    App::new()
        .add_plugins(DefaultPlugins)
        .add_systems(Startup, setup)
        .run();
}

fn setup(
    mut commands: Commands,
    asset_server: Res<AssetServer>,
    mut meshes: ResMut<Assets<Mesh>>,
    mut materials: ResMut<Assets<StandardMaterial>>,
) {
    commands.spawn((
        Camera3d::default(),
        Transform::from_xyz(0.0, 0.0, 5.0),
        GeneratedEnvironmentMapLight {
            environment_map: asset_server.load("square.png"),
            intensity: 1000.0,
            ..Default::default()
        },
    ));

    commands.spawn((
        Mesh3d(meshes.add(Sphere::new(1.0).mesh().build())),
        MeshMaterial3d(materials.add(StandardMaterial {
            perceptual_roughness: 0.1,
            metallic: 1.0,
            ..Default::default()
        })),
    ));
}
```

</details>
