### PR TITLE
Delete unused WeightsCurve, and enable feature for bevy_animation.

### DIFF
--- a/crates/bevy_animation/src/gltf_curves.rs
+++ b/crates/bevy_animation/src/gltf_curves.rs
@@ -366,32 +366,6 @@ impl<T> WideCubicKeyframeCurve<T> {
     }
 }
 
-/// A curve specifying the [`MorphWeights`] for a mesh in animation. The variants are broken
-/// down by interpolation mode (with the exception of `Constant`, which never interpolates).
-///
-/// This type is, itself, a `Curve<Vec<f32>>`; however, in order to avoid allocation, it is
-/// recommended to use its implementation of the [`IterableCurve`] trait, which allows iterating
-/// directly over information derived from the curve without allocating.
-///
-/// [`MorphWeights`]: bevy_mesh::morph::MorphWeights
-#[derive(Debug, Clone, Reflect)]
-#[reflect(Clone)]
-pub enum WeightsCurve {
-    /// A curve which takes a constant value over its domain. Notably, this is how animations with
-    /// only a single keyframe are interpreted.
-    Constant(ConstantCurve<Vec<f32>>),
-
-    /// A curve which interpolates weights linearly between keyframes.
-    Linear(WideLinearKeyframeCurve<f32>),
-
-    /// A curve which interpolates weights between keyframes in steps.
-    Step(WideSteppedKeyframeCurve<f32>),
-
-    /// A curve which interpolates between keyframes by using auxiliary tangent data to join
-    /// adjacent keyframes with a cubic Hermite spline, which is then sampled.
-    CubicSpline(WideCubicKeyframeCurve<f32>),
-}
-
 //---------//
 // HELPERS //
 //---------//

--- a/crates/bevy_gltf/Cargo.toml
+++ b/crates/bevy_gltf/Cargo.toml
@@ -18,7 +18,9 @@ pbr_specular_textures = ["bevy_pbr/pbr_specular_textures"]
 
 [dependencies]
 # bevy
-bevy_animation = { path = "../bevy_animation", version = "0.18.0-dev", optional = true }
+bevy_animation = { path = "../bevy_animation", version = "0.18.0-dev", optional = true, features = [
+  "bevy_mesh",
+] }
 bevy_app = { path = "../bevy_app", version = "0.18.0-dev" }
 bevy_asset = { path = "../bevy_asset", version = "0.18.0-dev" }
 bevy_color = { path = "../bevy_color", version = "0.18.0-dev" }


### PR DESCRIPTION
# Objective

- Fix `cargo b -p bevy_gltf --all-features`

## Solution

- Delete an unused symbol with the same name.
- Add the `bevy_mesh` feature on `bevy_animation` in `bevy_gltf`, so the correct WeightsCurve is chosen.

## Testing

- CI, and running with `--all-features`.
