### PR TITLE
`TargetEvent`: Ergonomics for custom entity events

### DIFF
--- a/crates/bevy_ecs/src/event/mod.rs
+++ b/crates/bevy_ecs/src/event/mod.rs
@@ -296,7 +296,7 @@ pub trait EntityEvent: Event {
 /// This trait is implemented by [`EntityEvent`] by default, but can be extended by third parties
 /// to support custom entity event types that don't implement [`EntityEvent`].
 ///
-/// Methods like [`EntityWorldMut::observe`](crate::world::EntityWorldMut::observe) constrain events to `EventFromEntity`
+/// Methods like [`EntityWorldMut::observe`](crate::world::EntityWorldMut::observe) constrain events to `TargetEvent`
 /// to avoid accidentally adding a global observer to an entity.
 ///
 /// # Example
@@ -306,16 +306,16 @@ pub trait EntityEvent: Event {
 /// #[derive(Event)]
 /// struct MyCustomEvent;
 ///
-/// impl EventFromEntity for MyCustomEvent {}
+/// impl TargetEvent for MyCustomEvent {}
 ///
 /// // Now can be used with entity.observe()
 /// entity.observe(|event: On<MyCustomEvent>| {
 ///     // observer logic
 /// });
 /// ```
-pub trait EventFromEntity: Event {}
+pub trait TargetEvent: Event {}
 
-impl<E: EntityEvent> EventFromEntity for E {}
+impl<E: EntityEvent> TargetEvent for E {}
 
 /// A trait for converting values into entity-targeted events with their triggers.
 ///
@@ -359,7 +359,7 @@ impl<E: EntityEvent> EventFromEntity for E {}
 ///     commands.spawn_empty().trigger(|entity| Explode(entity));
 /// }
 /// ```
-pub trait IntoEventFromEntity<M> {
+pub trait IntoTargetEvent<M> {
     /// The event type.
     type Event: for<'a> Event<Trigger<'a> = Self::Trigger>;
     /// The trigger type for this event.
@@ -369,10 +369,10 @@ pub trait IntoEventFromEntity<M> {
     fn into_event_from_entity(self, entity: Entity) -> (Self::Event, Self::Trigger);
 }
 
-/// Marker type for the `FnOnce(Entity) -> E` implementation of [`IntoEventFromEntity`].
-pub struct FnOnceIntoEventFromEntity;
+/// Marker type for the `FnOnce(Entity) -> E` implementation of [`IntoTargetEvent`].
+pub struct FnOnceIntoTargetEvent;
 
-impl<F, E, T> IntoEventFromEntity<(E, T, FnOnceIntoEventFromEntity)> for F
+impl<F, E, T> IntoTargetEvent<(E, T, FnOnceIntoTargetEvent)> for F
 where
     F: FnOnce(Entity) -> E,
     E: for<'a> Event<Trigger<'a> = T>,

--- a/crates/bevy_ecs/src/event/mod.rs
+++ b/crates/bevy_ecs/src/event/mod.rs
@@ -322,25 +322,6 @@ impl<E: EntityEvent> EventFromEntity for E {}
 /// This trait allows methods like [`EntityWorldMut::trigger`](crate::world::EntityWorldMut::trigger)
 /// to accept both the `FnOnce(Entity) -> E` pattern and custom implementations
 /// that may use non-default triggers.
-///
-/// # Example
-///
-/// ```ignore
-/// // Usage with FnOnce
-/// entity.trigger(|entity| MyEvent { entity });
-///
-/// // Custom implementation with non-default trigger
-/// struct MyEventWithCustomTrigger;
-///
-/// impl IntoEventFromEntity<()> for MyEventWithCustomTrigger {
-///     type Event = MyEvent;
-///     type Trigger = MyCustomTrigger;
-///
-///     fn into_event_from_entity(self, entity: Entity) -> (Self::Event, Self::Trigger) {
-///         (MyEvent { entity }, MyCustomTrigger::new(entity))
-///     }
-/// }
-/// ```
 pub trait IntoEventFromEntity<M> {
     /// The event type.
     type Event: for<'a> Event<Trigger<'a> = Self::Trigger>;

--- a/crates/bevy_ecs/src/event/mod.rs
+++ b/crates/bevy_ecs/src/event/mod.rs
@@ -292,7 +292,7 @@ pub trait EntityEvent: Event {
 }
 
 /// A general trait to mark events that can be observed directly on entities,
-/// and therefore allowed to be used in the context of [`EntityWorldMut::observe`] amongst others.
+/// and therefore allowed to be used in the context of [`EntityWorldMut::observe`](crate::world::EntityWorldMut::observe) amongst others.
 ///
 /// This trait is implemented only for [`EntityEvent`] by default, but can be extended by third parties
 /// to support custom entity event types that don't use the [`EntityEvent`] pattern.

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -75,7 +75,7 @@ pub mod prelude {
         component::Component,
         entity::{ContainsEntity, Entity, EntityMapper},
         error::{BevyError, Result},
-        event::{EntityEvent, Event, TargetEvent, IntoTargetEvent},
+        event::{EntityEvent, Event, IntoTargetEvent, TargetEvent},
         hierarchy::{ChildOf, ChildSpawner, ChildSpawnerCommands, Children},
         lifecycle::{Add, Despawn, Insert, Remove, RemovedComponents, Replace},
         message::{Message, MessageMutator, MessageReader, MessageWriter, Messages},

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -75,7 +75,7 @@ pub mod prelude {
         component::Component,
         entity::{ContainsEntity, Entity, EntityMapper},
         error::{BevyError, Result},
-        event::{EntityEvent, Event, EventFromEntity, IntoEventFromEntity},
+        event::{EntityEvent, Event, TargetEvent, IntoTargetEvent},
         hierarchy::{ChildOf, ChildSpawner, ChildSpawnerCommands, Children},
         lifecycle::{Add, Despawn, Insert, Remove, RemovedComponents, Replace},
         message::{Message, MessageMutator, MessageReader, MessageWriter, Messages},

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -75,7 +75,7 @@ pub mod prelude {
         component::Component,
         entity::{ContainsEntity, Entity, EntityMapper},
         error::{BevyError, Result},
-        event::{EntityEvent, Event},
+        event::{EntityEvent, Event, EventFromEntity, IntoEventFromEntity},
         hierarchy::{ChildOf, ChildSpawner, ChildSpawnerCommands, Children},
         lifecycle::{Add, Despawn, Insert, Remove, RemovedComponents, Replace},
         message::{Message, MessageMutator, MessageReader, MessageWriter, Messages},

--- a/crates/bevy_ecs/src/system/commands/entity_command.rs
+++ b/crates/bevy_ecs/src/system/commands/entity_command.rs
@@ -15,7 +15,7 @@ use crate::{
     change_detection::MaybeLocation,
     component::{Component, ComponentId},
     entity::{Entity, EntityClonerBuilder, OptIn, OptOut},
-    event::EventFromEntity,
+    event::TargetEvent,
     name::Name,
     relationship::RelationshipHookMode,
     system::IntoObserverSystem,
@@ -249,9 +249,9 @@ pub fn despawn() -> impl EntityCommand {
 }
 
 /// An [`EntityCommand`] that creates an [`Observer`](crate::observer::Observer)
-/// watching for an [`EventFromEntity`] of type `E` who targets this entity.
+/// watching for an [`TargetEvent`] of type `E` who targets this entity.
 #[track_caller]
-pub fn observe<E: EventFromEntity, B: Bundle, M>(
+pub fn observe<E: TargetEvent, B: Bundle, M>(
     observer: impl IntoObserverSystem<E, B, M>,
 ) -> impl EntityCommand {
     let caller = MaybeLocation::caller();

--- a/crates/bevy_ecs/src/system/commands/entity_command.rs
+++ b/crates/bevy_ecs/src/system/commands/entity_command.rs
@@ -15,7 +15,7 @@ use crate::{
     change_detection::MaybeLocation,
     component::{Component, ComponentId},
     entity::{Entity, EntityClonerBuilder, OptIn, OptOut},
-    event::EntityEvent,
+    event::EventFromEntity,
     name::Name,
     relationship::RelationshipHookMode,
     system::IntoObserverSystem,
@@ -249,10 +249,9 @@ pub fn despawn() -> impl EntityCommand {
 }
 
 /// An [`EntityCommand`] that creates an [`Observer`](crate::observer::Observer)
-/// watching for an [`EntityEvent`] of type `E` whose [`EntityEvent::event_target`]
-/// targets this entity.
+/// watching for an [`EventFromEntity`] of type `E` who targets this entity.
 #[track_caller]
-pub fn observe<E: EntityEvent, B: Bundle, M>(
+pub fn observe<E: EventFromEntity, B: Bundle, M>(
     observer: impl IntoObserverSystem<E, B, M>,
 ) -> impl EntityCommand {
     let caller = MaybeLocation::caller();

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -24,7 +24,7 @@ use crate::{
         InvalidEntityError, OptIn, OptOut,
     },
     error::{warn, BevyError, CommandWithEntity, ErrorContext, HandleError},
-    event::{Event, EventFromEntity, IntoEventFromEntity},
+    event::{Event, TargetEvent, IntoTargetEvent},
     message::Message,
     observer::Observer,
     resource::Resource,
@@ -2022,8 +2022,8 @@ impl<'a> EntityCommands<'a> {
         &mut self.commands
     }
 
-    /// Creates an [`Observer`] watching for an [`EventFromEntity`] of type `E` whose event targets this entity.
-    pub fn observe<E: EventFromEntity, B: Bundle, M>(
+    /// Creates an [`Observer`] watching for an [`TargetEvent`] of type `E` whose event targets this entity.
+    pub fn observe<E: TargetEvent, B: Bundle, M>(
         &mut self,
         observer: impl IntoObserverSystem<E, B, M>,
     ) -> &mut Self {
@@ -2276,9 +2276,9 @@ impl<'a> EntityCommands<'a> {
     }
 
     /// Passes the current entity into the given function, and triggers the event returned by that function.
-    /// See [`IntoEventFromEntity`] for usage examples.
+    /// See [`IntoTargetEvent`] for usage examples.
     #[track_caller]
-    pub fn trigger<M, T: IntoEventFromEntity<M>>(&mut self, event_fn: T) -> &mut Self
+    pub fn trigger<M, T: IntoTargetEvent<M>>(&mut self, event_fn: T) -> &mut Self
     where
         T::Event: Send + 'static,
         T::Trigger: Send + 'static,

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -2284,7 +2284,7 @@ impl<'a> EntityCommands<'a> {
         T::Trigger: Send + 'static,
     {
         let entity = self.entity;
-        let (mut event, mut trigger) = event_fn.into_event_from_entity(entity);
+        let (mut event, mut trigger) = event_fn.into_target_event(entity);
         let caller = MaybeLocation::caller();
         self.commands.queue(move |world: &mut World| {
             world.trigger_ref_with_caller(&mut event, &mut trigger, caller);

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -24,7 +24,7 @@ use crate::{
         InvalidEntityError, OptIn, OptOut,
     },
     error::{warn, BevyError, CommandWithEntity, ErrorContext, HandleError},
-    event::{Event, TargetEvent, IntoTargetEvent},
+    event::{Event, IntoTargetEvent, TargetEvent},
     message::Message,
     observer::Observer,
     resource::Resource,

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -2275,43 +2275,8 @@ impl<'a> EntityCommands<'a> {
         self.queue(entity_command::move_components::<B>(target))
     }
 
-    /// Passes the current entity into the given function, and triggers the [`EntityEvent`] returned by that function.
-    ///
-    /// # Example
-    ///
-    /// A surprising number of functions meet the trait bounds for `event_fn`:
-    ///
-    /// ```rust
-    /// # use bevy_ecs::prelude::*;
-    ///
-    /// #[derive(EntityEvent)]
-    /// struct Explode(Entity);
-    ///
-    /// impl From<Entity> for Explode {
-    ///    fn from(entity: Entity) -> Self {
-    ///       Explode(entity)
-    ///    }
-    /// }
-    ///
-    ///
-    /// fn trigger_via_constructor(mut commands: Commands) {
-    ///     // The fact that `Explode` is a single-field tuple struct
-    ///     // ensures that `Explode(entity)` is a function that generates
-    ///     // an EntityEvent, meeting the trait bounds for `event_fn`.
-    ///     commands.spawn_empty().trigger(Explode);
-    ///
-    /// }
-    ///
-    ///
-    /// fn trigger_via_from_trait(mut commands: Commands) {
-    ///     // This variant also works for events like `struct Explode { entity: Entity }`
-    ///     commands.spawn_empty().trigger(Explode::from);
-    /// }
-    ///
-    /// fn trigger_via_closure(mut commands: Commands) {
-    ///     commands.spawn_empty().trigger(|entity| Explode(entity));
-    /// }
-    /// ```
+    /// Passes the current entity into the given function, and triggers the event returned by that function.
+    /// See [`IntoEventFromEntity`] for usage examples.
     #[track_caller]
     pub fn trigger<M, T: IntoEventFromEntity<M>>(&mut self, event_fn: T) -> &mut Self
     where

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -2313,10 +2313,7 @@ impl<'a> EntityCommands<'a> {
     /// }
     /// ```
     #[track_caller]
-    pub fn trigger<M, T: IntoEventFromEntity<M>>(
-        &mut self,
-        event_fn: T,
-    ) -> &mut Self
+    pub fn trigger<M, T: IntoEventFromEntity<M>>(&mut self, event_fn: T) -> &mut Self
     where
         T::Event: Send + 'static,
         T::Trigger: Send + 'static,

--- a/crates/bevy_ecs/src/world/entity_access/world_mut.rs
+++ b/crates/bevy_ecs/src/world/entity_access/world_mut.rs
@@ -6,7 +6,7 @@ use crate::{
     change_detection::{ComponentTicks, MaybeLocation, MutUntyped, Tick},
     component::{Component, ComponentId, Components, Mutable, StorageType},
     entity::{Entity, EntityCloner, EntityClonerBuilder, EntityLocation, OptIn, OptOut},
-    event::{EntityComponentsTrigger, TargetEvent, IntoTargetEvent},
+    event::{EntityComponentsTrigger, IntoTargetEvent, TargetEvent},
     lifecycle::{Despawn, Remove, Replace, DESPAWN, REMOVE, REPLACE},
     observer::Observer,
     query::{Access, DebugCheckedUnwrap, ReadOnlyQueryData, ReleaseStateQueryData},

--- a/crates/bevy_ecs/src/world/entity_access/world_mut.rs
+++ b/crates/bevy_ecs/src/world/entity_access/world_mut.rs
@@ -6,7 +6,7 @@ use crate::{
     change_detection::{ComponentTicks, MaybeLocation, MutUntyped, Tick},
     component::{Component, ComponentId, Components, Mutable, StorageType},
     entity::{Entity, EntityCloner, EntityClonerBuilder, EntityLocation, OptIn, OptOut},
-    event::{EntityComponentsTrigger, EventFromEntity, IntoEventFromEntity},
+    event::{EntityComponentsTrigger, TargetEvent, IntoTargetEvent},
     lifecycle::{Despawn, Remove, Replace, DESPAWN, REMOVE, REPLACE},
     observer::Observer,
     query::{Access, DebugCheckedUnwrap, ReadOnlyQueryData, ReleaseStateQueryData},
@@ -1759,7 +1759,7 @@ impl<'w> EntityWorldMut<'w> {
         }
     }
 
-    /// Creates an [`Observer`] watching for an [`EventFromEntity`] of type `E` that targets this entity.
+    /// Creates an [`Observer`] watching for an [`TargetEvent`] of type `E` that targets this entity.
     ///
     /// # Panics
     ///
@@ -1767,14 +1767,14 @@ impl<'w> EntityWorldMut<'w> {
     ///
     /// Panics if the given system is an exclusive system.
     #[track_caller]
-    pub fn observe<E: EventFromEntity, B: Bundle, M>(
+    pub fn observe<E: TargetEvent, B: Bundle, M>(
         &mut self,
         observer: impl IntoObserverSystem<E, B, M>,
     ) -> &mut Self {
         self.observe_with_caller(observer, MaybeLocation::caller())
     }
 
-    pub(crate) fn observe_with_caller<E: EventFromEntity, B: Bundle, M>(
+    pub(crate) fn observe_with_caller<E: TargetEvent, B: Bundle, M>(
         &mut self,
         observer: impl IntoObserverSystem<E, B, M>,
         caller: MaybeLocation,
@@ -2074,9 +2074,9 @@ impl<'w> EntityWorldMut<'w> {
     }
 
     /// Passes the current entity into the given function, and triggers the event returned by that function.
-    /// See [`IntoEventFromEntity`] for usage examples.
+    /// See [`IntoTargetEvent`] for usage examples.
     #[track_caller]
-    pub fn trigger<M, T: IntoEventFromEntity<M>>(&mut self, event_fn: T) -> &mut Self {
+    pub fn trigger<M, T: IntoTargetEvent<M>>(&mut self, event_fn: T) -> &mut Self {
         let (mut event, mut trigger) = event_fn.into_event_from_entity(self.entity);
         let caller = MaybeLocation::caller();
         self.world_scope(|world| {

--- a/crates/bevy_ecs/src/world/entity_access/world_mut.rs
+++ b/crates/bevy_ecs/src/world/entity_access/world_mut.rs
@@ -2077,7 +2077,7 @@ impl<'w> EntityWorldMut<'w> {
     /// See [`IntoTargetEvent`] for usage examples.
     #[track_caller]
     pub fn trigger<M, T: IntoTargetEvent<M>>(&mut self, event_fn: T) -> &mut Self {
-        let (mut event, mut trigger) = event_fn.into_event_from_entity(self.entity);
+        let (mut event, mut trigger) = event_fn.into_target_event(self.entity);
         let caller = MaybeLocation::caller();
         self.world_scope(|world| {
             world.trigger_ref_with_caller(&mut event, &mut trigger, caller);

--- a/crates/bevy_ecs/src/world/entity_access/world_mut.rs
+++ b/crates/bevy_ecs/src/world/entity_access/world_mut.rs
@@ -2079,18 +2079,11 @@ impl<'w> EntityWorldMut<'w> {
     ///
     /// [`EntityCommands::trigger`]: crate::system::EntityCommands::trigger
     #[track_caller]
-    pub fn trigger<M, T: IntoEventFromEntity<M>>(
-        &mut self,
-        event_fn: T,
-    ) -> &mut Self {
+    pub fn trigger<M, T: IntoEventFromEntity<M>>(&mut self, event_fn: T) -> &mut Self {
         let (mut event, mut trigger) = event_fn.into_event_from_entity(self.entity);
         let caller = MaybeLocation::caller();
         self.world_scope(|world| {
-            world.trigger_ref_with_caller(
-                &mut event,
-                &mut trigger,
-                caller,
-            );
+            world.trigger_ref_with_caller(&mut event, &mut trigger, caller);
         });
         self
     }

--- a/crates/bevy_ecs/src/world/entity_access/world_mut.rs
+++ b/crates/bevy_ecs/src/world/entity_access/world_mut.rs
@@ -1759,8 +1759,7 @@ impl<'w> EntityWorldMut<'w> {
         }
     }
 
-    /// Creates an [`Observer`] watching for an [`EntityEvent`] of type `E` whose [`EntityEvent::event_target`]
-    /// targets this entity.
+    /// Creates an [`Observer`] watching for an [`EventFromEntity`] of type `E` that targets this entity.
     ///
     /// # Panics
     ///
@@ -2074,10 +2073,8 @@ impl<'w> EntityWorldMut<'w> {
         })
     }
 
-    /// Passes the current entity into the given function, and triggers the [`EntityEvent`] returned by that function.
-    /// See [`EntityCommands::trigger`] for usage examples
-    ///
-    /// [`EntityCommands::trigger`]: crate::system::EntityCommands::trigger
+    /// Passes the current entity into the given function, and triggers the event returned by that function.
+    /// See [`IntoEventFromEntity`] for usage examples.
     #[track_caller]
     pub fn trigger<M, T: IntoEventFromEntity<M>>(&mut self, event_fn: T) -> &mut Self {
         let (mut event, mut trigger) = event_fn.into_event_from_entity(self.entity);

--- a/crates/bevy_ui_widgets/src/observe.rs
+++ b/crates/bevy_ui_widgets/src/observe.rs
@@ -6,19 +6,19 @@ use core::marker::PhantomData;
 
 use bevy_ecs::{
     bundle::{Bundle, DynamicBundle},
-    event::EventFromEntity,
+    event::TargetEvent,
     system::IntoObserverSystem,
 };
 
 /// Helper struct that adds an observer when inserted as a [`Bundle`].
-pub struct AddObserver<E: EventFromEntity, B: Bundle, M, I: IntoObserverSystem<E, B, M>> {
+pub struct AddObserver<E: TargetEvent, B: Bundle, M, I: IntoObserverSystem<E, B, M>> {
     observer: I,
     marker: PhantomData<(E, B, M)>,
 }
 
 // SAFETY: Empty method bodies.
 unsafe impl<
-        E: EventFromEntity,
+        E: TargetEvent,
         B: Bundle,
         M: Send + Sync + 'static,
         I: IntoObserverSystem<E, B, M> + Send + Sync,
@@ -41,7 +41,7 @@ unsafe impl<
     }
 }
 
-impl<E: EventFromEntity, B: Bundle, M, I: IntoObserverSystem<E, B, M>> DynamicBundle
+impl<E: TargetEvent, B: Bundle, M, I: IntoObserverSystem<E, B, M>> DynamicBundle
     for AddObserver<E, B, M, I>
 {
     type Effect = Self;
@@ -67,7 +67,7 @@ impl<E: EventFromEntity, B: Bundle, M, I: IntoObserverSystem<E, B, M>> DynamicBu
 }
 
 /// Adds an observer as a bundle effect.
-pub fn observe<E: EventFromEntity, B: Bundle, M, I: IntoObserverSystem<E, B, M>>(
+pub fn observe<E: TargetEvent, B: Bundle, M, I: IntoObserverSystem<E, B, M>>(
     observer: I,
 ) -> AddObserver<E, B, M, I> {
     AddObserver {

--- a/crates/bevy_ui_widgets/src/observe.rs
+++ b/crates/bevy_ui_widgets/src/observe.rs
@@ -6,19 +6,19 @@ use core::marker::PhantomData;
 
 use bevy_ecs::{
     bundle::{Bundle, DynamicBundle},
-    event::EntityEvent,
+    event::EventFromEntity,
     system::IntoObserverSystem,
 };
 
 /// Helper struct that adds an observer when inserted as a [`Bundle`].
-pub struct AddObserver<E: EntityEvent, B: Bundle, M, I: IntoObserverSystem<E, B, M>> {
+pub struct AddObserver<E: EventFromEntity, B: Bundle, M, I: IntoObserverSystem<E, B, M>> {
     observer: I,
     marker: PhantomData<(E, B, M)>,
 }
 
 // SAFETY: Empty method bodies.
 unsafe impl<
-        E: EntityEvent,
+        E: EventFromEntity,
         B: Bundle,
         M: Send + Sync + 'static,
         I: IntoObserverSystem<E, B, M> + Send + Sync,
@@ -41,7 +41,7 @@ unsafe impl<
     }
 }
 
-impl<E: EntityEvent, B: Bundle, M, I: IntoObserverSystem<E, B, M>> DynamicBundle
+impl<E: EventFromEntity, B: Bundle, M, I: IntoObserverSystem<E, B, M>> DynamicBundle
     for AddObserver<E, B, M, I>
 {
     type Effect = Self;
@@ -67,7 +67,7 @@ impl<E: EntityEvent, B: Bundle, M, I: IntoObserverSystem<E, B, M>> DynamicBundle
 }
 
 /// Adds an observer as a bundle effect.
-pub fn observe<E: EntityEvent, B: Bundle, M, I: IntoObserverSystem<E, B, M>>(
+pub fn observe<E: EventFromEntity, B: Bundle, M, I: IntoObserverSystem<E, B, M>>(
     observer: I,
 ) -> AddObserver<E, B, M, I> {
     AddObserver {


### PR DESCRIPTION
# Objective

The Observers Overhaul is largely open-ended, however when it comes to entity events there are two method signatures that constrain how they can be used:

```rust
impl EntityComands {
  pub fn observe<E>(..) where
    // must be an 'EntityEvent'
    E:EntityEvent

  pub fn trigger<F,E>(func: F) where
    // must be an 'EntityEvent'
    E: EntityEvent,
    // must be constructable from only an Entity
    F: FnOnce(Entity) -> E,
    // must have default Trigger
    E::Trigger: Default
```
These are good patterns for most uses most of the time and we should continue to support only these by default, but with a few non-breaking tweaks we can open up unbounded possibilities for crate authors.

## Background

For context I am the author of an observer based [control flow library](https://crates.io/crates/beet_flow) where programmatic triggering and observing happens frequently. I experimented heavily with a pure `EntityEvent` rework but the ergonomics around triggering and storing the payload were too bad. I've revisited the situation several times with different approaches, but keep coming back to custom entity events as the most elegant solution for this use-case.

#21272, #21408 and #21642 can provide more context for the various patterns authors are trying to implement.

## Solution

In a nutshell `TargetEvent` is an unopinionated superset of `EntityEvent`, making room for alternate implementations. This feature makes non-breaking changes to a handful of function signatures, achieved through two new traits:

### `TargetEvent`

Methods like `EntityWorldMut::observe` rightfully constrain events to `EntityEvent` to avoid accidentally adding a global observer to an entity (which would never trigger). This pr introduces `TargetEvent` which is by default only implemented for `EntityEvent` but allows for third parties to extend it to their own patterns.

```rust
pub trait TargetEvent: Event {}
// by default only implemented for EntityEvent
impl<E: EntityEvent> TargetEvent for E {}
```

### `IntoTargetEvent`

Methods like `EntityWorldMut::trigger` currently accept a `FnOnce(Entity) -> E where E: EntityEvent`. Custom entity events may have a non-default trigger so `IntoTargetEvent::into_event_from_entity` returns a `(E, E::Trigger)` tuple. An example use-case for this is pairs that store the `event_target` on the trigger.

```rust
pub trait IntoTargetEvent<M>{
  type Event: for<'a> Event<Trigger<'a> = Self::Trigger>;
  type Trigger: Trigger<Self::Event>;

  fn into_event_from_entity(
    self,
    entity: Entity,
  ) -> (Self::Event, Self::Trigger);
}
```

### On Naming

I've tried a few different names and none seem to fit perfectly:
- `IntoEventFromEntity`: quite vague
- `IntoTargetEvent`: also vague
- `IntoEntityEvent`: confuses the concrete `EntityEvent` approach with others

I'm very much open to ideas here.

## Alternatives

### 1. Extension Methods

As discussed in #21457 my current solution is extension methods like `observe_any` and `trigger_action`. I see two issues with this approach:
- Even as the author I have a hard time remembering when to use vanilla vs custom methods
- Other custom entity event authors may end up creating their own patterns leading to even greater fragmentation.

```rust
#[derive(ActionEvent)]
enum Outcome{
  Pass,
  Fail
}

// using custom extension methods as a workaround
commands
  .spawn_empty()
  .observe_any(|outcome: On<Outcome>|{..})
  .trigger_action(Outcome::Pass);

// with this pr we can use default methods for custom entity events
commands
  .spawn_empty()
  .observe(|outcome: On<Outcome>|{..})
  .trigger(Outcome::Pass);
```

### 2. Payload Pattern

As @alice-i-cecile proposed in #21642 an approach for the `enum EntityEvent` is the payload pattern:
```rust
struct MyEvent {
  entity: Entity,
  payload: MyEnum,
}
```

This pattern is good but with the api in its current state it challenging to trigger programatically. This pr would allow the payload pattern to be triggered by the payload itself:
```rust
commands
  .spawn_empty()
  .trigger(MyEnum::Foo);
```

This PR is non-breaking and I think its in line with bevy's design goal of first class modularity: "replace what you need to". 
It serves as a cleaner approach than each library author trying to upstream changes to `EntityEvent` which can equally solve things for one case while breaking them for another.

## Further Work
- This pr adds the primitives but if we keep getting issues like 'i need changes to `EntityEvent` for xyz' it may be worth adding an example to make this route even clearer.


## Updates
- 2026-01-27: rename `EventFromEntity` to `TargetEvent`