### PR TITLE
Pass position to `HitData` for window pointer hits

### DIFF
--- a/crates/bevy_picking/src/window.rs
+++ b/crates/bevy_picking/src/window.rs
@@ -9,7 +9,7 @@
 //!
 //! ## Implementation Notes
 //!
-//! - This backend does not provide `position` or `normal` in `HitData`.
+//! - This backend does not provide `normal` in `HitData`.
 
 use core::f32;
 
@@ -34,11 +34,12 @@ pub fn update_window_hits(
     for (pointer_id, pointer_location) in pointers.iter() {
         if let Some(Location {
             target: NormalizedRenderTarget::Window(window_ref),
+            position,
             ..
         }) = pointer_location.location
         {
             let entity = window_ref.entity();
-            let hit_data = HitData::new(entity, 0.0, None, None);
+            let hit_data = HitData::new(entity, 0.0, Some(position.extend(0.0)), None);
             pointer_hits_writer.write(PointerHits::new(
                 *pointer_id,
                 vec![(entity, hit_data)],


### PR DESCRIPTION
# Objective

- Mouse position from `On<Pointer<Move>>` is `None` when accessing from an observer added to a window.
- Fixes #21778

## Solution

- Pass position to `HitData` in `bevy_picking::window::update_window_hits`
- Update doc comment

## Testing

The following now works:

```rust
use bevy::prelude::*;

fn main() {
    App::new()
        .add_plugins(DefaultPlugins)
        .add_systems(Startup, setup)
        .run();
}

fn setup(mut commands: Commands) {
    commands.spawn(Camera2d);
    commands
        .spawn(Window::default())
        .observe(|trigger: On<Pointer<Move>>| {
            assert!(
                trigger.hit.position.is_some(),
                "Position should not be None"
            );
        });
}
```


