### PR TITLE
SystemRunner param and macro syntax

### DIFF
--- a/crates/bevy_ecs/macros/Cargo.toml
+++ b/crates/bevy_ecs/macros/Cargo.toml
@@ -11,7 +11,7 @@ proc-macro = true
 [dependencies]
 bevy_macro_utils = { path = "../../bevy_macro_utils", version = "0.19.0-dev" }
 
-syn = { version = "2.0.108", features = ["full", "extra-traits"] }
+syn = { version = "2.0.108", features = ["full", "extra-traits", "visit-mut"] }
 quote = "1.0"
 proc-macro2 = "1.0"
 [lints]

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -9,6 +9,7 @@ mod event;
 mod message;
 mod query_data;
 mod query_filter;
+mod system_composition;
 mod world_query;
 
 use crate::{
@@ -727,4 +728,14 @@ pub fn derive_from_world(input: TokenStream) -> TokenStream {
                 }
             }
     })
+}
+
+#[proc_macro]
+pub fn compose(input: TokenStream) -> TokenStream {
+    system_composition::compose(input, false)
+}
+
+#[proc_macro]
+pub fn compose_with(input: TokenStream) -> TokenStream {
+    system_composition::compose(input, true)
 }

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -741,27 +741,26 @@ pub fn derive_from_world(input: TokenStream) -> TokenStream {
 /// let system_b = |a: In<u32>, world: &mut World| { println!("{}", *a + 12) };
 /// compose! {
 ///     || -> Result<(), RunSystemError> {
-///         let a = run!(system-a)?;
-///         run!(system_b);
+///         let a = system!(system_a).run()?;
+///         system!(system_b).run_with(a);
 ///     }
 /// }
 /// ```
 ///
-/// What's special is that the macro will expand any invocations of `run!()` into
-/// calls to `SystemRunner::run` or `SystemRunner::run_with`. The `run!()` accepts
-/// two parameters: first, a system identifier (or a path to one), and second, an
-/// optional input to invoke the system with.
+/// What's special is that the macro will expand any invocations of `system!()` into
+/// a reference to a `SystemRunner` param, which you can call `run` or `run_with` on
+/// as normal.
 ///
 /// Notes:
 /// 1. All system runners are passed through a `ParamSet`, so invoked systems will
 ///    not conflict with each other. However, invoked systems may still conflict
 ///    with system params in the outer closure.
 ///
-/// 2. `run!` will not accept expressions that evaluate to systems, only direct
+/// 2. `system!` will not accept expressions that evaluate to systems, only direct
 ///    identifiers or paths. So, if you want to call something like:
 ///
 ///    ```ignore
-///    run!(|query: Query<(&A, &B, &mut C)>| { ... })`
+///    system!(|query: Query<(&A, &B, &mut C)>| { ... }).run()`
 ///    ```
 ///
 ///    Assign the expression to a variable first.
@@ -783,27 +782,26 @@ pub fn compose(input: TokenStream) -> TokenStream {
 /// let system_b = |a: In<u32>, world: &mut World| { println!("{}", *a + 12) };
 /// compose_with! {
 ///     |input: In<u32>| -> Result<(), RunSystemError> {
-///         let a = run!(system_a, input)?;
-///         run!(system_b);
+///         let a = system!(system_a).run_with(input)?;
+///         system!(system_b).run_with(a);
 ///     }
 /// }
 /// ```
 ///
-/// What's special is that the macro will expand any invocations of `run!()` into
-/// calls to `SystemRunner::run` or `SystemRunner::run_with`. The `run!()` accepts
-/// two parameters: first, a system identifier (or a path to one), and second, an
-/// optional input to invoke the system with.
+/// What's special is that the macro will expand any invocations of `system!()` into
+/// a reference to a `SystemRunner` param, which you can call `run` or `run_with` on
+/// as normal.
 ///
 /// Notes:
 /// 1. All system runners are passed through a `ParamSet`, so invoked systems will
 ///    not conflict with each other. However, invoked systems may still conflict
 ///    with system params in the outer closure.
 ///
-/// 2. `run!` will not accept expressions that evaluate to systems, only direct
+/// 2. `system!` will not accept expressions that evaluate to systems, only direct
 ///    identifiers or paths. So, if you want to call something like:
 ///
 ///    ```ignore
-///    run!(|query: Query<(&A, &B, &mut C)>| { ... })`
+///    system!(|query: Query<(&A, &B, &mut C)>| { ... }).run()`
 ///    ```
 ///
 ///    Assign the expression to a variable first.

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -730,11 +730,83 @@ pub fn derive_from_world(input: TokenStream) -> TokenStream {
     })
 }
 
+/// Automatically compose systems together with function syntax.
+///
+/// This macro provides some nice syntax on top of the `SystemRunner` `SystemParam`
+/// to allow running systems inside other systems. Overall, the macro accepts normal
+/// closure syntax:
+///
+/// ```ignore
+/// let system_a = |world: &mut World| { 10 };
+/// let system_b = |a: In<u32>, world: &mut World| { println!("{}", *a + 12) };
+/// compose! {
+///     || -> Result<(), RunSystemError> {
+///         let a = run!(system-a)?;
+///         run!(system_b);
+///     }
+/// }
+/// ```
+///
+/// What's special is that the macro will expand any invocations of `run!()` into
+/// calls to `SystemRunner::run` or `SystemRunner::run_with`. The `run!()` accepts
+/// two parameters: first, a system identifier (or a path to one), and second, an
+/// optional input to invoke the system with.
+///
+/// Notes:
+/// 1. All system runners are passed through a `ParamSet`, so invoked systems will
+///    not conflict with each other. However, invoked systems may still conflict
+///    with system params in the outer closure.
+///
+/// 2. `run!` will not accept expressions that evaluate to systems, only direct
+///    identifiers or paths. So, if you want to call something like:
+///
+///    ```ignore
+///    run!(|query: Query<(&A, &B, &mut C)>| { ... })`
+///    ```
+///
+///    Assign the expression to a variable first.
 #[proc_macro]
 pub fn compose(input: TokenStream) -> TokenStream {
     system_composition::compose(input, false)
 }
 
+/// Automatically compose systems together with function syntax.
+///
+/// Unlike [`compose`], this macro allows generating systems that take input.
+///
+/// This macro provides some nice syntax on top of the `SystemRunner` `SystemParam`
+/// to allow running systems inside other systems. Overall, the macro accepts normal
+/// closure syntax:
+///
+/// ```ignore
+/// let system_a = |input: In<u32>, world: &mut World| { *input + 10 };
+/// let system_b = |a: In<u32>, world: &mut World| { println!("{}", *a + 12) };
+/// compose_with! {
+///     |input: In<u32>| -> Result<(), RunSystemError> {
+///         let a = run!(system_a, input)?;
+///         run!(system_b);
+///     }
+/// }
+/// ```
+///
+/// What's special is that the macro will expand any invocations of `run!()` into
+/// calls to `SystemRunner::run` or `SystemRunner::run_with`. The `run!()` accepts
+/// two parameters: first, a system identifier (or a path to one), and second, an
+/// optional input to invoke the system with.
+///
+/// Notes:
+/// 1. All system runners are passed through a `ParamSet`, so invoked systems will
+///    not conflict with each other. However, invoked systems may still conflict
+///    with system params in the outer closure.
+///
+/// 2. `run!` will not accept expressions that evaluate to systems, only direct
+///    identifiers or paths. So, if you want to call something like:
+///
+///    ```ignore
+///    run!(|query: Query<(&A, &B, &mut C)>| { ... })`
+///    ```
+///
+///    Assign the expression to a variable first.
 #[proc_macro]
 pub fn compose_with(input: TokenStream) -> TokenStream {
     system_composition::compose(input, true)

--- a/crates/bevy_ecs/macros/src/system_composition.rs
+++ b/crates/bevy_ecs/macros/src/system_composition.rs
@@ -2,11 +2,8 @@ use bevy_macro_utils::ensure_no_collision;
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use syn::{
-    parse::{Parse, ParseStream},
-    parse_macro_input, parse_quote, parse_quote_spanned,
-    spanned::Spanned,
-    visit_mut::VisitMut,
-    Expr, ExprMacro, Ident, Pat, Path, Token,
+    parse_macro_input, parse_quote, parse_quote_spanned, spanned::Spanned, visit_mut::VisitMut,
+    Expr, ExprMacro, Ident, Pat, Path,
 };
 
 use crate::bevy_ecs_path;
@@ -17,31 +14,12 @@ struct ExpandSystemCalls {
     system_paths: Vec<Path>,
 }
 
-struct SystemCall {
-    path: Path,
-    _comma: Option<Token![,]>,
-    input: Option<Box<Expr>>,
-}
-
-impl Parse for SystemCall {
-    fn parse(input: ParseStream) -> syn::Result<Self> {
-        let path = input.parse()?;
-        let comma: Option<Token![,]> = input.parse()?;
-        let input = comma.as_ref().and_then(|_| input.parse().ok());
-        Ok(Self {
-            path,
-            _comma: comma,
-            input,
-        })
-    }
-}
-
 impl VisitMut for ExpandSystemCalls {
     fn visit_expr_mut(&mut self, i: &mut Expr) {
         if let Expr::Macro(ExprMacro { attrs: _, mac }) = i
             && mac.path.is_ident(&self.call_ident)
         {
-            let call = match mac.parse_body::<SystemCall>() {
+            let call = match mac.parse_body::<Path>() {
                 Ok(call) => call,
                 Err(err) => {
                     *i = Expr::Verbatim(err.into_compile_error());
@@ -49,25 +27,18 @@ impl VisitMut for ExpandSystemCalls {
                 }
             };
 
-            let call_index = match self.system_paths.iter().position(|p| p == &call.path) {
+            let call_index = match self.system_paths.iter().position(|p| p == &call) {
                 Some(i) => i,
                 None => {
                     let len = self.system_paths.len();
-                    self.system_paths.push(call.path.clone());
+                    self.system_paths.push(call.clone());
                     len
                 }
             };
 
             let systems_ident = &self.systems_ident;
             let system_accessor = format_ident!("p{}", call_index);
-            let expr: Expr = match &call.input {
-                Some(input) => {
-                    parse_quote_spanned!(mac.span()=> #systems_ident.#system_accessor().run_with(#input))
-                }
-                None => {
-                    parse_quote_spanned!(mac.span()=> #systems_ident.#system_accessor().run())
-                }
-            };
+            let expr: Expr = parse_quote_spanned!(mac.span()=> #systems_ident.#system_accessor());
             *i = expr;
         } else {
             syn::visit_mut::visit_expr_mut(self, i);
@@ -77,7 +48,7 @@ impl VisitMut for ExpandSystemCalls {
 
 pub fn compose(input: TokenStream, has_input: bool) -> TokenStream {
     let bevy_ecs_path = bevy_ecs_path();
-    let call_ident = format_ident!("run");
+    let call_ident = format_ident!("system");
     let systems_ident = ensure_no_collision(format_ident!("__systems"), input.clone());
     let mut expr_closure = parse_macro_input!(input as syn::ExprClosure);
 
@@ -113,11 +84,14 @@ pub fn compose(input: TokenStream, has_input: bool) -> TokenStream {
     let mut builders: Vec<Expr> =
         vec![parse_quote!(#bevy_ecs_path::system::ParamBuilder); param_count];
     let system_builders: Vec<Expr> = visitor.system_paths.iter().map(|path| parse_quote_spanned!(path.span()=> #bevy_ecs_path::system::ParamBuilder::system(#path))).collect();
-    builders.push(parse_quote!(#bevy_ecs_path::system::ParamSetBuilder((#(#system_builders,)*))));
 
-    expr_closure.inputs.push(Pat::Type(
-        parse_quote!(mut #systems_ident: #bevy_ecs_path::system::ParamSet<(#(#runner_types,)*)>),
-    ));
+    if !runner_types.is_empty() {
+        builders
+            .push(parse_quote!(#bevy_ecs_path::system::ParamSetBuilder((#(#system_builders,)*))));
+        expr_closure.inputs.push(Pat::Type(
+            parse_quote!(mut #systems_ident: #bevy_ecs_path::system::ParamSet<(#(#runner_types,)*)>),
+        ));
+    }
 
     TokenStream::from(quote! {
         #bevy_ecs_path::system::SystemParamBuilder::build_system(

--- a/crates/bevy_ecs/macros/src/system_composition.rs
+++ b/crates/bevy_ecs/macros/src/system_composition.rs
@@ -1,0 +1,121 @@
+use core::mem;
+
+use bevy_macro_utils::ensure_no_collision;
+use proc_macro::TokenStream;
+use quote::{format_ident, quote};
+use syn::{
+    parse::{Parse, ParseStream},
+    parse_macro_input, parse_quote, parse_quote_spanned,
+    spanned::Spanned,
+    visit_mut::VisitMut,
+    Expr, ExprMacro, Ident, Pat, Path, Token,
+};
+
+use crate::bevy_ecs_path;
+
+struct ExpandSystemCalls {
+    call_ident: Ident,
+    systems_ident: Ident,
+    system_paths: Vec<Path>,
+}
+
+struct SystemCall {
+    path: Path,
+    _comma: Option<Token![,]>,
+    input: Option<Box<Expr>>,
+}
+
+impl Parse for SystemCall {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let path = input.parse()?;
+        let comma: Option<Token![,]> = input.parse()?;
+        let input = comma.as_ref().and_then(|_| input.parse().ok());
+        Ok(Self {
+            path,
+            _comma: comma,
+            input,
+        })
+    }
+}
+
+impl VisitMut for ExpandSystemCalls {
+    fn visit_expr_mut(&mut self, i: &mut Expr) {
+        if let Expr::Macro(ExprMacro { attrs: _, mac }) = i
+            && mac.path.is_ident(&self.call_ident)
+        {
+            let call = match mac.parse_body::<SystemCall>() {
+                Ok(call) => call,
+                Err(err) => {
+                    *i = Expr::Verbatim(err.into_compile_error());
+                    return;
+                }
+            };
+
+            let call_index = match self.system_paths.iter().position(|p| p == &call.path) {
+                Some(i) => i,
+                None => {
+                    let len = self.system_paths.len();
+                    self.system_paths.push(call.path.clone());
+                    len
+                }
+            };
+
+            let systems_ident = &self.systems_ident;
+            let system_accessor = format_ident!("p{}", call_index);
+            let expr: Expr = match &call.input {
+                Some(input) => {
+                    parse_quote_spanned!(mac.span()=> #systems_ident.#system_accessor().run_with(#input))
+                }
+                None => {
+                    parse_quote_spanned!(mac.span()=> #systems_ident.#system_accessor().run())
+                }
+            };
+            *i = expr;
+        } else {
+            syn::visit_mut::visit_expr_mut(self, i);
+        }
+    }
+}
+
+pub fn compose(input: TokenStream, has_input: bool) -> TokenStream {
+    let bevy_ecs_path = bevy_ecs_path();
+    let call_ident = format_ident!("run");
+    let systems_ident = ensure_no_collision(format_ident!("__systems"), input.clone());
+    let mut expr_closure = parse_macro_input!(input as syn::ExprClosure);
+
+    let mut visitor = ExpandSystemCalls {
+        call_ident,
+        systems_ident: systems_ident.clone(),
+        system_paths: Vec::new(),
+    };
+
+    syn::visit_mut::visit_expr_closure_mut(&mut visitor, &mut expr_closure);
+
+    let runner_types: Vec<syn::Type> = visitor
+        .system_paths
+        .iter()
+        .map(|path| parse_quote_spanned!(path.span()=> #bevy_ecs_path::system::SystemRunner<_, _>))
+        .collect();
+
+    let mut builders: Vec<Expr> = vec![
+        parse_quote!(#bevy_ecs_path::system::builder::ParamBuilder);
+        if has_input {
+            expr_closure.inputs.len() - 1
+        } else {
+            expr_closure.inputs.len()
+        }
+    ];
+    let system_builders: Vec<Expr> = visitor.system_paths.iter().map(|path| parse_quote_spanned!(path.span()=> #bevy_ecs_path::system::ParamBuilder::system(#path))).collect();
+    builders.push(parse_quote!(#bevy_ecs_path::system::ParamSetBuilder((#(#system_builders,)*))));
+
+    expr_closure.inputs.push(Pat::Type(
+        parse_quote!(mut #systems_ident: #bevy_ecs_path::system::ParamSet<(#(#runner_types,)*)>),
+    ));
+
+    TokenStream::from(quote! {
+        #bevy_ecs_path::system::SystemParamBuilder::build_system(
+            (#(#builders,)*),
+            #expr_closure
+        )
+    })
+}

--- a/crates/bevy_ecs/src/system/builder.rs
+++ b/crates/bevy_ecs/src/system/builder.rs
@@ -263,9 +263,10 @@ impl ParamBuilder {
     /// Helper method for adding a [`SystemRunner`] as a param, equivalent to [`SystemRunnerBuilder::boxed`]
     pub fn dyn_system<'w, 's, In, Out, Marker, Sys>(
         system: Sys,
-    ) -> impl SystemParamBuilder<SystemRunner<'w, 's, In, Out, Sys::System>>
+    ) -> impl SystemParamBuilder<SystemRunner<'w, 's, In, Out, dyn System<In = In, Out = Out>>>
     where
-        In: SystemInput,
+        In: SystemInput + 'static,
+        Out: 'static,
         Sys: IntoSystem<In, Out, Marker>,
     {
         SystemRunnerBuilder::boxed(Box::new(IntoSystem::into_system(system)))

--- a/crates/bevy_ecs/src/system/builder.rs
+++ b/crates/bevy_ecs/src/system/builder.rs
@@ -20,6 +20,7 @@ use crate::{
         World,
     },
 };
+use alloc::borrow::Cow;
 use core::{fmt::Debug, marker::PhantomData, mem};
 
 use super::{Res, ResMut, RunSystemError, SystemState, SystemStateFlags};
@@ -248,11 +249,26 @@ impl ParamBuilder {
         Self
     }
 
-    /// Helper method for adding a [`SystemRunner`] as a param, equivalent to [`SystemRunnerBuilder::from_system`]
-    pub fn system<'w, 's, In: SystemInput + 'static, Out: 'static, Marker>(
-        system: impl IntoSystem<In, Out, Marker>,
-    ) -> impl SystemParamBuilder<SystemRunner<'w, 's, In, Out>> {
-        SystemRunnerBuilder::from_system(system)
+    /// Helper method for adding a [`SystemRunner`] as a param, equivalent to [`SystemRunnerBuilder::new`]
+    pub fn system<'w, 's, In, Out, Marker, Sys>(
+        system: Sys,
+    ) -> impl SystemParamBuilder<SystemRunner<'w, 's, In, Out, Sys::System>>
+    where
+        In: SystemInput,
+        Sys: IntoSystem<In, Out, Marker>,
+    {
+        SystemRunnerBuilder::new(IntoSystem::into_system(system))
+    }
+
+    /// Helper method for adding a [`SystemRunner`] as a param, equivalent to [`SystemRunnerBuilder::boxed`]
+    pub fn dyn_system<'w, 's, In, Out, Marker, Sys>(
+        system: Sys,
+    ) -> impl SystemParamBuilder<SystemRunner<'w, 's, In, Out, Sys::System>>
+    where
+        In: SystemInput,
+        Sys: IntoSystem<In, Out, Marker>,
+    {
+        SystemRunnerBuilder::boxed(Box::new(IntoSystem::into_system(system)))
     }
 }
 
@@ -317,6 +333,7 @@ where
     Func: SystemParamFunction<Marker>,
     Builder: SystemParamBuilder<Func::Param>,
 {
+    #[inline]
     /// Returns a new `BuilderSystem` given a system param builder and a system function
     pub fn new(builder: Builder, func: Func) -> Self {
         Self {
@@ -326,6 +343,17 @@ where
                 meta: SystemMeta::new::<Func>(),
             },
         }
+    }
+
+    #[inline]
+    /// Returns this `BuilderSystem` with a custom name.
+    pub fn with_name(mut self, name: impl Into<Cow<'static, str>>) -> Self {
+        if let BuilderSystemInner::Uninitialized { meta, .. } = &mut self.inner {
+            meta.set_name(name);
+        } else {
+            panic!("Called with_name() on an already initialized BuilderSystem");
+        }
+        self
     }
 }
 
@@ -920,23 +948,28 @@ unsafe impl<P: SystemParam, B: SystemParamBuilder<P>> SystemParamBuilder<If<P>> 
 }
 
 /// A [`SystemParamBuilder`] for a [`SystemRunner`]
-pub struct SystemRunnerBuilder<In: SystemInput + 'static = (), Out: 'static = ()>(
-    BoxedSystem<In, Out>,
-);
+pub struct SystemRunnerBuilder<Sys: System + ?Sized>(Box<Sys>);
 
-impl<In: SystemInput + 'static, Out: 'static> SystemRunnerBuilder<In, Out> {
+impl<Sys: System> SystemRunnerBuilder<Sys> {
     /// Returns a `SystemRunnerBuilder` created from a given system.
-    pub fn from_system<S: IntoSystem<In, Out, M>, M>(system: S) -> Self {
-        Self(Box::new(S::into_system(system)))
+    pub fn new(system: Sys) -> Self {
+        Self(Box::new(system))
+    }
+}
+
+impl<In: SystemInput + 'static, Out: 'static> SystemRunnerBuilder<dyn System<In = In, Out = Out>> {
+    /// Returns a `SystemRunnerBuilder` created from a boxed system.
+    pub fn boxed(system: BoxedSystem<In, Out>) -> Self {
+        Self(system)
     }
 }
 
 // SAFETY: the state returned is always valid. In particular the access always
 // matches the contained system.
-unsafe impl<'w, 's, In: SystemInput + 'static, Out: 'static>
-    SystemParamBuilder<SystemRunner<'w, 's, In, Out>> for SystemRunnerBuilder<In, Out>
+unsafe impl<'w, 's, Sys: System + ?Sized>
+    SystemParamBuilder<SystemRunner<'w, 's, Sys::In, Sys::Out, Sys>> for SystemRunnerBuilder<Sys>
 {
-    fn build(mut self, world: &mut World) -> SystemRunnerState<In, Out> {
+    fn build(mut self, world: &mut World) -> SystemRunnerState<Sys> {
         let access = self.0.initialize(world);
         SystemRunnerState {
             system: Some(self.0),

--- a/crates/bevy_ecs/src/system/builder.rs
+++ b/crates/bevy_ecs/src/system/builder.rs
@@ -9,9 +9,10 @@ use crate::{
     query::{FilteredAccessSet, QueryData, QueryFilter, QueryState},
     resource::Resource,
     system::{
-        DynSystemParam, DynSystemParamState, FromInput, FunctionSystem, If, IntoResult, IntoSystem,
-        Local, ParamSet, Query, ReadOnlySystem, System, SystemInput, SystemMeta, SystemParam,
-        SystemParamFunction, SystemParamValidationError,
+        BoxedSystem, DynSystemParam, DynSystemParamState, FromInput, FunctionSystem, If,
+        IntoResult, IntoSystem, Local, ParamSet, Query, ReadOnlySystem, System, SystemInput,
+        SystemMeta, SystemParam, SystemParamFunction, SystemParamValidationError, SystemRunner,
+        SystemRunnerState,
     },
     world::{
         unsafe_world_cell::UnsafeWorldCell, DeferredWorld, FilteredResources,
@@ -245,6 +246,13 @@ impl ParamBuilder {
     pub fn query_filtered<'w, 's, D: QueryData + 'static, F: QueryFilter + 'static>(
     ) -> impl SystemParamBuilder<Query<'w, 's, D, F>> {
         Self
+    }
+
+    /// Helper method for adding a [`SystemRunner`] as a param, equivalent to [`SystemRunnerBuilder::from_system`]
+    pub fn system<'w, 's, In: SystemInput + 'static, Out: 'static, Marker>(
+        system: impl IntoSystem<In, Out, Marker>,
+    ) -> impl SystemParamBuilder<SystemRunner<'w, 's, In, Out>> {
+        SystemRunnerBuilder::from_system(system)
     }
 }
 
@@ -908,6 +916,32 @@ pub struct IfBuilder<T>(T);
 unsafe impl<P: SystemParam, B: SystemParamBuilder<P>> SystemParamBuilder<If<P>> for IfBuilder<B> {
     fn build(self, world: &mut World) -> <If<P> as SystemParam>::State {
         self.0.build(world)
+    }
+}
+
+/// A [`SystemParamBuilder`] for a [`SystemRunner`]
+pub struct SystemRunnerBuilder<In: SystemInput + 'static = (), Out: 'static = ()>(
+    BoxedSystem<In, Out>,
+);
+
+impl<In: SystemInput + 'static, Out: 'static> SystemRunnerBuilder<In, Out> {
+    /// Returns a `SystemRunnerBuilder` created from a given system.
+    pub fn from_system<S: IntoSystem<In, Out, M>, M>(system: S) -> Self {
+        Self(Box::new(S::into_system(system)))
+    }
+}
+
+// SAFETY: the state returned is always valid. In particular the access always
+// matches the contained system.
+unsafe impl<'w, 's, In: SystemInput + 'static, Out: 'static>
+    SystemParamBuilder<SystemRunner<'w, 's, In, Out>> for SystemRunnerBuilder<In, Out>
+{
+    fn build(mut self, world: &mut World) -> SystemRunnerState<In, Out> {
+        let access = self.0.initialize(world);
+        SystemRunnerState {
+            system: Some(self.0),
+            access,
+        }
     }
 }
 

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -153,6 +153,8 @@ pub use system_name::*;
 pub use system_param::*;
 pub use system_registry::*;
 
+pub use bevy_ecs_macros::{compose, compose_with};
+
 use crate::world::{FromWorld, World};
 
 /// Conversion trait to turn something into a [`System`].

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -2986,7 +2986,7 @@ where
             let mut accesses = conflicts.format_conflict_list(world);
             // Access list may be empty (if access to all components requested)
             if !accesses.is_empty() {
-                accesses.push(' ');
+                accesses.push('');
             }
             panic!("error[B0001]: SystemRunner({}) in system {system_name} accesses component(s) {accesses}in a way that conflicts with a previous system parameter. Consider using `Without<T>` to create disjoint system accesses or using a `ParamSet`. See: https://bevy.org/learn/errors/b0001", state.system.as_ref().map(|sys| sys.name()).unwrap_or(DebugName::borrowed("")));
         }

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -16,7 +16,7 @@ use crate::{
     },
     resource::{Resource, IS_RESOURCE},
     storage::NonSendData,
-    system::{Query, Single, SystemMeta},
+    system::{BoxedSystem, Query, RunSystemError, Single, System, SystemInput, SystemMeta},
     world::{
         unsafe_world_cell::UnsafeWorldCell, DeferredWorld, FilteredResources, FilteredResourcesMut,
         FromWorld, World,
@@ -2868,6 +2868,116 @@ unsafe impl SystemParam for FilteredResourcesMut<'_, '_> {
         // SAFETY: The caller ensures that `world` has access to anything registered in `init_access`,
         // and we registered all resource access in `state``.
         unsafe { FilteredResourcesMut::new(world, state, system_meta.last_run, change_tick) }
+    }
+}
+
+pub struct SystemRunner<'w, 's, In: SystemInput = (), Out = ()> {
+    world: UnsafeWorldCell<'w>,
+    system: &'s mut dyn System<In = In, Out = Out>,
+}
+
+impl<'w, 's, In: SystemInput + 'static, Out: 'static> SystemRunner<'w, 's, In, Out> {
+    #[inline]
+    pub fn run_with(&mut self, input: In::Inner<'_>) -> Result<Out, RunSystemError> {
+        // SAFETY:
+        // - all accesses are properly declared in `init_access`
+        unsafe { self.system.run_unsafe(input, self.world) }
+    }
+}
+
+impl<'w, 's, Out: 'static> SystemRunner<'w, 's, (), Out> {
+    #[inline]
+    pub fn run(&mut self) -> Result<Out, RunSystemError> {
+        self.run_with(())
+    }
+}
+
+/// The [`SystemParam::State`] for a [`SystemRunner`].
+pub struct SystemRunnerState<In: SystemInput = (), Out = ()> {
+    pub(crate) system: Option<BoxedSystem<In, Out>>,
+    pub(crate) access: FilteredAccessSet,
+}
+
+// SAFETY: SystemRunner registers all accesses and panics if a conflict is detected.
+unsafe impl<'w, 's, In: SystemInput + 'static, Out: 'static> SystemParam
+    for SystemRunner<'w, 's, In, Out>
+{
+    type State = SystemRunnerState<In, Out>;
+
+    type Item<'world, 'state> = SystemRunner<'world, 'state, In, Out>;
+
+    #[inline]
+    fn init_state(_world: &mut World) -> Self::State {
+        SystemRunnerState {
+            system: None,
+            access: FilteredAccessSet::default(),
+        }
+    }
+
+    fn init_access(
+        state: &Self::State,
+        system_meta: &mut SystemMeta,
+        component_access_set: &mut FilteredAccessSet,
+        world: &mut World,
+    ) {
+        //TODO: does this handle exclusive systems properly?
+        let conflicts = component_access_set.get_conflicts(&state.access);
+        if !conflicts.is_empty() {
+            let system_name = system_meta.name();
+            let mut accesses = conflicts.format_conflict_list(world);
+            // Access list may be empty (if access to all components requested)
+            if !accesses.is_empty() {
+                accesses.push(' ');
+            }
+            panic!("error[B0001]: SystemRunner({}) in system {system_name} accesses component(s) {accesses}in a way that conflicts with a previous system parameter. Consider using `Without<T>` to create disjoint system accesses or using a `ParamSet`. See: https://bevy.org/learn/errors/b0001", state.system.as_ref().map(|sys| sys.name()).unwrap_or(DebugName::borrowed("")));
+        }
+
+        component_access_set.extend(state.access.clone());
+    }
+
+    #[inline]
+    unsafe fn get_param<'world, 'state>(
+        state: &'state mut Self::State,
+        _system_meta: &SystemMeta,
+        world: UnsafeWorldCell<'world>,
+        _change_tick: Tick,
+    ) -> Self::Item<'world, 'state> {
+        SystemRunner {
+            world,
+            system: state.system.as_deref_mut().expect("SystemRunner accessed with invalid state. This should have been caught by `validate_param`"),
+        }
+    }
+
+    #[inline]
+    fn apply(state: &mut Self::State, _system_meta: &SystemMeta, world: &mut World) {
+        if let Some(sys) = &mut state.system {
+            sys.apply_deferred(world);
+        }
+    }
+
+    #[inline]
+    fn queue(state: &mut Self::State, _system_meta: &SystemMeta, world: DeferredWorld) {
+        if let Some(sys) = &mut state.system {
+            sys.queue_deferred(world);
+        }
+    }
+
+    unsafe fn validate_param(
+        state: &mut Self::State,
+        _system_meta: &SystemMeta,
+        world: UnsafeWorldCell,
+    ) -> Result<(), SystemParamValidationError> {
+        state.system.as_mut().ok_or(SystemParamValidationError {
+            skipped: false,
+            message: "SystemRunner must be manually initialized, for example with the system builder API.".into(),
+            param: DebugName::type_name::<Self>(),
+            field: "".into(),
+        }).and_then(|sys| {
+            // SAFETY: caller asserts that `world` has all accesses declared in `init_access`,
+            // which match the underlying system when `state.system` is `Ok`, and otherwise
+            // this branch will not be entered.
+            unsafe { sys.validate_param_unsafe(world) }
+        })
     }
 }
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -2986,7 +2986,7 @@ where
             let mut accesses = conflicts.format_conflict_list(world);
             // Access list may be empty (if access to all components requested)
             if !accesses.is_empty() {
-                accesses.push('');
+                accesses.push(' ');
             }
             panic!("error[B0001]: SystemRunner({}) in system {system_name} accesses component(s) {accesses}in a way that conflicts with a previous system parameter. Consider using `Without<T>` to create disjoint system accesses or using a `ParamSet`. See: https://bevy.org/learn/errors/b0001", state.system.as_ref().map(|sys| sys.name()).unwrap_or(DebugName::borrowed("")));
         }

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -2900,8 +2900,8 @@ unsafe impl SystemParam for FilteredResourcesMut<'_, '_> {
 /// }
 ///
 /// let get_sum = (
-///     ParamBuilder::system(count_a),
-///     ParamBuilder::system(count_b)
+///     ParamBuilder::dyn_system(count_a),
+///     ParamBuilder::dyn_system(count_b)
 /// )
 /// .build_state(&mut world)
 /// .build_system(

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -16,7 +16,7 @@ use crate::{
     },
     resource::{Resource, IS_RESOURCE},
     storage::NonSendData,
-    system::{BoxedSystem, Query, RunSystemError, Single, System, SystemInput, SystemMeta},
+    system::{Query, ReadOnlySystem, RunSystemError, Single, System, SystemInput, SystemMeta},
     world::{
         unsafe_world_cell::UnsafeWorldCell, DeferredWorld, FilteredResources, FilteredResourcesMut,
         FromWorld, World,
@@ -2871,21 +2871,78 @@ unsafe impl SystemParam for FilteredResourcesMut<'_, '_> {
     }
 }
 
-pub struct SystemRunner<'w, 's, In: SystemInput = (), Out = ()> {
+/// A [`SystemParam`] that allows running other systems.
+///
+/// To be useful, this must be configured using a [`SystemRunnerBuilder`](crate::system::SystemRunnerBuilder)
+/// to build the system using a [`SystemParamBuilder`](crate::prelude::SystemParamBuilder).
+///
+/// Also see the macros [`compose`](crate::system::compose) and [`compose_with`](crate::system::compose_with)
+/// for some nice syntax on top of this API.
+///
+/// # Examples
+///
+/// ```
+/// # use bevy_ecs::{prelude::*, system::*};
+/// #
+/// # #[derive(Component)]
+/// # struct A;
+/// #
+/// # #[derive(Component)]
+/// # struct B;
+/// # let mut world = World::new();
+/// #
+/// fn count_a(a: Query<&A>) -> usize {
+///     a.count()
+/// }
+///
+/// fn count_b(b: Query<&B>) -> usize {
+///     b.count()
+/// }
+///
+/// let get_sum = (
+///     ParamBuilder::system(count_a),
+///     ParamBuilder::system(count_b)
+/// )
+/// .build_state(&mut world)
+/// .build_system(
+///     |mut run_a: SystemRunner<(), usize>, mut run_b: SystemRunner<(), usize>| -> Result<usize, RunSystemError> {
+///         let a = run_a.run()?;
+///         let b = run_b.run()?;
+///         Ok(a + b)
+///     }
+/// );
+/// ```
+pub struct SystemRunner<'w, 's, In = (), Out = (), Sys = dyn System<In = In, Out = Out>>
+where
+    In: SystemInput,
+    Sys: System<In = In, Out = Out> + ?Sized,
+{
     world: UnsafeWorldCell<'w>,
-    system: &'s mut dyn System<In = In, Out = Out>,
+    system: &'s mut Sys,
 }
 
-impl<'w, 's, In: SystemInput + 'static, Out: 'static> SystemRunner<'w, 's, In, Out> {
+impl<'w, 's, In, Out, Sys> SystemRunner<'w, 's, In, Out, Sys>
+where
+    In: SystemInput,
+    Sys: System<In = In, Out = Out> + ?Sized,
+{
+    /// Run the system with input.
     #[inline]
     pub fn run_with(&mut self, input: In::Inner<'_>) -> Result<Out, RunSystemError> {
+        // SAFETY:
+        // - all accesses are properly declared in `init_access`
+        unsafe { self.system.validate_param_unsafe(self.world)? };
         // SAFETY:
         // - all accesses are properly declared in `init_access`
         unsafe { self.system.run_unsafe(input, self.world) }
     }
 }
 
-impl<'w, 's, Out: 'static> SystemRunner<'w, 's, (), Out> {
+impl<'w, 's, Out, Sys> SystemRunner<'w, 's, (), Out, Sys>
+where
+    Sys: System<In = (), Out = Out> + ?Sized,
+{
+    /// Run the system.
     #[inline]
     pub fn run(&mut self) -> Result<Out, RunSystemError> {
         self.run_with(())
@@ -2893,18 +2950,20 @@ impl<'w, 's, Out: 'static> SystemRunner<'w, 's, (), Out> {
 }
 
 /// The [`SystemParam::State`] for a [`SystemRunner`].
-pub struct SystemRunnerState<In: SystemInput = (), Out = ()> {
-    pub(crate) system: Option<BoxedSystem<In, Out>>,
+pub struct SystemRunnerState<Sys: System + ?Sized> {
+    pub(crate) system: Option<Box<Sys>>,
     pub(crate) access: FilteredAccessSet,
 }
 
 // SAFETY: SystemRunner registers all accesses and panics if a conflict is detected.
-unsafe impl<'w, 's, In: SystemInput + 'static, Out: 'static> SystemParam
-    for SystemRunner<'w, 's, In, Out>
+unsafe impl<'w, 's, In, Out, Sys> SystemParam for SystemRunner<'w, 's, In, Out, Sys>
+where
+    In: SystemInput,
+    Sys: System<In = In, Out = Out> + ?Sized,
 {
-    type State = SystemRunnerState<In, Out>;
+    type State = SystemRunnerState<Sys>;
 
-    type Item<'world, 'state> = SystemRunner<'world, 'state, In, Out>;
+    type Item<'world, 'state> = SystemRunner<'world, 'state, In, Out, Sys>;
 
     #[inline]
     fn init_state(_world: &mut World) -> Self::State {
@@ -2914,13 +2973,13 @@ unsafe impl<'w, 's, In: SystemInput + 'static, Out: 'static> SystemParam
         }
     }
 
+    #[inline]
     fn init_access(
         state: &Self::State,
         system_meta: &mut SystemMeta,
         component_access_set: &mut FilteredAccessSet,
         world: &mut World,
     ) {
-        //TODO: does this handle exclusive systems properly?
         let conflicts = component_access_set.get_conflicts(&state.access);
         if !conflicts.is_empty() {
             let system_name = system_meta.name();
@@ -2962,23 +3021,25 @@ unsafe impl<'w, 's, In: SystemInput + 'static, Out: 'static> SystemParam
         }
     }
 
+    #[inline]
     unsafe fn validate_param(
         state: &mut Self::State,
         _system_meta: &SystemMeta,
-        world: UnsafeWorldCell,
+        _world: UnsafeWorldCell,
     ) -> Result<(), SystemParamValidationError> {
-        state.system.as_mut().ok_or(SystemParamValidationError {
-            skipped: false,
-            message: "SystemRunner must be manually initialized, for example with the system builder API.".into(),
-            param: DebugName::type_name::<Self>(),
-            field: "".into(),
-        }).and_then(|sys| {
-            // SAFETY: caller asserts that `world` has all accesses declared in `init_access`,
-            // which match the underlying system when `state.system` is `Ok`, and otherwise
-            // this branch will not be entered.
-            unsafe { sys.validate_param_unsafe(world) }
-        })
+        let err = SystemParamValidationError::invalid::<Self>(
+            "SystemRunner must be manually initialized, for example with the system builder API.",
+        );
+        state.system.as_ref().map(|_| ()).ok_or(err)
     }
+}
+
+// SAFETY: if the internal system is readonly, this param can't mutate the world.
+unsafe impl<'w, 's, In, Out, Sys> ReadOnlySystemParam for SystemRunner<'w, 's, In, Out, Sys>
+where
+    In: SystemInput,
+    Sys: System<In = In, Out = Out> + ReadOnlySystem + ?Sized,
+{
 }
 
 /// An error that occurs when a system parameter is not valid,

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -2899,7 +2899,7 @@ unsafe impl SystemParam for FilteredResourcesMut<'_, '_> {
 ///     b.count()
 /// }
 ///
-/// let get_sum = (
+/// let get_sum: FunctionSystem<_, (), usize, _> = ( // type annotations should be unnecessary in most cases
 ///     ParamBuilder::dyn_system(count_a),
 ///     ParamBuilder::dyn_system(count_b)
 /// )

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -38,7 +38,7 @@ use thiserror::Error;
 use super::Populated;
 use variadics_please::{all_tuples, all_tuples_enumerated};
 
-/// A parameter that can be used in a [`System`](super::System).
+/// A parameter that can be used in a [`System`].
 ///
 /// # Derive
 ///
@@ -280,7 +280,7 @@ pub unsafe trait SystemParam: Sized {
     /// world mutations inbetween. Otherwise, while it won't lead to any undefined behavior,
     /// the validity of the param may change.
     ///
-    /// [`System::validate_param`](super::system::System::validate_param),
+    /// [`System::validate_param`],
     /// calls this method for each supplied system param.
     ///
     /// # Safety

--- a/examples/ecs/system_piping.rs
+++ b/examples/ecs/system_piping.rs
@@ -29,7 +29,7 @@ fn main() {
                 // for more info.
                 compose! {
                     || -> Result<(), RunSystemError> {
-                        let out = run!(warning_pipe_system)?;
+                        let out = system!(warning_pipe_system).run()?;
                         if let Err(err) = out {
                             error!("{err}");
                         }
@@ -38,7 +38,7 @@ fn main() {
                 },
                 compose! {
                     || -> Result<(), RunSystemError>  {
-                        let out = run!(parse_error_message_system)?;
+                        let out = system!(parse_error_message_system).run()?;
                         if let Err(err) = out {
                             error!("{err}");
                         }

--- a/release-content/migration-guides/system_input_unwrap.md
+++ b/release-content/migration-guides/system_input_unwrap.md
@@ -1,0 +1,9 @@
+---
+title: "New required method on SystemInput"
+pull_requests: [21811]
+---
+
+Custom implementations of the `SystemInput` trait will need to implement a new
+required method: `unwrap`. Like `wrap`, it converts between the inner input item
+and the wrapper, but in the opposite direction. In most cases it should be
+trivial to add.

--- a/release-content/migration-guides/system_input_unwrap.md
+++ b/release-content/migration-guides/system_input_unwrap.md
@@ -1,9 +1,0 @@
----
-title: "New required method on SystemInput"
-pull_requests: [21811]
----
-
-Custom implementations of the `SystemInput` trait will need to implement a new
-required method: `unwrap`. Like `wrap`, it converts between the inner input item
-and the wrapper, but in the opposite direction. In most cases it should be
-trivial to add.

--- a/release-content/release-notes/system_composition.md
+++ b/release-content/release-notes/system_composition.md
@@ -41,8 +41,8 @@ the new `SystemRunner` params seamless to use.
 ```rust
 compose! {
     || -> Result<usize, RunSystemError> {
-        let a = run!(count_a)?;
-        let b = run!(count_b)?;
+        let a = system!(count_a).run()?;
+        let b = system!(count_b).run()?;
         Ok(a + b)
     }
 }

--- a/release-content/release-notes/system_composition.md
+++ b/release-content/release-notes/system_composition.md
@@ -1,0 +1,49 @@
+---
+title: System Composition
+authors: ["@ecoskey"]
+pull_requests: [21811]
+---
+
+## `SystemRunner` SystemParam
+
+We've been working on some new tools to make composing multiple ECS systems together
+even easier. Bevy 0.18 introduces the `SystemRunner` `SystemParam`, allowing running
+systems inside other systems!
+
+```rust
+fn count_a(a: Query<&A>) -> usize {
+    a.count()
+}
+
+fn count_b(b: Query<&B>) -> usize {
+    b.count()
+}
+
+let get_sum = (
+    ParamBuilder::system(count_a),
+    ParamBuilder::system(count_b)
+)
+.build_system(
+    |mut run_a: SystemRunner<(), usize>, mut run_b: SystemRunner<(), usize>| -> Result<usize, RunSystemError> {
+        let a = run_a.run()?;
+        let b = run_b.run()?;
+        Ok(a + b)
+    }
+);
+```
+
+## `compose!` and `compose_with!`
+
+With this new API we've also added some nice macro syntax to go on top. The `compose!`
+and `compose_with!` macros will automatically transform a provided closure, making
+the new `SystemRunner` params seamless to use.
+
+```rust
+compose! {
+    || -> Result<usize, RunSystemError> {
+        let a = run!(count_a)?;
+        let b = run!(count_b)?;
+        Ok(a + b)
+    }
+}
+```

--- a/release-content/release-notes/system_composition.md
+++ b/release-content/release-notes/system_composition.md
@@ -7,7 +7,7 @@ pull_requests: [21811]
 ## `SystemRunner` SystemParam
 
 We've been working on some new tools to make composing multiple ECS systems together
-even easier. Bevy 0.18 introduces the `SystemRunner` `SystemParam`, allowing running
+even easier. Bevy 0.19 introduces the `SystemRunner` `SystemParam`, enabling the ability to run
 systems inside other systems!
 
 ```rust


### PR DESCRIPTION
# Objective

resolves #16680

Add a new system param for running systems inside other systems. Also, I've included some macros for nice syntax on top.

I'm pretty proud of how nice I was able to make this, but there's still a bit of work to do, especially around generic code :)

## Testing

- Ran examples
- Tried to migrate existing `pipe` and `map` impls, but failed. This PR is pretty robust for most use cases but isn't fully ready for generic code yet. In particular, it's difficult to make sure the input types match (often have to wrap with `StaticSystemInput`) and  `ReadOnlySystem` bound is inferred correctly when using for run conditions. These only really matter for combinators like `pipe` and `map` though, since otherwise they're run exactly the same.

---

## Showcase

<details>
  <summary>Click to view showcase</summary>

```rust
fn count_a(a: Query<&A>) -> u32 {
    a.count()
}

fn count_b(b: Query<&B>) -> u32 {
    b.count()
}

let get_sum = (
    ParamBuilder::system(count_a),
    ParamBuilder::system(count_b)
)
.build_system(
    |mut run_a: SystemRunner<(), u32>, mut run_b: SystemRunner<(), u32>| -> Result<u32, RunSystemError> {
        let a = run_a.run()?;
        let b = run_b.run()?;
        Ok(a + b)
    }
);

let get_sum = compose! {
    || -> Result<u32, RunSystemError> {
        let a = run!(count_a)?;
        let b = run!(count_b)?;
        Ok(a + b)
    }
}
```
</details>
