### PR TITLE
Allow deprecated `heapless::mpmc` to fix no_std builds

### DIFF
--- a/crates/bevy_tasks/src/edge_executor.rs
+++ b/crates/bevy_tasks/src/edge_executor.rs
@@ -471,6 +471,7 @@ impl<const C: usize> State<C> {
                 target_has_atomic = "64",
                 target_has_atomic = "ptr"
             )))]
+            #[allow(deprecated)]
             queue: heapless::mpmc::Queue::new(),
             waker: AtomicWaker::new(),
         }
@@ -481,7 +482,10 @@ impl<const C: usize> State<C> {
 mod different_executor_tests {
     use core::cell::Cell;
 
-    use bevy_tasks::{block_on, futures_lite::{pending, poll_once}};
+    use bevy_tasks::{
+        block_on,
+        futures_lite::{pending, poll_once},
+    };
     use futures_lite::pin;
 
     use super::LocalExecutor;


### PR DESCRIPTION
# Objective

`heapless` just deprecated their `mpmc` module in a minor version, which broke our `no_std` builds (because we choose to break our break our builds on warnings).

https://github.com/rust-embedded/heapless/issues/583
https://docs.rs/heapless/latest/heapless/mpmc/index.html

## Solution

Short term, fix our builds by allowing this usage of a deprecated function. However it is worth investigating: https://github.com/bevyengine/bevy/issues/21819