### PR TITLE
Feathers: set checkbox marker `Visibility::Inherited` when checked.

### DIFF
--- a/crates/bevy_feathers/src/controls/checkbox.rs
+++ b/crates/bevy_feathers/src/controls/checkbox.rs
@@ -289,7 +289,7 @@ fn set_checkbox_styles(
 
     // Change mark visibility
     commands.entity(mark_ent).insert(match checked {
-        true => Visibility::Visible,
+        true => Visibility::Inherited,
         false => Visibility::Hidden,
     });
 


### PR DESCRIPTION
# Objective

Seems the checkbox part is missing in PR #21789.

Make the checkbox marker invisible when the whole widget is `Visibility::Hidden`.

## Solution

Change the maker's visibility to `Inherited` rather than `Visible`.

## Testing

Manually added `Visibility::Hidden` to the root node of `examples/ui/feathers.rs`, and verified nothing is visible.
