### PR TITLE
Rename `Aabb2d`/`Aabb3d` to `BoundingRectangle`/`BoundingBox`

### DIFF
--- a/benches/benches/bevy_math/bounding.rs
+++ b/benches/benches/bevy_math/bounding.rs
@@ -1,6 +1,6 @@
 use benches::bench;
 use bevy_math::{
-    bounding::{Aabb3d, BoundingSphere, BoundingVolume},
+    bounding::{BoundingBox, BoundingSphere, BoundingVolume},
     prelude::*,
 };
 use core::hint::black_box;
@@ -19,8 +19,8 @@ struct PointCloud {
 }
 
 impl PointCloud {
-    fn aabb(&self) -> Aabb3d {
-        Aabb3d::from_point_cloud(self.isometry, self.points.iter().copied())
+    fn aabb(&self) -> BoundingBox {
+        BoundingBox::from_point_cloud(self.isometry, self.points.iter().copied())
     }
 
     fn sphere(&self) -> BoundingSphere {

--- a/crates/bevy_camera/src/primitives.rs
+++ b/crates/bevy_camera/src/primitives.rs
@@ -2,7 +2,7 @@ use core::borrow::Borrow;
 
 use bevy_ecs::{component::Component, entity::EntityHashMap, reflect::ReflectComponent};
 use bevy_math::{
-    bounding::{Aabb3d, BoundingVolume},
+    bounding::{BoundingBox, BoundingVolume},
     Affine3A, Mat3A, Mat4, Vec3, Vec3A, Vec4, Vec4Swizzles,
 };
 use bevy_mesh::{Mesh, VertexAttributeValues};
@@ -135,8 +135,8 @@ impl Aabb {
     }
 }
 
-impl From<Aabb3d> for Aabb {
-    fn from(aabb: Aabb3d) -> Self {
+impl From<BoundingBox> for Aabb {
+    fn from(aabb: BoundingBox) -> Self {
         Self {
             center: aabb.center(),
             half_extents: aabb.half_size(),
@@ -144,7 +144,7 @@ impl From<Aabb3d> for Aabb {
     }
 }
 
-impl From<Aabb> for Aabb3d {
+impl From<Aabb> for BoundingBox {
     fn from(aabb: Aabb) -> Self {
         Self {
             min: aabb.min(),

--- a/crates/bevy_gizmos/src/gizmos.rs
+++ b/crates/bevy_gizmos/src/gizmos.rs
@@ -18,7 +18,7 @@ use bevy_ecs::{
     },
     world::{unsafe_world_cell::UnsafeWorldCell, World},
 };
-use bevy_math::{bounding::Aabb3d, Isometry2d, Isometry3d, Vec2, Vec3};
+use bevy_math::{bounding::BoundingBox, Isometry2d, Isometry3d, Vec2, Vec3};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_transform::TransformPoint;
 use bevy_utils::default;
@@ -612,17 +612,17 @@ where
     /// ```
     /// # use bevy_gizmos::prelude::*;
     /// # use bevy_transform::prelude::*;
-    /// # use bevy_math::{bounding::Aabb3d, Vec3};
+    /// # use bevy_math::{bounding::BoundingBox, Vec3};
     /// # use bevy_color::palettes::basic::GREEN;
     /// fn system(mut gizmos: Gizmos) {
-    ///     gizmos.aabb_3d(Aabb3d::new(Vec3::ZERO, Vec3::ONE), Transform::IDENTITY, GREEN);
+    ///     gizmos.aabb_3d(BoundingBox::new(Vec3::ZERO, Vec3::ONE), Transform::IDENTITY, GREEN);
     /// }
     /// # bevy_ecs::system::assert_is_system(system);
     /// ```
     #[inline]
     pub fn aabb_3d(
         &mut self,
-        aabb: impl Into<Aabb3d>,
+        aabb: impl Into<BoundingBox>,
         transform: impl TransformPoint,
         color: impl Into<Color>,
     ) {

--- a/crates/bevy_picking/src/mesh_picking/ray_cast/intersections.rs
+++ b/crates/bevy_picking/src/mesh_picking/ray_cast/intersections.rs
@@ -1,4 +1,4 @@
-use bevy_math::{bounding::Aabb3d, Affine3A, Dir3, Ray3d, Vec2, Vec3, Vec3A};
+use bevy_math::{bounding::BoundingBox, Affine3A, Dir3, Ray3d, Vec2, Vec3, Vec3A};
 use bevy_mesh::{Indices, Mesh, PrimitiveTopology, VertexAttributeValues};
 use bevy_reflect::Reflect;
 
@@ -287,7 +287,7 @@ fn ray_triangle_intersection(
 /// The distance is zero if the ray starts inside the AABB.
 pub fn ray_aabb_intersection_3d(
     ray: Ray3d,
-    aabb: &Aabb3d,
+    aabb: &BoundingBox,
     model_to_world: &Affine3A,
 ) -> Option<f32> {
     // Transform the ray to model space

--- a/crates/bevy_picking/src/mesh_picking/ray_cast/mod.rs
+++ b/crates/bevy_picking/src/mesh_picking/ray_cast/mod.rs
@@ -10,7 +10,7 @@ use bevy_camera::{
     primitives::Aabb,
     visibility::{InheritedVisibility, ViewVisibility},
 };
-use bevy_math::{bounding::Aabb3d, Ray3d};
+use bevy_math::{bounding::BoundingBox, Ray3d};
 use bevy_mesh::{Mesh, Mesh2d, Mesh3d};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 
@@ -235,7 +235,7 @@ impl<'w, 's> MeshRayCast<'w, 's> {
                 if should_ray_cast
                     && let Some(distance) = ray_aabb_intersection_3d(
                         ray,
-                        &Aabb3d::new(aabb.center, aabb.half_extents),
+                        &BoundingBox::new(aabb.center, aabb.half_extents),
                         &transform.affine(),
                     )
                 {

--- a/examples/games/breakout.rs
+++ b/examples/games/breakout.rs
@@ -3,7 +3,7 @@
 //! Demonstrates Bevy's stepping capabilities if compiled with the `bevy_debug_stepping` feature.
 
 use bevy::{
-    math::bounding::{Aabb2d, BoundingCircle, BoundingVolume, IntersectsVolume},
+    math::bounding::{BoundingCircle, BoundingRectangle, BoundingVolume, IntersectsVolume},
     prelude::*,
 };
 
@@ -403,7 +403,7 @@ enum Collision {
 
 // Returns `Some` if `ball` collides with `bounding_box`.
 // The returned `Collision` is the side of `bounding_box` that `ball` hit.
-fn ball_collision(ball: BoundingCircle, bounding_box: Aabb2d) -> Option<Collision> {
+fn ball_collision(ball: BoundingCircle, bounding_box: BoundingRectangle) -> Option<Collision> {
     if !ball.intersects(&bounding_box) {
         return None;
     }

--- a/examples/games/contributors.rs
+++ b/examples/games/contributors.rs
@@ -1,6 +1,6 @@
 //! This example displays each contributor to the bevy source code as a bouncing bevy-ball.
 
-use bevy::{math::bounding::Aabb2d, prelude::*};
+use bevy::{math::bounding::BoundingRectangle, prelude::*};
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use std::{
@@ -262,7 +262,7 @@ fn collisions(
 
     let window_size = window.size();
 
-    let collision_area = Aabb2d::new(Vec2::ZERO, (window_size - SPRITE_SIZE) / 2.);
+    let collision_area = BoundingRectangle::new(Vec2::ZERO, (window_size - SPRITE_SIZE) / 2.);
 
     // The maximum height the birbs should try to reach is one birb below the top of the window.
     let max_bounce_height = (window_size.y - SPRITE_SIZE * 2.0).max(0.0);

--- a/examples/math/bounding_2d.rs
+++ b/examples/math/bounding_2d.rs
@@ -6,6 +6,8 @@ use bevy::{
     prelude::*,
 };
 
+use bevy::math::bounding::BoundingRectangle;
+
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
@@ -135,7 +137,7 @@ enum DesiredVolume {
 
 #[derive(Component, Debug)]
 enum CurrentVolume {
-    Aabb(Aabb2d),
+    Aabb(BoundingRectangle),
     Circle(BoundingCircle),
 }
 
@@ -153,12 +155,12 @@ fn update_volumes(
         match desired_volume {
             DesiredVolume::Aabb => {
                 let aabb = match shape {
-                    Shape::Rectangle(r) => r.aabb_2d(isometry),
-                    Shape::Circle(c) => c.aabb_2d(isometry),
-                    Shape::Triangle(t) => t.aabb_2d(isometry),
-                    Shape::Line(l) => l.aabb_2d(isometry),
-                    Shape::Capsule(c) => c.aabb_2d(isometry),
-                    Shape::Polygon(p) => p.aabb_2d(isometry),
+                    Shape::Rectangle(r) => r.bounding_rectangle(isometry),
+                    Shape::Circle(c) => c.bounding_rectangle(isometry),
+                    Shape::Triangle(t) => t.bounding_rectangle(isometry),
+                    Shape::Line(l) => l.bounding_rectangle(isometry),
+                    Shape::Capsule(c) => c.bounding_rectangle(isometry),
+                    Shape::Polygon(p) => p.bounding_rectangle(isometry),
                 };
                 commands.entity(entity).insert(CurrentVolume::Aabb(aabb));
             }
@@ -326,7 +328,7 @@ fn aabb_cast_system(
 ) {
     let ray_cast = get_and_draw_ray(&mut gizmos, &time);
     let aabb_cast = AabbCast2d {
-        aabb: Aabb2d::new(Vec2::ZERO, Vec2::splat(15.)),
+        aabb: BoundingRectangle::new(Vec2::ZERO, Vec2::splat(15.)),
         ray: ray_cast,
     };
 
@@ -387,7 +389,7 @@ fn aabb_intersection_system(
     mut volumes: Query<(&CurrentVolume, &mut Intersects)>,
 ) {
     let center = get_intersection_position(&time);
-    let aabb = Aabb2d::new(center, Vec2::splat(50.));
+    let aabb = BoundingRectangle::new(center, Vec2::splat(50.));
     gizmos.rect_2d(center, aabb.half_size() * 2., YELLOW);
 
     for (volume, mut intersects) in volumes.iter_mut() {

--- a/examples/math/custom_primitives.rs
+++ b/examples/math/custom_primitives.rs
@@ -13,7 +13,8 @@ use bevy::{
     input::common_conditions::{input_just_pressed, input_toggle_active},
     math::{
         bounding::{
-            Aabb2d, Bounded2d, Bounded3d, BoundedExtrusion, BoundingCircle, BoundingVolume,
+            Bounded2d, Bounded3d, BoundedExtrusion, BoundingCircle, BoundingRectangle,
+            BoundingVolume,
         },
         Isometry2d,
     },
@@ -294,7 +295,7 @@ fn bounding_shapes_2d(
             BoundingShape::None => (),
             BoundingShape::BoundingBox => {
                 // Get the AABB of the primitive with the rotation and translation of the mesh.
-                let aabb = HEART.aabb_2d(isometry);
+                let aabb = HEART.bounding_rectangle(isometry);
                 gizmos.rect_2d(aabb.center(), aabb.half_size() * 2., WHITE);
             }
             BoundingShape::BoundingSphere => {
@@ -328,7 +329,7 @@ fn bounding_shapes_3d(
             BoundingShape::None => (),
             BoundingShape::BoundingBox => {
                 // Get the AABB of the extrusion with the rotation and translation of the mesh.
-                let aabb = EXTRUSION.aabb_3d(transform.to_isometry());
+                let aabb = EXTRUSION.bounding_box(transform.to_isometry());
 
                 gizmos.primitive_3d(
                     &Cuboid::from_size(Vec3::from(aabb.half_size()) * 2.),
@@ -430,7 +431,7 @@ impl Measured2d for Heart {
 
 // The `Bounded2d` or `Bounded3d` traits are used to compute the Axis Aligned Bounding Boxes or bounding circles / spheres for primitives.
 impl Bounded2d for Heart {
-    fn aabb_2d(&self, isometry: impl Into<Isometry2d>) -> Aabb2d {
+    fn bounding_rectangle(&self, isometry: impl Into<Isometry2d>) -> BoundingRectangle {
         let isometry = isometry.into();
 
         // The center of the circle at the center of the right wing of the heart
@@ -443,7 +444,7 @@ impl Bounded2d for Heart {
         // The position of the tip at the bottom of the heart
         let tip_position = isometry.rotation * Vec2::new(0.0, -self.radius * (1. + SQRT_2));
 
-        Aabb2d {
+        BoundingRectangle {
             min: isometry.translation + min_circle.min(tip_position),
             max: isometry.translation + max_circle.max(tip_position),
         }


### PR DESCRIPTION
# Objective

Fixes the naming inconsistency between bounding volume types in Bevy's math API.

Currently we have:
- 2D: `BoundingCircle` (descriptive geometric name) vs `Aabb2d` (technical acronym)
- 3D: `BoundingSphere` (descriptive geometric name) vs `Aabb3d` (technical acronym)

This inconsistency was noted in the original discussion in #10570, where it was acknowledged that "bounding rectangle" would be more intuitive than "aabb2d", but consistency between 2D and 3D was prioritized at the time using the AABB naming convention.

**Note**: I recognize this is a matter of API design preference and may not align with everyone's vision. This PR is opened to facilitate discussion about the naming inconsistency and whether it's worth addressing. I'm happy to close this if maintainers feel the current naming is preferable, or adjust the approach based on feedback.

## Solution

Rename the types to establish a consistent `Bounding*` naming pattern with clear geometric shape names:

- `Aabb2d` → `BoundingRectangle` 
- `Aabb3d` → `BoundingBox`
- `Bounded2d::aabb_2d()` → `Bounded2d::bounding_rectangle()`
- `Bounded3d::aabb_3d()` → `Bounded3d::bounding_box()`

This creates a fully coherent API:
- **2D**: `BoundingCircle` and `BoundingRectangle`
- **3D**: `BoundingSphere` and `BoundingBox`

Benefits:
- **Consistency**: All bounding volumes now follow the same `Bounding*` + geometric shape pattern
- **Clarity**: Shape names (Circle, Rectangle, Sphere, Box) are immediately understandable
- **Accessibility**: "AABB" is technical jargon that not all developers know
- **Rust conventions**: Follows Rust's preference for descriptive names over acronyms

All old names are deprecated with backwards-compatible aliases and default trait implementations.

## Testing

- Ran `cargo test --package bevy_math --lib bounding` - all 103 tests pass
- Ran `cargo check --workspace` - no errors
- Verified examples compile and deprecated code paths work correctly

## Migration Guide

The old type and method names are deprecated but still functional. Update to the new names at your convenience:

**Types:**
```rust
// Before
use bevy_math::bounding::{Aabb2d, Aabb3d};

// After  
use bevy_math::bounding::{BoundingRectangle, BoundingBox};
```

**Trait methods:**
```rust
// Before
let bounding = shape.aabb_2d(isometry);
let bounding = shape.aabb_3d(isometry);

// After
let bounding = shape.bounding_rectangle(isometry);
let bounding = shape.bounding_box(isometry);
```

**Construction:**
```rust
// Before
let aabb = Aabb2d::new(center, half_size);
let aabb = Aabb3d::new(center, half_size);

// After
let rect = BoundingRectangle::new(center, half_size);
let bbox = BoundingBox::new(center, half_size);
```

**Cross-conversion methods:**
```rust
// Before
let aabb = bounding_circle.aabb_2d();
let aabb = bounding_sphere.aabb_3d();

// After
let rect = bounding_circle.bounding_rectangle();
let bbox = bounding_sphere.bounding_box();
```
