### PR TITLE
Add `Observer::with_components`

### DIFF
--- a/crates/bevy_ecs/src/observer/distributed_storage.rs
+++ b/crates/bevy_ecs/src/observer/distributed_storage.rs
@@ -301,6 +301,13 @@ impl Observer {
         self
     }
 
+    /// Observes the given `components`. This will cause the [`Observer`] to run whenever the [`Event`] has
+    /// an [`EntityComponentsTrigger`](crate::event::EntityComponentsTrigger) that targets any of the `components`.
+    pub fn with_components<I: IntoIterator<Item = ComponentId>>(mut self, components: I) -> Self {
+        self.descriptor.components.extend(components);
+        self
+    }
+
     /// Observes the given `event_key`. This will cause the [`Observer`] to run whenever an event with the given [`EventKey`]
     /// is triggered.
     /// # Safety


### PR DESCRIPTION
# Objective

- Closes #21848.

## Solution

- Add `Observer::with_components`, for consistency with `Observer::with_entities` for entities.

## Testing

- I didn't test it, but it's a very simple helper function, similar to already existing `Observer::with_component` (singular).