### PR TITLE
Fix immediate nested loaded assets not loading their dependencies.

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -2574,31 +2574,32 @@ mod tests {
         assert_eq!(get_started_load_count(app.world()), 2);
     }
 
+    /// A loader that immediately returns a [`TestAsset`].
+    struct TrivialLoader;
+
+    impl AssetLoader for TrivialLoader {
+        type Asset = TestAsset;
+        type Settings = ();
+        type Error = std::io::Error;
+
+        async fn load(
+            &self,
+            _reader: &mut dyn Reader,
+            _settings: &Self::Settings,
+            _load_context: &mut LoadContext<'_>,
+        ) -> Result<Self::Asset, Self::Error> {
+            Ok(TestAsset)
+        }
+
+        fn extensions(&self) -> &[&str] {
+            &["txt"]
+        }
+    }
+
     #[test]
     fn get_strong_handle_prevents_reload_when_asset_still_alive() {
         let (mut app, dir) = create_app();
         dir.insert_asset(Path::new("test.txt"), &[]);
-
-        struct TrivialLoader;
-
-        impl AssetLoader for TrivialLoader {
-            type Asset = TestAsset;
-            type Settings = ();
-            type Error = std::io::Error;
-
-            async fn load(
-                &self,
-                _reader: &mut dyn Reader,
-                _settings: &Self::Settings,
-                _load_context: &mut LoadContext<'_>,
-            ) -> Result<Self::Asset, Self::Error> {
-                Ok(TestAsset)
-            }
-
-            fn extensions(&self) -> &[&str] {
-                &["txt"]
-            }
-        }
 
         app.init_asset::<TestAsset>()
             .register_asset_loader(TrivialLoader);

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -321,6 +321,10 @@ pub enum DeserializeMetaError {
 /// Any asset state accessed by [`LoadContext`] will be tracked and stored for use in dependency events and asset preprocessing.
 pub struct LoadContext<'a> {
     pub(crate) asset_server: &'a AssetServer,
+    /// Specifies whether dependencies that are loaded deferred should be loaded.
+    ///
+    /// This allows us to skip loads for cases where we're never going to use the asset and we just
+    /// need the dependency information, for example during asset processing.
     pub(crate) should_load_dependencies: bool,
     populate_hashes: bool,
     asset_path: AssetPath<'static>,

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -536,7 +536,7 @@ impl<'a> LoadContext<'a> {
                 meta,
                 loader,
                 reader,
-                false,
+                self.should_load_dependencies,
                 self.populate_hashes,
             )
             .await


### PR DESCRIPTION
# Objective

- Previously if you loaded an immediate nested asset, it would **not** load any of its dependencies. This means that you could have handles in your asset that would never load.
- Fixes #20988

## Solution

- Propagate loading dependencies to immediate asset loads.
- I also deduped some test App setup code.

## Testing

- Added a test.

One case that does have a slightly undesirable effect is when you immediately-load an asset, take some data from it (but no dependency handles), and then drop the immediately-loaded asset. This change will now also initiate a dependency load, even though we won't use it.

However, A) it is much more surprising to have a handle that will never be loaded, B) we should end up cancelling the dependency load once we drop the handle, so we shouldn't pay too much of the cost of loading.