### PR TITLE
DespawnOnExit / DespawnOnEnter fix log spam 

### DIFF
--- a/crates/bevy_state/src/state_scoped.rs
+++ b/crates/bevy_state/src/state_scoped.rs
@@ -67,6 +67,7 @@ where
 
 /// Despawns entities marked with [`DespawnOnExit<S>`] when their state no
 /// longer matches the world state.
+/// If the entity has already been despawned no warning will be emitted
 pub fn despawn_entities_on_exit_state<S: States>(
     mut commands: Commands,
     mut transitions: MessageReader<StateTransitionEvent<S>>,
@@ -86,7 +87,7 @@ pub fn despawn_entities_on_exit_state<S: States>(
     };
     for (entity, binding) in &query {
         if binding.0 == *exited {
-            commands.entity(entity).despawn();
+            commands.entity(entity).try_despawn();
         }
     }
 }
@@ -133,6 +134,7 @@ pub struct DespawnOnEnter<S: States>(pub S);
 
 /// Despawns entities marked with [`DespawnOnEnter<S>`] when their state
 /// matches the world state.
+/// If the entity has already been despawned no warning will be emitted
 pub fn despawn_entities_on_enter_state<S: States>(
     mut commands: Commands,
     mut transitions: MessageReader<StateTransitionEvent<S>>,
@@ -152,7 +154,7 @@ pub fn despawn_entities_on_enter_state<S: States>(
     };
     for (entity, binding) in &query {
         if binding.0 == *entered {
-            commands.entity(entity).despawn();
+            commands.entity(entity).try_despawn();
         }
     }
 }

--- a/crates/bevy_state/src/state_scoped.rs
+++ b/crates/bevy_state/src/state_scoped.rs
@@ -67,7 +67,8 @@ where
 
 /// Despawns entities marked with [`DespawnOnExit<S>`] when their state no
 /// longer matches the world state.
-/// If the entity has already been despawned no warning will be emitted
+///
+/// If the entity has already been despawned no warning will be emitted.
 pub fn despawn_entities_on_exit_state<S: States>(
     mut commands: Commands,
     mut transitions: MessageReader<StateTransitionEvent<S>>,
@@ -134,7 +135,8 @@ pub struct DespawnOnEnter<S: States>(pub S);
 
 /// Despawns entities marked with [`DespawnOnEnter<S>`] when their state
 /// matches the world state.
-/// If the entity has already been despawned no warning will be emitted
+///
+/// If the entity has already been despawned no warning will be emitted.
 pub fn despawn_entities_on_enter_state<S: States>(
     mut commands: Commands,
     mut transitions: MessageReader<StateTransitionEvent<S>>,

--- a/examples/ecs/state_scoped.rs
+++ b/examples/ecs/state_scoped.rs
@@ -4,8 +4,9 @@
 //! This pattern is useful for managing menus, levels, or other state-specific
 //! content that should only exist during certain states.
 //!
-//! If the entity was already despawned then no error will be logged
-//! This means that you don't have to worry about duplicating in a hierarchy
+//! If the entity was already despawned then no error will be logged. This means
+//! that you don't have to worry about duplicate [`DespawnOnExit`] and
+//! [`DespawnOnEnter`] components deep in your hierarchy.
 
 use bevy::prelude::*;
 
@@ -69,9 +70,9 @@ fn on_a_exit(mut commands: Commands) {
             left: px(500),
             ..default()
         },
-        // You can apply this even when the parent has a state scope
-        // It is unnecessary but in complex hierarchies
-        // it saves you from having to mentally track which components are found at the top level
+        // You can apply this even when the parent has a state scoped component.
+        // It is unnecessary but in complex hierarchies it saves you from having to
+        // mentally track which components are found at the top level.
         (children![DespawnOnEnter(GameState::A)]),
     ));
 }

--- a/examples/ecs/state_scoped.rs
+++ b/examples/ecs/state_scoped.rs
@@ -3,6 +3,9 @@
 //!
 //! This pattern is useful for managing menus, levels, or other state-specific
 //! content that should only exist during certain states.
+//!
+//! If the entity was already despawned then no error will be logged
+//! This means that you don't have to worry about duplicating in a hierachy
 
 use bevy::prelude::*;
 
@@ -46,6 +49,7 @@ fn on_a_enter(mut commands: Commands) {
             left: px(0),
             ..default()
         },
+        (children![DespawnOnExit(GameState::A)]),
     ));
 }
 
@@ -65,6 +69,10 @@ fn on_a_exit(mut commands: Commands) {
             left: px(500),
             ..default()
         },
+        // You can apply this even when the parent has a state scope
+        // It is unneccesary but in complex hierarchies
+        // it saves you from having to mentally track which components are found at the top level
+        (children![DespawnOnEnter(GameState::A)]),
     ));
 }
 
@@ -84,6 +92,7 @@ fn on_b_enter(mut commands: Commands) {
             left: px(0),
             ..default()
         },
+        (children![DespawnOnExit(GameState::B)]),
     ));
 }
 
@@ -103,6 +112,7 @@ fn on_b_exit(mut commands: Commands) {
             left: px(500),
             ..default()
         },
+        (children![DespawnOnEnter(GameState::B)]),
     ));
 }
 

--- a/examples/ecs/state_scoped.rs
+++ b/examples/ecs/state_scoped.rs
@@ -5,7 +5,7 @@
 //! content that should only exist during certain states.
 //!
 //! If the entity was already despawned then no error will be logged
-//! This means that you don't have to worry about duplicating in a hierachy
+//! This means that you don't have to worry about duplicating in a hierarchy
 
 use bevy::prelude::*;
 
@@ -70,7 +70,7 @@ fn on_a_exit(mut commands: Commands) {
             ..default()
         },
         // You can apply this even when the parent has a state scope
-        // It is unneccesary but in complex hierarchies
+        // It is unnecessary but in complex hierarchies
         // it saves you from having to mentally track which components are found at the top level
         (children![DespawnOnEnter(GameState::A)]),
     ));


### PR DESCRIPTION
if entity was despawned such as in a hierachy

# Objective

- DespawnOnExit / DespawnOnEnter logs errors with despawning. 
    Most if not all use cases don't care if the item is already despawned.
    The user is typically saying "Ensure it is despawned" rather then "You should be the one to despawn"
- Fixes #21832

## Solution

- Changes the state_scoped code to use try despawn

## Testing

- I updated example state_scoped to include children with DespawnOnExit/DespawnOnEnter and added a brief explanation then I ran the examples 


