### PR TITLE
ssr fix and add some documents

### DIFF
--- a/crates/bevy_pbr/src/ssr/mod.rs
+++ b/crates/bevy_pbr/src/ssr/mod.rs
@@ -62,7 +62,8 @@ pub struct ScreenSpaceReflectionsPlugin;
 ///
 /// Screen-space reflections currently require deferred rendering in order to
 /// appear. Therefore, they also need the [`DepthPrepass`] and [`DeferredPrepass`]
-/// components, which are inserted automatically.
+/// components, which are inserted automatically,
+/// but deferred rendering itself is not automatically enabled.
 ///
 /// SSR currently performs no roughness filtering for glossy reflections, so
 /// only very smooth surfaces will reflect objects in screen space. You can


### PR DESCRIPTION
# Objective
Screen space reflection didn't work for my program, so I tried cloning bevy repo and running the ssr example to see whether it works or not, and it didn't. I figured out that the problem is that `prepare_ssr_pipelines` system only runs for views with `ExtractedAtmosphere`. So I removed this filter because it already uses `Has<ExtractedAtmosphere>`. And the example works afterwards.

I later found that the `With<ExtractedAtmosphere>` filter is not added to bevy 0.17, so the problem in my own program is not the same as the ssr example. I compared the ssr example and my program and found that I didn't add `DefaultOpaqueRendererMethod::deferred()` resource. So I added a few docs to state that deferred rendering is not automatically enabled when ssr is added.


## Solution
1. remove `With<ExtractedAtmosphere>` filter in `prepare_ssr_pipelines`.
2. add more documentation.

## Testing
I tested the ssr example and atmosphere example and both look fine.
