### PR TITLE
Fix shader compilation fail when using visibility range

### DIFF
--- a/crates/bevy_pbr/src/render/pbr.wgsl
+++ b/crates/bevy_pbr/src/render/pbr.wgsl
@@ -5,8 +5,6 @@
     decal::clustered::apply_decal_base_color,
 }
 
-
-
 #ifdef PREPASS_PIPELINE
 #import bevy_pbr::{
     prepass_io::{VertexOutput, FragmentOutput},


### PR DESCRIPTION
# Objective
When using both deferred rendering and visibility range, shader `pbr.wgsl` can't be compiled because `pbr_functions` is not imported.

The issue can be reproduced by using `DefaultOpaqueRendererMethod::deferred()` and adding `DeferredPrepass` to camera at the visibility_range example.

## Solution
Import `pbr_functions` when using `PREPASS_PIPELINE`.

## Testing
I tested on visibility_range and deferred_rendering example. However, importing something usually doesn't break anything.