### PR TITLE
Prevent WebGL builds from crashing on startup when using FpsOverlayPlugin

### DIFF
--- a/crates/bevy_dev_tools/Cargo.toml
+++ b/crates/bevy_dev_tools/Cargo.toml
@@ -10,6 +10,8 @@ keywords = ["bevy"]
 
 [features]
 bevy_ci_testing = ["serde", "ron"]
+webgl = ["bevy_render/webgl"]
+webgpu = ["bevy_render/webgpu"]
 
 [dependencies]
 # bevy

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -187,6 +187,7 @@ webgl = [
   "bevy_render?/webgl",
   "bevy_gizmos_render?/webgl",
   "bevy_sprite_render?/webgl",
+  "bevy_dev_tools?/webgl",
 ]
 
 webgpu = [
@@ -196,6 +197,7 @@ webgpu = [
   "bevy_render?/webgpu",
   "bevy_gizmos_render?/webgpu",
   "bevy_sprite_render?/webgpu",
+  "bevy_dev_tools?/webgpu",
 ]
 
 # Enable systems that allow for automated testing on CI


### PR DESCRIPTION
# Objective

- Fixes #21362
- The FrameTimeGraph uses a material that crashes in WebGL (but not WebGPU) even if the FrameTimeGraph is disabled. We need to prevent the FrameTimeGraph from being created when we build for WASM.

## Solution

- If the build is for WASM with only WebGL, we skip the ceration of the FrameTimeGraph. Additionally, if the FrameTimeGraph is enabled, we provide a warning to inform the user that the FrameTimeGraph isn't supported on WebGL. 

## Testing

- I used the repro provided in the issue.


