### PR TITLE
One-to-many asset processing

### DIFF
--- a/crates/bevy_asset/src/meta.rs
+++ b/crates/bevy_asset/src/meta.rs
@@ -70,9 +70,8 @@ pub enum AssetAction<LoaderSettings, ProcessSettings> {
         processor: String,
         settings: ProcessSettings,
     },
-    /// This asset should fail to load, since the original unprocessed asset was decomposed into
-    /// multiple files. This provides a better error message rather than just saying the file is
-    /// missing.
+    /// This asset has been decomposed into multiple files. The original asset path can no longer be
+    /// loaded.
     Decomposed,
     /// Do nothing with the asset
     Ignore,

--- a/crates/bevy_asset/src/meta.rs
+++ b/crates/bevy_asset/src/meta.rs
@@ -70,6 +70,10 @@ pub enum AssetAction<LoaderSettings, ProcessSettings> {
         processor: String,
         settings: ProcessSettings,
     },
+    /// This asset should fail to load, since the original unprocessed asset was decomposed into
+    /// multiple files. This provides a better error message rather than just saying the file is
+    /// missing.
+    Decomposed,
     /// Do nothing with the asset
     Ignore,
 }
@@ -113,6 +117,7 @@ pub struct AssetMetaMinimal {
 pub enum AssetActionMinimal {
     Load { loader: String },
     Process { processor: String },
+    Decomposed,
     Ignore,
 }
 
@@ -194,13 +199,12 @@ impl_downcast!(Settings);
 /// The () processor should never be called. This implementation exists to make the meta format nicer to work with.
 impl Process for () {
     type Settings = ();
-    type OutputLoader = ();
 
     async fn process(
         &self,
         _context: &mut bevy_asset::processor::ProcessContext<'_>,
         _settings: &Self::Settings,
-        _writer: &mut bevy_asset::io::Writer,
+        _writer_context: bevy_asset::processor::WriterContext<'_>,
     ) -> Result<(), bevy_asset::processor::ProcessError> {
         unreachable!()
     }

--- a/crates/bevy_asset/src/processor/mod.rs
+++ b/crates/bevy_asset/src/processor/mod.rs
@@ -912,6 +912,10 @@ impl AssetProcessor {
             for empty_dir in empty_dirs {
                 // We don't care if this succeeds, since it's just a cleanup task. It is best-effort
                 let _ = processed_writer.remove_empty_directory(&empty_dir).await;
+                // The directory may also have been an asset that was processed - try to delete its
+                // meta. If it fails, that either means there was no meta (which is fine), or the
+                // delete itself failed, which is also fine like above.
+                let _ = processed_writer.remove_meta(&empty_dir).await;
             }
 
             for path in unprocessed_paths {

--- a/crates/bevy_asset/src/processor/mod.rs
+++ b/crates/bevy_asset/src/processor/mod.rs
@@ -862,7 +862,7 @@ impl AssetProcessor {
                     }
                 {
                     // If this directory has a meta file, then it is likely a processed asset using
-                    // `ProcessContext::write_multiple`, so count the whole thing as an asset path.
+                    // `ProcessContext::write_partial`, so count the whole thing as an asset path.
                     paths.push(path);
                     return Ok(true);
                 }
@@ -1274,7 +1274,7 @@ impl AssetProcessor {
 
             let mut started_writes = 0;
             let mut finished_writes = AtomicU32::new(0);
-            let mut single_meta = None;
+            let mut full_meta = None;
             {
                 let mut context = ProcessContext::new(
                     self,
@@ -1289,7 +1289,7 @@ impl AssetProcessor {
                         processed_writer,
                         &mut started_writes,
                         &mut finished_writes,
-                        &mut single_meta,
+                        &mut full_meta,
                         asset_path,
                     ),
                 );
@@ -1318,7 +1318,7 @@ impl AssetProcessor {
                     .iter()
                     .map(|i| i.full_hash),
             );
-            let mut processed_meta = single_meta
+            let mut processed_meta = full_meta
                 .unwrap_or_else(|| Box::new(AssetMeta::<(), ()>::new(AssetAction::Decomposed)));
 
             new_processed_info.full_hash = full_hash;

--- a/crates/bevy_asset/src/processor/process.rs
+++ b/crates/bevy_asset/src/processor/process.rs
@@ -1,6 +1,6 @@
 use crate::{
     io::{
-        AssetReaderError, AssetWriterError, MissingAssetWriterError,
+        AssetReaderError, AssetWriterError, ErasedAssetWriter, MissingAssetWriterError,
         MissingProcessedAssetReaderError, MissingProcessedAssetWriterError, Reader,
         ReaderRequiredFeatures, Writer,
     },
@@ -17,32 +17,38 @@ use alloc::{
     string::{String, ToString},
     vec::Vec,
 };
+use bevy_platform::collections::HashSet;
 use bevy_reflect::TypePath;
 use bevy_tasks::{BoxedFuture, ConditionalSendFuture};
-use core::marker::PhantomData;
+use core::{
+    marker::PhantomData,
+    ops::{Deref, DerefMut},
+    sync::atomic::{AtomicU32, Ordering},
+};
+use futures_lite::AsyncWriteExt;
 use serde::{Deserialize, Serialize};
+use std::{
+    path::{Path, PathBuf},
+    sync::{Mutex, PoisonError},
+};
 use thiserror::Error;
 
-/// Asset "processor" logic that reads input asset bytes (stored on [`ProcessContext`]), processes the value in some way,
-/// and then writes the final processed bytes with [`Writer`]. The resulting bytes must be loadable with the given [`Process::OutputLoader`].
+/// Asset "processor" logic that reads input asset bytes (stored on [`ProcessContext`]), processes
+/// the value in some way, and then writes the processed assets with [`WriterContext`].
 ///
-/// This is a "low level", maximally flexible interface. Most use cases are better served by the [`LoadTransformAndSave`] implementation
-/// of [`Process`].
+/// This is a "low level", maximally flexible interface. Most use cases are better served by the
+/// [`LoadTransformAndSave`] implementation of [`Process`].
 pub trait Process: TypePath + Send + Sync + Sized + 'static {
     /// The configuration / settings used to process the asset. This will be stored in the [`AssetMeta`] and is user-configurable per-asset.
     type Settings: Settings + Default + Serialize + for<'a> Deserialize<'a>;
-    /// The [`AssetLoader`] that will be used to load the final processed asset.
-    type OutputLoader: AssetLoader;
-    /// Processes the asset stored on `context` in some way using the settings stored on `meta`. The results are written to `writer`. The
-    /// final written processed asset is loadable using [`Process::OutputLoader`]. This load will use the returned [`AssetLoader::Settings`].
+    /// Processes the asset stored on `context` in some way using the settings stored on `meta`. The
+    /// results are written to `writer_context`.
     fn process(
         &self,
         context: &mut ProcessContext,
         settings: &Self::Settings,
-        writer: &mut Writer,
-    ) -> impl ConditionalSendFuture<
-        Output = Result<<Self::OutputLoader as AssetLoader>::Settings, ProcessError>,
-    >;
+        writer_context: WriterContext<'_>,
+    ) -> impl ConditionalSendFuture<Output = Result<(), ProcessError>>;
 
     /// Gets the features of the reader required to process the asset.
     fn reader_required_features(_settings: &Self::Settings) -> ReaderRequiredFeatures {
@@ -172,6 +178,8 @@ pub enum ProcessError {
     AssetTransformError(Box<dyn core::error::Error + Send + Sync + 'static>),
     #[error("Assets without extensions are not supported.")]
     ExtensionRequired,
+    #[error(transparent)]
+    InvalidProcessOutput(#[from] InvalidProcessOutput),
 }
 
 impl<Loader, Transformer, Saver> Process for LoadTransformAndSave<Loader, Transformer, Saver>
@@ -182,14 +190,13 @@ where
 {
     type Settings =
         LoadTransformAndSaveSettings<Loader::Settings, Transformer::Settings, Saver::Settings>;
-    type OutputLoader = Saver::OutputLoader;
 
     async fn process(
         &self,
         context: &mut ProcessContext<'_>,
         settings: &Self::Settings,
-        writer: &mut Writer,
-    ) -> Result<<Self::OutputLoader as AssetLoader>::Settings, ProcessError> {
+        writer_context: WriterContext<'_>,
+    ) -> Result<(), ProcessError> {
         let pre_transformed_asset = TransformedAsset::<Loader::Asset>::from_loaded(
             context
                 .load_source_asset::<Loader>(&settings.loader_settings)
@@ -206,12 +213,16 @@ where
         let saved_asset =
             SavedAsset::<Transformer::AssetOutput>::from_transformed(&post_transformed_asset);
 
-        let output_settings = self
-            .saver
-            .save(writer, saved_asset, &settings.saver_settings)
+        let saver = &self.saver;
+        let saver_settings = &settings.saver_settings;
+        let mut writer = writer_context.write_single().await?;
+
+        let output_settings = saver
+            .save(&mut *writer, saved_asset, saver_settings)
             .await
             .map_err(|error| ProcessError::AssetSaveError(error.into()))?;
-        Ok(output_settings)
+
+        writer.finish::<Saver::OutputLoader>(output_settings).await
     }
 
     fn reader_required_features(settings: &Self::Settings) -> ReaderRequiredFeatures {
@@ -227,8 +238,8 @@ pub trait ErasedProcessor: Send + Sync {
         &'a self,
         context: &'a mut ProcessContext,
         settings: &'a dyn Settings,
-        writer: &'a mut Writer,
-    ) -> BoxedFuture<'a, Result<Box<dyn AssetMetaDyn>, ProcessError>>;
+        writer_context: WriterContext<'a>,
+    ) -> BoxedFuture<'a, Result<(), ProcessError>>;
     /// Type-erased variant of [`Process::reader_required_features`].
     // Note: This takes &self just to be dyn compatible.
     #[cfg_attr(
@@ -256,17 +267,11 @@ impl<P: Process> ErasedProcessor for P {
         &'a self,
         context: &'a mut ProcessContext,
         settings: &'a dyn Settings,
-        writer: &'a mut Writer,
-    ) -> BoxedFuture<'a, Result<Box<dyn AssetMetaDyn>, ProcessError>> {
+        writer_context: WriterContext<'a>,
+    ) -> BoxedFuture<'a, Result<(), ProcessError>> {
         Box::pin(async move {
             let settings = settings.downcast_ref().ok_or(ProcessError::WrongMetaType)?;
-            let loader_settings = <P as Process>::process(self, context, settings, writer).await?;
-            let output_meta: Box<dyn AssetMetaDyn> =
-                Box::new(AssetMeta::<P::OutputLoader, ()>::new(AssetAction::Load {
-                    loader: P::OutputLoader::type_path().to_string(),
-                    settings: loader_settings,
-                }));
-            Ok(output_meta)
+            <P as Process>::process(self, context, settings, writer_context).await
         })
     }
 
@@ -378,5 +383,283 @@ impl<'a> ProcessContext<'a> {
     #[inline]
     pub fn asset_reader(&mut self) -> &mut dyn Reader {
         &mut self.reader
+    }
+}
+
+/// The context for any writers that a [`Process`] may use.
+pub struct WriterContext<'a> {
+    /// The underlying writer of all writes for the [`Process`].
+    writer: &'a dyn ErasedAssetWriter,
+    /// The context for initializing a write.
+    // We use a Mutex to avoid requiring a mutable borrow for `write_multiple`. See `write_multiple`
+    // for more details.
+    init_context: Mutex<WriteInitContext<'a>>,
+    /// The number of writes that have been fully finished.
+    ///
+    /// Note we use an `AtomicU32` instead of a u32 so that writes (and therefore finish's) don't
+    /// need to be synchronous. We use a mutable borrow so that single-writes can just update the
+    /// value without atomics.
+    finished_writes: &'a mut AtomicU32,
+    /// The meta object to write when writing a single file. Must be set to [`Some`] when writing a
+    /// single file.
+    single_meta: &'a mut Option<Box<dyn AssetMetaDyn>>,
+    /// The path of the asset being processed.
+    path: &'a AssetPath<'static>,
+}
+
+/// The context for the initialization when writing a processed file.
+struct WriteInitContext<'a> {
+    /// The number of writes that have been started.
+    started_writes: &'a mut u32,
+    /// The set of currently started `write_multiple` instances.
+    ///
+    /// This protects us from starting writes for the same path multiple times.
+    started_paths: HashSet<PathBuf>,
+}
+
+impl<'a> WriterContext<'a> {
+    pub(crate) fn new(
+        writer: &'a dyn ErasedAssetWriter,
+        started_writes: &'a mut u32,
+        finished_writes: &'a mut AtomicU32,
+        single_meta: &'a mut Option<Box<dyn AssetMetaDyn>>,
+        path: &'a AssetPath<'static>,
+    ) -> Self {
+        Self {
+            writer,
+            init_context: Mutex::new(WriteInitContext {
+                started_writes,
+                started_paths: HashSet::new(),
+            }),
+            finished_writes,
+            single_meta,
+            path,
+        }
+    }
+
+    /// Start writing a single output file, which can be loaded with the `load_settings`.
+    ///
+    /// Returns an error if you have previously started writing.
+    pub async fn write_single(self) -> Result<SingleWriter<'a>, ProcessError> {
+        let started_writes = self
+            .init_context
+            .into_inner()
+            .unwrap_or_else(PoisonError::into_inner)
+            .started_writes;
+        if *started_writes != 0 {
+            return Err(ProcessError::InvalidProcessOutput(
+                InvalidProcessOutput::SingleFileAfterMultipleFile,
+            ));
+        }
+        *started_writes = 1;
+
+        let writer = self.writer.write(self.path.path()).await.map_err(|err| {
+            ProcessError::AssetWriterError {
+                path: self.path.clone_owned(),
+                err,
+            }
+        })?;
+        Ok(SingleWriter {
+            writer,
+            finished_writes: self.finished_writes.get_mut(),
+            path: self.path,
+            single_meta: self.single_meta,
+        })
+    }
+
+    /// Start writing one of multiple output file, which can be loaded with the `load_settings`.
+    ///
+    /// Returns an error if you have previously started writing a single file.
+    // Note: It would be nice to take this by a mutable reference instead. However, doing so would
+    // mean that the returned value would be tied to a "mutable reference lifetime", meaning we
+    // could not use more than one `MultipleWriter` instance concurrently.
+    pub async fn write_multiple(&self, file: &Path) -> Result<MultipleWriter<'_>, ProcessError> {
+        // Do all the validation in a scope so we don't hold the init_context for too long.
+        {
+            let mut init_context = self
+                .init_context
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner);
+            // Check whether this path is valid first so that we don't mark the write as started
+            // when it hasn't.
+            if !init_context.started_paths.insert(file.to_path_buf()) {
+                return Err(InvalidProcessOutput::RepeatedMultipleWriteToSamePath(
+                    file.to_path_buf(),
+                )
+                .into());
+            }
+            *init_context.started_writes += 1;
+        }
+
+        let path = self.path.path().join(file);
+        let path = AssetPath::from_path_buf(path).with_source(self.path.source().clone_owned());
+
+        let writer = self
+            .writer
+            .write(path.path())
+            .await
+            // Note: It's possible that a user receives the error and then tries to recover, but
+            // this would leave the process in an invalid state (since you would never be able to
+            // call `finish` enough times). We could decrement the `started_writes` counter, but
+            // it's unclear what a reasonable recovery a user could do in this case - just
+            // propagating the error is safer and makes more sense.
+            .map_err(|err| ProcessError::AssetWriterError {
+                path: path.clone_owned(),
+                err,
+            })?;
+        Ok(MultipleWriter {
+            meta_writer: self.writer,
+            writer,
+            finished_writes: &*self.finished_writes,
+            path,
+        })
+    }
+}
+
+/// An error regarding the output state of a [`Process`].
+#[derive(Error, Debug)]
+pub enum InvalidProcessOutput {
+    /// The processor didn't start a write at all.
+    #[error("The processor never started writing a file (never called `write_single` or `write_multiple`)")]
+    NoWriter,
+    /// The processor started a write but never finished it.
+    #[error("The processor started writing a file, but never called `finish`")]
+    UnfinishedWriter,
+    /// The processor started at least one multiple write, then continued with a single write.
+    #[error("The processor called `write_single` after already calling `write_multiple`")]
+    SingleFileAfterMultipleFile,
+    /// The processor started a multiple write with the same path multiple times.
+    #[error("The processor called `write_multiple` more than once with the same path")]
+    RepeatedMultipleWriteToSamePath(PathBuf),
+}
+
+/// The writer for a [`Process`] writing a single file (at the same path as the unprocessed asset).
+pub struct SingleWriter<'a> {
+    /// The writer to write to.
+    writer: Box<Writer>,
+    /// The counter for finished writes that will be incremented when the write completes.
+    finished_writes: &'a mut u32,
+    /// The meta object that will be assigned on [`Self::finish`].
+    single_meta: &'a mut Option<Box<dyn AssetMetaDyn>>,
+    /// The path of the asset being written.
+    path: &'a AssetPath<'static>,
+}
+
+impl SingleWriter<'_> {
+    /// Finishes a write and indicates that the written asset should be loaded with the provided
+    /// loader and the provided settings for that loader.
+    ///
+    /// This must be called before the [`Process`] ends.
+    pub async fn finish<L: AssetLoader>(
+        mut self,
+        load_settings: L::Settings,
+    ) -> Result<(), ProcessError> {
+        self.writer
+            .flush()
+            .await
+            .map_err(|err| ProcessError::AssetWriterError {
+                path: self.path.clone_owned(),
+                err: AssetWriterError::Io(err),
+            })?;
+
+        let output_meta = AssetMeta::<L, ()>::new(AssetAction::Load {
+            loader: L::type_path().to_string(),
+            settings: load_settings,
+        });
+
+        // This should always be none, since we consumed the WriterContext, and we consume the
+        // only borrow here.
+        assert!(self.single_meta.is_none());
+        *self.single_meta = Some(Box::new(output_meta));
+
+        // Make sure to increment finished writes at the very end, so that we only count it, once
+        // the future is finished anyway.
+        *self.finished_writes += 1;
+        Ok(())
+    }
+}
+
+/// A writer for a [`Process`] writing multiple files (as children of the unprocessed asset path).
+pub struct MultipleWriter<'a> {
+    /// The writer to use when writing the meta file for this file.
+    meta_writer: &'a dyn ErasedAssetWriter,
+    /// The writer to write to.
+    writer: Box<Writer>,
+    /// The counter for finished writes that will be incremented when the write completes.
+    finished_writes: &'a AtomicU32,
+    /// The path of the file being written.
+    ///
+    /// This includes the path relative to the unprocessed asset.
+    path: AssetPath<'static>,
+}
+
+impl MultipleWriter<'_> {
+    /// Finishes a write and indicates that the written asset should be loaded with the provided
+    /// loader and the provided settings for that loader.
+    ///
+    /// This must be called before the [`Process`] ends.
+    pub async fn finish<L: AssetLoader>(
+        mut self,
+        load_settings: L::Settings,
+    ) -> Result<(), ProcessError> {
+        self.writer
+            .flush()
+            .await
+            .map_err(|err| ProcessError::AssetWriterError {
+                path: self.path.clone_owned(),
+                err: AssetWriterError::Io(err),
+            })?;
+
+        let output_meta = AssetMeta::<L, ()>::new(AssetAction::Load {
+            loader: L::type_path().to_string(),
+            settings: load_settings,
+        });
+
+        let output_meta_bytes = AssetMetaDyn::serialize(&output_meta);
+
+        let result = self
+            .meta_writer
+            .write_meta_bytes(self.path.path(), &output_meta_bytes)
+            .await
+            .map_err(|err| ProcessError::AssetWriterError {
+                path: self.path.clone_owned(),
+                err,
+            });
+
+        if result.is_ok() {
+            // The ordering here doesn't really matter, since this is just a cheaper Mutex<u32>.
+            // Just in case, we'll be overly safe and use SeqCst.
+            self.finished_writes.fetch_add(1, Ordering::SeqCst);
+        }
+
+        result
+    }
+}
+
+impl Deref for SingleWriter<'_> {
+    type Target = Writer;
+
+    fn deref(&self) -> &Self::Target {
+        self.writer.as_ref()
+    }
+}
+
+impl DerefMut for SingleWriter<'_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.writer.as_mut()
+    }
+}
+
+impl Deref for MultipleWriter<'_> {
+    type Target = Writer;
+
+    fn deref(&self) -> &Self::Target {
+        self.writer.as_ref()
+    }
+}
+
+impl DerefMut for MultipleWriter<'_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.writer.as_mut()
     }
 }

--- a/crates/bevy_asset/src/processor/process.rs
+++ b/crates/bevy_asset/src/processor/process.rs
@@ -439,7 +439,7 @@ impl<'a> WriterContext<'a> {
 
     /// Start writing a single output file, which can be loaded with the `load_settings`.
     ///
-    /// Returns an error if you have previously started writing.
+    /// Returns an error if you have previously called [`Self::write_multiple`].
     pub async fn write_single(self) -> Result<SingleWriter<'a>, ProcessError> {
         let started_writes = self
             .init_context

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -1467,6 +1467,11 @@ impl AssetServer {
                                 path: asset_path.clone_owned(),
                             })
                         }
+                        AssetActionMinimal::Decomposed => {
+                            return Err(AssetLoadError::CannotLoadDecomposedAsset {
+                                path: asset_path.clone_owned(),
+                            })
+                        }
                         AssetActionMinimal::Ignore => {
                             return Err(AssetLoadError::CannotLoadIgnoredAsset {
                                 path: asset_path.clone_owned(),
@@ -2073,6 +2078,9 @@ pub enum AssetLoadError {
     #[error("Asset '{path}' is configured to be processed. It cannot be loaded directly.")]
     #[from(ignore)]
     CannotLoadProcessedAsset { path: AssetPath<'static> },
+    #[error("Asset '{path}' is the root of an asset that has been decomposed through processing. It cannot be loaded directly.")]
+    #[from(ignore)]
+    CannotLoadDecomposedAsset { path: AssetPath<'static> },
     #[error("Asset '{path}' is configured to be ignored. It cannot be loaded.")]
     #[from(ignore)]
     CannotLoadIgnoredAsset { path: AssetPath<'static> },

--- a/examples/asset/processing/asset_processing.rs
+++ b/examples/asset/processing/asset_processing.rs
@@ -254,7 +254,7 @@ impl Process for LineSplitterProcess {
         }
         for (i, line) in bytes.lines().map(Result::unwrap).enumerate() {
             let mut writer = writer_context
-                .write_multiple(Path::new(&format!("Line{i}.line")))
+                .write_partial(Path::new(&format!("Line{i}.line")))
                 .await?;
             writer.write_all(line.as_bytes()).await.map_err(|err| {
                 ProcessError::AssetWriterError {

--- a/examples/asset/processing/assets/multi.lines
+++ b/examples/asset/processing/assets/multi.lines
@@ -1,0 +1,4 @@
+A line of text,
+this one's next!
+A single process,
+produces excess.

--- a/release-content/migration-guides/process_trait_changes.md
+++ b/release-content/migration-guides/process_trait_changes.md
@@ -1,11 +1,62 @@
 ---
 title: Changes to the `Process` trait in `bevy_asset`.
-pull_requests: [21925]
+pull_requests: [21925, 21889]
 ---
 
-`ProcessContext` no longer includes `asset_bytes`. This has been replaced by `asset_reader`. To
-maintain current behavior in a `Process` implementation, you can read all the bytes into memory.
-If previously, you did:
+In previous versions, the `Process` trait had an associated type for the output loader, and took a
+`writer` argument. This is no longer the case (in order to support one-to-many asset processing).
+This change requires that users indicate whether they are using the "single" writer mode or the
+"multiple" writer mode.
+
+If your previous trait implementation of `Process` looked like this:
+
+```rust
+impl Process for MyThing {
+    type Settings = MyThingSettings;
+    type OutputLoader = SomeLoader;
+
+    async fn process(
+        &self,
+        context: &mut ProcessContext<'_>,
+        meta: AssetMeta<(), Self>,
+        writer: &mut Writer,
+    ) -> Result<SomeLoader::Settings, ProcessError> {
+        // Write to `writer`, then return the meta file you want.
+        let meta = todo!();
+        Ok(meta)
+    }
+}
+```
+
+Now it needs to look like:
+
+```rust
+impl Process for MyThing {
+    type Settings = MyThingSettings;
+
+    async fn process(
+        &self,
+        context: &mut ProcessContext<'_>,
+        meta: AssetMeta<(), Self>,
+        writer_context: WriteContext<'_>,
+    ) -> Result<(), ProcessError> {
+        let writer = writer_context.write_single().await?;
+        // Write to `writer`, then return the meta file you want.
+        let meta = todo!();
+        writer.finish(meta).await
+    }
+}
+```
+
+In addition, the returned `writer` is a wrapper around `&mut Writer`. This means you may need to
+explicitly dereference in order to pass this writer into functions that take a `&mut Writer`.
+
+This does not apply if you are using the `LoadTransformAndSave` process - existing uses should
+continue to work.
+
+The `ProcessContext` also no longer includes `asset_bytes`. This has been replaced by
+`asset_reader`. To maintain current behavior in a `Process` implementation, you can read all the
+bytes into memory. If previously, you did:
 
 ```rust
 // Inside `impl Process for Type`

--- a/release-content/migration-guides/process_trait_changes.md
+++ b/release-content/migration-guides/process_trait_changes.md
@@ -5,8 +5,8 @@ pull_requests: [21925, 21889]
 
 In previous versions, the `Process` trait had an associated type for the output loader, and took a
 `writer` argument. This is no longer the case (in order to support one-to-many asset processing).
-This change requires that users indicate whether they are using the "single" writer mode or the
-"multiple" writer mode.
+This change requires that users indicate whether they are using the "full" writer mode or the
+"partial" writer mode.
 
 If your previous trait implementation of `Process` looked like this:
 
@@ -40,7 +40,7 @@ impl Process for MyThing {
         meta: AssetMeta<(), Self>,
         writer_context: WriteContext<'_>,
     ) -> Result<(), ProcessError> {
-        let writer = writer_context.write_single().await?;
+        let writer = writer_context.write_full().await?;
         // Write to `writer`, then return the meta file you want.
         let meta = todo!();
         writer.finish(meta).await

--- a/release-content/release-notes/one_to_many_processing.md
+++ b/release-content/release-notes/one_to_many_processing.md
@@ -48,7 +48,9 @@ impl Process for LineSplitterProcess {
 Then if you have an asset like `shakespeare.txt`, you can load these separate files as
 `shakespeare.txt/Line0.line`, `shakespeare.txt/Line1.line`, etc. These separate files can have
 different file extensions, be loaded as completely separate asset types, or be entirely produced
-from scratch within the asset processor!
+from scratch within the asset processor! These files are treated as completely distinct assets, so
+loading them looks like a regular asset load (e.g.,
+`asset_server.load("shakespeare.txt/Line1.line")`).
 
 We plan to use this to break apart large glTF files into smaller, easier-to-load pieces -
-particularly for producing meshlets.
+particularly for producing virtual geometry meshes.

--- a/release-content/release-notes/one_to_many_processing.md
+++ b/release-content/release-notes/one_to_many_processing.md
@@ -8,7 +8,7 @@ In previous versions, asset processing was always one-to-one: a processor would 
 asset to process and write to a single file.
 
 Now, an asset processor can write to multiple files! When implementing the `Process` trait, you can
-call `writer_context.write_multiple` and provide the path relative to the original asset. So for
+call `writer_context.write_partial` and provide the path relative to the original asset. So for
 example, here we have a processor that reads all the lines in a file and writes them each to their
 own file:
 
@@ -30,7 +30,7 @@ impl Process for LineSplitterProcess {
         }
         for (i, line) in bytes.lines().map(Result::unwrap).enumerate() {
             let mut writer = writer_context
-                .write_multiple(Path::new(&format!("Line{i}.line")))
+                .write_partial(Path::new(&format!("Line{i}.line")))
                 .await?;
             writer.write_all(line.as_bytes()).await.map_err(|err| {
                 ProcessError::AssetWriterError {

--- a/release-content/release-notes/one_to_many_processing.md
+++ b/release-content/release-notes/one_to_many_processing.md
@@ -1,0 +1,54 @@
+---
+title: One-to-many Asset Processing
+authors: ["@andriyDev"]
+pull_requests: []
+---
+
+In previous versions, asset processing was always one-to-one: a processor would be given a single
+asset to process and write to a single file.
+
+Now, an asset processor can write to multiple files! When implementing the `Process` trait, you can
+call `writer_context.write_multiple` and provide the path relative to the original asset. So for
+example, here we have a processor that reads all the lines in a file and writes them each to their
+own file:
+
+```rust
+struct LineSplitterProcess;
+
+impl Process for LineSplitterProcess {
+    type Settings = ();
+
+    async fn process(
+        &self,
+        context: &mut ProcessContext<'_>,
+        meta: AssetMeta<(), Self>,
+        writer_context: WriterContext<'_>,
+    ) -> Result<(), ProcessError> {
+        let bytes = context.asset_bytes();
+        if bytes.is_empty() {
+            return Err(ProcessError::AssetTransformError("empty asset".into()));
+        }
+        for (i, line) in bytes.lines().map(Result::unwrap).enumerate() {
+            let mut writer = writer_context
+                .write_multiple(Path::new(&format!("Line{i}.line")))
+                .await?;
+            writer.write_all(line.as_bytes()).await.map_err(|err| {
+                ProcessError::AssetWriterError {
+                    path: context.path().clone_owned(),
+                    err: err.into(),
+                }
+            })?;
+            writer.finish::<TextLoader>(TextSettings::default()).await?;
+        }
+        Ok(())
+    }
+}
+```
+
+Then if you have an asset like `shakespeare.txt`, you can load these separate files as
+`shakespeare.txt/Line0.line`, `shakespeare.txt/Line1.line`, etc. These separate files can have
+different file extensions, be loaded as completely separate asset types, or be entirely produced
+from scratch within the asset processor!
+
+We plan to use this to break apart large glTF files into smaller, easier-to-load pieces -
+particularly for producing meshlets.


### PR DESCRIPTION
# Objective

- Allow processors to produce multiple files instead of just one.

## Solution

- Instead of passing a `&mut Writer` to `Process`, instead we pass a `WriterContext`. Users then just call `write_single` or `write_multiple` to decide whether they want a single file or multiple files. Once users are done writing, they call `SingleWriter::finish` or `MultipleWriter::finish`.
- I also added a new asset action - `Decomposed`. This makes it more obvious to callers that they are querying for the wrong asset path.

This means if you have an asset path like `path/to/my_asset.json`, and the `Process` produces files "part1.thing", "part2.thing", and "dir/mesh.gltf", these assets will be accessible at `path/to/my_asset.json/part1.thing`, `path/to/my_asset.json/part2.thing`, and `path/to/my_asset.json/dir/mesh.gltf`. In essence, the asset in the unprocessed directory becomes a folder in the processed directory.

## Testing

- The `asset_processing` example works and has been updated to include a "multiple" processor.
- Updated unit tests to account for "multiple" files.
- Created new tests too.
