### PR TITLE
Automatic scrollbar rendering

### DIFF
--- a/examples/ui/scroll.rs
+++ b/examples/ui/scroll.rs
@@ -230,6 +230,7 @@ fn vertically_scrolling_list(font_handle: Handle<Font>) -> impl Bundle {
                     align_self: AlignSelf::Stretch,
                     height: percent(50),
                     overflow: Overflow::scroll_y(), // n.b.
+                    scrollbar_width: 20.,
                     ..default()
                 },
                 BackgroundColor(Color::srgb(0.10, 0.10, 0.10)),
@@ -281,6 +282,7 @@ fn bidirectional_scrolling_list(font_handle: Handle<Font>) -> impl Bundle {
                     align_self: AlignSelf::Stretch,
                     height: percent(50),
                     overflow: Overflow::scroll(), // n.b.
+                    scrollbar_width: 20.,
                     ..default()
                 },
                 BackgroundColor(Color::srgb(0.10, 0.10, 0.10)),
@@ -336,6 +338,7 @@ fn bidirectional_scrolling_list_with_sticky(font_handle: Handle<Font>) -> impl B
                     align_self: AlignSelf::Stretch,
                     height: percent(50),
                     overflow: Overflow::scroll(), // n.b.
+                    scrollbar_width: 20.,
                     grid_template_columns: RepeatedGridTrack::auto(30),
                     ..default()
                 },
@@ -408,6 +411,7 @@ fn nested_scrolling_list(font_handle: Handle<Font>) -> impl Bundle {
                     align_self: AlignSelf::Stretch,
                     height: percent(50),
                     overflow: Overflow::scroll(),
+                    scrollbar_width: 20.,
                     ..default()
                 },
                 BackgroundColor(Color::srgb(0.10, 0.10, 0.10)),
@@ -419,6 +423,7 @@ fn nested_scrolling_list(font_handle: Handle<Font>) -> impl Bundle {
                             align_self: AlignSelf::Stretch,
                             height: percent(200. / 5. * (oi as f32 + 1.)),
                             overflow: Overflow::scroll_y(),
+                            scrollbar_width: 20.,
                             ..default()
                         },
                         BackgroundColor(Color::srgb(0.05, 0.05, 0.05)),

--- a/release-content/release-notes/automatic_scrollbar_rendering.md
+++ b/release-content/release-notes/automatic_scrollbar_rendering.md
@@ -1,7 +1,7 @@
 ---
 title: Automatic scrollbar rendering
 authors: ["@ickshonpe"]
-pull_requests: []
+pull_requests: [21897]
 ---
 
 Scrollbars are now drawn automatically for nodes with scrolled content and a `scrollbar_width` greater than 0.

--- a/release-content/release-notes/automatic_scrollbar_rendering.md
+++ b/release-content/release-notes/automatic_scrollbar_rendering.md
@@ -1,0 +1,16 @@
+---
+title: Automatic scrollbar rendering
+authors: ["@ickshonpe"]
+pull_requests: []
+---
+
+Scrollbars are now drawn automatically for nodes with scrolled content and a `scrollbar_width` greater than 0.
+
+Styling can be set using the `ScrollbarStyle` component. For now, it only supports changing the scrollbar's colors.
+
+`ComputedNode` has new methods that can be used to compute the geometry for a UI node's scrollbars:
+
+* `horizontal_scrollbar_gutter`
+* `vertical_scrollbar_gutter`
+* `horizontal_scrollbar_thumb`,
+* `vertical_scrollbar_thumb`


### PR DESCRIPTION
# Objective

Draw scrollbars automatically for nodes with scrolled content and a `scrollbar_width` greater than zero.

## Solution

* New `extract_scrollbars` system in `bevy_ui_render`, this automatically renders scrollbars for UI nodes with scrolling content.
* New component, `ScrollbarStyle`. For now, it only supports changing the colors.
* New methods on `ComputedNode` that compute the geometry for a UI node's scrollbars:
    * `horizontal_scrollbar_gutter`
    * `vertical_scrollbar_gutter`
    * `horizontal_scrollbar_thumb`,
    * `vertical_scrollbar_thumb`

## Testing

```
cargo run --example scroll
```

## Showcase

<img width="1924" height="1127" alt="Screenshot 2025-11-20 165637" src="https://github.com/user-attachments/assets/98f56f22-8454-4b78-95f1-52411d35fd3c" />
