### PR TITLE
Fix `MaterialExtension::enable_shadows` and disable shadows for forward decals

### DIFF
--- a/crates/bevy_pbr/src/decal/forward.rs
+++ b/crates/bevy_pbr/src/decal/forward.rs
@@ -115,6 +115,10 @@ impl MaterialExtension for ForwardDecalMaterialExt {
         Some(AlphaMode::Blend)
     }
 
+    fn enable_shadows() -> bool {
+        false
+    }
+
     fn specialize(
         _pipeline: &MaterialExtensionPipeline,
         descriptor: &mut RenderPipelineDescriptor,

--- a/crates/bevy_pbr/src/extended_material.rs
+++ b/crates/bevy_pbr/src/extended_material.rs
@@ -352,7 +352,7 @@ impl<B: Material, E: MaterialExtension> Material for ExtendedMaterial<B, E> {
     }
 
     fn enable_shadows() -> bool {
-        E::enable_prepass()
+        E::enable_shadows()
     }
 
     fn prepass_vertex_shader() -> ShaderRef {


### PR DESCRIPTION
# Objective

`MaterialExtension::enable_shadows` wrongly returns `E::enable_prepass()` instead of `E::enable_shadows()`

## Solution

Fix it.

Also disable shadows for forward decals because decals typically should not cast shadows.

## Testing

Run the decals example.