### PR TITLE
Replace `BTreeMap` with `IndexMap` for stored `ScheduleBuildPass`es

### DIFF
--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -10,7 +10,10 @@ use alloc::{
     vec,
     vec::Vec,
 };
-use bevy_platform::collections::{HashMap, HashSet};
+use bevy_platform::{
+    collections::{HashMap, HashSet},
+    hash::FixedHasher,
+};
 use bevy_utils::{default, TypeIdMap};
 use core::{
     any::{Any, TypeId},
@@ -698,7 +701,7 @@ pub struct ScheduleGraph {
     anonymous_sets: usize,
     changed: bool,
     settings: ScheduleBuildSettings,
-    passes: IndexMap<TypeId, Box<dyn ScheduleBuildPassObj>>,
+    passes: IndexMap<TypeId, Box<dyn ScheduleBuildPassObj>, FixedHasher>,
 }
 
 impl ScheduleGraph {


### PR DESCRIPTION
# Objective

- Part of #20115

We currently store schedule build passes as a `BTreeMap<TypeId, _>`; however `TypeId` doesn't have a useful ordering for us, and is subject to change across compiles.

## Solution

Switch to a `IndexMap<TypeId, _>`, so we can iterate in insertion order instead.

## Testing

Added a test to ensure consistent iteration order.