### PR TITLE
Solari: Fix energy loss from rgb9e5 light tile packing

### DIFF
--- a/crates/bevy_solari/src/realtime/presample_light_tiles.wgsl
+++ b/crates/bevy_solari/src/realtime/presample_light_tiles.wgsl
@@ -40,7 +40,7 @@ fn pack_resolved_light_sample(sample: ResolvedLightSample) -> ResolvedLightSampl
         sample.world_position.y,
         sample.world_position.z,
         pack2x16unorm(octahedral_encode(sample.world_normal)),
-        vec3_to_rgb9e5_(sample.radiance * view.exposure),
+        vec3_to_rgb9e5_(log2(sample.radiance * view.exposure + 1.0)),
         sample.inverse_pdf * select(1.0, -1.0, sample.world_position.w == 0.0),
     );
 }
@@ -49,7 +49,7 @@ fn unpack_resolved_light_sample(packed: ResolvedLightSamplePacked, exposure: f32
     return ResolvedLightSample(
         vec4(packed.world_position_x, packed.world_position_y, packed.world_position_z, select(1.0, 0.0, packed.inverse_pdf < 0.0)),
         octahedral_decode(unpack2x16unorm(packed.world_normal)),
-        rgb9e5_to_vec3_(packed.radiance) / exposure,
+        (exp2(rgb9e5_to_vec3_(packed.radiance)) - 1.0) / exposure,
         abs(packed.inverse_pdf),
     );
 }


### PR DESCRIPTION
After many many hours of debugging, I narrowed down the energy loss in solari to rgb9e5float issues.

All credit to @SparkyPotato for the solution, which is to use a log scale.

With this fix:
<img width="2564" height="1500" alt="image" src="https://github.com/user-attachments/assets/96d34e39-b2e6-48aa-97f3-aeea835d1305" />

Without this fix:
<img width="2564" height="1500" alt="image" src="https://github.com/user-attachments/assets/83be5dc0-e6ca-4561-bdcc-c5ecd8db51a4" />

Pathtraced reference:
<img width="2564" height="1500" alt="image" src="https://github.com/user-attachments/assets/cdd73e51-7e60-486d-8868-446a0c46bd1a" />