### PR TITLE
Remove unused `num_workgroups` from game_of_life shader

### DIFF
--- a/assets/shaders/game_of_life.wgsl
+++ b/assets/shaders/game_of_life.wgsl
@@ -30,7 +30,7 @@ fn randomFloat(value: u32) -> f32 {
 }
 
 @compute @workgroup_size(8, 8, 1)
-fn init(@builtin(global_invocation_id) invocation_id: vec3<u32>, @builtin(num_workgroups) num_workgroups: vec3<u32>) {
+fn init(@builtin(global_invocation_id) invocation_id: vec3<u32>) {
     let location = vec2<i32>(i32(invocation_id.x), i32(invocation_id.y));
 
     let randomNumber = randomFloat((invocation_id.y << 16u) | invocation_id.x);


### PR DESCRIPTION
# Objective

Remove unused `num_workgroups`.

## Testing

```
cargo run --example compute_shader_game_of_life
```
