### PR TITLE
Use RayMap and RenderLayers in bevy_sprite/picking_backend

### DIFF
--- a/crates/bevy_sprite/src/picking_backend.rs
+++ b/crates/bevy_sprite/src/picking_backend.rs
@@ -287,5 +287,5 @@ fn sprite_picking(
 
     pick_sets.for_each(|(pointer, picks, order)| {
         pointer_hits_writer.write(PointerHits::new(pointer, picks, order as f32));
-    })
+    });
 }


### PR DESCRIPTION
# Credit
- @bytemunch for the original PR and the brunt of the work
- @akimakinai for reviewing and introducing an important change to the RenderLayers logic

# Objective

- Adoption of the PR found [here](https://github.com/bevyengine/bevy/pull/18069) (as was recommended to me on the bevy discord)
- I upgraded the changes proposed there to work with bevy/main
- This likely fixes a bunch of unintuitive picking behavior around Viewports and RenderLayers. See the original PR for details.

## Solution

- Rewrote parts of `bevy_sprite/picking_backend.rs`. It now iterates over bevy_picking's `RayMap` to generate `PointerHit`s for each viable `Camera`, rather than just the first viable `Camera` found.
- Introduced checking if the `Camera`'s and `Sprite`'s `RenderLayers` intersect before generating a hit.

## Testing

- I tested it with my own game, running on bevy 0.17.3
- I don't expect the behavior to be different for a game built with bevy/main, as it's just the picking backend. However, that is still open for testing.

## What reviewers can test
- Before this change, `PointerHit`s would not generate on viewports of higher order, if their area overlapped with a viewport of lower order. For example, if you had a `Camera` render to the entire window, and then a second `Camera` render a smaller viewport on top, the smaller viewport would not detect `PointerHit`s. This should be fixed now.
- Before this change, a `Camera` not on the default `RenderLayers` layer, would generate and consume `PointerHit`s, even if it did not share any layers with the picked `Sprite`s. This could also block `Sprite`s from being picked at all. This should be fixed now.

## Extra note
The behavior of the picking backend is now to produce `PointerHit`s for each viable viewport under the cursor. This can lead to the unintuitive result, that you can pick a `Sprite` you can not see, due to being obscured by another viewport.
I have a solution for this and it would be a flag in `SpritePickingSettings`. Should I open a new PR for this or enter a discussion?