### PR TITLE
Don't render meshes that have prepass disabled to the prepass, even if they have shadows enabled.

### DIFF
--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -897,7 +897,7 @@ pub fn specialize_prepass_material_meshes(
             let Some(material) = render_materials.get(material_instance.asset_id) else {
                 continue;
             };
-            if !material.properties.prepass_enabled && !material.properties.shadows_enabled {
+            if !material.properties.prepass_enabled {
                 // If the material was previously specialized for prepass, remove it
                 view_specialized_material_pipeline_cache.remove(visible_entity);
                 continue;


### PR DESCRIPTION
Currently, the `specialize_prepass_material_meshes` function adds meshes to the prepass unless both `prepass_enabled` *and* `shadows_enabled` are false for that material. This seems incorrect, as (1) the flags are separate for a reason and (2) meshes are added to the shadow pass not in `specialize_prepass_material_meshes` but in `specialize_shadows`.

This patch changes `specialize_prepass_material_meshes` to skip adding meshes to the prepass if `prepass_enabled` is false, even if `shadows_enabled` is true.