### PR TITLE
Make items public that are necessary to add custom prepasses in application code.

### DIFF
--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -331,8 +331,8 @@ pub fn init_prepass_pipeline(
 }
 
 pub struct PrepassPipelineSpecializer {
-    pub(crate) pipeline: PrepassPipeline,
-    pub(crate) properties: Arc<MaterialProperties>,
+    pub pipeline: PrepassPipeline,
+    pub properties: Arc<MaterialProperties>,
 }
 
 impl SpecializedMeshPipeline for PrepassPipelineSpecializer {

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -1639,7 +1639,7 @@ fn extract_mesh_for_gpu_building(
 /// [`crate::material::queue_material_meshes`] check the skin and morph target
 /// tables for each mesh, but that would be too slow in the hot mesh queuing
 /// loop.
-pub(crate) fn set_mesh_motion_vector_flags(
+pub fn set_mesh_motion_vector_flags(
     mut render_mesh_instances: ResMut<RenderMeshInstances>,
     skin_uniforms: Res<SkinUniforms>,
     morph_indices: Res<MorphIndices>,


### PR DESCRIPTION
Currently, custom prepasses can't be easily added outside the `bevy_pbr` crate for two reasons:

1. The fields in `PrepassSpecializer` are private to the `bevy_pbr` crate, so a `PrepassSpecializer` can't be constructed. Furthermore, the `PrepassSpecializer::specialize` method itself calls private APIs, so a developer can't even copy and paste the `PrepassSpecializer` into application code.

2. The `set_mesh_motion_vector_flags` system is private, meaning that specialization systems for custom prepasses can't be ordered after it. This is a problem because those specialization systems may need to read the motion vector flags that that system sets.

This commit changes the fields in `PrepassSpecializer` to be public and also changes the `set_mesh_motion_vector_flags` system to be public.