### PR TITLE
Update hashbrown to 0.16.1

### DIFF
--- a/crates/bevy_platform/Cargo.toml
+++ b/crates/bevy_platform/Cargo.toml
@@ -67,7 +67,7 @@ spin = { version = "0.10.0", default-features = false, features = [
   "barrier",
 ] }
 foldhash = { version = "0.2.0", default-features = false }
-hashbrown = { version = "0.16.0", features = [
+hashbrown = { version = "0.16.1", features = [
   "equivalent",
   "raw-entry",
 ], optional = true, default-features = false }


### PR DESCRIPTION
# Objective

- `hashbrown` 0.16.0 does not provide `get_disjoint_key_value_mut()`, which is used in `crates\bevy_platform\src\collections\hash_map.rs `, We must update to hashbrown 0.16.1, which includes this method.

## Testing

- CI

---
