### PR TITLE
Fix the doc test for WebAssetPlugin

### DIFF
--- a/crates/bevy_asset/src/io/web.rs
+++ b/crates/bevy_asset/src/io/web.rs
@@ -23,12 +23,12 @@ use tracing::warn;
 /// Example usage:
 ///
 /// ```rust
-/// # use bevy_app::{App, Startup};
-/// # use bevy_ecs::prelude::{Commands, Res};
-/// # use bevy_asset::web::{WebAssetPlugin, AssetServer};
+/// # use bevy_app::{App, Startup, TaskPoolPlugin};
+/// # use bevy_ecs::prelude::{Commands, Component, Res};
+/// # use bevy_asset::{Asset, AssetApp, AssetPlugin, AssetServer, Handle, io::web::WebAssetPlugin};
+/// # use bevy_reflect::TypePath;
 /// # struct DefaultPlugins;
-/// # impl DefaultPlugins { fn set(plugin: WebAssetPlugin) -> WebAssetPlugin { plugin } }
-/// # use bevy_asset::web::AssetServer;
+/// # impl DefaultPlugins { fn set(&self, plugin: WebAssetPlugin) -> WebAssetPlugin { plugin } }
 /// # #[derive(Asset, TypePath, Default)]
 /// # struct Image;
 /// # #[derive(Component)]
@@ -36,6 +36,8 @@ use tracing::warn;
 /// # impl Sprite { fn from_image(_: Handle<Image>) -> Self { Sprite } }
 /// # fn main() {
 /// App::new()
+/// #   .add_plugins((TaskPoolPlugin::default(), AssetPlugin::default()))
+/// #   .init_asset::<Image>()
 ///     .add_plugins(DefaultPlugins.set(WebAssetPlugin {
 ///         silence_startup_warning: true,
 ///     }))

--- a/crates/bevy_asset/src/io/web.rs
+++ b/crates/bevy_asset/src/io/web.rs
@@ -36,11 +36,11 @@ use tracing::warn;
 /// # impl Sprite { fn from_image(_: Handle<Image>) -> Self { Sprite } }
 /// # fn main() {
 /// App::new()
-/// #   .add_plugins((TaskPoolPlugin::default(), AssetPlugin::default()))
-/// #   .init_asset::<Image>()
 ///     .add_plugins(DefaultPlugins.set(WebAssetPlugin {
 ///         silence_startup_warning: true,
 ///     }))
+/// #   .add_plugins((TaskPoolPlugin::default(), AssetPlugin::default()))
+/// #   .init_asset::<Image>()
 /// #   .add_systems(Startup, setup).run();
 /// # }
 /// // ...


### PR DESCRIPTION
# Objective

- Fix `cargo t -p bevy_asset --all-features`.
    - Note: `all-features` do not run on CI!
- The doc tests for the `WebAssetPlugin` don't compile at all. There are bad imports and we don't even add the `AssetPlugin`.

## Solution

- Add missing imports, and add missing plugins to the `App`.

## Testing

- Ran `cargo t -p bevy_asset --all-features` and it passes now!