### PR TITLE
Fix bevy_math when no alloc is available

### DIFF
--- a/crates/bevy_math/Cargo.toml
+++ b/crates/bevy_math/Cargo.toml
@@ -24,7 +24,7 @@ libm = { version = "0.2", optional = true }
 approx = { version = "0.5", default-features = false, optional = true }
 rand = { version = "0.9", default-features = false, optional = true }
 rand_distr = { version = "0.5", optional = true }
-smallvec = { version = "1", default-features = false }
+arrayvec = { version = "0.7", default-features = false }
 bevy_reflect = { path = "../bevy_reflect", version = "0.18.0-dev", default-features = false, features = [
   "glam",
 ], optional = true }

--- a/crates/bevy_math/src/bounding/bounded2d/primitive_impls.rs
+++ b/crates/bevy_math/src/bounding/bounded2d/primitive_impls.rs
@@ -14,7 +14,7 @@ use core::f32::consts::{FRAC_PI_2, PI, TAU};
 #[cfg(feature = "alloc")]
 use crate::primitives::{ConvexPolygon, Polygon, Polyline2d};
 
-use smallvec::SmallVec;
+use arrayvec::ArrayVec;
 
 use super::{Aabb2d, Bounded2d, BoundingCircle};
 
@@ -33,10 +33,10 @@ impl Bounded2d for Circle {
 // Compute the axis-aligned bounding points of a rotated arc, used for computing the AABB of arcs and derived shapes.
 // The return type has room for 7 points so that the CircularSector code can add an additional point.
 #[inline]
-fn arc_bounding_points(arc: Arc2d, rotation: impl Into<Rot2>) -> SmallVec<[Vec2; 7]> {
+fn arc_bounding_points(arc: Arc2d, rotation: impl Into<Rot2>) -> ArrayVec<Vec2, 7> {
     // Otherwise, the extreme points will always be either the endpoints or the axis-aligned extrema of the arc's circle.
     // We need to compute which axis-aligned extrema are actually contained within the rotated arc.
-    let mut bounds = SmallVec::<[Vec2; 7]>::new();
+    let mut bounds = ArrayVec::<Vec2, 7>::new();
     let rotation = rotation.into();
     bounds.push(rotation * arc.left_endpoint());
     bounds.push(rotation * arc.right_endpoint());

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -1727,13 +1727,14 @@ impl Triangle2d {
         let ca = a - c;
 
         // a^2 + b^2 < c^2 for an acute triangle
-        let mut side_lengths = [
+        let side_lengths = [
             ab.length_squared(),
             bc.length_squared(),
             ca.length_squared(),
         ];
-        side_lengths.sort_by(|a, b| a.partial_cmp(b).unwrap());
-        side_lengths[0] + side_lengths[1] > side_lengths[2]
+        let sum = side_lengths[0] + side_lengths[1] + side_lengths[2];
+        let max = side_lengths[0].max(side_lengths[1]).max(side_lengths[2]);
+        sum - max > max
     }
 
     /// Checks if the triangle is obtuse, meaning one angle is greater than 90 degrees
@@ -1745,13 +1746,14 @@ impl Triangle2d {
         let ca = a - c;
 
         // a^2 + b^2 > c^2 for an obtuse triangle
-        let mut side_lengths = [
+        let side_lengths = [
             ab.length_squared(),
             bc.length_squared(),
             ca.length_squared(),
         ];
-        side_lengths.sort_by(|a, b| a.partial_cmp(b).unwrap());
-        side_lengths[0] + side_lengths[1] < side_lengths[2]
+        let sum = side_lengths[0] + side_lengths[1] + side_lengths[2];
+        let max = side_lengths[0].max(side_lengths[1]).max(side_lengths[2]);
+        sum - max < max
     }
 
     /// Reverse the [`WindingOrder`] of the triangle

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -1235,13 +1235,14 @@ impl Triangle3d {
         let ca = a - c;
 
         // a^2 + b^2 < c^2 for an acute triangle
-        let mut side_lengths = [
+        let side_lengths = [
             ab.length_squared(),
             bc.length_squared(),
             ca.length_squared(),
         ];
-        side_lengths.sort_by(|a, b| a.partial_cmp(b).unwrap());
-        side_lengths[0] + side_lengths[1] > side_lengths[2]
+        let sum = side_lengths[0] + side_lengths[1] + side_lengths[2];
+        let max = side_lengths[0].max(side_lengths[1]).max(side_lengths[2]);
+        sum - max > max
     }
 
     /// Checks if the triangle is obtuse, meaning one angle is greater than 90 degrees
@@ -1253,13 +1254,14 @@ impl Triangle3d {
         let ca = a - c;
 
         // a^2 + b^2 > c^2 for an obtuse triangle
-        let mut side_lengths = [
+        let side_lengths = [
             ab.length_squared(),
             bc.length_squared(),
             ca.length_squared(),
         ];
-        side_lengths.sort_by(|a, b| a.partial_cmp(b).unwrap());
-        side_lengths[0] + side_lengths[1] < side_lengths[2]
+        let sum = side_lengths[0] + side_lengths[1] + side_lengths[2];
+        let max = side_lengths[0].max(side_lengths[1]).max(side_lengths[2]);
+        sum - max < max
     }
 
     /// Reverse the triangle by swapping the first and last vertices.


### PR DESCRIPTION
# Objective

`bevy_math` does not work when no `alloc` is available despite the existance of the `alloc` feature which should gate all logic that requires it. Support for no std + no alloc can be useful for some embedded usecases, for example using `bevy_math` types on the GPU using Rust GPU.

## Solution

Swap `smallvec` out with `arrayvec`, and fix two minor uses of `alloc::slice::sort_by` (not available on `core` because they allocate `Vec`s internally)

## Testing

- Unit tests still pass
- I was able to compile a shader with Rust GPU while depending on bevy_math