### PR TITLE
Remove `getrandom` dependency from `bevy_platform`.

### DIFF
--- a/crates/bevy_platform/Cargo.toml
+++ b/crates/bevy_platform/Cargo.toml
@@ -50,7 +50,6 @@ critical-section = ["dep:critical-section", "portable-atomic/critical-section"]
 web = [
   "std",
   "dep:web-time",
-  "dep:getrandom",
   "dep:wasm-bindgen-futures",
   "dep:wasm-bindgen",
   "dep:js-sys",
@@ -76,9 +75,6 @@ rayon = { version = "1", default-features = false, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-time = { version = "1.1", default-features = false, optional = true }
-getrandom = { version = "0.3.0", default-features = false, optional = true, features = [
-  "wasm_js",
-] }
 wasm-bindgen-futures = { version = "0.4", default-features = false, optional = true }
 futures-channel = { version = "0.3", default-features = false }
 js-sys = { version = "0.3", default-features = false, optional = true }


### PR DESCRIPTION
# Objective

Fixes #21336. 

`bevy_platform` and dependents such as `bevy_ecs` may be used on web without incurring the `RUSTFLAGS` requirement of `getrandom`.

## Solution

Remove dependency `bevy_platform` → `getrandom`.

Note: There was a suggestion of adding a dependency `bevy_math` → `getrandom` to replace it, but `bevy_math` does not actually depend transitively on `getrandom` at all (except in its examples), nor does any other Bevy library. If making `getrandom` work is desired for convenience of Bevy users, we could add `bevy_internal/web` → `getrandom/wasm_js`, but that would not be for the use of Bevy itself at all, and it would mean that Bevy users would hit the `RUSTFLAGS` requirement even if they don't truly need it.

## Testing

- Ran `cargo run -p ci -- compile` and `cargo run -p ci -- test`.
- Tested depending on this version of `bevy_ecs` in my own wasm32 project.
- Have not tested any further feature combinations.
