### PR TITLE
Add a UiTransform centered scene to examples/testbed/ui

### DIFF
--- a/examples/testbed/ui.rs
+++ b/examples/testbed/ui.rs
@@ -910,7 +910,7 @@ mod transformations {
                     ),
                     (
                         UiTransform::from_scale(Vec2::new(2., 0.5)),
-                        "Scale 2x 0.5.y",
+                        "Scale 2.x 0.5y",
                         GREEN,
                     ),
                     (
@@ -924,7 +924,7 @@ mod transformations {
                             scale: Vec2::new(-1., 1.),
                             rotation: Rot2::degrees(30.),
                         },
-                        "T 50px x\nS -1.x (refl)\nR 30d",
+                        "T 50px x\nS -1.x (refl)\nR 30deg",
                         DARK_CYAN,
                     ),
                 ] {
@@ -946,6 +946,7 @@ mod transformations {
                                 Node {
                                     width: px(100),
                                     height: px(100),
+                                    border_radius: BorderRadius::bottom_right(px(25.)),
                                     ..default()
                                 },
                                 BackgroundColor(background.into()),
@@ -956,6 +957,7 @@ mod transformations {
                                 Node {
                                     width: px(100),
                                     height: px(100),
+                                    border_radius: BorderRadius::bottom_right(px(25.)),
                                     ..default()
                                 },
                                 BackgroundColor(background.into()),


### PR DESCRIPTION
# Objective

Fixes #21815 

## Solution

- Adds a new scene to `examples/testbed/ui` called `Transformations` that calls some basic `UiTransform`s on Nodes.

This is my first PR for Bevy!

## Testing

I ran the example via console to test out the scene.

Tested on Desktop MacOS 15.7.1

## Showcase

<img width="902" height="780" alt="Screenshot 2025-11-29 at 11 29 52 AM" src="https://github.com/user-attachments/assets/602ab485-61dd-4887-a0ad-0624b3d79db8" />

To view, run in console: `cargo run --package bevy --example testbed_ui`
Press spacebar 11x until you see the new scene.
