### PR TITLE
Added required features data to docs export

### DIFF
--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -596,6 +596,7 @@ code_path = \"content/examples{}/{}\"
 shader_code_paths = {:?}
 github_code_path = \"{}\"
 header_message = \"Examples ({})\"
+required_features = {:?}
 +++
 
 {}
@@ -637,6 +638,7 @@ header_message = \"Examples ({})\"
                                 WebApi::Webgpu => "WebGPU",
                                 WebApi::Webgl2 => "WebGL2",
                             },
+                            to_show.required_features,
                             docblock,
                         )
                         .as_bytes(),


### PR DESCRIPTION
# Objective

This PR is a sister PR necessary for the website to have `required_features` data.
You will find more information on the motivations there: https://github.com/bevyengine/bevy-website/pull/2313

## Solution

- Add the required_features data to the examples docs export

## Testing

I tested both together and it worked fine
