### PR TITLE
Fix crash on exit due to destroyed surface texture

### DIFF
--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -1048,17 +1048,16 @@ pub fn prepare_view_targets(
 ) {
     let mut textures = <HashMap<_, _>>::default();
     for (entity, camera, view, texture_usage, msaa) in cameras.iter() {
-        let (Some(target_size), Some(target)) = (camera.physical_target_size, &camera.target)
-        else {
-            commands.entity(entity).try_remove::<ViewTarget>();
-
-            continue;
-        };
-
-        let Some(out_attachment) = view_target_attachments.get(target) else {
-			// If we can't find an output attachment we need to remove the ViewTarget 
-			// component to make sure the camera doesn't try rendering to an invalid 
-			// output attachment.
+        let (Some(target_size), Some(out_attachment)) = (
+            camera.physical_target_size,
+            camera
+                .target
+                .as_ref()
+                .and_then(|target| view_target_attachments.get(target)),
+        ) else {
+            // If we can't find an output attachment we need to remove the ViewTarget
+            // component to make sure the camera doesn't try rendering to an invalid
+            // output attachment.
             commands.entity(entity).try_remove::<ViewTarget>();
 
             continue;


### PR DESCRIPTION
# Objective

Fix crash when a window is closed on current main

<details>
  <summary>Crash log</summary>

```
❯ RUST_BACKTRACE=full cargo run --example 3d_scene -F dev
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.17s
     Running `target/debug/examples/3d_scene`
2025-11-29T21:39:06.551816Z  INFO bevy_diagnostic::system_information_diagnostics_plugin::internal: SystemInfo { os: "Linux (Arch Linux rolling)", kernel: "6.17.9-arch1-1", cpu: "AMD Ryzen 9 9950X 16-Core Processor", core_count: "16", memory: "186.4 GiB" }
2025-11-29T21:39:06.589438Z  INFO bevy_render::renderer: AdapterInfo { name: "NVIDIA GeForce RTX 5080", vendor: 4318, device: 11266, device_type: DiscreteGpu, driver: "NVIDIA", driver_info: "580.105.08", backend: Vulkan }
2025-11-29T21:39:06.953148Z  INFO bevy_render::batching::gpu_preprocessing: GPU preprocessing is fully supported on this device.
2025-11-29T21:39:06.959263Z  INFO bevy_winit::system: Creating new window 3d_scene (0v0)
2025-11-29T21:39:09.503214Z  INFO bevy_window::system: No windows are open, exiting
2025-11-29T21:39:09.504687Z  INFO bevy_winit::system: Closing window 0v0
2025-11-29T21:39:09.510808Z ERROR wgpu::backend::wgpu_core: Handling wgpu errors as fatal by default

thread '<unnamed>' (664835) panicked at /home/ssingh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/wgpu-26.0.1/src/backend/wgpu_core.rs:1852:22:
wgpu error: Validation Error

Caused by:
  In Queue::submit
    In a pass parameter
      Texture with '<Surface Texture>' label has been destroyed


stack backtrace:
   0:     0x557069cd5e42 - std[cbf56a46dac989f5]::backtrace_rs::backtrace::libunwind::trace
                               at /rustc/cc3eee7fbe17ea4b7238531cb97e1b7b8bd6afce/library/std/src/../../backtrace/src/backtrace/libunwind.rs:117:9
   1:     0x557069cd5e42 - std[cbf56a46dac989f5]::backtrace_rs::backtrace::trace_unsynchronized::<std[cbf56a46dac989f5]::sys::backtrace::_print_fmt::{closure#1}>
                               at /rustc/cc3eee7fbe17ea4b7238531cb97e1b7b8bd6afce/library/std/src/../../backtrace/src/backtrace/mod.rs:66:14
   2:     0x557069cd5e42 - std[cbf56a46dac989f5]::sys::backtrace::_print_fmt
                               at /rustc/cc3eee7fbe17ea4b7238531cb97e1b7b8bd6afce/library/std/src/sys/backtrace.rs:68:9
   3:     0x557069cd5e42 - <<std[cbf56a46dac989f5]::sys::backtrace::BacktraceLock>::print::DisplayBacktrace as core[a3424aac13c77cf6]::fmt::Display>::fmt
                               at /rustc/cc3eee7fbe17ea4b7238531cb97e1b7b8bd6afce/library/std/src/sys/backtrace.rs:38:26
   4:     0x557069cf05e7 - <core[a3424aac13c77cf6]::fmt::rt::Argument>::fmt
                               at /rustc/cc3eee7fbe17ea4b7238531cb97e1b7b8bd6afce/library/core/src/fmt/rt.rs:152:76
   5:     0x557069cf05e7 - core[a3424aac13c77cf6]::fmt::write
   6:     0x557069cdc5d6 - std[cbf56a46dac989f5]::io::default_write_fmt::<std[cbf56a46dac989f5]::sys::stdio::unix::Stderr>
                               at /rustc/cc3eee7fbe17ea4b7238531cb97e1b7b8bd6afce/library/std/src/io/mod.rs:639:11
   7:     0x557069cdc5d6 - <std[cbf56a46dac989f5]::sys::stdio::unix::Stderr as std[cbf56a46dac989f5]::io::Write>::write_fmt
                               at /rustc/cc3eee7fbe17ea4b7238531cb97e1b7b8bd6afce/library/std/src/io/mod.rs:1994:13
   8:     0x557069cb255a - <std[cbf56a46dac989f5]::sys::backtrace::BacktraceLock>::print
                               at /rustc/cc3eee7fbe17ea4b7238531cb97e1b7b8bd6afce/library/std/src/sys/backtrace.rs:41:9
   9:     0x557069cb255a - std[cbf56a46dac989f5]::panicking::default_hook::{closure#0}
                               at /rustc/cc3eee7fbe17ea4b7238531cb97e1b7b8bd6afce/library/std/src/panicking.rs:292:27
  10:     0x557069cce7e1 - std[cbf56a46dac989f5]::panicking::default_hook
                               at /rustc/cc3eee7fbe17ea4b7238531cb97e1b7b8bd6afce/library/std/src/panicking.rs:319:9
  11:     0x5570696cd6b3 - <alloc[9fa3fef380221c31]::boxed::Box<dyn for<'a, 'b> core[a3424aac13c77cf6]::ops::function::Fn<(&'a std[cbf56a46dac989f5]::panic::PanicHookInfo<'b>,), Output = ()> + core[a3424aac13c77cf6]::marker::Send + core[a3424aac13c77cf6]::marker::Sync> as core[a3424aac13c77cf6]::ops::function::Fn<(&std[cbf56a46dac989f5]::panic::PanicHookInfo,)>>::call
                               at /home/ssingh/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/boxed.rs:2220:9
  12:     0x5570696b9081 - bevy_ecs[ae55bfe1c74e77a3]::error::bevy_error::bevy_error_panic_hook::<alloc[9fa3fef380221c31]::boxed::Box<dyn for<'a, 'b> core[a3424aac13c77cf6]::ops::function::Fn<(&'a std[cbf56a46dac989f5]::panic::PanicHookInfo<'b>,), Output = ()> + core[a3424aac13c77cf6]::marker::Send + core[a3424aac13c77cf6]::marker::Sync>>::{closure#0}
                               at /home/ssingh/Projects/bevy/crates/bevy_ecs/src/error/bevy_error.rs:162:9
  13:     0x557069ccea82 - <alloc[9fa3fef380221c31]::boxed::Box<dyn for<'a, 'b> core[a3424aac13c77cf6]::ops::function::Fn<(&'a std[cbf56a46dac989f5]::panic::PanicHookInfo<'b>,), Output = ()> + core[a3424aac13c77cf6]::marker::Send + core[a3424aac13c77cf6]::marker::Sync> as core[a3424aac13c77cf6]::ops::function::Fn<(&std[cbf56a46dac989f5]::panic::PanicHookInfo,)>>::call
                               at /rustc/cc3eee7fbe17ea4b7238531cb97e1b7b8bd6afce/library/alloc/src/boxed.rs:2220:9
  14:     0x557069ccea82 - std[cbf56a46dac989f5]::panicking::panic_with_hook
                               at /rustc/cc3eee7fbe17ea4b7238531cb97e1b7b8bd6afce/library/std/src/panicking.rs:833:13
  15:     0x557069cb2618 - std[cbf56a46dac989f5]::panicking::panic_handler::{closure#0}
                               at /rustc/cc3eee7fbe17ea4b7238531cb97e1b7b8bd6afce/library/std/src/panicking.rs:698:13
  16:     0x557069ca9779 - std[cbf56a46dac989f5]::sys::backtrace::__rust_end_short_backtrace::<std[cbf56a46dac989f5]::panicking::panic_handler::{closure#0}, !>
                               at /rustc/cc3eee7fbe17ea4b7238531cb97e1b7b8bd6afce/library/std/src/sys/backtrace.rs:176:18
  17:     0x557069cb37cd - __rustc[f3f8441e4970532f]::rust_begin_unwind
                               at /rustc/cc3eee7fbe17ea4b7238531cb97e1b7b8bd6afce/library/std/src/panicking.rs:689:5
  18:     0x557069cf0d5c - core[a3424aac13c77cf6]::panicking::panic_fmt
                               at /rustc/cc3eee7fbe17ea4b7238531cb97e1b7b8bd6afce/library/core/src/panicking.rs:80:14
  19:     0x5570675ffab5 - wgpu[932fed8fce9d4b4b]::backend::wgpu_core::default_error_handler
                               at /home/ssingh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/wgpu-26.0.1/src/backend/wgpu_core.rs:659:5
  20:     0x5570675ff6e5 - <wgpu[932fed8fce9d4b4b]::backend::wgpu_core::ErrorSinkRaw>::handle_error
                               at /home/ssingh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/wgpu-26.0.1/src/backend/wgpu_core.rs:643:21
  21:     0x5570675ff3f4 - <wgpu[932fed8fce9d4b4b]::backend::wgpu_core::ContextWgpuCore>::handle_error_inner
                               at /home/ssingh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/wgpu-26.0.1/src/backend/wgpu_core.rs:298:14
  22:     0x5570675fcda3 - <wgpu[932fed8fce9d4b4b]::backend::wgpu_core::ContextWgpuCore>::handle_error_nolabel::<wgpu_core[2f77c8d0c0f83b61]::device::queue::QueueSubmitError>
                               at /home/ssingh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/wgpu-26.0.1/src/backend/wgpu_core.rs:323:14
  23:     0x55706760ed17 - <wgpu[932fed8fce9d4b4b]::backend::wgpu_core::CoreQueue as wgpu[932fed8fce9d4b4b]::dispatch::QueueInterface>::submit
                               at /home/ssingh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/wgpu-26.0.1/src/backend/wgpu_core.rs:1852:22
  24:     0x5570672eef2a - <wgpu[932fed8fce9d4b4b]::api::queue::Queue>::submit::<alloc[9fa3fef380221c31]::vec::Vec<wgpu[932fed8fce9d4b4b]::api::command_buffer::CommandBuffer>>
                               at /home/ssingh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/wgpu-26.0.1/src/api/queue.rs:253:32
  25:     0x557066f4965c - <bevy_render[cbe98d17828001b5]::renderer::graph_runner::RenderGraphRunner>::run::<bevy_render[cbe98d17828001b5]::renderer::render_system::{closure#1}>
                               at /home/ssingh/Projects/bevy/crates/bevy_render/src/renderer/graph_runner.rs:87:19
  26:     0x5570670a05ad - bevy_render[cbe98d17828001b5]::renderer::render_system
                               at /home/ssingh/Projects/bevy/crates/bevy_render/src/renderer/mod.rs:48:15
  27:     0x55706744d021 - <bevy_render[cbe98d17828001b5]::renderer::render_system as core[a3424aac13c77cf6]::ops::function::FnMut<(&mut bevy_ecs[ae55bfe1c74e77a3]::world::World, &mut bevy_ecs[ae55bfe1c74e77a3]::system::function_system::SystemState<bevy_ecs[ae55bfe1c74e77a3]::system::query::Query<(&bevy_render[cbe98d17828001b5]::view::ViewTarget, &bevy_render[cbe98d17828001b5]::camera::ExtractedCamera)>>)>>::call_mut
                               at /home/ssingh/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:166:5
  28:     0x5570670ad864 - <&mut bevy_render[cbe98d17828001b5]::renderer::render_system as core[a3424aac13c77cf6]::ops::function::FnMut<(&mut bevy_ecs[ae55bfe1c74e77a3]::world::World, &mut bevy_ecs[ae55bfe1c74e77a3]::system::function_system::SystemState<bevy_ecs[ae55bfe1c74e77a3]::system::query::Query<(&bevy_render[cbe98d17828001b5]::view::ViewTarget, &bevy_render[cbe98d17828001b5]::camera::ExtractedCamera)>>)>>::call_mut
                               at /home/ssingh/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:298:21
  29:     0x55706735dc8e - <_ as bevy_ecs[ae55bfe1c74e77a3]::system::exclusive_function_system::ExclusiveSystemParamFunction<fn(_) -> _>>::run::call_inner::<(), &mut bevy_ecs[ae55bfe1c74e77a3]::system::function_system::SystemState<bevy_ecs[ae55bfe1c74e77a3]::system::query::Query<(&bevy_render[cbe98d17828001b5]::view::ViewTarget, &bevy_render[cbe98d17828001b5]::camera::ExtractedCamera)>>, &mut bevy_render[cbe98d17828001b5]::renderer::render_system>
                               at /home/ssingh/Projects/bevy/crates/bevy_ecs/src/system/exclusive_function_system.rs:270:21
  30:     0x5570670ad95e - <bevy_render[cbe98d17828001b5]::renderer::render_system as bevy_ecs[ae55bfe1c74e77a3]::system::exclusive_function_system::ExclusiveSystemParamFunction<fn(&mut bevy_ecs[ae55bfe1c74e77a3]::system::function_system::SystemState<bevy_ecs[ae55bfe1c74e77a3]::system::query::Query<(&bevy_render[cbe98d17828001b5]::view::ViewTarget, &bevy_render[cbe98d17828001b5]::camera::ExtractedCamera)>>)>>::run
                               at /home/ssingh/Projects/bevy/crates/bevy_ecs/src/system/exclusive_function_system.rs:273:17
  31:     0x55706735e0ab - <bevy_ecs[ae55bfe1c74e77a3]::system::exclusive_function_system::ExclusiveFunctionSystem<fn(&mut bevy_ecs[ae55bfe1c74e77a3]::system::function_system::SystemState<bevy_ecs[ae55bfe1c74e77a3]::system::query::Query<(&bevy_render[cbe98d17828001b5]::view::ViewTarget, &bevy_render[cbe98d17828001b5]::camera::ExtractedCamera)>>), (), bevy_render[cbe98d17828001b5]::renderer::render_system> as bevy_ecs[ae55bfe1c74e77a3]::system::system::System>::run_unsafe::{closure#0}
                               at /home/ssingh/Projects/bevy/crates/bevy_ecs/src/system/exclusive_function_system.rs:135:33
  32:     0x55706702ac65 - <bevy_ecs[ae55bfe1c74e77a3]::world::World>::last_change_tick_scope::<core[a3424aac13c77cf6]::result::Result<(), bevy_ecs[ae55bfe1c74e77a3]::system::system::RunSystemError>, <bevy_ecs[ae55bfe1c74e77a3]::system::exclusive_function_system::ExclusiveFunctionSystem<fn(&mut bevy_ecs[ae55bfe1c74e77a3]::system::function_system::SystemState<bevy_ecs[ae55bfe1c74e77a3]::system::query::Query<(&bevy_render[cbe98d17828001b5]::view::ViewTarget, &bevy_render[cbe98d17828001b5]::camera::ExtractedCamera)>>), (), bevy_render[cbe98d17828001b5]::renderer::render_system> as bevy_ecs[ae55bfe1c74e77a3]::system::system::System>::run_unsafe::{closure#0}>
                               at /home/ssingh/Projects/bevy/crates/bevy_ecs/src/world/mod.rs:3070:9
  33:     0x55706735eb0a - <bevy_ecs[ae55bfe1c74e77a3]::system::exclusive_function_system::ExclusiveFunctionSystem<fn(&mut bevy_ecs[ae55bfe1c74e77a3]::system::function_system::SystemState<bevy_ecs[ae55bfe1c74e77a3]::system::query::Query<(&bevy_render[cbe98d17828001b5]::view::ViewTarget, &bevy_render[cbe98d17828001b5]::camera::ExtractedCamera)>>), (), bevy_render[cbe98d17828001b5]::renderer::render_system> as bevy_ecs[ae55bfe1c74e77a3]::system::system::System>::run_unsafe
                               at /home/ssingh/Projects/bevy/crates/bevy_ecs/src/system/exclusive_function_system.rs:113:15
  34:     0x55706735f7ab - <bevy_ecs[ae55bfe1c74e77a3]::system::exclusive_function_system::ExclusiveFunctionSystem<fn(&mut bevy_ecs[ae55bfe1c74e77a3]::system::function_system::SystemState<bevy_ecs[ae55bfe1c74e77a3]::system::query::Query<(&bevy_render[cbe98d17828001b5]::view::ViewTarget, &bevy_render[cbe98d17828001b5]::camera::ExtractedCamera)>>), (), bevy_render[cbe98d17828001b5]::renderer::render_system> as bevy_ecs[ae55bfe1c74e77a3]::system::system::System>::run_without_applying_deferred
                               at /home/ssingh/Projects/bevy/crates/bevy_ecs/src/system/system.rs:138:23
  35:     0x55706735f806 - <bevy_ecs[ae55bfe1c74e77a3]::system::exclusive_function_system::ExclusiveFunctionSystem<fn(&mut bevy_ecs[ae55bfe1c74e77a3]::system::function_system::SystemState<bevy_ecs[ae55bfe1c74e77a3]::system::query::Query<(&bevy_render[cbe98d17828001b5]::view::ViewTarget, &bevy_render[cbe98d17828001b5]::camera::ExtractedCamera)>>), (), bevy_render[cbe98d17828001b5]::renderer::render_system> as bevy_ecs[ae55bfe1c74e77a3]::system::system::System>::run
                               at /home/ssingh/Projects/bevy/crates/bevy_ecs/src/system/system.rs:119:24
  36:     0x55706988d090 - bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::__rust_begin_short_backtrace::run
                               at /home/ssingh/Projects/bevy/crates/bevy_ecs/src/schedule/executor/mod.rs:288:29
  37:     0x5570697be94d - <bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::ExecutorState>::spawn_exclusive_system_task::{closure#1}::{closure#0}
                               at /home/ssingh/Projects/bevy/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs:742:25
  38:     0x5570697254f9 - <<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::ExecutorState>::spawn_exclusive_system_task::{closure#1}::{closure#0} as core[a3424aac13c77cf6]::ops::function::FnOnce<()>>::call_once
                               at /home/ssingh/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
  39:     0x55706977f259 - <core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::ExecutorState>::spawn_exclusive_system_task::{closure#1}::{closure#0}> as core[a3424aac13c77cf6]::ops::function::FnOnce<()>>::call_once
                               at /home/ssingh/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/panic/unwind_safe.rs:274:9
  40:     0x5570697c3253 - std[cbf56a46dac989f5]::panicking::catch_unwind::do_call::<core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::ExecutorState>::spawn_exclusive_system_task::{closure#1}::{closure#0}>, ()>
                               at /home/ssingh/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:581:40
  41:     0x557069887a9b - __rust_try
  42:     0x557069886fae - std[cbf56a46dac989f5]::panicking::catch_unwind::<(), core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::ExecutorState>::spawn_exclusive_system_task::{closure#1}::{closure#0}>>
                               at /home/ssingh/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:544:19
  43:     0x557069886fae - std[cbf56a46dac989f5]::panic::catch_unwind::<core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::ExecutorState>::spawn_exclusive_system_task::{closure#1}::{closure#0}>, ()>
                               at /home/ssingh/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panic.rs:359:14
  44:     0x5570697bf233 - <bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::ExecutorState>::spawn_exclusive_system_task::{closure#1}
                               at /home/ssingh/Projects/bevy/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs:740:27
  45:     0x55706977f642 - <core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::ExecutorState>::spawn_exclusive_system_task::{closure#1}> as core[a3424aac13c77cf6]::future::future::Future>::poll
                               at /home/ssingh/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/panic/unwind_safe.rs:299:9
  46:     0x557069765c04 - <futures_lite[d9f7489fbab33684]::future::CatchUnwind<core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::ExecutorState>::spawn_exclusive_system_task::{closure#1}>> as core[a3424aac13c77cf6]::future::future::Future>::poll::{closure#0}
                               at /home/ssingh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-lite-2.6.1/src/future.rs:653:53
  47:     0x55706977f4f4 - <core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<futures_lite[d9f7489fbab33684]::future::CatchUnwind<core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::ExecutorState>::spawn_exclusive_system_task::{closure#1}>> as core[a3424aac13c77cf6]::future::future::Future>::poll::{closure#0}> as core[a3424aac13c77cf6]::ops::function::FnOnce<()>>::call_once
                               at /home/ssingh/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/panic/unwind_safe.rs:274:9
  48:     0x5570697c374d - std[cbf56a46dac989f5]::panicking::catch_unwind::do_call::<core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<futures_lite[d9f7489fbab33684]::future::CatchUnwind<core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::ExecutorState>::spawn_exclusive_system_task::{closure#1}>> as core[a3424aac13c77cf6]::future::future::Future>::poll::{closure#0}>, core[a3424aac13c77cf6]::task::poll::Poll<()>>
                               at /home/ssingh/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:581:40
  49:     0x557069887a9b - __rust_try
  50:     0x557069887a24 - std[cbf56a46dac989f5]::panicking::catch_unwind::<core[a3424aac13c77cf6]::task::poll::Poll<()>, core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<futures_lite[d9f7489fbab33684]::future::CatchUnwind<core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::ExecutorState>::spawn_exclusive_system_task::{closure#1}>> as core[a3424aac13c77cf6]::future::future::Future>::poll::{closure#0}>>
                               at /home/ssingh/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:544:19
  51:     0x557069887a24 - std[cbf56a46dac989f5]::panic::catch_unwind::<core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<futures_lite[d9f7489fbab33684]::future::CatchUnwind<core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::ExecutorState>::spawn_exclusive_system_task::{closure#1}>> as core[a3424aac13c77cf6]::future::future::Future>::poll::{closure#0}>, core[a3424aac13c77cf6]::task::poll::Poll<()>>
                               at /home/ssingh/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panic.rs:359:14
  52:     0x557069766ae8 - <futures_lite[d9f7489fbab33684]::future::CatchUnwind<core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::ExecutorState>::spawn_exclusive_system_task::{closure#1}>> as core[a3424aac13c77cf6]::future::future::Future>::poll
                               at /home/ssingh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-lite-2.6.1/src/future.rs:653:9
  53:     0x557069892db3 - <async_executor[9f76b1279a3f5047]::AsyncCallOnDrop<futures_lite[d9f7489fbab33684]::future::CatchUnwind<core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::ExecutorState>::spawn_exclusive_system_task::{closure#1}>>, <async_executor[9f76b1279a3f5047]::Executor>::spawn_inner<core[a3424aac13c77cf6]::result::Result<(), alloc[9fa3fef380221c31]::boxed::Box<dyn core[a3424aac13c77cf6]::any::Any + core[a3424aac13c77cf6]::marker::Send>>, futures_lite[d9f7489fbab33684]::future::CatchUnwind<core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::ExecutorState>::spawn_exclusive_system_task::{closure#1}>>>::{closure#0}> as core[a3424aac13c77cf6]::future::future::Future>::poll
                               at /home/ssingh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/async-executor-1.13.2/src/lib.rs:1179:31
  54:     0x557069896c98 - <async_task[6d75e66224110732]::raw::RawTask<async_executor[9f76b1279a3f5047]::AsyncCallOnDrop<futures_lite[d9f7489fbab33684]::future::CatchUnwind<core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::ExecutorState>::spawn_exclusive_system_task::{closure#1}>>, <async_executor[9f76b1279a3f5047]::Executor>::spawn_inner<core[a3424aac13c77cf6]::result::Result<(), alloc[9fa3fef380221c31]::boxed::Box<dyn core[a3424aac13c77cf6]::any::Any + core[a3424aac13c77cf6]::marker::Send>>, futures_lite[d9f7489fbab33684]::future::CatchUnwind<core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::ExecutorState>::spawn_exclusive_system_task::{closure#1}>>>::{closure#0}>, core[a3424aac13c77cf6]::result::Result<(), alloc[9fa3fef380221c31]::boxed::Box<dyn core[a3424aac13c77cf6]::any::Any + core[a3424aac13c77cf6]::marker::Send>>, <async_executor[9f76b1279a3f5047]::Executor>::schedule::{closure#0}, ()>>::run::{closure#1}
                               at /home/ssingh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/async-task-4.7.1/src/raw.rs:550:21
  55:     0x557069725734 - <<async_task[6d75e66224110732]::raw::RawTask<async_executor[9f76b1279a3f5047]::AsyncCallOnDrop<futures_lite[d9f7489fbab33684]::future::CatchUnwind<core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::ExecutorState>::spawn_exclusive_system_task::{closure#1}>>, <async_executor[9f76b1279a3f5047]::Executor>::spawn_inner<core[a3424aac13c77cf6]::result::Result<(), alloc[9fa3fef380221c31]::boxed::Box<dyn core[a3424aac13c77cf6]::any::Any + core[a3424aac13c77cf6]::marker::Send>>, futures_lite[d9f7489fbab33684]::future::CatchUnwind<core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::ExecutorState>::spawn_exclusive_system_task::{closure#1}>>>::{closure#0}>, core[a3424aac13c77cf6]::result::Result<(), alloc[9fa3fef380221c31]::boxed::Box<dyn core[a3424aac13c77cf6]::any::Any + core[a3424aac13c77cf6]::marker::Send>>, <async_executor[9f76b1279a3f5047]::Executor>::schedule::{closure#0}, ()>>::run::{closure#1} as core[a3424aac13c77cf6]::ops::function::FnOnce<()>>::call_once
                               at /home/ssingh/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
  56:     0x55706977f2db - <core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<async_task[6d75e66224110732]::raw::RawTask<async_executor[9f76b1279a3f5047]::AsyncCallOnDrop<futures_lite[d9f7489fbab33684]::future::CatchUnwind<core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::ExecutorState>::spawn_exclusive_system_task::{closure#1}>>, <async_executor[9f76b1279a3f5047]::Executor>::spawn_inner<core[a3424aac13c77cf6]::result::Result<(), alloc[9fa3fef380221c31]::boxed::Box<dyn core[a3424aac13c77cf6]::any::Any + core[a3424aac13c77cf6]::marker::Send>>, futures_lite[d9f7489fbab33684]::future::CatchUnwind<core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::ExecutorState>::spawn_exclusive_system_task::{closure#1}>>>::{closure#0}>, core[a3424aac13c77cf6]::result::Result<(), alloc[9fa3fef380221c31]::boxed::Box<dyn core[a3424aac13c77cf6]::any::Any + core[a3424aac13c77cf6]::marker::Send>>, <async_executor[9f76b1279a3f5047]::Executor>::schedule::{closure#0}, ()>>::run::{closure#1}> as core[a3424aac13c77cf6]::ops::function::FnOnce<()>>::call_once
                               at /home/ssingh/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/panic/unwind_safe.rs:274:9
  57:     0x5570697c336e - std[cbf56a46dac989f5]::panicking::catch_unwind::do_call::<core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<async_task[6d75e66224110732]::raw::RawTask<async_executor[9f76b1279a3f5047]::AsyncCallOnDrop<futures_lite[d9f7489fbab33684]::future::CatchUnwind<core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::ExecutorState>::spawn_exclusive_system_task::{closure#1}>>, <async_executor[9f76b1279a3f5047]::Executor>::spawn_inner<core[a3424aac13c77cf6]::result::Result<(), alloc[9fa3fef380221c31]::boxed::Box<dyn core[a3424aac13c77cf6]::any::Any + core[a3424aac13c77cf6]::marker::Send>>, futures_lite[d9f7489fbab33684]::future::CatchUnwind<core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::ExecutorState>::spawn_exclusive_system_task::{closure#1}>>>::{closure#0}>, core[a3424aac13c77cf6]::result::Result<(), alloc[9fa3fef380221c31]::boxed::Box<dyn core[a3424aac13c77cf6]::any::Any + core[a3424aac13c77cf6]::marker::Send>>, <async_executor[9f76b1279a3f5047]::Executor>::schedule::{closure#0}, ()>>::run::{closure#1}>, core[a3424aac13c77cf6]::task::poll::Poll<core[a3424aac13c77cf6]::result::Result<(), alloc[9fa3fef380221c31]::boxed::Box<dyn core[a3424aac13c77cf6]::any::Any + core[a3424aac13c77cf6]::marker::Send>>>>
                               at /home/ssingh/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:581:40
  58:     0x557069887a9b - __rust_try
  59:     0x5570698871c4 - std[cbf56a46dac989f5]::panicking::catch_unwind::<core[a3424aac13c77cf6]::task::poll::Poll<core[a3424aac13c77cf6]::result::Result<(), alloc[9fa3fef380221c31]::boxed::Box<dyn core[a3424aac13c77cf6]::any::Any + core[a3424aac13c77cf6]::marker::Send>>>, core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<async_task[6d75e66224110732]::raw::RawTask<async_executor[9f76b1279a3f5047]::AsyncCallOnDrop<futures_lite[d9f7489fbab33684]::future::CatchUnwind<core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::ExecutorState>::spawn_exclusive_system_task::{closure#1}>>, <async_executor[9f76b1279a3f5047]::Executor>::spawn_inner<core[a3424aac13c77cf6]::result::Result<(), alloc[9fa3fef380221c31]::boxed::Box<dyn core[a3424aac13c77cf6]::any::Any + core[a3424aac13c77cf6]::marker::Send>>, futures_lite[d9f7489fbab33684]::future::CatchUnwind<core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::ExecutorState>::spawn_exclusive_system_task::{closure#1}>>>::{closure#0}>, core[a3424aac13c77cf6]::result::Result<(), alloc[9fa3fef380221c31]::boxed::Box<dyn core[a3424aac13c77cf6]::any::Any + core[a3424aac13c77cf6]::marker::Send>>, <async_executor[9f76b1279a3f5047]::Executor>::schedule::{closure#0}, ()>>::run::{closure#1}>>
                               at /home/ssingh/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:544:19
  60:     0x5570698871c4 - std[cbf56a46dac989f5]::panic::catch_unwind::<core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<async_task[6d75e66224110732]::raw::RawTask<async_executor[9f76b1279a3f5047]::AsyncCallOnDrop<futures_lite[d9f7489fbab33684]::future::CatchUnwind<core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::ExecutorState>::spawn_exclusive_system_task::{closure#1}>>, <async_executor[9f76b1279a3f5047]::Executor>::spawn_inner<core[a3424aac13c77cf6]::result::Result<(), alloc[9fa3fef380221c31]::boxed::Box<dyn core[a3424aac13c77cf6]::any::Any + core[a3424aac13c77cf6]::marker::Send>>, futures_lite[d9f7489fbab33684]::future::CatchUnwind<core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::ExecutorState>::spawn_exclusive_system_task::{closure#1}>>>::{closure#0}>, core[a3424aac13c77cf6]::result::Result<(), alloc[9fa3fef380221c31]::boxed::Box<dyn core[a3424aac13c77cf6]::any::Any + core[a3424aac13c77cf6]::marker::Send>>, <async_executor[9f76b1279a3f5047]::Executor>::schedule::{closure#0}, ()>>::run::{closure#1}>, core[a3424aac13c77cf6]::task::poll::Poll<core[a3424aac13c77cf6]::result::Result<(), alloc[9fa3fef380221c31]::boxed::Box<dyn core[a3424aac13c77cf6]::any::Any + core[a3424aac13c77cf6]::marker::Send>>>>
                               at /home/ssingh/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panic.rs:359:14
  61:     0x55706989b7cd - <async_task[6d75e66224110732]::raw::RawTask<async_executor[9f76b1279a3f5047]::AsyncCallOnDrop<futures_lite[d9f7489fbab33684]::future::CatchUnwind<core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::ExecutorState>::spawn_exclusive_system_task::{closure#1}>>, <async_executor[9f76b1279a3f5047]::Executor>::spawn_inner<core[a3424aac13c77cf6]::result::Result<(), alloc[9fa3fef380221c31]::boxed::Box<dyn core[a3424aac13c77cf6]::any::Any + core[a3424aac13c77cf6]::marker::Send>>, futures_lite[d9f7489fbab33684]::future::CatchUnwind<core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::ExecutorState>::spawn_exclusive_system_task::{closure#1}>>>::{closure#0}>, core[a3424aac13c77cf6]::result::Result<(), alloc[9fa3fef380221c31]::boxed::Box<dyn core[a3424aac13c77cf6]::any::Any + core[a3424aac13c77cf6]::marker::Send>>, <async_executor[9f76b1279a3f5047]::Executor>::schedule::{closure#0}, ()>>::run
                               at /home/ssingh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/async-task-4.7.1/src/raw.rs:549:23
  62:     0x557069924fd2 - <async_task[6d75e66224110732]::runnable::Runnable>::run
                               at /home/ssingh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/async-task-4.7.1/src/runnable.rs:781:18
  63:     0x55706990a9bb - <async_executor[9f76b1279a3f5047]::State>::tick::{closure#0}
                               at /home/ssingh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/async-executor-1.13.2/src/lib.rs:733:18
  64:     0x55706990a4b5 - <async_executor[9f76b1279a3f5047]::Executor>::tick::{closure#0}
                               at /home/ssingh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/async-executor-1.13.2/src/lib.rs:324:29
  65:     0x5570697c9dec - <bevy_tasks[be92084dce5eafd]::thread_executor::ThreadExecutorTicker>::tick::{closure#0}
                               at /home/ssingh/Projects/bevy/crates/bevy_tasks/src/thread_executor.rs:105:39
  66:     0x55706975e735 - <bevy_tasks[be92084dce5eafd]::task_pool::TaskPool>::execute_scope::<(), <bevy_tasks[be92084dce5eafd]::task_pool::TaskPool>::scope_with_executor_inner<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::MultiThreadedExecutor as bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::SystemExecutor>::run::{closure#1}, ()>::{closure#0}::{closure#0}>::{closure#0}::{closure#0}::{closure#0}
                               at /home/ssingh/Projects/bevy/crates/bevy_tasks/src/task_pool.rs:542:45
  67:     0x55706977f583 - <core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<bevy_tasks[be92084dce5eafd]::task_pool::TaskPool>::execute_scope<(), <bevy_tasks[be92084dce5eafd]::task_pool::TaskPool>::scope_with_executor_inner<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::MultiThreadedExecutor as bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::SystemExecutor>::run::{closure#1}, ()>::{closure#0}::{closure#0}>::{closure#0}::{closure#0}::{closure#0}> as core[a3424aac13c77cf6]::future::future::Future>::poll
                               at /home/ssingh/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/panic/unwind_safe.rs:299:9
  68:     0x557069765b84 - <futures_lite[d9f7489fbab33684]::future::CatchUnwind<core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<bevy_tasks[be92084dce5eafd]::task_pool::TaskPool>::execute_scope<(), <bevy_tasks[be92084dce5eafd]::task_pool::TaskPool>::scope_with_executor_inner<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::MultiThreadedExecutor as bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::SystemExecutor>::run::{closure#1}, ()>::{closure#0}::{closure#0}>::{closure#0}::{closure#0}::{closure#0}>> as core[a3424aac13c77cf6]::future::future::Future>::poll::{closure#0}
                               at /home/ssingh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-lite-2.6.1/src/future.rs:653:53
  69:     0x55706977f474 - <core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<futures_lite[d9f7489fbab33684]::future::CatchUnwind<core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<bevy_tasks[be92084dce5eafd]::task_pool::TaskPool>::execute_scope<(), <bevy_tasks[be92084dce5eafd]::task_pool::TaskPool>::scope_with_executor_inner<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::MultiThreadedExecutor as bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::SystemExecutor>::run::{closure#1}, ()>::{closure#0}::{closure#0}>::{closure#0}::{closure#0}::{closure#0}>> as core[a3424aac13c77cf6]::future::future::Future>::poll::{closure#0}> as core[a3424aac13c77cf6]::ops::function::FnOnce<()>>::call_once
                               at /home/ssingh/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/panic/unwind_safe.rs:274:9
  70:     0x5570697c3647 - std[cbf56a46dac989f5]::panicking::catch_unwind::do_call::<core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<futures_lite[d9f7489fbab33684]::future::CatchUnwind<core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<bevy_tasks[be92084dce5eafd]::task_pool::TaskPool>::execute_scope<(), <bevy_tasks[be92084dce5eafd]::task_pool::TaskPool>::scope_with_executor_inner<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::MultiThreadedExecutor as bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::SystemExecutor>::run::{closure#1}, ()>::{closure#0}::{closure#0}>::{closure#0}::{closure#0}::{closure#0}>> as core[a3424aac13c77cf6]::future::future::Future>::poll::{closure#0}>, core[a3424aac13c77cf6]::task::poll::Poll<!>>
                               at /home/ssingh/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:581:40
  71:     0x557069887a9b - __rust_try
  72:     0x5570698877da - std[cbf56a46dac989f5]::panicking::catch_unwind::<core[a3424aac13c77cf6]::task::poll::Poll<!>, core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<futures_lite[d9f7489fbab33684]::future::CatchUnwind<core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<bevy_tasks[be92084dce5eafd]::task_pool::TaskPool>::execute_scope<(), <bevy_tasks[be92084dce5eafd]::task_pool::TaskPool>::scope_with_executor_inner<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::MultiThreadedExecutor as bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::SystemExecutor>::run::{closure#1}, ()>::{closure#0}::{closure#0}>::{closure#0}::{closure#0}::{closure#0}>> as core[a3424aac13c77cf6]::future::future::Future>::poll::{closure#0}>>
                               at /home/ssingh/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:544:19
  73:     0x5570698877da - std[cbf56a46dac989f5]::panic::catch_unwind::<core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<futures_lite[d9f7489fbab33684]::future::CatchUnwind<core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<bevy_tasks[be92084dce5eafd]::task_pool::TaskPool>::execute_scope<(), <bevy_tasks[be92084dce5eafd]::task_pool::TaskPool>::scope_with_executor_inner<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::MultiThreadedExecutor as bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::SystemExecutor>::run::{closure#1}, ()>::{closure#0}::{closure#0}>::{closure#0}::{closure#0}::{closure#0}>> as core[a3424aac13c77cf6]::future::future::Future>::poll::{closure#0}>, core[a3424aac13c77cf6]::task::poll::Poll<!>>
                               at /home/ssingh/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panic.rs:359:14
  74:     0x5570697667ea - <futures_lite[d9f7489fbab33684]::future::CatchUnwind<core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<bevy_tasks[be92084dce5eafd]::task_pool::TaskPool>::execute_scope<(), <bevy_tasks[be92084dce5eafd]::task_pool::TaskPool>::scope_with_executor_inner<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::MultiThreadedExecutor as bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::SystemExecutor>::run::{closure#1}, ()>::{closure#0}::{closure#0}>::{closure#0}::{closure#0}::{closure#0}>> as core[a3424aac13c77cf6]::future::future::Future>::poll
                               at /home/ssingh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-lite-2.6.1/src/future.rs:653:9
  75:     0x55706975d6e3 - <bevy_tasks[be92084dce5eafd]::task_pool::TaskPool>::execute_scope::<(), <bevy_tasks[be92084dce5eafd]::task_pool::TaskPool>::scope_with_executor_inner<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::MultiThreadedExecutor as bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::SystemExecutor>::run::{closure#1}, ()>::{closure#0}::{closure#0}>::{closure#0}::{closure#0}
                               at /home/ssingh/Projects/bevy/crates/bevy_tasks/src/task_pool.rs:545:77
  76:     0x557069766039 - <futures_lite[d9f7489fbab33684]::future::Or<<bevy_tasks[be92084dce5eafd]::task_pool::TaskPool>::scope_with_executor_inner<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::MultiThreadedExecutor as bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::SystemExecutor>::run::{closure#1}, ()>::{closure#0}::{closure#0}, <bevy_tasks[be92084dce5eafd]::task_pool::TaskPool>::execute_scope<(), <bevy_tasks[be92084dce5eafd]::task_pool::TaskPool>::scope_with_executor_inner<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::MultiThreadedExecutor as bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::SystemExecutor>::run::{closure#1}, ()>::{closure#0}::{closure#0}>::{closure#0}::{closure#0}> as core[a3424aac13c77cf6]::future::future::Future>::poll
                               at /home/ssingh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-lite-2.6.1/src/future.rs:454:46
  77:     0x55706975c15d - <bevy_tasks[be92084dce5eafd]::task_pool::TaskPool>::execute_scope::<(), <bevy_tasks[be92084dce5eafd]::task_pool::TaskPool>::scope_with_executor_inner<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::MultiThreadedExecutor as bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::SystemExecutor>::run::{closure#1}, ()>::{closure#0}::{closure#0}>::{closure#0}
                               at /home/ssingh/Projects/bevy/crates/bevy_tasks/src/task_pool.rs:548:41
  78:     0x55706975d1e7 - <bevy_tasks[be92084dce5eafd]::task_pool::TaskPool>::scope_with_executor_inner::<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::MultiThreadedExecutor as bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::SystemExecutor>::run::{closure#1}, ()>::{closure#0}
                               at /home/ssingh/Projects/bevy/crates/bevy_tasks/src/task_pool.rs:459:85
  79:     0x55706976577a - futures_lite[d9f7489fbab33684]::future::block_on::<alloc[9fa3fef380221c31]::vec::Vec<()>, <bevy_tasks[be92084dce5eafd]::task_pool::TaskPool>::scope_with_executor_inner<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::MultiThreadedExecutor as bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::SystemExecutor>::run::{closure#1}, ()>::{closure#0}>::{closure#0}
                               at /home/ssingh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-lite-2.6.1/src/future.rs:96:35
  80:     0x5570698fe6e4 - <std[cbf56a46dac989f5]::thread::local::LocalKey<core[a3424aac13c77cf6]::cell::RefCell<(parking[9edd71b36109867e]::Parker, core[a3424aac13c77cf6]::task::wake::Waker)>>>::try_with::<futures_lite[d9f7489fbab33684]::future::block_on<alloc[9fa3fef380221c31]::vec::Vec<()>, <bevy_tasks[be92084dce5eafd]::task_pool::TaskPool>::scope_with_executor_inner<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::MultiThreadedExecutor as bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::SystemExecutor>::run::{closure#1}, ()>::{closure#0}>::{closure#0}, alloc[9fa3fef380221c31]::vec::Vec<()>>
                               at /home/ssingh/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/local.rs:508:12
  81:     0x5570698fe563 - <std[cbf56a46dac989f5]::thread::local::LocalKey<core[a3424aac13c77cf6]::cell::RefCell<(parking[9edd71b36109867e]::Parker, core[a3424aac13c77cf6]::task::wake::Waker)>>>::with::<futures_lite[d9f7489fbab33684]::future::block_on<alloc[9fa3fef380221c31]::vec::Vec<()>, <bevy_tasks[be92084dce5eafd]::task_pool::TaskPool>::scope_with_executor_inner<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::MultiThreadedExecutor as bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::SystemExecutor>::run::{closure#1}, ()>::{closure#0}>::{closure#0}, alloc[9fa3fef380221c31]::vec::Vec<()>>
                               at /home/ssingh/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/local.rs:472:20
  82:     0x5570697654dd - futures_lite[d9f7489fbab33684]::future::block_on::<alloc[9fa3fef380221c31]::vec::Vec<()>, <bevy_tasks[be92084dce5eafd]::task_pool::TaskPool>::scope_with_executor_inner<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::MultiThreadedExecutor as bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::SystemExecutor>::run::{closure#1}, ()>::{closure#0}>
                               at /home/ssingh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-lite-2.6.1/src/future.rs:75:11
  83:     0x55706975b709 - <bevy_tasks[be92084dce5eafd]::task_pool::TaskPool>::scope_with_executor_inner::<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::MultiThreadedExecutor as bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::SystemExecutor>::run::{closure#1}, ()>
                               at /home/ssingh/Projects/bevy/crates/bevy_tasks/src/task_pool.rs:413:13
  84:     0x55706975c349 - <bevy_tasks[be92084dce5eafd]::task_pool::TaskPool>::scope_with_executor::<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::MultiThreadedExecutor as bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::SystemExecutor>::run::{closure#1}, ()>::{closure#0}
                               at /home/ssingh/Projects/bevy/crates/bevy_tasks/src/task_pool.rs:343:22
  85:     0x5570698fe407 - <std[cbf56a46dac989f5]::thread::local::LocalKey<alloc[9fa3fef380221c31]::sync::Arc<bevy_tasks[be92084dce5eafd]::thread_executor::ThreadExecutor>>>::try_with::<<bevy_tasks[be92084dce5eafd]::task_pool::TaskPool>::scope_with_executor<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::MultiThreadedExecutor as bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::SystemExecutor>::run::{closure#1}, ()>::{closure#0}, alloc[9fa3fef380221c31]::vec::Vec<()>>
                               at /home/ssingh/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/local.rs:508:12
  86:     0x5570698fe29d - <std[cbf56a46dac989f5]::thread::local::LocalKey<alloc[9fa3fef380221c31]::sync::Arc<bevy_tasks[be92084dce5eafd]::thread_executor::ThreadExecutor>>>::with::<<bevy_tasks[be92084dce5eafd]::task_pool::TaskPool>::scope_with_executor<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::MultiThreadedExecutor as bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::SystemExecutor>::run::{closure#1}, ()>::{closure#0}, alloc[9fa3fef380221c31]::vec::Vec<()>>
                               at /home/ssingh/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/local.rs:472:20
  87:     0x55706975b42c - <bevy_tasks[be92084dce5eafd]::task_pool::TaskPool>::scope_with_executor::<<bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::MultiThreadedExecutor as bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::SystemExecutor>::run::{closure#1}, ()>
                               at /home/ssingh/Projects/bevy/crates/bevy_tasks/src/task_pool.rs:339:31
  88:     0x5570698d5d34 - <bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::multi_threaded::MultiThreadedExecutor as bevy_ecs[ae55bfe1c74e77a3]::schedule::executor::SystemExecutor>::run
                               at /home/ssingh/Projects/bevy/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs:279:57
  89:     0x55706980e792 - <bevy_ecs[ae55bfe1c74e77a3]::schedule::schedule::Schedule>::run
                               at /home/ssingh/Projects/bevy/crates/bevy_ecs/src/schedule/schedule.rs:540:14
  90:     0x5570696aca61 - <bevy_ecs[ae55bfe1c74e77a3]::world::World>::run_schedule::<bevy_ecs[ae55bfe1c74e77a3]::intern::Interned<dyn bevy_ecs[ae55bfe1c74e77a3]::schedule::set::ScheduleLabel>>::{closure#0}
                               at /home/ssingh/Projects/bevy/crates/bevy_ecs/src/world/mod.rs:3673:57
  91:     0x5570696abc76 - <bevy_ecs[ae55bfe1c74e77a3]::world::World>::try_schedule_scope::<(), bevy_ecs[ae55bfe1c74e77a3]::intern::Interned<dyn bevy_ecs[ae55bfe1c74e77a3]::schedule::set::ScheduleLabel>, <bevy_ecs[ae55bfe1c74e77a3]::world::World>::run_schedule<bevy_ecs[ae55bfe1c74e77a3]::intern::Interned<dyn bevy_ecs[ae55bfe1c74e77a3]::schedule::set::ScheduleLabel>>::{closure#0}>
                               at /home/ssingh/Projects/bevy/crates/bevy_ecs/src/world/mod.rs:3591:21
  92:     0x5570696abad9 - <bevy_ecs[ae55bfe1c74e77a3]::world::World>::schedule_scope::<(), bevy_ecs[ae55bfe1c74e77a3]::intern::Interned<dyn bevy_ecs[ae55bfe1c74e77a3]::schedule::set::ScheduleLabel>, <bevy_ecs[ae55bfe1c74e77a3]::world::World>::run_schedule<bevy_ecs[ae55bfe1c74e77a3]::intern::Interned<dyn bevy_ecs[ae55bfe1c74e77a3]::schedule::set::ScheduleLabel>>::{closure#0}>
                               at /home/ssingh/Projects/bevy/crates/bevy_ecs/src/world/mod.rs:3643:14
  93:     0x5570696abab8 - <bevy_ecs[ae55bfe1c74e77a3]::world::World>::run_schedule::<bevy_ecs[ae55bfe1c74e77a3]::intern::Interned<dyn bevy_ecs[ae55bfe1c74e77a3]::schedule::set::ScheduleLabel>>
                               at /home/ssingh/Projects/bevy/crates/bevy_ecs/src/world/mod.rs:3673:14
  94:     0x5570696a8f93 - <bevy_app[8596c61a6a25de94]::sub_app::SubApp>::run_default_schedule
                               at /home/ssingh/Projects/bevy/crates/bevy_app/src/sub_app.rs:141:24
  95:     0x5570696a91e4 - <bevy_app[8596c61a6a25de94]::sub_app::SubApp>::update
                               at /home/ssingh/Projects/bevy/crates/bevy_app/src/sub_app.rs:147:14
  96:     0x55706707b40e - <bevy_render[cbe98d17828001b5]::pipelined_rendering::PipelinedRenderingPlugin as bevy_app[8596c61a6a25de94]::plugin::Plugin>::cleanup::{closure#0}
                               at /home/ssingh/Projects/bevy/crates/bevy_render/src/pipelined_rendering.rs:168:32
  97:     0x55706744e516 - std[cbf56a46dac989f5]::sys::backtrace::__rust_begin_short_backtrace::<<bevy_render[cbe98d17828001b5]::pipelined_rendering::PipelinedRenderingPlugin as bevy_app[8596c61a6a25de94]::plugin::Plugin>::cleanup::{closure#0}, ()>
                               at /home/ssingh/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/backtrace.rs:160:18
  98:     0x5570670439c0 - <std[cbf56a46dac989f5]::thread::Builder>::spawn_unchecked_::<<bevy_render[cbe98d17828001b5]::pipelined_rendering::PipelinedRenderingPlugin as bevy_app[8596c61a6a25de94]::plugin::Plugin>::cleanup::{closure#0}, ()>::{closure#1}::{closure#0}
                               at /home/ssingh/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/mod.rs:562:17
  99:     0x557066f925c1 - <core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<std[cbf56a46dac989f5]::thread::Builder>::spawn_unchecked_<<bevy_render[cbe98d17828001b5]::pipelined_rendering::PipelinedRenderingPlugin as bevy_app[8596c61a6a25de94]::plugin::Plugin>::cleanup::{closure#0}, ()>::{closure#1}::{closure#0}> as core[a3424aac13c77cf6]::ops::function::FnOnce<()>>::call_once
                               at /home/ssingh/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/panic/unwind_safe.rs:274:9
 100:     0x55706703e4db - std[cbf56a46dac989f5]::panicking::catch_unwind::do_call::<core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<std[cbf56a46dac989f5]::thread::Builder>::spawn_unchecked_<<bevy_render[cbe98d17828001b5]::pipelined_rendering::PipelinedRenderingPlugin as bevy_app[8596c61a6a25de94]::plugin::Plugin>::cleanup::{closure#0}, ()>::{closure#1}::{closure#0}>, ()>
                               at /home/ssingh/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:581:40
 101:     0x557067043a4b - __rust_try
 102:     0x5570670435ea - std[cbf56a46dac989f5]::panicking::catch_unwind::<(), core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<std[cbf56a46dac989f5]::thread::Builder>::spawn_unchecked_<<bevy_render[cbe98d17828001b5]::pipelined_rendering::PipelinedRenderingPlugin as bevy_app[8596c61a6a25de94]::plugin::Plugin>::cleanup::{closure#0}, ()>::{closure#1}::{closure#0}>>
                               at /home/ssingh/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:544:19
 103:     0x5570670435ea - std[cbf56a46dac989f5]::panic::catch_unwind::<core[a3424aac13c77cf6]::panic::unwind_safe::AssertUnwindSafe<<std[cbf56a46dac989f5]::thread::Builder>::spawn_unchecked_<<bevy_render[cbe98d17828001b5]::pipelined_rendering::PipelinedRenderingPlugin as bevy_app[8596c61a6a25de94]::plugin::Plugin>::cleanup::{closure#0}, ()>::{closure#1}::{closure#0}>, ()>
                               at /home/ssingh/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panic.rs:359:14
 104:     0x5570670435ea - <std[cbf56a46dac989f5]::thread::Builder>::spawn_unchecked_::<<bevy_render[cbe98d17828001b5]::pipelined_rendering::PipelinedRenderingPlugin as bevy_app[8596c61a6a25de94]::plugin::Plugin>::cleanup::{closure#0}, ()>::{closure#1}
                               at /home/ssingh/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/mod.rs:560:30
 105:     0x55706742811f - <<std[cbf56a46dac989f5]::thread::Builder>::spawn_unchecked_<<bevy_render[cbe98d17828001b5]::pipelined_rendering::PipelinedRenderingPlugin as bevy_app[8596c61a6a25de94]::plugin::Plugin>::cleanup::{closure#0}, ()>::{closure#1} as core[a3424aac13c77cf6]::ops::function::FnOnce<()>>::call_once::{shim:vtable#0}
                               at /home/ssingh/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
 106:     0x557069cd501f - <alloc[9fa3fef380221c31]::boxed::Box<dyn core[a3424aac13c77cf6]::ops::function::FnOnce<(), Output = ()>> as core[a3424aac13c77cf6]::ops::function::FnOnce<()>>::call_once
                               at /rustc/cc3eee7fbe17ea4b7238531cb97e1b7b8bd6afce/library/alloc/src/boxed.rs:2206:9
 107:     0x557069cd501f - <std[cbf56a46dac989f5]::sys::thread::unix::Thread>::new::thread_start
                               at /rustc/cc3eee7fbe17ea4b7238531cb97e1b7b8bd6afce/library/std/src/sys/thread/unix.rs:124:17
 108:     0x7f75f1a9698b - <unknown>
 109:     0x7f75f1b1a9cc - <unknown>
 110:                0x0 - <unknown>
Encountered a panic in system `bevy_render::renderer::render_system`!

```

</details>

## Solution

- Remove the `ViewTarget` when it becomes unavailable

## Testing

- Testing by running the bevy examples on linux