### PR TITLE
#21980 Fix Component/Relationship derive using non fully qualified path

### DIFF
--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -826,7 +826,7 @@ fn derive_relationship(
             }
 
             #[inline]
-            fn set_risky(&mut self, entity: Entity) {
+            fn set_risky(&mut self, entity: #bevy_ecs_path::entity::Entity) {
                 self.#relationship_member = entity;
             }
         }


### PR DESCRIPTION
# Objective

Fixes #21980

## Solution

Use fully qualified path for `Entity`

## Testing

The following code now compiles
```rust
mod test {
    fn derive_component_relationship_hygiene() {
        #[derive(Debug, bevy::prelude::Component)]
        #[relationship(relationship_target = RelTarget)]
        struct Rel(pub bevy::prelude::Entity);

        #[derive(Debug, bevy::prelude::Component)]
        #[relationship_target(relationship = Rel)]
        struct RelTarget(bevy::prelude::Entity);
    }
}```
