### PR TITLE
Fix unsound `&EntityMutExcept` to `FilteredEntityMut` conversion

### DIFF
--- a/crates/bevy_ecs/src/world/entity_access/except.rs
+++ b/crates/bevy_ecs/src/world/entity_access/except.rs
@@ -429,8 +429,8 @@ where
     }
 }
 
-impl<'w, 's, B: Bundle> From<&'w EntityMutExcept<'_, 's, B>> for FilteredEntityMut<'w, 's> {
-    fn from(value: &'w EntityMutExcept<'_, 's, B>) -> Self {
+impl<'w, 's, B: Bundle> From<&'w mut EntityMutExcept<'_, 's, B>> for FilteredEntityMut<'w, 's> {
+    fn from(value: &'w mut EntityMutExcept<'_, 's, B>) -> Self {
         // SAFETY:
         // - The FilteredEntityMut has the same component access as the given EntityMutExcept.
         unsafe { FilteredEntityMut::new(value.entity, value.access) }


### PR DESCRIPTION
# Objective

Fix an effectively `& &mut` -> `&mut` conversion.

## Solution

Switch it to `&mut &mut` -> `&mut`.