### PR TITLE
Add a new `almost_finish` method for `Timer` with immediate first `tick` action

### DIFF
--- a/crates/bevy_time/src/timer.rs
+++ b/crates/bevy_time/src/timer.rs
@@ -219,6 +219,7 @@ impl Timer {
     /// assert!(!timer.is_finished());
     /// assert_eq!(timer.remaining(), Duration::from_nanos(1));
     /// ```
+    #[inline]
     pub fn almost_finish(&mut self) {
         let remaining = self.remaining() - Duration::from_nanos(1);
         self.tick(remaining);


### PR DESCRIPTION
# Objective

Resolves #21860

This new method would tick the timer by `duration - 1 ns` leaving a very short waiting time for the first tick initiated by the user allowing immediate action.

## Solution

The `almost_finish` method updates the timer by ticking it with `1ns` remaining.

## Testing

Tests have been added in `almost_finished_repeating`.