### PR TITLE
add InfallibleMesh for mesh construction without unwraps

### DIFF
--- a/benches/benches/bevy_render/compute_normals.rs
+++ b/benches/benches/bevy_render/compute_normals.rs
@@ -5,7 +5,7 @@ use rand::random;
 use std::time::{Duration, Instant};
 
 use bevy_asset::RenderAssetUsages;
-use bevy_mesh::{Indices, Mesh, PrimitiveTopology};
+use bevy_mesh::{Indices, InfallibleMesh, Mesh, PrimitiveTopology};
 
 const GRID_SIZE: usize = 256;
 
@@ -28,7 +28,7 @@ fn compute_normals(c: &mut Criterion) {
             .flat_map(|i| std::iter::repeat(i).zip(0..GRID_SIZE))
             .map(|(i, j)| [i as f32, j as f32, random::<f32>()])
             .collect::<Vec<_>>();
-        Mesh::new(
+        InfallibleMesh::new(
             PrimitiveTopology::TriangleList,
             RenderAssetUsages::MAIN_WORLD,
         )

--- a/crates/bevy_camera/src/primitives.rs
+++ b/crates/bevy_camera/src/primitives.rs
@@ -23,8 +23,7 @@ impl MeshAabb for Mesh {
             return Some(aabb.into());
         }
 
-        let Ok(VertexAttributeValues::Float32x3(values)) =
-            self.try_attribute(Mesh::ATTRIBUTE_POSITION)
+        let Ok(VertexAttributeValues::Float32x3(values)) = self.attribute(Mesh::ATTRIBUTE_POSITION)
         else {
             return None;
         };

--- a/crates/bevy_gltf/src/loader/mod.rs
+++ b/crates/bevy_gltf/src/loader/mod.rs
@@ -31,7 +31,7 @@ use bevy_math::{Mat4, Vec3};
 use bevy_mesh::{
     morph::{MeshMorphWeights, MorphAttributes, MorphTargetImage, MorphWeights},
     skinning::{SkinnedMesh, SkinnedMeshInverseBindposes},
-    Indices, Mesh, Mesh3d, MeshVertexAttribute, PrimitiveTopology,
+    Indices, InfallibleMesh, Mesh, Mesh3d, MeshVertexAttribute, PrimitiveTopology,
 };
 #[cfg(feature = "pbr_transmission_textures")]
 use bevy_pbr::UvChannel;
@@ -727,7 +727,7 @@ impl GltfLoader {
                 };
                 let primitive_topology = primitive_topology(primitive.mode())?;
 
-                let mut mesh = Mesh::new(primitive_topology, settings.load_meshes);
+                let mut mesh = InfallibleMesh::new(primitive_topology, settings.load_meshes);
 
                 // Read vertex attributes
                 for (semantic, accessor) in primitive.attributes() {
@@ -837,7 +837,8 @@ impl GltfLoader {
                     });
                 }
 
-                let mesh_handle = load_context.add_labeled_asset(primitive_label.to_string(), mesh);
+                let mesh_handle =
+                    load_context.add_labeled_asset(primitive_label.to_string(), mesh.into());
                 primitives.push(super::GltfPrimitive::new(
                     &gltf_mesh,
                     &primitive,

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -1956,7 +1956,7 @@ impl From<ConvexPolygon> for Polygon {
 )]
 pub struct ConvexPolygon {
     /// The vertices of the [`ConvexPolygon`].
-    vertices: Vec<Vec2>,
+    pub vertices: Vec<Vec2>,
 }
 
 #[cfg(feature = "alloc")]

--- a/crates/bevy_mesh/src/mesh.rs
+++ b/crates/bevy_mesh/src/mesh.rs
@@ -137,7 +137,7 @@ impl<T> From<Option<T>> for MeshExtractableData<T> {
 /// that can be converted into a normal `Mesh` using `InfallibleMesh::into_mesh`.
 /// Designed for use during cpu-side mesh construction. Methods on this struct whose `Mesh`
 /// counterparts may return `MeshAccessError::ExtractedToRenderWorld` instead return plain values.
-#[derive(Asset, Debug, Clone, Reflect, PartialEq)]
+#[derive(Debug, Clone, Reflect, PartialEq)]
 #[reflect(Clone)]
 pub struct InfallibleMesh(Mesh);
 

--- a/crates/bevy_mesh/src/mesh.rs
+++ b/crates/bevy_mesh/src/mesh.rs
@@ -750,11 +750,11 @@ impl core::ops::Deref for InfallibleMesh {
 /// `StandardMaterial` or `ColorMaterial`:
 ///
 /// ```
-/// # use bevy_mesh::{Mesh, Indices, PrimitiveTopology};
+/// # use bevy_mesh::{Mesh, InfallibleMesh, Indices, PrimitiveTopology};
 /// # use bevy_asset::RenderAssetUsages;
 /// fn create_simple_parallelogram() -> Mesh {
 ///     // Create a new mesh using a triangle list topology, where each set of 3 vertices composes a triangle.
-///     Mesh::new(PrimitiveTopology::TriangleList, RenderAssetUsages::default())
+///     InfallibleMesh::new(PrimitiveTopology::TriangleList, RenderAssetUsages::default())
 ///         // Add 4 vertices, each with its own position attribute (coordinate in
 ///         // 3D space), for each of the corners of the parallelogram.
 ///         .with_inserted_attribute(
@@ -779,6 +779,7 @@ impl core::ops::Deref for InfallibleMesh {
 ///             // Second triangle
 ///             1, 3, 2
 ///         ]))
+///         .into()
 /// }
 /// ```
 ///

--- a/crates/bevy_mesh/src/mikktspace.rs
+++ b/crates/bevy_mesh/src/mikktspace.rs
@@ -84,7 +84,7 @@ pub(crate) fn generate_tangents_for_mesh(
         other => return Err(GenerateTangentsError::UnsupportedTopology(other)),
     };
 
-    let positions = mesh.try_attribute_option(Mesh::ATTRIBUTE_POSITION)?.ok_or(
+    let positions = mesh.attribute_option(Mesh::ATTRIBUTE_POSITION)?.ok_or(
         GenerateTangentsError::MissingVertexAttribute(Mesh::ATTRIBUTE_POSITION.name),
     )?;
     let VertexAttributeValues::Float32x3(positions) = positions else {
@@ -93,7 +93,7 @@ pub(crate) fn generate_tangents_for_mesh(
             VertexFormat::Float32x3,
         ));
     };
-    let normals = mesh.try_attribute_option(Mesh::ATTRIBUTE_NORMAL)?.ok_or(
+    let normals = mesh.attribute_option(Mesh::ATTRIBUTE_NORMAL)?.ok_or(
         GenerateTangentsError::MissingVertexAttribute(Mesh::ATTRIBUTE_NORMAL.name),
     )?;
     let VertexAttributeValues::Float32x3(normals) = normals else {
@@ -102,7 +102,7 @@ pub(crate) fn generate_tangents_for_mesh(
             VertexFormat::Float32x3,
         ));
     };
-    let uvs = mesh.try_attribute_option(Mesh::ATTRIBUTE_UV_0)?.ok_or(
+    let uvs = mesh.attribute_option(Mesh::ATTRIBUTE_UV_0)?.ok_or(
         GenerateTangentsError::MissingVertexAttribute(Mesh::ATTRIBUTE_UV_0.name),
     )?;
     let VertexAttributeValues::Float32x2(uvs) = uvs else {
@@ -115,7 +115,7 @@ pub(crate) fn generate_tangents_for_mesh(
     let len = positions.len();
     let tangents = vec![[0., 0., 0., 0.]; len];
     let mut mikktspace_mesh = MikktspaceGeometryHelper {
-        indices: mesh.try_indices_option()?,
+        indices: mesh.indices_option()?,
         positions,
         normals,
         uvs,

--- a/crates/bevy_mesh/src/primitives/dim2.rs
+++ b/crates/bevy_mesh/src/primitives/dim2.rs
@@ -81,17 +81,11 @@ impl Extrudable for CircleMeshBuilder {
 impl Meshable for Circle {
     type Output = CircleMeshBuilder;
 
-    fn mesh(&self) -> Self::Output {
+    fn mesh(self) -> Self::Output {
         CircleMeshBuilder {
-            circle: *self,
+            circle: self,
             ..Default::default()
         }
-    }
-}
-
-impl From<Circle> for Mesh {
-    fn from(circle: Circle) -> Self {
-        circle.mesh().build()
     }
 }
 
@@ -243,20 +237,11 @@ impl Extrudable for CircularSectorMeshBuilder {
 impl Meshable for CircularSector {
     type Output = CircularSectorMeshBuilder;
 
-    fn mesh(&self) -> Self::Output {
+    fn mesh(self) -> Self::Output {
         CircularSectorMeshBuilder {
-            sector: *self,
+            sector: self,
             ..Default::default()
         }
-    }
-}
-
-impl From<CircularSector> for Mesh {
-    /// Converts this sector into a [`Mesh`] using a default [`CircularSectorMeshBuilder`].
-    ///
-    /// See the documentation of [`CircularSectorMeshBuilder`] for more details.
-    fn from(sector: CircularSector) -> Self {
-        sector.mesh().build()
     }
 }
 
@@ -390,20 +375,11 @@ impl Extrudable for CircularSegmentMeshBuilder {
 impl Meshable for CircularSegment {
     type Output = CircularSegmentMeshBuilder;
 
-    fn mesh(&self) -> Self::Output {
+    fn mesh(self) -> Self::Output {
         CircularSegmentMeshBuilder {
-            segment: *self,
+            segment: self,
             ..Default::default()
         }
-    }
-}
-
-impl From<CircularSegment> for Mesh {
-    /// Converts this sector into a [`Mesh`] using a default [`CircularSegmentMeshBuilder`].
-    ///
-    /// See the documentation of [`CircularSegmentMeshBuilder`] for more details.
-    fn from(segment: CircularSegment) -> Self {
-        segment.mesh().build()
     }
 }
 
@@ -420,9 +396,9 @@ pub struct ConvexPolygonMeshBuilder {
 impl Meshable for ConvexPolygon {
     type Output = ConvexPolygonMeshBuilder;
 
-    fn mesh(&self) -> Self::Output {
+    fn mesh(self) -> Self::Output {
         Self::Output {
-            vertices: self.vertices().to_vec(),
+            vertices: self.vertices,
         }
     }
 }
@@ -453,12 +429,6 @@ impl Extrudable for ConvexPolygonMeshBuilder {
         vec![PerimeterSegment::Flat {
             indices: (0..self.vertices.len() as u32).chain([0]).collect(),
         }]
-    }
-}
-
-impl From<ConvexPolygon> for Mesh {
-    fn from(polygon: ConvexPolygon) -> Self {
-        polygon.mesh().build()
     }
 }
 
@@ -504,7 +474,7 @@ impl RegularPolygonMeshBuilder {
 impl Meshable for RegularPolygon {
     type Output = RegularPolygonMeshBuilder;
 
-    fn mesh(&self) -> Self::Output {
+    fn mesh(self) -> Self::Output {
         Self::Output {
             circumradius: self.circumcircle.radius,
             sides: self.sides,
@@ -527,12 +497,6 @@ impl Extrudable for RegularPolygonMeshBuilder {
         vec![PerimeterSegment::Flat {
             indices: (0..self.sides).chain([0]).collect(),
         }]
-    }
-}
-
-impl From<RegularPolygon> for Mesh {
-    fn from(polygon: RegularPolygon) -> Self {
-        polygon.mesh().build()
     }
 }
 
@@ -627,17 +591,11 @@ impl Extrudable for EllipseMeshBuilder {
 impl Meshable for Ellipse {
     type Output = EllipseMeshBuilder;
 
-    fn mesh(&self) -> Self::Output {
+    fn mesh(self) -> Self::Output {
         EllipseMeshBuilder {
-            ellipse: *self,
+            ellipse: self,
             ..Default::default()
         }
-    }
-}
-
-impl From<Ellipse> for Mesh {
-    fn from(ellipse: Ellipse) -> Self {
-        ellipse.mesh().build()
     }
 }
 
@@ -669,15 +627,8 @@ impl MeshBuilder for Segment2dMeshBuilder {
 impl Meshable for Segment2d {
     type Output = Segment2dMeshBuilder;
 
-    fn mesh(&self) -> Self::Output {
-        Segment2dMeshBuilder::new(*self)
-    }
-}
-
-impl From<Segment2d> for Mesh {
-    /// Converts this segment into a [`Mesh`] using a default [`Segment2dMeshBuilder`].
-    fn from(segment: Segment2d) -> Self {
-        segment.mesh().build()
+    fn mesh(self) -> Self::Output {
+        Segment2dMeshBuilder::new(self)
     }
 }
 
@@ -712,16 +663,8 @@ impl MeshBuilder for Polyline2dMeshBuilder {
 impl Meshable for Polyline2d {
     type Output = Polyline2dMeshBuilder;
 
-    fn mesh(&self) -> Self::Output {
-        Polyline2dMeshBuilder {
-            polyline: self.clone(),
-        }
-    }
-}
-
-impl From<Polyline2d> for Mesh {
-    fn from(polyline: Polyline2d) -> Self {
-        polyline.mesh().build()
+    fn mesh(self) -> Self::Output {
+        Polyline2dMeshBuilder { polyline: self }
     }
 }
 
@@ -844,17 +787,11 @@ impl Extrudable for AnnulusMeshBuilder {
 impl Meshable for Annulus {
     type Output = AnnulusMeshBuilder;
 
-    fn mesh(&self) -> Self::Output {
+    fn mesh(self) -> Self::Output {
         AnnulusMeshBuilder {
-            annulus: *self,
+            annulus: self,
             ..Default::default()
         }
-    }
-}
-
-impl From<Annulus> for Mesh {
-    fn from(annulus: Annulus) -> Self {
-        annulus.mesh().build()
     }
 }
 
@@ -931,16 +868,10 @@ impl Extrudable for RhombusMeshBuilder {
 impl Meshable for Rhombus {
     type Output = RhombusMeshBuilder;
 
-    fn mesh(&self) -> Self::Output {
+    fn mesh(self) -> Self::Output {
         Self::Output {
             half_diagonals: self.half_diagonals,
         }
-    }
-}
-
-impl From<Rhombus> for Mesh {
-    fn from(rhombus: Rhombus) -> Self {
-        rhombus.mesh().build()
     }
 }
 
@@ -963,8 +894,8 @@ impl Triangle2dMeshBuilder {
 impl Meshable for Triangle2d {
     type Output = Triangle2dMeshBuilder;
 
-    fn mesh(&self) -> Self::Output {
-        Self::Output { triangle: *self }
+    fn mesh(self) -> Self::Output {
+        Self::Output { triangle: self }
     }
 }
 
@@ -1012,12 +943,6 @@ impl Extrudable for Triangle2dMeshBuilder {
                 indices: vec![2, 1, 0, 2],
             }]
         }
-    }
-}
-
-impl From<Triangle2d> for Mesh {
-    fn from(triangle: Triangle2d) -> Self {
-        triangle.mesh().build()
     }
 }
 
@@ -1088,16 +1013,10 @@ impl Extrudable for RectangleMeshBuilder {
 impl Meshable for Rectangle {
     type Output = RectangleMeshBuilder;
 
-    fn mesh(&self) -> Self::Output {
+    fn mesh(self) -> Self::Output {
         RectangleMeshBuilder {
             half_size: self.half_size,
         }
-    }
-}
-
-impl From<Rectangle> for Mesh {
-    fn from(rectangle: Rectangle) -> Self {
-        rectangle.mesh().build()
     }
 }
 
@@ -1248,17 +1167,11 @@ impl Extrudable for Capsule2dMeshBuilder {
 impl Meshable for Capsule2d {
     type Output = Capsule2dMeshBuilder;
 
-    fn mesh(&self) -> Self::Output {
+    fn mesh(self) -> Self::Output {
         Capsule2dMeshBuilder {
-            capsule: *self,
+            capsule: self,
             ..Default::default()
         }
-    }
-}
-
-impl From<Capsule2d> for Mesh {
-    fn from(capsule: Capsule2d) -> Self {
-        capsule.mesh().build()
     }
 }
 
@@ -1276,7 +1189,7 @@ where
     P: Primitive2d + Meshable,
 {
     /// Create a new `RingMeshBuilder<P>` from a given `Ring<P>` shape.
-    pub fn new(ring: &Ring<P>) -> Self {
+    pub fn new(ring: Ring<P>) -> Self {
         Self {
             outer_shape_builder: ring.outer_shape.mesh(),
             inner_shape_builder: ring.inner_shape.mesh(),
@@ -1511,17 +1424,8 @@ where
 {
     type Output = RingMeshBuilder<P>;
 
-    fn mesh(&self) -> Self::Output {
+    fn mesh(self) -> Self::Output {
         RingMeshBuilder::new(self)
-    }
-}
-
-impl<P> From<Ring<P>> for Mesh
-where
-    P: Primitive2d + Meshable,
-{
-    fn from(ring: Ring<P>) -> Self {
-        ring.mesh().build()
     }
 }
 

--- a/crates/bevy_mesh/src/primitives/dim2.rs
+++ b/crates/bevy_mesh/src/primitives/dim2.rs
@@ -1,6 +1,7 @@
 use core::f32::consts::FRAC_PI_2;
 use core::mem;
 
+use crate::InfallibleMesh;
 use crate::{primitives::dim3::triangle3d, Indices, Mesh, PerimeterSegment, VertexAttributeValues};
 use bevy_asset::RenderAssetUsages;
 
@@ -59,11 +60,11 @@ impl CircleMeshBuilder {
 }
 
 impl MeshBuilder for CircleMeshBuilder {
-    fn build(&self) -> Mesh {
+    fn build_infallible(&self) -> InfallibleMesh {
         Ellipse::new(self.circle.radius, self.circle.radius)
             .mesh()
             .resolution(self.resolution)
-            .build()
+            .build_infallible()
     }
 }
 
@@ -175,7 +176,7 @@ impl CircularSectorMeshBuilder {
 }
 
 impl MeshBuilder for CircularSectorMeshBuilder {
-    fn build(&self) -> Mesh {
+    fn build_infallible(&self) -> InfallibleMesh {
         let resolution = self.resolution as usize;
         let mut indices = Vec::with_capacity((resolution - 1) * 3);
         let mut positions = Vec::with_capacity(resolution + 1);
@@ -210,7 +211,7 @@ impl MeshBuilder for CircularSectorMeshBuilder {
             indices.extend_from_slice(&[0, i, i + 1]);
         }
 
-        Mesh::new(
+        InfallibleMesh::new(
             PrimitiveTopology::TriangleList,
             RenderAssetUsages::default(),
         )
@@ -313,7 +314,7 @@ impl CircularSegmentMeshBuilder {
 }
 
 impl MeshBuilder for CircularSegmentMeshBuilder {
-    fn build(&self) -> Mesh {
+    fn build_infallible(&self) -> InfallibleMesh {
         let resolution = self.resolution as usize;
         let mut indices = Vec::with_capacity((resolution - 1) * 3);
         let mut positions = Vec::with_capacity(resolution + 1);
@@ -357,7 +358,7 @@ impl MeshBuilder for CircularSegmentMeshBuilder {
             indices.extend_from_slice(&[0, i, i + 1]);
         }
 
-        Mesh::new(
+        InfallibleMesh::new(
             PrimitiveTopology::TriangleList,
             RenderAssetUsages::default(),
         )
@@ -427,7 +428,7 @@ impl Meshable for ConvexPolygon {
 }
 
 impl MeshBuilder for ConvexPolygonMeshBuilder {
-    fn build(&self) -> Mesh {
+    fn build_infallible(&self) -> InfallibleMesh {
         let len = self.vertices.len();
         let mut indices = Vec::with_capacity((len - 2) * 3);
         let mut positions = Vec::with_capacity(len);
@@ -438,7 +439,7 @@ impl MeshBuilder for ConvexPolygonMeshBuilder {
         for i in 2..len as u32 {
             indices.extend_from_slice(&[0, i - 1, i]);
         }
-        Mesh::new(
+        InfallibleMesh::new(
             PrimitiveTopology::TriangleList,
             RenderAssetUsages::default(),
         )
@@ -512,12 +513,12 @@ impl Meshable for RegularPolygon {
 }
 
 impl MeshBuilder for RegularPolygonMeshBuilder {
-    fn build(&self) -> Mesh {
+    fn build_infallible(&self) -> InfallibleMesh {
         // The ellipse mesh is just a regular polygon with two radii
         Ellipse::new(self.circumradius, self.circumradius)
             .mesh()
             .resolution(self.sides)
-            .build()
+            .build_infallible()
     }
 }
 
@@ -576,7 +577,7 @@ impl EllipseMeshBuilder {
 }
 
 impl MeshBuilder for EllipseMeshBuilder {
-    fn build(&self) -> Mesh {
+    fn build_infallible(&self) -> InfallibleMesh {
         let resolution = self.resolution as usize;
         let mut indices = Vec::with_capacity((resolution - 2) * 3);
         let mut positions = Vec::with_capacity(resolution);
@@ -602,7 +603,7 @@ impl MeshBuilder for EllipseMeshBuilder {
             indices.extend_from_slice(&[0, i, i + 1]);
         }
 
-        Mesh::new(
+        InfallibleMesh::new(
             PrimitiveTopology::TriangleList,
             RenderAssetUsages::default(),
         )
@@ -655,11 +656,11 @@ impl Segment2dMeshBuilder {
 }
 
 impl MeshBuilder for Segment2dMeshBuilder {
-    fn build(&self) -> Mesh {
+    fn build_infallible(&self) -> InfallibleMesh {
         let positions = self.segment.vertices.map(|v| v.extend(0.0)).to_vec();
         let indices = Indices::U32(vec![0, 1]);
 
-        Mesh::new(PrimitiveTopology::LineList, RenderAssetUsages::default())
+        InfallibleMesh::new(PrimitiveTopology::LineList, RenderAssetUsages::default())
             .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, positions)
             .with_inserted_indices(indices)
     }
@@ -688,7 +689,7 @@ pub struct Polyline2dMeshBuilder {
 }
 
 impl MeshBuilder for Polyline2dMeshBuilder {
-    fn build(&self) -> Mesh {
+    fn build_infallible(&self) -> InfallibleMesh {
         let positions: Vec<_> = self
             .polyline
             .vertices
@@ -702,7 +703,7 @@ impl MeshBuilder for Polyline2dMeshBuilder {
                 .collect(),
         );
 
-        Mesh::new(PrimitiveTopology::LineList, RenderAssetUsages::default())
+        InfallibleMesh::new(PrimitiveTopology::LineList, RenderAssetUsages::default())
             .with_inserted_indices(indices)
             .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, positions)
     }
@@ -764,7 +765,7 @@ impl AnnulusMeshBuilder {
 }
 
 impl MeshBuilder for AnnulusMeshBuilder {
-    fn build(&self) -> Mesh {
+    fn build_infallible(&self) -> InfallibleMesh {
         let inner_radius = self.annulus.inner_circle.radius;
         let outer_radius = self.annulus.outer_circle.radius;
 
@@ -811,7 +812,7 @@ impl MeshBuilder for AnnulusMeshBuilder {
             indices.extend_from_slice(&[next_outer, next_inner, inner_vertex]);
         }
 
-        Mesh::new(
+        InfallibleMesh::new(
             PrimitiveTopology::TriangleList,
             RenderAssetUsages::default(),
         )
@@ -896,7 +897,7 @@ impl RhombusMeshBuilder {
 }
 
 impl MeshBuilder for RhombusMeshBuilder {
-    fn build(&self) -> Mesh {
+    fn build_infallible(&self) -> InfallibleMesh {
         let [hhd, vhd] = [self.half_diagonals.x, self.half_diagonals.y];
         let positions = vec![
             [hhd, 0.0, 0.0],
@@ -908,7 +909,7 @@ impl MeshBuilder for RhombusMeshBuilder {
         let uvs = vec![[1.0, 0.5], [0.5, 0.0], [0.0, 0.5], [0.5, 1.0]];
         let indices = Indices::U32(vec![2, 0, 1, 2, 3, 0]);
 
-        Mesh::new(
+        InfallibleMesh::new(
             PrimitiveTopology::TriangleList,
             RenderAssetUsages::default(),
         )
@@ -968,7 +969,7 @@ impl Meshable for Triangle2d {
 }
 
 impl MeshBuilder for Triangle2dMeshBuilder {
-    fn build(&self) -> Mesh {
+    fn build_infallible(&self) -> InfallibleMesh {
         let vertices_3d = self.triangle.vertices.map(|v| v.extend(0.));
 
         let positions: Vec<_> = vertices_3d.into();
@@ -988,7 +989,7 @@ impl MeshBuilder for Triangle2dMeshBuilder {
             Indices::U32(vec![2, 1, 0])
         };
 
-        Mesh::new(
+        InfallibleMesh::new(
             PrimitiveTopology::TriangleList,
             RenderAssetUsages::default(),
         )
@@ -1053,7 +1054,7 @@ impl RectangleMeshBuilder {
 }
 
 impl MeshBuilder for RectangleMeshBuilder {
-    fn build(&self) -> Mesh {
+    fn build_infallible(&self) -> InfallibleMesh {
         let [hw, hh] = [self.half_size.x, self.half_size.y];
         let positions = vec![
             [hw, hh, 0.0],
@@ -1065,7 +1066,7 @@ impl MeshBuilder for RectangleMeshBuilder {
         let uvs = vec![[1.0, 0.0], [0.0, 0.0], [0.0, 1.0], [1.0, 1.0]];
         let indices = Indices::U32(vec![0, 1, 2, 0, 2, 3]);
 
-        Mesh::new(
+        InfallibleMesh::new(
             PrimitiveTopology::TriangleList,
             RenderAssetUsages::default(),
         )
@@ -1143,7 +1144,7 @@ impl Capsule2dMeshBuilder {
 }
 
 impl MeshBuilder for Capsule2dMeshBuilder {
-    fn build(&self) -> Mesh {
+    fn build_infallible(&self) -> InfallibleMesh {
         // The resolution is the number of vertices for one semicircle
         let resolution = self.resolution;
         let vertex_count = 2 * resolution;
@@ -1207,7 +1208,7 @@ impl MeshBuilder for Capsule2dMeshBuilder {
         // Add indices for bottom right triangle of the part between the semicircles
         indices.extend_from_slice(&[resolution, vertex_count - 1, 0]);
 
-        Mesh::new(
+        InfallibleMesh::new(
             PrimitiveTopology::TriangleList,
             RenderAssetUsages::default(),
         )
@@ -1290,7 +1291,7 @@ where
     }
 
     fn get_vertex_attributes(&self) -> Option<RingMeshBuilderVertexAttributes> {
-        fn get_positions(mesh: &mut Mesh) -> Option<&mut Vec<[f32; 3]>> {
+        fn get_positions(mesh: &mut InfallibleMesh) -> Option<&mut Vec<[f32; 3]>> {
             if let VertexAttributeValues::Float32x3(data) =
                 mesh.attribute_mut(Mesh::ATTRIBUTE_POSITION)?
             {
@@ -1300,7 +1301,7 @@ where
             }
         }
 
-        fn get_uvs(mesh: &mut Mesh) -> Option<&mut Vec<[f32; 2]>> {
+        fn get_uvs(mesh: &mut InfallibleMesh) -> Option<&mut Vec<[f32; 2]>> {
             if let VertexAttributeValues::Float32x2(data) =
                 mesh.attribute_mut(Mesh::ATTRIBUTE_UV_0)?
             {
@@ -1310,7 +1311,7 @@ where
             }
         }
 
-        fn get_normals(mesh: &mut Mesh) -> Option<&mut Vec<[f32; 3]>> {
+        fn get_normals(mesh: &mut InfallibleMesh) -> Option<&mut Vec<[f32; 3]>> {
             if let VertexAttributeValues::Float32x3(data) =
                 mesh.attribute_mut(Mesh::ATTRIBUTE_NORMAL)?
             {
@@ -1320,8 +1321,8 @@ where
             }
         }
 
-        let mut outer = self.outer_shape_builder.build();
-        let mut inner = self.inner_shape_builder.build();
+        let mut outer = self.outer_shape_builder.build_infallible();
+        let mut inner = self.inner_shape_builder.build_infallible();
 
         assert_eq!(
             outer.primitive_topology(),
@@ -1371,7 +1372,7 @@ where
     /// It is assumed that the `primitive_topology` of the mesh returned by
     /// the underlying builder is [`PrimitiveTopology::TriangleList`]
     /// and that the mesh has [`Mesh::ATTRIBUTE_POSITION`], [`Mesh::ATTRIBUTE_NORMAL`] and [`Mesh::ATTRIBUTE_UV_0`] attributes.
-    fn build(&self) -> Mesh {
+    fn build_infallible(&self) -> InfallibleMesh {
         if let Some(RingMeshBuilderVertexAttributes {
             outer_uvs,
             inner_uvs,
@@ -1424,7 +1425,7 @@ where
             let mut positions = outer_positions;
             positions.extend_from_slice(&inner_positions);
 
-            Mesh::new(
+            InfallibleMesh::new(
                 PrimitiveTopology::TriangleList,
                 RenderAssetUsages::default(),
             )
@@ -1569,7 +1570,7 @@ mod tests {
 
     #[test]
     fn test_regular_polygon() {
-        let mut mesh = Mesh::from(RegularPolygon::new(7.0, 4));
+        let mut mesh = RegularPolygon::new(7.0, 4).mesh().build_infallible();
 
         let Some(VertexAttributeValues::Float32x3(mut positions)) =
             mesh.remove_attribute(Mesh::ATTRIBUTE_POSITION)

--- a/crates/bevy_mesh/src/primitives/dim3/capsule.rs
+++ b/crates/bevy_mesh/src/primitives/dim3/capsule.rs
@@ -1,4 +1,4 @@
-use crate::{Indices, Mesh, MeshBuilder, Meshable, PrimitiveTopology};
+use crate::{Indices, InfallibleMesh, Mesh, MeshBuilder, Meshable, PrimitiveTopology};
 use bevy_asset::RenderAssetUsages;
 use bevy_math::{ops, primitives::Capsule3d, Vec2, Vec3};
 use bevy_reflect::prelude::*;
@@ -94,7 +94,7 @@ impl Capsule3dMeshBuilder {
 }
 
 impl MeshBuilder for Capsule3dMeshBuilder {
-    fn build(&self) -> Mesh {
+    fn build_infallible(&self) -> InfallibleMesh {
         // code adapted from https://behreajj.medium.com/making-a-capsule-mesh-via-script-in-five-3d-environments-c2214abf02db
         let Capsule3dMeshBuilder {
             capsule,
@@ -407,7 +407,7 @@ impl MeshBuilder for Capsule3dMeshBuilder {
         assert_eq!(vs.len(), vert_len);
         assert_eq!(tris.len(), fs_len as usize);
 
-        Mesh::new(
+        InfallibleMesh::new(
             PrimitiveTopology::TriangleList,
             RenderAssetUsages::default(),
         )

--- a/crates/bevy_mesh/src/primitives/dim3/capsule.rs
+++ b/crates/bevy_mesh/src/primitives/dim3/capsule.rs
@@ -421,16 +421,10 @@ impl MeshBuilder for Capsule3dMeshBuilder {
 impl Meshable for Capsule3d {
     type Output = Capsule3dMeshBuilder;
 
-    fn mesh(&self) -> Self::Output {
+    fn mesh(self) -> Self::Output {
         Capsule3dMeshBuilder {
-            capsule: *self,
+            capsule: self,
             ..Default::default()
         }
-    }
-}
-
-impl From<Capsule3d> for Mesh {
-    fn from(capsule: Capsule3d) -> Self {
-        capsule.mesh().build()
     }
 }

--- a/crates/bevy_mesh/src/primitives/dim3/cone.rs
+++ b/crates/bevy_mesh/src/primitives/dim3/cone.rs
@@ -1,4 +1,4 @@
-use crate::{Indices, Mesh, MeshBuilder, Meshable, PrimitiveTopology};
+use crate::{Indices, InfallibleMesh, Mesh, MeshBuilder, Meshable, PrimitiveTopology};
 use bevy_asset::RenderAssetUsages;
 use bevy_math::{ops, primitives::Cone, Vec3};
 use bevy_reflect::prelude::*;
@@ -69,7 +69,7 @@ impl ConeMeshBuilder {
 }
 
 impl MeshBuilder for ConeMeshBuilder {
-    fn build(&self) -> Mesh {
+    fn build_infallible(&self) -> InfallibleMesh {
         let half_height = self.cone.height / 2.0;
 
         // `resolution` vertices for the base, `resolution` vertices for the bottom of the lateral surface,
@@ -160,7 +160,7 @@ impl MeshBuilder for ConeMeshBuilder {
             ConeAnchor::MidPoint => (),
         };
 
-        Mesh::new(
+        InfallibleMesh::new(
             PrimitiveTopology::TriangleList,
             RenderAssetUsages::default(),
         )
@@ -213,7 +213,7 @@ mod tests {
         }
         .mesh()
         .resolution(4)
-        .build();
+        .build_infallible();
 
         let Some(VertexAttributeValues::Float32x3(mut positions)) =
             mesh.remove_attribute(Mesh::ATTRIBUTE_POSITION)

--- a/crates/bevy_mesh/src/primitives/dim3/cone.rs
+++ b/crates/bevy_mesh/src/primitives/dim3/cone.rs
@@ -174,17 +174,11 @@ impl MeshBuilder for ConeMeshBuilder {
 impl Meshable for Cone {
     type Output = ConeMeshBuilder;
 
-    fn mesh(&self) -> Self::Output {
+    fn mesh(self) -> Self::Output {
         ConeMeshBuilder {
-            cone: *self,
+            cone: self,
             ..Default::default()
         }
-    }
-}
-
-impl From<Cone> for Mesh {
-    fn from(cone: Cone) -> Self {
-        cone.mesh().build()
     }
 }
 

--- a/crates/bevy_mesh/src/primitives/dim3/conical_frustum.rs
+++ b/crates/bevy_mesh/src/primitives/dim3/conical_frustum.rs
@@ -169,16 +169,10 @@ impl MeshBuilder for ConicalFrustumMeshBuilder {
 impl Meshable for ConicalFrustum {
     type Output = ConicalFrustumMeshBuilder;
 
-    fn mesh(&self) -> Self::Output {
+    fn mesh(self) -> Self::Output {
         ConicalFrustumMeshBuilder {
-            frustum: *self,
+            frustum: self,
             ..Default::default()
         }
-    }
-}
-
-impl From<ConicalFrustum> for Mesh {
-    fn from(frustum: ConicalFrustum) -> Self {
-        frustum.mesh().build()
     }
 }

--- a/crates/bevy_mesh/src/primitives/dim3/conical_frustum.rs
+++ b/crates/bevy_mesh/src/primitives/dim3/conical_frustum.rs
@@ -1,4 +1,4 @@
-use crate::{Indices, Mesh, MeshBuilder, Meshable, PrimitiveTopology};
+use crate::{Indices, InfallibleMesh, Mesh, MeshBuilder, Meshable, PrimitiveTopology};
 use bevy_asset::RenderAssetUsages;
 use bevy_math::{ops, primitives::ConicalFrustum, Vec3};
 use bevy_reflect::prelude::*;
@@ -61,7 +61,7 @@ impl ConicalFrustumMeshBuilder {
 }
 
 impl MeshBuilder for ConicalFrustumMeshBuilder {
-    fn build(&self) -> Mesh {
+    fn build_infallible(&self) -> InfallibleMesh {
         debug_assert!(self.resolution > 2);
         debug_assert!(self.segments > 0);
 
@@ -155,7 +155,7 @@ impl MeshBuilder for ConicalFrustumMeshBuilder {
         build_cap(true, radius_top);
         build_cap(false, radius_bottom);
 
-        Mesh::new(
+        InfallibleMesh::new(
             PrimitiveTopology::TriangleList,
             RenderAssetUsages::default(),
         )

--- a/crates/bevy_mesh/src/primitives/dim3/cuboid.rs
+++ b/crates/bevy_mesh/src/primitives/dim3/cuboid.rs
@@ -85,15 +85,9 @@ impl MeshBuilder for CuboidMeshBuilder {
 impl Meshable for Cuboid {
     type Output = CuboidMeshBuilder;
 
-    fn mesh(&self) -> Self::Output {
+    fn mesh(self) -> Self::Output {
         CuboidMeshBuilder {
             half_size: self.half_size,
         }
-    }
-}
-
-impl From<Cuboid> for Mesh {
-    fn from(cuboid: Cuboid) -> Self {
-        cuboid.mesh().build()
     }
 }

--- a/crates/bevy_mesh/src/primitives/dim3/cuboid.rs
+++ b/crates/bevy_mesh/src/primitives/dim3/cuboid.rs
@@ -1,4 +1,4 @@
-use crate::{Indices, Mesh, MeshBuilder, Meshable, PrimitiveTopology};
+use crate::{Indices, InfallibleMesh, Mesh, MeshBuilder, Meshable, PrimitiveTopology};
 use bevy_asset::RenderAssetUsages;
 use bevy_math::{primitives::Cuboid, Vec3};
 use bevy_reflect::prelude::*;
@@ -20,7 +20,7 @@ impl Default for CuboidMeshBuilder {
 }
 
 impl MeshBuilder for CuboidMeshBuilder {
-    fn build(&self) -> Mesh {
+    fn build_infallible(&self) -> InfallibleMesh {
         let min = -self.half_size;
         let max = self.half_size;
 
@@ -71,7 +71,7 @@ impl MeshBuilder for CuboidMeshBuilder {
             20, 21, 22, 22, 23, 20, // bottom
         ]);
 
-        Mesh::new(
+        InfallibleMesh::new(
             PrimitiveTopology::TriangleList,
             RenderAssetUsages::default(),
         )

--- a/crates/bevy_mesh/src/primitives/dim3/cylinder.rs
+++ b/crates/bevy_mesh/src/primitives/dim3/cylinder.rs
@@ -1,4 +1,4 @@
-use crate::{Indices, Mesh, MeshBuilder, Meshable, PrimitiveTopology};
+use crate::{Indices, InfallibleMesh, Mesh, MeshBuilder, Meshable, PrimitiveTopology};
 use bevy_asset::RenderAssetUsages;
 use bevy_math::{ops, primitives::Cylinder};
 use bevy_reflect::prelude::*;
@@ -94,7 +94,7 @@ impl CylinderMeshBuilder {
 }
 
 impl MeshBuilder for CylinderMeshBuilder {
-    fn build(&self) -> Mesh {
+    fn build_infallible(&self) -> InfallibleMesh {
         let resolution = self.resolution;
         let segments = self.segments;
 
@@ -193,7 +193,7 @@ impl MeshBuilder for CylinderMeshBuilder {
             CylinderAnchor::MidPoint => (),
         };
 
-        Mesh::new(
+        InfallibleMesh::new(
             PrimitiveTopology::TriangleList,
             RenderAssetUsages::default(),
         )

--- a/crates/bevy_mesh/src/primitives/dim3/cylinder.rs
+++ b/crates/bevy_mesh/src/primitives/dim3/cylinder.rs
@@ -207,16 +207,10 @@ impl MeshBuilder for CylinderMeshBuilder {
 impl Meshable for Cylinder {
     type Output = CylinderMeshBuilder;
 
-    fn mesh(&self) -> Self::Output {
+    fn mesh(self) -> Self::Output {
         CylinderMeshBuilder {
-            cylinder: *self,
+            cylinder: self,
             ..Default::default()
         }
-    }
-}
-
-impl From<Cylinder> for Mesh {
-    fn from(cylinder: Cylinder) -> Self {
-        cylinder.mesh().build()
     }
 }

--- a/crates/bevy_mesh/src/primitives/dim3/plane.rs
+++ b/crates/bevy_mesh/src/primitives/dim3/plane.rs
@@ -1,4 +1,4 @@
-use crate::{Indices, Mesh, MeshBuilder, Meshable, PrimitiveTopology};
+use crate::{Indices, InfallibleMesh, Mesh, MeshBuilder, Meshable, PrimitiveTopology};
 use bevy_asset::RenderAssetUsages;
 use bevy_math::{primitives::Plane3d, Dir3, Quat, Vec2, Vec3};
 use bevy_reflect::prelude::*;
@@ -94,7 +94,7 @@ impl PlaneMeshBuilder {
 }
 
 impl MeshBuilder for PlaneMeshBuilder {
-    fn build(&self) -> Mesh {
+    fn build_infallible(&self) -> InfallibleMesh {
         let z_vertex_count = self.subdivisions + 2;
         let x_vertex_count = self.subdivisions + 2;
         let num_vertices = (z_vertex_count * x_vertex_count) as usize;
@@ -131,7 +131,7 @@ impl MeshBuilder for PlaneMeshBuilder {
             }
         }
 
-        Mesh::new(
+        InfallibleMesh::new(
             PrimitiveTopology::TriangleList,
             RenderAssetUsages::default(),
         )

--- a/crates/bevy_mesh/src/primitives/dim3/plane.rs
+++ b/crates/bevy_mesh/src/primitives/dim3/plane.rs
@@ -145,16 +145,10 @@ impl MeshBuilder for PlaneMeshBuilder {
 impl Meshable for Plane3d {
     type Output = PlaneMeshBuilder;
 
-    fn mesh(&self) -> Self::Output {
+    fn mesh(self) -> Self::Output {
         PlaneMeshBuilder {
-            plane: *self,
+            plane: self,
             subdivisions: 0,
         }
-    }
-}
-
-impl From<Plane3d> for Mesh {
-    fn from(plane: Plane3d) -> Self {
-        plane.mesh().build()
     }
 }

--- a/crates/bevy_mesh/src/primitives/dim3/polyline3d.rs
+++ b/crates/bevy_mesh/src/primitives/dim3/polyline3d.rs
@@ -1,4 +1,4 @@
-use crate::{Indices, Mesh, MeshBuilder, Meshable, PrimitiveTopology};
+use crate::{Indices, InfallibleMesh, Mesh, MeshBuilder, Meshable, PrimitiveTopology};
 use bevy_asset::RenderAssetUsages;
 use bevy_math::primitives::Polyline3d;
 use bevy_reflect::prelude::*;
@@ -11,7 +11,7 @@ pub struct Polyline3dMeshBuilder {
 }
 
 impl MeshBuilder for Polyline3dMeshBuilder {
-    fn build(&self) -> Mesh {
+    fn build_infallible(&self) -> InfallibleMesh {
         let positions: Vec<_> = self.polyline.vertices.clone();
 
         let indices = Indices::U32(
@@ -20,7 +20,7 @@ impl MeshBuilder for Polyline3dMeshBuilder {
                 .collect(),
         );
 
-        Mesh::new(PrimitiveTopology::LineList, RenderAssetUsages::default())
+        InfallibleMesh::new(PrimitiveTopology::LineList, RenderAssetUsages::default())
             .with_inserted_indices(indices)
             .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, positions)
     }

--- a/crates/bevy_mesh/src/primitives/dim3/polyline3d.rs
+++ b/crates/bevy_mesh/src/primitives/dim3/polyline3d.rs
@@ -29,15 +29,7 @@ impl MeshBuilder for Polyline3dMeshBuilder {
 impl Meshable for Polyline3d {
     type Output = Polyline3dMeshBuilder;
 
-    fn mesh(&self) -> Self::Output {
-        Polyline3dMeshBuilder {
-            polyline: self.clone(),
-        }
-    }
-}
-
-impl From<Polyline3d> for Mesh {
-    fn from(polyline: Polyline3d) -> Self {
-        polyline.mesh().build()
+    fn mesh(self) -> Self::Output {
+        Polyline3dMeshBuilder { polyline: self }
     }
 }

--- a/crates/bevy_mesh/src/primitives/dim3/segment3d.rs
+++ b/crates/bevy_mesh/src/primitives/dim3/segment3d.rs
@@ -1,4 +1,4 @@
-use crate::{Indices, Mesh, MeshBuilder, Meshable, PrimitiveTopology};
+use crate::{Indices, InfallibleMesh, Mesh, MeshBuilder, Meshable, PrimitiveTopology};
 use bevy_asset::RenderAssetUsages;
 use bevy_math::primitives::Segment3d;
 use bevy_reflect::prelude::*;
@@ -11,11 +11,11 @@ pub struct Segment3dMeshBuilder {
 }
 
 impl MeshBuilder for Segment3dMeshBuilder {
-    fn build(&self) -> Mesh {
+    fn build_infallible(&self) -> InfallibleMesh {
         let positions: Vec<_> = self.segment.vertices.into();
         let indices = Indices::U32(vec![0, 1]);
 
-        Mesh::new(PrimitiveTopology::LineList, RenderAssetUsages::default())
+        InfallibleMesh::new(PrimitiveTopology::LineList, RenderAssetUsages::default())
             .with_inserted_indices(indices)
             .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, positions)
     }

--- a/crates/bevy_mesh/src/primitives/dim3/segment3d.rs
+++ b/crates/bevy_mesh/src/primitives/dim3/segment3d.rs
@@ -24,14 +24,8 @@ impl MeshBuilder for Segment3dMeshBuilder {
 impl Meshable for Segment3d {
     type Output = Segment3dMeshBuilder;
 
-    fn mesh(&self) -> Self::Output {
-        Segment3dMeshBuilder { segment: *self }
-    }
-}
-
-impl From<Segment3d> for Mesh {
-    fn from(segment: Segment3d) -> Self {
-        segment.mesh().build()
+    fn mesh(self) -> Self::Output {
+        Segment3dMeshBuilder { segment: self }
     }
 }
 

--- a/crates/bevy_mesh/src/primitives/dim3/sphere.rs
+++ b/crates/bevy_mesh/src/primitives/dim3/sphere.rs
@@ -1,4 +1,4 @@
-use crate::{Indices, Mesh, MeshBuilder, Meshable, PrimitiveTopology};
+use crate::{Indices, InfallibleMesh, Mesh, MeshBuilder, Meshable, PrimitiveTopology};
 use bevy_asset::RenderAssetUsages;
 use bevy_math::{ops, primitives::Sphere};
 use bevy_reflect::prelude::*;
@@ -81,7 +81,7 @@ impl SphereMeshBuilder {
     /// and an [`IcosphereError`] is returned.
     ///
     /// A good default is `5` subdivisions.
-    pub fn ico(&self, subdivisions: u32) -> Result<Mesh, IcosphereError> {
+    pub fn ico(&self, subdivisions: u32) -> Result<InfallibleMesh, IcosphereError> {
         if subdivisions >= 80 {
             /*
             Number of triangles:
@@ -151,7 +151,7 @@ impl SphereMeshBuilder {
 
         let indices = Indices::U32(indices);
 
-        Ok(Mesh::new(
+        Ok(InfallibleMesh::new(
             PrimitiveTopology::TriangleList,
             RenderAssetUsages::default(),
         )
@@ -165,7 +165,7 @@ impl SphereMeshBuilder {
     /// longitudinal sectors and latitudinal stacks, aka horizontal and vertical resolution.
     ///
     /// A good default is `32` sectors and `18` stacks.
-    pub fn uv(&self, sectors: u32, stacks: u32) -> Mesh {
+    pub fn uv(&self, sectors: u32, stacks: u32) -> InfallibleMesh {
         // Largely inspired from http://www.songho.ca/opengl/gl_sphere.html
 
         let sectors_f32 = sectors as f32;
@@ -220,7 +220,7 @@ impl SphereMeshBuilder {
             }
         }
 
-        Mesh::new(
+        InfallibleMesh::new(
             PrimitiveTopology::TriangleList,
             RenderAssetUsages::default(),
         )
@@ -238,7 +238,7 @@ impl MeshBuilder for SphereMeshBuilder {
     ///
     /// Panics if the sphere is a [`SphereKind::Ico`] with a subdivision count
     /// that is greater than or equal to `80` because there will be too many vertices.
-    fn build(&self) -> Mesh {
+    fn build_infallible(&self) -> InfallibleMesh {
         match self.kind {
             SphereKind::Ico { subdivisions } => self.ico(subdivisions).unwrap(),
             SphereKind::Uv { sectors, stacks } => self.uv(sectors, stacks),

--- a/crates/bevy_mesh/src/primitives/dim3/sphere.rs
+++ b/crates/bevy_mesh/src/primitives/dim3/sphere.rs
@@ -249,16 +249,10 @@ impl MeshBuilder for SphereMeshBuilder {
 impl Meshable for Sphere {
     type Output = SphereMeshBuilder;
 
-    fn mesh(&self) -> Self::Output {
+    fn mesh(self) -> Self::Output {
         SphereMeshBuilder {
-            sphere: *self,
+            sphere: self,
             ..Default::default()
         }
-    }
-}
-
-impl From<Sphere> for Mesh {
-    fn from(sphere: Sphere) -> Self {
-        sphere.mesh().build()
     }
 }

--- a/crates/bevy_mesh/src/primitives/dim3/tetrahedron.rs
+++ b/crates/bevy_mesh/src/primitives/dim3/tetrahedron.rs
@@ -1,5 +1,5 @@
 use super::triangle3d;
-use crate::{Indices, Mesh, MeshBuilder, Meshable, PrimitiveTopology};
+use crate::{Indices, InfallibleMesh, Mesh, MeshBuilder, Meshable, PrimitiveTopology};
 use bevy_asset::RenderAssetUsages;
 use bevy_math::primitives::{Tetrahedron, Triangle3d};
 use bevy_reflect::prelude::*;
@@ -12,7 +12,7 @@ pub struct TetrahedronMeshBuilder {
 }
 
 impl MeshBuilder for TetrahedronMeshBuilder {
-    fn build(&self) -> Mesh {
+    fn build_infallible(&self) -> InfallibleMesh {
         let mut faces: Vec<_> = self.tetrahedron.faces().into();
 
         // If the tetrahedron has negative orientation, reverse all the triangles so that
@@ -40,7 +40,7 @@ impl MeshBuilder for TetrahedronMeshBuilder {
         // There are four faces and none of them share vertices.
         let indices = Indices::U32(vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
 
-        Mesh::new(
+        InfallibleMesh::new(
             PrimitiveTopology::TriangleList,
             RenderAssetUsages::default(),
         )

--- a/crates/bevy_mesh/src/primitives/dim3/tetrahedron.rs
+++ b/crates/bevy_mesh/src/primitives/dim3/tetrahedron.rs
@@ -54,13 +54,7 @@ impl MeshBuilder for TetrahedronMeshBuilder {
 impl Meshable for Tetrahedron {
     type Output = TetrahedronMeshBuilder;
 
-    fn mesh(&self) -> Self::Output {
-        TetrahedronMeshBuilder { tetrahedron: *self }
-    }
-}
-
-impl From<Tetrahedron> for Mesh {
-    fn from(tetrahedron: Tetrahedron) -> Self {
-        tetrahedron.mesh().build()
+    fn mesh(self) -> Self::Output {
+        TetrahedronMeshBuilder { tetrahedron: self }
     }
 }

--- a/crates/bevy_mesh/src/primitives/dim3/torus.rs
+++ b/crates/bevy_mesh/src/primitives/dim3/torus.rs
@@ -161,16 +161,10 @@ impl MeshBuilder for TorusMeshBuilder {
 impl Meshable for Torus {
     type Output = TorusMeshBuilder;
 
-    fn mesh(&self) -> Self::Output {
+    fn mesh(self) -> Self::Output {
         TorusMeshBuilder {
-            torus: *self,
+            torus: self,
             ..Default::default()
         }
-    }
-}
-
-impl From<Torus> for Mesh {
-    fn from(torus: Torus) -> Self {
-        torus.mesh().build()
     }
 }

--- a/crates/bevy_mesh/src/primitives/dim3/torus.rs
+++ b/crates/bevy_mesh/src/primitives/dim3/torus.rs
@@ -1,4 +1,4 @@
-use crate::{Indices, Mesh, MeshBuilder, Meshable, PrimitiveTopology};
+use crate::{Indices, InfallibleMesh, Mesh, MeshBuilder, Meshable, PrimitiveTopology};
 use bevy_asset::RenderAssetUsages;
 use bevy_math::{ops, primitives::Torus, Vec3};
 use bevy_reflect::prelude::*;
@@ -77,7 +77,7 @@ impl TorusMeshBuilder {
 }
 
 impl MeshBuilder for TorusMeshBuilder {
-    fn build(&self) -> Mesh {
+    fn build_infallible(&self) -> InfallibleMesh {
         // code adapted from http://apparat-engine.blogspot.com/2013/04/procedural-meshes-torus.html
 
         let n_vertices = (self.major_resolution + 1) * (self.minor_resolution + 1);
@@ -147,7 +147,7 @@ impl MeshBuilder for TorusMeshBuilder {
             }
         }
 
-        Mesh::new(
+        InfallibleMesh::new(
             PrimitiveTopology::TriangleList,
             RenderAssetUsages::default(),
         )

--- a/crates/bevy_mesh/src/primitives/dim3/triangle3d.rs
+++ b/crates/bevy_mesh/src/primitives/dim3/triangle3d.rs
@@ -1,4 +1,4 @@
-use crate::{Indices, Mesh, MeshBuilder, Meshable, PrimitiveTopology};
+use crate::{Indices, InfallibleMesh, Mesh, MeshBuilder, Meshable, PrimitiveTopology};
 use bevy_asset::RenderAssetUsages;
 use bevy_math::{primitives::Triangle3d, Vec3};
 use bevy_reflect::prelude::*;
@@ -11,7 +11,7 @@ pub struct Triangle3dMeshBuilder {
 }
 
 impl MeshBuilder for Triangle3dMeshBuilder {
-    fn build(&self) -> Mesh {
+    fn build_infallible(&self) -> InfallibleMesh {
         let positions: Vec<_> = self.triangle.vertices.into();
         let uvs: Vec<_> = uv_coords(&self.triangle).into();
 
@@ -21,7 +21,7 @@ impl MeshBuilder for Triangle3dMeshBuilder {
 
         let indices = Indices::U32(vec![0, 1, 2]);
 
-        Mesh::new(
+        InfallibleMesh::new(
             PrimitiveTopology::TriangleList,
             RenderAssetUsages::default(),
         )

--- a/crates/bevy_mesh/src/primitives/dim3/triangle3d.rs
+++ b/crates/bevy_mesh/src/primitives/dim3/triangle3d.rs
@@ -35,8 +35,8 @@ impl MeshBuilder for Triangle3dMeshBuilder {
 impl Meshable for Triangle3d {
     type Output = Triangle3dMeshBuilder;
 
-    fn mesh(&self) -> Self::Output {
-        Triangle3dMeshBuilder { triangle: *self }
+    fn mesh(self) -> Self::Output {
+        Triangle3dMeshBuilder { triangle: self }
     }
 }
 
@@ -91,12 +91,6 @@ pub(crate) fn uv_coords(triangle: &Triangle3d) -> [[f32; 2]; 3] {
         let c_uv = [offset, 1.];
 
         [a_uv, b_uv, c_uv]
-    }
-}
-
-impl From<Triangle3d> for Mesh {
-    fn from(triangle: Triangle3d) -> Self {
-        triangle.mesh().build()
     }
 }
 

--- a/crates/bevy_mesh/src/primitives/extrusion.rs
+++ b/crates/bevy_mesh/src/primitives/extrusion.rs
@@ -4,7 +4,7 @@ use bevy_math::{
 };
 
 use super::{MeshBuilder, Meshable};
-use crate::{Indices, Mesh, PrimitiveTopology, VertexAttributeValues};
+use crate::{Indices, InfallibleMesh, Mesh, PrimitiveTopology, VertexAttributeValues};
 
 /// A type representing a segment of the perimeter of an extrudable mesh.
 pub enum PerimeterSegment {
@@ -177,12 +177,12 @@ where
     P: Primitive2d + Meshable,
     P::Output: Extrudable,
 {
-    fn build(&self) -> Mesh {
+    fn build_infallible(&self) -> InfallibleMesh {
         // Create and move the base mesh to the front
-        let mut front_face =
-            self.base_builder
-                .build()
-                .translated_by(Vec3::new(0., 0., self.half_depth));
+        let mut front_face = self
+            .base_builder
+            .build_infallible()
+            .translated_by(Vec3::new(0., 0., self.half_depth));
 
         // Move the uvs of the front face to be between (0., 0.) and (0.5, 0.5)
         if let Some(VertexAttributeValues::Float32x2(uvs)) =
@@ -413,7 +413,7 @@ where
                 }
             }
 
-            Mesh::new(PrimitiveTopology::TriangleList, front_face.asset_usage)
+            InfallibleMesh::new(PrimitiveTopology::TriangleList, front_face.asset_usage)
                 .with_inserted_indices(Indices::U32(indices))
                 .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, positions)
                 .with_inserted_attribute(Mesh::ATTRIBUTE_NORMAL, normals)

--- a/crates/bevy_mesh/src/primitives/extrusion.rs
+++ b/crates/bevy_mesh/src/primitives/extrusion.rs
@@ -92,7 +92,7 @@ where
 {
     type Output = ExtrusionBuilder<P>;
 
-    fn mesh(&self) -> Self::Output {
+    fn mesh(self) -> Self::Output {
         ExtrusionBuilder {
             base_builder: self.base_shape.mesh(),
             half_depth: self.half_depth,
@@ -118,7 +118,7 @@ where
     P::Output: Extrudable,
 {
     /// Create a new `ExtrusionBuilder<P>` from a given `base_shape` and the full `depth` of the extrusion.
-    pub fn new(base_shape: &P, depth: f32) -> Self {
+    pub fn new(base_shape: P, depth: f32) -> Self {
         Self {
             base_builder: base_shape.mesh(),
             half_depth: depth / 2.,
@@ -423,15 +423,5 @@ where
         front_face.merge(&back_face).unwrap();
         front_face.merge(&mantel).unwrap();
         front_face
-    }
-}
-
-impl<P> From<Extrusion<P>> for Mesh
-where
-    P: Primitive2d + Meshable,
-    P::Output: Extrudable,
-{
-    fn from(value: Extrusion<P>) -> Self {
-        value.mesh().build()
     }
 }

--- a/crates/bevy_mesh/src/primitives/mod.rs
+++ b/crates/bevy_mesh/src/primitives/mod.rs
@@ -28,6 +28,8 @@ pub use dim3::*;
 mod extrusion;
 pub use extrusion::*;
 
+use crate::InfallibleMesh;
+
 use super::Mesh;
 
 /// A trait for shapes that can be turned into a [`Mesh`].
@@ -41,12 +43,23 @@ pub trait Meshable {
 
 /// A trait used to build [`Mesh`]es from a configuration
 pub trait MeshBuilder {
+    /// Builds an [`InfallibleMesh`] based on the configuration in `self`.
+    fn build_infallible(&self) -> InfallibleMesh;
+
     /// Builds a [`Mesh`] based on the configuration in `self`.
-    fn build(&self) -> Mesh;
+    fn build(&self) -> Mesh {
+        self.build_infallible().into()
+    }
 }
 
 impl<T: MeshBuilder> From<T> for Mesh {
     fn from(builder: T) -> Self {
         builder.build()
+    }
+}
+
+impl<T: MeshBuilder> From<T> for InfallibleMesh {
+    fn from(builder: T) -> Self {
+        builder.build_infallible()
     }
 }

--- a/crates/bevy_mesh/src/primitives/mod.rs
+++ b/crates/bevy_mesh/src/primitives/mod.rs
@@ -38,7 +38,7 @@ pub trait Meshable {
     type Output: MeshBuilder;
 
     /// Creates a [`Mesh`] for a shape.
-    fn mesh(&self) -> Self::Output;
+    fn mesh(self) -> Self::Output;
 }
 
 /// A trait used to build [`Mesh`]es from a configuration
@@ -52,14 +52,22 @@ pub trait MeshBuilder {
     }
 }
 
-impl<T: MeshBuilder> From<T> for Mesh {
-    fn from(builder: T) -> Self {
-        builder.build()
+impl<T: MeshBuilder> Meshable for T {
+    type Output = Self;
+
+    fn mesh(self) -> Self::Output {
+        self
     }
 }
 
-impl<T: MeshBuilder> From<T> for InfallibleMesh {
-    fn from(builder: T) -> Self {
-        builder.build_infallible()
+impl<T: Meshable> From<T> for Mesh {
+    fn from(meshable: T) -> Self {
+        meshable.mesh().build()
+    }
+}
+
+impl<T: Meshable> From<T> for InfallibleMesh {
+    fn from(meshable: T) -> Self {
+        meshable.mesh().build_infallible()
     }
 }

--- a/crates/bevy_pbr/src/decal/forward.rs
+++ b/crates/bevy_pbr/src/decal/forward.rs
@@ -32,7 +32,7 @@ impl Plugin for ForwardDecalPlugin {
         let mesh = app.world_mut().resource_mut::<Assets<Mesh>>().add(
             Rectangle::from_size(Vec2::ONE)
                 .mesh()
-                .build()
+                .build_infallible()
                 .rotated_by(Quat::from_rotation_arc(Vec3::Z, Vec3::Y))
                 .with_generated_tangents()
                 .unwrap(),

--- a/crates/bevy_render/src/mesh/allocator.rs
+++ b/crates/bevy_render/src/mesh/allocator.rs
@@ -1029,7 +1029,10 @@ impl ElementLayout {
     /// Creates the appropriate [`ElementLayout`] for the given mesh's index
     /// data.
     fn index(mesh: &Mesh) -> Option<ElementLayout> {
-        let size = match mesh.indices()? {
+        let size = match mesh
+            .indices_option()
+            .expect("mesh data should always be available in render world")?
+        {
             Indices::U16(_) => 2,
             Indices::U32(_) => 4,
         };

--- a/crates/bevy_solari/src/scene/blas.rs
+++ b/crates/bevy_solari/src/scene/blas.rs
@@ -172,12 +172,15 @@ fn allocate_blas(
 
 fn is_mesh_raytracing_compatible(mesh: &Mesh) -> bool {
     let triangle_list = mesh.primitive_topology() == PrimitiveTopology::TriangleList;
-    let vertex_attributes = mesh.attributes().map(|(attribute, _)| attribute.id).eq([
+    let Ok(attributes) = mesh.attributes() else {
+        return false;
+    };
+    let vertex_attributes = attributes.map(|(attribute, _)| attribute.id).eq([
         Mesh::ATTRIBUTE_POSITION.id,
         Mesh::ATTRIBUTE_NORMAL.id,
         Mesh::ATTRIBUTE_UV_0.id,
         Mesh::ATTRIBUTE_TANGENT.id,
     ]);
-    let indexed_32 = matches!(mesh.indices(), Some(Indices::U32(..)));
+    let indexed_32 = matches!(mesh.indices(), Ok(Indices::U32(..)));
     mesh.enable_raytracing && triangle_list && vertex_attributes && indexed_32
 }

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -10,7 +10,7 @@ use bevy::{
     color::palettes::basic::YELLOW,
     core_pipeline::core_2d::{Transparent2d, CORE_2D_DEPTH_FORMAT},
     math::{ops, FloatOrd},
-    mesh::{Indices, MeshVertexAttribute, VertexBufferLayout},
+    mesh::{Indices, InfallibleMesh, MeshVertexAttribute, VertexBufferLayout},
     prelude::*,
     render::{
         mesh::RenderMesh,
@@ -58,7 +58,7 @@ fn star(
     // specified. We set `RenderAssetUsages::RENDER_WORLD`, meaning this mesh
     // will not be accessible in future frames from the `meshes` resource, in
     // order to save on memory once it has been uploaded to the GPU.
-    let mut star = Mesh::new(
+    let mut star = InfallibleMesh::new(
         PrimitiveTopology::TriangleList,
         RenderAssetUsages::RENDER_WORLD,
     );

--- a/examples/2d/mesh2d_vertex_color_texture.rs
+++ b/examples/2d/mesh2d_vertex_color_texture.rs
@@ -1,7 +1,7 @@
 //! Shows how to render a polygonal [`Mesh`], generated from a [`Rectangle`] primitive, in a 2D scene.
 //! Adds a texture and colored vertices, giving per-vertex tinting.
 
-use bevy::prelude::*;
+use bevy::{mesh::InfallibleMesh, prelude::*};
 
 fn main() {
     App::new()
@@ -19,7 +19,7 @@ fn setup(
     // Load the Bevy logo as a texture
     let texture_handle = asset_server.load("branding/banner.png");
     // Build a default quad mesh
-    let mut mesh = Mesh::from(Rectangle::default());
+    let mut mesh = InfallibleMesh::from(Rectangle::default().mesh());
     // Build vertex colors for the quad. One entry per vertex (the corners of the quad)
     let vertex_colors: Vec<[f32; 4]> = vec![
         LinearRgba::RED.to_f32_array(),

--- a/examples/3d/clustered_decal_maps.rs
+++ b/examples/3d/clustered_decal_maps.rs
@@ -197,7 +197,7 @@ fn spawn_plane_mesh(
             half_size: Vec2::splat(PLANE_HALF_SIZE),
         }
         .mesh()
-        .build()
+        .build_infallible()
         .with_duplicated_vertices()
         .with_computed_flat_normals()
         .with_generated_tangents()

--- a/examples/3d/generate_custom_mesh.rs
+++ b/examples/3d/generate_custom_mesh.rs
@@ -4,7 +4,7 @@
 
 use bevy::{
     asset::RenderAssetUsages,
-    mesh::{Indices, VertexAttributeValues},
+    mesh::{Indices, InfallibleMesh, VertexAttributeValues},
     prelude::*,
     render::render_resource::PrimitiveTopology,
 };
@@ -103,9 +103,9 @@ fn input_handler(
 }
 
 #[rustfmt::skip]
-fn create_cube_mesh() -> Mesh {
+fn create_cube_mesh() -> InfallibleMesh {
     // Keep the mesh data accessible in future frames to be able to mutate it in toggle_texture.
-    Mesh::new(PrimitiveTopology::TriangleList, RenderAssetUsages::MAIN_WORLD | RenderAssetUsages::RENDER_WORLD)
+    InfallibleMesh::new(PrimitiveTopology::TriangleList, RenderAssetUsages::MAIN_WORLD | RenderAssetUsages::RENDER_WORLD)
     .with_inserted_attribute(
         Mesh::ATTRIBUTE_POSITION,
         // Each array is an [x, y, z] coordinate in local space.

--- a/examples/3d/lines.rs
+++ b/examples/3d/lines.rs
@@ -2,7 +2,7 @@
 
 use bevy::{
     asset::RenderAssetUsages,
-    mesh::{MeshVertexBufferLayoutRef, PrimitiveTopology},
+    mesh::{InfallibleMesh, MeshVertexBufferLayoutRef, PrimitiveTopology},
     pbr::{MaterialPipeline, MaterialPipelineKey},
     prelude::*,
     reflect::TypePath,
@@ -96,7 +96,7 @@ impl From<LineList> for Mesh {
     fn from(line: LineList) -> Self {
         let vertices: Vec<_> = line.lines.into_iter().flat_map(|(a, b)| [a, b]).collect();
 
-        Mesh::new(
+        InfallibleMesh::new(
             // This tells wgpu that the positions are list of lines
             // where every pair is a start and end point
             PrimitiveTopology::LineList,
@@ -104,6 +104,7 @@ impl From<LineList> for Mesh {
         )
         // Add the vertices positions as an attribute
         .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, vertices)
+        .into()
     }
 }
 
@@ -115,7 +116,7 @@ struct LineStrip {
 
 impl From<LineStrip> for Mesh {
     fn from(line: LineStrip) -> Self {
-        Mesh::new(
+        InfallibleMesh::new(
             // This tells wgpu that the positions are a list of points
             // where a line will be drawn between each consecutive point
             PrimitiveTopology::LineStrip,
@@ -123,5 +124,6 @@ impl From<LineStrip> for Mesh {
         )
         // Add the point positions as an attribute
         .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, line.points)
+        .into()
     }
 }

--- a/examples/3d/motion_blur.rs
+++ b/examples/3d/motion_blur.rs
@@ -4,6 +4,7 @@
 use bevy::{
     image::{ImageAddressMode, ImageFilterMode, ImageSampler, ImageSamplerDescriptor},
     math::ops,
+    mesh::InfallibleMesh,
     post_process::motion_blur::MotionBlur,
     prelude::*,
 };
@@ -82,7 +83,7 @@ fn setup_scene(
         Transform::default().with_scale(Vec3::splat(-4000.0)),
     ));
     // Ground
-    let mut plane: Mesh = Plane3d::default().into();
+    let mut plane: InfallibleMesh = Plane3d::default().mesh().into();
     let uv_size = 4000.0;
     let uvs = vec![[uv_size, 0.0], [0.0, 0.0], [0.0, uv_size], [uv_size; 2]];
     plane.insert_attribute(Mesh::ATTRIBUTE_UV_0, uvs);

--- a/examples/3d/solari.rs
+++ b/examples/3d/solari.rs
@@ -179,19 +179,21 @@ fn add_raytracing_meshes_on_scene_load(
 
             // Ensure meshes are Solari compatible
             let mesh = meshes.get_mut(mesh_handle).unwrap();
-            if !mesh.contains_attribute(Mesh::ATTRIBUTE_UV_0) {
+            if !mesh.contains_attribute(Mesh::ATTRIBUTE_UV_0).unwrap() {
                 let vertex_count = mesh.count_vertices();
-                mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, vec![[0.0, 0.0]; vertex_count]);
+                mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, vec![[0.0, 0.0]; vertex_count])
+                    .unwrap();
                 mesh.insert_attribute(
                     Mesh::ATTRIBUTE_TANGENT,
                     vec![[0.0, 0.0, 0.0, 0.0]; vertex_count],
-                );
+                )
+                .unwrap();
             }
-            if !mesh.contains_attribute(Mesh::ATTRIBUTE_TANGENT) {
+            if !mesh.contains_attribute(Mesh::ATTRIBUTE_TANGENT).unwrap() {
                 mesh.generate_tangents().unwrap();
             }
-            if mesh.contains_attribute(Mesh::ATTRIBUTE_UV_1) {
-                mesh.remove_attribute(Mesh::ATTRIBUTE_UV_1);
+            if mesh.contains_attribute(Mesh::ATTRIBUTE_UV_1).unwrap() {
+                let _ = mesh.remove_attribute(Mesh::ATTRIBUTE_UV_1);
             }
 
             // Prevent rasterization if using pathtracer

--- a/examples/3d/vertex_colors.rs
+++ b/examples/3d/vertex_colors.rs
@@ -1,6 +1,9 @@
 //! Illustrates the use of vertex colors.
 
-use bevy::{mesh::VertexAttributeValues, prelude::*};
+use bevy::{
+    mesh::{InfallibleMesh, VertexAttributeValues},
+    prelude::*,
+};
 
 fn main() {
     App::new()
@@ -22,7 +25,7 @@ fn setup(
     ));
     // cube
     // Assign vertex colors based on vertex positions
-    let mut colorful_cube = Mesh::from(Cuboid::default());
+    let mut colorful_cube = InfallibleMesh::from(Cuboid::default().mesh());
     if let Some(VertexAttributeValues::Float32x3(positions)) =
         colorful_cube.attribute(Mesh::ATTRIBUTE_POSITION)
     {

--- a/examples/animation/custom_skinned_mesh.rs
+++ b/examples/animation/custom_skinned_mesh.rs
@@ -8,7 +8,7 @@ use bevy::{
     math::ops,
     mesh::{
         skinning::{SkinnedMesh, SkinnedMeshInverseBindposes},
-        Indices, PrimitiveTopology, VertexAttributeValues,
+        Indices, InfallibleMesh, PrimitiveTopology, VertexAttributeValues,
     },
     prelude::*,
 };
@@ -54,7 +54,7 @@ fn setup(
     ]);
 
     // Create a mesh
-    let mesh = Mesh::new(
+    let mesh = InfallibleMesh::new(
         PrimitiveTopology::TriangleList,
         RenderAssetUsages::RENDER_WORLD,
     )

--- a/examples/animation/morph_targets.rs
+++ b/examples/animation/morph_targets.rs
@@ -86,7 +86,7 @@ fn name_morphs(
         if let AssetEvent::<Mesh>::Added { id } = event
             && let Some(path) = asset_server.get_path(*id)
             && let Some(mesh) = meshes.get(*id)
-            && let Some(names) = mesh.morph_target_names()
+            && let Some(names) = mesh.morph_target_names().unwrap()
         {
             info!("Morph target names for {path:?}:");
 

--- a/examples/asset/alter_mesh.rs
+++ b/examples/asset/alter_mesh.rs
@@ -188,7 +188,7 @@ fn alter_mesh(
     // `ATTRIBUTE_POSITION` is a constant indicating that we want to know where the vertex is
     // located in space (as opposed to which way its normal is facing, vertex color, or other
     // details).
-    if let Some(VertexAttributeValues::Float32x3(positions)) =
+    if let Ok(VertexAttributeValues::Float32x3(positions)) =
         mesh.attribute_mut(Mesh::ATTRIBUTE_POSITION)
     {
         // Check a Local value (which only this system can make use of) to determine if we're

--- a/examples/gltf/query_gltf_primitives.rs
+++ b/examples/gltf/query_gltf_primitives.rs
@@ -35,7 +35,7 @@ fn find_top_material_and_mesh(
             }
 
             if let Some(mesh) = meshes.get_mut(mesh_handle)
-                && let Some(VertexAttributeValues::Float32x3(positions)) =
+                && let Ok(VertexAttributeValues::Float32x3(positions)) =
                     mesh.attribute_mut(Mesh::ATTRIBUTE_POSITION)
             {
                 for position in positions {

--- a/examples/math/custom_primitives.rs
+++ b/examples/math/custom_primitives.rs
@@ -17,7 +17,7 @@ use bevy::{
         },
         Isometry2d,
     },
-    mesh::{Extrudable, ExtrusionBuilder, PerimeterSegment},
+    mesh::{Extrudable, ExtrusionBuilder, InfallibleMesh, PerimeterSegment},
     prelude::*,
 };
 
@@ -510,7 +510,7 @@ impl HeartBuilder for ExtrusionBuilder<Heart> {
 
 impl MeshBuilder for HeartMeshBuilder {
     // This is where you should build the actual mesh.
-    fn build(&self) -> Mesh {
+    fn build_infallible(&self) -> InfallibleMesh {
         let radius = self.heart.radius;
         // The curved parts of each wing (half) of the heart have an angle of `PI * 1.25` or 225°
         let wing_angle = PI * 1.25;
@@ -553,7 +553,7 @@ impl MeshBuilder for HeartMeshBuilder {
         }
 
         // Here, the actual `Mesh` is created. We set the indices, vertices, normals and UVs created above and specify the topology of the mesh.
-        Mesh::new(
+        InfallibleMesh::new(
             bevy::mesh::PrimitiveTopology::TriangleList,
             RenderAssetUsages::default(),
         )

--- a/examples/math/custom_primitives.rs
+++ b/examples/math/custom_primitives.rs
@@ -472,9 +472,9 @@ impl Meshable for Heart {
     // The `MeshBuilder` can be used to create the actual mesh for that primitive.
     type Output = HeartMeshBuilder;
 
-    fn mesh(&self) -> Self::Output {
+    fn mesh(self) -> Self::Output {
         Self::Output {
-            heart: *self,
+            heart: self,
             resolution: 32,
         }
     }

--- a/examples/math/sampling_primitives.rs
+++ b/examples/math/sampling_primitives.rs
@@ -6,6 +6,7 @@ use bevy::{
     core_pipeline::tonemapping::Tonemapping,
     input::mouse::{AccumulatedMouseMotion, AccumulatedMouseScroll, MouseButtonInput},
     math::prelude::*,
+    mesh::InfallibleMesh,
     post_process::bloom::Bloom,
     prelude::*,
 };
@@ -206,7 +207,7 @@ impl Meshable for Shape {
 }
 
 impl MeshBuilder for ShapeMeshBuilder {
-    fn build(&self) -> Mesh {
+    fn build_infallible(&self) -> InfallibleMesh {
         match self.shape {
             Shape::Cuboid => CUBOID.mesh().into(),
             Shape::Sphere => SPHERE.mesh().into(),

--- a/examples/math/sampling_primitives.rs
+++ b/examples/math/sampling_primitives.rs
@@ -201,8 +201,8 @@ impl ShapeSample for Shape {
 impl Meshable for Shape {
     type Output = ShapeMeshBuilder;
 
-    fn mesh(&self) -> Self::Output {
-        ShapeMeshBuilder { shape: *self }
+    fn mesh(self) -> Self::Output {
+        ShapeMeshBuilder { shape: self }
     }
 }
 

--- a/examples/shader_advanced/custom_vertex_attribute.rs
+++ b/examples/shader_advanced/custom_vertex_attribute.rs
@@ -1,7 +1,7 @@
 //! A shader that reads a mesh's custom vertex attribute.
 
 use bevy::{
-    mesh::{MeshVertexAttribute, MeshVertexBufferLayoutRef},
+    mesh::{InfallibleMesh, MeshVertexAttribute, MeshVertexBufferLayoutRef},
     pbr::{MaterialPipeline, MaterialPipelineKey},
     prelude::*,
     reflect::TypePath,
@@ -32,7 +32,7 @@ fn setup(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<CustomMaterial>>,
 ) {
-    let mesh = Mesh::from(Cuboid::default())
+    let mesh = InfallibleMesh::from(Cuboid::default().mesh())
         // Sets the custom attribute
         .with_inserted_attribute(
             ATTRIBUTE_BLEND_COLOR,

--- a/examples/shader_advanced/specialized_mesh_pipeline.rs
+++ b/examples/shader_advanced/specialized_mesh_pipeline.rs
@@ -12,7 +12,7 @@ use bevy::{
     core_pipeline::core_3d::{Opaque3d, Opaque3dBatchSetKey, Opaque3dBinKey, CORE_3D_DEPTH_FORMAT},
     ecs::change_detection::Tick,
     math::{vec3, vec4},
-    mesh::{Indices, MeshVertexBufferLayoutRef, PrimitiveTopology},
+    mesh::{Indices, InfallibleMesh, MeshVertexBufferLayoutRef, PrimitiveTopology},
     pbr::{
         DrawMesh, MeshPipeline, MeshPipelineKey, MeshPipelineViewLayoutKey, RenderMeshInstances,
         SetMeshBindGroup, SetMeshViewBindGroup, SetMeshViewEmptyBindGroup,
@@ -53,7 +53,7 @@ fn setup(mut commands: Commands, mut meshes: ResMut<Assets<Mesh>>) {
     // Build a custom triangle mesh with colors
     // We define a custom mesh because the examples only uses a limited
     // set of vertex attributes for simplicity
-    let mesh = Mesh::new(
+    let mesh = InfallibleMesh::new(
         PrimitiveTopology::TriangleList,
         RenderAssetUsages::default(),
     )

--- a/examples/tools/scene_viewer/morph_viewer_plugin.rs
+++ b/examples/tools/scene_viewer/morph_viewer_plugin.rs
@@ -260,7 +260,7 @@ fn detect_morphs(
         let target_names = weights
             .first_mesh()
             .and_then(|h| meshes.get(h))
-            .and_then(|m| m.morph_target_names());
+            .and_then(|m| m.morph_target_names().unwrap_or_default());
         let targets = Target::new(name, weights.weights(), target_names, entity);
         detected.extend(targets);
     }

--- a/tests/3d/test_invalid_skinned_mesh.rs
+++ b/tests/3d/test_invalid_skinned_mesh.rs
@@ -6,7 +6,7 @@ use bevy::{
     math::ops,
     mesh::{
         skinning::{SkinnedMesh, SkinnedMeshInverseBindposes},
-        Indices, PrimitiveTopology, VertexAttributeValues,
+        Indices, InfallibleMesh, PrimitiveTopology, VertexAttributeValues,
     },
     post_process::motion_blur::MotionBlur,
     prelude::*,
@@ -96,7 +96,7 @@ fn setup_meshes(
     mut inverse_bindposes_assets: ResMut<Assets<SkinnedMeshInverseBindposes>>,
 ) {
     // Create a mesh with two rectangles.
-    let unskinned_mesh = Mesh::new(
+    let unskinned_mesh = InfallibleMesh::new(
         PrimitiveTopology::TriangleList,
         RenderAssetUsages::default(),
     )


### PR DESCRIPTION
# Objective

- implement the `InfallibleMesh` builder type suggested by @greeble-dev in https://github.com/bevyengine/bevy/pull/21732#pullrequestreview-3510297915
- remove all the `try_xxx` methods from `Mesh`, make the base methods return `Result`s

## Solution

builds on #21732 - could replace that, but i thought better to raise a different PR to keep the changes separated as this touches quite a lot more of the codebase. to see the diff for just this pr i created https://github.com/robtfm/bevy/pull/5/files which applies this onto the original pr.

- add `InfallibleMesh` type for use during cpu-side mesh construction, which wraps `Mesh` and ensures that the internal mesh data can't be extracted.
- modify primitives and examples to use the new type
- bonus: clean up the `From<primitives> for Mesh` code: remove ~30 individual `From<T> for Mesh` implementations and replace with a blanket impl, supported by modifying `Meshable::mesh` to take `self` instead of `&self`. basically all existing implementations were copying or cloning self anyway, so this doesn't seem like it should cause any issues.

## Changelog

Existing accessor methods on `Mesh` have been changed to return a `Result<T, MeshAccessError>` which will return an error if the Mesh has been extracted to the `RenderWorld`. 
When constructing meshes we now recommend using the `InfallibleMesh` type which guarantees the internal data cannot be extracted prior to being converted into a normal mesh.