### PR TITLE
Fix comment in `pointer_events`

### DIFF
--- a/crates/bevy_picking/src/events.rs
+++ b/crates/bevy_picking/src/events.rs
@@ -617,7 +617,7 @@ pub fn pointer_events(
             PointerAction::Release(button) => {
                 let state = pointer_state.get_mut(pointer_id, button);
 
-                // Emit Click and Up events on all the previously hovered entities.
+                // Emit Click and Release events on all the previously hovered entities.
                 for (hovered_entity, hit) in previous_hover_map
                     .get(&pointer_id)
                     .iter()


### PR DESCRIPTION
# Objective

Comment from `bevy_picking::events::pointer_events`: 
```
                // Emit Click and Up events on all the previously hovered entities.
```

The event is named `Release`, not `Up`.

## Solution

Replace `Up` with `Release`.
