### PR TITLE
`PointerbuttonState::clear`

### DIFF
--- a/crates/bevy_picking/src/events.rs
+++ b/crates/bevy_picking/src/events.rs
@@ -388,7 +388,7 @@ impl PointerState {
     pub fn clear(&mut self, pointer_id: PointerId) {
         for button in PointerButton::iter() {
             if let Some(state) = self.pointer_buttons.get_mut(&(pointer_id, button)) {
-                state.clear()
+                state.clear();
             }
         }
     }


### PR DESCRIPTION
# Objective

To clear the `PointerButtonState`, `clear` is called on each of its individual fields holding the button state data. Instead add a `clear` method to `PointerButtonState`.

## Solution

Add a `clear` method to `PointerButtonState` to clear its data.