### PR TITLE
Fix cargo features lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,7 +222,7 @@ common_api = [
 # COLLECTION: Features used to build 2D Bevy apps (does not include a render backend). You generally don't need to worry about this unless you are using a custom renderer.
 2d_api = ["common_api", "bevy_sprite"]
 
-# COLLECTION: Bevy's built-in 2D renderer, built on top of `bevy_render` 
+# COLLECTION: Bevy's built-in 2D renderer, built on top of `bevy_render`.
 2d_bevy_render = [
   "2d_api",
   "bevy_render",
@@ -245,7 +245,7 @@ common_api = [
   "zstd_rust",
 ]
 
-# COLLECTION: Bevy's built-in 3D renderer, built on top of `bevy_render` 
+# COLLECTION: Bevy's built-in 3D renderer, built on top of `bevy_render`.
 3d_bevy_render = [
   "3d_api",
   "bevy_render",
@@ -261,7 +261,7 @@ common_api = [
 # COLLECTION: Features used to build UI Bevy apps (does not include a render backend). You generally don't need to worry about this unless you are using a custom renderer.
 ui_api = ["default_app", "common_api", "bevy_ui"]
 
-# COLLECTION: Bevy's built-in UI renderer, built on top of `bevy_render` 
+# COLLECTION: Bevy's built-in UI renderer, built on top of `bevy_render`.
 ui_bevy_render = [
   "ui_api",
   "bevy_render",

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -44,11 +44,11 @@ collections to build your own "profile" equivalent, without needing to manually 
 |default_platform|These are platform support features, such as OS support/features, windowing and input backends, etc.|
 |common_api|Default scene definition features. Note that this does not include an actual renderer, such as bevy_render (Bevy's default render backend).|
 |2d_api|Features used to build 2D Bevy apps (does not include a render backend). You generally don't need to worry about this unless you are using a custom renderer.|
-|2d_bevy_render|Bevy's built-in 2D renderer, built on top of `bevy_render` |
+|2d_bevy_render|Bevy's built-in 2D renderer, built on top of `bevy_render`.|
 |3d_api|Features used to build 3D Bevy apps (does not include a render backend). You generally don't need to worry about this unless you are using a custom renderer.|
-|3d_bevy_render|Bevy's built-in 3D renderer, built on top of `bevy_render` |
+|3d_bevy_render|Bevy's built-in 3D renderer, built on top of `bevy_render`.|
 |ui_api|Features used to build UI Bevy apps (does not include a render backend). You generally don't need to worry about this unless you are using a custom renderer.|
-|ui_bevy_render|Bevy's built-in UI renderer, built on top of `bevy_render` |
+|ui_bevy_render|Bevy's built-in UI renderer, built on top of `bevy_render`.|
 |default_no_std|Recommended defaults for no_std applications|
 
 ### Feature List


### PR DESCRIPTION
# Objective

`markdownlint` fails on `docs/cargo_features.md` as it doesn't like the space before the pipe at the end of this line

## Solution

- Add a `.`

## Testing

- CI