### PR TITLE
remove unnecessary clone from `load_font_to_fontdb`

### DIFF
--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -620,25 +620,23 @@ pub fn load_font_to_fontdb(
     map_handle_to_font_id: &mut HashMap<AssetId<Font>, (cosmic_text::fontdb::ID, Arc<str>)>,
     fonts: &Assets<Font>,
 ) -> FontFaceInfo {
-    let font_handle = text_font.font.clone();
-    let (face_id, family_name) = map_handle_to_font_id
-        .entry(font_handle.id())
-        .or_insert_with(|| {
-            let font = fonts.get(font_handle.id()).expect(
-                "Tried getting a font that was not available, probably due to not being loaded yet",
-            );
-            let data = Arc::clone(&font.data);
-            let ids = font_system
-                .db_mut()
-                .load_font_source(cosmic_text::fontdb::Source::Binary(data));
+    let font_id = text_font.font.id();
+    let (face_id, family_name) = map_handle_to_font_id.entry(font_id).or_insert_with(|| {
+        let font = fonts.get(font_id).expect(
+            "Tried getting a font that was not available, probably due to not being loaded yet",
+        );
+        let data = Arc::clone(&font.data);
+        let ids = font_system
+            .db_mut()
+            .load_font_source(cosmic_text::fontdb::Source::Binary(data));
 
-            // TODO: it is assumed this is the right font face
-            let face_id = *ids.last().unwrap();
-            let face = font_system.db().face(face_id).unwrap();
+        // TODO: it is assumed this is the right font face
+        let face_id = *ids.last().unwrap();
+        let face = font_system.db().face(face_id).unwrap();
 
-            let family_name = Arc::from(face.families[0].0.as_str());
-            (face_id, family_name)
-        });
+        let family_name = Arc::from(face.families[0].0.as_str());
+        (face_id, family_name)
+    });
 
     let face = font_system.db().face(*face_id).unwrap();
 


### PR DESCRIPTION
# Objective

`load_font_to_fontdb` clones the font handle needlessly.

## Solution

Just call id() on it.
