### PR TITLE
compute the text buffer size during layout updates

### DIFF
--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -555,9 +555,11 @@ impl TextPipeline {
 
         let buffer = &mut computed.buffer;
         buffer.set_size(font_system, bounds.width, bounds.height);
-        let box_size = buffer_dimensions(buffer);
+        let mut box_size = Vec2::ZERO;
 
         let result = buffer.layout_runs().try_for_each(|run| {
+            box_size.x = box_size.x.max(run.line_w);
+            box_size.y += run.line_height;
             let mut current_section: Option<usize> = None;
             let mut start = 0.;
             let mut end = 0.;


### PR DESCRIPTION
# Objective

`queue_text` does a second pass to compute the size of the text buffer, this could be moved inside the layout update loop instead.

## Solution

Do the buffer size computation inside the update loop.

