### PR TITLE
Clarify docs for `ExtractSchedule`

### DIFF
--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -253,7 +253,7 @@ impl Render {
 /// running the next frame while rendering the current frame.
 ///
 /// This schedule is run on the render world, but it also has access to the main world.
-/// See [`MainWorld`] and [`Extract`] for details on how to access data from the main world.
+/// See [`MainWorld`] and [`Extract`] for details on how to access main world data from this schedule.
 #[derive(ScheduleLabel, PartialEq, Eq, Debug, Clone, Hash, Default)]
 pub struct ExtractSchedule;
 


### PR DESCRIPTION
The previous docs incorrectly states that the `ExtractSchedule` is run on the main world. Also some small additional changes.