### PR TITLE
Ignore text buffer metrics

### DIFF
--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -18,7 +18,7 @@ pub struct CosmicBuffer(pub Buffer);
 
 impl Default for CosmicBuffer {
     fn default() -> Self {
-        Self(Buffer::new_empty(Metrics::new(0.0, 0.000001)))
+        Self(Buffer::new_empty(Metrics::new(20.0, 20.0)))
     }
 }
 


### PR DESCRIPTION
# Objective

Since we set explicit font size and line height attributes for every text section, the `Metrics` values passed to the text buffer don't matter. We can just initialize the buffer with some dummy value and then ignore it.

## Solution

* Initialize the text buffer to some dummy values.
* Remove the code that collects and sets the metrics during text updates.

