### PR TITLE
Inline register_type_data to cut down on binary size

### DIFF
--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -758,7 +758,6 @@ pub trait FromType<T> {
     /// Inserts [`TypeData`] dependencies of this [`TypeData`].
     /// This is especially useful for trait [`TypeData`] that has a supertrait (ex: `A: B`).
     /// When the [`TypeData`] for `A` is inserted, the `B` [`TypeData`] will also be inserted.
-    // #[inline]
     fn insert_dependencies(_type_registration: &mut TypeRegistration) {}
 }
 


### PR DESCRIPTION
# Objective

My [TypeData dependencies](#22016 ) PR regressed native binary size by ~8mb.

(thank you [twitcher](https://github.com/bevyengine/twitcher/))

<img width="858" height="306" alt="image" src="https://github.com/user-attachments/assets/e6d86c67-33f6-4280-bee4-49771014b678" />

## Solution

- Inline `register_type_data`, which restores the original binary size:
  - `release breakout` before #22016: 127.3mb
  - `release breakout` after #22016: 136.4mb
  - `release breakout` after this PR: 127.4mb
