### PR TITLE
Fix some lints from rust 1.89 bump

### DIFF
--- a/crates/bevy_ecs/src/component/clone.rs
+++ b/crates/bevy_ecs/src/component/clone.rs
@@ -110,20 +110,18 @@ pub fn component_clone_via_reflect(source: &SourceComponent, ctx: &mut Component
     // Try to clone using ReflectFromReflect
     if let Some(reflect_from_reflect) =
         registry.get_type_data::<bevy_reflect::ReflectFromReflect>(type_id)
-    {
-        if let Some(mut component) =
+        && let Some(mut component) =
             reflect_from_reflect.from_reflect(source_component_reflect.as_partial_reflect())
+    {
+        if let Some(reflect_component) =
+            registry.get_type_data::<crate::reflect::ReflectComponent>(type_id)
         {
-            if let Some(reflect_component) =
-                registry.get_type_data::<crate::reflect::ReflectComponent>(type_id)
-            {
-                reflect_component.map_entities(&mut *component, ctx.entity_mapper());
-            }
-            drop(registry);
-
-            ctx.write_target_component_reflect(component);
-            return;
+            reflect_component.map_entities(&mut *component, ctx.entity_mapper());
         }
+        drop(registry);
+
+        ctx.write_target_component_reflect(component);
+        return;
     }
     // Else, try to clone using ReflectDefault
     if let Some(reflect_default) =

--- a/crates/bevy_ecs/src/entity/clone_entities.rs
+++ b/crates/bevy_ecs/src/entity/clone_entities.rs
@@ -1144,11 +1144,11 @@ impl OptOut {
     #[inline]
     fn filter_deny(&mut self, id: ComponentId, world: &World) {
         self.deny.insert(id);
-        if self.attach_required_by_components {
-            if let Some(required_by) = world.components().get_required_by(id) {
-                self.deny.extend(required_by.iter());
-            };
-        }
+        if self.attach_required_by_components
+            && let Some(required_by) = world.components().get_required_by(id)
+        {
+            self.deny.extend(required_by.iter());
+        };
     }
 }
 

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -219,18 +219,18 @@ impl World {
                         && observers.entity_component_observers.is_empty()
                     {
                         cache.component_observers.remove(component);
-                        if let Some(flag) = Observers::is_archetype_cached(event_key) {
-                            if let Some(by_component) = archetypes.by_component.get(component) {
-                                for archetype in by_component.keys() {
-                                    let archetype = &mut archetypes.archetypes[archetype.index()];
-                                    if archetype.contains(*component) {
-                                        let no_longer_observed = archetype
-                                            .iter_components()
-                                            .all(|id| !cache.component_observers.contains_key(&id));
+                        if let Some(flag) = Observers::is_archetype_cached(event_key)
+                            && let Some(by_component) = archetypes.by_component.get(component)
+                        {
+                            for archetype in by_component.keys() {
+                                let archetype = &mut archetypes.archetypes[archetype.index()];
+                                if archetype.contains(*component) {
+                                    let no_longer_observed = archetype
+                                        .iter_components()
+                                        .all(|id| !cache.component_observers.contains_key(&id));
 
-                                        if no_longer_observed {
-                                            archetype.flags.set(flag, false);
-                                        }
+                                    if no_longer_observed {
+                                        archetype.flags.set(flag, false);
                                     }
                                 }
                             }

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -3319,10 +3319,10 @@ mod tests {
 
         fn system(query: Query<EntityRef>) {
             for entity_ref in &query {
-                if let Some(c) = entity_ref.get_ref::<C>() {
-                    if !c.is_added() {
-                        panic!("Expected C to be added");
-                    }
+                if let Some(c) = entity_ref.get_ref::<C>()
+                    && !c.is_added()
+                {
+                    panic!("Expected C to be added");
                 }
             }
         }

--- a/crates/bevy_ecs/src/relationship/mod.rs
+++ b/crates/bevy_ecs/src/relationship/mod.rs
@@ -188,28 +188,27 @@ pub trait Relationship: Component + Sized {
             }
         }
         let target_entity = world.entity(entity).get::<Self>().unwrap().get();
-        if let Ok(mut target_entity_mut) = world.get_entity_mut(target_entity) {
-            if let Some(mut relationship_target) =
+        if let Ok(mut target_entity_mut) = world.get_entity_mut(target_entity)
+            && let Some(mut relationship_target) =
                 target_entity_mut.get_mut::<Self::RelationshipTarget>()
-            {
-                relationship_target.collection_mut_risky().remove(entity);
-                if relationship_target.len() == 0 {
-                    let command = |mut entity: EntityWorldMut| {
-                        // this "remove" operation must check emptiness because in the event that an identical
-                        // relationship is inserted on top, this despawn would result in the removal of that identical
-                        // relationship ... not what we want!
-                        if entity
-                            .get::<Self::RelationshipTarget>()
-                            .is_some_and(RelationshipTarget::is_empty)
-                        {
-                            entity.remove::<Self::RelationshipTarget>();
-                        }
-                    };
+        {
+            relationship_target.collection_mut_risky().remove(entity);
+            if relationship_target.len() == 0 {
+                let command = |mut entity: EntityWorldMut| {
+                    // this "remove" operation must check emptiness because in the event that an identical
+                    // relationship is inserted on top, this despawn would result in the removal of that identical
+                    // relationship ... not what we want!
+                    if entity
+                        .get::<Self::RelationshipTarget>()
+                        .is_some_and(RelationshipTarget::is_empty)
+                    {
+                        entity.remove::<Self::RelationshipTarget>();
+                    }
+                };
 
-                    world
-                        .commands()
-                        .queue_silenced(command.with_entity(target_entity));
-                }
+                world
+                    .commands()
+                    .queue_silenced(command.with_entity(target_entity));
             }
         }
     }

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -442,10 +442,10 @@ where
         // Note that the `downcast_mut` check is based on the static type,
         // and can be optimized out after monomorphization.
         let any: &mut dyn Any = &mut value;
-        if let Some(err) = any.downcast_mut::<SystemParamValidationError>() {
-            if err.skipped {
-                return Self::Skipped(core::mem::replace(err, SystemParamValidationError::EMPTY));
-            }
+        if let Some(err) = any.downcast_mut::<SystemParamValidationError>()
+            && err.skipped
+        {
+            return Self::Skipped(core::mem::replace(err, SystemParamValidationError::EMPTY));
         }
         Self::Failed(From::from(value))
     }


### PR DESCRIPTION
# Objective

- In #21822 the MSRV bump triggers some new lint warnings, so this pr fixes them.

## Solution

- Bumped the msrv in bevy_ecs and fixed the lints. But this pr does not actually bump the msrv. These fixes are all for combining nested if's together.