### PR TITLE
Add rust-toolchain file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,9 @@ updates:
       interval: weekly
     labels:
       - "C-Dependencies"
+  - package-ecosystem: rust-toolchain
+    directory: /
+    schedule:
+      interval: daily
+    labels:
+      - "C-Build-System"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
       - name: CI job
         # To run the tests one item at a time for troubleshooting, use
         # cargo --quiet test --lib -- --list | sed 's/: test$//' | MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-disable-weak-memory-emulation" xargs -n1 cargo miri test -p bevy_ecs --lib -- --exact
-        run: cargo +${{ en.NIGHTLY_TOOLCHAIN }} miri test -p bevy_ecs --features bevy_utils/debug
+        run: cargo +${{ env.NIGHTLY_TOOLCHAIN }} miri test -p bevy_ecs --features bevy_utils/debug
         env:
           # -Zrandomize-layout makes sure we dont rely on the layout of anything that might change
           RUSTFLAGS: -Zrandomize-layout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
       - name: CI job
         # To run the tests one item at a time for troubleshooting, use
         # cargo --quiet test --lib -- --list | sed 's/: test$//' | MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-disable-weak-memory-emulation" xargs -n1 cargo miri test -p bevy_ecs --lib -- --exact
-        run: cargo miri test -p bevy_ecs --features bevy_utils/debug
+        run: cargo +{{ en.NIGHTLY_TOOLCHAIN }} miri test -p bevy_ecs --features bevy_utils/debug
         env:
           # -Zrandomize-layout makes sure we dont rely on the layout of anything that might change
           RUSTFLAGS: -Zrandomize-layout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
       - name: CI job
         # To run the tests one item at a time for troubleshooting, use
         # cargo --quiet test --lib -- --list | sed 's/: test$//' | MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-disable-weak-memory-emulation" xargs -n1 cargo miri test -p bevy_ecs --lib -- --exact
-        run: cargo +{{ en.NIGHTLY_TOOLCHAIN }} miri test -p bevy_ecs --features bevy_utils/debug
+        run: cargo +${{ en.NIGHTLY_TOOLCHAIN }} miri test -p bevy_ecs --features bevy_utils/debug
         env:
           # -Zrandomize-layout makes sure we dont rely on the layout of anything that might change
           RUSTFLAGS: -Zrandomize-layout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,7 +227,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.91.1
         with:
           targets: x86_64-unknown-none
       - name: Install Linux dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,8 @@ jobs:
             ~/.cargo/git/db/
             target/
       - uses: dtolnay/rust-toolchain@stable
+      - name: override
+        run: rustup override set stable
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
       - name: Build & run tests
@@ -78,6 +80,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
+      - name: override
+        run: rustup override set stable
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,6 +272,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           target: wasm32-unknown-unknown
+      - name: override
+        run: rustup override set stable
       - name: Check wasm
         env:
           RUSTFLAGS: --cfg getrandom_backend="wasm_js"
@@ -302,6 +304,8 @@ jobs:
           toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
           targets: wasm32-unknown-unknown
           components: rust-src
+      - name: override
+        run: rustup override set ${{ env.NIGHTLY_TOOLCHAIN }}
       - name: Check wasm
         run: cargo check --target wasm32-unknown-unknown -Z build-std=std,panic_abort
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain
         with:
           targets: x86_64-unknown-none
       - name: Install Linux dependencies
@@ -199,7 +199,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain
         with:
           targets: thumbv6m-none-eabi
       - name: Install Linux dependencies
@@ -227,7 +227,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-      - uses: dtolnay/rust-toolchain@1.91.1
+      - uses: dtolnay/rust-toolchain
         with:
           targets: x86_64-unknown-none
       - name: Install Linux dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,9 +175,11 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-      - uses: dtolnay/rust-toolchain@1.91.1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-unknown-none
+      - name: override
+        run: rustup override set stable
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
       - name: Check Compile
@@ -203,9 +205,11 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-      - uses: dtolnay/rust-toolchain@1.91.1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           targets: thumbv6m-none-eabi
+      - name: override
+        run: rustup override set stable
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
       - name: Check Compile
@@ -231,9 +235,11 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-      - uses: dtolnay/rust-toolchain@1.91.1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-unknown-none
+      - name: override
+        run: rustup override set stable
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
       - name: Check Compile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,10 +110,12 @@ jobs:
         with:
           toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
           components: miri
+      - name: override
+        run: rustup override set ${{ env.NIGHTLY_TOOLCHAIN }}
       - name: CI job
         # To run the tests one item at a time for troubleshooting, use
         # cargo --quiet test --lib -- --list | sed 's/: test$//' | MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-disable-weak-memory-emulation" xargs -n1 cargo miri test -p bevy_ecs --lib -- --exact
-        run: cargo +${{ env.NIGHTLY_TOOLCHAIN }} miri test -p bevy_ecs --features bevy_utils/debug
+        run: cargo miri test -p bevy_ecs --features bevy_utils/debug
         env:
           # -Zrandomize-layout makes sure we dont rely on the layout of anything that might change
           RUSTFLAGS: -Zrandomize-layout
@@ -145,6 +147,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
+      - name: override
+        run: rustup override set stable
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
       - name: Check Compile
@@ -171,7 +175,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-      - uses: dtolnay/rust-toolchain
+      - uses: dtolnay/rust-toolchain@1.91.1
         with:
           targets: x86_64-unknown-none
       - name: Install Linux dependencies
@@ -199,7 +203,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-      - uses: dtolnay/rust-toolchain
+      - uses: dtolnay/rust-toolchain@1.91.1
         with:
           targets: thumbv6m-none-eabi
       - name: Install Linux dependencies
@@ -227,7 +231,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-      - uses: dtolnay/rust-toolchain
+      - uses: dtolnay/rust-toolchain@1.91.1
         with:
           targets: x86_64-unknown-none
       - name: Install Linux dependencies

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,2 @@
 [toolchain]
-profile = "default"
 channel = "1.91.1"
-# components = ["rustfmt", "miri"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.91"
-components = ["rustfmt"]
+components = ["rustfmt", "miri"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.91"
+

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.91"
+components = ["rustfmt"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
-channel = "1.91"
-components = ["rustfmt", "miri"]
+profile = "default"
+channel = "1.91.1"
+# components = ["rustfmt", "miri"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,2 @@
 [toolchain]
 channel = "1.91"
-


### PR DESCRIPTION
# Objective

- When bisecting a bug we end up using older versions of bevy that don't always compile with the most recent compiler
- We use cutting edge features and not everyone has the latest compiler version installed and they end up seeing errors that might not be easy to understand

## Solution

- Add a rust-toolchain file to document which compiler version is used for the current state of the repo
- This way when using git bisect we don't have to guess at which compiler version we should be using
- This means we will have to make a new PR to update the file every time there's a new rust version or at least every time we use a feature from a newer rust version
- Unfortunately, this caused a few issues with CI so I had to add rustup override steps to a few of the CI actions that were expecting a specific rust version or component. This way CI essentially doesn't have to care about the toolchain file.

## Testing

- I tested a local build and it used the expected compiler version