### PR TITLE
enable easier modification of image samplers in image loaders

### DIFF
--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -2270,6 +2270,6 @@ mod test {
             .set_anisotropic_filter(8);
 
         assert_eq!(my_sampler_in_a_loader.min_filter, ImageFilterMode::Linear);
-        assert_eq!(my_sampler_in_a_loader.anisotropy_clamp, 8)
+        assert_eq!(my_sampler_in_a_loader.anisotropy_clamp, 8);
     }
 }


### PR DESCRIPTION
# Objective

Previously, to modify a sampler when loading an image with settings it was required to set all fields individually. Much of the time, these settings are all the same so to enable repeating textures you have to set the address_mode 3 times. To set filters you have to set them another 3 times.

```rust
MeshMaterial3d(materials.add(
    StandardMaterial {
        base_color_texture:
            Some(
                asset_server.load_with_settings(
                    "floor_graph_base_color.png",
                    |settings: &mut ImageLoaderSettings| {
                        let  descriptor = settings.sampler.get_or_init_descriptor();
                        descriptor.address_mode_u = bevy::image::ImageAddressMode::Repeat;
                        descriptor.address_mode_v = bevy::image::ImageAddressMode::Repeat;
                        descriptor.address_mode_w = bevy::image::ImageAddressMode::Repeat;
                        descriptor.mag_filter = ImageFilterMode::Linear;
                        descriptor.min_filter = ImageFilterMode::Linear;
                        descriptor.mipmap_filter = ImageFilterMode::Linear;
                    }
                ),
            ),
        unlit: true,
        cull_mode: None,
        uv_transform: Affine2::from_scale(Vec2::new(30., 90.)),
        ..default()
    },
)),
```

## Solution

Add two new helpers, loosely modeled after the `Transform::with_<field>` functions. Further modifications can still be made to the descriptor for use cases which want to set one of the three fields differently, or additionally set anisotropy_clamp, etc.

```rust
let descriptor = settings
    .sampler
    .get_or_init_descriptor()
    .set_address_mode(ImageAddressMode::Repeat)
    .set_filter(ImageFilterMode::Linear);
```

## Testing

New test in bevy_image

## Showcase

```rust
MeshMaterial3d(materials.add(
    StandardMaterial {
        base_color_texture:
            Some(
                asset_server.load_with_settings(
                    "floor_graph_base_color.png",
                    |settings: &mut ImageLoaderSettings| {
                        let descriptor = settings
                            .sampler
                            .get_or_init_descriptor()
                            .set_address_mode(ImageAddressMode::Repeat)
                            .set_filter(ImageFilterMode::Linear);
                    }
                ),
            ),
        unlit: true,
        cull_mode: None,
        uv_transform: Affine2::from_scale(Vec2::new(30., 90.)),
        ..default()
    },
)),
```

This PR now includes:

- `set_filter`
- `set_address_mode`
- `set_anisotropic_filter`
