### PR TITLE
Make the ui_surface module public.

### DIFF
--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -25,7 +25,7 @@ use bevy_text::CosmicFontSystem;
 
 mod convert;
 pub mod debug;
-pub(crate) mod ui_surface;
+pub mod ui_surface;
 
 pub struct LayoutContext {
     pub scale_factor: f32,


### PR DESCRIPTION
# Objective

- Fix #17909

## Solution

- Make the `ui_surface` module public (not just pub(crate)), so that UiSurface can be querried and used with the function.

## Notes
Making this public may break encapsulation (notably it could allow removing the Resource), but given how lax the guarantees of ECS state are, I don't think that (a resource existing) is an assumption anyone can truly rely on.