### PR TITLE
Fix undefined behavior in screenshots on WASM

### DIFF
--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -125,7 +125,7 @@ send_wrapper = { version = "0.6.0" }
 proptest = "1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-js-sys = "0.3"
+js-sys = "0.3.83"
 web-sys = { version = "0.3.67", features = [
   'Blob',
   'Document',

--- a/crates/bevy_render/src/view/window/screenshot.rs
+++ b/crates/bevy_render/src/view/window/screenshot.rs
@@ -151,11 +151,13 @@ pub fn save_to_disk(path: impl AsRef<Path>) -> impl FnMut(On<ScreenshotCaptured>
                             let mut image_buffer = std::io::Cursor::new(Vec::new());
                             img.write_to(&mut image_buffer, format)
                                 .map_err(|e| JsValue::from_str(&format!("{e}")))?;
-                            // SAFETY: `image_buffer` only exist in this closure, and is not used after this line
-                            let parts = js_sys::Array::of1(&unsafe {
-                                js_sys::Uint8Array::view(image_buffer.into_inner().as_bytes())
-                                    .into()
-                            });
+
+                            let parts = js_sys::Array::of1(
+                                &js_sys::Uint8Array::new_from_slice(
+                                    image_buffer.into_inner().as_bytes(),
+                                )
+                                .into(),
+                            );
                             let blob = web_sys::Blob::new_with_u8_array_sequence(&parts)?;
                             let url = web_sys::Url::create_object_url_with_blob(&blob)?;
                             let window = web_sys::window().unwrap();


### PR DESCRIPTION
# Objective

Currently the screenshot example on https://bevy.org/examples/window/screenshot/ gives invalid PNG files when I tried it. Looking at them they have some of the right bytes, but also a bunch of garbage. The example works on native.

I narrowed it down to the one unsafe block in sight (thanks Rust!). I don't fully understand why the code stopped working or if it was ever valid, but in the meantime since it was written a safe API has been added, and using it made the problem go away.

## Solution

Bump `js-sys`, use the safe API.

## Testing

I ran the example with `bevy run --example screenshot web`