### PR TITLE
Implement `Clone` and `Copy` for bevy_ptr's `ConstNonNull` for parity with `NonNull`

### DIFF
--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -161,6 +161,7 @@ mod sealed {
 /// A newtype around [`NonNull`] that only allows conversion to read-only borrows or pointers.
 ///
 /// This type can be thought of as the `*const T` to [`NonNull<T>`]'s `*mut T`.
+#[derive(Clone, Copy)]
 #[repr(transparent)]
 pub struct ConstNonNull<T: ?Sized>(NonNull<T>);
 


### PR DESCRIPTION
# Objective

Fixes #22059 

## Solution

Just `#[derive(Clone, Copy)]` on `ConstNonNull` since it`s just a wrapper around `NonNull` which implements them

## Testing

Just tested if it compiles and functions as it should
