### PR TITLE
Use insert_debug_marker instead of debug_group

### DIFF
--- a/crates/bevy_render/src/renderer/graph_runner.rs
+++ b/crates/bevy_render/src/renderer/graph_runner.rs
@@ -135,7 +135,7 @@ impl RenderGraphRunner {
             // For now, we use a debug_marker as a workaround
             render_context
                 .command_encoder()
-                .insert_debug_marker(debug_group);
+                .insert_debug_marker(&format!("Start {debug_group}"));
         }
 
         // Queue up nodes without inputs, which can be run immediately
@@ -279,6 +279,12 @@ impl RenderGraphRunner {
             {
                 node_queue.push_front(node_state);
             }
+        }
+
+        if let Some(debug_group) = debug_group {
+            render_context
+                .command_encoder()
+                .insert_debug_marker(&format!("End {debug_group}"));
         }
 
         Ok(())


### PR DESCRIPTION
# Objective

- wgpu 27 changed debug_group validation which breaks the camera debug_group

## Solution

- Use insert_debug_marker until we find an alternative to using a debug_group

## Testing

- I tested my change with the wgpu 27 branch

---

## Showcase

Unfortunately, this means we lose the nice groupings for each camera but we can still see each marker when a camera is being rendered

<img width="540" height="147" alt="ngfx-ui_0ejTHJqRDH" src="https://github.com/user-attachments/assets/c5c3f697-fc63-450f-af43-7c6ba3e6e18d" />

<img width="548" height="109" alt="ngfx-ui_yCBEtE0i1E" src="https://github.com/user-attachments/assets/7c29774c-1dda-4ca9-a9e4-37454f33ca04" />
