### PR TITLE
Make Gizmos::rect_2d draw the joint of the upper left corner of the rectangle

### DIFF
--- a/crates/bevy_gizmos/src/gizmos.rs
+++ b/crates/bevy_gizmos/src/gizmos.rs
@@ -833,7 +833,7 @@ where
         }
         let isometry = isometry.into();
         let [tl, tr, br, bl] = rect_inner(size).map(|vec2| isometry * vec2);
-        self.linestrip_2d([tl, tr, br, bl, tl], color);
+        self.linestrip_2d([tl, tr, br, bl, tl, tr], color);
     }
 
     #[inline]


### PR DESCRIPTION
Make `Gizmos::rect_2d` draw the joint of the upper left corner of the rectangle

# Objective

- `Gizmos::rect_2d` does not draw the line joint between the left and top line segments. This looks odd when the line joint is not `GizmoLineJoint::None`.

## Solution

- `Gizmos::rect_2d` draws the rectangle using `Gizmos::linestrip_2d`, which doesn't draw a closed shape. 
-  In order to make `linestrip_2d` to draw a joint at a corner, that corner has to be in the points list with a predecessor and a successor.
-  `tl` has no predecessor when it's the first element in the list, and no successor when it's the last.
-  Appending `tr` to the list is enough to put `tl` between two other points, which causes the joint to be rendered.

## Testing

- I tested my change against a demo where I draw a selection box.

The test code is just this, and observing the result captured in the screenshots below:
```
    gizmos.rect_2d(selection.rect.center(), selection.rect.size(), Color::srgb_u8(0xFF, 0, 0));
```

---

## Showcase

Incorrect `GizmoLineJoint::Miter` joint without this change:

<img width="236" height="177" alt="Screenshot from 2025-12-09 22-42-06" src="https://github.com/user-attachments/assets/c06a93b1-631d-4dc4-915c-ff7999294a8a" />

Correct `GizmoLineJoint::Miter` joint with this change:

<img width="213" height="157" alt="Screenshot from 2025-12-09 22-43-06" src="https://github.com/user-attachments/assets/51117309-7a74-41d7-9503-528594c93884" />
