### PR TITLE
fix gltf path texture usages

### DIFF
--- a/crates/bevy_gltf/src/loader/mod.rs
+++ b/crates/bevy_gltf/src/loader/mod.rs
@@ -1137,7 +1137,7 @@ async fn load_image<'a, 'b>(
                     path: image_path,
                     is_srgb,
                     sampler_descriptor,
-                    render_asset_usages,
+                    render_asset_usages: settings.load_materials,
                 })
             }
         }


### PR DESCRIPTION
# Objective

the asset usages from `GltfLoaderSettings::load_materials` are not respected when loading path-based / non-embedded textures.

## Solution

use them