### PR TITLE
Add 64 bit Dir3 struct

### DIFF
--- a/crates/bevy_math/src/direction.rs
+++ b/crates/bevy_math/src/direction.rs
@@ -1041,7 +1041,7 @@ impl DDir3 {
     /// #[cfg(feature = "approx")]
     /// assert_relative_eq!(
     ///     result1,
-    ///     DDir3::from_xyz(0.75_f64.sqrt(), 0.5, 0.0).unwrap(),
+    ///     DDir3::from_xyz(0.75_f32.sqrt(), 0.5, 0.0).unwrap(),
     ///     epsilon = 0.000001
     /// );
     ///


### PR DESCRIPTION
# Objective
When working with 64 bit numbers and transforms i would find it much more convenient if bevy natively had a 64 bit direction type. Therefore I added a 64 bit direction type.

## Solution
Added a 64 bit direction type for 3d directions called `DDir3`. I was going to add one for Dir2, however, it would involve adding a 64 bit version of Rot2 which was out of the scope that I had intended for this PR.
I'm not entirely sold on the name `DDir3`, but it does follow glam's convention of 64bit structs being prefaced with D.
## Testing

- Did you test these changes? If so, how?
I added tests to the testing suite covering the new features added in this PR.
- Are there any parts that need more testing?
Nope, not as far as I know.
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
currently the ddir3_slerp test fails with the following message and I haven't the faintest clue how to fix it.
 ```
thread 'direction::tests::ddir3_slerp' (32568) panicked at crates/bevy_math/src/direction.rs:1663:9:
assert_relative_eq!(DDir3::Z.slerp(DDir3::Y, 2.0 / 3.0), DDir3::from_xyz(0.0, 0.75f64.sqrt(), 0.5f64).unwrap())

    left  = DDir3(DVec3(0.0, 0.8660254037844384, 0.5))
    right = DDir3(DVec3(0.0, 0.8660254037844387, 0.5000000000000001))
``` 
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?
64 bit Linux mint
