### PR TITLE
Fix wrong termination for asset hash reads.

### DIFF
--- a/crates/bevy_asset/src/meta.rs
+++ b/crates/bevy_asset/src/meta.rs
@@ -254,7 +254,7 @@ pub(crate) async fn get_asset_hash(
     loop {
         let bytes_read = asset_reader.read(&mut buffer).await?;
         hasher.update(&buffer[..bytes_read]);
-        if bytes_read < buffer.len() {
+        if bytes_read == 0 {
             // This means we've reached EOF, so we're done consuming asset bytes.
             break;
         }


### PR DESCRIPTION
# Objective

- #21925 changed the hash computation to read the file piece by piece. Unfortunately, the termination condition is wrong for this loop. We should only exit once the reader has no more bytes (`bytes_read == 0`), otherwise, the reader might partially fill the buffer, and that may be interpretted as an EOF.
- I originally did this check, but something was failing due to never terminating the read. Unclear what happened, maybe I got mixed up!

## Solution

- Check if there are no bytes left rather than if the buffer is partially filled.

## Testing

- Ran the asset tests with --all-features
- Ran the `asset_processor` example and it seems to work!