### PR TITLE
Revert "Support non-sRGB image formats for `RenderTarget::Image`"

### DIFF
--- a/crates/bevy_render/src/camera.rs
+++ b/crates/bevy_render/src/camera.rs
@@ -213,9 +213,9 @@ impl NormalizedRenderTargetExt for NormalizedRenderTarget {
             NormalizedRenderTarget::Image(image_target) => images
                 .get(&image_target.handle)
                 .map(|image| image.texture_format),
-            NormalizedRenderTarget::TextureView(id) => manual_texture_views
-                .get(id)
-                .map(|view| view.texture_view.texture().format()),
+            NormalizedRenderTarget::TextureView(id) => {
+                manual_texture_views.get(id).map(|tex| tex.format)
+            }
             NormalizedRenderTarget::None { .. } => None,
         }
     }

--- a/crates/bevy_render/src/texture/manual_texture_view.rs
+++ b/crates/bevy_render/src/texture/manual_texture_view.rs
@@ -1,8 +1,10 @@
 use bevy_camera::ManualTextureViewHandle;
 use bevy_ecs::{prelude::Component, resource::Resource};
+use bevy_image::BevyDefault;
 use bevy_math::UVec2;
 use bevy_platform::collections::HashMap;
 use bevy_render_macros::ExtractResource;
+use wgpu::TextureFormat;
 
 use crate::render_resource::TextureView;
 
@@ -11,11 +13,16 @@ use crate::render_resource::TextureView;
 pub struct ManualTextureView {
     pub texture_view: TextureView,
     pub size: UVec2,
+    pub format: TextureFormat,
 }
 
 impl ManualTextureView {
-    pub fn new(texture_view: TextureView, size: UVec2) -> Self {
-        Self { texture_view, size }
+    pub fn with_default_format(texture_view: TextureView, size: UVec2) -> Self {
+        Self {
+            texture_view,
+            size,
+            format: TextureFormat::bevy_default(),
+        }
     }
 }
 
@@ -29,7 +36,7 @@ impl ManualTextureView {
 /// # world.insert_resource(ManualTextureViews::default());
 /// # let texture_view = todo!();
 /// let manual_views = world.resource_mut::<ManualTextureViews>();
-/// let manual_view = ManualTextureView::new(texture_view, UVec2::new(1024, 1024));
+/// let manual_view = ManualTextureView::with_default_format(texture_view, UVec2::new(1024, 1024));
 ///
 /// // Choose an unused handle value; it's likely only you are inserting manual views.
 /// const MANUAL_VIEW_HANDLE: ManualTextureViewHandle = ManualTextureViewHandle::new(42);

--- a/crates/bevy_render/src/texture/texture_attachment.rs
+++ b/crates/bevy_render/src/texture/texture_attachment.rs
@@ -1,5 +1,5 @@
 use super::CachedTexture;
-use crate::render_resource::TextureView;
+use crate::render_resource::{TextureFormat, TextureView};
 use alloc::sync::Arc;
 use bevy_color::LinearRgba;
 use core::sync::atomic::{AtomicBool, Ordering};
@@ -127,13 +127,15 @@ impl DepthAttachment {
 #[derive(Clone)]
 pub struct OutputColorAttachment {
     pub view: TextureView,
+    pub format: TextureFormat,
     is_first_call: Arc<AtomicBool>,
 }
 
 impl OutputColorAttachment {
-    pub fn new(view: TextureView) -> Self {
+    pub fn new(view: TextureView, format: TextureFormat) -> Self {
         Self {
             view,
+            format,
             is_first_call: Arc::new(AtomicBool::new(true)),
         }
     }

--- a/crates/bevy_render/src/view/window/screenshot.rs
+++ b/crates/bevy_render/src/view/window/screenshot.rs
@@ -295,7 +295,7 @@ fn prepare_screenshots(
                 prepared.insert(*entity, state);
                 view_target_attachments.insert(
                     target.clone(),
-                    OutputColorAttachment::new(texture_view.clone()),
+                    OutputColorAttachment::new(texture_view.clone(), format.add_srgb_suffix()),
                 );
             }
             NormalizedRenderTarget::Image(image) => {
@@ -315,7 +315,7 @@ fn prepare_screenshots(
                 prepared.insert(*entity, state);
                 view_target_attachments.insert(
                     target.clone(),
-                    OutputColorAttachment::new(texture_view.clone()),
+                    OutputColorAttachment::new(texture_view.clone(), format.add_srgb_suffix()),
                 );
             }
             NormalizedRenderTarget::TextureView(texture_view) => {
@@ -326,7 +326,7 @@ fn prepare_screenshots(
                     );
                     continue;
                 };
-                let format = manual_texture_view.texture_view.texture().format();
+                let format = manual_texture_view.format;
                 let size = manual_texture_view.size.to_extents();
                 let (texture_view, state) = prepare_screenshot_state(
                     size,
@@ -339,7 +339,7 @@ fn prepare_screenshots(
                 prepared.insert(*entity, state);
                 view_target_attachments.insert(
                     target.clone(),
-                    OutputColorAttachment::new(texture_view.clone()),
+                    OutputColorAttachment::new(texture_view.clone(), format.add_srgb_suffix()),
                 );
             }
             NormalizedRenderTarget::None { .. } => {
@@ -550,7 +550,7 @@ pub(crate) fn submit_screenshot_commands(world: &World, encoder: &mut CommandEnc
                 };
                 let width = texture_view.size.x;
                 let height = texture_view.size.y;
-                let texture_format = texture_view.texture_view.texture().format();
+                let texture_format = texture_view.format;
                 let texture_view = texture_view.texture_view.deref();
                 render_screenshot(
                     encoder,


### PR DESCRIPTION
Reverts bevyengine/bevy#22031

Rationale see https://github.com/bevyengine/bevy/pull/22090