### PR TITLE
Make it possible to statically construct gizmo buffers

### DIFF
--- a/crates/bevy_gizmos/src/gizmos.rs
+++ b/crates/bevy_gizmos/src/gizmos.rs
@@ -308,6 +308,17 @@ where
     Clear: 'static + Send + Sync,
 {
     fn default() -> Self {
+        GizmoBuffer::new()
+    }
+}
+
+impl<Config, Clear> GizmoBuffer<Config, Clear>
+where
+    Config: GizmoConfigGroup,
+    Clear: 'static + Send + Sync,
+{
+    /// Constructs an empty `GizmoBuffer`.
+    pub const fn new() -> Self {
         GizmoBuffer {
             enabled: true,
             list_positions: Vec::new(),


### PR DESCRIPTION
# Objective

- statically construct gizmo buffers for some shenanigans

## Solution

- expose a const constructor

## Testing

- 