### PR TITLE
Bump tracy-client version

### DIFF
--- a/crates/bevy_log/Cargo.toml
+++ b/crates/bevy_log/Cargo.toml
@@ -32,7 +32,7 @@ tracing = { version = "0.1", default-features = false, features = ["std"] }
 # Tracy dependency compatibility table:
 # https://github.com/nagisa/rust_tracy_client
 tracing-tracy = { version = "0.11.4", optional = true }
-tracy-client = { version = "0.18.0", optional = true }
+tracy-client = { version = "0.18.3", optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_log-sys = "0.3.0"

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -113,7 +113,7 @@ smallvec = { version = "1", default-features = false, features = ["const_new"] }
 offset-allocator = "0.2"
 variadics_please = "1.1"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
-tracy-client = { version = "0.18.0", optional = true }
+tracy-client = { version = "0.18.3", optional = true }
 indexmap = { version = "2" }
 fixedbitset = { version = "0.5" }
 bitflags = "2"


### PR DESCRIPTION
# Objective

- Latest tracy version 0.13 doesn't work with tracy-client 0.18.0

## Solution

- Bump tracy-client to 0.18.3 per https://github.com/nagisa/rust_tracy_client?tab=readme-ov-file#version-support-table

## Testing

- Tested with tracy version 13.1
- I have not tested with tracy version 12

---

<details>
  <summary>Click to view showcase</summary>

```rust
println!("My super cool code.");
```

</details>
