### PR TITLE
reflect rendertarget

### DIFF
--- a/crates/bevy_camera/src/camera.rs
+++ b/crates/bevy_camera/src/camera.rs
@@ -811,7 +811,7 @@ impl Default for CameraOutputMode {
 /// The "target" that a [`Camera`] will render to. For example, this could be a `Window`
 /// swapchain or an [`Image`].
 #[derive(Component, Debug, Clone, Reflect, From)]
-#[reflect(Clone)]
+#[reflect(Clone, Component)]
 pub enum RenderTarget {
     /// Window to which the camera's view is rendered.
     Window(WindowRef),


### PR DESCRIPTION
RenderTarget was a Component that derived Reflect but did not Reflect Component

as of this merge today: https://github.com/bevyengine/bevy/commit/67633b34da677a825ea3c6900b884d012d56999b

Without this fix, spawning a scene with a camera (such as from a Blender export) causes a panic:

> scene contains the unregistered component `bevy_camera::camera::RenderTarget`. consider adding `#[reflect(Component)]` to your type
