### PR TITLE
Refactor GltfExtensionHandler Hooks

### DIFF
--- a/examples/gltf/gltf_extension_animation_graph.rs
+++ b/examples/gltf/gltf_extension_animation_graph.rs
@@ -135,15 +135,8 @@ impl GltfExtensionHandler for GltfExtensionHandlerAnimation {
     }
 
     #[cfg(feature = "bevy_animation")]
-    fn on_animation(
-        &mut self,
-        _extension_id: &str,
-        _value: Option<&serde_json::Value>,
-        _gltf_animation: &gltf::Animation,
-        name: Option<&str>,
-        handle: Handle<AnimationClip>,
-    ) {
-        if name.is_some_and(|v| v == "Walk") {
+    fn on_animation(&mut self, gltf_animation: &gltf::Animation, handle: Handle<AnimationClip>) {
+        if gltf_animation.name().is_some_and(|v| v == "Walk") {
             self.clip = Some(handle.clone());
         }
     }
@@ -160,8 +153,6 @@ impl GltfExtensionHandler for GltfExtensionHandlerAnimation {
 
     fn on_gltf_node(
         &mut self,
-        _extension_id: &str,
-        _value: Option<&serde_json::Value>,
         _load_context: &mut LoadContext<'_>,
         gltf_node: &gltf::Node,
         entity: &mut EntityWorldMut,
@@ -174,13 +165,10 @@ impl GltfExtensionHandler for GltfExtensionHandlerAnimation {
     /// Called when an individual Scene is done processing
     fn on_scene_completed(
         &mut self,
-        _extension_id: &str,
-        _value: Option<&serde_json::Value>,
+        load_context: &mut LoadContext<'_>,
         _scene: &gltf::Scene,
-        _name: Option<&str>,
         _world_root_id: Entity,
         world: &mut World,
-        load_context: &mut LoadContext<'_>,
     ) {
         // Create an AnimationGraph from the desired clip
         let (graph, index) = AnimationGraph::from_clip(self.clip.clone().unwrap());


### PR DESCRIPTION
As it turns out, many glTF extensions require accessing the data from other extensions.

Trying to isolate and scope access is much less helpful than exposing the glTF objects for consumers to take what they want.

This includes

- extension data in the "others" category (anything the gltf crate doesn't support explicitly)
- the functions that return the extension data the gltf crate *does* have hardcoded support for
- names and any other available data

---

The diff for users is that they

- no longer have to worry about defining extension ids to process
- no longer have to worry about multiple calls due to those ids
- now have to use `.extension_value()`, `.name()`, or similar to get relevant data
- Can now access `.light()` or any other data built-in to the gltf crate, such as [`.variants`](https://docs.rs/gltf/1.4.1/gltf/struct.Document.html#method.variants) for `KHR_materials_variants`.

An example diff on the user side can be viewed in the update commit for the Skein PR: https://github.com/rust-adventure/skein/pull/89/changes/ac1e510c9d136d60c23decd68b10f35f6e24f76b