### PR TITLE
derive `Clone` and `Copy` for newer `interaction_states` unit structs

### DIFF
--- a/crates/bevy_ui/src/interaction_states.rs
+++ b/crates/bevy_ui/src/interaction_states.rs
@@ -37,15 +37,15 @@ pub(crate) fn on_remove_disabled(
 
 /// Component that indicates whether a button or widget is currently in a pressed or "held down"
 /// state.
-#[derive(Component, Default, Debug, Clone)]
+#[derive(Component, Debug, Clone, Copy, Default)]
 pub struct Pressed;
 
 /// Component that indicates that a widget can be checked.
-#[derive(Component, Default, Debug, Clone)]
+#[derive(Component, Debug, Clone, Copy, Default)]
 pub struct Checkable;
 
 /// Component that indicates whether a checkbox or radio button is in a checked state.
-#[derive(Component, Default, Debug, Clone)]
+#[derive(Component, Debug, Clone, Copy, Default)]
 pub struct Checked;
 
 pub(crate) fn on_add_checkable(add: On<Add, Checked>, mut world: DeferredWorld) {


### PR DESCRIPTION
# Objective

- derive `Clone` and `Copy` for the newer unit structs in `interaction_states`, this is useful for frameworks that are generic over `Component + Clone/Copy` and is also the status quo for the existing `InteractionDisabled` component defined a few lines above

## Solution

- derive `Clone` and `Copy` for `Pressed`, `Checkable`, and `Checked`