### PR TITLE
Use slice `last` instead of iter `last.

### DIFF
--- a/crates/bevy_gltf/src/loader/mod.rs
+++ b/crates/bevy_gltf/src/loader/mod.rs
@@ -646,7 +646,7 @@ impl GltfLoader {
                 for extension in extensions.iter_mut() {
                     extension.on_texture(
                         texture.extensions(),
-                        texture_handles.iter().last().unwrap().clone(),
+                        texture_handles.last().unwrap().clone(),
                     );
                 }
             }
@@ -684,7 +684,7 @@ impl GltfLoader {
                         for extension in extensions.iter_mut() {
                             extension.on_texture(
                                 extension_data.as_ref(),
-                                texture_handles.iter().last().unwrap().clone(),
+                                texture_handles.last().unwrap().clone(),
                             );
                         }
                     }


### PR DESCRIPTION
# Objective

- Followup to #22106.

## Solution

- Use slice `last` instead of iter `last` for better performance - we don't need to iterate just to find the last element.