### PR TITLE
Fix: Ignores nodes that are hidden via their parents in directional nav

### DIFF
--- a/crates/bevy_input_focus/src/directional_navigation.rs
+++ b/crates/bevy_input_focus/src/directional_navigation.rs
@@ -60,7 +60,7 @@
 
 use alloc::vec::Vec;
 use bevy_app::prelude::*;
-use bevy_camera::visibility::{Visibility, InheritedVisibility};
+use bevy_camera::visibility::{InheritedVisibility, Visibility};
 use bevy_ecs::{
     entity::{EntityHashMap, EntityHashSet},
     prelude::*,
@@ -749,7 +749,7 @@ fn auto_rebuild_ui_navigation_graph(
             &ComputedNode,
             &UiGlobalTransform,
             Option<&Visibility>,
-            Option<&InheritedVisibility>
+            Option<&InheritedVisibility>,
         ),
         With<AutoDirectionalNavigation>,
     >,
@@ -760,19 +760,24 @@ fn auto_rebuild_ui_navigation_graph(
 
     let nodes: Vec<FocusableArea> = all_nodes
         .iter()
-        .filter_map(|(entity, computed, transform, visibility, inherited_visibility)| {
-            // Skip hidden or zero-size nodes
-            if computed.is_empty() || matches!(visibility, Some(Visibility::Hidden)) || 
-            (matches!(visibility, Some(Visibility::Inherited)) && matches!(inherited_visibility, Some(&InheritedVisibility::HIDDEN))) {
-                return None;
-            }
-            let (_scale, _rotation, translation) = transform.to_scale_angle_translation();
-            Some(FocusableArea {
-                entity,
-                position: translation,
-                size: computed.size(),
-            })
-        })
+        .filter_map(
+            |(entity, computed, transform, visibility, inherited_visibility)| {
+                // Skip hidden or zero-size nodes
+                if computed.is_empty()
+                    || matches!(visibility, Some(Visibility::Hidden))
+                    || (matches!(visibility, Some(Visibility::Inherited))
+                        && matches!(inherited_visibility, Some(&InheritedVisibility::HIDDEN)))
+                {
+                    return None;
+                }
+                let (_scale, _rotation, translation) = transform.to_scale_angle_translation();
+                Some(FocusableArea {
+                    entity,
+                    position: translation,
+                    size: computed.size(),
+                })
+            },
+        )
         .collect();
 
     auto_generate_navigation_edges(&mut directional_nav_map, &nodes, &config);


### PR DESCRIPTION
# Objective

- Fixes #21950

## Solution

- Updated the query as suggested in the issue to also check for `InheritedVisibility`. Entities that have `Visibility::INHERITED` and `InheritedVisibility::HIDDEN` should also be ignored for directional navigation

## Testing

- Did you test these changes? If so, how?
I did not test this change at all! And I wasn’t sure how best to set up an automated test for this since there is not an existing one for that function, else I would have. However, the logic change is simple at least… So if a test is desired, just let me know and please provide me with a little direction :) 