### PR TITLE
Fix: Clears directional navigation map between rebuilds

### DIFF
--- a/crates/bevy_input_focus/src/directional_navigation.rs
+++ b/crates/bevy_input_focus/src/directional_navigation.rs
@@ -773,6 +773,8 @@ fn auto_rebuild_ui_navigation_graph(
         })
         .collect();
 
+    // clear the old nav map between rebuilds to ensure any removed entities' edges are pruned
+    directional_nav_map.clear();
     auto_generate_navigation_edges(&mut directional_nav_map, &nodes, &config);
 }
 


### PR DESCRIPTION
# Objective

- Closes #21949 

## Solution

- Implements the solution as suggested by 21949. The Directional Navigation Map does not prune any old edges that may be connected to removed Nodes, so we clear the map between rebuilds of the map.

(If the more preferable solution figures out what nodes were removed and then calls `map.remove_multiple` instead, you can feel free to reject this)

## Testing

- Did you test these changes? If so, how?
I did not test this change, but the reporter of the issue did (via backport to an older version of Bevy). However, the fix is straightforward and explains itself. If you would like an automated test somehow, some pointers to tests that do similar would be welcome.