### PR TITLE
Fix compilation errors and warnings when running bevy_gltf with no features.

### DIFF
--- a/crates/bevy_gltf/src/loader/extensions/mod.rs
+++ b/crates/bevy_gltf/src/loader/extensions/mod.rs
@@ -7,7 +7,6 @@ mod khr_materials_specular;
 use alloc::sync::Arc;
 use async_lock::RwLock;
 
-use bevy_animation::AnimationClip;
 use bevy_asset::{Handle, LoadContext};
 use bevy_ecs::{
     entity::Entity,
@@ -15,8 +14,13 @@ use bevy_ecs::{
     world::{EntityWorldMut, World},
 };
 use bevy_pbr::StandardMaterial;
-use bevy_platform::collections::{HashMap, HashSet};
 use gltf::Node;
+
+#[cfg(feature = "bevy_animation")]
+use {
+    bevy_animation::AnimationClip,
+    bevy_platform::collections::{HashMap, HashSet},
+};
 
 use crate::GltfMesh;
 


### PR DESCRIPTION
# Objective

- #22106 accidentally added imports for AnimationClip, HashMap, and HashSet - but these are only available/used if the bevy_animation feature is enabled. So running `cargo t -p bevy_gltf` fails to compile and gives warnings!

## Solution

- Guard these `use` statements on the bevy_animation feature.

## Testing

- Ran `cargo t -p bevy_gltf`.
- Ran `cargo t -p bevy_gltf --all-features`.
