### PR TITLE
install x264 linux dependency in CI jobs that need it

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,6 +46,7 @@ jobs:
         with:
           wayland: true
           xkb: true
+          x264: true
 
       #  This does the following:
       #   - Replaces the docs icon with one that clearly denotes it's not the released package on crates.io

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -115,6 +115,7 @@ jobs:
         with:
           wayland: true
           xkb: true
+          x264: true
 
       # Fetch the cache using the complete key - to avoid rebuilding the cache if nothing changed
       - uses: actions/cache/restore@v4

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -67,6 +67,7 @@ jobs:
         with:
           wayland: true
           xkb: true
+          x264: true
       - name: Run lints
         # See tools/ci/src/main.rs for the commands this runs
         run: cargo run -p ci -- lints


### PR DESCRIPTION
# Objective

- Some CI jobs on a schedule / on main started failing after #21237 
- Fixes part of https://github.com/bevyengine/bevy/issues/21978

## Solution

- Install the linux dependencies needed
