### PR TITLE
disable scraping examples in doc

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -62,8 +62,6 @@ jobs:
           RUSTDOCFLAGS: -Zunstable-options --cfg=docsrs --generate-link-to-definition --html-after-content docs-rs/trait-tags.html
         run: |
           cargo doc \
-            -Zunstable-options \
-            -Zrustdoc-scrape-examples \
             --all-features \
             --workspace \
             --no-deps \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4691,7 +4691,6 @@ rustdoc-args = [
   "docs-rs/trait-tags.html",
 ]
 all-features = true
-cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
 
 [[example]]
 name = "monitor_info"


### PR DESCRIPTION
# Objective

- rustdoc example scrapping is too unstable, and often ICE 
- Fixes https://github.com/bevyengine/bevy/issues/21978

## Solution

- Stop using it
