### PR TITLE
gate SceneLoaderError behind same feature as scene loader

### DIFF
--- a/crates/bevy_scene/src/scene_loader.rs
+++ b/crates/bevy_scene/src/scene_loader.rs
@@ -3,13 +3,13 @@ use bevy_ecs::{
     world::{FromWorld, World},
 };
 use bevy_reflect::TypeRegistryArc;
-use thiserror::Error;
 
 #[cfg(feature = "serialize")]
 use {
     crate::{serde::SceneDeserializer, DynamicScene},
     bevy_asset::{io::Reader, AssetLoader, LoadContext},
     serde::de::DeserializeSeed,
+    thiserror::Error,
 };
 
 /// Asset loader for a Bevy dynamic scene (`.scn` / `.scn.ron`).
@@ -34,6 +34,7 @@ impl FromWorld for SceneLoader {
 }
 
 /// Possible errors that can be produced by [`SceneLoader`]
+#[cfg(feature = "serialize")]
 #[non_exhaustive]
 #[derive(Debug, Error)]
 pub enum SceneLoaderError {


### PR DESCRIPTION
# Objective

- Fixes #22138 
- Asset loader is gated by a feature, but the asset loader error type isn't

## Solution

- Gate the asset loader error type behind the same feature as the asset loader
