### PR TITLE
Suppress Warnings for unused code in bevy_gizmos_render

### DIFF
--- a/crates/bevy_gizmos_render/src/lib.rs
+++ b/crates/bevy_gizmos_render/src/lib.rs
@@ -147,7 +147,15 @@ fn extract_gizmo_data(
             continue;
         }
 
-        let Some(handle) = handle else {
+        #[cfg_attr(
+            not(any(feature = "bevy_pbr", feature = "bevy_sprite_render")),
+            expect(
+                unused_variables,
+                reason = "`handle` is unused when bevy_pbr and bevy_sprite_render are both disabled."
+            )
+        )]
+        let Some(handle) = handle
+        else {
             continue;
         };
 
@@ -215,6 +223,13 @@ struct LineGizmoUniform {
     _padding: bevy_math::Vec3,
 }
 
+#[cfg_attr(
+    not(any(feature = "bevy_pbr", feature = "bevy_sprite_render")),
+    expect(
+        dead_code,
+        reason = "fields are unused when bevy_pbr and bevy_sprite_render are both disabled."
+    )
+)]
 #[derive(Debug, Clone)]
 struct GpuLineGizmo {
     list_position_buffer: Buffer,
@@ -275,6 +290,13 @@ struct LineGizmoUniformBindgroupLayout {
     layout: BindGroupLayoutDescriptor,
 }
 
+#[cfg_attr(
+    not(any(feature = "bevy_pbr", feature = "bevy_sprite_render")),
+    expect(
+        dead_code,
+        reason = "fields are unused when bevy_pbr and bevy_sprite_render are both disabled."
+    )
+)]
 #[derive(Resource)]
 struct LineGizmoUniformBindgroup {
     bindgroup: BindGroup,
@@ -298,6 +320,13 @@ fn prepare_line_gizmo_bind_group(
     }
 }
 
+#[cfg_attr(
+    not(any(feature = "bevy_pbr", feature = "bevy_sprite_render")),
+    expect(
+        dead_code,
+        reason = "struct is not constructed when bevy_pbr and bevy_sprite_render are both disabled."
+    )
+)]
 struct SetLineGizmoBindGroup<const I: usize>;
 
 impl<const I: usize, P: PhaseItem> RenderCommand<P> for SetLineGizmoBindGroup<I> {
@@ -325,6 +354,13 @@ impl<const I: usize, P: PhaseItem> RenderCommand<P> for SetLineGizmoBindGroup<I>
     }
 }
 
+#[cfg_attr(
+    not(any(feature = "bevy_pbr", feature = "bevy_sprite_render")),
+    expect(
+        dead_code,
+        reason = "struct is not constructed when bevy_pbr and bevy_sprite_render are both disabled."
+    )
+)]
 struct DrawLineGizmo<const STRIP: bool>;
 
 impl<P: PhaseItem, const STRIP: bool> RenderCommand<P> for DrawLineGizmo<STRIP> {
@@ -384,6 +420,13 @@ impl<P: PhaseItem, const STRIP: bool> RenderCommand<P> for DrawLineGizmo<STRIP> 
     }
 }
 
+#[cfg_attr(
+    not(any(feature = "bevy_pbr", feature = "bevy_sprite_render")),
+    expect(
+        dead_code,
+        reason = "struct is not constructed when bevy_pbr and bevy_sprite_render are both disabled."
+    )
+)]
 struct DrawLineJointGizmo;
 
 impl<P: PhaseItem> RenderCommand<P> for DrawLineJointGizmo {
@@ -455,6 +498,13 @@ impl<P: PhaseItem> RenderCommand<P> for DrawLineJointGizmo {
     }
 }
 
+#[cfg_attr(
+    not(any(feature = "bevy_pbr", feature = "bevy_sprite_render")),
+    expect(
+        dead_code,
+        reason = "function is unused when bevy_pbr and bevy_sprite_render are both disabled."
+    )
+)]
 fn line_gizmo_vertex_buffer_layouts(strip: bool) -> Vec<VertexBufferLayout> {
     use VertexFormat::*;
     let mut position_layout = VertexBufferLayout {
@@ -509,6 +559,13 @@ fn line_gizmo_vertex_buffer_layouts(strip: bool) -> Vec<VertexBufferLayout> {
     }
 }
 
+#[cfg_attr(
+    not(any(feature = "bevy_pbr", feature = "bevy_sprite_render")),
+    expect(
+        dead_code,
+        reason = "function is unused when bevy_pbr and bevy_sprite_render are both disabled."
+    )
+)]
 fn line_joint_gizmo_vertex_buffer_layouts() -> Vec<VertexBufferLayout> {
     use VertexFormat::*;
     let mut position_layout = VertexBufferLayout {

--- a/crates/bevy_gizmos_render/src/retained.rs
+++ b/crates/bevy_gizmos_render/src/retained.rs
@@ -25,6 +25,13 @@ pub(crate) fn extract_linegizmos(
     query: Extract<Query<(Entity, &Gizmo, &GlobalTransform, Option<&RenderLayers>)>>,
 ) {
     let mut values = Vec::with_capacity(*previous_len);
+    #[cfg_attr(
+        not(any(feature = "bevy_pbr", feature = "bevy_sprite_render")),
+        expect(
+            unused_variables,
+            reason = "`render_layers` is unused when bevy_pbr and bevy_sprite_render are both disabled."
+        )
+    )]
     for (entity, gizmo, transform, render_layers) in &query {
         let joints_resolution = if let GizmoLineJoint::Round(resolution) = gizmo.line_config.joints
         {


### PR DESCRIPTION
# Objective

- Fixes #22137 

## Solution

Add `expect`’s to suppress the warnings generated after running `cargo build -p bevy_gizmos_render`.  All of the warnings stem from fields/structs/functions that go unused if neither the `bevy_pbr` or `bevy_sprite_render` features are on (they are only used if either the plugin in `pipeline_2d` or `pipeline_3d` are added), so the expects are gated to that particular circumstance.

## Testing

- Did you test these changes? If so, how?
Running `cargo build -p bevy_gizmos_render` emits no warnings
Running `cargo clippy` emits no warnings
