### PR TITLE
register read on DefaultErrorHandler in CombinatorSystem

### DIFF
--- a/crates/bevy_ecs/src/system/combinator.rs
+++ b/crates/bevy_ecs/src/system/combinator.rs
@@ -492,8 +492,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use crate::error::DefaultErrorHandler;
     use crate::prelude::*;
-    use crate::{error::DefaultErrorHandler, schedule::AndMarker};
     use bevy_utils::prelude::DebugName;
 
     use crate::{
@@ -523,12 +523,6 @@ mod tests {
 
         // `system` should not conflict with itself by mutably accessing the error handler resource.
         assert_system_does_not_conflict(system.clone());
-
-        let system = CombinatorSystem::<AndMarker, _, _>::new(
-            IntoSystem::into_system(a),
-            IntoSystem::into_system(a),
-            DebugName::borrowed("a AND a"),
-        );
 
         let mut schedule = Schedule::default();
         schedule.add_systems((my_system, system.pipe(asdf)));


### PR DESCRIPTION
# Objective
Fixes #22133

## Solution
`CombinatorSystem` now registers a read on the `DefaultErrorHandler` resource in `System::initialize` as @hymm suggested. I've also decided to deny `unsafe_op_in_unsafe_fn` in that method, which I think would have helped me find this beforehand..

## Testing
I've written a test that checks that `CombinatorSystems` can still access the resource mutably, checks that a combinatory system does conflict with a system which mutably accesses the resource, and runs such a schedule to possibly allow miri to catch the error that this PR fixes (this last point doesn't seem to be the true, but afaik that could be due to it not actually being run in parallel even when it's legal for the executor to do so?).