### PR TITLE
Fix shader import in manual 2d mesh example

### DIFF
--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -241,7 +241,7 @@ type DrawColoredMesh2d = (
 // using `include_str!()`, or loaded like any other asset with `asset_server.load()`.
 const COLORED_MESH2D_SHADER: &str = r"
 // Import the standard 2d mesh uniforms and set their bind groups
-#import bevy_sprite_render::mesh2d_functions
+#import bevy_sprite::mesh2d_functions
 
 // The structure of the vertex buffer is as specified in `specialize()`
 struct Vertex {


### PR DESCRIPTION
# Objective

- Fixes #22126

## Solution

- Use the correct import in the example shader

## Testing

- Tested on Linux with `cargo run --example mesh2d_manual`
