### PR TITLE
Add  `with_cloned_input` and `WithClonedInputWrapper` to system functionality

### DIFF
--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -299,6 +299,34 @@ pub trait IntoSystem<In: SystemInput, Out, Marker>: Sized {
         WithInputFromWrapper::new(self)
     }
 
+    /// Passes a clone of `value` as input to the system each run, turning it into
+    /// a system that takes no input.
+    ///
+    /// `Self` can have any [`SystemInput`] type that takes an owned value of `T`,
+    /// such as [`In`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use bevy_ecs::prelude::*;
+    /// #
+    ///
+    /// fn my_system(In(data): In<usize>) {
+    ///    println!("Value is {}!", data);
+    /// }
+    ///
+    /// # let mut schedule = Schedule::default();
+    /// schedule.add_systems(my_system.with_cloned_input(10));
+    /// # bevy_ecs::system::assert_is_system(my_system.with_cloned_input::(10));
+    /// ```
+    fn with_cloned_input<T>(self, value: T) -> WithClonedInputWrapper<Self::System, T>
+    where
+        for<'i> In: SystemInput<Inner<'i> = T>,
+        T: FromWorld + Send + Sync + 'static,
+    {
+        WithClonedInputWrapper::new(self, value)
+    }
+
     /// Get the [`TypeId`] of the [`System`] produced after calling [`into_system`](`IntoSystem::into_system`).
     #[inline]
     fn system_type_id(&self) -> TypeId {


### PR DESCRIPTION
# Objective

I didn't see an issue for something like this made yet, but I ran into a particularly non-ergonomic situation when working on a prototype where I wanted to be able to run a system that normally takes owned input via `In` with a static, cloneable value. The `with_input` and `with_input_from` functions both require the system takes a mutable reference to their input types, so they wouldn't work for my general case.

## Solution

I effectively copied the code from the `WithInputWrapper` and `WithInputFromWrapper` structs and modified it slightly so that it `clone`s the contained value and passes it as input to the wrapped system.

## Testing

The project successfully builds on my machine, and my personal game prototype was built and ran successfully using this extra functionality. Totally possible I missed an edge case though.

---

## Showcase

```rust
struct GridCoord {
  location: IVec2,
}

fn spawn_creature(In(location): In<IVec2>, mut commands: Commands) {
  commands.spawn((
    GridCoord { location },
    // some other stuff too...
  ))

  // and maybe some other stuff here...
}

struct CreaturePlugin;

impl Plugin for CreaturePlugin {
  fn build(app: &mut App) {
    app.add_systems(Startup, spawn_creature.with_cloned_input(IVec2::new(0, 0));
  }
}
```

The idea being that I want to use `spawn_creature` somewhere else with dynamic input, using `run_system_cached_with`, but on some schedule (in this case, `Startup`), I want to give it a constant input.