### PR TITLE
Revert "Fix: Clears directional navigation map between rebuilds 

### DIFF
--- a/crates/bevy_input_focus/src/directional_navigation.rs
+++ b/crates/bevy_input_focus/src/directional_navigation.rs
@@ -780,8 +780,6 @@ fn auto_rebuild_ui_navigation_graph(
         )
         .collect();
 
-    // clear the old nav map between rebuilds to ensure any removed entities' edges are pruned
-    directional_nav_map.clear();
     auto_generate_navigation_edges(&mut directional_nav_map, &nodes, &config);
 }
 


### PR DESCRIPTION
This reverts commit 545a97d67cdb87237e0bc5f02ecd17ec7e4b5c24, aka #22124.

# Objective

The cure was worse than the disease: losing manual edges is worse than being wrong with redraws.

Fixes #22136.

## Solution

 For now, we'll revert, then we'll look for a better solution. For now, users can get this behavior by manually calling [`clear`](https://docs.rs/bevy/latest/bevy/input_focus/directional_navigation/struct.DirectionalNavigationMap.html#method.clear).

Reopens #21949.