### PR TITLE
fix use-after-free in `AddObserver`

### DIFF
--- a/crates/bevy_ui_widgets/src/observe.rs
+++ b/crates/bevy_ui_widgets/src/observe.rs
@@ -2,7 +2,7 @@
 // It is certainly a useful thing to have.
 #![expect(unsafe_code, reason = "Unsafe code is used to improve performance.")]
 
-use core::marker::PhantomData;
+use core::{marker::PhantomData, mem};
 
 use bevy_ecs::{
     bundle::{Bundle, DynamicBundle},
@@ -48,18 +48,21 @@ impl<E: EntityEvent, B: Bundle, M, I: IntoObserverSystem<E, B, M>> DynamicBundle
 
     #[inline]
     unsafe fn get_components(
-        _ptr: bevy_ecs::ptr::MovingPtr<'_, Self>,
+        ptr: bevy_ecs::ptr::MovingPtr<'_, Self>,
         _func: &mut impl FnMut(bevy_ecs::component::StorageType, bevy_ecs::ptr::OwningPtr<'_>),
     ) {
-        // SAFETY: Empty function body
+        // SAFETY: We must not drop the pointer here, or it will be uninitialized in `apply_effect`
+        // below.
+        mem::forget(ptr);
     }
 
     #[inline]
     unsafe fn apply_effect(
-        ptr: bevy_ecs::ptr::MovingPtr<'_, core::mem::MaybeUninit<Self>>,
+        ptr: bevy_ecs::ptr::MovingPtr<'_, mem::MaybeUninit<Self>>,
         entity: &mut bevy_ecs::world::EntityWorldMut,
     ) {
-        // SAFETY: `get_components` does nothing, value was not moved.
+        // SAFETY: The pointer was not dropped in `get_components`, so the allocation is still
+        // initialized.
         let add_observer = unsafe { ptr.assume_init() };
         let add_observer = add_observer.read();
         entity.observe(add_observer.observer);


### PR DESCRIPTION
# Objective

Fixes #22152

## Solution



From the safety notes on `DynamicBundle::apply_effect`:

> If any part of `ptr` is to be accessed in this function, it must *not* be dropped at any point in `get_components`.

The `MovingPtr` [here](https://github.com/bevyengine/bevy/blob/8e4711cc40a883a1995dad06cc2b7e6f336b2f35/crates/bevy_ui_widgets/src/observe.rs#L51) is dropped when it goes out of scope, so the `assume_init` [here](https://github.com/bevyengine/bevy/blob/8e4711cc40a883a1995dad06cc2b7e6f336b2f35/crates/bevy_ui_widgets/src/observe.rs#L63) is invalid. This is fixed by `mem::forget`-ing the pointer in `get_components`, which will leave the allocation intact for `apply_effect`.

## Testing

Using the example from the issue, the logs are correct after this patch