### PR TITLE
Fix a crash in late_mesh_preprocessing 

### DIFF
--- a/crates/bevy_pbr/src/render/gpu_preprocess.rs
+++ b/crates/bevy_pbr/src/render/gpu_preprocess.rs
@@ -832,6 +832,22 @@ impl Node for LateGpuPreprocessNode {
         let pipeline_cache = world.resource::<PipelineCache>();
         let preprocess_pipelines = world.resource::<PreprocessPipelines>();
 
+        let maybe_pipeline_id = preprocess_pipelines
+            .late_gpu_occlusion_culling_preprocess
+            .pipeline_id;
+
+        // Fetch the pipeline.
+        let Some(preprocess_pipeline_id) = maybe_pipeline_id else {
+            warn!("The build mesh uniforms pipeline wasn't ready");
+            return Ok(());
+        };
+
+        let Some(preprocess_pipeline) = pipeline_cache.get_compute_pipeline(preprocess_pipeline_id)
+        else {
+            // This will happen while the pipeline is being compiled and is fine.
+            return Ok(());
+        };
+
         let mut compute_pass =
             render_context
                 .command_encoder()
@@ -839,27 +855,11 @@ impl Node for LateGpuPreprocessNode {
                     label: Some("late_mesh_preprocessing"),
                     timestamp_writes: None,
                 });
+
         let pass_span = diagnostics.pass_span(&mut compute_pass, "late_mesh_preprocessing");
 
         // Run the compute passes.
         for (view, bind_groups, view_uniform_offset) in self.view_query.iter_manual(world) {
-            let maybe_pipeline_id = preprocess_pipelines
-                .late_gpu_occlusion_culling_preprocess
-                .pipeline_id;
-
-            // Fetch the pipeline.
-            let Some(preprocess_pipeline_id) = maybe_pipeline_id else {
-                warn!("The build mesh uniforms pipeline wasn't ready");
-                return Ok(());
-            };
-
-            let Some(preprocess_pipeline) =
-                pipeline_cache.get_compute_pipeline(preprocess_pipeline_id)
-            else {
-                // This will happen while the pipeline is being compiled and is fine.
-                return Ok(());
-            };
-
             compute_pass.set_pipeline(preprocess_pipeline);
 
             // Loop over each phase. Because we built the phases in parallel,


### PR DESCRIPTION
# Objective

- early out obviates a diagnostics span end call, which panics on drop

## Solution

- early out before starting the diagnostic span

## Testing

- this was causing crashes in the occlusion_culling example. it no longer crashes