### PR TITLE
`auto_rebuild_ui_navigation_graph` visibility fix

### DIFF
--- a/crates/bevy_input_focus/src/directional_navigation.rs
+++ b/crates/bevy_input_focus/src/directional_navigation.rs
@@ -777,7 +777,7 @@ fn auto_rebuild_ui_navigation_graph(
         })
         .collect();
 
-    auto_generate_navigation_edges(&mut directional_nav_map, &nodes, &config)
+    auto_generate_navigation_edges(&mut directional_nav_map, &nodes, &config);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Objective

Fixes #22163

## Solution

* Schedule `auto_rebuild_ui_navigation_graph` after `VisibilityPropagate` so node visibility is up to date before it runs.
* In `auto_rebuild_ui_navigation_graph` rebuild the navigation graphs on changes to `InheritedVisibility`.