### PR TITLE
Enable the necessary features for `bevy_input` for `bevy_input_focus`

### DIFF
--- a/crates/bevy_input_focus/Cargo.toml
+++ b/crates/bevy_input_focus/Cargo.toml
@@ -63,7 +63,10 @@ libm = ["bevy_math/libm", "bevy_window/libm"]
 bevy_app = { path = "../bevy_app", version = "0.18.0-dev", default-features = false }
 bevy_camera = { path = "../bevy_camera", version = "0.18.0-dev", default-features = false }
 bevy_ecs = { path = "../bevy_ecs", version = "0.18.0-dev", default-features = false }
-bevy_input = { path = "../bevy_input", version = "0.18.0-dev", default-features = false }
+bevy_input = { path = "../bevy_input", version = "0.18.0-dev", default-features = false, features = [
+  "keyboard",
+  "gamepad",
+] }
 bevy_math = { path = "../bevy_math", version = "0.18.0-dev", default-features = false }
 bevy_picking = { path = "../bevy_picking", version = "0.18.0-dev", default-features = false, optional = true }
 bevy_ui = { path = "../bevy_ui", version = "0.18.0-dev", default-features = false }


### PR DESCRIPTION
# Objective

- Features added for `bevy_input` in #21447 wasn't enabled for `bevy_input_focus` which causes compilation error.

## Solution

- Enable them.

## Testing

- I checked that `cargo check -p bevy_input_focus` no longer fails.