### PR TITLE
impl Deref for BackgroundColor

### DIFF
--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -2205,7 +2205,7 @@ pub enum GridPlacementError {
 /// The background color of the node
 ///
 /// This serves as the "fill" color.
-#[derive(Component, Copy, Clone, Debug, PartialEq, Reflect)]
+#[derive(Component, Copy, Clone, Debug, Deref, DerefMut, PartialEq, Reflect)]
 #[reflect(Component, Default, Debug, PartialEq, Clone)]
 #[cfg_attr(
     feature = "serialize",


### PR DESCRIPTION
# Objective

Many newtypes in Bevy implement `Deref` and `DerefMut` for convenience. Let us extend that to `BackgroundColor`.

## Solution

Derived `Deref` and `DerefMut` for `BackgroundColor`.
