### PR TITLE
Fix atmosphere lighting issue for below ground geo

### DIFF
--- a/crates/bevy_pbr/src/render/pbr_lighting.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_lighting.wgsl
@@ -3,7 +3,7 @@
 #import bevy_pbr::{
     mesh_view_types::POINT_LIGHT_FLAGS_SPOT_LIGHT_Y_NEGATIVE,
     mesh_view_bindings as view_bindings,
-    atmosphere::functions::calculate_visible_sun_ratio,
+    atmosphere::functions::{calculate_visible_sun_ratio, clamp_to_surface},
     atmosphere::bruneton_functions::transmittance_lut_r_mu_to_uv,
 }
 #import bevy_render::maths::PI
@@ -862,8 +862,9 @@ color *= (*light).color.rgb * texture_sample;
     let O = vec3(0.0, atmosphere.bottom_radius, 0.0);
     let P_scaled = P * vec3(view_bindings::atmosphere_data.settings.scene_units_to_m);
     let P_as = P_scaled + O;
-    let r = length(P_as);
-    let local_up = normalize(P_as);
+    let P_clamped = clamp_to_surface(atmosphere, P_as);
+    let r = length(P_clamped);
+    let local_up = normalize(P_clamped);
     let mu_light = dot(L, local_up);
 
     // Sample atmosphere


### PR DESCRIPTION
# Objective

- Fix atmosphere lighting issue for below ground geo

Issue reported in discord channel for `rendering-dev` by Jondolf@

<img width="3840" height="2111" alt="image" src="https://github.com/user-attachments/assets/f2768fd5-2e70-46cb-b0f3-b078d115fd33" />

Repro on [f8a9f29](https://github.com/bevyengine/bevy/commit/f8a9f296bf45584feb987d626dbf331ac9b01918)

```rs
use bevy::{pbr::EarthlikeAtmosphere, prelude::*};

fn main() {
    App::new()
        .add_plugins(DefaultPlugins)
        .add_systems(Startup, setup)
        .run();
}

fn setup(
    mut commands: Commands,
    mut meshes: ResMut<Assets<Mesh>>,
    mut materials: ResMut<Assets<StandardMaterial>>,
    earthlike_atmosphere: Res<EarthlikeAtmosphere>,
) {
    commands.spawn((
        Mesh3d(meshes.add(Capsule3d::new(0.5, 1.0))),
        MeshMaterial3d(materials.add(Color::WHITE)),
    ));

    // Directional light
    commands.spawn((
        DirectionalLight {
            illuminance: 5000.0,
            shadows_enabled: true,
            ..default()
        },
        Transform::from_xyz(1.0, 2.0, 2.0).looking_at(Vec3::ZERO, Vec3::Y),
    ));

    // Camera and atmosphere
    commands.spawn((
        Camera3d::default(),
        earthlike_atmosphere.get(),
        Transform::from_xyz(10.0, 2.0, 15.0).looking_at(Vec3::new(0.0, 0.0, 0.0), Vec3::Y),
    ));
}
```

## Solution

- Clamp the position to the ground surface with a small epsilon before calculating occlusion from the planet

## Testing

- Ran the atmosphere example with local changes to put geo below-ground

---

## Showcase

Before
<img width="1283" height="720" alt="Screenshot 2025-12-17 at 1 58 21 PM" src="https://github.com/user-attachments/assets/f442e0f9-b688-4d16-ad08-d9b3414c8b0f" />

After

<img width="1275" height="719" alt="Screenshot 2025-12-17 at 1 57 56 PM" src="https://github.com/user-attachments/assets/557ea595-3b9d-4fbf-8c94-10377deb046a" />
