### PR TITLE
safety lint in bevy_reflect on wasm

### DIFF
--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -793,14 +793,14 @@ pub mod __macro_exports {
                     if INIT_DONE.swap(true, Ordering::Relaxed) {
                         return;
                     };
-                    // SAFETY:
-                    // This will call constructors on wasm platforms at most once (as long as `init` is the only function that calls `__wasm_call_ctors`).
-                    //
-                    // For more information see: https://docs.rs/inventory/latest/inventory/#webassembly-and-constructors
                     #[expect(
                         unsafe_code,
                         reason = "This function must be called to use inventory on wasm."
                     )]
+                    // SAFETY:
+                    // This will call constructors on wasm platforms at most once (as long as `init` is the only function that calls `__wasm_call_ctors`).
+                    //
+                    // For more information see: https://docs.rs/inventory/latest/inventory/#webassembly-and-constructors
                     unsafe {
                         __wasm_call_ctors();
                     }


### PR DESCRIPTION
# Objective

- `cargo clippy --target wasm32-unknown-unknown -p bevy_reflect --no-deps -- -D warnings` fail with
```
error: unsafe block missing a safety comment
   --> crates/bevy_reflect/src/lib.rs:804:21
    |
804 |                     unsafe {
    |                     ^^^^^^^^
    |
```

## Solution

- Change the order between the lint and the safety comment
