### PR TITLE
Add missing keybind to gizmos example

### DIFF
--- a/examples/gizmos/2d_gizmos.rs
+++ b/examples/gizmos/2d_gizmos.rs
@@ -149,6 +149,16 @@ fn update_config(
             _ => GizmoLineStyle::Solid,
         };
     }
+    if keyboard.just_pressed(KeyCode::KeyI) {
+        config.line.style = match config.line.style {
+            GizmoLineStyle::Solid => GizmoLineStyle::Dashed {
+                gap_scale: 3.0,
+                line_scale: 5.0,
+            },
+            GizmoLineStyle::Dotted => GizmoLineStyle::Solid,
+            _ => GizmoLineStyle::Dotted,
+        };
+    }
     if keyboard.just_pressed(KeyCode::KeyJ) {
         config.line.joints = match config.line.joints {
             GizmoLineJoint::Bevel => GizmoLineJoint::Miter,


### PR DESCRIPTION
# Objective

- I noticed that the example 2d_gizmos said about pressing J or K to cycle between joints, but letter K wasn't working, same with letter I

## Solution

- Just add the keybinds and make them cycle in reverse.

Other possible solution would be removing the mention to such letters entirely, but the example looks cooler with those.
