### PR TITLE
bevy_asset fails lint expectation in wasm on ProcessError

### DIFF
--- a/crates/bevy_asset/src/processor/process.rs
+++ b/crates/bevy_asset/src/processor/process.rs
@@ -231,9 +231,12 @@ pub trait ErasedProcessor: Send + Sync {
     ) -> BoxedFuture<'a, Result<Box<dyn AssetMetaDyn>, ProcessError>>;
     /// Type-erased variant of [`Process::reader_required_features`].
     // Note: This takes &self just to be dyn compatible.
-    #[expect(
-        clippy::result_large_err,
-        reason = "this is only an error here because this isn't a future"
+    #[cfg_attr(
+        not(target_arch = "wasm32"),
+        expect(
+            clippy::result_large_err,
+            reason = "this is only an error here because this isn't a future"
+        )
     )]
     fn reader_required_features(
         &self,


### PR DESCRIPTION
# Objective

- `cargo clippy --target wasm32-unknown-unknown -p bevy_asset --no-deps -- -D warnings` fails with
```
error: this lint expectation is unfulfilled
   --> crates/bevy_asset/src/processor/process.rs:235:9
    |
235 |         clippy::result_large_err,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
    |
```

## Solution

- don't expect the lint in wasm
