### PR TITLE
Remove dependency from "bevy_platform/web" to "bevy_platform/std"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,11 @@ jobs:
         uses: ./.github/actions/install-linux-deps
       - name: Check Compile
         run: cargo check -p bevy --no-default-features --features default_no_std --target x86_64-unknown-none
+      # Check for regression in "web" feature breaking no_std builds.
+      # This is not a separate CI job because the added feature should mostly have no effect
+      # and be able to reuse the prior build.
+      - name: Check Compile with --features=web
+        run: cargo check -p bevy --no-default-features --features default_no_std,web --target x86_64-unknown-none
 
   check-compiles-no-std-portable-atomic:
     runs-on: ubuntu-latest

--- a/crates/bevy_platform/Cargo.toml
+++ b/crates/bevy_platform/Cargo.toml
@@ -45,10 +45,8 @@ alloc = ["portable-atomic-util/alloc", "dep:hashbrown", "serde?/alloc"]
 ## on all platforms, including `no_std`.
 critical-section = ["dep:critical-section", "portable-atomic/critical-section"]
 
-## Enables use of browser APIs.
-## Note this is currently only applicable on `wasm32` architectures.
+## Enables use of browser APIs if the build is a `wasm32` target.
 web = [
-  "std",
   "dep:web-time",
   "dep:wasm-bindgen-futures",
   "dep:wasm-bindgen",


### PR DESCRIPTION
# Objective

Fixes #22168.

## Solution

Remove dependency from "bevy_platform/web" to "bevy_platform/std", partially reverting #20369.

This PR was made per @alice-i-cecile 's suggestion https://github.com/bevyengine/bevy/issues/22168#issuecomment-3667179194. I am not familiar enough with Bevy internal dependencies to know if this is a wise change.

## Testing

- Manually tested that the `no_std` build described in the issue succeeds.
- Added a regression test in CI.
- Did not test whether this has any negative effects on actual web builds.