### PR TITLE
MeshAllocator: Take padding elements into account in the MeshBufferSlice's range

### DIFF
--- a/crates/bevy_render/src/mesh/allocator.rs
+++ b/crates/bevy_render/src/mesh/allocator.rs
@@ -297,7 +297,8 @@ struct SlabAllocation {
     allocation: Allocation,
     /// The number of slots that this allocation takes up.
     slot_count: u32,
-    /// The number of padding elements that this allocation takes up.
+    /// The number of elements at the end that are padding.
+    /// This can happen when the size of each element is fewer than 4 bytes.
     padding_elem_count: u32,
 }
 


### PR DESCRIPTION
# Objective

When using `Indices::U16` (~or custom vertex attributes that have padding elements~ vertex buffer is never padded because wgpu requires it to be 4 bytes aligned), the `MeshAllocator::mesh_index_slice` doesn't take padding elems into account.
For example, run the `lines` example with the following change:
```diff
diff --git a/examples/3d/lines.rs b/examples/3d/lines.rs
index c29e9fb45..c9fcff054 100644
--- a/examples/3d/lines.rs
+++ b/examples/3d/lines.rs
@@ -121,6 +121,13 @@ impl From<LineStrip> for Mesh {
             PrimitiveTopology::LineStrip,
             RenderAssetUsages::RENDER_WORLD,
         )
+        .with_inserted_indices(bevy::mesh::Indices::U16(
+            line.points
+                .iter()
+                .enumerate()
+                .map(|(i, _v)| i as u16)
+                .collect(),
+        ))
         // Add the point positions as an attribute
         .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, line.points)
     }
```
The index count of LineStrip should be 3 with 1 padding in the slab, which should be 3 vertexes but RenderDoc shows 4 vertexes:
<img width="392" height="232" alt="屏幕截图_20251218_192125" src="https://github.com/user-attachments/assets/8e7f391b-56b8-4002-9e02-046f27272f9c" />
<img width="303" height="137" alt="屏幕截图_20251218_191554" src="https://github.com/user-attachments/assets/640ab5d9-574c-45c7-8808-9d772103a7a3" />


## Solution

Fix MeshAllocator by taking padding elements into account and subtract it from the end of the range.

## Testing

Run `lines` example with above patch, the index count is correct:
<img width="303" height="137" alt="屏幕截图_20251218_191455" src="https://github.com/user-attachments/assets/6f0fa9c2-89eb-4530-9478-82f60eb15a9f" />
