### PR TITLE
Move observe helper to ecs observer module

### DIFF
--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -6,11 +6,13 @@
 mod centralized_storage;
 mod distributed_storage;
 mod entity_cloning;
+mod observe;
 mod runner;
 mod system_param;
 
 pub use centralized_storage::*;
 pub use distributed_storage::*;
+pub use observe::*;
 pub use runner::*;
 pub use system_param::*;
 

--- a/crates/bevy_ecs/src/observer/observe.rs
+++ b/crates/bevy_ecs/src/observer/observe.rs
@@ -1,10 +1,10 @@
-// TODO: This probably doesn't belong in bevy_ui_widgets, but I am not sure where it should go.
-// It is certainly a useful thing to have.
+//! Helper utilities for adding observers as bundle effects.
+
 #![expect(unsafe_code, reason = "Unsafe code is used to improve performance.")]
 
 use core::{marker::PhantomData, mem};
 
-use bevy_ecs::{
+use crate::{
     bundle::{Bundle, DynamicBundle},
     event::EntityEvent,
     system::IntoObserverSystem,
@@ -26,16 +26,16 @@ unsafe impl<
 {
     #[inline]
     fn component_ids(
-        _components: &mut bevy_ecs::component::ComponentsRegistrator,
-    ) -> impl Iterator<Item = bevy_ecs::component::ComponentId> + use<E, B, M, I> {
+        _components: &mut crate::component::ComponentsRegistrator,
+    ) -> impl Iterator<Item = crate::component::ComponentId> + use<E, B, M, I> {
         // SAFETY: Empty iterator
         core::iter::empty()
     }
 
     #[inline]
     fn get_component_ids(
-        _components: &bevy_ecs::component::Components,
-    ) -> impl Iterator<Item = Option<bevy_ecs::component::ComponentId>> {
+        _components: &crate::component::Components,
+    ) -> impl Iterator<Item = Option<crate::component::ComponentId>> {
         // SAFETY: Empty iterator
         core::iter::empty()
     }
@@ -48,8 +48,8 @@ impl<E: EntityEvent, B: Bundle, M, I: IntoObserverSystem<E, B, M>> DynamicBundle
 
     #[inline]
     unsafe fn get_components(
-        ptr: bevy_ecs::ptr::MovingPtr<'_, Self>,
-        _func: &mut impl FnMut(bevy_ecs::component::StorageType, bevy_ecs::ptr::OwningPtr<'_>),
+        ptr: crate::ptr::MovingPtr<'_, Self>,
+        _func: &mut impl FnMut(crate::component::StorageType, crate::ptr::OwningPtr<'_>),
     ) {
         // SAFETY: We must not drop the pointer here, or it will be uninitialized in `apply_effect`
         // below.
@@ -58,8 +58,8 @@ impl<E: EntityEvent, B: Bundle, M, I: IntoObserverSystem<E, B, M>> DynamicBundle
 
     #[inline]
     unsafe fn apply_effect(
-        ptr: bevy_ecs::ptr::MovingPtr<'_, mem::MaybeUninit<Self>>,
-        entity: &mut bevy_ecs::world::EntityWorldMut,
+        ptr: crate::ptr::MovingPtr<'_, mem::MaybeUninit<Self>>,
+        entity: &mut crate::world::EntityWorldMut,
     ) {
         // SAFETY: The pointer was not dropped in `get_components`, so the allocation is still
         // initialized.

--- a/crates/bevy_feathers/src/controls/virtual_keyboard.rs
+++ b/crates/bevy_feathers/src/controls/virtual_keyboard.rs
@@ -1,9 +1,10 @@
+use bevy_ecs::observer::observe;
 use bevy_ecs::prelude::*;
 use bevy_input_focus::tab_navigation::TabGroup;
 use bevy_ui::Node;
 use bevy_ui::Val;
 use bevy_ui::{widget::Text, FlexDirection};
-use bevy_ui_widgets::{observe, Activate};
+use bevy_ui_widgets::Activate;
 
 use crate::controls::{button, ButtonProps};
 

--- a/crates/bevy_ui_widgets/src/lib.rs
+++ b/crates/bevy_ui_widgets/src/lib.rs
@@ -21,7 +21,6 @@
 mod button;
 mod checkbox;
 mod menu;
-mod observe;
 pub mod popover;
 mod radio;
 mod scrollbar;
@@ -30,7 +29,6 @@ mod slider;
 pub use button::*;
 pub use checkbox::*;
 pub use menu::*;
-pub use observe::*;
 pub use radio::*;
 pub use scrollbar::*;
 pub use slider::*;

--- a/examples/ui/standard_widgets_observers.rs
+++ b/examples/ui/standard_widgets_observers.rs
@@ -6,6 +6,7 @@
 
 use bevy::{
     color::palettes::basic::*,
+    ecs::observer::observe,
     input_focus::{
         tab_navigation::{TabGroup, TabIndex, TabNavigationPlugin},
         InputDispatchPlugin,
@@ -15,8 +16,8 @@ use bevy::{
     reflect::Is,
     ui::{Checked, InteractionDisabled, Pressed},
     ui_widgets::{
-        checkbox_self_update, observe, Activate, Button, Checkbox, Slider, SliderRange,
-        SliderThumb, SliderValue, UiWidgetsPlugins, ValueChange,
+        checkbox_self_update, Activate, Button, Checkbox, Slider, SliderRange, SliderThumb,
+        SliderValue, UiWidgetsPlugins, ValueChange,
     },
 };
 

--- a/examples/ui/virtual_keyboard.rs
+++ b/examples/ui/virtual_keyboard.rs
@@ -2,6 +2,7 @@
 
 use bevy::{
     color::palettes::css::NAVY,
+    ecs::observer::observe,
     feathers::{
         controls::{virtual_keyboard, VirtualKeyPressed},
         dark_theme::create_dark_theme,
@@ -9,7 +10,6 @@ use bevy::{
         FeathersPlugins,
     },
     prelude::*,
-    ui_widgets::observe,
 };
 
 fn main() {


### PR DESCRIPTION
# Objective

The `observe()` helper in `bevy_ui_widgets` is extremely useful in a bunch of contexts beyond just UI. I've ended up copying the original file from `bevy_ui_widgets`  into multiple projects to get this functionality without adding the whole feature.

## Solution

Move the helper out of `bevy_ui_widgets` and into `bevy_ecs`

## Testing

Moving code without changes

---

## Showcase

<details>
  <summary>EX: Adding colliders to a GLTF scene</summary>


```rust
commands.spawn((
    SceneRoot(gltf_scene_handle),
    RigidBody::Static,
    observe(add_colliders)
))


fn add_colliders(
    trigger: On<SceneInstanceReady>,
    children: Query<&Children>,
    mut commands: Commands,
) {
...
}
```

</details>
