### PR TITLE
Fix 3d gizmo pipeline when atmosphere present

### DIFF
--- a/crates/bevy_gizmos_render/src/pipeline_3d.rs
+++ b/crates/bevy_gizmos_render/src/pipeline_3d.rs
@@ -22,7 +22,7 @@ use bevy_ecs::{
     system::{Commands, Query, Res, ResMut},
 };
 use bevy_image::BevyDefault as _;
-use bevy_pbr::{MeshPipeline, MeshPipelineKey, SetMeshViewBindGroup};
+use bevy_pbr::{ExtractedAtmosphere, MeshPipeline, MeshPipelineKey, SetMeshViewBindGroup};
 use bevy_render::{
     render_asset::{prepare_assets, RenderAssets},
     render_phase::{
@@ -305,6 +305,7 @@ fn queue_line_gizmos_3d(
             Has<MotionVectorPrepass>,
             Has<DeferredPrepass>,
             Has<OrderIndependentTransparencySettings>,
+            Has<ExtractedAtmosphere>,
         ),
     )>,
 ) -> Result<(), BevyError> {
@@ -318,7 +319,7 @@ fn queue_line_gizmos_3d(
         view,
         msaa,
         render_layers,
-        (normal_prepass, depth_prepass, motion_vector_prepass, deferred_prepass, oit),
+        (normal_prepass, depth_prepass, motion_vector_prepass, deferred_prepass, oit, atmosphere),
     ) in &views
     {
         let Some(transparent_phase) = transparent_render_phases.get_mut(&view.retained_view_entity)
@@ -349,6 +350,10 @@ fn queue_line_gizmos_3d(
 
         if oit {
             view_key |= MeshPipelineKey::OIT_ENABLED;
+        }
+
+        if atmosphere {
+            view_key |= MeshPipelineKey::ATMOSPHERE;
         }
 
         for (entity, main_entity, config) in &line_gizmos {


### PR DESCRIPTION
# Objective

- Fixes https://github.com/bevyengine/bevy/issues/21784

## Solution

- Add missing atmosphere pipeline key in the gizmo pipeline.

## Testing

- Ran the 3d gizmo example with local changes to add the atmosphere to the camera and a directional light

---

## Showcase

<img width="1287" height="752" alt="Screenshot 2025-12-18 at 1 15 53 PM" src="https://github.com/user-attachments/assets/746c6801-4d1e-4745-9fcb-3e66d5cf7097" />
