### PR TITLE
Add support for SSR on web

### DIFF
--- a/crates/bevy_pbr/src/ssr/mod.rs
+++ b/crates/bevy_pbr/src/ssr/mod.rs
@@ -552,6 +552,9 @@ impl SpecializedRenderPipeline for ScreenSpaceReflectionsPipeline {
             shader_defs.push("ATMOSPHERE".into());
         }
 
+        #[cfg(not(target_arch = "wasm32"))]
+        shader_defs.push("USE_DEPTH_SAMPLERS".into());
+
         RenderPipelineDescriptor {
             label: Some("SSR pipeline".into()),
             layout,


### PR DESCRIPTION
# Objective

- Implemented WebGPU safe SSR (screen-space reflections) while preserving native behavior
- Fixes #21700 

## Solution

- Kept native SSR unchanged by defining `USE_DEPTH_SAMPLERS` shader def on native
- the pipeline still binds filtered depth samplers and uses `textureSampleLevel` on depth
- added manual depth sampling in `ssr/raymarch.wgsl` via `textureLoad` with clamped bilinear and nearest helpers
- This avoids the validation error previously happening on web (documented in the linked issue above)

## Testing

- Ran the ssr example on native and web using the bevy CLI 
- Ran the atmosphere example on native and web

---

## Showcase

Atmosphere example running (fixed) using deferred rendering + SSR on web browser (chrome)

<img width="1388" height="1140" alt="Screenshot 2025-12-18 at 3 26 21 PM" src="https://github.com/user-attachments/assets/bc9484c1-e3f2-4adf-a740-c0a7c3312a8d" />
