### PR TITLE
Add `Dir2::from_angle`

### DIFF
--- a/crates/bevy_math/src/direction.rs
+++ b/crates/bevy_math/src/direction.rs
@@ -179,6 +179,12 @@ impl Dir2 {
         Self::new_unchecked(Vec2::new(x, y))
     }
 
+    /// Creates a 2D direction containing `[angle.cos(), angle.sin()]`.
+    #[inline]
+    pub fn from_angle(angle: f32) -> Self {
+        Self(Vec2::from_angle(angle))
+    }
+
     /// Returns the inner [`Vec2`]
     pub const fn as_vec2(&self) -> Vec2 {
         self.0


### PR DESCRIPTION
# Objective

- I have found myself writing `Dir2::new_unchecked(Vec2::from_angle(angle))` or `Dir2::new(Vec2::from_angle(angle)).unwrap()` quite frequently. This is pretty cumbersome and should not require calling `.unwrap()` or unchecked functions.

## Solution

- Added `Dir2::from_angle(angle)`

