### PR TITLE
Extra `testbed_ui` font cases

### DIFF
--- a/examples/testbed/ui.rs
+++ b/examples/testbed/ui.rs
@@ -533,6 +533,48 @@ mod text {
                 ),
             ],
         ));
+
+        top += 35.;
+        commands.spawn((
+            Node {
+                left: px(100.),
+                top: px(top),
+                ..Default::default()
+            },
+            Text::new("FiraSans\t"),
+            TextFont {
+                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                font_size: 25.,
+                ..default()
+            },
+            DespawnOnExit(super::Scene::Text),
+            children![
+                (
+                    TextSpan::new("MonaSans\t"),
+                    TextFont {
+                        font: asset_server.load("fonts/MonaSans-VariableFont.ttf"),
+                        font_size: 25.,
+                        ..default()
+                    }
+                ),
+                (
+                    TextSpan::new("EBGaramond\t"),
+                    TextFont {
+                        font: asset_server.load("fonts/EBGaramond12-Regular.otf"),
+                        font_size: 25.,
+                        ..default()
+                    },
+                ),
+                (
+                    TextSpan::new("FiraMono"),
+                    TextFont {
+                        font: asset_server.load("fonts/FiraMono-Medium.ttf"),
+                        font_size: 25.,
+                        ..default()
+                    },
+                ),
+            ],
+        ));
     }
 }
 


### PR DESCRIPTION
# Objective

Modify the `testbed_ui` text scenes so it will catch bugs like #22191

## Solution

Add new cases to `testbed_ui`'s `text` scene displaying multiple text sections with different fonts and weights with spaces and without spaces.

## Showcase

<img width="1924" height="1127" alt="Screenshot 2025-12-19 142112" src="https://github.com/user-attachments/assets/3247c0d7-cfca-45ac-88dd-b8a8a4266dff" />
