### PR TITLE
Adds ability to pause in gizmo examples

### DIFF
--- a/examples/gizmos/2d_gizmos.rs
+++ b/examples/gizmos/2d_gizmos.rs
@@ -26,7 +26,8 @@ fn setup(mut commands: Commands) {
         Hold 'Up' or 'Down' to change the line width of round gizmos\n\
         Press '1' / '2' to toggle the visibility of straight / round gizmos\n\
         Press 'U' / 'I' to cycle through line styles\n\
-        Press 'J' / 'K' to cycle through line joins",
+        Press 'J' / 'K' to cycle through line joins\n\
+        Press 'Spacebar' to toggle pause",
         ),
         Node {
             position_type: PositionType::Absolute,
@@ -125,15 +126,16 @@ fn draw_example_collection(
 fn update_config(
     mut config_store: ResMut<GizmoConfigStore>,
     keyboard: Res<ButtonInput<KeyCode>>,
-    time: Res<Time>,
+    real_time: Res<Time<Real>>,
+    mut virtual_time: ResMut<Time<Virtual>>,
 ) {
     let (config, _) = config_store.config_mut::<DefaultGizmoConfigGroup>();
     if keyboard.pressed(KeyCode::ArrowRight) {
-        config.line.width += 5. * time.delta_secs();
+        config.line.width += 5. * real_time.delta_secs();
         config.line.width = config.line.width.clamp(0., 50.);
     }
     if keyboard.pressed(KeyCode::ArrowLeft) {
-        config.line.width -= 5. * time.delta_secs();
+        config.line.width -= 5. * real_time.delta_secs();
         config.line.width = config.line.width.clamp(0., 50.);
     }
     if keyboard.just_pressed(KeyCode::Digit1) {
@@ -179,11 +181,11 @@ fn update_config(
 
     let (my_config, _) = config_store.config_mut::<MyRoundGizmos>();
     if keyboard.pressed(KeyCode::ArrowUp) {
-        my_config.line.width += 5. * time.delta_secs();
+        my_config.line.width += 5. * real_time.delta_secs();
         my_config.line.width = my_config.line.width.clamp(0., 50.);
     }
     if keyboard.pressed(KeyCode::ArrowDown) {
-        my_config.line.width -= 5. * time.delta_secs();
+        my_config.line.width -= 5. * real_time.delta_secs();
         my_config.line.width = my_config.line.width.clamp(0., 50.);
     }
     if keyboard.just_pressed(KeyCode::Digit2) {
@@ -206,5 +208,12 @@ fn update_config(
             GizmoLineJoint::Round(_) => GizmoLineJoint::None,
             GizmoLineJoint::None => GizmoLineJoint::Bevel,
         };
+    }
+    if keyboard.just_pressed(KeyCode::Space) {
+        if virtual_time.is_paused() {
+            virtual_time.unpause();
+        } else {
+            virtual_time.pause();
+        }
     }
 }

--- a/examples/gizmos/3d_gizmos.rs
+++ b/examples/gizmos/3d_gizmos.rs
@@ -84,7 +84,8 @@ fn setup(
             Press '1' or '2' to toggle the visibility of straight gizmos or round gizmos\n\
             Press 'B' to show all AABB boxes\n\
             Press 'U' or 'I' to cycle through line styles for straight or round gizmos\n\
-            Press 'J' or 'K' to cycle through line joins for straight or round gizmos",
+            Press 'J' or 'K' to cycle through line joins for straight or round gizmos\n\
+            Press 'Spacebar' to toggle pause",
         ),
         Node {
             position_type: PositionType::Absolute,
@@ -206,7 +207,8 @@ fn draw_example_collection(
 fn update_config(
     mut config_store: ResMut<GizmoConfigStore>,
     keyboard: Res<ButtonInput<KeyCode>>,
-    time: Res<Time>,
+    real_time: Res<Time<Real>>,
+    mut virtual_time: ResMut<Time<Virtual>>,
 ) {
     if keyboard.just_pressed(KeyCode::KeyT) {
         for (_, config, _) in config_store.iter_mut() {
@@ -224,11 +226,11 @@ fn update_config(
 
     let (config, _) = config_store.config_mut::<DefaultGizmoConfigGroup>();
     if keyboard.pressed(KeyCode::ArrowRight) {
-        config.line.width += 5. * time.delta_secs();
+        config.line.width += 5. * real_time.delta_secs();
         config.line.width = config.line.width.clamp(0., 50.);
     }
     if keyboard.pressed(KeyCode::ArrowLeft) {
-        config.line.width -= 5. * time.delta_secs();
+        config.line.width -= 5. * real_time.delta_secs();
         config.line.width = config.line.width.clamp(0., 50.);
     }
     if keyboard.just_pressed(KeyCode::Digit1) {
@@ -255,11 +257,11 @@ fn update_config(
 
     let (my_config, _) = config_store.config_mut::<MyRoundGizmos>();
     if keyboard.pressed(KeyCode::ArrowUp) {
-        my_config.line.width += 5. * time.delta_secs();
+        my_config.line.width += 5. * real_time.delta_secs();
         my_config.line.width = my_config.line.width.clamp(0., 50.);
     }
     if keyboard.pressed(KeyCode::ArrowDown) {
-        my_config.line.width -= 5. * time.delta_secs();
+        my_config.line.width -= 5. * real_time.delta_secs();
         my_config.line.width = my_config.line.width.clamp(0., 50.);
     }
     if keyboard.just_pressed(KeyCode::Digit2) {
@@ -288,5 +290,12 @@ fn update_config(
         // AABB gizmos are normally only drawn on entities with a ShowAabbGizmo component
         // We can change this behavior in the configuration of AabbGizmoGroup
         config_store.config_mut::<AabbGizmoConfigGroup>().1.draw_all ^= true;
+    }
+    if keyboard.just_pressed(KeyCode::Space) {
+        if virtual_time.is_paused() {
+            virtual_time.unpause();
+        } else {
+            virtual_time.pause();
+        }
     }
 }


### PR DESCRIPTION
# Objective

- Fixes #22203 

## Solution

- Utilize the virtual clock to pause time! Use the real time clock in config as well, though, since increasing and decreasing line widths scales happens with elapsed time deltas.
- I did not include an indicator for when the scenes are paused / unpaused since it seems there is at least one thing constantly moving in the two scenes unless they are paused. (the 2d example has that constantly rotating oval, and the 3d example has that constantly moving grid gizmo in the air)

## Testing

- Did you test these changes? If so, how?
I ran both the affected examples:
`cargo run --example 3d_gizmos --features=“free_camera”`
`cargo run --example 2d_gizmos`
Pausing works as expected, and increasing/decreasing line widths while paused still works
