### PR TITLE
Clarify inconsistent GltfConvertCoordinates 0.18 behavior

### DIFF
--- a/crates/bevy_gltf/src/loader/mod.rs
+++ b/crates/bevy_gltf/src/loader/mod.rs
@@ -153,15 +153,18 @@ pub struct GltfLoader {
     /// per-load by [`GltfLoaderSettings::convert_coordinates`].
     ///
     /// Setting any of these values to true will result in the relevant entities
-    /// moving in the opposite direction when using the forward direction.
+    /// moving in opposite directions when using the forward direction.
     /// This means that within a scene, different entities in a hierarchy will
     /// move in different global directions when using the forward direction
     /// for that `Entity`.
     ///
-    /// For example, a parent `Entity` with a child that has a `Mesh3d`
-    /// component will move "backwards" when using its forward direction, and the
-    /// `Entity` holding the `Mesh3d` will move in the opposite direction when using
-    /// its forward direction.
+    /// For example, a parent `Entity` A, with a child `Entity` B that has a `Mesh3d`
+    /// component:
+    ///
+    /// - Entity A with a `Transform`
+    ///   - Entity B with a `Transform`, `Mesh3d`, `MeshMaterial3d`
+    ///
+    /// If A's forward moves "North", B's forward moves "South"
     pub default_convert_coordinates: GltfConvertCoordinates,
     /// glTF extension data processors.
     /// These are Bevy-side processors designed to access glTF
@@ -217,15 +220,18 @@ pub struct GltfLoaderSettings {
     /// If `None`, uses the global default set by [`GltfPlugin::convert_coordinates`](crate::GltfPlugin::convert_coordinates).
     ///
     /// Setting any of these values to true will result in the relevant entities
-    /// moving in the opposite direction when using the forward direction.
+    /// moving in opposite directions when using the forward direction.
     /// This means that within a scene, different entities in a hierarchy will
     /// move in different global directions when using the forward direction
     /// for that `Entity`.
     ///
-    /// For example, a parent `Entity` with a child that has a `Mesh3d`
-    /// component will move "backwards" when using its forward direction, and the
-    /// `Entity` holding the `Mesh3d` will move in the opposite direction when using
-    /// its forward direction.
+    /// For example, a parent `Entity` A, with a child `Entity` B that has a `Mesh3d`
+    /// component:
+    ///
+    /// - Entity A with a `Transform`
+    ///   - Entity B with a `Transform`, `Mesh3d`, `MeshMaterial3d`
+    ///
+    /// If A's forward moves "North", B's forward moves "South"
     pub convert_coordinates: Option<GltfConvertCoordinates>,
 }
 


### PR DESCRIPTION
# Objective

When using `GltfConvertCoordinates` as of #20394 , which is 0.18's version, using the flags results in the `forward` vector moving in a different direction for various entities in the hierarchy.

This is confusing, and (in my opinion) a broken behavior since it relies on users only ever moving the scene root or mesh entities `forward`. It is very common that a player's object is not *one mesh*. In fact this is the default case of the default Blender scene. The default cube turns into

- Scene
	- Parent Entity
		- Mesh3d/Material Entity

When using these flags the "Parent Entity"'s forward vector is the one that would be targeted to move the cube, since that is the root of the object. This Entity's forward direction would be in the opposite direction of the forward direction for the mesh, resulting in different entities in the hierarchy moving in different directions with no way to identify which will behave in which way.

## Solution

No fix. Just Documentation. The flag is experimental afaik and changes fall under being experimental.
