### PR TITLE
impl `VisitAssetDependencies` for `bevy_platform::collections::HashMap`

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -222,7 +222,7 @@ use bevy_ecs::{
     schedule::{IntoScheduleConfigs, SystemSet},
     world::FromWorld,
 };
-use bevy_platform::collections::HashSet;
+use bevy_platform::collections::{HashMap, HashSet};
 use bevy_reflect::{FromReflect, GetTypeRegistration, Reflect, TypePath};
 use core::any::TypeId;
 use tracing::error;
@@ -543,6 +543,22 @@ impl<A: Asset> VisitAssetDependencies for HashSet<Handle<A>> {
 impl VisitAssetDependencies for HashSet<UntypedHandle> {
     fn visit_dependencies(&self, visit: &mut impl FnMut(UntypedAssetId)) {
         for dependency in self {
+            visit(dependency.id());
+        }
+    }
+}
+
+impl<K, A: Asset> VisitAssetDependencies for HashMap<K, Handle<A>> {
+    fn visit_dependencies(&self, visit: &mut impl FnMut(UntypedAssetId)) {
+        for dependency in self.values() {
+            visit(dependency.id().untyped());
+        }
+    }
+}
+
+impl<K> VisitAssetDependencies for HashMap<K, UntypedHandle> {
+    fn visit_dependencies(&self, visit: &mut impl FnMut(UntypedAssetId)) {
+        for dependency in self.values() {
             visit(dependency.id());
         }
     }
@@ -2030,6 +2046,10 @@ mod tests {
             set_handles: HashSet<Handle<TestAsset>>,
             #[dependency]
             untyped_set_handles: HashSet<UntypedHandle>,
+            #[dependency]
+            map_handles: HashMap<(), Handle<TestAsset>>,
+            #[dependency]
+            untyped_map_handles: HashMap<(), UntypedHandle>,
         },
         StructStyle(#[dependency] TestAsset),
         Empty,
@@ -2053,6 +2073,10 @@ mod tests {
         set_handles: HashSet<Handle<TestAsset>>,
         #[dependency]
         untyped_set_handles: HashSet<UntypedHandle>,
+        #[dependency]
+        map_handles: HashMap<(), Handle<TestAsset>>,
+        #[dependency]
+        untyped_map_handles: HashMap<(), UntypedHandle>,
     }
 
     #[expect(


### PR DESCRIPTION
# Objective

This PR adopts what's left of #14162, implementing `VisitAssetDependencies` for `HashMap`. This was implemented for `HashSet`'s in #20735.
This accomplishes the ability to mark `Handle<T>`/`UntypedHandle` values of a hashmap as dependencies of a struct deriving `Asset` using `#[dependency]` on the hashmap field.

## Solution

`impl VisitAssetDependencies for HashMap`

## Testing

- Verified to build using `cargo build` at bevy root
- verified to not crash in use on a cherry-pick to 0.17.3 release

I believe there is no need for more testing, given the simplicity of the change and the similarity of the two added `impl` blocks to previous ones.
