### PR TITLE
Add wayland to `flake.nix` linux dependencies example

### DIFF
--- a/docs/linux_dependencies.md
+++ b/docs/linux_dependencies.md
@@ -156,6 +156,7 @@ Add a `flake.nix` file to the root of your GitHub repository containing:
                 xorg.libXi
                 xorg.libXrandr
                 libxkbcommon
+                wayland
               ];
             RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
             LD_LIBRARY_PATH = lib.makeLibraryPath [


### PR DESCRIPTION
# Objective

Fixes #22215

## Solution

- Adds wayland to `flake.nix` example in the Linux dependencies documentation

## Testing

- Did you test these changes? If so, how?
Use the main branch `flake.nix` and run `cargo build` and it gives:
`error: failed to run custom build command for wayland-sys v0.31.7`
With this change it does compile successfully

---
