### PR TITLE
Add command line option to choose a starting scene in the `testbed_*' examples

### DIFF
--- a/examples/testbed/2d.rs
+++ b/examples/testbed/2d.rs
@@ -54,28 +54,15 @@ enum Scene {
 impl std::str::FromStr for Scene {
     type Err = String;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "shapes" => Ok(Scene::Shapes),
-            "bloom" => Ok(Scene::Bloom),
-            "text" => Ok(Scene::Text),
-            "sprite" => Ok(Scene::Sprite),
-            "spriteslicing" => Ok(Scene::SpriteSlicing),
-            "gizmos" => Ok(Scene::Gizmos),
-            _ => Err(format!(
-                "Scene '{}' doesn't exist. Available scenes:\n\t{}",
-                s,
-                [
-                    "Shapes",
-                    "Bloom",
-                    "Text",
-                    "Sprite",
-                    "SpriteSlicing",
-                    "Gizmos"
-                ]
-                .join("\n\t")
-            )),
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        let mut isit = Self::default();
+        while s.to_lowercase() != format!("{isit:?}").to_lowercase() {
+            isit = isit.next();
+            if isit == Self::default() {
+                return Err(format!("Invalid Scene name: {s}"));
+            }
         }
+        Ok(isit)
     }
 }
 

--- a/examples/testbed/3d.rs
+++ b/examples/testbed/3d.rs
@@ -62,28 +62,15 @@ enum Scene {
 impl std::str::FromStr for Scene {
     type Err = String;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "light" => Ok(Scene::Light),
-            "bloom" => Ok(Scene::Bloom),
-            "gltf" => Ok(Scene::Gltf),
-            "animation" => Ok(Scene::Animation),
-            "gizmos" => Ok(Scene::Gizmos),
-            "gltfcoordinateconversion" => Ok(Scene::GltfCoordinateConversion),
-            _ => Err(format!(
-                "Scene '{}' doesn't exist. Available scenes:\n\t{}",
-                s,
-                [
-                    "Light",
-                    "Bloom",
-                    "Gltf",
-                    "Animation",
-                    "Gizmos",
-                    "GltfCoordinateConversion"
-                ]
-                .join("\n\t")
-            )),
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        let mut isit = Self::default();
+        while s.to_lowercase() != format!("{isit:?}").to_lowercase() {
+            isit = isit.next();
+            if isit == Self::default() {
+                return Err(format!("Invalid Scene name: {s}"));
+            }
         }
+        Ok(isit)
     }
 }
 

--- a/examples/testbed/ui.rs
+++ b/examples/testbed/ui.rs
@@ -86,45 +86,14 @@ impl std::str::FromStr for Scene {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "image" => Ok(Scene::Image),
-            "text" => Ok(Scene::Text),
-            "grid" => Ok(Scene::Grid),
-            "borders" => Ok(Scene::Borders),
-            "boxshadow" => Ok(Scene::BoxShadow),
-            "textwrap" => Ok(Scene::TextWrap),
-            "overflow" => Ok(Scene::Overflow),
-            "slice" => Ok(Scene::Slice),
-            "layoutrounding" => Ok(Scene::LayoutRounding),
-            "lineargradient" => Ok(Scene::LinearGradient),
-            "radialgradient" => Ok(Scene::RadialGradient),
-            "transformations" => Ok(Scene::Transformations),
-            #[cfg(feature = "bevy_ui_debug")]
-            "debugoutlines" => Ok(Scene::DebugOutlines),
-            "viewportcoords" => Ok(Scene::ViewportCoords),
-            _ => Err(format!(
-                "Scene '{}' doesn't exist. Available scenes:\n\t{}",
-                s,
-                [
-                    "Image",
-                    "Text",
-                    "Grid",
-                    "Borders",
-                    "BoxShadow",
-                    "TextWrap",
-                    "Overflow",
-                    "Slice",
-                    "LayoutRounding",
-                    "LinearGradient",
-                    "RadialGradient",
-                    "Transformations",
-                    #[cfg(feature = "bevy_ui_debug")]
-                    "DebugOutlines",
-                    "ViewportCoords",
-                ]
-                .join("\n\t")
-            )),
+        let mut isit = Self::default();
+        while s.to_lowercase() != format!("{isit:?}").to_lowercase() {
+            isit = isit.next();
+            if isit == Self::default() {
+                return Err(format!("Invalid Scene name: {s}"));
+            }
         }
+        Ok(isit)
     }
 }
 


### PR DESCRIPTION
# Objective

- Fixes #22218

## Solution

- Use `argh` to check if you passed a scene name, and if you did, start on that one instead of the default

## Testing

- Tested on my local machine, I don't see a reason why it would change between different machines and/or platforms
