### PR TITLE
Add doctest example for QueryState to to direct users to World::try_query for easy QueryState construction

### DIFF
--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -64,7 +64,7 @@ pub(super) union StorageId {
 ///
 /// Note:
 ///
-/// Constructing a [`QueryState`] for query execution can be made straightfoward with the use of [`World::try_query`] or
+/// Constructing a [`QueryState`] for query execution can be made straightforward with the use of [`World::try_query`] or
 /// [`World::try_query_filtered`].
 ///
 /// Example:


### PR DESCRIPTION
# Objective

It's easy for users to stumble across `World::query` or `DeferredWorld::query` but then be somewhat mystified as to how one goes about constructing a `QueryState` without getting into a knife fight with the borrow checker and/or requiring a `&mut World` they may not have.

## Solution

Provide users with a practical example that answers this question in a place in the docs they're likely to end up in regardless of which angle they encounter this problem from.

## Testing
N/A

## Showcase

N/A