### PR TITLE
Make `bevy_audio` optional for `android_shared_stdcxx`

### DIFF
--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -262,7 +262,7 @@ bevy_gltf = ["dep:bevy_gltf", "bevy_scene", "bevy_pbr"]
 dynamic_linking = ["bevy_diagnostic/dynamic_linking"]
 
 # Enable using a shared stdlib for cxx on Android.
-android_shared_stdcxx = ["bevy_audio/android_shared_stdcxx"]
+android_shared_stdcxx = ["bevy_audio?/android_shared_stdcxx"]
 
 # Enable AccessKit on Unix backends (currently only works with experimental
 # screen readers and forks.)


### PR DESCRIPTION
# Objective

- It's a bit unexpected to require `bevy_audio` even when it's not used with `default_platform`, which enables `android_shared_stdcxx`.

## Solution

- Treat this feature similar to `std`. It just enables `android_shared_stdcxx` on `cpal` inside `bevy_audio`.