### PR TITLE
Solari: Disable world cache jitter

### DIFF
--- a/crates/bevy_solari/src/realtime/world_cache_query.wgsl
+++ b/crates/bevy_solari/src/realtime/world_cache_query.wgsl
@@ -51,7 +51,7 @@ fn query_world_cache(world_position_in: vec3<f32>, world_normal: vec3<f32>, view
     var cell_size = get_cell_size(world_position, view_position);
 
     // https://tomclabault.github.io/blog/2025/regir, jitter_world_position_tangent_plane
-#ifndef NO_JITTER_WORLD_CACHE
+#ifdef JITTER_WORLD_CACHE
     let TBN = orthonormalize(world_normal);
     let offset = (rand_vec2f(rng) * 2.0 - 1.0) * cell_size * 0.5;
     world_position += offset.x * TBN[0] + offset.y * TBN[1];


### PR DESCRIPTION
I did a bunch of testing, and after recent rounds of improvements to specular GI, I don't think this is worth it anymore. Turning it off reduces light leaks with thin geometry.