### PR TITLE
Fix Updated images occasionally never displayed on materials by ensuring correct ordering of system sets

### DIFF
--- a/crates/bevy_ecs/src/schedule/auto_insert_apply_deferred.rs
+++ b/crates/bevy_ecs/src/schedule/auto_insert_apply_deferred.rs
@@ -1,6 +1,7 @@
 use alloc::{boxed::Box, collections::BTreeSet, vec::Vec};
 
-use bevy_platform::collections::{HashMap, HashSet};
+use bevy_platform::{collections::HashMap, hash::FixedHasher};
+use indexmap::IndexSet;
 
 use crate::{
     schedule::{graph::Dag, SystemKey, SystemSetKey},
@@ -222,7 +223,7 @@ impl ScheduleBuildPass for AutoInsertApplyDeferredPass {
     fn collapse_set(
         &mut self,
         set: SystemSetKey,
-        systems: &HashSet<SystemKey>,
+        systems: &IndexSet<SystemKey, FixedHasher>,
         dependency_flattening: &DiGraph<NodeId>,
     ) -> impl Iterator<Item = (NodeId, NodeId)> {
         if systems.is_empty() {

--- a/crates/bevy_ecs/src/schedule/pass.rs
+++ b/crates/bevy_ecs/src/schedule/pass.rs
@@ -1,14 +1,18 @@
 use alloc::{boxed::Box, vec::Vec};
-use bevy_platform::collections::HashSet;
-use core::any::{Any, TypeId};
+use core::{
+    any::{Any, TypeId},
+    fmt::Debug,
+};
+
+use bevy_platform::hash::FixedHasher;
+use bevy_utils::TypeIdMap;
+use indexmap::IndexSet;
 
 use super::{DiGraph, NodeId, ScheduleBuildError, ScheduleGraph};
 use crate::{
     schedule::{graph::Dag, SystemKey, SystemSetKey},
     world::World,
 };
-use bevy_utils::TypeIdMap;
-use core::fmt::Debug;
 
 /// A pass for modular modification of the dependency graph.
 pub trait ScheduleBuildPass: Send + Sync + Debug + 'static {
@@ -24,7 +28,7 @@ pub trait ScheduleBuildPass: Send + Sync + Debug + 'static {
     fn collapse_set(
         &mut self,
         set: SystemSetKey,
-        systems: &HashSet<SystemKey>,
+        systems: &IndexSet<SystemKey, FixedHasher>,
         dependency_flattening: &DiGraph<NodeId>,
     ) -> impl Iterator<Item = (NodeId, NodeId)>;
 
@@ -49,7 +53,7 @@ pub(super) trait ScheduleBuildPassObj: Send + Sync + Debug {
     fn collapse_set(
         &mut self,
         set: SystemSetKey,
-        systems: &HashSet<SystemKey>,
+        systems: &IndexSet<SystemKey, FixedHasher>,
         dependency_flattening: &DiGraph<NodeId>,
         dependencies_to_add: &mut Vec<(NodeId, NodeId)>,
     );
@@ -68,7 +72,7 @@ impl<T: ScheduleBuildPass> ScheduleBuildPassObj for T {
     fn collapse_set(
         &mut self,
         set: SystemSetKey,
-        systems: &HashSet<SystemKey>,
+        systems: &IndexSet<SystemKey, FixedHasher>,
         dependency_flattening: &DiGraph<NodeId>,
         dependencies_to_add: &mut Vec<(NodeId, NodeId)>,
     ) {

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -20,7 +20,7 @@ use core::{
     fmt::{Debug, Write},
 };
 use fixedbitset::FixedBitSet;
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 use log::{info, warn};
 use pass::ScheduleBuildPassObj;
 use thiserror::Error;
@@ -924,7 +924,7 @@ impl ScheduleGraph {
     pub fn systems_in_set(
         &self,
         system_set: InternedSystemSet,
-    ) -> Result<&HashSet<SystemKey>, ScheduleError> {
+    ) -> Result<&IndexSet<SystemKey, FixedHasher>, ScheduleError> {
         if self.changed {
             return Err(ScheduleError::Uninitialized);
         }
@@ -1018,7 +1018,7 @@ impl ScheduleGraph {
         }
     }
 
-    fn remove_systems_by_keys(&mut self, keys: &HashSet<SystemKey>) {
+    fn remove_systems_by_keys(&mut self, keys: &IndexSet<SystemKey, FixedHasher>) {
         for &key in keys {
             self.systems.remove(key);
 
@@ -2604,7 +2604,10 @@ mod tests {
             fn collapse_set(
                 &mut self,
                 _set: crate::schedule::SystemSetKey,
-                _systems: &bevy_platform::collections::HashSet<crate::schedule::SystemKey>,
+                _systems: &indexmap::IndexSet<
+                    crate::schedule::SystemKey,
+                    bevy_platform::hash::FixedHasher,
+                >,
                 _dependency_flattening: &crate::schedule::graph::DiGraph<crate::schedule::NodeId>,
             ) -> impl Iterator<Item = (crate::schedule::NodeId, crate::schedule::NodeId)>
             {


### PR DESCRIPTION
# Objective

- Fixes #22212

## Solution

Replace `HashSet` usage with `IndexSet` in `DagGroups` to maintain insertion order like the previous `Vec` implementation.

## Testing

Used the provided example in the bug report. Should we add it as a test or example somewhere?