### PR TITLE
fix decal index selection in light textures

### DIFF
--- a/crates/bevy_pbr/src/render/pbr_lighting.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_lighting.wgsl
@@ -711,7 +711,7 @@ fn point_light(
         let relative_position = (view_bindings::clustered_decals.decals[(*light).decal_index].local_from_world * vec4(P, 1.0)).xyz;
         let cubemap_type = view_bindings::clustered_decals.decals[(*light).decal_index].tag;
         let decal_uv = cubemap_uv(relative_position, cubemap_type);
-        let image_index = view_bindings::clustered_decals.decals[(*light).decal_index].image_index;
+        let image_index = view_bindings::clustered_decals.decals[(*light).decal_index].base_color_texture_index;
 
         texture_sample = textureSampleLevel(
             view_bindings::clustered_decal_textures[image_index],
@@ -759,7 +759,7 @@ fn spot_light(
             vec4((*input).P, 1.0)).xyz;
         if local_position.z < 0.0 {
             let decal_uv = (local_position.xy / (local_position.z * (*light).spot_light_tan_angle)) * vec2(-0.5, 0.5) + 0.5;
-            let image_index = view_bindings::clustered_decals.decals[(*light).decal_index].image_index;
+            let image_index = view_bindings::clustered_decals.decals[(*light).decal_index].base_color_texture_index;
 
             texture_sample = textureSampleLevel(
                 view_bindings::clustered_decal_textures[image_index],
@@ -840,7 +840,7 @@ fn directional_light(
         if (view_bindings::clustered_decals.decals[(*light).decal_index].tag != 0u)
                 || all(clamp(decal_uv, vec2(0.0), vec2(1.0)) == decal_uv)
         {
-            let image_index = view_bindings::clustered_decals.decals[(*light).decal_index].image_index;
+            let image_index = view_bindings::clustered_decals.decals[(*light).decal_index].base_color_texture_index;
 
             texture_sample = textureSampleLevel(
                 view_bindings::clustered_decal_textures[image_index],


### PR DESCRIPTION
# Objective

https://github.com/bevyengine/bevy/pull/22039 changed how many images are associated with a decal. light textures use decal base textures, ignoring the others.

fixes #22266 

## Solution

use base color texture index

## Testing

```
cargo run --example light_textures --features="pbr_light_textures"
```

## Showcase

### before

<img width="2734" height="1040" alt="screenshot-2025-12-25-at-08 53 17@2x" src="https://github.com/user-attachments/assets/77c26920-e7e2-4c96-8a94-275dfbaf759e" />


### after

<img width="2734" height="1040" alt="screenshot-2025-12-25-at-08 57 26@2x" src="https://github.com/user-attachments/assets/cb9d9fce-4f7f-4ccf-8da3-560057d2fd2e" />
