### PR TITLE
Self-referential relationships

### DIFF
--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -529,7 +529,7 @@ struct Require {
 
 struct Relationship {
     relationship_target: Type,
-    allow_self: bool,
+    allow_self_referential: bool,
 }
 
 struct RelationshipTarget {
@@ -736,19 +736,19 @@ mod kw {
     syn::custom_keyword!(relationship_target);
     syn::custom_keyword!(relationship);
     syn::custom_keyword!(linked_spawn);
-    syn::custom_keyword!(allow_self);
+    syn::custom_keyword!(allow_self_referential);
 }
 
 impl Parse for Relationship {
     fn parse(input: syn::parse::ParseStream) -> Result<Self> {
         let mut relationship_target: Option<Type> = None;
-        let mut allow_self: bool = false;
+        let mut allow_self_referential: bool = false;
 
         while !input.is_empty() {
             let lookahead = input.lookahead1();
-            if lookahead.peek(kw::allow_self) {
-                input.parse::<kw::allow_self>()?;
-                allow_self = true;
+            if lookahead.peek(kw::allow_self_referential) {
+                input.parse::<kw::allow_self_referential>()?;
+                allow_self_referential = true;
             } else if lookahead.peek(kw::relationship_target) {
                 input.parse::<kw::relationship_target>()?;
                 input.parse::<Token![=]>()?;
@@ -764,7 +764,7 @@ impl Parse for Relationship {
             relationship_target: relationship_target.ok_or_else(|| {
                 syn::Error::new(input.span(), "Missing `relationship_target = X` attribute")
             })?,
-            allow_self,
+            allow_self_referential,
         })
     }
 }
@@ -829,12 +829,12 @@ fn derive_relationship(
     let (impl_generics, type_generics, where_clause) = &ast.generics.split_for_impl();
 
     let relationship_target = &relationship.relationship_target;
-    let allow_self = relationship.allow_self;
+    let allow_self_referential = relationship.allow_self_referential;
 
     Ok(Some(quote! {
         impl #impl_generics #bevy_ecs_path::relationship::Relationship for #struct_name #type_generics #where_clause {
             type RelationshipTarget = #relationship_target;
-            const ALLOW_SELF: bool = #allow_self;
+            const ALLOW_SELF_REFERENTIAL: bool = #allow_self_referential;
 
             #[inline(always)]
             fn get(&self) -> #bevy_ecs_path::entity::Entity {

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -636,12 +636,12 @@ pub fn derive_resource(input: TokenStream) -> TokenStream {
 /// Allow relationships to point to their own entity:
 /// ```ignore
 /// #[derive(Component)]
-/// #[relationship(relationship_target = PeopleILike, allow_self)]
+/// #[relationship(relationship_target = PeopleILike, allow_self_referential)]
 /// pub struct LikedBy(pub Entity);
 /// ```
 /// ## Warning
 ///
-/// When `allow_self` is enabled, be careful when using recursive traversal methods
+/// When `allow_self_referential` is enabled, be careful when using recursive traversal methods
 /// like `iter_ancestors` or `root_ancestor`, as they will loop infinitely if an entity points to itself.
 ///
 /// ## Hooks

--- a/crates/bevy_ecs/src/relationship/mod.rs
+++ b/crates/bevy_ecs/src/relationship/mod.rs
@@ -77,13 +77,13 @@ use log::warn;
 /// ```
 ///
 /// By default, relationships cannot point to their own entity. If you want to allow self-referential
-/// relationships, you can use the `allow_self` attribute:
+/// relationships, you can use the `allow_self_referential` attribute:
 ///
 /// ```
 /// # use bevy_ecs::component::Component;
 /// # use bevy_ecs::entity::Entity;
 /// #[derive(Component)]
-/// #[relationship(relationship_target = PeopleILike, allow_self)]
+/// #[relationship(relationship_target = PeopleILike, allow_self_referential)]
 /// pub struct LikedBy(pub Entity);
 ///
 /// #[derive(Component)]
@@ -106,7 +106,7 @@ pub trait Relationship: Component + Sized {
     /// When `ALLOW_SELF` is `true`, be careful when using recursive traversal methods
     /// like `iter_ancestors` or `root_ancestor`, as they will loop infinitely if an entity
     /// points to itself.
-    const ALLOW_SELF: bool = false;
+    const ALLOW_SELF_REFERENTIAL: bool = false;
 
     /// Gets the [`Entity`] ID of the related entity.
     fn get(&self) -> Entity;
@@ -148,9 +148,9 @@ pub trait Relationship: Component + Sized {
             }
         }
         let target_entity = world.entity(entity).get::<Self>().unwrap().get();
-        if !Self::ALLOW_SELF && target_entity == entity {
+        if !Self::ALLOW_SELF_REFERENTIAL && target_entity == entity {
             warn!(
-                "{}The {}({target_entity:?}) relationship on entity {entity:?} points to itself. The invalid {} relationship has been removed.\nIf this is intended behavior self-referential relations can be enabled with the allow_self attribute: #[relationship(allow_self)]",
+                "{}The {}({target_entity:?}) relationship on entity {entity:?} points to itself. The invalid {} relationship has been removed.\nIf this is intended behavior self-referential relations can be enabled with the allow_self_referential attribute: #[relationship(allow_self_referential)]",
                 caller.map(|location|format!("{location}: ")).unwrap_or_default(),
                 DebugName::type_name::<Self>(),
                 DebugName::type_name::<Self>()
@@ -618,9 +618,9 @@ mod tests {
     }
 
     #[test]
-    fn self_relationship_succeeds_with_allow_self() {
+    fn self_relationship_succeeds_with_allow_self_referential() {
         #[derive(Component)]
-        #[relationship(relationship_target = RelTarget, allow_self)]
+        #[relationship(relationship_target = RelTarget, allow_self_referential)]
         struct Rel(Entity);
 
         #[derive(Component)]
@@ -637,9 +637,9 @@ mod tests {
     }
 
     #[test]
-    fn self_relationship_removal_with_allow_self() {
+    fn self_relationship_removal_with_allow_self_referential() {
         #[derive(Component)]
-        #[relationship(relationship_target = RelTarget, allow_self)]
+        #[relationship(relationship_target = RelTarget, allow_self_referential)]
         struct Rel(Entity);
 
         #[derive(Component)]

--- a/release-content/release-notes/allow_self_relationships.md
+++ b/release-content/release-notes/allow_self_relationships.md
@@ -4,17 +4,17 @@ authors: ["@mrchantey"]
 pull_requests: [22269]
 ---
 
-Relationships can now optionally point to their own entity by setting the `allow_self` attribute on the `#[relationship]` macro.
+Relationships can now optionally point to their own entity by setting the `allow_self_referential` attribute on the `#[relationship]` macro.
 
 By default pointing a relationship to its own entity will log a warning and remove the component. However, self-referential relationships are semantically valid in many cases: `Likes(self)`, `EmployedBy(self)`, `TalkingTo(self)`, `Healing(self)`, and many more.
 
 ## Usage
 
-To allow a relationship to point to its own entity, add the `allow_self` attribute:
+To allow a relationship to point to its own entity, add the `allow_self_referential` attribute:
 
 ```rust
 #[derive(Component)]
-#[relationship(relationship_target = PeopleILike, allow_self)]
+#[relationship(relationship_target = PeopleILike, allow_self_referential)]
 pub struct LikedBy(pub Entity);
 
 #[derive(Component)]


### PR DESCRIPTION
# Objective

Closes #18522

This pr allows entities to have, erm, self-relations..

By default pointing a relationship to its own entity will log a warning and remove the component. However, self-referential relationships are semantically valid in many cases: `Likes(self)`, `EmployedBy(self)`, `TalkingTo(self)`, `Healing(self)`.


## Solution

- Added `const ALLOW_SELF:bool = false` to the `Relationship` trait, 
- Updated section that disallows self-relations to check for this
- Added the `allow_self` flag to the macro

```rust
#[derive(Component)]
#[relationship(relationship_target = PeopleILike, allow_self)]
pub struct LikedBy(pub Entity);

#[derive(Component)]
#[relationship_target(relationship = LikedBy)]
pub struct PeopleILike(Vec<Entity>);

let entity = world.spawn_empty().id();
world.entity_mut(entity).insert(LikedBy(entity));

// The relationship is preserved
assert!(world.entity(entity).contains::<LikedBy>());
assert!(world.entity(entity).contains::<PeopleILike>());
```

## Testing

- added insert/remove tests

---

## Showcase


Relationships can now optionally point to their own entity by setting `#[relationship(allow_self)]`.

By default pointing a relationship to its own entity will log a warning and remove the component. However, self-referential relationships are semantically valid in many cases: `Likes(self)`, `EmployedBy(self)`, `TalkingTo(self)`, `Healing(self)`, and many more.


<details>
  <summary>Click to view usage</summary>

To allow a relationship to point to its own entity, add the `allow_self` attribute:

```rust
#[derive(Component)]
#[relationship(relationship_target = PeopleILike, allow_self)]
pub struct LikedBy(pub Entity);

#[derive(Component)]
#[relationship_target(relationship = LikedBy)]
pub struct PeopleILike(Vec<Entity>);
```

Now entities can have relationships that point to themselves:

```rust
let entity = world.spawn_empty().id();
world.entity_mut(entity).insert(LikedBy(entity));

// The relationship is preserved
assert!(world.entity(entity).contains::<LikedBy>());
assert!(world.entity(entity).contains::<PeopleILike>());
```

</details>