### PR TITLE
Auto navigation camera fix

### DIFF
--- a/crates/bevy_input_focus/src/directional_navigation.rs
+++ b/crates/bevy_input_focus/src/directional_navigation.rs
@@ -777,7 +777,7 @@ fn auto_rebuild_ui_navigation_graph(
 
         let (_scale, _rotation, translation) = transform.to_scale_angle_translation();
 
-        let camera_nodes = auto_nodes.entry(target_camera).or_insert(Vec::new());
+        let camera_nodes = auto_nodes.entry(target_camera).or_default();
 
         camera_nodes.push(FocusableArea {
             entity,
@@ -787,7 +787,7 @@ fn auto_rebuild_ui_navigation_graph(
     }
 
     for nodes in auto_nodes.values() {
-        auto_generate_navigation_edges(&mut directional_nav_map, &nodes, &config);
+        auto_generate_navigation_edges(&mut directional_nav_map, nodes, &config);
     }
 }
 


### PR DESCRIPTION
# Objective

Auto directional navigation ignores camera targets. Nodes that are rendered to different windows should not be added to the same navigation graph as though there is only a single window.

Fixes #22282

## Solution

Collect the `AutoDirectionalNavigation` nodes into separate lists for each camera, then call `auto_generate_navigation_edges` for each list.