### PR TITLE
Add MeshPass v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -722,6 +722,7 @@ bevy_image = { path = "crates/bevy_image", version = "0.18.0-dev", default-featu
 bevy_reflect = { path = "crates/bevy_reflect", version = "0.18.0-dev", default-features = false }
 bevy_render = { path = "crates/bevy_render", version = "0.18.0-dev", default-features = false }
 bevy_state = { path = "crates/bevy_state", version = "0.18.0-dev", default-features = false }
+bevy_pbr = { path = "crates/bevy_pbr", version = "0.18.0-dev", default-features = false }
 # Needed to poll Task examples
 futures-lite = "2.0.1"
 futures-timer = { version = "3", features = ["wasm-bindgen", "gloo-timers"] }
@@ -4956,4 +4957,15 @@ doc-scrape-examples = true
 name = "Mirror"
 description = "Demonstrates how to create a mirror with a second camera"
 category = "3D Rendering"
+wasm = true
+
+[[example]]
+name = "custom_mesh_pass"
+path = "examples/shader_advanced/custom_mesh_pass.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.custom_mesh_pass]
+name = "Custom Mesh Pass"
+description = "Demonstrates how to write a custom mesh pass"
+category = "Shaders"
 wasm = true

--- a/assets/shaders/custom_mesh_pass_material.wgsl
+++ b/assets/shaders/custom_mesh_pass_material.wgsl
@@ -1,0 +1,59 @@
+#import bevy_pbr::{
+    pbr_bindings,
+    pbr_types,
+    mesh_functions,
+    mesh_view_bindings,
+    view_transformations,
+}
+
+@group(#{MATERIAL_BIND_GROUP}) @binding(100) var<uniform> outline_color: vec4<f32>;
+
+const OUTLINE_WIDTH = 0.1;
+
+struct Vertex {
+    @builtin(instance_index) instance_index: u32,
+    @location(0) position: vec3<f32>,
+    @location(1) normal: vec3<f32>,
+};
+
+struct VertexOutput {
+    @builtin(position) clip_position: vec4<f32>,
+    @location(0) world_position: vec4<f32>,
+    @location(1) world_normal: vec3<f32>,
+};
+
+@vertex
+fn vertex(vertex: Vertex) -> VertexOutput {
+    var out: VertexOutput;
+
+    // This only works when the mesh is at the origin.
+    let expanded_position = vertex.position * (1 + OUTLINE_WIDTH);
+
+    var world_from_local = mesh_functions::get_world_from_local(vertex.instance_index);
+    out.world_position = mesh_functions::mesh_position_local_to_world(world_from_local, vec4<f32>(expanded_position, 1.0));
+    out.clip_position = view_transformations::position_world_to_clip(out.world_position.xyz);
+
+    out.world_normal = mesh_functions::mesh_normal_local_to_world(vertex.normal, vertex.instance_index);
+
+    return out;
+}
+
+fn fresnel(normal: vec3<f32>, view: vec3<f32>, power: f32) -> f32 {
+    return pow(1.0 - clamp(dot(normalize(normal), normalize(view)), 0.0, 1.0), power);
+}
+
+@fragment
+fn fragment(input: VertexOutput) -> @location(0) vec4<f32> {
+    let flags = pbr_bindings::material.flags;
+    let alpha_mode = flags & pbr_types::STANDARD_MATERIAL_FLAGS_ALPHA_MODE_RESERVED_BITS;
+    var color = outline_color;
+
+    if alpha_mode != pbr_types::STANDARD_MATERIAL_FLAGS_ALPHA_MODE_OPAQUE {
+        let V = normalize(mesh_view_bindings::view.world_position.xyz - input.world_position.xyz);
+        let N = normalize(input.world_normal);
+
+        color *= fresnel(N, V, 3.0);
+    }
+
+    return color;
+}

--- a/crates/bevy_core_pipeline/src/core_2d/main_transparent_pass_2d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/main_transparent_pass_2d_node.rs
@@ -4,10 +4,10 @@ use bevy_render::{
     camera::ExtractedCamera,
     diagnostic::RecordDiagnostics,
     render_graph::{NodeRunError, RenderGraphContext, ViewNode},
-    render_phase::{TrackedRenderPass, ViewSortedRenderPhases},
+    render_phase::{SortedRenderPhase, TrackedRenderPass},
     render_resource::{CommandEncoderDescriptor, RenderPassDescriptor, StoreOp},
     renderer::RenderContext,
-    view::{ExtractedView, ViewDepthTexture, ViewTarget},
+    view::{ViewDepthTexture, ViewTarget},
 };
 use tracing::error;
 #[cfg(feature = "trace")]
@@ -19,28 +19,23 @@ pub struct MainTransparentPass2dNode {}
 impl ViewNode for MainTransparentPass2dNode {
     type ViewQuery = (
         &'static ExtractedCamera,
-        &'static ExtractedView,
         &'static ViewTarget,
         &'static ViewDepthTexture,
+        &'static SortedRenderPhase<Transparent2d>,
     );
 
     fn run<'w>(
         &self,
         graph: &mut RenderGraphContext,
         render_context: &mut RenderContext<'w>,
-        (camera, view, target, depth): bevy_ecs::query::QueryItem<'w, '_, Self::ViewQuery>,
+        (camera, target, depth, transparent_phase): bevy_ecs::query::QueryItem<
+            'w,
+            '_,
+            Self::ViewQuery,
+        >,
         world: &'w World,
     ) -> Result<(), NodeRunError> {
-        let Some(transparent_phases) =
-            world.get_resource::<ViewSortedRenderPhases<Transparent2d>>()
-        else {
-            return Ok(());
-        };
-
         let view_entity = graph.view_entity();
-        let Some(transparent_phase) = transparent_phases.get(&view.retained_view_entity) else {
-            return Ok(());
-        };
 
         let diagnostics = render_context.diagnostic_recorder();
 

--- a/crates/bevy_core_pipeline/src/prepass/mod.rs
+++ b/crates/bevy_core_pipeline/src/prepass/mod.rs
@@ -34,6 +34,7 @@ use bevy_asset::UntypedAssetId;
 use bevy_ecs::prelude::*;
 use bevy_math::Mat4;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
+use bevy_render::extract_component::ExtractComponent;
 use bevy_render::mesh::allocator::SlabId;
 use bevy_render::render_phase::PhaseItemBatchSetKey;
 use bevy_render::sync_world::MainEntity;
@@ -53,13 +54,13 @@ pub const NORMAL_PREPASS_FORMAT: TextureFormat = TextureFormat::Rgb10a2Unorm;
 pub const MOTION_VECTOR_PREPASS_FORMAT: TextureFormat = TextureFormat::Rg16Float;
 
 /// If added to a [`bevy_camera::Camera3d`] then depth values will be copied to a separate texture available to the main pass.
-#[derive(Component, Default, Reflect, Clone)]
+#[derive(Component, Default, Reflect, Clone, ExtractComponent)]
 #[reflect(Component, Default, Clone)]
 pub struct DepthPrepass;
 
 /// If added to a [`bevy_camera::Camera3d`] then vertex world normals will be copied to a separate texture available to the main pass.
 /// Normals will have normal map textures already applied.
-#[derive(Component, Default, Reflect, Clone)]
+#[derive(Component, Default, Reflect, Clone, ExtractComponent)]
 #[reflect(Component, Default, Clone)]
 pub struct NormalPrepass;
 
@@ -67,13 +68,13 @@ pub struct NormalPrepass;
 ///
 /// Motion vectors are stored in the range -1,1, with +x right and +y down.
 /// A value of (1.0,1.0) indicates a pixel moved from the top left corner to the bottom right corner of the screen.
-#[derive(Component, Default, Reflect, Clone)]
+#[derive(Component, Default, Reflect, Clone, ExtractComponent)]
 #[reflect(Component, Default, Clone)]
 pub struct MotionVectorPrepass;
 
 /// If added to a [`bevy_camera::Camera3d`] then deferred materials will be rendered to the deferred gbuffer texture and will be available to subsequent passes.
 /// Note the default deferred lighting plugin also requires `DepthPrepass` to work correctly.
-#[derive(Component, Default, Reflect)]
+#[derive(Component, Default, Reflect, Clone, ExtractComponent)]
 #[reflect(Component, Default)]
 pub struct DeferredPrepass;
 

--- a/crates/bevy_gizmos_render/src/pipeline_2d.rs
+++ b/crates/bevy_gizmos_render/src/pipeline_2d.rs
@@ -20,8 +20,7 @@ use bevy_math::FloatOrd;
 use bevy_render::{
     render_asset::{prepare_assets, RenderAssets},
     render_phase::{
-        AddRenderCommand, DrawFunctions, PhaseItemExtraIndex, SetItemPipeline,
-        ViewSortedRenderPhases,
+        AddRenderCommand, DrawFunctions, PhaseItemExtraIndex, SetItemPipeline, SortedRenderPhase,
     },
     render_resource::*,
     view::{ExtractedView, Msaa, ViewTarget},
@@ -294,8 +293,12 @@ fn queue_line_gizmos_2d(
     pipeline_cache: Res<PipelineCache>,
     line_gizmos: Query<(Entity, &MainEntity, &GizmoMeshConfig)>,
     line_gizmo_assets: Res<RenderAssets<GpuLineGizmo>>,
-    mut transparent_render_phases: ResMut<ViewSortedRenderPhases<Transparent2d>>,
-    mut views: Query<(&ExtractedView, &Msaa, Option<&RenderLayers>)>,
+    mut views: Query<(
+        &ExtractedView,
+        &Msaa,
+        Option<&RenderLayers>,
+        &mut SortedRenderPhase<Transparent2d>,
+    )>,
 ) {
     let draw_function = draw_functions.read().get_id::<DrawLineGizmo2d>().unwrap();
     let draw_function_strip = draw_functions
@@ -303,12 +306,7 @@ fn queue_line_gizmos_2d(
         .get_id::<DrawLineGizmo2dStrip>()
         .unwrap();
 
-    for (view, msaa, render_layers) in &mut views {
-        let Some(transparent_phase) = transparent_render_phases.get_mut(&view.retained_view_entity)
-        else {
-            continue;
-        };
-
+    for (view, msaa, render_layers, mut transparent_phase) in views.iter_mut() {
         let mesh_key = Mesh2dPipelineKey::from_msaa_samples(msaa.samples())
             | Mesh2dPipelineKey::from_hdr(view.hdr);
 
@@ -375,20 +373,19 @@ fn queue_line_joint_gizmos_2d(
     pipeline_cache: Res<PipelineCache>,
     line_gizmos: Query<(Entity, &MainEntity, &GizmoMeshConfig)>,
     line_gizmo_assets: Res<RenderAssets<GpuLineGizmo>>,
-    mut transparent_render_phases: ResMut<ViewSortedRenderPhases<Transparent2d>>,
-    mut views: Query<(&ExtractedView, &Msaa, Option<&RenderLayers>)>,
+    mut views: Query<(
+        &ExtractedView,
+        &Msaa,
+        Option<&RenderLayers>,
+        &mut SortedRenderPhase<Transparent2d>,
+    )>,
 ) {
     let draw_function = draw_functions
         .read()
         .get_id::<DrawLineJointGizmo2d>()
         .unwrap();
 
-    for (view, msaa, render_layers) in &mut views {
-        let Some(transparent_phase) = transparent_render_phases.get_mut(&view.retained_view_entity)
-        else {
-            continue;
-        };
-
+    for (view, msaa, render_layers, mut transparent_phase) in views.iter_mut() {
         let mesh_key = Mesh2dPipelineKey::from_msaa_samples(msaa.samples())
             | Mesh2dPipelineKey::from_hdr(view.hdr);
 

--- a/crates/bevy_gizmos_render/src/pipeline_3d.rs
+++ b/crates/bevy_gizmos_render/src/pipeline_3d.rs
@@ -26,8 +26,7 @@ use bevy_pbr::{MeshPipeline, MeshPipelineKey, SetMeshViewBindGroup};
 use bevy_render::{
     render_asset::{prepare_assets, RenderAssets},
     render_phase::{
-        AddRenderCommand, DrawFunctions, PhaseItemExtraIndex, SetItemPipeline,
-        ViewSortedRenderPhases,
+        AddRenderCommand, DrawFunctions, PhaseItemExtraIndex, SetItemPipeline, SortedRenderPhase,
     },
     render_resource::*,
     view::{ExtractedView, Msaa, ViewTarget},
@@ -294,10 +293,10 @@ fn queue_line_gizmos_3d(
     pipeline_cache: Res<PipelineCache>,
     line_gizmos: Query<(Entity, &MainEntity, &GizmoMeshConfig)>,
     line_gizmo_assets: Res<RenderAssets<GpuLineGizmo>>,
-    mut transparent_render_phases: ResMut<ViewSortedRenderPhases<Transparent3d>>,
-    views: Query<(
+    mut views: Query<(
         &ExtractedView,
         &Msaa,
+        &mut SortedRenderPhase<Transparent3d>,
         Option<&RenderLayers>,
         (
             Has<NormalPrepass>,
@@ -317,15 +316,11 @@ fn queue_line_gizmos_3d(
     for (
         view,
         msaa,
+        mut transparent_phase,
         render_layers,
         (normal_prepass, depth_prepass, motion_vector_prepass, deferred_prepass, oit),
-    ) in &views
+    ) in &mut views
     {
-        let Some(transparent_phase) = transparent_render_phases.get_mut(&view.retained_view_entity)
-        else {
-            continue;
-        };
-
         let render_layers = render_layers.unwrap_or_default();
 
         let mut view_key = MeshPipelineKey::from_msaa_samples(msaa.samples())
@@ -414,10 +409,10 @@ fn queue_line_joint_gizmos_3d(
     pipeline_cache: Res<PipelineCache>,
     line_gizmos: Query<(Entity, &MainEntity, &GizmoMeshConfig)>,
     line_gizmo_assets: Res<RenderAssets<GpuLineGizmo>>,
-    mut transparent_render_phases: ResMut<ViewSortedRenderPhases<Transparent3d>>,
-    views: Query<(
+    mut views: Query<(
         &ExtractedView,
         &Msaa,
+        &mut SortedRenderPhase<Transparent3d>,
         Option<&RenderLayers>,
         (
             Has<NormalPrepass>,
@@ -435,15 +430,11 @@ fn queue_line_joint_gizmos_3d(
     for (
         view,
         msaa,
+        mut transparent_phase,
         render_layers,
         (normal_prepass, depth_prepass, motion_vector_prepass, deferred_prepass),
-    ) in &views
+    ) in &mut views
     {
-        let Some(transparent_phase) = transparent_render_phases.get_mut(&view.retained_view_entity)
-        else {
-            continue;
-        };
-
         let render_layers = render_layers.unwrap_or_default();
 
         let mut view_key = MeshPipelineKey::from_msaa_samples(msaa.samples())

--- a/crates/bevy_mesh/src/lib.rs
+++ b/crates/bevy_mesh/src/lib.rs
@@ -42,7 +42,7 @@ bitflags! {
     /// downward. The PBR mesh pipeline key bits start from the lowest bit and
     /// go upward. This allows the PBR bits in the downstream crate `bevy_pbr`
     /// to coexist in the same field without any shifts.
-    #[derive(Clone, Debug)]
+    #[derive(Copy, Clone, Debug)]
     pub struct BaseMeshPipelineKey: u64 {
         const MORPH_TARGETS = 1 << (u64::BITS - 1);
     }

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -60,12 +60,14 @@ bevy_utils = { path = "../bevy_utils", version = "0.18.0-dev" }
 bevy_platform = { path = "../bevy_platform", version = "0.18.0-dev", default-features = false, features = [
   "std",
 ] }
+bevy_pbr_macros = { path = "macros", version = "0.18.0-dev" }
 
 # other
 bitflags = { version = "2.3", features = ["bytemuck"] }
 fixedbitset = "0.5"
 thiserror = { version = "2", default-features = false }
 derive_more = { version = "2", default-features = false, features = ["from"] }
+variadics_please = "1.1"
 # meshlet
 lz4_flex = { version = "0.12", default-features = false, features = [
   "frame",

--- a/crates/bevy_pbr/macros/Cargo.toml
+++ b/crates/bevy_pbr/macros/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "bevy_pbr_macros"
+version = "0.18.0-dev"
+edition = "2024"
+description = "Derive implementations for bevy_pbr"
+homepage = "https://bevy.org"
+repository = "https://github.com/bevyengine/bevy"
+license = "MIT OR Apache-2.0"
+keywords = ["bevy"]
+
+[lib]
+proc-macro = true
+
+[dependencies]
+bevy_macro_utils = { path = "../../bevy_macro_utils", version = "0.18.0-dev" }
+
+syn = { version = "2.0", features = ["full"] }
+proc-macro2 = "1.0"
+quote = "1.0"
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+rustdoc-args = ["-Zunstable-options", "--generate-link-to-definition"]
+all-features = true

--- a/crates/bevy_pbr/macros/LICENSE-APACHE
+++ b/crates/bevy_pbr/macros/LICENSE-APACHE
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/crates/bevy_pbr/macros/LICENSE-MIT
+++ b/crates/bevy_pbr/macros/LICENSE-MIT
@@ -1,0 +1,19 @@
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/bevy_pbr/macros/src/lib.rs
+++ b/crates/bevy_pbr/macros/src/lib.rs
@@ -1,0 +1,538 @@
+#![expect(missing_docs, reason = "Not all docs are written yet, see #3492.")]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+use core::ops::Not;
+
+use bevy_macro_utils::BevyManifest;
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, Data, DeriveInput, Field, Index, Member};
+
+const BINNED: &str = "BinnedPhaseItem";
+const SORTED: &str = "SortedPhaseItem";
+
+const PHASE_ITEM_ATTR: &str = "phase_item";
+const SKIP_ATTR: &str = "skip";
+
+const PHASE_ITEM_TRAITS: [&str; 7] = [
+    "PhaseItem",                     // 0
+    "BinnedPhaseItem",               // 1
+    "SortedPhaseItem",               // 2
+    "CachedRenderPipelinePhaseItem", // 3
+    "QueueBinnedPhaseItem",          // 4
+    "QueueSortedPhaseItem",          // 5
+    "PhaseItemExt",                  // 6
+];
+
+const BINNED_BLACKLIST: [usize; 1] = [1];
+const SORTED_BLACKLIST: [usize; 1] = [5];
+
+pub(crate) fn bevy_render_path() -> syn::Path {
+    BevyManifest::shared(|manifest| manifest.get_path("bevy_render"))
+}
+
+pub(crate) fn bevy_ecs_path() -> syn::Path {
+    BevyManifest::shared(|manifest| manifest.get_path("bevy_ecs"))
+}
+
+pub(crate) fn bevy_pbr_path() -> syn::Path {
+    BevyManifest::shared(|manifest| manifest.get_path("bevy_pbr"))
+}
+
+/// Implements `PhaseItem`, `BinnedPhaseItem`, `CachedRenderPipelinePhaseItem`,
+/// `QueueBinnedPhaseItem` and `PhaseItemExt` for a wrapper type.
+///
+/// ### Newtypes
+/// For single-field tuple structs, all traits are derived automatically.
+///
+/// ### Non-newtype structs
+/// For other struct forms, `BinnedPhaseItem` cannot be derived automatically and must be
+/// skipped explicitly using `#[phase_item(skip(...))]`.
+///
+/// The `#[phase_item]` attribute is also responsible for indicating the inner phase item field.
+#[proc_macro_derive(BinnedPhaseItem, attributes(phase_item))]
+pub fn derive_binned_phase_item(input: TokenStream) -> TokenStream {
+    derive_phase_item(input, true)
+}
+
+/// Implements `PhaseItem`, `SortedPhaseItem`, `CachedRenderPipelinePhaseItem`,
+/// `QueueSortedPhaseItem` and `PhaseItemExt` for a wrapper type.
+///
+/// NOTE: Currently, we are using the default implementation of `sort` for `SortedPhaseItem`.
+///
+/// ### Newtypes
+/// For single-field tuple structs, all traits are derived automatically.
+///
+/// ### Non-newtype structs
+/// For other struct forms, `QueueSortedPhaseItem` cannot be derived automatically and must be
+/// skipped explicitly using `#[phase_item(skip(...))]`.
+///
+/// The `#[phase_item]` attribute is responsible for indicating the inner phase item field.
+#[proc_macro_derive(SortedPhaseItem, attributes(phase_item))]
+pub fn derive_sorted_phase_item(input: TokenStream) -> TokenStream {
+    derive_phase_item(input, false)
+}
+
+fn derive_phase_item(input: TokenStream, is_binned: bool) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+
+    let (member, inner_ty, skip_list) = match get_phase_item_field(&ast, is_binned) {
+        Ok(value) => value,
+        Err(err) => return err.to_compile_error().into(),
+    };
+
+    let bevy_render = bevy_render_path();
+    let bevy_ecs = bevy_ecs_path();
+    let bevy_pbr = bevy_pbr_path();
+
+    let struct_name = &ast.ident;
+    let generics = &ast.generics;
+    let (impl_generics, type_generics, where_clause) = generics.split_for_impl();
+
+    let phase_item_impl =
+        skip_list
+            .contains(&PHASE_ITEM_TRAITS[0])
+            .not()
+            .then_some(impl_phase_item(
+                struct_name,
+                &impl_generics,
+                &type_generics,
+                where_clause,
+                &member,
+                &bevy_render,
+                &bevy_ecs,
+            ));
+
+    let x_phase_item_impl = if is_binned {
+        skip_list
+            .contains(&PHASE_ITEM_TRAITS[1])
+            .not()
+            .then_some(impl_binned_phase_item(
+                struct_name,
+                &impl_generics,
+                &type_generics,
+                where_clause,
+                inner_ty,
+                &bevy_render,
+                &bevy_ecs,
+            ))
+    } else {
+        skip_list
+            .contains(&PHASE_ITEM_TRAITS[2])
+            .not()
+            .then_some(impl_sorted_phase_item(
+                struct_name,
+                &impl_generics,
+                &type_generics,
+                where_clause,
+                &member,
+                inner_ty,
+                &bevy_render,
+            ))
+    };
+
+    let cached_pipeline_impl =
+        skip_list
+            .contains(&PHASE_ITEM_TRAITS[3])
+            .not()
+            .then_some(impl_cached_pipeline(
+                struct_name,
+                &impl_generics,
+                &type_generics,
+                &member,
+                where_clause,
+                &bevy_render,
+            ));
+
+    let queue_x_phase_item_impl = if is_binned {
+        skip_list
+            .contains(&PHASE_ITEM_TRAITS[4])
+            .not()
+            .then_some(impl_queue_binned_phase_item(
+                struct_name,
+                &impl_generics,
+                &type_generics,
+                where_clause,
+                inner_ty,
+                &bevy_pbr,
+                &bevy_render,
+            ))
+    } else {
+        skip_list
+            .contains(&PHASE_ITEM_TRAITS[5])
+            .not()
+            .then_some(impl_queue_sorted_phase_item(
+                struct_name,
+                &impl_generics,
+                &type_generics,
+                where_clause,
+                inner_ty,
+                &bevy_pbr,
+            ))
+    };
+
+    let phase_item_ext_impl =
+        skip_list
+            .contains(&PHASE_ITEM_TRAITS[6])
+            .not()
+            .then_some(impl_phase_item_ext(
+                struct_name,
+                &impl_generics,
+                &type_generics,
+                where_clause,
+                inner_ty,
+                &bevy_pbr,
+            ));
+
+    TokenStream::from(quote! {
+        #phase_item_impl
+        #x_phase_item_impl
+        #cached_pipeline_impl
+        #queue_x_phase_item_impl
+        #phase_item_ext_impl
+    })
+}
+
+fn get_phase_item_field(
+    ast: &DeriveInput,
+    is_binned: bool,
+) -> syn::Result<(Member, &syn::Type, Vec<&str>)> {
+    let phase_item_kind = if is_binned { BINNED } else { SORTED };
+
+    let Data::Struct(data_struct) = &ast.data else {
+        return Err(syn::Error::new_spanned(
+            &ast.ident,
+            format!("`#[derive({phase_item_kind})]` is only supported for structs. Please ensure your type is a struct."),
+        ));
+    };
+
+    if data_struct.fields.is_empty() {
+        return Err(syn::Error::new_spanned(
+            &ast.ident,
+            format!("{phase_item_kind} cannot be derived on field-less structs"),
+        ));
+    }
+
+    // Collect all fields with #[phase_item]
+    let mut marked_fields: Vec<_> = data_struct
+        .fields
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, field)| {
+            field
+                .attrs
+                .iter()
+                .find(|a| a.path().is_ident(PHASE_ITEM_ATTR))
+                .map(|attr| (idx, field, attr))
+        })
+        .collect();
+
+    if marked_fields.len() > 1 {
+        let (_, _, second_attr) = marked_fields[1];
+        return Err(syn::Error::new_spanned(
+            second_attr,
+            format!("`#[{PHASE_ITEM_ATTR}]` attribute can only be used on a single field"),
+        ));
+    }
+
+    let (index, field, phase_item_attr) = match marked_fields.pop() {
+        // Handle explicit marking
+        Some((idx, field, attr)) => (idx, field, Some(attr)),
+        // Auto select for single field
+        None if data_struct.fields.len() == 1 => {
+            (0, data_struct.fields.iter().next().unwrap(), None)
+        }
+        None => {
+            return Err(syn::Error::new_spanned(
+                &ast.ident,
+                format!(
+                    "`#[derive({phase_item_kind})]` requires a field with the `#[{PHASE_ITEM_ATTR}]` attribute on multi-field structs",
+                ),
+            ));
+        }
+    };
+
+    let mut skip_list = Vec::new();
+    if let Some(attr) = phase_item_attr {
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident(SKIP_ATTR) {
+                meta.parse_nested_meta(|inner_meta| {
+                    let trait_name = inner_meta
+                        .path
+                        .get_ident()
+                        .ok_or_else(|| {
+                            syn::Error::new_spanned(&inner_meta.path, "expected identifier")
+                        })?
+                        .to_string();
+
+                    if let Some(idx) = PHASE_ITEM_TRAITS
+                        .iter()
+                        .position(|i| *i == trait_name.as_str())
+                    {
+                        skip_list.push(PHASE_ITEM_TRAITS[idx]);
+                    } else {
+                        return Err(syn::Error::new_spanned(
+                            &inner_meta.path,
+                            format!(
+                                "unexpected trait `{}`, expected one of: {}",
+                                trait_name,
+                                PHASE_ITEM_TRAITS.join(", ")
+                            ),
+                        ));
+                    }
+                    Ok(())
+                })
+            } else {
+                Err(meta.error(format!("unexpected attribute, expected `{SKIP_ATTR}`")))
+            }
+        })?;
+    }
+
+    let is_single_field = data_struct.fields.len() == 1;
+    let is_tuple_struct = matches!(data_struct.fields, syn::Fields::Unnamed(_));
+
+    if !(is_single_field && is_tuple_struct) {
+        let blacklist: Vec<_> = if is_binned {
+            &BINNED_BLACKLIST
+        } else {
+            &SORTED_BLACKLIST
+        }
+        .iter()
+        .map(|&idx| PHASE_ITEM_TRAITS[idx])
+        .collect();
+
+        let all_traits_valid = blacklist.iter().all(|i| skip_list.contains(i));
+        if !all_traits_valid {
+            return Err(syn::Error::new_spanned(
+                &ast.ident,
+                format!("`#[derive({phase_item_kind})]` can only implement the trait `{}` for single-field tuple structs.\n\
+                help: Use `#[phase_item(skip({}))]` on the field to skip it.", blacklist.join(", "), blacklist.join(", ")),
+            ));
+        }
+    }
+
+    let member = to_member(field, index);
+    Ok((member, &field.ty, skip_list))
+}
+
+fn to_member(field: &Field, index: usize) -> Member {
+    field
+        .ident
+        .as_ref()
+        .map(|name| Member::Named(name.clone()))
+        .unwrap_or_else(|| Member::Unnamed(Index::from(index)))
+}
+
+fn impl_phase_item(
+    struct_name: &syn::Ident,
+    impl_generics: &impl quote::ToTokens,
+    type_generics: &impl quote::ToTokens,
+    where_clause: Option<&syn::WhereClause>,
+    member: &Member,
+    bevy_render: &syn::Path,
+    bevy_ecs: &syn::Path,
+) -> proc_macro2::TokenStream {
+    quote! {
+        impl #impl_generics #bevy_render::render_phase::PhaseItem
+            for #struct_name #type_generics #where_clause
+        {
+            #[inline]
+            fn entity(&self) -> #bevy_ecs::entity::Entity {
+                self.#member.entity()
+            }
+
+            #[inline]
+            fn main_entity(&self) -> #bevy_render::sync_world::MainEntity {
+                self.#member.main_entity()
+            }
+
+            #[inline]
+            fn draw_function(&self) -> #bevy_render::render_phase::DrawFunctionId {
+                self.#member.draw_function()
+            }
+
+            #[inline]
+            fn batch_range(&self) -> &::core::ops::Range<u32> {
+                self.#member.batch_range()
+            }
+
+            #[inline]
+            fn batch_range_mut(&mut self) -> &mut ::core::ops::Range<u32> {
+                self.#member.batch_range_mut()
+            }
+
+            #[inline]
+            fn extra_index(&self) -> #bevy_render::render_phase::PhaseItemExtraIndex {
+                self.#member.extra_index()
+            }
+
+            #[inline]
+            fn batch_range_and_extra_index_mut(
+                &mut self,
+            ) -> (
+                &mut ::core::ops::Range<u32>,
+                &mut #bevy_render::render_phase::PhaseItemExtraIndex
+            ) {
+                self.#member.batch_range_and_extra_index_mut()
+            }
+        }
+    }
+}
+
+fn impl_binned_phase_item(
+    struct_name: &syn::Ident,
+    impl_generics: &impl quote::ToTokens,
+    type_generics: &impl quote::ToTokens,
+    where_clause: Option<&syn::WhereClause>,
+    inner_ty: &syn::Type,
+    bevy_render: &syn::Path,
+    bevy_ecs: &syn::Path,
+) -> proc_macro2::TokenStream {
+    quote! {
+        impl #impl_generics #bevy_render::render_phase::BinnedPhaseItem
+            for #struct_name #type_generics #where_clause
+        {
+            type BatchSetKey = <#inner_ty as #bevy_render::render_phase::BinnedPhaseItem>::BatchSetKey;
+            type BinKey = <#inner_ty as #bevy_render::render_phase::BinnedPhaseItem>::BinKey;
+
+            #[inline]
+            fn new(
+                batch_set_key: Self::BatchSetKey,
+                bin_key: Self::BinKey,
+                representative_entity: (#bevy_ecs::entity::Entity, #bevy_render::sync_world::MainEntity),
+                batch_range: ::core::ops::Range<u32>,
+                extra_index: #bevy_render::render_phase::PhaseItemExtraIndex,
+            ) -> Self {
+                Self(<#inner_ty as #bevy_render::render_phase::BinnedPhaseItem>::new(
+                    batch_set_key,
+                    bin_key,
+                    representative_entity,
+                    batch_range,
+                    extra_index,
+                ))
+            }
+        }
+    }
+}
+
+fn impl_sorted_phase_item(
+    struct_name: &syn::Ident,
+    impl_generics: &impl quote::ToTokens,
+    type_generics: &impl quote::ToTokens,
+    where_clause: Option<&syn::WhereClause>,
+    member: &Member,
+    inner_ty: &syn::Type,
+    bevy_render: &syn::Path,
+) -> proc_macro2::TokenStream {
+    quote! {
+        impl #impl_generics #bevy_render::render_phase::SortedPhaseItem
+            for #struct_name #type_generics #where_clause
+        {
+            type SortKey = <#inner_ty as #bevy_render::render_phase::SortedPhaseItem>::SortKey;
+
+            #[inline]
+            fn sort_key(&self) -> Self::SortKey {
+                <#inner_ty as #bevy_render::render_phase::SortedPhaseItem>::sort_key(&self.#member)
+            }
+
+            // NOTE: Currently, we are using the default implementation of `sort`.
+            // #[inline]
+            // fn sort(items: &mut [Self]) {
+            //     // To address this, we need to convert `&mut [Newtype]` to `&mut [Inner]`.
+            //     <#inner_ty as #bevy_render::render_phase::SortedPhaseItem>::sort(items)
+            //
+            //     // The simplest solution might be to reexport `radsort` and use it directly here.
+            //     radsort::sort_by_key(items, |item| item.sort_key().#member)
+            // }
+
+            #[inline]
+            fn indexed(&self) -> bool {
+                self.#member.indexed()
+            }
+        }
+    }
+}
+
+fn impl_cached_pipeline(
+    struct_name: &syn::Ident,
+    impl_generics: &impl quote::ToTokens,
+    type_generics: &impl quote::ToTokens,
+    member: &Member,
+    where_clause: Option<&syn::WhereClause>,
+    bevy_render: &syn::Path,
+) -> proc_macro2::TokenStream {
+    quote! {
+        impl #impl_generics #bevy_render::render_phase::CachedRenderPipelinePhaseItem
+            for #struct_name #type_generics #where_clause
+        {
+            #[inline]
+            fn cached_pipeline(&self) -> #bevy_render::render_resource::CachedRenderPipelineId {
+                self.#member.cached_pipeline()
+            }
+        }
+    }
+}
+
+fn impl_queue_binned_phase_item(
+    struct_name: &syn::Ident,
+    impl_generics: &impl quote::ToTokens,
+    type_generics: &impl quote::ToTokens,
+    where_clause: Option<&syn::WhereClause>,
+    inner_ty: &syn::Type,
+    bevy_pbr: &syn::Path,
+    bevy_render: &syn::Path,
+) -> proc_macro2::TokenStream {
+    quote! {
+        impl #impl_generics #bevy_pbr::QueueBinnedPhaseItem
+            for #struct_name #type_generics #where_clause
+        {
+            #[inline]
+            fn queue_item<BPI>(context: &#bevy_pbr::PhaseContext, render_phase: &mut #bevy_render::render_phase::BinnedRenderPhase<BPI>)
+            where
+                BPI: #bevy_render::render_phase::BinnedPhaseItem<BatchSetKey = Self::BatchSetKey, BinKey = Self::BinKey>,
+            {
+                <#inner_ty as #bevy_pbr::QueueBinnedPhaseItem>::queue_item(context, render_phase)
+            }
+        }
+    }
+}
+
+fn impl_queue_sorted_phase_item(
+    struct_name: &syn::Ident,
+    impl_generics: &impl quote::ToTokens,
+    type_generics: &impl quote::ToTokens,
+    where_clause: Option<&syn::WhereClause>,
+    inner_ty: &syn::Type,
+    bevy_pbr: &syn::Path,
+) -> proc_macro2::TokenStream {
+    quote! {
+        impl #impl_generics #bevy_pbr::QueueSortedPhaseItem
+            for #struct_name #type_generics #where_clause
+        {
+            #[inline]
+            fn get_item(context: &#bevy_pbr::PhaseContext) -> Option<Self> {
+                <#inner_ty as #bevy_pbr::QueueSortedPhaseItem>::get_item(context).map(Self)
+            }
+        }
+    }
+}
+
+fn impl_phase_item_ext(
+    struct_name: &syn::Ident,
+    impl_generics: &impl quote::ToTokens,
+    type_generics: &impl quote::ToTokens,
+    where_clause: Option<&syn::WhereClause>,
+    inner_ty: &syn::Type,
+    bevy_pbr: &syn::Path,
+) -> proc_macro2::TokenStream {
+    quote! {
+        impl #impl_generics #bevy_pbr::PhaseItemExt
+            for #struct_name #type_generics #where_clause
+        {
+            type PhaseFamily = <#inner_ty as #bevy_pbr::PhaseItemExt>::PhaseFamily;
+            type ExtractCondition = <#inner_ty as #bevy_pbr::PhaseItemExt>::ExtractCondition;
+            type RenderCommand = <#inner_ty as #bevy_pbr::PhaseItemExt>::RenderCommand;
+            const PHASE_TYPES: RenderPhaseType = <#inner_ty as #bevy_pbr::PhaseItemExt>::PHASE_TYPES;
+        }
+    }
+}

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -34,6 +34,7 @@ mod extended_material;
 mod fog;
 mod light_probe;
 mod lightmap;
+mod main_pass;
 mod material;
 mod material_bind_groups;
 mod medium;
@@ -53,6 +54,7 @@ use bevy_light::{
     AmbientLight, DirectionalLight, PointLight, ShadowFilteringMethod, SimulationLightSystems,
     SpotLight,
 };
+pub use bevy_pbr_macros::{BinnedPhaseItem, SortedPhaseItem};
 use bevy_shader::{load_shader_library, ShaderRef};
 pub use cluster::*;
 pub use components::*;
@@ -61,6 +63,7 @@ pub use extended_material::*;
 pub use fog::*;
 pub use light_probe::*;
 pub use lightmap::*;
+pub use main_pass::*;
 pub use material::*;
 pub use material_bind_groups::*;
 pub use medium::*;
@@ -222,7 +225,7 @@ impl Plugin for PbrPlugin {
                     use_gpu_instance_buffer_builder: self.use_gpu_instance_buffer_builder,
                     debug_flags: self.debug_flags,
                 },
-                MaterialsPlugin {
+                MainPassPlugin {
                     debug_flags: self.debug_flags,
                 },
                 MaterialPlugin::<StandardMaterial> {
@@ -327,7 +330,6 @@ impl Plugin for PbrPlugin {
                     extract_ambient_light_resource,
                     extract_ambient_light,
                     extract_shadow_filtering_method,
-                    late_sweep_material_instances,
                 ),
             )
             .add_systems(

--- a/crates/bevy_pbr/src/lightmap/mod.rs
+++ b/crates/bevy_pbr/src/lightmap/mod.rs
@@ -111,7 +111,7 @@ pub struct Lightmap {
 ///
 /// There is one of these per visible lightmapped mesh instance.
 #[derive(Debug)]
-pub(crate) struct RenderLightmap {
+pub struct RenderLightmap {
     /// The rectangle within the lightmap texture that the UVs are relative to.
     ///
     /// The top left coordinate is the `min` part of the rect, and the bottom
@@ -130,7 +130,7 @@ pub(crate) struct RenderLightmap {
     pub(crate) slot_index: LightmapSlotIndex,
 
     // Whether or not bicubic sampling should be used for this lightmap.
-    pub(crate) bicubic_sampling: bool,
+    pub bicubic_sampling: bool,
 }
 
 /// Stores data for all lightmaps in the render world.

--- a/crates/bevy_pbr/src/main_pass.rs
+++ b/crates/bevy_pbr/src/main_pass.rs
@@ -1,0 +1,519 @@
+use alloc::sync::Arc;
+
+use crate::*;
+use bevy_app::Plugin;
+use bevy_camera::{Camera3d, Projection};
+use bevy_core_pipeline::{
+    core_3d::{
+        AlphaMask3d, Opaque3d, Opaque3dBatchSetKey, Opaque3dBinKey, Transmissive3d, Transparent3d,
+    },
+    oit::OrderIndependentTransparencySettings,
+    prepass::{
+        DeferredPrepass, DepthPrepass, MotionVectorPrepass, NormalPrepass,
+        OpaqueNoLightmap3dBatchSetKey, OpaqueNoLightmap3dBinKey,
+    },
+    tonemapping::{DebandDither, Tonemapping},
+};
+use bevy_ecs::{
+    component::Component,
+    prelude::*,
+    query::{Has, QueryItem},
+    system::{Query, ResMut, SystemChangeTick},
+};
+use bevy_light::{EnvironmentMapLight, IrradianceVolume, ShadowFilteringMethod};
+use bevy_mesh::MeshVertexBufferLayoutRef;
+use bevy_render::{
+    camera::TemporalJitter,
+    extract_component::ExtractComponent,
+    render_phase::{
+        AddRenderCommand, BinnedPhaseItem, BinnedRenderPhase, BinnedRenderPhasePlugin,
+        BinnedRenderPhaseType, DrawFunctions, PhaseItemExtraIndex,
+    },
+    render_resource::{
+        RenderPipelineDescriptor, SpecializedMeshPipeline, SpecializedMeshPipelineError,
+    },
+    view::{ExtractedView, Msaa},
+    Render, RenderApp, RenderDebugFlags, RenderStartup, RenderSystems,
+};
+use bevy_shader::ShaderDefVal;
+
+#[derive(Default)]
+pub struct MainPassPlugin {
+    pub debug_flags: RenderDebugFlags,
+}
+impl Plugin for MainPassPlugin {
+    fn build(&self, app: &mut App) {
+        app.register_required_components::<Camera3d, MainPass>()
+            .add_plugins(MeshPassPlugin::<MainPass>::new(self.debug_flags));
+
+        let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
+        };
+
+        render_app
+            .add_systems(RenderStartup, init_material_pipeline)
+            .add_systems(
+                Render,
+                check_views_need_specialization::<MainPass>.in_set(RenderSystems::PrepareAssets),
+            );
+
+        add_prepass_and_shadow_pass(app, self.debug_flags);
+    }
+}
+
+fn add_prepass_and_shadow_pass(app: &mut App, debug_flags: RenderDebugFlags) {
+    app.add_plugins((PrepassPipelinePlugin, PrepassPlugin::new(debug_flags)))
+        .add_plugins(BinnedRenderPhasePlugin::<Shadow, MeshPipeline>::new(
+            debug_flags,
+        ));
+
+    let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
+        return;
+    };
+
+    render_app
+        .init_resource::<LightKeyCache>()
+        .init_resource::<LightSpecializationTicks>()
+        .init_resource::<SpecializedShadowMaterialPipelineCache>()
+        .init_resource::<DrawFunctions<Shadow>>()
+        .add_render_command::<Shadow, DrawPrepass>()
+        .add_systems(
+            Render,
+            (
+                check_views_lights_need_specialization.in_set(RenderSystems::PrepareAssets),
+                // specialize_shadows also needs to run after prepare_assets::<PreparedMaterial>,
+                // which is fine since ManageViews is after PrepareAssets
+                specialize_shadows
+                    .in_set(RenderSystems::ManageViews)
+                    .after(prepare_lights),
+                queue_shadows.in_set(RenderSystems::QueueMeshes),
+            ),
+        );
+}
+
+#[derive(Clone, Copy, Default, Component, ExtractComponent)]
+pub struct MainPass;
+
+impl MeshPass for MainPass {
+    type ViewKeySource = Self;
+    type Specializer = MaterialPipelineSpecializer;
+    type PhaseItems = (Opaque3d, AlphaMask3d, Transmissive3d, Transparent3d);
+}
+
+pub fn check_views_need_specialization<MP: MeshPass>(
+    mut view_key_cache: ResMut<ViewKeyCache<MP>>,
+    mut view_specialization_ticks: ResMut<ViewSpecializationTicks<MP>>,
+    mut views: Query<
+        (
+            &ExtractedView,
+            &Msaa,
+            Option<&Tonemapping>,
+            Option<&DebandDither>,
+            Option<&ShadowFilteringMethod>,
+            Has<ScreenSpaceAmbientOcclusion>,
+            (
+                Has<NormalPrepass>,
+                Has<DepthPrepass>,
+                Has<MotionVectorPrepass>,
+                Has<DeferredPrepass>,
+            ),
+            Option<&Camera3d>,
+            Has<TemporalJitter>,
+            Option<&Projection>,
+            Has<DistanceFog>,
+            (
+                Has<RenderViewLightProbes<EnvironmentMapLight>>,
+                Has<RenderViewLightProbes<IrradianceVolume>>,
+            ),
+            Has<OrderIndependentTransparencySettings>,
+        ),
+        With<MP>,
+    >,
+    ticks: SystemChangeTick,
+) {
+    for (
+        view,
+        msaa,
+        tonemapping,
+        dither,
+        shadow_filter_method,
+        ssao,
+        (normal_prepass, depth_prepass, motion_vector_prepass, deferred_prepass),
+        camera_3d,
+        temporal_jitter,
+        projection,
+        distance_fog,
+        (has_environment_maps, has_irradiance_volumes),
+        has_oit,
+    ) in views.iter_mut()
+    {
+        let mut view_key = MeshPipelineKey::from_msaa_samples(msaa.samples())
+            | MeshPipelineKey::from_hdr(view.hdr);
+
+        if normal_prepass {
+            view_key |= MeshPipelineKey::NORMAL_PREPASS;
+        }
+
+        if depth_prepass {
+            view_key |= MeshPipelineKey::DEPTH_PREPASS;
+        }
+
+        if motion_vector_prepass {
+            view_key |= MeshPipelineKey::MOTION_VECTOR_PREPASS;
+        }
+
+        if deferred_prepass {
+            view_key |= MeshPipelineKey::DEFERRED_PREPASS;
+        }
+
+        if temporal_jitter {
+            view_key |= MeshPipelineKey::TEMPORAL_JITTER;
+        }
+
+        if has_environment_maps {
+            view_key |= MeshPipelineKey::ENVIRONMENT_MAP;
+        }
+
+        if has_irradiance_volumes {
+            view_key |= MeshPipelineKey::IRRADIANCE_VOLUME;
+        }
+
+        if has_oit {
+            view_key |= MeshPipelineKey::OIT_ENABLED;
+        }
+
+        if let Some(projection) = projection {
+            view_key |= match projection {
+                Projection::Perspective(_) => MeshPipelineKey::VIEW_PROJECTION_PERSPECTIVE,
+                Projection::Orthographic(_) => MeshPipelineKey::VIEW_PROJECTION_ORTHOGRAPHIC,
+                Projection::Custom(_) => MeshPipelineKey::VIEW_PROJECTION_NONSTANDARD,
+            };
+        }
+
+        match shadow_filter_method.unwrap_or(&ShadowFilteringMethod::default()) {
+            ShadowFilteringMethod::Hardware2x2 => {
+                view_key |= MeshPipelineKey::SHADOW_FILTER_METHOD_HARDWARE_2X2;
+            }
+            ShadowFilteringMethod::Gaussian => {
+                view_key |= MeshPipelineKey::SHADOW_FILTER_METHOD_GAUSSIAN;
+            }
+            ShadowFilteringMethod::Temporal => {
+                view_key |= MeshPipelineKey::SHADOW_FILTER_METHOD_TEMPORAL;
+            }
+        }
+
+        if !view.hdr {
+            if let Some(tonemapping) = tonemapping {
+                view_key |= MeshPipelineKey::TONEMAP_IN_SHADER;
+                view_key |= tonemapping_pipeline_key(*tonemapping);
+            }
+            if let Some(DebandDither::Enabled) = dither {
+                view_key |= MeshPipelineKey::DEBAND_DITHER;
+            }
+        }
+        if ssao {
+            view_key |= MeshPipelineKey::SCREEN_SPACE_AMBIENT_OCCLUSION;
+        }
+        if distance_fog {
+            view_key |= MeshPipelineKey::DISTANCE_FOG;
+        }
+        if let Some(camera_3d) = camera_3d {
+            view_key |= screen_space_specular_transmission_pipeline_key(
+                camera_3d.screen_space_specular_transmission_quality,
+            );
+        }
+        if !view_key_cache
+            .get_mut(&view.retained_view_entity)
+            .is_some_and(|current_key| *current_key == view_key)
+        {
+            view_key_cache.insert(view.retained_view_entity, view_key);
+            view_specialization_ticks.insert(view.retained_view_entity, ticks.this_run());
+        }
+    }
+}
+
+pub fn init_material_pipeline(mut commands: Commands, mesh_pipeline: Res<MeshPipeline>) {
+    commands.insert_resource(MaterialPipeline {
+        mesh_pipeline: mesh_pipeline.clone(),
+    });
+}
+pub struct MaterialPipelineSpecializer {
+    pub(crate) pipeline: MaterialPipeline,
+    pub(crate) properties: Arc<MaterialProperties>,
+}
+
+impl MeshPassSpecializer for MaterialPipelineSpecializer {
+    type Pipeline = MaterialPipeline;
+
+    fn create_key(context: &SpecializerKeyContext) -> Self::Key {
+        let mut mesh_pipeline_key_bits = context.material.properties.mesh_pipeline_key_bits;
+        mesh_pipeline_key_bits.insert(alpha_mode_pipeline_key(
+            context.material.properties.alpha_mode,
+            &Msaa::from_samples(context.view_key.msaa_samples()),
+        ));
+        let mut mesh_key = context.view_key
+            | MeshPipelineKey::from_bits_retain(context.mesh_pipeline_key.bits())
+            | mesh_pipeline_key_bits;
+
+        if let Some(lightmap) = context.lightmap {
+            mesh_key |= MeshPipelineKey::LIGHTMAPPED;
+
+            if lightmap.bicubic_sampling {
+                mesh_key |= MeshPipelineKey::LIGHTMAP_BICUBIC_SAMPLING;
+            }
+        }
+
+        if context.has_crossfade {
+            mesh_key |= MeshPipelineKey::VISIBILITY_RANGE_DITHER;
+        }
+
+        if context
+            .view_key
+            .contains(MeshPipelineKey::MOTION_VECTOR_PREPASS)
+        {
+            // If the previous frame have skins or morph targets, note that.
+            if context
+                .mesh_instance_flags
+                .contains(RenderMeshInstanceFlags::HAS_PREVIOUS_SKIN)
+            {
+                mesh_key |= MeshPipelineKey::HAS_PREVIOUS_SKIN;
+            }
+            if context
+                .mesh_instance_flags
+                .contains(RenderMeshInstanceFlags::HAS_PREVIOUS_MORPH)
+            {
+                mesh_key |= MeshPipelineKey::HAS_PREVIOUS_MORPH;
+            }
+        }
+
+        let material_key = context.material.properties.material_key.clone();
+
+        Self::Key {
+            mesh_key,
+            material_key,
+            type_id: context.material_asset_id,
+            pass_id: context.pass_id,
+        }
+    }
+
+    fn new(pipeline: &Self::Pipeline, material: &PreparedMaterial) -> Self {
+        MaterialPipelineSpecializer {
+            pipeline: pipeline.clone(),
+            properties: material.properties.clone(),
+        }
+    }
+}
+
+impl SpecializedMeshPipeline for MaterialPipelineSpecializer {
+    type Key = ErasedMaterialPipelineKey;
+
+    fn specialize(
+        &self,
+        key: Self::Key,
+        layout: &MeshVertexBufferLayoutRef,
+    ) -> Result<RenderPipelineDescriptor, SpecializedMeshPipelineError> {
+        let mut descriptor = self
+            .pipeline
+            .mesh_pipeline
+            .specialize(key.mesh_key, layout)?;
+        descriptor.vertex.shader_defs.push(ShaderDefVal::UInt(
+            "MATERIAL_BIND_GROUP".into(),
+            MATERIAL_BIND_GROUP_INDEX as u32,
+        ));
+        if let Some(ref mut fragment) = descriptor.fragment {
+            fragment.shader_defs.push(ShaderDefVal::UInt(
+                "MATERIAL_BIND_GROUP".into(),
+                MATERIAL_BIND_GROUP_INDEX as u32,
+            ));
+        };
+        if let Some(vertex_shader) = self
+            .properties
+            .get_shader(MaterialVertexShader(key.pass_id))
+        {
+            descriptor.vertex.shader = vertex_shader.clone();
+        }
+
+        if let Some(fragment_shader) = self
+            .properties
+            .get_shader(MaterialFragmentShader(key.pass_id))
+        {
+            descriptor.fragment.as_mut().unwrap().shader = fragment_shader.clone();
+        }
+
+        descriptor
+            .layout
+            .insert(3, self.properties.material_layout.as_ref().unwrap().clone());
+
+        if let Some(specialize) = self.properties.specialize {
+            specialize(&self.pipeline, &mut descriptor, layout, key)?;
+        }
+
+        // If bindless mode is on, add a `BINDLESS` define.
+        if self.properties.bindless {
+            descriptor.vertex.shader_defs.push("BINDLESS".into());
+            if let Some(ref mut fragment) = descriptor.fragment {
+                fragment.shader_defs.push("BINDLESS".into());
+            }
+        }
+
+        Ok(descriptor)
+    }
+}
+
+pub struct NoExtractCondition;
+
+impl ExtractCondition for NoExtractCondition {
+    type ViewQuery = ();
+
+    #[inline]
+    fn should_extract(_item: QueryItem<'_, '_, Self::ViewQuery>) -> bool {
+        true
+    }
+}
+
+impl PhaseItemExt for Opaque3d {
+    type PhaseFamily = BinnedPhaseFamily;
+    type ExtractCondition = NoExtractCondition;
+    type RenderCommand = DrawMaterial;
+    const PHASE_TYPES: RenderPhaseType = RenderPhaseType::Opaque;
+}
+
+impl QueueBinnedPhaseItem for Opaque3d {
+    #[inline]
+    fn queue_item<BPI>(context: &PhaseContext, render_phase: &mut BinnedRenderPhase<BPI>)
+    where
+        BPI: BinnedPhaseItem<BatchSetKey = Self::BatchSetKey, BinKey = Self::BinKey>,
+    {
+        if context.material.properties.render_method == OpaqueRendererMethod::Deferred {
+            // Even though we aren't going to insert the entity into
+            // a bin, we still want to update its cache entry. That
+            // way, we know we don't need to re-examine it in future
+            // frames.
+            render_phase.update_cache(context.main_entity, None, context.current_change_tick);
+            return;
+        }
+        let (vertex_slab, index_slab) = context
+            .mesh_allocator
+            .mesh_slabs(&context.mesh_instance.mesh_asset_id);
+
+        render_phase.add(
+            Opaque3dBatchSetKey {
+                pipeline: context.pipeline_id,
+                draw_function: context.draw_function,
+                material_bind_group_index: Some(context.material.binding.group.0),
+                vertex_slab: vertex_slab.unwrap_or_default(),
+                index_slab,
+                lightmap_slab: context
+                    .mesh_instance
+                    .shared
+                    .lightmap_slab_index
+                    .map(|index| *index),
+            },
+            Opaque3dBinKey {
+                asset_id: context.mesh_instance.mesh_asset_id.into(),
+            },
+            (context.entity, context.main_entity),
+            context.mesh_instance.current_uniform_index,
+            BinnedRenderPhaseType::mesh(
+                context.mesh_instance.should_batch(),
+                &context.gpu_preprocessing_support,
+            ),
+            context.current_change_tick,
+        );
+    }
+}
+
+impl PhaseItemExt for AlphaMask3d {
+    type PhaseFamily = BinnedPhaseFamily;
+    type ExtractCondition = NoExtractCondition;
+    type RenderCommand = DrawMaterial;
+    const PHASE_TYPES: RenderPhaseType = RenderPhaseType::AlphaMask;
+}
+
+impl QueueBinnedPhaseItem for AlphaMask3d {
+    #[inline]
+    fn queue_item<BPI>(context: &PhaseContext, render_phase: &mut BinnedRenderPhase<BPI>)
+    where
+        BPI: BinnedPhaseItem<BatchSetKey = Self::BatchSetKey, BinKey = Self::BinKey>,
+    {
+        let (vertex_slab, index_slab) = context
+            .mesh_allocator
+            .mesh_slabs(&context.mesh_instance.mesh_asset_id);
+
+        render_phase.add(
+            OpaqueNoLightmap3dBatchSetKey {
+                pipeline: context.pipeline_id,
+                draw_function: context.draw_function,
+                material_bind_group_index: Some(context.material.binding.group.0),
+                vertex_slab: vertex_slab.unwrap_or_default(),
+                index_slab,
+            },
+            OpaqueNoLightmap3dBinKey {
+                asset_id: context.mesh_instance.mesh_asset_id.into(),
+            },
+            (context.entity, context.main_entity),
+            context.mesh_instance.current_uniform_index,
+            BinnedRenderPhaseType::mesh(
+                context.mesh_instance.should_batch(),
+                &context.gpu_preprocessing_support,
+            ),
+            context.current_change_tick,
+        );
+    }
+}
+
+impl PhaseItemExt for Transmissive3d {
+    type PhaseFamily = SortedPhaseFamily;
+    type ExtractCondition = NoExtractCondition;
+    type RenderCommand = DrawMaterial;
+    const PHASE_TYPES: RenderPhaseType = RenderPhaseType::Transmissive;
+}
+
+impl QueueSortedPhaseItem for Transmissive3d {
+    #[inline]
+    fn get_item(context: &PhaseContext) -> Option<Self> {
+        let (_, index_slab) = context
+            .mesh_allocator
+            .mesh_slabs(&context.mesh_instance.mesh_asset_id);
+        let distance = context.rangefinder.distance(&context.mesh_instance.center)
+            + context.material.properties.depth_bias;
+
+        Some(Transmissive3d {
+            entity: (context.entity, context.main_entity),
+            draw_function: context.draw_function,
+            pipeline: context.pipeline_id,
+            distance,
+            batch_range: 0..1,
+            extra_index: PhaseItemExtraIndex::None,
+            indexed: index_slab.is_some(),
+        })
+    }
+}
+
+impl PhaseItemExt for Transparent3d {
+    type PhaseFamily = SortedPhaseFamily;
+    type ExtractCondition = NoExtractCondition;
+    type RenderCommand = DrawMaterial;
+    const PHASE_TYPES: RenderPhaseType = RenderPhaseType::Transparent;
+}
+
+impl QueueSortedPhaseItem for Transparent3d {
+    #[inline]
+    fn get_item(context: &PhaseContext) -> Option<Self> {
+        let (_, index_slab) = context
+            .mesh_allocator
+            .mesh_slabs(&context.mesh_instance.mesh_asset_id);
+        let distance = context.rangefinder.distance(&context.mesh_instance.center)
+            + context.material.properties.depth_bias;
+
+        Some(Transparent3d {
+            entity: (context.entity, context.main_entity),
+            draw_function: context.draw_function,
+            pipeline: context.pipeline_id,
+            distance,
+            batch_range: 0..1,
+            extra_index: PhaseItemExtraIndex::None,
+            indexed: index_slab.is_some(),
+        })
+    }
+}

--- a/crates/bevy_pbr/src/meshlet/material_pipeline_prepare.rs
+++ b/crates/bevy_pbr/src/meshlet/material_pipeline_prepare.rs
@@ -162,6 +162,7 @@ pub fn prepare_material_meshlet_meshes_main_opaque_pass(
                 mesh_key: view_key,
                 material_key: material.properties.material_key.clone(),
                 type_id: material_id.type_id(),
+                pass_id: MainPass::id(),
             };
             let material_pipeline_specializer = MaterialPipelineSpecializer {
                 pipeline: material_pipeline.clone(),
@@ -334,6 +335,7 @@ pub fn prepare_material_meshlet_meshes_prepass(
                 mesh_key: view_key,
                 material_key: material.properties.material_key.clone(),
                 type_id: material_id.type_id(),
+                pass_id: Prepass::id(),
             };
             let material_pipeline_specializer = PrepassPipelineSpecializer {
                 pipeline: prepass_pipeline.clone(),

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -1,22 +1,13 @@
 mod prepass_bindings;
 
-use crate::{
-    alpha_mode_pipeline_key, binding_arrays_are_usable, buffer_layout,
-    collect_meshes_for_gpu_building, init_material_pipeline, set_mesh_motion_vector_flags,
-    setup_morph_and_skinning_defs, skin, DeferredAlphaMaskDrawFunction, DeferredFragmentShader,
-    DeferredOpaqueDrawFunction, DeferredVertexShader, DrawMesh, EntitySpecializationTicks,
-    ErasedMaterialPipelineKey, MaterialPipeline, MaterialProperties, MeshLayouts, MeshPipeline,
-    MeshPipelineKey, OpaqueRendererMethod, PreparedMaterial, PrepassAlphaMaskDrawFunction,
-    PrepassFragmentShader, PrepassOpaqueDrawFunction, PrepassVertexShader, RenderLightmaps,
-    RenderMaterialInstances, RenderMeshInstanceFlags, RenderMeshInstances, RenderPhaseType,
-    SetMaterialBindGroup, SetMeshBindGroup, ShadowView,
-};
+use crate::*;
 use bevy_app::{App, Plugin, PreUpdate};
 use bevy_asset::{embedded_asset, load_embedded_asset, AssetServer, Handle};
 use bevy_camera::{Camera, Camera3d};
 use bevy_core_pipeline::{core_3d::CORE_3D_DEPTH_FORMAT, deferred::*, prepass::*};
 use bevy_ecs::{
     prelude::*,
+    query::QueryItem,
     system::{
         lifetimeless::{Read, SRes},
         SystemParamItem,
@@ -25,25 +16,22 @@ use bevy_ecs::{
 use bevy_math::{Affine3A, Mat4, Vec4};
 use bevy_mesh::{Mesh, Mesh3d, MeshVertexBufferLayoutRef};
 use bevy_render::{
-    alpha::AlphaMode,
-    batching::gpu_preprocessing::GpuPreprocessingSupport,
+    extract_component::{ExtractComponent, ExtractComponentPlugin},
     globals::{GlobalsBuffer, GlobalsUniform},
-    mesh::{allocator::MeshAllocator, RenderMesh},
-    render_asset::{prepare_assets, RenderAssets},
     render_phase::*,
     render_resource::{binding_types::uniform_buffer, *},
     renderer::{RenderAdapter, RenderDevice, RenderQueue},
     sync_world::RenderEntity,
     view::{
-        ExtractedView, Msaa, RenderVisibilityRanges, RetainedViewEntity, ViewUniform,
-        ViewUniformOffset, ViewUniforms, VISIBILITY_RANGES_STORAGE_BUFFER_COUNT,
+        ExtractedView, Msaa, RenderVisibilityRanges, ViewUniform, ViewUniformOffset, ViewUniforms,
+        VISIBILITY_RANGES_STORAGE_BUFFER_COUNT,
     },
     Extract, ExtractSchedule, Render, RenderApp, RenderDebugFlags, RenderStartup, RenderSystems,
 };
 use bevy_shader::{load_shader_library, Shader, ShaderDefVal};
 use bevy_transform::prelude::GlobalTransform;
 pub use prepass_bindings::*;
-use tracing::{error, warn};
+use tracing::warn;
 
 #[cfg(feature = "meshlet")]
 use crate::meshlet::{
@@ -52,15 +40,8 @@ use crate::meshlet::{
 };
 
 use alloc::sync::Arc;
-use bevy_derive::{Deref, DerefMut};
-use bevy_ecs::{change_detection::Tick, system::SystemChangeTick};
-use bevy_platform::collections::HashMap;
-use bevy_render::{
-    erased_render_asset::ErasedRenderAssets,
-    sync_world::MainEntityHashMap,
-    view::RenderVisibleEntities,
-    RenderSystems::{PrepareAssets, PrepareResources},
-};
+use bevy_ecs::system::SystemChangeTick;
+use bevy_render::RenderSystems::{PrepareAssets, PrepareResources};
 use bevy_utils::default;
 
 /// Sets up everything required to use the prepass pipeline.
@@ -92,8 +73,7 @@ impl Plugin for PrepassPipelinePlugin {
             .add_systems(
                 Render,
                 prepare_prepass_view_bind_group.in_set(RenderSystems::PrepareBindGroups),
-            )
-            .init_resource::<SpecializedMeshPipelines<PrepassPipelineSpecializer>>();
+            );
     }
 }
 
@@ -119,8 +99,21 @@ impl Plugin for PrepassPlugin {
             .get_resource::<AnyPrepassPluginLoaded>()
             .is_none();
 
+        // QUESTION:
+        // When will we want to add `PrepassPlugin` multiple times?
+        // Why don't these guards protect systems like `check_prepass_views_need_specialization`?
         if no_prepass_plugin_loaded {
             app.insert_resource(AnyPrepassPluginLoaded)
+                .register_required_components::<Camera3d, Prepass>()
+                .register_required_components::<Camera3d, DeferredPass>()
+                .add_plugins((
+                    ExtractComponentPlugin::<DepthPrepass>::default(),
+                    ExtractComponentPlugin::<NormalPrepass>::default(),
+                    ExtractComponentPlugin::<MotionVectorPrepass>::default(),
+                    ExtractComponentPlugin::<DeferredPrepass>::default(),
+                    MeshPassPlugin::<Prepass>::new(self.debug_flags),
+                    MeshPassPlugin::<DeferredPass>::new(self.debug_flags),
+                ))
                 // At the start of each frame, last frame's GlobalTransforms become this frame's PreviousGlobalTransforms
                 // and last frame's view projection matrices become this frame's PreviousViewProjections
                 .add_systems(
@@ -129,13 +122,7 @@ impl Plugin for PrepassPlugin {
                         update_mesh_previous_global_transforms,
                         update_previous_view_data,
                     ),
-                )
-                .add_plugins((
-                    BinnedRenderPhasePlugin::<Opaque3dPrepass, MeshPipeline>::new(self.debug_flags),
-                    BinnedRenderPhasePlugin::<AlphaMask3dPrepass, MeshPipeline>::new(
-                        self.debug_flags,
-                    ),
-                ));
+                );
         }
 
         let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
@@ -151,26 +138,10 @@ impl Plugin for PrepassPlugin {
                 );
         }
 
-        render_app
-            .init_resource::<ViewPrepassSpecializationTicks>()
-            .init_resource::<ViewKeyPrepassCache>()
-            .init_resource::<SpecializedPrepassMaterialPipelineCache>()
-            .add_render_command::<Opaque3dPrepass, DrawPrepass>()
-            .add_render_command::<AlphaMask3dPrepass, DrawPrepass>()
-            .add_render_command::<Opaque3dDeferred, DrawPrepass>()
-            .add_render_command::<AlphaMask3dDeferred, DrawPrepass>()
-            .add_systems(
-                Render,
-                (
-                    check_prepass_views_need_specialization.in_set(PrepareAssets),
-                    specialize_prepass_material_meshes
-                        .in_set(RenderSystems::PrepareMeshes)
-                        .after(prepare_assets::<RenderMesh>)
-                        .after(collect_meshes_for_gpu_building)
-                        .after(set_mesh_motion_vector_flags),
-                    queue_prepass_material_meshes.in_set(RenderSystems::QueueMeshes),
-                ),
-            );
+        render_app.add_systems(
+            Render,
+            check_prepass_views_need_specialization::<Prepass>.in_set(PrepareAssets),
+        );
 
         #[cfg(feature = "meshlet")]
         render_app.add_systems(
@@ -181,6 +152,27 @@ impl Plugin for PrepassPlugin {
                 .run_if(resource_exists::<InstanceManager>),
         );
     }
+}
+
+#[derive(Clone, Copy, Default, Component, ExtractComponent)]
+pub struct Prepass;
+
+impl MeshPass for Prepass {
+    type ViewKeySource = Self;
+    type Specializer = PrepassPipelineSpecializer;
+    type PhaseItems = (Opaque3dPrepass, AlphaMask3dPrepass);
+}
+
+// Or `DeferredPrepass`?
+#[derive(Clone, Copy, Default, Component, ExtractComponent)]
+pub struct DeferredPass;
+
+// Currently we use `check_prepass_views_need_specialization` for both Prepass and DeferredPass.
+// Maybe split it later.
+impl MeshPass for DeferredPass {
+    type ViewKeySource = Prepass;
+    type Specializer = PrepassPipelineSpecializer;
+    type PhaseItems = (Opaque3dDeferred, AlphaMask3dDeferred);
 }
 
 #[derive(Resource)]
@@ -322,7 +314,7 @@ pub fn init_prepass_pipeline(
         view_layout_no_motion_vectors,
         mesh_layouts: mesh_pipeline.mesh_layouts.clone(),
         default_prepass_shader: load_embedded_asset!(asset_server.as_ref(), "prepass.wgsl"),
-        skins_use_uniform_buffers: skin::skins_use_uniform_buffers(&render_device.limits()),
+        skins_use_uniform_buffers: skins_use_uniform_buffers(&render_device.limits()),
         depth_clip_control_supported,
         binding_arrays_are_usable: binding_arrays_are_usable(&render_device, &render_adapter),
         empty_layout: BindGroupLayoutDescriptor::new("prepass_empty_layout", &[]),
@@ -333,6 +325,79 @@ pub fn init_prepass_pipeline(
 pub struct PrepassPipelineSpecializer {
     pub pipeline: PrepassPipeline,
     pub properties: Arc<MaterialProperties>,
+}
+
+impl MeshPassSpecializer for PrepassPipelineSpecializer {
+    type Pipeline = PrepassPipeline;
+
+    fn create_key(context: &SpecializerKeyContext) -> Self::Key {
+        let mut mesh_key =
+            context.view_key | MeshPipelineKey::from_bits_retain(context.mesh_pipeline_key.bits());
+
+        mesh_key |= alpha_mode_pipeline_key(
+            context.material.properties.alpha_mode,
+            &Msaa::from_samples(context.view_key.msaa_samples()),
+        );
+
+        let forward = match context.material.properties.render_method {
+            OpaqueRendererMethod::Forward => true,
+            OpaqueRendererMethod::Deferred => false,
+            OpaqueRendererMethod::Auto => unreachable!(),
+        };
+
+        // view_key already contains the deferred prepass flag
+        let deferred = context.view_key.contains(MeshPipelineKey::DEFERRED_PREPASS) && !forward;
+
+        if let Some(lightmap) = context.lightmap {
+            // Even though we don't use the lightmap in the forward prepass, the
+            // `SetMeshBindGroup` render command will bind the data for it. So
+            // we need to include the appropriate flag in the mesh pipeline key
+            // to ensure that the necessary bind group layout entries are
+            // present.
+            mesh_key |= MeshPipelineKey::LIGHTMAPPED;
+
+            if lightmap.bicubic_sampling && deferred {
+                mesh_key |= MeshPipelineKey::LIGHTMAP_BICUBIC_SAMPLING;
+            }
+        }
+
+        if context.has_crossfade {
+            mesh_key |= MeshPipelineKey::VISIBILITY_RANGE_DITHER;
+        }
+
+        // If the previous frame has skins or morph targets, note that.
+        if context
+            .view_key
+            .contains(MeshPipelineKey::MOTION_VECTOR_PREPASS)
+        {
+            if context
+                .mesh_instance_flags
+                .contains(RenderMeshInstanceFlags::HAS_PREVIOUS_SKIN)
+            {
+                mesh_key |= MeshPipelineKey::HAS_PREVIOUS_SKIN;
+            }
+            if context
+                .mesh_instance_flags
+                .contains(RenderMeshInstanceFlags::HAS_PREVIOUS_MORPH)
+            {
+                mesh_key |= MeshPipelineKey::HAS_PREVIOUS_MORPH;
+            }
+        }
+
+        ErasedMaterialPipelineKey {
+            mesh_key,
+            material_key: context.material.properties.material_key.clone(),
+            type_id: context.material_asset_id,
+            pass_id: context.pass_id,
+        }
+    }
+
+    fn new(pipeline: &Self::Pipeline, material: &PreparedMaterial) -> Self {
+        PrepassPipelineSpecializer {
+            pipeline: pipeline.clone(),
+            properties: material.properties.clone(),
+        }
+    }
 }
 
 impl SpecializedMeshPipeline for PrepassPipelineSpecializer {
@@ -347,9 +412,39 @@ impl SpecializedMeshPipeline for PrepassPipelineSpecializer {
         if self.properties.bindless {
             shader_defs.push("BINDLESS".into());
         }
-        let mut descriptor =
-            self.pipeline
-                .specialize(key.mesh_key, shader_defs, layout, &self.properties)?;
+
+        let mesh_key = key.mesh_key;
+
+        let mut bind_group_layouts = vec![
+            if mesh_key.contains(MeshPipelineKey::MOTION_VECTOR_PREPASS) {
+                self.pipeline.view_layout_motion_vectors.clone()
+            } else {
+                self.pipeline.view_layout_no_motion_vectors.clone()
+            },
+            self.pipeline.empty_layout.clone(),
+        ];
+
+        // NOTE: Eventually, it would be nice to only add this when the shaders are overloaded by the Material.
+        // The main limitation right now is that bind group order is hardcoded in shaders.
+        bind_group_layouts.push(self.properties.material_layout.as_ref().unwrap().clone());
+
+        // Setup prepass fragment targets - normals in slot 0 (or None if not needed), motion vectors in slot 1
+        let targets = prepass_target_descriptors(
+            mesh_key.contains(MeshPipelineKey::NORMAL_PREPASS),
+            mesh_key.contains(MeshPipelineKey::MOTION_VECTOR_PREPASS),
+            mesh_key.contains(MeshPipelineKey::DEFERRED_PREPASS),
+        );
+
+        let mut descriptor = self.pipeline.specialize(
+            mesh_key,
+            shader_defs,
+            layout,
+            &self.properties,
+            key.pass_id,
+            2,
+            bind_group_layouts,
+            targets,
+        )?;
 
         // This is a bit risky because it's possible to change something that would
         // break the prepass but be fine in the main pass.
@@ -374,16 +469,12 @@ impl PrepassPipeline {
         shader_defs: Vec<ShaderDefVal>,
         layout: &MeshVertexBufferLayoutRef,
         material_properties: &MaterialProperties,
+        pass_id: PassId,
+        mesh_bind_group_index: usize,
+        mut bind_group_layouts: Vec<BindGroupLayoutDescriptor>,
+        mut targets: Vec<Option<ColorTargetState>>,
     ) -> Result<RenderPipelineDescriptor, SpecializedMeshPipelineError> {
         let mut shader_defs = shader_defs;
-        let mut bind_group_layouts = vec![
-            if mesh_key.contains(MeshPipelineKey::MOTION_VECTOR_PREPASS) {
-                self.view_layout_motion_vectors.clone()
-            } else {
-                self.view_layout_no_motion_vectors.clone()
-            },
-            self.empty_layout.clone(),
-        ];
         let mut vertex_attributes = Vec::new();
 
         // Let the shader code know that it's running in a prepass pipeline.
@@ -393,17 +484,9 @@ impl PrepassPipeline {
 
         shader_defs.push(ShaderDefVal::UInt(
             "MATERIAL_BIND_GROUP".into(),
-            crate::MATERIAL_BIND_GROUP_INDEX as u32,
+            MATERIAL_BIND_GROUP_INDEX as u32,
         ));
-        // NOTE: Eventually, it would be nice to only add this when the shaders are overloaded by the Material.
-        // The main limitation right now is that bind group order is hardcoded in shaders.
-        bind_group_layouts.push(
-            material_properties
-                .material_layout
-                .as_ref()
-                .unwrap()
-                .clone(),
-        );
+
         #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
         shader_defs.push("WEBGL2".into());
         shader_defs.push("VERTEX_OUTPUT_INSTANCE_INDEX".into());
@@ -518,14 +601,8 @@ impl PrepassPipeline {
             &mut vertex_attributes,
             self.skins_use_uniform_buffers,
         );
-        bind_group_layouts.insert(2, bind_group);
+        bind_group_layouts.insert(mesh_bind_group_index, bind_group);
         let vertex_buffer_layout = layout.0.get_layout(&vertex_attributes)?;
-        // Setup prepass fragment targets - normals in slot 0 (or None if not needed), motion vectors in slot 1
-        let mut targets = prepass_target_descriptors(
-            mesh_key.contains(MeshPipelineKey::NORMAL_PREPASS),
-            mesh_key.contains(MeshPipelineKey::MOTION_VECTOR_PREPASS),
-            mesh_key.contains(MeshPipelineKey::DEFERRED_PREPASS),
-        );
 
         if targets.iter().all(Option::is_none) {
             // if no targets are required then clear the list, so that no fragment shader is required
@@ -540,22 +617,14 @@ impl PrepassPipeline {
             || emulate_unclipped_depth
             || (mesh_key.contains(MeshPipelineKey::MAY_DISCARD)
                 && material_properties
-                    .get_shader(PrepassFragmentShader)
+                    .get_shader(MaterialFragmentShader(pass_id))
                     .is_some());
 
         let fragment = fragment_required.then(|| {
             // Use the fragment shader from the material
-            let frag_shader_handle = if mesh_key.contains(MeshPipelineKey::DEFERRED_PREPASS) {
-                match material_properties.get_shader(DeferredFragmentShader) {
-                    Some(frag_shader_handle) => frag_shader_handle,
-                    None => self.default_prepass_shader.clone(),
-                }
-            } else {
-                match material_properties.get_shader(PrepassFragmentShader) {
-                    Some(frag_shader_handle) => frag_shader_handle,
-                    None => self.default_prepass_shader.clone(),
-                }
-            };
+            let frag_shader_handle = material_properties
+                .get_shader(MaterialFragmentShader(pass_id))
+                .unwrap_or(self.default_prepass_shader.clone());
 
             FragmentState {
                 shader: frag_shader_handle,
@@ -566,17 +635,10 @@ impl PrepassPipeline {
         });
 
         // Use the vertex shader from the material if present
-        let vert_shader_handle = if mesh_key.contains(MeshPipelineKey::DEFERRED_PREPASS) {
-            if let Some(handle) = material_properties.get_shader(DeferredVertexShader) {
-                handle
-            } else {
-                self.default_prepass_shader.clone()
-            }
-        } else if let Some(handle) = material_properties.get_shader(PrepassVertexShader) {
-            handle
-        } else {
-            self.default_prepass_shader.clone()
-        };
+        let vert_shader_handle = material_properties
+            .get_shader(MaterialVertexShader(pass_id))
+            .unwrap_or(self.default_prepass_shader.clone());
+
         let descriptor = RenderPipelineDescriptor {
             vertex: VertexState {
                 shader: vert_shader_handle,
@@ -747,42 +809,22 @@ pub fn prepare_prepass_view_bind_group(
     }
 }
 
-/// Stores the [`SpecializedPrepassMaterialViewPipelineCache`] for each view.
-#[derive(Resource, Deref, DerefMut, Default)]
-pub struct SpecializedPrepassMaterialPipelineCache {
-    // view_entity -> view pipeline cache
-    #[deref]
-    map: HashMap<RetainedViewEntity, SpecializedPrepassMaterialViewPipelineCache>,
-}
-
-/// Stores the cached render pipeline ID for each entity in a single view, as
-/// well as the last time it was changed.
-#[derive(Deref, DerefMut, Default)]
-pub struct SpecializedPrepassMaterialViewPipelineCache {
-    // material entity -> (tick, pipeline_id)
-    #[deref]
-    map: MainEntityHashMap<(Tick, CachedRenderPipelineId)>,
-}
-
-#[derive(Resource, Deref, DerefMut, Default, Clone)]
-pub struct ViewKeyPrepassCache(HashMap<RetainedViewEntity, MeshPipelineKey>);
-
-#[derive(Resource, Deref, DerefMut, Default, Clone)]
-pub struct ViewPrepassSpecializationTicks(HashMap<RetainedViewEntity, Tick>);
-
-pub fn check_prepass_views_need_specialization(
-    mut view_key_cache: ResMut<ViewKeyPrepassCache>,
-    mut view_specialization_ticks: ResMut<ViewPrepassSpecializationTicks>,
+pub fn check_prepass_views_need_specialization<P: MeshPass>(
+    mut view_key_cache: ResMut<ViewKeyCache<P>>,
+    mut view_specialization_ticks: ResMut<ViewSpecializationTicks<P>>,
     mut views: Query<(
         &ExtractedView,
         &Msaa,
         Option<&DepthPrepass>,
         Option<&NormalPrepass>,
         Option<&MotionVectorPrepass>,
+        Option<&DeferredPrepass>,
     )>,
     ticks: SystemChangeTick,
 ) {
-    for (view, msaa, depth_prepass, normal_prepass, motion_vector_prepass) in views.iter_mut() {
+    for (view, msaa, depth_prepass, normal_prepass, motion_vector_prepass, deferred_prepass) in
+        views.iter_mut()
+    {
         let mut view_key = MeshPipelineKey::from_msaa_samples(msaa.samples());
         if depth_prepass.is_some() {
             view_key |= MeshPipelineKey::DEPTH_PREPASS;
@@ -792,6 +834,11 @@ pub fn check_prepass_views_need_specialization(
         }
         if motion_vector_prepass.is_some() {
             view_key |= MeshPipelineKey::MOTION_VECTOR_PREPASS;
+        }
+        // NOTE: This parameter was moved from `specialize_prepass_material_meshes` to here,
+        // which means the specialization of prepass will be affected by `DeferredPrepass` now.
+        if deferred_prepass.is_some() {
+            view_key |= MeshPipelineKey::DEFERRED_PREPASS;
         }
 
         if let Some(current_key) = view_key_cache.get_mut(&view.retained_view_entity) {
@@ -806,408 +853,197 @@ pub fn check_prepass_views_need_specialization(
     }
 }
 
-pub fn specialize_prepass_material_meshes(
-    render_meshes: Res<RenderAssets<RenderMesh>>,
-    render_materials: Res<ErasedRenderAssets<PreparedMaterial>>,
-    render_mesh_instances: Res<RenderMeshInstances>,
-    render_material_instances: Res<RenderMaterialInstances>,
-    render_lightmaps: Res<RenderLightmaps>,
-    render_visibility_ranges: Res<RenderVisibilityRanges>,
-    view_key_cache: Res<ViewKeyPrepassCache>,
-    views: Query<(
-        &ExtractedView,
-        &RenderVisibleEntities,
-        &Msaa,
-        Option<&MotionVectorPrepass>,
-        Option<&DeferredPrepass>,
-    )>,
-    (
-        opaque_prepass_render_phases,
-        alpha_mask_prepass_render_phases,
-        opaque_deferred_render_phases,
-        alpha_mask_deferred_render_phases,
-    ): (
-        Res<ViewBinnedRenderPhases<Opaque3dPrepass>>,
-        Res<ViewBinnedRenderPhases<AlphaMask3dPrepass>>,
-        Res<ViewBinnedRenderPhases<Opaque3dDeferred>>,
-        Res<ViewBinnedRenderPhases<AlphaMask3dDeferred>>,
-    ),
-    (
-        mut specialized_material_pipeline_cache,
-        ticks,
-        prepass_pipeline,
-        mut pipelines,
-        pipeline_cache,
-        view_specialization_ticks,
-        entity_specialization_ticks,
-    ): (
-        ResMut<SpecializedPrepassMaterialPipelineCache>,
-        SystemChangeTick,
-        Res<PrepassPipeline>,
-        ResMut<SpecializedMeshPipelines<PrepassPipelineSpecializer>>,
-        Res<PipelineCache>,
-        Res<ViewPrepassSpecializationTicks>,
-        Res<EntitySpecializationTicks>,
-    ),
-) {
-    for (extracted_view, visible_entities, msaa, motion_vector_prepass, deferred_prepass) in &views
+pub struct PrepassExtractCondition;
+
+impl ExtractCondition for PrepassExtractCondition {
+    type ViewQuery = (
+        Has<DepthPrepass>,
+        Has<NormalPrepass>,
+        Has<MotionVectorPrepass>,
+    );
+
+    fn should_extract(
+        (depth_prepass, normal_prepass, motion_vector_prepass): QueryItem<'_, '_, Self::ViewQuery>,
+    ) -> bool {
+        depth_prepass || normal_prepass || motion_vector_prepass
+    }
+}
+
+pub struct DeferredExtractCondition;
+
+impl ExtractCondition for DeferredExtractCondition {
+    type ViewQuery = Has<DeferredPrepass>;
+
+    #[inline]
+    fn should_extract(deferred_prepass: QueryItem<'_, '_, Self::ViewQuery>) -> bool {
+        deferred_prepass
+    }
+}
+
+impl PhaseItemExt for Opaque3dPrepass {
+    type PhaseFamily = BinnedPhaseFamily;
+    type ExtractCondition = PrepassExtractCondition;
+    type RenderCommand = DrawPrepass;
+    const PHASE_TYPES: RenderPhaseType = RenderPhaseType::Opaque;
+}
+
+impl QueueBinnedPhaseItem for Opaque3dPrepass {
+    #[inline]
+    fn queue_item<BPI>(context: &PhaseContext, render_phase: &mut BinnedRenderPhase<BPI>)
+    where
+        BPI: BinnedPhaseItem<BatchSetKey = Self::BatchSetKey, BinKey = Self::BinKey>,
     {
-        if !opaque_deferred_render_phases.contains_key(&extracted_view.retained_view_entity)
-            && !alpha_mask_deferred_render_phases.contains_key(&extracted_view.retained_view_entity)
-            && !opaque_prepass_render_phases.contains_key(&extracted_view.retained_view_entity)
-            && !alpha_mask_prepass_render_phases.contains_key(&extracted_view.retained_view_entity)
-        {
-            continue;
-        }
+        if let OpaqueRendererMethod::Forward = context.material.properties.render_method {
+            let (vertex_slab, index_slab) = context
+                .mesh_allocator
+                .mesh_slabs(&context.mesh_instance.mesh_asset_id);
 
-        let Some(view_key) = view_key_cache.get(&extracted_view.retained_view_entity) else {
-            continue;
-        };
-
-        let view_tick = view_specialization_ticks
-            .get(&extracted_view.retained_view_entity)
-            .unwrap();
-        let view_specialized_material_pipeline_cache = specialized_material_pipeline_cache
-            .entry(extracted_view.retained_view_entity)
-            .or_default();
-
-        for (_, visible_entity) in visible_entities.iter::<Mesh3d>() {
-            let Some(material_instance) = render_material_instances.instances.get(visible_entity)
-            else {
-                continue;
-            };
-            let Some(mesh_instance) = render_mesh_instances.render_mesh_queue_data(*visible_entity)
-            else {
-                continue;
-            };
-            let entity_tick = entity_specialization_ticks
-                .get(visible_entity)
-                .unwrap()
-                .system_tick;
-            let last_specialized_tick = view_specialized_material_pipeline_cache
-                .get(visible_entity)
-                .map(|(tick, _)| *tick);
-            let needs_specialization = last_specialized_tick.is_none_or(|tick| {
-                view_tick.is_newer_than(tick, ticks.this_run())
-                    || entity_tick.is_newer_than(tick, ticks.this_run())
-            });
-            if !needs_specialization {
-                continue;
-            }
-            let Some(material) = render_materials.get(material_instance.asset_id) else {
-                continue;
-            };
-            if !material.properties.prepass_enabled {
-                // If the material was previously specialized for prepass, remove it
-                view_specialized_material_pipeline_cache.remove(visible_entity);
-                continue;
-            }
-            let Some(mesh) = render_meshes.get(mesh_instance.mesh_asset_id) else {
-                continue;
-            };
-
-            let mut mesh_key = *view_key | MeshPipelineKey::from_bits_retain(mesh.key_bits.bits());
-
-            let alpha_mode = material.properties.alpha_mode;
-            match alpha_mode {
-                AlphaMode::Opaque | AlphaMode::AlphaToCoverage | AlphaMode::Mask(_) => {
-                    mesh_key |= alpha_mode_pipeline_key(alpha_mode, msaa);
-                }
-                AlphaMode::Blend
-                | AlphaMode::Premultiplied
-                | AlphaMode::Add
-                | AlphaMode::Multiply => {
-                    // In case this material was previously in a valid alpha_mode, remove it to
-                    // stop the queue system from assuming its retained cache to be valid.
-                    view_specialized_material_pipeline_cache.remove(visible_entity);
-                    continue;
-                }
-            }
-
-            if material.properties.reads_view_transmission_texture {
-                // No-op: Materials reading from `ViewTransmissionTexture` are not rendered in the `Opaque3d`
-                // phase, and are therefore also excluded from the prepass much like alpha-blended materials.
-                view_specialized_material_pipeline_cache.remove(visible_entity);
-                continue;
-            }
-
-            let forward = match material.properties.render_method {
-                OpaqueRendererMethod::Forward => true,
-                OpaqueRendererMethod::Deferred => false,
-                OpaqueRendererMethod::Auto => unreachable!(),
-            };
-
-            let deferred = deferred_prepass.is_some() && !forward;
-
-            if deferred {
-                mesh_key |= MeshPipelineKey::DEFERRED_PREPASS;
-            }
-
-            if let Some(lightmap) = render_lightmaps.render_lightmaps.get(visible_entity) {
-                // Even though we don't use the lightmap in the forward prepass, the
-                // `SetMeshBindGroup` render command will bind the data for it. So
-                // we need to include the appropriate flag in the mesh pipeline key
-                // to ensure that the necessary bind group layout entries are
-                // present.
-                mesh_key |= MeshPipelineKey::LIGHTMAPPED;
-
-                if lightmap.bicubic_sampling && deferred {
-                    mesh_key |= MeshPipelineKey::LIGHTMAP_BICUBIC_SAMPLING;
-                }
-            }
-
-            if render_visibility_ranges.entity_has_crossfading_visibility_ranges(*visible_entity) {
-                mesh_key |= MeshPipelineKey::VISIBILITY_RANGE_DITHER;
-            }
-
-            // If the previous frame has skins or morph targets, note that.
-            if motion_vector_prepass.is_some() {
-                if mesh_instance
-                    .flags
-                    .contains(RenderMeshInstanceFlags::HAS_PREVIOUS_SKIN)
-                {
-                    mesh_key |= MeshPipelineKey::HAS_PREVIOUS_SKIN;
-                }
-                if mesh_instance
-                    .flags
-                    .contains(RenderMeshInstanceFlags::HAS_PREVIOUS_MORPH)
-                {
-                    mesh_key |= MeshPipelineKey::HAS_PREVIOUS_MORPH;
-                }
-            }
-
-            let erased_key = ErasedMaterialPipelineKey {
-                mesh_key,
-                material_key: material.properties.material_key.clone(),
-                type_id: material_instance.asset_id.type_id(),
-            };
-            let prepass_pipeline_specializer = PrepassPipelineSpecializer {
-                pipeline: prepass_pipeline.clone(),
-                properties: material.properties.clone(),
-            };
-            let pipeline_id = pipelines.specialize(
-                &pipeline_cache,
-                &prepass_pipeline_specializer,
-                erased_key,
-                &mesh.layout,
+            render_phase.add(
+                OpaqueNoLightmap3dBatchSetKey {
+                    draw_function: context.draw_function,
+                    pipeline: context.pipeline_id,
+                    material_bind_group_index: Some(context.material.binding.group.0),
+                    vertex_slab: vertex_slab.unwrap_or_default(),
+                    index_slab,
+                },
+                OpaqueNoLightmap3dBinKey {
+                    asset_id: context.mesh_instance.mesh_asset_id.into(),
+                },
+                (context.entity, context.main_entity),
+                context.mesh_instance.current_uniform_index,
+                BinnedRenderPhaseType::mesh(
+                    context.mesh_instance.should_batch(),
+                    &context.gpu_preprocessing_support,
+                ),
+                context.current_change_tick,
             );
-            let pipeline_id = match pipeline_id {
-                Ok(id) => id,
-                Err(err) => {
-                    error!("{}", err);
-                    continue;
-                }
-            };
-
-            view_specialized_material_pipeline_cache
-                .insert(*visible_entity, (ticks.this_run(), pipeline_id));
         }
     }
 }
 
-pub fn queue_prepass_material_meshes(
-    render_mesh_instances: Res<RenderMeshInstances>,
-    render_materials: Res<ErasedRenderAssets<PreparedMaterial>>,
-    render_material_instances: Res<RenderMaterialInstances>,
-    mesh_allocator: Res<MeshAllocator>,
-    gpu_preprocessing_support: Res<GpuPreprocessingSupport>,
-    mut opaque_prepass_render_phases: ResMut<ViewBinnedRenderPhases<Opaque3dPrepass>>,
-    mut alpha_mask_prepass_render_phases: ResMut<ViewBinnedRenderPhases<AlphaMask3dPrepass>>,
-    mut opaque_deferred_render_phases: ResMut<ViewBinnedRenderPhases<Opaque3dDeferred>>,
-    mut alpha_mask_deferred_render_phases: ResMut<ViewBinnedRenderPhases<AlphaMask3dDeferred>>,
-    views: Query<(&ExtractedView, &RenderVisibleEntities)>,
-    specialized_material_pipeline_cache: Res<SpecializedPrepassMaterialPipelineCache>,
-) {
-    for (extracted_view, visible_entities) in &views {
-        let (
-            mut opaque_phase,
-            mut alpha_mask_phase,
-            mut opaque_deferred_phase,
-            mut alpha_mask_deferred_phase,
-        ) = (
-            opaque_prepass_render_phases.get_mut(&extracted_view.retained_view_entity),
-            alpha_mask_prepass_render_phases.get_mut(&extracted_view.retained_view_entity),
-            opaque_deferred_render_phases.get_mut(&extracted_view.retained_view_entity),
-            alpha_mask_deferred_render_phases.get_mut(&extracted_view.retained_view_entity),
-        );
+impl PhaseItemExt for AlphaMask3dPrepass {
+    type PhaseFamily = BinnedPhaseFamily;
+    type ExtractCondition = PrepassExtractCondition;
+    type RenderCommand = DrawPrepass;
+    const PHASE_TYPES: RenderPhaseType = RenderPhaseType::AlphaMask;
+}
 
-        let Some(view_specialized_material_pipeline_cache) =
-            specialized_material_pipeline_cache.get(&extracted_view.retained_view_entity)
-        else {
-            continue;
-        };
+impl QueueBinnedPhaseItem for AlphaMask3dPrepass {
+    #[inline]
+    fn queue_item<BPI>(context: &PhaseContext, render_phase: &mut BinnedRenderPhase<BPI>)
+    where
+        BPI: BinnedPhaseItem<BatchSetKey = Self::BatchSetKey, BinKey = Self::BinKey>,
+    {
+        if let OpaqueRendererMethod::Forward = context.material.properties.render_method {
+            let (vertex_slab, index_slab) = context
+                .mesh_allocator
+                .mesh_slabs(&context.mesh_instance.mesh_asset_id);
 
-        // Skip if there's no place to put the mesh.
-        if opaque_phase.is_none()
-            && alpha_mask_phase.is_none()
-            && opaque_deferred_phase.is_none()
-            && alpha_mask_deferred_phase.is_none()
-        {
-            continue;
+            let batch_set_key = OpaqueNoLightmap3dBatchSetKey {
+                draw_function: context.draw_function,
+                pipeline: context.pipeline_id,
+                material_bind_group_index: Some(context.material.binding.group.0),
+                vertex_slab: vertex_slab.unwrap_or_default(),
+                index_slab,
+            };
+            let bin_key = OpaqueNoLightmap3dBinKey {
+                asset_id: context.mesh_instance.mesh_asset_id.into(),
+            };
+            render_phase.add(
+                batch_set_key,
+                bin_key,
+                (context.entity, context.main_entity),
+                context.mesh_instance.current_uniform_index,
+                BinnedRenderPhaseType::mesh(
+                    context.mesh_instance.should_batch(),
+                    &context.gpu_preprocessing_support,
+                ),
+                context.current_change_tick,
+            );
         }
+    }
+}
 
-        for (render_entity, visible_entity) in visible_entities.iter::<Mesh3d>() {
-            let Some((current_change_tick, pipeline_id)) =
-                view_specialized_material_pipeline_cache.get(visible_entity)
-            else {
-                continue;
-            };
+impl PhaseItemExt for Opaque3dDeferred {
+    type PhaseFamily = BinnedPhaseFamily;
+    type ExtractCondition = DeferredExtractCondition;
+    type RenderCommand = DrawPrepass;
+    const PHASE_TYPES: RenderPhaseType = RenderPhaseType::Opaque;
+}
 
-            // Skip the entity if it's cached in a bin and up to date.
-            if opaque_phase.as_mut().is_some_and(|phase| {
-                phase.validate_cached_entity(*visible_entity, *current_change_tick)
-            }) || alpha_mask_phase.as_mut().is_some_and(|phase| {
-                phase.validate_cached_entity(*visible_entity, *current_change_tick)
-            }) || opaque_deferred_phase.as_mut().is_some_and(|phase| {
-                phase.validate_cached_entity(*visible_entity, *current_change_tick)
-            }) || alpha_mask_deferred_phase.as_mut().is_some_and(|phase| {
-                phase.validate_cached_entity(*visible_entity, *current_change_tick)
-            }) {
-                continue;
-            }
+impl QueueBinnedPhaseItem for Opaque3dDeferred {
+    #[inline]
+    fn queue_item<BPI>(context: &PhaseContext, render_phase: &mut BinnedRenderPhase<BPI>)
+    where
+        BPI: BinnedPhaseItem<BatchSetKey = Self::BatchSetKey, BinKey = Self::BinKey>,
+    {
+        if let OpaqueRendererMethod::Deferred = context.material.properties.render_method {
+            let (vertex_slab, index_slab) = context
+                .mesh_allocator
+                .mesh_slabs(&context.mesh_instance.mesh_asset_id);
 
-            let Some(material_instance) = render_material_instances.instances.get(visible_entity)
-            else {
-                continue;
-            };
-            let Some(mesh_instance) = render_mesh_instances.render_mesh_queue_data(*visible_entity)
-            else {
-                continue;
-            };
-            let Some(material) = render_materials.get(material_instance.asset_id) else {
-                continue;
-            };
-            let (vertex_slab, index_slab) = mesh_allocator.mesh_slabs(&mesh_instance.mesh_asset_id);
+            render_phase.add(
+                OpaqueNoLightmap3dBatchSetKey {
+                    draw_function: context.draw_function,
+                    pipeline: context.pipeline_id,
+                    material_bind_group_index: Some(context.material.binding.group.0),
+                    vertex_slab: vertex_slab.unwrap_or_default(),
+                    index_slab,
+                },
+                OpaqueNoLightmap3dBinKey {
+                    asset_id: context.mesh_instance.mesh_asset_id.into(),
+                },
+                (context.entity, context.main_entity),
+                context.mesh_instance.current_uniform_index,
+                BinnedRenderPhaseType::mesh(
+                    context.mesh_instance.should_batch(),
+                    &context.gpu_preprocessing_support,
+                ),
+                context.current_change_tick,
+            );
+        }
+    }
+}
 
-            let deferred = match material.properties.render_method {
-                OpaqueRendererMethod::Forward => false,
-                OpaqueRendererMethod::Deferred => true,
-                OpaqueRendererMethod::Auto => unreachable!(),
-            };
+impl PhaseItemExt for AlphaMask3dDeferred {
+    type PhaseFamily = BinnedPhaseFamily;
+    type ExtractCondition = DeferredExtractCondition;
+    type RenderCommand = DrawPrepass;
+    const PHASE_TYPES: RenderPhaseType = RenderPhaseType::AlphaMask;
+}
 
-            match material.properties.render_phase_type {
-                RenderPhaseType::Opaque => {
-                    if deferred {
-                        let Some(draw_function) = material
-                            .properties
-                            .get_draw_function(DeferredOpaqueDrawFunction)
-                        else {
-                            continue;
-                        };
-                        opaque_deferred_phase.as_mut().unwrap().add(
-                            OpaqueNoLightmap3dBatchSetKey {
-                                draw_function,
-                                pipeline: *pipeline_id,
-                                material_bind_group_index: Some(material.binding.group.0),
-                                vertex_slab: vertex_slab.unwrap_or_default(),
-                                index_slab,
-                            },
-                            OpaqueNoLightmap3dBinKey {
-                                asset_id: mesh_instance.mesh_asset_id.into(),
-                            },
-                            (*render_entity, *visible_entity),
-                            mesh_instance.current_uniform_index,
-                            BinnedRenderPhaseType::mesh(
-                                mesh_instance.should_batch(),
-                                &gpu_preprocessing_support,
-                            ),
-                            *current_change_tick,
-                        );
-                    } else if let Some(opaque_phase) = opaque_phase.as_mut() {
-                        let (vertex_slab, index_slab) =
-                            mesh_allocator.mesh_slabs(&mesh_instance.mesh_asset_id);
-                        let Some(draw_function) = material
-                            .properties
-                            .get_draw_function(PrepassOpaqueDrawFunction)
-                        else {
-                            continue;
-                        };
-                        opaque_phase.add(
-                            OpaqueNoLightmap3dBatchSetKey {
-                                draw_function,
-                                pipeline: *pipeline_id,
-                                material_bind_group_index: Some(material.binding.group.0),
-                                vertex_slab: vertex_slab.unwrap_or_default(),
-                                index_slab,
-                            },
-                            OpaqueNoLightmap3dBinKey {
-                                asset_id: mesh_instance.mesh_asset_id.into(),
-                            },
-                            (*render_entity, *visible_entity),
-                            mesh_instance.current_uniform_index,
-                            BinnedRenderPhaseType::mesh(
-                                mesh_instance.should_batch(),
-                                &gpu_preprocessing_support,
-                            ),
-                            *current_change_tick,
-                        );
-                    }
-                }
-                RenderPhaseType::AlphaMask => {
-                    if deferred {
-                        let (vertex_slab, index_slab) =
-                            mesh_allocator.mesh_slabs(&mesh_instance.mesh_asset_id);
-                        let Some(draw_function) = material
-                            .properties
-                            .get_draw_function(DeferredAlphaMaskDrawFunction)
-                        else {
-                            continue;
-                        };
-                        let batch_set_key = OpaqueNoLightmap3dBatchSetKey {
-                            draw_function,
-                            pipeline: *pipeline_id,
-                            material_bind_group_index: Some(material.binding.group.0),
-                            vertex_slab: vertex_slab.unwrap_or_default(),
-                            index_slab,
-                        };
-                        let bin_key = OpaqueNoLightmap3dBinKey {
-                            asset_id: mesh_instance.mesh_asset_id.into(),
-                        };
-                        alpha_mask_deferred_phase.as_mut().unwrap().add(
-                            batch_set_key,
-                            bin_key,
-                            (*render_entity, *visible_entity),
-                            mesh_instance.current_uniform_index,
-                            BinnedRenderPhaseType::mesh(
-                                mesh_instance.should_batch(),
-                                &gpu_preprocessing_support,
-                            ),
-                            *current_change_tick,
-                        );
-                    } else if let Some(alpha_mask_phase) = alpha_mask_phase.as_mut() {
-                        let (vertex_slab, index_slab) =
-                            mesh_allocator.mesh_slabs(&mesh_instance.mesh_asset_id);
-                        let Some(draw_function) = material
-                            .properties
-                            .get_draw_function(PrepassAlphaMaskDrawFunction)
-                        else {
-                            continue;
-                        };
-                        let batch_set_key = OpaqueNoLightmap3dBatchSetKey {
-                            draw_function,
-                            pipeline: *pipeline_id,
-                            material_bind_group_index: Some(material.binding.group.0),
-                            vertex_slab: vertex_slab.unwrap_or_default(),
-                            index_slab,
-                        };
-                        let bin_key = OpaqueNoLightmap3dBinKey {
-                            asset_id: mesh_instance.mesh_asset_id.into(),
-                        };
-                        alpha_mask_phase.add(
-                            batch_set_key,
-                            bin_key,
-                            (*render_entity, *visible_entity),
-                            mesh_instance.current_uniform_index,
-                            BinnedRenderPhaseType::mesh(
-                                mesh_instance.should_batch(),
-                                &gpu_preprocessing_support,
-                            ),
-                            *current_change_tick,
-                        );
-                    }
-                }
-                _ => {}
-            }
+impl QueueBinnedPhaseItem for AlphaMask3dDeferred {
+    #[inline]
+    fn queue_item<BPI>(context: &PhaseContext, render_phase: &mut BinnedRenderPhase<BPI>)
+    where
+        BPI: BinnedPhaseItem<BatchSetKey = Self::BatchSetKey, BinKey = Self::BinKey>,
+    {
+        if let OpaqueRendererMethod::Deferred = context.material.properties.render_method {
+            let (vertex_slab, index_slab) = context
+                .mesh_allocator
+                .mesh_slabs(&context.mesh_instance.mesh_asset_id);
+
+            let batch_set_key = OpaqueNoLightmap3dBatchSetKey {
+                draw_function: context.draw_function,
+                pipeline: context.pipeline_id,
+                material_bind_group_index: Some(context.material.binding.group.0),
+                vertex_slab: vertex_slab.unwrap_or_default(),
+                index_slab,
+            };
+            let bin_key = OpaqueNoLightmap3dBinKey {
+                asset_id: context.mesh_instance.mesh_asset_id.into(),
+            };
+            render_phase.add(
+                batch_set_key,
+                bin_key,
+                (context.entity, context.main_entity),
+                context.mesh_instance.current_uniform_index,
+                BinnedRenderPhaseType::mesh(
+                    context.mesh_instance.should_batch(),
+                    &context.gpu_preprocessing_support,
+                ),
+                context.current_change_tick,
+            );
         }
     }
 }

--- a/crates/bevy_render/src/batching/mod.rs
+++ b/crates/bevy_render/src/batching/mod.rs
@@ -1,7 +1,7 @@
 use bevy_ecs::{
     component::Component,
     entity::Entity,
-    system::{ResMut, SystemParam, SystemParamItem},
+    system::{Query, SystemParam, SystemParamItem},
 };
 use bytemuck::Pod;
 use gpu_preprocessing::UntypedPhaseIndirectParametersBuffers;
@@ -9,8 +9,8 @@ use nonmax::NonMaxU32;
 
 use crate::{
     render_phase::{
-        BinnedPhaseItem, CachedRenderPipelinePhaseItem, DrawFunctionId, PhaseItemExtraIndex,
-        SortedPhaseItem, SortedRenderPhase, ViewBinnedRenderPhases,
+        BinnedPhaseItem, BinnedRenderPhase, CachedRenderPipelinePhaseItem, DrawFunctionId,
+        PhaseItemExtraIndex, SortedPhaseItem, SortedRenderPhase,
     },
     render_resource::{CachedRenderPipelineId, GpuArrayBufferable},
     sync_world::MainEntity,
@@ -179,11 +179,11 @@ pub trait GetFullBatchData: GetBatchData {
 }
 
 /// Sorts a render phase that uses bins.
-pub fn sort_binned_render_phase<BPI>(mut phases: ResMut<ViewBinnedRenderPhases<BPI>>)
+pub fn sort_binned_render_phase<BPI>(mut views: Query<&mut BinnedRenderPhase<BPI>>)
 where
     BPI: BinnedPhaseItem,
 {
-    for phase in phases.values_mut() {
+    for mut phase in views.iter_mut() {
         phase.multidrawable_meshes.sort_unstable_keys();
         phase.batchable_meshes.sort_unstable_keys();
         phase.unbatchable_meshes.sort_unstable_keys();

--- a/crates/bevy_render/src/render_phase/draw.rs
+++ b/crates/bevy_render/src/render_phase/draw.rs
@@ -54,6 +54,12 @@ pub enum DrawError {
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
 pub struct DrawFunctionId(u32);
 
+impl DrawFunctionId {
+    /// An draw function ID with a placeholder value. This may or may not correspond to an actual draw function,
+    /// and should be overwritten by a new value before being used.
+    pub const PLACEHOLDER: Self = Self(u32::MAX);
+}
+
 /// Stores all [`Draw`] functions for the [`PhaseItem`] type.
 ///
 /// For retrieval, the [`Draw`] functions are mapped to their respective [`TypeId`]s.

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -17,7 +17,7 @@ use bevy::{
         render_asset::RenderAssets,
         render_phase::{
             AddRenderCommand, DrawFunctions, PhaseItemExtraIndex, SetItemPipeline,
-            ViewSortedRenderPhases,
+            SortedRenderPhase,
         },
         render_resource::{
             BlendState, ColorTargetState, ColorWrites, CompareFunction, DepthBiasState,
@@ -381,19 +381,18 @@ pub fn queue_colored_mesh2d(
     pipeline_cache: Res<PipelineCache>,
     render_meshes: Res<RenderAssets<RenderMesh>>,
     render_mesh_instances: Res<RenderColoredMesh2dInstances>,
-    mut transparent_render_phases: ResMut<ViewSortedRenderPhases<Transparent2d>>,
-    views: Query<(&RenderVisibleEntities, &ExtractedView, &Msaa)>,
+    mut views: Query<(
+        &RenderVisibleEntities,
+        &ExtractedView,
+        &Msaa,
+        &mut SortedRenderPhase<Transparent2d>,
+    )>,
 ) {
     if render_mesh_instances.is_empty() {
         return;
     }
     // Iterate each view (a camera is a view)
-    for (visible_entities, view, msaa) in &views {
-        let Some(transparent_phase) = transparent_render_phases.get_mut(&view.retained_view_entity)
-        else {
-            continue;
-        };
-
+    for (visible_entities, view, msaa, mut transparent_phase) in views.iter_mut() {
         let draw_colored_mesh2d = transparent_draw_functions.read().id::<DrawColoredMesh2d>();
 
         let mesh_key = Mesh2dPipelineKey::from_msaa_samples(msaa.samples())

--- a/examples/README.md
+++ b/examples/README.md
@@ -467,6 +467,7 @@ Example | Description
 [Animated](../examples/shader/animate_shader.rs) | A shader that uses dynamic data like the time since startup
 [Array Texture](../examples/shader/array_texture.rs) | A shader that shows how to reuse the core bevy PBR shading functionality in a custom material that obtains the base color from an array texture.
 [Compute - Game of Life](../examples/shader/compute_shader_game_of_life.rs) | A compute shader that simulates Conway's Game of Life
+[Custom Mesh Pass](../examples/shader_advanced/custom_mesh_pass.rs) | Demonstrates how to write a custom mesh pass
 [Custom Render Phase](../examples/shader_advanced/custom_render_phase.rs) | Shows how to make a complete render phase
 [Custom Vertex Attribute](../examples/shader_advanced/custom_vertex_attribute.rs) | A shader that reads a mesh's custom vertex attribute
 [Custom phase item](../examples/shader_advanced/custom_phase_item.rs) | Demonstrates how to enqueue custom draw commands in a render phase

--- a/examples/shader_advanced/custom_mesh_pass.rs
+++ b/examples/shader_advanced/custom_mesh_pass.rs
@@ -1,0 +1,315 @@
+//! Demonstrates how to write a custom mesh pass
+//!
+//! The `MeshPass` in Bevy is designed for creating render passes that draw meshes with a set of new shaders in `Material`.
+//!
+//! This is useful for creating custom prepasses or implementing techniques like Inverted Hull Outline.
+
+use bevy::{
+    camera::{MainPassResolutionOverride, Viewport},
+    core_pipeline::core_3d::{
+        graph::{Core3d, Node3d},
+        Opaque3d, Transparent3d,
+    },
+    ecs::query::QueryItem,
+    mesh::MeshVertexBufferLayoutRef,
+    pbr::{
+        BinnedPhaseItem, DrawMaterial, ExtendedMaterial, MainPass, MaterialExtension,
+        MaterialExtensionKey, MaterialExtensionPipeline, MaterialPipelineSpecializer, MeshPass,
+        MeshPassPlugin, NoExtractCondition, PassShaders, PhaseContext, PhaseItemExt,
+        QueueSortedPhaseItem, RenderPhaseType, ShaderSet, SortedPhaseFamily, SortedPhaseItem,
+    },
+    prelude::*,
+    render::{
+        camera::ExtractedCamera,
+        diagnostic::RecordDiagnostics,
+        extract_component::ExtractComponent,
+        render_graph::{RenderGraphContext, RenderGraphExt, RenderLabel, ViewNode, ViewNodeRunner},
+        render_phase::{BinnedRenderPhase, SortedRenderPhase, TrackedRenderPass},
+        render_resource::{
+            AsBindGroup, CommandEncoderDescriptor, Face, RenderPassDescriptor,
+            RenderPipelineDescriptor, SpecializedMeshPipelineError, StoreOp,
+        },
+        renderer::RenderContext,
+        view::{ViewDepthTexture, ViewTarget},
+        RenderApp,
+    },
+};
+
+const SHADER_ASSET_PATH: &str = "shaders/custom_mesh_pass_material.wgsl";
+
+fn main() {
+    let mut app = App::new();
+    app.add_plugins((
+        DefaultPlugins,
+        MaterialPlugin::<ExtendedMaterial<StandardMaterial, OutlineExtension>>::default(),
+        MaterialPlugin::<ExtendedMaterial<StandardMaterial, TransparentOutlineExtension>>::default(
+        ),
+        MeshPassPlugin::<OutlinePass>::default(),
+    ))
+    // You can use `register_required_components` to add our `OutlinePass` to all cameras.
+    // Example: .register_required_components::<Camera3d, OutlinePass>()
+    .add_systems(Startup, setup);
+
+    let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
+        return;
+    };
+    render_app
+        .add_render_graph_node::<ViewNodeRunner<OutlinePassNode>>(Core3d, OutlinePassLabel)
+        .add_render_graph_edges(
+            Core3d,
+            (
+                Node3d::MainOpaquePass,
+                OutlinePassLabel,
+                Node3d::MainTransmissivePass,
+            ),
+        );
+
+    app.run();
+}
+
+#[derive(Debug, Hash, PartialEq, Eq, Clone, RenderLabel)]
+struct OutlinePassLabel;
+
+#[derive(Clone, Copy, Default, Component, ExtractComponent)]
+struct OutlinePass;
+
+impl MeshPass for OutlinePass {
+    type ViewKeySource = MainPass;
+    type Specializer = MaterialPipelineSpecializer;
+    type PhaseItems = (OutlineOpaque3d, OutlineTransparent3d);
+}
+
+// Single-field tuple structs can automatically forward all phase item traits from the inner type.
+#[derive(BinnedPhaseItem)]
+struct OutlineOpaque3d(Opaque3d);
+
+// Other struct forms have some limitations:
+// - `#[derive(BinnedPhaseItem)]` cannot derive `BinnedPhaseItem` automatically
+// - `#[derive(SortedPhaseItem)]` cannot derive `QueueSortedPhaseItem` automatically
+// - We have to skip those unsupported traits explicitly.
+#[derive(SortedPhaseItem)]
+struct OutlineTransparent3d {
+    // For demonstration, we also skip `PhaseItemExt`.
+    #[phase_item(skip(QueueSortedPhaseItem, PhaseItemExt))]
+    inner: Transparent3d,
+}
+
+// The APIs of `QueueBinnedPhaseItem` and `QueueSortedPhaseItem` are quite different.
+// For more details, check their definitions.
+impl QueueSortedPhaseItem for OutlineTransparent3d {
+    fn get_item(context: &PhaseContext) -> Option<Self> {
+        Transparent3d::get_item(context).map(|inner| Self { inner })
+    }
+}
+
+impl PhaseItemExt for OutlineTransparent3d {
+    type PhaseFamily = SortedPhaseFamily;
+    type ExtractCondition = NoExtractCondition;
+    type RenderCommand = DrawMaterial;
+    const PHASE_TYPES: RenderPhaseType = RenderPhaseType::Transparent;
+}
+
+#[derive(Asset, TypePath, AsBindGroup, Clone, Default)]
+struct OutlineExtension {
+    #[uniform(100)]
+    outline_color: LinearRgba,
+}
+
+impl MaterialExtension for OutlineExtension {
+    fn shaders() -> PassShaders {
+        let mut pass_shaders = PassShaders::default();
+        pass_shaders.extend([
+            (MainPass::id(), ShaderSet::default()),
+            (
+                OutlinePass::id(),
+                ShaderSet {
+                    vertex: SHADER_ASSET_PATH.into(),
+                    fragment: SHADER_ASSET_PATH.into(),
+                },
+            ),
+        ]);
+        pass_shaders
+    }
+
+    fn specialize(
+        _pipeline: &MaterialExtensionPipeline,
+        descriptor: &mut RenderPipelineDescriptor,
+        _layout: &MeshVertexBufferLayoutRef,
+        key: MaterialExtensionKey<Self>,
+    ) -> Result<(), SpecializedMeshPipelineError> {
+        if key.pass_id == OutlinePass::id() {
+            descriptor.primitive.cull_mode = Some(Face::Front);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Asset, TypePath, AsBindGroup, Clone, Default)]
+struct TransparentOutlineExtension {
+    #[uniform(100)]
+    outline_color: LinearRgba,
+}
+
+impl MaterialExtension for TransparentOutlineExtension {
+    fn shaders() -> PassShaders {
+        let mut pass_shaders = PassShaders::default();
+        pass_shaders.extend([
+            (MainPass::id(), ShaderSet::default()),
+            (
+                OutlinePass::id(),
+                // For simplicity, we are using the same shader for both opaque and transparent passes.
+                ShaderSet {
+                    vertex: SHADER_ASSET_PATH.into(),
+                    fragment: SHADER_ASSET_PATH.into(),
+                },
+            ),
+        ]);
+        pass_shaders
+    }
+
+    fn alpha_mode() -> Option<AlphaMode> {
+        Some(AlphaMode::Blend)
+    }
+}
+
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<ExtendedMaterial<StandardMaterial, OutlineExtension>>>,
+    mut transparent_materials: ResMut<
+        Assets<ExtendedMaterial<StandardMaterial, TransparentOutlineExtension>>,
+    >,
+) {
+    // Cube
+    commands.spawn((
+        MeshMaterial3d(materials.add(ExtendedMaterial {
+            base: StandardMaterial {
+                base_color: Color::srgb(1.0, 0.75, 0.75),
+                ..default()
+            },
+            extension: OutlineExtension {
+                outline_color: Color::srgb(0.6, 0.9, 0.70).to_linear(),
+            },
+        })),
+        Mesh3d(meshes.add(Cuboid::new(1.0, 1.0, 1.0).mesh())),
+        Transform::from_xyz(0.0, 0.5, -0.5),
+    ));
+
+    // Sphere
+    commands.spawn((
+        MeshMaterial3d(transparent_materials.add(ExtendedMaterial {
+            base: StandardMaterial {
+                base_color: Color::srgba(0.75, 0.75, 1.0, 0.5),
+                alpha_mode: AlphaMode::Blend,
+                ..default()
+            },
+            extension: TransparentOutlineExtension {
+                outline_color: Color::srgb(0.75, 0.6, 0.2).to_linear(),
+            },
+        })),
+        Mesh3d(meshes.add(Sphere::new(0.5).mesh())),
+        Transform::from_xyz(0.0, 0.5, 1.0),
+    ));
+
+    // Camera
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        // We are not using `register_required_components`, so let's manually
+        // mark the camera for rendering the custom pass.
+        OutlinePass,
+    ));
+
+    // Light
+    commands.spawn((
+        SpotLight::default(),
+        Transform::from_xyz(4.0, 5.0, 4.0).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
+}
+
+#[derive(Default)]
+struct OutlinePassNode;
+
+impl ViewNode for OutlinePassNode {
+    type ViewQuery = (
+        &'static ExtractedCamera,
+        &'static ViewTarget,
+        &'static ViewDepthTexture,
+        &'static BinnedRenderPhase<OutlineOpaque3d>,
+        &'static SortedRenderPhase<OutlineTransparent3d>,
+        Option<&'static MainPassResolutionOverride>,
+    );
+
+    fn run<'w>(
+        &self,
+        graph: &mut RenderGraphContext,
+        render_context: &mut RenderContext<'w>,
+        (camera, target, depth, opaque_phase, transparent_phase, resolution_override): QueryItem<
+            'w,
+            '_,
+            Self::ViewQuery,
+        >,
+        world: &'w World,
+    ) -> Result<(), bevy_render::render_graph::NodeRunError> {
+        let diagnostics = render_context.diagnostic_recorder();
+
+        let color_attachments = [Some(target.get_color_attachment())];
+        let depth_stencil_attachment = Some(depth.get_attachment(StoreOp::Store));
+
+        let view_entity = graph.view_entity();
+        render_context.add_command_buffer_generation_task(move |render_device| {
+            #[cfg(feature = "trace")]
+            let _main_opaque_pass_3d_span = info_span!("outline_opaque_pass_3d").entered();
+
+            // Command encoder setup
+            let mut command_encoder =
+                render_device.create_command_encoder(&CommandEncoderDescriptor {
+                    label: Some("outline_opaque_pass_3d_command_encoder"),
+                });
+
+            // Render pass setup
+            let render_pass = command_encoder.begin_render_pass(&RenderPassDescriptor {
+                label: Some("outline_opaque_pass_3d"),
+                color_attachments: &color_attachments,
+                depth_stencil_attachment,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+            let mut render_pass = TrackedRenderPass::new(&render_device, render_pass);
+            let pass_span = diagnostics.pass_span(&mut render_pass, "outline_pass");
+
+            if let Some(viewport) =
+                Viewport::from_viewport_and_override(camera.viewport.as_ref(), resolution_override)
+            {
+                render_pass.set_camera_viewport(&viewport);
+            }
+
+            // Opaque draws
+            if !opaque_phase.is_empty() {
+                #[cfg(feature = "trace")]
+                let _opaque_main_pass_3d_span = info_span!("opaque_outline_pass_3d").entered();
+                if let Err(err) = opaque_phase.render(&mut render_pass, world, view_entity) {
+                    error!("Error encountered while rendering the outline opaque phase {err:?}");
+                }
+            }
+
+            // Transparent draws
+            if !transparent_phase.items.is_empty() {
+                #[cfg(feature = "trace")]
+                let _transparent_main_pass_3d_span =
+                    info_span!("transparent_outline_pass_3d").entered();
+                if let Err(err) = transparent_phase.render(&mut render_pass, world, view_entity) {
+                    error!(
+                        "Error encountered while rendering the outline transparent phase {err:?}"
+                    );
+                }
+            }
+
+            pass_span.end(&mut render_pass);
+            drop(render_pass);
+            command_encoder.finish()
+        });
+
+        Ok(())
+    }
+}

--- a/examples/shader_advanced/custom_shader_instancing.rs
+++ b/examples/shader_advanced/custom_shader_instancing.rs
@@ -26,7 +26,7 @@ use bevy::{
         render_asset::RenderAssets,
         render_phase::{
             AddRenderCommand, DrawFunctions, PhaseItem, PhaseItemExtraIndex, RenderCommand,
-            RenderCommandResult, SetItemPipeline, TrackedRenderPass, ViewSortedRenderPhases,
+            RenderCommandResult, SetItemPipeline, SortedRenderPhase, TrackedRenderPass,
         },
         render_resource::*,
         renderer::RenderDevice,
@@ -129,17 +129,11 @@ fn queue_custom(
     meshes: Res<RenderAssets<RenderMesh>>,
     render_mesh_instances: Res<RenderMeshInstances>,
     material_meshes: Query<(Entity, &MainEntity), With<InstanceMaterialData>>,
-    mut transparent_render_phases: ResMut<ViewSortedRenderPhases<Transparent3d>>,
-    views: Query<(&ExtractedView, &Msaa)>,
+    mut views: Query<(&ExtractedView, &Msaa, &mut SortedRenderPhase<Transparent3d>)>,
 ) {
     let draw_custom = transparent_3d_draw_functions.read().id::<DrawCustom>();
 
-    for (view, msaa) in &views {
-        let Some(transparent_phase) = transparent_render_phases.get_mut(&view.retained_view_entity)
-        else {
-            continue;
-        };
-
+    for (view, msaa, mut transparent_phase) in views.iter_mut() {
         let msaa_key = MeshPipelineKey::from_msaa_samples(msaa.samples());
 
         let view_key = msaa_key | MeshPipelineKey::from_hdr(view.hdr);


### PR DESCRIPTION
# Objective

To simplify the effort required to create and add a custom mesh pipeline.

Replaces #21880 
Closes #21127

## Solution

Add `MeshPassPlugin` to handle the extract, specialize, and queue stages required to create a new mesh pipeline.

Usage：

<details>

```rust
#[derive(Clone, Copy, Default, Component, ExtractComponent)]
struct OutlinePass;

impl MeshPass for OutlinePass {
    type ViewKeySource = MainPass;
    type Specializer = MaterialPipelineSpecializer;
    type PhaseItems = (OutlineOpaque3d, ...);
}

#[derive(BinnedPhaseItem)]
struct OutlineOpaque3d(#[phase_item(skip(PhaseItemExt))] Opaque3d);

impl PhaseItemExt for OutlineOpaque3d {
    type PhaseFamily = BinnedPhaseFamily<Self>;
    type ExtractCondition = NoExtractCondition;
    type RenderCommand = DrawMaterial;
    const PHASE_TYPES: RenderPhaseType = RenderPhaseType::Opaque;
}

impl Material for OutlineMaterial {
	fn shaders() -> PassShaders {
        let mut pass_shaders = PassShaders::default();
        pass_shaders.extend([
            (MainPass::id(), ShaderSet::default()),
            (OutlinePass::id(), ShaderSet { vertex: PATH.into(), fragment: PATH.into() }),
        ]);
        pass_shaders
    }
}

fn main() {
    App::new()
        .add_plugins((MeshPassPlugin::<OutlinePass>::default(), ...))
        ...
}

```

</details>

For more details, please refer to custom_mesh_pass.rs.

In this version of MeshPass, we have removed the cumbersome `Option<Res<PhasesN<MP>>>`. Instead, we utilize `all_tuples!` to implement the required methods directly on the `QueryItem` of `(&mut RenderPhase, ...)` and call them within the `queue_material_meshes` system. This approach nearly eliminates all boilerplate code while still maintaining static dispatch.

Yes, this approach is based on making `XXXRenderPhase` a component. The main reason is: while we could do something similar with `(ResMut<ViewXXXRenderPhases<T>>, ...)`, we would need to handle multiple layers of conversion from `(ResMut<ViewXXXRenderPhases<T>>, ...)` to `(Option<&mut XXXRenderPhase<T>>, ...)`. To address this, we would have to write more traits and macros, which would be difficult to maintain. The flat `XXXRenderPhase` structure avoids this issue, making the implementation more straightforward and simpler.

## Testing

I ran the examples for the modules affected by this migration and did not observe any breaks.

## Showcase
<details>
<img width="1330" height="807" alt="Screenshot From 2025-12-23 21-54-00" src="https://github.com/user-attachments/assets/ffcb2ffd-2269-4b49-ac15-b2259d140b25" />
</details>