### PR TITLE
bevy_input_focus: don't add nothing when no input is enabled

### DIFF
--- a/crates/bevy_input_focus/src/lib.rs
+++ b/crates/bevy_input_focus/src/lib.rs
@@ -30,7 +30,9 @@ pub mod tab_navigation;
 mod autofocus;
 pub use autofocus::*;
 
-use bevy_app::{App, Plugin, PostStartup, PreUpdate};
+#[cfg(any(feature = "keyboard", feature = "gamepad", feature = "mouse"))]
+use bevy_app::PreUpdate;
+use bevy_app::{App, Plugin, PostStartup};
 use bevy_ecs::{
     entity::Entities, prelude::*, query::QueryData, system::SystemParam, traversal::Traversal,
 };
@@ -222,19 +224,21 @@ impl Plugin for InputDispatchPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(PostStartup, set_initial_focus)
             .init_resource::<InputFocus>()
-            .init_resource::<InputFocusVisible>()
-            .add_systems(
-                PreUpdate,
-                (
-                    #[cfg(feature = "keyboard")]
-                    dispatch_focused_input::<KeyboardInput>,
-                    #[cfg(feature = "gamepad")]
-                    dispatch_focused_input::<GamepadButtonChangedEvent>,
-                    #[cfg(feature = "mouse")]
-                    dispatch_focused_input::<MouseWheel>,
-                )
-                    .in_set(InputFocusSystems::Dispatch),
-            );
+            .init_resource::<InputFocusVisible>();
+
+        #[cfg(any(feature = "keyboard", feature = "gamepad", feature = "mouse"))]
+        app.add_systems(
+            PreUpdate,
+            (
+                #[cfg(feature = "keyboard")]
+                dispatch_focused_input::<KeyboardInput>,
+                #[cfg(feature = "gamepad")]
+                dispatch_focused_input::<GamepadButtonChangedEvent>,
+                #[cfg(feature = "mouse")]
+                dispatch_focused_input::<MouseWheel>,
+            )
+                .in_set(InputFocusSystems::Dispatch),
+        );
     }
 }
 


### PR DESCRIPTION
# Objective

- `cargo build --no-default-features --features bevy_input_focus` fails:
```
   Compiling bevy_input_focus v0.18.0-dev (/home/runner/work/bevy-releasability/bevy-releasability/crates/bevy_input_focus)
error[E0599]: no method named `in_set` found for unit type `()` in the current scope
   --> crates/bevy_input_focus/src/lib.rs:236:22
    |
228 | /                 (
229 | |                     #[cfg(feature = "keyboard")]
230 | |                     dispatch_focused_input::<KeyboardInput>,
231 | |                     #[cfg(feature = "gamepad")]
...   |
236 | |                     .in_set(InputFocusSystems::Dispatch),
    | |_____________________-^^^^^^
    |
```
- Introduced in #22177

## Solution

- Don't add an empty system tuple when no input feature is enabled
