### PR TITLE
bevy_render: dropped texture view is not Drop in wasm

### DIFF
--- a/crates/bevy_render/src/view/window/mod.rs
+++ b/crates/bevy_render/src/view/window/mod.rs
@@ -413,6 +413,10 @@ pub fn create_surfaces(
             // normally this is dropped on present but we double check here to be safe as failure to
             // drop it will cause validation errors in wgpu
             drop(window.swap_chain_texture.take());
+            #[cfg_attr(
+                target_arch = "wasm32",
+                expect(clippy::drop_non_drop, reason = "texture views are not drop on wasm")
+            )]
             drop(window.swap_chain_texture_view.take());
 
             data.configuration.width = window.physical_width;


### PR DESCRIPTION
# Objective

- `cargo clippy --no-deps --package bevy_render --target wasm32-unknown-unknown` fails:
```
warning: call to `std::mem::drop` with a value that does not implement `Drop`. Dropping such a type only extends its contained lifetimes
   --> crates/bevy_render/src/view/window/mod.rs:416:13
    |
416 |             drop(window.swap_chain_texture_view.take());
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
note: argument has type `std::option::Option<render_resource::texture::TextureView>`
   --> crates/bevy_render/src/view/window/mod.rs:416:18
    |
416 |             drop(window.swap_chain_texture_view.take());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#drop_non_drop
    = note: `#[warn(clippy::drop_non_drop)]` on by default

warning: `bevy_render` (lib) generated 1 warning
```

## Solution

- Expect the lint in wasm. It's not an actual problem, and special casing for wasm wouldn't be better
