### PR TITLE
Always present at least once for new windows.

### DIFF
--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -84,14 +84,17 @@ pub fn render_system(
 
         world.resource_scope(|world, mut windows: Mut<ExtractedWindows>| {
             let views = state.get(world);
-            for (view_target, camera) in views.iter() {
-                if let Some(NormalizedRenderTarget::Window(window)) = camera.target
-                    && view_target.needs_present()
-                {
-                    let Some(window) = windows.get_mut(&window.entity()) else {
-                        continue;
-                    };
+            for window in windows.values_mut() {
+                let view_needs_present = views.iter().any(|(view_target, camera)| {
+                    matches!(
+                        camera.target,
+                        Some(NormalizedRenderTarget::Window(w)) if w.entity() == window.entity
+                    ) && view_target.needs_present()
+                });
+
+                if view_needs_present || window.needs_initial_present {
                     window.present();
+                    window.needs_initial_present = false;
                 }
             }
         });

--- a/crates/bevy_render/src/view/window/mod.rs
+++ b/crates/bevy_render/src/view/window/mod.rs
@@ -64,6 +64,11 @@ pub struct ExtractedWindow {
     pub size_changed: bool,
     pub present_mode_changed: bool,
     pub alpha_mode: CompositeAlphaMode,
+    /// Whether this window needs an initial buffer commit.
+    ///
+    /// On Wayland, windows must present at least once before they are shown.
+    /// See <https://wayland.app/protocols/xdg-shell#xdg_surface>
+    pub needs_initial_present: bool,
 }
 
 impl ExtractedWindow {
@@ -145,6 +150,7 @@ fn extract_windows(
             swap_chain_texture_view_format: None,
             present_mode_changed: false,
             alpha_mode: window.composite_alpha_mode,
+            needs_initial_present: true,
         });
 
         if extracted_window.swap_chain_texture.is_none() {


### PR DESCRIPTION
Closes #22306. In theory we could cfg gate this for just wayland but doesn't seem harmful to do as a general case so nbd imo.

Don't have access to wayland right now so can't test but the docs [here](https://wayland.app/protocols/xdg-shell#xdg_surface) and [here](https://wayland-book.com/surfaces-in-depth/lifecycle.html) seem to confirm this is the right fix.