### PR TITLE
Small code size improvement

### DIFF
--- a/crates/bevy_picking/src/mesh_picking/ray_cast/intersections.rs
+++ b/crates/bevy_picking/src/mesh_picking/ray_cast/intersections.rs
@@ -67,7 +67,7 @@ pub(super) fn ray_intersection_over_mesh(
         Some(Indices::U32(indices)) => {
             ray_mesh_intersection(ray, transform, positions, normals, Some(indices), uvs, cull)
         }
-        None => ray_mesh_intersection::<usize>(ray, transform, positions, normals, None, uvs, cull),
+        None => ray_mesh_intersection::<u32>(ray, transform, positions, normals, None, uvs, cull),
     }
 }
 


### PR DESCRIPTION
# Objective

- Improve code size slightly

## Solution
- The index-less version of `ray_mesh_intersection<T>()` does not care about the indices type, so any `TryInto<usize>` will do.  
- By avoiding to monomorphize another version of `ray_mesh_intersection<T>` (with `T=usize`) when any of the existing one will do, we get a small improvement in code size (and presumably compilation time as well).

## Testing

- Built the `mesh_ray_cast` example, which works as expected

---
The gain is indeed small (0.8kB in dev, 3kB in release and noise (4B) in size-optimized builds)

## Showcase
`cargo bloat` is used to visualize the differences. Profile dev confirms that one less instance of the function is generated:
```sh
> # BEFORE (dev)
> cargo bloat --filter "ray_mesh_intersection$" --example mesh_ray_cast
File .text   Size        Crate Name
0.0%  0.0%   856B bevy_picking bevy_picking::mesh_picking::ray_cast::intersections::ray_mesh_intersection
0.0%  0.0%   856B bevy_picking bevy_picking::mesh_picking::ray_cast::intersections::ray_mesh_intersection
0.0%  0.0%   856B bevy_picking bevy_picking::mesh_picking::ray_cast::intersections::ray_mesh_intersection
0.0%  0.0% 2.5KiB              filtered data size, the file size is 263.3MiB

> # AFTER (dev)
> cargo bloat --filter "ray_mesh_intersection$" --example mesh_ray_cast
File .text Size        Crate Name
0.0%  0.0%   856B bevy_picking bevy_picking::mesh_picking::ray_cast::intersections::ray_mesh_intersection
0.0%  0.0%   856B bevy_picking bevy_picking::mesh_picking::ray_cast::intersections::ray_mesh_intersection
0.0%  0.0% 1.7KiB              filtered data size, the file size is 263.3MiB
```

In release the function is inlined into `ray_intersection_over_mesh()` which gains 3kB: 
```sh
> # BEFORE (release)
> cargo bloat --release --filter "ray_intersection_over_mesh$" --example mesh_ray_cast
File .text   Size        Crate Name
0.0%  0.0% 5.3KiB bevy_picking bevy_picking::mesh_picking::ray_cast::intersections::ray_intersection_over_mesh
0.0%  0.0% 5.3KiB              filtered data size, the file size is 100.7MiB

> # AFTER (release)
> cargo bloat --release --filter "ray_intersection_over_mesh$" --example mesh_ray_cast
File .text   Size        Crate Name
0.0%  0.0% 2.3KiB bevy_picking bevy_picking::mesh_picking::ray_cast::intersections::ray_intersection_over_mesh
0.0%  0.0% 2.3KiB              filtered data size, the file size is 100.7MiB
```