### PR TITLE
Fix: Closes shapes for 3d gizmos

### DIFF
--- a/crates/bevy_gizmos/src/gizmos.rs
+++ b/crates/bevy_gizmos/src/gizmos.rs
@@ -507,6 +507,41 @@ where
         self.strip_colors.push(LinearRgba::NAN);
     }
 
+    /// Draw a line in 3D made of straight segments between the points, with the first and last connected.
+    ///
+    /// # Example
+    /// ```
+    /// # use bevy_gizmos::prelude::*;
+    /// # use bevy_math::prelude::*;
+    /// # use bevy_color::palettes::basic::GREEN;
+    /// fn system(mut gizmos: Gizmos) {
+    ///     gizmos.lineloop([Vec3::ZERO, Vec3::X, Vec3::Y], GREEN);
+    /// }
+    /// # bevy_ecs::system::assert_is_system(system);
+    /// ```
+    #[inline]
+    pub fn lineloop(&mut self, positions: impl IntoIterator<Item = Vec3>, color: impl Into<Color>) {
+        if !self.enabled {
+            return;
+        }
+
+        // Loop back to the start; second is needed to ensure that
+        // the joint on the first corner is drawn.
+        let mut positions = positions.into_iter();
+        let first = positions.next();
+        let second = positions.next();
+
+        self.linestrip(
+            first
+                .into_iter()
+                .chain(second)
+                .chain(positions)
+                .chain(first)
+                .chain(second),
+            color,
+        );
+    }
+
     /// Draw a line in 3D made of straight segments between the points, with a color gradient.
     ///
     /// # Example
@@ -576,7 +611,7 @@ where
         }
         let isometry = isometry.into();
         let [tl, tr, br, bl] = rect_inner(size).map(|vec2| isometry * vec2.extend(0.));
-        self.linestrip([tl, tr, br, bl, tl], color);
+        self.lineloop([tl, tr, br, bl], color);
     }
 
     /// Draw a wireframe cube in 3D.
@@ -759,23 +794,7 @@ where
         if !self.enabled {
             return;
         }
-
-        // Loop back to the start; second is needed to ensure that
-        // the joint on the first corner is drawn.
-        let mut positions = positions.into_iter();
-        let first = positions.next();
-        let second = positions.next();
-
-        self.linestrip(
-            first
-                .into_iter()
-                .chain(second)
-                .chain(positions)
-                .chain(first)
-                .chain(second)
-                .map(|vec2| vec2.extend(0.)),
-            color,
-        );
+        self.lineloop(positions.into_iter().map(|vec2| vec2.extend(0.)), color);
     }
 
     /// Draw a line in 2D made of straight segments between the points, with a color gradient.

--- a/crates/bevy_gizmos/src/primitives/dim3.rs
+++ b/crates/bevy_gizmos/src/primitives/dim3.rs
@@ -287,7 +287,7 @@ where
 
         let isometry = isometry.into();
         let [a, b, c] = primitive.vertices;
-        self.linestrip([a, b, c, a].map(|vec3| isometry * vec3), color);
+        self.lineloop([a, b, c].map(|vec3| isometry * vec3), color);
     }
 }
 


### PR DESCRIPTION
# Objective

- Fixes #22204 

## Solution

- Refactored the solution from #22085 and made it use 3 dimensions; have 2d `lineloop` delegate to the 3d one.
- Updated any relevant usages of `linestrip` to use `lineloop` (rect and `GizmoPrimitive3d<Triangle3d>`). `GizmoPrimitive3d<Polyline3d>`, cube(), and aabb3d() still use `linestrip`. As far as I could tell, the cube looked ok for all corners in the `3d_gizmos` example (the black cube in the center of the scene) but another pair of eyes could be helpful there.
- This does not do anything for #22095 !

## Testing

- Ran `cargo run --example 3d_gizmos --features=free_camera` and saw that the green 3d square gizmo now closes
<img width="1063" height="182" alt="Screenshot 2025-12-30 at 4 06 41 PM" src="https://github.com/user-attachments/assets/5f9f4337-d1fe-4c2e-98c0-2d83fe4b0ea6" />

- Ran the demo in #22085 and ensured no regressions for 2d_gizmos
- Ran a modified demo for `Triangle3d` and verified that `Triangle3d` now closes
<details>
  <summary>Modified Demo for Triangle 3d</summary>

```rust
use bevy::prelude::*;

fn main() {
    App::new()
        .add_plugins(DefaultPlugins)
        .add_systems(Startup, setup)
        .add_systems(Update, draw_shapes)
        .run();
}

fn setup(
    mut config_store: ResMut<GizmoConfigStore>,
    mut commands: Commands
)
{
    let (config, _) = config_store.config_mut::<DefaultGizmoConfigGroup>();
    config.line.width = 10.0;
    config.line.joints = GizmoLineJoint::Miter;

    commands.spawn((Camera3d::default(), 
        Transform::from_xyz(0.0, 0.0, -5.0).looking_at(Vec3::ZERO, Vec3::Z)));
}

fn draw_shapes(mut gizmos: Gizmos) {
    gizmos.primitive_3d(
        &Triangle3d { vertices: [Vec3::ZERO, Vec3::new(1.0, 0., 0.), Vec3::new(0.0, 1.0, 0.) ] },
        Vec3::new(0.0, 0.0, 0.),
        Color::srgb_u8(0xFF, 0, 0)
    );
}
```

Before (notice notch in bottom left hand corner):
<img width="369" height="308" alt="Screenshot 2025-12-30 at 2 46 36 PM" src="https://github.com/user-attachments/assets/3b073b9e-7145-4eef-b070-13a56376b17f" />


After (notch in bottom left hand corner is gone):
<img width="361" height="339" alt="Screenshot 2025-12-30 at 2 47 28 PM" src="https://github.com/user-attachments/assets/47494176-b212-42ac-82b0-f042c94941f3" />

</details>
