### PR TITLE
Don't activate bevy_audio through android_shared_stdcxx

### DIFF
--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -262,7 +262,7 @@ bevy_gltf = ["dep:bevy_gltf", "bevy_scene", "bevy_pbr"]
 dynamic_linking = ["bevy_diagnostic/dynamic_linking"]
 
 # Enable using a shared stdlib for cxx on Android.
-android_shared_stdcxx = ["bevy_audio/android_shared_stdcxx"]
+android_shared_stdcxx = ["bevy_audio?/android_shared_stdcxx"]
 
 # Enable AccessKit on Unix backends (currently only works with experimental
 # screen readers and forks.)


### PR DESCRIPTION
# Objective

- Make it easier to replace bevy_audio

## Solution

Currently, the `default_platform` feature collection will activate `bevy_audio` through `android_shared_stdcxx`. This PR stops that.

Now, not adding the `audio` feature collection is enough to be able to use other audio solutions like `bevy_seedling` or `bevy_kira_audio`.

## Testing

- Tested on Linux