### PR TITLE
add gamepad to bevy_gilrs feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -310,7 +310,7 @@ bevy_post_process = ["bevy_internal/bevy_post_process"]
 bevy_anti_alias = ["bevy_internal/bevy_anti_alias"]
 
 # Adds gamepad support
-bevy_gilrs = ["bevy_internal/bevy_gilrs"]
+bevy_gilrs = ["gamepad", "bevy_internal/bevy_gilrs"]
 
 # [glTF](https://www.khronos.org/gltf/) support
 bevy_gltf = ["bevy_internal/bevy_gltf"]


### PR DESCRIPTION
# Objective

- Resolve discrepancy between documentation and implementation of the `bevy_gilrs` and `gamepad` feature flag
- Fixes #22319

## Solution

- Added `gamepad` to `bevy_gilrs` per the documentation

## Testing

- I recompiled Bevy with and without this change and ensured no failure to compile
