### PR TITLE
make `Archetype::component_index` pub

### DIFF
--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -936,7 +936,7 @@ impl Archetypes {
     }
 
     /// Get the component index
-    pub(crate) fn component_index(&self) -> &ComponentIndex {
+    pub fn component_index(&self) -> &ComponentIndex {
         &self.by_component
     }
 


### PR DESCRIPTION
# Objective
While experimenting with implementing a custom `Query` I noticed that `ComponentIndex` isn't accessible to user code, but it would be very useful to speed up archetype matching.

## Solution
Make `Archetype::component_index` getter pub. 