### PR TITLE
fix testbeds with argh in wasm

### DIFF
--- a/examples/testbed/2d.rs
+++ b/examples/testbed/2d.rs
@@ -16,7 +16,10 @@ pub struct Args {
 }
 
 fn main() {
+    #[cfg(not(target_arch = "wasm32"))]
     let args: Args = argh::from_env();
+    #[cfg(target_arch = "wasm32")]
+    let args: Args = Args::from_args(&[], &[]).unwrap();
 
     let mut app = App::new();
     app.add_plugins((DefaultPlugins,))

--- a/examples/testbed/3d.rs
+++ b/examples/testbed/3d.rs
@@ -16,7 +16,10 @@ pub struct Args {
 }
 
 fn main() {
+    #[cfg(not(target_arch = "wasm32"))]
     let args: Args = argh::from_env();
+    #[cfg(target_arch = "wasm32")]
+    let args: Args = Args::from_args(&[], &[]).unwrap();
 
     let mut app = App::new();
     app.add_plugins((DefaultPlugins,))

--- a/examples/testbed/ui.rs
+++ b/examples/testbed/ui.rs
@@ -16,7 +16,10 @@ pub struct Args {
 }
 
 fn main() {
+    #[cfg(not(target_arch = "wasm32"))]
     let args: Args = argh::from_env();
+    #[cfg(target_arch = "wasm32")]
+    let args: Args = Args::from_args(&[], &[]).unwrap();
 
     let mut app = App::new();
     app.add_plugins(DefaultPlugins.set(WindowPlugin {


### PR DESCRIPTION
# Objective

- #22223  used argh in the testbed examples
- this compile in wasm but crashes when running them

## Solution

- Fix it like the other examples using argh
