### PR TITLE
Fix panic in mesh picking when a mesh is `RENDER_WORLD` only

### DIFF
--- a/crates/bevy_picking/src/mesh_picking/ray_cast/intersections.rs
+++ b/crates/bevy_picking/src/mesh_picking/ray_cast/intersections.rs
@@ -46,21 +46,26 @@ pub(super) fn ray_intersection_over_mesh(
         return None; // ray_mesh_intersection assumes vertices are laid out in a triangle list
     }
     // Vertex positions are required
-    let positions = mesh.attribute(Mesh::ATTRIBUTE_POSITION)?.as_float3()?;
+    let positions = mesh
+        .try_attribute(Mesh::ATTRIBUTE_POSITION)
+        .ok()?
+        .as_float3()?;
 
     // Normals are optional
     let normals = mesh
-        .attribute(Mesh::ATTRIBUTE_NORMAL)
+        .try_attribute(Mesh::ATTRIBUTE_NORMAL)
+        .ok()
         .and_then(|normal_values| normal_values.as_float3());
 
     let uvs = mesh
-        .attribute(Mesh::ATTRIBUTE_UV_0)
+        .try_attribute(Mesh::ATTRIBUTE_UV_0)
+        .ok()
         .and_then(|uvs| match uvs {
             VertexAttributeValues::Float32x2(uvs) => Some(uvs.as_slice()),
             _ => None,
         });
 
-    match mesh.indices() {
+    match mesh.try_indices().ok() {
         Some(Indices::U16(indices)) => {
             ray_mesh_intersection(ray, transform, positions, normals, Some(indices), uvs, cull)
         }


### PR DESCRIPTION
## Objective

Fix a panic in mesh picking if a mesh is `RenderAssetUsages::RENDER_WORLD` only. The panic was reported in https://github.com/bevyengine/bevy/issues/22206, although that issue is framed as a broader concern and so is not resolved by this PR. The problem was introduced in https://github.com/bevyengine/bevy/pull/21732.

## Solution

Changed mesh accesses to use the non-panicking `try_` variants. This means extracted meshes are silently ignored as before.

I also did a quick scan to see if could spot any other engine crates that might have the same issue - didn't see any but could easily have missed one.

## Testing

Tested by modifying the `mesh_picking` example:

```diff
+    let mut p = Mesh::from(Cuboid::default());
+    p.asset_usage = bevy_asset::RenderAssetUsages::RENDER_WORLD;
     let shapes = [
-        meshes.add(Cuboid::default()),
+        meshes.add(p),
```
