### PR TITLE
make webgl2 padding consistent

### DIFF
--- a/crates/bevy_core_pipeline/src/skybox/mod.rs
+++ b/crates/bevy_core_pipeline/src/skybox/mod.rs
@@ -124,11 +124,11 @@ impl ExtractComponent for Skybox {
                 brightness: skybox.brightness * exposure,
                 transform: Transform::from_rotation(skybox.rotation.inverse()).to_matrix(),
                 #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
-                _wasm_padding_8b: 0,
+                _webgl2_padding_8b: 0,
                 #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
-                _wasm_padding_12b: 0,
+                _webgl2_padding_12b: 0,
                 #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
-                _wasm_padding_16b: 0,
+                _webgl2_padding_16b: 0,
             },
         ))
     }
@@ -140,11 +140,11 @@ pub struct SkyboxUniforms {
     brightness: f32,
     transform: Mat4,
     #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
-    _wasm_padding_8b: u32,
+    _webgl2_padding_8b: u32,
     #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
-    _wasm_padding_12b: u32,
+    _webgl2_padding_12b: u32,
     #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
-    _wasm_padding_16b: u32,
+    _webgl2_padding_16b: u32,
 }
 
 #[derive(Resource)]

--- a/crates/bevy_gizmos_render/src/lib.rs
+++ b/crates/bevy_gizmos_render/src/lib.rs
@@ -189,8 +189,8 @@ fn extract_gizmo_data(
                 joints_resolution,
                 gap_scale,
                 line_scale,
-                #[cfg(feature = "webgl")]
-                _padding: Default::default(),
+                #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
+                _webgl2_padding: Default::default(),
             },
             #[cfg(any(feature = "bevy_pbr", feature = "bevy_sprite_render"))]
             GizmoMeshConfig {
@@ -219,8 +219,8 @@ struct LineGizmoUniform {
     gap_scale: f32,
     line_scale: f32,
     /// WebGL2 structs must be 16 byte aligned.
-    #[cfg(feature = "webgl")]
-    _padding: bevy_math::Vec3,
+    #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
+    _webgl2_padding: bevy_math::Vec3,
 }
 
 #[cfg_attr(

--- a/crates/bevy_gizmos_render/src/pipeline_2d.rs
+++ b/crates/bevy_gizmos_render/src/pipeline_2d.rs
@@ -118,7 +118,7 @@ impl SpecializedRenderPipeline for LineGizmoPipeline {
         };
 
         let shader_defs = vec![
-            #[cfg(feature = "webgl")]
+            #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
             "SIXTEEN_BYTE_ALIGNMENT".into(),
         ];
 
@@ -203,7 +203,7 @@ impl SpecializedRenderPipeline for LineJointGizmoPipeline {
         };
 
         let shader_defs = vec![
-            #[cfg(feature = "webgl")]
+            #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
             "SIXTEEN_BYTE_ALIGNMENT".into(),
         ];
 

--- a/crates/bevy_gizmos_render/src/pipeline_3d.rs
+++ b/crates/bevy_gizmos_render/src/pipeline_3d.rs
@@ -149,7 +149,7 @@ impl Specializer<RenderPipeline> for LineGizmoPipelineSpecializer {
 
         let fragment = descriptor.fragment_mut()?;
 
-        #[cfg(feature = "webgl")]
+        #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
         fragment.shader_defs.push("SIXTEEN_BYTE_ALIGNMENT".into());
 
         if key.perspective {
@@ -203,7 +203,7 @@ impl SpecializedRenderPipeline for LineJointGizmoPipeline {
 
     fn specialize(&self, key: Self::Key) -> RenderPipelineDescriptor {
         let mut shader_defs = vec![
-            #[cfg(feature = "webgl")]
+            #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
             "SIXTEEN_BYTE_ALIGNMENT".into(),
         ];
 

--- a/crates/bevy_gizmos_render/src/retained.rs
+++ b/crates/bevy_gizmos_render/src/retained.rs
@@ -63,8 +63,8 @@ pub(crate) fn extract_linegizmos(
                 joints_resolution,
                 gap_scale,
                 line_scale,
-                #[cfg(feature = "webgl")]
-                _padding: Default::default(),
+                #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
+                _webgl2_padding: Default::default(),
             },
             #[cfg(any(feature = "bevy_pbr", feature = "bevy_sprite_render"))]
             bevy_gizmos::config::GizmoMeshConfig {

--- a/crates/bevy_render/src/globals.rs
+++ b/crates/bevy_render/src/globals.rs
@@ -52,7 +52,7 @@ pub struct GlobalsUniform {
     frame_count: u32,
     /// WebGL2 structs must be 16 byte aligned.
     #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
-    _wasm_padding: f32,
+    _webgl2_padding: f32,
 }
 
 /// The buffer containing the [`GlobalsUniform`]


### PR DESCRIPTION
# Objective

- correct some names to specify webgl2 instead of wasm (webgpu does not require this alignment)
- correct feature gates to only add the padding to structs on webgl2 and not webgpu
- correct feature gates to only set SIXTEEN_BYTE_ALIGNMENT shader def on webgl2 and not webgpu

## Solution

- do it

## Testing

- untested