### PR TITLE
derive Reflect on FpsOverlayConfig and FrameTimeGraphConfig

### DIFF
--- a/crates/bevy_dev_tools/src/fps_overlay.rs
+++ b/crates/bevy_dev_tools/src/fps_overlay.rs
@@ -8,11 +8,13 @@ use bevy_ecs::{
     component::Component,
     entity::Entity,
     query::{With, Without},
+    reflect::ReflectResource,
     resource::Resource,
     schedule::{common_conditions::resource_changed, IntoScheduleConfigs},
     system::{Commands, Query, Res, ResMut, Single},
 };
 use bevy_picking::Pickable;
+use bevy_reflect::Reflect;
 use bevy_render::storage::ShaderStorageBuffer;
 use bevy_text::{TextColor, TextFont, TextSpan};
 use bevy_time::common_conditions::on_timer;
@@ -87,7 +89,8 @@ impl Plugin for FpsOverlayPlugin {
 }
 
 /// Configuration options for the FPS overlay.
-#[derive(Resource, Clone)]
+#[derive(Resource, Clone, Reflect)]
+#[reflect(Resource)]
 pub struct FpsOverlayConfig {
     /// Configuration of text in the overlay.
     pub text_config: TextFont,
@@ -117,7 +120,7 @@ impl Default for FpsOverlayConfig {
 }
 
 /// Configuration of the frame time graph
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Reflect)]
 pub struct FrameTimeGraphConfig {
     /// Is the graph visible
     pub enabled: bool,


### PR DESCRIPTION
## Summary

Derives `Reflect` on `FpsOverlayConfig` and `FrameTimeGraphConfig` to enable runtime reflection capabilities for these configuration structs.
For example, allows modifying the config in bevy inspector egui.

## Changes

- Added `Reflect` derive to `FpsOverlayConfig` with `#[reflect(Resource)]` attribute
- Added `Reflect` derive to `FrameTimeGraphConfig` (required since it's a field in `FpsOverlayConfig`)
- Added `use bevy_reflect::Reflect;` import