### PR TITLE
Fix typo in doc comment [minor]

### DIFF
--- a/crates/bevy_camera_controller/src/pan_camera.rs
+++ b/crates/bevy_camera_controller/src/pan_camera.rs
@@ -81,7 +81,7 @@ pub struct PanCamera {
 /// - Pan speed: 500.0
 /// - Move up/down: W/S
 /// - Move left/right: A/D
-/// - Rotation speed: PI (radiradians per second)
+/// - Rotation speed: PI (radians per second)
 /// - Rotation ccw/cw: Q/E
 impl Default for PanCamera {
     /// Provides the default values for the `PanCamera` controller.


### PR DESCRIPTION

# Objective

- typo: "radiradians" instead of "radians"

## Solution

- Describe the solution used to achieve the objective above.

## Testing

- no testing needed, just a modified doc comment
 
