### PR TITLE
Fix copy-pasting mistake in extended material bindless example

### DIFF
--- a/examples/shader/extended_material_bindless.rs
+++ b/examples/shader/extended_material_bindless.rs
@@ -24,8 +24,7 @@ static SHADER_ASSET_PATH: &str = "shaders/extended_material_bindless.wgsl";
 /// The `#[data(50, ExampleBindlessExtensionUniform, binding_array(101))]`
 /// attribute specifies that the plain old data
 /// [`ExampleBindlessExtensionUniform`] will be placed into an array with
-/// binding 101 and will occupy index 50 in the
-/// `ExampleBindlessExtendedMaterialIndices` structure. (See the shader for the
+/// binding 101 and that the index referencing it will be stored in slot 50 of the `ExampleBindlessExtendedMaterialIndices` structure. (See below or lookup the shader for the
 /// definition of that structure.) That corresponds to the following shader
 /// declaration:
 ///


### PR DESCRIPTION
# Objective

- The docs are a bit weird, which is probably due to someone at some point accidentally copy-pasting the wgsl correspondence code

## Solution

- Write the actual code
- Also use our fancy `#{MATERIAL_BIND_GROUP}` in the docs, given that it's used in the shader :)
- Split the line a liiiiittle bit differently

## Testing

- None, just docs. Well, I did make sure that the stuff in the docs is the same as in the shader!
