### PR TITLE
Improve macro hygiene of `children!` by re-defining it in terms of `related!`

### DIFF
--- a/crates/bevy_ecs/src/hierarchy.rs
+++ b/crates/bevy_ecs/src/hierarchy.rs
@@ -537,7 +537,6 @@ pub fn validate_parent_has_component<C: Component>(
 /// # use bevy_ecs::name::Name;
 /// # use bevy_ecs::world::World;
 /// # use bevy_ecs::children;
-/// # use bevy_ecs::spawn::{Spawn, SpawnRelated};
 /// let mut world = World::new();
 /// world.spawn((
 ///     Name::new("Root"),
@@ -557,7 +556,7 @@ pub fn validate_parent_has_component<C: Component>(
 #[macro_export]
 macro_rules! children {
     [$($child:expr),*$(,)?] => {
-       $crate::hierarchy::Children::spawn($crate::recursive_spawn!($($child),*))
+        $crate::related!($crate::hierarchy::Children [$($child),*])
     };
 }
 

--- a/crates/bevy_feathers/src/controls/color_plane.rs
+++ b/crates/bevy_feathers/src/controls/color_plane.rs
@@ -9,7 +9,6 @@ use bevy_ecs::{
     observer::On,
     query::{Changed, Has, Or, With},
     reflect::ReflectComponent,
-    spawn::SpawnRelated,
     system::{Commands, Query, Res, ResMut},
 };
 use bevy_math::{Vec2, Vec3};

--- a/crates/bevy_feathers/src/controls/color_slider.rs
+++ b/crates/bevy_feathers/src/controls/color_slider.rs
@@ -11,7 +11,6 @@ use bevy_ecs::{
     hierarchy::Children,
     query::{Changed, Or, With},
     schedule::IntoScheduleConfigs,
-    spawn::SpawnRelated,
     system::Query,
 };
 use bevy_input_focus::tab_navigation::TabIndex;

--- a/crates/bevy_feathers/src/controls/color_swatch.rs
+++ b/crates/bevy_feathers/src/controls/color_swatch.rs
@@ -8,7 +8,6 @@ use bevy_ecs::{
     hierarchy::Children,
     query::Changed,
     reflect::ReflectComponent,
-    spawn::SpawnRelated,
     system::{Commands, Query},
 };
 use bevy_reflect::{prelude::ReflectDefault, Reflect};

--- a/crates/bevy_feathers/src/controls/slider.rs
+++ b/crates/bevy_feathers/src/controls/slider.rs
@@ -12,7 +12,6 @@ use bevy_ecs::{
     query::{Added, Changed, Has, Or, Spawned, With},
     reflect::ReflectComponent,
     schedule::IntoScheduleConfigs,
-    spawn::SpawnRelated,
     system::{Commands, Query, Res},
 };
 use bevy_input_focus::tab_navigation::TabIndex;

--- a/crates/bevy_feathers/src/controls/toggle_switch.rs
+++ b/crates/bevy_feathers/src/controls/toggle_switch.rs
@@ -11,7 +11,6 @@ use bevy_ecs::{
     query::{Added, Changed, Has, Or, With},
     reflect::ReflectComponent,
     schedule::IntoScheduleConfigs,
-    spawn::SpawnRelated,
     system::{Commands, Query},
     world::Mut,
 };


### PR DESCRIPTION
# Objective

Same deal as #22331 but for the `children!` macro.

## Solution

Make `children!`  delegate to `related!` in order to:
- Remove the need to import `SpawnRelated` when using it.
- Reduce code duplication.
- Make `children!` look less special-cased (it's just `related!` with a bevy-provided relation type).

## Testing

Removed imports of `SpawnRelated` where it's no longer needed, to prove it works.