### PR TITLE
Update BRP method names in code examples

### DIFF
--- a/crates/bevy_remote/src/lib.rs
+++ b/crates/bevy_remote/src/lib.rs
@@ -160,7 +160,7 @@
 //! ```json
 //! {
 //!     "jsonrpc": "2.0",
-//!     "method": "bevy/query",
+//!     "method": "world.query",
 //!     "id": 0,
 //!     "params": {
 //!         "data": {
@@ -182,7 +182,7 @@
 //! ```json
 //! {
 //!     "jsonrpc": "2.0",
-//!     "method": "bevy/query",
+//!     "method": "world.query",
 //!     "id": 0,
 //!     "params": {
 //!         "data": {


### PR DESCRIPTION
Fixes #22385

I searched for all the old methods listed in commit 3517af235ab1b132b4a63e0a4ce024cfe377a123. The `bevy/query` method was still being used in two JSON example blocks, while it was updated to `world.query`. This PR fixes that. I found no instances of the other old methods being used.
