### PR TITLE
Remove system fonts test code from the `text` example.

### DIFF
--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -7,7 +7,7 @@ use bevy::{
     color::palettes::css::GOLD,
     diagnostic::{DiagnosticsStore, FrameTimeDiagnosticsPlugin},
     prelude::*,
-    text::{CosmicFontSystem, FontFeatureTag, FontFeatures, Underline},
+    text::{FontFeatureTag, FontFeatures, Underline},
 };
 
 fn main() {
@@ -15,10 +15,6 @@ fn main() {
     app.add_plugins((DefaultPlugins, FrameTimeDiagnosticsPlugin::default()))
         .add_systems(Startup, setup)
         .add_systems(Update, (text_update_system, text_color_system));
-
-    let mut f = app.world_mut().resource_mut::<CosmicFontSystem>();
-    f.db_mut().load_system_fonts();
-
     app.run();
 }
 
@@ -40,7 +36,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         Underline,
         TextFont {
             // This font is loaded and will be used instead of the default font.
-            font: "Comic Sans MS".into(),
+            font: asset_server.load("fonts/FiraSans-Bold.ttf").into(),
             font_size: 67.0,
             ..default()
         },


### PR DESCRIPTION
# Objective

Included some naive test code for system fonts in the `text` example in #22156 by mistake.

## Solution

Revert the changes to the example.