### PR TITLE
Document that `configure_schedules()` only applies to currently existing schedules.

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1225,6 +1225,9 @@ impl App {
     }
 
     /// Applies the provided [`ScheduleBuildSettings`] to all schedules.
+    ///
+    /// This mutates all currently present schedules, but does not apply to any custom schedules
+    /// that might be added in the future.
     pub fn configure_schedules(
         &mut self,
         schedule_build_settings: ScheduleBuildSettings,

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -133,6 +133,9 @@ impl Schedules {
     }
 
     /// Applies the provided [`ScheduleBuildSettings`] to all schedules.
+    ///
+    /// This mutates all currently present schedules, but does not apply to schedules added
+    /// in the future.
     pub fn configure_schedules(&mut self, schedule_build_settings: ScheduleBuildSettings) {
         for (_, schedule) in &mut self.inner {
             schedule.set_build_settings(schedule_build_settings.clone());


### PR DESCRIPTION
# Objective

Clarify how to use the `configure_schedules()` function. The existing documentation confused me, because I thought that

```rust
let world = World::new();
...
schedules.configure_schedules(...);
schedules.add_systems(...);
```

would have an effect instead of having no effect.

## Solution

Add documentation to `configure_schedules()` functions, specifying that they only mutate existing schedules.

## Testing

`cargo doc --open`

<img width="679" height="216" alt="Screenshot 2026-01-05 at 12 37 01" src="https://github.com/user-attachments/assets/ba168507-c3eb-42b7-adfb-a54a4fe3fbae" />

