### PR TITLE
Remove the `Component` derive from `FontSource`.

### DIFF
--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -246,7 +246,7 @@ impl From<Justify> for cosmic_text::Align {
     }
 }
 
-#[derive(Component, Clone, Debug, Reflect, PartialEq)]
+#[derive(Clone, Debug, Reflect, PartialEq)]
 /// Specifies how the font face for a text span is sourced.
 ///
 /// A `FontSource` can either reference a font asset or identify a font by family name to be


### PR DESCRIPTION
# Objective

`FontSource` is not a `Component`, the derive is misleading.

## Solution

Remove the `Component` derive from `FontSource`.