### PR TITLE
Fix: "The build mesh uniforms pipeline wasn't ready” warning now fires only once

### DIFF
--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -42,6 +42,7 @@ bevy_derive = { path = "../bevy_derive", version = "0.18.0-dev" }
 bevy_diagnostic = { path = "../bevy_diagnostic", version = "0.18.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.18.0-dev" }
 bevy_light = { path = "../bevy_light", version = "0.18.0-dev" }
+bevy_log = { path = "../bevy_log", version = "0.18.0-dev" }
 bevy_image = { path = "../bevy_image", version = "0.18.0-dev" }
 bevy_mesh = { path = "../bevy_mesh", version = "0.18.0-dev", features = [
   "morph",

--- a/crates/bevy_pbr/src/render/gpu_preprocess.rs
+++ b/crates/bevy_pbr/src/render/gpu_preprocess.rs
@@ -26,6 +26,7 @@ use bevy_ecs::{
     system::{lifetimeless::Read, Commands, Query, Res, ResMut},
     world::{FromWorld, World},
 };
+use bevy_log::warn_once;
 use bevy_render::{
     batching::gpu_preprocessing::{
         BatchedInstanceBuffers, GpuOcclusionCullingWorkItemBuffers, GpuPreprocessingMode,
@@ -52,7 +53,7 @@ use bevy_render::{
     Render, RenderApp, RenderSystems,
 };
 use bevy_shader::Shader;
-use bevy_utils::{default, once, TypeIdMap};
+use bevy_utils::{default, TypeIdMap};
 use bitflags::bitflags;
 use smallvec::{smallvec, SmallVec};
 use tracing::warn;
@@ -838,7 +839,7 @@ impl Node for LateGpuPreprocessNode {
 
         // Fetch the pipeline.
         let Some(preprocess_pipeline_id) = maybe_pipeline_id else {
-            once!(warn!("The build mesh uniforms pipeline wasn't ready"));
+            warn_once!("The build mesh uniforms pipeline wasn't ready");
             return Ok(());
         };
 


### PR DESCRIPTION
# Objective

- Fixes #22358 

## Solution

- Use `warn_once` for the log message (and add `bevy_log` as a dependency for `bevy_pbr`)

## Testing

I added `main.rs` in the reproduction repo https://github.com/logankaser/bevy-uniforms-pipeline-repro/blob/main/src/main.rs as an example file in the main `bevy` repo and ran it with `bevy run --example repro --features=bevy_camera,bevy_core_pipeline,bevy_log,bevy_pbr,bevy_render,bevy_window,bevy_winit,webgpu web --open`.

I opened up the app in Chrome and verified in the console log that the warning only fires once

<details>
<summary>screenshots of console logs</summary>
In google chrome beforehand, you see the spam in the console:
<img width="705" height="285" alt="Screenshot 2026-01-05 at 10 04 57 PM" src="https://github.com/user-attachments/assets/7fe4cb1c-2df3-4d3b-a80d-4dfdaf2efb68" />

After the change, it just warns once:
<img width="728" height="62" alt="Screenshot 2026-01-06 at 12 06 14 AM" src="https://github.com/user-attachments/assets/c269f10e-1a7f-4daf-a8c8-dc812895eb68" />

</details>