### PR TITLE
 Directional navigation now considers UiTransform rotation

### DIFF
--- a/crates/bevy_input_focus/src/directional_navigation.rs
+++ b/crates/bevy_input_focus/src/directional_navigation.rs
@@ -307,6 +307,7 @@ impl DirectionalNavigationMap {
         self.neighbors.get(&entity)
     }
 }
+
 /// A system parameter for navigating between focusable entities in a directional way.
 #[derive(SystemParam, Debug)]
 pub struct DirectionalNavigation<'w> {

--- a/crates/bevy_ui/src/auto_directional_navigation.rs
+++ b/crates/bevy_ui/src/auto_directional_navigation.rs
@@ -16,17 +16,7 @@ use bevy_input_focus::{
 };
 
 use bevy_reflect::{prelude::*, Reflect};
-fn get_rotated_bounds(size: Vec2, rotation: f32) -> Vec2 {
-    if rotation == 0.0 {
-        return size;
-    }
-    let cos_r = ops::cos(rotation).abs();
-    let sin_r = ops::sin(rotation).abs();
-    Vec2::new(
-        size.x * cos_r + size.y * sin_r,
-        size.x * sin_r + size.y * cos_r,
-    )
-}
+
 /// Marker component to enable automatic directional navigation to and from the entity.
 ///
 /// Simply add this component to your UI entities so that the navigation algorithm will
@@ -111,7 +101,6 @@ pub struct AutoDirectionalNavigation {
 /// To use, the [`DirectionalNavigationPlugin`](bevy_input_focus::directional_navigation::DirectionalNavigationPlugin)
 /// must be added to the app.
 #[derive(SystemParam, Debug)]
-
 pub struct AutoDirectionalNavigator<'w, 's> {
     /// A system parameter for the manual directional navigation system provided by `bevy_input_focus`
     pub manual_directional_navigation: DirectionalNavigation<'w>,
@@ -241,4 +230,16 @@ impl<'w, 's> AutoDirectionalNavigator<'w, 's> {
             },
         )
     }
+}
+
+fn get_rotated_bounds(size: Vec2, rotation: f32) -> Vec2 {
+    if rotation == 0.0 {
+        return size;
+    }
+    let cos_r = ops::cos(rotation).abs();
+    let sin_r = ops::sin(rotation).abs();
+    Vec2::new(
+        size.x * cos_r + size.y * sin_r,
+        size.x * sin_r + size.y * cos_r,
+    )
 }


### PR DESCRIPTION
# Objective
Fixes #22234
The directional navigation system was ignoring `UiTransform` rotation and scaling when calculating which node to navigate to. This caused navigation to select incorrect nodes when they were rotated or scaled, because the system used unrotated layout positions instead of the visual positions seen by users.

## Solution
- Added `get_rotated_bounds()` helper function to calculate the axis-aligned bounding box of a rotated rectangle
- Updated `get_navigable_nodes()` to apply both rotation and scale transforms from `UiGlobalTransform` when creating `FocusableArea` structs
- Updated `entity_to_camera_and_focusable_area()` to apply rotation and scale transforms
- Used `bevy_math::ops` instead of `f32` methods for deterministic trigonometry

The fix ensures that directional navigation uses the visual position of nodes (after transforms) rather than just the layout position, so users navigate to the button they actually see on screen.

## Testing
- Tested with `auto_directional_navigation` example - navigation works correctly with scattered button layouts 

![Screencast From 2026-01-06 11-37-04](https://github.com/user-attachments/assets/fcaf5d24-f337-4f2d-b1e9-c08651bd9d97)



