### PR TITLE
Reduce aliasing and Moiré patterns in temporal shadow filtering

### DIFF
--- a/crates/bevy_pbr/src/render/pbr_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_functions.wgsl
@@ -420,7 +420,7 @@ fn apply_pbr_lighting(
         var shadow: f32 = 1.0;
         if ((in.flags & MESH_FLAGS_SHADOW_RECEIVER_BIT) != 0u
                 && (view_bindings::clusterable_objects.data[light_id].flags & mesh_view_types::POINT_LIGHT_FLAGS_SHADOWS_ENABLED_BIT) != 0u) {
-            shadow = shadows::fetch_point_shadow(light_id, in.world_position, in.world_normal);
+            shadow = shadows::fetch_point_shadow(light_id, in.world_position, in.world_normal, in.frag_coord.xy);
         }
 
         let light_contrib = lighting::point_light(light_id, &lighting_input, enable_diffuse, true);
@@ -439,7 +439,7 @@ fn apply_pbr_lighting(
         var transmitted_shadow: f32 = 1.0;
         if ((in.flags & (MESH_FLAGS_SHADOW_RECEIVER_BIT | MESH_FLAGS_TRANSMITTED_SHADOW_RECEIVER_BIT)) == (MESH_FLAGS_SHADOW_RECEIVER_BIT | MESH_FLAGS_TRANSMITTED_SHADOW_RECEIVER_BIT)
                 && (view_bindings::clusterable_objects.data[light_id].flags & mesh_view_types::POINT_LIGHT_FLAGS_SHADOWS_ENABLED_BIT) != 0u) {
-            transmitted_shadow = shadows::fetch_point_shadow(light_id, diffuse_transmissive_lobe_world_position, -in.world_normal);
+            transmitted_shadow = shadows::fetch_point_shadow(light_id, diffuse_transmissive_lobe_world_position, -in.world_normal, in.frag_coord.xy);
         }
 
         let transmitted_light_contrib =
@@ -473,6 +473,7 @@ fn apply_pbr_lighting(
                 in.world_position,
                 in.world_normal,
                 view_bindings::clusterable_objects.data[light_id].shadow_map_near_z,
+                in.frag_coord.xy,
             );
         }
 
@@ -497,6 +498,7 @@ fn apply_pbr_lighting(
                 diffuse_transmissive_lobe_world_position,
                 -in.world_normal,
                 view_bindings::clusterable_objects.data[light_id].shadow_map_near_z,
+                in.frag_coord.xy,
             );
         }
 
@@ -527,7 +529,7 @@ fn apply_pbr_lighting(
         var shadow: f32 = 1.0;
         if ((in.flags & MESH_FLAGS_SHADOW_RECEIVER_BIT) != 0u
                 && (view_bindings::lights.directional_lights[i].flags & mesh_view_types::DIRECTIONAL_LIGHT_FLAGS_SHADOWS_ENABLED_BIT) != 0u) {
-            shadow = shadows::fetch_directional_shadow(i, in.world_position, in.world_normal, view_z);
+            shadow = shadows::fetch_directional_shadow(i, in.world_position, in.world_normal, view_z, in.frag_coord.xy);
         }
 
         var light_contrib = lighting::directional_light(i, &lighting_input, enable_diffuse);
@@ -550,7 +552,7 @@ fn apply_pbr_lighting(
         var transmitted_shadow: f32 = 1.0;
         if ((in.flags & (MESH_FLAGS_SHADOW_RECEIVER_BIT | MESH_FLAGS_TRANSMITTED_SHADOW_RECEIVER_BIT)) == (MESH_FLAGS_SHADOW_RECEIVER_BIT | MESH_FLAGS_TRANSMITTED_SHADOW_RECEIVER_BIT)
                 && (view_bindings::lights.directional_lights[i].flags & mesh_view_types::DIRECTIONAL_LIGHT_FLAGS_SHADOWS_ENABLED_BIT) != 0u) {
-            transmitted_shadow = shadows::fetch_directional_shadow(i, diffuse_transmissive_lobe_world_position, -in.world_normal, view_z);
+            transmitted_shadow = shadows::fetch_directional_shadow(i, diffuse_transmissive_lobe_world_position, -in.world_normal, view_z, in.frag_coord.xy);
         }
 
         let transmitted_light_contrib =
@@ -613,7 +615,7 @@ fn apply_pbr_lighting(
 #else   // SCREEN_SPACE_REFLECTIONS
     let use_ssr = false;
 #endif  // SCREEN_SPACE_REFLECTIONS
-    
+
     if (!use_ssr) {
 #ifdef STANDARD_MATERIAL_ANISOTROPY
         var bent_normal_lighting_input = lighting_input;
@@ -781,7 +783,7 @@ fn apply_fog(fog_params: mesh_view_types::Fog, input_color: vec4<f32>, fragment_
         let view_to_world_normalized = view_to_world / distance;
         let n_directional_lights = view_bindings::lights.n_directional_lights;
         for (var i: u32 = 0u; i < n_directional_lights; i = i + 1u) {
-            let light = view_bindings::lights.directional_lights[i];            
+            let light = view_bindings::lights.directional_lights[i];
             let scattering_contribution = pow(
                 max(
                     dot(view_to_world_normalized, light.direction_to_light),
@@ -793,7 +795,7 @@ fn apply_fog(fog_params: mesh_view_types::Fog, input_color: vec4<f32>, fragment_
             // Sample shadow map to attenuate inscattering in shadowed areas
             var shadow: f32 = 1.0;
             if ((light.flags & mesh_view_types::DIRECTIONAL_LIGHT_FLAGS_SHADOWS_ENABLED_BIT) != 0u) {
-                shadow = shadows::fetch_directional_shadow(i, fragment_world_position_vec4, view_direction_normal, view_z);
+                shadow = shadows::fetch_directional_shadow(i, fragment_world_position_vec4, view_direction_normal, view_z, in.frag_coord.xy);
             }
             scattering += scattering_contribution * shadow;
         }

--- a/crates/bevy_pbr/src/render/shadows.wgsl
+++ b/crates/bevy_pbr/src/render/shadows.wgsl
@@ -16,7 +16,12 @@
 
 const flip_z: vec3<f32> = vec3<f32>(1.0, 1.0, -1.0);
 
-fn fetch_point_shadow(light_id: u32, frag_position: vec4<f32>, surface_normal: vec3<f32>) -> f32 {
+fn fetch_point_shadow(
+    light_id: u32,
+    frag_position: vec4<f32>,
+    surface_normal: vec3<f32>,
+    frag_coord_xy: vec2<f32>,
+) -> f32 {
     let light = &view_bindings::clusterable_objects.data[light_id];
 
     // because the shadow maps align with the axes and the frustum planes are at 45 degrees
@@ -54,12 +59,13 @@ fn fetch_point_shadow(light_id: u32, frag_position: vec4<f32>, surface_normal: v
             depth,
             light_id,
             (*light).soft_shadow_size,
+            frag_coord_xy,
         );
     }
 
     // Do the lookup, using HW PCF and comparison. Cubemaps assume a left-handed
     // coordinate space, so we have to flip the z-axis when sampling.
-    return sample_shadow_cubemap(frag_ls * flip_z, distance_to_light, depth, light_id);
+    return sample_shadow_cubemap(frag_ls * flip_z, distance_to_light, depth, light_id, frag_coord_xy);
 }
 
 fn fetch_spot_shadow(
@@ -67,6 +73,7 @@ fn fetch_spot_shadow(
     frag_position: vec4<f32>,
     surface_normal: vec3<f32>,
     near_z: f32,
+    frag_coord_xy: vec2<f32>,
 ) -> f32 {
     let light = &view_bindings::clusterable_objects.data[light_id];
 
@@ -108,10 +115,22 @@ fn fetch_spot_shadow(
     let array_index = i32(light_id) + view_bindings::lights.spot_light_shadowmap_offset;
     if ((*light).soft_shadow_size > 0.0) {
         return sample_shadow_map_pcss(
-            shadow_uv, depth, array_index, SPOT_SHADOW_TEXEL_SIZE, (*light).soft_shadow_size);
+            shadow_uv,
+            depth,
+            array_index,
+            frag_coord_xy,
+            SPOT_SHADOW_TEXEL_SIZE,
+            (*light).soft_shadow_size,
+        );
     }
 
-    return sample_shadow_map(shadow_uv, depth, array_index, SPOT_SHADOW_TEXEL_SIZE);
+    return sample_shadow_map(
+        shadow_uv,
+        depth,
+        array_index,
+        frag_coord_xy,
+        SPOT_SHADOW_TEXEL_SIZE,
+    );
 }
 
 fn get_cascade_index(light_id: u32, view_z: f32) -> u32 {
@@ -163,6 +182,7 @@ fn sample_directional_cascade(
     cascade_index: u32,
     frag_position: vec4<f32>,
     surface_normal: vec3<f32>,
+    frag_coord_xy: vec2<f32>,
 ) -> f32 {
     let light = &view_bindings::lights.directional_lights[light_id];
     let cascade = &(*light).cascades[cascade_index];
@@ -183,13 +203,31 @@ fn sample_directional_cascade(
     // If soft shadows are enabled, use the PCSS path.
     if ((*light).soft_shadow_size > 0.0) {
         return sample_shadow_map_pcss(
-            light_local.xy, light_local.z, array_index, texel_size, (*light).soft_shadow_size);
+            light_local.xy,
+            light_local.z,
+            array_index,
+            frag_coord_xy,
+            texel_size,
+            (*light).soft_shadow_size,
+        );
     }
 
-    return sample_shadow_map(light_local.xy, light_local.z, array_index, texel_size);
+    return sample_shadow_map(
+        light_local.xy,
+        light_local.z,
+        array_index,
+        frag_coord_xy,
+        texel_size,
+    );
 }
 
-fn fetch_directional_shadow(light_id: u32, frag_position: vec4<f32>, surface_normal: vec3<f32>, view_z: f32) -> f32 {
+fn fetch_directional_shadow(
+    light_id: u32,
+    frag_position: vec4<f32>,
+    surface_normal: vec3<f32>,
+    view_z: f32,
+    frag_coord_xy: vec2<f32>,
+) -> f32 {
     let light = &view_bindings::lights.directional_lights[light_id];
     let cascade_index = get_cascade_index(light_id, view_z);
 
@@ -197,7 +235,13 @@ fn fetch_directional_shadow(light_id: u32, frag_position: vec4<f32>, surface_nor
         return 1.0;
     }
 
-    var shadow = sample_directional_cascade(light_id, cascade_index, frag_position, surface_normal);
+    var shadow = sample_directional_cascade(
+        light_id,
+        cascade_index,
+        frag_position,
+        surface_normal,
+        frag_coord_xy,
+    );
 
     // Blend with the next cascade, if there is one.
     let next_cascade_index = cascade_index + 1u;
@@ -205,7 +249,13 @@ fn fetch_directional_shadow(light_id: u32, frag_position: vec4<f32>, surface_nor
         let this_far_bound = (*light).cascades[cascade_index].far_bound;
         let next_near_bound = (1.0 - (*light).cascades_overlap_proportion) * this_far_bound;
         if (-view_z >= next_near_bound) {
-            let next_shadow = sample_directional_cascade(light_id, next_cascade_index, frag_position, surface_normal);
+            let next_shadow = sample_directional_cascade(
+                light_id,
+                next_cascade_index,
+                frag_position,
+                surface_normal,
+                frag_coord_xy,
+            );
             shadow = mix(shadow, next_shadow, (-view_z - next_near_bound) / (this_far_bound - next_near_bound));
         }
     }


### PR DESCRIPTION
# Objective

- Reduce aliasing and Moiré patterns in temporal shadow filtering

## Solution

- Use interleaved gradient noise based on screen UV not light local UV

NOTE: It only affects **`ShadowFilteringMethod::Temporal` or non-temporal PCSS**

## Testing

Tested with `pcss` and `shadow_biases` examples. The latter was more useful - see showcase section.

NOTE: It only affects **`ShadowFilteringMethod::Temporal` or non-temporal PCSS**

However, this touches more code paths and all combinations need testing:
- Light types:
  - Point
  - Spot
  - Directional
- Shadow mapping
- Soft shadows (PCSS)
- Transmission
- Distance fog

---

## Showcase

`main`:
<img width="1392" height="860" alt="Screenshot 2026-01-06 at 01 12 48" src="https://github.com/user-attachments/assets/abcc38ab-baa8-434d-8280-b35698c2c030" />

`PR`:
<img width="1392" height="860" alt="Screenshot 2026-01-06 at 01 12 26" src="https://github.com/user-attachments/assets/b09d36ed-a7e1-455b-bd69-2b477c94b5bd" />

It also makes the full temporal mode where the noise patterns change each frame look much better, especially with TAA enabled. That is however a bit difficult to illustrate due to the animation aspect.