### PR TITLE
Remove `Strikethrough` from the `text` example

### DIFF
--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -40,7 +40,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             font_size: 67.0,
             ..default()
         },
-        Strikethrough,
         TextShadow::default(),
         // Set the justification of the Text
         TextLayout::new_with_justify(Justify::Center),


### PR DESCRIPTION
# Objective

Remove  the `Strikethrough` from the "hello bevy" message in the `text` example. Should only be underlined.
