### PR TITLE
Derive `PartialEq` for `InputFocus`

### DIFF
--- a/crates/bevy_input_focus/src/lib.rs
+++ b/crates/bevy_input_focus/src/lib.rs
@@ -85,7 +85,7 @@ use bevy_reflect::{prelude::*, Reflect};
 ///     world.insert_resource(InputFocus::from_entity(entity));
 /// }
 /// ```
-#[derive(Clone, Debug, Default, Resource)]
+#[derive(Clone, Debug, Default, Resource, PartialEq)]
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(Reflect),


### PR DESCRIPTION
# Objective

- Right now you can't do the the following:
```rust
focus.set_if_neq(InputFocus(Some(trigger.entity)));
```

## Solution

- Derive `PartialEq` for `InputFocus`