### PR TITLE
Update the doc link for Clone Behaviors section of `EntityCloner`

### DIFF
--- a/crates/bevy_ecs/src/component/mod.rs
+++ b/crates/bevy_ecs/src/component/mod.rs
@@ -433,7 +433,7 @@ use core::{fmt::Debug, marker::PhantomData, ops::Deref};
 /// You can specify how the [`Component`] is cloned when deriving it.
 ///
 /// Your options are the functions and variants of [`ComponentCloneBehavior`]
-/// See [Handlers section of `EntityClonerBuilder`](crate::entity::EntityClonerBuilder#handlers) to understand how this affects handler priority.
+/// See [Clone Behaviors section of `EntityCloner`](crate::entity::EntityCloner#clone-behaviors) to understand how this affects handler priority.
 /// ```
 /// # use bevy_ecs::prelude::*;
 ///
@@ -556,7 +556,7 @@ pub trait Component: Send + Sync + 'static {
 
     /// Called when registering this component, allowing to override clone function (or disable cloning altogether) for this component.
     ///
-    /// See [Handlers section of `EntityClonerBuilder`](crate::entity::EntityClonerBuilder#handlers) to understand how this affects handler priority.
+    /// See [Clone Behaviors section of `EntityCloner`](crate::entity::EntityCloner#clone-behaviors) to understand how this affects handler priority.
     #[inline]
     fn clone_behavior() -> ComponentCloneBehavior {
         ComponentCloneBehavior::Default

--- a/crates/bevy_ecs/src/entity/clone_entities.rs
+++ b/crates/bevy_ecs/src/entity/clone_entities.rs
@@ -836,7 +836,7 @@ impl<'w, Filter: CloneByFilter> EntityClonerBuilder<'w, Filter> {
     /// Overrides the [`ComponentCloneBehavior`] for a component in this builder.
     /// This handler will be used to clone the component instead of the global one defined by the [`EntityCloner`].
     ///
-    /// See [Handlers section of `EntityClonerBuilder`](EntityClonerBuilder#handlers) to understand how this affects handler priority.
+    /// See [Clone Behaviors section of `EntityCloner`](EntityCloner#clone-behaviors) to understand how this affects handler priority.
     pub fn override_clone_behavior<T: Component>(
         &mut self,
         clone_behavior: ComponentCloneBehavior,
@@ -852,7 +852,7 @@ impl<'w, Filter: CloneByFilter> EntityClonerBuilder<'w, Filter> {
     /// Overrides the [`ComponentCloneBehavior`] for a component with the given `component_id` in this builder.
     /// This handler will be used to clone the component instead of the global one defined by the [`EntityCloner`].
     ///
-    /// See [Handlers section of `EntityClonerBuilder`](EntityClonerBuilder#handlers) to understand how this affects handler priority.
+    /// See [Clone Behaviors section of `EntityCloner`](EntityCloner#clone-behaviors) to understand how this affects handler priority.
     pub fn override_clone_behavior_with_id(
         &mut self,
         component_id: ComponentId,


### PR DESCRIPTION
# Objective

Fixes #22302 

## Solution

Replace doc comments "[Handlers section of `EntityClonerBuilder`](crate::entity::EntityClonerBuilder#handlers)" with "[Clone Behaviors section of `EntityCloner`](crate::entity::EntityCloner#clone-behaviors)"

## Testing

Checked the updated document locally, now successfully points to the correct location
