### PR TITLE
docs: adds migration guide for Assets<Mesh> retaining render_world only meshes

### DIFF
--- a/release-content/migration-guides/assets_mesh_try_functions.md
+++ b/release-content/migration-guides/assets_mesh_try_functions.md
@@ -16,7 +16,7 @@ functions should be changed to their `try_*` equivalent and handled appropriatel
 
 ```rust
 // assets: Res<'w, Assets<Mesh>>
-let mesh = assets.get(some_mesh_handle) // or assets.get_mut(some_mesh_handle)
+let mesh = assets.get(some_mesh_handle).unwrap() // or assets.get_mut(some_mesh_handle).unwrap()
 
 // 0.17
 mesh.insert_attribute(...)


### PR DESCRIPTION
This is targeting `release-0.18.0`, NOT `main`!

# Objective

- Fixes #22206

## Solution

- Adds a migration guide for the changes in #21732. As someone not too familiar with mesh stuff, I’d appreciate a review from someone more familiar with the changes and mesh things!

FYI @robtfm @beicause 