### PR TITLE
Update `Combine` trait example to use `unwrap_or(false)`

### DIFF
--- a/crates/bevy_ecs/src/system/combinator.rs
+++ b/crates/bevy_ecs/src/system/combinator.rs
@@ -43,7 +43,7 @@ use super::{IntoSystem, ReadOnlySystem, RunSystemError, System};
 ///         a: impl FnOnce(A::In, &mut T) -> Result<A::Out, RunSystemError>,
 ///         b: impl FnOnce(B::In, &mut T) -> Result<B::Out, RunSystemError>,
 ///     ) -> Result<Self::Out, RunSystemError> {
-///         Ok(a((), data)? ^ b((), data)?)
+///         Ok(a((), data).unwrap_or(false) ^ b((), data).unwrap_or(false))
 ///     }
 /// }
 ///


### PR DESCRIPTION
# Objective

- Fixes #22363 

## Solution

- Replace `Ok(a((), data)? ^ b((), data)?)` with `Ok(a((), data).unwrap_or(false) ^ b((), data).unwrap_or(false))`

## Testing

- Doc test


