### PR TITLE
Allow reading the individual accesses of a `FilteredAccessSet`.

### DIFF
--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -1322,6 +1322,12 @@ impl FilteredAccessSet {
         &self.combined_access
     }
 
+    /// Returns a reference to the filtered accesses of the set.
+    #[inline]
+    pub fn filtered_accesses(&self) -> &[FilteredAccess] {
+        &self.filtered_accesses
+    }
+
     /// Returns `true` if this and `other` can be active at the same time.
     ///
     /// Access conflict resolution happen in two steps:


### PR DESCRIPTION
# Objective

- A `FilteredAccessSet` doesn't give access to the individual filters. This is sad for introspecting the access of systems (e.g., for visualizing systems in a schedule).

## Solution

- Add a getter for `filtered_accesses`.
