### PR TITLE
0.18: Fix markdown lint in `optional_asset_reader_seek.md` release note

### DIFF
--- a/release-content/release-notes/optional_asset_reader_seek.md
+++ b/release-content/release-notes/optional_asset_reader_seek.md
@@ -4,7 +4,7 @@ authors: ["@andriyDev", "@cart"]
 pull_requests: [22182]
 ---
 
-_TODO: This release note is not up to date with the changes in https://github.com/bevyengine/bevy/pull/22182._
+_TODO: This release note is not up to date with the changes in [#22182](https://github.com/bevyengine/bevy/pull/22182)._
 
 In Bevy 0.15, we replaced the `AsyncSeek` super trait on `Reader` with `AsyncSeekForward`. This
 allowed our `Reader` trait to apply to more cases (e.g., it could allow cases like an HTTP request,


### PR DESCRIPTION
Fix markdown lint that slipped into #22430.

I have not tested this locally - I'm relying on CI to verify.