### PR TITLE
Fix tilemap UV rounding error

### DIFF
--- a/crates/bevy_sprite_render/src/tilemap_chunk/tilemap_chunk_material.wgsl
+++ b/crates/bevy_sprite_render/src/tilemap_chunk/tilemap_chunk_material.wgsl
@@ -36,6 +36,7 @@ fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
     let chunk_size = textureDimensions(tile_data, 0);
     let tile_uv = in.uv * vec2<f32>(chunk_size);
     var tile_coord = clamp(vec2<u32>(floor(tile_uv)), vec2<u32>(0), chunk_size - 1);
+    let local_uv = tile_uv - vec2<f32>(tile_coord);
     tile_coord.y = chunk_size.y - 1 - tile_coord.y;
 
     let tile = get_tile_data(tile_coord);
@@ -44,7 +45,6 @@ fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
         discard;
     }
 
-    let local_uv = fract(tile_uv);
     let tex_color = textureSample(tileset, tileset_sampler, local_uv, tile.tileset_index);
     let final_color = tex_color * tile.color;
 


### PR DESCRIPTION
# Objective

Fixes #22250 

## Solution

Using `fract` in the shader produces the wrong value if the input uv is outside the range `0 .. 1`. Instead, subtract the already-calculated floor value to shift the uv into the correct range.

## Testing

The visible seams are gone in my own testing, and a user on discord reported that this worked for them as well.