### PR TITLE
[bevy_camera_controller] Implement customisable rotation system for camera movement

### DIFF
--- a/crates/bevy_camera_controller/src/free_camera.rs
+++ b/crates/bevy_camera_controller/src/free_camera.rs
@@ -28,8 +28,7 @@ use bevy_time::{Real, Time};
 use bevy_transform::prelude::Transform;
 use bevy_window::{CursorGrabMode, CursorOptions, Window};
 
-use core::{f32::consts::*, fmt};
-use std::cmp::PartialEq;
+use core::{cmp::PartialEq, f32::consts::*, fmt};
 
 /// A freecam-style camera controller plugin.
 ///


### PR DESCRIPTION
# Objective

- Add support for different movement coordinate systems in the `FreeCamera` controller.
- Fix an orientation issue where "forward" and "backward" key bindings were inverted relative to standard conventions.

## Solution

- **Introduced `RotationSystem` enum**: Added a configuration option to choose between two movement modes:
    - `YawPitchRoll` (Default): Movement is relative to the camera's full orientation. Looking up and moving forward moves you "up" in world space.
    - `Yaw`: Movement is constrained to the horizontal plane. Moving forward always keeps you at the same elevation, regardless of where the camera is looking.
- **Improved Movement Logic**: Refactored `run_freecamera_controller` to use a rotation-based translation instead of manually calculating forward/right vectors.
- **Fixed Inverted Z-Axis**: Corrected the forward/back input handling so that `key_forward` moves the camera along `-Z` and `key_back` moves it along `+Z`, aligning with standard right-handed coordinate systems used in Bevy.

## Testing

- **Manual Testing**: Verified both `RotationSystem` modes in a local scene. 
    - Confirmed that in `Yaw` mode, looking straight down and pressing "Forward" moves the camera horizontally.
    - Confirmed that in `YawPitchRoll` mode, looking straight down and pressing "Forward" moves the camera towards the ground.
- **Reviewer Testing**:
    - Attach a `FreeCamera` component to a camera or use the `free_camera_controller` example
    - Toggle `rotation_system` between `RotationSystem::Yaw` and `RotationSystem::YawPitchRoll` in the component initialization or via an inspector.
    - Verify that `W` moves you forward and `S` moves you backward.

---

## Showcase

This PR adds a new configuration option to the `FreeCamera` component to control movement behavior.

<details>
<summary>Click to view usage example</summary>

```rust
commands.spawn((
    Camera3dBundle::default(),
    FreeCamera {
        // Constrain movement to the floor regardless of look direction
        rotation_system: RotationSystem::Yaw,
        ..default()
    },
));
```


</details>