### PR TITLE
Improve error message for EntityNotSpawnedError - Main Branch

### DIFF
--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -1192,10 +1192,10 @@ impl fmt::Display for EntityValidButNotSpawnedError {
 #[derive(thiserror::Error, Copy, Clone, Debug, Eq, PartialEq)]
 pub enum EntityNotSpawnedError {
     /// The entity was invalid.
-    #[error("{0}")]
+    #[error("Entity despawned: {0}\nNote that interacting with a despawned entity is the most common cause of this error but there are others")]
     Invalid(#[from] InvalidEntityError),
     /// The entity was valid but was not spawned.
-    #[error("{0}")]
+    #[error("Entity not yet spawned: {0}\nNote that interacting with a not-yet-spawned entity is the most common cause of this error but there are others")]
     ValidButNotSpawned(#[from] EntityValidButNotSpawnedError),
 }
 


### PR DESCRIPTION
main branch version of #22444

The new `0.18` entity errors feel a bit 'inside baseball' for end-users, for instance interacting with a despawned entity makes no mention of the entity not being spawned:

```rust
let mut world = World::new();
let entity = world.spawn_empty().id();
world.entity_mut(entity).despawn();
world.entity(entity);

// Panic: The entity with ID 27v0 is invalid; its index now has generation 1.

```
Ideally I'd like to implement proper rust-style errors with a short paragraph detailing common causes and links to docs but thats a bigger discussion.

At least for `0.18` i think this very common error needs a prefix `Entity Not Spawned:`

- Before: `The entity with ID 27v0 is invalid; its index now has generation 1.`
- After: `Entity Not Spawned: The entity with ID 27v0 is invalid; its index now has generation 1.`