### PR TITLE
Add some methods and optimizations in buffer vec

### DIFF
--- a/crates/bevy_render/src/render_resource/buffer_vec.rs
+++ b/crates/bevy_render/src/render_resource/buffer_vec.rs
@@ -243,6 +243,7 @@ where
     T: NoUninit + Default,
 {
     pub fn grow_set(&mut self, index: u32, value: T) {
+        self.values.reserve(index as usize + 1);
         while index as usize + 1 > self.len() {
             self.values.push(T::default());
         }
@@ -345,6 +346,8 @@ where
         let element_size = u64::from(T::min_size()) as usize;
         let offset = self.data.len();
 
+        // `extend` does not optimize for reallocation. Related `trusted_len` feature is unstable.
+        self.data.reserve(self.data.len() + element_size);
         // TODO: Consider using unsafe code to push uninitialized, to prevent
         // the zeroing. It shows up in profiles.
         self.data.extend(iter::repeat_n(0, element_size));
@@ -375,6 +378,13 @@ where
     /// Returns the label
     pub fn get_label(&self) -> Option<&str> {
         self.label.as_deref()
+    }
+
+    /// Preallocates space for `count` elements in the internal CPU-side buffer.
+    ///
+    /// Unlike [`Self::reserve`], this doesn't have any effect on the GPU buffer.
+    pub fn reserve_internal(&mut self, count: usize) {
+        self.data.reserve(count * u64::from(T::min_size()) as usize);
     }
 
     /// Creates a [`Buffer`] on the [`RenderDevice`] with size
@@ -541,6 +551,31 @@ where
     /// Returns the length of the buffer.
     pub fn len(&self) -> usize {
         self.len
+    }
+
+    /// Returns the amount of space that the GPU will use before reallocating.
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Changes the debugging label of the buffer.
+    ///
+    /// The next time the buffer is updated (via [`Self::reserve`]), Bevy will inform
+    /// the driver of the new label.
+    pub fn set_label(&mut self, label: Option<&str>) {
+        let label = label.map(str::to_string);
+
+        if label != self.label {
+            self.label_changed = true;
+        }
+
+        self.label = label;
+    }
+
+    /// Returns the label
+    pub fn get_label(&self) -> Option<&str> {
+        self.label.as_deref()
     }
 
     /// Materializes the buffer on the GPU with space for `capacity` elements.


### PR DESCRIPTION
# Objective

`UninitBufferVec` is missing methods to get its capacity and set label. And `BufferVec` needs `reserve_internal` to reduce memory reallocation if element count is known.

Also there are two places that we can use `Vec::reserve` to preallocate memory.

## Solution

Add `reserve_internal` to `BufferVec`
Add `capacity` `set_label` `get_label` to `UninitBufferVec`
Use `Vec::reserve` to reduce some allocation

## Testing

CI