### PR TITLE
Expose current input focus from auto dir navigator for easier access

### DIFF
--- a/crates/bevy_ui/src/auto_directional_navigation.rs
+++ b/crates/bevy_ui/src/auto_directional_navigation.rs
@@ -136,7 +136,7 @@ pub struct AutoDirectionalNavigator<'w, 's> {
 impl<'w, 's> AutoDirectionalNavigator<'w, 's> {
     /// Returns the current input focus
     pub fn input_focus(&mut self) -> Option<Entity> {
-        return self.manual_directional_navigation.focus.0;
+        self.manual_directional_navigation.focus.0
     }
 
     /// Tries to find the neighbor in a given direction from the given entity. Assumes the entity is valid.


### PR DESCRIPTION
# Objective

- Make it easier for users to view the current focus from `AutoDirectionalNavigator` instead of having to go through the inner system parameter that stores the actual focus.

## Solution

- Adds a convenience method to `AutoDirectionalNavigator` called `input_focus` that returns it

## Testing

- `cargo run --example auto_directional_navigation` still works
