### PR TITLE
Add `FontSmoothing` to the `bevy_text` prelude

### DIFF
--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -60,9 +60,9 @@ pub use text_access::*;
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
-        Font, FontHinting, FontSource, FontStyle, FontWeight, FontWidth, Justify, LineBreak,
-        Strikethrough, StrikethroughColor, TextColor, TextError, TextFont, TextLayout, TextSpan,
-        Underline, UnderlineColor,
+        Font, FontHinting, FontSmoothing, FontSource, FontStyle, FontWeight, FontWidth, Justify,
+        LineBreak, Strikethrough, StrikethroughColor, TextColor, TextError, TextFont, TextLayout,
+        TextSpan, Underline, UnderlineColor,
     };
 }
 


### PR DESCRIPTION
# Objective

`FontSmoothing` isn't used that much, but it's part of the user-facing API and should be added to `bevy_text::prelude`.

## Solution

Add `FontSmoothing` to `bevy_text::prelude`.
