### PR TITLE
disable gltf extension examples in wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4503,7 +4503,7 @@ doc-scrape-examples = false
 name = "glTF extension AnimationGraph"
 description = "Uses glTF data to build an AnimationGraph via extension processing"
 category = "glTF"
-wasm = true
+wasm = false
 
 [[example]]
 name = "gltf_extension_mesh_2d"
@@ -4515,7 +4515,7 @@ doc-scrape-examples = false
 name = "glTF extension processing to build Mesh2ds from glTF data"
 description = "Uses glTF extension data to convert incoming Mesh3d/MeshMaterial3d assets to 2d"
 category = "glTF"
-wasm = true
+wasm = false
 
 [[example]]
 name = "query_gltf_primitives"


### PR DESCRIPTION
# Objective

- GLTF extension examples don't build in wasm

## Solution

- Don't build them in wasm

