### PR TITLE
Improve Debug names for SystemTypeSet.

### DIFF
--- a/crates/bevy_ecs/src/schedule/set.rs
+++ b/crates/bevy_ecs/src/schedule/set.rs
@@ -196,9 +196,7 @@ impl<T: 'static> SystemTypeSet<T> {
 
 impl<T> Debug for SystemTypeSet<T> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("SystemTypeSet")
-            .field(&format_args!("fn {}()", DebugName::type_name::<T>()))
-            .finish()
+        write!(f, "SystemTypeSet:{}", DebugName::type_name::<T>())
     }
 }
 

--- a/crates/bevy_ecs/src/schedule/set.rs
+++ b/crates/bevy_ecs/src/schedule/set.rs
@@ -14,8 +14,8 @@ use crate::{
     define_label,
     intern::Interned,
     system::{
-        ExclusiveFunctionSystem, ExclusiveSystemParamFunction, FromInput, FunctionSystem,
-        IntoResult, IsExclusiveFunctionSystem, IsFunctionSystem, SystemParamFunction,
+        ExclusiveSystemParamFunction, FromInput, IntoResult, IsExclusiveFunctionSystem,
+        IsFunctionSystem, SystemParamFunction,
     },
 };
 
@@ -293,11 +293,11 @@ where
     Marker: 'static,
     F: SystemParamFunction<Marker, In: FromInput<()>, Out: IntoResult<()>>,
 {
-    type Set = SystemTypeSet<FunctionSystem<Marker, (), (), F>>;
+    type Set = SystemTypeSet<F>;
 
     #[inline]
     fn into_system_set(self) -> Self::Set {
-        SystemTypeSet::<FunctionSystem<Marker, (), (), F>>::new()
+        SystemTypeSet::<F>::new()
     }
 }
 
@@ -308,11 +308,11 @@ where
     F::Out: IntoResult<()>,
     F: ExclusiveSystemParamFunction<Marker>,
 {
-    type Set = SystemTypeSet<ExclusiveFunctionSystem<Marker, (), F>>;
+    type Set = SystemTypeSet<F>;
 
     #[inline]
     fn into_system_set(self) -> Self::Set {
-        SystemTypeSet::<ExclusiveFunctionSystem<Marker, (), F>>::new()
+        SystemTypeSet::<F>::new()
     }
 }
 

--- a/crates/bevy_ecs/src/system/exclusive_function_system.rs
+++ b/crates/bevy_ecs/src/system/exclusive_function_system.rs
@@ -192,7 +192,7 @@ where
     }
 
     fn default_system_sets(&self) -> Vec<InternedSystemSet> {
-        let set = crate::schedule::SystemTypeSet::<Self>::new();
+        let set = crate::schedule::SystemTypeSet::<F>::new();
         vec![set.intern()]
     }
 

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -754,7 +754,7 @@ where
     }
 
     fn default_system_sets(&self) -> Vec<InternedSystemSet> {
-        let set = crate::schedule::SystemTypeSet::<Self>::new();
+        let set = crate::schedule::SystemTypeSet::<F>::new();
         vec![set.intern()]
     }
 


### PR DESCRIPTION
# Objective

- Debug names for `SystemTypeSet` are quite bad. For example, the system `fn a() {}` gets the `SystemTypeSet` `DebugName` of `SystemTypeSet(fn bevy_ecs::system::function_system::FunctionSystem<fn(), (), (), bevy_dev_tools::schedule_data::serde::tests::linear::a>())`. This includes an extraneous `FunctionSystem` which is only relevant for dealing with the lack of specialization in Rust, as well as extra In/Out args - even though the function dictates these.
- This is a step towards #10981.

## Solution

- Make `SystemTypeSet` store the function, not the wrapper (e.g., `FunctionSystem`). This should be safe since, a system can only ever have one of either `FunctionSystem` or `ExclusiveFunctionSystem` - either way, this implementation is unique so `SystemTypeSet<F>` will never overlap.
- Change debug printing for `SystemTypeSet` to just debug print as `SystemTypeSet:system_name_goes_here`.

## Testing

- Tests still pass.
