### PR TITLE
I want to get off Mr. Fresnel's wild ride

### DIFF
--- a/crates/bevy_pbr/src/light_probe/environment_map.wgsl
+++ b/crates/bevy_pbr/src/light_probe/environment_map.wgsl
@@ -240,9 +240,8 @@ fn environment_map_light(
     // Multiscattering approximation: https://www.jcgt.org/published/0008/01/03/paper.pdf
     // We initially used this (https://bruop.github.io/ibl) reference with Roughness Dependent
     // Fresnel, but it made fresnel very bright so we reverted to the "typical" fresnel term.
-    let Ess = F_ab.x + F_ab.y;
-    let FssEss = (F0 * Ess) * specular_occlusion;
-    let Ems = 1.0 - Ess;
+    let FssEss = (F0 * F_ab.x + F_ab.y) * specular_occlusion;
+    let Ems = 1.0 - (F_ab.x + F_ab.y);
     let Favg = F0 + (1.0 - F0) / 21.0;
     let Fms = FssEss * Favg / (1.0 - Ems * Favg);
     let FmsEms = Fms * Ems;


### PR DESCRIPTION
# Objective

- Unbreak fresnel.
- Fix a small math error.

## Solution

- Don't be stupid.

## Testing

### main: fresnel missing entirely

<img width="2784" height="1728" alt="image" src="https://github.com/user-attachments/assets/275d9529-d735-4102-a49c-d571a8c84d8d" />

### Roughness dependent fresnel: still too bright

<img width="2784" height="1728" alt="image" src="https://github.com/user-attachments/assets/b9e91403-5f76-411b-ba9d-6fdef0d071dc" />

Note how this violates the furnace test (reflection is brighter (has more energy) than what it is reflecting):

<img width="398" height="127" alt="image" src="https://github.com/user-attachments/assets/a507932a-9153-4a51-8d2e-d436f6cd0c75" />

### Fixed existing, boring fresnel: juuuuust right

<img width="2784" height="1728" alt="image" src="https://github.com/user-attachments/assets/b7c5b5be-c02f-4428-8280-1a27d0bb8b5c" />

and this one does not

<img width="453" height="130" alt="image" src="https://github.com/user-attachments/assets/6790e911-97a2-4fc9-b09a-c32370ecff0d" />

### Bistro

More fresnel than the 0.18 release post, but it seems like a correct amount, considering it lacks any specular occlusion.

Release post
<img width="1133" height="673" alt="image" src="https://github.com/user-attachments/assets/e5270bd2-a705-4ec1-91cf-03ff550e9ce2" />

This PR (light intensities different, doesn't affect fresnel)
<img width="2144" height="1368" alt="image" src="https://github.com/user-attachments/assets/eb35c91d-37a6-4fe6-b5bc-8f770c13ae1f" />

This PR + SSR - fresnel is further occluded where it should be
<img width="2144" height="1368" alt="image" src="https://github.com/user-attachments/assets/84dd2de0-dd92-4380-8bce-c19197c4ebf5" />

As soon as you add specular occlusion with SSR, the fresnel starts to make sense again, occluded objects no longer reflect the envmap in their fresnel reflection. Note the awnings here look bright in shadow because they are catching the envmap, until you turn on SSR which tones this down with specular occlusion.

<img width="1459" height="944" alt="image-3" src="https://github.com/user-attachments/assets/708d0c82-4fc6-4773-894f-6b1e0e0633f6" />

<img width="1459" height="944" alt="bevyssr" src="https://github.com/user-attachments/assets/f78774ca-97f9-48bf-94dc-46f119e91ba5" />

Note that the fresnel is actually helpful here - without it we wouldn't get this soft reflection of the scooter against the sky (env) on the pavers:

<img width="307" height="209" alt="image" src="https://github.com/user-attachments/assets/a6133c71-c39f-4a6b-aed7-274a77256c91" />

<img width="307" height="209" alt="image" src="https://github.com/user-attachments/assets/ec4d6258-1593-4248-8330-424708796c9b" />

