### PR TITLE
Include missing naga capabilities for wgpu 27

### DIFF
--- a/crates/bevy_shader/src/shader_cache.rs
+++ b/crates/bevy_shader/src/shader_cache.rs
@@ -537,8 +537,16 @@ fn get_capabilities(features: Features, downlevel: DownlevelFlags) -> Capabiliti
         features.contains(Features::SHADER_F16),
     );
     capabilities.set(
+        Capabilities::SHADER_FLOAT16_IN_FLOAT32,
+        downlevel.contains(DownlevelFlags::SHADER_F16_IN_F32),
+    );
+    capabilities.set(
         Capabilities::RAY_HIT_VERTEX_POSITION,
         features.intersects(Features::EXPERIMENTAL_RAY_HIT_VERTEX_RETURN),
+    );
+    capabilities.set(
+        Capabilities::TEXTURE_EXTERNAL,
+        features.intersects(Features::EXTERNAL_TEXTURE),
     );
 
     capabilities


### PR DESCRIPTION
# Objective

- Update Bevy’s shader capabilities mapping to match wgpu 27’s validator capabilities.
- make working with unpack2x16float and pack2x16float possible again

## Solution

- Added the missing SHADER_FLOAT16_IN_FLOAT32 and TEXTURE_EXTERNAL capability checks in get_capabilities to mirror wgpu-core’s create_validator.
