### PR TITLE
Check clipping before recording hits on text nodes

### DIFF
--- a/crates/bevy_ui/src/picking_backend.rs
+++ b/crates/bevy_ui/src/picking_backend.rs
@@ -212,16 +212,13 @@ pub fn ui_picking(
                         *cursor_position,
                         text_layout_info,
                         text_block,
+                    ) && clip_check_recursive(
+                        *cursor_position,
+                        node_entity,
+                        &clipping_query,
+                        &child_of_query,
                     ) {
-                        if settings.require_markers
-                            && !pickable_query.contains(text_entity)
-                            && !clip_check_recursive(
-                                *cursor_position,
-                                node_entity,
-                                &clipping_query,
-                                &child_of_query,
-                            )
-                        {
+                        if settings.require_markers && !pickable_query.contains(text_entity) {
                             continue;
                         }
 


### PR DESCRIPTION
# Objective

Fixes #22507

## Solution

Call `clip_check_recursive` when checking text nodes for pointer hits.

## Testing

Made a branch of bevy_immediate using this fix, as @PPakalns suggested:
https://github.com/ickshonpe/bevy_immediate/tree/text-picking-clip-fix

Then
```
cargo run --example demo
```
and select "Bevy Scrollareas" from the menu on the left.

You should see that scrolling the scrollable areas to the right no longer blocks interactions with the menu.