### PR TITLE
fix building custom_primitives examples in wasm

### DIFF
--- a/examples/math/custom_primitives.rs
+++ b/examples/math/custom_primitives.rs
@@ -390,6 +390,7 @@ fn switch_shapes(
     };
 }
 
+#[cfg(not(target_family = "wasm"))]
 fn toggle_wireframes(mut wireframe_config: ResMut<WireframeConfig>) {
     wireframe_config.global = !wireframe_config.global;
 }


### PR DESCRIPTION
# Objective

- Example `custom_primitives` doesn't build in wasm

## Solution

- Add the missing gate
