### PR TITLE
Fix Deploy Docs GH Action: Add `feature(rustdoc_internals)` to `bevy_material` when building docs

### DIFF
--- a/crates/bevy_material/src/lib.rs
+++ b/crates/bevy_material/src/lib.rs
@@ -9,6 +9,10 @@
 )]
 #![cfg_attr(any(docsrs, docsrs_dep), feature(rustdoc_internals))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![doc(
+    html_logo_url = "https://bevy.org/assets/icon.png",
+    html_favicon_url = "https://bevy.org/assets/icon.png"
+)]
 
 use bevy_asset::Handle;
 use bevy_shader::Shader;


### PR DESCRIPTION
# Objective

- Add a fix for currently failing Deploy Docs Action. [Example Log is here](https://github.com/bevyengine/bevy/actions/runs/20974377798/job/60285550096)
- Happening on main since #22426, It appears `bevy_material` is using `#[doc(fake_variadic)]` in a module, but doc builds for the crate aren’t building correctly. It suggests `help: add `#![feature(rustdoc_internals)]` to the crate attributes to enable`

## Solution

- Copy some configuration into `bevy_material` that is already used in other bevy crates that have `#[doc(fake_variadic)]`, e.g. `bevy_math` https://github.com/bevyengine/bevy/blob/main/crates/bevy_math/src/lib.rs#L2-L10 which adds the `rustdoc_internals` feature when building docs
- I added the icon stuff while I was at it since that seems to be in other lib.rs files as well

## Testing

I did not test this, but this seems to be a solved problem already for the other crates
