### PR TITLE
fix for deploy docs: doc_auto_cfg -> doc_cfg

### DIFF
--- a/crates/bevy_material/macros/src/lib.rs
+++ b/crates/bevy_material/macros/src/lib.rs
@@ -1,5 +1,5 @@
 #![expect(missing_docs, reason = "Not all docs are written yet, see #3492.")]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 use bevy_macro_utils::{derive_label, BevyManifest};
 use proc_macro::TokenStream;


### PR DESCRIPTION
# Objective

- More fix for GH Deploy Docs job, now it’s complaining about doc_auto_cfg https://github.com/bevyengine/bevy/actions/runs/21021330944/job/60436540537

## Solution

- Fix the thing

## Testing

- Ran `cargo doc` within `bevy_material` locally afterwards and made sure things work fine this time. bah