### PR TITLE
Display actual camera speed in UI

### DIFF
--- a/examples/camera/free_camera_controller.rs
+++ b/examples/camera/free_camera_controller.rs
@@ -176,8 +176,8 @@ fn update_text(
         free_camera.sensitivity,
         free_camera.friction,
         free_camera.scroll_factor,
-        free_camera.walk_speed,
-        free_camera.run_speed,
+        free_camera.walk_speed * free_camera_state.speed_multiplier,
+        free_camera.run_speed * free_camera_state.speed_multiplier,
         free_camera_state.velocity.length(),
     );
 }


### PR DESCRIPTION
# Objective

- The `free_camera_controller` example currently shows the unmodified base speeds in the UI, but not the actual speed influenced by the scroll multiplier. This can be confusing, as the displayed values don’t match the camera’s behavior. 
- In most use cases, users prefer to see the real-time effective speed rather than just viewing the static configuration values they have already set. We should demonstrate how to do that.

## Solution

- `* free_camera_state.speed_multiplier`

## Testing

- CI

---
