### PR TITLE
Move `AddObserver` and `observe` from bevy_ui_widgets into bevy_ecs

### DIFF
--- a/crates/bevy_ecs/src/observer/add_observer.rs
+++ b/crates/bevy_ecs/src/observer/add_observer.rs
@@ -1,10 +1,8 @@
-// TODO: This probably doesn't belong in bevy_ui_widgets, but I am not sure where it should go.
-// It is certainly a useful thing to have.
 #![expect(unsafe_code, reason = "Unsafe code is used to improve performance.")]
 
 use core::{marker::PhantomData, mem};
 
-use bevy_ecs::{
+use crate::{
     bundle::{Bundle, DynamicBundle},
     event::EntityEvent,
     system::IntoObserverSystem,

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -3,12 +3,14 @@
 //!
 //! See [`Event`] and [`Observer`] for in-depth documentation and usage examples.
 
+mod add_observer;
 mod centralized_storage;
 mod distributed_storage;
 mod entity_cloning;
 mod runner;
 mod system_param;
 
+pub use add_observer::*;
 pub use centralized_storage::*;
 pub use distributed_storage::*;
 pub use runner::*;

--- a/crates/bevy_feathers/src/controls/virtual_keyboard.rs
+++ b/crates/bevy_feathers/src/controls/virtual_keyboard.rs
@@ -1,9 +1,9 @@
-use bevy_ecs::prelude::*;
+use bevy_ecs::{observer::observe, prelude::*};
 use bevy_input_focus::tab_navigation::TabGroup;
 use bevy_ui::Node;
 use bevy_ui::Val;
 use bevy_ui::{widget::Text, FlexDirection};
-use bevy_ui_widgets::{observe, Activate};
+use bevy_ui_widgets::Activate;
 
 use crate::controls::{button, ButtonProps};
 

--- a/crates/bevy_ui_widgets/src/lib.rs
+++ b/crates/bevy_ui_widgets/src/lib.rs
@@ -21,7 +21,6 @@
 mod button;
 mod checkbox;
 mod menu;
-mod observe;
 pub mod popover;
 mod radio;
 mod scrollbar;
@@ -30,7 +29,6 @@ mod slider;
 pub use button::*;
 pub use checkbox::*;
 pub use menu::*;
-pub use observe::*;
 pub use radio::*;
 pub use scrollbar::*;
 pub use slider::*;

--- a/examples/ui/feathers.rs
+++ b/examples/ui/feathers.rs
@@ -2,6 +2,7 @@
 
 use bevy::{
     color::palettes,
+    ecs::observer::observe,
     feathers::{
         controls::{
             button, checkbox, color_plane, color_slider, color_swatch, radio, slider,
@@ -19,7 +20,7 @@ use bevy::{
     prelude::*,
     ui::{Checked, InteractionDisabled},
     ui_widgets::{
-        checkbox_self_update, observe, slider_self_update, Activate, RadioButton, RadioGroup,
+        checkbox_self_update, slider_self_update, Activate, RadioButton, RadioGroup,
         SliderPrecision, SliderStep, SliderValue, ValueChange,
     },
     window::SystemCursorIcon,

--- a/examples/ui/standard_widgets.rs
+++ b/examples/ui/standard_widgets.rs
@@ -8,6 +8,7 @@
 
 use bevy::{
     color::palettes::basic::*,
+    ecs::observer::observe,
     input_focus::{
         tab_navigation::{TabGroup, TabIndex, TabNavigationPlugin},
         InputDispatchPlugin, InputFocus,
@@ -16,7 +17,7 @@ use bevy::{
     prelude::*,
     ui::{Checked, InteractionDisabled, Pressed},
     ui_widgets::{
-        checkbox_self_update, observe,
+        checkbox_self_update,
         popover::{Popover, PopoverAlign, PopoverPlacement, PopoverSide},
         Activate, Button, Checkbox, CoreSliderDragState, MenuAction, MenuButton, MenuEvent,
         MenuItem, MenuPopup, RadioButton, RadioGroup, Slider, SliderRange, SliderThumb,

--- a/examples/ui/standard_widgets_observers.rs
+++ b/examples/ui/standard_widgets_observers.rs
@@ -6,6 +6,7 @@
 
 use bevy::{
     color::palettes::basic::*,
+    ecs::observer::observe,
     input_focus::{
         tab_navigation::{TabGroup, TabIndex, TabNavigationPlugin},
         InputDispatchPlugin,
@@ -15,8 +16,8 @@ use bevy::{
     reflect::Is,
     ui::{Checked, InteractionDisabled, Pressed},
     ui_widgets::{
-        checkbox_self_update, observe, Activate, Button, Checkbox, Slider, SliderRange,
-        SliderThumb, SliderValue, UiWidgetsPlugins, ValueChange,
+        checkbox_self_update, Activate, Button, Checkbox, Slider, SliderRange, SliderThumb,
+        SliderValue, UiWidgetsPlugins, ValueChange,
     },
 };
 

--- a/examples/ui/vertical_slider.rs
+++ b/examples/ui/vertical_slider.rs
@@ -1,6 +1,7 @@
 //! Simple example showing vertical and horizontal slider widgets with snap behavior and value labels
 
 use bevy::{
+    ecs::observer::observe,
     input_focus::{
         tab_navigation::{TabGroup, TabIndex, TabNavigationPlugin},
         InputDispatchPlugin,
@@ -8,8 +9,8 @@ use bevy::{
     picking::hover::Hovered,
     prelude::*,
     ui_widgets::{
-        observe, slider_self_update, CoreSliderDragState, Slider, SliderRange, SliderThumb,
-        SliderValue, TrackClick, UiWidgetsPlugins,
+        slider_self_update, CoreSliderDragState, Slider, SliderRange, SliderThumb, SliderValue,
+        TrackClick, UiWidgetsPlugins,
     },
 };
 

--- a/examples/ui/virtual_keyboard.rs
+++ b/examples/ui/virtual_keyboard.rs
@@ -2,6 +2,7 @@
 
 use bevy::{
     color::palettes::css::NAVY,
+    ecs::observer::observe,
     feathers::{
         controls::{virtual_keyboard, VirtualKeyPressed},
         dark_theme::create_dark_theme,
@@ -9,7 +10,6 @@ use bevy::{
         FeathersPlugins,
     },
     prelude::*,
-    ui_widgets::observe,
 };
 
 fn main() {


### PR DESCRIPTION
# Objective

- Addressing the top comment in the file: 
```
TODO: This probably doesn't belong in bevy_ui_widgets, but I am not sure where it should go.
```

## Solution

- I moved the module from `bevy_ui_widgets` into `bevy_ecs` (under the `observer` module)
- This seems like the most logical landing spot

## Testing

- `cargo run -p -- compile`
- `cargo run -p -- test`