### PR TITLE
Implements post-process vignette effect

### DIFF
--- a/crates/bevy_post_process/src/effect_stack/chromatic_aberration.rs
+++ b/crates/bevy_post_process/src/effect_stack/chromatic_aberration.rs
@@ -1,0 +1,120 @@
+use bevy_asset::Handle;
+use bevy_camera::Camera;
+use bevy_ecs::{
+    component::Component,
+    query::{QueryItem, With},
+    reflect::ReflectComponent,
+    resource::Resource,
+    system::lifetimeless::Read,
+};
+use bevy_image::Image;
+use bevy_reflect::{std_traits::ReflectDefault, Reflect};
+use bevy_render::{extract_component::ExtractComponent, render_resource::ShaderType};
+
+/// The raw RGBA data for the default chromatic aberration gradient.
+///
+/// This consists of one red pixel, one green pixel, and one blue pixel, in that
+/// order.
+pub(super) static DEFAULT_CHROMATIC_ABERRATION_LUT_DATA: [u8; 12] =
+    [255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255];
+
+/// The default chromatic aberration intensity amount, in a fraction of the
+/// window size.
+const DEFAULT_CHROMATIC_ABERRATION_INTENSITY: f32 = 0.02;
+
+/// The default maximum number of samples for chromatic aberration.
+const DEFAULT_CHROMATIC_ABERRATION_MAX_SAMPLES: u32 = 8;
+
+#[derive(Resource)]
+pub(super) struct DefaultChromaticAberrationLut(pub(super) Handle<Image>);
+
+/// Adds colored fringes to the edges of objects in the scene.
+///
+/// [Chromatic aberration] simulates the effect when lenses fail to focus all
+/// colors of light toward a single point. It causes rainbow-colored streaks to
+/// appear, which are especially apparent on the edges of objects. Chromatic
+/// aberration is commonly used for collision effects, especially in horror
+/// games.
+///
+/// Bevy's implementation is based on that of *Inside* ([Gjøl & Svendsen 2016]).
+/// It's based on a customizable lookup texture, which allows for changing the
+/// color pattern. By default, the color pattern is simply a 3×1 pixel texture
+/// consisting of red, green, and blue, in that order, but you can change it to
+/// any image in order to achieve different effects.
+///
+/// [Chromatic aberration]: https://en.wikipedia.org/wiki/Chromatic_aberration
+///
+/// [Gjøl & Svendsen 2016]: https://github.com/playdeadgames/publications/blob/master/INSIDE/rendering_inside_gdc2016.pdf
+#[derive(Reflect, Component, Clone)]
+#[reflect(Component, Default, Clone)]
+pub struct ChromaticAberration {
+    /// The lookup texture that determines the color gradient.
+    ///
+    /// By default (if None), this is a 3×1 texel texture consisting of one red
+    /// pixel, one green pixel, and one blue texel, in that order. This
+    /// recreates the most typical chromatic aberration pattern. However, you
+    /// can change it to achieve different artistic effects.
+    ///
+    /// The texture is always sampled in its vertical center, so it should
+    /// ordinarily have a height of 1 texel.
+    pub color_lut: Option<Handle<Image>>,
+
+    /// The size of the streaks around the edges of objects, as a fraction of
+    /// the window size.
+    ///
+    /// The default value is 0.02.
+    pub intensity: f32,
+
+    /// A cap on the number of texture samples that will be performed.
+    ///
+    /// Higher values result in smoother-looking streaks but are slower.
+    ///
+    /// The default value is 8.
+    pub max_samples: u32,
+}
+
+impl Default for ChromaticAberration {
+    fn default() -> Self {
+        Self {
+            color_lut: None,
+            intensity: DEFAULT_CHROMATIC_ABERRATION_INTENSITY,
+            max_samples: DEFAULT_CHROMATIC_ABERRATION_MAX_SAMPLES,
+        }
+    }
+}
+
+impl ExtractComponent for ChromaticAberration {
+    type QueryData = Read<ChromaticAberration>;
+
+    type QueryFilter = With<Camera>;
+
+    type Out = ChromaticAberration;
+
+    fn extract_component(
+        chromatic_aberration: QueryItem<'_, '_, Self::QueryData>,
+    ) -> Option<Self::Out> {
+        // Skip the postprocessing phase entirely if the intensity is zero.
+        if chromatic_aberration.intensity > 0.0 {
+            Some(chromatic_aberration.clone())
+        } else {
+            None
+        }
+    }
+}
+
+/// The on-GPU version of the [`ChromaticAberration`] settings.
+///
+/// See the documentation for [`ChromaticAberration`] for more information on
+/// each of these fields.
+#[derive(ShaderType, Default)]
+pub struct ChromaticAberrationUniform {
+    /// The intensity of the effect, in a fraction of the screen.
+    pub(super) intensity: f32,
+    /// A cap on the number of samples of the source texture that the shader
+    /// will perform.
+    pub(super) max_samples: u32,
+    /// Padding data.
+    pub(super) unused_1: u32,
+    /// Padding data.
+    pub(super) unused_2: u32,
+}

--- a/crates/bevy_post_process/src/effect_stack/chromatic_aberration.wgsl
+++ b/crates/bevy_post_process/src/effect_stack/chromatic_aberration.wgsl
@@ -2,9 +2,9 @@
 //
 // This makes edges of objects turn into multicolored streaks.
 
-#define_import_path bevy_core_pipeline::post_processing::chromatic_aberration
+#define_import_path bevy_post_process::effect_stack::chromatic_aberration
 
-// See `bevy_core_pipeline::post_process::ChromaticAberration` for more
+// See `bevy_post_process::effect_stack::ChromaticAberration` for more
 // information on these fields.
 struct ChromaticAberrationSettings {
     intensity: f32,
@@ -14,9 +14,9 @@ struct ChromaticAberrationSettings {
 }
 
 // The source framebuffer texture.
-@group(0) @binding(0) var chromatic_aberration_source_texture: texture_2d<f32>;
+@group(0) @binding(0) var source_texture: texture_2d<f32>;
 // The sampler used to sample the source framebuffer texture.
-@group(0) @binding(1) var chromatic_aberration_source_sampler: sampler;
+@group(0) @binding(1) var source_sampler: sampler;
 // The 1D lookup table for chromatic aberration.
 @group(0) @binding(2) var chromatic_aberration_lut_texture: texture_2d<f32>;
 // The sampler used to sample that lookup table.
@@ -35,7 +35,7 @@ fn chromatic_aberration(start_pos: vec2<f32>) -> vec3<f32> {
     // that's higher than the developer-specified maximum number of samples, in
     // which case we choose the maximum number of samples.
     let texel_length = length((end_pos - start_pos) *
-        vec2<f32>(textureDimensions(chromatic_aberration_source_texture)));
+        vec2<f32>(textureDimensions(source_texture)));
     let sample_count = min(u32(ceil(texel_length)), chromatic_aberration_settings.max_samples);
 
     var color: vec3<f32>;
@@ -55,8 +55,8 @@ fn chromatic_aberration(start_pos: vec2<f32>) -> vec3<f32> {
             // Sample the framebuffer.
             let sample_uv = mix(start_pos, end_pos, t);
             let sample = textureSampleLevel(
-                chromatic_aberration_source_texture,
-                chromatic_aberration_source_sampler,
+                source_texture,
+                source_sampler,
                 sample_uv,
                 0.0,
             ).rgb;
@@ -81,8 +81,8 @@ fn chromatic_aberration(start_pos: vec2<f32>) -> vec3<f32> {
         // then this shader will apply whatever tint is in the center of the LUT
         // texture to such pixels, which is wrong.
         color = textureSampleLevel(
-            chromatic_aberration_source_texture,
-            chromatic_aberration_source_sampler,
+            source_texture,
+            source_sampler,
             start_pos,
             0.0,
         ).rgb;

--- a/crates/bevy_post_process/src/effect_stack/mod.rs
+++ b/crates/bevy_post_process/src/effect_stack/mod.rs
@@ -1,28 +1,42 @@
 //! Miscellaneous built-in postprocessing effects.
 //!
-//! Currently, this consists only of chromatic aberration.
+//! Includes:
+//!
+//! - Chromatic Aberration
+//! - Vignette
+
+mod chromatic_aberration;
+mod vignette;
+
+pub use chromatic_aberration::ChromaticAberration;
+pub use vignette::Vignette;
+
+use crate::effect_stack::{
+    chromatic_aberration::{
+        ChromaticAberrationUniform, DefaultChromaticAberrationLut,
+        DEFAULT_CHROMATIC_ABERRATION_LUT_DATA,
+    },
+    vignette::VignetteUniform,
+};
 
 use bevy_app::{App, Plugin};
 use bevy_asset::{
     embedded_asset, load_embedded_asset, AssetServer, Assets, Handle, RenderAssetUsages,
 };
-use bevy_camera::Camera;
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
     component::Component,
     entity::Entity,
-    query::{QueryItem, With},
-    reflect::ReflectComponent,
+    query::{AnyOf, Or, QueryItem, With},
     resource::Resource,
     schedule::IntoScheduleConfigs as _,
     system::{lifetimeless::Read, Commands, Query, Res, ResMut},
     world::World,
 };
 use bevy_image::{BevyDefault, Image};
-use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{
     diagnostic::RecordDiagnostics,
-    extract_component::{ExtractComponent, ExtractComponentPlugin},
+    extract_component::ExtractComponentPlugin,
     render_asset::RenderAssets,
     render_graph::{
         NodeRunError, RenderGraphContext, RenderGraphExt as _, ViewNode, ViewNodeRunner,
@@ -33,8 +47,8 @@ use bevy_render::{
         CachedRenderPipelineId, ColorTargetState, ColorWrites, DynamicUniformBuffer, Extent3d,
         FilterMode, FragmentState, Operations, PipelineCache, RenderPassColorAttachment,
         RenderPassDescriptor, RenderPipelineDescriptor, Sampler, SamplerBindingType,
-        SamplerDescriptor, ShaderStages, ShaderType, SpecializedRenderPipeline,
-        SpecializedRenderPipelines, TextureDimension, TextureFormat, TextureSampleType,
+        SamplerDescriptor, ShaderStages, SpecializedRenderPipeline, SpecializedRenderPipelines,
+        TextureDimension, TextureFormat, TextureSampleType,
     },
     renderer::{RenderContext, RenderDevice, RenderQueue},
     texture::GpuImage,
@@ -50,74 +64,15 @@ use bevy_core_pipeline::{
     FullscreenShader,
 };
 
-/// The default chromatic aberration intensity amount, in a fraction of the
-/// window size.
-const DEFAULT_CHROMATIC_ABERRATION_INTENSITY: f32 = 0.02;
-
-/// The default maximum number of samples for chromatic aberration.
-const DEFAULT_CHROMATIC_ABERRATION_MAX_SAMPLES: u32 = 8;
-
-/// The raw RGBA data for the default chromatic aberration gradient.
-///
-/// This consists of one red pixel, one green pixel, and one blue pixel, in that
-/// order.
-static DEFAULT_CHROMATIC_ABERRATION_LUT_DATA: [u8; 12] =
-    [255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255];
-
-#[derive(Resource)]
-struct DefaultChromaticAberrationLut(Handle<Image>);
-
 /// A plugin that implements a built-in postprocessing stack with some common
 /// effects.
 ///
-/// Currently, this only consists of chromatic aberration.
+/// Includes:
+///
+/// - Chromatic Aberration
+/// - Vignette
 #[derive(Default)]
 pub struct EffectStackPlugin;
-
-/// Adds colored fringes to the edges of objects in the scene.
-///
-/// [Chromatic aberration] simulates the effect when lenses fail to focus all
-/// colors of light toward a single point. It causes rainbow-colored streaks to
-/// appear, which are especially apparent on the edges of objects. Chromatic
-/// aberration is commonly used for collision effects, especially in horror
-/// games.
-///
-/// Bevy's implementation is based on that of *Inside* ([Gjøl & Svendsen 2016]).
-/// It's based on a customizable lookup texture, which allows for changing the
-/// color pattern. By default, the color pattern is simply a 3×1 pixel texture
-/// consisting of red, green, and blue, in that order, but you can change it to
-/// any image in order to achieve different effects.
-///
-/// [Chromatic aberration]: https://en.wikipedia.org/wiki/Chromatic_aberration
-///
-/// [Gjøl & Svendsen 2016]: https://github.com/playdeadgames/publications/blob/master/INSIDE/rendering_inside_gdc2016.pdf
-#[derive(Reflect, Component, Clone)]
-#[reflect(Component, Default, Clone)]
-pub struct ChromaticAberration {
-    /// The lookup texture that determines the color gradient.
-    ///
-    /// By default (if None), this is a 3×1 texel texture consisting of one red
-    /// pixel, one green pixel, and one blue texel, in that order. This
-    /// recreates the most typical chromatic aberration pattern. However, you
-    /// can change it to achieve different artistic effects.
-    ///
-    /// The texture is always sampled in its vertical center, so it should
-    /// ordinarily have a height of 1 texel.
-    pub color_lut: Option<Handle<Image>>,
-
-    /// The size of the streaks around the edges of objects, as a fraction of
-    /// the window size.
-    ///
-    /// The default value is 0.02.
-    pub intensity: f32,
-
-    /// A cap on the number of texture samples that will be performed.
-    ///
-    /// Higher values result in smoother-looking streaks but are slower.
-    ///
-    /// The default value is 8.
-    pub max_samples: u32,
-}
 
 /// GPU pipeline data for the built-in postprocessing stack.
 ///
@@ -148,36 +103,21 @@ pub struct PostProcessingPipelineKey {
 #[derive(Component, Deref, DerefMut)]
 pub struct PostProcessingPipelineId(CachedRenderPipelineId);
 
-/// The on-GPU version of the [`ChromaticAberration`] settings.
-///
-/// See the documentation for [`ChromaticAberration`] for more information on
-/// each of these fields.
-#[derive(ShaderType)]
-pub struct ChromaticAberrationUniform {
-    /// The intensity of the effect, in a fraction of the screen.
-    intensity: f32,
-    /// A cap on the number of samples of the source texture that the shader
-    /// will perform.
-    max_samples: u32,
-    /// Padding data.
-    unused_1: u32,
-    /// Padding data.
-    unused_2: u32,
-}
-
 /// A resource, part of the render world, that stores the
 /// [`ChromaticAberrationUniform`]s for each view.
-#[derive(Resource, Deref, DerefMut, Default)]
+#[derive(Resource, Default)]
 pub struct PostProcessingUniformBuffers {
     chromatic_aberration: DynamicUniformBuffer<ChromaticAberrationUniform>,
+    vignette: DynamicUniformBuffer<VignetteUniform>,
 }
 
 /// A component, part of the render world, that stores the appropriate byte
 /// offset within the [`PostProcessingUniformBuffers`] for the camera it's
 /// attached to.
-#[derive(Component, Deref, DerefMut)]
+#[derive(Component)]
 pub struct PostProcessingUniformBufferOffsets {
     chromatic_aberration: u32,
+    vignette: u32,
 }
 
 /// The render node that runs the built-in postprocessing stack.
@@ -187,6 +127,7 @@ pub struct PostProcessingNode;
 impl Plugin for EffectStackPlugin {
     fn build(&self, app: &mut App) {
         load_shader_library!(app, "chromatic_aberration.wgsl");
+        load_shader_library!(app, "vignette.wgsl");
 
         embedded_asset!(app, "post_process.wgsl");
 
@@ -204,7 +145,8 @@ impl Plugin for EffectStackPlugin {
             RenderAssetUsages::RENDER_WORLD,
         ));
 
-        app.add_plugins(ExtractComponentPlugin::<ChromaticAberration>::default());
+        app.add_plugins(ExtractComponentPlugin::<ChromaticAberration>::default())
+            .add_plugins(ExtractComponentPlugin::<Vignette>::default());
 
         let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
             return;
@@ -246,16 +188,6 @@ impl Plugin for EffectStackPlugin {
     }
 }
 
-impl Default for ChromaticAberration {
-    fn default() -> Self {
-        Self {
-            color_lut: None,
-            intensity: DEFAULT_CHROMATIC_ABERRATION_INTENSITY,
-            max_samples: DEFAULT_CHROMATIC_ABERRATION_MAX_SAMPLES,
-        }
-    }
-}
-
 pub fn init_post_processing_pipeline(
     mut commands: Commands,
     render_device: Res<RenderDevice>,
@@ -268,9 +200,9 @@ pub fn init_post_processing_pipeline(
         &BindGroupLayoutEntries::sequential(
             ShaderStages::FRAGMENT,
             (
-                // Chromatic aberration source:
+                // Common source:
                 texture_2d(TextureSampleType::Float { filterable: true }),
-                // Chromatic aberration source sampler:
+                // Common source sampler:
                 sampler(SamplerBindingType::Filtering),
                 // Chromatic aberration LUT:
                 texture_2d(TextureSampleType::Float { filterable: true }),
@@ -278,6 +210,8 @@ pub fn init_post_processing_pipeline(
                 sampler(SamplerBindingType::Filtering),
                 // Chromatic aberration settings:
                 uniform_buffer::<ChromaticAberrationUniform>(true),
+                // Vignette settings:
+                uniform_buffer::<VignetteUniform>(true),
             ),
         ),
     );
@@ -334,7 +268,7 @@ impl ViewNode for PostProcessingNode {
     type ViewQuery = (
         Read<ViewTarget>,
         Read<PostProcessingPipelineId>,
-        Read<ChromaticAberration>,
+        AnyOf<(Read<ChromaticAberration>, Read<Vignette>)>,
         Read<PostProcessingUniformBufferOffsets>,
     );
 
@@ -342,9 +276,19 @@ impl ViewNode for PostProcessingNode {
         &self,
         _: &mut RenderGraphContext,
         render_context: &mut RenderContext<'w>,
-        (view_target, pipeline_id, chromatic_aberration, post_processing_uniform_buffer_offsets): QueryItem<'w, '_, Self::ViewQuery>,
+        (view_target, pipeline_id, post_effects, post_processing_uniform_buffer_offsets): QueryItem<
+            'w,
+            '_,
+            Self::ViewQuery,
+        >,
         world: &'w World,
     ) -> Result<(), NodeRunError> {
+        let (chromatic_aberration_opt, vignette_opt) = post_effects;
+
+        if chromatic_aberration_opt.is_none() && vignette_opt.is_none() {
+            return Ok(());
+        }
+
         let pipeline_cache = world.resource::<PipelineCache>();
         let post_processing_pipeline = world.resource::<PostProcessingPipeline>();
         let post_processing_uniform_buffers = world.resource::<PostProcessingUniformBuffers>();
@@ -356,11 +300,10 @@ impl ViewNode for PostProcessingNode {
             return Ok(());
         };
 
-        // We need the chromatic aberration LUT to be present.
+        // We need the chromatic aberration LUT to be present
         let Some(chromatic_aberration_lut) = gpu_image_assets.get(
-            chromatic_aberration
-                .color_lut
-                .as_ref()
+            chromatic_aberration_opt
+                .and_then(|ca| ca.color_lut.as_ref())
                 .unwrap_or(&default_lut.0),
         ) else {
             return Ok(());
@@ -370,6 +313,12 @@ impl ViewNode for PostProcessingNode {
         let Some(chromatic_aberration_uniform_buffer_binding) = post_processing_uniform_buffers
             .chromatic_aberration
             .binding()
+        else {
+            return Ok(());
+        };
+
+        let Some(vignette_uniform_buffer_binding) =
+            post_processing_uniform_buffers.vignette.binding()
         else {
             return Ok(());
         };
@@ -402,6 +351,7 @@ impl ViewNode for PostProcessingNode {
                 &chromatic_aberration_lut.texture_view,
                 &post_processing_pipeline.chromatic_aberration_lut_sampler,
                 chromatic_aberration_uniform_buffer_binding,
+                vignette_uniform_buffer_binding,
             )),
         );
 
@@ -411,7 +361,14 @@ impl ViewNode for PostProcessingNode {
         let pass_span = diagnostics.pass_span(&mut render_pass, "postprocessing");
 
         render_pass.set_pipeline(pipeline);
-        render_pass.set_bind_group(0, &bind_group, &[**post_processing_uniform_buffer_offsets]);
+        render_pass.set_bind_group(
+            0,
+            &bind_group,
+            &[
+                post_processing_uniform_buffer_offsets.chromatic_aberration,
+                post_processing_uniform_buffer_offsets.vignette,
+            ],
+        );
         render_pass.draw(0..3, 0..1);
 
         pass_span.end(&mut render_pass);
@@ -426,7 +383,7 @@ pub fn prepare_post_processing_pipelines(
     pipeline_cache: Res<PipelineCache>,
     mut pipelines: ResMut<SpecializedRenderPipelines<PostProcessingPipeline>>,
     post_processing_pipeline: Res<PostProcessingPipeline>,
-    views: Query<(Entity, &ExtractedView), With<ChromaticAberration>>,
+    views: Query<(Entity, &ExtractedView), Or<(With<ChromaticAberration>, With<Vignette>)>>,
 ) {
     for (entity, view) in views.iter() {
         let pipeline_id = pipelines.specialize(
@@ -454,45 +411,60 @@ pub fn prepare_post_processing_uniforms(
     mut post_processing_uniform_buffers: ResMut<PostProcessingUniformBuffers>,
     render_device: Res<RenderDevice>,
     render_queue: Res<RenderQueue>,
-    mut views: Query<(Entity, &ChromaticAberration)>,
+    mut views: Query<
+        (Entity, Option<&ChromaticAberration>, Option<&Vignette>),
+        Or<(With<ChromaticAberration>, With<Vignette>)>,
+    >,
 ) {
-    post_processing_uniform_buffers.clear();
+    post_processing_uniform_buffers.chromatic_aberration.clear();
+    post_processing_uniform_buffers.vignette.clear();
 
     // Gather up all the postprocessing settings.
-    for (view_entity, chromatic_aberration) in views.iter_mut() {
+    for (view_entity, chromatic_aberration_opt, vignette_opt) in views.iter_mut() {
         let chromatic_aberration_uniform_buffer_offset =
-            post_processing_uniform_buffers.push(&ChromaticAberrationUniform {
-                intensity: chromatic_aberration.intensity,
-                max_samples: chromatic_aberration.max_samples,
-                unused_1: 0,
-                unused_2: 0,
-            });
+            if let Some(chromatic_aberration) = chromatic_aberration_opt {
+                post_processing_uniform_buffers.chromatic_aberration.push(
+                    &ChromaticAberrationUniform {
+                        intensity: chromatic_aberration.intensity,
+                        max_samples: chromatic_aberration.max_samples,
+                        unused_1: 0,
+                        unused_2: 0,
+                    },
+                )
+            } else {
+                post_processing_uniform_buffers
+                    .chromatic_aberration
+                    .push(&ChromaticAberrationUniform::default())
+            };
+
+        let vignette_uniform_buffer_offset = if let Some(vignette) = vignette_opt {
+            post_processing_uniform_buffers
+                .vignette
+                .push(&VignetteUniform {
+                    intensity: vignette.intensity,
+                    radius: vignette.radius,
+                    smoothness: vignette.smoothness,
+                    roundness: vignette.roundness,
+                })
+        } else {
+            post_processing_uniform_buffers
+                .vignette
+                .push(&VignetteUniform::default())
+        };
+
         commands
             .entity(view_entity)
             .insert(PostProcessingUniformBufferOffsets {
                 chromatic_aberration: chromatic_aberration_uniform_buffer_offset,
+                vignette: vignette_uniform_buffer_offset,
             });
     }
 
     // Upload to the GPU.
-    post_processing_uniform_buffers.write_buffer(&render_device, &render_queue);
-}
-
-impl ExtractComponent for ChromaticAberration {
-    type QueryData = Read<ChromaticAberration>;
-
-    type QueryFilter = With<Camera>;
-
-    type Out = ChromaticAberration;
-
-    fn extract_component(
-        chromatic_aberration: QueryItem<'_, '_, Self::QueryData>,
-    ) -> Option<Self::Out> {
-        // Skip the postprocessing phase entirely if the intensity is zero.
-        if chromatic_aberration.intensity > 0.0 {
-            Some(chromatic_aberration.clone())
-        } else {
-            None
-        }
-    }
+    post_processing_uniform_buffers
+        .chromatic_aberration
+        .write_buffer(&render_device, &render_queue);
+    post_processing_uniform_buffers
+        .vignette
+        .write_buffer(&render_device, &render_queue);
 }

--- a/crates/bevy_post_process/src/effect_stack/mod.rs
+++ b/crates/bevy_post_process/src/effect_stack/mod.rs
@@ -283,9 +283,9 @@ impl ViewNode for PostProcessingNode {
         >,
         world: &'w World,
     ) -> Result<(), NodeRunError> {
-        let (chromatic_aberration_opt, vignette_opt) = post_effects;
+        let (maybe_chromatic_aberration, maybe_vignette) = post_effects;
 
-        if chromatic_aberration_opt.is_none() && vignette_opt.is_none() {
+        if maybe_chromatic_aberration.is_none() && maybe_vignette.is_none() {
             return Ok(());
         }
 
@@ -300,9 +300,8 @@ impl ViewNode for PostProcessingNode {
             return Ok(());
         };
 
-        // We need the chromatic aberration LUT to be present
         let Some(chromatic_aberration_lut) = gpu_image_assets.get(
-            chromatic_aberration_opt
+            maybe_chromatic_aberration
                 .and_then(|ca| ca.color_lut.as_ref())
                 .unwrap_or(&default_lut.0),
         ) else {
@@ -420,9 +419,9 @@ pub fn prepare_post_processing_uniforms(
     post_processing_uniform_buffers.vignette.clear();
 
     // Gather up all the postprocessing settings.
-    for (view_entity, chromatic_aberration_opt, vignette_opt) in views.iter_mut() {
+    for (view_entity, maybe_chromatic_aberration, maybe_vignette) in views.iter_mut() {
         let chromatic_aberration_uniform_buffer_offset =
-            if let Some(chromatic_aberration) = chromatic_aberration_opt {
+            if let Some(chromatic_aberration) = maybe_chromatic_aberration {
                 post_processing_uniform_buffers.chromatic_aberration.push(
                     &ChromaticAberrationUniform {
                         intensity: chromatic_aberration.intensity,
@@ -437,7 +436,7 @@ pub fn prepare_post_processing_uniforms(
                     .push(&ChromaticAberrationUniform::default())
             };
 
-        let vignette_uniform_buffer_offset = if let Some(vignette) = vignette_opt {
+        let vignette_uniform_buffer_offset = if let Some(vignette) = maybe_vignette {
             post_processing_uniform_buffers
                 .vignette
                 .push(&VignetteUniform {

--- a/crates/bevy_post_process/src/effect_stack/mod.rs
+++ b/crates/bevy_post_process/src/effect_stack/mod.rs
@@ -8,15 +8,11 @@
 mod chromatic_aberration;
 mod vignette;
 
-pub use chromatic_aberration::ChromaticAberration;
-pub use vignette::Vignette;
+pub use chromatic_aberration::{ChromaticAberration, ChromaticAberrationUniform};
+pub use vignette::{Vignette, VignetteUniform};
 
-use crate::effect_stack::{
-    chromatic_aberration::{
-        ChromaticAberrationUniform, DefaultChromaticAberrationLut,
-        DEFAULT_CHROMATIC_ABERRATION_LUT_DATA,
-    },
-    vignette::VignetteUniform,
+use crate::effect_stack::chromatic_aberration::{
+    DefaultChromaticAberrationLut, DEFAULT_CHROMATIC_ABERRATION_LUT_DATA,
 };
 
 use bevy_app::{App, Plugin};
@@ -103,8 +99,11 @@ pub struct PostProcessingPipelineKey {
 #[derive(Component, Deref, DerefMut)]
 pub struct PostProcessingPipelineId(CachedRenderPipelineId);
 
-/// A resource, part of the render world, that stores the
-/// [`ChromaticAberrationUniform`]s for each view.
+/// A resource, part of the render world, that stores the uniform buffers for
+/// post-processing effects.
+///
+/// This currently holds buffers for [`ChromaticAberrationUniform`] and
+/// [`VignetteUniform`], allowing them to be uploaded to the GPU efficiently.
 #[derive(Resource, Default)]
 pub struct PostProcessingUniformBuffers {
     chromatic_aberration: DynamicUniformBuffer<ChromaticAberrationUniform>,

--- a/crates/bevy_post_process/src/effect_stack/mod.rs
+++ b/crates/bevy_post_process/src/effect_stack/mod.rs
@@ -8,6 +8,7 @@
 mod chromatic_aberration;
 mod vignette;
 
+use bevy_color::ColorToComponents;
 pub use chromatic_aberration::{ChromaticAberration, ChromaticAberrationUniform};
 pub use vignette::{Vignette, VignetteUniform};
 
@@ -444,6 +445,10 @@ pub fn prepare_post_processing_uniforms(
                     radius: vignette.radius,
                     smoothness: vignette.smoothness,
                     roundness: vignette.roundness,
+                    center: vignette.center,
+                    unused_1: 0,
+                    unused_2: 0,
+                    color: vignette.color.to_srgba().to_vec4(),
                 })
         } else {
             post_processing_uniform_buffers

--- a/crates/bevy_post_process/src/effect_stack/mod.rs
+++ b/crates/bevy_post_process/src/effect_stack/mod.rs
@@ -445,8 +445,8 @@ pub fn prepare_post_processing_uniforms(
                     smoothness: vignette.smoothness,
                     roundness: vignette.roundness,
                     center: vignette.center,
-                    unused_1: 0,
-                    unused_2: 0,
+                    edge_compensation: vignette.edge_compensation,
+                    unused: 0,
                     color: vignette.color.to_srgba().to_vec4(),
                 })
         } else {

--- a/crates/bevy_post_process/src/effect_stack/post_process.wgsl
+++ b/crates/bevy_post_process/src/effect_stack/post_process.wgsl
@@ -1,9 +1,11 @@
 // Miscellaneous postprocessing effects, currently just chromatic aberration.
 
 #import bevy_core_pipeline::fullscreen_vertex_shader::FullscreenVertexOutput
-#import bevy_core_pipeline::post_processing::chromatic_aberration::chromatic_aberration
+#import bevy_post_process::effect_stack::chromatic_aberration::chromatic_aberration
+#import bevy_post_process::effect_stack::vignette::vignette
 
 @fragment
 fn fragment_main(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
-    return vec4(chromatic_aberration(in.uv), 1.0);
+    let color = chromatic_aberration(in.uv);
+    return vec4(vignette(in.uv, color), 1.0);
 }

--- a/crates/bevy_post_process/src/effect_stack/vignette.rs
+++ b/crates/bevy_post_process/src/effect_stack/vignette.rs
@@ -11,16 +11,16 @@ use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{extract_component::ExtractComponent, render_resource::ShaderType};
 
 /// The default vignette intensity amount.
-const DEFAULT_VIGNETTE_INTENSITY: f32 = 0.50;
+const DEFAULT_VIGNETTE_INTENSITY: f32 = 1.00;
 
 /// The default vignette radius amount.
-const DEFAULT_VIGNETTE_RADIUS: f32 = 1.00;
+const DEFAULT_VIGNETTE_RADIUS: f32 = 0.75;
 
 /// The default vignette smoothness amount.
-const DEFAULT_VIGNETTE_SMOOTHNESS: f32 = 0.50;
+const DEFAULT_VIGNETTE_SMOOTHNESS: f32 = 5.0;
 
 /// The default vignette roundness amount.
-const DEFAULT_VIGNETTE_ROUNDNESS: f32 = 0.75;
+const DEFAULT_VIGNETTE_ROUNDNESS: f32 = 1.00;
 
 /// Adds a gradual shading effect to the edges of the screen, drawing focus
 /// towards the center.
@@ -62,12 +62,6 @@ pub struct Vignette {
     ///
     /// The default value is 0.75
     pub roundness: f32,
-    /// The color of the vignette.
-    ///
-    /// Typically black for standard darkening, but can be any color for creative effects.
-    ///
-    /// The default value is `Color::BLACK`
-    pub color: Color,
     /// The center of the vignette in UV coordinates (0.0 to 1.0).
     ///
     /// `(0.5, 0.5)` is the exact center of the screen.
@@ -75,6 +69,13 @@ pub struct Vignette {
     ///
     /// The default value is `Vec2::new(0.5, 0.5)`
     pub center: Vec2,
+    pub edge_compensation: f32,
+    /// The color of the vignette.
+    ///
+    /// Typically black for standard darkening, but can be any color for creative effects.
+    ///
+    /// The default value is `Color::BLACK`
+    pub color: Color,
 }
 
 impl Default for Vignette {
@@ -85,6 +86,7 @@ impl Default for Vignette {
             smoothness: DEFAULT_VIGNETTE_SMOOTHNESS,
             roundness: DEFAULT_VIGNETTE_ROUNDNESS,
             color: Color::BLACK,
+            edge_compensation: 1.0,
             center: Vec2::new(0.5, 0.5),
         }
     }
@@ -118,7 +120,7 @@ pub struct VignetteUniform {
     /// The shape of the vignette.
     pub(super) roundness: f32,
     pub(super) center: Vec2,
-    pub(super) unused_1: u32,
-    pub(super) unused_2: u32,
+    pub(super) edge_compensation: f32,
+    pub(super) unused: u32,
     pub(super) color: Vec4,
 }

--- a/crates/bevy_post_process/src/effect_stack/vignette.rs
+++ b/crates/bevy_post_process/src/effect_stack/vignette.rs
@@ -1,0 +1,103 @@
+use bevy_camera::Camera;
+use bevy_ecs::{
+    component::Component,
+    query::{QueryItem, With},
+    reflect::ReflectComponent,
+    system::lifetimeless::Read,
+};
+use bevy_reflect::{std_traits::ReflectDefault, Reflect};
+use bevy_render::{extract_component::ExtractComponent, render_resource::ShaderType};
+
+/// The default vignette intensity amount.
+const DEFAULT_VIGNETTE_INTENSITY: f32 = 0.50;
+
+/// The default vignette radius amount.
+const DEFAULT_VIGNETTE_RADIUS: f32 = 1.00;
+
+/// The default vignette smoothness amount.
+const DEFAULT_VIGNETTE_SMOOTHNESS: f32 = 0.50;
+
+/// The default vignette roundness amount.
+const DEFAULT_VIGNETTE_ROUNDNESS: f32 = 0.75;
+
+/// Adds a gradual shading effect to the edges of the screen, drawing focus
+/// towards the center.
+///
+/// A [Vignette] darkens the corners of the image relative to the center,
+/// simulating the natural fall-off seen in camera lenses and human vision.
+/// This effect is widely used in cinematography and games to direct the
+/// player's attention or to evoke a specific mood (e.g., nostalgia or
+/// claustrophobia).
+///
+/// Bevy's implementation applies a radial mask to the screen, modifying
+/// the alpha channel or luminance of the final image. It supports adjusting
+/// the size, roundness, and softness of the falloff, allowing you to
+/// simulate various optical hardware or stylistic choices.
+#[derive(Reflect, Component, Clone)]
+#[reflect(Component, Default, Clone)]
+pub struct Vignette {
+    /// Controls the strength of the darkening effect.
+    ///
+    /// Range: `0.0` (No effect) to `1.0` (Fully black corners)
+    ///
+    /// The default value is 0.50
+    pub intensity: f32,
+    /// The size of the unvignetted center area.
+    ///
+    /// Range: `0.0` (Tiny center) to `2.0+` (Large center)
+    ///
+    /// The default value is 1.00
+    pub radius: f32,
+    /// The softness of the edge between the clear and dark areas.
+    ///
+    /// Range: `0.01` (Sharp edge) to `1.0` (Very soft edge)
+    ///
+    /// The default value is 0.50
+    pub smoothness: f32,
+    /// The shape of the vignette.
+    ///
+    /// `1.0` represents a perfect circle.
+    ///
+    /// The default value is 0.75
+    pub roundness: f32,
+}
+
+impl Default for Vignette {
+    fn default() -> Self {
+        Self {
+            intensity: DEFAULT_VIGNETTE_INTENSITY,
+            radius: DEFAULT_VIGNETTE_RADIUS,
+            smoothness: DEFAULT_VIGNETTE_SMOOTHNESS,
+            roundness: DEFAULT_VIGNETTE_ROUNDNESS,
+        }
+    }
+}
+
+impl ExtractComponent for Vignette {
+    type QueryData = Read<Vignette>;
+
+    type QueryFilter = With<Camera>;
+
+    type Out = Vignette;
+
+    fn extract_component(vignette: QueryItem<'_, '_, Self::QueryData>) -> Option<Self::Out> {
+        // Skip the postprocessing phase entirely if the intensity is zero.
+        if vignette.intensity > 0.0 {
+            Some(vignette.clone())
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(ShaderType, Default)]
+pub struct VignetteUniform {
+    /// Controls the strength of the darkening effect.
+    pub(super) intensity: f32,
+    /// The size of the unvignetted center area.
+    pub(super) radius: f32,
+    /// The softness of the edge between the clear and dark areas.
+    pub(super) smoothness: f32,
+    /// The shape of the vignette.
+    pub(super) roundness: f32,
+}

--- a/crates/bevy_post_process/src/effect_stack/vignette.rs
+++ b/crates/bevy_post_process/src/effect_stack/vignette.rs
@@ -52,7 +52,7 @@ pub struct Vignette {
     pub radius: f32,
     /// The softness of the edge between the clear and dark areas.
     ///
-    /// Range: `0.01` (Sharp edge) to `1.0` (Very soft edge)
+    /// Range: `0.01` (Sharp edge) to `1.0+` (Very soft edge)
     ///
     /// The default value is 0.50
     pub smoothness: f32,

--- a/crates/bevy_post_process/src/effect_stack/vignette.rs
+++ b/crates/bevy_post_process/src/effect_stack/vignette.rs
@@ -22,6 +22,9 @@ const DEFAULT_VIGNETTE_SMOOTHNESS: f32 = 5.0;
 /// The default vignette roundness amount.
 const DEFAULT_VIGNETTE_ROUNDNESS: f32 = 1.00;
 
+/// The default vignette edge compensation
+const DEFAULT_VIGNETTE_EDGE_COMPENSATION: f32 = 1.00;
+
 /// Adds a gradual shading effect to the edges of the screen, drawing focus
 /// towards the center.
 ///
@@ -69,6 +72,11 @@ pub struct Vignette {
     ///
     /// The default value is `Vec2::new(0.5, 0.5)`
     pub center: Vec2,
+    /// Used to make the vignette effect fit the screen better.
+    ///
+    /// Range: `0.0`(No fit) to `1.0` (Perfect fit)
+    ///
+    /// The default value is 1.00
     pub edge_compensation: f32,
     /// The color of the vignette.
     ///
@@ -86,7 +94,7 @@ impl Default for Vignette {
             smoothness: DEFAULT_VIGNETTE_SMOOTHNESS,
             roundness: DEFAULT_VIGNETTE_ROUNDNESS,
             color: Color::BLACK,
-            edge_compensation: 1.0,
+            edge_compensation: DEFAULT_VIGNETTE_EDGE_COMPENSATION,
             center: Vec2::new(0.5, 0.5),
         }
     }
@@ -119,8 +127,12 @@ pub struct VignetteUniform {
     pub(super) smoothness: f32,
     /// The shape of the vignette.
     pub(super) roundness: f32,
+    /// The center of the vignette.
     pub(super) center: Vec2,
+    /// The edge compensation of the vignette.
     pub(super) edge_compensation: f32,
+    /// Padding data.
     pub(super) unused: u32,
+    /// The color of the vignette.
     pub(super) color: Vec4,
 }

--- a/crates/bevy_post_process/src/effect_stack/vignette.rs
+++ b/crates/bevy_post_process/src/effect_stack/vignette.rs
@@ -1,10 +1,12 @@
 use bevy_camera::Camera;
+use bevy_color::Color;
 use bevy_ecs::{
     component::Component,
     query::{QueryItem, With},
     reflect::ReflectComponent,
     system::lifetimeless::Read,
 };
+use bevy_math::{Vec2, Vec4};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{extract_component::ExtractComponent, render_resource::ShaderType};
 
@@ -60,6 +62,19 @@ pub struct Vignette {
     ///
     /// The default value is 0.75
     pub roundness: f32,
+    /// The color of the vignette.
+    ///
+    /// Typically black for standard darkening, but can be any color for creative effects.
+    ///
+    /// The default value is `Color::BLACK`
+    pub color: Color,
+    /// The center of the vignette in UV coordinates (0.0 to 1.0).
+    ///
+    /// `(0.5, 0.5)` is the exact center of the screen.
+    /// Deviating from this allows for off-center or asymmetric vignette effects.
+    ///
+    /// The default value is `Vec2::new(0.5, 0.5)`
+    pub center: Vec2,
 }
 
 impl Default for Vignette {
@@ -69,6 +84,8 @@ impl Default for Vignette {
             radius: DEFAULT_VIGNETTE_RADIUS,
             smoothness: DEFAULT_VIGNETTE_SMOOTHNESS,
             roundness: DEFAULT_VIGNETTE_ROUNDNESS,
+            color: Color::BLACK,
+            center: Vec2::new(0.5, 0.5),
         }
     }
 }
@@ -100,4 +117,8 @@ pub struct VignetteUniform {
     pub(super) smoothness: f32,
     /// The shape of the vignette.
     pub(super) roundness: f32,
+    pub(super) center: Vec2,
+    pub(super) unused_1: u32,
+    pub(super) unused_2: u32,
+    pub(super) color: Vec4,
 }

--- a/crates/bevy_post_process/src/effect_stack/vignette.wgsl
+++ b/crates/bevy_post_process/src/effect_stack/vignette.wgsl
@@ -57,6 +57,7 @@ fn vignette(uv: vec2<f32>, color: vec3<f32>) -> vec3<f32> {
     let uv_from_center = centered_uv - offset;
     var scale_vec = aspect_ratio * vec2<f32>(1.0, 1.0 / roundness);
 
+    // Apply edge compensation to make the vignette fit the screen better.
     if (screen_aspect >= 1.0) {
         let compensation_factor = mix(1.0, 1.0 / screen_aspect, edge_comp);
         scale_vec.x *= compensation_factor;

--- a/crates/bevy_post_process/src/effect_stack/vignette.wgsl
+++ b/crates/bevy_post_process/src/effect_stack/vignette.wgsl
@@ -21,14 +21,14 @@ struct VignetteSettings {
 @group(0) @binding(5) var<uniform> vignette_settings: VignetteSettings;
 
 fn vignette(uv: vec2<f32>, color: vec3<f32>) -> vec3<f32> {
-    let intensity = clamp(vignette_settings.intensity, 0.0, 1.0);
+    let intensity = saturate(vignette_settings.intensity);
     let radius = max(vignette_settings.radius, 0.0);
     let smoothness = max(vignette_settings.smoothness, 0.0);
     let roundness = max(vignette_settings.roundness, 0.001);
 
     // Get the screen resolution.
     let dims = textureDimensions(source_texture);
-    let resolution = vec2<f32>(f32(dims.x), f32(dims.y));
+    let resolution = vec2<f32>(dims.xy);
 
     // Calculate the aspect ratio.
     //

--- a/crates/bevy_post_process/src/effect_stack/vignette.wgsl
+++ b/crates/bevy_post_process/src/effect_stack/vignette.wgsl
@@ -12,23 +12,31 @@ struct VignetteSettings {
     smoothness: f32,
     roundness: f32,
     center: vec2<f32>,
-    unused_a: u32,
-    unused_b: u32,
+    edge_compensation: f32,
+    unused: u32,
     color: vec4<f32>
 }
+
+const EPSILON: f32 = 1.19209290e-07;
 
 // The settings supplied by the developer.
 @group(0) @binding(5) var<uniform> vignette_settings: VignetteSettings;
 
 fn vignette(uv: vec2<f32>, color: vec3<f32>) -> vec3<f32> {
+    if (vignette_settings.intensity < EPSILON) {
+        return color;
+    }
+
     let intensity = saturate(vignette_settings.intensity);
     let radius = max(vignette_settings.radius, 0.0);
     let smoothness = max(vignette_settings.smoothness, 0.0);
-    let roundness = max(vignette_settings.roundness, 0.001);
+    let roundness = clamp(vignette_settings.roundness, EPSILON, 2.0-EPSILON);
+    let edge_comp = saturate(vignette_settings.edge_compensation);
 
     // Get the screen resolution.
     let dims = textureDimensions(source_texture);
     let resolution = vec2<f32>(dims.xy);
+    let screen_aspect = resolution.x / resolution.y;
 
     // Calculate the aspect ratio.
     //
@@ -47,17 +55,24 @@ fn vignette(uv: vec2<f32>, color: vec3<f32>) -> vec3<f32> {
     let offset = (vignette_settings.center - 0.5) * vec2<f32>(1.0, resolution.y / resolution.x);
 
     let uv_from_center = centered_uv - offset;
-    let final_uv = uv_from_center * aspect_ratio * vec2<f32>(1.0, 1.0 / roundness);
+    var scale_vec = aspect_ratio * vec2<f32>(1.0, 1.0 / roundness);
+
+    if (screen_aspect >= 1.0) {
+        let compensation_factor = mix(1.0, 1.0 / screen_aspect, edge_comp);
+        scale_vec.x *= compensation_factor;
+    } else {
+        let compensation_factor = mix(1.0, screen_aspect, edge_comp);
+        scale_vec.y *= compensation_factor;
+    }
+
+    let final_uv = uv_from_center * scale_vec;
 
     // Calculate distance from center.
-    let dist = length(final_uv) * 2.0;
-
-    let inner_edge = radius;
-    let outer_edge = inner_edge + smoothness;
-
-    // Generate a 0.0 to 1.0 factor based on distance within the edges.
-    let factor = smoothstep(inner_edge, outer_edge, dist);
+    let dist = length(final_uv) * (1.0 / radius);
+    let base_curve = 1.0 - (dist * dist);
+    let clamped_factor = clamp(base_curve, 0.0, 1.0);
+    let factor = pow(clamped_factor, smoothness);
 
     // Blend the original color with the vignette color.
-    return mix(color, vignette_settings.color.rgb, factor * intensity);
+    return mix(color, vignette_settings.color.rgb, (1.0 - factor) * intensity);
 }

--- a/crates/bevy_post_process/src/effect_stack/vignette.wgsl
+++ b/crates/bevy_post_process/src/effect_stack/vignette.wgsl
@@ -1,0 +1,43 @@
+// The vignette postprocessing effect.
+
+#define_import_path bevy_post_process::effect_stack::vignette
+
+#import bevy_post_process::effect_stack::chromatic_aberration::source_texture
+
+// See `bevy_post_process::effect_stack::Vignette` for more
+// information on these fields.
+struct VignetteSettings {
+    intensity: f32,
+    radius: f32,
+    smoothness: f32,
+    roundness: f32,
+}
+
+// The settings supplied by the developer.
+@group(0) @binding(5) var<uniform> vignette_settings: VignetteSettings;
+
+fn vignette(uv: vec2<f32>, color: vec3<f32>) -> vec3<f32> {
+    let intensity = clamp(vignette_settings.intensity, 0.0, 1.0);
+    let radius = max(vignette_settings.radius, 0.0);
+    let smoothness = max(vignette_settings.smoothness, 0.0);
+    let roundness = max(vignette_settings.roundness, 0.001);
+
+    // Correct for the screen aspect ratio so the vignette remains circular, not oval.
+    let dims = textureDimensions(source_texture);
+    let resolution = vec2<f32>(f32(dims.x), f32(dims.y));
+    let aspect_ratio = resolution / min(resolution.x, resolution.y);
+    // Center the UVs at (0,0) and apply aspect correction.
+    let centered_uv = (uv - 0.5) * aspect_ratio;
+    let final_uv = centered_uv * vec2<f32>(1.0, 1.0 / roundness);
+
+    // Calculate distance from center.
+    let dist = length(final_uv) * 2.0;
+
+    let inner_edge = radius;
+    let outer_edge = inner_edge + smoothness;
+
+    // Generate a 0.0 to 1.0 factor based on distance within the edges.
+    let factor = smoothstep(inner_edge, outer_edge, dist);
+
+    return mix(color, vec3<f32>(0.0), factor * intensity);
+}

--- a/examples/3d/post_processing.rs
+++ b/examples/3d/post_processing.rs
@@ -175,20 +175,20 @@ fn handle_keyboard_input(mut app_settings: ResMut<AppSettings>, input: Res<Butto
         0 => {
             app_settings.chromatic_aberration_intensity =
                 (app_settings.chromatic_aberration_intensity + delta)
-                    .clamp(0.0, MAX_CHROMATIC_ABERRATION_INTENSITY)
+                    .clamp(0.0, MAX_CHROMATIC_ABERRATION_INTENSITY);
         }
         1 => {
             app_settings.vignette_intensity =
-                (app_settings.vignette_intensity + delta).clamp(0.0, 1.0)
+                (app_settings.vignette_intensity + delta).clamp(0.0, 1.0);
         }
         2 => app_settings.vignette_radius = (app_settings.vignette_radius + delta).clamp(0.0, 2.0),
         3 => {
             app_settings.vignette_smoothness =
-                (app_settings.vignette_smoothness + delta).clamp(0.01, 1.0)
+                (app_settings.vignette_smoothness + delta).clamp(0.01, 1.0);
         }
         4 => {
             app_settings.vignette_roundness =
-                (app_settings.vignette_roundness + delta).clamp(0.5, 1.0)
+                (app_settings.vignette_roundness + delta).clamp(0.5, 1.0);
         }
         _ => {}
     }

--- a/examples/3d/post_processing.rs
+++ b/examples/3d/post_processing.rs
@@ -190,12 +190,12 @@ fn handle_keyboard_input(mut app_settings: ResMut<AppSettings>, input: Res<Butto
         }
         2 => app_settings.vignette_radius = (app_settings.vignette_radius + delta).clamp(0.0, 2.0),
         3 => {
-            app_settings.vignette_smoothness = (app_settings.vignette_smoothness + delta).max(0.01)
+            app_settings.vignette_smoothness = (app_settings.vignette_smoothness + delta).max(0.01);
         }
         4 => app_settings.vignette_roundness = (app_settings.vignette_roundness + delta).max(0.01),
         5 => {
             app_settings.vignette_edge_compensation =
-                (app_settings.vignette_edge_compensation + delta).clamp(0.0, 1.0)
+                (app_settings.vignette_edge_compensation + delta).clamp(0.0, 1.0);
         }
         _ => {}
     }

--- a/examples/3d/post_processing.rs
+++ b/examples/3d/post_processing.rs
@@ -1,17 +1,22 @@
 //! Demonstrates Bevy's built-in postprocessing features.
 //!
-//! Currently, this simply consists of chromatic aberration.
+//! Includes:
+//!
+//! - Chromatic Aberration
+//! - Vignette
 
 use std::f32::consts::PI;
 
 use bevy::{
-    light::CascadeShadowConfigBuilder, post_process::effect_stack::ChromaticAberration, prelude::*,
+    light::CascadeShadowConfigBuilder,
+    post_process::effect_stack::{ChromaticAberration, Vignette},
+    prelude::*,
     render::view::Hdr,
 };
 
 /// The number of units per frame to add to or subtract from intensity when the
 /// arrow keys are held.
-const CHROMATIC_ABERRATION_INTENSITY_ADJUSTMENT_SPEED: f32 = 0.002;
+const ADJUSTMENT_SPEED: f32 = 0.002;
 
 /// The maximum supported chromatic aberration intensity level.
 const MAX_CHROMATIC_ABERRATION_INTENSITY: f32 = 0.4;
@@ -19,21 +24,20 @@ const MAX_CHROMATIC_ABERRATION_INTENSITY: f32 = 0.4;
 /// The settings that the user can control.
 #[derive(Resource)]
 struct AppSettings {
+    selected: usize,
     /// The intensity of the chromatic aberration effect.
     chromatic_aberration_intensity: f32,
+    vignette_intensity: f32,
+    vignette_radius: f32,
+    vignette_smoothness: f32,
+    vignette_roundness: f32,
 }
 
 /// The entry point.
 fn main() {
     App::new()
         .init_resource::<AppSettings>()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                title: "Bevy Chromatic Aberration Example".into(),
-                ..default()
-            }),
-            ..default()
-        }))
+        .add_plugins(DefaultPlugins)
         .add_systems(Startup, setup)
         .add_systems(Update, handle_keyboard_input)
         .add_systems(
@@ -46,7 +50,7 @@ fn main() {
 }
 
 /// Creates the example scene and spawns the UI.
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>, app_settings: Res<AppSettings>) {
+fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Spawn the camera.
     spawn_camera(&mut commands, &asset_server);
 
@@ -54,7 +58,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, app_settings: R
     spawn_scene(&mut commands, &asset_server);
 
     // Spawn the help text.
-    spawn_text(&mut commands, &app_settings);
+    spawn_text(&mut commands);
 }
 
 /// Spawns the camera, including the [`ChromaticAberration`] component.
@@ -79,6 +83,8 @@ fn spawn_camera(commands: &mut Commands, asset_server: &AssetServer) {
         },
         // Include the `ChromaticAberration` component.
         ChromaticAberration::default(),
+        // Include the `Vignette` component.
+        Vignette::default(),
     ));
 }
 
@@ -118,13 +124,13 @@ fn spawn_scene(commands: &mut Commands, asset_server: &AssetServer) {
     ));
 }
 
-/// Spawns the help text at the bottom of the screen.
-fn spawn_text(commands: &mut Commands, app_settings: &AppSettings) {
+/// Spawns the help text.
+fn spawn_text(commands: &mut Commands) {
     commands.spawn((
-        create_help_text(app_settings),
+        Text::default(),
         Node {
             position_type: PositionType::Absolute,
-            bottom: px(12),
+            top: px(12),
             left: px(12),
             ..default()
         },
@@ -133,43 +139,65 @@ fn spawn_text(commands: &mut Commands, app_settings: &AppSettings) {
 
 impl Default for AppSettings {
     fn default() -> Self {
+        let vignette_default = Vignette::default();
         Self {
+            selected: 0,
             chromatic_aberration_intensity: ChromaticAberration::default().intensity,
+            vignette_intensity: vignette_default.intensity,
+            vignette_radius: vignette_default.radius,
+            vignette_smoothness: vignette_default.smoothness,
+            vignette_roundness: vignette_default.roundness,
         }
     }
 }
 
-/// Creates help text at the bottom of the screen.
-fn create_help_text(app_settings: &AppSettings) -> Text {
-    format!(
-        "Chromatic aberration intensity: {:.2} (Press Left or Right to change)",
-        app_settings.chromatic_aberration_intensity
-    )
-    .into()
-}
-
 /// Handles requests from the user to change the chromatic aberration intensity.
 fn handle_keyboard_input(mut app_settings: ResMut<AppSettings>, input: Res<ButtonInput<KeyCode>>) {
-    let mut delta = 0.0;
-    if input.pressed(KeyCode::ArrowLeft) {
-        delta -= CHROMATIC_ABERRATION_INTENSITY_ADJUSTMENT_SPEED;
-    } else if input.pressed(KeyCode::ArrowRight) {
-        delta += CHROMATIC_ABERRATION_INTENSITY_ADJUSTMENT_SPEED;
+    if input.just_pressed(KeyCode::ArrowUp) && app_settings.selected > 0 {
+        app_settings.selected -= 1;
+    } else if input.just_pressed(KeyCode::ArrowDown) && app_settings.selected < 4 {
+        app_settings.selected += 1;
     }
 
+    let mut delta = 0.0;
+    if input.pressed(KeyCode::ArrowLeft) {
+        delta -= ADJUSTMENT_SPEED;
+    } else if input.pressed(KeyCode::ArrowRight) {
+        delta += ADJUSTMENT_SPEED;
+    }
+    
     // If no arrow key was pressed, just bail out.
     if delta == 0.0 {
         return;
     }
 
-    app_settings.chromatic_aberration_intensity = (app_settings.chromatic_aberration_intensity
-        + delta)
-        .clamp(0.0, MAX_CHROMATIC_ABERRATION_INTENSITY);
+    match app_settings.selected {
+        0 => {
+            app_settings.chromatic_aberration_intensity =
+                (app_settings.chromatic_aberration_intensity + delta)
+                    .clamp(0.0, MAX_CHROMATIC_ABERRATION_INTENSITY)
+        }
+        1 => {
+            app_settings.vignette_intensity =
+                (app_settings.vignette_intensity + delta).clamp(0.0, 1.0)
+        }
+        2 => app_settings.vignette_radius = (app_settings.vignette_radius + delta).clamp(0.0, 2.0),
+        3 => {
+            app_settings.vignette_smoothness =
+                (app_settings.vignette_smoothness + delta).clamp(0.01, 1.0)
+        }
+        4 => {
+            app_settings.vignette_roundness =
+                (app_settings.vignette_roundness + delta).clamp(0.5, 1.0)
+        }
+        _ => {}
+    }
 }
 
 /// Updates the [`ChromaticAberration`] settings per the [`AppSettings`].
 fn update_chromatic_aberration_settings(
     mut chromatic_aberration: Query<&mut ChromaticAberration>,
+    mut vignette: Query<&mut Vignette>,
     app_settings: Res<AppSettings>,
 ) {
     let intensity = app_settings.chromatic_aberration_intensity;
@@ -187,12 +215,43 @@ fn update_chromatic_aberration_settings(
         chromatic_aberration.intensity = intensity;
         chromatic_aberration.max_samples = max_samples;
     }
+
+    for mut vignette in &mut vignette {
+        vignette.intensity = app_settings.vignette_intensity;
+        vignette.radius = app_settings.vignette_radius;
+        vignette.smoothness = app_settings.vignette_smoothness;
+        vignette.roundness = app_settings.vignette_roundness;
+    }
 }
 
 /// Updates the help text at the bottom of the screen to reflect the current
 /// [`AppSettings`].
-fn update_help_text(mut text: Query<&mut Text>, app_settings: Res<AppSettings>) {
-    for mut text in text.iter_mut() {
-        *text = create_help_text(&app_settings);
+fn update_help_text(mut text: Single<&mut Text>, app_settings: Res<AppSettings>) {
+    text.clear();
+    let text_list = vec![
+        format!(
+            "Chromatic aberration intensity: {:.2}\n",
+            app_settings.chromatic_aberration_intensity
+        ),
+        format!(
+            "Vignette intensity: {:.2}\n",
+            app_settings.vignette_intensity
+        ),
+        format!("Vignette radius: {:.2}\n", app_settings.vignette_radius),
+        format!(
+            "Vignette smoothness: {:.2}\n",
+            app_settings.vignette_smoothness
+        ),
+        format!(
+            "Vignette roundness: {:.2}\n",
+            app_settings.vignette_roundness
+        ),
+    ];
+    for (i, val) in text_list.iter().enumerate() {
+        if i == app_settings.selected {
+            text.push_str("> ");
+        }
+        text.push_str(val);
     }
+    text.push_str("\n(Press Up or Down to select)\n(Press Left or Right to change)");
 }

--- a/examples/3d/post_processing.rs
+++ b/examples/3d/post_processing.rs
@@ -165,7 +165,7 @@ fn handle_keyboard_input(mut app_settings: ResMut<AppSettings>, input: Res<Butto
     } else if input.pressed(KeyCode::ArrowRight) {
         delta += ADJUSTMENT_SPEED;
     }
-    
+
     // If no arrow key was pressed, just bail out.
     if delta == 0.0 {
         return;

--- a/examples/3d/post_processing.rs
+++ b/examples/3d/post_processing.rs
@@ -24,12 +24,17 @@ const MAX_CHROMATIC_ABERRATION_INTENSITY: f32 = 0.4;
 /// The settings that the user can control.
 #[derive(Resource)]
 struct AppSettings {
+    /// The index of the currently selected UI item.
     selected: usize,
     /// The intensity of the chromatic aberration effect.
     chromatic_aberration_intensity: f32,
+    /// The intensity of the vignette effect.
     vignette_intensity: f32,
+    /// The radius of the vignette.
     vignette_radius: f32,
+    /// The smoothness of the vignette.
     vignette_smoothness: f32,
+    /// The roundness of the vignette.
     vignette_roundness: f32,
 }
 

--- a/examples/3d/post_processing.rs
+++ b/examples/3d/post_processing.rs
@@ -36,6 +36,7 @@ struct AppSettings {
     vignette_smoothness: f32,
     /// The roundness of the vignette.
     vignette_roundness: f32,
+    /// The edge_compensation of the vignette.
     vignette_edge_compensation: f32,
 }
 
@@ -162,7 +163,7 @@ impl Default for AppSettings {
 fn handle_keyboard_input(mut app_settings: ResMut<AppSettings>, input: Res<ButtonInput<KeyCode>>) {
     if input.just_pressed(KeyCode::ArrowUp) && app_settings.selected > 0 {
         app_settings.selected -= 1;
-    } else if input.just_pressed(KeyCode::ArrowDown) && app_settings.selected < 6 {
+    } else if input.just_pressed(KeyCode::ArrowDown) && app_settings.selected < 5 {
         app_settings.selected += 1;
     }
 

--- a/examples/3d/post_processing.rs
+++ b/examples/3d/post_processing.rs
@@ -228,7 +228,7 @@ fn update_chromatic_aberration_settings(
 /// [`AppSettings`].
 fn update_help_text(mut text: Single<&mut Text>, app_settings: Res<AppSettings>) {
     text.clear();
-    let text_list = vec![
+    let text_list = [
         format!(
             "Chromatic aberration intensity: {:.2}\n",
             app_settings.chromatic_aberration_intensity

--- a/examples/3d/post_processing.rs
+++ b/examples/3d/post_processing.rs
@@ -36,7 +36,7 @@ struct AppSettings {
     vignette_smoothness: f32,
     /// The roundness of the vignette.
     vignette_roundness: f32,
-    /// The edge_compensation of the vignette.
+    /// The edge compensation of the vignette.
     vignette_edge_compensation: f32,
 }
 

--- a/release-content/release-notes/post-process_vignette_effect.md
+++ b/release-content/release-notes/post-process_vignette_effect.md
@@ -1,0 +1,16 @@
+---
+title: "Post-process vignette effect"
+authors: ["@Breakdown-Dog"]
+pull_requests: [22564]
+--- 
+
+We’ve added vignette, which is a common post-processing effect that creates a reduction of image brightness towards the periphery compared to the image center. It’s often used to draw focus to the center of the screen or to simulate the look of a camera lens.
+
+To use it, add the `Vignette` component to your camera:
+
+```rust
+commands.spawn((
+    Camera3d::default(),
+    Vignette::default()
+))
+```


### PR DESCRIPTION
# Objective

- Implement post-process vignette effect base on built-in postprocessing shader.

## Testing

- Component `ChromaticAberration` and `Vignette` can work independently.
- Example `post_processing` working well.
- CI

---

## Showcase
- No effect
<img width="2550" height="1338" alt="no_effect" src="https://github.com/user-attachments/assets/6ce3dbe5-39a6-4e04-bdaa-6703dc4b9701" />
- With Vignette
<img width="2559" height="1341" alt="no_ac" src="https://github.com/user-attachments/assets/15f2a402-d6b2-431c-8f13-2a608f5060a4" />
- With ChromaticAberration and Vignette
<img width="2559" height="1341" alt="vignette_1" src="https://github.com/user-attachments/assets/b99d4207-0cde-4459-ac8a-d1836fb5b8ee" />

</details>
