### PR TITLE
Allow for querying supported sample counts in Msaa

### DIFF
--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -16,7 +16,7 @@ use crate::{
     render_asset::RenderAssets,
     render_phase::ViewRangefinder3d,
     render_resource::{DynamicUniformBuffer, ShaderType, Texture, TextureView},
-    renderer::{RenderDevice, RenderQueue},
+    renderer::{RenderAdapter, RenderDevice, RenderQueue},
     sync_world::MainEntity,
     texture::{
         CachedTexture, ColorAttachment, DepthAttachment, GpuImage, ManualTextureViews,
@@ -259,6 +259,16 @@ impl Msaa {
             8 => Msaa::Sample8,
             _ => panic!("Unsupported MSAA sample count: {samples}"),
         }
+    }
+
+    /// Returns a non-empty list of supported `Msaa` sample counts by `render_adapter`, in increasing order.
+    pub fn supported_samples(render_adapter: &RenderAdapter) -> Vec<u32> {
+        // While max. sample count is defined on the device level in the underlying graphics APIs, for some reason
+        // WebGPU ties it to texture formats, so we pass the default non-HDR camera target format here for the query.
+        render_adapter
+            .get_texture_format_features(TextureFormat::Rgba8UnormSrgb)
+            .flags
+            .supported_sample_counts()
     }
 }
 

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -269,6 +269,11 @@ impl Msaa {
         }
     }
 
+    /// Creates `Msaa` with the highest sample count supported by `render_adapter`.
+    pub fn max_supported(render_adapter: &RenderAdapter) -> Self {
+        Self::from_samples(*Self::supported_samples(render_adapter).last().unwrap_or(&1))
+    }
+
     /// Returns a non-empty list of supported `Msaa` sample counts by `render_adapter`, in increasing order.
     pub fn supported_samples(render_adapter: &RenderAdapter) -> Vec<u32> {
         // While max. sample count is defined on the device level in the underlying graphics APIs, for some reason

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -217,11 +217,13 @@ impl Plugin for ViewPlugin {
 /// Component for configuring the number of samples for [Multi-Sample Anti-Aliasing](https://en.wikipedia.org/wiki/Multisample_anti-aliasing)
 /// for a [`Camera`](bevy_camera::Camera).
 ///
-/// Defaults to 4 samples. A higher number of samples results in smoother edges.
+/// Defaults to 4 samples, as it's the common baseline for web and native. A higher number of samples results in
+/// smoother edges.
+///
+/// Actual support for given sample counts varies by platform and GPU. Use [`Msaa::list_supported`] to get a list of
+/// actually supported sample counts on the current rendering device.
 ///
 /// Some advanced rendering features may require that MSAA is disabled.
-///
-/// Note that the web currently only supports 1 or 4 samples.
 #[derive(
     Component,
     Default,
@@ -251,6 +253,12 @@ impl Msaa {
         *self as u32
     }
 
+    /// Creates `Msaa` with the given sample count.
+    ///
+    /// `samples` must be 1, 2, 4 or 8.
+    ///
+    /// Use [`Self::list_supported`] to get a list of actually supported sample counts on the current rendering
+    /// device.
     pub fn from_samples(samples: u32) -> Self {
         match samples {
             1 => Msaa::Off,

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -271,17 +271,20 @@ impl Msaa {
 
     /// Creates `Msaa` with the highest sample count supported by `render_adapter`.
     pub fn max_supported(render_adapter: &RenderAdapter) -> Self {
-        Self::from_samples(*Self::supported_samples(render_adapter).last().unwrap_or(&1))
+        *Self::list_supported(render_adapter).last().unwrap()
     }
 
-    /// Returns a non-empty list of supported `Msaa` sample counts by `render_adapter`, in increasing order.
-    pub fn supported_samples(render_adapter: &RenderAdapter) -> Vec<u32> {
+    /// Returns a non-empty list of supported `Msaa` modes by `render_adapter`, in increasing order of sample counts.
+    pub fn list_supported(render_adapter: &RenderAdapter) -> Vec<Self> {
         // While max. sample count is defined on the device level in the underlying graphics APIs, for some reason
         // WebGPU ties it to texture formats, so we pass the default non-HDR camera target format here for the query.
         render_adapter
             .get_texture_format_features(TextureFormat::Rgba8UnormSrgb)
             .flags
             .supported_sample_counts()
+            .into_iter()
+            .map(Self::from_samples)
+            .collect()
     }
 }
 

--- a/examples/3d/anti_aliasing.rs
+++ b/examples/3d/anti_aliasing.rs
@@ -18,6 +18,7 @@ use bevy::{
     render::{
         camera::{MipBias, TemporalJitter},
         render_resource::{Extent3d, TextureDimension, TextureFormat},
+        renderer::RenderAdapter,
     },
 };
 
@@ -65,6 +66,7 @@ type DlssComponents = ();
 
 fn modify_aa(
     keys: Res<ButtonInput<KeyCode>>,
+    supported_msaa_sample_counts: Res<SupportedMsaaSampleCounts>,
     #[cfg(all(feature = "dlss", not(feature = "force_disable_dlss")))] camera: Single<
         (
             Entity,
@@ -115,18 +117,30 @@ fn modify_aa(
             .remove::<TaaComponents>()
             .remove::<DlssComponents>();
 
-        *msaa = Msaa::Sample4;
+        *msaa = Msaa::default();
     }
 
     // MSAA Sample Count
     if *msaa != Msaa::Off {
-        if keys.just_pressed(KeyCode::KeyQ) {
+        if keys.just_pressed(KeyCode::KeyQ)
+            && supported_msaa_sample_counts
+                .0
+                .contains(&Msaa::Sample2.samples())
+        {
             *msaa = Msaa::Sample2;
         }
-        if keys.just_pressed(KeyCode::KeyW) {
+        if keys.just_pressed(KeyCode::KeyW)
+            && supported_msaa_sample_counts
+                .0
+                .contains(&Msaa::Sample4.samples())
+        {
             *msaa = Msaa::Sample4;
         }
-        if keys.just_pressed(KeyCode::KeyE) {
+        if keys.just_pressed(KeyCode::KeyE)
+            && supported_msaa_sample_counts
+                .0
+                .contains(&Msaa::Sample8.samples())
+        {
             *msaa = Msaa::Sample8;
         }
     }
@@ -303,6 +317,7 @@ fn update_ui(
         With<Camera>,
     >,
     mut ui: Single<&mut Text>,
+    supported_msaa_sample_counts: Res<SupportedMsaaSampleCounts>,
     #[cfg(all(feature = "dlss", not(feature = "force_disable_dlss")))] dlss_supported: Option<
         Res<DlssSuperResolutionSupported>,
     >,
@@ -337,9 +352,20 @@ fn update_ui(
 
     if *msaa != Msaa::Off {
         ui.push_str("\n----------\n\nSample Count\n");
-        draw_selectable_menu_item(ui, "2", 'Q', *msaa == Msaa::Sample2);
-        draw_selectable_menu_item(ui, "4", 'W', *msaa == Msaa::Sample4);
-        draw_selectable_menu_item(ui, "8", 'E', *msaa == Msaa::Sample8);
+
+        for (sample_count, shortcut) in supported_msaa_sample_counts
+            .0
+            .iter()
+            .skip(1) // First supported sample count is always '1' (no multisampling), skip it
+            .zip(['Q', 'W', 'E'].into_iter())
+        {
+            draw_selectable_menu_item(
+                ui,
+                sample_count.to_string().as_str(),
+                shortcut,
+                msaa.samples() == *sample_count,
+            );
+        }
     }
 
     if let Some(fxaa) = fxaa {
@@ -408,6 +434,9 @@ fn update_ui(
     );
 }
 
+#[derive(Resource)]
+struct SupportedMsaaSampleCounts(Vec<u32>);
+
 /// Set up a simple 3D scene
 fn setup(
     mut commands: Commands,
@@ -415,6 +444,7 @@ fn setup(
     mut materials: ResMut<Assets<StandardMaterial>>,
     mut images: ResMut<Assets<Image>>,
     asset_server: Res<AssetServer>,
+    render_adapter: Res<RenderAdapter>,
 ) {
     // Plane
     commands.spawn((
@@ -481,6 +511,14 @@ fn setup(
             ..default()
         },
     ));
+
+    // Check for supported MSAA sample counts
+    let supported_msaa_sample_counts = Msaa::supported_samples(&render_adapter);
+    info!(
+        "Supported MSAA sample counts on this device: {:?}",
+        supported_msaa_sample_counts
+    );
+    commands.insert_resource(SupportedMsaaSampleCounts(supported_msaa_sample_counts));
 
     // example instructions
     commands.spawn((

--- a/examples/3d/anti_aliasing.rs
+++ b/examples/3d/anti_aliasing.rs
@@ -345,7 +345,7 @@ fn update_ui(
             .0
             .iter()
             .skip(1) // First supported sample count is always '1' (no multisampling), skip it
-            .zip(['Q', 'W', 'E'].into_iter())
+            .zip(['Q', 'W', 'E'])
         {
             draw_selectable_menu_item(
                 ui,


### PR DESCRIPTION
# Objective

Adds support for querying supported MSAA sample counts on the current GPU, making possible for users to select only supported MSAA modes, thus avoiding fatal WGPU validation errors.

- Fixes #15789 
- Closes #3961

## Solution

1. At first I tried to put validation right before texture creation (`TextureCache::get`), since for some reason WebGPU ties max. sample count info to texture formats, and that's trivially available there. But max. sample count query also requires a `RenderAdapter`, and passing it to all callsites was not really feasible.
2. Then I realized that the underlying graphics APIs provide max. sample count on the device level, so we can probably get away with using a dummy/default texture format, so query/validation can be put into `Msaa` implementation instead.

- `Msaa` now exposes a method to retrieve supported sample counts on the given `RenderAdapter`. Usage is opt-in, `Msaa::from_samples` still won't check for actual GPU support.
- A utility constructor is now also available to create `Msaa` with the highest supported sample count.
- `anti_aliasing` example got adapted to these changes, to only show supported MSAA modes.

## Testing

- Tested using the improved `anti_aliasing` example:
  - On an M1 MacBook it correctly displays only MSAAx2 and MSAAx4
  - On the web it correctly displays only MSAAx4
  - On a Windows laptop it correctly displays MSAAx2, MSAAx4 and MSAAx8, according to the iGPU's capabilities
- Not tested on MSAAx16 capable hardware (but there's not many such AFAIK anyway)
