### PR TITLE
Fix panic in update_viewport_render_target_size when despawning

### DIFF
--- a/crates/bevy_ui/src/widget/viewport.rs
+++ b/crates/bevy_ui/src/widget/viewport.rs
@@ -42,7 +42,11 @@ use bevy_reflect::Reflect;
 pub struct ViewportNode {
     /// The entity representing the [`Camera`] associated with this viewport.
     ///
-    /// Note that removing the [`ViewportNode`] component will not despawn this entity.
+    /// Note: Removing the [`ViewportNode`] component will not despawn this
+    /// entity.
+    ///
+    /// Note: Despawning the camera entity will leave a viewport node with an
+    /// invalid camera.
     pub camera: Entity,
 }
 
@@ -161,7 +165,9 @@ pub fn update_viewport_render_target_size(
     mut images: ResMut<Assets<Image>>,
 ) {
     for (viewport, computed_node) in &viewport_query {
-        let render_target = camera_query.get(viewport.camera).unwrap();
+        let Ok(render_target) = camera_query.get(viewport.camera) else {
+            continue;
+        };
         let size = computed_node.size();
 
         let Some(image_handle) = render_target.as_image() else {


### PR DESCRIPTION
# Objective

- Fix a panic when you despawn a camera linked to a `ViewportNode`.
- [In Discord](https://discord.com/channels/691052431525675048/866787577687310356/1461961801250898013) I was asking about why adding `Msaa::Off` to my camera causes a gray screen and it turns out it's related to my inspector egui camera. While trying to work out the cause, I was going through the egui inspector and despawning camera to see if it helped. While despawning one of my cameras which is referenced in a `ViewportNode`, I got this panic due to `unwrap()` being used.

## Solution

- Don't `unwrap` but just ignore the camera if it no longer exists. This can easily happen if the camera entity is despawned, e.g., using `DespawnOnExit` state, or manually despawned in an editor/inspector.
- This means that the `ViewportNode` is left with a dangling/invalid reference. I'm not sure how to solve that though?
- Also update the doc to mention what happens.
- Note: There's another unwrap in the system but I don't want to change it in this PR. I didn't experience that panic so I'd rather leave it out of this PR (it may be a useful panic so should be considered separately).

## Testing

- Tested in my Bevy 0.17 fork that it no longer panics.

