### PR TITLE
fix(examples): Use letter "t" to enter turbo mode, regardless of kb l…

### DIFF
--- a/examples/state/computed_states.rs
+++ b/examples/state/computed_states.rs
@@ -16,7 +16,7 @@
 //! And lastly, we'll add [`Tutorial`], a computed state deriving from [`TutorialState`], [`InGame`] and [`IsPaused`], with 2 distinct
 //! states to display the 2 tutorial texts.
 
-use bevy::{dev_tools::states::*, prelude::*};
+use bevy::{dev_tools::states::*, input::keyboard::Key, prelude::*};
 
 use ui::*;
 
@@ -282,11 +282,11 @@ fn toggle_pause(
 }
 
 fn toggle_turbo(
-    input: Res<ButtonInput<KeyCode>>,
+    input: Res<ButtonInput<Key>>,
     current_state: Res<State<AppState>>,
     mut next_state: ResMut<NextState<AppState>>,
 ) {
-    if input.just_pressed(KeyCode::KeyT)
+    if input.just_pressed(Key::Character("t".into()))
         && let AppState::InGame { paused, turbo } = current_state.get()
     {
         next_state.set(AppState::InGame {


### PR DESCRIPTION
…ayout

The help text reads "Press T to enter TURBO MODE", so I pressed T and nothing happened :shrug: ... But I use a Dvorak layout.

So I pressed Y for YURBO MODE and it worked :upside_down_face:

# Objective

Fix a little QoL issue found when looking at the examples. I.e. The in-game text tells me to press a key that does not work on my keyboard layout.

## Solution

I replaced the physical location based check (keycode) with a check for the meaning of the key, after it's mapped by the keyboard layout.

## Testing

```sh
cargo run --example computed_states --features="bevy_dev_tools"
```

The issue might be present in other states examples, I haven't checked