### PR TITLE
Replace old `E` generic with `M`, left over from `Event` to `Message` rename

### DIFF
--- a/crates/bevy_ecs/src/message/message_cursor.rs
+++ b/crates/bevy_ecs/src/message/message_cursor.rs
@@ -8,7 +8,7 @@ use core::marker::PhantomData;
 
 /// Stores the state for a [`MessageReader`] or [`MessageMutator`].
 ///
-/// Access to the [`Messages<E>`] resource is required to read any incoming messages.
+/// Access to the [`Messages<M>`] resource is required to read any incoming messages.
 ///
 /// In almost all cases, you should just use a [`MessageReader`] or [`MessageMutator`],
 /// which will automatically manage the state for you.
@@ -51,12 +51,12 @@ use core::marker::PhantomData;
 /// [`MessageReader`]: super::MessageReader
 /// [`MessageMutator`]: super::MessageMutator
 #[derive(Debug)]
-pub struct MessageCursor<E: Message> {
+pub struct MessageCursor<M: Message> {
     pub(super) last_message_count: usize,
-    pub(super) _marker: PhantomData<E>,
+    pub(super) _marker: PhantomData<M>,
 }
 
-impl<E: Message> Default for MessageCursor<E> {
+impl<M: Message> Default for MessageCursor<M> {
     fn default() -> Self {
         MessageCursor {
             last_message_count: 0,
@@ -65,7 +65,7 @@ impl<E: Message> Default for MessageCursor<E> {
     }
 }
 
-impl<E: Message> Clone for MessageCursor<E> {
+impl<M: Message> Clone for MessageCursor<M> {
     fn clone(&self) -> Self {
         MessageCursor {
             last_message_count: self.last_message_count,
@@ -74,36 +74,36 @@ impl<E: Message> Clone for MessageCursor<E> {
     }
 }
 
-impl<E: Message> MessageCursor<E> {
+impl<M: Message> MessageCursor<M> {
     /// See [`MessageReader::read`](super::MessageReader::read)
-    pub fn read<'a>(&'a mut self, messages: &'a Messages<E>) -> MessageIterator<'a, E> {
+    pub fn read<'a>(&'a mut self, messages: &'a Messages<M>) -> MessageIterator<'a, M> {
         self.read_with_id(messages).without_id()
     }
 
     /// See [`MessageMutator::read`](super::MessageMutator::read)
-    pub fn read_mut<'a>(&'a mut self, messages: &'a mut Messages<E>) -> MessageMutIterator<'a, E> {
+    pub fn read_mut<'a>(&'a mut self, messages: &'a mut Messages<M>) -> MessageMutIterator<'a, M> {
         self.read_mut_with_id(messages).without_id()
     }
 
     /// See [`MessageReader::read_with_id`](super::MessageReader::read_with_id)
     pub fn read_with_id<'a>(
         &'a mut self,
-        messages: &'a Messages<E>,
-    ) -> MessageIteratorWithId<'a, E> {
+        messages: &'a Messages<M>,
+    ) -> MessageIteratorWithId<'a, M> {
         MessageIteratorWithId::new(self, messages)
     }
 
     /// See [`MessageMutator::read_with_id`](super::MessageMutator::read_with_id)
     pub fn read_mut_with_id<'a>(
         &'a mut self,
-        messages: &'a mut Messages<E>,
-    ) -> MessageMutIteratorWithId<'a, E> {
+        messages: &'a mut Messages<M>,
+    ) -> MessageMutIteratorWithId<'a, M> {
         MessageMutIteratorWithId::new(self, messages)
     }
 
     /// See [`MessageReader::par_read`](super::MessageReader::par_read)
     #[cfg(feature = "multi_threaded")]
-    pub fn par_read<'a>(&'a mut self, messages: &'a Messages<E>) -> MessageParIter<'a, E> {
+    pub fn par_read<'a>(&'a mut self, messages: &'a Messages<M>) -> MessageParIter<'a, M> {
         MessageParIter::new(self, messages)
     }
 
@@ -111,13 +111,13 @@ impl<E: Message> MessageCursor<E> {
     #[cfg(feature = "multi_threaded")]
     pub fn par_read_mut<'a>(
         &'a mut self,
-        messages: &'a mut Messages<E>,
-    ) -> MessageMutParIter<'a, E> {
+        messages: &'a mut Messages<M>,
+    ) -> MessageMutParIter<'a, M> {
         MessageMutParIter::new(self, messages)
     }
 
     /// See [`MessageReader::len`](super::MessageReader::len)
-    pub fn len(&self, messages: &Messages<E>) -> usize {
+    pub fn len(&self, messages: &Messages<M>) -> usize {
         // The number of messages in this reader is the difference between the most recent message
         // and the last message seen by it. This will be at most the number of messages contained
         // with the messages (any others have already been dropped)
@@ -129,19 +129,19 @@ impl<E: Message> MessageCursor<E> {
     }
 
     /// Amount of messages we missed.
-    pub fn missed_messages(&self, messages: &Messages<E>) -> usize {
+    pub fn missed_messages(&self, messages: &Messages<M>) -> usize {
         messages
             .oldest_message_count()
             .saturating_sub(self.last_message_count)
     }
 
     /// See [`MessageReader::is_empty()`](super::MessageReader::is_empty)
-    pub fn is_empty(&self, messages: &Messages<E>) -> bool {
+    pub fn is_empty(&self, messages: &Messages<M>) -> bool {
         self.len(messages) == 0
     }
 
     /// See [`MessageReader::clear()`](super::MessageReader::clear)
-    pub fn clear(&mut self, messages: &Messages<E>) {
+    pub fn clear(&mut self, messages: &Messages<M>) {
         self.last_message_count = messages.message_count;
     }
 }

--- a/crates/bevy_ecs/src/message/message_mutator.rs
+++ b/crates/bevy_ecs/src/message/message_mutator.rs
@@ -42,22 +42,22 @@ use crate::{
 /// [`MessageReader`]: super::MessageReader
 /// [`MessageWriter`]: super::MessageWriter
 #[derive(SystemParam, Debug)]
-pub struct MessageMutator<'w, 's, E: Message> {
-    pub(super) reader: Local<'s, MessageCursor<E>>,
+pub struct MessageMutator<'w, 's, M: Message> {
+    pub(super) reader: Local<'s, MessageCursor<M>>,
     #[system_param(validation_message = "Message not initialized")]
-    messages: ResMut<'w, Messages<E>>,
+    messages: ResMut<'w, Messages<M>>,
 }
 
-impl<'w, 's, E: Message> MessageMutator<'w, 's, E> {
+impl<'w, 's, M: Message> MessageMutator<'w, 's, M> {
     /// Iterates over the messages this [`MessageMutator`] has not seen yet. This updates the
     /// [`MessageMutator`]'s message counter, which means subsequent message reads will not include messages
     /// that happened before now.
-    pub fn read(&mut self) -> MessageMutIterator<'_, E> {
+    pub fn read(&mut self) -> MessageMutIterator<'_, M> {
         self.reader.read_mut(&mut self.messages)
     }
 
     /// Like [`read`](Self::read), except also returning the [`MessageId`](super::MessageId) of the messages.
-    pub fn read_with_id(&mut self) -> MessageMutIteratorWithId<'_, E> {
+    pub fn read_with_id(&mut self) -> MessageMutIteratorWithId<'_, M> {
         self.reader.read_mut_with_id(&mut self.messages)
     }
 
@@ -97,7 +97,7 @@ impl<'w, 's, E: Message> MessageMutator<'w, 's, E> {
     /// assert_eq!(counter.into_inner(), 4950);
     /// ```
     #[cfg(feature = "multi_threaded")]
-    pub fn par_read(&mut self) -> MessageMutParIter<'_, E> {
+    pub fn par_read(&mut self) -> MessageMutParIter<'_, M> {
         self.reader.par_read_mut(&mut self.messages)
     }
 

--- a/crates/bevy_ecs/src/message/message_reader.rs
+++ b/crates/bevy_ecs/src/message/message_reader.rs
@@ -14,22 +14,22 @@ use crate::{
 ///
 /// [`MessageWriter<T>`]: super::MessageWriter
 #[derive(SystemParam, Debug)]
-pub struct MessageReader<'w, 's, E: Message> {
-    pub(super) reader: Local<'s, MessageCursor<E>>,
+pub struct MessageReader<'w, 's, M: Message> {
+    pub(super) reader: Local<'s, MessageCursor<M>>,
     #[system_param(validation_message = "Message not initialized")]
-    messages: Res<'w, Messages<E>>,
+    messages: Res<'w, Messages<M>>,
 }
 
-impl<'w, 's, E: Message> MessageReader<'w, 's, E> {
+impl<'w, 's, M: Message> MessageReader<'w, 's, M> {
     /// Iterates over the messages this [`MessageReader`] has not seen yet. This updates the
     /// [`MessageReader`]'s message counter, which means subsequent message reads will not include messages
     /// that happened before now.
-    pub fn read(&mut self) -> MessageIterator<'_, E> {
+    pub fn read(&mut self) -> MessageIterator<'_, M> {
         self.reader.read(&self.messages)
     }
 
     /// Like [`read`](Self::read), except also returning the [`MessageId`](super::MessageId) of the messages.
-    pub fn read_with_id(&mut self) -> MessageIteratorWithId<'_, E> {
+    pub fn read_with_id(&mut self) -> MessageIteratorWithId<'_, M> {
         self.reader.read_with_id(&self.messages)
     }
 
@@ -69,7 +69,7 @@ impl<'w, 's, E: Message> MessageReader<'w, 's, E> {
     /// assert_eq!(counter.into_inner(), 4950);
     /// ```
     #[cfg(feature = "multi_threaded")]
-    pub fn par_read(&mut self) -> MessageParIter<'_, E> {
+    pub fn par_read(&mut self) -> MessageParIter<'_, M> {
         self.reader.par_read(&self.messages)
     }
 

--- a/crates/bevy_ecs/src/message/message_writer.rs
+++ b/crates/bevy_ecs/src/message/message_writer.rs
@@ -54,19 +54,19 @@ use crate::{
 ///
 /// [`Observer`]: crate::observer::Observer
 #[derive(SystemParam)]
-pub struct MessageWriter<'w, E: Message> {
+pub struct MessageWriter<'w, M: Message> {
     #[system_param(validation_message = "Message not initialized")]
-    messages: ResMut<'w, Messages<E>>,
+    messages: ResMut<'w, Messages<M>>,
 }
 
-impl<'w, E: Message> MessageWriter<'w, E> {
+impl<'w, M: Message> MessageWriter<'w, M> {
     /// Writes an `message`, which can later be read by [`MessageReader`](super::MessageReader)s.
     /// This method returns the [ID](`MessageId`) of the written `message`.
     ///
     /// See [`Messages`] for details.
     #[doc(alias = "send")]
     #[track_caller]
-    pub fn write(&mut self, message: E) -> MessageId<E> {
+    pub fn write(&mut self, message: M) -> MessageId<M> {
         self.messages.write(message)
     }
 
@@ -77,7 +77,7 @@ impl<'w, E: Message> MessageWriter<'w, E> {
     /// See [`Messages`] for details.
     #[doc(alias = "send_batch")]
     #[track_caller]
-    pub fn write_batch(&mut self, messages: impl IntoIterator<Item = E>) -> WriteBatchIds<E> {
+    pub fn write_batch(&mut self, messages: impl IntoIterator<Item = M>) -> WriteBatchIds<M> {
         self.messages.write_batch(messages)
     }
 
@@ -87,9 +87,9 @@ impl<'w, E: Message> MessageWriter<'w, E> {
     /// See [`Messages`] for details.
     #[doc(alias = "send_default")]
     #[track_caller]
-    pub fn write_default(&mut self) -> MessageId<E>
+    pub fn write_default(&mut self) -> MessageId<M>
     where
-        E: Default,
+        M: Default,
     {
         self.messages.write_default()
     }

--- a/crates/bevy_ecs/src/message/messages.rs
+++ b/crates/bevy_ecs/src/message/messages.rs
@@ -92,17 +92,17 @@ use {
 /// [`message_update_system`]: super::message_update_system
 #[derive(Debug, Resource)]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Resource, Default))]
-pub struct Messages<E: Message> {
+pub struct Messages<M: Message> {
     /// Holds the oldest still active messages.
     /// Note that `a.start_message_count + a.len()` should always be equal to `messages_b.start_message_count`.
-    pub(crate) messages_a: MessageSequence<E>,
+    pub(crate) messages_a: MessageSequence<M>,
     /// Holds the newer messages.
-    pub(crate) messages_b: MessageSequence<E>,
+    pub(crate) messages_b: MessageSequence<M>,
     pub(crate) message_count: usize,
 }
 
-// Derived Default impl would incorrectly require E: Default
-impl<E: Message> Default for Messages<E> {
+// Derived Default impl would incorrectly require M: Default
+impl<M: Message> Default for Messages<M> {
     fn default() -> Self {
         Self {
             messages_a: Default::default(),
@@ -290,11 +290,11 @@ impl<M: Message> Messages<M> {
     }
 }
 
-impl<E: Message> Extend<E> for Messages<E> {
+impl<M: Message> Extend<M> for Messages<M> {
     #[track_caller]
     fn extend<I>(&mut self, iter: I)
     where
-        I: IntoIterator<Item = E>,
+        I: IntoIterator<Item = M>,
     {
         let old_count = self.message_count;
         let mut message_count = self.message_count;
@@ -328,13 +328,13 @@ impl<E: Message> Extend<E> for Messages<E> {
 
 #[derive(Debug)]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Default))]
-pub(crate) struct MessageSequence<E: Message> {
-    pub(crate) messages: Vec<MessageInstance<E>>,
+pub(crate) struct MessageSequence<M: Message> {
+    pub(crate) messages: Vec<MessageInstance<M>>,
     pub(crate) start_message_count: usize,
 }
 
-// Derived Default impl would incorrectly require E: Default
-impl<E: Message> Default for MessageSequence<E> {
+// Derived Default impl would incorrectly require M: Default
+impl<M: Message> Default for MessageSequence<M> {
     fn default() -> Self {
         Self {
             messages: Default::default(),
@@ -343,29 +343,29 @@ impl<E: Message> Default for MessageSequence<E> {
     }
 }
 
-impl<E: Message> Deref for MessageSequence<E> {
-    type Target = Vec<MessageInstance<E>>;
+impl<M: Message> Deref for MessageSequence<M> {
+    type Target = Vec<MessageInstance<M>>;
 
     fn deref(&self) -> &Self::Target {
         &self.messages
     }
 }
 
-impl<E: Message> DerefMut for MessageSequence<E> {
+impl<M: Message> DerefMut for MessageSequence<M> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.messages
     }
 }
 
 /// [`Iterator`] over written [`MessageIds`](`MessageId`) from a batch.
-pub struct WriteBatchIds<E> {
+pub struct WriteBatchIds<M> {
     last_count: usize,
     message_count: usize,
-    _marker: PhantomData<E>,
+    _marker: PhantomData<M>,
 }
 
-impl<E: Message> Iterator for WriteBatchIds<E> {
-    type Item = MessageId<E>;
+impl<M: Message> Iterator for WriteBatchIds<M> {
+    type Item = MessageId<M>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.last_count >= self.message_count {
@@ -389,7 +389,7 @@ impl<E: Message> Iterator for WriteBatchIds<E> {
     }
 }
 
-impl<E: Message> ExactSizeIterator for WriteBatchIds<E> {
+impl<M: Message> ExactSizeIterator for WriteBatchIds<M> {
     fn len(&self) -> usize {
         self.message_count.saturating_sub(self.last_count)
     }


### PR DESCRIPTION
# Objective

`M` stands for `Message`, `E` stands for `Event`.

## Solution

`E` -> `M`