### PR TITLE
re-enable gltf extension handler examples on wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4550,7 +4550,7 @@ doc-scrape-examples = false
 name = "glTF extension AnimationGraph"
 description = "Uses glTF data to build an AnimationGraph via extension processing"
 category = "glTF"
-wasm = false
+wasm = true
 
 [[example]]
 name = "gltf_extension_mesh_2d"
@@ -4562,7 +4562,7 @@ doc-scrape-examples = false
 name = "glTF extension processing to build Mesh2ds from glTF data"
 description = "Uses glTF extension data to convert incoming Mesh3d/MeshMaterial3d assets to 2d"
 category = "glTF"
-wasm = false
+wasm = true
 
 [[example]]
 name = "query_gltf_primitives"

--- a/examples/gltf/gltf_extension_animation_graph.rs
+++ b/examples/gltf/gltf_extension_animation_graph.rs
@@ -114,6 +114,16 @@ struct GltfExtensionHandlerAnimationPlugin;
 
 impl Plugin for GltfExtensionHandlerAnimationPlugin {
     fn build(&self, app: &mut App) {
+        #[cfg(target_family = "wasm")]
+        bevy::tasks::block_on(async {
+            app.world_mut()
+                .resource_mut::<GltfExtensionHandlers>()
+                .0
+                .write()
+                .await
+                .push(Box::new(GltfExtensionHandlerAnimation::default()))
+        });
+        #[cfg(not(target_family = "wasm"))]
         app.world_mut()
             .resource_mut::<GltfExtensionHandlers>()
             .0

--- a/examples/gltf/gltf_extension_mesh_2d.rs
+++ b/examples/gltf/gltf_extension_mesh_2d.rs
@@ -60,6 +60,16 @@ struct GltfToMesh2dPlugin;
 
 impl Plugin for GltfToMesh2dPlugin {
     fn build(&self, app: &mut App) {
+        #[cfg(target_family = "wasm")]
+        bevy::tasks::block_on(async {
+            app.world_mut()
+                .resource_mut::<GltfExtensionHandlers>()
+                .0
+                .write()
+                .await
+                .push(Box::new(GltfExtensionHandlerToMesh2d))
+        });
+        #[cfg(not(target_family = "wasm"))]
         app.world_mut()
             .resource_mut::<GltfExtensionHandlers>()
             .0


### PR DESCRIPTION
# Objective

Currently the `GltfExtensionHandler` examples are disabled on wasm due to an issue with API availability on wasm

## Solution

Use the correct APIs in the examples, flagged by platform.

## Testing

```
bevy run --example gltf_extension_animation_graph web
bevy run --example gltf_extension_mesh_2d web
```

## Showcase

<img width="1920" height="1080" alt="screenshot-2026-01-18-at-16 04 48" src="https://github.com/user-attachments/assets/d6a42c52-48da-4ad7-b4c2-ea512a06a5e5" />
<img width="1920" height="1080" alt="screenshot-2026-01-18-at-16 05 20" src="https://github.com/user-attachments/assets/b2066d3a-e07e-43f6-9490-0ca0f77e5810" />

