### PR TITLE
Reduce reflect size

### DIFF
--- a/crates/bevy_reflect/src/enums/helpers.rs
+++ b/crates/bevy_reflect/src/enums/helpers.rs
@@ -21,7 +21,6 @@ pub fn enum_hash(value: &dyn Enum) -> Option<u64> {
     Some(hasher.finish())
 }
 
-
 /// Compares an [`Enum`] with a [`PartialReflect`] value.
 ///
 /// Returns true if and only if all of the following are true:
@@ -96,10 +95,7 @@ pub fn enum_partial_eq(a: &dyn Enum, b: &dyn PartialReflect) -> Option<bool> {
 ///
 /// The ordering is same with `derive` macro. First order by variant index, then by fields.
 #[inline(never)]
-pub fn enum_partial_cmp(
-    a: &dyn Enum,
-    b: &dyn PartialReflect,
-) -> Option<::core::cmp::Ordering> {
+pub fn enum_partial_cmp(a: &dyn Enum, b: &dyn PartialReflect) -> Option<::core::cmp::Ordering> {
     // Both enums?
     let ReflectRef::Enum(b) = b.reflect_ref() else {
         return None;

--- a/crates/bevy_reflect/src/structs.rs
+++ b/crates/bevy_reflect/src/structs.rs
@@ -546,10 +546,7 @@ pub fn struct_partial_eq(a: &dyn Struct, b: &dyn PartialReflect) -> Option<bool>
 /// Returns [`None`] if the comparison couldn't be performed (e.g., kinds mismatch
 /// or an element comparison returns `None`).
 #[inline(never)]
-pub fn struct_partial_cmp(
-    a: &dyn Struct,
-    b: &dyn PartialReflect,
-) -> Option<::core::cmp::Ordering> {
+pub fn struct_partial_cmp(a: &dyn Struct, b: &dyn PartialReflect) -> Option<::core::cmp::Ordering> {
     let ReflectRef::Struct(struct_value) = b.reflect_ref() else {
         return None;
     };

--- a/crates/bevy_reflect/src/tuple_struct.rs
+++ b/crates/bevy_reflect/src/tuple_struct.rs
@@ -429,10 +429,7 @@ impl<'a> IntoIterator for &'a DynamicTupleStruct {
 ///
 /// Returns [`None`] if the comparison couldn't even be performed.
 #[inline(never)]
-pub fn tuple_struct_partial_eq(
-    a: &dyn TupleStruct,
-    b: &dyn PartialReflect,
-) -> Option<bool> {
+pub fn tuple_struct_partial_eq(a: &dyn TupleStruct, b: &dyn PartialReflect) -> Option<bool> {
     let ReflectRef::TupleStruct(tuple_struct) = b.reflect_ref() else {
         return Some(false);
     };


### PR DESCRIPTION
# Objective

After #22452 is merged, the binary size increased a lot (and also compile time). Try to decrease binary size again.

## Solution

Change the methods from generic to non-generic.

## Testing


compile `3d_shapes` example on macOS:

* before #22452 :  94.5mb
* at #22452 : 97.7mb
* at #22452 + to dynamic (another attempt) : 94.9mb
* at #22452 + dyn (**this PR**) : 94.5mb

also tried to see what if we disable reflection based cmp/eq entirely (which makes tests fails):

* disable reflection based cmp/eq entirely: 94.1mb 
