### PR TITLE
Add tests for items in `crates\bevy_math\src\bounding\mod.rs`

### DIFF
--- a/crates/bevy_math/src/bounding/mod.rs
+++ b/crates/bevy_math/src/bounding/mod.rs
@@ -115,3 +115,133 @@ mod raycast2d;
 pub use raycast2d::*;
 mod raycast3d;
 pub use raycast3d::*;
+
+#[cfg(test)]
+mod bounding_volume_tests {
+    use super::BoundingVolume;
+
+    #[derive(Default)]
+    struct TestBoundingVolume {
+        // Tracks if `BoundingVolume::rotate_by` was called
+        called_rotate_by: bool,
+        // Tracks if `BoundingVolume::translate_by` was called
+        called_translate_by: bool,
+        // Normally, bounding volumes shouldn't be affected by whether `rotate_by` or `translate_by`
+        // is called first, in situations where both are called. However, it is possible some
+        // `BoundingVolume` impls may give different results depending on the order.
+        //
+        // By keeping track of the order each function is called, we can ensure we don't break these
+        // impls - or at least, that we know they'll have broken.
+        rotate_by_called_first: bool,
+    }
+
+    // We are only testing provided methods for expected properties. Thus, where items in the impl
+    // below are not used by provided methods, they are intentionally given placeholder values (such
+    // as `()` or `unimplemented!()`).
+    impl BoundingVolume for TestBoundingVolume {
+        type Translation = i32;
+        type Rotation = i32;
+        type HalfSize = ();
+
+        fn rotate_by(&mut self, _: impl Into<Self::Rotation>) {
+            self.called_rotate_by = true;
+            if !self.called_translate_by {
+                self.rotate_by_called_first = true;
+            }
+        }
+
+        fn translate_by(&mut self, _: impl Into<Self::Translation>) {
+            self.called_translate_by = true;
+        }
+
+        fn center(&self) -> Self::Translation {
+            unimplemented!()
+        }
+        fn contains(&self, _: &Self) -> bool {
+            unimplemented!()
+        }
+        fn grow(&self, _: impl Into<Self::HalfSize>) -> Self {
+            unimplemented!()
+        }
+        fn half_size(&self) -> Self::HalfSize {
+            unimplemented!()
+        }
+        fn merge(&self, _: &Self) -> Self {
+            unimplemented!()
+        }
+        fn scale_around_center(&self, _: impl Into<Self::HalfSize>) -> Self {
+            unimplemented!()
+        }
+        fn shrink(&self, _: impl Into<Self::HalfSize>) -> Self {
+            unimplemented!()
+        }
+        fn visible_area(&self) -> f32 {
+            unimplemented!()
+        }
+    }
+
+    #[test]
+    fn rotated_by() {
+        let test_value = TestBoundingVolume::default().rotated_by(52);
+
+        assert!(
+            test_value.called_rotate_by,
+            "should call `BoundingVolume::rotate_by`"
+        );
+        assert!(
+            !test_value.called_translate_by,
+            "should not call `BoundingVolume::translate_by`"
+        );
+    }
+
+    #[test]
+    fn transform_by() {
+        let mut test_value = TestBoundingVolume::default();
+        test_value.transform_by(17, 17);
+
+        assert!(
+            test_value.called_rotate_by,
+            "should call `BoundingVolume::rotate_by`"
+        );
+        assert!(
+            test_value.called_translate_by,
+            "should call `BoundingVolume::translate_by`"
+        );
+        assert!(
+            test_value.rotate_by_called_first,
+            "should call `BoundingVolume::rotate_by` before `BoundingVolume::translate_by`"
+        );
+    }
+
+    #[test]
+    fn transformed_by() {
+        let test_value = TestBoundingVolume::default().transformed_by(48, 42);
+
+        assert!(
+            test_value.called_rotate_by,
+            "should call `BoundingVolume::rotate_by`"
+        );
+        assert!(
+            test_value.called_translate_by,
+            "should call `BoundingVolume::translate_by`"
+        );
+        assert!(
+            test_value.rotate_by_called_first,
+            "should call `BoundingVolume::rotate_by` before `BoundingVolume::translate_by`"
+        );
+    }
+
+    #[test]
+    fn translated_by() {
+        let test_value = TestBoundingVolume::default().translated_by(35);
+
+        assert!(
+            !test_value.called_rotate_by,
+            "should not call `BoundingVolume::rotate_by`"
+        );
+        assert!(
+            test_value.called_translate_by,
+            "should call `BoundingVolume::translate_by`"
+        );
+    }
+}


### PR DESCRIPTION
# Objective
Increase test coverage, one file at a time.

## Solution
Create tests to cover all lines in `crates\bevy_math\src\bounding\mod.rs`.

## Testing

- Did you test these changes? If so, how?
  - `cargo test --package bevy_math --all-features` returned no failures
  - `cargo tarpaulin --engine llvm --out html --packages bevy_math --include-files crates/bevy_math/* --all-features` shows a fully-green `crates\bevy_math\src\bounding\mod.rs`
- Are there any parts that need more testing?
  - The testing style may be a point of contention, but the tests themselves should be fine.
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
  - `cargo test --package bevy_math --all-features`
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?
  - N/A
