### PR TITLE
fix enum reflection based partial_cmp, disallow compare different variant names.

### DIFF
--- a/crates/bevy_reflect/src/enums/helpers.rs
+++ b/crates/bevy_reflect/src/enums/helpers.rs
@@ -106,8 +106,8 @@ pub fn enum_partial_cmp<TEnum: Enum + ?Sized>(
 
     // Same variant name?
     if a.variant_name() != b.variant_name() {
-        // Different variant names. 
-        // Ordering by variant index here can result in inconsistencies with 
+        // Different variant names.
+        // Ordering by variant index here can result in inconsistencies with
         // partial_eq when comparing between two different concrete enums,
         // so we simply return None here
         return None;

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -1677,7 +1677,7 @@ mod tests {
     }
 
     #[test]
-    fn enum_variant_index_ordering() {
+    fn enum_variant_ordering() {
         use core::cmp::Ordering;
 
         #[derive(PartialEq, PartialOrd, Reflect, Debug)]


### PR DESCRIPTION
# Objective

Fix https://github.com/bevyengine/bevy/issues/22586

The problem is in https://github.com/bevyengine/bevy/pull/22452 I used `variant_index` to compare two enum values. Because I want to maintain:

* if you have `a,b: A` and tries call `a.reflect_partial_cmp(b)`, the result should align with the version derived on `A`. 

But appearently for dynamic types and also `a: A; b: B` different types, the behaviour is a bit chaotic. (see https://github.com/bevyengine/bevy/issues/22586) 


## Solution

Don't compare by `variant_index` anymore. It's a different tradeoff, but I think it's a more sensible one.


## Testing

Modified unit tests 