### PR TITLE
Replace PathBuf-based AssetPath resolution with URL-style segment resolver

### DIFF
--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -695,7 +695,7 @@ pub fn split_asset_path_segments(path_str: &str) -> (bool, Vec<&str>) {
 
 /// Normalizes segments by applying '.' and '..' rules
 /// as per [RFC 1808](https://datatracker.ietf.org/doc/html/rfc1808)
-/// 'is_rooted' is reserved for future use (e.g. forbidding '..' above root). current behavior matches 'normalize_path'.
+/// `is_rooted` is reserved for future use (e.g. forbidding `..` above root). Current behavior matches `normalize_path`.
 pub(crate) fn normalize_asset_path_segments(segments: &[&str], _is_rooted: bool) -> Vec<String> {
     let mut result = Vec::new();
     for segment in segments {
@@ -715,8 +715,8 @@ pub(crate) fn normalize_asset_path_segments(segments: &[&str], _is_rooted: bool)
     result
 }
 
-/// Check normalize_asset_path_segments above for the implementation of this function.
-#[allow(dead_code)]
+/// See `normalize_asset_path_segments` above for the segment-based logic. This remains for `file_watcher` (filesystem paths).
+#[cfg(feature = "file_watcher")]
 pub(crate) fn normalize_path(path: &Path) -> PathBuf {
     let mut result_path = PathBuf::new();
     for elt in path.iter() {
@@ -740,10 +740,10 @@ pub(crate) fn normalize_path(path: &Path) -> PathBuf {
     result_path
 }
 
-/// Joins 'base_str' and 'rpath_str' then normalizes. Used by 'resolve_from_parts'.
-/// - 'rpath_is_rooted': if true, base is ignored and the result is rooted.
-/// - 'replace': if true (resolve_embed), drop the last base segment unless 'base_trailing_slash'.
-/// - 'rpath_str' must already have a leading '/' stripped when 'rpath_is_rooted' is true.
+/// Joins `base_str` and `rpath_str` then normalizes. Used by `resolve_from_parts`.
+/// - `rpath_is_rooted`: if true, base is ignored and the result is rooted.
+/// - `replace`: if true ([`resolve_embed`](AssetPath::resolve_embed)), drop the last base segment unless `base_trailing_slash`.
+/// - `rpath_str` must already have a leading `/` stripped when `rpath_is_rooted` is true.
 pub(crate) fn join_and_normalize_asset_path(
     base_str: &str,
     base_trailing_slash: bool,

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -452,7 +452,10 @@ impl<'a> AssetPath<'a> {
         rpath: &Path,
         rlabel: Option<&str>,
     ) -> AssetPath<'static> {
-        let base_str = self.path().to_str().expect("asset path must be valid UTF-8");
+        let base_str = self
+            .path()
+            .to_str()
+            .expect("asset path must be valid UTF-8");
         let base_trailing_slash = base_str.ends_with('/');
         let rpath_str = rpath.to_str().expect("asset path must be valid UTF-8");
         let rpath_is_rooted = rpath_str.starts_with('/');
@@ -1347,17 +1350,35 @@ mod tests {
         assert_eq!(split_asset_path_segments("/a/b"), (true, vec!["a", "b"]));
         assert_eq!(split_asset_path_segments("C:file"), (false, vec!["C:file"]));
         assert_eq!(split_asset_path_segments("a\\b"), (false, vec!["a\\b"]));
-        assert_eq!(split_asset_path_segments("a//b"), (false, vec!["a", "", "b"]));
+        assert_eq!(
+            split_asset_path_segments("a//b"),
+            (false, vec!["a", "", "b"])
+        );
     }
 
     #[test]
     fn test_normalize_asset_path_segments() {
-        assert_eq!(normalize_asset_path_segments(&["a", ".", "b"], false), vec!["a", "b"]);
-        assert_eq!(normalize_asset_path_segments(&["a", "..", "b"], false), vec!["b"]);
-        assert_eq!(normalize_asset_path_segments(&["a", "b", ".."], false), vec!["a"]);
-        assert_eq!(normalize_asset_path_segments(&["..", "a"], false), vec!["..", "a"]);
+        assert_eq!(
+            normalize_asset_path_segments(&["a", ".", "b"], false),
+            vec!["a", "b"]
+        );
+        assert_eq!(
+            normalize_asset_path_segments(&["a", "..", "b"], false),
+            vec!["b"]
+        );
+        assert_eq!(
+            normalize_asset_path_segments(&["a", "b", ".."], false),
+            vec!["a"]
+        );
+        assert_eq!(
+            normalize_asset_path_segments(&["..", "a"], false),
+            vec!["..", "a"]
+        );
         assert!(normalize_asset_path_segments(&["a", ".."], true).is_empty());
-        assert_eq!(normalize_asset_path_segments(&["a", "b", ".."], true), vec!["a"]);
+        assert_eq!(
+            normalize_asset_path_segments(&["a", "b", ".."], true),
+            vec!["a"]
+        );
     }
 
     #[test]
@@ -1408,17 +1429,11 @@ mod tests {
     fn test_resolve_rooted_dotdot() {
         // Rooted base: ".." does not escape above root; we pop when possible.
         let base = AssetPath::parse("/a/b");
-        assert_eq!(
-            base.resolve_str("../c").unwrap(),
-            AssetPath::from("/a/c")
-        );
+        assert_eq!(base.resolve_str("../c").unwrap(), AssetPath::from("/a/c"));
 
         // "/a" + "../b": ".." pops "a" -> root, then "b" -> "/b".
         let base = AssetPath::parse("/a");
-        assert_eq!(
-            base.resolve_str("../b").unwrap(),
-            AssetPath::from("/b")
-        );
+        assert_eq!(base.resolve_str("../b").unwrap(), AssetPath::from("/b"));
     }
 
     #[test]

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -680,12 +680,13 @@ impl<'de> Visitor<'de> for AssetPathVisitor {
     }
 }
 
-/*
-function that splits only on /, and returns (bool, Vec<&str>):
-bool = path starts with /
-Vec<&str> = segments between / (define once whether you keep or drop "" from // or trailing / and stick to it)
-*/
-
+/// Splits `path_str` into segments using `/` as the separator.
+///
+/// Returns `(is_rooted, segments)`:
+/// - `is_rooted`: `true` if `path_str` starts with `/` (the leading `/` is not included in `segments`).
+/// - `segments`: the segments between `/` characters. Empty strings from `//` or a trailing `/` are preserved.
+///
+/// Backslashes and colons are never treated as separators; they remain part of a segment.
 pub fn split_asset_path_segments(path_str: &str) -> (bool, Vec<&str>) {
     let is_rooted = path_str.starts_with('/');
     let to_split = path_str.strip_prefix('/').unwrap_or(path_str);
@@ -1335,14 +1336,6 @@ mod tests {
             AssetPath::from("../../a/b.gltf/c.bin")
         );
     }
-
-    /*
-    "a/b" -> (false, ["a", "b"])
-    "/a/b" -> (true, ["a", "b"])
-    "C:file" -> (false, ["C:file"]) (no split on :)
-    "a\\b" -> (false, ["a\\b"]) (no split on \)
-    "a//b" -> ["a","","b"]
-    */
 
     #[test]
     fn test_split_asset_path_segments() {


### PR DESCRIPTION
## Summary
This PR fixes #22420

Asset path resolution no longer relies on `PathBuf` / `Path` for joining and normalization.   
It now uses URL-style resolver that operates only on `/`-split path segments, ensuring identical behavior across platforms and avoiding filesystem-specific semantics. 

`AssetPath` is not a filesystem path. Using `PathBuf` introduced platform-dependent behavior like Windows drive letters and backslashes.  
This change makes resolution predictable, testable, and explicit.

## How it works

### 1. Splitting (only `/`)
- `split_asset_path_segments(path: &str) -> (is_rooted, segments)`
- Splits only on `/`
- `:`, `\`, and `//` are **not** special

Examples:
- `a/b` -> `(false, ["a", "b"])`
- `/a/b` -> `(true, ["a", "b"])`
- `C:file` -> `(false, ["C:file"])`
- `a\b` -> `(false, ["a\\b"])`
- `a//b` -> `(false, ["a", "", "b"])`

---

### 2. Normalization (`.` and `..`)
- `normalize_asset_path_segments(segments, is_rooted)`
- `.` removed
- `..` pops previous segment when possible, otherwise preserved
- Rooted behavior preserved:
  - `/a/b + ../c → /a/c`
  - `/a + ../b → /b`

---

### 3. Joining & resolving
- `join_and_normalize_asset_path(...)`
- Handles:
  - base + relative
  - `resolve_embed` replace semantics
  - trailing slash behavior
  - rooted relative ignores base
  - explicit source ignores base
- Single normalization pass after joining
- No extra leading `/` added (existing behavior preserved)

---

### 4. resolve_from_parts
- Uses the new helpers for all logic
- Only remaining `PathBuf` usage is `PathBuf::from(resolved)` at the end
- Removed from resolve path:
  - `PathBuf::from(self.path())`
  - `PathBuf::push`
  - `Path::strip_prefix`
  - `normalize_path`

---

## What stays the same
- `normalize_path` unchanged
- All existing semantics preserved:
  - `resolve`, `resolve_embed`
  - label-only
  - rooted relative
  - explicit source
  - trailing slash
  - `..` underflow
- `AssetPath` still stores a `Path`; only computation changed

---

## New internal helpers
- `split_asset_path_segments(path_str: &str) -> (bool, Vec<&str>)`
- `normalize_asset_path_segments(segments: &[&str], is_rooted: bool) -> Vec<String>`
- `join_and_normalize_asset_path(...) -> String`

---

## Tests

### Unit
- `split_asset_path_segments`: `a/b`, `/a/b`, `C:file`, `a\b`, `a//b`
- `normalize_asset_path_segments`: `.`, `..`, underflow, rooted
- `join_and_normalize_asset_path`: replace, trailing slash, rooted

### Regression
- Colon preserved: `C:file`, `a:b` → `a/b/C:file`, `a/b/a:b`
- Backslash preserved: `x\y`, `x\y/z` → `a/b/x\y`, `a/b/x\y/z`
- Rooted + `..`:  
  - `/a/b + ../c → /a/c`  
  - `/a + ../b → /b`
- Multiple `/` preserved: `a//b → x/a//b`

---

## Check
- `cargo test -p bevy_asset` (incl. doctests) passes
