### PR TITLE
Amend `AssetSaver` documentation

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -135,8 +135,6 @@
 //! After the loader is implemented, it needs to be registered with the [`AssetServer`] using [`App::register_asset_loader`](AssetApp::register_asset_loader).
 //! Once your asset type is loaded, you can use it in your game like any other asset type!
 //!
-//! If you want to save your assets back to disk, you should implement [`AssetSaver`](saver::AssetSaver) as well.
-//! This trait mirrors [`AssetLoader`] in structure, and works in tandem with [`AssetWriter`](io::AssetWriter), which mirrors [`AssetReader`](io::AssetReader).
 
 #![expect(missing_docs, reason = "Not all docs are written yet, see #3492.")]
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/crates/bevy_asset/src/saver.rs
+++ b/crates/bevy_asset/src/saver.rs
@@ -15,7 +15,11 @@ use serde::{Deserialize, Serialize};
 ///
 /// This trait is generally used in concert with [`AssetWriter`](crate::io::AssetWriter) to write assets as bytes.
 ///
-/// For a complementary version of this trait that can load assets, see [`AssetLoader`].
+/// For a version of this trait that can load assets, see [`AssetLoader`].
+///
+/// Note: This is currently only leveraged by the [`AssetProcessor`](crate::processor::AssetProcessor), and does not provide a
+/// suitable interface for general purpose asset persistence. See [github issue #11216](https://github.com/bevyengine/bevy/issues/11216).
+///
 pub trait AssetSaver: TypePath + Send + Sync + 'static {
     /// The top level [`Asset`] saved by this [`AssetSaver`].
     type Asset: Asset;


### PR DESCRIPTION
# Objective

`AssetSaver` documentation currently insists that it is a mirror of `AssetLoader` and encourages users to use it if they want to save assets.

This is unfortunate, as `AssetSaver` currently isn't really set up to do that without an awful lot of deeply weird hoop jumping, and thus serves as a bit of a trap.

## Solution

Remove doc comments promoting `AssetSaver` for this purpose and add a disclaimer noting that it does not do this - yet.

## Testing


## Showcase

