### PR TITLE
Add explicit mesh key initialization for manual_material example.

### DIFF
--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -1454,7 +1454,7 @@ pub struct PreparedMaterial {
     pub properties: Arc<MaterialProperties>,
 }
 
-fn base_specialize(
+pub fn base_specialize(
     world: &mut World,
     key: ErasedMaterialPipelineKey,
     layout: &MeshVertexBufferLayoutRef,

--- a/examples/shader_advanced/manual_material.rs
+++ b/examples/shader_advanced/manual_material.rs
@@ -7,14 +7,14 @@ use bevy::{
         lifetimeless::{SRes, SResMut},
         SystemChangeTick, SystemParamItem,
     },
-    material::MaterialProperties,
+    material::{key::ErasedMeshPipelineKey, MaterialProperties},
     pbr::{
-        late_sweep_material_instances, DrawMaterial, EntitiesNeedingSpecialization,
-        EntitySpecializationTickPair, EntitySpecializationTicks, MainPassOpaqueDrawFunction,
-        MaterialBindGroupAllocator, MaterialBindGroupAllocators,
+        base_specialize, late_sweep_material_instances, DrawMaterial,
+        EntitiesNeedingSpecialization, EntitySpecializationTickPair, EntitySpecializationTicks,
+        MainPassOpaqueDrawFunction, MaterialBindGroupAllocator, MaterialBindGroupAllocators,
         MaterialExtractEntitiesNeedingSpecializationSystems, MaterialExtractionSystems,
-        MaterialFragmentShader, PreparedMaterial, RenderMaterialBindings, RenderMaterialInstance,
-        RenderMaterialInstances, SpecializedMaterialPipelineCache,
+        MaterialFragmentShader, MeshPipelineKey, PreparedMaterial, RenderMaterialBindings,
+        RenderMaterialInstance, RenderMaterialInstances, SpecializedMaterialPipelineCache,
     },
     platform::collections::hash_map::Entry,
     prelude::*,
@@ -199,6 +199,8 @@ impl ErasedRenderAsset for ImageMaterial {
 
         let mut properties = MaterialProperties {
             material_layout: Some(material_layout),
+            mesh_pipeline_key_bits: ErasedMeshPipelineKey::new(MeshPipelineKey::empty()),
+            base_specialize: Some(base_specialize),
             ..Default::default()
         };
         properties.add_draw_function(MainPassOpaqueDrawFunction, draw_function_id);


### PR DESCRIPTION
Ideally this should be fully defaultable, but is problematic until we complete the 2d->3d rework where more items can be exported from `bevy_material`. The temp fix is just to initialize a few more fields. There are other hacky things we could do to keep the default initialization working but I'd rather just fix it correctly when we complete the refactor.