### PR TITLE
add Clone and PartialEq traits to NoFrustumCulling marker component

### DIFF
--- a/crates/bevy_camera/src/visibility/mod.rs
+++ b/crates/bevy_camera/src/visibility/mod.rs
@@ -261,7 +261,7 @@ impl<'a> SetViewVisibility for Mut<'a, ViewVisibility> {
 /// - when a [`Mesh`] is updated but its [`Aabb`] is not, which might happen with animations,
 /// - when using some light effects, like wanting a [`Mesh`] out of the [`Frustum`]
 ///   to appear in the reflection of a [`Mesh`] within.
-#[derive(Debug, Component, Default, Reflect)]
+#[derive(Debug, Component, Default, Reflect, Clone, PartialEq)]
 #[reflect(Component, Default, Debug)]
 pub struct NoFrustumCulling;
 


### PR DESCRIPTION
# Objective

fixes not being able to use the HierarchyPropagatePlugin with the NoFrustumCulling component by satisfying the trait bounds for Clone and PartialEq

## Solution

- add Clone and PartialEq trait to NoFrustumCulling struct

## Testing

i did not test this
