### PR TITLE
Solari: More reactive world cache by default

### DIFF
--- a/crates/bevy_solari/src/realtime/world_cache_query.wgsl
+++ b/crates/bevy_solari/src/realtime/world_cache_query.wgsl
@@ -16,7 +16,7 @@
 }
 
 /// How responsive the world cache is to changes in lighting (higher is less responsive, lower is more responsive)
-const WORLD_CACHE_MAX_TEMPORAL_SAMPLES: f32 = 32.0;
+const WORLD_CACHE_MAX_TEMPORAL_SAMPLES: f32 = 20.0;
 /// How many direct light samples each cell takes when updating each frame
 const WORLD_CACHE_DIRECT_LIGHT_SAMPLE_COUNT: u32 = 32u;
 /// Maximum amount of distance to trace GI rays between two cache cells


### PR DESCRIPTION
Helps lessen https://github.com/bevyengine/bevy/issues/22577 without much loss of overall stability for diffuse surfaces (mid-rough specular is still very tricky, might need to hash roughness in the WC key or something.)

Yes, I still need to make all these numbers configurable, probably sometime towards the end of this dev cycle.