### PR TITLE
Implement minimal asset saving

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ imported_assets
 .web-asset-cache
 examples/large_scenes/bistro/assets/*
 examples/large_scenes/caldera_hotel/assets/*
+examples/asset/saved_assets
 
 # Bevy Examples
 example_showcase_config.ron

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2016,6 +2016,18 @@ category = "Assets"
 wasm = false
 
 [[example]]
+name = "asset_saving"
+path = "examples/asset/asset_saving.rs"
+doc-scrape-examples = true
+required-features = ["bevy_picking", "sprite_picking"]
+
+[package.metadata.example.asset_saving]
+name = "Asset Saving"
+description = "Demonstrates how to save an asset (with subassets)"
+category = "Assets"
+wasm = true
+
+[[example]]
 name = "asset_settings"
 path = "examples/asset/asset_settings.rs"
 doc-scrape-examples = true

--- a/crates/bevy_asset/src/processor/process.rs
+++ b/crates/bevy_asset/src/processor/process.rs
@@ -16,6 +16,7 @@ use alloc::{
     string::{String, ToString},
     vec::Vec,
 };
+use bevy_ecs::error::BevyError;
 use bevy_reflect::TypePath;
 use bevy_tasks::{BoxedFuture, ConditionalSendFuture};
 use core::marker::PhantomData;
@@ -160,7 +161,7 @@ pub enum ProcessError {
     WrongMetaType,
     #[error("Encountered an error while saving the asset: {0}")]
     #[from(ignore)]
-    AssetSaveError(Box<dyn core::error::Error + Send + Sync + 'static>),
+    AssetSaveError(BevyError),
     #[error("Encountered an error while transforming the asset: {0}")]
     #[from(ignore)]
     AssetTransformError(Box<dyn core::error::Error + Send + Sync + 'static>),

--- a/crates/bevy_asset/src/processor/tests.rs
+++ b/crates/bevy_asset/src/processor/tests.rs
@@ -32,7 +32,7 @@ use crate::{
         AssetProcessor, GetProcessorError, LoadTransformAndSave, LogEntry, Process, ProcessContext,
         ProcessError, ProcessorState, ProcessorTransactionLog, ProcessorTransactionLogFactory,
     },
-    saver::AssetSaver,
+    saver::{tests::CoolTextSaver, AssetSaver},
     tests::{
         read_asset_as_string, read_meta_as_string, run_app_until, CoolText, CoolTextLoader,
         CoolTextRon, SubText,
@@ -426,43 +426,6 @@ fn run_app_until_finished_processing(app: &mut App, guard: RwLockWriteGuard<'_, 
     });
 }
 
-#[derive(TypePath)]
-struct CoolTextSaver;
-
-impl AssetSaver for CoolTextSaver {
-    type Asset = CoolText;
-    type Settings = ();
-    type OutputLoader = CoolTextLoader;
-    type Error = std::io::Error;
-
-    async fn save(
-        &self,
-        writer: &mut crate::io::Writer,
-        asset: crate::saver::SavedAsset<'_, '_, Self::Asset>,
-        _: &Self::Settings,
-    ) -> Result<(), Self::Error> {
-        let ron = CoolTextRon {
-            text: asset.text.clone(),
-            sub_texts: asset
-                .iter_labels()
-                .map(|label| asset.get_labeled::<SubText>(label).unwrap().text.clone())
-                .collect(),
-            dependencies: asset
-                .dependencies
-                .iter()
-                .map(|handle| handle.path().unwrap().path())
-                .map(|path| path.to_str().unwrap().to_string())
-                .collect(),
-            // NOTE: We can't handle embedded dependencies in any way, since we need to write to
-            // another file to do so.
-            embedded_dependencies: vec![],
-        };
-        let ron = ron::ser::to_string_pretty(&ron, PrettyConfig::new().new_line("\n")).unwrap();
-        writer.write_all(ron.as_bytes()).await?;
-        Ok(())
-    }
-}
-
 // Note: while we allow any Fn, since closures are unnameable types, creating a processor with a
 // closure cannot be used (since we need to include the name of the transformer in the meta
 // file).
@@ -637,7 +600,7 @@ fn asset_processor_transforms_asset_with_meta() {
     source_dir.insert_meta_text(path, r#"(
     meta_format_version: "1.0",
     asset: Process(
-        processor: "bevy_asset::processor::process::LoadTransformAndSave<bevy_asset::tests::CoolTextLoader, bevy_asset::processor::tests::RootAssetTransformer<bevy_asset::processor::tests::AddText, bevy_asset::tests::CoolText>, bevy_asset::processor::tests::CoolTextSaver>",
+        processor: "bevy_asset::processor::process::LoadTransformAndSave<bevy_asset::tests::CoolTextLoader, bevy_asset::processor::tests::RootAssetTransformer<bevy_asset::processor::tests::AddText, bevy_asset::tests::CoolText>, bevy_asset::saver::tests::CoolTextSaver>",
         settings: (
             loader_settings: (),
             transformer_settings: (),
@@ -1759,7 +1722,7 @@ fn writes_default_meta_for_processor() {
         r#"(
     meta_format_version: "1.0",
     asset: Process(
-        processor: "bevy_asset::processor::process::LoadTransformAndSave<bevy_asset::tests::CoolTextLoader, bevy_asset::processor::tests::RootAssetTransformer<bevy_asset::processor::tests::AddText, bevy_asset::tests::CoolText>, bevy_asset::processor::tests::CoolTextSaver>",
+        processor: "bevy_asset::processor::process::LoadTransformAndSave<bevy_asset::tests::CoolTextLoader, bevy_asset::processor::tests::RootAssetTransformer<bevy_asset::processor::tests::AddText, bevy_asset::tests::CoolText>, bevy_asset::saver::tests::CoolTextSaver>",
         settings: (
             loader_settings: (),
             transformer_settings: (),

--- a/crates/bevy_asset/src/processor/tests.rs
+++ b/crates/bevy_asset/src/processor/tests.rs
@@ -438,14 +438,14 @@ impl AssetSaver for CoolTextSaver {
     async fn save(
         &self,
         writer: &mut crate::io::Writer,
-        asset: crate::saver::SavedAsset<'_, Self::Asset>,
+        asset: crate::saver::SavedAsset<'_, '_, Self::Asset>,
         _: &Self::Settings,
     ) -> Result<(), Self::Error> {
         let ron = CoolTextRon {
             text: asset.text.clone(),
             sub_texts: asset
                 .iter_labels()
-                .map(|label| asset.get_labeled::<SubText, _>(label).unwrap().text.clone())
+                .map(|label| asset.get_labeled::<SubText>(label).unwrap().text.clone())
                 .collect(),
             dependencies: asset
                 .dependencies
@@ -846,7 +846,7 @@ impl AssetSaver for FakeBsnSaver {
     async fn save(
         &self,
         writer: &mut crate::io::Writer,
-        asset: crate::saver::SavedAsset<'_, Self::Asset>,
+        asset: crate::saver::SavedAsset<'_, '_, Self::Asset>,
         _settings: &Self::Settings,
     ) -> Result<(), Self::Error> {
         use std::io::{Error, ErrorKind};
@@ -1336,7 +1336,7 @@ fn nested_loads_of_processed_asset_reprocesses_on_reload() {
         async fn save(
             &self,
             writer: &mut crate::io::Writer,
-            asset: crate::saver::SavedAsset<'_, Self::Asset>,
+            asset: crate::saver::SavedAsset<'_, '_, Self::Asset>,
             _settings: &Self::Settings,
         ) -> Result<<Self::OutputLoader as AssetLoader>::Settings, Self::Error> {
             let serialized = serialize_as_leaf(asset.get().value.clone());

--- a/crates/bevy_asset/src/processor/tests.rs
+++ b/crates/bevy_asset/src/processor/tests.rs
@@ -1520,6 +1520,8 @@ fn only_reprocesses_wrong_hash_on_startup() {
             }
             asset.text.push(' ');
             asset.text.push_str(&asset.embedded);
+            // Clear the embedded text so that saving doesn't break.
+            asset.embedded.clear();
         }
     }
 

--- a/crates/bevy_asset/src/saver.rs
+++ b/crates/bevy_asset/src/saver.rs
@@ -295,6 +295,7 @@ impl<'a> SavedAssetBuilder<'a> {
     /// an asset).
     ///
     /// This is primarily used when **constructing** a new asset to be saved.
+    #[must_use]
     pub fn add_labeled_asset_with_new_handle<'b: 'a, A: Asset>(
         &mut self,
         label: impl Into<CowArc<'b, str>>,
@@ -336,6 +337,7 @@ impl<'a> SavedAssetBuilder<'a> {
 
     /// Same as [`Self::add_labeled_asset_with_new_handle`], but type-erased to allow for dynamic
     /// types.
+    #[must_use]
     pub fn add_labeled_asset_with_new_handle_erased<'b: 'a>(
         &mut self,
         label: impl Into<CowArc<'b, str>>,

--- a/crates/bevy_asset/src/saver.rs
+++ b/crates/bevy_asset/src/saver.rs
@@ -294,7 +294,12 @@ impl<'a> SavedAssetBuilder<'a> {
     /// Adds a labeled asset, creates a handle for it, and returns the handle (for use in creating
     /// an asset).
     ///
-    /// This is primarily used when **constructing** a new asset to be saved.
+    /// This is primarily used when **constructing** a new asset to be saved. Since assets commonly
+    /// store handles to their subassets, this function returns a handle that can be stored in your
+    /// root asset.
+    ///
+    /// If you already have a root asset instance (which already contains a subasset handle), use
+    /// [`Self::add_labeled_asset_with_existing_handle`] instead.
     #[must_use]
     pub fn add_labeled_asset_with_new_handle<'b: 'a, A: Asset>(
         &mut self,
@@ -320,8 +325,13 @@ impl<'a> SavedAssetBuilder<'a> {
 
     /// Adds a labeled asset with a pre-existing handle.
     ///
-    /// This is primarily used when attempting to save an existing asset (which already has its
-    /// handles populated).
+    /// This is primarily used when attempting to save a (root) asset that you already have an
+    /// instance of. Since this root asset instance already must have its fields populated
+    /// (including any subasset handles), this function allows you to record the subasset that
+    /// should be associated with that handle.
+    ///
+    /// If you do not have a root asset instance (you're creating one from scratch), use
+    /// [`Self::add_labeled_asset_with_new_handle`] instead.
     pub fn add_labeled_asset_with_existing_handle<'b: 'a, A: Asset>(
         &mut self,
         label: impl Into<CowArc<'b, str>>,

--- a/crates/bevy_asset/src/saver.rs
+++ b/crates/bevy_asset/src/saver.rs
@@ -172,26 +172,26 @@ impl<'a, 'b, A: Asset> SavedAsset<'a, 'b, A> {
     }
 
     /// Returns the labeled asset, if it exists and matches this type.
-    pub fn get_labeled<B: Asset>(&self, label: &str) -> Option<SavedAsset<'a, '_, B>> {
-        let labeled = self.labeled_assets.get(label)?;
+    pub fn get_labeled<B: Asset>(&self, label: impl AsRef<str>) -> Option<SavedAsset<'a, '_, B>> {
+        let labeled = self.labeled_assets.get(label.as_ref())?;
         labeled.asset.downcast()
     }
 
     /// Returns the type-erased labeled asset, if it exists and matches this type.
-    pub fn get_erased_labeled(&self, label: &str) -> Option<&ErasedSavedAsset<'a, '_>> {
-        let labeled = self.labeled_assets.get(label)?;
+    pub fn get_erased_labeled(&self, label: impl AsRef<str>) -> Option<&ErasedSavedAsset<'a, '_>> {
+        let labeled = self.labeled_assets.get(label.as_ref())?;
         Some(&labeled.asset)
     }
 
     /// Returns the [`UntypedHandle`] of the labeled asset with the provided 'label', if it exists.
-    pub fn get_untyped_handle(&self, label: &str) -> Option<UntypedHandle> {
-        let labeled = self.labeled_assets.get(label)?;
+    pub fn get_untyped_handle(&self, label: impl AsRef<str>) -> Option<UntypedHandle> {
+        let labeled = self.labeled_assets.get(label.as_ref())?;
         Some(labeled.handle.clone())
     }
 
     /// Returns the [`Handle`] of the labeled asset with the provided 'label', if it exists and is an asset of type `B`
-    pub fn get_handle<B: Asset>(&self, label: &str) -> Option<Handle<B>> {
-        let labeled = self.labeled_assets.get(label)?;
+    pub fn get_handle<B: Asset>(&self, label: impl AsRef<str>) -> Option<Handle<B>> {
+        let labeled = self.labeled_assets.get(label.as_ref())?;
         if let Ok(handle) = labeled.handle.clone().try_typed::<B>() {
             return Some(handle);
         }

--- a/crates/bevy_asset/src/saver.rs
+++ b/crates/bevy_asset/src/saver.rs
@@ -507,6 +507,9 @@ pub(crate) mod tests {
             asset: SavedAsset<'_, '_, Self::Asset>,
             _: &Self::Settings,
         ) -> Result<(), Self::Error> {
+            // NOTE: We can't handle embedded dependencies in any way, since we need to write to
+            // another file to do so.
+            assert!(asset.embedded.is_empty());
             let ron = CoolTextRon {
                 text: asset.text.clone(),
                 sub_texts: asset
@@ -519,8 +522,6 @@ pub(crate) mod tests {
                     .map(|handle| handle.path().unwrap().path())
                     .map(|path| path.to_str().unwrap().to_string())
                     .collect(),
-                // NOTE: We can't handle embedded dependencies in any way, since we need to write to
-                // another file to do so.
                 embedded_dependencies: vec![],
             };
             let ron = ron::ser::to_string_pretty(&ron, PrettyConfig::new().new_line("\n")).unwrap();

--- a/crates/bevy_image/src/compressed_image_saver.rs
+++ b/crates/bevy_image/src/compressed_image_saver.rs
@@ -27,7 +27,7 @@ impl AssetSaver for CompressedImageSaver {
     async fn save(
         &self,
         writer: &mut bevy_asset::io::Writer,
-        image: SavedAsset<'_, Self::Asset>,
+        image: SavedAsset<'_, '_, Self::Asset>,
         _settings: &Self::Settings,
     ) -> Result<ImageLoaderSettings, Self::Error> {
         let is_srgb = image.texture_descriptor.format.is_srgb();

--- a/crates/bevy_pbr/src/meshlet/asset.rs
+++ b/crates/bevy_pbr/src/meshlet/asset.rs
@@ -157,7 +157,7 @@ impl AssetSaver for MeshletMeshSaver {
     async fn save(
         &self,
         writer: &mut Writer,
-        asset: SavedAsset<'_, MeshletMesh>,
+        asset: SavedAsset<'_, '_, MeshletMesh>,
         _settings: &(),
     ) -> Result<(), MeshletMeshSaveOrLoadError> {
         // Write asset magic number

--- a/examples/README.md
+++ b/examples/README.md
@@ -255,6 +255,7 @@ Example | Description
 [Asset Decompression](../examples/asset/asset_decompression.rs) | Demonstrates loading a compressed asset
 [Asset Loading](../examples/asset/asset_loading.rs) | Demonstrates various methods to load assets
 [Asset Processing](../examples/asset/processing/asset_processing.rs) | Demonstrates how to process and load custom assets
+[Asset Saving](../examples/asset/asset_saving.rs) | Demonstrates how to save an asset (with subassets)
 [Asset Settings](../examples/asset/asset_settings.rs) | Demonstrates various methods of applying settings when loading an asset
 [Custom Asset](../examples/asset/custom_asset.rs) | Implements a custom asset loader
 [Custom Asset IO](../examples/asset/custom_asset_reader.rs) | Implements a custom AssetReader

--- a/examples/asset/asset_saving.rs
+++ b/examples/asset/asset_saving.rs
@@ -47,15 +47,9 @@ fn perform_save(boxes: Query<(&Sprite, &Transform), With<Box>>, asset_server: Re
     // First we extract all the data needed to produce an asset we can save.
     let boxes = boxes
         .iter()
-        .enumerate()
-        .map(|(index, (sprite, transform))| {
-            (
-                index.to_string(),
-                OneBox {
-                    position: transform.translation.xy(),
-                    color: sprite.color,
-                },
-            )
+        .map(|(sprite, transform)| OneBox {
+            position: transform.translation.xy(),
+            color: sprite.color,
         })
         .collect::<Vec<_>>();
 
@@ -65,11 +59,13 @@ fn perform_save(boxes: Query<(&Sprite, &Transform), With<Box>>, asset_server: Re
             // Build a `SavedAsset` instance from the boxes we extracted.
             let mut builder = SavedAssetBuilder::new(asset_server.clone(), ASSET_PATH.into());
             let mut many_boxes = ManyBoxes { boxes: vec![] };
-            for (label, one_box) in boxes.iter() {
-                many_boxes.boxes.push(
-                    builder
-                        .add_labeled_asset_with_new_handle(label, SavedAsset::from_asset(one_box)),
-                );
+            for (index, one_box) in boxes.iter().enumerate() {
+                many_boxes
+                    .boxes
+                    .push(builder.add_labeled_asset_with_new_handle(
+                        index.to_string(),
+                        SavedAsset::from_asset(one_box),
+                    ));
             }
 
             let saved_asset = builder.build(&many_boxes);

--- a/examples/asset/asset_saving.rs
+++ b/examples/asset/asset_saving.rs
@@ -1,0 +1,376 @@
+//! This example demonstrates how to save assets.
+
+use bevy::{
+    asset::{
+        io::{Reader, Writer},
+        saver::{save_using_saver, AssetSaver, SavedAsset, SavedAssetBuilder},
+        AssetLoader, AsyncWriteExt, LoadContext,
+    },
+    color::palettes::tailwind,
+    input::common_conditions::input_just_pressed,
+    prelude::*,
+    tasks::IoTaskPool,
+};
+use serde::{Deserialize, Serialize};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins.set(AssetPlugin {
+            // This is just overriding the default asset paths to scope this to the correct example
+            // folder. You can generally skip this in your own projects.
+            file_path: "examples/asset/saved_assets".to_string(),
+            ..Default::default()
+        }))
+        .add_plugins(box_editing_plugin)
+        .init_asset::<OneBox>()
+        .init_asset::<ManyBoxes>()
+        .register_asset_loader(ManyBoxesLoader)
+        .add_systems(
+            PreUpdate,
+            (
+                perform_save.run_if(input_just_pressed(KeyCode::F5)),
+                (
+                    start_load.run_if(input_just_pressed(KeyCode::F6)),
+                    wait_for_pending_loads,
+                )
+                    .chain(),
+            ),
+        )
+        .run();
+}
+
+const ASSET_PATH: &str = "my_scene.boxes";
+
+/// A system that takes the scene data, passes it to a task, and saves that scene data to
+/// [`ASSET_PATH`].
+fn perform_save(boxes: Query<(&Sprite, &Transform), With<Box>>, asset_server: Res<AssetServer>) {
+    // First we extract all the data needed to produce an asset we can save.
+    let boxes = boxes
+        .iter()
+        .enumerate()
+        .map(|(index, (sprite, transform))| {
+            (
+                index.to_string(),
+                OneBox {
+                    position: transform.translation.xy(),
+                    color: sprite.color,
+                },
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let asset_server = asset_server.clone();
+    IoTaskPool::get()
+        .spawn(async move {
+            // Build a `SavedAsset` instance from the boxes we extracted.
+            let mut builder = SavedAssetBuilder::new(asset_server.clone(), ASSET_PATH.into());
+            let mut many_boxes = ManyBoxes { boxes: vec![] };
+            for (label, one_box) in boxes.iter() {
+                many_boxes.boxes.push(
+                    builder
+                        .add_labeled_asset_with_new_handle(label, SavedAsset::from_asset(one_box)),
+                );
+            }
+
+            let saved_asset = builder.build(&many_boxes);
+            // Save the asset using the provided saver.
+            match save_using_saver(
+                asset_server.clone(),
+                &ManyBoxesSaver,
+                &ASSET_PATH.into(),
+                saved_asset,
+                &(),
+            )
+            .await
+            {
+                Ok(()) => info!("Completed save of {ASSET_PATH}"),
+                Err(err) => error!("Failed to save asset: {err}"),
+            }
+        })
+        .detach();
+}
+
+/// A system the starts loading [`ASSET_PATH`].
+fn start_load(mut commands: Commands, asset_server: Res<AssetServer>) {
+    commands.spawn(PendingLoad(asset_server.load(ASSET_PATH)));
+}
+
+/// Marks that a handle is currently loading.
+///
+/// Once loading is complete, the [`ManyBoxes`] data will be spawned.
+#[derive(Component)]
+struct PendingLoad(Handle<ManyBoxes>);
+
+/// Waits for any [`PendingLoad`]s to complete, and spawns in their boxes when they do.
+fn wait_for_pending_loads(
+    loads: Populated<(Entity, &PendingLoad)>,
+    many_boxes: Res<Assets<ManyBoxes>>,
+    one_boxes: Res<Assets<OneBox>>,
+    existing_boxes: Query<Entity, With<Box>>,
+    mut commands: Commands,
+) {
+    for (entity, load) in loads.iter() {
+        let Some(many_boxes) = many_boxes.get(&load.0) else {
+            continue;
+        };
+
+        commands.entity(entity).despawn();
+        for entity in existing_boxes.iter() {
+            commands.entity(entity).despawn();
+        }
+
+        for box_handle in many_boxes.boxes.iter() {
+            let Some(one_box) = one_boxes.get(box_handle) else {
+                return;
+            };
+            commands.spawn((
+                Sprite::from_color(one_box.color, Vec2::new(100.0, 100.0)),
+                Transform::from_translation(one_box.position.extend(0.0)),
+                Pickable::default(),
+                Box,
+            ));
+        }
+    }
+}
+
+/// An asset representing a single box.
+#[derive(Asset, TypePath, Clone, Serialize, Deserialize)]
+struct OneBox {
+    /// The position of the box.
+    position: Vec2,
+    /// The color of the box.
+    color: Color,
+}
+
+/// An asset representing many boxes.
+#[derive(Asset, TypePath)]
+struct ManyBoxes {
+    /// Stores handles to all the boxes that should be spawned.
+    ///
+    /// Note: in this trivial example, it seems more reasonable to just store [`Vec<OneBox>`], but
+    /// in a more realistic example this could be something like a whole [`Mesh`] (where a handle
+    /// makes more sense). We use a handle here to demonstrate saving subassets as well.
+    boxes: Vec<Handle<OneBox>>,
+}
+
+/// A serializable version of [`ManyBoxes`].
+#[derive(Serialize, Deserialize)]
+struct SerializableManyBoxes {
+    /// The boxes that exist in this scene.
+    boxes: Vec<OneBox>,
+}
+
+/// Am asset saver to save [`ManyBoxes`] assets.
+#[derive(TypePath)]
+struct ManyBoxesSaver;
+
+impl AssetSaver for ManyBoxesSaver {
+    type Asset = ManyBoxes;
+    type Error = BevyError;
+    type OutputLoader = ManyBoxesLoader;
+    type Settings = ();
+
+    async fn save(
+        &self,
+        writer: &mut Writer,
+        asset: SavedAsset<'_, '_, Self::Asset>,
+        _settings: &Self::Settings,
+    ) -> Result<(), Self::Error> {
+        let boxes = asset
+            .boxes
+            .iter()
+            .map(|handle| {
+                // TODO: We should have a better to get the asset for a subasset handle.
+                let label = handle
+                    .path()
+                    .and_then(|path| path.label())
+                    .ok_or_else(|| format!("Failed to get label for handle {handle:?}"))?;
+                asset
+                    .get_labeled::<OneBox>(label)
+                    .map(|subasset| subasset.get().clone())
+                    .ok_or_else(|| format!("Failed to find labeled asset for label {label}"))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        // Note: serializing to string isn't ideal since we can't do a streaming write, but this is
+        // fine for an example.
+        let serialized = ron::to_string(&SerializableManyBoxes { boxes })?;
+        writer.write_all(serialized.as_bytes()).await?;
+
+        Ok(())
+    }
+}
+
+/// An asset loader for loading [`ManyBoxes`] assets.
+#[derive(TypePath)]
+struct ManyBoxesLoader;
+
+impl AssetLoader for ManyBoxesLoader {
+    type Asset = ManyBoxes;
+    type Error = BevyError;
+    type Settings = ();
+
+    async fn load(
+        &self,
+        reader: &mut dyn Reader,
+        _settings: &Self::Settings,
+        load_context: &mut LoadContext<'_>,
+    ) -> Result<Self::Asset, Self::Error> {
+        let mut bytes = vec![];
+        reader.read_to_end(&mut bytes).await?;
+
+        let serialized: SerializableManyBoxes = ron::de::from_bytes(&bytes)?;
+
+        // Add the boxes as subassets.
+        let mut result_boxes = vec![];
+        for (index, one_box) in serialized.boxes.into_iter().enumerate() {
+            result_boxes.push(load_context.add_labeled_asset(index.to_string(), one_box));
+        }
+
+        Ok(ManyBoxes {
+            boxes: result_boxes,
+        })
+    }
+
+    fn extensions(&self) -> &[&str] {
+        &["boxes"]
+    }
+}
+
+/// Plugin for doing all the box-editing.
+///
+/// This doesn't really have anything to do with asset saving, but provides a real use-case.
+fn box_editing_plugin(app: &mut App) {
+    app.add_systems(Startup, setup)
+        .add_observer(spawn_box)
+        .add_observer(start_rotate_box_hue)
+        .add_observer(end_rotate_box_hue_on_release)
+        .add_observer(end_rotate_box_hue_on_out)
+        .add_systems(Update, rotate_hue)
+        .add_observer(stop_propagate_on_clicked_box)
+        .add_observer(drag_box);
+}
+
+#[derive(Component)]
+struct Box;
+
+/// Spawns the initial scene.
+fn setup(mut commands: Commands) {
+    commands.spawn(Camera2d);
+
+    commands.spawn(Text(
+        r"LMB (on background) - spawn new box
+LMB (on box) - drag to move
+RMB (on box) - rotate colors
+F5 - Save boxes
+F6 - Load boxes"
+            .into(),
+    ));
+}
+
+/// Spawns a new box whenever you left-click on the background.
+fn spawn_box(
+    event: On<Pointer<Press>>,
+    window: Query<(), With<Window>>,
+    camera: Single<(&Camera, &GlobalTransform)>,
+    mut commands: Commands,
+) {
+    if event.button != PointerButton::Primary {
+        return;
+    }
+    if !window.contains(event.entity) {
+        return;
+    }
+
+    let (camera, camera_transform) = camera.into_inner();
+    let Ok(click_point) =
+        camera.viewport_to_world_2d(camera_transform, event.pointer_location.position)
+    else {
+        return;
+    };
+    commands.spawn((
+        Sprite::from_color(tailwind::RED_500, Vec2::new(100.0, 100.0)),
+        Transform::from_translation(click_point.extend(0.0)),
+        Pickable::default(),
+        Box,
+    ));
+}
+
+/// A component to rotate the hue of a sprite every frame.
+#[derive(Component)]
+struct RotateHue;
+
+/// Rotates the hue of each [`Sprite`] tagged with [`RotateHue`].
+fn rotate_hue(time: Res<Time>, mut sprites: Query<&mut Sprite, With<RotateHue>>) {
+    for mut sprite in sprites.iter_mut() {
+        // Make a full rotation every 2 seconds.
+        sprite.color = sprite.color.rotate_hue(time.delta_secs() * 180.0);
+    }
+}
+
+/// Starts rotating the hue of a box that has been right-clicked.
+fn start_rotate_box_hue(
+    event: On<Pointer<Press>>,
+    boxes: Query<(), With<Box>>,
+    mut commands: Commands,
+) {
+    if event.button != PointerButton::Secondary {
+        return;
+    }
+    if !boxes.contains(event.entity) {
+        return;
+    }
+    commands.entity(event.entity).insert(RotateHue);
+}
+
+/// Stops rotating the box hue if it's right-click is released.
+fn end_rotate_box_hue_on_release(
+    event: On<Pointer<Release>>,
+    boxes: Query<(), (With<Box>, With<RotateHue>)>,
+    mut commands: Commands,
+) {
+    if event.button != PointerButton::Secondary {
+        return;
+    }
+    if !boxes.contains(event.entity) {
+        return;
+    }
+    commands.entity(event.entity).remove::<RotateHue>();
+}
+
+/// Stops rotating the box hue if the cursor moves off the entity.
+fn end_rotate_box_hue_on_out(
+    event: On<Pointer<Out>>,
+    boxes: Query<(), (With<Box>, With<RotateHue>)>,
+    mut commands: Commands,
+) {
+    if !boxes.contains(event.entity) {
+        return;
+    }
+    commands.entity(event.entity).remove::<RotateHue>();
+}
+
+/// Blocks propagation of pointer press events on left-clicked boxes.
+fn stop_propagate_on_clicked_box(mut event: On<Pointer<Press>>, boxes: Query<(), With<Box>>) {
+    if event.button != PointerButton::Primary {
+        return;
+    }
+    if !boxes.contains(event.entity) {
+        return;
+    }
+    event.propagate(false);
+}
+
+/// Drags a box when you left-click on one.
+fn drag_box(event: On<Pointer<Drag>>, mut boxes: Query<&mut Transform, With<Box>>) {
+    if event.button != PointerButton::Primary {
+        return;
+    }
+    let Ok(mut transform) = boxes.get_mut(event.entity) else {
+        return;
+    };
+
+    // This is wrong in general (e.g., doesn't consider scale), but it's close enough for our
+    // purposes.
+    transform.translation += Vec3::new(event.delta.x, -event.delta.y, 0.0);
+}

--- a/examples/asset/processing/asset_processing.rs
+++ b/examples/asset/processing/asset_processing.rs
@@ -218,7 +218,7 @@ impl AssetSaver for CoolTextSaver {
     async fn save(
         &self,
         writer: &mut Writer,
-        asset: SavedAsset<'_, Self::Asset>,
+        asset: SavedAsset<'_, '_, Self::Asset>,
         _settings: &Self::Settings,
     ) -> Result<TextSettings, Self::Error> {
         writer.write_all(asset.text.as_bytes()).await?;

--- a/release-content/migration-guides/asset_saver_changes.md
+++ b/release-content/migration-guides/asset_saver_changes.md
@@ -1,0 +1,47 @@
+---
+title: SavedAsset now contains two lifetimes.
+pull_requests: []
+---
+
+`SavedAsset` now holds two lifetimes instead of one. This is primarily used in the context of
+`AssetSaver`. So previously, users may have:
+
+```rust
+impl AssetSaver for MySaver {
+    type Asset = MyAsset;
+    type Settings = ();
+    type OutputLoader = MyLoader;
+    type Error = std::io::Error;
+
+    async fn save(
+        &self,
+        writer: &mut Writer,
+        asset: SavedAsset<'_, Self::Asset>,
+        settings: &Self::Settings,
+    ) -> Result<(), Self::Error> {
+        todo!()
+    }
+}
+```
+
+Now with the extra `SavedAsset` lifetime:
+
+```rust
+impl AssetSaver for MySaver {
+    type Asset = MyAsset;
+    type Settings = ();
+    type OutputLoader = MyLoader;
+    type Error = std::io::Error;
+
+    async fn save(
+        &self,
+        writer: &mut Writer,
+        asset: SavedAsset<'_, '_, Self::Asset>,
+        settings: &Self::Settings,
+    ) -> Result<(), Self::Error> {
+        todo!()
+    }
+}
+```
+
+In practice, this should not have an impact on usages.

--- a/release-content/release-notes/asset_saving.md
+++ b/release-content/release-notes/asset_saving.md
@@ -1,0 +1,52 @@
+---
+title: Asset Saving
+authors: ["@andriyDev"]
+pull_requests: []
+---
+
+Since Bevy 0.12, we've had the `AssetSaver` trait. Unfortunately, this trait was not really usable
+for asset saving: it was only intended for use with asset processing! This was a common stumbling
+block for users, and pointed to a gap in our API.
+
+Now, users can save their assets using `save_using_saver`. To use this involves two steps.
+
+## 1. Building the `SavedAsset`
+
+To build the `SavedAsset`, either use `SavedAsset::from_asset`, or `SavedAssetBuilder`. For example:
+
+```rust
+let asset_path: AssetPath<'static> = "my/file/path.whatever";
+let mut builder = SavedAssetBuilder::new(asset_server.clone(), asset_path.clone());
+
+let subasset_1 = Line("howdy".into());
+let subasset_2 = Line("goodbye".into());
+let handle_1 = builder.add_labeled_asset_with_new_handle(
+    "TheFirstLabel", SavedAsset::from_asset(&subasset_1));
+let handle_2 = builder.add_labeled_asset_with_new_handle(
+    "AnotherOne", SavedAsset::from_asset(&subasset_2));
+
+let main_asset = Book {
+    lines: vec![handle_1, handle_2],
+};
+let saved_asset = builder.build(&main_asset);
+```
+
+Note that since these assets are borrowed, building the `SavedAsset` should happen in the same async
+task as the next step.
+
+## 2. Calling `save_using_saver`
+
+Now, with a `SavedAsset`, we can just call `save_using_saver` and fill in any arguments:
+
+```rust
+save_using_saver(
+    asset_server.clone(),
+    &MyAssetSaver::default(),
+    &asset_path,
+    saved_asset,
+    &MySettings::default(),
+).await.unwrap();
+```
+
+Part of this includes implementing the `AssetSaver` trait on `MyAssetSaver`. In addition, this is an
+async function, so it is likely you will want to spawn this using `IoTaskPool::get().spawn(...)`.

--- a/release-content/release-notes/asset_saving.md
+++ b/release-content/release-notes/asset_saving.md
@@ -12,7 +12,16 @@ Now, users can save their assets using `save_using_saver`. To use this involves 
 
 ## 1. Building the `SavedAsset`
 
-To build the `SavedAsset`, either use `SavedAsset::from_asset`, or `SavedAssetBuilder`. For example:
+To build the `SavedAsset`, either use `SavedAsset::from_asset`:
+
+```rust
+let main_asset = InlinedBook {
+    lines: vec!["Save me!".to_string(), "Please!".to_string()],
+};
+let saved_asset = SavedAsset::from_asset(&main_asset);
+```
+
+Or for more complicated cases, `SavedAssetBuilder`:
 
 ```rust
 let asset_path: AssetPath<'static> = "my/file/path.whatever";


### PR DESCRIPTION
# Objective

- A step towards #11216.

## Solution

- Allow users to build `SavedAsset` instances by building up their labeled assets. This can either take an existing handle + asset ref, or will create a handle for your asset ref.
- Provide a function to correctly call the `AssetSaver`, and write out the correct meta file.

### Some things I am leaving to future PRs

- Making it easier to access subassets in an `AssetSaver`.
- Making a nicer API for asset saving (e.g., registering asset savers and looking up the appropriate saver for type ID + extension).

### Weird implementation details

- I needed to create my own Cow-like type (which I named `Moo`), since I needed to store just a ref or owned hashmap. I wrote a lengthy comment explaining why it's needed (TL;DR variance is complicated, Cow doesn't work). Note: it's possible we could just use CowArc instead, but we never need to clone the map so this seems like overkill. Also having a nice place to explain the variance problems is useful here.
- For the builder, I needed to add an extra lifetime to `add_labeled_asset_with_*<'b: 'a>`, since otherwise, the `CowArc` gets coerced to `'static` which means the lifetime of the subasset needs to be `'static`, which practically makes this unusable. By adding a second lifetime dedicated to the `CowArc`, 

## Testing

- Created a new example: this allows you to make a small "scene" of boxes, and save and load it to your heart's content!
- Added a couple simple tests.