### PR TITLE
Fix failed sub-asset loads getting stuck in `LoadState::Loading`

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -3062,8 +3062,7 @@ mod tests {
         test_load_state::<CoolText>(
             "sub-asset of malformed root asset",
             "malformed.cool.ron#subasset",
-            // XXX TODO: This is broken.
-            TestLoadState::Loading,
+            TestLoadState::Failed(TestAssetLoadError::AssetLoaderError),
         );
 
         test_load_state::<LoaderlessAsset>(

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -893,11 +893,13 @@ impl AssetServer {
                 Ok(final_handle)
             }
             Err(err) => {
-                self.send_asset_event(InternalAssetEvent::Failed {
-                    index: base_asset_id,
-                    error: err.clone(),
-                    path: path.into_owned(),
-                });
+                if let Some(asset_id) = asset_id {
+                    self.send_asset_event(InternalAssetEvent::Failed {
+                        index: asset_id,
+                        error: err.clone(),
+                        path: path.into_owned(),
+                    });
+                }
                 Err(err)
             }
         }


### PR DESCRIPTION
## Objective

Fix #22607. Also add a test that reproduces the issues.

If it makes things clearer, I can split this into an "add a test" PR and a separate "fix the bug" PR.

## Solution

There are three additions to `AssetServer::load_internal` that each fix a separate case. In source code order:

### Case 1

```rust
// Sub-asset exists, but is not of type `WrongAssetType`.
asset_server.load::<WrongAssetType>("asset#subasset");
```

Previously this would silently fail - the asset would successfully load, but the handle can't actually resolve to that asset so it's stuck in limbo.

Fixed by adding a type check, then sending a `AssetLoadError::RequestedHandleTypeMismatch` event and returning it as an error.

Note that this doesn't prevent someone loading the asset with the correct type - the error is only associated with the `<WrongAssetType>` handle.

### Case 2

```rust
// Sub-asset doesn't exist.
asset_server.load::<AssetType>("asset#non_existent_subasset");
```

Previously this was detected and would return a `AssetLoadError::MissingLabel` error from `load_internal`, but the load status for the handle wasn't set.

Fixed by sending an `InternalAssetEvent::Failed`.

### Case 3
```rust
// Asset loader returns an error.
asset_server.load::<AssetType>("malformed_asset#subasset");
```

Previously this was detected, but the event was sent with the root asset's id (`base_asset_id`) so it wasn't associated with the sub-asset's handle.

Fixed by using the sub-asset's id.

### Notes

Some of the events are only sent if `asset_id` is set. This might seem odd, but I think it's correct - `asset_id` can only be unset when using `load_untyped` with a sub-asset path, in which case there's no handle to associate with the error, and so there's no handle to pass to `get_load_status`.

## Testing

```sh
cargo test -p bevy_asset
cargo test -p bevy_asset --features "multi_threaded"
```