### PR TITLE
Fix artifacts when rendering large gizmos

### DIFF
--- a/crates/bevy_gizmos_render/src/lines.wgsl
+++ b/crates/bevy_gizmos_render/src/lines.wgsl
@@ -141,7 +141,10 @@ fn clip_near_plane(a: vec4<f32>, b: vec4<f32>) -> vec4<f32> {
         // Interpolate a towards b until it's at the near plane.
         let distance_a = a.z - a.w;
         let distance_b = b.z - b.w;
-        let t = distance_a / (distance_a - distance_b);
+        // Add an epsilon to the interpolator to ensure that the point is
+        // not just behind the clip plane due to floating-point imprecision,
+        // which can lead to lines showing up where they should not.
+        let t = distance_a / (distance_a - distance_b) + EPSILON;
         return mix(a, b, t);
     }
     return a;


### PR DESCRIPTION
# Objective

Fixes #22580, see the issue for more information.

## Solution

- Bring back the EPSILON that was removed in https://github.com/bevyengine/bevy/pull/21503

## Testing

Tested with the example code in the issue.

