### PR TITLE
Fix `FileAssetReader` clippy on Windows

### DIFF
--- a/crates/bevy_asset/src/io/file/file_asset.rs
+++ b/crates/bevy_asset/src/io/file/file_asset.rs
@@ -91,7 +91,7 @@ impl AssetReader for FileAssetReader {
                 #[cfg(not(target_os = "windows"))]
                 _guard,
                 #[cfg(target_os = "windows")]
-                _lifetime: PhantomData::default(),
+                _lifetime: PhantomData,
             })
     }
 
@@ -115,7 +115,7 @@ impl AssetReader for FileAssetReader {
                 #[cfg(not(target_os = "windows"))]
                 _guard,
                 #[cfg(target_os = "windows")]
-                _lifetime: PhantomData::default(),
+                _lifetime: PhantomData,
             })
     }
 


### PR DESCRIPTION
#22560 added this code:

```rust
.map(|file| GuardedFile {
    file,
    #[cfg(not(target_os = "windows"))]
    _guard,
    #[cfg(target_os = "windows")]
    _lifetime: PhantomData::default(),
})
```

But clippy says no!

```
error: use of `default` to create a unit struct                                                                                              
  --> crates\bevy_asset\src\io\file\file_asset.rs:94:28
   |
94 |                 _lifetime: PhantomData::default(),
   |                            ^^^^^^^^^^^-----------
   |                                       |
   |                                       help: remove this call to `default`
   |
```

## Testing

Tested on Win10 only.

```
cargo run --example asset_loading
```