### PR TITLE
`WinitSettings` cleanup

### DIFF
--- a/examples/large_scenes/bistro/src/main.rs
+++ b/examples/large_scenes/bistro/src/main.rs
@@ -32,7 +32,7 @@ use bevy::{
     diagnostic::FrameTimeDiagnosticsPlugin,
     prelude::*,
     window::{PresentMode, WindowResolution},
-    winit::{UpdateMode, WinitSettings},
+    winit::WinitSettings,
 };
 use mipmap_generator::{
     generate_mipmaps, MipmapGeneratorDebugTextPlugin, MipmapGeneratorPlugin,

--- a/examples/large_scenes/caldera_hotel/src/main.rs
+++ b/examples/large_scenes/caldera_hotel/src/main.rs
@@ -27,7 +27,7 @@ use bevy::{
     },
     scene::SceneInstanceReady,
     window::{PresentMode, WindowResolution},
-    winit::{UpdateMode, WinitSettings},
+    winit::WinitSettings,
 };
 
 #[derive(FromArgs, Resource, Clone)]

--- a/examples/stress_tests/many_cubes.rs
+++ b/examples/stress_tests/many_cubes.rs
@@ -24,7 +24,7 @@ use bevy::{
         view::NoIndirectDrawing,
     },
     window::{PresentMode, WindowResolution},
-    winit::{UpdateMode, WinitSettings},
+    winit::WinitSettings,
 };
 use rand::{seq::IndexedRandom, Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;

--- a/examples/stress_tests/many_gradients.rs
+++ b/examples/stress_tests/many_gradients.rs
@@ -14,7 +14,7 @@ use bevy::{
         RepeatedGridTrack,
     },
     window::{PresentMode, WindowResolution},
-    winit::{UpdateMode, WinitSettings},
+    winit::WinitSettings,
 };
 
 const COLS: usize = 30;

--- a/examples/stress_tests/many_materials.rs
+++ b/examples/stress_tests/many_materials.rs
@@ -4,7 +4,7 @@ use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     prelude::*,
     window::{PresentMode, WindowResolution},
-    winit::{UpdateMode, WinitSettings},
+    winit::WinitSettings,
 };
 use std::f32::consts::PI;
 


### PR DESCRIPTION
# Objective

#### Some cleanup
1. `many_gradients` inserts `WinitSettings` twice.
2. Replace manual configuration where `WinitSettings::continuous()` could be used.


