### PR TITLE
Make safety comments on unsafe traits internal comments

### DIFF
--- a/crates/bevy_asset/src/asset_changed.rs
+++ b/crates/bevy_asset/src/asset_changed.rs
@@ -149,7 +149,7 @@ pub struct AssetChangedState<A: AsAssetId> {
 }
 
 #[expect(unsafe_code, reason = "WorldQuery is an unsafe trait.")]
-/// SAFETY: `ROQueryFetch<Self>` is the same as `QueryFetch<Self>`
+// SAFETY: `ROQueryFetch<Self>` is the same as `QueryFetch<Self>`
 unsafe impl<A: AsAssetId> WorldQuery for AssetChanged<A> {
     type Fetch<'w> = AssetChangedFetch<'w, A>;
 
@@ -264,7 +264,7 @@ unsafe impl<A: AsAssetId> WorldQuery for AssetChanged<A> {
 }
 
 #[expect(unsafe_code, reason = "QueryFilter is an unsafe trait.")]
-/// SAFETY: read-only access
+// SAFETY: read-only access
 unsafe impl<A: AsAssetId> QueryFilter for AssetChanged<A> {
     const IS_ARCHETYPAL: bool = false;
 

--- a/crates/bevy_ecs/macros/src/query_data.rs
+++ b/crates/bevy_ecs/macros/src/query_data.rs
@@ -229,7 +229,7 @@ pub fn derive_query_data_impl(input: TokenStream) -> TokenStream {
     let data_impl = {
         let read_only_data_impl = if attributes.is_mutable {
             quote! {
-                /// SAFETY: we assert fields are readonly below
+                // SAFETY: we assert fields are readonly below
                 unsafe impl #user_impl_generics #path::query::QueryData
                 for #read_only_struct_name #user_ty_generics #user_where_clauses {
                     const IS_READ_ONLY: bool = true;
@@ -300,7 +300,7 @@ pub fn derive_query_data_impl(input: TokenStream) -> TokenStream {
         let is_read_only = !attributes.is_mutable;
 
         quote! {
-            /// SAFETY: we assert fields are readonly below
+            // SAFETY: we assert fields are readonly below
             unsafe impl #user_impl_generics #path::query::QueryData
             for #struct_name #user_ty_generics #user_where_clauses {
                 const IS_READ_ONLY: bool = #is_read_only;
@@ -369,7 +369,7 @@ pub fn derive_query_data_impl(input: TokenStream) -> TokenStream {
     };
 
     let read_only_data_impl = quote! {
-        /// SAFETY: we assert fields are readonly below
+        // SAFETY: we assert fields are readonly below
         unsafe impl #user_impl_generics #path::query::ReadOnlyQueryData
         for #read_only_struct_name #user_ty_generics #user_where_clauses {}
     };

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -383,9 +383,9 @@ pub trait ReleaseStateQueryData: QueryData {
 /// The trait must only be implemented for query data where its corresponding [`QueryData::IS_ARCHETYPAL`] is [`prim@true`].
 pub trait ArchetypeQueryData: QueryData {}
 
-/// SAFETY:
-/// `update_component_access` does nothing.
-/// This is sound because `fetch` does not access components.
+// SAFETY:
+// `update_component_access` does nothing.
+// This is sound because `fetch` does not access components.
 unsafe impl WorldQuery for Entity {
     type Fetch<'w> = ();
     type State = ();
@@ -435,7 +435,7 @@ unsafe impl WorldQuery for Entity {
     }
 }
 
-/// SAFETY: `Self` is the same as `Self::ReadOnly`
+// SAFETY: `Self` is the same as `Self::ReadOnly`
 unsafe impl QueryData for Entity {
     const IS_READ_ONLY: bool = true;
     const IS_ARCHETYPAL: bool = true;
@@ -464,7 +464,7 @@ unsafe impl QueryData for Entity {
     }
 }
 
-/// SAFETY: access is read only
+// SAFETY: access is read only
 unsafe impl ReadOnlyQueryData for Entity {}
 
 impl ReleaseStateQueryData for Entity {
@@ -475,9 +475,9 @@ impl ReleaseStateQueryData for Entity {
 
 impl ArchetypeQueryData for Entity {}
 
-/// SAFETY:
-/// `update_component_access` does nothing.
-/// This is sound because `fetch` does not access components.
+// SAFETY:
+// `update_component_access` does nothing.
+// This is sound because `fetch` does not access components.
 unsafe impl WorldQuery for EntityLocation {
     type Fetch<'w> = &'w Entities;
     type State = ();
@@ -532,7 +532,7 @@ unsafe impl WorldQuery for EntityLocation {
     }
 }
 
-/// SAFETY: `Self` is the same as `Self::ReadOnly`
+// SAFETY: `Self` is the same as `Self::ReadOnly`
 unsafe impl QueryData for EntityLocation {
     const IS_READ_ONLY: bool = true;
     const IS_ARCHETYPAL: bool = true;
@@ -561,7 +561,7 @@ unsafe impl QueryData for EntityLocation {
     }
 }
 
-/// SAFETY: access is read only
+// SAFETY: access is read only
 unsafe impl ReadOnlyQueryData for EntityLocation {}
 
 impl ReleaseStateQueryData for EntityLocation {
@@ -741,7 +741,7 @@ unsafe impl QueryData for SpawnDetails {
     }
 }
 
-/// SAFETY: access is read only
+// SAFETY: access is read only
 unsafe impl ReadOnlyQueryData for SpawnDetails {}
 
 impl ReleaseStateQueryData for SpawnDetails {
@@ -762,10 +762,10 @@ pub struct EntityFetch<'w> {
     this_run: Tick,
 }
 
-/// SAFETY:
-/// `fetch` accesses all components in a readonly way.
-/// This is sound because `update_component_access` sets read access for all components and panic when appropriate.
-/// Filters are unchanged.
+// SAFETY:
+// `fetch` accesses all components in a readonly way.
+// This is sound because `update_component_access` sets read access for all components and panic when appropriate.
+// Filters are unchanged.
 unsafe impl<'a> WorldQuery for EntityRef<'a> {
     type Fetch<'w> = EntityFetch<'w>;
     type State = ();
@@ -828,7 +828,7 @@ unsafe impl<'a> WorldQuery for EntityRef<'a> {
     }
 }
 
-/// SAFETY: `Self` is the same as `Self::ReadOnly`
+// SAFETY: `Self` is the same as `Self::ReadOnly`
 unsafe impl<'a> QueryData for EntityRef<'a> {
     const IS_READ_ONLY: bool = true;
     const IS_ARCHETYPAL: bool = true;
@@ -864,7 +864,7 @@ unsafe impl<'a> QueryData for EntityRef<'a> {
     }
 }
 
-/// SAFETY: access is read only
+// SAFETY: access is read only
 unsafe impl ReadOnlyQueryData for EntityRef<'_> {}
 
 impl ReleaseStateQueryData for EntityRef<'_> {
@@ -875,7 +875,7 @@ impl ReleaseStateQueryData for EntityRef<'_> {
 
 impl ArchetypeQueryData for EntityRef<'_> {}
 
-/// SAFETY: The accesses of `Self::ReadOnly` are a subset of the accesses of `Self`
+// SAFETY: The accesses of `Self::ReadOnly` are a subset of the accesses of `Self`
 unsafe impl<'a> WorldQuery for EntityMut<'a> {
     type Fetch<'w> = EntityFetch<'w>;
     type State = ();
@@ -938,7 +938,7 @@ unsafe impl<'a> WorldQuery for EntityMut<'a> {
     }
 }
 
-/// SAFETY: access of `EntityRef` is a subset of `EntityMut`
+// SAFETY: access of `EntityRef` is a subset of `EntityMut`
 unsafe impl<'a> QueryData for EntityMut<'a> {
     const IS_READ_ONLY: bool = false;
     const IS_ARCHETYPAL: bool = true;
@@ -982,7 +982,7 @@ impl ReleaseStateQueryData for EntityMut<'_> {
 
 impl ArchetypeQueryData for EntityMut<'_> {}
 
-/// SAFETY: The accesses of `Self::ReadOnly` are a subset of the accesses of `Self`
+// SAFETY: The accesses of `Self::ReadOnly` are a subset of the accesses of `Self`
 unsafe impl WorldQuery for FilteredEntityRef<'_, '_> {
     type Fetch<'w> = EntityFetch<'w>;
     type State = Access;
@@ -1047,7 +1047,7 @@ unsafe impl WorldQuery for FilteredEntityRef<'_, '_> {
     }
 }
 
-/// SAFETY: `Self` is the same as `Self::ReadOnly`
+// SAFETY: `Self` is the same as `Self::ReadOnly`
 unsafe impl<'a, 'b> QueryData for FilteredEntityRef<'a, 'b> {
     const IS_READ_ONLY: bool = true;
     const IS_ARCHETYPAL: bool = true;
@@ -1102,12 +1102,12 @@ unsafe impl<'a, 'b> QueryData for FilteredEntityRef<'a, 'b> {
     }
 }
 
-/// SAFETY: Access is read-only.
+// SAFETY: Access is read-only.
 unsafe impl ReadOnlyQueryData for FilteredEntityRef<'_, '_> {}
 
 impl ArchetypeQueryData for FilteredEntityRef<'_, '_> {}
 
-/// SAFETY: The accesses of `Self::ReadOnly` are a subset of the accesses of `Self`
+// SAFETY: The accesses of `Self::ReadOnly` are a subset of the accesses of `Self`
 unsafe impl WorldQuery for FilteredEntityMut<'_, '_> {
     type Fetch<'w> = EntityFetch<'w>;
     type State = Access;
@@ -1172,7 +1172,7 @@ unsafe impl WorldQuery for FilteredEntityMut<'_, '_> {
     }
 }
 
-/// SAFETY: access of `FilteredEntityRef` is a subset of `FilteredEntityMut`
+// SAFETY: access of `FilteredEntityRef` is a subset of `FilteredEntityMut`
 unsafe impl<'a, 'b> QueryData for FilteredEntityMut<'a, 'b> {
     const IS_READ_ONLY: bool = false;
     const IS_ARCHETYPAL: bool = true;
@@ -1227,9 +1227,9 @@ unsafe impl<'a, 'b> QueryData for FilteredEntityMut<'a, 'b> {
 
 impl ArchetypeQueryData for FilteredEntityMut<'_, '_> {}
 
-/// SAFETY: `EntityRefExcept` guards access to all components in the bundle `B`
-/// and populates `Access` values so that queries that conflict with this access
-/// are rejected.
+// SAFETY: `EntityRefExcept` guards access to all components in the bundle `B`
+// and populates `Access` values so that queries that conflict with this access
+// are rejected.
 unsafe impl<'a, 'b, B> WorldQuery for EntityRefExcept<'a, 'b, B>
 where
     B: Bundle,
@@ -1305,7 +1305,7 @@ where
     }
 }
 
-/// SAFETY: `Self` is the same as `Self::ReadOnly`.
+// SAFETY: `Self` is the same as `Self::ReadOnly`.
 unsafe impl<'a, 'b, B> QueryData for EntityRefExcept<'a, 'b, B>
 where
     B: Bundle,
@@ -1339,15 +1339,15 @@ where
     }
 }
 
-/// SAFETY: `EntityRefExcept` enforces read-only access to its contained
-/// components.
+// SAFETY: `EntityRefExcept` enforces read-only access to its contained
+// components.
 unsafe impl<B> ReadOnlyQueryData for EntityRefExcept<'_, '_, B> where B: Bundle {}
 
 impl<B: Bundle> ArchetypeQueryData for EntityRefExcept<'_, '_, B> {}
 
-/// SAFETY: `EntityMutExcept` guards access to all components in the bundle `B`
-/// and populates `Access` values so that queries that conflict with this access
-/// are rejected.
+// SAFETY: `EntityMutExcept` guards access to all components in the bundle `B`
+// and populates `Access` values so that queries that conflict with this access
+// are rejected.
 unsafe impl<'a, 'b, B> WorldQuery for EntityMutExcept<'a, 'b, B>
 where
     B: Bundle,
@@ -1423,8 +1423,8 @@ where
     }
 }
 
-/// SAFETY: All accesses that `EntityRefExcept` provides are also accesses that
-/// `EntityMutExcept` provides.
+// SAFETY: All accesses that `EntityRefExcept` provides are also accesses that
+// `EntityMutExcept` provides.
 unsafe impl<'a, 'b, B> QueryData for EntityMutExcept<'a, 'b, B>
 where
     B: Bundle,
@@ -1460,9 +1460,9 @@ where
 
 impl<B: Bundle> ArchetypeQueryData for EntityMutExcept<'_, '_, B> {}
 
-/// SAFETY:
-/// `update_component_access` does nothing.
-/// This is sound because `fetch` does not access components.
+// SAFETY:
+// `update_component_access` does nothing.
+// This is sound because `fetch` does not access components.
 unsafe impl WorldQuery for &Archetype {
     type Fetch<'w> = (&'w Entities, &'w Archetypes);
     type State = ();
@@ -1517,7 +1517,7 @@ unsafe impl WorldQuery for &Archetype {
     }
 }
 
-/// SAFETY: `Self` is the same as `Self::ReadOnly`
+// SAFETY: `Self` is the same as `Self::ReadOnly`
 unsafe impl QueryData for &Archetype {
     const IS_READ_ONLY: bool = true;
     const IS_ARCHETYPAL: bool = true;
@@ -1549,7 +1549,7 @@ unsafe impl QueryData for &Archetype {
     }
 }
 
-/// SAFETY: access is read only
+// SAFETY: access is read only
 unsafe impl ReadOnlyQueryData for &Archetype {}
 
 impl ReleaseStateQueryData for &Archetype {
@@ -1579,11 +1579,11 @@ impl<T: Component> Clone for ReadFetch<'_, T> {
 
 impl<T: Component> Copy for ReadFetch<'_, T> {}
 
-/// SAFETY:
-/// `fetch` accesses a single component in a readonly way.
-/// This is sound because `update_component_access` adds read access for that component and panic when appropriate.
-/// `update_component_access` adds a `With` filter for a component.
-/// This is sound because `matches_component_set` returns whether the set contains that component.
+// SAFETY:
+// `fetch` accesses a single component in a readonly way.
+// This is sound because `update_component_access` adds read access for that component and panic when appropriate.
+// `update_component_access` adds a `With` filter for a component.
+// This is sound because `matches_component_set` returns whether the set contains that component.
 unsafe impl<T: Component> WorldQuery for &T {
     type Fetch<'w> = ReadFetch<'w, T>;
     type State = ComponentId;
@@ -1676,7 +1676,7 @@ unsafe impl<T: Component> WorldQuery for &T {
     }
 }
 
-/// SAFETY: `Self` is the same as `Self::ReadOnly`
+// SAFETY: `Self` is the same as `Self::ReadOnly`
 unsafe impl<T: Component> QueryData for &T {
     const IS_READ_ONLY: bool = true;
     const IS_ARCHETYPAL: bool = true;
@@ -1722,7 +1722,7 @@ unsafe impl<T: Component> QueryData for &T {
     }
 }
 
-/// SAFETY: access is read only
+// SAFETY: access is read only
 unsafe impl<T: Component> ReadOnlyQueryData for &T {}
 
 impl<T: Component> ReleaseStateQueryData for &T {
@@ -1760,11 +1760,11 @@ impl<T: Component> Clone for RefFetch<'_, T> {
 
 impl<T: Component> Copy for RefFetch<'_, T> {}
 
-/// SAFETY:
-/// `fetch` accesses a single component in a readonly way.
-/// This is sound because `update_component_access` adds read access for that component and panic when appropriate.
-/// `update_component_access` adds a `With` filter for a component.
-/// This is sound because `matches_component_set` returns whether the set contains that component.
+// SAFETY:
+// `fetch` accesses a single component in a readonly way.
+// This is sound because `update_component_access` adds read access for that component and panic when appropriate.
+// `update_component_access` adds a `With` filter for a component.
+// This is sound because `matches_component_set` returns whether the set contains that component.
 unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
     type Fetch<'w> = RefFetch<'w, T>;
     type State = ComponentId;
@@ -1866,7 +1866,7 @@ unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
     }
 }
 
-/// SAFETY: `Self` is the same as `Self::ReadOnly`
+// SAFETY: `Self` is the same as `Self::ReadOnly`
 unsafe impl<'__w, T: Component> QueryData for Ref<'__w, T> {
     const IS_READ_ONLY: bool = true;
     const IS_ARCHETYPAL: bool = true;
@@ -1939,7 +1939,7 @@ unsafe impl<'__w, T: Component> QueryData for Ref<'__w, T> {
     }
 }
 
-/// SAFETY: access is read only
+// SAFETY: access is read only
 unsafe impl<'__w, T: Component> ReadOnlyQueryData for Ref<'__w, T> {}
 
 impl<T: Component> ReleaseStateQueryData for Ref<'_, T> {
@@ -1977,11 +1977,11 @@ impl<T: Component> Clone for WriteFetch<'_, T> {
 
 impl<T: Component> Copy for WriteFetch<'_, T> {}
 
-/// SAFETY:
-/// `fetch` accesses a single component mutably.
-/// This is sound because `update_component_access` adds write access for that component and panic when appropriate.
-/// `update_component_access` adds a `With` filter for a component.
-/// This is sound because `matches_component_set` returns whether the set contains that component.
+// SAFETY:
+// `fetch` accesses a single component mutably.
+// This is sound because `update_component_access` adds write access for that component and panic when appropriate.
+// `update_component_access` adds a `With` filter for a component.
+// This is sound because `matches_component_set` returns whether the set contains that component.
 unsafe impl<'__w, T: Component> WorldQuery for &'__w mut T {
     type Fetch<'w> = WriteFetch<'w, T>;
     type State = ComponentId;
@@ -2083,7 +2083,7 @@ unsafe impl<'__w, T: Component> WorldQuery for &'__w mut T {
     }
 }
 
-/// SAFETY: access of `&T` is a subset of `&mut T`
+// SAFETY: access of `&T` is a subset of `&mut T`
 unsafe impl<'__w, T: Component<Mutability = Mutable>> QueryData for &'__w mut T {
     const IS_READ_ONLY: bool = false;
     const IS_ARCHETYPAL: bool = true;
@@ -2167,12 +2167,12 @@ impl<T: Component<Mutability = Mutable>> ArchetypeQueryData for &mut T {}
 /// When `Mut<T>` is used in a query, it will be converted to `Ref<T>` when transformed into its read-only form, providing access to change detection methods.
 ///
 /// By contrast `&mut T` will result in a `Mut<T>` item in mutable form to record mutations, but result in a bare `&T` in read-only form.
-///
-/// SAFETY:
-/// `fetch` accesses a single component mutably.
-/// This is sound because `update_component_access` adds write access for that component and panic when appropriate.
-/// `update_component_access` adds a `With` filter for a component.
-/// This is sound because `matches_component_set` returns whether the set contains that component.
+//
+// SAFETY:
+// `fetch` accesses a single component mutably.
+// This is sound because `update_component_access` adds write access for that component and panic when appropriate.
+// `update_component_access` adds a `With` filter for a component.
+// This is sound because `matches_component_set` returns whether the set contains that component.
 unsafe impl<'__w, T: Component> WorldQuery for Mut<'__w, T> {
     type Fetch<'w> = WriteFetch<'w, T>;
     type State = ComponentId;
@@ -2298,10 +2298,10 @@ impl<T: WorldQuery> Clone for OptionFetch<'_, T> {
     }
 }
 
-/// SAFETY:
-/// `fetch` might access any components that `T` accesses.
-/// This is sound because `update_component_access` adds the same accesses as `T`.
-/// Filters are unchanged.
+// SAFETY:
+// `fetch` might access any components that `T` accesses.
+// This is sound because `update_component_access` adds the same accesses as `T`.
+// Filters are unchanged.
 unsafe impl<T: WorldQuery> WorldQuery for Option<T> {
     type Fetch<'w> = OptionFetch<'w, T>;
     type State = T::State;
@@ -2427,7 +2427,7 @@ unsafe impl<T: QueryData> QueryData for Option<T> {
     }
 }
 
-/// SAFETY: [`OptionFetch`] is read only because `T` is read only
+// SAFETY: [`OptionFetch`] is read only because `T` is read only
 unsafe impl<T: ReadOnlyQueryData> ReadOnlyQueryData for Option<T> {}
 
 impl<T: ReleaseStateQueryData> ReleaseStateQueryData for Option<T> {
@@ -2511,9 +2511,9 @@ impl<T> core::fmt::Debug for Has<T> {
     }
 }
 
-/// SAFETY:
-/// `update_component_access` does nothing.
-/// This is sound because `fetch` does not access components.
+// SAFETY:
+// `update_component_access` does nothing.
+// This is sound because `fetch` does not access components.
 unsafe impl<T: Component> WorldQuery for Has<T> {
     type Fetch<'w> = bool;
     type State = ComponentId;
@@ -2579,7 +2579,7 @@ unsafe impl<T: Component> WorldQuery for Has<T> {
     }
 }
 
-/// SAFETY: `Self` is the same as `Self::ReadOnly`
+// SAFETY: `Self` is the same as `Self::ReadOnly`
 unsafe impl<T: Component> QueryData for Has<T> {
     const IS_READ_ONLY: bool = true;
     const IS_ARCHETYPAL: bool = true;
@@ -2607,7 +2607,7 @@ unsafe impl<T: Component> QueryData for Has<T> {
     }
 }
 
-/// SAFETY: [`Has`] is read only
+// SAFETY: [`Has`] is read only
 unsafe impl<T: Component> ReadOnlyQueryData for Has<T> {}
 
 impl<T: Component> ReleaseStateQueryData for Has<T> {
@@ -2688,7 +2688,7 @@ macro_rules! impl_tuple_query_data {
         }
 
         $(#[$meta])*
-        /// SAFETY: each item in the tuple is read only
+        // SAFETY: each item in the tuple is read only
         unsafe impl<$($name: ReadOnlyQueryData),*> ReadOnlyQueryData for ($($name,)*) {}
 
         #[expect(
@@ -2730,11 +2730,11 @@ macro_rules! impl_anytuple_fetch {
             clippy::unused_unit,
             reason = "Zero-length tuples will generate some function bodies equivalent to `()`; however, this macro is meant for all applicable tuples, and as such it makes no sense to rewrite it just for that case."
         )]
-        /// SAFETY:
-        /// `fetch` accesses are a subset of the subqueries' accesses
-        /// This is sound because `update_component_access` adds accesses according to the implementations of all the subqueries.
-        /// `update_component_access` replaces the filters with a disjunction where every element is a conjunction of the previous filters and the filters of one of the subqueries.
-        /// This is sound because `matches_component_set` returns a disjunction of the results of the subqueries' implementations.
+        // SAFETY:
+        // `fetch` accesses are a subset of the subqueries' accesses
+        // This is sound because `update_component_access` adds accesses according to the implementations of all the subqueries.
+        // `update_component_access` replaces the filters with a disjunction where every element is a conjunction of the previous filters and the filters of one of the subqueries.
+        // This is sound because `matches_component_set` returns a disjunction of the results of the subqueries' implementations.
         unsafe impl<$($name: WorldQuery),*> WorldQuery for AnyOf<($($name,)*)> {
             type Fetch<'w> = ($(($name::Fetch<'w>, bool),)*);
             type State = ($($name::State,)*);
@@ -2890,7 +2890,7 @@ macro_rules! impl_anytuple_fetch {
         }
 
         $(#[$meta])*
-        /// SAFETY: each item in the tuple is read only
+        // SAFETY: each item in the tuple is read only
         unsafe impl<$($name: ReadOnlyQueryData),*> ReadOnlyQueryData for AnyOf<($($name,)*)> {}
 
         #[expect(
@@ -2936,9 +2936,9 @@ all_tuples!(
 /// This will rarely be useful to consumers of `bevy_ecs`.
 pub(crate) struct NopWorldQuery<D: QueryData>(PhantomData<D>);
 
-/// SAFETY:
-/// `update_component_access` does nothing.
-/// This is sound because `fetch` does not access components.
+// SAFETY:
+// `update_component_access` does nothing.
+// This is sound because `fetch` does not access components.
 unsafe impl<D: QueryData> WorldQuery for NopWorldQuery<D> {
     type Fetch<'w> = ();
     type State = D::State;
@@ -2987,7 +2987,7 @@ unsafe impl<D: QueryData> WorldQuery for NopWorldQuery<D> {
     }
 }
 
-/// SAFETY: `Self::ReadOnly` is `Self`
+// SAFETY: `Self::ReadOnly` is `Self`
 unsafe impl<D: QueryData> QueryData for NopWorldQuery<D> {
     const IS_READ_ONLY: bool = true;
     const IS_ARCHETYPAL: bool = true;
@@ -3014,7 +3014,7 @@ unsafe impl<D: QueryData> QueryData for NopWorldQuery<D> {
     }
 }
 
-/// SAFETY: `NopFetch` never accesses any data
+// SAFETY: `NopFetch` never accesses any data
 unsafe impl<D: QueryData> ReadOnlyQueryData for NopWorldQuery<D> {}
 
 impl<D: QueryData> ReleaseStateQueryData for NopWorldQuery<D> {
@@ -3023,9 +3023,9 @@ impl<D: QueryData> ReleaseStateQueryData for NopWorldQuery<D> {
 
 impl<D: QueryData> ArchetypeQueryData for NopWorldQuery<D> {}
 
-/// SAFETY:
-/// `update_component_access` does nothing.
-/// This is sound because `fetch` does not access components.
+// SAFETY:
+// `update_component_access` does nothing.
+// This is sound because `fetch` does not access components.
 unsafe impl<T: ?Sized> WorldQuery for PhantomData<T> {
     type Fetch<'w> = ();
 
@@ -3077,7 +3077,7 @@ unsafe impl<T: ?Sized> WorldQuery for PhantomData<T> {
     }
 }
 
-/// SAFETY: `Self::ReadOnly` is `Self`
+// SAFETY: `Self::ReadOnly` is `Self`
 unsafe impl<T: ?Sized> QueryData for PhantomData<T> {
     const IS_READ_ONLY: bool = true;
     const IS_ARCHETYPAL: bool = true;
@@ -3103,7 +3103,7 @@ unsafe impl<T: ?Sized> QueryData for PhantomData<T> {
     }
 }
 
-/// SAFETY: `PhantomData` never accesses any world data.
+// SAFETY: `PhantomData` never accesses any world data.
 unsafe impl<T: ?Sized> ReadOnlyQueryData for PhantomData<T> {}
 
 impl<T: ?Sized> ReleaseStateQueryData for PhantomData<T> {
@@ -3232,9 +3232,9 @@ mod tests {
     fn derive_release_state() {
         struct NonReleaseQueryData;
 
-        /// SAFETY:
-        /// `update_component_access` do nothing.
-        /// This is sound because `fetch` does not access components.
+        // SAFETY:
+        // `update_component_access` do nothing.
+        // This is sound because `fetch` does not access components.
         unsafe impl WorldQuery for NonReleaseQueryData {
             type Fetch<'w> = ();
             type State = ();
@@ -3287,7 +3287,7 @@ mod tests {
             }
         }
 
-        /// SAFETY: `Self` is the same as `Self::ReadOnly`
+        // SAFETY: `Self` is the same as `Self::ReadOnly`
         unsafe impl QueryData for NonReleaseQueryData {
             type ReadOnly = Self;
             const IS_READ_ONLY: bool = true;
@@ -3315,7 +3315,7 @@ mod tests {
             }
         }
 
-        /// SAFETY: access is read only
+        // SAFETY: access is read only
         unsafe impl ReadOnlyQueryData for NonReleaseQueryData {}
 
         impl ArchetypeQueryData for NonReleaseQueryData {}

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -141,11 +141,11 @@ pub unsafe trait QueryFilter: WorldQuery {
 /// ```
 pub struct With<T>(PhantomData<T>);
 
-/// SAFETY:
-/// `update_component_access` does not add any accesses.
-/// This is sound because [`QueryFilter::filter_fetch`] does not access any components.
-/// `update_component_access` adds a `With` filter for `T`.
-/// This is sound because `matches_component_set` returns whether the set contains the component.
+// SAFETY:
+// `update_component_access` does not add any accesses.
+// This is sound because [`QueryFilter::filter_fetch`] does not access any components.
+// `update_component_access` adds a `With` filter for `T`.
+// This is sound because `matches_component_set` returns whether the set contains the component.
 unsafe impl<T: Component> WorldQuery for With<T> {
     type Fetch<'w> = ();
     type State = ComponentId;
@@ -242,11 +242,11 @@ unsafe impl<T: Component> QueryFilter for With<T> {
 /// ```
 pub struct Without<T>(PhantomData<T>);
 
-/// SAFETY:
-/// `update_component_access` does not add any accesses.
-/// This is sound because [`QueryFilter::filter_fetch`] does not access any components.
-/// `update_component_access` adds a `Without` filter for `T`.
-/// This is sound because `matches_component_set` returns whether the set does not contain the component.
+// SAFETY:
+// `update_component_access` does not add any accesses.
+// This is sound because [`QueryFilter::filter_fetch`] does not access any components.
+// `update_component_access` adds a `Without` filter for `T`.
+// This is sound because `matches_component_set` returns whether the set does not contain the component.
 unsafe impl<T: Component> WorldQuery for Without<T> {
     type Fetch<'w> = ();
     type State = ComponentId;
@@ -383,11 +383,11 @@ macro_rules! impl_or_query_filter {
             clippy::unused_unit,
             reason = "Zero-length tuples will generate some function bodies equivalent to `()`; however, this macro is meant for all applicable tuples, and as such it makes no sense to rewrite it just for that case."
         )]
-        /// SAFETY:
-        /// [`QueryFilter::filter_fetch`] accesses are a subset of the subqueries' accesses
-        /// This is sound because `update_component_access` adds accesses according to the implementations of all the subqueries.
-        /// `update_component_access` replace the filters with a disjunction where every element is a conjunction of the previous filters and the filters of one of the subqueries.
-        /// This is sound because `matches_component_set` returns a disjunction of the results of the subqueries' implementations.
+        // SAFETY:
+        // [`QueryFilter::filter_fetch`] accesses are a subset of the subqueries' accesses
+        // This is sound because `update_component_access` adds accesses according to the implementations of all the subqueries.
+        // `update_component_access` replace the filters with a disjunction where every element is a conjunction of the previous filters and the filters of one of the subqueries.
+        // This is sound because `matches_component_set` returns a disjunction of the results of the subqueries' implementations.
         unsafe impl<$($filter: QueryFilter),*> WorldQuery for Or<($($filter,)*)> {
             type Fetch<'w> = ($(OrFetch<'w, $filter>,)*);
             type State = ($($filter::State,)*);
@@ -589,11 +589,11 @@ all_tuples!(
 /// [`DefaultQueryFilters`]: crate::entity_disabling::DefaultQueryFilters
 pub struct Allow<T>(PhantomData<T>);
 
-/// SAFETY:
-/// `update_component_access` does not add any accesses.
-/// This is sound because [`QueryFilter::filter_fetch`] does not access any components.
-/// `update_component_access` adds an archetypal filter for `T`.
-/// This is sound because it doesn't affect the query
+// SAFETY:
+// `update_component_access` does not add any accesses.
+// This is sound because [`QueryFilter::filter_fetch`] does not access any components.
+// `update_component_access` adds an archetypal filter for `T`.
+// This is sound because it doesn't affect the query
 unsafe impl<T: Component> WorldQuery for Allow<T> {
     type Fetch<'w> = ();
     type State = ComponentId;
@@ -736,11 +736,11 @@ impl<T: Component> Clone for AddedFetch<'_, T> {
     }
 }
 
-/// SAFETY:
-/// [`QueryFilter::filter_fetch`] accesses a single component in a readonly way.
-/// This is sound because `update_component_access` adds read access for that component and panics when appropriate.
-/// `update_component_access` adds a `With` filter for a component.
-/// This is sound because `matches_component_set` returns whether the set contains that component.
+// SAFETY:
+// [`QueryFilter::filter_fetch`] accesses a single component in a readonly way.
+// This is sound because `update_component_access` adds read access for that component and panics when appropriate.
+// `update_component_access` adds a `With` filter for a component.
+// This is sound because `matches_component_set` returns whether the set contains that component.
 unsafe impl<T: Component> WorldQuery for Added<T> {
     type Fetch<'w> = AddedFetch<'w, T>;
     type State = ComponentId;
@@ -963,11 +963,11 @@ impl<T: Component> Clone for ChangedFetch<'_, T> {
     }
 }
 
-/// SAFETY:
-/// `fetch` accesses a single component in a readonly way.
-/// This is sound because `update_component_access` add read access for that component and panics when appropriate.
-/// `update_component_access` adds a `With` filter for a component.
-/// This is sound because `matches_component_set` returns whether the set contains that component.
+// SAFETY:
+// `fetch` accesses a single component in a readonly way.
+// This is sound because `update_component_access` add read access for that component and panics when appropriate.
+// `update_component_access` adds a `With` filter for a component.
+// This is sound because `matches_component_set` returns whether the set contains that component.
 unsafe impl<T: Component> WorldQuery for Changed<T> {
     type Fetch<'w> = ChangedFetch<'w, T>;
     type State = ComponentId;

--- a/crates/bevy_ecs/src/query/mod.rs
+++ b/crates/bevy_ecs/src/query/mod.rs
@@ -824,8 +824,8 @@ mod tests {
     /// `QueryData` that performs read access on R to test that resource access is tracked
     struct ReadsRData;
 
-    /// SAFETY:
-    /// `update_component_access` adds resource read access for `R`.
+    // SAFETY:
+    // `update_component_access` adds resource read access for `R`.
     unsafe impl WorldQuery for ReadsRData {
         type Fetch<'w> = ();
         type State = ComponentId;
@@ -883,7 +883,7 @@ mod tests {
         }
     }
 
-    /// SAFETY: `Self` is the same as `Self::ReadOnly`
+    // SAFETY: `Self` is the same as `Self::ReadOnly`
     unsafe impl QueryData for ReadsRData {
         const IS_READ_ONLY: bool = true;
         const IS_ARCHETYPAL: bool = true;
@@ -914,7 +914,7 @@ mod tests {
         }
     }
 
-    /// SAFETY: access is read only
+    // SAFETY: access is read only
     unsafe impl ReadOnlyQueryData for ReadsRData {}
 
     impl ArchetypeQueryData for ReadsRData {}

--- a/crates/bevy_ecs/src/query/world_query.rs
+++ b/crates/bevy_ecs/src/query/world_query.rs
@@ -153,11 +153,11 @@ macro_rules! impl_tuple_world_query {
             reason = "Zero-length tuples will generate some function bodies equivalent to `()`; however, this macro is meant for all applicable tuples, and as such it makes no sense to rewrite it just for that case."
         )]
         $(#[$meta])*
-        /// SAFETY:
-        /// `fetch` accesses are the conjunction of the subqueries' accesses
-        /// This is sound because `update_component_access` adds accesses according to the implementations of all the subqueries.
-        /// `update_component_access` adds all `With` and `Without` filters from the subqueries.
-        /// This is sound because `matches_component_set` always returns `false` if any the subqueries' implementations return `false`.
+        // SAFETY:
+        // `fetch` accesses are the conjunction of the subqueries' accesses
+        // This is sound because `update_component_access` adds accesses according to the implementations of all the subqueries.
+        // `update_component_access` adds all `With` and `Without` filters from the subqueries.
+        // This is sound because `matches_component_set` always returns `false` if any the subqueries' implementations return `false`.
         unsafe impl<$($name: WorldQuery),*> WorldQuery for ($($name,)*) {
             type Fetch<'w> = ($($name::Fetch<'w>,)*);
             type State = ($($name::State,)*);

--- a/crates/bevy_ecs/src/system/combinator.rs
+++ b/crates/bevy_ecs/src/system/combinator.rs
@@ -277,7 +277,7 @@ where
     }
 }
 
-/// SAFETY: Both systems are read-only, so any system created by combining them will only read from the world.
+// SAFETY: Both systems are read-only, so any system created by combining them will only read from the world.
 unsafe impl<Func, A, B> ReadOnlySystem for CombinatorSystem<Func, A, B>
 where
     Func: Combine<A, B> + 'static,
@@ -479,7 +479,7 @@ where
     }
 }
 
-/// SAFETY: Both systems are read-only, so any system created by piping them will only read from the world.
+// SAFETY: Both systems are read-only, so any system created by piping them will only read from the world.
 unsafe impl<A, B> ReadOnlySystem for PipeSystem<A, B>
 where
     A: ReadOnlySystem,

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -772,7 +772,7 @@ where
     }
 }
 
-/// SAFETY: `F`'s param is [`ReadOnlySystemParam`], so this system will only read from the world.
+// SAFETY: `F`'s param is [`ReadOnlySystemParam`], so this system will only read from the world.
 unsafe impl<Marker, In, Out, F> ReadOnlySystem for FunctionSystem<Marker, In, Out, F>
 where
     Marker: 'static,

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -909,7 +909,7 @@ unsafe impl<'a, T: Resource> SystemParam for ResMut<'a, T> {
     }
 }
 
-/// SAFETY: only reads world
+// SAFETY: only reads world
 unsafe impl<'w> ReadOnlySystemParam for &'w World {}
 
 // SAFETY: `read_all` access is set and conflicts result in a panic
@@ -949,7 +949,7 @@ unsafe impl SystemParam for &'_ World {
     }
 }
 
-/// SAFETY: `DeferredWorld` can read all components and resources but cannot be used to gain any other mutable references.
+// SAFETY: `DeferredWorld` can read all components and resources but cannot be used to gain any other mutable references.
 unsafe impl<'w> SystemParam for DeferredWorld<'w> {
     type State = ();
     type Item<'world, 'state> = DeferredWorld<'world>;

--- a/crates/bevy_render/src/sync_world.rs
+++ b/crates/bevy_render/src/sync_world.rs
@@ -289,8 +289,8 @@ mod render_entities_world_query_impls {
         world::{unsafe_world_cell::UnsafeWorldCell, World},
     };
 
-    /// SAFETY: defers completely to `&RenderEntity` implementation,
-    /// and then only modifies the output safely.
+    // SAFETY: defers completely to `&RenderEntity` implementation,
+    // and then only modifies the output safely.
     unsafe impl WorldQuery for RenderEntity {
         type Fetch<'w> = <&'static RenderEntity as WorldQuery>::Fetch<'w>;
         type State = <&'static RenderEntity as WorldQuery>::State;
@@ -404,8 +404,8 @@ mod render_entities_world_query_impls {
         }
     }
 
-    /// SAFETY: defers completely to `&RenderEntity` implementation,
-    /// and then only modifies the output safely.
+    // SAFETY: defers completely to `&RenderEntity` implementation,
+    // and then only modifies the output safely.
     unsafe impl WorldQuery for MainEntity {
         type Fetch<'w> = <&'static MainEntity as WorldQuery>::Fetch<'w>;
         type State = <&'static MainEntity as WorldQuery>::State;

--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -34,11 +34,11 @@ impl From<taffy::NodeId> for LayoutNode {
 pub(crate) struct UiTree<T>(TaffyTree<T>);
 
 #[expect(unsafe_code, reason = "TaffyTree is safe as long as calc is not used")]
-/// SAFETY: Taffy Tree becomes thread unsafe when you use the calc feature, which we do not implement
+// SAFETY: Taffy Tree becomes thread unsafe when you use the calc feature, which we do not implement
 unsafe impl Send for UiTree<NodeMeasure> {}
 
 #[expect(unsafe_code, reason = "TaffyTree is safe as long as calc is not used")]
-/// SAFETY: Taffy Tree becomes thread unsafe when you use the calc feature, which we do not implement
+// SAFETY: Taffy Tree becomes thread unsafe when you use the calc feature, which we do not implement
 unsafe impl Sync for UiTree<NodeMeasure> {}
 
 impl<T> Deref for UiTree<T> {


### PR DESCRIPTION
# Objective

- Safety comments on implementations of unsafe traits should not be part of the public docs as these are meant to bevy devs explain why implementing the trait is safe.

## Solution

- Make them regular doc comments