### PR TITLE
Fix incorrect `TypeId` retrieval in reflect component clone

### DIFF
--- a/crates/bevy_ecs/src/entity/clone_entities.rs
+++ b/crates/bevy_ecs/src/entity/clone_entities.rs
@@ -243,7 +243,7 @@ impl<'a, 'b> ComponentCloneCtx<'a, 'b> {
             .component_info
             .type_id()
             .expect("Source component must have TypeId");
-        let component_type_id = component.type_id();
+        let component_type_id = (*component).type_id();
         if source_type_id != component_type_id {
             panic!("Passed component TypeId does not match source component TypeId")
         }


### PR DESCRIPTION
# Objective

Fix incorrect `TypeId` retrieval in `ComponentCloneCtx::write_target_component_reflect()`.

When cloning reflected components, the code incorrectly called `.type_id()` on a `Box<dyn Reflect>`, which returns the container's `TypeId` rather than the underlying concrete type's `TypeId`.

For example:

```rust
let boxed: Box<dyn Reflect> = Box::new(String::from("test"));

// Correct: dereferencing gets the concrete type's TypeId
assert_eq!((*boxed).type_id(), TypeId::of::<String>());

// Wrong: calling on Box returns something else
assert_ne!(boxed.type_id(), TypeId::of::<String>());
```

See Rust documentation: <https://doc.rust-lang.org/std/any/index.html#smart-pointers-and-dyn-any>.

## Solution

Dereference the `Box<dyn Reflect>` before calling `.type_id()` to obtain the concrete type's identifier.

Changed from:
```rust
let component_type_id = component.type_id();  // Wrong: returns Box's TypeId
```

To:
```rust
let component_type_id = (*component).type_id();  // Correct: returns concrete type's TypeId
```

## Testing

- `cargo fmt --check`
- `cargo test -p bevy_reflect`
- `cargo test -p bevy_ecs`

## Additional Notes

This pattern is error-prone. A safer long-term solution would be for `Reflect` trait to provide an unambiguous method like `typeid()` or `reflect_type_id()` that clearly indicates it returns the underlying type's identifier, not the trait object's.

---

## Code Change

<details>
<summary>View the specific change</summary>

**File**: `crates/bevy_ecs/src/entity/clone_entities.rs`

```diff
 pub fn write_target_component_reflect(&mut self, component: Box<dyn bevy_reflect::Reflect>) {
     /* ... */
     let source_type_id = self
         .component_info
         .type_id()
         .expect("Source component must have TypeId");
     
-    let component_type_id = component.type_id();
+    let component_type_id = (*component).type_id();
     
     if source_type_id != component_type_id {
         panic!("Passed component TypeId does not match source component TypeId")
     }
     /* ... */
 }
```

</details>

