### PR TITLE
Benchmark remote allocation

### DIFF
--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -715,7 +715,7 @@ impl EntityAllocator {
 
     /// Builds a new remote allocator that hooks into this [`EntityAllocator`].
     /// This is useful when you need to allocate entities without holding a reference to the world (like in async).
-    pub fn build_remote_allocator(&mut self) -> RemoteAllocator {
+    pub fn build_remote_allocator(&self) -> RemoteAllocator {
         RemoteAllocator::new(&self.inner)
     }
 


### PR DESCRIPTION
# Objective

After #18670, we have a `RemoteAllocator`, but we don't have benchmarks for it compared to the non-remote allocator. This PR just adds those benchmarks.

I don't know if we actually want these benchmarks, but it seems reasonable to have, and it took no time to make, so I figured I'd put it out there.

## Solution

Add `entity_allocator_allocate_fresh_remote` and `entity_allocator_allocate_reused_remote` benchmark groups.

## Testing

- CI, benchmarks

---

## Showcase

```txt
entity_allocator_allocate_fresh/10000_entities            1.00     22.8±0.29µs        ? ?/sec
entity_allocator_allocate_fresh/100_entities              1.00    227.9±6.37ns        ? ?/sec
entity_allocator_allocate_fresh/1_entities                1.00      6.2±3.83ns        ? ?/sec
entity_allocator_allocate_fresh_bulk/10000_entities       1.00     19.9±0.25µs        ? ?/sec
entity_allocator_allocate_fresh_bulk/100_entities         1.00    227.5±6.95ns        ? ?/sec
entity_allocator_allocate_fresh_bulk/1_entities           1.00     11.5±4.69ns        ? ?/sec
entity_allocator_allocate_fresh_remote/10000_entities     1.00     19.4±0.32µs        ? ?/sec
entity_allocator_allocate_fresh_remote/100_entities       1.00    174.2±3.63ns        ? ?/sec
entity_allocator_allocate_fresh_remote/1_entities         1.00      3.5±3.02ns        ? ?/sec
entity_allocator_allocate_reused/10000_entities           1.00     21.5±0.37µs        ? ?/sec
entity_allocator_allocate_reused/100_entities             1.00   233.3±11.77ns        ? ?/sec
entity_allocator_allocate_reused/1_entities               1.00      8.3±3.70ns        ? ?/sec
entity_allocator_allocate_reused_bulk/10000_entities      1.00     20.4±0.64µs        ? ?/sec
entity_allocator_allocate_reused_bulk/100_entities        1.00   261.5±45.59ns        ? ?/sec
entity_allocator_allocate_reused_bulk/1_entities          1.00    19.7±10.77ns        ? ?/sec
entity_allocator_allocate_reused_remote/10000_entities    1.00     77.9±1.53µs        ? ?/sec
entity_allocator_allocate_reused_remote/100_entities      1.00   774.9±16.28ns        ? ?/sec
entity_allocator_allocate_reused_remote/1_entities        1.00      7.3±3.60ns        ? ?/sec
```

Long story short, remote allocation is a little over 3 times slower than non-remote. All things considered, I think that's pretty good.
