### PR TITLE
Rename "labeled asset" to "subasset".

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -820,7 +820,7 @@ mod tests {
                 sub_texts: ron
                     .sub_texts
                     .drain(..)
-                    .map(|text| load_context.add_labeled_asset(text.clone(), SubText { text }))
+                    .map(|text| load_context.add_subasset(text.clone(), SubText { text }))
                     .collect(),
             })
         }
@@ -2574,8 +2574,8 @@ mod tests {
                 _settings: &Self::Settings,
                 load_context: &mut LoadContext<'_>,
             ) -> Result<Self::Asset, Self::Error> {
-                load_context.add_labeled_asset("A".into(), TestAsset);
-                load_context.add_labeled_asset("B".into(), TestAsset);
+                load_context.add_subasset("A".into(), TestAsset);
+                load_context.add_subasset("B".into(), TestAsset);
                 Ok(TestAsset)
             }
 
@@ -2852,7 +2852,7 @@ mod tests {
                 // Load the asset in the root context, but then put the handle in the subasset. So
                 // the subasset's (internal) load context never loaded `dep`.
                 let dep = load_context.load::<TestAsset>("abc.ron");
-                load_context.add_labeled_asset("subasset".into(), AssetWithDep { dep });
+                load_context.add_subasset("subasset".into(), AssetWithDep { dep });
                 Ok(TestAsset)
             }
 

--- a/crates/bevy_asset/src/loader_builders.rs
+++ b/crates/bevy_asset/src/loader_builders.rs
@@ -399,7 +399,7 @@ impl<'builder, 'reader, T> NestedLoader<'_, '_, T, Immediate<'builder, 'reader>>
         path: &AssetPath<'static>,
         asset_type_id: Option<TypeId>,
     ) -> Result<(Arc<dyn ErasedAssetLoader>, ErasedLoadedAsset), LoadDirectError> {
-        if path.label().is_some() {
+        if path.subasset_name().is_some() {
             return Err(LoadDirectError::RequestedSubasset(path.clone()));
         }
         self.load_context

--- a/crates/bevy_asset/src/processor/tests.rs
+++ b/crates/bevy_asset/src/processor/tests.rs
@@ -444,8 +444,14 @@ impl AssetSaver for CoolTextSaver {
         let ron = CoolTextRon {
             text: asset.text.clone(),
             sub_texts: asset
-                .iter_labels()
-                .map(|label| asset.get_labeled::<SubText, _>(label).unwrap().text.clone())
+                .iter_subasset_names()
+                .map(|subasset_name| {
+                    asset
+                        .get_subasset::<SubText, _>(subasset_name)
+                        .unwrap()
+                        .text
+                        .clone()
+                })
                 .collect(),
             dependencies: asset
                 .dependencies

--- a/crates/bevy_asset/src/server/loaders.rs
+++ b/crates/bevy_asset/src/server/loaders.rs
@@ -164,12 +164,12 @@ impl AssetLoaders {
             return self.get_by_name(type_name);
         }
 
-        // The presence of a label will affect loader choice
-        let label = asset_path.as_ref().and_then(|path| path.label());
+        // The presence of a subasset name will affect loader choice
+        let subasset_name = asset_path.as_ref().and_then(|path| path.subasset_name());
 
         // Try by asset type
         let candidates = if let Some(type_id) = asset_type_id {
-            if label.is_none() {
+            if subasset_name.is_none() {
                 Some(self.type_id_to_loaders.get(&type_id)?)
             } else {
                 None

--- a/crates/bevy_gltf/src/assets.rs
+++ b/crates/bevy_gltf/src/assets.rs
@@ -12,7 +12,7 @@ use bevy_platform::collections::HashMap;
 use bevy_reflect::{prelude::ReflectDefault, Reflect, TypePath};
 use bevy_scene::Scene;
 
-use crate::GltfAssetLabel;
+use crate::GltfSubassetName;
 
 /// Representation of a loaded glTF file.
 #[derive(Asset, Debug, TypePath)]
@@ -84,9 +84,9 @@ impl GltfMesh {
         }
     }
 
-    /// Subasset label for this mesh within the gLTF parent asset.
-    pub fn asset_label(&self) -> GltfAssetLabel {
-        GltfAssetLabel::Mesh(self.index)
+    /// Subasset name for this mesh within the gLTF parent asset.
+    pub fn subasset_name(&self) -> GltfSubassetName {
+        GltfSubassetName::Mesh(self.index)
     }
 }
 
@@ -152,9 +152,9 @@ impl GltfNode {
         }
     }
 
-    /// Subasset label for this node within the gLTF parent asset.
-    pub fn asset_label(&self) -> GltfAssetLabel {
-        GltfAssetLabel::Node(self.index)
+    /// Subasset name for this node within the gLTF parent asset.
+    pub fn subasset_name(&self) -> GltfSubassetName {
+        GltfSubassetName::Node(self.index)
     }
 }
 
@@ -207,9 +207,9 @@ impl GltfPrimitive {
         }
     }
 
-    /// Subasset label for this primitive within its parent [`GltfMesh`] within the gLTF parent asset.
-    pub fn asset_label(&self) -> GltfAssetLabel {
-        GltfAssetLabel::Primitive {
+    /// Subasset name for this primitive within its parent [`GltfMesh`] within the gLTF parent asset.
+    pub fn subasset_name(&self) -> GltfSubassetName {
+        GltfSubassetName::Primitive {
             mesh: self.parent_mesh_index,
             primitive: self.index,
         }
@@ -255,9 +255,9 @@ impl GltfSkin {
         }
     }
 
-    /// Subasset label for this skin within the gLTF parent asset.
-    pub fn asset_label(&self) -> GltfAssetLabel {
-        GltfAssetLabel::Skin(self.index)
+    /// Subasset name for this skin within the gLTF parent asset.
+    pub fn subasset_name(&self) -> GltfSubassetName {
+        GltfSubassetName::Skin(self.index)
     }
 }
 

--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -24,9 +24,9 @@
 //! fn spawn_gltf(mut commands: Commands, asset_server: Res<AssetServer>) {
 //!     commands.spawn((
 //!         // This is equivalent to "models/FlightHelmet/FlightHelmet.gltf#Scene0"
-//!         // The `#Scene0` label here is very important because it tells bevy to load the first scene in the glTF file.
+//!         // The `#Scene0` subasset name here is very important because it tells bevy to load the first scene in the glTF file.
 //!         // If this isn't specified bevy doesn't know which part of the glTF file to load.
-//!         SceneRoot(asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"))),
+//!         SceneRoot(asset_server.load(GltfSubassetName::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"))),
 //!         // You can use the transform to give it a position
 //!         Transform::from_xyz(2.0, 0.0, -5.0),
 //!     ));
@@ -82,13 +82,13 @@
 //! }
 //! ```
 //!
-//! ## Asset Labels
+//! ## Subasset names
 //!
-//! The glTF loader let's you specify labels that let you target specific parts of the glTF.
+//! The glTF loader let's you specify subasset names that let you target specific parts of the glTF.
 //!
-//! Be careful when using this feature, if you misspell a label it will simply ignore it without warning.
+//! Be careful when using this feature, if you misspell a subasset name it will simply ignore it without warning.
 //!
-//! You can use [`GltfAssetLabel`] to ensure you are using the correct label.
+//! You can use [`GltfSubassetName`] to ensure you are using the correct subasset name.
 //!
 //! # Supported KHR Extensions
 //!
@@ -129,8 +129,8 @@
 
 mod assets;
 pub mod convert_coordinates;
-mod label;
 mod loader;
+mod subasset_name;
 mod vertex_attributes;
 
 extern crate alloc;
@@ -152,12 +152,12 @@ use bevy_mesh::MeshVertexAttribute;
 /// This includes the most common types in this crate, re-exported for your convenience.
 pub mod prelude {
     #[doc(hidden)]
-    pub use crate::{assets::Gltf, assets::GltfExtras, label::GltfAssetLabel};
+    pub use crate::{assets::Gltf, assets::GltfExtras, subasset_name::GltfSubassetName};
 }
 
 use crate::{convert_coordinates::GltfConvertCoordinates, extensions::GltfExtensionHandlers};
 
-pub use {assets::*, label::GltfAssetLabel, loader::*};
+pub use {assets::*, loader::*, subasset_name::GltfSubassetName};
 
 // Has to store an Arc<Mutex<...>> as there is no other way to mutate fields of asset loaders.
 /// Stores default [`ImageSamplerDescriptor`] in main world.

--- a/crates/bevy_gltf/src/loader/gltf_ext/material.rs
+++ b/crates/bevy_gltf/src/loader/gltf_ext/material.rs
@@ -6,7 +6,7 @@ use gltf::{json::texture::Info, Material};
 
 use serde_json::value;
 
-use crate::GltfAssetLabel;
+use crate::GltfSubassetName;
 
 use super::texture::texture_transform_to_affine2;
 
@@ -161,13 +161,16 @@ pub(crate) fn warn_on_differing_texture_transforms(
     }
 }
 
-pub(crate) fn material_label(material: &Material, is_scale_inverted: bool) -> GltfAssetLabel {
+pub(crate) fn material_subasset_name(
+    material: &Material,
+    is_scale_inverted: bool,
+) -> GltfSubassetName {
     if let Some(index) = material.index() {
-        GltfAssetLabel::Material {
+        GltfSubassetName::Material {
             index,
             is_scale_inverted,
         }
     } else {
-        GltfAssetLabel::DefaultMaterial
+        GltfSubassetName::DefaultMaterial
     }
 }

--- a/crates/bevy_gltf/src/subasset_name.rs
+++ b/crates/bevy_gltf/src/subasset_name.rs
@@ -1,10 +1,10 @@
-//! Labels that can be used to load part of a glTF
+//! Subasset names that can be used to load part of a glTF
 
 use bevy_asset::AssetPath;
 
-/// Labels that can be used to load part of a glTF
+/// Subasset names that can be used to load part of a glTF
 ///
-/// You can use [`GltfAssetLabel::from_asset`] to add it to an asset path
+/// You can use [`GltfSubassetName::from_asset`] to add it to an asset path
 ///
 /// ```
 /// # use bevy_ecs::prelude::*;
@@ -13,7 +13,7 @@ use bevy_asset::AssetPath;
 /// # use bevy_gltf::prelude::*;
 ///
 /// fn load_gltf_scene(asset_server: Res<AssetServer>) {
-///     let gltf_scene: Handle<Scene> = asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"));
+///     let gltf_scene: Handle<Scene> = asset_server.load(GltfSubassetName::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"));
 /// }
 /// ```
 ///
@@ -26,11 +26,11 @@ use bevy_asset::AssetPath;
 /// # use bevy_gltf::prelude::*;
 ///
 /// fn load_gltf_scene(asset_server: Res<AssetServer>) {
-///     let gltf_scene: Handle<Scene> = asset_server.load(format!("models/FlightHelmet/FlightHelmet.gltf#{}", GltfAssetLabel::Scene(0)));
+///     let gltf_scene: Handle<Scene> = asset_server.load(format!("models/FlightHelmet/FlightHelmet.gltf#{}", GltfSubassetName::Scene(0)));
 /// }
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum GltfAssetLabel {
+pub enum GltfSubassetName {
     /// `Scene{}`: glTF Scene as a Bevy [`Scene`](bevy_scene::Scene)
     Scene(usize),
     /// `Node{}`: glTF Node as a [`GltfNode`](crate::GltfNode)
@@ -74,20 +74,20 @@ pub enum GltfAssetLabel {
     InverseBindMatrices(usize),
 }
 
-impl core::fmt::Display for GltfAssetLabel {
+impl core::fmt::Display for GltfSubassetName {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            GltfAssetLabel::Scene(index) => f.write_str(&format!("Scene{index}")),
-            GltfAssetLabel::Node(index) => f.write_str(&format!("Node{index}")),
-            GltfAssetLabel::Mesh(index) => f.write_str(&format!("Mesh{index}")),
-            GltfAssetLabel::Primitive { mesh, primitive } => {
+            GltfSubassetName::Scene(index) => f.write_str(&format!("Scene{index}")),
+            GltfSubassetName::Node(index) => f.write_str(&format!("Node{index}")),
+            GltfSubassetName::Mesh(index) => f.write_str(&format!("Mesh{index}")),
+            GltfSubassetName::Primitive { mesh, primitive } => {
                 f.write_str(&format!("Mesh{mesh}/Primitive{primitive}"))
             }
-            GltfAssetLabel::MorphTarget { mesh, primitive } => {
+            GltfSubassetName::MorphTarget { mesh, primitive } => {
                 f.write_str(&format!("Mesh{mesh}/Primitive{primitive}/MorphTargets"))
             }
-            GltfAssetLabel::Texture(index) => f.write_str(&format!("Texture{index}")),
-            GltfAssetLabel::Material {
+            GltfSubassetName::Texture(index) => f.write_str(&format!("Texture{index}")),
+            GltfSubassetName::Material {
                 index,
                 is_scale_inverted,
             } => f.write_str(&format!(
@@ -98,18 +98,18 @@ impl core::fmt::Display for GltfAssetLabel {
                     ""
                 }
             )),
-            GltfAssetLabel::DefaultMaterial => f.write_str("DefaultMaterial"),
-            GltfAssetLabel::Animation(index) => f.write_str(&format!("Animation{index}")),
-            GltfAssetLabel::Skin(index) => f.write_str(&format!("Skin{index}")),
-            GltfAssetLabel::InverseBindMatrices(index) => {
+            GltfSubassetName::DefaultMaterial => f.write_str("DefaultMaterial"),
+            GltfSubassetName::Animation(index) => f.write_str(&format!("Animation{index}")),
+            GltfSubassetName::Skin(index) => f.write_str(&format!("Skin{index}")),
+            GltfSubassetName::InverseBindMatrices(index) => {
                 f.write_str(&format!("Skin{index}/InverseBindMatrices"))
             }
         }
     }
 }
 
-impl GltfAssetLabel {
-    /// Add this label to an asset path
+impl GltfSubassetName {
+    /// Add this subasset name to an asset path.
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
@@ -118,10 +118,10 @@ impl GltfAssetLabel {
     /// # use bevy_gltf::prelude::*;
     ///
     /// fn load_gltf_scene(asset_server: Res<AssetServer>) {
-    ///     let gltf_scene: Handle<Scene> = asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"));
+    ///     let gltf_scene: Handle<Scene> = asset_server.load(GltfSubassetName::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"));
     /// }
     /// ```
     pub fn from_asset(&self, path: impl Into<AssetPath<'static>>) -> AssetPath<'static> {
-        path.into().with_label(self.to_string())
+        path.into().with_subasset_name(self.to_string())
     }
 }

--- a/examples/3d/anti_aliasing.rs
+++ b/examples/3d/anti_aliasing.rs
@@ -438,7 +438,7 @@ fn setup(
 
     // Flight Helmet
     commands.spawn(SceneRoot(asset_server.load(
-        GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"),
+        GltfSubassetName::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"),
     )));
 
     // Light

--- a/examples/3d/atmosphere.rs
+++ b/examples/3d/atmosphere.rs
@@ -236,7 +236,7 @@ fn setup_terrain_scene(
     commands.spawn((
         Terrain,
         SceneRoot(
-            asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/terrain/terrain.glb")),
+            asset_server.load(GltfSubassetName::Scene(0).from_asset("models/terrain/terrain.glb")),
         ),
         Transform::from_xyz(-1.0, 0.0, -0.5)
             .with_scale(Vec3::splat(0.5))

--- a/examples/3d/atmospheric_fog.rs
+++ b/examples/3d/atmospheric_fog.rs
@@ -67,7 +67,7 @@ fn setup_terrain_scene(
 
     // Terrain
     commands.spawn(SceneRoot(asset_server.load(
-        GltfAssetLabel::Scene(0).from_asset("models/terrain/Mountains.gltf"),
+        GltfSubassetName::Scene(0).from_asset("models/terrain/Mountains.gltf"),
     )));
 
     // Sky

--- a/examples/3d/clearcoat.rs
+++ b/examples/3d/clearcoat.rs
@@ -147,7 +147,8 @@ fn spawn_coated_glass_bubble_sphere(
 fn spawn_golf_ball(commands: &mut Commands, asset_server: &AssetServer) {
     commands.spawn((
         SceneRoot(
-            asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/GolfBall/GolfBall.glb")),
+            asset_server
+                .load(GltfSubassetName::Scene(0).from_asset("models/GolfBall/GolfBall.glb")),
         ),
         Transform::from_xyz(1.0, 1.0, 0.0).with_scale(Vec3::splat(SPHERE_SCALE)),
         ExampleSphere,

--- a/examples/3d/color_grading.rs
+++ b/examples/3d/color_grading.rs
@@ -344,14 +344,15 @@ fn add_camera(commands: &mut Commands, asset_server: &AssetServer, color_grading
 fn add_basic_scene(commands: &mut Commands, asset_server: &AssetServer) {
     // Spawn the main scene.
     commands.spawn(SceneRoot(asset_server.load(
-        GltfAssetLabel::Scene(0).from_asset("models/TonemappingTest/TonemappingTest.gltf"),
+        GltfSubassetName::Scene(0).from_asset("models/TonemappingTest/TonemappingTest.gltf"),
     )));
 
     // Spawn the flight helmet.
     commands.spawn((
         SceneRoot(
-            asset_server
-                .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf")),
+            asset_server.load(
+                GltfSubassetName::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"),
+            ),
         ),
         Transform::from_xyz(0.5, 0.0, -0.5).with_rotation(Quat::from_rotation_y(-0.15 * PI)),
     ));

--- a/examples/3d/contact_shadows.rs
+++ b/examples/3d/contact_shadows.rs
@@ -183,7 +183,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands
         .spawn((
             SceneRoot(asset_server.load(
-                GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"),
+                GltfSubassetName::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"),
             )),
             Transform::from_rotation(Quat::from_rotation_y(std::f32::consts::PI)),
         ))

--- a/examples/3d/deferred_rendering.rs
+++ b/examples/3d/deferred_rendering.rs
@@ -74,7 +74,7 @@ fn setup(
 
     // FlightHelmet
     let helmet_scene = asset_server
-        .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"));
+        .load(GltfSubassetName::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"));
 
     commands.spawn(SceneRoot(helmet_scene.clone()));
     commands.spawn((

--- a/examples/3d/depth_of_field.rs
+++ b/examples/3d/depth_of_field.rs
@@ -85,7 +85,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, app_settings: R
 
     // Spawn the scene.
     commands.spawn(SceneRoot(asset_server.load(
-        GltfAssetLabel::Scene(0).from_asset("models/DepthOfFieldExample/DepthOfFieldExample.glb"),
+        GltfSubassetName::Scene(0).from_asset("models/DepthOfFieldExample/DepthOfFieldExample.glb"),
     )));
 
     // Spawn the help text.

--- a/examples/3d/irradiance_volumes.rs
+++ b/examples/3d/irradiance_volumes.rs
@@ -484,16 +484,16 @@ fn handle_mouse_clicks(
 impl FromWorld for ExampleAssets {
     fn from_world(world: &mut World) -> Self {
         let fox_animation =
-            world.load_asset(GltfAssetLabel::Animation(1).from_asset("models/animated/Fox.glb"));
+            world.load_asset(GltfSubassetName::Animation(1).from_asset("models/animated/Fox.glb"));
         let (fox_animation_graph, fox_animation_node) =
             AnimationGraph::from_clip(fox_animation.clone());
 
         ExampleAssets {
             main_sphere: world.add_asset(Sphere::default().mesh().uv(32, 18)),
-            fox: world.load_asset(GltfAssetLabel::Scene(0).from_asset("models/animated/Fox.glb")),
+            fox: world.load_asset(GltfSubassetName::Scene(0).from_asset("models/animated/Fox.glb")),
             main_sphere_material: world.add_asset(Color::from(SILVER)),
             main_scene: world.load_asset(
-                GltfAssetLabel::Scene(0)
+                GltfSubassetName::Scene(0)
                     .from_asset("models/IrradianceVolumeExample/IrradianceVolumeExample.glb"),
             ),
             irradiance_volume: world.load_asset("irradiance_volumes/Example.vxgi.ktx2"),

--- a/examples/3d/light_textures.rs
+++ b/examples/3d/light_textures.rs
@@ -254,7 +254,7 @@ fn spawn_light_textures(
         Selection::PointLight,
         children![
             SceneRoot(
-                asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/Faces/faces.glb")),
+                asset_server.load(GltfSubassetName::Scene(0).from_asset("models/Faces/faces.glb")),
             ),
             (
                 Mesh3d(meshes.add(Sphere::new(1.0))),

--- a/examples/3d/lightmaps.rs
+++ b/examples/3d/lightmaps.rs
@@ -41,7 +41,7 @@ fn main() {
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>, args: Res<Args>) {
     commands.spawn(SceneRoot(asset_server.load(
-        GltfAssetLabel::Scene(0).from_asset("models/CornellBox/CornellBox.glb"),
+        GltfSubassetName::Scene(0).from_asset("models/CornellBox/CornellBox.glb"),
     )));
 
     let mut camera = commands.spawn((

--- a/examples/3d/mirror.rs
+++ b/examples/3d/mirror.rs
@@ -282,7 +282,7 @@ fn spawn_mirror_camera(
 /// [`play_fox_animation`].
 fn spawn_fox(commands: &mut Commands, asset_server: &AssetServer) {
     commands.spawn((
-        SceneRoot(asset_server.load(GltfAssetLabel::Scene(0).from_asset(FOX_ASSET_PATH))),
+        SceneRoot(asset_server.load(GltfSubassetName::Scene(0).from_asset(FOX_ASSET_PATH))),
         Transform::from_xyz(-50.0, 0.0, -100.0),
     ));
 }
@@ -630,7 +630,8 @@ fn play_fox_animation(
         return;
     }
 
-    let fox_animation = asset_server.load(GltfAssetLabel::Animation(0).from_asset(FOX_ASSET_PATH));
+    let fox_animation =
+        asset_server.load(GltfSubassetName::Animation(0).from_asset(FOX_ASSET_PATH));
     let (fox_animation_graph, fox_animation_node) =
         AnimationGraph::from_clip(fox_animation.clone());
     let fox_animation_graph = animation_graphs.add(fox_animation_graph);

--- a/examples/3d/mixed_lighting.rs
+++ b/examples/3d/mixed_lighting.rs
@@ -167,7 +167,7 @@ fn spawn_scene(commands: &mut Commands, asset_server: &AssetServer) {
     commands
         .spawn(SceneRoot(
             asset_server.load(
-                GltfAssetLabel::Scene(0)
+                GltfSubassetName::Scene(0)
                     .from_asset("models/MixedLightingExample/MixedLightingExample.gltf"),
             ),
         ))

--- a/examples/3d/post_processing.rs
+++ b/examples/3d/post_processing.rs
@@ -102,14 +102,15 @@ fn spawn_camera(commands: &mut Commands, asset_server: &AssetServer) {
 fn spawn_scene(commands: &mut Commands, asset_server: &AssetServer) {
     // Spawn the main scene.
     commands.spawn(SceneRoot(asset_server.load(
-        GltfAssetLabel::Scene(0).from_asset("models/TonemappingTest/TonemappingTest.gltf"),
+        GltfSubassetName::Scene(0).from_asset("models/TonemappingTest/TonemappingTest.gltf"),
     )));
 
     // Spawn the flight helmet.
     commands.spawn((
         SceneRoot(
-            asset_server
-                .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf")),
+            asset_server.load(
+                GltfSubassetName::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"),
+            ),
         ),
         Transform::from_xyz(0.5, 0.0, -0.5).with_rotation(Quat::from_rotation_y(-0.15 * PI)),
     ));

--- a/examples/3d/reflection_probes.rs
+++ b/examples/3d/reflection_probes.rs
@@ -111,7 +111,9 @@ fn setup(
 // Spawns the cubes, light, and camera.
 fn spawn_scene(commands: &mut Commands, asset_server: &AssetServer) {
     commands.spawn((
-        SceneRoot(asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/cubes/Cubes.glb"))),
+        SceneRoot(
+            asset_server.load(GltfSubassetName::Scene(0).from_asset("models/cubes/Cubes.glb")),
+        ),
         CubesScene,
     ));
 }

--- a/examples/3d/solari.rs
+++ b/examples/3d/solari.rs
@@ -86,7 +86,7 @@ fn setup_pica_pica(
         .spawn((
             SceneRoot(
                 asset_server.load(
-                    GltfAssetLabel::Scene(0)
+                    GltfSubassetName::Scene(0)
                         .from_asset("https://github.com/bevyengine/bevy_asset_files/raw/2a5950295a8b6d9d051d59c0df69e87abcda58c3/pica_pica/mini_diorama_01.glb")
                 ),
             ),
@@ -97,7 +97,7 @@ fn setup_pica_pica(
     commands
         .spawn((
             SceneRoot(asset_server.load(
-                GltfAssetLabel::Scene(0).from_asset("https://github.com/bevyengine/bevy_asset_files/raw/2a5950295a8b6d9d051d59c0df69e87abcda58c3/pica_pica/robot_01.glb")
+                GltfSubassetName::Scene(0).from_asset("https://github.com/bevyengine/bevy_asset_files/raw/2a5950295a8b6d9d051d59c0df69e87abcda58c3/pica_pica/robot_01.glb")
             )),
             Transform::from_scale(Vec3::splat(2.0))
                 .with_translation(Vec3::new(-2.0, 0.05, -2.1))

--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -27,9 +27,9 @@ fn setup(
         MeshMaterial3d(materials.add(Color::srgb(0.3, 0.5, 0.3))),
     ));
 
-    commands.spawn(SceneRoot(
-        asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/animated/Fox.glb")),
-    ));
+    commands.spawn(SceneRoot(asset_server.load(
+        GltfSubassetName::Scene(0).from_asset("models/animated/Fox.glb"),
+    )));
 
     // Light
     commands.spawn((

--- a/examples/3d/ssr.rs
+++ b/examples/3d/ssr.rs
@@ -280,8 +280,9 @@ fn spawn_cube(
 fn spawn_flight_helmet(commands: &mut Commands, asset_server: &AssetServer) {
     commands.spawn((
         SceneRoot(
-            asset_server
-                .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf")),
+            asset_server.load(
+                GltfSubassetName::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"),
+            ),
         ),
         Transform::from_scale(Vec3::splat(2.5)),
         FlightHelmetModel,

--- a/examples/3d/tonemapping.rs
+++ b/examples/3d/tonemapping.rs
@@ -100,7 +100,7 @@ fn setup_basic_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Main scene
     commands.spawn((
         SceneRoot(asset_server.load(
-            GltfAssetLabel::Scene(0).from_asset("models/TonemappingTest/TonemappingTest.gltf"),
+            GltfSubassetName::Scene(0).from_asset("models/TonemappingTest/TonemappingTest.gltf"),
         )),
         SceneNumber(1),
     ));
@@ -108,8 +108,9 @@ fn setup_basic_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Flight Helmet
     commands.spawn((
         SceneRoot(
-            asset_server
-                .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf")),
+            asset_server.load(
+                GltfSubassetName::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"),
+            ),
         ),
         Transform::from_xyz(0.5, 0.0, -0.5).with_rotation(Quat::from_rotation_y(-0.15 * PI)),
         SceneNumber(1),

--- a/examples/3d/visibility_range.rs
+++ b/examples/3d/visibility_range.rs
@@ -111,8 +111,9 @@ fn setup(
 
     commands.spawn((
         SceneRoot(
-            asset_server
-                .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf")),
+            asset_server.load(
+                GltfSubassetName::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"),
+            ),
         ),
         MainModel::HighPoly,
     ));
@@ -120,7 +121,7 @@ fn setup(
     commands.spawn((
         SceneRoot(
             asset_server.load(
-                GltfAssetLabel::Scene(0)
+                GltfSubassetName::Scene(0)
                     .from_asset("models/FlightHelmetLowPoly/FlightHelmetLowPoly.gltf"),
             ),
         ),

--- a/examples/3d/volumetric_fog.rs
+++ b/examples/3d/volumetric_fog.rs
@@ -59,9 +59,12 @@ fn main() {
 /// Initializes the scene.
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>, app_settings: Res<AppSettings>) {
     // Spawn the glTF scene.
-    commands.spawn(SceneRoot(asset_server.load(
-        GltfAssetLabel::Scene(0).from_asset("models/VolumetricFogExample/VolumetricFogExample.glb"),
-    )));
+    commands.spawn(SceneRoot(
+        asset_server.load(
+            GltfSubassetName::Scene(0)
+                .from_asset("models/VolumetricFogExample/VolumetricFogExample.glb"),
+        ),
+    ));
 
     // Spawn the camera.
     commands

--- a/examples/animation/animated_mesh.rs
+++ b/examples/animation/animated_mesh.rs
@@ -37,7 +37,7 @@ fn setup_mesh_and_animation(
     // Create an animation graph containing a single animation. We want the "run"
     // animation from our example asset, which has an index of two.
     let (graph, index) = AnimationGraph::from_clip(
-        asset_server.load(GltfAssetLabel::Animation(2).from_asset(GLTF_PATH)),
+        asset_server.load(GltfSubassetName::Animation(2).from_asset(GLTF_PATH)),
     );
 
     // Store the animation graph as an asset.
@@ -52,7 +52,7 @@ fn setup_mesh_and_animation(
     // Start loading the asset as a scene and store a reference to it in a
     // SceneRoot component. This component will automatically spawn a scene
     // containing our mesh once it has loaded.
-    let mesh_scene = SceneRoot(asset_server.load(GltfAssetLabel::Scene(0).from_asset(GLTF_PATH)));
+    let mesh_scene = SceneRoot(asset_server.load(GltfSubassetName::Scene(0).from_asset(GLTF_PATH)));
 
     // Spawn an entity with our components, and connect it to an observer that
     // will trigger when the scene is loaded and spawned.

--- a/examples/animation/animated_mesh_control.rs
+++ b/examples/animation/animated_mesh_control.rs
@@ -35,9 +35,9 @@ fn setup(
 ) {
     // Build the animation graph
     let (graph, node_indices) = AnimationGraph::from_clips([
-        asset_server.load(GltfAssetLabel::Animation(2).from_asset(FOX_PATH)),
-        asset_server.load(GltfAssetLabel::Animation(1).from_asset(FOX_PATH)),
-        asset_server.load(GltfAssetLabel::Animation(0).from_asset(FOX_PATH)),
+        asset_server.load(GltfSubassetName::Animation(2).from_asset(FOX_PATH)),
+        asset_server.load(GltfSubassetName::Animation(1).from_asset(FOX_PATH)),
+        asset_server.load(GltfSubassetName::Animation(0).from_asset(FOX_PATH)),
     ]);
 
     // Keep our animation graph in a Resource so that it can be inserted onto
@@ -77,7 +77,7 @@ fn setup(
 
     // Fox
     commands.spawn(SceneRoot(
-        asset_server.load(GltfAssetLabel::Scene(0).from_asset(FOX_PATH)),
+        asset_server.load(GltfSubassetName::Scene(0).from_asset(FOX_PATH)),
     ));
 
     // Instructions

--- a/examples/animation/animated_mesh_events.rs
+++ b/examples/animation/animated_mesh_events.rs
@@ -87,7 +87,7 @@ fn setup(
     // Build the animation graph
     let (graph, index) = AnimationGraph::from_clip(
         // We specifically want the "run" animation, which is the third one.
-        asset_server.load(GltfAssetLabel::Animation(2).from_asset(FOX_PATH)),
+        asset_server.load(GltfSubassetName::Animation(2).from_asset(FOX_PATH)),
     );
 
     // Insert a resource with the current scene information
@@ -126,7 +126,7 @@ fn setup(
 
     // Fox
     commands.spawn(SceneRoot(
-        asset_server.load(GltfAssetLabel::Scene(0).from_asset(FOX_PATH)),
+        asset_server.load(GltfSubassetName::Scene(0).from_asset(FOX_PATH)),
     ));
 
     // We're seeding the PRNG here to make this example deterministic for testing purposes.

--- a/examples/animation/animation_graph.rs
+++ b/examples/animation/animation_graph.rs
@@ -158,17 +158,17 @@ fn setup_assets_programmatically(
     let mut animation_graph = AnimationGraph::new();
     let blend_node = animation_graph.add_blend(0.5, animation_graph.root);
     animation_graph.add_clip(
-        asset_server.load(GltfAssetLabel::Animation(0).from_asset("models/animated/Fox.glb")),
+        asset_server.load(GltfSubassetName::Animation(0).from_asset("models/animated/Fox.glb")),
         1.0,
         animation_graph.root,
     );
     animation_graph.add_clip(
-        asset_server.load(GltfAssetLabel::Animation(1).from_asset("models/animated/Fox.glb")),
+        asset_server.load(GltfSubassetName::Animation(1).from_asset("models/animated/Fox.glb")),
         1.0,
         blend_node,
     );
     animation_graph.add_clip(
-        asset_server.load(GltfAssetLabel::Animation(2).from_asset("models/animated/Fox.glb")),
+        asset_server.load(GltfSubassetName::Animation(2).from_asset("models/animated/Fox.glb")),
         1.0,
         blend_node,
     );
@@ -240,7 +240,7 @@ fn setup_scene(
 
     commands.spawn((
         SceneRoot(
-            asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/animated/Fox.glb")),
+            asset_server.load(GltfSubassetName::Scene(0).from_asset("models/animated/Fox.glb")),
         ),
         Transform::from_scale(Vec3::splat(0.07)),
     ));

--- a/examples/animation/animation_masks.rs
+++ b/examples/animation/animation_masks.rs
@@ -141,7 +141,7 @@ fn setup_scene(
     // Spawn the fox.
     commands.spawn((
         SceneRoot(
-            asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/animated/Fox.glb")),
+            asset_server.load(GltfSubassetName::Scene(0).from_asset("models/animated/Fox.glb")),
         ),
         Transform::from_scale(Vec3::splat(0.07)),
     ));
@@ -352,7 +352,7 @@ fn setup_animation_graph_once_loaded(
         let animation_graph_nodes: [AnimationNodeIndex; 3] =
             std::array::from_fn(|animation_index| {
                 let handle = asset_server.load(
-                    GltfAssetLabel::Animation(animation_index)
+                    GltfSubassetName::Animation(animation_index)
                         .from_asset("models/animated/Fox.glb"),
                 );
                 let mask = if animation_index == 0 { 0 } else { 0x3f };

--- a/examples/animation/morph_targets.rs
+++ b/examples/animation/morph_targets.rs
@@ -31,7 +31,7 @@ fn setup(
     mut graphs: ResMut<Assets<AnimationGraph>>,
 ) {
     let (graph, index) = AnimationGraph::from_clip(
-        asset_server.load(GltfAssetLabel::Animation(2).from_asset(GLTF_PATH)),
+        asset_server.load(GltfSubassetName::Animation(2).from_asset(GLTF_PATH)),
     );
 
     commands
@@ -40,7 +40,7 @@ fn setup(
                 graph_handle: graphs.add(graph),
                 index,
             },
-            SceneRoot(asset_server.load(GltfAssetLabel::Scene(0).from_asset(GLTF_PATH))),
+            SceneRoot(asset_server.load(GltfSubassetName::Scene(0).from_asset(GLTF_PATH))),
         ))
         .observe(play_animation_when_ready);
 

--- a/examples/asset/alter_mesh.rs
+++ b/examples/asset/alter_mesh.rs
@@ -56,7 +56,7 @@ fn setup(
     // In normal use, you can call `asset_server.load`, however see below for an explanation of
     // `RenderAssetUsages`.
     let left_shape_model = asset_server.load_with_settings(
-        GltfAssetLabel::Primitive {
+        GltfSubassetName::Primitive {
             mesh: 0,
             // This field stores an index to this primitive in its parent mesh. In this case, we
             // want the first one. You might also have seen the syntax:
@@ -86,7 +86,7 @@ fn setup(
 
     // Here, we rely on the default loader settings to achieve a similar result to the above.
     let right_shape_model = asset_server.load(
-        GltfAssetLabel::Primitive {
+        GltfSubassetName::Primitive {
             mesh: 0,
             primitive: 0,
         }
@@ -160,7 +160,7 @@ fn alter_handle(
     // have to load the same path from storage media once: repeated attempts will re-use the
     // asset.
     mesh.0 = asset_server.load(
-        GltfAssetLabel::Primitive {
+        GltfSubassetName::Primitive {
             mesh: 0,
             primitive: 0,
         }

--- a/examples/asset/asset_loading.rs
+++ b/examples/asset/asset_loading.rs
@@ -16,19 +16,19 @@ fn setup(
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
     // By default AssetServer will load assets from inside the "assets" folder.
-    // For example, the next line will load GltfAssetLabel::Primitive{mesh:0,primitive:0}.from_asset("ROOT/assets/models/cube/cube.gltf"),
+    // For example, the next line will load GltfSubassetName::Primitive{mesh:0,primitive:0}.from_asset("ROOT/assets/models/cube/cube.gltf"),
     // where "ROOT" is the directory of the Application.
     //
     // This can be overridden by setting [`AssetPlugin.file_path`].
     let cube_handle = asset_server.load(
-        GltfAssetLabel::Primitive {
+        GltfSubassetName::Primitive {
             mesh: 0,
             primitive: 0,
         }
         .from_asset("models/cube/cube.gltf"),
     );
     let sphere_handle = asset_server.load(
-        GltfAssetLabel::Primitive {
+        GltfSubassetName::Primitive {
             mesh: 0,
             primitive: 0,
         }
@@ -59,7 +59,7 @@ fn setup(
     // The LoadedFolder asset will ultimately also hold handles to the assets, but waiting for it to load
     // and finding the right handle is more work!
     let torus_handle = asset_server.load(
-        GltfAssetLabel::Primitive {
+        GltfSubassetName::Primitive {
             mesh: 0,
             primitive: 0,
         }

--- a/examples/asset/hot_asset_reloading.rs
+++ b/examples/asset/hot_asset_reloading.rs
@@ -17,7 +17,7 @@ fn main() {
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Load our mesh:
     let scene_handle =
-        asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/torus/torus.gltf"));
+        asset_server.load(GltfSubassetName::Scene(0).from_asset("models/torus/torus.gltf"));
 
     // Any changes to the mesh will be reloaded automatically! Try making a change to torus.gltf.
     // You should see the changes immediately show up in your app.

--- a/examples/camera/projection_zoom.rs
+++ b/examples/camera/projection_zoom.rs
@@ -78,7 +78,7 @@ fn setup(
     commands.spawn((
         Name::new("Fox"),
         SceneRoot(
-            asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/animated/Fox.glb")),
+            asset_server.load(GltfSubassetName::Scene(0).from_asset("models/animated/Fox.glb")),
         ),
         // Note: the scale adjustment is purely an accident of our fox model, which renders
         // HUGE unless mitigated!

--- a/examples/games/alien_cake_addict.rs
+++ b/examples/games/alien_cake_addict.rs
@@ -132,7 +132,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut game: ResMu
 
     // spawn the game board
     let cell_scene =
-        asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/AlienCake/tile.glb"));
+        asset_server.load(GltfSubassetName::Scene(0).from_asset("models/AlienCake/tile.glb"));
     game.board = (0..BOARD_SIZE_J)
         .map(|j| {
             (0..BOARD_SIZE_I)
@@ -165,15 +165,15 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut game: ResMu
                 },
                 SceneRoot(
                     asset_server
-                        .load(GltfAssetLabel::Scene(0).from_asset("models/AlienCake/alien.glb")),
+                        .load(GltfSubassetName::Scene(0).from_asset("models/AlienCake/alien.glb")),
                 ),
             ))
             .id(),
     );
 
     // load the scene for the cake
-    game.bonus.handle =
-        asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/AlienCake/cakeBirthday.glb"));
+    game.bonus.handle = asset_server
+        .load(GltfSubassetName::Scene(0).from_asset("models/AlienCake/cakeBirthday.glb"));
 
     // scoreboard
     commands.spawn((

--- a/examples/games/loading_screen.rs
+++ b/examples/games/loading_screen.rs
@@ -141,7 +141,7 @@ fn load_level_1(
     ));
 
     // Save the asset into the `loading_assets` vector.
-    let fox = asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/animated/Fox.glb"));
+    let fox = asset_server.load(GltfSubassetName::Scene(0).from_asset("models/animated/Fox.glb"));
     loading_data.loading_assets.push(fox.clone().into());
     // Spawn the fox.
     commands.spawn((
@@ -175,7 +175,7 @@ fn load_level_2(
 
     // Spawn the helmet.
     let helmet_scene = asset_server
-        .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"));
+        .load(GltfSubassetName::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"));
     loading_data
         .loading_assets
         .push(helmet_scene.clone().into());

--- a/examples/gltf/custom_gltf_vertex_attribute.rs
+++ b/examples/gltf/custom_gltf_vertex_attribute.rs
@@ -50,7 +50,7 @@ fn setup(
 ) {
     // Add a mesh loaded from a glTF file. This mesh has data for `ATTRIBUTE_BARYCENTRIC`.
     let mesh = asset_server.load(
-        GltfAssetLabel::Primitive {
+        GltfSubassetName::Primitive {
             mesh: 0,
             primitive: 0,
         }

--- a/examples/gltf/edit_material_on_gltf.rs
+++ b/examples/gltf/edit_material_on_gltf.rs
@@ -31,7 +31,7 @@ fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     // FlightHelmet handle
     let flight_helmet = asset_server
-        .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"));
+        .load(GltfSubassetName::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"));
     // This model will keep its original materials
     commands.spawn(SceneRoot(flight_helmet.clone()));
     // This model will be tinted red

--- a/examples/gltf/gltf_extension_animation_graph.rs
+++ b/examples/gltf/gltf_extension_animation_graph.rs
@@ -45,7 +45,7 @@ fn setup_mesh_and_animation(mut commands: Commands, asset_server: Res<AssetServe
     // will trigger when the scene is loaded and spawned.
     commands
         .spawn(SceneRoot(
-            asset_server.load(GltfAssetLabel::Scene(0).from_asset(GLTF_PATH)),
+            asset_server.load(GltfSubassetName::Scene(0).from_asset(GLTF_PATH)),
         ))
         .observe(play_animation_when_ready);
 }
@@ -184,8 +184,7 @@ impl GltfExtensionHandler for GltfExtensionHandlerAnimation {
         let (graph, index) = AnimationGraph::from_clip(self.clip.clone().unwrap());
         // Store the animation graph as an asset with an arbitrary label
         // We only have one graph, so this label will be unique
-        let graph_handle =
-            load_context.add_labeled_asset("MyAnimationGraphLabel".to_string(), graph);
+        let graph_handle = load_context.add_subasset("MyAnimationGraphLabel".to_string(), graph);
 
         // Create a component that stores a reference to our animation
         let animation_to_play = AnimationToPlay {

--- a/examples/gltf/gltf_extension_mesh_2d.rs
+++ b/examples/gltf/gltf_extension_mesh_2d.rs
@@ -49,7 +49,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn((
         SceneRoot(
             asset_server
-                .load(GltfAssetLabel::Scene(0).from_asset("models/barycentric/barycentric.gltf")),
+                .load(GltfSubassetName::Scene(0).from_asset("models/barycentric/barycentric.gltf")),
         ),
         Transform::from_scale(150. * Vec3::ONE),
     ));
@@ -100,7 +100,7 @@ impl GltfExtensionHandler for GltfExtensionHandlerToMesh2d {
             && let Some(_) = entity.get::<MeshMaterial3d<StandardMaterial>>()
         {
             let material_handle =
-                load_context.add_labeled_asset("AColorMaterial".to_string(), CustomMaterial {});
+                load_context.add_subasset("AColorMaterial".to_string(), CustomMaterial {});
             let mesh_handle = mesh3d.0.clone();
             entity
                 .remove::<(Mesh3d, MeshMaterial3d<StandardMaterial>)>()

--- a/examples/gltf/gltf_skinned_mesh.rs
+++ b/examples/gltf/gltf_skinned_mesh.rs
@@ -26,7 +26,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     // Spawn the first scene in `models/SimpleSkin/SimpleSkin.gltf`
     commands.spawn(SceneRoot(asset_server.load(
-        GltfAssetLabel::Scene(0).from_asset("models/SimpleSkin/SimpleSkin.gltf"),
+        GltfSubassetName::Scene(0).from_asset("models/SimpleSkin/SimpleSkin.gltf"),
     )));
 }
 

--- a/examples/gltf/load_gltf.rs
+++ b/examples/gltf/load_gltf.rs
@@ -44,7 +44,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         .build(),
     ));
     commands.spawn(SceneRoot(asset_server.load(
-        GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"),
+        GltfSubassetName::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"),
     )));
 }
 

--- a/examples/gltf/load_gltf_extras.rs
+++ b/examples/gltf/load_gltf_extras.rs
@@ -29,7 +29,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     // a barebones scene containing one of each gltf_extra type
     commands.spawn(SceneRoot(asset_server.load(
-        GltfAssetLabel::Scene(0).from_asset("models/extras/gltf_extras.glb"),
+        GltfSubassetName::Scene(0).from_asset("models/extras/gltf_extras.glb"),
     )));
 
     // a place to display the extras on screen

--- a/examples/gltf/query_gltf_primitives.rs
+++ b/examples/gltf/query_gltf_primitives.rs
@@ -63,6 +63,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     ));
 
     commands.spawn(SceneRoot(asset_server.load(
-        GltfAssetLabel::Scene(0).from_asset("models/GltfPrimitives/gltf_primitives.glb"),
+        GltfSubassetName::Scene(0).from_asset("models/GltfPrimitives/gltf_primitives.glb"),
     )));
 }

--- a/examples/gltf/update_gltf_scene.rs
+++ b/examples/gltf/update_gltf_scene.rs
@@ -38,16 +38,18 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn((
         Transform::from_xyz(-1.0, 0.0, 0.0),
         SceneRoot(
-            asset_server
-                .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf")),
+            asset_server.load(
+                GltfSubassetName::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"),
+            ),
         ),
     ));
 
     // Spawn a second scene, and add a tag component to be able to target it later
     commands.spawn((
         SceneRoot(
-            asset_server
-                .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf")),
+            asset_server.load(
+                GltfSubassetName::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"),
+            ),
         ),
         MovedScene,
     ));

--- a/examples/large_scenes/mipmap_generator/examples/load_gltf.rs
+++ b/examples/large_scenes/mipmap_generator/examples/load_gltf.rs
@@ -70,7 +70,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(SceneRoot(
         asset_server.load(
             // This seems to be the correct path but bevy doesn't resolve it.
-            GltfAssetLabel::Scene(0)
+            GltfSubassetName::Scene(0)
                 .from_asset("../../../../assets/models/FlightHelmet/FlightHelmet.gltf"),
         ),
     ));

--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -114,9 +114,9 @@ fn setup(
 
     // Insert a resource with the current scene information
     let animation_clips = [
-        asset_server.load(GltfAssetLabel::Animation(2).from_asset("models/animated/Fox.glb")),
-        asset_server.load(GltfAssetLabel::Animation(1).from_asset("models/animated/Fox.glb")),
-        asset_server.load(GltfAssetLabel::Animation(0).from_asset("models/animated/Fox.glb")),
+        asset_server.load(GltfSubassetName::Animation(2).from_asset("models/animated/Fox.glb")),
+        asset_server.load(GltfSubassetName::Animation(1).from_asset("models/animated/Fox.glb")),
+        asset_server.load(GltfSubassetName::Animation(0).from_asset("models/animated/Fox.glb")),
     ];
     let mut animation_graph = AnimationGraph::new();
     let node_indices = animation_graph
@@ -133,7 +133,7 @@ fn setup(
 
     // NOTE: This fox model faces +z
     let fox_handle =
-        asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/animated/Fox.glb"));
+        asset_server.load(GltfSubassetName::Scene(0).from_asset("models/animated/Fox.glb"));
 
     let ring_directions = [
         (

--- a/examples/testbed/3d.rs
+++ b/examples/testbed/3d.rs
@@ -255,7 +255,7 @@ mod gltf {
         ));
         commands.spawn((
             SceneRoot(asset_server.load(
-                GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"),
+                GltfSubassetName::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"),
             )),
             DespawnOnExit(CURRENT_SCENE),
         ));
@@ -282,7 +282,7 @@ mod animation {
         mut graphs: ResMut<Assets<AnimationGraph>>,
     ) {
         let (graph, node) = AnimationGraph::from_clip(
-            asset_server.load(GltfAssetLabel::Animation(2).from_asset(FOX_PATH)),
+            asset_server.load(GltfSubassetName::Animation(2).from_asset(FOX_PATH)),
         );
 
         let graph_handle = graphs.add(graph);
@@ -308,7 +308,7 @@ mod animation {
 
         commands
             .spawn((
-                SceneRoot(asset_server.load(GltfAssetLabel::Scene(0).from_asset(FOX_PATH))),
+                SceneRoot(asset_server.load(GltfSubassetName::Scene(0).from_asset(FOX_PATH))),
                 DespawnOnExit(CURRENT_SCENE),
             ))
             .observe(pause_animation_frame);
@@ -428,7 +428,7 @@ mod gltf_coordinate_conversion {
         commands
             .spawn((
                 SceneRoot(asset_server.load_with_settings(
-                    GltfAssetLabel::Scene(0).from_asset("models/Faces/faces.glb"),
+                    GltfSubassetName::Scene(0).from_asset("models/Faces/faces.glb"),
                     |s: &mut GltfLoaderSettings| {
                         s.convert_coordinates = Some(GltfConvertCoordinates {
                             rotate_scene_entity: true,

--- a/examples/transforms/align.rs
+++ b/examples/transforms/align.rs
@@ -83,7 +83,7 @@ fn setup(
     commands.spawn((
         SceneRoot(
             asset_server
-                .load(GltfAssetLabel::Scene(0).from_asset("models/ship/craft_speederD.gltf")),
+                .load(GltfSubassetName::Scene(0).from_asset("models/ship/craft_speederD.gltf")),
         ),
         Ship {
             target_transform: random_axes_target_alignment(&RandomAxes(first, second)),

--- a/examples/window/multiple_windows.rs
+++ b/examples/window/multiple_windows.rs
@@ -12,9 +12,9 @@ fn main() {
 
 fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
     // add entities to the world
-    commands.spawn(SceneRoot(
-        asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/torus/torus.gltf")),
-    ));
+    commands.spawn(SceneRoot(asset_server.load(
+        GltfSubassetName::Scene(0).from_asset("models/torus/torus.gltf"),
+    )));
     // light
     commands.spawn((
         DirectionalLight::default(),

--- a/release-content/migration-guides/labeled_asset_to_subasset_rename.md
+++ b/release-content/migration-guides/labeled_asset_to_subasset_rename.md
@@ -1,0 +1,46 @@
+---
+title: Labeled assets are now called subassets.
+pull_requests: []
+---
+
+Previously, we had two terms for assets that "live inside" another - either "subasset" or "labeled
+asset". Our docs would sometimes call them one or the other (sometimes both!).
+
+We've now replaced all instances of "labeled asset" with "subasset". To this end, the following
+types/functions have been renamed:
+
+- `LoadedAsset::get_labeled` -> `LoadedAsset::get_subasset`
+- `LoadedAsset::iter_labels` -> `LoadedAsset::iter_subasset_names`
+- `ErasedLoadedAsset::get_labeled` -> `ErasedLoadedAsset::get_subasset`
+- `ErasedLoadedAsset::iter_labels` -> `ErasedLoadedAsset::iter_subasset_names`
+- `LoadContext::begin_labeled_asset` -> `LoadContext::begin_subasset`
+- `LoadContext::labeled_asset_scope` -> `LoadContext::subasset_scope`
+- `LoadContext::add_labeled_asset` -> `LoadContext::add_subasset`
+- `LoadContext::add_loaded_labeled_asset` -> `LoadContext::add_loaded_subasset`
+- `LoadContext::has_labeled_asset` -> `LoadContext::has_subasset`
+- `LoadContext::get_label_handle` -> `LoadContext::get_subasset_handle`
+- `ParseAssetPathError::InvalidLabelSyntax` -> `ParseAssetPathError::InvalidSubassetSyntax`
+- `ParseAssetPathError::MissingSubassetName` -> `ParseAssetPathError::MissingSubassetName`
+- `AssetPath::label` -> `AssetPath::subasset_name`
+- `AssetPath::label_cow` -> `AssetPath::subasset_name_cow`
+- `AssetPath::without_label` -> `AssetPath::without_subasset_name`
+- `AssetPath::remove_label` -> `AssetPath::remove_subasset_name`
+- `AssetPath::take_label` -> `AssetPath::take_subasset_name`
+- `AssetPath::with_label` -> `AssetPath::with_subasset_name`
+- `SavedAsset::get_labeled` -> `SavedAsset::get_subasset`
+- `SavedAsset::get_erased_labeled` -> `SavedAsset::get_erased_subasset`
+- `SavedAsset::iter_labels` -> `SavedAsset::iter_subasset_names`
+- `TransformedAsset::take_labeled_assets` -> `TransformedAsset::take_subassets`
+- `TransformedAsset::get_labeled` -> `TransformedAsset::get_subasset`
+- `TransformedAsset::get_erased_labeled` -> `TransformedAsset::get_erased_subasset`
+- `TransformedAsset::insert_labeled` -> `TransformedAsset::insert_subasset`
+- `TransformedAsset::iter_labels` -> `TransformedAsset::iter_subasset_names`
+- `TransformedSubAsset::get_labeled` -> `TransformedSubAsset::get_subasset`
+- `TransformedSubAsset::get_erased_labeled` -> `TransformedSubAsset::get_erased_subasset`
+- `TransformedSubAsset::insert_labeled` -> `TransformedSubAsset::insert_subasset`
+- `TransformedSubAsset::iter_labels` -> `TransformedSubAsset::iter_subasset_names`
+- `GltfAssetLabel` -> `GltfSubassetName`
+- `GltfMesh::asset_label` -> `GltfMesh::subasset_name`
+- `GltfNode::asset_label` -> `GltfNode::subasset_name`
+- `GltfPrimitive::asset_label` -> `GltfPrimitive::subasset_name`
+- `GltfSkin::asset_label` -> `GltfSkin::subasset_name`


### PR DESCRIPTION
# Objective

- We have a mix of terminology for subassets, and I think it makes it especially confusing when talking about the "labeled assets" in a LoadedAsset. Picking one is better, and I think more people are comfortable talking about subassets than "labeled assets".

## Solution

- Go through every instance of `label` in `bevy_asset` and rename it to `subasset` as relevant.
    - One standout: rename `AssetPath::label` to `AssetPath::subasset_name`.
- Update `bevy_gltf` (as its the main user of subassets in the bevy repo).
- Update the examples to match.

## Testing

- CI
