### PR TITLE
`animated_ui`: Animate `UiTransform::scale`, not `TextFont::font_size`

### DIFF
--- a/examples/animation/animated_ui.rs
+++ b/examples/animation/animated_ui.rs
@@ -1,10 +1,12 @@
 //! Shows how to use animation clips to animate UI properties.
 
 use bevy::{
-    animation::{AnimatedBy, AnimationEntityMut, AnimationEvaluationError, AnimationTargetId},
+    animation::{
+        animated_field, AnimatedBy, AnimationEntityMut, AnimationEvaluationError, AnimationTargetId,
+    },
     prelude::*,
 };
-use bevy_animation::animated_field;
+
 use std::any::TypeId;
 
 // Holds information about the animation we programmatically create.


### PR DESCRIPTION
# Objective

The animated_ui example interpolates the font size of the animated text entity, which rapidly generates gigabytes of font atlases.

Also, on main the text isn't even visible (and it still generates infinity font atlases). 

Fixes #22626, #22647

## Solution

Spawn the text with its font size set to the maximum value from the old animation curve. Then scale the text by interpolating the `UiTransform::scale` field, instead of the font size.

## Testing

```cargo run --example animated_ui```

The text should be visible and the memory usage should be stable.
