### PR TITLE
Adds tests for new `UiDebugOverlay` features into `testbed_ui`

### DIFF
--- a/examples/testbed/ui.rs
+++ b/examples/testbed/ui.rs
@@ -1515,12 +1515,13 @@ mod debug_outlines {
                 parent.spawn((
                     Node {
                         flex_direction: FlexDirection::Column,
-                        width: px(100),
-                        height: px(100),
+                        width: px(90),
+                        height: px(230),
                         overflow: Overflow::scroll_y(),
                         scrollbar_width: 20.,
                         ..default()
                     },
+                    ScrollPosition(Vec2::new(180., 180.)),
                     UiDebugOptions {
                         line_width: 3.,
                         outline_scrollbars: true,
@@ -1528,7 +1529,7 @@ mod debug_outlines {
                         show_clipped: false,
                         ..*debug_options
                     },
-                    Children::spawn(SpawnIter((0..6).map(move |i| {
+                    Children::spawn(SpawnIter((0..20).map(move |i| {
                         (
                             Node::default(),
                             children![(
@@ -1550,10 +1551,10 @@ mod debug_outlines {
                 parent.spawn((
                     Node {
                         flex_direction: FlexDirection::Row,
-                        width: px(100),
-                        height: px(100),
+                        width: px(156),
+                        height: px(70),
                         overflow: Overflow::scroll_x(),
-                        scrollbar_width: 20.,
+                        scrollbar_width: 10.,
                         ..default()
                     },
                     UiDebugOptions {
@@ -1563,7 +1564,7 @@ mod debug_outlines {
                         show_clipped: false,
                         ..*debug_options
                     },
-                    Children::spawn(SpawnIter((0..6).map(move |i| {
+                    Children::spawn(SpawnIter((0..20).map(move |i| {
                         (
                             Node::default(),
                             children![(
@@ -1585,12 +1586,13 @@ mod debug_outlines {
                 parent.spawn((
                     Node {
                         flex_direction: FlexDirection::Column,
-                        width: px(100),
-                        height: px(100),
+                        width: px(230),
+                        height: px(125),
                         overflow: Overflow::scroll(),
                         scrollbar_width: 20.,
                         ..default()
                     },
+                    ScrollPosition(Vec2::new(300., 0.)),
                     UiDebugOptions {
                         line_width: 3.,
                         outline_scrollbars: true,


### PR DESCRIPTION
# Objective

- Add some recently expanded UI Debug functionality to the testbed #21931 

## Solution

To `testbed/ui.rs`, Adds a second row of entities demonstrating:

1. border, padding, content box outlines with a rounded border radius
2. vertical scrollbar outline
3. horizontal scrollbar outline
4. bidirectional scrollbar outline

The scrollbars were taken from `scroll.rs` and I tried to strip them down to the barest code that shows them as outlines (so scrolling doesn’t work with them)

## Testing

`cargo run --example testbed_ui --features="bevy_ui_debug” -- debugoutlines` does the trick

## Showcase

If this screenshot / these new test cases expose(s) any bugs that are not intended behavior (i.e. why is the bottom left padding box’s corner also rounded when only the bottom right border radius was specified? Or why do the bidirectional scrollbars overlap the text?), please make an issue / let me know so that I can make an issue

<details>
  <summary>Screenshot</summary>

<img width="1282" height="747" alt="Screenshot 2026-01-23 at 6 50 18 PM" src="https://github.com/user-attachments/assets/a52fcec8-834c-46e9-b7a0-61c3e30cf730" />

</details>
