### PR TITLE
example image_node_resizing  crash: duplicate component

### DIFF
--- a/examples/ui/image_node_resizing.rs
+++ b/examples/ui/image_node_resizing.rs
@@ -99,10 +99,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 enabled: false,
                 ..default()
             },
-            UiDebugOptions {
-                enabled: false,
-                ..default()
-            },
             ChildOf(container),
         ))
         .observe(update_text);


### PR DESCRIPTION
# Objective

- New example added in https://github.com/bevyengine/bevy/pull/22606 doesn't work
```
thread 'main' (16547671) panicked at crates/bevy_ecs/src/bundle/info.rs:118:13:
Bundle (image_node_resizing::TextData, bevy_ui::widget::text::Text, bevy_text::text::TextColor, bevy_ui::ui_node::Node, bevy_ui_render::debug_overlay::UiDebugOptions, bevy_ui_render::debug_overlay::UiDebugOptions, bevy_ecs::hierarchy::ChildOf) has duplicate components: ["bevy_ui_render::debug_overlay::UiDebugOptions"]
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Encountered a panic when applying buffers for system `image_node_resizing::setup`!
```

## Solution

- Remove the duplicate component

## Testing

- `cargo run --example image_node_resizing`
