### PR TITLE
Replace `validate_parent_has_component` with `ValidateParentHasComponentPlugin`.

### DIFF
--- a/crates/bevy_app/src/hierarchy.rs
+++ b/crates/bevy_app/src/hierarchy.rs
@@ -1,0 +1,137 @@
+use core::marker::PhantomData;
+
+use bevy_ecs::{
+    change_detection::MaybeLocation,
+    component::Component,
+    entity::Entity,
+    hierarchy::ChildOf,
+    intern::Interned,
+    lifecycle::Insert,
+    message::{Message, MessageReader, MessageWriter},
+    name::Name,
+    observer::On,
+    query::{With, Without},
+    schedule::{common_conditions::on_message, IntoScheduleConfigs, ScheduleLabel, SystemSet},
+    system::Query,
+};
+use bevy_platform::prelude::format;
+use bevy_utils::prelude::DebugName;
+use log::warn;
+
+use crate::{Last, Plugin};
+
+/// A plugin that verifies that [`Component`] `C` has parents that also have that component.
+pub struct ValidateParentHasComponentPlugin<C: Component> {
+    schedule: Interned<dyn ScheduleLabel>,
+    marker: PhantomData<fn() -> C>,
+}
+
+impl<C: Component> Default for ValidateParentHasComponentPlugin<C> {
+    fn default() -> Self {
+        Self::in_schedule(Last)
+    }
+}
+
+impl<C: Component> ValidateParentHasComponentPlugin<C> {
+    /// Creates an instance of this plugin that inserts systems in the provided schedule.
+    pub fn in_schedule(label: impl ScheduleLabel) -> Self {
+        Self {
+            schedule: label.intern(),
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<C: Component> Plugin for ValidateParentHasComponentPlugin<C> {
+    fn build(&self, app: &mut crate::App) {
+        app.add_message::<CheckParentHasComponent<C>>()
+            .add_observer(validate_parent_has_component::<C>)
+            .add_systems(
+                self.schedule,
+                check_parent_has_component::<C>
+                    .run_if(on_message::<CheckParentHasComponent<C>>)
+                    .in_set(ValidateParentHasComponentSystems),
+            );
+    }
+}
+
+/// System set for systems added by [`ValidateParentHasComponentPlugin`].
+#[derive(SystemSet, PartialEq, Eq, Hash, Debug, Clone)]
+pub struct ValidateParentHasComponentSystems;
+
+/// An `Insert` observer that when run, will validate that the parent of a given entity contains
+/// component `C`. If the parent does not contain `C`, a warning will be logged later in the frame.
+fn validate_parent_has_component<C: Component>(
+    event: On<Insert, C>,
+    child: Query<&ChildOf>,
+    with_component: Query<(), With<C>>,
+    mut writer: MessageWriter<CheckParentHasComponent<C>>,
+) {
+    let Ok(child_of) = child.get(event.entity) else {
+        return;
+    };
+    if with_component.contains(child_of.parent()) {
+        return;
+    }
+    // This entity may be configured incorrectly, or the parent may just not have been populated
+    // yet. Send a message to check again later.
+    writer.write(CheckParentHasComponent::<C> {
+        entity: event.entity,
+        caller: event.caller(),
+        marker: PhantomData,
+    });
+}
+
+/// A message to indicate that this entity should be checked if its parent has a component.
+///
+/// While we initially check when emitting these messages, we want to do a second check later on in
+/// case the parent eventually gets populated.
+#[derive(Message)]
+struct CheckParentHasComponent<C: Component> {
+    /// The entity
+    entity: Entity,
+    caller: MaybeLocation,
+    marker: PhantomData<fn() -> C>,
+}
+
+/// System to handle "check parent" messages and log out any entities that still violate the
+/// component hierarchy.
+fn check_parent_has_component<C: Component>(
+    mut messages: MessageReader<CheckParentHasComponent<C>>,
+    children: Query<(&ChildOf, Option<&Name>), With<C>>,
+    components: Query<Option<&Name>, Without<C>>,
+) {
+    for CheckParentHasComponent {
+        entity,
+        caller,
+        marker: _,
+    } in messages.read()
+    {
+        let Ok((child_of, name)) = children.get(*entity) else {
+            // Either the entity has been despawned, no longer has `C`, or is no longer a child. In
+            // any case, we can say that this situation is no longer relevant.
+            continue;
+        };
+        let parent = child_of.0;
+        let Ok(parent_name) = components.get(parent) else {
+            // This can only fail if the parent now has the `C` component. If the parent was
+            // despawned, the child entity would also be despawned.
+            continue;
+        };
+        let debug_name = DebugName::type_name::<C>();
+        warn!(
+            "warning[B0004]: {}{name} with the {ty_name} component has a parent ({parent_name}) without {ty_name}.\n\
+            This will cause inconsistent behaviors! See: https://bevy.org/learn/errors/b0004",
+            caller.map(|c| format!("{c}: ")).unwrap_or_default(),
+            ty_name = debug_name.shortname(),
+            name = name.map_or_else(
+                || format!("Entity {entity}"),
+                |s| format!("The {s} entity")
+            ),
+            parent_name = parent_name.map_or_else(
+                || format!("{parent} entity"),
+                |s| format!("the {s} entity")
+            ),
+        );
+    }
+}

--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -24,6 +24,7 @@ extern crate alloc;
 extern crate self as bevy_app;
 
 mod app;
+mod hierarchy;
 mod main_schedule;
 mod panic_handler;
 mod plugin;
@@ -39,6 +40,7 @@ mod terminal_ctrl_c_handler;
 pub mod hotpatch;
 
 pub use app::*;
+pub use hierarchy::*;
 pub use main_schedule::*;
 pub use panic_handler::*;
 pub use plugin::*;

--- a/crates/bevy_camera/src/visibility/mod.rs
+++ b/crates/bevy_camera/src/visibility/mod.rs
@@ -10,10 +10,10 @@ use derive_more::derive::{Deref, DerefMut};
 pub use range::*;
 pub use render_layers::*;
 
-use bevy_app::{Plugin, PostUpdate};
+use bevy_app::{Plugin, PostUpdate, ValidateParentHasComponentPlugin};
 use bevy_asset::prelude::AssetChanged;
 use bevy_asset::{AssetEventSystems, Assets};
-use bevy_ecs::{hierarchy::validate_parent_has_component, prelude::*};
+use bevy_ecs::prelude::*;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_transform::{components::GlobalTransform, TransformSystems};
 use bevy_utils::{Parallel, TypeIdMap};
@@ -113,7 +113,6 @@ impl PartialEq<&Visibility> for Visibility {
 /// [`VisibilityPropagate`]: VisibilitySystems::VisibilityPropagate
 #[derive(Component, Deref, Debug, Default, Clone, Copy, Reflect, PartialEq, Eq)]
 #[reflect(Component, Default, Debug, PartialEq, Clone)]
-#[component(on_insert = validate_parent_has_component::<Self>)]
 pub struct InheritedVisibility(bool);
 
 impl InheritedVisibility {
@@ -394,7 +393,8 @@ impl Plugin for VisibilityPlugin {
     fn build(&self, app: &mut bevy_app::App) {
         use VisibilitySystems::*;
 
-        app.register_required_components::<Mesh3d, Visibility>()
+        app.add_plugins(ValidateParentHasComponentPlugin::<InheritedVisibility>::default())
+            .register_required_components::<Mesh3d, Visibility>()
             .register_required_components::<Mesh3d, VisibilityClass>()
             .register_required_components::<Mesh2d, Visibility>()
             .register_required_components::<Mesh2d, VisibilityClass>()

--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -8,7 +8,7 @@ use derive_more::derive::From;
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 
 #[cfg(feature = "bevy-support")]
-use bevy_ecs::{component::Component, hierarchy::validate_parent_has_component};
+use bevy_ecs::component::Component;
 
 #[cfg(feature = "bevy_reflect")]
 use {
@@ -47,11 +47,7 @@ use {
 /// [transform_example]: https://github.com/bevyengine/bevy/blob/latest/examples/transforms/transform.rs
 #[derive(Debug, PartialEq, Clone, Copy, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    feature = "bevy-support",
-    derive(Component),
-    component(on_insert = validate_parent_has_component::<GlobalTransform>)
-)]
+#[cfg_attr(feature = "bevy-support", derive(Component))]
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(Reflect),

--- a/crates/bevy_transform/src/plugins.rs
+++ b/crates/bevy_transform/src/plugins.rs
@@ -1,14 +1,17 @@
-use crate::systems::{
-    mark_dirty_trees, propagate_parent_transforms, sync_simple_transforms,
-    StaticTransformOptimizations,
+use crate::{
+    prelude::GlobalTransform,
+    systems::{
+        mark_dirty_trees, propagate_parent_transforms, sync_simple_transforms,
+        StaticTransformOptimizations,
+    },
 };
-use bevy_app::{App, Plugin, PostStartup, PostUpdate};
+use bevy_app::{App, Plugin, PostStartup, PostUpdate, ValidateParentHasComponentPlugin};
 use bevy_ecs::schedule::{IntoScheduleConfigs, SystemSet};
 
 /// Set enum for the systems relating to transform propagation
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
 pub enum TransformSystems {
-    /// Propagates changes in transform to children's [`GlobalTransform`](crate::components::GlobalTransform)
+    /// Propagates changes in transform to children's [`GlobalTransform`]
     Propagate,
 }
 
@@ -18,7 +21,8 @@ pub struct TransformPlugin;
 
 impl Plugin for TransformPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<StaticTransformOptimizations>()
+        app.add_plugins(ValidateParentHasComponentPlugin::<GlobalTransform>::default())
+            .init_resource::<StaticTransformOptimizations>()
             // add transform systems to startup so the first update is "correct"
             .add_systems(
                 PostStartup,

--- a/release-content/migration-guides/validate_parent_has_component_is_now_a_plugin.md
+++ b/release-content/migration-guides/validate_parent_has_component_is_now_a_plugin.md
@@ -1,6 +1,6 @@
 ---
 title: The `validate_parent_has_component` is superseded by `ValidateParentHasComponentPlugin`
-pull_requests: []
+pull_requests: [22675]
 ---
 
 The `validate_parent_has_component` insert hook has been replaced by a plugin:

--- a/release-content/migration-guides/validate_parent_has_component_is_now_a_plugin.md
+++ b/release-content/migration-guides/validate_parent_has_component_is_now_a_plugin.md
@@ -1,0 +1,8 @@
+---
+title: The `validate_parent_has_component` is superseded by `ValidateParentHasComponentPlugin`
+pull_requests: []
+---
+
+The `validate_parent_has_component` insert hook has been replaced by a plugin:
+`ValidateParentHasComponentPlugin`. This uses an observer, a resource, and a system to achieve a
+more robust (and less spurious) warning for invalid configuration of entities.


### PR DESCRIPTION
# Objective

- Fixes #21666.
- Fixes #19776

## Solution

Instead of warning in the hook, we instead send a message for the entity if its parent is missing the component. A system later reads these messages and checks again if the parent is missing the component, and only then logs. This is done by:

- Change the hook into an observer.
- Create a message to indicate a check is needed.
- Create a system to do this check.
- Create a plugin in `bevy_app` to add all these things to the app.
    - I couldn't think of a better place to put this, other than like `bevy_util`, but I didn't want to add to the "kitchen sink".
- Switch `GlobalTransform`/`InheritedVisibility` to use this plugin instead.
    - One thing to note is I only perform this check in the `Last` schedule. We could move this check if necessary, but I doubt many users will spawn a child, and then only add the parent's GlobalTransform **after** `PostUpdate` (not sure if this will even affect transform propagation though?)

Note: the memory usage is proportional to how many of these bad entities you spawn in a single frame.

## Testing

- I ran the following example:

```rust
use bevy::prelude::*;

fn main() {
    App::new()
        .add_plugins(DefaultPlugins)
        .add_systems(Startup, setup)
        .run();
}

fn setup(mut commands: Commands) {
    let parent = commands.spawn_empty().id();
    let child = commands.spawn_empty().id();

    // Initialize the child first, add the Visibility+Transform component, which implicitly adds the
    // InheritedVisibility+GlobalTransform component as well.
    commands
        .entity(child)
        .insert((ChildOf(parent), Visibility::Inherited, Transform::default()));

    // Also make the parent add the Visibility+Transform component so it is valid.
    commands
        .entity(parent)
        .insert((Visibility::Inherited, Transform::default()));
}
``` 

On main, this logs two warnings. With this PR, there are no logs! I also verified that omitting attaching the components to the parent still logs the warning.
