### PR TITLE
Fix occlusion culling

### DIFF
--- a/crates/bevy_pbr/src/render/gpu_preprocess.rs
+++ b/crates/bevy_pbr/src/render/gpu_preprocess.rs
@@ -1302,12 +1302,25 @@ impl FromWorld for PreprocessPipelines {
         let direct_bind_group_layout_entries = preprocess_direct_bind_group_layout_entries();
         let gpu_frustum_culling_bind_group_layout_entries = gpu_culling_bind_group_layout_entries();
         let gpu_early_occlusion_culling_bind_group_layout_entries =
-            gpu_occlusion_culling_bind_group_layout_entries().extend_with_indices(((
-                11,
-                storage_buffer::<PreprocessWorkItem>(/*has_dynamic_offset=*/ false),
-            ),));
+            gpu_occlusion_culling_bind_group_layout_entries().extend_with_indices((
+                (
+                    11,
+                    storage_buffer::<PreprocessWorkItem>(/*has_dynamic_offset=*/ false),
+                ),
+                (
+                    12,
+                    storage_buffer::<LatePreprocessWorkItemIndirectParameters>(
+                        /*has_dynamic_offset=*/ false,
+                    ),
+                ),
+            ));
         let gpu_late_occlusion_culling_bind_group_layout_entries =
-            gpu_occlusion_culling_bind_group_layout_entries();
+            gpu_occlusion_culling_bind_group_layout_entries().extend_with_indices(((
+                12,
+                storage_buffer_read_only::<LatePreprocessWorkItemIndirectParameters>(
+                    /*has_dynamic_offset=*/ false,
+                ),
+            ),));
 
         let reset_indirect_batch_sets_bind_group_layout_entries =
             DynamicBindGroupLayoutEntries::sequential(
@@ -1494,12 +1507,6 @@ fn gpu_occlusion_culling_bind_group_layout_entries() -> DynamicBindGroupLayoutEn
         (
             10,
             texture_2d(TextureSampleType::Float { filterable: true }),
-        ),
-        (
-            12,
-            storage_buffer::<LatePreprocessWorkItemIndirectParameters>(
-                /*has_dynamic_offset=*/ false,
-            ),
         ),
     ))
 }

--- a/crates/bevy_pbr/src/render/mesh_preprocess.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_preprocess.wgsl
@@ -112,10 +112,15 @@ struct Immediates {
 #ifdef EARLY_PHASE
 @group(0) @binding(11) var<storage, read_write> late_preprocess_work_items:
     array<PreprocessWorkItem>;
-#endif  // EARLY_PHASE
 
 @group(0) @binding(12) var<storage, read_write> late_preprocess_work_item_indirect_parameters:
     array<LatePreprocessWorkItemIndirectParameters>;
+#endif  // EARLY_PHASE
+
+#ifdef LATE_PHASE
+@group(0) @binding(12) var<storage, read> late_preprocess_work_item_indirect_parameters:
+    array<LatePreprocessWorkItemIndirectParameters>;
+#endif  // LATE_PHASE
 
 var<immediate> immediates: Immediates;
 #endif  // OCCLUSION_CULLING


### PR DESCRIPTION
# Objective

- fix #22655

## Solution

- separate readonly storage binding for late phase to make wgpu happy

## Testing

- occlusion_culling example no longer crashes



finding this was very difficult lol
