### PR TITLE
Make reflection optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,6 +190,7 @@ default_app = [
   "bevy_state",
   "bevy_window",
   "custom_cursor",
+  "reflection",
   "reflect_auto_register",
 ]
 
@@ -679,6 +680,9 @@ reflect_auto_register = ["bevy_internal/reflect_auto_register"]
 
 # Enable automatic reflect registration without inventory. See `reflect::load_type_registrations` for more info.
 reflect_auto_register_static = ["bevy_internal/reflect_auto_register_static"]
+
+# Enable reflection.
+reflection = ["bevy_internal/reflection"]
 
 # Enable winit custom cursor support
 custom_cursor = ["bevy_internal/custom_cursor"]

--- a/crates/bevy_animation/Cargo.toml
+++ b/crates/bevy_animation/Cargo.toml
@@ -19,7 +19,7 @@ bevy_math = { path = "../bevy_math", version = "0.19.0-dev" }
 bevy_mesh = { path = "../bevy_mesh", version = "0.19.0-dev", optional = true, features = [
   "morph",
 ] }
-bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev", features = [
+bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev", default-features = false, features = [
   "petgraph",
 ] }
 bevy_time = { path = "../bevy_time", version = "0.19.0-dev" }

--- a/crates/bevy_anti_alias/Cargo.toml
+++ b/crates/bevy_anti_alias/Cargo.toml
@@ -19,7 +19,7 @@ force_disable_dlss = ["dlss_wgpu?/mock"]
 [dependencies]
 # bevy
 bevy_asset = { path = "../bevy_asset", version = "0.19.0-dev" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev", default-features = false }
 bevy_render = { path = "../bevy_render", version = "0.19.0-dev" }
 bevy_camera = { path = "../bevy_camera", version = "0.19.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.19.0-dev" }

--- a/crates/bevy_audio/Cargo.toml
+++ b/crates/bevy_audio/Cargo.toml
@@ -14,7 +14,7 @@ bevy_app = { path = "../bevy_app", version = "0.19.0-dev" }
 bevy_asset = { path = "../bevy_asset", version = "0.19.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.19.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.19.0-dev" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev", default-features = false }
 bevy_transform = { path = "../bevy_transform", version = "0.19.0-dev" }
 
 # other

--- a/crates/bevy_camera/Cargo.toml
+++ b/crates/bevy_camera/Cargo.toml
@@ -15,7 +15,7 @@ bevy_asset = { path = "../bevy_asset", version = "0.19.0-dev" }
 bevy_image = { path = "../bevy_image", version = "0.19.0-dev" }
 bevy_mesh = { path = "../bevy_mesh", version = "0.19.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.19.0-dev" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev", features = [
+bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev", default-features = false, features = [
   "wgpu-types",
 ] }
 bevy_ecs = { path = "../bevy_ecs", version = "0.19.0-dev" }

--- a/crates/bevy_core_pipeline/Cargo.toml
+++ b/crates/bevy_core_pipeline/Cargo.toml
@@ -26,7 +26,7 @@ bevy_image = { path = "../bevy_image", version = "0.19.0-dev" }
 bevy_log = { path = "../bevy_log", version = "0.19.0-dev" }
 bevy_light = { path = "../bevy_light", version = "0.19.0-dev" }
 bevy_camera = { path = "../bevy_camera", version = "0.19.0-dev" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev", default-features = false }
 bevy_shader = { path = "../bevy_shader", version = "0.19.0-dev" }
 bevy_render = { path = "../bevy_render", version = "0.19.0-dev" }
 bevy_transform = { path = "../bevy_transform", version = "0.19.0-dev" }

--- a/crates/bevy_dev_tools/Cargo.toml
+++ b/crates/bevy_dev_tools/Cargo.toml
@@ -30,7 +30,7 @@ bevy_math = { path = "../bevy_math", version = "0.19.0-dev" }
 bevy_pbr = { path = "../bevy_pbr", version = "0.19.0-dev" }
 bevy_picking = { path = "../bevy_picking", version = "0.19.0-dev" }
 bevy_render = { path = "../bevy_render", version = "0.19.0-dev" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev", default-features = false }
 bevy_time = { path = "../bevy_time", version = "0.19.0-dev" }
 bevy_text = { path = "../bevy_text", version = "0.19.0-dev" }
 bevy_transform = { path = "../bevy_transform", version = "0.19.0-dev" }

--- a/crates/bevy_feathers/Cargo.toml
+++ b/crates/bevy_feathers/Cargo.toml
@@ -23,7 +23,7 @@ bevy_math = { path = "../bevy_math", version = "0.19.0-dev" }
 bevy_picking = { path = "../bevy_picking", version = "0.19.0-dev" }
 bevy_shader = { path = "../bevy_shader", version = "0.19.0-dev" }
 bevy_platform = { path = "../bevy_platform", version = "0.19.0-dev" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev", default-features = false }
 bevy_render = { path = "../bevy_render", version = "0.19.0-dev" }
 bevy_text = { path = "../bevy_text", version = "0.19.0-dev" }
 bevy_ui = { path = "../bevy_ui", version = "0.19.0-dev", features = [

--- a/crates/bevy_gizmos/Cargo.toml
+++ b/crates/bevy_gizmos/Cargo.toml
@@ -17,7 +17,7 @@ bevy_ecs = { path = "../bevy_ecs", version = "0.19.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.19.0-dev" }
 bevy_asset = { path = "../bevy_asset", version = "0.19.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.19.0-dev" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev", default-features = false }
 bevy_transform = { path = "../bevy_transform", version = "0.19.0-dev" }
 bevy_gizmos_macros = { path = "macros", version = "0.19.0-dev" }
 bevy_time = { path = "../bevy_time", version = "0.19.0-dev" }

--- a/crates/bevy_gltf/Cargo.toml
+++ b/crates/bevy_gltf/Cargo.toml
@@ -31,7 +31,7 @@ bevy_camera = { path = "../bevy_camera", version = "0.19.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.19.0-dev" }
 bevy_mesh = { path = "../bevy_mesh", version = "0.19.0-dev" }
 bevy_pbr = { path = "../bevy_pbr", version = "0.19.0-dev" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev", default-features = false }
 bevy_render = { path = "../bevy_render", version = "0.19.0-dev" }
 bevy_material = { path = "../bevy_material", version = "0.19.0-dev" }
 bevy_scene = { path = "../bevy_scene", version = "0.19.0-dev" }

--- a/crates/bevy_image/Cargo.toml
+++ b/crates/bevy_image/Cargo.toml
@@ -58,7 +58,7 @@ bevy_color = { path = "../bevy_color", version = "0.19.0-dev", features = [
 ] }
 bevy_ecs = { path = "../bevy_ecs", version = "0.19.0-dev", default-features = false }
 bevy_math = { path = "../bevy_math", version = "0.19.0-dev" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev", default-features = false }
 bevy_utils = { path = "../bevy_utils", version = "0.19.0-dev" }
 bevy_platform = { path = "../bevy_platform", version = "0.19.0-dev", default-features = false, features = [
   "std",

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -366,9 +366,7 @@ reflect_auto_register_static = [
   "bevy_ecs/reflect_auto_register",
 ]
 
-reflection = [
-  "bevy_reflect/enable_codegen",
-]
+reflection = ["bevy_reflect/enable_codegen"]
 
 # Enables bevy_reflect to access documentation comments of rust code at runtime
 reflect_documentation = ["bevy_reflect/reflect_documentation"]

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -349,6 +349,7 @@ reflect_functions = [
   "bevy_reflect/functions",
   "bevy_app/reflect_functions",
   "bevy_ecs/reflect_functions",
+  "reflection",
 ]
 
 # Enable automatic reflect registration using inventory.
@@ -363,6 +364,10 @@ reflect_auto_register_static = [
   "bevy_reflect/auto_register_static",
   "bevy_app/reflect_auto_register",
   "bevy_ecs/reflect_auto_register",
+]
+
+reflection = [
+  "bevy_reflect/enable_codegen",
 ]
 
 # Enables bevy_reflect to access documentation comments of rust code at runtime

--- a/crates/bevy_light/Cargo.toml
+++ b/crates/bevy_light/Cargo.toml
@@ -15,7 +15,7 @@ bevy_asset = { path = "../bevy_asset", version = "0.19.0-dev" }
 bevy_image = { path = "../bevy_image", version = "0.19.0-dev" }
 bevy_mesh = { path = "../bevy_mesh", version = "0.19.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.19.0-dev" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev", default-features = false }
 bevy_camera = { path = "../bevy_camera", version = "0.19.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.19.0-dev" }
 bevy_transform = { path = "../bevy_transform", version = "0.19.0-dev" }

--- a/crates/bevy_material/Cargo.toml
+++ b/crates/bevy_material/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["bevy"]
 bevy_asset = { path = "../bevy_asset", version = "0.19.0-dev" }
 bevy_derive = { path = "../bevy_derive", version = "0.19.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.19.0-dev" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev", default-features = false }
 bevy_material_macros = { path = "macros", version = "0.19.0-dev" }
 bevy_mesh = { path = "../bevy_mesh", version = "0.19.0-dev" }
 bevy_shader = { path = "../bevy_shader", version = "0.19.0-dev" }

--- a/crates/bevy_mesh/Cargo.toml
+++ b/crates/bevy_mesh/Cargo.toml
@@ -14,7 +14,7 @@ bevy_app = { path = "../bevy_app", version = "0.19.0-dev" }
 bevy_asset = { path = "../bevy_asset", version = "0.19.0-dev" }
 bevy_image = { path = "../bevy_image", version = "0.19.0-dev", optional = true }
 bevy_math = { path = "../bevy_math", version = "0.19.0-dev" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev", default-features = false }
 bevy_ecs = { path = "../bevy_ecs", version = "0.19.0-dev" }
 bevy_transform = { path = "../bevy_transform", version = "0.19.0-dev" }
 bevy_mikktspace = { version = "0.17.0-dev", optional = true }

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -51,7 +51,7 @@ bevy_mesh = { path = "../bevy_mesh", version = "0.19.0-dev", features = [
 bevy_shader = { path = "../bevy_shader", version = "0.19.0-dev" }
 bevy_material = { path = "../bevy_material", version = "0.19.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.19.0-dev" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev", default-features = false }
 bevy_render = { path = "../bevy_render", version = "0.19.0-dev", features = [
   "morph",
 ] }

--- a/crates/bevy_picking/Cargo.toml
+++ b/crates/bevy_picking/Cargo.toml
@@ -21,7 +21,7 @@ bevy_input = { path = "../bevy_input", version = "0.19.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.19.0-dev" }
 bevy_mesh = { path = "../bevy_mesh", version = "0.19.0-dev", optional = true }
 bevy_camera = { path = "../bevy_camera", version = "0.19.0-dev" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev", default-features = false }
 bevy_time = { path = "../bevy_time", version = "0.19.0-dev" }
 bevy_transform = { path = "../bevy_transform", version = "0.19.0-dev" }
 bevy_window = { path = "../bevy_window", version = "0.19.0-dev" }

--- a/crates/bevy_post_process/Cargo.toml
+++ b/crates/bevy_post_process/Cargo.toml
@@ -23,7 +23,7 @@ bevy_derive = { path = "../bevy_derive", version = "0.19.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.19.0-dev" }
 bevy_image = { path = "../bevy_image", version = "0.19.0-dev" }
 bevy_camera = { path = "../bevy_camera", version = "0.19.0-dev" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev", default-features = false }
 bevy_shader = { path = "../bevy_shader", version = "0.19.0-dev" }
 bevy_render = { path = "../bevy_render", version = "0.19.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.19.0-dev" }

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -10,7 +10,14 @@ keywords = ["bevy"]
 rust-version = "1.87.0"
 
 [features]
-default = ["std", "enable_codegen", "smallvec", "indexmap", "debug", "auto_register_inventory"]
+default = [
+  "std",
+  "enable_codegen",
+  "smallvec",
+  "indexmap",
+  "debug",
+  "auto_register_inventory",
+]
 
 # Enables reflection functionality
 enable_codegen = ["bevy_reflect_derive/enable_codegen"]

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -10,7 +10,10 @@ keywords = ["bevy"]
 rust-version = "1.87.0"
 
 [features]
-default = ["std", "smallvec", "indexmap", "debug", "auto_register_inventory"]
+default = ["std", "enable_codegen", "smallvec", "indexmap", "debug", "auto_register_inventory"]
+
+# Enables reflection functionality
+enable_codegen = ["bevy_reflect_derive/enable_codegen"]
 
 # Features
 

--- a/crates/bevy_reflect/derive/Cargo.toml
+++ b/crates/bevy_reflect/derive/Cargo.toml
@@ -24,6 +24,8 @@ auto_register = []
 auto_register_inventory = ["auto_register"]
 # Enables automatic reflection on platforms not supported by inventory. See `load_type_registrations` for more info.
 auto_register_static = ["auto_register", "dep:uuid"]
+# Enables reflection functionality
+enable_codegen = []
 
 [dependencies]
 bevy_macro_utils = { path = "../../bevy_macro_utils", version = "0.19.0-dev" }

--- a/crates/bevy_reflect/derive/src/lib.rs
+++ b/crates/bevy_reflect/derive/src/lib.rs
@@ -691,7 +691,7 @@ pub fn reflect_remote(args: TokenStream, input: TokenStream) -> TokenStream {
 /// [deriving `Reflect`]: Reflect
 #[proc_macro]
 pub fn impl_reflect_opaque(input: TokenStream) -> TokenStream {
-    maybe_early_out!(input);
+    maybe_early_out!();
     let def = parse_macro_input!(input with ReflectOpaqueDef::parse_reflect);
 
     let default_name = &def.type_path.segments.last().unwrap().ident;
@@ -756,7 +756,7 @@ pub fn impl_reflect_opaque(input: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro]
 pub fn impl_reflect(input: TokenStream) -> TokenStream {
-    maybe_early_out!(input);
+    maybe_early_out!();
     let ast = parse_macro_input!(input as DeriveInput);
     match_reflect_impls(ast, ReflectImplSource::ImplRemoteType)
 }
@@ -783,7 +783,7 @@ pub fn impl_reflect(input: TokenStream) -> TokenStream {
 /// [derives `Reflect`]: Reflect
 #[proc_macro]
 pub fn impl_from_reflect_opaque(input: TokenStream) -> TokenStream {
-    maybe_early_out!(input);
+    maybe_early_out!();
     let def = parse_macro_input!(input with ReflectOpaqueDef::parse_from_reflect);
 
     let default_name = &def.type_path.segments.last().unwrap().ident;
@@ -849,7 +849,7 @@ pub fn impl_from_reflect_opaque(input: TokenStream) -> TokenStream {
 /// [deriving `TypePath`]: TypePath
 #[proc_macro]
 pub fn impl_type_path(input: TokenStream) -> TokenStream {
-    maybe_early_out!(input);
+    maybe_early_out!();
     let def = parse_macro_input!(input as NamedTypePathDef);
 
     let type_path = match def {
@@ -894,7 +894,7 @@ pub fn impl_type_path(input: TokenStream) -> TokenStream {
 /// If you're experiencing linking issues try running `cargo clean` before rebuilding.
 #[proc_macro]
 pub fn load_type_registrations(_input: TokenStream) -> TokenStream {
-    maybe_early_out!(input);
+    maybe_early_out!();
     if !cfg!(feature = "auto_register_static") {
         return TokenStream::new();
     }

--- a/crates/bevy_reflect/derive/src/lib.rs
+++ b/crates/bevy_reflect/derive/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(not(feature = "enable_codegen"), allow(unused))]
 
 //! This crate contains macros used by Bevy's `Reflect` API.
 //!

--- a/crates/bevy_reflect/derive/src/lib.rs
+++ b/crates/bevy_reflect/derive/src/lib.rs
@@ -117,6 +117,21 @@ fn match_reflect_impls(ast: DeriveInput, source: ReflectImplSource) -> TokenStre
     })
 }
 
+#[cfg(feature = "enable_codegen")]
+macro_rules! maybe_early_out {
+    () => {};
+    ($expression:expr) => {};
+}
+#[cfg(not(feature = "enable_codegen"))]
+macro_rules! maybe_early_out {
+    () => {
+        return TokenStream::new();
+    };
+    ($expression:expr) => {
+        return $expression;
+    };
+}
+
 /// The main derive macro used by `bevy_reflect` for deriving its `Reflect` trait.
 ///
 /// This macro can be used on all structs and enums (unions are not supported).
@@ -399,6 +414,7 @@ fn match_reflect_impls(ast: DeriveInput, source: ReflectImplSource) -> TokenStre
 /// [`reflect_trait`]: macro@reflect_trait
 #[proc_macro_derive(Reflect, attributes(reflect, type_path, type_name))]
 pub fn derive_reflect(input: TokenStream) -> TokenStream {
+    maybe_early_out!();
     let ast = parse_macro_input!(input as DeriveInput);
     match_reflect_impls(ast, ReflectImplSource::DeriveLocalType)
 }
@@ -431,6 +447,7 @@ pub fn derive_reflect(input: TokenStream) -> TokenStream {
 /// such as when converting a partially-constructed dynamic type to a concrete one.
 #[proc_macro_derive(FromReflect, attributes(reflect))]
 pub fn derive_from_reflect(input: TokenStream) -> TokenStream {
+    maybe_early_out!();
     let ast = parse_macro_input!(input as DeriveInput);
 
     let derive_data = match ReflectDerive::from_input(
@@ -477,6 +494,7 @@ pub fn derive_from_reflect(input: TokenStream) -> TokenStream {
 /// To use this attribute, `#[type_path = "..."]` must also be specified.
 #[proc_macro_derive(TypePath, attributes(type_path, type_name))]
 pub fn derive_type_path(input: TokenStream) -> TokenStream {
+    maybe_early_out!();
     let ast = parse_macro_input!(input as DeriveInput);
     let derive_data = match ReflectDerive::from_input(
         &ast,
@@ -548,6 +566,7 @@ pub fn derive_type_path(input: TokenStream) -> TokenStream {
 /// [object-safe]: https://doc.rust-lang.org/reference/items/traits.html#object-safety
 #[proc_macro_attribute]
 pub fn reflect_trait(args: TokenStream, input: TokenStream) -> TokenStream {
+    maybe_early_out!(input);
     trait_reflection::reflect_trait(&args, input)
 }
 
@@ -633,6 +652,7 @@ pub fn reflect_trait(args: TokenStream, input: TokenStream) -> TokenStream {
 /// [transmuted]: std::mem::transmute
 #[proc_macro_attribute]
 pub fn reflect_remote(args: TokenStream, input: TokenStream) -> TokenStream {
+    maybe_early_out!(input);
     remote::reflect_remote(args, input)
 }
 
@@ -670,6 +690,7 @@ pub fn reflect_remote(args: TokenStream, input: TokenStream) -> TokenStream {
 /// [deriving `Reflect`]: Reflect
 #[proc_macro]
 pub fn impl_reflect_opaque(input: TokenStream) -> TokenStream {
+    maybe_early_out!(input);
     let def = parse_macro_input!(input with ReflectOpaqueDef::parse_reflect);
 
     let default_name = &def.type_path.segments.last().unwrap().ident;
@@ -734,6 +755,7 @@ pub fn impl_reflect_opaque(input: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro]
 pub fn impl_reflect(input: TokenStream) -> TokenStream {
+    maybe_early_out!(input);
     let ast = parse_macro_input!(input as DeriveInput);
     match_reflect_impls(ast, ReflectImplSource::ImplRemoteType)
 }
@@ -760,6 +782,7 @@ pub fn impl_reflect(input: TokenStream) -> TokenStream {
 /// [derives `Reflect`]: Reflect
 #[proc_macro]
 pub fn impl_from_reflect_opaque(input: TokenStream) -> TokenStream {
+    maybe_early_out!(input);
     let def = parse_macro_input!(input with ReflectOpaqueDef::parse_from_reflect);
 
     let default_name = &def.type_path.segments.last().unwrap().ident;
@@ -825,6 +848,7 @@ pub fn impl_from_reflect_opaque(input: TokenStream) -> TokenStream {
 /// [deriving `TypePath`]: TypePath
 #[proc_macro]
 pub fn impl_type_path(input: TokenStream) -> TokenStream {
+    maybe_early_out!(input);
     let def = parse_macro_input!(input as NamedTypePathDef);
 
     let type_path = match def {
@@ -869,6 +893,7 @@ pub fn impl_type_path(input: TokenStream) -> TokenStream {
 /// If you're experiencing linking issues try running `cargo clean` before rebuilding.
 #[proc_macro]
 pub fn load_type_registrations(_input: TokenStream) -> TokenStream {
+    maybe_early_out!(input);
     if !cfg!(feature = "auto_register_static") {
         return TokenStream::new();
     }

--- a/crates/bevy_remote/Cargo.toml
+++ b/crates/bevy_remote/Cargo.toml
@@ -20,7 +20,7 @@ bevy_derive = { path = "../bevy_derive", version = "0.19.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.19.0-dev", features = [
   "serialize",
 ] }
-bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev", default-features = false }
 bevy_tasks = { path = "../bevy_tasks", version = "0.19.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.19.0-dev", features = [
   "debug",

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -66,7 +66,7 @@ bevy_ecs = { path = "../bevy_ecs", version = "0.19.0-dev" }
 bevy_encase_derive = { path = "../bevy_encase_derive", version = "0.19.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.19.0-dev" }
 bevy_material = { path = "../bevy_material", version = "0.19.0-dev" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev", default-features = false }
 bevy_log = { path = "../bevy_log", version = "0.19.0-dev" }
 bevy_material_macros = { path = "../bevy_material/macros", version = "0.19.0-dev" }
 bevy_render_macros = { path = "../bevy_render/macros", version = "0.19.0-dev" }

--- a/crates/bevy_scene/Cargo.toml
+++ b/crates/bevy_scene/Cargo.toml
@@ -24,7 +24,7 @@ bevy_app = { path = "../bevy_app", version = "0.19.0-dev" }
 bevy_asset = { path = "../bevy_asset", version = "0.19.0-dev" }
 bevy_derive = { path = "../bevy_derive", version = "0.19.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.19.0-dev" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev", default-features = false }
 bevy_transform = { path = "../bevy_transform", version = "0.19.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.19.0-dev" }
 bevy_camera = { path = "../bevy_camera", version = "0.19.0-dev" }

--- a/crates/bevy_shader/Cargo.toml
+++ b/crates/bevy_shader/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["bevy", "shader"]
 [dependencies]
 # bevy
 bevy_asset = { path = "../bevy_asset", version = "0.19.0-dev" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev", default-features = false }
 bevy_platform = { path = "../bevy_platform", version = "0.19.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.19.0-dev" }
 

--- a/crates/bevy_solari/Cargo.toml
+++ b/crates/bevy_solari/Cargo.toml
@@ -26,7 +26,7 @@ bevy_pbr = { path = "../bevy_pbr", version = "0.19.0-dev" }
 bevy_platform = { path = "../bevy_platform", version = "0.19.0-dev", default-features = false, features = [
   "std",
 ] }
-bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev", default-features = false }
 bevy_render = { path = "../bevy_render", version = "0.19.0-dev" }
 bevy_image = { path = "../bevy_image", version = "0.19.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.19.0-dev" }

--- a/crates/bevy_sprite/Cargo.toml
+++ b/crates/bevy_sprite/Cargo.toml
@@ -23,7 +23,7 @@ bevy_camera = { path = "../bevy_camera", version = "0.19.0-dev" }
 bevy_mesh = { path = "../bevy_mesh", version = "0.19.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.19.0-dev" }
 bevy_picking = { path = "../bevy_picking", version = "0.19.0-dev", optional = true }
-bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev", default-features = false }
 bevy_transform = { path = "../bevy_transform", version = "0.19.0-dev" }
 bevy_window = { path = "../bevy_window", version = "0.19.0-dev", optional = true }
 bevy_derive = { path = "../bevy_derive", version = "0.19.0-dev" }

--- a/crates/bevy_sprite_render/Cargo.toml
+++ b/crates/bevy_sprite_render/Cargo.toml
@@ -28,7 +28,7 @@ bevy_shader = { path = "../bevy_shader", version = "0.19.0-dev" }
 bevy_material = { path = "../bevy_material", version = "0.19.0-dev" }
 bevy_sprite = { path = "../bevy_sprite", version = "0.19.0-dev" }
 bevy_text = { path = "../bevy_text", version = "0.19.0-dev", optional = true }
-bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev", default-features = false }
 bevy_render = { path = "../bevy_render", version = "0.19.0-dev" }
 bevy_transform = { path = "../bevy_transform", version = "0.19.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.19.0-dev" }

--- a/crates/bevy_text/Cargo.toml
+++ b/crates/bevy_text/Cargo.toml
@@ -21,7 +21,7 @@ bevy_ecs = { path = "../bevy_ecs", version = "0.19.0-dev" }
 bevy_image = { path = "../bevy_image", version = "0.19.0-dev" }
 bevy_log = { path = "../bevy_log", version = "0.19.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.19.0-dev" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev", default-features = false }
 bevy_utils = { path = "../bevy_utils", version = "0.19.0-dev" }
 bevy_platform = { path = "../bevy_platform", version = "0.19.0-dev", default-features = false, features = [
   "std",

--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -22,7 +22,7 @@ bevy_input = { path = "../bevy_input", version = "0.19.0-dev" }
 bevy_input_focus = { path = "../bevy_input_focus", version = "0.19.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.19.0-dev" }
 bevy_log = { path = "../bevy_log", version = "0.19.0-dev" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev", default-features = false }
 bevy_sprite = { path = "../bevy_sprite", version = "0.19.0-dev", features = [
   "bevy_text",
 ] }

--- a/crates/bevy_ui_render/Cargo.toml
+++ b/crates/bevy_ui_render/Cargo.toml
@@ -20,7 +20,7 @@ bevy_ecs = { path = "../bevy_ecs", version = "0.19.0-dev" }
 bevy_image = { path = "../bevy_image", version = "0.19.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.19.0-dev" }
 bevy_mesh = { path = "../bevy_mesh", version = "0.19.0-dev" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev", default-features = false }
 bevy_shader = { path = "../bevy_shader", version = "0.19.0-dev" }
 bevy_render = { path = "../bevy_render", version = "0.19.0-dev" }
 bevy_sprite = { path = "../bevy_sprite", version = "0.19.0-dev" }

--- a/crates/bevy_ui_widgets/Cargo.toml
+++ b/crates/bevy_ui_widgets/Cargo.toml
@@ -19,7 +19,7 @@ bevy_input_focus = { path = "../bevy_input_focus", version = "0.19.0-dev" }
 bevy_log = { path = "../bevy_log", version = "0.19.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.19.0-dev" }
 bevy_picking = { path = "../bevy_picking", version = "0.19.0-dev" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev", default-features = false }
 bevy_ui = { path = "../bevy_ui", version = "0.19.0-dev" }
 
 # other

--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -44,7 +44,7 @@ bevy_input = { path = "../bevy_input", version = "0.19.0-dev" }
 bevy_input_focus = { path = "../bevy_input_focus", version = "0.19.0-dev" }
 bevy_log = { path = "../bevy_log", version = "0.19.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.19.0-dev" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev", default-features = false }
 bevy_window = { path = "../bevy_window", version = "0.19.0-dev" }
 bevy_tasks = { path = "../bevy_tasks", version = "0.19.0-dev" }
 bevy_platform = { path = "../bevy_platform", version = "0.19.0-dev", default-features = false, features = [

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -40,7 +40,7 @@ collections to build your own "profile" equivalent, without needing to manually 
 |audio|Features used to build audio Bevy apps. **Feature set:** `bevy_audio`, `vorbis`.|
 |scene|Features used to compose Bevy scenes. **Feature set:** `bevy_scene`.|
 |picking|Enables picking functionality. **Feature set:** `bevy_picking`, `mesh_picking`, `sprite_picking`, `ui_picking`.|
-|default_app|The core pieces that most apps need. This serves as a baseline feature set for other higher level feature collections (such as "2d" and "3d"). It is also useful as a baseline feature set for scenarios like headless apps that require no rendering (ex: command line tools, servers, etc). **Feature set:** `async_executor`, `bevy_asset`, `bevy_input_focus`, `bevy_log`, `bevy_state`, `bevy_window`, `custom_cursor`, `reflect_auto_register`.|
+|default_app|The core pieces that most apps need. This serves as a baseline feature set for other higher level feature collections (such as "2d" and "3d"). It is also useful as a baseline feature set for scenarios like headless apps that require no rendering (ex: command line tools, servers, etc). **Feature set:** `async_executor`, `bevy_asset`, `bevy_input_focus`, `bevy_log`, `bevy_state`, `bevy_window`, `custom_cursor`, `reflection`, `reflect_auto_register`.|
 |default_platform|These are platform support features, such as OS support/features, windowing and input backends, etc. **Feature set:** `std`, `android-game-activity`, `android_shared_stdcxx`, `bevy_gilrs`, `bevy_winit`, `default_font`, `multi_threaded`, `webgl2`, `x11`, `wayland`, `sysinfo_plugin`.|
 |common_api|Default scene definition features. Note that this does not include an actual renderer, such as bevy_render (Bevy's default render backend). **Feature set:** `bevy_animation`, `bevy_camera`, `bevy_color`, `bevy_gizmos`, `bevy_image`, `bevy_mesh`, `bevy_shader`, `bevy_material`, `bevy_text`, `hdr`, `png`.|
 |2d_api|Features used to build 2D Bevy apps (does not include a render backend). You generally don't need to worry about this unless you are using a custom renderer. **Feature set:** `common_api`, `bevy_sprite`.|
@@ -164,6 +164,7 @@ This is the complete `bevy` cargo feature list, without "profiles" or "collectio
 |reflect_auto_register_static|Enable automatic reflect registration without inventory. See `reflect::load_type_registrations` for more info.|
 |reflect_documentation|Enables bevy_reflect to access documentation comments of rust code at runtime|
 |reflect_functions|Enable function reflection|
+|reflection|Enable reflection.|
 |serialize|Enable serialization support through serde|
 |shader_format_glsl|Enable support for shaders in GLSL|
 |shader_format_spirv|Enable support for shaders in SPIR-V|


### PR DESCRIPTION
# Objective

- Make it possible to disable reflection

## Solution

- add a default "enable_codegen" feature which must be set, otherwise all bevy_reflect proc macros behave as no-op passthrough.
- forward it to root cargo toml through bevy_internal, add it to default app feature collection
- make all existing usage of bevy_reflect in the repo default-features=false so that this feature collection is the only thing enabling it

## Testing

- this is entirely untested, i didnt even check if it compiled im going to sleep