### PR TITLE
Add padding for color_plane widget for wasm/webgl compat

### DIFF
--- a/crates/bevy_feathers/Cargo.toml
+++ b/crates/bevy_feathers/Cargo.toml
@@ -40,6 +40,8 @@ accesskit = "0.23"
 [features]
 default = []
 custom_cursor = ["bevy_window/custom_cursor"]
+webgl = []
+webgpu = []
 
 [lints]
 workspace = true

--- a/crates/bevy_feathers/src/assets/shaders/color_plane.wgsl
+++ b/crates/bevy_feathers/src/assets/shaders/color_plane.wgsl
@@ -5,21 +5,28 @@
     hsl_to_linear_rgb,
 }
 
-@group(1) @binding(0) var<uniform> fixed_channel: f32;
+struct ColorPlaneUniform {
+  fixed_channel : f32,
+#ifdef SIXTEEN_BYTE_ALIGNMENT
+  _webgl2_padding_12b : vec3<f32>,
+#endif
+}
+
+@group(1) @binding(0) var<uniform> uniform_data : ColorPlaneUniform;
 
 @fragment
 fn fragment(in: UiVertexOutput) -> @location(0) vec4<f32> {
     let uv = in.uv;
 #ifdef PLANE_RG
-    return vec4(srgb_to_linear_rgb(vec3(uv.x, uv.y, fixed_channel)), 1.0);
+    return vec4(srgb_to_linear_rgb(vec3(uv.x, uv.y, uniform_data.fixed_channel)), 1.0);
 #else ifdef PLANE_RB
-    return vec4(srgb_to_linear_rgb(vec3(uv.x, fixed_channel, uv.y)), 1.0);
+    return vec4(srgb_to_linear_rgb(vec3(uv.x, uniform_data.fixed_channel, uv.y)), 1.0);
 #else ifdef PLANE_GB
-    return vec4(srgb_to_linear_rgb(vec3(fixed_channel, uv.x, uv.y)), 1.0);
+    return vec4(srgb_to_linear_rgb(vec3(uniform_data.fixed_channel, uv.x, uv.y)), 1.0);
 #else ifdef PLANE_HS
-    return vec4(hsl_to_linear_rgb(vec3(uv.x, 1.0 - uv.y, fixed_channel)), 1.0);
+    return vec4(hsl_to_linear_rgb(vec3(uv.x, 1.0 - uv.y, uniform_data.fixed_channel)), 1.0);
 #else ifdef PLANE_HL
-    return vec4(hsl_to_linear_rgb(vec3(uv.x, fixed_channel, 1.0 - uv.y)), 1.0);
+    return vec4(hsl_to_linear_rgb(vec3(uv.x, uniform_data.fixed_channel, 1.0 - uv.y)), 1.0);
 #else
     // Error color
     return vec4(1.0, 0.0, 1.0, 1.0);

--- a/crates/bevy_feathers/src/controls/color_plane.rs
+++ b/crates/bevy_feathers/src/controls/color_plane.rs
@@ -84,6 +84,10 @@ struct ColorPlaneMaterial {
 
     #[uniform(0)]
     fixed_channel: f32,
+
+    #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
+    #[uniform(0)]
+    _webgl2_padding_12b: Vec3,
 }
 
 impl From<&ColorPlaneMaterial> for ColorPlaneMaterialKey {
@@ -207,6 +211,8 @@ fn update_plane_color(
             let material = r_materials.add(ColorPlaneMaterial {
                 plane: *plane,
                 fixed_channel: plane_value.0.z,
+                #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
+                _webgl2_padding_12b: Default::default(),
             });
             commands.entity(*inner_ent).insert(MaterialNode(material));
         }

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -191,6 +191,7 @@ webgl = [
   "bevy_gizmos_render?/webgl",
   "bevy_sprite_render?/webgl",
   "bevy_dev_tools?/webgl",
+  "bevy_feathers?/webgl",
 ]
 
 webgpu = [
@@ -201,6 +202,7 @@ webgpu = [
   "bevy_gizmos_render?/webgpu",
   "bevy_sprite_render?/webgpu",
   "bevy_dev_tools?/webgpu",
+  "bevy_feathers?/webgpu",
 ]
 
 # Enable systems that allow for automated testing on CI


### PR DESCRIPTION
# Objective

- Describe the objective or issue this PR addresses.
- If you're fixing a specific issue, say "Fixes #X".

The new bevy feathers color plane widget throws out wgpu alignment issues for the f32 in use. To enable wasm builds to use this widget add padding similar to the existing shaders/materials.

Note this is my first contribution, I yolo'd names and whatnot so if the names I chose suck I can change them I'm not wedded to the names.

## Solution

- Describe the solution used to achieve the objective above.

Add a Vec3 padding to the uniform and material struct to pad to 16 bytes on wasm builds.

## Testing

- Did you test these changes? If so, how?

Yep built before/after in linux (wayland though I could test X if pressed), macos, and windows. Those all continued to work as expected as they did before. And tested in wasm on safari/firefox/chrome (mostly latest versions I think of those) where all 3 couldn't render the shader widget with this fix in place as a cargo patch its all good and works the same as the native builds.

- Are there any parts that need more testing?

Maybe? I'm not sure I know enough to speak with any authority to that. I literally never program for the web this is all a fun side project in wasm for me and I honestly don't know if I did this jazz right or not. Real web programmers should yea/nay these bits I'm just a tourist.

- How can other people (reviewers) test your changes? Is there anything specific they need to know?

Just test/build on wasm with the color widget in place. All I did was use cargo patch to point to the fixed version like so:

Same patch against 0.18.1 release branch:
```
bevy = { git = "https://github.com/mitchty/bevy", branch = "colorplane-wasm" }
```

This branch:
```
bevy = { git = "https://github.com/mitchty/bevy", branch = "colorplane-wasm-fix" }
```

- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?

I tried testing on all the systems I setup cross compilation for which is most of em methinks/mehopes.

