### PR TITLE
update fullscreen material example comment to be clear about 2d support

### DIFF
--- a/examples/shader_advanced/fullscreen_material.rs
+++ b/examples/shader_advanced/fullscreen_material.rs
@@ -1,8 +1,9 @@
 //! Demonstrates how to write a custom fullscreen shader
 //!
 //! This example demonstrates working in 3d. To make the example work in 2d,
-//! replace `Node3d` with `Node2d`, use a `Camera2d`, and spawn `Mesh2d` instead
-//! of `Mesh3d`.
+//! replace 3d components with their 2d counterparts, and schedule the work
+//! to run in the `Core2d` schedule as described in the `FullscreenMaterial`
+//! comment in this file.
 
 use bevy::{
     core_pipeline::fullscreen_material::{FullscreenMaterial, FullscreenMaterialPlugin},
@@ -54,5 +55,14 @@ impl FullscreenMaterial for FullscreenEffect {
         "shaders/fullscreen_effect.wgsl".into()
     }
 
-    // Uses default run_in (Core3dSystems::PostProcess)
+    // The `FullscreenMaterial` uses 3d schedules by default.
+    // To make this work in 2d, you would need to schedule to
+    // run in `Core2d` and in a `Core2dSystems` set.
+    //
+    // fn schedule() -> impl bevy::ecs::schedule::ScheduleLabel + Clone {
+    //     bevy::core_pipeline::Core2d
+    // }
+    // fn run_in() -> impl SystemSet {
+    //     bevy::core_pipeline::Core2dSystems::PostProcess
+    // }
 }


### PR DESCRIPTION
# Objective

Due to comments in the current fullscreen material example, some users have thought that fullscreenmaterial doesn't work in 2d. It does.

## Solution

Update the comment to reflect the fact that this works with 2d, the example is just showcasing 3d.

## Showcase

Rectangle and Circle after swapping "3d" for "2d" in all example locations.

<img width="484" height="420" alt="image" src="https://github.com/user-attachments/assets/1711c67b-2166-4777-b1d4-09d283c5a162" />

<img width="1082" height="1040" alt="image" src="https://github.com/user-attachments/assets/9a331f95-d327-48cc-8823-fe84d1c86aef" />
