### PR TITLE
Make DepthOfField default respect DepthOfFieldMode default

### DIFF
--- a/crates/bevy_post_process/src/dof/mod.rs
+++ b/crates/bevy_post_process/src/dof/mod.rs
@@ -319,7 +319,7 @@ impl Default for DepthOfField {
             sensor_height: physical_camera_default.sensor_height,
             max_circle_of_confusion_diameter: 64.0,
             max_depth: f32::INFINITY,
-            mode: DepthOfFieldMode::Bokeh,
+            mode: DepthOfFieldMode::default(),
         }
     }
 }


### PR DESCRIPTION
# Objective

The default value for DepthOfFieldMode is Gaussian, but the default implementation of DepthOfField uses Bokeh.

Old version:
```rust
pub enum DepthOfFieldMode {
    /// ...
    Bokeh,

    /// ...
    /// This is the default.
    /// ...
    #[default]
    Gaussian,
}

impl Default for DepthOfField {
    fn default() -> Self {
        // ...
        Self {
            // ...
            mode: DepthOfFieldMode::Bokeh,
        }
    }
}
```

## Solution

This PR updates DepthOfField to use the default value of DepthOfFieldMode.

## Testing
The depth of field example compiles and runs. I adjusted it to use the default mode of DepthOfField and it correctly uses Gaussian now.
