### PR TITLE
Rename the `system_fonts` example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5360,7 +5360,7 @@ path = "examples/ui/system_fonts.rs"
 doc-scrape-examples = true
 
 [package.metadata.example.system_fonts]
-name = "system_fonts"
+name = "System Fonts"
 description = "Demonstrates how to use system fonts"
 category = "UI (User Interface)"
 wasm = true

--- a/examples/README.md
+++ b/examples/README.md
@@ -597,6 +597,7 @@ Example | Description
 [Standard Widgets](../examples/ui/standard_widgets.rs) | Demonstrates use of core (headless) widgets in Bevy UI
 [Standard Widgets (w/Observers)](../examples/ui/standard_widgets_observers.rs) | Demonstrates use of core (headless) widgets in Bevy UI, with Observers
 [Strikethrough and Underline](../examples/ui/strikethrough_and_underline.rs) | Demonstrates how to display text with strikethrough and underline.
+[System Fonts](../examples/ui/system_fonts.rs) | Demonstrates how to use system fonts
 [Tab Navigation](../examples/ui/tab_navigation.rs) | Demonstration of Tab Navigation between UI elements
 [Text](../examples/ui/text.rs) | Illustrates creating and updating text
 [Text Background Colors](../examples/ui/text_background_colors.rs) | Demonstrates text background colors
@@ -617,7 +618,6 @@ Example | Description
 [Viewport Node](../examples/ui/viewport_node.rs) | Demonstrates how to create a viewport node with picking support
 [Virtual Keyboard](../examples/ui/virtual_keyboard.rs) | Example demonstrating a virtual keyboard widget
 [Window Fallthrough](../examples/ui/window_fallthrough.rs) | Illustrates how to access `winit::window::Window`'s `hittest` functionality.
-[system_fonts](../examples/ui/system_fonts.rs) | Demonstrates how to use system fonts
 
 ### Usage
 


### PR DESCRIPTION
# Objective

The "system_fonts" example's name in its package meta data is the same as its filename, when the names of the other examples are capitalized and use spaces.

## Solution

Rename it.