### PR TITLE
Adds and (mostly) Implements an `Obb2d` `BoundingVolume` - 2D Oriented Bounding Boxes

### DIFF
--- a/crates/bevy_math/src/bounding/bounded2d/mod.rs
+++ b/crates/bevy_math/src/bounding/bounded2d/mod.rs
@@ -871,10 +871,10 @@ impl BoundingVolume for Obb2d {
 
     #[inline]
     fn contains(&self, other: &Self) -> bool {
-        // Convert the corners of `other` into this OBB's coordinate system.
         let other_corners = other.get_corners();
         // Check whether all corners are within the bounds of this OBB
         other_corners.iter().all(|&point| {
+            // Transform the corner into this OBB's coordinate system.
             let local_corner = self.isometry.inverse().transform_point(point);
             local_corner.x <= self.half_size.x
                 && local_corner.x >= -self.half_size.x
@@ -1012,6 +1012,7 @@ impl IntersectsVolume<Self> for Obb2d {
     }
 }
 
+#[inline]
 fn projections_have_overlap(
     normal: &Vec2,
     self_points: &[Vec2; 4],


### PR DESCRIPTION
# Objective
- See if there is appetite for Oriented Bounding Boxes in `bevy_math`. In #10570 , there was a mention of adding an OBB bounding volume as an option for primitives, so I get the impression that OBB’s could be useful.
- #13945 mentions creating an `Obb3d` if we pursue removing `Sphere` from what is now `bevy_camera`. It mentions that an `Obb3d` can also be useful outside of rendering. To warm up to doing this, I explored creating and implementing an `Obb2d` type first. The `Obb3d` struct would basically be what is in this PR but for three dimensions.

## Solution

- Creates and implements an `Obb2d` that also implements `BoundingVolume` and can detect collisions with the other two 2d bounding volume types (`Aabb2d` and `BoundingCircle`).
- This does NOT include `Obb2d` in the `Bounded2d` trait. I figured this can be done as a follow up if we feel good about having what I have written for `Obb2d`.
- `merge` is basically stubbed with a created `Aabb2d` from the two `Obb2d`’s converted back to an `Obb2d`. It is not really implemented in true OBB fashion because that seems more complicated to implement, given that the function specifies it should be the “smallest” bounding volume. If possible, I’d like to explore if we can merge this without it truly implemented and have an issue to follow up to really implement it (another math person can help out with implementing that too!). 

## Testing

- Added unit tests for the important things
