### PR TITLE
Remove unused 'experimental' folder in bevy_core_pipeline

### DIFF
--- a/crates/bevy_core_pipeline/src/experimental/mod.rs
+++ b/crates/bevy_core_pipeline/src/experimental/mod.rs
@@ -1,7 +1,0 @@
-//! Experimental rendering features.
-//!
-//! Experimental features are features with known problems, missing features,
-//! compatibility issues, low performance, and/or future breaking changes, but
-//! are included nonetheless for testing purposes.
-
-pub mod depth;


### PR DESCRIPTION
# Objective

- The 'experimental' module is currently not used.
- A similar experimental module exists under the `mip_generation` folder, which is fully implemented and actively used.

## Solution

- Simply remove the top-level `experimental` folder.

## Testing

- CI

---
