### PR TITLE
Remove unused `ScreenSpaceReflectionNode`.

### DIFF
--- a/crates/bevy_pbr/src/ssr/mod.rs
+++ b/crates/bevy_pbr/src/ssr/mod.rs
@@ -160,10 +160,6 @@ pub struct ScreenSpaceReflectionsUniform {
     use_secant: u32,
 }
 
-/// The node in the render graph that traces screen space reflections.
-#[derive(Default)]
-pub struct ScreenSpaceReflectionsNode;
-
 /// Identifies which screen space reflections render pipeline a view needs.
 #[derive(Component, Deref, DerefMut)]
 pub struct ScreenSpaceReflectionsPipelineId(pub CachedRenderPipelineId);


### PR DESCRIPTION
# Objective

- Since `RenderGraph` and `ViewNode` have been removed in favor of systems, the `ScreenSpaceReflectionNode` is no longer needed.

## Solution

- I just deleted the struct.

## Testing

- CI

---
