### PR TITLE
Use the shorthand functions to construct Vals and UiRects in examples

### DIFF
--- a/examples/large_scenes/bistro/src/main.rs
+++ b/examples/large_scenes/bistro/src/main.rs
@@ -307,8 +307,8 @@ pub fn setup(mut commands: Commands, asset_server: Res<AssetServer>, args: Res<A
         commands
             .spawn((
                 Node {
-                    left: Val::Px(1.5),
-                    top: Val::Px(1.5),
+                    left: px(1.5),
+                    top: px(1.5),
                     ..default()
                 },
                 GlobalZIndex(-1),

--- a/examples/large_scenes/caldera_hotel/src/main.rs
+++ b/examples/large_scenes/caldera_hotel/src/main.rs
@@ -244,8 +244,8 @@ pub fn setup(
         commands
             .spawn((
                 Node {
-                    left: Val::Px(1.5),
-                    top: Val::Px(1.5),
+                    left: px(1.5),
+                    top: px(1.5),
                     ..default()
                 },
                 GlobalZIndex(-1),

--- a/examples/large_scenes/mipmap_generator/src/lib.rs
+++ b/examples/large_scenes/mipmap_generator/src/lib.rs
@@ -155,8 +155,8 @@ fn init_loading_text(mut commands: Commands) {
     commands
         .spawn((
             Node {
-                left: Val::Px(1.5),
-                top: Val::Px(1.5),
+                left: px(1.5),
+                top: px(1.5),
                 ..default()
             },
             GlobalZIndex(-1),

--- a/examples/picking/dragdrop_picking.rs
+++ b/examples/picking/dragdrop_picking.rs
@@ -49,9 +49,9 @@ fn setup(
                 .spawn((
                     DraggableButton,
                     Node {
-                        width: Val::Px(BUTTON_WIDTH),
-                        height: Val::Px(BUTTON_HEIGHT),
-                        margin: UiRect::all(Val::Px(10.0)),
+                        width: px(BUTTON_WIDTH),
+                        height: px(BUTTON_HEIGHT),
+                        margin: UiRect::all(px(10.0)),
                         justify_content: JustifyContent::Center,
                         align_items: AlignItems::Center,
                         ..default()

--- a/examples/shader_advanced/render_depth_to_texture.rs
+++ b/examples/shader_advanced/render_depth_to_texture.rs
@@ -281,8 +281,8 @@ fn spawn_instructions(commands: &mut Commands) {
         Text::new("Use WASD to move the secondary camera"),
         Node {
             position_type: PositionType::Absolute,
-            top: Val::Px(12.0),
-            left: Val::Px(12.0),
+            top: px(12.0),
+            left: px(12.0),
             ..Node::default()
         },
     ));

--- a/examples/ui/images/image_node.rs
+++ b/examples/ui/images/image_node.rs
@@ -30,8 +30,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             ImageNode::new(asset_server.load("branding/icon.png")),
             // Child Node control `ImageNode` size
             Node {
-                width: Val::Px(256.),
-                height: Val::Px(256.),
+                width: px(256.),
+                height: px(256.),
                 ..default()
             }
         )],

--- a/examples/ui/layout/anchor_layout.rs
+++ b/examples/ui/layout/anchor_layout.rs
@@ -49,14 +49,14 @@ fn spawn_layout(mut commands: Commands, asset_server: Res<AssetServer>) {
             "left: 10px\ncenter: 10px",
             Node {
                 left: px(10),
-                margin: UiRect::vertical(Val::Auto),
+                margin: UiRect::vertical(auto()),
                 ..default()
             },
         ),
         (
             "center: 10px\ncenter: 10px",
             Node {
-                margin: UiRect::all(Val::Auto),
+                margin: UiRect::all(auto()),
                 ..default()
             },
         ),
@@ -64,7 +64,7 @@ fn spawn_layout(mut commands: Commands, asset_server: Res<AssetServer>) {
             "right: 10px\ncenter: 10px",
             Node {
                 right: px(10),
-                margin: UiRect::vertical(Val::Auto),
+                margin: UiRect::vertical(auto()),
                 ..default()
             },
         ),
@@ -79,7 +79,7 @@ fn spawn_layout(mut commands: Commands, asset_server: Res<AssetServer>) {
         (
             "center: 10px\nbottom: 10px",
             Node {
-                margin: UiRect::horizontal(Val::Auto),
+                margin: UiRect::horizontal(auto()),
                 bottom: px(10),
                 ..default()
             },

--- a/examples/ui/render_ui_to_texture.rs
+++ b/examples/ui/render_ui_to_texture.rs
@@ -92,11 +92,11 @@ fn setup(
                 .spawn((
                     Node {
                         position_type: PositionType::Absolute,
-                        width: Val::Auto,
-                        height: Val::Auto,
+                        width: auto(),
+                        height: auto(),
                         align_items: AlignItems::Center,
-                        padding: UiRect::all(Val::Px(20.)),
-                        border_radius: BorderRadius::all(Val::Px(10.)),
+                        padding: UiRect::all(px(20.)),
+                        border_radius: BorderRadius::all(px(10.)),
                         ..default()
                     },
                     BackgroundColor(BLUE.into()),
@@ -104,9 +104,8 @@ fn setup(
                 .observe(
                     |drag: On<Pointer<Drag>>, mut nodes: Query<(&mut Node, &ComputedNode)>| {
                         let (mut node, computed) = nodes.get_mut(drag.entity).unwrap();
-                        node.left =
-                            Val::Px(drag.pointer_location.position.x - computed.size.x / 2.0);
-                        node.top = Val::Px(drag.pointer_location.position.y - 50.0);
+                        node.left = px(drag.pointer_location.position.x - computed.size.x / 2.0);
+                        node.top = px(drag.pointer_location.position.y - 50.0);
                     },
                 )
                 .observe(

--- a/examples/ui/text/text.rs
+++ b/examples/ui/text/text.rs
@@ -86,10 +86,10 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands
         .spawn((
             Node {
-                margin: UiRect::all(Val::Px(12.0)),
+                margin: UiRect::all(px(12.0)),
                 position_type: PositionType::Absolute,
-                top: Val::Px(5.0),
-                right: Val::Px(5.0),
+                top: px(5.0),
+                right: px(5.0),
                 ..default()
             },
             Text::new("Opentype features:\n"),

--- a/examples/window/multi_window_text.rs
+++ b/examples/window/multi_window_text.rs
@@ -54,8 +54,8 @@ fn setup_scene(mut commands: Commands) {
 
     let node = Node {
         position_type: PositionType::Absolute,
-        top: Val::Px(12.0),
-        left: Val::Px(12.0),
+        top: px(12.0),
+        left: px(12.0),
         ..default()
     };
 


### PR DESCRIPTION
# Objective

- Fixes #22753 

## Solution

- Replace `Val::Px`  and `Val::Auto` with `px()` and `auto()` in examples

## Testing

- None
