### PR TITLE
Feature/populated message reader

### DIFF
--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -74,7 +74,9 @@ pub mod prelude {
         event::{EntityEvent, Event},
         hierarchy::{ChildOf, ChildSpawner, ChildSpawnerCommands, Children},
         lifecycle::{Add, Despawn, Insert, Remove, RemovedComponents, Replace},
-        message::{Message, MessageMutator, MessageReader, MessageWriter, Messages},
+        message::{
+            Message, MessageMutator, MessageReader, MessageWriter, Messages, PopulatedMessageReader,
+        },
         name::{Name, NameOrEntity},
         observer::{Observer, On},
         query::{Added, Allow, AnyOf, Changed, Has, Or, QueryBuilder, QueryState, With, Without},

--- a/crates/bevy_ecs/src/message/message_reader.rs
+++ b/crates/bevy_ecs/src/message/message_reader.rs
@@ -120,6 +120,8 @@ impl<'w, 's, M: Message> MessageReader<'w, 's, M> {
 /// Skips the system if there no messages.
 ///
 /// Use [`MessageReader<T>`] to run the system even if there are no messages.
+///
+/// Use the [`on_message`](crate::prelude::on_message) run condition to skip the system based on messages that it doesn't read.
 #[derive(Debug)]
 pub struct PopulatedMessageReader<'w, 's, M: Message>(MessageReader<'w, 's, M>);
 

--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -828,6 +828,8 @@ pub mod common_conditions {
     /// A [`SystemCondition`]-satisfying system that returns `true`
     /// if there are any new messages of the given type since it was last called.
     ///
+    /// To skip a system based on messages that it reads, use [`PopulatedMessageReader`](crate::prelude::PopulatedMessageReader) instead.
+    ///
     /// # Example
     ///
     /// ```


### PR DESCRIPTION
# Objective

Offer a way to skip a system that reads messages if there are no messages that need to be read.

## Solution

Add a `SystemParam`: `PopulatedMessageReader`.

## Testing

I added a test case