### PR TITLE
Exposing methods in `PipelineCache` for outside usage

### DIFF
--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -719,7 +719,7 @@ impl PipelineCache {
         self.waiting_pipelines.insert(id);
     }
 
-    fn process_pipeline_queue_system(mut cache: ResMut<Self>) {
+    pub(crate) fn process_pipeline_queue_system(mut cache: ResMut<Self>) {
         cache.process_queue();
     }
 


### PR DESCRIPTION
# Objective

if we expose 3 methods in the `PipelineCache`
- `set_shader`
- `remove_shader`
- `process_pipeline_queue_system`

then we enable external crates to setup their own pipelines using the `PipelineCache`.

Specifically for https://github.com/Kjolnyr/bevy_app_compute we need to duplicate the entire `PipelineCache` just to get access to these methods. If these are public, we will be able to merge this change in: https://github.com/Kjolnyr/bevy_app_compute/pull/27 (completely removing the massive duplication of code).

## Solution

Make the methods public + add some docs.

## Testing

Bevy still compiles :sunglasses:

## Showcase

In bevy_app_compute: https://github.com/Kjolnyr/bevy_app_compute/pull/27
