### PR TITLE
reflect imagesampler

### DIFF
--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -615,6 +615,11 @@ pub struct Image {
 /// [`ImageSampler::Default`], will read the sampler from the `ImagePlugin` at setup.
 /// Setting this to [`ImageSampler::Descriptor`] will override the global default descriptor for this [`Image`].
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(
+    feature = "bevy_reflect",
+    derive(Reflect),
+    reflect(Default, Debug, Clone)
+)]
 pub enum ImageSampler {
     /// Default image sampler, derived from the `ImagePlugin` setup.
     #[default]
@@ -660,6 +665,11 @@ impl ImageSampler {
 ///
 /// This type mirrors [`AddressMode`].
 #[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(
+    feature = "bevy_reflect",
+    derive(Reflect),
+    reflect(Default, Debug, Clone)
+)]
 pub enum ImageAddressMode {
     /// Clamp the value to the edge of the texture.
     ///
@@ -689,6 +699,11 @@ pub enum ImageAddressMode {
 ///
 /// This type mirrors [`FilterMode`].
 #[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(
+    feature = "bevy_reflect",
+    derive(Reflect),
+    reflect(Default, Debug, Clone)
+)]
 pub enum ImageFilterMode {
     /// Nearest neighbor sampling.
     ///
@@ -705,6 +720,7 @@ pub enum ImageFilterMode {
 ///
 /// This type mirrors [`CompareFunction`].
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Debug, Clone))]
 pub enum ImageCompareFunction {
     /// Function never passes
     Never,
@@ -732,6 +748,7 @@ pub enum ImageCompareFunction {
 ///
 /// This type mirrors [`SamplerBorderColor`].
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Debug, Clone))]
 pub enum ImageSamplerBorderColor {
     /// RGBA color `[0, 0, 0, 0]`.
     TransparentBlack,
@@ -755,6 +772,11 @@ pub enum ImageSamplerBorderColor {
 ///
 /// This types mirrors [`SamplerDescriptor`], but that might change in future versions.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(
+    feature = "bevy_reflect",
+    derive(Reflect),
+    reflect(Default, Debug, Clone)
+)]
 pub struct ImageSamplerDescriptor {
     pub label: Option<String>,
     /// How to deal with out of bounds accesses in the u (i.e. x) direction.


### PR DESCRIPTION
# Objective

I'm working on `Handle<Image>` support for [skein](https://bevyskein.dev/).
`ImageSampler` doesn't implement `Reflect`, so doesn't exist in the registry, but this is the definitive "what a sampler is" type for Bevy, and "Image" in Bevy is image data + sampler. So I want to allow people to define a real Bevy Sampler for their image data.

## Solution

`Reflect` `ImageSampler` to make it available to use.

## Testing

I ran the `3d_scene` to make sure it didn't crash, and the reflect/serialization example with `::default()` and `::nearest()`:

```json
{
    "bevy_image::image::ImageSampler": "Default"
}
```

```json
{
  "bevy_image::image::ImageSampler": {
    "Descriptor": {
      "label": null,
      "address_mode_u": "ClampToEdge",
      "address_mode_v": "ClampToEdge",
      "address_mode_w": "ClampToEdge",
      "mag_filter": "Nearest",
      "min_filter": "Nearest",
      "mipmap_filter": "Nearest",
      "lod_min_clamp": 0.0,
      "lod_max_clamp": 32.0,
      "compare": null,
      "anisotropy_clamp": 1,
      "border_color": null
    }
  }
}
```