### PR TITLE
Fallback to borderless fullscreen when monitor is unavailable

### DIFF
--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -1363,6 +1363,12 @@ pub enum WindowMode {
     /// the window's logical size may be different from its physical size.
     /// If you want to avoid that behavior, you can use the [`WindowResolution::set_scale_factor_override`] function
     /// or the [`WindowResolution::with_scale_factor_override`] builder method to set the scale factor to 1.0.
+    ///
+    /// Note: Exclusive fullscreen is not available on all platforms (for example
+    /// Wayland does not expose video mode switching to clients). When the selected
+    /// monitor or video mode cannot be resolved, the window falls back to
+    /// [`WindowMode::BorderlessFullscreen`] on the same monitor selection and a
+    /// warning is logged.
     Fullscreen(MonitorSelection, VideoModeSelection),
 }
 

--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -28,7 +28,7 @@ use crate::{
         convert_enabled_buttons, convert_resize_direction, convert_window_level,
         convert_window_theme, convert_winit_theme,
     },
-    get_selected_videomode, select_monitor,
+    resolve_exclusive_fullscreen, select_monitor,
     state::react_to_resize,
     winit_monitors::WinitMonitors,
     CreateMonitorParams, CreateWindowParams, WINIT_WINDOWS,
@@ -334,26 +334,17 @@ pub(crate) fn changed_windows(
                         ))))
                     }
                     WindowMode::Fullscreen(monitor_selection, video_mode_selection) => {
-                        let monitor = &select_monitor(
+                        let monitor = select_monitor(
                             &monitors,
                             winit_window.primary_monitor(),
                             winit_window.current_monitor(),
                             &monitor_selection,
-                        )
-                        .unwrap_or_else(|| {
-                            panic!("Could not find monitor for {monitor_selection:?}")
-                        });
-
-                        if let Some(video_mode) = get_selected_videomode(monitor, &video_mode_selection)
-                        {
-                            Some(Some(winit::window::Fullscreen::Exclusive(video_mode)))
-                        } else {
-                            warn!(
-                                "Could not find valid fullscreen video mode for {:?} {:?}",
-                                monitor_selection, video_mode_selection
-                            );
-                            None
-                        }
+                        );
+                        Some(Some(resolve_exclusive_fullscreen(
+                            monitor,
+                            monitor_selection,
+                            video_mode_selection,
+                        )))
                     }
                     WindowMode::Windowed => Some(None),
                 };

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -85,21 +85,11 @@ impl WinitWindows {
             WindowMode::BorderlessFullscreen(_) => winit_window_attributes
                 .with_fullscreen(Some(Fullscreen::Borderless(maybe_selected_monitor.clone()))),
             WindowMode::Fullscreen(monitor_selection, video_mode_selection) => {
-                let select_monitor = &maybe_selected_monitor
-                    .clone()
-                    .expect("Unable to get monitor.");
-
-                if let Some(video_mode) =
-                    get_selected_videomode(select_monitor, &video_mode_selection)
-                {
-                    winit_window_attributes.with_fullscreen(Some(Fullscreen::Exclusive(video_mode)))
-                } else {
-                    warn!(
-                        "Could not find valid fullscreen video mode for {:?} {:?}",
-                        monitor_selection, video_mode_selection
-                    );
-                    winit_window_attributes
-                }
+                winit_window_attributes.with_fullscreen(Some(resolve_exclusive_fullscreen(
+                    maybe_selected_monitor.clone(),
+                    monitor_selection,
+                    video_mode_selection,
+                )))
             }
             WindowMode::Windowed => {
                 if let Some(position) = winit_window_position(
@@ -382,6 +372,35 @@ pub fn get_selected_videomode(
                 && mode.bit_depth() == specified.bit_depth
         }),
     }
+}
+
+/// Resolves a `WindowMode::Fullscreen` request to a [`Fullscreen`] value.
+///
+/// Tries exclusive fullscreen first; falls back to borderless fullscreen and logs a
+/// warning if the monitor cannot be resolved or no matching video mode is available.
+pub(crate) fn resolve_exclusive_fullscreen(
+    monitor: Option<MonitorHandle>,
+    monitor_selection: MonitorSelection,
+    video_mode_selection: VideoModeSelection,
+) -> Fullscreen {
+    let video_mode = monitor
+        .as_ref()
+        .and_then(|m| get_selected_videomode(m, &video_mode_selection));
+    if let Some(video_mode) = video_mode {
+        return Fullscreen::Exclusive(video_mode);
+    }
+    if monitor.is_none() {
+        warn!(
+            "Could not find monitor for {:?}; falling back to borderless fullscreen",
+            monitor_selection
+        );
+    } else {
+        warn!(
+            "Could not find valid fullscreen video mode for {:?} {:?}; falling back to borderless fullscreen",
+            monitor_selection, video_mode_selection
+        );
+    }
+    Fullscreen::Borderless(monitor)
 }
 
 /// Gets a monitor's current video-mode.


### PR DESCRIPTION
# Objective

Exclusive fullscreen apps would not start on Wayland because the code used to expect a monitor to be available.

Fixes #18556

## Solution

Log a warning and fall back to borderless fullscreen

## Testing

Tested on Fedora 43 Wayland / COSMIC