### PR TITLE
fix AssetChanged safety comment

### DIFF
--- a/crates/bevy_asset/src/asset_changed.rs
+++ b/crates/bevy_asset/src/asset_changed.rs
@@ -170,7 +170,7 @@ unsafe impl<A: AsAssetId> WorldQuery for AssetChanged<A> {
         //   so the untyped pointer returned by `get_resource_by_id` can safely be dereferenced into that type.
         // - `update_component_access` declares a read on `state.resource_id`, so it is safe to
         //   read that resource here (see trait-level safety comments on `WorldQuery`, regarding
-        //   readonly resource access in `init_fetch`
+        //   readonly resource access in `init_fetch`)
         let Some(changes) = (unsafe {
             world
                 .get_resource_by_id(state.resource_id)


### PR DESCRIPTION
# Objective

- Fix #22787 

## Solution

- Refer more directly to the actual safety requirements on `WorldQuery`

## Testing

- N/A
