### PR TITLE
Fix asset extraction for `GpuAutoExposureCompensationCurve`

### DIFF
--- a/crates/bevy_post_process/src/auto_exposure/compensation_curve.rs
+++ b/crates/bevy_post_process/src/auto_exposure/compensation_curve.rs
@@ -196,13 +196,7 @@ impl RenderAsset for GpuAutoExposureCompensationCurve {
         source: &mut Self::SourceAsset,
         _previous_gpu_asset: Option<&Self>,
     ) -> Result<Self::SourceAsset, AssetExtractionError> {
-        Ok(AutoExposureCompensationCurve {
-            min_log_lum: source.min_log_lum,
-            max_log_lum: source.max_log_lum,
-            min_compensation: source.min_compensation,
-            max_compensation: source.max_compensation,
-            lut: source.lut,
-        })
+        Ok(source.clone())
     }
 
     fn prepare_asset(


### PR DESCRIPTION
# Objective

- When I am running the example `auto_exposure` on the main branch. I get errors, and the auto exposure effect does not work correctly.
```
2026-02-04T05:36:29.462198Z ERROR bevy_render::render_asset: bevy_post_process::auto_exposure::compensation_curve::GpuAutoExposureCompensationCurve with RenderAssetUsages == RENDER_WORLD cannot be extracted: The asset type does not support extraction. To clone the asset to the renderworld, use `RenderAssetUsages::default()`
2026-02-04T05:36:29.462407Z ERROR bevy_render::render_asset: bevy_post_process::auto_exposure::compensation_curve::GpuAutoExposureCompensationCurve with RenderAssetUsages == RENDER_WORLD cannot be extracted: The asset type does not support extraction. To clone the asset to the renderworld, use `RenderAssetUsages::default()`
```

- I believe the reason is that` GpuAutoExposureCompensationCurve` is missing the `take_gpu_data` function from the `RenderAsset` trait.

- The code snippet that outputs error information `(crates\bevy_render\src\render_asset.rs)`.
``` rust
for id in needs_extracting.drain() {
  if let Some(asset) = assets.get(id) {
      let asset_usage = A::asset_usage(asset);
      if asset_usage.contains(RenderAssetUsages::RENDER_WORLD) {
          if asset_usage == RenderAssetUsages::RENDER_WORLD {
              if let Some(asset) = assets.get_mut_untracked(id) {
                  let previous_asset = maybe_render_assets.as_ref().and_then(|render_assets| render_assets.get(id));
                  match A::take_gpu_data(asset, previous_asset) {
                      Ok(gpu_data_asset) => {
                          extracted_assets.push((id, gpu_data_asset));
                          added.insert(id);
                      }
                      Err(e) => {
                          error!("{} with RenderAssetUsages == RENDER_WORLD cannot be extracted: {e}", core::any::type_name::<A>());
                      }
                  };
              }
          } else {
              extracted_assets.push((id, asset.clone()));
              added.insert(id);
          }
      }
  }
}
```

## Solution

- Add `take_gpu_data()` function. 

## Testing

- The example `auto_exposure` works correctly.
- CI

---