### PR TITLE
remove redundant warns

### DIFF
--- a/crates/bevy_camera_controller/src/lib.rs
+++ b/crates/bevy_camera_controller/src/lib.rs
@@ -36,8 +36,6 @@
 //! Each camera controller is stored in its own module,
 //! and gated behind a feature flag of the same name.
 
-#![warn(missing_docs)]
-
 #[cfg(feature = "free_camera")]
 pub mod free_camera;
 

--- a/crates/bevy_picking/src/lib.rs
+++ b/crates/bevy_picking/src/lib.rs
@@ -152,8 +152,6 @@
 //! Because it is completely agnostic to the earlier stages of the pipeline, you can easily extend
 //! the plugin with arbitrary backends and input methods, yet still use all the high level features.
 
-#![deny(missing_docs)]
-
 extern crate alloc;
 
 pub mod backend;

--- a/crates/bevy_ui/src/picking_backend.rs
+++ b/crates/bevy_ui/src/picking_backend.rs
@@ -21,8 +21,6 @@
 //!   `(-0.5, -0.5, 0.)` at the top left and `(0.5, 0.5, 0.)` in the bottom right. Coordinates are
 //!   relative to the entire node, not just the visible region. This backend does not provide a `normal`.
 
-#![deny(missing_docs)]
-
 use crate::{clip_check_recursive, prelude::*, ui_transform::UiGlobalTransform, UiStack};
 use bevy_app::prelude::*;
 use bevy_camera::{visibility::InheritedVisibility, Camera, RenderTarget};


### PR DESCRIPTION
# Objective

- we have a blanket deny on missing docs, we don't need specific warns on it

## Solution

- yeet

## Testing

- ci