### PR TITLE
warn about risks of crashing the renderer

### DIFF
--- a/examples/app/render_recovery.rs
+++ b/examples/app/render_recovery.rs
@@ -63,7 +63,8 @@ fn setup(
     // help text
     commands.spawn((
         Text::new(
-            "Press O to trigger an OutOfMemory error\n\
+            "Test at your own risk: you may need to restart your computer to fully recover\n\
+            Press O to trigger an OutOfMemory error\n\
             Press V to trigger a Validation error\n\
             Press D to Destroy the render device (causes device lost error)\n\
             Press L to Loop infinitely in a compute shader (causes device lost error)\n\


### PR DESCRIPTION
# Objective

- The new render_recovery example can crash so hard that it's needed to restart to fully recover

## Solution

- Warn users about it
