### PR TITLE
Clamp F_ab in specular multiscatter to fix grazing angle artifacts

### DIFF
--- a/crates/bevy_pbr/src/render/pbr_lighting.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_lighting.wgsl
@@ -527,7 +527,9 @@ fn F_AB(perceptual_roughness: f32, NdotV: f32) -> vec2<f32> {
     let c1 = vec4<f32>(1.0, 0.0425, 1.04, -0.04);
     let r = perceptual_roughness * c0 + c1;
     let a004 = min(r.x * r.x, exp2(-9.28 * NdotV)) * r.x + r.y;
-    return vec2<f32>(-1.04, 1.04) * a004 + r.zw;
+    // Keep F_ab positive to avoid divide-by-zero in downstream BRDF terms.
+    let f_ab_epsilon = 0.00005;
+    return max(vec2<f32>(-1.04, 1.04) * a004 + r.zw, vec2<f32>(f_ab_epsilon));
 }
 
 fn EnvBRDFApprox(F0: vec3<f32>, F_ab: vec2<f32>) -> vec3<f32> {


### PR DESCRIPTION
# Objective

The F_AB() polynomial approximation produces F_ab values approaching zero or slightly negative on highly reflective surfaces viewed at grazing angles, causing fireflies and black pixelated aliasing.

## Solution

Clamp F_ab to a minimum of 0.00005.

## Testing

- `cargo run --example atmosphere` (with free camera to get grazing angle with water)

---

## Showcase

Before:

<img width="1542" height="561" alt="image" src="https://github.com/user-attachments/assets/b9649267-4dbc-4623-8938-9012d5059e3f" />

After:

<img width="1768" height="688" alt="image" src="https://github.com/user-attachments/assets/709c070a-4366-49fe-882d-ad9e1c2f1edb" />