### PR TITLE
Fix UV calculation for `SpriteMesh` when using a `TextureAtlasLayout`

### DIFF
--- a/crates/bevy_sprite_render/src/sprite_mesh/sprite_material.rs
+++ b/crates/bevy_sprite_render/src/sprite_mesh/sprite_material.rs
@@ -140,7 +140,7 @@ impl AsBindGroupShaderType<SpriteMaterialUniform> for SpriteMaterial {
 
             uv_transform *= Affine2::from_scale(ratio);
             uv_transform *= Affine2::from_translation(vec2(
-                rect.min.x / rect.size().y,
+                rect.min.x / rect.size().x,
                 rect.min.y / rect.size().y,
             ));
 


### PR DESCRIPTION
# Objective

Fixes #22835

## Solution

Divide the x min of the `Rect` by the width instead of the height

## Testing

I confirmed that all of the sprites in my game now look correct
