### PR TITLE
Make `bevy_gltf` optional for `bevy_pbr`

### DIFF
--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -251,7 +251,6 @@ bevy_anti_alias = ["dep:bevy_anti_alias", "bevy_core_pipeline"]
 bevy_post_process = ["dep:bevy_post_process", "bevy_core_pipeline"]
 bevy_pbr = [
   "dep:bevy_pbr",
-  "bevy_gltf",
   "bevy_light",
   "bevy_material",
   "bevy_core_pipeline",
@@ -268,7 +267,7 @@ bevy_ui_render = ["dep:bevy_ui_render", "bevy_sprite_render", "bevy_ui"]
 bevy_solari = ["dep:bevy_solari", "bevy_pbr"]
 bevy_gizmos = ["dep:bevy_gizmos", "bevy_camera", "bevy_light?/bevy_gizmos"]
 bevy_gizmos_render = ["dep:bevy_gizmos_render", "bevy_gizmos"]
-bevy_gltf = ["dep:bevy_gltf", "bevy_scene"]
+bevy_gltf = ["dep:bevy_gltf", "bevy_scene", "bevy_pbr?/bevy_gltf"]
 
 # Used to disable code that is unsupported when Bevy is dynamically linked
 dynamic_linking = ["bevy_diagnostic/dynamic_linking"]

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -11,12 +11,12 @@ keywords = ["bevy"]
 [features]
 webgl = ["bevy_light/webgl"]
 webgpu = ["bevy_light/webgpu"]
-pbr_transmission_textures = ["bevy_gltf/pbr_transmission_textures"]
+pbr_transmission_textures = ["bevy_gltf?/pbr_transmission_textures"]
 pbr_multi_layer_material_textures = [
-  "bevy_gltf/pbr_multi_layer_material_textures",
+  "bevy_gltf?/pbr_multi_layer_material_textures",
 ]
-pbr_anisotropy_texture = ["bevy_gltf/pbr_anisotropy_texture"]
-pbr_specular_textures = ["bevy_gltf/pbr_specular_textures"]
+pbr_anisotropy_texture = ["bevy_gltf?/pbr_anisotropy_texture"]
+pbr_specular_textures = ["bevy_gltf?/pbr_specular_textures"]
 experimental_pbr_pcss = ["bevy_light/experimental_pbr_pcss"]
 pbr_clustered_decals = []
 pbr_light_textures = []
@@ -43,7 +43,7 @@ bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.19.0-dev" }
 bevy_derive = { path = "../bevy_derive", version = "0.19.0-dev" }
 bevy_diagnostic = { path = "../bevy_diagnostic", version = "0.19.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.19.0-dev" }
-bevy_gltf = { path = "../bevy_gltf", version = "0.19.0-dev" }
+bevy_gltf = { path = "../bevy_gltf", version = "0.19.0-dev", optional = true }
 bevy_light = { path = "../bevy_light", version = "0.19.0-dev" }
 bevy_log = { path = "../bevy_log", version = "0.19.0-dev" }
 bevy_image = { path = "../bevy_image", version = "0.19.0-dev" }

--- a/crates/bevy_pbr/src/gltf.rs
+++ b/crates/bevy_pbr/src/gltf.rs
@@ -29,7 +29,8 @@ pub(crate) fn add_gltf(app: &mut App) {
         .push(Box::new(GltfExtensionHandlerPbr));
 }
 
-fn standard_material_from_gltf_material(material: &GltfMaterial) -> StandardMaterial {
+/// Converts a [`GltfMaterial`] to a [`StandardMaterial`]
+pub fn standard_material_from_gltf_material(material: &GltfMaterial) -> StandardMaterial {
     StandardMaterial {
         base_color: material.base_color,
         base_color_channel: material.base_color_channel.clone(),

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -28,6 +28,7 @@ mod atmosphere;
 mod cluster;
 mod components;
 pub mod contact_shadows;
+#[cfg(feature = "bevy_gltf")]
 mod gltf;
 use bevy_render::sync_component::SyncComponent;
 pub use contact_shadows::{
@@ -224,6 +225,7 @@ impl Plugin for PbrPlugin {
             ))
             .add_plugins((ScatteringMediumPlugin, AtmospherePlugin));
 
+        #[cfg(feature = "bevy_gltf")]
         if self.gltf_enable_standard_materials {
             gltf::add_gltf(app);
         }

--- a/release-content/migration-guides/gltf_pbr.md
+++ b/release-content/migration-guides/gltf_pbr.md
@@ -5,6 +5,8 @@ pull_requests: [22569]
 
 Previously, `bevy_gltf` depended on `bevy_pbr`. This meant scene definition was tightly coupled to rendering. This dependency has been inverted, to allow `bevy_gltf` to function without any of the rendering stack present.
 
+`bevy_gltf` is also an optional dependency.
+
 In 0.18, loading a material sub-asset would return a `Handle<StandardMaterial>`.
 
 ```rs


### PR DESCRIPTION
# Objective

- `bevy_pbr` no longer strictly requires `bevy_gltf`

## Solution

- Make `bevy_gltf` an optional dependency, and feature gate the usage

## Testing

- `cargo run --example animated_mesh` compiles `bevy_gltf` and displays the fox and grass 
- `cargo run --example 3d_shapes --no-default-features --features default_app,default_platform,3d_api,bevy_pbr,bevy_ui` compiles without `bevy_gltf` or `gltf`