### PR TITLE
Fix non-global `core` references in macros

### DIFF
--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -231,7 +231,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
                     // Safety: we pass valid offset of a field containing Entity (obtained via offset_off!)
                     unsafe {
                         #bevy_ecs_path::relationship::ComponentRelationshipAccessor::<Self>::relationship(
-                            core::mem::offset_of!(Self, #relationship_member)
+                            ::core::mem::offset_of!(Self, #relationship_member)
                         )
                     }
                 )
@@ -844,7 +844,7 @@ fn derive_relationship(
             #[inline]
             fn from(entity: #bevy_ecs_path::entity::Entity) -> Self {
                 Self {
-                    #(#members: core::default::Default::default(),)*
+                    #(#members: ::core::default::Default::default(),)*
                     #relationship_member: entity
                 }
             }
@@ -912,7 +912,7 @@ fn derive_relationship_target(
             #[inline]
             fn from_collection_risky(collection: Self::Collection) -> Self {
                 Self {
-                    #(#members: core::default::Default::default(),)*
+                    #(#members: ::core::default::Default::default(),)*
                     #relationship_member: collection
                 }
             }

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -137,13 +137,13 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
             fn component_ids(
                 components: &mut #ecs_path::component::ComponentsRegistrator,
             ) -> impl Iterator<Item = #ecs_path::component::ComponentId> + use<#(#generics_ty_list,)*> {
-                core::iter::empty()#(.chain(<#active_field_types as #ecs_path::bundle::Bundle>::component_ids(components)))*
+                ::core::iter::empty()#(.chain(<#active_field_types as #ecs_path::bundle::Bundle>::component_ids(components)))*
             }
 
             fn get_component_ids(
                 components: &#ecs_path::component::Components,
             ) -> impl Iterator<Item = Option<#ecs_path::component::ComponentId>> {
-                core::iter::empty()#(.chain(<#active_field_types as #ecs_path::bundle::Bundle>::get_component_ids(components)))*
+                ::core::iter::empty()#(.chain(<#active_field_types as #ecs_path::bundle::Bundle>::get_component_ids(components)))*
             }
         }
     };
@@ -173,7 +173,7 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
             #[allow(unused_variables)]
             #[inline]
             unsafe fn apply_effect(
-                ptr: #ecs_path::ptr::MovingPtr<'_, core::mem::MaybeUninit<Self>>,
+                ptr: #ecs_path::ptr::MovingPtr<'_, ::core::mem::MaybeUninit<Self>>,
                 func: &mut #ecs_path::world::EntityWorldMut<'_>,
             ) {
             }

--- a/crates/bevy_ecs/macros/src/query_data.rs
+++ b/crates/bevy_ecs/macros/src/query_data.rs
@@ -463,8 +463,8 @@ pub fn derive_query_data_impl(input: TokenStream) -> TokenStream {
 
                     fn iter_access(
                         _state: &Self::State,
-                    ) -> impl core::iter::Iterator<Item = #path::query::EcsAccessType<'_>> {
-                        core::iter::empty() #(.chain(<#field_types>::iter_access(&_state.#field_aliases)))*
+                    ) -> impl ::core::iter::Iterator<Item = #path::query::EcsAccessType<'_>> {
+                        ::core::iter::empty() #(.chain(<#field_types>::iter_access(&_state.#field_aliases)))*
                     }
                 }
 
@@ -534,8 +534,8 @@ pub fn derive_query_data_impl(input: TokenStream) -> TokenStream {
 
                 fn iter_access(
                     _state: &Self::State,
-                ) -> impl core::iter::Iterator<Item = #path::query::EcsAccessType<'_>> {
-                    core::iter::empty() #(.chain(<#field_types>::iter_access(&_state.#field_aliases)))*
+                ) -> impl ::core::iter::Iterator<Item = #path::query::EcsAccessType<'_>> {
+                    ::core::iter::empty() #(.chain(<#field_types>::iter_access(&_state.#field_aliases)))*
                 }
             }
 


### PR DESCRIPTION
# Objective
Some user-facing macros generate references to `core` using non-global paths. If a downstream crate has another module named `core` in scope, it shadows the standard library’s `core` module and causes a compile error when such macros are used.

This PR ensures all references to `core` in macro outputs use global paths.

## Solution

Added the `::` prefix to `core` paths that didn't already have one.

## Testing
Tested by running compile CI locally.