### PR TITLE
Add smol_str feature to bevy_reflect dependency for bevy_text.

### DIFF
--- a/crates/bevy_text/Cargo.toml
+++ b/crates/bevy_text/Cargo.toml
@@ -21,7 +21,9 @@ bevy_ecs = { path = "../bevy_ecs", version = "0.19.0-dev" }
 bevy_image = { path = "../bevy_image", version = "0.19.0-dev" }
 bevy_log = { path = "../bevy_log", version = "0.19.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.19.0-dev" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev", features = [
+  "smol_str",
+] }
 bevy_utils = { path = "../bevy_utils", version = "0.19.0-dev" }
 bevy_platform = { path = "../bevy_platform", version = "0.19.0-dev", default-features = false, features = [
   "std",


### PR DESCRIPTION
# Objective

- `cargo b -p bevy_text` fails to compile due to missing `Reflect` impl on `SmolStr`.
- Fixes #22497.

## Solution

- Add the `smol_str` feature to `bevy_text`s `bevy_reflect` dependency.

## Testing

- `cargo b -p bevy_text` fails to compile on main, but it succeeds with this PR.