### PR TITLE
Resolve multisampled prepass textures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1193,8 +1193,7 @@ doc-scrape-examples = false
 name = "Anti-aliasing"
 description = "Compares different anti-aliasing techniques supported by Bevy"
 category = "3D Rendering"
-# TAA not supported by WebGL
-wasm = false
+wasm = true
 
 [[example]]
 name = "atmospheric_fog"
@@ -4793,7 +4792,7 @@ required-features = ["bluenoise_texture"]
 name = "Screen Space Reflections"
 description = "Demonstrates screen space reflections with water ripples"
 category = "3D Rendering"
-wasm = false
+wasm = true
 
 [[example]]
 name = "camera_sub_view"
@@ -4842,7 +4841,7 @@ doc-scrape-examples = false
 name = "Depth of field"
 description = "Demonstrates depth of field"
 category = "3D Rendering"
-wasm = false
+wasm = true
 
 [[example]]
 name = "volumetric_fog"

--- a/assets/shaders/show_prepass.wgsl
+++ b/assets/shaders/show_prepass.wgsl
@@ -14,23 +14,15 @@ struct ShowPrepassSettings {
 @group(#{MATERIAL_BIND_GROUP}) @binding(0) var<uniform> settings: ShowPrepassSettings;
 
 @fragment
-fn fragment(
-#ifdef MULTISAMPLED
-    @builtin(sample_index) sample_index: u32,
-#endif
-    mesh: VertexOutput,
-) -> @location(0) vec4<f32> {
-#ifndef MULTISAMPLED
-    let sample_index = 0u;
-#endif
+fn fragment(mesh: VertexOutput) -> @location(0) vec4<f32> {
     if settings.show_depth == 1u {
-        let depth = bevy_pbr::prepass_utils::prepass_depth(mesh.position, sample_index);
+        let depth = bevy_pbr::prepass_utils::prepass_depth(mesh.position);
         return vec4(depth, depth, depth, 1.0);
     } else if settings.show_normals == 1u {
-        let normal = bevy_pbr::prepass_utils::prepass_normal(mesh.position, sample_index);
+        let normal = bevy_pbr::prepass_utils::prepass_normal(mesh.position);
         return vec4(normal, 1.0);
     } else if settings.show_motion_vectors == 1u {
-        let motion_vector = bevy_pbr::prepass_utils::prepass_motion_vector(mesh.position, sample_index);
+        let motion_vector = bevy_pbr::prepass_utils::prepass_motion_vector(mesh.position);
         return vec4(motion_vector / globals.delta_time, 0.0, 1.0);
     }
 

--- a/crates/bevy_anti_alias/src/taa/mod.rs
+++ b/crates/bevy_anti_alias/src/taa/mod.rs
@@ -23,7 +23,7 @@ use bevy_render::{
     camera::{ExtractedCamera, MipBias, TemporalJitter},
     diagnostic::RecordDiagnostics,
     render_resource::{
-        binding_types::{sampler, texture_2d, texture_depth_2d},
+        binding_types::{sampler, texture_2d},
         BindGroupEntries, BindGroupLayoutDescriptor, BindGroupLayoutEntries,
         CachedRenderPipelineId, Canonical, ColorTargetState, ColorWrites, FilterMode,
         FragmentState, Operations, PipelineCache, RenderPassColorAttachment, RenderPassDescriptor,
@@ -259,7 +259,7 @@ fn init_taa_pipeline(
                 // Motion Vectors
                 texture_2d(TextureSampleType::Float { filterable: true }),
                 // Depth
-                texture_depth_2d(),
+                texture_2d(TextureSampleType::Float { filterable: false }),
                 // Nearest sampler
                 sampler(SamplerBindingType::NonFiltering),
                 // Linear sampler

--- a/crates/bevy_anti_alias/src/taa/taa.wgsl
+++ b/crates/bevy_anti_alias/src/taa/taa.wgsl
@@ -162,7 +162,7 @@ fn taa(@location(0) uv: vec2<f32>) -> Output {
     history_color = YCoCg_to_RGB(history_color);
 
     // How confident we are that the history is representative of the current frame
-    var history_confidence = textureSample(history, nearest_sampler, uv).a;
+    var history_confidence = textureSample(history, linear_sampler, uv).a;
     let pixel_motion_vector = abs(closest_motion_vector) * texture_size;
     if pixel_motion_vector.x < 0.01 && pixel_motion_vector.y < 0.01 {
         // Increment when pixels are not moving

--- a/crates/bevy_anti_alias/src/taa/taa.wgsl
+++ b/crates/bevy_anti_alias/src/taa/taa.wgsl
@@ -13,7 +13,7 @@ const MIN_HISTORY_BLEND_RATE: f32 = 0.015; // Minimum blend rate allowed, to ens
 @group(0) @binding(0) var view_target: texture_2d<f32>;
 @group(0) @binding(1) var history: texture_2d<f32>;
 @group(0) @binding(2) var motion_vectors: texture_2d<f32>;
-@group(0) @binding(3) var depth: texture_depth_2d;
+@group(0) @binding(3) var depth: texture_2d<f32>;
 @group(0) @binding(4) var nearest_sampler: sampler;
 @group(0) @binding(5) var linear_sampler: sampler;
 
@@ -95,11 +95,11 @@ fn taa(@location(0) uv: vec2<f32>) -> Output {
     let d_uv_bl = uv + vec2(-offset.x, -offset.y);
     let d_uv_br = uv + vec2(offset.x, -offset.y);
     var closest_uv = uv;
-    let d_tl = textureSample(depth, nearest_sampler, d_uv_tl);
-    let d_tr = textureSample(depth, nearest_sampler, d_uv_tr);
-    var closest_depth = textureSample(depth, nearest_sampler, uv);
-    let d_bl = textureSample(depth, nearest_sampler, d_uv_bl);
-    let d_br = textureSample(depth, nearest_sampler, d_uv_br);
+    let d_tl = textureSample(depth, nearest_sampler, d_uv_tl).r;
+    let d_tr = textureSample(depth, nearest_sampler, d_uv_tr).r;
+    var closest_depth = textureSample(depth, nearest_sampler, uv).r;
+    let d_bl = textureSample(depth, nearest_sampler, d_uv_bl).r;
+    let d_br = textureSample(depth, nearest_sampler, d_uv_br).r;
     if d_tl > closest_depth {
         closest_uv = d_uv_tl;
         closest_depth = d_tl;

--- a/crates/bevy_core_pipeline/src/blit/blit.wgsl
+++ b/crates/bevy_core_pipeline/src/blit/blit.wgsl
@@ -1,9 +1,22 @@
 #import bevy_core_pipeline::fullscreen_vertex_shader::FullscreenVertexOutput
 
+#ifdef MULTISAMPLED
+@group(0) @binding(0) var in_texture: texture_multisampled_2d<f32>;
+#else
 @group(0) @binding(0) var in_texture: texture_2d<f32>;
 @group(0) @binding(1) var in_sampler: sampler;
+#endif
 
 @fragment
-fn fs_main(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
+fn fs_main(
+#ifdef MULTISAMPLED
+    @builtin(sample_index) sample_index: u32,
+#endif
+    in: FullscreenVertexOutput
+) -> @location(0) vec4<f32> {
+#ifdef MULTISAMPLED
+    return textureLoad(in_texture, vec2<i32>(in.position.xy), sample_index);
+#else
     return textureSample(in_texture, in_sampler, in.uv);
+#endif
 }

--- a/crates/bevy_core_pipeline/src/blit/blit.wgsl
+++ b/crates/bevy_core_pipeline/src/blit/blit.wgsl
@@ -1,22 +1,9 @@
 #import bevy_core_pipeline::fullscreen_vertex_shader::FullscreenVertexOutput
 
-#ifdef MULTISAMPLED
-@group(0) @binding(0) var in_texture: texture_multisampled_2d<f32>;
-#else
 @group(0) @binding(0) var in_texture: texture_2d<f32>;
 @group(0) @binding(1) var in_sampler: sampler;
-#endif
 
 @fragment
-fn fs_main(
-#ifdef MULTISAMPLED
-    @builtin(sample_index) sample_index: u32,
-#endif
-    in: FullscreenVertexOutput
-) -> @location(0) vec4<f32> {
-#ifdef MULTISAMPLED
-    return textureLoad(in_texture, vec2<i32>(in.position.xy), sample_index);
-#else
+fn fs_main(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
     return textureSample(in_texture, in_sampler, in.uv);
-#endif
 }

--- a/crates/bevy_core_pipeline/src/core_3d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/mod.rs
@@ -4,26 +4,6 @@ mod main_transparent_pass_3d_node;
 // PERF: vulkan docs recommend using 24 bit depth for better performance
 pub const CORE_3D_DEPTH_FORMAT: TextureFormat = TextureFormat::Depth32Float;
 
-/// True if multisampled depth textures are supported on this platform.
-///
-/// In theory, Naga supports depth textures on WebGL 2. In practice, it doesn't,
-/// because of a silly bug whereby Naga assumes that all depth textures are
-/// `sampler2DShadow` and will cheerfully generate invalid GLSL that tries to
-/// perform non-percentage-closer-filtering with such a sampler. Therefore we
-/// disable depth of field and screen space reflections entirely on WebGL 2.
-#[cfg(not(any(feature = "webgpu", not(target_arch = "wasm32"))))]
-pub const DEPTH_TEXTURE_SAMPLING_SUPPORTED: bool = false;
-
-/// True if multisampled depth textures are supported on this platform.
-///
-/// In theory, Naga supports depth textures on WebGL 2. In practice, it doesn't,
-/// because of a silly bug whereby Naga assumes that all depth textures are
-/// `sampler2DShadow` and will cheerfully generate invalid GLSL that tries to
-/// perform non-percentage-closer-filtering with such a sampler. Therefore we
-/// disable depth of field and screen space reflections entirely on WebGL 2.
-#[cfg(any(feature = "webgpu", not(target_arch = "wasm32")))]
-pub const DEPTH_TEXTURE_SAMPLING_SUPPORTED: bool = true;
-
 use core::ops::Range;
 
 use bevy_camera::{Camera, Camera3d, Camera3dDepthLoadOp};

--- a/crates/bevy_core_pipeline/src/deferred/node.rs
+++ b/crates/bevy_core_pipeline/src/deferred/node.rs
@@ -138,13 +138,13 @@ fn run_deferred_prepass_system(
         view_prepass_textures
             .normal
             .as_ref()
-            .map(|normals_texture| normals_texture.get_attachment()),
+            .map(|normals_texture| normals_texture.get_attachment(StoreOp::Store)),
     );
     color_attachments.push(
         view_prepass_textures
             .motion_vectors
             .as_ref()
-            .map(|motion_vectors_texture| motion_vectors_texture.get_attachment()),
+            .map(|motion_vectors_texture| motion_vectors_texture.get_attachment(StoreOp::Store)),
     );
 
     // If we clear the deferred texture with LoadOp::Clear(Default::default()) we get these errors:
@@ -168,7 +168,7 @@ fn run_deferred_prepass_system(
             .as_ref()
             .map(|deferred_texture| {
                 if is_late {
-                    deferred_texture.get_attachment()
+                    deferred_texture.get_attachment(StoreOp::Store)
                 } else {
                     #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
                     {
@@ -187,7 +187,7 @@ fn run_deferred_prepass_system(
                         not(target_arch = "wasm32"),
                         feature = "webgpu"
                     ))]
-                    deferred_texture.get_attachment()
+                    deferred_texture.get_attachment(StoreOp::Store)
                 }
             }),
     );
@@ -196,7 +196,9 @@ fn run_deferred_prepass_system(
         view_prepass_textures
             .deferred_lighting_pass_id
             .as_ref()
-            .map(|deferred_lighting_pass_id| deferred_lighting_pass_id.get_attachment()),
+            .map(|deferred_lighting_pass_id| {
+                deferred_lighting_pass_id.get_attachment(StoreOp::Store)
+            }),
     );
 
     // If all color attachments are none: clear the color attachment list so that no fragment shader is required

--- a/crates/bevy_core_pipeline/src/deferred/node.rs
+++ b/crates/bevy_core_pipeline/src/deferred/node.rs
@@ -2,7 +2,8 @@ use bevy_camera::{MainPassResolutionOverride, Viewport};
 use bevy_ecs::prelude::*;
 use bevy_render::occlusion_culling::OcclusionCulling;
 
-use bevy_render::view::{ExtractedView, NoIndirectDrawing};
+use bevy_render::render_resource::PipelineCache;
+use bevy_render::view::{ExtractedView, Msaa, NoIndirectDrawing};
 use bevy_render::{
     camera::ExtractedCamera,
     diagnostic::RecordDiagnostics,
@@ -15,7 +16,8 @@ use tracing::error;
 #[cfg(feature = "trace")]
 use tracing::info_span;
 
-use crate::prepass::ViewPrepassTextures;
+use crate::blit::BlitPipeline;
+use crate::prepass::{DepthPrepassResolvePipeline, ViewPrepassTextures};
 
 use super::{AlphaMask3dDeferred, Opaque3dDeferred};
 
@@ -23,8 +25,10 @@ use super::{AlphaMask3dDeferred, Opaque3dDeferred};
 type DeferredPrepassViewQueryData = (
     &'static ExtractedCamera,
     &'static ExtractedView,
+    &'static Msaa,
     &'static ViewDepthTexture,
     &'static ViewPrepassTextures,
+    Option<&'static DepthPrepassResolvePipeline>,
     Option<&'static MainPassResolutionOverride>,
     Has<OcclusionCulling>,
     Has<NoIndirectDrawing>,
@@ -33,6 +37,8 @@ type DeferredPrepassViewQueryData = (
 pub(crate) fn early_deferred_prepass(
     world: &World,
     view: ViewQuery<DeferredPrepassViewQueryData>,
+    blit_pipeline: Res<BlitPipeline>,
+    pipeline_cache: Res<PipelineCache>,
     opaque_deferred_phases: Res<ViewBinnedRenderPhases<Opaque3dDeferred>>,
     alpha_mask_deferred_phases: Res<ViewBinnedRenderPhases<AlphaMask3dDeferred>>,
     mut ctx: RenderContext,
@@ -41,8 +47,10 @@ pub(crate) fn early_deferred_prepass(
     let (
         camera,
         extracted_view,
+        msaa,
         view_depth_texture,
         view_prepass_textures,
+        depth_prepass_resolve_pipeliine,
         resolution_override,
         _,
         _,
@@ -53,6 +61,10 @@ pub(crate) fn early_deferred_prepass(
         view_entity,
         camera,
         extracted_view,
+        msaa,
+        &blit_pipeline,
+        &pipeline_cache,
+        depth_prepass_resolve_pipeliine,
         view_depth_texture,
         view_prepass_textures,
         resolution_override,
@@ -67,6 +79,8 @@ pub(crate) fn early_deferred_prepass(
 pub fn late_deferred_prepass(
     world: &World,
     view: ViewQuery<DeferredPrepassViewQueryData>,
+    blit_pipeline: Res<BlitPipeline>,
+    pipeline_cache: Res<PipelineCache>,
     opaque_deferred_phases: Res<ViewBinnedRenderPhases<Opaque3dDeferred>>,
     alpha_mask_deferred_phases: Res<ViewBinnedRenderPhases<AlphaMask3dDeferred>>,
     mut ctx: RenderContext,
@@ -75,8 +89,10 @@ pub fn late_deferred_prepass(
     let (
         camera,
         extracted_view,
+        msaa,
         view_depth_texture,
         view_prepass_textures,
+        depth_prepass_resolve_pipeliine,
         resolution_override,
         occlusion_culling,
         no_indirect_drawing,
@@ -91,6 +107,10 @@ pub fn late_deferred_prepass(
         view_entity,
         camera,
         extracted_view,
+        msaa,
+        &blit_pipeline,
+        &pipeline_cache,
+        depth_prepass_resolve_pipeliine,
         view_depth_texture,
         view_prepass_textures,
         resolution_override,
@@ -111,6 +131,10 @@ fn run_deferred_prepass_system(
     view_entity: Entity,
     camera: &ExtractedCamera,
     extracted_view: &ExtractedView,
+    msaa: &Msaa,
+    blit_pipeline: &BlitPipeline,
+    pipeline_cache: &PipelineCache,
+    depth_prepass_resolve_pipeline: Option<&DepthPrepassResolvePipeline>,
     view_depth_texture: &ViewDepthTexture,
     view_prepass_textures: &ViewPrepassTextures,
     resolution_override: Option<&MainPassResolutionOverride>,
@@ -125,6 +149,16 @@ fn run_deferred_prepass_system(
         alpha_mask_deferred_phases.get(&extracted_view.retained_view_entity),
     ) else {
         return;
+    };
+
+    let depth_prepass_resolve_pipeline = if let Some(pipeline_id) = depth_prepass_resolve_pipeline {
+        if let Some(pipeline) = pipeline_cache.get_render_pipeline(pipeline_id.0) {
+            Some(pipeline)
+        } else {
+            return;
+        }
+    } else {
+        None
     };
 
     #[cfg(feature = "trace")]
@@ -247,11 +281,36 @@ fn run_deferred_prepass_system(
     drop(render_pass);
 
     // After rendering to the view depth texture, copy it to the prepass depth texture
-    if let Some(prepass_depth_texture) = &view_prepass_textures.depth {
-        ctx.command_encoder().copy_texture_to_texture(
-            view_depth_texture.texture.as_image_copy(),
-            prepass_depth_texture.texture.texture.as_image_copy(),
-            view_prepass_textures.size,
-        );
+    if let Some(pipeline) = depth_prepass_resolve_pipeline
+        && let Some(prepass_depth_texture) = &view_prepass_textures.depth
+    {
+        let bind_group = if msaa.samples() > 1 {
+            blit_pipeline.create_bind_group_multisampled(
+                ctx.render_device(),
+                view_depth_texture.view(),
+                pipeline_cache,
+            )
+        } else {
+            blit_pipeline.create_bind_group(
+                ctx.render_device(),
+                view_depth_texture.view(),
+                pipeline_cache,
+            )
+        };
+        let label = "deferred_depth_prepass_resolve";
+        let mut render_pass = ctx.begin_tracked_render_pass(RenderPassDescriptor {
+            label: Some(label),
+            color_attachments: &[Some(prepass_depth_texture.get_attachment(StoreOp::Store))],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        });
+        let pass_span = diagnostics.pass_span(&mut render_pass, label);
+        render_pass.set_render_pipeline(pipeline);
+        render_pass.set_bind_group(0, &bind_group, &[]);
+        render_pass.draw(0..3, 0..1);
+        pass_span.end(&mut render_pass);
+        drop(render_pass);
     }
 }

--- a/crates/bevy_core_pipeline/src/lib.rs
+++ b/crates/bevy_core_pipeline/src/lib.rs
@@ -14,6 +14,7 @@ pub mod fullscreen_material;
 pub mod mip_generation;
 pub mod oit;
 pub mod prepass;
+pub mod resolve;
 pub mod schedule;
 pub mod tonemapping;
 pub mod upscaling;
@@ -25,6 +26,7 @@ pub use schedule::{Core2d, Core2dSystems, Core3d, Core3dSystems};
 mod fullscreen_vertex_shader;
 mod skybox;
 
+use crate::resolve::ResolvePlugin;
 use crate::schedule::camera_driver;
 use crate::{
     blit::BlitPlugin, core_2d::Core2dPlugin, core_3d::Core3dPlugin,
@@ -47,6 +49,7 @@ impl Plugin for CorePipelinePlugin {
         app.add_plugins((Core2dPlugin, Core3dPlugin, CopyDeferredLightingIdPlugin))
             .add_plugins((
                 BlitPlugin,
+                ResolvePlugin,
                 TonemappingPlugin,
                 UpscalingPlugin,
                 OrderIndependentTransparencyPlugin,

--- a/crates/bevy_core_pipeline/src/oit/oit_draw.wgsl
+++ b/crates/bevy_core_pipeline/src/oit/oit_draw.wgsl
@@ -8,7 +8,7 @@
 // Add the fragment to the oit buffer
 fn oit_draw(position: vec4f, color: vec4f) {
 #ifdef DEPTH_PREPASS
-    if position.z < prepass_utils::prepass_depth(position, 0u) {
+    if position.z < prepass_utils::prepass_depth(position) {
         return;
     }
 #endif

--- a/crates/bevy_core_pipeline/src/prepass/node.rs
+++ b/crates/bevy_core_pipeline/src/prepass/node.rs
@@ -16,6 +16,7 @@ use tracing::info_span;
 use crate::{
     blit::BlitPipeline,
     prepass::DepthPrepassResolvePipeline,
+    resolve::ResolvePipeline,
     skybox::prepass::{RenderSkyboxPrepassPipeline, SkyboxPrepassBindGroup},
 };
 
@@ -285,6 +286,7 @@ pub fn depth_prepass_resolve(
         ),
         With<ExtractedCamera>,
     >,
+    resolve_pipeline: Res<ResolvePipeline>,
     blit_pipeline: Res<BlitPipeline>,
     pipeline_cache: Res<PipelineCache>,
     mut ctx: RenderContext,
@@ -304,7 +306,7 @@ pub fn depth_prepass_resolve(
     let diagnostics = diagnostics.as_deref();
 
     let bind_group = if msaa.samples() > 1 {
-        blit_pipeline.create_bind_group_multisampled(
+        resolve_pipeline.create_bind_group(
             ctx.render_device(),
             view_depth_texture.view(),
             &pipeline_cache,

--- a/crates/bevy_core_pipeline/src/prepass/node.rs
+++ b/crates/bevy_core_pipeline/src/prepass/node.rs
@@ -310,7 +310,7 @@ fn run_prepass_system(
                 pipeline_cache,
             )
         };
-        let label = "depth_prepass_resolve_pass";
+        let label = "depth_prepass_resolve";
         let mut render_pass = ctx.begin_tracked_render_pass(RenderPassDescriptor {
             label: Some(label),
             color_attachments: &[Some(prepass_depth_texture.get_attachment(StoreOp::Store))],

--- a/crates/bevy_core_pipeline/src/resolve/mod.rs
+++ b/crates/bevy_core_pipeline/src/resolve/mod.rs
@@ -3,70 +3,60 @@ use bevy_app::{App, Plugin};
 use bevy_asset::{embedded_asset, load_embedded_asset, AssetServer, Handle};
 use bevy_ecs::prelude::*;
 use bevy_render::{
-    render_resource::{
-        binding_types::{sampler, texture_2d},
-        *,
-    },
+    render_resource::{binding_types::texture_2d_multisampled, *},
     renderer::RenderDevice,
     RenderApp, RenderStartup,
 };
-use bevy_shader::Shader;
+use bevy_shader::{Shader, ShaderDefVal};
 use bevy_utils::default;
 
-/// Adds support for specialized "blit pipelines", which can be used to write one texture to another.
-pub struct BlitPlugin;
+/// Adds support for specialized resolve pipelines,
+/// which can be used to resolve multisampled texture to another.
+pub struct ResolvePlugin;
 
-impl Plugin for BlitPlugin {
+impl Plugin for ResolvePlugin {
     fn build(&self, app: &mut App) {
-        embedded_asset!(app, "blit.wgsl");
+        embedded_asset!(app, "resolve.wgsl");
 
         let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
             return;
         };
 
         render_app
-            .allow_ambiguous_resource::<SpecializedRenderPipelines<BlitPipeline>>()
-            .init_resource::<SpecializedRenderPipelines<BlitPipeline>>()
-            .add_systems(RenderStartup, init_blit_pipeline);
+            .allow_ambiguous_resource::<SpecializedRenderPipelines<ResolvePipeline>>()
+            .init_resource::<SpecializedRenderPipelines<ResolvePipeline>>()
+            .add_systems(RenderStartup, init_resolve_pipeline);
     }
 }
 
 #[derive(Resource)]
-pub struct BlitPipeline {
+pub struct ResolvePipeline {
     pub layout: BindGroupLayoutDescriptor,
-    pub sampler: Sampler,
     pub fullscreen_shader: FullscreenShader,
     pub fragment_shader: Handle<Shader>,
 }
 
-pub fn init_blit_pipeline(
+pub fn init_resolve_pipeline(
     mut commands: Commands,
-    render_device: Res<RenderDevice>,
     fullscreen_shader: Res<FullscreenShader>,
     asset_server: Res<AssetServer>,
 ) {
     let layout = BindGroupLayoutDescriptor::new(
-        "blit_bind_group_layout",
-        &BindGroupLayoutEntries::sequential(
+        "resolve_bind_group_layout",
+        &BindGroupLayoutEntries::single(
             ShaderStages::FRAGMENT,
-            (
-                texture_2d(TextureSampleType::Float { filterable: false }),
-                sampler(SamplerBindingType::NonFiltering),
-            ),
+            texture_2d_multisampled(TextureSampleType::Float { filterable: false }),
         ),
     );
 
-    let sampler = render_device.create_sampler(&SamplerDescriptor::default());
-
-    commands.insert_resource(BlitPipeline {
+    commands.insert_resource(ResolvePipeline {
         layout,
-        sampler,
         fullscreen_shader: fullscreen_shader.clone(),
-        fragment_shader: load_embedded_asset!(asset_server.as_ref(), "blit.wgsl"),
+        fragment_shader: load_embedded_asset!(asset_server.as_ref(), "resolve.wgsl"),
     });
 }
 
-impl BlitPipeline {
+impl ResolvePipeline {
     pub fn create_bind_group(
         &self,
         render_device: &RenderDevice,
@@ -76,39 +66,35 @@ impl BlitPipeline {
         render_device.create_bind_group(
             None,
             &pipeline_cache.get_bind_group_layout(&self.layout),
-            &BindGroupEntries::sequential((src_texture, &self.sampler)),
+            &BindGroupEntries::single(src_texture),
         )
     }
 }
 
 #[derive(PartialEq, Eq, Hash, Clone, Copy)]
-pub struct BlitPipelineKey {
+pub struct ResolvePipelineKey {
     pub texture_format: TextureFormat,
-    pub blend_state: Option<BlendState>,
     pub samples: u32,
 }
 
-impl SpecializedRenderPipeline for BlitPipeline {
-    type Key = BlitPipelineKey;
+impl SpecializedRenderPipeline for ResolvePipeline {
+    type Key = ResolvePipelineKey;
 
     fn specialize(&self, key: Self::Key) -> RenderPipelineDescriptor {
         RenderPipelineDescriptor {
-            label: Some("blit pipeline".into()),
+            label: Some("resolve pipeline".into()),
             layout: vec![self.layout.clone()],
             vertex: self.fullscreen_shader.to_vertex_state(),
             fragment: Some(FragmentState {
                 shader: self.fragment_shader.clone(),
+                shader_defs: vec![ShaderDefVal::UInt("SAMPLE_COUNT".into(), key.samples)],
                 targets: vec![Some(ColorTargetState {
                     format: key.texture_format,
-                    blend: key.blend_state,
+                    blend: None,
                     write_mask: ColorWrites::ALL,
                 })],
                 ..default()
             }),
-            multisample: MultisampleState {
-                count: key.samples,
-                ..default()
-            },
             ..default()
         }
     }

--- a/crates/bevy_core_pipeline/src/resolve/resolve.wgsl
+++ b/crates/bevy_core_pipeline/src/resolve/resolve.wgsl
@@ -1,0 +1,15 @@
+#import bevy_core_pipeline::fullscreen_vertex_shader::FullscreenVertexOutput
+
+@group(0) @binding(0) var in_texture: texture_multisampled_2d<f32>;
+
+const SAMPLE_COUNT: u32 = #{SAMPLE_COUNT};
+
+@fragment
+fn fs_main(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
+    var out: vec4<f32> = vec4<f32>(0.0);
+    for (var i = 0u; i < SAMPLE_COUNT; i++){
+        out += textureLoad(in_texture, vec2<i32>(in.position.xy), i);
+    }
+    out /= f32(SAMPLE_COUNT);
+    return out;
+}

--- a/crates/bevy_core_pipeline/src/upscaling/mod.rs
+++ b/crates/bevy_core_pipeline/src/upscaling/mod.rs
@@ -74,7 +74,8 @@ fn prepare_view_upscaling_pipelines(
         let key = BlitPipelineKey {
             texture_format: view_target.out_texture_view_format(),
             blend_state,
-            samples: 1,
+            target_samples: 1,
+            src_multisampled: false,
         };
         let pipeline = pipelines.specialize(&pipeline_cache, &blit_pipeline, key);
 

--- a/crates/bevy_core_pipeline/src/upscaling/mod.rs
+++ b/crates/bevy_core_pipeline/src/upscaling/mod.rs
@@ -74,8 +74,7 @@ fn prepare_view_upscaling_pipelines(
         let key = BlitPipelineKey {
             texture_format: view_target.out_texture_view_format(),
             blend_state,
-            target_samples: 1,
-            src_multisampled: false,
+            samples: 1,
         };
         let pipeline = pipelines.specialize(&pipeline_cache, &blit_pipeline, key);
 

--- a/crates/bevy_dev_tools/src/render_debug.rs
+++ b/crates/bevy_dev_tools/src/render_debug.rs
@@ -37,7 +37,7 @@ use bevy_render::{
     },
     renderer::{RenderContext, RenderDevice, RenderQueue, ViewQuery},
     texture::{FallbackImage, GpuImage},
-    view::{Msaa, ViewTarget, ViewUniformOffset},
+    view::{ViewTarget, ViewUniformOffset},
     Render, RenderApp, RenderSystems,
 };
 use bevy_shader::Shader;
@@ -454,13 +454,6 @@ impl SpecializedRenderPipeline for RenderDebugOverlayPipeline {
             RenderDebugMode::DepthPyramid { .. } => shader_defs.push("DEBUG_DEPTH_PYRAMID".into()),
         }
 
-        if key
-            .view_layout_key
-            .contains(MeshPipelineViewLayoutKey::MULTISAMPLED)
-        {
-            shader_defs.push("MULTISAMPLED".into());
-        }
-
         let mesh_view_layout_descriptor = self
             .mesh_view_layouts
             .get_view_layout(key.view_layout_key)
@@ -504,19 +497,17 @@ fn prepare_debug_overlay_pipelines(
         Entity,
         &ViewTarget,
         &RenderDebugOverlay,
-        &Msaa,
         Option<&bevy_core_pipeline::prepass::ViewPrepassTextures>,
         Has<bevy_core_pipeline::oit::OrderIndependentTransparencySettings>,
         Has<bevy_pbr::ExtractedAtmosphere>,
     )>,
 ) {
-    for (entity, target, config, msaa, prepass_textures, has_oit, has_atmosphere) in &views {
+    for (entity, target, config, prepass_textures, has_oit, has_atmosphere) in &views {
         if !config.enabled {
             continue;
         }
 
-        let mut view_layout_key = MeshPipelineViewLayoutKey::from(*msaa)
-            | MeshPipelineViewLayoutKey::from(prepass_textures);
+        let mut view_layout_key = MeshPipelineViewLayoutKey::from(prepass_textures);
 
         if has_oit {
             view_layout_key |= MeshPipelineViewLayoutKey::OIT_ENABLED;

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -20,6 +20,7 @@ trace = [
   "bevy_pbr?/trace",
   "bevy_render?/trace",
   "bevy_winit?/trace",
+  "bevy_post_process?/trace",
 ]
 trace_chrome = ["bevy_log/tracing-chrome"]
 trace_tracy = ["bevy_render?/tracing-tracy", "bevy_log/tracing-tracy"]
@@ -192,6 +193,7 @@ webgl = [
   "bevy_sprite_render?/webgl",
   "bevy_dev_tools?/webgl",
   "bevy_feathers?/webgl",
+  "bevy_post_process?/webgl",
 ]
 
 webgpu = [
@@ -203,6 +205,7 @@ webgpu = [
   "bevy_sprite_render?/webgpu",
   "bevy_dev_tools?/webgpu",
   "bevy_feathers?/webgpu",
+  "bevy_post_process?/webgpu",
 ]
 
 # Enable systems that allow for automated testing on CI

--- a/crates/bevy_pbr/src/decal/forward_decal.wgsl
+++ b/crates/bevy_pbr/src/decal/forward_decal.wgsl
@@ -34,7 +34,7 @@ fn get_forward_decal_info(in: VertexOutput) -> ForwardDecalInformation {
     let Vt = vec3(dot(V, T), dot(V, B), dot(V, N));
 
     let frag_depth = depth_ndc_to_view_z(in.position.z);
-    let depth_pass_depth = depth_ndc_to_view_z(prepass_depth(in.position, 0u));
+    let depth_pass_depth = depth_ndc_to_view_z(prepass_depth(in.position));
     let diff_depth = frag_depth - depth_pass_depth;
     let diff_depth_abs = abs(diff_depth);
 

--- a/crates/bevy_pbr/src/deferred/deferred_lighting.wgsl
+++ b/crates/bevy_pbr/src/deferred/deferred_lighting.wgsl
@@ -52,7 +52,7 @@ fn fragment(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
     frag_coord.z = unpack_unorm3x4_plus_unorm_20_(deferred_data.b).w;
 #else
 #ifdef DEPTH_PREPASS
-    frag_coord.z = prepass_utils::prepass_depth(in.position, 0u);
+    frag_coord.z = prepass_utils::prepass_depth(in.position);
 #endif
 #endif
 
@@ -68,7 +68,7 @@ fn fragment(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
         pbr_input.diffuse_occlusion = min(pbr_input.diffuse_occlusion, ssao_multibounce);
 
         // Neubelt and Pettineo 2013, "Crafting a Next-gen Material Pipeline for The Order: 1886"
-        let NdotV = max(dot(pbr_input.N, pbr_input.V), 0.0001); 
+        let NdotV = max(dot(pbr_input.N, pbr_input.V), 0.0001);
         var perceptual_roughness: f32 = pbr_input.material.perceptual_roughness;
         let roughness = lighting::perceptualRoughnessToRoughness(perceptual_roughness);
         // Use SSAO to estimate the specular occlusion.
@@ -85,4 +85,3 @@ fn fragment(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
 
     return output_color;
 }
-

--- a/crates/bevy_pbr/src/meshlet/material_shade_nodes.rs
+++ b/crates/bevy_pbr/src/meshlet/material_shade_nodes.rs
@@ -176,11 +176,11 @@ pub fn meshlet_prepass(
         view_prepass_textures
             .normal
             .as_ref()
-            .map(|normals_texture| normals_texture.get_attachment()),
+            .map(|normals_texture| normals_texture.get_attachment(StoreOp::Store)),
         view_prepass_textures
             .motion_vectors
             .as_ref()
-            .map(|motion_vectors_texture| motion_vectors_texture.get_attachment()),
+            .map(|motion_vectors_texture| motion_vectors_texture.get_attachment(StoreOp::Store)),
         // Use None in place of Deferred attachments
         None,
         None,
@@ -287,19 +287,21 @@ pub fn meshlet_deferred_gbuffer_prepass(
         view_prepass_textures
             .normal
             .as_ref()
-            .map(|normals_texture| normals_texture.get_attachment()),
+            .map(|normals_texture| normals_texture.get_attachment(StoreOp::Store)),
         view_prepass_textures
             .motion_vectors
             .as_ref()
-            .map(|motion_vectors_texture| motion_vectors_texture.get_attachment()),
+            .map(|motion_vectors_texture| motion_vectors_texture.get_attachment(StoreOp::Store)),
         view_prepass_textures
             .deferred
             .as_ref()
-            .map(|deferred_texture| deferred_texture.get_attachment()),
+            .map(|deferred_texture| deferred_texture.get_attachment(StoreOp::Store)),
         view_prepass_textures
             .deferred_lighting_pass_id
             .as_ref()
-            .map(|deferred_lighting_pass_id| deferred_lighting_pass_id.get_attachment()),
+            .map(|deferred_lighting_pass_id| {
+                deferred_lighting_pass_id.get_attachment(StoreOp::Store)
+            }),
     ];
 
     let mut render_pass = ctx.begin_tracked_render_pass(RenderPassDescriptor {

--- a/crates/bevy_pbr/src/prepass/prepass_bindings.rs
+++ b/crates/bevy_pbr/src/prepass/prepass_bindings.rs
@@ -5,6 +5,10 @@ use bevy_render::render_resource::{
 
 use crate::MeshPipelineViewLayoutKey;
 
+/// Get the bind group entries of prepass textures.
+///
+/// If `float32_filterable` [`bevy_render::settings::WgpuFeatures::FLOAT32_FILTERABLE`] is true,
+/// depth texture binding will be filterable.
 pub fn get_bind_group_layout_entries(
     layout_key: MeshPipelineViewLayoutKey,
     float32_filterable: bool,
@@ -13,7 +17,9 @@ pub fn get_bind_group_layout_entries(
 
     if layout_key.contains(MeshPipelineViewLayoutKey::DEPTH_PREPASS) {
         // Depth texture
-        entries[0] = Some(texture_2d(TextureSampleType::Float { filterable: true }));
+        entries[0] = Some(texture_2d(TextureSampleType::Float {
+            filterable: float32_filterable,
+        }));
     }
 
     if layout_key.contains(MeshPipelineViewLayoutKey::NORMAL_PREPASS) {
@@ -23,9 +29,7 @@ pub fn get_bind_group_layout_entries(
 
     if layout_key.contains(MeshPipelineViewLayoutKey::MOTION_VECTOR_PREPASS) {
         // Motion Vectors texture
-        entries[2] = Some(texture_2d(TextureSampleType::Float {
-            filterable: float32_filterable,
-        }));
+        entries[2] = Some(texture_2d(TextureSampleType::Float { filterable: true }));
     }
 
     if layout_key.contains(MeshPipelineViewLayoutKey::DEFERRED_PREPASS) {

--- a/crates/bevy_pbr/src/prepass/prepass_bindings.rs
+++ b/crates/bevy_pbr/src/prepass/prepass_bindings.rs
@@ -7,22 +7,25 @@ use crate::MeshPipelineViewLayoutKey;
 
 pub fn get_bind_group_layout_entries(
     layout_key: MeshPipelineViewLayoutKey,
+    float32_filterable: bool,
 ) -> [Option<BindGroupLayoutEntryBuilder>; 4] {
     let mut entries: [Option<BindGroupLayoutEntryBuilder>; 4] = [None; 4];
 
     if layout_key.contains(MeshPipelineViewLayoutKey::DEPTH_PREPASS) {
         // Depth texture
-        entries[0] = Some(texture_2d(TextureSampleType::Float { filterable: false }));
+        entries[0] = Some(texture_2d(TextureSampleType::Float { filterable: true }));
     }
 
     if layout_key.contains(MeshPipelineViewLayoutKey::NORMAL_PREPASS) {
         // Normal texture
-        entries[1] = Some(texture_2d(TextureSampleType::Float { filterable: false }));
+        entries[1] = Some(texture_2d(TextureSampleType::Float { filterable: true }));
     }
 
     if layout_key.contains(MeshPipelineViewLayoutKey::MOTION_VECTOR_PREPASS) {
         // Motion Vectors texture
-        entries[2] = Some(texture_2d(TextureSampleType::Float { filterable: false }));
+        entries[2] = Some(texture_2d(TextureSampleType::Float {
+            filterable: float32_filterable,
+        }));
     }
 
     if layout_key.contains(MeshPipelineViewLayoutKey::DEFERRED_PREPASS) {

--- a/crates/bevy_pbr/src/prepass/prepass_bindings.rs
+++ b/crates/bevy_pbr/src/prepass/prepass_bindings.rs
@@ -1,12 +1,7 @@
 use bevy_core_pipeline::prepass::ViewPrepassTextures;
 use bevy_render::render_resource::{
-    binding_types::{
-        texture_2d, texture_2d_multisampled, texture_depth_2d, texture_depth_2d_multisampled,
-    },
-    BindGroupLayoutEntryBuilder, TextureAspect, TextureSampleType, TextureView,
-    TextureViewDescriptor,
+    binding_types::texture_2d, BindGroupLayoutEntryBuilder, TextureSampleType, TextureView,
 };
-use bevy_utils::default;
 
 use crate::MeshPipelineViewLayoutKey;
 
@@ -15,37 +10,19 @@ pub fn get_bind_group_layout_entries(
 ) -> [Option<BindGroupLayoutEntryBuilder>; 4] {
     let mut entries: [Option<BindGroupLayoutEntryBuilder>; 4] = [None; 4];
 
-    let multisampled = layout_key.contains(MeshPipelineViewLayoutKey::MULTISAMPLED);
-
     if layout_key.contains(MeshPipelineViewLayoutKey::DEPTH_PREPASS) {
         // Depth texture
-        entries[0] = if multisampled {
-            Some(texture_depth_2d_multisampled())
-        } else {
-            Some(texture_depth_2d())
-        };
+        entries[0] = Some(texture_2d(TextureSampleType::Float { filterable: false }));
     }
 
     if layout_key.contains(MeshPipelineViewLayoutKey::NORMAL_PREPASS) {
         // Normal texture
-        entries[1] = if multisampled {
-            Some(texture_2d_multisampled(TextureSampleType::Float {
-                filterable: false,
-            }))
-        } else {
-            Some(texture_2d(TextureSampleType::Float { filterable: false }))
-        };
+        entries[1] = Some(texture_2d(TextureSampleType::Float { filterable: false }));
     }
 
     if layout_key.contains(MeshPipelineViewLayoutKey::MOTION_VECTOR_PREPASS) {
         // Motion Vectors texture
-        entries[2] = if multisampled {
-            Some(texture_2d_multisampled(TextureSampleType::Float {
-                filterable: false,
-            }))
-        } else {
-            Some(texture_2d(TextureSampleType::Float { filterable: false }))
-        };
+        entries[2] = Some(texture_2d(TextureSampleType::Float { filterable: false }));
     }
 
     if layout_key.contains(MeshPipelineViewLayoutKey::DEFERRED_PREPASS) {
@@ -57,17 +34,8 @@ pub fn get_bind_group_layout_entries(
 }
 
 pub fn get_bindings(prepass_textures: Option<&ViewPrepassTextures>) -> [Option<TextureView>; 4] {
-    let depth_desc = TextureViewDescriptor {
-        label: Some("prepass_depth"),
-        aspect: TextureAspect::DepthOnly,
-        ..default()
-    };
-    let depth_view = prepass_textures
-        .and_then(|x| x.depth.as_ref())
-        .map(|texture| texture.texture.texture.create_view(&depth_desc));
-
     [
-        depth_view,
+        prepass_textures.and_then(|pt| pt.depth_view().cloned()),
         prepass_textures.and_then(|pt| pt.normal_view().cloned()),
         prepass_textures.and_then(|pt| pt.motion_vectors_view().cloned()),
         prepass_textures.and_then(|pt| pt.deferred_view().cloned()),

--- a/crates/bevy_pbr/src/prepass/prepass_utils.wgsl
+++ b/crates/bevy_pbr/src/prepass/prepass_utils.wgsl
@@ -3,33 +3,21 @@
 #import bevy_pbr::mesh_view_bindings as view_bindings
 
 #ifdef DEPTH_PREPASS
-fn prepass_depth(frag_coord: vec4<f32>, sample_index: u32) -> f32 {
-#ifdef MULTISAMPLED
-    return textureLoad(view_bindings::depth_prepass_texture, vec2<i32>(frag_coord.xy), i32(sample_index));
-#else // MULTISAMPLED
-    return textureLoad(view_bindings::depth_prepass_texture, vec2<i32>(frag_coord.xy), 0);
-#endif // MULTISAMPLED
+fn prepass_depth(frag_coord: vec4<f32>) -> f32 {
+    return textureLoad(view_bindings::depth_prepass_texture, vec2<i32>(frag_coord.xy), 0).r;
 }
 #endif // DEPTH_PREPASS
 
 #ifdef NORMAL_PREPASS
-fn prepass_normal(frag_coord: vec4<f32>, sample_index: u32) -> vec3<f32> {
-#ifdef MULTISAMPLED
-    let normal_sample = textureLoad(view_bindings::normal_prepass_texture, vec2<i32>(frag_coord.xy), i32(sample_index));
-#else
+fn prepass_normal(frag_coord: vec4<f32>) -> vec3<f32> {
     let normal_sample = textureLoad(view_bindings::normal_prepass_texture, vec2<i32>(frag_coord.xy), 0);
-#endif // MULTISAMPLED
     return normalize(normal_sample.xyz * 2.0 - vec3(1.0));
 }
 #endif // NORMAL_PREPASS
 
 #ifdef MOTION_VECTOR_PREPASS
-fn prepass_motion_vector(frag_coord: vec4<f32>, sample_index: u32) -> vec2<f32> {
-#ifdef MULTISAMPLED
-    let motion_vector_sample = textureLoad(view_bindings::motion_vector_prepass_texture, vec2<i32>(frag_coord.xy), i32(sample_index));
-#else
+fn prepass_motion_vector(frag_coord: vec4<f32>) -> vec2<f32> {
     let motion_vector_sample = textureLoad(view_bindings::motion_vector_prepass_texture, vec2<i32>(frag_coord.xy), 0);
-#endif
     return motion_vector_sample.rg;
 }
 #endif // MOTION_VECTOR_PREPASS

--- a/crates/bevy_pbr/src/render/mesh_view_bindings.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_view_bindings.wgsl
@@ -58,30 +58,17 @@ const VISIBILITY_RANGE_UNIFORM_BUFFER_SIZE: u32 = 64u;
 @group(0) @binding(19) var dt_lut_texture: texture_3d<f32>;
 @group(0) @binding(20) var dt_lut_sampler: sampler;
 
-#ifdef MULTISAMPLED
-#ifdef DEPTH_PREPASS
-@group(0) @binding(21) var depth_prepass_texture: texture_depth_multisampled_2d;
-#endif // DEPTH_PREPASS
-#ifdef NORMAL_PREPASS
-@group(0) @binding(22) var normal_prepass_texture: texture_multisampled_2d<f32>;
-#endif // NORMAL_PREPASS
-#ifdef MOTION_VECTOR_PREPASS
-@group(0) @binding(23) var motion_vector_prepass_texture: texture_multisampled_2d<f32>;
-#endif // MOTION_VECTOR_PREPASS
-
-#else // MULTISAMPLED
 
 #ifdef DEPTH_PREPASS
-@group(0) @binding(21) var depth_prepass_texture: texture_depth_2d;
+@group(0) @binding(21) var depth_prepass_texture: texture_2d<f32>;
 #endif // DEPTH_PREPASS
+
 #ifdef NORMAL_PREPASS
 @group(0) @binding(22) var normal_prepass_texture: texture_2d<f32>;
 #endif // NORMAL_PREPASS
 #ifdef MOTION_VECTOR_PREPASS
 @group(0) @binding(23) var motion_vector_prepass_texture: texture_2d<f32>;
 #endif // MOTION_VECTOR_PREPASS
-
-#endif // MULTISAMPLED
 
 #ifdef DEFERRED_PREPASS
 @group(0) @binding(24) var deferred_prepass_texture: texture_2d<u32>;

--- a/crates/bevy_pbr/src/render/mesh_view_types.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_view_types.wgsl
@@ -179,6 +179,9 @@ struct ScreenSpaceReflectionsSettings {
     linear_march_exponent: f32,
     bisection_steps: u32,
     use_secant: u32,
+#ifdef SIXTEEN_BYTE_ALIGNMENT
+    _webgl2_padding: u32,
+#endif
 };
 
 // See the `ContactShadows` rust struct.

--- a/crates/bevy_pbr/src/render/pbr_fragment.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_fragment.wgsl
@@ -62,7 +62,7 @@ fn pbr_input_from_vertex_output(
     );
 
 #ifdef LOAD_PREPASS_NORMALS
-    pbr_input.N = prepass_utils::prepass_normal(in.position, 0u);
+    pbr_input.N = prepass_utils::prepass_normal(in.position);
 #else
     pbr_input.N = normalize(pbr_input.world_normal);
 #endif

--- a/crates/bevy_pbr/src/ssao/mod.rs
+++ b/crates/bevy_pbr/src/ssao/mod.rs
@@ -22,9 +22,7 @@ use bevy_render::{
     extract_component::ExtractComponent,
     globals::{GlobalsBuffer, GlobalsUniform},
     render_resource::{
-        binding_types::{
-            sampler, texture_2d, texture_depth_2d, texture_storage_2d, uniform_buffer,
-        },
+        binding_types::{sampler, texture_2d, texture_storage_2d, uniform_buffer},
         *,
     },
     renderer::{RenderAdapter, RenderContext, RenderDevice, RenderQueue, ViewQuery},
@@ -347,7 +345,7 @@ impl FromWorld for SsaoPipelines {
             &BindGroupLayoutEntries::sequential(
                 ShaderStages::COMPUTE,
                 (
-                    texture_depth_2d(),
+                    texture_2d(TextureSampleType::Float { filterable: false }),
                     texture_storage_2d(depth_format, StorageTextureAccess::WriteOnly),
                     texture_storage_2d(depth_format, StorageTextureAccess::WriteOnly),
                     texture_storage_2d(depth_format, StorageTextureAccess::WriteOnly),

--- a/crates/bevy_pbr/src/ssao/preprocess_depth.wgsl
+++ b/crates/bevy_pbr/src/ssao/preprocess_depth.wgsl
@@ -7,7 +7,7 @@
 
 #import bevy_render::view::View
 
-@group(0) @binding(0) var input_depth: texture_depth_2d;
+@group(0) @binding(0) var input_depth: texture_2d<f32>;
 #ifdef USE_R16FLOAT
 @group(0) @binding(1) var preprocessed_depth_mip0: texture_storage_2d<r16float, write>;
 @group(0) @binding(2) var preprocessed_depth_mip1: texture_storage_2d<r16float, write>;

--- a/crates/bevy_pbr/src/ssr/mod.rs
+++ b/crates/bevy_pbr/src/ssr/mod.rs
@@ -39,7 +39,7 @@ use bevy_render::{
     renderer::{RenderAdapter, RenderContext, RenderDevice, RenderQueue, ViewQuery},
     sync_component::SyncComponent,
     texture::GpuImage,
-    view::{ExtractedView, Msaa, ViewTarget, ViewUniformOffset},
+    view::{ExtractedView, ViewTarget, ViewUniformOffset},
     Render, RenderApp, RenderStartup, RenderSystems,
 };
 use bevy_shader::{load_shader_library, Shader};

--- a/crates/bevy_pbr/src/ssr/mod.rs
+++ b/crates/bevy_pbr/src/ssr/mod.rs
@@ -171,7 +171,6 @@ pub struct ScreenSpaceReflectionsPipelineId(pub CachedRenderPipelineId);
 pub struct ScreenSpaceReflectionsPipeline {
     mesh_view_layouts: MeshPipelineViewLayouts,
     color_sampler: Sampler,
-    depth_linear_sampler: Sampler,
     depth_nearest_sampler: Sampler,
     bind_group_layout: BindGroupLayoutDescriptor,
     binding_arrays_are_usable: bool,
@@ -303,7 +302,6 @@ pub fn screen_space_reflections(
         &BindGroupEntries::sequential((
             postprocess.source,
             &ssr_pipeline.color_sampler,
-            &ssr_pipeline.depth_linear_sampler,
             &ssr_pipeline.depth_nearest_sampler,
             &stbn_view,
         )),
@@ -386,15 +384,6 @@ pub fn init_screen_space_reflections_pipeline(
         ..default()
     });
 
-    let depth_linear_sampler = render_device.create_sampler(&SamplerDescriptor {
-        label: "SSR depth linear sampler".into(),
-        address_mode_u: AddressMode::ClampToEdge,
-        address_mode_v: AddressMode::ClampToEdge,
-        mag_filter: FilterMode::Linear,
-        min_filter: FilterMode::Linear,
-        ..default()
-    });
-
     let depth_nearest_sampler = render_device.create_sampler(&SamplerDescriptor {
         label: "SSR depth nearest sampler".into(),
         address_mode_u: AddressMode::ClampToEdge,
@@ -407,7 +396,6 @@ pub fn init_screen_space_reflections_pipeline(
     commands.insert_resource(ScreenSpaceReflectionsPipeline {
         mesh_view_layouts: mesh_view_layouts.clone(),
         color_sampler,
-        depth_linear_sampler,
         depth_nearest_sampler,
         bind_group_layout,
         binding_arrays_are_usable: binding_arrays_are_usable(&render_device, &render_adapter),

--- a/crates/bevy_pbr/src/ssr/mod.rs
+++ b/crates/bevy_pbr/src/ssr/mod.rs
@@ -5,7 +5,7 @@ use core::ops::Range;
 use bevy_app::{App, Plugin};
 use bevy_asset::{load_embedded_asset, AssetServer, Handle};
 use bevy_core_pipeline::{
-    core_3d::{main_opaque_pass_3d, DEPTH_TEXTURE_SAMPLING_SUPPORTED},
+    core_3d::main_opaque_pass_3d,
     prepass::{DeferredPrepass, DepthPrepass, MotionVectorPrepass, NormalPrepass},
     schedule::{Core3d, Core3dSystems},
     FullscreenShader,
@@ -37,14 +37,14 @@ use bevy_render::{
         TextureViewDimension,
     },
     renderer::{RenderAdapter, RenderContext, RenderDevice, RenderQueue, ViewQuery},
+    settings::WgpuFeatures,
     sync_component::SyncComponent,
     texture::GpuImage,
     view::{ExtractedView, ViewTarget, ViewUniformOffset},
     Render, RenderApp, RenderStartup, RenderSystems,
 };
 use bevy_shader::{load_shader_library, Shader};
-use bevy_utils::{once, prelude::default};
-use tracing::info;
+use bevy_utils::prelude::default;
 
 use crate::{
     binding_arrays_are_usable, contact_shadows::ViewContactShadowsUniformOffset,
@@ -76,10 +76,6 @@ pub struct ScreenSpaceReflectionsPlugin;
 ///
 /// SSR is an approximation technique and produces artifacts in some situations.
 /// Hand-tuning the settings in this component will likely be useful.
-///
-/// Screen-space reflections are presently unsupported on WebGL 2 because of a
-/// bug whereby Naga doesn't generate correct GLSL when sampling depth buffers,
-/// which is required for screen-space raymarching.
 #[derive(Clone, Component, Reflect)]
 #[reflect(Component, Default, Clone)]
 #[require(DepthPrepass, DeferredPrepass)]
@@ -159,6 +155,8 @@ pub struct ScreenSpaceReflectionsUniform {
     bisection_steps: u32,
     /// A boolean converted to a `u32`.
     use_secant: u32,
+    #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
+    _webgl2_padding: u32,
 }
 
 /// Identifies which screen space reflections render pipeline a view needs.
@@ -195,6 +193,7 @@ pub struct ScreenSpaceReflectionsPipelineKey {
     is_hdr: bool,
     has_environment_maps: bool,
     has_atmosphere: bool,
+    depth_filterable: bool,
 }
 
 impl Plugin for ScreenSpaceReflectionsPlugin {
@@ -439,6 +438,7 @@ pub fn prepare_ssr_pipelines(
             With<DeferredPrepass>,
         ),
     >,
+    render_device: Res<RenderDevice>,
 ) {
     for (
         entity,
@@ -475,6 +475,9 @@ pub fn prepare_ssr_pipelines(
                 is_hdr: extracted_view.hdr,
                 has_environment_maps,
                 has_atmosphere,
+                depth_filterable: render_device
+                    .features()
+                    .contains(WgpuFeatures::FLOAT32_FILTERABLE),
             },
         );
 
@@ -520,14 +523,6 @@ impl ExtractComponent for ScreenSpaceReflections {
     type QueryFilter = ();
 
     fn extract_component(settings: QueryItem<'_, '_, Self::QueryData>) -> Option<Self::Out> {
-        if !DEPTH_TEXTURE_SAMPLING_SUPPORTED {
-            once!(info!(
-                "Disabling screen-space reflections on this platform because depth textures \
-                aren't supported correctly"
-            ));
-            return None;
-        }
-
         Some(settings.clone().into())
     }
 }
@@ -567,7 +562,12 @@ impl SpecializedRenderPipeline for ScreenSpaceReflectionsPipeline {
             shader_defs.push("BLUE_NOISE_TEXTURE".into());
         }
 
-        #[cfg(not(target_arch = "wasm32"))]
+        if key.depth_filterable {
+            shader_defs.push("DEPTH_FILTERABLE".into());
+        }
+
+        // WebGL2 disallows sampling same texture with different samplers.
+        #[cfg(not(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu"))))]
         shader_defs.push("USE_DEPTH_SAMPLERS".into());
 
         RenderPipelineDescriptor {
@@ -607,6 +607,8 @@ impl From<ScreenSpaceReflections> for ScreenSpaceReflectionsUniform {
             linear_march_exponent: settings.linear_march_exponent,
             bisection_steps: settings.bisection_steps,
             use_secant: settings.use_secant as u32,
+            #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
+            _webgl2_padding: 0,
         }
     }
 }

--- a/crates/bevy_pbr/src/ssr/raymarch.wgsl
+++ b/crates/bevy_pbr/src/ssr/raymarch.wgsl
@@ -25,8 +25,11 @@
 }
 
 #ifdef USE_DEPTH_SAMPLERS
+// Allows us to sample from the depth buffer with bilinear filtering.
+@group(2) @binding(2) var depth_linear_sampler: sampler;
+
 // Allows us to sample from the depth buffer with nearest-neighbor filtering.
-@group(2) @binding(2) var depth_nearest_sampler: sampler;
+@group(2) @binding(3) var depth_nearest_sampler: sampler;
 #endif
 
 // Manual depth fetch helpers used on WebGPU where depth + filtering sampler is invalid.

--- a/crates/bevy_pbr/src/ssr/raymarch.wgsl
+++ b/crates/bevy_pbr/src/ssr/raymarch.wgsl
@@ -32,7 +32,6 @@
 @group(2) @binding(3) var depth_nearest_sampler: sampler;
 #endif
 
-// Manual depth fetch helpers used on WebGPU where depth + filtering sampler is invalid.
 #ifndef USE_DEPTH_SAMPLERS
 fn depth_texel_clamped(texel: vec2<i32>) -> f32 {
     let dims = textureDimensions(depth_prepass_texture);
@@ -65,7 +64,11 @@ fn depth_sample_bilinear_clamped(uv: vec2<f32>, tex_size: vec2<f32>) -> f32 {
 
 fn depth_sample_linear(uv: vec2<f32>, tex_size: vec2<f32>) -> f32 {
 #ifdef USE_DEPTH_SAMPLERS
+#ifdef DEPTH_FILTERABLE
     return textureSampleLevel(depth_prepass_texture, depth_linear_sampler, uv, 0.0).r;
+#else
+    return depth_sample_bilinear_clamped(uv, tex_size);
+#endif
 #else
     return depth_sample_bilinear_clamped(uv, tex_size);
 #endif

--- a/crates/bevy_pbr/src/ssr/raymarch.wgsl
+++ b/crates/bevy_pbr/src/ssr/raymarch.wgsl
@@ -25,11 +25,8 @@
 }
 
 #ifdef USE_DEPTH_SAMPLERS
-// Allows us to sample from the depth buffer with bilinear filtering.
-@group(2) @binding(2) var depth_linear_sampler: sampler;
-
 // Allows us to sample from the depth buffer with nearest-neighbor filtering.
-@group(2) @binding(3) var depth_nearest_sampler: sampler;
+@group(2) @binding(2) var depth_nearest_sampler: sampler;
 #endif
 
 // Manual depth fetch helpers used on WebGPU where depth + filtering sampler is invalid.
@@ -65,7 +62,7 @@ fn depth_sample_bilinear_clamped(uv: vec2<f32>, tex_size: vec2<f32>) -> f32 {
 
 fn depth_sample_linear(uv: vec2<f32>, tex_size: vec2<f32>) -> f32 {
 #ifdef USE_DEPTH_SAMPLERS
-    return textureSampleLevel(depth_prepass_texture, depth_linear_sampler, uv, 0u).r;
+    return textureSampleLevel(depth_prepass_texture, depth_linear_sampler, uv, 0.0).r;
 #else
     return depth_sample_bilinear_clamped(uv, tex_size);
 #endif
@@ -73,7 +70,7 @@ fn depth_sample_linear(uv: vec2<f32>, tex_size: vec2<f32>) -> f32 {
 
 fn depth_sample_nearest(uv: vec2<f32>, tex_size: vec2<f32>) -> f32 {
 #ifdef USE_DEPTH_SAMPLERS
-    return textureSampleLevel(depth_prepass_texture, depth_nearest_sampler, uv, 0u).r;
+    return textureSampleLevel(depth_prepass_texture, depth_nearest_sampler, uv, 0.0).r;
 #else
     return depth_sample_nearest_clamped(uv, tex_size);
 #endif

--- a/crates/bevy_pbr/src/ssr/raymarch.wgsl
+++ b/crates/bevy_pbr/src/ssr/raymarch.wgsl
@@ -38,7 +38,7 @@ fn depth_texel_clamped(texel: vec2<i32>) -> f32 {
     let dims = textureDimensions(depth_prepass_texture);
     let max_coord = vec2<i32>(i32(dims.x) - 1, i32(dims.y) - 1);
     let clamped = clamp(texel, vec2<i32>(0), max_coord);
-    return textureLoad(depth_prepass_texture, clamped, 0);
+    return textureLoad(depth_prepass_texture, clamped, 0).r;
 }
 
 fn depth_sample_nearest_clamped(uv: vec2<f32>, tex_size: vec2<f32>) -> f32 {
@@ -65,7 +65,7 @@ fn depth_sample_bilinear_clamped(uv: vec2<f32>, tex_size: vec2<f32>) -> f32 {
 
 fn depth_sample_linear(uv: vec2<f32>, tex_size: vec2<f32>) -> f32 {
 #ifdef USE_DEPTH_SAMPLERS
-    return textureSampleLevel(depth_prepass_texture, depth_linear_sampler, uv, 0u);
+    return textureSampleLevel(depth_prepass_texture, depth_linear_sampler, uv, 0u).r;
 #else
     return depth_sample_bilinear_clamped(uv, tex_size);
 #endif
@@ -73,7 +73,7 @@ fn depth_sample_linear(uv: vec2<f32>, tex_size: vec2<f32>) -> f32 {
 
 fn depth_sample_nearest(uv: vec2<f32>, tex_size: vec2<f32>) -> f32 {
 #ifdef USE_DEPTH_SAMPLERS
-    return textureSampleLevel(depth_prepass_texture, depth_nearest_sampler, uv, 0u);
+    return textureSampleLevel(depth_prepass_texture, depth_nearest_sampler, uv, 0u).r;
 #else
     return depth_sample_nearest_clamped(uv, tex_size);
 #endif

--- a/crates/bevy_pbr/src/ssr/ssr.wgsl
+++ b/crates/bevy_pbr/src/ssr/ssr.wgsl
@@ -50,9 +50,9 @@
 // The sampler that lets us sample from the color framebuffer.
 @group(2) @binding(1) var color_sampler: sampler;
 
-// Group 1, bindings 2 and 3 are in `raymarch.wgsl`.
+// Group 2, bindings 2 is in `raymarch.wgsl`.
 
-@group(2) @binding(4) var stbn_texture: texture_2d_array<f32>;
+@group(2) @binding(3) var stbn_texture: texture_2d_array<f32>;
 
 struct BrdfSample {
     wi: vec3<f32>,

--- a/crates/bevy_pbr/src/ssr/ssr.wgsl
+++ b/crates/bevy_pbr/src/ssr/ssr.wgsl
@@ -50,7 +50,7 @@
 // The sampler that lets us sample from the color framebuffer.
 @group(2) @binding(1) var color_sampler: sampler;
 
-// Group 1, bindings 2 and 3 are in `raymarch.wgsl`.
+// Group 2, bindings 2 and 3 are in `raymarch.wgsl`.
 
 @group(2) @binding(4) var stbn_texture: texture_2d_array<f32>;
 

--- a/crates/bevy_pbr/src/ssr/ssr.wgsl
+++ b/crates/bevy_pbr/src/ssr/ssr.wgsl
@@ -61,7 +61,7 @@ struct BrdfSample {
 
 fn sample_specular_brdf(wo: vec3<f32>, roughness: f32, F0: vec3<f32>, urand: vec2<f32>, N: vec3<f32>) -> BrdfSample {
     var brdf_sample: BrdfSample;
-    
+
     // Use VNDF sampling for the half-vector.
     let wi = lighting::sample_visible_ggx(urand, roughness, N, wo);
     let H = normalize(wo + wi);
@@ -127,7 +127,7 @@ fn evaluate_ssr(R_world: vec3<f32>, P_world: vec3<f32>, jitter: f32) -> vec4<f32
 fn fragment(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
     // Sample the depth.
     var frag_coord = in.position;
-    frag_coord.z = prepass_utils::prepass_depth(in.position, 0u);
+    frag_coord.z = prepass_utils::prepass_depth(in.position);
 
     // Load the G-buffer data.
     let fragment = textureLoad(color_texture, vec2<i32>(frag_coord.xy), 0);
@@ -220,7 +220,7 @@ fn fragment(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
     // Sample the BRDF.
     let N_tangent = vec3(0.0, 0.0, 1.0);
     let V_tangent = V * tangent_to_world;
-    
+
     let brdf_sample = sample_specular_brdf(V_tangent, roughness, F0, urand, N_tangent);
     let R_stochastic = tangent_to_world * brdf_sample.wi;
     let brdf_sample_value_over_pdf = brdf_sample.value_over_pdf;

--- a/crates/bevy_pbr/src/ssr/ssr.wgsl
+++ b/crates/bevy_pbr/src/ssr/ssr.wgsl
@@ -50,9 +50,9 @@
 // The sampler that lets us sample from the color framebuffer.
 @group(2) @binding(1) var color_sampler: sampler;
 
-// Group 2, bindings 2 is in `raymarch.wgsl`.
+// Group 1, bindings 2 and 3 are in `raymarch.wgsl`.
 
-@group(2) @binding(3) var stbn_texture: texture_2d_array<f32>;
+@group(2) @binding(4) var stbn_texture: texture_2d_array<f32>;
 
 struct BrdfSample {
     wi: vec3<f32>,

--- a/crates/bevy_pbr/src/transmission/transmission.wgsl
+++ b/crates/bevy_pbr/src/transmission/transmission.wgsl
@@ -168,7 +168,7 @@ fn fetch_transmissive_background(offset_position: vec2<f32>, frag_coord: vec3<f3
 #ifdef DEPTH_PREPASS
 #ifndef WEBGL2
         // Use depth prepass data to reject values that are in front of the current fragment
-        if prepass_utils::prepass_depth(vec4<f32>(modified_offset_position * view_bindings::view.viewport.zw, 0.0, 0.0), 0u) > frag_coord.z {
+        if prepass_utils::prepass_depth(vec4<f32>(modified_offset_position * view_bindings::view.viewport.zw, 0.0, 0.0)) > frag_coord.z {
             sample = vec4<f32>(0.0);
         }
 #endif

--- a/crates/bevy_post_process/src/bloom/mod.rs
+++ b/crates/bevy_post_process/src/bloom/mod.rs
@@ -277,40 +277,17 @@ pub fn bloom(
 #[derive(Component)]
 pub struct BloomTexture {
     // First mip is half the screen resolution, successive mips are half the previous
-    #[cfg(any(
-        not(feature = "webgl"),
-        not(target_arch = "wasm32"),
-        feature = "webgpu"
-    ))]
     texture: CachedTexture,
-    // WebGL does not support binding specific mip levels for sampling, fallback to separate textures instead
-    #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
-    texture: Vec<CachedTexture>,
     mip_count: u32,
 }
 
 impl BloomTexture {
-    #[cfg(any(
-        not(feature = "webgl"),
-        not(target_arch = "wasm32"),
-        feature = "webgpu"
-    ))]
     fn view(&self, base_mip_level: u32) -> TextureView {
         self.texture.texture.create_view(&TextureViewDescriptor {
             base_mip_level,
             mip_level_count: Some(1u32),
             ..Default::default()
         })
-    }
-    #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
-    fn view(&self, base_mip_level: u32) -> TextureView {
-        self.texture[base_mip_level as usize]
-            .texture
-            .create_view(&TextureViewDescriptor {
-                base_mip_level: 0,
-                mip_level_count: Some(1u32),
-                ..Default::default()
-            })
     }
 }
 
@@ -345,29 +322,7 @@ fn prepare_bloom_textures(
                 view_formats: &[],
             };
 
-            #[cfg(any(
-                not(feature = "webgl"),
-                not(target_arch = "wasm32"),
-                feature = "webgpu"
-            ))]
             let texture = texture_cache.get(&render_device, texture_descriptor);
-            #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
-            let texture: Vec<CachedTexture> = (0..mip_count)
-                .map(|mip| {
-                    texture_cache.get(
-                        &render_device,
-                        TextureDescriptor {
-                            size: Extent3d {
-                                width: (texture_descriptor.size.width >> mip).max(1),
-                                height: (texture_descriptor.size.height >> mip).max(1),
-                                depth_or_array_layers: 1,
-                            },
-                            mip_level_count: 1,
-                            ..texture_descriptor.clone()
-                        },
-                    )
-                })
-                .collect();
 
             commands
                 .entity(entity)

--- a/crates/bevy_post_process/src/bloom/settings.rs
+++ b/crates/bevy_post_process/src/bloom/settings.rs
@@ -18,8 +18,6 @@ use bevy_render::{extract_component::ExtractComponent, sync_component::SyncCompo
 ///
 /// # Usage Notes
 ///
-/// **Bloom is currently not compatible with WebGL2.**
-///
 /// Often used in conjunction with `bevy_pbr::StandardMaterial::emissive` for 3d meshes.
 ///
 /// Bloom is best used alongside a tonemapping function that desaturates bright colors,

--- a/crates/bevy_post_process/src/dof/dof.wgsl
+++ b/crates/bevy_post_process/src/dof/dof.wgsl
@@ -76,9 +76,9 @@ struct DualOutput {
 
 // The depth texture for the main view.
 #ifdef MULTISAMPLED
-@group(0) @binding(1) var depth_texture: texture_depth_multisampled_2d;
+@group(0) @binding(1) var depth_texture: texture_multisampled_2d<f32>;
 #else   // MULTISAMPLED
-@group(0) @binding(1) var depth_texture: texture_depth_2d;
+@group(0) @binding(1) var depth_texture: texture_2d<f32>;
 #endif  // MULTISAMPLED
 
 // The main color texture.
@@ -123,7 +123,7 @@ fn calculate_circle_of_confusion(in_frag_coord: vec4<f32>) -> f32 {
 
     // Sample the depth.
     let frag_coord = vec2<i32>(floor(in_frag_coord.xy));
-    let raw_depth = textureLoad(depth_texture, frag_coord, 0);
+    let raw_depth = textureLoad(depth_texture, frag_coord, 0).r;
     let depth = min(-depth_ndc_to_view_z(raw_depth), dof_params.max_depth);
 
     // Calculate the circle of confusion.
@@ -212,7 +212,7 @@ fn gaussian_vertical(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
 //       │
 //       │
 @fragment
-fn bokeh_pass_0(in: FullscreenVertexOutput) -> DualOutput {
+fn bokeh_pass_a(in: FullscreenVertexOutput) -> DualOutput {
     let coc = calculate_circle_of_confusion(in.position);
     let vertical = box_blur_a(in.position, coc, vec2(0.0, 1.0));
     let diagonal = box_blur_a(in.position, coc, vec2(COS_NEG_FRAC_PI_6, SIN_NEG_FRAC_PI_6));
@@ -232,7 +232,7 @@ fn bokeh_pass_0(in: FullscreenVertexOutput) -> DualOutput {
 //       •
 #ifdef DUAL_INPUT
 @fragment
-fn bokeh_pass_1(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
+fn bokeh_pass_b(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
     let coc = calculate_circle_of_confusion(in.position);
     let output_0 = box_blur_a(in.position, coc, vec2(COS_NEG_FRAC_PI_6, SIN_NEG_FRAC_PI_6));
     let output_1 = box_blur_b(in.position, coc, vec2(COS_NEG_FRAC_PI_5_6, SIN_NEG_FRAC_PI_5_6));

--- a/crates/bevy_post_process/src/dof/mod.rs
+++ b/crates/bevy_post_process/src/dof/mod.rs
@@ -33,9 +33,7 @@ use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_render::{
     extract_component::{ComponentUniforms, DynamicUniformIndex, UniformComponentPlugin},
     render_resource::{
-        binding_types::{
-            sampler, texture_2d, texture_depth_2d, texture_depth_2d_multisampled, uniform_buffer,
-        },
+        binding_types::{sampler, texture_2d, texture_2d_multisampled, uniform_buffer},
         BindGroup, BindGroupEntries, BindGroupLayoutDescriptor, BindGroupLayoutEntries,
         CachedRenderPipelineId, ColorTargetState, ColorWrites, FilterMode, FragmentState, LoadOp,
         Operations, PipelineCache, RenderPassColorAttachment, RenderPassDescriptor,
@@ -56,13 +54,10 @@ use bevy_render::{
 use bevy_shader::Shader;
 use bevy_utils::{default, once};
 use smallvec::SmallVec;
-use tracing::{info, warn};
+use tracing::warn;
 
 use crate::bloom::bloom;
-use bevy_core_pipeline::{
-    core_3d::DEPTH_TEXTURE_SAMPLING_SUPPORTED, schedule::Core3d, tonemapping::tonemapping,
-    FullscreenShader,
-};
+use bevy_core_pipeline::{schedule::Core3d, tonemapping::tonemapping, FullscreenShader};
 
 /// A plugin that adds support for the depth of field effect to Bevy.
 #[derive(Default)]
@@ -123,8 +118,6 @@ pub enum DepthOfFieldMode {
     /// "spots" of light.
     ///
     /// For more information, see [Wikipedia's article on *bokeh*].
-    ///
-    /// This doesn't work on WebGPU.
     ///
     /// [Wikipedia's article on *bokeh*]: https://en.wikipedia.org/wiki/Bokeh
     Bokeh,
@@ -389,9 +382,9 @@ pub fn prepare_depth_of_field_view_bind_group_layouts(
                 (
                     uniform_buffer::<ViewUniform>(true),
                     if *msaa != Msaa::Off {
-                        texture_depth_2d_multisampled()
+                        texture_2d_multisampled(TextureSampleType::Float { filterable: false })
                     } else {
-                        texture_depth_2d()
+                        texture_2d(TextureSampleType::Float { filterable: false })
                     },
                     texture_2d(TextureSampleType::Float { filterable: true }),
                 ),
@@ -409,9 +402,9 @@ pub fn prepare_depth_of_field_view_bind_group_layouts(
                     (
                         uniform_buffer::<ViewUniform>(true),
                         if *msaa != Msaa::Off {
-                            texture_depth_2d_multisampled()
+                            texture_2d_multisampled(TextureSampleType::Float { filterable: false })
                         } else {
-                            texture_depth_2d()
+                            texture_2d(TextureSampleType::Float { filterable: false })
                         },
                         texture_2d(TextureSampleType::Float { filterable: true }),
                         texture_2d(TextureSampleType::Float { filterable: true }),
@@ -643,8 +636,8 @@ impl SpecializedRenderPipeline for DepthOfFieldPipeline {
                 entry_point: Some(match key.pass {
                     DofPass::GaussianHorizontal => "gaussian_horizontal".into(),
                     DofPass::GaussianVertical => "gaussian_vertical".into(),
-                    DofPass::BokehPass0 => "bokeh_pass_0".into(),
-                    DofPass::BokehPass1 => "bokeh_pass_1".into(),
+                    DofPass::BokehPass0 => "bokeh_pass_a".into(),
+                    DofPass::BokehPass1 => "bokeh_pass_b".into(),
                 }),
                 targets,
             }),
@@ -668,13 +661,6 @@ fn extract_depth_of_field_settings(
     mut commands: Commands,
     mut query: Extract<Query<(RenderEntity, &DepthOfField, &Projection)>>,
 ) {
-    if !DEPTH_TEXTURE_SAMPLING_SUPPORTED {
-        once!(info!(
-            "Disabling depth of field on this platform because depth textures aren't supported correctly"
-        ));
-        return;
-    }
-
     for (entity, depth_of_field, projection) in query.iter_mut() {
         let mut entity_commands = commands
             .get_entity(entity)

--- a/crates/bevy_post_process/src/motion_blur/motion_blur.wgsl
+++ b/crates/bevy_post_process/src/motion_blur/motion_blur.wgsl
@@ -28,13 +28,7 @@ fn fragment(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
     let shutter_angle = settings.shutter_angle;
     let this_motion_vector = textureSample(motion_vectors, texture_sampler, in.uv).rg;
 
-#ifdef NO_DEPTH_TEXTURE_SUPPORT
-    let this_depth = 0.0;
-    let depth_supported = false;
-#else
-    let depth_supported = true;
     let this_depth = textureSample(depth, texture_sampler, in.uv).r;
-#endif
 
     // The exposure vector is the distance that this fragment moved while the camera shutter was
     // open. This is the motion vector (total distance traveled) multiplied by the shutter angle (a
@@ -65,14 +59,10 @@ fn fragment(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
 
         let sample_color = textureSample(screen_texture, texture_sampler, sample_uv);
         let sample_motion = textureSample(motion_vectors, texture_sampler, sample_uv).rg;
-    #ifdef NO_DEPTH_TEXTURE_SUPPORT
-        let sample_depth = 0.0;
-    #else
         let sample_depth = textureSample(depth, texture_sampler, sample_uv).r;
-    #endif
 
         var weight = 1.0;
-        let is_sample_in_fg = !(depth_supported && sample_depth < this_depth && sample_depth > 0.0);
+        let is_sample_in_fg = !(sample_depth < this_depth && sample_depth > 0.0);
         // If the depth is 0.0, this fragment has no depth written to it and we assume it is in the
         // background. This ensures that things like skyboxes, which do not write to depth, are
         // correctly sampled in motion blur.

--- a/crates/bevy_post_process/src/motion_blur/motion_blur.wgsl
+++ b/crates/bevy_post_process/src/motion_blur/motion_blur.wgsl
@@ -3,16 +3,11 @@
 #import bevy_core_pipeline::fullscreen_vertex_shader::FullscreenVertexOutput
 #import bevy_render::globals::Globals
 
-#ifdef MULTISAMPLED
-@group(0) @binding(0) var screen_texture: texture_2d<f32>;
-@group(0) @binding(1) var motion_vectors: texture_multisampled_2d<f32>;
-@group(0) @binding(2) var depth: texture_depth_multisampled_2d;
-#else
 @group(0) @binding(0) var screen_texture: texture_2d<f32>;
 @group(0) @binding(1) var motion_vectors: texture_2d<f32>;
-@group(0) @binding(2) var depth: texture_depth_2d;
-#endif
+@group(0) @binding(2) var depth: texture_2d<f32>;
 @group(0) @binding(3) var texture_sampler: sampler;
+
 struct MotionBlur {
     shutter_angle: f32,
     samples: u32,
@@ -25,41 +20,22 @@ struct MotionBlur {
 @group(0) @binding(5) var<uniform> globals: Globals;
 
 @fragment
-fn fragment(
-    #ifdef MULTISAMPLED
-        @builtin(sample_index) sample_index: u32,
-    #endif
-    in: FullscreenVertexOutput
-) -> @location(0) vec4<f32> { 
+fn fragment(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
     let texture_size = vec2<f32>(textureDimensions(screen_texture));
     let frag_coords = vec2<i32>(in.uv * texture_size);
 
-#ifdef MULTISAMPLED
-    let base_color = textureLoad(screen_texture, frag_coords, i32(sample_index));
-#else
     let base_color = textureSample(screen_texture, texture_sampler, in.uv);
-#endif
-
     let shutter_angle = settings.shutter_angle;
-
-#ifdef MULTISAMPLED
-    let this_motion_vector = textureLoad(motion_vectors, frag_coords, i32(sample_index)).rg;
-#else
     let this_motion_vector = textureSample(motion_vectors, texture_sampler, in.uv).rg;
-#endif
 
 #ifdef NO_DEPTH_TEXTURE_SUPPORT
     let this_depth = 0.0;
     let depth_supported = false;
 #else
     let depth_supported = true;
-#ifdef MULTISAMPLED
-    let this_depth = textureLoad(depth, frag_coords, i32(sample_index));
-#else
-    let this_depth = textureSample(depth, texture_sampler, in.uv);
+    let this_depth = textureSample(depth, texture_sampler, in.uv).r;
 #endif
-#endif
-    
+
     // The exposure vector is the distance that this fragment moved while the camera shutter was
     // open. This is the motion vector (total distance traveled) multiplied by the shutter angle (a
     // fraction). In film, the shutter angle is commonly 0.5 or "180 degrees" (out of 360 total).
@@ -74,7 +50,7 @@ fn fragment(
     var weight_total = 0.0;
     let n_samples = i32(settings.samples);
     let noise = utils::interleaved_gradient_noise(vec2<f32>(frag_coords), globals.frame_count); // 0 to 1
-       
+
     for (var i = -n_samples; i < n_samples; i++) {
         // The current sample step vector, from in.uv
         let step_vector = 0.5 * exposure_vector * (f32(i) + noise) / f32(n_samples);
@@ -87,24 +63,12 @@ fn fragment(
 
         let sample_coords = vec2<i32>(sample_uv * texture_size);
 
-    #ifdef MULTISAMPLED
-        let sample_color = textureLoad(screen_texture, sample_coords, i32(sample_index));
-    #else
         let sample_color = textureSample(screen_texture, texture_sampler, sample_uv);
-    #endif
-    #ifdef MULTISAMPLED
-        let sample_motion = textureLoad(motion_vectors, sample_coords, i32(sample_index)).rg;
-    #else
         let sample_motion = textureSample(motion_vectors, texture_sampler, sample_uv).rg;
-    #endif
     #ifdef NO_DEPTH_TEXTURE_SUPPORT
         let sample_depth = 0.0;
     #else
-    #ifdef MULTISAMPLED
-        let sample_depth = textureLoad(depth, sample_coords, i32(sample_index));
-    #else
-        let sample_depth = textureSample(depth, texture_sampler, sample_uv);
-    #endif
+        let sample_depth = textureSample(depth, texture_sampler, sample_uv).r;
     #endif
 
         var weight = 1.0;
@@ -146,7 +110,7 @@ fn fragment(
         accumulator += weight * sample_color;
     }
 
-    let has_moved_less_than_a_pixel = 
+    let has_moved_less_than_a_pixel =
         dot(this_motion_vector * texture_size, this_motion_vector * texture_size) < 1.0;
     // In case no samples were accepted, fall back to base color.
     // We also fall back if motion is small, to not break antialiasing.

--- a/crates/bevy_post_process/src/msaa_writeback.rs
+++ b/crates/bevy_post_process/src/msaa_writeback.rs
@@ -115,9 +115,8 @@ fn prepare_msaa_writeback_pipelines(
         if msaa.samples() > 1 && should_writeback {
             let key = BlitPipelineKey {
                 texture_format: view_target.main_texture_format(),
-                target_samples: msaa.samples(),
+                samples: msaa.samples(),
                 blend_state: None,
-                src_multisampled: false,
             };
 
             let pipeline = pipelines.specialize(&pipeline_cache, &blit_pipeline, key);

--- a/crates/bevy_post_process/src/msaa_writeback.rs
+++ b/crates/bevy_post_process/src/msaa_writeback.rs
@@ -115,8 +115,9 @@ fn prepare_msaa_writeback_pipelines(
         if msaa.samples() > 1 && should_writeback {
             let key = BlitPipelineKey {
                 texture_format: view_target.main_texture_format(),
-                samples: msaa.samples(),
+                target_samples: msaa.samples(),
                 blend_state: None,
+                src_multisampled: false,
             };
 
             let pipeline = pipelines.specialize(&pipeline_cache, &blit_pipeline, key);

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -729,18 +729,22 @@ impl ViewTarget {
     /// Retrieve this target's main texture's color attachment.
     pub fn get_color_attachment(&self) -> RenderPassColorAttachment<'_> {
         if self.main_texture.load(Ordering::SeqCst) == 0 {
-            self.main_textures.a.get_attachment()
+            self.main_textures.a.get_attachment(StoreOp::Store)
         } else {
-            self.main_textures.b.get_attachment()
+            self.main_textures.b.get_attachment(StoreOp::Store)
         }
     }
 
     /// Retrieve this target's "unsampled" main texture's color attachment.
     pub fn get_unsampled_color_attachment(&self) -> RenderPassColorAttachment<'_> {
         if self.main_texture.load(Ordering::SeqCst) == 0 {
-            self.main_textures.a.get_unsampled_attachment()
+            self.main_textures
+                .a
+                .get_unsampled_attachment(StoreOp::Store)
         } else {
-            self.main_textures.b.get_unsampled_attachment()
+            self.main_textures
+                .b
+                .get_unsampled_attachment(StoreOp::Store)
         }
     }
 
@@ -794,7 +798,7 @@ impl ViewTarget {
     pub fn sampled_main_texture(&self) -> Option<&Texture> {
         self.main_textures
             .a
-            .resolve_target
+            .multisampled
             .as_ref()
             .map(|sampled| &sampled.texture)
     }
@@ -803,7 +807,7 @@ impl ViewTarget {
     pub fn sampled_main_texture_view(&self) -> Option<&TextureView> {
         self.main_textures
             .a
-            .resolve_target
+            .multisampled
             .as_ref()
             .map(|sampled| &sampled.default_view)
     }

--- a/crates/bevy_solari/src/realtime/node.rs
+++ b/crates/bevy_solari/src/realtime/node.rs
@@ -14,9 +14,7 @@ use bevy_ecs::{prelude::*, resource::Resource, system::Commands};
 use bevy_render::{
     diagnostic::RecordDiagnostics as _,
     render_resource::{
-        binding_types::{
-            storage_buffer_sized, texture_2d, texture_depth_2d, texture_storage_2d, uniform_buffer,
-        },
+        binding_types::{storage_buffer_sized, texture_2d, texture_storage_2d, uniform_buffer},
         BindGroupEntries, BindGroupLayoutDescriptor, BindGroupLayoutEntries,
         CachedComputePipelineId, ComputePassDescriptor, ComputePipelineDescriptor, LoadOp,
         PipelineCache, RenderPassDescriptor, ShaderStages, StorageTextureAccess, TextureFormat,
@@ -413,10 +411,10 @@ pub fn init_solari_lighting_pipelines(
                 storage_buffer_sized(false, None),
                 storage_buffer_sized(false, None),
                 texture_2d(TextureSampleType::Uint),
-                texture_depth_2d(),
+                texture_2d(TextureSampleType::Float { filterable: false }),
                 texture_2d(TextureSampleType::Float { filterable: true }),
                 texture_2d(TextureSampleType::Uint),
-                texture_depth_2d(),
+                texture_2d(TextureSampleType::Float { filterable: false }),
                 uniform_buffer::<ViewUniform>(true),
                 uniform_buffer::<PreviousViewData>(true),
                 storage_buffer_sized(false, None),

--- a/crates/bevy_solari/src/realtime/realtime_bindings.wgsl
+++ b/crates/bevy_solari/src/realtime/realtime_bindings.wgsl
@@ -14,10 +14,10 @@ enable wgpu_ray_query;
 @group(1) @binding(5) var<storage, read_write> gi_reservoirs_a: array<Reservoir>;
 @group(1) @binding(6) var<storage, read_write> gi_reservoirs_b: array<Reservoir>;
 @group(1) @binding(7) var gbuffer: texture_2d<u32>;
-@group(1) @binding(8) var depth_buffer: texture_depth_2d;
+@group(1) @binding(8) var depth_buffer: texture_2d<f32>;
 @group(1) @binding(9) var motion_vectors: texture_2d<f32>;
 @group(1) @binding(10) var previous_gbuffer: texture_2d<u32>;
-@group(1) @binding(11) var previous_depth_buffer: texture_depth_2d;
+@group(1) @binding(11) var previous_depth_buffer: texture_2d<f32>;
 @group(1) @binding(12) var<uniform> view: View;
 @group(1) @binding(13) var<uniform> previous_view: PreviousViewUniforms;
 

--- a/crates/bevy_solari/src/realtime/resolve_dlss_rr_textures.wgsl
+++ b/crates/bevy_solari/src/realtime/resolve_dlss_rr_textures.wgsl
@@ -13,7 +13,7 @@ fn resolve_dlss_rr_textures(@builtin(global_invocation_id) global_id: vec3<u32>)
 
     textureStore(specular_motion_vectors, pixel_id, vec4(0.0));
 
-    let depth = textureLoad(depth_buffer, global_id.xy, 0);
+    let depth = textureLoad(depth_buffer, global_id.xy, 0).r;
     if depth == 0.0 {
         textureStore(diffuse_albedo, pixel_id, vec4(0.0));
         textureStore(specular_albedo, pixel_id, vec4(0.5));

--- a/crates/bevy_solari/src/realtime/restir_di.wgsl
+++ b/crates/bevy_solari/src/realtime/restir_di.wgsl
@@ -27,7 +27,7 @@ fn initial_and_temporal(@builtin(workgroup_id) workgroup_id: vec3<u32>, @builtin
     let pixel_index = global_id.x + global_id.y * u32(view.main_pass_viewport.z);
     var rng = pixel_index + constants.frame_index;
 
-    let depth = textureLoad(depth_buffer, global_id.xy, 0);
+    let depth = textureLoad(depth_buffer, global_id.xy, 0).r;
     if depth == 0.0 {
         store_reservoir_b(global_id.xy, empty_reservoir());
         return;
@@ -50,7 +50,7 @@ fn spatial_and_shade(@builtin(global_invocation_id) global_id: vec3<u32>) {
     let pixel_index = global_id.x + global_id.y * u32(view.main_pass_viewport.z);
     var rng = pixel_index + constants.frame_index;
 
-    let depth = textureLoad(depth_buffer, global_id.xy, 0);
+    let depth = textureLoad(depth_buffer, global_id.xy, 0).r;
     if depth == 0.0 {
         store_reservoir_a(global_id.xy, empty_reservoir());
         return;
@@ -172,7 +172,7 @@ fn load_temporal_reservoir(pixel_id: vec2<u32>, depth: f32, world_position: vec3
 
 fn load_temporal_reservoir_inner(temporal_pixel_id: vec2<u32>, depth: f32, world_position: vec3<f32>, world_normal: vec3<f32>) -> NeighborInfo {
     // Check if the pixel features have changed heavily between the current and previous frame
-    let temporal_depth = textureLoad(previous_depth_buffer, temporal_pixel_id, 0);
+    let temporal_depth = textureLoad(previous_depth_buffer, temporal_pixel_id, 0).r;
     let temporal_surface = gpixel_resolve(textureLoad(previous_gbuffer, temporal_pixel_id, 0), temporal_depth, temporal_pixel_id, view.main_pass_viewport.zw, previous_view.world_from_clip);
     let temporal_diffuse_brdf = temporal_surface.material.base_color / PI;
     if pixel_dissimilar(depth, world_position, temporal_surface.world_position, world_normal, temporal_surface.world_normal, view) {

--- a/crates/bevy_solari/src/realtime/restir_gi.wgsl
+++ b/crates/bevy_solari/src/realtime/restir_gi.wgsl
@@ -24,7 +24,7 @@ fn initial_and_temporal(@builtin(global_invocation_id) global_id: vec3<u32>) {
     let pixel_index = global_id.x + global_id.y * u32(view.main_pass_viewport.z);
     var rng = pixel_index + constants.frame_index;
 
-    let depth = textureLoad(depth_buffer, global_id.xy, 0);
+    let depth = textureLoad(depth_buffer, global_id.xy, 0).r;
     if depth == 0.0 {
         gi_reservoirs_b[pixel_index] = empty_reservoir();
         return;
@@ -50,7 +50,7 @@ fn spatial_and_shade(@builtin(global_invocation_id) global_id: vec3<u32>) {
     let pixel_index = global_id.x + global_id.y * u32(view.main_pass_viewport.z);
     var rng = pixel_index + constants.frame_index;
 
-    let depth = textureLoad(depth_buffer, global_id.xy, 0);
+    let depth = textureLoad(depth_buffer, global_id.xy, 0).r;
     if depth == 0.0 {
         gi_reservoirs_a[pixel_index] = empty_reservoir();
         return;
@@ -146,7 +146,7 @@ fn load_temporal_reservoir(pixel_id: vec2<u32>, depth: f32, world_position: vec3
 
 fn load_temporal_reservoir_inner(temporal_pixel_id: vec2<u32>, depth: f32, world_position: vec3<f32>, world_normal: vec3<f32>) -> NeighborInfo {
     // Check if the pixel features have changed heavily between the current and previous frame
-    let temporal_depth = textureLoad(previous_depth_buffer, temporal_pixel_id, 0);
+    let temporal_depth = textureLoad(previous_depth_buffer, temporal_pixel_id, 0).r;
     let temporal_surface = gpixel_resolve(textureLoad(previous_gbuffer, temporal_pixel_id, 0), temporal_depth, temporal_pixel_id, view.main_pass_viewport.zw, previous_view.world_from_clip);
     let temporal_diffuse_brdf = temporal_surface.material.base_color / PI;
     if pixel_dissimilar(depth, world_position, temporal_surface.world_position, world_normal, temporal_surface.world_normal, view) {

--- a/crates/bevy_solari/src/realtime/specular_gi.wgsl
+++ b/crates/bevy_solari/src/realtime/specular_gi.wgsl
@@ -26,7 +26,7 @@ fn specular_gi(@builtin(global_invocation_id) global_id: vec3<u32>) {
     let pixel_index = global_id.x + global_id.y * u32(view.main_pass_viewport.z);
     var rng = pixel_index + constants.frame_index;
 
-    let depth = textureLoad(depth_buffer, global_id.xy, 0);
+    let depth = textureLoad(depth_buffer, global_id.xy, 0).r;
     if depth == 0.0 {
         return;
     }

--- a/examples/3d/depth_of_field.rs
+++ b/examples/3d/depth_of_field.rs
@@ -76,6 +76,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, app_settings: R
         Transform::from_xyz(0.0, 4.5, 8.25).looking_at(Vec3::ZERO, Vec3::Y),
         Tonemapping::TonyMcMapface,
         Bloom::NATURAL,
+        #[cfg(all(feature = "webgl2", target_arch = "wasm32", not(feature = "webgpu")))]
+        Msaa::Off,
     ));
 
     // Insert the depth of field settings.

--- a/examples/3d/skybox.rs
+++ b/examples/3d/skybox.rs
@@ -1,6 +1,5 @@
 //! Load a cubemap texture onto a cube like a skybox and cycle through different compressed texture formats
 
-#[cfg(not(target_arch = "wasm32"))]
 use bevy::anti_alias::taa::TemporalAntiAliasing;
 
 use bevy::{
@@ -73,7 +72,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn((
         Camera3d::default(),
         Msaa::Off,
-        #[cfg(not(target_arch = "wasm32"))]
         TemporalAntiAliasing::default(),
         ScreenSpaceAmbientOcclusion::default(),
         Transform::from_xyz(0.0, 0.0, 8.0).looking_at(Vec3::ZERO, Vec3::Y),

--- a/examples/shader/shader_prepass.rs
+++ b/examples/shader/shader_prepass.rs
@@ -130,10 +130,12 @@ fn setup(
         },
         children![
             TextSpan::new("Prepass Output: transparent\n"),
+            TextSpan::new(format!("Msaa: {:?}\n", Msaa::Off)),
             TextSpan::new("\n\n"),
             TextSpan::new("Controls\n"),
             TextSpan::new("---------------\n"),
             TextSpan::new("Space - Change output\n"),
+            TextSpan::new("KeyM  - Change MSAA\n"),
         ],
     ));
 }
@@ -215,6 +217,7 @@ fn toggle_prepass_view(
     material_handle: Single<&MeshMaterial3d<PrepassOutputMaterial>>,
     mut materials: ResMut<Assets<PrepassOutputMaterial>>,
     text: Single<Entity, With<Text>>,
+    mut camera_msaa: Single<&mut Msaa, With<Camera3d>>,
     mut writer: TextUiWriter,
 ) {
     if keycode.just_pressed(KeyCode::Space) {
@@ -237,5 +240,15 @@ fn toggle_prepass_view(
         mat.settings.show_depth = (*prepass_view == 1) as u32;
         mat.settings.show_normals = (*prepass_view == 2) as u32;
         mat.settings.show_motion_vectors = (*prepass_view == 3) as u32;
+    }
+
+    if keycode.just_pressed(KeyCode::KeyM) {
+        **camera_msaa = if **camera_msaa == Msaa::Off {
+            Msaa::Sample4
+        } else {
+            Msaa::Off
+        };
+        let text = *text;
+        *writer.text(text, 2) = format!("Msaa: {:?}\n", **camera_msaa);
     }
 }

--- a/examples/shader/shader_prepass.rs
+++ b/examples/shader/shader_prepass.rs
@@ -47,7 +47,6 @@ fn setup(
     commands.spawn((
         Camera3d::default(),
         Transform::from_xyz(-2.0, 3., 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-        // Disabling MSAA for maximum compatibility. Shader prepass with MSAA needs GPU capability MULTISAMPLED_SHADING
         Msaa::Off,
         // To enable the prepass you need to add the components associated with the ones you need
         // This will write the depth buffer to a texture that you can use in the main pass


### PR DESCRIPTION
# Objective

Fixes #22830, fixes #22831

## Solution

`DepthPrepass` texture is changed to `R32Float` which is resolved with new `ResolvePlugin` in `prepass_depth_resolve` pass. Bonus: WebGPU doesn't support filterable depth textures, but float32-filterable is generally supported. WebGL2 should also support resolved depth prepass.

Multisampled `NormalPrepass` and `MotionVectorPrepass` textures are transient and are resolved during prepass.

## Testing

`shader_prepass` example can toggle MSAA.
DLSS and solari are likely broken due to changed depth prepass texture format.