### PR TITLE
Enable borderless_game for winit on macos

### DIFF
--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -432,6 +432,18 @@ pub struct Window {
     ///
     /// [`WindowAttributesExtMacOS::with_titlebar_buttons_hidden`]: https://docs.rs/winit/latest/x86_64-apple-darwin/winit/platform/macos/trait.WindowAttributesExtMacOS.html#tymethod.with_titlebar_buttons_hidden
     pub titlebar_show_buttons: bool,
+    /// Hides the dock and menu bar when a borderless fullscreen window is active.
+    ///
+    /// Corresponds to [`WindowAttributesExtMacOS::with_borderless_game`].
+    ///
+    /// Defaults to `true` as this is the expected behavior for games.
+    ///
+    /// # Platform-specific
+    ///
+    /// - Only used on macOS.
+    ///
+    /// [`WindowAttributesExtMacOS::with_borderless_game`]: https://docs.rs/winit/latest/x86_64-apple-darwin/winit/platform/macos/trait.WindowAttributesExtMacOS.html#tymethod.with_borderless_game
+    pub borderless_game: bool,
     /// Sets whether the Window prefers the home indicator hidden.
     ///
     /// Corresponds to [`WindowAttributesExtIOS::with_prefers_home_indicator_hidden`].
@@ -504,6 +516,7 @@ impl Default for Window {
             titlebar_transparent: false,
             titlebar_show_title: true,
             titlebar_show_buttons: true,
+            borderless_game: true,
             prefers_home_indicator_hidden: false,
             prefers_status_bar_hidden: false,
             preferred_screen_edges_deferring_system_gestures: Default::default(),

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -152,7 +152,8 @@ impl WinitWindows {
                 .with_titlebar_hidden(!window.titlebar_shown)
                 .with_titlebar_transparent(window.titlebar_transparent)
                 .with_title_hidden(!window.titlebar_show_title)
-                .with_titlebar_buttons_hidden(!window.titlebar_show_buttons);
+                .with_titlebar_buttons_hidden(!window.titlebar_show_buttons)
+                .with_borderless_game(window.borderless_game);
         }
 
         #[cfg(target_os = "ios")]


### PR DESCRIPTION
## Problem

Borderless Fullscreen on macOS does not hide the menu bar. 

Fixes: #14783 

## Solution
winit 0.30 added a  window attribute that hides the dock and menu bar when using  on macOS. This exposes that option as a field on Bevy's component, defaulting to true since this is the expected behavior in games.

## Testing

Tested by setting
```
DefaultPlugins.set(WindowPlugin {
    primary_window: Some(Window {
        mode: WindowMode::BorderlessFullscreen(MonitorSelection::Primary),
...
``` 
Launch the bevy app, and you should see that the menu bar is hidden.


## Showcase
Before:
<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/52baa247-c329-42e7-81f7-ec330e20ab15" />

After:
<img width="3022" height="1964" alt="image" src="https://github.com/user-attachments/assets/a0732d44-d369-4069-97bc-c55b310c989c" />

## Known Issues

https://github.com/rust-windowing/winit/issues/4477 - when switching spaces (e.g. using mission control), the menu bar regains visibility -- fixed by https://github.com/rust-windowing/winit/pull/4482