### PR TITLE
Add `bevy_reflect/smol_str` to `bevy_internal`'s `bevy_text` feature

### DIFF
--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -223,6 +223,7 @@ bevy_sprite = ["dep:bevy_sprite", "bevy_camera"]
 bevy_text = [
   "dep:bevy_text",
   "bevy_image",
+  "bevy_reflect/smol_str",
   "bevy_sprite?/bevy_text",
   "bevy_sprite_render?/bevy_text",
 ]


### PR DESCRIPTION
# Objective

- Fixes #22497

## Solution

- Added `bevy_reflect/smol_str` feature to `bevy_text` feature in `bevy_internal`.

## Testing

- Ran `cargo build --no-default-features -Fcommon_api` successfully.