### PR TITLE
gltf: let extension handle late-added materials

### DIFF
--- a/crates/bevy_gltf/src/loader/mod.rs
+++ b/crates/bevy_gltf/src/loader/mod.rs
@@ -1585,10 +1585,7 @@ fn load_node(
                 let mat_label = material_label(&material, is_scale_inverted);
                 let material_label = mat_label.to_string();
 
-                // This will make sure we load the default material now since it would not have been
-                // added when iterating over all the gltf materials (since the default material is
-                // not explicitly listed in the gltf).
-                // It also ensures an inverted scale copy is instantiated if required.
+                // This adds materials that Bevy modifies depending on how they're used, like those with inverted scale.
                 if !root_load_context.has_labeled_asset(&material_label)
                     && !load_context.has_labeled_asset(&material_label)
                 {


### PR DESCRIPTION
# Objective

- #22569 broke some examples, some materials are not displayed

## Solution

- Some materials are added late because we modify them depending on how they're used (for example, with an inverted scale). Also triggers extensions on those

## Testing

examples `light_probe_blending`, `irradiance_volumes`, `pccm`, `pcss` are now fixed