### PR TITLE
Fix wrong component sync for GeneratedEnvironmentMapLight

### DIFF
--- a/crates/bevy_pbr/src/light_probe/generate.rs
+++ b/crates/bevy_pbr/src/light_probe/generate.rs
@@ -17,7 +17,7 @@ use bevy_core_pipeline::mip_generation::{self, DownsampleShaders, DownsamplingCo
 use bevy_ecs::{
     component::Component,
     entity::Entity,
-    query::{With, Without},
+    query::Without,
     resource::Resource,
     schedule::IntoScheduleConfigs,
     system::{Commands, Query, Res, ResMut},
@@ -128,7 +128,7 @@ impl Plugin for EnvironmentMapGenerationPlugin {
         embedded_asset!(app, "environment_filter.wgsl");
         embedded_asset!(app, "copy.wgsl");
 
-        app.add_plugins(SyncComponentPlugin::<EnvironmentMapLight, Self>::default())
+        app.add_plugins(SyncComponentPlugin::<GeneratedEnvironmentMapLight, Self>::default())
             .add_systems(Update, generate_environment_map_light);
 
         let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
@@ -557,10 +557,7 @@ pub struct GeneratorBindGroups {
 
 /// Prepares bind groups for environment map generation pipelines
 pub fn prepare_generated_environment_map_bind_groups(
-    light_probes: Query<
-        (Entity, &IntermediateTextures, &RenderEnvironmentMap),
-        With<RenderEnvironmentMap>,
-    >,
+    light_probes: Query<(Entity, &IntermediateTextures, &RenderEnvironmentMap)>,
     render_device: Res<RenderDevice>,
     pipeline_cache: Res<PipelineCache>,
     queue: Res<RenderQueue>,
@@ -1109,6 +1106,6 @@ pub fn generate_environment_map_light(
     }
 }
 
-impl SyncComponent<EnvironmentMapGenerationPlugin> for EnvironmentMapLight {
-    type Out = GeneratedEnvironmentMapLight;
+impl SyncComponent<EnvironmentMapGenerationPlugin> for GeneratedEnvironmentMapLight {
+    type Out = RenderEnvironmentMap;
 }


### PR DESCRIPTION
# Objective

Fixes the following log spam (and wrong sync behavior) introduced by #22766:

```
ERROR bevy_pbr::cluster: Clustered light or decal 5v0 had no assigned index!
```

## Solution

The components here are named in an interesting way. We have 3 components:
* `EnvironmentMapLight`
* `GeneratedEnvironmentMapLight`
* `RenderEnvironmentMap`

When I added the `SyncComponent` impl I pattern matched on the upper two names, and assumed that `EnvironmentMapLight` was the main world component and `GeneratedEnvironmentMapLight` was in the render world.

Actually `GeneratedEnvironmentMapLight` is a specific way to generate an `EnvironmentMapLight`, and the render world entity is called `RenderEnvironmentMap`. Fixing the `SyncComponent` impl to reflect that fixes the issue.

I still feel like there are other issues after this fix:
* `GeneratedEnvironmentMapLight` could really use a better name (`GenerateEnvironmentMapLight`? `RuntimeEnvironmentMapLight`?), and better docs.
* I think it's still missing some syncing logic, as far as I can tell nothing handles the generated `EnvironmentMapLight` if a `GeneratedEnvironmentMapLight` is updated or deleted? I didn't do a deep dive so I might have missed something.

## Testing

Tested with the `light_probe_blending` and `reflection_probes` examples.