### PR TITLE
Add performance clarification to `Single`

### DIFF
--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -2730,6 +2730,8 @@ impl<'w, 'q, Q: QueryData, F: QueryFilter> From<&'q mut Query<'w, '_, Q, F>>
 ///
 /// Use [`Option<Single<D, F>>`] instead if zero or one matching entities can exist.
 ///
+/// Note that [`Single`] is not used as a search optimization. It is used as a validation with slight overhead compared to [`Query`].
+///
 /// See [`Query`] for more details.
 ///
 /// [System parameter]: crate::system::SystemParam


### PR DESCRIPTION
# Objective

Many users reasonably assume that `Single` is faster than `Query` because it can early-exit after finding a match.
After reviewing the implementation, I found that it is not used as an optimization and instead exists to perform additional validation.

## Solution

Add documentation clarifying that Single is intended for validation and may incur slight overhead, since this behavior is not immediately obvious.

