### PR TITLE
Release-0.18.1: Ensure other half `Gizmos` Observer Fix lands correctly in release branch

### DIFF
--- a/crates/bevy_gizmos/src/gizmos.rs
+++ b/crates/bevy_gizmos/src/gizmos.rs
@@ -16,7 +16,7 @@ use bevy_ecs::{
         Deferred, ReadOnlySystemParam, Res, SystemBuffer, SystemMeta, SystemParam,
         SystemParamValidationError,
     },
-    world::{unsafe_world_cell::UnsafeWorldCell, World},
+    world::{unsafe_world_cell::UnsafeWorldCell, DeferredWorld, World},
 };
 use bevy_math::{bounding::Aabb3d, Isometry2d, Isometry3d, Vec2, Vec3};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
@@ -347,7 +347,11 @@ where
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,
 {
-    fn apply(&mut self, _system_meta: &SystemMeta, world: &mut World) {
+    fn apply(&mut self, system_meta: &SystemMeta, world: &mut World) {
+        self.queue(system_meta, world.into());
+    }
+
+    fn queue(&mut self, _system_meta: &SystemMeta, mut world: DeferredWorld) {
         let mut storage = world.resource_mut::<GizmoStorage<Config, Clear>>();
         storage.list_positions.append(&mut self.list_positions);
         storage.list_colors.append(&mut self.list_colors);


### PR DESCRIPTION
> [!IMPORTANT]
> This will be merged into the `release-0.18.1` branch, _not_ `main`

# Objective

- Ensure the missing part of #22800 (in the 0.18.1 milestone) that was merged as part of #22832 (in the 0.19.0 milestone) still lands in 0.18.1

## Solution

- Ensure `queue()` is implemented in the `SystemBuffer` `GizmoBuffer`, and that `apply()` delegates to `queue()`

The other half of the solution, #22800, is in the 0.18.1 milestone and will eventually get put into this branch whenever it is needed.

(The code in this PR used to be in #22800, but when #22832 was merged before it, the change became lost).