### PR TITLE
Make the automatic clustering heuristics use statistics from the previous frame instead of clustering multiple times.

### DIFF
--- a/crates/bevy_light/src/cluster/mod.rs
+++ b/crates/bevy_light/src/cluster/mod.rs
@@ -57,9 +57,9 @@ pub struct GlobalClusterSettings {
 #[derive(Debug, Copy, Clone, Reflect)]
 #[reflect(Clone)]
 pub enum ClusterFarZMode {
-    /// Calculate the required maximum z-depth based on currently visible
-    /// clusterable objects.  Makes better use of available clusters, speeding
-    /// up GPU lighting operations at the expense of some CPU time and using
+    /// Calculate the required maximum z-depth based on the clusterable objects
+    /// that were visible on the previous frame. Makes better use of available
+    /// clusters, speeding up GPU lighting operations at the expense of using
     /// more indices in the clusterable object index lists.
     MaxClusterableObjectRange,
     /// Constant max z-depth
@@ -125,6 +125,17 @@ pub struct Clusters {
     pub near: f32,
     /// Distance to the far plane of the last depth slice. This may change depending on [`ClusterZConfig`] used.
     pub far: f32,
+    /// The farthest Z value of any bounding sphere of any clusterable object on
+    /// the previous frame.
+    ///
+    /// This is used for the [`ClusterFarZMode::MaxClusterableObjectRange`]
+    /// feature.
+    pub last_frame_farthest_z: Option<f32>,
+    /// The sum of the number of objects that all clusters contained last frame.
+    ///
+    /// This is used for the `dynamic_resizing` feature, which automatically
+    /// grows the number of clusters if clusters have likely become too large.
+    pub last_frame_total_cluster_index_count: Option<usize>,
     /// All objects within the cluster.
     pub clusterable_objects: Vec<ObjectsInCluster>,
 }


### PR DESCRIPTION
Right now, before assigning objects to clusters, if the `dynamic_resizing` feature is enabled, `assign_objects_to_clusters` traverses the list of clusterable objects processing bounding spheres, and, if the `ClusterFarZMode::MaxClusterableObjectRange` feature is enabled, `assign_objects_to_clusters` traverses the list of clusterable objects processing bounding spheres again. This means that we potentially traverse the list of clusterable objects 3 times per frame, which has poor cache behavior. Worse, it means that we have to process clusterable objects on CPU, adding significant CPU overhead even when GPU clustering is enabled in my [branch]. In fact, this approach won't work at all when we have the ability to spawn lights and decals on the GPU without CPU involvement, because the CPU won't be aware of the index counts and Z extents to begin with.

This patch changes `assign_objects_to_clusters` to instead traverse the list once and gather relevant statistics as it does so. These statistics are saved for the *next* frame and used as heuristics for those features. This does mean that there might occasionally be a single frame of inefficient PBR shading. However, the savings are significant--a 28% speedup in `assign_objects_to_clusters`--and the heuristics are actually *better*, as they can now use the *actual* results of culling instead of relying on conservative bounding spheres for speed. Note also that this patch should never result in an *incorrect* frame, only a single potentially *less optimal* frame.

<img width="2756" height="1800" alt="Screenshot 2026-02-08 234232" src="https://github.com/user-attachments/assets/e857c688-edb2-4297-a2e2-f16ff5fa52bb" />

[branch]: https://github.com/pcwalton/bevy/tree/gpu-clustering