### PR TITLE
Add string-based plugin lookup methods to PluginGroupBuilder

### DIFF
--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -939,4 +939,95 @@ mod tests {
     fn construct_nested_plugin_groups() {
         PluginGroupC {}.build();
     }
+
+    #[test]
+    fn contains_plugin_named() {
+        let group = PluginGroupBuilder::start::<NoopPluginGroup>()
+            .add(PluginA)
+            .add(PluginB);
+
+        assert!(group.contains_plugin_named("bevy_app::plugin_group::tests::PluginA"));
+        assert!(group.contains_plugin_named("bevy_app::plugin_group::tests::PluginB"));
+        assert!(!group.contains_plugin_named("bevy_app::plugin_group::tests::PluginC"));
+        assert!(!group.contains_plugin_named("NonExistentPlugin"));
+    }
+
+    #[test]
+    fn enable_plugin_named() {
+        let group = PluginGroupBuilder::start::<NoopPluginGroup>()
+            .add(PluginA)
+            .add(PluginB)
+            .disable::<PluginA>();
+
+        assert!(!group.enabled::<PluginA>());
+        assert!(group.enabled::<PluginB>());
+
+        let group = group.enable_plugin_named("bevy_app::plugin_group::tests::PluginA");
+
+        assert!(group.enabled::<PluginA>());
+        assert!(group.enabled::<PluginB>());
+    }
+
+    #[test]
+    fn enable_plugin_named_nonexistent() {
+        let group = PluginGroupBuilder::start::<NoopPluginGroup>()
+            .add(PluginA)
+            .add(PluginB);
+
+        // Should not panic when plugin doesn't exist
+        let group = group.enable_plugin_named("NonExistentPlugin");
+
+        assert!(group.enabled::<PluginA>());
+        assert!(group.enabled::<PluginB>());
+    }
+
+    #[test]
+    fn disable_plugin_named() {
+        let group = PluginGroupBuilder::start::<NoopPluginGroup>()
+            .add(PluginA)
+            .add(PluginB);
+
+        assert!(group.enabled::<PluginA>());
+        assert!(group.enabled::<PluginB>());
+
+        let group = group.disable_plugin_named("bevy_app::plugin_group::tests::PluginB");
+
+        assert!(group.enabled::<PluginA>());
+        assert!(!group.enabled::<PluginB>());
+    }
+
+    #[test]
+    fn disable_plugin_named_nonexistent() {
+        let group = PluginGroupBuilder::start::<NoopPluginGroup>()
+            .add(PluginA)
+            .add(PluginB);
+
+        // Should not panic when plugin doesn't exist
+        let group = group.disable_plugin_named("NonExistentPlugin");
+
+        assert!(group.enabled::<PluginA>());
+        assert!(group.enabled::<PluginB>());
+    }
+
+    #[test]
+    fn named_plugins_persist_in_add_group() {
+        let group_a = PluginGroupBuilder::start::<NoopPluginGroup>()
+            .add(PluginA)
+            .add(PluginB);
+
+        let group_b = PluginGroupBuilder::start::<NoopPluginGroup>()
+            .add(PluginC)
+            .add_group(group_a);
+
+        // All plugins from both groups should be accessible by name
+        assert!(group_b.contains_plugin_named("bevy_app::plugin_group::tests::PluginA"));
+        assert!(group_b.contains_plugin_named("bevy_app::plugin_group::tests::PluginB"));
+        assert!(group_b.contains_plugin_named("bevy_app::plugin_group::tests::PluginC"));
+
+        // Test that we can disable by name after merging groups
+        let group_b = group_b.disable_plugin_named("bevy_app::plugin_group::tests::PluginA");
+        assert!(!group_b.enabled::<PluginA>());
+        assert!(group_b.enabled::<PluginB>());
+        assert!(group_b.enabled::<PluginC>());
+    }
 }


### PR DESCRIPTION
## Objective

Allow plugins to disable other plugins from a plugin group without requiring a compile-time dependency on the target plugin.

## Problem

It is common for a plugin to want to disable another plugin from a plugin group. However, the current `PluginGroupBuilder` interface requires specifying plugins as generic parameters (e.g., `.disable::<TargetPlugin>()`), which means the disabling plugin must include the target plugin as a compile-time dependency. This defeats the whole purpose of conditional plugin management, as you now have a hard dependency on something you're trying to optionally exclude.

## Solution

This PR adds string-based plugin lookup methods that use `core::any::type_name` instead of generic type parameters:

- `contains_plugin_named(&str)` - Check if a plugin exists by its type name
- `enable_plugin_named(&str)` - Enable a plugin by its type name  
- `disable_plugin_named(&str)` - Disable a plugin by its type name

These methods allow plugins to conditionally enable/disable other plugins without compile-time dependencies, enabling true dynamic plugin management.

## Implementation

- Adds a `names: BTreeMap<&'static str, TypeId>` field to `PluginGroupBuilder`
- Plugin type names are registered automatically when plugins are added via `upsert_plugin_state`
- Name mappings are preserved when merging plugin groups with `add_group()`
- Methods gracefully handle non-existent plugin names without panicking

## Testing

Added comprehensive tests covering:
- [x] `contains_plugin_named()` correctly identifies plugins by their type name
- [x] `enable_plugin_named()` enables the correct plugin
- [x] `disable_plugin_named()` disables the correct plugin
- [x] Methods handle non-existent plugin names gracefully without panicking
- [x] Name mappings persist when using `add_group()` to merge plugin groups