### PR TITLE
Add documentation links between common run conditions and skippable parameters

### DIFF
--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -432,6 +432,9 @@ pub mod common_conditions {
     /// A [`SystemCondition`]-satisfying system that returns `true`
     /// if the resource exists.
     ///
+    /// To skip a system with a [`Res`] or [`ResMut`](crate::prelude::ResMut) parameter if the resource does not exist,
+    /// you may instead wrap the parameter in [`If`](crate::prelude::If), like `If<Res<T>>` or `If<ResMut<T>>`.
+    ///
     /// # Example
     ///
     /// ```
@@ -874,6 +877,12 @@ pub mod common_conditions {
     /// A [`SystemCondition`]-satisfying system that returns `true`
     /// if there are any entities with the given component type.
     ///
+    /// This is equivalent to [`any_match_filter::<With<T>>()`]
+    ///
+    /// To skip a system with a [`Query`] parameter if the query is empty,
+    /// you may instead use [`Populated`](crate::prelude::Populated), if the query may match multiple entities,
+    /// or [`Single`](crate::prelude::Single), if it will only match one.
+    ///
     /// # Example
     ///
     /// ```
@@ -921,6 +930,12 @@ pub mod common_conditions {
 
     /// A [`SystemCondition`]-satisfying system that returns `true`
     /// if there are any entities that match the given [`QueryFilter`].
+    ///
+    /// For a simple `With<T>` filter, this is equivalent to [`any_with_component::<T>()`].
+    ///
+    /// To skip a system with a [`Query`] parameter if the query is empty,
+    /// you may instead use [`Populated`](crate::prelude::Populated), if the query may match multiple entities,
+    /// or [`Single`](crate::prelude::Single), if it will only match one.
     pub fn any_match_filter<F: QueryFilter>(query: Query<(), F>) -> bool {
         !query.is_empty()
     }

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -2786,6 +2786,9 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Single<'w, 's, D, F> {
 ///
 /// See [`Query`] for more details.
 ///
+/// If the system doesn't need to perform the query but should still be skipped if it is empty,
+/// you may use the [`any_with_component`](crate::schedule::common_conditions::any_with_component) or [`any_match_filter`](crate::schedule::common_conditions::any_match_filter) run conditions.
+///
 /// [System parameter]: crate::system::SystemParam
 pub struct Populated<'w, 's, D: QueryData, F: QueryFilter = ()>(pub(crate) Query<'w, 's, D, F>);
 


### PR DESCRIPTION
# Objective

Better documentation.  

Run conditions and skippable system parameters are both ways to skip running a system in some circumstances, and there is some overlap between the features.  Add some documentation links between features that do similar things.  

## Solution

Mention `If<Res<R>>` from the `resource_exists` common run condition.  

Mention `Populated` from the `any_match_filter` and `any_with_component` common run conditions, and vice versa, and add links between the two run conditions.  