### PR TITLE
Add PostProcessBindGroupCache

### DIFF
--- a/crates/bevy_core_pipeline/src/fullscreen_material.rs
+++ b/crates/bevy_core_pipeline/src/fullscreen_material.rs
@@ -28,15 +28,17 @@ use bevy_render::{
     render_resource::{
         binding_types::{sampler, texture_2d, uniform_buffer},
         encase::internal::WriteInto,
-        BindGroup, BindGroupEntries, BindGroupLayoutDescriptor, BindGroupLayoutEntries,
+        BindGroupEntries, BindGroupLayoutDescriptor, BindGroupLayoutEntries,
         CachedRenderPipelineId, Canonical, ColorTargetState, ColorWrites, FragmentState,
         Operations, PipelineCache, RenderPassColorAttachment, RenderPassDescriptor, RenderPipeline,
         RenderPipelineDescriptor, Sampler, SamplerBindingType, SamplerDescriptor, ShaderStages,
         ShaderType, Specializer, SpecializerKey, TextureFormat, TextureSampleType, TextureView,
-        TextureViewId, Variants,
+        Variants,
     },
     renderer::{RenderContext, RenderDevice, ViewQuery},
-    view::{ExtractedView, ViewTarget},
+    view::{
+        ExtractedView, PostProcessBindGroupCache, PostProcessBindGroupCacheBuilder, ViewTarget,
+    },
     Render, RenderApp, RenderStartup, RenderSystems,
 };
 use bevy_shader::ShaderRef;
@@ -214,7 +216,7 @@ fn prepare_fullscreen_material_pipelines<T: FullscreenMaterial>(
 /// We can't know ahead of time which one is the source or destination so we create a bind group
 /// for both
 #[derive(Component)]
-struct FullscreenMaterialBindGroup<T: FullscreenMaterial> {
+pub struct FullscreenMaterialBindGroup<T: FullscreenMaterial> {
     cache: PostProcessBindGroupCache,
     // This is in case someone wants multiple `FullscreenMaterial` per camera
     _marker: PhantomData<T>,

--- a/crates/bevy_core_pipeline/src/fullscreen_material.rs
+++ b/crates/bevy_core_pipeline/src/fullscreen_material.rs
@@ -214,9 +214,8 @@ fn prepare_fullscreen_material_pipelines<T: FullscreenMaterial>(
 /// We can't know ahead of time which one is the source or destination so we create a bind group
 /// for both
 #[derive(Component)]
-pub struct FullscreenMaterialBindGroup<T: FullscreenMaterial> {
-    a: (TextureViewId, BindGroup),
-    b: (TextureViewId, BindGroup),
+struct FullscreenMaterialBindGroup<T: FullscreenMaterial> {
+    cache: PostProcessBindGroupCache,
     // This is in case someone wants multiple `FullscreenMaterial` per camera
     _marker: PhantomData<T>,
 }
@@ -242,10 +241,7 @@ fn prepare_bind_groups<T: FullscreenMaterial>(
     };
 
     for (entity, view_target, mut maybe_bind_groups) in &mut view {
-        let main_texture_view = view_target.main_texture_view();
-        let main_texture_other_view = view_target.main_texture_other_view();
-
-        let create_bind_group = |texture: &TextureView| {
+        let builder = PostProcessBindGroupCacheBuilder::new(|texture: &TextureView| {
             (
                 texture.id(),
                 render_device.create_bind_group(
@@ -258,19 +254,15 @@ fn prepare_bind_groups<T: FullscreenMaterial>(
                     )),
                 ),
             )
-        };
+        });
 
         if let Some(bind_groups) = &mut maybe_bind_groups {
-            if bind_groups.a.0 != main_texture_view.id() {
-                bind_groups.a = create_bind_group(main_texture_view);
-            }
-            if bind_groups.b.0 != main_texture_other_view.id() {
-                bind_groups.b = create_bind_group(main_texture_other_view);
+            if bind_groups.cache.should_update(view_target) {
+                bind_groups.cache.update(view_target, builder);
             }
         } else {
             commands.entity(entity).insert(FullscreenMaterialBindGroup {
-                a: create_bind_group(main_texture_view),
-                b: create_bind_group(main_texture_other_view),
+                cache: builder.generate_bind_groups(view_target),
                 _marker: PhantomData::<T>,
             });
         }
@@ -297,11 +289,7 @@ pub fn fullscreen_material_system<T: FullscreenMaterial>(
     let source = post_process.source;
     let destination = post_process.destination;
 
-    let (_, bind_group) = if bind_groups.a.0 == source.id() {
-        &bind_groups.a
-    } else {
-        &bind_groups.b
-    };
+    let bind_group = bind_groups.cache.get_current_bind_group(source);
 
     let pass_descriptor = RenderPassDescriptor {
         label: Some("fullscreen_material_pass"),

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -15,7 +15,9 @@ use crate::{
     occlusion_culling::OcclusionCulling,
     render_asset::RenderAssets,
     render_phase::ViewRangefinder3d,
-    render_resource::{DynamicUniformBuffer, ShaderType, Texture, TextureView},
+    render_resource::{
+        BindGroup, DynamicUniformBuffer, ShaderType, Texture, TextureView, TextureViewId,
+    },
     renderer::{RenderDevice, RenderQueue},
     sync_world::MainEntity,
     texture::{
@@ -40,6 +42,7 @@ use core::{
     ops::Range,
     sync::atomic::{AtomicUsize, Ordering},
 };
+use std::marker::PhantomData;
 use wgpu::{
     BufferUsages, Color as WgpuColor, RenderPassColorAttachment, RenderPassDepthStencilAttachment,
     StoreOp, TextureDescriptor, TextureDimension, TextureFormat, TextureUsages,
@@ -969,6 +972,99 @@ impl ViewTarget {
                 destination_texture: &self.main_textures.a.texture.texture,
             }
         }
+    }
+}
+
+pub trait CreatePostProcessBindGroup:
+    Fn(&TextureView) -> (TextureViewId, BindGroup) + Copy
+{
+}
+
+impl<T: Fn(&TextureView) -> (TextureViewId, BindGroup) + Copy> CreatePostProcessBindGroup for T {}
+
+/// Used to create a [`PostProcessBindGroupCache`]
+pub struct PostProcessBindGroupCacheBuilder<F>
+where
+    F: CreatePostProcessBindGroup,
+{
+    create_bind_group: F,
+}
+
+impl<F> PostProcessBindGroupCacheBuilder<F>
+where
+    F: CreatePostProcessBindGroup,
+{
+    /// Initializes the [`PostProcessBindGroupCacheBuilder`]
+    ///
+    /// The closure should create the bind group that contains the source texture of a post
+    /// processing effect
+    pub fn new(create_bind_group: F) -> Self {
+        Self { create_bind_group }
+    }
+
+    /// Generates the bind group cache based on the [`Self::create_bind_group`] closure
+    pub fn generate_bind_groups(&self, view_target: &ViewTarget) -> PostProcessBindGroupCache {
+        PostProcessBindGroupCache::new(view_target, self.create_bind_group)
+    }
+}
+
+/// Caches the bind groups for each main textures used when making a post processing effect
+pub struct PostProcessBindGroupCache {
+    a: (TextureViewId, BindGroup),
+    b: (TextureViewId, BindGroup),
+}
+
+impl PostProcessBindGroupCache {
+    /// Creates the bind group for both main textures used in post processing effects
+    pub fn new<F: CreatePostProcessBindGroup>(
+        view_target: &ViewTarget,
+        create_bind_group: F,
+    ) -> Self {
+        Self {
+            a: create_bind_group(view_target.main_texture_view()),
+            b: create_bind_group(view_target.main_texture_other_view()),
+        }
+    }
+
+    /// Determines if the bind groups need to be updated based on the main textures id
+    ///
+    /// If you have anything else that determines if the bind groups need to be
+    /// updated you need to do it manually
+    pub fn should_update(&self, view_target: &ViewTarget) -> bool {
+        let (texture_a, _) = &self.a;
+        if *texture_a != view_target.main_texture_view().id() {
+            return true;
+        }
+        let (texture_b, _) = &self.b;
+        if *texture_b != view_target.main_texture_other_view().id() {
+            return true;
+        }
+
+        false
+    }
+
+    /// Updates the bind group associated with each main textures
+    ///
+    /// Use the builder to get the callback used when creating the bind group
+    pub fn update<F: CreatePostProcessBindGroup>(
+        &mut self,
+        view_target: &ViewTarget,
+        builder: PostProcessBindGroupCacheBuilder<F>,
+    ) {
+        self.a = (builder.create_bind_group)(view_target.main_texture_view());
+        self.b = (builder.create_bind_group)(view_target.main_texture_other_view());
+    }
+
+    /// Gets the bind group associated with the current main texture
+    ///
+    /// Generally, this will be the bind group associated with the source texture
+    pub fn get_current_bind_group(&self, texture: &TextureView) -> &BindGroup {
+        let (_, bind_group) = if self.a.0 == texture.id() {
+            &self.a
+        } else {
+            &self.b
+        };
+        bind_group
     }
 }
 

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -1001,7 +1001,7 @@ where
         Self { create_bind_group }
     }
 
-    /// Generates the bind group cache based on the [`Self::create_bind_group`] closure
+    /// Generates the bind group cache based on the `Self::create_bind_group` closure
     pub fn generate_bind_groups(&self, view_target: &ViewTarget) -> PostProcessBindGroupCache {
         PostProcessBindGroupCache::new(view_target, self.create_bind_group)
     }

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -42,7 +42,6 @@ use core::{
     ops::Range,
     sync::atomic::{AtomicUsize, Ordering},
 };
-use std::marker::PhantomData;
 use wgpu::{
     BufferUsages, Color as WgpuColor, RenderPassColorAttachment, RenderPassDepthStencilAttachment,
     StoreOp, TextureDescriptor, TextureDimension, TextureFormat, TextureUsages,


### PR DESCRIPTION
# Objective

- Correctly caching post process related bind groups can be a bit verbose and repetitive

## Solution

- Introduce `PostProcessBindGroupCache` that makes this easier to manage

## Testing

- I ported the fullscreen material to this new pattern and tested the example
