### PR TITLE
conditionally skip test cases that use the debug feature

### DIFF
--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -1884,6 +1884,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(not(feature = "debug"), ignore)]
     #[should_panic(
         expected = "Encountered an error in system `bevy_ecs::system::tests::simple_fallible_system::sys`: error"
     )]
@@ -1898,6 +1899,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(not(feature = "debug"), ignore)]
     #[should_panic(
         expected = "Encountered an error in system `bevy_ecs::system::tests::simple_fallible_exclusive_system::sys`: error"
     )]


### PR DESCRIPTION
# Objective

Two test cases in the `ecs` crate use the `debug` feature to produce the expected panic message. This causes those tests to fail while testing without `debug`.

## Solution

Conditionally ignore those test cases.

## Testing

Run the tests for `ecs` with no additional features enabled.