### PR TITLE
get game_menu running again

### DIFF
--- a/examples/games/game_menu.rs
+++ b/examples/games/game_menu.rs
@@ -24,7 +24,7 @@ enum DisplayQuality {
 }
 
 #[derive(Component)]
-struct Setting<T: Resource>(T);
+struct Setting<T>(T);
 
 // One of the two settings that can be set through the menu. It will be a resource in the app
 #[derive(Resource, Debug, PartialEq, Eq, Clone, Copy)]


### PR DESCRIPTION
# Objective

fixes #22897

## Solution

Introduces a new generic `Setting` component to differentiate between the Resource and the Component. This example was using one type as both uses.

## Testing

```
cargo run --example game_menu
```

https://github.com/user-attachments/assets/409f60c5-92cf-4201-a09f-820475194f86



