### PR TITLE
initial implementation of shared state for system params

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -464,16 +464,14 @@ fn derive_system_param_impl(
 
                 fn shared<'w, 's>() -> &'static [&'static #path::system::SharedStateVTable] {
                     use #path::__macro_exports::{OnceLock, Vec};
-                    use core::ptr;
-
                     static SHARED: OnceLock<&'static [&'static #path::system::SharedStateVTable]>
                         = OnceLock::new();
                     SHARED.get_or_init(|| {
                         let mut shared = Vec::new();
                         #shared_states
 
-                        shared.sort_unstable_by_key(|p| ptr::from_ref(*p) as usize);
-                        shared.dedup_by_key(|p| ptr::from_ref(*p) as usize);
+                        shared.sort_unstable();
+                        shared.dedup();
 
                         shared.leak()
                     })

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -395,7 +395,7 @@ fn derive_system_param_impl(
     };
     let shared_states = fields.iter().fold(shared_self, |mut tokens, field| {
         let ty = &field.ty;
-        tokens.extend(quote! { shared.extend(<#ty as SystemParam>::shared()); });
+        tokens.extend(quote! { shared.extend(<#ty as #path::system::SystemParam>::shared()); });
         tokens
     });
 

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -127,6 +127,7 @@ pub mod __macro_exports {
     // to `Vec` in `no_std` and `std` contexts.
     pub use crate::query::DebugCheckedUnwrap;
     pub use alloc::vec::Vec;
+    pub use bevy_platform::sync::OnceLock;
 }
 
 /// Event sent when a hotpatch happens.

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -219,12 +219,19 @@ mod tests {
         #[derive(Resource)]
         struct DidRun;
 
+        let mut schedule = Schedule::default();
+        schedule.add_systems(move |mut commands: Commands| {
+            commands.insert_resource(DidRun);
+        });
+
+        let mut world = World::default();
+        schedule.run(&mut world);
+        assert!(world.contains_resource::<DidRun>());
+
         let mut world = World::default();
         world
             .run_system_cached(move |mut commands: Commands| {
-                commands.queue(move |world: &mut World| {
-                    world.insert_resource(DidRun);
-                });
+                commands.insert_resource(DidRun);
             })
             .unwrap();
 

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -157,7 +157,7 @@ mod tests {
         component::Component,
         entity::{Entity, EntityMapper, EntityNotSpawnedError},
         entity_disabling::DefaultQueryFilters,
-        prelude::Or,
+        prelude::*,
         query::{Added, Changed, FilteredAccess, QueryFilter, With, Without},
         resource::Resource,
         world::{error::EntityDespawnError, EntityMut, EntityRef, Mut, World},
@@ -213,6 +213,23 @@ mod tests {
     #[derive(Component, Copy, Clone, PartialEq, Eq, Hash, Debug)]
     #[component(storage = "SparseSet")]
     struct SparseStored(u32);
+
+    #[test]
+    fn commands_are_applied_for_function_system() {
+        #[derive(Resource)]
+        struct DidRun;
+
+        let mut world = World::default();
+        world
+            .run_system_cached(move |mut commands: Commands| {
+                commands.queue(move |world: &mut World| {
+                    world.insert_resource(DidRun);
+                });
+            })
+            .unwrap();
+
+        assert!(world.contains_resource::<DidRun>());
+    }
 
     #[test]
     fn random_access() {

--- a/crates/bevy_ecs/src/lifecycle.rs
+++ b/crates/bevy_ecs/src/lifecycle.rs
@@ -60,7 +60,7 @@ use crate::{
     query::FilteredAccessSet,
     relationship::RelationshipHookMode,
     storage::SparseSet,
-    system::{Local, ReadOnlySystemParam, SystemMeta, SystemParam},
+    system::{Local, ReadOnlySystemParam, SharedStates, SystemMeta, SystemParam},
     world::{unsafe_world_cell::UnsafeWorldCell, DeferredWorld, World},
 };
 
@@ -621,7 +621,7 @@ unsafe impl<'a> SystemParam for &'a RemovedComponentMessages {
     type State = ();
     type Item<'w, 's> = &'w RemovedComponentMessages;
 
-    fn init_state(_world: &mut World) -> Self::State {}
+    unsafe fn init_state(_world: &mut World, _shared_states: &SharedStates) -> Self::State {}
 
     fn init_access(
         _state: &Self::State,

--- a/crates/bevy_ecs/src/message/message_reader.rs
+++ b/crates/bevy_ecs/src/message/message_reader.rs
@@ -2,7 +2,7 @@
 use crate::message::MessageParIter;
 use crate::{
     message::{Message, MessageCursor, MessageIterator, MessageIteratorWithId, Messages},
-    system::{Local, Res, SystemParam, SystemParamValidationError},
+    system::{Local, Res, SharedStates, SystemParam, SystemParamValidationError},
 };
 
 /// Reads [`Message`]s of type `T` in order and tracks which messages have already been read.
@@ -144,8 +144,12 @@ unsafe impl<'w, 's, M: Message> SystemParam for PopulatedMessageReader<'w, 's, M
     type State = <MessageReader<'w, 's, M> as SystemParam>::State;
     type Item<'world, 'state> = PopulatedMessageReader<'world, 'state, M>;
 
-    fn init_state(world: &mut crate::prelude::World) -> Self::State {
-        MessageReader::<M>::init_state(world)
+    unsafe fn init_state(
+        world: &mut crate::prelude::World,
+        shared_states: &SharedStates,
+    ) -> Self::State {
+        // SAFETY: requirements are upheld by MessageReader's implementation
+        unsafe { MessageReader::<M>::init_state(world, shared_states) }
     }
 
     fn init_access(

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -314,10 +314,12 @@ impl<'w, 's> Commands<'w, 's> {
     /// Take all commands from `other` and append them to `self`, leaving `other` empty.
     pub fn append(&mut self, other: &mut CommandQueue) {
         match &mut self.queue {
-            InternalQueue::CommandQueue(queue) => queue.bytes.append(&mut other.bytes),
+            InternalQueue::CommandQueue(queue) => {
+                queue.bytes.get_mut().append(other.bytes.get_mut());
+            }
             InternalQueue::RawCommandQueue(queue) => {
                 // SAFETY: Pointers in `RawCommandQueue` are never null
-                unsafe { queue.bytes.as_mut() }.append(&mut other.bytes);
+                unsafe { queue.bytes.as_mut() }.append(other.bytes.get_mut());
             }
         }
     }

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -61,7 +61,7 @@ use crate::{
 ///
 /// Add `mut commands: Commands` as a function argument to your system to get a
 /// copy of this struct that will be applied the next time a copy of [`ApplyDeferred`] runs.
-/// Commands are almost always used as a [`SystemParam`](crate::system::SystemParam).
+/// Commands are almost always used as a [`SystemParam`].
 ///
 /// ```
 /// # use bevy_ecs::prelude::*;

--- a/crates/bevy_ecs/src/system/system_name.rs
+++ b/crates/bevy_ecs/src/system/system_name.rs
@@ -8,6 +8,8 @@ use crate::{
 use bevy_utils::prelude::DebugName;
 use derive_more::derive::{Display, Into};
 
+use super::SharedStates;
+
 /// [`SystemParam`] that returns the name of the system which it is used in.
 ///
 /// This is not a reliable identifier, it is more so useful for debugging or logging.
@@ -49,7 +51,7 @@ unsafe impl SystemParam for SystemName {
     type State = ();
     type Item<'w, 's> = SystemName;
 
-    fn init_state(_world: &mut World) -> Self::State {}
+    unsafe fn init_state(_world: &mut World, _shared_states: &SharedStates) -> Self::State {}
 
     fn init_access(
         _state: &Self::State,

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -360,6 +360,29 @@ pub trait SystemParamSharedState: Send + Sync + 'static {
     fn queue(&mut self, system_meta: &SystemMeta, world: DeferredWorld) {}
 }
 
+impl<T: SystemBuffer + FromWorld + Sync> SystemParamSharedState for T {
+    fn init(world: &mut World) -> Self {
+        T::from_world(world)
+    }
+
+    fn init_access(
+        &self,
+        system_meta: &mut SystemMeta,
+        _component_access_set: &mut FilteredAccessSet,
+        _world: &mut World,
+    ) {
+        system_meta.set_has_deferred();
+    }
+
+    fn apply(&mut self, system_meta: &SystemMeta, world: &mut World) {
+        SystemBuffer::apply(self, system_meta, world);
+    }
+
+    fn queue(&mut self, system_meta: &SystemMeta, world: DeferredWorld) {
+        SystemBuffer::queue(self, system_meta, world);
+    }
+}
+
 /// Use this as the `SystemParam::State` for parts of the state that are shared
 pub struct SharedState<S: SystemParamSharedState>(NonNull<S>);
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -649,7 +649,6 @@ unsafe impl<D: QueryData + 'static, F: QueryFilter + 'static> SystemParam for Qu
 
     fn init_access(
         state: &Self::State,
-
         system_meta: &mut SystemMeta,
         component_access_set: &mut FilteredAccessSet,
         world: &mut World,
@@ -668,7 +667,6 @@ unsafe impl<D: QueryData + 'static, F: QueryFilter + 'static> SystemParam for Qu
     #[inline]
     unsafe fn get_param<'w, 's>(
         state: &'s mut Self::State,
-
         system_meta: &SystemMeta,
         world: UnsafeWorldCell<'w>,
         change_tick: Tick,
@@ -745,7 +743,6 @@ unsafe impl<'a, 'b, D: QueryData + 'static, F: QueryFilter + 'static> SystemPara
     #[inline]
     unsafe fn validate_param(
         state: &mut Self::State,
-
         system_meta: &SystemMeta,
         world: UnsafeWorldCell,
     ) -> Result<(), SystemParamValidationError> {
@@ -949,7 +946,6 @@ unsafe impl<'w, 's, D: ReadOnlyQueryData + 'static, F: QueryFilter + 'static> Re
 /// ```
 pub struct ParamSet<'w, 's, T: SystemParam> {
     param_states: &'s mut T::State,
-
     world: UnsafeWorldCell<'w>,
     system_meta: SystemMeta,
     change_tick: Tick,
@@ -968,7 +964,6 @@ macro_rules! impl_param_set {
         {
             type State = ($($param::State,)*);
             type Item<'w, 's> = ParamSet<'w, 's, ($($param,)*)>;
-
             fn shared() -> &'static [&'static SharedStateVTable] {
                 TUPLE_VTABLES.get_or_insert::<Self::State>(|| {
                     let mut shared = Vec::new();
@@ -1028,7 +1023,6 @@ macro_rules! impl_param_set {
             #[inline]
             unsafe fn validate_param<'w, 's>(
                 state: &'s mut Self::State,
-
                 system_meta: &SystemMeta,
                 world: UnsafeWorldCell<'w>,
             ) -> Result<(), SystemParamValidationError> {
@@ -1041,7 +1035,6 @@ macro_rules! impl_param_set {
             #[inline]
             unsafe fn get_param<'w, 's>(
                 state: &'s mut Self::State,
-
                 system_meta: &SystemMeta,
                 world: UnsafeWorldCell<'w>,
                 change_tick: Tick,
@@ -1171,7 +1164,6 @@ unsafe impl<'a, T: Resource> SystemParam for Res<'a, T> {
 
     fn init_access(
         &component_id: &Self::State,
-
         system_meta: &mut SystemMeta,
         component_access_set: &mut FilteredAccessSet,
         _world: &mut World,
@@ -1262,7 +1254,6 @@ unsafe impl<'a, T: Resource> SystemParam for ResMut<'a, T> {
 
     fn init_access(
         &component_id: &Self::State,
-
         system_meta: &mut SystemMeta,
         component_access_set: &mut FilteredAccessSet,
         _world: &mut World,
@@ -1317,7 +1308,6 @@ unsafe impl<'a, T: Resource> SystemParam for ResMut<'a, T> {
     #[inline]
     unsafe fn get_param<'w, 's>(
         &mut component_id: &'s mut Self::State,
-
         system_meta: &SystemMeta,
         world: UnsafeWorldCell<'w>,
         change_tick: Tick,
@@ -1393,7 +1383,6 @@ unsafe impl<'w> SystemParam for DeferredWorld<'w> {
 
     fn init_access(
         _state: &Self::State,
-
         system_meta: &mut SystemMeta,
         component_access_set: &mut FilteredAccessSet,
         _world: &mut World,
@@ -1590,7 +1579,6 @@ unsafe impl<'a, T: FromWorld + Send + 'static> SystemParam for Local<'a, T> {
 
     fn init_access(
         _state: &Self::State,
-
         _system_meta: &mut SystemMeta,
         _component_access_set: &mut FilteredAccessSet,
         _world: &mut World,
@@ -1804,7 +1792,6 @@ unsafe impl<T: SystemBuffer> SystemParam for Deferred<'_, T> {
     #[inline]
     unsafe fn get_param<'w, 's>(
         state: &'s mut Self::State,
-
         _system_meta: &SystemMeta,
         _world: UnsafeWorldCell<'w>,
         _change_tick: Tick,
@@ -1836,7 +1823,6 @@ unsafe impl SystemParam for ExclusiveMarker {
     #[inline]
     unsafe fn get_param<'world, 'state>(
         _state: &'state mut Self::State,
-
         _system_meta: &SystemMeta,
         _world: UnsafeWorldCell<'world>,
         _change_tick: Tick,
@@ -1937,7 +1923,6 @@ unsafe impl<'a, T: 'static> SystemParam for NonSend<'a, T> {
     #[inline]
     unsafe fn get_param<'w, 's>(
         &mut component_id: &'s mut Self::State,
-
         system_meta: &SystemMeta,
         world: UnsafeWorldCell<'w>,
         change_tick: Tick,
@@ -1970,7 +1955,6 @@ unsafe impl<'a, T: 'static> SystemParam for NonSendMut<'a, T> {
 
     fn init_access(
         &component_id: &Self::State,
-
         system_meta: &mut SystemMeta,
         component_access_set: &mut FilteredAccessSet,
         _world: &mut World,
@@ -1993,7 +1977,6 @@ unsafe impl<'a, T: 'static> SystemParam for NonSendMut<'a, T> {
     #[inline]
     unsafe fn validate_param(
         &mut component_id: &mut Self::State,
-
         _system_meta: &SystemMeta,
         world: UnsafeWorldCell,
     ) -> Result<(), SystemParamValidationError> {
@@ -2014,7 +1997,6 @@ unsafe impl<'a, T: 'static> SystemParam for NonSendMut<'a, T> {
     #[inline]
     unsafe fn get_param<'w, 's>(
         &mut component_id: &'s mut Self::State,
-
         system_meta: &SystemMeta,
         world: UnsafeWorldCell<'w>,
         change_tick: Tick,
@@ -2057,7 +2039,6 @@ unsafe impl<'a> SystemParam for &'a Archetypes {
     #[inline]
     unsafe fn get_param<'w, 's>(
         _state: &'s mut Self::State,
-
         _system_meta: &SystemMeta,
         world: UnsafeWorldCell<'w>,
         _change_tick: Tick,
@@ -2078,7 +2059,6 @@ unsafe impl<'a> SystemParam for &'a Components {
 
     fn init_access(
         _state: &Self::State,
-
         _system_meta: &mut SystemMeta,
         _component_access_set: &mut FilteredAccessSet,
         _world: &mut World,
@@ -2088,7 +2068,6 @@ unsafe impl<'a> SystemParam for &'a Components {
     #[inline]
     unsafe fn get_param<'w, 's>(
         _state: &'s mut Self::State,
-
         _system_meta: &SystemMeta,
         world: UnsafeWorldCell<'w>,
         _change_tick: Tick,
@@ -2109,7 +2088,6 @@ unsafe impl<'a> SystemParam for &'a Entities {
 
     fn init_access(
         _state: &Self::State,
-
         _system_meta: &mut SystemMeta,
         _component_access_set: &mut FilteredAccessSet,
         _world: &mut World,
@@ -2140,7 +2118,6 @@ unsafe impl<'a> SystemParam for &'a EntityAllocator {
 
     fn init_access(
         _state: &Self::State,
-
         _system_meta: &mut SystemMeta,
         _component_access_set: &mut FilteredAccessSet,
         _world: &mut World,
@@ -2238,7 +2215,6 @@ unsafe impl SystemParam for SystemChangeTick {
     #[inline]
     unsafe fn get_param<'w, 's>(
         _state: &'s mut Self::State,
-
         system_meta: &SystemMeta,
         _world: UnsafeWorldCell<'w>,
         change_tick: Tick,

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -866,8 +866,11 @@ macro_rules! impl_param_set {
             type Item<'w, 's> = ParamSet<'w, 's, ($($param,)*)>;
 
             fn shared() -> &'static [&'static SharedStateVTable] {
-                static SHARED: OnceLock<&'static [&'static SharedStateVTable]> = OnceLock::new();
-                SHARED.get_or_init(|| {
+                use bevy_platform::sync::Mutex;
+
+                static SHARED: Mutex<HashMap<TypeId, &'static [&'static SharedStateVTable]>> =
+                    Mutex::new(HashMap::new());
+                SHARED.lock().unwrap().entry(TypeId::of::<Self::State>()).or_insert_with(|| {
                     let mut shared = Vec::new();
                     $(shared.extend($param::shared());)*
 
@@ -2475,8 +2478,11 @@ macro_rules! impl_system_param_tuple {
             type Item<'w, 's> = ($($param::Item::<'w, 's>,)*);
 
             fn shared() -> &'static [&'static SharedStateVTable] {
-                static SHARED: OnceLock<&'static [&'static SharedStateVTable]> = OnceLock::new();
-                SHARED.get_or_init(|| {
+                use bevy_platform::sync::Mutex;
+
+                static SHARED: Mutex<HashMap<TypeId, &'static [&'static SharedStateVTable]>> =
+                    Mutex::new(HashMap::new());
+                SHARED.lock().unwrap().entry(TypeId::of::<Self::State>()).or_insert_with(|| {
                     let mut shared = Vec::new();
                     $(shared.extend($param::shared());)*
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -469,7 +469,7 @@ impl SharedStateVTable {
             Box::leak(Box::new(SharedStateVTable {
                 init: |world| {
                     let state = Box::new(S::init(world));
-                    NonNull::from_ref(Box::leak(state)).cast()
+                    NonNull::new(Box::into_raw(state)).unwrap().cast()
                 },
 
                 apply: |ptr, system_meta, world| {

--- a/crates/bevy_ecs/src/world/command_queue.rs
+++ b/crates/bevy_ecs/src/world/command_queue.rs
@@ -7,10 +7,11 @@ use crate::{
 use alloc::{boxed::Box, vec::Vec};
 use bevy_ptr::{OwningPtr, Unaligned};
 use core::{
+    cell::UnsafeCell,
     fmt::Debug,
     mem::{size_of, MaybeUninit},
     panic::AssertUnwindSafe,
-    ptr::{addr_of, NonNull},
+    ptr::NonNull,
 };
 use log::warn;
 
@@ -37,9 +38,9 @@ pub struct CommandQueue {
     // For each command, one `CommandMeta` is stored, followed by zero or more bytes
     // to store the command itself. To interpret these bytes, a pointer must
     // be passed to the corresponding `CommandMeta.apply_command_and_get_size` fn pointer.
-    pub(crate) bytes: Vec<MaybeUninit<u8>>,
-    pub(crate) cursor: usize,
-    pub(crate) panic_recovery: Vec<MaybeUninit<u8>>,
+    pub(crate) bytes: UnsafeCell<Vec<MaybeUninit<u8>>>,
+    pub(crate) cursor: UnsafeCell<usize>,
+    pub(crate) panic_recovery: UnsafeCell<Vec<MaybeUninit<u8>>>,
     pub(crate) caller: MaybeLocation,
 }
 
@@ -64,15 +65,12 @@ pub(crate) struct RawCommandQueue {
     pub(crate) panic_recovery: NonNull<Vec<MaybeUninit<u8>>>,
 }
 
-// CommandQueue needs to implement Debug manually, rather than deriving it, because the derived impl just prints
-// [core::mem::maybe_uninit::MaybeUninit<u8>, core::mem::maybe_uninit::MaybeUninit<u8>, ..] for every byte in the vec,
-// which gets extremely verbose very quickly, while also providing no useful information.
-// It is not possible to soundly print the values of the contained bytes, as some of them may be padding or uninitialized (#4863)
-// So instead, the manual impl just prints the length of vec.
+// CommandQueue needs to implement Debug manually, rather than deriving it, because the derived impl of
+// UnsafeCell doesn't print its contents.
+// The manual impl just prints the caller.
 impl Debug for CommandQueue {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("CommandQueue")
-            .field("len_bytes", &self.bytes.len())
             .field("caller", &self.caller)
             .finish_non_exhaustive()
     }
@@ -109,13 +107,14 @@ impl CommandQueue {
 
     /// Take all commands from `other` and append them to `self`, leaving `other` empty
     pub fn append(&mut self, other: &mut CommandQueue) {
-        self.bytes.append(&mut other.bytes);
+        self.bytes.get_mut().append(other.bytes.get_mut());
     }
 
     /// Returns false if there are any commands in the queue
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.cursor >= self.bytes.len()
+        // SAFETY: aliasing rules are upheld by `RawCommandQueue`s if they exist
+        unsafe { *self.cursor.get() >= (&*self.bytes.get()).len() }
     }
 
     /// Returns a [`RawCommandQueue`] instance sharing the underlying command queue.
@@ -127,9 +126,9 @@ impl CommandQueue {
         // SAFETY: self is always valid memory and caller upholds mutability requirement
         unsafe {
             RawCommandQueue {
-                bytes: NonNull::new_unchecked(addr_of!(self.bytes).cast_mut()),
-                cursor: NonNull::new_unchecked(addr_of!(self.cursor).cast_mut()),
-                panic_recovery: NonNull::new_unchecked(addr_of!(self.panic_recovery).cast_mut()),
+                bytes: NonNull::new_unchecked(self.bytes.get()),
+                cursor: NonNull::new_unchecked(self.cursor.get()),
+                panic_recovery: NonNull::new_unchecked(self.panic_recovery.get()),
             }
         }
     }
@@ -240,7 +239,7 @@ impl RawCommandQueue {
         // SAFETY: If this is the command queue on world, world will not be dropped as we have a mutable reference
         // If this is not the command queue on world we have exclusive ownership and self will not be mutated
         let start = *self.cursor.as_ref();
-        let stop = self.bytes.as_ref().len();
+        let stop = (*self.bytes.as_ref()).len();
         let mut local_cursor = start;
         // SAFETY: we are setting the global cursor to the current length to prevent the executing commands from applying
         // the remaining commands currently in this list. This is safe.
@@ -326,7 +325,9 @@ impl RawCommandQueue {
 
 impl Drop for CommandQueue {
     fn drop(&mut self) {
-        if !self.bytes.is_empty() {
+        // SAFETY: aliasing rules are upheld by `RawCommandQueue`s if they exist
+        let is_empty = unsafe { (&*self.bytes.get()).is_empty() };
+        if !is_empty {
             if let Some(caller) = self.caller.into_option() {
                 warn!("CommandQueue has un-applied commands being dropped. Did you forget to call SystemState::apply? caller:{caller:?}");
             } else {

--- a/crates/bevy_ecs/src/world/identifier.rs
+++ b/crates/bevy_ecs/src/world/identifier.rs
@@ -2,7 +2,7 @@ use crate::{
     change_detection::Tick,
     query::FilteredAccessSet,
     storage::SparseSetIndex,
-    system::{ExclusiveSystemParam, ReadOnlySystemParam, SystemMeta, SystemParam},
+    system::{ExclusiveSystemParam, ReadOnlySystemParam, SharedStates, SystemMeta, SystemParam},
     world::{FromWorld, World},
 };
 use bevy_platform::sync::atomic::{AtomicUsize, Ordering};
@@ -54,7 +54,7 @@ unsafe impl SystemParam for WorldId {
 
     type Item<'world, 'state> = WorldId;
 
-    fn init_state(_: &mut World) -> Self::State {}
+    unsafe fn init_state(_: &mut World, _shared_states: &SharedStates) -> Self::State {}
 
     fn init_access(
         _state: &Self::State,

--- a/crates/bevy_gizmos/src/gizmos.rs
+++ b/crates/bevy_gizmos/src/gizmos.rs
@@ -13,7 +13,7 @@ use bevy_ecs::{
     query::FilteredAccessSet,
     resource::Resource,
     system::{
-        Deferred, ReadOnlySystemParam, Res, SystemBuffer, SystemMeta, SystemParam,
+        Deferred, ReadOnlySystemParam, Res, SharedStates, SystemBuffer, SystemMeta, SystemParam,
         SystemParamValidationError,
     },
     world::{unsafe_world_cell::UnsafeWorldCell, DeferredWorld, World},
@@ -200,9 +200,10 @@ where
     type State = GizmosFetchState<Config, Clear>;
     type Item<'w, 's> = Gizmos<'w, 's, Config, Clear>;
 
-    fn init_state(world: &mut World) -> Self::State {
+    unsafe fn init_state(world: &mut World, shared_states: &SharedStates) -> Self::State {
         GizmosFetchState {
-            state: GizmosState::<Config, Clear>::init_state(world),
+            // SAFETY: caller upholds requirements
+            state: unsafe { GizmosState::<Config, Clear>::init_state(world, shared_states) },
         }
     }
 

--- a/crates/bevy_render/src/extract_param.rs
+++ b/crates/bevy_render/src/extract_param.rs
@@ -4,8 +4,8 @@ use bevy_ecs::{
     prelude::*,
     query::FilteredAccessSet,
     system::{
-        ReadOnlySystemParam, SystemMeta, SystemParam, SystemParamItem, SystemParamValidationError,
-        SystemState,
+        ReadOnlySystemParam, SharedStates, SystemMeta, SystemParam, SystemParamItem,
+        SystemParamValidationError, SystemState,
     },
     world::unsafe_world_cell::UnsafeWorldCell,
 };
@@ -72,11 +72,12 @@ where
     type State = ExtractState<P>;
     type Item<'w, 's> = Extract<'w, 's, P>;
 
-    fn init_state(world: &mut World) -> Self::State {
+    unsafe fn init_state(world: &mut World, shared_states: &SharedStates) -> Self::State {
         let mut main_world = world.resource_mut::<MainWorld>();
         ExtractState {
             state: SystemState::new(&mut main_world),
-            main_world_state: Res::<MainWorld>::init_state(world),
+            // SAFETY: caller upholds requirements
+            main_world_state: unsafe { Res::<MainWorld>::init_state(world, shared_states) },
         }
     }
 

--- a/crates/bevy_render/src/renderer/render_context.rs
+++ b/crates/bevy_render/src/renderer/render_context.rs
@@ -9,7 +9,7 @@ use bevy_ecs::component::ComponentId;
 use bevy_ecs::prelude::*;
 use bevy_ecs::query::{FilteredAccessSet, QueryData, QueryFilter, QueryState};
 use bevy_ecs::system::{
-    Deferred, SystemBuffer, SystemMeta, SystemParam, SystemParamValidationError,
+    Deferred, SharedStates, SystemBuffer, SystemMeta, SystemParam, SystemParamValidationError,
 };
 use bevy_ecs::world::unsafe_world_cell::UnsafeWorldCell;
 use bevy_ecs::world::DeferredWorld;
@@ -234,7 +234,7 @@ unsafe impl<'a, D: QueryData + 'static, F: QueryFilter + 'static> SystemParam
     type State = ViewQueryState<D, F>;
     type Item<'w, 's> = ViewQuery<'w, 's, D, F>;
 
-    fn init_state(world: &mut World) -> Self::State {
+    unsafe fn init_state(world: &mut World, _shared_states: &SharedStates) -> Self::State {
         ViewQueryState {
             resource_id: world
                 .components_registrator()


### PR DESCRIPTION
# Objective

Fixes #22885

## Solution

I added associated function to `SystemParam` which returns all of the types that the param uses as shared state. It returns a static slice of  `SharedStateVTable` which contains type-erased functions for working with the single instances of each type of shared state.

I've also added a new struct `SharedStates` which is used to manage the type-erased shared states. The `SystemParam::init_state` function accepts a reference to the shared states and implementers can use it to get typed pointers which it can store as part of the state. _**`SystemParam::init_state` is now `unsafe` to call.**_ It is required to make sure the newly constructed state does not outlive the `SharedStates`.

Each type that is to be used as shared state must implement `SystemParamSharedState` which is used internally to make the vtables.

### Open questions

#### How should `DynSystemParam` work?

Currently `SystemParam::shared` is an associated function so `DynSystemParam` can't forward to the concrete type. For now, I've added "Don't use shared state" to the safety requirements of `DynSystemParam::new`. Another possibility is to make it not share with anything else, but still share internally and log a warning.

### Todo

- [ ] redo impl of `SystemParam` for `Commands` to share their `InternaCommandQueue`s
- [ ] implement `SystemParamSharedState` in the `SystemParam` derive macro
- [ ] include the pointers to shared states in derived implementation of `SystemParam`

## Testing

I added a test case that confirms the shared state is actually shared.

## Showcase

See the test case for basic usage. It shares an `Arc<AtomicBool>`. https://github.com/Person-93/bevy/blob/4cb020a0c9065f5bf363316677d49d60b1de4d51/crates/bevy_ecs/src/system/system_param.rs#L3529-L3602