### PR TITLE
Fix Image pixel access error propagation for compressed formats

### DIFF
--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -1501,34 +1501,26 @@ impl Image {
     }
 
     /// Get a reference to the data bytes where a specific pixel's value is stored.
-    ///
-    /// Returns `Ok(None)` if the image data is not initialized.
     #[inline(always)]
-    pub fn pixel_bytes(&self, coords: UVec3) -> Result<Option<&[u8]>, TextureAccessError> {
+    pub fn pixel_bytes(&self, coords: UVec3) -> Result<&[u8], TextureAccessError> {
         let len = self.texture_descriptor.format.pixel_size()?;
-        let Some(data) = self.data.as_ref() else {
-            return Ok(None);
-        };
-
         let start = self.pixel_data_offset(coords)?;
-        Ok(Some(&data[start..(start + len)]))
+        let Some(data) = self.data.as_ref() else {
+            return Err(TextureAccessError::Uninitialized);
+        };
+        Ok(&data[start..(start + len)])
     }
 
     /// Get a mutable reference to the data bytes where a specific pixel's value is stored.
-    ///
-    /// Returns `Ok(None)` if the image data is not initialized.
     #[inline(always)]
-    pub fn pixel_bytes_mut(
-        &mut self,
-        coords: UVec3,
-    ) -> Result<Option<&mut [u8]>, TextureAccessError> {
+    pub fn pixel_bytes_mut(&mut self, coords: UVec3) -> Result<&mut [u8], TextureAccessError> {
         let len = self.texture_descriptor.format.pixel_size()?;
         let offset = self.pixel_data_offset(coords)?;
         let Some(data) = self.data.as_mut() else {
-            return Ok(None);
+            return Err(TextureAccessError::Uninitialized);
         };
 
-        Ok(Some(&mut data[offset..(offset + len)]))
+        Ok(&mut data[offset..(offset + len)])
     }
 
     /// Clears the content of the image with the given pixel. The image needs to be initialized on
@@ -1680,13 +1672,7 @@ impl Image {
 
     #[inline(always)]
     fn get_color_at_internal(&self, coords: UVec3) -> Result<Color, TextureAccessError> {
-        let Some(bytes) = self.pixel_bytes(coords)? else {
-            return Err(TextureAccessError::OutOfBounds {
-                x: coords.x,
-                y: coords.y,
-                z: coords.z,
-            });
-        };
+        let bytes = self.pixel_bytes(coords)?;
 
         // NOTE: GPUs are always Little Endian.
         // Make sure to respect that when we create color values from bytes.
@@ -1828,13 +1814,7 @@ impl Image {
     ) -> Result<(), TextureAccessError> {
         let format = self.texture_descriptor.format;
 
-        let Some(bytes) = self.pixel_bytes_mut(coords)? else {
-            return Err(TextureAccessError::OutOfBounds {
-                x: coords.x,
-                y: coords.y,
-                z: coords.z,
-            });
-        };
+        let bytes = self.pixel_bytes_mut(coords)?;
 
         // NOTE: GPUs are always Little Endian.
         // Make sure to respect that when we convert color values to bytes.
@@ -2028,6 +2008,8 @@ pub enum TextureAccessError {
     OutOfBounds { x: u32, y: u32, z: u32 },
     #[error("unsupported texture format: {0:?}")]
     UnsupportedTextureFormat(TextureFormat),
+    #[error("image data is not initialized")]
+    Uninitialized,
     #[error("attempt to access texture with different dimension")]
     WrongDimension,
 }

--- a/examples/2d/cpu_draw.rs
+++ b/examples/2d/cpu_draw.rs
@@ -67,7 +67,7 @@ fn setup(mut commands: Commands, mut images: ResMut<Assets<Image>>) {
             // (it is the 4th byte of each pixel, as per our `TextureFormat`)
 
             // Find our pixel by its coordinates
-            let pixel_bytes = image.pixel_bytes_mut(UVec3::new(x, y, 0)).unwrap().unwrap();
+            let pixel_bytes = image.pixel_bytes_mut(UVec3::new(x, y, 0)).unwrap();
             // Convert our f32 to u8
             pixel_bytes[3] = (a * u8::MAX as f32) as u8;
         }

--- a/release-content/migration-guides/image_pixel_bytes_result.md
+++ b/release-content/migration-guides/image_pixel_bytes_result.md
@@ -4,14 +4,13 @@ pull_requests: [22908]
 ---
 
 `Image::pixel_bytes`, `Image::pixel_bytes_mut`, and
-`Image::pixel_data_offset` now return
-`Result<..., TextureAccessError>` instead of `Option<...>`.
+`Image::pixel_data_offset` now return `Result<..., TextureAccessError>`.
 
-Previously, these methods returned `Option` and would silently return
-`None` for both out-of-bounds access and unsupported texture formats
-(such as compressed textures). This caused error information to be lost,
-making it impossible for callers to distinguish between these different
-failure cases.
+Previously, these methods returned `Option` and would silently fail for
+both out-of-bounds access and unsupported texture formats (such as
+compressed textures). This caused error information to be lost, making it
+impossible for callers to distinguish between these different failure
+cases.
 
 Now, these methods properly propagate `TextureAccessError`:
 
@@ -19,8 +18,7 @@ Now, these methods properly propagate `TextureAccessError`:
   bounds
 - `TextureAccessError::UnsupportedTextureFormat` for compressed or
   unsupported texture formats
-- `Ok(None)` (for `pixel_bytes`/`pixel_bytes_mut`) only when the image
-  data is not initialized
+- `TextureAccessError::Uninitialized` if the image data is not initialized
 
 ## Migration
 
@@ -34,11 +32,11 @@ if let Some(bytes) = image.pixel_bytes(coords) {
 
 // After
 match image.pixel_bytes(coords) {
-    Ok(Some(bytes)) => {
+    Ok(bytes) => {
         // use bytes
     }
-    Ok(None) => {
-        // image data not initialized
+    Err(TextureAccessError::Uninitialized) => {
+        // handle missing image data
     }
     Err(TextureAccessError::OutOfBounds { .. }) => {
         // handle out of bounds


### PR DESCRIPTION
follow up to #22414

in my comment <https://github.com/bevyengine/bevy/pull/22414#issuecomment-2645849258> i realized the warn added in #22414 would never actually trigger because `pixel_bytes` and `pixel_bytes_mut` were returning `Option` instead of `Result`, which caused the `UnsupportedTextureFormat` error to be lost and converted to `OutOfBounds`.

this changes:
- `pixel_data_offset` now returns `Result` instead of `Option`
- `pixel_bytes` and `pixel_bytes_mut` now return `Result` instead of `Option`
- errors are properly propagated so the warn in sprite picking actually triggers for compressed textures
- added a regression test `compressed_texture_format_is_reported_correctly`
- updated `examples/2d/cpu_draw.rs` for the new signature

should i remove the regression test if it's useless ?

thanks