### PR TITLE
`clear_all()` clears all (non-send data)

### DIFF
--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -3268,13 +3268,12 @@ impl World {
         Some(check)
     }
 
-    /// Clears all entities and resources, invalidating all [`Entity`] and resource fetches
-    /// such as [`Res`](crate::system::Res), [`ResMut`](crate::system::ResMut)
-    ///
-    /// Since resources are entities, this is identical to [`clear_entities`](Self::clear_entities).
-    /// Non-send data is not cleared.
+    /// Clears all entities, resources, and non-send data.
+    /// This invalidates all [`Entity`] and resource fetches such as [`Res`](crate::system::Res),
+    /// [`ResMut`](crate::system::ResMut)
     pub fn clear_all(&mut self) {
         self.clear_entities();
+        self.clear_non_send();
     }
 
     /// Despawns all entities in this [`World`].

--- a/release-content/migration-guides/resources_as_components.md
+++ b/release-content/migration-guides/resources_as_components.md
@@ -85,6 +85,6 @@ struct EntityStruct(#[entities] Entity);
 struct EntityStruct(#[entities] Entity);
 ```
 
-Next, `World::clear_entities` now also clears all resources.
+Next, `World::clear_entities` now also clears all resources, and `World::clear_all` now clears all entities, resources, and non-send data.
 
 Lastly, `World::remove_resource_by_id` now returns `bool` instead of `Option<()>`.


### PR DESCRIPTION
# Objective

Since #20934, `World::clear_all` and `World::clear_all_entities` behave identically. `World::clear_all` used to clear all resources and entities, but since resources are now components, `World::clear_all_entities` also does this.

## Solution

Since `World::clear_all_non_send()` was not included in `World::clear_all`, I've decided to include it.