### PR TITLE
Cut down on register_component codegen

### DIFF
--- a/crates/bevy_ecs/src/component/register.rs
+++ b/crates/bevy_ecs/src/component/register.rs
@@ -170,6 +170,7 @@ impl<'w> ComponentsRegistrator<'w> {
         )
     }
 
+    // This exists to cut down on monomorphized code in register_component, which reduces compile times and binary sizes.
     fn register_component_checked(
         &mut self,
         type_id: TypeId,
@@ -212,6 +213,7 @@ impl<'w> ComponentsRegistrator<'w> {
     /// # Safety
     ///
     /// Neither this component, nor its id may be registered or queued. This must be a new registration.
+    // This was written in a type-erased way to cut down on monomorphized code in register_component, which reduces compile times and binary sizes.
     unsafe fn register_component_unchecked(
         &mut self,
         type_id: TypeId,


### PR DESCRIPTION
#20934 [regressed](#22915) our binary sizes. This claws back 4 MiB on a release build of `3d_scene` by hoisting out the generic parts of register_component, allowing for more shared code. Based on my estimates, 0.9 MiB of this is part of the 8.3 MiB regression attributed to Resources as Components.