### PR TITLE
Fix culling for negative sized UI elements

### DIFF
--- a/crates/bevy_ui_render/src/box_shadow.rs
+++ b/crates/bevy_ui_render/src/box_shadow.rs
@@ -431,7 +431,7 @@ pub fn prepare_shadows(
                     positions[3] + positions_diff[3].extend(0.),
                 ];
 
-                let transformed_rect_size = box_shadow.transform.transform_vector2(rect_size);
+                let transformed_rect_size = box_shadow.transform.transform_vector2(rect_size).abs();
 
                 // Don't try to cull nodes that have a rotation
                 // In a rotation around the Z-axis, this value is 0.0 for an angle of 0.0 or π

--- a/crates/bevy_ui_render/src/gradient.rs
+++ b/crates/bevy_ui_render/src/gradient.rs
@@ -777,7 +777,8 @@ pub fn prepare_gradient(
                         corner_points[3] + positions_diff[3],
                     ];
 
-                    let transformed_rect_size = gradient.transform.transform_vector2(rect_size);
+                    let transformed_rect_size =
+                        gradient.transform.transform_vector2(rect_size).abs();
 
                     // Don't try to cull nodes that have a rotation
                     // In a rotation around the Z-axis, this value is 0.0 for an angle of 0.0 or π

--- a/crates/bevy_ui_render/src/lib.rs
+++ b/crates/bevy_ui_render/src/lib.rs
@@ -1571,7 +1571,7 @@ pub fn prepare_uinodes(
                             points[3] + positions_diff[3],
                         ];
 
-                        let transformed_rect_size = transform.transform_vector2(rect_size);
+                        let transformed_rect_size = transform.transform_vector2(rect_size).abs();
 
                         // Don't try to cull nodes that have a rotation
                         // In a rotation around the Z-axis, this value is 0.0 for an angle of 0.0 or π
@@ -1714,12 +1714,13 @@ pub fn prepare_uinodes(
                             ];
 
                             // cull nodes that are completely clipped
-                            let transformed_rect_size =
-                                extracted_uinode.transform.transform_vector2(rect_size);
-                            if positions_diff[0].x - positions_diff[1].x
-                                >= transformed_rect_size.x.abs()
+                            let transformed_rect_size = extracted_uinode
+                                .transform
+                                .transform_vector2(rect_size)
+                                .abs();
+                            if positions_diff[0].x - positions_diff[1].x >= transformed_rect_size.x
                                 || positions_diff[1].y - positions_diff[2].y
-                                    >= transformed_rect_size.y.abs()
+                                    >= transformed_rect_size.y
                             {
                                 continue;
                             }

--- a/crates/bevy_ui_render/src/ui_material_pipeline.rs
+++ b/crates/bevy_ui_render/src/ui_material_pipeline.rs
@@ -473,8 +473,10 @@ pub fn prepare_uimaterial_nodes<M: UiMaterial>(
                         positions[3] + positions_diff[3].extend(0.),
                     ];
 
-                    let transformed_rect_size =
-                        extracted_uinode.transform.transform_vector2(rect_size);
+                    let transformed_rect_size = extracted_uinode
+                        .transform
+                        .transform_vector2(rect_size)
+                        .abs();
 
                     // Don't try to cull nodes that have a rotation
                     // In a rotation around the Z-axis, this value is 0.0 for an angle of 0.0 or π

--- a/crates/bevy_ui_render/src/ui_texture_slice_pipeline.rs
+++ b/crates/bevy_ui_render/src/ui_texture_slice_pipeline.rs
@@ -518,7 +518,7 @@ pub fn prepare_ui_slices(
                     ];
 
                     let transformed_rect_size =
-                        texture_slices.transform.transform_vector2(rect_size);
+                        texture_slices.transform.transform_vector2(rect_size).abs();
 
                     // Don't try to cull nodes that have a rotation
                     // In a rotation around the Z-axis, this value is 0.0 for an angle of 0.0 or π


### PR DESCRIPTION
# Objective

Fixes #22906

## Solution

A similar solution had already been implemented for glyphs so I just copied that.

## Testing

See #22906 for a reproduction of the bug. After applying this fix, the result matches the expected.
