### PR TITLE
suppress warning caused by conditional compilation

### DIFF
--- a/crates/bevy_render/src/render_resource/buffer_vec.rs
+++ b/crates/bevy_render/src/render_resource/buffer_vec.rs
@@ -622,6 +622,13 @@ pub enum WriteBufferRangeError {
 }
 
 #[inline]
+#[cfg_attr(
+    not(feature = "type_label_buffers"),
+    expect(
+        clippy::extra_unused_type_parameters,
+        reason = "conditional compilation"
+    )
+)]
 pub(crate) fn make_buffer_label<'a, T>(label: &'a Option<String>) -> Option<&'a str> {
     #[cfg(feature = "type_label_buffers")]
     if label.is_none() {


### PR DESCRIPTION
# Objective

Suppress a warning caused by conditional compilation

## Solution

Conditionally add an `expect` attribute

## Testing

none