### PR TITLE
Fix missing import in SubStates derive macro (#22892)

### DIFF
--- a/crates/bevy_state/macros/src/states.rs
+++ b/crates/bevy_state/macros/src/states.rs
@@ -123,9 +123,8 @@ pub fn derive_substates(input: TokenStream) -> TokenStream {
             }
         }
 
-        use #state_set_trait_path as StateSet;
         impl #impl_generics #state_trait_path for #struct_name #ty_generics #where_clause {
-            const DEPENDENCY_DEPTH : usize = <Self as #trait_path>::SourceStates::SET_DEPENDENCY_DEPTH + 1;
+            const DEPENDENCY_DEPTH : usize = <<Self as #trait_path>::SourceStates as #state_set_trait_path>::SET_DEPENDENCY_DEPTH + 1;
         }
 
         impl #impl_generics #state_mutation_trait_path for #struct_name #ty_generics #where_clause {


### PR DESCRIPTION
# Objective

Hello, this pr fixes #22892 

## Solution

I fixed the 'missing import' bug, by hard coding the import in the code generated by the proc macro.

## Testing

The code example given in the issue now compiles fine.
