### PR TITLE
Adding change_tick to deferred_world

### DIFF
--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -826,7 +826,7 @@ impl<'w> DeferredWorld<'w> {
 
     /// Gets the current change tick of [`DeferredWorld`].
     #[inline]
-    pub fn change_tick(self) -> Tick {
+    pub fn change_tick(&mut self) -> Tick {
         self.world.change_tick()
     }
 }


### PR DESCRIPTION
# Objective
Fixes #22788 

## Solution

- Adding change_tick to deferred_world

## Testing

- Passes

---

## Showcase

- You can access change_tick to get `Tick` from deferred_world
