### PR TITLE
Add missing HTML preview to RED, GREEN and BLUE constants in srgba.rs

### DIFF
--- a/crates/bevy_color/src/srgba.rs
+++ b/crates/bevy_color/src/srgba.rs
@@ -44,37 +44,25 @@ impl Srgba {
     // The standard VGA colors, with alpha set to 1.0.
     // https://en.wikipedia.org/wiki/Web_colors#Basic_colors
 
-    /// <div style="background-color:rgb(0%, 0%, 0%); width: 10px; padding: 10px; border: 1px solid;"></div>
+    /// <div style="background-color:rgb(0%, 0%, 0%); width: 10px; padding: 10px; border: 1px solid;"></div><br />
+    /// A fully black color with full alpha.
     pub const BLACK: Srgba = Srgba::new(0.0, 0.0, 0.0, 1.0);
-    /// <div style="background-color:rgba(0%, 0%, 0%, 0%); width: 10px; padding: 10px; border: 1px solid;"></div>
+    /// <div style="background-color:rgba(0%, 0%, 0%, 0%); width: 10px; padding: 10px; border: 1px solid;"></div><br />
+    /// A fully transparent color with no alpha (alpha = 0.0).
     #[doc(alias = "transparent")]
     pub const NONE: Srgba = Srgba::new(0.0, 0.0, 0.0, 0.0);
-    /// <div style="background-color:rgb(100%, 100%, 100%); width: 10px; padding: 10px; border: 1px solid;"></div>
+    /// <div style="background-color:rgb(100%, 100%, 100%); width: 10px; padding: 10px; border: 1px solid;"></div><br />
+    /// A fully white color with full alpha.
     pub const WHITE: Srgba = Srgba::new(1.0, 1.0, 1.0, 1.0);
-
+    /// <div style="background-color:rgb(100%, 0%, 0%); width: 10px; padding: 10px; border: 1px solid;"></div><br />
     /// A fully red color with full alpha.
-    pub const RED: Self = Self {
-        red: 1.0,
-        green: 0.0,
-        blue: 0.0,
-        alpha: 1.0,
-    };
-
+    pub const RED: Srgba = Srgba::new(1.0, 0.0, 0.0, 1.0);
+    /// <div style="background-color:rgb(0%, 100%, 0%); width: 10px; padding: 10px; border: 1px solid;"></div><br />
     /// A fully green color with full alpha.
-    pub const GREEN: Self = Self {
-        red: 0.0,
-        green: 1.0,
-        blue: 0.0,
-        alpha: 1.0,
-    };
-
+    pub const GREEN: Srgba = Srgba::new(0.0, 1.0, 0.0, 1.0);
+    /// <div style="background-color:rgb(0%, 0%, 100%); width: 10px; padding: 10px; border: 1px solid;"></div><br />
     /// A fully blue color with full alpha.
-    pub const BLUE: Self = Self {
-        red: 0.0,
-        green: 0.0,
-        blue: 1.0,
-        alpha: 1.0,
-    };
+    pub const BLUE: Srgba = Srgba::new(0.0, 0.0, 1.0, 1.0);
 
     /// Construct a new [`Srgba`] color from components.
     ///


### PR DESCRIPTION
So that all colors show up correctly in documentation.

# Objective

Add missing HTML preview in docs to RED, GREEN and BLUE constant.

## Solution

Add the HTML comments as used for the other colors.

I've deliberately left the setup with the `Self { }` but maybe it should be harmonised with the other constants? (Seems like it would integrate better in docs, but maybe there is a reason?).


## Testing

Show up correctly when building bevy_color docs:

```bash
cargo doc -p bevy_color --open
```

Before:
<img width="1920" height="932" alt="image" src="https://github.com/user-attachments/assets/4a2c9b67-dc9a-458c-85ef-cbb21cad10cb" />

After:
<img width="1920" height="932" alt="image" src="https://github.com/user-attachments/assets/28a53794-8902-49a7-addb-c394f3a550ab" />

