### PR TITLE
Remove outdated Bloom WebGL2 note

### DIFF
--- a/crates/bevy_post_process/src/bloom/settings.rs
+++ b/crates/bevy_post_process/src/bloom/settings.rs
@@ -18,8 +18,6 @@ use bevy_render::{extract_component::ExtractComponent, sync_component::SyncCompo
 ///
 /// # Usage Notes
 ///
-/// **Bloom is currently not compatible with WebGL2.**
-///
 /// Often used in conjunction with `bevy_pbr::StandardMaterial::emissive` for 3d meshes.
 ///
 /// Bloom is best used alongside a tonemapping function that desaturates bright colors,


### PR DESCRIPTION
# Objective

There's a very scary-looking note in the `Bloom` docs that seems to be outdated since https://bevy.org/examples/2d-rendering/bloom-2d/ works fine on webgl. Unclear if there's still a compatibility concern here.

## Solution

> Alice 🌹 — 9:59 PM
> Can you make a PR to remove it?
> We can get more testing there

## Testing

The 2D and 3D examples work on WebGL 