### PR TITLE
Disambiguate Specialization Execution

### DIFF
--- a/crates/bevy_anti_alias/src/dlss/mod.rs
+++ b/crates/bevy_anti_alias/src/dlss/mod.rs
@@ -186,7 +186,7 @@ impl Plugin for DlssPlugin {
                     prepare::prepare_dlss::<DlssSuperResolutionFeature>,
                     prepare::prepare_dlss::<DlssRayReconstructionFeature>,
                 )
-                    .in_set(RenderSystems::ManageViews)
+                    .in_set(RenderSystems::PrepareViews)
                     .before(prepare_view_targets),
             );
 

--- a/crates/bevy_anti_alias/src/taa/mod.rs
+++ b/crates/bevy_anti_alias/src/taa/mod.rs
@@ -62,7 +62,7 @@ impl Plugin for TemporalAntiAliasPlugin {
             .add_systems(
                 Render,
                 (
-                    prepare_taa_jitter.in_set(RenderSystems::ManageViews),
+                    prepare_taa_jitter.in_set(RenderSystems::PrepareViews),
                     prepare_taa_pipelines.in_set(RenderSystems::Prepare),
                     prepare_taa_history_textures.in_set(RenderSystems::PrepareResources),
                 ),

--- a/crates/bevy_core_pipeline/src/core_3d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/mod.rs
@@ -128,7 +128,7 @@ impl Plugin for Core3dPlugin {
                     sort_phase_system::<Transparent3d>.in_set(RenderSystems::PhaseSort),
                     configure_occlusion_culling_view_targets
                         .after(prepare_view_targets)
-                        .in_set(RenderSystems::ManageViews),
+                        .in_set(RenderSystems::PrepareViews),
                     prepare_core_3d_depth_textures.in_set(RenderSystems::PrepareResources),
                     prepare_prepass_textures.in_set(RenderSystems::PrepareResources),
                 ),

--- a/crates/bevy_core_pipeline/src/oit/mod.rs
+++ b/crates/bevy_core_pipeline/src/oit/mod.rs
@@ -99,7 +99,7 @@ impl Plugin for OrderIndependentTransparencyPlugin {
             .add_systems(
                 Render,
                 (
-                    configure_camera_depth_usages.in_set(RenderSystems::ManageViews),
+                    configure_camera_depth_usages.in_set(RenderSystems::PrepareViews),
                     prepare_oit_buffers.in_set(RenderSystems::PrepareResources),
                 ),
             );

--- a/crates/bevy_pbr/src/atmosphere/mod.rs
+++ b/crates/bevy_pbr/src/atmosphere/mod.rs
@@ -162,7 +162,7 @@ impl Plugin for AtmospherePlugin {
             .add_systems(
                 Render,
                 (
-                    configure_camera_depth_usages.in_set(RenderSystems::ManageViews),
+                    configure_camera_depth_usages.in_set(RenderSystems::PrepareViews),
                     queue_render_sky_pipelines.in_set(RenderSystems::Queue),
                     prepare_atmosphere_textures.in_set(RenderSystems::PrepareResources),
                     prepare_probe_textures

--- a/crates/bevy_pbr/src/decal/clustered.rs
+++ b/crates/bevy_pbr/src/decal/clustered.rs
@@ -160,7 +160,7 @@ impl Plugin for ClusteredDecalPlugin {
             .add_systems(
                 Render,
                 prepare_decals
-                    .in_set(RenderSystems::ManageViews)
+                    .in_set(RenderSystems::PrepareViews)
                     .after(prepare_lights),
             )
             .add_systems(

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -323,7 +323,7 @@ impl Plugin for PbrPlugin {
                 Render,
                 (
                     prepare_lights
-                        .in_set(RenderSystems::ManageViews)
+                        .in_set(RenderSystems::CreateViews)
                         .after(sort_cameras),
                     prepare_clusters.in_set(RenderSystems::PrepareResources),
                 ),

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -306,7 +306,7 @@ impl Plugin for MaterialsPlugin {
                     Render,
                     (
                         specialize_material_meshes
-                            .in_set(RenderSystems::PrepareMeshes)
+                            .in_set(RenderSystems::Specialize)
                             .after(prepare_assets::<RenderMesh>)
                             .after(collect_meshes_for_gpu_building)
                             .after(set_mesh_motion_vector_flags),
@@ -327,9 +327,9 @@ impl Plugin for MaterialsPlugin {
                     (
                         check_views_lights_need_specialization.in_set(RenderSystems::PrepareAssets),
                         // specialize_shadows also needs to run after prepare_assets::<PreparedMaterial>,
-                        // which is fine since ManageViews is after PrepareAssets
+                        // which is fine since PrepareViews is after PrepareAssets
                         specialize_shadows
-                            .in_set(RenderSystems::ManageViews)
+                            .in_set(RenderSystems::Specialize)
                             .after(prepare_lights),
                         queue_shadows.in_set(RenderSystems::QueueMeshes),
                     ),

--- a/crates/bevy_pbr/src/meshlet/mod.rs
+++ b/crates/bevy_pbr/src/meshlet/mod.rs
@@ -185,7 +185,7 @@ impl Plugin for MeshletPlugin {
                     perform_pending_meshlet_mesh_writes.in_set(RenderSystems::PrepareAssets),
                     configure_meshlet_views
                         .after(prepare_view_targets)
-                        .in_set(RenderSystems::ManageViews),
+                        .in_set(RenderSystems::PrepareViews),
                     prepare_meshlet_per_frame_resources.in_set(RenderSystems::PrepareResources),
                     prepare_meshlet_view_bind_groups.in_set(RenderSystems::PrepareBindGroups),
                     queue_material_meshlet_meshes.in_set(RenderSystems::QueueMeshes),

--- a/crates/bevy_post_process/src/dof/mod.rs
+++ b/crates/bevy_post_process/src/dof/mod.rs
@@ -222,7 +222,7 @@ impl Plugin for DepthOfFieldPlugin {
                     prepare_auxiliary_depth_of_field_textures,
                 )
                     .after(prepare_view_targets)
-                    .in_set(RenderSystems::ManageViews),
+                    .in_set(RenderSystems::PrepareViews),
             )
             .add_systems(
                 Render,

--- a/crates/bevy_render/src/batching/gpu_preprocessing.rs
+++ b/crates/bevy_render/src/batching/gpu_preprocessing.rs
@@ -65,7 +65,7 @@ impl Plugin for BatchingPlugin {
             )
             .add_systems(
                 Render,
-                clear_indirect_parameters_buffers.in_set(RenderSystems::ManageViews),
+                clear_indirect_parameters_buffers.in_set(RenderSystems::PrepareViews),
             );
     }
 

--- a/crates/bevy_render/src/camera.rs
+++ b/crates/bevy_render/src/camera.rs
@@ -78,7 +78,7 @@ impl Plugin for CameraPlugin {
             render_app
                 .init_resource::<SortedCameras>()
                 .add_systems(ExtractSchedule, extract_cameras)
-                .add_systems(Render, sort_cameras.in_set(RenderSystems::ManageViews));
+                .add_systems(Render, sort_cameras.in_set(RenderSystems::CreateViews));
         }
     }
 }

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -154,7 +154,11 @@ pub enum RenderSystems {
     /// Prepares extracted meshes.
     PrepareMeshes,
     /// Create any additional views such as those used for shadow mapping.
-    ManageViews,
+    CreateViews,
+    /// Specialize material meshes and shadow views.
+    Specialize,
+    /// Prepare any additional views such as those used for shadow mapping.
+    PrepareViews,
     /// Queue drawable entities as phase items in render phases ready for
     /// sorting (if necessary)
     Queue,
@@ -221,7 +225,9 @@ impl Render {
             (
                 ExtractCommands,
                 PrepareMeshes,
-                ManageViews,
+                CreateViews,
+                Specialize,
+                PrepareViews,
                 Queue,
                 PhaseSort,
                 Prepare,
@@ -231,6 +237,7 @@ impl Render {
             )
                 .chain(),
         );
+        schedule.ignore_ambiguity(Specialize, Specialize);
 
         schedule.configure_sets((ExtractCommands, PrepareAssets, PrepareMeshes, Prepare).chain());
         schedule.configure_sets(

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -114,17 +114,17 @@ impl Plugin for ViewPlugin {
                 (
                     // `TextureView`s need to be dropped before reconfiguring window surfaces.
                     clear_view_attachments
-                        .in_set(RenderSystems::ManageViews)
+                        .in_set(RenderSystems::PrepareViews)
                         .before(create_surfaces),
                     cleanup_view_targets_for_resize
-                        .in_set(RenderSystems::ManageViews)
+                        .in_set(RenderSystems::PrepareViews)
                         .before(create_surfaces),
                     prepare_view_attachments
-                        .in_set(RenderSystems::ManageViews)
+                        .in_set(RenderSystems::PrepareViews)
                         .before(prepare_view_targets)
                         .after(prepare_windows),
                     prepare_view_targets
-                        .in_set(RenderSystems::ManageViews)
+                        .in_set(RenderSystems::PrepareViews)
                         .after(prepare_windows)
                         .after(crate::render_asset::prepare_assets::<GpuImage>)
                         .ambiguous_with(crate::camera::sort_cameras), // doesn't use `sorted_camera_index_for_target`

--- a/crates/bevy_render/src/view/window/mod.rs
+++ b/crates/bevy_render/src/view/window/mod.rs
@@ -41,7 +41,7 @@ impl Plugin for WindowRenderPlugin {
                         .run_if(need_surface_configuration)
                         .before(prepare_windows),
                 )
-                .add_systems(Render, prepare_windows.in_set(RenderSystems::ManageViews));
+                .add_systems(Render, prepare_windows.in_set(RenderSystems::PrepareViews));
         }
     }
 }

--- a/crates/bevy_render/src/view/window/screenshot.rs
+++ b/crates/bevy_render/src/view/window/screenshot.rs
@@ -434,7 +434,7 @@ impl Plugin for ScreenshotPlugin {
                 prepare_screenshots
                     .after(prepare_view_attachments)
                     .before(prepare_view_targets)
-                    .in_set(RenderSystems::ManageViews),
+                    .in_set(RenderSystems::PrepareViews),
             );
     }
 }

--- a/crates/bevy_sprite_render/src/mesh2d/material.rs
+++ b/crates/bevy_sprite_render/src/mesh2d/material.rs
@@ -306,7 +306,7 @@ where
                     Render,
                     (
                         specialize_material2d_meshes::<M>
-                            .in_set(RenderSystems::PrepareMeshes)
+                            .in_set(RenderSystems::Specialize)
                             .after(prepare_assets::<PreparedMaterial2d<M>>)
                             .after(prepare_assets::<RenderMesh>),
                         queue_material2d_meshes::<M>


### PR DESCRIPTION
# Objective

- Disambiguate Specialization Execution
- take us one step closer to no render app ambiguities (#22945 was the first step)

## Solution

- specialization systems do a &mut World trick which means they are ambiguous with everything.
- lets give them their own system set which is ambiguous with itself to let them do their thing
- add a couple RenderSystems sets for the stuff that needs to be before and after it

## Testing

- 3d_scene runs, but probably needs more testing to be sure