### PR TITLE
Introduce RenderGraphSystems

### DIFF
--- a/crates/bevy_core_pipeline/src/lib.rs
+++ b/crates/bevy_core_pipeline/src/lib.rs
@@ -18,6 +18,7 @@ pub mod schedule;
 pub mod tonemapping;
 pub mod upscaling;
 
+use bevy_ecs::schedule::IntoScheduleConfigs;
 pub use bevy_light::Skybox;
 pub use fullscreen_vertex_shader::FullscreenShader;
 pub use schedule::{Core2d, Core2dSystems, Core3d, Core3dSystems};
@@ -25,7 +26,9 @@ pub use schedule::{Core2d, Core2dSystems, Core3d, Core3dSystems};
 mod fullscreen_vertex_shader;
 mod skybox;
 
-use crate::schedule::camera_driver;
+use crate::schedule::{
+    camera_driver, handle_uncovered_swap_chains, submit_pending_command_buffers,
+};
 use crate::{
     blit::BlitPlugin, core_2d::Core2dPlugin, core_3d::Core3dPlugin,
     deferred::copy_lighting_id::CopyDeferredLightingIdPlugin, mip_generation::MipGenerationPlugin,
@@ -33,7 +36,7 @@ use crate::{
 };
 use bevy_app::{App, Plugin};
 use bevy_asset::embedded_asset;
-use bevy_render::renderer::RenderGraph;
+use bevy_render::renderer::{RenderGraph, RenderGraphSystems};
 use bevy_render::RenderApp;
 use oit::OrderIndependentTransparencyPlugin;
 
@@ -55,8 +58,14 @@ impl Plugin for CorePipelinePlugin {
         let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
             return;
         };
-        render_app
-            .init_resource::<FullscreenShader>()
-            .add_systems(RenderGraph, camera_driver);
+        render_app.init_resource::<FullscreenShader>().add_systems(
+            RenderGraph,
+            (
+                camera_driver.in_set(RenderGraphSystems::Render),
+                (submit_pending_command_buffers, handle_uncovered_swap_chains)
+                    .chain()
+                    .in_set(RenderGraphSystems::Submit),
+            ),
+        );
     }
 }

--- a/crates/bevy_core_pipeline/src/schedule.rs
+++ b/crates/bevy_core_pipeline/src/schedule.rs
@@ -98,6 +98,10 @@ impl Core2d {
     }
 }
 
+/// Holds the entity of windows that are a render target for a camera
+#[derive(Resource)]
+struct CameraWindows(HashSet<Entity>);
+
 /// The default entry point for camera driven rendering added to the root [`bevy_render::renderer::RenderGraph`]
 /// schedule. This system iterates over all cameras in the world, executing their associated
 /// rendering schedules defined by the [`bevy_render::camera::CameraRenderGraph`] component.
@@ -154,13 +158,12 @@ pub fn camera_driver(world: &mut World) {
             world.run_schedule(schedule);
         }
     }
-
-    submit_pending_command_buffers(world);
     world.remove_resource::<CurrentView>();
-    handle_uncovered_swap_chains(world, &camera_windows);
+
+    world.insert_resource(CameraWindows(camera_windows));
 }
 
-fn submit_pending_command_buffers(world: &mut World) {
+pub(crate) fn submit_pending_command_buffers(world: &mut World) {
     let mut pending = world.resource_mut::<PendingCommandBuffers>();
     let buffer_count = pending.len();
     let buffers = pending.take();
@@ -172,15 +175,17 @@ fn submit_pending_command_buffers(world: &mut World) {
     }
 }
 
-fn handle_uncovered_swap_chains(world: &mut World, camera_windows: &HashSet<Entity>) {
+pub(crate) fn handle_uncovered_swap_chains(world: &mut World) {
     let windows_to_clear: Vec<_> = {
         let clear_color = world.resource::<ClearColor>().0.to_linear();
+        let Some(camera_windows) = world.remove_resource::<CameraWindows>() else {
+            return;
+        };
         let windows = world.resource::<ExtractedWindows>();
-
         windows
             .iter()
             .filter_map(|(window_entity, window)| {
-                if camera_windows.contains(window_entity) {
+                if camera_windows.0.contains(window_entity) {
                     return None;
                 }
                 let swap_chain_texture = window.swap_chain_texture_view.as_ref()?;

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -85,7 +85,7 @@ use crate::{
     mesh::{MeshRenderAssetPlugin, RenderMesh},
     render_asset::prepare_assets,
     render_resource::PipelineCache,
-    renderer::{render_system, RenderAdapterInfo},
+    renderer::{render_system, RenderAdapterInfo, RenderGraph},
     settings::RenderCreation,
     storage::StoragePlugin,
     texture::TexturePlugin,
@@ -317,6 +317,8 @@ impl Plugin for RenderPlugin {
                     PipelineCache::extract_shaders,
                 ),
             );
+
+            render_app.add_schedule(RenderGraph::base_schedule());
 
             render_app.init_schedule(RenderStartup);
             render_app.update_schedule = Some(RenderRecovery.intern());

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -33,8 +33,31 @@ pub struct RenderGraph;
 
 impl RenderGraph {
     pub fn base_schedule() -> Schedule {
-        Schedule::new(Self)
+        let mut schedule = Schedule::new(Self);
+        schedule.configure_sets(
+            (
+                RenderGraphSystems::Begin,
+                RenderGraphSystems::Render,
+                RenderGraphSystems::Submit,
+                RenderGraphSystems::Finish,
+            )
+                .chain(),
+        );
+        schedule
     }
+}
+
+/// System sets for the root [`RenderGraph`] schedule.
+#[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
+pub enum RenderGraphSystems {
+    /// Runs before rendering. Used for per-frame setup.
+    Begin,
+    /// The main rendering phase.
+    Render,
+    /// Submits pending command buffers generated during [`RenderGraphSystems::Render`]
+    Submit,
+    /// Runs after rendering and submit. Used for per-frame finalization.
+    Finish,
 }
 
 /// The main render system that drives the rendering process. This system runs the [`RenderGraph`]


### PR DESCRIPTION
# Objective

- It's sometimes useful to order things relative to the `RenderGraph`

## Solution

- Introduce `RenderGraphSytems` that contains all the important phases of the `RenderGraph` execution

## Testing

- I tested the 3d_scene and it worked

## Note

This is needed to fix diagnostic recording of gpu timestamps.