### PR TITLE
Add `BeforeAdd` and `AfterRemove` lifecycle events

### DIFF
--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -49,12 +49,16 @@ pub fn derive_resource(input: TokenStream) -> TokenStream {
 
     let storage = storage_path(&bevy_ecs_path, StorageTy::Table);
 
+    let before_add_path = None;
     let on_add_path = None;
     let on_remove_path = None;
     let on_insert_path = None;
     let on_replace_path = None;
     let on_despawn_path = None;
+    let after_remove_path = None;
 
+    let before_add =
+        hook_register_function_call(&bevy_ecs_path, quote! {before_add}, before_add_path);
     let on_add = hook_register_function_call(&bevy_ecs_path, quote! {on_add}, on_add_path);
     let on_remove = hook_register_function_call(&bevy_ecs_path, quote! {on_remove}, on_remove_path);
     let on_insert = hook_register_function_call(&bevy_ecs_path, quote! {on_insert}, on_insert_path);
@@ -62,6 +66,8 @@ pub fn derive_resource(input: TokenStream) -> TokenStream {
         hook_register_function_call(&bevy_ecs_path, quote! {on_replace}, on_replace_path);
     let on_despawn =
         hook_register_function_call(&bevy_ecs_path, quote! {on_despawn}, on_despawn_path);
+    let after_remove =
+        hook_register_function_call(&bevy_ecs_path, quote! {after_remove}, after_remove_path);
 
     ast.generics
         .make_where_clause()
@@ -95,11 +101,13 @@ pub fn derive_resource(input: TokenStream) -> TokenStream {
                 #(#register_required)*
             }
 
+            #before_add
             #on_add
             #on_insert
             #on_replace
             #on_remove
             #on_despawn
+            #after_remove
 
             fn clone_behavior() -> #bevy_ecs_path::component::ComponentCloneBehavior {
                 #bevy_ecs_path::component::ComponentCloneBehavior::Default
@@ -160,11 +168,17 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
 
     let storage = storage_path(&bevy_ecs_path, attrs.storage);
 
+    let before_add_path = attrs
+        .before_add
+        .map(|path| path.to_token_stream(&bevy_ecs_path));
     let on_add_path = attrs
         .on_add
         .map(|path| path.to_token_stream(&bevy_ecs_path));
     let on_remove_path = attrs
         .on_remove
+        .map(|path| path.to_token_stream(&bevy_ecs_path));
+    let after_remove_path = attrs
+        .after_remove
         .map(|path| path.to_token_stream(&bevy_ecs_path));
 
     let on_insert_path = if relationship.is_some() {
@@ -232,6 +246,8 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
             .map(|path| path.to_token_stream(&bevy_ecs_path))
     };
 
+    let before_add =
+        hook_register_function_call(&bevy_ecs_path, quote! {before_add}, before_add_path);
     let on_add = hook_register_function_call(&bevy_ecs_path, quote! {on_add}, on_add_path);
     let on_insert = hook_register_function_call(&bevy_ecs_path, quote! {on_insert}, on_insert_path);
     let on_discard =
@@ -239,6 +255,8 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
     let on_remove = hook_register_function_call(&bevy_ecs_path, quote! {on_remove}, on_remove_path);
     let on_despawn =
         hook_register_function_call(&bevy_ecs_path, quote! {on_despawn}, on_despawn_path);
+    let after_remove =
+        hook_register_function_call(&bevy_ecs_path, quote! {after_remove}, after_remove_path);
 
     ast.generics
         .make_where_clause()
@@ -338,11 +356,13 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
                 #(#register_required)*
             }
 
+            #before_add
             #on_add
             #on_insert
             #on_discard
             #on_remove
             #on_despawn
+            #after_remove
 
             fn clone_behavior() -> #bevy_ecs_path::component::ComponentCloneBehavior {
                 #clone_behavior
@@ -460,11 +480,13 @@ pub const REQUIRE: &str = "require";
 pub const RELATIONSHIP: &str = "relationship";
 pub const RELATIONSHIP_TARGET: &str = "relationship_target";
 
+pub const BEFORE_ADD: &str = "before_add";
 pub const ON_ADD: &str = "on_add";
 pub const ON_INSERT: &str = "on_insert";
 pub const ON_DISCARD: &str = "on_discard";
 pub const ON_REMOVE: &str = "on_remove";
 pub const ON_DESPAWN: &str = "on_despawn";
+pub const AFTER_REMOVE: &str = "after_remove";
 pub const MAP_ENTITIES: &str = "map_entities";
 
 pub const IMMUTABLE: &str = "immutable";
@@ -583,11 +605,13 @@ impl Parse for MapEntitiesAttributeKind {
 struct Attrs {
     storage: StorageTy,
     requires: Option<Punctuated<Require, Comma>>,
+    before_add: Option<HookAttributeKind>,
     on_add: Option<HookAttributeKind>,
     on_insert: Option<HookAttributeKind>,
     on_discard: Option<HookAttributeKind>,
     on_remove: Option<HookAttributeKind>,
     on_despawn: Option<HookAttributeKind>,
+    after_remove: Option<HookAttributeKind>,
     relationship: Option<Relationship>,
     relationship_target: Option<RelationshipTarget>,
     immutable: bool,
@@ -623,11 +647,13 @@ const SPARSE_SET: &str = "SparseSet";
 fn parse_component_attr(ast: &DeriveInput) -> Result<Attrs> {
     let mut attrs = Attrs {
         storage: StorageTy::Table,
+        before_add: None,
         on_add: None,
         on_insert: None,
         on_discard: None,
         on_remove: None,
         on_despawn: None,
+        after_remove: None,
         requires: None,
         relationship: None,
         relationship_target: None,
@@ -650,6 +676,11 @@ fn parse_component_attr(ast: &DeriveInput) -> Result<Attrs> {
                             )));
                         }
                     };
+                    Ok(())
+                } else if nested.path.is_ident(BEFORE_ADD) {
+                    attrs.before_add = Some(HookAttributeKind::parse(nested.input, || {
+                        parse_quote! { Self::before_add }
+                    })?);
                     Ok(())
                 } else if nested.path.is_ident(ON_ADD) {
                     attrs.on_add = Some(HookAttributeKind::parse(nested.input, || {
@@ -674,6 +705,11 @@ fn parse_component_attr(ast: &DeriveInput) -> Result<Attrs> {
                 } else if nested.path.is_ident(ON_DESPAWN) {
                     attrs.on_despawn = Some(HookAttributeKind::parse(nested.input, || {
                         parse_quote! { Self::on_despawn }
+                    })?);
+                    Ok(())
+                } else if nested.path.is_ident(AFTER_REMOVE) {
+                    attrs.after_remove = Some(HookAttributeKind::parse(nested.input, || {
+                        parse_quote! { Self::after_remove }
                     })?);
                     Ok(())
                 } else if nested.path.is_ident(IMMUTABLE) {

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -371,6 +371,10 @@ bitflags::bitflags! {
         const ON_DISCARD_OBSERVER = (1 << 7);
         const ON_REMOVE_OBSERVER = (1 << 8);
         const ON_DESPAWN_OBSERVER = (1 << 9);
+        const ON_BEFORE_ADD_HOOK     = (1 << 10);
+        const ON_AFTER_REMOVE_HOOK   = (1 << 11);
+        const ON_BEFORE_ADD_OBSERVER = (1 << 12);
+        const ON_AFTER_REMOVE_OBSERVER = (1 << 13);
     }
 }
 
@@ -736,6 +740,28 @@ impl Archetype {
     #[inline]
     pub fn has_despawn_observer(&self) -> bool {
         self.flags().contains(ArchetypeFlags::ON_DESPAWN_OBSERVER)
+    }
+
+    /// Returns true if any of the components in this archetype have a `before_add` hook.
+    pub fn has_before_add_hook(&self) -> bool {
+        self.flags().contains(ArchetypeFlags::ON_BEFORE_ADD_HOOK)
+    }
+
+    /// Returns true if any of the components in this archetype have an `after_remove` hook.
+    pub fn has_after_remove_hook(&self) -> bool {
+        self.flags().contains(ArchetypeFlags::ON_AFTER_REMOVE_HOOK)
+    }
+
+    /// Returns true if any of the components in this archetype are watched by a `BeforeAdd` observer.
+    pub fn has_before_add_observer(&self) -> bool {
+        self.flags()
+            .contains(ArchetypeFlags::ON_BEFORE_ADD_OBSERVER)
+    }
+
+    /// Returns true if any of the components in this archetype are watched by an `AfterRemove` observer.
+    pub fn has_after_remove_observer(&self) -> bool {
+        self.flags()
+            .contains(ArchetypeFlags::ON_AFTER_REMOVE_OBSERVER)
     }
 }
 

--- a/crates/bevy_ecs/src/bundle/insert.rs
+++ b/crates/bevy_ecs/src/bundle/insert.rs
@@ -12,7 +12,7 @@ use crate::{
     component::{Components, StorageType},
     entity::{Entities, Entity, EntityLocation},
     event::EntityComponentsTrigger,
-    lifecycle::{Add, Discard, Insert, ADD, DISCARD, INSERT},
+    lifecycle::{Add, BeforeAdd, Discard, Insert, ADD, BEFORE_ADD, DISCARD, INSERT},
     observer::Observers,
     query::DebugCheckedUnwrap as _,
     relationship::RelationshipHookMode,
@@ -193,6 +193,36 @@ impl<'w> BundleInserter<'w> {
                     archetype_after_insert.existing().iter().copied(),
                     caller,
                     relationship_hook_mode,
+                );
+            }
+
+            // Trigger BeforeAdd for newly added components (before the archetype move).
+            // The entity is still in the old archetype; component data has NOT been written yet.
+            if !archetype_after_insert.added().is_empty() {
+                let new_archetype = match archetype_move_type {
+                    ArchetypeMoveType::SameArchetype => archetype.as_ref(),
+                    ArchetypeMoveType::NewArchetypeSameTable { new_archetype }
+                    | ArchetypeMoveType::NewArchetypeNewTable { new_archetype, .. } => {
+                        new_archetype.as_ref()
+                    }
+                };
+                if new_archetype.has_before_add_observer() {
+                    deferred_world.trigger_raw(
+                        BEFORE_ADD,
+                        &mut BeforeAdd { entity },
+                        &mut EntityComponentsTrigger {
+                            components: archetype_after_insert.added(),
+                            old_archetype: Some(archetype.as_ref()),
+                            new_archetype: Some(new_archetype),
+                        },
+                        caller,
+                    );
+                }
+                deferred_world.trigger_before_add(
+                    new_archetype,
+                    entity,
+                    archetype_after_insert.added().iter().copied(),
+                    caller,
                 );
             }
         }

--- a/crates/bevy_ecs/src/bundle/remove.rs
+++ b/crates/bevy_ecs/src/bundle/remove.rs
@@ -26,6 +26,17 @@ pub(crate) struct BundleRemover<'w> {
     pub(crate) relationship_hook_mode: RelationshipHookMode,
 }
 
+#[inline]
+fn explicit_components_in_archetype<'a>(
+    explicit_components: &'a [ComponentId],
+    archetype: &'a Archetype,
+) -> impl Iterator<Item = ComponentId> + 'a {
+    explicit_components
+        .iter()
+        .copied()
+        .filter(move |component_id| archetype.contains(*component_id))
+}
+
 impl<'w> BundleRemover<'w> {
     /// Creates a new [`BundleRemover`], if such a remover would do anything.
     ///
@@ -136,195 +147,210 @@ impl<'w> BundleRemover<'w> {
             &[ComponentId],
         ) -> (bool, T),
     ) -> (EntityLocation, T) {
-        // Hooks
+        let bundle_info = self.bundle_info.as_ref();
+        let explicit_components = bundle_info.explicit_components();
+        let old_archetype_id = location.archetype_id;
+        // Save flags before mutation invalidates archetype references.
+        let has_after_remove_hook = self.old_archetype.as_ref().has_after_remove_hook();
+        let has_after_remove_observer = self.old_archetype.as_ref().has_after_remove_observer();
+
         // SAFETY: all bundle components exist in World
         unsafe {
-            // SAFETY: We only keep access to archetype/bundle data.
+            let old_archetype = self.old_archetype.as_ref();
+            let new_archetype = self.new_archetype.as_ref();
+            let has_discard_observer = old_archetype.has_discard_observer();
+            let has_remove_observer = old_archetype.has_remove_observer();
+            let observer_components = (has_discard_observer || has_remove_observer).then(|| {
+                explicit_components_in_archetype(explicit_components, old_archetype)
+                    .collect::<Vec<_>>()
+            });
+
+            // SAFETY: We only keep access to archetype metadata.
             let mut deferred_world = self.world.into_deferred();
-            let bundle_components_in_archetype = || {
-                self.bundle_info
-                    .as_ref()
-                    .iter_explicit_components()
-                    .filter(|component_id| self.old_archetype.as_ref().contains(*component_id))
-            };
-            if self.old_archetype.as_ref().has_discard_observer() {
-                let components = bundle_components_in_archetype().collect::<Vec<_>>();
+            if has_discard_observer {
+                let components = observer_components.as_ref().unwrap();
                 // SAFETY: the DISCARD event_key corresponds to the Discard event's type
                 deferred_world.trigger_raw(
                     DISCARD,
                     &mut Discard { entity },
                     &mut EntityComponentsTrigger {
-                        components: &components,
-                        old_archetype: Some(self.old_archetype.as_ref()),
-                        new_archetype: Some(self.new_archetype.as_ref()),
+                        components,
+                        old_archetype: Some(old_archetype),
+                        new_archetype: Some(new_archetype),
                     },
                     caller,
                 );
             }
             deferred_world.trigger_on_discard(
-                self.old_archetype.as_ref(),
+                old_archetype,
                 entity,
-                bundle_components_in_archetype(),
+                explicit_components_in_archetype(explicit_components, old_archetype),
                 caller,
                 self.relationship_hook_mode,
             );
-            if self.old_archetype.as_ref().has_remove_observer() {
-                let components = bundle_components_in_archetype().collect::<Vec<_>>();
+            if has_remove_observer {
+                let components = observer_components.as_ref().unwrap();
                 // SAFETY: the REMOVE event_key corresponds to the Remove event's type
                 deferred_world.trigger_raw(
                     REMOVE,
                     &mut Remove { entity },
                     &mut EntityComponentsTrigger {
-                        components: &components,
-                        old_archetype: Some(self.old_archetype.as_ref()),
-                        new_archetype: Some(self.new_archetype.as_ref()),
+                        components,
+                        old_archetype: Some(old_archetype),
+                        new_archetype: Some(new_archetype),
                     },
                     caller,
                 );
             }
             deferred_world.trigger_on_remove(
-                self.old_archetype.as_ref(),
+                old_archetype,
                 entity,
-                bundle_components_in_archetype(),
+                explicit_components_in_archetype(explicit_components, old_archetype),
                 caller,
             );
         }
 
-        // SAFETY: We still have the cell, so this is unique, it doesn't conflict with other references, and we drop it shortly.
-        let world = unsafe { self.world.world_mut() };
+        let (new_location, pre_remove_result) = {
+            // SAFETY: We still have the cell, so this is unique, it doesn't conflict with other references, and we drop it shortly.
+            let world = unsafe { self.world.world_mut() };
 
-        let (needs_drop, pre_remove_result) = pre_remove(
-            &mut world.storages.sparse_sets,
-            self.old_and_new_table
-                .as_ref()
-                // SAFETY: There is no conflicting access for this scope.
-                .map(|(old, _)| unsafe { &mut *old.as_ptr() }),
-            &world.components,
-            self.bundle_info.as_ref().explicit_components(),
-        );
+            let (needs_drop, pre_remove_result) = pre_remove(
+                &mut world.storages.sparse_sets,
+                self.old_and_new_table
+                    .as_ref()
+                    // SAFETY: There is no conflicting access for this scope.
+                    .map(|(old, _)| unsafe { &mut *old.as_ptr() }),
+                &world.components,
+                explicit_components,
+            );
 
-        // Handle sparse set removes
-        for component_id in self.bundle_info.as_ref().iter_explicit_components() {
-            if self.old_archetype.as_ref().contains(component_id) {
-                world.removed_components.write(component_id, entity);
+            {
+                let old_archetype = self.old_archetype.as_ref();
+                for &component_id in explicit_components {
+                    if !old_archetype.contains(component_id) {
+                        continue;
+                    }
+                    world.removed_components.write(component_id, entity);
 
-                // Make sure to drop components stored in sparse sets.
-                // Dense components are dropped later in `move_to_and_drop_missing_unchecked`.
-                if let Some(StorageType::SparseSet) =
-                    self.old_archetype.as_ref().get_storage_type(component_id)
-                {
-                    world
-                        .storages
-                        .sparse_sets
-                        .get_mut(component_id)
-                        // Set exists because the component existed on the entity
-                        .unwrap()
-                        // If it was already forgotten, it would not be in the set.
-                        .remove(entity);
+                    // Make sure to drop components stored in sparse sets.
+                    // Dense components are dropped later in `move_to_and_drop_missing_unchecked`.
+                    if let Some(StorageType::SparseSet) =
+                        old_archetype.get_storage_type(component_id)
+                    {
+                        world
+                            .storages
+                            .sparse_sets
+                            .get_mut(component_id)
+                            // Set exists because the component existed on the entity
+                            .unwrap()
+                            // If it was already forgotten, it would not be in the set.
+                            .remove(entity);
+                    }
                 }
             }
-        }
 
-        // Handle archetype change
-        let remove_result = self
-            .old_archetype
-            .as_mut()
-            .swap_remove(location.archetype_row);
-        // if an entity was moved into this entity's archetype row, update its archetype row
-        if let Some(swapped_entity) = remove_result.swapped_entity {
-            let swapped_location = world.entities.get_spawned(swapped_entity).unwrap();
-
-            world.entities.update_existing_location(
-                swapped_entity.index(),
-                Some(EntityLocation {
-                    archetype_id: swapped_location.archetype_id,
-                    archetype_row: location.archetype_row,
-                    table_id: swapped_location.table_id,
-                    table_row: swapped_location.table_row,
-                }),
-            );
-        }
-
-        // Handle table change
-        let new_location = if let Some((mut old_table, mut new_table)) = self.old_and_new_table {
-            let move_result = if needs_drop {
-                // SAFETY: old_table_row exists
-                unsafe {
-                    old_table
-                        .as_mut()
-                        .move_to_and_drop_missing_unchecked(location.table_row, new_table.as_mut())
-                }
-            } else {
-                // SAFETY: old_table_row exists
-                unsafe {
-                    old_table.as_mut().move_to_and_forget_missing_unchecked(
-                        location.table_row,
-                        new_table.as_mut(),
-                    )
-                }
-            };
-
-            // SAFETY: move_result.new_row is a valid position in new_archetype's table
-            let new_location = unsafe {
-                self.new_archetype
-                    .as_mut()
-                    .allocate(entity, move_result.new_row)
-            };
-
-            // if an entity was moved into this entity's table row, update its table row
-            if let Some(swapped_entity) = move_result.swapped_entity {
+            let remove_result = self
+                .old_archetype
+                .as_mut()
+                .swap_remove(location.archetype_row);
+            if let Some(swapped_entity) = remove_result.swapped_entity {
                 let swapped_location = world.entities.get_spawned(swapped_entity).unwrap();
 
                 world.entities.update_existing_location(
                     swapped_entity.index(),
                     Some(EntityLocation {
                         archetype_id: swapped_location.archetype_id,
-                        archetype_row: swapped_location.archetype_row,
+                        archetype_row: location.archetype_row,
                         table_id: swapped_location.table_id,
-                        table_row: location.table_row,
+                        table_row: swapped_location.table_row,
                     }),
                 );
-                world.archetypes[swapped_location.archetype_id]
-                    .set_entity_table_row(swapped_location.archetype_row, location.table_row);
             }
 
-            new_location
-        } else {
-            // The tables are the same
-            self.new_archetype
-                .as_mut()
-                .allocate(entity, location.table_row)
+            let new_location = if let Some((mut old_table, mut new_table)) = self.old_and_new_table
+            {
+                let move_result = if needs_drop {
+                    // SAFETY: old_table_row exists
+                    unsafe {
+                        old_table.as_mut().move_to_and_drop_missing_unchecked(
+                            location.table_row,
+                            new_table.as_mut(),
+                        )
+                    }
+                } else {
+                    // SAFETY: old_table_row exists
+                    unsafe {
+                        old_table.as_mut().move_to_and_forget_missing_unchecked(
+                            location.table_row,
+                            new_table.as_mut(),
+                        )
+                    }
+                };
+
+                // SAFETY: move_result.new_row is a valid position in new_archetype's table
+                let allocated_location = unsafe {
+                    self.new_archetype
+                        .as_mut()
+                        .allocate(entity, move_result.new_row)
+                };
+
+                if let Some(swapped_entity) = move_result.swapped_entity {
+                    let swapped_location = world.entities.get_spawned(swapped_entity).unwrap();
+
+                    world.entities.update_existing_location(
+                        swapped_entity.index(),
+                        Some(EntityLocation {
+                            archetype_id: swapped_location.archetype_id,
+                            archetype_row: swapped_location.archetype_row,
+                            table_id: swapped_location.table_id,
+                            table_row: location.table_row,
+                        }),
+                    );
+                    world.archetypes[swapped_location.archetype_id]
+                        .set_entity_table_row(swapped_location.archetype_row, location.table_row);
+                }
+
+                allocated_location
+            } else {
+                self.new_archetype
+                    .as_mut()
+                    .allocate(entity, location.table_row)
+            };
+
+            // SAFETY: The entity is valid and has been moved to the new location already.
+            unsafe {
+                world
+                    .entities
+                    .update_existing_location(entity.index(), Some(new_location));
+            }
+
+            (new_location, pre_remove_result)
         };
 
-        // SAFETY: The entity is valid and has been moved to the new location already.
-        unsafe {
-            world
-                .entities
-                .update_existing_location(entity.index(), Some(new_location));
-        }
-
-        // Trigger AfterRemove for removed components.
-        // The entity is now in the new archetype; component data has been dropped.
-        // SAFETY: all bundle components exist in World
-        unsafe {
-            let old_archetype = self.old_archetype.as_ref();
-            if old_archetype.has_after_remove_hook() || old_archetype.has_after_remove_observer() {
-                let mut deferred_world = self.world.into_deferred();
-                let bundle_components_in_archetype = || {
-                    self.bundle_info
-                        .as_ref()
-                        .iter_explicit_components()
-                        .filter(|component_id| old_archetype.contains(*component_id))
-                };
+        // Trigger AfterRemove after the entity has moved and removed data is gone.
+        // SAFETY:
+        // - all bundle components exist in World
+        // - only type metadata is read from archetypes during these hooks
+        if has_after_remove_hook || has_after_remove_observer {
+            // SAFETY:
+            // - `old_archetype_id` and `new_location.archetype_id` are valid IDs
+            // - only type metadata is read from archetypes while triggering hooks/observers
+            unsafe {
+                let world = self.world;
+                let archetypes = world.archetypes();
+                let old_archetype = &archetypes[old_archetype_id];
+                let mut deferred_world = world.into_deferred();
                 deferred_world.trigger_after_remove(
                     old_archetype,
                     entity,
-                    bundle_components_in_archetype(),
+                    explicit_components_in_archetype(explicit_components, old_archetype),
                     caller,
                 );
-                if old_archetype.has_after_remove_observer() {
-                    let removed_components = bundle_components_in_archetype().collect::<Vec<_>>();
-                    let new_archetype = self.new_archetype.as_ref();
+                if has_after_remove_observer {
+                    let new_archetype = &archetypes[new_location.archetype_id];
+                    let removed_components =
+                        explicit_components_in_archetype(explicit_components, old_archetype)
+                            .collect::<Vec<_>>();
                     deferred_world.trigger_raw(
                         AFTER_REMOVE,
                         &mut AfterRemove { entity },

--- a/crates/bevy_ecs/src/bundle/remove.rs
+++ b/crates/bevy_ecs/src/bundle/remove.rs
@@ -9,7 +9,7 @@ use crate::{
     component::{ComponentId, Components, StorageType},
     entity::{Entity, EntityLocation},
     event::EntityComponentsTrigger,
-    lifecycle::{Discard, Remove, DISCARD, REMOVE},
+    lifecycle::{AfterRemove, Discard, Remove, AFTER_REMOVE, DISCARD, REMOVE},
     observer::Observers,
     relationship::RelationshipHookMode,
     storage::{SparseSets, Storages, Table},
@@ -301,6 +301,42 @@ impl<'w> BundleRemover<'w> {
             world
                 .entities
                 .update_existing_location(entity.index(), Some(new_location));
+        }
+
+        // Trigger AfterRemove for removed components.
+        // The entity is now in the new archetype; component data has been dropped.
+        // SAFETY: all bundle components exist in World
+        unsafe {
+            let old_archetype = self.old_archetype.as_ref();
+            if old_archetype.has_after_remove_hook() || old_archetype.has_after_remove_observer() {
+                let mut deferred_world = self.world.into_deferred();
+                let bundle_components_in_archetype = || {
+                    self.bundle_info
+                        .as_ref()
+                        .iter_explicit_components()
+                        .filter(|component_id| old_archetype.contains(*component_id))
+                };
+                deferred_world.trigger_after_remove(
+                    old_archetype,
+                    entity,
+                    bundle_components_in_archetype(),
+                    caller,
+                );
+                if old_archetype.has_after_remove_observer() {
+                    let removed_components = bundle_components_in_archetype().collect::<Vec<_>>();
+                    let new_archetype = self.new_archetype.as_ref();
+                    deferred_world.trigger_raw(
+                        AFTER_REMOVE,
+                        &mut AfterRemove { entity },
+                        &mut EntityComponentsTrigger {
+                            components: &removed_components,
+                            old_archetype: Some(old_archetype),
+                            new_archetype: Some(new_archetype),
+                        },
+                        caller,
+                    );
+                }
+            }
         }
 
         (new_location, pre_remove_result)

--- a/crates/bevy_ecs/src/bundle/spawner.rs
+++ b/crates/bevy_ecs/src/bundle/spawner.rs
@@ -8,7 +8,7 @@ use crate::{
     change_detection::{MaybeLocation, Tick},
     entity::{Entity, EntityAllocator, EntityLocation},
     event::EntityComponentsTrigger,
-    lifecycle::{Add, Insert, ADD, INSERT},
+    lifecycle::{Add, BeforeAdd, Insert, ADD, BEFORE_ADD, INSERT},
     relationship::RelationshipHookMode,
     storage::Table,
     world::{unsafe_world_cell::UnsafeWorldCell, World},
@@ -96,6 +96,36 @@ impl<'w> BundleSpawner<'w> {
     ) -> EntityLocation {
         // SAFETY: We do not make any structural changes to the archetype graph through self.world so these pointers always remain valid
         let bundle_info = self.bundle_info.as_ref();
+
+        // Fire BeforeAdd before component data is written.
+        // The entity has been allocated but has no location or components yet.
+        // This matches the insert path where BeforeAdd fires before the archetype move.
+        // Ordering: observer → hooks (matching pre-modification event convention).
+        // SAFETY: All components in the bundle are guaranteed to exist in the World.
+        // DeferredWorld is dropped before we take mutable references below.
+        unsafe {
+            let mut deferred_world = self.world.into_deferred();
+            let archetype = self.archetype.as_ref();
+            if archetype.has_before_add_observer() {
+                deferred_world.trigger_raw(
+                    BEFORE_ADD,
+                    &mut BeforeAdd { entity },
+                    &mut EntityComponentsTrigger {
+                        components: bundle_info.contributed_components(),
+                        old_archetype: None,
+                        new_archetype: Some(archetype),
+                    },
+                    caller,
+                );
+            }
+            deferred_world.trigger_before_add(
+                archetype,
+                entity,
+                bundle_info.iter_contributed_components(),
+                caller,
+            );
+        }
+
         let location = {
             let table = self.table.as_mut();
             let archetype = self.archetype.as_mut();

--- a/crates/bevy_ecs/src/bundle/tests.rs
+++ b/crates/bevy_ecs/src/bundle/tests.rs
@@ -6,23 +6,31 @@ use crate::{
 struct A;
 
 #[derive(Component)]
-#[component(on_add = a_on_add, on_insert = a_on_insert, on_discard = a_on_discard, on_remove = a_on_remove)]
+#[component(before_add = a_before_add, on_add = a_on_add, on_insert = a_on_insert, on_discard = a_on_discard, on_remove = a_on_remove, after_remove = a_after_remove)]
 struct AMacroHooks;
 
-fn a_on_add(mut world: DeferredWorld, _: HookContext) {
+fn a_before_add(mut world: DeferredWorld, _: HookContext) {
     world.resource_mut::<R>().assert_order(0);
 }
 
-fn a_on_insert(mut world: DeferredWorld, _: HookContext) {
+fn a_on_add(mut world: DeferredWorld, _: HookContext) {
     world.resource_mut::<R>().assert_order(1);
 }
 
-fn a_on_discard(mut world: DeferredWorld, _: HookContext) {
+fn a_on_insert(mut world: DeferredWorld, _: HookContext) {
     world.resource_mut::<R>().assert_order(2);
 }
 
-fn a_on_remove(mut world: DeferredWorld, _: HookContext) {
+fn a_on_discard(mut world: DeferredWorld, _: HookContext) {
     world.resource_mut::<R>().assert_order(3);
+}
+
+fn a_on_remove(mut world: DeferredWorld, _: HookContext) {
+    world.resource_mut::<R>().assert_order(4);
+}
+
+fn a_after_remove(mut world: DeferredWorld, _: HookContext) {
+    world.resource_mut::<R>().assert_order(5);
 }
 
 #[derive(Component)]
@@ -74,14 +82,16 @@ fn component_hook_order_spawn_despawn() {
     world.init_resource::<R>();
     world
         .register_component_hooks::<A>()
-        .on_add(|mut world, _| world.resource_mut::<R>().assert_order(0))
-        .on_insert(|mut world, _| world.resource_mut::<R>().assert_order(1))
-        .on_discard(|mut world, _| world.resource_mut::<R>().assert_order(2))
-        .on_remove(|mut world, _| world.resource_mut::<R>().assert_order(3));
+        .before_add(|mut world, _| world.resource_mut::<R>().assert_order(0))
+        .on_add(|mut world, _| world.resource_mut::<R>().assert_order(1))
+        .on_insert(|mut world, _| world.resource_mut::<R>().assert_order(2))
+        .on_discard(|mut world, _| world.resource_mut::<R>().assert_order(3))
+        .on_remove(|mut world, _| world.resource_mut::<R>().assert_order(4))
+        .after_remove(|mut world, _| world.resource_mut::<R>().assert_order(5));
 
     let entity = world.spawn(A).id();
     world.despawn(entity);
-    assert_eq!(4, world.resource::<R>().0);
+    assert_eq!(6, world.resource::<R>().0);
 }
 
 #[test]
@@ -92,7 +102,7 @@ fn component_hook_order_spawn_despawn_with_macro_hooks() {
     let entity = world.spawn(AMacroHooks).id();
     world.despawn(entity);
 
-    assert_eq!(4, world.resource::<R>().0);
+    assert_eq!(6, world.resource::<R>().0);
 }
 
 #[test]
@@ -101,16 +111,18 @@ fn component_hook_order_insert_remove() {
     world.init_resource::<R>();
     world
         .register_component_hooks::<A>()
-        .on_add(|mut world, _| world.resource_mut::<R>().assert_order(0))
-        .on_insert(|mut world, _| world.resource_mut::<R>().assert_order(1))
-        .on_discard(|mut world, _| world.resource_mut::<R>().assert_order(2))
-        .on_remove(|mut world, _| world.resource_mut::<R>().assert_order(3));
+        .before_add(|mut world, _| world.resource_mut::<R>().assert_order(0))
+        .on_add(|mut world, _| world.resource_mut::<R>().assert_order(1))
+        .on_insert(|mut world, _| world.resource_mut::<R>().assert_order(2))
+        .on_discard(|mut world, _| world.resource_mut::<R>().assert_order(3))
+        .on_remove(|mut world, _| world.resource_mut::<R>().assert_order(4))
+        .after_remove(|mut world, _| world.resource_mut::<R>().assert_order(5));
 
     let mut entity = world.spawn_empty();
     entity.insert(A);
     entity.remove::<A>();
     entity.flush();
-    assert_eq!(4, world.resource::<R>().0);
+    assert_eq!(6, world.resource::<R>().0);
 }
 
 #[test]
@@ -262,4 +274,105 @@ struct Ignore {
     foo: i32,
     #[bundle(ignore)]
     bar: i32,
+}
+
+#[test]
+fn before_add_hook_does_not_fire_on_replace() {
+    #[derive(Resource, Default)]
+    struct BeforeAddCount(usize);
+
+    let mut world = World::new();
+    world.init_resource::<BeforeAddCount>();
+    world
+        .register_component_hooks::<A>()
+        .before_add(|mut world, _| {
+            world.resource_mut::<BeforeAddCount>().0 += 1;
+        });
+
+    let entity = world.spawn(A).id();
+    assert_eq!(1, world.resource::<BeforeAddCount>().0);
+
+    let mut entity = world.entity_mut(entity);
+    entity.insert(A);
+    entity.flush();
+    assert_eq!(1, world.resource::<BeforeAddCount>().0);
+}
+
+#[test]
+fn after_remove_component_data_not_accessible() {
+    let mut world = World::new();
+    world
+        .register_component_hooks::<V>()
+        .after_remove(|world, ctx| {
+            assert!(world.entity(ctx.entity).get::<V>().is_none());
+        });
+
+    let mut entity = world.spawn_empty();
+    entity.insert(V("test"));
+    entity.remove::<V>();
+    entity.flush();
+}
+
+#[test]
+fn before_add_component_not_accessible_during_spawn() {
+    let mut world = World::new();
+    world
+        .register_component_hooks::<V>()
+        .before_add(|world, ctx| {
+            assert!(world.get_entity(ctx.entity).is_err());
+        });
+
+    world.spawn(V("test"));
+}
+
+#[test]
+fn before_add_component_not_accessible_during_insert() {
+    let mut world = World::new();
+    world
+        .register_component_hooks::<V>()
+        .before_add(|world, ctx| {
+            assert!(world.entity(ctx.entity).get::<V>().is_none());
+        });
+
+    let mut entity = world.spawn_empty();
+    entity.insert(V("test"));
+    entity.flush();
+}
+
+#[test]
+fn before_add_observer_order() {
+    let mut world = World::new();
+    world.init_resource::<R>();
+    world.add_observer(|_: On<BeforeAdd, A>, mut r: ResMut<R>| r.assert_order(0));
+    world.add_observer(|_: On<Add, A>, mut r: ResMut<R>| r.assert_order(1));
+
+    world.spawn(A);
+    assert_eq!(2, world.resource::<R>().0);
+}
+
+#[test]
+fn after_remove_observer_order() {
+    let mut world = World::new();
+    world.init_resource::<R>();
+    world.add_observer(|_: On<Remove, A>, mut r: ResMut<R>| r.assert_order(0));
+    world.add_observer(|_: On<AfterRemove, A>, mut r: ResMut<R>| r.assert_order(1));
+
+    let mut entity = world.spawn_empty();
+    entity.insert(A);
+    entity.remove::<A>();
+    entity.flush();
+    assert_eq!(2, world.resource::<R>().0);
+}
+
+#[test]
+fn before_add_observer_fires_before_hook() {
+    let mut world = World::new();
+    world.init_resource::<R>();
+    world.add_observer(|_: On<BeforeAdd, A>, mut r: ResMut<R>| r.assert_order(0));
+    world
+        .register_component_hooks::<A>()
+        .before_add(|mut world, _| world.resource_mut::<R>().assert_order(1));
+
+    world.spawn(A);
+    assert_eq!(2, world.resource::<R>().0);
 }

--- a/crates/bevy_ecs/src/component/constants.rs
+++ b/crates/bevy_ecs/src/component/constants.rs
@@ -10,5 +10,9 @@ pub const DISCARD: usize = 2;
 pub const REMOVE: usize = 3;
 /// `usize` for [`Despawn`](crate::lifecycle::Despawn) component used in lifecycle observers.
 pub const DESPAWN: usize = 4;
+/// `usize` for the [`BeforeAdd`](crate::lifecycle::BeforeAdd) component used in lifecycle observers.
+pub const BEFORE_ADD: usize = 5;
+/// `usize` for the [`AfterRemove`](crate::lifecycle::AfterRemove) component used in lifecycle observers.
+pub const AFTER_REMOVE: usize = 6;
 /// `usize` of the [`IsResource`](crate::resource::IsResource) component used to mark entities with resources.
-pub const IS_RESOURCE: usize = 5;
+pub const IS_RESOURCE: usize = 7;

--- a/crates/bevy_ecs/src/component/info.rs
+++ b/crates/bevy_ecs/src/component/info.rs
@@ -129,6 +129,12 @@ impl ComponentInfo {
         if self.hooks().on_despawn.is_some() {
             flags.insert(ArchetypeFlags::ON_DESPAWN_HOOK);
         }
+        if self.hooks().before_add.is_some() {
+            flags.insert(ArchetypeFlags::ON_BEFORE_ADD_HOOK);
+        }
+        if self.hooks().after_remove.is_some() {
+            flags.insert(ArchetypeFlags::ON_AFTER_REMOVE_HOOK);
+        }
     }
 
     /// Provides a reference to the collection of hooks associated with this [`Component`]

--- a/crates/bevy_ecs/src/component/mod.rs
+++ b/crates/bevy_ecs/src/component/mod.rs
@@ -354,10 +354,13 @@ use core::{fmt::Debug, marker::PhantomData, ops::Deref};
 /// See [`ComponentHooks`] for a detailed explanation of component's hooks.
 ///
 /// Alternatively to the example shown in [`ComponentHooks`]' documentation, hooks can be configured using following attributes:
+/// - `#[component(before_add = before_add_function)]`
 /// - `#[component(on_add = on_add_function)]`
 /// - `#[component(on_insert = on_insert_function)]`
 /// - `#[component(on_discard = on_discard_function)]`
 /// - `#[component(on_remove = on_remove_function)]`
+/// - `#[component(on_despawn = on_despawn_function)]`
+/// - `#[component(after_remove = after_remove_function)]`
 ///
 /// ```
 /// # use bevy_ecs::component::Component;

--- a/crates/bevy_ecs/src/component/mod.rs
+++ b/crates/bevy_ecs/src/component/mod.rs
@@ -373,8 +373,8 @@ use core::{fmt::Debug, marker::PhantomData, ops::Deref};
 /// // Another possible way of configuring hooks:
 /// // #[component(on_add = my_on_add_hook, on_insert = my_on_insert_hook)]
 /// //
-/// // We don't have a discard or remove hook, so we can leave them out:
-/// // #[component(on_discard = my_on_discard_hook, on_remove = my_on_remove_hook)]
+/// // We don't have other hooks, so we can leave them out:
+/// // #[component(before_add = .., on_discard = .., on_remove = .., on_despawn = .., after_remove = ..)]
 /// struct ComponentA;
 ///
 /// fn my_on_add_hook(world: DeferredWorld, context: HookContext) {
@@ -520,6 +520,11 @@ pub trait Component: Send + Sync + 'static {
     /// * For a component to be immutable, this type must be [`Immutable`].
     type Mutability: ComponentMutability;
 
+    /// Gets the `before_add` [`ComponentHook`] for this [`Component`] if one is defined.
+    fn before_add() -> Option<ComponentHook> {
+        None
+    }
+
     /// Gets the `on_add` [`ComponentHook`] for this [`Component`] if one is defined.
     fn on_add() -> Option<ComponentHook> {
         None
@@ -542,6 +547,11 @@ pub trait Component: Send + Sync + 'static {
 
     /// Gets the `on_despawn` [`ComponentHook`] for this [`Component`] if one is defined.
     fn on_despawn() -> Option<ComponentHook> {
+        None
+    }
+
+    /// Gets the `after_remove` [`ComponentHook`] for this [`Component`] if one is defined.
+    fn after_remove() -> Option<ComponentHook> {
         None
     }
 

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -75,7 +75,9 @@ pub mod prelude {
         error::{BevyError, Result},
         event::{EntityEvent, Event},
         hierarchy::{ChildOf, ChildSpawner, ChildSpawnerCommands, Children},
-        lifecycle::{Add, Despawn, Discard, Insert, Remove, RemovedComponents},
+        lifecycle::{
+            Add, AfterRemove, BeforeAdd, Despawn, Discard, Insert, Remove, RemovedComponents,
+        },
         message::{
             Message, MessageMutator, MessageReader, MessageWriter, Messages, PopulatedMessageReader,
         },

--- a/crates/bevy_ecs/src/lifecycle.rs
+++ b/crates/bevy_ecs/src/lifecycle.rs
@@ -29,7 +29,8 @@
 //! - [`Despawn`]: Triggered for each component on an entity when it is despawned.
 //! - [`AfterRemove`]: Triggered after a component has been removed from an entity. Component data is **no longer** accessible.
 //!
-//! [`Discard`] hooks are evaluated before [`Remove`], then [`Despawn`], then finally [`AfterRemove`] hooks are evaluated.
+//! When a component is removed (without despawning), [`Discard`] hooks are evaluated first, then [`Remove`], then [`AfterRemove`].
+//! When an entity is despawned, [`Despawn`] hooks are evaluated first, followed by [`Discard`], then [`Remove`], then [`AfterRemove`].
 //!
 //! [`Add`] and [`Remove`] are counterparts: they are only triggered when a component is added or removed
 //! from an entity in such a way as to cause a change in the component's presence on that entity.
@@ -283,6 +284,8 @@ impl ComponentHooks {
     /// Despawning an entity counts as removing all of its components.
     ///
     /// At the time this hook runs, the component data is **no longer** accessible on the entity.
+    /// During despawn, the entity's location has also been cleared, so
+    /// [`World::get_entity`](crate::world::World::get_entity) will return `Err` for the entity.
     ///
     /// # Panics
     ///

--- a/crates/bevy_ecs/src/lifecycle.rs
+++ b/crates/bevy_ecs/src/lifecycle.rs
@@ -13,21 +13,23 @@
 //!
 //! # Types of lifecycle events
 //!
-//! There are five types of lifecycle events, split into two categories. First, we have lifecycle events that are triggered
+//! There are seven types of lifecycle events, split into two categories. First, we have lifecycle events that are triggered
 //! when a component is added to an entity:
 //!
+//! - [`BeforeAdd`]: Triggered before a component is added to an entity that did not already have it. Component data is **not** yet accessible.
 //! - [`Add`]: Triggered when a component is added to an entity that did not already have it.
 //! - [`Insert`]: Triggered when a component is added to an entity, regardless of whether it already had it.
 //!
-//! When both events occur, [`Add`] hooks are evaluated before [`Insert`].
+//! When all events occur, [`BeforeAdd`] hooks are evaluated first, then [`Add`], then [`Insert`].
 //!
 //! Next, we have lifecycle events that are triggered when a component is removed from an entity:
 //!
 //! - [`Discard`]: Triggered when a component is removed from an entity, regardless if it is then replaced with a new value.
 //! - [`Remove`]: Triggered when a component is removed from an entity and not replaced, before the component is removed.
 //! - [`Despawn`]: Triggered for each component on an entity when it is despawned.
+//! - [`AfterRemove`]: Triggered after a component has been removed from an entity. Component data is **no longer** accessible.
 //!
-//! [`Discard`] hooks are evaluated before [`Remove`], then finally [`Despawn`] hooks are evaluated.
+//! [`Discard`] hooks are evaluated before [`Remove`], then [`Despawn`], then finally [`AfterRemove`] hooks are evaluated.
 //!
 //! [`Add`] and [`Remove`] are counterparts: they are only triggered when a component is added or removed
 //! from an entity in such a way as to cause a change in the component's presence on that entity.
@@ -76,7 +78,8 @@ use core::{
     option,
 };
 
-/// The type used for [`Component`] lifecycle hooks such as `on_add`, `on_insert` or `on_remove`.
+/// The type used for [`Component`] lifecycle hooks such as `before_add`, `on_add`, `on_insert`,
+/// `on_discard`, `on_remove`, `on_despawn`, or `after_remove`.
 pub type ComponentHook = for<'w> fn(DeferredWorld<'w>, HookContext);
 
 /// Context provided to a [`ComponentHook`].
@@ -147,15 +150,20 @@ pub struct HookContext {
 /// ```
 #[derive(Debug, Clone, Default)]
 pub struct ComponentHooks {
+    pub(crate) before_add: Option<ComponentHook>,
     pub(crate) on_add: Option<ComponentHook>,
     pub(crate) on_insert: Option<ComponentHook>,
     pub(crate) on_discard: Option<ComponentHook>,
     pub(crate) on_remove: Option<ComponentHook>,
     pub(crate) on_despawn: Option<ComponentHook>,
+    pub(crate) after_remove: Option<ComponentHook>,
 }
 
 impl ComponentHooks {
     pub(crate) fn update_from_component<C: Component + ?Sized>(&mut self) -> &mut Self {
+        if let Some(hook) = C::before_add() {
+            self.before_add(hook);
+        }
         if let Some(hook) = C::on_add() {
             self.on_add(hook);
         }
@@ -171,8 +179,30 @@ impl ComponentHooks {
         if let Some(hook) = C::on_despawn() {
             self.on_despawn(hook);
         }
+        if let Some(hook) = C::after_remove() {
+            self.after_remove(hook);
+        }
 
         self
+    }
+
+    /// Register a [`ComponentHook`] that will be run before a component is added to an entity.
+    /// A `before_add` hook will always run before `on_add` hooks.
+    /// Spawning an entity counts as adding all of its components.
+    ///
+    /// At the time this hook runs, the component data has **not** yet been written to the entity.
+    ///
+    /// For **insert**, the entity is in its old archetype and can be queried normally
+    /// (it just doesn't have the new component yet).
+    /// For **spawn**, the entity has no location or components yet, so attempting to
+    /// access the entity through the world will fail.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if the component already has a `before_add` hook
+    pub fn before_add(&mut self, hook: ComponentHook) -> &mut Self {
+        self.try_before_add(hook)
+            .expect("Component already has a before_add hook")
     }
 
     /// Register a [`ComponentHook`] that will be run when this component is added to an entity.
@@ -248,6 +278,33 @@ impl ComponentHooks {
             .expect("Component already has an on_despawn hook")
     }
 
+    /// Register a [`ComponentHook`] that will be run after a component has been removed from an entity.
+    /// An `after_remove` hook runs after `on_remove` hooks and after the component data has been dropped.
+    /// Despawning an entity counts as removing all of its components.
+    ///
+    /// At the time this hook runs, the component data is **no longer** accessible on the entity.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if the component already has an `after_remove` hook
+    pub fn after_remove(&mut self, hook: ComponentHook) -> &mut Self {
+        self.try_after_remove(hook)
+            .expect("Component already has an after_remove hook")
+    }
+
+    /// Attempt to register a [`ComponentHook`] that will be run before a component is added to an entity.
+    ///
+    /// This is a fallible version of [`Self::before_add`].
+    ///
+    /// Returns `None` if the component already has a `before_add` hook.
+    pub fn try_before_add(&mut self, hook: ComponentHook) -> Option<&mut Self> {
+        if self.before_add.is_some() {
+            return None;
+        }
+        self.before_add = Some(hook);
+        Some(self)
+    }
+
     /// Attempt to register a [`ComponentHook`] that will be run when this component is added to an entity.
     ///
     /// This is a fallible version of [`Self::on_add`].
@@ -312,8 +369,23 @@ impl ComponentHooks {
         self.on_despawn = Some(hook);
         Some(self)
     }
+
+    /// Attempt to register a [`ComponentHook`] that will be run after a component has been removed from an entity.
+    ///
+    /// This is a fallible version of [`Self::after_remove`].
+    ///
+    /// Returns `None` if the component already has an `after_remove` hook.
+    pub fn try_after_remove(&mut self, hook: ComponentHook) -> Option<&mut Self> {
+        if self.after_remove.is_some() {
+            return None;
+        }
+        self.after_remove = Some(hook);
+        Some(self)
+    }
 }
 
+/// [`EventKey`] for [`BeforeAdd`]
+pub const BEFORE_ADD: EventKey = EventKey(ComponentId::new(crate::component::BEFORE_ADD));
 /// [`EventKey`] for [`Add`]
 pub const ADD: EventKey = EventKey(ComponentId::new(crate::component::ADD));
 /// [`EventKey`] for [`Insert`]
@@ -324,6 +396,24 @@ pub const DISCARD: EventKey = EventKey(ComponentId::new(crate::component::DISCAR
 pub const REMOVE: EventKey = EventKey(ComponentId::new(crate::component::REMOVE));
 /// [`EventKey`] for [`Despawn`]
 pub const DESPAWN: EventKey = EventKey(ComponentId::new(crate::component::DESPAWN));
+/// [`EventKey`] for [`AfterRemove`]
+pub const AFTER_REMOVE: EventKey = EventKey(ComponentId::new(crate::component::AFTER_REMOVE));
+
+/// Trigger emitted before a component is added to an entity that does not already have it.
+/// Runs before `Add` and before the component data is written.
+///
+/// For **insert**, the entity is in its old archetype and can be queried normally.
+/// For **spawn**, the entity has no location or components yet.
+///
+/// See [`ComponentHooks::before_add`](`crate::lifecycle::ComponentHooks::before_add`) for more information.
+#[derive(Debug, Clone, EntityEvent)]
+#[entity_event(trigger = EntityComponentsTrigger<'a>)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
+#[cfg_attr(feature = "bevy_reflect", reflect(Debug))]
+pub struct BeforeAdd {
+    /// The entity this component is about to be added to.
+    pub entity: Entity,
+}
 
 /// Trigger emitted when a component is inserted onto an entity that does not already have that
 /// component. Runs before `Insert`.
@@ -390,6 +480,18 @@ pub struct Remove {
 #[doc(alias = "OnDespawn")]
 pub struct Despawn {
     /// The entity that held this component before it was despawned.
+    pub entity: Entity,
+}
+
+/// Trigger emitted after a component has been removed from an entity.
+/// Runs after `Remove` and after the component data has been dropped.
+/// See [`ComponentHooks::after_remove`](`crate::lifecycle::ComponentHooks::after_remove`) for more information.
+#[derive(Debug, Clone, EntityEvent)]
+#[entity_event(trigger = EntityComponentsTrigger<'a>)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
+#[cfg_attr(feature = "bevy_reflect", reflect(Debug))]
+pub struct AfterRemove {
+    /// The entity this component was removed from.
     pub entity: Entity,
 }
 

--- a/crates/bevy_ecs/src/observer/centralized_storage.rs
+++ b/crates/bevy_ecs/src/observer/centralized_storage.rs
@@ -26,11 +26,13 @@ use crate::{
 #[derive(Default, Debug)]
 pub struct Observers {
     // Cached ECS observers to save a lookup for high-traffic built-in event types.
+    before_add: CachedObservers,
     add: CachedObservers,
     insert: CachedObservers,
     discard: CachedObservers,
     remove: CachedObservers,
     despawn: CachedObservers,
+    after_remove: CachedObservers,
     // Map from event type to set of observers watching for that event
     cache: HashMap<EventKey, CachedObservers>,
 }
@@ -40,34 +42,40 @@ impl Observers {
         use crate::lifecycle::*;
 
         match event_key {
+            BEFORE_ADD => &mut self.before_add,
             ADD => &mut self.add,
             INSERT => &mut self.insert,
             DISCARD => &mut self.discard,
             REMOVE => &mut self.remove,
             DESPAWN => &mut self.despawn,
+            AFTER_REMOVE => &mut self.after_remove,
             _ => self.cache.entry(event_key).or_default(),
         }
     }
 
     /// Attempts to get the observers for the given `event_key`.
     ///
-    /// When accessing the observers for lifecycle events, such as [`Add`], [`Insert`], [`Discard`], [`Remove`], and [`Despawn`],
+    /// When accessing the observers for lifecycle events, such as [`BeforeAdd`], [`Add`], [`Insert`], [`Discard`], [`Remove`], [`Despawn`], and [`AfterRemove`],
     /// use the [`EventKey`] constants from the [`lifecycle`](crate::lifecycle) module.
     ///
+    /// [`BeforeAdd`]: crate::lifecycle::BeforeAdd
     /// [`Add`]: crate::lifecycle::Add
     /// [`Insert`]: crate::lifecycle::Insert
     /// [`Discard`]: crate::lifecycle::Discard
     /// [`Remove`]: crate::lifecycle::Remove
     /// [`Despawn`]: crate::lifecycle::Despawn
+    /// [`AfterRemove`]: crate::lifecycle::AfterRemove
     pub fn try_get_observers(&self, event_key: EventKey) -> Option<&CachedObservers> {
         use crate::lifecycle::*;
 
         match event_key {
+            BEFORE_ADD => Some(&self.before_add),
             ADD => Some(&self.add),
             INSERT => Some(&self.insert),
             DISCARD => Some(&self.discard),
             REMOVE => Some(&self.remove),
             DESPAWN => Some(&self.despawn),
+            AFTER_REMOVE => Some(&self.after_remove),
             _ => self.cache.get(&event_key),
         }
     }
@@ -76,11 +84,13 @@ impl Observers {
         use crate::lifecycle::*;
 
         match event_key {
+            BEFORE_ADD => Some(ArchetypeFlags::ON_BEFORE_ADD_OBSERVER),
             ADD => Some(ArchetypeFlags::ON_ADD_OBSERVER),
             INSERT => Some(ArchetypeFlags::ON_INSERT_OBSERVER),
             DISCARD => Some(ArchetypeFlags::ON_DISCARD_OBSERVER),
             REMOVE => Some(ArchetypeFlags::ON_REMOVE_OBSERVER),
             DESPAWN => Some(ArchetypeFlags::ON_DESPAWN_OBSERVER),
+            AFTER_REMOVE => Some(ArchetypeFlags::ON_AFTER_REMOVE_OBSERVER),
             _ => None,
         }
     }
@@ -90,6 +100,14 @@ impl Observers {
         component_id: ComponentId,
         flags: &mut ArchetypeFlags,
     ) {
+        if self
+            .before_add
+            .component_observers
+            .contains_key(&component_id)
+        {
+            flags.insert(ArchetypeFlags::ON_BEFORE_ADD_OBSERVER);
+        }
+
         if self.add.component_observers.contains_key(&component_id) {
             flags.insert(ArchetypeFlags::ON_ADD_OBSERVER);
         }
@@ -108,6 +126,14 @@ impl Observers {
 
         if self.despawn.component_observers.contains_key(&component_id) {
             flags.insert(ArchetypeFlags::ON_DESPAWN_OBSERVER);
+        }
+
+        if self
+            .after_remove
+            .component_observers
+            .contains_key(&component_id)
+        {
+            flags.insert(ArchetypeFlags::ON_AFTER_REMOVE_OBSERVER);
         }
     }
 }

--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -616,6 +616,40 @@ impl<'w> DeferredWorld<'w> {
             .ok()
     }
 
+    /// Triggers all `before_add` hooks for [`ComponentId`] in target.
+    ///
+    /// The `archetype` parameter should be the **new** archetype (the one containing
+    /// the components being added), since the components don't exist in the old archetype.
+    ///
+    /// # Safety
+    /// Caller must ensure [`ComponentId`] in target exist in self.
+    #[inline]
+    pub(crate) unsafe fn trigger_before_add(
+        &mut self,
+        archetype: &Archetype,
+        entity: Entity,
+        targets: impl Iterator<Item = ComponentId>,
+        caller: MaybeLocation,
+    ) {
+        if archetype.has_before_add_hook() {
+            for component_id in targets {
+                // SAFETY: Caller ensures that these components exist
+                let hooks = unsafe { self.components().get_info_unchecked(component_id) }.hooks();
+                if let Some(hook) = hooks.before_add {
+                    hook(
+                        DeferredWorld { world: self.world },
+                        HookContext {
+                            entity,
+                            component_id,
+                            caller,
+                            relationship_hook_mode: RelationshipHookMode::Run,
+                        },
+                    );
+                }
+            }
+        }
+    }
+
     /// Triggers all `on_add` hooks for [`ComponentId`] in target.
     ///
     /// # Safety
@@ -759,6 +793,40 @@ impl<'w> DeferredWorld<'w> {
                 // SAFETY: Caller ensures that these components exist
                 let hooks = unsafe { self.components().get_info_unchecked(component_id) }.hooks();
                 if let Some(hook) = hooks.on_despawn {
+                    hook(
+                        DeferredWorld { world: self.world },
+                        HookContext {
+                            entity,
+                            component_id,
+                            caller,
+                            relationship_hook_mode: RelationshipHookMode::Run,
+                        },
+                    );
+                }
+            }
+        }
+    }
+
+    /// Triggers all `after_remove` hooks for [`ComponentId`] in target.
+    ///
+    /// The `archetype` parameter should be the **old** archetype (the one that contained
+    /// the removed components), since the components no longer exist in the new archetype.
+    ///
+    /// # Safety
+    /// Caller must ensure [`ComponentId`] in target exist in self.
+    #[inline]
+    pub(crate) unsafe fn trigger_after_remove(
+        &mut self,
+        archetype: &Archetype,
+        entity: Entity,
+        targets: impl Iterator<Item = ComponentId>,
+        caller: MaybeLocation,
+    ) {
+        if archetype.has_after_remove_hook() {
+            for component_id in targets {
+                // SAFETY: Caller ensures that these components exist
+                let hooks = unsafe { self.components().get_info_unchecked(component_id) }.hooks();
+                if let Some(hook) = hooks.after_remove {
                     hook(
                         DeferredWorld { world: self.world },
                         HookContext {

--- a/crates/bevy_ecs/src/world/entity_access/world_mut.rs
+++ b/crates/bevy_ecs/src/world/entity_access/world_mut.rs
@@ -1748,8 +1748,7 @@ impl<'w> EntityWorldMut<'w> {
             // lists) is unchanged by entity-level swap_remove operations.
             // SAFETY: Archetype cannot be mutably aliased by DeferredWorld.
             let (archetype, mut deferred_world) = unsafe {
-                let archetype: *const Archetype =
-                    &self.world.archetypes[location.archetype_id];
+                let archetype: *const Archetype = &self.world.archetypes[location.archetype_id];
                 let world = self.world.as_unsafe_world_cell();
                 (&*archetype, world.into_deferred())
             };

--- a/crates/bevy_ecs/src/world/entity_access/world_mut.rs
+++ b/crates/bevy_ecs/src/world/entity_access/world_mut.rs
@@ -7,7 +7,7 @@ use crate::{
     component::{Component, ComponentId, Components, Mutable, StorageType},
     entity::{Entity, EntityCloner, EntityClonerBuilder, EntityLocation, OptIn, OptOut},
     event::{EntityComponentsTrigger, EntityEvent},
-    lifecycle::{Despawn, Discard, Remove, DESPAWN, DISCARD, REMOVE},
+    lifecycle::{AfterRemove, Despawn, Discard, Remove, AFTER_REMOVE, DESPAWN, DISCARD, REMOVE},
     observer::IntoEntityObserver,
     query::{
         has_conflicts, DebugCheckedUnwrap, QueryAccessError, ReadOnlyQueryData,
@@ -1734,6 +1734,42 @@ impl<'w> EntityWorldMut<'w> {
             }
             self.world.archetypes[moved_location.archetype_id]
                 .set_entity_table_row(moved_location.archetype_row, table_row);
+        }
+
+        // Trigger AfterRemove for all components after data has been dropped.
+        // The entity's location is None at this point (set above).
+        if archetype.has_after_remove_hook() || archetype.has_after_remove_observer() {
+            // SAFETY: Archetype cannot be mutably aliased by DeferredWorld.
+            // We only read type-level metadata (flags, component lists) which is not
+            // modified by the swap_remove/table operations above.
+            let (archetype, mut deferred_world) = unsafe {
+                let archetype: *const Archetype = archetype;
+                let world = self.world.as_unsafe_world_cell();
+                (&*archetype, world.into_deferred())
+            };
+            // SAFETY: All component IDs in the archetype exist in the world.
+            unsafe {
+                deferred_world.trigger_after_remove(
+                    archetype,
+                    self.entity,
+                    archetype.iter_components(),
+                    caller,
+                );
+                if archetype.has_after_remove_observer() {
+                    deferred_world.trigger_raw(
+                        AFTER_REMOVE,
+                        &mut AfterRemove {
+                            entity: self.entity,
+                        },
+                        &mut EntityComponentsTrigger {
+                            components: archetype.components(),
+                            old_archetype: Some(archetype),
+                            new_archetype: None,
+                        },
+                        caller,
+                    );
+                }
+            }
         }
 
         // finish

--- a/crates/bevy_ecs/src/world/entity_access/world_mut.rs
+++ b/crates/bevy_ecs/src/world/entity_access/world_mut.rs
@@ -1658,6 +1658,10 @@ impl<'w> EntityWorldMut<'w> {
             );
         }
 
+        // Save flags before mutations invalidate the archetype reference.
+        let has_after_remove_hook = archetype.has_after_remove_hook();
+        let has_after_remove_observer = archetype.has_after_remove_observer();
+
         // do the despawn
         let change_tick = self.world.change_tick();
         for component_id in archetype.components() {
@@ -1738,12 +1742,14 @@ impl<'w> EntityWorldMut<'w> {
 
         // Trigger AfterRemove for all components after data has been dropped.
         // The entity's location is None at this point (set above).
-        if archetype.has_after_remove_hook() || archetype.has_after_remove_observer() {
+        if has_after_remove_hook || has_after_remove_observer {
+            // Re-borrow archetype: the original reference from line 1587 was invalidated
+            // by `&mut self.world.archetypes` above. Type-level metadata (flags, component
+            // lists) is unchanged by entity-level swap_remove operations.
             // SAFETY: Archetype cannot be mutably aliased by DeferredWorld.
-            // We only read type-level metadata (flags, component lists) which is not
-            // modified by the swap_remove/table operations above.
             let (archetype, mut deferred_world) = unsafe {
-                let archetype: *const Archetype = archetype;
+                let archetype: *const Archetype =
+                    &self.world.archetypes[location.archetype_id];
                 let world = self.world.as_unsafe_world_cell();
                 (&*archetype, world.into_deferred())
             };

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -51,10 +51,13 @@ use crate::{
     entity::{Entities, Entity, EntityAllocator, EntityNotSpawnedError, SpawnError},
     entity_disabling::DefaultQueryFilters,
     error::{DefaultErrorHandler, ErrorHandler},
-    lifecycle::{ComponentHooks, RemovedComponentMessages, ADD, DESPAWN, DISCARD, INSERT, REMOVE},
+    lifecycle::{
+        ComponentHooks, RemovedComponentMessages, ADD, AFTER_REMOVE, BEFORE_ADD, DESPAWN, DISCARD,
+        INSERT, REMOVE,
+    },
     message::{Message, MessageId, Messages, WriteBatchIds},
     observer::Observers,
-    prelude::{Add, Despawn, DetectChangesMut, Discard, Insert, Remove},
+    prelude::{Add, AfterRemove, BeforeAdd, Despawn, DetectChangesMut, Discard, Insert, Remove},
     query::{DebugCheckedUnwrap, QueryData, QueryFilter, QueryState},
     relationship::RelationshipHookMode,
     resource::{IsResource, Resource, ResourceEntities, IS_RESOURCE},
@@ -174,6 +177,12 @@ impl World {
 
         let on_despawn = self.register_event_key::<Despawn>();
         assert_eq!(DESPAWN, on_despawn);
+
+        let before_add = self.register_event_key::<BeforeAdd>();
+        assert_eq!(BEFORE_ADD, before_add);
+
+        let after_remove = self.register_event_key::<AfterRemove>();
+        assert_eq!(AFTER_REMOVE, after_remove);
 
         let is_resource = self.register_component::<IsResource>();
         assert_eq!(IS_RESOURCE, is_resource);


### PR DESCRIPTION
# Objective

 - Add `BeforeAdd` and `AfterRemove` lifecycle events to complete the symmetric lifecycle: BeforeAdd -> Add -> Insert -> Discard -> Remove -> AfterRemove                    
  - Without these events, there is no point in the lifecycle where the entity is observable in the "component absent" state — Add fires after the component exists, and Remove fires before it's gone                                                                                                                                  
  - These are prerequisites for query-based observers like DataAdded<Without<T>> (#20817), which need to evaluate queries when the component is not yet/no longer present                                
  - Part of the structured lifecycle proposal (#20729)

## Solution

Added before_add and after_remove as both component hooks and observer events, following the same patterns as existing lifecycle events:

  - `BeforeAdd` fires before Add and Insert. During insert, it fires before the archetype move (component data is not yet accessible). During spawn, it fires after data is written but before Add/Insert hooks.
  - `AfterRemove` fires after Remove. Component data has already been dropped and is not accessible. Fires during both remove() and despawn().

  > [!NOTE]                                                                                                                                                          
  > `BeforeAdd`/`AfterRemove` are interim names. A future PR will introduce a `Before<E>`/`After<E>` wrapper scheme.     

## Testing

  - Extended 3 existing hook ordering tests to verify before_add fires at position 0 and after_remove fires at position 5 in the full lifecycle sequence             
  - Added 7 new tests covering: replace skips before_add, component data inaccessibility during before_add/after_remove, entity inaccessibility during spawn's  before_add, and observer-before-hook ordering for both events  

---

## Showcase

<details>
  <summary>Click to view showcase</summary>

```rust
  // Component hooks
  world.register_component_hooks::<Health>()
      .before_add(|world, ctx| {
          // Fires before the component exists on the entity
          // Good for "about to gain component" logic
      })
      .after_remove(|world, ctx| {
          // Fires after the component is fully gone
          // Good for "component is now absent" cleanup
      });

  // Observers
  world.add_observer(|_: On<BeforeAdd, Health>, /* ... */| {
      // Entity does not yet have Health
  });

  world.add_observer(|_: On<AfterRemove, Health>, /* ... */| {
      // Entity no longer has Health
  });

  // Derive macro
  #[derive(Component)]
  #[component(before_add = on_before, after_remove = on_after)]
  struct Health(f32);
```

</details>