### PR TITLE
Reimplement #22722 after it was lost in the parley migration.

### DIFF
--- a/crates/bevy_text/src/font_atlas.rs
+++ b/crates/bevy_text/src/font_atlas.rs
@@ -61,7 +61,7 @@ impl FontAtlas {
         Self {
             texture_atlas,
             glyph_to_atlas_index: HashMap::default(),
-            dynamic_texture_atlas_builder: DynamicTextureAtlasBuilder::new(size, 1),
+            dynamic_texture_atlas_builder: DynamicTextureAtlasBuilder::new(size, 2),
             texture,
         }
     }


### PR DESCRIPTION
# Objective

- This fix was lost in the parley migration (#22879).

## Solution

- Do the same thing as #22722.

## Testing

- PixelEagle should show the diff. The edges of some characters look nicer!
- This doesn't seem to fully fix things, as shuffling the order that glyphs are allocated makes things look different in some cases.