### PR TITLE
Remove resources from scenes

### DIFF
--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -1,12 +1,11 @@
 use crate::{DynamicSceneBuilder, Scene, SceneSpawnError};
 use bevy_asset::Asset;
-use bevy_ecs::reflect::ReflectResource;
 use bevy_ecs::{
     entity::{Entity, EntityHashMap, SceneEntityMapper},
     reflect::{AppTypeRegistry, ReflectComponent},
     world::World,
 };
-use bevy_reflect::{PartialReflect, TypePath};
+use bevy_reflect::{PartialReflect, Reflect, TypePath};
 
 use bevy_ecs::component::ComponentCloneBehavior;
 use bevy_ecs::relationship::RelationshipHookMode;
@@ -14,7 +13,7 @@ use bevy_ecs::relationship::RelationshipHookMode;
 #[cfg(feature = "serialize")]
 use {crate::serde::SceneSerializer, bevy_reflect::TypeRegistry, serde::Serialize};
 
-/// A collection of serializable resources and dynamic entities.
+/// A collection of serializable dynamic entities.
 ///
 /// Each dynamic entity in the collection contains its own run-time defined set of components.
 /// To spawn a dynamic scene, you can use either:
@@ -23,8 +22,6 @@ use {crate::serde::SceneSerializer, bevy_reflect::TypeRegistry, serde::Serialize
 /// * using the [`DynamicSceneBuilder`] to construct a `DynamicScene` from `World`.
 #[derive(Asset, TypePath, Default)]
 pub struct DynamicScene {
-    /// Resources stored in the dynamic scene.
-    pub resources: Vec<Box<dyn PartialReflect>>,
     /// Entities contained in the dynamic scene.
     pub entities: Vec<DynamicEntity>,
 }
@@ -38,6 +35,18 @@ pub struct DynamicEntity {
     /// A vector of boxed components that belong to the given entity and
     /// implement the [`PartialReflect`] trait.
     pub components: Vec<Box<dyn PartialReflect>>,
+}
+
+impl DynamicEntity {
+    /// Returns true if a dynamic entity has a particular component
+    pub fn has<T: Reflect + TypePath>(&self) -> bool {
+        for component in &self.components {
+            if component.represents::<T>() {
+                return true;
+            }
+        }
+        false
+    }
 }
 
 impl DynamicScene {
@@ -58,7 +67,6 @@ impl DynamicScene {
                     .flat_map(bevy_ecs::archetype::Archetype::entities)
                     .map(bevy_ecs::archetype::ArchetypeEntity::id),
             )
-            .extract_resources()
             .build()
     }
 
@@ -136,50 +144,6 @@ impl DynamicScene {
                 });
             }
         }
-
-        // Insert resources after all entities have been added to the world.
-        // This ensures the entities are available for the resources to reference during mapping.
-        for resource in &self.resources {
-            let type_info = resource.get_represented_type_info().ok_or_else(|| {
-                SceneSpawnError::NoRepresentedType {
-                    type_path: resource.reflect_type_path().to_string(),
-                }
-            })?;
-            let registration = type_registry.get(type_info.type_id()).ok_or_else(|| {
-                SceneSpawnError::UnregisteredButReflectedType {
-                    type_path: type_info.type_path().to_string(),
-                }
-            })?;
-            registration.data::<ReflectResource>().ok_or_else(|| {
-                SceneSpawnError::UnregisteredResource {
-                    type_path: type_info.type_path().to_string(),
-                }
-            })?;
-            // reflect_resource existing, implies that reflect_component also exists
-            let reflect_component = registration
-                .data::<ReflectComponent>()
-                .expect("ReflectComponent is depended on ReflectResource");
-
-            let resource_id = reflect_component.register_component(world);
-
-            // check if the resource already exists, if not spawn it, otherwise override the value
-            let entity = if let Some(entity) = world.resource_entities().get(resource_id) {
-                *entity
-            } else {
-                world.spawn_empty().id()
-            };
-
-            SceneEntityMapper::world_scope(entity_map, world, |world, mapper| {
-                reflect_component.apply_or_insert_mapped(
-                    &mut world.entity_mut(entity),
-                    resource.as_partial_reflect(),
-                    &type_registry,
-                    mapper,
-                    RelationshipHookMode::Skip,
-                );
-            });
-        }
-
         Ok(())
     }
 

--- a/crates/bevy_scene/src/dynamic_scene_builder.rs
+++ b/crates/bevy_scene/src/dynamic_scene_builder.rs
@@ -1,18 +1,14 @@
-use core::any::TypeId;
-
 use crate::reflect_utils::clone_reflect_value;
 use crate::{DynamicEntity, DynamicScene, SceneFilter};
 use alloc::collections::BTreeMap;
-use bevy_ecs::resource::IS_RESOURCE;
+use bevy_ecs::entity_disabling::DefaultQueryFilters;
 use bevy_ecs::{
-    component::{Component, ComponentId},
-    entity_disabling::DefaultQueryFilters,
+    component::Component,
     prelude::Entity,
-    reflect::{AppTypeRegistry, ReflectComponent, ReflectResource},
+    reflect::{AppTypeRegistry, ReflectComponent},
     resource::Resource,
     world::World,
 };
-use bevy_reflect::PartialReflect;
 use bevy_utils::default;
 
 /// A [`DynamicScene`] builder, used to build a scene from a [`World`] by extracting some entities and resources.
@@ -60,7 +56,6 @@ use bevy_utils::default;
 ///
 /// [`Reflect`]: bevy_reflect::Reflect
 pub struct DynamicSceneBuilder<'w> {
-    extracted_resources: BTreeMap<ComponentId, Box<dyn PartialReflect>>,
     extracted_scene: BTreeMap<Entity, DynamicEntity>,
     component_filter: SceneFilter,
     resource_filter: SceneFilter,
@@ -70,11 +65,14 @@ pub struct DynamicSceneBuilder<'w> {
 impl<'w> DynamicSceneBuilder<'w> {
     /// Prepare a builder that will extract entities and their component from the given [`World`].
     pub fn from_world(world: &'w World) -> Self {
+        // allow everything except DefaultQueryFilters and AppTypeRegistry
+        let resource_filter = SceneFilter::allow_all()
+            .deny::<DefaultQueryFilters>()
+            .deny::<AppTypeRegistry>();
         Self {
-            extracted_resources: default(),
             extracted_scene: default(),
             component_filter: SceneFilter::default(),
-            resource_filter: SceneFilter::default(),
+            resource_filter,
             original_world: world,
         }
     }
@@ -212,7 +210,6 @@ impl<'w> DynamicSceneBuilder<'w> {
     #[must_use]
     pub fn build(self) -> DynamicScene {
         DynamicScene {
-            resources: self.extracted_resources.into_values().collect(),
             entities: self.extracted_scene.into_values().collect(),
         }
     }
@@ -274,6 +271,8 @@ impl<'w> DynamicSceneBuilder<'w> {
         let type_registry = self.original_world.resource::<AppTypeRegistry>().read();
 
         for entity in entities {
+            let mut skip_entity = false;
+
             if self.extracted_scene.contains_key(&entity) {
                 continue;
             }
@@ -284,9 +283,6 @@ impl<'w> DynamicSceneBuilder<'w> {
             };
 
             let original_entity = self.original_world.entity(entity);
-            if original_entity.contains_id(IS_RESOURCE) {
-                continue;
-            }
 
             for &component_id in original_entity.archetype().components().iter() {
                 let mut extract_and_push = || {
@@ -300,6 +296,13 @@ impl<'w> DynamicSceneBuilder<'w> {
 
                     if is_denied {
                         // Component is either in the denylist or _not_ in the allowlist
+                        return None;
+                    }
+
+                    let is_resource_denied = self.resource_filter.is_denied_by_id(type_id);
+
+                    if is_resource_denied {
+                        skip_entity = true;
                         return None;
                     }
 
@@ -317,7 +320,9 @@ impl<'w> DynamicSceneBuilder<'w> {
                 };
                 extract_and_push();
             }
-            self.extracted_scene.insert(entity, entry);
+            if !skip_entity {
+                self.extracted_scene.insert(entity, entry);
+            }
         }
 
         self
@@ -349,52 +354,15 @@ impl<'w> DynamicSceneBuilder<'w> {
     ///
     /// [`allow_resource`]: Self::allow_resource
     /// [`deny_resource`]: Self::deny_resource
-    #[must_use]
-    pub fn extract_resources(mut self) -> Self {
-        // Don't extract the DefaultQueryFilters resource
-        let original_world_dqf_id = self
+    pub fn extract_resources(self) -> Self {
+        // TODO: Add a filter that filters out the entities whose resources are not registered by type.
+        let entities: Vec<Entity> = self
             .original_world
-            .components()
-            .get_valid_resource_id(TypeId::of::<DefaultQueryFilters>());
-
-        let type_registry = self.original_world.resource::<AppTypeRegistry>().read();
-
-        for (component_id, entity) in self.original_world.resource_entities().iter() {
-            if Some(*component_id) == original_world_dqf_id {
-                continue;
-            }
-            let mut extract_and_push = || {
-                let type_id = self
-                    .original_world
-                    .components()
-                    .get_info(*component_id)?
-                    .type_id()?;
-
-                let is_denied = self.resource_filter.is_denied_by_id(type_id);
-
-                if is_denied {
-                    // Resource is either in the denylist or _not_ in the allowlist
-                    return None;
-                }
-
-                let type_registration = type_registry.get(type_id)?;
-
-                type_registration.data::<ReflectResource>()?;
-                let component = type_registration
-                    .data::<ReflectComponent>()?
-                    .reflect(self.original_world.entity(*entity))?;
-
-                let component =
-                    clone_reflect_value(component.as_partial_reflect(), type_registration);
-
-                self.extracted_resources.insert(*component_id, component);
-                Some(())
-            };
-            extract_and_push();
-        }
-
-        drop(type_registry);
-        self
+            .resource_entities()
+            .values()
+            .cloned()
+            .collect();
+        self.extract_entities(entities.into_iter())
     }
 }
 
@@ -581,8 +549,8 @@ mod tests {
             .extract_resources()
             .build();
 
-        assert_eq!(scene.resources.len(), 1);
-        assert!(scene.resources[0].represents::<ResourceA>());
+        assert_eq!(scene.entities.len(), 1);
+        assert!(scene.entities[0].has::<ResourceA>());
     }
 
     #[test]
@@ -600,8 +568,8 @@ mod tests {
             .extract_resources()
             .build();
 
-        assert_eq!(scene.resources.len(), 1);
-        assert!(scene.resources[0].represents::<ResourceA>());
+        assert_eq!(scene.entities.len(), 1);
+        assert!(scene.entities[0].has::<ResourceA>());
     }
 
     #[test]
@@ -678,8 +646,9 @@ mod tests {
             .extract_resources()
             .build();
 
-        assert_eq!(scene.resources.len(), 1);
-        assert!(scene.resources[0].represents::<ResourceA>());
+        assert_eq!(scene.entities.len(), 2);
+        assert!(scene.entities[0].has::<ResourceB>());
+        assert!(scene.entities[1].has::<ResourceA>())
     }
 
     #[test]
@@ -702,8 +671,8 @@ mod tests {
             .extract_resources()
             .build();
 
-        assert_eq!(scene.resources.len(), 1);
-        assert!(scene.resources[0].represents::<ResourceB>());
+        assert_eq!(scene.entities.len(), 1);
+        assert!(scene.entities[0].has::<ResourceB>());
     }
 
     #[test]
@@ -739,8 +708,8 @@ mod tests {
             .expect("component should be concrete due to `FromReflect`")
             .is::<SomeType>());
 
-        let resource = &scene.resources[0];
-        assert!(resource
+        let resource = &scene.entities[1];
+        assert!(resource.components[0]
             .try_as_reflect()
             .expect("resource should be concrete due to `FromReflect`")
             .is::<SomeResource>());

--- a/crates/bevy_scene/src/dynamic_scene_builder.rs
+++ b/crates/bevy_scene/src/dynamic_scene_builder.rs
@@ -65,14 +65,10 @@ pub struct DynamicSceneBuilder<'w> {
 impl<'w> DynamicSceneBuilder<'w> {
     /// Prepare a builder that will extract entities and their component from the given [`World`].
     pub fn from_world(world: &'w World) -> Self {
-        // allow everything except DefaultQueryFilters and AppTypeRegistry
-        let resource_filter = SceneFilter::allow_all()
-            .deny::<DefaultQueryFilters>()
-            .deny::<AppTypeRegistry>();
         Self {
             extracted_scene: default(),
             component_filter: SceneFilter::default(),
-            resource_filter,
+            resource_filter: SceneFilter::default(),
             original_world: world,
         }
     }
@@ -119,7 +115,9 @@ impl<'w> DynamicSceneBuilder<'w> {
     /// If `T` has already been denied, then it will be removed from the denylist.
     #[must_use]
     pub fn allow_component<T: Component>(mut self) -> Self {
-        self.component_filter = self.component_filter.allow::<T>();
+        if let Some(component_id) = self.original_world.component_id::<T>() {
+            self.component_filter = self.component_filter.allow(component_id);
+        }
         self
     }
 
@@ -131,7 +129,9 @@ impl<'w> DynamicSceneBuilder<'w> {
     /// If `T` has already been allowed, then it will be removed from the allowlist.
     #[must_use]
     pub fn deny_component<T: Component>(mut self) -> Self {
-        self.component_filter = self.component_filter.deny::<T>();
+        if let Some(component_id) = self.original_world.component_id::<T>() {
+            self.component_filter = self.component_filter.deny(component_id);
+        }
         self
     }
 
@@ -165,7 +165,9 @@ impl<'w> DynamicSceneBuilder<'w> {
     /// If `T` has already been denied, then it will be removed from the denylist.
     #[must_use]
     pub fn allow_resource<T: Resource>(mut self) -> Self {
-        self.resource_filter = self.resource_filter.allow::<T>();
+        if let Some(component_id) = self.original_world.component_id::<T>() {
+            self.resource_filter = self.resource_filter.allow(component_id);
+        }
         self
     }
 
@@ -177,7 +179,9 @@ impl<'w> DynamicSceneBuilder<'w> {
     /// If `T` has already been allowed, then it will be removed from the allowlist.
     #[must_use]
     pub fn deny_resource<T: Resource>(mut self) -> Self {
-        self.resource_filter = self.resource_filter.deny::<T>();
+        if let Some(component_id) = self.original_world.component_id::<T>() {
+            self.resource_filter = self.resource_filter.deny(component_id);
+        }
         self
     }
 
@@ -283,19 +287,16 @@ impl<'w> DynamicSceneBuilder<'w> {
             let original_entity = self.original_world.entity(entity);
 
             for &component_id in original_entity.archetype().components().iter() {
+                if self.component_filter.is_denied(component_id) {
+                    continue;
+                }
+
                 let mut extract_and_push = || {
                     let type_id = self
                         .original_world
                         .components()
                         .get_info(component_id)?
                         .type_id()?;
-
-                    let is_denied = self.component_filter.is_denied_by_id(type_id);
-
-                    if is_denied {
-                        // Component is either in the denylist or _not_ in the allowlist
-                        return None;
-                    }
 
                     let type_registration = type_registry.get(type_id)?;
 
@@ -363,10 +364,8 @@ impl<'w> DynamicSceneBuilder<'w> {
             SceneFilter::Allowlist(ref list) => {
                 // if DefaultQueryFilters or AppTypeRegistry has specifically been allowed to be added, we don't change that
                 let mut entities = vec![];
-                for type_id in list {
-                    if let Some(component_id) = self.original_world.components().get_id(*type_id)
-                        && let Some(entity) =
-                            self.original_world.resource_entities().get(component_id)
+                for component_id in list {
+                    if let Some(entity) = self.original_world.resource_entities().get(*component_id)
                     {
                         entities.push(*entity);
                     }
@@ -375,13 +374,7 @@ impl<'w> DynamicSceneBuilder<'w> {
             }
             SceneFilter::Denylist(ref list) => {
                 // also deny DefaultQueryFilters and AppTypeRegistry
-                let mut deny_component_id: bevy_platform::collections::hash_set::HashSet<
-                    bevy_ecs::component::ComponentId,
-                > = list
-                    .clone()
-                    .iter()
-                    .filter_map(|type_id| self.original_world.components().get_id(*type_id))
-                    .collect();
+                let mut deny_component_id = list.clone();
                 if let Some(id) = dqf_id {
                     deny_component_id.insert(id);
                 }

--- a/crates/bevy_scene/src/dynamic_scene_builder.rs
+++ b/crates/bevy_scene/src/dynamic_scene_builder.rs
@@ -271,8 +271,6 @@ impl<'w> DynamicSceneBuilder<'w> {
         let type_registry = self.original_world.resource::<AppTypeRegistry>().read();
 
         for entity in entities {
-            let mut skip_entity = false;
-
             if self.extracted_scene.contains_key(&entity) {
                 continue;
             }
@@ -299,13 +297,6 @@ impl<'w> DynamicSceneBuilder<'w> {
                         return None;
                     }
 
-                    let is_resource_denied = self.resource_filter.is_denied_by_id(type_id);
-
-                    if is_resource_denied {
-                        skip_entity = true;
-                        return None;
-                    }
-
                     let type_registration = type_registry.get(type_id)?;
 
                     let component = type_registration
@@ -320,9 +311,7 @@ impl<'w> DynamicSceneBuilder<'w> {
                 };
                 extract_and_push();
             }
-            if !skip_entity {
-                self.extracted_scene.insert(entity, entry);
-            }
+            self.extracted_scene.insert(entity, entry);
         }
 
         self
@@ -355,13 +344,62 @@ impl<'w> DynamicSceneBuilder<'w> {
     /// [`allow_resource`]: Self::allow_resource
     /// [`deny_resource`]: Self::deny_resource
     pub fn extract_resources(self) -> Self {
-        // TODO: Add a filter that filters out the entities whose resources are not registered by type.
-        let entities: Vec<Entity> = self
-            .original_world
-            .resource_entities()
-            .values()
-            .cloned()
-            .collect();
+        let dqf_id = self.original_world.resource_id::<DefaultQueryFilters>();
+        let atr_id = self.original_world.resource_id::<AppTypeRegistry>();
+        let entities = match self.resource_filter {
+            SceneFilter::Unset => {
+                // extract all resources, excluding DefaultQueryFilters and AppTypeRegistry
+                let mut entities = vec![];
+                for (component_id, entity) in self.original_world.resource_entities().iter() {
+                    if dqf_id.is_some_and(|id| *component_id == id)
+                        || atr_id.is_some_and(|id| *component_id == id)
+                    {
+                        continue;
+                    }
+                    entities.push(*entity);
+                }
+                entities
+            }
+            SceneFilter::Allowlist(ref list) => {
+                // if DefaultQueryFilters or AppTypeRegistry has specifically been allowed to be added, we don't change that
+                let mut entities = vec![];
+                for type_id in list {
+                    if let Some(component_id) = self.original_world.components().get_id(*type_id)
+                        && let Some(entity) =
+                            self.original_world.resource_entities().get(component_id)
+                    {
+                        entities.push(*entity);
+                    }
+                }
+                entities
+            }
+            SceneFilter::Denylist(ref list) => {
+                // also deny DefaultQueryFilters and AppTypeRegistry
+                let mut deny_component_id: bevy_platform::collections::hash_set::HashSet<
+                    bevy_ecs::component::ComponentId,
+                > = list
+                    .clone()
+                    .iter()
+                    .filter_map(|type_id| self.original_world.components().get_id(*type_id))
+                    .collect();
+                if let Some(id) = dqf_id {
+                    deny_component_id.insert(id);
+                }
+                if let Some(id) = atr_id {
+                    deny_component_id.insert(id);
+                }
+                let mut entities = vec![];
+                for (component_id, entity) in self.original_world.resource_entities().iter() {
+                    if deny_component_id.contains(component_id) {
+                        continue;
+                    } else {
+                        entities.push(*entity);
+                    }
+                }
+                entities
+            }
+        };
+
         self.extract_entities(entities.into_iter())
     }
 }

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -122,8 +122,10 @@ mod tests {
     use bevy_ecs::{
         component::Component,
         entity::Entity,
+        entity_disabling::DefaultQueryFilters,
         hierarchy::{ChildOf, Children},
         reflect::{AppTypeRegistry, ReflectComponent},
+        resource::IsResource,
         world::World,
     };
     use bevy_reflect::Reflect;
@@ -166,6 +168,8 @@ mod tests {
             .register_type::<Circle>()
             .register_type::<Rectangle>()
             .register_type::<Triangle>()
+            .register_type::<IsResource>()
+            .register_type::<DefaultQueryFilters>()
             .register_type::<FinishLine>();
 
         let scene_handle = app

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -1,14 +1,10 @@
-use core::any::TypeId;
-
 use crate::reflect_utils::clone_reflect_value;
 use crate::{DynamicScene, SceneSpawnError};
 use bevy_asset::Asset;
-use bevy_ecs::resource::IS_RESOURCE;
 use bevy_ecs::{
     component::ComponentCloneBehavior,
     entity::{Entity, EntityHashMap, SceneEntityMapper},
-    entity_disabling::DefaultQueryFilters,
-    reflect::{AppTypeRegistry, ReflectComponent, ReflectResource},
+    reflect::{AppTypeRegistry, ReflectComponent},
     relationship::RelationshipHookMode,
     world::World,
 };
@@ -66,73 +62,9 @@ impl Scene {
     ) -> Result<(), SceneSpawnError> {
         let type_registry = type_registry.read();
 
-        let self_dqf_id = self
-            .world
-            .components()
-            .get_resource_id(TypeId::of::<DefaultQueryFilters>());
-
-        // Resources archetype
-        for (component_id, source_entity) in self.world.resource_entities().iter() {
-            if Some(*component_id) == self_dqf_id {
-                continue;
-            }
-            if !world
-                .get_entity(*source_entity)
-                .ok()
-                .is_some_and(|entity_ref| entity_ref.contains_id(*component_id))
-            {
-                continue;
-            }
-
-            let component_info = self
-                .world
-                .components()
-                .get_info(*component_id)
-                .expect("component_ids in archetypes should have ComponentInfo");
-
-            let type_id = component_info
-                .type_id()
-                .expect("reflected resources must have a type_id");
-
-            let registration =
-                type_registry
-                    .get(type_id)
-                    .ok_or_else(|| SceneSpawnError::UnregisteredType {
-                        std_type_name: component_info.name(),
-                    })?;
-            registration.data::<ReflectResource>().ok_or_else(|| {
-                SceneSpawnError::UnregisteredResource {
-                    type_path: registration.type_info().type_path().to_string(),
-                }
-            })?;
-            // reflect_resource existing, implies that reflect_component also exists
-            let reflect_component = registration
-                .data::<ReflectComponent>()
-                .expect("ReflectComponent is depended on ReflectResource");
-
-            // check if the resource already exists in the other world, if not spawn it
-            let destination_entity =
-                if let Some(entity) = world.resource_entities().get(*component_id) {
-                    *entity
-                } else {
-                    world.spawn_empty().id()
-                };
-
-            reflect_component.copy(
-                &self.world,
-                world,
-                *source_entity,
-                destination_entity,
-                &type_registry,
-            );
-        }
-
         // Ensure that all scene entities have been allocated in the destination
         // world before handling components that may contain references that need mapping.
         for archetype in self.world.archetypes().iter() {
-            if archetype.contains(IS_RESOURCE) {
-                continue;
-            }
             for scene_entity in archetype.entities() {
                 entity_map
                     .entry(scene_entity.id())
@@ -141,9 +73,6 @@ impl Scene {
         }
 
         for archetype in self.world.archetypes().iter() {
-            if archetype.contains(IS_RESOURCE) {
-                continue;
-            }
             for scene_entity in archetype.entities() {
                 let entity = *entity_map
                     .get(&scene_entity.id())

--- a/crates/bevy_scene/src/scene_filter.rs
+++ b/crates/bevy_scene/src/scene_filter.rs
@@ -1,5 +1,5 @@
+use bevy_ecs::component::ComponentId;
 use bevy_platform::collections::{hash_set::IntoIter, HashSet};
-use core::any::{Any, TypeId};
 
 /// A filter used to control which types can be added to a [`DynamicScene`].
 ///
@@ -31,13 +31,13 @@ pub enum SceneFilter {
     /// Types not contained within this set should not be allowed to be saved to an associated [`DynamicScene`].
     ///
     /// [`DynamicScene`]: crate::DynamicScene
-    Allowlist(HashSet<TypeId>),
+    Allowlist(HashSet<ComponentId>),
     /// Contains the set of prohibited types by their [`TypeId`].
     ///
     /// Types contained within this set should not be allowed to be saved to an associated [`DynamicScene`].
     ///
     /// [`DynamicScene`]: crate::DynamicScene
-    Denylist(HashSet<TypeId>),
+    Denylist(HashSet<ComponentId>),
 }
 
 impl SceneFilter {
@@ -59,7 +59,7 @@ impl SceneFilter {
         Self::Allowlist(HashSet::default())
     }
 
-    /// Allow the given type, `T`.
+    /// Allow the given component.
     ///
     /// If this filter is already set as a [`Denylist`],
     /// then the given type will be removed from the denied set.
@@ -70,37 +70,22 @@ impl SceneFilter {
     /// [`Unset`]: SceneFilter::Unset
     /// [`Allowlist`]: SceneFilter::Allowlist
     #[must_use]
-    pub fn allow<T: Any>(self) -> Self {
-        self.allow_by_id(TypeId::of::<T>())
-    }
-
-    /// Allow the given type.
-    ///
-    /// If this filter is already set as a [`Denylist`],
-    /// then the given type will be removed from the denied set.
-    ///
-    /// If this filter is [`Unset`], then it will be completely replaced by a new [`Allowlist`].
-    ///
-    /// [`Denylist`]: SceneFilter::Denylist
-    /// [`Unset`]: SceneFilter::Unset
-    /// [`Allowlist`]: SceneFilter::Allowlist
-    #[must_use]
-    pub fn allow_by_id(mut self, type_id: TypeId) -> Self {
+    pub fn allow(mut self, id: ComponentId) -> Self {
         match &mut self {
             Self::Unset => {
-                self = Self::Allowlist([type_id].into_iter().collect());
+                self = Self::Allowlist([id].into_iter().collect());
             }
             Self::Allowlist(list) => {
-                list.insert(type_id);
+                list.insert(id);
             }
             Self::Denylist(list) => {
-                list.remove(&type_id);
+                list.remove(&id);
             }
         }
         self
     }
 
-    /// Deny the given type, `T`.
+    /// Deny the given component.
     ///
     /// If this filter is already set as an [`Allowlist`],
     /// then the given type will be removed from the allowed set.
@@ -111,74 +96,41 @@ impl SceneFilter {
     /// [`Unset`]: SceneFilter::Unset
     /// [`Denylist`]: SceneFilter::Denylist
     #[must_use]
-    pub fn deny<T: Any>(self) -> Self {
-        self.deny_by_id(TypeId::of::<T>())
-    }
-
-    /// Deny the given type.
-    ///
-    /// If this filter is already set as an [`Allowlist`],
-    /// then the given type will be removed from the allowed set.
-    ///
-    /// If this filter is [`Unset`], then it will be completely replaced by a new [`Denylist`].
-    ///
-    /// [`Allowlist`]: SceneFilter::Allowlist
-    /// [`Unset`]: SceneFilter::Unset
-    /// [`Denylist`]: SceneFilter::Denylist
-    #[must_use]
-    pub fn deny_by_id(mut self, type_id: TypeId) -> Self {
+    pub fn deny(mut self, id: ComponentId) -> Self {
         match &mut self {
             Self::Unset => {
-                self = Self::Denylist([type_id].into_iter().collect());
+                self = Self::Denylist([id].into_iter().collect());
             }
             Self::Allowlist(list) => {
-                list.remove(&type_id);
+                list.remove(&id);
             }
             Self::Denylist(list) => {
-                list.insert(type_id);
+                list.insert(id);
             }
         }
         self
     }
 
-    /// Returns true if the given type, `T`, is allowed by the filter.
+    /// Returns true if the given component is allowed by the filter.
     ///
     /// If the filter is [`Unset`], this will always return `true`.
     ///
     /// [`Unset`]: SceneFilter::Unset
-    pub fn is_allowed<T: Any>(&self) -> bool {
-        self.is_allowed_by_id(TypeId::of::<T>())
-    }
-
-    /// Returns true if the given type is allowed by the filter.
-    ///
-    /// If the filter is [`Unset`], this will always return `true`.
-    ///
-    /// [`Unset`]: SceneFilter::Unset
-    pub fn is_allowed_by_id(&self, type_id: TypeId) -> bool {
+    pub fn is_allowed(&self, id: ComponentId) -> bool {
         match self {
             Self::Unset => true,
-            Self::Allowlist(list) => list.contains(&type_id),
-            Self::Denylist(list) => !list.contains(&type_id),
+            Self::Allowlist(list) => list.contains(&id),
+            Self::Denylist(list) => !list.contains(&id),
         }
     }
 
-    /// Returns true if the given type, `T`, is denied by the filter.
+    /// Returns true if the given component is denied by the filter.
     ///
     /// If the filter is [`Unset`], this will always return `false`.
     ///
     /// [`Unset`]: SceneFilter::Unset
-    pub fn is_denied<T: Any>(&self) -> bool {
-        self.is_denied_by_id(TypeId::of::<T>())
-    }
-
-    /// Returns true if the given type is denied by the filter.
-    ///
-    /// If the filter is [`Unset`], this will always return `false`.
-    ///
-    /// [`Unset`]: SceneFilter::Unset
-    pub fn is_denied_by_id(&self, type_id: TypeId) -> bool {
-        !self.is_allowed_by_id(type_id)
+    pub fn is_denied(&self, id: ComponentId) -> bool {
+        !self.is_allowed(id)
     }
 
     /// Returns an iterator over the items in the filter.
@@ -186,7 +138,7 @@ impl SceneFilter {
     /// If the filter is [`Unset`], this will return an empty iterator.
     ///
     /// [`Unset`]: SceneFilter::Unset
-    pub fn iter(&self) -> Box<dyn ExactSizeIterator<Item = &TypeId> + '_> {
+    pub fn iter(&self) -> Box<dyn ExactSizeIterator<Item = &ComponentId> + '_> {
         match self {
             Self::Unset => Box::new(core::iter::empty()),
             Self::Allowlist(list) | Self::Denylist(list) => Box::new(list.iter()),
@@ -219,8 +171,8 @@ impl SceneFilter {
 }
 
 impl IntoIterator for SceneFilter {
-    type Item = TypeId;
-    type IntoIter = IntoIter<TypeId>;
+    type Item = ComponentId;
+    type IntoIter = IntoIter<ComponentId>;
 
     fn into_iter(self) -> Self::IntoIter {
         match self {
@@ -234,44 +186,41 @@ impl IntoIterator for SceneFilter {
 mod tests {
     use super::*;
 
+    const ID1: ComponentId = ComponentId::new(1);
+    const ID2: ComponentId = ComponentId::new(2);
+
     #[test]
     fn should_set_list_type_if_none() {
-        let filter = SceneFilter::Unset.allow::<i32>();
+        let filter = SceneFilter::Unset.allow(ID2);
         assert!(matches!(filter, SceneFilter::Allowlist(_)));
 
-        let filter = SceneFilter::Unset.deny::<i32>();
+        let filter = SceneFilter::Unset.deny(ID2);
         assert!(matches!(filter, SceneFilter::Denylist(_)));
     }
 
     #[test]
     fn should_add_to_list() {
-        let filter = SceneFilter::default().allow::<i16>().allow::<i32>();
+        let filter = SceneFilter::default().allow(ID1).allow(ID2);
         assert_eq!(2, filter.len());
-        assert!(filter.is_allowed::<i16>());
-        assert!(filter.is_allowed::<i32>());
+        assert!(filter.is_allowed(ID1));
+        assert!(filter.is_allowed(ID2));
 
-        let filter = SceneFilter::default().deny::<i16>().deny::<i32>();
+        let filter = SceneFilter::default().deny(ID1).deny(ID2);
         assert_eq!(2, filter.len());
-        assert!(filter.is_denied::<i16>());
-        assert!(filter.is_denied::<i32>());
+        assert!(filter.is_denied(ID1));
+        assert!(filter.is_denied(ID2));
     }
 
     #[test]
     fn should_remove_from_list() {
-        let filter = SceneFilter::default()
-            .allow::<i16>()
-            .allow::<i32>()
-            .deny::<i32>();
+        let filter = SceneFilter::default().allow(ID1).allow(ID2).deny(ID2);
         assert_eq!(1, filter.len());
-        assert!(filter.is_allowed::<i16>());
-        assert!(!filter.is_allowed::<i32>());
+        assert!(filter.is_allowed(ID1));
+        assert!(!filter.is_allowed(ID2));
 
-        let filter = SceneFilter::default()
-            .deny::<i16>()
-            .deny::<i32>()
-            .allow::<i32>();
+        let filter = SceneFilter::default().deny(ID1).deny(ID2).allow(ID2);
         assert_eq!(1, filter.len());
-        assert!(filter.is_denied::<i16>());
-        assert!(!filter.is_denied::<i32>());
+        assert!(filter.is_denied(ID1));
+        assert!(!filter.is_denied(ID2));
     }
 }

--- a/crates/bevy_scene/src/scene_filter.rs
+++ b/crates/bevy_scene/src/scene_filter.rs
@@ -10,7 +10,7 @@ use core::any::{Any, TypeId};
 /// [`DynamicScene`]: crate::DynamicScene
 /// [components]: bevy_ecs::prelude::Component
 /// [resources]: bevy_ecs::prelude::Resource
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub enum SceneFilter {
     /// Represents an unset filter.
     ///
@@ -24,7 +24,8 @@ pub enum SceneFilter {
     /// [`Allowlist`]: SceneFilter::Allowlist
     /// [Allowing]: SceneFilter::allow
     /// [denying]: SceneFilter::deny
-    DenyByDefault(HashSet<TypeId>),
+    #[default]
+    Unset,
     /// Contains the set of permitted types by their [`TypeId`].
     ///
     /// Types not contained within this set should not be allowed to be saved to an associated [`DynamicScene`].
@@ -37,12 +38,6 @@ pub enum SceneFilter {
     ///
     /// [`DynamicScene`]: crate::DynamicScene
     Denylist(HashSet<TypeId>),
-}
-
-impl Default for SceneFilter {
-    fn default() -> Self {
-        SceneFilter::DenyByDefault(HashSet::default())
-    }
 }
 
 impl SceneFilter {
@@ -92,7 +87,7 @@ impl SceneFilter {
     #[must_use]
     pub fn allow_by_id(mut self, type_id: TypeId) -> Self {
         match &mut self {
-            Self::DenyByDefault(_) => {
+            Self::Unset => {
                 self = Self::Allowlist([type_id].into_iter().collect());
             }
             Self::Allowlist(list) => {
@@ -133,9 +128,8 @@ impl SceneFilter {
     #[must_use]
     pub fn deny_by_id(mut self, type_id: TypeId) -> Self {
         match &mut self {
-            Self::DenyByDefault(list) => {
-                list.insert(type_id);
-                self = Self::Denylist(list.clone()); // TODO: shouldn't need a clone here
+            Self::Unset => {
+                self = Self::Denylist([type_id].into_iter().collect());
             }
             Self::Allowlist(list) => {
                 list.remove(&type_id);
@@ -163,7 +157,7 @@ impl SceneFilter {
     /// [`Unset`]: SceneFilter::Unset
     pub fn is_allowed_by_id(&self, type_id: TypeId) -> bool {
         match self {
-            Self::DenyByDefault(list) => !list.contains(&type_id),
+            Self::Unset => true,
             Self::Allowlist(list) => list.contains(&type_id),
             Self::Denylist(list) => !list.contains(&type_id),
         }
@@ -194,9 +188,8 @@ impl SceneFilter {
     /// [`Unset`]: SceneFilter::Unset
     pub fn iter(&self) -> Box<dyn ExactSizeIterator<Item = &TypeId> + '_> {
         match self {
-            Self::DenyByDefault(list) | Self::Allowlist(list) | Self::Denylist(list) => {
-                Box::new(list.iter())
-            }
+            Self::Unset => Box::new(core::iter::empty()),
+            Self::Allowlist(list) | Self::Denylist(list) => Box::new(list.iter()),
         }
     }
 
@@ -207,7 +200,8 @@ impl SceneFilter {
     /// [`Unset`]: SceneFilter::Unset
     pub fn len(&self) -> usize {
         match self {
-            Self::DenyByDefault(list) | Self::Allowlist(list) | Self::Denylist(list) => list.len(),
+            Self::Unset => 0,
+            Self::Allowlist(list) | Self::Denylist(list) => list.len(),
         }
     }
 
@@ -218,9 +212,8 @@ impl SceneFilter {
     /// [`Unset`]: SceneFilter::Unset
     pub fn is_empty(&self) -> bool {
         match self {
-            Self::DenyByDefault(list) | Self::Allowlist(list) | Self::Denylist(list) => {
-                list.is_empty()
-            }
+            Self::Unset => true,
+            Self::Allowlist(list) | Self::Denylist(list) => list.is_empty(),
         }
     }
 }
@@ -231,9 +224,8 @@ impl IntoIterator for SceneFilter {
 
     fn into_iter(self) -> Self::IntoIter {
         match self {
-            Self::DenyByDefault(list) | Self::Allowlist(list) | Self::Denylist(list) => {
-                list.into_iter()
-            }
+            Self::Unset => Default::default(),
+            Self::Allowlist(list) | Self::Denylist(list) => list.into_iter(),
         }
     }
 }
@@ -244,10 +236,10 @@ mod tests {
 
     #[test]
     fn should_set_list_type_if_none() {
-        let filter = SceneFilter::DenyByDefault(HashSet::default()).allow::<i32>();
+        let filter = SceneFilter::Unset.allow::<i32>();
         assert!(matches!(filter, SceneFilter::Allowlist(_)));
 
-        let filter = SceneFilter::DenyByDefault(HashSet::default()).deny::<i32>();
+        let filter = SceneFilter::Unset.deny::<i32>();
         assert!(matches!(filter, SceneFilter::Denylist(_)));
     }
 

--- a/crates/bevy_scene/src/scene_filter.rs
+++ b/crates/bevy_scene/src/scene_filter.rs
@@ -10,7 +10,7 @@ use core::any::{Any, TypeId};
 /// [`DynamicScene`]: crate::DynamicScene
 /// [components]: bevy_ecs::prelude::Component
 /// [resources]: bevy_ecs::prelude::Resource
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SceneFilter {
     /// Represents an unset filter.
     ///
@@ -24,8 +24,7 @@ pub enum SceneFilter {
     /// [`Allowlist`]: SceneFilter::Allowlist
     /// [Allowing]: SceneFilter::allow
     /// [denying]: SceneFilter::deny
-    #[default]
-    Unset,
+    DenyByDefault(HashSet<TypeId>),
     /// Contains the set of permitted types by their [`TypeId`].
     ///
     /// Types not contained within this set should not be allowed to be saved to an associated [`DynamicScene`].
@@ -38,6 +37,12 @@ pub enum SceneFilter {
     ///
     /// [`DynamicScene`]: crate::DynamicScene
     Denylist(HashSet<TypeId>),
+}
+
+impl Default for SceneFilter {
+    fn default() -> Self {
+        SceneFilter::DenyByDefault(HashSet::default())
+    }
 }
 
 impl SceneFilter {
@@ -87,7 +92,7 @@ impl SceneFilter {
     #[must_use]
     pub fn allow_by_id(mut self, type_id: TypeId) -> Self {
         match &mut self {
-            Self::Unset => {
+            Self::DenyByDefault(_) => {
                 self = Self::Allowlist([type_id].into_iter().collect());
             }
             Self::Allowlist(list) => {
@@ -128,7 +133,10 @@ impl SceneFilter {
     #[must_use]
     pub fn deny_by_id(mut self, type_id: TypeId) -> Self {
         match &mut self {
-            Self::Unset => self = Self::Denylist([type_id].into_iter().collect()),
+            Self::DenyByDefault(list) => {
+                list.insert(type_id);
+                self = Self::Denylist(list.clone()); // TODO: shouldn't need a clone here
+            }
             Self::Allowlist(list) => {
                 list.remove(&type_id);
             }
@@ -155,7 +163,7 @@ impl SceneFilter {
     /// [`Unset`]: SceneFilter::Unset
     pub fn is_allowed_by_id(&self, type_id: TypeId) -> bool {
         match self {
-            Self::Unset => true,
+            Self::DenyByDefault(list) => !list.contains(&type_id),
             Self::Allowlist(list) => list.contains(&type_id),
             Self::Denylist(list) => !list.contains(&type_id),
         }
@@ -186,8 +194,9 @@ impl SceneFilter {
     /// [`Unset`]: SceneFilter::Unset
     pub fn iter(&self) -> Box<dyn ExactSizeIterator<Item = &TypeId> + '_> {
         match self {
-            Self::Unset => Box::new(core::iter::empty()),
-            Self::Allowlist(list) | Self::Denylist(list) => Box::new(list.iter()),
+            Self::DenyByDefault(list) | Self::Allowlist(list) | Self::Denylist(list) => {
+                Box::new(list.iter())
+            }
         }
     }
 
@@ -198,8 +207,7 @@ impl SceneFilter {
     /// [`Unset`]: SceneFilter::Unset
     pub fn len(&self) -> usize {
         match self {
-            Self::Unset => 0,
-            Self::Allowlist(list) | Self::Denylist(list) => list.len(),
+            Self::DenyByDefault(list) | Self::Allowlist(list) | Self::Denylist(list) => list.len(),
         }
     }
 
@@ -210,8 +218,9 @@ impl SceneFilter {
     /// [`Unset`]: SceneFilter::Unset
     pub fn is_empty(&self) -> bool {
         match self {
-            Self::Unset => true,
-            Self::Allowlist(list) | Self::Denylist(list) => list.is_empty(),
+            Self::DenyByDefault(list) | Self::Allowlist(list) | Self::Denylist(list) => {
+                list.is_empty()
+            }
         }
     }
 }
@@ -222,8 +231,9 @@ impl IntoIterator for SceneFilter {
 
     fn into_iter(self) -> Self::IntoIter {
         match self {
-            Self::Unset => Default::default(),
-            Self::Allowlist(list) | Self::Denylist(list) => list.into_iter(),
+            Self::DenyByDefault(list) | Self::Allowlist(list) | Self::Denylist(list) => {
+                list.into_iter()
+            }
         }
     }
 }
@@ -234,10 +244,10 @@ mod tests {
 
     #[test]
     fn should_set_list_type_if_none() {
-        let filter = SceneFilter::Unset.allow::<i32>();
+        let filter = SceneFilter::DenyByDefault(HashSet::default()).allow::<i32>();
         assert!(matches!(filter, SceneFilter::Allowlist(_)));
 
-        let filter = SceneFilter::Unset.deny::<i32>();
+        let filter = SceneFilter::DenyByDefault(HashSet::default()).deny::<i32>();
         assert!(matches!(filter, SceneFilter::Denylist(_)));
     }
 

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -122,12 +122,6 @@ pub enum SceneSpawnError {
         /// Type of the unregistered component.
         type_path: String,
     },
-    /// Scene contains an unregistered resource type.
-    #[error("scene contains the unregistered resource `{type_path}`. consider adding `#[reflect(Resource)]` to your type")]
-    UnregisteredResource {
-        /// Type of the unregistered resource.
-        type_path: String,
-    },
     /// Scene contains an unregistered type.
     #[error(
         "scene contains the unregistered type `{std_type_name}`. \
@@ -715,10 +709,12 @@ mod tests {
     use bevy_asset::{AssetPlugin, AssetServer, Handle};
     use bevy_ecs::{
         component::Component,
+        entity_disabling::DefaultQueryFilters,
         hierarchy::Children,
         observer::On,
         prelude::{ReflectComponent, ReflectResource},
         query::With,
+        resource::IsResource,
         system::{Commands, Query, Res, ResMut, RunSystemOnce},
     };
     use bevy_reflect::Reflect;
@@ -867,6 +863,8 @@ mod tests {
         app.init_resource::<TriggerCount>();
 
         app.register_type::<ComponentF>();
+        app.register_type::<IsResource>();
+        app.register_type::<DefaultQueryFilters>();
         app.world_mut().spawn(ComponentF);
         app.world_mut().spawn(ComponentF);
 
@@ -1074,7 +1072,9 @@ mod tests {
             .register_type::<ComponentA>()
             .register_type::<ChildOf>()
             .register_type::<Children>()
-            .register_type::<ComponentF>();
+            .register_type::<ComponentF>()
+            .register_type::<IsResource>()
+            .register_type::<DefaultQueryFilters>();
         app.update();
 
         let mut scene_world = World::new();

--- a/crates/bevy_scene/src/serde.rs
+++ b/crates/bevy_scene/src/serde.rs
@@ -80,13 +80,6 @@ impl<'a> Serialize for SceneSerializer<'a> {
     {
         let mut state = serializer.serialize_struct(SCENE_STRUCT, 2)?;
         state.serialize_field(
-            SCENE_RESOURCES,
-            &SceneMapSerializer {
-                entries: &self.scene.resources,
-                registry: self.registry,
-            },
-        )?;
-        state.serialize_field(
             SCENE_ENTITIES,
             &EntitiesSerializer {
                 entities: &self.scene.entities,
@@ -197,7 +190,6 @@ impl<'a> Serialize for SceneMapSerializer<'a> {
 #[derive(Deserialize)]
 #[serde(field_identifier, rename_all = "lowercase")]
 enum SceneField {
-    Resources,
     Entities,
 }
 
@@ -222,7 +214,7 @@ impl<'a, 'de> DeserializeSeed<'de> for SceneDeserializer<'a> {
     {
         deserializer.deserialize_struct(
             SCENE_STRUCT,
-            &[SCENE_RESOURCES, SCENE_ENTITIES],
+            &[SCENE_ENTITIES],
             SceneVisitor {
                 type_registry: self.type_registry,
             },
@@ -245,40 +237,22 @@ impl<'a, 'de> Visitor<'de> for SceneVisitor<'a> {
     where
         A: SeqAccess<'de>,
     {
-        let resources = seq
-            .next_element_seed(SceneMapDeserializer {
-                registry: self.type_registry,
-            })?
-            .ok_or_else(|| Error::missing_field(SCENE_RESOURCES))?;
-
         let entities = seq
             .next_element_seed(SceneEntitiesDeserializer {
                 type_registry: self.type_registry,
             })?
             .ok_or_else(|| Error::missing_field(SCENE_ENTITIES))?;
 
-        Ok(DynamicScene {
-            resources,
-            entities,
-        })
+        Ok(DynamicScene { entities })
     }
 
     fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
     where
         A: MapAccess<'de>,
     {
-        let mut resources = None;
         let mut entities = None;
         while let Some(key) = map.next_key()? {
             match key {
-                SceneField::Resources => {
-                    if resources.is_some() {
-                        return Err(Error::duplicate_field(SCENE_RESOURCES));
-                    }
-                    resources = Some(map.next_value_seed(SceneMapDeserializer {
-                        registry: self.type_registry,
-                    })?);
-                }
                 SceneField::Entities => {
                     if entities.is_some() {
                         return Err(Error::duplicate_field(SCENE_ENTITIES));
@@ -290,13 +264,9 @@ impl<'a, 'de> Visitor<'de> for SceneVisitor<'a> {
             }
         }
 
-        let resources = resources.ok_or_else(|| Error::missing_field(SCENE_RESOURCES))?;
         let entities = entities.ok_or_else(|| Error::missing_field(SCENE_ENTITIES))?;
 
-        Ok(DynamicScene {
-            resources,
-            entities,
-        })
+        Ok(DynamicScene { entities })
     }
 }
 
@@ -518,6 +488,7 @@ mod tests {
         prelude::{Component, ReflectComponent, ReflectResource, Resource, World},
         query::{With, Without},
         reflect::AppTypeRegistry,
+        resource::IsResource,
         world::FromWorld,
     };
     use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize};
@@ -611,6 +582,7 @@ mod tests {
             registry.register::<MyEntityRef>();
             registry.register::<Entity>();
             registry.register::<MyResource>();
+            registry.register::<IsResource>();
         }
         world.insert_resource(registry);
         world
@@ -632,12 +604,15 @@ mod tests {
             .build();
 
         let expected = r#"(
-  resources: {
-    "bevy_scene::serde::tests::MyResource": (
-      foo: 123,
-    ),
-  },
   entities: {
+    4294967290: (
+      components: {
+        "bevy_ecs::resource::IsResource": ((13)),
+        "bevy_scene::serde::tests::MyResource": (
+          foo: 123,
+        ),
+      },
+    ),
     4294967291: (
       components: {
         "bevy_scene::serde::tests::Bar": (345),
@@ -667,26 +642,28 @@ mod tests {
     #[test]
     fn should_deserialize() {
         let world = create_world();
-
         let input = r#"(
-  resources: {
-    "bevy_scene::serde::tests::MyResource": (
-      foo: 123,
-    ),
-  },
   entities: {
     8589934591: (
+        components: {
+          "bevy_scene::serde::tests::MyResource": (
+            foo: 123,
+          ),
+          "bevy_ecs::resource::IsResource": ((42)),
+        },
+    ),
+    8589934590: (
       components: {
         "bevy_scene::serde::tests::Foo": (123),
       },
     ),
-    8589934590: (
+    8589934589: (
       components: {
         "bevy_scene::serde::tests::Foo": (123),
         "bevy_scene::serde::tests::Bar": (345),
       },
     ),
-    8589934589: (
+    8589934588: (
       components: {
         "bevy_scene::serde::tests::Foo": (123),
         "bevy_scene::serde::tests::Bar": (345),
@@ -702,14 +679,9 @@ mod tests {
         let scene = scene_deserializer.deserialize(&mut deserializer).unwrap();
 
         assert_eq!(
-            1,
-            scene.resources.len(),
-            "expected `resources` to contain 1 resource"
-        );
-        assert_eq!(
-            3,
+            4,
             scene.entities.len(),
-            "expected `entities` to contain 3 entities"
+            "expected `entities` to contain 1 resource"
         );
 
         let mut map = EntityHashMap::default();
@@ -815,7 +787,7 @@ mod tests {
 
         assert_eq!(
             vec![
-                0, 1, 253, 255, 255, 255, 15, 1, 37, 98, 101, 118, 121, 95, 115, 99, 101, 110, 101,
+                1, 253, 255, 255, 255, 15, 1, 37, 98, 101, 118, 121, 95, 115, 99, 101, 110, 101,
                 58, 58, 115, 101, 114, 100, 101, 58, 58, 116, 101, 115, 116, 115, 58, 58, 77, 121,
                 67, 111, 109, 112, 111, 110, 101, 110, 116, 1, 2, 3, 102, 102, 166, 63, 205, 204,
                 108, 64, 1, 12, 72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33
@@ -856,10 +828,10 @@ mod tests {
 
         assert_eq!(
             vec![
-                146, 128, 129, 206, 255, 255, 255, 253, 145, 129, 217, 37, 98, 101, 118, 121, 95,
-                115, 99, 101, 110, 101, 58, 58, 115, 101, 114, 100, 101, 58, 58, 116, 101, 115,
-                116, 115, 58, 58, 77, 121, 67, 111, 109, 112, 111, 110, 101, 110, 116, 147, 147, 1,
-                2, 3, 146, 202, 63, 166, 102, 102, 202, 64, 108, 204, 205, 129, 165, 84, 117, 112,
+                146, 129, 206, 255, 255, 255, 253, 145, 129, 217, 37, 98, 101, 118, 121, 95, 115,
+                99, 101, 110, 101, 58, 58, 115, 101, 114, 100, 101, 58, 58, 116, 101, 115, 116,
+                115, 58, 58, 77, 121, 67, 111, 109, 112, 111, 110, 101, 110, 116, 147, 147, 1, 2,
+                3, 146, 202, 63, 166, 102, 102, 202, 64, 108, 204, 205, 129, 165, 84, 117, 112,
                 108, 101, 172, 72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33
             ],
             buf


### PR DESCRIPTION
# Objective

Currently, in scenes, resources are stored like this:
```
(
  resources: {
    "scene::ResourceA": (
      score: 1,
    ),
  },
  entities: {
    4294967297: (
      components: {
        ...
      },
    ),
    4294967298: (
      components: {
        ...
      },
    ),
  },
)
```

Since resources-as-components (#20934), it has become possible to attach other components to the resource entities. This is very useful for networking and something we want to support. Currently, however, the scene format does not support additional components in the format. This means that this data will be lost when converting a world to a scene and back to a world. This loss can be a pain for people working with resources.

## Solution

Since resources are already stored on entities, this PR removes `resources: { ... }` and instead everything is done on the entity level:

```
(
  entities: {
    4294967296: (
      components: {
        "scene::ResourceA": (
          score: 1,
        ),
        "bevy_ecs::resource::IsResource": ((12)),
        "replicon::Replicated": () // yay ^_^
      },
    ),
    4294967297: (
      components: {
        ...
      },
    ),
    4294967298: (
      components: {
        ...
      },
    ),
  },
)
```

## Testing

**TODO:** Add a test, for what happens when a resource is loaded from a scene twice. What should that even do?