### PR TITLE
Fix web assets path on windows

### DIFF
--- a/crates/bevy_asset/src/io/web.rs
+++ b/crates/bevy_asset/src/io/web.rs
@@ -134,7 +134,7 @@ async fn get(path: PathBuf) -> Result<Box<dyn Reader>, AssetReaderError> {
     })?;
 
     #[cfg(target_os = "windows")]
-    let str_path = &str_path.replace('\\', "/");
+    let str_path = &str_path.replace(std::path::MAIN_SEPARATOR, "/");
 
     #[cfg(all(not(target_arch = "wasm32"), feature = "web_asset_cache"))]
     if let Some(data) = web_asset_cache::try_load_from_cache(str_path).await? {


### PR DESCRIPTION
# Objective

- Web assets sometimes fail on windows because it can end up with mixed forward and back slashes.

## Solution

- Normalize the path to always use forward slash

## Testing

- I tested it with bevy_city from #22973 and it fixed all the web assets issue I had