### PR TITLE
update animation example to use gltf root asset

### DIFF
--- a/examples/animation/animated_mesh_control.rs
+++ b/examples/animation/animated_mesh_control.rs
@@ -20,7 +20,7 @@ fn main() {
         .add_systems(Startup, setup)
         .add_systems(
             Update,
-            check_fox_asset_ready.run_if(not(resource_exists::<Animations>)),
+            spawn_fox_asset_when_ready.run_if(not(resource_exists::<Animations>)),
         )
         .add_systems(
             Update,
@@ -94,7 +94,7 @@ fn setup(
     ));
 }
 
-fn check_fox_asset_ready(
+fn spawn_fox_asset_when_ready(
     mut commands: Commands,
     fox_handle: Res<Fox>,
     asset_server: Res<AssetServer>,


### PR DESCRIPTION
# Objective

It is a fairly common situation that a user looks at the animation examples in the bevy repo, uses them, and causes their application to load the glTF multiple times because the examples use many sub-assets directly. Users take this pattern with them and load sub-assets from the same glTF file in many different places in their application. (ex: a scene in one system and animations in another).

This approach *also* prevents using names to access animations, since Bevy's sub-asset id system doesn't currently use names to expose glTF sub-assets to applications, which means users must rely on indices that can change out from under them over time.

## Solution

Replace one example that loads animations with glTF root asset usage instead to gather feedback on general approach, before potentially modifying more examples.

This will expose loading patterns, such as needing to wait for the glTF asset to be loaded, which are *also* papercuts in regular Bevy application usage.

My general thought process is that we should use glTF root assets for any example that retrieves 2 or more sub-assets from a glTF file. Examples that, for example, only spawn a single `Scene` can stay as they are.

## Testing

```
cargo run --example animated_mesh_control
```

## Showcase


https://github.com/user-attachments/assets/6717f794-96fd-449e-abcc-1bd96b682127

