### PR TITLE
Fix `WGPU_SETTINGS_PRIO="webgl2"` after atmosphere landed.

### DIFF
--- a/crates/bevy_pbr/src/atmosphere/mod.rs
+++ b/crates/bevy_pbr/src/atmosphere/mod.rs
@@ -56,6 +56,7 @@ use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{
     extract_component::UniformComponentPlugin,
     render_resource::{DownlevelFlags, ShaderType, SpecializedRenderPipelines},
+    renderer::RenderDevice,
     sync_component::SyncComponent,
     sync_world::RenderEntity,
     Extract, ExtractSchedule, RenderStartup,
@@ -140,6 +141,15 @@ impl Plugin for AtmospherePlugin {
             .contains(TextureUsages::STORAGE_BINDING)
         {
             warn!("AtmospherePlugin not loaded. GPU lacks support: TextureFormat::Rgba16Float does not support TextureUsages::STORAGE_BINDING.");
+            return;
+        }
+
+        // Check the `RenderDevice` in addition to the `RenderAdapter`. The
+        // former takes the `WGPU_SETTINGS_PRIO` environment variable into
+        // account, and the latter doesn't.
+        let render_device = render_app.world().resource::<RenderDevice>();
+        if render_device.limits().max_storage_textures_per_shader_stage == 0 {
+            warn!("AtmospherePlugin not loaded. GPU lacks support: `max_storage_textures_per_shader_stage` is 0");
             return;
         }
 


### PR DESCRIPTION
The atmosphere plugin only checks `RenderAdapter` to determine whether it's safe to run, not `RenderDevice`. As PR #18113 discovered, this causes `WGPU_SETTINGS_PRIO="webgl2"` to fail, because that environment variable only affects `RenderDevice`, not `RenderAdapter`. Like that PR, this PR fixes atmosphere to check `RenderDevice` in addition to `RenderAdapter`.