### PR TITLE
Swap tables when moving the only entity in them

### DIFF
--- a/crates/bevy_ecs/src/bundle/insert.rs
+++ b/crates/bevy_ecs/src/bundle/insert.rs
@@ -288,7 +288,11 @@ impl<'w> BundleInserter<'w> {
                 }
                 // PERF: store "non bundle" components in edge, then just move those to avoid
                 // redundant copies
-                let move_result = table.move_to_superset_unchecked(result.table_row, new_table);
+                let move_result = table.move_to_superset_unchecked(
+                    result.table_row,
+                    new_table,
+                    archetype_after_insert.added(),
+                );
                 let new_location = new_archetype.allocate(entity, move_result.new_row);
                 entities.update_existing_location(entity.index(), Some(new_location));
 

--- a/crates/bevy_ecs/src/bundle/remove.rs
+++ b/crates/bevy_ecs/src/bundle/remove.rs
@@ -247,12 +247,15 @@ impl<'w> BundleRemover<'w> {
 
         // Handle table change
         let new_location = if let Some((mut old_table, mut new_table)) = self.old_and_new_table {
+            let removed_columns = self.bundle_info.as_ref().explicit_components();
             let move_result = if needs_drop {
                 // SAFETY: old_table_row exists
                 unsafe {
-                    old_table
-                        .as_mut()
-                        .move_to_and_drop_missing_unchecked(location.table_row, new_table.as_mut())
+                    old_table.as_mut().move_to_and_drop_missing_unchecked(
+                        location.table_row,
+                        new_table.as_mut(),
+                        removed_columns,
+                    )
                 }
             } else {
                 // SAFETY: old_table_row exists
@@ -260,6 +263,7 @@ impl<'w> BundleRemover<'w> {
                     old_table.as_mut().move_to_and_forget_missing_unchecked(
                         location.table_row,
                         new_table.as_mut(),
+                        removed_columns,
                     )
                 }
             };

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1419,6 +1419,35 @@ mod tests {
     }
 
     #[test]
+    fn single_entity_table_does_not_move() {
+        let mut world = World::new();
+
+        // This is the only entity in its table
+        let mut entity = world.spawn(A(0));
+        let id = entity.id();
+        let a_ptr_1 = core::ptr::from_ref(entity.get::<A>().unwrap());
+
+        // Moving the only entity should move the entire column,
+        // preserving the address of the component
+        entity.insert(B(0));
+        let a_ptr_2 = core::ptr::from_ref(entity.get::<A>().unwrap());
+        assert_eq!(a_ptr_1, a_ptr_2);
+
+        entity.remove::<B>();
+        let a_ptr_2 = core::ptr::from_ref(entity.get::<A>().unwrap());
+        assert_eq!(a_ptr_1, a_ptr_2);
+
+        // Adding a second entity to the table will prevent the optimization,
+        // and the component data will need to be copied to the new column
+        world.spawn(A(1));
+        let mut entity = world.get_entity_mut(id).unwrap();
+        let a_ptr_1 = core::ptr::from_ref(entity.get::<A>().unwrap());
+        entity.insert(B(0));
+        let a_ptr_2 = core::ptr::from_ref(entity.get::<A>().unwrap());
+        assert_ne!(a_ptr_1, a_ptr_2);
+    }
+
+    #[test]
     fn non_send() {
         let mut world = World::default();
         world.insert_non_send(123i32);

--- a/crates/bevy_ecs/src/storage/thin_array_ptr.rs
+++ b/crates/bevy_ecs/src/storage/thin_array_ptr.rs
@@ -228,7 +228,7 @@ impl<T> ThinArrayPtr<T> {
     /// - ensure that `current_len` is indeed the len of the array
     #[inline]
     unsafe fn last_element(&mut self, current_len: usize) -> Option<*mut T> {
-        (current_len != 0).then_some(self.data.as_ptr().add(current_len - 1))
+        (current_len != 0).then(|| self.data.as_ptr().add(current_len - 1))
     }
 
     /// Clears the array, removing (and dropping) Note that this method has no effect on the allocated capacity of the vector.
@@ -273,5 +273,18 @@ impl<T> ThinArrayPtr<T> {
         // - non-null and well-aligned
         // - we have a shared reference to self - the data will not be mutated during 'a
         unsafe { core::slice::from_raw_parts(self.data.as_ptr(), slice_len) }
+    }
+
+    /// Get the [`ThinArrayPtr`] as a slice with a given length.
+    ///
+    /// # Safety
+    /// - `slice_len` must match the actual length of the array
+    #[inline]
+    pub unsafe fn as_slice_mut(&mut self, slice_len: usize) -> &mut [T] {
+        // SAFETY:
+        // - the data is valid - allocated with the same allocator
+        // - non-null and well-aligned
+        // - we have a shared reference to self - the data will not be mutated during 'a
+        unsafe { core::slice::from_raw_parts_mut(self.data.as_ptr(), slice_len) }
     }
 }


### PR DESCRIPTION
# Objective

Improve the performance of table moves for tables that only have one entity.  

This is common for games that have a special "player" entity that has components added and removed during the game.  It may also affect resource entities when used with `resource_scope`, although since the resource component itself is removed, this will only help if other large components are added to resource entities.  

## Solution

If the only entity in a table moves to an empty table, swap the `Table` values.  That moves all the components at once, at the cost of moving a few pointers.  

Of course, that also moves columns that should exist in one table but not the other.  So move those columns back to the correct table.  

Moving the columns requires the two tables have the same capacity, since all columns in a table must have the same capacity.  

Unfortunately, the columns are stored in an `ImmutableSparseSet`, which does not allow columns to be changed.  That type uses `Box<[T]>` instead of `Vec<T>` to reduce the storage to two pointers instead of three, so simply switching back to `SparseSet` would be a regression in memory usage.  

So, we first make `SparseSet` smaller.  

`SparseSet` stores two parallel lists, `dense` and `indices`, that always have the same length.  But if we use `ThinArrayPtr`, we can store a single copy of the length and capacity, and use it for both lists!  Now `SparseSet` stores two pointers and two `usize`s, length and capacity.  That is the same size as the old `ImmutableSparseSet`, which stored two pointers and two `usize`s, one length for each `Box<[T]>`.  

`SparseSet` also stores a `SparseArray`, which stores a `Vec<Option<T>>`.  But we treat out-of-range indexes and `None` values in that list the same.  So, any time we resize the `Vec`, we can fill the remaining capacity with `None` values.  That requires no additional allocation, and means we always have `length == capacity` and can store it as a `Box<[Option<T>]>`.  

With those changes, `SparseSet` is as small as `ImmutableSparseSet`, so we can eliminate `ImmutableSparseSet`.  

## Testing

Added a unit test to ensure that a component value isn't moved when this optimization triggers.  Detect that by ensuring that the pointer address does not change.  

This change should be benchmarked to see whether it actually improves performance for table moves of large "player" entities, but I do not know how to write such a benchmark.  