### PR TITLE
Enable `debug` feature when `trace_tracy` is enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -426,7 +426,7 @@ raw_vulkan_init = ["bevy_internal/raw_vulkan_init"]
 type_label_buffers = ["bevy_internal/type_label_buffers"]
 
 # Tracing support, saving a file in Chrome Tracing format
-trace_chrome = ["trace", "bevy_internal/trace_chrome"]
+trace_chrome = ["trace", "bevy_internal/trace_chrome", "debug"]
 
 # Tracing support, exposing a port for Tracy
 trace_tracy = ["trace", "bevy_internal/trace_tracy", "debug"]


### PR DESCRIPTION
# Objective

- When running tracy you generally want to be able to see the full names of things

## Solution

- Enable `debug` when `trace_tracy` is enabled.