### PR TITLE
Add notes about using the R channel as the occlusion_texture

### DIFF
--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -428,6 +428,7 @@ pub struct StandardMaterial {
     /// It is very common to use an RGB texture that uses the red channel for the [`StandardMaterial::occlusion_texture`],
     /// and the B and G channels for [`StandardMaterial::metallic_roughness_texture`].
     /// In such cases, use the same image handle for both fields.
+    /// Notably, this is the setup used by [glTF](https://docs.blender.org/manual/en/latest/addons/import_export/scene_gltf2.html#baked-ambient-occlusion).
     #[texture(7)]
     #[sampler(8)]
     #[dependency]


### PR DESCRIPTION
# Objective

- I wasn't sure if Bevy supported the common ARM-RGB encoding (r = AO, G = Roughness, B = Metallic). The docs weren't helpful here.

## Solution

- I set up a tiny test scene to make sure. Yes, Bevy works perfectly fine with that setup! Let's make it easier for future users by documenting it.
- This "Use the R channel for this texture" trick can also be used for other textures, like the clearcoat, but IME the most common thing is ambient occlusion, so I only added it there for now.

## Testing

- Local test project
