### PR TITLE
Adds text gizmos to testbeds

### DIFF
--- a/examples/testbed/2d.rs
+++ b/examples/testbed/2d.rs
@@ -395,14 +395,13 @@ mod gizmos {
             )
             .resolution(64);
 
-        gizmos
-            .text_2d(
-                Isometry2d::from_translation(Vec2::new(-200.0, 0.0)), 
-                "text_2d gizmo", 
-                15., 
-                Vec2 { x: 0., y: 0. }, 
-                Color::WHITE
-            );
+        gizmos.text_2d(
+            Isometry2d::from_translation(Vec2::new(-200.0, 0.0)),
+            "text_2d gizmo",
+            15.,
+            Vec2 { x: 0., y: 0. },
+            Color::WHITE,
+        );
 
         // 2d grids with all variations of outer edges on or off
         for i in 0..4 {

--- a/examples/testbed/3d.rs
+++ b/examples/testbed/3d.rs
@@ -358,14 +358,13 @@ mod gizmos {
             .sphere(Isometry3d::from_translation(Vec3::X * -3.5), 0.75, GREEN)
             .resolution(30_000 / 3);
 
-        gizmos
-            .text(
-                Isometry3d::from_translation(Vec3::Y * 1.5), 
-                "text gizmo", 
-                0.3, 
-                Vec2 { x: 0., y: 0. }, 
-                Color::WHITE
-            );
+        gizmos.text(
+            Isometry3d::from_translation(Vec3::Y * 1.5),
+            "text gizmo",
+            0.3,
+            Vec2 { x: 0., y: 0. },
+            Color::WHITE,
+        );
 
         // 3d grids with all variations of outer edges on or off
         for i in 0..8 {


### PR DESCRIPTION
# Objective

- Fixed both #23058 and #23059 

## Solution

- Adds text gizmos to the 2D and 3D testbed examples

## Testing

Tested on Windows 11/Nvidia/Vulkan

---

## Showcase

<details>
  <summary>Click to view showcase</summary>

### testbed_2d

<img width="1282" height="752" alt="image" src="https://github.com/user-attachments/assets/ce20cf8f-c6f0-49be-8290-9f912c144f65" />


### testbed_3d

<img width="1282" height="752" alt="image" src="https://github.com/user-attachments/assets/2de280bd-bf2f-4335-a7ba-c25fc9a53d25" />


</details>
