### PR TITLE
building bevy with only feature bevy_input_focus fails

### DIFF
--- a/crates/bevy_input_focus/src/navigator.rs
+++ b/crates/bevy_input_focus/src/navigator.rs
@@ -109,7 +109,7 @@ fn score_candidate(
     let dy = (candidate_rect.min.y - origin_rect.max.y)
         .max(origin_rect.min.y - candidate_rect.max.y)
         .max(0.0);
-    let distance = (dx * dx + dy * dy).sqrt();
+    let distance = bevy_math::ops::sqrt(dx * dx + dy * dy);
 
     // Check max distance
     if let Some(max_dist) = config.max_search_distance {


### PR DESCRIPTION
# Objective

- `cargo build --features bevy_input_focus --no-default-features` fails
```
error[E0599]: no method named `sqrt` found for type `f32` in the current scope
   --> crates/bevy_input_focus/src/navigator.rs:112:40
    |
112 |     let distance = (dx * dx + dy * dy).sqrt();
    |                                        ^^^^ method not found in `f32`
```

## Solution

- use `sqrt` from bevy_math
