### PR TITLE
bevy_pbr format in wasm

### DIFF
--- a/crates/bevy_pbr/src/gltf.rs
+++ b/crates/bevy_pbr/src/gltf.rs
@@ -18,7 +18,7 @@ pub(crate) fn add_gltf(app: &mut App) {
             .0
             .write()
             .await
-            .push(Box::new(GltfExtensionHandlerPbr))
+            .push(Box::new(GltfExtensionHandlerPbr));
     });
 
     #[cfg(not(target_family = "wasm"))]


### PR DESCRIPTION
```
error: consider adding a `;` to the last statement for consistent formatting
  --> crates/bevy_pbr/src/gltf.rs:16:9
   |
16 | /         app.world_mut()
17 | |             .resource_mut::<GltfExtensionHandlers>()
18 | |             .0
19 | |             .write()
20 | |             .await
21 | |             .push(Box::new(GltfExtensionHandlerPbr))
   | |____________________________________________________^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/beta/index.html#semicolon_if_nothing_returned
   = note: `-D clippy::semicolon-if-nothing-returned` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::semicolon_if_nothing_returned)]`
help: add a `;` here
   |
16 |         app.world_mut()
...
20 |             .await
21 ~             .push(Box::new(GltfExtensionHandlerPbr));
```

do it