### PR TITLE
Fix `DynamicTextureAtlasBuilder` incorrectly padding added textures.

### DIFF
--- a/crates/bevy_text/src/font_atlas.rs
+++ b/crates/bevy_text/src/font_atlas.rs
@@ -59,7 +59,7 @@ impl FontAtlas {
         Self {
             texture_atlas: TextureAtlasLayout::new_empty(size),
             glyph_to_atlas_index: HashMap::default(),
-            dynamic_texture_atlas_builder: DynamicTextureAtlasBuilder::new(size, 1),
+            dynamic_texture_atlas_builder: DynamicTextureAtlasBuilder::new(size, 2),
             texture,
         }
     }


### PR DESCRIPTION
# Objective

- #22939 has been introducing diffs in the testbed_ui Text example, but the only thing that was changing was the order that glyphs are allocated to the font atlas. The font atlas **should be** resilient to this and produce no diffs in that case.
- Another PR had similar diffs and also seemed to be due to changing the order of glyphs being allocated.

## Solution

- Previously `DynamicTextureAtlasBuilder` would allocate glyph size + padding, and then copy the glyph into that rectangle - but this means that copying would start at (0,0) meaning we would "blend" with the top and left edges (which breaks things).
- Now we copy to (padding, padding).
- Remove (padding, padding) allocate-able space from the bottom and right to ensure we don't accidentally put textures on the right or bottom edges.

## Testing

- Added unit tests to ensure that allocation works and that padding works.
- The rendering change here is quite interesting! https://pixel-eagle.com/project/B04F67C0-C054-4A6F-92EC-F599FEC2FD1D?filter=PR-23091 Some cases, like the `l` in `black` in the Text screenshot look **substantially** better!

Note this is orthogonal to #23056 which is about `TextureAtlasBuilder`, not `DynamicTextureAtlasBuilder`.