### PR TITLE
Add a `setup` Component derive helper

### DIFF
--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -232,7 +232,20 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
             .map(|path| path.to_token_stream(&bevy_ecs_path))
     };
 
-    let on_add = hook_register_function_call(&bevy_ecs_path, quote! {on_add}, on_add_path);
+    let on_add = if let Some(setup) = attrs.setup {
+        let on_add = on_add_path.map(|meta| quote! { #meta(world, ctx) });
+        let on_add = quote! {
+            fn on_add() -> ::core::option::Option<#bevy_ecs_path::lifecycle::ComponentHook> {
+                ::core::option::Option::Some(|mut world, ctx| {
+                    world.commands().run_system_cached_with(#setup, ctx.entity);
+                    #on_add
+                })
+            }
+        };
+        Some(on_add)
+    } else {
+        hook_register_function_call(&bevy_ecs_path, quote! {on_add}, on_add_path)
+    };
     let on_insert = hook_register_function_call(&bevy_ecs_path, quote! {on_insert}, on_insert_path);
     let on_discard =
         hook_register_function_call(&bevy_ecs_path, quote! {on_discard}, on_discard_path);
@@ -457,6 +470,7 @@ pub(crate) fn map_entities(
 pub const COMPONENT: &str = "component";
 pub const STORAGE: &str = "storage";
 pub const REQUIRE: &str = "require";
+pub const SETUP: &str = "setup";
 pub const RELATIONSHIP: &str = "relationship";
 pub const RELATIONSHIP_TARGET: &str = "relationship_target";
 
@@ -583,6 +597,7 @@ impl Parse for MapEntitiesAttributeKind {
 struct Attrs {
     storage: StorageTy,
     requires: Option<Punctuated<Require, Comma>>,
+    setup: Option<ExprPath>,
     on_add: Option<HookAttributeKind>,
     on_insert: Option<HookAttributeKind>,
     on_discard: Option<HookAttributeKind>,
@@ -629,6 +644,7 @@ fn parse_component_attr(ast: &DeriveInput) -> Result<Attrs> {
         on_remove: None,
         on_despawn: None,
         requires: None,
+        setup: None,
         relationship: None,
         relationship_target: None,
         immutable: false,
@@ -705,6 +721,9 @@ fn parse_component_attr(ast: &DeriveInput) -> Result<Attrs> {
             } else {
                 attrs.requires = Some(punctuated);
             }
+        } else if attr.path().is_ident(SETUP) {
+            let expr = attr.parse_args::<ExprPath>()?;
+            attrs.setup = Some(expr);
         } else if attr.path().is_ident(RELATIONSHIP) {
             let relationship = attr.parse_args::<Relationship>()?;
             attrs.relationship = Some(relationship);

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -644,6 +644,14 @@ pub fn derive_resource(input: TokenStream) -> TokenStream {
 /// When `allow_self_referential` is enabled, be careful when using recursive traversal methods
 /// like `iter_ancestors` or `root_ancestor`, as they will loop infinitely if an entity points to itself.
 ///
+/// ## Setup
+/// ```ignore
+/// #[derive(Component)]
+/// #[setup(function)]
+/// struct MyComponent;
+/// ```
+/// where `function` is a path to a system that accepts `In<Entity>`.
+///
 /// ## Hooks
 /// ```ignore
 /// #[derive(Component)]
@@ -664,7 +672,7 @@ pub fn derive_resource(input: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro_derive(
     Component,
-    attributes(component, require, relationship, relationship_target, entities)
+    attributes(component, require, setup, relationship, relationship_target, entities)
 )]
 pub fn derive_component(input: TokenStream) -> TokenStream {
     component::derive_component(input)

--- a/crates/bevy_ecs/src/component/mod.rs
+++ b/crates/bevy_ecs/src/component/mod.rs
@@ -445,6 +445,28 @@ use core::{fmt::Debug, marker::PhantomData, ops::Deref};
 ///
 /// ```
 ///
+/// # Run a system when this component is added
+///
+/// A very common case is to have a marker component defining some entity "prototype" and then
+/// attaching a world `On<Add, MyComponent>` observer to load assets, insert components, or attach
+/// other observers.
+///
+/// As an ergonomic shorthand for this pattern, you can declare a setup system that will be run
+/// any time this component gets added to an entity.
+/// ```
+/// # use bevy_ecs::prelude::*;
+///
+/// #[derive(Component)]
+/// #[setup(say_hello)]
+/// struct HelloComponent;
+///
+/// fn say_hello(In(entity): In<Entity>) {
+///     println!("Hello from {entity}!");
+/// }
+/// ```
+/// This is essentially an alternative to the `on_add` hook that gives you full access to
+/// regular system semantics, and in fact is implemented using the `on_add` hook!
+///
 /// # Implementing the trait for foreign types
 ///
 /// As a consequence of the [orphan rule], it is not possible to separate into two different crates the implementation of `Component` from the definition of a type.


### PR DESCRIPTION
# Objective

- A very common pattern has emerged since Observers were added where an `On<Add, Component>` observer is used to "set up" an entity prototype based on a marker struct:
```rs
pub fn plugin(app: &mut App) {
    app.add_observer(setup);
}
#[derive(Component)]
pub struct MyComponent;
fn setup(evt: On<Add, MyComponent>, mut commands: Commands) {
    commands
        .entity(evt.entity)
        .insert((
            // insert some other components, maybe fetch
            // data from a query, use the asset server, etc...
        ))
        .observe(some_other_observer);
}
```
- Looking through open-source repos from the [Bevy Jam 7](https://itch.io/jam/bevy-jam-7), I see this exact pattern multiple times in nearly every repo. It's really useful! 
  - In my own submission, 42 out of 80 plugin functions consist solely of adding one such setup observer.
- We can make this more ergonomic!


## Solution

Add a `setup` derive helper to the `Component` derive helper so that devs can statically declare setup systems without needing to add any plugin machinery.

## Testing

Tested in a sample project and it works as expected. 
Helper expands to a hook like this: 
```rs
fn on_add() -> ::core::option::Option<::bevy::ecs::lifecycle::ComponentHook> {
    ::core::option::Option::Some(|mut world, ctx| {
        world.commands().run_system_cached_with(setup, ctx.entity);
        on_add(world, ctx)
    })
}
```
where the `on_add(world, ctx)` is the custom on_add hook set via `#[component(on_add = ...)]` or omitted if none is set.

---

## Showcase

```rust
#[derive(Component)]
#[setup(setup)]
pub struct MyComponent;
fn setup(entity: In<Entity>, mut commands: Commands) {
    commands
        .entity(*entity)
        .insert((
            // insert some other components, maybe fetch
            // data from a query, use the asset server, etc...
        ))
        .observe(some_other_observer);
}
```

---

## Note

A-OK if this isn't a direction that's wanted, just figured I'd throw the PR out there because if it goes through I'd use it to remove 42 plugins from my code!