### PR TITLE
Break dependency from `bevy_anti_alias` on `bevy_post_process` by splitting `PostProcess` set

### DIFF
--- a/crates/bevy_anti_alias/Cargo.toml
+++ b/crates/bevy_anti_alias/Cargo.toml
@@ -31,7 +31,6 @@ bevy_shader = { path = "../bevy_shader", version = "0.19.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.19.0-dev" }
 bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.19.0-dev" }
 bevy_diagnostic = { path = "../bevy_diagnostic", version = "0.19.0-dev" }
-bevy_post_process = { path = "../bevy_post_process", version = "0.19.0-dev" }
 
 # other
 tracing = { version = "0.1", default-features = false, features = ["std"] }

--- a/crates/bevy_anti_alias/src/dlss/mod.rs
+++ b/crates/bevy_anti_alias/src/dlss/mod.rs
@@ -28,7 +28,6 @@ use bevy_core_pipeline::{
 };
 use bevy_ecs::prelude::*;
 use bevy_math::{UVec2, Vec2};
-use bevy_post_process::bloom::bloom;
 use bevy_reflect::{reflect_remote, Reflect};
 use bevy_render::{
     camera::{MipBias, TemporalJitter},
@@ -194,8 +193,7 @@ impl Plugin for DlssPlugin {
             Core3d,
             (node::dlss_super_resolution, node::dlss_ray_reconstruction)
                 .chain()
-                .before(bloom)
-                .in_set(Core3dSystems::PostProcess),
+                .in_set(Core3dSystems::EarlyPostProcess),
         );
     }
 }

--- a/crates/bevy_anti_alias/src/taa/mod.rs
+++ b/crates/bevy_anti_alias/src/taa/mod.rs
@@ -17,7 +17,6 @@ use bevy_ecs::{
 };
 use bevy_image::{BevyDefault as _, ToExtents};
 use bevy_math::vec2;
-use bevy_post_process::{bloom::bloom, motion_blur::motion_blur};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{
     camera::{ExtractedCamera, MipBias, TemporalJitter},
@@ -70,10 +69,7 @@ impl Plugin for TemporalAntiAliasPlugin {
 
         render_app.add_systems(
             Core3d,
-            temporal_anti_alias
-                .before(motion_blur)
-                .before(bloom)
-                .in_set(Core3dSystems::PostProcess),
+            temporal_anti_alias.in_set(Core3dSystems::EarlyPostProcess),
         );
     }
 }

--- a/crates/bevy_core_pipeline/src/schedule.rs
+++ b/crates/bevy_core_pipeline/src/schedule.rs
@@ -34,6 +34,7 @@ pub struct Core3d;
 /// These stages include and run in the following order:
 /// - `Prepass`: Initial rendering operations, such as depth pre-pass.
 /// - `MainPass`: The primary rendering operations, including drawing opaque and transparent objects.
+/// - `EarlyPostProcess`: Initial post processing effects.
 /// - `PostProcess`: Final rendering operations, such as post-processing effects.
 ///
 /// Additional systems can be added to these sets to customize the rendering pipeline, or additional
@@ -42,6 +43,7 @@ pub struct Core3d;
 pub enum Core3dSystems {
     Prepass,
     MainPass,
+    EarlyPostProcess,
     PostProcess,
 }
 
@@ -57,7 +59,7 @@ impl Core3d {
             ..Default::default()
         });
 
-        schedule.configure_sets((Prepass, MainPass, PostProcess).chain());
+        schedule.configure_sets((Prepass, MainPass, EarlyPostProcess, PostProcess).chain());
 
         schedule
     }
@@ -69,14 +71,18 @@ pub struct Core2d;
 
 /// System sets for the Core 2D rendering pipeline, defining the main stages of rendering.
 /// These stages include and run in the following order:
+/// - `Prepass`: Initial rendering operations, such as depth pre-pass.
 /// - `MainPass`: The primary rendering operations, including drawing 2D sprites and meshes.
+/// - `EarlyPostProcess`: Initial post processing effects.
 /// - `PostProcess`: Final rendering operations, such as post-processing effects.
 ///
 /// Additional systems can be added to these sets to customize the rendering pipeline, or additional
 /// sets can be created relative to these core sets.
 #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Core2dSystems {
+    Prepass,
     MainPass,
+    EarlyPostProcess,
     PostProcess,
 }
 
@@ -92,7 +98,7 @@ impl Core2d {
             ..Default::default()
         });
 
-        schedule.configure_sets((MainPass, PostProcess).chain());
+        schedule.configure_sets((Prepass, MainPass, EarlyPostProcess, PostProcess).chain());
 
         schedule
     }

--- a/release-content/migration-guides/post_processing.md
+++ b/release-content/migration-guides/post_processing.md
@@ -1,0 +1,11 @@
+---
+title: Post Processing Split
+pull_requests: [23098]
+---
+
+`Core2dSystems` and `Core3dSystems` have split `PostProcess` set.  2d now has a `Prepass`.  Both systems have the following sets:
+
+- `Prepass`
+- `MainPass`
+- `EarlyPostProcess`
+- `PostProcess`


### PR DESCRIPTION
# Objective

- During https://github.com/bevyengine/bevy/pull/22144 , we slightly linearlised the crate build, by explicit dependency on system ordering. [See this comment](https://github.com/bevyengine/bevy/pull/22144/changes#r2697878715)

## Solution

- Split `PostProcess` set into `EarlyPostProcess` and `PostProcess` sets
- Move `taa` and `dlss` into `EarlyPostProcess`

<img width="309" height="539" alt="aa-no-pp" src="https://github.com/user-attachments/assets/bb32b71a-4743-46e4-ad2c-f06ef7db854f" />

## Testing

- CI
- `cargo run --example anti_aliasing`