### PR TITLE
bugfix: recompute inherited visibility when ChildOf component is removed

### DIFF
--- a/crates/bevy_camera/src/visibility/mod.rs
+++ b/crates/bevy_camera/src/visibility/mod.rs
@@ -1022,7 +1022,7 @@ mod test {
 
         assert!(
             !is_visible(&app, child),
-            "Child1 should inherit visibility from parent"
+            "Child should inherit visibility from parent"
         );
 
         // Detach a child from the invisible parent


### PR DESCRIPTION
# Objective

Whenever an entity that was inheriting its invisibility was orphaned, its inherited visibility would not be recomputed, consequently remaining invisible. It is my opinion - which I feel is supported by existing comments in the code - that this should result in the entity becoming visible again.

## Solution

Checking for removed components is a bit awkward (ideally one would have use an additional `Removed<ChildOf>` predicate in the disjunction of `changed`. Instead, we consider a secondary loop over `RemovedComponents<ChildOf>`

## Testing

I included an additional unit test, having checked it did not pass prior to my changes.