### PR TITLE
Parallelize `mark_meshes_as_changed_if_their_materials_changed`.

### DIFF
--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -654,9 +654,9 @@ fn mark_meshes_as_changed_if_their_materials_changed<M>(
 ) where
     M: Material,
 {
-    for mut mesh in &mut changed_meshes_query {
+    changed_meshes_query.par_iter_mut().for_each(|mut mesh| {
         mesh.set_changed();
-    }
+    });
 }
 
 /// Fills the [`RenderMaterialInstances`] resources from the meshes in the


### PR DESCRIPTION
This tiny system loops over all instances and can actually show up in the profile when the instance count reaches the millions. This PR fixes that. The `mark_meshes_as_changed_if_their_materials_changed` system in `many_cubes --no-cpu-culling --instance-count 3000000` (with PR #23101 applied) goes from 2.92 ms per frame to 0.669 ms per frame with this patch applied, a 4.4x speedup.

Before and after:
<img width="2756" height="1800" alt="Screenshot 2026-02-21 143243" src="https://github.com/user-attachments/assets/556b0ca2-28e8-4f01-960a-57690ab54fb4" />
