### PR TITLE
Add an `ImageSaver` `AssetSaver`, and simplify / split the asset saving example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1961,6 +1961,18 @@ category = "Assets"
 wasm = false
 
 [[example]]
+name = "asset_saving"
+path = "examples/asset/asset_saving.rs"
+doc-scrape-examples = true
+required-features = ["ui_picking", "sprite_picking", "png"]
+
+[package.metadata.example.asset_saving]
+name = "Asset Saving"
+description = "Demonstrates how to save an asset"
+category = "Assets"
+wasm = true
+
+[[example]]
 name = "asset_saving_with_subassets"
 path = "examples/asset/asset_saving_with_subassets.rs"
 doc-scrape-examples = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1961,14 +1961,14 @@ category = "Assets"
 wasm = false
 
 [[example]]
-name = "asset_saving"
-path = "examples/asset/asset_saving.rs"
+name = "asset_saving_with_subassets"
+path = "examples/asset/asset_saving_with_subassets.rs"
 doc-scrape-examples = true
 required-features = ["ui_picking", "sprite_picking"]
 
-[package.metadata.example.asset_saving]
-name = "Asset Saving"
-description = "Demonstrates how to save an asset (with subassets)"
+[package.metadata.example.asset_saving_with_subassets]
+name = "Asset Saving with Subassets"
+description = "Demonstrates how to save an asset with subassets"
 category = "Assets"
 wasm = true
 

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -517,6 +517,19 @@ impl<'a> AssetPath<'a> {
         Some(extension)
     }
 
+    /// Returns the extension, excluding multiple `.` values.
+    ///
+    /// Ex: Returns `"ron"` for `"my_asset.config.ron"`
+    ///
+    /// Also strips out anything follow a `?` to handle query parameters in URIs.
+    pub fn get_extension(&self) -> Option<&str> {
+        let full_extension = self.get_full_extension()?;
+        Some(match full_extension.rfind(".") {
+            None => full_extension,
+            Some(index) => &full_extension[(index + 1)..],
+        })
+    }
+
     pub(crate) fn iter_secondary_extensions(full_extension: &str) -> impl Iterator<Item = &str> {
         full_extension.char_indices().filter_map(|(i, c)| {
             if c == '.' {
@@ -1251,7 +1264,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_extension() {
+    fn test_get_full_extension() {
         let result = AssetPath::from("http://a.tar.gz#Foo");
         assert_eq!(result.get_full_extension(), Some("tar.gz"));
 
@@ -1263,5 +1276,20 @@ mod tests {
 
         let result = AssetPath::from("asset.Custom");
         assert_eq!(result.get_full_extension(), Some("Custom"));
+    }
+
+    #[test]
+    fn test_get_extension() {
+        let result = AssetPath::from("http://a.tar.gz#Foo");
+        assert_eq!(result.get_extension(), Some("gz"));
+
+        let result = AssetPath::from("http://a#Foo");
+        assert_eq!(result.get_extension(), None);
+
+        let result = AssetPath::from("http://a.tar.bz2?foo=bar#Baz");
+        assert_eq!(result.get_extension(), Some("bz2"));
+
+        let result = AssetPath::from("asset.Custom");
+        assert_eq!(result.get_extension(), Some("Custom"));
     }
 }

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -503,15 +503,15 @@ impl<'a> AssetPath<'a> {
     /// Ex: Returns `"config.ron"` for `"my_asset.config.ron"`
     ///
     /// Also strips out anything following a `?` to handle query parameters in URIs
-    pub fn get_full_extension(&self) -> Option<String> {
+    pub fn get_full_extension(&self) -> Option<&str> {
         let file_name = self.path().file_name()?.to_str()?;
         let index = file_name.find('.')?;
-        let mut extension = file_name[index + 1..].to_owned();
+        let mut extension = &file_name[index + 1..];
 
         // Strip off any query parameters
         let query = extension.find('?');
         if let Some(offset) = query {
-            extension.truncate(offset);
+            extension = &extension[..offset];
         }
 
         Some(extension)
@@ -706,7 +706,6 @@ pub(crate) fn normalize_path(path: &Path) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use crate::AssetPath;
-    use alloc::string::ToString;
     use std::path::Path;
 
     #[test]
@@ -1254,15 +1253,15 @@ mod tests {
     #[test]
     fn test_get_extension() {
         let result = AssetPath::from("http://a.tar.gz#Foo");
-        assert_eq!(result.get_full_extension(), Some("tar.gz".to_string()));
+        assert_eq!(result.get_full_extension(), Some("tar.gz"));
 
         let result = AssetPath::from("http://a#Foo");
         assert_eq!(result.get_full_extension(), None);
 
         let result = AssetPath::from("http://a.tar.bz2?foo=bar#Baz");
-        assert_eq!(result.get_full_extension(), Some("tar.bz2".to_string()));
+        assert_eq!(result.get_full_extension(), Some("tar.bz2"));
 
         let result = AssetPath::from("asset.Custom");
-        assert_eq!(result.get_full_extension(), Some("Custom".to_string()));
+        assert_eq!(result.get_full_extension(), Some("Custom"));
     }
 }

--- a/crates/bevy_asset/src/processor/mod.rs
+++ b/crates/bevy_asset/src/processor/mod.rs
@@ -436,7 +436,7 @@ impl AssetProcessor {
         let path = path.into();
         let Some(processor) = path
             .get_full_extension()
-            .and_then(|extension| self.get_default_processor(&extension))
+            .and_then(|extension| self.get_default_processor(extension))
         else {
             return self
                 .server
@@ -1073,7 +1073,7 @@ impl AssetProcessor {
             Err(AssetReaderError::NotFound(_path)) => {
                 let (meta, processor) = if let Some(processor) = asset_path
                     .get_full_extension()
-                    .and_then(|ext| self.get_default_processor(&ext))
+                    .and_then(|ext| self.get_default_processor(ext))
                 {
                     // Note: It doesn't matter whether we use the Long or Short kind, since we're
                     // returning the processor here anyway, and we're only using this meta to pass

--- a/crates/bevy_asset/src/processor/process.rs
+++ b/crates/bevy_asset/src/processor/process.rs
@@ -203,7 +203,12 @@ where
 
         let output_settings = self
             .saver
-            .save(writer, saved_asset, &settings.saver_settings)
+            .save(
+                writer,
+                saved_asset,
+                &settings.saver_settings,
+                context.path.clone(),
+            )
             .await
             .map_err(|error| ProcessError::AssetSaveError(error.into()))?;
         Ok(output_settings)

--- a/crates/bevy_asset/src/processor/tests.rs
+++ b/crates/bevy_asset/src/processor/tests.rs
@@ -811,6 +811,7 @@ impl AssetSaver for FakeBsnSaver {
         writer: &mut crate::io::Writer,
         asset: crate::saver::SavedAsset<'_, '_, Self::Asset>,
         _settings: &Self::Settings,
+        _asset_path: AssetPath<'_>,
     ) -> Result<(), Self::Error> {
         use std::io::{Error, ErrorKind};
 
@@ -1301,6 +1302,7 @@ fn nested_loads_of_processed_asset_reprocesses_on_reload() {
             writer: &mut crate::io::Writer,
             asset: crate::saver::SavedAsset<'_, '_, Self::Asset>,
             _settings: &Self::Settings,
+            _asset_path: AssetPath<'_>,
         ) -> Result<<Self::OutputLoader as AssetLoader>::Settings, Self::Error> {
             let serialized = serialize_as_leaf(asset.get().value.clone());
             writer.write_all(serialized.as_bytes()).await

--- a/crates/bevy_asset/src/saver.rs
+++ b/crates/bevy_asset/src/saver.rs
@@ -43,6 +43,7 @@ pub trait AssetSaver: TypePath + Send + Sync + 'static {
         writer: &mut Writer,
         asset: SavedAsset<'_, '_, Self::Asset>,
         settings: &Self::Settings,
+        asset_path: AssetPath<'_>,
     ) -> impl ConditionalSendFuture<
         Output = Result<<Self::OutputLoader as AssetLoader>::Settings, Self::Error>,
     >;
@@ -57,6 +58,7 @@ pub trait ErasedAssetSaver: Send + Sync + 'static {
         writer: &'a mut Writer,
         asset: &'a ErasedLoadedAsset,
         settings: &'a dyn Settings,
+        asset_path: AssetPath<'a>,
     ) -> BoxedFuture<'a, Result<(), BevyError>>;
 
     /// The type name of the [`AssetSaver`].
@@ -69,13 +71,14 @@ impl<S: AssetSaver> ErasedAssetSaver for S {
         writer: &'a mut Writer,
         asset: &'a ErasedLoadedAsset,
         settings: &'a dyn Settings,
+        asset_path: AssetPath<'a>,
     ) -> BoxedFuture<'a, Result<(), BevyError>> {
         Box::pin(async move {
             let settings = settings
                 .downcast_ref::<S::Settings>()
                 .expect("AssetLoader settings should match the loader type");
             let saved_asset = SavedAsset::<S::Asset>::from_loaded(asset).unwrap();
-            if let Err(err) = self.save(writer, saved_asset, settings).await {
+            if let Err(err) = self.save(writer, saved_asset, settings, asset_path).await {
                 return Err(err.into());
             }
             Ok(())
@@ -536,7 +539,7 @@ pub async fn save_using_saver<S: AssetSaver>(
     let mut file_writer = writer.write(path.path()).await?;
 
     let loader_settings = saver
-        .save(&mut file_writer, asset, settings)
+        .save(&mut file_writer, asset, settings, path.clone())
         .await
         .map_err(|err| SaveAssetError::SaverError(Arc::new(err.into())))?;
 
@@ -577,7 +580,7 @@ pub(crate) mod tests {
     use crate::{
         saver::{save_using_saver, AssetSaver, SavedAsset, SavedAssetBuilder},
         tests::{create_app, run_app_until, CoolText, CoolTextLoader, CoolTextRon, SubText},
-        AssetApp, AssetServer, Assets,
+        AssetApp, AssetPath, AssetServer, Assets,
     };
 
     fn new_subtext(text: &str) -> SubText {
@@ -600,6 +603,7 @@ pub(crate) mod tests {
             writer: &mut crate::io::Writer,
             asset: SavedAsset<'_, '_, Self::Asset>,
             _: &Self::Settings,
+            _: AssetPath<'_>,
         ) -> Result<(), Self::Error> {
             // NOTE: We can't handle embedded dependencies in any way, since we need to write to
             // another file to do so.

--- a/crates/bevy_asset/src/server/loaders.rs
+++ b/crates/bevy_asset/src/server/loaders.rs
@@ -216,12 +216,12 @@ impl AssetLoaders {
 
         // Try extracting the extension from the path
         if let Some(full_extension) = asset_path.and_then(AssetPath::get_full_extension) {
-            if let Some(&index) = try_extension(full_extension.as_str()) {
+            if let Some(&index) = try_extension(full_extension) {
                 return self.get_by_index(index);
             }
 
             // Try secondary extensions from the path
-            for extension in AssetPath::iter_secondary_extensions(&full_extension) {
+            for extension in AssetPath::iter_secondary_extensions(full_extension) {
                 if let Some(&index) = try_extension(extension) {
                     return self.get_by_index(index);
                 }
@@ -269,8 +269,8 @@ impl AssetLoaders {
     pub(crate) fn get_by_path(&self, path: &AssetPath<'_>) -> Option<MaybeAssetLoader> {
         let extension = path.get_full_extension()?;
 
-        let result = core::iter::once(extension.as_str())
-            .chain(AssetPath::iter_secondary_extensions(&extension))
+        let result = core::iter::once(extension)
+            .chain(AssetPath::iter_secondary_extensions(extension))
             .filter_map(|extension| self.extension_to_loaders.get(extension)?.last().copied())
             .find_map(|index| self.get_by_index(index))?;
 

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -282,9 +282,9 @@ impl AssetServer {
                 };
             };
 
-            let mut extensions = vec![full_extension.clone()];
+            let mut extensions = vec![full_extension.to_string()];
             extensions.extend(
-                AssetPath::iter_secondary_extensions(&full_extension).map(ToString::to_string),
+                AssetPath::iter_secondary_extensions(full_extension).map(ToString::to_string),
             );
 
             MissingAssetLoaderForExtensionError { extensions }

--- a/crates/bevy_image/src/compressed_image_saver.rs
+++ b/crates/bevy_image/src/compressed_image_saver.rs
@@ -1,6 +1,9 @@
 use crate::{Image, ImageFormat, ImageFormatSetting, ImageLoader, ImageLoaderSettings};
 
-use bevy_asset::saver::{AssetSaver, SavedAsset};
+use bevy_asset::{
+    saver::{AssetSaver, SavedAsset},
+    AssetPath,
+};
 use bevy_reflect::TypePath;
 use futures_lite::AsyncWriteExt;
 use thiserror::Error;
@@ -33,6 +36,7 @@ impl AssetSaver for CompressedImageSaver {
         writer: &mut bevy_asset::io::Writer,
         image: SavedAsset<'_, '_, Self::Asset>,
         _settings: &Self::Settings,
+        _asset_path: AssetPath<'_>,
     ) -> Result<ImageLoaderSettings, Self::Error> {
         let is_srgb = image.texture_descriptor.format.is_srgb();
 

--- a/crates/bevy_image/src/lib.rs
+++ b/crates/bevy_image/src/lib.rs
@@ -36,6 +36,7 @@ mod hdr_texture_loader;
 mod image_loader;
 #[cfg(feature = "ktx2")]
 mod ktx2;
+mod saver;
 mod texture_atlas;
 mod texture_atlas_builder;
 
@@ -51,6 +52,7 @@ pub use hdr_texture_loader::*;
 pub use image_loader::*;
 #[cfg(feature = "ktx2")]
 pub use ktx2::*;
+pub use saver::*;
 pub use texture_atlas::*;
 pub use texture_atlas_builder::*;
 

--- a/crates/bevy_image/src/saver.rs
+++ b/crates/bevy_image/src/saver.rs
@@ -9,13 +9,14 @@ use wgpu_types::TextureFormat;
 
 use crate::{Image, ImageFormat, ImageFormatSetting, ImageLoader, ImageLoaderSettings};
 
-/// Saver for images that can be saved by the `image` crate.
+/// [`AssetSaver`] for images that can be saved by the `image` crate.
 ///
 /// Unlike `CompressedImageSaver`, this does not attempt to do any "texture optimization", like
 /// compression (though some file formats intrinsically perform some compression, e.g., JPEG).
 ///
-/// Some file formats do not support all texture formats. In some cases, [`ImageSaver`] will convert
-/// the image to allow writing as the requested file format.
+/// Some file formats do not support all texture formats (e.g., PNG does not support
+/// [`TextureFormat::Rg8Unorm`]). In some cases, [`ImageSaver`] will convert the image to allow
+/// writing as the requested file format.
 #[derive(Clone, TypePath)]
 pub struct ImageSaver;
 
@@ -135,17 +136,19 @@ pub enum SaveImageError {
     /// Cannot deduce file format from extension because there is no extension.
     #[error("SaveImageFormatSetting::FromExtension was set, but the asset path has no extension")]
     MissingExtension,
-    /// Cannot deduce file format from extension since this extension is unknown.
+    /// Cannot deduce file format from extension since this extension is unknown. Holds the
+    /// extension that could not be matched.
     #[error("could not determine asset format for extension \"{0}\"")]
     UnknownExtension(String),
-    /// [`Image::data`] is [`None`], so there is no data to save.
-    #[error("the provided image does not contain any pixel data. Its data may live on the GPU (which we can't save out)")]
+    /// [`Image::data`] is [`None`], so there is no data to save. See
+    /// [`RenderAssetUsages`](bevy_asset::RenderAssetUsages) for more.
+    #[error("the provided image does not contain any pixel data. Its data may live on the GPU (which we can't save out) due to `RenderAssetUsages`")]
     ImageMissingData,
     /// The image saver doesn't support the file format being requested.
     #[error("the requested file format {0:?} is not supported for saving")]
     UnsupportedFormat(ImageFormat),
-    /// The image saver doesn't support the format of the image data for the image format.
-    #[error("the image uses a color type \"{1:?}\" that is not supported for saving by the image format \"{0:?}\"")]
+    /// The image saver doesn't support the texture format of the image data for the image format.
+    #[error("the image uses a texture format \"{1:?}\" that is not supported for saving by the image format \"{0:?}\"")]
     UnsupportedSaveColorTypeForFormat(ImageFormat, TextureFormat),
     /// The [`image`] crate returned an error.
     #[error(transparent)]

--- a/crates/bevy_image/src/saver.rs
+++ b/crates/bevy_image/src/saver.rs
@@ -35,17 +35,10 @@ impl AssetSaver for ImageSaver {
     ) -> Result<ImageLoaderSettings, Self::Error> {
         let format = match settings.format {
             SaveImageFormatSetting::Format(format) => format,
-            SaveImageFormatSetting::FromExtension => match asset_path.get_full_extension() {
+            SaveImageFormatSetting::FromExtension => match asset_path.get_extension() {
                 None => return Err(SaveImageError::MissingExtension),
-                Some(mut extension) => {
-                    // Only include the last "segment" of the extension. Strip off anything before
-                    // the last dot.
-                    if let Some(index) = extension.rfind(".") {
-                        extension = &extension[(index + 1)..];
-                    }
-                    ImageFormat::from_extension(extension)
-                        .ok_or_else(|| SaveImageError::UnknownExtension(extension.to_owned()))?
-                }
+                Some(extension) => ImageFormat::from_extension(extension)
+                    .ok_or_else(|| SaveImageError::UnknownExtension(extension.to_owned()))?,
             },
         };
 

--- a/crates/bevy_image/src/saver.rs
+++ b/crates/bevy_image/src/saver.rs
@@ -1,6 +1,6 @@
 use std::io::Cursor;
 
-use bevy_asset::{saver::AssetSaver, AsyncWriteExt};
+use bevy_asset::{saver::AssetSaver, AssetPath, AsyncWriteExt};
 use bevy_reflect::TypePath;
 use image::{write_buffer_with_format, ExtendedColorType};
 use serde::{Deserialize, Serialize};
@@ -31,12 +31,12 @@ impl AssetSaver for ImageSaver {
         _writer: &mut bevy_asset::io::Writer,
         asset: bevy_asset::saver::SavedAsset<'_, '_, Self::Asset>,
         settings: &Self::Settings,
-        asset_path: bevy_asset::AssetPath<'_>,
+        asset_path: AssetPath<'_>,
     ) -> Result<ImageLoaderSettings, Self::Error> {
         let format = match settings.format {
             SaveImageFormatSetting::Format(format) => format,
             SaveImageFormatSetting::FromExtension => match asset_path.get_extension() {
-                None => return Err(SaveImageError::MissingExtension),
+                None => return Err(SaveImageError::MissingExtension(asset_path.into_owned())),
                 Some(extension) => ImageFormat::from_extension(extension)
                     .ok_or_else(|| SaveImageError::UnknownExtension(extension.to_owned()))?,
             },
@@ -127,8 +127,8 @@ pub enum SaveImageFormatSetting {
 #[derive(Error, Debug)]
 pub enum SaveImageError {
     /// Cannot deduce file format from extension because there is no extension.
-    #[error("SaveImageFormatSetting::FromExtension was set, but the asset path has no extension")]
-    MissingExtension,
+    #[error("SaveImageFormatSetting::FromExtension was set, but the asset path \"{0}\" has no extension")]
+    MissingExtension(AssetPath<'static>),
     /// Cannot deduce file format from extension since this extension is unknown. Holds the
     /// extension that could not be matched.
     #[error("could not determine asset format for extension \"{0}\"")]

--- a/crates/bevy_image/src/saver.rs
+++ b/crates/bevy_image/src/saver.rs
@@ -1,0 +1,351 @@
+use std::io::Cursor;
+
+use bevy_asset::{saver::AssetSaver, AsyncWriteExt};
+use bevy_reflect::TypePath;
+use image::{write_buffer_with_format, ExtendedColorType};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use wgpu_types::TextureFormat;
+
+use crate::{Image, ImageFormat, ImageFormatSetting, ImageLoader, ImageLoaderSettings};
+
+/// Saver for images that can be saved by the `image` crate.
+///
+/// Unlike `CompressedImageSaver`, this does not attempt to do any "texture optimization", like
+/// compression (though some file formats intrinsically perform some compression, e.g., JPEG).
+///
+/// Some file formats do not support all texture formats. In some cases, [`ImageSaver`] will convert
+/// the image to allow writing as the requested file format.
+#[derive(Clone, TypePath)]
+pub struct ImageSaver;
+
+impl AssetSaver for ImageSaver {
+    type Asset = Image;
+    type Error = SaveImageError;
+    type OutputLoader = ImageLoader;
+    type Settings = ImageSaverSettings;
+
+    async fn save(
+        &self,
+        _writer: &mut bevy_asset::io::Writer,
+        asset: bevy_asset::saver::SavedAsset<'_, '_, Self::Asset>,
+        settings: &Self::Settings,
+        asset_path: bevy_asset::AssetPath<'_>,
+    ) -> Result<ImageLoaderSettings, Self::Error> {
+        let format = match settings.format {
+            SaveImageFormatSetting::Format(format) => format,
+            SaveImageFormatSetting::FromExtension => match asset_path.get_full_extension() {
+                None => return Err(SaveImageError::MissingExtension),
+                Some(mut extension) => {
+                    // Only include the last "segment" of the extension. Strip off anything before
+                    // the last dot.
+                    if let Some(index) = extension.rfind(".") {
+                        extension = &extension[(index + 1)..];
+                    }
+                    ImageFormat::from_extension(extension)
+                        .ok_or_else(|| SaveImageError::UnknownExtension(extension.to_owned()))?
+                }
+            },
+        };
+
+        let Some(_asset_data) = asset.data.as_ref() else {
+            return Err(SaveImageError::ImageMissingData);
+        };
+
+        // TODO: Consider supporting more formats here!
+        let (image_crate_format, color_type, is_srgb): (_, ExtendedColorType, _) = match format {
+            #[cfg(feature = "png")]
+            ImageFormat::Png => match asset.texture_descriptor.format {
+                TextureFormat::R8Unorm => (image::ImageFormat::Png, ExtendedColorType::L8, false),
+                TextureFormat::Rgba8Unorm => {
+                    (image::ImageFormat::Png, ExtendedColorType::Rgba8, false)
+                }
+                TextureFormat::Rgba8UnormSrgb => {
+                    (image::ImageFormat::Png, ExtendedColorType::Rgba8, true)
+                }
+                _ => {
+                    return Err(SaveImageError::UnsupportedSaveColorTypeForFormat(
+                        ImageFormat::Png,
+                        asset.texture_descriptor.format,
+                    ))
+                }
+            },
+            // FIXME: https://github.com/rust-lang/rust/issues/129031
+            #[expect(
+                clippy::allow_attributes,
+                reason = "`unreachable_patterns` may not always lint"
+            )]
+            #[allow(
+                unreachable_patterns,
+                reason = "The wildcard pattern will be unreachable if only save-able formats are enabled"
+            )]
+            _ => return Err(SaveImageError::UnsupportedFormat(format)),
+        };
+
+        #[expect(clippy::allow_attributes, reason = "this lint only sometimes lints")]
+        #[allow(
+            unreachable_code,
+            reason = "this code is unreachable if none of the supported save formats are enabled"
+        )]
+        let mut bytes = vec![];
+        write_buffer_with_format(
+            &mut Cursor::new(&mut bytes),
+            _asset_data,
+            asset.width(),
+            asset.height(),
+            color_type,
+            image_crate_format,
+        )?;
+
+        _writer.write_all(&bytes).await?;
+
+        Ok(ImageLoaderSettings {
+            format: ImageFormatSetting::Format(format),
+            // Passing in the original texture format breaks things. For example, PNG will save R8
+            // data as RGBA8 data: if we later try to load as R8, we get 4 times as many pixels!
+            texture_format: None,
+            is_srgb,
+            sampler: asset.sampler.clone(),
+            asset_usage: asset.asset_usage,
+            array_layout: None,
+        })
+    }
+}
+
+/// Settings for how to save an image.
+#[derive(Serialize, Deserialize, Default, Clone, Debug)]
+pub struct ImageSaverSettings {
+    /// Defines the file format that the image will be saved as.
+    pub format: SaveImageFormatSetting,
+}
+
+/// The setting for how to choose which file-format to use.
+#[derive(Serialize, Deserialize, Default, Clone, Copy, Debug)]
+pub enum SaveImageFormatSetting {
+    /// The file format to write will be deduced from the file path being written to.
+    #[default]
+    FromExtension,
+    /// This is the explicit file format being written.
+    Format(ImageFormat),
+}
+
+/// An error while saving an image.
+#[derive(Error, Debug)]
+pub enum SaveImageError {
+    /// Cannot deduce file format from extension because there is no extension.
+    #[error("SaveImageFormatSetting::FromExtension was set, but the asset path has no extension")]
+    MissingExtension,
+    /// Cannot deduce file format from extension since this extension is unknown.
+    #[error("could not determine asset format for extension \"{0}\"")]
+    UnknownExtension(String),
+    /// [`Image::data`] is [`None`], so there is no data to save.
+    #[error("the provided image does not contain any pixel data. Its data may live on the GPU (which we can't save out)")]
+    ImageMissingData,
+    /// The image saver doesn't support the file format being requested.
+    #[error("the requested file format {0:?} is not supported for saving")]
+    UnsupportedFormat(ImageFormat),
+    /// The image saver doesn't support the format of the image data for the image format.
+    #[error("the image uses a color type \"{1:?}\" that is not supported for saving by the image format \"{0:?}\"")]
+    UnsupportedSaveColorTypeForFormat(ImageFormat, TextureFormat),
+    /// The [`image`] crate returned an error.
+    #[error(transparent)]
+    ImageError(#[from] image::ImageError),
+    /// Writing the bytes returned an error.
+    #[error(transparent)]
+    IoError(#[from] std::io::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use bevy_app::{App, TaskPoolPlugin};
+    use bevy_asset::{
+        io::{
+            memory::{Dir, MemoryAssetReader, MemoryAssetWriter},
+            AssetSourceBuilder, AssetSourceId,
+        },
+        saver::{save_using_saver, SavedAsset},
+        AssetApp, AssetPath, AssetPlugin, AssetServer, Assets, RenderAssetUsages,
+    };
+    use bevy_color::Srgba;
+    use bevy_ecs::world::World;
+    use bevy_math::UVec2;
+    use bevy_platform::future::block_on;
+    use wgpu_types::TextureFormat;
+
+    use crate::{
+        CompressedImageFormats, Image, ImageLoader, ImageSaver, ImageSaverSettings,
+        TextureFormatPixelInfo,
+    };
+
+    fn create_app() -> (App, Dir) {
+        let mut app = App::new();
+        let dir = Dir::default();
+        let dir_clone_1 = dir.clone();
+        let dir_clone_2 = dir.clone();
+        app.register_asset_source(
+            AssetSourceId::Default,
+            AssetSourceBuilder::new(move || {
+                Box::new(MemoryAssetReader {
+                    root: dir_clone_1.clone(),
+                })
+            })
+            .with_writer(move |_| {
+                Some(Box::new(MemoryAssetWriter {
+                    root: dir_clone_2.clone(),
+                }))
+            }),
+        )
+        .add_plugins((
+            TaskPoolPlugin::default(),
+            AssetPlugin {
+                watch_for_changes_override: Some(false),
+                use_asset_processor_override: Some(false),
+                ..Default::default()
+            },
+        ))
+        .init_asset::<Image>()
+        .register_asset_loader(ImageLoader::new(CompressedImageFormats::empty()));
+
+        (app, dir)
+    }
+
+    fn run_app_until(app: &mut App, mut predicate: impl FnMut(&mut World) -> Option<()>) {
+        const LARGE_ITERATION_COUNT: usize = 10000;
+        for _ in 0..LARGE_ITERATION_COUNT {
+            app.update();
+            if predicate(app.world_mut()).is_some() {
+                return;
+            }
+        }
+
+        panic!("Ran out of loops to return `Some` from `predicate`");
+    }
+
+    #[expect(clippy::allow_attributes, reason = "only occasionally unused")]
+    #[allow(unused, reason = "only used for feature-flagged image formats")]
+    fn roundtrip_for_type(file_name: &str, color_type: TextureFormat) {
+        let (mut app, dir) = create_app();
+        let asset_server = app.world().resource::<AssetServer>().clone();
+
+        let asset_path = AssetPath::from_path(Path::new(file_name));
+
+        const WIDTH: u32 = 5;
+        let mut image = Image::new(
+            wgpu_types::Extent3d {
+                width: WIDTH,
+                height: WIDTH,
+                depth_or_array_layers: 1,
+            },
+            wgpu_types::TextureDimension::D2,
+            vec![0; color_type.pixel_size().unwrap() * WIDTH as usize * WIDTH as usize],
+            color_type,
+            RenderAssetUsages::all(),
+        );
+        for y in 0..WIDTH {
+            for x in 0..WIDTH {
+                image
+                    .set_color_at(
+                        x,
+                        y,
+                        Srgba::new(
+                            (x + 1) as f32 / WIDTH as f32,
+                            (y + 1) as f32 / WIDTH as f32,
+                            (x + y + 2) as f32 / (2 * WIDTH) as f32,
+                            1.0,
+                        )
+                        .into(),
+                    )
+                    .unwrap();
+            }
+        }
+
+        {
+            let asset_server = asset_server.clone();
+            let image = image.clone();
+            let asset_path = asset_path.clone_owned();
+            block_on(async move {
+                let saved_asset = SavedAsset::from_asset(&image);
+                save_using_saver(
+                    asset_server,
+                    &ImageSaver,
+                    &asset_path,
+                    saved_asset,
+                    &ImageSaverSettings::default(),
+                )
+                .await
+            })
+            .unwrap();
+        }
+
+        assert!(dir.get_asset(asset_path.path()).is_some());
+
+        let handle = asset_server.load::<Image>(asset_path);
+        run_app_until(&mut app, |_| asset_server.is_loaded(&handle).then_some(()));
+
+        let loaded_image = app
+            .world()
+            .resource::<Assets<Image>>()
+            .get(&handle)
+            .unwrap();
+
+        assert_eq!(loaded_image.size(), UVec2::new(WIDTH, WIDTH));
+        let compare_images = 'compare_images: {
+            for y in 0..WIDTH {
+                for x in 0..WIDTH {
+                    if image.get_color_at(x, y).unwrap() != loaded_image.get_color_at(x, y).unwrap()
+                    {
+                        break 'compare_images Err((x, y));
+                    }
+                }
+            }
+            Ok(())
+        };
+
+        if let Err((x, y)) = compare_images {
+            fn image_to_string(image: &Image) -> String {
+                (0..WIDTH)
+                    .map(|y| {
+                        (0..WIDTH)
+                            .map(|x| {
+                                let color = image.get_color_at(x, y).unwrap().to_srgba();
+                                format!(
+                                    "({},{},{})",
+                                    (color.red * 255.0) as u32,
+                                    (color.green * 255.0) as u32,
+                                    (color.blue * 255.0) as u32,
+                                )
+                            })
+                            .collect::<Vec<_>>()
+                            .join(" ")
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            }
+            panic!(
+                "Mismatch in color at ({x}, {y})\nleft:\n{}\nright:\n{}",
+                image_to_string(loaded_image),
+                image_to_string(&image)
+            );
+        }
+    }
+
+    #[cfg(feature = "png")]
+    mod png_tests {
+        use super::*;
+
+        #[test]
+        fn roundtrip_png_r8_unorm() {
+            roundtrip_for_type("image.png", TextureFormat::R8Unorm);
+        }
+        #[test]
+        fn roundtrip_png_rgba8_unorm_srgb() {
+            roundtrip_for_type("image.png", TextureFormat::Rgba8UnormSrgb);
+        }
+        #[test]
+        fn roundtrip_png_rgba8_unorm() {
+            roundtrip_for_type("image.png", TextureFormat::Rgba8Unorm);
+        }
+    }
+}

--- a/crates/bevy_pbr/src/meshlet/asset.rs
+++ b/crates/bevy_pbr/src/meshlet/asset.rs
@@ -2,7 +2,7 @@ use alloc::sync::Arc;
 use bevy_asset::{
     io::{Reader, Writer},
     saver::{AssetSaver, SavedAsset},
-    Asset, AssetLoader, AsyncReadExt, AsyncWriteExt, LoadContext,
+    Asset, AssetLoader, AssetPath, AsyncReadExt, AsyncWriteExt, LoadContext,
 };
 use bevy_math::{Vec2, Vec3};
 use bevy_reflect::TypePath;
@@ -159,6 +159,7 @@ impl AssetSaver for MeshletMeshSaver {
         writer: &mut Writer,
         asset: SavedAsset<'_, '_, MeshletMesh>,
         _settings: &(),
+        _asset_path: AssetPath<'_>,
     ) -> Result<(), MeshletMeshSaveOrLoadError> {
         // Write asset magic number
         writer

--- a/examples/README.md
+++ b/examples/README.md
@@ -257,7 +257,8 @@ Example | Description
 [Asset Decompression](../examples/asset/asset_decompression.rs) | Demonstrates loading a compressed asset
 [Asset Loading](../examples/asset/asset_loading.rs) | Demonstrates various methods to load assets
 [Asset Processing](../examples/asset/processing/asset_processing.rs) | Demonstrates how to process and load custom assets
-[Asset Saving](../examples/asset/asset_saving.rs) | Demonstrates how to save an asset (with subassets)
+[Asset Saving](../examples/asset/asset_saving.rs) | Demonstrates how to save an asset
+[Asset Saving with Subassets](../examples/asset/asset_saving_with_subassets.rs) | Demonstrates how to save an asset with subassets
 [Asset Settings](../examples/asset/asset_settings.rs) | Demonstrates various methods of applying settings when loading an asset
 [Custom Asset](../examples/asset/custom_asset.rs) | Implements a custom asset loader
 [Custom Asset IO](../examples/asset/custom_asset_reader.rs) | Implements a custom AssetReader

--- a/examples/asset/asset_saving.rs
+++ b/examples/asset/asset_saving.rs
@@ -4,7 +4,7 @@ use bevy::{
     asset::{
         io::{Reader, Writer},
         saver::{save_using_saver, AssetSaver, SavedAsset, SavedAssetBuilder},
-        AssetLoader, AsyncWriteExt, LoadContext,
+        AssetLoader, AssetPath, AsyncWriteExt, LoadContext,
     },
     color::palettes::tailwind,
     input::common_conditions::input_just_pressed,
@@ -171,6 +171,7 @@ impl AssetSaver for ManyBoxesSaver {
         writer: &mut Writer,
         asset: SavedAsset<'_, '_, Self::Asset>,
         _settings: &Self::Settings,
+        _asset_path: AssetPath<'_>,
     ) -> Result<(), Self::Error> {
         let boxes = asset
             .boxes

--- a/examples/asset/asset_saving.rs
+++ b/examples/asset/asset_saving.rs
@@ -1,0 +1,296 @@
+//! This example demonstrates how to save assets in the common case where the asset contains no
+//! subassets.
+
+use bevy::{
+    asset::{
+        saver::{save_using_saver, SavedAsset},
+        RenderAssetUsages,
+    },
+    camera::ScalingMode,
+    color::palettes::tailwind,
+    image::{ImageLoaderSettings, ImageSampler, ImageSaver, ImageSaverSettings},
+    input::common_conditions::input_just_pressed,
+    picking::pointer::Location,
+    prelude::*,
+    render::render_resource::{Extent3d, TextureDimension, TextureFormat},
+    sprite::Anchor,
+    tasks::IoTaskPool,
+};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins.set(AssetPlugin {
+            // This is just overriding the default asset paths to scope this to the correct example
+            // folder. You can generally skip this in your own projects.
+            file_path: "examples/asset/saved_assets".to_string(),
+            ..Default::default()
+        }))
+        .add_plugins(image_drawing_plugin)
+        .add_systems(
+            PreUpdate,
+            perform_save.run_if(input_just_pressed(KeyCode::F5)),
+        )
+        .run();
+}
+
+const ASSET_PATH: &str = "art_project.png";
+
+fn perform_save(
+    image_to_save: Res<ImageToSave>,
+    images: Res<Assets<Image>>,
+    asset_server: Res<AssetServer>,
+) {
+    let image = images.get(&image_to_save.0).unwrap();
+
+    let image = image.clone();
+    let asset_server = asset_server.clone();
+    IoTaskPool::get()
+        .spawn(async move {
+            match save_using_saver(
+                asset_server.clone(),
+                &ImageSaver,
+                &ASSET_PATH.into(),
+                SavedAsset::from_asset(&image),
+                &ImageSaverSettings::default(),
+            )
+            .await
+            {
+                Ok(()) => info!("Completed save of {ASSET_PATH}"),
+                Err(err) => error!("Failed to save asset: {err}"),
+            }
+        })
+        .detach();
+}
+
+/// Plugin for doing image drawing.
+///
+/// This doesn't really have anything to do with asset saving, but provides a real-use case.
+fn image_drawing_plugin(app: &mut App) {
+    app.add_systems(Startup, setup)
+        .add_observer(on_drag_start)
+        .add_observer(on_drag)
+        .add_observer(try_plot)
+        .init_resource::<DrawColor>()
+        .add_observer(on_enter_selectable)
+        .add_observer(on_leave_selectable)
+        .add_observer(on_press_selectable);
+}
+
+#[derive(Resource)]
+struct ImageToSave(Handle<Image>);
+
+#[derive(Component)]
+struct SpriteToSave;
+
+fn setup(
+    mut commands: Commands,
+    asset_server: Res<AssetServer>,
+    mut images: ResMut<Assets<Image>>,
+) {
+    commands.spawn((
+        Camera2d,
+        Projection::Orthographic(OrthographicProjection {
+            scaling_mode: ScalingMode::FixedVertical {
+                viewport_height: 125.0,
+            },
+            ..OrthographicProjection::default_2d()
+        }),
+    ));
+
+    commands.spawn(Text(
+        r"Select a color from the palette at the top
+LMB - Draw with selected color
+F5 - Save image"
+            .into(),
+    ));
+
+    let handle =
+        asset_server.load_with_settings(ASSET_PATH, |settings: &mut ImageLoaderSettings| {
+            settings.sampler = ImageSampler::nearest();
+        });
+    commands.spawn((
+        Sprite {
+            image: handle.clone(),
+            ..Default::default()
+        },
+        SpriteToSave,
+        Pickable::default(),
+    ));
+
+    // We're doing something a little cursed here: we initiate a load, and then insert a default
+    // image into that handle. If the load succeeds, the image will be replaced with the loaded
+    // contents. If it fails, the default image will remain. In real code, you likely want to poll
+    // `AssetServer::load_state` and only insert this on load failure.
+    images
+        .insert(&handle, {
+            let mut image = Image::new_fill(
+                Extent3d {
+                    width: 100,
+                    height: 100,
+                    depth_or_array_layers: 1,
+                },
+                TextureDimension::D2,
+                &[0, 0, 0, 255],
+                TextureFormat::Rgba8Unorm,
+                RenderAssetUsages::all(),
+            );
+            image.sampler = ImageSampler::nearest();
+            image
+        })
+        .unwrap();
+
+    commands.insert_resource(ImageToSave(handle));
+
+    let container = commands
+        .spawn((
+            Node {
+                width: Val::Percent(100.0),
+                height: Val::Percent(100.0),
+                align_content: AlignContent::End,
+                justify_content: JustifyContent::Center,
+                ..Default::default()
+            },
+            Pickable::IGNORE,
+        ))
+        .id();
+
+    for color in [
+        Color::WHITE,
+        Color::Srgba(tailwind::RED_500),
+        Color::Srgba(tailwind::ORANGE_500),
+        Color::Srgba(tailwind::YELLOW_500),
+        Color::Srgba(tailwind::GREEN_500),
+        Color::Srgba(tailwind::BLUE_500),
+        Color::Srgba(tailwind::INDIGO_500),
+        Color::Srgba(tailwind::VIOLET_500),
+        Color::BLACK,
+    ] {
+        let mut entity = commands.spawn((
+            Node {
+                width: Val::Vw(5.0),
+                height: Val::Vh(5.0),
+                border: UiRect::all(Val::Px(5.0)),
+                ..Default::default()
+            },
+            SelectableColor,
+            BackgroundColor(color),
+            BorderColor::all(NORMAL_COLOR),
+            ChildOf(container),
+        ));
+        if color == Color::WHITE {
+            entity.insert((Selected, BorderColor::all(SELECTED_COLOR)));
+        }
+    }
+}
+
+#[derive(EntityEvent)]
+struct TryPlot {
+    entity: Entity,
+    location: Location,
+}
+
+fn on_drag_start(event: On<Pointer<DragStart>>, mut commands: Commands) {
+    commands.trigger(TryPlot {
+        entity: event.entity,
+        location: event.pointer_location.clone(),
+    });
+}
+
+fn on_drag(event: On<Pointer<Drag>>, mut commands: Commands) {
+    commands.trigger(TryPlot {
+        entity: event.entity,
+        location: event.pointer_location.clone(),
+    });
+}
+
+fn try_plot(
+    event: On<TryPlot>,
+    sprite: Query<(&Sprite, &Anchor, &GlobalTransform), With<SpriteToSave>>,
+    camera: Single<(&Camera, &GlobalTransform)>,
+    texture_atlases: Res<Assets<TextureAtlasLayout>>,
+    draw_color: Res<DrawColor>,
+    mut images: ResMut<Assets<Image>>,
+) {
+    let Ok((sprite, anchor, sprite_transform)) = sprite.get(event.entity) else {
+        return;
+    };
+    let (camera, camera_transform) = camera.into_inner();
+    let Ok(world_position) = camera.viewport_to_world_2d(camera_transform, event.location.position)
+    else {
+        return;
+    };
+    let relative_to_sprite = sprite_transform
+        .affine()
+        .inverse()
+        .transform_point3(world_position.extend(0.0));
+    let Ok(pixel_space) = sprite.compute_pixel_space_point(
+        relative_to_sprite.xy(),
+        *anchor,
+        &images,
+        &texture_atlases,
+    ) else {
+        return;
+    };
+    let pixel_coordinates = pixel_space.floor().as_uvec2();
+    let mut image = images.get_mut(&sprite.image).unwrap();
+    // For an actual drawing app, you'd at least draw a line from the last point, but this is
+    // simpler.
+    image
+        .set_color_at(pixel_coordinates.x, pixel_coordinates.y, draw_color.0)
+        .unwrap();
+}
+
+#[derive(Resource, Default)]
+struct DrawColor(Color);
+
+#[derive(Component)]
+struct SelectableColor;
+
+#[derive(Component)]
+struct Selected;
+
+const NORMAL_COLOR: Color = Color::BLACK;
+const HIGHLIGHT_COLOR: Color = Color::Srgba(tailwind::NEUTRAL_500);
+const SELECTED_COLOR: Color = Color::Srgba(tailwind::RED_600);
+
+fn on_enter_selectable(
+    event: On<Pointer<Enter>>,
+    mut border: Query<&mut BorderColor, (With<SelectableColor>, Without<Selected>)>,
+) {
+    let Ok(mut border) = border.get_mut(event.entity) else {
+        return;
+    };
+
+    *border = BorderColor::all(HIGHLIGHT_COLOR);
+}
+
+fn on_leave_selectable(
+    event: On<Pointer<Leave>>,
+    mut border: Query<&mut BorderColor, (With<SelectableColor>, Without<Selected>)>,
+) {
+    let Ok(mut border) = border.get_mut(event.entity) else {
+        return;
+    };
+
+    *border = BorderColor::all(NORMAL_COLOR);
+}
+
+fn on_press_selectable(
+    event: On<Pointer<Press>>,
+    mut borders: Query<(Entity, &mut BorderColor, &BackgroundColor), With<SelectableColor>>,
+    mut draw_color: ResMut<DrawColor>,
+    mut commands: Commands,
+) {
+    if !borders.contains(event.entity) {
+        return;
+    }
+    for (entity, mut border, _) in borders.iter_mut() {
+        commands.entity(entity).remove::<Selected>();
+        *border = BorderColor::all(NORMAL_COLOR);
+    }
+    let (_, mut border, background_color) = borders.get_mut(event.entity).unwrap();
+    *border = BorderColor::all(SELECTED_COLOR);
+    commands.entity(event.entity).insert(Selected);
+
+    draw_color.0 = background_color.0;
+}

--- a/examples/asset/asset_saving.rs
+++ b/examples/asset/asset_saving.rs
@@ -98,7 +98,7 @@ fn setup(
     ));
 
     commands.spawn(Text(
-        r"Select a color from the palette at the top
+        r"Select a color from the palette at the bottom
 LMB - Draw with selected color
 F5 - Save image"
             .into(),
@@ -146,7 +146,7 @@ F5 - Save image"
             Node {
                 width: Val::Percent(100.0),
                 height: Val::Percent(100.0),
-                align_content: AlignContent::End,
+                align_items: AlignItems::End,
                 justify_content: JustifyContent::Center,
                 ..Default::default()
             },

--- a/examples/asset/asset_saving_with_subassets.rs
+++ b/examples/asset/asset_saving_with_subassets.rs
@@ -1,4 +1,4 @@
-//! This example demonstrates how to save assets.
+//! This example demonstrates how to save assets that include subassets.
 
 use bevy::{
     asset::{

--- a/examples/asset/processing/asset_processing.rs
+++ b/examples/asset/processing/asset_processing.rs
@@ -7,7 +7,7 @@ use bevy::{
         processor::LoadTransformAndSave,
         saver::{AssetSaver, SavedAsset},
         transformer::{AssetTransformer, TransformedAsset},
-        AssetLoader, AsyncWriteExt, LoadContext,
+        AssetLoader, AssetPath, AsyncWriteExt, LoadContext,
     },
     prelude::*,
     reflect::TypePath,
@@ -220,6 +220,7 @@ impl AssetSaver for CoolTextSaver {
         writer: &mut Writer,
         asset: SavedAsset<'_, '_, Self::Asset>,
         _settings: &Self::Settings,
+        _asset_path: AssetPath<'_>,
     ) -> Result<TextSettings, Self::Error> {
         writer.write_all(asset.text.as_bytes()).await?;
         Ok(TextSettings::default())

--- a/release-content/migration-guides/asset_saver_changes.md
+++ b/release-content/migration-guides/asset_saver_changes.md
@@ -1,10 +1,10 @@
 ---
-title: SavedAsset now contains two lifetimes.
+title: SavedAsset now contains two lifetimes, and AssetSaver now takes an AssetPath.
 pull_requests: []
 ---
 
 `SavedAsset` now holds two lifetimes instead of one. This is primarily used in the context of
-`AssetSaver`. So previously, users may have:
+`AssetSaver`. `AssetSaver` also now takes an `AssetPath`. So previously, users may have:
 
 ```rust
 impl AssetSaver for MySaver {
@@ -24,7 +24,7 @@ impl AssetSaver for MySaver {
 }
 ```
 
-Now with the extra `SavedAsset` lifetime:
+Now with the extra `SavedAsset` lifetime, and the extra `AssetPath`:
 
 ```rust
 impl AssetSaver for MySaver {
@@ -38,6 +38,7 @@ impl AssetSaver for MySaver {
         writer: &mut Writer,
         asset: SavedAsset<'_, '_, Self::Asset>,
         settings: &Self::Settings,
+        asset_path: AssetPath<'_>,
     ) -> Result<(), Self::Error> {
         todo!()
     }

--- a/release-content/migration-guides/get_full_extension.md
+++ b/release-content/migration-guides/get_full_extension.md
@@ -1,6 +1,6 @@
 ---
 title: get_full_extension now returns Option<&str>.
-pull_requests: [14791, 15458, 15269]
+pull_requests: [23105]
 ---
 
 Previously, `AssetPath::get_full_extension` returned `Option<String>`. Now it returns

--- a/release-content/migration-guides/get_full_extension.md
+++ b/release-content/migration-guides/get_full_extension.md
@@ -1,0 +1,17 @@
+---
+title: get_full_extension now returns Option<&str>.
+pull_requests: [14791, 15458, 15269]
+---
+
+Previously, `AssetPath::get_full_extension` returned `Option<String>`. Now it returns
+`Option<&str>`. To maintain behavior, change the following:
+
+```rust
+asset_path.get_full_extension()
+```
+
+To:
+
+```rust
+asset_path.get_full_extension().map(ToString::to_string)
+```


### PR DESCRIPTION
# Objective

- Allow users to save images.
- Make a "simple" example of asset saving (as opposed to the existing complex example).

## Solution

- Pass in the asset path to `AssetSaver`s.
- Make `get_full_extension` return a `&str` instead of an owned `String`.
- Created a new `ImageSaver` that currently only supports PNG.
    - We can extend this in the future if we want more support. It's not super straightforward since e.g., JPEG doesn't support alpha and wgpu TextureFormat doesn't have a regular RGB8 format.
- Renamed the old `asset_saving` example to `asset_saving_with_subassets`.
- Created a new `asset_saving` example which allows drawing an image and then saving it.

## Testing

- The new example works!