### PR TITLE
Implements post-process lens distortion effects

### DIFF
--- a/crates/bevy_post_process/src/effect_stack/lens_distortion.rs
+++ b/crates/bevy_post_process/src/effect_stack/lens_distortion.rs
@@ -39,7 +39,7 @@ pub struct LensDistortion {
     /// The overall strength of the distortion effect.
     ///
     /// Positive values typically produce **barrel distortion** (bulging outwards),
-    /// while negative values produce **cup-shaped distortion** (pinching inwards).
+    /// while negative values produce **pincushion distortion** (pinching inwards).
     /// This corresponds roughly to the radial distortion coefficient `k₁`
     /// in the simplified model.
     ///

--- a/crates/bevy_post_process/src/effect_stack/lens_distortion.rs
+++ b/crates/bevy_post_process/src/effect_stack/lens_distortion.rs
@@ -104,10 +104,7 @@ impl ExtractComponent for LensDistortion {
 
     fn extract_component(lens_distortion: QueryItem<'_, '_, Self::QueryData>) -> Option<Self::Out> {
         // Skip the postprocessing phase entirely if the intensity is negligible.
-        if abs(lens_distortion.intensity) > 1e-4
-            || lens_distortion.scale != DEFAULT_LENS_DISTORTION_SCALE
-            || lens_distortion.center != DEFAULT_LENS_DISTORTION_CENTER
-        {
+        if abs(lens_distortion.intensity) > 1e-4 {
             Some(lens_distortion.clone())
         } else {
             None

--- a/crates/bevy_post_process/src/effect_stack/lens_distortion.rs
+++ b/crates/bevy_post_process/src/effect_stack/lens_distortion.rs
@@ -1,0 +1,136 @@
+use bevy_ecs::{
+    component::Component,
+    query::{QueryItem, With},
+    system::lifetimeless::Read,
+};
+use bevy_math::{ops::abs, Vec2};
+use bevy_reflect::Reflect;
+use bevy_render::{
+    extract_component::ExtractComponent, render_resource::ShaderType, sync_component::SyncComponent,
+};
+
+/// The default lens distortion intensity amount.
+const DEFAULT_LENS_DISTORTION_INTENSITY: f32 = 0.5;
+
+/// The default lens distortion scale amount.
+const DEFAULT_LENS_DISTORTION_SCALE: f32 = 1.0;
+
+/// The default lens distortion multiplier.
+const DEFAULT_LENS_DISTORTION_MULTIPLIER: Vec2 = Vec2::ONE;
+
+/// The default lens distortion center.
+const DEFAULT_LENS_DISTORTION_CENTER: Vec2 = Vec2::splat(0.5);
+
+/// The default lens distortion edge curvature.
+const DEFAULT_LENS_DISTORTION_EDGE_CURVATURE: f32 = 0.0;
+
+/// Simulates the warping of the image caused by real-world camera lenses.
+///
+/// [Lens distortion] simulates the imperfections of optical systems, where
+/// straight lines in the real world appear curved in the image. This effect
+/// is commonly used to create a sense of unease or disorientation, to mimic
+/// specific camera equipment, or to enhance the scale and immersion of scenes.
+///
+/// Bevy's implementation is based on a simplified special case of the
+/// Brown-Conrady model, where p₁ = p₂ = 0 and control is retained only
+/// for k₁ and k₂.
+#[derive(Reflect, Component, Clone)]
+pub struct LensDistortion {
+    /// The overall strength of the distortion effect.
+    ///
+    /// Positive values typically produce **barrel distortion** (bulging outwards),
+    /// while negative values produce **cup-shaped distortion** (pinching inwards).
+    /// This corresponds roughly to the radial distortion coefficient `k₁`
+    /// in the simplified model.
+    ///
+    /// The default value is 0.5.
+    pub intensity: f32,
+    /// A global scale factor applied to the final distorted image.
+    ///
+    /// Strong distortion pushes pixels away from the center or pulls them in,
+    /// resulting in visible **stretching artifacts** at the screen edges.
+    /// Increasing this value zooms in to **crop out** these extreme edge artifacts,
+    /// ensuring the screen remains fully covered at the cost of a tighter field of view.
+    ///
+    /// The default value is 1.0(No zoom).
+    pub scale: f32,
+    /// A multiplier that determines how the distortion scales along the X and Y axes.
+    ///
+    /// By default, this should be `Vec2::ONE` for uniform radial distortion.
+    /// Modifying these values allows for anamorphic-like effects where the distortion
+    /// is stronger on one axis than the other. When a component of multiplier is set to 0.0,
+    /// no distortion effect is applied.
+    ///
+    /// The default value is `Vec2::ONE`
+    pub multiplier: Vec2,
+    /// The center point of the distortion effect in UV space `[0.0, 1.0]`.
+    ///
+    /// Distortion radiates outward or inward from this point.
+    ///
+    /// The default value is `Vec2::splat(0.5)`
+    pub center: Vec2,
+    /// Controls the sharpness of the distortion curve near the screen edges.
+    ///
+    /// `edge_curvature` provides indirect control over the k₂ parameter.
+    /// The reason for indirect control is that k₁ and k₂ are typically correlated.
+    /// If k₂ did not vary with k₁, it would easily cause visual jumping when intensity
+    /// transitions from positive to negative. Furthermore, improper configuration of
+    /// the k₂ parameter can result in unnatural distortion artifacts. In most cases,
+    /// setting k₂ to 0.0 is appropriate.
+    ///
+    /// The default value is 0.0.
+    pub edge_curvature: f32,
+}
+
+impl Default for LensDistortion {
+    fn default() -> Self {
+        Self {
+            intensity: DEFAULT_LENS_DISTORTION_INTENSITY,
+            scale: DEFAULT_LENS_DISTORTION_SCALE,
+            multiplier: DEFAULT_LENS_DISTORTION_MULTIPLIER,
+            center: DEFAULT_LENS_DISTORTION_CENTER,
+            edge_curvature: DEFAULT_LENS_DISTORTION_EDGE_CURVATURE,
+        }
+    }
+}
+
+impl SyncComponent for LensDistortion {
+    type Out = Self;
+}
+
+impl ExtractComponent for LensDistortion {
+    type QueryData = Read<LensDistortion>;
+    type QueryFilter = With<LensDistortion>;
+
+    fn extract_component(lens_distortion: QueryItem<'_, '_, Self::QueryData>) -> Option<Self::Out> {
+        // Skip the postprocessing phase entirely if the intensity is negligible.
+        if abs(lens_distortion.intensity) > 1e-4
+            || lens_distortion.scale != DEFAULT_LENS_DISTORTION_SCALE
+            || lens_distortion.center != DEFAULT_LENS_DISTORTION_CENTER
+        {
+            Some(lens_distortion.clone())
+        } else {
+            None
+        }
+    }
+}
+
+/// The on-GPU version of the [`LensDistortion`] settings.
+///
+/// See the documentation for [`LensDistortion`] for more information on
+/// each of these fields.
+#[derive(ShaderType, Default)]
+pub struct LensDistortionUniform {
+    /// The overall strength of the distortion effect.
+    pub(super) intensity: f32,
+    /// A global scale factor applied to the final distorted image.
+    pub(super) scale: f32,
+    /// A multiplier that determines how the distortion scales along the X and Y axes.
+    pub(super) multiplier: Vec2,
+    /// The center point of the distortion effect in UV space `[0.0, 1.0]`.
+    pub(super) center: Vec2,
+    /// Controls the sharpness of the distortion curve near the screen edges.
+    pub(super) edge_curvature: f32,
+    /// Padding data.
+    pub(super) unused: u32,
+}

--- a/crates/bevy_post_process/src/effect_stack/lens_distortion.rs
+++ b/crates/bevy_post_process/src/effect_stack/lens_distortion.rs
@@ -1,0 +1,137 @@
+use bevy_ecs::{
+    component::Component,
+    query::{QueryItem, With},
+    system::lifetimeless::Read,
+};
+use bevy_math::{ops::abs, Vec2};
+use bevy_reflect::Reflect;
+use bevy_render::{
+    extract_component::ExtractComponent, render_resource::ShaderType, sync_component::SyncComponent,
+};
+
+/// The default lens distortion intensity amount.
+const DEFAULT_LENS_DISTORTION_INTENSITY: f32 = 0.5;
+
+/// The default lens distortion scale amount.
+const DEFAULT_LENS_DISTORTION_SCALE: f32 = 1.0;
+
+/// The default lens distortion multiplier.
+const DEFAULT_LENS_DISTORTION_MULTIPLIER: Vec2 = Vec2::ONE;
+
+/// The default lens distortion center.
+const DEFAULT_LENS_DISTORTION_CENTER: Vec2 = Vec2::splat(0.5);
+
+/// The default lens distortion edge curvature.
+const DEFAULT_LENS_DISTORTION_EDGE_CURVATURE: f32 = 0.0;
+
+/// Simulates the warping of the image caused by real-world camera lenses.
+///
+/// [Lens distortion] simulates the imperfections of optical systems, where
+/// straight lines in the real world appear curved in the image. This effect
+/// is commonly used to create a sense of unease or disorientation, to mimic
+/// specific camera equipment, or to enhance the scale and immersion of scenes.
+///
+/// Bevy's implementation is based on a simplified special case of the
+/// Brown-Conrady model, where p₁ = p₂ = 0 and control is retained only
+/// for k₁ and k₂.
+#[derive(Reflect, Component, Clone)]
+pub struct LensDistortion {
+    /// The overall strength of the distortion effect.
+    ///
+    /// Positive values typically produce **barrel distortion** (bulging outwards),
+    /// while negative values produce **cup-shaped distortion** (pinching inwards).
+    /// This corresponds roughly to the radial distortion coefficient `k₁`
+    /// in the simplified model.
+    ///
+    /// The default value is 0.5.
+    pub intensity: f32,
+    /// A global scale factor applied to the final distorted image.
+    ///
+    /// Strong distortion pushes pixels away from the center or pulls them in,
+    /// resulting in visible **stretching artifacts** at the screen edges.
+    /// Increasing this value zooms in to **crop out** these extreme edge artifacts,
+    /// ensuring the screen remains fully covered at the cost of a tighter field of view.
+    ///
+    /// The default value is 1.0(No zoom).
+    pub scale: f32,
+    /// A multiplier that determines how the distortion scales along the X and Y axes.
+    ///
+    /// By default, this should be `Vec2::ONE` for uniform radial distortion.
+    /// Modifying these values allows for anamorphic-like effects where the distortion
+    /// is stronger on one axis than the other. When a component of multiplier is set to 0.0,
+    /// no distortion effect is applied.
+    ///
+    /// The default value is `Vec2::ONE`
+    pub multiplier: Vec2,
+    /// The center point of the distortion effect in UV space `[0.0, 1.0]`.
+    ///
+    /// Distortion radiates outward or inward from this point.
+    ///
+    /// The default value is `Vec2::splat(0.5)`
+    pub center: Vec2,
+    /// Controls the sharpness of the distortion curve near the screen edges.
+    ///
+    /// `edge_curvature` provides indirect control over the k₂ parameter.
+    /// The reason for indirect control is that k₁ and k₂ are typically correlated.
+    /// If k₂ did not vary with k₁, it would easily cause visual jumping when intensity
+    /// transitions from positive to negative. Furthermore, improper configuration of
+    /// the k₂ parameter can result in unnatural distortion artifacts. In most cases,
+    /// setting k₂ to 0.0 is appropriate.
+    ///
+    /// The default value is 0.0.
+    pub edge_curvature: f32,
+}
+
+impl Default for LensDistortion {
+    fn default() -> Self {
+        Self {
+            intensity: DEFAULT_LENS_DISTORTION_INTENSITY,
+            scale: DEFAULT_LENS_DISTORTION_SCALE,
+            multiplier: DEFAULT_LENS_DISTORTION_MULTIPLIER,
+            center: DEFAULT_LENS_DISTORTION_CENTER,
+            edge_curvature: DEFAULT_LENS_DISTORTION_EDGE_CURVATURE,
+        }
+    }
+}
+
+impl SyncComponent for LensDistortion {
+    type Target = Self;
+}
+
+impl ExtractComponent for LensDistortion {
+    type QueryData = Read<LensDistortion>;
+    type QueryFilter = With<LensDistortion>;
+    type Out = Self;
+
+    fn extract_component(lens_distortion: QueryItem<'_, '_, Self::QueryData>) -> Option<Self::Out> {
+        // Skip the postprocessing phase entirely if the intensity is negligible.
+        if abs(lens_distortion.intensity) > 1e-4
+            || lens_distortion.scale != DEFAULT_LENS_DISTORTION_SCALE
+            || lens_distortion.center != DEFAULT_LENS_DISTORTION_CENTER
+        {
+            Some(lens_distortion.clone())
+        } else {
+            None
+        }
+    }
+}
+
+/// The on-GPU version of the [`LensDistortion`] settings.
+///
+/// See the documentation for [`LensDistortion`] for more information on
+/// each of these fields.
+#[derive(ShaderType, Default)]
+pub struct LensDistortionUniform {
+    /// The overall strength of the distortion effect.
+    pub(super) intensity: f32,
+    /// A global scale factor applied to the final distorted image.
+    pub(super) scale: f32,
+    /// A multiplier that determines how the distortion scales along the X and Y axes.
+    pub(super) multiplier: Vec2,
+    /// The center point of the distortion effect in UV space `[0.0, 1.0]`.
+    pub(super) center: Vec2,
+    /// Controls the sharpness of the distortion curve near the screen edges.
+    pub(super) edge_curvature: f32,
+    /// Padding data.
+    pub(super) unused: u32,
+}

--- a/crates/bevy_post_process/src/effect_stack/lens_distortion.rs
+++ b/crates/bevy_post_process/src/effect_stack/lens_distortion.rs
@@ -105,10 +105,7 @@ impl ExtractComponent for LensDistortion {
 
     fn extract_component(lens_distortion: QueryItem<'_, '_, Self::QueryData>) -> Option<Self::Out> {
         // Skip the postprocessing phase entirely if the intensity is negligible.
-        if abs(lens_distortion.intensity) > 1e-4
-            || lens_distortion.scale != DEFAULT_LENS_DISTORTION_SCALE
-            || lens_distortion.center != DEFAULT_LENS_DISTORTION_CENTER
-        {
+        if abs(lens_distortion.intensity) > 1e-4 {
             Some(lens_distortion.clone())
         } else {
             None

--- a/crates/bevy_post_process/src/effect_stack/lens_distortion.wgsl
+++ b/crates/bevy_post_process/src/effect_stack/lens_distortion.wgsl
@@ -1,0 +1,63 @@
+// The lens distortion postprocessing effect.
+
+#define_import_path bevy_post_process::effect_stack::lens_distortion
+
+#import bevy_post_process::effect_stack::chromatic_aberration::{source_texture, source_sampler}
+
+// See `bevy_post_process::effect_stack::LensDistortion` for more
+// information on these fields.
+struct LensDistortionSettings {
+    intensity: f32,
+    scale: f32,
+    multiplier: vec2<f32>,
+    center: vec2<f32>,
+    edge_curvature: f32,
+    unused: u32,
+}
+
+const EPSILON: f32 = 1.19209290e-07;
+
+// The settings supplied by the developer.
+@group(0) @binding(6) var<uniform> lens_distortion_settings: LensDistortionSettings;
+
+fn lens_distortion(uv: vec2<f32>, color: vec3<f32>) -> vec3<f32>{
+    let intensity = lens_distortion_settings.intensity;
+    let multiplier = lens_distortion_settings.multiplier;
+    let center = lens_distortion_settings.center;
+
+    let uv_centered = uv - center;
+    // Prevent division by zero.
+    let radius = max(length(uv_centered), EPSILON);
+
+    let direction = uv_centered / radius;
+    let weight_x = abs(direction.x);
+    let weight_y = abs(direction.y);
+    let adjust = weight_x * multiplier.x + weight_y * multiplier.y;
+
+    // Maintains the correlation between k2 and k1, while ensuring the sign of k2
+    // is determinedsolely by `edge_curvature` rather than being influenced by intensity.
+    let k1 = intensity * adjust;
+    let k2 = k1 * intensity * lens_distortion_settings.edge_curvature;
+
+    // Simplify version: r' = r(1 + k1*r^2 + k2*r^4)
+    //
+    // k1 dominates the overall distortion shape, while k2 provides subtle
+    // edge refinement.Using only k1 and k2 offers an optimal balance between
+    // visual fidelity and performance for real-time rendering, making higher-order
+    // terms (k3) generally unnecessary.
+    let r2 = radius*radius;
+    let r_distorted = radius * (1.0 + k1 * r2 + k2 * r2 * r2);
+
+    let uv_distorted = direction * r_distorted + center;
+    let uv_scaled = (uv_distorted - center) / lens_distortion_settings.scale + center;
+
+    let uv_safe = clamp(uv_scaled, vec2<f32>(0.0), vec2<f32>(1.0));
+
+    let sampled_color = textureSample(
+        source_texture,
+        source_sampler,
+        uv_safe
+    );
+
+    return sampled_color.rgb;
+}

--- a/crates/bevy_post_process/src/effect_stack/lens_distortion.wgsl
+++ b/crates/bevy_post_process/src/effect_stack/lens_distortion.wgsl
@@ -2,8 +2,6 @@
 
 #define_import_path bevy_post_process::effect_stack::lens_distortion
 
-#import bevy_post_process::effect_stack::chromatic_aberration::{source_texture, source_sampler}
-
 // See `bevy_post_process::effect_stack::LensDistortion` for more
 // information on these fields.
 struct LensDistortionSettings {
@@ -20,8 +18,11 @@ const EPSILON: f32 = 1.19209290e-07;
 // The settings supplied by the developer.
 @group(0) @binding(6) var<uniform> lens_distortion_settings: LensDistortionSettings;
 
-fn lens_distortion(uv: vec2<f32>, color: vec3<f32>) -> vec3<f32>{
+fn lens_distortion(uv: vec2<f32>) -> vec2<f32>{
     let intensity = lens_distortion_settings.intensity;
+    if (abs(intensity) < EPSILON) {
+        return uv;
+    }
     let multiplier = lens_distortion_settings.multiplier;
     let center = lens_distortion_settings.center;
 
@@ -53,11 +54,5 @@ fn lens_distortion(uv: vec2<f32>, color: vec3<f32>) -> vec3<f32>{
 
     let uv_safe = clamp(uv_scaled, vec2<f32>(0.0), vec2<f32>(1.0));
 
-    let sampled_color = textureSample(
-        source_texture,
-        source_sampler,
-        uv_safe
-    );
-
-    return sampled_color.rgb;
+    return uv_safe;
 }

--- a/crates/bevy_post_process/src/effect_stack/lens_distortion.wgsl
+++ b/crates/bevy_post_process/src/effect_stack/lens_distortion.wgsl
@@ -32,20 +32,18 @@ fn lens_distortion(uv: vec2<f32>) -> vec2<f32>{
     let radius = max(length(uv_centered), MATH_EPSILON);
 
     let direction = uv_centered / radius;
-    let weight_x = abs(direction.x);
-    let weight_y = abs(direction.y);
-    let adjust = weight_x * multiplier.x + weight_y * multiplier.y;
+    let adjust = dot(abs(direction), multiplier);
 
     // Maintains the correlation between k2 and k1, while ensuring the sign of k2
-    // is determinedsolely by `edge_curvature` rather than being influenced by intensity.
+    // is determined solely by `edge_curvature` rather than being influenced by intensity.
     let k1 = intensity * adjust;
     let k2 = k1 * intensity * lens_distortion_settings.edge_curvature;
 
     let r2 = radius * radius;
-    let r_distorted = radius * (1.0 + k1 * r2 + k2 * r2 * r2);
+    let r_distorted = radius * (1.0 + (k1 + k2 * r2) * r2);
 
     let uv_distorted = direction * r_distorted + center;
-    
+
     // Compensates for the distortion pushing pixels outside the [0,1] UV bounds.
     let uv_scaled = (uv_distorted - center) / lens_distortion_settings.scale + center;
 

--- a/crates/bevy_post_process/src/effect_stack/mod.rs
+++ b/crates/bevy_post_process/src/effect_stack/mod.rs
@@ -3,6 +3,7 @@
 //! Includes:
 //!
 //! - Chromatic Aberration
+//! - Lens Distortion
 //! - Vignette
 
 mod chromatic_aberration;
@@ -67,6 +68,7 @@ use bevy_core_pipeline::{
 /// Includes:
 ///
 /// - Chromatic Aberration
+/// - Lens Distortion
 /// - Vignette
 #[derive(Default)]
 pub struct EffectStackPlugin;

--- a/crates/bevy_post_process/src/effect_stack/mod.rs
+++ b/crates/bevy_post_process/src/effect_stack/mod.rs
@@ -6,10 +6,13 @@
 //! - Vignette
 
 mod chromatic_aberration;
+mod lens_distortion;
 mod vignette;
 
 use bevy_color::ColorToComponents;
+use bevy_math::Vec2;
 pub use chromatic_aberration::{ChromaticAberration, ChromaticAberrationUniform};
+pub use lens_distortion::{LensDistortion, LensDistortionUniform};
 pub use vignette::{Vignette, VignetteUniform};
 
 use crate::effect_stack::chromatic_aberration::{
@@ -106,6 +109,7 @@ pub struct PostProcessingPipelineId(CachedRenderPipelineId);
 pub struct PostProcessingUniformBuffers {
     chromatic_aberration: DynamicUniformBuffer<ChromaticAberrationUniform>,
     vignette: DynamicUniformBuffer<VignetteUniform>,
+    lens_distortion: DynamicUniformBuffer<LensDistortionUniform>,
 }
 
 /// A component, part of the render world, that stores the appropriate byte
@@ -115,11 +119,13 @@ pub struct PostProcessingUniformBuffers {
 pub struct PostProcessingUniformBufferOffsets {
     chromatic_aberration: u32,
     vignette: u32,
+    lens_distortion: u32,
 }
 
 impl Plugin for EffectStackPlugin {
     fn build(&self, app: &mut App) {
         load_shader_library!(app, "chromatic_aberration.wgsl");
+        load_shader_library!(app, "lens_distortion.wgsl");
         load_shader_library!(app, "vignette.wgsl");
 
         embedded_asset!(app, "post_process.wgsl");
@@ -139,6 +145,7 @@ impl Plugin for EffectStackPlugin {
         ));
 
         app.add_plugins(ExtractComponentPlugin::<ChromaticAberration>::default())
+            .add_plugins(ExtractComponentPlugin::<LensDistortion>::default())
             .add_plugins(ExtractComponentPlugin::<Vignette>::default());
 
         let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
@@ -190,6 +197,8 @@ pub fn init_post_processing_pipeline(
                 uniform_buffer::<ChromaticAberrationUniform>(true),
                 // Vignette settings:
                 uniform_buffer::<VignetteUniform>(true),
+                // Lens Distortion settings;
+                uniform_buffer::<LensDistortionUniform>(true),
             ),
         ),
     );
@@ -246,7 +255,7 @@ pub(crate) fn post_processing(
     view: ViewQuery<(
         &ViewTarget,
         &PostProcessingPipelineId,
-        AnyOf<(&ChromaticAberration, &Vignette)>,
+        AnyOf<(&ChromaticAberration, &Vignette, &LensDistortion)>,
         &PostProcessingUniformBufferOffsets,
     )>,
     pipeline_cache: Res<PipelineCache>,
@@ -259,9 +268,12 @@ pub(crate) fn post_processing(
     let (view_target, pipeline_id, post_effects, post_processing_uniform_buffer_offsets) =
         view.into_inner();
 
-    let (maybe_chromatic_aberration, maybe_vignette) = post_effects;
+    let (maybe_chromatic_aberration, maybe_vignette, maybe_lens_distortion) = post_effects;
 
-    if maybe_chromatic_aberration.is_none() && maybe_vignette.is_none() {
+    if maybe_chromatic_aberration.is_none()
+        && maybe_vignette.is_none()
+        && maybe_lens_distortion.is_none()
+    {
         return;
     }
 
@@ -288,6 +300,12 @@ pub(crate) fn post_processing(
     };
 
     let Some(vignette_uniform_buffer_binding) = post_processing_uniform_buffers.vignette.binding()
+    else {
+        return;
+    };
+
+    let Some(lens_distortion_uniform_buffer_binding) =
+        post_processing_uniform_buffers.lens_distortion.binding()
     else {
         return;
     };
@@ -319,6 +337,7 @@ pub(crate) fn post_processing(
             &post_processing_pipeline.chromatic_aberration_lut_sampler,
             chromatic_aberration_uniform_buffer_binding,
             vignette_uniform_buffer_binding,
+            lens_distortion_uniform_buffer_binding,
         )),
     );
 
@@ -335,6 +354,7 @@ pub(crate) fn post_processing(
         &[
             post_processing_uniform_buffer_offsets.chromatic_aberration,
             post_processing_uniform_buffer_offsets.vignette,
+            post_processing_uniform_buffer_offsets.lens_distortion,
         ],
     );
     render_pass.draw(0..3, 0..1);
@@ -348,7 +368,14 @@ pub fn prepare_post_processing_pipelines(
     pipeline_cache: Res<PipelineCache>,
     mut pipelines: ResMut<SpecializedRenderPipelines<PostProcessingPipeline>>,
     post_processing_pipeline: Res<PostProcessingPipeline>,
-    views: Query<(Entity, &ExtractedView), Or<(With<ChromaticAberration>, With<Vignette>)>>,
+    views: Query<
+        (Entity, &ExtractedView),
+        Or<(
+            With<ChromaticAberration>,
+            With<Vignette>,
+            With<LensDistortion>,
+        )>,
+    >,
 ) {
     for (entity, view) in views.iter() {
         let pipeline_id = pipelines.specialize(
@@ -377,15 +404,26 @@ pub fn prepare_post_processing_uniforms(
     render_device: Res<RenderDevice>,
     render_queue: Res<RenderQueue>,
     mut views: Query<
-        (Entity, Option<&ChromaticAberration>, Option<&Vignette>),
-        Or<(With<ChromaticAberration>, With<Vignette>)>,
+        (
+            Entity,
+            Option<&ChromaticAberration>,
+            Option<&Vignette>,
+            Option<&LensDistortion>,
+        ),
+        Or<(
+            With<ChromaticAberration>,
+            With<Vignette>,
+            With<LensDistortion>,
+        )>,
     >,
 ) {
     post_processing_uniform_buffers.chromatic_aberration.clear();
     post_processing_uniform_buffers.vignette.clear();
 
     // Gather up all the postprocessing settings.
-    for (view_entity, maybe_chromatic_aberration, maybe_vignette) in views.iter_mut() {
+    for (view_entity, maybe_chromatic_aberration, maybe_vignette, maybe_lens_distortion) in
+        views.iter_mut()
+    {
         let chromatic_aberration_uniform_buffer_offset =
             if let Some(chromatic_aberration) = maybe_chromatic_aberration {
                 post_processing_uniform_buffers.chromatic_aberration.push(
@@ -421,11 +459,30 @@ pub fn prepare_post_processing_uniforms(
                 .push(&VignetteUniform::default())
         };
 
+        let lens_distortion_uniform_buffer_offset =
+            if let Some(lens_distortion) = maybe_lens_distortion {
+                post_processing_uniform_buffers
+                    .lens_distortion
+                    .push(&LensDistortionUniform {
+                        intensity: lens_distortion.intensity,
+                        scale: lens_distortion.scale.max(1e-4),
+                        multiplier: lens_distortion.multiplier.max(Vec2::ZERO),
+                        center: lens_distortion.center.clamp(Vec2::ZERO, Vec2::ONE),
+                        edge_curvature: lens_distortion.edge_curvature,
+                        unused: 0,
+                    })
+            } else {
+                post_processing_uniform_buffers
+                    .lens_distortion
+                    .push(&LensDistortionUniform::default())
+            };
+
         commands
             .entity(view_entity)
             .insert(PostProcessingUniformBufferOffsets {
                 chromatic_aberration: chromatic_aberration_uniform_buffer_offset,
                 vignette: vignette_uniform_buffer_offset,
+                lens_distortion: lens_distortion_uniform_buffer_offset,
             });
     }
 
@@ -435,5 +492,8 @@ pub fn prepare_post_processing_uniforms(
         .write_buffer(&render_device, &render_queue);
     post_processing_uniform_buffers
         .vignette
+        .write_buffer(&render_device, &render_queue);
+    post_processing_uniform_buffers
+        .lens_distortion
         .write_buffer(&render_device, &render_queue);
 }

--- a/crates/bevy_post_process/src/effect_stack/mod.rs
+++ b/crates/bevy_post_process/src/effect_stack/mod.rs
@@ -3,13 +3,17 @@
 //! Includes:
 //!
 //! - Chromatic Aberration
+//! - Lens Distortion
 //! - Vignette
 
 mod chromatic_aberration;
+mod lens_distortion;
 mod vignette;
 
 use bevy_color::ColorToComponents;
+use bevy_math::Vec2;
 pub use chromatic_aberration::{ChromaticAberration, ChromaticAberrationUniform};
+pub use lens_distortion::{LensDistortion, LensDistortionUniform};
 pub use vignette::{Vignette, VignetteUniform};
 
 use crate::effect_stack::chromatic_aberration::{
@@ -65,6 +69,7 @@ use bevy_core_pipeline::{
 /// Includes:
 ///
 /// - Chromatic Aberration
+/// - Lens Distortion
 /// - Vignette
 #[derive(Default)]
 pub struct EffectStackPlugin;
@@ -107,6 +112,7 @@ pub struct PostProcessingPipelineId(CachedRenderPipelineId);
 pub struct PostProcessingUniformBuffers {
     chromatic_aberration: DynamicUniformBuffer<ChromaticAberrationUniform>,
     vignette: DynamicUniformBuffer<VignetteUniform>,
+    lens_distortion: DynamicUniformBuffer<LensDistortionUniform>,
 }
 
 /// A component, part of the render world, that stores the appropriate byte
@@ -116,11 +122,13 @@ pub struct PostProcessingUniformBuffers {
 pub struct PostProcessingUniformBufferOffsets {
     chromatic_aberration: u32,
     vignette: u32,
+    lens_distortion: u32,
 }
 
 impl Plugin for EffectStackPlugin {
     fn build(&self, app: &mut App) {
         load_shader_library!(app, "chromatic_aberration.wgsl");
+        load_shader_library!(app, "lens_distortion.wgsl");
         load_shader_library!(app, "vignette.wgsl");
 
         embedded_asset!(app, "post_process.wgsl");
@@ -140,6 +148,7 @@ impl Plugin for EffectStackPlugin {
         ));
 
         app.add_plugins(ExtractComponentPlugin::<ChromaticAberration>::default())
+            .add_plugins(ExtractComponentPlugin::<LensDistortion>::default())
             .add_plugins(ExtractComponentPlugin::<Vignette>::default());
 
         let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
@@ -191,6 +200,8 @@ pub fn init_post_processing_pipeline(
                 uniform_buffer::<ChromaticAberrationUniform>(true),
                 // Vignette settings:
                 uniform_buffer::<VignetteUniform>(true),
+                // Lens Distortion settings;
+                uniform_buffer::<LensDistortionUniform>(true),
             ),
         ),
     );
@@ -247,7 +258,7 @@ pub(crate) fn post_processing(
     view: ViewQuery<(
         &ViewTarget,
         &PostProcessingPipelineId,
-        AnyOf<(&ChromaticAberration, &Vignette)>,
+        AnyOf<(&ChromaticAberration, &Vignette, &LensDistortion)>,
         &PostProcessingUniformBufferOffsets,
     )>,
     pipeline_cache: Res<PipelineCache>,
@@ -260,9 +271,12 @@ pub(crate) fn post_processing(
     let (view_target, pipeline_id, post_effects, post_processing_uniform_buffer_offsets) =
         view.into_inner();
 
-    let (maybe_chromatic_aberration, maybe_vignette) = post_effects;
+    let (maybe_chromatic_aberration, maybe_vignette, maybe_lens_distortion) = post_effects;
 
-    if maybe_chromatic_aberration.is_none() && maybe_vignette.is_none() {
+    if maybe_chromatic_aberration.is_none()
+        && maybe_vignette.is_none()
+        && maybe_lens_distortion.is_none()
+    {
         return;
     }
 
@@ -289,6 +303,12 @@ pub(crate) fn post_processing(
     };
 
     let Some(vignette_uniform_buffer_binding) = post_processing_uniform_buffers.vignette.binding()
+    else {
+        return;
+    };
+
+    let Some(lens_distortion_uniform_buffer_binding) =
+        post_processing_uniform_buffers.lens_distortion.binding()
     else {
         return;
     };
@@ -320,6 +340,7 @@ pub(crate) fn post_processing(
             &post_processing_pipeline.chromatic_aberration_lut_sampler,
             chromatic_aberration_uniform_buffer_binding,
             vignette_uniform_buffer_binding,
+            lens_distortion_uniform_buffer_binding,
         )),
     );
 
@@ -336,6 +357,7 @@ pub(crate) fn post_processing(
         &[
             post_processing_uniform_buffer_offsets.chromatic_aberration,
             post_processing_uniform_buffer_offsets.vignette,
+            post_processing_uniform_buffer_offsets.lens_distortion,
         ],
     );
     render_pass.draw(0..3, 0..1);
@@ -354,6 +376,7 @@ pub fn prepare_post_processing_pipelines(
         Or<(
             With<ChromaticAberration>,
             With<Vignette>,
+            With<LensDistortion>,
             With<ExtractedCamera>,
         )>,
     >,
@@ -381,15 +404,26 @@ pub fn prepare_post_processing_uniforms(
     render_device: Res<RenderDevice>,
     render_queue: Res<RenderQueue>,
     mut views: Query<
-        (Entity, Option<&ChromaticAberration>, Option<&Vignette>),
-        Or<(With<ChromaticAberration>, With<Vignette>)>,
+        (
+            Entity,
+            Option<&ChromaticAberration>,
+            Option<&Vignette>,
+            Option<&LensDistortion>,
+        ),
+        Or<(
+            With<ChromaticAberration>,
+            With<Vignette>,
+            With<LensDistortion>,
+        )>,
     >,
 ) {
     post_processing_uniform_buffers.chromatic_aberration.clear();
     post_processing_uniform_buffers.vignette.clear();
 
     // Gather up all the postprocessing settings.
-    for (view_entity, maybe_chromatic_aberration, maybe_vignette) in views.iter_mut() {
+    for (view_entity, maybe_chromatic_aberration, maybe_vignette, maybe_lens_distortion) in
+        views.iter_mut()
+    {
         let chromatic_aberration_uniform_buffer_offset =
             if let Some(chromatic_aberration) = maybe_chromatic_aberration {
                 post_processing_uniform_buffers.chromatic_aberration.push(
@@ -425,11 +459,30 @@ pub fn prepare_post_processing_uniforms(
                 .push(&VignetteUniform::default())
         };
 
+        let lens_distortion_uniform_buffer_offset =
+            if let Some(lens_distortion) = maybe_lens_distortion {
+                post_processing_uniform_buffers
+                    .lens_distortion
+                    .push(&LensDistortionUniform {
+                        intensity: lens_distortion.intensity,
+                        scale: lens_distortion.scale.max(1e-4),
+                        multiplier: lens_distortion.multiplier.max(Vec2::ZERO),
+                        center: lens_distortion.center.clamp(Vec2::ZERO, Vec2::ONE),
+                        edge_curvature: lens_distortion.edge_curvature,
+                        unused: 0,
+                    })
+            } else {
+                post_processing_uniform_buffers
+                    .lens_distortion
+                    .push(&LensDistortionUniform::default())
+            };
+
         commands
             .entity(view_entity)
             .insert(PostProcessingUniformBufferOffsets {
                 chromatic_aberration: chromatic_aberration_uniform_buffer_offset,
                 vignette: vignette_uniform_buffer_offset,
+                lens_distortion: lens_distortion_uniform_buffer_offset,
             });
     }
 
@@ -439,5 +492,8 @@ pub fn prepare_post_processing_uniforms(
         .write_buffer(&render_device, &render_queue);
     post_processing_uniform_buffers
         .vignette
+        .write_buffer(&render_device, &render_queue);
+    post_processing_uniform_buffers
+        .lens_distortion
         .write_buffer(&render_device, &render_queue);
 }

--- a/crates/bevy_post_process/src/effect_stack/post_process.wgsl
+++ b/crates/bevy_post_process/src/effect_stack/post_process.wgsl
@@ -2,10 +2,12 @@
 
 #import bevy_core_pipeline::fullscreen_vertex_shader::FullscreenVertexOutput
 #import bevy_post_process::effect_stack::chromatic_aberration::chromatic_aberration
+#import bevy_post_process::effect_stack::lens_distortion::lens_distortion
 #import bevy_post_process::effect_stack::vignette::vignette
 
 @fragment
 fn fragment_main(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
     let color = chromatic_aberration(in.uv);
-    return vec4(vignette(in.uv, color), 1.0);
+    let color_distorted = lens_distortion(in.uv, color);
+    return vec4(vignette(in.uv, color_distorted), 1.0);
 }

--- a/crates/bevy_post_process/src/effect_stack/post_process.wgsl
+++ b/crates/bevy_post_process/src/effect_stack/post_process.wgsl
@@ -7,7 +7,7 @@
 
 @fragment
 fn fragment_main(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
-    let color = chromatic_aberration(in.uv);
-    let color_distorted = lens_distortion(in.uv, color);
-    return vec4(vignette(in.uv, color_distorted), 1.0);
+    let distorted_uv = lens_distortion(in.uv);
+    let color = chromatic_aberration(distorted_uv);
+    return vec4(vignette(in.uv, color), 1.0);
 }

--- a/examples/3d/post_processing.rs
+++ b/examples/3d/post_processing.rs
@@ -99,7 +99,7 @@ fn spawn_camera(commands: &mut Commands, asset_server: &AssetServer) {
         // Include the `Vignette` component.
         Vignette::default(),
         // Include the `LensDistortion` component.
-        //LensDistortion::default(),
+        LensDistortion::default(),
     ));
 }
 

--- a/examples/3d/post_processing.rs
+++ b/examples/3d/post_processing.rs
@@ -40,9 +40,9 @@ struct AppSettings {
     vignette_edge_compensation: f32,
     /// The intensity of the lens distortion effect.
     lens_distortion_intensity: f32,
-    /// The multiplier_x of the lens distortion effect.
+    /// Distortion strength multiplier for the horizontal direction.
     lens_distortion_multiplier_x: f32,
-    /// The multiplier_y of the lens distortion effect.
+    /// Distortion strength multiplier for the vertical direction.
     lens_distortion_multiplier_y: f32,
 }
 

--- a/examples/3d/post_processing.rs
+++ b/examples/3d/post_processing.rs
@@ -10,7 +10,7 @@ use std::f32::consts::PI;
 use bevy::{
     camera::Hdr,
     light::CascadeShadowConfigBuilder,
-    post_process::effect_stack::{ChromaticAberration, Vignette},
+    post_process::effect_stack::{ChromaticAberration, LensDistortion, Vignette},
     prelude::*,
 };
 
@@ -30,14 +30,20 @@ struct AppSettings {
     chromatic_aberration_intensity: f32,
     /// The intensity of the vignette effect.
     vignette_intensity: f32,
-    /// The radius of the vignette.
+    /// The radius of the vignette effect.
     vignette_radius: f32,
-    /// The smoothness of the vignette.
+    /// The smoothness of the vignette effect.
     vignette_smoothness: f32,
-    /// The roundness of the vignette.
+    /// The roundness of the vignette effect.
     vignette_roundness: f32,
-    /// The edge compensation of the vignette.
+    /// The edge compensation of the vignette effect.
     vignette_edge_compensation: f32,
+    /// The intensity of the lens distortion effect.
+    lens_distortion_intensity: f32,
+    /// The multiplier_x of the lens distortion effect.
+    lens_distortion_multiplier_x: f32,
+    /// The multiplier_y of the lens distortion effect.
+    lens_distortion_multiplier_y: f32,
 }
 
 /// The entry point.
@@ -92,6 +98,8 @@ fn spawn_camera(commands: &mut Commands, asset_server: &AssetServer) {
         ChromaticAberration::default(),
         // Include the `Vignette` component.
         Vignette::default(),
+        // Include the `LensDistortion` component.
+        //LensDistortion::default(),
     ));
 }
 
@@ -147,6 +155,7 @@ fn spawn_text(commands: &mut Commands) {
 impl Default for AppSettings {
     fn default() -> Self {
         let vignette_default = Vignette::default();
+        let lens_distortion = LensDistortion::default();
         Self {
             selected: 0,
             chromatic_aberration_intensity: ChromaticAberration::default().intensity,
@@ -155,6 +164,9 @@ impl Default for AppSettings {
             vignette_smoothness: vignette_default.smoothness,
             vignette_roundness: vignette_default.roundness,
             vignette_edge_compensation: vignette_default.edge_compensation,
+            lens_distortion_intensity: lens_distortion.intensity,
+            lens_distortion_multiplier_x: lens_distortion.multiplier.x,
+            lens_distortion_multiplier_y: lens_distortion.multiplier.y,
         }
     }
 }
@@ -163,7 +175,7 @@ impl Default for AppSettings {
 fn handle_keyboard_input(mut app_settings: ResMut<AppSettings>, input: Res<ButtonInput<KeyCode>>) {
     if input.just_pressed(KeyCode::ArrowUp) && app_settings.selected > 0 {
         app_settings.selected -= 1;
-    } else if input.just_pressed(KeyCode::ArrowDown) && app_settings.selected < 5 {
+    } else if input.just_pressed(KeyCode::ArrowDown) && app_settings.selected < 8 {
         app_settings.selected += 1;
     }
 
@@ -198,6 +210,18 @@ fn handle_keyboard_input(mut app_settings: ResMut<AppSettings>, input: Res<Butto
             app_settings.vignette_edge_compensation =
                 (app_settings.vignette_edge_compensation + delta).clamp(0.0, 1.0);
         }
+        6 => {
+            app_settings.lens_distortion_intensity =
+                (app_settings.lens_distortion_intensity + delta).clamp(-1.0, 1.0);
+        }
+        7 => {
+            app_settings.lens_distortion_multiplier_x =
+                (app_settings.lens_distortion_multiplier_x + delta).clamp(0.0, 1.0);
+        }
+        8 => {
+            app_settings.lens_distortion_multiplier_y =
+                (app_settings.lens_distortion_multiplier_y + delta).clamp(0.0, 1.0);
+        }
         _ => {}
     }
 }
@@ -206,6 +230,7 @@ fn handle_keyboard_input(mut app_settings: ResMut<AppSettings>, input: Res<Butto
 fn update_chromatic_aberration_settings(
     mut chromatic_aberration: Query<&mut ChromaticAberration>,
     mut vignette: Query<&mut Vignette>,
+    mut lens_distortion: Query<&mut LensDistortion>,
     app_settings: Res<AppSettings>,
 ) {
     let intensity = app_settings.chromatic_aberration_intensity;
@@ -230,6 +255,12 @@ fn update_chromatic_aberration_settings(
         vignette.smoothness = app_settings.vignette_smoothness;
         vignette.roundness = app_settings.vignette_roundness;
         vignette.edge_compensation = app_settings.vignette_edge_compensation;
+    }
+
+    for mut lens_distortion in &mut lens_distortion {
+        lens_distortion.intensity = app_settings.lens_distortion_intensity;
+        lens_distortion.multiplier.x = app_settings.lens_distortion_multiplier_x;
+        lens_distortion.multiplier.y = app_settings.lens_distortion_multiplier_y;
     }
 }
 
@@ -258,6 +289,18 @@ fn update_help_text(mut text: Single<&mut Text>, app_settings: Res<AppSettings>)
         format!(
             "Vignette edge_compensation: {:.2}\n",
             app_settings.vignette_edge_compensation
+        ),
+        format!(
+            "Lens Distortion intensity: {:.2}\n",
+            app_settings.lens_distortion_intensity
+        ),
+        format!(
+            "Lens Distortion multiplier x: {:.2}\n",
+            app_settings.lens_distortion_multiplier_x
+        ),
+        format!(
+            "Lens Distortion multiplier y: {:.2}\n",
+            app_settings.lens_distortion_multiplier_y
         ),
     ];
     for (i, val) in text_list.iter().enumerate() {

--- a/examples/3d/post_processing.rs
+++ b/examples/3d/post_processing.rs
@@ -4,6 +4,7 @@
 //!
 //! - Chromatic Aberration
 //! - Vignette
+//! - Lens Distortion
 
 use std::f32::consts::PI;
 

--- a/release-content/release-notes/lens_distortion.md
+++ b/release-content/release-notes/lens_distortion.md
@@ -1,0 +1,16 @@
+---
+title: "Lens Distortion"
+authors: ["@Breakdown-Dog"]
+pull_requests: [23110]
+--- 
+
+We’ve added lens distortion, which is a common post-processing effect that creates a spatial warping of the image towards the periphery compared to the image center. It’s often used to simulate the optical characteristics of a real camera lens or to add a stylized, dynamic look to the scene.
+
+To use it, add the `LensDistortion` component to your camera:
+
+```rust
+commands.spawn((
+    Camera3d::default(),
+    LensDistortion::default(),
+))
+```


### PR DESCRIPTION
# Objective

- Implements post-process lens distortion effects based on `EffectStackPlugin`.

## Solution

- This PR's implementation is based on a simplified special case of the Brown-Conrady model, where p₁ = p₂ = 0 and control is retained only for k₁ and k₂.
- Additionally, supports controlling the degree of distortion in the horizontal and vertical directions based on the direction vector.

## Testing

- These effect components can work independently.
- The example works as expected.
- CI

---

## Showcase

- Barrel distortion
<img width="1918" height="1104" alt="tu" src="https://github.com/user-attachments/assets/6d1b1660-0892-4433-a152-4ac277b9382c" />

- Pincushion distortion
<img width="1935" height="1084" alt="ao" src="https://github.com/user-attachments/assets/2d3c5373-43a8-427c-bd0a-59ccce4448fc" />

- Pincushion distortion with no distortion on the x-axis.
<img width="1921" height="1089" alt="ao_no_x" src="https://github.com/user-attachments/assets/c1b4b55d-7b7f-4cb7-8459-debe4cf2f283" />

- With all effects.
<img width="2559" height="1314" alt="cur" src="https://github.com/user-attachments/assets/724cfa30-9b36-42b9-a480-0d96720f760b" />
