### PR TITLE
Fix 16 byte alignment typo (WebGL 2: 16 bit -> 16 byte)

### DIFF
--- a/assets/shaders/custom_material.wesl
+++ b/assets/shaders/custom_material.wesl
@@ -6,7 +6,7 @@ struct VertexOutput {
 }
 
 struct CustomMaterial {
-    // Needed for 16-bit alignment on WebGL2
+    // Needed for 16 byte alignment on WebGL2
     time: vec4<f32>,
 }
 

--- a/examples/shader/shader_material_wesl.rs
+++ b/examples/shader/shader_material_wesl.rs
@@ -93,7 +93,7 @@ fn update(
 #[derive(Asset, TypePath, AsBindGroup, Clone)]
 #[bind_group_data(CustomMaterialKey)]
 struct CustomMaterial {
-    // Needed for 16 bit alignment in WebGL2
+    // Needed for 16 byte alignment on WebGL2
     #[uniform(0)]
     time: Vec4,
     party_mode: bool,


### PR DESCRIPTION
# Objective

WebGL 2 requires 16 **byte** UBO alignment. Some comments incorrectly state 16 **bits**.

## Solution

Fix comment typos.

## Testing

N/A

---

## Showcase

N/A
