### PR TITLE
TODO should not be a doc comment

### DIFF
--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -385,7 +385,6 @@ pub fn get_selected_videomode(
 }
 
 /// Gets a monitor's current video-mode.
-///
 // TODO: When Winit 0.31 releases this function can be removed and replaced with
 // `MonitorHandle::current_video_mode()`
 fn get_current_videomode(monitor: &MonitorHandle) -> Option<VideoModeHandle> {


### PR DESCRIPTION
# Objective

- `TODO` should not appear in docs.rs generated documentation

## Solution

- `///` -> `//`

## Testing

- Untested, pushed with faith