### PR TITLE
Despawn atlas sprites on scene exit in `testbed_2d` 

### DIFF
--- a/examples/testbed/2d.rs
+++ b/examples/testbed/2d.rs
@@ -535,6 +535,7 @@ mod texture_atlas_builder {
                                 * (Vec3::Y * IMAGE_SIZE.y as f32 + anchor.as_vec().extend(0.)),
                     ),
                     anchor,
+                    DespawnOnExit(super::Scene::TextureAtlasBuilder),
                 ));
             }
         }


### PR DESCRIPTION
# Objective

Some cleanup is missing from the 2d testbed's `TextureAtlasBuilder` scene.

## Solution

Add `DespawnOnExit(super::Scene::TextureAtlasBuilder)` to the atlas sprites.