### PR TITLE
Change `Text::new` to take in `impl ToString`

### DIFF
--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -111,8 +111,8 @@ pub struct Text(pub String);
 
 impl Text {
     /// Makes a new text component.
-    pub fn new(text: impl Into<String>) -> Self {
-        Self(text.into())
+    pub fn new(text: impl ToString) -> Self {
+        Self(text.to_string())
     }
 }
 


### PR DESCRIPTION
# Objective

`impl Into<String>` is good for types that are already `String` adjacent, changing to `impl ToString` allows passing any type that impls `Display`, like all core primitives ('i32', 'f32', etc)

## Solution

Change `Text::new` to take in `impl ToString`

## Testing

Ran an ui example