### PR TITLE
Add enum variant index to GetPath

### DIFF
--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -309,7 +309,7 @@
 //!   value: vec![None, None, Some(123)],
 //! };
 //! assert_eq!(
-//!   my_struct.path::<u32>(".value[2].0").unwrap(),
+//!   my_struct.path::<u32>(".value[2]{1.0}").unwrap(),
 //!   &123,
 //! );
 //! ```

--- a/crates/bevy_reflect/src/path/access.rs
+++ b/crates/bevy_reflect/src/path/access.rs
@@ -22,6 +22,8 @@ pub enum Access<'a> {
     TupleIndex(usize),
     /// An index-based access on a list.
     ListIndex(usize),
+    /// A witness for validating the access of an enum variant.
+    VariantIndex(usize),
 }
 
 impl fmt::Display for Access<'_> {
@@ -31,6 +33,7 @@ impl fmt::Display for Access<'_> {
             Access::FieldIndex(index) => write!(f, "#{index}"),
             Access::TupleIndex(index) => write!(f, ".{index}"),
             Access::ListIndex(index) => write!(f, "[{index}]"),
+            Access::VariantIndex(index) => write!(f, "{{{index}}}"),
         }
     }
 }
@@ -47,6 +50,7 @@ impl<'a> Access<'a> {
             Self::FieldIndex(value) => Access::FieldIndex(value),
             Self::TupleIndex(value) => Access::TupleIndex(value),
             Self::ListIndex(value) => Access::ListIndex(value),
+            Self::VariantIndex(value) => Access::VariantIndex(value),
         }
     }
 
@@ -102,6 +106,20 @@ impl<'a> Access<'a> {
             (&Self::ListIndex(index), Array(list)) => Ok(list.get(index)),
             (Self::ListIndex(_), actual) => Err(AccessErrorKind::IncompatibleTypes {
                 expected: ReflectKind::List,
+                actual: actual.into(),
+            }),
+            (&Self::VariantIndex(index), Enum(enum_ref)) => {
+                if enum_ref.variant_index() == index {
+                    Ok(Some(enum_ref.as_partial_reflect()))
+                } else {
+                    Err(AccessErrorKind::IncorrectEnumVariantIndex {
+                        expected: index,
+                        actual: enum_ref.variant_index(),
+                    })
+                }
+            }
+            (&Self::VariantIndex(_), actual) => Err(AccessErrorKind::IncompatibleTypes {
+                expected: ReflectKind::Enum,
                 actual: actual.into(),
             }),
         }
@@ -163,6 +181,20 @@ impl<'a> Access<'a> {
                 expected: ReflectKind::List,
                 actual: actual.into(),
             }),
+            (&Self::VariantIndex(index), Enum(enum_ref)) => {
+                if enum_ref.variant_index() == index {
+                    Ok(Some(enum_ref.as_partial_reflect_mut()))
+                } else {
+                    Err(AccessErrorKind::IncorrectEnumVariantIndex {
+                        expected: index,
+                        actual: enum_ref.variant_index(),
+                    })
+                }
+            }
+            (&Self::VariantIndex(_), actual) => Err(AccessErrorKind::IncompatibleTypes {
+                expected: ReflectKind::Enum,
+                actual: actual.into(),
+            }),
         }
     }
 
@@ -170,7 +202,10 @@ impl<'a> Access<'a> {
     pub fn display_value(&self) -> &dyn fmt::Display {
         match self {
             Self::Field(value) => value,
-            Self::FieldIndex(value) | Self::TupleIndex(value) | Self::ListIndex(value) => value,
+            Self::FieldIndex(value)
+            | Self::TupleIndex(value)
+            | Self::ListIndex(value)
+            | Self::VariantIndex(value) => value,
         }
     }
 
@@ -179,6 +214,7 @@ impl<'a> Access<'a> {
             Self::Field(_) => "field",
             Self::FieldIndex(_) => "field index",
             Self::TupleIndex(_) | Self::ListIndex(_) => "index",
+            Self::VariantIndex(_) => "variant index",
         }
     }
 }

--- a/crates/bevy_reflect/src/path/access.rs
+++ b/crates/bevy_reflect/src/path/access.rs
@@ -1,7 +1,7 @@
 //! Representation for individual element accesses within a path.
 
 use alloc::borrow::Cow;
-use core::fmt;
+use core::fmt::{self};
 
 use super::error::AccessErrorKind;
 use crate::{enums::VariantType, AccessError, PartialReflect, ReflectKind, ReflectMut, ReflectRef};
@@ -22,8 +22,20 @@ pub enum Access<'a> {
     TupleIndex(usize),
     /// An index-based access on a list.
     ListIndex(usize),
-    /// A witness for validating the access of an enum variant.
-    VariantIndex(usize),
+    /// Variant index-based access for an enum.
+    Variant(VariantAccess<'a>),
+}
+/// Field Access for Enum variants.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum VariantAccess<'a> {
+    /// Access for a unit enum variant - ex: `Option::None`
+    Unit(usize),
+    /// Access for a struct enum variant, keyed on field name.
+    Field(usize, Cow<'a, str>),
+    /// Access for a struct enum variant, keyed on field index.
+    FieldIndex(usize, usize),
+    /// Access for a Tuple enum variant, keyed on tuple index.
+    TupleIndex(usize, usize),
 }
 
 impl fmt::Display for Access<'_> {
@@ -33,7 +45,17 @@ impl fmt::Display for Access<'_> {
             Access::FieldIndex(index) => write!(f, "#{index}"),
             Access::TupleIndex(index) => write!(f, ".{index}"),
             Access::ListIndex(index) => write!(f, "[{index}]"),
-            Access::VariantIndex(index) => write!(f, "{{{index}}}"),
+            Access::Variant(index) => write!(f, "{}", index),
+        }
+    }
+}
+impl fmt::Display for VariantAccess<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            VariantAccess::Unit(vidx) => write!(f, "{{{vidx}}}"),
+            VariantAccess::Field(vidx, field) => write!(f, "{{{vidx}.{field}}}"),
+            VariantAccess::FieldIndex(vidx, index) => write!(f, "{{{vidx}#{index}}}"),
+            VariantAccess::TupleIndex(vidx, index) => write!(f, "{{{vidx}.{index}}}"),
         }
     }
 }
@@ -45,12 +67,22 @@ impl<'a> Access<'a> {
     /// the field's [`Cow<str>`] will be converted to its owned
     /// counterpart, which doesn't require a reference.
     pub fn into_owned(self) -> Access<'static> {
+        use VariantAccess::*;
         match self {
             Self::Field(value) => Access::Field(Cow::Owned(value.into_owned())),
             Self::FieldIndex(value) => Access::FieldIndex(value),
             Self::TupleIndex(value) => Access::TupleIndex(value),
             Self::ListIndex(value) => Access::ListIndex(value),
-            Self::VariantIndex(value) => Access::VariantIndex(value),
+            Self::Variant(Unit(v)) => Access::Variant(Unit(v)),
+            Self::Variant(Field(v_index, field)) => {
+                Access::Variant(Field(v_index, Cow::Owned(field.into_owned())))
+            }
+            Self::Variant(FieldIndex(v_index, index)) => {
+                Access::Variant(FieldIndex(v_index, index))
+            }
+            Self::Variant(TupleIndex(v_index, index)) => {
+                Access::Variant(TupleIndex(v_index, index))
+            }
         }
     }
 
@@ -69,21 +101,14 @@ impl<'a> Access<'a> {
         base: &'r dyn PartialReflect,
     ) -> InnerResult<Option<&'r dyn PartialReflect>> {
         use ReflectRef::*;
+        use VariantAccess::*;
 
         let invalid_variant =
             |expected, actual| AccessErrorKind::IncompatibleEnumVariantTypes { expected, actual };
 
         match (self, base.reflect_ref()) {
             (Self::Field(field), Struct(struct_ref)) => Ok(struct_ref.field(field.as_ref())),
-            (Self::Field(field), Enum(enum_ref)) => match enum_ref.variant_type() {
-                VariantType::Struct => Ok(enum_ref.field(field.as_ref())),
-                actual => Err(invalid_variant(VariantType::Struct, actual)),
-            },
             (&Self::FieldIndex(index), Struct(struct_ref)) => Ok(struct_ref.field_at(index)),
-            (&Self::FieldIndex(index), Enum(enum_ref)) => match enum_ref.variant_type() {
-                VariantType::Struct => Ok(enum_ref.field_at(index)),
-                actual => Err(invalid_variant(VariantType::Struct, actual)),
-            },
             (Self::Field(_) | Self::FieldIndex(_), actual) => {
                 Err(AccessErrorKind::IncompatibleTypes {
                     expected: ReflectKind::Struct,
@@ -93,10 +118,7 @@ impl<'a> Access<'a> {
 
             (&Self::TupleIndex(index), TupleStruct(tuple)) => Ok(tuple.field(index)),
             (&Self::TupleIndex(index), Tuple(tuple)) => Ok(tuple.field(index)),
-            (&Self::TupleIndex(index), Enum(enum_ref)) => match enum_ref.variant_type() {
-                VariantType::Tuple => Ok(enum_ref.field_at(index)),
-                actual => Err(invalid_variant(VariantType::Tuple, actual)),
-            },
+
             (Self::TupleIndex(_), actual) => Err(AccessErrorKind::IncompatibleTypes {
                 expected: ReflectKind::Tuple,
                 actual: actual.into(),
@@ -108,7 +130,46 @@ impl<'a> Access<'a> {
                 expected: ReflectKind::List,
                 actual: actual.into(),
             }),
-            (&Self::VariantIndex(index), Enum(enum_ref)) => {
+            (Self::Variant(Field(index, field)), Enum(enum_ref)) => {
+                if enum_ref.variant_index() != *index {
+                    Err(AccessErrorKind::IncorrectEnumVariantIndex {
+                        expected: *index,
+                        actual: enum_ref.variant_index(),
+                    })
+                } else {
+                    match enum_ref.variant_type() {
+                        VariantType::Struct => Ok(enum_ref.field(field.as_ref())),
+                        actual => Err(invalid_variant(VariantType::Struct, actual)),
+                    }
+                }
+            }
+            (&Self::Variant(FieldIndex(v_index, index)), Enum(enum_ref)) => {
+                if enum_ref.variant_index() != v_index {
+                    Err(AccessErrorKind::IncorrectEnumVariantIndex {
+                        expected: v_index,
+                        actual: enum_ref.variant_index(),
+                    })
+                } else {
+                    match enum_ref.variant_type() {
+                        VariantType::Struct => Ok(enum_ref.field_at(index)),
+                        actual => Err(invalid_variant(VariantType::Struct, actual)),
+                    }
+                }
+            }
+            (&Self::Variant(TupleIndex(v_index, index)), Enum(enum_ref)) => {
+                if enum_ref.variant_index() != v_index {
+                    Err(AccessErrorKind::IncorrectEnumVariantIndex {
+                        expected: v_index,
+                        actual: enum_ref.variant_index(),
+                    })
+                } else {
+                    match enum_ref.variant_type() {
+                        VariantType::Tuple => Ok(enum_ref.field_at(index)),
+                        actual => Err(invalid_variant(VariantType::Tuple, actual)),
+                    }
+                }
+            }
+            (&Self::Variant(Unit(index)), Enum(enum_ref)) => {
                 if enum_ref.variant_index() == index {
                     Ok(Some(enum_ref.as_partial_reflect()))
                 } else {
@@ -118,7 +179,7 @@ impl<'a> Access<'a> {
                     })
                 }
             }
-            (&Self::VariantIndex(_), actual) => Err(AccessErrorKind::IncompatibleTypes {
+            (&Self::Variant(_), actual) => Err(AccessErrorKind::IncompatibleTypes {
                 expected: ReflectKind::Enum,
                 actual: actual.into(),
             }),
@@ -142,21 +203,14 @@ impl<'a> Access<'a> {
         base: &'r mut dyn PartialReflect,
     ) -> InnerResult<Option<&'r mut dyn PartialReflect>> {
         use ReflectMut::*;
+        use VariantAccess::*;
 
         let invalid_variant =
             |expected, actual| AccessErrorKind::IncompatibleEnumVariantTypes { expected, actual };
 
         match (self, base.reflect_mut()) {
             (Self::Field(field), Struct(struct_mut)) => Ok(struct_mut.field_mut(field.as_ref())),
-            (Self::Field(field), Enum(enum_mut)) => match enum_mut.variant_type() {
-                VariantType::Struct => Ok(enum_mut.field_mut(field.as_ref())),
-                actual => Err(invalid_variant(VariantType::Struct, actual)),
-            },
             (&Self::FieldIndex(index), Struct(struct_mut)) => Ok(struct_mut.field_at_mut(index)),
-            (&Self::FieldIndex(index), Enum(enum_mut)) => match enum_mut.variant_type() {
-                VariantType::Struct => Ok(enum_mut.field_at_mut(index)),
-                actual => Err(invalid_variant(VariantType::Struct, actual)),
-            },
             (Self::Field(_) | Self::FieldIndex(_), actual) => {
                 Err(AccessErrorKind::IncompatibleTypes {
                     expected: ReflectKind::Struct,
@@ -166,10 +220,6 @@ impl<'a> Access<'a> {
 
             (&Self::TupleIndex(index), TupleStruct(tuple)) => Ok(tuple.field_mut(index)),
             (&Self::TupleIndex(index), Tuple(tuple)) => Ok(tuple.field_mut(index)),
-            (&Self::TupleIndex(index), Enum(enum_mut)) => match enum_mut.variant_type() {
-                VariantType::Tuple => Ok(enum_mut.field_at_mut(index)),
-                actual => Err(invalid_variant(VariantType::Tuple, actual)),
-            },
             (Self::TupleIndex(_), actual) => Err(AccessErrorKind::IncompatibleTypes {
                 expected: ReflectKind::Tuple,
                 actual: actual.into(),
@@ -181,7 +231,46 @@ impl<'a> Access<'a> {
                 expected: ReflectKind::List,
                 actual: actual.into(),
             }),
-            (&Self::VariantIndex(index), Enum(enum_ref)) => {
+            (Self::Variant(Field(index, field)), Enum(enum_ref)) => {
+                if enum_ref.variant_index() != *index {
+                    Err(AccessErrorKind::IncorrectEnumVariantIndex {
+                        expected: *index,
+                        actual: enum_ref.variant_index(),
+                    })
+                } else {
+                    match enum_ref.variant_type() {
+                        VariantType::Struct => Ok(enum_ref.field_mut(field.as_ref())),
+                        actual => Err(invalid_variant(VariantType::Struct, actual)),
+                    }
+                }
+            }
+            (&Self::Variant(FieldIndex(v_index, index)), Enum(enum_ref)) => {
+                if enum_ref.variant_index() != v_index {
+                    Err(AccessErrorKind::IncorrectEnumVariantIndex {
+                        expected: v_index,
+                        actual: enum_ref.variant_index(),
+                    })
+                } else {
+                    match enum_ref.variant_type() {
+                        VariantType::Struct => Ok(enum_ref.field_at_mut(index)),
+                        actual => Err(invalid_variant(VariantType::Struct, actual)),
+                    }
+                }
+            }
+            (&Self::Variant(TupleIndex(v_index, index)), Enum(enum_ref)) => {
+                if enum_ref.variant_index() != v_index {
+                    Err(AccessErrorKind::IncorrectEnumVariantIndex {
+                        expected: v_index,
+                        actual: enum_ref.variant_index(),
+                    })
+                } else {
+                    match enum_ref.variant_type() {
+                        VariantType::Tuple => Ok(enum_ref.field_at_mut(index)),
+                        actual => Err(invalid_variant(VariantType::Tuple, actual)),
+                    }
+                }
+            }
+            (&Self::Variant(Unit(index)), Enum(enum_ref)) => {
                 if enum_ref.variant_index() == index {
                     Ok(Some(enum_ref.as_partial_reflect_mut()))
                 } else {
@@ -191,7 +280,7 @@ impl<'a> Access<'a> {
                     })
                 }
             }
-            (&Self::VariantIndex(_), actual) => Err(AccessErrorKind::IncompatibleTypes {
+            (&Self::Variant(_), actual) => Err(AccessErrorKind::IncompatibleTypes {
                 expected: ReflectKind::Enum,
                 actual: actual.into(),
             }),
@@ -202,19 +291,21 @@ impl<'a> Access<'a> {
     pub fn display_value(&self) -> &dyn fmt::Display {
         match self {
             Self::Field(value) => value,
-            Self::FieldIndex(value)
-            | Self::TupleIndex(value)
-            | Self::ListIndex(value)
-            | Self::VariantIndex(value) => value,
+            Self::FieldIndex(value) | Self::TupleIndex(value) | Self::ListIndex(value) => value,
+            Self::Variant(value) => value,
         }
     }
 
     pub(super) fn kind(&self) -> &'static str {
+        use VariantAccess::*;
         match self {
             Self::Field(_) => "field",
             Self::FieldIndex(_) => "field index",
             Self::TupleIndex(_) | Self::ListIndex(_) => "index",
-            Self::VariantIndex(_) => "variant index",
+            Self::Variant(Unit(_)) => "unit variant index",
+            Self::Variant(FieldIndex(_, _)) => "variant index with field index",
+            Self::Variant(TupleIndex(_, _)) => "variant index with tuple index",
+            Self::Variant(Field(_, _)) => "variant index with field",
         }
     }
 }

--- a/crates/bevy_reflect/src/path/error.rs
+++ b/crates/bevy_reflect/src/path/error.rs
@@ -120,9 +120,8 @@ impl fmt::Display for AccessError<'_> {
                         "The {type_accessed} accessed doesn't have index `{}`",
                         access.display_value()
                     ),
-                    // This should be unreachable.
-                    // TODO - make sure we fix this when we make paired v_index + field access
-                    Access::VariantIndex(_) => write!(f, "If you are reading this, send help." ),
+                    //TODO - migrate IncompatibleEnumVariantTypes here.
+                    Access::Variant(_) => write!(f, "If you are reading this, send help." ),
                     
                 }
             }

--- a/crates/bevy_reflect/src/path/error.rs
+++ b/crates/bevy_reflect/src/path/error.rs
@@ -27,6 +27,14 @@ pub enum AccessErrorKind {
         /// The actual [`VariantType`] that was found.
         actual: VariantType,
     },
+    /// An error that occurs when using an [`Access`] on the wrong enum variant index.
+    /// (ex: attempting to access `{3}` on Option<u32>)
+    IncorrectEnumVariantIndex {
+        /// The variant index that was expected based on the [`Access`]
+        expected: usize,
+        /// The actual index of the enum variant
+        actual: usize
+    },
 }
 
 impl AccessErrorKind {
@@ -111,7 +119,11 @@ impl fmt::Display for AccessError<'_> {
                         f,
                         "The {type_accessed} accessed doesn't have index `{}`",
                         access.display_value()
-                    )
+                    ),
+                    // This should be unreachable.
+                    // TODO - make sure we fix this when we make paired v_index + field access
+                    Access::VariantIndex(_) => write!(f, "If you are reading this, send help." ),
+                    
                 }
             }
             AccessErrorKind::IncompatibleTypes { expected, actual } => write!(
@@ -124,6 +136,7 @@ impl fmt::Display for AccessError<'_> {
                 "Expected variant {} access to access a {expected:?} variant, found a {actual:?} variant instead.",
                 access.kind()
             ),
+            AccessErrorKind::IncorrectEnumVariantIndex { expected, actual } => write!(f, "Expected to access variant {} at index {expected:?}, found variant with index {actual:?} instead.", access.kind()),
         }
     }
 }

--- a/crates/bevy_reflect/src/path/error.rs
+++ b/crates/bevy_reflect/src/path/error.rs
@@ -1,7 +1,7 @@
 use core::fmt;
 
 use super::Access;
-use crate::{enums::VariantType, ReflectKind};
+use crate::{enums::VariantType, ReflectKind, VariantAccess};
 
 /// The kind of [`AccessError`], along with some kind-specific information.
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -28,12 +28,12 @@ pub enum AccessErrorKind {
         actual: VariantType,
     },
     /// An error that occurs when using an [`Access`] on the wrong enum variant index.
-    /// (ex: attempting to access `{3}` on Option<u32>)
+    /// (ex: attempting to access `{3}` on `Option<u32>`)
     IncorrectEnumVariantIndex {
         /// The variant index that was expected based on the [`Access`]
         expected: usize,
         /// The actual index of the enum variant
-        actual: usize
+        actual: usize,
     },
 }
 
@@ -99,6 +99,7 @@ impl fmt::Display for AccessError<'_> {
 
         match kind {
             AccessErrorKind::MissingField(type_accessed) => {
+                use VariantAccess::*;
                 match access {
                     Access::Field(field) => write!(
                         f,
@@ -120,11 +121,27 @@ impl fmt::Display for AccessError<'_> {
                         "The {type_accessed} accessed doesn't have index `{}`",
                         access.display_value()
                     ),
-                    //TODO - migrate IncompatibleEnumVariantTypes here.
-                    Access::Variant(_) => write!(f, "If you are reading this, send help." ),
-                    
+                    Access::Variant(v_access) => match v_access {
+                        // It ~should~ be syntactically impossible to express the access of a field on a unit variant,
+                        // (eg, you should be getting a IncompatibleEnumVariantType error instead)
+                        // but if we manage to break this in the future this error will be a breadcrumb.
+                        Unit(_index) => write!(f, "You have attempted to access a field on a unit Enum Variant"),
+                        Field(index, field) => write!(
+                            f,
+                            "The {type_accessed} variant at index {} doesn't have {} `{}` field",
+                            index,
+                            if let Some("a" | "e" | "i" | "o" | "u") = field.get(0..1) {
+                                "an"
+                            } else {
+                                "a"
+                            },
+                            access.display_value()
+                        ),
+                        FieldIndex(index, _) => write!(f, "The {type_accessed} variant at index {} doesn't have field index `{}`",index, access.display_value()),
+                        TupleIndex(index, _) => write!(f,"The {type_accessed} variant at index {}, doesn't have tuple index `{}`",index,access.display_value()),
+                    }
                 }
-            }
+            },
             AccessErrorKind::IncompatibleTypes { expected, actual } => write!(
                 f,
                 "Expected {} access to access a {expected}, found a {actual} instead.",

--- a/crates/bevy_reflect/src/path/mod.rs
+++ b/crates/bevy_reflect/src/path/mod.rs
@@ -807,6 +807,16 @@ mod tests {
             })
         );
         assert_eq!(
+            a.reflect_path("tuple_variant{1.32}").err().unwrap(),
+            ReflectPathError::InvalidAccess(AccessError {
+                kind: AccessErrorKind::MissingField(ReflectKind::Enum),
+                access: ParsedPath::parse_static("tuple_variant{1.32}").unwrap()[1]
+                    .access
+                    .clone(),
+                offset: Some(14)
+            })
+        );
+        assert_eq!(
             a.reflect_path("x[0]").err().unwrap(),
             invalid_access(2, ReflectKind::Struct, ReflectKind::List, "x[0]")
         );

--- a/crates/bevy_reflect/src/path/mod.rs
+++ b/crates/bevy_reflect/src/path/mod.rs
@@ -683,6 +683,10 @@ mod tests {
         let j = ParsedPath::parse("tuple_variant.1").unwrap();
         let k = ParsedPath::parse("struct_variant.東京").unwrap();
         let l = ParsedPath::parse("struct_variant#0").unwrap();
+        let i2 = ParsedPath::parse("unit_variant{0}").unwrap();
+        let j2 = ParsedPath::parse("tuple_variant{1}.1").unwrap();
+        let k2 = ParsedPath::parse("struct_variant{2}.東京").unwrap();
+        let l2 = ParsedPath::parse("struct_variant{2}#0").unwrap();
         let m = ParsedPath::parse("array[2]").unwrap();
         let n = ParsedPath::parse("tuple.1").unwrap();
 
@@ -698,6 +702,10 @@ mod tests {
             assert_eq!(*j.element::<u32>(&a).unwrap(), 321);
             assert_eq!(*k.element::<char>(&a).unwrap(), 'm');
             assert_eq!(*l.element::<char>(&a).unwrap(), 'm');
+            assert_eq!(*i2.element::<F>(&a).unwrap(), F::Unit);
+            assert_eq!(*j2.element::<u32>(&a).unwrap(), 321);
+            assert_eq!(*k2.element::<char>(&a).unwrap(), 'm');
+            assert_eq!(*l2.element::<char>(&a).unwrap(), 'm');
             assert_eq!(*m.element::<i32>(&a).unwrap(), 309);
             assert_eq!(*n.element::<f32>(&a).unwrap(), 1.23);
         }
@@ -792,6 +800,19 @@ mod tests {
                     expected: VariantType::Tuple,
                 },
                 access: ParsedPath::parse_static("unit_variant.0").unwrap()[1]
+                    .access
+                    .clone(),
+                offset: Some(13),
+            })
+        );
+        assert_eq!(
+            a.reflect_path("unit_variant{4}.0").err().unwrap(),
+            ReflectPathError::InvalidAccess(AccessError {
+                kind: AccessErrorKind::IncorrectEnumVariantIndex {
+                    expected: 4,
+                    actual: 0
+                },
+                access: ParsedPath::parse_static("unit_variant{4}.0").unwrap()[1]
                     .access
                     .clone(),
                 offset: Some(13),

--- a/crates/bevy_reflect/src/path/mod.rs
+++ b/crates/bevy_reflect/src/path/mod.rs
@@ -181,15 +181,8 @@ impl<'a> ReflectPath<'a> for &'a str {
 /// Pathing for [`Enum`] elements works a bit differently than in normal Rust.
 /// Usually, you would need to pattern match an enum, branching off on the desired variants.
 /// Paths used by this trait do not have any pattern matching capabilities;
-/// instead, they assume the variant is already known ahead of time.
+/// instead, they rely on the variant's index.
 ///
-/// The syntax used, therefore, depends on the variant being accessed:
-/// - Struct variants use the struct syntax (outlined above)
-/// - Tuple variants use the tuple syntax (outlined above)
-/// - Unit variants have no fields to access
-///
-/// If the variant cannot be known ahead of time, the path will need to be split up
-/// and proper enum pattern matching will need to be handled manually.
 ///
 /// ### Example
 /// ```
@@ -204,16 +197,16 @@ impl<'a> ReflectPath<'a> for &'a str {
 /// }
 ///
 /// let tuple_variant = MyEnum::Tuple(true);
-/// assert_eq!(tuple_variant.path::<bool>(".0").unwrap(), &true);
+/// assert_eq!(tuple_variant.path::<bool>("{1.0}").unwrap(), &true);
 ///
 /// let struct_variant = MyEnum::Struct { value: 123 };
 /// // Access via field name
-/// assert_eq!(struct_variant.path::<u32>(".value").unwrap(), &123);
+/// assert_eq!(struct_variant.path::<u32>("{2.value}").unwrap(), &123);
 /// // Access via field index
-/// assert_eq!(struct_variant.path::<u32>("#0").unwrap(), &123);
+/// assert_eq!(struct_variant.path::<u32>("{2#0}").unwrap(), &123);
 ///
 /// // Error: Expected struct variant
-/// assert!(matches!(tuple_variant.path::<u32>(".value"), Err(_)));
+/// assert!(matches!(tuple_variant.path::<u32>("{1.value}"), Err(_)));
 /// ```
 ///
 /// # Chaining
@@ -233,7 +226,7 @@ impl<'a> ReflectPath<'a> for &'a str {
 ///   value: vec![None, None, Some(123)],
 /// };
 /// assert_eq!(
-///   my_struct.path::<u32>(".value[2].0").unwrap(),
+///   my_struct.path::<u32>(".value[2]{1.0}").unwrap(),
 ///   &123,
 /// );
 /// ```
@@ -381,6 +374,9 @@ impl ParsedPath {
     /// - Unnamed field access (`.1`)
     /// - Field index access (`#0`)
     /// - Sequence access (`[2]`)
+    /// - Enum Unit Variant access (`{0}`) - ex, `Option::None`
+    /// - Enum Tuple Variant access (`{1.0}`) - ex, `Option::Some(true)`
+    /// - Enum Struct Variant access (`{2.some_field_name}`)
     ///
     /// # Example
     /// ```
@@ -404,7 +400,7 @@ impl ParsedPath {
     ///   },
     /// };
     ///
-    /// let parsed_path = ParsedPath::parse("bar#0.1[2].0").unwrap();
+    /// let parsed_path = ParsedPath::parse("bar#0.1[2]{1.0}").unwrap();
     /// // Breakdown:
     /// //   "bar" - Access struct field named "bar"
     /// //   "#0" - Access struct field at index 0
@@ -679,14 +675,10 @@ mod tests {
         let f = ParsedPath::parse("z.0.1").unwrap();
         let g = ParsedPath::parse("x#0").unwrap();
         let h = ParsedPath::parse("x#1#0").unwrap();
-        let i = ParsedPath::parse("unit_variant").unwrap();
-        let j = ParsedPath::parse("tuple_variant.1").unwrap();
-        let k = ParsedPath::parse("struct_variant.東京").unwrap();
-        let l = ParsedPath::parse("struct_variant#0").unwrap();
-        let i2 = ParsedPath::parse("unit_variant{0}").unwrap();
-        let j2 = ParsedPath::parse("tuple_variant{1}.1").unwrap();
-        let k2 = ParsedPath::parse("struct_variant{2}.東京").unwrap();
-        let l2 = ParsedPath::parse("struct_variant{2}#0").unwrap();
+        let i = ParsedPath::parse("unit_variant{0}").unwrap();
+        let j = ParsedPath::parse("tuple_variant{1.1}").unwrap();
+        let k = ParsedPath::parse("struct_variant{2.東京}").unwrap();
+        let l = ParsedPath::parse("struct_variant{2#0}").unwrap();
         let m = ParsedPath::parse("array[2]").unwrap();
         let n = ParsedPath::parse("tuple.1").unwrap();
 
@@ -702,10 +694,6 @@ mod tests {
             assert_eq!(*j.element::<u32>(&a).unwrap(), 321);
             assert_eq!(*k.element::<char>(&a).unwrap(), 'm');
             assert_eq!(*l.element::<char>(&a).unwrap(), 'm');
-            assert_eq!(*i2.element::<F>(&a).unwrap(), F::Unit);
-            assert_eq!(*j2.element::<u32>(&a).unwrap(), 321);
-            assert_eq!(*k2.element::<char>(&a).unwrap(), 'm');
-            assert_eq!(*l2.element::<char>(&a).unwrap(), 'm');
             assert_eq!(*m.element::<i32>(&a).unwrap(), 309);
             assert_eq!(*n.element::<f32>(&a).unwrap(), 1.23);
         }
@@ -766,10 +754,10 @@ mod tests {
         assert_eq!(*a.path::<usize>("x#0").unwrap(), 10);
         assert_eq!(*a.path::<f32>("x#1#0").unwrap(), 3.14);
 
-        assert_eq!(*a.path::<F>("unit_variant").unwrap(), F::Unit);
-        assert_eq!(*a.path::<u32>("tuple_variant.1").unwrap(), 321);
-        assert_eq!(*a.path::<char>("struct_variant.東京").unwrap(), 'm');
-        assert_eq!(*a.path::<char>("struct_variant#0").unwrap(), 'm');
+        assert_eq!(*a.path::<F>("unit_variant{0}").unwrap(), F::Unit);
+        assert_eq!(*a.path::<u32>("tuple_variant{1.1}").unwrap(), 321);
+        assert_eq!(*a.path::<char>("struct_variant{2.東京}").unwrap(), 'm');
+        assert_eq!(*a.path::<char>("struct_variant{2#0}").unwrap(), 'm');
 
         assert_eq!(*a.path::<i32>("array[2]").unwrap(), 309);
 
@@ -780,7 +768,7 @@ mod tests {
         *a.path_mut::<f32>("y[1].mосква").unwrap() = 3.0;
         assert_eq!(a.y[1].mосква, 3.0);
 
-        *a.path_mut::<u32>("tuple_variant.0").unwrap() = 1337;
+        *a.path_mut::<u32>("tuple_variant{1.0}").unwrap() = 1337;
         assert_eq!(a.tuple_variant, F::Tuple(1337, 321));
 
         assert_eq!(
@@ -793,26 +781,26 @@ mod tests {
         );
 
         assert_eq!(
-            a.reflect_path("unit_variant.0").err().unwrap(),
+            a.reflect_path("unit_variant{0.0}").err().unwrap(),
             ReflectPathError::InvalidAccess(AccessError {
                 kind: AccessErrorKind::IncompatibleEnumVariantTypes {
                     actual: VariantType::Unit,
                     expected: VariantType::Tuple,
                 },
-                access: ParsedPath::parse_static("unit_variant.0").unwrap()[1]
+                access: ParsedPath::parse_static("unit_variant{0.0}").unwrap()[1]
                     .access
                     .clone(),
                 offset: Some(13),
             })
         );
         assert_eq!(
-            a.reflect_path("unit_variant{4}.0").err().unwrap(),
+            a.reflect_path("unit_variant{4.0}").err().unwrap(),
             ReflectPathError::InvalidAccess(AccessError {
                 kind: AccessErrorKind::IncorrectEnumVariantIndex {
                     expected: 4,
                     actual: 0
                 },
-                access: ParsedPath::parse_static("unit_variant{4}.0").unwrap()[1]
+                access: ParsedPath::parse_static("unit_variant{4.0}").unwrap()[1]
                     .access
                     .clone(),
                 offset: Some(13),

--- a/crates/bevy_reflect/src/path/parse.rs
+++ b/crates/bevy_reflect/src/path/parse.rs
@@ -97,6 +97,15 @@ impl<'a> PathParser<'a> {
                     None => Err(Error::Unclosed),
                 }
             }
+            Token::CloseCurly => Err(Error::CloseBeforeOpen),
+            Token::OpenCurly => {
+                let index_ident = self.next_ident()?.variant_index()?;
+                match self.next_token() {
+                    Some(Token::CloseCurly) => Ok(index_ident),
+                    Some(other) => Err(Error::BadClose(other)),
+                    None => Err(Error::Unclosed),
+                }
+            }
         }
     }
 
@@ -137,6 +146,9 @@ impl<'a> Ident<'a> {
     fn list_index(self) -> Result<Access<'a>, Error<'a>> {
         Ok(Access::ListIndex(self.0.parse()?))
     }
+    fn variant_index(self) -> Result<Access<'a>, Error<'a>> {
+        Ok(Access::VariantIndex(self.0.parse()?))
+    }
 }
 
 // NOTE: We use repr(u8) so that the `match byte` in `Token::symbol_from_byte`
@@ -149,6 +161,8 @@ enum Token<'a> {
     Pound = b'#',
     OpenBracket = b'[',
     CloseBracket = b']',
+    OpenCurly = b'{',
+    CloseCurly = b'}',
     Ident(Ident<'a>),
 }
 
@@ -159,19 +173,23 @@ impl fmt::Display for Token<'_> {
             Token::Pound => f.write_char('#'),
             Token::OpenBracket => f.write_char('['),
             Token::CloseBracket => f.write_char(']'),
+            Token::OpenCurly => f.write_char('{'),
+            Token::CloseCurly => f.write_char('}'),
             Token::Ident(ident) => f.write_str(ident.0),
         }
     }
 }
 
 impl<'a> Token<'a> {
-    const SYMBOLS: &'static [u8] = b".#[]";
+    const SYMBOLS: &'static [u8] = b".#[]{}";
     fn symbol_from_byte(byte: u8) -> Option<Self> {
         match byte {
             b'.' => Some(Self::Dot),
             b'#' => Some(Self::Pound),
             b'[' => Some(Self::OpenBracket),
             b']' => Some(Self::CloseBracket),
+            b'{' => Some(Self::OpenCurly),
+            b'}' => Some(Self::CloseCurly),
             _ => None,
         }
     }

--- a/crates/bevy_reflect/src/path/parse.rs
+++ b/crates/bevy_reflect/src/path/parse.rs
@@ -90,7 +90,7 @@ impl<'a> PathParser<'a> {
             Token::Dot => Ok(self.next_ident()?.field()),
             Token::Pound => self.next_ident()?.field_index(),
             Token::Ident(ident) => Ok(ident.field()),
-            Token::CloseBracket => Err(Error::CloseBeforeOpen),
+            Token::CloseBracket | Token::CloseCurly => Err(Error::CloseBeforeOpen),
             Token::OpenBracket => {
                 let index_ident = self.next_ident()?.list_index()?;
                 match self.next_token() {
@@ -99,8 +99,6 @@ impl<'a> PathParser<'a> {
                     None => Err(Error::Unclosed),
                 }
             }
-            Token::CloseCurly => Err(Error::CloseBeforeOpen),
-
             Token::OpenCurly => {
                 let index_ident = self.next_ident()?.variant_index()?;
                 let vindex = (match index_ident {

--- a/crates/bevy_reflect/src/path/parse.rs
+++ b/crates/bevy_reflect/src/path/parse.rs
@@ -5,6 +5,8 @@ use core::{
 };
 use thiserror::Error;
 
+use crate::VariantAccess;
+
 use super::{Access, ReflectPathError};
 
 /// An error that occurs when parsing reflect path strings.
@@ -98,10 +100,50 @@ impl<'a> PathParser<'a> {
                 }
             }
             Token::CloseCurly => Err(Error::CloseBeforeOpen),
+
             Token::OpenCurly => {
                 let index_ident = self.next_ident()?.variant_index()?;
+                let vindex = (match index_ident {
+                    // "Safety" here depends on variant_index only returning Unit
+                    Access::Variant(VariantAccess::Unit(v)) => Some(v),
+                    _ => None,
+                })
+                .expect("unreachable");
                 match self.next_token() {
+                    //This is a unit variant, form: {1}
                     Some(Token::CloseCurly) => Ok(index_ident),
+                    //This is a field variant, form {1.field}
+                    Some(Token::Dot) => {
+                        let val_ident = self.next_ident()?.field();
+                        match self.next_token() {
+                            Some(Token::CloseCurly) => match val_ident {
+                                Access::Field(cow) => {
+                                    Ok(Access::Variant(VariantAccess::Field(vindex, cow)))
+                                }
+                                Access::TupleIndex(idx) => {
+                                    Ok(Access::Variant(VariantAccess::TupleIndex(vindex, idx)))
+                                }
+                                // "Safety" here depends on Ident::field only returning Field/TupleIndex
+                                _ => panic!("unreachable"),
+                            },
+                            _ => Err(Error::Unclosed),
+                        }
+                    }
+                    //this is an index variant, form {1#2}
+                    Some(Token::Pound) => {
+                        let val_ident = self.next_ident()?.field_index()?;
+                        let val = (match val_ident {
+                            Access::FieldIndex(val) => Some(val),
+                            _ => None,
+                        })
+                        .expect("unreachable");
+                        match self.next_token() {
+                            Some(Token::CloseCurly) => {
+                                Ok(Access::Variant(VariantAccess::FieldIndex(vindex, val)))
+                            }
+                            _ => Err(Error::Unclosed),
+                        }
+                    }
                     Some(other) => Err(Error::BadClose(other)),
                     None => Err(Error::Unclosed),
                 }
@@ -147,7 +189,7 @@ impl<'a> Ident<'a> {
         Ok(Access::ListIndex(self.0.parse()?))
     }
     fn variant_index(self) -> Result<Access<'a>, Error<'a>> {
-        Ok(Access::VariantIndex(self.0.parse()?))
+        Ok(Access::Variant(VariantAccess::Unit(self.0.parse()?)))
     }
 }
 

--- a/release-content/migration-guides/reflect_path_variant_index_support.md
+++ b/release-content/migration-guides/reflect_path_variant_index_support.md
@@ -1,0 +1,85 @@
+---
+title: ReflectPath
+pull_requests: [23137]
+---
+
+`ReflectPath` in  `bevy_reflect` now supports and enforces accessing specified enum variants under reflection.
+
+In previous releases, access to an enum under reflection was treated the same way as accessing a struct with a similar shape.
+
+In example:
+
+```rust
+//0.18
+
+struct MyStruct(u32,u32);
+let my_struct = MyStruct(6,5);
+// String encoding access for the first field of a tuple struct.
+let value_index_0 = ".0"
+// String encoding access for the second field of a tuple struct.
+let value_index_1 = ".1"
+// We can use these for accessing a tuple struct....
+let six = value_index_0.reflect_element::<u32>(my_struct).unwrap();
+let five = value_index_1.reflect_element::<u32>(my_struct).unwrap();
+
+
+let err_six : Result<u32> = Err(6);
+let ok_five : Result<u32> = Ok(5);
+// or even an enum with the shape of a tuple struct
+let still_six = value_index_0.reflect_element::<u32>(err_six).unwrap();
+// But we can see here that our path does not encode any difference between variants Ok and Err!
+let still_five = value_index_0.reflect_element(ok_fiveanother_enum).unwrap();
+```
+
+This poses obvious soundness issues with our path!
+
+
+ Now that `ReflectPath` can encode and enforce assumptions about which variant we are accessing, we can enforce a limited degree of soundness:
+ 
+ 
+ ```rust
+ //0.19
+ 
+struct MyStruct(u32,u32);
+let my_struct = MyStruct(6,5);
+// String encoding access for the first field of a tuple struct.
+let value_index_0 = ".0"
+// String encoding access for the second field of a tuple struct.
+let value_index_1 = ".1"
+// String encoding access for the variant at index 0, and the field at index 0
+let variant_index_0_value_index_0 = "{0.0}"
+// String encoding access for the variant at index 1 and the field at index 0
+let variant_index_1_value_index_0 = "{1.0}"
+// We can use these for accessing a tuple struct....
+let six = path_a.reflect_element::<u32>(my_struct).unwrap();
+let five = path_b.reflect_element::<u32>(my_struct).unwrap();
+
+
+let err_six : Result<u32> = Err(6);
+let ok_five : Result<u32> = Ok(5);
+// this now panics! 
+let _  = value_index_0.reflect_element::<u32>(err_six).unwrap();
+//  "Ok" is at index 1, but our path wants index 0, so this will also panic!
+let  _  = variant_index_0_value_index_0.reflect_element::<u32>(ok_five).unwrap(); 
+// Here we can successfully access specifically value 0 of variant 0
+let safe_six = variant_index_0_value_index_0.reflect_element::<u32>(err_six).unwrap();
+// Or, value 0 of variant 1
+let final_five = variant_index_1_value_index_0.reflect_element::<u32>(ok_five).unwrap();
+ ```
+
+
+This change also changes the syntax supported by `ReflectPath` into something that is capable of statically addressing arbitrary fields on types.
+
+Because of this ambiguity, users wishing to express structural access to a field without an instance of a type could not do so, which impaired the ergonomics and utility of abstractions built on top of `ReflectPath` in spaces such as BRP, editors, or inspectors.
+
+
+
+Copy the contents of this file into a new file in `./migration-guides`, update the metadata, and add migration guide content here.
+
+Remember, your aim is to communicate:
+
+- What has changed since the last release?
+- Why did we make this breaking change?
+- How can users migrate their existing code?
+
+For more specifics about style and content, see the [instructions](./migration_guides.md).

--- a/release-content/migration-guides/reflect_path_variant_index_support.md
+++ b/release-content/migration-guides/reflect_path_variant_index_support.md
@@ -33,10 +33,8 @@ let still_five = value_index_0.reflect_element(ok_fiveanother_enum).unwrap();
 
 This poses obvious soundness issues with our path!
 
-
  Now that `ReflectPath` can encode and enforce assumptions about which variant we are accessing, we can enforce a limited degree of soundness:
- 
- 
+
  ```rust
  //0.19
  
@@ -67,19 +65,6 @@ let safe_six = variant_index_0_value_index_0.reflect_element::<u32>(err_six).unw
 let final_five = variant_index_1_value_index_0.reflect_element::<u32>(ok_five).unwrap();
  ```
 
-
 This change also changes the syntax supported by `ReflectPath` into something that is capable of statically addressing arbitrary fields on types.
 
 Because of this ambiguity, users wishing to express structural access to a field without an instance of a type could not do so, which impaired the ergonomics and utility of abstractions built on top of `ReflectPath` in spaces such as BRP, editors, or inspectors.
-
-
-
-Copy the contents of this file into a new file in `./migration-guides`, update the metadata, and add migration guide content here.
-
-Remember, your aim is to communicate:
-
-- What has changed since the last release?
-- Why did we make this breaking change?
-- How can users migrate their existing code?
-
-For more specifics about style and content, see the [instructions](./migration_guides.md).


### PR DESCRIPTION
# Objective

Currently, the machinery provided by Bevy's `GetPath` trait is agnostic about which enum variant it provides access to.

This limitation prevents users from disambiguating between identically named fields on variant structs (ehh...) or indices on variant tuples (EG, there's no way to disambiguate access between say,  `Result::Ok` or `Result::Err`).

Historically, this ability to disambiguate hasn't been necessary to support common reflection cases, as we can generally assume that under reflection, you have an instance available to reflect, and can therefor interrogate the structure of the instance if you really need to.

However, as `The Editor` (tm) fast approaches, a new category of use-cases for `bevy_reflect` are being uncovered -
They include such cases as:
 - Abstractions on top of reflection, such that an `AccessPath` may need to be constructed without access to an instance of a type
 - Overrides for `CustomAttribute` (or similarly stored future concepts) data to decorate editor functionality at runtime - allowing the `TypeRegistry` or similar, editor/inspector-specific resource to play host to arbitrary field level data

Imagine, for example, some resource -
```rust
HashMap<(TypeId, AccessPath), &dyn MyMagicWidgetBuilder>
```
where a tool author might be able to selectively override inspector widget construction for their project.

Today, we can't build that, because `AccessPath` can facilitate arbitrary structural access for an instance, but the inability to discriminate between enum variants means it can't express arbitrary structural access for a type. 



## Solution

Implement a minimal adjustment to `GetPath` to support discrimination between enum variant indices.




## Testing


Changes necessary to support this feature were small enough that the existing test suite was able to provide adequate coverage with only minimal additions.


## Showcase


Example of accessing an enum under reflection today:
```rust
let six = Some(6).path::<u32>(".0").unwrap();
```
Example of proposed change:
```rust
let six = Some(6).path::<u32>("{1.0}").unwrap();
```


## Alternatives and Disclaimers

### I do not understand the current design choice.

I'm not sure why we chose not to do this originally. 
It is very possible I have overlooked some vital use-case that my change would invalidate or over-complicate.

### This syntax is kinda gross

I'm not really a huge fan of this syntax. 

The current implementation of `Access` relies on being able to jam the `Token` enum into a `u8` - I did what seemed sensible with the token space available. It seems extremely plausible that better ideas exist here.

### We could support this but not require it

I started with an even smaller version of this change that would make specifying the enum variant index optional - the syntax would work largely as is, but you could optionally supply an enum variant index and `Access` would validate it for you if it found one.

I'm still not entirely confident that's not a superior option, but I ended up doing this instead simply because I kind of stalled out trying to write docs that adequately explained what good optional validation would be to anyone without info-dumping my editor design manifesto into a doc comment.


### We could just not do this.

We could also just re-implement most of this machinery in a more specifically targeted fashion for Inspector/Editor use instead.

For my part, I believe expanding this concept very slightly to support adjacent use-cases makes more sense than re-implementing this elsewhere, but I also feel I am largely ignorant of the full scope of the design goals for `bevy_reflect`, and could certainly be wrong.