### PR TITLE
Fix `AssetChanged<A>` UB

### DIFF
--- a/crates/bevy_asset/src/asset_changed.rs
+++ b/crates/bevy_asset/src/asset_changed.rs
@@ -170,9 +170,8 @@ unsafe impl<A: AsAssetId> WorldQuery for AssetChanged<A> {
         // SAFETY:
         // - `state.resource_id` was obtained from `world.init_resource::<AssetChanges<A::Asset>>()`,
         //   so the untyped pointer returned by `get_resource_by_id` can safely be dereferenced into that type.
-        // - `update_component_access` declares a read on `state.resource_id`, so it is safe to
-        //   read that resource here (see trait-level safety comments on `WorldQuery`, regarding
-        //   readonly resource access in `init_fetch`)
+        // - `init_nested_access` declares a read on `state.resource_id`, so it is safe to
+        //   read that resource here (see trait-level safety comments on `WorldQuery`)
         let Some(changes) = (unsafe {
             world
                 .get_resource_by_id(state.resource_id)


### PR DESCRIPTION
# Objective

Fixes #23057.

## Solution

Uses Nested Queries from #21557 to also register the resource entity to the access set.

## Testing

Added an extra test.