### PR TITLE
Bump `bevy_reflect` MSRV to 1.95.0 and revert "Workaround rustfmt panic on `quote!(Self(#var))` in Rust 1.93.0 (#22669)"

### DIFF
--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://bevy.org"
 repository = "https://github.com/bevyengine/bevy"
 license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
-rust-version = "1.87.0"
+rust-version = "1.95.0"
 
 [features]
 default = ["std", "smallvec", "indexmap", "debug", "auto_register_inventory"]

--- a/crates/bevy_reflect/derive/src/from_reflect.rs
+++ b/crates/bevy_reflect/derive/src/from_reflect.rs
@@ -146,11 +146,6 @@ fn impl_struct_internal(
     // The constructed "Self" ident
     let __this = Ident::new("__this", Span::call_site());
 
-    // Workaround for rustfmt issue: https://github.com/rust-lang/rustfmt/issues/6779
-    // `quote!(Self(#__this))` causes rustfmt to panic in Rust 1.93.0+
-    // TODO: not needed after Rust 1.94
-    let self_ty = quote!(Self);
-
     // The reflected type: either `Self` or a remote type
     let (reflect_ty, constructor, retval) = if let Some(remote_ty) = remote_ty {
         let constructor = match remote_ty.as_expr_path() {
@@ -162,10 +157,10 @@ fn impl_struct_internal(
         (
             quote!(#remote_ty),
             quote!(#constructor),
-            quote!(#self_ty(#__this)),
+            quote!(Self(#__this)),
         )
     } else {
-        (quote!(#self_ty), quote!(#self_ty), quote!(#__this))
+        (quote!(Self), quote!(Self), quote!(#__this))
     };
 
     let constructor = if is_defaultable {


### PR DESCRIPTION
# Objective

* This PR reverts https://github.com/bevyengine/bevy/pull/22669 since the temporary workaround should no longer be needed in 1.93.1+.

The root cause for the rustfmt ICE was fixed in <https://github.com/rust-lang/rust/pull/150590> which was included in the Rust 1.93.1 point release.

## Solution

* Plain revert of #22669.
* Since top-level `bevy` MSRV was bumped to 1.95.0 in https://github.com/bevyengine/bevy/commit/4fd09ffd231ffce3d8dc455510907c407609878b, this PR also bumps `bevy_reflect` MSRV to 1.95.0.

## Testing

- Upstream `rust-lang/rust` regression test: https://github.com/rust-lang/rust/blob/859951e3c7c9d0322c39bad49221937455bdffcd/tests/ui/parser/macro/kw-in-item-pos-recovery-149692.rs
- Against changes in this PR:
  - `cargo +stable fmt` of Rust 1.93.1 toolchain locally does not ICE (`rustfmt 1.8.0-stable (01f6ddf758 2026-02-11)`)
  - `cargo +1.93.0 fmt` does.
