### PR TITLE
`DetectChanges::is_changed_after`

### DIFF
--- a/crates/bevy_ecs/src/change_detection/params.rs
+++ b/crates/bevy_ecs/src/change_detection/params.rs
@@ -1311,16 +1311,22 @@ impl<'w> MutUntyped<'w> {
 impl<'w> DetectChanges for MutUntyped<'w> {
     #[inline]
     fn is_added(&self) -> bool {
-        self.ticks
-            .added
-            .is_newer_than(self.ticks.last_run, self.ticks.this_run)
+        self.is_added_after(self.ticks.last_run)
     }
 
     #[inline]
     fn is_changed(&self) -> bool {
-        self.ticks
-            .changed
-            .is_newer_than(self.ticks.last_run, self.ticks.this_run)
+        self.is_changed_after(self.ticks.last_run)
+    }
+
+    #[inline]
+    fn is_added_after(&self, other: Tick) -> bool {
+        self.ticks.added.is_newer_than(other, self.ticks.this_run)
+    }
+
+    #[inline]
+    fn is_changed_after(&self, other: Tick) -> bool {
+        self.ticks.changed.is_newer_than(other, self.ticks.this_run)
     }
 
     #[inline]

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -102,11 +102,7 @@ pub(super) unsafe fn observer_system_runner<E: Event, B: Bundle, S: ObserverSyst
         #[cfg(feature = "hotpatching")]
         if world
             .get_resource_ref::<crate::HotPatchChanges>()
-            .map(|r| {
-                r.last_changed()
-                    .is_newer_than((*system).get_last_run(), world.change_tick())
-            })
-            .unwrap_or(true)
+            .is_none_or(|r| r.is_changed_after((*system).get_last_run()))
         {
             (*system).refresh_hotpatch();
         };

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -754,7 +754,14 @@ impl SpawnDetails {
     /// Returns `true` if the entity spawned since the last time this system ran.
     /// Otherwise, returns `false`.
     pub fn is_spawned(self) -> bool {
-        self.spawn_tick.is_newer_than(self.last_run, self.this_run)
+        self.is_spawned_after(self.last_run)
+    }
+
+    /// Returns `true` if the entity spawned after the `other` tick.
+    /// Otherwise, returns `false`.
+    #[inline]
+    pub fn is_spawned_after(self, other: Tick) -> bool {
+        self.spawn_tick.is_newer_than(other, self.this_run)
     }
 
     /// Returns the `Tick` this entity spawned at.

--- a/crates/bevy_ecs/src/system/system_registry.rs
+++ b/crates/bevy_ecs/src/system/system_registry.rs
@@ -405,9 +405,7 @@ impl World {
         #[cfg(feature = "hotpatching")]
         if self
             .get_resource_ref::<HotPatchChanges>()
-            .map(|r| r.last_changed())
-            .unwrap_or_default()
-            .is_newer_than(system.get_last_run(), self.change_tick())
+            .is_none_or(|r| r.is_changed_after(system.get_last_run()))
         {
             system.refresh_hotpatch();
         }

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -227,7 +227,6 @@ pub fn update_mesh_previous_global_transforms(
         (PreviousMeshFilter, Without<PreviousGlobalTransform>),
     >,
     mut meshes: Query<(Ref<GlobalTransform>, &mut PreviousGlobalTransform), PreviousMeshFilter>,
-    system_change_tick: SystemChangeTick,
 ) {
     if !views.iter().any(|camera| camera.is_active) {
         return;
@@ -238,10 +237,7 @@ pub fn update_mesh_previous_global_transforms(
         commands.entity(entity).try_insert(new_previous_transform);
     }
     meshes.par_iter_mut().for_each(|(transform, mut previous)| {
-        if transform
-            .last_changed()
-            .is_newer_than(previous.last_changed(), system_change_tick.this_run())
-        {
+        if transform.is_changed_after(previous.last_changed()) {
             *previous = PreviousGlobalTransform(transform.affine());
         }
     });


### PR DESCRIPTION
# Objective

Make it easier to compare ticks between `Ref`s.  

The pattern used in #23106 to compare changed ticks seems very powerful!  But the second `Tick` parameter in `Tick::is_newer_than` makes it awkward to use, and requires the developer know about the `SystemChangeTick` system parameter.  Which is silly, because the `Ref` *already has* those ticks.  

## Solution

Introduce `DetectChanges::is_changed_after`, `DetectChanges::is_added_after`, and `SpawnDetails::is_spawned_after` methods.  These call `Tick::is_newer_than` on the appropriate tick, using the `last_run` tick that is already stored.  

## Showcase

```diff
-        if transform
-            .last_changed()
-            .is_newer_than(previous.last_changed(), system_change_tick.this_run())
-        {
+        if transform.is_changed_after(previous.last_changed()) {
```