### PR TITLE
fix: reparenting perf

### DIFF
--- a/crates/bevy_app/src/propagate.rs
+++ b/crates/bevy_app/src/propagate.rs
@@ -12,7 +12,7 @@ use bevy_ecs::{
     intern::Interned,
     lifecycle::{Insert, Remove, RemovedComponents},
     observer::On,
-    query::{Changed, Or, QueryFilter, With, Without},
+    query::{Changed, Has, Or, QueryFilter, With, Without},
     relationship::{Relationship, RelationshipTarget},
     schedule::{IntoScheduleConfigs, ScheduleLabel, SystemSet},
     system::{Commands, Local, Query},


### PR DESCRIPTION
# Objective

`HierarchyPropagatePlugin` contains a system `update_reparented` that scans every entity with the relationship component `R` every frame to test for `Changed<R>`. This means iterating over every child entity every frame, even when nothing has changed. This is a significant per-frame cost that scales linearly with child entity population.

Fixes #23155 

# Solution

Replace the `update_reparented` system and its `Changed<R>` query with two reactive lifecycle observers:

- **`on_r_inserted`**: registered on `On<Insert, R>`, fires only when `R` is actually inserted onto an entity. Copies `Inherited<C>` from the new parent if it has one, otherwise removes it from the entity.
- **`on_r_removed`**: registered on `On<Remove, R>`, fires only when `R` is actually removed from an entity. Removes `Inherited<C>` if the entity had inherited one.

This replaces an O(n) per-frame scan with O(1) per-event reactions.

## What about mutations?

`Changed<R>` also detects direct mutations to `R`, while `On<Insert, R>` does not. 

From what I can tell, this is safe to drop; **please review this logic for correctness!**

Relationship components like `ChildOf` must only be changed via `insert`, never by direct mutation. This is because `R` carries bookkeeping semantics enforced by component hooks. Inserting a new value triggers hooks that remove the entity from the old parent's `RelationshipTarget` and add it to the new one. Direct mutation via `Mut<R>` bypasses these hooks entirely, leaving the `RelationshipTarget` of both the old and new parent in an inconsistent state. Any app doing this already has a bug. `On<Insert, R>` fires for **both** first-time additions and replacements (re-inserts with a new value), which covers every valid way a relationship can change:

| Case | Old (`Changed<R>`) | New (`On<Insert, R>` / `On<Remove, R>`) |
|---|---|---|
| New child spawned with `R` | ✅ | ✅ via `On<Insert, R>` |
| Entity reparented (`insert(R)`) | ✅ | ✅ via `On<Insert, R>` |
| `R` removed (entity orphaned) | ✅ via `orphaned` query | ✅ via `On<Remove, R>` |
| `R` mutated directly via `Mut<R>` | ✅ | ❌ unsupported: breaks relationship invariants |

# Testing

All existing propagation tests pass, including:
- `test_reparented`: entity moved to a non-propagating parent loses `Inherited<C>`
- `test_reparented_with_prior`: entity moved between two propagating parents picks up the new value
- `test_remove_orphan`: entity with `R` removed loses `Inherited<C>`
