### PR TITLE
Don't process meshes for reextraction that were changed, by using an atomic bitfield.

### DIFF
--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -1992,8 +1992,7 @@ impl<'a> Iterator for AtomicU64ZeroBitIter<'a> {
     type Item = u32;
 
     fn next(&mut self) -> Option<Self::Item> {
-        // Repeatedly the next word if we're out of zero bits to find in the
-        // word.
+        // Repeatedly load the next word if we're out of zero bits in this one.
         while self.current_word == !0 {
             self.current_word = self.bits.get(self.next_index)?.load(Ordering::Relaxed);
             self.next_index += 1;


### PR DESCRIPTION
This should fix the problems reported in #23134. It's broadly the same solution as #23150, but modified to avoid iterating over changed entities more than once, either through full table scans or otherwise. PR #23150 regressed performance of `extract_meshes_for_gpu_building` by quite a bit; this one only regresses it by a small amount.

`bevy_city` with #23150 (and a couple other perf improvements):
<img width="2756" height="1800" alt="Screenshot 2026-02-25 214108" src="https://github.com/user-attachments/assets/171345c6-3711-48f6-a0a0-e2c4228d4da4" />

`bevy_city` with this patch and those same improvements:
<img width="2756" height="1800" alt="Screenshot 2026-02-25 221954" src="https://github.com/user-attachments/assets/aaf1f6cb-74cb-4f4c-8d6b-2ee0245f8a59" />
