### PR TITLE
Remove redundant `after` ordering from `build_text_interop`

### DIFF
--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -244,8 +244,6 @@ fn build_text_interop(app: &mut App) {
                 .ambiguous_with(widget::update_image_content_size_system),
             widget::text_system
                 .in_set(UiSystems::PostLayout)
-                .after(bevy_text::load_font_assets_into_font_collection)
-                .after(bevy_asset::AssetEventSystems)
                 // Text2d and bevy_ui text are entirely on separate entities
                 .ambiguous_with(bevy_text::detect_text_needs_rerender::<bevy_sprite::Text2d>)
                 .ambiguous_with(bevy_sprite::update_text2d_layout)


### PR DESCRIPTION
# Objective

Remove these `after` constraints on `text_system` from `build_text_interop`:

```
.after(bevy_text::load_font_assets_into_font_collection)
.after(bevy_asset::AssetEventSystems)
```

They are redundant because `text_system` runs in `UiSystems::PostLayout`, which is already ordered after `load_font_assets_into_font_collection` and `AssetEventSystems` through `UiSystems::Content`.

## Solution

Remove them.