### PR TITLE
docs: update deprecated xorg packages in nix instructions

### DIFF
--- a/docs/linux_dependencies.md
+++ b/docs/linux_dependencies.md
@@ -151,19 +151,19 @@ Add a `flake.nix` file to the root of your GitHub repository containing:
                 vulkan-tools
                 # Other dependencies
                 libudev-zero
-                xorg.libX11
-                xorg.libXcursor
-                xorg.libXi
-                xorg.libXrandr
+                libx11
+                libxcursor
+                libxi
+                libxrandr
                 libxkbcommon
                 wayland
               ];
             RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
             LD_LIBRARY_PATH = lib.makeLibraryPath [
               vulkan-loader
-              xorg.libX11
-              xorg.libXi
-              xorg.libXcursor
+              libx11
+              libxi
+              libxcursor
               libxkbcommon
               wayland
             ];
@@ -191,7 +191,7 @@ mkShell rec {
   ];
   buildInputs = [
     udev alsa-lib-with-plugins vulkan-loader
-    xorg.libX11 xorg.libXcursor xorg.libXi xorg.libXrandr # To use the x11 feature
+    libx11 libxcursor libxi libxrandr # To use the x11 feature
     libxkbcommon wayland # To use the wayland feature
   ];
   LD_LIBRARY_PATH = lib.makeLibraryPath buildInputs;


### PR DESCRIPTION
# Objective

- Resolves Nix evaluation warnings caused by [the deprecation of the `xorg` package set in `nixpkgs`](https://github.com/NixOS/nixpkgs/pull/479724).

## Solution

- Replaced deprecated `xorg.libX...` package names with their updated names (`libx11`, `libxcursor`, `libxi`, `libxrandr`).

## Testing

- The previous listed package names gave the following warnings:
  ```shell
  evaluation warning: The xorg package set has been deprecated, 'xorg.libX11' has been renamed to 'libx11'
  evaluation warning: The xorg package set has been deprecated, 'xorg.libXcursor' has been renamed to 'libxcursor'
  evaluation warning: The xorg package set has been deprecated, 'xorg.libXi' has been renamed to 'libxi'
  evaluation warning: The xorg package set has been deprecated, 'xorg.libXrandr' has been renamed to 'libxrandr'
  ```
- After the change there are no more warnings and uses the same packages