### PR TITLE
Component features for resources

### DIFF
--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -32,14 +32,28 @@ pub fn derive_resource(input: TokenStream) -> TokenStream {
         return err.into_compile_error().into();
     }
 
+    let attrs = match parse_resource_attr(&ast) {
+        Ok(attrs) => attrs,
+        Err(e) => return e.into_compile_error().into(),
+    };
+
+    let relationship = match derive_relationship(&ast, &attrs, &bevy_ecs_path) {
+        Ok(value) => value,
+        Err(err) => err.into_compile_error().into(),
+    };
+    let relationship_target = match derive_relationship_target(&ast, &attrs, &bevy_ecs_path) {
+        Ok(value) => value,
+        Err(err) => err.into_compile_error().into(),
+    };
+
     // Implement the Component trait.
     let map_entities = map_entities(
         &ast.data,
         &bevy_ecs_path,
         Ident::new("this", Span::call_site()),
-        false,
-        false,
-        None
+        relationship.is_some(),
+        relationship_target.is_some(),
+        attrs.map_entities
     ).map(|map_entities_impl| quote! {
         fn map_entities<M: #bevy_ecs_path::entity::EntityMapper>(this: &mut Self, mapper: &mut M) {
             use #bevy_ecs_path::entity::MapEntities;
@@ -47,19 +61,85 @@ pub fn derive_resource(input: TokenStream) -> TokenStream {
         }
     });
 
-    let storage = storage_path(&bevy_ecs_path, StorageTy::Table);
+    let storage = storage_path(&bevy_ecs_path, attrs.storage);
 
-    let on_add_path = None;
-    let on_remove_path = None;
-    let on_insert_path = None;
-    let on_replace_path = None;
-    let on_despawn_path = None;
+    let on_add_path = attrs
+        .on_add
+        .map(|path| path.to_token_stream(&bevy_ecs_path));
+    let on_remove_path = attrs
+        .on_remove
+        .map(|path| path.to_token_stream(&bevy_ecs_path));
+
+    let on_insert_path = if relationship.is_some() {
+        if attrs.on_insert.is_some() {
+            return syn::Error::new(
+                ast.span(),
+                "Custom on_insert hooks are not supported as relationships already define an on_insert hook",
+            )
+            .into_compile_error()
+            .into();
+        }
+
+        Some(quote!(<Self as #bevy_ecs_path::relationship::Relationship>::on_insert))
+    } else {
+        attrs
+            .on_insert
+            .map(|path| path.to_token_stream(&bevy_ecs_path))
+    };
+
+    let on_discard_path = if relationship.is_some() {
+        if attrs.on_discard.is_some() {
+            return syn::Error::new(
+                ast.span(),
+                "Custom on_discard hooks are not supported as Relationships already define an on_discard hook",
+            )
+            .into_compile_error()
+            .into();
+        }
+
+        Some(quote!(<Self as #bevy_ecs_path::relationship::Relationship>::on_discard))
+    } else if attrs.relationship_target.is_some() {
+        if attrs.on_discard.is_some() {
+            return syn::Error::new(
+                ast.span(),
+                "Custom on_discard hooks are not supported as RelationshipTarget already defines an on_discard hook",
+            )
+            .into_compile_error()
+            .into();
+        }
+
+        Some(quote!(<Self as #bevy_ecs_path::relationship::RelationshipTarget>::on_discard))
+    } else {
+        attrs
+            .on_discard
+            .map(|path| path.to_token_stream(&bevy_ecs_path))
+    };
+
+    let on_despawn_path = if attrs
+        .relationship_target
+        .is_some_and(|target| target.linked_spawn)
+    {
+        if attrs.on_despawn.is_some() {
+            return syn::Error::new(
+                ast.span(),
+                "Custom on_despawn hooks are not supported as this RelationshipTarget already defines an on_despawn hook, via the 'linked_spawn' attribute",
+            )
+            .into_compile_error()
+            .into();
+        }
+
+        Some(quote!(<Self as #bevy_ecs_path::relationship::RelationshipTarget>::on_despawn))
+    } else {
+        attrs
+            .on_despawn
+            .map(|path| path.to_token_stream(&bevy_ecs_path))
+    };
 
     let on_add = hook_register_function_call(&bevy_ecs_path, quote! {on_add}, on_add_path);
-    let on_remove = hook_register_function_call(&bevy_ecs_path, quote! {on_remove}, on_remove_path);
     let on_insert = hook_register_function_call(&bevy_ecs_path, quote! {on_insert}, on_insert_path);
-    let on_replace =
-        hook_register_function_call(&bevy_ecs_path, quote! {on_replace}, on_replace_path);
+    let on_discard =
+        hook_register_function_call(&bevy_ecs_path, quote! {on_discard}, on_discard_path);
+    let on_remove = hook_register_function_call(&bevy_ecs_path, quote! {on_remove}, on_remove_path);
     let on_despawn =
         hook_register_function_call(&bevy_ecs_path, quote! {on_despawn}, on_despawn_path);
 
@@ -71,8 +151,8 @@ pub fn derive_resource(input: TokenStream) -> TokenStream {
     let struct_name = &ast.ident;
     let (impl_generics, type_generics, where_clause) = &ast.generics.split_for_impl();
 
-    let mut register_required = Vec::with_capacity(1);
-    // We add the component_id existence check here to avoid recursive init during required components initialization.
+    let requires = &attrs.requires;
+    let mut register_required = Vec::with_capacity(attrs.requires.iter().len() + 1);
     register_required.push(quote! {
         let resource_component_id = if let Some(id) = required_components.components_registrator().component_id::<#struct_name #type_generics>() {
             id
@@ -81,13 +161,88 @@ pub fn derive_resource(input: TokenStream) -> TokenStream {
         };
         required_components.register_required::<#bevy_ecs_path::resource::IsResource>(move || #bevy_ecs_path::resource::IsResource::new(resource_component_id));
     });
+    if let Some(requires) = requires {
+        for require in requires {
+            let ident = &require.path;
+            let constructor = match &require.func {
+                Some(func) => quote! { || { let x: #ident = (#func)().into(); x } },
+                None => quote! { <#ident as Default>::default },
+            };
+            register_required.push(quote! {
+                required_components.register_required::<#ident>(#constructor);
+            });
+        }
+    }
+
+    let required_component_docs = attrs.requires.map(|r| {
+        let paths = r
+            .iter()
+            .map(|r| format!("[`{}`]", r.path.to_token_stream()))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let doc = format!("**Required Components**: {paths}. \n\n A component's Required Components are inserted whenever it is inserted. Note that this will also insert the required components _of_ the required components, recursively, in depth-first order.");
+        quote! {
+            #[doc = #doc]
+        }
+    });
+
+    let mutable_type = (attrs.immutable || relationship.is_some())
+        .then_some(quote! { #bevy_ecs_path::component::Immutable })
+        .unwrap_or(quote! { #bevy_ecs_path::component::Mutable });
+
+    let clone_behavior = if relationship_target.is_some() || relationship.is_some() {
+        quote!(
+            use #bevy_ecs_path::relationship::{
+                RelationshipCloneBehaviorBase, RelationshipCloneBehaviorViaClone, RelationshipCloneBehaviorViaReflect,
+                RelationshipTargetCloneBehaviorViaClone, RelationshipTargetCloneBehaviorViaReflect, RelationshipTargetCloneBehaviorHierarchy
+                };
+            (&&&&&&&#bevy_ecs_path::relationship::RelationshipCloneBehaviorSpecialization::<Self>::default()).default_clone_behavior()
+        )
+    } else if let Some(behavior) = attrs.clone_behavior {
+        quote!(#bevy_ecs_path::component::ComponentCloneBehavior::#behavior)
+    } else {
+        quote!(
+            use #bevy_ecs_path::component::{DefaultCloneBehaviorBase, DefaultCloneBehaviorViaClone};
+            (&&&#bevy_ecs_path::component::DefaultCloneBehaviorSpecialization::<Self>::default()).default_clone_behavior()
+        )
+    };
+
+    let relationship_accessor = if (relationship.is_some() || relationship_target.is_some())
+        && let Data::Struct(DataStruct {
+            fields,
+            struct_token,
+            ..
+        }) = &ast.data
+        && let Ok(field) = relationship_field(fields, "Relationship", struct_token.span())
+    {
+        let relationship_member = field.ident.clone().map_or(Member::from(0), Member::Named);
+        if relationship.is_some() {
+            quote! {
+                Some(
+                    // Safety: we pass valid offset of a field containing Entity (obtained via offset_off!)
+                    unsafe {
+                        #bevy_ecs_path::relationship::ComponentRelationshipAccessor::<Self>::relationship(
+                            ::core::mem::offset_of!(Self, #relationship_member)
+                        )
+                    }
+                )
+            }
+        } else {
+            quote! {
+                Some(#bevy_ecs_path::relationship::ComponentRelationshipAccessor::<Self>::relationship_target())
+            }
+        }
+    } else {
+        quote! {None}
+    };
 
     // This puts `register_required` before `register_recursive_requires` to ensure that the constructors of _all_ top
     // level components are initialized first, giving them precedence over recursively defined constructors for the same component type
     let component_derive_token_stream = TokenStream::from(quote! {
+        #required_component_docs
         impl #impl_generics #bevy_ecs_path::component::Component for #struct_name #type_generics #where_clause {
             const STORAGE_TYPE: #bevy_ecs_path::component::StorageType = #storage;
-            type Mutability = #bevy_ecs_path::component::Mutable;
+            type Mutability = #mutable_type;
             fn register_required_components(
                 _requiree: #bevy_ecs_path::component::ComponentId,
                 required_components: &mut #bevy_ecs_path::component::RequiredComponentsRegistrator,
@@ -97,20 +252,24 @@ pub fn derive_resource(input: TokenStream) -> TokenStream {
 
             #on_add
             #on_insert
-            #on_replace
+            #on_discard
             #on_remove
             #on_despawn
 
             fn clone_behavior() -> #bevy_ecs_path::component::ComponentCloneBehavior {
-                #bevy_ecs_path::component::ComponentCloneBehavior::Default
+                #clone_behavior
             }
 
             #map_entities
 
             fn relationship_accessor() -> Option<#bevy_ecs_path::relationship::ComponentRelationshipAccessor<Self>> {
-                None
+                #relationship_accessor
             }
         }
+
+        #relationship
+
+        #relationship_target
     });
 
     // Implement the Resource trait.
@@ -455,6 +614,7 @@ pub(crate) fn map_entities(
 }
 
 pub const COMPONENT: &str = "component";
+pub const RESOURCE: &str = "resource";
 pub const STORAGE: &str = "storage";
 pub const REQUIRE: &str = "require";
 pub const RELATIONSHIP: &str = "relationship";
@@ -639,6 +799,110 @@ fn parse_component_attr(ast: &DeriveInput) -> Result<Attrs> {
     let mut require_paths = HashSet::new();
     for attr in ast.attrs.iter() {
         if attr.path().is_ident(COMPONENT) {
+            attr.parse_nested_meta(|nested| {
+                if nested.path.is_ident(STORAGE) {
+                    attrs.storage = match nested.value()?.parse::<LitStr>()?.value() {
+                        s if s == TABLE => StorageTy::Table,
+                        s if s == SPARSE_SET => StorageTy::SparseSet,
+                        s => {
+                            return Err(nested.error(format!(
+                                "Invalid storage type `{s}`, expected '{TABLE}' or '{SPARSE_SET}'.",
+                            )));
+                        }
+                    };
+                    Ok(())
+                } else if nested.path.is_ident(ON_ADD) {
+                    attrs.on_add = Some(HookAttributeKind::parse(nested.input, || {
+                        parse_quote! { Self::on_add }
+                    })?);
+                    Ok(())
+                } else if nested.path.is_ident(ON_INSERT) {
+                    attrs.on_insert = Some(HookAttributeKind::parse(nested.input, || {
+                        parse_quote! { Self::on_insert }
+                    })?);
+                    Ok(())
+                } else if nested.path.is_ident(ON_DISCARD) {
+                    attrs.on_discard = Some(HookAttributeKind::parse(nested.input, || {
+                        parse_quote! { Self::on_discard }
+                    })?);
+                    Ok(())
+                } else if nested.path.is_ident(ON_REMOVE) {
+                    attrs.on_remove = Some(HookAttributeKind::parse(nested.input, || {
+                        parse_quote! { Self::on_remove }
+                    })?);
+                    Ok(())
+                } else if nested.path.is_ident(ON_DESPAWN) {
+                    attrs.on_despawn = Some(HookAttributeKind::parse(nested.input, || {
+                        parse_quote! { Self::on_despawn }
+                    })?);
+                    Ok(())
+                } else if nested.path.is_ident(IMMUTABLE) {
+                    attrs.immutable = true;
+                    Ok(())
+                } else if nested.path.is_ident(CLONE_BEHAVIOR) {
+                    attrs.clone_behavior = Some(nested.value()?.parse()?);
+                    Ok(())
+                } else if nested.path.is_ident(MAP_ENTITIES) {
+                    attrs.map_entities = Some(nested.input.parse::<MapEntitiesAttributeKind>()?);
+                    Ok(())
+                } else {
+                    Err(nested.error("Unsupported attribute"))
+                }
+            })?;
+        } else if attr.path().is_ident(REQUIRE) {
+            let punctuated =
+                attr.parse_args_with(Punctuated::<Require, Comma>::parse_terminated)?;
+            for require in punctuated.iter() {
+                if !require_paths.insert(require.path.to_token_stream().to_string()) {
+                    return Err(syn::Error::new(
+                        require.path.span(),
+                        "Duplicate required components are not allowed.",
+                    ));
+                }
+            }
+            if let Some(current) = &mut attrs.requires {
+                current.extend(punctuated);
+            } else {
+                attrs.requires = Some(punctuated);
+            }
+        } else if attr.path().is_ident(RELATIONSHIP) {
+            let relationship = attr.parse_args::<Relationship>()?;
+            attrs.relationship = Some(relationship);
+        } else if attr.path().is_ident(RELATIONSHIP_TARGET) {
+            let relationship_target = attr.parse_args::<RelationshipTarget>()?;
+            attrs.relationship_target = Some(relationship_target);
+        }
+    }
+
+    if attrs.relationship_target.is_some() && attrs.clone_behavior.is_some() {
+        return Err(syn::Error::new(
+                attrs.clone_behavior.span(),
+                "A Relationship Target already has its own clone behavior, please remove `clone_behavior = ...`",
+            ));
+    }
+
+    Ok(attrs)
+}
+
+fn parse_resource_attr(ast: &DeriveInput) -> Result<Attrs> {
+    let mut attrs = Attrs {
+        storage: StorageTy::Table,
+        on_add: None,
+        on_insert: None,
+        on_discard: None,
+        on_remove: None,
+        on_despawn: None,
+        requires: None,
+        relationship: None,
+        relationship_target: None,
+        immutable: false,
+        clone_behavior: None,
+        map_entities: None,
+    };
+
+    let mut require_paths = HashSet::new();
+    for attr in ast.attrs.iter() {
+        if attr.path().is_ident(RESOURCE) {
             attr.parse_nested_meta(|nested| {
                 if nested.path.is_ident(STORAGE) {
                     attrs.storage = match nested.value()?.parse::<LitStr>()?.value() {

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -562,7 +562,10 @@ pub fn derive_message(input: TokenStream) -> TokenStream {
 }
 
 /// Implement the `Resource` trait.
-#[proc_macro_derive(Resource)]
+#[proc_macro_derive(
+    Resource,
+    attributes(resource, require, relationship, relationship_target, entities)
+)]
 pub fn derive_resource(input: TokenStream) -> TokenStream {
     component::derive_resource(input)
 }

--- a/crates/bevy_ecs/src/reflect/entity_commands.rs
+++ b/crates/bevy_ecs/src/reflect/entity_commands.rs
@@ -1,4 +1,5 @@
 use crate::{
+    component::{Component, Mutable},
     prelude::Mut,
     reflect::{AppTypeRegistry, ReflectBundle, ReflectComponent},
     resource::Resource,
@@ -96,7 +97,9 @@ pub trait ReflectCommandExt {
     /// # Note
     ///
     /// - The given [`Resource`] is removed from the [`World`](crate::world::World) before the command is applied.
-    fn insert_reflect_with_registry<T: Resource + AsRef<TypeRegistry>>(
+    fn insert_reflect_with_registry<
+        T: Resource + AsRef<TypeRegistry> + Component<Mutability = Mutable>,
+    >(
         &mut self,
         component: Box<dyn PartialReflect>,
     ) -> &mut Self;
@@ -161,7 +164,9 @@ pub trait ReflectCommandExt {
     fn remove_reflect(&mut self, component_type_path: impl Into<Cow<'static, str>>) -> &mut Self;
     /// Same as [`remove_reflect`](ReflectCommandExt::remove_reflect), but using the `T` resource as type registry instead of
     /// `AppTypeRegistry`.
-    fn remove_reflect_with_registry<T: Resource + AsRef<TypeRegistry>>(
+    fn remove_reflect_with_registry<
+        T: Resource + AsRef<TypeRegistry> + Component<Mutability = Mutable>,
+    >(
         &mut self,
         component_type_path: impl Into<Cow<'static, str>>,
     ) -> &mut Self;
@@ -174,7 +179,9 @@ impl ReflectCommandExt for EntityCommands<'_> {
         })
     }
 
-    fn insert_reflect_with_registry<T: Resource + AsRef<TypeRegistry>>(
+    fn insert_reflect_with_registry<
+        T: Resource + AsRef<TypeRegistry> + Component<Mutability = Mutable>,
+    >(
         &mut self,
         component: Box<dyn PartialReflect>,
     ) -> &mut Self {
@@ -190,7 +197,9 @@ impl ReflectCommandExt for EntityCommands<'_> {
         })
     }
 
-    fn remove_reflect_with_registry<T: Resource + AsRef<TypeRegistry>>(
+    fn remove_reflect_with_registry<
+        T: Resource + AsRef<TypeRegistry> + Component<Mutability = Mutable>,
+    >(
         &mut self,
         component_type_path: impl Into<Cow<'static, str>>,
     ) -> &mut Self {
@@ -240,7 +249,9 @@ impl<'w> EntityWorldMut<'w> {
     ///   [`Component`](crate::component::Component) or [`Bundle`](crate::bundle::Bundle).
     /// - If the component or bundle data is invalid. See [`PartialReflect::apply`] for further details.
     /// - If the given [`Resource`] is not present in the [`World`](crate::world::World).
-    pub fn insert_reflect_with_registry<T: Resource + AsRef<TypeRegistry>>(
+    pub fn insert_reflect_with_registry<
+        T: Resource + AsRef<TypeRegistry> + Component<Mutability = Mutable>,
+    >(
         &mut self,
         component: Box<dyn PartialReflect>,
     ) -> &mut Self {
@@ -293,7 +304,9 @@ impl<'w> EntityWorldMut<'w> {
     ///
     /// - If the entity has been despawned while this `EntityWorldMut` is still alive.
     /// - If [`AppTypeRegistry`] is not present in the [`World`](crate::world::World).
-    pub fn remove_reflect_with_registry<T: Resource + AsRef<TypeRegistry>>(
+    pub fn remove_reflect_with_registry<
+        T: Resource + AsRef<TypeRegistry> + Component<Mutability = Mutable>,
+    >(
         &mut self,
         component_type_path: Cow<'static, str>,
     ) -> &mut Self {
@@ -342,7 +355,9 @@ impl<'w> EntityWorldMut<'w> {
     ///
     /// - If the entity has been despawned while this `EntityWorldMut` is still alive.
     /// - If [`AppTypeRegistry`] is not present in the [`World`](crate::world::World).
-    pub fn take_reflect_with_registry<T: Resource + AsRef<TypeRegistry>>(
+    pub fn take_reflect_with_registry<
+        T: Resource + AsRef<TypeRegistry> + Component<Mutability = Mutable>,
+    >(
         &mut self,
         component_type_path: Cow<'static, str>,
     ) -> Option<Box<dyn Reflect>> {

--- a/crates/bevy_ecs/src/resource.rs
+++ b/crates/bevy_ecs/src/resource.rs
@@ -4,7 +4,7 @@ use core::ops::{Deref, DerefMut};
 use log::warn;
 
 use crate::{
-    component::{Component, ComponentId, Mutable},
+    component::{Component, ComponentId},
     entity::Entity,
     lifecycle::HookContext,
     storage::SparseSet,
@@ -85,7 +85,7 @@ use bevy_platform::cell::SyncUnsafeCell;
     label = "invalid `Resource`",
     note = "consider annotating `{Self}` with `#[derive(Resource)]`"
 )]
-pub trait Resource: Component<Mutability = Mutable> {}
+pub trait Resource: Component {}
 
 /// A cache that links each `ComponentId` from a resource to the corresponding entity.
 #[derive(Default)]
@@ -308,5 +308,12 @@ mod tests {
         assert!(world.entity(id).get::<IsResource>().is_none());
         assert!(world.entity(second_entity).get::<TestResource>().is_some());
         assert!(world.entity(second_entity).get::<IsResource>().is_some());
+    }
+
+    #[test]
+    fn component_features() {
+        #[derive(Resource)]
+        #[resource(immutable)]
+        struct MyResource;
     }
 }

--- a/crates/bevy_ecs/src/resource.rs
+++ b/crates/bevy_ecs/src/resource.rs
@@ -210,13 +210,15 @@ pub const IS_RESOURCE: ComponentId = ComponentId::new(crate::component::IS_RESOU
 mod tests {
     use crate::{
         change_detection::MaybeLocation,
-        entity::Entity,
+        entity::{Entity, EntityMapper, MapEntities},
+        lifecycle::HookContext,
         ptr::OwningPtr,
+        relationship,
         resource::{IsResource, Resource},
-        world::World,
+        world::{DeferredWorld, World},
     };
     use alloc::vec::Vec;
-    use bevy_platform::prelude::String;
+    use bevy_platform::{collections::HashMap, prelude::String};
 
     #[test]
     fn unique_resource_entities() {
@@ -312,8 +314,34 @@ mod tests {
 
     #[test]
     fn component_features() {
+        #[allow(dead_code)]
+        fn do_nothing(_world: DeferredWorld, _context: HookContext) {}
+
         #[derive(Resource)]
-        #[resource(immutable)]
-        struct MyResource;
+        #[resource(
+            immutable,
+            storage = "SparseSet",
+            on_add = do_nothing,
+            on_insert = do_nothing,
+            on_discard = do_nothing,
+            on_remove = do_nothing,
+            on_despawn = do_nothing,
+            clone_behavior = Ignore,
+            map_entities,
+        )]
+        #[allow(dead_code)]
+        struct MyResource {
+            items: HashMap<Entity, usize>,
+        }
+
+        impl MapEntities for MyResource {
+            fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {
+                self.items = self
+                    .items
+                    .drain()
+                    .map(|(id, count)| (entity_mapper.get_mapped(id), count))
+                    .collect();
+            }
+        }
     }
 }

--- a/crates/bevy_ecs/src/world/entity_access/world_mut.rs
+++ b/crates/bevy_ecs/src/world/entity_access/world_mut.rs
@@ -697,7 +697,7 @@ impl<'w> EntityWorldMut<'w> {
     ///
     /// See [`World::resource_scope`] for further details.
     #[track_caller]
-    pub fn resource_scope<R: Resource, U>(
+    pub fn resource_scope<R: Resource + Component<Mutability = Mutable>, U>(
         &mut self,
         f: impl FnOnce(&mut EntityWorldMut, Mut<R>) -> U,
     ) -> U {
@@ -716,7 +716,7 @@ impl<'w> EntityWorldMut<'w> {
     /// then re-adds the resource before returning. Returns `None` if the resource does not exist in the [`World`].
     ///
     /// See [`World::try_resource_scope`] for further details.
-    pub fn try_resource_scope<R: Resource, U>(
+    pub fn try_resource_scope<R: Resource + Component<Mutability = Mutable>, U>(
         &mut self,
         f: impl FnOnce(&mut EntityWorldMut, Mut<R>) -> U,
     ) -> Option<U> {

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -2755,7 +2755,10 @@ impl World {
     /// [`World::clear_resources`] or [`World::clear_all`], the resource will *not* be re-inserted
     /// at the end of the scope.
     #[track_caller]
-    pub fn resource_scope<R: Resource, U>(&mut self, f: impl FnOnce(&mut World, Mut<R>) -> U) -> U {
+    pub fn resource_scope<R: Resource + Component<Mutability = Mutable>, U>(
+        &mut self,
+        f: impl FnOnce(&mut World, Mut<R>) -> U,
+    ) -> U {
         self.try_resource_scope(f)
             .unwrap_or_else(|| panic!("resource does not exist: {}", DebugName::type_name::<R>()))
     }
@@ -2773,7 +2776,7 @@ impl World {
     /// If the world's resource metadata is cleared within the scope, such as by calling
     /// [`World::clear_resources`] or [`World::clear_all`], the resource will *not* be re-inserted
     /// at the end of the scope.
-    pub fn try_resource_scope<R: Resource, U>(
+    pub fn try_resource_scope<R: Resource + Component<Mutability = Mutable>, U>(
         &mut self,
         f: impl FnOnce(&mut World, Mut<R>) -> U,
     ) -> Option<U> {
@@ -2792,7 +2795,7 @@ impl World {
         // the resource is inserted even if the user-provided closure unwinds.
         // this facilitates localized panic recovery and makes app shutdown in response to a panic more graceful
         // by avoiding knock-on errors.
-        struct ReinsertGuard<'a, R: Resource> {
+        struct ReinsertGuard<'a, R: Resource + Component<Mutability = Mutable>> {
             world: &'a mut World,
             entity: Entity,
             component_id: ComponentId,
@@ -2800,7 +2803,7 @@ impl World {
             ticks: ComponentTicks,
             caller: MaybeLocation,
         }
-        impl<R: Resource> Drop for ReinsertGuard<'_, R> {
+        impl<R: Resource + Component<Mutability = Mutable>> Drop for ReinsertGuard<'_, R> {
             fn drop(&mut self) {
                 // take ownership of the value first so it'll get dropped if we return early
                 // SAFETY: drop semantics ensure that `self.value` will never be accessed again after this call


### PR DESCRIPTION
# Objective

Now that resources are components, any component feature can become a resource feature. We know we *can*, now we just need to figure out whether or not we *should*.

## Solution

We're going through a list of features we can enable for resources, in the order of most reasonable to least reasonable. I invite everyone to add to this discussion and list reasons for or against adding a feature. This includes weird edge cases, confusing semantics, or novel use cases. In order to learn more about the features I'm referencing in a Component context, [the documentation](https://docs.rs/bevy/latest/bevy/ecs/component/trait.Component.html) is a good start.

### Configurable Storage

```rust
#[derive(Resource)]
#[resource(storage = "SparseSet")]
struct MyResource;
```

Pretty much a no-brainer: 0 downsides.

### Custom Entity Mapping

```rust
#[derive(Resource)]
#[resource(map_entities)]
struct MyResource {
    items: HashMap<Entity, usize>,
}

impl MapEntities for MyResource {
    fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {
        self.items = self
            .items
            .drain()
            .map(|(id, count)| (entity_mapper.get_mapped(id), count))
            .collect();
    }
}
```
I'd have to do some testing to see that this actually does work in the contexts of entity cloning and scenes, but this should also be a pretty clear win without any downside.

### Clone Behaviour

```rust
#[derive(Resource)]
#[resource(clone_behaviour = Ignore)]
struct MyResource;
```

Used in very similar contexts to custom entity mapping. I should write tests for this, but otherwise a pretty clear win.

### Immutable Resources

```rust
#[derive(Resource)]
#[resource(immutable)]
struct MyResource {};
```

Why would you want an immutable resource? Not sure, but from now, you can. The only downside is that methods operating on mutable resources need to be annotated with `Component<Mutability = Mutable>`. Take for example `try_resource_scope`:

```rust
pub fn try_resource_scope<T: Resource + Component<Mutability = Mutable>, U>(&mut self) -> ...
```

So there's a bit of extra boilerplate there.

### Resource Hooks

```rust
fn resource_hook(_world: DeferredWorld, _context: Hookcontext) {
    println!("Hello");
}

#[derive(Resource)]
#[resource(on_add = resource_hook)]
struct MyResource;
```

The original PR #20934 added support for observers. Component (resource) hooks, are slightly different. One potential problem with adding support for this is that `resource_hook` might read an invalid world state.

The 'resource-ness' of `MyResource` is determined by two things: the presence of an `IsResource` marker component on the same entity and there being an entry in the `ResourceEntities` hashmap (stored on `World`). `IsResource` is a required component and is added alongside `MyResource` in the same insertion.

Afterwards, the `ResourceEntities` hashmap is updated in the `on_insert` hook for `IsResource`. I'm uncertain whether or not this runs before or after any `on_insert` / `on_add` hooks for `MyResource`, so the `MyResource` hooks might perceive an invalid world state. The same goes for the `on_discard` / `on_remove` hooks.

This might not be such a big problem, because hooks are intended to maintain invariants. Only after all hooks are ran, can a user expect that everything is in order, but not before. If this is documented correctly, I think we can allow this.

### Required Components

```
#[derive(Resource)]
#[require(Foo)]
struct MyResource;
```

Required components are really useful. Replicon uses them for [networking components](https://docs.rs/bevy_replicon/latest/bevy_replicon/) and it would be good to use the same code for resources. However there is a number of problems:
- Additional components added to resource entities are *not* saved to scenes #22968.
- We need a way to prevent `#[require(MyResource)]` on a component *or* resource.
- What about `#[require(IsResource)]`? Doubly requiring `IsResource` on a resource probably shouldn't be possible.

### Relations

I don't know what this would even mean in the context of resources.