### PR TITLE
Disable global ambient light in white furnace test

### DIFF
--- a/examples/testbed/white_furnace.rs
+++ b/examples/testbed/white_furnace.rs
@@ -72,6 +72,10 @@ fn setup(
     mut images: ResMut<Assets<Image>>,
 ) {
     let sphere_mesh = meshes.add(Sphere::new(0.45));
+
+    // Light should come from the environment map only
+    commands.insert_resource(GlobalAmbientLight::NONE);
+
     // add entities to the world
     for y in -2..=2 {
         for x in -5..=5 {


### PR DESCRIPTION
# Objective
The recently added white furnace test doesn't disable global ambient lighting, which makes the results appear brighter than they should be.

## Solution
Disable global ambient lighting in the white furnace test.

## Testing

- Tested by running `cargo run --example testbed_white_furnace`

The PBR renderer still loses energy for partially metallic materials, but it appears to work fine for pure dielectrics or metals when using a solid color light.

---

## Showcase

<img width="1280" height="720" alt="color_based" src="https://github.com/user-attachments/assets/3491336e-5244-4b57-8f1a-6879edc8b458" />
<img width="1280" height="720" alt="image_based" src="https://github.com/user-attachments/assets/bf59f8f2-2290-490d-beed-c64be44c2d22" />
