### PR TITLE
Add font weight to `InheritableFont`

### DIFF
--- a/crates/bevy_feathers/src/controls/button.rs
+++ b/crates/bevy_feathers/src/controls/button.rs
@@ -14,7 +14,7 @@ use bevy_ecs::{
 use bevy_input_focus::tab_navigation::TabIndex;
 use bevy_picking::{hover::Hovered, PickingSystems};
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
-use bevy_text::FontSize;
+use bevy_text::{FontSize, FontWeight};
 use bevy_ui::{AlignItems, InteractionDisabled, JustifyContent, Node, Pressed, UiRect, Val};
 use bevy_ui_widgets::Button;
 
@@ -88,6 +88,7 @@ pub fn button<C: SpawnableList<ChildOf> + Send + Sync + 'static, B: Bundle>(
         InheritableFont {
             font: HandleOrPath::Path(fonts::REGULAR.to_owned()),
             font_size: FontSize::Px(14.0),
+            weight: FontWeight::NORMAL,
         },
         overrides,
         Children::spawn(children),

--- a/crates/bevy_feathers/src/controls/checkbox.rs
+++ b/crates/bevy_feathers/src/controls/checkbox.rs
@@ -17,7 +17,7 @@ use bevy_input_focus::tab_navigation::TabIndex;
 use bevy_math::Rot2;
 use bevy_picking::{hover::Hovered, PickingSystems};
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
-use bevy_text::FontSize;
+use bevy_text::{FontSize, FontWeight};
 use bevy_ui::{
     AlignItems, BorderRadius, Checked, Display, FlexDirection, InteractionDisabled, JustifyContent,
     Node, PositionType, UiRect, UiTransform, Val,
@@ -81,6 +81,7 @@ pub fn checkbox<C: SpawnableList<ChildOf> + Send + Sync + 'static, B: Bundle>(
         InheritableFont {
             font: HandleOrPath::Path(fonts::REGULAR.to_owned()),
             font_size: FontSize::Px(14.0),
+            weight: FontWeight::NORMAL,
         },
         overrides,
         Children::spawn((

--- a/crates/bevy_feathers/src/controls/radio.rs
+++ b/crates/bevy_feathers/src/controls/radio.rs
@@ -16,7 +16,7 @@ use bevy_ecs::{
 use bevy_input_focus::tab_navigation::TabIndex;
 use bevy_picking::{hover::Hovered, PickingSystems};
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
-use bevy_text::FontSize;
+use bevy_text::{FontSize, FontWeight};
 use bevy_ui::{
     AlignItems, BorderRadius, Checked, Display, FlexDirection, InteractionDisabled, JustifyContent,
     Node, UiRect, Val,
@@ -75,6 +75,7 @@ pub fn radio<C: SpawnableList<ChildOf> + Send + Sync + 'static, B: Bundle>(
         InheritableFont {
             font: HandleOrPath::Path(fonts::REGULAR.to_owned()),
             font_size: FontSize::Px(14.0),
+            weight: FontWeight::NORMAL,
         },
         overrides,
         Children::spawn((

--- a/crates/bevy_feathers/src/controls/slider.rs
+++ b/crates/bevy_feathers/src/controls/slider.rs
@@ -17,7 +17,7 @@ use bevy_ecs::{
 use bevy_input_focus::tab_navigation::TabIndex;
 use bevy_picking::PickingSystems;
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
-use bevy_text::FontSize;
+use bevy_text::{FontSize, FontWeight};
 use bevy_ui::{
     widget::Text, AlignItems, BackgroundGradient, ColorStop, Display, FlexDirection, Gradient,
     InteractionDisabled, InterpolationColorSpace, JustifyContent, LinearGradient, Node,
@@ -123,6 +123,7 @@ pub fn slider<B: Bundle>(props: SliderProps, overrides: B) -> impl Bundle {
             InheritableFont {
                 font: HandleOrPath::Path(fonts::MONO.to_owned()),
                 font_size: FontSize::Px(12.0),
+                weight: FontWeight::NORMAL,
             },
             children![(Text::new("10.0"), ThemedText, SliderValueText,)],
         )],

--- a/crates/bevy_feathers/src/font_styles.rs
+++ b/crates/bevy_feathers/src/font_styles.rs
@@ -9,7 +9,7 @@ use bevy_ecs::{
     system::{Commands, Query, Res},
 };
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
-use bevy_text::{Font, FontSize, TextFont};
+use bevy_text::{Font, FontSize, FontWeight, TextFont};
 
 use crate::{handle_or_path::HandleOrPath, theme::ThemedText};
 
@@ -23,6 +23,8 @@ pub struct InheritableFont {
     pub font: HandleOrPath<Font>,
     /// The desired font size.
     pub font_size: FontSize,
+    /// The desired font weight.
+    pub weight: FontWeight,
 }
 
 impl InheritableFont {
@@ -31,6 +33,7 @@ impl InheritableFont {
         Self {
             font: HandleOrPath::Handle(handle),
             font_size: FontSize::Px(16.0),
+            weight: FontWeight::NORMAL,
         }
     }
 
@@ -39,6 +42,7 @@ impl InheritableFont {
         Self {
             font: HandleOrPath::Path(path.to_string()),
             font_size: FontSize::Px(16.0),
+            weight: FontWeight::NORMAL,
         }
     }
 }
@@ -60,6 +64,7 @@ pub(crate) fn on_changed_font(
         commands.entity(insert.entity).insert(Propagate(TextFont {
             font: font.into(),
             font_size: style.font_size,
+            weight: style.weight,
             ..Default::default()
         }));
     }


### PR DESCRIPTION
# Objective

When using a variable font it would be nice to be able to propagate the font weight using `InheritableFont`.

## Solution

- Add `weight` field to `InheritableFont`

## Testing

I tested that it works propagating font weight with a variable font:

```rust
commands.spawn((
    InheritableFont {
        font_size: 14.,
        font: font_handle.into(),
        weight: FontWeight::EXTRA_LIGHT,
    },
    children![(Text::new("Hello world"), ThemedText)],
));
```
