### PR TITLE
enable glam/encase when building bevy_mesh/morph

### DIFF
--- a/crates/bevy_mesh/Cargo.toml
+++ b/crates/bevy_mesh/Cargo.toml
@@ -37,6 +37,7 @@ thiserror = { version = "2", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 derive_more = { version = "2", default-features = false, features = ["from"] }
 encase = "0.12"
+glam = { version = "0.32.0", default-features = false, optional = true }
 
 [dev-dependencies]
 approx = "0.5"
@@ -46,7 +47,7 @@ serde_json = "1.0.140"
 default = []
 ## Adds serialization support through `serde`.
 serialize = ["dep:serde", "wgpu-types/serde"]
-morph = ["dep:bevy_image"]
+morph = ["dep:bevy_image", "glam/encase"]
 
 [lints]
 workspace = true


### PR DESCRIPTION
# Objective

- bevy_mesh fails to build with feature morph
```
error[E0277]: the trait bound `bevy_math::Vec3: ShaderSize` is not satisfied
   --> crates/bevy_mesh/src/morph.rs:142:17
    |
142 |     pub normal: Vec3,
    |                 ^^^^ the trait `ShaderSize` is not implemented for `bevy_math::Vec3`
    |
    = help: the following other types implement trait `ShaderSize`:
              &T
              &mut T
              Arc<T>
              ArrayLength
              AtomicI32
              AtomicU32
              Box<T>
              Cell<T>
            and 12 others
note: required by a bound in `morph::_::{closure#0}::check::assert_impl`
```

## Solution

- add glam/encase as a dependency to the morph feature

## Testing

- `cargo build --package bevy_mesh --features morph`
