### PR TITLE
Fix minimum version of `wasm-bindgen-futures`.

### DIFF
--- a/crates/bevy_platform/Cargo.toml
+++ b/crates/bevy_platform/Cargo.toml
@@ -81,7 +81,7 @@ async-io = { version = "2.0.0", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-time = { version = "1.1", default-features = false, optional = true }
-wasm-bindgen-futures = { version = "0.4", default-features = false, optional = true }
+wasm-bindgen-futures = { version = "0.4.46", default-features = false, optional = true }
 futures-channel = { version = "0.3", default-features = false }
 js-sys = { version = "0.3", default-features = false, optional = true }
 wasm-bindgen = { version = "0.2", default-features = false, optional = true }


### PR DESCRIPTION
# Objective

`bevy_platform` optionally uses `wasm-bindgen-futures/std`, but that feature did not exist before version 0.4.46. This can result in a build failure when adding a Bevy dependency to a project with a long-standing lockfile or intentionally minimal versions.

## Solution

Increase the minimum version requirement for `bevy_platform` → `wasm-bindgen-futures` to be 0.4.46, not 0.4.

## Testing

Not tested beyond CI, but it would be difficult for this change to break anything.

(Testing for bugs of the type this PR fixes is #9593.)