### PR TITLE
Allow `extract_mesh_materials` to run in parallel with `extract_meshes_for_gpu_building`.

### DIFF
--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -191,9 +191,7 @@ impl Plugin for MeshRenderPlugin {
                 .init_resource::<RenderMaterialInstances>()
                 .configure_sets(
                     ExtractSchedule,
-                    MeshExtractionSystems
-                        .after(view::extract_visibility_ranges)
-                        .after(late_sweep_material_instances),
+                    MeshExtractionSystems.after(view::extract_visibility_ranges),
                 )
                 .add_systems(
                     ExtractSchedule,


### PR DESCRIPTION
The ordering dates back to 56784de769d96f2113f6ce682026e8bd8cfa180f, before erased materials and whatnot. At this point, the systems seem to have no components or resources in common at all, so let's see if we can allow them to run in parallel.

With all my other PRs landed, this will save about 4.12 ms per frame in `many_cubes` with millions of cubes, so this is a significant savings.