### PR TITLE
Extraction Example 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2321,7 +2321,7 @@ doc-scrape-examples = true
 
 [package.metadata.example.extraction]
 name = "Extraction"
-description = "Demonstrates different ways to extract components"
+description = "Demonstrates different ways of extracting components, copying them from the main world to the render world"
 category = "ECS (Entity Component System)"
 wasm = false
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -332,7 +332,7 @@ Example | Description
 [ECS Guide](../examples/ecs/ecs_guide.rs) | Full guide to Bevy's ECS
 [Entity disabling](../examples/ecs/entity_disabling.rs) | Demonstrates how to hide entities from the ECS without deleting them
 [Error handling](../examples/ecs/error_handling.rs) | How to return and handle errors across the ECS
-[Extraction](../examples/ecs/extraction.rs) | Demonstrates different ways to extract components
+[Extraction](../examples/ecs/extraction.rs) | Demonstrates different ways of extracting components, copying them from the main world to the render world
 [Fallible System Parameters](../examples/ecs/fallible_params.rs) | Systems are skipped if their parameters cannot be acquired
 [Fixed Timestep](../examples/ecs/fixed_timestep.rs) | Shows how to create systems that run every fixed timestep, rather than every tick
 [Generic System](../examples/ecs/generic_system.rs) | Shows how to create systems that can be reused with different types

--- a/examples/ecs/extraction.rs
+++ b/examples/ecs/extraction.rs
@@ -1,7 +1,11 @@
-//! Demonstrates different ways to extract components to another world.
+//! Demonstrates different ways of extracting components from the main world to the render world.
 //!
-//! Multiple entities are spawned, each with a different marker component: A, B, C.
-//! Each component contains the current elapsed time, updated each frame on the Main World.
+//! This is usually done as an intermediary step for transferring data to the GPU, making
+//! it accessible inside shaders.  
+//!
+//! In this example, multiple entities are spawned, each with a different marker component: A, B, C.
+//! Each component contains the current elapsed time, updated each frame on the Main World, and is
+//! extracted to the render world in a different way.
 
 use bevy::prelude::*;
 use bevy::render::{


### PR DESCRIPTION
An example demonstrating automatic and manual extraction of components from the Main World to the Render World. 

This is a common point of confusion for new users that want to do custom rendering, and I don't think any of the current examples show how to manually extract components (or aren't at all focused on it at least).

In the future this should probably be changed to be about extraction between two arbitrary worlds, instead of being specific to the Render World. Possibly after / if github.com/bevyengine/bevy/pull/22852 is merged.  