### PR TITLE
Delete warning message about corrupted writes.

### DIFF
--- a/crates/bevy_pbr/src/meshlet/asset.rs
+++ b/crates/bevy_pbr/src/meshlet/asset.rs
@@ -184,9 +184,6 @@ impl AssetSaver for MeshletMeshSaver {
         write_slice(&asset.bvh, &mut writer)?;
         write_slice(&asset.meshlets, &mut writer)?;
         write_slice(&asset.meshlet_cull_data, &mut writer)?;
-        // BUG: Flushing helps with an async_fs bug, but it still fails sometimes. https://github.com/smol-rs/async-fs/issues/45
-        // ERROR bevy_asset::server: Failed to load asset with asset loader MeshletMeshLoader: failed to fill whole buffer
-        writer.flush()?;
         writer.finish()?;
 
         Ok(())


### PR DESCRIPTION
# Objective

- Remove a stale warning.

## Solution

- This issue is no longer relevant after https://github.com/smol-rs/piper/pull/31. The warning is now removed.
- I also removed the extra flush. Internally finish already calls flush, so everything is fine here.

## Testing

- None.