### PR TITLE
Set doc-scrape-example = true for recently merged example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1036,7 +1036,7 @@ wasm = true
 name = "tilemap_chunk_orientation"
 path = "examples/2d/tilemap_chunk_orientation.rs"
 # Causes an ICE on docs.rs
-doc-scrape-examples = false
+doc-scrape-examples = true
 
 [package.metadata.example.tilemap_chunk_orientation]
 name = "Tilemap Chunk with Orientations"


### PR DESCRIPTION
# Objective

- PR was merged recently that didn’t set doc-scrape-example to true

## Solution

Set it to true since the bug has been resolved. all examples can be scraped now.

(At this point in time, all other examples are already set to true)