### PR TITLE
Close the web_asset_cache file before ending the cache future.

### DIFF
--- a/crates/bevy_asset/src/io/web.rs
+++ b/crates/bevy_asset/src/io/web.rs
@@ -260,6 +260,7 @@ mod web_asset_cache {
 
         let mut cache_file = async_fs::File::create(&cache_path).await?;
         cache_file.write_all(data).await?;
+        cache_file.close().await?;
 
         Ok(())
     }


### PR DESCRIPTION
# Objective

- bevy_city is failing for some users, even after https://github.com/smol-rs/piper/pull/31.

## Solution

- Close (and thus flush) the file before calling the caching done.

## Testing

- Ran bevy_city a few times deleting the cache each time. Seems to work!