### PR TITLE
mention extendedmaterial in the stdmat docs

### DIFF
--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -14,7 +14,7 @@ use crate::{deferred::DEFAULT_PBR_DEFERRED_LIGHTING_PASS_ID, *};
 /// <https://google.github.io/filament/notes/material_properties.html>.
 ///
 /// May be created directly from a [`Color`] or an [`Image`].
-/// 
+///
 /// The `StandardMaterial` can be extended with more data and custom
 /// shaders using [`ExtendedMaterial`]. Examples of how to do this can
 /// be found in the Bevy examples.


### PR DESCRIPTION
# Objective

Some people don't know `ExtendedMaterial` exists and that it can be used to extend the `StandardMaterial` with custom data and shaders.

## Solution

We can mention it on the `StandardMaterial` docs.