### PR TITLE
fix: process window position before size in changed_windows

### DIFF
--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -354,6 +354,26 @@ pub(crate) fn changed_windows(
                     }
             }
 
+            // Set position before size so the window is on the correct monitor
+            // (and thus using the correct scale factor) when size is applied.
+            if window.position != cache.position
+                && let Some(position) = crate::winit_window_position(
+                    &window.position,
+                    &window.resolution,
+                    &monitors,
+                    winit_window.primary_monitor(),
+                    winit_window.current_monitor(),
+                ) {
+                    let should_set = match winit_window.outer_position() {
+                        Ok(current_position) => current_position != position,
+                        _ => true,
+                    };
+
+                    if should_set {
+                        winit_window.set_outer_position(position);
+                    }
+                }
+
             if window.resolution != cache.resolution {
                 let mut physical_size = PhysicalSize::new(
                     window.resolution.physical_width(),
@@ -443,24 +463,6 @@ pub(crate) fn changed_windows(
                     },
                 );
             }
-
-            if window.position != cache.position
-                && let Some(position) = crate::winit_window_position(
-                    &window.position,
-                    &window.resolution,
-                    &monitors,
-                    winit_window.primary_monitor(),
-                    winit_window.current_monitor(),
-                ) {
-                    let should_set = match winit_window.outer_position() {
-                        Ok(current_position) => current_position != position,
-                        _ => true,
-                    };
-
-                    if should_set {
-                        winit_window.set_outer_position(position);
-                    }
-                }
 
             if let Some(maximized) = window.internal.take_maximize_request() {
                 winit_window.set_maximized(maximized);


### PR DESCRIPTION
## Summary

When a bevy app starts, winit creates the window on a default monitor. If the app then sets the window's position to a location on a different monitor with a different scale factor, both position and size may be applied in the same pass through `changed_windows()`.

Currently, size is processed first (via `request_inner_size`), then position (via `set_outer_position`). Since the window hasn't moved yet when `request_inner_size` runs, it uses the default monitor's scale factor for the size calculation — not the scale factor of the monitor the window is about to move to. This produces the wrong size when the two monitors have different scale factors.

This PR moves the position block above the size block so the window is on the target monitor before `request_inner_size` runs.

## Context

This change is a **no-op with current released versions of winit**. Today, winit's `set_outer_position` has a bug where it uses the window's current monitor's scale factor instead of the target monitor's ([rust-windowing/winit#4505](https://github.com/rust-windowing/winit/pull/4505)), so the window doesn't reliably land at the correct position regardless of ordering.

Once winit merges that fix and bevy takes a dependency on a version that includes it, the ordering will matter: `set_outer_position` will correctly move the window to the target monitor, and `request_inner_size` needs to run *after* that move so it sees the correct `scale_factor()`.

The change is safe and backwards-compatible — it just reorders two independent blocks within the same function.

## Testing

Tested on macOS (1x + 2x) and Windows (1x + 1.5x) with the patched winit. Window appears at the correct position and size on the target monitor.