### PR TITLE
Optimize `update-caches` CI

### DIFF
--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -126,6 +126,7 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-${{ matrix.toolchain }}-${{ matrix.target }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('Cargo.lock') }}-${{ steps.get-date.outputs.date }}
+          lookup-only: true
 
       - name: Install Bevy dependencies
         if: steps.cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
# Objective

The current `update-caches` workflow has several issues:

- Installing apt dependencies even if we are not going to build bevy (had an exact cache hit)
- Actually restoring the cache (and then not using it as nothing else gets executed)

## Solution

- Skip installing Linux deps if we got a cache hit
- Don't restore the cache, only check if it exists

## Testing

Ran it on my fork, https://github.com/ShaharNaveh/bevy/actions/runs/22799581882