### PR TITLE
Don't let the clustering vertex shader see any read-write storage buffers.

### DIFF
--- a/crates/bevy_pbr/src/cluster/cluster_raster.wgsl
+++ b/crates/bevy_pbr/src/cluster/cluster_raster.wgsl
@@ -64,8 +64,10 @@ struct ClusterOffsetsAndCountsElementAtomic {
 
 // The list of clusterable object Z slices that we read from to.
 @group(0) @binding(0) var<storage> z_slices: array<ClusterableObjectZSlice>;
+#ifndef VERTEX_SHADER
 // The list of indices per cluster that we write to in the populate pass.
 @group(0) @binding(1) var<storage, read_write> index_lists: ClusterableObjectIndexLists;
+#endif  // VERTEX_SHADER
 // Information about each light.
 @group(0) @binding(2) var<storage> clustered_lights: ClusteredLights;
 // Information about each light probe (reflection probe or irradiance volume).
@@ -77,6 +79,7 @@ struct ClusterOffsetsAndCountsElementAtomic {
 @group(0) @binding(5) var<uniform> lights: Lights;
 // Information about the view.
 @group(0) @binding(6) var<uniform> view: View;
+#ifndef VERTEX_SHADER
 #ifdef POPULATE_PASS
 // The number of objects in each cluster, and the offset of each list.
 @group(0) @binding(7) var<storage> offsets_and_counts: ClusterOffsetsAndCounts;
@@ -92,6 +95,7 @@ struct ClusterOffsetsAndCountsElementAtomic {
 // During the count pass, we write to this.
 @group(0) @binding(7) var<storage, read_write> offsets_and_counts: ClusterOffsetsAndCountsAtomic;
 #endif  // POPULATE_PASS
+#endif  // VERTEX_SHADER
 
 // The vertex entry point.
 @vertex
@@ -152,6 +156,8 @@ fn calculate_vertex_position(vertex: Vertex, cluster_bounds: vec4<u32>) -> vec4<
         vec2<f32>(framebuffer_position) / vec2<f32>(lights.cluster_dimensions.xy);
     return vec4(mix(vec2(-1.0, 1.0), vec2(1.0, -1.0), vertex_position), 0.0, 1.0);
 }
+
+#ifndef VERTEX_SHADER
 
 // Performs a fine-grained test to ensure that the object intersects a single
 // froxel and records the result.
@@ -225,6 +231,8 @@ fn fragment_main(varyings: Varyings) -> @location(0) vec4<f32> {
 
     return vec4<f32>(0.0);
 }
+
+#endif  // VERTEX_SHADER
 
 // Returns true if the given sphere intersects the AABB with the given
 // boundaries.
@@ -426,6 +434,7 @@ fn sin_atan(tan_theta: f32) -> f32 {
     return tan_theta * inverseSqrt(1.0 + tan_theta * tan_theta);
 }
 
+#ifndef VERTEX_SHADER
 #ifdef POPULATE_PASS
 // Allocates space in the appropriate list and returns the global index that the
 // object index should be written to.
@@ -491,6 +500,7 @@ fn increment_object_count(cluster_index: u32, object_type: u32) {
     }
 }
 #endif  // POPULATE_PASS
+#endif  // VERTEX_SHADER
 
 // Looks up and returns the world-space center and radius of the bounding sphere
 // for the object with the given index and type.

--- a/crates/bevy_pbr/src/cluster/gpu.rs
+++ b/crates/bevy_pbr/src/cluster/gpu.rs
@@ -511,7 +511,7 @@ impl FromWorld for ClusteringRasterPipeline {
             // @group(0) @binding(1) var<storage, read_write> index_lists:
             // ClusterableObjectIndexLists;
             binding_types::storage_buffer::<GpuClusterableObjectIndexListsStorage>(false)
-                .build(1, ShaderStages::VERTEX_FRAGMENT),
+                .build(1, ShaderStages::FRAGMENT),
             // @group(0) @binding(2) var<storage> clustered_lights:
             // ClusteredLights;
             binding_types::storage_buffer_read_only::<GpuClusteredLight>(false)
@@ -538,20 +538,20 @@ impl FromWorld for ClusteringRasterPipeline {
         // ClusterOffsetsAndCountsAtomic;
         bind_group_layout_entries_count_pass.push(
             binding_types::storage_buffer::<GpuClusterOffsetsAndCountsStorage>(false)
-                .build(7, ShaderStages::VERTEX_FRAGMENT),
+                .build(7, ShaderStages::FRAGMENT),
         );
 
         // @group(0) @binding(7) var<storage> offsets_and_counts:
         // ClusterOffsetsAndCounts;
         bind_group_layout_entries_populate_pass.push(
             binding_types::storage_buffer_read_only::<GpuClusterOffsetsAndCountsStorage>(false)
-                .build(7, ShaderStages::VERTEX_FRAGMENT),
+                .build(7, ShaderStages::FRAGMENT),
         );
         // @group(0) @binding(8) var<storage, read_write>
         // scratchpad_offsets_and_counts: ClusterOffsetsAndCountsAtomic;
         bind_group_layout_entries_populate_pass.push(
             binding_types::storage_buffer::<GpuClusterOffsetsAndCountsStorage>(false)
-                .build(8, ShaderStages::VERTEX_FRAGMENT),
+                .build(8, ShaderStages::FRAGMENT),
         );
 
         let bind_group_layout_count_pass = BindGroupLayoutDescriptor::new(
@@ -577,12 +577,15 @@ impl SpecializedRenderPipeline for ClusteringRasterPipeline {
     type Key = ClusteringRasterPipelineKey;
 
     fn specialize(&self, key: Self::Key) -> RenderPipelineDescriptor {
-        let mut shader_defs = vec![];
+        let mut fragment_shader_defs = vec![];
         if key.populate_pass {
-            shader_defs.push(ShaderDefVal::from("POPULATE_PASS"));
+            fragment_shader_defs.push(ShaderDefVal::from("POPULATE_PASS"));
         } else {
-            shader_defs.push(ShaderDefVal::from("COUNT_PASS"));
+            fragment_shader_defs.push(ShaderDefVal::from("COUNT_PASS"));
         }
+
+        let mut vertex_shader_defs = fragment_shader_defs.clone();
+        vertex_shader_defs.push(ShaderDefVal::from("VERTEX_SHADER"));
 
         RenderPipelineDescriptor {
             label: if key.populate_pass {
@@ -598,7 +601,7 @@ impl SpecializedRenderPipeline for ClusteringRasterPipeline {
             immediate_size: 0,
             vertex: VertexState {
                 shader: self.shader.clone(),
-                shader_defs: shader_defs.clone(),
+                shader_defs: vertex_shader_defs,
                 entry_point: Some("vertex_main".into()),
                 buffers: vec![VertexBufferLayout {
                     array_stride: size_of::<Vec2>() as u64,
@@ -612,7 +615,7 @@ impl SpecializedRenderPipeline for ClusteringRasterPipeline {
             },
             fragment: Some(FragmentState {
                 shader: self.shader.clone(),
-                shader_defs: shader_defs.clone(),
+                shader_defs: fragment_shader_defs,
                 entry_point: Some("fragment_main".into()),
                 targets: vec![Some(ColorTargetState {
                     format: TextureFormat::R8Unorm,


### PR DESCRIPTION
The WebGPU spec forbids vertex shaders from having read-write storage buffers attached. As an extension, `wgpu` allows this on some hardware, but many mobile GPUs don't support it either. Because our bind group for GPU clustering rasterization specified `VERTEX_FRAGMENT` for all bindings, this was causing errors, even though we never actually used those read-write storage buffers in any vertex shaders.

This commit should fix the issue, by putting all read-write SSBO bindings behind `#ifdef`s and changing the `ShaderStages` for those bindings to `FRAGMENT`.

This should address the crashes in #23208 and #23216. I'm not sure if it'll address the incorrect lighting on certain devices in #23208, however; we may have to disable GPU clustering on those GPUs.