### PR TITLE
docs(ui): add composition guidance for leaf content components

### DIFF
--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -17,16 +17,16 @@
 //! - or one entity with [`widget::ViewportNode`].
 //!
 //! Use parent/child nodes to combine them:
-//! ```no_run
-//! # use bevy::prelude::*;
-//! fn setup(mut commands: Commands) {
-//!     commands
-//!         .spawn(Node::default()) // parent layout node
-//!         .with_children(|parent| {
-//!             parent.spawn(Text::new("Title"));
-//!             parent.spawn(ImageNode::default());
-//!         });
-//! }
+//! ```
+//! # use bevy_ecs::world::World;
+//! # use bevy_ui::prelude::*;
+//! # let mut world = World::default();
+//! world
+//!     .spawn(Node::default()) // parent layout node
+//!     .with_children(|parent| {
+//!         parent.spawn(Text::new("Title"));
+//!         parent.spawn(ImageNode::default());
+//!     });
 //! ```
 //!
 //! Avoid placing multiple leaf content components (for example, `Text` + `ImageNode`) on one


### PR DESCRIPTION
## Summary

Adds concise documentation guidance for UI composition in `bevy_ui` crate docs:
- keep one leaf content component (`Text`, `ImageNode`, or `ViewportNode`) per entity,
- compose mixed content through parent/child nodes,
- avoid placing multiple leaf content components on one entity.

## Issue alignment

- Addresses: #2249
- Related: #21576

## Scope guardrails

In scope:
- docs guidance in `crates/bevy_ui/src/lib.rs`

Out of scope:
- engine/runtime behavior changes
- generated `examples/README.md` edits (kept in sync with templated generator)

## Validation

Ran:
- `cargo fmt --all -- --check`
- `cargo run -p build-templated-pages -- update examples`

Passed.
