### PR TITLE
Skip swap-chain texture acquisition for windows with no camera target

### DIFF
--- a/crates/bevy_render/src/view/window/mod.rs
+++ b/crates/bevy_render/src/view/window/mod.rs
@@ -242,9 +242,25 @@ pub fn prepare_windows(
     mut windows: ResMut<ExtractedWindows>,
     mut window_surfaces: ResMut<WindowSurfaces>,
     render_device: Res<RenderDevice>,
+    sorted_cameras: Res<crate::camera::SortedCameras>,
     #[cfg(target_os = "linux")] render_instance: Res<RenderInstance>,
 ) {
     for window in windows.windows.values_mut() {
+        // Skip acquiring a swap-chain texture for windows that no camera
+        // targets. This avoids a wasted clear pass in
+        // `handle_uncovered_swap_chains` that triggers a DMA-fence fd leak on
+        // Adreno 740 (Quest 3). The exception is windows that still need their
+        // initial present (required on Wayland).
+        let is_camera_target = sorted_cameras.0.iter().any(|c| {
+            matches!(
+                &c.target,
+                Some(bevy_camera::NormalizedRenderTarget::Window(w)) if w.entity() == window.entity
+            )
+        });
+        if !is_camera_target && !window.needs_initial_present {
+            continue;
+        }
+
         let window_surfaces = window_surfaces.deref_mut();
         let Some(surface_data) = window_surfaces.surfaces.get(&window.entity) else {
             continue;


### PR DESCRIPTION
# Objective

Fix a file descriptor leak on Adreno 740 (Quest 3) caused by unnecessary render passes on windows that no camera is targeting.

`prepare_windows` calls `get_current_texture()` for every window unconditionally, and `handle_uncovered_swap_chains` then creates a `no_camera_clear_pass` render pass for any window without an active camera. On Adreno 740, each of these render pass submissions against a `wgpu::Surface` swap-chain texture leaks one `sync_file` DMA-fence fd per frame. At 60fps, that exhausts the Quest 3's 32,768 fd limit in about 9 minutes and crashes the app with `EMFILE`.

This affects any Bevy app on Quest 3 (and probably other Adreno devices) where a window surface exists but no camera renders to it — the main case being XR apps using `bevy_oxr`, where cameras target OpenXR swapchain images via `ManualTextureView`.

Unity hit what could be a related Adreno driver issue and shipped a workaround in Unity 6.3: [[Android Vulkan memory leak on Adreno devices](https://issuetracker.unity3d.com/issues/android-vulkan-memory-leak-on-some-adreno-devices-when-graphics-api-is-set-to-vulkan)](https://issuetracker.unity3d.com/issues/android-vulkan-memory-leak-on-some-adreno-devices-when-graphics-api-is-set-to-vulkan).

## Root cause

Tracking this down took 3 days of systematic binary-fold debugging with Claude Code, progressively narrowing from "the app crashes after 7.5 minutes" to the exact render pass responsible. The full investigation — elimination phases, fd monitoring logs, and the causal chain — is at: https://gitlab.com/wobble-bot-games/fd-leak-repro

The chain:
1. `WindowRenderPlugin::prepare_windows` calls `surface.get_current_texture()` every frame, populating `swap_chain_texture_view`
2. `handle_uncovered_swap_chains` iterates `ExtractedWindows` and creates a `no_camera_clear_pass` for any window that has a texture view but no active camera
3. That command buffer gets submitted to the GPU
4. Adreno 740 driver leaks a `sync_file` DMA fence fd on each submission targeting a Surface texture

## Fix

In `prepare_windows`, check `SortedCameras` (already populated in `CreateViews`, before `PrepareViews`) to see whether any camera targets each window. Skip `get_current_texture()` for uncovered windows. Without a texture view, `handle_uncovered_swap_chains` has nothing to work with and creates no render pass.

The `needs_initial_present` exception is preserved so Wayland windows still present at least once, as xdg-shell requires.

For standard desktop apps where cameras cover all visible windows, this changes nothing. For uncovered windows, behavior is the same as before — they weren't being presented anyway (only windows with an active camera or `needs_initial_present` get `present()` called in `present_frames`).

## Steps to reproduce

1. Build a minimal Bevy app for Android with the render pipeline enabled but no camera targeting the window (e.g. an XR app where cameras target OpenXR swapchain images)
2. Deploy to Meta Quest 3 (Adreno 740)
3. Monitor file descriptors:

```bash
adb logcat | grep FD_MONITOR
# or directly:
adb shell ls /proc/\$(adb shell pidof <package>)/fd | wc -l
```

4. Watch the fd count climb ~60/s until `EMFILE` at ~9 minutes

## Testing

Tested on Meta Quest 3 (Adreno 740, Qualcomm Vulkan 1.1) with a minimal Bevy app: window with full render pipeline, no camera, simulating the XR case.

**Before (vanilla `main`):**
```
FD_MONITOR: t=1s  fds=160  delta=+0
FD_MONITOR: t=2s  fds=220  delta=+60   rate=30.0/s
FD_MONITOR: t=3s  fds=280  delta=+120  rate=40.0/s
FD_MONITOR: t=5s  fds=400  delta=+240  rate=48.0/s
FD_MONITOR: t=10s fds=700  delta=+540  rate=54.0/s
FD_MONITOR: t=13s fds=880  delta=+720  rate=55.4/s
⚠ LEAK DETECTED — ~60 fds/s, crash in ~9 minutes
```

**After (this PR):**
```
FD_MONITOR: t=1s  fds=104  delta=+0  rate=0.0/s
FD_MONITOR: t=5s  fds=104  delta=+0  rate=0.0/s
FD_MONITOR: t=10s fds=104  delta=+0  rate=0.0/s
FD_MONITOR: t=18s fds=104  delta=+0  rate=0.0/s
✅ Zero leak — stable indefinitely
```

## Migration guide

No API changes. `prepare_windows` takes an additional `Res<SortedCameras>` system parameter, but this is an internal render system that users don't typically override.