### PR TITLE
Perf: conditional execution for `extract_skins` system

### DIFF
--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -198,7 +198,11 @@ impl Plugin for MeshRenderPlugin {
                 .add_systems(
                     ExtractSchedule,
                     (
-                        extract_skins,
+                        extract_skins.run_if(
+                            |skinned_meshes: Extract<Query<(), With<SkinnedMesh>>>| {
+                                !skinned_meshes.is_empty()
+                            },
+                        ),
                         extract_morphs,
                         gpu_preprocessing::clear_batched_gpu_instance_buffers::<MeshPipeline>
                             .before(MeshExtractionSystems),


### PR DESCRIPTION
# Objective

- In an app with no skinned meshes and many entities, traces were dominated by `extract_skins`. This was significant - 10ms in a 30ms frame.

<img width="1008" height="546" alt="image" src="https://github.com/user-attachments/assets/710d66d1-fb16-4b95-8f1c-388d1f2731b7" />

## Solution

- Don't run the system if there are no skinned meshes. There is some other performance pathology going on here, and you will hit it as soon as you add one skinned mesh, but for those of us with none, this is a simple way to avoid it at all.

## Testing

- Skinned mesh examples still work.