### PR TITLE
Docs & Migration Guides: Remove mentions of Cosmic Text where it seemed appropriate

### DIFF
--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -377,7 +377,7 @@ pub struct TextFont {
     /// Specifies the font face used for this text section.
     ///
     /// A `FontSource` can be a handle to a font asset, a font family name,
-    /// or a generic font category that is resolved using Cosmic Text's font database.
+    /// or a generic font category that is resolved using Parley's font database.
     pub font: FontSource,
     /// The vertical height of rasterized glyphs in the font atlas in pixels.
     ///

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -377,7 +377,7 @@ pub struct TextFont {
     /// Specifies the font face used for this text section.
     ///
     /// A `FontSource` can be a handle to a font asset, a font family name,
-    /// or a generic font category that is resolved using Parley's font database.
+    /// or a generic font category that is resolved using Parley's [`FontContext`](`parley::FontContext`) which is accessible through the [`FontCx`] resource.
     pub font: FontSource,
     /// The vertical height of rasterized glyphs in the font atlas in pixels.
     ///

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -377,7 +377,9 @@ pub struct TextFont {
     /// Specifies the font face used for this text section.
     ///
     /// A `FontSource` can be a handle to a font asset, a font family name,
-    /// or a generic font category that is resolved using Parley's [`FontContext`](`parley::FontContext`) which is accessible through the [`FontCx`] resource.
+    /// or a generic font category that is resolved using Parley's
+    /// [`FontContext`](`parley::FontContext`) which is accessible through the
+    /// [`FontCx`](`crate::FontCx`) resource.
     pub font: FontSource,
     /// The vertical height of rasterized glyphs in the font atlas in pixels.
     ///

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -173,7 +173,7 @@ pub struct TextMeasure {
 }
 
 impl TextMeasure {
-    /// Checks if the cosmic text buffer is needed for measuring the text.
+    /// Checks if the text buffer is needed for measuring the text.
     #[inline]
     pub const fn needs_buffer(height: Option<f32>, available_width: AvailableSpace) -> bool {
         height.is_none() && matches!(available_width, AvailableSpace::Definite(_))

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -173,7 +173,7 @@ pub struct TextMeasure {
 }
 
 impl TextMeasure {
-    /// Checks if the text buffer is needed for measuring the text.
+    /// Checks if the Parley text layout is needed for measuring the text.
     #[inline]
     pub const fn needs_buffer(height: Option<f32>, available_width: AvailableSpace) -> bool {
         height.is_none() && matches!(available_width, AvailableSpace::Definite(_))

--- a/release-content/migration-guides/TextFont_font_and_font_size_changes.md
+++ b/release-content/migration-guides/TextFont_font_and_font_size_changes.md
@@ -9,7 +9,7 @@ pull_requests: [22156, 22614]
 
 `FontSource` implements `From<Handle<Font>>`, migration of existing code should only require calling `into()` on the handle.
 
-Font texture atlases are no longer automatically cleared when the font asset they were generated from is removed. This is because there is no way to remove individual fonts from cosmic text's `FontSystem`. So even after the asset is removed, the font is still accessible using the family name with `FontSource::family` and removing the text atlases naively could cause a panic as rendering expects them to be present.
+Font texture atlases are no longer automatically cleared when the font asset they were generated from is removed. Even after the asset is removed, the font is still accessible using the family name with `FontSource::family`. Removing the text atlases naively could cause a panic as rendering expects them to be present.
 
 For `font_size`, the migration is to wrap the `f32` value in a `FontSize::Px(...)`.
 

--- a/release-content/release-notes/generic_font_families.md
+++ b/release-content/release-notes/generic_font_families.md
@@ -1,23 +1,23 @@
 ---
 title: "Generic Font Families"
 authors: ["@ickshonpe"]
-pull_requests: [22396]
+pull_requests: [22396, 22879]
 ---
 
 Bevy now supports generic font families, allowing font faces to be selected using broadly defined categories (such as `FontSource::Serif` or `FontSource::Monospace`) without naming a specific font family.
 
-The `CosmicFontSystem` resource can be used to update the font family associated with each generic font variant:
+The `FontCx` resource can be used to update the font family associated with each generic font variant:
 
 ```rust
-let mut font_system = CosmicFontSystem::default();
-let mut font_database = font_system.db_mut();
-font_database.set_serif_family("Allegro");
-font_database.set_sans_serif_family("Encode Sans");
-font_database.set_cursive_family("Cedarville Cursive");
-font_database.set_fantasy_family("Argusho");
-font_database.set_monospace_family("Lucida Console");
+fn font_families(mut font_system: ResMut<FontCx>) {
+  font_system.set_serif_family("Allegro");
+  font_system.set_sans_serif_family("Encode Sans");
+  font_system.set_cursive_family("Cedarville Cursive");
+  font_system.set_fantasy_family("Argusho");
+  font_system.set_monospace_family("Lucida Console");
 
-// `CosmicFontSystem::get_family` can be used to look the family associated with a `FontSource`
-let family_name = font_system.get_family(&FontSource::Serif).unwrap();
-assert_eq!(family_name.as_str(), "Allegro");
+  // `FontCx::get_family` can be used to look up the family associated with a `FontSource`
+  let family_name = font_system.get_family(&FontSource::Serif).unwrap();
+  assert_eq!(family_name.as_str(), "Allegro");
+}
 ```

--- a/release-content/release-notes/new_font_features.md
+++ b/release-content/release-notes/new_font_features.md
@@ -1,7 +1,7 @@
 ---
 title: "New Font features"
 authors: ["@ickshonpe"]
-pull_requests: [22156, 22614]
+pull_requests: [22156, 22614, 22879]
 ---
 
 `TextFont` has been expanded to include new fields:
@@ -24,13 +24,9 @@ FontSource has two variants: Handle, which identifies a font by asset handle, an
 
 `FontStyle` is an enum used to set the slant style of a font, with variants `Normal`, `Italic`, or `Oblique`.
 
-The system font support is very basic for now. You load them using the `CosmicFontSystem` resource:
+The system font support is very basic for now. To load them, you must enable the `bevy/system_font_discovery` feature.
 
-```rust
-font_system.db_mut().load_system_fonts()
-```
-
-Then they are available to be selected by family name using `FontSource::Family`.
+Then they are available to be selected by family name using `FontSource::Family` via the `FontCx` resource.
 
 The `font_size` field is now a `FontSize`, enabling responsive font sizing.
 


### PR DESCRIPTION
# Objective

- Fixes #22947 
- Prep for impending RC (soon)

## Solution

- Removed remaining mentions to the best of my ability, replacing it with Parley where it felt appropriate.
- I figured the migration guides should be updated too, since users would be migrating to a version where Cosmic has already been replaced, so no need to give them outdated information.