### PR TITLE
Use `EntityIndexSet` in `Children`

### DIFF
--- a/crates/bevy_ecs/src/entity/clone_entities.rs
+++ b/crates/bevy_ecs/src/entity/clone_entities.rs
@@ -2152,13 +2152,7 @@ mod tests {
             .linked_cloning(true)
             .clone_entity(root, clone_root);
 
-        let root_children = world
-            .entity(clone_root)
-            .get::<Children>()
-            .unwrap()
-            .iter()
-            .cloned()
-            .collect::<Vec<_>>();
+        let root_children = world.entity(clone_root).get::<Children>().unwrap().to_vec();
 
         assert!(root_children.iter().all(|e| *e != child1 && *e != child2));
         assert_eq!(root_children.len(), 2);
@@ -2179,13 +2173,7 @@ mod tests {
         );
 
         assert_eq!(
-            world
-                .entity(root)
-                .get::<Children>()
-                .unwrap()
-                .iter()
-                .map(|e| *e)
-                .collect::<Vec<_>>(),
+            world.entity(root).get::<Children>().unwrap().to_vec(),
             &[child1, child2]
         );
     }

--- a/crates/bevy_ecs/src/entity/clone_entities.rs
+++ b/crates/bevy_ecs/src/entity/clone_entities.rs
@@ -1468,8 +1468,8 @@ mod tests {
         world::{DeferredWorld, FromWorld, World},
     };
     use bevy_ptr::OwningPtr;
+    use core::alloc::Layout;
     use core::marker::PhantomData;
-    use core::{alloc::Layout, ops::Deref};
 
     #[cfg(feature = "bevy_reflect")]
     mod reflect {
@@ -2179,7 +2179,13 @@ mod tests {
         );
 
         assert_eq!(
-            world.entity(root).get::<Children>().unwrap().deref(),
+            world
+                .entity(root)
+                .get::<Children>()
+                .unwrap()
+                .iter()
+                .map(|e| *e)
+                .collect::<Vec<_>>(),
             &[child1, child2]
         );
     }

--- a/crates/bevy_ecs/src/hierarchy.rs
+++ b/crates/bevy_ecs/src/hierarchy.rs
@@ -233,6 +233,12 @@ impl Children {
     pub fn contains(&self, entity: &Entity) -> bool {
         self.0.contains(entity)
     }
+
+    /// Collects the children into a [`Vec`].
+    #[inline]
+    pub fn to_vec(&self) -> alloc::vec::Vec<Entity> {
+        self.0.iter().copied().collect()
+    }
 }
 
 impl<'a> IntoIterator for &'a Children {
@@ -532,7 +538,7 @@ mod tests {
         world
             .entity(entity)
             .get::<Children>()
-            .map(|c| c.into_iter().copied().collect::<Vec<_>>())
+            .map(|c| c.to_vec())
             .unwrap_or_default()
     }
 

--- a/crates/bevy_ecs/src/hierarchy.rs
+++ b/crates/bevy_ecs/src/hierarchy.rs
@@ -6,6 +6,7 @@
 //! [`Relationship`]: crate::relationship::Relationship
 //! [`RelationshipTarget`]: crate::relationship::RelationshipTarget
 
+use crate::entity::EntityIndexSet;
 #[cfg(feature = "bevy_reflect")]
 use crate::reflect::{ReflectComponent, ReflectFromWorld};
 use crate::{
@@ -16,13 +17,11 @@ use crate::{
     system::EntityCommands,
     world::{EntityWorldMut, FromWorld, World},
 };
-use alloc::vec::Vec;
 #[cfg(feature = "bevy_reflect")]
 use bevy_reflect::std_traits::ReflectDefault;
 #[cfg(all(feature = "serialize", feature = "bevy_reflect"))]
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 use core::ops::Deref;
-use core::slice;
 
 /// Stores the parent entity of this child entity with this component.
 ///
@@ -148,23 +147,18 @@ impl FromWorld for ChildOf {
 #[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 #[cfg_attr(feature = "bevy_reflect", reflect(Component, FromWorld, Default))]
 #[doc(alias = "IsParent")]
-pub struct Children(Vec<Entity>);
+pub struct Children(EntityIndexSet);
 
 impl Children {
     /// Swaps the child at `a_index` with the child at `b_index`.
     #[inline]
     pub fn swap(&mut self, a_index: usize, b_index: usize) {
-        self.0.swap(a_index, b_index);
+        self.0.swap_indices(a_index, b_index);
     }
 
-    /// Sorts children [stably](https://en.wikipedia.org/wiki/Sorting_algorithm#Stability)
-    /// in place using the provided comparator function.
+    /// Sorts children in place using the provided comparator function.
     ///
-    /// For the underlying implementation, see [`slice::sort_by`].
-    ///
-    /// For the unstable version, see [`sort_unstable_by`](Children::sort_unstable_by).
-    ///
-    /// See also [`sort_by_key`](Children::sort_by_key), [`sort_by_cached_key`](Children::sort_by_cached_key).
+    /// See also [`sort_by_key`](Children::sort_by_key).
     #[inline]
     pub fn sort_by<F>(&mut self, compare: F)
     where
@@ -173,47 +167,46 @@ impl Children {
         self.0.sort_by(compare);
     }
 
-    /// Sorts children [stably](https://en.wikipedia.org/wiki/Sorting_algorithm#Stability)
-    /// in place using the provided key extraction function.
+    /// Sorts children in place using the provided key extraction function.
     ///
-    /// For the underlying implementation, see [`slice::sort_by_key`].
-    ///
-    /// For the unstable version, see [`sort_unstable_by_key`](Children::sort_unstable_by_key).
-    ///
-    /// See also [`sort_by`](Children::sort_by), [`sort_by_cached_key`](Children::sort_by_cached_key).
+    /// See also [`sort_by`](Children::sort_by).
     #[inline]
-    pub fn sort_by_key<K, F>(&mut self, compare: F)
+    pub fn sort_by_key<K, F>(&mut self, mut compare: F)
     where
         F: FnMut(&Entity) -> K,
         K: Ord,
     {
-        self.0.sort_by_key(compare);
+        self.0.sort_by(|a, b| compare(a).cmp(&compare(b)));
     }
 
-    /// Sorts children [stably](https://en.wikipedia.org/wiki/Sorting_algorithm#Stability)
-    /// in place using the provided key extraction function. Only evaluates each key at most
-    /// once per sort, caching the intermediate results in memory.
-    ///
-    /// For the underlying implementation, see [`slice::sort_by_cached_key`].
+    /// Sorts children in place using the provided key extraction function.
+    /// Only evaluates each key at most once per sort, caching the intermediate
+    /// results in memory.
     ///
     /// See also [`sort_by`](Children::sort_by), [`sort_by_key`](Children::sort_by_key).
     #[inline]
-    pub fn sort_by_cached_key<K, F>(&mut self, compare: F)
+    pub fn sort_by_cached_key<K, F>(&mut self, mut compare: F)
     where
         F: FnMut(&Entity) -> K,
         K: Ord,
     {
-        self.0.sort_by_cached_key(compare);
+        // Collect (index, key) pairs, sort by key, then reorder.
+        let mut indexed_keys: alloc::vec::Vec<(usize, K)> = self
+            .0
+            .iter()
+            .enumerate()
+            .map(|(i, e)| (i, compare(e)))
+            .collect();
+        indexed_keys.sort_by(|a, b| a.1.cmp(&b.1));
+        let order: alloc::vec::Vec<Entity> = indexed_keys.iter().map(|(i, _)| self.0[*i]).collect();
+        self.0.clear();
+        self.0.extend(order);
     }
 
     /// Sorts children [unstably](https://en.wikipedia.org/wiki/Sorting_algorithm#Stability)
     /// in place using the provided comparator function.
     ///
-    /// For the underlying implementation, see [`slice::sort_unstable_by`].
-    ///
     /// For the stable version, see [`sort_by`](Children::sort_by).
-    ///
-    /// See also [`sort_unstable_by_key`](Children::sort_unstable_by_key).
     #[inline]
     pub fn sort_unstable_by<F>(&mut self, compare: F)
     where
@@ -225,25 +218,27 @@ impl Children {
     /// Sorts children [unstably](https://en.wikipedia.org/wiki/Sorting_algorithm#Stability)
     /// in place using the provided key extraction function.
     ///
-    /// For the underlying implementation, see [`slice::sort_unstable_by_key`].
-    ///
     /// For the stable version, see [`sort_by_key`](Children::sort_by_key).
-    ///
-    /// See also [`sort_unstable_by`](Children::sort_unstable_by).
     #[inline]
-    pub fn sort_unstable_by_key<K, F>(&mut self, compare: F)
+    pub fn sort_unstable_by_key<K, F>(&mut self, mut compare: F)
     where
         F: FnMut(&Entity) -> K,
         K: Ord,
     {
-        self.0.sort_unstable_by_key(compare);
+        self.0.sort_unstable_by(|a, b| compare(a).cmp(&compare(b)));
+    }
+
+    /// Returns `true` if the given entity is a child.
+    #[inline]
+    pub fn contains(&self, entity: &Entity) -> bool {
+        self.0.contains(entity)
     }
 }
 
 impl<'a> IntoIterator for &'a Children {
     type Item = <Self::IntoIter as Iterator>::Item;
 
-    type IntoIter = slice::Iter<'a, Entity>;
+    type IntoIter = crate::entity::index_set::Iter<'a>;
 
     #[inline(always)]
     fn into_iter(self) -> Self::IntoIter {
@@ -252,7 +247,7 @@ impl<'a> IntoIterator for &'a Children {
 }
 
 impl Deref for Children {
-    type Target = [Entity];
+    type Target = EntityIndexSet;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -532,6 +527,15 @@ mod tests {
     };
     use alloc::{vec, vec::Vec};
 
+    /// Helper to collect children into a Vec for test comparisons.
+    fn children_vec(world: &World, entity: Entity) -> Vec<Entity> {
+        world
+            .entity(entity)
+            .get::<Children>()
+            .map(|c| c.into_iter().copied().collect::<Vec<_>>())
+            .unwrap_or_default()
+    }
+
     #[derive(PartialEq, Eq, Debug)]
     struct Node {
         entity: Entity,
@@ -558,7 +562,7 @@ mod tests {
                 .entity(entity)
                 .get::<Children>()
                 .map_or_else(Default::default, |c| {
-                    c.iter().map(|e| get_hierarchy(world, e)).collect()
+                    c.into_iter().map(|&e| get_hierarchy(world, e)).collect()
                 }),
         }
     }
@@ -856,7 +860,8 @@ mod tests {
     fn replace_children() {
         let mut world = World::new();
         let parent = world.spawn(Children::spawn((Spawn(()), Spawn(())))).id();
-        let &[child_a, child_b] = &world.entity(parent).get::<Children>().unwrap().0[..] else {
+        let children_v = children_vec(&world, parent);
+        let &[child_a, child_b] = children_v.as_slice() else {
             panic!("Tried to spawn 2 children on an entity and didn't get 2 children");
         };
 
@@ -910,8 +915,7 @@ mod tests {
         world.entity_mut(parent).add_child(child);
         world.entity_mut(parent).add_child(child);
 
-        let children = world.get::<Children>(parent).unwrap();
-        assert_eq!(children.0, [child]);
+        assert_eq!(children_vec(&world, parent), vec![child]);
         assert_eq!(
             world.entity(child).get::<ChildOf>().unwrap(),
             &ChildOf(parent)
@@ -943,10 +947,7 @@ mod tests {
             world.entity(child_b).get::<ChildOf>().unwrap(),
             &ChildOf(parent)
         );
-        assert_eq!(
-            world.entity(parent).get::<Children>().unwrap().0,
-            [child_a, child_b]
-        );
+        assert_eq!(children_vec(&world, parent), vec![child_a, child_b]);
 
         // Test replacing relations and changing order
         world.entity_mut(parent).replace_children_with_difference(
@@ -967,8 +968,8 @@ mod tests {
             &ChildOf(parent)
         );
         assert_eq!(
-            world.entity(parent).get::<Children>().unwrap().0,
-            [child_d, child_c, child_a]
+            children_vec(&world, parent),
+            vec![child_d, child_c, child_a]
         );
         assert!(!world.entity(child_b).contains::<ChildOf>());
 
@@ -1025,10 +1026,7 @@ mod tests {
             world.entity(child_b).get::<ChildOf>().unwrap(),
             &ChildOf(parent)
         );
-        assert_eq!(
-            world.entity(parent).get::<Children>().unwrap().0,
-            [child_a, child_b]
-        );
+        assert_eq!(children_vec(&world, parent), vec![child_a, child_b]);
 
         // Test replacing relations and changing order
         world.entity_mut(parent).replace_children_with_difference(
@@ -1044,10 +1042,7 @@ mod tests {
             world.entity(child_d).get::<ChildOf>().unwrap(),
             &ChildOf(parent)
         );
-        assert_eq!(
-            world.entity(parent).get::<Children>().unwrap().0,
-            [child_d, child_c]
-        );
+        assert_eq!(children_vec(&world, parent), vec![child_d, child_c]);
         assert!(!world.entity(child_a).contains::<ChildOf>());
         assert!(!world.entity(child_b).contains::<ChildOf>());
     }
@@ -1065,15 +1060,12 @@ mod tests {
         let initial_order = [child_a, child_b, child_c, child_d];
         world.entity_mut(parent).add_children(&initial_order);
 
-        assert_eq!(
-            world.entity_mut(parent).get::<Children>().unwrap().0,
-            initial_order
-        );
+        assert_eq!(children_vec(&world, parent), initial_order.to_vec());
 
         let new_order = [child_d, child_b, child_a, child_c];
         world.entity_mut(parent).replace_children(&new_order);
 
-        assert_eq!(world.entity(parent).get::<Children>().unwrap().0, new_order);
+        assert_eq!(children_vec(&world, parent), new_order.to_vec());
     }
 
     #[test]
@@ -1154,8 +1146,8 @@ mod tests {
             .entity_mut(child)
             .insert_with_relationship_hook_mode(ChildOf(other), RelationshipHookMode::Skip);
         assert_eq!(
-            &**world.entity(parent).get::<Children>().unwrap(),
-            &[child],
+            children_vec(&world, parent),
+            vec![child],
             "Children should still have the old value, as on_insert/on_discard didn't run"
         );
     }

--- a/crates/bevy_ecs/src/relationship/related_methods.rs
+++ b/crates/bevy_ecs/src/relationship/related_methods.rs
@@ -727,15 +727,27 @@ mod tests {
         let some_child = Some(&child_value);
 
         parent.replace_children(&[child2, child3]);
-        let children = parent.get::<Children>().unwrap().collection();
-        assert_eq!(children, &[child2, child3]);
+        let children: Vec<_> = parent
+            .get::<Children>()
+            .unwrap()
+            .collection()
+            .iter()
+            .copied()
+            .collect();
+        assert_eq!(children, [child2, child3]);
         assert_eq!(parent.world().get::<ChildOf>(child1), None);
         assert_eq!(parent.world().get::<ChildOf>(child2), some_child);
         assert_eq!(parent.world().get::<ChildOf>(child3), some_child);
 
         parent.replace_children_with_difference(&[child3], &[child1, child2], &[child1]);
-        let children = parent.get::<Children>().unwrap().collection();
-        assert_eq!(children, &[child1, child2]);
+        let children: Vec<_> = parent
+            .get::<Children>()
+            .unwrap()
+            .collection()
+            .iter()
+            .copied()
+            .collect();
+        assert_eq!(children, [child1, child2]);
         assert_eq!(parent.world().get::<ChildOf>(child1), some_child);
         assert_eq!(parent.world().get::<ChildOf>(child2), some_child);
         assert_eq!(parent.world().get::<ChildOf>(child3), None);

--- a/crates/bevy_ecs/src/relationship/related_methods.rs
+++ b/crates/bevy_ecs/src/relationship/related_methods.rs
@@ -727,26 +727,14 @@ mod tests {
         let some_child = Some(&child_value);
 
         parent.replace_children(&[child2, child3]);
-        let children: Vec<_> = parent
-            .get::<Children>()
-            .unwrap()
-            .collection()
-            .iter()
-            .copied()
-            .collect();
+        let children = parent.get::<Children>().unwrap().to_vec();
         assert_eq!(children, [child2, child3]);
         assert_eq!(parent.world().get::<ChildOf>(child1), None);
         assert_eq!(parent.world().get::<ChildOf>(child2), some_child);
         assert_eq!(parent.world().get::<ChildOf>(child3), some_child);
 
         parent.replace_children_with_difference(&[child3], &[child1, child2], &[child1]);
-        let children: Vec<_> = parent
-            .get::<Children>()
-            .unwrap()
-            .collection()
-            .iter()
-            .copied()
-            .collect();
+        let children = parent.get::<Children>().unwrap().to_vec();
         assert_eq!(children, [child1, child2]);
         assert_eq!(parent.world().get::<ChildOf>(child1), some_child);
         assert_eq!(parent.world().get::<ChildOf>(child2), some_child);

--- a/crates/bevy_ecs/src/relationship/relationship_source_collection.rs
+++ b/crates/bevy_ecs/src/relationship/relationship_source_collection.rs
@@ -509,7 +509,7 @@ impl RelationshipSourceCollection for EntityIndexSet {
     }
 
     fn add(&mut self, entity: Entity) -> bool {
-        self.insert(entity)
+        self.0.insert(entity)
     }
 
     fn remove(&mut self, entity: Entity) -> bool {
@@ -534,6 +534,59 @@ impl RelationshipSourceCollection for EntityIndexSet {
 
     fn extend_from_iter(&mut self, entities: impl IntoIterator<Item = Entity>) {
         self.extend(entities);
+    }
+}
+
+impl OrderedRelationshipSourceCollection for EntityIndexSet {
+    fn insert(&mut self, index: usize, entity: Entity) {
+        // Add to end, then move to position
+        self.0.insert(entity);
+        let len = self.0.len();
+        if index < len {
+            self.0.swap_indices(len - 1, index);
+        }
+    }
+
+    fn remove_at(&mut self, index: usize) -> Option<Entity> {
+        (index < self.0.len()).then(|| self.0.swap_remove_index(index).unwrap())
+    }
+
+    fn insert_stable(&mut self, index: usize, entity: Entity) {
+        if index < self.0.len() {
+            // Insert at end then shift into position
+            self.0.insert(entity);
+            let last = self.0.len() - 1;
+            self.0.move_index(last, index);
+        } else {
+            self.0.insert(entity);
+        }
+    }
+
+    fn remove_at_stable(&mut self, index: usize) -> Option<Entity> {
+        (index < self.0.len()).then(|| self.0.shift_remove_index(index).unwrap())
+    }
+
+    fn sort(&mut self) {
+        self.0.sort_unstable();
+    }
+
+    fn insert_sorted(&mut self, entity: Entity) {
+        self.0.insert(entity);
+        self.0.sort_unstable();
+    }
+
+    fn place_most_recent(&mut self, index: usize) {
+        if !self.0.is_empty() {
+            let last = self.0.len() - 1;
+            self.0.move_index(last, index.min(last));
+        }
+    }
+
+    fn place(&mut self, entity: Entity, index: usize) {
+        if let Some(current) = self.0.get_index_of(&entity) {
+            let target = index.min(self.0.len() - 1);
+            self.0.move_index(current, target);
+        }
     }
 }
 

--- a/crates/bevy_text/src/text_access.rs
+++ b/crates/bevy_text/src/text_access.rs
@@ -212,7 +212,7 @@ impl<'a, R: TextRoot> Iterator for TextSpanIter<'a, R> {
             let (children, idx) = self.stack.last_mut()?;
 
             loop {
-                let Some(child) = children.get(*idx) else {
+                let Some(child) = children.get_index(*idx) else {
                     break;
                 };
 
@@ -328,7 +328,7 @@ impl<'w, 's, R: TextRoot> TextWriter<'w, 's, R> {
             };
 
             loop {
-                let Some(child) = children.get(*idx) else {
+                let Some(child) = children.get_index(*idx) else {
                     // All children at this stack entry have been iterated.
                     stack.pop();
                     break;
@@ -522,7 +522,7 @@ impl<'w, 's, R: TextRoot> TextWriter<'w, 's, R> {
             };
 
             loop {
-                let Some(child) = children.get(*idx) else {
+                let Some(child) = children.get_index(*idx) else {
                     // All children at this stack entry have been iterated.
                     stack.pop();
                     break;

--- a/crates/bevy_ui/src/experimental/ghost_hierarchy.rs
+++ b/crates/bevy_ui/src/experimental/ghost_hierarchy.rs
@@ -142,9 +142,8 @@ impl<'w, 's> UiChildren<'w, 's> {
             .get(entity)
             .ok()
             .flatten()
-            .map(|children| children.as_ref())
-            .unwrap_or(&[])
-            .iter()
+            .into_iter()
+            .flat_map(|children| children.into_iter())
             .copied()
     }
 


### PR DESCRIPTION
# Objective

- Fix #23295 
- Alternative to #23297 

## Solution

- Use an index set for fast lookups, while maintaining insertion order and index lookups used by existing features.