### PR TITLE
ViewportNode.camera is now an Option<Entity>

### DIFF
--- a/crates/bevy_ui/src/widget/viewport.rs
+++ b/crates/bevy_ui/src/widget/viewport.rs
@@ -46,15 +46,18 @@ pub struct ViewportNode {
     /// entity.
     ///
     /// Note: Despawning the camera entity will leave a viewport node with an
-    /// invalid camera.
-    pub camera: Entity,
+    /// invalid camera. It will automatically be set to none when
+    /// [`update_viewport_render_target_size`] runs next.
+    pub camera: Option<Entity>,
 }
 
 impl ViewportNode {
     /// Creates a new [`ViewportNode`] with a given `camera`.
     #[inline]
     pub const fn new(camera: Entity) -> Self {
-        Self { camera }
+        Self {
+            camera: Some(camera),
+        }
     }
 }
 
@@ -66,7 +69,7 @@ pub fn viewport_picking(
     mut commands: Commands,
     mut viewport_query: Query<(
         Entity,
-        &ViewportNode,
+        &mut ViewportNode,
         &PointerId,
         &mut PointerLocation,
         &ComputedNode,
@@ -103,7 +106,7 @@ pub fn viewport_picking(
 
     for (
         viewport_entity,
-        &viewport,
+        mut viewport,
         &viewport_pointer_id,
         mut viewport_pointer_location,
         computed_node,
@@ -115,7 +118,11 @@ pub fn viewport_picking(
             viewport_pointer_location.location = None;
             continue;
         };
-        let Ok((camera, render_target)) = camera_query.get(viewport.camera) else {
+        let Some(camera_entity) = viewport.camera else {
+            continue;
+        };
+        let Ok((camera, render_target)) = camera_query.get(camera_entity) else {
+            viewport.camera = None;
             continue;
         };
         let Some(cam_viewport_size) = camera.logical_viewport_size() else {
@@ -157,15 +164,19 @@ pub fn viewport_picking(
 
 /// Updates the size of the associated render target for viewports when the node size changes.
 pub fn update_viewport_render_target_size(
-    viewport_query: Query<
-        (&ViewportNode, &ComputedNode),
+    mut viewport_query: Query<
+        (&mut ViewportNode, &ComputedNode),
         Or<(Changed<ComputedNode>, Changed<ViewportNode>)>,
     >,
     camera_query: Query<&RenderTarget>,
     mut images: ResMut<Assets<Image>>,
 ) {
-    for (viewport, computed_node) in &viewport_query {
-        let Ok(render_target) = camera_query.get(viewport.camera) else {
+    for (mut viewport, computed_node) in &mut viewport_query {
+        let Some(camera) = viewport.camera else {
+            continue;
+        };
+        let Ok(render_target) = camera_query.get(camera) else {
+            viewport.camera = None;
             continue;
         };
         let size = computed_node.size();

--- a/crates/bevy_ui_render/src/lib.rs
+++ b/crates/bevy_ui_render/src/lib.rs
@@ -848,9 +848,12 @@ pub fn extract_viewport_nodes(
         let Some(extracted_camera_entity) = camera_mapper.map(camera) else {
             continue;
         };
+        let Some(camera_entity) = viewport_node.camera else {
+            continue;
+        };
 
         let Some(image) = camera_query
-            .get(viewport_node.camera)
+            .get(camera_entity)
             .ok()
             .and_then(|(_, render_target)| render_target.as_image())
         else {

--- a/release-content/migration-guides/viewport_node_option_camera.md
+++ b/release-content/migration-guides/viewport_node_option_camera.md
@@ -1,6 +1,6 @@
 ---
 title: "`ViewportNode`'s `camera` is now an `Option<Entity>`"
-pull_requests: []
+pull_requests: [23298]
 ---
 
 The `ViewportNode`'s `camera` field is now an `Option<Entity>`. `ViewportNode`s can now exist without a valid camera.

--- a/release-content/migration-guides/viewport_node_option_camera.md
+++ b/release-content/migration-guides/viewport_node_option_camera.md
@@ -1,0 +1,6 @@
+---
+title: "`ViewportNode`'s `camera` is now an `Option<Entity>`"
+pull_requests: []
+---
+
+The `ViewportNode`'s `camera` field is now an `Option<Entity>`. `ViewportNode`s can now exist without a valid camera.


### PR DESCRIPTION
# Objective

- Fixes #22641 

## Solution

- Changes `ViewportNode.camera` to an `Option<Entity>`. Update this field to None if the camera is not found in `viewport_picking` and, more importantly, `update_viewport_render_target_size`. I did not put this same logic in `extract_viewport_nodes` because I wasn’t sure whether to add a `mut` to the query / if that affects performance or something (but if I should, let me know)

## Testing

- `cargo run --example viewport_node` still works