### PR TITLE
Remove dead code `handle_uncovered_swap_chains` system

### DIFF
--- a/crates/bevy_core_pipeline/src/lib.rs
+++ b/crates/bevy_core_pipeline/src/lib.rs
@@ -26,9 +26,7 @@ pub use schedule::{Core2d, Core2dSystems, Core3d, Core3dSystems};
 
 mod fullscreen_vertex_shader;
 
-use crate::schedule::{
-    camera_driver, handle_uncovered_swap_chains, submit_pending_command_buffers,
-};
+use crate::schedule::{camera_driver, submit_pending_command_buffers};
 use crate::{
     blit::BlitPlugin, core_2d::Core2dPlugin, core_3d::Core3dPlugin,
     deferred::copy_lighting_id::CopyDeferredLightingIdPlugin, mip_generation::MipGenerationPlugin,
@@ -64,9 +62,7 @@ impl Plugin for CorePipelinePlugin {
             RenderGraph,
             (
                 camera_driver.in_set(RenderGraphSystems::Render),
-                (submit_pending_command_buffers, handle_uncovered_swap_chains)
-                    .chain()
-                    .in_set(RenderGraphSystems::Submit),
+                submit_pending_command_buffers.in_set(RenderGraphSystems::Submit),
             ),
         );
     }

--- a/crates/bevy_core_pipeline/src/schedule.rs
+++ b/crates/bevy_core_pipeline/src/schedule.rs
@@ -9,20 +9,15 @@
 //! The [`camera_driver`] system is responsible for iterating over all cameras in the world
 //! and executing their associated schedules. In this way, the schedule for each camera is a
 //! sub-schedule or sub-graph of the root render graph schedule.
-use bevy_camera::{ClearColor, NormalizedRenderTarget};
+use bevy_camera::NormalizedRenderTarget;
 use bevy_ecs::{
     prelude::*,
     schedule::{IntoScheduleConfigs, Schedule, ScheduleLabel, SystemSet},
 };
 use bevy_log::info_span;
-use bevy_platform::collections::HashSet;
 use bevy_render::{
     camera::{ExtractedCamera, SortedCameras},
-    render_resource::{
-        CommandEncoderDescriptor, LoadOp, Operations, RenderPassColorAttachment,
-        RenderPassDescriptor, StoreOp,
-    },
-    renderer::{CurrentView, PendingCommandBuffers, RenderDevice, RenderQueue},
+    renderer::{CurrentView, PendingCommandBuffers, RenderQueue},
     view::ExtractedWindows,
 };
 
@@ -98,25 +93,18 @@ impl Core2d {
     }
 }
 
-/// Holds the entity of windows that are a render target for a camera
-#[derive(Resource)]
-struct CameraWindows(HashSet<Entity>);
-
 /// The default entry point for camera driven rendering added to the root [`bevy_render::renderer::RenderGraph`]
 /// schedule. This system iterates over all cameras in the world, executing their associated
 /// rendering schedules defined by the [`bevy_render::camera::CameraRenderGraph`] component.
 ///
-/// After executing all camera schedules, it submits any pending command buffers to the GPU
-/// and clears any swap chains that were not covered by a camera. Users can order any additional
-/// operations (e.g. one-off compute passes) before or after this system in the root render
-/// graph schedule.
+/// After executing all camera schedules, it submits any pending command buffers to the GPU.
+/// Users can order any additional operations (e.g. one-off compute passes) before or after
+/// this system in the root render graph schedule.
 pub fn camera_driver(world: &mut World) {
     let sorted_cameras: Vec<_> = {
         let sorted = world.resource::<SortedCameras>();
         sorted.0.iter().map(|c| (c.entity, c.order)).collect()
     };
-
-    let mut camera_windows = HashSet::default();
 
     for camera in sorted_cameras {
         #[cfg(feature = "trace")]
@@ -134,13 +122,11 @@ pub fn camera_driver(world: &mut World) {
         if let Some(NormalizedRenderTarget::Window(window_ref)) = &target {
             let window_entity = window_ref.entity();
             let windows = world.resource::<ExtractedWindows>();
-            if windows
+            if !windows
                 .windows
                 .get(&window_entity)
                 .is_some_and(|w| w.physical_width > 0 && w.physical_height > 0)
             {
-                camera_windows.insert(window_entity);
-            } else {
                 run_schedule = false;
             }
         }
@@ -159,8 +145,6 @@ pub fn camera_driver(world: &mut World) {
         }
     }
     world.remove_resource::<CurrentView>();
-
-    world.insert_resource(CameraWindows(camera_windows));
 }
 
 pub(crate) fn submit_pending_command_buffers(world: &mut World) {
@@ -173,59 +157,4 @@ pub(crate) fn submit_pending_command_buffers(world: &mut World) {
         let queue = world.resource::<RenderQueue>();
         queue.submit(buffers);
     }
-}
-
-pub(crate) fn handle_uncovered_swap_chains(world: &mut World) {
-    let windows_to_clear: Vec<_> = {
-        let clear_color = world.resource::<ClearColor>().0.to_linear();
-        let Some(camera_windows) = world.remove_resource::<CameraWindows>() else {
-            return;
-        };
-        let windows = world.resource::<ExtractedWindows>();
-        windows
-            .iter()
-            .filter_map(|(window_entity, window)| {
-                if camera_windows.0.contains(window_entity) {
-                    return None;
-                }
-                let swap_chain_texture = window.swap_chain_texture_view.as_ref()?;
-                Some((swap_chain_texture.clone(), clear_color))
-            })
-            .collect()
-    };
-
-    if windows_to_clear.is_empty() {
-        return;
-    }
-
-    let render_device = world.resource::<RenderDevice>();
-    let render_queue = world.resource::<RenderQueue>();
-
-    let mut encoder = render_device.create_command_encoder(&CommandEncoderDescriptor::default());
-
-    for (swap_chain_texture, clear_color) in &windows_to_clear {
-        #[cfg(feature = "trace")]
-        let _span = bevy_log::info_span!("no_camera_clear_pass").entered();
-
-        let pass_descriptor = RenderPassDescriptor {
-            label: Some("no_camera_clear_pass"),
-            color_attachments: &[Some(RenderPassColorAttachment {
-                view: swap_chain_texture,
-                depth_slice: None,
-                resolve_target: None,
-                ops: Operations {
-                    load: LoadOp::Clear((*clear_color).into()),
-                    store: StoreOp::Store,
-                },
-            })],
-            depth_stencil_attachment: None,
-            timestamp_writes: None,
-            occlusion_query_set: None,
-            multiview_mask: None,
-        };
-
-        encoder.begin_render_pass(&pass_descriptor);
-    }
-
-    render_queue.submit([encoder.finish()]);
 }

--- a/crates/bevy_render/src/view/window/mod.rs
+++ b/crates/bevy_render/src/view/window/mod.rs
@@ -247,10 +247,9 @@ pub fn prepare_windows(
 ) {
     for window in windows.windows.values_mut() {
         // Skip acquiring a swap-chain texture for windows that no camera
-        // targets. This avoids a wasted clear pass in
-        // `handle_uncovered_swap_chains` that triggers a DMA-fence fd leak on
-        // Adreno 740 (Quest 3). The exception is windows that still need their
-        // initial present (required on Wayland).
+        // targets. This avoids a DMA-fence fd leak on Adreno 740 (Quest 3).
+        // The exception is windows that still need their initial present
+        // (required on Wayland).
         let is_camera_target = sorted_cameras.0.iter().any(|c| {
             matches!(
                 &c.target,


### PR DESCRIPTION
# Objective

- Fixes #23292
- The `handle_uncovered_swap_chains` system became dead code after #23276 skipped swap-chain texture acquisition for windows without camera targets.
- The system's filter (`.swap_chain_texture_view.as_ref()?`) always returns `None` for uncovered windows now, so it never does any work.

## Solution

- Remove the `handle_uncovered_swap_chains` system from `bevy_core_pipeline::schedule`
- Remove the `CameraWindows` resource that only existed to support it
- Remove the `camera_windows` HashSet tracking in `camera_driver` that only existed to populate `CameraWindows`
- Simplify the system registration in `CorePipelinePlugin` from a chained tuple to just `submit_pending_command_buffers`
- Update the comment in `prepare_windows` that referenced the removed function

## Testing

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p bevy_core_pipeline -p bevy_render -- -D warnings` — no warnings
- `cargo test -p bevy_core_pipeline -p bevy_render` — all tests pass
