### PR TITLE
Fix Solari flickering by ordering solari_lighting

### DIFF
--- a/crates/bevy_solari/src/realtime/mod.rs
+++ b/crates/bevy_solari/src/realtime/mod.rs
@@ -7,6 +7,7 @@ use bevy_app::{App, Plugin};
 use bevy_asset::embedded_asset;
 use bevy_camera::Hdr;
 use bevy_core_pipeline::{
+    core_3d::main_opaque_pass_3d,
     prepass::{
         DeferredPrepass, DeferredPrepassDoubleBuffer, DepthPrepass, DepthPrepassDoubleBuffer,
         MotionVectorPrepass,
@@ -68,7 +69,12 @@ impl Plugin for SolariLightingPlugin {
                 Render,
                 prepare_solari_lighting_resources.in_set(RenderSystems::PrepareResources),
             )
-            .add_systems(Core3d, solari_lighting.in_set(Core3dSystems::MainPass));
+            .add_systems(
+                Core3d,
+                solari_lighting
+                    .before(main_opaque_pass_3d)
+                    .in_set(Core3dSystems::MainPass),
+            );
     }
 }
 


### PR DESCRIPTION
# Objective

Solari was flickering when DLSS was enabled after #23036.

## Solution

My intuition was that this was a pre-existing system ordering issue, exposed by happenstance due to tweaks in the exact topo-sort being used.

That's consistent with both flickering and spooky action at a distance.

After some digging, I found that `solari_lighting`'s system ordering was not consistent with `deferred_lighting`, and was free-floating inside of `Core3dSystems::MainPass)`.

Ordering this before the `main_opaque_3d_pass` fixed the bug! I think the root ambiguity has something to do with the order in which GPU commands are queued, but that's a bit beyond my expertise.

This bug likely exists without DLSS, and before the linked PR, but is hard to surface due to the topo sort of systems we were typically falling into.

## Testing

`cargo run --example solari --features="bevy_solari https free_camera dlss"`
