### PR TITLE
Add `Counter` resource

### DIFF
--- a/examples/app/persisting_preferences.rs
+++ b/examples/app/persisting_preferences.rs
@@ -29,6 +29,7 @@ fn main() {
             }),
             ..default()
         }))
+        .init_resource::<Counter>()
         .add_plugins(PreferencesPlugin::new(
             "org.bevy.examples.persisting_preferences",
         ))


### PR DESCRIPTION
requires the `Counter` resource at runtime.

# Objective

Fix a runtime panic/error that occurs when a system attempts to access the `Counter` resource, but it has not been inserted into the world.

## Solution

Use `App` method `init_resource::<Counter>()` to insert the `Counter` resource.

## Testing

Yes, this change have been tested.
