### PR TITLE
Add `WindowSettings` resource

### DIFF
--- a/examples/window/persisting_window_settings.rs
+++ b/examples/window/persisting_window_settings.rs
@@ -27,6 +27,7 @@ fn main() {
             }),
             ..default()
         }))
+        .init_resource::<WindowSettings>()
         .add_plugins(PreferencesPlugin::new(
             "org.bevy.examples.persisting_window_settings",
         ))


### PR DESCRIPTION
requires the `WindowSettings` resource at runtime.

# Objective

Fix a runtime panic/error that occurs when a system attempts to access the `WindowSettings` resource, but it has not been inserted into the world.

## Solution

Use `App` method `init_resource::<WindowSettings>()` to insert the `WindowSettings` resource.

## Testing

Yes, this change has been tested.