### PR TITLE
do not scrape type_data example, causes ICE

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2970,7 +2970,8 @@ wasm = false
 [[example]]
 name = "type_data"
 path = "examples/reflection/type_data.rs"
-doc-scrape-examples = true
+# causes ICE due to impl in a fn: rust-lang issue 149089
+doc-scrape-examples = false
 
 [package.metadata.example.type_data]
 name = "Type Data"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2970,7 +2970,7 @@ wasm = false
 [[example]]
 name = "type_data"
 path = "examples/reflection/type_data.rs"
-# causes ICE due to impl in a fn: rust-lang issue 149089
+# causes ICE due to impl in a fn: https://github.com/rust-lang/rust/issues/149089
 doc-scrape-examples = false
 
 [package.metadata.example.type_data]


### PR DESCRIPTION
# Objective

- Fix deploy-docs job

## Solution

- Do not scrape the `type_data` example since it causes an ICE. Supposedly it’s the only one currently.