### PR TITLE
Add doc comment to AsBindGroup derive macro linking to trait docs

### DIFF
--- a/crates/bevy_render/macros/src/lib.rs
+++ b/crates/bevy_render/macros/src/lib.rs
@@ -56,6 +56,13 @@ pub fn derive_extract_component(input: TokenStream) -> TokenStream {
     extract_component::derive_extract_component(input)
 }
 
+/// Derives the `AsBindGroup` trait for a struct, enabling it to be
+/// converted into a bind group layout and bind group for use in rendering.
+///
+/// For detailed information on the available attributes (`#[uniform]`, `#[texture]`,
+/// `#[sampler]`, `#[storage_texture]`, `#[storage]`, `#[bind_group_data]`, `#[bindless]`,
+/// and `#[data]`), see the [`AsBindGroup`](bevy_render::render_resource::AsBindGroup)
+/// trait documentation.
 #[proc_macro_derive(
     AsBindGroup,
     attributes(


### PR DESCRIPTION
# Objective

- Fixes #16955
- The `AsBindGroup` derive macro has no doc comment and no link to the trait documentation, where all the derive attributes (`#[uniform]`, `#[texture]`, `#[sampler]`, etc.) are documented.

## Solution

- Added a doc comment to the derive macro with a brief description and a link to the `AsBindGroup` trait documentation for the full attribute reference.

## Testing

- `cargo doc --workspace --no-deps` builds successfully with the new intra-doc link resolving correctly.