### PR TITLE
Document why MAX_JOINTS and MAX_MORPH_WEIGHTS are set to their current values

### DIFF
--- a/crates/bevy_gltf/src/loader/mod.rs
+++ b/crates/bevy_gltf/src/loader/mod.rs
@@ -77,7 +77,11 @@ use self::{
 };
 use crate::convert_coordinates::GltfConvertCoordinates;
 
+/// Maximum number of joints supported for skinned meshes.
+///
 /// Must match [`MAX_JOINTS`](https://docs.rs/bevy/latest/bevy/pbr/constant.MAX_JOINTS.html)
+/// in `bevy_pbr`. This value is used to allocate buffers and is chosen
+/// because it is guaranteed to work on all GPUs and platforms.
 pub const MAX_JOINTS: usize = 256;
 
 /// An error that occurs when loading a glTF file.

--- a/crates/bevy_mesh/src/morph.rs
+++ b/crates/bevy_mesh/src/morph.rs
@@ -12,6 +12,11 @@ use thiserror::Error;
 pub const MAX_TEXTURE_WIDTH: u32 = 2048;
 
 /// Max target count available for [morph targets](MorphWeights).
+///
+/// This value is used to allocate buffers. The current value is chosen
+/// because it is guaranteed to work on all GPUs and platforms. Allowing
+/// bigger values would require checking the GPU limits at runtime, which
+/// would mean not using consts anymore.
 pub const MAX_MORPH_WEIGHTS: usize = 256;
 
 /// The maximum number of morph target components, if morph target textures are


### PR DESCRIPTION
# Objective

- Fixes #15974
- `MAX_JOINTS` and `MAX_MORPH_WEIGHTS` constants have no documentation explaining why they are set to their current values (256).

## Solution

- Added doc comments explaining that these values are used to allocate buffers and are chosen because they are guaranteed to work on all GPUs and platforms. Noted that larger values would require runtime GPU limit checks instead of constants.

## Testing

- `cargo doc --workspace --no-deps` builds successfully.