### PR TITLE
Rename bevy_image::Volume to ImageVolume for clarity

### DIFF
--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -2150,12 +2150,12 @@ impl<'a> ImageType<'a> {
 }
 
 /// Used to calculate the total number of pixels for an image size.
-pub trait Volume {
+pub trait ImageVolume {
     /// Calculates the total number of pixels in the item.
     fn volume(&self) -> usize;
 }
 
-impl Volume for Extent3d {
+impl ImageVolume for Extent3d {
     /// Calculates the total number of pixels in the [`Extent3d`].
     fn volume(&self) -> usize {
         (self.width * self.height * self.depth_or_array_layers) as usize


### PR DESCRIPTION
# Objective

- Fixes #23184
- `bevy_image::Volume` uses too broad of a name that could be confused with audio volume or physical volume. Bevy prefers descriptive type names that make sense in a global game engine context.

## Solution

- Renamed the `Volume` trait to `ImageVolume` to clearly indicate it relates to image pixel volume calculations.

## Testing

- `cargo check --workspace` compiles successfully with the rename.