### PR TITLE
Fix AccessibilityRequested reflection serialization by marking it as opaque

### DIFF
--- a/crates/bevy_a11y/src/lib.rs
+++ b/crates/bevy_a11y/src/lib.rs
@@ -108,10 +108,11 @@ pub struct ActionRequest(pub accesskit::ActionRequest);
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(Reflect),
-    reflect(opaque),
     reflect(Default, Clone, Resource)
 )]
-pub struct AccessibilityRequested(Arc<AtomicBool>);
+pub struct AccessibilityRequested(
+    #[cfg_attr(feature = "bevy_reflect", reflect(skip_serializing))] Arc<AtomicBool>,
+);
 
 impl AccessibilityRequested {
     /// Checks if any assistive technology has requested accessibility


### PR DESCRIPTION
# Objective

- Fixes #22816
- Serializing a `DynamicScene` panics because `AccessibilityRequested` contains an `Arc<AtomicBool>` which does not implement `ReflectSerialize`.

## Solution

- Added `#[reflect(skip_serializing)]` to the inner `Arc<AtomicBool>` field of `AccessibilityRequested`, so the reflection serializer skips it and uses `Default` on deserialization.

## Testing

- Reproduced with the program from the original issue using `DefaultPlugins`. Scene serialization via `DynamicScene::serialize` no longer panics on `AccessibilityRequested`.