### PR TITLE
Add ComputedNode::logical_size() method

### DIFF
--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -95,8 +95,10 @@ impl ComputedNode {
 
     /// The calculated node size as width and height in logical pixels.
     ///
-    /// Logical size is the physical size divided by the scale factor,
-    /// and matches the coordinate space used by cursor/mouse positions.
+    /// Logical size is the physical size divided by the scale factor.
+    /// Note that this is in UI logical space, which accounts for both the window
+    /// scale factor and [`UiScale`](super::UiScale). To convert pointer positions
+    /// to UI logical space, divide by `UiScale` as well.
     #[inline]
     pub fn logical_size(&self) -> Vec2 {
         self.size * self.inverse_scale_factor


### PR DESCRIPTION
# Objective

- Fixes #17462
- `ComputedNode::size()` returns the physical size, but cursor/mouse positions use logical coordinates. Users must manually multiply by `inverse_scale_factor`, which is easy to miss — especially when developing on displays with a scale factor of 1.

## Solution

- Added a `ComputedNode::logical_size()` method that returns `size * inverse_scale_factor`, matching the coordinate space used by cursor/mouse positions.

## Testing

- The method is a simple multiplication of existing fields. Verified it compiles and returns expected values.