### PR TITLE
Add Copy trait to Pickable component

### DIFF
--- a/crates/bevy_picking/src/lib.rs
+++ b/crates/bevy_picking/src/lib.rs
@@ -192,7 +192,7 @@ pub mod prelude {
 ///
 /// See the documentation on the fields for more details.
 #[derive(Component, Debug, Clone, Copy, Reflect, PartialEq, Eq)]
-#[reflect(Component, Default, Debug, PartialEq, Clone, Copy)]
+#[reflect(Component, Default, Debug, PartialEq, Clone)]
 pub struct Pickable {
     /// Should this entity block entities below it from being picked?
     ///


### PR DESCRIPTION
It not deriving Copy makes config structs with it also non-Copy It has two simple flags, there's no reason for it not to be

# Objective

Make Pickable Copy so that config structs that have it as a field could also be Copy

## Solution

Have it derive Copy

## Testing

No need, it doesn't break anything

