### PR TITLE
Remove deprecated `generate_view_layouts` function

### DIFF
--- a/crates/bevy_pbr/src/render/mesh_view_bindings.rs
+++ b/crates/bevy_pbr/src/render/mesh_view_bindings.rs
@@ -73,7 +73,7 @@ pub struct MeshPipelineViewLayout {
 bitflags::bitflags! {
     /// A key that uniquely identifies a [`MeshPipelineViewLayout`].
     ///
-    /// Used to generate all possible layouts for the mesh pipeline in [`generate_view_layouts`],
+    /// Used to generate all possible layouts for the mesh pipeline in [`layout_entries`],
     /// so special care must be taken to not add too many flags, as the number of possible layouts
     /// will grow exponentially.
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -540,47 +540,6 @@ impl MeshPipelineViewLayouts {
 
         layout
     }
-}
-
-/// Generates all possible view layouts for the mesh pipeline, based on all combinations of
-/// [`MeshPipelineViewLayoutKey`] flags.
-#[deprecated(since = "0.19.0", note = "Use `layout_entries` instead")]
-pub fn generate_view_layouts(
-    render_device: &RenderDevice,
-    render_adapter: &RenderAdapter,
-    clustered_forward_buffer_binding_type: BufferBindingType,
-    visibility_ranges_buffer_binding_type: BufferBindingType,
-) -> [MeshPipelineViewLayout; MeshPipelineViewLayoutKey::COUNT] {
-    array::from_fn(|i| {
-        let key = MeshPipelineViewLayoutKey::from_bits_truncate(i as u32);
-        let entries = layout_entries(
-            clustered_forward_buffer_binding_type,
-            visibility_ranges_buffer_binding_type,
-            key,
-            render_device,
-            render_adapter,
-        );
-
-        #[cfg(debug_assertions)]
-        let texture_count: usize = entries
-            .iter()
-            .flat_map(|e| {
-                e.iter()
-                    .filter(|entry| matches!(entry.ty, BindingType::Texture { .. }))
-            })
-            .count();
-
-        MeshPipelineViewLayout {
-            main_layout: BindGroupLayoutDescriptor::new(key.label(), &entries[0]),
-            binding_array_layout: BindGroupLayoutDescriptor::new(
-                format!("{}_binding_array", key.label()),
-                &entries[1],
-            ),
-            empty_layout: BindGroupLayoutDescriptor::new(format!("{}_empty", key.label()), &[]),
-            #[cfg(debug_assertions)]
-            texture_count,
-        }
-    })
 }
 
 #[derive(Component)]


### PR DESCRIPTION
# Objective

- Fixes #17537
- The `generate_view_layouts` function was deprecated in #17714 (0.19.0) in favor of `layout_entries`. It has no internal callers and can now be fully removed.

## Solution

- Remove the deprecated `generate_view_layouts` function from `bevy_pbr::render::mesh_view_bindings`
- Update the doc comment on `MeshPipelineViewLayoutKey` to reference `layout_entries` instead of the removed function

## Testing

- `cargo check -p bevy_pbr` passes cleanly
- No other references to `generate_view_layouts` exist in the codebase

## Migration Guide

- `generate_view_layouts` has been removed. Use `layout_entries` instead, as indicated by the deprecation notice added in 0.19.0.