### PR TITLE
Add `trigger_ref` and `trigger_ref_with` to `Commands`

### DIFF
--- a/crates/bevy_ecs/src/system/commands/command.rs
+++ b/crates/bevy_ecs/src/system/commands/command.rs
@@ -240,6 +240,50 @@ pub fn trigger_with<E: Event<Trigger<'static>: Send + Sync>>(
     }
 }
 
+/// Triggers the given [`Event`], which will run any [`Observer`]s watching for it,
+/// and then calls `after` with the (possibly modified) event.
+///
+/// This is the deferred equivalent of [`World::trigger_ref`].
+///
+/// [`Observer`]: crate::observer::Observer
+/// [`World::trigger_ref`]: World::trigger_ref
+#[track_caller]
+pub fn trigger_ref<'a, E: Event<Trigger<'a>: Default>>(
+    mut event: E,
+    after: impl FnOnce(&mut World, &mut E) + Send + 'static,
+) -> impl Command {
+    let caller = MaybeLocation::caller();
+    move |world: &mut World| {
+        world.trigger_ref_with_caller(
+            &mut event,
+            &mut <E::Trigger<'_> as Default>::default(),
+            caller,
+        );
+        after(world, &mut event);
+    }
+}
+
+/// Triggers the given [`Event`] using the given [`Trigger`], which will run any [`Observer`]s watching for it,
+/// and then calls `after` with the (possibly modified) event.
+///
+/// This is the deferred equivalent of [`World::trigger_ref_with`].
+///
+/// [`Trigger`]: crate::event::Trigger
+/// [`Observer`]: crate::observer::Observer
+/// [`World::trigger_ref_with`]: World::trigger_ref_with
+#[track_caller]
+pub fn trigger_ref_with<E: Event<Trigger<'static>: Send + Sync>>(
+    mut event: E,
+    mut trigger: E::Trigger<'static>,
+    after: impl FnOnce(&mut World, &mut E) + Send + 'static,
+) -> impl Command {
+    let caller = MaybeLocation::caller();
+    move |world: &mut World| {
+        world.trigger_ref_with_caller(&mut event, &mut trigger, caller);
+        after(world, &mut event);
+    }
+}
+
 /// A [`Command`] that writes an arbitrary [`Message`].
 #[track_caller]
 pub fn write_message<M: Message>(message: M) -> impl Command {

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -1159,6 +1159,40 @@ impl<'w, 's> Commands<'w, 's> {
         self.queue(command::trigger_with(event, trigger));
     }
 
+    /// Triggers the given [`Event`], which will run any [`Observer`]s watching for it,
+    /// and then calls `after` with the (possibly modified) event.
+    ///
+    /// This is the deferred equivalent of [`World::trigger_ref`].
+    ///
+    /// [`Observer`]: crate::observer::Observer
+    /// [`World::trigger_ref`]: World::trigger_ref
+    #[track_caller]
+    pub fn trigger_ref<'a, E: Event<Trigger<'a>: Default>>(
+        &mut self,
+        event: E,
+        after: impl FnOnce(&mut World, &mut E) + Send + 'static,
+    ) {
+        self.queue(command::trigger_ref(event, after));
+    }
+
+    /// Triggers the given [`Event`] using the given [`Trigger`], which will run any [`Observer`]s watching for it,
+    /// and then calls `after` with the (possibly modified) event.
+    ///
+    /// This is the deferred equivalent of [`World::trigger_ref_with`].
+    ///
+    /// [`Trigger`]: crate::event::Trigger
+    /// [`Observer`]: crate::observer::Observer
+    /// [`World::trigger_ref_with`]: World::trigger_ref_with
+    #[track_caller]
+    pub fn trigger_ref_with<E: Event<Trigger<'static>: Send + Sync>>(
+        &mut self,
+        event: E,
+        trigger: E::Trigger<'static>,
+        after: impl FnOnce(&mut World, &mut E) + Send + 'static,
+    ) {
+        self.queue(command::trigger_ref_with(event, trigger, after));
+    }
+
     /// Spawns an [`Observer`](crate::observer::Observer) and returns the [`EntityCommands`] associated
     /// with the entity that stores the observer.
     ///


### PR DESCRIPTION
# Objective

- Fixes #17585

## Solution

- Added `Commands::trigger_ref` and `Commands::trigger_ref_with` methods that accept an `after: impl FnOnce(&mut World, &mut E)` callback, which runs after observers have processed the event.
- Added corresponding `command::trigger_ref` and `command::trigger_ref_with` builder functions in `command.rs`.
- Since commands are deferred, a direct `&mut E` return isn't possible like on `World::trigger_ref`. The callback pattern lets callers inspect or use the event after observers have modified it.

## Testing

- `cargo check -p bevy_ecs` — compiles cleanly
- `cargo test -p bevy_ecs --lib -- trigger` — all 4 trigger-related tests pass
- `cargo clippy -p bevy_ecs -- -Dwarnings` — no warnings
- `cargo fmt --all -- --check` — formatting clean