### PR TITLE
Document composition order for `Transform`

### DIFF
--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -42,6 +42,9 @@ fn assert_is_normalized(message: &str, length_squared: f32) {
 /// * To be displayed, an entity must have both a [`Transform`] and a [`GlobalTransform`].
 ///   [`GlobalTransform`] is automatically inserted whenever [`Transform`] is inserted.
 ///
+/// Transforms compose from right to left: if `t1` and `t2` are transforms, then `t1 * t2`
+/// corresponds to applying `t2` *first*, *then* applying `t1`.
+///
 /// ## [`Transform`] and [`GlobalTransform`]
 ///
 /// [`Transform`] is the position of an entity relative to its parent position, or the reference


### PR DESCRIPTION
# Objective

It is not obvious whether `t1 * t2` means that `t1` should be applied before or after `t2`. There may be a convention for matrix multiplication, but:
1. Not everyone may be familiar with it
2. It is not obvious that `Transform`s follow the same convention.

## Solution

This specifies what the composition order is in the docs.

## Testing

Nothing to test except checking that the documentation builds and displays correctly, which I did by running `cargo doc` and opening the result with a web browser.