### PR TITLE
Add fail-fast Cargo sanity check to prevent misleading CI comments

### DIFF
--- a/.github/workflows/ci-comment-failures.yml
+++ b/.github/workflows/ci-comment-failures.yml
@@ -71,7 +71,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue_number,
-                body: 'You added a new example but didn\'t add metadata for it. Please update the root Cargo.toml file.'
+                body: 'You added a new example but didn\'t add metadata for it. Please update the root Cargo.toml file.\n\n[View CI logs](https://github.com/' + context.repo.owner + '/' + context.repo.repo + '/actions/runs/${{ github.event.workflow_run.id }})'
               });
             }
             if (fs.existsSync('./missing-update')) {
@@ -79,7 +79,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue_number,
-                body: 'The generated `examples/README.md` is out of sync with the example metadata in `Cargo.toml` or the example readme template. Please run `cargo run -p build-templated-pages -- update examples` to update it, and commit the file change.'
+                body: 'The generated `examples/README.md` is out of sync with the example metadata in `Cargo.toml` or the example readme template. Please run `cargo run -p build-templated-pages -- update examples` to update it, and commit the file change.\n\n[View CI logs](https://github.com/' + context.repo.owner + '/' + context.repo.repo + '/actions/runs/${{ github.event.workflow_run.id }})'
               });
             }
 
@@ -144,7 +144,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue_number,
-                body: 'You added a new feature but didn\'t add a description for it. Please update the root Cargo.toml file.'
+                body: 'You added a new feature but didn\'t add a description for it. Please update the root Cargo.toml file.\n\n[View CI logs](https://github.com/' + context.repo.owner + '/' + context.repo.repo + '/actions/runs/${{ github.event.workflow_run.id }})'
               });
             }
             if (fs.existsSync('./missing-update')) {
@@ -152,7 +152,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue_number,
-                body: 'You added a new feature but didn\'t update the readme. Please run `cargo run -p build-templated-pages -- update features` to update it, and commit the file change.'
+                body: 'You added a new feature but didn\'t update the readme. Please run `cargo run -p build-templated-pages -- update features` to update it, and commit the file change.\n\n[View CI logs](https://github.com/' + context.repo.owner + '/' + context.repo.repo + '/actions/runs/${{ github.event.workflow_run.id }})'
               });
             }
 
@@ -216,5 +216,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issue_number,
-              body: 'Your PR increases Bevy Minimum Supported Rust Version. Please update the `rust-version` field in the root Cargo.toml file.'
+              body: 'Your PR increases Bevy Minimum Supported Rust Version. Please update the `rust-version` field in the root Cargo.toml file.\n\n[View CI logs](https://github.com/' + context.repo.owner + '/' + context.repo.repo + '/actions/runs/${{ github.event.workflow_run.id }})'
             });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -438,6 +438,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
         with:
           toolchain: stable
+      - name: Validate Cargo dependency resolution
+        id: cargo-sanity
+        run: cargo metadata --format-version 1 > /dev/null
       - name: check for missing metadata
         id: missing-metadata
         run: cargo run -p build-templated-pages -- check-missing examples
@@ -455,7 +458,7 @@ jobs:
           mkdir -p ./missing-examples
           echo ${{ github.event.number }} > ./missing-examples/NR
       - name: log failed task - missing metadata
-        if: ${{ failure() && github.event_name == 'pull_request' && steps.missing-metadata.conclusion == 'failure' }}
+        if: ${{ failure() && github.event_name == 'pull_request' && steps.missing-metadata.conclusion == 'failure' && steps.cargo-sanity.conclusion == 'success' }}
         run: touch ./missing-examples/missing-metadata
       - name: log failed task - missing update
         if: ${{ failure() && github.event_name == 'pull_request' && steps.missing-update.conclusion == 'failure' }}
@@ -477,6 +480,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
         with:
           toolchain: stable
+      - name: Validate Cargo dependency resolution
+        id: cargo-sanity
+        run: cargo metadata --format-version 1 > /dev/null
       - name: check for missing features
         id: missing-features
         run: cargo run -p build-templated-pages -- check-missing features
@@ -494,7 +500,7 @@ jobs:
           mkdir -p ./missing-features
           echo ${{ github.event.number }} > ./missing-features/NR
       - name: log failed task - missing features
-        if: ${{ failure() && github.event_name == 'pull_request' && steps.missing-features.conclusion == 'failure' }}
+        if: ${{ failure() && github.event_name == 'pull_request' && steps.missing-features.conclusion == 'failure' && steps.cargo-sanity.conclusion == 'success' }}
         run: touch ./missing-features/missing-features
       - name: log failed task - missing update
         if: ${{ failure() && github.event_name == 'pull_request' && steps.missing-update.conclusion == 'failure' }}


### PR DESCRIPTION
# Objective

- Fixes #15400

## Solution

- Added a `cargo metadata --format-version 1` sanity check step before both `check-missing-examples-in-docs` and `check-missing-features-in-docs` jobs. The marker files that trigger PR comments are now only created when the sanity check passes, so Cargo-level failures (e.g. dependency resolution errors) no longer produce misleading 'missing metadata' comments. Also added [View CI logs] links to all PR failure comments for easier debugging.

## Testing

- Reviewed the workflow logic to confirm: if `cargo-sanity` fails, subsequent steps are skipped, and the marker condition now requires `steps.cargo-sanity.conclusion == 'success'`, so no misleading artifact is created. Verified the comment URL template resolves correctly using the existing `github.event.workflow_run.id` context variable.