### PR TITLE
Add documentation to under-documented derive macros

### DIFF
--- a/crates/bevy_asset/macros/src/lib.rs
+++ b/crates/bevy_asset/macros/src/lib.rs
@@ -13,7 +13,24 @@ pub(crate) fn bevy_asset_path() -> Path {
 
 const DEPENDENCY_ATTRIBUTE: &str = "dependency";
 
-/// Implement the `Asset` trait.
+/// Derive macro for the `Asset` trait.
+///
+/// Marks a type as a loadable asset. Also derives `VisitAssetDependencies`
+/// automatically. Use `#[dependency]` on `Handle<T>` fields to declare asset
+/// dependencies that should be loaded alongside this asset.
+///
+/// See the `Asset` trait docs for full explanation.
+///
+/// ```ignore
+/// #[derive(Asset, TypePath)]
+/// struct MyMaterial {
+///     // This handle is tracked as a dependency.
+///     #[dependency]
+///     texture: Handle<Image>,
+///     // Not a dependency, won't be tracked.
+///     name: String,
+/// }
+/// ```
 #[proc_macro_derive(Asset, attributes(dependency))]
 pub fn derive_asset(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
@@ -32,7 +49,23 @@ pub fn derive_asset(input: TokenStream) -> TokenStream {
     })
 }
 
-/// Implement the `VisitAssetDependencies` trait.
+/// Derive macro for the `VisitAssetDependencies` trait.
+///
+/// Generates dependency-visiting code for asset types. This is automatically
+/// derived when using `#[derive(Asset)]`, so you typically only need this
+/// if implementing the `Asset` trait manually.
+///
+/// Use `#[dependency]` on `Handle<T>` fields to mark them as dependencies.
+///
+/// See the `VisitAssetDependencies` trait docs for full explanation.
+///
+/// ```ignore
+/// #[derive(VisitAssetDependencies)]
+/// struct MyData {
+///     #[dependency]
+///     texture: Handle<Image>,
+/// }
+/// ```
 #[proc_macro_derive(VisitAssetDependencies, attributes(dependency))]
 pub fn derive_asset_dependency_visitor(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -48,7 +48,36 @@ impl Default for BundleAttributes {
     }
 }
 
-/// Implement the `Bundle` trait.
+/// Derive macro for the `Bundle` trait.
+///
+/// Bundles group components together for spawning. Each field must implement
+/// `Component` or `Bundle`.
+///
+/// See the `Bundle` trait docs for full explanation.
+///
+/// # Attributes
+///
+/// ## Field attributes
+///
+/// ```ignore
+/// #[derive(Bundle)]
+/// struct MyBundle {
+///     // Skip this field when inserting; it must implement Default.
+///     #[bundle(ignore)]
+///     metadata: String,
+/// }
+/// ```
+///
+/// ## Container attributes
+///
+/// ```ignore
+/// // Opt out of BundleFromComponents impl (e.g. for bundles with SpawnRelatedBundle fields).
+/// #[derive(Bundle)]
+/// #[bundle(ignore_from_components)]
+/// struct MyBundle {
+///     // ...
+/// }
+/// ```
 #[proc_macro_derive(Bundle, attributes(bundle))]
 pub fn derive_bundle(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
@@ -205,7 +234,25 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
     })
 }
 
-/// Implement the `MapEntities` trait.
+/// Derive macro for the `MapEntities` trait.
+///
+/// Automatically maps all `Entity` fields to new values during entity remapping
+/// (e.g. scene loading, entity cloning). By default, all fields of type `Entity`
+/// are mapped. Use `#[entities]` to select specific fields.
+///
+/// See the `MapEntities` trait docs for full explanation.
+///
+/// ```ignore
+/// #[derive(MapEntities)]
+/// struct Spring {
+///     #[entities]
+///     a: Entity,
+///     #[entities]
+///     b: Entity,
+///     // Fields without #[entities] are not mapped when the attribute is present.
+///     stiffness: f32,
+/// }
+/// ```
 #[proc_macro_derive(MapEntities, attributes(entities))]
 pub fn derive_map_entities(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
@@ -231,7 +278,37 @@ pub fn derive_map_entities(input: TokenStream) -> TokenStream {
     })
 }
 
-/// Implement `SystemParam` to use a struct as a parameter in a system
+/// Derive macro for the `SystemParam` trait.
+///
+/// Allows using a custom struct as a system parameter. Each field must implement
+/// `SystemParam`. The struct may have two lifetimes: `'w` (world data) and `'s`
+/// (param state). No other lifetime names are allowed.
+///
+/// See the `SystemParam` trait docs for full explanation.
+///
+/// # Attributes
+///
+/// ## Container attributes
+///
+/// ```ignore
+/// // Generate a builder struct (named `MyParamBuilder`) for use with SystemParamBuilder.
+/// #[derive(SystemParam)]
+/// #[system_param(builder)]
+/// struct MyParam<'w, 's> {
+///     query: Query<'w, 's, Entity>,
+/// }
+/// ```
+///
+/// ## Field attributes
+///
+/// ```ignore
+/// #[derive(SystemParam)]
+/// struct MyParam<'w> {
+///     // Override the validation error message for this field.
+///     #[system_param(validation_message = "Missing required resource")]
+///     res: Res<'w, MyResource>,
+/// }
+/// ```
 #[proc_macro_derive(SystemParam, attributes(system_param))]
 pub fn derive_system_param(input: TokenStream) -> TokenStream {
     let token_stream = input.clone();
@@ -480,13 +557,60 @@ fn derive_system_param_impl(
     }))
 }
 
-/// Implement `QueryData` to use a struct as a data parameter in a query
+/// Derive macro for the `QueryData` trait.
+///
+/// Allows using a custom struct as a data parameter in a `Query`. Each field
+/// must also implement `QueryData`. Reference lifetimes must be `'static`.
+///
+/// See the `QueryData` trait docs for full explanation.
+///
+/// # Attributes
+///
+/// ```ignore
+/// // Mark the query as mutable to allow &mut component references.
+/// #[derive(QueryData)]
+/// #[query_data(mutable)]
+/// struct MyQuery {
+///     component: &'static mut Health,
+/// }
+///
+/// // Derive additional traits on the generated item structs.
+/// #[derive(QueryData)]
+/// #[query_data(derive(Debug))]
+/// struct DebugQuery {
+///     entity: Entity,
+/// }
+///
+/// // Enable contiguous iteration support.
+/// #[derive(QueryData)]
+/// #[query_data(mutable, contiguous(all))]
+/// struct FastQuery {
+///     value: &'static mut Transform,
+/// }
+/// ```
 #[proc_macro_derive(QueryData, attributes(query_data))]
 pub fn derive_query_data(input: TokenStream) -> TokenStream {
     derive_query_data_impl(input)
 }
 
-/// Implement `QueryFilter` to use a struct as a filter parameter in a query
+/// Derive macro for the `QueryFilter` trait.
+///
+/// Allows using a custom struct as a filter parameter in a `Query`. Each field
+/// must implement `QueryFilter`.
+///
+/// See the `QueryFilter` trait docs for full explanation.
+///
+/// ```ignore
+/// #[derive(QueryFilter)]
+/// struct MyFilter {
+///     with_a: With<ComponentA>,
+///     without_b: Without<ComponentB>,
+/// }
+///
+/// fn my_system(query: Query<Entity, MyFilter>) {
+///     // ...
+/// }
+/// ```
 #[proc_macro_derive(QueryFilter, attributes(query_filter))]
 pub fn derive_query_filter(input: TokenStream) -> TokenStream {
     derive_query_filter_impl(input)
@@ -522,7 +646,20 @@ pub(crate) fn bevy_ecs_path() -> syn::Path {
     BevyManifest::shared(|manifest| manifest.get_path("bevy_ecs"))
 }
 
-/// Implement the `Event` trait.
+/// Derive macro for the `Event` trait.
+///
+/// Marks a type as an event that can be sent and received via `EventWriter`
+/// and `EventReader`.
+///
+/// See the `Event` trait docs for full explanation.
+///
+/// ```ignore
+/// #[derive(Event)]
+/// struct CollisionEvent {
+///     entity_a: Entity,
+///     entity_b: Entity,
+/// }
+/// ```
 #[proc_macro_derive(Event, attributes(event))]
 pub fn derive_event(input: TokenStream) -> TokenStream {
     event::derive_event(input)
@@ -546,19 +683,64 @@ pub fn derive_entity_event(input: TokenStream) -> TokenStream {
     event::derive_entity_event(input)
 }
 
-/// Implement the `Message` trait.
+/// Derive macro for the `Message` trait.
+///
+/// Marks a type as a buffered message that can be sent between systems via
+/// `MessageWriter` and read via `MessageReader`.
+///
+/// See the `Message` trait docs for full explanation.
+///
+/// ```ignore
+/// #[derive(Message)]
+/// struct DamageEvent {
+///     amount: f32,
+/// }
+/// ```
 #[proc_macro_derive(Message)]
 pub fn derive_message(input: TokenStream) -> TokenStream {
     message::derive_message(input)
 }
 
-/// Implement the `Resource` trait.
+/// Derive macro for the `Resource` trait.
+///
+/// Marks a type as a globally unique singleton in the `World`. Access it in
+/// systems via `Res<T>` (read-only) or `ResMut<T>` (mutable).
+///
+/// See the `Resource` trait docs for full explanation.
+///
+/// ```ignore
+/// #[derive(Resource)]
+/// struct GameSettings {
+///     volume: f32,
+/// }
+///
+/// fn read_settings(settings: Res<GameSettings>) {
+///     // ...
+/// }
+/// ```
 #[proc_macro_derive(Resource)]
 pub fn derive_resource(input: TokenStream) -> TokenStream {
     component::derive_resource(input)
 }
 
-/// Implement the `SettingsGroup` trait.
+/// Derive macro for the `SettingsGroup` trait.
+///
+/// Marks a type as a settings group for configuration management.
+///
+/// See the `SettingsGroup` trait docs for full explanation.
+///
+/// # Attributes
+///
+/// ```ignore
+/// #[derive(SettingsGroup)]
+/// // Override the group name (defaults to snake_case of type name).
+/// #[settings_group(group = "rendering")]
+/// // Specify a settings file source.
+/// #[settings_group(file = "config/rendering.toml")]
+/// struct RenderSettings {
+///     // ...
+/// }
+/// ```
 #[proc_macro_derive(SettingsGroup, attributes(settings_group))]
 pub fn derive_settings_group(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
@@ -717,7 +899,24 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
     component::derive_component(input)
 }
 
-/// Implement the `FromWorld` trait.
+/// Derive macro for the `FromWorld` trait.
+///
+/// Generates a `FromWorld` implementation that calls `FromWorld::from_world`
+/// on each field. Works on structs and enums.
+///
+/// See the `FromWorld` trait docs for full explanation.
+///
+/// For enums, mark the variant to construct with `#[from_world]`:
+///
+/// ```ignore
+/// #[derive(FromWorld)]
+/// enum MyEnum {
+///     // This variant will be constructed by FromWorld.
+///     #[from_world]
+///     Active { count: usize },
+///     Inactive,
+/// }
+/// ```
 #[proc_macro_derive(FromWorld, attributes(from_world))]
 pub fn derive_from_world(input: TokenStream) -> TokenStream {
     let bevy_ecs_path = bevy_ecs_path();

--- a/crates/bevy_material/macros/src/lib.rs
+++ b/crates/bevy_material/macros/src/lib.rs
@@ -10,6 +10,12 @@ pub(crate) fn bevy_material_path() -> syn::Path {
     BevyManifest::shared(|manifest| manifest.get_path("bevy_material"))
 }
 
+/// Derive macro generating an impl of the trait `ShaderLabel`.
+///
+/// Generates a unique label for shader types, used internally by the
+/// rendering pipeline to identify shaders.
+///
+/// This does not work for unions.
 #[proc_macro_derive(ShaderLabel)]
 pub fn derive_shader_label(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
@@ -21,6 +27,12 @@ pub fn derive_shader_label(input: TokenStream) -> TokenStream {
     derive_label(input, "ShaderLabel", &trait_path)
 }
 
+/// Derive macro generating an impl of the trait `DrawFunctionLabel`.
+///
+/// Generates a unique label for draw function types, used internally by the
+/// rendering pipeline to identify draw functions.
+///
+/// This does not work for unions.
 #[proc_macro_derive(DrawFunctionLabel)]
 pub fn derive_draw_function_label(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);

--- a/crates/bevy_render/macros/src/lib.rs
+++ b/crates/bevy_render/macros/src/lib.rs
@@ -19,6 +19,19 @@ pub(crate) fn bevy_ecs_path() -> syn::Path {
     BevyManifest::shared(|manifest| manifest.get_path("bevy_ecs"))
 }
 
+/// Derive macro for the `ExtractResource` trait.
+///
+/// Extracts a `Resource` from the main world into the render world by cloning it
+/// each frame during the `ExtractSchedule`. The type must implement `Clone`.
+///
+/// See the `ExtractResource` trait docs for full explanation.
+///
+/// ```ignore
+/// #[derive(Resource, Clone, ExtractResource)]
+/// struct MyRenderSettings {
+///     clear_color: Color,
+/// }
+/// ```
 #[proc_macro_derive(ExtractResource)]
 pub fn derive_extract_resource(input: TokenStream) -> TokenStream {
     extract_resource::derive_extract_resource(input)
@@ -56,6 +69,96 @@ pub fn derive_extract_component(input: TokenStream) -> TokenStream {
     extract_component::derive_extract_component(input)
 }
 
+/// Derive macro for the `AsBindGroup` trait.
+///
+/// Converts a type into a `BindGroup` for use in shaders. Field attributes
+/// define which fields become GPU bindings.
+///
+/// See the `AsBindGroup` trait docs for full explanation.
+///
+/// # Field attributes
+///
+/// ```ignore
+/// #[derive(AsBindGroup)]
+/// struct MyMaterial {
+///     // Bind a field as a uniform buffer (must implement ShaderType).
+///     #[uniform(0)]
+///     color: LinearRgba,
+///
+///     // Bind as a texture and sampler (field must be Handle<Image> or Option<Handle<Image>>).
+///     #[texture(1)]
+///     #[sampler(2)]
+///     color_texture: Handle<Image>,
+///
+///     // Bind as a storage buffer (Handle<ShaderBuffer> or raw Buffer with `buffer` flag).
+///     #[storage(3, read_only)]
+///     values: Handle<ShaderBuffer>,
+///     #[storage(4, read_only, buffer)]
+///     raw_buf: Buffer,
+///
+///     // Bind as a storage texture.
+///     #[storage_texture(5)]
+///     output: Handle<Image>,
+/// }
+/// ```
+///
+/// ## `texture` arguments
+///
+/// | Argument              | Values                                                         | Default              |
+/// |-----------------------|----------------------------------------------------------------|----------------------|
+/// | `dimension` = "..."   | `"1d"`, `"2d"`, `"2d_array"`, `"3d"`, `"cube"`, `"cube_array"` | `"2d"`               |
+/// | `sample_type` = "..." | `"float"`, `"depth"`, `"s_int"`, `"u_int"`                     | `"float"`            |
+/// | `filterable` = ...    | `true`, `false`                                                | `true`               |
+/// | `multisampled` = ...  | `true`, `false`                                                | `false`              |
+/// | `visibility(...)`     | `all`, `none`, or a list of `vertex`, `fragment`, `compute`    | `vertex`, `fragment` |
+///
+/// ## `sampler` arguments
+///
+/// | Argument               | Values                                            | Default              |
+/// |------------------------|---------------------------------------------------|----------------------|
+/// | `sampler_type` = "..." | `"filtering"`, `"non_filtering"`, `"comparison"`  | `"filtering"`        |
+/// | `visibility(...)`      | `all`, `none`, or a list of `vertex`, `fragment`, `compute` | `vertex`, `fragment` |
+///
+/// ## `storage` arguments
+///
+/// | Argument            | Values                                                      | Default              |
+/// |---------------------|-------------------------------------------------------------|----------------------|
+/// | `read_only`         | if present, buffer is read-only                             | `false`              |
+/// | `buffer`            | if present, field is a raw wgpu `Buffer`                    |                      |
+/// | `visibility(...)`   | `all`, `none`, or a list of `vertex`, `fragment`, `compute` | `vertex`, `fragment` |
+///
+/// ## `storage_texture` arguments
+///
+/// | Argument             | Values                                                      | Default      |
+/// |----------------------|-------------------------------------------------------------|--------------|
+/// | `dimension` = "..."  | `"1d"`, `"2d"`, `"2d_array"`, `"3d"`, `"cube"`, `"cube_array"` | `"2d"`   |
+/// | `image_format` = ... | any `TextureFormat` member                                  | `Rgba8Unorm` |
+/// | `access` = ...       | any `StorageTextureAccess` member                           | `ReadWrite`  |
+/// | `visibility(...)`    | `all`, `none`, or a list of `vertex`, `fragment`, `compute` | `compute`    |
+///
+/// # Struct-level attributes
+///
+/// ```ignore
+/// // Convert the whole struct to a shader type for uniform binding.
+/// #[derive(AsBindGroup)]
+/// #[uniform(0, MyMaterialUniform)]
+/// struct MyMaterial { /* ... */ }
+///
+/// // Store extra data alongside the bind group for pipeline specialization.
+/// #[derive(AsBindGroup)]
+/// #[bind_group_data(MyMaterialKey)]
+/// struct MyMaterial { /* ... */ }
+///
+/// // Enable bindless mode for reduced GPU state changes.
+/// #[derive(AsBindGroup)]
+/// #[bindless]
+/// struct MyMaterial { /* ... */ }
+///
+/// // Use `data` for a single buffer containing an array (instead of array of buffers).
+/// #[derive(AsBindGroup)]
+/// #[data(0, MyMaterialUniform, binding_array(10))]
+/// struct MyMaterial { /* ... */ }
+/// ```
 #[proc_macro_derive(
     AsBindGroup,
     attributes(

--- a/crates/bevy_state/macros/src/lib.rs
+++ b/crates/bevy_state/macros/src/lib.rs
@@ -9,15 +9,46 @@ mod states;
 use bevy_macro_utils::BevyManifest;
 use proc_macro::TokenStream;
 
-/// Implements the `States` trait for a type - see the trait
-/// docs for an example usage.
+/// Derive macro for the `States` trait.
+///
+/// Defines world-wide states for a finite-state machine. The type must also
+/// derive `Clone`, `PartialEq`, `Eq`, `Hash`, `Debug`, and `Default` (the
+/// default variant is the starting state).
+///
+/// See the `States` trait docs for full explanation.
+///
+/// ```ignore
+/// #[derive(States, Clone, PartialEq, Eq, Hash, Debug, Default)]
+/// enum GameState {
+///     #[default]
+///     MainMenu,
+///     InGame,
+///     Paused,
+/// }
+/// ```
 #[proc_macro_derive(States, attributes(states))]
 pub fn derive_states(input: TokenStream) -> TokenStream {
     states::derive_states(input)
 }
 
-/// Implements the `SubStates` trait for a type - see the trait
-/// docs for an example usage.
+/// Derive macro for the `SubStates` trait.
+///
+/// Defines a sub-state that only exists when a source state matches a specific
+/// value. While active, sub-states can be manually modified unlike `ComputedStates`.
+///
+/// See the `SubStates` trait docs for full explanation.
+///
+/// ```ignore
+/// #[derive(SubStates, Clone, PartialEq, Eq, Hash, Debug, Default)]
+/// // This sub-state only exists when AppState is InGame.
+/// #[source(AppState = AppState::InGame)]
+/// enum GamePhase {
+///     #[default]
+///     Setup,
+///     Battle,
+///     Conclusion,
+/// }
+/// ```
 #[proc_macro_derive(SubStates, attributes(states, source))]
 pub fn derive_substates(input: TokenStream) -> TokenStream {
     states::derive_substates(input)


### PR DESCRIPTION
# Objective

- Fixes #6195

## Solution

- Added cheat-sheet style doc comments to 18 derive macros across 5 macro crates (bevy_ecs_macros, bevy_render_macros, bevy_asset_macros, bevy_state_macros, bevy_material_macros), following the existing Component/EntityEvent pattern. Each macro now documents its supported attributes with ignore code examples and references the trait docs for full explanation.

## Testing

- cargo check and cargo doc --no-deps on all affected macro crates build without warnings. Verified rendered docs show attribute cheat sheets.