### PR TITLE
Reject invalid `scale_factor_override` values instead of panicking

### DIFF
--- a/crates/bevy_camera/src/projection.rs
+++ b/crates/bevy_camera/src/projection.rs
@@ -386,9 +386,14 @@ impl CameraProjection for PerspectiveProjection {
     }
 
     fn update(&mut self, width: f32, height: f32) {
-        self.aspect_ratio = AspectRatio::try_new(width, height)
-            .expect("Failed to update PerspectiveProjection: width and height must be positive, non-zero values")
-            .ratio();
+        // A degenerate render area (zero or non-finite width/height, e.g. a minimized
+        // window or a scale factor of 0.0) makes `AspectRatio::try_new` return an error.
+        // Keep the previous valid aspect ratio instead of panicking. `bevy_camera` has no
+        // logging dependency (adding one is out of scope) and `update` returns `()`, so the
+        // error cannot be surfaced; the transient degenerate frame is simply skipped.
+        if let Ok(aspect_ratio) = AspectRatio::try_new(width, height) {
+            self.aspect_ratio = aspect_ratio.ratio();
+        }
     }
 
     fn far(&self) -> f32 {
@@ -816,5 +821,37 @@ mod tests {
         // The w_axis.z element of an infinite reverse perspective matrix equals
         // the near plane distance. Verify it matches what we requested.
         assert_eq!(custom_matrix.w_axis.z, 0.01);
+    }
+
+    /// Updating a projection with a degenerate render area (zero or non-finite
+    /// width/height) must not panic and must leave the previous valid aspect ratio
+    /// untouched, while a valid update still applies. Regression test for issue #24273.
+    #[test]
+    fn update_with_degenerate_size_keeps_previous_aspect_ratio() {
+        let mut proj = PerspectiveProjection::default();
+
+        // Establish a known-good aspect ratio.
+        proj.update(16.0, 9.0);
+        let valid_aspect = proj.aspect_ratio;
+        assert_eq!(valid_aspect, 16.0 / 9.0);
+
+        // Each degenerate input must be ignored, leaving the aspect ratio unchanged.
+        for (width, height) in [
+            (0.0, 9.0),
+            (16.0, 0.0),
+            (f32::NAN, 9.0),
+            (16.0, f32::INFINITY),
+            (f32::NEG_INFINITY, 9.0),
+        ] {
+            proj.update(width, height);
+            assert_eq!(
+                proj.aspect_ratio, valid_aspect,
+                "degenerate size ({width}, {height}) must not change the aspect ratio"
+            );
+        }
+
+        // A subsequent valid update still applies.
+        proj.update(4.0, 3.0);
+        assert_eq!(proj.aspect_ratio, 4.0 / 3.0);
     }
 }

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -902,6 +902,9 @@ pub struct WindowResolution {
     /// Code-provided ratio of physical size to logical size.
     ///
     /// Should be used instead of `scale_factor` when set.
+    ///
+    /// Must be finite and greater than zero. The `winit` backend rejects invalid
+    /// values, warning and reverting or clearing the override.
     scale_factor_override: Option<f32>,
     /// OS-provided ratio of physical size to logical size.
     ///
@@ -931,6 +934,9 @@ impl WindowResolution {
     }
 
     /// Builder method for adding a scale factor override to the resolution.
+    ///
+    /// The override must be finite and greater than zero; the `winit` backend
+    /// rejects invalid values.
     pub fn with_scale_factor_override(mut self, scale_factor_override: f32) -> Self {
         self.set_scale_factor_override(Some(scale_factor_override));
         self
@@ -1037,6 +1043,9 @@ impl WindowResolution {
     ///
     /// This can change the logical and physical sizes if the resulting physical
     /// size is not within the limits.
+    ///
+    /// The override must be finite and greater than zero. The `winit` backend
+    /// rejects invalid values, warning and reverting the override.
     #[inline]
     pub fn set_scale_factor_override(&mut self, scale_factor_override: Option<f32>) {
         self.scale_factor_override = scale_factor_override;

--- a/crates/bevy_winit/src/state.rs
+++ b/crates/bevy_winit/src/state.rs
@@ -351,9 +351,25 @@ impl ApplicationHandler<WinitUserEvent> for WinitAppRunnerState {
                         }
                     }
                     WindowEvent::Touch(touch) => {
-                        let location = touch
-                            .location
-                            .to_logical(win.resolution.scale_factor() as f64);
+                        // A touch can arrive in the same winit event batch as a reflect-corrupted
+                        // scale factor override, before `changed_windows` reverts it. Fall back to
+                        // the OS-provided base scale factor — which is validated too, since the
+                        // whole `WindowResolution` is reflect-writable and the base can be corrupted
+                        // as well — with `1.0` as a last resort, so the dpi conversion below cannot
+                        // panic. `changed_windows` warns about the invalid override on the same
+                        // frame, so stay silent here.
+                        let scale_factor = win.resolution.scale_factor() as f64;
+                        let scale_factor = if winit::dpi::validate_scale_factor(scale_factor) {
+                            scale_factor
+                        } else {
+                            let base = win.resolution.base_scale_factor() as f64;
+                            if winit::dpi::validate_scale_factor(base) {
+                                base
+                            } else {
+                                1.0
+                            }
+                        };
+                        let location = touch.location.to_logical(scale_factor);
                         self.bevy_window_events
                             .send(converters::convert_touch_input(touch, location, window));
                     }
@@ -565,8 +581,14 @@ impl WinitAppRunnerState {
                 let mut query = self.world_mut()
                     .query_filtered::<(Entity, &Window, &CursorOptions), (With<CachedWindow>, Without<RawHandleWrapper>)>();
                 if let Ok((entity, window, cursor_options)) = query.single(&self.world()) {
-                    let window = window.clone();
+                    let mut window = window.clone();
                     let cursor_options = cursor_options.clone();
+
+                    // Sanitize the cloned window before recreating it: an invalid scale factor
+                    // override could have been set via reflection while the app was suspended,
+                    // and `changed_windows` cannot revert it while the window is gone. The live
+                    // component is reverted by `changed_windows` once the window exists again.
+                    crate::system::sanitize_scale_factor_override(&mut window);
 
                     WINIT_WINDOWS.with_borrow_mut(|winit_windows| {
                         ACCESS_KIT_ADAPTERS.with_borrow_mut(|adapters| {

--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -18,7 +18,7 @@ use bevy_window::{
 use tracing::{error, info, warn};
 
 use winit::{
-    dpi::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize},
+    dpi::{validate_scale_factor, LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize},
     event_loop::ActiveEventLoop,
 };
 
@@ -40,6 +40,24 @@ use bevy_math::{IVec2, UVec2};
 use winit::platform::ios::WindowExtIOS;
 #[cfg(target_arch = "wasm32")]
 use winit::platform::web::WindowExtWebSys;
+
+/// Clears an invalid scale factor override on `window` before it is handed to winit for
+/// window creation.
+///
+/// A scale factor override can be set via reflection (e.g. by an inspector), bypassing
+/// `set_scale_factor_override`. An invalid value (zero, non-finite, or negative) would panic
+/// inside winit's dpi conversions during creation, so clear it here.
+pub(crate) fn sanitize_scale_factor_override(window: &mut Window) {
+    if let Some(sf) = window.resolution.scale_factor_override()
+        && !validate_scale_factor(sf as f64)
+    {
+        warn!(
+            "Ignoring invalid scale factor override {sf} for window {}: scale factors must be finite and positive.",
+            window.title.as_str()
+        );
+        window.resolution.set_scale_factor_override(None);
+    }
+}
 
 /// Creates new windows on the [`winit`] backend for each entity with a newly-added
 /// [`Window`] component.
@@ -65,6 +83,8 @@ pub fn create_windows(
                 }
 
                 info!("Creating new window {} ({})", window.title.as_str(), entity);
+
+                sanitize_scale_factor_override(&mut window);
 
                 let winit_window = winit_windows.create_window(
                     event_loop,
@@ -327,6 +347,23 @@ pub(crate) fn changed_windows(
             let Some(winit_window) = winit_windows.get_window(entity) else {
                 continue;
             };
+
+            // A scale factor override set via reflection (e.g. by an inspector) bypasses
+            // `set_scale_factor_override`, so it can hold an invalid value that would panic
+            // in winit's dpi conversions. Revert to the last valid override from the cache
+            // (which does not derive `Reflect`, so it is always trusted) before anything
+            // below reads it — notably the `Centered` branch of the position block.
+            if let Some(sf) = window.resolution.scale_factor_override()
+                && !validate_scale_factor(sf as f64)
+            {
+                warn!(
+                    "Ignoring invalid scale factor override {sf} for window {}: scale factors must be finite and positive. Reverting to the previous value.",
+                    window.title.as_str()
+                );
+                window
+                    .resolution
+                    .set_scale_factor_override(cache.resolution.scale_factor_override());
+            }
 
             if window.title != cache.title {
                 winit_window.set_title(window.title.as_str());
@@ -643,3 +680,28 @@ pub(crate) fn changed_cursor_options(
 /// When a window is unfocused, this is used to send key release events for all the currently held keys.
 #[derive(Default, Component)]
 pub struct WinitWindowPressedKeys(pub(crate) HashMap<KeyCode, Key>);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_scale_factor_override_clears_only_invalid() {
+        // An invalid override (zero here) is cleared so winit's dpi conversions cannot panic.
+        let mut window = Window::default();
+        window.resolution.set_scale_factor_override(Some(0.0));
+        sanitize_scale_factor_override(&mut window);
+        assert_eq!(window.resolution.scale_factor_override(), None);
+
+        // A valid override is left untouched.
+        let mut window = Window::default();
+        window.resolution.set_scale_factor_override(Some(2.0));
+        sanitize_scale_factor_override(&mut window);
+        assert_eq!(window.resolution.scale_factor_override(), Some(2.0));
+
+        // An absent override stays absent.
+        let mut window = Window::default();
+        sanitize_scale_factor_override(&mut window);
+        assert_eq!(window.resolution.scale_factor_override(), None);
+    }
+}


### PR DESCRIPTION
# Objective

- Fixes #23141
- Fixes #24273
- Setting `WindowResolution::scale_factor_override` to an invalid value such as `0.0`, a negative number, `NaN`, infinity, or a subnormal crashes the engine. Editor tooling makes this easy to hit: `bevy_inspector_egui` writes the field through `bevy_reflect`, bypassing `set_scale_factor_override`, and toggling the override from `None` to `Some` starts it at `f32::default()`, which is `0.0`.

## Background: where the panics actually are today

The specific panic in the original report, winit's `dpi` assert reached from `changed_windows`, no longer exists on `main`; PR #24746 removed that conversion. The bug is still live, though: the same invalid override crashes through four other paths. I audited every `dpi` conversion in `bevy_winit` and every panic-capable consumer of `scale_factor()` across the repo, and this is the complete set:

1. **Window creation** with an invalid override, where `create_windows` feeds it into `to_physical`: `dpi` assert. On macOS this aborts the process, because the assert fires inside an FFI callback that cannot unwind.
2. **`WindowPosition::Centered`** repositioning: `dpi` assert.
3. **Touch input**, via `to_logical` in the winit event handler, before any per-frame system can react: `dpi` assert.
4. **`PerspectiveProjection::update`**: `camera_system` re-reads `Window::width()` and `Window::height()`, which become `physical / 0.0 = inf`, and panics in `AspectRatio::try_new(...).expect(...)`. This path never touches `bevy_winit`, and it is exactly #24273.

## Solution

Validate where the values are consumed, using winit's own `winit::dpi::validate_scale_factor`. It is re-exported from the `dpi` crate, so there is no new dependency, and its documentation explicitly recommends calling it before passing values to winit.

- **`changed_windows`** reverts an invalid override to the last valid value from `CachedWindow`, which does not derive `Reflect` and therefore cannot be corrupted through reflection, and warns once. The revert runs before the position block, so the `Centered` path never observes the value; and because it restores the value before the resolution diff, no spurious `WindowScaleFactorChanged` is emitted. It self-converges: one extra no-op pass, no warn spam, no event loop.
- **Window creation**: a small shared helper, `sanitize_scale_factor_override`, clears an invalid override with a warning before the winit window is built. It covers both creation paths: `create_windows`, and the Android resume recreation, which runs while `changed_windows` cannot revert because the winit window is gone during suspension.
- **Touch handling** can observe a corrupted value mid-frame, before `changed_windows` runs, so it falls back to the validated base scale factor, or `1.0` as a last resort; the whole `WindowResolution` is reflect-writable, so the base can be corrupted too.
- **`PerspectiveProjection::update`** keeps the previous valid aspect ratio instead of panicking on a degenerate size, whether zero, `NaN`, or infinite. This closes #24273 regardless of where the bad value comes from. It is deliberately silent: `bevy_camera` has no logging dependency, and the root cause already warns in `bevy_winit` on the same frame.
- **`bevy_window` getters and setter are intentionally untouched**, with doc additions only, per the review feedback that getters must return the stored value. A setter-side guard cannot protect the reflection path anyway, so validation lives at the single consumption boundary instead.

Worst case after this change: a reflect-corrupted override yields at most one visually degenerate frame, coming from plain float math in UI and orthographic code, which was audited and contains no panics, and the value is then reverted. One completeness caveat: the per-frame revert requires a live winit window, which is why the Android resume path sanitizes independently.

Cost when the override is valid or absent: an `Option` check plus `is_sign_positive() && is_normal()`, only on paths that already run, namely change detection, window creation, and touch events. No allocation, no behavior change.

## Testing

- **End-to-end repro suite**: https://github.com/omar-y-abdi/bevy-23141-repro. It lives out of tree since examples cannot depend on `bevy_inspector_egui`. Full before-and-after matrix with captured logs in its README.
  - bevy 0.19 with the real `bevy_inspector_egui` 0.37 reproduces the original `dpi` assert. Its `--auto` mode performs the same `bevy_reflect` field write the inspector performs, so no manual clicking is needed; manual inspector instructions are included too.
  - The same reflect mutation against unfixed `main` panics in `bevy_camera`, in `projection.rs`, which is empirical confirmation of the #24273 path.
  - Against this branch, window creation with `with_scale_factor_override(0.0)`, a runtime reflect-write of `Some(0.0)`, and the `Centered` variant all run clean; the warning fires and the override visibly reverts. The inspector crate only supports released bevy, hence the `main` proofs drive the identical reflect write directly.
- **Unit tests**: a `PerspectiveProjection::update` degenerate-size regression test covering zero, `NaN`, and both infinities, asserting the aspect ratio is preserved and that valid updates still apply; and a `sanitize_scale_factor_override` helper test asserting an invalid override is cleared while valid and absent overrides stay untouched.
- `cargo fmt --check`, `cargo clippy -p bevy_winit -p bevy_camera -p bevy_window -- -D warnings`, and `cargo test -p bevy_window -p bevy_camera -p bevy_winit` are all green, with 47 unit tests plus doctests and 0 failures.
- Tested on macOS arm64. The Android resume path is `cfg`-gated; it is verified by inspection and covered by CI's Android build.
