### PR TITLE
Fix fishy spawn batch implementation

### DIFF
--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -704,7 +704,7 @@ impl SparseSetIndex for Entity {
 /// See the module docs for how these ids and this allocator participate in the life cycle of an entity.
 #[derive(Default, Debug)]
 pub struct EntityAllocator {
-    inner: remote_allocator::Allocator,
+    pub(crate) inner: remote_allocator::Allocator,
 }
 
 impl EntityAllocator {
@@ -723,19 +723,6 @@ impl EntityAllocator {
     /// and its allocated [`Entity`] values can still be used in this world.
     pub fn has_remote_allocator(&self, allocator: &RemoteAllocator) -> bool {
         allocator.is_connected_to(&self.inner)
-    }
-
-    /// The total number of indices given out.
-    pub fn total_entity_indices(&self) -> u32 {
-        self.inner.total_entity_indices()
-    }
-
-    /// Flushes the entities that have been freed locally into the full allocator.
-    /// This is not public because it is subject to change.
-    /// It is sometimes useful to call this for tests that depend on the entity allocator behaving more predictably.
-    #[cfg(test)]
-    pub(crate) fn flush_freed(&mut self) {
-        self.inner.flush_freed();
     }
 
     /// This allows `freed` to be retrieved from [`alloc`](Self::alloc), etc.

--- a/crates/bevy_ecs/src/entity/remote_allocator.rs
+++ b/crates/bevy_ecs/src/entity/remote_allocator.rs
@@ -885,7 +885,7 @@ impl SharedAllocator {
 /// The allocator assumes that it is the only one with [`FreeList::free`] permissions.
 /// If this were cloned, that assumption would be broken, leading to undefined behavior.
 /// This is in contrast to the [`RemoteAllocator`], which may be cloned freely.
-pub(super) struct Allocator {
+pub(crate) struct Allocator {
     /// The shared allocator state, which we share with any [`RemoteAllocator`]s.
     shared: Arc<SharedAllocator>,
     /// The local free list.
@@ -917,7 +917,7 @@ impl Allocator {
 
     /// The total number of indices given out.
     #[inline]
-    pub(super) fn total_entity_indices(&self) -> u32 {
+    pub(crate) fn total_entity_indices(&self) -> u32 {
         self.shared.fresh.total_entity_indices()
     }
 
@@ -928,9 +928,11 @@ impl Allocator {
         self.shared.free.num_free()
     }
 
-    /// Flushes the [`local_free`](Self::local_free) list to the shared allocator.
+    /// Flushes the entities that have been freed locally into the full allocator.
+    /// This is not exposed publicly because it is subject to change.
+    /// It is sometimes useful to call this for tests that depend on the entity allocator behaving more predictably.
     #[inline]
-    pub(super) fn flush_freed(&mut self) {
+    pub(crate) fn flush_freed(&mut self) {
         // SAFETY: We have `&mut self`.
         unsafe {
             self.shared.free.free(self.local_free.as_slice());

--- a/crates/bevy_ecs/src/world/spawn_batch.rs
+++ b/crates/bevy_ecs/src/world/spawn_batch.rs
@@ -133,10 +133,10 @@ mod tests {
     fn spawn_batch_does_not_leak_entities() {
         let mut world = World::new();
         world.spawn_batch((0u32..50).filter(|&i| i & 1 > 0).map(|_| ComponentA));
-        let total_allocated = world.entity_allocator().total_entity_indices();
-        world.entity_allocator_mut().flush_freed();
+        let total_allocated = world.entity_allocator().inner.total_entity_indices();
+        world.entity_allocator_mut().inner.flush_freed();
         world.entity_allocator_mut().alloc();
-        let reused = world.entity_allocator().total_entity_indices() == total_allocated;
+        let reused = world.entity_allocator().inner.total_entity_indices() == total_allocated;
         assert!(reused);
     }
 }


### PR DESCRIPTION
# Objective

Current spawn batch implementation leaks entity allocations.

For iterators that give a fixed upper bound that is greater than the lower bound, 
the current implementation over-allocates entities and never frees them.
I checked and this has been a bug for a very long time, so impact is probably low.

## Solution

Free the over allocated entities.
We could also use the lower bound of the iterator, but that is not enough since the iterator doesn't always meet its lower bound.

## Testing

I added a test that works here but fails on main.

## Other things to look at

Should we really be allocating at the high iterator bound? It's probably helpful in most cases, but it could brick the ecs and panic if the high bound is more than u32::MAX or something, and if it is significantly higher than the truth, it would cause real slow downs allocating and then freeing all those entities.

Should we restructure this to work without needing a `Drop` implementation. That would let us implement `fold` and such, which could improve performance where the iterator is the bottleneck. This would either come with a breaking change (like needing to call `spawn_rest` instead of just letting the spawn iterator drop) or a lot of unsafe code that would need to properly handle unwinds etc. Probably not too bad, but more complexity to maintain.