### PR TITLE
Add Clearcoat support to the G-Buffer

### DIFF
--- a/crates/bevy_pbr/src/deferred/mod.rs
+++ b/crates/bevy_pbr/src/deferred/mod.rs
@@ -310,6 +310,7 @@ impl SpecializedRenderPipeline for DeferredLightingLayout {
         if key.contains(MeshPipelineKey::ATMOSPHERE) {
             shader_defs.push("ATMOSPHERE".into());
         }
+        shader_defs.push("STANDARD_MATERIAL_CLEARCOAT".into());
 
         // Always true, since we're in the deferred lighting pipeline
         shader_defs.push("DEFERRED_PREPASS".into());

--- a/crates/bevy_pbr/src/deferred/pbr_deferred_functions.wgsl
+++ b/crates/bevy_pbr/src/deferred/pbr_deferred_functions.wgsl
@@ -39,11 +39,15 @@ fn deferred_gbuffer_from_pbr_input(in: PbrInput) -> vec4<u32> {
         diffuse_occlusion,
         in.frag_coord.z));
 #else
+    let clearcoat = u32(round(saturate(in.material.clearcoat) * 15.0));
+    let clearcoat_perceptual_roughness =
+        u32(round(clamp(in.material.clearcoat_perceptual_roughness, 0.0, 0.5) * 30.0));
+    let clearcoat_props = f32(clearcoat | (clearcoat_perceptual_roughness << 4u)) / 255.0;
     var props = deferred_types::pack_unorm4x8_(vec4(
         reflectance, // could be fewer bits
         in.material.metallic, // could be fewer bits
         diffuse_occlusion, // is this worth including?
-        0.0)); // spare
+        clearcoat_props));
 #endif // WEBGL2
     let flags = deferred_types::deferred_flags_from_mesh_material_flags(in.flags, in.material.flags);
     let octahedral_normal = octahedral_encode(normalize(in.N));
@@ -106,7 +110,10 @@ fn pbr_input_from_deferred_gbuffer(frag_coord: vec4<f32>, gbuffer: vec4<u32>) ->
     pbr.material.reflectance = vec3(saturate(props.r - 0.03333333333));
 #else
     let props = deferred_types::unpack_unorm4x8_(gbuffer.b);
+    let clearcoat_props = u32(round(props.a * 255.0));
     pbr.material.reflectance = vec3(props.r);
+    pbr.material.clearcoat = f32(clearcoat_props & 0x0fu) / 15.0;
+    pbr.material.clearcoat_perceptual_roughness = f32(clearcoat_props >> 4u) / 30.0;
 #endif // WEBGL2
     pbr.material.metallic = props.g;
     pbr.diffuse_occlusion = vec3(props.b);
@@ -122,6 +129,7 @@ fn pbr_input_from_deferred_gbuffer(frag_coord: vec4<f32>, gbuffer: vec4<u32>) ->
     pbr.world_position = world_position;
     pbr.N = N;
     pbr.V = V;
+    pbr.clearcoat_N = N;
     pbr.is_orthographic = is_orthographic;
 
     return pbr;


### PR DESCRIPTION
Fixes #23284.

# Objective 
This PR extends the deferred PBR G-buffer so deferred rendering can preserve clearcoat material data. Previously, clearcoat data was discarded. We make use of a spare byte in `props` that was unused. The issue referenced mentioned a possibility of also adding anisotropy, however, since the G-buffer does not encode a surface basis aside from the normal, we'd either need to add that in (major break) or add in a very quantized version of anisotropic direction (which would likely compromise any artistic use). For the moment, we're just going to do clearcoat. 

This, to me, is a sort of stopgap; more configurable G-buffer support for materials would be the real longer term solution, but is a larger controversial lift.

## Solution
The deferred G-buffer packing for the non-WebGL2 path now uses the spare props byte to store clearcoat parameters:

- 4 bits for clearcoat strength
  - This tends to be binary in assets I've seen.
- 4 bits for clearcoat perceptual roughness, mapped over [0.0, 0.5]
  - This seems to be the only real valid range; greater than 0.5 and the specular lobe is so diffuse, you can't tell it's there.

On unpack, those values are reconstructed into the deferred PbrInput, and deferred clearcoat uses the reconstructed base normal as its clearcoat normal fallback. There is no room for clearcoat normals in the G-buffer.

Note: The deferred lighting shader is also compiled with clearcoat support enabled so the packed data is actually consumed during lighting. We do this unconditionally! Adding in a pass over all visible entities to check if we should enable this or not seems like a bad thing to do, but I'm open to changing it.

The existing reflectance, metallic, and monochrome occlusion packing remains unchanged, and the WebGL2 path is intentionally left untouched; that path uses the spare byte for depth.

## Testing
Tested locally on macOS by running a deferred-rendering test app against a local Bevy patch override and verifying that clearcoat now appears in the deferred path.

This change should be platform-agnostic; it only updates shader packing/unpacking logic in the non-WebGL2 deferred path and does not rely on any new packing shader APIs. Even so, it would be useful to get additional validation on Windows and Linux to confirm there are no shader compilation or runtime differences across backends/drivers.

Reviewers can test this by running a deferred-rendering scene with materials that have visible clearcoat and clearcoat roughness variation. An example with clearcoat enabled is attached.

Some areas to focus on:
- comparing behavior across other platforms/backends where possible
- sanity-checking roughness and strength quantization
- checking the performance hit introduced by unconditional clearcoat in the deferred shader

---

## Showcase

A sphere with clearcoat! Wow!

<img width="1260" height="697" alt="Screenshot 2026-03-14 at 7 17 52 AM" src="https://github.com/user-attachments/assets/7c9b46f7-be7b-436f-bc3a-daf2651f17b0" />

Example to use for testing: [ex1.rs.zip](https://github.com/user-attachments/files/25995936/ex1.rs.zip)
