### PR TITLE
Document multi_threaded feature requirement in bevy_tasks

### DIFF
--- a/crates/bevy_tasks/README.md
+++ b/crates/bevy_tasks/README.md
@@ -17,12 +17,33 @@ or ordering of spawned tasks.
 It is based on [`async-executor`][async-executor], a lightweight executor that allows the end user to manage their own threads.
 `async-executor` is based on async-task, a core piece of async-std.
 
+## Enabling Multi-Threading
+
+By default, `bevy_tasks` runs all tasks on a single thread. To enable actual multi-threaded
+task execution, you must activate the `multi_threaded` feature:
+
+```toml
+[dependencies]
+bevy_tasks = { version = "0.19", features = ["multi_threaded"] }
+```
+
+Without this feature, the `TaskPool` API is still available, but all tasks run sequentially
+on a single thread. Methods like `TaskPoolBuilder::num_threads()` become no-ops, and
+`TaskPool::thread_num()` always returns `1`.
+
+Note that the full `bevy` crate enables this feature by default through its own `multi_threaded`
+feature flag. This mainly affects users who depend on `bevy_tasks` directly as a standalone crate.
+
+> **Tip:** `available_parallelism()` reports the number of hardware threads available to the process
+> (mirroring `std::thread::available_parallelism`). It does not reflect whether the `multi_threaded`
+> feature is enabled. Check `TaskPool::thread_num()` to see how many threads a pool is actually using.
+
 ## Usage
 
 In order to be able to optimize task execution in multi-threaded environments,
 bevy provides three different thread pools via which tasks of different kinds can be spawned.
 (The same API is used in single-threaded environments, even if execution is limited to a single thread.
-This currently applies to Wasm targets.)
+This currently applies to Wasm targets and to builds without the `multi_threaded` feature.)
 The determining factor for what kind of work should go in each pool is latency requirements:
 
 * For CPU-intensive work (tasks that generally spin until completion) we have a standard

--- a/crates/bevy_tasks/src/lib.rs
+++ b/crates/bevy_tasks/src/lib.rs
@@ -122,10 +122,17 @@ pub mod prelude {
 
 /// Gets the logical CPU core count available to the current process.
 ///
-/// This is identical to `std::thread::available_parallelism`, except
+/// This is identical to [`std::thread::available_parallelism`], except
 /// it will return a default value of 1 if it internally errors out.
 ///
 /// This will always return at least 1.
+///
+/// # Note
+///
+/// This reports hardware capabilities, not the number of threads that `bevy_tasks` will
+/// actually use. Without the `multi_threaded` feature enabled, task pools are limited to a
+/// single thread regardless of what this function returns. To check how many threads a
+/// pool is using, call [`TaskPool::thread_num()`] instead.
 pub fn available_parallelism() -> usize {
     cfg::switch! {{
         cfg::std => {

--- a/crates/bevy_tasks/src/single_threaded_task_pool.rs
+++ b/crates/bevy_tasks/src/single_threaded_task_pool.rs
@@ -24,14 +24,19 @@ crate::cfg::std! {
 }
 
 /// Used to create a [`TaskPool`].
+///
+/// This is the single-threaded version of `TaskPoolBuilder`, which is used when the
+/// `multi_threaded` feature is not enabled. All builder methods that configure threading
+/// (such as [`num_threads`](Self::num_threads)) are no-ops in this mode. Enable the
+/// `multi_threaded` feature for actual multi-threaded task execution.
 #[derive(Debug, Default, Clone)]
 pub struct TaskPoolBuilder {}
 
-/// This is a dummy struct for wasm support to provide the same api as with the multithreaded
-/// task pool. In the case of the multithreaded task pool this struct is used to spawn
-/// tasks on a specific thread. But the wasm task pool just calls
-/// `wasm_bindgen_futures::spawn_local` for spawning which just runs tasks on the main thread
-/// and so the [`ThreadExecutor`] does nothing.
+/// A dummy implementation that provides the same API as the multi-threaded [`ThreadExecutor`].
+///
+/// In the multi-threaded task pool, this struct is used to spawn tasks on a specific thread.
+/// In this single-threaded fallback (active without the `multi_threaded` feature, or on Wasm
+/// targets), it does nothing.
 #[derive(Default)]
 pub struct ThreadExecutor<'a>(PhantomData<&'a ()>);
 impl<'a> ThreadExecutor<'a> {
@@ -47,27 +52,27 @@ impl TaskPoolBuilder {
         Self::default()
     }
 
-    /// No op on the single threaded task pool
+    /// No-op. Thread count is always 1 without the `multi_threaded` feature.
     pub fn num_threads(self, _num_threads: usize) -> Self {
         self
     }
 
-    /// No op on the single threaded task pool
+    /// No-op. Stack size configuration requires the `multi_threaded` feature.
     pub fn stack_size(self, _stack_size: usize) -> Self {
         self
     }
 
-    /// No op on the single threaded task pool
+    /// No-op. Thread naming requires the `multi_threaded` feature.
     pub fn thread_name(self, _thread_name: String) -> Self {
         self
     }
 
-    /// No op on the single threaded task pool
+    /// No-op. Thread spawn callbacks require the `multi_threaded` feature.
     pub fn on_thread_spawn(self, _f: impl Fn() + Send + Sync + 'static) -> Self {
         self
     }
 
-    /// No op on the single threaded task pool
+    /// No-op. Thread destroy callbacks require the `multi_threaded` feature.
     pub fn on_thread_destroy(self, _f: impl Fn() + Send + Sync + 'static) -> Self {
         self
     }
@@ -80,6 +85,10 @@ impl TaskPoolBuilder {
 
 /// A thread pool for executing tasks. Tasks are futures that are being automatically driven by
 /// the pool on threads owned by the pool. In this case - main thread only.
+///
+/// This is the single-threaded implementation, active when the `multi_threaded` feature is not
+/// enabled. All tasks run sequentially on the calling thread. To get actual parallel execution,
+/// enable the `multi_threaded` feature on `bevy_tasks`.
 #[derive(Debug, Default, Clone)]
 pub struct TaskPool {}
 


### PR DESCRIPTION
# Objective

- Fixes #21585

## Solution

- Added docs to bevy_tasks README, lib.rs, and single_threaded_task_pool.rs explaining that multi_threaded must be explicitly enabled when using bevy_tasks as a standalone crate. Updated no-op builder methods to mention which feature they require.

## Testing

- cargo doc -p bevy_tasks builds with no new warnings