### PR TITLE
feat(text): add coverage-based text shadows

### DIFF
--- a/crates/bevy_sprite/src/text2d.rs
+++ b/crates/bevy_sprite/src/text2d.rs
@@ -15,11 +15,11 @@ use bevy_ecs::{
     component::Component,
     entity::Entity,
     prelude::ReflectComponent,
-    query::{Changed, Without},
+    query::{Changed, Has, Or, Without},
     system::{Commands, Local, Query, Res, ResMut},
 };
 use bevy_image::prelude::*;
-use bevy_math::{FloatOrd, Vec2, Vec3};
+use bevy_math::{FloatOrd, Vec2};
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_text::{
     ComputedTextBlock, Font, FontAtlasSet, FontCx, FontHinting, LayoutCx, LetterSpacing, LineBreak,
@@ -141,10 +141,11 @@ pub type Text2dWriter<'w, 's> = TextWriter<'w, 's, Text2d>;
 #[derive(Component, Copy, Clone, Debug, PartialEq, Reflect)]
 #[reflect(Component, Default, Debug, Clone, PartialEq)]
 pub struct Text2dShadow {
-    /// Shadow displacement
-    /// With a value of zero the shadow will be hidden directly behind the text
+    /// Shadow displacement in logical pixels
+    ///
+    /// Clamped to 16 px after layout scaling
     pub offset: Vec2,
-    /// Color of the shadow
+    /// Color of the shadow.
     pub color: Color,
 }
 
@@ -183,6 +184,7 @@ pub fn update_text2d_layout(
         &mut TextLayoutInfo,
         &mut ComputedTextBlock,
         Ref<FontHinting>,
+        Has<Text2dShadow>,
     )>,
     mut text_reader: Text2dReader,
     mut font_system: ResMut<FontCx>,
@@ -225,6 +227,7 @@ pub fn update_text2d_layout(
         mut text_layout_info,
         mut computed,
         hinting,
+        has_shadow,
     ) in &mut text_query
     {
         let entity_mask = maybe_entity_mask.unwrap_or_default();
@@ -246,10 +249,12 @@ pub fn update_text2d_layout(
             *scale_factor
         };
 
+        let text_effect_padding = has_shadow;
         let text_changed = scale_factor != text_layout_info.scale_factor
             || text2d.is_changed()
             || block.is_changed()
             || computed.needs_rerender(viewport_size_changed, rem_size.is_changed())
+            || text_layout_info.uses_text_effect_padding != text_effect_padding
             || (!reprocess_queue.is_empty() && reprocess_queue.remove(&entity));
 
         if !(text_changed || bounds.is_changed() || hinting.is_changed()) {
@@ -314,6 +319,7 @@ pub fn update_text2d_layout(
             text_bounds,
             block.justify,
             *hinting,
+            text_effect_padding,
         ) {
             Err(TextError::NoSuchFont | TextError::NoSuchFontFamily(_)) => {
                 // There was an error processing the text layout.
@@ -351,22 +357,43 @@ pub fn calculate_bounds_text2d(
             &TextLayoutInfo,
             &Anchor,
             &TextBounds,
+            Option<&Text2dShadow>,
             Option<&mut Aabb>,
         ),
-        (Changed<TextLayoutInfo>, Without<NoFrustumCulling>),
+        (
+            Or<(
+                Changed<TextLayoutInfo>,
+                Changed<Anchor>,
+                Changed<TextBounds>,
+                Changed<Text2dShadow>,
+            )>,
+            Without<NoFrustumCulling>,
+        ),
     >,
 ) {
-    for (entity, layout_info, anchor, text_bounds, aabb) in &mut text_to_update_aabb {
+    for (entity, layout_info, anchor, text_bounds, maybe_shadow, aabb) in &mut text_to_update_aabb {
         let size = Vec2::new(
             text_bounds.width.unwrap_or(layout_info.size.x),
             text_bounds.height.unwrap_or(layout_info.size.y),
         );
 
-        let x1 = (Anchor::TOP_LEFT.0.x - anchor.as_vec().x) * size.x;
-        let x2 = (Anchor::TOP_LEFT.0.x - anchor.as_vec().x + 1.) * size.x;
-        let y1 = (Anchor::TOP_LEFT.0.y - anchor.as_vec().y - 1.) * size.y;
-        let y2 = (Anchor::TOP_LEFT.0.y - anchor.as_vec().y) * size.y;
-        let new_aabb = Aabb::from_min_max(Vec3::new(x1, y1, 0.), Vec3::new(x2, y2, 0.));
+        let base_min = Vec2::new(
+            (Anchor::TOP_LEFT.0.x - anchor.as_vec().x) * size.x,
+            (Anchor::TOP_LEFT.0.y - anchor.as_vec().y - 1.) * size.y,
+        );
+        let base_max = Vec2::new(
+            (Anchor::TOP_LEFT.0.x - anchor.as_vec().x + 1.) * size.x,
+            (Anchor::TOP_LEFT.0.y - anchor.as_vec().y) * size.y,
+        );
+        let mut min = base_min;
+        let mut max = base_max;
+
+        if let Some(shadow) = maybe_shadow {
+            min = min.min(base_min + shadow.offset);
+            max = max.max(base_max + shadow.offset);
+        }
+
+        let new_aabb = Aabb::from_min_max(min.extend(0.0), max.extend(0.0));
 
         if let Some(mut aabb) = aabb {
             *aabb = new_aabb;
@@ -520,5 +547,38 @@ mod tests {
         approx::assert_abs_diff_eq!(first_aabb.half_extents.y, second_aabb.half_extents.y);
         assert!(FIRST_TEXT.len() < SECOND_TEXT.len());
         assert!(first_aabb.half_extents.x < second_aabb.half_extents.x);
+    }
+
+    #[test]
+    fn calculate_bounds_text2d_expands_aabb_for_shadow() {
+        let (mut app, entity) = setup();
+
+        app.update();
+
+        let base_aabb = *app
+            .world()
+            .get_entity(entity)
+            .expect("Could not find entity")
+            .get::<Aabb>()
+            .expect("Could not find base AABB");
+
+        app.world_mut().entity_mut(entity).insert(Text2dShadow {
+            offset: Vec2::new(10.0, -4.0),
+            color: Color::BLACK,
+        });
+
+        app.update();
+
+        let shadow_aabb = *app
+            .world()
+            .get_entity(entity)
+            .expect("Could not find entity")
+            .get::<Aabb>()
+            .expect("Could not find shadow AABB");
+
+        approx::assert_abs_diff_eq!(shadow_aabb.center.x, base_aabb.center.x + 5.0);
+        approx::assert_abs_diff_eq!(shadow_aabb.center.y, base_aabb.center.y - 2.0);
+        approx::assert_abs_diff_eq!(shadow_aabb.half_extents.x, base_aabb.half_extents.x + 5.0);
+        approx::assert_abs_diff_eq!(shadow_aabb.half_extents.y, base_aabb.half_extents.y + 2.0);
     }
 }

--- a/crates/bevy_sprite_render/src/render/mod.rs
+++ b/crates/bevy_sprite_render/src/render/mod.rs
@@ -321,19 +321,18 @@ pub struct ExtractedSlice {
     pub size: Vec2,
 }
 
-pub const EXTRACTED_TEXT_EFFECT_NONE: u32 = 0;
-pub const EXTRACTED_TEXT_EFFECT_SHADOW: u32 = 1;
-
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub enum ExtractedTextEffectKind {
-    #[default]
-    None = EXTRACTED_TEXT_EFFECT_NONE as isize,
-    Shadow = EXTRACTED_TEXT_EFFECT_SHADOW as isize,
+bitflags::bitflags! {
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+    #[repr(transparent)]
+    pub struct ExtractedTextEffectFlags: u32 {
+        const NONE = 0;
+        const SHADOW = 1 << 0;
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default)]
 pub struct ExtractedTextEffect {
-    pub kind: ExtractedTextEffectKind,
+    pub flags: ExtractedTextEffectFlags,
     pub params: Vec4,
     pub shadow_color: LinearRgba,
 }
@@ -341,7 +340,7 @@ pub struct ExtractedTextEffect {
 impl ExtractedTextEffect {
     pub fn shadow(sample_offset: Vec2, shadow_color: LinearRgba) -> Self {
         Self {
-            kind: ExtractedTextEffectKind::Shadow,
+            flags: ExtractedTextEffectFlags::SHADOW,
             params: Vec4::new(sample_offset.x, sample_offset.y, 0.0, 0.0),
             shadow_color,
         }
@@ -516,7 +515,7 @@ impl SpriteInstance {
             i_uv_offset_scale: uv_offset_scale.to_array(),
             i_effect_params: text_effect.params.to_array(),
             i_shadow_color: text_effect.shadow_color.to_f32_array(),
-            i_effect_flags: [text_effect.kind as u32, 0, 0, 0],
+            i_effect_flags: [text_effect.flags.bits(), 0, 0, 0],
         }
     }
 }
@@ -893,15 +892,11 @@ pub fn prepare_sprite_image_bind_groups(
                                 (slice.size * -Vec2::splat(0.5) + slice.offset).extend(0.0),
                             );
 
-                        let text_effect =
-                            if extracted_sprite.text_effect.kind == ExtractedTextEffectKind::None {
-                                ExtractedTextEffect::default()
-                            } else {
-                                let mut text_effect = extracted_sprite.text_effect;
-                                text_effect.params.x /= batch_image_size.x;
-                                text_effect.params.y /= batch_image_size.y;
-                                text_effect
-                            };
+                        let mut text_effect = extracted_sprite.text_effect;
+                        if text_effect.flags.contains(ExtractedTextEffectFlags::SHADOW) {
+                            text_effect.params.x /= batch_image_size.x;
+                            text_effect.params.y /= batch_image_size.y;
+                        }
 
                         // Store the vertex data and add the item to the render phase
                         sprite_meta

--- a/crates/bevy_sprite_render/src/render/mod.rs
+++ b/crates/bevy_sprite_render/src/render/mod.rs
@@ -213,7 +213,7 @@ impl SpecializedRenderPipeline for SpritePipeline {
         let format = key.target_format();
 
         let instance_rate_vertex_buffer_layout = VertexBufferLayout {
-            array_stride: 80,
+            array_stride: 128,
             step_mode: VertexStepMode::Instance,
             attributes: vec![
                 // @location(0) i_model_transpose_col0: vec4<f32>,
@@ -245,6 +245,24 @@ impl SpecializedRenderPipeline for SpritePipeline {
                     format: VertexFormat::Float32x4,
                     offset: 64,
                     shader_location: 4,
+                },
+                // @location(5) i_effect_params: vec4<f32>,
+                VertexAttribute {
+                    format: VertexFormat::Float32x4,
+                    offset: 80,
+                    shader_location: 5,
+                },
+                // @location(6) i_shadow_color: vec4<f32>,
+                VertexAttribute {
+                    format: VertexFormat::Float32x4,
+                    offset: 96,
+                    shader_location: 6,
+                },
+                // @location(7) i_effect_flags: vec4<u32>,
+                VertexAttribute {
+                    format: VertexFormat::Uint32x4,
+                    offset: 112,
+                    shader_location: 7,
                 },
             ],
         };
@@ -303,6 +321,33 @@ pub struct ExtractedSlice {
     pub size: Vec2,
 }
 
+pub const EXTRACTED_TEXT_EFFECT_NONE: u32 = 0;
+pub const EXTRACTED_TEXT_EFFECT_SHADOW: u32 = 1;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ExtractedTextEffectKind {
+    #[default]
+    None = EXTRACTED_TEXT_EFFECT_NONE as isize,
+    Shadow = EXTRACTED_TEXT_EFFECT_SHADOW as isize,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ExtractedTextEffect {
+    pub kind: ExtractedTextEffectKind,
+    pub params: Vec4,
+    pub shadow_color: LinearRgba,
+}
+
+impl ExtractedTextEffect {
+    pub fn shadow(sample_offset: Vec2, shadow_color: LinearRgba) -> Self {
+        Self {
+            kind: ExtractedTextEffectKind::Shadow,
+            params: Vec4::new(sample_offset.x, sample_offset.y, 0.0, 0.0),
+            shadow_color,
+        }
+    }
+}
+
 pub struct ExtractedSprite {
     pub main_entity: Entity,
     pub render_entity: Entity,
@@ -314,6 +359,7 @@ pub struct ExtractedSprite {
     pub image_handle_id: AssetId<Image>,
     pub flip_x: bool,
     pub flip_y: bool,
+    pub text_effect: ExtractedTextEffect,
     pub kind: ExtractedSpriteKind,
 }
 
@@ -396,6 +442,7 @@ pub fn extract_sprites(
                 flip_x: sprite.flip_x,
                 flip_y: sprite.flip_y,
                 image_handle_id: sprite.image.id(),
+                text_effect: ExtractedTextEffect::default(),
                 kind: ExtractedSpriteKind::Slices {
                     indices: start..end,
                 },
@@ -425,6 +472,7 @@ pub fn extract_sprites(
                 flip_x: sprite.flip_x,
                 flip_y: sprite.flip_y,
                 image_handle_id: sprite.image.id(),
+                text_effect: ExtractedTextEffect::default(),
                 kind: ExtractedSpriteKind::Single {
                     anchor: anchor.as_vec(),
                     rect,
@@ -444,11 +492,19 @@ struct SpriteInstance {
     pub i_model_transpose: [Vec4; 3],
     pub i_color: [f32; 4],
     pub i_uv_offset_scale: [f32; 4],
+    pub i_effect_params: [f32; 4],
+    pub i_shadow_color: [f32; 4],
+    pub i_effect_flags: [u32; 4],
 }
 
 impl SpriteInstance {
     #[inline]
-    fn from(transform: &Affine3A, color: &LinearRgba, uv_offset_scale: &Vec4) -> Self {
+    fn from(
+        transform: &Affine3A,
+        color: &LinearRgba,
+        uv_offset_scale: &Vec4,
+        text_effect: ExtractedTextEffect,
+    ) -> Self {
         let transpose_model_3x3 = transform.matrix3.transpose();
         Self {
             i_model_transpose: [
@@ -458,6 +514,9 @@ impl SpriteInstance {
             ],
             i_color: color.to_f32_array(),
             i_uv_offset_scale: uv_offset_scale.to_array(),
+            i_effect_params: text_effect.params.to_array(),
+            i_shadow_color: text_effect.shadow_color.to_f32_array(),
+            i_effect_flags: [text_effect.kind as u32, 0, 0, 0],
         }
     }
 }
@@ -795,6 +854,7 @@ pub fn prepare_sprite_image_bind_groups(
                             &transform,
                             &extracted_sprite.color,
                             &uv_offset_scale,
+                            ExtractedTextEffect::default(),
                         ));
 
                     current_batch.as_mut().unwrap().get_mut().range.end += 1;
@@ -833,6 +893,16 @@ pub fn prepare_sprite_image_bind_groups(
                                 (slice.size * -Vec2::splat(0.5) + slice.offset).extend(0.0),
                             );
 
+                        let text_effect =
+                            if extracted_sprite.text_effect.kind == ExtractedTextEffectKind::None {
+                                ExtractedTextEffect::default()
+                            } else {
+                                let mut text_effect = extracted_sprite.text_effect;
+                                text_effect.params.x /= batch_image_size.x;
+                                text_effect.params.y /= batch_image_size.y;
+                                text_effect
+                            };
+
                         // Store the vertex data and add the item to the render phase
                         sprite_meta
                             .sprite_instance_buffer
@@ -840,6 +910,7 @@ pub fn prepare_sprite_image_bind_groups(
                                 &transform,
                                 &extracted_sprite.color,
                                 &uv_offset_scale,
+                                text_effect,
                             ));
 
                         current_batch.as_mut().unwrap().get_mut().range.end += 1;

--- a/crates/bevy_sprite_render/src/render/sprite.wgsl
+++ b/crates/bevy_sprite_render/src/render/sprite.wgsl
@@ -15,6 +15,9 @@
 
 #import bevy_sprite::sprite_view_bindings::view
 
+const TEXT_EFFECT_NONE: u32 = 0u;
+const TEXT_EFFECT_SHADOW: u32 = 1u;
+
 struct VertexInput {
     @builtin(vertex_index) index: u32,
     // NOTE: Instance-rate vertex buffer members prefixed with i_
@@ -25,12 +28,18 @@ struct VertexInput {
     @location(2) i_model_transpose_col2: vec4<f32>,
     @location(3) i_color: vec4<f32>,
     @location(4) i_uv_offset_scale: vec4<f32>,
+    @location(5) i_effect_params: vec4<f32>,
+    @location(6) i_shadow_color: vec4<f32>,
+    @location(7) i_effect_flags: vec4<u32>,
 }
 
 struct VertexOutput {
     @builtin(position) clip_position: vec4<f32>,
     @location(0) uv: vec2<f32>,
     @location(1) @interpolate(flat) color: vec4<f32>,
+    @location(2) @interpolate(flat) shadow_color: vec4<f32>,
+    @location(3) @interpolate(flat) effect_params: vec4<f32>,
+    @location(4) @interpolate(flat) effect_kind: u32,
 };
 
 @vertex
@@ -50,6 +59,9 @@ fn vertex(in: VertexInput) -> VertexOutput {
     )) * vec4<f32>(vertex_position, 1.0);
     out.uv = vec2<f32>(vertex_position.xy) * in.i_uv_offset_scale.zw + in.i_uv_offset_scale.xy;
     out.color = in.i_color;
+    out.shadow_color = in.i_shadow_color;
+    out.effect_params = in.i_effect_params;
+    out.effect_kind = in.i_effect_flags.x;
 
     return out;
 }
@@ -57,9 +69,45 @@ fn vertex(in: VertexInput) -> VertexOutput {
 @group(1) @binding(0) var sprite_texture: texture_2d<f32>;
 @group(1) @binding(1) var sprite_sampler: sampler;
 
+fn composite_text_layers(
+    fill_color: vec4<f32>,
+    shadow_color: vec4<f32>,
+    fill_cov: f32,
+    shadow_cov: f32,
+) -> vec4<f32> {
+    let fill_alpha = fill_color.a * fill_cov;
+    let shadow_alpha = shadow_color.a * shadow_cov;
+    let shadow_weight = shadow_alpha * (1.0 - fill_alpha);
+    let alpha = fill_alpha + shadow_weight;
+
+    if alpha <= 0.0 {
+        return vec4<f32>(0.0);
+    }
+
+    let rgb = (fill_color.rgb * fill_alpha + shadow_color.rgb * shadow_weight) / alpha;
+    return vec4<f32>(rgb, alpha);
+}
+
 @fragment
 fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
-    var color = in.color * textureSample(sprite_texture, sprite_sampler, in.uv);
+    var color = vec4<f32>(0.0);
+    let base_sample = textureSample(sprite_texture, sprite_sampler, in.uv);
+
+    if in.effect_kind == TEXT_EFFECT_NONE {
+        color = in.color * base_sample;
+    } else {
+        let fill_cov = base_sample.a;
+        if in.effect_kind == TEXT_EFFECT_SHADOW {
+            let shadow_uv = in.uv - in.effect_params.xy;
+            let shadow_cov = textureSampleLevel(sprite_texture, sprite_sampler, shadow_uv, 0.0).a;
+            color = composite_text_layers(
+                in.color,
+                in.shadow_color,
+                fill_cov,
+                shadow_cov * (1.0 - fill_cov),
+            );
+        }
+    }
 
 #ifdef TONEMAP_IN_SHADER
     color = tonemapping::tone_mapping(color, view.color_grading);

--- a/crates/bevy_sprite_render/src/render/sprite.wgsl
+++ b/crates/bevy_sprite_render/src/render/sprite.wgsl
@@ -15,7 +15,6 @@
 
 #import bevy_sprite::sprite_view_bindings::view
 
-const TEXT_EFFECT_NONE: u32 = 0u;
 const TEXT_EFFECT_SHADOW: u32 = 1u;
 
 struct VertexInput {
@@ -39,7 +38,7 @@ struct VertexOutput {
     @location(1) @interpolate(flat) color: vec4<f32>,
     @location(2) @interpolate(flat) shadow_color: vec4<f32>,
     @location(3) @interpolate(flat) effect_params: vec4<f32>,
-    @location(4) @interpolate(flat) effect_kind: u32,
+    @location(4) @interpolate(flat) effect_flags: u32,
 };
 
 @vertex
@@ -61,7 +60,7 @@ fn vertex(in: VertexInput) -> VertexOutput {
     out.color = in.i_color;
     out.shadow_color = in.i_shadow_color;
     out.effect_params = in.i_effect_params;
-    out.effect_kind = in.i_effect_flags.x;
+    out.effect_flags = in.i_effect_flags.x;
 
     return out;
 }
@@ -93,11 +92,11 @@ fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
     var color = vec4<f32>(0.0);
     let base_sample = textureSample(sprite_texture, sprite_sampler, in.uv);
 
-    if in.effect_kind == TEXT_EFFECT_NONE {
+    if in.effect_flags == 0u {
         color = in.color * base_sample;
     } else {
         let fill_cov = base_sample.a;
-        if in.effect_kind == TEXT_EFFECT_SHADOW {
+        if (in.effect_flags & TEXT_EFFECT_SHADOW) != 0u {
             let shadow_uv = in.uv - in.effect_params.xy;
             let shadow_cov = textureSampleLevel(sprite_texture, sprite_sampler, shadow_uv, 0.0).a;
             color = composite_text_layers(

--- a/crates/bevy_sprite_render/src/text2d/mod.rs
+++ b/crates/bevy_sprite_render/src/text2d/mod.rs
@@ -1,5 +1,6 @@
 use crate::{
     ExtractedSlice, ExtractedSlices, ExtractedSprite, ExtractedSpriteKind, ExtractedSprites,
+    ExtractedTextEffect,
 };
 use bevy_asset::AssetId;
 use bevy_camera::visibility::ViewVisibility;
@@ -9,15 +10,18 @@ use bevy_ecs::{
     query::Has,
     system::{Commands, Query, ResMut},
 };
-use bevy_math::{Vec2, Vec3};
+use bevy_math::{Rect, Vec2, Vec3};
 use bevy_render::sync_world::TemporaryRenderEntity;
 use bevy_render::Extract;
 use bevy_sprite::{Anchor, Text2dShadow};
 use bevy_text::{
     ComputedTextBlock, PositionedGlyph, Strikethrough, StrikethroughColor, TextBackgroundColor,
-    TextBounds, TextColor, TextLayoutInfo, Underline, UnderlineColor,
+    TextBounds, TextColor, TextLayoutInfo, Underline, UnderlineColor, TEXT_EFFECT_PADDING,
 };
 use bevy_transform::prelude::GlobalTransform;
+
+const TEXT2D_BACKGROUND_Z_OFFSET: f32 = -0.0003;
+const TEXT2D_SHADOW_Z_OFFSET: f32 = -0.0002;
 
 /// This system extracts the sprites from the 2D text components and adds them to the
 /// "render world".
@@ -49,9 +53,6 @@ pub fn extract_text2d_sprite(
         )>,
     >,
 ) {
-    let mut start = extracted_slices.slices.len();
-    let mut end = start + 1;
-
     for (
         main_entity,
         view_visibility,
@@ -64,8 +65,11 @@ pub fn extract_text2d_sprite(
     ) in text2d_query.iter()
     {
         let inverse_scale_factor = text_layout_info.scale_factor.recip();
-        let scaling =
-            GlobalTransform::from_scale(Vec3::new(inverse_scale_factor, -inverse_scale_factor, 1.));
+        let scaling = GlobalTransform::from_scale(Vec3::new(
+            inverse_scale_factor,
+            -inverse_scale_factor,
+            1.0,
+        ));
         if !view_visibility.get() {
             continue;
         }
@@ -74,8 +78,9 @@ pub fn extract_text2d_sprite(
             text_bounds.width.unwrap_or(text_layout_info.size.x),
             text_bounds.height.unwrap_or(text_layout_info.size.y),
         );
-
         let top_left = (Anchor::TOP_LEFT.0 - anchor.as_vec()) * size;
+        let text_transform =
+            *global_transform * GlobalTransform::from_translation(top_left.extend(0.0)) * scaling;
 
         for run in text_layout_info.run_geometry.iter() {
             let section_entity = computed_block.entities()[run.section_index].entity;
@@ -84,10 +89,8 @@ pub fn extract_text2d_sprite(
             };
             let render_entity = commands.spawn(TemporaryRenderEntity).id();
             let offset = run.bounds.center();
-            let transform = *global_transform
-                * GlobalTransform::from_translation(top_left.extend(0.))
-                * scaling
-                * GlobalTransform::from_translation(offset.extend(0.));
+            let transform = text_transform
+                * GlobalTransform::from_translation(offset.extend(TEXT2D_BACKGROUND_Z_OFFSET));
             extracted_sprites.sprites.push(ExtractedSprite {
                 main_entity,
                 render_entity,
@@ -96,6 +99,7 @@ pub fn extract_text2d_sprite(
                 image_handle_id: AssetId::default(),
                 flip_x: false,
                 flip_y: true,
+                text_effect: ExtractedTextEffect::default(),
                 kind: ExtractedSpriteKind::Single {
                     anchor: Vec2::ZERO,
                     rect: None,
@@ -105,109 +109,31 @@ pub fn extract_text2d_sprite(
             });
         }
 
-        if let Some(shadow) = maybe_shadow {
-            let shadow_transform = *global_transform
-                * GlobalTransform::from_translation((top_left + shadow.offset).extend(0.))
-                * scaling;
-            let color = shadow.color.into();
+        let shadow_effect = maybe_shadow.map(|shadow| {
+            (
+                LinearRgba::from(shadow.color),
+                clamp_text2d_shadow_offset(shadow.offset, text_layout_info.scale_factor),
+            )
+        });
+        let base_transform =
+            *global_transform * GlobalTransform::from_translation(top_left.extend(0.0));
+        let shadow_transform = shadow_effect.map(|(_, shadow_offset)| {
+            base_transform
+                * GlobalTransform::from_translation(
+                    (shadow_offset * inverse_scale_factor).extend(0.0),
+                )
+                * scaling
+        });
+        let glyph_text_effect = shadow_effect
+            .map(|(color, offset)| {
+                ExtractedTextEffect::shadow(Vec2::new(offset.x, -offset.y), color)
+            })
+            .unwrap_or_default();
+        let glyph_padding = combined_text_effect_padding(shadow_effect.map(|(_, offset)| offset));
 
-            for (
-                i,
-                PositionedGlyph {
-                    position,
-                    atlas_info,
-                    ..
-                },
-            ) in text_layout_info.glyphs.iter().enumerate()
-            {
-                extracted_slices.slices.push(ExtractedSlice {
-                    offset: *position,
-                    rect: atlas_info.rect,
-                    size: atlas_info.rect.size(),
-                });
-
-                if text_layout_info
-                    .glyphs
-                    .get(i + 1)
-                    .is_none_or(|info| info.atlas_info.texture != atlas_info.texture)
-                {
-                    let render_entity = commands.spawn(TemporaryRenderEntity).id();
-                    extracted_sprites.sprites.push(ExtractedSprite {
-                        main_entity,
-                        render_entity,
-                        transform: shadow_transform,
-                        color,
-                        image_handle_id: atlas_info.texture,
-                        flip_x: false,
-                        flip_y: true,
-                        kind: ExtractedSpriteKind::Slices {
-                            indices: start..end,
-                        },
-                    });
-                    start = end;
-                }
-
-                end += 1;
-            }
-
-            for run in text_layout_info.run_geometry.iter() {
-                let section_entity = computed_block.entities()[run.section_index].entity;
-                let Ok((_, has_strikethrough, has_underline, _, _)) =
-                    decoration_query.get(section_entity)
-                else {
-                    continue;
-                };
-
-                if has_strikethrough {
-                    let render_entity = commands.spawn(TemporaryRenderEntity).id();
-                    let offset = run.strikethrough_position();
-                    let transform =
-                        shadow_transform * GlobalTransform::from_translation(offset.extend(0.));
-                    extracted_sprites.sprites.push(ExtractedSprite {
-                        main_entity,
-                        render_entity,
-                        transform,
-                        color,
-                        image_handle_id: AssetId::default(),
-                        flip_x: false,
-                        flip_y: false,
-                        kind: ExtractedSpriteKind::Single {
-                            anchor: Vec2::ZERO,
-                            rect: None,
-                            scaling_mode: None,
-                            custom_size: Some(run.strikethrough_size()),
-                        },
-                    });
-                }
-
-                if has_underline {
-                    let render_entity = commands.spawn(TemporaryRenderEntity).id();
-                    let offset = run.underline_position();
-                    let transform =
-                        shadow_transform * GlobalTransform::from_translation(offset.extend(0.));
-                    extracted_sprites.sprites.push(ExtractedSprite {
-                        main_entity,
-                        render_entity,
-                        transform,
-                        color,
-                        image_handle_id: AssetId::default(),
-                        flip_x: false,
-                        flip_y: false,
-                        kind: ExtractedSpriteKind::Single {
-                            anchor: Vec2::ZERO,
-                            rect: None,
-                            scaling_mode: None,
-                            custom_size: Some(run.underline_size()),
-                        },
-                    });
-                }
-            }
-        }
-
-        let transform =
-            *global_transform * GlobalTransform::from_translation(top_left.extend(0.)) * scaling;
         let mut color = LinearRgba::WHITE;
         let mut current_section = usize::MAX;
+        let mut start = extracted_slices.slices.len();
 
         for (
             i,
@@ -232,10 +158,13 @@ pub fn extract_text2d_sprite(
                     .unwrap_or_default();
                 current_section = *section_index;
             }
+
             extracted_slices.slices.push(ExtractedSlice {
                 offset: *position,
-                rect: atlas_info.rect,
-                size: atlas_info.rect.size(),
+                rect: glyph_padding
+                    .map(|padding| expanded_effect_rect(atlas_info.rect, padding))
+                    .unwrap_or(atlas_info.rect),
+                size: atlas_info.rect.size() + glyph_padding.unwrap_or(Vec2::ZERO) * 2.0,
             });
 
             if text_layout_info.glyphs.get(i + 1).is_none_or(|info| {
@@ -246,26 +175,25 @@ pub fn extract_text2d_sprite(
                 extracted_sprites.sprites.push(ExtractedSprite {
                     main_entity,
                     render_entity,
-                    transform,
+                    transform: text_transform,
                     color,
                     image_handle_id: atlas_info.texture,
                     flip_x: false,
                     flip_y: true,
+                    text_effect: glyph_text_effect,
                     kind: ExtractedSpriteKind::Slices {
-                        indices: start..end,
+                        indices: start..extracted_slices.slices.len(),
                     },
                 });
-                start = end;
+                start = extracted_slices.slices.len();
             }
-
-            end += 1;
         }
 
         for run in text_layout_info.run_geometry.iter() {
             let section_entity = computed_block.entities()[run.section_index].entity;
             let Ok((
                 text_color,
-                has_strike_through,
+                has_strikethrough,
                 has_underline,
                 maybe_strikethrough_color,
                 maybe_underline_color,
@@ -273,32 +201,42 @@ pub fn extract_text2d_sprite(
             else {
                 continue;
             };
-            if has_strike_through {
+
+            if has_strikethrough {
                 let color = maybe_strikethrough_color
                     .map(|c| c.0)
                     .unwrap_or(text_color.0)
                     .to_linear();
-                let render_entity = commands.spawn(TemporaryRenderEntity).id();
                 let offset = run.strikethrough_position();
-                let transform = *global_transform
-                    * GlobalTransform::from_translation(top_left.extend(0.))
-                    * scaling
-                    * GlobalTransform::from_translation(offset.extend(0.));
-                extracted_sprites.sprites.push(ExtractedSprite {
+                let size = run.strikethrough_size();
+
+                if let Some(shadow) = maybe_shadow {
+                    let Some(shadow_transform) = shadow_transform else {
+                        continue;
+                    };
+
+                    extract_text2d_decoration(
+                        &mut commands,
+                        &mut extracted_sprites,
+                        main_entity,
+                        shadow_transform,
+                        offset,
+                        shadow.color.into(),
+                        size,
+                        TEXT2D_SHADOW_Z_OFFSET,
+                    );
+                }
+
+                extract_text2d_decoration(
+                    &mut commands,
+                    &mut extracted_sprites,
                     main_entity,
-                    render_entity,
-                    transform,
+                    text_transform,
+                    offset,
                     color,
-                    image_handle_id: AssetId::default(),
-                    flip_x: false,
-                    flip_y: false,
-                    kind: ExtractedSpriteKind::Single {
-                        anchor: Vec2::ZERO,
-                        rect: None,
-                        scaling_mode: None,
-                        custom_size: Some(run.strikethrough_size()),
-                    },
-                });
+                    size,
+                    0.0,
+                );
             }
 
             if has_underline {
@@ -306,28 +244,92 @@ pub fn extract_text2d_sprite(
                     .map(|c| c.0)
                     .unwrap_or(text_color.0)
                     .to_linear();
-                let render_entity = commands.spawn(TemporaryRenderEntity).id();
                 let offset = run.underline_position();
-                let transform = *global_transform
-                    * GlobalTransform::from_translation(top_left.extend(0.))
-                    * scaling
-                    * GlobalTransform::from_translation(offset.extend(0.));
-                extracted_sprites.sprites.push(ExtractedSprite {
+                let size = run.underline_size();
+
+                if let Some(shadow) = maybe_shadow {
+                    let Some(shadow_transform) = shadow_transform else {
+                        continue;
+                    };
+
+                    extract_text2d_decoration(
+                        &mut commands,
+                        &mut extracted_sprites,
+                        main_entity,
+                        shadow_transform,
+                        offset,
+                        shadow.color.into(),
+                        size,
+                        TEXT2D_SHADOW_Z_OFFSET,
+                    );
+                }
+
+                extract_text2d_decoration(
+                    &mut commands,
+                    &mut extracted_sprites,
                     main_entity,
-                    render_entity,
-                    transform,
+                    text_transform,
+                    offset,
                     color,
-                    image_handle_id: AssetId::default(),
-                    flip_x: false,
-                    flip_y: false,
-                    kind: ExtractedSpriteKind::Single {
-                        anchor: Vec2::ZERO,
-                        rect: None,
-                        scaling_mode: None,
-                        custom_size: Some(run.underline_size()),
-                    },
-                });
+                    size,
+                    0.0,
+                );
             }
         }
+    }
+}
+
+fn extract_text2d_decoration(
+    commands: &mut Commands,
+    extracted_sprites: &mut ExtractedSprites,
+    main_entity: Entity,
+    transform: GlobalTransform,
+    offset: Vec2,
+    color: LinearRgba,
+    size: Vec2,
+    z_offset: f32,
+) {
+    let render_entity = commands.spawn(TemporaryRenderEntity).id();
+    extracted_sprites.sprites.push(ExtractedSprite {
+        main_entity,
+        render_entity,
+        transform: transform * GlobalTransform::from_translation(offset.extend(z_offset)),
+        color,
+        image_handle_id: AssetId::default(),
+        flip_x: false,
+        flip_y: false,
+        text_effect: ExtractedTextEffect::default(),
+        kind: ExtractedSpriteKind::Single {
+            anchor: Vec2::ZERO,
+            rect: None,
+            scaling_mode: None,
+            custom_size: Some(size),
+        },
+    });
+}
+
+fn clamp_text2d_shadow_offset(offset: Vec2, scale_factor: f32) -> Vec2 {
+    let sampled_offset = offset * scale_factor;
+    let limit = TEXT_EFFECT_PADDING as f32;
+    if sampled_offset.x.abs() <= limit && sampled_offset.y.abs() <= limit {
+        return sampled_offset;
+    }
+
+    sampled_offset.clamp(Vec2::splat(-limit), Vec2::splat(limit))
+}
+
+fn expanded_effect_rect(fill_rect: Rect, padding: Vec2) -> Rect {
+    Rect {
+        min: fill_rect.min - padding,
+        max: fill_rect.max + padding,
+    }
+}
+
+fn combined_text_effect_padding(shadow_offset: Option<Vec2>) -> Option<Vec2> {
+    let padding = shadow_offset.map_or(Vec2::ZERO, |shadow_offset| shadow_offset.abs().ceil());
+    if padding == Vec2::ZERO {
+        None
+    } else {
+        Some(padding)
     }
 }

--- a/crates/bevy_text/src/font_atlas.rs
+++ b/crates/bevy_text/src/font_atlas.rs
@@ -14,6 +14,9 @@ pub struct GlyphCacheKey {
     pub glyph_id: u16,
 }
 
+#[doc(hidden)]
+pub const TEXT_EFFECT_PADDING: u32 = 16;
+
 /// Rasterized glyphs are cached, stored in, and retrieved from, a `FontAtlas`.
 ///
 /// A `FontAtlas` contains one or more textures, each of which contains one or more glyphs packed into them.
@@ -91,6 +94,7 @@ impl FontAtlas {
         key: GlyphCacheKey,
         texture: &Image,
         offset: Vec2,
+        text_effect_padding: bool,
     ) -> Result<(), TextError> {
         let mut atlas_texture = textures
             .get_mut(&self.texture)
@@ -101,6 +105,16 @@ impl FontAtlas {
             texture,
             &mut atlas_texture,
         ) {
+            if text_effect_padding {
+                let glyph_rect = self
+                    .texture_atlas
+                    .textures
+                    .get_mut(glyph_index)
+                    .expect("newly added glyph must have an atlas rect");
+                let padding = UVec2::splat(TEXT_EFFECT_PADDING);
+                glyph_rect.min += padding;
+                glyph_rect.max -= padding;
+            }
             self.glyph_to_atlas_index.insert(
                 key,
                 GlyphAtlasLocation {
@@ -133,10 +147,18 @@ pub fn add_glyph_to_atlas(
     scaler: &mut Scaler,
     font_smoothing: FontSmoothing,
     glyph_id: u16,
+    text_effect_padding: bool,
 ) -> Result<GlyphAtlasInfo, TextError> {
-    let (glyph_texture, offset) = get_outlined_glyph_texture(scaler, glyph_id, font_smoothing)?;
+    let (glyph_texture, offset) =
+        get_glyph_texture(scaler, glyph_id, font_smoothing, text_effect_padding)?;
     let mut add_char_to_font_atlas = |atlas: &mut FontAtlas| -> Result<(), TextError> {
-        atlas.add_glyph(textures, GlyphCacheKey { glyph_id }, &glyph_texture, offset)
+        atlas.add_glyph(
+            textures,
+            GlyphCacheKey { glyph_id },
+            &glyph_texture,
+            offset,
+            text_effect_padding,
+        )
     };
     if !font_atlases
         .iter_mut()
@@ -153,7 +175,13 @@ pub fn add_glyph_to_atlas(
 
         let mut new_atlas = FontAtlas::new(textures, UVec2::splat(containing), font_smoothing);
 
-        new_atlas.add_glyph(textures, GlyphCacheKey { glyph_id }, &glyph_texture, offset)?;
+        new_atlas.add_glyph(
+            textures,
+            GlyphCacheKey { glyph_id },
+            &glyph_texture,
+            offset,
+            text_effect_padding,
+        )?;
 
         font_atlases.push(new_atlas);
     }
@@ -167,10 +195,11 @@ pub fn add_glyph_to_atlas(
     clippy::identity_op,
     reason = "Alignment improves clarity during RGBA operations."
 )]
-pub fn get_outlined_glyph_texture(
+pub fn get_glyph_texture(
     scaler: &mut Scaler,
     glyph_id: u16,
     font_smoothing: FontSmoothing,
+    text_effect_padding: bool,
 ) -> Result<(Image, Vec2), TextError> {
     let image = swash::scale::Render::new(&[
         swash::scale::Source::ColorOutline(0),
@@ -209,6 +238,29 @@ pub fn get_outlined_glyph_texture(
         }
     }
 
+    let (data, width, height) = if text_effect_padding {
+        let padding = TEXT_EFFECT_PADDING;
+        let padded_width = width + padding * 2;
+        let padded_height = height + padding * 2;
+        let mut padded_rgba = vec![0; padded_width as usize * padded_height as usize * 4];
+        let src_row_bytes = width as usize * 4;
+        let dst_stride = padded_width as usize * 4;
+        let dst_x = padding as usize * 4;
+        let dst_y = padding as usize;
+
+        for row in 0..height as usize {
+            let src_start = row * src_row_bytes;
+            let src_end = src_start + src_row_bytes;
+            let dst_start = (row + dst_y) * dst_stride + dst_x;
+            let dst_end = dst_start + src_row_bytes;
+            padded_rgba[dst_start..dst_end].copy_from_slice(&rgba[src_start..src_end]);
+        }
+
+        (padded_rgba, padded_width, padded_height)
+    } else {
+        (rgba, width, height)
+    };
+
     Ok((
         Image::new(
             Extent3d {
@@ -217,7 +269,7 @@ pub fn get_outlined_glyph_texture(
                 depth_or_array_layers: 1,
             },
             TextureDimension::D2,
-            rgba,
+            data,
             TextureFormat::Rgba8UnormSrgb,
             RenderAssetUsages::MAIN_WORLD,
         ),

--- a/crates/bevy_text/src/font_atlas_set.rs
+++ b/crates/bevy_text/src/font_atlas_set.rs
@@ -22,6 +22,8 @@ pub struct FontAtlasKey {
     pub hinting: FontHinting,
     /// Antialiasing method
     pub font_smoothing: FontSmoothing,
+    /// Whether the atlas reserves padded glyph margins for text effects.
+    pub text_effect_padding: bool,
 }
 
 /// Set of rasterized fonts stored in [`FontAtlas`]es.

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -308,6 +308,7 @@ impl TextPipeline {
         bounds: TextBounds,
         justify: Justify,
         hinting: FontHinting,
+        text_effect_padding: bool,
     ) -> Result<(), TextError> {
         computed.needs_rerender = false;
         layout_info.clear();
@@ -332,6 +333,7 @@ impl TextPipeline {
                         variations_hash,
                         hinting,
                         font_smoothing,
+                        text_effect_padding,
                     };
 
                     let Some(font_ref) =
@@ -365,6 +367,7 @@ impl TextPipeline {
                                         &mut scaler,
                                         font_smoothing,
                                         glyph_id,
+                                        text_effect_padding,
                                     )
                                 })?;
 
@@ -403,7 +406,7 @@ impl TextPipeline {
         }
 
         layout_info.size = Vec2::new(layout.full_width(), layout.height()).ceil();
-
+        layout_info.uses_text_effect_padding = text_effect_padding;
         Ok(())
     }
 }
@@ -446,6 +449,8 @@ pub fn resolve_font_source<'a>(
 pub struct TextLayoutInfo {
     /// The target scale factor for this text layout
     pub scale_factor: f32,
+    /// Whether the layout's cached glyph atlas rects include text-effect padding.
+    pub uses_text_effect_padding: bool,
     /// Scaled and positioned glyphs in screenspace
     pub glyphs: Vec<PositionedGlyph>,
     /// Geometry of each text run used to render text decorations like background colors, strikethrough, and underline.
@@ -466,6 +471,7 @@ impl TextLayoutInfo {
     /// Clear the layout, retaining capacity
     pub fn clear(&mut self) {
         self.scale_factor = 1.;
+        self.uses_text_effect_padding = false;
         self.glyphs.clear();
         self.run_geometry.clear();
         self.size = Vec2::ZERO;

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -9,7 +9,7 @@ use bevy_ecs::{
     change_detection::DetectChanges,
     component::Component,
     entity::Entity,
-    query::With,
+    query::{Has, With},
     reflect::ReflectComponent,
     system::{Query, Res, ResMut},
     world::Ref,
@@ -145,9 +145,10 @@ impl From<String> for Text {
 #[reflect(Component, Default, Debug, Clone, PartialEq)]
 pub struct TextShadow {
     /// Shadow displacement in logical pixels
-    /// With a value of zero the shadow will be hidden directly behind the text
+    ///
+    /// Clamped to 16 px after layout scaling
     pub offset: Vec2,
-    /// Color of the shadow
+    /// Color of the shadow.
     pub color: Color,
 }
 
@@ -348,13 +349,20 @@ pub fn text_system(
         &mut TextNodeFlags,
         &mut ComputedTextBlock,
         Ref<FontHinting>,
+        Has<TextShadow>,
     )>,
     mut scale_cx: ResMut<ScaleCx>,
 ) {
-    for (node, block, mut text_layout_info, mut text_flags, mut computed, hinting) in
+    for (node, block, mut text_layout_info, mut text_flags, mut computed, hinting, has_shadow) in
         &mut text_query
     {
-        if node.is_changed() || text_flags.needs_recompute || hinting.is_changed() {
+        let text_effect_padding = has_shadow;
+
+        if node.is_changed()
+            || text_flags.needs_recompute
+            || hinting.is_changed()
+            || text_layout_info.uses_text_effect_padding != text_effect_padding
+        {
             // Skip the text node if it is waiting for a new measure func
             if text_flags.needs_measure_fn {
                 continue;
@@ -377,6 +385,7 @@ pub fn text_system(
                 physical_node_size,
                 block.justify,
                 *hinting,
+                text_effect_padding,
             ) {
                 Err(
                     TextError::NoSuchFont

--- a/crates/bevy_ui/src/widget/text_editable.rs
+++ b/crates/bevy_ui/src/widget/text_editable.rs
@@ -301,6 +301,7 @@ pub fn update_editable_text_layout(
             let layout = driver.layout();
 
             info.scale_factor = layout.scale();
+            info.uses_text_effect_padding = false;
             info.size = (
                 layout.width() / layout.scale(),
                 layout.height() / layout.scale(),
@@ -329,6 +330,7 @@ pub fn update_editable_text_layout(
                                 variations_hash: FixedHasher.hash_one(coords),
                                 hinting: *hinting,
                                 font_smoothing: brush.font_smoothing,
+                                text_effect_padding: false,
                             };
 
                             for glyph in glyph_run.positioned_glyphs() {
@@ -359,6 +361,7 @@ pub fn update_editable_text_layout(
                                         &mut scaler,
                                         text_font.font_smoothing,
                                         glyph.id as u16,
+                                        false,
                                     )
                                 }) else {
                                     continue;

--- a/crates/bevy_ui_render/src/lib.rs
+++ b/crates/bevy_ui_render/src/lib.rs
@@ -25,7 +25,7 @@ use bevy_reflect::prelude::ReflectDefault;
 use bevy_reflect::Reflect;
 use bevy_render::camera::{extract_cameras, CameraMainPassTextureFormats};
 use bevy_shader::load_shader_library;
-use bevy_sprite_render::SpriteAssetEvents;
+use bevy_sprite_render::{ExtractedTextEffect, ExtractedTextEffectKind, SpriteAssetEvents};
 use bevy_ui::widget::{ImageNode, TextScroll, TextShadow, ViewportNode};
 use bevy_ui::{
     BackgroundColor, BorderColor, CalculatedClip, ComputedNode, ComputedStackIndex,
@@ -65,7 +65,7 @@ use gradient::GradientPlugin;
 use bevy_platform::collections::{HashMap, HashSet};
 use bevy_text::{
     ComputedTextBlock, PositionedGlyph, Strikethrough, StrikethroughColor, TextBackgroundColor,
-    TextColor, TextCursorStyle, TextLayoutInfo, Underline, UnderlineColor,
+    TextColor, TextCursorStyle, TextLayoutInfo, Underline, UnderlineColor, TEXT_EFFECT_PADDING,
 };
 use bevy_transform::components::GlobalTransform;
 use box_shadow::BoxShadowPlugin;
@@ -112,7 +112,9 @@ pub mod stack_z_offsets {
     pub const IMAGE: f32 = 0.04;
     pub const MATERIAL: f32 = 0.05;
     pub const TEXT_SELECTION: f32 = 0.055;
-    pub const TEXT: f32 = 0.06;
+    pub const TEXT_BACKGROUND: f32 = 0.059;
+    pub const TEXT_SHADOW: f32 = 0.06;
+    pub const TEXT: f32 = 0.062;
     pub const TEXT_STRIKETHROUGH: f32 = 0.07;
     pub const TEXT_CURSOR: f32 = 0.08;
 }
@@ -127,7 +129,6 @@ pub enum RenderUiSystems {
     ExtractBorders,
     ExtractViewportNodes,
     ExtractTextBackgrounds,
-    ExtractTextShadows,
     ExtractText,
     ExtractCursor,
     ExtractDebug,
@@ -225,7 +226,6 @@ impl Plugin for UiRenderPlugin {
                     RenderUiSystems::ExtractTextureSlice,
                     RenderUiSystems::ExtractBorders,
                     RenderUiSystems::ExtractTextBackgrounds,
-                    RenderUiSystems::ExtractTextShadows,
                     RenderUiSystems::ExtractText,
                     RenderUiSystems::ExtractCursor,
                     RenderUiSystems::ExtractDebug,
@@ -244,7 +244,6 @@ impl Plugin for UiRenderPlugin {
                     extract_uinode_borders.in_set(RenderUiSystems::ExtractBorders),
                     extract_viewport_nodes.in_set(RenderUiSystems::ExtractViewportNodes),
                     extract_text_decorations.in_set(RenderUiSystems::ExtractTextBackgrounds),
-                    extract_text_shadows.in_set(RenderUiSystems::ExtractTextShadows),
                     extract_text_sections.in_set(RenderUiSystems::ExtractText),
                     extract_text_cursor.in_set(RenderUiSystems::ExtractCursor),
                     #[cfg(feature = "bevy_ui_debug")]
@@ -368,6 +367,7 @@ pub struct ExtractedGlyph {
     pub color: LinearRgba,
     pub translation: Vec2,
     pub rect: Rect,
+    pub effect: ExtractedTextEffect,
 }
 
 #[derive(Resource, Default)]
@@ -941,6 +941,7 @@ pub fn extract_text_sections(
             &TextLayoutInfo,
             Option<&TextScroll>,
             Option<&TextCursorStyle>,
+            Option<&TextShadow>,
         )>,
     >,
     text_styles: Extract<Query<&TextColor>>,
@@ -963,6 +964,7 @@ pub fn extract_text_sections(
         text_layout_info,
         text_scroll,
         cursor_style,
+        maybe_shadow,
     ) in &uinode_query
     {
         // Skip if not visible or if size is set to zero (e.g. when a parent is set to `Display::None`)
@@ -989,6 +991,17 @@ pub fn extract_text_sections(
         } else {
             maybe_clip.map(|clip| clip.clip)
         };
+
+        let shadow = maybe_shadow.map(|shadow| {
+            (
+                shadow.color.into(),
+                clamp_ui_shadow_offset(shadow.offset, text_layout_info.scale_factor),
+            )
+        });
+        let glyph_effect = shadow
+            .map(|(color, offset)| ExtractedTextEffect::shadow(offset, color))
+            .unwrap_or_default();
+        let glyph_padding = combined_text_effect_padding(shadow.map(|(_, offset)| offset));
 
         let mut color = text_color.0.to_linear();
 
@@ -1038,7 +1051,10 @@ pub fn extract_text_sections(
             extracted_uinodes.glyphs.push(ExtractedGlyph {
                 color,
                 translation: *position,
-                rect: atlas_info.rect,
+                rect: glyph_padding
+                    .map(|padding| expanded_effect_rect(atlas_info.rect, padding))
+                    .unwrap_or(atlas_info.rect),
+                effect: glyph_effect,
             });
 
             if text_layout_info
@@ -1064,171 +1080,29 @@ pub fn extract_text_sections(
     }
 }
 
-pub fn extract_text_shadows(
-    mut commands: Commands,
-    mut extracted_uinodes: ResMut<ExtractedUiNodes>,
-    uinode_query: Extract<
-        Query<(
-            Entity,
-            &ComputedNode,
-            &ComputedStackIndex,
-            &UiGlobalTransform,
-            &ComputedUiTargetCamera,
-            &InheritedVisibility,
-            Option<&CalculatedClip>,
-            &TextLayoutInfo,
-            &TextShadow,
-            &ComputedTextBlock,
-            Option<&TextScroll>,
-        )>,
-    >,
-    text_decoration_query: Extract<Query<(Has<Strikethrough>, Has<Underline>)>>,
-    camera_map: Extract<UiCameraMap>,
-) {
-    let mut start = extracted_uinodes.glyphs.len();
-    let mut end = start + 1;
+fn clamp_ui_shadow_offset(offset: Vec2, scale_factor: f32) -> Vec2 {
+    let sampled_offset = offset * scale_factor;
+    let limit = TEXT_EFFECT_PADDING as f32;
+    if sampled_offset.x.abs() <= limit && sampled_offset.y.abs() <= limit {
+        return sampled_offset;
+    }
 
-    let mut camera_mapper = camera_map.get_mapper();
-    for (
-        entity,
-        uinode,
-        stack_index,
-        global_transform,
-        target,
-        inherited_visibility,
-        maybe_clip,
-        text_layout_info,
-        shadow,
-        computed_block,
-        text_scroll,
-    ) in &uinode_query
-    {
-        // Skip if not visible or if size is set to zero (e.g. when a parent is set to `Display::None`)
-        if !inherited_visibility.get() || uinode.is_empty() {
-            continue;
-        }
+    sampled_offset.clamp(Vec2::splat(-limit), Vec2::splat(limit))
+}
 
-        let Some(extracted_camera_entity) = camera_mapper.map(target) else {
-            continue;
-        };
+fn expanded_effect_rect(fill_rect: Rect, padding: Vec2) -> Rect {
+    Rect {
+        min: fill_rect.min - padding,
+        max: fill_rect.max + padding,
+    }
+}
 
-        let node_transform = Affine2::from(*global_transform)
-            * Affine2::from_translation(
-                uinode.content_box().min + shadow.offset / uinode.inverse_scale_factor()
-                    - text_scroll.map_or(Vec2::ZERO, |s| s.0),
-            );
-
-        let clip = if text_scroll.is_some() {
-            let content_box = uinode.content_box();
-            let text_clip = Rect::from_center_size(
-                global_transform.affine().translation + content_box.center(),
-                content_box.size(),
-            );
-            Some(maybe_clip.map_or(text_clip, |clip| clip.clip.intersect(text_clip)))
-        } else {
-            maybe_clip.map(|clip| clip.clip)
-        };
-
-        for (
-            i,
-            PositionedGlyph {
-                position,
-                atlas_info,
-                section_index,
-                ..
-            },
-        ) in text_layout_info.glyphs.iter().enumerate()
-        {
-            extracted_uinodes.glyphs.push(ExtractedGlyph {
-                color: shadow.color.into(),
-                translation: *position,
-                rect: atlas_info.rect,
-            });
-
-            if text_layout_info.glyphs.get(i + 1).is_none_or(|info| {
-                info.section_index != *section_index
-                    || info.atlas_info.texture != atlas_info.texture
-            }) {
-                extracted_uinodes.uinodes.push(ExtractedUiNode {
-                    transform: node_transform,
-                    z_order: stack_index.0 as f32 + stack_z_offsets::TEXT,
-                    render_entity: commands.spawn(TemporaryRenderEntity).id(),
-                    image: atlas_info.texture,
-                    clip,
-                    extracted_camera_entity,
-                    item: ExtractedUiItem::Glyphs { range: start..end },
-                    main_entity: entity.into(),
-                });
-                start = end;
-            }
-
-            end += 1;
-        }
-
-        for run in text_layout_info.run_geometry.iter() {
-            let Some(section_entity) = computed_block
-                .entities()
-                .get(run.section_index)
-                .map(|t| t.entity)
-            else {
-                continue;
-            };
-            let Ok((has_strikethrough, has_underline)) = text_decoration_query.get(section_entity)
-            else {
-                continue;
-            };
-
-            if has_strikethrough {
-                extracted_uinodes.uinodes.push(ExtractedUiNode {
-                    z_order: stack_index.0 as f32 + stack_z_offsets::TEXT,
-                    render_entity: commands.spawn(TemporaryRenderEntity).id(),
-                    clip,
-                    image: AssetId::default(),
-                    extracted_camera_entity,
-                    transform: node_transform
-                        * Affine2::from_translation(run.strikethrough_position()),
-                    item: ExtractedUiItem::Node {
-                        color: shadow.color.into(),
-                        rect: Rect {
-                            min: Vec2::ZERO,
-                            max: run.strikethrough_size(),
-                        },
-                        atlas_scaling: None,
-                        flip_x: false,
-                        flip_y: false,
-                        border: BorderRect::ZERO,
-                        border_radius: ResolvedBorderRadius::ZERO,
-                        node_type: NodeType::Rect,
-                    },
-                    main_entity: entity.into(),
-                });
-            }
-
-            if has_underline {
-                extracted_uinodes.uinodes.push(ExtractedUiNode {
-                    z_order: stack_index.0 as f32 + stack_z_offsets::TEXT,
-                    render_entity: commands.spawn(TemporaryRenderEntity).id(),
-                    clip,
-                    image: AssetId::default(),
-                    extracted_camera_entity,
-                    transform: node_transform * Affine2::from_translation(run.underline_position()),
-                    item: ExtractedUiItem::Node {
-                        color: shadow.color.into(),
-                        rect: Rect {
-                            min: Vec2::ZERO,
-                            max: run.underline_size(),
-                        },
-                        atlas_scaling: None,
-                        flip_x: false,
-                        flip_y: false,
-                        border: BorderRect::ZERO,
-                        border_radius: ResolvedBorderRadius::ZERO,
-                        node_type: NodeType::Rect,
-                    },
-                    main_entity: entity.into(),
-                });
-            }
-        }
+fn combined_text_effect_padding(shadow_offset: Option<Vec2>) -> Option<Vec2> {
+    let padding = shadow_offset.map_or(Vec2::ZERO, |shadow_offset| shadow_offset.abs().ceil());
+    if padding == Vec2::ZERO {
+        None
+    } else {
+        Some(padding)
     }
 }
 
@@ -1247,6 +1121,7 @@ pub fn extract_text_decorations(
             &ComputedUiTargetCamera,
             &TextLayoutInfo,
             Option<&TextScroll>,
+            Option<&TextShadow>,
         )>,
     >,
     text_background_colors_query: Extract<
@@ -1271,6 +1146,7 @@ pub fn extract_text_decorations(
         camera,
         text_layout_info,
         text_scroll,
+        maybe_shadow,
     ) in &uinode_query
     {
         // Skip if not visible or if size is set to zero (e.g. when a parent is set to `Display::None`)
@@ -1298,6 +1174,13 @@ pub fn extract_text_decorations(
             maybe_clip.map(|clip| clip.clip)
         };
 
+        let shadow = maybe_shadow.map(|shadow| {
+            (
+                shadow.color.into(),
+                clamp_ui_shadow_offset(shadow.offset, text_layout_info.scale_factor),
+            )
+        });
+
         for run in text_layout_info.run_geometry.iter() {
             let Some(section_entity) = computed_block
                 .entities()
@@ -1318,7 +1201,7 @@ pub fn extract_text_decorations(
 
             if let Some(text_background_color) = text_background_color {
                 extracted_uinodes.uinodes.push(ExtractedUiNode {
-                    z_order: stack_index.0 as f32 + stack_z_offsets::TEXT,
+                    z_order: stack_index.0 as f32 + stack_z_offsets::TEXT_BACKGROUND,
                     render_entity: commands.spawn(TemporaryRenderEntity).id(),
                     clip,
                     image: AssetId::default(),
@@ -1346,29 +1229,34 @@ pub fn extract_text_decorations(
                     .map(|sc| sc.0)
                     .unwrap_or(text_color.0)
                     .to_linear();
+                let position = run.strikethrough_position();
+                let size = run.strikethrough_size();
 
-                extracted_uinodes.uinodes.push(ExtractedUiNode {
-                    z_order: stack_index.0 as f32 + stack_z_offsets::TEXT_STRIKETHROUGH,
-                    render_entity: commands.spawn(TemporaryRenderEntity).id(),
+                if let Some((shadow_color, shadow_offset)) = shadow {
+                    extract_text_decoration(
+                        &mut commands,
+                        &mut extracted_uinodes,
+                        entity,
+                        clip,
+                        extracted_camera_entity,
+                        transform * Affine2::from_translation(position + shadow_offset),
+                        stack_index.0 as f32 + stack_z_offsets::TEXT_SHADOW,
+                        shadow_color,
+                        size,
+                    );
+                }
+
+                extract_text_decoration(
+                    &mut commands,
+                    &mut extracted_uinodes,
+                    entity,
                     clip,
-                    image: AssetId::default(),
                     extracted_camera_entity,
-                    transform: transform * Affine2::from_translation(run.strikethrough_position()),
-                    item: ExtractedUiItem::Node {
-                        color,
-                        rect: Rect {
-                            min: Vec2::ZERO,
-                            max: run.strikethrough_size(),
-                        },
-                        atlas_scaling: None,
-                        flip_x: false,
-                        flip_y: false,
-                        border: BorderRect::ZERO,
-                        border_radius: ResolvedBorderRadius::ZERO,
-                        node_type: NodeType::Rect,
-                    },
-                    main_entity: entity.into(),
-                });
+                    transform * Affine2::from_translation(position),
+                    stack_index.0 as f32 + stack_z_offsets::TEXT_STRIKETHROUGH,
+                    color,
+                    size,
+                );
             }
 
             if maybe_underline.is_some() {
@@ -1376,32 +1264,72 @@ pub fn extract_text_decorations(
                     .map(|uc| uc.0)
                     .unwrap_or(text_color.0)
                     .to_linear();
+                let position = run.underline_position();
+                let size = run.underline_size();
 
-                extracted_uinodes.uinodes.push(ExtractedUiNode {
-                    z_order: stack_index.0 as f32 + stack_z_offsets::TEXT_STRIKETHROUGH,
-                    render_entity: commands.spawn(TemporaryRenderEntity).id(),
+                if let Some((shadow_color, shadow_offset)) = shadow {
+                    extract_text_decoration(
+                        &mut commands,
+                        &mut extracted_uinodes,
+                        entity,
+                        clip,
+                        extracted_camera_entity,
+                        transform * Affine2::from_translation(position + shadow_offset),
+                        stack_index.0 as f32 + stack_z_offsets::TEXT_SHADOW,
+                        shadow_color,
+                        size,
+                    );
+                }
+
+                extract_text_decoration(
+                    &mut commands,
+                    &mut extracted_uinodes,
+                    entity,
                     clip,
-                    image: AssetId::default(),
                     extracted_camera_entity,
-                    transform: transform * Affine2::from_translation(run.underline_position()),
-                    item: ExtractedUiItem::Node {
-                        color,
-                        rect: Rect {
-                            min: Vec2::ZERO,
-                            max: run.underline_size(),
-                        },
-                        atlas_scaling: None,
-                        flip_x: false,
-                        flip_y: false,
-                        border: BorderRect::ZERO,
-                        border_radius: ResolvedBorderRadius::ZERO,
-                        node_type: NodeType::Rect,
-                    },
-                    main_entity: entity.into(),
-                });
+                    transform * Affine2::from_translation(position),
+                    stack_index.0 as f32 + stack_z_offsets::TEXT_STRIKETHROUGH,
+                    color,
+                    size,
+                );
             }
         }
     }
+}
+
+fn extract_text_decoration(
+    commands: &mut Commands,
+    extracted_uinodes: &mut ExtractedUiNodes,
+    entity: Entity,
+    clip: Option<Rect>,
+    extracted_camera_entity: Entity,
+    transform: Affine2,
+    z_order: f32,
+    color: LinearRgba,
+    size: Vec2,
+) {
+    extracted_uinodes.uinodes.push(ExtractedUiNode {
+        z_order,
+        render_entity: commands.spawn(TemporaryRenderEntity).id(),
+        clip,
+        image: AssetId::default(),
+        extracted_camera_entity,
+        transform,
+        item: ExtractedUiItem::Node {
+            color,
+            rect: Rect {
+                min: Vec2::ZERO,
+                max: size,
+            },
+            atlas_scaling: None,
+            flip_x: false,
+            flip_y: false,
+            border: BorderRect::ZERO,
+            border_radius: ResolvedBorderRadius::ZERO,
+            node_type: NodeType::Rect,
+        },
+        main_entity: entity.into(),
+    });
 }
 
 #[repr(C)]
@@ -1423,6 +1351,8 @@ struct UiVertex {
     pub size: [f32; 2],
     /// Position relative to the center of the UI node.
     pub point: [f32; 2],
+    pub shadow_color: [f32; 4],
+    pub effect_params: [f32; 4],
 }
 
 #[derive(Resource)]
@@ -1475,6 +1405,7 @@ pub mod shader_flags {
     pub const BORDER_BOTTOM: u32 = 2048;
     pub const BORDER_ALL: u32 = BORDER_LEFT + BORDER_TOP + BORDER_RIGHT + BORDER_BOTTOM;
     pub const INVERT: u32 = 4096;
+    pub const TEXT_EFFECT_SHADOW: u32 = 8192;
 }
 
 pub fn queue_uinodes(
@@ -1819,6 +1750,8 @@ pub fn prepare_uinodes(
                                 ],
                                 size: rect_size.into(),
                                 point: points[i].into(),
+                                shadow_color: [0.0; 4],
+                                effect_params: [0.0; 4],
                             });
                         }
 
@@ -1840,6 +1773,14 @@ pub fn prepare_uinodes(
                             let color = glyph.color.to_f32_array();
                             let glyph_rect = glyph.rect;
                             let rect_size = glyph_rect.size();
+                            let effect_flags = match glyph.effect.kind {
+                                ExtractedTextEffectKind::None => 0,
+                                ExtractedTextEffectKind::Shadow => shader_flags::TEXT_EFFECT_SHADOW,
+                            };
+                            let shadow_color = glyph.effect.shadow_color.to_f32_array();
+                            let mut effect_params = glyph.effect.params;
+                            effect_params.x /= atlas_extent.x;
+                            effect_params.y /= atlas_extent.y;
 
                             // Specify the corners of the glyph
                             let positions = QUAD_VERTEX_POSITIONS.map(|pos| {
@@ -1916,11 +1857,15 @@ pub fn prepare_uinodes(
                                     position: positions_clipped[i].into(),
                                     uv: uvs[i].into(),
                                     color,
-                                    flags: shader_flags::TEXTURED | shader_flags::CORNERS[i],
+                                    flags: shader_flags::TEXTURED
+                                        | shader_flags::CORNERS[i]
+                                        | effect_flags,
                                     radius: [0.0; 4],
                                     border: [0.0; 4],
                                     size: rect_size.into(),
                                     point: [0.0; 2],
+                                    shadow_color,
+                                    effect_params: effect_params.to_array(),
                                 });
                             }
 

--- a/crates/bevy_ui_render/src/lib.rs
+++ b/crates/bevy_ui_render/src/lib.rs
@@ -25,7 +25,7 @@ use bevy_reflect::prelude::ReflectDefault;
 use bevy_reflect::Reflect;
 use bevy_render::camera::{extract_cameras, CameraMainPassTextureFormats};
 use bevy_shader::load_shader_library;
-use bevy_sprite_render::{ExtractedTextEffect, ExtractedTextEffectKind, SpriteAssetEvents};
+use bevy_sprite_render::{ExtractedTextEffect, ExtractedTextEffectFlags, SpriteAssetEvents};
 use bevy_ui::widget::{ImageNode, TextScroll, TextShadow, ViewportNode};
 use bevy_ui::{
     BackgroundColor, BorderColor, CalculatedClip, ComputedNode, ComputedStackIndex,
@@ -1773,9 +1773,14 @@ pub fn prepare_uinodes(
                             let color = glyph.color.to_f32_array();
                             let glyph_rect = glyph.rect;
                             let rect_size = glyph_rect.size();
-                            let effect_flags = match glyph.effect.kind {
-                                ExtractedTextEffectKind::None => 0,
-                                ExtractedTextEffectKind::Shadow => shader_flags::TEXT_EFFECT_SHADOW,
+                            let effect_flags = if glyph
+                                .effect
+                                .flags
+                                .contains(ExtractedTextEffectFlags::SHADOW)
+                            {
+                                shader_flags::TEXT_EFFECT_SHADOW
+                            } else {
+                                0
                             };
                             let shadow_color = glyph.effect.shadow_color.to_f32_array();
                             let mut effect_params = glyph.effect.params;

--- a/crates/bevy_ui_render/src/pipeline.rs
+++ b/crates/bevy_ui_render/src/pipeline.rs
@@ -74,6 +74,10 @@ impl SpecializedRenderPipeline for UiPipeline {
                 VertexFormat::Float32x2,
                 // position relative to the center
                 VertexFormat::Float32x2,
+                // shadow color
+                VertexFormat::Float32x4,
+                // effect params
+                VertexFormat::Float32x4,
             ],
         );
         let shader_defs = if key.anti_alias {

--- a/crates/bevy_ui_render/src/ui.wgsl
+++ b/crates/bevy_ui_render/src/ui.wgsl
@@ -12,6 +12,8 @@ const BORDER_RIGHT: u32 = 1024u;
 const BORDER_BOTTOM: u32 = 2048u;
 const BORDER_ANY: u32 = BORDER_LEFT + BORDER_TOP + BORDER_RIGHT + BORDER_BOTTOM;
 const INVERT: u32 = 4096u;
+const TEXT_EFFECT_SHADOW: u32 = 8192u;
+const TEXT_EFFECT_MASK: u32 = TEXT_EFFECT_SHADOW;
 
 fn enabled(flags: u32, mask: u32) -> bool {
     return (flags & mask) != 0u;
@@ -25,11 +27,13 @@ struct VertexOutput {
 
     @location(2) @interpolate(flat) size: vec2<f32>,
     @location(3) @interpolate(flat) flags: u32,
-    @location(4) @interpolate(flat) radius: vec4<f32>,    
-    @location(5) @interpolate(flat) border: vec4<f32>,    
+    @location(4) @interpolate(flat) radius: vec4<f32>,
+    @location(5) @interpolate(flat) border: vec4<f32>,
 
     // Position relative to the center of the rectangle.
     @location(6) point: vec2<f32>,
+    @location(7) @interpolate(flat) shadow_color: vec4<f32>,
+    @location(8) @interpolate(flat) effect_params: vec4<f32>,
     @builtin(position) position: vec4<f32>,
 };
 
@@ -47,9 +51,13 @@ fn vertex(
     @location(5) border: vec4<f32>,
     @location(6) size: vec2<f32>,
     @location(7) point: vec2<f32>,
+    @location(8) shadow_color: vec4<f32>,
+    @location(9) effect_params: vec4<f32>,
 ) -> VertexOutput {
     var out: VertexOutput;
     out.uv = vertex_uv;
+    out.shadow_color = shadow_color;
+    out.effect_params = effect_params;
     out.position = view.clip_from_world * vec4(vertex_position, 1.0);
     out.color = vertex_color;
     out.flags = flags;
@@ -63,6 +71,25 @@ fn vertex(
 
 @group(1) @binding(0) var sprite_texture: texture_2d<f32>;
 @group(1) @binding(1) var sprite_sampler: sampler;
+
+fn composite_text_layers(
+    fill_color: vec4<f32>,
+    shadow_color: vec4<f32>,
+    fill_cov: f32,
+    shadow_cov: f32,
+) -> vec4<f32> {
+    let fill_alpha = fill_color.a * fill_cov;
+    let shadow_alpha = shadow_color.a * shadow_cov;
+    let shadow_weight = shadow_alpha * (1.0 - fill_alpha);
+    let alpha = fill_alpha + shadow_weight;
+
+    if alpha <= 0.0 {
+        return vec4<f32>(0.0);
+    }
+
+    let rgb = (fill_color.rgb * fill_alpha + shadow_color.rgb * shadow_weight) / alpha;
+    return vec4<f32>(rgb, alpha);
+}
 
 // The returned value is the shortest distance from the given point to the boundary of the rounded 
 // box.
@@ -214,11 +241,24 @@ fn draw_uinode_background(
 
 @fragment
 fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
-    let texture_color = textureSample(sprite_texture, sprite_sampler, in.uv);
+    var color = in.color;
+    let base_sample = textureSample(sprite_texture, sprite_sampler, in.uv);
 
-    // Only use the color sampled from the texture if the `TEXTURED` flag is enabled. 
-    // This allows us to draw both textured and untextured shapes together in the same batch.
-    let color = select(in.color, in.color * texture_color, enabled(in.flags, TEXTURED));
+    if enabled(in.flags, TEXTURED) {
+        if enabled(in.flags, TEXT_EFFECT_MASK) {
+            let fill_cov = base_sample.a;
+            let shadow_uv = in.uv - in.effect_params.xy;
+            let shadow_cov = textureSampleLevel(sprite_texture, sprite_sampler, shadow_uv, 0.0).a;
+            color = composite_text_layers(
+                in.color,
+                in.shadow_color,
+                fill_cov,
+                shadow_cov * (1.0 - fill_cov),
+            );
+        } else {
+            color = in.color * base_sample;
+        }
+    }
 
     if enabled(in.flags, BORDER_ANY) {
         return draw_uinode_border(color, in.point, in.size, in.radius, in.border, in.flags);


### PR DESCRIPTION
# Objective
part of #17076, first PR with https://github.com/bevyengine/bevy/pull/23369 stacked on top of this PR 
the current `TextShadow` implementation creates duplicate glyph geometry at a different z-order. this means semi-transparent text has the shadow bleeding through the fill, since they're separate quads blended independently by the GPU.

__i dont know very much about this part of the code and text rendering techniques, if this implementation is bad, too hard to review, or you dont like for any reason this can be closed without any problem :) i dont want to waste anyone times, so really no problem if you dont want it!__
## Solution
instead of emitting separate shadow geometry, the glyph atlas is padded and the shadow is sampled + composited in the fragment shader in the same pass. fill is composited over shadow per-fragment, before outputting alpha — so semi-transparent text just works, no bleed-through.
the old `extract_text_shadows` system is removed and shadow extraction is folded into the main text extraction pass.
adds `Text2dShadow` for sprite text.
## Testing
updated `examples/ui/text/text.rs` and `examples/2d/text2d.rs` with shadow demos including animated alpha.
## Showcase
```rust
commands.spawn((
    Text::new("shadowed"),
    TextColor(Color::srgba(1.0, 1.0, 1.0, 0.5)),
    TextShadow {
        offset: Vec2::new(2.0, 2.0),
        color: Color::BLACK,
    },
));
```

https://github.com/user-attachments/assets/99eba551-9a52-4b9f-8308-3b34063c2e31

thanks !