### PR TITLE
Derive Reflect for ParsedPath and its children

### DIFF
--- a/crates/bevy_reflect/src/path/access.rs
+++ b/crates/bevy_reflect/src/path/access.rs
@@ -1,6 +1,7 @@
 //! Representation for individual element accesses within a path.
 
 use alloc::borrow::Cow;
+use bevy_reflect_derive::Reflect;
 use core::fmt;
 
 use super::error::AccessErrorKind;
@@ -12,7 +13,8 @@ type InnerResult<T> = Result<T, AccessErrorKind>;
 /// Multiple accesses can be combined into a [`ParsedPath`](super::ParsedPath).
 ///
 /// Can be applied to a [`dyn Reflect`](crate::Reflect) to get a reference to the targeted element.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Reflect)]
+#[reflect(Debug, Clone, PartialEq, PartialOrd, Hash)]
 pub enum Access<'a> {
     /// A name-based field access on a struct.
     Field(Cow<'a, str>),

--- a/crates/bevy_reflect/src/path/mod.rs
+++ b/crates/bevy_reflect/src/path/mod.rs
@@ -295,7 +295,8 @@ pub trait GetPath: PartialReflect {
 impl<T: Reflect + ?Sized> GetPath for T {}
 
 /// An [`Access`] combined with an `offset` for more helpful error reporting.
-#[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq, Hash, Reflect)]
+#[reflect(Clone, Debug, PartialEq, PartialOrd, Hash)]
 pub struct OffsetAccess {
     /// The [`Access`] itself.
     pub access: Access<'static>,
@@ -363,7 +364,8 @@ impl From<Access<'static>> for OffsetAccess {
 /// ];
 /// let my_path = ParsedPath::from(path_elements);
 /// ```
-#[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq, Hash, From)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq, Hash, From, Reflect)]
+#[reflect(Clone, Debug, PartialEq, PartialOrd, Hash)]
 pub struct ParsedPath(
     /// This is a vector of pre-parsed [`OffsetAccess`]es.
     pub Vec<OffsetAccess>,


### PR DESCRIPTION
# Objective

Fixes #22974 

## Solution

This uses the standard Reflect derive macro to ParsedPath and the types it uses. It doesn't do anything special to handle the `'a` parameter in `Access<'a>`, but that's fine because `ParsedPath` uses `'static` for that parameter anyway.

## Testing

I built the docs locally to make sure the implementations were being derived.

<img width="1020" height="253" alt="image" src="https://github.com/user-attachments/assets/d3fb5630-52f5-4bad-9873-2596684b36a2" />

I also verified that the derive macro created the Enum instance for Access that we'd expect.

<img width="1010" height="86" alt="image" src="https://github.com/user-attachments/assets/ef4d52f3-2dad-4442-b56e-2d3d4bc32f52" />
