### PR TITLE
Disable gpu clustering on android

### DIFF
--- a/crates/bevy_pbr/src/cluster/mod.rs
+++ b/crates/bevy_pbr/src/cluster/mod.rs
@@ -73,7 +73,7 @@ pub(crate) fn make_global_cluster_settings(world: &World) -> GlobalClusterSettin
     // `RenderDevice` limits in addition to the `RenderAdapter`.
     // Some android devices report the capabilities and limits wrong, so we can't rely on them.
     // See <https://github.com/bevyengine/bevy/issues/23208> for Android issues
-    let gpu_clustering_supported = cfg!(target_os = "android")
+    let gpu_clustering_supported = !cfg!(target_os = "android")
         && adapter
             .get_downlevel_capabilities()
             .flags


### PR DESCRIPTION
# Objective

- GPU clustering of lights have issues on some android devices
- Fixes #23208

## Solution

- Disable GPU clustering on android
