### PR TITLE
docs: Remove misleading ViewVisibility docs

### DIFF
--- a/crates/bevy_camera/src/visibility/mod.rs
+++ b/crates/bevy_camera/src/visibility/mod.rs
@@ -175,11 +175,6 @@ pub struct VisibilityClass(pub SmallVec<[TypeId; 1]>);
 /// Algorithmically computed indication of whether an entity is visible and should be extracted for
 /// rendering.
 ///
-/// Each frame, this will be reset to `false` during [`VisibilityPropagate`] systems in
-/// [`PostUpdate`]. Later in the frame, systems in [`CheckVisibility`] will mark any visible
-/// entities using [`ViewVisibility::set`]. Because of this, values of this type will be marked as
-/// changed every frame, even when they do not change.
-///
 /// If you wish to add a custom visibility system that sets this value, be sure to add it to the
 /// [`CheckVisibility`] set.
 ///


### PR DESCRIPTION
# Objective

Fixes #23383.

## Solution

This removes a part of the `ViewVisibility` docs comment that suggests it to be unreliable in change-detection even though bevy_pbr and some examples use it for exactly that and it works just fine in general.

#22466 has made it possible to use reliable change-detection with `ViewVisibility`.

## Testing

This does not change any code or logic. It only changes a docs comment. Therefore no testing is required.