### PR TITLE
Fixed cluster sampling issues for volumetric point and spot lights

### DIFF
--- a/crates/bevy_pbr/src/volumetric_fog/volumetric_fog.wgsl
+++ b/crates/bevy_pbr/src/volumetric_fog/volumetric_fog.wgsl
@@ -336,7 +336,6 @@ fn fragment(@builtin(position) position: vec4<f32>) -> @location(0) vec4<f32> {
     }
 
     // Point lights and Spot lights
-    let view_z = view_start_pos.z;
     let is_orthographic = view.clip_from_view[3].w == 1.0;
 
     // Reset `background_alpha` for a new raymarch.


### PR DESCRIPTION
# Objective

- Fixes #18371 
- Fixes sampling volumetric sampling issues when camera is outside of Fog Volume

## Solution

- The problem was that only the point / spot lights that overlap with the first z-slice of the cluster grid were considered in the ray marching algo. In the updated code, I moved the ray marching to the outer loop. Then for each sample, I get the cluster index from the sample's view position, with the index I find all lights contributing to this cluster and add up their light contributions.
- Another issue I found while looking into this issue is that the ray origin for the volumetric tracing was the camera origin, even when the camera was outside the `FogVolume`. This is now fixed in both directional light and the point / spotlight implementations.

## Testing

I tested using the code given in the bug report and adapted it to the latest version of bevy:
```rust
use bevy::{
    color::palettes::css::RED,
    core_pipeline::{tonemapping::Tonemapping},
    light::{
        FogVolume, VolumetricFog, VolumetricLight,
    },
    post_process::bloom::Bloom,
    prelude::*,
};

fn main() {
    App::new()
        .add_plugins(DefaultPlugins)
        .insert_resource(GlobalAmbientLight::NONE)
        .add_systems(Startup, setup)
        .add_systems(Update, move_camera)
        .run();
}

fn setup(mut commands: Commands) {
    commands.spawn((
        Transform::from_xyz(-2., 0., 0.),
        SpotLight {
            intensity: 500_000.0, // lumens
            color: RED.into(),
            shadow_maps_enabled: true,
            ..default()
        },
        VolumetricLight,
    ));

    commands.spawn((
        Transform::from_xyz(2., 0., 0.),
        SpotLight {
            intensity: 500_000.0, // lumens
            color: RED.into(),
            shadow_maps_enabled: true,
            ..default()
        },
        VolumetricLight,
    ));

    commands.spawn((
        FogVolume::default(),
        Transform::from_scale(Vec3::splat(35.0)),
    ));

    commands.spawn((
        Camera3d::default(),
        Camera { ..default() },
        Transform::from_xyz(0., 0., 5.),
        Tonemapping::TonyMcMapface,
        Bloom::default(),
        VolumetricFog {
            ..default()
        },
    ));
}

fn move_camera(
    mut query: Query<&mut Transform, With<Camera3d>>,
    input: Res<ButtonInput<KeyCode>>,
    time: Res<Time>,
) {
    for mut transform in query.iter_mut() {
        if input.pressed(KeyCode::ArrowUp) {
            transform.translation.z -= 10. * time.delta_secs();
        }

        if input.pressed(KeyCode::ArrowDown) {
            transform.translation.z += 10. * time.delta_secs();
        }

        if input.pressed(KeyCode::KeyZ) {
            transform.translation.z = 5.;
        }

        if input.pressed(KeyCode::KeyX) {
            transform.translation.z = 130.;
        }
    }
}
```
---

## Showcase

After changes (using code from: #18371):

https://github.com/user-attachments/assets/b3d085bb-06f2-413a-83dc-56c5b2f0609b


Note: The flickering of the light is due to the regular sampling interval, adding more samples or jittering the ray origin minimizes this problem.

Ray marching when camera is outside of `FogVolume` (Before):
<img width="1300" height="775" alt="camera_outside_before" src="https://github.com/user-attachments/assets/d01a37c3-389b-4212-8e44-306aa6edec59" />

After:
<img width="1300" height="775" alt="camera_outside_after" src="https://github.com/user-attachments/assets/b9c4949a-6759-481f-82b1-cf914fc9fe3a" />

