### PR TITLE
Ensure the previous mesh input buffer is nonempty.

### DIFF
--- a/crates/bevy_render/src/batching/gpu_preprocessing.rs
+++ b/crates/bevy_render/src/batching/gpu_preprocessing.rs
@@ -447,7 +447,7 @@ where
     /// Writes the buffer to the GPU.
     fn write_buffer(&mut self, render_device: &RenderDevice, render_queue: &RenderQueue) {
         // `Self::ensure_nonempty` must have been called first.
-        debug_assert_ne!(self.buffer.len(), 0);
+        debug_assert!(!self.buffer.is_empty());
         // Only write the modified portion of this buffer. Typically, that
         // portion will be much smaller than the full size of the buffer.
         self.buffer.write_buffer_range(


### PR DESCRIPTION
`AtomicRawBufferVec` won't create the underlying buffer if all ranges to be uploaded are empty. This patch ensures that that doesn't happen by ensuring that the uploaded region is at least 1 element in size.

This fixes `generate_custom_mesh` after PR #23242 and likely other examples as well.