### PR TITLE
Make passing in the type registry for scene ser/de explicit.

### DIFF
--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -42,13 +42,35 @@ pub struct DynamicEntity {
 
 impl DynamicScene {
     /// Create a new dynamic scene from a given scene.
-    pub fn from_scene(scene: &Scene) -> Self {
-        Self::from_world(&scene.world)
+    ///
+    /// The `type_registry` provides type information for extracting components and resources
+    /// through reflection. You can get this registry from the **main** world, using
+    /// `main_world.resource::<AppTypeRegistry>().read()` or `app_type_registry_res.read()`
+    /// (for `Res<AppTypeRegistry>`). Note: the scene world is unlikely to have a type registry
+    /// internally.
+    pub fn from_scene(scene: &Scene, type_registry: &TypeRegistry) -> Self {
+        Self::from_world_with(&scene.world, type_registry)
     }
 
     /// Create a new dynamic scene from a given world.
+    ///
+    /// Panics if `world` does not contain [`AppTypeRegistry`]. Use [`Self::from_world_with`] to
+    /// handle this case.
     pub fn from_world(world: &World) -> Self {
-        DynamicSceneBuilder::from_world(world)
+        let type_registry = world.resource::<AppTypeRegistry>().read();
+        Self::from_world_with(world, &type_registry)
+    }
+
+    /// Create a new dynamic scene from a given world.
+    ///
+    /// The `type_registry` provides type information for extracting components and resources
+    /// through reflection. If the `world` is the "real" world (e.g., not a world in a [`Scene`]),
+    /// the `world` will contain the registry, which can be acquired using
+    /// `world.resource::<AppTypeRegistry>().read()`. For extracting from "scene worlds", you
+    /// will need to get the type registry from the main world (you can clone the `AppTypeRegistry`
+    /// out of the world to avoid borrowing the world itself).
+    pub fn from_world_with(world: &World, type_registry: &TypeRegistry) -> Self {
+        DynamicSceneBuilder::from_world(world, type_registry)
             .extract_entities(
                 // we do this instead of a query, in order to completely sidestep default query filters.
                 // while we could use `Allow<_>`, this wouldn't account for custom disabled components
@@ -71,10 +93,8 @@ impl DynamicScene {
         &self,
         world: &mut World,
         entity_map: &mut EntityHashMap<Entity>,
-        type_registry: &AppTypeRegistry,
+        type_registry: &TypeRegistry,
     ) -> Result<(), SceneSpawnError> {
-        let type_registry = type_registry.read();
-
         // First ensure that every entity in the scene has a corresponding world
         // entity in the entity map.
         for scene_entity in &self.entities {
@@ -129,7 +149,7 @@ impl DynamicScene {
                     reflect_component.apply_or_insert_mapped(
                         &mut world.entity_mut(entity),
                         component.as_partial_reflect(),
-                        &type_registry,
+                        type_registry,
                         mapper,
                         RelationshipHookMode::Skip,
                     );
@@ -173,7 +193,7 @@ impl DynamicScene {
                 reflect_component.apply_or_insert_mapped(
                     &mut world.entity_mut(entity),
                     resource.as_partial_reflect(),
-                    &type_registry,
+                    type_registry,
                     mapper,
                     RelationshipHookMode::Skip,
                 );
@@ -194,7 +214,7 @@ impl DynamicScene {
         entity_map: &mut EntityHashMap<Entity>,
     ) -> Result<(), SceneSpawnError> {
         let registry = world.resource::<AppTypeRegistry>().clone();
-        self.write_to_world_with(world, entity_map, &registry)
+        self.write_to_world_with(world, entity_map, &registry.read())
     }
 
     // TODO: move to AssetSaver when it is implemented
@@ -250,11 +270,10 @@ mod tests {
 
     #[test]
     fn resource_entity_map_maps_entities() {
-        let type_registry = AppTypeRegistry::default();
-        type_registry.write().register::<TestResource>();
+        let app_type_registry = AppTypeRegistry::default();
+        app_type_registry.write().register::<TestResource>();
 
         let mut source_world = World::new();
-        source_world.insert_resource(type_registry.clone());
 
         let original_entity_a = source_world.spawn_empty().id();
         let original_entity_b = source_world.spawn_empty().id();
@@ -265,15 +284,18 @@ mod tests {
         });
 
         // Write the scene.
-        let scene = DynamicSceneBuilder::from_world(&source_world)
-            .extract_resources()
-            .extract_entity(original_entity_a)
-            .extract_entity(original_entity_b)
-            .build();
+        let scene = {
+            let type_registry = app_type_registry.read();
+            DynamicSceneBuilder::from_world(&source_world, &type_registry)
+                .extract_resources()
+                .extract_entity(original_entity_a)
+                .extract_entity(original_entity_b)
+                .build()
+        };
 
         let mut entity_map = EntityHashMap::default();
         let mut destination_world = World::new();
-        destination_world.insert_resource(type_registry);
+        destination_world.insert_resource(app_type_registry);
 
         scene
             .write_to_world(&mut destination_world, &mut entity_map)
@@ -306,10 +328,13 @@ mod tests {
 
         // We then write this relationship to a new scene, and then write that scene back to the
         // world to create another parent and child relationship
-        let scene = DynamicSceneBuilder::from_world(&world)
-            .extract_entity(original_parent_entity)
-            .extract_entity(original_child_entity)
-            .build();
+        let scene = {
+            let type_registry = world.resource::<AppTypeRegistry>().read();
+            DynamicSceneBuilder::from_world(&world, &type_registry)
+                .extract_entity(original_parent_entity)
+                .extract_entity(original_child_entity)
+                .build()
+        };
         let mut entity_map = EntityHashMap::default();
         scene.write_to_world(&mut world, &mut entity_map).unwrap();
 

--- a/crates/bevy_scene/src/dynamic_scene_builder.rs
+++ b/crates/bevy_scene/src/dynamic_scene_builder.rs
@@ -8,11 +8,11 @@ use bevy_ecs::{
     component::{Component, ComponentId},
     entity_disabling::DefaultQueryFilters,
     prelude::Entity,
-    reflect::{AppTypeRegistry, ReflectComponent, ReflectResource},
+    reflect::{ReflectComponent, ReflectResource},
     resource::Resource,
     world::World,
 };
-use bevy_reflect::PartialReflect;
+use bevy_reflect::{PartialReflect, TypeRegistry};
 use bevy_utils::default;
 
 /// A [`DynamicScene`] builder, used to build a scene from a [`World`] by extracting some entities and resources.
@@ -55,27 +55,46 @@ use bevy_utils::default;
 /// # let mut world = World::default();
 /// # world.init_resource::<AppTypeRegistry>();
 /// # let entity = world.spawn(ComponentA).id();
-/// let dynamic_scene = DynamicSceneBuilder::from_world(&world).extract_entity(entity).build();
+/// let type_registry = world.resource::<AppTypeRegistry>().read();
+/// let dynamic_scene = DynamicSceneBuilder::from_world(&world, &type_registry)
+///     .extract_entity(entity)
+///     .build();
 /// ```
 ///
+/// [`AppTypeRegistry`]: bevy_ecs::reflect::AppTypeRegistry
 /// [`Reflect`]: bevy_reflect::Reflect
 pub struct DynamicSceneBuilder<'w> {
+    /// The resources that have been extracted so far.
     extracted_resources: BTreeMap<ComponentId, Box<dyn PartialReflect>>,
+    /// The entities that have been extracted so far.
     extracted_scene: BTreeMap<Entity, DynamicEntity>,
+    /// The filter to determine which components extract.
     component_filter: SceneFilter,
+    /// The filter to determine which resources to extract.
     resource_filter: SceneFilter,
+    /// The world from which to build the scene.
     original_world: &'w World,
+    /// The type registry to use for extracting items from the world.
+    type_registry: &'w TypeRegistry,
 }
 
 impl<'w> DynamicSceneBuilder<'w> {
     /// Prepare a builder that will extract entities and their component from the given [`World`].
-    pub fn from_world(world: &'w World) -> Self {
+    ///
+    /// The `type_registry` provides type information for extracting components and resources
+    /// through reflection. If the `world` is the "real" world (e.g., not a world in a
+    /// [`Scene`](crate::Scene)), the `world` will contain the registry, which can be acquired using
+    /// `world.resource::<AppTypeRegistry>().read()`. For extracting from "scene worlds", you
+    /// will need to get the type registry from the main world (you can clone the `AppTypeRegistry`
+    /// out of the world to avoid borrowing the world itself).
+    pub fn from_world(world: &'w World, type_registry: &'w TypeRegistry) -> Self {
         Self {
             extracted_resources: default(),
             extracted_scene: default(),
             component_filter: SceneFilter::default(),
             resource_filter: SceneFilter::default(),
             original_world: world,
+            type_registry,
         }
     }
 
@@ -260,7 +279,8 @@ impl<'w> DynamicSceneBuilder<'w> {
     /// # let _entity = world.spawn(MyComponent).id();
     /// let mut query = world.query_filtered::<Entity, With<MyComponent>>();
     ///
-    /// let scene = DynamicSceneBuilder::from_world(&world)
+    /// let type_registry = world.resource::<AppTypeRegistry>().read();
+    /// let scene = DynamicSceneBuilder::from_world(&world, &type_registry)
     ///     .extract_entities(query.iter(&world))
     ///     .build();
     /// ```
@@ -271,8 +291,6 @@ impl<'w> DynamicSceneBuilder<'w> {
     /// [`deny`]: Self::deny_component
     #[must_use]
     pub fn extract_entities(mut self, entities: impl Iterator<Item = Entity>) -> Self {
-        let type_registry = self.original_world.resource::<AppTypeRegistry>().read();
-
         for entity in entities {
             if self.extracted_scene.contains_key(&entity) {
                 continue;
@@ -303,7 +321,7 @@ impl<'w> DynamicSceneBuilder<'w> {
                         return None;
                     }
 
-                    let type_registration = type_registry.get(type_id)?;
+                    let type_registration = self.type_registry.get(type_id)?;
 
                     let component = type_registration
                         .data::<ReflectComponent>()?
@@ -343,7 +361,9 @@ impl<'w> DynamicSceneBuilder<'w> {
     /// # world.init_resource::<AppTypeRegistry>();
     /// world.insert_resource(MyResource);
     ///
-    /// let mut builder = DynamicSceneBuilder::from_world(&world).extract_resources();
+    /// let type_registry = world.resource::<AppTypeRegistry>().read();
+    /// let mut builder = DynamicSceneBuilder::from_world(&world, &type_registry)
+    ///     .extract_resources();
     /// let scene = builder.build();
     /// ```
     ///
@@ -356,8 +376,6 @@ impl<'w> DynamicSceneBuilder<'w> {
             .original_world
             .components()
             .get_valid_id(TypeId::of::<DefaultQueryFilters>());
-
-        let type_registry = self.original_world.resource::<AppTypeRegistry>().read();
 
         for (component_id, entity) in self.original_world.resource_entities().iter() {
             if Some(*component_id) == original_world_dqf_id {
@@ -377,7 +395,7 @@ impl<'w> DynamicSceneBuilder<'w> {
                     return None;
                 }
 
-                let type_registration = type_registry.get(type_id)?;
+                let type_registration = self.type_registry.get(type_id)?;
 
                 type_registration.data::<ReflectResource>()?;
                 let component = type_registration
@@ -393,7 +411,6 @@ impl<'w> DynamicSceneBuilder<'w> {
             extract_and_push();
         }
 
-        drop(type_registry);
         self
     }
 }
@@ -404,11 +421,11 @@ mod tests {
         component::Component,
         prelude::{Entity, Resource},
         query::With,
-        reflect::{AppTypeRegistry, ReflectComponent, ReflectResource},
+        reflect::{ReflectComponent, ReflectResource},
         world::World,
     };
 
-    use bevy_reflect::Reflect;
+    use bevy_reflect::{Reflect, TypeRegistry};
 
     use super::DynamicSceneBuilder;
 
@@ -432,13 +449,12 @@ mod tests {
     fn extract_one_entity() {
         let mut world = World::default();
 
-        let atr = AppTypeRegistry::default();
-        atr.write().register::<ComponentA>();
-        world.insert_resource(atr);
+        let mut type_registry = TypeRegistry::default();
+        type_registry.register::<ComponentA>();
 
         let entity = world.spawn((ComponentA, ComponentB)).id();
 
-        let scene = DynamicSceneBuilder::from_world(&world)
+        let scene = DynamicSceneBuilder::from_world(&world, &type_registry)
             .extract_entity(entity)
             .build();
 
@@ -452,13 +468,12 @@ mod tests {
     fn extract_one_entity_twice() {
         let mut world = World::default();
 
-        let atr = AppTypeRegistry::default();
-        atr.write().register::<ComponentA>();
-        world.insert_resource(atr);
+        let mut type_registry = TypeRegistry::default();
+        type_registry.register::<ComponentA>();
 
         let entity = world.spawn((ComponentA, ComponentB)).id();
 
-        let scene = DynamicSceneBuilder::from_world(&world)
+        let scene = DynamicSceneBuilder::from_world(&world, &type_registry)
             .extract_entity(entity)
             .extract_entity(entity)
             .build();
@@ -473,17 +488,13 @@ mod tests {
     fn extract_one_entity_two_components() {
         let mut world = World::default();
 
-        let atr = AppTypeRegistry::default();
-        {
-            let mut register = atr.write();
-            register.register::<ComponentA>();
-            register.register::<ComponentB>();
-        }
-        world.insert_resource(atr);
+        let mut type_registry = TypeRegistry::default();
+        type_registry.register::<ComponentA>();
+        type_registry.register::<ComponentB>();
 
         let entity = world.spawn((ComponentA, ComponentB)).id();
 
-        let scene = DynamicSceneBuilder::from_world(&world)
+        let scene = DynamicSceneBuilder::from_world(&world, &type_registry)
             .extract_entity(entity)
             .build();
 
@@ -497,7 +508,6 @@ mod tests {
     #[test]
     fn extract_entity_order() {
         let mut world = World::default();
-        world.init_resource::<AppTypeRegistry>();
 
         // Spawn entities in order
         let entity_a = world.spawn_empty().id();
@@ -506,7 +516,8 @@ mod tests {
         let entity_d = world.spawn_empty().id();
 
         // Insert entities out of order
-        let builder = DynamicSceneBuilder::from_world(&world)
+        let type_registry = TypeRegistry::default();
+        let builder = DynamicSceneBuilder::from_world(&world, &type_registry)
             .extract_entity(entity_b)
             .extract_entities([entity_d, entity_a].into_iter())
             .extract_entity(entity_c);
@@ -524,20 +535,16 @@ mod tests {
     fn extract_query() {
         let mut world = World::default();
 
-        let atr = AppTypeRegistry::default();
-        {
-            let mut register = atr.write();
-            register.register::<ComponentA>();
-            register.register::<ComponentB>();
-        }
-        world.insert_resource(atr);
+        let mut type_registry = TypeRegistry::default();
+        type_registry.register::<ComponentA>();
+        type_registry.register::<ComponentB>();
 
         let entity_a_b = world.spawn((ComponentA, ComponentB)).id();
         let entity_a = world.spawn(ComponentA).id();
         let _entity_b = world.spawn(ComponentB).id();
 
         let mut query = world.query_filtered::<Entity, With<ComponentA>>();
-        let scene = DynamicSceneBuilder::from_world(&world)
+        let scene = DynamicSceneBuilder::from_world(&world, &type_registry)
             .extract_entities(query.iter(&world))
             .build();
 
@@ -551,14 +558,13 @@ mod tests {
     fn remove_componentless_entity() {
         let mut world = World::default();
 
-        let atr = AppTypeRegistry::default();
-        atr.write().register::<ComponentA>();
-        world.insert_resource(atr);
+        let mut type_registry = TypeRegistry::default();
+        type_registry.register::<ComponentA>();
 
         let entity_a = world.spawn(ComponentA).id();
         let entity_b = world.spawn(ComponentB).id();
 
-        let scene = DynamicSceneBuilder::from_world(&world)
+        let scene = DynamicSceneBuilder::from_world(&world, &type_registry)
             .extract_entities([entity_a, entity_b].into_iter())
             .remove_empty_entities()
             .build();
@@ -571,13 +577,12 @@ mod tests {
     fn extract_one_resource() {
         let mut world = World::default();
 
-        let atr = AppTypeRegistry::default();
-        atr.write().register::<ResourceA>();
-        world.insert_resource(atr);
+        let mut type_registry = TypeRegistry::default();
+        type_registry.register::<ResourceA>();
 
         world.insert_resource(ResourceA);
 
-        let scene = DynamicSceneBuilder::from_world(&world)
+        let scene = DynamicSceneBuilder::from_world(&world, &type_registry)
             .extract_resources()
             .build();
 
@@ -589,13 +594,12 @@ mod tests {
     fn extract_one_resource_twice() {
         let mut world = World::default();
 
-        let atr = AppTypeRegistry::default();
-        atr.write().register::<ResourceA>();
-        world.insert_resource(atr);
+        let mut type_registry = TypeRegistry::default();
+        type_registry.register::<ResourceA>();
 
         world.insert_resource(ResourceA);
 
-        let scene = DynamicSceneBuilder::from_world(&world)
+        let scene = DynamicSceneBuilder::from_world(&world, &type_registry)
             .extract_resources()
             .extract_resources()
             .build();
@@ -608,19 +612,15 @@ mod tests {
     fn should_extract_allowed_components() {
         let mut world = World::default();
 
-        let atr = AppTypeRegistry::default();
-        {
-            let mut register = atr.write();
-            register.register::<ComponentA>();
-            register.register::<ComponentB>();
-        }
-        world.insert_resource(atr);
+        let mut type_registry = TypeRegistry::default();
+        type_registry.register::<ComponentA>();
+        type_registry.register::<ComponentB>();
 
         let entity_a_b = world.spawn((ComponentA, ComponentB)).id();
         let entity_a = world.spawn(ComponentA).id();
         let entity_b = world.spawn(ComponentB).id();
 
-        let scene = DynamicSceneBuilder::from_world(&world)
+        let scene = DynamicSceneBuilder::from_world(&world, &type_registry)
             .allow_component::<ComponentA>()
             .extract_entities([entity_a_b, entity_a, entity_b].into_iter())
             .build();
@@ -635,19 +635,15 @@ mod tests {
     fn should_not_extract_denied_components() {
         let mut world = World::default();
 
-        let atr = AppTypeRegistry::default();
-        {
-            let mut register = atr.write();
-            register.register::<ComponentA>();
-            register.register::<ComponentB>();
-        }
-        world.insert_resource(atr);
+        let mut type_registry = TypeRegistry::default();
+        type_registry.register::<ComponentA>();
+        type_registry.register::<ComponentB>();
 
         let entity_a_b = world.spawn((ComponentA, ComponentB)).id();
         let entity_a = world.spawn(ComponentA).id();
         let entity_b = world.spawn(ComponentB).id();
 
-        let scene = DynamicSceneBuilder::from_world(&world)
+        let scene = DynamicSceneBuilder::from_world(&world, &type_registry)
             .deny_component::<ComponentA>()
             .extract_entities([entity_a_b, entity_a, entity_b].into_iter())
             .build();
@@ -662,18 +658,14 @@ mod tests {
     fn should_extract_allowed_resources() {
         let mut world = World::default();
 
-        let atr = AppTypeRegistry::default();
-        {
-            let mut register = atr.write();
-            register.register::<ResourceA>();
-            register.register::<ResourceB>();
-        }
-        world.insert_resource(atr);
+        let mut type_registry = TypeRegistry::default();
+        type_registry.register::<ResourceA>();
+        type_registry.register::<ResourceB>();
 
         world.insert_resource(ResourceA);
         world.insert_resource(ResourceB);
 
-        let scene = DynamicSceneBuilder::from_world(&world)
+        let scene = DynamicSceneBuilder::from_world(&world, &type_registry)
             .allow_resource::<ResourceA>()
             .extract_resources()
             .build();
@@ -686,18 +678,14 @@ mod tests {
     fn should_not_extract_denied_resources() {
         let mut world = World::default();
 
-        let atr = AppTypeRegistry::default();
-        {
-            let mut register = atr.write();
-            register.register::<ResourceA>();
-            register.register::<ResourceB>();
-        }
-        world.insert_resource(atr);
+        let mut type_registry = TypeRegistry::default();
+        type_registry.register::<ResourceA>();
+        type_registry.register::<ResourceB>();
 
         world.insert_resource(ResourceA);
         world.insert_resource(ResourceB);
 
-        let scene = DynamicSceneBuilder::from_world(&world)
+        let scene = DynamicSceneBuilder::from_world(&world, &type_registry)
             .deny_resource::<ResourceA>()
             .extract_resources()
             .build();
@@ -717,18 +705,14 @@ mod tests {
         struct SomeResource(i32);
 
         let mut world = World::default();
-        let atr = AppTypeRegistry::default();
-        {
-            let mut register = atr.write();
-            register.register::<SomeType>();
-            register.register::<SomeResource>();
-        }
-        world.insert_resource(atr);
+        let mut type_registry = TypeRegistry::default();
+        type_registry.register::<SomeType>();
+        type_registry.register::<SomeResource>();
 
         world.insert_resource(SomeResource(123));
         let entity = world.spawn(SomeType(123)).id();
 
-        let scene = DynamicSceneBuilder::from_world(&world)
+        let scene = DynamicSceneBuilder::from_world(&world, &type_registry)
             .extract_resources()
             .extract_entities(vec![entity].into_iter())
             .build();

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -310,11 +310,9 @@ mod tests {
         assert!(app.world().entity(scene_entity).get::<Children>().is_none());
 
         let create_dynamic_scene = |mut scene: Scene, world: &World| {
-            scene
-                .world
-                .insert_resource(world.resource::<AppTypeRegistry>().clone());
+            let type_registry = world.resource::<AppTypeRegistry>().read();
             let entities: Vec<Entity> = scene.world.query::<Entity>().iter(&scene.world).collect();
-            DynamicSceneBuilder::from_world(&scene.world)
+            DynamicSceneBuilder::from_world(&scene.world, &type_registry)
                 .extract_entities(entities.into_iter())
                 .build()
         };

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -12,7 +12,7 @@ use bevy_ecs::{
     relationship::RelationshipHookMode,
     world::World,
 };
-use bevy_reflect::TypePath;
+use bevy_reflect::{TypePath, TypeRegistry};
 
 /// A composition of [`World`] objects.
 ///
@@ -34,7 +34,7 @@ impl Scene {
     /// Create a new scene from a given dynamic scene.
     pub fn from_dynamic_scene(
         dynamic_scene: &DynamicScene,
-        type_registry: &AppTypeRegistry,
+        type_registry: &TypeRegistry,
     ) -> Result<Scene, SceneSpawnError> {
         let mut world = World::new();
         let mut entity_map = EntityHashMap::default();

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -752,10 +752,11 @@ mod tests {
         let mut scene_world = World::new();
 
         // create a new DynamicScene manually
-        let type_registry = app.world().resource::<AppTypeRegistry>().clone();
-        scene_world.insert_resource(type_registry);
         scene_world.spawn(ComponentA { x: 3.0, y: 4.0 });
-        let scene = DynamicScene::from_world(&scene_world);
+        let scene = DynamicScene::from_world_with(
+            &scene_world,
+            &app.world().resource::<AppTypeRegistry>().read(),
+        );
         let scene_handle = app
             .world_mut()
             .resource_mut::<Assets<DynamicScene>>()
@@ -822,9 +823,12 @@ mod tests {
             .query_filtered::<Entity, With<A>>()
             .single(&world)
             .unwrap();
-        let scene = DynamicSceneBuilder::from_world(&world)
-            .extract_entity(entity)
-            .build();
+        let scene = {
+            let type_registry = world.resource::<AppTypeRegistry>().read();
+            DynamicSceneBuilder::from_world(&world, &type_registry)
+                .extract_entity(entity)
+                .build()
+        };
 
         let scene_id = world.resource_mut::<Assets<DynamicScene>>().add(scene);
         let instance_id = scene_spawner
@@ -878,8 +882,11 @@ mod tests {
                  type_registry: Res<'_, AppTypeRegistry>,
                  asset_server: Res<'_, AssetServer>| {
                     asset_server.add(
-                        Scene::from_dynamic_scene(&DynamicScene::from_world(world), &type_registry)
-                            .unwrap(),
+                        Scene::from_dynamic_scene(
+                            &DynamicScene::from_world(world),
+                            &type_registry.read(),
+                        )
+                        .unwrap(),
                     )
                 },
             )
@@ -888,7 +895,7 @@ mod tests {
 
     fn build_dynamic_scene(app: &mut App) -> Handle<DynamicScene> {
         app.world_mut()
-            .run_system_once(|world: &World, asset_server: Res<'_, AssetServer>| {
+            .run_system_once(|world: &World, asset_server: Res<AssetServer>| {
                 asset_server.add(DynamicScene::from_world(world))
             })
             .expect("Failed to run dynamic scene builder system.")

--- a/crates/bevy_scene/src/serde.rs
+++ b/crates/bevy_scene/src/serde.rs
@@ -679,10 +679,13 @@ mod tests {
 
         world.insert_resource(MyResource { foo: 123 });
 
-        let scene = DynamicSceneBuilder::from_world(&world)
-            .extract_entities([a, b, c, d].into_iter())
-            .extract_resources()
-            .build();
+        let scene = {
+            let type_registry = world.resource::<AppTypeRegistry>().read();
+            DynamicSceneBuilder::from_world(&world, &type_registry)
+                .extract_entities([a, b, c, d].into_iter())
+                .extract_resources()
+                .build()
+        };
 
         let expected = r#"(
   resources: {

--- a/examples/scene/scene.rs
+++ b/examples/scene/scene.rs
@@ -165,17 +165,15 @@ fn log_system(
 /// and then serializes the resulting dynamic scene.
 fn save_scene_system(world: &mut World) {
     let asset_server = world.resource::<AssetServer>().clone();
+    // The `TypeRegistry` resource contains information about all registered types (including components).
+    // This is used to construct scenes, so we'll want to ensure that we use the registry from the
+    // main world. To do this, we can simply clone the `AppTypeRegistry` resource.
+    let type_registry = world.resource::<AppTypeRegistry>().clone();
+
     // Scenes can be created from any ECS World.
     // You can either create a new one for the scene or use the current World.
     // For demonstration purposes, we'll create a new one.
     let mut scene_world = World::new();
-
-    // The `TypeRegistry` resource contains information about all registered types (including components).
-    // This is used to construct scenes, so we'll want to ensure that our previous type registrations
-    // exist in this new scene world as well.
-    // To do this, we can simply clone the `AppTypeRegistry` resource.
-    let type_registry = world.resource::<AppTypeRegistry>().clone();
-    scene_world.insert_resource(type_registry);
 
     let mut component_b = ComponentB::from_world(world);
     component_b.value = "hello".to_string();
@@ -191,7 +189,7 @@ fn save_scene_system(world: &mut World) {
 
     // With our sample world ready to go, we can now create our scene using DynamicScene or DynamicSceneBuilder.
     // For simplicity, we will create our scene using DynamicScene:
-    let scene = DynamicScene::from_world(&scene_world);
+    let scene = DynamicScene::from_world_with(&scene_world, &type_registry.read());
 
     // Scenes can be serialized like this:
     let type_registry = world.resource::<AppTypeRegistry>();

--- a/release-content/migration-guides/scene_type_registry.md
+++ b/release-content/migration-guides/scene_type_registry.md
@@ -3,7 +3,7 @@ title: DynamicSceneBuilder and DynamicScene::from_scene now require a &TypeRegis
 pull_requests: [23401]
 ---
 
-Previously, `DynamicSceneBuilder` and `DynamicScene` would get the type registry out of the worlda
+Previously, `DynamicSceneBuilder` and `DynamicScene` would get the type registry out of the world
 being extracted. However, when building a world from scratch just for serialization, this required
 artificially cloning the registry and putting it in the world being saved.
 

--- a/release-content/migration-guides/scene_type_registry.md
+++ b/release-content/migration-guides/scene_type_registry.md
@@ -1,0 +1,53 @@
+---
+title: DynamicSceneBuilder and DynamicScene::from_scene now require a &TypeRegistry
+pull_requests: [23401]
+---
+
+Previously, `DynamicSceneBuilder` and `DynamicScene` would get the type registry out of the worlda
+being extracted. However, when building a world from scratch just for serialization, this required
+artificially cloning the registry and putting it in the world being saved.
+
+Now, `DynamicSceneBuilder` and `DynamicScene::from_scene` require an existing type registry. For
+example, before:
+
+```rust
+let world: &World = ...;
+let scene = DynamicSceneBuilder::from_world(world)
+    .extract_entity(e1)
+    .extract_entity(e2)
+    .extract_resources()
+    .build();
+```
+
+Becomes:
+
+```rust
+let world: &World = ...;
+let scene = {
+    let type_registry = world.resource::<AppTypeRegistry>().read();
+    DynamicSceneBuilder::from_world(world, &type_registry)
+        .extract_entity(e1)
+        .extract_entity(e2)
+        .extract_resources()
+        .build()
+};
+```
+
+For `DynamicScene::from_scene`, before:
+
+```rust
+let type_registry: AppTypeRegistry = get_from_main_world();
+let mut scene: Scene = ...;
+// Previously the scene world needed the type registry.
+scene.world.insert_resource(type_registry);
+let dynamic_scene = DynamicScene::from_scene(scene);
+```
+
+Becomes:
+
+```rust
+let type_registry: AppTypeRegistry = get_from_main_world();
+let scene: Scene = ...;
+// No need to insert into the scene!
+let dynamic_scene = DynamicScene::from_scene(scene, &type_registry.read());
+```


### PR DESCRIPTION
# Objective

- Previously, you needed to insert the type registry into the scene you're serializing, which results in weird behavior since some users are extracting the resources out of the scene (which would include the type registry).

## Solution

- Make the scene APIs explicitly take a type registry so that users are less likely to get it wrong, and no longer need to insert the registry into the world/scene being serialized.

## Testing

- Updated tests. Tests pass
- The scene example still works.
