### PR TITLE
Update default error handler to use `Severity`.

### DIFF
--- a/crates/bevy_ecs/src/error/handler.rs
+++ b/crates/bevy_ecs/src/error/handler.rs
@@ -1,6 +1,7 @@
 use core::fmt::Display;
 
 use crate::{change_detection::Tick, error::BevyError, prelude::Resource};
+use bevy_ecs::error::Severity;
 use bevy_utils::prelude::DebugName;
 use derive_more::derive::{Deref, DerefMut};
 
@@ -104,7 +105,7 @@ macro_rules! inner {
 pub type ErrorHandler = fn(BevyError, ErrorContext);
 
 /// Error handler to call when an error is not handled otherwise.
-/// Defaults to [`panic()`].
+/// Defaults to [`match_severity()`].
 ///
 /// When updated while a [`Schedule`] is running, it doesn't take effect for
 /// that schedule until it's completed.
@@ -115,7 +116,20 @@ pub struct DefaultErrorHandler(pub ErrorHandler);
 
 impl Default for DefaultErrorHandler {
     fn default() -> Self {
-        Self(panic)
+        Self(match_severity)
+    }
+}
+
+/// Error handler that defers to an error's [`Severity`].
+#[track_caller]
+#[inline]
+pub fn match_severity(err: BevyError, ctx: ErrorContext) {
+    match err.severity() {
+        Severity::Ignore => ignore(err, ctx),
+        Severity::Debug => debug(err, ctx),
+        Severity::Warning => warn(err, ctx),
+        Severity::Error => error(err, ctx),
+        Severity::Critical => panic(err, ctx),
     }
 }
 

--- a/crates/bevy_ecs/src/error/mod.rs
+++ b/crates/bevy_ecs/src/error/mod.rs
@@ -5,7 +5,7 @@
 //! variant of the returned `Result`.
 //!
 //! All [`BevyError`]s returned by a system, observer or command are handled by an "error handler". By default, the
-//! [`panic`] error handler function is used, resulting in a panic with the error message attached.
+//! [`match_severity`] error handler function is used, which defers to an error's [`Severity`].
 //!
 //! You can change the default behavior by registering a custom error handler:
 //! Use [`DefaultErrorHandler`] to set a custom error handler function for a world,
@@ -15,6 +15,7 @@
 //!
 //! Bevy provides a number of pre-built error-handlers for you to use:
 //!
+//! - [`match_severity`] defers to an error's [`Severity`], using one of the handlers listed below.
 //! - [`panic`] – panics with the system error
 //! - [`error`] – logs the system error at the `error` level
 //! - [`warn`] – logs the system error at the `warn` level


### PR DESCRIPTION
Followup to #22201. ~~Includes the changes in #23408, which is currently in the queue.~~

Adds a new default error handler that defers to an error's `Severity`.