### PR TITLE
Make the AI Policy more visible to newcomers

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -45,5 +45,5 @@ jobs:
               repo: context.repo.repo,
               body: `**Welcome**, new contributor!
 
-              Please make sure you've read our [contributing guide](https://bevy.org/learn/contribute/introduction) and we look forward to reviewing your pull request shortly ✨`
+              Please make sure you've read our [contributing guide](https://bevy.org/learn/contribute/introduction), as well as our [policy regarding AI usage](https://bevy.org/learn/contribute/policies/ai/), and we look forward to reviewing your pull request shortly ✨`
             })

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
 # Contributing to Bevy
 
 If you'd like to help build Bevy, start by reading this
-[introduction](https://bevy.org/learn/contribute/introduction). Thanks for contributing!
+[introduction](https://bevy.org/learn/contribute/introduction), as well as our [policy regarding AI usage](https://bevy.org/learn/contribute/policies/ai/). Thanks for contributing!


### PR DESCRIPTION
# Objective

We adopted an AI Policy regarding LLM assisted/generated PRs, but due to https://github.com/bevyengine/bevy/pull/23276 slipping through, it became clear this wasn't being surfaced to newcomers more easily, leading to some confusion.

So to alleviate concerns raised by https://github.com/bevyengine/bevy/issues/23418, we should rectify that.

## Solution

Simple, just link the AI Policy directly to newcomers. Links added to the welcoming message and the CONTRIBUTING.md should at least allow a more immediate notice to new contributors about our stance on AI usage/contributions.

Further work is updating the Introduction page on the website to also link to the AI Policy, perhaps with a more summarised explanation. If this policy is important, it needs to be aggressively linked to and mentioned so that readers find their way to it more easily.

## Testing

How do we test the welcoming message function? :smile: 

