### PR TITLE
Fix upscaling blend state auto-detection using render order instead of query iteration order

### DIFF
--- a/crates/bevy_core_pipeline/src/upscaling/mod.rs
+++ b/crates/bevy_core_pipeline/src/upscaling/mod.rs
@@ -2,7 +2,6 @@ use crate::blit::{BlitPipeline, BlitPipelineKey};
 use bevy_app::prelude::*;
 use bevy_camera::CameraOutputMode;
 use bevy_ecs::prelude::*;
-use bevy_platform::collections::HashSet;
 use bevy_render::{
     camera::ExtractedCamera, render_resource::*, view::ViewTarget, Render, RenderApp, RenderSystems,
 };
@@ -80,6 +79,8 @@ fn prepare_view_upscaling_pipelines(
         if maybe_pipeline.is_none_or(|ViewUpscalingPipeline(_, cached_key)| *cached_key != key) {
             let pipeline = pipelines.specialize(&pipeline_cache, &blit_pipeline, key);
 
+            // Ensure the pipeline is loaded before continuing the frame to prevent frames without
+            // any GPU work submitted
             pipeline_cache.block_on_render_pipeline(pipeline);
 
             commands


### PR DESCRIPTION
# Objective

`prepare_view_upscaling_pipelines` uses a `HashSet` to track which output textures have been seen during Query iteration, and assigns replace mode (`blend: None`) to the first camera seen for each output. Query iteration order is archetype-based and does not match camera render order (`ExtractedCamera::order`). It's not deterministic. A camera that renders *later* can be iterated *first*, get assigned replace mode, and overwrite the output of cameras that rendered before it.

As an example scenario, say you have three cameras targeting two outputs:

| Camera | `order` | Target | `blend_state` |
|--------|---------|--------|---------------|
| A | 0 | Image (intermediate) | `None` (auto) |
| B | 1 | Window | `Some(ALPHA_BLENDING)` |
| C | 2 | Window | `None` (auto) |

Camera B has a custom render graph node that writes to the window before its upscaling pass. Camera C is an overlay with transparent clear color.

Expected outcome: Camera C (auto-detect, second to the window by render order) gets alpha blending, preserving B's output.

Actual outcome: If C is iterated before B in the Query, C is the "first seen" for the window. It gets replace mode. At render time, C executes last (order 2) and overwrites B's output with transparent black.

## Solution

Use `ExtractedCamera::sorted_camera_index_for_target` (already computed in render order) instead of the `HashSet`-based first-seen heuristic. `blend_state: None` now correctly assigns replace mode only to the camera that actually renders first to each output target, rather than whichever camera happens to be iterated first in the ECS query. 


## Testing

Compiled and confirmed this patch solved the issue I experienced (similar to the example). 