### PR TITLE
recovery fallback image

### DIFF
--- a/crates/bevy_render/src/render_resource/texture.rs
+++ b/crates/bevy_render/src/render_resource/texture.rs
@@ -1,6 +1,9 @@
-use crate::renderer::WgpuWrapper;
+use crate::renderer::{RenderDevice, WgpuWrapper};
 use bevy_derive::{Deref, DerefMut};
-use bevy_ecs::resource::Resource;
+use bevy_ecs::{
+    resource::Resource,
+    world::{FromWorld, World},
+};
 use bevy_image::ImageSamplerDescriptor;
 use bevy_utils::define_atomic_id;
 use core::ops::Deref;
@@ -171,3 +174,13 @@ pub struct DefaultImageSamplerDescriptor(pub ImageSamplerDescriptor);
 /// image sampler.
 #[derive(Resource, Debug, Clone, Deref, DerefMut)]
 pub struct DefaultImageSampler(pub(crate) Sampler);
+
+impl FromWorld for DefaultImageSampler {
+    fn from_world(world: &mut World) -> Self {
+        let descriptor = world.resource::<DefaultImageSamplerDescriptor>();
+        let wgpu_descriptor = descriptor.as_wgpu();
+        let device = world.resource::<RenderDevice>();
+        let sampler = device.create_sampler(&wgpu_descriptor);
+        Self(sampler)
+    }
+}

--- a/crates/bevy_render/src/texture/mod.rs
+++ b/crates/bevy_render/src/texture/mod.rs
@@ -14,8 +14,8 @@ pub use texture_cache::*;
 
 use crate::{
     extract_resource::ExtractResourcePlugin, init_gpu_resource, render_asset::RenderAssetPlugin,
-    render_resource::DefaultImageSamplerDescriptor, renderer::RenderDevice, GpuResourceAppExt,
-    Render, RenderApp, RenderStartup, RenderSystems,
+    render_resource::DefaultImageSamplerDescriptor, GpuResourceAppExt, Render, RenderApp,
+    RenderStartup, RenderSystems,
 };
 use bevy_app::{App, Plugin};
 use bevy_asset::AssetApp;
@@ -66,7 +66,7 @@ impl Plugin for TexturePlugin {
             render_app.add_systems(
                 RenderStartup,
                 (
-                    init_default_image_sampler,
+                    init_gpu_resource::<DefaultImageSampler>,
                     init_gpu_resource::<FallbackImage>,
                     init_gpu_resource::<FallbackImageZero>,
                     init_gpu_resource::<FallbackImageCubemap>,
@@ -77,12 +77,4 @@ impl Plugin for TexturePlugin {
             );
         }
     }
-}
-
-fn init_default_image_sampler(world: &mut World) {
-    let descriptor = world.resource::<DefaultImageSamplerDescriptor>();
-    let wgpu_descriptor = descriptor.as_wgpu();
-    let device = world.resource::<RenderDevice>();
-    let sampler = device.create_sampler(&wgpu_descriptor);
-    world.insert_resource(DefaultImageSampler(sampler));
 }


### PR DESCRIPTION
# Objective

- Fallback image samplers need to be recreated on RenderDevice reset.
- Continue Render Recovery efforts #23350 #22761
- Part of goal https://github.com/bevyengine/bevy/issues/23029

## Solution

- They have a bit more involved ordering requirements, thats why I split them out to this PR.

## Testing

- ran some examples, and ambiguity detection
