### PR TITLE
Fix sparse buffer error on devices with low storage buffer limits

### DIFF
--- a/crates/bevy_render/src/render_resource/sparse_buffer_vec.rs
+++ b/crates/bevy_render/src/render_resource/sparse_buffer_vec.rs
@@ -16,7 +16,7 @@ use bevy_ecs::{
     system::{Res, ResMut},
     world::{FromWorld, World},
 };
-use bevy_log::{error, warn};
+use bevy_log::{error, info};
 use bevy_material::{
     bind_group_layout_entries::{
         binding_types::{storage_buffer, storage_buffer_read_only, uniform_buffer},


### PR DESCRIPTION
## Objective

Prevents a validation error where max_storage_buffers_per_shader_stage is less than 3 when using sparse buffers.

Fixes #23404

## Solution

 - Added a hardware limit check inside the `FromWorld` implementation for `SparseBufferUpdatePipelines`.
 - Wrapped the pipeline's layout and shader fields in Options.
 - Updated `AtomicSparseBufferVec::write_buffers` to pass the `RenderDevice `into the `should_perform_full_reupload` check. If the storage buffer limit is too low, the buffer now falls back to `write_entire_buffer`.

## Testing

- Did you test these changes? If so, how?
All commands below were ran with and without `WGPU_SETTINGS_PRIO=webgl2`:
cargo test -p bevy_render
cargo r --example 3d_gizmos --features free_camera
cargo r --example 3d_rotation
cargo r --example 3d_scene
cargo r --example 3d_shapes
cargo r --example 3d_text_gizmos
cargo r --example 3d_viewport_to_world 

- Are there any parts that need more testing?
Not that i reckon
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
Run the test written above
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?
Tested locally on Linux 6.19.8-1-cachyos using an NVIDIA RTX 4070 Super and an AMD Ryzen 9 9950X. Could not test on other systems or hardware.
