### PR TITLE
Change the order of arguments to `load_erased`.

### DIFF
--- a/crates/bevy_asset/src/reflect.rs
+++ b/crates/bevy_asset/src/reflect.rs
@@ -422,7 +422,7 @@ impl LoadFromPath for AssetServer {
         type_id: TypeId,
         path: AssetPath<'static>,
     ) -> UntypedHandle {
-        self.load_erased(path, type_id)
+        self.load_erased(type_id, path)
     }
 }
 

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -374,8 +374,8 @@ impl AssetServer {
     /// `type_id`.
     pub fn load_erased<'a>(
         &self,
-        path: impl Into<AssetPath<'a>>,
         type_id: TypeId,
+        path: impl Into<AssetPath<'a>>,
     ) -> UntypedHandle {
         self.load_erased_with_meta_transform(path, type_id, None, ())
     }


### PR DESCRIPTION
# Objective

- Requested by cart: https://discord.com/channels/691052431525675048/749332104487108618/1484705643330797678

## Solution

- Reorder the arguments of `load_erased`.
    - This makes it look more like `load` (the type comes first and then the path).
    - Paths could also be quite long, so it's nice to get the "short argument" out of the way first.
    
No migration guide because this was introduced in the 0.19 cycle.