### PR TITLE
Rename `load_from_path_untyped` to `load_from_path_erased`.

### DIFF
--- a/crates/bevy_asset/src/reflect.rs
+++ b/crates/bevy_asset/src/reflect.rs
@@ -399,15 +399,12 @@ pub trait LoadFromPath {
     /// Initiates the load for the given expected type ID, and the path.
     ///
     /// See [`AssetServer::load_erased`] for more.
-    fn load_from_path_untyped(
-        &mut self,
-        type_id: TypeId,
-        path: AssetPath<'static>,
-    ) -> UntypedHandle;
+    fn load_from_path_erased(&mut self, type_id: TypeId, path: AssetPath<'static>)
+        -> UntypedHandle;
 }
 
 impl LoadFromPath for LoadContext<'_> {
-    fn load_from_path_untyped(
+    fn load_from_path_erased(
         &mut self,
         type_id: TypeId,
         path: AssetPath<'static>,
@@ -417,7 +414,7 @@ impl LoadFromPath for LoadContext<'_> {
 }
 
 impl LoadFromPath for AssetServer {
-    fn load_from_path_untyped(
+    fn load_from_path_erased(
         &mut self,
         type_id: TypeId,
         path: AssetPath<'static>,
@@ -462,7 +459,7 @@ impl ReflectDeserializerProcessor for HandleDeserializeProcessor<'_> {
             let type_id = asset_type.type_id();
             return Ok(Ok(Box::new(match typed_handle_reference.reference {
                 HandleReference::Path(path) => {
-                    self.load_from_path.load_from_path_untyped(type_id, path)
+                    self.load_from_path.load_from_path_erased(type_id, path)
                 }
                 HandleReference::Uuid(uuid) => UntypedHandle::Uuid { type_id, uuid },
             })));
@@ -480,9 +477,7 @@ impl ReflectDeserializerProcessor for HandleDeserializeProcessor<'_> {
 
         let type_id = reflect_handle.asset_type_id;
         Ok(Ok(reflect_handle.typed(match handle_reference {
-            HandleReference::Path(path) => {
-                self.load_from_path.load_from_path_untyped(type_id, path)
-            }
+            HandleReference::Path(path) => self.load_from_path.load_from_path_erased(type_id, path),
             HandleReference::Uuid(uuid) => UntypedHandle::Uuid { type_id, uuid },
         })))
     }

--- a/crates/bevy_scene/src/serde.rs
+++ b/crates/bevy_scene/src/serde.rs
@@ -729,7 +729,7 @@ mod tests {
     struct FakeHandleCreator;
 
     impl LoadFromPath for FakeHandleCreator {
-        fn load_from_path_untyped(
+        fn load_from_path_erased(
             &mut self,
             _type_id: TypeId,
             _path: AssetPath<'static>,


### PR DESCRIPTION
# Objective

- Rename this method to match up with `load_erased`.
- Untyped loads are for loads that don't provide an expected type. That's not the case here!

## Solution

- Rename!

No migration guide because this was introduced in the 0.19 cycle.