### PR TITLE
Remove processed variants of fields from `AssetSourceBuilder`.

### DIFF
--- a/crates/bevy_asset/src/io/embedded/mod.rs
+++ b/crates/bevy_asset/src/io/embedded/mod.rs
@@ -86,52 +86,23 @@ impl EmbeddedAssetRegistry {
     /// Registers the [`EMBEDDED`] [`AssetSource`](crate::io::AssetSource) with the given [`AssetSourceBuilders`].
     pub fn register_source(&self, sources: &mut AssetSourceBuilders) {
         let dir = self.dir.clone();
-        let processed_dir = self.dir.clone();
 
-        #[cfg_attr(
-            not(feature = "embedded_watcher"),
-            expect(
-                unused_mut,
-                reason = "Variable is only mutated when `embedded_watcher` feature is enabled."
-            )
-        )]
-        let mut source =
-            AssetSourceBuilder::new(move || Box::new(MemoryAssetReader { root: dir.clone() }))
-                .with_processed_reader(move || {
-                    Box::new(MemoryAssetReader {
-                        root: processed_dir.clone(),
-                    })
-                })
-                // Note that we only add a processed watch warning because we don't want to warn
-                // noisily about embedded watching (which is niche) when users enable file watching.
-                .with_processed_watch_warning(
-                    "Consider enabling the `embedded_watcher` cargo feature.",
-                );
+        let source =
+            AssetSourceBuilder::new(move || Box::new(MemoryAssetReader { root: dir.clone() }));
 
         #[cfg(feature = "embedded_watcher")]
-        {
+        let source = {
             let root_paths = self.root_paths.clone();
             let dir = self.dir.clone();
-            let processed_root_paths = self.root_paths.clone();
-            let processed_dir = self.dir.clone();
-            source = source
-                .with_watcher(move |sender| {
-                    Some(Box::new(EmbeddedWatcher::new(
-                        dir.clone(),
-                        root_paths.clone(),
-                        sender,
-                        core::time::Duration::from_millis(300),
-                    )))
-                })
-                .with_processed_watcher(move |sender| {
-                    Some(Box::new(EmbeddedWatcher::new(
-                        processed_dir.clone(),
-                        processed_root_paths.clone(),
-                        sender,
-                        core::time::Duration::from_millis(300),
-                    )))
-                });
-        }
+            source.with_watcher(move |sender| {
+                Some(Box::new(EmbeddedWatcher::new(
+                    dir.clone(),
+                    root_paths.clone(),
+                    sender,
+                    core::time::Duration::from_millis(300),
+                )))
+            })
+        };
         sources.insert(EMBEDDED, source);
     }
 }

--- a/crates/bevy_asset/src/io/source.rs
+++ b/crates/bevy_asset/src/io/source.rs
@@ -307,7 +307,7 @@ impl AssetSourceBuilders {
         // Unprocessed sources are only built for processing them, so we hard-code watching their
         // assets to true.
         const WATCH: bool = true;
-        // We don't intend to write to the unprocessed sources, so we can avoid create the root
+        // We don't intend to write to the unprocessed sources, so we can avoid creating the root
         // directory for it.
         const CREATE_ROOT_FOR_WRITER: bool = false;
 
@@ -491,11 +491,12 @@ impl AssetSource {
         }
     }
 
-    /// Wraps the [`AssetReader`] so that [`AssetReader`] futures (such as [`AssetReader::read`] to
-    /// wait until the [`AssetProcessor`] has finished processing the requested asset.
+    /// Wraps the [`AssetReader`] so that [`AssetReader`] futures (such as [`AssetReader::read`])
+    /// will wait until the [`AssetProcessor`] has finished processing the requested asset.
     ///
     /// Returns the ungated reader to allow the [`AssetProcessor`] to read without blocking itself,
-    /// and the writer, as only the processor is allowed to write to a processed asset source.
+    /// and returns the writer, as only the processor is allowed to write to a processed asset
+    /// source.
     ///
     /// [`AssetReader`]: crate::io::AssetReader
     /// [`AssetReader::read`]: crate::io::AssetReader::read

--- a/crates/bevy_asset/src/io/source.rs
+++ b/crates/bevy_asset/src/io/source.rs
@@ -11,6 +11,7 @@ use atomicow::CowArc;
 use bevy_ecs::resource::Resource;
 use bevy_platform::collections::HashMap;
 use core::{fmt::Display, hash::Hash, time::Duration};
+use derive_more::{Deref, DerefMut};
 use thiserror::Error;
 use tracing::warn;
 
@@ -129,23 +130,8 @@ pub struct AssetSourceBuilder {
                 + Sync,
         >,
     >,
-    /// The [`ErasedAssetReader`] to use for processed assets.
-    pub processed_reader: Option<Box<dyn FnMut() -> Box<dyn ErasedAssetReader> + Send + Sync>>,
-    /// The [`ErasedAssetWriter`] to use for processed assets.
-    pub processed_writer:
-        Option<Box<dyn FnMut(bool) -> Option<Box<dyn ErasedAssetWriter>> + Send + Sync>>,
-    /// The [`AssetWatcher`] to use for processed assets, if any.
-    pub processed_watcher: Option<
-        Box<
-            dyn FnMut(async_channel::Sender<AssetSourceEvent>) -> Option<Box<dyn AssetWatcher>>
-                + Send
-                + Sync,
-        >,
-    >,
     /// The warning message to display when watching an unprocessed asset fails.
     pub watch_warning: Option<&'static str>,
-    /// The warning message to display when watching a processed asset fails.
-    pub processed_watch_warning: Option<&'static str>,
 }
 
 impl AssetSourceBuilder {
@@ -157,40 +143,28 @@ impl AssetSourceBuilder {
             reader: Box::new(reader),
             writer: None,
             watcher: None,
-            processed_reader: None,
-            processed_writer: None,
-            processed_watcher: None,
             watch_warning: None,
-            processed_watch_warning: None,
         }
     }
 
-    /// Builds a new [`AssetSource`] with the given `id`. If `watch` is true, the unprocessed source will watch for changes.
-    /// If `watch_processed` is true, the processed source will watch for changes.
+    /// Builds a new [`AssetSource`] with the given `id`.
+    ///
+    /// If `watch` is true, the source will watch for changes. If `create_root_for_writer`, the
+    /// source is told its writer should create the root directory (if it does not exist).
     pub fn build(
         &mut self,
         id: AssetSourceId<'static>,
         watch: bool,
-        watch_processed: bool,
+        create_root_for_writer: bool,
     ) -> AssetSource {
         let reader = self.reader.as_mut()().into();
-        let writer = self.writer.as_mut().and_then(|w| w(false));
-        let processed_writer = self.processed_writer.as_mut().and_then(|w| w(true));
+        let writer = self.writer.as_mut().and_then(|w| w(create_root_for_writer));
         let mut source = AssetSource {
             id: id.clone(),
             reader,
             writer,
-            processed_reader: self
-                .processed_reader
-                .as_mut()
-                .map(|r| r())
-                .map(Into::<Arc<_>>::into),
-            ungated_processed_reader: None,
-            processed_writer,
             event_receiver: None,
             watcher: None,
-            processed_event_receiver: None,
-            processed_watcher: None,
         };
 
         if watch {
@@ -208,20 +182,6 @@ impl AssetSourceBuilder {
             }
         }
 
-        if watch_processed {
-            let (sender, receiver) = async_channel::unbounded();
-            match self.processed_watcher.as_mut().and_then(|w| w(sender)) {
-                Some(w) => {
-                    source.processed_watcher = Some(w);
-                    source.processed_event_receiver = Some(receiver);
-                }
-                None => {
-                    if let Some(warning) = self.processed_watch_warning {
-                        warn!("{id} does not have a processed AssetWatcher configured. {warning}");
-                    }
-                }
-            }
-        }
         source
     }
 
@@ -255,71 +215,23 @@ impl AssetSourceBuilder {
         self
     }
 
-    /// Will use the given `reader` function to construct processed [`AssetReader`](crate::io::AssetReader) instances.
-    pub fn with_processed_reader(
-        mut self,
-        reader: impl FnMut() -> Box<dyn ErasedAssetReader> + Send + Sync + 'static,
-    ) -> Self {
-        self.processed_reader = Some(Box::new(reader));
-        self
-    }
-
-    /// Will use the given `writer` function to construct processed [`AssetWriter`](crate::io::AssetWriter) instances.
-    pub fn with_processed_writer(
-        mut self,
-        writer: impl FnMut(bool) -> Option<Box<dyn ErasedAssetWriter>> + Send + Sync + 'static,
-    ) -> Self {
-        self.processed_writer = Some(Box::new(writer));
-        self
-    }
-
-    /// Will use the given `watcher` function to construct processed [`AssetWatcher`] instances.
-    pub fn with_processed_watcher(
-        mut self,
-        watcher: impl FnMut(async_channel::Sender<AssetSourceEvent>) -> Option<Box<dyn AssetWatcher>>
-            + Send
-            + Sync
-            + 'static,
-    ) -> Self {
-        self.processed_watcher = Some(Box::new(watcher));
-        self
-    }
-
     /// Enables a warning for the unprocessed source watcher, which will print when watching is enabled and the unprocessed source doesn't have a watcher.
     pub fn with_watch_warning(mut self, warning: &'static str) -> Self {
         self.watch_warning = Some(warning);
         self
     }
 
-    /// Enables a warning for the processed source watcher, which will print when watching is enabled and the processed source doesn't have a watcher.
-    pub fn with_processed_watch_warning(mut self, warning: &'static str) -> Self {
-        self.processed_watch_warning = Some(warning);
-        self
-    }
-
     /// Returns a builder containing the "platform default source" for the given `path` and `processed_path`.
     /// For most platforms, this will use [`FileAssetReader`](crate::io::file::FileAssetReader) / [`FileAssetWriter`](crate::io::file::FileAssetWriter),
     /// but some platforms (such as Android) have their own default readers / writers / watchers.
-    pub fn platform_default(path: &str, processed_path: Option<&str>) -> Self {
-        let default = Self::new(AssetSource::get_default_reader(path.to_string()))
+    pub fn platform_default(path: &str) -> Self {
+        Self::new(AssetSource::get_default_reader(path.to_string()))
             .with_writer(AssetSource::get_default_writer(path.to_string()))
             .with_watcher(AssetSource::get_default_watcher(
                 path.to_string(),
                 Duration::from_millis(300),
             ))
-            .with_watch_warning(AssetSource::get_default_watch_warning());
-        if let Some(processed_path) = processed_path {
-            default
-                .with_processed_reader(AssetSource::get_default_reader(processed_path.to_string()))
-                .with_processed_writer(AssetSource::get_default_writer(processed_path.to_string()))
-                .with_processed_watcher(AssetSource::get_default_watcher(
-                    processed_path.to_string(),
-                    Duration::from_millis(300),
-                ))
-                .with_processed_watch_warning(AssetSource::get_default_watch_warning())
-        } else {
-            default
-        }
+            .with_watch_warning(AssetSource::get_default_watch_warning())
     }
 }
 
@@ -344,6 +256,14 @@ impl AssetSourceBuilders {
         }
     }
 
+    /// Returns whether there is currently a builder for the given `id`.
+    pub fn contains<'b>(&self, id: impl Into<AssetSourceId<'b>>) -> bool {
+        match id.into() {
+            AssetSourceId::Default => self.default.is_some(),
+            AssetSourceId::Name(name) => self.sources.contains_key(&name),
+        }
+    }
+
     /// Gets a mutable builder with the given `id`, if it exists.
     pub fn get_mut<'a, 'b>(
         &'a mut self,
@@ -355,15 +275,17 @@ impl AssetSourceBuilders {
         }
     }
 
-    /// Builds a new [`AssetSources`] collection. If `watch` is true, the unprocessed sources will watch for changes.
-    /// If `watch_processed` is true, the processed sources will watch for changes.
-    pub fn build_sources(&mut self, watch: bool, watch_processed: bool) -> AssetSources {
+    /// Builds a new [`AssetSources`] collection.
+    ///
+    /// If `watch` is true, the sources will watch for changes. If `create_root_for_writer` is true,
+    /// the sources are told their writers should create the root directory (if it does not exist).
+    pub fn build_sources(&mut self, watch: bool, create_root_for_writer: bool) -> AssetSources {
         let mut sources = <HashMap<_, _>>::default();
         for (id, source) in &mut self.sources {
             let source = source.build(
                 AssetSourceId::Name(id.clone_owned()),
                 watch,
-                watch_processed,
+                create_root_for_writer,
             );
             sources.insert(id.clone_owned(), source);
         }
@@ -373,17 +295,59 @@ impl AssetSourceBuilders {
             default: self
                 .default
                 .as_mut()
-                .map(|p| p.build(AssetSourceId::Default, watch, watch_processed))
+                .map(|p| p.build(AssetSourceId::Default, watch, create_root_for_writer))
                 .expect(MISSING_DEFAULT_SOURCE),
         }
     }
 
+    /// Builds these sources to be used as unprocessed sources which we intend to process.
+    pub(crate) fn build_unprocessed_sources(
+        &mut self,
+    ) -> HashMap<AssetSourceId<'static>, AssetSource> {
+        // Unprocessed sources are only built for processing them, so we hard-code watching their
+        // assets to true.
+        const WATCH: bool = true;
+        // We don't intend to write to the unprocessed sources, so we can avoid create the root
+        // directory for it.
+        const CREATE_ROOT_FOR_WRITER: bool = false;
+
+        let mut sources = HashMap::default();
+        for (id, source) in &mut self.sources {
+            let source = source.build(
+                AssetSourceId::Name(id.clone_owned()),
+                WATCH,
+                CREATE_ROOT_FOR_WRITER,
+            );
+            sources.insert(AssetSourceId::Name(id.clone_owned()), source);
+        }
+
+        if let Some(default) = self.default.as_mut() {
+            sources.insert(
+                AssetSourceId::Default,
+                default.build(AssetSourceId::Default, WATCH, CREATE_ROOT_FOR_WRITER),
+            );
+        }
+
+        sources
+    }
+
     /// Initializes the default [`AssetSourceBuilder`] if it has not already been set.
-    pub fn init_default_source(&mut self, path: &str, processed_path: Option<&str>) {
+    pub fn init_default_source(&mut self, path: &str) {
         self.default
-            .get_or_insert_with(|| AssetSourceBuilder::platform_default(path, processed_path));
+            .get_or_insert_with(|| AssetSourceBuilder::platform_default(path));
+    }
+
+    pub(crate) fn ids<'a>(&'a self) -> impl Iterator<Item = AssetSourceId<'a>> {
+        self.default
+            .is_some()
+            .then_some(AssetSourceId::Default)
+            .into_iter()
+            .chain(self.sources.keys().cloned().map(AssetSourceId::Name))
     }
 }
+
+#[derive(Resource, Default, Deref, DerefMut)]
+pub(crate) struct UnprocessedAssetSourceBuilders(pub(crate) AssetSourceBuilders);
 
 /// A collection of unprocessed and processed [`AssetReader`](crate::io::AssetReader), [`AssetWriter`](crate::io::AssetWriter), and [`AssetWatcher`] instances
 /// for a specific asset source, identified by an [`AssetSourceId`].
@@ -391,17 +355,8 @@ pub struct AssetSource {
     id: AssetSourceId<'static>,
     reader: Arc<dyn ErasedAssetReader>,
     writer: Option<Box<dyn ErasedAssetWriter>>,
-    processed_reader: Option<Arc<dyn ErasedAssetReader>>,
-    /// The ungated version of `processed_reader`.
-    ///
-    /// This allows the processor to read all the processed assets to initialize itself without
-    /// being gated on itself (causing a deadlock).
-    ungated_processed_reader: Option<Arc<dyn ErasedAssetReader>>,
-    processed_writer: Option<Box<dyn ErasedAssetWriter>>,
     watcher: Option<Box<dyn AssetWatcher>>,
-    processed_watcher: Option<Box<dyn AssetWatcher>>,
     event_receiver: Option<async_channel::Receiver<AssetSourceEvent>>,
-    processed_event_receiver: Option<async_channel::Receiver<AssetSourceEvent>>,
 }
 
 impl AssetSource {
@@ -425,49 +380,10 @@ impl AssetSource {
             .ok_or_else(|| MissingAssetWriterError(self.id.clone_owned()))
     }
 
-    /// Return's this source's processed [`AssetReader`](crate::io::AssetReader), if it exists.
-    #[inline]
-    pub fn processed_reader(
-        &self,
-    ) -> Result<&dyn ErasedAssetReader, MissingProcessedAssetReaderError> {
-        self.processed_reader
-            .as_deref()
-            .ok_or_else(|| MissingProcessedAssetReaderError(self.id.clone_owned()))
-    }
-
-    /// Return's this source's ungated processed [`AssetReader`](crate::io::AssetReader), if it
-    /// exists.
-    #[inline]
-    pub(crate) fn ungated_processed_reader(&self) -> Option<&dyn ErasedAssetReader> {
-        self.ungated_processed_reader.as_deref()
-    }
-
-    /// Return's this source's processed [`AssetWriter`](crate::io::AssetWriter), if it exists.
-    #[inline]
-    pub fn processed_writer(
-        &self,
-    ) -> Result<&dyn ErasedAssetWriter, MissingProcessedAssetWriterError> {
-        self.processed_writer
-            .as_deref()
-            .ok_or_else(|| MissingProcessedAssetWriterError(self.id.clone_owned()))
-    }
-
     /// Return's this source's unprocessed event receiver, if the source is currently watching for changes.
     #[inline]
     pub fn event_receiver(&self) -> Option<&async_channel::Receiver<AssetSourceEvent>> {
         self.event_receiver.as_ref()
-    }
-
-    /// Return's this source's processed event receiver, if the source is currently watching for changes.
-    #[inline]
-    pub fn processed_event_receiver(&self) -> Option<&async_channel::Receiver<AssetSourceEvent>> {
-        self.processed_event_receiver.as_ref()
-    }
-
-    /// Returns true if the assets in this source should be processed.
-    #[inline]
-    pub fn should_process(&self) -> bool {
-        self.processed_writer.is_some()
     }
 
     /// Returns a builder function for this platform's default [`AssetReader`](crate::io::AssetReader). `path` is the relative path to
@@ -575,17 +491,30 @@ impl AssetSource {
         }
     }
 
-    /// This will cause processed [`AssetReader`](crate::io::AssetReader) futures (such as [`AssetReader::read`](crate::io::AssetReader::read)) to wait until
-    /// the [`AssetProcessor`](crate::AssetProcessor) has finished processing the requested asset.
-    pub(crate) fn gate_on_processor(&mut self, processing_state: Arc<ProcessingState>) {
-        if let Some(reader) = self.processed_reader.take() {
-            self.ungated_processed_reader = Some(reader.clone());
-            self.processed_reader = Some(Arc::new(ProcessorGatedReader::new(
-                self.id(),
-                reader,
-                processing_state,
-            )));
-        }
+    /// Wraps the [`AssetReader`] so that [`AssetReader`] futures (such as [`AssetReader::read`] to
+    /// wait until the [`AssetProcessor`] has finished processing the requested asset.
+    ///
+    /// Returns the ungated reader to allow the [`AssetProcessor`] to read without blocking itself,
+    /// and the writer, as only the processor is allowed to write to a processed asset source.
+    ///
+    /// [`AssetReader`]: crate::io::AssetReader
+    /// [`AssetReader::read`]: crate::io::AssetReader::read
+    /// [`AssetProcessor`]: crate::AssetProcessor
+    pub(crate) fn gate_on_processor(
+        &mut self,
+        processing_state: Arc<ProcessingState>,
+    ) -> (Arc<dyn ErasedAssetReader>, Box<dyn ErasedAssetWriter>) {
+        let reader = self.reader.clone();
+        self.reader = Arc::new(ProcessorGatedReader::new(
+            self.id(),
+            reader.clone(),
+            processing_state,
+        ));
+        let writer = self
+            .writer
+            .take()
+            .expect("processed asset sources must include a writer");
+        (reader, writer)
     }
 }
 
@@ -610,6 +539,20 @@ impl AssetSources {
         }
     }
 
+    /// Gets the [`AssetSource`] mutably with the given `id`, if it exists.
+    fn get_mut<'a, 'b>(
+        &'a mut self,
+        id: impl Into<AssetSourceId<'b>>,
+    ) -> Result<&'a mut AssetSource, MissingAssetSourceError> {
+        match id.into().into_owned() {
+            AssetSourceId::Default => Ok(&mut self.default),
+            AssetSourceId::Name(name) => self
+                .sources
+                .get_mut(&name)
+                .ok_or(MissingAssetSourceError(AssetSourceId::Name(name))),
+        }
+    }
+
     /// Iterates all asset sources in the collection (including the default source).
     pub fn iter(&self) -> impl Iterator<Item = &AssetSource> {
         self.sources.values().chain(Some(&self.default))
@@ -620,16 +563,6 @@ impl AssetSources {
         self.sources.values_mut().chain(Some(&mut self.default))
     }
 
-    /// Iterates all processed asset sources in the collection (including the default source).
-    pub fn iter_processed(&self) -> impl Iterator<Item = &AssetSource> {
-        self.iter().filter(|p| p.should_process())
-    }
-
-    /// Mutably iterates all processed asset sources in the collection (including the default source).
-    pub fn iter_processed_mut(&mut self) -> impl Iterator<Item = &mut AssetSource> {
-        self.iter_mut().filter(|p| p.should_process())
-    }
-
     /// Iterates over the [`AssetSourceId`] of every [`AssetSource`] in the collection (including the default source).
     pub fn ids(&self) -> impl Iterator<Item = AssetSourceId<'static>> + '_ {
         self.sources
@@ -638,19 +571,40 @@ impl AssetSources {
             .chain(Some(AssetSourceId::Default))
     }
 
-    /// This will cause processed [`AssetReader`](crate::io::AssetReader) futures (such as [`AssetReader::read`](crate::io::AssetReader::read)) to wait until
-    /// the [`AssetProcessor`](crate::AssetProcessor) has finished processing the requested asset.
-    pub(crate) fn gate_on_processor(&mut self, processing_state: Arc<ProcessingState>) {
-        for source in self.iter_processed_mut() {
-            source.gate_on_processor(processing_state.clone());
+    /// Wraps the [`AssetReader`] of every source in `self` with a corresponding entry in
+    /// `unprocessed_sources`, so that [`AssetReader`] futures (such as [`AssetReader::read`] wait
+    /// until the [`AssetProcessor`] has finished processing the requested asset.
+    ///
+    /// Panics if there is a source in `unprocessed_sources` without a corresponding source in
+    /// `self`.
+    ///
+    /// Returns the ungated reader and the writer for each processed source.
+    ///
+    /// [`AssetReader`]: crate::io::AssetReader
+    /// [`AssetReader::read`]: crate::io::AssetReader::read
+    /// [`AssetProcessor`]: crate::AssetProcessor
+    pub(crate) fn gate_on_processor(
+        &mut self,
+        unprocessed_sources: &HashMap<AssetSourceId<'static>, AssetSource>,
+        processing_state: Arc<ProcessingState>,
+    ) -> HashMap<AssetSourceId<'static>, (Arc<dyn ErasedAssetReader>, Box<dyn ErasedAssetWriter>)>
+    {
+        let mut source_id_to_ungated_reader_and_writer = HashMap::new();
+        for (id, _) in unprocessed_sources.iter() {
+            let ungated_reader_and_writer = self
+                .get_mut(id)
+                .expect("every unprocessed source should have a corresponding final source")
+                .gate_on_processor(processing_state.clone());
+            source_id_to_ungated_reader_and_writer.insert(id.clone(), ungated_reader_and_writer);
         }
+        source_id_to_ungated_reader_and_writer
     }
 }
 
 /// An error returned when an [`AssetSource`] does not exist for a given id.
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
 #[error("Asset Source '{0}' does not exist")]
-pub struct MissingAssetSourceError(AssetSourceId<'static>);
+pub struct MissingAssetSourceError(pub(crate) AssetSourceId<'static>);
 
 /// An error returned when an [`AssetWriter`](crate::io::AssetWriter) does not exist for a given id.
 #[derive(Error, Debug, Clone)]

--- a/crates/bevy_asset/src/io/source.rs
+++ b/crates/bevy_asset/src/io/source.rs
@@ -300,8 +300,8 @@ impl AssetSourceBuilders {
         }
     }
 
-    /// Builds these sources to be used as unprocessed sources which we intend to process.
-    pub(crate) fn build_unprocessed_sources(
+    /// Builds these sources to be used as sources which we intend to process.
+    pub(crate) fn build_as_sources_to_process(
         &mut self,
     ) -> HashMap<AssetSourceId<'static>, AssetSource> {
         // Unprocessed sources are only built for processing them, so we hard-code watching their
@@ -346,8 +346,10 @@ impl AssetSourceBuilders {
     }
 }
 
+/// The collection of asset sources that will be processed by
+/// [`AssetProcessor`](crate::AssetProcessor).
 #[derive(Resource, Default, Deref, DerefMut)]
-pub(crate) struct UnprocessedAssetSourceBuilders(pub(crate) AssetSourceBuilders);
+pub(crate) struct AssetSourceBuildersToProcess(pub(crate) AssetSourceBuilders);
 
 /// A collection of unprocessed and processed [`AssetReader`](crate::io::AssetReader), [`AssetWriter`](crate::io::AssetWriter), and [`AssetWatcher`] instances
 /// for a specific asset source, identified by an [`AssetSourceId`].
@@ -573,10 +575,10 @@ impl AssetSources {
     }
 
     /// Wraps the [`AssetReader`] of every source in `self` with a corresponding entry in
-    /// `unprocessed_sources`, so that [`AssetReader`] futures (such as [`AssetReader::read`] wait
+    /// `sources_to_process`, so that [`AssetReader`] futures (such as [`AssetReader::read`] wait
     /// until the [`AssetProcessor`] has finished processing the requested asset.
     ///
-    /// Panics if there is a source in `unprocessed_sources` without a corresponding source in
+    /// Panics if there is a source in `sources_to_process` without a corresponding source in
     /// `self`.
     ///
     /// Returns the ungated reader and the writer for each processed source.
@@ -586,15 +588,15 @@ impl AssetSources {
     /// [`AssetProcessor`]: crate::AssetProcessor
     pub(crate) fn gate_on_processor(
         &mut self,
-        unprocessed_sources: &HashMap<AssetSourceId<'static>, AssetSource>,
+        sources_to_process: &HashMap<AssetSourceId<'static>, AssetSource>,
         processing_state: Arc<ProcessingState>,
     ) -> HashMap<AssetSourceId<'static>, (Arc<dyn ErasedAssetReader>, Box<dyn ErasedAssetWriter>)>
     {
         let mut source_id_to_ungated_reader_and_writer = HashMap::new();
-        for (id, _) in unprocessed_sources.iter() {
+        for (id, _) in sources_to_process.iter() {
             let ungated_reader_and_writer = self
                 .get_mut(id)
-                .expect("every unprocessed source should have a corresponding final source")
+                .expect("every source to process should have a corresponding final source")
                 .gate_on_processor(processing_state.clone());
             source_id_to_ungated_reader_and_writer.insert(id.clone(), ungated_reader_and_writer);
         }

--- a/crates/bevy_asset/src/io/source.rs
+++ b/crates/bevy_asset/src/io/source.rs
@@ -173,7 +173,7 @@ impl AssetSourceBuilder {
         watch: bool,
         watch_processed: bool,
     ) -> AssetSource {
-        let reader = self.reader.as_mut()();
+        let reader = self.reader.as_mut()().into();
         let writer = self.writer.as_mut().and_then(|w| w(false));
         let processed_writer = self.processed_writer.as_mut().and_then(|w| w(true));
         let mut source = AssetSource {
@@ -389,7 +389,7 @@ impl AssetSourceBuilders {
 /// for a specific asset source, identified by an [`AssetSourceId`].
 pub struct AssetSource {
     id: AssetSourceId<'static>,
-    reader: Box<dyn ErasedAssetReader>,
+    reader: Arc<dyn ErasedAssetReader>,
     writer: Option<Box<dyn ErasedAssetWriter>>,
     processed_reader: Option<Arc<dyn ErasedAssetReader>>,
     /// The ungated version of `processed_reader`.

--- a/crates/bevy_asset/src/io/web.rs
+++ b/crates/bevy_asset/src/io/web.rs
@@ -72,15 +72,13 @@ impl Plugin for WebAssetPlugin {
         #[cfg(feature = "http")]
         app.register_asset_source(
             "http",
-            AssetSourceBuilder::new(move || Box::new(WebAssetReader::Http))
-                .with_processed_reader(move || Box::new(WebAssetReader::Http)),
+            AssetSourceBuilder::new(move || Box::new(WebAssetReader::Http)),
         );
 
         #[cfg(feature = "https")]
         app.register_asset_source(
             "https",
-            AssetSourceBuilder::new(move || Box::new(WebAssetReader::Https))
-                .with_processed_reader(move || Box::new(WebAssetReader::Https)),
+            AssetSourceBuilder::new(move || Box::new(WebAssetReader::Https)),
         );
     }
 }

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -205,10 +205,14 @@ pub use server::*;
 pub use uuid;
 
 use crate::{
-    io::{embedded::EmbeddedAssetRegistry, AssetSourceBuilder, AssetSourceBuilders, AssetSourceId},
+    io::{
+        embedded::EmbeddedAssetRegistry, AssetSourceBuilder, AssetSourceBuilders, AssetSourceId,
+        UnprocessedAssetSourceBuilders,
+    },
     processor::{AssetProcessor, Process},
 };
 use alloc::{
+    format,
     string::{String, ToString},
     sync::Arc,
     vec::Vec,
@@ -223,7 +227,8 @@ use bevy_ecs::{
 use bevy_platform::collections::HashSet;
 use bevy_reflect::{FromReflect, GetTypeRegistration, Reflect, TypePath};
 use core::any::TypeId;
-use tracing::error;
+use std::path::Path;
+use tracing::{error, warn};
 
 /// Provides "asset" loading and processing functionality. An [`Asset`] is a "runtime value" that is loaded from an [`AssetSource`],
 /// which can be something like a filesystem, a network, etc.
@@ -344,72 +349,133 @@ impl Default for AssetPlugin {
 
 impl AssetPlugin {
     const DEFAULT_UNPROCESSED_FILE_PATH: &'static str = "assets";
-    /// NOTE: this is in the Default sub-folder to make this forward compatible with "import profiles"
-    /// and to allow us to put the "processor transaction log" at `imported_assets/log`
-    const DEFAULT_PROCESSED_FILE_PATH: &'static str = "imported_assets/Default";
+    const DEFAULT_PROCESSED_FILE_PATH: &'static str = "imported_assets";
 }
 
 impl Plugin for AssetPlugin {
     fn build(&self, app: &mut App) {
+        // Create the default asset source as a "final" source when in unprocessed mode, and an
+        // "unprocessed" source (whose final source is created later) in processed mode.
+        match self.mode {
+            AssetMode::Unprocessed => {
+                let mut sources = app
+                    .world_mut()
+                    .get_resource_or_init::<AssetSourceBuilders>();
+                sources.init_default_source(&self.file_path);
+            }
+            AssetMode::Processed => {
+                // Only (try to) register the default source as processed if the user hasn't set the
+                // default source to be unprocessed.
+                if !app
+                    .world()
+                    .get_resource::<AssetSourceBuilders>()
+                    .map(|sources| sources.contains(AssetSourceId::Default))
+                    .unwrap_or(false)
+                {
+                    let mut sources = app
+                        .world_mut()
+                        .get_resource_or_init::<UnprocessedAssetSourceBuilders>();
+                    sources.init_default_source(&self.file_path);
+                }
+            }
+        }
         let embedded = EmbeddedAssetRegistry::default();
         {
             let mut sources = app
                 .world_mut()
                 .get_resource_or_init::<AssetSourceBuilders>();
-            sources.init_default_source(
-                &self.file_path,
-                (!matches!(self.mode, AssetMode::Unprocessed))
-                    .then_some(self.processed_file_path.as_str()),
-            );
             embedded.register_source(&mut sources);
         }
         {
             let watch = self
                 .watch_for_changes_override
                 .unwrap_or(cfg!(feature = "watch"));
-            match self.mode {
-                AssetMode::Unprocessed => {
-                    let mut builders = app.world_mut().resource_mut::<AssetSourceBuilders>();
-                    let sources = builders.build_sources(watch, false);
+            let use_asset_processor = self
+                .use_asset_processor_override
+                .unwrap_or(cfg!(feature = "asset_processor"));
 
-                    app.insert_resource(AssetServer::new_with_meta_check(
-                        Arc::new(sources),
-                        AssetServerMode::Unprocessed,
-                        self.meta_check.clone(),
-                        watch,
-                        self.unapproved_path_mode.clone(),
-                    ));
-                }
+            match self.mode {
                 AssetMode::Processed => {
-                    let use_asset_processor = self
-                        .use_asset_processor_override
-                        .unwrap_or(cfg!(feature = "asset_processor"));
-                    if use_asset_processor {
-                        let mut builders = app.world_mut().resource_mut::<AssetSourceBuilders>();
-                        let (processor, sources) = AssetProcessor::new(&mut builders, watch);
-                        // the main asset server shares loaders with the processor asset server
-                        app.insert_resource(AssetServer::new_with_loaders(
-                            sources,
-                            processor.server().data.loaders.clone(),
-                            AssetServerMode::Processed,
-                            AssetMetaCheck::Always,
-                            watch,
-                            self.unapproved_path_mode.clone(),
-                        ))
-                        .insert_resource(processor)
-                        .add_systems(bevy_app::Startup, AssetProcessor::start);
-                    } else {
-                        let mut builders = app.world_mut().resource_mut::<AssetSourceBuilders>();
-                        let sources = builders.build_sources(false, watch);
-                        app.insert_resource(AssetServer::new_with_meta_check(
-                            Arc::new(sources),
-                            AssetServerMode::Processed,
-                            AssetMetaCheck::Always,
-                            watch,
-                            self.unapproved_path_mode.clone(),
-                        ));
+                    // Create the final sources for any sources that need to be processed.
+                    app.world_mut()
+                        .try_resource_scope::<UnprocessedAssetSourceBuilders, _>(
+                            |world, unprocessed_sources| {
+                                let mut final_sources =
+                                    world.get_resource_or_init::<AssetSourceBuilders>();
+                                // Create the corresponding "processed" source for each unprocessed source in the final
+                                // sources.
+                                let create_processed_source = |id: &AssetSourceId<'_>| {
+                                    // Let the lifetime live longer while joining the paths.
+                                    let child_path;
+                                    AssetSourceBuilder::platform_default(
+                                        Path::new(&self.processed_file_path)
+                                            .join(match id {
+                                                AssetSourceId::Default => "Default",
+                                                AssetSourceId::Name(name) => {
+                                                    child_path = format!("Name/{name}");
+                                                    &child_path
+                                                }
+                                            })
+                                            .to_str()
+                                            .unwrap(),
+                                    )
+                                };
+                                for id in unprocessed_sources.ids() {
+                                    if final_sources.contains(&id) {
+                                        // Don't replace an existing source if it's already there. This allows
+                                        // `AssetApp::set_processed_asset_source_for_unprocessed_source` to configure a
+                                        // "replacement" source for writing processed assets.
+                                        continue;
+                                    }
+                                    final_sources
+                                        .insert(id.clone_owned(), create_processed_source(&id));
+                                }
+                            },
+                        );
+                }
+                AssetMode::Unprocessed => {
+                    // Check to see if there are any asset sources that we marked as processed -
+                    // this is likely a mistake, and we should warn the user so they are not
+                    // confused!
+                    if let Some(unprocessed_sources) =
+                        app.world().get_resource::<UnprocessedAssetSourceBuilders>()
+                    {
+                        let ids: Vec<_> = unprocessed_sources.ids().collect();
+                        if !ids.is_empty() {
+                            warn!("AssetMode is set to Unprocessed");
+                        }
                     }
                 }
+            }
+
+            if use_asset_processor {
+                let mut unprocessed_sources = app
+                    .world_mut()
+                    .remove_resource::<UnprocessedAssetSourceBuilders>()
+                    .unwrap_or_default()
+                    .0;
+                let mut final_sources = app.world_mut().resource_mut::<AssetSourceBuilders>();
+                let (processor, sources) =
+                    AssetProcessor::new(&mut unprocessed_sources, &mut final_sources, watch);
+                // the main asset server shares loaders with the processor asset server
+                app.insert_resource(AssetServer::new_with_loaders(
+                    sources,
+                    processor.server().data.loaders.clone(),
+                    AssetMetaCheck::Always,
+                    watch,
+                    self.unapproved_path_mode.clone(),
+                ))
+                .insert_resource(processor)
+                .add_systems(bevy_app::Startup, AssetProcessor::start);
+            } else {
+                let mut builders = app.world_mut().resource_mut::<AssetSourceBuilders>();
+                let sources = builders.build_sources(watch, /*create_root_for_writer=*/ false);
+                app.insert_resource(AssetServer::new_with_meta_check(
+                    Arc::new(sources),
+                    AssetMetaCheck::Always,
+                    watch,
+                    self.unapproved_path_mode.clone(),
+                ));
             }
         }
         app.insert_resource(embedded)
@@ -561,6 +627,40 @@ pub trait AssetApp {
         id: impl Into<AssetSourceId<'static>>,
         source: AssetSourceBuilder,
     ) -> &mut Self;
+    /// Registers the given [`AssetSourceBuilder`] as "unprocessed" with the given `id`.
+    ///
+    /// The provided source builder will be used as the "unprocessed" source. A corresponding
+    /// "processed" source will be created - the processed source will hold the final processed
+    /// assets which should be shipped to users.
+    ///
+    /// When the asset processor is enabled (i.e., the `asset_processor` feature is enabled), the
+    /// processor will read assets from the unprocessed source, process them (if needed), and then
+    /// write them to the processed source.
+    ///
+    /// Note that asset sources must be registered before adding [`AssetPlugin`] to your application,
+    /// since registered asset sources are built at that point and not after.
+    fn register_processed_asset_source(
+        &mut self,
+        id: impl Into<AssetSourceId<'static>>,
+        source: AssetSourceBuilder,
+    ) -> &mut Self;
+    /// Registers both given sources as an asset source that should be processed.
+    ///
+    /// Assets are read from `unprocessed_source`, processed, then written to `processed_source`.
+    ///
+    /// Unlike [`Self::register_processed_asset_source`], this source does not automatically create
+    /// the processed source for you - the given `processed_source` is used instead. This should
+    /// only be used by advanced users who want fine-grained control of where processed assets are
+    /// written (e.g., to some shared artifact server), or by tests that don't want processed assets
+    /// written to disk at all.
+    ///
+    /// This method must be called before [`AssetPlugin`] is added to your [`App`].
+    fn register_processed_asset_source_with_final_source(
+        &mut self,
+        id: impl Into<AssetSourceId<'static>>,
+        unprocessed_source: AssetSourceBuilder,
+        processed_source: AssetSourceBuilder,
+    ) -> &mut Self;
     /// Sets the default asset processor for the given `extension`.
     fn set_default_asset_processor<P: Process>(&mut self, extension: &str) -> &mut Self;
     /// Initializes the given loader in the [`App`]'s [`AssetServer`].
@@ -610,13 +710,82 @@ impl AssetApp for App {
             error!("{} must be registered before `AssetPlugin` (typically added as part of `DefaultPlugins`)", id);
         }
 
+        if let Some(unprocessed_sources) = self
+            .world()
+            .get_resource::<UnprocessedAssetSourceBuilders>()
+            && unprocessed_sources.contains(id.clone())
         {
-            let mut sources = self
-                .world_mut()
-                .get_resource_or_init::<AssetSourceBuilders>();
-            sources.insert(id, source);
+            error!("The given asset source id {id} has already been registered as a \"processed\" asset source. Cannot register the asset source as unprocessed");
+            return self;
         }
 
+        let mut sources = self
+            .world_mut()
+            .get_resource_or_init::<AssetSourceBuilders>();
+        sources.insert(id, source);
+
+        self
+    }
+
+    fn register_processed_asset_source(
+        &mut self,
+        id: impl Into<AssetSourceId<'static>>,
+        source: AssetSourceBuilder,
+    ) -> &mut Self {
+        let id = id.into();
+        if self.world().get_resource::<AssetServer>().is_some() {
+            error!("{} must be registered before `AssetPlugin` (typically added as part of `DefaultPlugins`)", id);
+        }
+
+        if let Some(sources) = self.world().get_resource::<AssetSourceBuilders>()
+            && sources.contains(id.clone())
+            && !self
+                .world()
+                .get_resource::<UnprocessedAssetSourceBuilders>()
+                .map(|sources| sources.contains(id.clone()))
+                .unwrap_or(false)
+        {
+            error!("The given asset source id {id} has already been registered as an \"unprocessed\" asset source. Cannot register the asset source as processed");
+            return self;
+        }
+
+        let mut sources = self
+            .world_mut()
+            .get_resource_or_init::<UnprocessedAssetSourceBuilders>();
+        sources.insert(id, source);
+
+        self
+    }
+
+    fn register_processed_asset_source_with_final_source(
+        &mut self,
+        id: impl Into<AssetSourceId<'static>>,
+        unprocessed_source: AssetSourceBuilder,
+        processed_source: AssetSourceBuilder,
+    ) -> &mut Self {
+        let id = id.into();
+        if self.world().get_resource::<AssetServer>().is_some() {
+            error!("{} must be registered before `AssetPlugin` (typically added as part of `DefaultPlugins`)", id);
+        }
+
+        if let Some(sources) = self.world().get_resource::<AssetSourceBuilders>()
+            && sources.contains(id.clone())
+            && !self
+                .world()
+                .get_resource::<UnprocessedAssetSourceBuilders>()
+                .map(|sources| sources.contains(id.clone()))
+                .unwrap_or(false)
+        {
+            error!("The given asset source id {id} has already been registered as an \"unprocessed\" asset source. Cannot register the asset source as processed");
+            return self;
+        }
+
+        self.world_mut()
+            .get_resource_or_init::<UnprocessedAssetSourceBuilders>()
+            .insert(id.clone(), unprocessed_source);
+        self.world_mut()
+            .get_resource_or_init::<AssetSourceBuilders>()
+            .insert(id, processed_source);
         self
     }
 

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -206,8 +206,8 @@ pub use uuid;
 
 use crate::{
     io::{
-        embedded::EmbeddedAssetRegistry, AssetSourceBuilder, AssetSourceBuilders, AssetSourceId,
-        UnprocessedAssetSourceBuilders,
+        embedded::EmbeddedAssetRegistry, AssetSourceBuilder, AssetSourceBuilders,
+        AssetSourceBuildersToProcess, AssetSourceId,
     },
     processor::{AssetProcessor, FileTransactionLogFactory, Process},
 };
@@ -375,7 +375,7 @@ impl Plugin for AssetPlugin {
                 {
                     let mut sources = app
                         .world_mut()
-                        .get_resource_or_init::<UnprocessedAssetSourceBuilders>();
+                        .get_resource_or_init::<AssetSourceBuildersToProcess>();
                     sources.init_default_source(&self.file_path);
                 }
             }
@@ -399,12 +399,12 @@ impl Plugin for AssetPlugin {
                 AssetMode::Processed => {
                     // Create the final sources for any sources that need to be processed.
                     app.world_mut()
-                        .try_resource_scope::<UnprocessedAssetSourceBuilders, _>(
-                            |world, unprocessed_sources| {
+                        .try_resource_scope::<AssetSourceBuildersToProcess, _>(
+                            |world, sources_to_process| {
                                 let mut final_sources =
                                     world.get_resource_or_init::<AssetSourceBuilders>();
-                                // Create the corresponding "processed" source for each unprocessed source in the final
-                                // sources.
+                                // Create the corresponding "processed" source for each source to
+                                // process in the final sources.
                                 let create_processed_source = |id: &AssetSourceId<'_>| {
                                     // Let the lifetime live longer while joining the paths.
                                     let child_path;
@@ -421,11 +421,13 @@ impl Plugin for AssetPlugin {
                                             .unwrap(),
                                     )
                                 };
-                                for id in unprocessed_sources.ids() {
+                                for id in sources_to_process.ids() {
                                     if final_sources.contains(&id) {
-                                        // Don't replace an existing source if it's already there. This allows
-                                        // `AssetApp::set_processed_asset_source_for_unprocessed_source` to configure a
-                                        // "replacement" source for writing processed assets.
+                                        // Don't replace an existing source if it's already there.
+                                        // This allows
+                                        // `AssetApp::register_processed_asset_source_with_final_source`
+                                        // to configure a "replacement" source for writing
+                                        // processed assets.
                                         continue;
                                     }
                                     final_sources
@@ -438,15 +440,15 @@ impl Plugin for AssetPlugin {
             }
 
             if use_asset_processor {
-                let mut unprocessed_sources = app
+                let mut sources_to_process = app
                     .world_mut()
-                    .remove_resource::<UnprocessedAssetSourceBuilders>()
+                    .remove_resource::<AssetSourceBuildersToProcess>()
                     .unwrap_or_default()
                     .0;
                 let mut final_sources = app.world_mut().resource_mut::<AssetSourceBuilders>();
                 let log_path = Path::new(&self.processed_file_path).join("log");
                 let (processor, sources) = AssetProcessor::new(
-                    &mut unprocessed_sources,
+                    &mut sources_to_process,
                     &mut final_sources,
                     watch,
                     Box::new(FileTransactionLogFactory {
@@ -634,11 +636,11 @@ pub trait AssetApp {
     fn register_processed_asset_source(
         &mut self,
         id: impl Into<AssetSourceId<'static>>,
-        source: AssetSourceBuilder,
+        source_to_process: AssetSourceBuilder,
     ) -> &mut Self;
     /// Registers both given sources as an asset source that should be processed.
     ///
-    /// Assets are read from `unprocessed_source`, processed, then written to `processed_source`.
+    /// Assets are read from `source_to_process`, processed, then written to `processed_source`.
     ///
     /// Unlike [`Self::register_processed_asset_source`], this source does not automatically create
     /// the processed source for you - the given `processed_source` is used instead. This should
@@ -650,7 +652,7 @@ pub trait AssetApp {
     fn register_processed_asset_source_with_final_source(
         &mut self,
         id: impl Into<AssetSourceId<'static>>,
-        unprocessed_source: AssetSourceBuilder,
+        source_to_process: AssetSourceBuilder,
         processed_source: AssetSourceBuilder,
     ) -> &mut Self;
     /// Sets the default asset processor for the given `extension`.
@@ -702,9 +704,8 @@ impl AssetApp for App {
             error!("{} must be registered before `AssetPlugin` (typically added as part of `DefaultPlugins`)", id);
         }
 
-        if let Some(unprocessed_sources) = self
-            .world()
-            .get_resource::<UnprocessedAssetSourceBuilders>()
+        if let Some(unprocessed_sources) =
+            self.world().get_resource::<AssetSourceBuildersToProcess>()
             && unprocessed_sources.contains(id.clone())
         {
             error!("The given asset source id {id} has already been registered as a \"processed\" asset source. Cannot register the asset source as unprocessed");
@@ -722,7 +723,7 @@ impl AssetApp for App {
     fn register_processed_asset_source(
         &mut self,
         id: impl Into<AssetSourceId<'static>>,
-        source: AssetSourceBuilder,
+        source_to_process: AssetSourceBuilder,
     ) -> &mut Self {
         let id = id.into();
         if self.world().get_resource::<AssetServer>().is_some() {
@@ -733,7 +734,7 @@ impl AssetApp for App {
             && sources.contains(id.clone())
             && !self
                 .world()
-                .get_resource::<UnprocessedAssetSourceBuilders>()
+                .get_resource::<AssetSourceBuildersToProcess>()
                 .map(|sources| sources.contains(id.clone()))
                 .unwrap_or(false)
         {
@@ -743,8 +744,8 @@ impl AssetApp for App {
 
         let mut sources = self
             .world_mut()
-            .get_resource_or_init::<UnprocessedAssetSourceBuilders>();
-        sources.insert(id, source);
+            .get_resource_or_init::<AssetSourceBuildersToProcess>();
+        sources.insert(id, source_to_process);
 
         self
     }
@@ -752,7 +753,7 @@ impl AssetApp for App {
     fn register_processed_asset_source_with_final_source(
         &mut self,
         id: impl Into<AssetSourceId<'static>>,
-        unprocessed_source: AssetSourceBuilder,
+        source_to_process: AssetSourceBuilder,
         processed_source: AssetSourceBuilder,
     ) -> &mut Self {
         let id = id.into();
@@ -764,7 +765,7 @@ impl AssetApp for App {
             && sources.contains(id.clone())
             && !self
                 .world()
-                .get_resource::<UnprocessedAssetSourceBuilders>()
+                .get_resource::<AssetSourceBuildersToProcess>()
                 .map(|sources| sources.contains(id.clone()))
                 .unwrap_or(false)
         {
@@ -773,8 +774,8 @@ impl AssetApp for App {
         }
 
         self.world_mut()
-            .get_resource_or_init::<UnprocessedAssetSourceBuilders>()
-            .insert(id.clone(), unprocessed_source);
+            .get_resource_or_init::<AssetSourceBuildersToProcess>()
+            .insert(id.clone(), source_to_process);
         self.world_mut()
             .get_resource_or_init::<AssetSourceBuilders>()
             .insert(id, processed_source);

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -635,15 +635,11 @@ pub trait AssetApp {
         id: impl Into<AssetSourceId<'static>>,
         source: AssetSourceBuilder,
     ) -> &mut Self;
-    /// Registers the given [`AssetSourceBuilder`] as "unprocessed" with the given `id`.
+    /// Registers an [`AssetSourceBuilder`] as an asset source that should be processed.
     ///
-    /// The provided source builder will be used as the "unprocessed" source. A corresponding
-    /// "processed" source will be created - the processed source will hold the final processed
-    /// assets which should be shipped to users.
-    ///
-    /// When the asset processor is enabled (i.e., the `asset_processor` feature is enabled), the
-    /// processor will read assets from the unprocessed source, process them (if needed), and then
-    /// write them to the processed source.
+    /// The provided source builder will be read during asset processing (i.e., the
+    /// `asset_processor` feature is enabled), and the processed assets are written to an
+    /// automatically created source (readable from the given `id`).
     ///
     /// Note that asset sources must be registered before adding [`AssetPlugin`] to your application,
     /// since registered asset sources are built at that point and not after.

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -229,7 +229,7 @@ use bevy_platform::collections::HashSet;
 use bevy_reflect::{FromReflect, GetTypeRegistration, Reflect, TypePath};
 use core::any::TypeId;
 use std::path::Path;
-use tracing::{error, warn};
+use tracing::error;
 
 /// Provides "asset" loading and processing functionality. An [`Asset`] is a "runtime value" that is loaded from an [`AssetSource`],
 /// which can be something like a filesystem, a network, etc.
@@ -434,19 +434,7 @@ impl Plugin for AssetPlugin {
                             },
                         );
                 }
-                AssetMode::Unprocessed => {
-                    // Check to see if there are any asset sources that we marked as processed -
-                    // this is likely a mistake, and we should warn the user so they are not
-                    // confused!
-                    if let Some(unprocessed_sources) =
-                        app.world().get_resource::<UnprocessedAssetSourceBuilders>()
-                    {
-                        let ids: Vec<_> = unprocessed_sources.ids().collect();
-                        if !ids.is_empty() {
-                            warn!("AssetMode is set to Unprocessed");
-                        }
-                    }
-                }
+                AssetMode::Unprocessed => {}
             }
 
             if use_asset_processor {

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -209,9 +209,10 @@ use crate::{
         embedded::EmbeddedAssetRegistry, AssetSourceBuilder, AssetSourceBuilders, AssetSourceId,
         UnprocessedAssetSourceBuilders,
     },
-    processor::{AssetProcessor, Process},
+    processor::{AssetProcessor, FileTransactionLogFactory, Process},
 };
 use alloc::{
+    boxed::Box,
     format,
     string::{String, ToString},
     sync::Arc,
@@ -455,8 +456,15 @@ impl Plugin for AssetPlugin {
                     .unwrap_or_default()
                     .0;
                 let mut final_sources = app.world_mut().resource_mut::<AssetSourceBuilders>();
-                let (processor, sources) =
-                    AssetProcessor::new(&mut unprocessed_sources, &mut final_sources, watch);
+                let log_path = Path::new(&self.processed_file_path).join("log");
+                let (processor, sources) = AssetProcessor::new(
+                    &mut unprocessed_sources,
+                    &mut final_sources,
+                    watch,
+                    Box::new(FileTransactionLogFactory {
+                        file_path: log_path,
+                    }),
+                );
                 // the main asset server shares loaders with the processor asset server
                 app.insert_resource(AssetServer::new_with_loaders(
                     sources,

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -3,8 +3,8 @@ use crate::{
     loader_builders::{Deferred, NestedLoader, StaticTyped},
     meta::{AssetHash, AssetMeta, AssetMetaDyn, ProcessedInfo, ProcessedInfoMinimal, Settings},
     path::AssetPath,
-    Asset, AssetIndex, AssetLoadError, AssetServer, AssetServerMode, Assets, ErasedAssetIndex,
-    Handle, UntypedAssetId, UntypedHandle,
+    Asset, AssetIndex, AssetLoadError, AssetServer, Assets, ErasedAssetIndex, Handle,
+    UntypedAssetId, UntypedHandle,
 };
 use alloc::{boxed::Box, string::ToString, vec::Vec};
 use atomicow::CowArc;
@@ -573,10 +573,7 @@ impl<'a> LoadContext<'a> {
     ) -> Result<Vec<u8>, ReadAssetBytesError> {
         let path = path.into();
         let source = self.asset_server.get_source(path.source())?;
-        let asset_reader = match self.asset_server.mode() {
-            AssetServerMode::Unprocessed => source.reader(),
-            AssetServerMode::Processed => source.processed_reader()?,
-        };
+        let asset_reader = source.reader();
         let mut reader = asset_reader.read(path.path()).await?;
         let hash = if self.populate_hashes {
             // NOTE: ensure meta is read while the asset bytes reader is still active to ensure transactionality

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -246,7 +246,7 @@ impl<'a> AssetPath<'a> {
     /// Gets the "asset source", if one was defined. If none was defined, the default source
     /// will be used.
     #[inline]
-    pub fn source(&self) -> &AssetSourceId<'_> {
+    pub fn source(&self) -> &AssetSourceId<'a> {
         &self.source
     }
 
@@ -270,7 +270,7 @@ impl<'a> AssetPath<'a> {
 
     /// Gets the path to the asset in the "virtual filesystem" without a label (if a label is currently set).
     #[inline]
-    pub fn without_label(&self) -> AssetPath<'_> {
+    pub fn without_label(&self) -> AssetPath<'a> {
         Self {
             source: self.source.clone(),
             path: self.path.clone(),

--- a/crates/bevy_asset/src/processor/log.rs
+++ b/crates/bevy_asset/src/processor/log.rs
@@ -116,19 +116,6 @@ pub struct FileTransactionLogFactory {
     pub file_path: PathBuf,
 }
 
-const LOG_PATH: &str = "imported_assets/log";
-
-impl Default for FileTransactionLogFactory {
-    fn default() -> Self {
-        #[cfg(not(target_arch = "wasm32"))]
-        let base_path = crate::io::file::get_base_path();
-        #[cfg(target_arch = "wasm32")]
-        let base_path = PathBuf::new();
-        let file_path = base_path.join(LOG_PATH);
-        Self { file_path }
-    }
-}
-
 impl ProcessorTransactionLogFactory for FileTransactionLogFactory {
     fn read(&self) -> BoxedFuture<'_, Result<Vec<LogEntry>, BevyError>> {
         let path = self.file_path.clone();

--- a/crates/bevy_asset/src/processor/mod.rs
+++ b/crates/bevy_asset/src/processor/mod.rs
@@ -215,7 +215,7 @@ impl ProcessedSources {
 /// A single processed source.
 struct ProcessedSource {
     /// The unprocessed source, where the original unprocessed assets are read from.
-    unprocessed_source: AssetSource,
+    source_to_process: AssetSource,
     /// The ungated reader for the processed source.
     ///
     /// This is not gated on the processor, so that the processor can actually read the current
@@ -227,15 +227,15 @@ struct ProcessedSource {
 
 impl ProcessedSource {
     fn unprocessed_reader(&self) -> &dyn ErasedAssetReader {
-        self.unprocessed_source.reader()
+        self.source_to_process.reader()
     }
 
     fn unprocessed_writer(&self) -> Result<&dyn ErasedAssetWriter, MissingAssetWriterError> {
-        self.unprocessed_source.writer()
+        self.source_to_process.writer()
     }
 
     fn unprocessed_event_receiver(&self) -> Option<&async_channel::Receiver<AssetSourceEvent>> {
-        self.unprocessed_source.event_receiver()
+        self.source_to_process.event_receiver()
     }
 
     fn processed_reader(&self) -> &dyn ErasedAssetReader {
@@ -250,14 +250,14 @@ impl ProcessedSource {
 impl AssetProcessor {
     /// Creates a new [`AssetProcessor`] instance.
     pub fn new(
-        unprocessed_sources: &mut AssetSourceBuilders,
+        sources_to_process: &mut AssetSourceBuilders,
         final_sources: &mut AssetSourceBuilders,
         watch_processed: bool,
         default_transaction_log_factory: Box<dyn ProcessorTransactionLogFactory + 'static>,
     ) -> (Self, Arc<AssetSources>) {
         let state = Arc::new(ProcessingState::new());
 
-        let unprocessed_sources = unprocessed_sources.build_unprocessed_sources();
+        let unprocessed_sources = sources_to_process.build_as_sources_to_process();
         // TODO: It would be nice if we didn't need an additional "gating" step - we should just
         // create the asset source gated. But currently we need an additional `build_sources` step,
         // so we need to gate after the fact.
@@ -1449,7 +1449,7 @@ impl AssetProcessorData {
                 .remove(&id)
                 .expect("there is an unprocessed source for each processed reader");
             let processed_source = ProcessedSource {
-                unprocessed_source,
+                source_to_process: unprocessed_source,
                 ungated_processed_reader,
                 processed_writer,
             };

--- a/crates/bevy_asset/src/processor/mod.rs
+++ b/crates/bevy_asset/src/processor/mod.rs
@@ -41,19 +41,21 @@ mod log;
 mod process;
 
 use async_lock::RwLockReadGuardArc;
+use atomicow::CowArc;
 pub use log::*;
 pub use process::*;
 
 use crate::{
     io::{
         AssetReaderError, AssetSource, AssetSourceBuilders, AssetSourceEvent, AssetSourceId,
-        AssetSources, AssetWriterError, ErasedAssetReader, MissingAssetSourceError,
+        AssetSources, AssetWriterError, ErasedAssetReader, ErasedAssetWriter,
+        MissingAssetSourceError, MissingAssetWriterError,
     },
     meta::{
         get_asset_hash, get_full_asset_hash, AssetAction, AssetActionMinimal, AssetHash, AssetMeta,
         AssetMetaDyn, AssetMetaMinimal, ProcessedInfo, ProcessedInfoMinimal,
     },
-    AssetLoadError, AssetMetaCheck, AssetPath, AssetServer, AssetServerMode, DeserializeMetaError,
+    AssetLoadError, AssetMetaCheck, AssetPath, AssetServer, DeserializeMetaError,
     MissingAssetLoaderForExtensionError, UnapprovedPathMode, WriteDefaultMetaError,
 };
 use alloc::{borrow::ToOwned, boxed::Box, string::String, sync::Arc, vec, vec::Vec};
@@ -110,10 +112,12 @@ pub struct AssetProcessorData {
     /// this once, and before the asset processor starts - there is no reason to await (and it
     /// avoids needing to use [`block_on`](bevy_tasks::block_on) to set the factory).
     log_factory: Mutex<Option<Box<dyn ProcessorTransactionLogFactory>>>,
+    /// The transaction log for recording the state of individual processing tasks.
     log: async_lock::RwLock<Option<Box<dyn ProcessorTransactionLog>>>,
     /// The processors that will be used to process assets.
     processors: RwLock<Processors>,
-    sources: Arc<AssetSources>,
+    /// The sources being processed.
+    sources: ProcessedSources,
 }
 
 /// The current state of processing, including the overall state and the state of all assets.
@@ -155,27 +159,126 @@ enum ShortTypeProcessorEntry {
     Ambiguous(Vec<&'static str>),
 }
 
+/// The set of sources being processed.
+#[derive(Default)]
+struct ProcessedSources {
+    /// The default source.
+    default: Option<ProcessedSource>,
+    /// The named sources.
+    named: HashMap<CowArc<'static, str>, ProcessedSource>,
+}
+
+impl ProcessedSources {
+    /// Gets the source with the given `id`.
+    fn get_source(
+        &self,
+        id: &AssetSourceId<'static>,
+    ) -> Result<&ProcessedSource, MissingAssetSourceError> {
+        match id {
+            AssetSourceId::Default => self
+                .default
+                .as_ref()
+                .ok_or_else(|| MissingAssetSourceError(id.clone())),
+            AssetSourceId::Name(name) => self
+                .named
+                .get(name)
+                .ok_or_else(|| MissingAssetSourceError(id.clone())),
+        }
+    }
+
+    /// Iterates through all sources being processed.
+    fn iter(&self) -> impl Iterator<Item = (AssetSourceId<'static>, &ProcessedSource)> {
+        self.default
+            .as_ref()
+            .map(|source| (AssetSourceId::Default, source))
+            .into_iter()
+            .chain(
+                self.named
+                    .iter()
+                    .map(|(name, source)| (AssetSourceId::Name(name.clone()), source)),
+            )
+    }
+
+    /// Inserts the `source` with the given `id`.
+    fn insert(&mut self, id: AssetSourceId<'static>, source: ProcessedSource) {
+        match id {
+            AssetSourceId::Default => {
+                self.default = Some(source);
+            }
+            AssetSourceId::Name(name) => {
+                self.named.insert(name, source);
+            }
+        }
+    }
+}
+
+/// A single processed source.
+struct ProcessedSource {
+    /// The unprocessed source, where the original unprocessed assets are read from.
+    unprocessed_source: AssetSource,
+    /// The ungated reader for the processed source.
+    ///
+    /// This is not gated on the processor, so that the processor can actually read the current
+    /// state without being blocked on itself.
+    ungated_processed_reader: Arc<dyn ErasedAssetReader>,
+    /// The processed source, where the processed assets are written to.
+    processed_writer: Box<dyn ErasedAssetWriter>,
+}
+
+impl ProcessedSource {
+    fn unprocessed_reader(&self) -> &dyn ErasedAssetReader {
+        self.unprocessed_source.reader()
+    }
+
+    fn unprocessed_writer(&self) -> Result<&dyn ErasedAssetWriter, MissingAssetWriterError> {
+        self.unprocessed_source.writer()
+    }
+
+    fn unprocessed_event_receiver(&self) -> Option<&async_channel::Receiver<AssetSourceEvent>> {
+        self.unprocessed_source.event_receiver()
+    }
+
+    fn processed_reader(&self) -> &dyn ErasedAssetReader {
+        self.ungated_processed_reader.as_ref()
+    }
+
+    fn processed_writer(&self) -> &dyn ErasedAssetWriter {
+        self.processed_writer.as_ref()
+    }
+}
+
 impl AssetProcessor {
     /// Creates a new [`AssetProcessor`] instance.
     pub fn new(
-        sources: &mut AssetSourceBuilders,
+        unprocessed_sources: &mut AssetSourceBuilders,
+        final_sources: &mut AssetSourceBuilders,
         watch_processed: bool,
     ) -> (Self, Arc<AssetSources>) {
         let state = Arc::new(ProcessingState::new());
-        let mut sources = sources.build_sources(true, watch_processed);
-        sources.gate_on_processor(state.clone());
-        let sources = Arc::new(sources);
 
-        let data = Arc::new(AssetProcessorData::new(sources.clone(), state));
+        let unprocessed_sources = unprocessed_sources.build_unprocessed_sources();
+        // TODO: It would be nice if we didn't need an additional "gating" step - we should just
+        // create the asset source gated. But currently we need an additional `build_sources` step,
+        // so we need to gate after the fact.
+        let mut final_sources =
+            final_sources.build_sources(watch_processed, /*create_root_for_writer=*/ true);
+        let ungated_processed_readers_and_writers =
+            final_sources.gate_on_processor(&unprocessed_sources, state.clone());
+        let final_sources = Arc::new(final_sources);
+
+        let data = Arc::new(AssetProcessorData::new(
+            unprocessed_sources,
+            ungated_processed_readers_and_writers,
+            state,
+        ));
         // The asset processor uses its own asset server with its own id space
         let server = AssetServer::new_with_meta_check(
-            sources.clone(),
-            AssetServerMode::Processed,
+            final_sources.clone(),
             AssetMetaCheck::Always,
             false,
             UnapprovedPathMode::default(),
         );
-        (Self { server, data }, sources)
+        (Self { server, data }, final_sources)
     }
 
     /// Gets a reference to the [`Arc`] containing the [`AssetProcessorData`].
@@ -192,20 +295,6 @@ impl AssetProcessor {
     /// Retrieves the current [`ProcessorState`]
     pub async fn get_state(&self) -> ProcessorState {
         self.data.processing_state.get_state().await
-    }
-
-    /// Retrieves the [`AssetSource`] for this processor
-    #[inline]
-    pub fn get_source<'a>(
-        &self,
-        id: impl Into<AssetSourceId<'a>>,
-    ) -> Result<&AssetSource, MissingAssetSourceError> {
-        self.data.sources.get(id.into())
-    }
-
-    #[inline]
-    pub fn sources(&self) -> &AssetSources {
-        &self.data.sources
     }
 
     /// Logs an unrecoverable error. On the next run of the processor, all assets will be regenerated. This should only be used as a last resort.
@@ -294,8 +383,8 @@ impl AssetProcessor {
         &self,
         sender: &async_channel::Sender<(AssetSourceId<'static>, PathBuf)>,
     ) {
-        for source in self.sources().iter_processed() {
-            self.queue_processing_tasks_for_folder(source, PathBuf::from(""), sender)
+        for (id, source) in self.data.sources.iter() {
+            self.queue_processing_tasks_for_folder(&id, source, PathBuf::from(""), sender)
                 .await
                 .unwrap();
         }
@@ -307,21 +396,20 @@ impl AssetProcessor {
         &self,
         sender: &async_channel::Sender<(AssetSourceId<'static>, PathBuf)>,
     ) {
-        for source in self.data.sources.iter_processed() {
-            let Some(receiver) = source.event_receiver().cloned() else {
+        for (id, source) in self.data.sources.iter() {
+            let Some(receiver) = source.unprocessed_event_receiver().cloned() else {
                 continue;
             };
-            let source_id = source.id();
             let processor = self.clone();
             let sender = sender.clone();
             IoTaskPool::get()
                 .spawn(async move {
                     while let Ok(event) = receiver.recv().await {
-                        let Ok(source) = processor.get_source(source_id.clone()) else {
+                        let Ok(source) = processor.data.sources.get_source(&id) else {
                             return;
                         };
                         processor
-                            .handle_asset_source_event(source, event, &sender)
+                            .handle_asset_source_event(&id, source, event, &sender)
                             .await;
                     }
                 })
@@ -394,10 +482,12 @@ impl AssetProcessor {
                     pending_tasks += 1;
                     IoTaskPool::get()
                         .spawn(async move {
-                            let Ok(source) = processor.get_source(source_id) else {
+                            let Ok(source) = processor.data.sources.get_source(&source_id) else {
                                 return;
                             };
-                            processor.process_asset(source, path, new_task_sender).await;
+                            processor
+                                .process_asset(&source_id, source, path, new_task_sender)
+                                .await;
                             // If the channel gets closed, that's ok. Just ignore it.
                             let _ = task_finished_sender.send(()).await;
                         })
@@ -456,12 +546,12 @@ impl AssetProcessor {
         let meta = processor.default_meta(processor_path_kind);
         let serialized_meta = meta.serialize();
 
-        let source = self.get_source(path.source())?;
+        let source = self.data.sources.get_source(&path.source().clone_owned())?;
 
         // Note: we get the reader rather than the processed reader, since we want to write the meta
         // file for the unprocessed version of that asset (so it will be processed by the default
         // processor).
-        let reader = source.reader();
+        let reader = source.unprocessed_reader();
         match reader.read_meta_bytes(path.path()).await {
             Ok(_) => return Err(WriteDefaultMetaError::MetaAlreadyExists),
             Err(AssetReaderError::NotFound(_)) => {
@@ -475,7 +565,7 @@ impl AssetProcessor {
             }
         }
 
-        let writer = source.writer()?;
+        let writer = source.unprocessed_writer()?;
         writer
             .write_meta_bytes(path.path(), &serialized_meta)
             .await?;
@@ -485,7 +575,8 @@ impl AssetProcessor {
 
     async fn handle_asset_source_event(
         &self,
-        source: &AssetSource,
+        id: &AssetSourceId<'static>,
+        source: &ProcessedSource,
         event: AssetSourceEvent,
         new_task_sender: &async_channel::Sender<(AssetSourceId<'static>, PathBuf)>,
     ) {
@@ -495,32 +586,31 @@ impl AssetProcessor {
             | AssetSourceEvent::AddedMeta(path)
             | AssetSourceEvent::ModifiedAsset(path)
             | AssetSourceEvent::ModifiedMeta(path) => {
-                let _ = new_task_sender.send((source.id(), path)).await;
+                let _ = new_task_sender.send((id.clone(), path)).await;
             }
             AssetSourceEvent::RemovedAsset(path) => {
-                self.handle_removed_asset(source, path).await;
+                self.handle_removed_asset(id, source, path).await;
             }
             AssetSourceEvent::RemovedMeta(path) => {
-                self.handle_removed_meta(source, path, new_task_sender)
-                    .await;
+                self.handle_removed_meta(id, path, new_task_sender).await;
             }
             AssetSourceEvent::AddedFolder(path) => {
-                self.handle_added_folder(source, path, new_task_sender)
+                self.handle_added_folder(id, source, path, new_task_sender)
                     .await;
             }
             // NOTE: As a heads up for future devs: this event shouldn't be run in parallel with other events that might
             // touch this folder (ex: the folder might be re-created with new assets). Clean up the old state first.
             // Currently this event handler is not parallel, but it could be (and likely should be) in the future.
             AssetSourceEvent::RemovedFolder(path) => {
-                self.handle_removed_folder(source, &path).await;
+                self.handle_removed_folder(id, source, &path).await;
             }
             AssetSourceEvent::RenamedAsset { old, new } => {
                 // If there was a rename event, but the path hasn't changed, this asset might need reprocessing.
                 // Sometimes this event is returned when an asset is moved "back" into the asset folder
                 if old == new {
-                    let _ = new_task_sender.send((source.id(), new)).await;
+                    let _ = new_task_sender.send((id.clone(), new)).await;
                 } else {
-                    self.handle_renamed_asset(source, old, new, new_task_sender)
+                    self.handle_renamed_asset(id, source, old, new, new_task_sender)
                         .await;
                 }
             }
@@ -528,38 +618,39 @@ impl AssetProcessor {
                 // If there was a rename event, but the path hasn't changed, this asset meta might need reprocessing.
                 // Sometimes this event is returned when an asset meta is moved "back" into the asset folder
                 if old == new {
-                    let _ = new_task_sender.send((source.id(), new)).await;
+                    let _ = new_task_sender.send((id.clone(), new)).await;
                 } else {
                     debug!("Meta renamed from {old:?} to {new:?}");
                     // Renaming meta should not assume that an asset has also been renamed. Check both old and new assets to see
                     // if they should be re-imported (and/or have new meta generated)
-                    let _ = new_task_sender.send((source.id(), old)).await;
-                    let _ = new_task_sender.send((source.id(), new)).await;
+                    let _ = new_task_sender.send((id.clone(), old)).await;
+                    let _ = new_task_sender.send((id.clone(), new)).await;
                 }
             }
             AssetSourceEvent::RenamedFolder { old, new } => {
                 // If there was a rename event, but the path hasn't changed, this asset folder might need reprocessing.
                 // Sometimes this event is returned when an asset meta is moved "back" into the asset folder
                 if old == new {
-                    self.handle_added_folder(source, new, new_task_sender).await;
+                    self.handle_added_folder(id, source, new, new_task_sender)
+                        .await;
                 } else {
                     // PERF: this reprocesses everything in the moved folder. this is not necessary in most cases, but
                     // requires some nuance when it comes to path handling.
-                    self.handle_removed_folder(source, &old).await;
-                    self.handle_added_folder(source, new, new_task_sender).await;
+                    self.handle_removed_folder(id, source, &old).await;
+                    self.handle_added_folder(id, source, new, new_task_sender)
+                        .await;
                 }
             }
             AssetSourceEvent::RemovedUnknown { path, is_meta } => {
-                let processed_reader = source.ungated_processed_reader().unwrap();
+                let processed_reader = source.processed_reader();
                 match processed_reader.is_directory(&path).await {
                     Ok(is_directory) => {
                         if is_directory {
-                            self.handle_removed_folder(source, &path).await;
+                            self.handle_removed_folder(id, source, &path).await;
                         } else if is_meta {
-                            self.handle_removed_meta(source, path, new_task_sender)
-                                .await;
+                            self.handle_removed_meta(id, path, new_task_sender).await;
                         } else {
-                            self.handle_removed_asset(source, path).await;
+                            self.handle_removed_asset(id, source, path).await;
                         }
                     }
                     Err(err) => {
@@ -571,14 +662,14 @@ impl AssetProcessor {
                                 error!(
                                     "Path '{}' was removed, but the destination reader could not determine if it \
                                     was a folder or a file due to the following error: {err}",
-                                    AssetPath::from_path(&path).with_source(source.id())
+                                    AssetPath::from_path(&path).with_source(id.clone())
                                 );
                             }
                             AssetReaderError::HttpError(status) => {
                                 error!(
                                     "Path '{}' was removed, but the destination reader could not determine if it \
                                     was a folder or a file due to receiving an unexpected HTTP Status {status}",
-                                    AssetPath::from_path(&path).with_source(source.id())
+                                    AssetPath::from_path(&path).with_source(id.clone())
                                 );
                             }
                         }
@@ -590,15 +681,16 @@ impl AssetProcessor {
 
     async fn handle_added_folder(
         &self,
-        source: &AssetSource,
+        id: &AssetSourceId<'static>,
+        source: &ProcessedSource,
         path: PathBuf,
         new_task_sender: &async_channel::Sender<(AssetSourceId<'static>, PathBuf)>,
     ) {
         debug!(
             "Folder {} was added. Attempting to re-process",
-            AssetPath::from_path(&path).with_source(source.id())
+            AssetPath::from_path(&path).with_source(id.clone())
         );
-        self.queue_processing_tasks_for_folder(source, path, new_task_sender)
+        self.queue_processing_tasks_for_folder(id, source, path, new_task_sender)
             .await
             .unwrap();
     }
@@ -606,7 +698,7 @@ impl AssetProcessor {
     /// Responds to a removed meta event by reprocessing the asset at the given path.
     async fn handle_removed_meta(
         &self,
-        source: &AssetSource,
+        id: &AssetSourceId<'static>,
         path: PathBuf,
         new_task_sender: &async_channel::Sender<(AssetSourceId<'static>, PathBuf)>,
     ) {
@@ -616,22 +708,27 @@ impl AssetProcessor {
         // user-initiated action.
         debug!(
             "Meta for asset {} was removed. Attempting to re-process",
-            AssetPath::from_path(&path).with_source(source.id())
+            AssetPath::from_path(&path).with_source(id.clone())
         );
-        let _ = new_task_sender.send((source.id(), path)).await;
+        let _ = new_task_sender.send((id.clone(), path)).await;
     }
 
     /// Removes all processed assets stored at the given path (respecting transactionality), then removes the folder itself.
-    async fn handle_removed_folder(&self, source: &AssetSource, path: &Path) {
+    async fn handle_removed_folder(
+        &self,
+        id: &AssetSourceId<'static>,
+        source: &ProcessedSource,
+        path: &Path,
+    ) {
         debug!(
             "Removing folder {} because source was removed",
             path.display()
         );
-        let processed_reader = source.ungated_processed_reader().unwrap();
+        let processed_reader = source.processed_reader();
         match processed_reader.read_directory(path).await {
             Ok(mut path_stream) => {
                 while let Some(child_path) = path_stream.next().await {
-                    self.handle_removed_asset(source, child_path).await;
+                    self.handle_removed_asset(id, source, child_path).await;
                 }
             }
             Err(err) => match err {
@@ -654,14 +751,14 @@ impl AssetProcessor {
                 }
             },
         }
-        let processed_writer = source.processed_writer().unwrap();
+        let processed_writer = source.processed_writer();
         if let Err(err) = processed_writer.remove_directory(path).await {
             match err {
                 AssetWriterError::Io(err) => {
                     // we can ignore NotFound because if the "final" file in a folder was removed
                     // then we automatically clean up this folder
                     if err.kind() != ErrorKind::NotFound {
-                        let asset_path = AssetPath::from_path(path).with_source(source.id());
+                        let asset_path = AssetPath::from_path(path).with_source(id.clone());
                         error!("Failed to remove destination folder that no longer exists in {asset_path}: {err}");
                     }
                 }
@@ -671,8 +768,13 @@ impl AssetProcessor {
 
     /// Removes the processed version of an asset and associated in-memory metadata. This will block until all existing reads/writes to the
     /// asset have finished, thanks to the `file_transaction_lock`.
-    async fn handle_removed_asset(&self, source: &AssetSource, path: PathBuf) {
-        let asset_path = AssetPath::from(path).with_source(source.id());
+    async fn handle_removed_asset(
+        &self,
+        id: &AssetSourceId<'static>,
+        source: &ProcessedSource,
+        path: PathBuf,
+    ) {
+        let asset_path = AssetPath::from(path).with_source(id.clone());
         debug!("Removing processed {asset_path} because source was removed");
         let lock = {
             // Scope the infos lock so we don't hold up other processing for too long.
@@ -686,22 +788,23 @@ impl AssetProcessor {
         // we must wait for uncontested write access to the asset source to ensure existing
         // readers/writers can finish their operations
         let _write_lock = lock.write();
-        self.remove_processed_asset_and_meta(source, asset_path.path())
-            .await;
+        let writer = source.processed_writer();
+        self.remove_asset_and_meta(writer, asset_path.path()).await;
     }
 
     /// Handles a renamed source asset by moving its processed results to the new location and updating in-memory paths + metadata.
     /// This will cause direct path dependencies to break.
     async fn handle_renamed_asset(
         &self,
-        source: &AssetSource,
+        id: &AssetSourceId<'static>,
+        source: &ProcessedSource,
         old: PathBuf,
         new: PathBuf,
         new_task_sender: &async_channel::Sender<(AssetSourceId<'static>, PathBuf)>,
     ) {
-        let old = AssetPath::from(old).with_source(source.id());
-        let new = AssetPath::from(new).with_source(source.id());
-        let processed_writer = source.processed_writer().unwrap();
+        let old = AssetPath::from(old).with_source(id.clone());
+        let new = AssetPath::from(new).with_source(id.clone());
+        let processed_writer = source.processed_writer();
         let result = {
             // Scope the infos lock so we don't hold up other processing for too long.
             let mut infos = self.data.processing_state.asset_infos.write().await;
@@ -726,18 +829,19 @@ impl AssetProcessor {
 
     async fn queue_processing_tasks_for_folder(
         &self,
-        source: &AssetSource,
+        id: &AssetSourceId<'static>,
+        source: &ProcessedSource,
         path: PathBuf,
         new_task_sender: &async_channel::Sender<(AssetSourceId<'static>, PathBuf)>,
     ) -> Result<(), AssetReaderError> {
-        if source.reader().is_directory(&path).await? {
-            let mut path_stream = source.reader().read_directory(&path).await?;
+        if source.unprocessed_reader().is_directory(&path).await? {
+            let mut path_stream = source.unprocessed_reader().read_directory(&path).await?;
             while let Some(path) = path_stream.next().await {
-                Box::pin(self.queue_processing_tasks_for_folder(source, path, new_task_sender))
+                Box::pin(self.queue_processing_tasks_for_folder(id, source, path, new_task_sender))
                     .await?;
             }
         } else {
-            let _ = new_task_sender.send((source.id(), path)).await;
+            let _ = new_task_sender.send((id.clone(), path)).await;
         }
         Ok(())
     }
@@ -874,16 +978,14 @@ impl AssetProcessor {
             }
         }
 
-        for source in self.sources().iter_processed() {
-            let Some(processed_reader) = source.ungated_processed_reader() else {
-                continue;
-            };
-            let Ok(processed_writer) = source.processed_writer() else {
-                continue;
-            };
+        for (id, source) in self.data.sources.iter() {
+            let unprocessed_reader = source.unprocessed_reader();
+            let processed_reader = source.processed_reader();
+            let processed_writer = source.processed_writer();
+
             let mut unprocessed_paths = Vec::new();
             get_asset_paths(
-                source.reader(),
+                unprocessed_reader,
                 PathBuf::from(""),
                 &mut unprocessed_paths,
                 None,
@@ -911,12 +1013,12 @@ impl AssetProcessor {
             }
 
             for path in unprocessed_paths {
-                asset_infos.get_or_insert(AssetPath::from(path).with_source(source.id()));
+                asset_infos.get_or_insert(AssetPath::from(path).with_source(id.clone()));
             }
 
             for path in processed_paths {
                 let mut dependencies = Vec::new();
-                let asset_path = AssetPath::from(path).with_source(source.id());
+                let asset_path = AssetPath::from(path).with_source(id.clone());
                 if let Some(info) = asset_infos.get_mut(&asset_path) {
                     match processed_reader.read_meta_bytes(asset_path.path()).await {
                         Ok(meta_bytes) => {
@@ -938,20 +1040,20 @@ impl AssetProcessor {
                                 }
                                 Err(err) => {
                                     trace!("Removing processed data for {asset_path} because meta could not be parsed: {err}");
-                                    self.remove_processed_asset_and_meta(source, asset_path.path())
+                                    self.remove_asset_and_meta(processed_writer, asset_path.path())
                                         .await;
                                 }
                             }
                         }
                         Err(err) => {
                             trace!("Removing processed data for {asset_path} because meta failed to load: {err}");
-                            self.remove_processed_asset_and_meta(source, asset_path.path())
+                            self.remove_asset_and_meta(processed_writer, asset_path.path())
                                 .await;
                         }
                     }
                 } else {
                     trace!("Removing processed data for non-existent asset {asset_path}");
-                    self.remove_processed_asset_and_meta(source, asset_path.path())
+                    self.remove_asset_and_meta(processed_writer, asset_path.path())
                         .await;
                 }
 
@@ -971,20 +1073,19 @@ impl AssetProcessor {
 
     /// Removes the processed version of an asset and its metadata, if it exists. This _is not_ transactional like `remove_processed_asset_transactional`, nor
     /// does it remove existing in-memory metadata.
-    async fn remove_processed_asset_and_meta(&self, source: &AssetSource, path: &Path) {
-        if let Err(err) = source.processed_writer().unwrap().remove(path).await {
+    async fn remove_asset_and_meta(&self, writer: &dyn ErasedAssetWriter, path: &Path) {
+        if let Err(err) = writer.remove(path).await {
             warn!("Failed to remove non-existent asset {path:?}: {err}");
         }
 
-        if let Err(err) = source.processed_writer().unwrap().remove_meta(path).await {
+        if let Err(err) = writer.remove_meta(path).await {
             warn!("Failed to remove non-existent meta {path:?}: {err}");
         }
 
-        self.clean_empty_processed_ancestor_folders(source, path)
-            .await;
+        self.clean_empty_ancestor_folders(writer, path).await;
     }
 
-    async fn clean_empty_processed_ancestor_folders(&self, source: &AssetSource, path: &Path) {
+    async fn clean_empty_ancestor_folders(&self, writer: &dyn ErasedAssetWriter, path: &Path) {
         // As a safety precaution don't delete absolute paths to avoid deleting folders outside of the destination folder
         if path.is_absolute() {
             error!("Attempted to clean up ancestor folders of an absolute path. This is unsafe so the operation was skipped.");
@@ -994,13 +1095,7 @@ impl AssetProcessor {
             if parent == Path::new("") {
                 break;
             }
-            if source
-                .processed_writer()
-                .unwrap()
-                .remove_empty_directory(parent)
-                .await
-                .is_err()
-            {
+            if writer.remove_empty_directory(parent).await.is_err() {
                 // if we fail to delete a folder, stop walking up the tree
                 break;
             }
@@ -1016,11 +1111,12 @@ impl AssetProcessor {
     /// [`ProcessorGatedReader`]: crate::io::processor_gated::ProcessorGatedReader
     async fn process_asset(
         &self,
-        source: &AssetSource,
+        id: &AssetSourceId<'static>,
+        source: &ProcessedSource,
         path: PathBuf,
         processor_task_event: async_channel::Sender<(AssetSourceId<'static>, PathBuf)>,
     ) {
-        let asset_path = AssetPath::from(path).with_source(source.id());
+        let asset_path = AssetPath::from(path).with_source(id.clone());
         let result = self.process_asset_internal(source, &asset_path).await;
         let mut infos = self.data.processing_state.asset_infos.write().await;
         infos
@@ -1030,14 +1126,14 @@ impl AssetProcessor {
 
     async fn process_asset_internal(
         &self,
-        source: &AssetSource,
+        source: &ProcessedSource,
         asset_path: &AssetPath<'static>,
     ) -> Result<ProcessResult, ProcessError> {
         // TODO: check if already processing to protect against duplicate hot-reload events
         debug!("Processing {}", asset_path);
         let server = &self.server;
         let path = asset_path.path();
-        let reader = source.reader();
+        let reader = source.unprocessed_reader();
 
         let reader_err = |err| ProcessError::AssetReaderError {
             path: asset_path.clone(),
@@ -1101,7 +1197,7 @@ impl AssetProcessor {
             }
         };
 
-        let processed_writer = source.processed_writer()?;
+        let processed_writer = source.processed_writer();
 
         let new_hash = {
             // Create a reader just for computing the hash. Keep this scoped here so that we drop it
@@ -1278,15 +1374,12 @@ impl AssetProcessor {
                                     error!("Failed to remove asset {path:?}: {message}");
                                     state_is_valid = false;
                                 };
-                                let Ok(source) = self.get_source(path.source()) else {
-                                    unrecoverable_err(&"AssetSource does not exist");
-                                    continue;
-                                };
-                                let Ok(processed_writer) = source.processed_writer() else {
-                                    unrecoverable_err(&"AssetSource does not have a processed AssetWriter registered");
+                                let Ok(source) = self.data.sources.get_source(path.source()) else {
+                                    unrecoverable_err(&"Processed asset source does not exist");
                                     continue;
                                 };
 
+                                let processed_writer = source.processed_writer();
                                 if let Err(err) = processed_writer.remove(path.path()).await {
                                     match err {
                                         AssetWriterError::Io(err) => {
@@ -1316,11 +1409,9 @@ impl AssetProcessor {
 
             if !state_is_valid {
                 error!("Processed asset transaction log state was invalid and unrecoverable for some reason (see previous logs). Removing processed assets and starting fresh.");
-                for source in self.sources().iter_processed() {
-                    let Ok(processed_writer) = source.processed_writer() else {
-                        continue;
-                    };
-                    if let Err(err) = processed_writer
+                for (_, source) in self.data.sources.iter() {
+                    if let Err(err) = source
+                        .processed_writer()
                         .remove_assets_in_directory(Path::new(""))
                         .await
                     {
@@ -1339,10 +1430,31 @@ impl AssetProcessor {
 
 impl AssetProcessorData {
     /// Initializes a new [`AssetProcessorData`] using the given [`AssetSources`].
-    pub(crate) fn new(sources: Arc<AssetSources>, processing_state: Arc<ProcessingState>) -> Self {
+    pub(crate) fn new(
+        mut unprocessed_sources: HashMap<AssetSourceId<'static>, AssetSource>,
+        ungated_processed_readers_and_writers: HashMap<
+            AssetSourceId<'static>,
+            (Arc<dyn ErasedAssetReader>, Box<dyn ErasedAssetWriter>),
+        >,
+        processing_state: Arc<ProcessingState>,
+    ) -> Self {
+        let mut processed_sources = ProcessedSources::default();
+        for (id, (ungated_processed_reader, processed_writer)) in
+            ungated_processed_readers_and_writers
+        {
+            let unprocessed_source = unprocessed_sources
+                .remove(&id)
+                .expect("there is an unprocessed source for each processed reader");
+            let processed_source = ProcessedSource {
+                unprocessed_source,
+                ungated_processed_reader,
+                processed_writer,
+            };
+            processed_sources.insert(id, processed_source);
+        }
         AssetProcessorData {
             processing_state,
-            sources,
+            sources: processed_sources,
             log_factory: Mutex::new(Some(Box::new(FileTransactionLogFactory::default()))),
             log: Default::default(),
             processors: Default::default(),

--- a/crates/bevy_asset/src/processor/mod.rs
+++ b/crates/bevy_asset/src/processor/mod.rs
@@ -253,6 +253,7 @@ impl AssetProcessor {
         unprocessed_sources: &mut AssetSourceBuilders,
         final_sources: &mut AssetSourceBuilders,
         watch_processed: bool,
+        default_transaction_log_factory: Box<dyn ProcessorTransactionLogFactory + 'static>,
     ) -> (Self, Arc<AssetSources>) {
         let state = Arc::new(ProcessingState::new());
 
@@ -270,6 +271,7 @@ impl AssetProcessor {
             unprocessed_sources,
             ungated_processed_readers_and_writers,
             state,
+            default_transaction_log_factory,
         ));
         // The asset processor uses its own asset server with its own id space
         let server = AssetServer::new_with_meta_check(
@@ -1437,6 +1439,7 @@ impl AssetProcessorData {
             (Arc<dyn ErasedAssetReader>, Box<dyn ErasedAssetWriter>),
         >,
         processing_state: Arc<ProcessingState>,
+        default_transaction_log_factory: Box<dyn ProcessorTransactionLogFactory + 'static>,
     ) -> Self {
         let mut processed_sources = ProcessedSources::default();
         for (id, (ungated_processed_reader, processed_writer)) in
@@ -1455,7 +1458,7 @@ impl AssetProcessorData {
         AssetProcessorData {
             processing_state,
             sources: processed_sources,
-            log_factory: Mutex::new(Some(Box::new(FileTransactionLogFactory::default()))),
+            log_factory: Mutex::new(Some(default_transaction_log_factory)),
             log: Default::default(),
             processors: Default::default(),
         }

--- a/crates/bevy_asset/src/processor/tests.rs
+++ b/crates/bevy_asset/src/processor/tests.rs
@@ -72,7 +72,24 @@ fn create_empty_asset_processor() -> AssetProcessor {
         AssetSourceBuilder::new(move || Box::new(memory_reader.clone())),
     );
 
-    AssetProcessor::new(&mut sources, false).0
+    let processed_dir = Dir::default();
+    let processed_dir_clone = processed_dir.clone();
+    let mut final_sources = AssetSourceBuilders::default();
+    final_sources.insert(
+        AssetSourceId::Default,
+        AssetSourceBuilder::new(move || {
+            Box::new(MemoryAssetReader {
+                root: processed_dir_clone.clone(),
+            })
+        })
+        .with_writer(move |_| {
+            Some(Box::new(MemoryAssetWriter {
+                root: processed_dir.clone(),
+            }))
+        }),
+    );
+
+    AssetProcessor::new(&mut sources, &mut final_sources, false).0
 }
 
 #[test]
@@ -340,16 +357,16 @@ fn create_app_with_asset_processor(extra_sources: &[String]) -> AppWithProcessor
 
         impl AssetWatcher for FakeWatcher {}
 
-        app.register_asset_source(
-            source_id,
+        app.register_processed_asset_source_with_final_source(
+            source_id.clone(),
             AssetSourceBuilder::new(move || Box::new(source_memory_reader.clone()))
                 .with_writer(move |_| Some(Box::new(source_memory_writer.clone())))
                 .with_watcher(move |sender: async_channel::Sender<AssetSourceEvent>| {
                     source_event_sender_sender.send_blocking(sender).unwrap();
                     Some(Box::new(FakeWatcher))
-                })
-                .with_processed_reader(move || Box::new(processed_memory_reader.clone()))
-                .with_processed_writer(move |_| Some(Box::new(processed_memory_writer.clone()))),
+                }),
+            AssetSourceBuilder::new(move || Box::new(processed_memory_reader.clone()))
+                .with_writer(move |_| Some(Box::new(processed_memory_writer.clone()))),
         );
 
         UnfinishedProcessingDirs {
@@ -407,10 +424,10 @@ fn run_app_until_finished_processing(app: &mut App, guard: RwLockWriteGuard<'_, 
     // yet. So wait for processing to start, then finish.
     run_app_until(app, |_| {
         // Before we even consider whether the processor is started, make sure that none of the
-        // receivers have anything left in them. This prevents us accidentally, considering the
+        // receivers have anything left in them. This prevents us accidentally considering the
         // processor as processing before all the events have been processed.
-        for source in processor.sources().iter() {
-            let Some(recv) = source.event_receiver() else {
+        for (_, source) in processor.data.sources.iter() {
+            let Some(recv) = source.unprocessed_event_receiver() else {
                 continue;
             };
             if !recv.is_empty() {
@@ -1632,11 +1649,11 @@ fn only_reprocesses_wrong_hash_on_startup() {
         root: default_processed_dir.clone(),
     };
 
-    app.register_asset_source(
+    app.register_processed_asset_source_with_final_source(
         AssetSourceId::Default,
-        AssetSourceBuilder::new(move || Box::new(source_memory_reader.clone()))
-            .with_processed_reader(move || Box::new(processed_memory_reader.clone()))
-            .with_processed_writer(move |_| Some(Box::new(processed_memory_writer.clone()))),
+        AssetSourceBuilder::new(move || Box::new(source_memory_reader.clone())),
+        AssetSourceBuilder::new(move || Box::new(processed_memory_reader.clone()))
+            .with_writer(move |_| Some(Box::new(processed_memory_writer.clone()))),
     );
 
     app.add_plugins((

--- a/crates/bevy_asset/src/processor/tests.rs
+++ b/crates/bevy_asset/src/processor/tests.rs
@@ -89,7 +89,13 @@ fn create_empty_asset_processor() -> AssetProcessor {
         }),
     );
 
-    AssetProcessor::new(&mut sources, &mut final_sources, false).0
+    AssetProcessor::new(
+        &mut sources,
+        &mut final_sources,
+        false,
+        Box::new(FakeTransactionLogFactory),
+    )
+    .0
 }
 
 #[test]
@@ -254,48 +260,48 @@ fn serialize_as_cool_text(text: &str) -> String {
     ron::ser::to_string_pretty(&cool_text_ron, PrettyConfig::new().new_line("\n")).unwrap()
 }
 
+/// A dummy transaction log factory that just creates [`FakeTransactionLog`].
+struct FakeTransactionLogFactory;
+
+impl ProcessorTransactionLogFactory for FakeTransactionLogFactory {
+    fn read(&self) -> BoxedFuture<'_, Result<Vec<LogEntry>, BevyError>> {
+        Box::pin(async move { Ok(vec![]) })
+    }
+
+    fn create_new_log(
+        &self,
+    ) -> BoxedFuture<'_, Result<Box<dyn ProcessorTransactionLog>, BevyError>> {
+        Box::pin(async move { Ok(Box::new(FakeTransactionLog) as _) })
+    }
+}
+
+/// A dummy transaction log that just drops every log.
+// TODO: In the future it's possible for us to have a test of the transaction log, so making
+// this more complex may be necessary.
+struct FakeTransactionLog;
+
+impl ProcessorTransactionLog for FakeTransactionLog {
+    fn begin_processing<'a>(
+        &'a mut self,
+        _asset: &'a AssetPath<'_>,
+    ) -> BoxedFuture<'a, Result<(), BevyError>> {
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn end_processing<'a>(
+        &'a mut self,
+        _asset: &'a AssetPath<'_>,
+    ) -> BoxedFuture<'a, Result<(), BevyError>> {
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn unrecoverable(&mut self) -> BoxedFuture<'_, Result<(), BevyError>> {
+        Box::pin(async move { Ok(()) })
+    }
+}
+
 /// Sets the transaction log for the app to a fake one to prevent touching the filesystem.
 fn set_fake_transaction_log(app: &mut App) {
-    /// A dummy transaction log factory that just creates [`FakeTransactionLog`].
-    struct FakeTransactionLogFactory;
-
-    impl ProcessorTransactionLogFactory for FakeTransactionLogFactory {
-        fn read(&self) -> BoxedFuture<'_, Result<Vec<LogEntry>, BevyError>> {
-            Box::pin(async move { Ok(vec![]) })
-        }
-
-        fn create_new_log(
-            &self,
-        ) -> BoxedFuture<'_, Result<Box<dyn ProcessorTransactionLog>, BevyError>> {
-            Box::pin(async move { Ok(Box::new(FakeTransactionLog) as _) })
-        }
-    }
-
-    /// A dummy transaction log that just drops every log.
-    // TODO: In the future it's possible for us to have a test of the transaction log, so making
-    // this more complex may be necessary.
-    struct FakeTransactionLog;
-
-    impl ProcessorTransactionLog for FakeTransactionLog {
-        fn begin_processing<'a>(
-            &'a mut self,
-            _asset: &'a AssetPath<'_>,
-        ) -> BoxedFuture<'a, Result<(), BevyError>> {
-            Box::pin(async move { Ok(()) })
-        }
-
-        fn end_processing<'a>(
-            &'a mut self,
-            _asset: &'a AssetPath<'_>,
-        ) -> BoxedFuture<'a, Result<(), BevyError>> {
-            Box::pin(async move { Ok(()) })
-        }
-
-        fn unrecoverable(&mut self) -> BoxedFuture<'_, Result<(), BevyError>> {
-            Box::pin(async move { Ok(()) })
-        }
-    }
-
     app.world()
         .resource::<AssetProcessor>()
         .data()

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -70,7 +70,6 @@ pub(crate) struct AssetServerData {
     asset_event_sender: Sender<InternalAssetEvent>,
     asset_event_receiver: Receiver<InternalAssetEvent>,
     sources: Arc<AssetSources>,
-    mode: AssetServerMode,
     meta_check: AssetMetaCheck,
     unapproved_path_mode: UnapprovedPathMode,
 }
@@ -92,14 +91,12 @@ impl AssetServer {
     /// asset sources and hot-reload them.
     pub fn new(
         sources: Arc<AssetSources>,
-        mode: AssetServerMode,
         watching_for_changes: bool,
         unapproved_path_mode: UnapprovedPathMode,
     ) -> Self {
         Self::new_with_loaders(
             sources,
             Default::default(),
-            mode,
             AssetMetaCheck::Always,
             watching_for_changes,
             unapproved_path_mode,
@@ -110,7 +107,6 @@ impl AssetServer {
     /// asset sources and hot-reload them.
     pub fn new_with_meta_check(
         sources: Arc<AssetSources>,
-        mode: AssetServerMode,
         meta_check: AssetMetaCheck,
         watching_for_changes: bool,
         unapproved_path_mode: UnapprovedPathMode,
@@ -118,7 +114,6 @@ impl AssetServer {
         Self::new_with_loaders(
             sources,
             Default::default(),
-            mode,
             meta_check,
             watching_for_changes,
             unapproved_path_mode,
@@ -128,7 +123,6 @@ impl AssetServer {
     pub(crate) fn new_with_loaders(
         sources: Arc<AssetSources>,
         loaders: Arc<RwLock<AssetLoaders>>,
-        mode: AssetServerMode,
         meta_check: AssetMetaCheck,
         watching_for_changes: bool,
         unapproved_path_mode: UnapprovedPathMode,
@@ -139,7 +133,6 @@ impl AssetServer {
         Self {
             data: Arc::new(AssetServerData {
                 sources,
-                mode,
                 meta_check,
                 asset_event_sender,
                 asset_event_receiver,
@@ -1143,33 +1136,29 @@ impl AssetServer {
                     return;
                 };
 
-                let asset_reader = match server.data.mode {
-                    AssetServerMode::Unprocessed => source.reader(),
-                    AssetServerMode::Processed => match source.processed_reader() {
-                        Ok(reader) => reader,
-                        Err(_) => {
-                            error!(
-                                "Failed to load {path}. AssetSource {} does not have a processed AssetReader",
-                                path.source()
-                            );
-                            return;
-                        }
-                    },
-                };
-
                 let mut handles = Vec::new();
-                match load_folder(source.id(), path.path(), asset_reader, &server, &mut handles).await {
+                match load_folder(
+                    source.id(),
+                    path.path(),
+                    source.reader(),
+                    &server,
+                    &mut handles,
+                )
+                .await
+                {
                     Ok(_) => server.send_asset_event(InternalAssetEvent::Loaded {
                         index,
-                        loaded_asset: LoadedAsset::new_with_dependencies(
-                            LoadedFolder { handles },
-                        )
-                        .into(),
+                        loaded_asset: LoadedAsset::new_with_dependencies(LoadedFolder { handles })
+                            .into(),
                     }),
                     Err(err) => {
                         error!("Failed to load folder. {err}");
-                        server.send_asset_event(InternalAssetEvent::Failed { index, error: err, path });
-                    },
+                        server.send_asset_event(InternalAssetEvent::Failed {
+                            index,
+                            error: err,
+                            path,
+                        });
+                    }
                 }
             })
             .detach();
@@ -1406,11 +1395,6 @@ impl AssetServer {
         Some(info.path.as_ref()?.clone())
     }
 
-    /// Returns the [`AssetServerMode`] this server is currently in.
-    pub fn mode(&self) -> AssetServerMode {
-        self.data.mode
-    }
-
     /// Pre-register a loader that will later be added.
     ///
     /// Assets loaded with matching extensions will be blocked until the
@@ -1468,10 +1452,7 @@ impl AssetServer {
         AssetLoadError,
     > {
         let source = self.get_source(asset_path.source())?;
-        let asset_reader = match self.data.mode {
-            AssetServerMode::Unprocessed => source.reader(),
-            AssetServerMode::Processed => source.processed_reader()?,
-        };
+        let asset_reader = source.reader();
         let read_meta = match &self.data.meta_check {
             AssetMetaCheck::Always => true,
             AssetMetaCheck::Paths(paths) => paths.contains(asset_path),
@@ -1899,20 +1880,9 @@ pub fn handle_internal_asset_events(world: &mut World) {
         };
 
         for source in server.data.sources.iter() {
-            match server.data.mode {
-                AssetServerMode::Unprocessed => {
-                    if let Some(receiver) = source.event_receiver() {
-                        while let Ok(event) = receiver.try_recv() {
-                            handle_event(source.id(), event);
-                        }
-                    }
-                }
-                AssetServerMode::Processed => {
-                    if let Some(receiver) = source.processed_event_receiver() {
-                        while let Ok(event) = receiver.try_recv() {
-                            handle_event(source.id(), event);
-                        }
-                    }
+            if let Some(receiver) = source.event_receiver() {
+                while let Ok(event) = receiver.try_recv() {
+                    handle_event(source.id(), event);
                 }
             }
         }

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -1722,8 +1722,12 @@ impl AssetServer {
     /// meta file that will use the default asset processor for the path, see
     /// [`AssetProcessor::write_default_meta_file_for_path`].
     ///
-    /// Note if there is already a meta file for `path`, this function returns
+    /// If there is already a meta file for `path`, this function returns
     /// `Err(WriteDefaultMetaError::MetaAlreadyExists)`.
+    ///
+    /// This function will also fail for "processed" asset sources, with
+    /// `Err(WriteDefaultMetaError::MissingAssetWriter)`. Use
+    /// [`AssetProcessor::write_default_meta_file_for_path`] for these sources.
     ///
     /// [`AssetProcessor::write_default_meta_file_for_path`]:  crate::AssetProcessor::write_default_meta_file_for_path
     pub async fn write_default_loader_meta_file_for_path(

--- a/examples/asset/extra_source.rs
+++ b/examples/asset/extra_source.rs
@@ -18,7 +18,7 @@ fn main() {
         // This must be done before AssetPlugin finalizes building assets.
         .register_asset_source(
             "example_files",
-            AssetSourceBuilder::platform_default("examples/asset/files", None),
+            AssetSourceBuilder::platform_default("examples/asset/files"),
         )
         // DefaultPlugins contains AssetPlugin so it must be added to our App
         // after inserting our new asset source.

--- a/examples/asset/processing/asset_processing.rs
+++ b/examples/asset/processing/asset_processing.rs
@@ -32,8 +32,7 @@ fn main() {
                 // This is just overriding the default paths to scope this to the correct example folder
                 // You can generally skip this in your own projects
                 file_path: "examples/asset/processing/assets".to_string(),
-                processed_file_path: "examples/asset/processing/imported_assets/Default"
-                    .to_string(),
+                processed_file_path: "examples/asset/processing/imported_assets".to_string(),
                 ..default()
             }),
             TextPlugin,

--- a/release-content/migration-guides/asset_sources_no_processed_reader.md
+++ b/release-content/migration-guides/asset_sources_no_processed_reader.md
@@ -3,7 +3,7 @@ title: Asset sources no longer contain "processed" versions of its fields.
 pull_requests: []
 ---
 
-In previous versions of Bevy, as sources contained two "parts". The "regular" part (i.e., the
+In previous versions of Bevy, asset sources contained two "parts". The "regular" part (i.e., the
 unprocessed reader, writer, watcher, etc) and the "processed" part (i.e., the processed reader,
 writer, watcher, etc). For many sources, these were actually duplicated. For example, the "web"
 asset source set its `reader` and `processed_reader` to the same value.
@@ -37,8 +37,8 @@ processing).
    `register_asset_source` directly). Come talk to us in the Bevy Discord `#assets-dev` to help us
    understand your use case!
 
-3. If you do not need the default asset source to be processed, you may remove `AssetPlugin::mode`
-   from the `AssetPlugin.
+3. If you do not need the default asset source to be processed, set `AssetPlugin::mode` to
+   `AssetMode::Unprocessed` in the `AssetPlugin`.
 
 So for example, if your app looks like the following:
 
@@ -85,7 +85,8 @@ fn main() {
                     ).unwrap()))
         )
         .add_plugins(DefaultPlugins.set(AssetPlugin {
-            // Remove this if you don't want the default source to be processed.
+            // If you don't want the default source to be processed, set this to
+            // `AssetMode::Unprocessed` (which is the default for `AssetPlugin`).
             mode: AssetMode::Processed,
             ..Default::default()
         }))

--- a/release-content/migration-guides/asset_sources_no_processed_reader.md
+++ b/release-content/migration-guides/asset_sources_no_processed_reader.md
@@ -1,0 +1,98 @@
+---
+title: Asset sources no longer contain "processed" versions of its fields.
+pull_requests: []
+---
+
+In previous versions of Bevy, as sources contained two "parts". The "regular" part (i.e., the
+unprocessed reader, writer, watcher, etc) and the "processed" part (i.e., the processed reader,
+writer, watcher, etc). For many sources, these were actually duplicated. For example, the "web"
+asset source set its `reader` and `processed_reader` to the same value.
+
+Now, asset sources contain only a single part. There's now only one reader, writer, watcher, etc.
+Processed sources now need to explicitly specify that they intend to be processed. Processed sources
+also create their processed reader, writer, watcher, etc, automatically!
+
+**For users who don't use asset processing:** nothing changes! Presumably your asset sources already
+don't include any of the "processed" versions, and registering unprocessed sources remain the same.
+You should be able to ignore this migration guide (though we do recommend users try using asset
+processing).
+
+**For users who do use asset processing:** do with the following.
+
+1. For asset sources that should be processed, replace `app.register_asset_source(...)` with
+   `app.register_processed_asset_source(...)`.
+2. Remove any instances of:
+   1. `source_builder.with_processed_reader(...)`
+   2. `source_builder.with_processed_writer(...)`
+   3. `source_builder.with_processed_watcher(...)`
+   4. `source_builder.with_processed_watch_warning(...)`
+
+   The processing system now automatically creates these readers for you (as regular file readers
+   into the `imported_assets` folder, or whatever folder is set as the processed path).
+
+   **For advanced users:** you may override the automatically created processed source using
+   `set_processed_asset_source_for_unprocessed_source`. Consider whether you actually need this
+   though. It may be more efficient to use the automatic source during dev, and then use a
+   completely different "bundled" source when publishing (where you would just use
+   `register_asset_source` directly). Come talk to us in the Bevy Discord `#assets-dev` to help us
+   understand your use case!
+
+3. If you do not need the default asset source to be processed, you may remove `AssetPlugin::mode`
+   from the `AssetPlugin.
+
+So for example, if your app looks like the following:
+
+```rust
+fn main() {
+    App::new()
+        .register_asset_source(
+            AssetSourceBuilder::new(|| Box::new(FileAssetReader::new("some/unprocessed/path")))
+                .with_watcher(|sender| Box::new(FileWatcher::new(
+                        Path::new("some/unprocessed/path").into(),
+                        sender,
+                        Duration::from_secs(1.0),
+                    ).unwrap()))
+                .with_processed_reader(|| Box::new(FileAssetReader::new("the/processed/path")))
+                .with_processed_writer(|create_root| Box::new(FileAssetWriter::new(
+                        "the/processed/path",
+                        create_root,
+                    )))
+                .with_processed_watcher(|sender| Box::new(FileWatcher::new(
+                        Path::new("the/processed/path").into(),
+                        sender,
+                        Duration::from_secs(1.0),
+                    ).unwrap()))
+        )
+        .add_plugins(DefaultPlugins.set(AssetPlugin {
+            mode: AssetMode::Processed,
+            ..Default::default()
+        }))
+        .run();
+}
+```
+
+Now, it would look like:
+
+```rust
+fn main() {
+    App::new()
+        .register_processed_asset_source(
+            AssetSourceBuilder::new(|| Box::new(FileAssetReader::new("some/unprocessed/path")))
+                .with_watcher(|sender| Box::new(FileWatcher::new(
+                        Path::new("some/unprocessed/path").into(),
+                        sender,
+                        Duration::from_secs(1.0),
+                    ).unwrap()))
+        )
+        .add_plugins(DefaultPlugins.set(AssetPlugin {
+            // Remove this if you don't want the default source to be processed.
+            mode: AssetMode::Processed,
+            ..Default::default()
+        }))
+        .run();
+}
+```
+
+As an added consequence of this, `AssetServer::write_default_loader_meta_file_for_path` no longer
+works for processed asset sources. Instead, you can use
+`AssetProcessor::write_default_meta_file_for_path` for these asset sources.

--- a/release-content/migration-guides/asset_sources_no_processed_reader.md
+++ b/release-content/migration-guides/asset_sources_no_processed_reader.md
@@ -31,7 +31,7 @@ processing).
    into the `imported_assets` folder, or whatever folder is set as the processed path).
 
    **For advanced users:** you may override the automatically created processed source using
-   `set_processed_asset_source_for_unprocessed_source`. Consider whether you actually need this
+   `register_processed_asset_source_with_final_source`. Consider whether you actually need this
    though. It may be more efficient to use the automatic source during dev, and then use a
    completely different "bundled" source when publishing (where you would just use
    `register_asset_source` directly). Come talk to us in the Bevy Discord `#assets-dev` to help us
@@ -76,10 +76,22 @@ Now, it would look like:
 ```rust
 fn main() {
     App::new()
-        .register_processed_asset_source(
+        .register_processed_asset_source_with_final_source(
             AssetSourceBuilder::new(|| Box::new(FileAssetReader::new("some/unprocessed/path")))
                 .with_watcher(|sender| Box::new(FileWatcher::new(
                         Path::new("some/unprocessed/path").into(),
+                        sender,
+                        Duration::from_secs(1.0),
+                    ).unwrap())),
+            // Note: if you don't care where the processed assets end up, omit this and use
+            // `register_processed_asset_source` instead!
+            AssetSourceBuilder::new(|| Box::new(FileAssetReader::new("the/processed/path")))
+                .with_writer(|create_root| Box::new(FileAssetWriter::new(
+                        "the/processed/path",
+                        create_root,
+                    )))
+                .with_watcher(|sender| Box::new(FileWatcher::new(
+                        Path::new("the/processed/path").into(),
                         sender,
                         Duration::from_secs(1.0),
                     ).unwrap()))


### PR DESCRIPTION
# Objective

- Previously, asset sources were kind of annoying to create. A big reason for this is the fact that you need to define both the reader **and** the processed reader. Otherwise, your asset source would not be usable if `AssetPlugin::mode` was set to `Processed`.
    - In other words, asset sources were not very composable, since you may want to handle the processed and unprocessed assets differently.
- In addition, the whole asset processing system was "entangled" with the rest of the asset system - everywhere we needed to read assets we'd need to match on the `AssetPlugin::mode`, and pick the appropriate reader. In all these cases though, we just wanted to read the final assets.

## Solution

- `AssetSources` now only include the final sources (the sources that your game will read).
- When registering sources, there are now two methods `register_asset_source` (for sources that won't be processed), or `register_processed_asset_source` (for sources that should be processed).  Users need to pick which one they want.
    - `register_processed_asset_source` stores the asset source in a separate `UnprocessedAssetSourceBuilders` resource. Later in `AssetPlugin` we create the processed source for each unprocessed source.

This significantly decouples asset processing from the rest of the asset system. There are 2 main ways that they remain coupled now:

1. We can't build the asset sources until the AssetPlugin is added. This means we don't have things like the `ProcessingState` to gate the processed sources on. This means the AssetPlugin (which builds the sources) needs to know about processing to create the sources.
    - If we had runtime asset sources, we could initialize the `ProcessingState` in a `ProcessingPlugin`, and then immediately create the asset sources when calling `register_processed_asset_source` without needing to wait or deal with this in the `AssetPlugin`.
2. We don't have a good way to make the default asset source processed. Currently this is controlled by `AssetPlugin::mode`.
    - Solving this would also be nice for runtime asset sources.

Solving this coupling would also make it easier to turn asset processing on and off: currently, it's a feature on `bevy_asset`. This could instead be a plugin the is conditionally added in `DefaultPlugins` - meaning we have to recompile much less.

## Testing

- Ran the `asset_processing` example. It works with and without the `asset_processor` enabled (i.e., in dev and in prod).