### PR TITLE
Fix `bevy_diagnostic` rustdoc issues

### DIFF
--- a/crates/bevy_diagnostic/src/diagnostic.rs
+++ b/crates/bevy_diagnostic/src/diagnostic.rs
@@ -213,7 +213,7 @@ impl Diagnostic {
     /// apart, no smoothing will be applied. As measurements come in more
     /// frequently, the smoothing takes a greater effect such that it takes
     /// approximately `smoothing_factor` seconds for 83% of an instantaneous
-    /// change in measurement to e reflected in the smoothed value.
+    /// change in measurement to be reflected in the smoothed value.
     ///
     /// A smoothing factor of 0.0 will effectively disable smoothing.
     #[must_use]
@@ -239,7 +239,7 @@ impl Diagnostic {
     }
 
     /// Return the simple moving average of this diagnostic's recent values.
-    /// N.B. this a cheap operation as the sum is cached.
+    /// N.B. this is a cheap operation as the sum is cached.
     pub fn average(&self) -> Option<f64> {
         if !self.history.is_empty() {
             Some(self.sum / self.history.len() as f64)
@@ -314,12 +314,12 @@ impl DiagnosticsStore {
         self.diagnostics.insert(diagnostic.path.clone(), diagnostic);
     }
 
-    /// Get the [`DiagnosticMeasurement`] with the given [`DiagnosticPath`], if it exists.
+    /// Get the [`Diagnostic`] with the given [`DiagnosticPath`], if it exists.
     pub fn get(&self, path: &DiagnosticPath) -> Option<&Diagnostic> {
         self.diagnostics.get(path)
     }
 
-    /// Mutably get the [`DiagnosticMeasurement`] with the given [`DiagnosticPath`], if it exists.
+    /// Mutably get the [`Diagnostic`] with the given [`DiagnosticPath`], if it exists.
     pub fn get_mut(&mut self, path: &DiagnosticPath) -> Option<&mut Diagnostic> {
         self.diagnostics.get_mut(path)
     }

--- a/crates/bevy_diagnostic/src/lib.rs
+++ b/crates/bevy_diagnostic/src/lib.rs
@@ -8,7 +8,7 @@
 
 //! This crate provides a straightforward solution for integrating diagnostics in the [Bevy game engine](https://bevy.org/).
 //! It allows users to easily add diagnostic functionality to their Bevy applications, enhancing
-//! their ability to monitor and optimize their game's.
+//! their ability to monitor and optimize their games.
 
 #[cfg(feature = "std")]
 extern crate std;


### PR DESCRIPTION
While reading `bevy_diagnostic` rustdoc, I noticed two instances of wrong types being used in the rustdoc compared to the actual signature of the function. After discovering this, I gave the whole create a review for simple doc fixes and found a couple of extra ones that this PR now also fixes.

(Skipping PR template due to the triviality of the PR)


