### PR TITLE
Clear view upscaling pipelines on render recovery

### DIFF
--- a/crates/bevy_core_pipeline/src/upscaling/mod.rs
+++ b/crates/bevy_core_pipeline/src/upscaling/mod.rs
@@ -36,6 +36,7 @@ impl Plugin for UpscalingPlugin {
 #[derive(Component)]
 pub struct ViewUpscalingPipeline(CachedRenderPipelineId, BlitPipelineKey);
 
+/// This is not required on first startup but is required during render recovery
 fn clear_view_upscaling_pipelines(
     mut commands: Commands,
     views: Query<Entity, With<ViewUpscalingPipeline>>,


### PR DESCRIPTION
# Objective

- Continue Render Recovery efforts #23350 #22761 #23433
- Part of goal #23029

## Solution

- Clear view upscaling pipelines on reload

## Testing

- existing examples run fine. render_recovery example does not work yet, but in combination with the other fixes and some not-yet-PR'd fixes this is a load bearing change needed for it to work
