### PR TITLE
Add NoCpuCulling to bevy_city

### DIFF
--- a/examples/large_scenes/bevy_city/src/main.rs
+++ b/examples/large_scenes/bevy_city/src/main.rs
@@ -4,7 +4,7 @@ use argh::FromArgs;
 use assets::{load_assets, CityAssets};
 use bevy::{
     anti_alias::taa::TemporalAntiAliasing,
-    camera::{Exposure, Hdr},
+    camera::{visibility::NoCpuCulling, Exposure, Hdr},
     camera_controller::free_camera::{FreeCamera, FreeCameraPlugin},
     color::palettes::css::WHITE,
     feathers::{dark_theme::create_dark_theme, theme::UiTheme, FeathersPlugins},
@@ -15,6 +15,7 @@ use bevy::{
     },
     post_process::bloom::Bloom,
     prelude::*,
+    scene::SceneInstanceReady,
     window::{PresentMode, WindowResolution},
     winit::WinitSettings,
 };
@@ -36,6 +37,10 @@ pub struct Args {
     /// size
     #[argh(option, default = "30")]
     size: u32,
+
+    /// adds NoCpuCulling to all meshes
+    #[argh(switch)]
+    no_cpu_culling: bool,
 }
 
 fn main() {
@@ -75,10 +80,11 @@ fn main() {
                 setup,
                 setup_settings_ui,
                 load_assets,
-                setup_city.after(load_assets),
+                (setup_city.after(load_assets), add_no_cpu_culling).chain(),
             ),
         )
         .add_systems(Update, simulate_cars)
+        .add_observer(add_no_cpu_culling_on_scene_ready)
         .run();
 }
 
@@ -157,6 +163,34 @@ fn simulate_cars(
 
             let progress = car.distance_traveled / road_len;
             car_transform.translation = (road.start + car.offset) + direction * road_len * progress;
+        }
+    }
+}
+
+fn add_no_cpu_culling(
+    mut commands: Commands,
+    meshes: Query<Entity, (With<Mesh3d>, Without<NoCpuCulling>)>,
+    args: Res<Args>,
+) {
+    if args.no_cpu_culling {
+        for entity in meshes.iter() {
+            commands.entity(entity).insert(NoCpuCulling);
+        }
+    }
+}
+
+fn add_no_cpu_culling_on_scene_ready(
+    scene_ready: On<SceneInstanceReady>,
+    mut commands: Commands,
+    children: Query<&Children>,
+    meshes: Query<(), (With<Mesh3d>, Without<NoCpuCulling>)>,
+    args: Res<Args>,
+) {
+    if args.no_cpu_culling {
+        for descendant in children.iter_descendants(scene_ready.entity) {
+            if meshes.get(descendant).is_ok() {
+                commands.entity(descendant).insert(NoCpuCulling);
+            }
         }
     }
 }


### PR DESCRIPTION
# Objective

- We want to see the impact of `NoCpuCulling` in `bevy_city`

## Solution

- Add a new flag that adds the component on all meshes in the scene

## Testing

- I ran bevy_city with and without the flag. On my machine enabling it went from 82fps to 95fps and being effectively gpu bound.
