### PR TITLE
Add needs_shader_reload to PipelineCache

### DIFF
--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -211,6 +211,8 @@ pub struct PipelineCache {
     /// If `true`, disables asynchronous pipeline compilation.
     /// This has no effect on macOS, wasm, or without the `multi_threaded` feature.
     pub(crate) synchronous_pipeline_compilation: bool,
+    /// If `true`, the shader cache needs to be repopulated from the main world's `Assets<Shader>`.
+    needs_shader_reload: bool,
 }
 
 impl PipelineCache {
@@ -262,6 +264,7 @@ impl PipelineCache {
             pipelines: default(),
             global_shader_defs,
             synchronous_pipeline_compilation,
+            needs_shader_reload: true,
         }
     }
 
@@ -719,6 +722,18 @@ impl PipelineCache {
         shaders: Extract<Res<Assets<Shader>>>,
         mut events: Extract<MessageReader<AssetEvent<Shader>>>,
     ) {
+        if cache.needs_shader_reload {
+            cache.needs_shader_reload = false;
+            for (id, shader) in shaders.iter() {
+                let mut shader = shader.clone();
+                shader.shader_defs.extend(cache.global_shader_defs.clone());
+                cache.set_shader(id, shader);
+            }
+            // Drain events so we don't double-process shaders we just loaded.
+            for _ in events.read() {}
+            return;
+        }
+
         for event in events.read() {
             #[expect(
                 clippy::match_same_arms,


### PR DESCRIPTION
# Objective

- Continue Render Recovery efforts #23350 #22761 #23433 #23458 #23459
- Part of goal #23029
- Make shaders work after reload

## Solution

- This is a kinda ugly hack. I explored like 5 different ways of doing this, none of them are satisfying and they are all much larger diffs than this. The crux of the problem is that the composer's capabilities may differ on the new device, due to switching from dedicated to integrated GPU. This means that we cannot even retain the composed modules. The ShaderCache and PipelineCache are quite annoyingly tangled, and I have some glimpses of how to fix it in the future but I dont want to block render recovery on it.
- For now, we just do the kinda brute force thing and reinsert all the shaders, recompose etc

## Testing

- examples run
- in combination with the rest of the fixes and a couple other local changes i havent PRd yet, render_recovery example works. 