### PR TITLE
render asset recovery

### DIFF
--- a/crates/bevy_core_pipeline/src/tonemapping/mod.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/mod.rs
@@ -427,7 +427,8 @@ fn setup_tonemapping_lut_image(bytes: &[u8], image_type: ImageType) -> Image {
         CompressedImageFormats::NONE,
         false,
         image_sampler,
-        RenderAssetUsages::RENDER_WORLD,
+        // LUT must be kept in main world for render recovery reasons
+        RenderAssetUsages::default(),
     )
     .unwrap()
 }

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -259,6 +259,10 @@ impl Plugin for MeshRenderPlugin {
                     .init_gpu_resource::<RenderMeshInstanceGpuQueues>()
                     .init_resource::<MeshesToReextractNextFrame>()
                     .add_systems(
+                        RenderStartup,
+                        mark_all_meshes_for_reextraction,
+                    )
+                    .add_systems(
                         ExtractSchedule,
                             extract_meshes_for_gpu_building.in_set(MeshExtractionSystems),
                     )
@@ -324,6 +328,23 @@ impl Plugin for MeshRenderPlugin {
             ShaderSettings {
                 shader_defs: mesh_bindings_shader_defs.clone(),
             });
+    }
+}
+
+/// Drains all entities from [`RenderMeshInstances`] into [`MeshesToReextractNextFrame`].
+fn mark_all_meshes_for_reextraction(
+    mut render_mesh_instances: ResMut<RenderMeshInstances>,
+    mut meshes_to_reextract: ResMut<MeshesToReextractNextFrame>,
+) {
+    match *render_mesh_instances {
+        RenderMeshInstances::CpuBuilding(ref mut cpu) => {
+            meshes_to_reextract.extend(cpu.keys());
+            cpu.clear();
+        }
+        RenderMeshInstances::GpuBuilding(ref mut gpu) => {
+            meshes_to_reextract.extend(gpu.keys());
+            gpu.clear();
+        }
     }
 }
 

--- a/crates/bevy_render/src/erased_render_asset.rs
+++ b/crates/bevy_render/src/erased_render_asset.rs
@@ -1,6 +1,6 @@
 use crate::{
     render_resource::AsBindGroupError, ExtractSchedule, MainWorld, Render, RenderApp,
-    RenderSystems, Res,
+    RenderStartup, RenderSystems, Res,
 };
 use bevy_app::{App, Plugin, SubApp};
 use bevy_asset::RenderAssetUsages;
@@ -128,6 +128,10 @@ impl<A: ErasedRenderAsset, AFTER: ErasedRenderAssetDependency + 'static> Plugin
                 .allow_ambiguous_resource::<ErasedRenderAssets<A::ErasedAsset>>()
                 .init_resource::<PrepareNextFrameAssets<A>>()
                 .add_systems(
+                    RenderStartup,
+                    collect_erased_render_assets_to_reextract::<A>,
+                )
+                .add_systems(
                     ExtractSchedule,
                     extract_erased_render_asset::<A>.in_set(AssetExtractionSystems),
                 );
@@ -240,12 +244,49 @@ impl<A: ErasedRenderAsset> FromWorld for CachedExtractErasedRenderAssetSystemSta
     }
 }
 
-/// This system extracts all created or modified assets of the corresponding [`ErasedRenderAsset::SourceAsset`] type
-/// into the "render world".
+/// Resource inserted during [`RenderStartup`] containing asset IDs that need
+/// re-extraction from the main world after device recovery.
+#[derive(Resource)]
+pub(crate) struct ErasedRenderAssetsToReExtract<A: ErasedRenderAsset> {
+    ids: Vec<AssetId<A::SourceAsset>>,
+}
+
+/// Drains all asset IDs from [`ErasedRenderAssets<A>`] to mark for re-extraction.
+fn collect_erased_render_assets_to_reextract<A: ErasedRenderAsset>(
+    mut commands: Commands,
+    mut render_assets: ResMut<ErasedRenderAssets<A::ErasedAsset>>,
+    mut prepare_next_frame: ResMut<PrepareNextFrameAssets<A>>,
+) {
+    let source_type_id = core::any::TypeId::of::<A::SourceAsset>();
+    // ErasedRenderAssets is shared across all material types that produce
+    // the same ErasedAsset type. Drain only the entries matching our SourceAsset.
+    let mut ids = Vec::new();
+    render_assets.0.retain(|untyped_id, _| {
+        if untyped_id.type_id() == source_type_id {
+            ids.push(untyped_id.typed());
+            false
+        } else {
+            true
+        }
+    });
+    prepare_next_frame.assets.clear();
+    if !ids.is_empty() {
+        commands.insert_resource(ErasedRenderAssetsToReExtract::<A> { ids });
+    }
+}
+
+/// Extracts all created or modified assets of the corresponding [`ErasedRenderAsset::SourceAsset`] type
+/// into the "render world", including any assets invalidated by device recovery.
 pub(crate) fn extract_erased_render_asset<A: ErasedRenderAsset>(
     mut commands: Commands,
+    mut to_reextract: Option<ResMut<ErasedRenderAssetsToReExtract<A>>>,
     mut main_world: ResMut<MainWorld>,
 ) {
+    let reextract_ids = to_reextract
+        .as_mut()
+        .map(|r| core::mem::take(&mut r.ids))
+        .filter(|ids| !ids.is_empty());
+
     main_world.resource_scope(
         |world, mut cached_state: Mut<CachedExtractErasedRenderAssetSystemState<A>>| {
             let (mut events, mut assets) = cached_state.state.get_mut(world).unwrap();
@@ -253,6 +294,10 @@ pub(crate) fn extract_erased_render_asset<A: ErasedRenderAsset>(
             let mut needs_extracting = <HashSet<_>>::default();
             let mut removed = <HashSet<_>>::default();
             let mut modified = <HashSet<_>>::default();
+
+            if let Some(reextract_ids) = reextract_ids {
+                needs_extracting.extend(reextract_ids);
+            }
 
             for event in events.read() {
                 #[expect(

--- a/crates/bevy_render/src/render_asset.rs
+++ b/crates/bevy_render/src/render_asset.rs
@@ -1,6 +1,6 @@
 use crate::{
     render_resource::AsBindGroupError, Extract, ExtractSchedule, MainWorld, Render, RenderApp,
-    RenderSystems, Res,
+    RenderStartup, RenderSystems, Res,
 };
 use bevy_app::{App, Plugin, SubApp};
 use bevy_asset::{Asset, AssetEvent, AssetId, Assets, RenderAssetUsages};
@@ -140,6 +140,7 @@ impl<A: RenderAsset, AFTER: RenderAssetDependency + 'static> Plugin
                 .init_resource::<RenderAssets<A>>()
                 .allow_ambiguous_resource::<RenderAssets<A>>()
                 .init_resource::<PrepareNextFrameAssets<A>>()
+                .add_systems(RenderStartup, collect_render_assets_to_reextract::<A>)
                 .add_systems(
                     ExtractSchedule,
                     extract_render_asset::<A>.in_set(AssetExtractionSystems),
@@ -254,12 +255,38 @@ impl<A: RenderAsset> FromWorld for CachedExtractRenderAssetSystemState<A> {
     }
 }
 
-/// This system extracts all created or modified assets of the corresponding [`RenderAsset::SourceAsset`] type
-/// into the "render world".
+/// Resource inserted during [`RenderStartup`] containing asset IDs that need
+/// re-extraction from the main world after device recovery.
+#[derive(Resource)]
+pub(crate) struct RenderAssetsToReExtract<A: RenderAsset> {
+    ids: Vec<AssetId<A::SourceAsset>>,
+}
+
+/// Drains all asset IDs from [`RenderAssets<A>`] to mark for re-extraction.
+fn collect_render_assets_to_reextract<A: RenderAsset>(
+    mut commands: Commands,
+    mut render_assets: ResMut<RenderAssets<A>>,
+    mut prepare_next_frame: ResMut<PrepareNextFrameAssets<A>>,
+) {
+    let ids: Vec<_> = render_assets.0.drain().map(|(id, _)| id).collect();
+    prepare_next_frame.assets.clear();
+    if !ids.is_empty() {
+        commands.insert_resource(RenderAssetsToReExtract::<A> { ids });
+    }
+}
+
+/// Extracts all created or modified assets of the corresponding [`RenderAsset::SourceAsset`] type
+/// into the "render world", including any assets invalidated by device recovery.
 pub(crate) fn extract_render_asset<A: RenderAsset>(
     mut commands: Commands,
+    mut to_reextract: Option<ResMut<RenderAssetsToReExtract<A>>>,
     mut main_world: ResMut<MainWorld>,
 ) {
+    let reextract_ids = to_reextract
+        .as_mut()
+        .map(|r| core::mem::take(&mut r.ids))
+        .filter(|ids| !ids.is_empty());
+
     main_world.resource_scope(
         |world, mut cached_state: Mut<CachedExtractRenderAssetSystemState<A>>| {
             let (mut events, mut assets, maybe_render_assets) = cached_state.state.get_mut(world).unwrap();
@@ -267,6 +294,10 @@ pub(crate) fn extract_render_asset<A: RenderAsset>(
             let mut needs_extracting = <HashSet<_>>::default();
             let mut removed = <HashSet<_>>::default();
             let mut modified = <HashSet<_>>::default();
+
+            if let Some(reextract_ids) = reextract_ids {
+                needs_extracting.extend(reextract_ids);
+            }
 
             for event in events.read() {
                 #[expect(


### PR DESCRIPTION
# Objective

- Continue Render Recovery efforts #23350 #22761 #23433 #23458 #23459 #23461
- Part of goal #23029
- Make render assets exist again after reload

## Solution

- We re-extract everything from the main world. This assumes things *exist* on the main world, which is not actually always true. This is enough for most examples and simple usage to be recoverable, but it's really butting up against bevy_asset deficiencies. The next step to making this truly production grade is asset streaming, which will probably be my next goal.

## Testing

- examples run
- in combination with the rest of the fixes, render_recovery example works. 
