### PR TITLE
Render Recovery release note

### DIFF
--- a/crates/bevy_render/src/error_handler.rs
+++ b/crates/bevy_render/src/error_handler.rs
@@ -5,7 +5,7 @@ use bevy_ecs::{
 };
 use std::sync::Mutex;
 use wgpu::ErrorSource;
-use wgpu_types::error::ErrorType;
+pub use wgpu_types::error::ErrorType;
 
 use crate::{
     insert_future_resources,

--- a/release-content/release-notes/render-recovery.md
+++ b/release-content/release-notes/render-recovery.md
@@ -1,0 +1,24 @@
+---
+title: "Render Recovery"
+authors: ["@atlv24"]
+pull_requests: [22761, 23350, 23349, 23433, 23458, 23444, 23459, 23461, 23463, 22714, 22759, 16481]
+--- 
+
+You can now recover from rendering errors such as device loss by reloading the renderer:
+
+```rs
+use bevy::render::error_handler::{ErrorType, RenderErrorHandler, RenderErrorPolicy};
+
+app.insert_resource(RenderErrorHandler(
+    |error, main_world, render_world| match error.ty {
+        ErrorType::Internal => panic!(),
+        ErrorType::OutOfMemory => RenderErrorPolicy::StopRendering,
+        ErrorType::Validation => RenderErrorPolicy::Ignore,
+        ErrorType::DeviceLost => RenderErrorPolicy::Recover(default()),
+    },
+));
+```
+
+NOTE: this is just an example showing the different errors and policies available, and not a recommendation for how to handle errors.
+
+The default error handler behaves identically to how Bevy behaved before: validation errors are ignored, and other errors crash/hang the application.


### PR DESCRIPTION
# Objective

- Completes goal and closes #23029
- Culmination of #22761, #23350, #23349, #23433, #23458, #23444, #23459, #23461, #23463, #22714, #22759, #16481

## Solution

- Add a release note.
- Re-export a wgpu type that you need to match on to handle errors.

## Testing

- cargo run --example render_recovery   with all the other PRs merged in. Press 5 and then V, the app will not crash. Note that D for "destroy device" will still crash: this is a WGPU problem resolved by https://github.com/gfx-rs/wgpu/pull/9281.

# Note

I opted not to change the default recovery behavior yet. I believe we need testing in user projects and just general trodding of this code path before committing to a new default. It works in a simple example, it might not work in a complex project. We need to field test this and likely iterate to really call this ready IMO.