### PR TITLE
Add `#[inline]` and `#repr[transparent]` to `ComponentIdSet` to attempt to fix perf regression

### DIFF
--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -1283,6 +1283,7 @@ impl FilteredAccessSet {
 
 /// A set of [`ComponentId`]s.
 #[derive(Default, Eq, PartialEq, Hash)]
+#[repr(transparent)]
 pub struct ComponentIdSet(FixedBitSet);
 
 impl ComponentIdSet {
@@ -1466,6 +1467,7 @@ impl Extend<ComponentId> for ComponentIdSet {
 ///
 /// This is equivalent to `map(ComponentId::new)`,
 /// but is a named type to allow it to be used in associated types.
+#[repr(transparent)]
 pub struct ComponentIdIter<I>(I);
 
 impl<I: Iterator<Item = usize>> Iterator for ComponentIdIter<I> {


### PR DESCRIPTION
# Objective

Attempt to fix a performance regression from adding the `ComponentSet` type in #23384.  See #23464.  

## Solution

Add `#[inline]` attributes to the new trait impls.  I had added them to the inherent methods, but forgot about the traits!  

## Testing

I have not tested this at all, so I don't know whether it will actually fix the issue!  I don't even understand how #23384 could have affected those benchmarks in the first place, since they don't seem to call any methods on `Access` during the loop.  

But these trait methods all simply delegate to methods on `FixedBitSet`, so marking them `#[inline]` seems harmless at worst.  