### PR TITLE
Add storage buffers limit check for gpu occlusion

### DIFF
--- a/crates/bevy_render/src/batching/gpu_preprocessing.rs
+++ b/crates/bevy_render/src/batching/gpu_preprocessing.rs
@@ -1229,7 +1229,9 @@ impl FromWorld for GpuPreprocessingSupport {
             .features()
             .contains(Features::INDIRECT_FIRST_INSTANCE | Features::IMMEDIATES);
         // Depth downsampling for occlusion culling requires 12 textures
+        // and the early occlusion culling pass requires 10 storage buffers
         let limit_support = device.limits().max_storage_textures_per_shader_stage >= 12 &&
+            device.limits().max_storage_buffers_per_shader_stage >= 10 &&
             // Even if the adapter supports compute, we might be simulating a lack of
             // compute via device limits (see `WgpuSettingsPriority::WebGL2` and
             // `wgpu::Limits::downlevel_webgl2_defaults()`). This will have set all the


### PR DESCRIPTION
# Objective

- unblock wgpu 29 upgrade

## Solution

- check relevant limits to enable occlusion culling

## Testing

patched this over the wgpu 29 upgrade branch and it no longer errors