### PR TITLE
Remove unused `GltfAssetLabel::MorphTarget` variant.

### DIFF
--- a/_release-content/migration-guides/no_more_morph_targets.md
+++ b/_release-content/migration-guides/no_more_morph_targets.md
@@ -1,0 +1,11 @@
+---
+title: Morph targets are now stored in meshes.
+pull_requests: [23023, 23485]
+---
+
+Previously, morph targets were stored as a `Handle<Image>` in a `Mesh`. Now, morph targets are
+stored inside the `Mesh` itself.
+
+As a consequence, `Gltf` assets no longer provide a `GltfAssetLabel::MorphTarget` subasset. This
+subasset can be replaced with the corresponding `GltfAssetLabel::Primitive` to look up the correct
+`Mesh`, followed by `Mesh::get_morph_targets`.

--- a/crates/bevy_gltf/src/label.rs
+++ b/crates/bevy_gltf/src/label.rs
@@ -44,14 +44,6 @@ pub enum GltfAssetLabel {
         /// Index of this primitive in its parent mesh
         primitive: usize,
     },
-    /// `Mesh{}/Primitive{}/MorphTargets`: Morph target animation data for a glTF Primitive
-    /// as a Bevy [`Image`](bevy_image::prelude::Image)
-    MorphTarget {
-        /// Index of the mesh for this primitive
-        mesh: usize,
-        /// Index of this primitive in its parent mesh
-        primitive: usize,
-    },
     /// `Texture{}`: glTF Texture as a Bevy [`Image`](bevy_image::prelude::Image)
     Texture(usize),
     /// `Material{}`: glTF Material as Bevy [`GltfMaterial`](crate::GltfMaterial)
@@ -81,9 +73,6 @@ impl core::fmt::Display for GltfAssetLabel {
             GltfAssetLabel::Mesh(index) => f.write_str(&format!("Mesh{index}")),
             GltfAssetLabel::Primitive { mesh, primitive } => {
                 f.write_str(&format!("Mesh{mesh}/Primitive{primitive}"))
-            }
-            GltfAssetLabel::MorphTarget { mesh, primitive } => {
-                f.write_str(&format!("Mesh{mesh}/Primitive{primitive}/MorphTargets"))
             }
             GltfAssetLabel::Texture(index) => f.write_str(&format!("Texture{index}")),
             GltfAssetLabel::Material {


### PR DESCRIPTION
# Objective

- This is a followup to #23023.
- This variant is now unused!

## Solution

- Remove the variant.
- Start a migration guide for #23023. I haven't fleshed it out, because tbh I don't really understand the proper migration for #23023. I've also left the migration for accessing the morph targets a little vague because I highly doubt anyone is accessing it.