### PR TITLE
Remove incorrect docs

### DIFF
--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -318,9 +318,6 @@ where
     /// For a type implementing [`PartialReflect`], combines `reflect_clone` and
     /// `take` in a useful fashion, automatically constructing an appropriate
     /// [`ReflectCloneError`] if the downcast fails.
-    ///
-    /// This is an associated function, rather than a method, because methods
-    /// with generic types prevent dyn-compatibility.
     fn reflect_clone_and_take<T: 'static>(&self) -> Result<T, ReflectCloneError>
     where
         Self: TypePath + Sized,


### PR DESCRIPTION
# Objective

`reflect_clone_and_take` was added in #19944, but during code review switched from being an associated function to a method (though the git history of that switch was lost to a force push). When the switch was made, the docs were not corrected.

## Solution

Correct the docs.