### PR TITLE
Improve fullscreen material example and add WebGL2 padding

### DIFF
--- a/examples/shader_advanced/fullscreen_material.rs
+++ b/examples/shader_advanced/fullscreen_material.rs
@@ -50,7 +50,7 @@ fn update_intensity(effects: Query<&mut FullscreenEffect>, time: Res<Time>) {
     for mut effect in effects {
         let phase = time.elapsed_secs() * FullscreenEffect::FREQUENCY;
         // Make it loop periodically
-        let mut intensity = phase.sin();
+        let mut intensity = ops::sin(phase);
 
         // We need to remap the intensity to be between 0 and 1 instead of -1 and 1
         intensity = (intensity + 1.0) / 2.0;


### PR DESCRIPTION
# Objective

Improve the fullscreen material example by making the aberration intensity oscillate, as well as making it work on WebGL2

## Solution

- Make the chromatic aberration intensity oscillate using the sin of the elapsed time
- Add padding to the `FullscreenEffect` struct on WebGL2

## Testing

I tested the example locally on firefox (nightly) with WebGL2

## Showcase

A short gif of the example running on WebGL2
![Fullscreen material example](https://github.com/user-attachments/assets/0433843f-6c02-48f7-a29a-7b4aaeda2444)