### PR TITLE
Allow referencing glTF subassets by name instead of indices.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -648,6 +648,9 @@ https = ["bevy_internal/https"]
 # Enable caching downloaded assets on the filesystem. NOTE: this cache currently never invalidates entries!
 web_asset_cache = ["bevy_internal/web_asset_cache"]
 
+# Set the default for loading glTF files to use the name of the subasset instead of the index.
+gltf_named_subassets_default = ["bevy_internal/gltf_named_subassets_default"]
+
 # Enable stepping-based debugging of Bevy systems
 bevy_debug_stepping = [
   "bevy_internal/bevy_debug_stepping",

--- a/_release-content/release-notes/gltf_name_labels.md
+++ b/_release-content/release-notes/gltf_name_labels.md
@@ -1,0 +1,49 @@
+---
+title: Assets in glTF files can now be referenced by name.
+authors: ["@andriyDev"]
+pull_requests: []
+---
+
+In previous versions of Bevy, subassets from a glTF file needed to be loaded by the **index** in the
+glTF file. This would look like:
+
+```rust
+let mesh1 = asset_server.load::<Mesh>("my.gltf#Mesh5/Primitive2");
+// OR
+let mesh1 = asset_server.load::<Mesh>(GltfAssetLabel::Primitive {
+    mesh: 5,
+    primitive: 2,
+}.from_asset("my.gltf"));
+```
+
+This is unfortunate though because **the index is arbitrary**. Tools like Blender could rearrange
+the order of subassets, making your asset paths no longer point to what it did before. glTF has a
+solution for this: names! But up until now, the only way to use these names was by loading the root
+asset as a `Gltf`, then accessing it from `Assets<Gltf>`, then lookup the correct handle (for
+meshes this would mean accessing `Gltf::named_meshes`, then looking up the `GltfMesh`, and then
+finding the correct primitive in that).
+
+Now, glTF files can be loaded using names! So the above example could become:
+
+```rust
+let mesh1 = asset_server.load::<Mesh>("my.gltf#Primitive:FireHydrant/2");
+// OR
+let mesh1 = asset_server.load::<Mesh>(GltfNamedAssetLabel::Primitive {
+    mesh: "FireHydrant",
+    primitive: 2,
+}.from_asset("my.gltf"));
+```
+
+This can be enabled through:
+
+1. Enabling the new `gltf_named_subassets_default` feature on `bevy_gltf`. This is a temporary
+   feature, and will be removed in Bevy 0.20 when this behavior becomes the default.
+2. Setting `GltfPlugin::label_mode` to `GltfLabelMode::Names`.
+3. Setting `GltfLoaderSettings::label_mode` to `GltfLabelMode::Names`.
+
+Enabling this feature will prevent loading unnamed subassets. Only named subassets can be loaded by
+name. Unnamed subassets can still be access through the `Gltf` asset if necessary.
+
+In addition, enabling this may prevent loading of some glTF files if there are non-unique names (per
+subasset type). Some tools (e.g., Blender) enforce unique names, so this should not break most glTF
+files.

--- a/_release-content/release-notes/gltf_name_labels.md
+++ b/_release-content/release-notes/gltf_name_labels.md
@@ -1,7 +1,7 @@
 ---
 title: Assets in glTF files can now be referenced by name.
 authors: ["@andriyDev"]
-pull_requests: []
+pull_requests: [23505]
 ---
 
 In previous versions of Bevy, subassets from a glTF file needed to be loaded by the **index** in the

--- a/_release-content/release-notes/gltf_name_labels.md
+++ b/_release-content/release-notes/gltf_name_labels.md
@@ -34,7 +34,7 @@ let mesh1 = asset_server.load::<Mesh>(GltfNamedAssetLabel::Primitive {
 }.from_asset("my.gltf"));
 ```
 
-This can be enabled through:
+This can be enabled through any of the following (in increasing order of specificity):
 
 1. Enabling the new `gltf_named_subassets_default` feature on `bevy_gltf`. This is a temporary
    feature, and will be removed in Bevy 0.20 when this behavior becomes the default.

--- a/crates/bevy_gltf/Cargo.toml
+++ b/crates/bevy_gltf/Cargo.toml
@@ -13,6 +13,7 @@ pbr_transmission_textures = []
 pbr_multi_layer_material_textures = []
 pbr_anisotropy_texture = []
 pbr_specular_textures = []
+gltf_named_subassets_default = []
 
 [dependencies]
 # bevy
@@ -25,6 +26,7 @@ bevy_color = { path = "../bevy_color", version = "0.19.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.19.0-dev" }
 bevy_image = { path = "../bevy_image", version = "0.19.0-dev" }
 bevy_light = { path = "../bevy_light", version = "0.19.0-dev" }
+bevy_log = { path = "../bevy_log", version = "0.19.0-dev" }
 bevy_camera = { path = "../bevy_camera", version = "0.19.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.19.0-dev" }
 bevy_mesh = { path = "../bevy_mesh", version = "0.19.0-dev", features = [
@@ -55,6 +57,7 @@ gltf = { version = "1.4.0", default-features = false, features = [
   "names",
   "utils",
 ] }
+atomicow = { version = "1.1", default-features = false, features = ["std"] }
 async-lock = { version = "3.0", default-features = false }
 thiserror = { version = "2", default-features = false }
 base64 = "0.22.0"

--- a/crates/bevy_gltf/src/label.rs
+++ b/crates/bevy_gltf/src/label.rs
@@ -1,6 +1,7 @@
 //! Labels that can be used to load part of a glTF
 
 use bevy_asset::AssetPath;
+use serde::{Deserialize, Serialize};
 
 /// Labels that can be used to load part of a glTF
 ///
@@ -29,7 +30,7 @@ use bevy_asset::AssetPath;
 ///     let gltf_scene: Handle<Scene> = asset_server.load(format!("models/FlightHelmet/FlightHelmet.gltf#{}", GltfAssetLabel::Scene(0)));
 /// }
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum GltfAssetLabel {
     /// `Scene{}`: glTF Scene as a Bevy [`Scene`](bevy_scene::Scene)
     Scene(usize),
@@ -112,4 +113,146 @@ impl GltfAssetLabel {
     pub fn from_asset(&self, path: impl Into<AssetPath<'static>>) -> AssetPath<'static> {
         path.into().with_label(self.to_string())
     }
+}
+
+/// Labels that can be used to load part of a glTF
+///
+/// You can use [`GltfAssetLabel::from_asset`] to add it to an asset path
+///
+/// ```
+/// # use bevy_ecs::prelude::*;
+/// # use bevy_asset::prelude::*;
+/// # use bevy_scene::prelude::*;
+/// # use bevy_gltf::prelude::*;
+///
+/// fn load_gltf_scene(asset_server: Res<AssetServer>) {
+///     let gltf_scene: Handle<Scene> = asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"));
+/// }
+/// ```
+///
+/// Or when formatting a string for the path
+///
+/// ```
+/// # use bevy_ecs::prelude::*;
+/// # use bevy_asset::prelude::*;
+/// # use bevy_scene::prelude::*;
+/// # use bevy_gltf::prelude::*;
+///
+/// fn load_gltf_scene(asset_server: Res<AssetServer>) {
+///     let gltf_scene: Handle<Scene> = asset_server.load(format!("models/FlightHelmet/FlightHelmet.gltf#{}", GltfAssetLabel::Scene(0)));
+/// }
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GltfNamedAssetLabel<'a> {
+    /// `Scene:{}`: glTF Scene as a Bevy [`Scene`](bevy_scene::Scene)
+    Scene(&'a str),
+    /// `Node:{}`: glTF Node as a [`GltfNode`](crate::GltfNode)
+    Node(&'a str),
+    /// `Mesh:{}`: glTF Mesh as a [`GltfMesh`](crate::GltfMesh)
+    Mesh(&'a str),
+    /// `Primitive:{mesh}/{primitive_index}`: glTF Primitive as a Bevy [`Mesh`](bevy_mesh::Mesh)
+    Primitive {
+        /// Name of the mesh this primitive belongs to.
+        mesh: &'a str,
+        /// Index within the mesh for this primitive.
+        primitive_index: usize,
+    },
+    /// `Primitive/MorphTargets:{}`: Morph target animation data for a glTF Primitive
+    /// as a Bevy [`Image`](bevy_image::prelude::Image)
+    MorphTarget {
+        /// Name of the mesh for this primitive.
+        mesh: &'a str,
+        /// Index within the mesh for this primitive.
+        primitive_index: usize,
+    },
+    /// `Texture:{}`: glTF Texture as a Bevy [`Image`](bevy_image::prelude::Image)
+    Texture(&'a str),
+    /// `Material:{}`: glTF Material as Bevy [`GltfMaterial`](crate::GltfMaterial)
+    Material {
+        /// Name of this material
+        name: &'a str,
+        /// Used to set the [`Face`](wgpu_types::Face) of the material, useful if it is used with
+        /// negative scale
+        is_scale_inverted: bool,
+    },
+    /// `DefaultMaterial`: glTF's default Material
+    DefaultMaterial,
+    /// `Animation:{}`: glTF Animation as Bevy [`AnimationClip`](bevy_animation::AnimationClip)
+    Animation(&'a str),
+    /// `Skin:{}`: glTF mesh skin as [`GltfSkin`](crate::GltfSkin)
+    Skin(&'a str),
+    /// `Skin/InverseBindMatrices:{}`: glTF mesh skin matrices as Bevy
+    /// [`SkinnedMeshInverseBindposes`](bevy_mesh::skinning::SkinnedMeshInverseBindposes)
+    InverseBindMatrices {
+        /// Name of the skin these matrices belong to.
+        skin: &'a str,
+    },
+}
+
+impl core::fmt::Display for GltfNamedAssetLabel<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Scene(name) => f.write_str(&format!("Scene:{name}")),
+            Self::Node(name) => f.write_str(&format!("Node:{name}")),
+            Self::Mesh(name) => f.write_str(&format!("Mesh:{name}")),
+            Self::Primitive {
+                mesh,
+                primitive_index,
+            } => f.write_str(&format!("Primitive:{mesh}/{primitive_index}")),
+            Self::MorphTarget {
+                mesh,
+                primitive_index,
+            } => f.write_str(&format!("MorphTargets:{mesh}/{primitive_index}")),
+            Self::Texture(name) => f.write_str(&format!("Texture{name}")),
+            Self::Material {
+                name,
+                is_scale_inverted,
+            } => f.write_str(&format!(
+                "Material:{name}{}",
+                if *is_scale_inverted {
+                    " (inverted)"
+                } else {
+                    ""
+                }
+            )),
+            Self::DefaultMaterial => f.write_str("DefaultMaterial"),
+            Self::Animation(name) => f.write_str(&format!("Animation:{name}")),
+            Self::Skin(name) => f.write_str(&format!("Skin:{name}")),
+            Self::InverseBindMatrices { skin } => {
+                f.write_str(&format!("Skin/InverseBindMatrices:{skin}"))
+            }
+        }
+    }
+}
+
+impl GltfNamedAssetLabel<'_> {
+    /// Add this label to an asset path
+    ///
+    /// ```
+    /// # use bevy_ecs::prelude::*;
+    /// # use bevy_asset::prelude::*;
+    /// # use bevy_scene::prelude::*;
+    /// # use bevy_gltf::prelude::*;
+    ///
+    /// fn load_gltf_scene(asset_server: Res<AssetServer>) {
+    ///     let gltf_scene: Handle<Scene> = asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"));
+    /// }
+    /// ```
+    pub fn from_asset(&self, path: impl Into<AssetPath<'static>>) -> AssetPath<'static> {
+        path.into().with_label(self.to_string())
+    }
+}
+
+/// Defines the way that labels for glTF subassets are created.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Serialize, Deserialize)]
+pub enum GltfLabelMode {
+    /// glTF subassets are labeled using their index within the glTF.
+    ///
+    /// This is primarily for compatibility: glTF does not require that every piece of data is
+    /// named. This mode allows referencing data when the name is missing or non-unique. See
+    /// [`GltfAssetLabel`] for more.
+    Indices,
+    /// glTF subassets are labeled using their name within the glTF. This imposes restrictions
+    /// during loading, like that names in the glTF are unique (for their data type).
+    Names,
 }

--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -155,12 +155,21 @@ use bevy_mesh::MeshVertexAttribute;
 /// This includes the most common types in this crate, re-exported for your convenience.
 pub mod prelude {
     #[doc(hidden)]
-    pub use crate::{assets::Gltf, assets::GltfExtras, label::GltfAssetLabel};
+    pub use crate::{
+        assets::Gltf,
+        assets::GltfExtras,
+        label::{GltfAssetLabel, GltfNamedAssetLabel},
+    };
 }
 
 use crate::{convert_coordinates::GltfConvertCoordinates, extensions::GltfExtensionHandlers};
 
-pub use {assets::*, label::GltfAssetLabel, loader::*, material::GltfMaterial};
+pub use {
+    assets::*,
+    label::{GltfAssetLabel, GltfLabelMode, GltfNamedAssetLabel},
+    loader::*,
+    material::GltfMaterial,
+};
 
 /// Re-exports for GLTF
 pub mod gltf {
@@ -229,6 +238,10 @@ pub struct GltfPlugin {
     /// per-load by [`GltfLoaderSettings::convert_coordinates`].
     pub convert_coordinates: GltfConvertCoordinates,
 
+    /// The default mode for creating glTF subasset labels. This can be overridden per-load by
+    /// [`GltfLoaderSettings::label_mode`].
+    pub label_mode: GltfLabelMode,
+
     /// Registry for custom vertex attributes.
     ///
     /// To specify, use [`GltfPlugin::add_custom_vertex_attribute`].
@@ -245,6 +258,11 @@ impl Default for GltfPlugin {
             default_sampler: ImageSamplerDescriptor::linear(),
             custom_vertex_attributes: HashMap::default(),
             convert_coordinates: GltfConvertCoordinates::default(),
+            label_mode: if cfg!(feature = "gltf_named_subassets_default") {
+                GltfLabelMode::Names
+            } else {
+                GltfLabelMode::Indices
+            },
             skinned_mesh_bounds_policy: Default::default(),
         }
     }
@@ -300,6 +318,7 @@ impl Plugin for GltfPlugin {
             custom_vertex_attributes: self.custom_vertex_attributes.clone(),
             default_sampler,
             default_convert_coordinates: self.convert_coordinates,
+            default_label_mode: self.label_mode,
             extensions: extensions.0.clone(),
             default_skinned_mesh_bounds_policy: self.skinned_mesh_bounds_policy,
         });

--- a/crates/bevy_gltf/src/loader/gltf_ext/material.rs
+++ b/crates/bevy_gltf/src/loader/gltf_ext/material.rs
@@ -6,8 +6,6 @@ use gltf::{json::texture::Info, Material};
 
 use serde_json::value;
 
-use crate::GltfAssetLabel;
-
 use super::texture::texture_transform_to_affine2;
 
 #[cfg(any(
@@ -158,16 +156,5 @@ pub(crate) fn warn_on_differing_texture_transforms(
             "Only texture transforms on base color textures are supported, but {material_name} ({material_index}) \
             has a texture transform on {texture_name} (index {}), which will be ignored.", info.texture().index()
         );
-    }
-}
-
-pub(crate) fn material_label(material: &Material, is_scale_inverted: bool) -> GltfAssetLabel {
-    if let Some(index) = material.index() {
-        GltfAssetLabel::Material {
-            index,
-            is_scale_inverted,
-        }
-    } else {
-        GltfAssetLabel::DefaultMaterial
     }
 }

--- a/crates/bevy_gltf/src/loader/mod.rs
+++ b/crates/bevy_gltf/src/loader/mod.rs
@@ -3159,4 +3159,52 @@ mod test {
             ["Animation:MoonWalk", "__anim_0"]
         );
     }
+
+    #[test]
+    fn duplicate_name_returns_error() {
+        let gltf_path = "test.gltf";
+        let gltf_str = r#"
+{
+    "asset": {
+        "version": "2.0"
+    },
+    "nodes": [
+        { "name": "l1" },
+        { "name": "l2" }
+    ],
+    "scene": 0,
+    "scenes": [
+        { "name": "MainWorld", "nodes": [0] },
+        { "name": "MainWorld", "nodes": [1] }
+    ]
+}
+"#;
+
+        let dir = Dir::default();
+        dir.insert_asset_text(Path::new(gltf_path), gltf_str);
+        let mut app = test_app(dir);
+        app.update();
+        let asset_server = app.world().resource::<AssetServer>().clone();
+        let handle: Handle<Gltf> =
+            asset_server.load_with_settings(gltf_path, |settings: &mut GltfLoaderSettings| {
+                settings.label_mode = Some(GltfLabelMode::Names);
+            });
+        let handle_id = handle.id();
+        app.update();
+        run_app_until(&mut app, |_world| {
+            let load_state = asset_server.get_load_state(handle_id).unwrap();
+            if load_state.is_failed() {
+                Some(())
+            } else {
+                None
+            }
+        });
+        let load_state = asset_server.get_load_state(handle_id).unwrap();
+        match load_state {
+            LoadState::Failed(err) => {
+                assert!(err.to_string().contains("duplicate subasset label: Scene:MainWorld"), "expected to contain \"duplicate subasset label: Scene:MainWorld\", but got: {err}");
+            }
+            state => panic!("expected state to be LoadState::Failed but got {state:?}"),
+        }
+    }
 }

--- a/crates/bevy_gltf/src/loader/mod.rs
+++ b/crates/bevy_gltf/src/loader/mod.rs
@@ -2363,14 +2363,18 @@ fn create_label_maker<T: Clone>(
 mod test {
     use std::path::Path;
 
-    use crate::{Gltf, GltfAssetLabel, GltfMaterial, GltfNode, GltfSkin};
+    use crate::{
+        Gltf, GltfAssetLabel, GltfLabelMode, GltfLoaderSettings, GltfMaterial, GltfMesh, GltfNode,
+        GltfSkin,
+    };
     use bevy_app::{App, TaskPoolPlugin};
     use bevy_asset::{
         io::{
             memory::{Dir, MemoryAssetReader},
             AssetSourceBuilder, AssetSourceId,
         },
-        AssetApp, AssetLoader, AssetPlugin, AssetServer, Assets, Handle, LoadContext, LoadState,
+        Asset, AssetApp, AssetLoader, AssetPlugin, AssetServer, Assets, Handle, LoadContext,
+        LoadState,
     };
     use bevy_ecs::{resource::Resource, world::World};
     use bevy_image::{Image, ImageLoaderSettings};
@@ -2396,6 +2400,9 @@ mod test {
             crate::GltfPlugin::default(),
         ));
 
+        #[cfg(feature = "bevy_animation")]
+        app.init_asset::<bevy_animation::AnimationClip>();
+
         app.finish();
         app.cleanup();
 
@@ -2415,7 +2422,7 @@ mod test {
         panic!("Ran out of loops to return `Some` from `predicate`");
     }
 
-    fn load_gltf_into_app(gltf_path: &str, gltf: &str) -> App {
+    fn load_gltf_into_app(gltf_path: &str, gltf: &str, label_mode: GltfLabelMode) -> App {
         #[expect(
             dead_code,
             reason = "This struct is used to keep the handle alive. As such, we have no need to handle the handle directly."
@@ -2428,7 +2435,13 @@ mod test {
         let mut app = test_app(dir);
         app.update();
         let asset_server = app.world().resource::<AssetServer>().clone();
-        let handle: Handle<Gltf> = asset_server.load(gltf_path.to_string());
+        let handle: Handle<Gltf> = asset_server.load_with_settings(
+            gltf_path.to_string(),
+            // This makes the test invariant to any feature flag business.
+            move |settings: &mut GltfLoaderSettings| {
+                settings.label_mode = Some(label_mode);
+            },
+        );
         let handle_id = handle.id();
         app.insert_resource(GltfHandle(handle));
         app.update();
@@ -2462,6 +2475,7 @@ mod test {
     "scenes": [{ "nodes": [0] }]
 }
 "#,
+            GltfLabelMode::Indices,
         );
         let asset_server = app.world().resource::<AssetServer>();
         let handle = asset_server.load(gltf_path);
@@ -2504,6 +2518,7 @@ mod test {
     "scenes": [{ "nodes": [0] }]
 }
 "#,
+            GltfLabelMode::Indices,
         );
         let asset_server = app.world().resource::<AssetServer>();
         let handle = asset_server.load(gltf_path);
@@ -2545,6 +2560,7 @@ mod test {
     "scenes": [{ "nodes": [0] }]
 }
 "#,
+            GltfLabelMode::Indices,
         );
         let asset_server = app.world().resource::<AssetServer>();
         let handle = asset_server.load(gltf_path);
@@ -2604,6 +2620,7 @@ mod test {
     "scenes": [{ "nodes": [0] }]
 }
 "#,
+            GltfLabelMode::Indices,
         );
         let asset_server = app.world().resource::<AssetServer>();
         let handle = asset_server.load(gltf_path);
@@ -2770,6 +2787,7 @@ mod test {
     "scenes": [{ "nodes": [0] }]
 }
 "#,
+            GltfLabelMode::Indices,
         );
         let asset_server = app.world().resource::<AssetServer>();
         let handle = asset_server.load(gltf_path);
@@ -2948,5 +2966,197 @@ mod test {
                 .is_loaded_with_dependencies(&handle)
                 .then_some(())
         });
+    }
+
+    fn get_subasset_name<A: Asset>(handle: &Handle<A>) -> String {
+        handle.path().unwrap().label().unwrap().to_string()
+    }
+
+    #[test]
+    fn single_named_node() {
+        let gltf_path = "test.gltf";
+        let app = load_gltf_into_app(
+            gltf_path,
+            r#"
+{
+    "asset": {
+        "version": "2.0"
+    },
+    "nodes": [
+        {},
+        {},
+        {},
+        {},
+        {
+            "name": "TestSingleNode"
+        },
+        {},
+        {}
+    ],
+    "scene": 0,
+    "scenes": [{ "nodes": [0, 1, 2, 3, 4, 5, 6] }]
+}
+"#,
+            GltfLabelMode::Names,
+        );
+        let asset_server = app.world().resource::<AssetServer>();
+        let handle = asset_server.load(gltf_path);
+        let gltf_root_assets = app.world().resource::<Assets<Gltf>>();
+        let gltf_root = gltf_root_assets.get(&handle).unwrap();
+        assert_eq!(gltf_root.nodes.len(), 7);
+        let mut node_labels = gltf_root
+            .nodes
+            .iter()
+            .map(get_subasset_name)
+            .collect::<Vec<_>>();
+        // This index is the only one that should be named.
+        assert_eq!(node_labels[4], "Node:TestSingleNode");
+        node_labels.remove(4);
+
+        assert_eq!(node_labels.len(), 6);
+        for (index, node_label) in node_labels.into_iter().enumerate() {
+            assert!(node_label.starts_with(&format!("__node_{index}_")));
+        }
+    }
+
+    #[test]
+    fn named_and_unnamed_elements() {
+        let gltf_path = "test.gltf";
+        let app = load_gltf_into_app(
+            gltf_path,
+            r#"
+{
+    "asset": {
+        "version": "2.0"
+    },
+    "buffers": [
+        {
+            "uri" : "data:application/gltf-buffer;base64,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "byteLength" : 12
+        }
+    ],
+    "bufferViews": [
+        {
+            "buffer": 0,
+            "byteLength": 12
+        }
+    ],
+    "accessors": [
+        {
+            "bufferView" : 0,
+            "componentType" : 5126,
+            "count" : 1,
+            "type" : "VEC3",
+            "min": [0.0, 0.0, 0.0],
+            "max": [0.0, 0.0, 0.0]
+        }
+    ],
+    "meshes": [
+        {
+            "name": "Net",
+            "primitives": [
+                {
+                    "mode": 4,
+                    "attributes": { "POSITION": 0 },
+                    "material": 0
+                },
+                {
+                    "mode": 4,
+                    "attributes": { "POSITION": 0 },
+                    "material": 1
+                }
+            ]
+        },
+        {
+            "primitives": [
+                {
+                    "mode": 4,
+                    "attributes": { "POSITION": 0 },
+                    "material": 0
+                }
+            ]
+        }
+    ],
+    "materials": [
+        {},
+        { "name": "Fireball" }
+    ],
+    "animations": [
+        { "name": "MoonWalk", "channels": [], "samplers": [] },
+        { "channels": [], "samplers": [] }
+    ],
+    "nodes": [
+        {},
+        { "name": "No-duh" },
+        { "mesh": 0, "scale": [-1, 1, 1] }
+    ],
+    "scene": 0,
+    "scenes": [{
+        "name": "HelloWorld",
+        "nodes": [0]
+    }, {
+        "nodes": [1]
+    }]
+}
+"#,
+            GltfLabelMode::Names,
+        );
+        let asset_server = app.world().resource::<AssetServer>();
+        let handle = asset_server.load(gltf_path);
+        let gltf_root_assets = app.world().resource::<Assets<Gltf>>();
+        let gltf_meshes = app.world().resource::<Assets<GltfMesh>>();
+        let gltf_root = gltf_root_assets.get(&handle).unwrap();
+
+        fn handles_to_labels<A: Asset>(handles: &[Handle<A>]) -> Vec<String> {
+            let mut names = handles
+                .iter()
+                .map(get_subasset_name)
+                .map(|name| {
+                    if !name.starts_with('_') {
+                        return name;
+                    }
+                    // Return everything before the last _.
+                    name.rsplit_once('_').unwrap().0.to_string()
+                })
+                .collect::<Vec<_>>();
+            names.sort();
+            names
+        }
+
+        assert_eq!(
+            handles_to_labels(&gltf_root.scenes),
+            ["Scene:HelloWorld", "__scene_0"]
+        );
+        assert_eq!(
+            handles_to_labels(&gltf_root.meshes),
+            ["Mesh:Net", "__mesh_0"]
+        );
+        assert_eq!(
+            handles_to_labels(&gltf_root.materials),
+            ["Material:Fireball", "__mat_0"]
+        );
+        assert_eq!(
+            handles_to_labels(&gltf_root.nodes),
+            ["Node:No-duh", "__node_0", "__node_1"]
+        );
+
+        let primitives = gltf_root
+            .meshes
+            .iter()
+            .flat_map(|gltf_mesh_handle| {
+                gltf_meshes.get(gltf_mesh_handle).unwrap().primitives.iter()
+            })
+            .map(|primitive| primitive.mesh.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            handles_to_labels(&primitives),
+            ["Primitive:Net/0", "Primitive:Net/1", "__prim_0"]
+        );
+
+        #[cfg(feature = "bevy_animation")]
+        assert_eq!(
+            handles_to_labels(&gltf_root.animations),
+            ["Animation:MoonWalk", "__anim_0"]
+        );
     }
 }

--- a/crates/bevy_gltf/src/loader/mod.rs
+++ b/crates/bevy_gltf/src/loader/mod.rs
@@ -3,6 +3,7 @@ pub mod gltf_ext;
 
 use alloc::sync::Arc;
 use async_lock::RwLock;
+use atomicow::CowArc;
 #[cfg(feature = "bevy_animation")]
 use bevy_animation::{prelude::*, AnimatedBy, AnimationTargetId};
 use bevy_asset::{
@@ -26,6 +27,7 @@ use bevy_image::{
     ImageType, TextureError,
 };
 use bevy_light::{DirectionalLight, PointLight, SpotLight};
+use bevy_log::warn_once;
 use bevy_math::{Mat4, Vec3};
 #[cfg(feature = "pbr_transmission_textures")]
 use bevy_mesh::UvChannel;
@@ -34,12 +36,16 @@ use bevy_mesh::{
     skinning::{SkinnedMesh, SkinnedMeshInverseBindposes},
     Indices, Mesh, Mesh3d, MeshVertexAttribute, PrimitiveTopology,
 };
-use bevy_platform::collections::{HashMap, HashSet};
+use bevy_platform::{
+    collections::{hash_map::Entry, HashMap, HashSet},
+    hash::RandomState,
+};
 use bevy_reflect::TypePath;
 use bevy_scene::Scene;
 #[cfg(not(target_arch = "wasm32"))]
 use bevy_tasks::IoTaskPool;
 use bevy_transform::components::Transform;
+use core::hash::{BuildHasher, Hasher};
 use gltf::{
     accessor::Iter,
     image::Source,
@@ -55,9 +61,12 @@ use tracing::{error, info_span, warn};
 use wgpu_types::Face;
 
 use crate::{
-    convert_coordinates::ConvertCoordinates as _, vertex_attributes::convert_attribute, Gltf,
-    GltfAssetLabel, GltfExtras, GltfMaterial, GltfMaterialExtras, GltfMaterialName, GltfMeshExtras,
-    GltfMeshName, GltfNode, GltfSceneExtras, GltfSceneName, GltfSkin, GltfSkinnedMeshBoundsPolicy,
+    convert_coordinates::ConvertCoordinates as _,
+    label::{GltfLabelMode, GltfNamedAssetLabel},
+    vertex_attributes::convert_attribute,
+    Gltf, GltfAssetLabel, GltfExtras, GltfMaterial, GltfMaterialExtras, GltfMaterialName,
+    GltfMeshExtras, GltfMeshName, GltfNode, GltfSceneExtras, GltfSceneName, GltfSkin,
+    GltfSkinnedMeshBoundsPolicy,
 };
 
 #[cfg(feature = "bevy_animation")]
@@ -66,10 +75,7 @@ use self::{
     extensions::{AnisotropyExtension, ClearcoatExtension, SpecularExtension},
     gltf_ext::{
         check_for_cycles, get_linear_textures,
-        material::{
-            alpha_mode, material_label, needs_tangents, uv_channel,
-            warn_on_differing_texture_transforms,
-        },
+        material::{alpha_mode, needs_tangents, uv_channel, warn_on_differing_texture_transforms},
         mesh::{primitive_name, primitive_topology},
         scene::{node_name, node_transform},
         texture::{texture_sampler, texture_transform_to_affine2},
@@ -134,6 +140,9 @@ pub enum GltfError {
     #[error("GLTF model must be a tree, found cycle instead at node indices: {0:?}")]
     #[from(ignore)]
     CircularChildren(String),
+    /// Duplicate name found when using [`GltfLabelMode::Names`].
+    #[error("glTF file contained a duplicate subasset label: {0}")]
+    DuplicateName(String),
     /// Failed to load a file.
     #[error("failed to load file: {0}")]
     Io(#[from] Error),
@@ -155,6 +164,9 @@ pub struct GltfLoader {
     /// The default glTF coordinate conversion setting. This can be overridden
     /// per-load by [`GltfLoaderSettings::convert_coordinates`].
     pub default_convert_coordinates: GltfConvertCoordinates,
+    /// The default label mode setting. This can be overridden per-load by
+    /// [`GltfLoaderSettings::label_mode`].
+    pub default_label_mode: GltfLabelMode,
     /// glTF extension data processors.
     /// These are Bevy-side processors designed to access glTF
     /// extension data during the loading process.
@@ -211,8 +223,13 @@ pub struct GltfLoaderSettings {
     pub validate: bool,
     /// Overrides the default glTF coordinate conversion setting.
     ///
-    /// If `None`, uses the global default set by [`GltfPlugin::convert_coordinates`](crate::GltfPlugin::convert_coordinates).
+    /// If [`None`], uses the global default set by [`GltfPlugin::convert_coordinates`](crate::GltfPlugin::convert_coordinates).
     pub convert_coordinates: Option<GltfConvertCoordinates>,
+    /// Overrides the default option for how labels are assigned.
+    ///
+    /// If [`None`] uses the global default set by
+    /// [`GltfPlugin::label_mode`](crate::GltfPlugin::label_mode).
+    pub label_mode: Option<GltfLabelMode>,
     /// Optionally overrides [`GltfPlugin::skinned_mesh_bounds_policy`](crate::GltfPlugin).
     pub skinned_mesh_bounds_policy: Option<GltfSkinnedMeshBoundsPolicy>,
 }
@@ -230,6 +247,7 @@ impl Default for GltfLoaderSettings {
             override_sampler: false,
             validate: true,
             convert_coordinates: None,
+            label_mode: None,
             skinned_mesh_bounds_policy: None,
         }
     }
@@ -291,6 +309,20 @@ impl GltfLoader {
             None => loader.default_convert_coordinates,
         };
 
+        let label_mode = match settings.label_mode {
+            Some(label_mode) => label_mode,
+            None => {
+                if loader.default_label_mode == GltfLabelMode::Indices
+                    && !cfg!(feature = "gltf_named_subassets_default")
+                {
+                    warn_once!("Starting from Bevy 0.20, by default all glTF subassets will be renamed to use their names instead of their indices. \
+                    You are currently loading glTF files using the old behavior. Consider opting-in to the new loading behavior by enabling the `gltf_named_subassets_default` feature. \
+                    If you want to continue using the old behavior going forward (even after 0.20), manually set the `label_mode` option in the `GltfPlugin` or `GltfLoaderSettings`. See the release notes for more.");
+                }
+                loader.default_label_mode
+            }
+        };
+
         let skinned_mesh_bounds_policy = settings
             .skinned_mesh_bounds_policy
             .unwrap_or(loader.default_skinned_mesh_bounds_policy);
@@ -304,7 +336,20 @@ impl GltfLoader {
                 curve::{ConstantCurve, Interval, UnevenSampleAutoCurve},
                 Quat, Vec4,
             };
-            use gltf::animation::util::ReadOutputs;
+            use gltf::{animation::util::ReadOutputs, Animation};
+
+            let mut animation_label_maker = create_label_maker::<Animation>(
+                label_mode,
+                "anim",
+                |animation| {
+                    (
+                        GltfAssetLabel::Animation(animation.index()),
+                        IndexUsage::Normal,
+                    )
+                },
+                |name, _| GltfNamedAssetLabel::Animation(name),
+            );
+
             let mut animations = vec![];
             let mut named_animations = <HashMap<_, _>>::default();
             let mut animation_roots = <HashSet<_>>::default();
@@ -577,7 +622,7 @@ impl GltfLoader {
                 }
 
                 let handle = load_context.add_labeled_asset(
-                    GltfAssetLabel::Animation(animation.index()).to_string(),
+                    animation_label_maker(animation.clone(), animation.name())?,
                     animation_clip,
                 );
                 if let Some(name) = animation.name() {
@@ -608,6 +653,90 @@ impl GltfLoader {
             Some(sampler) => sampler,
             None => &loader.default_sampler.lock().unwrap().clone(),
         };
+
+        let mut texture_label_maker = create_label_maker::<gltf::Texture>(
+            label_mode,
+            "tex",
+            |texture| (GltfAssetLabel::Texture(texture.index()), IndexUsage::Normal),
+            |name, _| GltfNamedAssetLabel::Texture(name),
+        );
+        let mut material_label_maker = create_label_maker::<(Material, bool)>(
+            label_mode,
+            "mat",
+            |(material, is_scale_inverted)| match material.index() {
+                // TODO: The default material should also probably be invertible?
+                // If the material is the default material, then just abort immediately. Otherwise,
+                // since the default material JSON has name = null, we'd give this material a name
+                // like `__mat_0_2137`, which is not useful.
+                None => (GltfAssetLabel::DefaultMaterial, IndexUsage::Abort),
+                Some(index) => (
+                    GltfAssetLabel::Material {
+                        index,
+                        is_scale_inverted,
+                    },
+                    IndexUsage::Normal,
+                ),
+            },
+            // We don't need to handle `DefaultMaterial` here since, the default material never has
+            // a name!
+            |name, (_, is_scale_inverted)| GltfNamedAssetLabel::Material {
+                name,
+                is_scale_inverted,
+            },
+        );
+        let mut primitive_label_maker = create_label_maker::<(gltf::Mesh, gltf::Primitive)>(
+            label_mode,
+            "prim",
+            |(mesh, primitive)| {
+                (
+                    GltfAssetLabel::Primitive {
+                        mesh: mesh.index(),
+                        primitive: primitive.index(),
+                    },
+                    IndexUsage::Normal,
+                )
+            },
+            |name, (_, primitive)| GltfNamedAssetLabel::Primitive {
+                mesh: name,
+                primitive_index: primitive.index(),
+            },
+        );
+        let mut mesh_label_maker = create_label_maker::<gltf::Mesh>(
+            label_mode,
+            "mesh",
+            |mesh| (GltfAssetLabel::Mesh(mesh.index()), IndexUsage::Normal),
+            |name, _| GltfNamedAssetLabel::Mesh(name),
+        );
+        let mut inverse_bindposes_label_maker = create_label_maker::<gltf::Skin>(
+            label_mode,
+            "ibp",
+            |skin| {
+                (
+                    GltfAssetLabel::InverseBindMatrices(skin.index()),
+                    IndexUsage::Normal,
+                )
+            },
+            |name, _| GltfNamedAssetLabel::InverseBindMatrices { skin: name },
+        );
+        let mut node_label_maker = create_label_maker::<Node>(
+            label_mode,
+            "node",
+            |node| (GltfAssetLabel::Node(node.index()), IndexUsage::Normal),
+            |name, _| GltfNamedAssetLabel::Node(name),
+        );
+        let mut skin_label_maker = create_label_maker::<gltf::Skin>(
+            label_mode,
+            "skin",
+            |skin| (GltfAssetLabel::Skin(skin.index()), IndexUsage::Normal),
+            |name, _| GltfNamedAssetLabel::Skin(name),
+        );
+        let mut scene_label_maker = create_label_maker::<gltf::Scene>(
+            label_mode,
+            "scene",
+            |scene| (GltfAssetLabel::Scene(scene.index()), IndexUsage::Normal),
+            |name, _| GltfNamedAssetLabel::Scene(name),
+        );
+
         // We collect handles to ensure loaded images from paths are not unloaded before they are used elsewhere
         // in the loader. This prevents "reloads", but it also prevents dropping the is_srgb context on reload.
         //
@@ -617,6 +746,7 @@ impl GltfLoader {
         let mut texture_handles = Vec::new();
         if gltf.textures().len() == 1 || cfg!(target_arch = "wasm32") {
             for texture in gltf.textures() {
+                let label = texture_label_maker(texture.clone(), texture.name())?;
                 let image = load_image(
                     texture.clone(),
                     &buffer_data,
@@ -625,6 +755,7 @@ impl GltfLoader {
                     loader.supported_compressed_formats,
                     default_sampler,
                     settings,
+                    label,
                 )
                 .await?;
                 image.process_loaded_texture(load_context, &mut texture_handles);
@@ -641,6 +772,7 @@ impl GltfLoader {
                         let asset_path = load_context.path().clone();
                         let linear_textures = &linear_textures;
                         let buffer_data = &buffer_data;
+                        let label = texture_label_maker(gltf_texture.clone(), gltf_texture.name());
                         scope.spawn(async move {
                             load_image(
                                 gltf_texture,
@@ -650,6 +782,7 @@ impl GltfLoader {
                                 loader.supported_compressed_formats,
                                 default_sampler,
                                 settings,
+                                label?,
                             )
                             .await
                         });
@@ -678,12 +811,14 @@ impl GltfLoader {
         if !settings.load_materials.is_empty() {
             // NOTE: materials must be loaded after textures because image load() calls will happen before load_with_settings, preventing is_srgb from being set properly
             for material in gltf.materials() {
-                let (label, gltf_material) = load_material(
+                let gltf_material = load_material(
                     &material,
                     &texture_handles,
                     false,
                     load_context.path().clone(),
                 );
+                let label: CowArc<'static, str> =
+                    material_label_maker((material.clone(), false), material.name())?;
                 let handle = load_context.add_labeled_asset(label.clone(), gltf_material.clone());
 
                 if let Some(name) = material.name() {
@@ -697,7 +832,7 @@ impl GltfLoader {
                         &material,
                         handle.clone(),
                         &gltf_material,
-                        &label.clone(),
+                        &label,
                     );
                 }
 
@@ -725,10 +860,10 @@ impl GltfLoader {
                 meshes_on_non_skinned_nodes.contains(&gltf_mesh.index());
 
             for primitive in gltf_mesh.primitives() {
-                let primitive_label = GltfAssetLabel::Primitive {
-                    mesh: gltf_mesh.index(),
-                    primitive: primitive.index(),
-                };
+                let primitive_label = primitive_label_maker(
+                    (gltf_mesh.clone(), primitive.clone()),
+                    gltf_mesh.name(),
+                )?;
 
                 // a Mesh that can be generated by a user's extension,
                 // such as when decompressing draco buffers
@@ -864,7 +999,7 @@ impl GltfLoader {
                     warn!("Failed to generate skinned mesh bounds: {err}");
                 }
 
-                let mesh_handle = load_context.add_labeled_asset(primitive_label.to_string(), mesh);
+                let mesh_handle = load_context.add_labeled_asset(primitive_label, mesh);
                 primitives.push(super::GltfPrimitive::new(
                     &gltf_mesh,
                     &primitive,
@@ -888,7 +1023,8 @@ impl GltfLoader {
                 gltf_mesh.extras().as_deref().map(GltfExtras::from),
             );
 
-            let handle = load_context.add_labeled_asset(mesh.asset_label().to_string(), mesh);
+            let mesh_label = mesh_label_maker(gltf_mesh.clone(), gltf_mesh.name())?;
+            let handle = load_context.add_labeled_asset(mesh_label, mesh);
             if let Some(name) = gltf_mesh.name() {
                 named_meshes.insert(name.into(), handle.clone());
             }
@@ -899,39 +1035,43 @@ impl GltfLoader {
             meshes.push(handle);
         }
 
-        let skinned_mesh_inverse_bindposes: Vec<_> = gltf
+        let skinned_mesh_inverse_bindposes = gltf
             .skins()
-            .map(|gltf_skin| {
-                let reader = gltf_skin.reader(|buffer| Some(&buffer_data[buffer.index()]));
-                let local_to_bone_bind_matrices: Vec<Mat4> = reader
-                    .read_inverse_bind_matrices()
-                    .map(|mats| {
-                        mats.map(|mat| {
-                            Mat4::from_cols_array_2d(&mat)
-                                * convert_coordinates.mesh_conversion_mat4()
+            .map(
+                #[expect(clippy::result_large_err, reason = "GltfError holds an AssetLoadError")]
+                |gltf_skin| -> Result<Handle<SkinnedMeshInverseBindposes>, GltfError> {
+                    let reader = gltf_skin.reader(|buffer| Some(&buffer_data[buffer.index()]));
+                    let local_to_bone_bind_matrices: Vec<Mat4> = reader
+                        .read_inverse_bind_matrices()
+                        .map(|mats| {
+                            mats.map(|mat| {
+                                Mat4::from_cols_array_2d(&mat)
+                                    * convert_coordinates.mesh_conversion_mat4()
+                            })
+                            .collect()
                         })
-                        .collect()
-                    })
-                    .unwrap_or_else(|| {
-                        core::iter::repeat_n(Mat4::IDENTITY, gltf_skin.joints().len()).collect()
-                    });
+                        .unwrap_or_else(|| {
+                            core::iter::repeat_n(Mat4::IDENTITY, gltf_skin.joints().len()).collect()
+                        });
 
-                load_context.add_labeled_asset(
-                    GltfAssetLabel::InverseBindMatrices(gltf_skin.index()).to_string(),
-                    SkinnedMeshInverseBindposes::from(local_to_bone_bind_matrices),
-                )
-            })
-            .collect();
+                    let label = inverse_bindposes_label_maker(gltf_skin.clone(), gltf_skin.name())?;
+                    Ok(load_context.add_labeled_asset(
+                        label,
+                        SkinnedMeshInverseBindposes::from(local_to_bone_bind_matrices),
+                    ))
+                },
+            )
+            .collect::<Result<Vec<_>, _>>()?;
 
         let mut nodes = HashMap::<usize, Handle<GltfNode>>::default();
         let mut named_nodes = <HashMap<_, _>>::default();
-        let mut skins = <HashMap<_, _>>::default();
+        let mut skins = HashMap::<usize, Handle<GltfSkin>>::default();
         let mut named_skins = <HashMap<_, _>>::default();
 
         // First, create the node handles.
         for node in gltf.nodes() {
-            let label = GltfAssetLabel::Node(node.index());
-            let label_handle = load_context.get_label_handle(label.to_string());
+            let label = node_label_maker(node.clone(), node.name())?;
+            let label_handle = load_context.get_label_handle(label);
             nodes.insert(node.index(), label_handle);
         }
 
@@ -940,17 +1080,20 @@ impl GltfLoader {
 
         // Now populate the nodes.
         for node in gltf.nodes() {
-            let skin = node.skin().map(|skin| {
-                skins
-                    .entry(skin.index())
-                    .or_insert_with(|| {
-                        let joints: Vec<_> = skin
-                            .joints()
-                            .map(|joint| nodes.get(&joint.index()).unwrap().clone())
-                            .collect();
+            #[expect(clippy::result_large_err, reason = "GltfError holds an AssetLoadError")]
+            let skin = node
+                .skin()
+                .map(|skin| -> Result<Handle<GltfSkin>, GltfError> {
+                    match skins.entry(skin.index()) {
+                        Entry::Occupied(entry) => Ok(entry.get().clone()),
+                        Entry::Vacant(entry) => {
+                            let joints: Vec<_> = skin
+                                .joints()
+                                .map(|joint| nodes.get(&joint.index()).unwrap().clone())
+                                .collect();
 
-                        if joints.len() > MAX_JOINTS {
-                            warn!(
+                            if joints.len() > MAX_JOINTS {
+                                warn!(
                                 "The glTF skin {} has {} joints, but the maximum supported is {}",
                                 skin.name()
                                     .map(ToString::to_string)
@@ -958,26 +1101,33 @@ impl GltfLoader {
                                 joints.len(),
                                 MAX_JOINTS
                             );
+                            }
+
+                            let gltf_skin = GltfSkin::new(
+                                &skin,
+                                joints,
+                                skinned_mesh_inverse_bindposes[skin.index()].clone(),
+                                skin.extras().as_deref().map(GltfExtras::from),
+                            );
+
+                            let label = skin_label_maker(skin.clone(), skin.name())?;
+                            let handle = load_context.add_labeled_asset(label, gltf_skin);
+
+                            if let Some(name) = skin.name() {
+                                named_skins.insert(name.into(), handle.clone());
+                            }
+
+                            entry.insert(handle.clone());
+
+                            Ok(handle)
                         }
-
-                        let gltf_skin = GltfSkin::new(
-                            &skin,
-                            joints,
-                            skinned_mesh_inverse_bindposes[skin.index()].clone(),
-                            skin.extras().as_deref().map(GltfExtras::from),
-                        );
-
-                        let handle = load_context
-                            .add_labeled_asset(gltf_skin.asset_label().to_string(), gltf_skin);
-
-                        if let Some(name) = skin.name() {
-                            named_skins.insert(name.into(), handle.clone());
-                        }
-
-                        handle
-                    })
-                    .clone()
-            });
+                    }
+                });
+            let skin = if let Some(skin) = skin {
+                Some(skin?)
+            } else {
+                None
+            };
 
             let children = node
                 .children()
@@ -1001,8 +1151,8 @@ impl GltfLoader {
             #[cfg(feature = "bevy_animation")]
             let gltf_node = gltf_node.with_animation_root(animation_roots.contains(&node.index()));
 
-            let handle =
-                load_context.add_labeled_asset(gltf_node.asset_label().to_string(), gltf_node);
+            let label = node_label_maker(node.clone(), node.name())?;
+            let handle = load_context.add_labeled_asset(label, gltf_node);
             nodes.insert(node.index(), handle.clone());
             if let Some(name) = node.name() {
                 named_nodes.insert(name.into(), handle);
@@ -1059,6 +1209,8 @@ impl GltfLoader {
                             &convert_coordinates,
                             &mut extensions,
                             skinned_mesh_bounds_policy,
+                            &mut material_label_maker,
+                            &mut primitive_label_maker,
                         );
                         if result.is_err() {
                             err = Some(result);
@@ -1122,16 +1274,25 @@ impl GltfLoader {
             }
 
             let loaded_scene = scene_load_context.finish(Scene::new(world));
-            let scene_handle = load_context.add_loaded_labeled_asset(
-                GltfAssetLabel::Scene(scene.index()).to_string(),
-                loaded_scene,
-            );
+            let label = scene_label_maker(scene.clone(), scene.name())?;
+            let scene_handle = load_context.add_loaded_labeled_asset(label, loaded_scene);
 
             if let Some(name) = scene.name() {
                 named_scenes.insert(name.into(), scene_handle.clone());
             }
             scenes.push(scene_handle);
         }
+
+        // Rust thinks these label makers could use the `gltf` borrow in their drop impl. Drop
+        // them early to allow us to move the `gltf`.
+        drop(texture_label_maker);
+        drop(material_label_maker);
+        drop(primitive_label_maker);
+        drop(mesh_label_maker);
+        drop(inverse_bindposes_label_maker);
+        drop(skin_label_maker);
+        drop(node_label_maker);
+        drop(scene_label_maker);
 
         Ok(Gltf {
             default_scene: gltf
@@ -1191,6 +1352,7 @@ async fn load_image<'a, 'b>(
     supported_compressed_formats: CompressedImageFormats,
     default_sampler: &ImageSamplerDescriptor,
     settings: &GltfLoaderSettings,
+    label: CowArc<'static, str>,
 ) -> Result<ImageOrPath, GltfError> {
     let is_srgb = !linear_textures.contains(&gltf_texture.index());
     let sampler_descriptor = if settings.override_sampler {
@@ -1212,10 +1374,7 @@ async fn load_image<'a, 'b>(
                 ImageSampler::Descriptor(sampler_descriptor),
                 settings.load_materials,
             )?;
-            Ok(ImageOrPath::Image {
-                image,
-                label: GltfAssetLabel::Texture(gltf_texture.index()),
-            })
+            Ok(ImageOrPath::Image { image, label })
         }
         Source::Uri { uri, mime_type } => {
             let uri = percent_encoding::percent_decode_str(uri)
@@ -1234,7 +1393,7 @@ async fn load_image<'a, 'b>(
                         ImageSampler::Descriptor(sampler_descriptor),
                         settings.load_materials,
                     )?,
-                    label: GltfAssetLabel::Texture(gltf_texture.index()),
+                    label,
                 })
             } else {
                 let image_path = gltf_path
@@ -1257,7 +1416,7 @@ fn load_material(
     textures: &[Handle<Image>],
     is_scale_inverted: bool,
     asset_path: AssetPath<'_>,
-) -> (String, GltfMaterial) {
+) -> GltfMaterial {
     let pbr = material.pbr_metallic_roughness();
 
     // TODO: handle missing label handle errors here?
@@ -1416,7 +1575,7 @@ fn load_material(
     let base_emissive = LinearRgba::rgb(emissive[0], emissive[1], emissive[2]);
     let emissive = base_emissive * material.emissive_strength().unwrap_or(1.0);
 
-    let gltf_material = GltfMaterial {
+    GltfMaterial {
         base_color: Color::linear_rgba(color[0], color[1], color[2], color[3]),
         base_color_channel,
         base_color_texture,
@@ -1495,12 +1654,7 @@ fn load_material(
         specular_tint_channel: specular.specular_color_channel,
         #[cfg(feature = "pbr_specular_textures")]
         specular_tint_texture: specular.specular_color_texture,
-    };
-
-    (
-        material_label(material, is_scale_inverted).to_string(),
-        gltf_material,
-    )
+    }
 }
 
 /// Loads a glTF node.
@@ -1511,8 +1665,8 @@ fn load_material(
         reason = "`GltfError` is only barely past the threshold for large errors."
     )
 )]
-fn load_node(
-    gltf_node: &Node,
+fn load_node<'document>(
+    gltf_node: &Node<'document>,
     child_spawner: &mut ChildSpawner,
     root_load_context: &LoadContext,
     load_context: &mut LoadContext,
@@ -1527,6 +1681,14 @@ fn load_node(
     convert_coordinates: &GltfConvertCoordinates,
     extensions: &mut [Box<dyn extensions::ErasedGltfExtensionHandler>],
     skinned_mesh_bounds_policy: GltfSkinnedMeshBoundsPolicy,
+    material_label_maker: &mut dyn for<'b> FnMut(
+        (Material<'document>, bool),
+        Option<&'b str>,
+    ) -> Result<CowArc<'static, str>, GltfError>,
+    primitive_label_maker: &mut dyn for<'b> FnMut(
+        (gltf::Mesh<'document>, gltf::Primitive<'document>),
+        Option<&'b str>,
+    ) -> Result<CowArc<'static, str>, GltfError>,
 ) -> Result<(), GltfError> {
     let mut gltf_error = None;
     let transform = node_transform(gltf_node);
@@ -1627,22 +1789,30 @@ fn load_node(
             // append primitives
             for primitive in mesh.primitives() {
                 let material = primitive.material();
-                let mat_label = material_label(&material, is_scale_inverted);
-                let material_label = mat_label.to_string();
+                let material_label = match material_label_maker(
+                    (material.clone(), is_scale_inverted),
+                    material.name(),
+                ) {
+                    Ok(label) => label,
+                    Err(err) => {
+                        gltf_error = Some(err);
+                        return;
+                    }
+                };
 
                 // This adds materials that Bevy modifies depending on how they're used, like those with inverted scale.
-                if !root_load_context.has_labeled_asset(&material_label)
-                    && !load_context.has_labeled_asset(&material_label)
+                if !root_load_context.has_labeled_asset(material_label.clone())
+                    && !load_context.has_labeled_asset(material_label.clone())
                 {
-                    let (label, gltf_material) = load_material(
+                    let gltf_material = load_material(
                         &material,
                         textures,
                         is_scale_inverted,
                         load_context.path().clone(),
                     );
                     // TODO: maybe move this into `load_material` ?
-                    let handle =
-                        load_context.add_labeled_asset(label.clone(), gltf_material.clone());
+                    let handle = load_context
+                        .add_labeled_asset(material_label.clone(), gltf_material.clone());
 
                     // let extensions handle material data
                     for extension in extensions.iter_mut() {
@@ -1651,15 +1821,19 @@ fn load_node(
                             &material,
                             handle.clone(),
                             &gltf_material,
-                            &label.clone(),
+                            &material_label,
                         );
                     }
                 }
 
-                let primitive_label = GltfAssetLabel::Primitive {
-                    mesh: mesh.index(),
-                    primitive: primitive.index(),
-                };
+                let primitive_label =
+                    match primitive_label_maker((mesh.clone(), primitive.clone()), mesh.name()) {
+                        Ok(label) => label,
+                        Err(err) => {
+                            gltf_error = Some(err);
+                            return;
+                        }
+                    };
                 let bounds = primitive.bounding_box();
                 let parent_entity = parent.target_entity();
 
@@ -1670,7 +1844,7 @@ fn load_node(
 
                 let mut mesh_entity = parent.spawn((
                     // TODO: handle missing label handle errors here?
-                    Mesh3d(load_context.get_label_handle(primitive_label.to_string())),
+                    Mesh3d(load_context.get_label_handle(primitive_label)),
                     // TODO: could add the `GltfMaterial` here
                     mesh_entity_transform,
                 ));
@@ -1748,7 +1922,7 @@ fn load_node(
                         &mesh,
                         &material,
                         &mut mesh_entity,
-                        &mat_label.to_string(),
+                        material_label.as_ref(),
                     );
                 }
             }
@@ -1852,6 +2026,8 @@ fn load_node(
                 convert_coordinates,
                 extensions,
                 skinned_mesh_bounds_policy,
+                material_label_maker,
+                primitive_label_maker,
             ) {
                 gltf_error = Some(err);
                 return;
@@ -1878,12 +2054,12 @@ fn load_node(
                 weights.resize(max_morph_target_count, 0.0);
             }
 
-            let primitive_label = mesh.primitives().next().map(|p| GltfAssetLabel::Primitive {
-                mesh: mesh.index(),
-                primitive: p.index(),
-            });
-            let first_mesh =
-                primitive_label.map(|label| load_context.get_label_handle(label.to_string()));
+            let primitive_label = mesh
+                .primitives()
+                .next()
+                .map(|primitive| primitive_label_maker((mesh.clone(), primitive), mesh.name()))
+                .transpose()?;
+            let first_mesh = primitive_label.map(|label| load_context.get_label_handle(label));
             node.insert(MorphWeights::new(weights, first_mesh)?);
         }
     }
@@ -1988,7 +2164,7 @@ impl<'a> DataUri<'a> {
 enum ImageOrPath {
     Image {
         image: Image,
-        label: GltfAssetLabel,
+        label: CowArc<'static, str>,
     },
     Path {
         path: AssetPath<'static>,
@@ -2010,9 +2186,7 @@ impl ImageOrPath {
         handles: &mut Vec<Handle<Image>>,
     ) {
         let handle = match self {
-            ImageOrPath::Image { label, image } => {
-                load_context.add_labeled_asset(label.to_string(), image)
-            }
+            ImageOrPath::Image { label, image } => load_context.add_labeled_asset(label, image),
             ImageOrPath::Path {
                 path,
                 is_srgb,
@@ -2100,6 +2274,89 @@ struct AnimationContext {
 pub struct MorphTargetNames {
     /// The list of target names (or shape keys)
     pub target_names: Vec<String>,
+}
+
+/// The intended usage of a returned [`GltfAssetLabel`].
+enum IndexUsage {
+    /// The normal case. In [`GltfLabelMode::Indices`], the index is used as the label. In
+    /// [`GltfLabelMode::Names`], the index is used to dedupe labels.
+    Normal,
+    /// The index should be used as the label for the element, ignoring any other steps.
+    ///
+    /// This should only be used when the [`GltfAssetLabel`] matches the [`GltfNamedAssetLabel`].
+    Abort,
+}
+
+/// Returns a function that creates the label to use for calls like
+/// [`LoadContext::add_labeled_asset`].
+///
+/// For [`GltfLabelMode::Indices`], labels are deduped to reduce memory usage. For
+/// [`GltfLabelMode::Names`], if the element has a name, the name is checked for duplicates
+/// (returning error if one is found), and then the name is used (through `create_named`). If the
+/// element does not have a name, the label is randomly assigned, ensuring there are no duplicates.
+/// The `unnamed_prefix` is used to ensure unnamed elements are distinct across multiple "label
+/// makers".
+fn create_label_maker<T: Clone>(
+    label_mode: GltfLabelMode,
+    unnamed_prefix: &'static str,
+    mut create_index: impl FnMut(T) -> (GltfAssetLabel, IndexUsage),
+    mut create_named: impl for<'a> FnMut(&'a str, T) -> GltfNamedAssetLabel<'a>,
+) -> impl for<'a> FnMut(T, Option<&'a str>) -> Result<CowArc<'static, str>, GltfError> {
+    let mut source_index_to_label = HashMap::<_, CowArc<'static, str>>::new();
+    let mut used_names = HashSet::new();
+    let mut unlabeled_index = 0;
+    let mut source_index_to_unlabeled_index = HashMap::new();
+    let hasher_state = RandomState::default();
+    #[expect(clippy::result_large_err, reason = "GltfError holds an AssetLoadError")]
+    move |value: T, name: Option<&str>| {
+        let (index, index_usage) = create_index(value.clone());
+        // First, check if the `GltfAssetLabel` has already been handled. If we're using
+        // `GltfLabelMode::Names`, we only want to check for duplicate names between different
+        // entries, not the same element called multiple times.
+        let label_entry = match source_index_to_label.entry(index) {
+            Entry::Occupied(entry) => return Ok(entry.get().clone()),
+            Entry::Vacant(entry) => entry,
+        };
+        match index_usage {
+            IndexUsage::Normal => {}
+            IndexUsage::Abort => {
+                return Ok(label_entry.insert(index.to_string().into()).clone());
+            }
+        }
+        let label = match (label_mode, name) {
+            // Note: We could handle this case earlier, but doing it here means that the label
+            // `Arc`s are shared for repeated calls, since we look up into the HashMap to dedupe.
+            (GltfLabelMode::Indices, _) => index.to_string().into(),
+            (GltfLabelMode::Names, Some(name)) => {
+                let label: CowArc<'static, str> = create_named(name, value).to_string().into();
+                if !used_names.insert(label.clone()) {
+                    return Err(GltfError::DuplicateName(label.to_string()));
+                }
+                label
+            }
+            (GltfLabelMode::Names, None) => {
+                let unlabeled_index = match source_index_to_unlabeled_index.entry(index) {
+                    Entry::Occupied(entry) => *entry.get(),
+                    Entry::Vacant(entry) => {
+                        let new_index = *entry.insert(unlabeled_index);
+                        unlabeled_index += 1;
+                        new_index
+                    }
+                };
+                // Make the label be the unnamed_prefix, the index of its usage, and a hash of that
+                // string so users don't try to use this name. Since we also use the `RandomState`,
+                // every load should result in a different set of labels.
+                format!("__{unnamed_prefix}_{unlabeled_index}_{:x}", {
+                    let mut hasher = hasher_state.build_hasher();
+                    hasher.write(unnamed_prefix.as_bytes());
+                    hasher.write_u32(unlabeled_index);
+                    hasher.finish() as u16
+                })
+                .into()
+            }
+        };
+        Ok(label_entry.insert(label).clone())
+    }
 }
 
 #[cfg(test)]

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -213,6 +213,9 @@ bevy_ci_testing = ["bevy_dev_tools/bevy_ci_testing", "bevy_render?/ci_limits"]
 # Enable glTF animation loading
 gltf_animation = ["bevy_animation", "bevy_gltf?/bevy_animation"]
 
+# Set the default for loading glTF files to use the name of the subasset instead of the index.
+gltf_named_subassets_default = ["bevy_gltf?/gltf_named_subassets_default"]
+
 # Enables support for morph target weights in bevy_mesh
 morph = ["bevy_mesh?/morph", "bevy_render?/morph"]
 

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -134,6 +134,7 @@ This is the complete `bevy` cargo feature list, without "profiles" or "collectio
 |gif|GIF image format support|
 |glam_assert|Enable assertions to check the validity of parameters passed to glam|
 |gltf_animation|Enable glTF animation loading|
+|gltf_named_subassets_default|Set the default for loading glTF files to use the name of the subasset instead of the index.|
 |hdr|HDR image format support|
 |hotpatching|Enable hotpatching of Bevy systems|
 |http|Enables downloading assets from HTTP sources. Warning: there are security implications. Read the docs on WebAssetPlugin.|


### PR DESCRIPTION
# Objective

- Fixes #2948.
- Unlike previous attempts, this PR A) will continue to support indices going into the future, B) provides a nicer migration path.

## Solution

- Add a new feature flag for the new "names" mode.
- Add a `label_mode` to the `GltfPlugin` to allow overriding it globally.
- Add a `label_mode` to the `GltfLoaderSettings` to allow overriding it for individual assets.
- Create a "label maker" factory. Each label type creates a label maker, then when creating a new subasset you just feed in the arguments, and the name, and it produces the correct label based on the `label_mode`.

## Testing

- Added unit tests!
- Nothing breaks for the `anti_aliasing` example using the `Indices` mode.
- I migrated the `anti_aliasing` example as a test. It required 1) setting the GltfPlugin::label_mode, 2) loading with the `GltfNamedAssetLabel` instead, and **3) mutating the FlightHelmet.gltf to include a name for the only scene**.
    - I looked at several of our example models, and most of them include a scene name - however some do not!