### PR TITLE
support disabling gpu clustering

### DIFF
--- a/crates/bevy_pbr/src/cluster/mod.rs
+++ b/crates/bevy_pbr/src/cluster/mod.rs
@@ -733,7 +733,12 @@ impl ViewClusterBindings {
                 clusterable_object_index_lists,
                 cluster_offsets_and_counts,
             } => {
-                clusterable_object_index_lists.write_buffer(render_device);
+                // Ensure the buffer is always allocated even when empty (GPU clustering is disabled)
+                if clusterable_object_index_lists.is_empty() {
+                    clusterable_object_index_lists.reserve(1, render_device);
+                } else {
+                    clusterable_object_index_lists.write_buffer(render_device);
+                }
                 cluster_offsets_and_counts.write_buffer(render_device, render_queue);
             }
         }


### PR DESCRIPTION
# Objective

- Bevy crashes on android

```
thread 'Compute Task Pool (6)' (17463129) panicked at crates/bevy_pbr/src/render/mesh_view_bindings.rs:727:26:
called `Option::unwrap()` on a `None` value
```

## Solution

- Make sure the buffer exists

## Testing

- Bevy now works when I forcibly set `gpu_clustering_supported` to false
- Running on Android on an open PR