### PR TITLE
Implement `MapEntities` for the unit type

### DIFF
--- a/crates/bevy_ecs/src/entity/map_entities.rs
+++ b/crates/bevy_ecs/src/entity/map_entities.rs
@@ -195,6 +195,10 @@ impl<T: MapEntities, A: smallvec::Array<Item = T>> MapEntities for SmallVec<A> {
     }
 }
 
+impl MapEntities for () {
+    fn map_entities<E: EntityMapper>(&mut self, _entity_mapper: &mut E) {}
+}
+
 /// An implementor of this trait knows how to map an [`Entity`] into another [`Entity`].
 ///
 /// Usually this is done by using an [`EntityHashMap<Entity>`] to map source entities


### PR DESCRIPTION
Adds an empty `MapEntities` implementation for the `()` type, which basically represents an empty map.

Makes it possible to have a struct with a generic argument requiring a `MapEntities` bound defaulting to `()`.
