### PR TITLE
gate bloom on hdr check

### DIFF
--- a/crates/bevy_post_process/src/bloom/mod.rs
+++ b/crates/bevy_post_process/src/bloom/mod.rs
@@ -112,7 +112,7 @@ pub fn bloom(
         downsampling_pipeline_ids,
     ) = view.into_inner();
 
-    if bloom_settings.intensity == 0.0 {
+    if bloom_settings.intensity == 0.0 || !view_target.is_hdr() {
         return;
     }
 


### PR DESCRIPTION
# Objective

- Fixes #23142

## Solution

- Don't run bloom if the view is not HDR

## Testing

- transmission example