### PR TITLE
update parley to version 0.8

### DIFF
--- a/crates/bevy_text/Cargo.toml
+++ b/crates/bevy_text/Cargo.toml
@@ -39,7 +39,7 @@ smallvec = { version = "1", default-features = false }
 smol_str = { version = "0.2", default-features = false }
 sys-locale = "0.3.0"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
-parley = { version = "0.7.0", default-features = false, features = ["std"] }
+parley = { version = "0.8.0", default-features = false, features = ["std"] }
 swash = { version = "0.2.6" }
 
 [lints]

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -13,10 +13,9 @@ use bevy_log::warn_once;
 use bevy_math::{Rect, Vec2};
 use bevy_platform::hash::FixedHasher;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
-use parley::style::{OverflowWrap, TextWrapMode};
+use parley::style::{OverflowWrap, TextWrapMode, WordBreak};
 use parley::{
-    Alignment, AlignmentOptions, FontFamily, FontStack, Layout, PositionedLayoutItem,
-    StyleProperty, WordBreakStrength,
+    Alignment, AlignmentOptions, FontFamily, Layout, PositionedLayoutItem, StyleProperty,
 };
 use swash::FontRef;
 
@@ -169,7 +168,7 @@ impl TextPipeline {
 
             match linebreak {
                 LineBreak::AnyCharacter => {
-                    builder.push_default(StyleProperty::WordBreak(WordBreakStrength::BreakAll));
+                    builder.push_default(StyleProperty::WordBreak(WordBreak::BreakAll));
                 }
                 LineBreak::WordOrCharacter => {
                     builder.push_default(StyleProperty::OverflowWrap(OverflowWrap::Anywhere));
@@ -178,7 +177,7 @@ impl TextPipeline {
                     builder.push_default(StyleProperty::TextWrapMode(TextWrapMode::NoWrap));
                 }
                 LineBreak::WordBoundary => {
-                    builder.push_default(StyleProperty::WordBreak(WordBreakStrength::Normal));
+                    builder.push_default(StyleProperty::WordBreak(WordBreak::Normal));
                 }
             }
 
@@ -194,10 +193,7 @@ impl TextPipeline {
 
                 let family = resolve_font_source(&section.text_font.font, fonts)?;
 
-                builder.push(
-                    StyleProperty::FontStack(FontStack::Single(family)),
-                    range.clone(),
-                );
+                builder.push(StyleProperty::FontFamily(family), range.clone());
                 builder.push(
                     StyleProperty::Brush(TextBrush::new(
                         section.index as u32,
@@ -423,22 +419,24 @@ pub fn resolve_font_source<'a>(
     Ok(match font {
         FontSource::Handle(handle) => {
             let font = fonts.get(handle.id()).ok_or(TextError::NoSuchFont)?;
-            FontFamily::Named(Cow::Owned(font.family_name.as_str().to_owned()))
+            FontFamily::Single(parley::FontFamilyName::Named(Cow::Owned(
+                font.family_name.as_str().to_owned(),
+            )))
         }
-        FontSource::Family(family) => FontFamily::Named(Cow::Borrowed(family.as_str())),
-        FontSource::Serif => FontFamily::Generic(parley::GenericFamily::Serif),
-        FontSource::SansSerif => FontFamily::Generic(parley::GenericFamily::SansSerif),
-        FontSource::Cursive => FontFamily::Generic(parley::GenericFamily::Cursive),
-        FontSource::Fantasy => FontFamily::Generic(parley::GenericFamily::Fantasy),
-        FontSource::Monospace => FontFamily::Generic(parley::GenericFamily::Monospace),
-        FontSource::SystemUi => FontFamily::Generic(parley::GenericFamily::SystemUi),
-        FontSource::UiSerif => FontFamily::Generic(parley::GenericFamily::UiSerif),
-        FontSource::UiSansSerif => FontFamily::Generic(parley::GenericFamily::UiSansSerif),
-        FontSource::UiMonospace => FontFamily::Generic(parley::GenericFamily::UiMonospace),
-        FontSource::UiRounded => FontFamily::Generic(parley::GenericFamily::UiRounded),
-        FontSource::Emoji => FontFamily::Generic(parley::GenericFamily::Emoji),
-        FontSource::Math => FontFamily::Generic(parley::GenericFamily::Math),
-        FontSource::FangSong => FontFamily::Generic(parley::GenericFamily::FangSong),
+        FontSource::Family(family) => FontFamily::named(family.as_str()),
+        FontSource::Serif => parley::GenericFamily::Serif.into(),
+        FontSource::SansSerif => parley::GenericFamily::SansSerif.into(),
+        FontSource::Cursive => parley::GenericFamily::Cursive.into(),
+        FontSource::Fantasy => parley::GenericFamily::Fantasy.into(),
+        FontSource::Monospace => parley::GenericFamily::Monospace.into(),
+        FontSource::SystemUi => parley::GenericFamily::SystemUi.into(),
+        FontSource::UiSerif => parley::GenericFamily::UiSerif.into(),
+        FontSource::UiSansSerif => parley::GenericFamily::UiSansSerif.into(),
+        FontSource::UiMonospace => parley::GenericFamily::UiMonospace.into(),
+        FontSource::UiRounded => parley::GenericFamily::UiRounded.into(),
+        FontSource::Emoji => parley::GenericFamily::Emoji.into(),
+        FontSource::Math => parley::GenericFamily::Math.into(),
+        FontSource::FangSong => parley::GenericFamily::FangSong.into(),
     })
 }
 

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -8,6 +8,7 @@ use bevy_reflect::prelude::*;
 use bevy_utils::{default, once};
 use core::fmt::{Debug, Formatter};
 use core::str::from_utf8;
+use parley::setting::Tag;
 use parley::{FontFeature, Layout};
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
@@ -898,14 +899,14 @@ where
     }
 }
 
-impl From<&FontFeatures> for parley::style::FontSettings<'static, FontFeature> {
+impl From<&FontFeatures> for parley::style::FontFeatures<'static> {
     fn from(font_features: &FontFeatures) -> Self {
-        parley::style::FontSettings::List(
+        parley::style::FontFeatures::List(
             font_features
                 .features
                 .iter()
                 .map(|(tag, value)| FontFeature {
-                    tag: u32::from_be_bytes(tag.0),
+                    tag: Tag::new(&tag.0),
                     value: *value as u16,
                 })
                 .collect(),

--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -51,7 +51,8 @@ thiserror = { version = "2", default-features = false }
 derive_more = { version = "2", default-features = false, features = ["from"] }
 smallvec = { version = "1", default-features = false }
 accesskit = "0.24"
-parley = { version = "0.7.0", default-features = false, features = ["std"] }
+parley = { version = "0.8.0", default-features = false, features = ["std"] }
+swash = { version = "0.2.6" }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 
 [dev-dependencies]

--- a/crates/bevy_ui/src/widget/text_editable.rs
+++ b/crates/bevy_ui/src/widget/text_editable.rs
@@ -20,8 +20,8 @@ use bevy_text::{
     PositionedGlyph, RemSize, RunGeometry, ScaleCx, TextBrush, TextFont, TextLayoutInfo,
 };
 use bevy_time::{Real, Time};
-use parley::{swash::FontRef, BoundingBox};
-use parley::{FontFamily, FontStack, PositionedLayoutItem};
+use parley::{BoundingBox, PositionedLayoutItem};
+use swash::FontRef;
 
 struct TextInputMeasure {
     height: f32,
@@ -122,13 +122,10 @@ pub fn editable_text_system(
             continue;
         };
 
-        let family = match font_family {
-            FontFamily::Named(name) => FontFamily::Named(name.into_owned().into()),
-            FontFamily::Generic(generic) => FontFamily::Generic(generic),
-        };
+        let family = font_family.into_owned();
         let style_set = editable_text.editor.edit_styles();
         style_set.insert(parley::StyleProperty::LineHeight(line_height.eval()));
-        style_set.insert(parley::StyleProperty::FontStack(FontStack::Single(family)));
+        style_set.insert(parley::StyleProperty::FontFamily(family));
 
         let logical_viewport_size = target.logical_size();
         let font_size = text_font.font_size.eval(logical_viewport_size, rem_size.0);

--- a/crates/bevy_ui_widgets/Cargo.toml
+++ b/crates/bevy_ui_widgets/Cargo.toml
@@ -25,7 +25,7 @@ bevy_text = { path = "../bevy_text", version = "0.19.0-dev" }
 
 # other
 accesskit = "0.24"
-parley = { version = "0.7", default-features = false }
+parley = { version = "0.8.0", default-features = false }
 smol_str = "0.2"
 
 [features]


### PR DESCRIPTION
# Objective

https://github.com/linebender/parley/releases/tag/v0.8.0

## Solution

Didn't change much, just accomodated some API changes. 

Parley no longer re-exports FontRef, so had to add swash to bevy_ui's dependencies. `editable_text` should be using `TextPipeline`, then this won't be necessary.