### PR TITLE
Remove unnecessary `reserve` in `BufferVec::push`

### DIFF
--- a/crates/bevy_render/src/render_resource/buffer_vec.rs
+++ b/crates/bevy_render/src/render_resource/buffer_vec.rs
@@ -551,8 +551,6 @@ where
         let element_size = u64::from(T::min_size()) as usize;
         let offset = self.data.len();
 
-        // `extend` does not optimize for reallocation. Related `trusted_len` feature is unstable.
-        self.data.reserve(self.data.len() + element_size);
         // We can't optimize and push uninitialized data here (using e.g. spare_capacity_mut())
         // because write_into() does not initialize inner padding bytes in T's expansion
         self.data.extend(iter::repeat_n(0, element_size));


### PR DESCRIPTION
# Objective

In https://github.com/bevyengine/bevy/pull/22470#discussion_r2679394948 I thought `Vec::extend(repeat_n( ... ))` doesn't have `TrustedLen` optimization but I was wrong! Rust std is allowed to use unstable features internally. See https://godbolt.org/z/x4sGj9on9 the generated MIR uses `Vec::extend_trusted`.

## Solution

Remove the unnecessary `reserve`

## Testing

None