### PR TITLE
Update Android game activity to be compatible with android-activity v0.6.1

### DIFF
--- a/examples/mobile/android_example/gradle/libs.versions.toml
+++ b/examples/mobile/android_example/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ junitVersion = "1.1.5"
 espressoCore = "3.5.1"
 appcompat = "1.6.1"
 material = "1.10.0"
-gamesActivity = "2.0.2"
+gamesActivity = "4.4.0" # Note: This must be compatible with `android-activity` crate used by bevy.
 
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }


### PR DESCRIPTION
# Objective

https://github.com/rust-mobile/android-activity/releases/tag/v0.6.1 requires GameActivity 4.4.0

## Solution

Update it to fix crash.

## Testing

Tested on Android.