### PR TITLE
Fix material slot overflow in bindless slab

### DIFF
--- a/crates/bevy_pbr/src/material_bind_groups.rs
+++ b/crates/bevy_pbr/src/material_bind_groups.rs
@@ -940,10 +940,18 @@ impl MaterialBindlessSlab {
         }
 
         // OK, we can allocate in this slab. Assign a slot ID.
-        let slot = self
-            .free_slots
-            .pop()
-            .unwrap_or(MaterialBindGroupSlot(self.live_allocation_count));
+        let slot = match self.free_slots.pop() {
+            Some(slot) => slot,
+            None => {
+                // The material bind group slot is packed into 16 bits on
+                // the GPU, so spill to a new slab before we would overflow.
+                if self.live_allocation_count > 0xFFFF {
+                    trace!("Slab material bind group slot would overflow, can't allocate");
+                    return Err(unprepared_bind_group);
+                }
+                MaterialBindGroupSlot(self.live_allocation_count)
+            }
+        };
 
         // Bump the live allocation count.
         self.live_allocation_count += 1;
@@ -1630,6 +1638,7 @@ where
                 if self.bindings.len() < slot as usize + 1 {
                     self.bindings.resize_with(slot as usize + 1, || None);
                 }
+                debug_assert!(self.bindings[slot as usize].is_none());
                 self.bindings[slot as usize] = Some(MaterialBindlessBinding::new(resource));
 
                 self.len += 1;

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -661,6 +661,14 @@ impl MeshUniform {
             Some((slot_index, _)) => slot_index.into(),
         };
 
+        let material_slot = u32::from(material_bind_group_slot);
+        debug_assert!(
+            material_slot <= 0xFFFF,
+            "Material bind group slot {material_slot} overflowed"
+        );
+        let material_and_lightmap_bind_group_slot =
+            material_slot | ((lightmap_bind_group_slot as u32) << 16);
+
         Self {
             world_from_local: mesh_transforms.world_from_local.to_transpose(),
             previous_world_from_local: mesh_transforms.previous_world_from_local.to_transpose(),
@@ -670,8 +678,7 @@ impl MeshUniform {
             flags: mesh_transforms.flags,
             first_vertex_index,
             current_skin_index: current_skin_index.unwrap_or(u32::MAX),
-            material_and_lightmap_bind_group_slot: u32::from(material_bind_group_slot)
-                | ((lightmap_bind_group_slot as u32) << 16),
+            material_and_lightmap_bind_group_slot,
             tag: tag.unwrap_or(0),
             morph_descriptor_index: match morph_descriptor_index {
                 Some(morph_descriptor_index) => morph_descriptor_index.0,
@@ -1492,6 +1499,13 @@ impl RenderMeshInstanceGpuBuilder {
         };
 
         // Create the mesh input uniform.
+        let material_slot = u32::from(self.shared.material_bindings_index.slot);
+        debug_assert!(
+            material_slot <= 0xFFFF,
+            "Material bind group slot {material_slot} overflowed"
+        );
+        let material_and_lightmap_bind_group_slot = material_slot | ((lightmap_slot as u32) << 16);
+
         let mesh_input_uniform = MeshInputUniform {
             world_from_local: self.world_from_local.to_transpose(),
             lightmap_uv_rect: self.lightmap_uv_rect,
@@ -1506,9 +1520,7 @@ impl RenderMeshInstanceGpuBuilder {
                 vertex_count
             },
             current_skin_index,
-            material_and_lightmap_bind_group_slot: u32::from(
-                self.shared.material_bindings_index.slot,
-            ) | ((lightmap_slot as u32) << 16),
+            material_and_lightmap_bind_group_slot,
             tag: self.shared.tag,
             morph_descriptor_index,
         };


### PR DESCRIPTION
# Objective

Fixes #23128

When allocating in MaterialBindlessSlab it can hold up to 32 bits of allocations. However, when used on the GPU the slot is packed into 16 bits and combined with the lightmap slot, and when it overflows both slots end up being wrong.

## Solution

Add some debug asserts to validate that the bit packing succeeds, and limit the slab to 16 bits of allocations.

I'm not super well versed in this part of the codebase, so I don't know if this is the best spot to put the check, since the limitation isn't really on the slab itself. And I don't know if this has other ramifications that need to be handled.

## Testing

Test using the reproducer from the issue.