### PR TITLE
Fix stale occlusion culling components

### DIFF
--- a/crates/bevy_core_pipeline/src/mip_generation/experimental/depth.rs
+++ b/crates/bevy_core_pipeline/src/mip_generation/experimental/depth.rs
@@ -697,7 +697,15 @@ pub fn prepare_view_depth_pyramids(
     mut texture_cache: ResMut<TextureCache>,
     depth_pyramid_dummy_texture: Res<DepthPyramidDummyTexture>,
     views: Query<(Entity, &ExtractedView), (With<OcclusionCulling>, Without<NoIndirectDrawing>)>,
+    stale_views: Query<Entity, (With<ViewDepthPyramid>, Without<OcclusionCulling>)>,
 ) {
+    // Remove old resources when occlusion culling gets disabled
+    for view_entity in &stale_views {
+        commands
+            .entity(view_entity)
+            .remove::<(ViewDepthPyramid, ViewDownsampleDepthBindGroup)>();
+    }
+
     for (view_entity, view) in &views {
         commands.entity(view_entity).insert(ViewDepthPyramid::new(
             &render_device,


### PR DESCRIPTION
# Objective

Fixes #23108

When occlusion culling gets disabled for a view we didn't clean up the generated components, which caused some later occlusion culling systems to run in an invalid state.

This problem was discovered recently, and while I haven't bisected it my guess is that it's been present since the retained render world. We could really use a more general approach to catching and/or preventing these issues with stale resources.

## Solution

Remove stale resources in the prepare system before we make new ones.

## Testing

`cargo run --example occlusion_culling` and press space a couple of times.
