### PR TITLE
Add render_layers scene to testbed_3d

### DIFF
--- a/examples/testbed/3d.rs
+++ b/examples/testbed/3d.rs
@@ -715,11 +715,8 @@ mod white_furnace_environment_map_light {
 mod render_layers {
     const CURRENT_SCENE: super::Scene = super::Scene::RenderLayers;
 
-    use std::f32::consts::PI;
-
     use bevy::{
         camera::{visibility::RenderLayers, Viewport},
-        light::CascadeShadowConfigBuilder,
         prelude::*,
         window::PrimaryWindow,
     };
@@ -771,22 +768,6 @@ mod render_layers {
             Transform::from_xyz(4.0, 8.0, 4.0),
             DespawnOnExit(CURRENT_SCENE),
         ));
-
-        // commands.spawn((
-        //     Transform::from_rotation(Quat::from_euler(EulerRot::ZYX, 0.0, 1.0, -PI / 4.)),
-        //     DirectionalLight {
-        //         shadow_maps_enabled: true,
-        //         ..default()
-        //     },
-        //     CascadeShadowConfigBuilder {
-        //         num_cascades: 2,
-        //         first_cascade_far_bound: 200.0,
-        //         maximum_distance: 280.0,
-        //         ..default()
-        //     }
-        //     .build(),
-        //     DespawnOnExit(CURRENT_SCENE),
-        // ));
 
         let window_half_size = window.physical_size() / 2;
 


### PR DESCRIPTION
# Objective

- RenderLayers are easy to break and so is multiple viewport support

## Solution

- Add a new scene to testbed_3d that shows multiple cameras at the same time all with different combinations of render layers

## Testing

- I ran the example locally and toggled between all the scenes

---

## Showcase

<img width="1282" height="752" alt="testbed_3d_KmHPJ8pweU" src="https://github.com/user-attachments/assets/dad376f3-fd72-424d-b68d-7048843da179" />

As you can see, this already highlights a bug with shadows not respecting render layers