### PR TITLE
Hashmap visit asset dependencies impl

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -2046,6 +2046,10 @@ mod tests {
             set_handles: HashSet<Handle<TestAsset>>,
             #[dependency]
             untyped_set_handles: HashSet<UntypedHandle>,
+            #[dependency]
+            map_handles: HashMap<String, Handle<TestAsset>>,
+            #[dependency]
+            untyped_map_handles: HashMap<String, UntypedHandle>,
         },
         StructStyle(#[dependency] TestAsset),
         Empty,
@@ -2069,6 +2073,10 @@ mod tests {
         set_handles: HashSet<Handle<TestAsset>>,
         #[dependency]
         untyped_set_handles: HashSet<UntypedHandle>,
+        #[dependency]
+        map_handles: HashMap<String, Handle<TestAsset>>,
+        #[dependency]
+        untyped_map_handles: HashMap<String, UntypedHandle>,
     }
 
     #[expect(


### PR DESCRIPTION
# Objective

- Allow tagging of HashMaps with `#[dependency]`, for assets which contain variable binding assignments to asset handles.

## Solution

- The solution is to create an implementation of VisitAssetDependencies for HashMap that behaves similarly to HashSet. 

## Testing

- The changes were tested by adding `map_handles` and `untyped_map_handles` to `StructTestAsset` and `EnumTestAsset`. Then, `cargo test` was ran in `crates/bevy_asset`. 

## Showcase
I plan to use this to create a map of material bindings to material handles. In the below example, `materials` is a map of bindings (e.g. "$east", "$south"). Each `Element` contains up to six references, so this helps when there are block templates that only use one material for all faces.

```rust
#[derive(Asset, Reflect, Clone)]
#[type_path = "ovx::blocks::template"]
#[type_name = "BlockTemplate"]
pub struct BlockTemplate {
    #[dependency]
    pub inherits: Vec<Handle<BlockTemplate>>,
    #[dependency]
    pub materials: HashMap<String, Handle<BlockMaterial>>,
    pub elements: HashMap<String, Element>,
    pub variants: HashMap<String, Variant>,
    pub states: HashMap<String, BlockState>,
}
```
