### PR TITLE
Silence RA warnings in `export-content/app.rs`

### DIFF
--- a/tools/export-content/src/app.rs
+++ b/tools/export-content/src/app.rs
@@ -1,3 +1,7 @@
+#![expect(
+    unused_assignments,
+    reason = "fields in ParseError are only read via Diagnostic/Error derive macro expansions, which are generating spurious warnings"
+)]
 use std::{env, fs, io::Write, path::PathBuf};
 
 use miette::{diagnostic, Context, Diagnostic, IntoDiagnostic, NamedSource, Result};


### PR DESCRIPTION
# Objective

<img width="709" height="662" alt="image" src="https://github.com/user-attachments/assets/2628d574-a915-4929-83c0-40985371cd66" />

Spurious warnings are bad for developer wellbeing: silence them somehow.

## Solution

Add a file-level expect to silence these.

I couldn't find a more targeted solution: this seems to be a bug in the generated macro code and/or rustc's linting.
Adding allow to the struct definition itself didn't work.

We could move `ParseError` into its own module and then scope the expect down. This would eliminate false negatives, but be really quite scuffed.

## Testing

RA warnings are no more!