### PR TITLE
Fix docs.rs extensions README providing invalid `Cargo.toml` snippet

### DIFF
--- a/docs-rs/README.md
+++ b/docs-rs/README.md
@@ -18,7 +18,7 @@ rustdoc-args = [
 ]
 
 [lints.rust]
-unexpected_cfgs = { check-cfg = ['cfg(docsrs_dep)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(docsrs_dep)'] }
 ```
 
 ## Local Testing


### PR DESCRIPTION
# Objective

The README in `docs-rs/` tells you to add this line to your `Cargo.toml`:
```toml
[lints.rust]
unexpected_cfgs = { check-cfg = ['cfg(docsrs_dep)'] }
```

However this does not compile due to this error:
```
error: missing field `level`
  --> Cargo.toml:41:19
   |
41 | unexpected_cfgs = { check-cfg = ['cfg(docsrs_dep)'] }
   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

## Solution

Looking at Bevy's own `Cargo.toml`, this lint is used with the `warn` level.
```toml
unexpected_cfgs = { level = "warn", check-cfg = ['cfg(docsrs_dep)'] }
```

So I updated the docs.rs README to be the same.

## Testing

I copied and pasted the new snippet into my `Cargo.toml` and it worked.