### PR TITLE
Add white furnace analog for 2D color consistency

### DIFF
--- a/examples/testbed/2d.rs
+++ b/examples/testbed/2d.rs
@@ -607,7 +607,7 @@ mod color_consistency {
                 position_type: PositionType::Absolute,
                 bottom: Val::Px(0.0),
                 left: Val::Px(0.0),
-                width: Val::Percent(100.0),
+                width: Val::Percent(33.3),
                 height: Val::Px(STRIP_HEIGHT),
                 ..default()
             },

--- a/examples/testbed/2d.rs
+++ b/examples/testbed/2d.rs
@@ -34,6 +34,8 @@ fn main() {
             OnEnter(Scene::TextureAtlasBuilder),
             texture_atlas_builder::setup,
         )
+        .add_systems(OnEnter(Scene::ColorConsistency), color_consistency::setup)
+        .add_systems(OnExit(Scene::ColorConsistency), color_consistency::teardown)
         .add_systems(Update, switch_scene)
         .add_systems(Update, gizmos::draw_gizmos.run_if(in_state(Scene::Gizmos)));
 
@@ -58,6 +60,7 @@ enum Scene {
     SpriteSlicing,
     Gizmos,
     TextureAtlasBuilder,
+    ColorConsistency,
 }
 
 impl std::str::FromStr for Scene {
@@ -84,7 +87,8 @@ impl Next for Scene {
             Scene::Sprite => Scene::SpriteSlicing,
             Scene::SpriteSlicing => Scene::Gizmos,
             Scene::Gizmos => Scene::TextureAtlasBuilder,
-            Scene::TextureAtlasBuilder => Scene::Shapes,
+            Scene::TextureAtlasBuilder => Scene::ColorConsistency,
+            Scene::ColorConsistency => Scene::Shapes,
         }
     }
 }
@@ -541,5 +545,81 @@ mod texture_atlas_builder {
                 ));
             }
         }
+    }
+}
+
+mod color_consistency {
+    //! Visual regression test for <https://github.com/bevyengine/bevy/issues/23577>.
+    //!
+    //! The clear color and shapes rendered using different pipelines (sprites,
+    //! 2D meshes, UI background) should produce identical pixel values for the
+    //! same sRGB input color.
+    //!
+    //! If the color conversion paths are consistent, the entire window will appear
+    //! as a uniform solid color with no visible boundaries between the strips.
+
+    use bevy::{core_pipeline::tonemapping::Tonemapping, prelude::*};
+
+    // The sRGB value from issue #23577: 0.1 * 255 = 25.5 exactly in 8-bit space,
+    // so inconsistent rounding shows up as a 1-step difference.
+    const TEST_COLOR: Color = Color::srgb(0.1, 0.1, 0.1);
+    const DEFAULT_WIDTH: f32 = 1280.0;
+    const DEFAULT_HEIGHT: f32 = 720.0;
+    const STRIP_WIDTH: f32 = DEFAULT_WIDTH / 3.0;
+    const STRIP_HEIGHT: f32 = DEFAULT_HEIGHT / 3.0;
+
+    pub fn setup(
+        mut commands: Commands,
+        mut meshes: ResMut<Assets<Mesh>>,
+        mut materials: ResMut<Assets<ColorMaterial>>,
+    ) {
+        // The window background is drawn with the clear color.
+        commands.insert_resource(ClearColor(TEST_COLOR));
+
+        // Make sure there's no tonemapping
+        commands.spawn((
+            Camera2d,
+            Tonemapping::None,
+            DespawnOnExit(super::Scene::ColorConsistency),
+        ));
+
+        // Top third for sprites
+        commands.spawn((
+            Sprite {
+                color: TEST_COLOR,
+                custom_size: Some(Vec2::new(STRIP_WIDTH, STRIP_HEIGHT)),
+                ..default()
+            },
+            Transform::from_xyz(0.0, STRIP_HEIGHT, 0.0),
+            DespawnOnExit(super::Scene::ColorConsistency),
+        ));
+
+        // Middle third for 2D meshes
+        commands.spawn((
+            Mesh2d(meshes.add(Rectangle::new(STRIP_WIDTH, STRIP_HEIGHT))),
+            MeshMaterial2d(materials.add(ColorMaterial::from_color(TEST_COLOR))),
+            Transform::from_xyz(0.0, 0.0, 0.0),
+            DespawnOnExit(super::Scene::ColorConsistency),
+        ));
+
+        // Bottom third for UI nodes
+        commands.spawn((
+            Node {
+                position_type: PositionType::Absolute,
+                bottom: Val::Px(0.0),
+                left: Val::Px(0.0),
+                width: Val::Percent(100.0),
+                height: Val::Px(STRIP_HEIGHT),
+                ..default()
+            },
+            BackgroundColor(TEST_COLOR),
+            DespawnOnExit(super::Scene::ColorConsistency),
+        ));
+    }
+
+    // Remember to reset the clear color
+    // Tonemapping is per-camera, and is reset by despawning
+    pub fn teardown(mut commands: Commands) {
+        commands.insert_resource(ClearColor::default());
     }
 }

--- a/examples/testbed/2d.rs
+++ b/examples/testbed/2d.rs
@@ -617,7 +617,7 @@ mod color_consistency {
     }
 
     // Remember to reset the clear color
-    // Tonemapping is per-camera, and is reset by despawning
+    // Tonemapping is per-camera, and is reset when the camera despawns
     pub fn teardown(mut commands: Commands) {
         commands.insert_resource(ClearColor::default());
     }

--- a/examples/testbed/2d.rs
+++ b/examples/testbed/2d.rs
@@ -560,8 +560,7 @@ mod color_consistency {
 
     use bevy::{core_pipeline::tonemapping::Tonemapping, prelude::*};
 
-    // The sRGB value from issue #23577: 0.1 * 255 = 25.5 exactly in 8-bit space,
-    // so inconsistent rounding shows up as a 1-step difference.
+    // We've chosen the sRGB value from issue #23577, in case it can be reproduced elsewhere.
     const TEST_COLOR: Color = Color::srgb(0.1, 0.1, 0.1);
     const DEFAULT_WIDTH: f32 = 1280.0;
     const DEFAULT_HEIGHT: f32 = 720.0;


### PR DESCRIPTION
# Objective

Create a regression test for https://github.com/bevyengine/bevy/issues/23577.

## Solution

Copy the white furnace test idea by spawning a bunch of 2D things with exactly the same color.

Split out from #23584.

## Testing

`cargo run -example testbed_2d`. Press space to get to the example that's all grey.

Locally, this is all one uniform grey for me: I could not reproduce #23577.

Still, this is a useful property to test for!
