### PR TITLE
Update SpriteMesh in PostUpdate

### DIFF
--- a/crates/bevy_sprite_render/src/sprite_mesh/mod.rs
+++ b/crates/bevy_sprite_render/src/sprite_mesh/mod.rs
@@ -18,7 +18,7 @@ use bevy_sprite::{prelude::SpriteMesh, Anchor};
 mod sprite_material;
 pub use sprite_material::*;
 
-use crate::MeshMaterial2d;
+use crate::{check_entities_needing_specialization, MeshMaterial2d};
 
 pub struct SpriteMeshPlugin;
 
@@ -26,7 +26,12 @@ impl Plugin for SpriteMeshPlugin {
     fn build(&self, app: &mut bevy_app::App) {
         app.add_plugins(SpriteMaterialPlugin);
 
-        app.add_systems(PostUpdate, (add_mesh, add_material).chain());
+        app.add_systems(
+            PostUpdate,
+            (add_mesh, add_material)
+                .chain()
+                .before(check_entities_needing_specialization::<SpriteMaterial>),
+        );
     }
 }
 


### PR DESCRIPTION
# Objective

Fixes #23590

## Solution

Move `SpriteMesh`'s `add_mesh` and `add_material` to PostUpdate
Sprites spawned during `PostUpdate` will still exhibit the problem, but this is an improvement.

## Testing

Test with the reproduction from #23590 to see that it fixes the problem.

