### PR TITLE
Do not enable bevy_render dependency through debug feature

### DIFF
--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -453,7 +453,7 @@ gestures = ["bevy_input/gestures"]
 
 hotpatching = ["bevy_app/hotpatching", "bevy_ecs/hotpatching"]
 
-debug = ["bevy_utils/debug", "bevy_ecs/debug", "bevy_render/debug"]
+debug = ["bevy_utils/debug", "bevy_ecs/debug", "bevy_render?/debug"]
 
 screenrecording = ["bevy_dev_tools/screenrecording"]
 


### PR DESCRIPTION
# Objective

Enabling Bevy's `debug` feature also enables its `bevy_render` dependency.

## Solution

Don't.