### PR TITLE
Fix clippy::used_underscore_binding in Reflect derive for struct enum variant

### DIFF
--- a/crates/bevy_reflect/derive/src/enum_utility.rs
+++ b/crates/bevy_reflect/derive/src/enum_utility.rs
@@ -154,7 +154,7 @@ pub(crate) trait VariantBuilder: Sized {
 
             for field in fields {
                 let member = as_member(field.data.ident.as_ref(), field.declaration_index);
-                let alias = format_ident!("_{}", member);
+                let alias = format_ident!("__{}", member);
 
                 let variant_field = VariantField {
                     alias: &alias,


### PR DESCRIPTION
# Objective

```rust
#[derive(Reflect)]
pub enum Projection {
    Perspective { fov: f64 },
    Orthographic { scale: f64 },
}
```

This will yield a clippy lint of `used_underscore_binding` due to the macro generating the member alias with only a single underscore, and that alias being used.

## Solution

Tack on another underscore to better convey the internal nature of the binding

## Testing

Before
```
cargo clippy -p bevy_camera -- -W clippy::used_underscore_binding 2>&1 | wc -l
     834
```

After:
```
cargo clippy -p bevy_camera -- -W clippy::used_underscore_binding 2>&1 | wc -l
     205
```