### PR TITLE
Correctly order UiSystems::Stack

### DIFF
--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -150,6 +150,7 @@ impl Plugin for UiPlugin {
                     UiSystems::Content,
                     UiSystems::Layout,
                     UiSystems::PostLayout,
+                    UiSystems::Stack,
                 )
                     .chain(),
             )


### PR DESCRIPTION
# Objective

`UiSystems::Stack` is not ordered correctly relative to its siblings.

Spotted while reviewing #23346.

## Solution

Add it to the .chain call.

Note that the other variants not chained run in `PreUpdate`.