### PR TITLE
Fix typo in safety comment for pointer usage

### DIFF
--- a/crates/bevy_ecs/src/storage/thin_array_ptr.rs
+++ b/crates/bevy_ecs/src/storage/thin_array_ptr.rs
@@ -143,7 +143,7 @@ impl<T> ThinArrayPtr<T> {
         // - We have a reference to self, so no other mutable accesses to the element can occur
         unsafe {
             ptr.as_ref()
-                // SAFETY: We can use `unwarp_unchecked` because the pointer isn't null)
+                // SAFETY: We can use `unwrap_unchecked` because the pointer isn't null)
                 .debug_checked_unwrap()
         }
     }


### PR DESCRIPTION
While looking at the code for `bevy_ecs/src/storage/thin_array_ptr.rs`, I came across this slight typo. It isn't critical I thought that I'd just fix it. 