### PR TITLE
Return/log an error when attempting to load an empty asset path.

### DIFF
--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -352,6 +352,14 @@ pub enum UntypedHandle {
 }
 
 impl UntypedHandle {
+    /// Returns the equivalent of [`Handle`]'s default implementation for the given type ID.
+    pub fn default_for_type(type_id: TypeId) -> Self {
+        Self::Uuid {
+            type_id,
+            uuid: AssetId::<()>::DEFAULT_UUID,
+        }
+    }
+
     /// Returns the [`UntypedAssetId`] for the referenced asset.
     #[inline]
     pub fn id(&self) -> UntypedAssetId {

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -744,6 +744,7 @@ mod tests {
         sync::Mutex,
     };
     use bevy_reflect::{Reflect, TypePath};
+    use bevy_tasks::block_on;
     use core::{any::TypeId, time::Duration};
     use futures_lite::AsyncReadExt;
     use serde::{Deserialize, Serialize};
@@ -2801,8 +2802,7 @@ mod tests {
         source.insert_asset_text(Path::new(ASSET_PATH), "blah");
 
         let asset_server = app.world().resource::<AssetServer>().clone();
-        bevy_tasks::block_on(asset_server.write_default_loader_meta_file_for_path(ASSET_PATH))
-            .unwrap();
+        block_on(asset_server.write_default_loader_meta_file_for_path(ASSET_PATH)).unwrap();
 
         assert_eq!(
             read_meta_as_string(&source, Path::new(ASSET_PATH)),
@@ -2829,7 +2829,7 @@ mod tests {
 
         let asset_server = app.world().resource::<AssetServer>().clone();
         assert!(matches!(
-            bevy_tasks::block_on(asset_server.write_default_loader_meta_file_for_path(ASSET_PATH)),
+            block_on(asset_server.write_default_loader_meta_file_for_path(ASSET_PATH)),
             Err(WriteDefaultMetaError::MetaAlreadyExists)
         ));
 
@@ -3082,5 +3082,59 @@ mod tests {
             "loaderless",
             TestLoadState::Failed(TestAssetLoadError::MissingAssetLoader),
         );
+    }
+
+    #[test]
+    fn load_empty_path_returns_default() {
+        let mut app = create_app().0;
+
+        // Not necessary but better to make things more realistic to ensure we hit the right error
+        // case.
+        app.init_asset::<TestAsset>()
+            .register_asset_loader(TrivialLoader);
+
+        const TYPE_ID: TypeId = TypeId::of::<TestAsset>();
+
+        fn boring_settings(_: &mut ()) {}
+
+        let asset_server = app.world().resource::<AssetServer>().clone();
+
+        for path in ["", "no_path://#WithALabel"] {
+            // TODO: We have way too many "load" variants. We **need** to simplify this.
+            assert_eq!(asset_server.load(path), Handle::<TestAsset>::default());
+            assert_eq!(
+                asset_server.load_acquire(path, ()),
+                Handle::<TestAsset>::default()
+            );
+            assert_eq!(
+                asset_server.load_acquire_override(path, ()),
+                Handle::<TestAsset>::default()
+            );
+            assert_eq!(
+                asset_server.load_acquire_with_settings(path, boring_settings, ()),
+                Handle::<TestAsset>::default()
+            );
+            assert_eq!(
+                asset_server.load_erased(TYPE_ID, path),
+                Handle::<TestAsset>::default()
+            );
+            assert_eq!(
+                asset_server.load_override(path),
+                Handle::<TestAsset>::default()
+            );
+            assert_eq!(asset_server.load_untyped(path), Handle::default());
+            assert!(matches!(
+                block_on(asset_server.load_untyped_async(path)),
+                Err(AssetLoadError::EmptyPath(reported_path)) if AssetPath::from(path) == reported_path
+            ));
+            assert_eq!(
+                asset_server.load_with_settings(path, |_: &mut ()| {}),
+                Handle::<TestAsset>::default()
+            );
+            assert_eq!(
+                asset_server.load_with_settings_override(path, |_: &mut ()| {}),
+                Handle::<TestAsset>::default()
+            );
+        }
     }
 }

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -16,8 +16,9 @@ use core::any::{Any, TypeId};
 use downcast_rs::{impl_downcast, Downcast};
 use ron::error::SpannedError;
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use thiserror::Error;
+use tracing::error;
 
 /// Loads an [`Asset`] from a given byte [`Reader`]. This can accept [`AssetLoader::Settings`], which configure how the [`Asset`]
 /// should be loaded.
@@ -568,6 +569,11 @@ impl<'a> LoadContext<'a> {
         path: impl Into<AssetPath<'c>>,
     ) -> Result<Vec<u8>, ReadAssetBytesError> {
         let path = path.into();
+        if path.path() == Path::new("") {
+            error!("Attempted to load an asset with an empty path \"{path}\"!");
+            return Err(ReadAssetBytesError::EmptyPath(path.into_owned()));
+        }
+
         let source = self.asset_server.get_source(path.source())?;
         let asset_reader = match self.asset_server.mode() {
             AssetServerMode::Unprocessed => source.reader(),
@@ -681,6 +687,8 @@ impl<'a> LoadContext<'a> {
 /// An error produced when calling [`LoadContext::read_asset_bytes`]
 #[derive(Error, Debug)]
 pub enum ReadAssetBytesError {
+    #[error("Attempted to load an asset with an empty path \"{0}\"")]
+    EmptyPath(AssetPath<'static>),
     #[error(transparent)]
     DeserializeMetaError(#[from] DeserializeMetaError),
     #[error(transparent)]

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -339,6 +339,8 @@ impl<A: Asset> AssetContainer for A {
 /// [immediately]: crate::Immediate
 #[derive(Error, Debug)]
 pub enum LoadDirectError {
+    #[error("Attempting to load asset with no path \"{0}\"")]
+    EmptyPath(AssetPath<'static>),
     #[error("Requested to load an asset path ({0:?}) with a subasset, but this is unsupported. See issue #18291")]
     RequestedSubasset(AssetPath<'static>),
     #[error("Failed to load dependency {dependency:?} {error}")]

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -339,7 +339,7 @@ impl<A: Asset> AssetContainer for A {
 /// [immediately]: crate::Immediate
 #[derive(Error, Debug)]
 pub enum LoadDirectError {
-    #[error("Attempting to load asset with no path \"{0}\"")]
+    #[error("Attempted to load an asset with an empty path \"{0}\"")]
     EmptyPath(AssetPath<'static>),
     #[error("Requested to load an asset path ({0:?}) with a subasset, but this is unsupported. See issue #18291")]
     RequestedSubasset(AssetPath<'static>),

--- a/crates/bevy_asset/src/loader_builders.rs
+++ b/crates/bevy_asset/src/loader_builders.rs
@@ -307,7 +307,7 @@ impl NestedLoader<'_, '_, StaticTyped, Deferred> {
     pub fn load<'c, A: Asset>(self, path: impl Into<AssetPath<'c>>) -> Handle<A> {
         let path = path.into().to_owned();
         if path.path() == Path::new("") {
-            error!("Attempting to load asset with no path \"{path}\"!");
+            error!("Attempted to load an asset with an empty path \"{path}\"!");
             return Handle::default();
         }
         let handle = if self.load_context.should_load_dependencies {
@@ -341,7 +341,7 @@ impl NestedLoader<'_, '_, DynamicTyped, Deferred> {
     pub fn load<'p>(self, path: impl Into<AssetPath<'p>>) -> UntypedHandle {
         let path = path.into().to_owned();
         if path.path() == Path::new("") {
-            error!("Attempting to load asset with no path \"{path}\"!");
+            error!("Attempted to load an asset with an empty path \"{path}\"!");
             return UntypedHandle::default_for_type(self.typing.asset_type_id);
         }
         let handle = if self.load_context.should_load_dependencies {
@@ -378,7 +378,7 @@ impl NestedLoader<'_, '_, UnknownTyped, Deferred> {
     pub fn load<'p>(self, path: impl Into<AssetPath<'p>>) -> Handle<LoadedUntypedAsset> {
         let path = path.into().to_owned();
         if path.path() == Path::new("") {
-            error!("Attempting to load asset with no path \"{path}\"!");
+            error!("Attempted to load an asset with an empty path \"{path}\"!");
             return Handle::default();
         }
         let handle = if self.load_context.should_load_dependencies {
@@ -414,7 +414,7 @@ impl<'builder, 'reader, T> NestedLoader<'_, '_, T, Immediate<'builder, 'reader>>
         asset_type_id: Option<TypeId>,
     ) -> Result<(Arc<dyn ErasedAssetLoader>, ErasedLoadedAsset), LoadDirectError> {
         if path.path() == Path::new("") {
-            error!("Attempting to load asset with no path \"{path}\"!");
+            error!("Attempted to load an asset with an empty path \"{path}\"!");
             return Err(LoadDirectError::EmptyPath(path.clone_owned()));
         }
         if path.label().is_some() {

--- a/crates/bevy_asset/src/loader_builders.rs
+++ b/crates/bevy_asset/src/loader_builders.rs
@@ -9,6 +9,8 @@ use crate::{
 };
 use alloc::{borrow::ToOwned, boxed::Box, sync::Arc};
 use core::any::TypeId;
+use std::path::Path;
+use tracing::error;
 
 // Utility type for handling the sources of reader references
 enum ReaderRef<'a> {
@@ -304,6 +306,10 @@ impl NestedLoader<'_, '_, StaticTyped, Deferred> {
     /// [`with_unknown_type`]: Self::with_unknown_type
     pub fn load<'c, A: Asset>(self, path: impl Into<AssetPath<'c>>) -> Handle<A> {
         let path = path.into().to_owned();
+        if path.path() == Path::new("") {
+            error!("Attempting to load asset with no path \"{path}\"!");
+            return Handle::default();
+        }
         let handle = if self.load_context.should_load_dependencies {
             self.load_context.asset_server.load_with_meta_transform(
                 path,
@@ -334,6 +340,10 @@ impl NestedLoader<'_, '_, DynamicTyped, Deferred> {
     /// [`with_dynamic_type`]: Self::with_dynamic_type
     pub fn load<'p>(self, path: impl Into<AssetPath<'p>>) -> UntypedHandle {
         let path = path.into().to_owned();
+        if path.path() == Path::new("") {
+            error!("Attempting to load asset with no path \"{path}\"!");
+            return UntypedHandle::default_for_type(self.typing.asset_type_id);
+        }
         let handle = if self.load_context.should_load_dependencies {
             self.load_context
                 .asset_server
@@ -367,6 +377,10 @@ impl NestedLoader<'_, '_, UnknownTyped, Deferred> {
     /// This will infer the asset type from metadata.
     pub fn load<'p>(self, path: impl Into<AssetPath<'p>>) -> Handle<LoadedUntypedAsset> {
         let path = path.into().to_owned();
+        if path.path() == Path::new("") {
+            error!("Attempting to load asset with no path \"{path}\"!");
+            return Handle::default();
+        }
         let handle = if self.load_context.should_load_dependencies {
             self.load_context
                 .asset_server
@@ -399,6 +413,10 @@ impl<'builder, 'reader, T> NestedLoader<'_, '_, T, Immediate<'builder, 'reader>>
         path: &AssetPath<'static>,
         asset_type_id: Option<TypeId>,
     ) -> Result<(Arc<dyn ErasedAssetLoader>, ErasedLoadedAsset), LoadDirectError> {
+        if path.path() == Path::new("") {
+            error!("Attempting to load asset with no path \"{path}\"!");
+            return Err(LoadDirectError::EmptyPath(path.clone_owned()));
+        }
         if path.label().is_some() {
             return Err(LoadDirectError::RequestedSubasset(path.clone()));
         }

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -509,7 +509,7 @@ impl AssetServer {
     ) -> Handle<A> {
         let path = path.into().into_owned();
         if path.path() == Path::new("") {
-            error!("Attempting to load asset with no path \"{path}\"!");
+            error!("Attempted to load an asset with an empty path \"{path}\"!");
             return Handle::default();
         }
 
@@ -546,7 +546,7 @@ impl AssetServer {
     ) -> UntypedHandle {
         let path = path.into().into_owned();
         if path.path() == Path::new("") {
-            error!("Attempting to load asset with no path \"{path}\"!");
+            error!("Attempted to load an asset with an empty path \"{path}\"!");
             return UntypedHandle::default_for_type(type_id);
         }
 
@@ -630,7 +630,7 @@ impl AssetServer {
     ) -> Handle<LoadedUntypedAsset> {
         let path = path.into().into_owned();
         if path.path() == Path::new("") {
-            error!("Attempting to load asset with no path \"{path}\"!");
+            error!("Attempted to load an asset with an empty path \"{path}\"!");
             return Handle::default();
         }
 
@@ -2101,7 +2101,7 @@ impl RecursiveDependencyLoadState {
     reason = "Adding docs to the variants would not add information beyond the error message and the names"
 )]
 pub enum AssetLoadError {
-    #[error("Attempting to load asset with no path \"{0}\"")]
+    #[error("Attempted to load an asset with an empty path \"{0}\"")]
     EmptyPath(AssetPath<'static>),
     #[error("Requested handle of type {requested:?} for asset '{path}' does not match actual asset type '{actual_asset_name}', which used loader '{loader_name}'")]
     RequestedHandleTypeMismatch {

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -508,6 +508,10 @@ impl AssetServer {
         override_unapproved: bool,
     ) -> Handle<A> {
         let path = path.into().into_owned();
+        if path.path() == Path::new("") {
+            error!("Attempting to load asset with no path \"{path}\"!");
+            return Handle::default();
+        }
 
         if path.is_unapproved() {
             match (&self.data.unapproved_path_mode, override_unapproved) {
@@ -541,6 +545,11 @@ impl AssetServer {
         guard: G,
     ) -> UntypedHandle {
         let path = path.into().into_owned();
+        if path.path() == Path::new("") {
+            error!("Attempting to load asset with no path \"{path}\"!");
+            return UntypedHandle::default_for_type(type_id);
+        }
+
         let mut infos = self.write_infos();
         let (handle, should_load) = infos.get_or_create_path_handle_erased(
             path.clone(),
@@ -605,6 +614,10 @@ impl AssetServer {
         self.write_infos().stats.started_load_tasks += 1;
 
         let path: AssetPath = path.into();
+        if path.path() == Path::new("") {
+            return Err(AssetLoadError::EmptyPath(path.clone_owned()));
+        }
+
         self.load_internal(None, path, false, None)
             .await
             .map(|h| h.expect("handle must be returned, since we didn't pass in an input handle"))
@@ -616,6 +629,11 @@ impl AssetServer {
         meta_transform: Option<MetaTransform>,
     ) -> Handle<LoadedUntypedAsset> {
         let path = path.into().into_owned();
+        if path.path() == Path::new("") {
+            error!("Attempting to load asset with no path \"{path}\"!");
+            return Handle::default();
+        }
+
         let untyped_source = AssetSourceId::Name(match path.source() {
             AssetSourceId::Default => CowArc::Static(UNTYPED_SOURCE_SUFFIX),
             AssetSourceId::Name(source) => {
@@ -2083,6 +2101,8 @@ impl RecursiveDependencyLoadState {
     reason = "Adding docs to the variants would not add information beyond the error message and the names"
 )]
 pub enum AssetLoadError {
+    #[error("Attempting to load asset with no path \"{0}\"")]
+    EmptyPath(AssetPath<'static>),
     #[error("Requested handle of type {requested:?} for asset '{path}' does not match actual asset type '{actual_asset_name}', which used loader '{loader_name}'")]
     RequestedHandleTypeMismatch {
         path: AssetPath<'static>,


### PR DESCRIPTION
# Objective

- Partially addresses https://discord.com/channels/691052431525675048/749332104487108618/1489425547598762095
    - Currently BSN will attempt to load a string whenever a handle is seen. Unfortunately, BSN treats nothing to mean the empty string. The asset system then tries to load the empty string and returns various unhelpful error messages depending on your OS.
    - This doesn't totally fix the issue - BSN should probably not be loading these paths at all. But more generally the asset system should just ignore empty paths entirely since it should never load a meaningful path.

## Solution

- In every load variant, add a check for the empty path and log an error or return an error in that case. We also return a default handle in that case (where necessary).
- Intentionally don't handle `load_folder`. You could theoretically want to load the root folder!

To address some alternative implementations:
- There isn't a common loading API that all roads lead to! Each one is a little different, so we need to handle them in each case. We should investigate collapsing some of these though.
- `AssetPath` still needs to be allowed to parse an empty path, since for stuff like joining asset paths, that needs to support cases like "only a subasset label", or "joining the empty path with some subdir path".

## Testing

- Added a test to test all the load variants on `AssetServer`.