### PR TITLE
Fix for 22822 ComputedStates example

### DIFF
--- a/examples/state/computed_states.rs
+++ b/examples/state/computed_states.rs
@@ -54,6 +54,8 @@ impl ComputedStates for InGame {
     // Our computed state depends on `AppState`, so we need to specify it as the SourceStates type.
     type SourceStates = AppState;
 
+    // This is necessary to prevent `setup_game` from running when the app is already in `AppState::InGame`
+    // and only `paused` and `turbo` are changed
     const ALLOW_SAME_STATE_TRANSITIONS: bool = false;
     // The compute function takes in the `SourceStates`
     fn compute(sources: AppState) -> Option<Self> {


### PR DESCRIPTION
# Objective

- Fixes #22822

## Solution

- Adds ALLOW_SAME_STATE_TRANSITIONS = false to ComputedStates in computed_states example

## Testing

- Tested by running example on  x86_64 Linux 4.19 + KDE.  Behavior noted in #22822 no longer occurs.