### PR TITLE
Make the default for the HandleTemplate to use Handle::default().

### DIFF
--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -215,7 +215,7 @@ pub enum HandleTemplate<T: Asset> {
 
 impl<T: Asset> Default for HandleTemplate<T> {
     fn default() -> Self {
-        Self::Path(Default::default())
+        Self::Handle(Default::default())
     }
 }
 


### PR DESCRIPTION
# Objective

- Not setting any value to a handle in BSN results in BSN attempting to load an empty path! This is not handled well (see #23654 for some fixes there).
- Even with #23654, we would still get errors in the logs which is not ideal.

## Solution

- Use the Handle variant for the template!