### PR TITLE
fix editable_text example after new text plugins added to DefaultPlugins

### DIFF
--- a/examples/ui/text/editable_text.rs
+++ b/examples/ui/text/editable_text.rs
@@ -8,7 +8,7 @@
 use bevy::color::palettes::css::{DARK_GREY, YELLOW};
 use bevy::input_focus::{
     tab_navigation::{TabGroup, TabIndex, TabNavigationPlugin},
-     InputFocus,
+    InputFocus,
 };
 use bevy::prelude::*;
 use bevy::text::{EditableText, FontCx, LayoutCx, TextCursorStyle};


### PR DESCRIPTION
# Objective

- Example `editable_text` crashes because of duplicated plugins

## Solution

- Remove the duplicated plugins

## Testing

- `cargo run -example editable_text`
