### PR TITLE
Don't unnecesarily enable reflection in bevy_render by removing the `default` feature of `bevy_render`

### DIFF
--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -55,8 +55,6 @@ serialize = ["bevy_mesh/serialize"]
 reflect_auto_register = ["bevy_app/reflect_auto_register"]
 reflect_functions = ["bevy_app/reflect_functions"]
 
-default = ["reflect_auto_register", "reflect_functions"]
-
 [dependencies]
 # bevy
 bevy_app = { path = "../bevy_app", version = "0.19.0-dev" }


### PR DESCRIPTION
# Objective

- https://github.com/bevyengine/bevy/pull/23446/changes#r3036236068 spotted that we enable reflect in render unnecessarily

## Solution

- Remove it

## Testing

- CI
- `cargo run --example server --features="bevy_remote"` + `curl -d'{"jsonrpc":"2.0","method":"schedule.graph","id":1,"params":{"schedule_label":"Render"}}' -X POST -H "Accept: applcation/json" -H "Content-Type: application/json" http://127.0.0.1:15703` still works