### PR TITLE
add template_value to prelude

### DIFF
--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -506,8 +506,9 @@
 /// This includes the most common types in this crate, re-exported for your convenience.
 pub mod prelude {
     pub use crate::{
-        bsn, bsn_list, on, CommandsSceneExt, EntityCommandsSceneExt, EntityWorldMutSceneExt,
-        PatchFromTemplate, PatchTemplate, Scene, SceneList, ScenePatchInstance, WorldSceneExt,
+        bsn, bsn_list, on, template_value, CommandsSceneExt, EntityCommandsSceneExt,
+        EntityWorldMutSceneExt, PatchFromTemplate, PatchTemplate, Scene, SceneList,
+        ScenePatchInstance, WorldSceneExt,
     };
 }
 


### PR DESCRIPTION
# Objective

`template_value` is not in the prelude, but seems useful enough to be. It seems like the main way to include an existing component value in a `bsn!` declaration since using `{transform}` and similar expressions doesn't work.

```rust
// some Transform, maybe from an `In<Transform>` or other argument.
let transform = Transform::from_xyz(5., 0., 5.);

bsn! {
    #SomeThing
    template_value(transform)
}
```

## Solution

Add `template_value` to the prelude.
