### PR TITLE
add template to prelude

### DIFF
--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -98,7 +98,7 @@ pub mod prelude {
             Res, ResMut, Single, System, SystemIn, SystemInput, SystemParamBuilder,
             SystemParamFunction,
         },
-        template::{FromTemplate, Template},
+        template::{template, FromTemplate, Template},
         world::{
             EntityMut, EntityRef, EntityWorldMut, FilteredResources, FilteredResourcesMut,
             FromWorld, World,


### PR DESCRIPTION
# Objective

similar to #23669 , `template` seems useful and is used in documentation examples, as well as the [scene bsn example](https://github.com/bevyengine/bevy/blob/6b0fb37e2c73cfb9181a06888162d1d2534cef99/examples/scene/bsn.rs#L2), but is not in the prelude.

## Solution

Add `template` to the prelude
