### PR TITLE
impl Clone for bevy_light Shader markers

### DIFF
--- a/crates/bevy_light/src/lib.rs
+++ b/crates/bevy_light/src/lib.rs
@@ -251,7 +251,7 @@ pub struct NotShadowCaster;
 /// **Note:** If you're using diffuse transmission, setting [`NotShadowReceiver`] will
 /// cause both “regular” shadows as well as diffusely transmitted shadows to be disabled,
 /// even when [`TransmittedShadowReceiver`] is being used.
-#[derive(Debug, Component, Reflect, Default)]
+#[derive(Debug, Component, Reflect, Default, Clone)]
 #[reflect(Component, Default, Debug)]
 pub struct NotShadowReceiver;
 /// Add this component to make a [`Mesh3d`] using a PBR material with `StandardMaterial::diffuse_transmission > 0.0`
@@ -261,7 +261,7 @@ pub struct NotShadowReceiver;
 /// (and potentially even baking a thickness texture!) to match the geometry of the mesh, in order to avoid self-shadow artifacts.
 ///
 /// **Note:** Using [`NotShadowReceiver`] overrides this component.
-#[derive(Debug, Component, Reflect, Default)]
+#[derive(Debug, Component, Reflect, Default, Clone)]
 #[reflect(Component, Default, Debug)]
 pub struct TransmittedShadowReceiver;
 


### PR DESCRIPTION
# Objective

Enable the use of `NotShadowReceiver` in `bsn!` by implementing `Clone` (`Default` is already implemented).

```rust
error[E0277]: the trait bound `NotShadowReceiver: Clone` is not satisfied
   --> src/spawn_circle.rs:375:27
    |
375 |           world.spawn_scene(bsn! {
    |  ___________________________^
376 | |             #SpawnCircle
377 | |             SpawnCircle
378 | |             SpawnEventToTrigger({self.event})
...   |
394 | |             )]
395 | |         });
    | |_________^ the trait `Clone` is not implemented for `NotShadowReceiver`
    |
```

I also noticed `TransmittedShadowReceiver` would have the same issue, so added `Clone` there as well.

---

An alternative would be to implement `FromTemplate` instead of `Default` and `Clone`. I'm not sure which solution is preferred in general, but these are Marker components so don't require any additional values.