### PR TITLE
Atmosphere as entity migration guide

### DIFF
--- a/_release-content/migration-guides/atmosphere_entity.md
+++ b/_release-content/migration-guides/atmosphere_entity.md
@@ -6,6 +6,8 @@ pull_requests: [23651]
 Previously, the `Atmosphere` component was added on the camera. Instead,
 spawn an `Atmosphere` as an entity. The nearest atmosphere will be chosen for rendering.
 
+`AtmosphereSettings` still belongs on the camera. It is the component that enables atmosphere rendering for that view.
+
 The `scene_units_to_m` field has been removed from `AtmosphereSettings`. Use `Transform` on the `Atmosphere` entity for scale. It is inversely proportional to the old `scene_units_to_m` factor. For example, to treat one unit as 1 km (as with `scene_units_to_m: 1000.0`), set scale to `0.001`.
 
 ```rust


### PR DESCRIPTION
# Objective

- Once PR #23651 is merged we need a migration guide for breaking changes to Bevy's atmosphere.
- Post the release note changes as a new PR to review grammar/writing separately

## Solution

- Write a migration guide detailing the breaking changes
- Adhere to a friendly non-technical tone 
- Explain the new way of scaling the atmosphere with `Transform`

## Out of scope
- Explain how to customize the apparent up axis (i.e. horizon's orientation) -> this should follow intuitively but maybe I should add this too? or maybe this belongs in a release note instead? 