### PR TITLE
conditionally disable tests on miri for taking way too long

### DIFF
--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -2064,6 +2064,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "This test takes ~460s on CI")]
     fn queue_register_component_toctou() {
         for _ in 0..1000 {
             let w = World::new();

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -3048,6 +3048,7 @@ mod tests {
     struct Marker;
 
     #[test]
+    #[cfg_attr(miri, ignore = "This test takes ~70s on CI")]
     fn query_iter_sorts() {
         let mut world = World::new();
         for i in 0..100 {

--- a/crates/bevy_ecs/src/query/mod.rs
+++ b/crates/bevy_ecs/src/query/mod.rs
@@ -157,6 +157,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "This test takes ~170s on CI")]
     fn query_filtered_exactsizeiterator_len() {
         fn choose(n: usize, k: usize) -> usize {
             if n == 0 || k == 0 || n < k {


### PR DESCRIPTION
# Objective

The PR CI takes a long time, particularly because of miri. maybe disable some tests on miri?
related to #20818 (partitioning seems to lead to about 20 6-8minute slices if running on ubuntu, but miri also doesn't have a cached build, I'm not sure how much that could help; 20x 6 minutes is like a lot compared to 1x 25-30 minutes which I think was the reason @mockersf stopped pursuing that direction)

## Solution

I've found 3 tests which take quite a bit longer than the rest. These are pretty low hanging fruits for reducing the time miri takes to test, HOWEVER I'm not sure if these tests benefit from miri (especially the toctou one) and should definitely run on miri.

Edit: looks like this doesn't result in any meaningful difference because now the windows build is the bottleneck