### PR TITLE
Fix panic on Android Quest Headset suspend event

### DIFF
--- a/crates/bevy_winit/src/state.rs
+++ b/crates/bevy_winit/src/state.rs
@@ -545,10 +545,11 @@ impl WinitAppRunnerState {
                 let mut query = self
                     .world_mut()
                     .query_filtered::<Entity, With<PrimaryWindow>>();
-                let entity = query.single(&self.world()).unwrap();
-                self.world_mut()
-                    .entity_mut(entity)
-                    .remove::<RawHandleWrapper>();
+                if let Ok(entity) = query.single(&self.world()) {
+                    self.world_mut()
+                        .entity_mut(entity)
+                        .remove::<RawHandleWrapper>();
+                }
             }
         }
 


### PR DESCRIPTION
When Android sends a suspend event like leaving the Guardian boundary on the Quest headset, the .unwrap() panics with NoEntities, crashing the app.