### PR TITLE
Expand examples for `NestedQuery` to show how to delegate a `QueryData` impl

### DIFF
--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -2742,7 +2742,7 @@ impl<'__w, T: Component<Mutability = Mutable>> ContiguousQueryData for Mut<'__w,
 /// let &Data(data) = query.query(&mut world).get(child).unwrap();
 /// assert_eq!(data, 3);
 ///
-/// /// This is the relational query data.
+/// // This is the relational query data.
 /// // This will never actually be constructed,
 /// // and is only used as a `QueryData` type.
 /// pub struct Parent<D: ReadOnlyQueryData, F: QueryFilter = ()>(D, F);


### PR DESCRIPTION
# Objective

Demonstrate how to use `NestedQuery` to implement relational queries.  

There is more design work required before making first-party relational queries, but third-party implementations are already possible using `NestedQuery`.  The documentation does not make it clear how to actually implement them, though, and the only real example is buried in the PR description of #21557.  

## Solution

Expand the examples for `NestedQuery` to include the implementation of a `Parent<D>` relational query.  Keep one example that uses `#[derive(QueryData)]` with a method on the generated `Item` type, but also add an example with a manual `QueryData` impl that delegates everything.  