### PR TITLE
Add `-Zno-embed-metadata` Cargo flag to `config_fast_builds.toml`

### DIFF
--- a/.cargo/config_fast_builds.toml
+++ b/.cargo/config_fast_builds.toml
@@ -68,7 +68,7 @@
 # ## `no-embed-metadata`
 #
 # This options avoids unnecessary metadata duplication and can reduce the size of the `target` directory by
-# 9% to 36%, depending on build configuration.
+# around 5% on dev builds, potentially more on release builds.
 #
 # Note: Unlike other flags in this file, `no-embed-metadata` is a Cargo flag, not a rustc flag, and is at the
 # bottom of this file.


### PR DESCRIPTION
# Objective

Reduce the size of the `target` directory with Bevy builds.

## Solution

I found this [blog](https://kobzol.github.io/rust/rustc/2025/06/02/reduce-cargo-target-dir-size-with-z-no-embed-metadata.html) about `-Zno-embed-metadata`, Cargo flag that reduces the size of the `target` directory by avoiding duplicate metadata or something.

## Testing

I compiled the `main` branch with and without this branch and the size of the `target` directory went from 11.61G without the flag to 11.15G with the flag. Not a huge difference, but still a 4% decrease.
