### PR TITLE
Impl `Scene` for `Box<dyn Scene>`. Same for `SceneList`

### DIFF
--- a/crates/bevy_feathers/src/font_styles.rs
+++ b/crates/bevy_feathers/src/font_styles.rs
@@ -18,7 +18,7 @@ use crate::theme::ThemedText;
 /// downward to any child text entity that has the [`ThemedText`] marker.
 #[derive(Component, Default, Clone, Debug, Reflect, FromTemplate)]
 #[reflect(Component, Default)]
-#[require(ThemedText, PropagateOver::<TextFont>::default())]
+#[require(ThemedText, PropagateOver::<TextFont>)]
 pub struct InheritableFont {
     /// The font handle.
     pub font: Handle<Font>,

--- a/crates/bevy_feathers/src/theme.rs
+++ b/crates/bevy_feathers/src/theme.rs
@@ -105,7 +105,7 @@ pub struct ThemeBorderColor(pub ThemeToken);
 #[component(immutable)]
 #[derive(Reflect)]
 #[reflect(Component, Clone)]
-#[require(ThemedText, PropagateOver::<TextColor>::default())]
+#[require(ThemedText, PropagateOver::<TextColor>)]
 pub struct ThemeFontColor(pub ThemeToken);
 
 /// A marker component that is used to indicate that the text entity wants to opt-in to using

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -177,6 +177,33 @@ macro_rules! scene_impl {
 
 all_tuples!(scene_impl, 0, 12, P);
 
+impl Scene for Box<dyn Scene> {
+    fn resolve(
+        &self,
+        context: &mut ResolveContext,
+        scene: &mut ResolvedScene,
+    ) -> Result<(), ResolveSceneError> {
+        (**self).resolve(context, scene)
+    }
+    fn register_dependencies(&self, dependencies: &mut SceneDependencies) {
+        (**self).register_dependencies(dependencies);
+    }
+}
+
+impl SceneList for Box<dyn SceneList> {
+    fn resolve_list(
+        &self,
+        context: &mut ResolveContext,
+        scenes: &mut Vec<ResolvedScene>,
+    ) -> Result<(), ResolveSceneError> {
+        (**self).resolve_list(context, scenes)
+    }
+
+    fn register_dependencies(&self, dependencies: &mut SceneDependencies) {
+        (**self).register_dependencies(dependencies);
+    }
+}
+
 /// A [`Scene`] that patches a [`Template`] of type `T` with a given function `F`.
 ///
 /// Functionally, a [`TemplatePatch`] scene will initialize a [`Default`] value of the patched

--- a/crates/bevy_scene/src/scene_list.rs
+++ b/crates/bevy_scene/src/scene_list.rs
@@ -99,24 +99,3 @@ impl<S: Scene> SceneList for Vec<S> {
         }
     }
 }
-
-impl SceneList for Vec<Box<dyn Scene>> {
-    fn resolve_list(
-        &self,
-        context: &mut ResolveContext,
-        scenes: &mut Vec<ResolvedScene>,
-    ) -> Result<(), ResolveSceneError> {
-        for scene in self {
-            let mut resolved_scene = ResolvedScene::default();
-            scene.resolve(context, &mut resolved_scene)?;
-            scenes.push(resolved_scene);
-        }
-        Ok(())
-    }
-
-    fn register_dependencies(&self, dependencies: &mut SceneDependencies) {
-        for scene in self {
-            scene.register_dependencies(dependencies);
-        }
-    }
-}


### PR DESCRIPTION
# Objective

Sometimes being generic on the scene type isn't desirable (ex: `field: Option<S: Scene>` requires defining `S`, even if you aren't setting the scene).

Being able to erase scene types while still using them in scenes is critical functionality.

## Solution

- Impl `Scene` for `Box<dyn Scene>`
- Impl `SceneList` for `Box<dyn SceneList>`

(I also snuck in a minor unrelated style fix. Forgive me :smile: )