### PR TITLE
`PositionedGlyph` migration guide

### DIFF
--- a/_release-content/migration-guides/removed_PositionedGlyph_byte_index_and_byte_length.md
+++ b/_release-content/migration-guides/removed_PositionedGlyph_byte_index_and_byte_length.md
@@ -5,4 +5,4 @@ pull_requests: [23695]
 
 `PositionedGlyph`'s `byte_index` and `byte_length` fields have been removed. Unlike Cosmic Text, `Parley` doesn't expose these values in its `GlyphRun`s.
 
-If needed, these range can be retrieved using `visual_clusters` by mapping each cluster's `text_range` to its corresponding `Glyph`(s), but this approach is fragile.
+If needed, these range can be retrieved using `visual_clusters` by mapping each cluster's `text_range` to its corresponding `Glyph`(s). However, this approach is quite fragile.


### PR DESCRIPTION
# Objective

The fields removed by #23695 were `pub`, this PR adds a migration guide.
