### PR TITLE
Remove unused parts of `AssetLoaders::find`

### DIFF
--- a/crates/bevy_asset/src/server/loaders.rs
+++ b/crates/bevy_asset/src/server/loaders.rs
@@ -156,7 +156,6 @@ impl AssetLoaders {
         &self,
         type_name: Option<&str>,
         asset_type_id: Option<TypeId>,
-        extension: Option<&str>,
         asset_path: Option<&AssetPath<'_>>,
     ) -> Option<MaybeAssetLoader> {
         // If provided the type name of the loader, return that immediately
@@ -207,13 +206,6 @@ impl AssetLoaders {
             }
         };
 
-        // Try the provided extension
-        if let Some(extension) = extension
-            && let Some(&index) = try_extension(extension)
-        {
-            return self.get_by_index(index);
-        }
-
         // Try extracting the extension from the path
         if let Some(full_extension) = asset_path.and_then(AssetPath::get_full_extension) {
             if let Some(&index) = try_extension(full_extension) {
@@ -236,15 +228,15 @@ impl AssetLoaders {
         {
             Some(loader) => {
                 warn!(
-                    "Multiple AssetLoaders found for Asset: {:?}; Path: {:?}; Extension: {:?}",
-                    asset_type_id, asset_path, extension
+                    "Multiple AssetLoaders found for Asset: {:?}; Path: {:?};",
+                    asset_type_id, asset_path
                 );
                 Some(loader)
             }
             None => {
                 warn!(
-                    "No AssetLoader found for Asset: {:?}; Path: {:?}; Extension: {:?}",
-                    asset_type_id, asset_path, extension
+                    "No AssetLoader found for Asset: {:?}; Path: {:?};",
+                    asset_type_id, asset_path
                 );
                 None
             }
@@ -599,7 +591,6 @@ mod tests {
                 .find(
                     None,
                     Some(TypeId::of::<A>()),
-                    None,
                     Some(&AssetPath::from_path(Path::new("asset.a"))),
                 )
                 .unwrap()
@@ -620,7 +611,6 @@ mod tests {
                 .find(
                     None,
                     Some(TypeId::of::<B>()),
-                    None,
                     Some(&AssetPath::from_path(Path::new("asset.b"))),
                 )
                 .unwrap()
@@ -641,7 +631,6 @@ mod tests {
                 .find(
                     None,
                     Some(TypeId::of::<C>()),
-                    None,
                     Some(&AssetPath::from_path(Path::new("asset.c"))),
                 )
                 .unwrap()
@@ -664,7 +653,6 @@ mod tests {
                 .find(
                     None,
                     Some(TypeId::of::<C>()),
-                    None,
                     Some(&AssetPath::from_path(Path::new("asset.a"))),
                 )
                 .unwrap()
@@ -685,7 +673,6 @@ mod tests {
                 .find(
                     None,
                     Some(TypeId::of::<C>()),
-                    None,
                     Some(&AssetPath::from_path(Path::new("asset.b"))),
                 )
                 .unwrap()
@@ -708,7 +695,6 @@ mod tests {
                 .find(
                     None,
                     Some(TypeId::of::<A>()),
-                    None,
                     Some(&AssetPath::from_path(Path::new("asset.x"))),
                 )
                 .unwrap()
@@ -729,7 +715,6 @@ mod tests {
                 .find(
                     None,
                     Some(TypeId::of::<A>()),
-                    None,
                     Some(&AssetPath::from_path(Path::new("asset"))),
                 )
                 .unwrap()
@@ -768,7 +753,6 @@ mod tests {
                 .find(
                     None,
                     Some(TypeId::of::<A>()),
-                    None,
                     Some(&AssetPath::from_path(Path::new("asset.a"))),
                 )
                 .unwrap()
@@ -787,7 +771,6 @@ mod tests {
                 .find(
                     None,
                     Some(TypeId::of::<A>()),
-                    None,
                     Some(&AssetPath::from_path(Path::new("asset.x"))),
                 )
                 .unwrap()
@@ -806,7 +789,6 @@ mod tests {
                 .find(
                     None,
                     Some(TypeId::of::<A>()),
-                    None,
                     Some(&AssetPath::from_path(Path::new("asset"))),
                 )
                 .unwrap()

--- a/crates/bevy_asset/src/server/loaders.rs
+++ b/crates/bevy_asset/src/server/loaders.rs
@@ -156,7 +156,7 @@ impl AssetLoaders {
         &self,
         type_name: Option<&str>,
         asset_type_id: Option<TypeId>,
-        asset_path: Option<&AssetPath<'_>>,
+        asset_path: &AssetPath<'_>,
     ) -> Option<MaybeAssetLoader> {
         // If provided the type name of the loader, return that immediately
         if let Some(type_name) = type_name {
@@ -164,7 +164,7 @@ impl AssetLoaders {
         }
 
         // The presence of a label will affect loader choice
-        let label = asset_path.as_ref().and_then(|path| path.label());
+        let label = asset_path.label();
 
         // Try by asset type
         let candidates = if let Some(type_id) = asset_type_id {
@@ -207,7 +207,7 @@ impl AssetLoaders {
         };
 
         // Try extracting the extension from the path
-        if let Some(full_extension) = asset_path.and_then(AssetPath::get_full_extension) {
+        if let Some(full_extension) = asset_path.get_full_extension() {
             if let Some(&index) = try_extension(full_extension) {
                 return self.get_by_index(index);
             }
@@ -591,7 +591,7 @@ mod tests {
                 .find(
                     None,
                     Some(TypeId::of::<A>()),
-                    Some(&AssetPath::from_path(Path::new("asset.a"))),
+                    &AssetPath::from_path(Path::new("asset.a")),
                 )
                 .unwrap()
                 .get(),
@@ -611,7 +611,7 @@ mod tests {
                 .find(
                     None,
                     Some(TypeId::of::<B>()),
-                    Some(&AssetPath::from_path(Path::new("asset.b"))),
+                    &AssetPath::from_path(Path::new("asset.b")),
                 )
                 .unwrap()
                 .get(),
@@ -631,7 +631,7 @@ mod tests {
                 .find(
                     None,
                     Some(TypeId::of::<C>()),
-                    Some(&AssetPath::from_path(Path::new("asset.c"))),
+                    &AssetPath::from_path(Path::new("asset.c")),
                 )
                 .unwrap()
                 .get(),
@@ -653,7 +653,7 @@ mod tests {
                 .find(
                     None,
                     Some(TypeId::of::<C>()),
-                    Some(&AssetPath::from_path(Path::new("asset.a"))),
+                    &AssetPath::from_path(Path::new("asset.a")),
                 )
                 .unwrap()
                 .get(),
@@ -673,7 +673,7 @@ mod tests {
                 .find(
                     None,
                     Some(TypeId::of::<C>()),
-                    Some(&AssetPath::from_path(Path::new("asset.b"))),
+                    &AssetPath::from_path(Path::new("asset.b")),
                 )
                 .unwrap()
                 .get(),
@@ -695,7 +695,7 @@ mod tests {
                 .find(
                     None,
                     Some(TypeId::of::<A>()),
-                    Some(&AssetPath::from_path(Path::new("asset.x"))),
+                    &AssetPath::from_path(Path::new("asset.x")),
                 )
                 .unwrap()
                 .get(),
@@ -715,7 +715,7 @@ mod tests {
                 .find(
                     None,
                     Some(TypeId::of::<A>()),
-                    Some(&AssetPath::from_path(Path::new("asset"))),
+                    &AssetPath::from_path(Path::new("asset")),
                 )
                 .unwrap()
                 .get(),
@@ -753,7 +753,7 @@ mod tests {
                 .find(
                     None,
                     Some(TypeId::of::<A>()),
-                    Some(&AssetPath::from_path(Path::new("asset.a"))),
+                    &AssetPath::from_path(Path::new("asset.a")),
                 )
                 .unwrap()
                 .get(),
@@ -771,7 +771,7 @@ mod tests {
                 .find(
                     None,
                     Some(TypeId::of::<A>()),
-                    Some(&AssetPath::from_path(Path::new("asset.x"))),
+                    &AssetPath::from_path(Path::new("asset.x")),
                 )
                 .unwrap()
                 .get(),
@@ -789,7 +789,7 @@ mod tests {
                 .find(
                     None,
                     Some(TypeId::of::<A>()),
-                    Some(&AssetPath::from_path(Path::new("asset"))),
+                    &AssetPath::from_path(Path::new("asset")),
                 )
                 .unwrap()
                 .get(),

--- a/crates/bevy_asset/src/server/loaders.rs
+++ b/crates/bevy_asset/src/server/loaders.rs
@@ -154,15 +154,9 @@ impl AssetLoaders {
     /// Find an [`AssetLoader`] based on provided search criteria
     pub(crate) fn find(
         &self,
-        type_name: Option<&str>,
         asset_type_id: Option<TypeId>,
         asset_path: &AssetPath<'_>,
     ) -> Option<MaybeAssetLoader> {
-        // If provided the type name of the loader, return that immediately
-        if let Some(type_name) = type_name {
-            return self.get_by_name(type_name);
-        }
-
         // The presence of a label will affect loader choice
         let label = asset_path.label();
 
@@ -589,7 +583,6 @@ mod tests {
         let loader = block_on(
             loaders
                 .find(
-                    None,
                     Some(TypeId::of::<A>()),
                     &AssetPath::from_path(Path::new("asset.a")),
                 )
@@ -609,7 +602,6 @@ mod tests {
         let loader = block_on(
             loaders
                 .find(
-                    None,
                     Some(TypeId::of::<B>()),
                     &AssetPath::from_path(Path::new("asset.b")),
                 )
@@ -629,7 +621,6 @@ mod tests {
         let loader = block_on(
             loaders
                 .find(
-                    None,
                     Some(TypeId::of::<C>()),
                     &AssetPath::from_path(Path::new("asset.c")),
                 )
@@ -651,7 +642,6 @@ mod tests {
         let loader = block_on(
             loaders
                 .find(
-                    None,
                     Some(TypeId::of::<C>()),
                     &AssetPath::from_path(Path::new("asset.a")),
                 )
@@ -671,7 +661,6 @@ mod tests {
         let loader = block_on(
             loaders
                 .find(
-                    None,
                     Some(TypeId::of::<C>()),
                     &AssetPath::from_path(Path::new("asset.b")),
                 )
@@ -693,7 +682,6 @@ mod tests {
         let loader = block_on(
             loaders
                 .find(
-                    None,
                     Some(TypeId::of::<A>()),
                     &AssetPath::from_path(Path::new("asset.x")),
                 )
@@ -713,7 +701,6 @@ mod tests {
         let loader = block_on(
             loaders
                 .find(
-                    None,
                     Some(TypeId::of::<A>()),
                     &AssetPath::from_path(Path::new("asset")),
                 )
@@ -751,7 +738,6 @@ mod tests {
         let loader = block_on(
             loaders
                 .find(
-                    None,
                     Some(TypeId::of::<A>()),
                     &AssetPath::from_path(Path::new("asset.a")),
                 )
@@ -769,7 +755,6 @@ mod tests {
         let loader = block_on(
             loaders
                 .find(
-                    None,
                     Some(TypeId::of::<A>()),
                     &AssetPath::from_path(Path::new("asset.x")),
                 )
@@ -787,7 +772,6 @@ mod tests {
         let loader = block_on(
             loaders
                 .find(
-                    None,
                     Some(TypeId::of::<A>()),
                     &AssetPath::from_path(Path::new("asset")),
                 )

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -1559,8 +1559,7 @@ impl AssetServer {
                     let error = || AssetLoadError::MissingAssetLoader {
                         loader_name: None,
                         asset_type_id,
-                        extension: None,
-                        asset_path: Some(asset_path.to_string()),
+                        asset_path: asset_path.to_string(),
                     };
 
                     let loader = loader.ok_or_else(error)?.get().await.map_err(|_| error())?;
@@ -1576,8 +1575,7 @@ impl AssetServer {
             let error = || AssetLoadError::MissingAssetLoader {
                 loader_name: None,
                 asset_type_id,
-                extension: None,
-                asset_path: Some(asset_path.to_string()),
+                asset_path: asset_path.to_string(),
             };
 
             let loader = loader.ok_or_else(error)?.get().await.map_err(|_| error())?;
@@ -2104,12 +2102,11 @@ pub enum AssetLoadError {
         actual_asset_name: &'static str,
         loader_name: &'static str,
     },
-    #[error("Could not find an asset loader matching: Loader Name: {loader_name:?}; Asset Type: {asset_type_id:?}; Extension: {extension:?}; Path: {asset_path:?};")]
+    #[error("Could not find an asset loader matching: Loader Name: {loader_name:?}; Asset Type: {asset_type_id:?}; Path: {asset_path:?};")]
     MissingAssetLoader {
         loader_name: Option<String>,
         asset_type_id: Option<TypeId>,
-        extension: Option<String>,
-        asset_path: Option<String>,
+        asset_path: String,
     },
     #[error(transparent)]
     MissingAssetLoaderForExtension(#[from] MissingAssetLoaderForExtensionError),

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -1554,10 +1554,7 @@ impl AssetServer {
                 }
                 Err(AssetReaderError::NotFound(_)) => {
                     // TODO: Handle error transformation
-                    let loader = {
-                        self.read_loaders()
-                            .find(None, asset_type_id, Some(asset_path))
-                    };
+                    let loader = { self.read_loaders().find(None, asset_type_id, asset_path) };
 
                     let error = || AssetLoadError::MissingAssetLoader {
                         loader_name: None,
@@ -1574,10 +1571,7 @@ impl AssetServer {
                 Err(err) => return Err(err.into()),
             }
         } else {
-            let loader = {
-                self.read_loaders()
-                    .find(None, asset_type_id, Some(asset_path))
-            };
+            let loader = { self.read_loaders().find(None, asset_type_id, asset_path) };
 
             let error = || AssetLoadError::MissingAssetLoader {
                 loader_name: None,

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -1554,10 +1554,9 @@ impl AssetServer {
                 }
                 Err(AssetReaderError::NotFound(_)) => {
                     // TODO: Handle error transformation
-                    let loader = { self.read_loaders().find(None, asset_type_id, asset_path) };
+                    let loader = { self.read_loaders().find(asset_type_id, asset_path) };
 
                     let error = || AssetLoadError::MissingAssetLoader {
-                        loader_name: None,
                         asset_type_id,
                         asset_path: asset_path.to_string(),
                     };
@@ -1570,10 +1569,9 @@ impl AssetServer {
                 Err(err) => return Err(err.into()),
             }
         } else {
-            let loader = { self.read_loaders().find(None, asset_type_id, asset_path) };
+            let loader = { self.read_loaders().find(asset_type_id, asset_path) };
 
             let error = || AssetLoadError::MissingAssetLoader {
-                loader_name: None,
                 asset_type_id,
                 asset_path: asset_path.to_string(),
             };
@@ -2102,9 +2100,8 @@ pub enum AssetLoadError {
         actual_asset_name: &'static str,
         loader_name: &'static str,
     },
-    #[error("Could not find an asset loader matching: Loader Name: {loader_name:?}; Asset Type: {asset_type_id:?}; Path: {asset_path:?};")]
+    #[error("Could not find an asset loader matching: Asset Type: {asset_type_id:?}; Path: {asset_path:?};")]
     MissingAssetLoader {
-        loader_name: Option<String>,
         asset_type_id: Option<TypeId>,
         asset_path: String,
     },

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -1556,7 +1556,7 @@ impl AssetServer {
                     // TODO: Handle error transformation
                     let loader = {
                         self.read_loaders()
-                            .find(None, asset_type_id, None, Some(asset_path))
+                            .find(None, asset_type_id, Some(asset_path))
                     };
 
                     let error = || AssetLoadError::MissingAssetLoader {
@@ -1576,7 +1576,7 @@ impl AssetServer {
         } else {
             let loader = {
                 self.read_loaders()
-                    .find(None, asset_type_id, None, Some(asset_path))
+                    .find(None, asset_type_id, Some(asset_path))
             };
 
             let error = || AssetLoadError::MissingAssetLoader {


### PR DESCRIPTION
## Objective

`AssetLoaders::find` maps from various properties to an asset loader:

```rust
fn find(
    &self,
    type_name: Option<&str>,
    asset_type_id: Option<TypeId>,
    extension: Option<&str>,
    asset_path: Option<&AssetPath<'_>>,
) -> Option<MaybeAssetLoader> {
```

But in practice the `type_name` and `extension` parameters are always `None`, and the `asset_path` parameter is always `Some`. 

## Solution

This PR removes the unused parts:

```diff
 fn find(
     &self,
-    type_name: Option<&str>,
     asset_type_id: Option<TypeId>,
-    extension: Option<&str>,
-    asset_path: Option<&AssetPath<'_>>,
+    asset_path: &AssetPath<'_>,
 ) -> Option<MaybeAssetLoader> {
```

`AssetLoaders::find` is `pub(crate)`, so this should not affect users.

I looked back at the [original PR](https://github.com/bevyengine/bevy/pull/11644) and couldn't spot any cases where these parameters were ever used. I'm not sure if that's an oversight or if they were intended for future use. 

I also made matching changes to `AssetLoaderError::MissingAssetLoaders`. This is `pub` so technically should have a migration guide. I'm not entirely convinced that's necessary for such a trivial change, but happy to add one if requested.

```diff
 MissingAssetLoader {
-    loader_name: Option<String>,
     asset_type_id: Option<TypeId>,
-    extension: Option<String>,
-    asset_path: Option<String>,
+    asset_path: String,
 },
```

## Testing

```sh
cargo test -p bevy_asset
cargo run --example asset_loading
cargo run --example asset_processing --features="file_watcher asset_processor"
```