### PR TITLE
Remove SystemState from more benches

### DIFF
--- a/benches/benches/bevy_ecs/fragmentation.rs
+++ b/benches/benches/bevy_ecs/fragmentation.rs
@@ -1,5 +1,4 @@
 use bevy_ecs::prelude::*;
-use bevy_ecs::system::SystemState;
 use core::hint::black_box;
 use criterion::*;
 use glam::*;


### PR DESCRIPTION
# Objective

Fixes #23238
I thought there would be more instances to fix :-)

## Solution

Same as #23687

## Testing

Ran affected benches and the regression results are a bit flaky -- but seeing that only the ~regression~ bench logic has been changed, this should be OK.

```sh
cargo bench -p benches --bench ecs -- iter_fragmented
```

