### PR TITLE
Don't remove entry from `ResourceEntities` when removing a resource by ID

### DIFF
--- a/crates/bevy_ecs/src/resource.rs
+++ b/crates/bevy_ecs/src/resource.rs
@@ -106,13 +106,6 @@ impl ResourceEntities {
         self.deref().get(id).copied()
     }
 
-    /// Removes the entry for the given resource component.
-    /// Returns the entity that was removed, or `None` if there was no entity.
-    #[inline]
-    pub(crate) fn remove(&mut self, id: ComponentId) -> Option<Entity> {
-        self.0.get_mut().remove(id)
-    }
-
     #[inline]
     fn deref(&self) -> &SparseArray<ComponentId, Entity> {
         // SAFETY: There are no other mutable references to the map.
@@ -262,7 +255,7 @@ mod tests {
             }
         });
         assert_eq!(world.entities().count_spawned(), start + 3);
-        let e3 = *world.resource_entities().get(id3).unwrap();
+        let e3 = world.resource_entities().get(id3).unwrap();
         assert!(world.remove_resource_by_id(id3));
         // the entity is stable: removing the resource should only remove the component from the entity, not despawn the entity
         assert_eq!(world.entities().count_spawned(), start + 3);
@@ -272,13 +265,13 @@ mod tests {
                 world.insert_resource_by_id(id3, ptr, MaybeLocation::caller());
             }
         });
-        assert_eq!(e3, *world.resource_entities().get(id3).unwrap());
+        assert_eq!(e3, world.resource_entities().get(id3).unwrap());
         // again, the entity is stable: see previous explanation
-        let e1 = *world.resource_entities().get(id1).unwrap();
+        let e1 = world.resource_entities().get(id1).unwrap();
         world.remove_resource::<TestResource1>();
         assert_eq!(world.entities().count_spawned(), start + 3);
         world.init_resource::<TestResource1>();
-        assert_eq!(e1, *world.resource_entities().get(id1).unwrap());
+        assert_eq!(e1, world.resource_entities().get(id1).unwrap());
         // make sure that trying to add a resource twice results, doesn't change the entity count
         world.insert_resource(TestResource2(String::from("Bar")));
         assert_eq!(world.entities().count_spawned(), start + 3);

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -3653,7 +3653,7 @@ impl World {
     /// **You should prefer to use the typed API [`World::remove_resource`] where possible and only
     /// use this in cases where the actual types are not known at compile time.**
     pub fn remove_resource_by_id(&mut self, component_id: ComponentId) -> bool {
-        if let Some(&entity) = self.resource_entities.get(component_id)
+        if let Some(entity) = self.resource_entities.get(component_id)
             && let Ok(mut entity_mut) = self.get_entity_mut(entity)
             && entity_mut.contains_id(component_id)
         {


### PR DESCRIPTION
# Objective

Make the behavior of `World::remove_resource` and `World::remove_resource_by_id` consistent.  Currently, `remove_resource` will leave the entity in the `ResourceEntities` map so that re-initializing the resource keeps the same `Entity`, but `remove_resource_by_id` will remove it from the map.  

## Solution

Change `remove` to `get` in `remove_resource_by_id`.  

## Testing

Updated the existing unit test to ensure that re-initializing the resource keeps the same `Entity`.  