### PR TITLE
Use absolute paths in ECS macros

### DIFF
--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -66,7 +66,7 @@ pub fn derive_resource(input: TokenStream) -> TokenStream {
     ast.generics
         .make_where_clause()
         .predicates
-        .push(parse_quote! { Self: Send + Sync + 'static });
+        .push(parse_quote! { Self: ::core::marker::Send + ::core::marker::Sync + 'static });
 
     let struct_name = &ast.ident;
     let (impl_generics, type_generics, where_clause) = &ast.generics.split_for_impl();
@@ -74,7 +74,7 @@ pub fn derive_resource(input: TokenStream) -> TokenStream {
     let mut register_required = Vec::with_capacity(1);
     // We add the component_id existence check here to avoid recursive init during required components initialization.
     register_required.push(quote! {
-        let resource_component_id = if let Some(id) = required_components.components_registrator().component_id::<#struct_name #type_generics>() {
+        let resource_component_id = if let ::core::option::Option::Some(id) = required_components.components_registrator().component_id::<#struct_name #type_generics>() {
             id
         } else {
             required_components.components_registrator().register_component::<#struct_name #type_generics>()
@@ -107,8 +107,8 @@ pub fn derive_resource(input: TokenStream) -> TokenStream {
 
             #map_entities
 
-            fn relationship_accessor() -> Option<#bevy_ecs_path::relationship::ComponentRelationshipAccessor<Self>> {
-                None
+            fn relationship_accessor() -> ::core::option::Option<#bevy_ecs_path::relationship::ComponentRelationshipAccessor<Self>> {
+                ::core::option::Option::None
             }
         }
     });
@@ -243,7 +243,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
     ast.generics
         .make_where_clause()
         .predicates
-        .push(parse_quote! { Self: Send + Sync + 'static });
+        .push(parse_quote! { Self: ::core::marker::Send + ::core::marker::Sync + 'static });
 
     let requires = &attrs.requires;
     let mut register_required = Vec::with_capacity(attrs.requires.iter().len());
@@ -252,7 +252,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
             let ident = &require.path;
             let constructor = match &require.func {
                 Some(func) => quote! { || { let x: #ident = (#func)().into(); x } },
-                None => quote! { <#ident as Default>::default },
+                None => quote! { <#ident as ::core::default::Default>::default },
             };
             register_required.push(quote! {
                 required_components.register_required::<#ident>(#constructor);
@@ -306,7 +306,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
         let relationship_member = field.ident.clone().map_or(Member::from(0), Member::Named);
         if relationship.is_some() {
             quote! {
-                Some(
+                ::core::option::Option::Some(
                     // Safety: we pass valid offset of a field containing Entity (obtained via offset_off!)
                     unsafe {
                         #bevy_ecs_path::relationship::ComponentRelationshipAccessor::<Self>::relationship(
@@ -317,11 +317,11 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
             }
         } else {
             quote! {
-                Some(#bevy_ecs_path::relationship::ComponentRelationshipAccessor::<Self>::relationship_target())
+                ::core::option::Option::Some(#bevy_ecs_path::relationship::ComponentRelationshipAccessor::<Self>::relationship_target())
             }
         }
     } else {
-        quote! {None}
+        quote! {::core::option::Option::None}
     };
 
     // This puts `register_required` before `register_recursive_requires` to ensure that the constructors of _all_ top
@@ -350,7 +350,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
 
             #map_entities
 
-            fn relationship_accessor() -> Option<#bevy_ecs_path::relationship::ComponentRelationshipAccessor<Self>> {
+            fn relationship_accessor() -> ::core::option::Option<#bevy_ecs_path::relationship::ComponentRelationshipAccessor<Self>> {
                 #relationship_accessor
             }
         }

--- a/crates/bevy_ecs/macros/src/event.rs
+++ b/crates/bevy_ecs/macros/src/event.rs
@@ -19,7 +19,7 @@ pub fn derive_event(input: TokenStream) -> TokenStream {
     ast.generics
         .make_where_clause()
         .predicates
-        .push(parse_quote! { Self: Send + Sync + 'static });
+        .push(parse_quote! { Self: ::core::marker::Send + ::core::marker::Sync + 'static });
 
     let mut processed_attrs = Vec::new();
     let mut trigger: Option<Type> = None;
@@ -63,7 +63,7 @@ pub fn derive_entity_event(input: TokenStream) -> TokenStream {
     ast.generics
         .make_where_clause()
         .predicates
-        .push(parse_quote! { Self: Send + Sync + 'static });
+        .push(parse_quote! { Self: ::core::marker::Send + ::core::marker::Sync + 'static });
 
     let mut auto_propagate = false;
     let mut propagate = false;
@@ -139,7 +139,7 @@ pub fn derive_entity_event(input: TokenStream) -> TokenStream {
         quote! {
             impl #impl_generics #bevy_ecs_path::event::SetEntityEventTarget for #struct_name #type_generics #where_clause {
                 fn set_event_target(&mut self, entity: #bevy_ecs_path::entity::Entity) {
-                    self.#entity_field = Into::into(entity);
+                    self.#entity_field = ::core::convert::Into::into(entity);
                 }
             }
         }

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -140,13 +140,13 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
         unsafe impl #impl_generics #ecs_path::bundle::Bundle for #struct_name #ty_generics #where_clause {
             fn component_ids(
                 components: &mut #ecs_path::component::ComponentsRegistrator,
-            ) -> impl Iterator<Item = #ecs_path::component::ComponentId> + use<#(#generics_ty_list,)*> {
+            ) -> impl ::core::iter::Iterator<Item = #ecs_path::component::ComponentId> + use<#(#generics_ty_list,)*> {
                 ::core::iter::empty()#(.chain(<#active_field_types as #ecs_path::bundle::Bundle>::component_ids(components)))*
             }
 
             fn get_component_ids(
                 components: &#ecs_path::component::Components,
-            ) -> impl Iterator<Item = Option<#ecs_path::component::ComponentId>> {
+            ) -> impl ::core::iter::Iterator<Item = ::core::option::Option<#ecs_path::component::ComponentId>> {
                 ::core::iter::empty()#(.chain(<#active_field_types as #ecs_path::bundle::Bundle>::get_component_ids(components)))*
             }
         }
@@ -459,14 +459,14 @@ fn derive_system_param_impl(
                     system_meta: &#path::system::SystemMeta,
                     world: #path::world::unsafe_world_cell::UnsafeWorldCell<'w>,
                     change_tick: #path::change_detection::Tick,
-                ) -> Result<Self::Item<'w, 's>, #path::system::SystemParamValidationError> {
+                ) -> ::core::result::Result<Self::Item<'w, 's>, #path::system::SystemParamValidationError> {
                     let (#(#tuple_patterns,)*) = &mut state.state;
                     #(
                         let #field_locals = unsafe {
                             <#field_types as #path::system::SystemParam>::get_param(#field_locals, system_meta, world, change_tick)
                         }.map_err(|err| #path::system::SystemParamValidationError::new::<Self>(err.skipped, #field_validation_messages, #field_validation_names))?;
                     )*
-                    Result::Ok(#struct_name {
+                    ::core::result::Result::Ok(#struct_name {
                         #(#field_members: #field_locals,)*
                     })
                 }
@@ -599,15 +599,15 @@ pub fn derive_settings_group(input: TokenStream) -> TokenStream {
 
     let group_name = override_name.unwrap_or(pascal_to_snake_case(&name.to_string()));
     let file_name = override_file
-        .map(|f| quote! { Some(#f) })
-        .unwrap_or(quote! { None });
+        .map(|f| quote! { ::core::option::Option::Some(#f) })
+        .unwrap_or(quote! { ::core::option::Option::None });
 
     let expanded = quote! {
         impl SettingsGroup for #name {
             fn settings_group_name() -> &'static str {
                 #group_name
             }
-            fn settings_source() -> Option<&'static str> {
+            fn settings_source() -> ::core::option::Option<&'static str> {
                 #file_name
             }
         }

--- a/crates/bevy_ecs/macros/src/message.rs
+++ b/crates/bevy_ecs/macros/src/message.rs
@@ -9,7 +9,7 @@ pub fn derive_message(input: TokenStream) -> TokenStream {
     ast.generics
         .make_where_clause()
         .predicates
-        .push(parse_quote! { Self: Send + Sync + 'static });
+        .push(parse_quote! { Self: ::core::marker::Send + ::core::marker::Sync + 'static });
 
     let struct_name = &ast.ident;
     let (impl_generics, type_generics, where_clause) = &ast.generics.split_for_impl();

--- a/crates/bevy_ecs/macros/src/query_data.rs
+++ b/crates/bevy_ecs/macros/src/query_data.rs
@@ -456,8 +456,8 @@ pub fn derive_query_data_impl(input: TokenStream) -> TokenStream {
                         _fetch: &mut <Self as #path::query::WorldQuery>::Fetch<'__w>,
                         _entity: #path::entity::Entity,
                         _table_row: #path::storage::TableRow,
-                    ) -> Option<Self::Item<'__w, '__s>> {
-                        Some(Self::Item {
+                    ) -> ::core::option::Option<Self::Item<'__w, '__s>> {
+                        ::core::option::Option::Some(Self::Item {
                             #(#field_members: <#read_only_field_types>::fetch(&_state.#field_aliases, &mut _fetch.#field_aliases, _entity, _table_row)?,)*
                         })
                     }
@@ -538,8 +538,8 @@ pub fn derive_query_data_impl(input: TokenStream) -> TokenStream {
                     _fetch: &mut <Self as #path::query::WorldQuery>::Fetch<'__w>,
                     _entity: #path::entity::Entity,
                     _table_row: #path::storage::TableRow,
-                ) -> Option<Self::Item<'__w, '__s>> {
-                    Some(Self::Item {
+                ) -> ::core::option::Option<Self::Item<'__w, '__s>> {
+                    ::core::option::Option::Some(Self::Item {
                         #(#field_members: <#field_types>::fetch(&_state.#field_aliases, &mut _fetch.#field_aliases, _entity, _table_row)?,)*
                     })
                 }

--- a/crates/bevy_ecs/macros/src/world_query.rs
+++ b/crates/bevy_ecs/macros/src/world_query.rs
@@ -82,7 +82,7 @@ pub(crate) fn world_query_impl(
             #marker_name: &'__w(),
         }
 
-        impl #user_impl_generics_with_world Clone for #fetch_struct_name #user_ty_generics_with_world
+        impl #user_impl_generics_with_world ::core::clone::Clone for #fetch_struct_name #user_ty_generics_with_world
             #user_where_clauses_with_world {
                 fn clone(&self) -> Self {
                     Self {
@@ -158,7 +158,7 @@ pub(crate) fn world_query_impl(
 
             fn init_nested_access(
                 state: &Self::State,
-                _system_name: Option<&str>,
+                _system_name: ::core::option::Option<&str>,
                 _component_access_set: &mut #path::query::FilteredAccessSet,
                 _world: #path::world::unsafe_world_cell::UnsafeWorldCell,
             ) {
@@ -171,8 +171,8 @@ pub(crate) fn world_query_impl(
                 }
             }
 
-            fn get_state(components: &#path::component::Components) -> Option<#state_struct_name #user_ty_generics> {
-                Some(#state_struct_name {
+            fn get_state(components: &#path::component::Components) -> ::core::option::Option<#state_struct_name #user_ty_generics> {
+                ::core::option::Option::Some(#state_struct_name {
                     #(#field_aliases: <#field_types>::get_state(components)?,)*
                 })
             }


### PR DESCRIPTION
# Objective

- Improve macro hygiene.

## Solution

- Use absolute paths in ECS macros.

## Testing

- `cargo run -p ci -- compile`

## Note

- The `SettingsGroup` derive is unhygienic (bare `impl SettingsGroup for ...`). I tried prepending the path from `BevyManifest` and adding `extern crate self as bevy_settings` to `bevy_settings`'s lib. This worked for the unit tests in `bevy_settings`, but the examples using `bevy_settings` failed to resolve the path. I haven't investigated further to keep this PR simple, but I can open an issue for fixing the hygiene of `#[derive(SettingsGroup)]`.
- Many other macros in Bevy don't use absolute paths as much as they could, such as in `bevy_reflect`. I'll open another PR if this one is accepted.