### PR TITLE
Add `bevy_error!` and `bail!` macros to `BevyError`

### DIFF
--- a/crates/bevy_ecs/src/error/bevy_error.rs
+++ b/crates/bevy_ecs/src/error/bevy_error.rs
@@ -70,6 +70,7 @@ impl BevyError {
     ///
     /// fn some_function(val: i64) -> Result<(), BevyError> {
     ///     if val < 0 {
+    ///         // Consider using the bevy_error! or even the bail! macro for format! support
     ///         let error =
     ///             BevyError::new(Severity::Panic, format!("Value can't be negative {val}"));
     ///         return Err(error);
@@ -417,6 +418,72 @@ pub fn bevy_error_panic_hook(
     }
 }
 
+/// Creates a new [`BevyError`] from a string.
+///
+/// Strings can be formatted like the [`format!`](std::format!) macro. Severity
+/// can optionally be provided to change it from the default [`Severity::Panic`].
+/// This can be done by adding the severity as the fist argument.
+///
+/// # Example
+/// ```
+/// use bevy_ecs::{bevy_error, error::{BevyError, Severity}};
+///
+/// fn this_will_fail(value: u32) -> Result<(), BevyError> {
+///     if value == 0 {
+///         return Err(bevy_error!(Severity::Debug, "A debug message"));
+///     } else {
+///         return Err(bevy_error!("We can even do formatting {value}, {}", "hello"));
+///     }
+/// }
+/// ```
+#[macro_export]
+macro_rules! bevy_error {
+    ($fmt:literal) => {
+        $crate::error::BevyError::new($crate::error::Severity::Panic, $fmt)
+    };
+    ($fmt:literal, $($arg:tt)*) => {
+        $crate::error::BevyError::new($crate::error::Severity::Panic, $crate::__macro_exports::format!($fmt, $($arg)*))
+    };
+    ($severity:expr, $fmt:literal) => {
+        $crate::error::BevyError::new($severity, $fmt)
+    };
+    ($severity:expr, $fmt:literal, $($arg:tt)*) => {
+        $crate::error::BevyError::new($severity, $crate::__macro_exports::format!($fmt, $($arg)*))
+    };
+    ($severity:expr) => {
+        compile_error!("missing error message")
+    };
+}
+
+/// Returns early with an error.
+///
+/// Equivalent to <code>return Err([bevy_error!(\...)](bevy_error!))</code>
+/// As a result the returned error defaults to [`Severity::Panic`]. As with
+/// `bevy_error!` the severity can be changed by providing a severity as the
+/// first argument
+///
+/// # Example
+/// ```
+/// use bevy_ecs::{bail, error::{BevyError, Severity}};
+///
+/// fn do_some_stuff(val: i32) -> Result<(), BevyError> {
+///     if val < 0 {
+///         bail!(Severity::Warning, "Something is broken: {}", val);
+///     } else if val == 0 {
+///         bail!("Value really can't be zero");
+///     }
+///
+///     // ...
+///     Ok(())
+/// }
+/// ```
+#[macro_export]
+macro_rules! bail {
+    ($($args:tt)+) => {
+        return core::result::Result::Err($crate::bevy_error!($($args)*))
+    };
+}
+
 #[cfg(test)]
 mod tests {
     use crate::error::BevyError;
@@ -521,5 +588,42 @@ mod tests {
 
         assert!(new_error.is::<Fun>());
         assert_eq!(new_error.downcast_ref::<Fun>(), Some(&Fun(1)));
+    }
+
+    /// Testing the functionality would be difficult so we at least check if it
+    /// compiles.
+    #[test]
+    fn bevy_error_macro() {
+        bevy_error!("One arg");
+        bevy_error!(crate::error::Severity::Debug, "With severity");
+        bevy_error!(
+            crate::error::Severity::Debug,
+            "With severity and args {}",
+            4 / 3
+        );
+
+        // This is the pain in the ass one since both args are literals but neither is severity
+        bevy_error!("Format string {}", 1 + 2);
+    }
+
+    #[test]
+    fn bevy_bail_macro() {
+        // Simplest way to specify the return type
+        fn t(f: impl Fn() -> Result<(), BevyError>) {
+            let val = f();
+
+            assert!(val.is_err(), "expected error got {:?}", val);
+        }
+
+        t(|| bail!("One arg"));
+        t(|| bail!(crate::error::Severity::Debug, "With severity"));
+        t(|| {
+            bail!(
+                crate::error::Severity::Debug,
+                "With severity and args {}",
+                2
+            )
+        });
+        t(|| bail!("Format string {}", 1 + 2));
     }
 }

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -132,6 +132,7 @@ pub mod __macro_exports {
     // included `extern crate alloc;`. This re-export ensures we have access
     // to `Vec` in `no_std` and `std` contexts.
     pub use crate::query::DebugCheckedUnwrap;
+    pub use alloc::format;
     pub use alloc::vec::Vec;
 }
 


### PR DESCRIPTION
# Objective

These macros were originally part of #23684 but were removed to help the pr cross the finish line.

## Solution

Reintroduce and discuss them here.

## Testing

2 testcases to prove the expanded code compiles.

---

`bevy_ecs` has been expanded with 2 macros to simplify creation of `BevyError`s.
```rust
// Now instead of this.
let error = BevyError::new(Severity::Panic, "hello error");
// You can do this. It even support `format!` syntax
let error = bevy_error!("{} bottles of beer on the wall.", 99);

// Quickly return from a fallible system using bail.
bail!("{} bottles of beer.", 99);
// Expands to something like this
return Err(BevyError::panic("Take on down, pass it around,");

// You can even specify the severity by passing it in as the first argument
bevy_error!(Severity::Debug, "{} bottles of beer on the wall.", 98);
```