### PR TITLE
Make text input colors more legible

### DIFF
--- a/crates/bevy_feathers/src/dark_theme.rs
+++ b/crates/bevy_feathers/src/dark_theme.rs
@@ -104,7 +104,7 @@ pub fn create_dark_theme() -> ThemeProps {
                 tokens::TEXT_INPUT_TEXT_DISABLED,
                 palette::WHITE.with_alpha(0.5),
             ),
-            (tokens::TEXT_INPUT_CURSOR, palette::ACCENT.lighter(0.1)),
+            (tokens::TEXT_INPUT_CURSOR, palette::ACCENT.lighter(0.2)),
             (tokens::TEXT_INPUT_SELECTION, palette::ACCENT),
         ]),
     }

--- a/crates/bevy_feathers/src/dark_theme.rs
+++ b/crates/bevy_feathers/src/dark_theme.rs
@@ -99,13 +99,13 @@ pub fn create_dark_theme() -> ThemeProps {
             (tokens::COLOR_PLANE_BG, palette::GRAY_1),
             // Text Input
             (tokens::TEXT_INPUT_BG, palette::GRAY_1),
-            (tokens::TEXT_INPUT_TEXT, palette::LIGHT_GRAY_1),
+            (tokens::TEXT_INPUT_TEXT, palette::WHITE),
             (
                 tokens::TEXT_INPUT_TEXT_DISABLED,
                 palette::WHITE.with_alpha(0.5),
             ),
-            (tokens::TEXT_INPUT_CURSOR, palette::ACCENT),
-            (tokens::TEXT_INPUT_SELECTION, palette::GRAY_2),
+            (tokens::TEXT_INPUT_CURSOR, palette::ACCENT.lighter(0.1)),
+            (tokens::TEXT_INPUT_SELECTION, palette::ACCENT),
         ]),
     }
 }


### PR DESCRIPTION
I had a hard time seeing text in the text inputs, so I changed the default dark theme to make it more legible.

## Before

<img width="378" height="72" alt="Screenshot 2026-04-09 at 10 11 04 PM" src="https://github.com/user-attachments/assets/94c3a00c-93cb-4de5-9c19-b1993fd01e26" />

## After

<img width="378" height="72" alt="Screenshot 2026-04-09 at 10 09 05 PM" src="https://github.com/user-attachments/assets/f49a8e08-1bff-4487-8034-9a638254e554" />
