### PR TITLE
Added `map_severity` method to `ResultSeverityExt`

### DIFF
--- a/crates/bevy_ecs/src/error/bevy_error.rs
+++ b/crates/bevy_ecs/src/error/bevy_error.rs
@@ -306,13 +306,19 @@ pub trait ResultSeverityExt<T, E> {
     /// # Example
     /// ```
     /// # use bevy_ecs::error::{BevyError, ResultSeverityExt, Severity};
+    /// # use thiserror::Error;
     /// # fn validate(_string: &str) -> Result<(), ValidationError> {
     /// #     Err(ValidationError::IncorrectVersion)
     /// # }
+    ///
+    /// #[derive(Error, Debug)]
     /// pub enum ValidationError {
+    ///     #[error("Incorrect version")]
     ///     IncorrectVersion,
+    ///     #[error("Syntax error")]
     ///     SyntaxError,
     /// }
+    ///
     /// fn fallible() -> Result<(), BevyError> {
     ///     // This failure is expected in some contexts, so we downgrade its severity.
     ///     let _parsed: usize = validate("I am not a number")

--- a/crates/bevy_ecs/src/error/bevy_error.rs
+++ b/crates/bevy_ecs/src/error/bevy_error.rs
@@ -311,7 +311,7 @@ pub trait ResultSeverityExt<T, E> {
     /// ```
     /// # use bevy_ecs::error::{BevyError, ResultSeverityExt, Severity};
     /// # use thiserror::Error;
-    /// # fn validate(_string: &str) -> Result<(), ValidationError> {
+    /// # fn validate(_string: &str) -> Result<usize, ValidationError> {
     /// #     Err(ValidationError::IncorrectVersion)
     /// # }
     ///

--- a/crates/bevy_ecs/src/error/bevy_error.rs
+++ b/crates/bevy_ecs/src/error/bevy_error.rs
@@ -306,7 +306,7 @@ pub trait ResultSeverityExt<T, E> {
     /// # Example
     /// ```
     /// # use bevy_ecs::error::{BevyError, ResultSeverityExt, Severity};
-    /// # fn validate() -> Result<(), ValidationError> {
+    /// # fn validate(_string: &str) -> Result<(), ValidationError> {
     /// #     Err(ValidationError::IncorrectVersion)
     /// # }
     /// pub enum ValidationError {
@@ -316,7 +316,6 @@ pub trait ResultSeverityExt<T, E> {
     /// fn fallible() -> Result<(), BevyError> {
     ///     // This failure is expected in some contexts, so we downgrade its severity.
     ///     let _parsed: usize = validate("I am not a number")
-    ///         .parse()
     ///         .map_severity(|e| match e {
     ///             ValidationError::IncorrectVersion => Severity::Debug,
     ///             ValidationError::SyntaxError => Severity::Error,

--- a/crates/bevy_ecs/src/error/bevy_error.rs
+++ b/crates/bevy_ecs/src/error/bevy_error.rs
@@ -283,7 +283,7 @@ impl BevyError {
 }
 
 /// Extension methods for annotating errors with a [`Severity`].
-pub trait ResultSeverityExt<T> {
+pub trait ResultSeverityExt<T, E> {
     /// Overrides the [`Severity`] of the error if this result is `Err`.
     /// This does not change control flow; it only annotates the error.
     ///
@@ -299,14 +299,47 @@ pub trait ResultSeverityExt<T> {
     /// }
     /// ```
     fn with_severity(self, severity: Severity) -> Result<T, BevyError>;
+
+    /// Overrides the [`Severity`] of the error if this result is `Err`.
+    /// This does not change control flow; it only annotates the error.
+    ///
+    /// # Example
+    /// ```
+    /// # use bevy_ecs::error::{BevyError, ResultSeverityExt, Severity};
+    /// # fn validate() -> Result<(), ValidationError> {
+    /// #     Err(ValidationError::IncorrectVersion)
+    /// # }
+    /// pub enum ValidationError {
+    ///     IncorrectVersion,
+    ///     SyntaxError,
+    /// }
+    /// fn fallible() -> Result<(), BevyError> {
+    ///     // This failure is expected in some contexts, so we downgrade its severity.
+    ///     let _parsed: usize = validate("I am not a number")
+    ///         .parse()
+    ///         .map_severity(|e| match e {
+    ///             ValidationError::IncorrectVersion => Severity::Debug,
+    ///             ValidationError::SyntaxError => Severity::Error,
+    ///         })?;
+    ///     Ok(())
+    /// }
+    /// ```
+    fn map_severity(self, f: impl FnOnce(&E) -> Severity) -> Result<T, BevyError>;
 }
 
-impl<T, E> ResultSeverityExt<T> for Result<T, E>
+impl<T, E> ResultSeverityExt<T, E> for Result<T, E>
 where
     E: Into<BevyError>,
 {
     fn with_severity(self, severity: Severity) -> Result<T, BevyError> {
         self.map_err(|e| e.into().with_severity(severity))
+    }
+
+    fn map_severity(self, f: impl FnOnce(&E) -> Severity) -> Result<T, BevyError> {
+        self.map_err(|e| {
+            let severity = f(&e);
+            e.into().with_severity(severity)
+        })
     }
 }
 

--- a/crates/bevy_ecs/src/error/bevy_error.rs
+++ b/crates/bevy_ecs/src/error/bevy_error.rs
@@ -18,10 +18,11 @@ use core::{
 /// You can change the behavior of the fallback handler by modifying the [`FallbackErrorHandler`] resource.
 ///
 /// By default, errors without an assigned severity use [`Severity::Panic`], and will cause your application to panic.
-/// You can change the severity of an error by using [`with_severity`] on any [`Result`] type.
+/// You can change the severity of an error by using [`with_severity`], or [`map_severity`] on any [`Result`] type.
 ///
 /// [`FallbackErrorHandler`]: crate::error::handler::FallbackErrorHandler
 /// [`with_severity`]: ResultSeverityExt::with_severity
+/// [`map_severity`]: ResultSeverityExt::map_severity
 ///
 /// # Backtraces
 ///
@@ -242,9 +243,10 @@ struct InnerBevyError {
 /// you can modify the [fallback error handler], and read the [`Severity`] stored inside of each [`BevyError`].
 ///
 /// You can change the severity of an error (including assigning an error severity) to an ordinary result
-/// by calling [`with_severity`].
+/// by calling [`with_severity`] or [`map_severity`].
 ///
 /// [`with_severity`]: ResultSeverityExt::with_severity
+/// [`map_severity`]: ResultSeverityExt::map_severity
 /// [fallback error handler]: crate::error::handler::FallbackErrorHandler
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd)]
 pub enum Severity {
@@ -298,6 +300,8 @@ pub trait ResultSeverityExt<T, E> {
     ///     Ok(())
     /// }
     /// ```
+    ///
+    /// For more fine grained control see [`Result::map_severity`]
     fn with_severity(self, severity: Severity) -> Result<T, BevyError>;
 
     /// Overrides the [`Severity`] of the error if this result is `Err`.
@@ -329,6 +333,8 @@ pub trait ResultSeverityExt<T, E> {
     ///     Ok(())
     /// }
     /// ```
+    ///
+    /// If you don't need to inspect the error, use [`Result::with_severity`]
     fn map_severity(self, f: impl FnOnce(&E) -> Severity) -> Result<T, BevyError>;
 }
 

--- a/examples/ecs/error_handling.rs
+++ b/examples/ecs/error_handling.rs
@@ -1,12 +1,10 @@
 //! Showcases how fallible systems and observers can make use of Rust's powerful result handling
 //! syntax.
 
-use bevy::ecs::{error::warn, world::DeferredWorld};
+use bevy::ecs::{entity::SpawnError, error::warn, world::DeferredWorld};
 use bevy::math::sampling::UniformMeshSampler;
 use bevy::prelude::*;
 
-use bevy_ecs::entity::SpawnError;
-use bevy_ecs::system::RunSystemOnce;
 use chacha20::ChaCha8Rng;
 use rand::distr::Distribution;
 use rand::SeedableRng;

--- a/examples/ecs/error_handling.rs
+++ b/examples/ecs/error_handling.rs
@@ -5,6 +5,8 @@ use bevy::ecs::{error::warn, world::DeferredWorld};
 use bevy::math::sampling::UniformMeshSampler;
 use bevy::prelude::*;
 
+use bevy_ecs::entity::SpawnError;
+use bevy_ecs::system::RunSystemOnce;
 use chacha20::ChaCha8Rng;
 use rand::distr::Distribution;
 use rand::SeedableRng;
@@ -158,6 +160,16 @@ fn failing_system(world: &mut World) -> Result {
         // The default error severity is Severity::Panic.
         // We can add a Severity level to any Result locally to downgrade it appropriately.
         .with_severity(Severity::Warning)?;
+
+    world
+        // This entity doesn't exist!
+        .spawn_empty_at(Entity::from_raw_u32(12345678).unwrap())
+        .map_severity(|e| match e {
+            // Not that concerning, we just need to make sure to find a different entity
+            SpawnError::AlreadySpawned => Severity::Debug,
+            // Oh no
+            SpawnError::Invalid(_) => Severity::Error,
+        })?;
 
     Ok(())
 }


### PR DESCRIPTION
# Objective

Part of: #23680

## Solution

Add `map_severity` method onto `ResultSeverityExt` 


## Showcase

```rust
world
        // This entity doesn't exist!
        .spawn_empty_at(Entity::from_raw_u32(12345678).unwrap())
        .map_severity(|e| match e {
            // Not that concerning, we just need to make sure to find a different entity
            SpawnError::AlreadySpawned => Severity::Debug,
            // Oh no
            SpawnError::Invalid(_) => Severity::Error,
        })?;
```