### PR TITLE
Don't trigger change detections in`Assets<A>::track_assets` if not necessary

### DIFF
--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -571,7 +571,6 @@ impl<A: Asset> Assets<A> {
     /// A system that synchronizes the state of assets in this collection with the [`AssetServer`]. This manages
     /// [`Handle`] drop events.
     pub fn track_assets(mut assets: ResMut<Self>, asset_server: Res<AssetServer>) {
-        let assets = &mut *assets;
         // note that we must hold this lock for the entire duration of this function to ensure
         // that `asset_server.load` calls that occur during it block, which ensures that
         // re-loads are kicked off appropriately. This function must be "transactional" relative


### PR DESCRIPTION
# Objective

Fix #23626 

## Solution

Don't mutably dereference `assets` when not needed

## Testing

Tried to write a integration test but couldn't get it to work with `MinimalPlugins`. Tested manually

<details>

<summary>Methodology</summary>

Ran

```rust
//! asd
use bevy::prelude::*;

/// asd
fn main() -> AppExit {
    App::new()
        .add_plugins(DefaultPlugins)
        .add_systems(Update, test)
        .run()
}

/// asd
fn test(assets: Res<Assets<Mesh>>) {
    if assets.is_changed() {
        info!("{}", assets.changed_by());
    }
}
```

observed (note we're not getting spammed each frame):

```
2026-04-10T18:36:47.589526Z  INFO bevy_diagnostic::system_information_diagnostics_plugin::internal: ...
2026-04-10T18:36:47.623739Z  INFO bevy_render::renderer: ...
2026-04-10T18:36:48.048787Z  INFO bevy_pbr::cluster: GPU clustering is supported on this device.
2026-04-10T18:36:48.048922Z  INFO bevy_render::batching::gpu_preprocessing: GPU preprocessing is fully supported on this device.
2026-04-10T18:36:48.051537Z  INFO bevy_winit::system: Creating new window bevy (65v0)
2026-04-10T18:36:48.064398Z  INFO bevy: crates/bevy_sprite_render/src/sprite_mesh/mod.rs:42:22
2026-04-10T18:36:48.169366Z  INFO bevy: crates/bevy_asset/src/assets.rs:613:30
2026-04-10T18:36:57.181161Z  INFO bevy_window::system: No windows are open, exiting
2026-04-10T18:36:57.182245Z  INFO bevy_winit::system: Closing window 65v0
```

</details>
