### PR TITLE
Optimize render asset extraction by reusing heap allocations

### DIFF
--- a/benches/benches/bevy_render/extract_render_asset.rs
+++ b/benches/benches/bevy_render/extract_render_asset.rs
@@ -1,0 +1,96 @@
+use bevy_app::{App, AppLabel};
+use bevy_asset::{Asset, AssetApp, AssetEvent, AssetId, Assets, RenderAssetUsages};
+use bevy_ecs::prelude::*;
+use bevy_reflect::TypePath;
+use bevy_render::{
+    extract_plugin::ExtractPlugin,
+    render_asset::{PrepareAssetError, RenderAsset, RenderAssetPlugin},
+    RenderApp,
+};
+use criterion::{criterion_group, BenchmarkId, Criterion, Throughput};
+use std::time::{Duration, Instant};
+
+#[derive(Asset, TypePath, Clone, Debug)]
+struct DummyAsset;
+
+struct DummyRenderAsset;
+
+impl RenderAsset for DummyRenderAsset {
+    type SourceAsset = DummyAsset;
+    type Param = ();
+
+    fn asset_usage(_: &Self::SourceAsset) -> RenderAssetUsages {
+        RenderAssetUsages::RENDER_WORLD
+    }
+
+    fn prepare_asset(
+        _source_asset: Self::SourceAsset,
+        _asset_id: AssetId<Self::SourceAsset>,
+        _param: &mut bevy_ecs::system::SystemParamItem<Self::Param>,
+        _previous_asset: Option<&Self>,
+    ) -> Result<Self, PrepareAssetError<Self::SourceAsset>> {
+        Ok(DummyRenderAsset)
+    }
+}
+
+fn extract_render_asset_bench(c: &mut Criterion) {
+    let mut group = c.benchmark_group("extract_render_asset");
+
+    // Test different payload sizes
+    for size in [10, 100, 1_000, 10_000, 100_000] {
+        group.throughput(Throughput::Elements(size as u64));
+        group.bench_with_input(BenchmarkId::new("allocations", size), &size, |b, &size| {
+            // --- ONCE PER BENCHMARK SCALE ---
+            let mut app = App::new();
+
+            app.add_plugins(bevy_asset::AssetPlugin::default());
+            app.init_asset::<DummyAsset>();
+            app.add_plugins(ExtractPlugin::default());
+            app.add_plugins(RenderAssetPlugin::<DummyRenderAsset>::default());
+
+            app.finish();
+            app.cleanup();
+
+            let mut handles = Vec::with_capacity(size);
+            {
+                let mut assets = app.world_mut().resource_mut::<Assets<DummyAsset>>();
+                for _ in 0..size {
+                    handles.push(assets.add(DummyAsset));
+                }
+            }
+
+            // Run one initial update to flush any startup systems
+            app.update();
+
+            b.iter_custom(|iters| {
+                let mut total = Duration::default();
+
+                for _ in 0..iters {
+                    // Send N messages to trigger extraction logic
+                    for handle in &handles {
+                        app.world_mut()
+                            .write_message(AssetEvent::Modified { id: handle.id() });
+                    }
+
+                    let bevy_app::SubApps { main, sub_apps } = app.sub_apps_mut();
+                    let render_app = sub_apps
+                        .get_mut(&RenderApp.intern())
+                        .expect("RenderApp should exist");
+                    let render_world = render_app.world_mut();
+
+                    // Measuring the extract call
+                    let start = Instant::now();
+                    bevy_render::extract_plugin::extract(main.world_mut(), render_world);
+                    total += Instant::now().duration_since(start);
+
+                    // Run a standard app update to allow Bevy's internal systems to flush/clear the message queues.
+                    app.update();
+                }
+                total
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, extract_render_asset_bench);

--- a/benches/benches/bevy_render/main.rs
+++ b/benches/benches/bevy_render/main.rs
@@ -1,11 +1,13 @@
 use criterion::criterion_main;
 
 mod compute_normals;
+mod extract_render_asset;
 mod render_layers;
 mod torus;
 
 criterion_main!(
     render_layers::benches,
     compute_normals::benches,
-    torus::benches
+    torus::benches,
+    extract_render_asset::benches
 );

--- a/crates/bevy_render/src/erased_render_asset.rs
+++ b/crates/bevy_render/src/erased_render_asset.rs
@@ -6,7 +6,7 @@ use bevy_app::{App, Plugin, SubApp};
 use bevy_asset::RenderAssetUsages;
 use bevy_asset::{Asset, AssetEvent, AssetId, Assets, UntypedAssetId};
 use bevy_ecs::{
-    prelude::{Commands, IntoScheduleConfigs, MessageReader, ResMut, Resource},
+    prelude::{Commands, IntoScheduleConfigs, Local, MessageReader, ResMut, Resource},
     schedule::{ScheduleConfigs, SystemSet},
     system::{ScheduleSystem, StaticSystemParam, SystemParam, SystemParamItem, SystemState},
     world::{FromWorld, Mut},
@@ -278,10 +278,17 @@ fn collect_erased_render_assets_to_reextract<A: ErasedRenderAsset>(
 /// Extracts all created or modified assets of the corresponding [`ErasedRenderAsset::SourceAsset`] type
 /// into the "render world", including any assets invalidated by device recovery.
 pub(crate) fn extract_erased_render_asset<A: ErasedRenderAsset>(
-    mut commands: Commands,
     mut to_reextract: Option<ResMut<ErasedRenderAssetsToReExtract<A>>>,
+    mut extracted_assets: ResMut<ExtractedAssets<A>>,
     mut main_world: ResMut<MainWorld>,
+    mut needs_extracting: Local<HashSet<AssetId<A::SourceAsset>>>,
 ) {
+    extracted_assets.extracted.clear();
+    extracted_assets.removed.clear();
+    extracted_assets.modified.clear();
+    extracted_assets.added.clear();
+    needs_extracting.clear();
+
     let reextract_ids = to_reextract
         .as_mut()
         .map(|r| core::mem::take(&mut r.ids))
@@ -290,10 +297,6 @@ pub(crate) fn extract_erased_render_asset<A: ErasedRenderAsset>(
     main_world.resource_scope(
         |world, mut cached_state: Mut<CachedExtractErasedRenderAssetSystemState<A>>| {
             let (mut events, mut assets) = cached_state.state.get_mut(world).unwrap();
-
-            let mut needs_extracting = <HashSet<_>>::default();
-            let mut removed = <HashSet<_>>::default();
-            let mut modified = <HashSet<_>>::default();
 
             if let Some(reextract_ids) = reextract_ids {
                 needs_extracting.extend(reextract_ids);
@@ -310,7 +313,7 @@ pub(crate) fn extract_erased_render_asset<A: ErasedRenderAsset>(
                     }
                     AssetEvent::Modified { id } => {
                         needs_extracting.insert(*id);
-                        modified.insert(*id);
+                        extracted_assets.modified.insert(*id);
                     }
                     AssetEvent::Removed { .. } => {
                         // We don't care that the asset was removed from Assets<T> in the main world.
@@ -318,8 +321,8 @@ pub(crate) fn extract_erased_render_asset<A: ErasedRenderAsset>(
                     }
                     AssetEvent::Unused { id } => {
                         needs_extracting.remove(id);
-                        modified.remove(id);
-                        removed.insert(*id);
+                        extracted_assets.modified.remove(id);
+                        extracted_assets.removed.insert(*id);
                     }
                     AssetEvent::LoadedWithDependencies { .. } => {
                         // TODO: handle this
@@ -327,31 +330,23 @@ pub(crate) fn extract_erased_render_asset<A: ErasedRenderAsset>(
                 }
             }
 
-            let mut extracted_assets = Vec::new();
-            let mut added = <HashSet<_>>::default();
             for id in needs_extracting.drain() {
                 if let Some(asset) = assets.get(id) {
                     let asset_usage = A::asset_usage(asset);
                     if asset_usage.contains(RenderAssetUsages::RENDER_WORLD) {
                         if asset_usage == RenderAssetUsages::RENDER_WORLD {
                             if let Some(asset) = assets.remove(id) {
-                                extracted_assets.push((id, asset));
-                                added.insert(id);
+                                extracted_assets.extracted.push((id, asset));
+                                extracted_assets.added.insert(id);
                             }
                         } else {
-                            extracted_assets.push((id, asset.clone()));
-                            added.insert(id);
+                            extracted_assets.extracted.push((id, asset.clone()));
+                            extracted_assets.added.insert(id);
                         }
                     }
                 }
             }
 
-            commands.insert_resource(ExtractedAssets::<A> {
-                extracted: extracted_assets,
-                removed,
-                modified,
-                added,
-            });
             cached_state.state.apply(world);
         },
     );

--- a/crates/bevy_render/src/render_asset.rs
+++ b/crates/bevy_render/src/render_asset.rs
@@ -5,7 +5,7 @@ use crate::{
 use bevy_app::{App, Plugin, SubApp};
 use bevy_asset::{Asset, AssetEvent, AssetId, Assets, RenderAssetUsages};
 use bevy_ecs::{
-    prelude::{Commands, IntoScheduleConfigs, MessageReader, ResMut, Resource},
+    prelude::{Commands, IntoScheduleConfigs, Local, MessageReader, ResMut, Resource},
     schedule::{ScheduleConfigs, SystemSet},
     system::{ScheduleSystem, StaticSystemParam, SystemParam, SystemParamItem, SystemState},
     world::{FromWorld, Mut},
@@ -278,10 +278,17 @@ fn collect_render_assets_to_reextract<A: RenderAsset>(
 /// Extracts all created or modified assets of the corresponding [`RenderAsset::SourceAsset`] type
 /// into the "render world", including any assets invalidated by device recovery.
 pub(crate) fn extract_render_asset<A: RenderAsset>(
-    mut commands: Commands,
     mut to_reextract: Option<ResMut<RenderAssetsToReExtract<A>>>,
+    mut extracted_assets: ResMut<ExtractedAssets<A>>,
     mut main_world: ResMut<MainWorld>,
+    mut needs_extracting: Local<HashSet<AssetId<A::SourceAsset>>>,
 ) {
+    extracted_assets.extracted.clear();
+    extracted_assets.removed.clear();
+    extracted_assets.modified.clear();
+    extracted_assets.added.clear();
+    needs_extracting.clear();
+
     let reextract_ids = to_reextract
         .as_mut()
         .map(|r| core::mem::take(&mut r.ids))
@@ -290,10 +297,6 @@ pub(crate) fn extract_render_asset<A: RenderAsset>(
     main_world.resource_scope(
         |world, mut cached_state: Mut<CachedExtractRenderAssetSystemState<A>>| {
             let (mut events, mut assets, maybe_render_assets) = cached_state.state.get_mut(world).unwrap();
-
-            let mut needs_extracting = <HashSet<_>>::default();
-            let mut removed = <HashSet<_>>::default();
-            let mut modified = <HashSet<_>>::default();
 
             if let Some(reextract_ids) = reextract_ids {
                 needs_extracting.extend(reextract_ids);
@@ -310,7 +313,7 @@ pub(crate) fn extract_render_asset<A: RenderAsset>(
                     }
                     AssetEvent::Modified { id } => {
                         needs_extracting.insert(*id);
-                        modified.insert(*id);
+                        extracted_assets.modified.insert(*id);
                     }
                     AssetEvent::Removed { .. } => {
                         // We don't care that the asset was removed from Assets<T> in the main world.
@@ -318,8 +321,8 @@ pub(crate) fn extract_render_asset<A: RenderAsset>(
                     }
                     AssetEvent::Unused { id } => {
                         needs_extracting.remove(id);
-                        modified.remove(id);
-                        removed.insert(*id);
+                        extracted_assets.modified.remove(id);
+                        extracted_assets.removed.insert(*id);
                     }
                     AssetEvent::LoadedWithDependencies { .. } => {
                         // TODO: handle this
@@ -327,8 +330,6 @@ pub(crate) fn extract_render_asset<A: RenderAsset>(
                 }
             }
 
-            let mut extracted_assets = Vec::new();
-            let mut added = <HashSet<_>>::default();
             for id in needs_extracting.drain() {
                 if let Some(asset) = assets.get(id) {
                     let asset_usage = A::asset_usage(asset);
@@ -338,8 +339,8 @@ pub(crate) fn extract_render_asset<A: RenderAsset>(
                                 let previous_asset = maybe_render_assets.as_ref().and_then(|render_assets| render_assets.get(id));
                                 match A::take_gpu_data(asset, previous_asset) {
                                     Ok(gpu_data_asset) => {
-                                        extracted_assets.push((id, gpu_data_asset));
-                                        added.insert(id);
+                                        extracted_assets.extracted.push((id, gpu_data_asset));
+                                        extracted_assets.added.insert(id);
                                     }
                                     Err(e) => {
                                         error!("{} with RenderAssetUsages == RENDER_WORLD cannot be extracted: {e}", core::any::type_name::<A>());
@@ -347,19 +348,13 @@ pub(crate) fn extract_render_asset<A: RenderAsset>(
                                 };
                             }
                         } else {
-                            extracted_assets.push((id, asset.clone()));
-                            added.insert(id);
+                            extracted_assets.extracted.push((id, asset.clone()));
+                            extracted_assets.added.insert(id);
                         }
                     }
                 }
             }
 
-            commands.insert_resource(ExtractedAssets::<A> {
-                extracted: extracted_assets,
-                removed,
-                modified,
-                added,
-            });
             cached_state.state.apply(world);
         },
     );


### PR DESCRIPTION
# Objective

- Address CPU overhead in the render asset extraction phase.
- Prior to this change, `extract_render_asset` and `extract_erased_render_asset` created several fresh `HashSet` and `Vec` collections every frame.
- Furthermore, these collections were being sent to the render world via `Commands::insert_resource`, which causes the previous frame's resource (and its allocated capacity) to be dropped and deallocated.
- This results in unnecessary pressure on the global allocator and lower CPU cache efficiency due to constant memory re-initialization.

## Solution

-  Converted the temporary `needs_extracting` `HashSet` into a `Local` system parameter. This allows the collection to retain its capacity between system runs.
- Switched from using `Commands::insert_resource` to using `ResMut<ExtractedAssets<A>>`. By calling `.clear()` on the existing resource instead of replacing it, we reuse the heap-allocated buffers for the `extracted` Vec and the `removed`, `modified`, and `added` HashSets.

## Testing

- Introduced a micro-benchmark simulating N unique asset modifications per frame to trigger the extraction logic.

```
cargo bench -p benches --bench render -- extract_render_asset
```

---

## Showcase

### Criterion Table
```
extract_render_asset/allocations/10
                        time:   [8.6633 µs 8.7004 µs 8.7432 µs]
                        thrpt:  [1.1437 Melem/s 1.1494 Melem/s 1.1543 Melem/s]
                 change:
                        time:   [−0.3467% +0.2334% +0.8050%] (p = 0.42 > 0.05)
                        thrpt:  [−0.7986% −0.2329% +0.3479%]
                        No change in performance detected.
extract_render_asset/allocations/100
                        time:   [11.256 µs 11.297 µs 11.340 µs]
                        thrpt:  [8.8183 Melem/s 8.8519 Melem/s 8.8838 Melem/s]
                 change:
                        time:   [−13.487% −12.672% −11.536%] (p = 0.00 < 0.05)
                        thrpt:  [+13.041% +14.511% +15.590%]
                        Performance has improved.
extract_render_asset/allocations/1000
                        time:   [34.867 µs 35.037 µs 35.222 µs]
                        thrpt:  [28.392 Melem/s 28.541 Melem/s 28.681 Melem/s]
                 change:
                        time:   [−42.567% −41.359% −40.454%] (p = 0.00 < 0.05)
                        thrpt:  [+67.938% +70.530% +74.116%]
                        Performance has improved.
extract_render_asset/allocations/10000
                        time:   [302.54 µs 305.30 µs 308.22 µs]
                        thrpt:  [32.445 Melem/s 32.755 Melem/s 33.053 Melem/s]
                 change:
                        time:   [−39.411% −37.491% −35.597%] (p = 0.00 < 0.05)
                        thrpt:  [+55.272% +59.976% +65.047%]
                        Performance has improved.
extract_render_asset/allocations/100000
                        time:   [4.7822 ms 4.9347 ms 5.1028 ms]
                        thrpt:  [19.597 Melem/s 20.265 Melem/s 20.911 Melem/s]
                 change:
                        time:   [−9.8539% −6.8588% −3.4015%] (p = 0.00 < 0.05)
                        thrpt:  [+3.5212% +7.3639% +10.931%]
                        Performance has improved.

```