### PR TITLE
Implement geometric growth for bevy_render buffers

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -110,3 +110,7 @@ harness = false
 name = "tasks"
 path = "benches/bevy_tasks/main.rs"
 harness = false
+
+[features]
+# Forces the wgpu instance to be initialized using the raw Vulkan HAL, enabling additional configuration
+raw_vulkan_init = ["bevy_render/raw_vulkan_init"]

--- a/benches/benches/bevy_render/buffer_vec.rs
+++ b/benches/benches/bevy_render/buffer_vec.rs
@@ -1,0 +1,49 @@
+use bevy_render::render_resource::{BufferUsages, PollType, RawBufferVec};
+use bevy_render::renderer::initialize_renderer;
+use bevy_render::settings::{RenderResources, WgpuSettings};
+use bevy_tasks::block_on;
+use core::hint::black_box;
+use criterion::{criterion_group, Criterion};
+use std::time::{Duration, Instant};
+
+pub fn buffer_vec_benches(c: &mut Criterion) {
+    let settings = WgpuSettings::default();
+    let backends = settings.backends.expect("No backends found");
+
+    let RenderResources(device, queue, ..) = block_on(initialize_renderer(
+        backends,
+        None, // No window needed for buffer tests
+        &settings,
+        #[cfg(feature = "raw_vulkan_init")]
+        Default::default(),
+    ));
+
+    c.bench_function("raw_buffer_vec_incremental_write", |b| {
+        b.iter_custom(|iters| {
+            let mut total = Duration::default();
+
+            for _ in 0..iters {
+                let start = Instant::now();
+
+                // Simulate incremental writes to the buffer vec, writing after each push
+                let mut vec = RawBufferVec::<u32>::new(BufferUsages::STORAGE);
+                for i in 0..5000 {
+                    vec.push(i);
+                    vec.write_buffer(&device, &queue);
+                }
+                total += Instant::now().duration_since(start);
+
+                black_box(&vec);
+                // Cleanup allocated buffers to prevent memory bloat during the benchmark
+                queue.submit(None);
+                device
+                    .poll(PollType::wait_indefinitely())
+                    .expect("Failed to poll device");
+            }
+
+            total
+        });
+    });
+}
+
+criterion_group!(benches, buffer_vec_benches);

--- a/benches/benches/bevy_render/main.rs
+++ b/benches/benches/bevy_render/main.rs
@@ -1,5 +1,6 @@
 use criterion::criterion_main;
 
+mod buffer_vec;
 mod compute_normals;
 mod render_layers;
 mod torus;
@@ -7,5 +8,6 @@ mod torus;
 criterion_main!(
     render_layers::benches,
     compute_normals::benches,
-    torus::benches
+    torus::benches,
+    buffer_vec::benches
 );

--- a/crates/bevy_render/src/render_resource/buffer_vec.rs
+++ b/crates/bevy_render/src/render_resource/buffer_vec.rs
@@ -154,9 +154,11 @@ impl<T: NoUninit> RawBufferVec<T> {
     /// the `RawBufferVec` was created, the buffer on the [`RenderDevice`]
     /// is marked as [`BufferUsages::COPY_DST`](BufferUsages).
     pub fn reserve(&mut self, capacity: usize, device: &RenderDevice) {
-        let size = self.item_size * capacity;
-        if capacity > self.capacity || (self.changed && size > 0) {
-            self.capacity = capacity;
+        if capacity > self.capacity || (self.changed && capacity > 0) {
+            if capacity > self.capacity {
+                self.capacity = capacity.max(self.capacity * 2);
+            }
+            let size = self.item_size * self.capacity;
             self.buffer = Some(device.create_buffer(&wgpu::BufferDescriptor {
                 label: make_buffer_label::<Self>(&self.label),
                 size: size as BufferAddress,
@@ -383,9 +385,11 @@ where
     /// the `AtomicRawBufferVec` was created, the buffer on the [`RenderDevice`]
     /// is marked as [`BufferUsages::COPY_DST`](BufferUsages).
     pub fn reserve(&mut self, capacity: usize, device: &RenderDevice) {
-        let size = size_of::<T::Blob>() * capacity;
-        if capacity > self.capacity || (self.changed && size > 0) {
-            self.capacity = capacity;
+        if capacity > self.capacity || (self.changed && capacity > 0) {
+            if capacity > self.capacity {
+                self.capacity = capacity.max(self.capacity * 2);
+            }
+            let size = size_of::<T::Blob>() * self.capacity;
             self.buffer = Some(device.create_buffer(&wgpu::BufferDescriptor {
                 label: make_buffer_label::<Self>(&self.label),
                 size: size as BufferAddress,
@@ -609,8 +613,9 @@ where
         if capacity <= self.capacity && !self.label_changed {
             return;
         }
-
-        self.capacity = capacity;
+        if capacity > self.capacity {
+            self.capacity = capacity.max(self.capacity * 2);
+        }
         let size = u64::from(T::min_size()) as usize * capacity;
         self.buffer = Some(device.create_buffer(&wgpu::BufferDescriptor {
             label: make_buffer_label::<Self>(&self.label),
@@ -793,8 +798,9 @@ where
         if capacity <= self.capacity && !self.label_changed {
             return;
         }
-
-        self.capacity = capacity;
+        if capacity > self.capacity {
+            self.capacity = capacity.max(self.capacity * 2);
+        }
         let size = self.item_size * capacity;
         self.buffer = Some(device.create_buffer(&wgpu::BufferDescriptor {
             label: make_buffer_label::<Self>(&self.label),
@@ -883,9 +889,8 @@ where
         if capacity <= self.capacity {
             return;
         }
-
-        let size = size_of::<T>() * capacity;
-        self.capacity = capacity;
+        self.capacity = capacity.max(self.capacity * 2);
+        let size = size_of::<T>() * self.capacity;
         self.buffer = Some(render_device.create_buffer(&wgpu::BufferDescriptor {
             label: Some(&self.label),
             size: size as u64,

--- a/tools/ci/src/commands/test.rs
+++ b/tools/ci/src/commands/test.rs
@@ -32,7 +32,7 @@ impl Prepare for TestCommand {
                     sh,
                     // `--benches` runs each benchmark once in order to verify that they behave
                     // correctly and do not panic.
-                    "cargo test --workspace --benches {no_fail_fast...} {jobs...}"
+                    "cargo test --workspace --benches --features raw_vulkan_init {no_fail_fast...} {jobs...}"
                 ),
                 "Please fix failing tests in output above.",
             )


### PR DESCRIPTION
# Objective

- Currently, several buffer implementations in `bevy_render` resize exactly to the requested capacity. This leads to frequent reallocations and GPU buffer creations when a buffer grows incrementally.
- This PR introduces exponential growth strategy (similar to std::vec::Vec and [AtomicSparseBufferVec](https://github.com/bevyengine/bevy/blob/5330b01ed6dfe8ee9ea98c97ded72e44ca336c74/crates/bevy_render/src/render_resource/sparse_buffer_vec.rs#L647-L664)) to significantly reduce the overhead of resizing.

## Solution

I have updated the `reserve` function across several internal buffer types in `crates/bevy_render/src/render_resource/buffer_vec.rs`:
- RawBufferVec
- AtomicRawBufferVec
- StorageBuffer
- DynamicStorageBuffer
- UniformBuffer

I am using `self.capacity = capacity.max(self.capacity * 2)` to provide enough headroom to accommodate future growth without frequent re-allocation.

## Testing

- Created a new benchmark `buffer_vec` to measure incremental writes.

```
cargo bench -p benches --bench render -- buffer_vec
```

---

## Showcase

### Criterion Table

```
raw_buffer_vec_incremental_write
                        time:   [9.8906 ms 9.9676 ms 10.043 ms]
                        change: [−13.950% −12.355% −10.897%] (p = 0.00 < 0.05)
                        Performance has improved.
```