### PR TITLE
Add `calloop::sources=debug` to default log filters

### DIFF
--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -286,6 +286,7 @@ pub const DEFAULT_FILTER: &str = concat!(
     "symphonia_format_riff::demuxer=warn,",
     "symphonia_format_wav::demuxer=warn,",
     "calloop::loop_logic=error,",
+    "calloop::sources=debug,",
 );
 
 impl Default for LogPlugin {


### PR DESCRIPTION
# Objective

When setting the default log level to `trace` (e.g. with `RUST_LOG=trace`), one of the log messages that gets enabled looks like `[calloop] Processing events for source type ...`. This message is logged at the trace level 1-3 times every frame, making it extremely spammy. Although the purpose of trace-level logs is to be verbose, logging the same unactionable thing every frame is excessive.
While normally there would be a bunch of stuff that always gets logged every frame, the default filters provided by `LogPlugin` exclude all of that at every log level, except for this one thing which slips through.

## Solution

Add the offending module to the default filters.

## Testing

Manually tested with the [`logs`](https://github.com/bevyengine/bevy/blob/main/examples/app/logs.rs) example and various `RUST_LOG` values.