### PR TITLE
`reborrow` methods for `RelatedSpawnerCommands` and `EntityEntryCommands`

### DIFF
--- a/crates/bevy_ecs/src/relationship/related_methods.rs
+++ b/crates/bevy_ecs/src/relationship/related_methods.rs
@@ -624,6 +624,17 @@ impl<'w, R: Relationship> RelatedSpawnerCommands<'w, R> {
         }
     }
 
+    /// Returns a [`RelatedSpawnerCommands`] with a smaller lifetime.
+    ///
+    /// This is useful if you have `&mut RelatedSpawnerCommands` but need `RelatedSpawnerCommands`.
+    pub fn reborrow(&mut self) -> RelatedSpawnerCommands<'_, R> {
+        RelatedSpawnerCommands {
+            target: self.target,
+            commands: self.commands.reborrow(),
+            _marker: PhantomData,
+        }
+    }
+
     /// Spawns an entity with the given `bundle` and an `R` relationship targeting the `target`
     /// entity this spawner was initialized with.
     pub fn spawn(&mut self, bundle: impl Bundle) -> EntityCommands<'_> {

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -2293,6 +2293,16 @@ impl<'a, T: Component<Mutability = Mutable>> EntityEntryCommands<'a, T> {
 }
 
 impl<'a, T: Component> EntityEntryCommands<'a, T> {
+    /// Returns a [`EntityEntryCommands`] with a smaller lifetime.
+    ///
+    /// This is useful if you have `&mut EntityEntryCommands` but need `EntityEntryCommands`.
+    pub fn reborrow(&mut self) -> EntityEntryCommands<'_, T> {
+        EntityEntryCommands {
+            entity_commands: self.entity_commands.reborrow(),
+            marker: PhantomData,
+        }
+    }
+
     /// [Insert](EntityCommands::insert) `default` into this entity,
     /// if `T` is not already present.
     #[track_caller]


### PR DESCRIPTION
# Objective

Offer `reborrow` methods for `RelatedSpawnerCommands` and `EntityEntryCommands`, just like `Commands` and `EntityCommands` have them.

I want to write wrapper types with these and it would make things easier for me if this method existed for them.