### PR TITLE
Fix(input focus): Bypass change detection in `process_recorded_focus_changes`

### DIFF
--- a/crates/bevy_input_focus/src/gained_and_lost.rs
+++ b/crates/bevy_input_focus/src/gained_and_lost.rs
@@ -36,7 +36,7 @@ pub fn process_recorded_focus_changes(mut focus: ResMut<InputFocus>, mut command
 
     // We need to track the previous focus as we go,
     // so we can send the correct FocusLost events when focus changes.
-    let mut previous_focus = focus.bypass_change_detection().original_focus;
+    let mut previous_focus = focus.original_focus;
     for change in focus.bypass_change_detection().recorded_changes.drain(..) {
         match change {
             Some(new_focus) => {

--- a/crates/bevy_input_focus/src/gained_and_lost.rs
+++ b/crates/bevy_input_focus/src/gained_and_lost.rs
@@ -28,10 +28,16 @@ pub struct FocusLost {
 ///
 /// This system is part of [`InputFocusPlugin`](super::InputFocusPlugin).
 pub fn process_recorded_focus_changes(mut focus: ResMut<InputFocus>, mut commands: Commands) {
+    // This function does not actually mutate the `focus.current_focus`, which is
+    // what is exposed to the user via `InputFocus::get`. Other fields are not exposed.
+    // So, we `bypass_change_detection` when accessing `focus` to avoid false signaling
+    // that we changed the `current_focus`. That is what users would care about if
+    // they were to be checking `focus.is_changed()`.
+
     // We need to track the previous focus as we go,
     // so we can send the correct FocusLost events when focus changes.
-    let mut previous_focus = focus.original_focus;
-    for change in focus.recorded_changes.drain(..) {
+    let mut previous_focus = focus.bypass_change_detection().original_focus;
+    for change in focus.bypass_change_detection().recorded_changes.drain(..) {
         match change {
             Some(new_focus) => {
                 if let Some(old_focus) = previous_focus {
@@ -49,7 +55,7 @@ pub fn process_recorded_focus_changes(mut focus: ResMut<InputFocus>, mut command
         }
     }
 
-    focus.original_focus = focus.current_focus;
+    focus.bypass_change_detection().original_focus = focus.current_focus;
 }
 
 #[cfg(test)]

--- a/crates/bevy_input_focus/src/lib.rs
+++ b/crates/bevy_input_focus/src/lib.rs
@@ -107,11 +107,11 @@ pub struct InputFocus {
     /// The set of input focus changes that have been recorded since the last time [`FocusGained`] and [`FocusLost`] events were sent.
     ///
     /// These are stored in a first-in-first-out manner, so the most recent change is at the end of the vector.
-    pub(crate) recorded_changes: Vec<Option<Entity>>,
+    recorded_changes: Vec<Option<Entity>>,
     /// The entity that had input focus at the time of the last sent [`FocusGained`] or [`FocusLost`] event, if any.
     ///
     /// This is used to determine which events to send when processing recorded focus changes.
-    pub(crate) original_focus: Option<Entity>,
+    original_focus: Option<Entity>,
 }
 
 impl InputFocus {

--- a/crates/bevy_input_focus/src/lib.rs
+++ b/crates/bevy_input_focus/src/lib.rs
@@ -107,11 +107,11 @@ pub struct InputFocus {
     /// The set of input focus changes that have been recorded since the last time [`FocusGained`] and [`FocusLost`] events were sent.
     ///
     /// These are stored in a first-in-first-out manner, so the most recent change is at the end of the vector.
-    recorded_changes: Vec<Option<Entity>>,
+    pub(crate) recorded_changes: Vec<Option<Entity>>,
     /// The entity that had input focus at the time of the last sent [`FocusGained`] or [`FocusLost`] event, if any.
     ///
     /// This is used to determine which events to send when processing recorded focus changes.
-    original_focus: Option<Entity>,
+    pub(crate) original_focus: Option<Entity>,
 }
 
 impl InputFocus {


### PR DESCRIPTION
# Objective

- Fixes #23759 
- `Res<InputFocus>` has `is_changed()` returning true every frame because `process_recorded_focus_changes` mutates it every frame now. Other systems that were relying on `InputFocus.is_changed()` for when the `current_focus` changes are no longer working as intended because of that change.

## Solution

- Bypass change detection whenever `ResMut<InputFocus>` is accessed in `process_recorded_focus_changes`.

## Testing

- `cargo run --example feathers --features=“experimental_bevy_feathers”`: text cursor now blinks correctly again
- `cargo run --example directional_navigation` verified via `println!` statement in `update_focus_display` that the system isn’t running on every frame (since it has a run condition `.run_if(|input_focus: Res<InputFocus>| input_focus.is_changed())`)