### PR TITLE
fix(RenderDebugOverlayPlugin): Require the `bevy_pbr` feature for inclusion in `DefaultPlugins`

### DIFF
--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -89,7 +89,7 @@ plugin_group! {
         bevy_state::app:::StatesPlugin,
         #[cfg(feature = "bevy_ci_testing")]
         bevy_dev_tools::ci_testing:::CiTestingPlugin,
-        #[cfg(feature = "bevy_dev_tools")]
+        #[custom(cfg(all(feature = "bevy_dev_tools", feature = "bevy_pbr")))]
         bevy_dev_tools::render_debug:::RenderDebugOverlayPlugin,
         #[cfg(feature = "hotpatching")]
         bevy_app::hotpatch:::HotPatchPlugin,


### PR DESCRIPTION
# Objective

- Fixes #23673 
- The `RenderDebugOverlayPlugin` is a `DefaultPlugin` that currently only requires the `bevy_dev_tools` feature. However, under the hood in its `init_render_debug_overlay_pipeline` system, it requires the `MeshPipelineViewLayouts` resource to be initialized. The resource is initialized in the `MeshRenderPlugin` (system `init_mesh_pipeline_view_layouts`). The `MeshRenderPlugin` is part of the `PbrPlugin`, which is a plugin in `DefaultPlugins` that requires the `bevy_pbr` feature. This causes an error when you have a bevy project with `DefaultPlugins`, without default features, and have the `bevy_dev_tools` feature enabled.

## Solution

- The `RenderDebugOverlayPlugin` additionally requires the `bevy_pbr` feature so that it can be included in `DefaultPlugins`. This ensures `MeshPipelineViewLayouts` is initialized so that `RenderDebugOverlayPlugin` can properly initialize.
- If `RenderDebugOverlayPlugin` can be more dexterously changed to still be enabled with just the `bevy_dev_tools` feature, and `bevy_pbr` specific logic can be handled within the plugin itself, then this can PR can be rejected. 

## Testing

- I created a scratch bevy project with the configuration described in the linked issue, but pointing to this branch fix for its bevy dependency. It successfully runs.