### PR TITLE
Optimize texture attachment access by relaxing atomic memory ordering

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -39,6 +39,7 @@ glam = { version = "0.32.0", default-features = false, features = [
 rand = "0.10"
 chacha20 = { version = "0.10.0", default-features = false, features = ["rng"] }
 nonmax = { version = "0.5", default-features = false }
+wgpu = { version = "29.0.1", default-features = false }
 
 [lints.clippy]
 doc_markdown = "warn"

--- a/benches/benches/bevy_render/main.rs
+++ b/benches/benches/bevy_render/main.rs
@@ -2,10 +2,12 @@ use criterion::criterion_main;
 
 mod compute_normals;
 mod render_layers;
+mod texture_attachment;
 mod torus;
 
 criterion_main!(
     render_layers::benches,
     compute_normals::benches,
+    texture_attachment::benches,
     torus::benches
 );

--- a/benches/benches/bevy_render/texture_attachment.rs
+++ b/benches/benches/bevy_render/texture_attachment.rs
@@ -1,0 +1,86 @@
+use bevy_render::render_resource::{Extent3d, StoreOp, TextureFormat, TextureUsages};
+use bevy_render::renderer::RenderDevice;
+use bevy_render::texture::{
+    CachedTexture, ColorAttachment, DepthAttachment, OutputColorAttachment,
+};
+use bevy_tasks::block_on;
+use core::hint::black_box;
+use criterion::{criterion_group, Criterion};
+use wgpu::{
+    Color, DeviceDescriptor, Instance, RequestAdapterOptions, TextureDescriptor, TextureDimension,
+    TextureViewDescriptor,
+};
+
+fn texture_attachment(c: &mut Criterion) {
+    // Setup WGPU device to produce valid texture views for benchmarks
+    let instance = Instance::default();
+    let Ok(adapter) = block_on(instance.request_adapter(&RequestAdapterOptions::default())) else {
+        eprintln!("No WGPU adapter found, skipping texture_attachment benchmark");
+        return;
+    };
+
+    let (device, _) = block_on(adapter.request_device(&DeviceDescriptor::default())).unwrap();
+    let render_device = RenderDevice::from(device);
+
+    // Create a dummy 1x1 texture and view
+    let texture = render_device.create_texture(&TextureDescriptor {
+        label: None,
+        size: Extent3d {
+            width: 1,
+            height: 1,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: TextureDimension::D2,
+        format: TextureFormat::Rgba8Unorm,
+        usage: TextureUsages::RENDER_ATTACHMENT,
+        view_formats: &[],
+    });
+    let view = texture.create_view(&TextureViewDescriptor::default());
+
+    let cached_texture = CachedTexture {
+        texture: texture.clone(),
+        default_view: view.clone(),
+    };
+
+    // Initialize the target attachment structures
+    let color_attachment = ColorAttachment::new(cached_texture.clone(), None, None, None);
+    let depth_attachment = DepthAttachment::new(view.clone(), None);
+    let output_attachment = OutputColorAttachment::new(view.clone(), TextureFormat::Rgba8Unorm);
+
+    let mut group = c.benchmark_group("texture_attachment");
+    group.bench_function("color_attachment_get", |b| {
+        b.iter(|| {
+            black_box(color_attachment.get_attachment());
+        });
+    });
+
+    group.bench_function("depth_attachment_get", |b| {
+        b.iter(|| {
+            black_box(depth_attachment.get_attachment(StoreOp::Store));
+        });
+    });
+
+    group.bench_function("output_color_attachment_get", |b| {
+        b.iter(|| {
+            black_box(output_attachment.get_attachment(None));
+        });
+    });
+
+    group.bench_function("color_attachment_new_and_get", |b| {
+        b.iter(|| {
+            let att = ColorAttachment::new(
+                black_box(cached_texture.clone()),
+                None,
+                None,
+                Some(black_box(Color::BLACK)),
+            );
+            black_box(att.get_attachment());
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, texture_attachment);

--- a/crates/bevy_render/src/texture/texture_attachment.rs
+++ b/crates/bevy_render/src/texture/texture_attachment.rs
@@ -40,7 +40,7 @@ impl ColorAttachment {
     /// The returned attachment will always have writing enabled (`store: StoreOp::Load`).
     pub fn get_attachment(&self) -> RenderPassColorAttachment<'_> {
         if let Some(resolve_target) = self.resolve_target.as_ref() {
-            let first_call = self.is_first_call.fetch_and(false, Ordering::SeqCst);
+            let first_call = self.is_first_call.fetch_and(false, Ordering::Relaxed);
 
             RenderPassColorAttachment {
                 view: &resolve_target.default_view,
@@ -64,7 +64,7 @@ impl ColorAttachment {
     ///
     /// The returned attachment will always have writing enabled (`store: StoreOp::Load`).
     pub fn get_unsampled_attachment(&self) -> RenderPassColorAttachment<'_> {
-        let first_call = self.is_first_call.fetch_and(false, Ordering::SeqCst);
+        let first_call = self.is_first_call.fetch_and(false, Ordering::Relaxed);
 
         RenderPassColorAttachment {
             view: &self.texture.default_view,
@@ -81,7 +81,7 @@ impl ColorAttachment {
     }
 
     pub(crate) fn mark_as_cleared(&self) {
-        self.is_first_call.store(false, Ordering::SeqCst);
+        self.is_first_call.store(false, Ordering::Relaxed);
     }
 }
 
@@ -108,7 +108,7 @@ impl DepthAttachment {
     pub fn get_attachment(&self, store: StoreOp) -> RenderPassDepthStencilAttachment<'_> {
         let first_call = self
             .is_first_call
-            .fetch_and(store != StoreOp::Store, Ordering::SeqCst);
+            .fetch_and(store != StoreOp::Store, Ordering::Relaxed);
 
         RenderPassDepthStencilAttachment {
             view: &self.view,
@@ -148,7 +148,7 @@ impl OutputColorAttachment {
     /// the provided `clear_color` if this is the first time calling this function, otherwise it
     /// will be loaded.
     pub fn get_attachment(&self, clear_color: Option<LinearRgba>) -> RenderPassColorAttachment<'_> {
-        let first_call = self.is_first_call.fetch_and(false, Ordering::SeqCst);
+        let first_call = self.is_first_call.fetch_and(false, Ordering::Relaxed);
 
         RenderPassColorAttachment {
             view: &self.view,
@@ -168,6 +168,6 @@ impl OutputColorAttachment {
     // we re-use is_first_call atomic to track usage, which assumes that calls to get_attachment
     // are always consumed by a render pass that writes to the attachment
     pub fn needs_present(&self) -> bool {
-        !self.is_first_call.load(Ordering::SeqCst)
+        !self.is_first_call.load(Ordering::Relaxed)
     }
 }


### PR DESCRIPTION
# Objective

- The objective of this PR is to improve the performance of texture attachment retrieval within the rendering pipeline.
- It addresses unnecessary overhead caused by strict atomic synchronization when tracking the "first call" state of attachments.

## Solution

- Changed the memory ordering for `is_first_call` atomic operations from `Ordering::SeqCst` to `Ordering::Relaxed`.

Rationale: `is_first_call` is only used to answer a simple question: "Am I the first thread to request this attachment for a render pass?". Because the surrounding data (the texture view, format, clear color) is already fully initialized and completely immutable by the time this is called, there is no dependent memory that requires synchronization. The `fetch_and(false)` itself is atomic, meaning it will safely return `true` exactly once, no matter how many threads call it concurrently. `Relaxed` memory ordering is correct for given scenario.

## Testing

- Added benchmarks comparing the previous SeqCst implementation against the Relaxed implementation.

`cargo bench -p benches --bench render -- texture_attachment`

---

```
texture_attachment/color_attachment_get
                        time:   [1.7758 ns 1.7833 ns 1.7909 ns]
                        change: [−45.886% −44.975% −44.042%] (p = 0.00 < 0.05)
                        Performance has improved.
texture_attachment/depth_attachment_get
                        time:   [2.3377 ns 2.3486 ns 2.3602 ns]
                        change: [−1.9965% −1.0377% −0.1363%] (p = 0.03 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
texture_attachment/output_color_attachment_get
                        time:   [1.7992 ns 1.8058 ns 1.8125 ns]
                        change: [−1.5831% −0.9112% −0.2491%] (p = 0.01 < 0.05)
                        Change within noise threshold.
texture_attachment/color_attachment_new_and_get
                        time:   [56.642 ns 57.698 ns 58.719 ns]
                        change: [+0.0036% +1.6169% +3.3741%] (p = 0.05 < 0.05)
                        Change within noise threshold.

```