### PR TITLE
Rename `FeathersPlugin` to `FeathersCorePlugin`

### DIFF
--- a/_release-content/migration-guides/rename-feathers-plugin.md
+++ b/_release-content/migration-guides/rename-feathers-plugin.md
@@ -1,6 +1,6 @@
 ---
 title: Rename `FeathersPlugin` to `FeathersCorePlugin`
-pull_requests: [TODO]
+pull_requests: [23771]
 ---
 
 `FeathersPlugin` has been renamed to `FeathersCorePlugin` to reduce confusion with `FeathersPlugins`, the `PluginGroup`.

--- a/_release-content/migration-guides/rename-feathers-plugin.md
+++ b/_release-content/migration-guides/rename-feathers-plugin.md
@@ -1,0 +1,6 @@
+---
+title: Rename `FeathersPlugin` to `FeathersCorePlugin`
+pull_requests: [TODO]
+---
+
+`FeathersPlugin` has been renamed to `FeathersCorePlugin` to reduce confusion with `FeathersPlugins`, the `PluginGroup`.

--- a/crates/bevy_feathers/src/lib.rs
+++ b/crates/bevy_feathers/src/lib.rs
@@ -56,9 +56,9 @@ pub mod theme;
 pub mod tokens;
 
 /// Plugin which installs observers and systems for feathers themes, cursors, and all controls.
-pub struct FeathersPlugin;
+pub struct FeathersCorePlugin;
 
-impl Plugin for FeathersPlugin {
+impl Plugin for FeathersCorePlugin {
     fn build(&self, app: &mut bevy_app::App) {
         app.init_resource::<UiTheme>();
 
@@ -110,6 +110,6 @@ impl PluginGroup for FeathersPlugins {
     fn build(self) -> PluginGroupBuilder {
         PluginGroupBuilder::start::<Self>()
             .add(TabNavigationPlugin)
-            .add(FeathersPlugin)
+            .add(FeathersCorePlugin)
     }
 }


### PR DESCRIPTION
# Objective

`FeathersPlugin` is extremely similar to `FeathersPlugins`. This is particularly bad because they can both be added via `.add_plugins`.

Fixes #21213.

## Solution

Rename to `FeathersCorePlugin`. It's a perfectly inoffensive name, and will not be accidentally confused.