### PR TITLE
Swap to orthographic perspective when aligning freecam to axes

### DIFF
--- a/crates/bevy_camera_controller/src/free_camera.rs
+++ b/crates/bevy_camera_controller/src/free_camera.rs
@@ -16,7 +16,7 @@
 // TODO: Discuss switching camera to orthographic mode.
 
 use bevy_app::{App, Plugin, RunFixedMainLoop, RunFixedMainLoopSystems};
-use bevy_camera::Camera;
+use bevy_camera::{Camera, OrthographicProjection, Projection};
 use bevy_ecs::prelude::*;
 use bevy_input::keyboard::KeyCode;
 use bevy_input::mouse::{
@@ -45,8 +45,13 @@ impl Plugin for FreeCameraPlugin {
         // This ordering is required so that both fixed update and update systems can see the results correctly
         app.add_systems(
             RunFixedMainLoop,
-            (run_freecamera_controller, rotate_freecam_to)
-                .chain()
+            (
+                run_freecamera_controller,
+                // These systems do not have a dependency on each other,
+                // so we should not use .chain() to order them
+                rotate_freecam_to.after(run_freecamera_controller),
+                snap_freecam_projection.after(run_freecamera_controller),
+            )
                 .in_set(RunFixedMainLoopSystems::BeforeFixedMainLoop),
         );
     }
@@ -236,7 +241,7 @@ impl Default for FreeCameraState {
     }
 }
 
-/// A state machine that represents the current motion state of the free camera,
+/// A state machine representing the current motion state of the free camera,
 /// used to determine how to update the camera's perspective projection and orientation.
 ///
 /// Stored in [`FreeCameraState`] and updated by the [`FreeCameraPlugin`] systems in response to user input.
@@ -246,13 +251,24 @@ pub enum FreeCamMotion {
     /// The camera is snapping to a predefined orientation.
     Snapping {
         /// Dictates camera movement during camera snap at speed, specified in [`FreeCamera`] by [`FreeCamera::rotation_speed`] field.
-        /// Consist of counter of seconds from pressing curve snap hotkeys and curve that used to interpolate between old and new rotation
+        ///
+        /// The first argument tracks the seconds since this state was enterered.
+        /// The second argument is the curve that used to interpolate between old and new rotation.
         rotation_curve: (f32, SampleAutoCurve<Quat>),
+        /// The previous projection before snapping, used to restore the original projection when returning to free camera mode.
+        previous_projection: Projection,
     },
     /// The camera's orientation is at rest, locked to a predefined orientation.
-    Snapped,
+    Snapped {
+        /// The previous projection before snapping, used to restore the original projection when returning to free camera mode.
+        previous_projection: Projection,
+    },
+    /// The camera is returning to free movement after being snapped to an axis.
+    Returning {
+        /// The previous projection before snapping, used to restore the original projection when returning to free camera mode.
+        previous_projection: Projection,
+    },
 }
-
 /// Updates the camera's position and orientation based on user input.
 ///
 /// - [`FreeCamera`] contains static configuration such as key bindings, movement speed, and sensitivity.
@@ -271,11 +287,19 @@ pub fn run_freecamera_controller(
     key_input: Res<ButtonInput<KeyCode>>,
     mut toggle_cursor_grab: Local<bool>,
     mut mouse_cursor_grab: Local<bool>,
-    free_cam: Single<(&mut Transform, &mut FreeCameraState, &FreeCamera), With<Camera>>,
+    free_cam: Single<
+        (
+            &mut Transform,
+            &mut FreeCameraState,
+            &FreeCamera,
+            &Projection,
+        ),
+        With<Camera>,
+    >,
 ) {
     let dt = time.delta_secs();
 
-    let (mut transform, mut state, config) = free_cam.into_inner();
+    let (mut transform, mut state, config, projection) = free_cam.into_inner();
     if !state.initialized {
         let (yaw, pitch, _roll) = transform.rotation.to_euler(EulerRot::YXZ);
         state.yaw = yaw;
@@ -393,7 +417,14 @@ pub fn run_freecamera_controller(
     // Handle mouse input
     if accumulated_mouse_motion.delta != Vec2::ZERO && cursor_grab {
         // Update our state machine
-        state.motion_state = FreeCamMotion::Free;
+        if let FreeCamMotion::Snapped {
+            previous_projection,
+        } = &state.motion_state
+        {
+            state.motion_state = FreeCamMotion::Returning {
+                previous_projection: previous_projection.clone(),
+            };
+        }
 
         // Apply look update
         state.pitch = (state.pitch
@@ -438,16 +469,18 @@ pub fn run_freecamera_controller(
     }
 
     if let Some((dir, up)) = rotate_to {
-        let start = transform.rotation;
-        let target = Transform::default().looking_to(dir, up).rotation; // I don't understand why Quat::look_to_rh produce different result.
-        let angle = target.angle_between(start);
+        let rotation_start = transform.rotation;
+        let rotation_target = Transform::default().looking_to(dir, up).rotation; // I don't understand why Quat::look_to_rh produce different result.
+        let angle = rotation_target.angle_between(rotation_start);
         let rotation_time = angle / config.rotation_speed;
 
         if let Ok(interval) = Interval::new(0.0, rotation_time) {
-            let curve = SampleAutoCurve::new(interval, [start, target])
-                .expect("Interval should be in bounds as start and end are finite numbers");
+            let rotation_curve =
+                SampleAutoCurve::new(interval, [rotation_start, rotation_target]).unwrap();
+
             state.motion_state = FreeCamMotion::Snapping {
-                rotation_curve: (0.0, curve),
+                rotation_curve: (0.0, rotation_curve),
+                previous_projection: projection.clone(),
             };
         }
     }
@@ -470,6 +503,8 @@ pub fn rotate_freecam_to(
 
     let FreeCamMotion::Snapping {
         rotation_curve: (progress, curve),
+        previous_projection,
+        ..
     } = &mut state.motion_state
     else {
         return;
@@ -478,9 +513,32 @@ pub fn rotate_freecam_to(
     *progress += time.delta_secs();
     transform.rotation = curve.sample_clamped(*progress);
     if !curve.domain().contains(*progress) {
-        state.motion_state = FreeCamMotion::Snapped;
+        state.motion_state = FreeCamMotion::Snapped {
+            previous_projection: previous_projection.clone(),
+        };
     }
     let (yaw, pitch, _roll) = transform.rotation.to_euler(EulerRot::YXZ);
     state.pitch = pitch;
     state.yaw = yaw;
+}
+
+/// Snaps the projection of the [`FreeCamera`] camera when transitioning between [`FreeCamMotion::Snapped`] and [`FreeCamMotion::Free`].
+// TODO: this should smoothly warp the projection instead of snapping it
+pub fn snap_freecam_projection(
+    free_cam: Single<(&mut FreeCameraState, &mut Projection), With<Camera>>,
+) {
+    let (mut state, mut projection) = free_cam.into_inner();
+
+    match &mut state.motion_state {
+        FreeCamMotion::Snapped { .. } => {
+            *projection = Projection::Orthographic(OrthographicProjection::default_3d());
+        }
+        FreeCamMotion::Returning {
+            previous_projection,
+        } => {
+            *projection = previous_projection.clone();
+            state.motion_state = FreeCamMotion::Free;
+        }
+        FreeCamMotion::Free | FreeCamMotion::Snapping { .. } => {}
+    }
 }

--- a/crates/bevy_camera_controller/src/free_camera.rs
+++ b/crates/bevy_camera_controller/src/free_camera.rs
@@ -218,9 +218,8 @@ pub struct FreeCameraState {
     pub speed_multiplier: f32,
     /// This [`FreeCamera`]'s translation velocity.
     pub velocity: Vec3,
-    /// Dictates camera movement during camera snap at speed, specified in [`FreeCamera`] by [`FreeCamera::rotation_speed`] field.
-    /// Consist of counter of seconds from pressing curve snap hotkeys and curve that used to interpolate between old and new rotation
-    pub rotation_curve: Option<(f32, SampleAutoCurve<Quat>)>,
+    /// The current motion state of the free camera, used to determine how to update the camera's perspective projection and orientation.
+    pub motion_state: FreeCamMotion,
 }
 
 impl Default for FreeCameraState {
@@ -232,9 +231,26 @@ impl Default for FreeCameraState {
             yaw: 0.0,
             speed_multiplier: 1.0,
             velocity: Vec3::ZERO,
-            rotation_curve: None,
+            motion_state: FreeCamMotion::Free,
         }
     }
+}
+
+/// A state machine that represents the current motion state of the free camera,
+/// used to determine how to update the camera's perspective projection and orientation.
+///
+/// Stored in [`FreeCameraState`] and updated by the [`FreeCameraPlugin`] systems in response to user input.
+pub enum FreeCamMotion {
+    /// The camera is moving freely based on user input.
+    Free,
+    /// The camera is snapping to a predefined orientation.
+    Snapping {
+        /// Dictates camera movement during camera snap at speed, specified in [`FreeCamera`] by [`FreeCamera::rotation_speed`] field.
+        /// Consist of counter of seconds from pressing curve snap hotkeys and curve that used to interpolate between old and new rotation
+        rotation_curve: (f32, SampleAutoCurve<Quat>),
+    },
+    /// The camera's orientation is at rest, locked to a predefined orientation.
+    Snapped,
 }
 
 /// Updates the camera's position and orientation based on user input.
@@ -379,6 +395,9 @@ pub fn run_freecamera_controller(
 
     // Handle mouse input
     if accumulated_mouse_motion.delta != Vec2::ZERO && cursor_grab {
+        // Update our state machine
+        state.motion_state = FreeCamMotion::Free;
+
         // Apply look update
         state.pitch = (state.pitch
             - accumulated_mouse_motion.delta.y * RADIANS_PER_DOT * config.sensitivity)
@@ -420,6 +439,7 @@ pub fn run_freecamera_controller(
             rotate_to = Some((Dir3::Y, Dir3::Z));
         }
     }
+
     if let Some((dir, up)) = rotate_to {
         let start = transform.rotation;
         let target = Transform::default().looking_to(dir, up).rotation; // I don't understand why Quat::look_to_rh produce different result.
@@ -429,7 +449,9 @@ pub fn run_freecamera_controller(
         if let Ok(interval) = Interval::new(0.0, rotation_time) {
             let curve = SampleAutoCurve::new(interval, [start, target])
                 .expect("Interval should be in bounds as start and end are finite numbers");
-            state.rotation_curve = Some((0.0, curve));
+            state.motion_state = FreeCamMotion::Snapping {
+                rotation_curve: (0.0, curve),
+            };
         }
     }
 }
@@ -450,13 +472,18 @@ pub fn rotate_freecam_to(
     if !state.enabled {
         return;
     }
-    let Some((progress, curve)) = state.rotation_curve.as_mut() else {
+
+    let FreeCamMotion::Snapping {
+        rotation_curve: (progress, curve),
+    } = &mut state.motion_state
+    else {
         return;
     };
+
     *progress += time.delta_secs();
     transform.rotation = curve.sample_clamped(*progress);
     if !curve.domain().contains(*progress) {
-        state.rotation_curve = None;
+        state.motion_state = FreeCamMotion::Snapped;
     }
     let (yaw, pitch, _roll) = transform.rotation.to_euler(EulerRot::YXZ);
     state.pitch = pitch;

--- a/crates/bevy_camera_controller/src/free_camera.rs
+++ b/crates/bevy_camera_controller/src/free_camera.rs
@@ -47,11 +47,10 @@ impl Plugin for FreeCameraPlugin {
             RunFixedMainLoop,
             (
                 run_freecamera_controller,
-                // These systems do not have a dependency on each other,
-                // so we should not use .chain() to order them
-                rotate_freecam_to.after(run_freecamera_controller),
-                snap_freecam_projection.after(run_freecamera_controller),
+                rotate_freecam_to,
+                snap_freecam_projection,
             )
+                .chain()
                 .in_set(RunFixedMainLoopSystems::BeforeFixedMainLoop),
         );
     }
@@ -252,7 +251,7 @@ pub enum FreeCamMotion {
     Snapping {
         /// Dictates camera movement during camera snap at speed, specified in [`FreeCamera`] by [`FreeCamera::rotation_speed`] field.
         ///
-        /// The first argument tracks the seconds since this state was enterered.
+        /// The first argument tracks the seconds since this state was entered.
         /// The second argument is the curve that used to interpolate between old and new rotation.
         rotation_curve: (f32, SampleAutoCurve<Quat>),
         /// The previous projection before snapping, used to restore the original projection when returning to free camera mode.
@@ -269,6 +268,7 @@ pub enum FreeCamMotion {
         previous_projection: Projection,
     },
 }
+
 /// Updates the camera's position and orientation based on user input.
 ///
 /// - [`FreeCamera`] contains static configuration such as key bindings, movement speed, and sensitivity.
@@ -437,6 +437,16 @@ pub fn run_freecamera_controller(
     // Handle touch input
     for touch in touch_input.iter() {
         if touch.delta() != Vec2::ZERO {
+            // Update our state machine
+            if let FreeCamMotion::Snapped {
+                previous_projection,
+            } = &state.motion_state
+            {
+                state.motion_state = FreeCamMotion::Returning {
+                    previous_projection: previous_projection.clone(),
+                };
+            }
+
             state.pitch = (state.pitch - touch.delta().y * RADIANS_PER_DOT * config.sensitivity)
                 .clamp(-PI / 2., PI / 2.);
             state.yaw -= touch.delta().x * RADIANS_PER_DOT * config.sensitivity;
@@ -475,12 +485,31 @@ pub fn run_freecamera_controller(
         let rotation_time = angle / config.rotation_speed;
 
         if let Ok(interval) = Interval::new(0.0, rotation_time) {
+            // Do not overwrite a stored projection
+            // We only want to log the projection if we are using the user-defined projection,
+            // not if have already snapped / are snapping
+            let previous_projection = match &state.motion_state {
+                FreeCamMotion::Free => projection,
+                FreeCamMotion::Snapping {
+                    previous_projection,
+                    ..
+                }
+                | FreeCamMotion::Returning {
+                    previous_projection,
+                    ..
+                }
+                | FreeCamMotion::Snapped {
+                    previous_projection,
+                    ..
+                } => previous_projection,
+            };
+
             let rotation_curve =
                 SampleAutoCurve::new(interval, [rotation_start, rotation_target]).unwrap();
 
             state.motion_state = FreeCamMotion::Snapping {
                 rotation_curve: (0.0, rotation_curve),
-                previous_projection: projection.clone(),
+                previous_projection: previous_projection.clone(),
             };
         }
     }
@@ -531,6 +560,14 @@ pub fn snap_freecam_projection(
 
     match &mut state.motion_state {
         FreeCamMotion::Snapped { .. } => {
+            // Avoid constantly mutating the projection if it is already in the desired state
+            if matches!(
+                // Ensure that this check itself does not trigger change detection!
+                projection.bypass_change_detection(),
+                Projection::Orthographic(..)
+            ) {
+                return;
+            }
             *projection = Projection::Orthographic(OrthographicProjection::default_3d());
         }
         FreeCamMotion::Returning {

--- a/crates/bevy_camera_controller/src/free_camera.rs
+++ b/crates/bevy_camera_controller/src/free_camera.rs
@@ -167,7 +167,7 @@ impl fmt::Display for FreeCamera {
             f,
             "
 Freecam Controls:
-    Mouse - Move camera orientation
+    Mouse - Change camera orientation when cursor grabbed
     Scroll - Adjust movement speed
     {:?} - Hold to grab cursor
     {:?} - Toggle cursor grab
@@ -175,9 +175,9 @@ Freecam Controls:
     {:?} & {:?} - Fly sideways left & right
     {:?} & {:?} - Fly up & down
     {:?} - Fly faster while held
-    [{:?} +] {:?} - Snap to Up (+Y)/Down (-Y)
-    [{:?} +] {:?} - Snap to Right (+X)/Left (-X)
-    [{:?} +] {:?} - Snap to Front (-Z)/Back (+Z)",
+    [{:?} +] {:?} - Snap to +Y Axis (Up) / -Y Axis (Down)
+    [{:?} +] {:?} - Snap to +X Axis (Right) / -X Axis (Left)
+    [{:?} +] {:?} - Snap to +Z Axis (Front) / -Z Axis (Back)",
             self.mouse_key_cursor_grab,
             self.keyboard_key_toggle_cursor_grab,
             self.key_forward,

--- a/crates/bevy_camera_controller/src/free_camera.rs
+++ b/crates/bevy_camera_controller/src/free_camera.rs
@@ -166,18 +166,18 @@ impl fmt::Display for FreeCamera {
         write!(
             f,
             "
-Freecamera Controls:
-    Mouse\t- Move camera orientation
-    Scroll\t- Adjust movement speed
-    {:?}\t- Hold to grab cursor
-    {:?}\t- Toggle cursor grab
-    {:?} & {:?}\t- Fly forward & backwards
-    {:?} & {:?}\t- Fly sideways left & right
-    {:?} & {:?}\t- Fly up & down
-    {:?}\t- Fly faster while held
-    [{:?} + ]{:?}\t- Snap to Up (+Y)/Down (-Y)
-    [{:?} + ]{:?}\t- Snap to Right (+X)/Left (-X)
-    [{:?} + ]{:?}\t- Snap to Front (-Z)/Back (+Z)",
+Freecam Controls:
+    Mouse - Move camera orientation
+    Scroll - Adjust movement speed
+    {:?} - Hold to grab cursor
+    {:?} - Toggle cursor grab
+    {:?} & {:?} - Fly forward & backwards
+    {:?} & {:?} - Fly sideways left & right
+    {:?} & {:?} - Fly up & down
+    {:?} - Fly faster while held
+    [{:?} +] {:?} - Snap to Up (+Y)/Down (-Y)
+    [{:?} +] {:?} - Snap to Right (+X)/Left (-X)
+    [{:?} +] {:?} - Snap to Front (-Z)/Back (+Z)",
             self.mouse_key_cursor_grab,
             self.keyboard_key_toggle_cursor_grab,
             self.key_forward,

--- a/crates/bevy_camera_controller/src/free_camera.rs
+++ b/crates/bevy_camera_controller/src/free_camera.rs
@@ -271,14 +271,11 @@ pub fn run_freecamera_controller(
     key_input: Res<ButtonInput<KeyCode>>,
     mut toggle_cursor_grab: Local<bool>,
     mut mouse_cursor_grab: Local<bool>,
-    mut query: Query<(&mut Transform, &mut FreeCameraState, &FreeCamera), With<Camera>>,
+    free_cam: Single<(&mut Transform, &mut FreeCameraState, &FreeCamera), With<Camera>>,
 ) {
     let dt = time.delta_secs();
 
-    let Ok((mut transform, mut state, config)) = query.single_mut() else {
-        return;
-    };
-
+    let (mut transform, mut state, config) = free_cam.into_inner();
     if !state.initialized {
         let (yaw, pitch, _roll) = transform.rotation.to_euler(EulerRot::YXZ);
         state.yaw = yaw;
@@ -463,12 +460,10 @@ pub fn run_freecamera_controller(
 ///
 /// This system is typically added via the [`FreeCameraPlugin`].
 pub fn rotate_freecam_to(
-    mut query: Query<(&mut Transform, &mut FreeCameraState), With<Camera>>,
+    free_cam: Single<(&mut Transform, &mut FreeCameraState), With<Camera>>,
     time: Res<Time<Real>>,
 ) {
-    let Ok((mut transform, mut state)) = query.single_mut() else {
-        return;
-    };
+    let (mut transform, mut state) = free_cam.into_inner();
     if !state.enabled {
         return;
     }


### PR DESCRIPTION
# Objective

Analogous snap-to-view functionality in other softer changes the camera into orthographic mode.
This is very helpful

Fixes #23697.

## Solution

- Do a light code-quality pass on the existing camera controller to make changes and testing easier.
- Swap to an explicit state-machine for managing the camera controller's movement.
- Carefully record the previous projection so we can return to it.
- When swapping to axes is complete, set the projection to orthographic.
- When returning to unlocked-axis-mode (`Free`), restore the previous projection.

I've opted to leave "smooth interpolation to/from orthographic" for future work. It's nice to have, but this PR is already a healthy size.

## Testing

`cargo run --example free_camera_controller --features="free_camera"`

## Help Needed

The example itself seems quite broken when using an orthographic projection.

At first, I thought that this was a problem with my logic, but no, simply inserting `Perspective::Orthographic(OrthographicProjection::default_3d())` onto the camera breaks things.

In the default view, nothing appears. Moving the viewport around, you get something like the following:

<img width="561" height="345" alt="image" src="https://github.com/user-attachments/assets/4f69de5e-405b-4e41-869e-953bb3caede9" />

I can reproduce this behavior when using the PR as submitted, but you do need to look around a bit to see anything other than the clear color.

I don't know how why this is occurring, or how wide-spread this problem is, but we need to fix it before we can merge this PR.