### PR TITLE
Rename Font::try_from_bytes to from_bytes

### DIFF
--- a/_release-content/migration-guides/rename_font_from_bytes.md
+++ b/_release-content/migration-guides/rename_font_from_bytes.md
@@ -1,6 +1,6 @@
 ---
 title: Rename `Font::try_from_bytes` to `Font::from_bytes`
-pull_requests: [23777]
+pull_requests: [22879, 23777]
 ---
 
 `Font::try_from_bytes` has been renamed to `Font::from_bytes` to reflect that it no longer returns `Result`.

--- a/_release-content/migration-guides/rename_font_from_bytes.md
+++ b/_release-content/migration-guides/rename_font_from_bytes.md
@@ -1,0 +1,16 @@
+---
+title: Rename `Font::try_from_bytes` to `Font::from_bytes`
+pull_requests: [23777]
+---
+
+`Font::try_from_bytes` has been renamed to `Font::from_bytes` to reflect that it no longer returns `Result`.
+
+```rust
+// 0.18
+let font = Font::try_from_bytes(bytes.to_vec()).unwrap();
+
+// 0.19
+let font = Font::from_bytes(bytes.to_vec(), "MyFontFamily");
+```
+
+Note that the family name is not part of this specific change, but is required in 0.19.

--- a/crates/bevy_sprite/src/text2d.rs
+++ b/crates/bevy_sprite/src/text2d.rs
@@ -435,9 +435,7 @@ mod tests {
             app,
             Handle::default(),
             "../../bevy_text/src/FiraMono-subset.ttf",
-            |bytes: &[u8], _path: String| {
-                Font::try_from_bytes(bytes.to_vec(), "bevy default font")
-            }
+            |bytes: &[u8], _path: String| { Font::from_bytes(bytes.to_vec(), "bevy default font") }
         );
 
         let world = app.world_mut();

--- a/crates/bevy_text/src/font.rs
+++ b/crates/bevy_text/src/font.rs
@@ -36,7 +36,7 @@ pub struct Font {
 
 impl Font {
     /// Creates a [`Font`] from bytes
-    pub fn try_from_bytes(font_data: Vec<u8>, family_name: &str) -> Font {
+    pub fn from_bytes(font_data: Vec<u8>, family_name: &str) -> Font {
         Self {
             data: Blob::from(font_data),
             family_name: family_name.into(),

--- a/crates/bevy_text/src/font_loader.rs
+++ b/crates/bevy_text/src/font_loader.rs
@@ -32,7 +32,7 @@ impl AssetLoader for FontLoader {
         let path = load_context.path();
         let mut bytes = Vec::new();
         reader.read_to_end(&mut bytes).await?;
-        let font = Font::try_from_bytes(bytes, &path.to_string());
+        let font = Font::from_bytes(bytes, &path.to_string());
         Ok(font)
     }
 

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -128,7 +128,7 @@ impl Plugin for TextPlugin {
         {
             use bevy_asset::{AssetId, Assets};
             let mut assets = app.world_mut().resource_mut::<Assets<Font>>();
-            let asset = Font::try_from_bytes(DEFAULT_FONT_DATA.to_vec(), "bevy default font");
+            let asset = Font::from_bytes(DEFAULT_FONT_DATA.to_vec(), "bevy default font");
             assets.insert(AssetId::default(), asset).unwrap();
         };
     }


### PR DESCRIPTION
# Objective

Names beginning in `try_` (i.e. `Font::try_from_bytes` in this case) imply that they are fallible - that is, they return an `Option` or `Result` if the constructor fails while checking invariants. This method used to return a `Result`, but no longer does after the recent change to using `parley`.

## Solution

This PR renames the method to `from_bytes` to convey that it's now infallible.

## Testing

I switched to my fork locally for my game, and it works with the new name. There isn't much to test here.

However, this _is_ technically a breaking change to the API (but so is the existing change on the main branch, so it should be fine).
