### PR TITLE
fix(settings wasm): fix compilation errors / match store_fs fn signatures

### DIFF
--- a/crates/bevy_settings/src/store_wasm.rs
+++ b/crates/bevy_settings/src/store_wasm.rs
@@ -1,5 +1,3 @@
-use crate::prefs_file::serialize_table;
-use crate::{prefs::PreferencesStore, PreferencesFile, PreferencesFileContent};
 use bevy_log::error;
 use bevy_tasks::IoTaskPool;
 use web_sys::window;
@@ -31,9 +29,9 @@ impl PreferencesStore {
     /// # Arguments
     /// * `filename` - the name of the file to be saved
     /// * `contents` - the contents of the file
-    pub(crate) fn save(&self, filename: &str, contents: &PreferencesFile) {
+    pub(crate) fn save(&self, filename: &str, contents: toml::Table) {
         if let Ok(Some(storage)) = window().unwrap().local_storage() {
-            let toml_str = serialize_table(&contents.table);
+            let toml_str = contents.to_string();
             storage
                 .set_item(&self.storage_key(filename).as_str(), &toml_str)
                 .unwrap();
@@ -45,11 +43,11 @@ impl PreferencesStore {
     /// # Arguments
     /// * `filename` - the name of the file to be saved
     /// * `contents` - the contents of the file
-    pub(crate) fn save_async(&self, filename: &str, contents: PreferencesFileContent) {
+    pub(crate) fn save_async(&self, filename: &str, contents: toml::Table) {
         IoTaskPool::get().scope(|scope| {
             scope.spawn(async {
                 if let Ok(Some(storage)) = window().unwrap().local_storage() {
-                    let toml_str = serialize_table(&contents.0);
+                    let toml_str = contents.to_string();
                     storage
                         .set_item(&self.storage_key(filename).as_str(), &toml_str)
                         .unwrap();
@@ -63,7 +61,7 @@ impl PreferencesStore {
     ///
     /// # Arguments
     /// * `filename` - The name of the preferences file, without the file extension.
-    pub(crate) fn load(&mut self, filename: &str) -> Option<PreferencesFile> {
+    pub(crate) fn load(&self, filename: &str) -> Option<toml::Table> {
         if let Ok(Some(storage)) = window().unwrap().local_storage() {
             let storage_key = self.storage_key(filename);
             let Ok(Some(toml_str)) = storage.get_item(&storage_key) else {
@@ -79,7 +77,7 @@ impl PreferencesStore {
             };
 
             match table_value {
-                toml::Value::Table(table) => Some(PreferencesFile::from_table(table)),
+                toml::Value::Table(table) => Some(table),
                 _ => {
                     error!("Preferences file must be a table");
                     None


### PR DESCRIPTION
# Objective

- Unblock #23719 - The PR revealed that wasm builds are currently broken for `bevy_settings` when trying to merge to main.
- On main, if you try to build an example that requires `bevy_settings` for wasm targets, it fails with the same compilation error (i.e. `cargo build --release --example persisting_preferences --target wasm32-unknown-unknown --features=“bevy_settings”`)

## Solution

- Fix up `store_wasm.rs`. The function signatures should match those in `store_fs.rs`, and remove any references that do not exist.

## Testing

- With the `Cargo.toml` change from #23719, was able to build the wasm target described in Objective successfully. Then, prepared the wasm target and served it locally following the examples/README.md directions. The example works as expected for web interactions.