### PR TITLE
fix(wireframes): only set depth bias when topology is triangles

### DIFF
--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -746,7 +746,10 @@ impl SpecializedMeshPipeline for Wireframe3dPipeline {
         layout: &MeshVertexBufferLayoutRef,
     ) -> Result<RenderPipelineDescriptor, SpecializedMeshPipelineError> {
         let mut descriptor = self.mesh_pipeline.specialize(key.mesh_key, layout)?;
-        descriptor.depth_stencil.as_mut().unwrap().bias.slope_scale = 1.0;
+
+        if descriptor.primitive.topology.is_triangles() {
+            descriptor.depth_stencil.as_mut().unwrap().bias.slope_scale = 1.0;
+        }
 
         if key.wide {
             descriptor.label = Some("wireframe_3d_wide_pipeline".into());

--- a/crates/bevy_sprite_render/src/mesh2d/wireframe2d.rs
+++ b/crates/bevy_sprite_render/src/mesh2d/wireframe2d.rs
@@ -346,7 +346,9 @@ impl SpecializedMeshPipeline for Wireframe2dPipeline {
         let fragment = descriptor.fragment.as_mut().unwrap();
         fragment.shader = self.shader.clone();
         descriptor.primitive.polygon_mode = PolygonMode::Line;
-        descriptor.depth_stencil.as_mut().unwrap().bias.slope_scale = 1.0;
+        if descriptor.primitive.topology.is_triangles() {
+            descriptor.depth_stencil.as_mut().unwrap().bias.slope_scale = 1.0;
+        }
         Ok(descriptor)
     }
 }


### PR DESCRIPTION
# Objective

- Fixes #23772 
- Fixes #23774 
- Fixes wireframe plugins. wgpu added some validation around `DepthBiasState`:
```rust
            if (ds.bias.is_enabled() || ds.bias.clamp != 0.0)
                && !desc.primitive.topology.is_triangles()
            {
                return Err(pipeline::CreateRenderPipelineError::DepthStencilState(
                    pipeline::DepthStencilStateError::DepthBiasWithIncompatibleTopology(
                        desc.primitive.topology,
                    ),
                ));
            }
```
`ds.bias.is_enabled()` returns true if either `constant` and `slope_scale` are non zero values.
This was causing the following error message when running the `2d_shapes` and `3d_shapes` examples (the following msg is for `3d_shapes`)

```
2026-04-13T05:14:12.638678Z ERROR bevy_render::error_handler: Caught rendering error: Validation Error

Caused by:
  In Device::create_render_pipeline, label = 'wireframe_3d_pipeline'
    Depth/stencil state is invalid
      Depth bias is not compatible with non-triangle topology LineList
```

## Solution

- Wireframe plugins should only set the depth bias’ `slope_scale` to a non-zero value if the topology *is* triangles. This complies with the validation done in wgpu.

## Testing

- I can now turn on the wireframes in `cargo run --example 2d_shapes` and `cargo run --example 3d_shapes` 