### PR TITLE
Fix documentation error

### DIFF
--- a/crates/bevy_world_serialization/src/components.rs
+++ b/crates/bevy_world_serialization/src/components.rs
@@ -12,7 +12,7 @@ use crate::{DynamicWorld, WorldAsset};
 /// Adding this component will spawn the world as a child of that entity.
 /// Once it's spawned, the entity will have a [`WorldInstance`](crate::WorldInstance) component.
 ///
-/// Note: This was recently renamed from `WorldAssetRoot`, in the interest of giving "scene" terminology to
+/// Note: This was recently renamed from `SceneRoot`, in the interest of giving "scene" terminology to
 /// Bevy's next generation scene system, available in `bevy_scene`.
 #[derive(
     Component, FromTemplate, Clone, Debug, Default, Deref, DerefMut, Reflect, PartialEq, Eq, From,


### PR DESCRIPTION
WorldAssetRoot was in fact not previously called WorldAssetRoot, but SceneRoot ;)
