### PR TITLE
Insert ResolvedScenes as dynamic bundles

### DIFF
--- a/benches/benches/bevy_scene/spawn.rs
+++ b/benches/benches/bevy_scene/spawn.rs
@@ -1,5 +1,6 @@
 use bevy_reflect::TypePath;
 use criterion::{criterion_group, Criterion};
+use glam::Mat4;
 use std::{path::Path, time::Duration};
 
 use bevy_app::App;
@@ -56,6 +57,16 @@ fn ui_loaded_asset() -> impl Scene {
 #[derive(Component, Default, Clone)]
 struct Marker;
 
+#[derive(Component, Default, Clone)]
+#[expect(unused, reason = "this exists to take up space")]
+struct Marker1(Mat4);
+#[derive(Component, Default, Clone)]
+#[expect(unused, reason = "this exists to take up space")]
+struct Marker2(Mat4);
+#[derive(Component, Default, Clone)]
+#[expect(unused, reason = "this exists to take up space")]
+struct Marker3(Mat4);
+
 fn button() -> impl Scene {
     bsn! {
         Button
@@ -67,16 +78,16 @@ fn button() -> impl Scene {
             align_items: AlignItems::Center,
         }
         Children [
-            (Text("Text") Marker),
-            (Text("Text") Marker),
-            (Text("Text") Marker),
-            (Text("Text") Marker),
-            (Text("Text") Marker),
-            (Text("Text") Marker),
-            (Text("Text") Marker),
-            (Text("Text") Marker),
-            (Text("Text") Marker),
-            (Text("Text") Marker),
+            (Text("Text") Marker Marker1 Marker2 Marker3),
+            (Text("Text") Marker Marker1 Marker2 Marker3),
+            (Text("Text") Marker Marker1 Marker2 Marker3),
+            (Text("Text") Marker Marker1 Marker2 Marker3),
+            (Text("Text") Marker Marker1 Marker2 Marker3),
+            (Text("Text") Marker Marker1 Marker2 Marker3),
+            (Text("Text") Marker Marker1 Marker2 Marker3),
+            (Text("Text") Marker Marker1 Marker2 Marker3),
+            (Text("Text") Marker Marker1 Marker2 Marker3),
+            (Text("Text") Marker Marker1 Marker2 Marker3),
         ]
     }
 }
@@ -93,16 +104,76 @@ fn raw_button() -> impl Bundle {
             ..Default::default()
         },
         children![
-            (Text("Text".into()), Marker),
-            (Text("Text".into()), Marker),
-            (Text("Text".into()), Marker),
-            (Text("Text".into()), Marker),
-            (Text("Text".into()), Marker),
-            (Text("Text".into()), Marker),
-            (Text("Text".into()), Marker),
-            (Text("Text".into()), Marker),
-            (Text("Text".into()), Marker),
-            (Text("Text".into()), Marker),
+            (
+                Text("Text".into()),
+                Marker,
+                Marker1::default(),
+                Marker2::default(),
+                Marker3::default()
+            ),
+            (
+                Text("Text".into()),
+                Marker,
+                Marker1::default(),
+                Marker2::default(),
+                Marker3::default()
+            ),
+            (
+                Text("Text".into()),
+                Marker,
+                Marker1::default(),
+                Marker2::default(),
+                Marker3::default()
+            ),
+            (
+                Text("Text".into()),
+                Marker,
+                Marker1::default(),
+                Marker2::default(),
+                Marker3::default()
+            ),
+            (
+                Text("Text".into()),
+                Marker,
+                Marker1::default(),
+                Marker2::default(),
+                Marker3::default()
+            ),
+            (
+                Text("Text".into()),
+                Marker,
+                Marker1::default(),
+                Marker2::default(),
+                Marker3::default()
+            ),
+            (
+                Text("Text".into()),
+                Marker,
+                Marker1::default(),
+                Marker2::default(),
+                Marker3::default()
+            ),
+            (
+                Text("Text".into()),
+                Marker,
+                Marker1::default(),
+                Marker2::default(),
+                Marker3::default()
+            ),
+            (
+                Text("Text".into()),
+                Marker,
+                Marker1::default(),
+                Marker2::default(),
+                Marker3::default()
+            ),
+            (
+                Text("Text".into()),
+                Marker,
+                Marker1::default(),
+                Marker2::default(),
+                Marker3::default()
+            ),
         ],
     )
 }

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -76,7 +76,6 @@ std = [
   "arrayvec/std",
   "log/std",
   "bevy_platform/std",
-  "downcast-rs/std",
 ]
 
 ## `critical-section` provides the building blocks for synchronization primitives
@@ -127,7 +126,6 @@ log = { version = "0.4", default-features = false }
 bumpalo = "3"
 subsecond = { version = "0.7.0-rc.0", optional = true }
 slotmap = { version = "1.0.7", default-features = false }
-downcast-rs = { version = "2", default-features = false }
 
 concurrent-queue = { version = "2.5.0", default-features = false }
 [target.'cfg(not(all(target_has_atomic = "8", target_has_atomic = "16", target_has_atomic = "32", target_has_atomic = "64", target_has_atomic = "ptr")))'.dependencies]

--- a/crates/bevy_ecs/src/bundle/mod.rs
+++ b/crates/bevy_ecs/src/bundle/mod.rs
@@ -14,6 +14,7 @@ mod remove;
 mod spawner;
 #[cfg(test)]
 mod tests;
+mod writer;
 
 pub(crate) use insert::BundleInserter;
 pub(crate) use remove::BundleRemover;
@@ -22,6 +23,7 @@ pub(crate) use spawner::BundleSpawner;
 use bevy_ptr::MovingPtr;
 use core::mem::MaybeUninit;
 pub use info::*;
+pub use writer::*;
 
 /// Derive the [`Bundle`] trait
 ///

--- a/crates/bevy_ecs/src/bundle/writer.rs
+++ b/crates/bevy_ecs/src/bundle/writer.rs
@@ -1,0 +1,104 @@
+use crate::{
+    component::{Component, ComponentId, ComponentsRegistrator},
+    relationship::RelationshipHookMode,
+    world::EntityWorldMut,
+};
+use alloc::vec::Vec;
+use bevy_ptr::OwningPtr;
+use bumpalo::Bump;
+use core::ptr::NonNull;
+
+/// Enables pushing components to internal scratch space (uses a bump allocator), which can then be
+/// written as a dynamic bundle. The contents are cleared after each write and the allocated scratch
+/// space is reused across writes.
+#[derive(Default)]
+pub struct BundleWriter {
+    // Correctness: this should not be exposed, otherwise a caller could clear bundle_scratch, which
+    // would ultimately result in Drop not being called on any of the items currently stored here
+    bundle_scratch: OwnedBundleScratch,
+    // Safety: this cannot be exposed, otherwise `alloc.reset()` could be called in arbitrary places,
+    // which could invalidate the data stored in OwnedBundleScratch.
+    alloc: Bump,
+}
+
+// SAFETY: The `NonNull` in `OwnedBundleScratch` is always a `Component`, which is Send
+unsafe impl Send for BundleWriter {}
+
+impl BundleWriter {
+    /// Pushes the given component to the back of the current bundle scratch space. It will register
+    /// the component in `components` if it does not already exist.
+    ///
+    /// # Safety
+    ///
+    /// `components` must be from the same world that all previous [`Self::push_component`] calls were called with,
+    /// and the _next_  [`Self::write`] call.
+    pub unsafe fn push_component<C: Component>(
+        &mut self,
+        components: &mut ComponentsRegistrator,
+        component: C,
+    ) {
+        let id = components.register_component::<C>();
+        let component_mut = self.alloc.alloc(component);
+        // SAFETY: component_mut is not null, as it was allocated above with the `component` value
+        let component_ptr =
+            unsafe { NonNull::new_unchecked(core::ptr::from_mut(component_mut).cast::<u8>()) };
+        // SAFETY: component id looked up above
+        unsafe { self.bundle_scratch.push_ptr(id, component_ptr) };
+    }
+
+    /// Writes the current contents of the bundle to the given `entity` and clears the scratch space.
+    ///
+    /// # Safety
+    ///
+    /// `entity` must be from the same world that all [`Self::push_component`] calls since the last
+    /// [`Self::write`] were called with.
+    pub unsafe fn write(&mut self, entity: &mut EntityWorldMut) {
+        // SAFETY: caller verifies that `entity` is from the same world as all previous `push_component` calls.
+        unsafe { self.bundle_scratch.write(entity, RelationshipHookMode::Run) };
+        self.alloc.reset();
+    }
+}
+
+/// An expandable scratch space for defining a dynamic bundle. This is similar to [`BundleScratch`],
+/// but it uses raw pointers instead of references with lifetimes. This makes it _significantly_
+/// harder to use safely, so it should only be used in contexts where it can be easily verified.
+#[derive(Default)]
+struct OwnedBundleScratch {
+    component_ids: Vec<ComponentId>,
+    component_ptrs: Vec<NonNull<u8>>,
+}
+
+impl OwnedBundleScratch {
+    /// Pushes the `ptr` component onto this storage with the given `id` [`ComponentId`].
+    ///
+    /// # Safety
+    /// The `id` [`ComponentId`] must match the component `ptr` for whatever [`World`] this scratch will
+    /// be written to. `ptr` must contain valid uniquely-owned data that matches the type of component referenced
+    /// in `id`.
+    pub unsafe fn push_ptr(&mut self, id: ComponentId, ptr: NonNull<u8>) {
+        self.component_ids.push(id);
+        self.component_ptrs.push(ptr);
+    }
+
+    /// Writes the scratch components to the given entity in the given world.
+    ///
+    /// # Safety
+    /// All [`ComponentId`] values in this instance must come from `world`.
+    pub unsafe fn write(
+        &mut self,
+        entity: &mut EntityWorldMut,
+        relationship_hook_insert_mode: RelationshipHookMode,
+    ) {
+        // SAFETY:
+        // - All `component_ids` are from the same world as `entity`
+        // - All `component_data_ptrs` are valid types represented by `component_ids`
+        unsafe {
+            entity.insert_by_ids_internal(
+                &self.component_ids,
+                self.component_ptrs.drain(..).map(|ptr| OwningPtr::new(ptr)),
+                relationship_hook_insert_mode,
+            );
+        }
+        self.component_ids.clear();
+    }
+}

--- a/crates/bevy_ecs/src/bundle/writer.rs
+++ b/crates/bevy_ecs/src/bundle/writer.rs
@@ -108,3 +108,28 @@ impl BundleWriter {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{bundle::BundleWriter, component::Component, name::Name, world::World};
+
+    #[test]
+    fn write_component() {
+        #[derive(Component)]
+        struct X;
+
+        let mut world = World::new();
+        let mut bundle_writer = BundleWriter::default();
+        // SAFETY: the same world is used for every bundle_writer operation
+        unsafe {
+            let mut components = world.components_registrator();
+            bundle_writer.push_component(&mut components, X);
+            bundle_writer.push_component(&mut components, Name::new("Hi"));
+            let mut entity = world.spawn_empty();
+            bundle_writer.write(&mut entity);
+
+            assert_eq!(entity.get::<Name>().unwrap().as_str(), "Hi");
+            assert!(entity.contains::<X>());
+        }
+    }
+}

--- a/crates/bevy_ecs/src/bundle/writer.rs
+++ b/crates/bevy_ecs/src/bundle/writer.rs
@@ -15,7 +15,7 @@ use core::{alloc::Layout, ptr::NonNull};
 pub struct BundleWriter {
     // Correctness: this should never be made public or mismatched component ids could be inserted
     component_ids: Vec<ComponentId>,
-    // Correctness: this should never be made public or arbitary non-components could be inserted
+    // Correctness: this should never be made public or arbitrary non-components could be inserted
     component_ptrs: Vec<NonNull<u8>>,
     // Safety: this cannot be exposed, otherwise `alloc.reset()` could be called in arbitrary places,
     // which could invalidate the data stored in OwnedBundleScratch.

--- a/crates/bevy_ecs/src/bundle/writer.rs
+++ b/crates/bevy_ecs/src/bundle/writer.rs
@@ -18,7 +18,7 @@ pub struct BundleWriter {
     // Correctness: this should never be made public or arbitrary non-components could be inserted
     component_ptrs: Vec<NonNull<u8>>,
     // Safety: this cannot be exposed, otherwise `alloc.reset()` could be called in arbitrary places,
-    // which could invalidate the data stored in OwnedBundleScratch.
+    // which could invalidate the data stored in `component_ptrs`.
     alloc: Bump,
 }
 
@@ -106,6 +106,12 @@ impl BundleWriter {
                 }
             }
         }
+    }
+
+    /// Returns true if there are currently no components.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.component_ids.is_empty()
     }
 }
 

--- a/crates/bevy_ecs/src/bundle/writer.rs
+++ b/crates/bevy_ecs/src/bundle/writer.rs
@@ -13,15 +13,16 @@ use core::{alloc::Layout, ptr::NonNull};
 /// space is reused across writes.
 #[derive(Default)]
 pub struct BundleWriter {
-    // Correctness: this should not be exposed, otherwise a caller could clear bundle_scratch, which
-    // would ultimately result in Drop not being called on any of the items currently stored here
-    bundle_scratch: OwnedBundleScratch,
+    // Correctness: this should never be made public or mismatched component ids could be inserted
+    component_ids: Vec<ComponentId>,
+    // Correctness: this should never be made public or arbitary non-components could be inserted
+    component_ptrs: Vec<NonNull<u8>>,
     // Safety: this cannot be exposed, otherwise `alloc.reset()` could be called in arbitrary places,
     // which could invalidate the data stored in OwnedBundleScratch.
     alloc: Bump,
 }
 
-// SAFETY: The `NonNull` in `OwnedBundleScratch` is always a `Component`, which is Send
+// SAFETY: The `NonNull`s in component_ptrs are always a `Component`, which is Send
 unsafe impl Send for BundleWriter where Bump: Send {}
 
 impl BundleWriter {
@@ -58,10 +59,10 @@ impl BundleWriter {
         component: OwningPtr<'_>,
         layout: Layout,
     ) {
-        let start_ptr = self.alloc.alloc_layout(layout);
-        core::ptr::copy(component.as_ptr(), start_ptr.as_ptr(), layout.size());
-        // SAFETY: component id looked up above
-        unsafe { self.bundle_scratch.push_ptr(id, start_ptr) };
+        let ptr = self.alloc.alloc_layout(layout);
+        core::ptr::copy(component.as_ptr(), ptr.as_ptr(), layout.size());
+        self.component_ids.push(id);
+        self.component_ptrs.push(ptr);
     }
 
     /// Writes the current contents of the bundle to the given `entity` and clears the scratch space.
@@ -71,42 +72,6 @@ impl BundleWriter {
     /// `entity` must be from the same world that all [`Self::push_component`] calls since the last
     /// [`Self::write`] were called with.
     pub unsafe fn write(&mut self, entity: &mut EntityWorldMut) {
-        // SAFETY: caller verifies that `entity` is from the same world as all previous `push_component` calls.
-        unsafe { self.bundle_scratch.write(entity, RelationshipHookMode::Run) };
-        self.alloc.reset();
-    }
-}
-
-/// An expandable scratch space for defining a dynamic bundle. This is similar to [`BundleScratch`],
-/// but it uses raw pointers instead of references with lifetimes. This makes it _significantly_
-/// harder to use safely, so it should only be used in contexts where it can be easily verified.
-#[derive(Default)]
-struct OwnedBundleScratch {
-    component_ids: Vec<ComponentId>,
-    component_ptrs: Vec<NonNull<u8>>,
-}
-
-impl OwnedBundleScratch {
-    /// Pushes the `ptr` component onto this storage with the given `id` [`ComponentId`].
-    ///
-    /// # Safety
-    /// The `id` [`ComponentId`] must match the component `ptr` for whatever [`World`] this scratch will
-    /// be written to. `ptr` must contain valid uniquely-owned data that matches the type of component referenced
-    /// in `id`.
-    pub unsafe fn push_ptr(&mut self, id: ComponentId, ptr: NonNull<u8>) {
-        self.component_ids.push(id);
-        self.component_ptrs.push(ptr);
-    }
-
-    /// Writes the scratch components to the given entity in the given world.
-    ///
-    /// # Safety
-    /// All [`ComponentId`] values in this instance must come from `world`.
-    pub unsafe fn write(
-        &mut self,
-        entity: &mut EntityWorldMut,
-        relationship_hook_insert_mode: RelationshipHookMode,
-    ) {
         // SAFETY:
         // - All `component_ids` are from the same world as `entity`
         // - All `component_data_ptrs` are valid types represented by `component_ids`
@@ -114,9 +79,10 @@ impl OwnedBundleScratch {
             entity.insert_by_ids_internal(
                 &self.component_ids,
                 self.component_ptrs.drain(..).map(|ptr| OwningPtr::new(ptr)),
-                relationship_hook_insert_mode,
+                RelationshipHookMode::Run,
             );
         }
         self.component_ids.clear();
+        self.alloc.reset();
     }
 }

--- a/crates/bevy_ecs/src/bundle/writer.rs
+++ b/crates/bevy_ecs/src/bundle/writer.rs
@@ -11,8 +11,10 @@ use core::{alloc::Layout, ptr::NonNull};
 /// Enables pushing components to internal scratch space (uses a bump allocator), which can then be
 /// written as a dynamic bundle. The contents are cleared after each write and the allocated scratch
 /// space is reused across writes.
+///
+/// Also see [`BundleWriter`].
 #[derive(Default)]
-pub struct BundleWriter {
+pub struct BundleScratch {
     // Correctness: this should never be made public or mismatched component ids could be inserted
     component_ids: Vec<ComponentId>,
     // Correctness: this should never be made public or arbitrary non-components could be inserted
@@ -22,10 +24,64 @@ pub struct BundleWriter {
     alloc: Bump,
 }
 
-// SAFETY: The `NonNull`s in component_ptrs are always a `Component`, which is Send
-unsafe impl Send for BundleWriter where Bump: Send {}
+impl BundleScratch {
+    /// Creates a new [`BundleWriter`] using this scratch space. For safety / correctness, this will
+    /// clear any existing components.
+    ///
+    /// Note that for performance reasons this will _not_ clear the internal allocator. To avoid leaking,
+    /// make sure every component pushed to the [`BundleWriter`] is followed by either a
+    /// [`BundleWriter::write`] or a [`BundleScratch::manual_drop`].
+    #[inline]
+    pub fn writer<'a>(&'a mut self) -> BundleWriter<'a> {
+        // This is necessary to ensure safety / correctness is maintained in the context of catch_unwind
+        // or a skipped `write`
+        self.component_ids.clear();
+        self.component_ptrs.clear();
+        BundleWriter(self)
+    }
 
-impl BundleWriter {
+    /// Returns true if there are currently no components stored in the scratch space.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.component_ids.is_empty()
+    }
+
+    /// This will drop all components currently stored in the scratch space. This is generally used to
+    /// ensure drops occur in error scenarios.
+    ///
+    /// # Safety
+    /// `components` must be from the same world as the components that were pushed to this writer.
+    pub unsafe fn manual_drop(&mut self, components: &Components) {
+        for (id, ptr) in self
+            .component_ids
+            .drain(..)
+            .zip(self.component_ptrs.drain(..))
+        {
+            if let Some(info) = components.get_info(id)
+                && let Some(drop) = info.drop()
+            {
+                // SAFETY: ptr is a valid component that matches the given component id
+                unsafe {
+                    let ptr = OwningPtr::new(ptr);
+                    (drop)(ptr);
+                }
+            }
+        }
+        self.alloc.reset();
+    }
+}
+
+/// Enables pushing components to the internal [`BundleScratch`], which can then be
+/// written as a dynamic bundle.
+///
+/// Components pushed to this writer should either be followed by a [`BundleWriter::write`] or a
+/// [`BundleScratch::manual_drop`] to avoid leaking.
+pub struct BundleWriter<'a>(&'a mut BundleScratch);
+
+// SAFETY: The `NonNull`s in component_ptrs are always a `Component`, which is Send
+unsafe impl Send for BundleScratch where Bump: Send {}
+
+impl<'a> BundleWriter<'a> {
     /// Pushes the given component to the back of the current bundle scratch space. It will register
     /// the component in `components` if it does not already exist.
     ///
@@ -59,10 +115,10 @@ impl BundleWriter {
         component: OwningPtr<'_>,
         layout: Layout,
     ) {
-        let ptr = self.alloc.alloc_layout(layout);
+        let ptr = self.0.alloc.alloc_layout(layout);
         core::ptr::copy(component.as_ptr(), ptr.as_ptr(), layout.size());
-        self.component_ids.push(id);
-        self.component_ptrs.push(ptr);
+        self.0.component_ids.push(id);
+        self.0.component_ptrs.push(ptr);
     }
 
     /// Writes the current contents of the bundle to the given `entity` and clears the scratch space.
@@ -71,53 +127,34 @@ impl BundleWriter {
     ///
     /// `entity` must be from the same world that all [`Self::push_component`] calls since the last
     /// [`Self::write`] were called with.
-    pub unsafe fn write(&mut self, entity: &mut EntityWorldMut) {
+    pub unsafe fn write(self, entity: &mut EntityWorldMut) {
         // SAFETY:
         // - All `component_ids` are from the same world as `entity`
         // - All `component_data_ptrs` are valid types represented by `component_ids`
         unsafe {
             entity.insert_by_ids_internal(
-                &self.component_ids,
-                self.component_ptrs.drain(..).map(|ptr| OwningPtr::new(ptr)),
+                &self.0.component_ids,
+                self.0
+                    .component_ptrs
+                    .drain(..)
+                    .map(|ptr| OwningPtr::new(ptr)),
                 RelationshipHookMode::Run,
             );
         }
-        self.component_ids.clear();
-        self.alloc.reset();
-    }
-
-    /// This will drop all components currently stored
-    ///
-    /// # Safety
-    /// `components` must be from the same world as the components that were pushed to this writer.
-    pub unsafe fn manual_drop(&mut self, components: &Components) {
-        for (id, ptr) in self
-            .component_ids
-            .drain(..)
-            .zip(self.component_ptrs.drain(..))
-        {
-            if let Some(info) = components.get_info(id)
-                && let Some(drop) = info.drop()
-            {
-                // SAFETY: ptr is a valid component that matches the given component id
-                unsafe {
-                    let ptr = OwningPtr::new(ptr);
-                    (drop)(ptr);
-                }
-            }
-        }
+        self.0.component_ids.clear();
+        self.0.alloc.reset();
     }
 
     /// Returns true if there are currently no components.
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.component_ids.is_empty()
+        self.0.component_ids.is_empty()
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{bundle::BundleWriter, component::Component, name::Name, world::World};
+    use crate::{bundle::BundleScratch, component::Component, name::Name, world::World};
 
     #[test]
     fn write_component() {
@@ -125,7 +162,8 @@ mod tests {
         struct X;
 
         let mut world = World::new();
-        let mut bundle_writer = BundleWriter::default();
+        let mut bundle_scratch = BundleScratch::default();
+        let mut bundle_writer = bundle_scratch.writer();
         // SAFETY: the same world is used for every bundle_writer operation
         unsafe {
             let mut components = world.components_registrator();

--- a/crates/bevy_ecs/src/bundle/writer.rs
+++ b/crates/bevy_ecs/src/bundle/writer.rs
@@ -6,7 +6,7 @@ use crate::{
 use alloc::vec::Vec;
 use bevy_ptr::OwningPtr;
 use bumpalo::Bump;
-use core::ptr::NonNull;
+use core::{alloc::Layout, ptr::NonNull};
 
 /// Enables pushing components to internal scratch space (uses a bump allocator), which can then be
 /// written as a dynamic bundle. The contents are cleared after each write and the allocated scratch
@@ -22,7 +22,7 @@ pub struct BundleWriter {
 }
 
 // SAFETY: The `NonNull` in `OwnedBundleScratch` is always a `Component`, which is Send
-unsafe impl Send for BundleWriter {}
+unsafe impl Send for BundleWriter where Bump: Send {}
 
 impl BundleWriter {
     /// Pushes the given component to the back of the current bundle scratch space. It will register
@@ -38,12 +38,30 @@ impl BundleWriter {
         component: C,
     ) {
         let id = components.register_component::<C>();
-        let component_mut = self.alloc.alloc(component);
-        // SAFETY: component_mut is not null, as it was allocated above with the `component` value
-        let component_ptr =
-            unsafe { NonNull::new_unchecked(core::ptr::from_mut(component_mut).cast::<u8>()) };
+        OwningPtr::make(component, |ptr| {
+            // SAFETY: ptr points to a C component value which matches the `id` looked up above.
+            // Layout matches C.
+            self.push_component_by_id(id, ptr, Layout::new::<C>());
+        });
+    }
+
+    /// Pushes the given component ptr to the back of the current bundle scratch space.
+    ///
+    /// # Safety
+    ///
+    /// `components` must be from the same world that all previous [`Self::push_component`] calls were called with,
+    /// and the _next_ [`Self::write`] call. `component` must point to a [`Component`] value that matches `id`.
+    /// `layout` must correspond to the layout of the [`Component`] type.
+    pub unsafe fn push_component_by_id(
+        &mut self,
+        id: ComponentId,
+        component: OwningPtr<'_>,
+        layout: Layout,
+    ) {
+        let start_ptr = self.alloc.alloc_layout(layout);
+        core::ptr::copy(component.as_ptr(), start_ptr.as_ptr(), layout.size());
         // SAFETY: component id looked up above
-        unsafe { self.bundle_scratch.push_ptr(id, component_ptr) };
+        unsafe { self.bundle_scratch.push_ptr(id, start_ptr) };
     }
 
     /// Writes the current contents of the bundle to the given `entity` and clears the scratch space.

--- a/crates/bevy_ecs/src/bundle/writer.rs
+++ b/crates/bevy_ecs/src/bundle/writer.rs
@@ -86,7 +86,7 @@ impl BundleWriter {
         self.alloc.reset();
     }
 
-    /// This will drop all componets currently stored
+    /// This will drop all components currently stored
     ///
     /// # Safety
     /// `components` must be from the same world as the components that were pushed to this writer.

--- a/crates/bevy_ecs/src/bundle/writer.rs
+++ b/crates/bevy_ecs/src/bundle/writer.rs
@@ -1,5 +1,5 @@
 use crate::{
-    component::{Component, ComponentId, ComponentsRegistrator},
+    component::{Component, ComponentId, Components, ComponentsRegistrator},
     relationship::RelationshipHookMode,
     world::EntityWorldMut,
 };
@@ -84,5 +84,27 @@ impl BundleWriter {
         }
         self.component_ids.clear();
         self.alloc.reset();
+    }
+
+    /// This will drop all componets currently stored
+    ///
+    /// # Safety
+    /// `components` must be from the same world as the components that were pushed to this writer.
+    pub unsafe fn manual_drop(&mut self, components: &Components) {
+        for (id, ptr) in self
+            .component_ids
+            .drain(..)
+            .zip(self.component_ptrs.drain(..))
+        {
+            if let Some(info) = components.get_info(id)
+                && let Some(drop) = info.drop()
+            {
+                // SAFETY: ptr is a valid component that matches the given component id
+                unsafe {
+                    let ptr = OwningPtr::new(ptr);
+                    (drop)(ptr);
+                }
+            }
+        }
     }
 }

--- a/crates/bevy_ecs/src/entity/clone_entities.rs
+++ b/crates/bevy_ecs/src/entity/clone_entities.rs
@@ -82,7 +82,7 @@ pub struct ComponentCloneCtx<'a, 'b> {
     component_id: ComponentId,
     target_component_written: bool,
     target_component_moved: bool,
-    bundle_scratch: &'a mut BundleScratch<'b>,
+    bundle_scratch: &'a mut BundleScratchSpace<'b>,
     bundle_scratch_allocator: &'b Bump,
     allocator: &'a EntityAllocator,
     source: Entity,
@@ -109,7 +109,7 @@ impl<'a, 'b> ComponentCloneCtx<'a, 'b> {
         source: Entity,
         target: Entity,
         bundle_scratch_allocator: &'b Bump,
-        bundle_scratch: &'a mut BundleScratch<'b>,
+        bundle_scratch: &'a mut BundleScratchSpace<'b>,
         allocator: &'a EntityAllocator,
         component_info: &'a ComponentInfo,
         entity_cloner: &'a mut EntityClonerState,
@@ -378,12 +378,12 @@ pub struct EntityCloner {
 }
 
 /// An expandable scratch space for defining a dynamic bundle.
-struct BundleScratch<'a> {
+struct BundleScratchSpace<'a> {
     component_ids: Vec<ComponentId>,
     component_ptrs: Vec<PtrMut<'a>>,
 }
 
-impl<'a> BundleScratch<'a> {
+impl<'a> BundleScratchSpace<'a> {
     pub(crate) fn with_capacity(capacity: usize) -> Self {
         Self {
             component_ids: Vec::with_capacity(capacity),
@@ -575,7 +575,7 @@ impl EntityCloner {
 
         // PERF: reusing allocated space across clones would be more efficient. Consider an allocation model similar to `Commands`.
         let bundle_scratch_allocator = Bump::new();
-        let mut bundle_scratch: BundleScratch;
+        let mut bundle_scratch: BundleScratchSpace;
         let mut moved_components: Vec<ComponentId> = Vec::new();
         let mut deferred_cloned_component_ids: Vec<ComponentId> = Vec::new();
         {
@@ -596,7 +596,7 @@ impl EntityCloner {
             #[cfg(not(feature = "bevy_reflect"))]
             let app_registry = Option::<()>::None;
 
-            bundle_scratch = BundleScratch::with_capacity(source_archetype.component_count());
+            bundle_scratch = BundleScratchSpace::with_capacity(source_archetype.component_count());
 
             let target_archetype = LazyCell::new(|| {
                 world

--- a/crates/bevy_ecs/src/template.rs
+++ b/crates/bevy_ecs/src/template.rs
@@ -3,14 +3,12 @@
 pub use bevy_ecs_macros::FromTemplate;
 
 use crate::{
-    bundle::Bundle,
     entity::Entity,
-    error::{BevyError, Result},
+    error::Result,
     resource::Resource,
     world::{EntityWorldMut, Mut, World},
 };
-use alloc::{boxed::Box, vec, vec::Vec};
-use downcast_rs::{impl_downcast, Downcast};
+use alloc::{vec, vec::Vec};
 use variadics_please::all_tuples;
 
 /// A [`Template`] is something that, given a spawn context (target [`Entity`], [`World`], etc), can produce a [`Template::Output`].
@@ -451,29 +449,6 @@ impl Template for EntityReference {
 
 impl FromTemplate for Entity {
     type Template = EntityReference;
-}
-
-/// A type-erased, object-safe, downcastable version of [`Template`].
-pub trait ErasedTemplate: Downcast + Send + Sync {
-    /// Applies this template to the given `entity`.
-    fn apply(&self, context: &mut TemplateContext) -> Result<(), BevyError>;
-
-    /// Clones this template. See [`Clone`].
-    fn clone_template(&self) -> Box<dyn ErasedTemplate>;
-}
-
-impl_downcast!(ErasedTemplate);
-
-impl<T: Template<Output: Bundle> + Send + Sync + 'static> ErasedTemplate for T {
-    fn apply(&self, context: &mut TemplateContext) -> Result<(), BevyError> {
-        let bundle = self.build_template(context)?;
-        context.entity.insert(bundle);
-        Ok(())
-    }
-
-    fn clone_template(&self) -> Box<dyn ErasedTemplate> {
-        Box::new(Template::clone_template(self))
-    }
 }
 
 /// A [`Template`] driven by a function that returns an output. This is used to create "free floating" templates without

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -1322,28 +1322,28 @@ mod tests {
         };
     }
 
+    #[derive(Component, Default)]
+    struct Fail;
+    impl FromTemplate for Fail {
+        type Template = Fail;
+    }
+    impl Template for Fail {
+        type Output = Fail;
+
+        fn build_template(
+            &self,
+            _context: &mut bevy_ecs::template::TemplateContext,
+        ) -> Result<Self::Output> {
+            Err(BevyError::error("fail!"))
+        }
+
+        fn clone_template(&self) -> Self {
+            todo!()
+        }
+    }
+
     #[test]
     fn drop_is_called_for_uninserted_components() {
-        #[derive(Component, Default)]
-        struct Fail;
-        impl FromTemplate for Fail {
-            type Template = Fail;
-        }
-        impl Template for Fail {
-            type Output = Fail;
-
-            fn build_template(
-                &self,
-                _context: &mut bevy_ecs::template::TemplateContext,
-            ) -> Result<Self::Output> {
-                Err(BevyError::error("fail!"))
-            }
-
-            fn clone_template(&self) -> Self {
-                todo!()
-            }
-        }
-
         #[derive(Component, FromTemplate)]
         struct DropTracker(Option<Arc<Mutex<usize>>>);
 
@@ -1366,6 +1366,18 @@ mod tests {
         let result = world.spawn_scene(scene);
         assert!(result.is_err());
         assert_eq!(1, *count_arc.lock().unwrap());
+    }
+
+    #[test]
+    fn despawn_on_failed_spawn() {
+        let mut app = test_app();
+        let world = app.world_mut();
+        let current_entities = world.entities().len();
+        let result = world.spawn_scene(bsn! {
+           Fail
+        });
+        assert!(result.is_err());
+        assert_eq!(current_entities, world.entities().len());
     }
 
     fn run_app_until(app: &mut App, mut predicate: impl FnMut() -> bool) {

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -559,6 +559,7 @@ impl Plugin for ScenePlugin {
 mod tests {
     use crate::{self as bevy_scene, ScenePlugin};
     use crate::{prelude::*, ScenePatch};
+    use alloc::sync::Arc;
     use bevy_app::{App, TaskPoolPlugin};
     use bevy_asset::io::memory::{Dir, MemoryAssetReader};
     use bevy_asset::io::{AssetSourceBuilder, AssetSourceId};
@@ -566,6 +567,7 @@ mod tests {
     use bevy_ecs::prelude::*;
     use bevy_reflect::TypePath;
     use std::path::Path;
+    use std::sync::Mutex;
 
     fn test_app() -> App {
         let mut app = App::new();
@@ -1318,6 +1320,52 @@ mod tests {
             Name
             Name
         };
+    }
+
+    #[test]
+    fn drop_is_called_for_uninserted_components() {
+        #[derive(Component, Default)]
+        struct Fail;
+        impl FromTemplate for Fail {
+            type Template = Fail;
+        }
+        impl Template for Fail {
+            type Output = Fail;
+
+            fn build_template(
+                &self,
+                _context: &mut bevy_ecs::template::TemplateContext,
+            ) -> Result<Self::Output> {
+                Err(BevyError::error("fail!"))
+            }
+
+            fn clone_template(&self) -> Self {
+                todo!()
+            }
+        }
+
+        #[derive(Component, FromTemplate)]
+        struct DropTracker(Option<Arc<Mutex<usize>>>);
+
+        impl Drop for DropTracker {
+            fn drop(&mut self) {
+                if let Some(count) = &mut self.0 {
+                    *count.lock().unwrap() += 1;
+                }
+            }
+        }
+
+        let mut app = test_app();
+        let world = app.world_mut();
+        let count_arc = Arc::new(Mutex::new(0));
+        let count = Some(count_arc.clone());
+        let scene = bsn! {
+            DropTracker({count.clone()})
+            Fail
+        };
+        let result = world.spawn_scene(scene);
+        assert!(result.is_err());
+        assert_eq!(1, *count_arc.lock().unwrap());
     }
 
     fn run_app_until(app: &mut App, mut predicate: impl FnMut() -> bool) {

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -1,3 +1,4 @@
+#![expect(unsafe_code, reason = "Unsafe code is used to improve performance.")]
 //! Composable scene authoring for Bevy, defined using the Bevy Scene Notation (BSN) format.
 //!
 //! Game entities rarely exist in isolation.
@@ -556,12 +557,15 @@ impl Plugin for ScenePlugin {
 
 #[cfg(test)]
 mod tests {
-    use crate::prelude::*;
     use crate::{self as bevy_scene, ScenePlugin};
+    use crate::{prelude::*, ScenePatch};
     use bevy_app::{App, TaskPoolPlugin};
-    use bevy_asset::{Asset, AssetApp, AssetPlugin, AssetServer, Handle};
+    use bevy_asset::io::memory::{Dir, MemoryAssetReader};
+    use bevy_asset::io::{AssetSourceBuilder, AssetSourceId};
+    use bevy_asset::{Asset, AssetApp, AssetLoader, AssetPlugin, AssetServer, Assets, Handle};
     use bevy_ecs::prelude::*;
     use bevy_reflect::TypePath;
+    use std::path::Path;
 
     fn test_app() -> App {
         let mut app = App::new();
@@ -600,6 +604,104 @@ mod tests {
             }
         }
 
+        let id = world.spawn_scene(b()).unwrap().id();
+        let root = world.entity(id);
+
+        let position = root.get::<Position>().unwrap();
+        assert_eq!(position.x, 1.);
+        assert_eq!(position.y, 2.);
+        assert_eq!(position.z, 0.);
+
+        let children = root.get::<Children>().unwrap();
+        assert_eq!(children.len(), 2);
+
+        let x = world.entity(children[0]);
+        let name = x.get::<Name>().unwrap();
+        assert_eq!(name.as_str(), "X");
+
+        let y = world.entity(children[1]);
+        let name = y.get::<Name>().unwrap();
+        assert_eq!(name.as_str(), "Y");
+    }
+
+    #[test]
+    fn loaded_asset_inheritance_patching() {
+        #[derive(Component, FromTemplate)]
+        struct Position {
+            x: f32,
+            y: f32,
+            z: f32,
+        }
+
+        fn b() -> impl Scene {
+            bsn! {
+                :"a.bsn"
+                Position { x: 1. }
+                Children [ #Y ]
+            }
+        }
+
+        fn a() -> impl Scene {
+            bsn! {
+                Position { y: 2. }
+                Children [ #X ]
+            }
+        }
+
+        let mut app = App::new();
+        let dir = Dir::default();
+        let dir_clone = dir.clone();
+        app.register_asset_source(
+            AssetSourceId::Default,
+            AssetSourceBuilder::new(move || {
+                Box::new(MemoryAssetReader {
+                    root: dir_clone.clone(),
+                })
+            }),
+        );
+        app.add_plugins((
+            TaskPoolPlugin::default(),
+            AssetPlugin::default(),
+            ScenePlugin,
+        ));
+
+        app.finish();
+        app.cleanup();
+        // Create a fake loader to act as a ScenePatch loaded from a file.
+        app.register_asset_loader(FakeSceneLoader);
+
+        #[derive(TypePath)]
+        struct FakeSceneLoader;
+
+        impl AssetLoader for FakeSceneLoader {
+            type Asset = ScenePatch;
+            type Error = std::io::Error;
+            type Settings = ();
+
+            async fn load(
+                &self,
+                _reader: &mut dyn bevy_asset::io::Reader,
+                _settings: &Self::Settings,
+                load_context: &mut bevy_asset::LoadContext<'_>,
+            ) -> Result<Self::Asset, Self::Error> {
+                Ok(ScenePatch::load_with(load_context, a()))
+            }
+        }
+
+        // Insert an asset that the fake loader can fake read.
+        dir.insert_asset_text(Path::new("a.bsn"), "");
+        let asset_server = app.world().resource::<AssetServer>().clone();
+        let handle = asset_server.load("a.bsn");
+        assert!(app.world().get_resource::<Assets<ScenePatch>>().is_some());
+        run_app_until(&mut app, || asset_server.is_loaded(&handle));
+        let patch = app
+            .world()
+            .resource::<Assets<ScenePatch>>()
+            .get(&handle)
+            .unwrap();
+        assert!(patch.resolved.is_some());
+
+        let world = app.world_mut();
         let id = world.spawn_scene(b()).unwrap().id();
         let root = world.entity(id);
 
@@ -1216,5 +1318,17 @@ mod tests {
             Name
             Name
         };
+    }
+
+    fn run_app_until(app: &mut App, mut predicate: impl FnMut() -> bool) {
+        const LARGE_ITERATION_COUNT: usize = 10000;
+        for _ in 0..LARGE_ITERATION_COUNT {
+            app.update();
+            if predicate() {
+                return;
+            }
+        }
+
+        panic!("Ran out of loops to return `Some` from `predicate`");
     }
 }

--- a/crates/bevy_scene/src/resolved_scene.rs
+++ b/crates/bevy_scene/src/resolved_scene.rs
@@ -54,10 +54,14 @@ impl ResolvedSceneRoot {
 
         // SAFETY: caller verifies that `bundle_writer` is either empty or contains component ids registered
         // in `entity`'s World
-        unsafe {
-            self.scene.apply(&mut context, bundle_writer, ())?;
+        let result = unsafe { self.scene.apply(&mut context, bundle_writer, ()) };
+        if result.is_err() {
+            // SAFETY: Components comes from the same world as the `context` passed in to self.scene.apply above
+            unsafe {
+                bundle_writer.manual_drop(entity.world().components());
+            }
         }
-        Ok(())
+        result
     }
 
     fn new_scoped_entities(&self) -> ScopedEntities {
@@ -100,7 +104,7 @@ impl ResolvedSceneListRoot {
             func(&mut entity);
             entities.push(entity.id());
             // SAFETY: bundle_writer is always used with the same world
-            unsafe {
+            let result = unsafe {
                 scene.apply(
                     &mut TemplateContext::new(
                         &mut entity,
@@ -109,7 +113,14 @@ impl ResolvedSceneListRoot {
                     ),
                     &mut bundle_writer,
                     (),
-                )?;
+                )
+            };
+            if let Err(err) = result {
+                // SAFETY: Components comes from the same world as the `context` passed in to self.scene.apply above
+                unsafe {
+                    bundle_writer.manual_drop(entity.world().components());
+                }
+                return Err(err);
             }
         }
 

--- a/crates/bevy_scene/src/resolved_scene.rs
+++ b/crates/bevy_scene/src/resolved_scene.rs
@@ -24,13 +24,18 @@ pub struct ResolvedSceneRoot {
 
 impl ResolvedSceneRoot {
     /// This will spawn a new [`Entity`], then call [`ResolvedSceneRoot::apply`] on it.
+    /// If this fails mid-spawn, the intermediate entity will be despawned.
     pub fn spawn<'w>(&self, world: &'w mut World) -> Result<EntityWorldMut<'w>, ApplySceneError> {
         let mut entity = world.spawn_empty();
         // SAFETY: bundle writer is empty
-        unsafe {
-            self.apply(&mut entity, &mut BundleWriter::default())?;
+        let result = unsafe { self.apply(&mut entity, &mut BundleWriter::default()) };
+        match result {
+            Ok(_) => Ok(entity),
+            Err(err) => {
+                entity.despawn();
+                Err(err)
+            }
         }
-        Ok(entity)
     }
 
     /// Applies this scene to the given [`EntityWorldMut`].
@@ -54,7 +59,7 @@ impl ResolvedSceneRoot {
 
         // SAFETY: caller verifies that `bundle_writer` is either empty or contains component ids registered
         // in `entity`'s World
-        let result = unsafe { self.scene.apply(&mut context, bundle_writer, ()) };
+        let result = unsafe { self.scene.apply(&mut context, bundle_writer) };
         if result.is_err() {
             // SAFETY: Components comes from the same world as the `context` passed in to self.scene.apply above
             unsafe {
@@ -112,7 +117,6 @@ impl ResolvedSceneListRoot {
                         &self.entity_scopes,
                     ),
                     &mut bundle_writer,
-                    (),
                 )
             };
             if let Err(err) = result {
@@ -181,8 +185,6 @@ impl ResolvedScene {
     ///
     /// If this [`ResolvedScene`] inherits from another scene, that scene will be applied _first_.
     ///
-    /// This _does not write_ the final `bundle_writer` contents to the entity in `context`.
-    ///
     /// # Safety
     ///
     /// `bundle_writer` must either be empty or only contain components registered with the given
@@ -191,7 +193,6 @@ impl ResolvedScene {
         &self,
         context: &mut TemplateContext,
         bundle_writer: &mut BundleWriter,
-        skip_templates: impl SkipTemplate,
     ) -> Result<(), ApplySceneError> {
         if let Some(inherited) = &self.inherited {
             let scene_patches = context.resource::<Assets<ScenePatch>>();
@@ -231,7 +232,7 @@ impl ResolvedScene {
                         inherited: inherited.handle.path().cloned(),
                         error: Box::new(e),
                     })?;
-                self.apply_templates_without_bundle_write(context, bundle_writer, skip_templates)?;
+                self.apply_templates_without_bundle_write(context, bundle_writer, ())?;
                 // SAFETY: World is only used for component registration, which does not affect
                 // the entity location
                 let components = &mut context.entity.world_mut().components_registrator();
@@ -260,7 +261,7 @@ impl ResolvedScene {
         } else {
             // SAFETY: bundle_writer was used with the same World across all cases in this function,
             unsafe {
-                self.apply_templates_without_bundle_write(context, bundle_writer, skip_templates)?;
+                self.apply_templates_without_bundle_write(context, bundle_writer, ())?;
                 // SAFETY: World is only used for component registration, which does not affect
                 // the entity location
                 let components = &mut context.entity.world_mut().components_registrator();
@@ -377,7 +378,6 @@ impl ResolvedScene {
                                         context.entity_scopes,
                                     ),
                                     bundle_writer,
-                                    (),
                                 )
                                 .map_err(|e| ApplySceneError::RelatedSceneError {
                                     relationship_type_name: related_resolved_scenes

--- a/crates/bevy_scene/src/resolved_scene.rs
+++ b/crates/bevy_scene/src/resolved_scene.rs
@@ -74,7 +74,7 @@ pub struct ResolvedSceneListRoot {
 }
 
 impl ResolvedSceneListRoot {
-    /// Spawns a new [`Entity`] for each [`ResolvedScene`] in the list, and calls [`ResolvedScene::apply`] on them.
+    /// Spawns a new [`Entity`] for each [`ResolvedScene`] in the list, and applies that [`ResolvedScene`] to them.
     pub fn spawn<'w>(&self, world: &'w mut World) -> Result<Vec<Entity>, ApplySceneError> {
         self.spawn_with(world, |_| {})
     }
@@ -118,7 +118,7 @@ impl ResolvedSceneListRoot {
 }
 
 /// A final resolved scene (usually produced by calling [`Scene::resolve`]). This consists of:
-/// 1. A collection of [`Template`]s to apply to a spawned [`Entity`], which are stored as [`ErasedTemplate`]s.
+/// 1. A collection of [`Template`]s to apply to a spawned [`Entity`], which are stored as [`ErasedComponentTemplate`]s and [`ErasedBundleTemplate`]s.
 /// 2. A collection of [`RelatedResolvedScenes`], which will be spawned as "related" entities (ex: [`Children`] entities).
 /// 3. The inherited [`ScenePatch`] if it exists.
 ///
@@ -411,8 +411,8 @@ impl ResolvedScene {
             .unwrap()
     }
 
-    /// This will get the [`ErasedTemplate`] for the given [`TypeId`], if it already exists in this [`ResolvedScene`]. If it doesn't exist,
-    /// it will use the `default` function to create a new [`ErasedTemplate`]. _For correctness, the [`TypeId`] of the [`Template`] returned
+    /// This will get the [`ErasedComponentTemplate`] for the given [`TypeId`], if it already exists in this [`ResolvedScene`]. If it doesn't exist,
+    /// it will use the `default` function to create a new [`ErasedComponentTemplate`]. _For correctness, the [`TypeId`] of the [`Template`] returned
     /// by `default` should match the passed in `type_id`_.
     ///
     /// This uses "copy-on-write" behavior for inherited scenes. If a [`Template`] that the inherited scene has is requested, it will be
@@ -459,7 +459,7 @@ impl ResolvedScene {
         template
     }
 
-    /// Returns the [`ErasedTemplate`] for the given `type_id`, if it exists in this [`ResolvedScene`]. This ignores scene inheritance.
+    /// Returns the [`ErasedComponentTemplate`] for the given `type_id`, if it exists in this [`ResolvedScene`]. This ignores scene inheritance.
     pub fn get_direct_erased_template(
         &self,
         type_id: TypeId,
@@ -561,13 +561,13 @@ pub enum InheritSceneError {
     },
 }
 
-/// An error produced when calling [`ResolvedScene::apply`].
+/// An error produced when applying a [`ResolvedScene`].
 #[derive(Error, Debug)]
 pub enum ApplySceneError {
     /// Caused when a [`Template`] fails to build
     #[error("Failed to build a Template in the current Scene: {0}")]
     TemplateBuildError(BevyError),
-    /// Caused when the inherited [`ResolvedScene`] fails to [`ResolvedScene::apply`].
+    /// Caused when the inherited [`ResolvedScene`] fails to apply a [`ResolvedScene`].
     #[error("Failed to apply the inherited Scene (asset path: \"{inherited:?}\"): {error}")]
     InheritedSceneApplyError {
         /// The asset path of the inherited scene that failed to apply.
@@ -591,7 +591,7 @@ pub enum ApplySceneError {
         /// The asset id of the inherited scene.
         id: AssetId<ScenePatch>,
     },
-    /// Caused when a related [`ResolvedScene`] fails to [`ResolvedScene::apply`].
+    /// Caused when a related [`ResolvedScene`] fails to apply.
     #[error(
         "Failed to apply the related {relationship_type_name} Scene at index {index}: {error}"
     )]

--- a/crates/bevy_scene/src/resolved_scene.rs
+++ b/crates/bevy_scene/src/resolved_scene.rs
@@ -1,17 +1,17 @@
 use crate::{ResolveContext, ScenePatch};
 use bevy_asset::{AssetId, AssetPath, Assets, Handle, UntypedAssetId};
 use bevy_ecs::{
-    bundle::Bundle,
+    bundle::{Bundle, BundleWriter},
+    component::{Component, ComponentsRegistrator},
     entity::Entity,
     error::{BevyError, Result},
-    relationship::Relationship,
-    template::{
-        EntityScopes, ErasedTemplate, ScopedEntities, ScopedEntityIndex, Template, TemplateContext,
-    },
+    relationship::{Relationship, RelationshipTarget},
+    template::{EntityScopes, ScopedEntities, ScopedEntityIndex, Template, TemplateContext},
     world::{EntityWorldMut, World},
 };
+use bevy_platform::collections::HashSet;
 use bevy_utils::TypeIdMap;
-use core::any::TypeId;
+use core::any::{Any, TypeId};
 use thiserror::Error;
 
 /// A final "spawnable" root [`ResolvedScene`]. This includes the [`EntityScopes`] for the whole tree.
@@ -26,7 +26,10 @@ impl ResolvedSceneRoot {
     /// This will spawn a new [`Entity`], then call [`ResolvedSceneRoot::apply`] on it.
     pub fn spawn<'w>(&self, world: &'w mut World) -> Result<EntityWorldMut<'w>, ApplySceneError> {
         let mut entity = world.spawn_empty();
-        self.apply(&mut entity)?;
+        // SAFETY: bundle writer is empty
+        unsafe {
+            self.apply(&mut entity, &mut BundleWriter::default())?;
+        }
         Ok(entity)
     }
 
@@ -36,13 +39,29 @@ impl ResolvedSceneRoot {
     /// spawn all of this [`ResolvedScene`]'s related entities.
     ///
     /// If this root [`ResolvedScene`] inherits from another scene, that scene will be applied _first_.
-    pub fn apply(&self, entity: &mut EntityWorldMut) -> Result<(), ApplySceneError> {
-        let mut scoped_entities = ScopedEntities::new(self.entity_scopes.entity_len());
-        self.scene.apply(&mut TemplateContext::new(
-            entity,
-            &mut scoped_entities,
-            &self.entity_scopes,
-        ))
+    ///
+    /// # Safety
+    ///
+    /// `bundle_writer` must either be empty, or contain only components with ids registered in
+    /// `entity`'s World
+    pub unsafe fn apply(
+        &self,
+        entity: &mut EntityWorldMut,
+        bundle_writer: &mut BundleWriter,
+    ) -> Result<(), ApplySceneError> {
+        let mut scoped_entities = self.new_scoped_entities();
+        let mut context = TemplateContext::new(entity, &mut scoped_entities, &self.entity_scopes);
+
+        // SAFETY: caller verifies that `bundle_writer` is either empty or contains component ids registered
+        // in `entity`'s World
+        unsafe {
+            self.scene.apply(&mut context, bundle_writer, ())?;
+        }
+        Ok(())
+    }
+
+    fn new_scoped_entities(&self) -> ScopedEntities {
+        ScopedEntities::new(self.entity_scopes.entity_len())
     }
 }
 
@@ -67,6 +86,7 @@ impl ResolvedSceneListRoot {
     ) -> Result<Vec<Entity>, ApplySceneError> {
         let mut entities = Vec::new();
         let mut scoped_entities = ScopedEntities::new(self.entity_scopes.entity_len());
+        let mut bundle_writer = BundleWriter::default();
         for scene in self.scenes.iter() {
             let mut entity = if let Some(scoped_entity_index) =
                 scene.entity_indices.first().copied()
@@ -79,11 +99,18 @@ impl ResolvedSceneListRoot {
 
             func(&mut entity);
             entities.push(entity.id());
-            scene.apply(&mut TemplateContext::new(
-                &mut entity,
-                &mut scoped_entities,
-                &self.entity_scopes,
-            ))?;
+            // SAFETY: bundle_writer is always used with the same world
+            unsafe {
+                scene.apply(
+                    &mut TemplateContext::new(
+                        &mut entity,
+                        &mut scoped_entities,
+                        &self.entity_scopes,
+                    ),
+                    &mut bundle_writer,
+                    (),
+                )?;
+            }
         }
 
         Ok(entities)
@@ -105,15 +132,17 @@ impl ResolvedSceneListRoot {
 /// [`Children`]: bevy_ecs::hierarchy::Children
 #[derive(Default)]
 pub struct ResolvedScene {
-    /// The collection of [`Template`]s to apply to a spawned [`Entity`]. This can have multiple copies of the same [`Template`].
-    templates: Vec<Box<dyn ErasedTemplate>>,
+    /// The collection of component [`Template`]s to apply to a spawned [`Entity`]. This can have multiple copies of the same [`Template`].
+    component_templates: Vec<Box<dyn ErasedComponentTemplate>>,
+    /// The collection of Bundle templates to apply to a spawned [`Entity`].
+    bundle_templates: Vec<Box<dyn ErasedBundleTemplate>>,
     /// The collection of [`RelatedResolvedScenes`], which will be spawned as "related" entities (ex: [`Children`] entities).
     ///
     /// [`Children`]: bevy_ecs::hierarchy::Children
     // PERF: special casing Children might make sense here to avoid hashing
     related: TypeIdMap<RelatedResolvedScenes>,
     /// The inherited [`ScenePatch`] to apply _first_ before applying this [`ResolvedScene`].
-    inherited: Option<Handle<ScenePatch>>,
+    inherited: Option<InheritedSceneInfo>,
     /// A [`TypeId`] to `templates` index mapping. If a [`Template`] is intended to be shared / patched across scenes, it should be registered
     /// here.
     template_indices: TypeIdMap<usize>,
@@ -140,30 +169,108 @@ impl ResolvedScene {
     /// spawn all of this [`ResolvedScene`]'s related entities.
     ///
     /// If this [`ResolvedScene`] inherits from another scene, that scene will be applied _first_.
-    pub fn apply(&self, context: &mut TemplateContext) -> Result<(), ApplySceneError> {
+    ///
+    /// This _does not write_ the final `bundle_writer` contents to the entity in `context`.
+    ///
+    /// # Safety
+    ///
+    /// `bundle_writer` must either be empty or only contain components registered with the given
+    /// `context`'s World.
+    unsafe fn apply(
+        &self,
+        context: &mut TemplateContext,
+        bundle_writer: &mut BundleWriter,
+        skip_templates: impl SkipTemplate,
+    ) -> Result<(), ApplySceneError> {
         if let Some(inherited) = &self.inherited {
             let scene_patches = context.resource::<Assets<ScenePatch>>();
-            let Some(patch) = scene_patches.get(inherited) else {
+            let Some(patch) = scene_patches.get(&inherited.handle) else {
                 return Err(ApplySceneError::MissingInheritedScene {
-                    path: inherited.path().cloned(),
-                    id: inherited.id(),
+                    path: inherited.handle.path().cloned(),
+                    id: inherited.handle.id(),
                 });
             };
             let Some(resolved_inherited) = &patch.resolved else {
                 return Err(ApplySceneError::UnresolvedInheritedScene {
-                    path: inherited.path().cloned(),
-                    id: inherited.id(),
+                    path: inherited.handle.path().cloned(),
+                    id: inherited.handle.id(),
                 });
             };
             let resolved_inherited = resolved_inherited.clone();
-            resolved_inherited.apply(context.entity).map_err(|e| {
-                ApplySceneError::InheritedSceneApplyError {
-                    inherited: inherited.path().cloned(),
-                    error: Box::new(e),
+            let mut inherited_scoped_entites = resolved_inherited.new_scoped_entities();
+            let mut inherited_context = TemplateContext::new(
+                context.entity,
+                &mut inherited_scoped_entites,
+                &resolved_inherited.entity_scopes,
+            );
+            // SAFETY: bundle_writer is used with the same World across all template.apply calls,
+            // and the next bundle_writer.write call
+            unsafe {
+                resolved_inherited
+                    .scene
+                    .apply_templates_without_bundle_write(
+                        &mut inherited_context,
+                        bundle_writer,
+                        // this will skip building / inserting templates that
+                        // have local copies in the current scene
+                        // (inherited templates are copy-on-write)()
+                        &inherited.duplicate_templates,
+                    )
+                    .map_err(|e| ApplySceneError::InheritedSceneApplyError {
+                        inherited: inherited.handle.path().cloned(),
+                        error: Box::new(e),
+                    })?;
+                self.apply_templates_without_bundle_write(context, bundle_writer, skip_templates)?;
+                // SAFETY: World is only used for component registration, which does not affect
+                // the entity location
+                let components = &mut context.entity.world_mut().components_registrator();
+                // This inserts empty RelationshipTarget collections to avoid archetype moves when then related entities are spawned
+                // It pre-allocates space in the collection to avoid reallocs as related entities are added.
+                for related in self.related.values() {
+                    (related.insert_relationship_target)(
+                        bundle_writer,
+                        components,
+                        related.scenes.len(),
+                    );
                 }
-            })?;
-        }
 
+                bundle_writer.write(context.entity);
+
+                let mut inherited_context = TemplateContext::new(
+                    context.entity,
+                    &mut inherited_scoped_entites,
+                    &resolved_inherited.entity_scopes,
+                );
+                resolved_inherited
+                    .scene
+                    .apply_related(&mut inherited_context, bundle_writer)?;
+                self.apply_related(context, bundle_writer)?;
+            }
+        } else {
+            // SAFETY: bundle_writer was used with the same World across all cases in this function,
+            unsafe {
+                self.apply_templates_without_bundle_write(context, bundle_writer, skip_templates)?;
+                // SAFETY: World is only used for component registration, which does not affect
+                // the entity location
+                let components = &mut context.entity.world_mut().components_registrator();
+                // This inserts empty RelationshipTarget collections to avoid archetype moves when then related entities are spawned
+                // It pre-allocates space in the collection to avoid reallocs as related entities are added.
+                for related in self.related.values() {
+                    (related.insert_relationship_target)(
+                        bundle_writer,
+                        components,
+                        related.scenes.len(),
+                    );
+                }
+                bundle_writer.write(context.entity);
+                self.apply_related(context, bundle_writer)?;
+            }
+        };
+
+        Ok(())
+    }
+
+    fn set_current_entity_in_scope(&self, context: &mut TemplateContext) {
         if let Some(scoped_entity_index) = self.entity_indices.first().copied() {
             context.scoped_entities.set(
                 context.entity_scopes,
@@ -171,12 +278,53 @@ impl ResolvedScene {
                 context.entity.id(),
             );
         }
-        for template in &self.templates {
-            template
-                .apply(context)
-                .map_err(ApplySceneError::TemplateBuildError)?;
+    }
+
+    /// # Safety
+    ///
+    /// `bundle_writer` must either be empty or only contain components registered with the given
+    /// `context`'s World.
+    unsafe fn apply_templates_without_bundle_write(
+        &self,
+        context: &mut TemplateContext,
+        bundle_writer: &mut BundleWriter,
+        skip_templates: impl SkipTemplate,
+    ) -> Result<(), ApplySceneError> {
+        self.set_current_entity_in_scope(context);
+        for template in &self.component_templates {
+            if skip_templates.should_skip((**template).type_id()) {
+                continue;
+            }
+            // SAFETY: bundle_writer is used with the same World across all template.apply calls,
+            // and the next bundle_writer.write call
+            unsafe {
+                template
+                    .apply(context, bundle_writer)
+                    .map_err(ApplySceneError::TemplateBuildError)?;
+            }
         }
 
+        for template in &self.bundle_templates {
+            // SAFETY: bundle_writer is used with the same World across all template.apply calls,
+            // and the next bundle_writer.write call
+            unsafe {
+                template
+                    .apply(context)
+                    .map_err(ApplySceneError::TemplateBuildError)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// # Safety
+    ///
+    /// `bundle_writer` must either be empty or only contain components registered with the given
+    /// `context`'s World.
+    unsafe fn apply_related(
+        &self,
+        context: &mut TemplateContext,
+        bundle_writer: &mut BundleWriter,
+    ) -> Result<(), ApplySceneError> {
         for related_resolved_scenes in self.related.values() {
             let target = context.entity.id();
             context
@@ -195,19 +343,43 @@ impl ResolvedScene {
                         } else {
                             world.spawn_empty()
                         };
-                        (related_resolved_scenes.insert)(&mut entity, target);
+                        // SAFETY: bundle_writer is used with the same World across all template.apply calls,
+                        // and the next bundle_writer.write call
+                        unsafe {
+                            (related_resolved_scenes.insert_relationship)(
+                                bundle_writer,
+                                // SAFETY: World is only used for component registration, which does not affect
+                                // the entity location
+                                &mut entity.world_mut().components_registrator(),
+                                target,
+                            );
+                        };
                         // PERF: this will result in an archetype move
-                        scene
-                            .apply(&mut TemplateContext::new(
-                                &mut entity,
-                                context.scoped_entities,
-                                context.entity_scopes,
-                            ))
-                            .map_err(|e| ApplySceneError::RelatedSceneError {
-                                relationship_type_name: related_resolved_scenes.relationship_name,
-                                index,
-                                error: Box::new(e),
-                            })?;
+                        // SAFETY: bundle_writer is used with the same World across all template.apply calls,
+                        // and the next bundle_writer.write call
+                        unsafe {
+                            scene
+                                .apply(
+                                    &mut TemplateContext::new(
+                                        &mut entity,
+                                        context.scoped_entities,
+                                        context.entity_scopes,
+                                    ),
+                                    bundle_writer,
+                                    (),
+                                )
+                                .map_err(|e| ApplySceneError::RelatedSceneError {
+                                    relationship_type_name: related_resolved_scenes
+                                        .relationship_name,
+                                    index,
+                                    error: Box::new(e),
+                                })?;
+                        }
+                        // SAFETY: bundle_writer was used with the same World across all template.apply calls,
+                        // and this "write" call
+                        unsafe {
+                            bundle_writer.write(&mut entity);
+                        }
                     }
                     Ok(())
                 })?;
@@ -226,12 +398,15 @@ impl ResolvedScene {
     /// [`Template`] for a given [`TypeId`].
     pub fn get_or_insert_template<
         'a,
-        T: Template<Output: Bundle> + Default + Send + Sync + 'static,
+        T: Template<Output: Component> + Default + Send + Sync + 'static,
     >(
         &'a mut self,
         context: &mut ResolveContext,
     ) -> &'a mut T {
-        self.get_or_insert_erased_template(context, TypeId::of::<T>(), || Box::new(T::default()))
+        (self.get_or_insert_erased_template(context, TypeId::of::<T>(), || Box::new(T::default()))
+            as &mut dyn Any)
+            // PERF: this could be unchecked, given that we control what is stored here
+            // The method isn't stable yet, and it would require making get_or_insert_erased_template unsafe
             .downcast_mut()
             .unwrap()
     }
@@ -249,45 +424,52 @@ impl ResolvedScene {
         &'a mut self,
         context: &mut ResolveContext,
         type_id: TypeId,
-        default: fn() -> Box<dyn ErasedTemplate>,
-    ) -> &'a mut dyn ErasedTemplate {
-        self.internal_get_or_insert_template_with(type_id, || {
-            if let Some(inherited_scene) = context.inherited
-                && let Some(resolved_inherited) = &inherited_scene.resolved
+        default: fn() -> Box<dyn ErasedComponentTemplate>,
+    ) -> &'a mut dyn ErasedComponentTemplate {
+        let mut is_inherited = false;
+        let index = self.template_indices.entry(type_id).or_insert_with(|| {
+            let index = self.component_templates.len();
+            let value = if let Some(inherited_patch) = &mut context.inherited
+                && let Some(resolved_inherited) = &inherited_patch.resolved
                 && let Some(inherited_template) =
                     resolved_inherited.scene.get_direct_erased_template(type_id)
             {
+                is_inherited = true;
                 inherited_template.clone_template()
             } else {
                 default()
-            }
-        })
-    }
-
-    fn internal_get_or_insert_template_with(
-        &mut self,
-        type_id: TypeId,
-        get_value: impl FnOnce() -> Box<dyn ErasedTemplate>,
-    ) -> &mut dyn ErasedTemplate {
-        let index = self.template_indices.entry(type_id).or_insert_with(|| {
-            let index = self.templates.len();
-            self.templates.push(get_value());
+            };
+            self.component_templates.push(value);
             index
         });
-        self.templates
+        let template = self
+            .component_templates
             .get_mut(*index)
             .map(|value| &mut **value)
-            .unwrap()
+            .unwrap();
+
+        if is_inherited {
+            self.inherited
+                .as_mut()
+                .unwrap()
+                .duplicate_templates
+                .insert(type_id);
+        }
+
+        template
     }
 
     /// Returns the [`ErasedTemplate`] for the given `type_id`, if it exists in this [`ResolvedScene`]. This ignores scene inheritance.
-    pub fn get_direct_erased_template(&self, type_id: TypeId) -> Option<&dyn ErasedTemplate> {
+    pub fn get_direct_erased_template(
+        &self,
+        type_id: TypeId,
+    ) -> Option<&dyn ErasedComponentTemplate> {
         let index = self.template_indices.get(&type_id)?;
-        Some(&*self.templates[*index])
+        Some(&*self.component_templates[*index])
     }
 
     /// Adds the `template` to the "back" of the [`ResolvedScene`] (it will applied later than earlier [`Template`]s).
-    pub fn push_template<T: Template<Output: Bundle> + Send + Sync + 'static>(
+    pub fn push_template<T: Template<Output: Component> + Send + Sync + 'static>(
         &mut self,
         template: T,
     ) {
@@ -295,10 +477,22 @@ impl ResolvedScene {
     }
 
     /// Adds the `template` to the "back" of the [`ResolvedScene`] (it will applied later than earlier [`Template`]s).
-    pub fn push_template_erased(&mut self, template: Box<dyn ErasedTemplate>) {
-        self.templates.push(template);
+    pub fn push_template_erased(&mut self, template: Box<dyn ErasedComponentTemplate>) {
+        self.component_templates.push(template);
     }
 
+    /// Adds the `template` to the "back" of the [`ResolvedScene`] (it will applied later than earlier [`Template`]s).
+    pub fn push_bundle_template<T: Template<Output: Bundle> + Send + Sync + 'static>(
+        &mut self,
+        template: T,
+    ) {
+        self.push_bundle_template_erased(Box::new(template));
+    }
+
+    /// Adds the `template` to the "back" of the [`ResolvedScene`] (it will applied later than earlier [`Template`]s).
+    pub fn push_bundle_template_erased(&mut self, template: Box<dyn ErasedBundleTemplate>) {
+        self.bundle_templates.push(template);
+    }
     /// This will return the existing [`RelatedResolvedScenes`], if it exists. If not, a new empty [`RelatedResolvedScenes`] will be inserted and returned.
     ///
     /// This is used to add new related scenes and read existing related scenes.
@@ -317,19 +511,33 @@ impl ResolvedScene {
     pub fn inherit(&mut self, handle: Handle<ScenePatch>) -> Result<(), InheritSceneError> {
         if let Some(inherited) = &self.inherited {
             return Err(InheritSceneError::MultipleInheritance {
-                id: inherited.id().untyped(),
-                path: inherited.path().cloned(),
+                id: inherited.handle.id().untyped(),
+                path: inherited.handle.path().cloned(),
             });
         }
-        if !(self.templates.is_empty() && self.related.is_empty()) {
+        if !(self.component_templates.is_empty() && self.related.is_empty()) {
             return Err(InheritSceneError::LateInheritance {
                 id: handle.id().untyped(),
                 path: handle.path().cloned(),
             });
         }
-        self.inherited = Some(handle);
+        self.inherited = Some(InheritedSceneInfo {
+            handle,
+            duplicate_templates: HashSet::default(),
+        });
         Ok(())
     }
+}
+
+/// Information about a [`ResolvedScene`]'s inherited scene.
+#[derive(Debug)]
+pub(crate) struct InheritedSceneInfo {
+    /// The handle of the inherited scene.
+    pub(crate) handle: Handle<ScenePatch>,
+    /// Template types that occur in _both_ the current scene and its inherited scene.
+    /// This is used to skip insertion of these types when applying the inherited
+    /// resolved scene.
+    pub(crate) duplicate_templates: HashSet<TypeId>,
 }
 
 /// The error returned by [`ResolvedScene::inherit`].
@@ -402,8 +610,11 @@ pub enum ApplySceneError {
 pub struct RelatedResolvedScenes {
     /// The related resolved scenes. Each entry in the list corresponds to a new related entity that will be spawned with the given scene.
     pub scenes: Vec<ResolvedScene>,
-    /// The function that will be called to add the relationship to the spawned scene.
-    pub insert: fn(&mut EntityWorldMut, target: Entity),
+    /// The function that will be called to add the relationship to the spawned related scene.
+    pub insert_relationship:
+        unsafe fn(&mut BundleWriter, &mut ComponentsRegistrator, target: Entity),
+    /// The function that will be called to add the relationship target to the spawned scene with the given capacity.
+    pub insert_relationship_target: unsafe fn(&mut BundleWriter, &mut ComponentsRegistrator, usize),
     /// The type name of the relationship. This is used for more helpful error message.
     pub relationship_name: &'static str,
 }
@@ -421,10 +632,109 @@ impl RelatedResolvedScenes {
     pub fn new<R: Relationship>() -> Self {
         Self {
             scenes: Vec::new(),
-            insert: |entity, target| {
-                entity.insert(R::from(target));
+            insert_relationship: |bundle_writer, components_registrator, target| {
+                // SAFETY: caller ensures bundler_writer is always used with the same World
+                unsafe { bundle_writer.push_component(components_registrator, R::from(target)) };
+            },
+            insert_relationship_target: |bundle_writer, components_registrator, capacity| {
+                let relationship_target =
+                    <<R as Relationship>::RelationshipTarget as RelationshipTarget>::with_capacity(
+                        capacity,
+                    );
+                // SAFETY: caller ensures bundler_writer is always used with the same World
+                unsafe {
+                    bundle_writer.push_component(components_registrator, relationship_target);
+                };
             },
             relationship_name: core::any::type_name::<R>(),
         }
+    }
+}
+
+/// A type-erased, object-safe, downcastable version of [`Template`] that produces a [`Component`], which will be added to the
+/// given [`BundleWriter`].
+pub trait ErasedComponentTemplate: Any + Send + Sync {
+    /// Applies this template to the given `entity`.
+    ///
+    /// # Safety
+    ///
+    /// `bundle_writer` must always be used with the same World that is stored in `context`. This
+    /// is intended to be used by a scene system in a scoped / controlled / easily verifiable context.
+    /// If you are calling it outside of that context, you are almost certainly doing something wrong!
+    unsafe fn apply(
+        &self,
+        context: &mut TemplateContext,
+        bundle_writer: &mut BundleWriter,
+    ) -> Result<(), BevyError>;
+
+    /// Clones this template. See [`Clone`].
+    fn clone_template(&self) -> Box<dyn ErasedComponentTemplate>;
+}
+
+impl<T: Template<Output: Component> + Send + Sync + 'static> ErasedComponentTemplate for T {
+    unsafe fn apply(
+        &self,
+        context: &mut TemplateContext,
+        bundle_writer: &mut BundleWriter,
+    ) -> Result<(), BevyError> {
+        let component = self.build_template(context)?;
+        // SAFETY: world_mut is only used to register components, which does not affect entity location
+        let mut components = unsafe { context.entity.world_mut().components_registrator() };
+        // SAFETY: The caller verifies that `bundle_writer` is always used with the same World.
+        unsafe { bundle_writer.push_component(&mut components, component) };
+
+        Ok(())
+    }
+
+    fn clone_template(&self) -> Box<dyn ErasedComponentTemplate> {
+        Box::new(Template::clone_template(self))
+    }
+}
+
+/// A type-erased, object-safe, downcastable version of [`Template`] that produces a [`Bundle`], which will be added
+/// immediately to a given `entity`.
+pub trait ErasedBundleTemplate: Any + Send + Sync {
+    /// Applies this template to the given `entity`.
+    ///
+    /// # Safety
+    ///
+    /// `bundle_writer` must always be used with the same World that is stored in `context`. This
+    /// is intended to be used by a scene system in a scoped / controlled / easily verifiable context.
+    /// If you are calling it outside of that context, you are almost certainly doing something wrong!
+    unsafe fn apply(&self, context: &mut TemplateContext) -> Result<(), BevyError>;
+
+    /// Clones this template. See [`Clone`].
+    fn clone_template(&self) -> Box<dyn ErasedBundleTemplate>;
+}
+
+impl<T: Template<Output: Bundle> + Send + Sync + 'static> ErasedBundleTemplate for T {
+    unsafe fn apply(&self, context: &mut TemplateContext) -> Result<(), BevyError> {
+        let bundle = self.build_template(context)?;
+        context.entity.insert(bundle);
+        Ok(())
+    }
+
+    fn clone_template(&self) -> Box<dyn ErasedBundleTemplate> {
+        Box::new(Template::clone_template(self))
+    }
+}
+
+/// A filter to skip the template for a given `TypeId`
+trait SkipTemplate {
+    /// Returns true if the template with `type_id` should be skipped.
+    fn should_skip(&self, type_id: TypeId) -> bool;
+}
+
+impl SkipTemplate for &HashSet<TypeId> {
+    #[inline]
+    fn should_skip(&self, type_id: TypeId) -> bool {
+        self.contains(&type_id)
+    }
+}
+
+impl SkipTemplate for () {
+    #[inline]
+    fn should_skip(&self, _type_id: TypeId) -> bool {
+        false
     }
 }

--- a/crates/bevy_scene/src/resolved_scene.rs
+++ b/crates/bevy_scene/src/resolved_scene.rs
@@ -197,10 +197,10 @@ impl ResolvedScene {
                 });
             };
             let resolved_inherited = resolved_inherited.clone();
-            let mut inherited_scoped_entites = resolved_inherited.new_scoped_entities();
+            let mut inherited_scoped_entities = resolved_inherited.new_scoped_entities();
             let mut inherited_context = TemplateContext::new(
                 context.entity,
-                &mut inherited_scoped_entites,
+                &mut inherited_scoped_entities,
                 &resolved_inherited.entity_scopes,
             );
             // SAFETY: bundle_writer is used with the same World across all template.apply calls,
@@ -238,7 +238,7 @@ impl ResolvedScene {
 
                 let mut inherited_context = TemplateContext::new(
                     context.entity,
-                    &mut inherited_scoped_entites,
+                    &mut inherited_scoped_entities,
                     &resolved_inherited.entity_scopes,
                 );
                 resolved_inherited

--- a/crates/bevy_scene/src/resolved_scene.rs
+++ b/crates/bevy_scene/src/resolved_scene.rs
@@ -1,7 +1,7 @@
 use crate::{ResolveContext, ScenePatch};
 use bevy_asset::{AssetId, AssetPath, Assets, Handle, UntypedAssetId};
 use bevy_ecs::{
-    bundle::{Bundle, BundleWriter},
+    bundle::{Bundle, BundleScratch, BundleWriter},
     component::{Component, ComponentsRegistrator},
     entity::Entity,
     error::{BevyError, Result},
@@ -27,8 +27,7 @@ impl ResolvedSceneRoot {
     /// If this fails mid-spawn, the intermediate entity will be despawned.
     pub fn spawn<'w>(&self, world: &'w mut World) -> Result<EntityWorldMut<'w>, ApplySceneError> {
         let mut entity = world.spawn_empty();
-        // SAFETY: bundle writer is empty
-        let result = unsafe { self.apply(&mut entity, &mut BundleWriter::default()) };
+        let result = self.apply(&mut entity, &mut BundleScratch::default());
         match result {
             Ok(_) => Ok(entity),
             Err(err) => {
@@ -44,26 +43,19 @@ impl ResolvedSceneRoot {
     /// spawn all of this [`ResolvedScene`]'s related entities.
     ///
     /// If this root [`ResolvedScene`] inherits from another scene, that scene will be applied _first_.
-    ///
-    /// # Safety
-    ///
-    /// `bundle_writer` must either be empty, or contain only components with ids registered in
-    /// `entity`'s World
-    pub unsafe fn apply(
+    pub fn apply(
         &self,
         entity: &mut EntityWorldMut,
-        bundle_writer: &mut BundleWriter,
+        bundle_scratch: &mut BundleScratch,
     ) -> Result<(), ApplySceneError> {
         let mut scoped_entities = self.new_scoped_entities();
         let mut context = TemplateContext::new(entity, &mut scoped_entities, &self.entity_scopes);
 
-        // SAFETY: caller verifies that `bundle_writer` is either empty or contains component ids registered
-        // in `entity`'s World
-        let result = unsafe { self.scene.apply(&mut context, bundle_writer) };
-        if result.is_err() {
+        let result = self.scene.apply(&mut context, bundle_scratch);
+        if !bundle_scratch.is_empty() {
             // SAFETY: Components comes from the same world as the `context` passed in to self.scene.apply above
             unsafe {
-                bundle_writer.manual_drop(entity.world().components());
+                bundle_scratch.manual_drop(entity.world().components());
             }
         }
         result
@@ -95,7 +87,7 @@ impl ResolvedSceneListRoot {
     ) -> Result<Vec<Entity>, ApplySceneError> {
         let mut entities = Vec::new();
         let mut scoped_entities = ScopedEntities::new(self.entity_scopes.entity_len());
-        let mut bundle_writer = BundleWriter::default();
+        let mut bundle_scratch = BundleScratch::default();
         for scene in self.scenes.iter() {
             let mut entity = if let Some(scoped_entity_index) =
                 scene.entity_indices.first().copied()
@@ -108,21 +100,14 @@ impl ResolvedSceneListRoot {
 
             func(&mut entity);
             entities.push(entity.id());
-            // SAFETY: bundle_writer is always used with the same world
-            let result = unsafe {
-                scene.apply(
-                    &mut TemplateContext::new(
-                        &mut entity,
-                        &mut scoped_entities,
-                        &self.entity_scopes,
-                    ),
-                    &mut bundle_writer,
-                )
-            };
+            let result = scene.apply(
+                &mut TemplateContext::new(&mut entity, &mut scoped_entities, &self.entity_scopes),
+                &mut bundle_scratch,
+            );
             if let Err(err) = result {
                 // SAFETY: Components comes from the same world as the `context` passed in to self.scene.apply above
                 unsafe {
-                    bundle_writer.manual_drop(entity.world().components());
+                    bundle_scratch.manual_drop(entity.world().components());
                 }
                 return Err(err);
             }
@@ -184,16 +169,32 @@ impl ResolvedScene {
     /// spawn all of this [`ResolvedScene`]'s related entities.
     ///
     /// If this [`ResolvedScene`] inherits from another scene, that scene will be applied _first_.
-    ///
-    /// # Safety
-    ///
-    /// `bundle_writer` must either be empty or only contain components registered with the given
-    /// `context`'s World.
-    unsafe fn apply(
+    fn apply(
         &self,
         context: &mut TemplateContext,
-        bundle_writer: &mut BundleWriter,
+        bundle_scratch: &mut BundleScratch,
     ) -> Result<(), ApplySceneError> {
+        self.apply_with(context, bundle_scratch, |_, _| {})
+    }
+
+    /// Applies this scene to the given [`TemplateContext`] (which holds an already-spawned [`EntityWorldMut`]).
+    ///
+    /// This will apply all of the [`Template`]s in this [`ResolvedScene`] to the entity in the [`TemplateContext`]. It will also
+    /// spawn all of this [`ResolvedScene`]'s related entities.
+    ///
+    /// If this [`ResolvedScene`] inherits from another scene, that scene will be applied _first_.
+    ///
+    /// This will call `writer_ops` right before calling [`BundleWriter::write`]. This will pass in the `context` value,
+    /// which is the same context used to write all of the scene components to the [`BundleWriter`]. This ensures that
+    /// writing to [`BundleWriter`] with the [`TemplateContext`] is safe (although those functions, if they are called, are still
+    /// unsafe functions / the caller should verify they are using the passed in `context`).
+    fn apply_with(
+        &self,
+        context: &mut TemplateContext,
+        bundle_scratch: &mut BundleScratch,
+        writer_ops: impl FnOnce(&mut TemplateContext, &mut BundleWriter),
+    ) -> Result<(), ApplySceneError> {
+        let mut bundle_writer = bundle_scratch.writer();
         if let Some(inherited) = &self.inherited {
             let scene_patches = context.resource::<Assets<ScenePatch>>();
             let Some(patch) = scene_patches.get(&inherited.handle) else {
@@ -222,7 +223,7 @@ impl ResolvedScene {
                     .scene
                     .apply_templates_without_bundle_write(
                         &mut inherited_context,
-                        bundle_writer,
+                        &mut bundle_writer,
                         // this will skip building / inserting templates that
                         // have local copies in the current scene
                         // (inherited templates are copy-on-write)()
@@ -232,7 +233,7 @@ impl ResolvedScene {
                         inherited: inherited.handle.path().cloned(),
                         error: Box::new(e),
                     })?;
-                self.apply_templates_without_bundle_write(context, bundle_writer, ())?;
+                self.apply_templates_without_bundle_write(context, &mut bundle_writer, ())?;
                 // SAFETY: World is only used for component registration, which does not affect
                 // the entity location
                 let components = &mut context.entity.world_mut().components_registrator();
@@ -240,11 +241,13 @@ impl ResolvedScene {
                 // It pre-allocates space in the collection to avoid reallocs as related entities are added.
                 for related in self.related.values() {
                     (related.insert_relationship_target)(
-                        bundle_writer,
+                        &mut bundle_writer,
                         components,
                         related.scenes.len(),
                     );
                 }
+
+                (writer_ops)(context, &mut bundle_writer);
 
                 bundle_writer.write(context.entity);
 
@@ -255,13 +258,13 @@ impl ResolvedScene {
                 );
                 resolved_inherited
                     .scene
-                    .apply_related(&mut inherited_context, bundle_writer)?;
-                self.apply_related(context, bundle_writer)?;
+                    .apply_related(&mut inherited_context, bundle_scratch)?;
+                self.apply_related(context, bundle_scratch)?;
             }
         } else {
             // SAFETY: bundle_writer was used with the same World across all cases in this function,
             unsafe {
-                self.apply_templates_without_bundle_write(context, bundle_writer, ())?;
+                self.apply_templates_without_bundle_write(context, &mut bundle_writer, ())?;
                 // SAFETY: World is only used for component registration, which does not affect
                 // the entity location
                 let components = &mut context.entity.world_mut().components_registrator();
@@ -269,13 +272,14 @@ impl ResolvedScene {
                 // It pre-allocates space in the collection to avoid reallocs as related entities are added.
                 for related in self.related.values() {
                     (related.insert_relationship_target)(
-                        bundle_writer,
+                        &mut bundle_writer,
                         components,
                         related.scenes.len(),
                     );
                 }
+                (writer_ops)(context, &mut bundle_writer);
                 bundle_writer.write(context.entity);
-                self.apply_related(context, bundle_writer)?;
+                self.apply_related(context, bundle_scratch)?;
             }
         };
 
@@ -328,14 +332,10 @@ impl ResolvedScene {
         Ok(())
     }
 
-    /// # Safety
-    ///
-    /// `bundle_writer` must either be empty or only contain components registered with the given
-    /// `context`'s World.
-    unsafe fn apply_related(
+    fn apply_related(
         &self,
         context: &mut TemplateContext,
-        bundle_writer: &mut BundleWriter,
+        bundle_scratch: &mut BundleScratch,
     ) -> Result<(), ApplySceneError> {
         for related_resolved_scenes in self.related.values() {
             let target = context.entity.id();
@@ -355,42 +355,37 @@ impl ResolvedScene {
                         } else {
                             world.spawn_empty()
                         };
-                        // SAFETY: bundle_writer is used with the same World across all template.apply calls,
-                        // and the next bundle_writer.write call
-                        unsafe {
-                            (related_resolved_scenes.insert_relationship)(
-                                bundle_writer,
-                                // SAFETY: World is only used for component registration, which does not affect
-                                // the entity location
-                                &mut entity.world_mut().components_registrator(),
-                                target,
-                            );
-                        };
-                        // PERF: this will result in an archetype move
-                        // SAFETY: bundle_writer is used with the same World across all template.apply calls,
-                        // and the next bundle_writer.write call
-                        unsafe {
-                            scene
-                                .apply(
-                                    &mut TemplateContext::new(
-                                        &mut entity,
-                                        context.scoped_entities,
-                                        context.entity_scopes,
-                                    ),
-                                    bundle_writer,
-                                )
-                                .map_err(|e| ApplySceneError::RelatedSceneError {
-                                    relationship_type_name: related_resolved_scenes
-                                        .relationship_name,
-                                    index,
-                                    error: Box::new(e),
-                                })?;
-                        }
-                        // SAFETY: bundle_writer was used with the same World across all template.apply calls,
-                        // and this "write" call
-                        unsafe {
-                            bundle_writer.write(&mut entity);
-                        }
+
+                        scene
+                            .apply_with(
+                                &mut TemplateContext::new(
+                                    &mut entity,
+                                    context.scoped_entities,
+                                    context.entity_scopes,
+                                ),
+                                bundle_scratch,
+                                |context, bundle_writer| {
+                                    // SAFETY: `context` is used to write all previous `bundle_writer` components
+                                    // and is also used to write this relationship component
+                                    unsafe {
+                                        (related_resolved_scenes.insert_relationship)(
+                                            bundle_writer,
+                                            // SAFETY: World is only used for component registration, which does not affect
+                                            // the entity location
+                                            &mut context
+                                                .entity
+                                                .world_mut()
+                                                .components_registrator(),
+                                            target,
+                                        );
+                                    }
+                                },
+                            )
+                            .map_err(|e| ApplySceneError::RelatedSceneError {
+                                relationship_type_name: related_resolved_scenes.relationship_name,
+                                index,
+                                error: Box::new(e),
+                            })?;
                     }
                     Ok(())
                 })?;

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -2,6 +2,7 @@ use crate::{InheritSceneError, ResolvedScene, SceneList, ScenePatch};
 use bevy_asset::{Asset, AssetPath, AssetServer, Assets};
 use bevy_ecs::{
     bundle::Bundle,
+    component::Component,
     error::Result,
     event::EntityEvent,
     name::Name,
@@ -280,7 +281,7 @@ impl<T: Template> PatchTemplate for T {
 
 impl<
         F: Fn(&mut T, &mut ResolveContext) + Send + Sync + 'static,
-        T: Template<Output: Bundle> + Send + Sync + Default + 'static,
+        T: Template<Output: Component> + Send + Sync + Default + 'static,
     > Scene for TemplatePatch<F, T>
 {
     fn resolve(
@@ -371,7 +372,7 @@ impl Scene for InheritSceneAsset {
     }
 }
 
-impl<F: (Fn(&mut TemplateContext) -> Result<O>) + Clone + Send + Sync + 'static, O: Bundle> Scene
+impl<F: (Fn(&mut TemplateContext) -> Result<O>) + Clone + Send + Sync + 'static, O: Component> Scene
     for FnTemplate<F, O>
 {
     fn resolve(
@@ -491,7 +492,7 @@ impl<
         _context: &mut ResolveContext,
         scene: &mut ResolvedScene,
     ) -> Result<(), ResolveSceneError> {
-        scene.push_template(OnTemplate(self.0.clone(), PhantomData));
+        scene.push_bundle_template(OnTemplate(self.0.clone(), PhantomData));
         Ok(())
     }
 }

--- a/crates/bevy_scene/src/scene_patch.rs
+++ b/crates/bevy_scene/src/scene_patch.rs
@@ -6,7 +6,7 @@ use alloc::sync::Arc;
 use bevy_asset::{Asset, AssetServer, Assets, Handle, LoadFromPath, UntypedHandle};
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
-    bundle::BundleWriter,
+    bundle::BundleScratch,
     component::Component,
     entity::Entity,
     template::{EntityScopes, FromTemplate},
@@ -105,12 +105,9 @@ impl ScenePatch {
             .resolved
             .as_deref()
             .ok_or(SpawnSceneError::UnresolvedSceneError)?;
-        // SAFETY: `bundle_writer` is empty
-        unsafe {
-            resolved
-                .apply(entity, &mut BundleWriter::default())
-                .map_err(SpawnSceneError::ApplySceneError)
-        }
+        resolved
+            .apply(entity, &mut BundleScratch::default())
+            .map_err(SpawnSceneError::ApplySceneError)
     }
 }
 

--- a/crates/bevy_scene/src/scene_patch.rs
+++ b/crates/bevy_scene/src/scene_patch.rs
@@ -117,7 +117,7 @@ impl ScenePatch {
 /// An [`Error`] that occurs during scene spawning.
 #[derive(Error, Debug)]
 pub enum SpawnSceneError {
-    /// Calling [`ResolvedScene::apply`] failed.
+    /// Failed to apply a [`ResolvedScene`]s.
     #[error(transparent)]
     ApplySceneError(#[from] ApplySceneError),
     #[error(transparent)]

--- a/crates/bevy_scene/src/scene_patch.rs
+++ b/crates/bevy_scene/src/scene_patch.rs
@@ -6,6 +6,7 @@ use alloc::sync::Arc;
 use bevy_asset::{Asset, AssetServer, Assets, Handle, LoadFromPath, UntypedHandle};
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
+    bundle::BundleWriter,
     component::Component,
     entity::Entity,
     template::{EntityScopes, FromTemplate},
@@ -104,9 +105,12 @@ impl ScenePatch {
             .resolved
             .as_deref()
             .ok_or(SpawnSceneError::UnresolvedSceneError)?;
-        resolved
-            .apply(entity)
-            .map_err(SpawnSceneError::ApplySceneError)
+        // SAFETY: `bundle_writer` is empty
+        unsafe {
+            resolved
+                .apply(entity, &mut BundleWriter::default())
+                .map_err(SpawnSceneError::ApplySceneError)
+        }
     }
 }
 

--- a/crates/bevy_scene/src/spawn.rs
+++ b/crates/bevy_scene/src/spawn.rs
@@ -2,7 +2,7 @@ use crate::{Scene, SceneList, SceneListPatch, ScenePatch, ScenePatchInstance, Sp
 use alloc::sync::Arc;
 use bevy_asset::{AssetEvent, AssetServer, Assets, Handle};
 use bevy_ecs::{
-    bundle::BundleWriter, message::MessageCursor, prelude::*, relationship::Relationship,
+    bundle::BundleScratch, message::MessageCursor, prelude::*, relationship::Relationship,
 };
 use bevy_platform::collections::HashMap;
 use tracing::error;
@@ -678,7 +678,7 @@ pub fn on_add_scene_patch_instance(
 pub fn spawn_queued(
     world: &mut World,
     scene_patch_instances: &mut QueryState<&ScenePatchInstance>,
-    mut bundle_writer: Local<BundleWriter>,
+    mut bundle_scratch: Local<BundleScratch>,
     mut reader: Local<MessageCursor<AssetEvent<ScenePatch>>>,
     mut list_reader: Local<MessageCursor<AssetEvent<SceneListPatch>>>,
 ) {
@@ -691,7 +691,7 @@ pub fn spawn_queued(
                 queued.spawn_queued(
                     world,
                     scene_patch_instances,
-                    &mut bundle_writer,
+                    &mut bundle_scratch,
                     &list_patches,
                 );
             }
@@ -706,10 +706,7 @@ pub fn spawn_queued(
                         for entity in entities {
                             if let Ok(mut entity_mut) = world.get_entity_mut(entity)
                                 && let Err(err) =
-                                    // SAFETY: bundle_writer is always used with `world`
-                                    unsafe {
-                                        resolved.apply(&mut entity_mut, &mut bundle_writer)
-                                    }
+                                    resolved.apply(&mut entity_mut, &mut bundle_scratch)
                             {
                                 error!(
                                     "Failed to apply scene (id: {}) to entity {entity}: {}",
@@ -769,7 +766,7 @@ impl QueuedScenes {
         &mut self,
         world: &mut World,
         scene_patch_instances: &mut QueryState<&ScenePatchInstance>,
-        bundle_writer: &mut BundleWriter,
+        bundle_scratch: &mut BundleScratch,
         list_patches: &Assets<SceneListPatch>,
     ) {
         for entity in core::mem::take(&mut self.new_scene_entities) {
@@ -779,8 +776,7 @@ impl QueuedScenes {
             let patches = world.resource::<Assets<ScenePatch>>();
             if let Some(resolved) = patches.get(handle).and_then(|p| p.resolved.clone()) {
                 let mut entity_mut = world.get_entity_mut(entity).unwrap();
-                // SAFETY: bundle_writer is always used with `world`
-                if let Err(err) = unsafe { resolved.apply(&mut entity_mut, bundle_writer) } {
+                if let Err(err) = resolved.apply(&mut entity_mut, bundle_scratch) {
                     let scene_patch_instance = scene_patch_instances.get(world, entity).unwrap();
                     let handle = &scene_patch_instance.0;
                     let id = handle.id();

--- a/crates/bevy_scene/src/spawn.rs
+++ b/crates/bevy_scene/src/spawn.rs
@@ -1,7 +1,9 @@
 use crate::{Scene, SceneList, SceneListPatch, ScenePatch, ScenePatchInstance, SpawnSceneError};
 use alloc::sync::Arc;
 use bevy_asset::{AssetEvent, AssetServer, Assets, Handle};
-use bevy_ecs::{message::MessageCursor, prelude::*, relationship::Relationship};
+use bevy_ecs::{
+    bundle::BundleWriter, message::MessageCursor, prelude::*, relationship::Relationship,
+};
 use bevy_platform::collections::HashMap;
 use tracing::error;
 
@@ -676,6 +678,7 @@ pub fn on_add_scene_patch_instance(
 pub fn spawn_queued(
     world: &mut World,
     scene_patch_instances: &mut QueryState<&ScenePatchInstance>,
+    mut bundle_writer: Local<BundleWriter>,
     mut reader: Local<MessageCursor<AssetEvent<ScenePatch>>>,
     mut list_reader: Local<MessageCursor<AssetEvent<SceneListPatch>>>,
 ) {
@@ -685,7 +688,12 @@ pub fn spawn_queued(
                 if queued.is_empty() {
                     break;
                 }
-                queued.spawn_queued(world, scene_patch_instances, &list_patches);
+                queued.spawn_queued(
+                    world,
+                    scene_patch_instances,
+                    &mut bundle_writer,
+                    &list_patches,
+                );
             }
 
             world.resource_scope(|world, events: Mut<Messages<AssetEvent<ScenePatch>>>| {
@@ -697,7 +705,11 @@ pub fn spawn_queued(
                     {
                         for entity in entities {
                             if let Ok(mut entity_mut) = world.get_entity_mut(entity)
-                                && let Err(err) = resolved.apply(&mut entity_mut)
+                                && let Err(err) =
+                                    // SAFETY: bundle_writer is always used with `world`
+                                    unsafe {
+                                        resolved.apply(&mut entity_mut, &mut bundle_writer)
+                                    }
                             {
                                 error!(
                                     "Failed to apply scene (id: {}) to entity {entity}: {}",
@@ -757,6 +769,7 @@ impl QueuedScenes {
         &mut self,
         world: &mut World,
         scene_patch_instances: &mut QueryState<&ScenePatchInstance>,
+        bundle_writer: &mut BundleWriter,
         list_patches: &Assets<SceneListPatch>,
     ) {
         for entity in core::mem::take(&mut self.new_scene_entities) {
@@ -766,7 +779,8 @@ impl QueuedScenes {
             let patches = world.resource::<Assets<ScenePatch>>();
             if let Some(resolved) = patches.get(handle).and_then(|p| p.resolved.clone()) {
                 let mut entity_mut = world.get_entity_mut(entity).unwrap();
-                if let Err(err) = resolved.apply(&mut entity_mut) {
+                // SAFETY: bundle_writer is always used with `world`
+                if let Err(err) = unsafe { resolved.apply(&mut entity_mut, bundle_writer) } {
                     let scene_patch_instance = scene_patch_instances.get(world, entity).unwrap();
                     let handle = &scene_patch_instance.0;
                     let id = handle.id();


### PR DESCRIPTION
# Objective

Currently BSN inserts each component one-by-one. This is incredibly expensive, as it forces an archetype move after every insert.

## Solution

Scene templates now write their outputs to reusable bundle scratch space (which uses a bump allocator). The final bundle is written after all components (including inherited components) are written to the bundle.

- Introduce a `BundleWriter`, which enables defining a dynamic bundle using scratch space in a bump allocator. Currently this only supports writing individual components to the `BundleWriter`, because supporting arbitrary bundles is much harder (ex: dynamic bundle effects). This sadly means that we are temporarily constraining both `bsn! { Node }` and `bsn! { @SomeTemplate }` "template patches"  to _require_ a component output. Custom scene impls can still push arbitrary bundles, which are inserted before the final dynamic bundle write. In practice I believe this will cover the relevant use cases in the short term.
- We now skip duplicate insertions of components when spawning inherited scenes.
- We now write empty RelationshipTarget collections, pre-allocated to the correct size to the dynamic bundle, which both avoids another archetype move and ensures we only allocate the inner relationship target collection once.
- We now write the Relationship component to the dynamic bundle, avoiding an archetype move
- I added a new "loaded scene inheritance" test variant, just to make sure that case still works
- `ErasedTemplate` has been moved to `bevy_scene`, as it is now "opinionated", more specific to `bevy_scene`, and less safe to use in a general context

<img width="795" height="274" alt="image" src="https://github.com/user-attachments/assets/68ea02c7-6b7e-4f7c-9474-603188fe6d0b" />

These are benchmarks that produce the same UI scene hierarchy through different means (the benchmarks have been updated to have a few "matrix wrapper" components to show the cost of archetype moves):
- `immediate_function_scene`: a test of going through the whole "scene building" process, then spawning. this is the cost of ad-hoc scenes that don't reuse work from inherited scenes
- `immediate_loaded_scene`: a test where we instantiate a bunch of inherited scene instances, where the inherited scene has already been computed / cached.
- `raw_bundle_no_scene`: just spawning the raw bundle directly