### PR TITLE
Solari: Fix self-intersection artifacts

### DIFF
--- a/crates/bevy_solari/src/pathtracer/pathtracer.wgsl
+++ b/crates/bevy_solari/src/pathtracer/pathtracer.wgsl
@@ -74,7 +74,7 @@ fn pathtrace(@builtin(global_invocation_id) global_id: vec3<u32>) {
             let next_bounce = evaluate_and_sample_brdf(wo, ray_hit.world_normal, ray_hit.world_tangent, ray_hit.material, &rng);
             if next_bounce.pdf == 0.0 { break; }
             ray_direction = next_bounce.wi;
-            ray_origin = ray_hit.world_position;
+            ray_origin = ray_hit.world_position + (ray_hit.geometric_world_normal * RAY_T_MIN);
             ray_t_min = RAY_T_MIN;
             p_bounce = next_bounce.pdf;
             throughput *= next_bounce.throughput;

--- a/crates/bevy_solari/src/realtime/restir_di.wgsl
+++ b/crates/bevy_solari/src/realtime/restir_di.wgsl
@@ -12,7 +12,7 @@ enable wgpu_ray_query;
 #import bevy_solari::gbuffer_utils::{gpixel_resolve, pixel_dissimilar, permute_pixel}
 #import bevy_solari::presample_light_tiles::unpack_resolved_light_sample
 #import bevy_solari::sampling::{LightSample, NULL_LIGHT_ID, calculate_resolved_light_contribution, resolve_and_calculate_light_contribution, resolve_light_sample, trace_light_visibility, balance_heuristic}
-#import bevy_solari::scene_bindings::{light_sources, previous_frame_light_id_translations, LIGHT_NOT_PRESENT_THIS_FRAME}
+#import bevy_solari::scene_bindings::{light_sources, previous_frame_light_id_translations, LIGHT_NOT_PRESENT_THIS_FRAME, RAY_T_MIN}
 #import bevy_solari::specular_gi::SPECULAR_GI_FOR_DI_ROUGHNESS_THRESHOLD
 #import bevy_solari::realtime_bindings::{view_output, light_tile_samples, light_tile_resolved_samples, di_reservoirs_a, di_reservoirs_b, gbuffer, depth_buffer, motion_vectors, previous_gbuffer, previous_depth_buffer, view, previous_view, constants, ResolvedLightSamplePacked}
 
@@ -71,7 +71,7 @@ fn spatial_and_shade(@builtin(global_invocation_id) global_id: vec3<u32>) {
 
     if reservoir_valid(combined_reservoir) {
         let resolved_light_sample = resolve_light_sample(combined_reservoir.sample, light_sources[combined_reservoir.sample.light_id >> 16u]);
-        combined_reservoir.unbiased_contribution_weight *= trace_light_visibility(surface.world_position, resolved_light_sample.world_position);
+        combined_reservoir.unbiased_contribution_weight *= trace_light_visibility(surface.world_position + (surface.world_normal * RAY_T_MIN), resolved_light_sample.world_position);
     }
 
     // More stability, less accuracy (shadows extend further out than they should)
@@ -129,7 +129,7 @@ fn generate_initial_reservoir(world_position: vec3<f32>, world_normal: vec3<f32>
         let inverse_target_function = select(0.0, 1.0 / reservoir_target_function, reservoir_target_function > 0.0);
         reservoir.unbiased_contribution_weight = weight_sum * inverse_target_function;
 
-        reservoir.unbiased_contribution_weight *= trace_light_visibility(world_position, light_sample_world_position);
+        reservoir.unbiased_contribution_weight *= trace_light_visibility(world_position + (world_normal * RAY_T_MIN), light_sample_world_position);
     }
 
     reservoir.confidence_weight = 1.0;

--- a/crates/bevy_solari/src/realtime/restir_gi.wgsl
+++ b/crates/bevy_solari/src/realtime/restir_gi.wgsl
@@ -72,7 +72,7 @@ fn spatial_and_shade(@builtin(global_invocation_id) global_id: vec3<u32>) {
     gi_reservoirs_a[pixel_index] = combined_reservoir;
 #endif
 
-    combined_reservoir.unbiased_contribution_weight *= trace_point_visibility(surface.world_position, combined_reservoir.sample_point_world_position);
+    combined_reservoir.unbiased_contribution_weight *= trace_point_visibility(surface.world_position + (surface.world_normal * RAY_T_MIN), combined_reservoir.sample_point_world_position);
 
     // More stability, less accuracy (shadows extend further out than they should)
 #ifdef BIASED_RESAMPLING
@@ -91,7 +91,7 @@ fn generate_initial_reservoir(world_position: vec3<f32>, world_normal: vec3<f32>
     var reservoir = empty_reservoir();
 
     let ray_direction = sample_uniform_hemisphere(world_normal, rng);
-    let ray = trace_ray(world_position, ray_direction, RAY_T_MIN, RAY_T_MAX, RAY_FLAG_NONE);
+    let ray = trace_ray(world_position + (world_normal * RAY_T_MIN), ray_direction, RAY_T_MIN, RAY_T_MAX, RAY_FLAG_NONE);
 
     if ray.kind == RAY_QUERY_INTERSECTION_NONE {
         return reservoir;

--- a/crates/bevy_solari/src/realtime/specular_gi.wgsl
+++ b/crates/bevy_solari/src/realtime/specular_gi.wgsl
@@ -81,7 +81,7 @@ fn trace_glossy_path(pixel_id: vec2<u32>, primary_surface: ResolvedGPixel, initi
     var radiance = vec3(0.0);
     var throughput = vec3(1.0);
 
-    var ray_origin = primary_surface.world_position;
+    var ray_origin = primary_surface.world_position + (primary_surface.world_normal * RAY_T_MIN);
     var wi = initial_wi;
     var p_bounce = initial_p_bounce;
     var path_spread = path_spread_heuristic(initial_ray_t, primary_surface.material.roughness);
@@ -92,7 +92,7 @@ fn trace_glossy_path(pixel_id: vec2<u32>, primary_surface: ResolvedGPixel, initi
 #endif
 
     // Trace up to three bounces
-    for (var i = 0u; i < 3u; i += 1u) {
+    for (var i = 0u; i< 3u; i += 1u) {
         // Trace ray
         let ray = trace_ray(ray_origin, wi, RAY_T_MIN, RAY_T_MAX, RAY_FLAG_NONE);
         if ray.kind == RAY_QUERY_INTERSECTION_NONE { break; }
@@ -147,7 +147,7 @@ fn trace_glossy_path(pixel_id: vec2<u32>, primary_surface: ResolvedGPixel, initi
         let wi_tangent = sample_ggx_vndf(wo_tangent, ray_hit.material.roughness, rng);
         if ggx_vndf_sample_invalid(wi_tangent) { break; }
         wi = wi_tangent.x * T + wi_tangent.y * B + wi_tangent.z * N;
-        ray_origin = ray_hit.world_position;
+        ray_origin = ray_hit.world_position + (ray_hit.geometric_world_normal * RAY_T_MIN);
 
         // Update throughput for next bounce
         p_bounce = ggx_vndf_pdf(wo_tangent, wi_tangent, ray_hit.material.roughness);

--- a/crates/bevy_solari/src/realtime/specular_gi.wgsl
+++ b/crates/bevy_solari/src/realtime/specular_gi.wgsl
@@ -92,7 +92,7 @@ fn trace_glossy_path(pixel_id: vec2<u32>, primary_surface: ResolvedGPixel, initi
 #endif
 
     // Trace up to three bounces
-    for (var i = 0u; i< 3u; i += 1u) {
+    for (var i = 0u; i < 3u; i += 1u) {
         // Trace ray
         let ray = trace_ray(ray_origin, wi, RAY_T_MIN, RAY_T_MAX, RAY_FLAG_NONE);
         if ray.kind == RAY_QUERY_INTERSECTION_NONE { break; }

--- a/crates/bevy_solari/src/realtime/world_cache_update.wgsl
+++ b/crates/bevy_solari/src/realtime/world_cache_update.wgsl
@@ -52,7 +52,7 @@ fn sample_gi(@builtin(workgroup_id) workgroup_id: vec3<u32>, @builtin(global_inv
     if rand_f(&rng) >= f32(WORLD_CACHE_CELL_UPDATES_SOFT_CAP) / f32(world_cache_active_cells_count) { return; }
 
     let ray_direction = sample_cosine_hemisphere(geometry_data.world_normal, &rng);
-    let ray = trace_ray(geometry_data.world_position, ray_direction, RAY_T_MIN, WORLD_CACHE_MAX_GI_RAY_DISTANCE, RAY_FLAG_NONE);
+    let ray = trace_ray(geometry_data.world_position + (geometry_data.world_normal * RAY_T_MIN), ray_direction, RAY_T_MIN, WORLD_CACHE_MAX_GI_RAY_DISTANCE, RAY_FLAG_NONE);
     if ray.kind != RAY_QUERY_INTERSECTION_NONE {
         let ray_hit = resolve_ray_hit_full(ray);
         let cell_life = atomicLoad(&world_cache_life[cell_index]);
@@ -119,7 +119,7 @@ fn sample_random_light_ris(world_position: vec3<f32>, world_normal: vec3<f32>, w
         let inverse_target_function = select(0.0, 1.0 / selected_sample_target_function, selected_sample_target_function > 0.0);
         unbiased_contribution_weight = weight_sum * inverse_target_function;
 
-        unbiased_contribution_weight *= trace_light_visibility(world_position, selected_sample_world_position);
+        unbiased_contribution_weight *= trace_light_visibility(world_position + (world_position * RAY_T_MIN), selected_sample_world_position);
     }
 
     return selected_sample_radiance * unbiased_contribution_weight;

--- a/crates/bevy_solari/src/scene/sampling.wgsl
+++ b/crates/bevy_solari/src/scene/sampling.wgsl
@@ -220,7 +220,7 @@ fn trace_light_visibility(ray_origin: vec3<f32>, light_sample_world_position: ve
         let ray = ray_direction - ray_origin;
         let dist = length(ray);
         ray_direction = ray / dist;
-        ray_t_max = dist - RAY_T_MIN - RAY_T_MIN;
+        ray_t_max = dist - RAY_T_MIN;
     }
 
     if ray_t_max < RAY_T_MIN { return 0.0; }
@@ -234,7 +234,7 @@ fn trace_point_visibility(ray_origin: vec3<f32>, point: vec3<f32>) -> f32 {
     let dist = length(ray);
     let ray_direction = ray / dist;
 
-    let ray_t_max = dist - RAY_T_MIN - RAY_T_MIN;
+    let ray_t_max = dist - RAY_T_MIN;
     if ray_t_max < RAY_T_MIN { return 0.0; }
 
     let ray_hit = trace_ray(ray_origin, ray_direction, RAY_T_MIN, ray_t_max, RAY_FLAG_TERMINATE_ON_FIRST_HIT);


### PR DESCRIPTION
Fix self intersection artifacts by offsetting the ray origin along the geometric normal (or shading normal when geo normal not available, e.g. from gbuffer).



Fixes flickering in Solari's many\_lights test scene.

