### PR TITLE
fix(atmosphere): clamp r to shell for above-outer-radius camera

### DIFF
--- a/crates/bevy_pbr/src/atmosphere/functions.wgsl
+++ b/crates/bevy_pbr/src/atmosphere/functions.wgsl
@@ -145,9 +145,15 @@ fn sample_multiscattering_lut(r: f32, mu: f32) -> vec3<f32> {
 }
 
 fn sample_sky_view_lut(r: f32, ray_dir_as: vec3<f32>) -> vec3<f32> {
+    // Defense-in-depth clamp. get_view_position() already clamps callers that go
+    // through it, but some call sites pass r directly. The SkyView LUT is
+    // parameterized only for r in [inner_radius, outer_radius]; sampling outside
+    // produces out-of-bounds UVs and black / garbage sky. Clamp to just inside
+    // the outer shell so the parameterization stays valid for orbital cameras.
+    let r_c = min(r, atmosphere.outer_radius - 1.0);
     let mu = ray_dir_as.y;
     let azimuth = fast_atan2(ray_dir_as.x, -ray_dir_as.z);
-    let uv = sky_view_lut_r_mu_azimuth_to_uv(r, mu, azimuth);
+    let uv = sky_view_lut_r_mu_azimuth_to_uv(r_c, mu, azimuth);
     return textureSampleLevel(sky_view_lut, atmosphere_lut_sampler, uv, 0.0).rgb;
 }
 
@@ -289,11 +295,21 @@ fn calculate_visible_sun_ratio(atmosphere: Atmosphere, r: f32, mu: f32, sun_angu
 
 /// Clamp a position to the planet surface (with a small epsilon) to avoid underground artifacts.
 fn clamp_to_surface(atmosphere: Atmosphere, position: vec3<f32>) -> vec3<f32> {
+    // Clamp to the atmosphere shell [inner_radius + eps, outer_radius - eps].
+    // The SkyView / AerialView LUT parameterizations are only valid inside the
+    // shell; outside the outer boundary (e.g. orbital cameras), sampling
+    // produces out-of-bounds UVs and the sky pass goes black. Clamping here
+    // means every caller of get_view_position() is safe.
     let min_radius = atmosphere.inner_radius + EPSILON;
+    let max_radius = atmosphere.outer_radius - EPSILON;
     let r = length(position);
     if r < min_radius {
         let up = normalize(position);
         return up * min_radius;
+    }
+    if r > max_radius {
+        let up = normalize(position);
+        return up * max_radius;
     }
     return position;
 }


### PR DESCRIPTION
## Problem

When camera altitude exceeds `atmosphere.outer_radius` (e.g. orbital / space views), Hillaire's SkyView and AerialView LUTs are parameterized only for `r ∈ [inner_radius, outer_radius]`. Sampling outside the shell produces out-of-bounds UVs, and the sky pass emits black or garbage output instead of a transmittance-only path to space.

The stock `clamp_to_surface()` only clamps below `inner_radius`; nothing clamps above `outer_radius`.

## Fix

Two changes in `crates/bevy_pbr/src/atmosphere/functions.wgsl`:

1. Extend `clamp_to_surface()` to also clamp `r > outer_radius - EPSILON` down to `outer_radius - EPSILON`. Because `get_view_position()` routes every `world_pos` through `clamp_to_surface()`, all downstream callers (`render_sky`, `aerial_view_lut_out`, `raymarch_atmosphere`) inherit the fix without touching their files.
2. Defense-in-depth clamp at the top of `sample_sky_view_lut(r, ray_dir_as)` for callers that pass `r` directly.

## Testing

I hit this bug while bringing up orbital views in [ExoPrime](https://github.com/thephfox), a Rust space game on Bevy 0.18.1. Local backport of this patch renders the planet disk correctly with terminator and limb at 375 km altitude via the built-in sky pass; the same build goes black without the patch.

I'd love help verifying this against the 3d atmosphere examples and getting a proper example in (`examples/3d/atmosphere_orbital.rs` at 400 km camera) — flagging now as a draft so reviewers can decide whether the approach is the right shape before I invest in that.

## Related

- #17555 (Atmosphere LUT parameterization improvements, merged 2025-02-03) — improved the LUT parameterization but does not add an above-outer-radius branch
- #17632 (atmosphere DX12 panic) — complementary

## Migration notes

None. Pure visual fix. Cameras inside the shell are unaffected.

## Changelog

```
### Fixed
- Atmosphere renders correctly when camera altitude exceeds outer_radius (orbital / space views).
```

cc @JMS55 @mate-h @IceSentry