### PR TITLE
Solari brdf fixes

### DIFF
--- a/crates/bevy_solari/src/pathtracer/pathtracer.wgsl
+++ b/crates/bevy_solari/src/pathtracer/pathtracer.wgsl
@@ -71,7 +71,7 @@ fn pathtrace(@builtin(global_invocation_id) global_id: vec3<u32>) {
             }
 
             // Sample new ray direction from the material BRDF for next bounce and apply BRDF
-            let next_bounce = evaluate_and_sample_brdf(wo, ray_hit.world_normal, ray_hit.world_tangent, ray_hit.material, &rng);
+            let next_bounce = evaluate_and_sample_brdf(wo, ray_hit.world_normal, ray_hit.material, &rng);
             if next_bounce.pdf == 0.0 { break; }
             ray_direction = next_bounce.wi;
             ray_origin = ray_hit.world_position + (ray_hit.geometric_world_normal * RAY_T_MIN);

--- a/crates/bevy_solari/src/pathtracer/pathtracer.wgsl
+++ b/crates/bevy_solari/src/pathtracer/pathtracer.wgsl
@@ -1,11 +1,11 @@
 enable wgpu_ray_query;
 
 #import bevy_core_pipeline::tonemapping::tonemapping_luminance as luminance
-#import bevy_pbr::pbr_functions::{calculate_tbn_mikktspace, calculate_F0}
+#import bevy_pbr::pbr_functions::calculate_F0_dielectric
 #import bevy_pbr::utils::{rand_f, rand_vec2f}
-#import bevy_render::maths::PI
+#import bevy_render::maths::{PI, orthonormalize}
 #import bevy_render::view::View
-#import bevy_solari::brdf::{evaluate_brdf, evaluate_and_sample_brdf, fresnel}
+#import bevy_solari::brdf::{evaluate_brdf, evaluate_and_sample_brdf, lobe_reflectances}
 #import bevy_solari::sampling::{sample_random_light, random_emissive_light_pdf, ggx_vndf_pdf, power_heuristic}
 #import bevy_solari::scene_bindings::{trace_ray, resolve_ray_hit_full, ResolvedRayHitFull, RAY_T_MIN, RAY_T_MAX, MIRROR_ROUGHNESS_THRESHOLD}
 
@@ -96,23 +96,21 @@ fn pathtrace(@builtin(global_invocation_id) global_id: vec3<u32>) {
 }
 
 fn brdf_pdf(wo: vec3<f32>, wi: vec3<f32>, ray_hit: ResolvedRayHitFull) -> f32 {
-    let NdotV = max(dot(ray_hit.world_normal, wo), 0.0001);
-    let F0 = calculate_F0(ray_hit.material.base_color, ray_hit.material.metallic, vec3(ray_hit.material.reflectance));
-    let df = 1.0 - luminance(fresnel(F0, NdotV));
-
-    let diffuse_weight = mix(df, 0.0, ray_hit.material.metallic);
-    let specular_weight = 1.0 - diffuse_weight;
-
-    let TBN = calculate_tbn_mikktspace(ray_hit.world_normal, ray_hit.world_tangent);
+    let TBN = orthonormalize(ray_hit.world_normal);
     let T = TBN[0];
     let B = TBN[1];
     let N = TBN[2];
+
+    let NdotV = max(dot(N, wo), 0.0001);
+    let F0_metal = ray_hit.material.base_color;
+    let F0_dielectric = calculate_F0_dielectric(vec3(ray_hit.material.reflectance));
+    let rho = lobe_reflectances(F0_metal, F0_dielectric, ray_hit.material, NdotV);
+    let specular_weight = luminance(rho.rho_spec) / luminance(rho.rho_spec + rho.rho_diff);
 
     let wo_tangent = vec3(dot(wo, T), dot(wo, B), dot(wo, N));
     let wi_tangent = vec3(dot(wi, T), dot(wi, B), dot(wi, N));
 
     let diffuse_pdf = wi_tangent.z / PI;
     let specular_pdf = ggx_vndf_pdf(wo_tangent, wi_tangent, ray_hit.material.roughness);
-    let pdf = (diffuse_weight * diffuse_pdf) + (specular_weight * specular_pdf);
-    return pdf;
+    return specular_weight * specular_pdf + (1.0 - specular_weight) * diffuse_pdf;
 }

--- a/crates/bevy_solari/src/scene/brdf.wgsl
+++ b/crates/bevy_solari/src/scene/brdf.wgsl
@@ -6,7 +6,7 @@ enable wgpu_ray_query;
 #import bevy_pbr::lighting::{D_GGX, V_SmithGGXCorrelated, specular_multiscatter}
 #import bevy_pbr::pbr_functions::{calculate_tbn_mikktspace, calculate_diffuse_color, calculate_F0}
 #import bevy_pbr::utils::{rand_f, sample_cosine_hemisphere}
-#import bevy_render::maths::PI
+#import bevy_render::maths::{PI, orthonormalize}
 #import bevy_solari::sampling::{sample_ggx_vndf, ggx_vndf_pdf, ggx_vndf_sample_invalid}
 #import bevy_solari::scene_bindings::{ResolvedMaterial, MIRROR_ROUGHNESS_THRESHOLD, brdf_dfg_lut, brdf_dfg_lut_sampler}
 
@@ -19,7 +19,6 @@ struct EvaluateAndSampleBrdfResult {
 fn evaluate_and_sample_brdf(
     wo: vec3<f32>,
     world_normal: vec3<f32>,
-    world_tangent: vec4<f32>,
     material: ResolvedMaterial,
     rng: ptr<function, u32>,
 ) -> EvaluateAndSampleBrdfResult {
@@ -31,7 +30,7 @@ fn evaluate_and_sample_brdf(
     let diffuse_weight = mix(df, 0.0, material.metallic);
     let specular_weight = 1.0 - diffuse_weight;
 
-    let TBN = calculate_tbn_mikktspace(world_normal, world_tangent);
+    let TBN = orthonormalize(world_normal);
     let T = TBN[0];
     let B = TBN[1];
     let N = TBN[2];

--- a/crates/bevy_solari/src/scene/brdf.wgsl
+++ b/crates/bevy_solari/src/scene/brdf.wgsl
@@ -4,7 +4,7 @@ enable wgpu_ray_query;
 
 #import bevy_core_pipeline::tonemapping::tonemapping_luminance as luminance
 #import bevy_pbr::lighting::{D_GGX, V_SmithGGXCorrelated, specular_multiscatter}
-#import bevy_pbr::pbr_functions::{calculate_tbn_mikktspace, calculate_diffuse_color, calculate_F0}
+#import bevy_pbr::pbr_functions::calculate_F0_dielectric
 #import bevy_pbr::utils::{rand_f, sample_cosine_hemisphere}
 #import bevy_render::maths::{PI, orthonormalize}
 #import bevy_solari::sampling::{sample_ggx_vndf, ggx_vndf_pdf, ggx_vndf_sample_invalid}
@@ -16,52 +16,77 @@ struct EvaluateAndSampleBrdfResult {
     pdf: f32,
 }
 
+struct LobeReflectances {
+    rho_spec: vec3<f32>,
+    rho_diff: vec3<f32>,
+}
+
+// Hemispherical reflectance of each lobe
+fn lobe_reflectances(F0_metal: vec3<f32>, F0_dielectric: vec3<f32>, material: ResolvedMaterial, NdotV: f32) -> LobeReflectances {
+    if material.roughness <= MIRROR_ROUGHNESS_THRESHOLD {
+        let F_m = fresnel(F0_metal, NdotV);
+        let F_d = fresnel(F0_dielectric, NdotV);
+        return LobeReflectances(
+            material.metallic * F_m + (1.0 - material.metallic) * F_d,
+            (1.0 - material.metallic) * (vec3(1.0) - F_d) * material.base_color,
+        );
+    }
+    let F_ab = F_AB(material.perceptual_roughness, NdotV);
+    let ms_factor = 1.0 / (F_ab.x + F_ab.y) - 1.0;
+    let rho_spec_m = (F0_metal * F_ab.x + vec3(F_ab.y)) * (vec3(1.0) + F0_metal * ms_factor);
+    let rho_spec_d = (F0_dielectric * F_ab.x + vec3(F_ab.y)) * (vec3(1.0) + F0_dielectric * ms_factor);
+    return LobeReflectances(
+        material.metallic * rho_spec_m + (1.0 - material.metallic) * rho_spec_d,
+        (1.0 - material.metallic) * (vec3(1.0) - rho_spec_d) * material.base_color,
+    );
+}
+
 fn evaluate_and_sample_brdf(
     wo: vec3<f32>,
     world_normal: vec3<f32>,
     material: ResolvedMaterial,
     rng: ptr<function, u32>,
 ) -> EvaluateAndSampleBrdfResult {
-    let NdotV = dot(world_normal, wo);
-    if NdotV < 0.0001 { return EvaluateAndSampleBrdfResult(vec3(0.0), vec3(0.0), 0.0); }
-    let F0 = calculate_F0(material.base_color, material.metallic, vec3(material.reflectance));
-    let df = 1.0 - luminance(fresnel(F0, NdotV));
-
-    let diffuse_weight = mix(df, 0.0, material.metallic);
-    let specular_weight = 1.0 - diffuse_weight;
-
     let TBN = orthonormalize(world_normal);
     let T = TBN[0];
     let B = TBN[1];
     let N = TBN[2];
 
-    let wo_tangent = vec3(dot(wo, T), dot(wo, B), dot(wo, N));
+    let NdotV = dot(N, wo);
+    if NdotV < 0.0001 { return EvaluateAndSampleBrdfResult(vec3(0.0), vec3(0.0), 0.0); }
 
+    let F0_metal = material.base_color;
+    let F0_dielectric = calculate_F0_dielectric(vec3(material.reflectance));
+    let rho = lobe_reflectances(F0_metal, F0_dielectric, material, NdotV);
+    let specular_weight = luminance(rho.rho_spec) / luminance(rho.rho_spec + rho.rho_diff);
+
+    let wo_tangent = vec3(dot(wo, T), dot(wo, B), dot(wo, N));
     var wi: vec3<f32>;
     var wi_tangent: vec3<f32>;
-    let diffuse_selected = rand_f(rng) < diffuse_weight;
+    let diffuse_selected = rand_f(rng) < (1.0 - specular_weight);
     if diffuse_selected {
-        wi = sample_cosine_hemisphere(world_normal, rng);
+        wi = sample_cosine_hemisphere(N, rng);
         wi_tangent = vec3(dot(wi, T), dot(wi, B), dot(wi, N));
     } else {
         wi_tangent = sample_ggx_vndf(wo_tangent, material.roughness, rng);
-        if ggx_vndf_sample_invalid(wi_tangent) {
-            return EvaluateAndSampleBrdfResult(vec3(0.0), vec3(0.0), 0.0);
-        }
+        if ggx_vndf_sample_invalid(wi_tangent) { return EvaluateAndSampleBrdfResult(vec3(0.0), vec3(0.0), 0.0); }
         wi = wi_tangent.x * T + wi_tangent.y * B + wi_tangent.z * N;
+    }
+
+    // Mirror is a delta function
+    if material.roughness <= MIRROR_ROUGHNESS_THRESHOLD {
+        if diffuse_selected {
+            return EvaluateAndSampleBrdfResult(wi, rho.rho_diff / (1.0 - specular_weight), 1.0);
+        } else {
+            if dot(N, wi) <= 0.0 { return EvaluateAndSampleBrdfResult(vec3(0.0), vec3(0.0), 0.0); }
+            return EvaluateAndSampleBrdfResult(wi, rho.rho_spec / specular_weight, 1.0);
+        }
     }
 
     let diffuse_pdf = wi_tangent.z / PI;
     let specular_pdf = ggx_vndf_pdf(wo_tangent, wi_tangent, material.roughness);
-    let pdf = (diffuse_weight * diffuse_pdf) + (specular_weight * specular_pdf);
-
-    var throughput = evaluate_brdf(wo, wi, world_normal, material);
-    if diffuse_selected || material.roughness > MIRROR_ROUGHNESS_THRESHOLD {
-        throughput /= pdf;
-    } else {
-        throughput /= specular_weight;
-    }
-
+    let pdf = specular_weight * specular_pdf + (1.0 - specular_weight) * diffuse_pdf;
+    let throughput = evaluate_brdf(wo, wi, world_normal, material) / pdf;
     return EvaluateAndSampleBrdfResult(wi, throughput, pdf);
 }
 
@@ -75,31 +100,31 @@ fn evaluate_brdf(
 }
 
 fn evaluate_diffuse_brdf(wo: vec3<f32>, wi: vec3<f32>, world_normal: vec3<f32>, material: ResolvedMaterial) -> vec3<f32> {
-    let diffuse_color = calculate_diffuse_color(material.base_color, material.metallic, 0.0, 0.0) / PI;
-
     let NdotL = dot(world_normal, wi);
     let NdotV = dot(world_normal, wo);
     if NdotL < 0.0001 || NdotV < 0.0001 { return vec3(0.0); }
-    let F0 = calculate_F0(material.base_color, material.metallic, vec3(material.reflectance));
-    let layering = (1.0 - fresnel(F0, NdotL)) * (1.0 - fresnel(F0, NdotV));
 
-    return diffuse_color * layering * NdotL;
+    let F0_dielectric = calculate_F0_dielectric(vec3(material.reflectance));
+    let rho = lobe_reflectances(material.base_color, F0_dielectric, material, NdotV);
+    return rho.rho_diff / PI * NdotL;
 }
 
 fn evaluate_specular_brdf(wo: vec3<f32>, wi: vec3<f32>, world_normal: vec3<f32>, material: ResolvedMaterial) -> vec3<f32> {
     let H = normalize(wi + wo);
     let NdotL = dot(world_normal, wi);
     let NdotH = dot(world_normal, H);
-    let LdotH = dot(wi, H);
+    let HdotV = dot(H, wo);
     let NdotV = dot(world_normal, wo);
-    if NdotL < 0.0001 || NdotH < 0.0001 || LdotH < 0.0001 || NdotV < 0.0001 { return vec3(0.0); }
+    if NdotL < 0.0001 || NdotH < 0.0001 || HdotV < 0.0001 || NdotV < 0.0001 { return vec3(0.0); }
 
-    let F0 = calculate_F0(material.base_color, material.metallic, vec3(material.reflectance));
-    let F = fresnel(F0, LdotH);
+    let F0_metal = material.base_color;
+    let F0_dielectric = calculate_F0_dielectric(vec3(material.reflectance));
 
     if material.roughness <= MIRROR_ROUGHNESS_THRESHOLD {
         if abs(NdotH - 1.0) < 0.0001 {
-            return F;
+            let F_m = fresnel(F0_metal, HdotV);
+            let F_d = fresnel(F0_dielectric, HdotV);
+            return material.metallic * F_m + (1.0 - material.metallic) * F_d;
         } else {
             return vec3(0.0);
         }
@@ -108,7 +133,10 @@ fn evaluate_specular_brdf(wo: vec3<f32>, wi: vec3<f32>, world_normal: vec3<f32>,
     let D = D_GGX(material.roughness, NdotH);
     let Vs = V_SmithGGXCorrelated(material.roughness, NdotV, NdotL);
     let F_ab = F_AB(material.perceptual_roughness, NdotV);
-    return specular_multiscatter(D, Vs, F, F0, F_ab, 1.0) * NdotL;
+    let F_m = fresnel(F0_metal, HdotV);
+    let F_d = fresnel(F0_dielectric, HdotV);
+    return (material.metallic * specular_multiscatter(D, Vs, F_m, F0_metal, F_ab, 1.0)
+          + (1.0 - material.metallic) * specular_multiscatter(D, Vs, F_d, F0_dielectric, F_ab, 1.0)) * NdotL;
 }
 
 fn fresnel(f0: vec3<f32>, LdotH: f32) -> vec3<f32> {

--- a/crates/bevy_solari/src/scene/brdf.wgsl
+++ b/crates/bevy_solari/src/scene/brdf.wgsl
@@ -71,14 +71,9 @@ fn evaluate_and_sample_brdf(
         wi_tangent = sample_ggx_vndf(wo_tangent, material.roughness, rng);
         if ggx_vndf_sample_invalid(wi_tangent) { return EvaluateAndSampleBrdfResult(vec3(0.0), vec3(0.0), 0.0); }
         wi = wi_tangent.x * T + wi_tangent.y * B + wi_tangent.z * N;
-    }
-
-    // Mirror is a delta function
-    if material.roughness <= MIRROR_ROUGHNESS_THRESHOLD {
-        if diffuse_selected {
-            return EvaluateAndSampleBrdfResult(wi, rho.rho_diff / (1.0 - specular_weight), 1.0);
-        } else {
-            if dot(N, wi) <= 0.0 { return EvaluateAndSampleBrdfResult(vec3(0.0), vec3(0.0), 0.0); }
+        
+        // Mirror specular is a delta function
+        if material.roughness <= MIRROR_ROUGHNESS_THRESHOLD {
             return EvaluateAndSampleBrdfResult(wi, rho.rho_spec / specular_weight, 1.0);
         }
     }


### PR DESCRIPTION
# Objective

BRDF fixes for solari! 

## Solution

- Use a local TBN instead of mikktspace, which was producing seams on the spheres used for the white furnace test.
- Separate metallic/dielectric paths, evaluating each endpoint separately then blending rather than working with a blended F0. This is the same as what #23203 did for IBL.
- The Fresnel layering that was introduced isn't energy conserving. Instead, I compute the total energy reflected by the specular lobe using the DFG table and Filament's multi-scattering approximation. I can then scale the diffuse by the complement to ensure energy conservation. 
A downside to this approach is that it breaks reciprocity because of the simplifications that Filament's multi-scattering formulation makes. As far as I can tell the path tracer is unidirectional, so this shouldn't cause issues. The fix to restore reciprocity would be to add the full Kulla-Conty compensation lobe, which requires an extra LUT.

Note: I've mostly focused on getting this correct, performance can probably be improved. For example, this does entirely too many `F_AB` lookups.

## Testing and showcase

#### White furnace
We're still not passing, but the changes improve it a lot.

On main:
<img width="1920" height="1013" alt="0_main" src="https://github.com/user-attachments/assets/d786555d-bc54-486f-b69c-24b3685c1420" />
With the LUT-based F_AB:
<img width="1920" height="1013" alt="1_main_F_AB" src="https://github.com/user-attachments/assets/8ed15249-e710-4411-bd90-de128cd05eea" />
Adding the local TBN:
<img width="1920" height="1013" alt="2_proper_tbn" src="https://github.com/user-attachments/assets/8e86ded5-23f3-443a-b382-5a1bafb5de4f" />
Adding the BRDF fixes: 
<img width="1920" height="1013" alt="3_proper_brdf" src="https://github.com/user-attachments/assets/6fe2eda6-bb6a-4603-88c0-78b105307e7d" />

#### Bunch of spheres
Notice the darkening on main for the middle row of spheres, with metallic=0.5.

Main:
<img width="1920" height="1165" alt="main" src="https://github.com/user-attachments/assets/840d2b68-e5ba-4d67-93ec-01045ed7afba" />
This PR:
<img width="1920" height="1165" alt="new_brdf" src="https://github.com/user-attachments/assets/85182f7c-5ef4-491c-82e7-bde8e247bd7c" />

#### Dragons
The shading differences are particularly visible on the dragons in the front row. 
There is some kind of exposure or tonemapping difference between bevy and cycles that's been driving me crazy, but I haven't been able to track it down.

<img width="1920" height="1165" alt="animated" src="https://github.com/user-attachments/assets/6947c8ed-4f4f-42a8-8d0c-858111daf9b2" />


<details>
  <summary>Individual images</summary>

Main:
<img width="1920" height="1165" alt="main" src="https://github.com/user-attachments/assets/706398b4-2c2f-4c26-98e2-3e31fcf224b2" />

This PR:
<img width="1920" height="1165" alt="fix_brdf" src="https://github.com/user-attachments/assets/10e9b765-2c7c-4346-b51c-840a932016e3" />

Cycles:
<img width="1920" height="1165" alt="cycles" src="https://github.com/user-attachments/assets/2241db89-222e-48f1-815b-ec450e4097d6" />

</details>


#### More Dragons

<img width="1920" height="1165" alt="animated" src="https://github.com/user-attachments/assets/1bffa462-b49c-42b4-b785-86bf48234dd0" />


<details>
  <summary>Individual images</summary>
Main:
<img width="1920" height="1165" alt="main" src="https://github.com/user-attachments/assets/3e5f28e8-e25b-45d9-9623-c3aa58f08955" />


This PR:
<img width="1920" height="1165" alt="fix_brdf" src="https://github.com/user-attachments/assets/04c84ba9-0586-40d1-8480-54f2157420cf" />


Cycles:
<img width="1920" height="1165" alt="cycles" src="https://github.com/user-attachments/assets/ed2a63c9-6b50-49b2-99c3-4cb012d05af1" />

</details>