### PR TITLE
Fix and Polish Feathers Checkbox

### DIFF
--- a/crates/bevy_feathers/src/controls/checkbox.rs
+++ b/crates/bevy_feathers/src/controls/checkbox.rs
@@ -23,7 +23,7 @@ use bevy_ui::{
     AlignItems, BorderRadius, Checked, Display, FlexDirection, InteractionDisabled, JustifyContent,
     Node, PositionType, Pressed, UiRect, UiTransform, Val,
 };
-use bevy_ui_widgets::Checkbox;
+use bevy_ui_widgets::{ActivateOnPress, Checkbox};
 
 use crate::{
     constants::{fonts, size},
@@ -202,6 +202,7 @@ fn update_checkbox_styles(
             Has<InteractionDisabled>,
             Has<Checked>,
             Has<Pressed>,
+            Has<ActivateOnPress>,
             &Hovered,
             &ThemeFontColor,
         ),
@@ -220,7 +221,9 @@ fn update_checkbox_styles(
     mut q_mark: Query<&ThemeBorderColor, With<CheckboxMark>>,
     mut commands: Commands,
 ) {
-    for (checkbox_ent, disabled, checked, pressed, hovered, font_color) in q_checkboxes.iter() {
+    for (checkbox_ent, disabled, checked, pressed, activate_on_press, hovered, font_color) in
+        q_checkboxes.iter()
+    {
         let Some(outline_ent) = q_children
             .iter_descendants(checkbox_ent)
             .find(|en| q_outline.contains(*en))
@@ -243,6 +246,7 @@ fn update_checkbox_styles(
             checked,
             pressed,
             hovered.0,
+            activate_on_press,
             outline_bg,
             outline_border,
             mark_color,
@@ -259,6 +263,7 @@ fn update_checkbox_styles_remove(
             Has<InteractionDisabled>,
             Has<Checked>,
             Has<Pressed>,
+            Has<ActivateOnPress>,
             &Hovered,
             &ThemeFontColor,
         ),
@@ -270,15 +275,24 @@ fn update_checkbox_styles_remove(
     mut removed_disabled: RemovedComponents<InteractionDisabled>,
     mut removed_checked: RemovedComponents<Checked>,
     mut remove_pressed: RemovedComponents<Pressed>,
+    mut remove_activate_on_press: RemovedComponents<ActivateOnPress>,
     mut commands: Commands,
 ) {
     removed_disabled
         .read()
         .chain(removed_checked.read())
         .chain(remove_pressed.read())
+        .chain(remove_activate_on_press.read())
         .for_each(|ent| {
-            if let Ok((checkbox_ent, disabled, checked, pressed, hovered, font_color)) =
-                q_checkboxes.get(ent)
+            if let Ok((
+                checkbox_ent,
+                disabled,
+                checked,
+                pressed,
+                activate_on_press,
+                hovered,
+                font_color,
+            )) = q_checkboxes.get(ent)
             {
                 let Some(outline_ent) = q_children
                     .iter_descendants(checkbox_ent)
@@ -302,6 +316,7 @@ fn update_checkbox_styles_remove(
                     checked,
                     pressed,
                     hovered.0,
+                    activate_on_press,
                     outline_bg,
                     outline_border,
                     mark_color,
@@ -320,6 +335,7 @@ fn set_checkbox_styles(
     checked: bool,
     pressed: bool,
     hovered: bool,
+    activate_on_press: bool,
     outline_bg: &ThemeBackgroundColor,
     outline_border: &ThemeBorderColor,
     mark_color: &ThemeBorderColor,
@@ -329,7 +345,7 @@ fn set_checkbox_styles(
     let outline_border_token = if checked {
         if disabled {
             tokens::CHECKBOX_BORDER_CHECKED_DISABLED
-        } else if pressed {
+        } else if pressed && !activate_on_press {
             tokens::CHECKBOX_BORDER_CHECKED_PRESSED
         } else if hovered {
             tokens::CHECKBOX_BORDER_CHECKED_HOVER
@@ -339,7 +355,7 @@ fn set_checkbox_styles(
     } else {
         if disabled {
             tokens::CHECKBOX_BORDER_DISABLED
-        } else if pressed {
+        } else if pressed && !activate_on_press {
             tokens::CHECKBOX_BORDER_PRESSED
         } else if hovered {
             tokens::CHECKBOX_BORDER_HOVER
@@ -351,7 +367,7 @@ fn set_checkbox_styles(
     let outline_bg_token = if checked {
         if disabled {
             tokens::CHECKBOX_BG_CHECKED_DISABLED
-        } else if pressed {
+        } else if pressed && !activate_on_press {
             tokens::CHECKBOX_BG_CHECKED_PRESSED
         } else if hovered {
             tokens::CHECKBOX_BG_CHECKED_HOVER
@@ -361,7 +377,7 @@ fn set_checkbox_styles(
     } else {
         if disabled {
             tokens::CHECKBOX_BG_DISABLED
-        } else if pressed {
+        } else if pressed && !activate_on_press {
             tokens::CHECKBOX_BG_PRESSED
         } else if hovered {
             tokens::CHECKBOX_BG_HOVER

--- a/crates/bevy_feathers/src/controls/checkbox.rs
+++ b/crates/bevy_feathers/src/controls/checkbox.rs
@@ -314,10 +314,20 @@ fn set_checkbox_styles(
     font_color: &ThemeFontColor,
     commands: &mut Commands,
 ) {
-    let outline_border_token = match (disabled, hovered) {
-        (true, _) => tokens::CHECKBOX_BORDER_DISABLED,
-        (false, true) => tokens::CHECKBOX_BORDER_HOVER,
-        _ => tokens::CHECKBOX_BORDER,
+    let outline_border_token = if disabled {
+        tokens::CHECKBOX_BORDER_DISABLED
+    } else if checked {
+        if hovered {
+            tokens::CHECKBOX_BORDER_CHECKED_HOVER
+        } else {
+            tokens::CHECKBOX_BORDER_CHECKED
+        }
+    } else {
+        if hovered {
+            tokens::CHECKBOX_BORDER_HOVER
+        } else {
+            tokens::CHECKBOX_BORDER
+        }
     };
 
     let outline_bg_token = match (disabled, checked) {

--- a/crates/bevy_feathers/src/controls/checkbox.rs
+++ b/crates/bevy_feathers/src/controls/checkbox.rs
@@ -21,7 +21,7 @@ use bevy_scene::prelude::*;
 use bevy_text::{FontSize, FontWeight};
 use bevy_ui::{
     AlignItems, BorderRadius, Checked, Display, FlexDirection, InteractionDisabled, JustifyContent,
-    Node, PositionType, UiRect, UiTransform, Val,
+    Node, PositionType, Pressed, UiRect, UiTransform, Val,
 };
 use bevy_ui_widgets::Checkbox;
 
@@ -201,12 +201,18 @@ fn update_checkbox_styles(
             Entity,
             Has<InteractionDisabled>,
             Has<Checked>,
+            Has<Pressed>,
             &Hovered,
             &ThemeFontColor,
         ),
         (
             With<CheckboxFrame>,
-            Or<(Changed<Hovered>, Added<Checked>, Added<InteractionDisabled>)>,
+            Or<(
+                Changed<Hovered>,
+                Added<Checked>,
+                Added<Pressed>,
+                Added<InteractionDisabled>,
+            )>,
         ),
     >,
     q_children: Query<&Children>,
@@ -214,7 +220,7 @@ fn update_checkbox_styles(
     mut q_mark: Query<&ThemeBorderColor, With<CheckboxMark>>,
     mut commands: Commands,
 ) {
-    for (checkbox_ent, disabled, checked, hovered, font_color) in q_checkboxes.iter() {
+    for (checkbox_ent, disabled, checked, pressed, hovered, font_color) in q_checkboxes.iter() {
         let Some(outline_ent) = q_children
             .iter_descendants(checkbox_ent)
             .find(|en| q_outline.contains(*en))
@@ -235,6 +241,7 @@ fn update_checkbox_styles(
             mark_ent,
             disabled,
             checked,
+            pressed,
             hovered.0,
             outline_bg,
             outline_border,
@@ -251,6 +258,7 @@ fn update_checkbox_styles_remove(
             Entity,
             Has<InteractionDisabled>,
             Has<Checked>,
+            Has<Pressed>,
             &Hovered,
             &ThemeFontColor,
         ),
@@ -261,13 +269,15 @@ fn update_checkbox_styles_remove(
     mut q_mark: Query<&ThemeBorderColor, With<CheckboxMark>>,
     mut removed_disabled: RemovedComponents<InteractionDisabled>,
     mut removed_checked: RemovedComponents<Checked>,
+    mut remove_pressed: RemovedComponents<Pressed>,
     mut commands: Commands,
 ) {
     removed_disabled
         .read()
+        .chain(remove_pressed.read())
         .chain(removed_checked.read())
         .for_each(|ent| {
-            if let Ok((checkbox_ent, disabled, checked, hovered, font_color)) =
+            if let Ok((checkbox_ent, disabled, checked, pressed, hovered, font_color)) =
                 q_checkboxes.get(ent)
             {
                 let Some(outline_ent) = q_children
@@ -290,6 +300,7 @@ fn update_checkbox_styles_remove(
                     mark_ent,
                     disabled,
                     checked,
+                    pressed,
                     hovered.0,
                     outline_bg,
                     outline_border,
@@ -307,6 +318,7 @@ fn set_checkbox_styles(
     mark_ent: Entity,
     disabled: bool,
     checked: bool,
+    pressed: bool,
     hovered: bool,
     outline_bg: &ThemeBackgroundColor,
     outline_border: &ThemeBorderColor,

--- a/crates/bevy_feathers/src/controls/checkbox.rs
+++ b/crates/bevy_feathers/src/controls/checkbox.rs
@@ -326,19 +326,21 @@ fn set_checkbox_styles(
     font_color: &ThemeFontColor,
     commands: &mut Commands,
 ) {
-    let outline_border_token = if disabled {
-        tokens::CHECKBOX_BORDER_DISABLED
-    } else if checked {
-        if pressed {
-            tokens::CHECKBOX_BORDER_DISABLED // TODO
+    let outline_border_token = if checked {
+        if disabled {
+            tokens::CHECKBOX_BORDER_CHECKED_DISABLED
+        } else if pressed {
+            tokens::CHECKBOX_BORDER_CHECKED_PRESSED
         } else if hovered {
             tokens::CHECKBOX_BORDER_CHECKED_HOVER
         } else {
             tokens::CHECKBOX_BORDER_CHECKED
         }
     } else {
-        if pressed {
-            tokens::CHECKBOX_BORDER_DISABLED // TODO
+        if disabled {
+            tokens::CHECKBOX_BORDER_DISABLED
+        } else if pressed {
+            tokens::CHECKBOX_BORDER_PRESSED
         } else if hovered {
             tokens::CHECKBOX_BORDER_HOVER
         } else {
@@ -349,6 +351,8 @@ fn set_checkbox_styles(
     let outline_bg_token = if checked {
         if disabled {
             tokens::CHECKBOX_BG_CHECKED_DISABLED
+        } else if pressed {
+            tokens::CHECKBOX_BG_CHECKED_PRESSED
         } else if hovered {
             tokens::CHECKBOX_BG_CHECKED_HOVER
         } else {
@@ -357,6 +361,8 @@ fn set_checkbox_styles(
     } else {
         if disabled {
             tokens::CHECKBOX_BG_DISABLED
+        } else if pressed {
+            tokens::CHECKBOX_BG_PRESSED
         } else if hovered {
             tokens::CHECKBOX_BG_HOVER
         } else {

--- a/crates/bevy_feathers/src/controls/checkbox.rs
+++ b/crates/bevy_feathers/src/controls/checkbox.rs
@@ -274,8 +274,8 @@ fn update_checkbox_styles_remove(
 ) {
     removed_disabled
         .read()
-        .chain(remove_pressed.read())
         .chain(removed_checked.read())
+        .chain(remove_pressed.read())
         .for_each(|ent| {
             if let Ok((checkbox_ent, disabled, checked, pressed, hovered, font_color)) =
                 q_checkboxes.get(ent)
@@ -329,13 +329,17 @@ fn set_checkbox_styles(
     let outline_border_token = if disabled {
         tokens::CHECKBOX_BORDER_DISABLED
     } else if checked {
-        if hovered {
+        if pressed {
+            tokens::CHECKBOX_BORDER_DISABLED // TODO
+        } else if hovered {
             tokens::CHECKBOX_BORDER_CHECKED_HOVER
         } else {
             tokens::CHECKBOX_BORDER_CHECKED
         }
     } else {
-        if hovered {
+        if pressed {
+            tokens::CHECKBOX_BORDER_DISABLED // TODO
+        } else if hovered {
             tokens::CHECKBOX_BORDER_HOVER
         } else {
             tokens::CHECKBOX_BORDER

--- a/crates/bevy_feathers/src/controls/checkbox.rs
+++ b/crates/bevy_feathers/src/controls/checkbox.rs
@@ -330,11 +330,22 @@ fn set_checkbox_styles(
         }
     };
 
-    let outline_bg_token = match (disabled, checked) {
-        (true, true) => tokens::CHECKBOX_BG_CHECKED_DISABLED,
-        (true, false) => tokens::CHECKBOX_BG_DISABLED,
-        (false, true) => tokens::CHECKBOX_BG_CHECKED,
-        (false, false) => tokens::CHECKBOX_BG,
+    let outline_bg_token = if checked {
+        if disabled {
+            tokens::CHECKBOX_BG_CHECKED_DISABLED
+        } else if hovered {
+            tokens::CHECKBOX_BG_CHECKED_HOVER
+        } else {
+            tokens::CHECKBOX_BG_CHECKED
+        }
+    } else {
+        if disabled {
+            tokens::CHECKBOX_BG_DISABLED
+        } else if hovered {
+            tokens::CHECKBOX_BG_HOVER
+        } else {
+            tokens::CHECKBOX_BG
+        }
     };
 
     let mark_token = match disabled {

--- a/crates/bevy_feathers/src/dark_theme.rs
+++ b/crates/bevy_feathers/src/dark_theme.rs
@@ -71,7 +71,7 @@ pub fn create_dark_theme() -> ThemeProps {
             ),
             (
                 tokens::CHECKBOX_BG_CHECKED_DISABLED,
-                palette::GRAY_3.with_alpha(0.5),
+                palette::GRAY_1.with_alpha(0.5),
             ),
             (tokens::CHECKBOX_BORDER, palette::GRAY_3),
             (tokens::CHECKBOX_BORDER_HOVER, palette::GRAY_3.lighter(0.05)),

--- a/crates/bevy_feathers/src/dark_theme.rs
+++ b/crates/bevy_feathers/src/dark_theme.rs
@@ -53,14 +53,19 @@ pub fn create_dark_theme() -> ThemeProps {
             // Checkbox
             (tokens::CHECKBOX_BG, palette::GRAY_3),
             (tokens::CHECKBOX_BG_HOVER, palette::GRAY_3),
+            (tokens::CHECKBOX_BG_PRESSED, palette::GRAY_3),
+            (
+                tokens::CHECKBOX_BG_DISABLED,
+                palette::GRAY_1.with_alpha(0.5),
+            ),
             (tokens::CHECKBOX_BG_CHECKED, palette::ACCENT),
             (
                 tokens::CHECKBOX_BG_CHECKED_HOVER,
                 palette::ACCENT.lighter(0.05),
             ),
             (
-                tokens::CHECKBOX_BG_DISABLED,
-                palette::GRAY_1.with_alpha(0.5),
+                tokens::CHECKBOX_BG_CHECKED_PRESSED,
+                palette::ACCENT.lighter(0.1),
             ),
             (
                 tokens::CHECKBOX_BG_CHECKED_DISABLED,
@@ -69,6 +74,10 @@ pub fn create_dark_theme() -> ThemeProps {
             (tokens::CHECKBOX_BORDER, palette::GRAY_3),
             (tokens::CHECKBOX_BORDER_HOVER, palette::GRAY_3.lighter(0.1)),
             (
+                tokens::CHECKBOX_BORDER_PRESSED,
+                palette::GRAY_3.lighter(0.15),
+            ),
+            (
                 tokens::CHECKBOX_BORDER_DISABLED,
                 palette::GRAY_3.with_alpha(0.5),
             ),
@@ -76,6 +85,14 @@ pub fn create_dark_theme() -> ThemeProps {
             (
                 tokens::CHECKBOX_BORDER_CHECKED_HOVER,
                 palette::ACCENT.lighter(0.05),
+            ),
+            (
+                tokens::CHECKBOX_BORDER_CHECKED_PRESSED,
+                palette::ACCENT.lighter(0.1),
+            ),
+            (
+                tokens::CHECKBOX_BORDER_CHECKED_DISABLED,
+                palette::GRAY_3.with_alpha(0.5),
             ),
             (tokens::CHECKBOX_MARK, palette::WHITE),
             (tokens::CHECKBOX_MARK_DISABLED, palette::LIGHT_GRAY_2),

--- a/crates/bevy_feathers/src/dark_theme.rs
+++ b/crates/bevy_feathers/src/dark_theme.rs
@@ -67,6 +67,8 @@ pub fn create_dark_theme() -> ThemeProps {
                 tokens::CHECKBOX_BORDER_DISABLED,
                 palette::GRAY_3.with_alpha(0.5),
             ),
+            (tokens::CHECKBOX_BORDER_CHECKED, palette::ACCENT),
+            (tokens::CHECKBOX_BORDER_CHECKED_HOVER, palette::ACCENT), // TODO
             (tokens::CHECKBOX_MARK, palette::WHITE),
             (tokens::CHECKBOX_MARK_DISABLED, palette::LIGHT_GRAY_2),
             (tokens::CHECKBOX_TEXT, palette::LIGHT_GRAY_1),

--- a/crates/bevy_feathers/src/dark_theme.rs
+++ b/crates/bevy_feathers/src/dark_theme.rs
@@ -52,7 +52,12 @@ pub fn create_dark_theme() -> ThemeProps {
             (tokens::SCROLLBAR_THUMB_HOVER, palette::ACCENT.lighter(0.1)),
             // Checkbox
             (tokens::CHECKBOX_BG, palette::GRAY_3),
+            (tokens::CHECKBOX_BG_HOVER, palette::GRAY_3),
             (tokens::CHECKBOX_BG_CHECKED, palette::ACCENT),
+            (
+                tokens::CHECKBOX_BG_CHECKED_HOVER,
+                palette::ACCENT.lighter(0.05),
+            ),
             (
                 tokens::CHECKBOX_BG_DISABLED,
                 palette::GRAY_1.with_alpha(0.5),
@@ -68,7 +73,10 @@ pub fn create_dark_theme() -> ThemeProps {
                 palette::GRAY_3.with_alpha(0.5),
             ),
             (tokens::CHECKBOX_BORDER_CHECKED, palette::ACCENT),
-            (tokens::CHECKBOX_BORDER_CHECKED_HOVER, palette::ACCENT), // TODO
+            (
+                tokens::CHECKBOX_BORDER_CHECKED_HOVER,
+                palette::ACCENT.lighter(0.05),
+            ),
             (tokens::CHECKBOX_MARK, palette::WHITE),
             (tokens::CHECKBOX_MARK_DISABLED, palette::LIGHT_GRAY_2),
             (tokens::CHECKBOX_TEXT, palette::LIGHT_GRAY_1),

--- a/crates/bevy_feathers/src/dark_theme.rs
+++ b/crates/bevy_feathers/src/dark_theme.rs
@@ -72,10 +72,10 @@ pub fn create_dark_theme() -> ThemeProps {
                 palette::GRAY_3.with_alpha(0.5),
             ),
             (tokens::CHECKBOX_BORDER, palette::GRAY_3),
-            (tokens::CHECKBOX_BORDER_HOVER, palette::GRAY_3.lighter(0.1)),
+            (tokens::CHECKBOX_BORDER_HOVER, palette::GRAY_3.lighter(0.05)),
             (
                 tokens::CHECKBOX_BORDER_PRESSED,
-                palette::GRAY_3.lighter(0.15),
+                palette::GRAY_3.lighter(0.1),
             ),
             (
                 tokens::CHECKBOX_BORDER_DISABLED,

--- a/crates/bevy_feathers/src/tokens.rs
+++ b/crates/bevy_feathers/src/tokens.rs
@@ -98,7 +98,7 @@ pub const CHECKBOX_BG_DISABLED: ThemeToken =
     ThemeToken::new_static("feathers.checkbox.bg.disabled");
 /// Checkbox background around the checkmark
 pub const CHECKBOX_BG_CHECKED: ThemeToken = ThemeToken::new_static("feathers.checkbox.bg.checked");
-/// Checkbox border around the checkmark (disabled)
+/// Checkbox border around the checkmark (checked+disabled)
 pub const CHECKBOX_BG_CHECKED_DISABLED: ThemeToken =
     ThemeToken::new_static("feathers.checkbox.bg.checked.disabled");
 /// Checkbox border around the checkmark
@@ -106,6 +106,12 @@ pub const CHECKBOX_BORDER: ThemeToken = ThemeToken::new_static("feathers.checkbo
 /// Checkbox border around the checkmark (hovered)
 pub const CHECKBOX_BORDER_HOVER: ThemeToken =
     ThemeToken::new_static("feathers.checkbox.border.hover");
+/// Checkbox border around the checkmark (checked)
+pub const CHECKBOX_BORDER_CHECKED: ThemeToken =
+    ThemeToken::new_static("feathers.checkbox.border.checked");
+/// Checkbox border around the checkmark (checked+hovered)
+pub const CHECKBOX_BORDER_CHECKED_HOVER: ThemeToken =
+    ThemeToken::new_static("feathers.checkbox.border.checked.hover");
 /// Checkbox border around the checkmark (disabled)
 pub const CHECKBOX_BORDER_DISABLED: ThemeToken =
     ThemeToken::new_static("feathers.checkbox.border.disabled");

--- a/crates/bevy_feathers/src/tokens.rs
+++ b/crates/bevy_feathers/src/tokens.rs
@@ -95,13 +95,19 @@ pub const SCROLLBAR_THUMB_HOVER: ThemeToken =
 pub const CHECKBOX_BG: ThemeToken = ThemeToken::new_static("feathers.checkbox.bg");
 /// Checkbox background around the checkmark (hovered)
 pub const CHECKBOX_BG_HOVER: ThemeToken = ThemeToken::new_static("feathers.checkbox.bg.hover");
+/// Checkbox background around the checkmark (pressed)
+pub const CHECKBOX_BG_PRESSED: ThemeToken = ThemeToken::new_static("feathers.checkbox.bg.pressed");
 /// Checkbox border around the checkmark (disabled)
 pub const CHECKBOX_BG_DISABLED: ThemeToken =
     ThemeToken::new_static("feathers.checkbox.bg.disabled");
 /// Checkbox background around the checkmark (checked)
 pub const CHECKBOX_BG_CHECKED: ThemeToken = ThemeToken::new_static("feathers.checkbox.bg.checked");
 /// Checkbox background around the checkmark (checked+hover)
-pub const CHECKBOX_BG_CHECKED_HOVER: ThemeToken = ThemeToken::new_static("feathers.checkbox.bg.checked.hover");
+pub const CHECKBOX_BG_CHECKED_HOVER: ThemeToken =
+    ThemeToken::new_static("feathers.checkbox.bg.checked.hover");
+/// Checkbox background around the checkmark (checked+pressed)
+pub const CHECKBOX_BG_CHECKED_PRESSED: ThemeToken =
+    ThemeToken::new_static("feathers.checkbox.bg.checked.pressed");
 /// Checkbox border around the checkmark (checked+disabled)
 pub const CHECKBOX_BG_CHECKED_DISABLED: ThemeToken =
     ThemeToken::new_static("feathers.checkbox.bg.checked.disabled");
@@ -110,15 +116,24 @@ pub const CHECKBOX_BORDER: ThemeToken = ThemeToken::new_static("feathers.checkbo
 /// Checkbox border around the checkmark (hovered)
 pub const CHECKBOX_BORDER_HOVER: ThemeToken =
     ThemeToken::new_static("feathers.checkbox.border.hover");
+/// Checkbox border around the checkmark (hovered)
+pub const CHECKBOX_BORDER_PRESSED: ThemeToken =
+    ThemeToken::new_static("feathers.checkbox.border.pressed");
+/// Checkbox border around the checkmark (disabled)
+pub const CHECKBOX_BORDER_DISABLED: ThemeToken =
+    ThemeToken::new_static("feathers.checkbox.border.disabled");
 /// Checkbox border around the checkmark (checked)
 pub const CHECKBOX_BORDER_CHECKED: ThemeToken =
     ThemeToken::new_static("feathers.checkbox.border.checked");
 /// Checkbox border around the checkmark (checked+hovered)
 pub const CHECKBOX_BORDER_CHECKED_HOVER: ThemeToken =
     ThemeToken::new_static("feathers.checkbox.border.checked.hover");
-/// Checkbox border around the checkmark (disabled)
-pub const CHECKBOX_BORDER_DISABLED: ThemeToken =
-    ThemeToken::new_static("feathers.checkbox.border.disabled");
+/// Checkbox border around the checkmark (checked+pressed)
+pub const CHECKBOX_BORDER_CHECKED_PRESSED: ThemeToken =
+    ThemeToken::new_static("feathers.checkbox.border.checked.pressed");
+/// Checkbox border around the checkmark (checked+disabled)
+pub const CHECKBOX_BORDER_CHECKED_DISABLED: ThemeToken =
+    ThemeToken::new_static("feathers.checkbox.border.checked.disabled");
 /// Checkbox check mark
 pub const CHECKBOX_MARK: ThemeToken = ThemeToken::new_static("feathers.checkbox.mark");
 /// Checkbox check mark (disabled)

--- a/crates/bevy_feathers/src/tokens.rs
+++ b/crates/bevy_feathers/src/tokens.rs
@@ -116,7 +116,7 @@ pub const CHECKBOX_BORDER: ThemeToken = ThemeToken::new_static("feathers.checkbo
 /// Checkbox border around the checkmark (hovered)
 pub const CHECKBOX_BORDER_HOVER: ThemeToken =
     ThemeToken::new_static("feathers.checkbox.border.hover");
-/// Checkbox border around the checkmark (hovered)
+/// Checkbox border around the checkmark (pressed)
 pub const CHECKBOX_BORDER_PRESSED: ThemeToken =
     ThemeToken::new_static("feathers.checkbox.border.pressed");
 /// Checkbox border around the checkmark (disabled)

--- a/crates/bevy_feathers/src/tokens.rs
+++ b/crates/bevy_feathers/src/tokens.rs
@@ -93,11 +93,15 @@ pub const SCROLLBAR_THUMB_HOVER: ThemeToken =
 
 /// Checkbox background around the checkmark
 pub const CHECKBOX_BG: ThemeToken = ThemeToken::new_static("feathers.checkbox.bg");
+/// Checkbox background around the checkmark (hovered)
+pub const CHECKBOX_BG_HOVER: ThemeToken = ThemeToken::new_static("feathers.checkbox.bg.hover");
 /// Checkbox border around the checkmark (disabled)
 pub const CHECKBOX_BG_DISABLED: ThemeToken =
     ThemeToken::new_static("feathers.checkbox.bg.disabled");
-/// Checkbox background around the checkmark
+/// Checkbox background around the checkmark (checked)
 pub const CHECKBOX_BG_CHECKED: ThemeToken = ThemeToken::new_static("feathers.checkbox.bg.checked");
+/// Checkbox background around the checkmark (checked+hover)
+pub const CHECKBOX_BG_CHECKED_HOVER: ThemeToken = ThemeToken::new_static("feathers.checkbox.bg.checked.hover");
 /// Checkbox border around the checkmark (checked+disabled)
 pub const CHECKBOX_BG_CHECKED_DISABLED: ThemeToken =
     ThemeToken::new_static("feathers.checkbox.bg.checked.disabled");

--- a/crates/bevy_ui_widgets/src/checkbox.rs
+++ b/crates/bevy_ui_widgets/src/checkbox.rs
@@ -12,9 +12,10 @@ use bevy_ecs::{
 use bevy_input::keyboard::{KeyCode, KeyboardInput};
 use bevy_input::ButtonState;
 use bevy_input_focus::{FocusedInput, InputFocus, InputFocusVisible};
-use bevy_picking::events::{Click, Pointer};
-use bevy_ui::{Checkable, Checked, InteractionDisabled};
+use bevy_picking::events::{Cancel, Click, DragEnd, Pointer, Press, Release};
+use bevy_ui::{Checkable, Checked, InteractionDisabled, Pressed};
 
+use crate::ActivateOnPress;
 use crate::ValueChange;
 use bevy_ecs::entity::Entity;
 
@@ -56,26 +57,95 @@ fn checkbox_on_key_input(
 fn checkbox_on_pointer_click(
     mut click: On<Pointer<Click>>,
     q_checkbox: Query<(Has<Checked>, Has<InteractionDisabled>), With<Checkbox>>,
-    focus: Option<ResMut<InputFocus>>,
-    focus_visible: Option<ResMut<InputFocusVisible>>,
     mut commands: Commands,
 ) {
     if let Ok((is_checked, disabled)) = q_checkbox.get(click.entity) {
-        // Clicking on a button makes it the focused input,
-        // and hides the focus ring if it was visible.
-        if let Some(mut focus) = focus {
-            focus.set(click.entity);
-        }
-        if let Some(mut focus_visible) = focus_visible {
-            focus_visible.0 = false;
-        }
-
         click.propagate(false);
         if !disabled {
             commands.trigger(ValueChange {
                 source: click.entity,
                 value: !is_checked,
             });
+        }
+    }
+}
+
+fn checkbox_on_pointer_down(
+    mut press: On<Pointer<Press>>,
+    mut q_checkbox: Query<
+        (
+            Entity,
+            Has<InteractionDisabled>,
+            Has<Checked>,
+            Has<Pressed>,
+            Has<ActivateOnPress>,
+        ),
+        With<Checkbox>,
+    >,
+    focus: Option<ResMut<InputFocus>>,
+    focus_visible: Option<ResMut<InputFocusVisible>>,
+    mut commands: Commands,
+) {
+    if let Ok((checkbox, disabled, checked, pressed, activate_on_press)) =
+        q_checkbox.get_mut(press.entity)
+    {
+        // Clicking on a button makes it the focused input,
+        // and hides the focus ring if it was visible.
+        if let Some(mut focus) = focus {
+            focus.set(press.entity);
+        }
+        if let Some(mut focus_visible) = focus_visible {
+            focus_visible.0 = false;
+        }
+
+        press.propagate(false);
+        if !disabled && !pressed {
+            commands.entity(checkbox).insert(Pressed);
+            if activate_on_press {
+                commands.trigger(ValueChange {
+                    source: press.entity,
+                    value: !checked,
+                });
+            }
+        }
+    }
+}
+
+fn checkbox_on_pointer_up(
+    mut release: On<Pointer<Release>>,
+    mut q_checkbox: Query<(Entity, Has<InteractionDisabled>, Has<Pressed>), With<Checkbox>>,
+    mut commands: Commands,
+) {
+    if let Ok((checkbox, disabled, pressed)) = q_checkbox.get_mut(release.entity) {
+        release.propagate(false);
+        if !disabled && pressed {
+            commands.entity(checkbox).remove::<Pressed>();
+        }
+    }
+}
+
+fn checkbox_on_pointer_drag_end(
+    mut drag_end: On<Pointer<DragEnd>>,
+    mut q_checkbox: Query<(Entity, Has<InteractionDisabled>, Has<Pressed>), With<Checkbox>>,
+    mut commands: Commands,
+) {
+    if let Ok((checkbox, disabled, pressed)) = q_checkbox.get_mut(drag_end.entity) {
+        drag_end.propagate(false);
+        if !disabled && pressed {
+            commands.entity(checkbox).remove::<Pressed>();
+        }
+    }
+}
+
+fn checkbox_on_pointer_cancel(
+    mut cancel: On<Pointer<Cancel>>,
+    mut q_checkbox: Query<(Entity, Has<InteractionDisabled>, Has<Pressed>), With<Checkbox>>,
+    mut commands: Commands,
+) {
+    if let Ok((checkbox, disabled, pressed)) = q_checkbox.get_mut(cancel.entity) {
+        cancel.propagate(false);
+        if !disabled && pressed {
+            commands.entity(checkbox).remove::<Pressed>();
         }
     }
 }
@@ -176,6 +246,10 @@ impl Plugin for CheckboxPlugin {
     fn build(&self, app: &mut App) {
         app.add_observer(checkbox_on_key_input)
             .add_observer(checkbox_on_pointer_click)
+            .add_observer(checkbox_on_pointer_down)
+            .add_observer(checkbox_on_pointer_up)
+            .add_observer(checkbox_on_pointer_drag_end)
+            .add_observer(checkbox_on_pointer_cancel)
             .add_observer(checkbox_on_set_checked)
             .add_observer(checkbox_on_toggle_checked);
     }

--- a/crates/bevy_ui_widgets/src/checkbox.rs
+++ b/crates/bevy_ui_widgets/src/checkbox.rs
@@ -56,7 +56,10 @@ fn checkbox_on_key_input(
 
 fn checkbox_on_pointer_click(
     mut click: On<Pointer<Click>>,
-    q_checkbox: Query<(Has<Checked>, Has<InteractionDisabled>), With<Checkbox>>,
+    q_checkbox: Query<
+        (Has<Checked>, Has<InteractionDisabled>),
+        (With<Checkbox>, Without<ActivateOnPress>),
+    >,
     mut commands: Commands,
 ) {
     if let Ok((is_checked, disabled)) = q_checkbox.get(click.entity) {

--- a/examples/ui/widgets/feathers_gallery.rs
+++ b/examples/ui/widgets/feathers_gallery.rs
@@ -23,8 +23,8 @@ use bevy::{
     text::{EditableText, TextEdit, TextEditChange},
     ui::{Checked, InteractionDisabled},
     ui_widgets::{
-        checkbox_self_update, slider_self_update, Activate, RadioButton, RadioGroup,
-        SliderPrecision, SliderStep, SliderValue, ValueChange,
+        checkbox_self_update, slider_self_update, Activate, ActivateOnPress, RadioButton,
+        RadioGroup, SliderPrecision, SliderStep, SliderValue, ValueChange,
     },
     window::SystemCursorIcon,
 };
@@ -263,6 +263,26 @@ fn demo_root() -> impl Scene {
                             } else {
                                 button.remove::<InteractionDisabled>();
                             }
+                            let mut checkbox = commands.entity(change.source);
+                            if change.value {
+                                checkbox.insert(Checked);
+                            } else {
+                                checkbox.remove::<Checked>();
+                            }
+                        }
+                    )
+                ),
+                (
+                    checkbox(CheckboxProps {
+                        caption: Box::new(bsn_list!(
+                            (Text("Fast Click Checkbox") ThemedText),
+                        )),
+                    })
+                    ActivateOnPress
+                    on(
+                        |change: On<ValueChange<bool>>,
+                         mut commands: Commands| {
+                            info!("Checkbox clicked!");
                             let mut checkbox = commands.entity(change.source);
                             if change.value {
                                 checkbox.insert(Checked);


### PR DESCRIPTION
# Objective

* Fix toggle behavior
* Add more style tokens and polish appearance

The original intention for the Feathers Checkbox was to toggle the change immediately on mouse press, but currently only toggles on mouse release, and lacks styling. Both behaviors are desirable depending on context, such as being able to cancel an expensive checkmark click that vastly changes render settings, so this pull request allows both, with the mouse-press behavior enabled via the `ActivateOnPress` component.

In addition to adding styling, there will no longer a visible outline for the checkbox in the checked state in the default theme. Having a border and check symbol made it visually busy, especially at small sizes.

---

## Showcase

### Before

<img width="161" height="83" alt="Screenshot 2026-04-15 at 7 58 09 PM" src="https://github.com/user-attachments/assets/9cae7bcf-0b2a-46db-954a-b09332a7b06f" />

### After

<img width="161" height="108" alt="Screenshot 2026-04-15 at 8 34 57 PM" src="https://github.com/user-attachments/assets/72d5083f-20db-45cd-8c1b-1ee711fcedf3" />

(Not pictured: new intermediate styling for mouse press)
