### PR TITLE
Fix QueuedScenes not existing when spawning queued scenes

### DIFF
--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -541,6 +541,7 @@ pub struct ScenePlugin;
 impl Plugin for ScenePlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<QueuedScenes>()
+            .init_resource::<WaitingScenes>()
             .init_asset::<ScenePatch>()
             .init_asset::<SceneListPatch>()
             .add_systems(
@@ -560,7 +561,9 @@ mod tests {
     use crate::{self as bevy_scene, ScenePlugin};
     use bevy_app::{App, TaskPoolPlugin};
     use bevy_asset::{Asset, AssetApp, AssetPlugin, AssetServer, Handle};
+    use bevy_ecs::lifecycle::HookContext;
     use bevy_ecs::prelude::*;
+    use bevy_ecs::world::DeferredWorld;
     use bevy_reflect::TypePath;
 
     fn test_app() -> App {
@@ -1216,5 +1219,33 @@ mod tests {
             Name
             Name
         };
+    }
+
+    #[test]
+    fn queue_spawn_scene_during_spawn() {
+        #[derive(Component, Default, Clone)]
+        #[component(on_insert)]
+        struct SpawnOnInsert;
+
+        impl SpawnOnInsert {
+            fn on_insert(mut world: DeferredWorld, _context: HookContext) {
+                world.commands().queue_spawn_scene(scene2());
+            }
+        }
+
+        let mut app = test_app();
+
+        fn scene1() -> impl Scene {
+            bsn!(SpawnOnInsert)
+        }
+
+        fn scene2() -> impl Scene {
+            bsn!(#Name)
+        }
+
+        let world = app.world_mut();
+        world.queue_spawn_scene(scene1());
+
+        app.update();
     }
 }

--- a/crates/bevy_scene/src/spawn.rs
+++ b/crates/bevy_scene/src/spawn.rs
@@ -586,7 +586,7 @@ pub fn resolve_scene_patches(
     assets: Res<AssetServer>,
     mut patches: ResMut<Assets<ScenePatch>>,
     mut list_patches: ResMut<Assets<SceneListPatch>>,
-    mut queued: ResMut<QueuedScenes>,
+    mut waiting: ResMut<WaitingScenes>,
 ) {
     for event in events.read() {
         match *event {
@@ -602,11 +602,11 @@ pub fn resolve_scene_patches(
                 }
             }
             AssetEvent::Removed { id } => {
-                if let Some(waiting) = queued.waiting_scene_entities.remove(&id)
-                    && !waiting.is_empty()
+                if let Some(waiting_entities) = waiting.scene_entities.remove(&id)
+                    && !waiting_entities.is_empty()
                 {
                     error!(
-                        "Failed to spawn entities waiting for scene {id:?} because it was removed: {waiting:?}"
+                        "Failed to spawn entities waiting for scene {id:?} because it was removed: {waiting_entities:?}"
                     );
                 }
             }
@@ -626,18 +626,19 @@ pub fn resolve_scene_patches(
                 }
             }
             AssetEvent::Removed { id } => {
-                if let Some(waiting) = queued.waiting_scene_list_spawns.remove(&id)
-                    && waiting > 0
+                if let Some(waiting_scene_lists) = waiting.scene_list_spawns.remove(&id)
+                    && waiting_scene_lists > 0
                 {
                     error!(
-                        "Failed to spawn scene list {id:?} {waiting} times because it was removed."
+                        "Failed to spawn scene list {id:?} {waiting_scene_lists} times because it was removed."
                     );
                 }
 
-                if let Some(waiting) = queued.waiting_related_list_entities.remove(&id)
-                    && !waiting.is_empty()
+                if let Some(waiting_related) = waiting.related_list_entities.remove(&id)
+                    && !waiting_related.is_empty()
                 {
-                    let waiting_entities = waiting.iter().map(|r| r.entity).collect::<Vec<_>>();
+                    let waiting_entities =
+                        waiting_related.iter().map(|r| r.entity).collect::<Vec<_>>();
                     error!(
                         "Failed to spawn related entities for scene list {id:?} because it was removed: {waiting_entities:?}"
                     );
@@ -654,9 +655,14 @@ pub struct QueuedScenes {
     new_scene_entities: Vec<Entity>,
     related_scene_list_spawns: Vec<(RelatedSceneListSpawn, Handle<SceneListPatch>)>,
     scene_list_spawns: Vec<Handle<SceneListPatch>>,
-    waiting_scene_entities: HashMap<Handle<ScenePatch>, Vec<Entity>>,
-    waiting_related_list_entities: HashMap<Handle<SceneListPatch>, Vec<RelatedSceneListSpawn>>,
-    waiting_scene_list_spawns: HashMap<Handle<SceneListPatch>, usize>,
+}
+
+/// A [`Resource`] that tracks entities / scenes that are waiting for an asset to load
+#[derive(Resource, Default)]
+pub struct WaitingScenes {
+    scene_entities: HashMap<Handle<ScenePatch>, Vec<Entity>>,
+    related_list_entities: HashMap<Handle<SceneListPatch>, Vec<RelatedSceneListSpawn>>,
+    scene_list_spawns: HashMap<Handle<SceneListPatch>, usize>,
 }
 
 pub(crate) struct RelatedSceneListSpawn {
@@ -676,16 +682,18 @@ pub fn on_add_scene_patch_instance(
 pub fn spawn_queued(
     world: &mut World,
     scene_patch_instances: &mut QueryState<&ScenePatchInstance>,
+    mut queued: Local<QueuedScenes>,
     mut reader: Local<MessageCursor<AssetEvent<ScenePatch>>>,
     mut list_reader: Local<MessageCursor<AssetEvent<SceneListPatch>>>,
 ) {
+    core::mem::swap(&mut *world.resource_mut::<QueuedScenes>(), &mut queued);
     world.resource_scope(|world, mut list_patches: Mut<Assets<SceneListPatch>>| {
-        world.resource_scope(|world, mut queued: Mut<QueuedScenes>| {
+        world.resource_scope(|world, mut waiting: Mut<WaitingScenes>| {
             loop {
                 if queued.is_empty() {
                     break;
                 }
-                queued.spawn_queued(world, scene_patch_instances, &list_patches);
+                queued.spawn_queued(world, &mut waiting, scene_patch_instances, &list_patches);
             }
 
             world.resource_scope(|world, events: Mut<Messages<AssetEvent<ScenePatch>>>| {
@@ -693,7 +701,7 @@ pub fn spawn_queued(
                     let patches = world.resource::<Assets<ScenePatch>>();
                     if let AssetEvent::LoadedWithDependencies { id } = event
                         && let Some(resolved) = patches.get(*id).and_then(|p| p.resolved.clone())
-                        && let Some(entities) = queued.waiting_scene_entities.remove(id)
+                        && let Some(entities) = waiting.scene_entities.remove(id)
                     {
                         for entity in entities {
                             if let Ok(mut entity_mut) = world.get_entity_mut(entity)
@@ -715,7 +723,7 @@ pub fn spawn_queued(
                             && let Some(list_patch) = list_patches.get_mut(*id)
                         {
                             if let Some(scene_list_spawns) =
-                                queued.waiting_related_list_entities.remove(id)
+                                waiting.related_list_entities.remove(id)
                             {
                                 for scene_list_spawn in scene_list_spawns {
                                     let result = list_patch.spawn_with(world, |entity| {
@@ -728,8 +736,7 @@ pub fn spawn_queued(
                                 }
                             }
 
-                            if let Some(waiting_list_spawns) =
-                                queued.waiting_scene_list_spawns.remove(id)
+                            if let Some(waiting_list_spawns) = waiting.scene_list_spawns.remove(id)
                             {
                                 for _ in 0..waiting_list_spawns {
                                     let result = list_patch.spawn(world);
@@ -756,6 +763,7 @@ impl QueuedScenes {
     fn spawn_queued(
         &mut self,
         world: &mut World,
+        waiting_scenes: &mut WaitingScenes,
         scene_patch_instances: &mut QueryState<&ScenePatchInstance>,
         list_patches: &Assets<SceneListPatch>,
     ) {
@@ -777,8 +785,8 @@ impl QueuedScenes {
                     );
                 }
             } else {
-                let entities = self
-                    .waiting_scene_entities
+                let entities = waiting_scenes
+                    .scene_entities
                     .entry(handle.clone())
                     .or_default();
                 entities.push(entity);
@@ -800,8 +808,8 @@ impl QueuedScenes {
                     );
                 }
             } else {
-                let entities = self
-                    .waiting_related_list_entities
+                let entities = waiting_scenes
+                    .related_list_entities
                     .entry(handle)
                     .or_default();
                 entities.push(scene_list_spawn);
@@ -820,7 +828,7 @@ impl QueuedScenes {
                     );
                 }
             } else {
-                let count = self.waiting_scene_list_spawns.entry(handle).or_default();
+                let count = waiting_scenes.scene_list_spawns.entry(handle).or_default();
                 *count += 1;
             }
         }


### PR DESCRIPTION
# Objective

Fix #23731

## Solution

1. Slim down QueuedScenes to the minimum by breaking out "waiting scenes" into its own resource
2. Store two copies of QueuedScene (one in the system and one in the resource) and mem::swap them when the system runs

## Testing

Added a test, derived from the repro in #23731