### PR TITLE
Rename `MeshPipelineSet` to `MeshPipelineSystems`

### DIFF
--- a/_release-content/migration-guides/meshpipelineset-renderstartup-systems.md
+++ b/_release-content/migration-guides/meshpipelineset-renderstartup-systems.md
@@ -3,4 +3,4 @@ title: Resources `MeshPipelineViewLayouts`, `MeshPipeline` and `RenderDebugOverl
 pull_requests: [22443]
 ---
 
-Systems using the `MeshPipelineViewLayouts`, `MeshPipeline` and `RenderDebugOverlayPipeline` resources in the `RenderStartup` schedule now need to be run after the `MeshPipelineSet` system set.
+Systems using the `MeshPipelineViewLayouts`, `MeshPipeline` and `RenderDebugOverlayPipeline` resources in the `RenderStartup` schedule now need to be run after the `MeshPipelineSystems` system set.

--- a/crates/bevy_dev_tools/src/render_debug.rs
+++ b/crates/bevy_dev_tools/src/render_debug.rs
@@ -43,7 +43,7 @@ use bevy_shader::Shader;
 use bevy_ui_render::render_pass::ui_pass;
 
 use bevy_pbr::{
-    Bluenoise, MeshPipelineSet, MeshPipelineViewLayoutKey, MeshPipelineViewLayouts,
+    Bluenoise, MeshPipelineSystems, MeshPipelineViewLayoutKey, MeshPipelineViewLayouts,
     MeshViewBindGroup, ViewContactShadowsUniformOffset, ViewEnvironmentMapUniformOffset,
     ViewFogUniformOffset, ViewLightProbesUniformOffset, ViewLightsUniformOffset,
     ViewScreenSpaceReflectionsUniformOffset,
@@ -73,7 +73,7 @@ impl Plugin for RenderDebugOverlayPlugin {
 
         render_app.add_systems(
             RenderStartup,
-            init_render_debug_overlay_pipeline.after(MeshPipelineSet),
+            init_render_debug_overlay_pipeline.after(MeshPipelineSystems),
         );
     }
 

--- a/crates/bevy_gizmos_render/src/pipeline_3d.rs
+++ b/crates/bevy_gizmos_render/src/pipeline_3d.rs
@@ -17,7 +17,7 @@ use bevy_ecs::{
     system::{Commands, Query, Res, ResMut},
 };
 use bevy_pbr::{
-    MeshPipeline, MeshPipelineKey, MeshPipelineSet, SetMeshViewBindGroup, ViewKeyCache,
+    MeshPipeline, MeshPipelineKey, MeshPipelineSystems, SetMeshViewBindGroup, ViewKeyCache,
 };
 use bevy_render::{
     render_asset::{prepare_assets, RenderAssets},
@@ -54,7 +54,7 @@ impl Plugin for LineGizmo3dPlugin {
                 RenderStartup,
                 init_line_gizmo_pipelines
                     .after(init_line_gizmo_uniform_bind_group_layout)
-                    .after(MeshPipelineSet),
+                    .after(MeshPipelineSystems),
             )
             .add_systems(
                 Render,

--- a/crates/bevy_pbr/src/deferred/mod.rs
+++ b/crates/bevy_pbr/src/deferred/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    DistanceFog, ExtractedAtmosphere, MeshPipeline, MeshPipelineKey, MeshPipelineSet,
+    DistanceFog, ExtractedAtmosphere, MeshPipeline, MeshPipelineKey, MeshPipelineSystems,
     MeshViewBindGroup, RenderViewLightProbes, ScreenSpaceAmbientOcclusion,
     ScreenSpaceReflectionsUniform, ViewContactShadowsUniformOffset,
     ViewEnvironmentMapUniformOffset, ViewFogUniformOffset, ViewLightProbesUniformOffset,
@@ -108,7 +108,7 @@ impl Plugin for DeferredPbrLightingPlugin {
             .init_gpu_resource::<SpecializedRenderPipelines<DeferredLightingLayout>>()
             .add_systems(
                 RenderStartup,
-                init_deferred_lighting_layout.after(MeshPipelineSet),
+                init_deferred_lighting_layout.after(MeshPipelineSystems),
             )
             .add_systems(
                 Render,

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -307,7 +307,10 @@ impl Plugin for MaterialsPlugin {
                 .add_render_command::<Transparent3d, DrawMaterial>()
                 .add_render_command::<Opaque3d, DrawMaterial>()
                 .add_render_command::<AlphaMask3d, DrawMaterial>()
-                .add_systems(RenderStartup, init_material_pipeline.after(MeshPipelineSystems))
+                .add_systems(
+                    RenderStartup,
+                    init_material_pipeline.after(MeshPipelineSystems),
+                )
                 .add_systems(
                     Render,
                     (

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -307,7 +307,7 @@ impl Plugin for MaterialsPlugin {
                 .add_render_command::<Transparent3d, DrawMaterial>()
                 .add_render_command::<Opaque3d, DrawMaterial>()
                 .add_render_command::<AlphaMask3d, DrawMaterial>()
-                .add_systems(RenderStartup, init_material_pipeline.after(MeshPipelineSet))
+                .add_systems(RenderStartup, init_material_pipeline.after(MeshPipelineSystems))
                 .add_systems(
                     Render,
                     (

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -143,7 +143,7 @@ impl MeshRenderPlugin {
 pub const MESH_PIPELINE_VIEW_LAYOUT_SAFE_MAX_TEXTURES: usize = 10;
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
-pub struct MeshPipelineSet;
+pub struct MeshPipelineSystems;
 
 impl Plugin for MeshRenderPlugin {
     fn build(&self, app: &mut App) {
@@ -321,7 +321,7 @@ impl Plugin for MeshRenderPlugin {
                 RenderStartup,
                 (init_mesh_pipeline_view_layouts, init_mesh_pipeline)
                     .chain()
-                    .in_set(MeshPipelineSet),
+                    .in_set(MeshPipelineSystems),
             );
         }
 

--- a/crates/bevy_pbr/src/ssr/mod.rs
+++ b/crates/bevy_pbr/src/ssr/mod.rs
@@ -47,7 +47,7 @@ use tracing::info;
 
 use crate::{
     binding_arrays_are_usable, contact_shadows::ViewContactShadowsUniformOffset,
-    deferred::deferred_lighting, Bluenoise, ExtractedAtmosphere, MeshPipelineSet,
+    deferred::deferred_lighting, Bluenoise, ExtractedAtmosphere, MeshPipelineSystems,
     MeshPipelineViewLayoutKey, MeshPipelineViewLayouts, MeshViewBindGroup, RenderViewLightProbes,
     ViewEnvironmentMapUniformOffset, ViewFogUniformOffset, ViewLightProbesUniformOffset,
     ViewLightsUniformOffset,
@@ -212,7 +212,7 @@ impl Plugin for ScreenSpaceReflectionsPlugin {
             .init_gpu_resource::<SpecializedRenderPipelines<ScreenSpaceReflectionsPipeline>>()
             .add_systems(
                 RenderStartup,
-                init_screen_space_reflections_pipeline.after(MeshPipelineSet),
+                init_screen_space_reflections_pipeline.after(MeshPipelineSystems),
             )
             .add_systems(Render, prepare_ssr_pipelines.in_set(RenderSystems::Prepare))
             .add_systems(

--- a/crates/bevy_pbr/src/volumetric_fog/mod.rs
+++ b/crates/bevy_pbr/src/volumetric_fog/mod.rs
@@ -49,7 +49,7 @@ use bevy_render::{
 };
 use render::{volumetric_fog, VolumetricFogPipeline, VolumetricFogUniformBuffer};
 
-use crate::{volumetric_fog::render::init_volumetric_fog_pipeline, MeshPipelineSet};
+use crate::{volumetric_fog::render::init_volumetric_fog_pipeline, MeshPipelineSystems};
 
 pub mod render;
 
@@ -85,7 +85,7 @@ impl Plugin for VolumetricFogPlugin {
             .init_gpu_resource::<VolumetricFogUniformBuffer>()
             .add_systems(
                 RenderStartup,
-                init_volumetric_fog_pipeline.after(MeshPipelineSet),
+                init_volumetric_fog_pipeline.after(MeshPipelineSystems),
             )
             .add_systems(ExtractSchedule, render::extract_volumetric_fog)
             .add_systems(

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -1,7 +1,7 @@
 use crate::{
     collect_meshes_for_gpu_building,
     render::{PreprocessBindGroups, PreprocessPipelines},
-    set_mesh_motion_vector_flags, DrawMesh, MeshPipeline, MeshPipelineKey, MeshPipelineSet,
+    set_mesh_motion_vector_flags, DrawMesh, MeshPipeline, MeshPipelineKey, MeshPipelineSystems,
     RenderLightmaps, RenderMeshInstanceFlags, RenderMeshInstances, SetMeshBindGroup,
     SetMeshViewBindGroup, SetMeshViewBindingArrayBindGroup, ViewKeyCache,
 };
@@ -152,7 +152,7 @@ impl Plugin for WireframePlugin {
             .init_gpu_resource::<PendingWireframeQueues>()
             .add_systems(
                 RenderStartup,
-                init_wireframe_3d_pipeline.after(MeshPipelineSet),
+                init_wireframe_3d_pipeline.after(MeshPipelineSystems),
             )
             .add_systems(
                 Core3d,

--- a/examples/shader_advanced/custom_render_phase.rs
+++ b/examples/shader_advanced/custom_render_phase.rs
@@ -131,7 +131,10 @@ impl Plugin for MeshStencilPhasePlugin {
             .add_render_command::<Stencil3d, DrawMesh3dStencil>()
             .init_resource::<ViewSortedRenderPhases<Stencil3d>>()
             .init_resource::<PendingCustomMeshQueues>()
-            .add_systems(RenderStartup, init_stencil_pipeline.after(MeshPipelineSystems))
+            .add_systems(
+                RenderStartup,
+                init_stencil_pipeline.after(MeshPipelineSystems),
+            )
             .add_systems(ExtractSchedule, extract_camera_phases)
             .add_systems(
                 Render,

--- a/examples/shader_advanced/custom_render_phase.rs
+++ b/examples/shader_advanced/custom_render_phase.rs
@@ -15,7 +15,7 @@ use std::ops::Range;
 use bevy::camera::Viewport;
 use bevy::core_pipeline::core_3d::TransparentSortingInfo3d;
 use bevy::math::Affine3Ext;
-use bevy::pbr::{MeshPipelineSet, SetMeshViewEmptyBindGroup, ViewKeyCache};
+use bevy::pbr::{MeshPipelineSystems, SetMeshViewEmptyBindGroup, ViewKeyCache};
 use bevy::{
     camera::MainPassResolutionOverride,
     core_pipeline::{core_3d::main_opaque_pass_3d, schedule::Core3d, Core3dSystems},
@@ -131,7 +131,7 @@ impl Plugin for MeshStencilPhasePlugin {
             .add_render_command::<Stencil3d, DrawMesh3dStencil>()
             .init_resource::<ViewSortedRenderPhases<Stencil3d>>()
             .init_resource::<PendingCustomMeshQueues>()
-            .add_systems(RenderStartup, init_stencil_pipeline.after(MeshPipelineSet))
+            .add_systems(RenderStartup, init_stencil_pipeline.after(MeshPipelineSystems))
             .add_systems(ExtractSchedule, extract_camera_phases)
             .add_systems(
                 Render,

--- a/examples/shader_advanced/custom_shader_instancing.rs
+++ b/examples/shader_advanced/custom_shader_instancing.rs
@@ -8,7 +8,7 @@
 //! It's generally recommended to try the built-in instancing before going with this approach.
 
 use bevy::core_pipeline::core_3d::TransparentSortingInfo3d;
-use bevy::pbr::{MeshPipelineSet, SetMeshViewBindingArrayBindGroup, ViewKeyCache};
+use bevy::pbr::{MeshPipelineSystems, SetMeshViewBindingArrayBindGroup, ViewKeyCache};
 use bevy::{
     camera::visibility::NoFrustumCulling,
     core_pipeline::core_3d::Transparent3d,
@@ -108,7 +108,7 @@ impl Plugin for CustomMaterialPlugin {
         app.sub_app_mut(RenderApp)
             .add_render_command::<Transparent3d, DrawCustom>()
             .init_resource::<SpecializedMeshPipelines<CustomPipeline>>()
-            .add_systems(RenderStartup, init_custom_pipeline.after(MeshPipelineSet))
+            .add_systems(RenderStartup, init_custom_pipeline.after(MeshPipelineSystems))
             .add_systems(
                 Render,
                 (

--- a/examples/shader_advanced/custom_shader_instancing.rs
+++ b/examples/shader_advanced/custom_shader_instancing.rs
@@ -108,7 +108,10 @@ impl Plugin for CustomMaterialPlugin {
         app.sub_app_mut(RenderApp)
             .add_render_command::<Transparent3d, DrawCustom>()
             .init_resource::<SpecializedMeshPipelines<CustomPipeline>>()
-            .add_systems(RenderStartup, init_custom_pipeline.after(MeshPipelineSystems))
+            .add_systems(
+                RenderStartup,
+                init_custom_pipeline.after(MeshPipelineSystems),
+            )
             .add_systems(
                 Render,
                 (

--- a/examples/shader_advanced/specialized_mesh_pipeline.rs
+++ b/examples/shader_advanced/specialized_mesh_pipeline.rs
@@ -14,7 +14,7 @@ use bevy::{
     math::{vec3, vec4},
     mesh::{Indices, MeshVertexBufferLayoutRef, PrimitiveTopology},
     pbr::{
-        DrawMesh, MeshPipeline, MeshPipelineKey, MeshPipelineSet, MeshPipelineViewLayoutKey,
+        DrawMesh, MeshPipeline, MeshPipelineKey, MeshPipelineSystems, MeshPipelineViewLayoutKey,
         RenderMeshInstances, SetMeshBindGroup, SetMeshViewBindGroup, SetMeshViewEmptyBindGroup,
         ViewKeyCache,
     },
@@ -118,7 +118,7 @@ impl Plugin for CustomRenderedMeshPipelinePlugin {
             .add_render_command::<Opaque3d, DrawSpecializedPipelineCommands>()
             .add_systems(
                 RenderStartup,
-                init_custom_mesh_pipeline.after(MeshPipelineSet),
+                init_custom_mesh_pipeline.after(MeshPipelineSystems),
             )
             .add_systems(
                 Render,


### PR DESCRIPTION
# Objective

According to #18900 , rename `MeshPipelineSet` to `MeshPipelineSystems` for a consistent naming convention.
`MeshPipelineSet` was introduced in this cycle, so no migration guide required. 

## Testing

```
cargo run --example specialized_mesh_pipeline
```
