### PR TITLE
`feathers_gallery` infinite update loop fix

### DIFF
--- a/examples/ui/widgets/feathers_gallery.rs
+++ b/examples/ui/widgets/feathers_gallery.rs
@@ -712,9 +712,9 @@ fn handle_hex_color_change(
     mut colors: ResMut<DemoWidgetStates>,
 ) {
     let editable_text = *q_text_input;
-    if let Ok(color) = Srgba::hex(editable_text.value().to_string()) {
-        if color != colors.rgb_color {
-            colors.rgb_color = color;
-        }
+    if let Ok(color) = Srgba::hex(editable_text.value().to_string())
+        && color != colors.rgb_color
+    {
+        colors.rgb_color = color;
     }
 }

--- a/examples/ui/widgets/feathers_gallery.rs
+++ b/examples/ui/widgets/feathers_gallery.rs
@@ -713,6 +713,8 @@ fn handle_hex_color_change(
 ) {
     let editable_text = *q_text_input;
     if let Ok(color) = Srgba::hex(editable_text.value().to_string()) {
-        colors.rgb_color = color;
+        if color != colors.rgb_color {
+            colors.rgb_color = color;
+        }
     }
 }


### PR DESCRIPTION
# Objective

In the `feathers_gallery` example, on a `TextEditChange` `handle_hex_color_change` updates `DemoWidgetStates` which causes `update_colors` to update the hex input triggering another `TextEditChange`.

## Solution

Only update `DemoWidgetStates` in `handle_hex_color_change` if the new color is different.