### PR TITLE
Wrap tracing spans in `#[cfg(feature = "trace")]`

### DIFF
--- a/crates/bevy_core_pipeline/src/schedule.rs
+++ b/crates/bevy_core_pipeline/src/schedule.rs
@@ -15,6 +15,7 @@ use bevy_ecs::{
     prelude::*,
     schedule::{IntoScheduleConfigs, Schedule, ScheduleLabel, SystemSet},
 };
+#[cfg(feature = "trace")]
 use bevy_log::info_span;
 use bevy_render::{
     camera::{ExtractedCamera, SortedCameras},
@@ -171,10 +172,12 @@ pub fn camera_driver(world: &mut World) {
 
 pub(crate) fn submit_pending_command_buffers(world: &mut World) {
     let mut pending = world.resource_mut::<PendingCommandBuffers>();
+    #[cfg(feature = "trace")]
     let buffer_count = pending.len();
     let buffers = pending.take();
 
     if !buffers.is_empty() {
+        #[cfg(feature = "trace")]
         let _span = info_span!("queue_submit", count = buffer_count).entered();
         let queue = world.resource::<RenderQueue>();
         queue.submit(buffers);

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -80,7 +80,9 @@ use indexmap::IndexSet;
 use material_bind_groups::MaterialBindingId;
 use static_assertions::const_assert_eq;
 use std::sync::mpsc;
-use tracing::{error, info_span, warn};
+#[cfg(feature = "trace")]
+use tracing::info_span;
+use tracing::{error, warn};
 
 use self::irradiance_volume::IRRADIANCE_VOLUMES_ARE_USABLE;
 use crate::{
@@ -2528,6 +2530,7 @@ pub fn collect_meshes_for_gpu_building(
                         let reextract_tx = reextract_tx.clone();
                         let removed_tx = removed_tx.clone();
                         scope.spawn(async move {
+                            #[cfg(feature = "trace")]
                             let _span = info_span!("prepared_mesh_producer").entered();
                             changed
                                 .drain(..)
@@ -2566,6 +2569,7 @@ pub fn collect_meshes_for_gpu_building(
                         let reextract_tx = reextract_tx.clone();
                         let removed_tx = removed_tx.clone();
                         scope.spawn(async move {
+                            #[cfg(feature = "trace")]
                             let _span = info_span!("prepared_mesh_producer").entered();
                             for (entity, mesh_instance_builder, mesh_culling_builder) in
                                 changed_cpu_culling

--- a/crates/bevy_render/src/batching/gpu_preprocessing.rs
+++ b/crates/bevy_render/src/batching/gpu_preprocessing.rs
@@ -2341,12 +2341,14 @@ pub fn write_batched_instance_buffers<GFBD>(
 
     ComputeTaskPool::get().scope(|scope| {
         scope.spawn(async {
+            #[cfg(feature = "trace")]
             let _span = bevy_log::info_span!("write_current_input_buffers").entered();
             current_input_buffer
                 .buffer
                 .write_buffers(render_device, render_queue);
         });
         scope.spawn(async {
+            #[cfg(feature = "trace")]
             let _span = bevy_log::info_span!("write_previous_input_buffers").entered();
             previous_input_buffer.write_buffer(render_device, render_queue);
         });
@@ -2360,6 +2362,7 @@ pub fn write_batched_instance_buffers<GFBD>(
             } = *phase_instance_buffers;
 
             scope.spawn(async {
+                #[cfg(feature = "trace")]
                 let _span = bevy_log::info_span!("write_phase_instance_buffers").entered();
                 data_buffer.write_buffer(render_device);
                 late_indexed_indirect_parameters_buffer.write_buffer(render_device, render_queue);
@@ -2369,6 +2372,7 @@ pub fn write_batched_instance_buffers<GFBD>(
 
             for phase_work_item_buffers in work_item_buffers.values_mut() {
                 scope.spawn(async {
+                    #[cfg(feature = "trace")]
                     let _span = bevy_log::info_span!("write_work_item_buffers").entered();
                     match *phase_work_item_buffers {
                         PreprocessWorkItemBuffers::Direct(ref mut buffer_vec) => {
@@ -2640,6 +2644,7 @@ pub fn write_indirect_parameters_buffers(
     ComputeTaskPool::get().scope(|scope| {
         for phase_indirect_parameters_buffers in indirect_parameters_buffers.values_mut() {
             scope.spawn(async {
+                #[cfg(feature = "trace")]
                 let _span = bevy_log::info_span!("indexed_data").entered();
                 phase_indirect_parameters_buffers
                     .indexed
@@ -2647,6 +2652,7 @@ pub fn write_indirect_parameters_buffers(
                     .write_buffer(render_device);
             });
             scope.spawn(async {
+                #[cfg(feature = "trace")]
                 let _span = bevy_log::info_span!("non_indexed_data").entered();
                 phase_indirect_parameters_buffers
                     .non_indexed
@@ -2655,6 +2661,7 @@ pub fn write_indirect_parameters_buffers(
             });
 
             scope.spawn(async {
+                #[cfg(feature = "trace")]
                 let _span = bevy_log::info_span!("indexed_cpu_metadata").entered();
                 phase_indirect_parameters_buffers
                     .indexed
@@ -2662,6 +2669,7 @@ pub fn write_indirect_parameters_buffers(
                     .write_buffer(render_device, render_queue);
             });
             scope.spawn(async {
+                #[cfg(feature = "trace")]
                 let _span = bevy_log::info_span!("non_indexed_cpu_metadata").entered();
                 phase_indirect_parameters_buffers
                     .non_indexed
@@ -2670,6 +2678,7 @@ pub fn write_indirect_parameters_buffers(
             });
 
             scope.spawn(async {
+                #[cfg(feature = "trace")]
                 let _span = bevy_log::info_span!("non_indexed_gpu_metadata").entered();
                 phase_indirect_parameters_buffers
                     .non_indexed
@@ -2677,6 +2686,7 @@ pub fn write_indirect_parameters_buffers(
                     .write_buffer(render_device);
             });
             scope.spawn(async {
+                #[cfg(feature = "trace")]
                 let _span = bevy_log::info_span!("indexed_gpu_metadata").entered();
                 phase_indirect_parameters_buffers
                     .indexed
@@ -2685,6 +2695,7 @@ pub fn write_indirect_parameters_buffers(
             });
 
             scope.spawn(async {
+                #[cfg(feature = "trace")]
                 let _span = bevy_log::info_span!("indexed_batch_sets").entered();
                 phase_indirect_parameters_buffers
                     .indexed
@@ -2692,6 +2703,7 @@ pub fn write_indirect_parameters_buffers(
                     .write_buffer(render_device, render_queue);
             });
             scope.spawn(async {
+                #[cfg(feature = "trace")]
                 let _span = bevy_log::info_span!("non_indexed_batch_sets").entered();
                 phase_indirect_parameters_buffers
                     .non_indexed

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -19,7 +19,9 @@ use bevy_camera::NormalizedRenderTarget;
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::schedule::ScheduleLabel;
 use bevy_ecs::{prelude::*, system::SystemState};
-use bevy_log::{debug, info, info_span, warn};
+#[cfg(feature = "trace")]
+use bevy_log::info_span;
+use bevy_log::{debug, info, warn};
 use bevy_render::camera::ExtractedCamera;
 use bevy_window::RawHandleWrapperHolder;
 use wgpu::{
@@ -87,6 +89,7 @@ pub fn render_system(
     }
 
     {
+        #[cfg(feature = "trace")]
         let _span = info_span!("present_frames").entered();
 
         world.resource_scope(|world, mut windows: Mut<ExtractedWindows>| {

--- a/crates/bevy_render/src/renderer/render_context.rs
+++ b/crates/bevy_render/src/renderer/render_context.rs
@@ -13,6 +13,7 @@ use bevy_ecs::system::{
 };
 use bevy_ecs::world::unsafe_world_cell::UnsafeWorldCell;
 use bevy_ecs::world::DeferredWorld;
+#[cfg(feature = "trace")]
 use bevy_log::info_span;
 use core::marker::PhantomData;
 use wgpu::CommandBuffer;
@@ -103,8 +104,10 @@ impl RenderContextState {
 }
 
 impl SystemBuffer for RenderContextState {
-    fn queue(&mut self, system_meta: &SystemMeta, mut world: DeferredWorld) {
-        let _span = info_span!("RenderContextState::apply", system = %system_meta.name()).entered();
+    fn queue(&mut self, _system_meta: &SystemMeta, mut world: DeferredWorld) {
+        #[cfg(feature = "trace")]
+        let _span =
+            info_span!("RenderContextState::apply", system = %_system_meta.name()).entered();
 
         let inner = &mut *self.0;
 

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -10,6 +10,7 @@ use bevy_ecs::{
         Local, Query, SystemParam,
     },
 };
+#[cfg(feature = "trace")]
 use bevy_log::info_span;
 use bevy_platform::collections::{HashMap, HashSet};
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
@@ -194,6 +195,7 @@ impl RenderVisibleEntitiesClass {
         &mut self,
         visible_mesh_entities_cpu_culling: &[(Entity, MainEntity)],
     ) {
+        #[cfg(feature = "trace")]
         let _update_from = info_span!("update_from", name = "update_from").entered();
 
         let old_entities_cpu_culling = mem::take(&mut self.entities_cpu_culling);
@@ -203,6 +205,7 @@ impl RenderVisibleEntitiesClass {
         // entities. The lists must be sorted.
         let mut old_entity_cpu_culling_iter = old_entities_cpu_culling.iter().peekable();
         {
+            #[cfg(feature = "trace")]
             let _old_entity_cpu_culling_span =
                 info_span!("old_entity_cpu_culling", name = "old_entity_cpu_culling").entered();
             for (render_entity, visible_main_entity) in visible_mesh_entities_cpu_culling {
@@ -236,6 +239,7 @@ impl RenderVisibleEntitiesClass {
         // Any entities that do CPU culling and that we didn't see yet are
         // removed, so drain them.
         {
+            #[cfg(feature = "trace")]
             let _old_entity_cpu_culling_removal_span = info_span!(
                 "old_entity_cpu_culling_removal",
                 name = "old_entity_cpu_culling_removal"


### PR DESCRIPTION
# Objective

- Reducing tracing overhead.
- Ensure that heavy `info_span!` calls and their associated logic are only compiled and executed when the `trace` feature is enabled.
- Fixes a memory leak on web, per #23949.

## Solution

- Wrapped `info_span!` entries with `#[cfg(feature = "trace")]`. 

## Testing

- `cargo check`
---

## Showcase

I observed in flamegraph profiling that certain span creations were consuming ~1.5% of total CPU time. 

<img width="1233" height="464" alt="image" src="https://github.com/user-attachments/assets/85527538-be64-4305-97dd-89c16ff56674" />
