### PR TITLE
Allow Outline's to have negative offset values

### DIFF
--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -298,6 +298,8 @@ pub fn ui_layout_system(
                         target_size,
                     )
                     .unwrap_or(0.)
+                    // Clamp outline offsets to at least the length of the node's shorter side
+                    // Negative offset outlines can be useful to create thing like in-set focus indicators
                     .max(-0.5 * node.size.min_element());
             }
 

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -298,7 +298,7 @@ pub fn ui_layout_system(
                         target_size,
                     )
                     .unwrap_or(0.)
-                    .max(0.);
+                    .max(-0.5 * node.size.min_element());
             }
 
             node.bypass_change_detection().scrollbar_size =


### PR DESCRIPTION
# Objective

Allow negative outline offset values

## Solution

Instead of clamping outline offsets to equal or above zero, clamp them to equal or above the length of the node's shorter side.