### PR TITLE
Fix light bounding spheres being ambiguous with TransformSystems::Propagate.

### DIFF
--- a/crates/bevy_light/src/lib.rs
+++ b/crates/bevy_light/src/lib.rs
@@ -222,8 +222,8 @@ impl Plugin for LightPlugin {
                         .after(VisibilitySystems::CheckVisibility)
                         .before(VisibilitySystems::MarkNewlyHiddenEntitiesInvisible),
                     (
-                        update_point_light_bounding_spheres,
-                        update_spot_light_bounding_spheres,
+                        update_point_light_bounding_spheres.after(TransformSystems::Propagate),
+                        update_spot_light_bounding_spheres.after(TransformSystems::Propagate),
                         add_light_probe_and_decal_aabbs,
                     )
                         .in_set(SimulationLightSystems::UpdateBounds)


### PR DESCRIPTION
# Objective

- Resolves a "strict ambiguity" from #23843.
    - TL;DR, adding systems before this schedule with `Commands` could cause these systems being ambiguous.
- A step for #23846.

## Solution

- Explicitly order these lighting bounds updates after the transform propagation.

## Testing

- This removes a "strict ambiguity" from #23846.