### PR TITLE
FromTemplate for TilemapChunkTileData

### DIFF
--- a/crates/bevy_sprite_render/src/tilemap_chunk/mod.rs
+++ b/crates/bevy_sprite_render/src/tilemap_chunk/mod.rs
@@ -127,7 +127,7 @@ impl Default for TileData {
 
 /// Component storing the data of tiles within a chunk.
 /// Each index corresponds to a specific tile in the tileset. `None` indicates an empty tile.
-#[derive(Component, Clone, Debug, Deref, DerefMut, Reflect)]
+#[derive(Component, Clone, Debug, Deref, DerefMut, Reflect, FromTemplate)]
 #[reflect(Component, Clone, Debug)]
 pub struct TilemapChunkTileData(pub Vec<Option<TileData>>);
 


### PR DESCRIPTION
### In Tilemap usage, TilemapChunk implements FromTemplate, so it can be used directly. However, TilemapChunkTileData cannot; it must be wrapped in a template before use.

```rust
bsn! { 
    TilemapChunk { 
        chunk_size: chunk_size, 
        tile_display_size: tile_display_size, 
        tileset: { tileset.clone() }, 
        alpha_mode: AlphaMode2d::default(), 
    }
    template(|_| TilemapChunkTileData(tile_data.clone())) 
}
```
### Similar to the previous FontSize PR (https://github.com/bevyengine/bevy/pull/23724), it can be used after modification
```rust
bsn! { 
    TilemapChunk { 
        chunk_size: chunk_size, 
        tile_display_size: tile_display_size, 
        tileset: { tileset.clone() }, 
        alpha_mode: AlphaMode2d::default(), 
    } 
    TilemapChunkTileData({ tile_data.clone() }) 
}
```
