### PR TITLE
Remove unused &Camera in `update_gizmo_meshes`.

### DIFF
--- a/crates/bevy_gizmos_render/src/transform_gizmo_render.rs
+++ b/crates/bevy_gizmos_render/src/transform_gizmo_render.rs
@@ -351,10 +351,14 @@ fn spawn_gizmo_meshes(
 
 fn update_gizmo_meshes(
     focus: Option<bevy_ecs::system::Single<&GlobalTransform, With<TransformGizmoFocus>>>,
-    marked_cameras: Query<(&Camera, &GlobalTransform), With<TransformGizmoCamera>>,
+    marked_cameras: Query<&GlobalTransform, (With<TransformGizmoCamera>, With<Camera>)>,
     all_cameras: Query<
-        (&Camera, &GlobalTransform),
-        (Without<GizmoOverlayCamera>, Without<TransformGizmoRoot>),
+        &GlobalTransform,
+        (
+            Without<GizmoOverlayCamera>,
+            Without<TransformGizmoRoot>,
+            With<Camera>,
+        ),
     >,
     settings: Option<Res<TransformGizmoSettings>>,
     state: Option<Res<TransformGizmoState>>,
@@ -394,7 +398,7 @@ fn update_gizmo_meshes(
         *root_vis = Visibility::Hidden;
         return;
     };
-    let Some((_, cam_tf)): Option<(&Camera, &GlobalTransform)> =
+    let Some(cam_tf): Option<&GlobalTransform> =
         bevy_gizmos::resolve_gizmo_camera!(marked_cameras, all_cameras)
     else {
         *root_vis = Visibility::Hidden;


### PR DESCRIPTION
# Objective

- Removes an entirely unused component in `update_gizmo_meshes`.
- Resolve a "strict ambiguity" for #23846.

## Solution

- Remove the arg! Replace with `With<Camera>`.

## Testing

- Ran the `3d_gizmos` example. It still works!