### PR TITLE
Fix some UI widgets accidentally being ambiguous with recomputing the ComputedNode::stack_index, which is not used.

### DIFF
--- a/crates/bevy_ui_widgets/src/popover.rs
+++ b/crates/bevy_ui_widgets/src/popover.rs
@@ -311,6 +311,9 @@ impl Plugin for PopoverPlugin {
             PostUpdate,
             position_popover
                 .in_set(UiSystems::Layout)
+                // The Stack systems just modify the stack_index of ComputedNode, which this system
+                // doesn't use.
+                .ambiguous_with(UiSystems::Stack)
                 .after(ui_layout_system)
                 .before(update_scrollbar_thumb),
         );

--- a/crates/bevy_ui_widgets/src/scrollbar.rs
+++ b/crates/bevy_ui_widgets/src/scrollbar.rs
@@ -462,6 +462,9 @@ impl Plugin for ScrollbarPlugin {
                 PostUpdate,
                 update_scrollbar_thumb
                     .in_set(UiSystems::Layout)
+                    // The Stack systems just modify the stack_index of ComputedNode, which this
+                    // system doesn't use.
+                    .ambiguous_with(UiSystems::Stack)
                     .after(ui_layout_system),
             );
     }


### PR DESCRIPTION
# Objective

- Resolves 2 "strict ambiguities" from #23843.

## Solution

- Make these two widget systems ambiguous with the Stack stage.
    - This only contains the ui_stack_system which only updates the stack_index of the `ComputedNode`, which is unused by these systems. So we don't care about order here.

## Testing

- Fixes the ambiguities in #23846.
