### PR TITLE
`ComputedStackIndex` component

### DIFF
--- a/_release-content/migration-guides/computed_stack_index.md
+++ b/_release-content/migration-guides/computed_stack_index.md
@@ -3,4 +3,4 @@ title: "`ComputedNode::stack_index` has been replaced by `ComputedStackIndex`"
 pull_requests: [23878]
 ---
 
-The `stack_index` field has been removed from `ComputedNode`. Instead the stack index for each UI node is stored on a specialized component `ComputedStackIndex`, which is required by `ComputedNode`. 
+The `stack_index` field has been removed from `ComputedNode`. Instead the stack index for each UI node is stored on a specialized component `ComputedStackIndex`, which is required by `ComputedNode`.

--- a/_release-content/migration-guides/computed_stack_index.md
+++ b/_release-content/migration-guides/computed_stack_index.md
@@ -1,0 +1,7 @@
+---
+title: "`ComputedNode::stack_index` has been replaced by `ComputedStackIndex`"
+pull_requests: [23878]
+---
+
+The `stack_index` field has been removed from `ComputedNode`. Instead the stack index for each UI node is stored on a specialized component `ComputedStackIndex`, which is required by `ComputedNode`. 
+

--- a/_release-content/migration-guides/computed_stack_index.md
+++ b/_release-content/migration-guides/computed_stack_index.md
@@ -4,4 +4,3 @@ pull_requests: [23878]
 ---
 
 The `stack_index` field has been removed from `ComputedNode`. Instead the stack index for each UI node is stored on a specialized component `ComputedStackIndex`, which is required by `ComputedNode`. 
-

--- a/_release-content/migration-guides/ui_stack_index.md
+++ b/_release-content/migration-guides/ui_stack_index.md
@@ -1,7 +1,0 @@
----
-title: "`ComputedNode::stack_index` has been replaced by `ComputedStackIndex`"
-pull_requests: []
----
-
-The UI stack index is no longer stored on `ComputedNode`. Instead it's now stored in its own component `ComputedStackIndex`, which is required by `ComputedNode`. 
-

--- a/_release-content/migration-guides/ui_stack_index.md
+++ b/_release-content/migration-guides/ui_stack_index.md
@@ -1,0 +1,7 @@
+---
+title: "`ComputedNode::stack_index` has been replaced by `ComputedStackIndex`"
+pull_requests: []
+---
+
+The UI stack index is no longer stored on `ComputedNode`. Instead it's now stored in its own component `ComputedStackIndex`, which is required by `ComputedNode`. 
+

--- a/crates/bevy_ui/src/accessibility.rs
+++ b/crates/bevy_ui/src/accessibility.rs
@@ -179,9 +179,7 @@ impl Plugin for AccessibilityPlugin {
                 sync_bounds_and_transforms
                     .after(button_changed)
                     .after(image_changed)
-                    .after(label_changed)
-                    // the listed systems do not affect calculated size
-                    .ambiguous_with(crate::ui_stack_system),
+                    .after(label_changed),
             )
                 .in_set(UiSystems::PostLayout)
                 .before(AccessibilitySystems::Update),

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -80,7 +80,7 @@ use bevy_input::InputSystems;
 use bevy_transform::TransformSystems;
 use layout::ui_surface::UiSurface;
 use stack::ui_stack_system;
-pub use stack::{UiStack, UiStackIndex};
+pub use stack::{UiStack, ComputedStackIndex};
 use update::{propagate_ui_target_cameras, update_clipping_system};
 
 /// The basic plugin for Bevy UI

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -80,7 +80,7 @@ use bevy_input::InputSystems;
 use bevy_transform::TransformSystems;
 use layout::ui_surface::UiSurface;
 use stack::ui_stack_system;
-pub use stack::{UiStack, ComputedStackIndex};
+pub use stack::{ComputedStackIndex, UiStack};
 use update::{propagate_ui_target_cameras, update_clipping_system};
 
 /// The basic plugin for Bevy UI

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -192,14 +192,7 @@ impl Plugin for UiPlugin {
                 ui_layout_system
                     .in_set(UiSystems::Layout)
                     .ambiguous_with(bevy_sprite::update_text2d_layout),
-                ui_stack_system
-                    .in_set(UiSystems::Stack)
-                    // These systems don't care about stack index
-                    .ambiguous_with(widget::measure_text_system)
-                    .ambiguous_with(ui_layout_system)
-                    .ambiguous_with(widget::update_viewport_render_target_size)
-                    .in_set(AmbiguousWithText)
-                    .before(UiSystems::PostLayout),
+                ui_stack_system.in_set(UiSystems::Stack),
                 update_clipping_system.in_set(UiSystems::PostLayout),
                 // Potential conflicts: `Assets<Image>`
                 // They run independently since `widget::image_node_system` will only ever observe
@@ -261,7 +254,6 @@ fn build_text_interop(app: &mut App) {
                 // as editable_text_system or related systems could generate focus changes
                 // which should be processed ASAP.
                 .before(bevy_input_focus::InputFocusSystems::FocusChangeEvents)
-                .ambiguous_with(ui_stack_system)
                 .ambiguous_with(widget::text_system)
                 .ambiguous_with(bevy_sprite::calculate_bounds_text2d),
         ),

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -80,7 +80,7 @@ use bevy_input::InputSystems;
 use bevy_transform::TransformSystems;
 use layout::ui_surface::UiSurface;
 use stack::ui_stack_system;
-pub use stack::UiStack;
+pub use stack::{UiStack, UiStackIndex};
 use update::{propagate_ui_target_cameras, update_clipping_system};
 
 /// The basic plugin for Bevy UI

--- a/crates/bevy_ui/src/stack.rs
+++ b/crates/bevy_ui/src/stack.rs
@@ -4,11 +4,15 @@ use crate::{
     experimental::{UiChildren, UiRootNodes},
     ComputedNode, GlobalZIndex, ZIndex,
 };
+use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{entity::EntityHashSet, prelude::*};
 use core::ops::Range;
 
-/// Draw order of the of the node, lower value is drawn below higher.
-#[derive(Component, PartialEq, Eq)]
+/// The order of the node in the UI layout.
+/// Nodes with a higher stack index are drawn on top of and receive interactions before nodes with lower stack indices.
+///
+/// Automatically calculated in [`UiSystems::Stack`](`super::UiSystems::Stack`).
+#[derive(Component, Default, PartialEq, Eq, Deref, DerefMut)]
 pub struct UiStackIndex(pub u32);
 
 /// The current UI stack, which contains all UI nodes ordered by their depth (back-to-front).
@@ -53,7 +57,7 @@ pub fn ui_stack_system(
     zindex_global_node_query: Query<(Entity, &GlobalZIndex, Option<&ZIndex>), With<ComputedNode>>,
     ui_children: UiChildren,
     zindex_query: Query<Option<&ZIndex>, (With<ComputedNode>, Without<GlobalZIndex>)>,
-    mut update_query: Query<&mut ComputedNode>,
+    mut update_query: Query<&mut UiStackIndex>,
 ) {
     ui_stack.partition.clear();
     ui_stack.uinodes.clear();
@@ -100,8 +104,8 @@ pub fn ui_stack_system(
     }
 
     for (i, entity) in ui_stack.uinodes.iter().enumerate() {
-        if let Ok(mut node) = update_query.get_mut(*entity) {
-            node.bypass_change_detection().stack_index = i as u32;
+        if let Ok(mut stack_index) = update_query.get_mut(*entity) {
+            stack_index.0 = i as u32;
         }
     }
 }

--- a/crates/bevy_ui/src/stack.rs
+++ b/crates/bevy_ui/src/stack.rs
@@ -13,7 +13,7 @@ use core::ops::Range;
 ///
 /// Automatically calculated in [`UiSystems::Stack`](`super::UiSystems::Stack`).
 #[derive(Component, Default, PartialEq, Eq, Deref, DerefMut)]
-pub struct UiStackIndex(pub u32);
+pub struct ComputedStackIndex(pub u32);
 
 /// The current UI stack, which contains all UI nodes ordered by their depth (back-to-front).
 ///
@@ -54,10 +54,13 @@ pub fn ui_stack_system(
     mut ui_stack: ResMut<UiStack>,
     ui_root_nodes: UiRootNodes,
     root_node_query: Query<(Entity, Option<&GlobalZIndex>, Option<&ZIndex>)>,
-    zindex_global_node_query: Query<(Entity, &GlobalZIndex, Option<&ZIndex>), With<ComputedNode>>,
+    zindex_global_node_query: Query<
+        (Entity, &GlobalZIndex, Option<&ZIndex>),
+        With<ComputedStackIndex>,
+    >,
     ui_children: UiChildren,
-    zindex_query: Query<Option<&ZIndex>, (With<ComputedNode>, Without<GlobalZIndex>)>,
-    mut update_query: Query<&mut UiStackIndex>,
+    zindex_query: Query<Option<&ZIndex>, (With<ComputedStackIndex>, Without<GlobalZIndex>)>,
+    mut update_query: Query<&mut ComputedStackIndex>,
 ) {
     ui_stack.partition.clear();
     ui_stack.uinodes.clear();
@@ -114,7 +117,7 @@ fn update_uistack_recursive(
     cache: &mut ChildBufferCache,
     node_entity: Entity,
     ui_children: &UiChildren,
-    zindex_query: &Query<Option<&ZIndex>, (With<ComputedNode>, Without<GlobalZIndex>)>,
+    zindex_query: &Query<Option<&ZIndex>, (With<ComputedStackIndex>, Without<GlobalZIndex>)>,
     ui_stack: &mut Vec<Entity>,
 ) {
     ui_stack.push(node_entity);

--- a/crates/bevy_ui/src/stack.rs
+++ b/crates/bevy_ui/src/stack.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     experimental::{UiChildren, UiRootNodes},
-    ComputedNode, GlobalZIndex, ZIndex,
+    GlobalZIndex, ZIndex,
 };
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{entity::EntityHashSet, prelude::*};

--- a/crates/bevy_ui/src/stack.rs
+++ b/crates/bevy_ui/src/stack.rs
@@ -7,6 +7,10 @@ use crate::{
 use bevy_ecs::{entity::EntityHashSet, prelude::*};
 use core::ops::Range;
 
+/// Draw order of the of the node, lower value is drawn below higher.
+#[derive(Component, PartialEq, Eq)]
+pub struct UiStackIndex(pub u32);
+
 /// The current UI stack, which contains all UI nodes ordered by their depth (back-to-front).
 ///
 /// The first entry is the furthest node from the camera and is the first one to get rendered

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -1,6 +1,6 @@
 use crate::{
     ui_transform::{UiGlobalTransform, UiTransform},
-    ContentSize, FocusPolicy, UiRect, Val,
+    ContentSize, FocusPolicy, UiRect, UiStackIndex, Val,
 };
 use bevy_camera::{visibility::Visibility, Camera, RenderTarget};
 use bevy_color::{Alpha, Color};
@@ -26,11 +26,6 @@ use tracing::warn;
 #[derive(Component, Debug, Copy, Clone, PartialEq, Reflect)]
 #[reflect(Component, Default, Debug, Clone)]
 pub struct ComputedNode {
-    /// The order of the node in the UI layout.
-    /// Nodes with a higher stack index are drawn on top of and receive interactions before nodes with lower stack indices.
-    ///
-    /// Automatically calculated in [`UiSystems::Stack`](`super::UiSystems::Stack`).
-    pub stack_index: u32,
     /// The size of the node as width and height in physical pixels.
     ///
     /// Automatically calculated by [`ui_layout_system`](`super::layout::ui_layout_system`).
@@ -106,14 +101,6 @@ impl ComputedNode {
     #[inline]
     pub const fn is_empty(&self) -> bool {
         self.size.x <= 0. || self.size.y <= 0.
-    }
-
-    /// The order of the node in the UI layout.
-    /// Nodes with a higher stack index are drawn on top of and receive interactions before nodes with lower stack indices.
-    ///
-    /// Automatically calculated in [`UiSystems::Stack`](super::UiSystems::Stack).
-    pub const fn stack_index(&self) -> u32 {
-        self.stack_index
     }
 
     /// The calculated node size as width and height in physical pixels before rounding.
@@ -393,7 +380,6 @@ impl ComputedNode {
 
 impl ComputedNode {
     pub const DEFAULT: Self = Self {
-        stack_index: 0,
         size: Vec2::ZERO,
         content_size: Vec2::ZERO,
         scrollbar_size: Vec2::ZERO,
@@ -481,6 +467,7 @@ impl From<BVec2> for IgnoreScroll {
 #[derive(Component, Clone, PartialEq, Debug, Reflect)]
 #[require(
     ComputedNode,
+    UiStackIndex,
     ContentSize,
     ComputedUiTargetCamera,
     ComputedUiRenderTargetInfo,

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -1,6 +1,6 @@
 use crate::{
     ui_transform::{UiGlobalTransform, UiTransform},
-    ContentSize, FocusPolicy, UiRect, UiStackIndex, Val,
+    ContentSize, FocusPolicy, UiRect, ComputedStackIndex, Val,
 };
 use bevy_camera::{visibility::Visibility, Camera, RenderTarget};
 use bevy_color::{Alpha, Color};
@@ -25,6 +25,7 @@ use tracing::warn;
 /// handle size without any delays.
 #[derive(Component, Debug, Copy, Clone, PartialEq, Reflect)]
 #[reflect(Component, Default, Debug, Clone)]
+#[require(ComputedStackIndex)]
 pub struct ComputedNode {
     /// The size of the node as width and height in physical pixels.
     ///
@@ -467,7 +468,7 @@ impl From<BVec2> for IgnoreScroll {
 #[derive(Component, Clone, PartialEq, Debug, Reflect)]
 #[require(
     ComputedNode,
-    UiStackIndex,
+    ComputedStackIndex,
     ContentSize,
     ComputedUiTargetCamera,
     ComputedUiRenderTargetInfo,

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -1,6 +1,6 @@
 use crate::{
     ui_transform::{UiGlobalTransform, UiTransform},
-    ContentSize, FocusPolicy, UiRect, ComputedStackIndex, Val,
+    ComputedStackIndex, ContentSize, FocusPolicy, UiRect, Val,
 };
 use bevy_camera::{visibility::Visibility, Camera, RenderTarget};
 use bevy_color::{Alpha, Color};

--- a/crates/bevy_ui_render/src/box_shadow.rs
+++ b/crates/bevy_ui_render/src/box_shadow.rs
@@ -28,7 +28,7 @@ use bevy_render::{GpuResourceAppExt, RenderApp, RenderStartup};
 use bevy_shader::{Shader, ShaderDefVal};
 use bevy_ui::{
     BoxShadow, CalculatedClip, ComputedNode, ComputedUiRenderTargetInfo, ComputedUiTargetCamera,
-    ResolvedBorderRadius, UiGlobalTransform, Val,
+    ResolvedBorderRadius, UiGlobalTransform, UiStackIndex, Val,
 };
 use bevy_utils::default;
 use bytemuck::{Pod, Zeroable};
@@ -210,6 +210,7 @@ pub fn extract_shadows(
         Query<(
             Entity,
             &ComputedNode,
+            &UiStackIndex,
             &UiGlobalTransform,
             &InheritedVisibility,
             &BoxShadow,
@@ -222,7 +223,7 @@ pub fn extract_shadows(
 ) {
     let mut mapping = camera_map.get_mapper();
 
-    for (entity, uinode, transform, visibility, box_shadow, clip, camera, target) in
+    for (entity, uinode, stack_index, transform, visibility, box_shadow, clip, camera, target) in
         &box_shadow_query
     {
         // Skip if no visible shadows
@@ -277,7 +278,7 @@ pub fn extract_shadows(
 
             extracted_box_shadows.box_shadows.push(ExtractedBoxShadow {
                 render_entity: commands.spawn(TemporaryRenderEntity).id(),
-                stack_index: uinode.stack_index,
+                stack_index: stack_index.0,
                 transform: Affine2::from(transform) * Affine2::from_translation(offset),
                 color: drop_shadow.color.into(),
                 bounds: shadow_size + 6. * blur_radius,

--- a/crates/bevy_ui_render/src/box_shadow.rs
+++ b/crates/bevy_ui_render/src/box_shadow.rs
@@ -27,8 +27,8 @@ use bevy_render::{
 use bevy_render::{GpuResourceAppExt, RenderApp, RenderStartup};
 use bevy_shader::{Shader, ShaderDefVal};
 use bevy_ui::{
-    BoxShadow, CalculatedClip, ComputedNode, ComputedUiRenderTargetInfo, ComputedUiTargetCamera,
-    ResolvedBorderRadius, UiGlobalTransform, UiStackIndex, Val,
+    BoxShadow, CalculatedClip, ComputedNode, ComputedStackIndex, ComputedUiRenderTargetInfo,
+    ComputedUiTargetCamera, ResolvedBorderRadius, UiGlobalTransform, Val,
 };
 use bevy_utils::default;
 use bytemuck::{Pod, Zeroable};
@@ -210,7 +210,7 @@ pub fn extract_shadows(
         Query<(
             Entity,
             &ComputedNode,
-            &UiStackIndex,
+            &ComputedStackIndex,
             &UiGlobalTransform,
             &InheritedVisibility,
             &BoxShadow,

--- a/crates/bevy_ui_render/src/debug_overlay.rs
+++ b/crates/bevy_ui_render/src/debug_overlay.rs
@@ -30,6 +30,7 @@ use bevy_ui::ComputedNode;
 use bevy_ui::ComputedUiTargetCamera;
 use bevy_ui::ResolvedBorderRadius;
 use bevy_ui::UiStack;
+use bevy_ui::UiStackIndex;
 
 /// Configuration for the UI debug overlay
 ///
@@ -176,6 +177,7 @@ pub fn extract_debug_overlay(
         Query<(
             Entity,
             &ComputedNode,
+            &UiStackIndex,
             &UiGlobalTransform,
             &InheritedVisibility,
             Option<&CalculatedClip>,
@@ -188,7 +190,8 @@ pub fn extract_debug_overlay(
 ) {
     let mut camera_mapper = camera_map.get_mapper();
 
-    for (entity, uinode, transform, visibility, maybe_clip, computed_target, debug) in &uinode_query
+    for (entity, uinode, stack_index, transform, visibility, maybe_clip, computed_target, debug) in
+        &uinode_query
     {
         let debug_options = debug.copied().unwrap_or((*debug_options.as_ref()).into());
         if !debug_options.enabled {
@@ -205,7 +208,7 @@ pub fn extract_debug_overlay(
         let color = debug_options
             .line_color_override
             .unwrap_or_else(|| Hsla::sequential_dispersed(entity.index_u32()).into());
-        let z_order = (ui_stack.uinodes.len() as u32 + uinode.stack_index()) as f32;
+        let z_order = (ui_stack.uinodes.len() as u32 + stack_index.0) as f32;
         let border = BorderRect::all(debug_options.line_width / uinode.inverse_scale_factor());
         let transform = transform.affine();
 

--- a/crates/bevy_ui_render/src/debug_overlay.rs
+++ b/crates/bevy_ui_render/src/debug_overlay.rs
@@ -27,10 +27,10 @@ use bevy_sprite::BorderRect;
 use bevy_ui::ui_transform::UiGlobalTransform;
 use bevy_ui::CalculatedClip;
 use bevy_ui::ComputedNode;
+use bevy_ui::ComputedStackIndex;
 use bevy_ui::ComputedUiTargetCamera;
 use bevy_ui::ResolvedBorderRadius;
 use bevy_ui::UiStack;
-use bevy_ui::ComputedStackIndex;
 
 /// Configuration for the UI debug overlay
 ///

--- a/crates/bevy_ui_render/src/debug_overlay.rs
+++ b/crates/bevy_ui_render/src/debug_overlay.rs
@@ -30,7 +30,7 @@ use bevy_ui::ComputedNode;
 use bevy_ui::ComputedUiTargetCamera;
 use bevy_ui::ResolvedBorderRadius;
 use bevy_ui::UiStack;
-use bevy_ui::UiStackIndex;
+use bevy_ui::ComputedStackIndex;
 
 /// Configuration for the UI debug overlay
 ///
@@ -177,7 +177,7 @@ pub fn extract_debug_overlay(
         Query<(
             Entity,
             &ComputedNode,
-            &UiStackIndex,
+            &ComputedStackIndex,
             &UiGlobalTransform,
             &InheritedVisibility,
             Option<&CalculatedClip>,

--- a/crates/bevy_ui_render/src/gradient.rs
+++ b/crates/bevy_ui_render/src/gradient.rs
@@ -34,7 +34,8 @@ use bevy_shader::Shader;
 use bevy_sprite::BorderRect;
 use bevy_ui::{
     BackgroundGradient, BorderGradient, ColorStop, ComputedUiRenderTargetInfo, ConicGradient,
-    Gradient, InterpolationColorSpace, LinearGradient, RadialGradient, ResolvedBorderRadius, Val,
+    Gradient, InterpolationColorSpace, LinearGradient, RadialGradient, ResolvedBorderRadius,
+    UiStackIndex, Val,
 };
 use bevy_utils::default;
 use bytemuck::{Pod, Zeroable};
@@ -343,6 +344,7 @@ pub fn extract_gradients(
         Query<(
             Entity,
             &ComputedNode,
+            &UiStackIndex,
             &ComputedUiTargetCamera,
             &ComputedUiRenderTargetInfo,
             &UiGlobalTransform,
@@ -359,6 +361,7 @@ pub fn extract_gradients(
     for (
         entity,
         uinode,
+        stack_index,
         camera,
         target,
         transform,
@@ -390,7 +393,7 @@ pub fn extract_gradients(
                 if let Some(color) = gradient.get_single() {
                     // With a single color stop there's no gradient, fill the node with the color
                     extracted_uinodes.uinodes.push(ExtractedUiNode {
-                        z_order: uinode.stack_index as f32
+                        z_order: stack_index.0 as f32
                             + match node_type {
                                 NodeType::Rect | NodeType::Inverted => stack_z_offsets::GRADIENT,
                                 NodeType::Border(_) => stack_z_offsets::BORDER_GRADIENT,
@@ -438,7 +441,7 @@ pub fn extract_gradients(
 
                         extracted_gradients.items.push(ExtractedGradient {
                             render_entity: commands.spawn(TemporaryRenderEntity).id(),
-                            stack_index: uinode.stack_index,
+                            stack_index: stack_index.0,
                             transform: transform.into(),
                             stops_range: range_start..extracted_color_stops.0.len(),
                             rect: Rect {
@@ -488,7 +491,7 @@ pub fn extract_gradients(
 
                         extracted_gradients.items.push(ExtractedGradient {
                             render_entity: commands.spawn(TemporaryRenderEntity).id(),
-                            stack_index: uinode.stack_index,
+                            stack_index: stack_index.0,
                             transform: transform.into(),
                             stops_range: range_start..extracted_color_stops.0.len(),
                             rect: Rect {
@@ -544,7 +547,7 @@ pub fn extract_gradients(
 
                         extracted_gradients.items.push(ExtractedGradient {
                             render_entity: commands.spawn(TemporaryRenderEntity).id(),
-                            stack_index: uinode.stack_index,
+                            stack_index: stack_index.0,
                             transform: transform.into(),
                             stops_range: range_start..extracted_color_stops.0.len(),
                             rect: Rect {

--- a/crates/bevy_ui_render/src/gradient.rs
+++ b/crates/bevy_ui_render/src/gradient.rs
@@ -33,9 +33,9 @@ use bevy_render::{sync_world::MainEntity, GpuResourceAppExt, RenderStartup};
 use bevy_shader::Shader;
 use bevy_sprite::BorderRect;
 use bevy_ui::{
-    BackgroundGradient, BorderGradient, ColorStop, ComputedUiRenderTargetInfo, ConicGradient,
-    Gradient, InterpolationColorSpace, LinearGradient, RadialGradient, ResolvedBorderRadius,
-    UiStackIndex, Val,
+    BackgroundGradient, BorderGradient, ColorStop, ComputedStackIndex, ComputedUiRenderTargetInfo,
+    ConicGradient, Gradient, InterpolationColorSpace, LinearGradient, RadialGradient,
+    ResolvedBorderRadius, Val,
 };
 use bevy_utils::default;
 use bytemuck::{Pod, Zeroable};
@@ -344,7 +344,7 @@ pub fn extract_gradients(
         Query<(
             Entity,
             &ComputedNode,
-            &UiStackIndex,
+            &ComputedStackIndex,
             &ComputedUiTargetCamera,
             &ComputedUiRenderTargetInfo,
             &UiGlobalTransform,

--- a/crates/bevy_ui_render/src/lib.rs
+++ b/crates/bevy_ui_render/src/lib.rs
@@ -28,8 +28,9 @@ use bevy_shader::load_shader_library;
 use bevy_sprite_render::SpriteAssetEvents;
 use bevy_ui::widget::{ImageNode, TextScroll, TextShadow, ViewportNode};
 use bevy_ui::{
-    BackgroundColor, BorderColor, CalculatedClip, ComputedNode, ComputedUiTargetCamera, Display,
-    Node, OuterColor, Outline, ResolvedBorderRadius, UiGlobalTransform, ComputedStackIndex,
+    BackgroundColor, BorderColor, CalculatedClip, ComputedNode, ComputedStackIndex,
+    ComputedUiTargetCamera, Display, Node, OuterColor, Outline, ResolvedBorderRadius,
+    UiGlobalTransform,
 };
 
 use bevy_app::prelude::*;

--- a/crates/bevy_ui_render/src/lib.rs
+++ b/crates/bevy_ui_render/src/lib.rs
@@ -29,7 +29,7 @@ use bevy_sprite_render::SpriteAssetEvents;
 use bevy_ui::widget::{ImageNode, TextScroll, TextShadow, ViewportNode};
 use bevy_ui::{
     BackgroundColor, BorderColor, CalculatedClip, ComputedNode, ComputedUiTargetCamera, Display,
-    Node, OuterColor, Outline, ResolvedBorderRadius, UiGlobalTransform, UiStackIndex,
+    Node, OuterColor, Outline, ResolvedBorderRadius, UiGlobalTransform, ComputedStackIndex,
 };
 
 use bevy_app::prelude::*;
@@ -389,7 +389,7 @@ pub fn extract_uinode_background_colors(
         Query<(
             Entity,
             &ComputedNode,
-            &UiStackIndex,
+            &ComputedStackIndex,
             &UiGlobalTransform,
             &InheritedVisibility,
             Option<&CalculatedClip>,
@@ -489,7 +489,7 @@ pub fn extract_uinode_images(
         Query<(
             Entity,
             &ComputedNode,
-            &UiStackIndex,
+            &ComputedStackIndex,
             &UiGlobalTransform,
             &InheritedVisibility,
             Option<&CalculatedClip>,
@@ -577,7 +577,7 @@ pub fn extract_uinode_borders(
             Entity,
             Option<&Node>,
             &ComputedNode,
-            &UiStackIndex,
+            &ComputedStackIndex,
             &UiGlobalTransform,
             &InheritedVisibility,
             Option<&CalculatedClip>,
@@ -856,7 +856,7 @@ pub fn extract_viewport_nodes(
         Query<(
             Entity,
             &ComputedNode,
-            &UiStackIndex,
+            &ComputedStackIndex,
             &UiGlobalTransform,
             &InheritedVisibility,
             Option<&CalculatedClip>,
@@ -930,7 +930,7 @@ pub fn extract_text_sections(
         Query<(
             Entity,
             &ComputedNode,
-            &UiStackIndex,
+            &ComputedStackIndex,
             &UiGlobalTransform,
             &InheritedVisibility,
             Option<&CalculatedClip>,
@@ -1070,7 +1070,7 @@ pub fn extract_text_shadows(
         Query<(
             Entity,
             &ComputedNode,
-            &UiStackIndex,
+            &ComputedStackIndex,
             &UiGlobalTransform,
             &ComputedUiTargetCamera,
             &InheritedVisibility,
@@ -1238,7 +1238,7 @@ pub fn extract_text_decorations(
         Query<(
             Entity,
             &ComputedNode,
-            &UiStackIndex,
+            &ComputedStackIndex,
             &ComputedTextBlock,
             &UiGlobalTransform,
             &InheritedVisibility,

--- a/crates/bevy_ui_render/src/lib.rs
+++ b/crates/bevy_ui_render/src/lib.rs
@@ -29,7 +29,7 @@ use bevy_sprite_render::SpriteAssetEvents;
 use bevy_ui::widget::{ImageNode, TextScroll, TextShadow, ViewportNode};
 use bevy_ui::{
     BackgroundColor, BorderColor, CalculatedClip, ComputedNode, ComputedUiTargetCamera, Display,
-    Node, OuterColor, Outline, ResolvedBorderRadius, UiGlobalTransform,
+    Node, OuterColor, Outline, ResolvedBorderRadius, UiGlobalTransform, UiStackIndex,
 };
 
 use bevy_app::prelude::*;
@@ -389,6 +389,7 @@ pub fn extract_uinode_background_colors(
         Query<(
             Entity,
             &ComputedNode,
+            &UiStackIndex,
             &UiGlobalTransform,
             &InheritedVisibility,
             Option<&CalculatedClip>,
@@ -404,6 +405,7 @@ pub fn extract_uinode_background_colors(
     for (
         entity,
         uinode,
+        stack_index,
         transform,
         inherited_visibility,
         clip,
@@ -428,7 +430,7 @@ pub fn extract_uinode_background_colors(
         if !background_color.is_fully_transparent() {
             extracted_uinodes.uinodes.push(ExtractedUiNode {
                 render_entity: commands.spawn(TemporaryRenderEntity).id(),
-                z_order: uinode.stack_index as f32 + stack_z_offsets::BACKGROUND_COLOR,
+                z_order: stack_index.0 as f32 + stack_z_offsets::BACKGROUND_COLOR,
                 clip: clip.map(|clip| clip.clip),
                 image: AssetId::default(),
                 extracted_camera_entity,
@@ -455,7 +457,7 @@ pub fn extract_uinode_background_colors(
         {
             extracted_uinodes.uinodes.push(ExtractedUiNode {
                 render_entity: commands.spawn(TemporaryRenderEntity).id(),
-                z_order: uinode.stack_index as f32 + stack_z_offsets::BACKGROUND_COLOR,
+                z_order: stack_index.0 as f32 + stack_z_offsets::BACKGROUND_COLOR,
                 clip: clip.map(|clip| clip.clip),
                 image: AssetId::default(),
                 extracted_camera_entity,
@@ -487,6 +489,7 @@ pub fn extract_uinode_images(
         Query<(
             Entity,
             &ComputedNode,
+            &UiStackIndex,
             &UiGlobalTransform,
             &InheritedVisibility,
             Option<&CalculatedClip>,
@@ -497,7 +500,9 @@ pub fn extract_uinode_images(
     camera_map: Extract<UiCameraMap>,
 ) {
     let mut camera_mapper = camera_map.get_mapper();
-    for (entity, uinode, transform, inherited_visibility, clip, camera, image) in &uinode_query {
+    for (entity, uinode, stack_index, transform, inherited_visibility, clip, camera, image) in
+        &uinode_query
+    {
         let content_box = uinode.content_box();
         // Skip invisible images
         if !inherited_visibility.get()
@@ -543,7 +548,7 @@ pub fn extract_uinode_images(
         };
 
         extracted_uinodes.uinodes.push(ExtractedUiNode {
-            z_order: uinode.stack_index as f32 + stack_z_offsets::IMAGE,
+            z_order: stack_index.0 as f32 + stack_z_offsets::IMAGE,
             render_entity: commands.spawn(TemporaryRenderEntity).id(),
             clip: clip.map(|clip| clip.clip),
             image: image.image.id(),
@@ -572,6 +577,7 @@ pub fn extract_uinode_borders(
             Entity,
             Option<&Node>,
             &ComputedNode,
+            &UiStackIndex,
             &UiGlobalTransform,
             &InheritedVisibility,
             Option<&CalculatedClip>,
@@ -588,6 +594,7 @@ pub fn extract_uinode_borders(
         entity,
         node,
         computed_node,
+        stack_index,
         transform,
         inherited_visibility,
         maybe_clip,
@@ -642,7 +649,7 @@ pub fn extract_uinode_borders(
                 completed_flags |= border_flags;
 
                 extracted_uinodes.uinodes.push(ExtractedUiNode {
-                    z_order: computed_node.stack_index as f32 + stack_z_offsets::BORDER,
+                    z_order: stack_index.0 as f32 + stack_z_offsets::BORDER,
                     image,
                     clip: maybe_clip.map(|clip| clip.clip),
                     extracted_camera_entity,
@@ -674,7 +681,7 @@ pub fn extract_uinode_borders(
         {
             let outline_size = computed_node.outlined_node_size();
             extracted_uinodes.uinodes.push(ExtractedUiNode {
-                z_order: computed_node.stack_index as f32 + stack_z_offsets::BORDER,
+                z_order: stack_index.0 as f32 + stack_z_offsets::BORDER,
                 render_entity: commands.spawn(TemporaryRenderEntity).id(),
                 image,
                 clip: maybe_clip.map(|clip| clip.clip),
@@ -849,6 +856,7 @@ pub fn extract_viewport_nodes(
         Query<(
             Entity,
             &ComputedNode,
+            &UiStackIndex,
             &UiGlobalTransform,
             &InheritedVisibility,
             Option<&CalculatedClip>,
@@ -859,8 +867,16 @@ pub fn extract_viewport_nodes(
     camera_map: Extract<UiCameraMap>,
 ) {
     let mut camera_mapper = camera_map.get_mapper();
-    for (entity, uinode, transform, inherited_visibility, clip, camera, viewport_node) in
-        &uinode_query
+    for (
+        entity,
+        uinode,
+        stack_index,
+        transform,
+        inherited_visibility,
+        clip,
+        camera,
+        viewport_node,
+    ) in &uinode_query
     {
         // Skip invisible images
         if !inherited_visibility.get() || uinode.is_empty() {
@@ -883,7 +899,7 @@ pub fn extract_viewport_nodes(
         };
 
         extracted_uinodes.uinodes.push(ExtractedUiNode {
-            z_order: uinode.stack_index as f32 + stack_z_offsets::IMAGE,
+            z_order: stack_index.0 as f32 + stack_z_offsets::IMAGE,
             render_entity: commands.spawn(TemporaryRenderEntity).id(),
             clip: clip.map(|clip| clip.clip),
             image: image.id(),
@@ -914,6 +930,7 @@ pub fn extract_text_sections(
         Query<(
             Entity,
             &ComputedNode,
+            &UiStackIndex,
             &UiGlobalTransform,
             &InheritedVisibility,
             Option<&CalculatedClip>,
@@ -935,6 +952,7 @@ pub fn extract_text_sections(
     for (
         entity,
         uinode,
+        stack_index,
         global_transform,
         inherited_visibility,
         maybe_clip,
@@ -1028,7 +1046,7 @@ pub fn extract_text_sections(
                 .is_none_or(|info| info.atlas_info.texture != atlas_info.texture)
             {
                 extracted_uinodes.uinodes.push(ExtractedUiNode {
-                    z_order: uinode.stack_index as f32 + stack_z_offsets::TEXT,
+                    z_order: stack_index.0 as f32 + stack_z_offsets::TEXT,
                     render_entity: commands.spawn(TemporaryRenderEntity).id(),
                     image: atlas_info.texture,
                     clip,
@@ -1052,6 +1070,7 @@ pub fn extract_text_shadows(
         Query<(
             Entity,
             &ComputedNode,
+            &UiStackIndex,
             &UiGlobalTransform,
             &ComputedUiTargetCamera,
             &InheritedVisibility,
@@ -1072,6 +1091,7 @@ pub fn extract_text_shadows(
     for (
         entity,
         uinode,
+        stack_index,
         global_transform,
         target,
         inherited_visibility,
@@ -1130,7 +1150,7 @@ pub fn extract_text_shadows(
             }) {
                 extracted_uinodes.uinodes.push(ExtractedUiNode {
                     transform: node_transform,
-                    z_order: uinode.stack_index as f32 + stack_z_offsets::TEXT,
+                    z_order: stack_index.0 as f32 + stack_z_offsets::TEXT,
                     render_entity: commands.spawn(TemporaryRenderEntity).id(),
                     image: atlas_info.texture,
                     clip,
@@ -1159,7 +1179,7 @@ pub fn extract_text_shadows(
 
             if has_strikethrough {
                 extracted_uinodes.uinodes.push(ExtractedUiNode {
-                    z_order: uinode.stack_index as f32 + stack_z_offsets::TEXT,
+                    z_order: stack_index.0 as f32 + stack_z_offsets::TEXT,
                     render_entity: commands.spawn(TemporaryRenderEntity).id(),
                     clip,
                     image: AssetId::default(),
@@ -1185,7 +1205,7 @@ pub fn extract_text_shadows(
 
             if has_underline {
                 extracted_uinodes.uinodes.push(ExtractedUiNode {
-                    z_order: uinode.stack_index as f32 + stack_z_offsets::TEXT,
+                    z_order: stack_index.0 as f32 + stack_z_offsets::TEXT,
                     render_entity: commands.spawn(TemporaryRenderEntity).id(),
                     clip,
                     image: AssetId::default(),
@@ -1218,6 +1238,7 @@ pub fn extract_text_decorations(
         Query<(
             Entity,
             &ComputedNode,
+            &UiStackIndex,
             &ComputedTextBlock,
             &UiGlobalTransform,
             &InheritedVisibility,
@@ -1241,6 +1262,7 @@ pub fn extract_text_decorations(
     for (
         entity,
         uinode,
+        stack_index,
         computed_block,
         global_transform,
         inherited_visibility,
@@ -1295,7 +1317,7 @@ pub fn extract_text_decorations(
 
             if let Some(text_background_color) = text_background_color {
                 extracted_uinodes.uinodes.push(ExtractedUiNode {
-                    z_order: uinode.stack_index as f32 + stack_z_offsets::TEXT,
+                    z_order: stack_index.0 as f32 + stack_z_offsets::TEXT,
                     render_entity: commands.spawn(TemporaryRenderEntity).id(),
                     clip,
                     image: AssetId::default(),
@@ -1325,7 +1347,7 @@ pub fn extract_text_decorations(
                     .to_linear();
 
                 extracted_uinodes.uinodes.push(ExtractedUiNode {
-                    z_order: uinode.stack_index as f32 + stack_z_offsets::TEXT_STRIKETHROUGH,
+                    z_order: stack_index.0 as f32 + stack_z_offsets::TEXT_STRIKETHROUGH,
                     render_entity: commands.spawn(TemporaryRenderEntity).id(),
                     clip,
                     image: AssetId::default(),
@@ -1355,7 +1377,7 @@ pub fn extract_text_decorations(
                     .to_linear();
 
                 extracted_uinodes.uinodes.push(ExtractedUiNode {
-                    z_order: uinode.stack_index as f32 + stack_z_offsets::TEXT_STRIKETHROUGH,
+                    z_order: stack_index.0 as f32 + stack_z_offsets::TEXT_STRIKETHROUGH,
                     render_entity: commands.spawn(TemporaryRenderEntity).id(),
                     clip,
                     image: AssetId::default(),

--- a/crates/bevy_ui_render/src/text.rs
+++ b/crates/bevy_ui_render/src/text.rs
@@ -7,8 +7,8 @@ use bevy_render::{sync_world::TemporaryRenderEntity, Extract};
 use bevy_sprite::BorderRect;
 use bevy_text::{TextCursorStyle, TextLayoutInfo};
 use bevy_ui::{
-    widget::TextScroll, CalculatedClip, ComputedNode, ComputedUiTargetCamera, ResolvedBorderRadius,
-    UiGlobalTransform, ComputedStackIndex,
+    widget::TextScroll, CalculatedClip, ComputedNode, ComputedStackIndex, ComputedUiTargetCamera,
+    ResolvedBorderRadius, UiGlobalTransform,
 };
 
 use crate::{

--- a/crates/bevy_ui_render/src/text.rs
+++ b/crates/bevy_ui_render/src/text.rs
@@ -8,7 +8,7 @@ use bevy_sprite::BorderRect;
 use bevy_text::{TextCursorStyle, TextLayoutInfo};
 use bevy_ui::{
     widget::TextScroll, CalculatedClip, ComputedNode, ComputedUiTargetCamera, ResolvedBorderRadius,
-    UiGlobalTransform,
+    UiGlobalTransform, UiStackIndex,
 };
 
 use crate::{
@@ -22,6 +22,7 @@ pub fn extract_text_cursor(
         Query<(
             Entity,
             &ComputedNode,
+            &UiStackIndex,
             &UiGlobalTransform,
             &InheritedVisibility,
             Option<&CalculatedClip>,
@@ -38,6 +39,7 @@ pub fn extract_text_cursor(
     for (
         entity,
         uinode,
+        stack_index,
         global_transform,
         inherited_visibility,
         maybe_clip,
@@ -80,7 +82,7 @@ pub fn extract_text_cursor(
             for selection in text_layout_info.selection_rects.iter() {
                 extracted_uinodes.uinodes.push(ExtractedUiNode {
                     render_entity: commands.spawn(TemporaryRenderEntity).id(),
-                    z_order: uinode.stack_index as f32 + stack_z_offsets::TEXT_SELECTION,
+                    z_order: stack_index.0 as f32 + stack_z_offsets::TEXT_SELECTION,
                     clip,
                     image: AssetId::default(),
                     extracted_camera_entity,
@@ -109,7 +111,7 @@ pub fn extract_text_cursor(
         {
             extracted_uinodes.uinodes.push(ExtractedUiNode {
                 render_entity: commands.spawn(TemporaryRenderEntity).id(),
-                z_order: uinode.stack_index as f32 + stack_z_offsets::TEXT_CURSOR,
+                z_order: stack_index.0 as f32 + stack_z_offsets::TEXT_CURSOR,
                 clip,
                 image: AssetId::default(),
                 extracted_camera_entity,

--- a/crates/bevy_ui_render/src/text.rs
+++ b/crates/bevy_ui_render/src/text.rs
@@ -8,7 +8,7 @@ use bevy_sprite::BorderRect;
 use bevy_text::{TextCursorStyle, TextLayoutInfo};
 use bevy_ui::{
     widget::TextScroll, CalculatedClip, ComputedNode, ComputedUiTargetCamera, ResolvedBorderRadius,
-    UiGlobalTransform, UiStackIndex,
+    UiGlobalTransform, ComputedStackIndex,
 };
 
 use crate::{
@@ -22,7 +22,7 @@ pub fn extract_text_cursor(
         Query<(
             Entity,
             &ComputedNode,
-            &UiStackIndex,
+            &ComputedStackIndex,
             &UiGlobalTransform,
             &InheritedVisibility,
             Option<&CalculatedClip>,

--- a/crates/bevy_ui_render/src/ui_material_pipeline.rs
+++ b/crates/bevy_ui_render/src/ui_material_pipeline.rs
@@ -24,6 +24,7 @@ use bevy_render::{
 use bevy_render::{GpuResourceAppExt, RenderApp, RenderStartup};
 use bevy_shader::{load_shader_library, Shader, ShaderRef};
 use bevy_sprite::BorderRect;
+use bevy_ui::UiStackIndex;
 use bevy_utils::default;
 use bytemuck::{Pod, Zeroable};
 use core::{hash::Hash, marker::PhantomData, ops::Range};
@@ -325,6 +326,7 @@ pub fn extract_ui_material_nodes<M: UiMaterial>(
         Query<(
             Entity,
             &ComputedNode,
+            &UiStackIndex,
             &UiGlobalTransform,
             &MaterialNode<M>,
             &InheritedVisibility,
@@ -336,8 +338,16 @@ pub fn extract_ui_material_nodes<M: UiMaterial>(
 ) {
     let mut camera_mapper = camera_map.get_mapper();
 
-    for (entity, computed_node, transform, handle, inherited_visibility, clip, camera) in
-        uinode_query.iter()
+    for (
+        entity,
+        computed_node,
+        stack_index,
+        transform,
+        handle,
+        inherited_visibility,
+        clip,
+        camera,
+    ) in uinode_query.iter()
     {
         // skip invisible nodes
         if !inherited_visibility.get() || computed_node.is_empty() {
@@ -355,7 +365,7 @@ pub fn extract_ui_material_nodes<M: UiMaterial>(
 
         extracted_uinodes.uinodes.push(ExtractedUiMaterialNode {
             render_entity: commands.spawn(TemporaryRenderEntity).id(),
-            stack_index: computed_node.stack_index,
+            stack_index: stack_index.0,
             transform: transform.into(),
             material: handle.id(),
             rect: Rect {

--- a/crates/bevy_ui_render/src/ui_material_pipeline.rs
+++ b/crates/bevy_ui_render/src/ui_material_pipeline.rs
@@ -24,7 +24,7 @@ use bevy_render::{
 use bevy_render::{GpuResourceAppExt, RenderApp, RenderStartup};
 use bevy_shader::{load_shader_library, Shader, ShaderRef};
 use bevy_sprite::BorderRect;
-use bevy_ui::UiStackIndex;
+use bevy_ui::ComputedStackIndex;
 use bevy_utils::default;
 use bytemuck::{Pod, Zeroable};
 use core::{hash::Hash, marker::PhantomData, ops::Range};
@@ -326,7 +326,7 @@ pub fn extract_ui_material_nodes<M: UiMaterial>(
         Query<(
             Entity,
             &ComputedNode,
-            &UiStackIndex,
+            &ComputedStackIndex,
             &UiGlobalTransform,
             &MaterialNode<M>,
             &InheritedVisibility,

--- a/crates/bevy_ui_render/src/ui_texture_slice_pipeline.rs
+++ b/crates/bevy_ui_render/src/ui_texture_slice_pipeline.rs
@@ -28,7 +28,7 @@ use bevy_shader::Shader;
 use bevy_sprite::{SliceScaleMode, SpriteImageMode, TextureSlicer};
 use bevy_sprite_render::SpriteAssetEvents;
 use bevy_ui::widget;
-use bevy_ui::UiStackIndex;
+use bevy_ui::ComputedStackIndex;
 use bevy_utils::default;
 use binding_types::{sampler, texture_2d};
 use bytemuck::{Pod, Zeroable};
@@ -220,7 +220,7 @@ pub fn extract_ui_texture_slices(
         Query<(
             Entity,
             &ComputedNode,
-            &UiStackIndex,
+            &ComputedStackIndex,
             &UiGlobalTransform,
             &InheritedVisibility,
             Option<&CalculatedClip>,

--- a/crates/bevy_ui_render/src/ui_texture_slice_pipeline.rs
+++ b/crates/bevy_ui_render/src/ui_texture_slice_pipeline.rs
@@ -28,6 +28,7 @@ use bevy_shader::Shader;
 use bevy_sprite::{SliceScaleMode, SpriteImageMode, TextureSlicer};
 use bevy_sprite_render::SpriteAssetEvents;
 use bevy_ui::widget;
+use bevy_ui::UiStackIndex;
 use bevy_utils::default;
 use binding_types::{sampler, texture_2d};
 use bytemuck::{Pod, Zeroable};
@@ -219,6 +220,7 @@ pub fn extract_ui_texture_slices(
         Query<(
             Entity,
             &ComputedNode,
+            &UiStackIndex,
             &UiGlobalTransform,
             &InheritedVisibility,
             Option<&CalculatedClip>,
@@ -230,7 +232,9 @@ pub fn extract_ui_texture_slices(
 ) {
     let mut camera_mapper = camera_map.get_mapper();
 
-    for (entity, uinode, transform, inherited_visibility, clip, camera, image) in &slicers_query {
+    for (entity, uinode, stack_index, transform, inherited_visibility, clip, camera, image) in
+        &slicers_query
+    {
         let content_box = uinode.content_box();
 
         // Skip invisible images
@@ -281,7 +285,7 @@ pub fn extract_ui_texture_slices(
 
         extracted_ui_slicers.slices.push(ExtractedUiTextureSlice {
             render_entity: commands.spawn(TemporaryRenderEntity).id(),
-            stack_index: uinode.stack_index,
+            stack_index: stack_index.0,
             transform: Affine2::from(*transform) * Affine2::from_translation(content_box.center()),
             color: image.color.into(),
             rect: Rect {

--- a/crates/bevy_ui_widgets/src/popover.rs
+++ b/crates/bevy_ui_widgets/src/popover.rs
@@ -311,9 +311,6 @@ impl Plugin for PopoverPlugin {
             PostUpdate,
             position_popover
                 .in_set(UiSystems::Layout)
-                // The Stack systems just modify the stack_index of ComputedNode, which this system
-                // doesn't use.
-                .ambiguous_with(UiSystems::Stack)
                 .after(ui_layout_system)
                 .before(update_scrollbar_thumb),
         );

--- a/crates/bevy_ui_widgets/src/scrollbar.rs
+++ b/crates/bevy_ui_widgets/src/scrollbar.rs
@@ -462,9 +462,6 @@ impl Plugin for ScrollbarPlugin {
                 PostUpdate,
                 update_scrollbar_thumb
                     .in_set(UiSystems::Layout)
-                    // The Stack systems just modify the stack_index of ComputedNode, which this
-                    // system doesn't use.
-                    .ambiguous_with(UiSystems::Stack)
                     .after(ui_layout_system),
             );
     }


### PR DESCRIPTION
# Objective

Split off the stack index field from `ComputedNode` into its own specialized component.
* Makes for a cleaner UI schedule and a clearer division of responsibilities.
* More fine-grained change detection, might allow for some new optimisations. 

Fixes #23862

## Solution

* Remove the `stack_index` field and its accessor from `ComputedNode`.
* New component `ComputedStackIndex`, newtyping a `u32`.
* Require `ComputedStackIndex` on `ComputedNode`. 
* In `ui_stack_system`, query for and update `ComputedStackIndex` instead of `ComputedNode`.
* In rendering add queries for `ComputedStackIndex`.
* Removed the ambiguity supression for `ui_stack_system`, as no longer needed.

Notes
* `ui_stack_system` should probably replace its `With<Node>` query filters with `With<ComputedStackIndex>`.  It uses the ghost hierarchy navigation params though, which complicates things, so I left them alone here.
* In the future it might make sense to make the value optional, with `None` indicating the UI node was removed from the layout via `Display::None`.
