### PR TITLE
Disable VALIDATION_INDIRECT_CALL by default in release builds for wgpu

### DIFF
--- a/crates/bevy_render/src/settings.rs
+++ b/crates/bevy_render/src/settings.rs
@@ -127,7 +127,10 @@ impl Default for WgpuSettings {
 
         let gles3_minor_version = Gles3MinorVersion::from_env().unwrap_or_default();
 
-        let instance_flags = InstanceFlags::default().with_env();
+        let mut instance_flags = InstanceFlags::default();
+        #[cfg(not(debug_assertions))]
+        instance_flags.remove(InstanceFlags::VALIDATION_INDIRECT_CALL);
+        instance_flags = instance_flags.with_env();
 
         Self {
             device_label: Default::default(),


### PR DESCRIPTION
**Objective**

Improves performance in release builds by disabling `VALIDATION_INDIRECT_CALL` wgpu instance default flag. Currently, even release builds have this validation enabled ([link](https://github.com/gfx-rs/wgpu/blob/ff438f3cadb8a25e0f36409566a6fb50f6707e02/wgpu-types/src/instance.rs#L253-L264)), causing unnecessary compute passes that add sometimes `~13%` CPU overhead in stress tests.

## Solution
Modified `crates/bevy_render/src/settings.rs` to explicitly remove `VALIDATION_INDIRECT_CALL` in release builds. Users can still apply environment variable overrides by using `WGPU_VALIDATION_INDIRECT_CALL` ([link](https://github.com/gfx-rs/wgpu/blob/ff438f3cadb8a25e0f36409566a6fb50f6707e02/wgpu-types/src/instance.rs#L313-L315)).

This ensures:
- **Debug builds**: Unchanged, indirect validation is enabled.
- **Release builds**: Indirect validation is disabled by default.
- **User override**: Users can re-enable in release build by using `WGPU_VALIDATION_INDIRECT_CALL=1` environment variable.

## Testing

Tested on macOS with stress test scene:
- **Command**: `cargo run --profile profiling --example  many_materials` and `cargo run --profile profiling --example many_shadow_lights -- -m 50 -l 50`
- **Without fix** (env var off): ~132 FPS on [many_materials](https://github.com/bevyengine/bevy/blob/main/examples/stress_tests/many_materials.rs) and ~13FPS on [many_shadow_lights](https://github.com/CrazyRoka/bevy/blob/many_shadow_lights/examples/stress_tests/many_shadow_lights.rs)
- **With fix** (default): ~148 FPS  on [many_materials](https://github.com/bevyengine/bevy/blob/main/examples/stress_tests/many_materials.rs) and ~18FPS on [many_shadow_lights](https://github.com/CrazyRoka/bevy/blob/many_shadow_lights/examples/stress_tests/many_shadow_lights.rs)
- **With WGPU_VALIDATION_INDIRECT_CALL=1**: produces same result as "without fix" - 132FPS and 13FPS

The improvement is visible when comparing release build with vs without `WGPU_VALIDATION_INDIRECT_CALL=1`. The fix aligns the default with the expected behavior - validation enabled in debug, disabled in release.

**Tested on**: 

```
SystemInfo { os: "macOS 15.3.1 Sequoia", kernel: "24.3.0", cpu: "Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz", core_count: "6", memory: "16.0 GiB" }
AdapterInfo { name: "AMD Radeon Pro 5300M", vendor: 0, device: 0, device_type: DiscreteGpu, device_pci_bus_id: "", driver: "", driver_info: "", backend: Metal, subgroup_min_size: 4, subgroup_max_size: 64, transient_saves_memory: false }
```
---

### Profiling results before fix

It's clearly visible that `inject_validation_pass takes` ~13% CPU time.

<img width="1427" height="499" alt="image" src="https://github.com/user-attachments/assets/734a93a7-8988-4a4a-a295-bef64a00ff68" />
