### PR TITLE
"Run once" Scenes

### DIFF
--- a/crates/bevy_scene/Cargo.toml
+++ b/crates/bevy_scene/Cargo.toml
@@ -23,5 +23,6 @@ bevy_utils = { path = "../bevy_utils", version = "0.19.0-dev" }
 thiserror = { version = "2", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 variadics_please = "1.0"
+
 [lints]
 workspace = true

--- a/crates/bevy_scene/src/resolved_scene.rs
+++ b/crates/bevy_scene/src/resolved_scene.rs
@@ -1,5 +1,5 @@
-use crate::{ResolveContext, ScenePatch};
-use bevy_asset::{AssetId, AssetPath, Assets, Handle, UntypedAssetId};
+use crate::{ResolveContext, ResolveSceneError, Scene, SceneList, ScenePatch};
+use bevy_asset::{AssetId, AssetPath, AssetServer, Assets, Handle, UntypedAssetId};
 use bevy_ecs::{
     bundle::{Bundle, BundleScratch, BundleWriter},
     component::{Component, ComponentsRegistrator},
@@ -23,6 +23,31 @@ pub struct ResolvedSceneRoot {
 }
 
 impl ResolvedSceneRoot {
+    /// Resolves the current `scene` (using [`Scene::resolve`]). This should only be called after every dependency has loaded from the `scene`'s
+    /// [`Scene::register_dependencies`].
+    pub fn resolve(
+        scene: Box<dyn Scene>,
+        assets: &AssetServer,
+        patches: &Assets<ScenePatch>,
+    ) -> Result<Self, ResolveSceneError> {
+        let mut resolved_scene = ResolvedScene::default();
+        let mut entity_scopes = EntityScopes::default();
+        scene.resolve_box(
+            &mut ResolveContext {
+                assets,
+                patches,
+                current_scope: 0,
+                entity_scopes: &mut entity_scopes,
+                inherited: None,
+            },
+            &mut resolved_scene,
+        )?;
+        Ok(ResolvedSceneRoot {
+            scene: resolved_scene,
+            entity_scopes,
+        })
+    }
+
     /// This will spawn a new [`Entity`], then call [`ResolvedSceneRoot::apply`] on it.
     /// If this fails mid-spawn, the intermediate entity will be despawned.
     pub fn spawn<'w>(&self, world: &'w mut World) -> Result<EntityWorldMut<'w>, ApplySceneError> {
@@ -75,6 +100,30 @@ pub struct ResolvedSceneListRoot {
 }
 
 impl ResolvedSceneListRoot {
+    /// Resolves the current `scene_list` (using [`SceneList::resolve_list`]). This should only be
+    /// called after every dependency has loaded from the `scene_list`'s [`SceneList::register_dependencies`].
+    pub fn resolve(
+        scene_list: Box<dyn SceneList>,
+        assets: &AssetServer,
+        patches: &Assets<ScenePatch>,
+    ) -> Result<Self, ResolveSceneError> {
+        let mut resolved_scenes = Vec::new();
+        let mut entity_scopes = EntityScopes::default();
+        scene_list.resolve_list_box(
+            &mut ResolveContext {
+                assets,
+                patches,
+                current_scope: 0,
+                entity_scopes: &mut entity_scopes,
+                inherited: None,
+            },
+            &mut resolved_scenes,
+        )?;
+        Ok(ResolvedSceneListRoot {
+            scenes: resolved_scenes,
+            entity_scopes,
+        })
+    }
     /// Spawns a new [`Entity`] for each [`ResolvedScene`] in the list, and applies that [`ResolvedScene`] to them.
     pub fn spawn<'w>(&self, world: &'w mut World) -> Result<Vec<Entity>, ApplySceneError> {
         self.spawn_with(world, |_| {})

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -67,7 +67,16 @@ pub trait Scene: SceneBox {
     fn register_dependencies(&self, _dependencies: &mut SceneDependencies) {}
 }
 
-/// Boxed version of [`Scene`], which enables implementing [`Scene`] for [`Box<dyn Scene>`].
+/// Boxed version of [`Scene`], which enables implementing [`Scene`] for [`Box<dyn Scene>`]. Most
+/// developers do not need to think about or use this trait.
+///
+/// ## Why does this exist?
+///
+/// [`Scene::resolve`] consumes `self`, which by default is not something that [`Box<dyn Scene>`]
+/// can do in Rust, as `dyn Scene` is "unsized". The "way out" is to have every [`Scene`] type
+/// _also_ know how to resolve itself for `self: Box<Self>`. [`SceneBox`] has a blanket impl
+/// for `Scene + Sized` (which can just rely on the [`Scene`] impl). Then [`Box<dyn Scene>`] has a
+/// manual [`SceneBox`] impl that relies on the _stored_ [`SceneBox::resolve_box`] impl.
 pub trait SceneBox: Send + Sync + 'static {
     /// See [`Scene::resolve`].
     fn resolve_box(

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -37,7 +37,7 @@ use variadics_please::all_tuples;
 ///
 /// See [`ResolvedScene`] for more information on how it can be composed.
 ///
-/// A [`Scene`] can have dependencies (defined with [`Self::register_dependencies`]), which _must_ be loaded before calling [`Scene::resolve`], or it
+/// A [`Scene`] can have dependencies (defined in [`Scene::register_dependencies`]), which _must_ be loaded before calling [`Scene::resolve`], or it
 /// might return a [`ResolveSceneError`].
 ///
 /// You generally don't need to resolve [`Scene`]s yourself. Instead use APIs like [`World::spawn_scene`] or [`World::queue_spawn_scene`]
@@ -70,6 +70,8 @@ pub trait Scene: SceneBox {
 /// Boxed version of [`Scene`], which enables implementing [`Scene`] for [`Box<dyn Scene>`]. Most
 /// developers do not need to think about or use this trait.
 ///
+/// Related: [`SceneListBox`].
+///
 /// ## Why does this exist?
 ///
 /// [`Scene::resolve`] consumes `self`, which by default is not something that [`Box<dyn Scene>`]
@@ -77,6 +79,8 @@ pub trait Scene: SceneBox {
 /// _also_ know how to resolve itself for `self: Box<Self>`. [`SceneBox`] has a blanket impl
 /// for `Scene + Sized` (which can just rely on the [`Scene`] impl). Then [`Box<dyn Scene>`] has a
 /// manual [`SceneBox`] impl that relies on the _stored_ [`SceneBox::resolve_box`] impl.
+///
+/// [`SceneListBox`]: crate::SceneListBox
 pub trait SceneBox: Send + Sync + 'static {
     /// See [`Scene::resolve`].
     fn resolve_box(
@@ -159,6 +163,9 @@ pub enum ResolveSceneError {
     /// Caused when inheriting a scene during [`Scene::resolve`] fails.
     #[error(transparent)]
     InheritSceneError(#[from] InheritSceneError),
+    /// Caused when a Scene/SceneList is not present on the scene asset.
+    #[error("The Scene/SceneList is not present on the scene asset. This is likely because the scene has already been resolved, which consumed the source scene")]
+    MissingScene,
 }
 
 /// Context used by [`Scene`] implementations during [`Scene::resolve`].

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -37,7 +37,7 @@ use variadics_please::all_tuples;
 ///
 /// See [`ResolvedScene`] for more information on how it can be composed.
 ///
-/// A [`Scene`] can have dependencies (defined with [`Scene::register_dependencies`]), which _must_ be loaded before calling [`Scene::resolve`], or it
+/// A [`Scene`] can have dependencies (defined with [`Self::register_dependencies`]), which _must_ be loaded before calling [`Scene::resolve`], or it
 /// might return a [`ResolveSceneError`].
 ///
 /// You generally don't need to resolve [`Scene`]s yourself. Instead use APIs like [`World::spawn_scene`] or [`World::queue_spawn_scene`]
@@ -47,24 +47,67 @@ use variadics_please::all_tuples;
 /// [`World::queue_spawn_scene`]: crate::WorldSceneExt::queue_spawn_scene
 /// [`Entity`]: bevy_ecs::entity::Entity
 /// [`Component`]: bevy_ecs::component::Component
-pub trait Scene: Send + Sync + 'static {
+pub trait Scene: SceneBox {
     /// This will apply the changes described in this [`Scene`] to the given [`ResolvedScene`]. This should not be called until all of the dependencies
     /// in [`Scene::register_dependencies`] have been loaded. The scene system will generally call this method on behalf of developers.
     ///
     /// [`Scene`]s are free to modify [`ResolvedScene`] in arbitrary ways. In the context of related entities, in general they should just be pushing new
     /// entities to the back of the list.
     fn resolve(
-        &self,
+        self,
         context: &mut ResolveContext,
         scene: &mut ResolvedScene,
     ) -> Result<(), ResolveSceneError>;
 
-    /// [`Scene`] can have [`Asset`] dependencies, which _must_ be loaded before calling [`Scene::resolve`] or it might return a [`ResolveSceneError`]!
+    /// [`Scene`] can have [`Asset`] dependencies, which _must_ be loaded before calling [`Scene::resolve`] / [`SceneList::resolve_list`] or it might return a [`ResolveSceneError`]!
     ///
-    /// In most cases, the scene system will ensure [`Scene::resolve`] is called _after_ these dependencies have been loaded.
+    /// In most cases, the scene system will ensure [`Scene::resolve`] / [`SceneList::resolve_list`] is called _after_ these dependencies have been loaded.
     ///
     /// [`Asset`]: bevy_asset::Asset
     fn register_dependencies(&self, _dependencies: &mut SceneDependencies) {}
+}
+
+/// Boxed version of [`Scene`], which enables implementing [`Scene`] for [`Box<dyn Scene>`].
+pub trait SceneBox: Send + Sync + 'static {
+    /// See [`Scene::resolve`].
+    fn resolve_box(
+        self: Box<Self>,
+        context: &mut ResolveContext,
+        scene: &mut ResolvedScene,
+    ) -> Result<(), ResolveSceneError>;
+
+    /// See [`Scene::register_dependencies`].
+    fn register_dependencies_box(&self, _dependencies: &mut SceneDependencies);
+}
+
+impl<S: Scene + Sized> SceneBox for S {
+    #[inline]
+    fn resolve_box(
+        self: Box<Self>,
+        context: &mut ResolveContext,
+        scene: &mut ResolvedScene,
+    ) -> Result<(), ResolveSceneError> {
+        (*self).resolve(context, scene)
+    }
+
+    #[inline]
+    fn register_dependencies_box(&self, dependencies: &mut SceneDependencies) {
+        self.register_dependencies(dependencies);
+    }
+}
+
+impl<T: ?Sized + SceneBox> Scene for Box<T> {
+    fn resolve(
+        self,
+        context: &mut ResolveContext,
+        scene: &mut ResolvedScene,
+    ) -> Result<(), ResolveSceneError> {
+        self.resolve_box(context, scene)
+    }
+
+    fn register_dependencies(&self, dependencies: &mut SceneDependencies) {
+        (**self).register_dependencies_box(dependencies);
+    }
 }
 
 /// A collection of asset dependencies required by a [`Scene`].
@@ -146,7 +189,7 @@ impl<'a> ResolveContext<'a> {
 macro_rules! scene_impl {
     ($($patch: ident),*) => {
         impl<$($patch: Scene),*> Scene for ($($patch,)*) {
-            fn resolve(&self, _context: &mut ResolveContext, _scene: &mut ResolvedScene) -> Result<(), ResolveSceneError> {
+            fn resolve(self, _context: &mut ResolveContext, _scene: &mut ResolvedScene) -> Result<(), ResolveSceneError> {
                 #[expect(
                     clippy::allow_attributes,
                     reason = "This is inside a macro, and as such, may not trigger in all cases."
@@ -178,33 +221,6 @@ macro_rules! scene_impl {
 
 all_tuples!(scene_impl, 0, 12, P);
 
-impl Scene for Box<dyn Scene> {
-    fn resolve(
-        &self,
-        context: &mut ResolveContext,
-        scene: &mut ResolvedScene,
-    ) -> Result<(), ResolveSceneError> {
-        (**self).resolve(context, scene)
-    }
-    fn register_dependencies(&self, dependencies: &mut SceneDependencies) {
-        (**self).register_dependencies(dependencies);
-    }
-}
-
-impl SceneList for Box<dyn SceneList> {
-    fn resolve_list(
-        &self,
-        context: &mut ResolveContext,
-        scenes: &mut Vec<ResolvedScene>,
-    ) -> Result<(), ResolveSceneError> {
-        (**self).resolve_list(context, scenes)
-    }
-
-    fn register_dependencies(&self, dependencies: &mut SceneDependencies) {
-        (**self).register_dependencies(dependencies);
-    }
-}
-
 /// A [`Scene`] that patches a [`Template`] of type `T` with a given function `F`.
 ///
 /// Functionally, a [`TemplatePatch`] scene will initialize a [`Default`] value of the patched
@@ -231,16 +247,16 @@ impl SceneList for Box<dyn SceneList> {
 /// let position = Position { x: 0, y: 0};
 /// // applying patch to position would result in { x: 10, y: 0 }
 /// ```
-pub struct TemplatePatch<F: Fn(&mut T, &mut ResolveContext), T>(pub F, pub PhantomData<T>);
+pub struct TemplatePatch<F: FnOnce(&mut T, &mut ResolveContext), T>(pub F, pub PhantomData<T>);
 
 /// Returns a [`Scene`] that completely overwrites the current value of a [`Template`] `T` with the given `value`.
 /// The `value` is cloned each time the [`Template`] is built.
-pub fn template_value<T: Template + Clone>(
+pub fn template_value<T: Template>(
     value: T,
-) -> TemplatePatch<impl Fn(&mut T, &mut ResolveContext), T> {
+) -> TemplatePatch<impl FnOnce(&mut T, &mut ResolveContext), T> {
     TemplatePatch(
         move |input: &mut T, _context: &mut ResolveContext| {
-            *input = value.clone();
+            *input = value;
         },
         PhantomData,
     )
@@ -253,14 +269,14 @@ pub trait PatchFromTemplate {
     type Template;
 
     /// Takes a "patch function" `func`, and turns it into a [`TemplatePatch`].
-    fn patch<F: Fn(&mut Self::Template, &mut ResolveContext)>(
+    fn patch<F: FnOnce(&mut Self::Template, &mut ResolveContext)>(
         func: F,
     ) -> TemplatePatch<F, Self::Template>;
 }
 
 impl<G: FromTemplate> PatchFromTemplate for G {
     type Template = G::Template;
-    fn patch<F: Fn(&mut Self::Template, &mut ResolveContext)>(
+    fn patch<F: FnOnce(&mut Self::Template, &mut ResolveContext)>(
         func: F,
     ) -> TemplatePatch<F, Self::Template> {
         TemplatePatch(func, PhantomData)
@@ -270,22 +286,25 @@ impl<G: FromTemplate> PatchFromTemplate for G {
 /// A helper function that returns a [`TemplatePatch`] [`Scene`] for something that implements [`Template`].
 pub trait PatchTemplate: Sized {
     /// Takes a "patch function" `func` that patches this [`Template`], and turns it into a [`TemplatePatch`].
-    fn patch_template<F: Fn(&mut Self, &mut ResolveContext)>(func: F) -> TemplatePatch<F, Self>;
+    fn patch_template<F: FnOnce(&mut Self, &mut ResolveContext)>(func: F)
+        -> TemplatePatch<F, Self>;
 }
 
 impl<T: Template> PatchTemplate for T {
-    fn patch_template<F: Fn(&mut Self, &mut ResolveContext)>(func: F) -> TemplatePatch<F, Self> {
+    fn patch_template<F: FnOnce(&mut Self, &mut ResolveContext)>(
+        func: F,
+    ) -> TemplatePatch<F, Self> {
         TemplatePatch(func, PhantomData)
     }
 }
 
 impl<
-        F: Fn(&mut T, &mut ResolveContext) + Send + Sync + 'static,
+        F: FnOnce(&mut T, &mut ResolveContext) + Send + Sync + 'static,
         T: Template<Output: Component> + Send + Sync + Default + 'static,
     > Scene for TemplatePatch<F, T>
 {
     fn resolve(
-        &self,
+        self,
         context: &mut ResolveContext,
         scene: &mut ResolvedScene,
     ) -> Result<(), ResolveSceneError> {
@@ -317,7 +336,7 @@ impl<R: Relationship, L: SceneList> RelatedScenes<R, L> {
 
 impl<R: Relationship, L: SceneList> Scene for RelatedScenes<R, L> {
     fn resolve(
-        &self,
+        self,
         context: &mut ResolveContext,
         scene: &mut ResolvedScene,
     ) -> Result<(), ResolveSceneError> {
@@ -352,7 +371,7 @@ impl<I: Into<AssetPath<'static>>> From<I> for InheritSceneAsset {
 
 impl Scene for InheritSceneAsset {
     fn resolve(
-        &self,
+        self,
         context: &mut ResolveContext,
         scene: &mut ResolvedScene,
     ) -> Result<(), ResolveSceneError> {
@@ -376,7 +395,7 @@ impl<F: (Fn(&mut TemplateContext) -> Result<O>) + Clone + Send + Sync + 'static,
     for FnTemplate<F, O>
 {
     fn resolve(
-        &self,
+        self,
         _context: &mut ResolveContext,
         scene: &mut ResolvedScene,
     ) -> Result<(), ResolveSceneError> {
@@ -402,7 +421,7 @@ pub struct NameEntityReference {
 
 impl Scene for NameEntityReference {
     fn resolve(
-        &self,
+        self,
         context: &mut ResolveContext,
         scene: &mut ResolvedScene,
     ) -> Result<(), ResolveSceneError> {
@@ -429,7 +448,7 @@ pub struct SceneScope<S: Scene>(pub S);
 
 impl<S: Scene> Scene for SceneScope<S> {
     fn resolve(
-        &self,
+        self,
         context: &mut ResolveContext,
         scene: &mut ResolvedScene,
     ) -> Result<(), ResolveSceneError> {
@@ -447,7 +466,7 @@ pub struct SceneListScope<L: SceneList>(pub L);
 
 impl<L: SceneList> SceneList for SceneListScope<L> {
     fn resolve_list(
-        &self,
+        self,
         context: &mut ResolveContext,
         scenes: &mut Vec<ResolvedScene>,
     ) -> Result<(), ResolveSceneError> {
@@ -488,7 +507,7 @@ impl<
     > Scene for OnTemplate<I, E, B, M>
 {
     fn resolve(
-        &self,
+        self,
         _context: &mut ResolveContext,
         scene: &mut ResolvedScene,
     ) -> Result<(), ResolveSceneError> {

--- a/crates/bevy_scene/src/scene_list.rs
+++ b/crates/bevy_scene/src/scene_list.rs
@@ -23,6 +23,16 @@ pub trait SceneList: SceneListBox {
 }
 
 /// Boxed version of [`SceneList`], which enables implementing [`SceneList`] for [`Box<dyn SceneList>`].
+/// Most developers do not need to think about or use this trait.
+///
+/// ## Why does this exist?
+///
+/// [`SceneList::resolve_list`] consumes `self`, which by default is not something that
+/// [`Box<dyn SceneList>`] can do in Rust, as `dyn Scene` is "unsized". The "way out" is to have
+/// every [`Scene`] type _also_ know how to resolve itself for `self: Box<Self>`. [`SceneListBox`]
+/// has a blanket impl for `SceneList + Sized` (which can just rely on the [`SceneList`] impl).
+/// Then [`Box<dyn SceneList>`] has a manual [`SceneListBox`] impl that relies on the _stored_
+/// [`SceneListBox::resolve_list_box`] impl.
 pub trait SceneListBox: Send + Sync + 'static {
     /// See [`SceneList::resolve_list`].
     fn resolve_list_box(
@@ -45,6 +55,7 @@ impl<L: SceneList> SceneListBox for L {
         (*self).resolve_list(context, scenes)
     }
 
+    #[inline]
     fn register_dependencies_box(&self, dependencies: &mut SceneDependencies) {
         self.register_dependencies(dependencies);
     }

--- a/crates/bevy_scene/src/scene_list.rs
+++ b/crates/bevy_scene/src/scene_list.rs
@@ -25,6 +25,8 @@ pub trait SceneList: SceneListBox {
 /// Boxed version of [`SceneList`], which enables implementing [`SceneList`] for [`Box<dyn SceneList>`].
 /// Most developers do not need to think about or use this trait.
 ///
+/// Related: [`SceneBox`].
+///
 /// ## Why does this exist?
 ///
 /// [`SceneList::resolve_list`] consumes `self`, which by default is not something that
@@ -33,6 +35,8 @@ pub trait SceneList: SceneListBox {
 /// has a blanket impl for `SceneList + Sized` (which can just rely on the [`SceneList`] impl).
 /// Then [`Box<dyn SceneList>`] has a manual [`SceneListBox`] impl that relies on the _stored_
 /// [`SceneListBox::resolve_list_box`] impl.
+///
+/// [`SceneBox`]: crate::SceneBox
 pub trait SceneListBox: Send + Sync + 'static {
     /// See [`SceneList::resolve_list`].
     fn resolve_list_box(

--- a/crates/bevy_scene/src/scene_list.rs
+++ b/crates/bevy_scene/src/scene_list.rs
@@ -6,11 +6,11 @@ use variadics_please::all_tuples;
 /// [`Scene`] is to [`Entity`] as [`SceneList`] is to [`Vec<Entity>`].
 ///
 /// [`Entity`]: bevy_ecs::entity::Entity
-pub trait SceneList: Send + Sync + 'static {
+pub trait SceneList: SceneListBox {
     /// This will apply the changes described in this [`SceneList`] to the given [`Vec<ResolvedScene>`]. This should not be called until all of
     /// the dependencies in [`Scene::register_dependencies`] have been loaded.
     fn resolve_list(
-        &self,
+        self,
         context: &mut ResolveContext,
         scenes: &mut Vec<ResolvedScene>,
     ) -> Result<(), ResolveSceneError>;
@@ -22,6 +22,48 @@ pub trait SceneList: Send + Sync + 'static {
     fn register_dependencies(&self, dependencies: &mut SceneDependencies);
 }
 
+/// Boxed version of [`SceneList`], which enables implementing [`SceneList`] for [`Box<dyn SceneList>`].
+pub trait SceneListBox: Send + Sync + 'static {
+    /// See [`SceneList::resolve_list`].
+    fn resolve_list_box(
+        self: Box<Self>,
+        context: &mut ResolveContext,
+        scenes: &mut Vec<ResolvedScene>,
+    ) -> Result<(), ResolveSceneError>;
+
+    /// See [`SceneList::register_dependencies`].
+    fn register_dependencies_box(&self, dependencies: &mut SceneDependencies);
+}
+
+impl<L: SceneList> SceneListBox for L {
+    #[inline]
+    fn resolve_list_box(
+        self: Box<Self>,
+        context: &mut ResolveContext,
+        scenes: &mut Vec<ResolvedScene>,
+    ) -> Result<(), ResolveSceneError> {
+        (*self).resolve_list(context, scenes)
+    }
+
+    fn register_dependencies_box(&self, dependencies: &mut SceneDependencies) {
+        self.register_dependencies(dependencies);
+    }
+}
+
+impl<T: ?Sized + SceneListBox> SceneList for Box<T> {
+    fn resolve_list(
+        self,
+        context: &mut ResolveContext,
+        scenes: &mut Vec<ResolvedScene>,
+    ) -> Result<(), ResolveSceneError> {
+        self.resolve_list_box(context, scenes)
+    }
+
+    fn register_dependencies(&self, dependencies: &mut SceneDependencies) {
+        (**self).register_dependencies_box(dependencies);
+    }
+}
+
 /// Corresponds to a single member of a [`SceneList`] (an [`Entity`] with an `S` [`Scene`]).
 ///
 /// [`Entity`]: bevy_ecs::entity::Entity
@@ -29,7 +71,7 @@ pub struct EntityScene<S>(pub S);
 
 impl<S: Scene> SceneList for EntityScene<S> {
     fn resolve_list(
-        &self,
+        self,
         context: &mut ResolveContext,
         scenes: &mut Vec<ResolvedScene>,
     ) -> Result<(), ResolveSceneError> {
@@ -47,7 +89,7 @@ impl<S: Scene> SceneList for EntityScene<S> {
 macro_rules! scene_list_impl {
     ($($list: ident),*) => {
         impl<$($list: SceneList),*> SceneList for ($($list,)*) {
-            fn resolve_list(&self, _context: &mut ResolveContext, _scenes: &mut Vec<ResolvedScene>) -> Result<(), ResolveSceneError> {
+            fn resolve_list(self, _context: &mut ResolveContext, _scenes: &mut Vec<ResolvedScene>) -> Result<(), ResolveSceneError> {
                 #[expect(
                     clippy::allow_attributes,
                     reason = "This is inside a macro, and as such, may not trigger in all cases."
@@ -81,7 +123,7 @@ all_tuples!(scene_list_impl, 0, 12, P);
 
 impl<S: Scene> SceneList for Vec<S> {
     fn resolve_list(
-        &self,
+        self,
         context: &mut ResolveContext,
         scenes: &mut Vec<ResolvedScene>,
     ) -> Result<(), ResolveSceneError> {

--- a/crates/bevy_scene/src/scene_patch.rs
+++ b/crates/bevy_scene/src/scene_patch.rs
@@ -19,7 +19,13 @@ use thiserror::Error;
 #[derive(Asset, TypePath)]
 pub struct ScenePatch {
     /// A [`Scene`].
-    pub scene: Box<dyn Scene>,
+    pub resolve_scene: Option<
+        Box<
+            dyn FnOnce(&mut ResolveContext, &mut ResolvedScene) -> Result<(), ResolveSceneError>
+                + Send
+                + Sync,
+        >,
+    >,
     /// The dependencies of `scene` (populated using [`Scene::register_dependencies`]). These are "asset dependencies" and will affect the load state.
     #[dependency]
     pub dependencies: Vec<UntypedHandle>,
@@ -46,7 +52,9 @@ impl ScenePatch {
             .map(|i| load_from_path.load_from_path_erased(i.type_id, i.path.clone()))
             .collect::<Vec<_>>();
         ScenePatch {
-            scene: Box::new(scene),
+            resolve_scene: Some(Box::new(|context, resolved_scene| {
+                scene.resolve(context, resolved_scene)
+            })),
             dependencies,
             resolved: None,
         }
@@ -59,19 +67,10 @@ impl ScenePatch {
         assets: &AssetServer,
         patches: &Assets<ScenePatch>,
     ) -> Result<(), ResolveSceneError> {
-        let resolved = self.resolve_internal(assets, patches)?;
-        self.resolved = Some(Arc::new(resolved));
-        Ok(())
-    }
-
-    pub(crate) fn resolve_internal(
-        &self,
-        assets: &AssetServer,
-        patches: &Assets<ScenePatch>,
-    ) -> Result<ResolvedSceneRoot, ResolveSceneError> {
         let mut scene = ResolvedScene::default();
         let mut entity_scopes = EntityScopes::default();
-        self.scene.resolve(
+        let resolve_scene = self.resolve_scene.take().unwrap();
+        (resolve_scene)(
             &mut ResolveContext {
                 assets,
                 patches,
@@ -81,11 +80,11 @@ impl ScenePatch {
             },
             &mut scene,
         )?;
-
-        Ok(ResolvedSceneRoot {
+        self.resolved = Some(Arc::new(ResolvedSceneRoot {
             scene,
             entity_scopes,
-        })
+        }));
+        Ok(())
     }
 
     /// Spawns the scene in `world` as a new entity. This should only be called after [`ScenePatch::resolve`].
@@ -133,7 +132,16 @@ pub struct ScenePatchInstance(pub Handle<ScenePatch>);
 #[derive(Asset, TypePath)]
 pub struct SceneListPatch {
     /// A [`SceneList`].
-    pub scene_list: Box<dyn SceneList>,
+    pub resolve_scene_list: Option<
+        Box<
+            dyn FnOnce(
+                    &mut ResolveContext,
+                    &mut Vec<ResolvedScene>,
+                ) -> Result<(), ResolveSceneError>
+                + Send
+                + Sync,
+        >,
+    >,
 
     /// The dependencies of `scene_list` (populated using [`SceneList::register_dependencies`]). These are "asset dependencies" and will affect the load state.
     #[dependency]
@@ -155,7 +163,9 @@ impl SceneListPatch {
             .map(|dep| assets.load_builder().load_erased(dep.type_id, &dep.path))
             .collect::<Vec<_>>();
         SceneListPatch {
-            scene_list: Box::new(scene_list),
+            resolve_scene_list: Some(Box::new(|context, scenes| {
+                scene_list.resolve_list(context, scenes)
+            })),
             dependencies,
             resolved: None,
         }
@@ -168,21 +178,10 @@ impl SceneListPatch {
         assets: &AssetServer,
         patches: &Assets<ScenePatch>,
     ) -> Result<(), ResolveSceneError> {
-        let resolved = self.resolve_internal(assets, patches)?;
-        self.resolved = Some(resolved);
-        Ok(())
-    }
-
-    /// Resolves the current `scene` (using [`SceneList::resolve_list`]). This should only be called after every dependency has loaded from the `scene_list`'s
-    /// [`SceneList::register_dependencies`].
-    pub(crate) fn resolve_internal(
-        &self,
-        assets: &AssetServer,
-        patches: &Assets<ScenePatch>,
-    ) -> Result<ResolvedSceneListRoot, ResolveSceneError> {
+        let resolve_scene_list = self.resolve_scene_list.take().unwrap();
         let mut scenes = Vec::new();
         let mut entity_scopes = EntityScopes::default();
-        self.scene_list.resolve_list(
+        (resolve_scene_list)(
             &mut ResolveContext {
                 assets,
                 patches,
@@ -192,11 +191,11 @@ impl SceneListPatch {
             },
             &mut scenes,
         )?;
-
-        Ok(ResolvedSceneListRoot {
+        self.resolved = Some(ResolvedSceneListRoot {
             scenes,
             entity_scopes,
-        })
+        });
+        Ok(())
     }
 
     /// Spawns the scene list in `world` as new entities. This should only be called after [`SceneListPatch::resolve`].

--- a/crates/bevy_scene/src/scene_patch.rs
+++ b/crates/bevy_scene/src/scene_patch.rs
@@ -1,6 +1,6 @@
 use crate::{
-    ApplySceneError, ResolveContext, ResolveSceneError, ResolvedScene, ResolvedSceneListRoot,
-    ResolvedSceneRoot, Scene, SceneDependencies, SceneList,
+    ApplySceneError, ResolveSceneError, ResolvedSceneListRoot, ResolvedSceneRoot, Scene,
+    SceneDependencies, SceneList,
 };
 use alloc::sync::Arc;
 use bevy_asset::{Asset, AssetServer, Assets, Handle, LoadFromPath, UntypedHandle};
@@ -9,7 +9,7 @@ use bevy_ecs::{
     bundle::BundleScratch,
     component::Component,
     entity::Entity,
-    template::{EntityScopes, FromTemplate},
+    template::FromTemplate,
     world::{EntityWorldMut, World},
 };
 use bevy_reflect::TypePath;
@@ -59,23 +59,10 @@ impl ScenePatch {
         assets: &AssetServer,
         patches: &Assets<ScenePatch>,
     ) -> Result<(), ResolveSceneError> {
-        let mut resolved_scene = ResolvedScene::default();
-        let mut entity_scopes = EntityScopes::default();
         let scene = self.scene.take().unwrap();
-        scene.resolve_box(
-            &mut ResolveContext {
-                assets,
-                patches,
-                current_scope: 0,
-                entity_scopes: &mut entity_scopes,
-                inherited: None,
-            },
-            &mut resolved_scene,
-        )?;
-        self.resolved = Some(Arc::new(ResolvedSceneRoot {
-            scene: resolved_scene,
-            entity_scopes,
-        }));
+        self.resolved = Some(Arc::new(ResolvedSceneRoot::resolve(
+            scene, assets, patches,
+        )?));
         Ok(())
     }
 
@@ -160,22 +147,7 @@ impl SceneListPatch {
         patches: &Assets<ScenePatch>,
     ) -> Result<(), ResolveSceneError> {
         let scene_list = self.scene_list.take().unwrap();
-        let mut resolved_scenes = Vec::new();
-        let mut entity_scopes = EntityScopes::default();
-        scene_list.resolve_list_box(
-            &mut ResolveContext {
-                assets,
-                patches,
-                current_scope: 0,
-                entity_scopes: &mut entity_scopes,
-                inherited: None,
-            },
-            &mut resolved_scenes,
-        )?;
-        self.resolved = Some(ResolvedSceneListRoot {
-            scenes: resolved_scenes,
-            entity_scopes,
-        });
+        self.resolved = Some(ResolvedSceneListRoot::resolve(scene_list, assets, patches)?);
         Ok(())
     }
 

--- a/crates/bevy_scene/src/scene_patch.rs
+++ b/crates/bevy_scene/src/scene_patch.rs
@@ -15,7 +15,7 @@ use bevy_ecs::{
 use bevy_reflect::TypePath;
 use thiserror::Error;
 
-/// An [`Asset`] that holds a [`Scene`], tracks its dependencies, and holds the [`ResolvedScene`] (after the [`Scene`] has been loaded and resolved).
+/// An [`Asset`] that holds a [`Scene`], tracks its dependencies, and holds the [`ResolvedSceneRoot`] (after the [`Scene`] has been loaded and resolved).
 #[derive(Asset, TypePath)]
 pub struct ScenePatch {
     /// A [`Scene`].
@@ -23,7 +23,7 @@ pub struct ScenePatch {
     /// The dependencies of `scene` (populated using [`Scene::register_dependencies`]). These are "asset dependencies" and will affect the load state.
     #[dependency]
     pub dependencies: Vec<UntypedHandle>,
-    /// The [`ResolvedScene`], if exists. This is populated after the [`Scene`] has been loaded and resolved
+    /// The [`ResolvedSceneRoot`], if exists. This is populated after the [`Scene`] has been loaded and resolved
     // TODO: consider breaking this out to prevent mutating asset events when resolved. Assets as Entities will enable this!
     // TODO: This Arc exists to allow nested ResolvedSceneRoot::apply when borrowing inherited ScenePatch assets (see the ResolvedSceneRoot::apply implementation).
     pub resolved: Option<Arc<ResolvedSceneRoot>>,
@@ -92,7 +92,9 @@ impl ScenePatch {
 /// An [`Error`] that occurs during scene spawning.
 #[derive(Error, Debug)]
 pub enum SpawnSceneError {
-    /// Failed to apply a [`ResolvedScene`]s.
+    /// Failed to apply a [`ResolvedScene`].
+    ///
+    /// [`ResolvedScene`]: crate::ResolvedScene
     #[error(transparent)]
     ApplySceneError(#[from] ApplySceneError),
     #[error(transparent)]
@@ -107,7 +109,7 @@ pub enum SpawnSceneError {
 #[derive(Component, FromTemplate, Deref, DerefMut)]
 pub struct ScenePatchInstance(pub Handle<ScenePatch>);
 
-/// An [`Asset`] that holds a [`SceneList`], tracks its dependencies, and holds a [`Vec`] of [`ResolvedScene`] (after the [`SceneList`] has been loaded and resolved)
+/// An [`Asset`] that holds a [`SceneList`], tracks its dependencies, and holds a [`ResolvedSceneListRoot`] (after the [`SceneList`] has been loaded and resolved)
 #[derive(Asset, TypePath)]
 pub struct SceneListPatch {
     /// A [`SceneList`].

--- a/crates/bevy_scene/src/scene_patch.rs
+++ b/crates/bevy_scene/src/scene_patch.rs
@@ -19,13 +19,7 @@ use thiserror::Error;
 #[derive(Asset, TypePath)]
 pub struct ScenePatch {
     /// A [`Scene`].
-    pub resolve_scene: Option<
-        Box<
-            dyn FnOnce(&mut ResolveContext, &mut ResolvedScene) -> Result<(), ResolveSceneError>
-                + Send
-                + Sync,
-        >,
-    >,
+    pub scene: Option<Box<dyn Scene>>,
     /// The dependencies of `scene` (populated using [`Scene::register_dependencies`]). These are "asset dependencies" and will affect the load state.
     #[dependency]
     pub dependencies: Vec<UntypedHandle>,
@@ -52,9 +46,7 @@ impl ScenePatch {
             .map(|i| load_from_path.load_from_path_erased(i.type_id, i.path.clone()))
             .collect::<Vec<_>>();
         ScenePatch {
-            resolve_scene: Some(Box::new(|context, resolved_scene| {
-                scene.resolve(context, resolved_scene)
-            })),
+            scene: Some(Box::new(scene)),
             dependencies,
             resolved: None,
         }
@@ -67,10 +59,10 @@ impl ScenePatch {
         assets: &AssetServer,
         patches: &Assets<ScenePatch>,
     ) -> Result<(), ResolveSceneError> {
-        let mut scene = ResolvedScene::default();
+        let mut resolved_scene = ResolvedScene::default();
         let mut entity_scopes = EntityScopes::default();
-        let resolve_scene = self.resolve_scene.take().unwrap();
-        (resolve_scene)(
+        let scene = self.scene.take().unwrap();
+        scene.resolve_box(
             &mut ResolveContext {
                 assets,
                 patches,
@@ -78,10 +70,10 @@ impl ScenePatch {
                 entity_scopes: &mut entity_scopes,
                 inherited: None,
             },
-            &mut scene,
+            &mut resolved_scene,
         )?;
         self.resolved = Some(Arc::new(ResolvedSceneRoot {
-            scene,
+            scene: resolved_scene,
             entity_scopes,
         }));
         Ok(())
@@ -132,16 +124,7 @@ pub struct ScenePatchInstance(pub Handle<ScenePatch>);
 #[derive(Asset, TypePath)]
 pub struct SceneListPatch {
     /// A [`SceneList`].
-    pub resolve_scene_list: Option<
-        Box<
-            dyn FnOnce(
-                    &mut ResolveContext,
-                    &mut Vec<ResolvedScene>,
-                ) -> Result<(), ResolveSceneError>
-                + Send
-                + Sync,
-        >,
-    >,
+    pub scene_list: Option<Box<dyn SceneList>>,
 
     /// The dependencies of `scene_list` (populated using [`SceneList::register_dependencies`]). These are "asset dependencies" and will affect the load state.
     #[dependency]
@@ -163,9 +146,7 @@ impl SceneListPatch {
             .map(|dep| assets.load_builder().load_erased(dep.type_id, &dep.path))
             .collect::<Vec<_>>();
         SceneListPatch {
-            resolve_scene_list: Some(Box::new(|context, scenes| {
-                scene_list.resolve_list(context, scenes)
-            })),
+            scene_list: Some(Box::new(scene_list)),
             dependencies,
             resolved: None,
         }
@@ -178,10 +159,10 @@ impl SceneListPatch {
         assets: &AssetServer,
         patches: &Assets<ScenePatch>,
     ) -> Result<(), ResolveSceneError> {
-        let resolve_scene_list = self.resolve_scene_list.take().unwrap();
-        let mut scenes = Vec::new();
+        let scene_list = self.scene_list.take().unwrap();
+        let mut resolved_scenes = Vec::new();
         let mut entity_scopes = EntityScopes::default();
-        (resolve_scene_list)(
+        scene_list.resolve_list_box(
             &mut ResolveContext {
                 assets,
                 patches,
@@ -189,10 +170,10 @@ impl SceneListPatch {
                 entity_scopes: &mut entity_scopes,
                 inherited: None,
             },
-            &mut scenes,
+            &mut resolved_scenes,
         )?;
         self.resolved = Some(ResolvedSceneListRoot {
-            scenes,
+            scenes: resolved_scenes,
             entity_scopes,
         });
         Ok(())

--- a/crates/bevy_scene/src/scene_patch.rs
+++ b/crates/bevy_scene/src/scene_patch.rs
@@ -59,7 +59,7 @@ impl ScenePatch {
         assets: &AssetServer,
         patches: &Assets<ScenePatch>,
     ) -> Result<(), ResolveSceneError> {
-        let scene = self.scene.take().unwrap();
+        let scene = self.scene.take().ok_or(ResolveSceneError::MissingScene)?;
         self.resolved = Some(Arc::new(ResolvedSceneRoot::resolve(
             scene, assets, patches,
         )?));
@@ -148,7 +148,10 @@ impl SceneListPatch {
         assets: &AssetServer,
         patches: &Assets<ScenePatch>,
     ) -> Result<(), ResolveSceneError> {
-        let scene_list = self.scene_list.take().unwrap();
+        let scene_list = self
+            .scene_list
+            .take()
+            .ok_or(ResolveSceneError::MissingScene)?;
         self.resolved = Some(ResolvedSceneListRoot::resolve(scene_list, assets, patches)?);
         Ok(())
     }

--- a/crates/bevy_scene/src/spawn.rs
+++ b/crates/bevy_scene/src/spawn.rs
@@ -634,10 +634,10 @@ pub fn resolve_scene_patches(
     for event in list_events.read() {
         match *event {
             AssetEvent::LoadedWithDependencies { id } => {
-                if let Some(mut list_patch) = list_patches.get_mut(id) {
-                    if let Err(err) = list_patch.resolve(&assets, &patches) {
-                        error!("Failed to resolve scene list {id}: {err}");
-                    }
+                if let Some(mut list_patch) = list_patches.get_mut(id)
+                    && let Err(err) = list_patch.resolve(&assets, &patches)
+                {
+                    error!("Failed to resolve scene list {id}: {err}");
                 }
             }
             AssetEvent::Removed { id } => {

--- a/crates/bevy_scene/src/spawn.rs
+++ b/crates/bevy_scene/src/spawn.rs
@@ -1,8 +1,12 @@
-use crate::{Scene, SceneList, SceneListPatch, ScenePatch, ScenePatchInstance, SpawnSceneError};
+use crate::{
+    ResolveContext, ResolvedScene, ResolvedSceneRoot, Scene, SceneList, SceneListPatch, ScenePatch,
+    ScenePatchInstance, SpawnSceneError,
+};
 use alloc::sync::Arc;
 use bevy_asset::{AssetEvent, AssetServer, Assets, Handle};
 use bevy_ecs::{
     bundle::BundleScratch, message::MessageCursor, prelude::*, relationship::Relationship,
+    template::EntityScopes,
 };
 use bevy_platform::collections::HashMap;
 use tracing::error;
@@ -593,11 +597,23 @@ pub fn resolve_scene_patches(
     for event in events.read() {
         match *event {
             AssetEvent::LoadedWithDependencies { id } => {
-                if let Some(patch) = patches.get(id) {
-                    match patch.resolve_internal(&assets, &patches) {
-                        Ok(resolved) => {
+                if let Some(patch) = patches.get_mut(id).and_then(|mut p| p.resolve_scene.take()) {
+                    let mut scene = ResolvedScene::default();
+                    let mut entity_scopes = EntityScopes::default();
+                    let mut resolve_context = ResolveContext {
+                        assets: &assets,
+                        patches: &patches,
+                        current_scope: 0,
+                        entity_scopes: &mut entity_scopes,
+                        inherited: None,
+                    };
+                    match (patch)(&mut resolve_context, &mut scene) {
+                        Ok(()) => {
                             let mut patch = patches.get_mut(id).unwrap();
-                            patch.resolved = Some(Arc::new(resolved));
+                            patch.resolved = Some(Arc::new(ResolvedSceneRoot {
+                                scene,
+                                entity_scopes,
+                            }));
                         }
                         Err(err) => error!("Failed to resolve scene {id}: {err}"),
                     }
@@ -619,11 +635,8 @@ pub fn resolve_scene_patches(
         match *event {
             AssetEvent::LoadedWithDependencies { id } => {
                 if let Some(mut list_patch) = list_patches.get_mut(id) {
-                    match list_patch.resolve_internal(&assets, &patches) {
-                        Ok(resolved) => {
-                            list_patch.resolved = Some(resolved);
-                        }
-                        Err(err) => error!("Failed to resolve scene list {id}: {err}"),
+                    if let Err(err) = list_patch.resolve(&assets, &patches) {
+                        error!("Failed to resolve scene list {id}: {err}");
                     }
                 }
             }

--- a/crates/bevy_scene/src/spawn.rs
+++ b/crates/bevy_scene/src/spawn.rs
@@ -597,8 +597,8 @@ pub fn resolve_scene_patches(
     for event in events.read() {
         match *event {
             AssetEvent::LoadedWithDependencies { id } => {
-                if let Some(patch) = patches.get_mut(id).and_then(|mut p| p.resolve_scene.take()) {
-                    let mut scene = ResolvedScene::default();
+                if let Some(scene) = patches.get_mut(id).and_then(|mut p| p.scene.take()) {
+                    let mut resolved_scene = ResolvedScene::default();
                     let mut entity_scopes = EntityScopes::default();
                     let mut resolve_context = ResolveContext {
                         assets: &assets,
@@ -607,11 +607,11 @@ pub fn resolve_scene_patches(
                         entity_scopes: &mut entity_scopes,
                         inherited: None,
                     };
-                    match (patch)(&mut resolve_context, &mut scene) {
+                    match scene.resolve_box(&mut resolve_context, &mut resolved_scene) {
                         Ok(()) => {
                             let mut patch = patches.get_mut(id).unwrap();
                             patch.resolved = Some(Arc::new(ResolvedSceneRoot {
-                                scene,
+                                scene: resolved_scene,
                                 entity_scopes,
                             }));
                         }

--- a/crates/bevy_scene/src/spawn.rs
+++ b/crates/bevy_scene/src/spawn.rs
@@ -1,12 +1,11 @@
 use crate::{
-    ResolveContext, ResolvedScene, ResolvedSceneRoot, Scene, SceneList, SceneListPatch, ScenePatch,
-    ScenePatchInstance, SpawnSceneError,
+    ResolvedSceneRoot, Scene, SceneList, SceneListPatch, ScenePatch, ScenePatchInstance,
+    SpawnSceneError,
 };
 use alloc::sync::Arc;
 use bevy_asset::{AssetEvent, AssetServer, Assets, Handle};
 use bevy_ecs::{
     bundle::BundleScratch, message::MessageCursor, prelude::*, relationship::Relationship,
-    template::EntityScopes,
 };
 use bevy_platform::collections::HashMap;
 use tracing::error;
@@ -598,22 +597,10 @@ pub fn resolve_scene_patches(
         match *event {
             AssetEvent::LoadedWithDependencies { id } => {
                 if let Some(scene) = patches.get_mut(id).and_then(|mut p| p.scene.take()) {
-                    let mut resolved_scene = ResolvedScene::default();
-                    let mut entity_scopes = EntityScopes::default();
-                    let mut resolve_context = ResolveContext {
-                        assets: &assets,
-                        patches: &patches,
-                        current_scope: 0,
-                        entity_scopes: &mut entity_scopes,
-                        inherited: None,
-                    };
-                    match scene.resolve_box(&mut resolve_context, &mut resolved_scene) {
-                        Ok(()) => {
+                    match ResolvedSceneRoot::resolve(scene, &assets, &patches) {
+                        Ok(resolved) => {
                             let mut patch = patches.get_mut(id).unwrap();
-                            patch.resolved = Some(Arc::new(ResolvedSceneRoot {
-                                scene: resolved_scene,
-                                entity_scopes,
-                            }));
+                            patch.resolved = Some(Arc::new(resolved));
                         }
                         Err(err) => error!("Failed to resolve scene {id}: {err}"),
                     }


### PR DESCRIPTION
# Objective

`Scene` and `SceneList` currently require "repeatability".  This puts some burden on developers setting "field patches" in BSN, as the "right hand side" values must either be Copy or have a manual Clone. This results in scenes like:

```rust
let mesh = meshes.add(Circle::new(4.0));
let material = materials.add(Color::WHITE);

bsn! {
    Mesh3d({mesh.clone()})
    MeshMaterial3d::<StandardMaterial>({material.clone()})
}
```

In practice, thanks to inheritance caching, repeatability is no longer required.

## Solution

- Make `Scene` and `SceneList` consume `self`.
- Add `SceneBox` and `SceneListBox` subtraits to enable `Box<dyn Scene>` to impl `Scene` and consume itself.
- Switch to `FnOnce` for patches.

This enables the following code to work:

```rust
let mesh = meshes.add(Circle::new(4.0));
let material = materials.add(Color::WHITE);

bsn! {
    Mesh3d(mesh)
    MeshMaterial3d::<StandardMaterial>(material)
}
```