### PR TITLE
MSRV CI job fail to use cargo rust-version dependency resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -521,7 +521,6 @@ jobs:
         run: |
           msrv=`cargo metadata --no-deps --format-version 1 | jq --raw-output '.packages[] | select(.name=="bevy") | .rust_version'`
           echo "msrv=$msrv" >> $GITHUB_OUTPUT
-          rm Cargo.lock
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
           toolchain: ${{ steps.msrv.outputs.msrv }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -521,7 +521,7 @@ jobs:
         run: |
           msrv=`cargo metadata --no-deps --format-version 1 | jq --raw-output '.packages[] | select(.name=="bevy") | .rust_version'`
           echo "msrv=$msrv" >> $GITHUB_OUTPUT
-          rm cargo.lock
+          rm Cargo.lock
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
           toolchain: ${{ steps.msrv.outputs.msrv }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -521,6 +521,7 @@ jobs:
         run: |
           msrv=`cargo metadata --no-deps --format-version 1 | jq --raw-output '.packages[] | select(.name=="bevy") | .rust_version'`
           echo "msrv=$msrv" >> $GITHUB_OUTPUT
+          rm cargo.lock
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
           toolchain: ${{ steps.msrv.outputs.msrv }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/bevy"
 rust-version = "1.92.0"
 
 [workspace]
-resolver = "2"
+resolver = "3"
 members = [
   # All of Bevy's official crates are within the `crates` folder!
   "crates/*",


### PR DESCRIPTION
# Objective

- CI fails because of a wrong MSRV issue

## Solution

- ~`cargo metadata` creates a lock file with the current stable version, which is then used by the MSRV~ turns out `cargo metadata --no-deps` doesn't lock the lock file unlike `cargo metadata`
- ~clear the stable lock file~
- also update the resolver to v3: https://doc.rust-lang.org/edition-guide/rust-2024/cargo-resolver.html

## Testing

- CI