### PR TITLE
Handle the case where there is no resume time.

### DIFF
--- a/crates/bevy_winit/src/state.rs
+++ b/crates/bevy_winit/src/state.rs
@@ -163,12 +163,13 @@ impl ApplicationHandler<WinitUserEvent> for WinitAppRunnerState {
 
         self.wait_elapsed = match cause {
             StartCause::WaitCancelled {
-                requested_resume: Some(resume),
-                ..
+                requested_resume, ..
             } => {
                 // If the resume time is not after now, it means that at least the wait timeout
-                // has elapsed.
-                resume <= Instant::now()
+                // has elapsed. Alternatively, if the resume time is unset, the wait never elapses.
+                requested_resume
+                    .map(|resume| resume <= Instant::now())
+                    .unwrap_or_default()
             }
             _ => true,
         };


### PR DESCRIPTION
# Objective

- Fix the case where the UpdateMode::reactive is set to Duration::MAX.

## Solution

- When `StartCause::WaitCancelled::requested_resume` is `None`, always report this case as not having elapsed the wait time.

## Testing

- Ran the desktop_request_redraw with `UpdateMode::reactive(Duration::MAX)` and now it updates only when a redraw happens or a window even happens!
