### PR TITLE
Fix Feathers radio groups, add `radio_self_update()`

### DIFF
--- a/crates/bevy_ui_widgets/src/radio.rs
+++ b/crates/bevy_ui_widgets/src/radio.rs
@@ -8,6 +8,7 @@ use bevy_ecs::{
     observer::On,
     query::{Has, With, Without},
     reflect::ReflectComponent,
+    relationship::Relationship,
     system::{Commands, Query},
 };
 use bevy_input::keyboard::{KeyCode, KeyboardInput};
@@ -328,5 +329,26 @@ impl Plugin for RadioGroupPlugin {
             .add_observer(radio_button_on_pointer_up)
             .add_observer(radio_button_on_pointer_drag_end)
             .add_observer(radio_button_on_pointer_cancel);
+    }
+}
+
+/// Observer function which updates the radio button in response to a [`ValueChange`] event.
+/// This can be used to make the radio button automatically update its own state and within
+/// the correct radio group when clicked, as opposed to managing the checkbox state externally.
+pub fn radio_self_update(
+    value_change: On<ValueChange<Entity>>,
+    q_radio: Query<Entity, With<RadioButton>>,
+    q_parents: Query<&ChildOf>,
+    mut commands: Commands,
+) {
+    for radio in q_radio.iter() {
+        if radio == value_change.value {
+            commands.entity(radio).insert(Checked);
+        } else if let Ok(child_of) = q_parents.get(radio) {
+            if child_of.get() == value_change.source {
+                // Only uncheck other radio buttons in the same group
+                commands.entity(radio).remove::<Checked>();
+            }
+        }
     }
 }

--- a/crates/bevy_ui_widgets/src/radio.rs
+++ b/crates/bevy_ui_widgets/src/radio.rs
@@ -352,3 +352,31 @@ pub fn radio_self_update(
         }
     }
 }
+
+/// Observer function which updates the radio button in response to a [`ValueChange`] event.
+/// This can be used to make the radio button automatically update its own state and within
+/// the correct radio group when clicked, as opposed to managing the checkbox state externally.
+pub fn radio_self_update2(
+    value_change: On<ValueChange<Entity>>,
+    q_radio_group: Query<(Entity, &Children), With<RadioGroup>>,
+    q_radio: Query<Entity, With<RadioButton>>,
+    mut commands: Commands,
+) {
+    // Get the children of the source radio group
+    let Some((_radio_group, children)) = q_radio_group
+        .iter()
+        .find(|(group, _)| *group == value_change.source)
+    else {
+        return;
+    };
+
+    // Iterate the children for this radio group
+    let mut iter = q_radio.iter_many(children);
+    while let Some(radio) = iter.fetch_next() {
+        if radio == value_change.value {
+            commands.entity(radio).insert(Checked);
+        } else {
+            commands.entity(radio).remove::<Checked>();
+        }
+    }
+}

--- a/crates/bevy_ui_widgets/src/radio.rs
+++ b/crates/bevy_ui_widgets/src/radio.rs
@@ -8,7 +8,6 @@ use bevy_ecs::{
     observer::On,
     query::{Has, With, Without},
     reflect::ReflectComponent,
-    relationship::Relationship,
     system::{Commands, Query},
 };
 use bevy_input::keyboard::{KeyCode, KeyboardInput};
@@ -337,40 +336,16 @@ impl Plugin for RadioGroupPlugin {
 /// the correct radio group when clicked, as opposed to managing the checkbox state externally.
 pub fn radio_self_update(
     value_change: On<ValueChange<Entity>>,
-    q_radio: Query<Entity, With<RadioButton>>,
-    q_parents: Query<&ChildOf>,
-    mut commands: Commands,
-) {
-    for radio in q_radio.iter() {
-        if radio == value_change.value {
-            commands.entity(radio).insert(Checked);
-        } else if let Ok(child_of) = q_parents.get(radio) {
-            if child_of.get() == value_change.source {
-                // Only uncheck other radio buttons in the same group
-                commands.entity(radio).remove::<Checked>();
-            }
-        }
-    }
-}
-
-/// Observer function which updates the radio button in response to a [`ValueChange`] event.
-/// This can be used to make the radio button automatically update its own state and within
-/// the correct radio group when clicked, as opposed to managing the checkbox state externally.
-pub fn radio_self_update2(
-    value_change: On<ValueChange<Entity>>,
-    q_radio_group: Query<(Entity, &Children), With<RadioGroup>>,
+    q_radio_group: Query<&Children, With<RadioGroup>>,
     q_radio: Query<Entity, With<RadioButton>>,
     mut commands: Commands,
 ) {
     // Get the children of the source radio group
-    let Some((_radio_group, children)) = q_radio_group
-        .iter()
-        .find(|(group, _)| *group == value_change.source)
-    else {
+    let Ok(children) = q_radio_group.get(value_change.source) else {
         return;
     };
 
-    // Iterate the children for this radio group
+    // Iterate the children of this radio group
     let mut iter = q_radio.iter_many(children);
     while let Some(radio) = iter.fetch_next() {
         if radio == value_change.value {

--- a/crates/bevy_ui_widgets/src/radio.rs
+++ b/crates/bevy_ui_widgets/src/radio.rs
@@ -331,9 +331,9 @@ impl Plugin for RadioGroupPlugin {
     }
 }
 
-/// Observer function which updates the radio button in response to a [`ValueChange`] event.
-/// This can be used to make the radio button automatically update its own state and within
-/// the correct radio group when clicked, as opposed to managing the checkbox state externally.
+/// Observer function which updates the radio buttons in a group in response to a [`ValueChange`] event.
+/// This can be used to make the radio buttons automatically update their own states and within
+/// the correct radio group when clicked, as opposed to managing the states externally.
 pub fn radio_self_update(
     value_change: On<ValueChange<Entity>>,
     q_radio_group: Query<&Children, With<RadioGroup>>,

--- a/crates/bevy_ui_widgets/src/radio.rs
+++ b/crates/bevy_ui_widgets/src/radio.rs
@@ -277,7 +277,7 @@ fn radio_button_on_pointer_drag_end(
     }
 }
 
-fn checkbox_on_pointer_cancel(
+fn radio_button_on_pointer_cancel(
     mut cancel: On<Pointer<Cancel>>,
     mut q_radio: Query<(Entity, Has<InteractionDisabled>, Has<Pressed>), With<RadioButton>>,
     mut commands: Commands,
@@ -327,6 +327,6 @@ impl Plugin for RadioGroupPlugin {
             .add_observer(radio_button_on_pointer_down)
             .add_observer(radio_button_on_pointer_up)
             .add_observer(radio_button_on_pointer_drag_end)
-            .add_observer(checkbox_on_pointer_cancel);
+            .add_observer(radio_button_on_pointer_cancel);
     }
 }

--- a/examples/ui/widgets/feathers_gallery.rs
+++ b/examples/ui/widgets/feathers_gallery.rs
@@ -30,7 +30,7 @@ use bevy::{
     ui::{Checked, InteractionDisabled},
     ui_widgets::{
         checkbox_self_update, radio_self_update, slider_self_update, Activate, ActivateOnPress,
-        RadioButton, RadioGroup, SliderPrecision, SliderStep, SliderValue, ValueChange,
+        RadioGroup, SliderPrecision, SliderStep, SliderValue, ValueChange,
     },
     window::SystemCursorIcon,
 };
@@ -352,63 +352,74 @@ fn demo_column_1() -> impl Scene {
             (
                 Node {
                     display: Display::Flex,
-                    flex_direction: FlexDirection::Column,
-                    row_gap: px(4),
+                    flex_direction: FlexDirection::Row,
+                    align_items: AlignItems::Center,
+                    justify_content: JustifyContent::Start,
+                    column_gap: px(8),
                 }
-                RadioGroup
-                on(radio_self_update)
                 Children [
-                    (radio(RadioProps {
-                        caption: Box::new(bsn_list!(
-                            (Text("One") ThemedText),
-                        )),
-                    }) Checked),
-                    (radio(RadioProps {
-                        caption: Box::new(bsn_list!(
-                            (Text("Two") ThemedText),
-                        )),
-                    })),
-                    (radio(RadioProps {
-                        caption: Box::new(bsn_list!(
-                            (Text("Fast Click") ThemedText),
-                        )),
-                    }) ActivateOnPress),
-                    (radio(RadioProps {
-                        caption: Box::new(bsn_list!(
-                            (Text("Disabled") ThemedText),
-                        )),
-                    }) InteractionDisabled),
-                ]
-            ),
-            (
-                Node {
-                    display: Display::Flex,
-                    flex_direction: FlexDirection::Column,
-                    row_gap: px(4),
-                }
-                RadioGroup
-                on(radio_self_update)
-                Children [
-                    (radio(RadioProps {
-                        caption: Box::new(bsn_list!(
-                            (Text("One") ThemedText),
-                        )),
-                    }) Checked),
-                    (radio(RadioProps {
-                        caption: Box::new(bsn_list!(
-                            (Text("Two") ThemedText),
-                        )),
-                    })),
-                    (radio(RadioProps {
-                        caption: Box::new(bsn_list!(
-                            (Text("Fast Click") ThemedText),
-                        )),
-                    }) ActivateOnPress),
-                    (radio(RadioProps {
-                        caption: Box::new(bsn_list!(
-                            (Text("Disabled") ThemedText),
-                        )),
-                    }) InteractionDisabled),
+                    (
+                        Node {
+                            display: Display::Flex,
+                            flex_direction: FlexDirection::Column,
+                            row_gap: px(4),
+                        }
+                        RadioGroup
+                        on(radio_self_update)
+                        Children [
+                            (radio(RadioProps {
+                                caption: Box::new(bsn_list!(
+                                    (Text("One") ThemedText),
+                                )),
+                            }) Checked),
+                            (radio(RadioProps {
+                                caption: Box::new(bsn_list!(
+                                    (Text("Two") ThemedText),
+                                )),
+                            })),
+                            (radio(RadioProps {
+                                caption: Box::new(bsn_list!(
+                                    (Text("Fast Click") ThemedText),
+                                )),
+                            }) ActivateOnPress),
+                            (radio(RadioProps {
+                                caption: Box::new(bsn_list!(
+                                    (Text("Disabled") ThemedText),
+                                )),
+                            }) InteractionDisabled),
+                        ]
+                    ),
+                    (
+                        Node {
+                            display: Display::Flex,
+                            flex_direction: FlexDirection::Column,
+                            row_gap: px(4),
+                        }
+                        RadioGroup
+                        on(radio_self_update)
+                        Children [
+                            (radio(RadioProps {
+                                caption: Box::new(bsn_list!(
+                                    (Text("One") ThemedText),
+                                )),
+                            }) Checked),
+                            (radio(RadioProps {
+                                caption: Box::new(bsn_list!(
+                                    (Text("Two") ThemedText),
+                                )),
+                            })),
+                            (radio(RadioProps {
+                                caption: Box::new(bsn_list!(
+                                    (Text("Fast Click") ThemedText),
+                                )),
+                            }) ActivateOnPress),
+                            (radio(RadioProps {
+                                caption: Box::new(bsn_list!(
+                                    (Text("Disabled") ThemedText),
+                                )),
+                            }) InteractionDisabled),
+                        ]
+                    )
                 ]
             ),
             (

--- a/examples/ui/widgets/feathers_gallery.rs
+++ b/examples/ui/widgets/feathers_gallery.rs
@@ -29,7 +29,7 @@ use bevy::{
     text::{EditableText, TextEdit, TextEditChange},
     ui::{Checked, InteractionDisabled},
     ui_widgets::{
-        checkbox_self_update, radio_self_update2, slider_self_update, Activate, ActivateOnPress,
+        checkbox_self_update, radio_self_update, slider_self_update, Activate, ActivateOnPress,
         RadioButton, RadioGroup, SliderPrecision, SliderStep, SliderValue, ValueChange,
     },
     window::SystemCursorIcon,
@@ -356,7 +356,7 @@ fn demo_column_1() -> impl Scene {
                     row_gap: px(4),
                 }
                 RadioGroup
-                on(radio_self_update2)
+                on(radio_self_update)
                 Children [
                     (radio(RadioProps {
                         caption: Box::new(bsn_list!(
@@ -387,7 +387,7 @@ fn demo_column_1() -> impl Scene {
                     row_gap: px(4),
                 }
                 RadioGroup
-                on(radio_self_update2)
+                on(radio_self_update)
                 Children [
                     (radio(RadioProps {
                         caption: Box::new(bsn_list!(

--- a/examples/ui/widgets/feathers_gallery.rs
+++ b/examples/ui/widgets/feathers_gallery.rs
@@ -34,6 +34,7 @@ use bevy::{
     },
     window::SystemCursorIcon,
 };
+use bevy_ecs::relationship::Relationship;
 
 /// A struct to hold the state of various widgets shown in the demo.
 #[derive(Resource)]
@@ -359,12 +360,63 @@ fn demo_column_1() -> impl Scene {
                 on(
                     |value_change: On<ValueChange<Entity>>,
                         q_radio: Query<Entity, With<RadioButton>>,
+                        q_parents: Query<&ChildOf>,
                         mut commands: Commands| {
                         for radio in q_radio.iter() {
                             if radio == value_change.value {
                                 commands.entity(radio).insert(Checked);
-                            } else {
-                                commands.entity(radio).remove::<Checked>();
+                            } else if let Ok(child_of) = q_parents.get(radio) {
+                                if child_of.get() == value_change.source {
+                                    // Only uncheck other radio buttons in the same group
+                                    commands.entity(radio).remove::<Checked>();
+                                }
+                            }
+                        }
+                    }
+                )
+                Children [
+                    (radio(RadioProps {
+                        caption: Box::new(bsn_list!(
+                            (Text("One") ThemedText),
+                        )),
+                    }) Checked),
+                    (radio(RadioProps {
+                        caption: Box::new(bsn_list!(
+                            (Text("Two") ThemedText),
+                        )),
+                    })),
+                    (radio(RadioProps {
+                        caption: Box::new(bsn_list!(
+                            (Text("Fast Click") ThemedText),
+                        )),
+                    }) ActivateOnPress),
+                    (radio(RadioProps {
+                        caption: Box::new(bsn_list!(
+                            (Text("Disabled") ThemedText),
+                        )),
+                    }) InteractionDisabled),
+                ]
+            ),
+            (
+                Node {
+                    display: Display::Flex,
+                    flex_direction: FlexDirection::Column,
+                    row_gap: px(4),
+                }
+                RadioGroup
+                on(
+                    |value_change: On<ValueChange<Entity>>,
+                        q_radio: Query<Entity, With<RadioButton>>,
+                        q_parents: Query<&ChildOf>,
+                        mut commands: Commands| {
+                        for radio in q_radio.iter() {
+                            if radio == value_change.value {
+                                commands.entity(radio).insert(Checked);
+                            } else if let Ok(child_of) = q_parents.get(radio) {
+                                if child_of.get() == value_change.source {
+                                    // Only uncheck other radio buttons in the same group
+                                    commands.entity(radio).remove::<Checked>();
+                                }
                             }
                         }
                     }

--- a/examples/ui/widgets/feathers_gallery.rs
+++ b/examples/ui/widgets/feathers_gallery.rs
@@ -29,12 +29,11 @@ use bevy::{
     text::{EditableText, TextEdit, TextEditChange},
     ui::{Checked, InteractionDisabled},
     ui_widgets::{
-        checkbox_self_update, slider_self_update, Activate, ActivateOnPress, RadioButton,
-        RadioGroup, SliderPrecision, SliderStep, SliderValue, ValueChange,
+        checkbox_self_update, radio_self_update, slider_self_update, Activate, ActivateOnPress,
+        RadioButton, RadioGroup, SliderPrecision, SliderStep, SliderValue, ValueChange,
     },
     window::SystemCursorIcon,
 };
-use bevy_ecs::relationship::Relationship;
 
 /// A struct to hold the state of various widgets shown in the demo.
 #[derive(Resource)]
@@ -357,23 +356,7 @@ fn demo_column_1() -> impl Scene {
                     row_gap: px(4),
                 }
                 RadioGroup
-                on(
-                    |value_change: On<ValueChange<Entity>>,
-                        q_radio: Query<Entity, With<RadioButton>>,
-                        q_parents: Query<&ChildOf>,
-                        mut commands: Commands| {
-                        for radio in q_radio.iter() {
-                            if radio == value_change.value {
-                                commands.entity(radio).insert(Checked);
-                            } else if let Ok(child_of) = q_parents.get(radio) {
-                                if child_of.get() == value_change.source {
-                                    // Only uncheck other radio buttons in the same group
-                                    commands.entity(radio).remove::<Checked>();
-                                }
-                            }
-                        }
-                    }
-                )
+                on(radio_self_update)
                 Children [
                     (radio(RadioProps {
                         caption: Box::new(bsn_list!(
@@ -404,23 +387,7 @@ fn demo_column_1() -> impl Scene {
                     row_gap: px(4),
                 }
                 RadioGroup
-                on(
-                    |value_change: On<ValueChange<Entity>>,
-                        q_radio: Query<Entity, With<RadioButton>>,
-                        q_parents: Query<&ChildOf>,
-                        mut commands: Commands| {
-                        for radio in q_radio.iter() {
-                            if radio == value_change.value {
-                                commands.entity(radio).insert(Checked);
-                            } else if let Ok(child_of) = q_parents.get(radio) {
-                                if child_of.get() == value_change.source {
-                                    // Only uncheck other radio buttons in the same group
-                                    commands.entity(radio).remove::<Checked>();
-                                }
-                            }
-                        }
-                    }
-                )
+                on(radio_self_update)
                 Children [
                     (radio(RadioProps {
                         caption: Box::new(bsn_list!(

--- a/examples/ui/widgets/feathers_gallery.rs
+++ b/examples/ui/widgets/feathers_gallery.rs
@@ -29,7 +29,7 @@ use bevy::{
     text::{EditableText, TextEdit, TextEditChange},
     ui::{Checked, InteractionDisabled},
     ui_widgets::{
-        checkbox_self_update, radio_self_update, slider_self_update, Activate, ActivateOnPress,
+        checkbox_self_update, radio_self_update2, slider_self_update, Activate, ActivateOnPress,
         RadioButton, RadioGroup, SliderPrecision, SliderStep, SliderValue, ValueChange,
     },
     window::SystemCursorIcon,
@@ -356,7 +356,7 @@ fn demo_column_1() -> impl Scene {
                     row_gap: px(4),
                 }
                 RadioGroup
-                on(radio_self_update)
+                on(radio_self_update2)
                 Children [
                     (radio(RadioProps {
                         caption: Box::new(bsn_list!(
@@ -387,7 +387,7 @@ fn demo_column_1() -> impl Scene {
                     row_gap: px(4),
                 }
                 RadioGroup
-                on(radio_self_update)
+                on(radio_self_update2)
                 Children [
                     (radio(RadioProps {
                         caption: Box::new(bsn_list!(


### PR DESCRIPTION
# Objective

No helper nor example code exists for handling multiple radio button groups. Currently if a user tries to use existing feathers_gallery code to create multiple radio groups, radio buttons from all other groups will become unchecked.

## Solution

- Within queries, only update the radio buttons inside their own group
- Add `radio_self_update()` convenience function to encapsulate this desired behavior

## Testing

Manually tested inside feathers_gallery example