### PR TITLE
Fix morph target motion blur

### DIFF
--- a/crates/bevy_pbr/src/prepass/prepass.wgsl
+++ b/crates/bevy_pbr/src/prepass/prepass.wgsl
@@ -140,7 +140,7 @@ fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
 #ifdef MORPH_TARGETS
 
 #ifdef HAS_PREVIOUS_MORPH
-    let prev_vertex = morph_prev_vertex(vertex_no_morph);
+    let prev_vertex = morph_prev_vertex(vertex_no_morph, vertex_no_morph.instance_index);
 #else   // HAS_PREVIOUS_MORPH
     let prev_vertex = vertex_no_morph;
 #endif  // HAS_PREVIOUS_MORPH


### PR DESCRIPTION
I didn't update a call to `morph_prev_vertex` in commit https://github.com/bevyengine/bevy/pull/23023/changes/dbb003c4fc688f863d7428dba207ee1b240b1ed0 (part of #23023), so the prepass shader fails to compile if motion blur is enabled.

## Testing

```sh
cargo run --example many_morph_targets -- --count 4 --motion-blur
cargo run --example many_morph_targets -- --count 4
```