### PR TITLE
Allow `bsn!` scene inheritance to use paths with generics

### DIFF
--- a/crates/bevy_scene/macros/src/bsn/parse.rs
+++ b/crates/bevy_scene/macros/src/bsn/parse.rs
@@ -224,7 +224,7 @@ impl BsnInheritedScene {
             let path = input.parse::<LitStr>()?;
             BsnInheritedScene::Asset(path)
         } else {
-            let function = input.parse::<Ident>()?;
+            let function = input.parse::<Path>()?;
             let args = if input.peek(Paren) {
                 let content;
                 parenthesized!(content in input);

--- a/crates/bevy_scene/macros/src/bsn/types.rs
+++ b/crates/bevy_scene/macros/src/bsn/types.rs
@@ -55,7 +55,7 @@ pub enum BsnSceneListItem {
 pub enum BsnInheritedScene {
     Asset(LitStr),
     Fn {
-        function: Ident,
+        function: Path,
         args: Option<Punctuated<Expr, Token![,]>>,
     },
 }

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -1423,4 +1423,36 @@ mod tests {
 
         panic!("Ran out of loops to return `Some` from `predicate`");
     }
+
+    #[test]
+    fn inheritance_with_generics() {
+        #[derive(Component, FromTemplate, PartialEq, Eq, Debug)]
+        struct Foo<T: FromTemplate<Template: Default + Template<Output = T>>> {
+            value: T,
+            number: u32,
+        }
+
+        fn b() -> impl Scene {
+            bsn! {
+                :a::<0, i32>
+                Children [ #Y ]
+            }
+        }
+
+        fn a<
+            const A: u32,
+            T: 'static
+                + Send
+                + Sync
+                + FromTemplate<Template: Send + Sync + Default + Template<Output = T>>,
+        >() -> impl Scene {
+            bsn! {
+                Foo<T>{
+                    number: A
+                }
+            }
+        }
+
+        b();
+    }
 }


### PR DESCRIPTION
# Objective
support generics in `bsn!` scene inheritance syntax (i.e. `:some_scene::<T>`)

## Solution
Parse `Path` instead of an `Ident` for scene inheritance

## Testing

added `inheritance_with_generics` test to `bevy_scene/src/lib.rs`