### PR TITLE
Add `are_dependencies_loaded` and `are_direct_dependencies_loaded` to `AssetServer`.

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -3174,4 +3174,47 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn resource_are_dependencies_loaded() {
+        let (mut app, dir) = create_app();
+        dir.insert_asset_text(Path::new("abc.txt"), "");
+        dir.insert_asset_text(Path::new("def.txt"), "");
+        dir.insert_asset_text(Path::new("ghi.txt"), "");
+
+        app.init_asset::<TestAsset>()
+            .register_asset_loader(TrivialLoader);
+
+        let asset_server = app.world().resource::<AssetServer>().clone();
+
+        #[derive(Resource, VisitAssetDependencies)]
+        struct MyAssetHolder {
+            #[dependency]
+            abc: Handle<TestAsset>,
+            #[dependency]
+            def: Handle<TestAsset>,
+            #[dependency]
+            ghi: Handle<TestAsset>,
+        }
+
+        app.insert_resource(MyAssetHolder {
+            abc: asset_server.load("abc.txt"),
+            def: asset_server.load("def.txt"),
+            ghi: asset_server.load("ghi.txt"),
+        });
+
+        assert!(!asset_server.are_dependencies_loaded(app.world().resource::<MyAssetHolder>()));
+        assert!(
+            !asset_server.are_direct_dependencies_loaded(app.world().resource::<MyAssetHolder>())
+        );
+
+        run_app_until(&mut app, |world| {
+            asset_server
+                .are_dependencies_loaded(world.resource::<MyAssetHolder>())
+                .then_some(())
+        });
+        assert!(
+            asset_server.are_direct_dependencies_loaded(app.world().resource::<MyAssetHolder>())
+        );
+    }
 }

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -17,7 +17,7 @@ use crate::{
     Asset, AssetEvent, AssetHandleProvider, AssetId, AssetIndex, AssetLoadFailedEvent,
     AssetMetaCheck, Assets, DeserializeMetaError, ErasedAssetIndex, ErasedLoadedAsset, Handle,
     LoadedUntypedAsset, UnapprovedPathMode, UntypedAssetId, UntypedAssetLoadFailedEvent,
-    UntypedHandle,
+    UntypedHandle, VisitAssetDependencies,
 };
 use alloc::{borrow::ToOwned, boxed::Box, vec, vec::Vec};
 use alloc::{
@@ -1356,6 +1356,56 @@ impl AssetServer {
                 RecursiveDependencyLoadState::Loaded
             ))
         )
+    }
+
+    /// Returns true if all of `value`s dependencies (included recursive dependencies) are loaded.
+    ///
+    /// This allows querying for whether all the handles in a resource or component are loaded.
+    pub fn are_dependencies_loaded(&self, value: &impl VisitAssetDependencies) -> bool {
+        let infos = self.read_infos();
+        let mut loaded = true;
+        value.visit_dependencies(&mut |asset_id| {
+            let index = match asset_id {
+                // Ignore UUID assets - this effectively makes them considered loaded.
+                UntypedAssetId::Uuid { .. } => return,
+                UntypedAssetId::Index { type_id, index } => ErasedAssetIndex::new(index, type_id),
+            };
+            let Some(info) = infos.get(index) else {
+                // If the asset ID is no longer valid, we consider that as not loaded.
+                loaded = false;
+                return;
+            };
+
+            if !info.rec_dep_load_state.is_loaded() {
+                loaded = false;
+            }
+        });
+        loaded
+    }
+
+    /// Returns true if all of `value`s dependencies (excluding recursive dependencies) are loaded.
+    ///
+    /// This allows querying for whether all the handles in a resource or component are loaded.
+    pub fn are_direct_dependencies_loaded(&self, value: &impl VisitAssetDependencies) -> bool {
+        let infos = self.read_infos();
+        let mut loaded = true;
+        value.visit_dependencies(&mut |asset_id| {
+            let index = match asset_id {
+                // Ignore UUID assets - this effectively makes them considered loaded.
+                UntypedAssetId::Uuid { .. } => return,
+                UntypedAssetId::Index { type_id, index } => ErasedAssetIndex::new(index, type_id),
+            };
+            let Some(info) = infos.get(index) else {
+                // If the asset ID is no longer valid, we consider that as not loaded.
+                loaded = false;
+                return;
+            };
+
+            if !info.dep_load_state.is_loaded() {
+                loaded = false;
+            }
+        });
+        loaded
     }
 
     /// Returns an active handle for the given path, if the asset at the given path has already started loading,


### PR DESCRIPTION
# Objective

- It's currently very painful to deal with resources holding handles. You can't just poll if its assets are loaded.

## Solution

- Add a simple function to just poll every dependency of a `VisitAssetDependencies`.
- Since we can now derive `VisitAssetDependencies` on stuff, we can now just pass a resource to these functions and find out if they are loaded.

## Testing

- Added a basic test.