### PR TITLE
`ambiguity_detection` requires `debug` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4287,6 +4287,7 @@ wasm = false
 name = "ambiguity_detection"
 path = "tests/ecs/ambiguity_detection.rs"
 doc-scrape-examples = true
+required-features = ["debug"]
 
 [package.metadata.example.ambiguity_detection]
 hidden = true


### PR DESCRIPTION
# Objective

- Work done for the issue [`ambiguity_detection` example should require `debug` feature](https://github.com/bevyengine/bevy/issues/23907)