### PR TITLE
Upgrade Parley to v0.9.0

### DIFF
--- a/crates/bevy_text/Cargo.toml
+++ b/crates/bevy_text/Cargo.toml
@@ -39,7 +39,7 @@ smallvec = { version = "1", default-features = false }
 smol_str = { version = "0.2", default-features = false }
 sys-locale = "0.3.0"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
-parley = { version = "0.8.0", default-features = false, features = ["std"] }
+parley = { version = "0.9.0", default-features = false, features = ["std"] }
 swash = { version = "0.2.6" }
 
 [lints]

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -388,10 +388,12 @@ impl TextPipeline {
                     layout_info.run_geometry.push(RunGeometry {
                         section_index,
                         bounds: Rect::new(
-                            glyph_run.offset(),
-                            line.metrics().min_coord,
-                            glyph_run.offset() + glyph_run.advance(),
-                            line.metrics().max_coord,
+                            line.metrics().inline_min_coord + glyph_run.offset(),
+                            line.metrics().block_min_coord,
+                            line.metrics().inline_min_coord
+                                + glyph_run.offset()
+                                + glyph_run.advance(),
+                            line.metrics().block_max_coord,
                         ),
                         strikethrough_y: glyph_run.baseline() - run.metrics().strikethrough_offset,
                         strikethrough_thickness: run.metrics().strikethrough_size,
@@ -561,21 +563,14 @@ impl TextMeasureInfo {
         // whenever a canonical state is required.
         let layout = &mut computed.layout;
         layout.break_all_lines(bounds.width);
-        layout.align(bounds.width, Alignment::Start, AlignmentOptions::default());
+        layout.align(Alignment::Start, AlignmentOptions::default());
         buffer_dimensions(layout)
     }
 }
 
 fn layout_with_bounds(layout: &mut Layout<TextBrush>, bounds: TextBounds, justify: Justify) {
     layout.break_all_lines(bounds.width);
-
-    let container_width = if bounds.width.is_none() && justify != Justify::Left {
-        Some(layout.width())
-    } else {
-        bounds.width
-    };
-
-    layout.align(container_width, justify.into(), AlignmentOptions::default());
+    layout.align(justify.into(), AlignmentOptions::default());
 }
 
 /// Calculate the size of the text area for the given buffer.

--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -51,7 +51,7 @@ thiserror = { version = "2", default-features = false }
 derive_more = { version = "2", default-features = false, features = ["from"] }
 smallvec = { version = "1", default-features = false }
 accesskit = "0.24"
-parley = { version = "0.8.0", default-features = false, features = ["std"] }
+parley = { version = "0.9.0", default-features = false, features = ["std"] }
 swash = { version = "0.2.6" }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 

--- a/crates/bevy_ui/src/widget/text_editable.rs
+++ b/crates/bevy_ui/src/widget/text_editable.rs
@@ -413,10 +413,15 @@ pub fn update_editable_text_layout(
                             info.run_geometry.push(RunGeometry {
                                 section_index: brush.section_index as usize,
                                 bounds: Rect {
-                                    min: Vec2::new(glyph_run.offset(), line.metrics().min_coord),
+                                    min: Vec2::new(
+                                        line.metrics().inline_min_coord + glyph_run.offset(),
+                                        line.metrics().block_min_coord,
+                                    ),
                                     max: Vec2::new(
-                                        glyph_run.offset() + glyph_run.advance(),
-                                        line.metrics().max_coord,
+                                        line.metrics().inline_min_coord
+                                            + glyph_run.offset()
+                                            + glyph_run.advance(),
+                                        line.metrics().block_max_coord,
                                     ),
                                 },
                                 strikethrough_y: glyph_run.baseline()

--- a/crates/bevy_ui_widgets/Cargo.toml
+++ b/crates/bevy_ui_widgets/Cargo.toml
@@ -26,7 +26,7 @@ bevy_window = { path = "../bevy_window", version = "0.19.0-dev" }
 
 # other
 accesskit = "0.24"
-parley = { version = "0.8.0", default-features = false }
+parley = { version = "0.9.0", default-features = false }
 smol_str = "0.2"
 
 [features]


### PR DESCRIPTION
This is a pretty small Parley release, but it does include one bug fix for Bevy (+ some dep bumps)

Release notes: https://github.com/linebender/parley/releases/tag/v0.9.0