### PR TITLE
Upgrade `ron` version from `0.8` to `0.12` in `bevy_transform`

### DIFF
--- a/crates/bevy_transform/Cargo.toml
+++ b/crates/bevy_transform/Cargo.toml
@@ -29,7 +29,7 @@ bevy_math = { path = "../bevy_math", version = "0.19.0-dev", default-features = 
   "approx",
 ] }
 approx = "0.5.1"
-ron = "0.8"
+ron = "0.12"
 
 [features]
 # Turning off default features leaves you with a barebones


### PR DESCRIPTION
# Objective

All other crates in the Bevy workspace already depend on `ron = "0.12"`, but `bevy_transform` was still pinned to the outdated `ron = "0.8"`. This brings it in line with the rest of the workspace and avoids pulling in two different versions of `ron`.

## Solution

- Updated `crates/bevy_transform/Cargo.toml` to use `ron = "0.12"`.

All crates that depend on `ron` in this workspace now use the same version:
| Crate | Version |
|---|---|
| `bevy_animation` | `0.12` |
| `bevy_asset` | `0.12` |
| `bevy_dev_tools` | `0.12` |
| `bevy_reflect` | `0.12` |
| `bevy_transform` | `0.12` ← this PR |
| `bevy_world_serialization` | `0.12` |

## Testing

- `cargo check` passes with the updated dependency.
- No behavioral changes — this is a pure dependency version bump.
- Reviewers can verify by running `cargo test -p bevy_transform`.

---

