### PR TITLE
Align `bevy_transform`'s feature flags

### DIFF
--- a/_release-content/migration-guides/align_transform_feature_flags.md
+++ b/_release-content/migration-guides/align_transform_feature_flags.md
@@ -10,10 +10,10 @@ Tracing instrumentation is now gated on the new `trace` feature (using `tracing`
 directly, matching `bevy_ecs`):
 
 ```toml
-# 0.15
+# 0.18
 bevy_transform = { features = ["bevy_log"] }
 
-# 0.16
+# 0.19
 bevy_transform = { features = ["trace"] }
 ```
 
@@ -21,9 +21,9 @@ Parallel transform propagation is no longer tied to the `std` feature. It now
 requires the explicit `multi_threaded` feature:
 
 ```toml
-# 0.15 — parallel was enabled implicitly via std
+# 0.18 — parallel was enabled implicitly via std
 bevy_transform = { features = ["std"] }
 
-# 0.16 — opt in explicitly
+# 0.19 — opt in explicitly
 bevy_transform = { features = ["std", "multi_threaded"] }
 ```

--- a/_release-content/migration-guides/align_transform_feature_flags.md
+++ b/_release-content/migration-guides/align_transform_feature_flags.md
@@ -1,0 +1,29 @@
+---
+title: Align bevy_transform's feature flags
+pull_requests: [23919]
+---
+
+`bevy_transform` no longer depends on `bevy_log`. The `bevy_log` feature flag
+has been removed.
+
+Tracing instrumentation is now gated on the new `trace` feature (using `tracing`
+directly, matching `bevy_ecs`):
+
+```toml
+# 0.15
+bevy_transform = { features = ["bevy_log"] }
+
+# 0.16
+bevy_transform = { features = ["trace"] }
+```
+
+Parallel transform propagation is no longer tied to the `std` feature. It now
+requires the explicit `multi_threaded` feature:
+
+```toml
+# 0.15 — parallel was enabled implicitly via std
+bevy_transform = { features = ["std"] }
+
+# 0.16 — opt in explicitly
+bevy_transform = { features = ["std", "multi_threaded"] }
+```

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -138,7 +138,7 @@ multi_threaded = [
   "bevy_ecs/multi_threaded",
   "bevy_render?/multi_threaded",
   "bevy_tasks/multi_threaded",
-  "bevy_transform/multi_threaded"
+  "bevy_transform/multi_threaded",
 ]
 async-io = ["std", "bevy_tasks/async-io"]
 

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -138,6 +138,7 @@ multi_threaded = [
   "bevy_ecs/multi_threaded",
   "bevy_render?/multi_threaded",
   "bevy_tasks/multi_threaded",
+  "bevy_transform/multi_threaded"
 ]
 async-io = ["std", "bevy_tasks/async-io"]
 

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -21,7 +21,7 @@ keywords = ["bevy"]
 # wgpu-types = { git = "https://github.com/gfx-rs/wgpu", rev = "..." }
 decoupled_naga = ["bevy_shader/decoupled_naga"]
 
-multi_threaded = ["bevy_tasks/multi_threaded"]
+multi_threaded = ["bevy_tasks/multi_threaded", "bevy_transform/multi_threaded"]
 
 morph = ["bevy_mesh/morph"]
 

--- a/crates/bevy_transform/Cargo.toml
+++ b/crates/bevy_transform/Cargo.toml
@@ -12,7 +12,6 @@ keywords = ["bevy"]
 # bevy
 bevy_app = { path = "../bevy_app", version = "0.19.0-dev", default-features = false, optional = true }
 bevy_ecs = { path = "../bevy_ecs", version = "0.19.0-dev", default-features = false, optional = true }
-bevy_log = { path = "../bevy_log", version = "0.19.0-dev", default-features = false, optional = true }
 bevy_math = { path = "../bevy_math", version = "0.19.0-dev", default-features = false }
 bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev", default-features = false, optional = true }
 bevy_tasks = { path = "../bevy_tasks", version = "0.19.0-dev", default-features = false }
@@ -21,6 +20,7 @@ serde = { version = "1", default-features = false, features = [
   "derive",
 ], optional = true }
 thiserror = { version = "2", default-features = false }
+tracing = { version = "0.1", default-features = false, optional = true }
 derive_more = { version = "2", default-features = false, features = ["from"] }
 
 [dev-dependencies]
@@ -37,6 +37,10 @@ ron = "0.8"
 default = ["std", "bevy-support", "bevy_reflect", "async_executor"]
 
 # Functionality
+
+## Enables multithreading support. Schedules will attempt to run systems on
+## multiple threads whenever possible.
+multi_threaded = ["bevy_tasks/multi_threaded"]
 
 ## Adds normal Bevy impls like deriving components, bundles, reflection, as well as adding
 ## systems for transform propagation and more.
@@ -56,6 +60,12 @@ bevy_reflect = [
   "bevy_app/bevy_reflect",
 ]
 
+# Debugging Features
+
+## Enables `tracing` integration, allowing spans and other metrics to be reported
+## through that framework.
+trace = ["std", "dep:tracing"]
+
 # Executor Backend
 
 ## Uses `async-executor` as a task execution backend.
@@ -70,7 +80,6 @@ async_executor = ["std", "bevy_tasks/async_executor"]
 std = [
   "alloc",
   "bevy_app?/std",
-  "bevy_log",
   "bevy_ecs?/std",
   "bevy_math/std",
   "bevy_reflect?/std",

--- a/crates/bevy_transform/src/systems.rs
+++ b/crates/bevy_transform/src/systems.rs
@@ -278,7 +278,7 @@ pub fn mark_dirty_trees(
                 );
             };
             #[cfg(feature = "trace")]
-            info_span!("producer_mark_dirty").in_scope(producer);
+            info_span!("producer_mark_dirty").in_scope(&mut producer);
             #[cfg(not(feature = "trace"))]
             producer();
         });

--- a/crates/bevy_transform/src/systems.rs
+++ b/crates/bevy_transform/src/systems.rs
@@ -30,9 +30,9 @@ pub fn propagate_transforms_for<F: QueryFilter + 'static>(
     }
 }
 
-#[cfg(all(not(target_arch = "wasm32"), feature = "multi_threaded"))]
+#[cfg(feature = "multi_threaded")]
 pub use parallel::propagate_parent_transforms;
-#[cfg(any(target_arch = "wasm32", not(feature = "multi_threaded")))]
+#[cfg(not(feature = "multi_threaded"))]
 pub use serial::propagate_parent_transforms;
 
 /// Update [`GlobalTransform`] component of entities that aren't in the hierarchy
@@ -54,14 +54,14 @@ pub fn sync_simple_transforms(
     mut orphaned: RemovedComponents<ChildOf>,
 ) {
     // Update changed entities.
-    #[cfg(all(not(target_arch = "wasm32"), feature = "multi_threaded"))]
+    #[cfg(feature = "multi_threaded")]
     query
         .p0()
         .par_iter_mut()
         .for_each(|(transform, mut global_transform)| {
             *global_transform = GlobalTransform::from(*transform);
         });
-    #[cfg(any(target_arch = "wasm32", not(feature = "multi_threaded")))]
+    #[cfg(not(feature = "multi_threaded"))]
     query
         .p0()
         .iter_mut()
@@ -115,23 +115,25 @@ pub fn mark_dirty_trees(
     parents: Query<&ChildOf>,
     static_optimizations: Res<StaticTransformOptimizations>,
     // Cached allocations for multi-threaded parallel implementation
-    #[cfg(all(not(target_arch = "wasm32"), feature = "multi_threaded"))] mut shared_bitset: Local<
+    #[cfg(feature = "multi_threaded")] mut shared_bitset: Local<
         alloc::vec::Vec<core::sync::atomic::AtomicU64>,
     >,
-    #[cfg(all(not(target_arch = "wasm32"), feature = "multi_threaded"))] mut local_bitset: Local<
+    #[cfg(feature = "multi_threaded")] mut local_bitset: Local<
         bevy_utils::Parallel<alloc::vec::Vec<u64>>,
     >,
-    #[cfg(all(not(target_arch = "wasm32"), feature = "multi_threaded"))]
-    mut consumer_channels: Local<bevy_utils::BufferedChannel<Entity>>,
-    #[cfg(all(not(target_arch = "wasm32"), feature = "multi_threaded"))]
-    mut traversal_channels: Local<bevy_utils::BufferedChannel<Entity>>,
+    #[cfg(feature = "multi_threaded")] mut consumer_channels: Local<
+        bevy_utils::BufferedChannel<Entity>,
+    >,
+    #[cfg(feature = "multi_threaded")] mut traversal_channels: Local<
+        bevy_utils::BufferedChannel<Entity>,
+    >,
 ) {
     if !static_optimizations.is_enabled() {
         return;
     }
 
     // Simple serial implementation that iterates changed entities and traverses the tree.
-    #[cfg(any(target_arch = "wasm32", not(feature = "multi_threaded")))]
+    #[cfg(not(feature = "multi_threaded"))]
     for entity in changed.iter().chain(orphaned.read()) {
         let mut next = entity;
         while let Ok(mut tree) = transforms.get_mut(next) {
@@ -160,7 +162,7 @@ pub fn mark_dirty_trees(
     // of the scope and asynchronously await incoming batches of work. This allows the entire
     // pipeline to start working as soon as there is available work to process, instead of running
     // each stage serially with inner parallelism.
-    #[cfg(all(not(target_arch = "wasm32"), feature = "multi_threaded"))]
+    #[cfg(feature = "multi_threaded")]
     {
         use bevy_tasks::ComputeTaskPool;
         use core::sync::atomic::Ordering;
@@ -318,7 +320,7 @@ pub fn mark_dirty_trees(
 // module, and make the multithreaded module no_std compatible.
 //
 /// Serial hierarchy traversal. Useful in `no_std` or single threaded contexts.
-#[cfg(any(target_arch = "wasm32", not(feature = "multi_threaded")))]
+#[cfg(not(feature = "multi_threaded"))]
 mod serial {
     use crate::prelude::*;
     use alloc::vec::Vec;
@@ -480,7 +482,7 @@ mod serial {
 //
 /// Parallel hierarchy traversal with a batched work sharing scheduler. Often 2-5 times faster than
 /// the serial version.
-#[cfg(all(not(target_arch = "wasm32"), feature = "multi_threaded"))]
+#[cfg(feature = "multi_threaded")]
 mod parallel {
     use crate::prelude::*;
     // TODO: this implementation could be used in no_std if there are equivalents of these.

--- a/crates/bevy_transform/src/systems.rs
+++ b/crates/bevy_transform/src/systems.rs
@@ -4,8 +4,6 @@ use crate::{
 };
 
 use bevy_ecs::{prelude::*, query::QueryFilter};
-#[cfg(feature = "bevy_log")]
-use bevy_log::warn_once;
 
 /// Generic system that propagates transforms,
 /// using [`TransformHelper`] for any entity matching the filter `F`.
@@ -18,12 +16,12 @@ pub fn propagate_transforms_for<F: QueryFilter + 'static>(
         let result = tf_helper
             .compute_global_transform(entity)
             .inspect_err(|_err| {
-                #[cfg(feature = "bevy_log")]
-                warn_once!(
+                #[cfg(feature = "trace")]
+                bevy_utils::once!(tracing::warn!(
                     "Failed to compute GlobalTransform for entity {:?}: {:?}",
                     entity,
                     _err
-                );
+                ));
             });
 
         if let Ok(computed) = result {
@@ -32,9 +30,9 @@ pub fn propagate_transforms_for<F: QueryFilter + 'static>(
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(all(not(target_arch = "wasm32"), feature = "multi_threaded"))]
 pub use parallel::propagate_parent_transforms;
-#[cfg(not(feature = "std"))]
+#[cfg(any(target_arch = "wasm32", not(feature = "multi_threaded")))]
 pub use serial::propagate_parent_transforms;
 
 /// Update [`GlobalTransform`] component of entities that aren't in the hierarchy
@@ -56,9 +54,17 @@ pub fn sync_simple_transforms(
     mut orphaned: RemovedComponents<ChildOf>,
 ) {
     // Update changed entities.
+    #[cfg(all(not(target_arch = "wasm32"), feature = "multi_threaded"))]
     query
         .p0()
         .par_iter_mut()
+        .for_each(|(transform, mut global_transform)| {
+            *global_transform = GlobalTransform::from(*transform);
+        });
+    #[cfg(any(target_arch = "wasm32", not(feature = "multi_threaded")))]
+    query
+        .p0()
+        .iter_mut()
         .for_each(|(transform, mut global_transform)| {
             *global_transform = GlobalTransform::from(*transform);
         });
@@ -108,20 +114,24 @@ pub fn mark_dirty_trees(
     mut transforms: Query<&mut TransformTreeChanged>,
     parents: Query<&ChildOf>,
     static_optimizations: Res<StaticTransformOptimizations>,
-    // Cached allocations for std-only parallel implementation
-    #[cfg(feature = "std")] mut shared_bitset: Local<
+    // Cached allocations for multi-threaded parallel implementation
+    #[cfg(all(not(target_arch = "wasm32"), feature = "multi_threaded"))] mut shared_bitset: Local<
         alloc::vec::Vec<core::sync::atomic::AtomicU64>,
     >,
-    #[cfg(feature = "std")] mut local_bitset: Local<bevy_utils::Parallel<alloc::vec::Vec<u64>>>,
-    #[cfg(feature = "std")] mut consumer_channels: Local<bevy_utils::BufferedChannel<Entity>>,
-    #[cfg(feature = "std")] mut traversal_channels: Local<bevy_utils::BufferedChannel<Entity>>,
+    #[cfg(all(not(target_arch = "wasm32"), feature = "multi_threaded"))] mut local_bitset: Local<
+        bevy_utils::Parallel<alloc::vec::Vec<u64>>,
+    >,
+    #[cfg(all(not(target_arch = "wasm32"), feature = "multi_threaded"))]
+    mut consumer_channels: Local<bevy_utils::BufferedChannel<Entity>>,
+    #[cfg(all(not(target_arch = "wasm32"), feature = "multi_threaded"))]
+    mut traversal_channels: Local<bevy_utils::BufferedChannel<Entity>>,
 ) {
     if !static_optimizations.is_enabled() {
         return;
     }
 
     // Simple serial implementation that iterates changed entities and traverses the tree.
-    #[cfg(not(feature = "std"))]
+    #[cfg(any(target_arch = "wasm32", not(feature = "multi_threaded")))]
     for entity in changed.iter().chain(orphaned.read()) {
         let mut next = entity;
         while let Ok(mut tree) = transforms.get_mut(next) {
@@ -150,12 +160,12 @@ pub fn mark_dirty_trees(
     // of the scope and asynchronously await incoming batches of work. This allows the entire
     // pipeline to start working as soon as there is available work to process, instead of running
     // each stage serially with inner parallelism.
-    #[cfg(feature = "std")]
+    #[cfg(all(not(target_arch = "wasm32"), feature = "multi_threaded"))]
     {
-        use bevy_log::info_span;
-        use bevy_log::tracing::Instrument;
         use bevy_tasks::ComputeTaskPool;
         use core::sync::atomic::Ordering;
+        #[cfg(feature = "trace")]
+        use tracing::{info_span, Instrument};
 
         ComputeTaskPool::get().scope(|scope| {
             traversal_channels.chunk_size = 1024;
@@ -167,8 +177,8 @@ pub fn mark_dirty_trees(
             let parents_ref = &parents;
 
             // Consumer: drain the channel of moved entities and call set_changed() on the marker.
-            scope.spawn(
-                async move {
+            scope.spawn({
+                let fut = async move {
                     while let Ok(mut chunk) = consumer_rx.recv().await {
                         for entity in chunk.drain() {
                             if let Ok(mut tree) = transforms.get_mut(entity) {
@@ -176,17 +186,19 @@ pub fn mark_dirty_trees(
                             }
                         }
                     }
-                }
-                .instrument(info_span!("consumer_mark_dirty")),
-            );
+                };
+                #[cfg(feature = "trace")]
+                let fut = fut.instrument(info_span!("consumer_mark_dirty"));
+                fut
+            });
 
             // Traversal: each task loops until the producer channel is exhausted, walking each
             // entity's ancestor chain and forwarding newly marked entities to the consumer task.
             for _ in 0..(ComputeTaskPool::get().thread_num() - 1).max(1) {
                 let traversal_rx = traversal_rx.clone();
                 let mut consumer_tx = consumer_tx.clone();
-                scope.spawn(
-                    async move {
+                scope.spawn({
+                    let fut = async move {
                         while let Ok(mut chunk) = traversal_rx.recv().await {
                             for mut entity in chunk.drain() {
                                 let mut first_iteration = true;
@@ -237,9 +249,11 @@ pub fn mark_dirty_trees(
                                 }
                             }
                         }
-                    }
-                    .instrument(info_span!("par_traversal_mark_dirty")),
-                );
+                    };
+                    #[cfg(feature = "trace")]
+                    let fut = fut.instrument(info_span!("par_traversal_mark_dirty"));
+                    fut
+                });
             }
 
             // Producer: Feed changed entities and orphans into producer tasks. The senders are
@@ -249,7 +263,7 @@ pub fn mark_dirty_trees(
             // Note that we send the entity directly to the consumer as well, we do this to start
             // feeding it work as soon as possible. The traversal worker should skip sending these
             // leaves to the consumer because it has already been sent here.
-            info_span!("producer_mark_dirty").in_scope(move || {
+            let mut producer = move || {
                 for entity in orphaned.read() {
                     let _ = traversal_tx.send_blocking(entity);
                     let _ = consumer_tx.send_blocking(entity);
@@ -262,7 +276,11 @@ pub fn mark_dirty_trees(
                         let _ = consumer_tx.send_blocking(entity);
                     },
                 );
-            });
+            };
+            #[cfg(feature = "trace")]
+            info_span!("producer_mark_dirty").in_scope(producer);
+            #[cfg(not(feature = "trace"))]
+            producer();
         });
 
         // Merge thread-local bitsets into the shared bitset, growing it to accommodate the largest
@@ -300,7 +318,7 @@ pub fn mark_dirty_trees(
 // module, and make the multithreaded module no_std compatible.
 //
 /// Serial hierarchy traversal. Useful in `no_std` or single threaded contexts.
-#[cfg(not(feature = "std"))]
+#[cfg(any(target_arch = "wasm32", not(feature = "multi_threaded")))]
 mod serial {
     use crate::prelude::*;
     use alloc::vec::Vec;
@@ -462,7 +480,7 @@ mod serial {
 //
 /// Parallel hierarchy traversal with a batched work sharing scheduler. Often 2-5 times faster than
 /// the serial version.
-#[cfg(feature = "std")]
+#[cfg(all(not(target_arch = "wasm32"), feature = "multi_threaded"))]
 mod parallel {
     use crate::prelude::*;
     // TODO: this implementation could be used in no_std if there are equivalents of these.
@@ -568,8 +586,8 @@ mod parallel {
         nodes: &NodeQuery,
         static_optimizations: &StaticTransformOptimizations,
     ) {
-        #[cfg(feature = "std")]
-        let _span = bevy_log::info_span!("transform propagation worker").entered();
+        #[cfg(feature = "trace")]
+        let _span = tracing::info_span!("transform propagation worker").entered();
 
         let mut outbox = queue.local_queue.borrow_local_mut();
         loop {


### PR DESCRIPTION
# Objective

`bevy_transform`'s multi-threading behavior was previously gated on `feature = "std"`, which incorrectly conflated standard library availability with multi-threading capability. This means:

- Users who enabled `no_std` but had multi-threading available lost parallelism unintentionally.
- Users who had `std` but wanted single-threaded execution (e.g. WASM) still attempted to use the parallel path.
- `bevy_internal`'s `multi_threaded` feature did not propagate down to `bevy_transform`, so the parallel implementation was not activated when expected.
- The `bevy_log` dependency was pulled in unconditionally via the `std` feature, when the only use was optional trace-level warnings.

## Solution

- Added an explicit `multi_threaded` feature to `bevy_transform`, backed by `bevy_tasks/multi_threaded`, matching the pattern used by `bevy_ecs` and other crates.
- Replaced all `#[cfg(feature = "std")]` / `#[cfg(not(feature = "std"))]` guards on parallel/serial code paths with `#[cfg(all(not(target_arch = "wasm32"), feature = "multi_threaded"))]` / `#[cfg(any(target_arch = "wasm32", not(feature = "multi_threaded")))]` — the same guard pattern already used in `bevy_ecs`.
- Added `bevy_transform/multi_threaded` to `bevy_internal`'s and `bevy_render`'s `multi_threaded` feature lists so parallel transforms are activated end-to-end when building Bevy with `multi_threaded`.
- Removed the `bevy_log` dependency from `bevy_transform`. Its sole usage was a `warn_once!` inside `propagate_transforms_for`. This is replaced with a direct `tracing::warn!` wrapped in `bevy_utils::once!`, gated on a new opt-in `trace` feature (`dep:tracing`). This keeps the default build lighter.
- Inlined the `trace` feature spans in `mark_dirty_trees` that previously depended on `bevy_log`'s re-exported `tracing`, now using `tracing` directly under `#[cfg(feature = "trace")]`.

## Testing

- All existing unit tests in `bevy_transform::systems::test` pass unchanged — no behavioral changes, only cfg guard corrections.
- No performance regressions observed by [Benchmark](https://github.com/bevyengine/bevy/pull/23906).

---
