### PR TITLE
Allowing using ChildOf directly inside bsn! macro

### DIFF
--- a/crates/bevy_ecs/src/hierarchy.rs
+++ b/crates/bevy_ecs/src/hierarchy.rs
@@ -14,6 +14,7 @@ use crate::{
     entity::Entity,
     relationship::{RelatedSpawner, RelatedSpawnerCommands},
     system::EntityCommands,
+    template::FromTemplate,
     world::{EntityWorldMut, FromWorld, World},
 };
 use alloc::vec::Vec;
@@ -90,7 +91,7 @@ use core::slice;
 /// ```
 ///
 /// [`Relationship`]: crate::relationship::Relationship
-#[derive(Component, Clone, PartialEq, Eq, Debug)]
+#[derive(Component, FromTemplate, Clone, PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 #[cfg_attr(
     feature = "bevy_reflect",

--- a/crates/bevy_ecs/src/template.rs
+++ b/crates/bevy_ecs/src/template.rs
@@ -403,6 +403,8 @@ pub trait SpecializeFromTemplate: Sized {}
 
 /// A [`Template`] reference to an [`Entity`].
 pub enum EntityReference {
+    /// A reference to a specific [`Entity`]
+    SpecificEntity(Entity),
     /// A reference to an entity via a [`ScopedEntityIndex`]
     ScopedEntityIndex(ScopedEntityIndex),
 }
@@ -427,12 +429,19 @@ impl Default for EntityReference {
     }
 }
 
+impl From<Entity> for EntityReference {
+    fn from(entity: Entity) -> Self {
+        Self::SpecificEntity(entity)
+    }
+}
+
 impl Template for EntityReference {
     type Output = Entity;
 
     fn build_template(&self, context: &mut TemplateContext) -> Result<Self::Output> {
         Ok(match self {
-            EntityReference::ScopedEntityIndex(scoped_entity_index) => {
+            Self::SpecificEntity(entity) => *entity,
+            Self::ScopedEntityIndex(scoped_entity_index) => {
                 context.get_scoped_entity(*scoped_entity_index)
             }
         })
@@ -440,6 +449,7 @@ impl Template for EntityReference {
 
     fn clone_template(&self) -> Self {
         match self {
+            Self::SpecificEntity(entity) => Self::SpecificEntity(*entity),
             Self::ScopedEntityIndex(scoped_entity_index) => {
                 Self::ScopedEntityIndex(*scoped_entity_index)
             }

--- a/crates/bevy_ecs/src/template.rs
+++ b/crates/bevy_ecs/src/template.rs
@@ -404,7 +404,7 @@ pub trait SpecializeFromTemplate: Sized {}
 /// A [`Template`] reference to an [`Entity`].
 pub enum EntityReference {
     /// A reference to a specific [`Entity`]
-    SpecificEntity(Entity),
+    Entity(Entity),
     /// A reference to an entity via a [`ScopedEntityIndex`]
     ScopedEntityIndex(ScopedEntityIndex),
 }
@@ -431,7 +431,7 @@ impl Default for EntityReference {
 
 impl From<Entity> for EntityReference {
     fn from(entity: Entity) -> Self {
-        Self::SpecificEntity(entity)
+        Self::Entity(entity)
     }
 }
 
@@ -440,7 +440,7 @@ impl Template for EntityReference {
 
     fn build_template(&self, context: &mut TemplateContext) -> Result<Self::Output> {
         Ok(match self {
-            Self::SpecificEntity(entity) => *entity,
+            Self::Entity(entity) => *entity,
             Self::ScopedEntityIndex(scoped_entity_index) => {
                 context.get_scoped_entity(*scoped_entity_index)
             }
@@ -449,7 +449,7 @@ impl Template for EntityReference {
 
     fn clone_template(&self) -> Self {
         match self {
-            Self::SpecificEntity(entity) => Self::SpecificEntity(*entity),
+            Self::Entity(entity) => Self::Entity(*entity),
             Self::ScopedEntityIndex(scoped_entity_index) => {
                 Self::ScopedEntityIndex(*scoped_entity_index)
             }

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -569,6 +569,7 @@ mod tests {
     use bevy_asset::{Asset, AssetApp, AssetLoader, AssetPlugin, AssetServer, Assets, Handle};
     use bevy_ecs::lifecycle::HookContext;
     use bevy_ecs::prelude::*;
+    use bevy_ecs::relationship::Relationship;
     use bevy_ecs::world::DeferredWorld;
     use bevy_reflect::TypePath;
     use std::path::Path;
@@ -1152,6 +1153,34 @@ mod tests {
 
         let sprite = root.get::<Sprite>().unwrap();
         assert_eq!(sprite.0, handle);
+    }
+
+    #[test]
+    fn child_of_template() {
+        let mut app = test_app();
+
+        let world = app.world_mut();
+
+        fn scene(root: Entity) -> impl SceneList {
+            bsn_list! {
+                ( #Child1 ChildOf(root) ),
+                ( #Child2 ChildOf(#Child1) ),
+            }
+        }
+
+        let root = world.spawn_empty().id();
+
+        let ids = world.spawn_scene_list(scene(root)).unwrap();
+        assert_eq!(ids.len(), 2);
+
+        let [a, b] = world.entity(&*ids)[..] else {
+            unreachable!()
+        };
+        assert_eq!(a.get::<Name>().unwrap().as_str(), "Child1");
+        assert_eq!(a.get::<ChildOf>().unwrap().get(), root);
+
+        assert_eq!(b.get::<Name>().unwrap().as_str(), "Child2");
+        assert_eq!(b.get::<ChildOf>().unwrap().get(), a.id());
     }
 
     #[test]


### PR DESCRIPTION
# Objective

If I want to spawn a scene as a child of an entity that already exists, the current api doesn't offer an straightfoward solution.

The easies I found is by doing something like this:

```rust
const my_entity = ...;
commands.spawn_scene(bsn! {
    template(move |_| Ok(ChildOf(my_entity)))
    scenes::list_item(text)
});

```

## Solution

- Deriving directly `FromTemplate` for `ChildOf`.
- Adding a new variant to `EntityReference`.
- This allows code like this to work directly
```rust
fn scene(root: Entity) -> impl Scene {
    bsn! {
        ( #Child1 ChildOf(root) ),
    }
}
```

## Testing

- Running unit tests locally.
