### PR TITLE
`bevy_text` Emoji support

### DIFF
--- a/crates/bevy_text/src/font_atlas.rs
+++ b/crates/bevy_text/src/font_atlas.rs
@@ -91,6 +91,7 @@ impl FontAtlas {
         key: GlyphCacheKey,
         texture: &Image,
         offset: Vec2,
+        is_alpha_mask: bool,
     ) -> Result<(), TextError> {
         let mut atlas_texture = textures
             .get_mut(&self.texture)
@@ -106,6 +107,7 @@ impl FontAtlas {
                 GlyphAtlasLocation {
                     glyph_index,
                     offset,
+                    is_alpha_mask,
                 },
             );
             Ok(())
@@ -137,7 +139,13 @@ pub fn add_glyph_to_atlas(
     let (glyph_texture, offset, is_alpha_mask) =
         get_outlined_glyph_texture(scaler, glyph_id, font_smoothing)?;
     let mut add_char_to_font_atlas = |atlas: &mut FontAtlas| -> Result<(), TextError> {
-        atlas.add_glyph(textures, GlyphCacheKey { glyph_id }, &glyph_texture, offset)
+        atlas.add_glyph(
+            textures,
+            GlyphCacheKey { glyph_id },
+            &glyph_texture,
+            offset,
+            is_alpha_mask,
+        )
     };
     if !font_atlases
         .iter_mut()
@@ -154,12 +162,18 @@ pub fn add_glyph_to_atlas(
 
         let mut new_atlas = FontAtlas::new(textures, UVec2::splat(containing), font_smoothing);
 
-        new_atlas.add_glyph(textures, GlyphCacheKey { glyph_id }, &glyph_texture, offset)?;
+        new_atlas.add_glyph(
+            textures,
+            GlyphCacheKey { glyph_id },
+            &glyph_texture,
+            offset,
+            is_alpha_mask,
+        )?;
 
         font_atlases.push(new_atlas);
     }
 
-    get_glyph_atlas_info(font_atlases, GlyphCacheKey { glyph_id }, is_alpha_mask)
+    get_glyph_atlas_info(font_atlases, GlyphCacheKey { glyph_id })
         .ok_or(TextError::InconsistentAtlasState)
 }
 
@@ -238,7 +252,6 @@ pub fn get_outlined_glyph_texture(
 pub fn get_glyph_atlas_info(
     font_atlases: &mut [FontAtlas],
     cache_key: GlyphCacheKey,
-    is_alpha_mask: bool,
 ) -> Option<GlyphAtlasInfo> {
     font_atlases.iter().find_map(|atlas| {
         atlas
@@ -247,7 +260,7 @@ pub fn get_glyph_atlas_info(
                 offset: location.offset,
                 rect: atlas.texture_atlas.textures[location.glyph_index].as_rect(),
                 texture: atlas.texture.id(),
-                is_alpha_mask,
+                is_alpha_mask: location.is_alpha_mask,
             })
     })
 }

--- a/crates/bevy_text/src/font_atlas.rs
+++ b/crates/bevy_text/src/font_atlas.rs
@@ -227,8 +227,9 @@ pub fn get_outlined_glyph_texture(
             }
             rgba
         }
-        swash::scale::image::Content::Color => image.data,
-        swash::scale::image::Content::SubpixelMask => image.data,
+        swash::scale::image::Content::Color | swash::scale::image::Content::SubpixelMask => {
+            image.data
+        }
     };
 
     Ok((

--- a/crates/bevy_text/src/font_atlas.rs
+++ b/crates/bevy_text/src/font_atlas.rs
@@ -134,7 +134,8 @@ pub fn add_glyph_to_atlas(
     font_smoothing: FontSmoothing,
     glyph_id: u16,
 ) -> Result<GlyphAtlasInfo, TextError> {
-    let (glyph_texture, offset) = get_outlined_glyph_texture(scaler, glyph_id, font_smoothing)?;
+    let (glyph_texture, offset, is_alpha_mask) =
+        get_outlined_glyph_texture(scaler, glyph_id, font_smoothing)?;
     let mut add_char_to_font_atlas = |atlas: &mut FontAtlas| -> Result<(), TextError> {
         atlas.add_glyph(textures, GlyphCacheKey { glyph_id }, &glyph_texture, offset)
     };
@@ -158,7 +159,7 @@ pub fn add_glyph_to_atlas(
         font_atlases.push(new_atlas);
     }
 
-    get_glyph_atlas_info(font_atlases, GlyphCacheKey { glyph_id })
+    get_glyph_atlas_info(font_atlases, GlyphCacheKey { glyph_id }, is_alpha_mask)
         .ok_or(TextError::InconsistentAtlasState)
 }
 
@@ -171,7 +172,7 @@ pub fn get_outlined_glyph_texture(
     scaler: &mut Scaler,
     glyph_id: u16,
     font_smoothing: FontSmoothing,
-) -> Result<(Image, Vec2), TextError> {
+) -> Result<(Image, Vec2, bool), TextError> {
     let image = swash::scale::Render::new(&[
         swash::scale::Source::ColorOutline(0),
         swash::scale::Source::ColorBitmap(swash::scale::StrikeWith::BestFit),
@@ -229,6 +230,7 @@ pub fn get_outlined_glyph_texture(
             RenderAssetUsages::MAIN_WORLD,
         ),
         Vec2::new(left as f32, -top as f32),
+        image.content == swash::scale::image::Content::Mask,
     ))
 }
 
@@ -236,6 +238,7 @@ pub fn get_outlined_glyph_texture(
 pub fn get_glyph_atlas_info(
     font_atlases: &mut [FontAtlas],
     cache_key: GlyphCacheKey,
+    is_alpha_mask: bool,
 ) -> Option<GlyphAtlasInfo> {
     font_atlases.iter().find_map(|atlas| {
         atlas
@@ -244,6 +247,7 @@ pub fn get_glyph_atlas_info(
                 offset: location.offset,
                 rect: atlas.texture_atlas.textures[location.glyph_index].as_rect(),
                 texture: atlas.texture.id(),
+                is_alpha_mask,
             })
     })
 }

--- a/crates/bevy_text/src/font_atlas.rs
+++ b/crates/bevy_text/src/font_atlas.rs
@@ -187,27 +187,34 @@ pub fn get_outlined_glyph_texture(
     let height = image.placement.height;
 
     let px = (width * height) as usize;
-    let mut rgba = vec![0u8; px * 4];
-    match font_smoothing {
-        FontSmoothing::AntiAliased => {
-            for i in 0..px {
-                let a = image.data[i];
-                rgba[i * 4 + 0] = 255; // R
-                rgba[i * 4 + 1] = 255; // G
-                rgba[i * 4 + 2] = 255; // B
-                rgba[i * 4 + 3] = a; // A from swash
+    let rgba = match image.content {
+        swash::scale::image::Content::Mask => {
+            let mut rgba = vec![0u8; px * 4];
+            match font_smoothing {
+                FontSmoothing::AntiAliased => {
+                    for i in 0..px {
+                        let a = image.data[i];
+                        rgba[i * 4 + 0] = 255; // R
+                        rgba[i * 4 + 1] = 255; // G
+                        rgba[i * 4 + 2] = 255; // B
+                        rgba[i * 4 + 3] = a; // A from swash
+                    }
+                }
+                FontSmoothing::None => {
+                    for i in 0..px {
+                        let a = image.data[i];
+                        rgba[i * 4 + 0] = 255; // R
+                        rgba[i * 4 + 1] = 255; // G
+                        rgba[i * 4 + 2] = 255; // B
+                        rgba[i * 4 + 3] = if 127 < a { 255 } else { 0 }; // A from swash
+                    }
+                }
             }
+            rgba
         }
-        FontSmoothing::None => {
-            for i in 0..px {
-                let a = image.data[i];
-                rgba[i * 4 + 0] = 255; // R
-                rgba[i * 4 + 1] = 255; // G
-                rgba[i * 4 + 2] = 255; // B
-                rgba[i * 4 + 3] = if 127 < a { 255 } else { 0 }; // A from swash
-            }
-        }
-    }
+        swash::scale::image::Content::Color => image.data,
+        swash::scale::image::Content::SubpixelMask => image.data,
+    };
 
     Ok((
         Image::new(

--- a/crates/bevy_text/src/glyph.rs
+++ b/crates/bevy_text/src/glyph.rs
@@ -40,7 +40,7 @@ pub struct GlyphAtlasInfo {
     pub rect: Rect,
     /// The required offset (relative positioning) when placed
     pub offset: Vec2,
-    /// True if this is an alpha mask
+    /// True if this glyph is stored as a tintable alpha mask
     pub is_alpha_mask: bool,
 }
 
@@ -55,4 +55,6 @@ pub struct GlyphAtlasLocation {
     pub glyph_index: usize,
     /// The required offset (relative positioning) when placed
     pub offset: Vec2,
+    /// True if this glyph is stored as a tintable alpha mask
+    pub is_alpha_mask: bool,
 }

--- a/crates/bevy_text/src/glyph.rs
+++ b/crates/bevy_text/src/glyph.rs
@@ -40,6 +40,8 @@ pub struct GlyphAtlasInfo {
     pub rect: Rect,
     /// The required offset (relative positioning) when placed
     pub offset: Vec2,
+    /// True if this is an alpha mask
+    pub is_alpha_mask: bool,
 }
 
 /// The location of a glyph in an atlas,

--- a/crates/bevy_ui_render/src/lib.rs
+++ b/crates/bevy_ui_render/src/lib.rs
@@ -35,7 +35,7 @@ use bevy_ui::{
 
 use bevy_app::prelude::*;
 use bevy_asset::{AssetEvent, AssetId, Assets};
-use bevy_color::{Alpha, ColorToComponents, Gray, LinearRgba};
+use bevy_color::{Alpha, ColorToComponents, LinearRgba};
 use bevy_core_pipeline::schedule::{Core2d, Core2dSystems, Core3d, Core3dSystems};
 use bevy_core_pipeline::upscaling::upscaling;
 use bevy_ecs::prelude::*;

--- a/crates/bevy_ui_render/src/lib.rs
+++ b/crates/bevy_ui_render/src/lib.rs
@@ -35,7 +35,7 @@ use bevy_ui::{
 
 use bevy_app::prelude::*;
 use bevy_asset::{AssetEvent, AssetId, Assets};
-use bevy_color::{Alpha, ColorToComponents, LinearRgba};
+use bevy_color::{Alpha, ColorToComponents, Gray, LinearRgba};
 use bevy_core_pipeline::schedule::{Core2d, Core2dSystems, Core3d, Core3dSystems};
 use bevy_core_pipeline::upscaling::upscaling;
 use bevy_ecs::prelude::*;
@@ -1022,7 +1022,9 @@ pub fn extract_text_sections(
                 current_section_index = *section_index;
             }
 
-            let color = if let Some(selected_text_color) = selected_text_color
+            let color = if !atlas_info.is_alpha_mask {
+                LinearRgba::WHITE
+            } else if let Some(selected_text_color) = selected_text_color
                 && text_layout_info
                     .selection_rects
                     .iter()
@@ -1030,7 +1032,8 @@ pub fn extract_text_sections(
                         let glyph_rect = Rect::from_center_size(*position, atlas_info.rect.size());
                         selection_rect.contains(glyph_rect.min)
                             && selection_rect.contains(glyph_rect.max)
-                    }) {
+                    })
+            {
                 selected_text_color
             } else {
                 color


### PR DESCRIPTION
# Objective

Add basic emoji support.

## Solution

* In `get_outlined_glyph_texture` just use the given rgba image data if the image from swash is not an alpha mask.
* Add `is_alpha_mask` bool fields to `GlyphAtlasInfo` and `GlyphAtlasLocation`.
* In `extract_text_sections` only apply a color tint if the glyph image is an alpha mask.

## Testing

Should be compatible with all the existing features, I tested `TextShadow`s and they worked correctly.

The changes here feel a bit half baked, but it's  super simple and I've got leave for somewhere so hammered this out in a rush.

<img width="1827" height="887" alt="emoji" src="https://github.com/user-attachments/assets/633a3711-8761-438d-9e57-928c725f24f6" />
