### PR TITLE
Add `FromTemplate` derive to most `bevy_ui_widgets` components

### DIFF
--- a/crates/bevy_ui_widgets/src/button.rs
+++ b/crates/bevy_ui_widgets/src/button.rs
@@ -2,6 +2,7 @@ use accesskit::Role;
 use bevy_a11y::AccessibilityNode;
 use bevy_app::{App, Plugin};
 use bevy_ecs::query::Has;
+use bevy_ecs::template::FromTemplate;
 use bevy_ecs::{
     component::Component,
     entity::Entity,
@@ -20,13 +21,13 @@ use crate::Activate;
 /// Headless button widget. This widget maintains a "pressed" state, which is used to
 /// indicate whether the button is currently being pressed by the user. It emits an [`Activate`]
 /// event when the button is un-pressed.
-#[derive(Component, Default, Debug, Clone)]
+#[derive(Component, FromTemplate, Default, Debug, Clone)]
 #[require(AccessibilityNode(accesskit::Node::new(Role::Button)))]
 pub struct Button;
 
 /// Optional marker component that indicates we want the button to activate on the pointer down
 /// event, this is used for menu buttons.
-#[derive(Component, Default, Debug, Clone)]
+#[derive(Component, FromTemplate, Default, Debug, Clone)]
 pub struct ActivateOnPress;
 
 fn button_on_key_event(

--- a/crates/bevy_ui_widgets/src/checkbox.rs
+++ b/crates/bevy_ui_widgets/src/checkbox.rs
@@ -4,6 +4,7 @@ use bevy_app::{App, Plugin};
 use bevy_ecs::event::EntityEvent;
 use bevy_ecs::query::{Has, With, Without};
 use bevy_ecs::system::ResMut;
+use bevy_ecs::template::FromTemplate;
 use bevy_ecs::{
     component::Component,
     observer::On,
@@ -29,7 +30,7 @@ use bevy_ecs::entity::Entity;
 /// The [`Checkbox`] component can be used to implement other kinds of toggle widgets. If you
 /// are going to do a toggle switch, you should override the [`AccessibilityNode`] component with
 /// the `Switch` role instead of the `Checkbox` role.
-#[derive(Component, Debug, Default, Clone)]
+#[derive(Component, FromTemplate, Debug, Default, Clone)]
 #[require(AccessibilityNode(accesskit::Node::new(Role::CheckBox)), Checkable)]
 pub struct Checkbox;
 

--- a/crates/bevy_ui_widgets/src/menu.rs
+++ b/crates/bevy_ui_widgets/src/menu.rs
@@ -39,7 +39,7 @@ use bevy_ecs::{
     observer::On,
     query::{Has, With},
     schedule::IntoScheduleConfigs,
-    system::{Commands, Query, Res, ResMut},
+    system::{Commands, Query, Res, ResMut}, template::FromTemplate,
 };
 use bevy_input::{
     keyboard::{KeyCode, KeyboardInput},
@@ -110,7 +110,7 @@ pub enum MenuLayout {
 /// Some care needs to be taken in implementing a menu button: we normally want menu buttons to
 /// toggle the open state of the menu; but clicking on the button will cause focus loss which means
 /// that the menu will always be closed by the time the click event is processed.
-#[derive(Component, Debug, Default, Clone)]
+#[derive(Component, FromTemplate, Debug, Default, Clone)]
 #[require(
     AccessibilityNode(accesskit::Node::new(Role::MenuListPopup)),
     TabGroup::modal()
@@ -122,7 +122,7 @@ pub struct MenuPopup {
 }
 
 /// Component that defines a menu item.
-#[derive(Component, Debug, Clone, Default)]
+#[derive(Component, FromTemplate, Debug, Clone, Default)]
 #[require(AccessibilityNode(accesskit::Node::new(Role::MenuItem)))]
 pub struct MenuItem;
 
@@ -397,7 +397,7 @@ fn menu_item_on_pointer_cancel(
 
 /// Headless menu button widget. This is meant to be combined with the `Button` component, and
 /// adds a few more key codes - arrow keys to open the popup.
-#[derive(Component, Default, Debug, Clone)]
+#[derive(Component, FromTemplate, Default, Debug, Clone)]
 #[require(
     AccessibilityNode(accesskit::Node::new(Role::Button)),
     Button,

--- a/crates/bevy_ui_widgets/src/menu.rs
+++ b/crates/bevy_ui_widgets/src/menu.rs
@@ -39,7 +39,8 @@ use bevy_ecs::{
     observer::On,
     query::{Has, With},
     schedule::IntoScheduleConfigs,
-    system::{Commands, Query, Res, ResMut}, template::FromTemplate,
+    system::{Commands, Query, Res, ResMut},
+    template::FromTemplate,
 };
 use bevy_input::{
     keyboard::{KeyCode, KeyboardInput},

--- a/crates/bevy_ui_widgets/src/popover.rs
+++ b/crates/bevy_ui_widgets/src/popover.rs
@@ -80,7 +80,7 @@ pub struct PopoverPlacement {
 
 /// Component which is inserted into a popover element to make it dynamically position relative to
 /// an parent element.
-#[derive(Component, FromTemplate, PartialEq, Default)]
+#[derive(Component, PartialEq, Default)]
 pub struct Popover {
     /// List of potential positions for the popover element relative to the parent.
     pub positions: Vec<PopoverPlacement>,

--- a/crates/bevy_ui_widgets/src/popover.rs
+++ b/crates/bevy_ui_widgets/src/popover.rs
@@ -7,7 +7,7 @@ use bevy_ecs::{
     hierarchy::{ChildOf, Children},
     query::Without,
     schedule::IntoScheduleConfigs,
-    system::{ParamSet, Query},
+    system::{ParamSet, Query}, template::FromTemplate,
 };
 use bevy_math::{Affine2, Rect, Vec2};
 use bevy_ui::{
@@ -79,7 +79,7 @@ pub struct PopoverPlacement {
 
 /// Component which is inserted into a popover element to make it dynamically position relative to
 /// an parent element.
-#[derive(Component, PartialEq, Default)]
+#[derive(Component, FromTemplate, PartialEq, Default)]
 pub struct Popover {
     /// List of potential positions for the popover element relative to the parent.
     pub positions: Vec<PopoverPlacement>,

--- a/crates/bevy_ui_widgets/src/popover.rs
+++ b/crates/bevy_ui_widgets/src/popover.rs
@@ -7,7 +7,8 @@ use bevy_ecs::{
     hierarchy::{ChildOf, Children},
     query::Without,
     schedule::IntoScheduleConfigs,
-    system::{ParamSet, Query}, template::FromTemplate,
+    system::{ParamSet, Query},
+    template::FromTemplate,
 };
 use bevy_math::{Affine2, Rect, Vec2};
 use bevy_ui::{

--- a/crates/bevy_ui_widgets/src/popover.rs
+++ b/crates/bevy_ui_widgets/src/popover.rs
@@ -8,7 +8,6 @@ use bevy_ecs::{
     query::Without,
     schedule::IntoScheduleConfigs,
     system::{ParamSet, Query},
-    template::FromTemplate,
 };
 use bevy_math::{Affine2, Rect, Vec2};
 use bevy_ui::{

--- a/crates/bevy_ui_widgets/src/radio.rs
+++ b/crates/bevy_ui_widgets/src/radio.rs
@@ -8,7 +8,7 @@ use bevy_ecs::{
     observer::On,
     query::{Has, With, Without},
     reflect::ReflectComponent,
-    system::{Commands, Query},
+    system::{Commands, Query}, template::FromTemplate,
 };
 use bevy_input::keyboard::{KeyCode, KeyboardInput};
 use bevy_input::ButtonState;
@@ -35,7 +35,7 @@ use crate::{ActivateOnPress, ValueChange};
 /// associated with a particular constant value, and would be checked whenever that value is equal
 /// to the group's value. This also means that as long as each button's associated value is unique
 /// within the group, it should never be the case that more than one button is selected at a time.
-#[derive(Component, Debug, Clone, Default)]
+#[derive(Component, FromTemplate, Debug, Clone, Default)]
 #[require(AccessibilityNode(accesskit::Node::new(Role::RadioGroup)))]
 pub struct RadioGroup;
 
@@ -51,7 +51,7 @@ pub struct RadioGroup;
 /// either through a mouse click or when a [`RadioGroup`] checks the widget.
 /// If the [`RadioButton`] is focusable, it can also be checked using the `Enter` or `Space` keys,
 /// in which case the event will likewise be emitted.
-#[derive(Component, Debug, Clone, Default)]
+#[derive(Component, FromTemplate, Debug, Clone, Default)]
 #[require(AccessibilityNode(accesskit::Node::new(Role::RadioButton)), Checkable)]
 #[derive(Reflect)]
 #[reflect(Component)]

--- a/crates/bevy_ui_widgets/src/radio.rs
+++ b/crates/bevy_ui_widgets/src/radio.rs
@@ -8,7 +8,8 @@ use bevy_ecs::{
     observer::On,
     query::{Has, With, Without},
     reflect::ReflectComponent,
-    system::{Commands, Query}, template::FromTemplate,
+    system::{Commands, Query},
+    template::FromTemplate,
 };
 use bevy_input::keyboard::{KeyCode, KeyboardInput};
 use bevy_input::ButtonState;

--- a/crates/bevy_ui_widgets/src/scrollbar.rs
+++ b/crates/bevy_ui_widgets/src/scrollbar.rs
@@ -9,7 +9,8 @@ use bevy_ecs::{
     query::{With, Without},
     reflect::ReflectComponent,
     schedule::IntoScheduleConfigs,
-    system::{Query, Res}, template::FromTemplate,
+    system::{Query, Res},
+    template::FromTemplate,
 };
 use bevy_math::{Affine2, Vec2};
 use bevy_picking::events::{Cancel, Drag, DragEnd, DragStart, Pointer, Press};

--- a/crates/bevy_ui_widgets/src/scrollbar.rs
+++ b/crates/bevy_ui_widgets/src/scrollbar.rs
@@ -53,7 +53,7 @@ pub enum ControlOrientation {
 /// The application is free to position the scrollbars relative to the scrolling container however
 /// it wants: it can overlay them on top of the scrolling content, or use a grid layout to displace
 /// the content to make room for the scrollbars.
-#[derive(Component, Debug, Reflect, Clone, PartialEq, FromTemplate)]
+#[derive(Component, FromTemplate, Debug, Reflect, Clone, PartialEq)]
 #[reflect(Component)]
 pub struct Scrollbar {
     /// Entity being scrolled.
@@ -73,7 +73,7 @@ pub struct Scrollbar {
 /// A `ScrollbarThumb` UI node does not have a `Node` component. It only has `Border` and `BorderRadius` styling properties.
 /// Its layout is handled after `ui_layout_system` in `update_scroll_thumb` so that its size and position can be set relative to the scrolling area's
 /// size and scroll position.
-#[derive(Component, Debug, Default, FromTemplate)]
+#[derive(Component, FromTemplate, Debug, Default)]
 #[require(
     CoreScrollbarDragState,
     ComputedNode,

--- a/crates/bevy_ui_widgets/src/scrollbar.rs
+++ b/crates/bevy_ui_widgets/src/scrollbar.rs
@@ -9,7 +9,7 @@ use bevy_ecs::{
     query::{With, Without},
     reflect::ReflectComponent,
     schedule::IntoScheduleConfigs,
-    system::{Query, Res},
+    system::{Query, Res}, template::FromTemplate,
 };
 use bevy_math::{Affine2, Vec2};
 use bevy_picking::events::{Cancel, Drag, DragEnd, DragStart, Pointer, Press};
@@ -53,7 +53,7 @@ pub enum ControlOrientation {
 /// The application is free to position the scrollbars relative to the scrolling container however
 /// it wants: it can overlay them on top of the scrolling content, or use a grid layout to displace
 /// the content to make room for the scrollbars.
-#[derive(Component, Debug, Reflect, Clone, PartialEq)]
+#[derive(Component, Debug, Reflect, Clone, PartialEq, FromTemplate)]
 #[reflect(Component)]
 pub struct Scrollbar {
     /// Entity being scrolled.
@@ -73,7 +73,7 @@ pub struct Scrollbar {
 /// A `ScrollbarThumb` UI node does not have a `Node` component. It only has `Border` and `BorderRadius` styling properties.
 /// Its layout is handled after `ui_layout_system` in `update_scroll_thumb` so that its size and position can be set relative to the scrolling area's
 /// size and scroll position.
-#[derive(Component, Debug, Default)]
+#[derive(Component, Debug, Default, FromTemplate)]
 #[require(
     CoreScrollbarDragState,
     ComputedNode,

--- a/crates/bevy_ui_widgets/src/slider.rs
+++ b/crates/bevy_ui_widgets/src/slider.rs
@@ -224,7 +224,7 @@ impl Default for SliderStep {
 /// The value in this component represents the number of decimal places of desired precision, so a
 /// value of 2 would round to the nearest 1/100th. A value of -3 would round to the nearest
 /// thousand.
-#[derive(Component, Debug, Default, Clone, Copy, Reflect)]
+#[derive(Component, FromTemplate, Debug, Default, Clone, Copy, Reflect)]
 #[reflect(Component, Default)]
 pub struct SliderPrecision(pub i32);
 

--- a/crates/bevy_ui_widgets/src/slider.rs
+++ b/crates/bevy_ui_widgets/src/slider.rs
@@ -113,12 +113,12 @@ pub struct Slider {
 pub struct SliderThumb;
 
 /// A component which stores the current value of the slider.
-#[derive(Component, FromTemplate, Debug, Default, PartialEq, Clone, Copy)]
+#[derive(Component, Debug, Default, PartialEq, Clone, Copy)]
 #[component(immutable)]
 pub struct SliderValue(pub f32);
 
 /// A component which represents the allowed range of the slider value. Defaults to 0.0..=1.0.
-#[derive(Component, FromTemplate, Debug, PartialEq, Clone, Copy)]
+#[derive(Component, Debug, PartialEq, Clone, Copy)]
 #[component(immutable)]
 pub struct SliderRange {
     /// The beginning of the allowed range for the slider value.
@@ -203,7 +203,7 @@ impl Default for SliderRange {
 
 /// Defines the amount by which to increment or decrement the slider value when using keyboard
 /// shortcuts. Defaults to 1.0.
-#[derive(Component, FromTemplate, Debug, PartialEq, Clone)]
+#[derive(Component, Debug, PartialEq, Clone)]
 #[component(immutable)]
 #[derive(Reflect)]
 #[reflect(Component)]
@@ -224,7 +224,7 @@ impl Default for SliderStep {
 /// The value in this component represents the number of decimal places of desired precision, so a
 /// value of 2 would round to the nearest 1/100th. A value of -3 would round to the nearest
 /// thousand.
-#[derive(Component, FromTemplate, Debug, Default, Clone, Copy, Reflect)]
+#[derive(Component, Debug, Default, Clone, Copy, Reflect)]
 #[reflect(Component, Default)]
 pub struct SliderPrecision(pub i32);
 

--- a/crates/bevy_ui_widgets/src/slider.rs
+++ b/crates/bevy_ui_widgets/src/slider.rs
@@ -8,6 +8,7 @@ use bevy_ecs::hierarchy::Children;
 use bevy_ecs::lifecycle::Insert;
 use bevy_ecs::query::Has;
 use bevy_ecs::system::Res;
+use bevy_ecs::template::FromTemplate;
 use bevy_ecs::world::DeferredWorld;
 use bevy_ecs::{
     component::Component,
@@ -92,7 +93,7 @@ pub enum TrackClick {
 ///
 /// In cases where overhang is desired for artistic reasons, the thumb may have additional
 /// decorative child elements, absolutely positioned, which don't affect the size measurement.
-#[derive(Component, Debug, Default, Clone)]
+#[derive(Component, FromTemplate, Debug, Default, Clone)]
 #[require(
     AccessibilityNode(accesskit::Node::new(Role::Slider)),
     CoreSliderDragState,
@@ -108,16 +109,16 @@ pub struct Slider {
 }
 
 /// Marker component that identifies which descendant element is the slider thumb.
-#[derive(Component, Debug, Default, Clone)]
+#[derive(Component, FromTemplate, Debug, Default, Clone)]
 pub struct SliderThumb;
 
 /// A component which stores the current value of the slider.
-#[derive(Component, Debug, Default, PartialEq, Clone, Copy)]
+#[derive(Component, FromTemplate, Debug, Default, PartialEq, Clone, Copy)]
 #[component(immutable)]
 pub struct SliderValue(pub f32);
 
 /// A component which represents the allowed range of the slider value. Defaults to 0.0..=1.0.
-#[derive(Component, Debug, PartialEq, Clone, Copy)]
+#[derive(Component, FromTemplate, Debug, PartialEq, Clone, Copy)]
 #[component(immutable)]
 pub struct SliderRange {
     /// The beginning of the allowed range for the slider value.
@@ -202,7 +203,7 @@ impl Default for SliderRange {
 
 /// Defines the amount by which to increment or decrement the slider value when using keyboard
 /// shortcuts. Defaults to 1.0.
-#[derive(Component, Debug, PartialEq, Clone)]
+#[derive(Component, FromTemplate, Debug, PartialEq, Clone)]
 #[component(immutable)]
 #[derive(Reflect)]
 #[reflect(Component)]
@@ -223,7 +224,7 @@ impl Default for SliderStep {
 /// The value in this component represents the number of decimal places of desired precision, so a
 /// value of 2 would round to the nearest 1/100th. A value of -3 would round to the nearest
 /// thousand.
-#[derive(Component, Debug, Default, Clone, Copy, Reflect)]
+#[derive(Component, FromTemplate, Debug, Default, Clone, Copy, Reflect)]
 #[reflect(Component, Default)]
 pub struct SliderPrecision(pub i32);
 


### PR DESCRIPTION
This is a naive pass over the `bevy_ui_widgets` crate that adds `FromTemplate` to everything except the `CoreSliderDragState` and `CoreScrollbarDragState` components, which are state-management components.