### PR TITLE
Use BSN helpers to initialize FontSource.

### DIFF
--- a/crates/bevy_feathers/src/display/label.rs
+++ b/crates/bevy_feathers/src/display/label.rs
@@ -1,29 +1,20 @@
 //! BSN scene function for displaying a plain text string in the correct font.
 use bevy_app::PropagateOver;
-use bevy_asset::AssetServer;
-use bevy_ecs::template::template;
 use bevy_scene::{bsn, Scene};
-use bevy_text::{FontSource, FontWeight, TextFont};
+use bevy_text::{FontSourceTemplate, FontWeight, TextFont};
 use bevy_ui::widget::Text;
 
-use crate::{
-    constants::{fonts, size},
-    theme::ThemeTextColor,
-    tokens,
-};
+use crate::{constants::size, theme::ThemeTextColor, tokens};
 
 /// A text label.
 pub fn label(text: impl Into<String>) -> impl Scene {
     bsn! {
         Text(text)
-        template(|ctx| {
-            Ok(TextFont {
-                font: FontSource::Handle(ctx.resource::<AssetServer>().load(fonts::REGULAR)),
-                font_size: size::MEDIUM_FONT,
-                weight: FontWeight::NORMAL,
-                ..Default::default()
-            })
-        })
+        TextFont {
+            font: FontSourceTemplate::Handle("fonts/FiraSans-Bold.ttf"),
+            font_size: size::MEDIUM_FONT,
+            weight: FontWeight::NORMAL,
+        }
         PropagateOver<TextFont>
         ThemeTextColor(tokens::TEXT_MAIN)
     }
@@ -33,14 +24,11 @@ pub fn label(text: impl Into<String>) -> impl Scene {
 pub fn label_dim(text: impl Into<String>) -> impl Scene {
     bsn! {
         Text(text)
-        template(|ctx| {
-            Ok(TextFont {
-                font: FontSource::Handle(ctx.resource::<AssetServer>().load(fonts::REGULAR)),
-                font_size: size::MEDIUM_FONT,
-                weight: FontWeight::NORMAL,
-                ..Default::default()
-            })
-        })
+        TextFont {
+            font: FontSourceTemplate::Handle("fonts/FiraSans-Bold.ttf"),
+            font_size: size::MEDIUM_FONT,
+            weight: FontWeight::NORMAL,
+        }
         PropagateOver<TextFont>
         ThemeTextColor(tokens::TEXT_DIM)
     }
@@ -50,14 +38,11 @@ pub fn label_dim(text: impl Into<String>) -> impl Scene {
 pub fn label_small(text: impl Into<String>) -> impl Scene {
     bsn! {
         Text(text)
-        template(|ctx| {
-            Ok(TextFont {
-                font: FontSource::Handle(ctx.resource::<AssetServer>().load(fonts::REGULAR)),
-                font_size: size::EXTRA_SMALL_FONT,
-                weight: FontWeight::NORMAL,
-                ..Default::default()
-            })
-        })
+        TextFont {
+            font: FontSourceTemplate::Handle("fonts/FiraSans-Bold.ttf"),
+            font_size: size::EXTRA_SMALL_FONT,
+            weight: FontWeight::NORMAL,
+        }
         PropagateOver<TextFont>
         ThemeTextColor(tokens::TEXT_MAIN)
     }


### PR DESCRIPTION
Removes the complex `template` call and replaces it with the simpler BSN asset helper template.