### PR TITLE
Refactor the `effect_stack` post-processing module

### DIFF
--- a/crates/bevy_post_process/src/effect_stack/chromatic_aberration.rs
+++ b/crates/bevy_post_process/src/effect_stack/chromatic_aberration.rs
@@ -20,13 +20,6 @@ use bevy_render::{
 pub(super) static DEFAULT_CHROMATIC_ABERRATION_LUT_DATA: [u8; 12] =
     [255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255];
 
-/// The default chromatic aberration intensity amount, in a fraction of the
-/// window size.
-const DEFAULT_CHROMATIC_ABERRATION_INTENSITY: f32 = 0.02;
-
-/// The default maximum number of samples for chromatic aberration.
-const DEFAULT_CHROMATIC_ABERRATION_MAX_SAMPLES: u32 = 8;
-
 #[derive(Resource)]
 pub(crate) struct DefaultChromaticAberrationLut(pub(crate) Handle<Image>);
 
@@ -79,8 +72,8 @@ impl Default for ChromaticAberration {
     fn default() -> Self {
         Self {
             color_lut: None,
-            intensity: DEFAULT_CHROMATIC_ABERRATION_INTENSITY,
-            max_samples: DEFAULT_CHROMATIC_ABERRATION_MAX_SAMPLES,
+            intensity: 0.02,
+            max_samples: 8,
         }
     }
 }
@@ -97,8 +90,8 @@ impl ExtractComponent for ChromaticAberration {
     fn extract_component(
         chromatic_aberration: QueryItem<'_, '_, Self::QueryData>,
     ) -> Option<Self::Out> {
-        // Skip the postprocessing phase entirely if the intensity is zero.
-        if chromatic_aberration.intensity > 0.0 {
+        // Skip the postprocessing phase entirely if the intensity is negligible.
+        if chromatic_aberration.intensity > 1e-4 {
             Some(chromatic_aberration.clone())
         } else {
             None
@@ -112,13 +105,8 @@ impl ExtractComponent for ChromaticAberration {
 /// each of these fields.
 #[derive(ShaderType, Default)]
 pub struct ChromaticAberrationUniform {
-    /// The intensity of the effect, in a fraction of the screen.
     pub(super) intensity: f32,
-    /// A cap on the number of samples of the source texture that the shader
-    /// will perform.
     pub(super) max_samples: u32,
-    /// Padding data.
     pub(super) unused_1: u32,
-    /// Padding data.
     pub(super) unused_2: u32,
 }

--- a/crates/bevy_post_process/src/effect_stack/chromatic_aberration.wgsl
+++ b/crates/bevy_post_process/src/effect_stack/chromatic_aberration.wgsl
@@ -16,13 +16,11 @@ struct ChromaticAberrationSettings {
 // The source framebuffer texture.
 @group(0) @binding(0) var source_texture: texture_2d<f32>;
 // The sampler used to sample the source framebuffer texture.
-@group(0) @binding(1) var source_sampler: sampler;
+@group(0) @binding(1) var common_sampler: sampler;
 // The 1D lookup table for chromatic aberration.
 @group(0) @binding(2) var chromatic_aberration_lut_texture: texture_2d<f32>;
-// The sampler used to sample that lookup table.
-@group(0) @binding(3) var chromatic_aberration_lut_sampler: sampler;
 // The settings supplied by the developer.
-@group(0) @binding(4) var<uniform> chromatic_aberration_settings: ChromaticAberrationSettings;
+@group(0) @binding(3) var<uniform> chromatic_aberration_settings: ChromaticAberrationSettings;
 
 fn chromatic_aberration(start_pos: vec2<f32>) -> vec3<f32> {
     // Radial chromatic aberration implemented using the *Inside* technique:
@@ -56,7 +54,7 @@ fn chromatic_aberration(start_pos: vec2<f32>) -> vec3<f32> {
             let sample_uv = mix(start_pos, end_pos, t);
             let sample = textureSampleLevel(
                 source_texture,
-                source_sampler,
+                common_sampler,
                 sample_uv,
                 0.0,
             ).rgb;
@@ -65,7 +63,7 @@ fn chromatic_aberration(start_pos: vec2<f32>) -> vec3<f32> {
             let lut_u = mix(lut_u_offset, 1.0 - lut_u_offset, t);
             let modulate = textureSampleLevel(
                 chromatic_aberration_lut_texture,
-                chromatic_aberration_lut_sampler,
+                common_sampler,
                 vec2(lut_u, 0.5),
                 0.0,
             ).rgb;
@@ -82,7 +80,7 @@ fn chromatic_aberration(start_pos: vec2<f32>) -> vec3<f32> {
         // texture to such pixels, which is wrong.
         color = textureSampleLevel(
             source_texture,
-            source_sampler,
+            common_sampler,
             start_pos,
             0.0,
         ).rgb;

--- a/crates/bevy_post_process/src/effect_stack/lens_distortion.wgsl
+++ b/crates/bevy_post_process/src/effect_stack/lens_distortion.wgsl
@@ -17,9 +17,9 @@ const VISUAL_THRESHOLD: f32 = 1e-4;
 const MATH_EPSILON: f32 = 1e-6;
 
 // The settings supplied by the developer.
-@group(0) @binding(6) var<uniform> lens_distortion_settings: LensDistortionSettings;
+@group(0) @binding(5) var<uniform> lens_distortion_settings: LensDistortionSettings;
 
-fn lens_distortion(uv: vec2<f32>) -> vec2<f32>{
+fn lens_distortion(uv: vec2<f32>) -> vec2<f32> {
     let intensity = lens_distortion_settings.intensity;
     if (abs(intensity) < VISUAL_THRESHOLD) {
         return uv;

--- a/crates/bevy_post_process/src/effect_stack/mod.rs
+++ b/crates/bevy_post_process/src/effect_stack/mod.rs
@@ -11,7 +11,6 @@ mod lens_distortion;
 mod vignette;
 
 use bevy_color::ColorToComponents;
-use bevy_math::Vec2;
 pub use chromatic_aberration::{ChromaticAberration, ChromaticAberrationUniform};
 pub use lens_distortion::{LensDistortion, LensDistortionUniform};
 pub use vignette::{Vignette, VignetteUniform};
@@ -81,10 +80,8 @@ pub struct EffectStackPlugin;
 pub struct PostProcessingPipeline {
     /// The layout of bind group 0, containing the source, LUT, and settings.
     bind_group_layout: BindGroupLayoutDescriptor,
-    /// Specifies how to sample the source framebuffer texture.
-    source_sampler: Sampler,
-    /// Specifies how to sample the chromatic aberration gradient.
-    chromatic_aberration_lut_sampler: Sampler,
+    /// A shared sampler used to sample both the source framebuffer texture and the LUT texture.
+    common_sampler: Sampler,
     /// The asset handle for the fullscreen vertex shader.
     fullscreen_shader: FullscreenShader,
     /// The fragment shader asset handle.
@@ -176,7 +173,7 @@ impl Plugin for EffectStackPlugin {
     }
 }
 
-pub fn init_post_processing_pipeline(
+pub(crate) fn init_post_processing_pipeline(
     mut commands: Commands,
     render_device: Res<RenderDevice>,
     fullscreen_shader: Res<FullscreenShader>,
@@ -190,12 +187,10 @@ pub fn init_post_processing_pipeline(
             (
                 // Common source:
                 texture_2d(TextureSampleType::Float { filterable: true }),
-                // Common source sampler:
+                // Common sampler:
                 sampler(SamplerBindingType::Filtering),
                 // Chromatic aberration LUT:
                 texture_2d(TextureSampleType::Float { filterable: true }),
-                // Chromatic aberration LUT sampler:
-                sampler(SamplerBindingType::Filtering),
                 // Chromatic aberration settings:
                 uniform_buffer::<ChromaticAberrationUniform>(true),
                 // Vignette settings:
@@ -208,15 +203,7 @@ pub fn init_post_processing_pipeline(
 
     // Both source and chromatic aberration LUTs should be sampled
     // bilinearly.
-
-    let source_sampler = render_device.create_sampler(&SamplerDescriptor {
-        mipmap_filter: MipmapFilterMode::Linear,
-        min_filter: FilterMode::Linear,
-        mag_filter: FilterMode::Linear,
-        ..default()
-    });
-
-    let chromatic_aberration_lut_sampler = render_device.create_sampler(&SamplerDescriptor {
+    let common_sampler = render_device.create_sampler(&SamplerDescriptor {
         mipmap_filter: MipmapFilterMode::Linear,
         min_filter: FilterMode::Linear,
         mag_filter: FilterMode::Linear,
@@ -225,8 +212,7 @@ pub fn init_post_processing_pipeline(
 
     commands.insert_resource(PostProcessingPipeline {
         bind_group_layout,
-        source_sampler,
-        chromatic_aberration_lut_sampler,
+        common_sampler,
         fullscreen_shader: fullscreen_shader.clone(),
         fragment_shader: load_embedded_asset!(asset_server.as_ref(), "post_process.wgsl"),
     });
@@ -335,9 +321,8 @@ pub(crate) fn post_processing(
         &pipeline_cache.get_bind_group_layout(&post_processing_pipeline.bind_group_layout),
         &BindGroupEntries::sequential((
             post_process.source,
-            &post_processing_pipeline.source_sampler,
+            &post_processing_pipeline.common_sampler,
             &chromatic_aberration_lut.texture_view,
-            &post_processing_pipeline.chromatic_aberration_lut_sampler,
             chromatic_aberration_uniform_buffer_binding,
             vignette_uniform_buffer_binding,
             lens_distortion_uniform_buffer_binding,
@@ -366,7 +351,7 @@ pub(crate) fn post_processing(
 }
 
 /// Specializes the built-in postprocessing pipeline for each applicable view.
-pub fn prepare_post_processing_pipelines(
+pub(crate) fn prepare_post_processing_pipelines(
     mut commands: Commands,
     pipeline_cache: Res<PipelineCache>,
     mut pipelines: ResMut<SpecializedRenderPipelines<PostProcessingPipeline>>,
@@ -398,7 +383,7 @@ pub fn prepare_post_processing_pipelines(
 
 /// Gathers the built-in postprocessing settings for every view and uploads them
 /// to the GPU.
-pub fn prepare_post_processing_uniforms(
+pub(crate) fn prepare_post_processing_uniforms(
     mut commands: Commands,
     mut post_processing_uniform_buffers: ResMut<PostProcessingUniformBuffers>,
     render_device: Res<RenderDevice>,
@@ -419,6 +404,7 @@ pub fn prepare_post_processing_uniforms(
 ) {
     post_processing_uniform_buffers.chromatic_aberration.clear();
     post_processing_uniform_buffers.vignette.clear();
+    post_processing_uniform_buffers.lens_distortion.clear();
 
     // Gather up all the postprocessing settings.
     for (view_entity, maybe_chromatic_aberration, maybe_vignette, maybe_lens_distortion) in
@@ -444,10 +430,10 @@ pub fn prepare_post_processing_uniforms(
             post_processing_uniform_buffers
                 .vignette
                 .push(&VignetteUniform {
-                    intensity: vignette.intensity,
-                    radius: vignette.radius,
-                    smoothness: vignette.smoothness,
-                    roundness: vignette.roundness,
+                    intensity: vignette.intensity.min(1.0),
+                    radius: vignette.radius.max(1e-6),
+                    smoothness: vignette.smoothness.max(0.0),
+                    roundness: vignette.roundness.clamp(1e-6, 2.0 - 1e-6),
                     center: vignette.center,
                     edge_compensation: vignette.edge_compensation,
                     unused: 0,
@@ -466,8 +452,8 @@ pub fn prepare_post_processing_uniforms(
                     .push(&LensDistortionUniform {
                         intensity: lens_distortion.intensity,
                         scale: lens_distortion.scale.max(1e-6),
-                        multiplier: lens_distortion.multiplier.max(Vec2::ZERO),
-                        center: lens_distortion.center.clamp(Vec2::ZERO, Vec2::ONE),
+                        multiplier: lens_distortion.multiplier,
+                        center: lens_distortion.center,
                         edge_curvature: lens_distortion.edge_curvature,
                         unused: 0,
                     })

--- a/crates/bevy_post_process/src/effect_stack/vignette.rs
+++ b/crates/bevy_post_process/src/effect_stack/vignette.rs
@@ -12,21 +12,6 @@ use bevy_render::{
     extract_component::ExtractComponent, render_resource::ShaderType, sync_component::SyncComponent,
 };
 
-/// The default vignette intensity amount.
-const DEFAULT_VIGNETTE_INTENSITY: f32 = 1.0;
-
-/// The default vignette radius amount.
-const DEFAULT_VIGNETTE_RADIUS: f32 = 0.75;
-
-/// The default vignette smoothness amount.
-const DEFAULT_VIGNETTE_SMOOTHNESS: f32 = 5.0;
-
-/// The default vignette roundness amount.
-const DEFAULT_VIGNETTE_ROUNDNESS: f32 = 1.0;
-
-/// The default vignette edge compensation
-const DEFAULT_VIGNETTE_EDGE_COMPENSATION: f32 = 1.0;
-
 /// Adds a gradual shading effect to the edges of the screen, drawing focus
 /// towards the center.
 ///
@@ -91,12 +76,12 @@ pub struct Vignette {
 impl Default for Vignette {
     fn default() -> Self {
         Self {
-            intensity: DEFAULT_VIGNETTE_INTENSITY,
-            radius: DEFAULT_VIGNETTE_RADIUS,
-            smoothness: DEFAULT_VIGNETTE_SMOOTHNESS,
-            roundness: DEFAULT_VIGNETTE_ROUNDNESS,
+            intensity: 1.0,
+            radius: 0.75,
+            smoothness: 5.0,
+            roundness: 1.0,
             color: Color::BLACK,
-            edge_compensation: DEFAULT_VIGNETTE_EDGE_COMPENSATION,
+            edge_compensation: 1.0,
             center: Vec2::new(0.5, 0.5),
         }
     }
@@ -112,8 +97,8 @@ impl ExtractComponent for Vignette {
     type Out = Self;
 
     fn extract_component(vignette: QueryItem<'_, '_, Self::QueryData>) -> Option<Self::Out> {
-        // Skip the postprocessing phase entirely if the intensity is zero.
-        if vignette.intensity > 0.0 {
+        // Skip the postprocessing phase entirely if the intensity is negligible.
+        if vignette.intensity > 1e-4 {
             Some(vignette.clone())
         } else {
             None
@@ -121,22 +106,18 @@ impl ExtractComponent for Vignette {
     }
 }
 
+/// The on-GPU version of the [`Vignette`] settings.
+///
+/// See the documentation for [`Vignette`] for more information on
+/// each of these fields.
 #[derive(ShaderType, Default)]
 pub struct VignetteUniform {
-    /// Controls the strength of the darkening effect.
     pub(super) intensity: f32,
-    /// The size of the unvignetted center area.
     pub(super) radius: f32,
-    /// The softness of the edge between the clear and dark areas.
     pub(super) smoothness: f32,
-    /// The shape of the vignette.
     pub(super) roundness: f32,
-    /// The center of the vignette.
     pub(super) center: Vec2,
-    /// The edge compensation of the vignette.
     pub(super) edge_compensation: f32,
-    /// Padding data.
     pub(super) unused: u32,
-    /// The color of the vignette.
     pub(super) color: Vec4,
 }

--- a/crates/bevy_post_process/src/effect_stack/vignette.wgsl
+++ b/crates/bevy_post_process/src/effect_stack/vignette.wgsl
@@ -17,21 +17,20 @@ struct VignetteSettings {
     color: vec4<f32>
 }
 
-const EPSILON: f32 = 1.19209290e-07;
+const VISUAL_THRESHOLD: f32 = 1e-4;
 
 // The settings supplied by the developer.
-@group(0) @binding(5) var<uniform> vignette_settings: VignetteSettings;
+@group(0) @binding(4) var<uniform> vignette_settings: VignetteSettings;
 
 fn vignette(uv: vec2<f32>, color: vec3<f32>) -> vec3<f32> {
-    if (vignette_settings.intensity < EPSILON) {
+    let intensity = vignette_settings.intensity;
+    if (intensity < VISUAL_THRESHOLD) {
         return color;
     }
-
-    let intensity = saturate(vignette_settings.intensity);
-    let radius = max(vignette_settings.radius, 0.0);
-    let smoothness = max(vignette_settings.smoothness, 0.0);
-    let roundness = clamp(vignette_settings.roundness, EPSILON, 2.0-EPSILON);
-    let edge_comp = saturate(vignette_settings.edge_compensation);
+    let radius = vignette_settings.radius;
+    let smoothness = vignette_settings.smoothness;
+    let roundness = vignette_settings.roundness;
+    let edge_comp = vignette_settings.edge_compensation;
 
     // Get the screen resolution.
     let dims = textureDimensions(source_texture);


### PR DESCRIPTION
# Objective

- I strongly agree with the doc style suggested by @mate-h in #23110. When I originally wrote the vignette docs, I just tried to match the style of the initial chromatic aberration comments without thinking too much about it. Now, I’ve updated them to be consistent with the current lens distortion docs.

- I also made a few other minor changes to make the code cleaner.

## Solution

- Merged Samplers: Replaced `source_sampler` and `chromatic_aberration_lut_sampler` with a single `common_sampler` (Both samplers are configured identically).
- CPU-side Clamping: Moved mathematical bounds checks (e.g., clamp, max) from WGSL shaders into `prepare_post_processing_uniforms`. I only clamp values that would cause shader errors or result in unexpected behavior.
- Unified Thresholds: Standardized the “skip post-processing” check to > 1e-4 for both `ChromaticAberration` and `Vignette ` extraction, avoiding unnecessary draw calls for negligible values.
- Cleanup: Removed redundant `DEFAULT_*` constants in favor of inline literals in Default implementations.

## Testing

- `post-processing` example works properly.

---