### PR TITLE
Fix `#[derive(QueryData)]` on empty structs

### DIFF
--- a/crates/bevy_ecs/macros/src/query_data.rs
+++ b/crates/bevy_ecs/macros/src/query_data.rs
@@ -60,21 +60,21 @@ fn contiguous_item_struct(
     };
 
     match fields {
-        Fields::Named(_) => quote! {
+        Fields::Named(_) if !fields.is_empty() => quote! {
             #derive_macro_call
             #item_attrs
             #visibility struct #item_struct_name #user_impl_generics_with_world_and_state #user_where_clauses_with_world_and_state {
                 #(#(#field_attrs)* #field_visibilities #field_members: <#field_types as #path::query::ContiguousQueryData>::Contiguous<'__w, '__s>,)*
             }
         },
-        Fields::Unnamed(_) => quote! {
+        Fields::Unnamed(_) if !fields.is_empty() => quote! {
             #derive_macro_call
             #item_attrs
             #visibility struct #item_struct_name #user_impl_generics_with_world_and_state(
                 #( #field_visibilities <#field_types as #path::query::ContiguousQueryData>::Contiguous<'__w, '__s>, )*
             ) #user_where_clauses_with_world_and_state;
         },
-        Fields::Unit => quote! {
+        Fields::Unit | Fields::Named(_) | Fields::Unnamed(_) => quote! {
             #item_attrs
             #visibility type #item_struct_name #user_ty_generics_with_world_and_state = #struct_name #user_ty_generics;
         },

--- a/crates/bevy_ecs/macros/src/world_query.rs
+++ b/crates/bevy_ecs/macros/src/world_query.rs
@@ -30,21 +30,21 @@ pub(crate) fn item_struct(
     };
 
     match fields {
-        Fields::Named(_) => quote! {
+        Fields::Named(_) if !fields.is_empty() => quote! {
             #derive_macro_call
             #item_attrs
             #visibility struct #item_struct_name #user_impl_generics_with_world_and_state #user_where_clauses_with_world_and_state {
                 #(#(#field_attrs)* #field_visibilities #field_members: <#field_types as #path::query::QueryData>::Item<'__w, '__s>,)*
             }
         },
-        Fields::Unnamed(_) => quote! {
+        Fields::Unnamed(_) if !fields.is_empty() => quote! {
             #derive_macro_call
             #item_attrs
             #visibility struct #item_struct_name #user_impl_generics_with_world_and_state(
                 #( #field_visibilities <#field_types as #path::query::QueryData>::Item<'__w, '__s>, )*
             ) #user_where_clauses_with_world_and_state;
         },
-        Fields::Unit => quote! {
+        Fields::Unit | Fields::Named(_) | Fields::Unnamed(_) => quote! {
             #item_attrs
             #visibility type #item_struct_name #user_ty_generics_with_world_and_state = #struct_name #user_ty_generics;
         },

--- a/crates/bevy_ecs/src/query/mod.rs
+++ b/crates/bevy_ecs/src/query/mod.rs
@@ -852,4 +852,70 @@ mod tests {
         let _ = world.query::<QueryDataA>().contiguous_iter_mut(&mut world);
         let _ = world.query::<QueryDataB<D>>().contiguous_iter(&world);
     }
+
+    // regression test for https://github.com/bevyengine/bevy/pull/23930
+    #[test]
+    fn query_data_derive_empty() {
+        #[derive(QueryData)]
+        struct QueryDataA {}
+
+        #[derive(QueryData)]
+        struct QueryDataB();
+
+        #[derive(QueryData)]
+        #[query_data(mutable)]
+        struct QueryDataC {}
+
+        #[derive(QueryData)]
+        #[query_data(mutable)]
+        struct QueryDataD();
+
+        #[derive(QueryData)]
+        #[query_data(contiguous(immutable))]
+        struct QueryDataE {}
+
+        #[derive(QueryData)]
+        #[query_data(contiguous(immutable))]
+        struct QueryDataF();
+
+        #[derive(QueryData)]
+        #[query_data(mutable, contiguous(immutable))]
+        struct QueryDataG {}
+
+        #[derive(QueryData)]
+        #[query_data(mutable, contiguous(immutable))]
+        struct QueryDataH();
+
+        #[derive(QueryData)]
+        #[query_data(contiguous(mutable))]
+        struct QueryDataI {}
+
+        #[derive(QueryData)]
+        #[query_data(contiguous(mutable))]
+        struct QueryDataJ();
+
+        #[derive(QueryData)]
+        #[query_data(mutable, contiguous(mutable))]
+        struct QueryDataK {}
+
+        #[derive(QueryData)]
+        #[query_data(mutable, contiguous(mutable))]
+        struct QueryDataL();
+
+        #[derive(QueryData)]
+        #[query_data(contiguous(all))]
+        struct QueryDataM {}
+
+        #[derive(QueryData)]
+        #[query_data(contiguous(all))]
+        struct QueryDataN();
+
+        #[derive(QueryData)]
+        #[query_data(mutable, contiguous(all))]
+        struct QueryDataO {}
+
+        #[derive(QueryData)]
+        #[query_data(mutable, contiguous(all))]
+        struct QueryDataP();
+    }
 }


### PR DESCRIPTION
# Objective

- Allow `#[derive(QueryData)]` on structs with no fields.

## Solution

- The derive fails for (non-unit) structs with no fields because the lifetime parameters of the generated structs are unused. Unit structs use a type alias instead of creating a new struct, avoiding the unused lifetime problem. Use type aliases for structs with no fields.

## Testing

- Added regression test
- Ran `cargo run -p ci -- compile`