### PR TITLE
Docs: Specify that `Relationship`s may only be one-to-many or one-to-one

### DIFF
--- a/crates/bevy_ecs/src/relationship/mod.rs
+++ b/crates/bevy_ecs/src/relationship/mod.rs
@@ -27,7 +27,9 @@ use log::warn;
 
 /// A [`Component`] on a "source" [`Entity`] that references another target [`Entity`], creating a "relationship" between them. Every [`Relationship`]
 /// has a corresponding [`RelationshipTarget`] type (and vice-versa), which exists on the "target" entity of a relationship and contains the list of all
-/// "source" entities that relate to the given "target"
+/// "source" entities that relate to the given "target".
+///
+/// A [`Relationship`] may only be one-to-many (or one-to-one): an [`Entity`] may point to at most one [`Entity`] through the [`Relationship`] component.
 ///
 /// The [`Relationship`] component is the "source of truth" and the [`RelationshipTarget`] component reflects that source of truth. When a [`Relationship`]
 /// component is inserted on an [`Entity`], the corresponding [`RelationshipTarget`] component is immediately inserted on the target component if it does


### PR DESCRIPTION
This may be deduced by observing that the `Relationship` component only stores one entity ID, but in my opinion, to become aware of such a fundamental limitation, one should not need to look at the implementation and do some deducing.

Tested by running `cargo doc --no-deps` from the root of the repository and opening the relevant webpage.