### PR TITLE
Don't panic in `AssetPath` deserialization

### DIFF
--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -773,6 +773,12 @@ mod tests {
     }
 
     #[test]
+    fn test_serialize() {
+        assert!(ron::de::from_str::<AssetPath>("\"a/b.test\"").is_ok());
+        assert!(ron::de::from_str::<AssetPath>("\"a/b.test#\"").is_err());
+    }
+
+    #[test]
     fn test_parent() {
         // Parent consumes path segments, returns None when insufficient
         let result = AssetPath::from("a/b.test");

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -685,13 +685,6 @@ impl<'de> Visitor<'de> for AssetPathVisitor {
             Err(err) => Err(E::custom(err)),
         }
     }
-
-    fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
-    where
-        E: serde::de::Error,
-    {
-        Ok(AssetPath::from(v))
-    }
 }
 
 /// Normalizes the path by collapsing all occurrences of '.' and '..' dot-segments where possible

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -680,7 +680,10 @@ impl<'de> Visitor<'de> for AssetPathVisitor {
     where
         E: serde::de::Error,
     {
-        Ok(AssetPath::parse(v).into_owned())
+        match AssetPath::try_parse(v) {
+            Ok(path) => Ok(path.into_owned()),
+            Err(err) => Err(E::custom(err)),
+        }
     }
 
     fn visit_string<E>(self, v: String) -> Result<Self::Value, E>


### PR DESCRIPTION
## Objective

`AssetPath` deserialization panics if the path is malformed. This seems a bit rude, and prevents the user from getting deserialization errors that would help track down the problem.

## Solution

Instead of calling `AssetPath::parse`, call `AssetPath::try_parse` and handle any errors.

Now, calling `ron::de::from_str` on `"a/b.test#"` returns a useful error:

```rust
Err(SpannedError {
    code: Message(
        "Asset label must be at least one character. Either specify the label after the '#' or remove the '#'",
    ),
    span: Span {
        start: Position { line: 1, col: 2, },
        end: Position { line: 1, col: 12 },
    },
})
```

The PR also removes the `visit_string` method of the `AssetPath` deserializer. `visit_string` is an optimization that avoids copies when the deserializer can take ownership of the string (see [serde docs](https://docs.rs/serde/latest/serde/de/trait.Visitor.html#method.visit_string)). But `AssetPath` didn't take ownership of the string, so there's no reason to implement it.

## Testing

```sh
cargo test -p bevy_asset
cargo run --example world_serialization
```