### PR TITLE
Rely on Default + Clone auto-impl for FromTemplate where possible

### DIFF
--- a/crates/bevy_ui_widgets/src/button.rs
+++ b/crates/bevy_ui_widgets/src/button.rs
@@ -2,7 +2,6 @@ use accesskit::Role;
 use bevy_a11y::AccessibilityNode;
 use bevy_app::{App, Plugin};
 use bevy_ecs::query::Has;
-use bevy_ecs::template::FromTemplate;
 use bevy_ecs::{
     component::Component,
     entity::Entity,
@@ -21,13 +20,13 @@ use crate::Activate;
 /// Headless button widget. This widget maintains a "pressed" state, which is used to
 /// indicate whether the button is currently being pressed by the user. It emits an [`Activate`]
 /// event when the button is un-pressed.
-#[derive(Component, FromTemplate, Default, Debug, Clone)]
+#[derive(Component, Default, Debug, Clone)]
 #[require(AccessibilityNode(accesskit::Node::new(Role::Button)))]
 pub struct Button;
 
 /// Optional marker component that indicates we want the button to activate on the pointer down
 /// event, this is used for menu buttons.
-#[derive(Component, FromTemplate, Default, Debug, Clone)]
+#[derive(Component, Default, Debug, Clone)]
 pub struct ActivateOnPress;
 
 fn button_on_key_event(

--- a/crates/bevy_ui_widgets/src/checkbox.rs
+++ b/crates/bevy_ui_widgets/src/checkbox.rs
@@ -4,7 +4,6 @@ use bevy_app::{App, Plugin};
 use bevy_ecs::event::EntityEvent;
 use bevy_ecs::query::{Has, With, Without};
 use bevy_ecs::system::ResMut;
-use bevy_ecs::template::FromTemplate;
 use bevy_ecs::{
     component::Component,
     observer::On,
@@ -30,7 +29,7 @@ use bevy_ecs::entity::Entity;
 /// The [`Checkbox`] component can be used to implement other kinds of toggle widgets. If you
 /// are going to do a toggle switch, you should override the [`AccessibilityNode`] component with
 /// the `Switch` role instead of the `Checkbox` role.
-#[derive(Component, FromTemplate, Debug, Default, Clone)]
+#[derive(Component, Debug, Default, Clone)]
 #[require(AccessibilityNode(accesskit::Node::new(Role::CheckBox)), Checkable)]
 pub struct Checkbox;
 

--- a/crates/bevy_ui_widgets/src/menu.rs
+++ b/crates/bevy_ui_widgets/src/menu.rs
@@ -40,7 +40,6 @@ use bevy_ecs::{
     query::{Has, With},
     schedule::IntoScheduleConfigs,
     system::{Commands, Query, Res, ResMut},
-    template::FromTemplate,
 };
 use bevy_input::{
     keyboard::{KeyCode, KeyboardInput},
@@ -111,7 +110,7 @@ pub enum MenuLayout {
 /// Some care needs to be taken in implementing a menu button: we normally want menu buttons to
 /// toggle the open state of the menu; but clicking on the button will cause focus loss which means
 /// that the menu will always be closed by the time the click event is processed.
-#[derive(Component, FromTemplate, Debug, Default, Clone)]
+#[derive(Component, Debug, Default, Clone)]
 #[require(
     AccessibilityNode(accesskit::Node::new(Role::MenuListPopup)),
     TabGroup::modal()
@@ -123,7 +122,7 @@ pub struct MenuPopup {
 }
 
 /// Component that defines a menu item.
-#[derive(Component, FromTemplate, Debug, Clone, Default)]
+#[derive(Component, Debug, Clone, Default)]
 #[require(AccessibilityNode(accesskit::Node::new(Role::MenuItem)))]
 pub struct MenuItem;
 
@@ -398,7 +397,7 @@ fn menu_item_on_pointer_cancel(
 
 /// Headless menu button widget. This is meant to be combined with the `Button` component, and
 /// adds a few more key codes - arrow keys to open the popup.
-#[derive(Component, FromTemplate, Default, Debug, Clone)]
+#[derive(Component, Default, Debug, Clone)]
 #[require(
     AccessibilityNode(accesskit::Node::new(Role::Button)),
     Button,

--- a/crates/bevy_ui_widgets/src/radio.rs
+++ b/crates/bevy_ui_widgets/src/radio.rs
@@ -9,7 +9,6 @@ use bevy_ecs::{
     query::{Has, With, Without},
     reflect::ReflectComponent,
     system::{Commands, Query},
-    template::FromTemplate,
 };
 use bevy_input::keyboard::{KeyCode, KeyboardInput};
 use bevy_input::ButtonState;
@@ -36,7 +35,7 @@ use crate::{ActivateOnPress, ValueChange};
 /// associated with a particular constant value, and would be checked whenever that value is equal
 /// to the group's value. This also means that as long as each button's associated value is unique
 /// within the group, it should never be the case that more than one button is selected at a time.
-#[derive(Component, FromTemplate, Debug, Clone, Default)]
+#[derive(Component, Debug, Clone, Default)]
 #[require(AccessibilityNode(accesskit::Node::new(Role::RadioGroup)))]
 pub struct RadioGroup;
 
@@ -52,7 +51,7 @@ pub struct RadioGroup;
 /// either through a mouse click or when a [`RadioGroup`] checks the widget.
 /// If the [`RadioButton`] is focusable, it can also be checked using the `Enter` or `Space` keys,
 /// in which case the event will likewise be emitted.
-#[derive(Component, FromTemplate, Debug, Clone, Default)]
+#[derive(Component, Debug, Clone, Default)]
 #[require(AccessibilityNode(accesskit::Node::new(Role::RadioButton)), Checkable)]
 #[derive(Reflect)]
 #[reflect(Component)]

--- a/crates/bevy_ui_widgets/src/slider.rs
+++ b/crates/bevy_ui_widgets/src/slider.rs
@@ -8,7 +8,6 @@ use bevy_ecs::hierarchy::Children;
 use bevy_ecs::lifecycle::Insert;
 use bevy_ecs::query::Has;
 use bevy_ecs::system::Res;
-use bevy_ecs::template::FromTemplate;
 use bevy_ecs::world::DeferredWorld;
 use bevy_ecs::{
     component::Component,
@@ -93,7 +92,7 @@ pub enum TrackClick {
 ///
 /// In cases where overhang is desired for artistic reasons, the thumb may have additional
 /// decorative child elements, absolutely positioned, which don't affect the size measurement.
-#[derive(Component, FromTemplate, Debug, Default, Clone)]
+#[derive(Component, Debug, Default, Clone)]
 #[require(
     AccessibilityNode(accesskit::Node::new(Role::Slider)),
     CoreSliderDragState,
@@ -109,7 +108,7 @@ pub struct Slider {
 }
 
 /// Marker component that identifies which descendant element is the slider thumb.
-#[derive(Component, FromTemplate, Debug, Default, Clone)]
+#[derive(Component, Debug, Default, Clone)]
 pub struct SliderThumb;
 
 /// A component which stores the current value of the slider.
@@ -224,7 +223,7 @@ impl Default for SliderStep {
 /// The value in this component represents the number of decimal places of desired precision, so a
 /// value of 2 would round to the nearest 1/100th. A value of -3 would round to the nearest
 /// thousand.
-#[derive(Component, FromTemplate, Debug, Default, Clone, Copy, Reflect)]
+#[derive(Component, Debug, Default, Clone, Copy, Reflect)]
 #[reflect(Component, Default)]
 pub struct SliderPrecision(pub i32);
 


### PR DESCRIPTION
# Objective / Solution

- Revert most of #23924

Manual FromTemplate derives are unnecessary for anything that doesn't require custom template logic. Letting a type be a template for itself is less confusing, has fewer corner cases, and does less codegen.

The rule of thumb to follow is "Use `Default + Clone` for anything that doesn't need custom template logic". In the case of #23924, the only type that needs custom template logic is `Scrollbar`, because it has the `target: Entity` field, which benefits from having an "entity template".
