### PR TITLE
Rename EntityReference to EntityTemplate

### DIFF
--- a/crates/bevy_ecs/src/template.rs
+++ b/crates/bevy_ecs/src/template.rs
@@ -402,7 +402,7 @@ impl<T: Clone + Default + Unpin> FromTemplate for T {
 pub trait SpecializeFromTemplate: Sized {}
 
 /// A [`Template`] reference to an [`Entity`].
-pub enum EntityReference {
+pub enum EntityTemplate {
     /// A reference to a specific [`Entity`]
     Entity(Entity),
     /// A reference to an entity via a [`ScopedEntityIndex`]
@@ -423,19 +423,19 @@ pub struct ScopedEntityIndex {
     pub index: usize,
 }
 
-impl Default for EntityReference {
+impl Default for EntityTemplate {
     fn default() -> Self {
         Self::ScopedEntityIndex(ScopedEntityIndex { scope: 0, index: 0 })
     }
 }
 
-impl From<Entity> for EntityReference {
+impl From<Entity> for EntityTemplate {
     fn from(entity: Entity) -> Self {
         Self::Entity(entity)
     }
 }
 
-impl Template for EntityReference {
+impl Template for EntityTemplate {
     type Output = Entity;
 
     fn build_template(&self, context: &mut TemplateContext) -> Result<Self::Output> {
@@ -458,7 +458,7 @@ impl Template for EntityReference {
 }
 
 impl FromTemplate for Entity {
-    type Template = EntityReference;
+    type Template = EntityTemplate;
 }
 
 /// A [`Template`] driven by a function that returns an output. This is used to create "free floating" templates without

--- a/crates/bevy_scene/macros/src/bsn/codegen.rs
+++ b/crates/bevy_scene/macros/src/bsn/codegen.rs
@@ -432,7 +432,7 @@ impl BsnType {
                 let index = ctx.entity_refs.get(ident.to_string());
                 let bevy_ecs = ctx.bevy_ecs;
                 assignments.push(quote! {
-                    #(#base_path.)*#member = #bevy_ecs::template::EntityReference::ScopedEntityIndex(
+                    #(#base_path.)*#member = #bevy_ecs::template::EntityTemplate::ScopedEntityIndex(
                         #bevy_ecs::template::ScopedEntityIndex {
                             scope: _context.current_entity_scope(), index: #index
                         }


### PR DESCRIPTION
# Objective

`EntityReference` is a template, but it doesn't follow standard naming conventions. `EntityTemplate` follows conventions and is much more self-documenting / instructive.

## Solution

- Rename `EntityReference` to `EntityTemplate`