### PR TITLE
Add different color for unfocused selected editable text

### DIFF
--- a/crates/bevy_feathers/src/controls/text_input.rs
+++ b/crates/bevy_feathers/src/controls/text_input.rs
@@ -132,6 +132,8 @@ fn update_text_cursor_color(
         for mut cursor_style in q_text_input.iter_mut() {
             cursor_style.color = theme.color(&tokens::TEXT_INPUT_CURSOR);
             cursor_style.selection_color = theme.color(&tokens::TEXT_INPUT_SELECTION);
+            cursor_style.unfocused_selection_color =
+                theme.color(&tokens::TEXT_INPUT_SELECTION_UNFOCUSED);
         }
     }
 }

--- a/crates/bevy_feathers/src/dark_theme.rs
+++ b/crates/bevy_feathers/src/dark_theme.rs
@@ -259,6 +259,7 @@ pub fn create_dark_theme() -> ThemeProps {
             ),
             (tokens::TEXT_INPUT_CURSOR, palette::ACCENT.lighter(0.2)),
             (tokens::TEXT_INPUT_SELECTION, palette::ACCENT),
+            (tokens::TEXT_INPUT_SELECTION, palette::ACCENT.lighter(0.2)),
             (tokens::TEXT_INPUT_X_AXIS, palette::X_AXIS),
             (tokens::TEXT_INPUT_Y_AXIS, palette::Y_AXIS),
             (tokens::TEXT_INPUT_Z_AXIS, palette::Z_AXIS),

--- a/crates/bevy_feathers/src/dark_theme.rs
+++ b/crates/bevy_feathers/src/dark_theme.rs
@@ -259,7 +259,10 @@ pub fn create_dark_theme() -> ThemeProps {
             ),
             (tokens::TEXT_INPUT_CURSOR, palette::ACCENT.lighter(0.2)),
             (tokens::TEXT_INPUT_SELECTION, palette::ACCENT),
-            (tokens::TEXT_INPUT_SELECTION_UNFOCUSED, palette::ACCENT.lighter(0.2)),
+            (
+                tokens::TEXT_INPUT_SELECTION_UNFOCUSED,
+                palette::ACCENT.lighter(0.2),
+            ),
             (tokens::TEXT_INPUT_X_AXIS, palette::X_AXIS),
             (tokens::TEXT_INPUT_Y_AXIS, palette::Y_AXIS),
             (tokens::TEXT_INPUT_Z_AXIS, palette::Z_AXIS),

--- a/crates/bevy_feathers/src/dark_theme.rs
+++ b/crates/bevy_feathers/src/dark_theme.rs
@@ -259,7 +259,7 @@ pub fn create_dark_theme() -> ThemeProps {
             ),
             (tokens::TEXT_INPUT_CURSOR, palette::ACCENT.lighter(0.2)),
             (tokens::TEXT_INPUT_SELECTION, palette::ACCENT),
-            (tokens::TEXT_INPUT_SELECTION, palette::ACCENT.lighter(0.2)),
+            (tokens::TEXT_INPUT_SELECTION_UNFOCUSED, palette::ACCENT.lighter(0.2)),
             (tokens::TEXT_INPUT_X_AXIS, palette::X_AXIS),
             (tokens::TEXT_INPUT_Y_AXIS, palette::Y_AXIS),
             (tokens::TEXT_INPUT_Z_AXIS, palette::Z_AXIS),

--- a/crates/bevy_feathers/src/tokens.rs
+++ b/crates/bevy_feathers/src/tokens.rs
@@ -319,6 +319,9 @@ pub const TEXT_INPUT_TEXT_DISABLED: ThemeToken =
 pub const TEXT_INPUT_CURSOR: ThemeToken = ThemeToken::new_static("feathers.textinput.cursor");
 /// Selection color for text input
 pub const TEXT_INPUT_SELECTION: ThemeToken = ThemeToken::new_static("feathers.textinput.selection");
+/// Selection color for unfocused text input
+pub const TEXT_INPUT_SELECTION_UNFOCUSED: ThemeToken =
+    ThemeToken::new_static("feathers.textinput.selection.unfocused");
 /// Background color for label text
 pub const TEXT_INPUT_LABEL_BG: ThemeToken = ThemeToken::new_static("feathers.textinput.label.bg");
 /// Sigil color for X

--- a/crates/bevy_text/src/cursor.rs
+++ b/crates/bevy_text/src/cursor.rs
@@ -1,5 +1,5 @@
 use bevy_color::{
-    palettes::css::{GREEN, RED},
+    palettes::css::{BLUE, GREEN, RED},
     Color,
 };
 use bevy_ecs::component::Component;
@@ -16,6 +16,8 @@ pub struct TextCursorStyle {
     pub color: Color,
     /// Background color of selected text
     pub selection_color: Color,
+    /// Background color of unfocused selected text
+    pub unfocused_selection_color: Color,
     /// If some, overrides the color of selected text
     pub selected_text_color: Option<Color>,
 }
@@ -25,6 +27,7 @@ impl Default for TextCursorStyle {
         Self {
             color: RED.into(),
             selection_color: Color::from(GREEN),
+            unfocused_selection_color: Color::from(BLUE),
             selected_text_color: None,
         }
     }

--- a/crates/bevy_ui_render/Cargo.toml
+++ b/crates/bevy_ui_render/Cargo.toml
@@ -18,6 +18,7 @@ bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.19.0-dev" }
 bevy_derive = { path = "../bevy_derive", version = "0.19.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.19.0-dev" }
 bevy_image = { path = "../bevy_image", version = "0.19.0-dev" }
+bevy_input_focus = { path = "../bevy_input_focus", version = "0.19.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.19.0-dev" }
 bevy_mesh = { path = "../bevy_mesh", version = "0.19.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev" }

--- a/crates/bevy_ui_render/src/text.rs
+++ b/crates/bevy_ui_render/src/text.rs
@@ -2,6 +2,7 @@ use bevy_asset::AssetId;
 use bevy_camera::visibility::InheritedVisibility;
 use bevy_color::Alpha;
 use bevy_ecs::prelude::*;
+use bevy_input_focus::InputFocus;
 use bevy_math::{Affine2, Rect, Vec2};
 use bevy_render::{sync_world::TemporaryRenderEntity, Extract};
 use bevy_sprite::BorderRect;
@@ -33,6 +34,7 @@ pub fn extract_text_cursor(
         )>,
     >,
     camera_map: Extract<UiCameraMap>,
+    input_focus: Extract<Option<Res<InputFocus>>>,
 ) {
     let mut camera_mapper = camera_map.get_mapper();
 
@@ -74,10 +76,22 @@ pub fn extract_text_cursor(
             maybe_clip.map(|clip| clip.clip)
         };
 
-        if !text_layout_info.selection_rects.is_empty()
-            && !cursor_style.selection_color.is_fully_transparent()
+        let mut focused = false;
+
+        if let Some(input_focus) = input_focus.as_ref()
+            && Some(entity) == input_focus.get()
         {
-            let selection_color = cursor_style.selection_color.to_linear();
+            focused = true;
+        }
+
+        let sc = if focused {
+            cursor_style.selection_color
+        } else {
+            cursor_style.unfocused_selection_color
+        };
+
+        if !text_layout_info.selection_rects.is_empty() && !sc.is_fully_transparent() {
+            let selection_color = sc.to_linear();
 
             for selection in text_layout_info.selection_rects.iter() {
                 extracted_uinodes.uinodes.push(ExtractedUiNode {


### PR DESCRIPTION
# Objective

- Closes #23889

## Solution

- Added `unfocused_selection_color: Color` to `TextCursorStyle`

## Testing

- `cargo run --example multiple_text_inputs`

<img width="517" height="399" alt="Screenshot 2026-04-23 at 10 07 43 pm" src="https://github.com/user-attachments/assets/e68d7ce0-8545-4870-b67d-5c795fab6462" />

- `cargo run --example feathers_gallery --features="experimental_bevy_feathers"`

<img width="261" height="123" alt="Screenshot 2026-04-23 at 10 11 46 pm" src="https://github.com/user-attachments/assets/d2ec6994-afa4-4915-9645-99e1464439d4" />
