### PR TITLE
Use a local TBN in the solari BRDF

### DIFF
--- a/crates/bevy_solari/src/pathtracer/pathtracer.wgsl
+++ b/crates/bevy_solari/src/pathtracer/pathtracer.wgsl
@@ -71,7 +71,7 @@ fn pathtrace(@builtin(global_invocation_id) global_id: vec3<u32>) {
             }
 
             // Sample new ray direction from the material BRDF for next bounce and apply BRDF
-            let next_bounce = evaluate_and_sample_brdf(wo, ray_hit.world_normal, ray_hit.world_tangent, ray_hit.material, &rng);
+            let next_bounce = evaluate_and_sample_brdf(wo, ray_hit.world_normal, ray_hit.material, &rng);
             if next_bounce.pdf == 0.0 { break; }
             ray_direction = next_bounce.wi;
             ray_origin = ray_hit.world_position + (ray_hit.geometric_world_normal * RAY_T_MIN);

--- a/crates/bevy_solari/src/pathtracer/pathtracer.wgsl
+++ b/crates/bevy_solari/src/pathtracer/pathtracer.wgsl
@@ -1,9 +1,9 @@
 enable wgpu_ray_query;
 
 #import bevy_core_pipeline::tonemapping::tonemapping_luminance as luminance
-#import bevy_pbr::pbr_functions::{calculate_tbn_mikktspace, calculate_F0}
+#import bevy_pbr::pbr_functions::calculate_F0
 #import bevy_pbr::utils::{rand_f, rand_vec2f}
-#import bevy_render::maths::PI
+#import bevy_render::maths::{PI, orthonormalize}
 #import bevy_render::view::View
 #import bevy_solari::brdf::{evaluate_brdf, evaluate_and_sample_brdf, fresnel}
 #import bevy_solari::sampling::{sample_random_light, random_emissive_light_pdf, ggx_vndf_pdf, power_heuristic}
@@ -103,7 +103,7 @@ fn brdf_pdf(wo: vec3<f32>, wi: vec3<f32>, ray_hit: ResolvedRayHitFull) -> f32 {
     let diffuse_weight = mix(df, 0.0, ray_hit.material.metallic);
     let specular_weight = 1.0 - diffuse_weight;
 
-    let TBN = calculate_tbn_mikktspace(ray_hit.world_normal, ray_hit.world_tangent);
+    let TBN = orthonormalize(ray_hit.world_normal);
     let T = TBN[0];
     let B = TBN[1];
     let N = TBN[2];

--- a/crates/bevy_solari/src/realtime/specular_gi.wgsl
+++ b/crates/bevy_solari/src/realtime/specular_gi.wgsl
@@ -3,7 +3,7 @@ enable wgpu_ray_query;
 #define_import_path bevy_solari::specular_gi
 
 #import bevy_core_pipeline::tonemapping::tonemapping_luminance as luminance
-#import bevy_pbr::pbr_functions::{calculate_tbn_mikktspace, calculate_diffuse_color, calculate_F0}
+#import bevy_pbr::pbr_functions::{calculate_diffuse_color, calculate_F0}
 #import bevy_pbr::utils::rand_f
 #import bevy_render::maths::{orthonormalize, PI}
 #import bevy_render::view::View
@@ -100,7 +100,7 @@ fn trace_glossy_path(pixel_id: vec2<u32>, primary_surface: ResolvedGPixel, initi
         if ray.kind == RAY_QUERY_INTERSECTION_NONE { break; }
         let ray_hit = resolve_ray_hit_full(ray);
 
-        let TBN = calculate_tbn_mikktspace(ray_hit.world_normal, ray_hit.world_tangent);
+        let TBN = orthonormalize(ray_hit.world_normal);
         let T = TBN[0];
         let B = TBN[1];
         let N = TBN[2];

--- a/crates/bevy_solari/src/scene/brdf.wgsl
+++ b/crates/bevy_solari/src/scene/brdf.wgsl
@@ -6,7 +6,7 @@ enable wgpu_ray_query;
 #import bevy_pbr::lighting::{D_GGX, V_SmithGGXCorrelated, specular_multiscatter}
 #import bevy_pbr::pbr_functions::{calculate_tbn_mikktspace, calculate_diffuse_color, calculate_F0}
 #import bevy_pbr::utils::{rand_f, sample_cosine_hemisphere}
-#import bevy_render::maths::PI
+#import bevy_render::maths::{PI, orthonormalize}
 #import bevy_solari::sampling::{sample_ggx_vndf, ggx_vndf_pdf, ggx_vndf_sample_invalid}
 #import bevy_solari::scene_bindings::{ResolvedMaterial, MIRROR_ROUGHNESS_THRESHOLD, brdf_dfg_lut, brdf_dfg_lut_sampler}
 
@@ -19,7 +19,6 @@ struct EvaluateAndSampleBrdfResult {
 fn evaluate_and_sample_brdf(
     wo: vec3<f32>,
     world_normal: vec3<f32>,
-    world_tangent: vec4<f32>,
     material: ResolvedMaterial,
     rng: ptr<function, u32>,
 ) -> EvaluateAndSampleBrdfResult {
@@ -31,7 +30,7 @@ fn evaluate_and_sample_brdf(
     let diffuse_weight = mix(df, 0.0, material.metallic);
     let specular_weight = 1.0 - diffuse_weight;
 
-    let TBN = calculate_tbn_mikktspace(world_normal, world_tangent);
+    let TBN = orthonormalize(world_normal);
     let T = TBN[0];
     let B = TBN[1];
     let N = TBN[2];

--- a/crates/bevy_solari/src/scene/brdf.wgsl
+++ b/crates/bevy_solari/src/scene/brdf.wgsl
@@ -4,7 +4,7 @@ enable wgpu_ray_query;
 
 #import bevy_core_pipeline::tonemapping::tonemapping_luminance as luminance
 #import bevy_pbr::lighting::{D_GGX, V_SmithGGXCorrelated, specular_multiscatter}
-#import bevy_pbr::pbr_functions::{calculate_tbn_mikktspace, calculate_diffuse_color, calculate_F0}
+#import bevy_pbr::pbr_functions::{calculate_diffuse_color, calculate_F0}
 #import bevy_pbr::utils::{rand_f, sample_cosine_hemisphere}
 #import bevy_render::maths::{PI, orthonormalize}
 #import bevy_solari::sampling::{sample_ggx_vndf, ggx_vndf_pdf, ggx_vndf_sample_invalid}


### PR DESCRIPTION
# Objective
BRDF fixes for solari. Split off from #23818.

## Solution

Use a local TBN instead of mikktspace, which was producing seams on the spheres used for the white furnace test.

## Testing
On main:
<img width="1920" height="1013" alt="1_main_F_AB" src="https://github.com/user-attachments/assets/c05acf43-faa1-4128-9cdc-807ed2364518" />

This PR:
<img width="1920" height="1013" alt="2_proper_tbn" src="https://github.com/user-attachments/assets/7230e9d9-02ec-4435-8d74-1b7b7a314e27" />
