### PR TITLE
Fix Motion Blur for WebGL2

### DIFF
--- a/crates/bevy_core_pipeline/src/core_3d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/mod.rs
@@ -6,23 +6,29 @@ pub const CORE_3D_DEPTH_FORMAT: TextureFormat = TextureFormat::Depth32Float;
 
 /// True if multisampled depth textures are supported on this platform.
 ///
-/// In theory, Naga supports depth textures on WebGL 2. In practice, it doesn't,
-/// because of a silly bug whereby Naga assumes that all depth textures are
-/// `sampler2DShadow` and will cheerfully generate invalid GLSL that tries to
-/// perform non-percentage-closer-filtering with such a sampler. Therefore we
-/// disable depth of field and screen space reflections entirely on WebGL 2.
+/// WebGL 2:
+/// - doesn't support `copy_texture_to_texture` for depth textures yet, thus it doesn't support `DepthPrepass`.
+/// - doesn't support creating multisampled textures if they are not pure `RENDER_ATTACHMENT`,
+///   so it doesn't support Msaa when reading `ViewDepthTexture`.
+/// - shadow sampler `texture_depth_2d` doesn't support sampling, only supports comparison.
+///
+/// To read depth texture on WebGL 2, we can only use `ViewDepthTexture` with `Msaa::Off` and bind depth texture as unfilterable `texture_2d<f32>`.
+/// Therefore we disable depth of field and screen space reflections entirely on WebGL 2.
 #[cfg(not(any(feature = "webgpu", not(target_arch = "wasm32"))))]
-pub const DEPTH_TEXTURE_SAMPLING_SUPPORTED: bool = false;
+pub const DEPTH_PREPASS_TEXTURE_SUPPORTED: bool = false;
 
 /// True if multisampled depth textures are supported on this platform.
 ///
-/// In theory, Naga supports depth textures on WebGL 2. In practice, it doesn't,
-/// because of a silly bug whereby Naga assumes that all depth textures are
-/// `sampler2DShadow` and will cheerfully generate invalid GLSL that tries to
-/// perform non-percentage-closer-filtering with such a sampler. Therefore we
-/// disable depth of field and screen space reflections entirely on WebGL 2.
+/// WebGL 2:
+/// - doesn't support `copy_texture_to_texture` for depth textures yet, thus it doesn't support `DepthPrepass`.
+/// - doesn't support creating multisampled textures if they are not pure `RENDER_ATTACHMENT`,
+///   so it doesn't support Msaa when reading `ViewDepthTexture`.
+/// - shadow sampler `texture_depth_2d` doesn't support sampling, only supports comparison.
+///
+/// To read depth texture on WebGL 2, we can only use `ViewDepthTexture` with `Msaa::Off` and bind depth texture as unfilterable `texture_2d<f32>`.
+/// Therefore we disable depth of field and screen space reflections entirely on WebGL 2.
 #[cfg(any(feature = "webgpu", not(target_arch = "wasm32")))]
-pub const DEPTH_TEXTURE_SAMPLING_SUPPORTED: bool = true;
+pub const DEPTH_PREPASS_TEXTURE_SUPPORTED: bool = true;
 
 use core::{f32, ops::Range};
 

--- a/crates/bevy_core_pipeline/src/prepass/node.rs
+++ b/crates/bevy_core_pipeline/src/prepass/node.rs
@@ -253,6 +253,7 @@ fn run_prepass_system(
     if deferred_prepass.is_none()
         && let Some(prepass_depth_texture) = &view_prepass_textures.depth
     {
+        // TODO: Copy depth texture fails for WebGL2, https://github.com/bevyengine/bevy/issues/9710
         ctx.command_encoder().copy_texture_to_texture(
             view_depth_texture.texture.as_image_copy(),
             prepass_depth_texture.texture.texture.as_image_copy(),

--- a/crates/bevy_pbr/src/ssr/mod.rs
+++ b/crates/bevy_pbr/src/ssr/mod.rs
@@ -5,7 +5,7 @@ use core::ops::Range;
 use bevy_app::{App, Plugin};
 use bevy_asset::{load_embedded_asset, AssetServer, Handle};
 use bevy_core_pipeline::{
-    core_3d::{main_opaque_pass_3d, DEPTH_TEXTURE_SAMPLING_SUPPORTED},
+    core_3d::{main_opaque_pass_3d, DEPTH_PREPASS_TEXTURE_SUPPORTED},
     prepass::{DeferredPrepass, DepthPrepass, MotionVectorPrepass, NormalPrepass},
     schedule::{Core3d, Core3dSystems},
     FullscreenShader,
@@ -528,7 +528,7 @@ impl ExtractComponent for ScreenSpaceReflections {
     type Out = ScreenSpaceReflectionsUniform;
 
     fn extract_component(settings: QueryItem<'_, '_, Self::QueryData>) -> Option<Self::Out> {
-        if !DEPTH_TEXTURE_SAMPLING_SUPPORTED {
+        if !DEPTH_PREPASS_TEXTURE_SUPPORTED {
             once!(info!(
                 "Disabling screen-space reflections on this platform because depth textures \
                 aren't supported correctly"

--- a/crates/bevy_post_process/src/dof/mod.rs
+++ b/crates/bevy_post_process/src/dof/mod.rs
@@ -60,7 +60,7 @@ use tracing::{info, warn};
 
 use crate::bloom::bloom;
 use bevy_core_pipeline::{
-    core_3d::DEPTH_TEXTURE_SAMPLING_SUPPORTED, schedule::Core3d, tonemapping::tonemapping,
+    core_3d::DEPTH_PREPASS_TEXTURE_SUPPORTED, schedule::Core3d, tonemapping::tonemapping,
     FullscreenShader,
 };
 
@@ -667,7 +667,7 @@ fn extract_depth_of_field_settings(
     mut commands: Commands,
     mut query: Extract<Query<(RenderEntity, &DepthOfField, &Projection)>>,
 ) {
-    if !DEPTH_TEXTURE_SAMPLING_SUPPORTED {
+    if !DEPTH_PREPASS_TEXTURE_SUPPORTED {
         once!(info!(
             "Disabling depth of field on this platform because depth textures aren't supported correctly"
         ));

--- a/crates/bevy_post_process/src/motion_blur/mod.rs
+++ b/crates/bevy_post_process/src/motion_blur/mod.rs
@@ -8,9 +8,9 @@ use crate::{
 };
 use bevy_app::{App, Plugin};
 use bevy_asset::embedded_asset;
-use bevy_camera::Camera;
+use bevy_camera::{Camera, Camera3d};
 use bevy_core_pipeline::{
-    prepass::{DepthPrepass, MotionVectorPrepass, ViewPrepassTextures},
+    prepass::{MotionVectorPrepass, ViewPrepassTextures},
     schedule::{Core3d, Core3dSystems},
 };
 use bevy_ecs::{
@@ -18,7 +18,7 @@ use bevy_ecs::{
     query::{QueryItem, With},
     reflect::ReflectComponent,
     schedule::IntoScheduleConfigs,
-    system::Res,
+    system::{Query, Res},
 };
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{
@@ -28,12 +28,12 @@ use bevy_render::{
     },
     globals::GlobalsBuffer,
     render_resource::{
-        BindGroupEntries, Operations, PipelineCache, RenderPassColorAttachment,
-        RenderPassDescriptor, ShaderType, SpecializedRenderPipelines,
+        BindGroupEntries, LoadOp, Operations, PipelineCache, RenderPassColorAttachment,
+        RenderPassDescriptor, ShaderType, SpecializedRenderPipelines, StoreOp, TextureUsages,
     },
     renderer::{RenderContext, ViewQuery},
     sync_component::SyncComponent,
-    view::{Msaa, ViewTarget},
+    view::{prepare_view_targets, Msaa, ViewDepthTexture, ViewTarget},
     GpuResourceAppExt, Render, RenderApp, RenderStartup, RenderSystems,
 };
 
@@ -72,7 +72,7 @@ pub mod pipeline;
 /// ````
 #[derive(Reflect, Component, Clone)]
 #[reflect(Component, Default, Clone)]
-#[require(DepthPrepass, MotionVectorPrepass)]
+#[require(MotionVectorPrepass)]
 pub struct MotionBlur {
     /// The strength of motion blur from `0.0` to `1.0`.
     ///
@@ -165,7 +165,13 @@ impl Plugin for MotionBlurPlugin {
             .add_systems(RenderStartup, pipeline::init_motion_blur_pipeline)
             .add_systems(
                 Render,
-                pipeline::prepare_motion_blur_pipelines.in_set(RenderSystems::Prepare),
+                (
+                    pipeline::prepare_motion_blur_pipelines.in_set(RenderSystems::Prepare),
+                    prepare_view_depth_texture_usages_for_motion_blur
+                        .in_set(RenderSystems::PrepareViews)
+                        .after(prepare_view_targets)
+                        .ambiguous_with_all(),
+                ),
             );
 
         render_app.add_systems(
@@ -180,6 +186,7 @@ pub fn motion_blur(
         &ViewTarget,
         &MotionBlurPipelineId,
         &ViewPrepassTextures,
+        &ViewDepthTexture,
         &MotionBlurUniform,
         &Msaa,
     )>,
@@ -189,7 +196,8 @@ pub fn motion_blur(
     globals_buffer: Res<GlobalsBuffer>,
     mut ctx: RenderContext,
 ) {
-    let (view_target, pipeline_id, prepass_textures, motion_blur_uniform, msaa) = view.into_inner();
+    let (view_target, pipeline_id, prepass_textures, depth, motion_blur_uniform, msaa) =
+        view.into_inner();
 
     if motion_blur_uniform.samples == 0 || motion_blur_uniform.shutter_angle <= 0.0 {
         return; // We can skip running motion blur in these cases.
@@ -202,9 +210,7 @@ pub fn motion_blur(
     let Some(settings_binding) = settings_uniforms.uniforms().binding() else {
         return;
     };
-    let (Some(prepass_motion_vectors_texture), Some(prepass_depth_texture)) =
-        (&prepass_textures.motion_vectors, &prepass_textures.depth)
-    else {
+    let Some(prepass_motion_vectors_texture) = &prepass_textures.motion_vectors else {
         return;
     };
     let Some(globals_uniforms) = globals_buffer.buffer.binding() else {
@@ -225,7 +231,7 @@ pub fn motion_blur(
         &BindGroupEntries::sequential((
             post_process.source,
             &prepass_motion_vectors_texture.texture.default_view,
-            &prepass_depth_texture.texture.default_view,
+            depth.view(),
             &motion_blur_pipeline.sampler,
             settings_binding.clone(),
             globals_uniforms.clone(),
@@ -241,7 +247,10 @@ pub fn motion_blur(
             view: post_process.destination,
             depth_slice: None,
             resolve_target: None,
-            ops: Operations::default(),
+            ops: Operations {
+                load: LoadOp::Clear(Default::default()),
+                store: StoreOp::Store,
+            },
         })],
         depth_stencil_attachment: None,
         timestamp_writes: None,
@@ -255,4 +264,12 @@ pub fn motion_blur(
     render_pass.draw(0..3, 0..1);
 
     pass_span.end(&mut render_pass);
+}
+
+fn prepare_view_depth_texture_usages_for_motion_blur(
+    mut view_targets: Query<&mut Camera3d, With<MotionBlurUniform>>,
+) {
+    for mut camera in view_targets.iter_mut() {
+        camera.depth_texture_usages.0 |= TextureUsages::TEXTURE_BINDING.bits();
+    }
 }

--- a/crates/bevy_post_process/src/motion_blur/motion_blur.wgsl
+++ b/crates/bevy_post_process/src/motion_blur/motion_blur.wgsl
@@ -6,11 +6,11 @@
 #ifdef MULTISAMPLED
 @group(0) @binding(0) var screen_texture: texture_2d<f32>;
 @group(0) @binding(1) var motion_vectors: texture_multisampled_2d<f32>;
-@group(0) @binding(2) var depth: texture_depth_multisampled_2d;
+@group(0) @binding(2) var depth: texture_multisampled_2d<f32>;
 #else
 @group(0) @binding(0) var screen_texture: texture_2d<f32>;
 @group(0) @binding(1) var motion_vectors: texture_2d<f32>;
-@group(0) @binding(2) var depth: texture_depth_2d;
+@group(0) @binding(2) var depth: texture_2d<f32>;
 #endif
 @group(0) @binding(3) var texture_sampler: sampler;
 struct MotionBlur {
@@ -30,7 +30,7 @@ fn fragment(
         @builtin(sample_index) sample_index: u32,
     #endif
     in: FullscreenVertexOutput
-) -> @location(0) vec4<f32> { 
+) -> @location(0) vec4<f32> {
     let texture_size = vec2<f32>(textureDimensions(screen_texture));
     let frag_coords = vec2<i32>(in.uv * texture_size);
 
@@ -48,16 +48,10 @@ fn fragment(
     let this_motion_vector = textureSample(motion_vectors, texture_sampler, in.uv).rg;
 #endif
 
-#ifdef NO_DEPTH_TEXTURE_SUPPORT
-    let this_depth = 0.0;
-    let depth_supported = false;
-#else
-    let depth_supported = true;
 #ifdef MULTISAMPLED
-    let this_depth = textureLoad(depth, frag_coords, i32(sample_index));
+    let this_depth = textureLoad(depth, frag_coords, i32(sample_index)).x;
 #else
-    let this_depth = textureSample(depth, texture_sampler, in.uv);
-#endif
+    let this_depth = textureLoad(depth, frag_coords, 0).x;
 #endif
     
     // The exposure vector is the distance that this fragment moved while the camera shutter was
@@ -74,7 +68,7 @@ fn fragment(
     var weight_total = 0.0;
     let n_samples = i32(settings.samples);
     let noise = utils::interleaved_gradient_noise(vec2<f32>(frag_coords), globals.frame_count); // 0 to 1
-       
+
     for (var i = -n_samples; i < n_samples; i++) {
         // The current sample step vector, from in.uv
         let step_vector = 0.5 * exposure_vector * (f32(i) + noise) / f32(n_samples);
@@ -97,18 +91,15 @@ fn fragment(
     #else
         let sample_motion = textureSample(motion_vectors, texture_sampler, sample_uv).rg;
     #endif
-    #ifdef NO_DEPTH_TEXTURE_SUPPORT
-        let sample_depth = 0.0;
-    #else
+
     #ifdef MULTISAMPLED
-        let sample_depth = textureLoad(depth, sample_coords, i32(sample_index));
+        let sample_depth = textureLoad(depth, sample_coords, i32(sample_index)).x;
     #else
-        let sample_depth = textureSample(depth, texture_sampler, sample_uv);
-    #endif
+        let sample_depth = textureLoad(depth, sample_coords, 0).x;
     #endif
 
         var weight = 1.0;
-        let is_sample_in_fg = !(depth_supported && sample_depth < this_depth && sample_depth > 0.0);
+        let is_sample_in_fg = !(sample_depth < this_depth && sample_depth > 0.0);
         // If the depth is 0.0, this fragment has no depth written to it and we assume it is in the
         // background. This ensures that things like skyboxes, which do not write to depth, are
         // correctly sampled in motion blur.
@@ -146,7 +137,7 @@ fn fragment(
         accumulator += weight * sample_color;
     }
 
-    let has_moved_less_than_a_pixel = 
+    let has_moved_less_than_a_pixel =
         dot(this_motion_vector * texture_size, this_motion_vector * texture_size) < 1.0;
     // In case no samples were accepted, fall back to base color.
     // We also fall back if motion is small, to not break antialiasing.

--- a/crates/bevy_post_process/src/motion_blur/pipeline.rs
+++ b/crates/bevy_post_process/src/motion_blur/pipeline.rs
@@ -10,14 +10,12 @@ use bevy_ecs::{
 use bevy_render::{
     globals::GlobalsUniform,
     render_resource::{
-        binding_types::{
-            sampler, texture_2d, texture_2d_multisampled, texture_depth_2d,
-            texture_depth_2d_multisampled, uniform_buffer_sized,
-        },
+        binding_types::{sampler, texture_2d, texture_2d_multisampled, uniform_buffer_sized},
         BindGroupLayoutDescriptor, BindGroupLayoutEntries, CachedRenderPipelineId,
-        ColorTargetState, ColorWrites, FragmentState, PipelineCache, RenderPipelineDescriptor,
-        Sampler, SamplerBindingType, SamplerDescriptor, ShaderStages, ShaderType,
-        SpecializedRenderPipeline, SpecializedRenderPipelines, TextureFormat, TextureSampleType,
+        ColorTargetState, ColorWrites, FilterMode, FragmentState, PipelineCache,
+        RenderPipelineDescriptor, Sampler, SamplerBindingType, SamplerDescriptor, ShaderStages,
+        ShaderType, SpecializedRenderPipeline, SpecializedRenderPipelines, TextureFormat,
+        TextureSampleType,
     },
     renderer::RenderDevice,
     view::{ExtractedView, Msaa},
@@ -50,7 +48,7 @@ impl MotionBlurPipeline {
                 // Motion Vectors
                 texture_2d(TextureSampleType::Float { filterable: true }),
                 // Depth
-                texture_depth_2d(),
+                texture_2d(TextureSampleType::Float { filterable: false }),
                 // Linear Sampler
                 sampler(SamplerBindingType::Filtering),
                 // Motion blur settings uniform input
@@ -68,7 +66,7 @@ impl MotionBlurPipeline {
                 // Motion Vectors
                 texture_2d_multisampled(TextureSampleType::Float { filterable: false }),
                 // Depth
-                texture_depth_2d_multisampled(),
+                texture_2d_multisampled(TextureSampleType::Float { filterable: false }),
                 // Linear Sampler
                 sampler(SamplerBindingType::Filtering),
                 // Motion blur settings uniform input
@@ -78,7 +76,11 @@ impl MotionBlurPipeline {
             ),
         );
 
-        let sampler = render_device.create_sampler(&SamplerDescriptor::default());
+        let sampler = render_device.create_sampler(&SamplerDescriptor {
+            mag_filter: FilterMode::Linear,
+            min_filter: FilterMode::Linear,
+            ..Default::default()
+        });
         let layout = BindGroupLayoutDescriptor::new("motion_blur_layout", mb_layout);
         let layout_msaa = BindGroupLayoutDescriptor::new("motion_blur_layout_msaa", mb_layout_msaa);
 
@@ -130,7 +132,6 @@ impl SpecializedRenderPipeline for MotionBlurPipeline {
 
         #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
         {
-            shader_defs.push("NO_DEPTH_TEXTURE_SUPPORT".into());
             shader_defs.push("SIXTEEN_BYTE_ALIGNMENT".into());
         }
 


### PR DESCRIPTION
# Objective

- Fixes #23061 

## Solution
- Following @beicause ’s guidance and previous work in and around the issue, I just copied all of the relevant Motion Blur WebGL2 changes from their PR that fixes it (#22554) and tested that it still works. 
- WebGPU, as far as I can test on main, already works correctly, so this is strictly for WebGL2. I will say it *does* look a little different on WebGL2, but the motion blur is at least working in some capacity. WebGPU motion blur still looks the same after this change

This PR does *not* include the dof fixes that #22554 also contains.

## Testing

```
cargo build --release --example motion_blur --target wasm32-unknown-unknown
wasm-bindgen --out-name wasm_example \
  --out-dir examples/wasm/target \
  --target web target/wasm32-unknown-unknown/release/examples/motion_blur.wasm
```
And `basic-http-server examples/wasm` in Google Chrome works.
(Note that #23627 might affect your ability to run this example, so try to run it on Chrome if it’s available to you at least)

## Showcase

<details>
<summary>Video of Motion Blur Examples</summary>
WebGL2 (Chrome on Mac):

https://github.com/user-attachments/assets/081cd232-4c88-4d57-922c-cf3adbfc5f4f

WebGPU (Chrome on Mac):

https://github.com/user-attachments/assets/61452178-29f9-4d04-ba56-6b4485d23b14

</details>