### PR TITLE
Improve default colors for text_input widgets

### DIFF
--- a/crates/bevy_feathers/src/dark_theme.rs
+++ b/crates/bevy_feathers/src/dark_theme.rs
@@ -259,10 +259,7 @@ pub fn create_dark_theme() -> ThemeProps {
             ),
             (tokens::TEXT_INPUT_CURSOR, palette::ACCENT.lighter(0.2)),
             (tokens::TEXT_INPUT_SELECTION, palette::ACCENT),
-            (
-                tokens::TEXT_INPUT_SELECTION_UNFOCUSED,
-                palette::ACCENT.lighter(0.2),
-            ),
+            (tokens::TEXT_INPUT_SELECTION_UNFOCUSED, palette::TRANSPARENT),
             (tokens::TEXT_INPUT_X_AXIS, palette::X_AXIS),
             (tokens::TEXT_INPUT_Y_AXIS, palette::Y_AXIS),
             (tokens::TEXT_INPUT_Z_AXIS, palette::Z_AXIS),

--- a/crates/bevy_feathers/src/palette.rs
+++ b/crates/bevy_feathers/src/palette.rs
@@ -1,6 +1,8 @@
 //! The Feathers standard color palette.
 use bevy_color::Color;
 
+/// <div style="background-color: transparent; width: 10px; padding: 10px; border: 1px solid;"></div>
+pub const TRANSPARENT: Color = Color::oklcha(0.0, 0.0, 0.0, 0.0);
 /// <div style="background-color: #000000; width: 10px; padding: 10px; border: 1px solid;"></div>
 pub const BLACK: Color = Color::oklcha(0.0, 0.0, 0.0, 1.0);
 /// <div style="background-color: #1F1F24; width: 10px; padding: 10px; border: 1px solid;"></div> - window background

--- a/crates/bevy_text/src/cursor.rs
+++ b/crates/bevy_text/src/cursor.rs
@@ -1,5 +1,5 @@
 use bevy_color::{
-    palettes::css::{BLUE, GREEN, RED},
+    palettes::tailwind::{SKY_200, SLATE_200, SLATE_600},
     Color,
 };
 use bevy_ecs::component::Component;
@@ -25,9 +25,9 @@ pub struct TextCursorStyle {
 impl Default for TextCursorStyle {
     fn default() -> Self {
         Self {
-            color: RED.into(),
-            selection_color: Color::from(GREEN),
-            unfocused_selection_color: Color::from(BLUE),
+            color: Color::from(SLATE_600),
+            selection_color: Color::from(SKY_200),
+            unfocused_selection_color: Color::from(SLATE_200),
             selected_text_color: None,
         }
     }

--- a/crates/bevy_text/src/cursor.rs
+++ b/crates/bevy_text/src/cursor.rs
@@ -1,5 +1,5 @@
 use bevy_color::{
-    palettes::tailwind::{SLATE_400, SLATE_700},
+    palettes::tailwind::{SKY_300, SKY_400, SLATE_700},
     Color,
 };
 use bevy_ecs::component::Component;
@@ -18,9 +18,8 @@ pub struct TextCursorStyle {
     pub selection_color: Color,
     /// Background color of unfocused selected text
     ///
-    /// By default, this is completely transparent.
-    /// This is a common choice in many applications,
-    /// in order to reduce visual clutter.
+    /// In many applications, this is completely transparent.
+    /// This reduces visual clutter of de-emphasized text inputs.
     pub unfocused_selection_color: Color,
     /// If some, overrides the color of selected text
     pub selected_text_color: Option<Color>,
@@ -30,8 +29,8 @@ impl Default for TextCursorStyle {
     fn default() -> Self {
         Self {
             color: Color::from(SLATE_700),
-            selection_color: Color::from(SLATE_400),
-            unfocused_selection_color: Color::srgba(0.0, 0.0, 0.0, 0.0),
+            selection_color: Color::from(SKY_300),
+            unfocused_selection_color: Color::from(SKY_400),
             selected_text_color: None,
         }
     }

--- a/crates/bevy_text/src/cursor.rs
+++ b/crates/bevy_text/src/cursor.rs
@@ -17,6 +17,9 @@ pub struct TextCursorStyle {
     /// Background color of selected text
     pub selection_color: Color,
     /// Background color of unfocused selected text
+    ///
+    /// In many applications, this is completely transparent,
+    /// in order to reduce visual clutter.
     pub unfocused_selection_color: Color,
     /// If some, overrides the color of selected text
     pub selected_text_color: Option<Color>,

--- a/crates/bevy_text/src/cursor.rs
+++ b/crates/bevy_text/src/cursor.rs
@@ -18,7 +18,8 @@ pub struct TextCursorStyle {
     pub selection_color: Color,
     /// Background color of unfocused selected text
     ///
-    /// In many applications, this is completely transparent,
+    /// By default, this is completely transparent.
+    /// This is a common choice in many applications,
     /// in order to reduce visual clutter.
     pub unfocused_selection_color: Color,
     /// If some, overrides the color of selected text
@@ -30,7 +31,7 @@ impl Default for TextCursorStyle {
         Self {
             color: Color::from(SLATE_600),
             selection_color: Color::from(SKY_200),
-            unfocused_selection_color: Color::from(SLATE_200),
+            unfocused_selection_color: Color::srgba(0.0, 0.0, 0.0, 0.0),
             selected_text_color: None,
         }
     }

--- a/crates/bevy_text/src/cursor.rs
+++ b/crates/bevy_text/src/cursor.rs
@@ -1,5 +1,5 @@
 use bevy_color::{
-    palettes::tailwind::{SKY_200, SLATE_200, SLATE_600},
+    palettes::tailwind::{SLATE_400, SLATE_700},
     Color,
 };
 use bevy_ecs::component::Component;
@@ -29,8 +29,8 @@ pub struct TextCursorStyle {
 impl Default for TextCursorStyle {
     fn default() -> Self {
         Self {
-            color: Color::from(SLATE_600),
-            selection_color: Color::from(SKY_200),
+            color: Color::from(SLATE_700),
+            selection_color: Color::from(SLATE_400),
             unfocused_selection_color: Color::srgba(0.0, 0.0, 0.0, 0.0),
             selected_text_color: None,
         }

--- a/examples/ui/text/editable_text_filter.rs
+++ b/examples/ui/text/editable_text_filter.rs
@@ -1,6 +1,7 @@
 //! Demonstrates a minimal [`EditableTextFilter`] with an 8-character hex input.
 
-use bevy::color::palettes::css::{DARK_SLATE_GRAY, YELLOW};
+use bevy::color::palettes::css::DARK_SLATE_GRAY;
+use bevy::color::palettes::tailwind::SLATE_300;
 use bevy::input_focus::AutoFocus;
 use bevy::prelude::*;
 use bevy::text::{EditableText, EditableTextFilter, TextCursorStyle};
@@ -39,7 +40,7 @@ fn setup(mut commands: Commands) {
                 EditableTextFilter::new(|c| c.is_ascii_hexdigit()),
                 TextFont::from_font_size(32.),
                 BackgroundColor(DARK_SLATE_GRAY.into()),
-                BorderColor::all(YELLOW),
+                BorderColor::all(SLATE_300),
                 AutoFocus,
             ));
         });

--- a/examples/ui/text/ime_support.rs
+++ b/examples/ui/text/ime_support.rs
@@ -6,7 +6,8 @@
 //! To use IME input, the system must have fonts installed that support the target script.
 //! This example uses [`FontSource::SansSerif`], which resolves to a system sans-serif font.
 //! On systems without e.g. CJK fonts installed, CJK input will render as boxes or question marks.
-use bevy::color::palettes::css::{DARK_GREY, YELLOW};
+use bevy::color::palettes::css::DARK_GREY;
+use bevy::color::palettes::tailwind::SLATE_300;
 use bevy::input_focus::{
     tab_navigation::{TabGroup, TabIndex, TabNavigationPlugin},
     InputFocus,
@@ -59,7 +60,7 @@ fn setup(mut commands: Commands) {
                 font_size: FontSize::Px(32.0),
                 ..default()
             },
-            BorderColor::from(Color::from(YELLOW)),
+            BorderColor::from(Color::from(SLATE_300)),
             EditableText::default(),
             TextCursorStyle::default(),
             TabIndex(0),

--- a/examples/ui/text/multiline_text_input.rs
+++ b/examples/ui/text/multiline_text_input.rs
@@ -1,6 +1,7 @@
 //! Demonstrates a single, minimal multiline [`EditableText`] widget.
 
-use bevy::color::palettes::css::{DARK_SLATE_GRAY, YELLOW};
+use bevy::color::palettes::css::DARK_SLATE_GRAY;
+use bevy::color::palettes::tailwind::SLATE_300;
 use bevy::input::keyboard::{Key, KeyboardInput};
 use bevy::input_focus::tab_navigation::{TabGroup, TabIndex, TabNavigationPlugin};
 use bevy::input_focus::{AutoFocus, FocusedInput};
@@ -73,7 +74,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                 ..default()
                             },
                             BackgroundColor(DARK_SLATE_GRAY.into()),
-                            BorderColor::all(YELLOW),
+                            BorderColor::all(SLATE_300),
                             MultilineInput,
                             TabIndex(0),
                             AutoFocus,
@@ -134,7 +135,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                         ..default()
                                     },
                                     BackgroundColor(DARK_SLATE_GRAY.into()),
-                                    BorderColor::all(YELLOW),
+                                    BorderColor::all(SLATE_300),
                                     EditableText::new("8"),
                                     EditableTextFilter::new(|c| c.is_ascii_digit()),
                                     TextCursorStyle {
@@ -215,7 +216,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                         ..default()
                                     },
                                     BackgroundColor(DARK_SLATE_GRAY.into()),
-                                    BorderColor::all(YELLOW),
+                                    BorderColor::all(SLATE_300),
                                     EditableText::new("30"),
                                     EditableTextFilter::new(|c| c.is_ascii_digit()),
                                     TextCursorStyle {

--- a/examples/ui/text/multiple_text_inputs.rs
+++ b/examples/ui/text/multiple_text_inputs.rs
@@ -4,7 +4,7 @@
 //! that is kept synchronized with the [`EditableText`]'s contents by the [`synchronize_output_text`] system, and the third column is updated
 //! by the [`submit_text`] system when the user submits the [`EditableText`]'s text by pressing `Ctrl` + `Enter`.
 
-use bevy::color::palettes::css::YELLOW;
+use bevy::color::palettes::tailwind::SLATE_300;
 use bevy::input::keyboard::Key;
 use bevy::input_focus::AutoFocus;
 use bevy::input_focus::{
@@ -103,7 +103,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     BackgroundColor(bevy::color::palettes::css::DARK_GREY.into()),
                     TextInputRow(row),
                     TabIndex(row as i32),
-                    BorderColor::all(YELLOW),
+                    BorderColor::all(SLATE_300),
                 ));
                 if row == 0 {
                     input.insert(AutoFocus);
@@ -229,7 +229,7 @@ fn update_row_border_colors(
 
     for (row, mut border_color, is_input) in &mut row_borders {
         let mut color = if is_input {
-            YELLOW.into()
+            SLATE_300.into()
         } else {
             Color::WHITE
         };

--- a/examples/ui/text/text_input.rs
+++ b/examples/ui/text/text_input.rs
@@ -45,44 +45,38 @@ fn main() {
 struct TextOutput;
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    // Set up a camera
-    // We need a camera to see the UI
     commands.spawn(Camera2d);
 
-    // Create a root UI node, so we can place the input above the output in a column
     let root = commands
         .spawn(Node {
-            display: Display::Block,
+            display: Display::Flex,
+            flex_direction: FlexDirection::Column,
+            padding: px(20).all(),
+            row_gap: px(16),
             ..default()
         })
         .id();
 
     let text_instructions = commands
         .spawn((
-            Node {
-                width: px(400),
-                height: px(100),
-                ..Default::default()
-            },
-            BorderColor::from(Color::from(SLATE_300)),
             Text::new("Ctrl+Enter to submit text"),
             TextFont {
                 font: asset_server.load("fonts/FiraSans-Bold.ttf").into(),
                 font_size: FontSize::Px(30.0),
                 ..default()
             },
-            UiTransform::from_translation(Val2::ZERO),
         ))
         .id();
 
-    let text_input_left = build_input_text(&mut commands, true, 30.0);
-    let text_input_right = build_input_text(&mut commands, false, 50.0);
+    let text_input_left = build_input_text(&mut commands, true, 24.0);
+    let text_input_right = build_input_text(&mut commands, false, 24.0);
 
     let input_container = commands
         .spawn((
             Node {
                 display: Display::Flex,
                 align_items: AlignItems::Start,
+                column_gap: px(16),
                 ..default()
             },
             AutoFocus,
@@ -94,23 +88,21 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let text_output = commands
         .spawn((
             Node {
-                width: px(400),
-                height: px(100),
-                border: px(5).all(),
+                width: px(416),
+                border: px(2).all(),
+                padding: px(8).all(),
                 ..Default::default()
             },
             BorderColor::from(Color::from(SLATE_300)),
-            Text::new("testing"),
+            Text::new(""),
             TextOutput,
             TextFont {
-                font_size: FontSize::Px(70.0),
+                font_size: FontSize::Px(24.0),
                 ..default()
             },
-            UiTransform::from_translation(Val2::px(5.0, 200.0)),
         ))
         .id();
 
-    // Assemble our hierarchy
     commands
         .entity(input_container)
         .add_children(&[text_input_left, text_input_right]);
@@ -125,8 +117,8 @@ fn build_input_text(commands: &mut Commands, is_left: bool, font_size: f32) -> E
         .spawn((
             Node {
                 width: px(200),
-                border: px(5).all(),
-                padding: px(5).all(),
+                border: px(2).all(),
+                padding: px(8).all(),
                 ..Default::default()
             },
             BorderColor::from(Color::from(SLATE_300)),
@@ -142,7 +134,6 @@ fn build_input_text(commands: &mut Commands, is_left: bool, font_size: f32) -> E
             TextCursorStyle::default(),
             TabIndex(if is_left { 0 } else { 1 }),
             BackgroundColor(DARK_GREY.into()),
-            UiTransform::from_translation(Val2::px(if is_left { 0.0 } else { 300.0 }, 50.0)),
         ))
         .id()
 }

--- a/examples/ui/text/text_input.rs
+++ b/examples/ui/text/text_input.rs
@@ -22,7 +22,8 @@
 //! To enable this feature in your own project, add the `system_clipboard` feature to your list of enabled features for `bevy` in your `Cargo.toml`.
 //!
 //! See the module documentation for [`editable_text`](bevy::ui_widgets::editable_text) for more details.
-use bevy::color::palettes::css::{DARK_GREY, YELLOW};
+use bevy::color::palettes::css::DARK_GREY;
+use bevy::color::palettes::tailwind::SLATE_300;
 use bevy::input_focus::AutoFocus;
 use bevy::input_focus::{
     tab_navigation::{TabGroup, TabIndex, TabNavigationPlugin},
@@ -63,7 +64,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 height: px(100),
                 ..Default::default()
             },
-            BorderColor::from(Color::from(YELLOW)),
+            BorderColor::from(Color::from(SLATE_300)),
             Text::new("Ctrl+Enter to submit text"),
             TextFont {
                 font: asset_server.load("fonts/FiraSans-Bold.ttf").into(),
@@ -98,7 +99,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 border: px(5).all(),
                 ..Default::default()
             },
-            BorderColor::from(Color::from(YELLOW)),
+            BorderColor::from(Color::from(SLATE_300)),
             Text::new("testing"),
             TextOutput,
             TextFont {
@@ -128,7 +129,7 @@ fn build_input_text(commands: &mut Commands, is_left: bool, font_size: f32) -> E
                 padding: px(5).all(),
                 ..Default::default()
             },
-            BorderColor::from(Color::from(YELLOW)),
+            BorderColor::from(Color::from(SLATE_300)),
             Name::new(if is_left { "Left" } else { "Right" }),
             EditableText {
                 max_characters: (!is_left).then_some(7),


### PR DESCRIPTION
# Objective

- Text input is one of the headline feature in Bevy 0.19.
- Our defaults are currently very ugly, and shown across our user-facing text examples.
- Good default matter for user perception of quality, and to make quick prototyping easier.
- Additionally, the layout in the text_input example is erratic in a way that looks poorly made.

Fixes #23955.

## Solution

1. Clean up the default colors for text input by picking boring, uncontroversial tailwind colors.
2. Change the css::YELLOW borders in our text input examples to something neutral that looks nice with our background.
3. Fix up the layout for the `text_input` example so it's both simpler and looks much better.

## Testing

`cargo run --example text_input`

## Showcase

Before:

<img width="873" height="773" alt="image" src="https://github.com/user-attachments/assets/bcc70bf6-e6b1-4bf4-b671-7924ac24e984" />

After:

<img width="757" height="274" alt="image" src="https://github.com/user-attachments/assets/e1a3e325-b3a7-4a9b-831e-6886e6a818fc" />
