### PR TITLE
BSN: Improve error handling by changing `into` to `try_into`

### DIFF
--- a/crates/bevy_scene/macros/src/bsn/codegen.rs
+++ b/crates/bevy_scene/macros/src/bsn/codegen.rs
@@ -91,12 +91,12 @@ impl BsnTokenStream for BsnRoot {
         // any compile errors. This keeps autocomplete working in broken states,
         // e.g. when typing the name of a field but no value yet.
         quote! {
-            #bevy_scene::SceneScope({
+            #bevy_scene::SceneScope((|| {
                 #(#hoisted_exprs)*
                 let _res = #tokens;
                 #(#errors)*
-                _res
-            })
+                Ok(_res)
+            })())
         }
     }
 }
@@ -114,10 +114,12 @@ impl BsnTokenStream for BsnListRoot {
         // e.g. when typing the name of a field but no value yet.
         quote! {
             {
-                #(#hoisted_exprs)*
-                let _res = #bevy_scene::SceneListScope(#tokens);
-                #(#errors)*
-                _res
+                (|| {
+                    #(#hoisted_exprs)*
+                    let _res = #bevy_scene::SceneListScope(#tokens);
+                    #(#errors)*
+                    Ok(_res)
+                })()
             }
         }
     }
@@ -232,7 +234,7 @@ impl BsnEntry {
                     #bevy_scene::InheritSceneAsset::from(#lit)
                 }),
                 BsnInheritedScene::Fn { function, args } => Ok(quote! {
-                    #bevy_scene::SceneScope(#function(#args))
+                    #bevy_scene::SceneScope(Ok(#function(#args)))
                 }),
             },
             BsnEntry::Name(ident) => {
@@ -543,9 +545,9 @@ impl ToTokens for BsnType {
 impl ToTokens for BsnValue {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         match self {
-            BsnValue::Expr(e) => quote! {{#e}.into()}.to_tokens(tokens),
-            BsnValue::Closure(c) => quote! {(#c).into()}.to_tokens(tokens),
-            BsnValue::Ident(i) => quote! {(#i).into()}.to_tokens(tokens),
+            BsnValue::Expr(e) => quote! {{#e}.try_into()?}.to_tokens(tokens),
+            BsnValue::Closure(c) => quote! {(#c).try_into()?}.to_tokens(tokens),
+            BsnValue::Ident(i) => quote! {(#i).try_into()?}.to_tokens(tokens),
             BsnValue::Lit(Lit::Str(s)) => quote! {#s.try_into()?}.to_tokens(tokens),
             BsnValue::Lit(l) => l.to_tokens(tokens),
             BsnValue::Tuple(t) => {

--- a/crates/bevy_scene/macros/src/bsn/codegen.rs
+++ b/crates/bevy_scene/macros/src/bsn/codegen.rs
@@ -113,14 +113,12 @@ impl BsnTokenStream for BsnListRoot {
         // any compile errors. This keeps autocomplete working in broken states,
         // e.g. when typing the name of a field but no value yet.
         quote! {
-            {
-                (|| {
-                    #(#hoisted_exprs)*
-                    let _res = #bevy_scene::SceneListScope(#tokens);
-                    #(#errors)*
-                    Ok(_res)
-                })()
-            }
+            #bevy_scene::SceneListScope((|| {
+                #(#hoisted_exprs)*
+                let _res = #tokens;
+                #(#errors)*
+                Ok(_res)
+            })())
         }
     }
 }

--- a/crates/bevy_scene/macros/src/bsn/codegen.rs
+++ b/crates/bevy_scene/macros/src/bsn/codegen.rs
@@ -756,8 +756,8 @@ mod tests {
     #[test]
     fn bsn_root_preserves_inference_on_error() {
         // Arrange
-        let expected = "bevy_scene :: SceneScope ({ let _res = bevy_scene :: auto_nest_tuple \
-            ! () ; :: core :: compile_error ! { \"Test Error\" } _res })";
+        let expected = "bevy_scene :: SceneScope ((|| { let _res = bevy_scene :: auto_nest_tuple \
+            ! () ; :: core :: compile_error ! { \"Test Error\" } Ok (_res) }) ())";
 
         let mut refs = EntityRefs::default();
         let paths = TestPaths::new();
@@ -780,10 +780,10 @@ mod tests {
     fn bsn_list_root_preserves_inference_on_error() {
         // Arrange
         let expected =
-            "{ let _res = bevy_scene :: SceneListScope (bevy_scene :: auto_nest_tuple ! ()) ;"
+            "bevy_scene :: SceneListScope ((|| { let _res = bevy_scene :: auto_nest_tuple ! () ;"
                 .to_string()
                 + " :: core :: compile_error ! { \"Test Error\" }"
-                + " _res }";
+                + " Ok (_res) }) ())";
 
         let mut refs = EntityRefs::default();
         let paths = TestPaths::new();

--- a/crates/bevy_scene/macros/src/bsn/codegen.rs
+++ b/crates/bevy_scene/macros/src/bsn/codegen.rs
@@ -165,6 +165,7 @@ impl BsnEntry {
                 Ok(quote! {
                     <#path as #bevy_scene::PatchTemplate>::patch_template(move |value, _context| {
                         #(#assigns)*
+                        Ok(())
                     })
                 })
             }
@@ -182,6 +183,7 @@ impl BsnEntry {
                 Ok(quote! {
                     <#path as #bevy_scene::PatchFromTemplate>::patch(move |value, _context| {
                         #(#assigns)*
+                        Ok(())
                     })
                 })
             }
@@ -191,6 +193,7 @@ impl BsnEntry {
             } => Ok(quote! {
                 <#type_path as #bevy_scene::PatchTemplate>::patch_template(move |value, _context| {
                     *value = #type_path::#const_ident;
+                    Ok(())
                 })
             }),
             BsnEntry::SceneExpression(block) => Ok(quote! {{#block}}),
@@ -201,6 +204,7 @@ impl BsnEntry {
             }) => Ok(quote! {
                 <#type_path as #bevy_scene::PatchTemplate>::patch_template(move |value, _context| {
                     *value = #type_path::#function(#args);
+                    Ok(())
                 })
             }),
             BsnEntry::FromTemplateConstructor(BsnConstructor {
@@ -210,6 +214,7 @@ impl BsnEntry {
             }) => Ok(quote! {
                 <#type_path as #bevy_scene::PatchFromTemplate>::patch(move |value, _context| {
                     *value = <#type_path as #bevy_ecs::template::FromTemplate>::Template::#function(#args);
+                    Ok(())
                 })
             }),
             BsnEntry::RelatedSceneList(BsnRelatedSceneList {
@@ -239,6 +244,7 @@ impl BsnEntry {
             BsnEntry::NameExpression(expr) => Ok(quote! {
                 <#bevy_ecs::name::Name as #bevy_scene::PatchFromTemplate>::patch(move |value, _context| {
                     *value = #bevy_ecs::Name({#expr}.into());
+                    Ok(())
                 })
             }),
         }
@@ -540,7 +546,7 @@ impl ToTokens for BsnValue {
             BsnValue::Expr(e) => quote! {{#e}.into()}.to_tokens(tokens),
             BsnValue::Closure(c) => quote! {(#c).into()}.to_tokens(tokens),
             BsnValue::Ident(i) => quote! {(#i).into()}.to_tokens(tokens),
-            BsnValue::Lit(Lit::Str(s)) => quote! {#s.into()}.to_tokens(tokens),
+            BsnValue::Lit(Lit::Str(s)) => quote! {#s.try_into()?}.to_tokens(tokens),
             BsnValue::Lit(l) => l.to_tokens(tokens),
             BsnValue::Tuple(t) => {
                 let inner = t.0.iter();

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -1521,22 +1521,16 @@ mod tests {
                 Some(HandleComponent(FakeHandle("valid".into())))
             );
 
-            let err_scene = world.spawn_scene(bsn! { HandleComponent("malformed#") });
+            assert!(world
+                .spawn_scene(bsn! { HandleComponent("malformed#") })
+                .is_err());
 
-            assert_eq!(
-                err_scene.err().unwrap().to_string(),
-                ParseAssetPathError::MissingLabel.to_string() + "\n",
-            );
-
-            let err_scene_list = world.spawn_scene_list(bsn_list! {
-                (HandleComponent("valid")),
-                (HandleComponent("malformed#")),
-            });
-
-            assert_eq!(
-                err_scene_list.err().unwrap().to_string(),
-                ParseAssetPathError::MissingLabel.to_string() + "\n",
-            );
+            assert!(world
+                .spawn_scene_list(bsn_list! {
+                    (HandleComponent("valid")),
+                    (HandleComponent("malformed#")),
+                })
+                .is_err());
         }
 
         // Test `BsnValue::Expr` and `BsnValue::Ident`.

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -1490,30 +1490,78 @@ mod tests {
 
     #[test]
     fn fallibility() {
-        // We can't use `Handle` for testing right now as it doesn't have a
-        // `TryFrom<&'static str>`. So we make a fake one.
-        #[derive(Default, Clone)]
-        struct FakeHandle(#[expect(unused, reason = "For testing only")] AssetPath<'static>);
-
-        impl TryFrom<&'static str> for FakeHandle {
-            type Error = ParseAssetPathError;
-
-            fn try_from(value: &'static str) -> Result<Self, Self::Error> {
-                Ok(Self(AssetPath::try_parse(value)?))
-            }
-        }
-
-        #[derive(Default, Clone, Component, FromTemplate)]
-        struct TestComponent(#[expect(unused, reason = "Just for testing")] FakeHandle);
-
         let mut app = test_app();
         let world = app.world_mut();
 
-        let result = world.spawn_scene(bsn! { TestComponent("malformed_path#") });
+        {
+            // We can't use `Handle` for testing right now as it doesn't have a
+            // `TryFrom<&'static str>`. So we make a fake one.
+            #[derive(Default, Clone, Debug, PartialEq, Eq)]
+            struct FakeHandle(AssetPath<'static>);
 
-        assert_eq!(
-            result.err().unwrap().to_string(),
-            ParseAssetPathError::MissingLabel.to_string() + "\n",
-        );
+            impl TryFrom<&'static str> for FakeHandle {
+                type Error = ParseAssetPathError;
+
+                fn try_from(value: &'static str) -> Result<Self, Self::Error> {
+                    Ok(Self(AssetPath::try_parse(value)?))
+                }
+            }
+
+            #[derive(Default, Clone, Component, FromTemplate, Debug, PartialEq, Eq)]
+            struct TestComponent(FakeHandle);
+
+            let ok_scene = world
+                .spawn_scene(bsn! { TestComponent("valid_path") })
+                .unwrap()
+                .id();
+
+            assert_eq!(
+                world.entity(ok_scene).get::<TestComponent>().cloned(),
+                Some(TestComponent(FakeHandle("valid_path".into())))
+            );
+
+            let err_scene = world.spawn_scene(bsn! { TestComponent("malformed_path#") });
+
+            assert_eq!(
+                err_scene.err().unwrap().to_string(),
+                ParseAssetPathError::MissingLabel.to_string() + "\n",
+            );
+
+            let err_scene_list = world.spawn_scene_list(bsn_list! {
+                (TestComponent("valid_path")),
+                (TestComponent("malformed_path#"))
+            });
+
+            assert_eq!(
+                err_scene_list.err().unwrap().to_string(),
+                ParseAssetPathError::MissingLabel.to_string() + "\n",
+            );
+        }
+
+        {
+            #[derive(Default, Clone, Component, PartialEq, Eq, Debug)]
+            struct TestComponent(u32);
+
+            let ok_scene = world
+                .spawn_scene(bsn! { TestComponent({0i32}) })
+                .unwrap()
+                .id();
+
+            assert_eq!(
+                world.entity(ok_scene).get::<TestComponent>().cloned(),
+                Some(TestComponent(0))
+            );
+
+            let err_scene = world.spawn_scene(bsn! { TestComponent({-1i32}) });
+
+            assert!(err_scene.is_err());
+
+            let err_scene_list = world.spawn_scene(bsn! {
+                 TestComponent({0i32})
+                 TestComponent({-1i32})
+            });
+
+            assert!(err_scene_list.is_err());
+        }
     }
 }

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -1493,9 +1493,10 @@ mod tests {
         let mut app = test_app();
         let world = app.world_mut();
 
+        // Test `BsnValue::Lit`.
         {
-            // We can't use `Handle` for testing right now as it doesn't have a
-            // `TryFrom<&'static str>`. So we make a fake one.
+            // Ideally we'd be using the real `Handle`. But we can't use it for
+            // testing errors until it implements `TryFrom<&'static str>`.
             #[derive(Default, Clone, Debug, PartialEq, Eq)]
             struct FakeHandle(AssetPath<'static>);
 
@@ -1508,19 +1509,19 @@ mod tests {
             }
 
             #[derive(Default, Clone, Component, FromTemplate, Debug, PartialEq, Eq)]
-            struct TestComponent(FakeHandle);
+            struct HandleComponent(FakeHandle);
 
             let ok_scene = world
-                .spawn_scene(bsn! { TestComponent("valid_path") })
+                .spawn_scene(bsn! { HandleComponent("valid") })
                 .unwrap()
                 .id();
 
             assert_eq!(
-                world.entity(ok_scene).get::<TestComponent>().cloned(),
-                Some(TestComponent(FakeHandle("valid_path".into())))
+                world.entity(ok_scene).get::<HandleComponent>().cloned(),
+                Some(HandleComponent(FakeHandle("valid".into())))
             );
 
-            let err_scene = world.spawn_scene(bsn! { TestComponent("malformed_path#") });
+            let err_scene = world.spawn_scene(bsn! { HandleComponent("malformed#") });
 
             assert_eq!(
                 err_scene.err().unwrap().to_string(),
@@ -1528,8 +1529,8 @@ mod tests {
             );
 
             let err_scene_list = world.spawn_scene_list(bsn_list! {
-                (TestComponent("valid_path")),
-                (TestComponent("malformed_path#"))
+                (HandleComponent("valid")),
+                (HandleComponent("malformed#")),
             });
 
             assert_eq!(
@@ -1538,30 +1539,35 @@ mod tests {
             );
         }
 
+        // Test `BsnValue::Expr` and `BsnValue::Ident`.
         {
+            // A component with a single `u32`, so we can test for failure by
+            // passing it a negative `i32`.
             #[derive(Default, Clone, Component, PartialEq, Eq, Debug)]
-            struct TestComponent(u32);
+            struct U32Component(u32);
 
-            let ok_scene = world
-                .spawn_scene(bsn! { TestComponent({0i32}) })
-                .unwrap()
-                .id();
+            const ZERO: i32 = 0;
+            const MINUS_ONE: i32 = -1;
 
-            assert_eq!(
-                world.entity(ok_scene).get::<TestComponent>().cloned(),
-                Some(TestComponent(0))
-            );
+            assert!(world.spawn_scene(bsn! { U32Component({0i32}) }).is_ok());
+            assert!(world.spawn_scene(bsn! { U32Component({-1i32}) }).is_err());
 
-            let err_scene = world.spawn_scene(bsn! { TestComponent({-1i32}) });
+            assert!(world.spawn_scene(bsn! { U32Component(ZERO) }).is_ok());
+            assert!(world.spawn_scene(bsn! { U32Component(MINUS_ONE) }).is_err());
 
-            assert!(err_scene.is_err());
+            assert!(world
+                .spawn_scene(bsn! {
+                     U32Component({0i32})
+                     U32Component({-1i32})
+                })
+                .is_err());
 
-            let err_scene_list = world.spawn_scene(bsn! {
-                 TestComponent({0i32})
-                 TestComponent({-1i32})
-            });
-
-            assert!(err_scene_list.is_err());
+            assert!(world
+                .spawn_scene(bsn! {
+                     U32Component(0)
+                     U32Component(MINUS_ONE)
+                })
+                .is_err());
         }
     }
 }

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -566,7 +566,10 @@ mod tests {
     use bevy_app::{App, TaskPoolPlugin};
     use bevy_asset::io::memory::{Dir, MemoryAssetReader};
     use bevy_asset::io::{AssetSourceBuilder, AssetSourceId};
-    use bevy_asset::{Asset, AssetApp, AssetLoader, AssetPlugin, AssetServer, Assets, Handle};
+    use bevy_asset::{
+        Asset, AssetApp, AssetLoader, AssetPath, AssetPlugin, AssetServer, Assets, Handle,
+        ParseAssetPathError,
+    };
     use bevy_ecs::lifecycle::HookContext;
     use bevy_ecs::prelude::*;
     use bevy_ecs::relationship::Relationship;
@@ -1483,5 +1486,34 @@ mod tests {
         }
 
         b();
+    }
+
+    #[test]
+    fn fallibility() {
+        // We can't use `Handle` for testing right now as it doesn't have a
+        // `TryFrom<&'static str>`. So we make a fake one.
+        #[derive(Default, Clone)]
+        struct FakeHandle(#[expect(unused, reason = "For testing only")] AssetPath<'static>);
+
+        impl TryFrom<&'static str> for FakeHandle {
+            type Error = ParseAssetPathError;
+
+            fn try_from(value: &'static str) -> Result<Self, Self::Error> {
+                Ok(Self(AssetPath::try_parse(value)?))
+            }
+        }
+
+        #[derive(Default, Clone, Component, FromTemplate)]
+        struct TestComponent(#[expect(unused, reason = "Just for testing")] FakeHandle);
+
+        let mut app = test_app();
+        let world = app.world_mut();
+
+        let result = world.spawn_scene(bsn! { TestComponent("malformed_path#") });
+
+        assert_eq!(
+            result.err().unwrap().to_string(),
+            ParseAssetPathError::MissingLabel.to_string() + "\n",
+        );
     }
 }

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -477,23 +477,22 @@ impl<S: Scene> Scene for SceneScope<S> {
         context: &mut ResolveContext,
         scene: &mut ResolvedScene,
     ) -> Result<(), ResolveSceneError> {
-        context.new_entity_scope(|context| {
-            self.0
-                .map_err(ResolveSceneError::TemplateError)?
-                .resolve(context, scene)
-        })
+        match self.0 {
+            Ok(inner) => context.new_entity_scope(|context| inner.resolve(context, scene)),
+            Err(err) => Err(ResolveSceneError::TemplateError(err)),
+        }
     }
 
     fn register_dependencies(&self, dependencies: &mut SceneDependencies) {
-        if let Ok(scene) = &self.0 {
-            scene.register_dependencies(dependencies);
+        if let Ok(inner) = &self.0 {
+            inner.register_dependencies(dependencies);
         }
     }
 }
 
 /// A [`SceneList`] that will create a new "entity scope" and fully resolve the given scene list `L` on top of the current [`Vec<ResolvedScene>`]
 /// (using that scope). It is not "inherited" or cached.
-pub struct SceneListScope<L: SceneList>(pub L);
+pub struct SceneListScope<L: SceneList>(pub Result<L, BevyError>);
 
 impl<L: SceneList> SceneList for SceneListScope<L> {
     fn resolve_list(
@@ -501,27 +500,15 @@ impl<L: SceneList> SceneList for SceneListScope<L> {
         context: &mut ResolveContext,
         scenes: &mut Vec<ResolvedScene>,
     ) -> Result<(), ResolveSceneError> {
-        context.new_entity_scope(|context| self.0.resolve_list(context, scenes))
+        match self.0 {
+            Ok(inner) => context.new_entity_scope(|context| inner.resolve_list(context, scenes)),
+            Err(err) => Err(ResolveSceneError::TemplateError(err)),
+        }
     }
 
     fn register_dependencies(&self, dependencies: &mut SceneDependencies) {
-        self.0.register_dependencies(dependencies);
-    }
-}
-
-impl<L: SceneList> SceneList for Result<SceneListScope<L>, BevyError> {
-    fn resolve_list(
-        self,
-        context: &mut ResolveContext,
-        scenes: &mut Vec<ResolvedScene>,
-    ) -> Result<(), ResolveSceneError> {
-        self.map_err(ResolveSceneError::TemplateError)?
-            .resolve_list(context, scenes)
-    }
-
-    fn register_dependencies(&self, dependencies: &mut SceneDependencies) {
-        if let Ok(scene_list) = &self {
-            scene_list.register_dependencies(dependencies);
+        if let Ok(inner) = &self.0 {
+            inner.register_dependencies(dependencies);
         }
     }
 }

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -469,7 +469,7 @@ impl Scene for NameEntityReference {
 
 /// A [`Scene`] that will create a new "entity scope" and fully resolve the given scene `S` on top of the current [`ResolvedScene`] (using that scope).
 /// It is not "inherited" or cached.
-pub struct SceneScope<S: Scene>(pub S);
+pub struct SceneScope<S: Scene>(pub Result<S, BevyError>);
 
 impl<S: Scene> Scene for SceneScope<S> {
     fn resolve(
@@ -477,11 +477,17 @@ impl<S: Scene> Scene for SceneScope<S> {
         context: &mut ResolveContext,
         scene: &mut ResolvedScene,
     ) -> Result<(), ResolveSceneError> {
-        context.new_entity_scope(|context| self.0.resolve(context, scene))
+        context.new_entity_scope(|context| {
+            self.0
+                .map_err(ResolveSceneError::TemplateError)?
+                .resolve(context, scene)
+        })
     }
 
     fn register_dependencies(&self, dependencies: &mut SceneDependencies) {
-        self.0.register_dependencies(dependencies);
+        if let Ok(scene) = &self.0 {
+            scene.register_dependencies(dependencies);
+        }
     }
 }
 
@@ -500,6 +506,23 @@ impl<L: SceneList> SceneList for SceneListScope<L> {
 
     fn register_dependencies(&self, dependencies: &mut SceneDependencies) {
         self.0.register_dependencies(dependencies);
+    }
+}
+
+impl<L: SceneList> SceneList for Result<SceneListScope<L>, BevyError> {
+    fn resolve_list(
+        self,
+        context: &mut ResolveContext,
+        scenes: &mut Vec<ResolvedScene>,
+    ) -> Result<(), ResolveSceneError> {
+        self.map_err(ResolveSceneError::TemplateError)?
+            .resolve_list(context, scenes)
+    }
+
+    fn register_dependencies(&self, dependencies: &mut SceneDependencies) {
+        if let Ok(scene_list) = &self {
+            scene_list.register_dependencies(dependencies);
+        }
     }
 }
 

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -334,8 +334,7 @@ impl<
         scene: &mut ResolvedScene,
     ) -> Result<(), ResolveSceneError> {
         let template = scene.get_or_insert_template::<T>(context);
-        (self.0)(template, context).map_err(ResolveSceneError::BevyError)?;
-        Ok(())
+        (self.0)(template, context).map_err(ResolveSceneError::BevyError)
     }
 }
 

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -166,9 +166,9 @@ pub enum ResolveSceneError {
     /// Caused when a Scene/SceneList is not present on the scene asset.
     #[error("The Scene/SceneList is not present on the scene asset. This is likely because the scene has already been resolved, which consumed the source scene")]
     MissingScene,
-    /// XXX TODO: Document. Bikeshed name.
+    /// Caused when scene resolution encounters a generic [`BevyError`].
     #[error("{0}")]
-    TemplateError(BevyError),
+    BevyError(BevyError),
 }
 
 /// Context used by [`Scene`] implementations during [`Scene::resolve`].
@@ -334,7 +334,7 @@ impl<
         scene: &mut ResolvedScene,
     ) -> Result<(), ResolveSceneError> {
         let template = scene.get_or_insert_template::<T>(context);
-        (self.0)(template, context).map_err(ResolveSceneError::TemplateError)?;
+        (self.0)(template, context).map_err(ResolveSceneError::BevyError)?;
         Ok(())
     }
 }
@@ -469,6 +469,8 @@ impl Scene for NameEntityReference {
 
 /// A [`Scene`] that will create a new "entity scope" and fully resolve the given scene `S` on top of the current [`ResolvedScene`] (using that scope).
 /// It is not "inherited" or cached.
+///
+/// If the value is an error, then calling `resolve` will return that error.
 pub struct SceneScope<S: Scene>(pub Result<S, BevyError>);
 
 impl<S: Scene> Scene for SceneScope<S> {
@@ -479,7 +481,7 @@ impl<S: Scene> Scene for SceneScope<S> {
     ) -> Result<(), ResolveSceneError> {
         match self.0 {
             Ok(inner) => context.new_entity_scope(|context| inner.resolve(context, scene)),
-            Err(err) => Err(ResolveSceneError::TemplateError(err)),
+            Err(err) => Err(ResolveSceneError::BevyError(err)),
         }
     }
 
@@ -492,6 +494,8 @@ impl<S: Scene> Scene for SceneScope<S> {
 
 /// A [`SceneList`] that will create a new "entity scope" and fully resolve the given scene list `L` on top of the current [`Vec<ResolvedScene>`]
 /// (using that scope). It is not "inherited" or cached.
+//
+/// If the value is an error, then calling `resolve_list` will return that error.
 pub struct SceneListScope<L: SceneList>(pub Result<L, BevyError>);
 
 impl<L: SceneList> SceneList for SceneListScope<L> {
@@ -502,7 +506,7 @@ impl<L: SceneList> SceneList for SceneListScope<L> {
     ) -> Result<(), ResolveSceneError> {
         match self.0 {
             Ok(inner) => context.new_entity_scope(|context| inner.resolve_list(context, scenes)),
-            Err(err) => Err(ResolveSceneError::TemplateError(err)),
+            Err(err) => Err(ResolveSceneError::BevyError(err)),
         }
     }
 

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -3,7 +3,7 @@ use bevy_asset::{Asset, AssetPath, AssetServer, Assets};
 use bevy_ecs::{
     bundle::Bundle,
     component::Component,
-    error::Result,
+    error::{BevyError, Result},
     event::EntityEvent,
     name::Name,
     relationship::Relationship,
@@ -166,6 +166,9 @@ pub enum ResolveSceneError {
     /// Caused when a Scene/SceneList is not present on the scene asset.
     #[error("The Scene/SceneList is not present on the scene asset. This is likely because the scene has already been resolved, which consumed the source scene")]
     MissingScene,
+    /// XXX TODO: Document. Bikeshed name.
+    #[error("{0}")]
+    TemplateError(BevyError),
 }
 
 /// Context used by [`Scene`] implementations during [`Scene::resolve`].
@@ -258,21 +261,26 @@ all_tuples!(scene_impl, 0, 12, P);
 ///
 /// let patch = Position::patch(|position_template, context| {
 ///     position_template.x = 10;
+///     Ok(())
 /// });
 ///
 /// let position = Position { x: 0, y: 0};
 /// // applying patch to position would result in { x: 10, y: 0 }
 /// ```
-pub struct TemplatePatch<F: FnOnce(&mut T, &mut ResolveContext), T>(pub F, pub PhantomData<T>);
+pub struct TemplatePatch<F: FnOnce(&mut T, &mut ResolveContext) -> Result, T>(
+    pub F,
+    pub PhantomData<T>,
+);
 
 /// Returns a [`Scene`] that completely overwrites the current value of a [`Template`] `T` with the given `value`.
 /// The `value` is cloned each time the [`Template`] is built.
 pub fn template_value<T: Template>(
     value: T,
-) -> TemplatePatch<impl FnOnce(&mut T, &mut ResolveContext), T> {
+) -> TemplatePatch<impl FnOnce(&mut T, &mut ResolveContext) -> Result, T> {
     TemplatePatch(
         move |input: &mut T, _context: &mut ResolveContext| {
             *input = value;
+            Ok(())
         },
         PhantomData,
     )
@@ -285,14 +293,14 @@ pub trait PatchFromTemplate {
     type Template;
 
     /// Takes a "patch function" `func`, and turns it into a [`TemplatePatch`].
-    fn patch<F: FnOnce(&mut Self::Template, &mut ResolveContext)>(
+    fn patch<F: FnOnce(&mut Self::Template, &mut ResolveContext) -> Result>(
         func: F,
     ) -> TemplatePatch<F, Self::Template>;
 }
 
 impl<G: FromTemplate> PatchFromTemplate for G {
     type Template = G::Template;
-    fn patch<F: FnOnce(&mut Self::Template, &mut ResolveContext)>(
+    fn patch<F: FnOnce(&mut Self::Template, &mut ResolveContext) -> Result>(
         func: F,
     ) -> TemplatePatch<F, Self::Template> {
         TemplatePatch(func, PhantomData)
@@ -302,12 +310,13 @@ impl<G: FromTemplate> PatchFromTemplate for G {
 /// A helper function that returns a [`TemplatePatch`] [`Scene`] for something that implements [`Template`].
 pub trait PatchTemplate: Sized {
     /// Takes a "patch function" `func` that patches this [`Template`], and turns it into a [`TemplatePatch`].
-    fn patch_template<F: FnOnce(&mut Self, &mut ResolveContext)>(func: F)
-        -> TemplatePatch<F, Self>;
+    fn patch_template<F: FnOnce(&mut Self, &mut ResolveContext) -> Result>(
+        func: F,
+    ) -> TemplatePatch<F, Self>;
 }
 
 impl<T: Template> PatchTemplate for T {
-    fn patch_template<F: FnOnce(&mut Self, &mut ResolveContext)>(
+    fn patch_template<F: FnOnce(&mut Self, &mut ResolveContext) -> Result>(
         func: F,
     ) -> TemplatePatch<F, Self> {
         TemplatePatch(func, PhantomData)
@@ -315,7 +324,7 @@ impl<T: Template> PatchTemplate for T {
 }
 
 impl<
-        F: FnOnce(&mut T, &mut ResolveContext) + Send + Sync + 'static,
+        F: FnOnce(&mut T, &mut ResolveContext) -> Result + Send + Sync + 'static,
         T: Template<Output: Component> + Send + Sync + Default + 'static,
     > Scene for TemplatePatch<F, T>
 {
@@ -325,7 +334,7 @@ impl<
         scene: &mut ResolvedScene,
     ) -> Result<(), ResolveSceneError> {
         let template = scene.get_or_insert_template::<T>(context);
-        (self.0)(template, context);
+        (self.0)(template, context).map_err(ResolveSceneError::TemplateError)?;
         Ok(())
     }
 }


### PR DESCRIPTION
_Closed in favor of #23981. See comment: https://github.com/bevyengine/bevy/pull/23966#issuecomment-4317865522_

## Objective

My original goal was to avoid panicking on a malformed `AssetPath`:

```rust
// Panics inside `AssetPath::parse_internal`
world.spawn_scene(bsn! { Mesh3d("malformed#") })
```

Fixing this meant changing a bunch of things to use `try_into` instead of `into`. The fix works for any type that implements `TryFrom` - it's not specific to `AssetPath`.

The PR doesn't *completely* fix `AssetPath`. That would mean changing the `AssetPath` `From<&'static str>` to be `TryFrom`, which is a big and controversial change. See https://github.com/bevyengine/bevy/issues/23936 for details.

## Solution

The code generated by `bsn! { Mesh3d("malformed#") }` is:

```rust
bevy_scene::SceneScope({
    let _res = (<Mesh3d as bevy_scene::PatchFromTemplate>::patch(move |value, _context| {
        value.0 = "malformed#".into();
    }));
    _res
})
```

The panic is inside `"malformed#".into()`, which calls `From<&'static str> for AssetPath<'static>`, which calls `AssetPath::parse_internal`.

To fix this, I started by making the patch closure return a `bevy_ecs::Result`.

```diff
-pub struct TemplatePatch<F: FnOnce(&mut T, &mut ResolveContext), T>(pub F, pub PhantomData<T>);
+pub struct TemplatePatch<F: FnOnce(&mut T, &mut ResolveContext) -> Result, T>(pub F, pub PhantomData<T>);
```

And then handle the result where scene resolution calls the closure:

```diff
 impl<
-        F: FnOnce(&mut T, &mut ResolveContext) + Send + Sync + 'static,
+        F: FnOnce(&mut T, &mut ResolveContext) -> Result + Send + Sync + 'static,
         T: Template<Output: Component> + Send + Sync + Default + 'static,
     > Scene for TemplatePatch<F, T>
 {
     fn resolve(
         self,
         context: &mut ResolveContext,
         scene: &mut ResolvedScene,
     ) -> Result<(), ResolveSceneError> {
         let template = scene.get_or_insert_template::<T>(context);
-        (self.0)(template, context);
-        Ok(())
+       (self.0)(template, context).map_err(ResolveSceneError::BevyError)
     }
 }
```

And change the codegen for string literals to use `try_into()?` instead `into()`.

```diff
 impl ToTokens for BsnValue {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         match self {
             BsnValue::Expr(e) => quote! {{#e}.into()}.to_tokens(tokens),
             BsnValue::Closure(c) => quote! {(#c).into()}.to_tokens(tokens),
             BsnValue::Ident(i) => quote! {(#i).into()}.to_tokens(tokens),
-            BsnValue::Lit(Lit::Str(s)) => quote! {#s.into()}.to_tokens(tokens),
+            BsnValue::Lit(Lit::Str(s)) => quote! {#s.try_into()?}.to_tokens(tokens),
             BsnValue::Lit(l) => l.to_tokens(tokens),
```

This is enough to get the specific case of `AssetPath` from `str` working. However, it doesn't handle anything other than string literals - the above code has more cases that call `into`, including `BsnValue::Expr` and `BsnValue::Ident`.

I tried changing these too, but ran into a problem. The code generated by `bsn! {Value(X_AXIS)}` is:

```rust
bevy_scene::SceneScope({
    let _expr0 = (X_AXIS).try_into()?; // <-- try_into is now here
    let _res = (<Value as bevy_scene::PatchFromTemplate>::patch(move |value, _context| {
        value.0 = _expr0;
        Ok(())
    }));
    _res
})
```

The `try_into` that came from `BsnValue::Ident` is not in the patch closure like before - it's been hoisted up to `SceneScope`. This is due to `BsnType::process_field` calling `HoistedExpressions::hoist` for certain values.

I fixed this by wrapping everything in a closure:

```diff
-bevy_scene::SceneScope({
+bevy_scene::SceneScope({ ||(
     let _expr0 = (X_AXIS).try_into()?;
     let _res = (<Value as bevy_scene::PatchFromTemplate>::patch(move |value, _context| {
         value.0 = _expr0;
         Ok(())
     }));
-    _res
+    Ok(_res)
-})
+})())
```

 And changing  `SceneScope` to take the `Result` from that closure.
 
```diff
-pub struct SceneScope<S: Scene>(pub S);
+pub struct SceneScope<S: Scene>(pub Result<S, BevyError>);
```

The error is then returned by `SceneScope::resolve`. This is arguably a bit weird, as the error could have been handled earlier. But that would mean making the `bsn!` macro itself return `Result<SceneScope, BevyError>`, which seems too disruptive.

#### Non-String Literals

The original code special cased string literals - other literals don't get an `into()`

```rust
BsnValue::Lit(Lit::Str(s)) => quote! {#s.into()}.to_tokens(tokens),
BsnValue::Lit(l) => l.to_tokens(tokens),
```

That could be changed pretty easily, and I didn't get any errors when testing it:

```diff
-BsnValue::Lit(Lit::Str(s)) => quote! {#s.into()}.to_tokens(tokens),
-BsnValue::Lit(l) => l.to_tokens(tokens),
+BsnValue::Lit(l) => quote! {#l.into()}.to_tokens(tokens),
```

But this PR does *not* make that change - maybe there was a good reason for only supporting string literals? I can add it if requested.

## Objection!

There's one big flaw with this PR. Previously some things would have been compile errors:

```rust
// ERROR: the trait bound `u32: From<i32>` is not satisfied
world.spawn_scene(bsn! { U32Component({-1i32}) })
```

Now this is a runtime error, and it might be hard for the user to work out where the invalid value came from.

A related objection is: does anything _other_ than `AssetPath` need this error behaviour? I'm struggling to think of examples.

## Testing

```sh
cargo test -p bevy_scene
cargo test -p bevy_scene_macros
cargo run --example feathers_gallery --features "experimental_bevy_feathers"
cargo run --example 3d_scene
cargo run --example bsn
```

Also checked that `rust-analyzer` auto-complete still works.

## Performance

`cargo bench -p benches --bench scene` reported no differences. Tested on Win10, desktop Zen 4.

I checked the release profile disassembly of a simple scene with an infallible `TryInto` - this wasn't an exhaustive check, but I didn't spot any significant differences other than an extra block that calls `drop` on the `BevyError` in the new `ResolveSceneError::TemplateError`. 

Binary sizes for `feathers_gallery` increased slightly:

| Profile | Before | After |
|-|-|-|
| dev | 146,020 | 146,120 (+0.06%) |
| release | 87,051 | 87,260 (+0.2%) |
| release + thin lto | 76,921 | 76,944 (+0.02%) |
