### PR TITLE
Dont send focus events if focus didnt change

### DIFF
--- a/crates/bevy_input_focus/src/gained_and_lost.rs
+++ b/crates/bevy_input_focus/src/gained_and_lost.rs
@@ -38,6 +38,10 @@ pub fn process_recorded_focus_changes(mut focus: ResMut<InputFocus>, mut command
     // so we can send the correct FocusLost events when focus changes.
     let mut previous_focus = focus.original_focus;
     for change in focus.bypass_change_detection().recorded_changes.drain(..) {
+        // Only send focus change events if the focused entity actually changed.
+        if change == previous_focus {
+            continue;
+        }
         match change {
             Some(new_focus) => {
                 if let Some(old_focus) = previous_focus {

--- a/crates/bevy_input_focus/src/gained_and_lost.rs
+++ b/crates/bevy_input_focus/src/gained_and_lost.rs
@@ -188,25 +188,6 @@ mod tests {
     }
 
     #[test]
-    fn set_focus_to_same_entity() {
-        let mut app = setup_app();
-        let entity = app.world_mut().spawn_empty().id();
-
-        app.world_mut().resource_mut::<InputFocus>().set(entity);
-        app.update();
-        take_log(&mut app);
-
-        // Setting focus to the already-focused entity still records a change.
-        app.world_mut().resource_mut::<InputFocus>().set(entity);
-        app.update();
-
-        assert_eq!(
-            take_log(&mut app),
-            vec![FocusEvent::Lost(entity), FocusEvent::Gained(entity)]
-        );
-    }
-
-    #[test]
     fn clear_when_already_none() {
         let mut app = setup_app();
         take_log(&mut app);


### PR DESCRIPTION
# Objective
Currently `FocusGained` and `FocusLost` events are send even when the entity was already in focus. For example when clicking the same text field twice, the text field will receive another `FocusLost` and `FocusGained` event on the second click, although it was already in focus. 

This could be intended behavior and it can always be worked around by deduplicating focus events yourself, so this PR is only a suggestion.

## Testing
I have more PRs ready to go that will add optional select all on focus gained support , which I used for testing this deduplication.