### PR TITLE
Optional select all text on focus

### DIFF
--- a/crates/bevy_feathers/src/controls/number_input.rs
+++ b/crates/bevy_feathers/src/controls/number_input.rs
@@ -19,7 +19,7 @@ use bevy_text::{
     EditableText, EditableTextFilter, FontSource, FontWeight, TextEdit, TextEditChange, TextFont,
 };
 use bevy_ui::{px, widget::Text, AlignItems, AlignSelf, Display, JustifyContent, Node, UiRect};
-use bevy_ui_widgets::ValueChange;
+use bevy_ui_widgets::{SelectAllOnFocus, ValueChange};
 
 use crate::{
     constants::{fonts, size},
@@ -162,6 +162,7 @@ pub fn number_input(props: NumberInputProps) -> impl Scene {
                 visible_width: None,
                 max_characters: Some(20),
             })
+            SelectAllOnFocus,
             on(number_input_on_text_change)
             on(number_input_on_enter_key)
             on(number_input_on_focus_loss)

--- a/crates/bevy_input_focus/src/gained_and_lost.rs
+++ b/crates/bevy_input_focus/src/gained_and_lost.rs
@@ -38,6 +38,10 @@ pub fn process_recorded_focus_changes(mut focus: ResMut<InputFocus>, mut command
     // so we can send the correct FocusLost events when focus changes.
     let mut previous_focus = focus.original_focus;
     for change in focus.bypass_change_detection().recorded_changes.drain(..) {
+        // Only send focus change events if the focused entity actually changed.
+        if change == previous_focus {
+            continue;
+        }
         match change {
             Some(new_focus) => {
                 if let Some(old_focus) = previous_focus {

--- a/crates/bevy_input_focus/src/gained_and_lost.rs
+++ b/crates/bevy_input_focus/src/gained_and_lost.rs
@@ -188,25 +188,6 @@ mod tests {
     }
 
     #[test]
-    fn set_focus_to_same_entity() {
-        let mut app = setup_app();
-        let entity = app.world_mut().spawn_empty().id();
-
-        app.world_mut().resource_mut::<InputFocus>().set(entity);
-        app.update();
-        take_log(&mut app);
-
-        // Setting focus to the already-focused entity still records a change.
-        app.world_mut().resource_mut::<InputFocus>().set(entity);
-        app.update();
-
-        assert_eq!(
-            take_log(&mut app),
-            vec![FocusEvent::Lost(entity), FocusEvent::Gained(entity)]
-        );
-    }
-
-    #[test]
     fn clear_when_already_none() {
         let mut app = setup_app();
         take_log(&mut app);

--- a/crates/bevy_text/src/text_edit.rs
+++ b/crates/bevy_text/src/text_edit.rs
@@ -136,6 +136,11 @@ pub enum TextEdit {
     ///
     /// Typically generated in response to select-all commands such as Ctrl + A or Cmd + A.
     SelectAll,
+    /// Selects all text if the current selection is collapsed.
+    ///
+    /// Typically generated in response to a chain of focus gained by pointer press into
+    /// pointer release events.
+    SelectAllIfCollapsed,
     /// Moves the cursor to the given point.
     ///
     /// Typically generated in response to a pointer press within the text area.
@@ -259,6 +264,11 @@ impl TextEdit {
             TextEdit::LineEnd(true) => driver.select_to_line_end(),
             TextEdit::CollapseSelection => driver.collapse_selection(),
             TextEdit::SelectAll => driver.select_all(),
+            TextEdit::SelectAllIfCollapsed => {
+                if driver.editor.raw_selection().is_collapsed() {
+                    driver.select_all();
+                }
+            }
             TextEdit::MoveToPoint(point) => driver.move_to_point(point.x, point.y),
             TextEdit::ExtendSelectionToPoint(point) => {
                 driver.extend_selection_to_point(point.x, point.y);

--- a/crates/bevy_ui_widgets/src/editable_text.rs
+++ b/crates/bevy_ui_widgets/src/editable_text.rs
@@ -11,9 +11,9 @@ use bevy_app::{App, Plugin, PostUpdate, PreUpdate};
 use bevy_ecs::prelude::*;
 use bevy_input::keyboard::{Key, KeyboardInput};
 use bevy_input::{ButtonInput, InputSystems};
-use bevy_input_focus::{FocusLost, FocusedInput, InputFocus, InputFocusSystems};
+use bevy_input_focus::{FocusGained, FocusLost, FocusedInput, InputFocus, InputFocusSystems};
 use bevy_math::Vec2;
-use bevy_picking::events::{Drag, Pointer, Press};
+use bevy_picking::events::{Drag, Pointer, Press, Release};
 use bevy_picking::pointer::PointerButton;
 use bevy_text::{EditableText, PreeditCursor, TextEdit};
 use bevy_ui::widget::{scroll_editable_text, update_editable_text_layout, TextScroll};
@@ -231,18 +231,24 @@ fn on_pointer_drag(
         return;
     }
 
-    let Some(local_pos) = transform.try_inverse().map(|inverse| {
-        inverse
-            .transform_point2(drag.pointer_location.position * target.scale_factor() / ui_scale.0)
-            - node.content_box().min
-            + text_scroll.0
+    let Some((drag_start_local_pos, current_local_pos)) = transform.try_inverse().map(|inverse| {
+        let transform_pos = |pointer_pos| {
+            inverse.transform_point2(pointer_pos * target.scale_factor() / ui_scale.0)
+                - node.content_box().min
+                + text_scroll.0
+        };
+        let current_pos = drag.pointer_location.position;
+        let drag_start_pos = current_pos - drag.distance;
+        (transform_pos(drag_start_pos), transform_pos(current_pos))
     }) else {
         return;
     };
 
-    editable_text
-        .pending_edits
-        .push(TextEdit::ExtendSelectionToPoint(local_pos));
+    editable_text.pending_edits.extend([
+        TextEdit::MoveToPoint(drag_start_local_pos),
+        TextEdit::ExtendSelectionToPoint(current_local_pos),
+    ]);
+
     drag.propagate(false);
 }
 
@@ -374,9 +380,67 @@ fn listen_for_ime_input_when_text_input_focused(
 /// previous input.
 /// The IME stays enabled because both entities are [`EditableText`],
 /// and no [`Ime::Disabled`] event is ever fired to trigger the cleanup in [`on_ime_input`].
-fn on_focus_lost(trigger: On<FocusLost>, mut editable_text_query: Query<&mut EditableText>) {
+fn on_focus_lost_clear_ime(
+    trigger: On<FocusLost>,
+    mut editable_text_query: Query<&mut EditableText>,
+) {
     if let Ok(mut editable_text) = editable_text_query.get_mut(trigger.entity) {
         editable_text.queue_edit(TextEdit::clear_ime_compose());
+    }
+}
+
+/// Marker component for [`EditableText`] widgets that should select all text on focus.
+///
+/// If a pointer press is what caused the focus, the select all is deferred until
+/// pointer release and is only applied if there is no other selection by then.
+/// For example, if pointer dragging caused a selection to be made, we don't want
+/// to replace it with a select all.
+#[derive(Component, Clone, Default)]
+pub struct SelectAllOnFocus;
+
+/// Resource to track when a pointer press caused focus on an [`EditableText`].
+/// A corresponding pointer release will select all text if there is no other selection.
+#[derive(Resource, Default)]
+struct QueuedSelectAll(Option<(Entity, PointerButton)>);
+
+fn on_focus_select_all(
+    focus_gained: On<FocusGained>,
+    mut pointer_presses: MessageReader<Pointer<Press>>,
+    mut q_text_input: Query<&mut EditableText, With<SelectAllOnFocus>>,
+    mut queued_select_all: ResMut<QueuedSelectAll>,
+) {
+    let target = focus_gained.event_target();
+    if let Ok(mut editable_text) = q_text_input.get_mut(target) {
+        // Ideally, FocusGained would contain information on how it was gained instead.
+        let focus_gained_by_pointer_press =
+            pointer_presses.read().find(|press| press.entity == target);
+        if let Some(press) = focus_gained_by_pointer_press {
+            queued_select_all.0 = Some((target, press.button));
+        } else {
+            editable_text.queue_edit(TextEdit::SelectAll);
+        }
+    }
+}
+
+/// `on_focus_select_all` defers selection until pointer release if the focus was gained
+/// by a pointer press. This system applies the queued selection.
+///
+/// Note, that the `Pointer<Release>` does not have to happen on the same entity.
+fn apply_queued_select_all(
+    mut pointer_releases: MessageReader<Pointer<Release>>,
+    mut queued_select_all: ResMut<QueuedSelectAll>,
+    mut q_text_input: Query<&mut EditableText, With<SelectAllOnFocus>>,
+) {
+    let Some((target, button)) = queued_select_all.0 else {
+        return;
+    };
+    for pointer_release in pointer_releases.read() {
+        if pointer_release.button == button
+            && let Ok(mut editable_text) = q_text_input.get_mut(target)
+        {
+            editable_text.queue_edit(TextEdit::SelectAllIfCollapsed);
+            queued_select_all.0 = None;
+        }
     }
 }
 
@@ -410,10 +474,12 @@ pub struct EditableTextInputPlugin;
 
 impl Plugin for EditableTextInputPlugin {
     fn build(&self, app: &mut App) {
-        app.add_observer(on_focused_keyboard_input)
+        app.init_resource::<QueuedSelectAll>()
+            .add_observer(on_focused_keyboard_input)
             .add_observer(on_pointer_drag)
             .add_observer(on_pointer_press)
-            .add_observer(on_focus_lost)
+            .add_observer(on_focus_lost_clear_ime)
+            .add_observer(on_focus_select_all)
             .add_systems(
                 PreUpdate,
                 (
@@ -436,6 +502,12 @@ impl Plugin for EditableTextInputPlugin {
                     // FocusChangeEvents does not mutate the actual InputFocus;
                     // this is a false positive that can be ignored
                     .ambiguous_with(InputFocusSystems::FocusChangeEvents),
+            )
+            .add_systems(
+                PostUpdate,
+                apply_queued_select_all
+                    .in_set(UiSystems::PostLayout)
+                    .before(update_editable_text_layout),
             );
 
         // These components cannot be registered in `bevy_text` where `EditableText` is defined,


### PR DESCRIPTION
builds on top of #23967

# Objective
It is common for text input fields to select all text when they are focused. Bevy text inputs should optionally support this too.

## Solution
Provide a new component `SelectAllOnFocus` that can be added to an entity with `EditableText` to enable selecting all text on `FocusGained`.

The select all behavior for `FocusGained` by pointer press needs special attention: select all is deferred until pointer release, because if the pointer press is followed by pointer dragging to select only a section of the text, the select all should not fire. 

If the focus gaining pointer press is released on a different entity (but no text was selected by dragging) the select all still fires. This was not universally the case in all text input fields from other applications I tested and could be changed. The last selection in the video below shows an example of this.

## Testing
Added `SelectAllOnFocus` to the `number_input` of `bevy_feathers`:

https://github.com/user-attachments/assets/e643f396-0b29-4d23-ae7a-c16c942e574f

## Questions
I'm not familiar with ime and I'm unsure how/if this PR interacts with it.