### PR TITLE
Fix warnings in rustc nightly due to introduction of From<f16> for f32

### DIFF
--- a/crates/bevy_ui/src/layout/convert.rs
+++ b/crates/bevy_ui/src/layout/convert.rs
@@ -31,7 +31,7 @@ impl Val {
 
     fn into_length_percentage(self, context: &LayoutContext) -> taffy::style::LengthPercentage {
         match self {
-            Val::Auto => style_helpers::length(0.),
+            Val::Auto => style_helpers::length(0.0_f32),
             Val::Percent(value) => style_helpers::percent(value / 100.),
             Val::Px(value) => style_helpers::length(context.scale_factor * value),
             Val::VMin(value) => {

--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -182,8 +182,8 @@ impl UiSurface {
                         // Note: Taffy percentages are floats ranging from 0.0 to 1.0.
                         // So this is setting width:100% and height:100%
                         size: taffy::geometry::Size {
-                            width: taffy::style_helpers::percent(1.0),
-                            height: taffy::style_helpers::percent(1.0),
+                            width: taffy::style_helpers::percent(1.0_f32),
+                            height: taffy::style_helpers::percent(1.0_f32),
                         },
                         align_items: Some(taffy::style::AlignItems::Start),
                         justify_items: Some(taffy::style::JustifyItems::Start),


### PR DESCRIPTION
# Objective

There's a new warning for code that uses literals with `Into<f32>` because the compiler can no longer infer that the literal should be an `f32` after `From<f16> for f32` was introduced.

See: https://github.com/rust-lang/rust/issues/154024

## Solution

Explicit `f32` literals.

## Note

This behavior might make `Into<f32>` arguments inconvenient in the future.
