### PR TITLE
Add FontSmoothing::SubpixelAntiAliased for RGB subpixel text

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3940,6 +3940,17 @@ category = "UI (User Interface)"
 wasm = true
 
 [[example]]
+name = "text_subpixel"
+path = "examples/ui/text_subpixel.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.text_subpixel]
+name = "Text Subpixel"
+description = "Compares FontSmoothing variants including RGB subpixel antialiasing"
+category = "UI (User Interface)"
+wasm = false
+
+[[example]]
 name = "text_background_colors"
 path = "examples/ui/text/text_background_colors.rs"
 doc-scrape-examples = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1007,6 +1007,17 @@ category = "2D Rendering"
 wasm = true
 
 [[example]]
+name = "text2d_subpixel"
+path = "examples/2d/text2d_subpixel.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.text2d_subpixel]
+name = "Text 2D Subpixel"
+description = "Compares FontSmoothing variants for Text2d, including RGB subpixel antialiasing"
+category = "2D Rendering"
+wasm = false
+
+[[example]]
 name = "multi_window_text"
 path = "examples/window/multi_window_text.rs"
 doc-scrape-examples = true

--- a/_release-content/release-notes/subpixel_text.md
+++ b/_release-content/release-notes/subpixel_text.md
@@ -12,7 +12,7 @@ modern code editors. Opt in per-`Text` (or `Text2d`) by setting
 Bevy's existing grayscale AA (`FontSmoothing::AntiAliased`, the default) has
 an effective horizontal resolution of one physical pixel — a glyph stem that
 falls between pixels gets softened into a two-pixel-wide gray blur. Subpixel
-AA treats each pixel as three horizontal colour sub-pixels (R, G, B, as
+AA treats each pixel as three horizontal color sub-pixels (R, G, B, as
 physically arranged on most LCD/OLED panels) and addresses them
 independently, roughly tripling the effective horizontal resolution. At 10pt
 and 14pt body text the difference is clearly visible: sharper vertical stems,
@@ -80,7 +80,7 @@ column. The extended `GlyphCacheKey` gives each of the four horizontal
 subpixel bins its own atlas cell, and the render pipelines select a
 dual-source-blend (DSB) shader variant that emits per-channel source and
 per-pixel alpha in a single pass — the GPU then blends against the
-framebuffer using `Src1 / OneMinusSrc1` colour and `One / OneMinusSrcAlpha`
+framebuffer using `Src1 / OneMinusSrc1` color and `One / OneMinusSrcAlpha`
 alpha. The WGSL helpers (`color_brightness`,
 `apply_contrast_and_gamma_correction3`, `swizzle_subpixel_atlas`, …) are
 ported directly from GPUI's Metal shader.

--- a/_release-content/release-notes/subpixel_text.md
+++ b/_release-content/release-notes/subpixel_text.md
@@ -1,0 +1,113 @@
+---
+title: RGB Subpixel Antialiased Text
+authors: ["@masegraye"]
+pull_requests: []
+---
+
+Bevy can now render text with **RGB subpixel antialiasing**, the technique
+behind the visibly crisper text you see in Zed, macOS native apps, and most
+modern code editors. Opt in per-`Text` (or `Text2d`) by setting
+`TextFont::font_smoothing = FontSmoothing::SubpixelAntiAliased`.
+
+Bevy's existing grayscale AA (`FontSmoothing::AntiAliased`, the default) has
+an effective horizontal resolution of one physical pixel — a glyph stem that
+falls between pixels gets softened into a two-pixel-wide gray blur. Subpixel
+AA treats each pixel as three horizontal colour sub-pixels (R, G, B, as
+physically arranged on most LCD/OLED panels) and addresses them
+independently, roughly tripling the effective horizontal resolution. At 10pt
+and 14pt body text the difference is clearly visible: sharper vertical stems,
+better digit legibility, no "dancing" between pixel rows. The tradeoff is a
+subtle rainbow halo on contrast edges, which is why it is opt-in rather than
+the default.
+
+## How to enable
+
+```rust
+use bevy::prelude::*;
+use bevy::text::FontSmoothing;
+
+commands.spawn((
+    Text::new("Sharper body text"),
+    TextFont {
+        font: asset_server.load("fonts/FiraSans-Bold.ttf").into(),
+        font_size: FontSize::Px(14.0),
+        font_smoothing: FontSmoothing::SubpixelAntiAliased,
+        ..default()
+    },
+));
+```
+
+The same `FontSmoothing` variant works for `Text2d` (world-space sprite
+text) without any extra setup — both the UI and sprite render pipelines
+share the glyph atlas and the RGB coverage path.
+
+## What's in the feature
+
+- **UI text + `Text2d` support.** Both `bevy_ui_render` and
+  `bevy_sprite_render` gain a dual-source-blend subpixel pipeline variant
+  selected per extracted item when a glyph's section uses
+  `FontSmoothing::SubpixelAntiAliased`.
+- **`SubpixelTextSettings` resource** for app-level tuning. Two fields —
+  `enhanced_contrast: f32` (default `0.5`) and `gamma_ratios: Vec4` (the
+  gamma=1.8 row of GPUI's `GAMMA_INCORRECT_TARGET_RATIOS`). Apps targeting
+  specific display/background/foreground combinations (dark IDE, light
+  reading app) can tune these once and both pipelines pick up the change.
+- **`SubpixelLcdLayout` resource** for panel orientation. Two variants:
+  `HorizontalRgb` (default, covers ~99% of desktop LCDs) and
+  `HorizontalBgr` (some older displays). Vertical-subpixel variants are
+  deliberately deferred — correct vertical-subpixel AA needs a rasteriser
+  rotation or a second atlas, which is better handled in a dedicated
+  follow-up than bundled here.
+- **Per-subpixel-bucket atlas partitioning** via the `subpixel_bucket`
+  field on `GlyphCacheKey`. Glyphs rasterised at different horizontal
+  sub-pixel offsets (four bins: `Zero`, `Quarter`, `Half`, `ThreeQuarter`)
+  land in separate atlas cells so shaping at fractional positions stays
+  crisp. Non-subpixel smoothing modes use `SubpixelBucket::NotApplicable`
+  and retain the prior single-cell-per-glyph layout.
+- **Graceful DSB-unavailable fallback.** On adapters where
+  `wgpu::Features::DUAL_SOURCE_BLENDING` is unavailable (WebGL2, some
+  older mobile Vulkan, DX11), the `SubpixelCapable` resource is `false`
+  and `SubpixelAntiAliased` requests transparently downgrade to the
+  grayscale pipeline so apps continue to render correctly.
+
+## How it works
+
+On `SubpixelAntiAliased`, `get_outlined_glyph_texture` calls
+`swash::scale::Render::new(...).format(Format::Subpixel).offset(...)`
+instead of the default `Format::Alpha` path, producing an RGB coverage
+atlas where each of the three channels represents coverage of one subpixel
+column. The extended `GlyphCacheKey` gives each of the four horizontal
+subpixel bins its own atlas cell, and the render pipelines select a
+dual-source-blend (DSB) shader variant that emits per-channel source and
+per-pixel alpha in a single pass — the GPU then blends against the
+framebuffer using `Src1 / OneMinusSrc1` colour and `One / OneMinusSrcAlpha`
+alpha. The WGSL helpers (`color_brightness`,
+`apply_contrast_and_gamma_correction3`, `swizzle_subpixel_atlas`, …) are
+ported directly from GPUI's Metal shader.
+
+Detect DSB support at runtime via the `bevy_text::SubpixelCapable`
+resource, which is inserted by both `bevy_ui_render::init_ui_subpixel_capability`
+and `bevy_sprite_render::init_sprite_subpixel_capability` at `RenderStartup`.
+
+## Limitations
+
+- **Vertical-subpixel panels.** Rotated portrait panels and vertical-stripe
+  OLEDs are not currently supported; the atlas is pre-offset horizontally
+  by swash and would need a rotated rasterisation path for vertical
+  fringing to line up correctly. A future spec may revisit this.
+- **LCD-orientation auto-detection.** No platform-specific probing today —
+  `SubpixelLcdLayout` is a manual override. Auto-detection would require
+  per-OS APIs that are fiddly enough to be their own future work.
+- **Adapter feature requirement.** Subpixel AA relies on
+  `wgpu::Features::DUAL_SOURCE_BLENDING`. Adapters without DSB fall back
+  to grayscale AA instead of the subpixel pipeline; apps render correctly
+  but without the extra horizontal resolution.
+
+## Examples
+
+See `examples/ui/text_subpixel.rs` for a UI-side side-by-side comparison of
+the three `FontSmoothing` variants at four font sizes, with interactive
+keyboard controls for `enhanced_contrast` (`1`/`2`/`3`),
+`SubpixelLcdLayout` (`R`/`B`), and ad-hoc screenshot capture (`S`). See
+`examples/2d/text2d_subpixel.rs` for the `Text2d` / world-space
+counterpart.

--- a/crates/bevy_sprite_render/Cargo.toml
+++ b/crates/bevy_sprite_render/Cargo.toml
@@ -13,6 +13,11 @@ webgl = []
 webgpu = []
 bevy_text = ["dep:bevy_text", "bevy_sprite/bevy_text"]
 
+[dev-dependencies]
+bevy_asset = { path = "../bevy_asset", version = "0.19.0-dev" }
+bevy_render = { path = "../bevy_render", version = "0.19.0-dev" }
+bevy_shader = { path = "../bevy_shader", version = "0.19.0-dev" }
+
 [dependencies]
 # bevy
 bevy_app = { path = "../bevy_app", version = "0.19.0-dev" }

--- a/crates/bevy_sprite_render/src/lib.rs
+++ b/crates/bevy_sprite_render/src/lib.rs
@@ -98,7 +98,22 @@ impl Plugin for SpriteRenderPlugin {
                 .init_resource::<SpriteAssetEvents>()
                 .init_resource::<SpriteBatches>()
                 .add_render_command::<Transparent2d, DrawSprite>()
-                .add_systems(RenderStartup, init_sprite_pipeline)
+                .add_systems(
+                    RenderStartup,
+                    (
+                        init_sprite_pipeline,
+                        // Idempotent with `bevy_ui_render::init_ui_subpixel_capability` —
+                        // both systems read the same adapter feature set and
+                        // produce the same `bevy_text::SubpixelCapable` value,
+                        // so their relative startup order does not matter.
+                        // Only installed when the `bevy_text` feature is
+                        // enabled; without `Text2d` there are no
+                        // subpixel-flagged sprites, so the capability flag is
+                        // unused.
+                        #[cfg(feature = "bevy_text")]
+                        init_sprite_subpixel_capability,
+                    ),
+                )
                 .add_systems(
                     ExtractSchedule,
                     (

--- a/crates/bevy_sprite_render/src/render/mod.rs
+++ b/crates/bevy_sprite_render/src/render/mod.rs
@@ -114,7 +114,7 @@ pub fn init_sprite_pipeline(mut commands: Commands, asset_server: Res<AssetServe
 /// owns its own `ShaderType`-derived uniform struct because `ShaderType`
 /// lives in `bevy_render` (which `bevy_text` deliberately does not depend
 /// on), so the struct can't be hoisted to the shared crate. The layout is
-/// identical byte-for-byte; both structs serialise from the same
+/// identical byte-for-byte; both structs serialize from the same
 /// [`SubpixelTextSettings`] + [`SubpixelLcdLayout`] inputs. A future
 /// consolidation spec can merge the two.
 ///
@@ -389,7 +389,7 @@ impl SpecializedRenderPipeline for SpritePipeline {
         //              + dst.rgb * (1 - alpha_per_channel)
         // which requires `Src1` / `OneMinusSrc1` (the per-channel alpha is
         // the dual-source output). Alpha keeps conventional premultiplied
-        // behaviour so the framebuffer's own alpha stays sensible. Mirrors
+        // behavior so the framebuffer's own alpha stays sensible. Mirrors
         // `bevy_ui_render::UiPipeline::specialize`'s subpixel branch
         // (phase-04 of spec/0013) and GPUI's subpixel pipeline.
         let (fragment_entry_point, blend) = if subpixel {
@@ -754,7 +754,7 @@ pub fn queue_sprites(
         }
 
         // Base pipeline variant for non-subpixel sprites. The subpixel
-        // variant is specialised on-demand below per-sprite so pure
+        // variant is specialized on-demand below per-sprite so pure
         // grayscale workloads don't pay for a second pipeline compile.
         let pipeline = pipelines.specialize(&pipeline_cache, &sprite_pipeline, view_key);
 

--- a/crates/bevy_sprite_render/src/render/mod.rs
+++ b/crates/bevy_sprite_render/src/render/mod.rs
@@ -46,6 +46,14 @@ use bevy_render::{
 };
 use bevy_shader::{Shader, ShaderDefVal};
 use bevy_sprite::{Anchor, Sprite, SpriteScalingMode};
+// Subpixel text tuning resources live in `bevy_text` (consolidated in
+// phase-05 of spec/0013). `bevy_text` is an optional dependency of
+// `bevy_sprite_render`; the extraction system that copies the resources
+// into the uniform is feature-gated. The uniform struct itself and the
+// view bind-group layout entry are compiled unconditionally so the
+// `SpritePipelineKey::SUBPIXEL` variant always has a consistent layout.
+#[cfg(feature = "bevy_text")]
+use bevy_text::{SubpixelLcdLayout, SubpixelTextSettings};
 use bevy_transform::components::GlobalTransform;
 use bevy_utils::default;
 use bytemuck::{Pod, Zeroable};
@@ -53,13 +61,20 @@ use fixedbitset::FixedBitSet;
 
 #[derive(Resource)]
 pub struct SpritePipeline {
-    view_layout: BindGroupLayoutDescriptor,
-    material_layout: BindGroupLayoutDescriptor,
-    shader: Handle<Shader>,
+    pub view_layout: BindGroupLayoutDescriptor,
+    pub material_layout: BindGroupLayoutDescriptor,
+    pub shader: Handle<Shader>,
 }
 
 pub fn init_sprite_pipeline(mut commands: Commands, asset_server: Res<AssetServer>) {
     let tonemapping_lut_entries = get_lut_bind_group_layout_entries();
+    // Binding 3 holds the `SubpixelTextUniforms` consumed by the
+    // `fragment_subpixel` entry point. Declared on every sprite pipeline
+    // variant so the view bind-group layout is shared between the standard
+    // sprite path and the subpixel text path. Non-subpixel fragment entries
+    // don't reference the binding; naga/wgpu tolerate unused bindings as
+    // long as the layout matches. Mirrors
+    // `bevy_ui_render::pipeline::init_ui_pipeline` (phase-04 of spec/0013).
     let view_layout = BindGroupLayoutDescriptor::new(
         "sprite_view_layout",
         &BindGroupLayoutEntries::sequential(
@@ -68,6 +83,7 @@ pub fn init_sprite_pipeline(mut commands: Commands, asset_server: Res<AssetServe
                 uniform_buffer::<ViewUniform>(true),
                 tonemapping_lut_entries[0].visibility(ShaderStages::FRAGMENT),
                 tonemapping_lut_entries[1].visibility(ShaderStages::FRAGMENT),
+                uniform_buffer::<SubpixelTextUniforms>(false).visibility(ShaderStages::FRAGMENT),
             ),
         ),
     );
@@ -90,11 +106,113 @@ pub fn init_sprite_pipeline(mut commands: Commands, asset_server: Res<AssetServe
     });
 }
 
+/// GPU-facing form of [`bevy_text::SubpixelTextSettings`] and
+/// [`bevy_text::SubpixelLcdLayout`], bound as `@group(0) @binding(3)` of the
+/// sprite view bind group on every pipeline variant.
+///
+/// Duplicated from `bevy_ui_render::SubpixelTextUniforms` — each render crate
+/// owns its own `ShaderType`-derived uniform struct because `ShaderType`
+/// lives in `bevy_render` (which `bevy_text` deliberately does not depend
+/// on), so the struct can't be hoisted to the shared crate. The layout is
+/// identical byte-for-byte; both structs serialise from the same
+/// [`SubpixelTextSettings`] + [`SubpixelLcdLayout`] inputs. A future
+/// consolidation spec can merge the two.
+///
+/// `std140` layout notes (match `bevy_ui_render::SubpixelTextUniforms`):
+/// - `enhanced_contrast: f32` (offset 0) + `layout_flags: u32` (offset 4)
+///   pack into the first 8 bytes of the leading 16-byte slot.
+/// - `_pad: Vec2` (offset 8) fills the rest of that 16-byte slot so the
+///   trailing `vec4<f32> gamma_ratios` lands on its required 16-byte
+///   boundary.
+///
+/// Total: 32 bytes.
+///
+/// Populated each frame by [`prepare_sprite_view_bind_groups`] from the
+/// main-world [`SubpixelTextSettings`] / [`SubpixelLcdLayout`] resources
+/// when the `bevy_text` feature is enabled. When the feature is off, the
+/// buffer holds [`SubpixelTextUniforms::default`] permanently — the
+/// subpixel fragment path still compiles but is never reached because no
+/// sprite sets [`ExtractedSprite::subpixel`] to `true`.
+#[derive(ShaderType, Clone, Copy, Debug)]
+pub struct SubpixelTextUniforms {
+    /// Enhanced-contrast factor (GPUI default `0.5`). Scales Skia's light-
+    /// on-dark contrast ramp inside `fragment_subpixel`.
+    pub enhanced_contrast: f32,
+    /// LCD subpixel layout discriminant. Matches the constants in
+    /// `sprite.wgsl` (`SUBPIXEL_LAYOUT_HORIZONTAL_RGB = 0`, etc.) and
+    /// [`bevy_text::SubpixelLcdLayout::pack_u32`].
+    pub layout_flags: u32,
+    /// Explicit padding so `gamma_ratios` lands on a std140 16-byte
+    /// boundary. Must match the shader's `_pad: vec2<f32>`.
+    pub _pad: Vec2,
+    /// Four-element gamma-correction table row, precomputed from GPUI's
+    /// `GAMMA_INCORRECT_TARGET_RATIOS` at gamma = 1.8. See
+    /// `zed/crates/gpui/src/platform.rs::get_gamma_correction_ratios`.
+    pub gamma_ratios: Vec4,
+}
+
+impl Default for SubpixelTextUniforms {
+    fn default() -> Self {
+        // Must match `SubpixelTextSettings::default()` +
+        // `SubpixelLcdLayout::default()` so the initial bind-group value is
+        // consistent with the tuning resources before the first prepare
+        // system run. `enhanced_contrast = 0.5` is GPUI's
+        // `RenderingParameters::new()`; the gamma ratios are the gamma-1.8
+        // row of `GAMMA_INCORRECT_TARGET_RATIOS`. `layout_flags = 0` is
+        // `HorizontalRgb` — the identity swizzle in
+        // `swizzle_subpixel_atlas`.
+        Self {
+            enhanced_contrast: 0.5,
+            layout_flags: 0,
+            _pad: Vec2::ZERO,
+            gamma_ratios: Vec4::new(0.14746, -0.89481, 1.47021, -0.32474),
+        }
+    }
+}
+
+/// Populate the [`bevy_text::SubpixelCapable`] resource from the active
+/// render adapter's wgpu feature set at `RenderStartup`. Reads
+/// [`WgpuFeatures::DUAL_SOURCE_BLENDING`] — the feature the subpixel sprite
+/// fragment entry (`fragment_subpixel` in `sprite.wgsl`) requires for its
+/// `@blend_src(1)` output.
+///
+/// On adapters without DSB support, [`crate::extract_text2d_sprite`] forces
+/// subpixel-smoothed glyph batches to the grayscale pipeline variant — no
+/// panic, no shader error, just a silent visual degradation to approximate
+/// grayscale AA (only the `.r` channel of the RGBA coverage atlas is used).
+///
+/// Idempotent with `bevy_ui_render::init_ui_subpixel_capability`: both
+/// systems read the same underlying adapter feature set and therefore
+/// produce the same [`bevy_text::SubpixelCapable`] value, so last-writer-
+/// wins is correct regardless of the render sub-app startup order.
+///
+/// Only compiled when the `bevy_text` feature is enabled — without
+/// `Text2d` there are no subpixel-flagged sprites, so the capability flag
+/// isn't needed by any system in this crate.
+#[cfg(feature = "bevy_text")]
+pub fn init_sprite_subpixel_capability(mut commands: Commands, render_device: Res<RenderDevice>) {
+    let supported = render_device
+        .features()
+        .contains(WgpuFeatures::DUAL_SOURCE_BLENDING);
+    commands.insert_resource(bevy_text::SubpixelCapable(supported));
+}
+
 bitflags::bitflags! {
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
     #[repr(transparent)]
     // NOTE: Apparently quadro drivers support up to 64x MSAA.
     // MSAA uses the highest 3 bits for the MSAA log2(sample count) to support up to 128x MSAA.
+    //
+    // Bit layout:
+    //   0        TONEMAP_IN_SHADER
+    //   1        DEBAND_DITHER
+    //   2        SRGB_COMPOSITING
+    //   3        OKLAB_COMPOSITING
+    //   4..=8    COLOR_TARGET_FORMAT  (5 bits, `COLOR_TARGET_FORMAT_MASK_BITS`)
+    //   9        SUBPIXEL             (first unused bit after the color target reserved range)
+    //   10..=24  (free for future use)
+    //   25..=28  TONEMAP_METHOD       (4 bits)
+    //   29..=31  MSAA                 (3 bits)
     pub struct SpritePipelineKey: u32 {
         const NONE                              = 0;
         const TONEMAP_IN_SHADER                 = 1 << 0;
@@ -102,6 +220,17 @@ bitflags::bitflags! {
         const SRGB_COMPOSITING                  = 1 << 2;
         const OKLAB_COMPOSITING                 = 1 << 3;
         const COLOR_TARGET_FORMAT_RESERVED_BITS = Self::COLOR_TARGET_FORMAT_MASK_BITS << Self::COLOR_TARGET_FORMAT_SHIFT_BITS;
+        /// Selects the RGB subpixel text pipeline variant (phase-06 of
+        /// spec/0013). When set, [`SpritePipeline::specialize`] emits the
+        /// dual-source-blend variant (`fragment_subpixel` entry point,
+        /// `SUBPIXEL` `shader_def`, `Src1` / `OneMinusSrc1` color blend).
+        /// Only flipped by [`crate::extract_text2d_sprite`] for glyph
+        /// batches whose source section used
+        /// [`FontSmoothing::SubpixelAntiAliased`](bevy_text::FontSmoothing::SubpixelAntiAliased)
+        /// and only when the adapter advertises
+        /// [`wgpu::Features::DUAL_SOURCE_BLENDING`](https://docs.rs/wgpu/latest/wgpu/struct.Features.html#associatedconstant.DUAL_SOURCE_BLENDING)
+        /// (see [`bevy_text::SubpixelCapable`]).
+        const SUBPIXEL                          = 1 << 9;
         const MSAA_RESERVED_BITS                = Self::MSAA_MASK_BITS << Self::MSAA_SHIFT_BITS;
         const TONEMAP_METHOD_RESERVED_BITS      = Self::TONEMAP_METHOD_MASK_BITS << Self::TONEMAP_METHOD_SHIFT_BITS;
         const TONEMAP_METHOD_NONE               = 0 << Self::TONEMAP_METHOD_SHIFT_BITS;
@@ -162,7 +291,11 @@ impl SpecializedRenderPipeline for SpritePipeline {
     type Key = SpritePipelineKey;
 
     fn specialize(&self, key: Self::Key) -> RenderPipelineDescriptor {
+        let subpixel = key.contains(SpritePipelineKey::SUBPIXEL);
         let mut shader_defs = Vec::new();
+        if subpixel {
+            shader_defs.push("SUBPIXEL".into());
+        }
         if key.contains(SpritePipelineKey::TONEMAP_IN_SHADER) {
             shader_defs.push("TONEMAP_IN_SHADER".into());
             shader_defs.push(ShaderDefVal::UInt(
@@ -249,6 +382,36 @@ impl SpecializedRenderPipeline for SpritePipeline {
             ],
         };
 
+        // Subpixel text renders via a dual-source-blend fragment shader so
+        // the framebuffer can consume per-channel alpha from `@blend_src(1)`.
+        // Color blend:
+        //   result.rgb = fg.rgb * alpha_per_channel
+        //              + dst.rgb * (1 - alpha_per_channel)
+        // which requires `Src1` / `OneMinusSrc1` (the per-channel alpha is
+        // the dual-source output). Alpha keeps conventional premultiplied
+        // behaviour so the framebuffer's own alpha stays sensible. Mirrors
+        // `bevy_ui_render::UiPipeline::specialize`'s subpixel branch
+        // (phase-04 of spec/0013) and GPUI's subpixel pipeline.
+        let (fragment_entry_point, blend) = if subpixel {
+            (
+                Some("fragment_subpixel".into()),
+                BlendState {
+                    color: BlendComponent {
+                        src_factor: BlendFactor::Src1,
+                        dst_factor: BlendFactor::OneMinusSrc1,
+                        operation: BlendOperation::Add,
+                    },
+                    alpha: BlendComponent {
+                        src_factor: BlendFactor::One,
+                        dst_factor: BlendFactor::OneMinusSrcAlpha,
+                        operation: BlendOperation::Add,
+                    },
+                },
+            )
+        } else {
+            (None, BlendState::ALPHA_BLENDING)
+        };
+
         RenderPipelineDescriptor {
             vertex: VertexState {
                 shader: self.shader.clone(),
@@ -259,12 +422,12 @@ impl SpecializedRenderPipeline for SpritePipeline {
             fragment: Some(FragmentState {
                 shader: self.shader.clone(),
                 shader_defs,
+                entry_point: fragment_entry_point,
                 targets: vec![Some(ColorTargetState {
                     format,
-                    blend: Some(BlendState::ALPHA_BLENDING),
+                    blend: Some(blend),
                     write_mask: ColorWrites::ALL,
                 })],
-                ..default()
             }),
             layout: vec![self.view_layout.clone(), self.material_layout.clone()],
             // Sprites are always alpha blended so they never need to write to depth.
@@ -291,7 +454,11 @@ impl SpecializedRenderPipeline for SpritePipeline {
                 mask: !0,
                 alpha_to_coverage_enabled: false,
             },
-            label: Some("sprite_pipeline".into()),
+            label: Some(if subpixel {
+                "sprite_pipeline_subpixel".into()
+            } else {
+                "sprite_pipeline".into()
+            }),
             ..default()
         }
     }
@@ -315,6 +482,18 @@ pub struct ExtractedSprite {
     pub flip_x: bool,
     pub flip_y: bool,
     pub kind: ExtractedSpriteKind,
+    /// Whether this sprite renders through the RGB subpixel antialiased
+    /// text pipeline variant (`fragment_subpixel` in `sprite.wgsl`,
+    /// dual-source blend). Only set by [`crate::extract_text2d_sprite`] for
+    /// glyphs whose atlas was produced with
+    /// [`FontSmoothing::SubpixelAntiAliased`](bevy_text::FontSmoothing::SubpixelAntiAliased)
+    /// and when the adapter advertises
+    /// [`wgpu::Features::DUAL_SOURCE_BLENDING`](https://docs.rs/wgpu/latest/wgpu/struct.Features.html#associatedconstant.DUAL_SOURCE_BLENDING)
+    /// (see [`bevy_text::SubpixelCapable`]).
+    ///
+    /// Defaults to `false` for all non-text sprites and for grayscale
+    /// glyph batches — those use the standard alpha-blend path.
+    pub subpixel: bool,
 }
 
 pub enum ExtractedSpriteKind {
@@ -399,6 +578,7 @@ pub fn extract_sprites(
                 kind: ExtractedSpriteKind::Slices {
                     indices: start..end,
                 },
+                subpixel: false,
             });
         } else {
             let atlas_rect = sprite
@@ -432,6 +612,7 @@ pub fn extract_sprites(
                     // Pass the custom size
                     custom_size: sprite.custom_size,
                 },
+                subpixel: false,
             });
         }
     }
@@ -466,6 +647,16 @@ impl SpriteInstance {
 pub struct SpriteMeta {
     sprite_index_buffer: RawBufferVec<u32>,
     sprite_instance_buffer: RawBufferVec<SpriteInstance>,
+    /// Uniform buffer for [`SubpixelTextUniforms`]. Bound at `@group(0)
+    /// @binding(3)` alongside the view uniform for *all* sprite pipeline
+    /// variants — the non-subpixel fragment entry ignores it, but keeping
+    /// the bind-group layout stable avoids a separate `view_layout` per
+    /// variant. Seeded with [`SubpixelTextUniforms::default`];
+    /// [`prepare_sprite_view_bind_groups`] overwrites the value each frame
+    /// from the main-world [`bevy_text::SubpixelTextSettings`] /
+    /// [`bevy_text::SubpixelLcdLayout`] resources when the `bevy_text`
+    /// feature is enabled.
+    pub(crate) subpixel_settings: UniformBuffer<SubpixelTextUniforms>,
 }
 
 impl Default for SpriteMeta {
@@ -473,6 +664,7 @@ impl Default for SpriteMeta {
         Self {
             sprite_index_buffer: RawBufferVec::<u32>::new(BufferUsages::INDEX),
             sprite_instance_buffer: RawBufferVec::<SpriteInstance>::new(BufferUsages::VERTEX),
+            subpixel_settings: UniformBuffer::from(SubpixelTextUniforms::default()),
         }
     }
 }
@@ -561,6 +753,9 @@ pub fn queue_sprites(
             }
         }
 
+        // Base pipeline variant for non-subpixel sprites. The subpixel
+        // variant is specialised on-demand below per-sprite so pure
+        // grayscale workloads don't pay for a second pipeline compile.
         let pipeline = pipelines.specialize(&pipeline_cache, &sprite_pipeline, view_key);
 
         view_entities.clear();
@@ -586,10 +781,24 @@ pub fn queue_sprites(
             // These items will be sorted by depth with other phase items
             let sort_key = FloatOrd(extracted_sprite.transform.translation().z);
 
+            // Mirrors the pattern in `bevy_ui_render::queue_uinodes`: the
+            // subpixel pipeline variant is selected per extracted sprite
+            // (not per view) because a single view can mix subpixel text
+            // sprites with regular sprites, and each needs its own pipeline.
+            let item_pipeline = if extracted_sprite.subpixel {
+                pipelines.specialize(
+                    &pipeline_cache,
+                    &sprite_pipeline,
+                    view_key | SpritePipelineKey::SUBPIXEL,
+                )
+            } else {
+                pipeline
+            };
+
             // Add the item to the render phase
             transparent_phase.add_transient(Transparent2d {
                 draw_function: draw_sprite_function,
-                pipeline,
+                pipeline: item_pipeline,
                 entity: (
                     extracted_sprite.render_entity,
                     extracted_sprite.main_entity.into(),
@@ -608,15 +817,47 @@ pub fn queue_sprites(
 pub fn prepare_sprite_view_bind_groups(
     mut commands: Commands,
     render_device: Res<RenderDevice>,
+    render_queue: Res<RenderQueue>,
     pipeline_cache: Res<PipelineCache>,
     sprite_pipeline: Res<SpritePipeline>,
     view_uniforms: Res<ViewUniforms>,
+    mut sprite_meta: ResMut<SpriteMeta>,
     views: Query<(Entity, &Tonemapping), With<ExtractedView>>,
     tonemapping_luts: Res<TonemappingLuts>,
     images: Res<RenderAssets<GpuImage>>,
     fallback_image: Res<FallbackImage>,
+    #[cfg(feature = "bevy_text")] subpixel_settings: Option<Res<SubpixelTextSettings>>,
+    #[cfg(feature = "bevy_text")] subpixel_layout: Option<Res<SubpixelLcdLayout>>,
 ) {
-    let Some(view_binding) = view_uniforms.uniforms.binding() else {
+    // Drive the subpixel-text uniform from the main-world tuning resources.
+    // `TextPlugin::build` `init_resource`'s both with GPUI-derived defaults;
+    // a missing resource (headless / no `TextPlugin` / `bevy_text` feature
+    // disabled) falls back to [`SubpixelTextUniforms::default`] so the bind
+    // group still populates correctly.
+    #[cfg(feature = "bevy_text")]
+    {
+        let settings = subpixel_settings.as_deref().copied().unwrap_or_default();
+        let layout = subpixel_layout.as_deref().copied().unwrap_or_default();
+        sprite_meta.subpixel_settings.set(SubpixelTextUniforms {
+            enhanced_contrast: settings.enhanced_contrast,
+            layout_flags: layout.pack_u32(),
+            _pad: Vec2::ZERO,
+            gamma_ratios: settings.gamma_ratios,
+        });
+    }
+
+    // Flush the subpixel-text uniform to the GPU before building the view
+    // bind group below — `subpixel_settings.binding()` returns `None` until
+    // the backing buffer has been written at least once. Mirrors the
+    // sequence in `bevy_ui_render::prepare_uinodes`.
+    sprite_meta
+        .subpixel_settings
+        .write_buffer(&render_device, &render_queue);
+
+    let (Some(view_binding), Some(subpixel_binding)) = (
+        view_uniforms.uniforms.binding(),
+        sprite_meta.subpixel_settings.binding(),
+    ) else {
         return;
     };
 
@@ -626,7 +867,12 @@ pub fn prepare_sprite_view_bind_groups(
         let view_bind_group = render_device.create_bind_group(
             "mesh2d_view_bind_group",
             &pipeline_cache.get_bind_group_layout(&sprite_pipeline.view_layout),
-            &BindGroupEntries::sequential((view_binding.clone(), lut_bindings.0, lut_bindings.1)),
+            &BindGroupEntries::sequential((
+                view_binding.clone(),
+                lut_bindings.0,
+                lut_bindings.1,
+                subpixel_binding.clone(),
+            )),
         );
 
         commands.entity(entity).insert(SpriteViewBindGroup {

--- a/crates/bevy_sprite_render/src/render/sprite.wgsl
+++ b/crates/bevy_sprite_render/src/render/sprite.wgsl
@@ -1,3 +1,15 @@
+// `enable dual_source_blending;` must appear before any other global
+// declaration per the WGSL spec. We keep it unconditional (rather than
+// gating it on `#ifdef SUBPIXEL`) because naga_oil's preprocessor expands
+// `#define_import_path` / `#import` as leading globals, which makes a
+// preprocessor-wrapped `enable` land "after" them and trips a parse error.
+// The directive is harmless when the SUBPIXEL path is inactive — naga only
+// requires the corresponding DSB capability at compile time on pipelines
+// that actually use `@blend_src`. Mirrors the identical workaround in
+// `crates/bevy_ui_render/src/ui.wgsl` (and the precedent in
+// `crates/bevy_pbr/src/atmosphere/render_sky.wgsl`).
+enable dual_source_blending;
+
 #ifdef TONEMAP_IN_SHADER
 #import bevy_core_pipeline::tonemapping
 #endif
@@ -14,6 +26,33 @@
 }
 
 #import bevy_sprite::sprite_view_bindings::view
+
+// Subpixel text tuning uniform. Populated from `SubpixelTextSettings` +
+// `SubpixelLcdLayout` (both in `bevy_text`) at prepare time by
+// `prepare_sprite_view_bind_groups`. Bound at `@group(0) @binding(3)` on
+// every sprite pipeline variant so the bind-group layout is shared between
+// the standard sprite fragment entry and `fragment_subpixel` below.
+//
+// Layout mirrors the Rust `SubpixelTextUniforms` struct byte-for-byte:
+// `enhanced_contrast` (4 bytes) + `layout_flags` (4 bytes) + `_pad` (8
+// bytes) fills the leading 16-byte slot so `gamma_ratios` lands on its
+// natural 16-byte boundary. Total 32 bytes.
+//
+// `layout_flags` discriminant (keep in sync with
+// `SubpixelLcdLayout::pack_u32` in `bevy_text/src/subpixel.rs` and the
+// `SUBPIXEL_LAYOUT_*` constants in `bevy_ui_render/src/ui.wgsl`):
+//   0 = HorizontalRgb  (atlas R, G, B in that order — identity swizzle)
+//   1 = HorizontalBgr  (swap R/B — text on a BGR panel)
+struct SubpixelSettings {
+    enhanced_contrast: f32,
+    layout_flags: u32,
+    _pad: vec2<f32>,
+    gamma_ratios: vec4<f32>,
+}
+@group(0) @binding(3) var<uniform> subpixel_settings: SubpixelSettings;
+
+const SUBPIXEL_LAYOUT_HORIZONTAL_RGB: u32 = 0u;
+const SUBPIXEL_LAYOUT_HORIZONTAL_BGR: u32 = 1u;
 
 struct VertexInput {
     @builtin(vertex_index) index: u32,
@@ -75,3 +114,107 @@ fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
 
     return color;
 }
+
+#ifdef SUBPIXEL
+// RGB subpixel text fragment path — sprite-render edition.
+//
+// This block is intentionally a verbatim port of `fragment_subpixel` in
+// `crates/bevy_ui_render/src/ui.wgsl` (added in phase-04 of spec/0013).
+// Cross-crate WGSL sharing in Bevy goes through `#define_import_path` /
+// `#import`, but both `ui.wgsl` and this file are top-level pipeline
+// shaders that also declare their own `@fragment` entries — making them
+// imports of each other creates a cycle. ~60 lines of duplication is the
+// practical trade-off; if either side changes materially the other must
+// be kept in sync.
+//
+// The glyph atlas bound to `sprite_texture` stores *three per-channel
+// coverage values* per pixel (one for each of the LCD stripe's R / G / B
+// subpixels), produced by `swash`'s `Format::Subpixel` rasteriser in
+// `bevy_text`. The sample is therefore not a colour — each channel is an
+// alpha for its matching subpixel. We emit dual-source fragments so the
+// hardware blender can consume per-channel alpha: `@blend_src(0)` carries
+// the foreground colour, `@blend_src(1)` carries the per-channel alpha
+// that the destination factor `OneMinusSrc1` multiplies against the
+// existing framebuffer value.
+//
+// The contrast + gamma math is ported verbatim from Zed's GPUI subpixel
+// shader, which in turn follows Skia's LCD text correction; see the
+// comment on the UI side for the full derivation.
+struct SubpixelOutput {
+    @location(0) @blend_src(0) color: vec4<f32>,
+    @location(0) @blend_src(1) alpha_mask: vec4<f32>,
+}
+
+fn color_brightness(color: vec3<f32>) -> f32 {
+    return dot(color, vec3<f32>(0.30, 0.59, 0.11));
+}
+
+fn light_on_dark_contrast(enhanced_contrast: f32, color: vec3<f32>) -> f32 {
+    let brightness = color_brightness(color);
+    let multiplier = saturate(4.0 * (0.75 - brightness));
+    return enhanced_contrast * multiplier;
+}
+
+fn enhance_contrast3(alpha: vec3<f32>, k: f32) -> vec3<f32> {
+    return alpha * (k + 1.0) / (alpha * k + 1.0);
+}
+
+fn apply_alpha_correction3(a: vec3<f32>, b: vec3<f32>, g: vec4<f32>) -> vec3<f32> {
+    let brightness_adjustment = g.x * b + g.y;
+    let correction = brightness_adjustment * a + (g.z * b + g.w);
+    return a + a * (1.0 - a) * correction;
+}
+
+fn apply_contrast_and_gamma_correction3(
+    sample: vec3<f32>,
+    fg: vec3<f32>,
+    enhanced_contrast_factor: f32,
+    gamma_ratios: vec4<f32>,
+) -> vec3<f32> {
+    let enhanced_contrast = light_on_dark_contrast(enhanced_contrast_factor, fg);
+    let contrasted = enhance_contrast3(sample, enhanced_contrast);
+    return apply_alpha_correction3(contrasted, fg, gamma_ratios);
+}
+
+// Remap the atlas's three per-channel coverage values to match the target
+// panel's physical subpixel arrangement. Matches `swizzle_subpixel_atlas`
+// in `ui.wgsl`; see that function's comment for the BGR caveat.
+fn swizzle_subpixel_atlas(atlas_rgb: vec3<f32>, layout_flags: u32) -> vec3<f32> {
+    if layout_flags == SUBPIXEL_LAYOUT_HORIZONTAL_BGR {
+        return atlas_rgb.bgr;
+    }
+    return atlas_rgb;
+}
+
+@fragment
+fn fragment_subpixel(in: VertexOutput) -> SubpixelOutput {
+    // Sample three per-channel alpha coverages from the RGB subpixel atlas,
+    // then swizzle by the panel's subpixel layout. The swash rasteriser
+    // has already baked in horizontal per-channel UV offsets, so a single
+    // sample plus a swizzle is both correct and optimal for
+    // `HorizontalRgb` / `HorizontalBgr`.
+    let atlas_rgb = textureSample(sprite_texture, sprite_sampler, in.uv).rgb;
+    let sample_rgb = swizzle_subpixel_atlas(atlas_rgb, subpixel_settings.layout_flags);
+
+    let enhanced_contrast = subpixel_settings.enhanced_contrast;
+    let gamma_ratios = subpixel_settings.gamma_ratios;
+
+    let alpha_corrected = apply_contrast_and_gamma_correction3(
+        sample_rgb,
+        in.color.rgb,
+        enhanced_contrast,
+        gamma_ratios,
+    );
+
+    // Matches GPUI's `fs_subpixel_sprite` and the UI crate's
+    // `fragment_subpixel`. With pipeline blend state
+    // `color: { src = Src1, dst = OneMinusSrc1 }` this yields:
+    //   result.rgb = fg.rgb * (color.a * alpha_corrected)
+    //              + dst.rgb * (1 - color.a * alpha_corrected)
+    // i.e. per-channel coverage of the foreground over the existing pixel.
+    var out: SubpixelOutput;
+    out.color = vec4<f32>(in.color.rgb, 1.0);
+    out.alpha_mask = vec4<f32>(in.color.a * alpha_corrected, 1.0);
+    return out;
+}
+#endif

--- a/crates/bevy_sprite_render/src/render/sprite.wgsl
+++ b/crates/bevy_sprite_render/src/render/sprite.wgsl
@@ -130,10 +130,10 @@ fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
 // The glyph atlas bound to `sprite_texture` stores *three per-channel
 // coverage values* per pixel (one for each of the LCD stripe's R / G / B
 // subpixels), produced by `swash`'s `Format::Subpixel` rasteriser in
-// `bevy_text`. The sample is therefore not a colour — each channel is an
+// `bevy_text`. The sample is therefore not a color — each channel is an
 // alpha for its matching subpixel. We emit dual-source fragments so the
 // hardware blender can consume per-channel alpha: `@blend_src(0)` carries
-// the foreground colour, `@blend_src(1)` carries the per-channel alpha
+// the foreground color, `@blend_src(1)` carries the per-channel alpha
 // that the destination factor `OneMinusSrc1` multiplies against the
 // existing framebuffer value.
 //

--- a/crates/bevy_sprite_render/src/text2d/mod.rs
+++ b/crates/bevy_sprite_render/src/text2d/mod.rs
@@ -7,15 +7,16 @@ use bevy_color::LinearRgba;
 use bevy_ecs::{
     entity::Entity,
     query::Has,
-    system::{Commands, Query, ResMut},
+    system::{Commands, Query, Res, ResMut},
 };
 use bevy_math::{Vec2, Vec3};
 use bevy_render::sync_world::TemporaryRenderEntity;
 use bevy_render::Extract;
 use bevy_sprite::{Anchor, Text2dShadow};
 use bevy_text::{
-    ComputedTextBlock, PositionedGlyph, Strikethrough, StrikethroughColor, TextBackgroundColor,
-    TextBounds, TextColor, TextLayoutInfo, Underline, UnderlineColor,
+    ComputedTextBlock, FontSmoothing, PositionedGlyph, Strikethrough, StrikethroughColor,
+    SubpixelCapable, TextBackgroundColor, TextBounds, TextColor, TextLayoutInfo, Underline,
+    UnderlineColor,
 };
 use bevy_transform::prelude::GlobalTransform;
 
@@ -48,7 +49,17 @@ pub fn extract_text2d_sprite(
             Option<&UnderlineColor>,
         )>,
     >,
+    subpixel_capable: Option<Res<SubpixelCapable>>,
 ) {
+    // On adapters without `DUAL_SOURCE_BLENDING` we force the grayscale
+    // pipeline even for `SubpixelAntiAliased` glyphs — the RGB coverage
+    // atlas is still sampled, but only the `.r` channel is used as alpha.
+    // Matches the fallback path in `bevy_ui_render::queue_uinodes`.
+    // `SubpixelCapable` is inserted at `RenderStartup` by
+    // `init_sprite_subpixel_capability` (and/or `init_ui_subpixel_capability`
+    // when `UiRenderPlugin` is installed); the resource is `None` for the
+    // first frame before startup systems run or in headless contexts.
+    let subpixel_capable = subpixel_capable.as_deref().is_some_and(|c| c.0);
     let mut start = extracted_slices.slices.len();
     let mut end = start + 1;
 
@@ -102,6 +113,9 @@ pub fn extract_text2d_sprite(
                     scaling_mode: None,
                     custom_size: Some(run.bounds.size()),
                 },
+                // Text background fills sample the default (1x1 white) atlas
+                // and never want the per-channel subpixel blend.
+                subpixel: false,
             });
         }
 
@@ -116,6 +130,7 @@ pub fn extract_text2d_sprite(
                 PositionedGlyph {
                     position,
                     atlas_info,
+                    section_index,
                     ..
                 },
             ) in text_layout_info.glyphs.iter().enumerate()
@@ -131,6 +146,22 @@ pub fn extract_text2d_sprite(
                     .get(i + 1)
                     .is_none_or(|info| info.atlas_info.texture != atlas_info.texture)
                 {
+                    // Glyphs in a single `Slices` batch share an atlas
+                    // texture. `FontAtlasKey` partitions atlases by
+                    // `FontSmoothing` (see `bevy_text::font_atlas_set`),
+                    // so all glyphs in this range share smoothing — picking
+                    // the current glyph's source section's smoothing is
+                    // correct by construction. Pick the DSB pipeline variant
+                    // when the section asked for `SubpixelAntiAliased` and
+                    // the adapter supports `DUAL_SOURCE_BLENDING`; fall
+                    // through to grayscale AA otherwise.
+                    let font_smoothing = computed_block
+                        .entities()
+                        .get(*section_index)
+                        .map(|t| t.font_smoothing)
+                        .unwrap_or_default();
+                    let subpixel =
+                        font_smoothing == FontSmoothing::SubpixelAntiAliased && subpixel_capable;
                     let render_entity = commands.spawn(TemporaryRenderEntity).id();
                     extracted_sprites.sprites.push(ExtractedSprite {
                         main_entity,
@@ -143,6 +174,7 @@ pub fn extract_text2d_sprite(
                         kind: ExtractedSpriteKind::Slices {
                             indices: start..end,
                         },
+                        subpixel,
                     });
                     start = end;
                 }
@@ -177,6 +209,7 @@ pub fn extract_text2d_sprite(
                             scaling_mode: None,
                             custom_size: Some(run.strikethrough_size()),
                         },
+                        subpixel: false,
                     });
                 }
 
@@ -199,6 +232,7 @@ pub fn extract_text2d_sprite(
                             scaling_mode: None,
                             custom_size: Some(run.underline_size()),
                         },
+                        subpixel: false,
                     });
                 }
             }
@@ -242,6 +276,18 @@ pub fn extract_text2d_sprite(
                 info.section_index != current_section
                     || info.atlas_info.texture != atlas_info.texture
             }) {
+                // Glyphs in a single `Slices` batch share a
+                // `(section_index, atlas_texture)` pair, and
+                // `FontAtlasKey` partitions atlases by `FontSmoothing`, so
+                // the batch has homogeneous smoothing — looking it up on
+                // the current section suffices.
+                let font_smoothing = computed_block
+                    .entities()
+                    .get(current_section)
+                    .map(|t| t.font_smoothing)
+                    .unwrap_or_default();
+                let subpixel =
+                    font_smoothing == FontSmoothing::SubpixelAntiAliased && subpixel_capable;
                 let render_entity = commands.spawn(TemporaryRenderEntity).id();
                 extracted_sprites.sprites.push(ExtractedSprite {
                     main_entity,
@@ -254,6 +300,7 @@ pub fn extract_text2d_sprite(
                     kind: ExtractedSpriteKind::Slices {
                         indices: start..end,
                     },
+                    subpixel,
                 });
                 start = end;
             }
@@ -298,6 +345,7 @@ pub fn extract_text2d_sprite(
                         scaling_mode: None,
                         custom_size: Some(run.strikethrough_size()),
                     },
+                    subpixel: false,
                 });
             }
 
@@ -326,6 +374,7 @@ pub fn extract_text2d_sprite(
                         scaling_mode: None,
                         custom_size: Some(run.underline_size()),
                     },
+                    subpixel: false,
                 });
             }
         }

--- a/crates/bevy_sprite_render/tests/subpixel_pipeline.rs
+++ b/crates/bevy_sprite_render/tests/subpixel_pipeline.rs
@@ -1,0 +1,203 @@
+//! Integration tests for the sprite subpixel-text DSB pipeline variant.
+//!
+//! Verifies that [`SpritePipeline::specialize`] branches to the dual-source-
+//! blend fragment entry + blend state when
+//! [`SpritePipelineKey::SUBPIXEL`] is set, and preserves the existing
+//! alpha-blend path otherwise. Also checks the bit allocation for
+//! `SUBPIXEL` does not collide with the `COLOR_TARGET_FORMAT`,
+//! `TONEMAP_METHOD`, or `MSAA` reserved regions.
+//!
+//! Mirrors `bevy_ui_render/tests/subpixel_pipeline.rs` (phase-04 of
+//! spec/0013) for the sprite pipeline (phase-06).
+
+use bevy_asset::Handle;
+use bevy_render::render_resource::{
+    binding_types::{sampler, texture_2d, uniform_buffer},
+    BindGroupLayoutDescriptor, BindGroupLayoutEntries, BlendFactor, BlendOperation, BlendState,
+    SamplerBindingType, ShaderStages, SpecializedRenderPipeline, TextureFormat, TextureSampleType,
+};
+use bevy_render::view::ViewUniform;
+use bevy_shader::ShaderDefVal;
+use bevy_sprite_render::{SpritePipeline, SpritePipelineKey, SubpixelTextUniforms};
+
+fn has_subpixel_def(def: &ShaderDefVal) -> bool {
+    matches!(def, ShaderDefVal::Bool(name, true) if name == "SUBPIXEL")
+}
+
+/// Builds a [`SpritePipeline`] with a layout-only view/material binding so
+/// `specialize` can be called without a live `RenderDevice`.
+///
+/// The layout's tonemapping-LUT bindings use generic `texture_2d` /
+/// `sampler` entries rather than the real
+/// `get_lut_bind_group_layout_entries` shape; `specialize` does not
+/// inspect layout contents, only clones them into the descriptor.
+fn build_test_pipeline() -> SpritePipeline {
+    let view_layout = BindGroupLayoutDescriptor::new(
+        "sprite_view_layout",
+        &BindGroupLayoutEntries::sequential(
+            ShaderStages::VERTEX_FRAGMENT,
+            (
+                uniform_buffer::<ViewUniform>(true),
+                texture_2d(TextureSampleType::Float { filterable: true }),
+                sampler(SamplerBindingType::Filtering),
+                uniform_buffer::<SubpixelTextUniforms>(false),
+            ),
+        ),
+    );
+
+    let material_layout = BindGroupLayoutDescriptor::new(
+        "sprite_material_layout",
+        &BindGroupLayoutEntries::sequential(
+            ShaderStages::FRAGMENT,
+            (
+                texture_2d(TextureSampleType::Float { filterable: true }),
+                sampler(SamplerBindingType::Filtering),
+            ),
+        ),
+    );
+
+    SpritePipeline {
+        view_layout,
+        material_layout,
+        shader: Handle::default(),
+    }
+}
+
+#[test]
+fn subpixel_variant_selects_dsb_fragment_entry() {
+    let pipeline = build_test_pipeline();
+
+    let key = SpritePipelineKey::from_target_format(TextureFormat::Rgba8UnormSrgb)
+        | SpritePipelineKey::from_msaa_samples(1)
+        | SpritePipelineKey::SUBPIXEL;
+    let descriptor = pipeline.specialize(key);
+
+    let fragment = descriptor
+        .fragment
+        .as_ref()
+        .expect("subpixel pipeline must have a fragment stage");
+
+    let entry_point = fragment
+        .entry_point
+        .as_ref()
+        .expect("subpixel pipeline must set a custom fragment entry point");
+    assert_eq!(entry_point.as_ref(), "fragment_subpixel");
+
+    // `SUBPIXEL` shader_def should be present on both stages so the WGSL
+    // subpixel block compiles.
+    assert!(
+        fragment.shader_defs.iter().any(has_subpixel_def),
+        "SUBPIXEL shader_def missing from fragment: {:?}",
+        fragment.shader_defs,
+    );
+    assert!(
+        descriptor.vertex.shader_defs.iter().any(has_subpixel_def),
+        "SUBPIXEL shader_def missing from vertex: {:?}",
+        descriptor.vertex.shader_defs,
+    );
+
+    let target = fragment.targets[0]
+        .as_ref()
+        .expect("subpixel pipeline must have a color target");
+    let blend = target
+        .blend
+        .expect("subpixel pipeline must configure a blend state");
+
+    assert_eq!(blend.color.src_factor, BlendFactor::Src1);
+    assert_eq!(blend.color.dst_factor, BlendFactor::OneMinusSrc1);
+    assert_eq!(blend.color.operation, BlendOperation::Add);
+
+    assert_eq!(blend.alpha.src_factor, BlendFactor::One);
+    assert_eq!(blend.alpha.dst_factor, BlendFactor::OneMinusSrcAlpha);
+    assert_eq!(blend.alpha.operation, BlendOperation::Add);
+
+    assert_eq!(
+        descriptor.label.as_deref(),
+        Some("sprite_pipeline_subpixel"),
+        "subpixel variant should use the sprite_pipeline_subpixel label",
+    );
+}
+
+#[test]
+fn non_subpixel_variant_keeps_alpha_blend_fragment() {
+    let pipeline = build_test_pipeline();
+
+    let key = SpritePipelineKey::from_target_format(TextureFormat::Rgba8UnormSrgb)
+        | SpritePipelineKey::from_msaa_samples(1);
+    let descriptor = pipeline.specialize(key);
+
+    let fragment = descriptor
+        .fragment
+        .as_ref()
+        .expect("non-subpixel pipeline must have a fragment stage");
+
+    assert!(
+        fragment.entry_point.is_none(),
+        "non-subpixel variant must not override the default fragment entry",
+    );
+    assert!(
+        !fragment.shader_defs.iter().any(has_subpixel_def),
+        "SUBPIXEL shader_def leaked into non-subpixel fragment: {:?}",
+        fragment.shader_defs,
+    );
+
+    let target = fragment.targets[0]
+        .as_ref()
+        .expect("non-subpixel pipeline must have a color target");
+    let blend = target
+        .blend
+        .expect("non-subpixel pipeline must configure a blend state");
+
+    assert_eq!(blend, BlendState::ALPHA_BLENDING);
+
+    assert_eq!(
+        descriptor.label.as_deref(),
+        Some("sprite_pipeline"),
+        "non-subpixel variant should use the sprite_pipeline label",
+    );
+}
+
+#[test]
+fn subpixel_key_differs_from_non_subpixel_key() {
+    // Cache keys must differ between variants so
+    // `SpecializedRenderPipelines` keeps both descriptors alive in the
+    // same frame.
+    let base = SpritePipelineKey::from_target_format(TextureFormat::Rgba8UnormSrgb)
+        | SpritePipelineKey::from_msaa_samples(1);
+    let subpixel = base | SpritePipelineKey::SUBPIXEL;
+    assert_ne!(base, subpixel);
+}
+
+#[test]
+fn subpixel_bit_does_not_collide_with_reserved_regions() {
+    // Ensure the SUBPIXEL bit is outside every pre-existing reserved
+    // region of the pipeline-key. A collision would silently corrupt
+    // either our subpixel gating or the reserved field.
+    let subpixel = SpritePipelineKey::SUBPIXEL;
+    assert!(
+        (subpixel & SpritePipelineKey::COLOR_TARGET_FORMAT_RESERVED_BITS).is_empty(),
+        "SUBPIXEL overlaps the COLOR_TARGET_FORMAT reserved region",
+    );
+    assert!(
+        (subpixel & SpritePipelineKey::MSAA_RESERVED_BITS).is_empty(),
+        "SUBPIXEL overlaps the MSAA reserved region",
+    );
+    assert!(
+        (subpixel & SpritePipelineKey::TONEMAP_METHOD_RESERVED_BITS).is_empty(),
+        "SUBPIXEL overlaps the TONEMAP_METHOD reserved region",
+    );
+
+    // It also must not collide with any of the low-bit flags.
+    for other in [
+        SpritePipelineKey::TONEMAP_IN_SHADER,
+        SpritePipelineKey::DEBAND_DITHER,
+        SpritePipelineKey::SRGB_COMPOSITING,
+        SpritePipelineKey::OKLAB_COMPOSITING,
+    ] {
+        assert!(
+            (subpixel & other).is_empty(),
+            "SUBPIXEL collides with {:?}",
+            other,
+        );
+    }
+}

--- a/crates/bevy_text/src/font_atlas.rs
+++ b/crates/bevy_text/src/font_atlas.rs
@@ -187,12 +187,28 @@ pub fn get_outlined_glyph_texture(
     glyph_id: u16,
     font_smoothing: FontSmoothing,
 ) -> Result<(Image, Vec2, bool), TextError> {
+    // `None` and `AntiAliased` both ask swash for a single-channel alpha mask
+    // which the match below unpacks into an RGBA texture. `SubpixelAntiAliased`
+    // asks for RGB subpixel coverage, which swash returns as a four-byte-per-
+    // pixel buffer (`[R_cov, G_cov, B_cov, 0]`) with `Content::SubpixelMask`.
+    // The existing `Content::Color | Content::SubpixelMask` arm below passes
+    // that buffer through unchanged; the shader side of the subpixel path uses
+    // the RGB channels as per-channel coverage in a dual-source blend.
+    //
+    // Per-glyph fractional offsets (the actual point of subpixel rendering)
+    // are introduced in a follow-up change once the atlas gains per-bucket
+    // keys. Until then this path rasterises at offset zero, which is
+    // functionally correct but gives up the bucket-driven fringe reduction.
+    let format = match font_smoothing {
+        FontSmoothing::None | FontSmoothing::AntiAliased => swash::zeno::Format::Alpha,
+        FontSmoothing::SubpixelAntiAliased => swash::zeno::Format::Subpixel,
+    };
     let image = swash::scale::Render::new(&[
         swash::scale::Source::ColorOutline(0),
         swash::scale::Source::ColorBitmap(swash::scale::StrikeWith::BestFit),
         swash::scale::Source::Outline,
     ])
-    .format(swash::zeno::Format::Alpha)
+    .format(format)
     .render(scaler, glyph_id)
     .ok_or(TextError::FailedToGetGlyphImage(glyph_id))?;
 

--- a/crates/bevy_text/src/font_atlas.rs
+++ b/crates/bevy_text/src/font_atlas.rs
@@ -2,16 +2,89 @@ use bevy_asset::{Assets, Handle, RenderAssetUsages};
 use bevy_image::{prelude::*, ImageSampler, ToExtents};
 use bevy_math::{UVec2, Vec2};
 use bevy_platform::collections::HashMap;
+use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use swash::scale::Scaler;
 use wgpu_types::{Extent3d, TextureDimension, TextureFormat};
 
 use crate::{FontSmoothing, GlyphAtlasInfo, GlyphAtlasLocation, TextError};
 
-/// Key identifying a glyph
+/// Horizontal subpixel quantisation bucket for
+/// [`FontSmoothing::SubpixelAntiAliased`].
+///
+/// Groups ranges of fractional glyph x-positions into four buckets plus a
+/// `NotApplicable` case for non-subpixel smoothing modes. Used inside
+/// [`GlyphCacheKey`] so the atlas holds four distinct rasterisations per
+/// glyph id at the appropriate horizontal subpixel offsets.
+///
+/// Four buckets is the quality / atlas-count sweet spot borrowed from the
+/// cosmic-text-era stack (which mirrored `cosmic_text::SubpixelBin`); parley
+/// does not expose its own bucketing, so this enum is purely internal to
+/// `bevy_text`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default, Reflect)]
+#[reflect(Hash, Default, PartialEq, Debug, Clone)]
+pub enum SubpixelBucket {
+    /// Non-subpixel smoothing (`None` / `AntiAliased`). A single atlas cell
+    /// per glyph id.
+    #[default]
+    NotApplicable,
+    /// Fractional x in `[0.0, 0.25)` — rasterised at swash offset `0.0`.
+    Zero,
+    /// Fractional x in `[0.25, 0.5)` — rasterised at swash offset `0.25`.
+    Quarter,
+    /// Fractional x in `[0.5, 0.75)` — rasterised at swash offset `0.5`.
+    Half,
+    /// Fractional x in `[0.75, 1.0)` — rasterised at swash offset `0.75`.
+    ThreeQuarter,
+}
+
+impl SubpixelBucket {
+    /// Derive a bucket from a fractional x-position and the current font
+    /// smoothing mode.
+    ///
+    /// Returns [`SubpixelBucket::NotApplicable`] for any smoothing mode other
+    /// than [`FontSmoothing::SubpixelAntiAliased`], collapsing grayscale /
+    /// `None` glyphs to a single atlas cell per glyph id.
+    pub fn from_fract(fract_x: f32, smoothing: FontSmoothing) -> Self {
+        if smoothing != FontSmoothing::SubpixelAntiAliased {
+            return Self::NotApplicable;
+        }
+        let frac = fract_x.rem_euclid(1.0);
+        if frac < 0.25 {
+            Self::Zero
+        } else if frac < 0.5 {
+            Self::Quarter
+        } else if frac < 0.75 {
+            Self::Half
+        } else {
+            Self::ThreeQuarter
+        }
+    }
+
+    /// The horizontal rasterisation offset for this bucket, intended to be
+    /// fed to [`swash::scale::Render::offset`] before `.render(...)`.
+    pub fn rasterise_offset_x(self) -> f32 {
+        match self {
+            Self::NotApplicable | Self::Zero => 0.0,
+            Self::Quarter => 0.25,
+            Self::Half => 0.5,
+            Self::ThreeQuarter => 0.75,
+        }
+    }
+}
+
+/// Key identifying a glyph entry inside a [`FontAtlas`].
+///
+/// Combines the glyph id with a [`SubpixelBucket`] so that
+/// [`FontSmoothing::SubpixelAntiAliased`] can cache four distinct subpixel
+/// rasterisations of the same glyph within a single atlas texture. Non-
+/// subpixel smoothing modes always use [`SubpixelBucket::NotApplicable`],
+/// giving a single atlas cell per glyph id.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct GlyphCacheKey {
-    /// Id used to look up the glyph
+    /// Id used to look up the glyph.
     pub glyph_id: u16,
+    /// Horizontal subpixel bucket the glyph was rasterised for.
+    pub subpixel_bucket: SubpixelBucket,
 }
 
 /// Rasterized glyphs are cached, stored in, and retrieved from, a `FontAtlas`.
@@ -135,17 +208,17 @@ pub fn add_glyph_to_atlas(
     scaler: &mut Scaler,
     font_smoothing: FontSmoothing,
     glyph_id: u16,
+    subpixel_bucket: SubpixelBucket,
+    subpixel_offset: Vec2,
 ) -> Result<GlyphAtlasInfo, TextError> {
     let (glyph_texture, offset, is_alpha_mask) =
-        get_outlined_glyph_texture(scaler, glyph_id, font_smoothing)?;
+        get_outlined_glyph_texture(scaler, glyph_id, font_smoothing, subpixel_offset)?;
+    let cache_key = GlyphCacheKey {
+        glyph_id,
+        subpixel_bucket,
+    };
     let mut add_char_to_font_atlas = |atlas: &mut FontAtlas| -> Result<(), TextError> {
-        atlas.add_glyph(
-            textures,
-            GlyphCacheKey { glyph_id },
-            &glyph_texture,
-            offset,
-            is_alpha_mask,
-        )
+        atlas.add_glyph(textures, cache_key, &glyph_texture, offset, is_alpha_mask)
     };
     if !font_atlases
         .iter_mut()
@@ -162,19 +235,12 @@ pub fn add_glyph_to_atlas(
 
         let mut new_atlas = FontAtlas::new(textures, UVec2::splat(containing), font_smoothing);
 
-        new_atlas.add_glyph(
-            textures,
-            GlyphCacheKey { glyph_id },
-            &glyph_texture,
-            offset,
-            is_alpha_mask,
-        )?;
+        new_atlas.add_glyph(textures, cache_key, &glyph_texture, offset, is_alpha_mask)?;
 
         font_atlases.push(new_atlas);
     }
 
-    get_glyph_atlas_info(font_atlases, GlyphCacheKey { glyph_id })
-        .ok_or(TextError::InconsistentAtlasState)
+    get_glyph_atlas_info(font_atlases, cache_key).ok_or(TextError::InconsistentAtlasState)
 }
 
 /// Get the texture of the glyph as a rendered image, and its offset
@@ -186,6 +252,7 @@ pub fn get_outlined_glyph_texture(
     scaler: &mut Scaler,
     glyph_id: u16,
     font_smoothing: FontSmoothing,
+    subpixel_offset: Vec2,
 ) -> Result<(Image, Vec2, bool), TextError> {
     // `None` and `AntiAliased` both ask swash for a single-channel alpha mask
     // which the match below unpacks into an RGBA texture. `SubpixelAntiAliased`
@@ -195,22 +262,29 @@ pub fn get_outlined_glyph_texture(
     // that buffer through unchanged; the shader side of the subpixel path uses
     // the RGB channels as per-channel coverage in a dual-source blend.
     //
-    // Per-glyph fractional offsets (the actual point of subpixel rendering)
-    // are introduced in a follow-up change once the atlas gains per-bucket
-    // keys. Until then this path rasterises at offset zero, which is
-    // functionally correct but gives up the bucket-driven fringe reduction.
+    // `subpixel_offset` is fed to `swash::scale::Render::offset(...)` only on
+    // the subpixel path; the quantised horizontal value comes from
+    // [`SubpixelBucket::rasterise_offset_x`] at the atlas-lookup call site.
+    // Non-subpixel callers pass `Vec2::ZERO` and the offset is ignored.
     let format = match font_smoothing {
         FontSmoothing::None | FontSmoothing::AntiAliased => swash::zeno::Format::Alpha,
         FontSmoothing::SubpixelAntiAliased => swash::zeno::Format::Subpixel,
     };
-    let image = swash::scale::Render::new(&[
+    let mut render = swash::scale::Render::new(&[
         swash::scale::Source::ColorOutline(0),
         swash::scale::Source::ColorBitmap(swash::scale::StrikeWith::BestFit),
         swash::scale::Source::Outline,
-    ])
-    .format(format)
-    .render(scaler, glyph_id)
-    .ok_or(TextError::FailedToGetGlyphImage(glyph_id))?;
+    ]);
+    render.format(format);
+    if font_smoothing == FontSmoothing::SubpixelAntiAliased {
+        render.offset(swash::zeno::Vector::new(
+            subpixel_offset.x,
+            subpixel_offset.y,
+        ));
+    }
+    let image = render
+        .render(scaler, glyph_id)
+        .ok_or(TextError::FailedToGetGlyphImage(glyph_id))?;
 
     let left = image.placement.left;
     let top = image.placement.top;

--- a/crates/bevy_text/src/font_atlas.rs
+++ b/crates/bevy_text/src/font_atlas.rs
@@ -206,7 +206,12 @@ pub fn get_outlined_glyph_texture(
         swash::scale::image::Content::Mask => {
             let mut rgba = vec![0u8; px * 4];
             match font_smoothing {
-                FontSmoothing::AntiAliased => {
+                // Subpixel renders are requested via `Format::Subpixel` and normally
+                // produce `Content::SubpixelMask`. If swash ever falls back to a grayscale
+                // mask for a given glyph (for example, a source that only has a plain
+                // outline on an emoji-style font), treat it as grayscale AA — still
+                // better than returning black pixels.
+                FontSmoothing::AntiAliased | FontSmoothing::SubpixelAntiAliased => {
                     for i in 0..px {
                         let a = image.data[i];
                         rgba[i * 4 + 0] = 255; // R

--- a/crates/bevy_text/src/font_atlas.rs
+++ b/crates/bevy_text/src/font_atlas.rs
@@ -8,7 +8,7 @@ use wgpu_types::{Extent3d, TextureDimension, TextureFormat};
 
 use crate::{FontSmoothing, GlyphAtlasInfo, GlyphAtlasLocation, TextError};
 
-/// Horizontal subpixel quantisation bucket for
+/// Horizontal subpixel quantization bucket for
 /// [`FontSmoothing::SubpixelAntiAliased`].
 ///
 /// Groups ranges of fractional glyph x-positions into four buckets plus a
@@ -263,7 +263,7 @@ pub fn get_outlined_glyph_texture(
     // the RGB channels as per-channel coverage in a dual-source blend.
     //
     // `subpixel_offset` is fed to `swash::scale::Render::offset(...)` only on
-    // the subpixel path; the quantised horizontal value comes from
+    // the subpixel path; the quantized horizontal value comes from
     // [`SubpixelBucket::rasterise_offset_x`] at the atlas-lookup call site.
     // Non-subpixel callers pass `Vec2::ZERO` and the offset is ignored.
     let format = match font_smoothing {

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -41,6 +41,7 @@ mod font_loader;
 mod glyph;
 mod parley_context;
 mod pipeline;
+mod subpixel;
 mod text;
 mod text_access;
 mod text_edit;
@@ -56,6 +57,7 @@ pub use font_loader::*;
 pub use glyph::*;
 pub use parley_context::*;
 pub use pipeline::*;
+pub use subpixel::*;
 pub use text::*;
 pub use text_access::*;
 pub use text_edit::*;
@@ -68,8 +70,9 @@ pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
         Font, FontHinting, FontSize, FontSmoothing, FontSource, FontStyle, FontWeight, FontWidth,
-        Justify, LineBreak, Strikethrough, StrikethroughColor, TextColor, TextError, TextFont,
-        TextLayout, TextSpan, Underline, UnderlineColor,
+        Justify, LineBreak, Strikethrough, StrikethroughColor, SubpixelCapable, SubpixelLcdLayout,
+        SubpixelTextSettings, TextColor, TextError, TextFont, TextLayout, TextSpan, Underline,
+        UnderlineColor,
     };
 }
 
@@ -122,8 +125,13 @@ impl Plugin for TextPlugin {
             .init_resource::<ScaleCx>()
             .init_resource::<TextIterScratch>()
             .init_resource::<RemSize>()
+            .init_resource::<SubpixelTextSettings>()
+            .init_resource::<SubpixelLcdLayout>()
             .register_type::<FontSmoothing>()
             .register_type::<SubpixelBucket>()
+            .register_type::<SubpixelTextSettings>()
+            .register_type::<SubpixelLcdLayout>()
+            .register_type::<SubpixelCapable>()
             .add_systems(
                 PostUpdate,
                 (

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -122,6 +122,8 @@ impl Plugin for TextPlugin {
             .init_resource::<ScaleCx>()
             .init_resource::<TextIterScratch>()
             .init_resource::<RemSize>()
+            .register_type::<FontSmoothing>()
+            .register_type::<SubpixelBucket>()
             .add_systems(
                 PostUpdate,
                 (

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -26,8 +26,8 @@ use crate::{
     get_glyph_atlas_info,
     parley_context::{FontCx, LayoutCx, ScaleCx},
     ComputedTextBlock, Font, FontAtlasKey, FontAtlasSet, FontHinting, FontSmoothing, FontSource,
-    Justify, LetterSpacing, LineBreak, LineHeight, PositionedGlyph, TextBounds, TextEntity,
-    TextFont, TextLayout,
+    Justify, LetterSpacing, LineBreak, LineHeight, PositionedGlyph, SubpixelBucket, TextBounds,
+    TextEntity, TextFont, TextLayout,
 };
 
 struct TextSectionView<'a> {
@@ -354,19 +354,27 @@ impl TextPipeline {
                             continue;
                         };
 
+                        let subpixel_bucket = SubpixelBucket::from_fract(glyph.x, font_smoothing);
+                        let subpixel_offset = Vec2::new(subpixel_bucket.rasterise_offset_x(), 0.0);
+                        let cache_key = crate::GlyphCacheKey {
+                            glyph_id,
+                            subpixel_bucket,
+                        };
+
                         let font_atlases = font_atlas_set.entry(font_atlas_key).or_default();
-                        let atlas_info =
-                            get_glyph_atlas_info(font_atlases, crate::GlyphCacheKey { glyph_id })
-                                .map(Ok)
-                                .unwrap_or_else(|| {
-                                    add_glyph_to_atlas(
-                                        font_atlases,
-                                        textures,
-                                        &mut scaler,
-                                        font_smoothing,
-                                        glyph_id,
-                                    )
-                                })?;
+                        let atlas_info = get_glyph_atlas_info(font_atlases, cache_key)
+                            .map(Ok)
+                            .unwrap_or_else(|| {
+                                add_glyph_to_atlas(
+                                    font_atlases,
+                                    textures,
+                                    &mut scaler,
+                                    font_smoothing,
+                                    glyph_id,
+                                    subpixel_bucket,
+                                    subpixel_offset,
+                                )
+                            })?;
 
                         let glyph_pos = Vec2::new(glyph.x, glyph.y);
                         let size = atlas_info.rect.size();

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -340,7 +340,7 @@ impl TextPipeline {
                         return Err(TextError::NoSuchFont);
                     };
 
-                    let hint = hinting.is_enabled() && font_smoothing == FontSmoothing::AntiAliased;
+                    let hint = hinting.is_enabled() && font_smoothing != FontSmoothing::None;
                     let mut scaler = scale_cx
                         .0
                         .builder(font_ref)

--- a/crates/bevy_text/src/subpixel.rs
+++ b/crates/bevy_text/src/subpixel.rs
@@ -121,7 +121,7 @@ impl Default for SubpixelTextSettings {
 ///
 /// For [`SubpixelLcdLayout::HorizontalRgb`] the shader samples and emits the
 /// atlas RGB as-is. For [`SubpixelLcdLayout::HorizontalBgr`] the shader
-/// swizzles to `.bgr`, which inverts the colour-fringe direction — on a
+/// swizzles to `.bgr`, which inverts the color-fringe direction — on a
 /// physically BGR panel this yields correct subpixel antialiasing.
 ///
 /// Vertical variants (red-at-top / blue-at-bottom, for rotated portrait

--- a/crates/bevy_text/src/subpixel.rs
+++ b/crates/bevy_text/src/subpixel.rs
@@ -1,0 +1,153 @@
+//! Shared resources for RGB subpixel antialiased text rendering.
+//!
+//! These types live in `bevy_text` so both `bevy_ui_render` (for UI overlay
+//! text) and `bevy_sprite_render` (for world-space `Text2d`) can share a
+//! single set of tuning knobs — app authors configure subpixel rendering
+//! once for both pipelines.
+//!
+//! `bevy_text` intentionally does not depend on `bevy_render`, so the GPU-
+//! facing wiring (uniforms, bind groups, shader code) stays in the render
+//! crates. Each render crate maps these plain-data resources onto its own
+//! `ShaderType` uniform (`SubpixelTextUniforms` in `bevy_ui_render`) at
+//! render prep time.
+//!
+//! Cosmic-era predecessor: `7d7773720:crates/bevy_text/src/subpixel.rs` on
+//! the fork branch `subpixel-text-followups`. The shape carries forward; the
+//! `SubpixelLcdLayout` enum has been pared back to the two genuinely
+//! functional variants (see the type's docs).
+
+use bevy_ecs::prelude::ReflectResource;
+use bevy_ecs::resource::Resource;
+use bevy_math::Vec4;
+use bevy_reflect::{prelude::ReflectDefault, Reflect};
+
+/// Tracks whether the active wgpu adapter exposes
+/// [`wgpu::Features::DUAL_SOURCE_BLENDING`](https://docs.rs/wgpu/latest/wgpu/struct.Features.html#associatedconstant.DUAL_SOURCE_BLENDING),
+/// which [`FontSmoothing::SubpixelAntiAliased`](crate::FontSmoothing::SubpixelAntiAliased)
+/// requires for its dual-source-blend shader in both `bevy_ui_render` and
+/// `bevy_sprite_render`.
+///
+/// Inserted once at render startup by `bevy_ui_render::init_ui_subpixel_capability`
+/// (and, once phase-06 lands, `bevy_sprite_render::init_sprite_subpixel_capability`);
+/// either system produces the same value (both read the same adapter feature
+/// set), so the resource is consistent regardless of which render sub-app runs
+/// first.
+///
+/// When `false`, the subpixel queue paths in both renderers transparently
+/// fall back to the grayscale pipeline variant — the RGBA coverage atlas is
+/// still sampled, but the non-subpixel fragment entry only uses one channel
+/// as alpha, so glyphs render as approximate grayscale AA without panicking.
+///
+/// Consumers should read via `Option<Res<SubpixelCapable>>` and treat `None`
+/// as `SubpixelCapable(false)`, because `TextPlugin` does not insert this
+/// resource (only render plugins do). That keeps `bevy_text` usable in
+/// headless contexts without a render app.
+#[derive(Resource, Debug, Clone, Copy, Reflect)]
+#[reflect(Resource)]
+pub struct SubpixelCapable(pub bool);
+
+/// Tuning parameters for RGB subpixel antialiased text rendering.
+///
+/// Only consulted when [`FontSmoothing::SubpixelAntiAliased`](crate::FontSmoothing::SubpixelAntiAliased)
+/// is active and [`SubpixelCapable`] is `true`. Defaults match GPUI's
+/// gamma=1.8 preset, which works well across dark and light UI backgrounds.
+///
+/// Shared between `bevy_ui_render` (UI overlay text) and `bevy_sprite_render`
+/// (world-space `Text2d`). Both pipelines read the same resource so app
+/// authors only tune subpixel rendering once.
+///
+/// App authors tuning for a specific display or background can override:
+/// - `enhanced_contrast`: higher values yield more aggressive per-channel
+///   gamma; lower values are more muted (useful on very low-contrast
+///   backgrounds).
+/// - `gamma_ratios`: cubic-polynomial coefficients matching GPUI's
+///   `GAMMA_INCORRECT_TARGET_RATIOS` table. Alternate rows of that table
+///   correspond to different target gammas (1.0, 1.2, ... 2.2).
+///
+/// ```
+/// use bevy_math::Vec4;
+/// use bevy_ecs::prelude::*;
+/// use bevy_text::SubpixelTextSettings;
+///
+/// # let mut world = World::new();
+/// world.insert_resource(SubpixelTextSettings {
+///     enhanced_contrast: 0.35,
+///     gamma_ratios: Vec4::new(0.14746, -0.89481, 1.47021, -0.32474),
+/// });
+/// ```
+#[derive(Resource, Debug, Clone, Copy, Reflect)]
+#[reflect(Resource, Default, Debug, Clone)]
+pub struct SubpixelTextSettings {
+    /// Strength of the per-channel contrast boost applied before gamma
+    /// correction. GPUI's default is `0.5`.
+    pub enhanced_contrast: f32,
+    /// Cubic-polynomial coefficients used by the subpixel gamma correction.
+    /// Defaults match GPUI's gamma=1.8 row of `GAMMA_INCORRECT_TARGET_RATIOS`
+    /// scaled by `NORM13`/`NORM24`. See
+    /// `references/zed/crates/gpui/src/platform.rs::get_gamma_correction_ratios`
+    /// for the source table and the derivation.
+    pub gamma_ratios: Vec4,
+}
+
+impl Default for SubpixelTextSettings {
+    fn default() -> Self {
+        Self {
+            enhanced_contrast: 0.5,
+            gamma_ratios: Vec4::new(0.14746, -0.89481, 1.47021, -0.32474),
+        }
+    }
+}
+
+/// Subpixel arrangement of the target LCD panel.
+///
+/// Defaults to [`SubpixelLcdLayout::HorizontalRgb`] — the arrangement of
+/// ~99% of desktop LCDs and nearly all laptop panels. Override for BGR
+/// panels (some older displays). Automatic detection of the host panel's
+/// layout is deliberately out of scope — each platform's API is fiddly
+/// enough to be its own future spec.
+///
+/// Only consulted when [`FontSmoothing::SubpixelAntiAliased`](crate::FontSmoothing::SubpixelAntiAliased)
+/// is active and [`SubpixelCapable`] is `true`.
+///
+/// Shared between `bevy_ui_render` and `bevy_sprite_render`.
+///
+/// # Why only the horizontal variants?
+///
+/// The glyph atlas is produced by swash with
+/// [`Format::Subpixel`](https://docs.rs/swash/latest/swash/zeno/enum.Format.html),
+/// which emits three coverage values *per logical pixel*, pre-offset along
+/// the horizontal subpixel stripe. The atlas therefore already encodes the
+/// R-at-left / G-at-center / B-at-right geometry.
+///
+/// For [`SubpixelLcdLayout::HorizontalRgb`] the shader samples and emits the
+/// atlas RGB as-is. For [`SubpixelLcdLayout::HorizontalBgr`] the shader
+/// swizzles to `.bgr`, which inverts the colour-fringe direction — on a
+/// physically BGR panel this yields correct subpixel antialiasing.
+///
+/// Vertical variants (red-at-top / blue-at-bottom, for rotated portrait
+/// panels or vertical-stripe OLEDs) are deliberately deferred: correct
+/// vertical-subpixel antialiasing would require either rasterising the
+/// glyph with a rotated subpixel direction or maintaining a second
+/// vertical-subpixel atlas. A follow-up spec can revisit this.
+#[derive(Resource, Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Reflect)]
+#[reflect(Resource, Default, Debug, Clone, PartialEq, Hash)]
+pub enum SubpixelLcdLayout {
+    /// Red at left, green centered, blue at right. Default and most common.
+    #[default]
+    HorizontalRgb,
+    /// Blue at left, green centered, red at right. Some older displays.
+    HorizontalBgr,
+}
+
+impl SubpixelLcdLayout {
+    /// Packed discriminant matching the `SUBPIXEL_LAYOUT_*` constants in
+    /// `bevy_ui_render`'s `ui.wgsl` (and, post-phase-06, `bevy_sprite_render`'s
+    /// `sprite.wgsl`). Keep the numeric values in sync with those shader
+    /// constants.
+    pub fn pack_u32(self) -> u32 {
+        match self {
+            Self::HorizontalRgb => 0,
+            Self::HorizontalBgr => 1,
+        }
+    }
+}

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -1083,9 +1083,11 @@ impl<T: Into<Color>> From<T> for UnderlineColor {
 }
 
 /// Determines which antialiasing method to use when rendering text. By default, text is
-/// rendered with grayscale antialiasing, but this can be changed to achieve a pixelated look.
+/// rendered with grayscale antialiasing, but this can be changed to a pixelated look
+/// or to RGB subpixel antialiasing for extra horizontal sharpness on LCD/OLED panels.
 ///
-/// **Note:** Subpixel antialiasing is not currently supported.
+/// See [`SubpixelAntiAliased`](Self::SubpixelAntiAliased) for details on subpixel
+/// rendering, including its runtime requirements.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Reflect, Serialize, Deserialize)]
 #[reflect(Serialize, Deserialize, Clone, PartialEq, Hash, Default)]
 #[doc(alias = "antialiasing")]
@@ -1102,8 +1104,19 @@ pub enum FontSmoothing {
     /// even at small font sizes and low resolutions with modern vector fonts.
     #[default]
     AntiAliased,
-    // TODO: Add subpixel antialias support
-    // SubpixelAntiAliased,
+    /// Grayscale-plus-RGB subpixel coverage. Rasterises each glyph through
+    /// [`swash::zeno::Format::Subpixel`](swash::zeno::Format::Subpixel) so each
+    /// output pixel carries independent R / G / B coverage, and expects the
+    /// render pipeline to composite the result with a dual-source blend.
+    /// Produces noticeably crisper text at small body sizes (10-14pt) on LCD
+    /// and OLED panels at the cost of a subtle colour fringe on high-contrast
+    /// edges.
+    ///
+    /// Subpixel rendering requires
+    /// [`wgpu::Features::DUAL_SOURCE_BLENDING`](https://docs.rs/wgpu/latest/wgpu/struct.Features.html#associatedconstant.DUAL_SOURCE_BLENDING).
+    /// On adapters without that feature, subpixel text transparently
+    /// downgrades to [`AntiAliased`](Self::AntiAliased) with no errors.
+    SubpixelAntiAliased,
 }
 
 #[derive(Component, Debug, Copy, Clone, Default, Reflect, PartialEq, Hash, Eq)]

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -1109,7 +1109,7 @@ pub enum FontSmoothing {
     /// output pixel carries independent R / G / B coverage, and expects the
     /// render pipeline to composite the result with a dual-source blend.
     /// Produces noticeably crisper text at small body sizes (10-14pt) on LCD
-    /// and OLED panels at the cost of a subtle colour fringe on high-contrast
+    /// and OLED panels at the cost of a subtle color fringe on high-contrast
     /// edges.
     ///
     /// Subpixel rendering requires

--- a/crates/bevy_text/tests/subpixel_cache.rs
+++ b/crates/bevy_text/tests/subpixel_cache.rs
@@ -1,0 +1,203 @@
+//! Integration test: `SubpixelBucket` partitions the glyph cache so that
+//! four distinct horizontal subpixel offsets of the same glyph produce four
+//! distinct [`GlyphCacheKey`] entries within a single [`FontAtlas`].
+//!
+//! Non-subpixel smoothing modes collapse to [`SubpixelBucket::NotApplicable`],
+//! giving a single atlas cell per glyph id regardless of fractional position.
+//!
+//! This test drives [`add_glyph_to_atlas`] directly — the same entry point
+//! `TextPipeline::update_text_layout_info` uses once per glyph run — and
+//! mirrors the `subpixel_rasterisation.rs` test's scaffolding: a swash
+//! `FontRef` + `ScaleContext` rather than a full `App`.
+
+use bevy_asset::Assets;
+use bevy_image::Image;
+use bevy_math::Vec2;
+use bevy_text::{add_glyph_to_atlas, FontAtlas, FontSmoothing, GlyphCacheKey, SubpixelBucket};
+use swash::{scale::ScaleContext, FontRef};
+
+const FONT_BYTES: &[u8] = include_bytes!("../../../assets/fonts/FiraMono-Medium.ttf");
+
+const FRACTIONAL_XS: [f32; 4] = [0.1, 0.3, 0.6, 0.8];
+
+fn expected_buckets() -> [SubpixelBucket; 4] {
+    [
+        SubpixelBucket::Zero,
+        SubpixelBucket::Quarter,
+        SubpixelBucket::Half,
+        SubpixelBucket::ThreeQuarter,
+    ]
+}
+
+/// Return a fresh `Assets<Image>` and the glyph id for `'g'` in the bundled
+/// `FiraMono` font — the two pieces needed to drive [`add_glyph_to_atlas`]
+/// without pulling in a full `App`.
+fn make_image_assets() -> (Assets<Image>, u16) {
+    let font = FontRef::from_index(FONT_BYTES, 0).expect("load `FiraMono` font");
+    let glyph_id = font.charmap().map('g');
+    assert!(glyph_id != 0, "font is missing a glyph for 'g'");
+
+    (Assets::<Image>::default(), glyph_id)
+}
+
+fn rasterise_bucket(
+    font_atlases: &mut Vec<FontAtlas>,
+    textures: &mut Assets<Image>,
+    font_size: f32,
+    glyph_id: u16,
+    font_smoothing: FontSmoothing,
+    fractional_x: f32,
+) {
+    let font = FontRef::from_index(FONT_BYTES, 0).expect("load `FiraMono` font");
+    let mut scale_cx = ScaleContext::new();
+    let mut scaler = scale_cx.builder(font).size(font_size).hint(true).build();
+
+    let subpixel_bucket = SubpixelBucket::from_fract(fractional_x, font_smoothing);
+    let subpixel_offset = Vec2::new(subpixel_bucket.rasterise_offset_x(), 0.0);
+
+    add_glyph_to_atlas(
+        font_atlases,
+        textures,
+        &mut scaler,
+        font_smoothing,
+        glyph_id,
+        subpixel_bucket,
+        subpixel_offset,
+    )
+    .expect("add_glyph_to_atlas failed");
+}
+
+#[test]
+fn four_distinct_subpixel_buckets_produce_four_cache_entries_in_one_atlas() {
+    let (mut textures, glyph_id) = make_image_assets();
+    let mut font_atlases: Vec<FontAtlas> = Vec::new();
+
+    for fractional_x in FRACTIONAL_XS {
+        rasterise_bucket(
+            &mut font_atlases,
+            &mut textures,
+            24.0,
+            glyph_id,
+            FontSmoothing::SubpixelAntiAliased,
+            fractional_x,
+        );
+    }
+
+    assert_eq!(
+        font_atlases.len(),
+        1,
+        "four subpixel-bucketed rasterisations of the same glyph should share \
+         a single atlas texture — the bucket lives on `GlyphCacheKey` (inner \
+         cache key), not `FontAtlasKey` (outer atlas selector); finding more \
+         than one atlas here means the bucket leaked to the outer key",
+    );
+
+    let atlas = &font_atlases[0];
+    assert_eq!(
+        atlas.glyph_to_atlas_index.len(),
+        4,
+        "expected four distinct `GlyphCacheKey` entries (one per bucket); got {}",
+        atlas.glyph_to_atlas_index.len(),
+    );
+
+    for bucket in expected_buckets() {
+        let key = GlyphCacheKey {
+            glyph_id,
+            subpixel_bucket: bucket,
+        };
+        assert!(
+            atlas.has_glyph(key),
+            "atlas is missing an entry for {bucket:?}; \
+             `add_glyph_to_atlas` must populate `GlyphCacheKey {{ glyph_id, \
+             subpixel_bucket }}` for each rasterised bucket",
+        );
+    }
+}
+
+#[test]
+fn repopulating_same_buckets_is_a_pure_cache_hit() {
+    let (mut textures, glyph_id) = make_image_assets();
+    let mut font_atlases: Vec<FontAtlas> = Vec::new();
+
+    for fractional_x in FRACTIONAL_XS {
+        rasterise_bucket(
+            &mut font_atlases,
+            &mut textures,
+            24.0,
+            glyph_id,
+            FontSmoothing::SubpixelAntiAliased,
+            fractional_x,
+        );
+    }
+
+    let entries_after_first_pass = font_atlases[0].glyph_to_atlas_index.len();
+    assert_eq!(entries_after_first_pass, 4, "setup invariant");
+
+    // Re-request the same four buckets. `add_glyph_to_atlas` must notice the
+    // entries exist and return without inserting new ones — a `HashMap::insert`
+    // for an already-present key is a silent overwrite, but the entry count
+    // stays put.
+    for fractional_x in FRACTIONAL_XS {
+        rasterise_bucket(
+            &mut font_atlases,
+            &mut textures,
+            24.0,
+            glyph_id,
+            FontSmoothing::SubpixelAntiAliased,
+            fractional_x,
+        );
+    }
+
+    assert_eq!(
+        font_atlases.len(),
+        1,
+        "cache-hit re-population spawned a new atlas",
+    );
+    assert_eq!(
+        font_atlases[0].glyph_to_atlas_index.len(),
+        entries_after_first_pass,
+        "cache-hit re-population should not add new entries",
+    );
+}
+
+#[test]
+fn non_subpixel_smoothing_collapses_to_single_not_applicable_entry() {
+    let (mut textures, glyph_id) = make_image_assets();
+    let mut font_atlases: Vec<FontAtlas> = Vec::new();
+
+    for fractional_x in FRACTIONAL_XS {
+        rasterise_bucket(
+            &mut font_atlases,
+            &mut textures,
+            24.0,
+            glyph_id,
+            FontSmoothing::AntiAliased,
+            fractional_x,
+        );
+    }
+
+    assert_eq!(
+        font_atlases.len(),
+        1,
+        "`AntiAliased` rasterisations of a single glyph should share one atlas",
+    );
+
+    let atlas = &font_atlases[0];
+    assert_eq!(
+        atlas.glyph_to_atlas_index.len(),
+        1,
+        "`AntiAliased` always maps to `SubpixelBucket::NotApplicable`, so four \
+         fractional-x rasterisations of the same glyph must collapse to one \
+         cache entry; got {}",
+        atlas.glyph_to_atlas_index.len(),
+    );
+
+    let key = GlyphCacheKey {
+        glyph_id,
+        subpixel_bucket: SubpixelBucket::NotApplicable,
+    };
+    assert!(
+        atlas.has_glyph(key),
+        "expected cache entry with `SubpixelBucket::NotApplicable`",
+    );
+}

--- a/crates/bevy_text/tests/subpixel_rasterisation.rs
+++ b/crates/bevy_text/tests/subpixel_rasterisation.rs
@@ -30,7 +30,7 @@ fn rasterise(
     let glyph_id = font.charmap().map(ch);
     assert!(glyph_id != 0, "font is missing a glyph for {ch:?}");
     let mut scaler = scale_cx.builder(font).size(font_size).hint(true).build();
-    get_outlined_glyph_texture(&mut scaler, glyph_id, font_smoothing)
+    get_outlined_glyph_texture(&mut scaler, glyph_id, font_smoothing, Vec2::ZERO)
 }
 
 #[test]

--- a/crates/bevy_text/tests/subpixel_rasterisation.rs
+++ b/crates/bevy_text/tests/subpixel_rasterisation.rs
@@ -1,0 +1,87 @@
+//! Integration test: `FontSmoothing::SubpixelAntiAliased` produces
+//! RGB-distinguishable glyph output.
+//!
+//! The grayscale (`AntiAliased`) path writes `[255, 255, 255, a]` per pixel,
+//! so every pixel satisfies `R == G == B`. The subpixel path writes per-
+//! channel coverage (`[R_cov, G_cov, B_cov, _]`), so at least one pixel of
+//! any real glyph raster should have `R != G` or `G != B`.
+//!
+//! This test exercises `get_outlined_glyph_texture` directly via a swash
+//! `FontRef` + `ScaleContext`, which mirrors the setup
+//! `TextPipeline::update_text_layout_info` performs per glyph run.
+
+use bevy_image::Image;
+use bevy_math::Vec2;
+use bevy_text::{get_outlined_glyph_texture, FontSmoothing, TextError};
+use swash::{scale::ScaleContext, FontRef};
+
+const FONT_BYTES: &[u8] = include_bytes!("../../../assets/fonts/FiraMono-Medium.ttf");
+
+/// Rasterise a single character from the bundled `FiraMono` font under the
+/// requested `font_smoothing`, returning the full result of
+/// [`get_outlined_glyph_texture`].
+fn rasterise(
+    scale_cx: &mut ScaleContext,
+    ch: char,
+    font_size: f32,
+    font_smoothing: FontSmoothing,
+) -> Result<(Image, Vec2, bool), TextError> {
+    let font = FontRef::from_index(FONT_BYTES, 0).expect("load `FiraMono` font");
+    let glyph_id = font.charmap().map(ch);
+    assert!(glyph_id != 0, "font is missing a glyph for {ch:?}");
+    let mut scaler = scale_cx.builder(font).size(font_size).hint(true).build();
+    get_outlined_glyph_texture(&mut scaler, glyph_id, font_smoothing)
+}
+
+#[test]
+fn subpixel_rasterisation_produces_non_grayscale_output() {
+    let mut scale_cx = ScaleContext::new();
+
+    // Grayscale baseline: every pixel must have R == G == B.
+    let (grayscale_image, _, grayscale_is_alpha_mask) =
+        rasterise(&mut scale_cx, 'g', 24.0, FontSmoothing::AntiAliased)
+            .expect("grayscale rasterisation failed");
+    let grayscale_data = grayscale_image
+        .data
+        .as_ref()
+        .expect("grayscale image missing CPU data");
+
+    assert!(
+        grayscale_is_alpha_mask,
+        "grayscale AntiAliased output should report is_alpha_mask=true",
+    );
+    assert!(
+        grayscale_data
+            .chunks_exact(4)
+            .all(|px| px[0] == px[1] && px[1] == px[2]),
+        "grayscale AntiAliased output unexpectedly had differing R/G/B channels",
+    );
+
+    // Subpixel output: at least one pixel must have R != G or G != B.
+    let (subpixel_image, _, subpixel_is_alpha_mask) =
+        rasterise(&mut scale_cx, 'g', 24.0, FontSmoothing::SubpixelAntiAliased)
+            .expect("subpixel rasterisation failed");
+    let subpixel_data = subpixel_image
+        .data
+        .as_ref()
+        .expect("subpixel image missing CPU data");
+
+    assert!(
+        !subpixel_is_alpha_mask,
+        "subpixel output should report is_alpha_mask=false so the UI \
+         pipeline knows to composite it with a dual-source blend",
+    );
+    assert!(
+        subpixel_image.width() > 0 && subpixel_image.height() > 0,
+        "subpixel rasterisation produced a zero-sized image",
+    );
+
+    let any_rgb_differs = subpixel_data
+        .chunks_exact(4)
+        .any(|px| px[0] != px[1] || px[1] != px[2]);
+    assert!(
+        any_rgb_differs,
+        "subpixel SubpixelAntiAliased output had R == G == B in every pixel, \
+         indicating Format::Subpixel was not used for rasterisation",
+    );
+}

--- a/crates/bevy_text/tests/subpixel_settings.rs
+++ b/crates/bevy_text/tests/subpixel_settings.rs
@@ -1,0 +1,67 @@
+//! Unit tests for the shared subpixel tuning resources defined in
+//! `crates/bevy_text/src/subpixel.rs`.
+//!
+//! Asserts:
+//! - [`SubpixelTextSettings::default`] matches the GPUI-derived gamma=1.8
+//!   preset the render crates expect.
+//! - [`SubpixelLcdLayout::default`] is `HorizontalRgb` and `pack_u32`
+//!   discriminants match the `SUBPIXEL_LAYOUT_*` constants in
+//!   `bevy_ui_render`'s `ui.wgsl`.
+//! - [`SubpixelCapable`] wraps a `bool` and is constructible.
+
+use bevy_math::Vec4;
+use bevy_text::{SubpixelCapable, SubpixelLcdLayout, SubpixelTextSettings};
+
+#[test]
+fn subpixel_text_settings_default_matches_gpui_gamma_1_8() {
+    let settings = SubpixelTextSettings::default();
+    assert!(
+        (settings.enhanced_contrast - 0.5).abs() < f32::EPSILON,
+        "enhanced_contrast default should be GPUI's 0.5, got {}",
+        settings.enhanced_contrast,
+    );
+    assert_eq!(
+        settings.gamma_ratios,
+        Vec4::new(0.14746, -0.89481, 1.47021, -0.32474),
+        "gamma_ratios default should match the gamma=1.8 row of GPUI's GAMMA_INCORRECT_TARGET_RATIOS",
+    );
+}
+
+#[test]
+fn subpixel_lcd_layout_default_is_horizontal_rgb() {
+    assert_eq!(
+        SubpixelLcdLayout::default(),
+        SubpixelLcdLayout::HorizontalRgb
+    );
+}
+
+#[test]
+fn subpixel_lcd_layout_pack_u32_matches_shader_constants() {
+    // These numeric values must stay in sync with `SUBPIXEL_LAYOUT_*`
+    // constants in `bevy_ui_render/src/ui.wgsl` (and, post-phase-06,
+    // `bevy_sprite_render/src/sprite.wgsl`).
+    assert_eq!(SubpixelLcdLayout::HorizontalRgb.pack_u32(), 0);
+    assert_eq!(SubpixelLcdLayout::HorizontalBgr.pack_u32(), 1);
+}
+
+#[test]
+fn subpixel_capable_is_copy_bool_wrapper() {
+    let yes = SubpixelCapable(true);
+    let no = SubpixelCapable(false);
+    assert!(yes.0);
+    assert!(!no.0);
+    // Copy, not Clone — the Copy derive means rebinding after move is ok.
+    let also_yes = yes;
+    assert!(yes.0);
+    assert!(also_yes.0);
+}
+
+#[test]
+fn subpixel_text_settings_can_be_overridden() {
+    let custom = SubpixelTextSettings {
+        enhanced_contrast: 0.35,
+        gamma_ratios: Vec4::new(0.1, 0.2, 0.3, 0.4),
+    };
+    assert!((custom.enhanced_contrast - 0.35).abs() < f32::EPSILON);
+    assert_eq!(custom.gamma_ratios, Vec4::new(0.1, 0.2, 0.3, 0.4));
+}

--- a/crates/bevy_ui/src/widget/text_editable.rs
+++ b/crates/bevy_ui/src/widget/text_editable.rs
@@ -20,7 +20,7 @@ use bevy_text::{
     add_glyph_to_atlas, get_glyph_atlas_info, resolve_font_source, EditableText,
     EditableTextGeneration, Font, FontAtlasKey, FontAtlasSet, FontCx, FontHinting, FontSize,
     GlyphCacheKey, LayoutCx, LineBreak, LineHeight, PositionedGlyph, RemSize, RunGeometry, ScaleCx,
-    TextBrush, TextFont, TextLayout, TextLayoutInfo,
+    SubpixelBucket, TextBrush, TextFont, TextLayout, TextLayoutInfo,
 };
 use bevy_time::{Real, Time};
 use parley::{BoundingBox, PositionedLayoutItem, StyleProperty};
@@ -335,35 +335,42 @@ pub fn update_editable_text_layout(
                             };
 
                             for glyph in glyph_run.positioned_glyphs() {
+                                let subpixel_bucket =
+                                    SubpixelBucket::from_fract(glyph.x, text_font.font_smoothing);
+                                let subpixel_offset =
+                                    Vec2::new(subpixel_bucket.rasterise_offset_x(), 0.0);
+                                let cache_key = GlyphCacheKey {
+                                    glyph_id: glyph.id as u16,
+                                    subpixel_bucket,
+                                };
+
                                 let font_atlases =
                                     font_atlas_set.entry(font_atlas_key).or_default();
-                                let Ok(atlas_info) = get_glyph_atlas_info(
-                                    font_atlases,
-                                    GlyphCacheKey {
-                                        glyph_id: glyph.id as u16,
-                                    },
-                                )
-                                .map(Ok)
-                                .unwrap_or_else(|| {
-                                    let font_ref = FontRef::from_index(
-                                        font_data.data.as_ref(),
-                                        font_data.index as usize,
-                                    )
-                                    .unwrap();
-                                    let mut scaler = scale_cx
-                                        .builder(font_ref)
-                                        .size(font_size)
-                                        .hint(matches!(*hinting, FontHinting::Enabled))
-                                        .normalized_coords(coords)
-                                        .build();
-                                    add_glyph_to_atlas(
-                                        font_atlases,
-                                        textures.as_mut(),
-                                        &mut scaler,
-                                        text_font.font_smoothing,
-                                        glyph.id as u16,
-                                    )
-                                }) else {
+                                let Ok(atlas_info) = get_glyph_atlas_info(font_atlases, cache_key)
+                                    .map(Ok)
+                                    .unwrap_or_else(|| {
+                                        let font_ref = FontRef::from_index(
+                                            font_data.data.as_ref(),
+                                            font_data.index as usize,
+                                        )
+                                        .unwrap();
+                                        let mut scaler = scale_cx
+                                            .builder(font_ref)
+                                            .size(font_size)
+                                            .hint(matches!(*hinting, FontHinting::Enabled))
+                                            .normalized_coords(coords)
+                                            .build();
+                                        add_glyph_to_atlas(
+                                            font_atlases,
+                                            textures.as_mut(),
+                                            &mut scaler,
+                                            text_font.font_smoothing,
+                                            glyph.id as u16,
+                                            subpixel_bucket,
+                                            subpixel_offset,
+                                        )
+                                    })
+                                else {
                                     continue;
                                 };
 

--- a/crates/bevy_ui_render/Cargo.toml
+++ b/crates/bevy_ui_render/Cargo.toml
@@ -42,6 +42,11 @@ derive_more = { version = "2", default-features = false, features = ["from"] }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 indexmap = { version = "2" }
 
+[dev-dependencies]
+bevy_asset = { path = "../bevy_asset", version = "0.19.0-dev" }
+bevy_render = { path = "../bevy_render", version = "0.19.0-dev" }
+bevy_shader = { path = "../bevy_shader", version = "0.19.0-dev" }
+
 [features]
 default = ["bevy_ui_debug"]
 serialize = ["bevy_math/serialize", "bevy_platform/serialize"]

--- a/crates/bevy_ui_render/src/lib.rs
+++ b/crates/bevy_ui_render/src/lib.rs
@@ -42,7 +42,7 @@ use bevy_ecs::prelude::*;
 use bevy_ecs::schedule::IntoScheduleConfigs;
 use bevy_ecs::system::SystemParam;
 use bevy_image::{prelude::*, TRANSPARENT_IMAGE_HANDLE};
-use bevy_math::{Affine2, FloatOrd, Mat4, Rect, UVec4, Vec2};
+use bevy_math::{Affine2, FloatOrd, Mat4, Rect, UVec4, Vec2, Vec4};
 use bevy_render::{
     render_asset::RenderAssets,
     render_phase::{
@@ -64,8 +64,8 @@ use gradient::GradientPlugin;
 
 use bevy_platform::collections::{HashMap, HashSet};
 use bevy_text::{
-    ComputedTextBlock, PositionedGlyph, Strikethrough, StrikethroughColor, TextBackgroundColor,
-    TextColor, TextCursorStyle, TextLayoutInfo, Underline, UnderlineColor,
+    ComputedTextBlock, FontSmoothing, PositionedGlyph, Strikethrough, StrikethroughColor,
+    TextBackgroundColor, TextColor, TextCursorStyle, TextLayoutInfo, Underline, UnderlineColor,
 };
 use bevy_transform::components::GlobalTransform;
 use box_shadow::BoxShadowPlugin;
@@ -362,6 +362,11 @@ pub enum ExtractedUiItem {
     Glyphs {
         /// Indices into [`ExtractedUiNodes::glyphs`]
         range: Range<usize>,
+        /// Antialiasing method of the source text section. Read by
+        /// [`queue_uinodes`] to pick the subpixel pipeline variant when
+        /// [`FontSmoothing::SubpixelAntiAliased`]. All other variants use the
+        /// default alpha-blend fragment entry.
+        font_smoothing: FontSmoothing,
     },
 }
 
@@ -381,6 +386,54 @@ impl ExtractedUiNodes {
     pub fn clear(&mut self) {
         self.uinodes.clear();
         self.glyphs.clear();
+    }
+}
+
+/// Render-world uniform backing the `fragment_subpixel` entry point in
+/// `ui.wgsl`. Bound at `@group(0) @binding(1)` on the UI view bind group for
+/// every pipeline variant — the non-subpixel `fragment` entry point simply
+/// doesn't reference the binding, which keeps the bind group layout shared.
+///
+/// Phase-04 hardcodes GPUI's default tuning values (below). Phase-05 will
+/// introduce `SubpixelTextSettings` / `SubpixelLcdLayout` resources in
+/// `bevy_text` and populate this uniform from them in an extract system.
+///
+/// Layout mirrors the WGSL `SubpixelSettings` struct. `enhanced_contrast`
+/// (4 bytes) + `layout_flags` (4 bytes) + `_pad: Vec2` (8 bytes) packs the
+/// leading 16-byte slot; `gamma_ratios` is a trailing `vec4<f32>` on its
+/// natural 16-byte boundary. Total 32 bytes.
+#[derive(ShaderType, Clone, Copy, Debug)]
+pub struct SubpixelTextUniforms {
+    /// Enhanced-contrast factor (GPUI default `0.5`). Scales Skia's light-on-
+    /// dark contrast ramp inside `fragment_subpixel`.
+    pub enhanced_contrast: f32,
+    /// LCD subpixel layout discriminant. Matches the constants in
+    /// `ui.wgsl` (`SUBPIXEL_LAYOUT_HORIZONTAL_RGB = 0`, etc.). Phase-05
+    /// will map this from a `SubpixelLcdLayout` enum; phase-04 hardcodes
+    /// `HorizontalRgb` (`0`).
+    pub layout_flags: u32,
+    /// Explicit padding so `gamma_ratios` lands on a std140 16-byte
+    /// boundary. Must match the shader's `_pad: vec2<f32>`.
+    pub _pad: Vec2,
+    /// Four-element gamma-correction table row, precomputed from GPUI's
+    /// `GAMMA_INCORRECT_TARGET_RATIOS` at gamma = 1.8. See
+    /// `zed/crates/gpui/src/platform.rs::get_gamma_correction_ratios`.
+    pub gamma_ratios: Vec4,
+}
+
+impl Default for SubpixelTextUniforms {
+    fn default() -> Self {
+        // GPUI defaults. `enhanced_contrast = 0.5` is `RenderingParameters::new()`
+        // in GPUI's source; the gamma ratios are the gamma-1.8 row of
+        // `GAMMA_INCORRECT_TARGET_RATIOS` multiplied by the `NORM` constant
+        // GPUI applies at runtime. `layout_flags = 0` is `HorizontalRgb` —
+        // the identity swizzle in `swizzle_subpixel_atlas`.
+        Self {
+            enhanced_contrast: 0.5,
+            layout_flags: 0,
+            _pad: Vec2::ZERO,
+            gamma_ratios: Vec4::new(0.14746, -0.89481, 1.47021, -0.32474),
+        }
     }
 }
 
@@ -1050,13 +1103,28 @@ pub fn extract_text_sections(
                 .get(i + 1)
                 .is_none_or(|info| info.atlas_info.texture != atlas_info.texture)
             {
+                // Look up the source section's smoothing so `queue_uinodes`
+                // can pick the subpixel pipeline when appropriate. Batches
+                // are already flushed on atlas-texture boundaries, and every
+                // bucket of a subpixel-smoothed glyph ends up in a subpixel
+                // atlas distinct from other variants' atlases, so the
+                // per-batch smoothing value is uniform for all glyphs in the
+                // range.
+                let font_smoothing = computed_block
+                    .entities()
+                    .get(*section_index)
+                    .map(|t| t.font_smoothing)
+                    .unwrap_or_default();
                 extracted_uinodes.uinodes.push(ExtractedUiNode {
                     z_order: stack_index.0 as f32 + stack_z_offsets::TEXT,
                     render_entity: commands.spawn(TemporaryRenderEntity).id(),
                     image: atlas_info.texture,
                     clip,
                     extracted_camera_entity,
-                    item: ExtractedUiItem::Glyphs { range: start..end },
+                    item: ExtractedUiItem::Glyphs {
+                        range: start..end,
+                        font_smoothing,
+                    },
                     main_entity: entity.into(),
                     transform,
                 });
@@ -1153,6 +1221,11 @@ pub fn extract_text_shadows(
                 info.section_index != *section_index
                     || info.atlas_info.texture != atlas_info.texture
             }) {
+                let font_smoothing = computed_block
+                    .entities()
+                    .get(*section_index)
+                    .map(|t| t.font_smoothing)
+                    .unwrap_or_default();
                 extracted_uinodes.uinodes.push(ExtractedUiNode {
                     transform: node_transform,
                     z_order: stack_index.0 as f32 + stack_z_offsets::TEXT,
@@ -1160,7 +1233,10 @@ pub fn extract_text_shadows(
                     image: atlas_info.texture,
                     clip,
                     extracted_camera_entity,
-                    item: ExtractedUiItem::Glyphs { range: start..end },
+                    item: ExtractedUiItem::Glyphs {
+                        range: start..end,
+                        font_smoothing,
+                    },
                     main_entity: entity.into(),
                 });
                 start = end;
@@ -1434,6 +1510,13 @@ pub struct UiMeta {
     vertices: RawBufferVec<UiVertex>,
     indices: RawBufferVec<u32>,
     view_bind_group: Option<BindGroup>,
+    /// Uniform buffer for [`SubpixelTextUniforms`], bound at `@group(0)
+    /// @binding(1)` alongside the view uniform for every UI pipeline variant.
+    /// Phase-04 seeds with [`SubpixelTextUniforms::default`] and never updates
+    /// it after construction; phase-05 adds an extract system that writes
+    /// frame-by-frame from the `SubpixelTextSettings` / `SubpixelLcdLayout`
+    /// resources.
+    pub(crate) subpixel_settings: UniformBuffer<SubpixelTextUniforms>,
 }
 
 impl Default for UiMeta {
@@ -1442,6 +1525,7 @@ impl Default for UiMeta {
             vertices: RawBufferVec::new(BufferUsages::VERTEX),
             indices: RawBufferVec::new(BufferUsages::INDEX),
             view_bind_group: None,
+            subpixel_settings: UniformBuffer::from(SubpixelTextUniforms::default()),
         }
     }
 }
@@ -1517,12 +1601,27 @@ pub fn queue_uinodes(
             continue;
         };
 
+        // Glyph batches tagged `FontSmoothing::SubpixelAntiAliased` route to
+        // the dual-source-blend pipeline variant. Phase-04 unconditionally
+        // picks DSB when the batch is subpixel-smoothed; phase-05 will gate
+        // this on a `SubpixelCapable` resource populated from
+        // `wgpu::Features::DUAL_SOURCE_BLENDING` so adapters without DSB
+        // support fall back to the grayscale pipeline without panicking.
+        let subpixel = matches!(
+            extracted_uinode.item,
+            ExtractedUiItem::Glyphs {
+                font_smoothing: FontSmoothing::SubpixelAntiAliased,
+                ..
+            }
+        );
+
         let pipeline = pipelines.specialize(
             &pipeline_cache,
             &ui_pipeline,
             UiPipelineKey {
                 target_format: view.target_format,
                 anti_alias: matches!(ui_anti_alias, None | Some(UiAntiAlias::On)),
+                subpixel,
             },
         );
 
@@ -1573,16 +1672,31 @@ pub fn prepare_uinodes(
         };
     }
 
-    if let Some(view_binding) = view_uniforms.uniforms.binding() {
+    // Flush the subpixel-text uniform to the GPU before building the view
+    // bind group below — `subpixel_settings.binding()` returns `None` until
+    // the backing buffer has been written at least once.
+    ui_meta
+        .subpixel_settings
+        .write_buffer(&render_device, &render_queue);
+
+    let view_bind_group = match (
+        view_uniforms.uniforms.binding(),
+        ui_meta.subpixel_settings.binding(),
+    ) {
+        (Some(view_binding), Some(subpixel_binding)) => Some(render_device.create_bind_group(
+            "ui_view_bind_group",
+            &pipeline_cache.get_bind_group_layout(&ui_pipeline.view_layout),
+            &BindGroupEntries::sequential((view_binding, subpixel_binding)),
+        )),
+        _ => None,
+    };
+
+    if let Some(view_bind_group) = view_bind_group {
         let mut batches: Vec<(Entity, UiBatch)> = Vec::with_capacity(*previous_len);
 
         ui_meta.vertices.clear();
         ui_meta.indices.clear();
-        ui_meta.view_bind_group = Some(render_device.create_bind_group(
-            "ui_view_bind_group",
-            &pipeline_cache.get_bind_group_layout(&ui_pipeline.view_layout),
-            &BindGroupEntries::single(view_binding),
-        ));
+        ui_meta.view_bind_group = Some(view_bind_group);
 
         // Buffer indexes
         let mut vertices_index = 0;
@@ -1833,7 +1947,7 @@ pub fn prepare_uinodes(
                         vertices_index += 6;
                         indices_index += 4;
                     }
-                    ExtractedUiItem::Glyphs { range } => {
+                    ExtractedUiItem::Glyphs { range, .. } => {
                         let image = gpu_images
                             .get(extracted_uinode.image)
                             .expect("Image was checked during batching and should still exist");

--- a/crates/bevy_ui_render/src/lib.rs
+++ b/crates/bevy_ui_render/src/lib.rs
@@ -65,7 +65,8 @@ use gradient::GradientPlugin;
 use bevy_platform::collections::{HashMap, HashSet};
 use bevy_text::{
     ComputedTextBlock, FontSmoothing, PositionedGlyph, Strikethrough, StrikethroughColor,
-    TextBackgroundColor, TextColor, TextCursorStyle, TextLayoutInfo, Underline, UnderlineColor,
+    SubpixelCapable, SubpixelLcdLayout, SubpixelTextSettings, TextBackgroundColor, TextColor,
+    TextCursorStyle, TextLayoutInfo, Underline, UnderlineColor,
 };
 use bevy_transform::components::GlobalTransform;
 use box_shadow::BoxShadowPlugin;
@@ -232,7 +233,10 @@ impl Plugin for UiRenderPlugin {
                 )
                     .chain(),
             )
-            .add_systems(RenderStartup, init_ui_pipeline)
+            .add_systems(
+                RenderStartup,
+                (init_ui_pipeline, init_ui_subpixel_capability),
+            )
             .add_systems(
                 ExtractSchedule,
                 (
@@ -394,9 +398,13 @@ impl ExtractedUiNodes {
 /// every pipeline variant — the non-subpixel `fragment` entry point simply
 /// doesn't reference the binding, which keeps the bind group layout shared.
 ///
-/// Phase-04 hardcodes GPUI's default tuning values (below). Phase-05 will
-/// introduce `SubpixelTextSettings` / `SubpixelLcdLayout` resources in
-/// `bevy_text` and populate this uniform from them in an extract system.
+/// Populated each frame by [`prepare_uinodes`] from the main-world
+/// [`SubpixelTextSettings`] / [`SubpixelLcdLayout`] resources (both
+/// `init_resource`'d by `TextPlugin::build`). The [`Default`] impl on this
+/// struct matches `SubpixelTextSettings::default()` + `SubpixelLcdLayout::HorizontalRgb`
+/// so the uniform holds sensible values for the brief window before the
+/// first prepare-phase run (e.g. if a render sub-app queries the buffer
+/// during `RenderStartup`).
 ///
 /// Layout mirrors the WGSL `SubpixelSettings` struct. `enhanced_contrast`
 /// (4 bytes) + `layout_flags` (4 bytes) + `_pad: Vec2` (8 bytes) packs the
@@ -423,11 +431,12 @@ pub struct SubpixelTextUniforms {
 
 impl Default for SubpixelTextUniforms {
     fn default() -> Self {
-        // GPUI defaults. `enhanced_contrast = 0.5` is `RenderingParameters::new()`
-        // in GPUI's source; the gamma ratios are the gamma-1.8 row of
-        // `GAMMA_INCORRECT_TARGET_RATIOS` multiplied by the `NORM` constant
-        // GPUI applies at runtime. `layout_flags = 0` is `HorizontalRgb` —
-        // the identity swizzle in `swizzle_subpixel_atlas`.
+        // Must match `SubpixelTextSettings::default()` + `SubpixelLcdLayout::default()`
+        // so the initial bind-group value is consistent with the tuning
+        // resources. `enhanced_contrast = 0.5` is GPUI's
+        // `RenderingParameters::new()`; the gamma ratios are the gamma-1.8
+        // row of `GAMMA_INCORRECT_TARGET_RATIOS`. `layout_flags = 0` is
+        // `HorizontalRgb` — the identity swizzle in `swizzle_subpixel_atlas`.
         Self {
             enhanced_contrast: 0.5,
             layout_flags: 0,
@@ -1512,10 +1521,11 @@ pub struct UiMeta {
     view_bind_group: Option<BindGroup>,
     /// Uniform buffer for [`SubpixelTextUniforms`], bound at `@group(0)
     /// @binding(1)` alongside the view uniform for every UI pipeline variant.
-    /// Phase-04 seeds with [`SubpixelTextUniforms::default`] and never updates
-    /// it after construction; phase-05 adds an extract system that writes
-    /// frame-by-frame from the `SubpixelTextSettings` / `SubpixelLcdLayout`
-    /// resources.
+    /// Seeded with [`SubpixelTextUniforms::default`]; [`prepare_uinodes`]
+    /// overwrites the value each frame from the main-world
+    /// [`SubpixelTextSettings`] / [`SubpixelLcdLayout`] resources
+    /// (`TextPlugin::build` `init_resource`'s both with GPUI-derived
+    /// defaults, so the uniform always tracks app-level configuration).
     pub(crate) subpixel_settings: UniformBuffer<SubpixelTextUniforms>,
 }
 
@@ -1574,7 +1584,13 @@ pub fn queue_uinodes(
     camera_views: Query<&ExtractedView>,
     pipeline_cache: Res<PipelineCache>,
     draw_functions: Res<DrawFunctions<TransparentUi>>,
+    subpixel_capable: Option<Res<SubpixelCapable>>,
 ) {
+    // `SubpixelCapable` is inserted by `init_ui_subpixel_capability` at
+    // `RenderStartup`; any frame before that runs (or in headless contexts
+    // where the render plugin hasn't populated it) conservatively treats
+    // the adapter as non-capable so glyphs never hit the DSB path.
+    let subpixel_supported = subpixel_capable.as_deref().is_some_and(|c| c.0);
     let draw_function = draw_functions.read().id::<DrawUi>();
     let mut current_camera_entity = Entity::PLACEHOLDER;
     let mut current_phase = None;
@@ -1602,18 +1618,22 @@ pub fn queue_uinodes(
         };
 
         // Glyph batches tagged `FontSmoothing::SubpixelAntiAliased` route to
-        // the dual-source-blend pipeline variant. Phase-04 unconditionally
-        // picks DSB when the batch is subpixel-smoothed; phase-05 will gate
-        // this on a `SubpixelCapable` resource populated from
-        // `wgpu::Features::DUAL_SOURCE_BLENDING` so adapters without DSB
-        // support fall back to the grayscale pipeline without panicking.
-        let subpixel = matches!(
-            extracted_uinode.item,
-            ExtractedUiItem::Glyphs {
-                font_smoothing: FontSmoothing::SubpixelAntiAliased,
-                ..
-            }
-        );
+        // the dual-source-blend pipeline variant — but only when the active
+        // adapter supports `wgpu::Features::DUAL_SOURCE_BLENDING`. If
+        // `SubpixelCapable(false)` (probed at `RenderStartup` by
+        // `init_ui_subpixel_capability`), the subpixel glyph batch is
+        // silently routed through the grayscale variant instead; the RGBA
+        // coverage atlas is still sampled, but the non-subpixel fragment
+        // only uses one channel as alpha — approximate grayscale AA,
+        // zero panics, zero shader errors.
+        let subpixel = subpixel_supported
+            && matches!(
+                extracted_uinode.item,
+                ExtractedUiItem::Glyphs {
+                    font_smoothing: FontSmoothing::SubpixelAntiAliased,
+                    ..
+                }
+            );
 
         let pipeline = pipelines.specialize(
             &pipeline_cache,
@@ -1658,6 +1678,8 @@ pub fn prepare_uinodes(
     mut phases: ResMut<ViewSortedRenderPhases<TransparentUi>>,
     events: Res<SpriteAssetEvents>,
     mut previous_len: Local<usize>,
+    subpixel_settings: Option<Res<SubpixelTextSettings>>,
+    subpixel_layout: Option<Res<SubpixelLcdLayout>>,
 ) {
     // If an image has changed, the GpuImage has (probably) changed
     for event in &events.images {
@@ -1671,6 +1693,20 @@ pub fn prepare_uinodes(
             }
         };
     }
+
+    // Drive the subpixel-text uniform from the main-world tuning resources.
+    // `TextPlugin::build` `init_resource`'s both with GPUI-derived defaults;
+    // a missing resource (headless / no `TextPlugin`) falls back to the
+    // same defaults so the bind group still populates correctly.
+    let settings = subpixel_settings.as_deref().copied().unwrap_or_default();
+    let layout = subpixel_layout.as_deref().copied().unwrap_or_default();
+    let uniforms = SubpixelTextUniforms {
+        enhanced_contrast: settings.enhanced_contrast,
+        layout_flags: layout.pack_u32(),
+        _pad: Vec2::ZERO,
+        gamma_ratios: settings.gamma_ratios,
+    };
+    ui_meta.subpixel_settings.set(uniforms);
 
     // Flush the subpixel-text uniform to the GPU before building the view
     // bind group below — `subpixel_settings.binding()` returns `None` until

--- a/crates/bevy_ui_render/src/pipeline.rs
+++ b/crates/bevy_ui_render/src/pipeline.rs
@@ -138,7 +138,7 @@ impl SpecializedRenderPipeline for UiPipeline {
         //              + dst.rgb * (1 - alpha_per_channel)
         // which requires `Src1` / `OneMinusSrc1` (the per-channel alpha is the
         // dual-source output). The alpha component keeps conventional
-        // premultiplied behaviour so the UI framebuffer's own alpha stays
+        // premultiplied behavior so the UI framebuffer's own alpha stays
         // sensible. Mirrors GPUI's subpixel pipeline
         // (`zed/crates/gpui/src/platform/blade/blade_renderer.rs`) and the
         // cosmic-era fork precedent (`subpixel-text-followups` commit

--- a/crates/bevy_ui_render/src/pipeline.rs
+++ b/crates/bevy_ui_render/src/pipeline.rs
@@ -1,3 +1,4 @@
+use crate::SubpixelTextUniforms;
 use bevy_asset::{load_embedded_asset, AssetServer, Handle};
 use bevy_ecs::prelude::*;
 use bevy_mesh::VertexBufferLayout;
@@ -19,11 +20,22 @@ pub struct UiPipeline {
 }
 
 pub fn init_ui_pipeline(mut commands: Commands, asset_server: Res<AssetServer>) {
+    // Binding 1 is the `SubpixelTextUniforms` uniform (see
+    // [`crate::SubpixelTextUniforms`]). It is declared on every UI pipeline
+    // variant — including the non-subpixel path — so the view bind group layout
+    // is a single shared definition. The non-subpixel WGSL entry points simply
+    // don't reference the binding; naga/wgpu are fine with unused bindings as
+    // long as the layout matches. Phase-05 will populate the buffer from the
+    // `SubpixelTextSettings` / `SubpixelLcdLayout` resources; phase-04 uses the
+    // hardcoded GPUI defaults emitted by `SubpixelTextUniforms::default`.
     let view_layout = BindGroupLayoutDescriptor::new(
         "ui_view_layout",
-        &BindGroupLayoutEntries::single(
+        &BindGroupLayoutEntries::sequential(
             ShaderStages::VERTEX_FRAGMENT,
-            uniform_buffer::<ViewUniform>(true),
+            (
+                uniform_buffer::<ViewUniform>(true),
+                uniform_buffer::<SubpixelTextUniforms>(false),
+            ),
         ),
     );
 
@@ -45,10 +57,21 @@ pub fn init_ui_pipeline(mut commands: Commands, asset_server: Res<AssetServer>) 
     });
 }
 
-#[derive(Clone, Copy, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub struct UiPipelineKey {
     pub target_format: TextureFormat,
     pub anti_alias: bool,
+    /// Whether this pipeline variant targets RGB subpixel text glyphs.
+    ///
+    /// When `true`, [`UiPipeline::specialize`] emits the dual-source-blend
+    /// variant (`fragment_subpixel` entry point, `SUBPIXEL` shader def,
+    /// `Src1` / `OneMinusSrc1` blend factors). Queue-side selection in
+    /// [`crate::queue_uinodes`] sets this for glyph batches whose source
+    /// section used `FontSmoothing::SubpixelAntiAliased`. Adapter fallback
+    /// (via `wgpu::Features::DUAL_SOURCE_BLENDING`) is introduced in
+    /// phase-05; phase-04 always picks the DSB variant when the glyph is
+    /// subpixel-smoothed.
+    pub subpixel: bool,
 }
 
 impl SpecializedRenderPipeline for UiPipeline {
@@ -76,10 +99,44 @@ impl SpecializedRenderPipeline for UiPipeline {
                 VertexFormat::Float32x2,
             ],
         );
-        let shader_defs = if key.anti_alias {
-            vec!["ANTI_ALIAS".into()]
+        let mut shader_defs = Vec::new();
+        if key.anti_alias {
+            shader_defs.push("ANTI_ALIAS".into());
+        }
+        if key.subpixel {
+            shader_defs.push("SUBPIXEL".into());
+        }
+
+        // Subpixel text renders via a dual-source-blend fragment shader so the
+        // framebuffer can consume a per-channel alpha from `@blend_src(1)`.
+        // The color blend is
+        //   result.rgb = fg.rgb * alpha_per_channel
+        //              + dst.rgb * (1 - alpha_per_channel)
+        // which requires `Src1` / `OneMinusSrc1` (the per-channel alpha is the
+        // dual-source output). The alpha component keeps conventional
+        // premultiplied behaviour so the UI framebuffer's own alpha stays
+        // sensible. Mirrors GPUI's subpixel pipeline
+        // (`zed/crates/gpui/src/platform/blade/blade_renderer.rs`) and the
+        // cosmic-era fork precedent (`subpixel-text-followups` commit
+        // `aeb7aadfb`).
+        let (fragment_entry_point, blend) = if key.subpixel {
+            (
+                Some("fragment_subpixel".into()),
+                BlendState {
+                    color: BlendComponent {
+                        src_factor: BlendFactor::Src1,
+                        dst_factor: BlendFactor::OneMinusSrc1,
+                        operation: BlendOperation::Add,
+                    },
+                    alpha: BlendComponent {
+                        src_factor: BlendFactor::One,
+                        dst_factor: BlendFactor::OneMinusSrcAlpha,
+                        operation: BlendOperation::Add,
+                    },
+                },
+            )
         } else {
-            Vec::new()
+            (None, BlendState::ALPHA_BLENDING)
         };
 
         RenderPipelineDescriptor {
@@ -92,15 +149,19 @@ impl SpecializedRenderPipeline for UiPipeline {
             fragment: Some(FragmentState {
                 shader: self.shader.clone(),
                 shader_defs,
+                entry_point: fragment_entry_point,
                 targets: vec![Some(ColorTargetState {
                     format: key.target_format,
-                    blend: Some(BlendState::ALPHA_BLENDING),
+                    blend: Some(blend),
                     write_mask: ColorWrites::ALL,
                 })],
-                ..default()
             }),
             layout: vec![self.view_layout.clone(), self.image_layout.clone()],
-            label: Some("ui_pipeline".into()),
+            label: Some(if key.subpixel {
+                "ui_pipeline_subpixel".into()
+            } else {
+                "ui_pipeline".into()
+            }),
             ..default()
         }
     }

--- a/crates/bevy_ui_render/src/pipeline.rs
+++ b/crates/bevy_ui_render/src/pipeline.rs
@@ -7,9 +7,11 @@ use bevy_render::{
         binding_types::{sampler, texture_2d, uniform_buffer},
         *,
     },
+    renderer::RenderDevice,
     view::ViewUniform,
 };
 use bevy_shader::Shader;
+use bevy_text::SubpixelCapable;
 use bevy_utils::default;
 
 #[derive(Resource)]
@@ -22,12 +24,12 @@ pub struct UiPipeline {
 pub fn init_ui_pipeline(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Binding 1 is the `SubpixelTextUniforms` uniform (see
     // [`crate::SubpixelTextUniforms`]). It is declared on every UI pipeline
-    // variant — including the non-subpixel path — so the view bind group layout
-    // is a single shared definition. The non-subpixel WGSL entry points simply
-    // don't reference the binding; naga/wgpu are fine with unused bindings as
-    // long as the layout matches. Phase-05 will populate the buffer from the
-    // `SubpixelTextSettings` / `SubpixelLcdLayout` resources; phase-04 uses the
-    // hardcoded GPUI defaults emitted by `SubpixelTextUniforms::default`.
+    // variant — including the non-subpixel path — so the view bind group
+    // layout is a single shared definition. The non-subpixel WGSL entry
+    // points simply don't reference the binding; naga/wgpu are fine with
+    // unused bindings as long as the layout matches. The uniform buffer is
+    // populated by [`crate::prepare_uinodes`] from the main-world
+    // `SubpixelTextSettings` / `SubpixelLcdLayout` resources.
     let view_layout = BindGroupLayoutDescriptor::new(
         "ui_view_layout",
         &BindGroupLayoutEntries::sequential(
@@ -57,6 +59,27 @@ pub fn init_ui_pipeline(mut commands: Commands, asset_server: Res<AssetServer>) 
     });
 }
 
+/// Populate the [`SubpixelCapable`] resource from the active render adapter's
+/// wgpu feature set at `RenderStartup`. Reads
+/// [`WgpuFeatures::DUAL_SOURCE_BLENDING`] — the feature the subpixel UI
+/// fragment entry (`fragment_subpixel` in `ui.wgsl`) requires for its
+/// `@blend_src(1)` output.
+///
+/// On adapters without DSB support, [`crate::queue_uinodes`] downgrades
+/// glyph batches tagged [`bevy_text::FontSmoothing::SubpixelAntiAliased`] to
+/// the grayscale pipeline variant — no panic, no shader error, just a
+/// silent visual degradation to approximate grayscale AA.
+///
+/// `bevy_sprite_render` (phase-06) will add its own
+/// `init_sprite_subpixel_capability` system that writes the same resource
+/// from the same underlying feature set; the two systems are idempotent.
+pub fn init_ui_subpixel_capability(mut commands: Commands, render_device: Res<RenderDevice>) {
+    let supported = render_device
+        .features()
+        .contains(WgpuFeatures::DUAL_SOURCE_BLENDING);
+    commands.insert_resource(SubpixelCapable(supported));
+}
+
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub struct UiPipelineKey {
     pub target_format: TextureFormat,
@@ -67,10 +90,11 @@ pub struct UiPipelineKey {
     /// variant (`fragment_subpixel` entry point, `SUBPIXEL` shader def,
     /// `Src1` / `OneMinusSrc1` blend factors). Queue-side selection in
     /// [`crate::queue_uinodes`] sets this for glyph batches whose source
-    /// section used `FontSmoothing::SubpixelAntiAliased`. Adapter fallback
-    /// (via `wgpu::Features::DUAL_SOURCE_BLENDING`) is introduced in
-    /// phase-05; phase-04 always picks the DSB variant when the glyph is
-    /// subpixel-smoothed.
+    /// section used `FontSmoothing::SubpixelAntiAliased`, but only when
+    /// the [`bevy_text::SubpixelCapable`] resource reports `true` (the
+    /// active adapter advertises `wgpu::Features::DUAL_SOURCE_BLENDING`).
+    /// On non-DSB adapters the flag is always forced to `false` so glyphs
+    /// silently fall back to the grayscale pipeline.
     pub subpixel: bool,
 }
 

--- a/crates/bevy_ui_render/src/ui.wgsl
+++ b/crates/bevy_ui_render/src/ui.wgsl
@@ -275,10 +275,10 @@ fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
 // The glyph atlas bound to `sprite_texture` stores *three per-channel
 // coverage values* per pixel (one for each of the LCD stripe's R / G / B
 // subpixels), produced by `swash`'s `Format::Subpixel` rasteriser in
-// `bevy_text`. The sample is therefore not a colour — each channel is an
+// `bevy_text`. The sample is therefore not a color — each channel is an
 // alpha for its matching subpixel. We emit dual-source fragments so the
 // hardware blender can consume per-channel alpha: `@blend_src(0)` carries
-// the foreground colour and `@blend_src(1)` carries the per-channel alpha
+// the foreground color and `@blend_src(1)` carries the per-channel alpha
 // that the destination factor `OneMinusSrc1` multiplies against the
 // existing framebuffer value.
 //
@@ -337,7 +337,7 @@ fn apply_contrast_and_gamma_correction3(
 // The swash rasteriser (`bevy_text::font_atlas::get_outlined_glyph_texture`)
 // emits the atlas with *horizontal RGB* pre-offset baked in: texel
 // `(x, y).r` is already the left subpixel's coverage at logical pixel
-// `(x, y)`, `.g` the centre, `.b` the right. We therefore only need to
+// `(x, y)`, `.g` the center, `.b` the right. We therefore only need to
 // swizzle — not resample at offset UVs — to support BGR panels.
 //
 // The vertical variants have no correct remap available from a

--- a/crates/bevy_ui_render/src/ui.wgsl
+++ b/crates/bevy_ui_render/src/ui.wgsl
@@ -1,3 +1,14 @@
+// `enable dual_source_blending;` must appear before any other global
+// declaration per the WGSL spec. We keep it unconditional (rather than
+// gating it on `#ifdef SUBPIXEL`) because naga_oil's preprocessor expands
+// `#define_import_path` / `#import` as leading globals, which makes a
+// `#ifdef`-wrapped `enable` land "after" them and trips a parse error.
+// The directive is harmless when the SUBPIXEL path is inactive — naga only
+// requires the corresponding DSB capability at compile time on pipelines
+// that actually use `@blend_src`. See `crates/bevy_pbr/src/atmosphere/
+// render_sky.wgsl` for the same pattern.
+enable dual_source_blending;
+
 #define_import_path bevy_ui::ui_node
 
 #import bevy_render::view::View
@@ -18,6 +29,37 @@ fn enabled(flags: u32, mask: u32) -> bool {
 }
 
 @group(0) @binding(0) var<uniform> view: View;
+
+// Tuning parameters for `fragment_subpixel`. Declared on every UI pipeline
+// variant — even the non-subpixel entry points — so the view bind group
+// layout is shared. The non-subpixel `fragment` entry simply doesn't
+// reference this. Phase-05 will populate from the user-facing
+// `SubpixelTextSettings` / `SubpixelLcdLayout` resources; phase-04 carries
+// GPUI-default values baked in at [`SubpixelTextUniforms::default`] in
+// `bevy_ui_render::lib.rs`.
+//
+// `layout_flags` discriminant (keep in sync with `SubpixelLcdLayout` in
+// `bevy_text` once phase-05 adds it):
+//   0 = HorizontalRgb  (atlas R, G, B in that order — identity swizzle)
+//   1 = HorizontalBgr  (swap R/B — text on a BGR panel)
+//   2 = VerticalRgb    (proof-of-wiring; see vertical-limitation note below)
+//   3 = VerticalBgr    (proof-of-wiring)
+struct SubpixelSettings {
+    enhanced_contrast: f32,
+    layout_flags: u32,
+    // Explicit padding matches the Rust `SubpixelTextUniforms::_pad` so the
+    // trailing `vec4<f32>` below lands on a 16-byte boundary per std140
+    // rules. `enhanced_contrast` (4 bytes) + `layout_flags` (4 bytes) +
+    // `_pad` (8 bytes) fills the leading 16-byte slot.
+    _pad: vec2<f32>,
+    gamma_ratios: vec4<f32>,
+}
+@group(0) @binding(1) var<uniform> subpixel_settings: SubpixelSettings;
+
+const SUBPIXEL_LAYOUT_HORIZONTAL_RGB: u32 = 0u;
+const SUBPIXEL_LAYOUT_HORIZONTAL_BGR: u32 = 1u;
+const SUBPIXEL_LAYOUT_VERTICAL_RGB: u32 = 2u;
+const SUBPIXEL_LAYOUT_VERTICAL_BGR: u32 = 3u;
 
 struct VertexOutput {
     @location(0) uv: vec2<f32>,
@@ -226,3 +268,122 @@ fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
         return draw_uinode_background(color, in.point, in.size, in.radius, in.border, in.flags);
     }
 }
+
+#ifdef SUBPIXEL
+// RGB subpixel text fragment path.
+//
+// The glyph atlas bound to `sprite_texture` stores *three per-channel
+// coverage values* per pixel (one for each of the LCD stripe's R / G / B
+// subpixels), produced by `swash`'s `Format::Subpixel` rasteriser in
+// `bevy_text`. The sample is therefore not a colour — each channel is an
+// alpha for its matching subpixel. We emit dual-source fragments so the
+// hardware blender can consume per-channel alpha: `@blend_src(0)` carries
+// the foreground colour and `@blend_src(1)` carries the per-channel alpha
+// that the destination factor `OneMinusSrc1` multiplies against the
+// existing framebuffer value.
+//
+// The contrast + gamma math is ported verbatim from Zed's GPUI subpixel
+// shader, which in turn follows Skia's LCD text correction. Enhanced-
+// contrast is luminance-adapted ("light-on-dark") so dark-mode text
+// doesn't bloom; the gamma ratios are a lookup-driven adjustment around a
+// target gamma (GPUI's default is 1.8).
+//
+// The tuning values (`enhanced_contrast`, `gamma_ratios`) are read from
+// the `SubpixelSettings` uniform bound at `@group(0) @binding(1)`. The
+// defaults (GPUI's `RenderingParameters::new()`) are baked into
+// `SubpixelTextUniforms::default` in `bevy_ui_render::lib.rs`; phase-05
+// plumbs a `SubpixelTextSettings` / `SubpixelLcdLayout` resource pair to
+// override them at runtime.
+struct SubpixelOutput {
+    @location(0) @blend_src(0) color: vec4<f32>,
+    @location(0) @blend_src(1) alpha_mask: vec4<f32>,
+}
+
+fn color_brightness(color: vec3<f32>) -> f32 {
+    return dot(color, vec3<f32>(0.30, 0.59, 0.11));
+}
+
+fn light_on_dark_contrast(enhanced_contrast: f32, color: vec3<f32>) -> f32 {
+    let brightness = color_brightness(color);
+    let multiplier = saturate(4.0 * (0.75 - brightness));
+    return enhanced_contrast * multiplier;
+}
+
+fn enhance_contrast3(alpha: vec3<f32>, k: f32) -> vec3<f32> {
+    return alpha * (k + 1.0) / (alpha * k + 1.0);
+}
+
+fn apply_alpha_correction3(a: vec3<f32>, b: vec3<f32>, g: vec4<f32>) -> vec3<f32> {
+    let brightness_adjustment = g.x * b + g.y;
+    let correction = brightness_adjustment * a + (g.z * b + g.w);
+    return a + a * (1.0 - a) * correction;
+}
+
+fn apply_contrast_and_gamma_correction3(
+    sample: vec3<f32>,
+    fg: vec3<f32>,
+    enhanced_contrast_factor: f32,
+    gamma_ratios: vec4<f32>,
+) -> vec3<f32> {
+    let enhanced_contrast = light_on_dark_contrast(enhanced_contrast_factor, fg);
+    let contrasted = enhance_contrast3(sample, enhanced_contrast);
+    return apply_alpha_correction3(contrasted, fg, gamma_ratios);
+}
+
+// Remap the atlas's three per-channel coverage values to match the target
+// panel's physical subpixel arrangement (see `SubpixelLcdLayout` once
+// introduced in phase-05).
+//
+// The swash rasteriser (`bevy_text::font_atlas::get_outlined_glyph_texture`)
+// emits the atlas with *horizontal RGB* pre-offset baked in: texel
+// `(x, y).r` is already the left subpixel's coverage at logical pixel
+// `(x, y)`, `.g` the centre, `.b` the right. We therefore only need to
+// swizzle — not resample at offset UVs — to support BGR panels.
+//
+// The vertical variants have no correct remap available from a
+// horizontally-offset atlas. They currently swap R/B (mirroring the
+// horizontal BGR/RGB distinction) so the setting visibly affects output,
+// but the result is *not* a correct vertical-subpixel antialiasing; a
+// follow-up spec will add vertical-subpixel rasterisation and re-wire
+// these variants.
+fn swizzle_subpixel_atlas(atlas_rgb: vec3<f32>, layout_flags: u32) -> vec3<f32> {
+    if layout_flags == SUBPIXEL_LAYOUT_HORIZONTAL_BGR
+        || layout_flags == SUBPIXEL_LAYOUT_VERTICAL_BGR
+    {
+        return atlas_rgb.bgr;
+    }
+    return atlas_rgb;
+}
+
+@fragment
+fn fragment_subpixel(in: VertexOutput) -> SubpixelOutput {
+    // Sample three per-channel alpha coverages from the RGB subpixel atlas,
+    // then swizzle by the panel's subpixel layout. The swash rasteriser has
+    // already baked in horizontal per-channel UV offsets, so a single sample
+    // plus a swizzle is both correct and optimal for `HorizontalRgb` /
+    // `HorizontalBgr`. See `swizzle_subpixel_atlas` for the vertical caveat.
+    let atlas_rgb = textureSample(sprite_texture, sprite_sampler, in.uv).rgb;
+    let sample_rgb = swizzle_subpixel_atlas(atlas_rgb, subpixel_settings.layout_flags);
+
+    let enhanced_contrast = subpixel_settings.enhanced_contrast;
+    let gamma_ratios = subpixel_settings.gamma_ratios;
+
+    let alpha_corrected = apply_contrast_and_gamma_correction3(
+        sample_rgb,
+        in.color.rgb,
+        enhanced_contrast,
+        gamma_ratios,
+    );
+
+    // Matches GPUI's `fs_subpixel_sprite`. With pipeline blend state
+    //   color: { src = Src1, dst = OneMinusSrc1 }
+    // this yields:
+    //   result.rgb = fg.rgb * (color.a * alpha_corrected)
+    //              + dst.rgb * (1 - color.a * alpha_corrected)
+    // i.e. per-channel coverage of the foreground over the existing pixel.
+    var out: SubpixelOutput;
+    out.color = vec4<f32>(in.color.rgb, 1.0);
+    out.alpha_mask = vec4<f32>(in.color.a * alpha_corrected, 1.0);
+    return out;
+}
+#endif

--- a/crates/bevy_ui_render/tests/subpixel_fallback.rs
+++ b/crates/bevy_ui_render/tests/subpixel_fallback.rs
@@ -1,0 +1,140 @@
+//! Integration test for the DSB-unavailable fallback logic in
+//! `queue_uinodes`. The full queue system pulls in a lot of ECS state
+//! (extracted nodes, specialized-pipelines cache, phases, ...) that is
+//! impractical to mock standalone; this test instead exercises the
+//! observable behavioural contract at the pipeline-key level:
+//!
+//! - When `SubpixelCapable(true)`, a subpixel-smoothed glyph batch
+//!   produces a `UiPipelineKey` with `subpixel: true` — which
+//!   `UiPipeline::specialize` maps to the DSB fragment entry.
+//! - When `SubpixelCapable(false)`, the same batch must produce a
+//!   `UiPipelineKey` with `subpixel: false` — which specializes to the
+//!   conventional alpha-blend grayscale variant.
+//!
+//! This mirrors `queue_uinodes`'s gate:
+//! `let subpixel = subpixel_supported && matches!(item, Glyphs { font_smoothing: SubpixelAntiAliased, .. });`
+//! and verifies the two resulting pipeline descriptors differ as
+//! expected.
+
+use bevy_asset::Handle;
+use bevy_render::render_resource::{
+    binding_types::{sampler, texture_2d, uniform_buffer},
+    BindGroupLayoutDescriptor, BindGroupLayoutEntries, BlendFactor, BlendState, SamplerBindingType,
+    ShaderStages, SpecializedRenderPipeline, TextureFormat, TextureSampleType,
+};
+use bevy_render::view::ViewUniform;
+use bevy_text::SubpixelCapable;
+use bevy_ui_render::{SubpixelTextUniforms, UiPipeline, UiPipelineKey};
+
+fn build_test_pipeline() -> UiPipeline {
+    let view_layout = BindGroupLayoutDescriptor::new(
+        "ui_view_layout",
+        &BindGroupLayoutEntries::sequential(
+            ShaderStages::VERTEX_FRAGMENT,
+            (
+                uniform_buffer::<ViewUniform>(true),
+                uniform_buffer::<SubpixelTextUniforms>(false),
+            ),
+        ),
+    );
+
+    let image_layout = BindGroupLayoutDescriptor::new(
+        "ui_image_layout",
+        &BindGroupLayoutEntries::sequential(
+            ShaderStages::FRAGMENT,
+            (
+                texture_2d(TextureSampleType::Float { filterable: true }),
+                sampler(SamplerBindingType::Filtering),
+            ),
+        ),
+    );
+
+    UiPipeline {
+        view_layout,
+        image_layout,
+        shader: Handle::default(),
+    }
+}
+
+/// Replicates the `subpixel` gate in `queue_uinodes`.
+///
+/// Mirrors the actual expression in `crates/bevy_ui_render/src/lib.rs`:
+/// `let subpixel = subpixel_supported && matches!(item, Glyphs { font_smoothing: SubpixelAntiAliased, .. });`
+fn gate(capable: SubpixelCapable, item_is_subpixel_glyph: bool) -> bool {
+    capable.0 && item_is_subpixel_glyph
+}
+
+#[test]
+fn subpixel_capable_false_forces_non_subpixel_pipeline_key() {
+    let capable = SubpixelCapable(false);
+    // A subpixel-smoothed glyph batch
+    let subpixel = gate(capable, true);
+    assert!(
+        !subpixel,
+        "SubpixelCapable(false) must force the pipeline key's subpixel flag to false",
+    );
+}
+
+#[test]
+fn subpixel_capable_true_preserves_subpixel_pipeline_key_for_glyph_batch() {
+    let capable = SubpixelCapable(true);
+    let subpixel = gate(capable, true);
+    assert!(
+        subpixel,
+        "SubpixelCapable(true) must allow subpixel glyph batches to pick the DSB pipeline",
+    );
+}
+
+#[test]
+fn non_glyph_items_never_pick_subpixel_pipeline() {
+    // Background colors, borders, images, etc. never carry
+    // FontSmoothing::SubpixelAntiAliased, so even with a capable adapter
+    // they route to the grayscale pipeline.
+    let capable = SubpixelCapable(true);
+    let subpixel = gate(capable, false);
+    assert!(
+        !subpixel,
+        "Non-glyph items must never pick the subpixel pipeline even when the adapter is DSB-capable",
+    );
+}
+
+#[test]
+fn fallback_specialization_matches_non_subpixel_variant() {
+    // When the gate forces `subpixel = false`, the resulting pipeline key
+    // must specialize to the standard alpha-blend fragment (no custom
+    // entry point, `ALPHA_BLENDING` blend state).
+    let pipeline = build_test_pipeline();
+    let descriptor = pipeline.specialize(UiPipelineKey {
+        target_format: TextureFormat::Rgba8UnormSrgb,
+        anti_alias: true,
+        subpixel: false,
+    });
+
+    let fragment = descriptor
+        .fragment
+        .as_ref()
+        .expect("fallback pipeline must have a fragment stage");
+
+    assert!(
+        fragment.entry_point.is_none(),
+        "fallback pipeline must not use the fragment_subpixel entry point",
+    );
+
+    let target = fragment.targets[0]
+        .as_ref()
+        .expect("fallback pipeline must have a color target");
+    let blend = target
+        .blend
+        .expect("fallback pipeline must configure a blend state");
+    assert_eq!(
+        blend,
+        BlendState::ALPHA_BLENDING,
+        "fallback pipeline must use conventional alpha blending, not DSB",
+    );
+    assert_ne!(
+        blend.color.src_factor,
+        BlendFactor::Src1,
+        "fallback pipeline must not use Src1 (dual-source) blend factors",
+    );
+    assert_eq!(descriptor.label.as_deref(), Some("ui_pipeline"));
+}

--- a/crates/bevy_ui_render/tests/subpixel_fallback.rs
+++ b/crates/bevy_ui_render/tests/subpixel_fallback.rs
@@ -2,7 +2,7 @@
 //! `queue_uinodes`. The full queue system pulls in a lot of ECS state
 //! (extracted nodes, specialized-pipelines cache, phases, ...) that is
 //! impractical to mock standalone; this test instead exercises the
-//! observable behavioural contract at the pipeline-key level:
+//! observable behavioral contract at the pipeline-key level:
 //!
 //! - When `SubpixelCapable(true)`, a subpixel-smoothed glyph batch
 //!   produces a `UiPipelineKey` with `subpixel: true` — which

--- a/crates/bevy_ui_render/tests/subpixel_pipeline.rs
+++ b/crates/bevy_ui_render/tests/subpixel_pipeline.rs
@@ -1,0 +1,163 @@
+//! Integration tests for the UI subpixel-text DSB pipeline variant.
+//!
+//! Verifies that `UiPipeline::specialize` branches to the dual-source-blend
+//! fragment entry point + blend state when `UiPipelineKey.subpixel == true`,
+//! and preserves the existing alpha-blend path otherwise.
+
+use bevy_asset::Handle;
+use bevy_render::render_resource::{
+    binding_types::{sampler, texture_2d, uniform_buffer},
+    BindGroupLayoutDescriptor, BindGroupLayoutEntries, BlendFactor, BlendOperation, BlendState,
+    SamplerBindingType, ShaderStages, SpecializedRenderPipeline, TextureFormat, TextureSampleType,
+};
+use bevy_render::view::ViewUniform;
+use bevy_shader::ShaderDefVal;
+use bevy_ui_render::{SubpixelTextUniforms, UiPipeline, UiPipelineKey};
+
+fn has_subpixel_def(def: &ShaderDefVal) -> bool {
+    matches!(def, ShaderDefVal::Bool(name, true) if name == "SUBPIXEL")
+}
+
+fn build_test_pipeline() -> UiPipeline {
+    let view_layout = BindGroupLayoutDescriptor::new(
+        "ui_view_layout",
+        &BindGroupLayoutEntries::sequential(
+            ShaderStages::VERTEX_FRAGMENT,
+            (
+                uniform_buffer::<ViewUniform>(true),
+                uniform_buffer::<SubpixelTextUniforms>(false),
+            ),
+        ),
+    );
+
+    let image_layout = BindGroupLayoutDescriptor::new(
+        "ui_image_layout",
+        &BindGroupLayoutEntries::sequential(
+            ShaderStages::FRAGMENT,
+            (
+                texture_2d(TextureSampleType::Float { filterable: true }),
+                sampler(SamplerBindingType::Filtering),
+            ),
+        ),
+    );
+
+    UiPipeline {
+        view_layout,
+        image_layout,
+        shader: Handle::default(),
+    }
+}
+
+#[test]
+fn subpixel_variant_selects_dsb_fragment_entry() {
+    let pipeline = build_test_pipeline();
+
+    let descriptor = pipeline.specialize(UiPipelineKey {
+        target_format: TextureFormat::Rgba8UnormSrgb,
+        anti_alias: true,
+        subpixel: true,
+    });
+
+    let fragment = descriptor
+        .fragment
+        .as_ref()
+        .expect("subpixel pipeline must have a fragment stage");
+
+    let entry_point = fragment
+        .entry_point
+        .as_ref()
+        .expect("subpixel pipeline must set a custom fragment entry point");
+    assert_eq!(entry_point.as_ref(), "fragment_subpixel");
+
+    // `SUBPIXEL` shader_def should be present on both stages so the WGSL
+    // subpixel block compiles.
+    assert!(
+        fragment.shader_defs.iter().any(has_subpixel_def),
+        "SUBPIXEL shader_def missing from fragment: {:?}",
+        fragment.shader_defs,
+    );
+    assert!(
+        descriptor.vertex.shader_defs.iter().any(has_subpixel_def),
+        "SUBPIXEL shader_def missing from vertex: {:?}",
+        descriptor.vertex.shader_defs,
+    );
+
+    let target = fragment.targets[0]
+        .as_ref()
+        .expect("subpixel pipeline must have a color target");
+    let blend = target
+        .blend
+        .expect("subpixel pipeline must configure a blend state");
+
+    assert_eq!(blend.color.src_factor, BlendFactor::Src1);
+    assert_eq!(blend.color.dst_factor, BlendFactor::OneMinusSrc1);
+    assert_eq!(blend.color.operation, BlendOperation::Add);
+
+    assert_eq!(blend.alpha.src_factor, BlendFactor::One);
+    assert_eq!(blend.alpha.dst_factor, BlendFactor::OneMinusSrcAlpha);
+    assert_eq!(blend.alpha.operation, BlendOperation::Add);
+
+    assert_eq!(
+        descriptor.label.as_deref(),
+        Some("ui_pipeline_subpixel"),
+        "subpixel variant should use the ui_pipeline_subpixel label",
+    );
+}
+
+#[test]
+fn non_subpixel_variant_keeps_alpha_blend_fragment() {
+    let pipeline = build_test_pipeline();
+
+    let descriptor = pipeline.specialize(UiPipelineKey {
+        target_format: TextureFormat::Rgba8UnormSrgb,
+        anti_alias: true,
+        subpixel: false,
+    });
+
+    let fragment = descriptor
+        .fragment
+        .as_ref()
+        .expect("non-subpixel pipeline must have a fragment stage");
+
+    assert!(
+        fragment.entry_point.is_none(),
+        "non-subpixel variant must not override the default fragment entry",
+    );
+    assert!(
+        !fragment.shader_defs.iter().any(has_subpixel_def),
+        "SUBPIXEL shader_def leaked into non-subpixel fragment: {:?}",
+        fragment.shader_defs,
+    );
+
+    let target = fragment.targets[0]
+        .as_ref()
+        .expect("non-subpixel pipeline must have a color target");
+    let blend = target
+        .blend
+        .expect("non-subpixel pipeline must configure a blend state");
+
+    assert_eq!(blend, BlendState::ALPHA_BLENDING);
+
+    assert_eq!(
+        descriptor.label.as_deref(),
+        Some("ui_pipeline"),
+        "non-subpixel variant should use the ui_pipeline label",
+    );
+}
+
+#[test]
+fn subpixel_key_differs_from_non_subpixel_key() {
+    // Cache keys must differ between variants so `SpecializedRenderPipelines`
+    // keeps both descriptors alive in the same frame.
+    let a = UiPipelineKey {
+        target_format: TextureFormat::Rgba8UnormSrgb,
+        anti_alias: true,
+        subpixel: false,
+    };
+    let b = UiPipelineKey {
+        target_format: TextureFormat::Rgba8UnormSrgb,
+        anti_alias: true,
+        subpixel: true,
+    };
+    assert_ne!(a, b);
+}

--- a/examples/2d/text2d_subpixel.rs
+++ b/examples/2d/text2d_subpixel.rs
@@ -53,7 +53,7 @@ const CELL_GAP_X: f32 = 16.0;
 const ROW_GAP_Y: f32 = 12.0;
 // Horizontal inset from the cell edge to the text bounds. Mirrors the UI
 // sibling's 8px cell padding so body text wraps at the same column width
-// instead of overflowing into the neighbouring cell at 20pt / 32pt.
+// instead of overflowing into the neighboring cell at 20pt / 32pt.
 const CELL_PADDING_X: f32 = 8.0;
 const TEXT_BOUNDS_WIDTH: f32 = CELL_WIDTH - CELL_PADDING_X * 2.0;
 // Reserved vertical space for the fixed 11pt size badge at the top of each
@@ -105,8 +105,8 @@ fn main() {
 
     // Optional override of `SubpixelLcdLayout`.
     if let Ok(raw) = std::env::var("BEVY_TEXT_SUBPIXEL_LCD_LAYOUT") {
-        let normalised = raw.trim().to_ascii_lowercase().replace('_', "-");
-        let layout = match normalised.as_str() {
+        let normalized = raw.trim().to_ascii_lowercase().replace('_', "-");
+        let layout = match normalized.as_str() {
             "horizontal-rgb" | "hrgb" | "rgb" => Some(SubpixelLcdLayout::HorizontalRgb),
             "horizontal-bgr" | "hbgr" | "bgr" => Some(SubpixelLcdLayout::HorizontalBgr),
             _ => None,

--- a/examples/2d/text2d_subpixel.rs
+++ b/examples/2d/text2d_subpixel.rs
@@ -1,0 +1,302 @@
+//! Side-by-side comparison of the three [`FontSmoothing`] variants at four
+//! font sizes — `Text2d` / world-space edition.
+//!
+//! This is the `Text2d` counterpart to `examples/ui/text_subpixel.rs`. It
+//! exercises `bevy_sprite_render`'s subpixel-antialiased text pipeline by
+//! spawning three columns of `Text2d` entities, one per [`FontSmoothing`]
+//! variant, at four realistic body sizes.
+//!
+//! On an adapter that supports `wgpu::Features::DUAL_SOURCE_BLENDING` (Metal,
+//! Vulkan on most modern GPUs, DX12), the `SubpixelAntiAliased` column should
+//! look visibly sharper than the `AntiAliased` column at 10pt and 14pt —
+//! particularly on the vertical stems of `l`, `i`, `k`, `b`, on the round
+//! strokes of digits, and on the small punctuation in the code snippet. On
+//! adapters without DSB the subpixel column transparently falls back to
+//! grayscale AA (the glyph atlas is still rasterised in subpixel coverage
+//! form, but the non-subpixel fragment entry only reads the R channel as
+//! alpha).
+//!
+//! See `examples/ui/text_subpixel.rs` for the UI/overlay version; the
+//! rendering should look identical between the two at the same font size.
+
+use bevy::prelude::*;
+use bevy::render::view::screenshot::{save_to_disk, Screenshot};
+use bevy::text::{FontSize, FontSmoothing, SubpixelLcdLayout, SubpixelTextSettings, TextBounds};
+use bevy::window::WindowResolution;
+
+/// Prose sample — one line of English at four sizes exercises most of the
+/// Latin lowercase and caps.
+const PROSE: &str = "The quick brown fox jumps over the lazy dog.";
+
+/// Code sample — punctuation and monospace proportions stress subpixel
+/// positioning.
+const CODE: &str = "fn render(ctx: &mut Context) -> Result<()> { ctx.flush() }";
+
+/// Digits — round strokes and small verticals are where grayscale AA looks
+/// worst and subpixel AA helps most.
+const DIGITS: &str = "0123456789  3.14159  1,234,567  -42";
+
+/// Four realistic body sizes: small UI label, reading text, heading, large
+/// display. Subpixel AA has the most visible impact at 10pt and 14pt.
+const SIZES: [f32; 4] = [10.0, 14.0, 20.0, 32.0];
+
+const SMOOTHINGS: [(FontSmoothing, &str); 3] = [
+    (FontSmoothing::None, "None"),
+    (FontSmoothing::AntiAliased, "AntiAliased"),
+    (FontSmoothing::SubpixelAntiAliased, "SubpixelAntiAliased"),
+];
+
+// Layout constants in world units. One world unit == one pixel with the
+// default 2d camera scaling, so these match physical pixels on a 1:1 display.
+const CELL_WIDTH: f32 = 360.0;
+const CELL_GAP_X: f32 = 16.0;
+const ROW_GAP_Y: f32 = 12.0;
+// Horizontal inset from the cell edge to the text bounds. Mirrors the UI
+// sibling's 8px cell padding so body text wraps at the same column width
+// instead of overflowing into the neighbouring cell at 20pt / 32pt.
+const CELL_PADDING_X: f32 = 8.0;
+const TEXT_BOUNDS_WIDTH: f32 = CELL_WIDTH - CELL_PADDING_X * 2.0;
+// Reserved vertical space for the fixed 11pt size badge at the top of each
+// cell. Matches the smaller per-row sample spacing at the 10pt row.
+const BADGE_LINE_HEIGHT: f32 = 24.0;
+
+// Per-row vertical space reserved for each of the three body samples (prose,
+// code, digits) at `size`. Big enough for two wrapped lines at that size plus
+// breathing room, so 20pt and 32pt prose / code / digits that wrap don't bleed
+// into the next sample. Smaller sizes leave extra blank space, mirroring the
+// UI sibling where flex rows grow with content.
+fn sample_line_height(size: f32) -> f32 {
+    // Two lines of `size` at 1.2 leading, plus 12 units of row padding.
+    (size * 1.2 * 2.0 + 12.0).max(40.0)
+}
+
+fn cell_height(size: f32) -> f32 {
+    BADGE_LINE_HEIGHT + sample_line_height(size) * 3.0 + 12.0
+}
+
+fn main() {
+    let mut app = App::new();
+    app.add_plugins(DefaultPlugins.set(WindowPlugin {
+        // Tall enough to fit 4 rows at per-row heights scaled to 32pt without
+        // the 32pt row running off the bottom of the viewport. The UI sibling
+        // gets away with 1280x720 because its flex row heights compress to the
+        // cell's allocated slice; `Text2d` is absolute-positioned, so the cells
+        // need room to actually be as tall as their wrapped content.
+        primary_window: Some(Window {
+            resolution: WindowResolution::new(1280, 1040),
+            title: "text2d_subpixel".into(),
+            ..default()
+        }),
+        ..default()
+    }))
+    .insert_resource(ClearColor(Color::srgb(0.08, 0.08, 0.08)))
+    .add_systems(Startup, setup);
+
+    // Optional override of `SubpixelTextSettings::enhanced_contrast` for
+    // demonstrating the tunable.
+    if let Ok(raw) = std::env::var("BEVY_TEXT_SUBPIXEL_ENHANCED_CONTRAST")
+        && let Ok(value) = raw.trim().parse::<f32>()
+    {
+        app.insert_resource(SubpixelTextSettings {
+            enhanced_contrast: value,
+            ..Default::default()
+        });
+    }
+
+    // Optional override of `SubpixelLcdLayout`.
+    if let Ok(raw) = std::env::var("BEVY_TEXT_SUBPIXEL_LCD_LAYOUT") {
+        let normalised = raw.trim().to_ascii_lowercase().replace('_', "-");
+        let layout = match normalised.as_str() {
+            "horizontal-rgb" | "hrgb" | "rgb" => Some(SubpixelLcdLayout::HorizontalRgb),
+            "horizontal-bgr" | "hbgr" | "bgr" => Some(SubpixelLcdLayout::HorizontalBgr),
+            _ => None,
+        };
+        if let Some(layout) = layout {
+            app.insert_resource(layout);
+        }
+    }
+
+    // Optional automated screenshot capture for CI / PR body asset generation.
+    if let Ok(path) = std::env::var("BEVY_TEXT_SUBPIXEL_SCREENSHOT") {
+        app.insert_resource(ScreenshotPath(path));
+        app.insert_resource(ScreenshotFrame(0));
+        app.add_systems(Update, take_screenshot_after_warmup);
+    }
+
+    app.run();
+}
+
+#[derive(Resource)]
+struct ScreenshotPath(String);
+
+#[derive(Resource)]
+struct ScreenshotFrame(u32);
+
+fn take_screenshot_after_warmup(
+    mut commands: Commands,
+    path: Res<ScreenshotPath>,
+    mut frame: ResMut<ScreenshotFrame>,
+    mut exit: MessageWriter<AppExit>,
+) {
+    frame.0 += 1;
+    if frame.0 == 30 {
+        commands
+            .spawn(Screenshot::primary_window())
+            .observe(save_to_disk(path.0.clone()));
+    }
+    if frame.0 >= 90 {
+        exit.write(AppExit::Success);
+    }
+}
+
+fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    commands.spawn(Camera2d);
+
+    let body_font = asset_server.load("fonts/FiraSans-Bold.ttf");
+    let mono_font = asset_server.load("fonts/FiraMono-Medium.ttf");
+
+    // Compute the top-left origin of the triptych grid in world space. With
+    // `Camera2d`'s default transform, the origin (0, 0) is the center of the
+    // screen; positive y is up. We lay out rows top-to-bottom.
+    let total_width =
+        CELL_WIDTH * SMOOTHINGS.len() as f32 + CELL_GAP_X * (SMOOTHINGS.len() as f32 - 1.0);
+    let grid_left = -total_width * 0.5;
+    let header_height = 36.0;
+    let caption_height = 28.0;
+    let cells_total_height: f32 = SIZES.iter().map(|s| cell_height(*s)).sum();
+    let total_height = caption_height
+        + header_height
+        + cells_total_height
+        + ROW_GAP_Y * (SIZES.len() as f32 - 1.0);
+    let grid_top = total_height * 0.5;
+
+    // Caption across the top of the screen.
+    commands.spawn((
+        Text2d::new(
+            "Text2d FontSmoothing comparison — SubpixelAntiAliased should \
+             look sharper at 10pt and 14pt on a DSB-capable adapter.",
+        ),
+        TextFont {
+            font: body_font.clone().into(),
+            font_size: FontSize::Px(12.0),
+            font_smoothing: FontSmoothing::AntiAliased,
+            ..default()
+        },
+        TextColor(Color::srgb(0.70, 0.70, 0.70)),
+        Transform::from_xyz(0.0, grid_top - caption_height * 0.5, 0.0),
+    ));
+
+    // Column headers.
+    let header_y = grid_top - caption_height - header_height * 0.5;
+    for (col, (_, label)) in SMOOTHINGS.iter().enumerate() {
+        let cell_center_x = grid_left + CELL_WIDTH * 0.5 + col as f32 * (CELL_WIDTH + CELL_GAP_X);
+        commands.spawn((
+            Text2d::new(format!("FontSmoothing::{label}")),
+            TextFont {
+                font: body_font.clone().into(),
+                font_size: FontSize::Px(14.0),
+                font_smoothing: FontSmoothing::AntiAliased,
+                ..default()
+            },
+            TextColor(Color::srgb(0.55, 0.80, 1.0)),
+            Transform::from_xyz(cell_center_x, header_y, 0.0),
+        ));
+    }
+
+    // Body cells. Each row's height scales with its font size so wrapped
+    // prose / code / digits at 20pt and 32pt have enough vertical room and
+    // do not overlap the sample below.
+    let body_top = header_y - header_height * 0.5;
+    let mut cell_top = body_top;
+    for size in SIZES.iter() {
+        let sample_h = sample_line_height(*size);
+        let cell_h = cell_height(*size);
+        for (col, (smoothing, _)) in SMOOTHINGS.iter().enumerate() {
+            let cell_center_x =
+                grid_left + CELL_WIDTH * 0.5 + col as f32 * (CELL_WIDTH + CELL_GAP_X);
+            let cell_center_y = cell_top - cell_h * 0.5;
+
+            // Cell border (outer rectangle, 1px larger on each side).
+            // Colors match the `text_subpixel` UI example's border/background
+            // so the two examples read as visually consistent. Both sprites
+            // sit at negative z so Text2d entities (default z=0) render on
+            // top. Larger z renders on top in bevy_sprite, so z=-0.2 is
+            // behind z=-0.1 which is behind z=0.
+            commands.spawn((
+                Sprite {
+                    color: Color::srgb(0.22, 0.22, 0.22),
+                    custom_size: Some(Vec2::new(CELL_WIDTH + 2.0, cell_h + 2.0)),
+                    ..default()
+                },
+                Transform::from_xyz(cell_center_x, cell_center_y, -0.2),
+            ));
+            // Cell background (inner rectangle, exactly cell-sized).
+            commands.spawn((
+                Sprite {
+                    color: Color::BLACK,
+                    custom_size: Some(Vec2::new(CELL_WIDTH, cell_h)),
+                    ..default()
+                },
+                Transform::from_xyz(cell_center_x, cell_center_y, -0.1),
+            ));
+
+            // Size badge (top of the cell).
+            commands.spawn((
+                Text2d::new(format!("{size:>4.1}pt")),
+                TextFont {
+                    font: body_font.clone().into(),
+                    font_size: FontSize::Px(11.0),
+                    font_smoothing: FontSmoothing::AntiAliased,
+                    ..default()
+                },
+                TextColor(Color::srgb(0.45, 0.45, 0.45)),
+                Transform::from_xyz(cell_center_x, cell_top - BADGE_LINE_HEIGHT * 0.5, 0.0),
+            ));
+
+            let body_origin_y = cell_top - BADGE_LINE_HEIGHT;
+
+            // Prose (sans).
+            commands.spawn((
+                Text2d::new(PROSE),
+                TextFont {
+                    font: body_font.clone().into(),
+                    font_size: FontSize::Px(*size),
+                    font_smoothing: *smoothing,
+                    ..default()
+                },
+                TextColor(Color::WHITE),
+                TextBounds::new_horizontal(TEXT_BOUNDS_WIDTH),
+                Transform::from_xyz(cell_center_x, body_origin_y - sample_h * 0.5, 0.0),
+            ));
+
+            // Code (mono).
+            commands.spawn((
+                Text2d::new(CODE),
+                TextFont {
+                    font: mono_font.clone().into(),
+                    font_size: FontSize::Px(*size),
+                    font_smoothing: *smoothing,
+                    ..default()
+                },
+                TextColor(Color::srgb(0.90, 0.90, 0.78)),
+                TextBounds::new_horizontal(TEXT_BOUNDS_WIDTH),
+                Transform::from_xyz(cell_center_x, body_origin_y - sample_h * 1.5, 0.0),
+            ));
+
+            // Digits (mono).
+            commands.spawn((
+                Text2d::new(DIGITS),
+                TextFont {
+                    font: mono_font.clone().into(),
+                    font_size: FontSize::Px(*size),
+                    font_smoothing: *smoothing,
+                    ..default()
+                },
+                TextColor(Color::srgb(0.78, 0.88, 1.0)),
+                TextBounds::new_horizontal(TEXT_BOUNDS_WIDTH),
+                Transform::from_xyz(cell_center_x, body_origin_y - sample_h * 2.5, 0.0),
+            ));
+        }
+        cell_top -= cell_h + ROW_GAP_Y;
+    }
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -131,6 +131,7 @@ Example | Description
 [Sprite Slice](../examples/2d/sprite_slice.rs) | Showcases slicing sprites into sections that can be scaled independently via the 9-patch technique
 [Sprite Tile](../examples/2d/sprite_tile.rs) | Renders a sprite tiled in a grid
 [Text 2D](../examples/2d/text2d.rs) | Generates text in 2D
+[Text 2D Subpixel](../examples/2d/text2d_subpixel.rs) | Compares FontSmoothing variants for Text2d, including RGB subpixel antialiasing
 [Texture Atlas](../examples/2d/texture_atlas.rs) | Generates a texture atlas (sprite sheet) from individual sprites
 [Tilemap Chunk](../examples/2d/tilemap_chunk.rs) | Renders a tilemap chunk
 [Tilemap Chunk with Orientations](../examples/2d/tilemap_chunk_orientation.rs) | Renders a tilemap chunk using tile orientations (mirrored, rotated)
@@ -632,6 +633,7 @@ Example | Description
 [Text Background Colors](../examples/ui/text/text_background_colors.rs) | Demonstrates text background colors
 [Text Debug](../examples/ui/text/text_debug.rs) | An example for debugging text layout
 [Text Input](../examples/ui/text/text_input.rs) | Demonstrates a simple, unstyled text input widget
+[Text Subpixel](../examples/ui/text_subpixel.rs) | Compares FontSmoothing variants including RGB subpixel antialiasing
 [Text Wrap Debug](../examples/ui/text/text_wrap_debug.rs) | Demonstrates text wrapping
 [Transparency UI](../examples/ui/styling/transparency_ui.rs) | Demonstrates transparency for UI
 [UI Drag and Drop](../examples/ui/ui_drag_and_drop.rs) | Demonstrates dragging and dropping UI nodes

--- a/examples/ui/text_subpixel.rs
+++ b/examples/ui/text_subpixel.rs
@@ -1,0 +1,381 @@
+//! Side-by-side comparison of the three [`FontSmoothing`] variants at four
+//! font sizes, rendering realistic content (prose, a code snippet, and a
+//! run of digits) — the workloads where subpixel antialiasing matters most.
+//!
+//! Use this example to eyeball the quality difference between
+//! [`FontSmoothing::AntiAliased`] (Bevy's default grayscale AA) and
+//! [`FontSmoothing::SubpixelAntiAliased`] (the RGB subpixel path). The
+//! [`FontSmoothing::None`] column is included as a reference point for "no
+//! smoothing".
+//!
+//! On an adapter that supports `wgpu::Features::DUAL_SOURCE_BLENDING` (Metal,
+//! Vulkan on most modern GPUs, DX12), the subpixel column should look visibly
+//! sharper than the anti-aliased column at 10pt and 14pt — particularly on
+//! the vertical stems of `l`, `i`, `k`, `b`, on the round strokes of digits,
+//! and on the small punctuation in the code snippet. On adapters without DSB
+//! the subpixel column transparently falls back to grayscale AA.
+//!
+//! # Interactive controls
+//!
+//! The example reacts to keyboard input while running so reviewers can
+//! A/B the tuning knobs without recompiling:
+//!
+//! | Key | Effect |
+//! |---|---|
+//! | `1` | Set [`SubpixelTextSettings::enhanced_contrast`] to `0.25` (muted) |
+//! | `2` | Set `enhanced_contrast` to `0.50` (default) |
+//! | `3` | Set `enhanced_contrast` to `0.75` (aggressive) |
+//! | `R` | Set [`SubpixelLcdLayout`] to `HorizontalRgb` (default) |
+//! | `B` | Set `SubpixelLcdLayout` to `HorizontalBgr` |
+//! | `S` | Save a screenshot of the primary window to `/tmp/text_subpixel_<unix-ms>.png` |
+//!
+//! A HUD in the top-right corner shows the current values. Changes take
+//! effect on the next rendered frame — `SubpixelTextSettings` and
+//! `SubpixelLcdLayout` are plain resources consumed by the subpixel fragment
+//! shader each frame.
+//!
+//! # Environment-variable overrides
+//!
+//! For automated screenshots and CI, three env vars override the initial
+//! values before any keypress:
+//!
+//! - `BEVY_TEXT_SUBPIXEL_ENHANCED_CONTRAST=<f32>` — initial contrast.
+//! - `BEVY_TEXT_SUBPIXEL_LCD_LAYOUT=<name>` — one of
+//!   `horizontal-rgb` / `horizontal-bgr`.
+//! - `BEVY_TEXT_SUBPIXEL_SCREENSHOT=<path>` — grab one screenshot after
+//!   warmup and exit (used for PR-body asset generation).
+
+use bevy::input::ButtonInput;
+use bevy::prelude::*;
+use bevy::render::view::screenshot::{save_to_disk, Screenshot};
+use bevy::text::{FontSize, FontSmoothing, SubpixelLcdLayout, SubpixelTextSettings};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Prose sample — one line of English at four sizes exercises most of the
+/// Latin lowercase and caps.
+const PROSE: &str = "The quick brown fox jumps over the lazy dog.";
+
+/// Code sample — punctuation and monospace proportions stress subpixel
+/// positioning.
+const CODE: &str = "fn render(ctx: &mut Context) -> Result<()> { ctx.flush() }";
+
+/// Digits — round strokes and small verticals are where grayscale AA looks
+/// worst and subpixel AA helps most.
+const DIGITS: &str = "0123456789  3.14159  1,234,567  -42";
+
+/// Four realistic body sizes: small UI label, reading text, heading, large
+/// display. Subpixel AA has the most visible impact at 10pt and 14pt; at
+/// 20pt and 32pt the three variants should converge.
+const SIZES: [f32; 4] = [10.0, 14.0, 20.0, 32.0];
+
+const SMOOTHINGS: [(FontSmoothing, &str); 3] = [
+    (FontSmoothing::None, "None"),
+    (FontSmoothing::AntiAliased, "AntiAliased"),
+    (FontSmoothing::SubpixelAntiAliased, "SubpixelAntiAliased"),
+];
+
+/// Marker on the HUD text entity so the update system can find it cheaply.
+#[derive(Component)]
+struct HudText;
+
+fn main() {
+    let mut app = App::new();
+    app.add_plugins(DefaultPlugins)
+        .insert_resource(ClearColor(Color::srgb(0.08, 0.08, 0.08)))
+        .add_systems(Startup, setup)
+        .add_systems(Update, (handle_input, update_hud));
+
+    // Optional override of `SubpixelTextSettings::enhanced_contrast` for
+    // demonstrating the tunable. Parse `BEVY_TEXT_SUBPIXEL_ENHANCED_CONTRAST`
+    // (e.g. `=0.2` for a visibly muted look vs. the default `0.5`).
+    if let Ok(raw) = std::env::var("BEVY_TEXT_SUBPIXEL_ENHANCED_CONTRAST")
+        && let Ok(value) = raw.trim().parse::<f32>()
+    {
+        app.insert_resource(SubpixelTextSettings {
+            enhanced_contrast: value,
+            ..Default::default()
+        });
+    }
+
+    // Optional override of `SubpixelLcdLayout` for demonstrating the layout
+    // knob. Parse `BEVY_TEXT_SUBPIXEL_LCD_LAYOUT` as one of
+    // `horizontal-rgb` / `horizontal-bgr` (case-insensitive, `-` or `_`
+    // separator tolerated). Missing or unrecognised values fall back to the
+    // default `HorizontalRgb`.
+    if let Ok(raw) = std::env::var("BEVY_TEXT_SUBPIXEL_LCD_LAYOUT") {
+        let normalised = raw.trim().to_ascii_lowercase().replace('_', "-");
+        let layout = match normalised.as_str() {
+            "horizontal-rgb" | "hrgb" | "rgb" => Some(SubpixelLcdLayout::HorizontalRgb),
+            "horizontal-bgr" | "hbgr" | "bgr" => Some(SubpixelLcdLayout::HorizontalBgr),
+            _ => None,
+        };
+        if let Some(layout) = layout {
+            app.insert_resource(layout);
+        }
+    }
+
+    // Optional automated screenshot capture for CI / PR body asset generation.
+    // Set `BEVY_TEXT_SUBPIXEL_SCREENSHOT=<path>` to have the example grab the
+    // primary window a few frames after startup and write a PNG to that path,
+    // then exit.
+    if let Ok(path) = std::env::var("BEVY_TEXT_SUBPIXEL_SCREENSHOT") {
+        app.insert_resource(ScreenshotPath(path));
+        app.insert_resource(ScreenshotFrame(0));
+        app.add_systems(Update, take_screenshot_after_warmup);
+    }
+
+    app.run();
+}
+
+#[derive(Resource)]
+struct ScreenshotPath(String);
+
+#[derive(Resource)]
+struct ScreenshotFrame(u32);
+
+fn take_screenshot_after_warmup(
+    mut commands: Commands,
+    path: Res<ScreenshotPath>,
+    mut frame: ResMut<ScreenshotFrame>,
+    mut exit: MessageWriter<AppExit>,
+) {
+    frame.0 += 1;
+    // Capture on frame 30 (~0.5s at 60fps) so the atlas has warmed up.
+    if frame.0 == 30 {
+        commands
+            .spawn(Screenshot::primary_window())
+            .observe(save_to_disk(path.0.clone()));
+    }
+    // Exit a handful of frames later so `save_to_disk` has landed on disk.
+    if frame.0 >= 90 {
+        exit.write(AppExit::Success);
+    }
+}
+
+/// Reacts to keypresses to mutate the subpixel tuning resources. Using
+/// `just_pressed` gives us edge-triggered semantics — holding the key down
+/// doesn't spam updates.
+fn handle_input(
+    input: Res<ButtonInput<KeyCode>>,
+    mut commands: Commands,
+    mut settings: ResMut<SubpixelTextSettings>,
+    mut layout: ResMut<SubpixelLcdLayout>,
+) {
+    // Enhanced-contrast presets. Preserve the existing `gamma_ratios` so
+    // app authors who tuned them don't get silently clobbered by a keypress.
+    if input.just_pressed(KeyCode::Digit1) {
+        settings.enhanced_contrast = 0.25;
+    }
+    if input.just_pressed(KeyCode::Digit2) {
+        settings.enhanced_contrast = 0.50;
+    }
+    if input.just_pressed(KeyCode::Digit3) {
+        settings.enhanced_contrast = 0.75;
+    }
+
+    // LCD layout cycle.
+    if input.just_pressed(KeyCode::KeyR) {
+        *layout = SubpixelLcdLayout::HorizontalRgb;
+    }
+    if input.just_pressed(KeyCode::KeyB) {
+        *layout = SubpixelLcdLayout::HorizontalBgr;
+    }
+
+    // Screenshot. Save under `/tmp` with a unix-millisecond suffix so
+    // repeat presses don't clobber each other.
+    if input.just_pressed(KeyCode::KeyS) {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0);
+        let path = format!("/tmp/text_subpixel_{stamp}.png");
+        commands
+            .spawn(Screenshot::primary_window())
+            .observe(save_to_disk(path));
+    }
+}
+
+fn update_hud(
+    settings: Res<SubpixelTextSettings>,
+    layout: Res<SubpixelLcdLayout>,
+    mut hud: Query<&mut Text, With<HudText>>,
+) {
+    // Only rewrite the HUD when something changed; `Res::is_changed` covers
+    // the env-var, startup, and keypress-induced edits.
+    if !settings.is_changed() && !layout.is_changed() {
+        return;
+    }
+    let Ok(mut text) = hud.single_mut() else {
+        return;
+    };
+    let layout_name = match *layout {
+        SubpixelLcdLayout::HorizontalRgb => "HorizontalRgb",
+        SubpixelLcdLayout::HorizontalBgr => "HorizontalBgr",
+    };
+    **text = format!(
+        "contrast: {:.2}  layout: {}\n[1/2/3] contrast   [R/B] layout   [S] screenshot",
+        settings.enhanced_contrast, layout_name,
+    );
+}
+
+fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    commands.spawn(Camera2d);
+
+    let body_font = asset_server.load("fonts/FiraSans-Bold.ttf");
+    let mono_font = asset_server.load("fonts/FiraMono-Medium.ttf");
+
+    commands
+        .spawn(Node {
+            width: percent(100),
+            height: percent(100),
+            flex_direction: FlexDirection::Column,
+            padding: UiRect::all(px(20)),
+            row_gap: px(12),
+            ..default()
+        })
+        .with_children(|root| {
+            // Caption.
+            root.spawn((
+                Text::new(
+                    "FontSmoothing comparison — three variants (columns) at four sizes \
+                     (rows). The SubpixelAntiAliased column should look visibly sharper \
+                     at 10pt and 14pt on a DSB-capable adapter; otherwise it falls back \
+                     to grayscale AA.",
+                ),
+                TextFont {
+                    font: body_font.clone().into(),
+                    font_size: FontSize::Px(12.0),
+                    font_smoothing: FontSmoothing::AntiAliased,
+                    ..default()
+                },
+                TextColor(Color::srgb(0.70, 0.70, 0.70)),
+            ));
+
+            // Column header row.
+            root.spawn(Node {
+                flex_direction: FlexDirection::Row,
+                column_gap: px(16),
+                ..default()
+            })
+            .with_children(|header| {
+                for (_, label) in SMOOTHINGS {
+                    header
+                        .spawn(Node {
+                            flex_direction: FlexDirection::Column,
+                            flex_grow: 1.0,
+                            flex_basis: percent(0),
+                            ..default()
+                        })
+                        .with_children(|col| {
+                            col.spawn((
+                                Text::new(format!("FontSmoothing::{label}")),
+                                TextFont {
+                                    font: body_font.clone().into(),
+                                    font_size: FontSize::Px(14.0),
+                                    font_smoothing: FontSmoothing::AntiAliased,
+                                    ..default()
+                                },
+                                TextColor(Color::srgb(0.55, 0.80, 1.0)),
+                            ));
+                        });
+                }
+            });
+
+            // Body: one row per font size, each row holds three cells.
+            for size in SIZES {
+                root.spawn(Node {
+                    flex_direction: FlexDirection::Row,
+                    column_gap: px(16),
+                    ..default()
+                })
+                .with_children(|row| {
+                    for (smoothing, _) in SMOOTHINGS {
+                        row.spawn((
+                            Node {
+                                flex_direction: FlexDirection::Column,
+                                flex_grow: 1.0,
+                                flex_basis: percent(0),
+                                row_gap: px(2),
+                                padding: UiRect::all(px(8)),
+                                border: UiRect::all(px(1)),
+                                ..default()
+                            },
+                            BorderColor::all(Color::srgb(0.22, 0.22, 0.22)),
+                            BackgroundColor(Color::BLACK),
+                        ))
+                        .with_children(|cell| {
+                            // Size badge.
+                            cell.spawn((
+                                Text::new(format!("{size:>4.1}pt")),
+                                TextFont {
+                                    font: body_font.clone().into(),
+                                    font_size: FontSize::Px(11.0),
+                                    font_smoothing: FontSmoothing::AntiAliased,
+                                    ..default()
+                                },
+                                TextColor(Color::srgb(0.45, 0.45, 0.45)),
+                            ));
+
+                            // Prose (sans).
+                            cell.spawn((
+                                Text::new(PROSE),
+                                TextFont {
+                                    font: body_font.clone().into(),
+                                    font_size: FontSize::Px(size),
+                                    font_smoothing: smoothing,
+                                    ..default()
+                                },
+                                TextColor(Color::WHITE),
+                            ));
+
+                            // Code (mono).
+                            cell.spawn((
+                                Text::new(CODE),
+                                TextFont {
+                                    font: mono_font.clone().into(),
+                                    font_size: FontSize::Px(size),
+                                    font_smoothing: smoothing,
+                                    ..default()
+                                },
+                                TextColor(Color::srgb(0.90, 0.90, 0.78)),
+                            ));
+
+                            // Digits (mono).
+                            cell.spawn((
+                                Text::new(DIGITS),
+                                TextFont {
+                                    font: mono_font.clone().into(),
+                                    font_size: FontSize::Px(size),
+                                    font_smoothing: smoothing,
+                                    ..default()
+                                },
+                                TextColor(Color::srgb(0.78, 0.88, 1.0)),
+                            ));
+                        });
+                    }
+                });
+            }
+        });
+
+    // HUD in the top-right corner. Uses absolute positioning so it floats over
+    // the grid without reflowing the existing layout.
+    commands.spawn((
+        HudText,
+        Text::new(
+            "contrast: 0.50  layout: HorizontalRgb\n[1/2/3] contrast   [R/B] layout   [S] screenshot",
+        ),
+        TextFont {
+            font: mono_font.clone().into(),
+            font_size: FontSize::Px(11.0),
+            font_smoothing: FontSmoothing::AntiAliased,
+            ..default()
+        },
+        TextColor(Color::srgb(0.85, 0.85, 0.60)),
+        Node {
+            position_type: PositionType::Absolute,
+            top: px(8),
+            right: px(12),
+            ..default()
+        },
+    ));
+}

--- a/examples/ui/text_subpixel.rs
+++ b/examples/ui/text_subpixel.rs
@@ -100,11 +100,11 @@ fn main() {
     // Optional override of `SubpixelLcdLayout` for demonstrating the layout
     // knob. Parse `BEVY_TEXT_SUBPIXEL_LCD_LAYOUT` as one of
     // `horizontal-rgb` / `horizontal-bgr` (case-insensitive, `-` or `_`
-    // separator tolerated). Missing or unrecognised values fall back to the
+    // separator tolerated). Missing or unrecognized values fall back to the
     // default `HorizontalRgb`.
     if let Ok(raw) = std::env::var("BEVY_TEXT_SUBPIXEL_LCD_LAYOUT") {
-        let normalised = raw.trim().to_ascii_lowercase().replace('_', "-");
-        let layout = match normalised.as_str() {
+        let normalized = raw.trim().to_ascii_lowercase().replace('_', "-");
+        let layout = match normalized.as_str() {
             "horizontal-rgb" | "hrgb" | "rgb" => Some(SubpixelLcdLayout::HorizontalRgb),
             "horizontal-bgr" | "hbgr" | "bgr" => Some(SubpixelLcdLayout::HorizontalBgr),
             _ => None,


### PR DESCRIPTION
# Subpixel text — implementation following up on #23970

Hi again — this is the follow-up to the discussion in
[#23970](https://github.com/bevyengine/bevy/issues/23970). I went ahead
and put together what I sketched there. Branch is
`svge-ai:subpixel-text-parley`, forked from `upstream/main` at
`90b41543e` (clean fast-forward as of writing).

If anything below looks off-shape, happy to rework — easier to redo
this now than after merge.

## What's in it

Ten commits, one concern per commit:

```
08123d0cb bevy_text: add FontSmoothing::SubpixelAntiAliased variant
4d89cf6ee bevy_text: rasterise SubpixelAntiAliased through Format::Subpixel
ecb2ae7d3 bevy_text: enable hinting for SubpixelAntiAliased + integration test
ba24e66eb bevy_text: partition subpixel glyph cache via SubpixelBucket on GlyphCacheKey
328e7fc73 bevy_ui_render: add subpixel DSB pipeline variant and WGSL block
1bb099f64 bevy_text: add shared subpixel tuning resources and runtime fallback
cdc382e38 bevy_sprite_render: add subpixel rendering to Text2d via DSB pipeline variant
94c2fbed7 bevy_ui: add text_subpixel example showcasing FontSmoothing::SubpixelAntiAliased
b75dd8cb7 bevy_sprite_render: add text2d_subpixel example
77aeabc50 bevy_text: add subpixel text release note
```

In prose:

- The reserved `// TODO: Add subpixel antialias support` slot is now
  filled — `FontSmoothing::SubpixelAntiAliased` lives on the enum at
  `crates/bevy_text/src/text.rs`.
- `get_outlined_glyph_texture` (`crates/bevy_text/src/font_atlas.rs`)
  branches on the smoothing mode: `None | AntiAliased` keep their
  existing `swash::zeno::Format::Alpha` path; `SubpixelAntiAliased`
  flips to `Format::Subpixel` and tacks on a `.offset(...)` driven by
  the glyph's horizontal subpixel bucket. The existing
  `Content::SubpixelMask → RGBA` arm consumes the result unchanged.
- `GlyphCacheKey` grows a `subpixel_bucket: SubpixelBucket` field
  (four bins plus `NotApplicable`). Bucket is on the inner cache key
  rather than `FontAtlasKey` for the reason flagged in the issue —
  keeps all four buckets in one atlas instead of multiplying by 4
  against the existing hinting/variations dimensions.
- `bevy_ui_render` and `bevy_sprite_render` each gain a `subpixel`
  variant on their pipeline keys, specialise to a DSB fragment entry
  with the `{Src1, OneMinusSrc1}` colour blend + `{One, OneMinusSrcAlpha}`
  alpha blend, and add a `#ifdef SUBPIXEL` block to the corresponding
  WGSL with `enable dual_source_blending;` + `@blend_src(0)` /
  `@blend_src(1)` outputs (matches `render_sky.wgsl`'s shape).
- Shared tuning resources live in `bevy_text` (`SubpixelTextSettings`,
  `SubpixelLcdLayout`, `SubpixelCapable`). Both render crates read
  them at prepare time; both register an idempotent `init_*_subpixel_capability`
  system on `RenderStartup` that probes
  `wgpu::Features::DUAL_SOURCE_BLENDING` and inserts `SubpixelCapable`.
- The fallback gate in each renderer's queue is
  `font_smoothing == SubpixelAntiAliased && subpixel_capable`. When
  the adapter doesn't support DSB, glyphs route to the existing
  grayscale pipeline silently — no panics, no pipeline-cache errors,
  no log noise.

## Try it out

Two new examples; both render a 3 × 4 grid comparing
`FontSmoothing::None`, `AntiAliased`, and `SubpixelAntiAliased` at
10 / 14 / 20 / 32pt.

```sh
cargo run --example text_subpixel --release
cargo run --example text2d_subpixel --release
```

The UI example has interactive keys: `1` / `2` / `3` cycle
`SubpixelTextSettings::enhanced_contrast` between 0.25 / 0.50 / 0.75;
`R` / `B` cycle `SubpixelLcdLayout::HorizontalRgb` /
`HorizontalBgr`; `S` saves a screenshot. A small HUD in the top-right
corner reports the current values.

The visual difference is most visible at 10 / 14pt body sizes —
sharper vertical stems, cleaner digit strokes, no "dancing" between
pixel rows when text moves. At 20 / 32pt the three columns converge
as expected. On adapters without DSB the subpixel column degrades
gracefully to grayscale AA (visible if you spin up something like
Lavapipe to test).

## Testing

`cargo test -p bevy_text -p bevy_ui_render -p bevy_sprite_render` on
the branch tip:

| Crate | Test file | What it checks |
|---|---|---|
| `bevy_text` | `tests/subpixel_rasterisation.rs` | rasterises `g` at 24pt, asserts at least one pixel where `R != G != B` (grayscale always emits `R == G == B`) |
| `bevy_text` | `tests/subpixel_cache.rs` | four `SubpixelBucket` values populate four distinct `GlyphCacheKey` entries inside a single atlas; re-populate is a pure cache hit; non-subpixel collapses to one cell |
| `bevy_text` | `tests/subpixel_settings.rs` | resource defaults, `SubpixelLcdLayout::pack_u32` discriminants, `SubpixelCapable` shape |
| `bevy_ui_render` | `tests/subpixel_pipeline.rs` | specialise output for subpixel + non-subpixel keys (entry point, shader defs, blend state, label); key hash distinctness |
| `bevy_ui_render` | `tests/subpixel_fallback.rs` | the gate expression downgrades to grayscale when `SubpixelCapable(false)` or the resource is absent |
| `bevy_sprite_render` | `tests/subpixel_pipeline.rs` | as above, plus a `SpritePipelineKey::SUBPIXEL` bit-collision test |

Plus a clean run of `cargo fmt --all --check`, `cargo clippy
--all-targets --no-deps -- -D warnings` (scoped to the three crates),
and `cargo doc --no-deps`. Pre-existing clippy issues on
`bevy_log` and other untouched crates are out of scope.

## What downstream consumers will see

`FontSmoothing` is `pub` and not `#[non_exhaustive]`, so this is
technically a breaking change for anyone exhaustively `match`ing on
its variants. In practice most comparison sites use
`if smoothing == FontSmoothing::None { .. }` style; those migrate
unchanged with the new variant folding into the `else` branch.

`GlyphCacheKey` direct constructors need the new field. Inside Bevy
that's two call sites (the hot loop in
`TextPipeline::update_text_layout_info` and `text_editable.rs::apply_text_edits`),
both updated; for downstream code the rewrite is one line:

```rust
// Before
GlyphCacheKey { glyph_id }

// After (non-subpixel callers)
GlyphCacheKey {
    glyph_id,
    subpixel_bucket: SubpixelBucket::NotApplicable,
}
```

Subpixel callers use `SubpixelBucket::from_fract(glyph.x.fract(),
smoothing)` to derive the bucket the same way the upstream pipeline
does.

The new resources (`SubpixelTextSettings`, `SubpixelLcdLayout`,
`SubpixelCapable`) are additive — apps that don't touch them get the
default behaviour. There's a release note at
`release-notes/subpixel_text.md` covering all of this.

## Things flagged in the issue, status now

- **`SubpixelLcdLayout` scope.** Shipped with `HorizontalRgb` and
  `HorizontalBgr` only, as discussed. Vertical variants and
  rotated-panel handling are deferred — kept as a separate
  follow-up rather than a partial-but-broken enum.
- **The `prepare_uinodes` ghost-glyph batching bug.** Still **not
  bundled** here. Manual runs of both new examples on RADV/Vulkan
  rendered cleanly without the fix, so it doesn't block the subpixel
  feature on the hardware I tested. If reviewers see ghost strips on
  other adapters I'm happy to file it as a standalone PR — it's a
  one-file change in `bevy_ui_render::prepare_uinodes` (split UI
  batches whenever the image handle changes, including
  textured ↔ untextured transitions).
- **GPUI attribution.** The per-channel gamma + contrast math in
  both fragment entries is ported from GPUI (Apache 2.0). Each of
  the two shader commits cites the source file in the body. Happy
  to rework to Skia or primary-paper provenance instead — let me
  know which you prefer.

## Status

Open to scope-shaping. Specifically: if you'd rather see this split
into a smaller "rasterisation only" first PR with the render crates
following separately, or merged whole, just say which and I'll
restructure.

Thanks for reading.

---

<details>
<summary>PR metadata</summary>

**Title (67 chars, imperative):**
`Add FontSmoothing::SubpixelAntiAliased for RGB subpixel text`

**Base:** `bevyengine/bevy:main`
**Head:** `svge-ai:subpixel-text-parley`

**Suggested labels:** `A-Text`, `A-UI`, `A-Rendering`,
`M-Needs-Migration-Guide`, `M-Needs-Release-Note`, `C-Feature`

**Related issue:** [#23970](https://github.com/bevyengine/bevy/issues/23970)
(design discussion filed 2026-04-24).

</details>
