### PR TITLE
Replace the NestedLoader API with NestedLoadBuilder (matching LoadBuilder).

### DIFF
--- a/_release-content/migration-guides/load_builder.md
+++ b/_release-content/migration-guides/load_builder.md
@@ -1,6 +1,6 @@
 ---
 title: Advanced AssetServer load variants are now exposed through a builder pattern.
-pull_requests: [23663]
+pull_requests: [23663, 23979]
 ---
 
 In previous versions of Bevy, there were many different ways to load an asset:
@@ -28,3 +28,19 @@ asset_server
     .override_unapproved()
     .load(path)
 ```
+
+## NestedLoader
+
+To match this change, `NestedLoader` has been replaced with
+`NestedLoadBuilder`. Similarly, `LoadContext::loader` has been replaced by
+`LoadContext::load_builder`. The various calls have now been simplified:
+
+- `context.loader().load(path)` -> `context.load_builder().load(path)`
+- `context.loader().with_dynamic_type(type_id).load(path)` -> `context.load_builder().load_erased(type_id, path)`
+- `context.loader().with_unknown_type().load(path)` -> `context.load_builder().load_untyped(path)`
+- `context.loader().immediate().load(path)` -> `context.load_builder().load_async(path)`
+- `context.loader().immediate().with_dynamic_type(type_id).load(path)` -> `context.load_builder().load_erased_async(type_id, path)`
+- `context.loader().immediate().with_unknown_type().load(path)` -> `context.load_builder().load_untyped_async(path)`
+- `context.loader().immediate().with_reader(reader).load(path)` -> `context.load_builder().load_async_from_reader(path, reader)`
+- `context.loader().immediate().with_reader(reader).with_dynamic_type(type_id).load(path)` -> `context.load_builder().load_erased_async_from_reader(type_id, path, reader)`
+- `context.loader().immediate().with_reader(reader).with_unknown_type().load(path)` -> `context.load_builder().load_untyped_async_from_reader(path, reader)`

--- a/_release-content/migration-guides/load_builder.md
+++ b/_release-content/migration-guides/load_builder.md
@@ -38,9 +38,9 @@ To match this change, `NestedLoader` has been replaced with
 - `context.loader().load(path)` -> `context.load_builder().load(path)`
 - `context.loader().with_dynamic_type(type_id).load(path)` -> `context.load_builder().load_erased(type_id, path)`
 - `context.loader().with_unknown_type().load(path)` -> `context.load_builder().load_untyped(path)`
-- `context.loader().immediate().load(path)` -> `context.load_builder().load_async(path)`
-- `context.loader().immediate().with_dynamic_type(type_id).load(path)` -> `context.load_builder().load_erased_async(type_id, path)`
-- `context.loader().immediate().with_unknown_type().load(path)` -> `context.load_builder().load_untyped_async(path)`
-- `context.loader().immediate().with_reader(reader).load(path)` -> `context.load_builder().load_async_from_reader(path, reader)`
-- `context.loader().immediate().with_reader(reader).with_dynamic_type(type_id).load(path)` -> `context.load_builder().load_erased_async_from_reader(type_id, path, reader)`
-- `context.loader().immediate().with_reader(reader).with_unknown_type().load(path)` -> `context.load_builder().load_untyped_async_from_reader(path, reader)`
+- `context.loader().immediate().load(path)` -> `context.load_builder().load_value(path)`
+- `context.loader().immediate().with_dynamic_type(type_id).load(path)` -> `context.load_builder().load_erased_value(type_id, path)`
+- `context.loader().immediate().with_unknown_type().load(path)` -> `context.load_builder().load_untyped_value(path)`
+- `context.loader().immediate().with_reader(reader).load(path)` -> `context.load_builder().load_value_from_reader(path, reader)`
+- `context.loader().immediate().with_reader(reader).with_dynamic_type(type_id).load(path)` -> `context.load_builder().load_erased_value_from_reader(type_id, path, reader)`
+- `context.loader().immediate().with_reader(reader).with_unknown_type().load(path)` -> `context.load_builder().load_untyped_value_from_reader(path, reader)`

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -194,9 +194,7 @@ pub use futures_lite::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 pub use handle::*;
 pub use id::*;
 pub use loader::*;
-pub use loader_builders::{
-    Deferred, DynamicTyped, Immediate, NestedLoader, StaticTyped, UnknownTyped,
-};
+pub use loader_builders::NestedLoadBuilder;
 pub use path::*;
 pub use reflect::*;
 pub use render_asset::*;
@@ -810,8 +808,7 @@ mod tests {
             for dep in ron.embedded_dependencies {
                 let loaded = load_context
                     .loader()
-                    .immediate()
-                    .load::<CoolText>(&dep)
+                    .load_async::<CoolText>(&dep)
                     .await
                     .map_err(|_| Self::Error::CannotLoadDependency {
                         dependency: dep.into(),
@@ -1990,8 +1987,7 @@ mod tests {
                 // We expect this load to fail.
                 load_context
                     .loader()
-                    .immediate()
-                    .load::<SubText>("a.cool.ron#A")
+                    .load_async::<SubText>("a.cool.ron#A")
                     .await?;
                 Ok(TestAsset)
             }
@@ -2758,12 +2754,8 @@ mod tests {
             ) -> Result<Self::Asset, Self::Error> {
                 let mut nested_path = String::new();
                 reader.read_to_string(&mut nested_path).await?;
-                let deferred_nested: LoadedAsset<DeferredNested> = load_context
-                    .loader()
-                    .immediate()
-                    .load(nested_path)
-                    .await
-                    .unwrap();
+                let deferred_nested: LoadedAsset<DeferredNested> =
+                    load_context.loader().load_async(nested_path).await.unwrap();
                 Ok(ImmediateNested(deferred_nested.get().0.clone()))
             }
 

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -807,7 +807,7 @@ mod tests {
             let mut embedded = String::new();
             for dep in ron.embedded_dependencies {
                 let loaded = load_context
-                    .loader()
+                    .load_builder()
                     .load_async::<CoolText>(&dep)
                     .await
                     .map_err(|_| Self::Error::CannotLoadDependency {
@@ -1986,7 +1986,7 @@ mod tests {
             ) -> Result<Self::Asset, Self::Error> {
                 // We expect this load to fail.
                 load_context
-                    .loader()
+                    .load_builder()
                     .load_async::<SubText>("a.cool.ron#A")
                     .await?;
                 Ok(TestAsset)
@@ -2754,8 +2754,11 @@ mod tests {
             ) -> Result<Self::Asset, Self::Error> {
                 let mut nested_path = String::new();
                 reader.read_to_string(&mut nested_path).await?;
-                let deferred_nested: LoadedAsset<DeferredNested> =
-                    load_context.loader().load_async(nested_path).await.unwrap();
+                let deferred_nested: LoadedAsset<DeferredNested> = load_context
+                    .load_builder()
+                    .load_async(nested_path)
+                    .await
+                    .unwrap();
                 Ok(ImmediateNested(deferred_nested.get().0.clone()))
             }
 

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -808,7 +808,7 @@ mod tests {
             for dep in ron.embedded_dependencies {
                 let loaded = load_context
                     .load_builder()
-                    .load_async::<CoolText>(&dep)
+                    .load_value::<CoolText>(&dep)
                     .await
                     .map_err(|_| Self::Error::CannotLoadDependency {
                         dependency: dep.into(),
@@ -1987,7 +1987,7 @@ mod tests {
                 // We expect this load to fail.
                 load_context
                     .load_builder()
-                    .load_async::<SubText>("a.cool.ron#A")
+                    .load_value::<SubText>("a.cool.ron#A")
                     .await?;
                 Ok(TestAsset)
             }
@@ -2756,7 +2756,7 @@ mod tests {
                 reader.read_to_string(&mut nested_path).await?;
                 let deferred_nested: LoadedAsset<DeferredNested> = load_context
                     .load_builder()
-                    .load_async(nested_path)
+                    .load_value(nested_path)
                     .await
                     .unwrap();
                 Ok(ImmediateNested(deferred_nested.get().0.clone()))

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -1,6 +1,6 @@
 use crate::{
     io::{AssetReaderError, MissingAssetSourceError, MissingProcessedAssetReaderError, Reader},
-    loader_builders::{Deferred, NestedLoader, StaticTyped},
+    loader_builders::NestedLoadBuilder,
     meta::{AssetHash, AssetMeta, AssetMetaDyn, ProcessedInfo, ProcessedInfoMinimal, Settings},
     path::AssetPath,
     Asset, AssetIndex, AssetLoadError, AssetServer, AssetServerMode, Assets, ErasedAssetIndex,
@@ -333,11 +333,7 @@ impl<A: Asset> AssetContainer for A {
     }
 }
 
-/// An error that occurs when attempting to call [`NestedLoader::load`] which
-/// is configured to work [immediately].
-///
-/// [`NestedLoader::load`]: crate::NestedLoader::load
-/// [immediately]: crate::Immediate
+/// An error that occurs when attempting an async load using [`NestedLoadBuilder`].
 #[derive(Error, Debug)]
 pub enum LoadDirectError {
     #[error("Attempted to load an asset with an empty path \"{0}\"")]
@@ -667,8 +663,8 @@ impl<'a> LoadContext<'a> {
 
     /// Create a builder for loading nested assets in this context.
     #[must_use]
-    pub fn loader(&mut self) -> NestedLoader<'a, '_, StaticTyped, Deferred> {
-        NestedLoader::new(self)
+    pub fn loader(&mut self) -> NestedLoadBuilder<'a, '_> {
+        NestedLoadBuilder::new(self)
     }
 
     /// Retrieves a handle for the asset at the given path and adds that path as a dependency of the asset.

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -663,7 +663,7 @@ impl<'a> LoadContext<'a> {
 
     /// Create a builder for loading nested assets in this context.
     #[must_use]
-    pub fn loader(&mut self) -> NestedLoadBuilder<'a, '_> {
+    pub fn load_builder(&mut self) -> NestedLoadBuilder<'a, '_> {
         NestedLoadBuilder::new(self)
     }
 
@@ -674,9 +674,9 @@ impl<'a> LoadContext<'a> {
     /// If the current context is configured to not load dependencies automatically (ex: [`AssetProcessor`](crate::processor::AssetProcessor)),
     /// a load will not be kicked off automatically. It is then the calling context's responsibility to begin a load if necessary.
     ///
-    /// If you need to override asset settings, asset type, or load directly, please see [`LoadContext::loader`].
+    /// If you need to override asset settings, asset type, or load directly, please see [`LoadContext::load_builder`].
     pub fn load<'b, A: Asset>(&mut self, path: impl Into<AssetPath<'b>>) -> Handle<A> {
-        self.loader().load(path)
+        self.load_builder().load(path)
     }
 }
 

--- a/crates/bevy_asset/src/loader_builders.rs
+++ b/crates/bevy_asset/src/loader_builders.rs
@@ -1,5 +1,5 @@
 //! Implementations of the builder-pattern used for loading dependent assets via
-//! [`LoadContext::loader`].
+//! [`LoadContext::load_builder`].
 
 use crate::{
     io::Reader,

--- a/crates/bevy_asset/src/loader_builders.rs
+++ b/crates/bevy_asset/src/loader_builders.rs
@@ -3,12 +3,12 @@
 
 use crate::{
     io::Reader,
-    meta::{meta_transform_settings, AssetMetaDyn, MetaTransform, Settings},
+    meta::{loader_settings_meta_transform, MetaTransform, Settings},
     Asset, AssetLoadError, AssetPath, ErasedAssetLoader, ErasedLoadedAsset, Handle, LoadContext,
     LoadDirectError, LoadedAsset, LoadedUntypedAsset, UntypedHandle,
 };
 use alloc::{borrow::ToOwned, boxed::Box, sync::Arc};
-use core::any::TypeId;
+use core::any::{type_name, TypeId};
 use std::path::Path;
 use tracing::error;
 
@@ -28,366 +28,102 @@ impl ReaderRef<'_> {
 }
 
 /// A builder for loading nested assets inside a [`LoadContext`].
-///
-/// # Loader state
-///
-/// The type parameters `T` and `M` determine how this will load assets:
-/// - `T`: the typing of this loader. How do we know what type of asset to load?
-///
-///   See [`StaticTyped`] (the default), [`DynamicTyped`], and [`UnknownTyped`].
-///
-/// - `M`: the load mode. Do we want to load this asset right now (in which case
-///   you will have to `await` the operation), or do we just want a [`Handle`],
-///   and leave the actual asset loading to later?
-///
-///   See [`Deferred`] (the default) and [`Immediate`].
-///
-/// When configuring this builder, you can freely switch between these modes
-/// via functions like [`deferred`] and [`immediate`].
-///
-/// ## Typing
-///
-/// To inform the loader of what type of asset to load:
-/// - in [`StaticTyped`]: statically providing a type parameter `A: Asset` to
-///   [`load`].
-///
-///   This is the simplest way to get a [`Handle<A>`] to the loaded asset, as
-///   long as you know the type of `A` at compile time.
-///
-/// - in [`DynamicTyped`]: providing the [`TypeId`] of the asset at runtime.
-///
-///   If you know the type ID of the asset at runtime, but not at compile time,
-///   use [`with_dynamic_type`] followed by [`load`] to start loading an asset
-///   of that type. This lets you get an [`UntypedHandle`] (via [`Deferred`]),
-///   or a [`ErasedLoadedAsset`] (via [`Immediate`]).
-///
-/// - in [`UnknownTyped`]: loading either a type-erased version of the asset
-///   ([`ErasedLoadedAsset`]), or a handle *to a handle* of the actual asset
-///   ([`LoadedUntypedAsset`]).
-///
-///   If you have no idea what type of asset you will be loading (not even at
-///   runtime with a [`TypeId`]), use this.
-///
-/// ## Load mode
-///
-/// To inform the loader how you want to load the asset:
-/// - in [`Deferred`]: when you request to load the asset, you get a [`Handle`]
-///   for it, but the actual loading won't be completed until later.
-///
-///   Use this if you only need a [`Handle`] or [`UntypedHandle`].
-///
-/// - in [`Immediate`]: the load request will load the asset right then and
-///   there, waiting until the asset is fully loaded and giving you access to
-///   it.
-///
-///   Note that this requires you to `await` a future, so you must be in an
-///   async context to use direct loading. In an asset loader, you will be in
-///   an async context.
-///
-///   Use this if you need the *value* of another asset in order to load the
-///   current asset. For example, if you are deriving a new asset from the
-///   referenced asset, or you are building a collection of assets. This will
-///   add the path of the asset as a "load dependency".
-///
-///   If the current loader is used in a [`Process`] "asset preprocessor",
-///   such as a [`LoadTransformAndSave`] preprocessor, changing a "load
-///   dependency" will result in re-processing of the asset.
-///
-/// # Load kickoff
-///
-/// If the current context is a normal [`AssetServer::load`], an actual asset
-/// load will be kicked off immediately, which ensures the load happens as soon
-/// as possible. "Normal loads" kicked from within a normal Bevy App will
-/// generally configure the context to kick off loads immediately.
-///
-/// If the current context is configured to not load dependencies automatically
-/// (ex: [`AssetProcessor`]), a load will not be kicked off automatically. It is
-/// then the calling context's responsibility to begin a load if necessary.
-///
-/// # Lifetimes
-///
-/// - `ctx`: the lifetime of the associated [`AssetServer`](crate::AssetServer) reference
-/// - `builder`: the lifetime of the temporary builder structs
-///
-/// [`deferred`]: Self::deferred
-/// [`immediate`]: Self::immediate
-/// [`load`]: Self::load
-/// [`with_dynamic_type`]: Self::with_dynamic_type
-/// [`AssetServer::load`]: crate::AssetServer::load
-/// [`AssetProcessor`]: crate::processor::AssetProcessor
-/// [`Process`]: crate::processor::Process
-/// [`LoadTransformAndSave`]: crate::processor::LoadTransformAndSave
-pub struct NestedLoader<'ctx, 'builder, T, M> {
+pub struct NestedLoadBuilder<'ctx, 'builder> {
     load_context: &'builder mut LoadContext<'ctx>,
+    /// A function to modify the meta for an asset loader. In practice, this just mutates the loader
+    /// settings of a load.
     meta_transform: Option<MetaTransform>,
-    typing: T,
-    mode: M,
+    /// Whether unapproved paths are allowed to be loaded.
+    override_unapproved: bool,
 }
 
-mod sealed {
-    pub trait Typing {}
-
-    pub trait Mode {}
-}
-
-/// [`NestedLoader`] will be provided the type of asset as a type parameter on
-/// [`load`].
-///
-/// [`load`]: NestedLoader::load
-pub struct StaticTyped(());
-
-impl sealed::Typing for StaticTyped {}
-
-/// [`NestedLoader`] has been configured with info on what type of asset to load
-/// at runtime.
-pub struct DynamicTyped {
-    asset_type_id: TypeId,
-}
-
-impl sealed::Typing for DynamicTyped {}
-
-/// [`NestedLoader`] does not know what type of asset it will be loading.
-pub struct UnknownTyped(());
-
-impl sealed::Typing for UnknownTyped {}
-
-/// [`NestedLoader`] will create and return asset handles immediately, but only
-/// actually load the asset later.
-pub struct Deferred(());
-
-impl sealed::Mode for Deferred {}
-
-/// [`NestedLoader`] will immediately load an asset when requested.
-pub struct Immediate<'builder, 'reader> {
-    reader: Option<&'builder mut (dyn Reader + 'reader)>,
-}
-
-impl sealed::Mode for Immediate<'_, '_> {}
-
-// common to all states
-
-impl<'ctx, 'builder> NestedLoader<'ctx, 'builder, StaticTyped, Deferred> {
+impl<'ctx, 'builder> NestedLoadBuilder<'ctx, 'builder> {
     pub(crate) fn new(load_context: &'builder mut LoadContext<'ctx>) -> Self {
-        NestedLoader {
+        NestedLoadBuilder {
             load_context,
             meta_transform: None,
-            typing: StaticTyped(()),
-            mode: Deferred(()),
+            override_unapproved: false,
         }
     }
 }
 
-impl<'ctx, 'builder, T: sealed::Typing, M: sealed::Mode> NestedLoader<'ctx, 'builder, T, M> {
-    fn with_transform(
+impl<'ctx, 'builder> NestedLoadBuilder<'ctx, 'builder> {
+    /// Use the given `settings` function to override the asset's [`AssetLoader`] settings.
+    ///
+    /// The type `S` must match the configured [`AssetLoader::Settings`] or `settings` changes will
+    /// be ignored and an error will be printed to the log.
+    ///
+    /// Repeatedly calling this method will "chain" the operations (matching the order of these
+    /// calls).
+    ///
+    /// [`AssetLoader`]: crate::AssetLoader
+    /// [`AssetLoader::Settings`]: crate::AssetLoader::Settings
+    #[must_use]
+    pub fn with_settings<S: Settings>(
         mut self,
-        transform: impl Fn(&mut dyn AssetMetaDyn) + Send + Sync + 'static,
+        settings: impl Fn(&mut S) + Send + Sync + 'static,
     ) -> Self {
-        if let Some(prev_transform) = self.meta_transform {
+        let new_transform = loader_settings_meta_transform(settings);
+        if let Some(prev_transform) = self.meta_transform.take() {
             self.meta_transform = Some(Box::new(move |meta| {
                 prev_transform(meta);
-                transform(meta);
+                new_transform(meta);
             }));
         } else {
-            self.meta_transform = Some(Box::new(transform));
+            self.meta_transform = Some(new_transform);
         }
         self
     }
 
-    /// Configure the settings used to load the asset.
-    ///
-    /// If the settings type `S` does not match the settings expected by `A`'s asset loader, an error will be printed to the log
-    /// and the asset load will fail.
-    #[must_use]
-    pub fn with_settings<S: Settings>(
-        self,
-        settings: impl Fn(&mut S) + Send + Sync + 'static,
-    ) -> Self {
-        self.with_transform(move |meta| meta_transform_settings(meta, &settings))
+    /// Loads from unapproved paths are allowed, even if
+    /// [`AssetPlugin::unapproved_path_mode`](crate::AssetPlugin::unapproved_path_mode) is
+    /// [`Deny`](crate::UnapprovedPathMode::Deny).
+    #[must_use = "the load doesn't start until LoadBuilder has been consumed"]
+    pub fn override_unapproved(mut self) -> Self {
+        self.override_unapproved = true;
+        self
     }
 
-    // convert between `T`s
-
-    /// When [`load`]ing, you must pass in the asset type as a type parameter
-    /// statically.
+    /// Loads the provided path as the given type and returns the handle.
     ///
-    /// If you don't know the type statically (at compile time), consider
-    /// [`with_dynamic_type`] or [`with_unknown_type`].
-    ///
-    /// [`load`]: Self::load
-    /// [`with_dynamic_type`]: Self::with_dynamic_type
-    /// [`with_unknown_type`]: Self::with_unknown_type
-    #[must_use]
-    pub fn with_static_type(self) -> NestedLoader<'ctx, 'builder, StaticTyped, M> {
-        NestedLoader {
-            load_context: self.load_context,
-            meta_transform: self.meta_transform,
-            typing: StaticTyped(()),
-            mode: self.mode,
-        }
+    /// This is a "deferred" load, meaning the caller will not have access to the loaded data; to
+    /// access the loaded data, use [`Self::load_async`].
+    pub fn load<'a, A: Asset>(self, path: impl Into<AssetPath<'a>>) -> Handle<A> {
+        // The doc comment slightly lies: if `LoadContext::should_load_dependencies` is true, the
+        // load will not be started, but the matching handle will still be returned. The caller
+        // can't tell the difference.
+        self.load_internal(TypeId::of::<A>(), Some(type_name::<A>()), path.into())
+            .typed_debug_checked()
     }
 
-    /// When [`load`]ing, the loader will attempt to load an asset with the
-    /// given [`TypeId`].
+    /// Loads the provided path as the given type and returns the handle.
     ///
-    /// [`load`]: Self::load
-    #[must_use]
-    pub fn with_dynamic_type(
-        self,
-        asset_type_id: TypeId,
-    ) -> NestedLoader<'ctx, 'builder, DynamicTyped, M> {
-        NestedLoader {
-            load_context: self.load_context,
-            meta_transform: self.meta_transform,
-            typing: DynamicTyped { asset_type_id },
-            mode: self.mode,
-        }
+    /// This is a "deferred" load, meaning the caller will not have access to the loaded data; to
+    /// access the loaded data, use [`Self::load_erased_async`].
+    pub fn load_erased<'a>(self, type_id: TypeId, path: impl Into<AssetPath<'a>>) -> UntypedHandle {
+        self.load_internal(type_id, None, path.into())
     }
 
-    /// When [`load`]ing, we will infer what type of asset to load from
-    /// metadata.
+    /// Loads the provided path with an unknown type (which is guessed based on the path or meta
+    /// file).
     ///
-    /// [`load`]: Self::load
-    #[must_use]
-    pub fn with_unknown_type(self) -> NestedLoader<'ctx, 'builder, UnknownTyped, M> {
-        NestedLoader {
-            load_context: self.load_context,
-            meta_transform: self.meta_transform,
-            typing: UnknownTyped(()),
-            mode: self.mode,
-        }
-    }
-
-    // convert between `M`s
-
-    /// When [`load`]ing, create only asset handles, rather than returning the
-    /// actual asset.
-    ///
-    /// [`load`]: Self::load
-    pub fn deferred(self) -> NestedLoader<'ctx, 'builder, T, Deferred> {
-        NestedLoader {
-            load_context: self.load_context,
-            meta_transform: self.meta_transform,
-            typing: self.typing,
-            mode: Deferred(()),
-        }
-    }
-
-    /// The [`load`] call itself will load an asset, rather than scheduling the
-    /// loading to happen later.
-    ///
-    /// This gives you access to the loaded asset, but requires you to be in an
-    /// async context, and be able to `await` the resulting future.
-    ///
-    /// [`load`]: Self::load
-    #[must_use]
-    pub fn immediate<'c>(self) -> NestedLoader<'ctx, 'builder, T, Immediate<'builder, 'c>> {
-        NestedLoader {
-            load_context: self.load_context,
-            meta_transform: self.meta_transform,
-            typing: self.typing,
-            mode: Immediate { reader: None },
-        }
-    }
-}
-
-// deferred loading logic
-
-impl NestedLoader<'_, '_, StaticTyped, Deferred> {
-    /// Retrieves a handle for the asset at the given path and adds that path as
-    /// a dependency of this asset.
-    ///
-    /// This requires you to know the type of asset statically.
-    /// - If you have runtime info for what type of asset you're loading (e.g. a
-    ///   [`TypeId`]), use [`with_dynamic_type`].
-    /// - If you do not know at all what type of asset you're loading, use
-    ///   [`with_unknown_type`].
-    ///
-    /// [`with_dynamic_type`]: Self::with_dynamic_type
-    /// [`with_unknown_type`]: Self::with_unknown_type
-    pub fn load<'c, A: Asset>(self, path: impl Into<AssetPath<'c>>) -> Handle<A> {
+    /// This is a "deferred" load, meaning the caller will not have access to the loaded data; to
+    /// access the loaded data, use [`Self::load_untyped_async`].
+    pub fn load_untyped<'a>(self, path: impl Into<AssetPath<'a>>) -> Handle<LoadedUntypedAsset> {
         let path = path.into().to_owned();
         if path.path() == Path::new("") {
             error!("Attempted to load an asset with an empty path \"{path}\"!");
             return Handle::default();
         }
         let handle = if self.load_context.should_load_dependencies {
-            self.load_context.asset_server.load_with_meta_transform(
-                path,
-                self.meta_transform,
-                (),
-                true,
-            )
-        } else {
             self.load_context
                 .asset_server
-                .get_or_create_path_handle(path, self.meta_transform)
-        };
-        // `load_with_meta_transform` and `get_or_create_path_handle` always returns a Strong
-        // variant, so we are safe to unwrap.
-        let index = (&handle).try_into().unwrap();
-        self.load_context.dependencies.insert(index);
-        handle
-    }
-}
-
-impl NestedLoader<'_, '_, DynamicTyped, Deferred> {
-    /// Retrieves a handle for the asset at the given path and adds that path as
-    /// a dependency of this asset.
-    ///
-    /// This requires you to pass in the asset type ID into
-    /// [`with_dynamic_type`].
-    ///
-    /// [`with_dynamic_type`]: Self::with_dynamic_type
-    pub fn load<'p>(self, path: impl Into<AssetPath<'p>>) -> UntypedHandle {
-        let path = path.into().to_owned();
-        if path.path() == Path::new("") {
-            error!("Attempted to load an asset with an empty path \"{path}\"!");
-            return UntypedHandle::default_for_type(self.typing.asset_type_id);
-        }
-        let handle = if self.load_context.should_load_dependencies {
-            self.load_context
-                .asset_server
-                .load_with_meta_transform_erased(
+                .load_unknown_type_with_meta_transform(
                     path,
-                    self.typing.asset_type_id,
-                    None,
                     self.meta_transform,
                     (),
-                    false,
+                    self.override_unapproved,
                 )
-        } else {
-            self.load_context
-                .asset_server
-                .get_or_create_path_handle_erased(
-                    path,
-                    self.typing.asset_type_id,
-                    None,
-                    self.meta_transform,
-                )
-        };
-        // `load_with_meta_transform_erased` and `get_or_create_path_handle_erased` always returns a
-        // Strong variant, so we are safe to unwrap.
-        let index = (&handle).try_into().unwrap();
-        self.load_context.dependencies.insert(index);
-        handle
-    }
-}
-
-impl NestedLoader<'_, '_, UnknownTyped, Deferred> {
-    /// Retrieves a handle for the asset at the given path and adds that path as
-    /// a dependency of this asset.
-    ///
-    /// This will infer the asset type from metadata.
-    pub fn load<'p>(self, path: impl Into<AssetPath<'p>>) -> Handle<LoadedUntypedAsset> {
-        let path = path.into().to_owned();
-        if path.path() == Path::new("") {
-            error!("Attempted to load an asset with an empty path \"{path}\"!");
-            return Handle::default();
-        }
-        let handle = if self.load_context.should_load_dependencies {
-            self.load_context
-                .asset_server
-                .load_unknown_type_with_meta_transform(path, self.meta_transform, (), false)
         } else {
             self.load_context
                 .asset_server
@@ -399,22 +135,135 @@ impl NestedLoader<'_, '_, UnknownTyped, Deferred> {
         self.load_context.dependencies.insert(index);
         handle
     }
-}
 
-// immediate loading logic
-
-impl<'builder, 'reader, T> NestedLoader<'_, '_, T, Immediate<'builder, 'reader>> {
-    /// Specify the reader to use to read the asset data.
-    #[must_use]
-    pub fn with_reader(mut self, reader: &'builder mut (dyn Reader + 'reader)) -> Self {
-        self.mode.reader = Some(reader);
-        self
+    /// Loads the provided path as the given type, returning the loaded data.
+    ///
+    /// This load is async and therefore needs to be awaited before returning the loaded data.
+    pub async fn load_async<'a, A: Asset>(
+        self,
+        path: impl Into<AssetPath<'a>>,
+    ) -> Result<LoadedAsset<A>, LoadDirectError> {
+        self.load_typed_async_internal(path.into().into_owned(), None)
+            .await
     }
 
-    async fn load_internal(
+    /// Loads the provided path as the given type, returning the loaded data.
+    ///
+    /// This load is async and therefore needs to be awaited before returning the loaded data.
+    pub async fn load_erased_async<'a>(
         self,
+        type_id: TypeId,
+        path: impl Into<AssetPath<'a>>,
+    ) -> Result<ErasedLoadedAsset, LoadDirectError> {
+        self.load_async_internal(Some(type_id), &path.into().into_owned(), None)
+            .await
+            .map(|(_, asset)| asset)
+    }
+
+    /// Loads the provided path with an unknown type (which is guessed based on the path or meta
+    /// file), returning the loaded data.
+    ///
+    /// This load is async and therefore needs to be awaited before returning the loaded data.
+    pub async fn load_untyped_async<'a>(
+        self,
+        path: impl Into<AssetPath<'a>>,
+    ) -> Result<ErasedLoadedAsset, LoadDirectError> {
+        self.load_async_internal(None, &path.into().into_owned(), None)
+            .await
+            .map(|(_, asset)| asset)
+    }
+
+    /// Loads the given type from the given `reader`, returning the loaded data.
+    ///
+    /// This load is async and therefore needs to be awaited before returning the loaded data. The
+    /// provided path determines the path used for handles of subassets, as well as any relative
+    /// paths of assets used by the nested loader.
+    pub async fn load_async_from_reader<'a, A: Asset>(
+        self,
+        path: impl Into<AssetPath<'a>>,
+        reader: &'builder mut dyn Reader,
+    ) -> Result<LoadedAsset<A>, LoadDirectError> {
+        self.load_typed_async_internal(path.into().into_owned(), Some(reader))
+            .await
+    }
+
+    /// Loads the given type from the given `reader`, returning the loaded data.
+    ///
+    /// This load is async and therefore needs to be awaited before returning the loaded data. The
+    /// provided path determines the path used for handles of subassets, as well as any relative
+    /// paths of assets used by the nested loader.
+    /// that path as a dependency of this asset.
+    pub async fn load_erased_async_from_reader<'a>(
+        self,
+        type_id: TypeId,
+        path: impl Into<AssetPath<'a>>,
+        reader: &'builder mut dyn Reader,
+    ) -> Result<ErasedLoadedAsset, LoadDirectError> {
+        self.load_async_internal(Some(type_id), &path.into().into_owned(), Some(reader))
+            .await
+            .map(|(_, asset)| asset)
+    }
+
+    /// Loads an asset from the given `reader` with an unknown type (which is guessed based on the
+    /// path or meta file), returning the loaded data.
+    ///
+    /// This load is async and therefore needs to be awaited before returning the loaded data. The
+    /// provided path determines the path used for handles of subassets, as well as any relative
+    /// paths of assets used by the nested loader.
+    pub async fn load_untyped_async_from_reader<'a>(
+        self,
+        path: impl Into<AssetPath<'a>>,
+        reader: &'builder mut dyn Reader,
+    ) -> Result<ErasedLoadedAsset, LoadDirectError> {
+        self.load_async_internal(None, &path.into().into_owned(), Some(reader))
+            .await
+            .map(|(_, asset)| asset)
+    }
+
+    /// Acquires the handle for the given type and path, and if necessary, begins a corresponding
+    /// (deferred) load.
+    fn load_internal<'a>(
+        self,
+        type_id: TypeId,
+        type_name: Option<&str>,
+        path: AssetPath<'a>,
+    ) -> UntypedHandle {
+        let path = path.to_owned();
+        if path.path() == Path::new("") {
+            error!("Attempted to load an asset with an empty path \"{path}\"!");
+            return UntypedHandle::default_for_type(type_id);
+        }
+        let handle = if self.load_context.should_load_dependencies {
+            self.load_context.asset_server.load_with_meta_transform(
+                path,
+                type_id,
+                type_name,
+                self.meta_transform,
+                (),
+                self.override_unapproved,
+            )
+        } else {
+            self.load_context
+                .asset_server
+                .get_or_create_path_handle_erased(path, type_id, type_name, self.meta_transform)
+        };
+        // `load_with_meta_transform` and `get_or_create_path_handle` always returns a Strong
+        // variant, so we are safe to unwrap.
+        let index = (&handle).try_into().unwrap();
+        self.load_context.dependencies.insert(index);
+        handle
+    }
+
+    /// Creates a future to do a nested load.
+    ///
+    /// The type is either provided, or it is deduced from the path or meta file. If `reader` is
+    /// [`Some`], the load reads from the provided reader. Otherwise, the asset is loaded from
+    /// `path`.
+    async fn load_async_internal(
+        self,
+        type_id: Option<TypeId>,
         path: &AssetPath<'static>,
-        asset_type_id: Option<TypeId>,
+        reader: Option<&'builder mut dyn Reader>,
     ) -> Result<(Arc<dyn ErasedAssetLoader>, ErasedLoadedAsset), LoadDirectError> {
         if path.path() == Path::new("") {
             error!("Attempted to load an asset with an empty path \"{path}\"!");
@@ -428,11 +277,11 @@ impl<'builder, 'reader, T> NestedLoader<'_, '_, T, Immediate<'builder, 'reader>>
             .write_infos()
             .stats
             .started_load_tasks += 1;
-        let (mut meta, loader, mut reader) = if let Some(reader) = self.mode.reader {
-            let loader = if let Some(asset_type_id) = asset_type_id {
+        let (mut meta, loader, mut reader) = if let Some(reader) = reader {
+            let loader = if let Some(type_id) = type_id {
                 self.load_context
                     .asset_server
-                    .get_asset_loader_with_asset_type_id(asset_type_id)
+                    .get_asset_loader_with_asset_type_id(type_id)
                     .await
                     .map_err(|error| LoadDirectError::LoadError {
                         dependency: path.clone(),
@@ -454,7 +303,7 @@ impl<'builder, 'reader, T> NestedLoader<'_, '_, T, Immediate<'builder, 'reader>>
             let (meta, loader, reader) = self
                 .load_context
                 .asset_server
-                .get_meta_loader_and_reader(path, asset_type_id)
+                .get_meta_loader_and_reader(path, type_id)
                 .await
                 .map_err(|error| LoadDirectError::LoadError {
                     dependency: path.clone(),
@@ -479,26 +328,19 @@ impl<'builder, 'reader, T> NestedLoader<'_, '_, T, Immediate<'builder, 'reader>>
             .await?;
         Ok((loader, asset))
     }
-}
 
-impl NestedLoader<'_, '_, StaticTyped, Immediate<'_, '_>> {
-    /// Attempts to load the asset at the given `path` immediately.
-    ///
-    /// This requires you to know the type of asset statically.
-    /// - If you have runtime info for what type of asset you're loading (e.g. a
-    ///   [`TypeId`]), use [`with_dynamic_type`].
-    /// - If you do not know at all what type of asset you're loading, use
-    ///   [`with_unknown_type`].
-    ///
-    /// [`with_dynamic_type`]: Self::with_dynamic_type
-    /// [`with_unknown_type`]: Self::with_unknown_type
-    #[expect(clippy::result_large_err, reason = "Asset loading is not a hot path.")]
-    pub async fn load<'p, A: Asset>(
+    /// Same as [`Self::load_async_internal`], but with a generic to ensure the returned handle type
+    /// is correct.
+    #[expect(
+        clippy::result_large_err,
+        reason = "we need to give the user the correct error type"
+    )]
+    async fn load_typed_async_internal<A: Asset>(
         self,
-        path: impl Into<AssetPath<'p>>,
+        path: AssetPath<'static>,
+        reader: Option<&'builder mut dyn Reader>,
     ) -> Result<LoadedAsset<A>, LoadDirectError> {
-        let path = path.into().into_owned();
-        self.load_internal(&path, Some(TypeId::of::<A>()))
+        self.load_async_internal(Some(TypeId::of::<A>()), &path, reader)
             .await
             .and_then(move |(loader, untyped_asset)| {
                 untyped_asset
@@ -513,39 +355,5 @@ impl NestedLoader<'_, '_, StaticTyped, Immediate<'_, '_>> {
                         },
                     })
             })
-    }
-}
-
-impl NestedLoader<'_, '_, DynamicTyped, Immediate<'_, '_>> {
-    /// Attempts to load the asset at the given `path` immediately.
-    ///
-    /// This requires you to pass in the asset type ID into
-    /// [`with_dynamic_type`].
-    ///
-    /// [`with_dynamic_type`]: Self::with_dynamic_type
-    pub async fn load<'p>(
-        self,
-        path: impl Into<AssetPath<'p>>,
-    ) -> Result<ErasedLoadedAsset, LoadDirectError> {
-        let path = path.into().into_owned();
-        let asset_type_id = Some(self.typing.asset_type_id);
-        self.load_internal(&path, asset_type_id)
-            .await
-            .map(|(_, asset)| asset)
-    }
-}
-
-impl NestedLoader<'_, '_, UnknownTyped, Immediate<'_, '_>> {
-    /// Attempts to load the asset at the given `path` immediately.
-    ///
-    /// This will infer the asset type from metadata.
-    pub async fn load<'p>(
-        self,
-        path: impl Into<AssetPath<'p>>,
-    ) -> Result<ErasedLoadedAsset, LoadDirectError> {
-        let path = path.into().into_owned();
-        self.load_internal(&path, None)
-            .await
-            .map(|(_, asset)| asset)
     }
 }

--- a/crates/bevy_asset/src/loader_builders.rs
+++ b/crates/bevy_asset/src/loader_builders.rs
@@ -192,7 +192,6 @@ impl<'ctx, 'builder> NestedLoadBuilder<'ctx, 'builder> {
     /// This load is async and therefore needs to be awaited before returning the loaded data. The
     /// provided path determines the path used for handles of subassets, as well as any relative
     /// paths of assets used by the nested loader.
-    /// that path as a dependency of this asset.
     pub async fn load_erased_async_from_reader<'a>(
         self,
         type_id: TypeId,

--- a/crates/bevy_asset/src/loader_builders.rs
+++ b/crates/bevy_asset/src/loader_builders.rs
@@ -87,7 +87,7 @@ impl<'ctx, 'builder> NestedLoadBuilder<'ctx, 'builder> {
     /// Loads the provided path as the given type and returns the handle.
     ///
     /// This is a "deferred" load, meaning the caller will not have access to the loaded data; to
-    /// access the loaded data, use [`Self::load_async`].
+    /// access the loaded data, use [`Self::load_value`].
     pub fn load<'a, A: Asset>(self, path: impl Into<AssetPath<'a>>) -> Handle<A> {
         // The doc comment slightly lies: if `LoadContext::should_load_dependencies` is true, the
         // load will not be started, but the matching handle will still be returned. The caller
@@ -99,7 +99,7 @@ impl<'ctx, 'builder> NestedLoadBuilder<'ctx, 'builder> {
     /// Loads the provided path as the given type and returns the handle.
     ///
     /// This is a "deferred" load, meaning the caller will not have access to the loaded data; to
-    /// access the loaded data, use [`Self::load_erased_async`].
+    /// access the loaded data, use [`Self::load_erased_value`].
     pub fn load_erased<'a>(self, type_id: TypeId, path: impl Into<AssetPath<'a>>) -> UntypedHandle {
         self.load_internal(type_id, None, path.into())
     }
@@ -108,7 +108,7 @@ impl<'ctx, 'builder> NestedLoadBuilder<'ctx, 'builder> {
     /// file).
     ///
     /// This is a "deferred" load, meaning the caller will not have access to the loaded data; to
-    /// access the loaded data, use [`Self::load_untyped_async`].
+    /// access the loaded data, use [`Self::load_untyped_value`].
     pub fn load_untyped<'a>(self, path: impl Into<AssetPath<'a>>) -> Handle<LoadedUntypedAsset> {
         let path = path.into().to_owned();
         if path.path() == Path::new("") {
@@ -139,23 +139,23 @@ impl<'ctx, 'builder> NestedLoadBuilder<'ctx, 'builder> {
     /// Loads the provided path as the given type, returning the loaded data.
     ///
     /// This load is async and therefore needs to be awaited before returning the loaded data.
-    pub async fn load_async<'a, A: Asset>(
+    pub async fn load_value<'a, A: Asset>(
         self,
         path: impl Into<AssetPath<'a>>,
     ) -> Result<LoadedAsset<A>, LoadDirectError> {
-        self.load_typed_async_internal(path.into().into_owned(), None)
+        self.load_typed_value_internal(path.into().into_owned(), None)
             .await
     }
 
     /// Loads the provided path as the given type, returning the loaded data.
     ///
     /// This load is async and therefore needs to be awaited before returning the loaded data.
-    pub async fn load_erased_async<'a>(
+    pub async fn load_erased_value<'a>(
         self,
         type_id: TypeId,
         path: impl Into<AssetPath<'a>>,
     ) -> Result<ErasedLoadedAsset, LoadDirectError> {
-        self.load_async_internal(Some(type_id), &path.into().into_owned(), None)
+        self.load_value_internal(Some(type_id), &path.into().into_owned(), None)
             .await
             .map(|(_, asset)| asset)
     }
@@ -164,11 +164,11 @@ impl<'ctx, 'builder> NestedLoadBuilder<'ctx, 'builder> {
     /// file), returning the loaded data.
     ///
     /// This load is async and therefore needs to be awaited before returning the loaded data.
-    pub async fn load_untyped_async<'a>(
+    pub async fn load_untyped_value<'a>(
         self,
         path: impl Into<AssetPath<'a>>,
     ) -> Result<ErasedLoadedAsset, LoadDirectError> {
-        self.load_async_internal(None, &path.into().into_owned(), None)
+        self.load_value_internal(None, &path.into().into_owned(), None)
             .await
             .map(|(_, asset)| asset)
     }
@@ -178,12 +178,12 @@ impl<'ctx, 'builder> NestedLoadBuilder<'ctx, 'builder> {
     /// This load is async and therefore needs to be awaited before returning the loaded data. The
     /// provided path determines the path used for handles of subassets, as well as any relative
     /// paths of assets used by the nested loader.
-    pub async fn load_async_from_reader<'a, A: Asset>(
+    pub async fn load_value_from_reader<'a, A: Asset>(
         self,
         path: impl Into<AssetPath<'a>>,
         reader: &'builder mut dyn Reader,
     ) -> Result<LoadedAsset<A>, LoadDirectError> {
-        self.load_typed_async_internal(path.into().into_owned(), Some(reader))
+        self.load_typed_value_internal(path.into().into_owned(), Some(reader))
             .await
     }
 
@@ -192,13 +192,13 @@ impl<'ctx, 'builder> NestedLoadBuilder<'ctx, 'builder> {
     /// This load is async and therefore needs to be awaited before returning the loaded data. The
     /// provided path determines the path used for handles of subassets, as well as any relative
     /// paths of assets used by the nested loader.
-    pub async fn load_erased_async_from_reader<'a>(
+    pub async fn load_erased_value_from_reader<'a>(
         self,
         type_id: TypeId,
         path: impl Into<AssetPath<'a>>,
         reader: &'builder mut dyn Reader,
     ) -> Result<ErasedLoadedAsset, LoadDirectError> {
-        self.load_async_internal(Some(type_id), &path.into().into_owned(), Some(reader))
+        self.load_value_internal(Some(type_id), &path.into().into_owned(), Some(reader))
             .await
             .map(|(_, asset)| asset)
     }
@@ -209,12 +209,12 @@ impl<'ctx, 'builder> NestedLoadBuilder<'ctx, 'builder> {
     /// This load is async and therefore needs to be awaited before returning the loaded data. The
     /// provided path determines the path used for handles of subassets, as well as any relative
     /// paths of assets used by the nested loader.
-    pub async fn load_untyped_async_from_reader<'a>(
+    pub async fn load_untyped_value_from_reader<'a>(
         self,
         path: impl Into<AssetPath<'a>>,
         reader: &'builder mut dyn Reader,
     ) -> Result<ErasedLoadedAsset, LoadDirectError> {
-        self.load_async_internal(None, &path.into().into_owned(), Some(reader))
+        self.load_value_internal(None, &path.into().into_owned(), Some(reader))
             .await
             .map(|(_, asset)| asset)
     }
@@ -258,7 +258,7 @@ impl<'ctx, 'builder> NestedLoadBuilder<'ctx, 'builder> {
     /// The type is either provided, or it is deduced from the path or meta file. If `reader` is
     /// [`Some`], the load reads from the provided reader. Otherwise, the asset is loaded from
     /// `path`.
-    async fn load_async_internal(
+    async fn load_value_internal(
         self,
         type_id: Option<TypeId>,
         path: &AssetPath<'static>,
@@ -328,18 +328,18 @@ impl<'ctx, 'builder> NestedLoadBuilder<'ctx, 'builder> {
         Ok((loader, asset))
     }
 
-    /// Same as [`Self::load_async_internal`], but with a generic to ensure the returned handle type
+    /// Same as [`Self::load_value_internal`], but with a generic to ensure the returned handle type
     /// is correct.
     #[expect(
         clippy::result_large_err,
         reason = "we need to give the user the correct error type"
     )]
-    async fn load_typed_async_internal<A: Asset>(
+    async fn load_typed_value_internal<A: Asset>(
         self,
         path: AssetPath<'static>,
         reader: Option<&'builder mut dyn Reader>,
     ) -> Result<LoadedAsset<A>, LoadDirectError> {
-        self.load_async_internal(Some(TypeId::of::<A>()), &path, reader)
+        self.load_value_internal(Some(TypeId::of::<A>()), &path, reader)
             .await
             .and_then(move |(loader, untyped_asset)| {
                 untyped_asset

--- a/crates/bevy_asset/src/processor/tests.rs
+++ b/crates/bevy_asset/src/processor/tests.rs
@@ -758,8 +758,7 @@ impl AssetLoader for FakeBsnLoader {
         let parent_bsn = bsn.parent_bsn.unwrap();
         let parent_bsn = load_context
             .loader()
-            .immediate()
-            .load(parent_bsn)
+            .load_async(parent_bsn)
             .await
             .map_err(|err| Error::new(ErrorKind::InvalidData, err))?;
         let mut new_bsn: FakeBsn = parent_bsn.take();
@@ -951,8 +950,7 @@ fn asset_processor_loading_can_read_source_assets() {
                 // Bevy, so it needs to load the source assets to make sense.
                 let gltf = load_context
                     .loader()
-                    .immediate()
-                    .load(gltf)
+                    .load_async(gltf)
                     .await
                     .map_err(|err| Error::new(ErrorKind::InvalidData, err))?;
                 gltfs.push(gltf.take());
@@ -1261,7 +1259,7 @@ fn nested_loads_of_processed_asset_reprocesses_on_reload() {
             Ok(match serialized {
                 NesterSerialized::Leaf(value) => Nester { value },
                 NesterSerialized::Path(path) => {
-                    let loaded_asset = load_context.loader().immediate().load(path).await.unwrap();
+                    let loaded_asset = load_context.loader().load_async(path).await.unwrap();
                     loaded_asset.take()
                 }
             })

--- a/crates/bevy_asset/src/processor/tests.rs
+++ b/crates/bevy_asset/src/processor/tests.rs
@@ -757,7 +757,7 @@ impl AssetLoader for FakeBsnLoader {
 
         let parent_bsn = bsn.parent_bsn.unwrap();
         let parent_bsn = load_context
-            .loader()
+            .load_builder()
             .load_async(parent_bsn)
             .await
             .map_err(|err| Error::new(ErrorKind::InvalidData, err))?;
@@ -949,7 +949,7 @@ fn asset_processor_loading_can_read_source_assets() {
                 // gltfx files come from "generic" software that doesn't know anything about
                 // Bevy, so it needs to load the source assets to make sense.
                 let gltf = load_context
-                    .loader()
+                    .load_builder()
                     .load_async(gltf)
                     .await
                     .map_err(|err| Error::new(ErrorKind::InvalidData, err))?;
@@ -1259,7 +1259,7 @@ fn nested_loads_of_processed_asset_reprocesses_on_reload() {
             Ok(match serialized {
                 NesterSerialized::Leaf(value) => Nester { value },
                 NesterSerialized::Path(path) => {
-                    let loaded_asset = load_context.loader().load_async(path).await.unwrap();
+                    let loaded_asset = load_context.load_builder().load_async(path).await.unwrap();
                     loaded_asset.take()
                 }
             })

--- a/crates/bevy_asset/src/processor/tests.rs
+++ b/crates/bevy_asset/src/processor/tests.rs
@@ -758,7 +758,7 @@ impl AssetLoader for FakeBsnLoader {
         let parent_bsn = bsn.parent_bsn.unwrap();
         let parent_bsn = load_context
             .load_builder()
-            .load_async(parent_bsn)
+            .load_value(parent_bsn)
             .await
             .map_err(|err| Error::new(ErrorKind::InvalidData, err))?;
         let mut new_bsn: FakeBsn = parent_bsn.take();
@@ -950,7 +950,7 @@ fn asset_processor_loading_can_read_source_assets() {
                 // Bevy, so it needs to load the source assets to make sense.
                 let gltf = load_context
                     .load_builder()
-                    .load_async(gltf)
+                    .load_value(gltf)
                     .await
                     .map_err(|err| Error::new(ErrorKind::InvalidData, err))?;
                 gltfs.push(gltf.take());
@@ -1259,7 +1259,7 @@ fn nested_loads_of_processed_asset_reprocesses_on_reload() {
             Ok(match serialized {
                 NesterSerialized::Leaf(value) => Nester { value },
                 NesterSerialized::Path(path) => {
-                    let loaded_asset = load_context.load_builder().load_async(path).await.unwrap();
+                    let loaded_asset = load_context.load_builder().load_value(path).await.unwrap();
                     loaded_asset.take()
                 }
             })

--- a/crates/bevy_asset/src/reflect.rs
+++ b/crates/bevy_asset/src/reflect.rs
@@ -409,7 +409,7 @@ impl LoadFromPath for LoadContext<'_> {
         type_id: TypeId,
         path: AssetPath<'static>,
     ) -> UntypedHandle {
-        self.loader().load_erased(type_id, path)
+        self.load_builder().load_erased(type_id, path)
     }
 }
 

--- a/crates/bevy_asset/src/reflect.rs
+++ b/crates/bevy_asset/src/reflect.rs
@@ -409,7 +409,7 @@ impl LoadFromPath for LoadContext<'_> {
         type_id: TypeId,
         path: AssetPath<'static>,
     ) -> UntypedHandle {
-        self.loader().with_dynamic_type(type_id).load(path)
+        self.loader().load_erased(type_id, path)
     }
 }
 

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -526,25 +526,7 @@ impl AssetServer {
             .load(path.into())
     }
 
-    pub(crate) fn load_with_meta_transform<'a, A: Asset, G: Send + Sync + 'static>(
-        &self,
-        path: impl Into<AssetPath<'a>>,
-        meta_transform: Option<MetaTransform>,
-        guard: G,
-        override_unapproved: bool,
-    ) -> Handle<A> {
-        self.load_with_meta_transform_erased(
-            path,
-            TypeId::of::<A>(),
-            Some(type_name::<A>()),
-            meta_transform,
-            guard,
-            override_unapproved,
-        )
-        .typed_unchecked()
-    }
-
-    pub(crate) fn load_with_meta_transform_erased<'a, G: Send + Sync + 'static>(
+    pub(crate) fn load_with_meta_transform<'a, G: Send + Sync + 'static>(
         &self,
         path: impl Into<AssetPath<'a>>,
         type_id: TypeId,
@@ -2070,7 +2052,7 @@ impl<'a> LoadBuilder<'a> {
         type_name: Option<&str>,
         asset_path: AssetPath<'_>,
     ) -> UntypedHandle {
-        self.asset_server.load_with_meta_transform_erased(
+        self.asset_server.load_with_meta_transform(
             asset_path,
             type_id,
             type_name,

--- a/crates/bevy_gltf/src/loader/mod.rs
+++ b/crates/bevy_gltf/src/loader/mod.rs
@@ -2017,7 +2017,7 @@ impl ImageOrPath {
                 sampler_descriptor,
                 render_asset_usages,
             } => load_context
-                .loader()
+                .load_builder()
                 .with_settings(move |settings: &mut ImageLoaderSettings| {
                     settings.is_srgb = is_srgb;
                     settings.sampler = ImageSampler::Descriptor(sampler_descriptor.clone());

--- a/examples/asset/asset_decompression.rs
+++ b/examples/asset/asset_decompression.rs
@@ -75,11 +75,8 @@ impl AssetLoader for GzAssetLoader {
         let mut reader = VecReader::new(bytes_uncompressed);
 
         let uncompressed = load_context
-            .loader()
-            .with_unknown_type()
-            .immediate()
-            .with_reader(&mut reader)
-            .load(contained_path)
+            .load_builder()
+            .load_untyped_async_from_reader(contained_path, &mut reader)
             .await?;
 
         Ok(GzAsset { uncompressed })

--- a/examples/asset/asset_decompression.rs
+++ b/examples/asset/asset_decompression.rs
@@ -76,7 +76,7 @@ impl AssetLoader for GzAssetLoader {
 
         let uncompressed = load_context
             .load_builder()
-            .load_untyped_async_from_reader(contained_path, &mut reader)
+            .load_untyped_value_from_reader(contained_path, &mut reader)
             .await?;
 
         Ok(GzAsset { uncompressed })

--- a/examples/asset/processing/asset_processing.rs
+++ b/examples/asset/processing/asset_processing.rs
@@ -150,20 +150,18 @@ impl AssetLoader for CoolTextLoader {
         let mut base_text = ron.text;
         for embedded in ron.embedded_dependencies {
             let loaded = load_context
-                .loader()
-                .immediate()
-                .load::<Text>(&embedded)
+                .load_builder()
+                .load_async::<Text>(&embedded)
                 .await?;
             base_text.push_str(&loaded.get().0);
         }
         for (path, settings_override) in ron.dependencies_with_settings {
             let loaded = load_context
-                .loader()
+                .load_builder()
                 .with_settings(move |settings| {
                     *settings = settings_override.clone();
                 })
-                .immediate()
-                .load::<Text>(&path)
+                .load_async::<Text>(&path)
                 .await?;
             base_text.push_str(&loaded.get().0);
         }

--- a/examples/asset/processing/asset_processing.rs
+++ b/examples/asset/processing/asset_processing.rs
@@ -151,7 +151,7 @@ impl AssetLoader for CoolTextLoader {
         for embedded in ron.embedded_dependencies {
             let loaded = load_context
                 .load_builder()
-                .load_async::<Text>(&embedded)
+                .load_value::<Text>(&embedded)
                 .await?;
             base_text.push_str(&loaded.get().0);
         }
@@ -161,7 +161,7 @@ impl AssetLoader for CoolTextLoader {
                 .with_settings(move |settings| {
                     *settings = settings_override.clone();
                 })
-                .load_async::<Text>(&path)
+                .load_value::<Text>(&path)
                 .await?;
             base_text.push_str(&loaded.get().0);
         }


### PR DESCRIPTION
# Objective

- Followup to #23663.
- Make the nested loading API easier to understand (when reading from docs.rs).

## Solution

- Remove the type-state stuff from `NestedLoader`. Make each way of calling load just be its own function.
- Add override_unapproved to the `NestedLoader`.
- Rename `NestedLoader` to `NestedLoadBuilder` (to match `LoadBuilder`).
- Rename `.loader()` to `.load_builder()` just like `AssetServer::load_builder`.

Some decisions:

- I included `override_unapproved` to match LoadBuilder. We could remove this to say "loaders shouldn't be able to override", but I don't think that's problematic, and I'd rather have it for completeness.
- I omitted `with_guard` from `NestedLoadBuilder`. This option doesn't really make sense, plus you could just use the async methods to do this instead.
- Since we omitted the `with_guard` (since it really doesn't make sense in this context), I decided not to reuse `LoadBuilder` in any way here. Either way, we need to deal with dependencies, so we couldn't just use it directly anyway.
- I just created all 9 load variants as separate methods. That's a lot compared to the 4 variants in LoadBuilder. We could reduce it to 6 load variants, if we kept the `with_reader` stuff as a type-state like we did with `NestedLoader`. I'm not a fan of how many variants we have, but I don't think there's a way to do this without opening up impossible configurations, like doing with_reader for a deferred call - this doesn't work!