### PR TITLE
Fix cleaning empty processed directories getting permanently stuck.

### DIFF
--- a/crates/bevy_asset/src/processor/mod.rs
+++ b/crates/bevy_asset/src/processor/mod.rs
@@ -984,13 +984,14 @@ impl AssetProcessor {
             .await;
     }
 
-    async fn clean_empty_processed_ancestor_folders(&self, source: &AssetSource, path: &Path) {
+    async fn clean_empty_processed_ancestor_folders(&self, source: &AssetSource, mut path: &Path) {
         // As a safety precaution don't delete absolute paths to avoid deleting folders outside of the destination folder
         if path.is_absolute() {
             error!("Attempted to clean up ancestor folders of an absolute path. This is unsafe so the operation was skipped.");
             return;
         }
         while let Some(parent) = path.parent() {
+            path = parent;
             if parent == Path::new("") {
                 break;
             }


### PR DESCRIPTION
# Objective

- Fix an obvious infinite loop.

## Solution

- Change `path` variable so we keep "going up" instead of repeatedly deleting the same path.

It's not clear what the actual effects may be, I just noticed this in the code but not an actual bug. I believe what would happen is the first delete would succeed, and then the second delete would error which would break the loop. This is clearly the wrong behavior though.

## Testing

- None.