### PR TITLE
Make sure #[track_caller] in EntityCommands::insert_if_neq works as intended

### DIFF
--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -27,6 +27,7 @@ use crate::{
     event::{EntityEvent, Event},
     message::Message,
     observer::{IntoEntityObserver, IntoObserver},
+    relationship::RelationshipHookMode,
     resource::Resource,
     schedule::ScheduleLabel,
     system::{
@@ -1485,12 +1486,20 @@ impl<'a> EntityCommands<'a> {
     /// missing.
     #[track_caller]
     pub fn insert_if_neq<T: Component + PartialEq>(&mut self, component: T) -> &mut Self {
+        let caller = MaybeLocation::caller();
+
         self.queue(move |mut entity: EntityWorldMut| {
             if entity
                 .get::<T>()
                 .is_none_or(|old_component| *old_component != component)
             {
-                entity.insert(component);
+                move_as_ptr!(component);
+                entity.insert_with_caller(
+                    component,
+                    InsertMode::Replace,
+                    caller,
+                    RelationshipHookMode::Run,
+                );
             }
         })
     }
@@ -2483,6 +2492,7 @@ impl<'a, T: Component> EntityEntryCommands<'a, T> {
 #[cfg(test)]
 mod tests {
     use crate::{
+        change_detection::MaybeLocation,
         component::Component,
         resource::Resource,
         system::Commands,
@@ -2737,6 +2747,34 @@ mod tests {
 
         assert_eq!(n_added, 1);
         assert_eq!(world.get::<P>(entity2).unwrap().0, 42);
+    }
+
+    #[test]
+    #[track_caller]
+    fn insert_component_if_not_equal_tracks_caller() {
+        use core::panic::Location;
+
+        #[derive(Component, PartialEq)]
+        struct P(u8);
+
+        let mut world = World::default();
+        let mut command_queue = CommandQueue::default();
+
+        let entity = Commands::new(&mut command_queue, &world)
+            .spawn(P(41u8))
+            .id();
+        command_queue.apply(&mut world);
+        world.clear_trackers();
+
+        Commands::new(&mut command_queue, &world)
+            .entity(entity)
+            .insert_if_neq(P(42u8));
+        command_queue.apply(&mut world);
+
+        assert_eq!(
+            world.entity(entity).get_changed_by::<P>().unwrap(),
+            MaybeLocation::new(Location::caller())
+        );
     }
 
     #[test]

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -2492,7 +2492,6 @@ impl<'a, T: Component> EntityEntryCommands<'a, T> {
 #[cfg(test)]
 mod tests {
     use crate::{
-        change_detection::MaybeLocation,
         component::Component,
         resource::Resource,
         system::Commands,
@@ -2749,8 +2748,8 @@ mod tests {
         assert_eq!(world.get::<P>(entity2).unwrap().0, 42);
     }
 
+    #[cfg(feature = "track_location")]
     #[test]
-    #[track_caller]
     fn insert_component_if_not_equal_tracks_caller() {
         use core::panic::Location;
 
@@ -2766,14 +2765,27 @@ mod tests {
         command_queue.apply(&mut world);
         world.clear_trackers();
 
-        Commands::new(&mut command_queue, &world)
-            .entity(entity)
-            .insert_if_neq(P(42u8));
+        macro_rules! insert_if_neq_with_expected_caller {
+            ($commands:expr, $entity:expr, $component:expr) => {{
+                $commands.entity($entity).insert_if_neq($component);
+                Location::caller()
+            }};
+        }
+
+        let expected = insert_if_neq_with_expected_caller!(
+            Commands::new(&mut command_queue, &world),
+            entity,
+            P(42u8)
+        );
         command_queue.apply(&mut world);
 
         assert_eq!(
-            world.entity(entity).get_changed_by::<P>().unwrap(),
-            MaybeLocation::new(Location::caller())
+            world
+                .entity(entity)
+                .get_changed_by::<P>()
+                .unwrap()
+                .into_option(),
+            Some(expected)
         );
     }
 


### PR DESCRIPTION
intended

# Objective

Fixes https://github.com/bevyengine/bevy/issues/23962

## Solution

As suggested in the issue: "go back to insert_with_caller so that we can call MaybeLocation::caller() outside of the closure and then pass it through explicitly".

## Testing

Added a unit test and made sure it fails without the fix.

