### PR TITLE
Add more derives for `ScheduleCleanupPolicy`

### DIFF
--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -1461,7 +1461,7 @@ impl ProcessScheduleConfig for InternedSystemSet {
 }
 
 /// Policy to use when removing systems.
-#[derive(Default)]
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ScheduleCleanupPolicy {
     /// Remove the referenced set and any systems in the set.
     /// Attempts to maintain the order between the transitive dependencies by adding new edges


### PR DESCRIPTION
In my own API I want to pass a single value of `ScheduleCleanupPolicy` to multiple methods taking it as an argument. Without `Clone`/`Copy` this is not possible.

I added the required derives. Felt free to add a few more.