### PR TITLE
Change `AssetPath::path` to be a `CowArc<'_, str>` instead of a `CowArc<'_, Path>`

### DIFF
--- a/_release-content/migration-guides/asset_path_string.md
+++ b/_release-content/migration-guides/asset_path_string.md
@@ -1,0 +1,31 @@
+---
+title: AssetPath now stores a str instead of a Path.
+pull_requests: [23992]
+---
+
+In previous versions of Bevy, `AssetPath` internally stored `CowArc<'_, Path>`. This awkwardly took
+our platform-agnostic asset system and coupled it to the path representation of the target platform.
+This could result in different behavior of asset paths depending on what platform you authored
+assets on versus what platform you compile for.
+
+Now, `AssetPath` internally stores `CowArc<'_, str>`. This means the handling of paths is entirely
+up to us (and users). The advantage is now the platform is **only** relevant when interacting with
+the non-platform-agnostic asset sources. This also allows asset sources to be more flexible in their
+implementations, allowing the path to be a more free-form descriptor.
+
+Of course, handling raw strings is not ideal, so we've created utilities for common path operations.
+Below is a list of some common `Path` operations and their equivalent:
+
+- `path.extension()` -> `path_file_extension(path)`
+- `path.file_name()` -> `path_basename(path)`
+- `path.parent()` -> `path_parent(path)`
+- `path.is_absolute()` -> `is_absolute_path(path)`
+- `path.ancestors()` -> `path_ancestors(path)`
+- `path.join(other)` -> `join_paths(path, other)`
+- `path.components()` *or* `path.iter()` -> `path_components(path)`
+
+When creating asset paths, also consider using `clean_path` to convert raw paths (which may contain
+platform-specific features) into platform-agnostic paths.
+
+In addition, `AssetPath::from_path` and `AssetPath::from_path_buf` have been replaced by
+`AssetPath::from_str_path` and `AssetPath::from_string_path` respectively.

--- a/benches/benches/bevy_scene/spawn.rs
+++ b/benches/benches/bevy_scene/spawn.rs
@@ -1,7 +1,7 @@
 use bevy_reflect::TypePath;
 use criterion::{criterion_group, Criterion};
 use glam::Mat4;
-use std::{path::Path, time::Duration};
+use std::time::Duration;
 
 use bevy_app::App;
 use bevy_asset::{
@@ -40,7 +40,7 @@ fn spawn(c: &mut Criterion) {
         );
 
         // Insert an asset that the fake loader can fake read.
-        dir.insert_asset_text(Path::new("button.bsn"), "");
+        dir.insert_asset_text("button.bsn", "");
 
         let asset_server = app.world().resource::<AssetServer>().clone();
         let handle = asset_server.load("button.bsn");
@@ -84,7 +84,7 @@ fn spawn(c: &mut Criterion) {
             },
         );
 
-        dir.insert_asset_text(Path::new("a.bsn"), "");
+        dir.insert_asset_text("a.bsn", "");
 
         let asset_server = app.world().resource::<AssetServer>().clone();
         let handle = asset_server.load::<ScenePatch>("a.bsn");
@@ -111,7 +111,7 @@ fn spawn(c: &mut Criterion) {
             },
         );
 
-        dir.insert_asset_text(Path::new("a.bsn"), "");
+        dir.insert_asset_text("a.bsn", "");
 
         let asset_server = app.world().resource::<AssetServer>().clone();
         let handle = asset_server.load::<ScenePatch>("a.bsn");

--- a/crates/bevy_asset/src/io/embedded/embedded_watcher.rs
+++ b/crates/bevy_asset/src/io/embedded/embedded_watcher.rs
@@ -3,7 +3,7 @@ use crate::io::{
     memory::Dir,
     AssetSourceEvent, AssetWatcher,
 };
-use alloc::{boxed::Box, sync::Arc, vec::Vec};
+use alloc::{boxed::Box, string::String, sync::Arc, vec::Vec};
 use bevy_platform::collections::HashMap;
 use bevy_platform::sync::{PoisonError, RwLock};
 use core::time::Duration;
@@ -27,7 +27,7 @@ impl EmbeddedWatcher {
     /// Creates a new `EmbeddedWatcher` that watches for changes to the embedded assets in the given `dir`.
     pub fn new(
         dir: Dir,
-        root_paths: Arc<RwLock<HashMap<Box<Path>, PathBuf>>>,
+        root_paths: Arc<RwLock<HashMap<Box<str>, String>>>,
         sender: async_channel::Sender<AssetSourceEvent>,
         debounce_wait_time: Duration,
     ) -> Self {
@@ -51,7 +51,7 @@ impl AssetWatcher for EmbeddedWatcher {}
 /// the initial static bytes from the file embedded in the binary.
 pub(crate) struct EmbeddedEventHandler {
     sender: async_channel::Sender<AssetSourceEvent>,
-    root_paths: Arc<RwLock<HashMap<Box<Path>, PathBuf>>>,
+    root_paths: Arc<RwLock<HashMap<Box<str>, String>>>,
     root: PathBuf,
     dir: Dir,
     last_event: Option<AssetSourceEvent>,
@@ -62,13 +62,13 @@ impl FilesystemEventHandler for EmbeddedEventHandler {
         self.last_event = None;
     }
 
-    fn get_path(&self, absolute_path: &Path) -> Option<(PathBuf, bool)> {
+    fn get_path(&self, absolute_path: &Path) -> Option<(String, bool)> {
         let (local_path, is_meta) = get_asset_path(&self.root, absolute_path);
         let final_path = self
             .root_paths
             .read()
             .unwrap_or_else(PoisonError::into_inner)
-            .get(local_path.as_path())?
+            .get(local_path.as_str())?
             .clone();
         if is_meta {
             warn!("Meta file asset hot-reloading is not supported yet: {final_path:?}");

--- a/crates/bevy_asset/src/io/embedded/mod.rs
+++ b/crates/bevy_asset/src/io/embedded/mod.rs
@@ -4,17 +4,23 @@ mod embedded_watcher;
 #[cfg(feature = "embedded_watcher")]
 pub use embedded_watcher::*;
 
-use crate::io::{
-    memory::{Dir, MemoryAssetReader, Value},
-    AssetSourceBuilder, AssetSourceBuilders,
+use crate::{
+    clean_path,
+    io::{
+        memory::{Dir, MemoryAssetReader, Value},
+        AssetSourceBuilder, AssetSourceBuilders,
+    },
+    path_parent,
 };
-use crate::AssetServer;
-use alloc::boxed::Box;
+use crate::{join_paths, AssetServer};
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+};
 use bevy_app::App;
 use bevy_ecs::{resource::Resource, world::World};
 #[cfg(feature = "embedded_watcher")]
 use bevy_platform::sync::{Arc, PoisonError, RwLock};
-use std::path::{Path, PathBuf};
 
 #[cfg(feature = "embedded_watcher")]
 use alloc::borrow::ToOwned;
@@ -32,7 +38,7 @@ pub const EMBEDDED: &str = "embedded";
 pub struct EmbeddedAssetRegistry {
     dir: Dir,
     #[cfg(feature = "embedded_watcher")]
-    root_paths: Arc<RwLock<bevy_platform::collections::HashMap<Box<Path>, PathBuf>>>,
+    root_paths: Arc<RwLock<bevy_platform::collections::HashMap<Box<str>, String>>>,
 }
 
 impl EmbeddedAssetRegistry {
@@ -47,12 +53,12 @@ impl EmbeddedAssetRegistry {
             reason = "The `full_path` argument is not used when `embedded_watcher` is disabled."
         )
     )]
-    pub fn insert_asset(&self, full_path: PathBuf, asset_path: &Path, value: impl Into<Value>) {
+    pub fn insert_asset(&self, full_path: String, asset_path: &str, value: impl Into<Value>) {
         #[cfg(feature = "embedded_watcher")]
         self.root_paths
             .write()
             .unwrap_or_else(PoisonError::into_inner)
-            .insert(full_path.into(), asset_path.to_owned());
+            .insert(full_path.into(), asset_path.to_string());
         self.dir.insert_asset(asset_path, value);
     }
 
@@ -67,7 +73,7 @@ impl EmbeddedAssetRegistry {
             reason = "The `full_path` argument is not used when `embedded_watcher` is disabled."
         )
     )]
-    pub fn insert_meta(&self, full_path: &Path, asset_path: &Path, value: impl Into<Value>) {
+    pub fn insert_meta(&self, full_path: &str, asset_path: &str, value: impl Into<Value>) {
         #[cfg(feature = "embedded_watcher")]
         self.root_paths
             .write()
@@ -79,7 +85,7 @@ impl EmbeddedAssetRegistry {
     /// Removes an asset stored using `full_path` (the full path as [`file`] would return for that file, if it was capable of
     /// running in a non-rust file). If no asset is stored with at `full_path` its a no-op.
     /// It returning `Option` contains the originally stored `Data` or `None`.
-    pub fn remove_asset(&self, full_path: &Path) -> Option<super::memory::Data> {
+    pub fn remove_asset(&self, full_path: &str) -> Option<super::memory::Data> {
         self.dir.remove_asset(full_path)
     }
 
@@ -191,7 +197,7 @@ impl GetAssetServer for AssetServer {
 macro_rules! load_embedded_asset {
     (@get: $path: literal, $provider: expr) => {{
         let path = $crate::embedded_path!($path);
-        let path = $crate::AssetPath::from_path_buf(path).with_source("embedded");
+        let path = $crate::AssetPath::from_string_path(path).with_source("embedded");
         let asset_server = $crate::io::embedded::GetAssetServer::get_asset_server($provider);
         (path, asset_server)
     }};
@@ -205,8 +211,8 @@ macro_rules! load_embedded_asset {
     }};
 }
 
-/// Returns the [`Path`] for a given `embedded` asset.
-/// This is used internally by [`embedded_asset`] and can be used to get a [`Path`]
+/// Returns the [`String`] path for a given `embedded` asset.
+/// This is used internally by [`embedded_asset`] and can be used to get a [`String`] path
 /// that matches the [`AssetPath`](crate::AssetPath) used by that asset.
 ///
 /// [`embedded_asset`]: crate::embedded_asset
@@ -218,12 +224,7 @@ macro_rules! embedded_path {
 
     ($source_path: expr, $path_str: expr) => {{
         let crate_name = module_path!().split(':').next().unwrap();
-        $crate::io::embedded::_embedded_asset_path(
-            crate_name,
-            $source_path.as_ref(),
-            file!().as_ref(),
-            $path_str.as_ref(),
-        )
+        $crate::io::embedded::_embedded_asset_path(crate_name, $source_path, file!(), $path_str)
     }};
 }
 
@@ -237,29 +238,27 @@ macro_rules! embedded_path {
 #[doc(hidden)]
 pub fn _embedded_asset_path(
     crate_name: &str,
-    src_prefix: &Path,
-    file_path: &Path,
-    asset_path: &Path,
-) -> PathBuf {
-    let file_path = if cfg!(not(target_family = "windows")) {
-        // Work around bug: https://github.com/bevyengine/bevy/issues/14246
-        // Note, this will break any paths on Linux/Mac containing "\"
-        PathBuf::from(file_path.to_str().unwrap().replace("\\", "/"))
-    } else {
-        PathBuf::from(file_path)
-    };
-    let mut maybe_parent = file_path.parent();
+    src_prefix: &str,
+    file_path: &str,
+    asset_path: &str,
+) -> String {
+    let file_path = clean_path(file_path);
+    let mut maybe_parent = path_parent(&file_path);
     let after_src = loop {
         let Some(parent) = maybe_parent else {
             panic!("Failed to find src_prefix {src_prefix:?} in {file_path:?}")
         };
         if parent.ends_with(src_prefix) {
-            break file_path.strip_prefix(parent).unwrap();
+            let relative_path = file_path.strip_prefix(parent).unwrap();
+            // Also remove the slash for the parent.
+            break &relative_path[1..];
         }
-        maybe_parent = parent.parent();
+        maybe_parent = path_parent(parent);
     };
-    let asset_path = after_src.parent().unwrap().join(asset_path);
-    Path::new(crate_name).join(asset_path)
+    let asset_path = path_parent(after_src)
+        .map(|parent| join_paths(parent, asset_path))
+        .unwrap_or_else(|| asset_path.to_string());
+    join_paths(crate_name, &asset_path)
 }
 
 /// Creates a new `embedded` asset by embedding the bytes of the given path into the current binary
@@ -353,18 +352,18 @@ macro_rules! embedded_asset {
 /// Returns the path used by the watcher.
 #[doc(hidden)]
 #[cfg(feature = "embedded_watcher")]
-pub fn watched_path(source_file_path: &'static str, asset_path: &'static str) -> PathBuf {
-    PathBuf::from(source_file_path)
-        .parent()
-        .unwrap()
-        .join(asset_path)
+pub fn watched_path(source_file_path: &'static str, asset_path: &'static str) -> String {
+    join_paths(
+        path_parent(&clean_path(source_file_path)).unwrap(),
+        asset_path,
+    )
 }
 
 /// Returns an empty PathBuf.
 #[doc(hidden)]
 #[cfg(not(feature = "embedded_watcher"))]
-pub fn watched_path(_source_file_path: &'static str, _asset_path: &'static str) -> PathBuf {
-    PathBuf::from("")
+pub fn watched_path(_source_file_path: &'static str, _asset_path: &'static str) -> String {
+    String::new()
 }
 
 /// Loads an "internal" asset by embedding the string stored in the given `path_str` and associates it with the given handle.
@@ -421,7 +420,7 @@ macro_rules! load_internal_binary_asset {
 #[cfg(test)]
 mod tests {
     use super::{_embedded_asset_path, EmbeddedAssetRegistry};
-    use std::path::Path;
+    use alloc::string::ToString;
 
     // Relative paths show up if this macro is being invoked by a local crate.
     // In this case we know the relative path is a sub- path of the workspace
@@ -429,13 +428,9 @@ mod tests {
 
     #[test]
     fn embedded_asset_path_from_local_crate() {
-        let asset_path = _embedded_asset_path(
-            "my_crate",
-            "src".as_ref(),
-            "src/foo/plugin.rs".as_ref(),
-            "the/asset.png".as_ref(),
-        );
-        assert_eq!(asset_path, Path::new("my_crate/foo/the/asset.png"));
+        let asset_path =
+            _embedded_asset_path("my_crate", "src", "src/foo/plugin.rs", "the/asset.png");
+        assert_eq!(asset_path, "my_crate/foo/the/asset.png");
     }
 
     // A blank src_path removes the embedded's file path altogether only the
@@ -444,11 +439,11 @@ mod tests {
     fn embedded_asset_path_from_local_crate_blank_src_path_questionable() {
         let asset_path = _embedded_asset_path(
             "my_crate",
-            "".as_ref(),
-            "src/foo/some/deep/path/plugin.rs".as_ref(),
-            "the/asset.png".as_ref(),
+            "",
+            "src/foo/some/deep/path/plugin.rs",
+            "the/asset.png",
         );
-        assert_eq!(asset_path, Path::new("my_crate/the/asset.png"));
+        assert_eq!(asset_path, "my_crate/the/asset.png");
     }
 
     #[test]
@@ -456,9 +451,9 @@ mod tests {
     fn embedded_asset_path_from_local_crate_bad_src() {
         let _asset_path = _embedded_asset_path(
             "my_crate",
-            "NOT-THERE".as_ref(),
-            "src/foo/plugin.rs".as_ref(),
-            "the/asset.png".as_ref(),
+            "NOT-THERE",
+            "src/foo/plugin.rs",
+            "the/asset.png",
         );
     }
 
@@ -466,11 +461,11 @@ mod tests {
     fn embedded_asset_path_from_local_example_crate() {
         let asset_path = _embedded_asset_path(
             "example_name",
-            "examples/foo".as_ref(),
-            "examples/foo/example.rs".as_ref(),
-            "the/asset.png".as_ref(),
+            "examples/foo",
+            "examples/foo/example.rs",
+            "the/asset.png",
         );
-        assert_eq!(asset_path, Path::new("example_name/the/asset.png"));
+        assert_eq!(asset_path, "example_name/the/asset.png");
     }
 
     // Absolute paths show up if this macro is being invoked by an external
@@ -479,22 +474,22 @@ mod tests {
     fn embedded_asset_path_from_external_crate() {
         let asset_path = _embedded_asset_path(
             "my_crate",
-            "src".as_ref(),
-            "/path/to/crate/src/foo/plugin.rs".as_ref(),
-            "the/asset.png".as_ref(),
+            "src",
+            "/path/to/crate/src/foo/plugin.rs",
+            "the/asset.png",
         );
-        assert_eq!(asset_path, Path::new("my_crate/foo/the/asset.png"));
+        assert_eq!(asset_path, "my_crate/foo/the/asset.png");
     }
 
     #[test]
     fn embedded_asset_path_from_external_crate_root_src_path() {
         let asset_path = _embedded_asset_path(
             "my_crate",
-            "/path/to/crate/src".as_ref(),
-            "/path/to/crate/src/foo/plugin.rs".as_ref(),
-            "the/asset.png".as_ref(),
+            "/path/to/crate/src",
+            "/path/to/crate/src/foo/plugin.rs",
+            "the/asset.png",
         );
-        assert_eq!(asset_path, Path::new("my_crate/foo/the/asset.png"));
+        assert_eq!(asset_path, "my_crate/foo/the/asset.png");
     }
 
     // Although extraneous slashes are permitted at the end, e.g., "src////",
@@ -504,11 +499,11 @@ mod tests {
     fn embedded_asset_path_from_external_crate_extraneous_beginning_slashes() {
         let asset_path = _embedded_asset_path(
             "my_crate",
-            "////src".as_ref(),
-            "/path/to/crate/src/foo/plugin.rs".as_ref(),
-            "the/asset.png".as_ref(),
+            "////src",
+            "/path/to/crate/src/foo/plugin.rs",
+            "the/asset.png",
         );
-        assert_eq!(asset_path, Path::new("my_crate/foo/the/asset.png"));
+        assert_eq!(asset_path, "my_crate/foo/the/asset.png");
     }
 
     // We don't handle this edge case because it is ambiguous with the
@@ -517,22 +512,22 @@ mod tests {
     fn embedded_asset_path_from_external_crate_is_ambiguous() {
         let asset_path = _embedded_asset_path(
             "my_crate",
-            "src".as_ref(),
-            "/path/to/.cargo/registry/src/crate/src/src/plugin.rs".as_ref(),
-            "the/asset.png".as_ref(),
+            "src",
+            "/path/to/.cargo/registry/src/crate/src/src/plugin.rs",
+            "the/asset.png",
         );
         // Really, should be "my_crate/src/the/asset.png"
-        assert_eq!(asset_path, Path::new("my_crate/the/asset.png"));
+        assert_eq!(asset_path, "my_crate/the/asset.png");
     }
 
     #[test]
     fn remove_embedded_asset() {
         let reg = EmbeddedAssetRegistry::default();
-        let path = std::path::PathBuf::from("a/b/asset.png");
-        reg.insert_asset(path.clone(), &path, &[]);
-        assert!(reg.dir.get_asset(&path).is_some());
-        assert!(reg.remove_asset(&path).is_some());
-        assert!(reg.dir.get_asset(&path).is_none());
-        assert!(reg.remove_asset(&path).is_none());
+        let path = "a/b/asset.png";
+        reg.insert_asset(path.to_string(), &path, &[]);
+        assert!(reg.dir.get_asset(path).is_some());
+        assert!(reg.remove_asset(path).is_some());
+        assert!(reg.dir.get_asset(path).is_none());
+        assert!(reg.remove_asset(path).is_none());
     }
 }

--- a/crates/bevy_asset/src/io/file/file_asset.rs
+++ b/crates/bevy_asset/src/io/file/file_asset.rs
@@ -1,6 +1,9 @@
-use crate::io::{
-    get_meta_path, AssetReader, AssetReaderError, AssetWriter, AssetWriterError, PathStream,
-    Reader, ReaderNotSeekableError, SeekableReader, Writer,
+use crate::{
+    clean_path,
+    io::{
+        get_meta_path, AssetReader, AssetReaderError, AssetWriter, AssetWriterError, PathStream,
+        Reader, ReaderNotSeekableError, SeekableReader, Writer,
+    },
 };
 use async_fs::{read_dir, File};
 #[cfg(not(target_os = "windows"))]
@@ -9,7 +12,7 @@ use async_io::Timer;
 use async_lock::{Semaphore, SemaphoreGuard};
 use futures_lite::StreamExt;
 
-use alloc::{borrow::ToOwned, boxed::Box};
+use alloc::{boxed::Box, string::ToString};
 #[cfg(target_os = "windows")]
 use core::marker::PhantomData;
 #[cfg(not(target_os = "windows"))]
@@ -72,7 +75,7 @@ impl<'a> Reader for GuardedFile<'a> {
 }
 
 impl AssetReader for FileAssetReader {
-    async fn read<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
+    async fn read<'a>(&'a self, path: &'a str) -> Result<impl Reader + 'a, AssetReaderError> {
         #[cfg(not(target_os = "windows"))]
         let _guard = maybe_get_semaphore().await;
 
@@ -81,7 +84,7 @@ impl AssetReader for FileAssetReader {
             .await
             .map_err(|e| {
                 if e.kind() == std::io::ErrorKind::NotFound {
-                    AssetReaderError::NotFound(full_path)
+                    AssetReaderError::NotFound(full_path.to_string_lossy().to_string())
                 } else {
                     e.into()
                 }
@@ -95,17 +98,17 @@ impl AssetReader for FileAssetReader {
             })
     }
 
-    async fn read_meta<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
+    async fn read_meta<'a>(&'a self, path: &'a str) -> Result<impl Reader + 'a, AssetReaderError> {
         #[cfg(not(target_os = "windows"))]
         let _guard = maybe_get_semaphore().await;
 
-        let meta_path = get_meta_path(path);
+        let meta_path = get_meta_path(Path::new(path));
         let full_path = self.root_path.join(meta_path);
         File::open(&full_path)
             .await
             .map_err(|e| {
                 if e.kind() == std::io::ErrorKind::NotFound {
-                    AssetReaderError::NotFound(full_path)
+                    AssetReaderError::NotFound(full_path.to_string_lossy().to_string())
                 } else {
                     e.into()
                 }
@@ -121,7 +124,7 @@ impl AssetReader for FileAssetReader {
 
     async fn read_directory<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> Result<Box<PathStream>, AssetReaderError> {
         let full_path = self.root_path.join(path);
         match read_dir(&full_path).await {
@@ -146,7 +149,7 @@ impl AssetReader for FileAssetReader {
                             return None;
                         }
                         let relative_path = path.strip_prefix(&root_path).unwrap();
-                        Some(relative_path.to_owned())
+                        Some(clean_path(relative_path.to_string_lossy().as_ref()).to_string())
                     })
                 });
                 let read_dir: Box<PathStream> = Box::new(mapped_stream);
@@ -154,7 +157,9 @@ impl AssetReader for FileAssetReader {
             }
             Err(e) => {
                 if e.kind() == std::io::ErrorKind::NotFound {
-                    Err(AssetReaderError::NotFound(full_path))
+                    Err(AssetReaderError::NotFound(
+                        full_path.to_string_lossy().to_string(),
+                    ))
                 } else {
                     Err(e.into())
                 }
@@ -162,17 +167,17 @@ impl AssetReader for FileAssetReader {
         }
     }
 
-    async fn is_directory<'a>(&'a self, path: &'a Path) -> Result<bool, AssetReaderError> {
+    async fn is_directory<'a>(&'a self, path: &'a str) -> Result<bool, AssetReaderError> {
         let full_path = self.root_path.join(path);
         let metadata = full_path
             .metadata()
-            .map_err(|_e| AssetReaderError::NotFound(path.to_owned()))?;
+            .map_err(|_e| AssetReaderError::NotFound(full_path.to_string_lossy().to_string()))?;
         Ok(metadata.file_type().is_dir())
     }
 }
 
 impl AssetWriter for FileAssetWriter {
-    async fn write<'a>(&'a self, path: &'a Path) -> Result<Box<Writer>, AssetWriterError> {
+    async fn write<'a>(&'a self, path: &'a str) -> Result<Box<Writer>, AssetWriterError> {
         let full_path = self.root_path.join(path);
         if let Some(parent) = full_path.parent() {
             async_fs::create_dir_all(parent).await?;
@@ -182,8 +187,8 @@ impl AssetWriter for FileAssetWriter {
         Ok(writer)
     }
 
-    async fn write_meta<'a>(&'a self, path: &'a Path) -> Result<Box<Writer>, AssetWriterError> {
-        let meta_path = get_meta_path(path);
+    async fn write_meta<'a>(&'a self, path: &'a str) -> Result<Box<Writer>, AssetWriterError> {
+        let meta_path = get_meta_path(Path::new(path));
         let full_path = self.root_path.join(meta_path);
         if let Some(parent) = full_path.parent() {
             async_fs::create_dir_all(parent).await?;
@@ -193,14 +198,14 @@ impl AssetWriter for FileAssetWriter {
         Ok(writer)
     }
 
-    async fn remove<'a>(&'a self, path: &'a Path) -> Result<(), AssetWriterError> {
+    async fn remove<'a>(&'a self, path: &'a str) -> Result<(), AssetWriterError> {
         let full_path = self.root_path.join(path);
         async_fs::remove_file(full_path).await?;
         Ok(())
     }
 
-    async fn remove_meta<'a>(&'a self, path: &'a Path) -> Result<(), AssetWriterError> {
-        let meta_path = get_meta_path(path);
+    async fn remove_meta<'a>(&'a self, path: &'a str) -> Result<(), AssetWriterError> {
+        let meta_path = get_meta_path(Path::new(path));
         let full_path = self.root_path.join(meta_path);
         async_fs::remove_file(full_path).await?;
         Ok(())
@@ -208,8 +213,8 @@ impl AssetWriter for FileAssetWriter {
 
     async fn rename<'a>(
         &'a self,
-        old_path: &'a Path,
-        new_path: &'a Path,
+        old_path: &'a str,
+        new_path: &'a str,
     ) -> Result<(), AssetWriterError> {
         let full_old_path = self.root_path.join(old_path);
         let full_new_path = self.root_path.join(new_path);
@@ -222,11 +227,11 @@ impl AssetWriter for FileAssetWriter {
 
     async fn rename_meta<'a>(
         &'a self,
-        old_path: &'a Path,
-        new_path: &'a Path,
+        old_path: &'a str,
+        new_path: &'a str,
     ) -> Result<(), AssetWriterError> {
-        let old_meta_path = get_meta_path(old_path);
-        let new_meta_path = get_meta_path(new_path);
+        let old_meta_path = get_meta_path(Path::new(old_path));
+        let new_meta_path = get_meta_path(Path::new(new_path));
         let full_old_path = self.root_path.join(old_meta_path);
         let full_new_path = self.root_path.join(new_meta_path);
         if let Some(parent) = full_new_path.parent() {
@@ -236,19 +241,19 @@ impl AssetWriter for FileAssetWriter {
         Ok(())
     }
 
-    async fn create_directory<'a>(&'a self, path: &'a Path) -> Result<(), AssetWriterError> {
+    async fn create_directory<'a>(&'a self, path: &'a str) -> Result<(), AssetWriterError> {
         let full_path = self.root_path.join(path);
         async_fs::create_dir_all(full_path).await?;
         Ok(())
     }
 
-    async fn remove_directory<'a>(&'a self, path: &'a Path) -> Result<(), AssetWriterError> {
+    async fn remove_directory<'a>(&'a self, path: &'a str) -> Result<(), AssetWriterError> {
         let full_path = self.root_path.join(path);
         async_fs::remove_dir_all(full_path).await?;
         Ok(())
     }
 
-    async fn remove_empty_directory<'a>(&'a self, path: &'a Path) -> Result<(), AssetWriterError> {
+    async fn remove_empty_directory<'a>(&'a self, path: &'a str) -> Result<(), AssetWriterError> {
         let full_path = self.root_path.join(path);
         async_fs::remove_dir(full_path).await?;
         Ok(())
@@ -256,7 +261,7 @@ impl AssetWriter for FileAssetWriter {
 
     async fn remove_assets_in_directory<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> Result<(), AssetWriterError> {
         let full_path = self.root_path.join(path);
         async_fs::remove_dir_all(&full_path).await?;

--- a/crates/bevy_asset/src/io/file/file_watcher.rs
+++ b/crates/bevy_asset/src/io/file/file_watcher.rs
@@ -2,7 +2,11 @@ use crate::{
     io::{AssetSourceEvent, AssetWatcher},
     path::normalize_path,
 };
-use alloc::{borrow::ToOwned, vec::Vec};
+use alloc::{
+    borrow::Cow,
+    string::{String, ToString},
+    vec::Vec,
+};
 use async_channel::Sender;
 use core::time::Duration;
 use notify_debouncer_full::{
@@ -56,10 +60,17 @@ fn make_absolute_path(path: &Path) -> Result<PathBuf, std::io::Error> {
     // We use `normalize` + `absolute` instead of `canonicalize` to avoid reading the filesystem to
     // resolve the path. This also means that paths that no longer exist can still become absolute
     // (e.g., a file that was renamed will have the "old" path no longer exist).
-    Ok(normalize_path(&std::path::absolute(path)?))
+    Ok(PathBuf::from(normalize_path(
+        std::path::absolute(path)?.to_str().ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidFilename,
+                "Cannot convert path to absolute path",
+            )
+        })?,
+    )))
 }
 
-pub(crate) fn get_asset_path(root: &Path, absolute_path: &Path) -> (PathBuf, bool) {
+pub(crate) fn get_asset_path(root: &Path, absolute_path: &Path) -> (String, bool) {
     let relative_path = absolute_path.strip_prefix(root).unwrap_or_else(|_| {
         panic!(
             "FileWatcher::get_asset_path() failed to strip prefix from absolute path: absolute_path={}, root={}",
@@ -69,11 +80,11 @@ pub(crate) fn get_asset_path(root: &Path, absolute_path: &Path) -> (PathBuf, boo
     });
     let is_meta = relative_path.extension().is_some_and(|e| e == "meta");
     let asset_path = if is_meta {
-        relative_path.with_extension("")
+        Cow::Owned(relative_path.with_extension(""))
     } else {
-        relative_path.to_owned()
+        Cow::Borrowed(relative_path)
     };
-    (asset_path, is_meta)
+    (asset_path.to_string_lossy().to_string(), is_meta)
 }
 
 /// This is a bit more abstracted than it normally would be because we want to try _very hard_ not to duplicate this
@@ -259,7 +270,7 @@ impl FilesystemEventHandler for FileEventHandler {
     fn begin(&mut self) {
         self.last_event = None;
     }
-    fn get_path(&self, absolute_path: &Path) -> Option<(PathBuf, bool)> {
+    fn get_path(&self, absolute_path: &Path) -> Option<(String, bool)> {
         Some(get_asset_path(&self.root, absolute_path))
     }
 
@@ -276,7 +287,7 @@ pub(crate) trait FilesystemEventHandler: Send + Sync + 'static {
     fn begin(&mut self);
     /// Returns an actual asset path (if one exists for the given `absolute_path`), as well as a [`bool`] that is
     /// true if the `absolute_path` corresponds to a meta file.
-    fn get_path(&self, absolute_path: &Path) -> Option<(PathBuf, bool)>;
+    fn get_path(&self, absolute_path: &Path) -> Option<(String, bool)>;
     /// Handle the given event
     fn handle(&mut self, absolute_paths: &[PathBuf], event: AssetSourceEvent);
 }

--- a/crates/bevy_asset/src/io/file/sync_file_asset.rs
+++ b/crates/bevy_asset/src/io/file/sync_file_asset.rs
@@ -6,12 +6,16 @@ use crate::io::{
     PathStream, Reader, ReaderNotSeekableError, SeekableReader, Writer,
 };
 
-use alloc::{borrow::ToOwned, boxed::Box, vec::Vec};
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+    vec::Vec,
+};
 use core::{pin::Pin, task::Poll};
 use std::{
     fs::{read_dir, File},
     io::{Read, Seek, SeekFrom, Write},
-    path::{Path, PathBuf},
+    path::Path,
 };
 
 use super::{FileAssetReader, FileAssetWriter};
@@ -84,10 +88,10 @@ impl AsyncWrite for FileWriter {
     }
 }
 
-struct DirReader(Vec<PathBuf>);
+struct DirReader(Vec<String>);
 
 impl Stream for DirReader {
-    type Item = PathBuf;
+    type Item = String;
 
     fn poll_next(
         self: Pin<&mut Self>,
@@ -99,13 +103,15 @@ impl Stream for DirReader {
 }
 
 impl AssetReader for FileAssetReader {
-    async fn read<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
+    async fn read<'a>(&'a self, path: &'a str) -> Result<impl Reader + 'a, AssetReaderError> {
         let full_path = self.root_path.join(path);
         match File::open(&full_path) {
             Ok(file) => Ok(FileReader(file)),
             Err(e) => {
                 if e.kind() == std::io::ErrorKind::NotFound {
-                    Err(AssetReaderError::NotFound(full_path))
+                    Err(AssetReaderError::NotFound(
+                        full_path.to_string_lossy().to_string(),
+                    ))
                 } else {
                     Err(e.into())
                 }
@@ -113,14 +119,16 @@ impl AssetReader for FileAssetReader {
         }
     }
 
-    async fn read_meta<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
-        let meta_path = get_meta_path(path);
+    async fn read_meta<'a>(&'a self, path: &'a str) -> Result<impl Reader + 'a, AssetReaderError> {
+        let meta_path = get_meta_path(Path::new(path));
         let full_path = self.root_path.join(meta_path);
         match File::open(&full_path) {
             Ok(file) => Ok(FileReader(file)),
             Err(e) => {
                 if e.kind() == std::io::ErrorKind::NotFound {
-                    Err(AssetReaderError::NotFound(full_path))
+                    Err(AssetReaderError::NotFound(
+                        full_path.to_string_lossy().to_string(),
+                    ))
                 } else {
                     Err(e.into())
                 }
@@ -130,7 +138,7 @@ impl AssetReader for FileAssetReader {
 
     async fn read_directory<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> Result<Box<PathStream>, AssetReaderError> {
         let full_path = self.root_path.join(path);
         match read_dir(&full_path) {
@@ -155,8 +163,9 @@ impl AssetReader for FileAssetReader {
                             return None;
                         }
 
-                        let relative_path = path.strip_prefix(&root_path).unwrap();
-                        Some(relative_path.to_owned())
+                        let relative_path =
+                            path.strip_prefix(&root_path).unwrap().to_string_lossy();
+                        Some(relative_path.to_string())
                     })
                 });
                 let read_dir: Box<PathStream> = Box::new(DirReader(mapped_stream.collect()));
@@ -164,7 +173,9 @@ impl AssetReader for FileAssetReader {
             }
             Err(e) => {
                 if e.kind() == std::io::ErrorKind::NotFound {
-                    Err(AssetReaderError::NotFound(full_path))
+                    Err(AssetReaderError::NotFound(
+                        full_path.to_string_lossy().to_string(),
+                    ))
                 } else {
                     Err(e.into())
                 }
@@ -172,17 +183,17 @@ impl AssetReader for FileAssetReader {
         }
     }
 
-    async fn is_directory<'a>(&'a self, path: &'a Path) -> Result<bool, AssetReaderError> {
+    async fn is_directory<'a>(&'a self, path: &'a str) -> Result<bool, AssetReaderError> {
         let full_path = self.root_path.join(path);
         let metadata = full_path
             .metadata()
-            .map_err(|_e| AssetReaderError::NotFound(path.to_owned()))?;
+            .map_err(|_e| AssetReaderError::NotFound(path.to_string()))?;
         Ok(metadata.file_type().is_dir())
     }
 }
 
 impl AssetWriter for FileAssetWriter {
-    async fn write<'a>(&'a self, path: &'a Path) -> Result<Box<Writer>, AssetWriterError> {
+    async fn write<'a>(&'a self, path: &'a str) -> Result<Box<Writer>, AssetWriterError> {
         let full_path = self.root_path.join(path);
         if let Some(parent) = full_path.parent() {
             std::fs::create_dir_all(parent)?;
@@ -192,8 +203,8 @@ impl AssetWriter for FileAssetWriter {
         Ok(writer)
     }
 
-    async fn write_meta<'a>(&'a self, path: &'a Path) -> Result<Box<Writer>, AssetWriterError> {
-        let meta_path = get_meta_path(path);
+    async fn write_meta<'a>(&'a self, path: &'a str) -> Result<Box<Writer>, AssetWriterError> {
+        let meta_path = get_meta_path(Path::new(path));
         let full_path = self.root_path.join(meta_path);
         if let Some(parent) = full_path.parent() {
             std::fs::create_dir_all(parent)?;
@@ -203,32 +214,32 @@ impl AssetWriter for FileAssetWriter {
         Ok(writer)
     }
 
-    async fn remove<'a>(&'a self, path: &'a Path) -> Result<(), AssetWriterError> {
+    async fn remove<'a>(&'a self, path: &'a str) -> Result<(), AssetWriterError> {
         let full_path = self.root_path.join(path);
         std::fs::remove_file(full_path)?;
         Ok(())
     }
 
-    async fn remove_meta<'a>(&'a self, path: &'a Path) -> Result<(), AssetWriterError> {
-        let meta_path = get_meta_path(path);
+    async fn remove_meta<'a>(&'a self, path: &'a str) -> Result<(), AssetWriterError> {
+        let meta_path = get_meta_path(Path::new(path));
         let full_path = self.root_path.join(meta_path);
         std::fs::remove_file(full_path)?;
         Ok(())
     }
 
-    async fn create_directory<'a>(&'a self, path: &'a Path) -> Result<(), AssetWriterError> {
+    async fn create_directory<'a>(&'a self, path: &'a str) -> Result<(), AssetWriterError> {
         let full_path = self.root_path.join(path);
         std::fs::create_dir_all(full_path)?;
         Ok(())
     }
 
-    async fn remove_directory<'a>(&'a self, path: &'a Path) -> Result<(), AssetWriterError> {
+    async fn remove_directory<'a>(&'a self, path: &'a str) -> Result<(), AssetWriterError> {
         let full_path = self.root_path.join(path);
         std::fs::remove_dir_all(full_path)?;
         Ok(())
     }
 
-    async fn remove_empty_directory<'a>(&'a self, path: &'a Path) -> Result<(), AssetWriterError> {
+    async fn remove_empty_directory<'a>(&'a self, path: &'a str) -> Result<(), AssetWriterError> {
         let full_path = self.root_path.join(path);
         std::fs::remove_dir(full_path)?;
         Ok(())
@@ -236,7 +247,7 @@ impl AssetWriter for FileAssetWriter {
 
     async fn remove_assets_in_directory<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> Result<(), AssetWriterError> {
         let full_path = self.root_path.join(path);
         std::fs::remove_dir_all(&full_path)?;
@@ -246,8 +257,8 @@ impl AssetWriter for FileAssetWriter {
 
     async fn rename<'a>(
         &'a self,
-        old_path: &'a Path,
-        new_path: &'a Path,
+        old_path: &'a str,
+        new_path: &'a str,
     ) -> Result<(), AssetWriterError> {
         let full_old_path = self.root_path.join(old_path);
         let full_new_path = self.root_path.join(new_path);
@@ -260,11 +271,11 @@ impl AssetWriter for FileAssetWriter {
 
     async fn rename_meta<'a>(
         &'a self,
-        old_path: &'a Path,
-        new_path: &'a Path,
+        old_path: &'a str,
+        new_path: &'a str,
     ) -> Result<(), AssetWriterError> {
-        let old_meta_path = get_meta_path(old_path);
-        let new_meta_path = get_meta_path(new_path);
+        let old_meta_path = get_meta_path(Path::new(old_path));
+        let new_meta_path = get_meta_path(Path::new(new_path));
         let full_old_path = self.root_path.join(old_meta_path);
         let full_new_path = self.root_path.join(new_meta_path);
         if let Some(parent) = full_new_path.parent() {

--- a/crates/bevy_asset/src/io/gated.rs
+++ b/crates/bevy_asset/src/io/gated.rs
@@ -55,7 +55,7 @@ impl<R: AssetReader> GatedReader<R> {
 }
 
 impl<R: AssetReader> AssetReader for GatedReader<R> {
-    async fn read<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
+    async fn read<'a>(&'a self, path: &'a str) -> Result<impl Reader + 'a, AssetReaderError> {
         let receiver = {
             let mut gates = self.gates.write().unwrap_or_else(PoisonError::into_inner);
             let gates = gates
@@ -68,18 +68,18 @@ impl<R: AssetReader> AssetReader for GatedReader<R> {
         Ok(result)
     }
 
-    async fn read_meta<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
+    async fn read_meta<'a>(&'a self, path: &'a str) -> Result<impl Reader + 'a, AssetReaderError> {
         self.reader.read_meta(path).await
     }
 
     async fn read_directory<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> Result<Box<PathStream>, AssetReaderError> {
         self.reader.read_directory(path).await
     }
 
-    async fn is_directory<'a>(&'a self, path: &'a Path) -> Result<bool, AssetReaderError> {
+    async fn is_directory<'a>(&'a self, path: &'a str) -> Result<bool, AssetReaderError> {
         self.reader.is_directory(path).await
     }
 }

--- a/crates/bevy_asset/src/io/memory.rs
+++ b/crates/bevy_asset/src/io/memory.rs
@@ -1,8 +1,18 @@
-use crate::io::{
-    AssetReader, AssetReaderError, AssetWriter, AssetWriterError, PathStream, Reader,
-    ReaderNotSeekableError, SeekableReader,
+use crate::{
+    io::{
+        AssetReader, AssetReaderError, AssetWriter, AssetWriterError, PathStream, Reader,
+        ReaderNotSeekableError, SeekableReader,
+    },
+    join_paths, path_components, split_path,
 };
-use alloc::{borrow::ToOwned, boxed::Box, sync::Arc, vec, vec::Vec};
+use alloc::{
+    borrow::ToOwned,
+    boxed::Box,
+    string::{String, ToString},
+    sync::Arc,
+    vec,
+    vec::Vec,
+};
 use bevy_platform::{
     collections::HashMap,
     sync::{PoisonError, RwLock},
@@ -10,10 +20,7 @@ use bevy_platform::{
 use core::{pin::Pin, task::Poll};
 use futures_io::{AsyncRead, AsyncWrite};
 use futures_lite::Stream;
-use std::{
-    io::{Error, ErrorKind, SeekFrom},
-    path::{Path, PathBuf},
-};
+use std::io::{Error, ErrorKind, SeekFrom};
 
 use super::AsyncSeek;
 
@@ -22,7 +29,7 @@ struct DirInternal {
     assets: HashMap<Box<str>, Data>,
     metadata: HashMap<Box<str>, Data>,
     dirs: HashMap<Box<str>, Dir>,
-    path: PathBuf,
+    path: String,
 }
 
 /// A clone-able (internally Arc-ed) / thread-safe "in memory" filesystem.
@@ -32,24 +39,25 @@ pub struct Dir(Arc<RwLock<DirInternal>>);
 
 impl Dir {
     /// Creates a new [`Dir`] for the given `path`.
-    pub fn new(path: PathBuf) -> Self {
+    pub fn new(path: String) -> Self {
         Self(Arc::new(RwLock::new(DirInternal {
             path,
             ..Default::default()
         })))
     }
 
-    pub fn insert_asset_text(&self, path: &Path, asset: &str) {
+    pub fn insert_asset_text(&self, path: &str, asset: &str) {
         self.insert_asset(path, asset.as_bytes().to_vec());
     }
 
-    pub fn insert_meta_text(&self, path: &Path, asset: &str) {
+    pub fn insert_meta_text(&self, path: &str, asset: &str) {
         self.insert_meta(path, asset.as_bytes().to_vec());
     }
 
-    pub fn insert_asset(&self, path: &Path, value: impl Into<Value>) {
+    pub fn insert_asset(&self, path: &str, value: impl Into<Value>) {
         let mut dir = self.clone();
-        if let Some(parent) = path.parent() {
+        let (parent, basename) = split_path(path);
+        if let Some(parent) = parent {
             dir = self.get_or_insert_dir(parent);
         }
         dir.0
@@ -57,10 +65,10 @@ impl Dir {
             .unwrap_or_else(PoisonError::into_inner)
             .assets
             .insert(
-                path.file_name().unwrap().to_string_lossy().into(),
+                basename.unwrap().into(),
                 Data {
                     value: value.into(),
-                    path: path.to_owned(),
+                    path: path.to_string(),
                 },
             );
     }
@@ -68,12 +76,13 @@ impl Dir {
     /// Removes the stored asset at `path`.
     ///
     /// Returns the [`Data`] stored if found, [`None`] otherwise.
-    pub fn remove_asset(&self, path: &Path) -> Option<Data> {
+    pub fn remove_asset(&self, path: &str) -> Option<Data> {
         let mut dir = self.clone();
-        if let Some(parent) = path.parent() {
+        let (parent, basename) = split_path(path);
+        if let Some(parent) = parent {
             dir = self.get_or_insert_dir(parent);
         }
-        let key: Box<str> = path.file_name().unwrap().to_string_lossy().into();
+        let key: Box<str> = basename.unwrap().into();
         dir.0
             .write()
             .unwrap_or_else(PoisonError::into_inner)
@@ -81,9 +90,10 @@ impl Dir {
             .remove(&key)
     }
 
-    pub fn insert_meta(&self, path: &Path, value: impl Into<Value>) {
+    pub fn insert_meta(&self, path: &str, value: impl Into<Value>) {
         let mut dir = self.clone();
-        if let Some(parent) = path.parent() {
+        let (parent, basename) = split_path(path);
+        if let Some(parent) = parent {
             dir = self.get_or_insert_dir(parent);
         }
         dir.0
@@ -91,10 +101,10 @@ impl Dir {
             .unwrap_or_else(PoisonError::into_inner)
             .metadata
             .insert(
-                path.file_name().unwrap().to_string_lossy().into(),
+                basename.unwrap().into(),
                 Data {
                     value: value.into(),
-                    path: path.to_owned(),
+                    path: path.to_string(),
                 },
             );
     }
@@ -102,12 +112,13 @@ impl Dir {
     /// Removes the stored metadata at `path`.
     ///
     /// Returns the [`Data`] stored if found, [`None`] otherwise.
-    pub fn remove_metadata(&self, path: &Path) -> Option<Data> {
+    pub fn remove_metadata(&self, path: &str) -> Option<Data> {
         let mut dir = self.clone();
-        if let Some(parent) = path.parent() {
+        let (parent, basename) = split_path(path);
+        if let Some(parent) = parent {
             dir = self.get_or_insert_dir(parent);
         }
-        let key: Box<str> = path.file_name().unwrap().to_string_lossy().into();
+        let key: Box<str> = basename.unwrap().into();
         dir.0
             .write()
             .unwrap_or_else(PoisonError::into_inner)
@@ -115,15 +126,15 @@ impl Dir {
             .remove(&key)
     }
 
-    pub fn get_or_insert_dir(&self, path: &Path) -> Dir {
+    pub fn get_or_insert_dir(&self, path: &str) -> Dir {
         let mut dir = self.clone();
-        let mut full_path = PathBuf::new();
-        for c in path.components() {
-            full_path.push(c);
-            let name = c.as_os_str().to_string_lossy().into();
+        let mut full_path = String::new();
+        for name in path_components(path) {
+            full_path.push('/');
+            full_path.push_str(name);
             dir = {
                 let dirs = &mut dir.0.write().unwrap_or_else(PoisonError::into_inner).dirs;
-                dirs.entry(name)
+                dirs.entry(name.into())
                     .or_insert_with(|| Dir::new(full_path.clone()))
                     .clone()
             };
@@ -135,12 +146,13 @@ impl Dir {
     /// Removes the dir at `path`.
     ///
     /// Returns the [`Dir`] stored if found, [`None`] otherwise.
-    pub fn remove_dir(&self, path: &Path) -> Option<Dir> {
+    pub fn remove_dir(&self, path: &str) -> Option<Dir> {
         let mut dir = self.clone();
-        if let Some(parent) = path.parent() {
+        let (parent, basename) = split_path(path);
+        if let Some(parent) = parent {
             dir = self.get_or_insert_dir(parent);
         }
-        let key: Box<str> = path.file_name().unwrap().to_string_lossy().into();
+        let key: Box<str> = basename.unwrap().into();
         dir.0
             .write()
             .unwrap_or_else(PoisonError::into_inner)
@@ -148,60 +160,61 @@ impl Dir {
             .remove(&key)
     }
 
-    pub fn get_dir(&self, path: &Path) -> Option<Dir> {
+    pub fn get_dir(&self, path: &str) -> Option<Dir> {
         let mut dir = self.clone();
-        for p in path.components() {
-            let component = p.as_os_str().to_str().unwrap();
+        for name in path_components(path) {
             let next_dir = dir
                 .0
                 .read()
                 .unwrap_or_else(PoisonError::into_inner)
                 .dirs
-                .get(component)?
+                .get(name)?
                 .clone();
             dir = next_dir;
         }
         Some(dir)
     }
 
-    pub fn get_asset(&self, path: &Path) -> Option<Data> {
+    pub fn get_asset(&self, path: &str) -> Option<Data> {
         let mut dir = self.clone();
-        if let Some(parent) = path.parent() {
+        let (parent, basename) = split_path(path);
+        if let Some(parent) = parent {
             dir = dir.get_dir(parent)?;
         }
 
-        path.file_name().and_then(|f| {
+        basename.and_then(|f| {
             dir.0
                 .read()
                 .unwrap_or_else(PoisonError::into_inner)
                 .assets
-                .get(f.to_str().unwrap())
+                .get(f)
                 .cloned()
         })
     }
 
-    pub fn get_metadata(&self, path: &Path) -> Option<Data> {
+    pub fn get_metadata(&self, path: &str) -> Option<Data> {
         let mut dir = self.clone();
-        if let Some(parent) = path.parent() {
+        let (parent, basename) = split_path(path);
+        if let Some(parent) = parent {
             dir = dir.get_dir(parent)?;
         }
 
-        path.file_name().and_then(|f| {
+        basename.and_then(|f| {
             dir.0
                 .read()
                 .unwrap_or_else(PoisonError::into_inner)
                 .metadata
-                .get(f.to_str().unwrap())
+                .get(f)
                 .cloned()
         })
     }
 
-    pub fn path(&self) -> PathBuf {
+    pub fn path(&self) -> String {
         self.0
             .read()
             .unwrap_or_else(PoisonError::into_inner)
             .path
-            .to_owned()
+            .to_string()
     }
 }
 
@@ -222,7 +235,7 @@ impl DirStream {
 }
 
 impl Stream for DirStream {
-    type Item = PathBuf;
+    type Item = String;
 
     fn poll_next(
         self: Pin<&mut Self>,
@@ -236,7 +249,7 @@ impl Stream for DirStream {
             .dirs
             .keys()
             .nth(dir_index)
-            .map(|d| dir.path.join(d.as_ref()))
+            .map(|d| join_paths(&dir.path, d.as_ref()))
         {
             this.dir_index += 1;
             Poll::Ready(Some(dir_path))
@@ -266,7 +279,7 @@ pub struct MemoryAssetWriter {
 /// Asset data stored in a [`Dir`].
 #[derive(Clone, Debug)]
 pub struct Data {
-    path: PathBuf,
+    path: String,
     value: Value,
 }
 
@@ -279,7 +292,7 @@ pub enum Value {
 
 impl Data {
     /// The path that this data was written to.
-    pub fn path(&self) -> &Path {
+    pub fn path(&self) -> &str {
         &self.path
     }
 
@@ -361,29 +374,29 @@ impl Reader for DataReader {
 }
 
 impl AssetReader for MemoryAssetReader {
-    async fn read<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
+    async fn read<'a>(&'a self, path: &'a str) -> Result<impl Reader + 'a, AssetReaderError> {
         self.root
             .get_asset(path)
             .map(|data| DataReader {
                 data,
                 bytes_read: 0,
             })
-            .ok_or_else(|| AssetReaderError::NotFound(path.to_path_buf()))
+            .ok_or_else(|| AssetReaderError::NotFound(path.to_string()))
     }
 
-    async fn read_meta<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
+    async fn read_meta<'a>(&'a self, path: &'a str) -> Result<impl Reader + 'a, AssetReaderError> {
         self.root
             .get_metadata(path)
             .map(|data| DataReader {
                 data,
                 bytes_read: 0,
             })
-            .ok_or_else(|| AssetReaderError::NotFound(path.to_path_buf()))
+            .ok_or_else(|| AssetReaderError::NotFound(path.to_string()))
     }
 
     async fn read_directory<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> Result<Box<PathStream>, AssetReaderError> {
         self.root
             .get_dir(path)
@@ -391,10 +404,10 @@ impl AssetReader for MemoryAssetReader {
                 let stream: Box<PathStream> = Box::new(DirStream::new(dir));
                 stream
             })
-            .ok_or_else(|| AssetReaderError::NotFound(path.to_path_buf()))
+            .ok_or_else(|| AssetReaderError::NotFound(path.to_string()))
     }
 
-    async fn is_directory<'a>(&'a self, path: &'a Path) -> Result<bool, AssetReaderError> {
+    async fn is_directory<'a>(&'a self, path: &'a str) -> Result<bool, AssetReaderError> {
         Ok(self.root.get_dir(path).is_some())
     }
 }
@@ -404,7 +417,7 @@ struct DataWriter {
     /// The dir to write to.
     dir: Dir,
     /// The path to write to.
-    path: PathBuf,
+    path: String,
     /// The current buffer of data.
     ///
     /// This will include data that has been flushed already.
@@ -446,7 +459,7 @@ impl AsyncWrite for DataWriter {
 }
 
 impl AssetWriter for MemoryAssetWriter {
-    async fn write<'a>(&'a self, path: &'a Path) -> Result<Box<super::Writer>, AssetWriterError> {
+    async fn write<'a>(&'a self, path: &'a str) -> Result<Box<super::Writer>, AssetWriterError> {
         Ok(Box::new(DataWriter {
             dir: self.root.clone(),
             path: path.to_owned(),
@@ -457,7 +470,7 @@ impl AssetWriter for MemoryAssetWriter {
 
     async fn write_meta<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> Result<Box<super::Writer>, AssetWriterError> {
         Ok(Box::new(DataWriter {
             dir: self.root.clone(),
@@ -467,7 +480,7 @@ impl AssetWriter for MemoryAssetWriter {
         }))
     }
 
-    async fn remove<'a>(&'a self, path: &'a Path) -> Result<(), AssetWriterError> {
+    async fn remove<'a>(&'a self, path: &'a str) -> Result<(), AssetWriterError> {
         if self.root.remove_asset(path).is_none() {
             return Err(AssetWriterError::Io(Error::new(
                 ErrorKind::NotFound,
@@ -477,15 +490,15 @@ impl AssetWriter for MemoryAssetWriter {
         Ok(())
     }
 
-    async fn remove_meta<'a>(&'a self, path: &'a Path) -> Result<(), AssetWriterError> {
+    async fn remove_meta<'a>(&'a self, path: &'a str) -> Result<(), AssetWriterError> {
         self.root.remove_metadata(path);
         Ok(())
     }
 
     async fn rename<'a>(
         &'a self,
-        old_path: &'a Path,
-        new_path: &'a Path,
+        old_path: &'a str,
+        new_path: &'a str,
     ) -> Result<(), AssetWriterError> {
         let Some(old_asset) = self.root.get_asset(old_path) else {
             return Err(AssetWriterError::Io(Error::new(
@@ -503,8 +516,8 @@ impl AssetWriter for MemoryAssetWriter {
 
     async fn rename_meta<'a>(
         &'a self,
-        old_path: &'a Path,
-        new_path: &'a Path,
+        old_path: &'a str,
+        new_path: &'a str,
     ) -> Result<(), AssetWriterError> {
         let Some(old_meta) = self.root.get_metadata(old_path) else {
             return Err(AssetWriterError::Io(Error::new(
@@ -520,14 +533,14 @@ impl AssetWriter for MemoryAssetWriter {
         Ok(())
     }
 
-    async fn create_directory<'a>(&'a self, path: &'a Path) -> Result<(), AssetWriterError> {
+    async fn create_directory<'a>(&'a self, path: &'a str) -> Result<(), AssetWriterError> {
         // Just pretend we're on a file system that doesn't consider directory re-creation a
         // failure.
         self.root.get_or_insert_dir(path);
         Ok(())
     }
 
-    async fn remove_directory<'a>(&'a self, path: &'a Path) -> Result<(), AssetWriterError> {
+    async fn remove_directory<'a>(&'a self, path: &'a str) -> Result<(), AssetWriterError> {
         if self.root.remove_dir(path).is_none() {
             return Err(AssetWriterError::Io(Error::new(
                 ErrorKind::NotFound,
@@ -537,7 +550,7 @@ impl AssetWriter for MemoryAssetWriter {
         Ok(())
     }
 
-    async fn remove_empty_directory<'a>(&'a self, path: &'a Path) -> Result<(), AssetWriterError> {
+    async fn remove_empty_directory<'a>(&'a self, path: &'a str) -> Result<(), AssetWriterError> {
         let Some(dir) = self.root.get_dir(path) else {
             return Err(AssetWriterError::Io(Error::new(
                 ErrorKind::NotFound,
@@ -559,7 +572,7 @@ impl AssetWriter for MemoryAssetWriter {
 
     async fn remove_assets_in_directory<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> Result<(), AssetWriterError> {
         let Some(dir) = self.root.get_dir(path) else {
             return Err(AssetWriterError::Io(Error::new(
@@ -579,12 +592,11 @@ impl AssetWriter for MemoryAssetWriter {
 #[cfg(test)]
 pub mod test {
     use super::Dir;
-    use std::path::Path;
 
     #[test]
     fn memory_dir() {
         let dir = Dir::default();
-        let a_path = Path::new("a.txt");
+        let a_path = "a.txt";
         let a_data = "a".as_bytes().to_vec();
         let a_meta = "ameta".as_bytes().to_vec();
 
@@ -598,7 +610,7 @@ pub mod test {
         assert_eq!(meta.path(), a_path);
         assert_eq!(meta.value(), a_meta);
 
-        let b_path = Path::new("x/y/b.txt");
+        let b_path = "x/y/b.txt";
         let b_data = "b".as_bytes().to_vec();
         let b_meta = "meta".as_bytes().to_vec();
         dir.insert_asset(b_path, b_data.clone());

--- a/crates/bevy_asset/src/io/mod.rs
+++ b/crates/bevy_asset/src/io/mod.rs
@@ -25,7 +25,7 @@ mod source;
 pub use futures_lite::AsyncWriteExt;
 pub use source::*;
 
-use alloc::{boxed::Box, sync::Arc, vec::Vec};
+use alloc::{boxed::Box, string::String, sync::Arc, vec::Vec};
 use bevy_tasks::{BoxedFuture, ConditionalSendFuture};
 use core::{
     mem::size_of,
@@ -44,8 +44,8 @@ use thiserror::Error;
 #[derive(Error, Debug, Clone)]
 pub enum AssetReaderError {
     /// Path not found.
-    #[error("Path not found: {}", _0.display())]
-    NotFound(PathBuf),
+    #[error("Path not found: {0}")]
+    NotFound(String),
 
     /// Encountered an I/O error while loading an asset.
     #[error("Encountered an I/O error while loading asset: {0}")]
@@ -194,39 +194,38 @@ pub trait AssetReader: Send + Sync + 'static {
     /// The preferred style for implementing this method is an `async fn` returning an opaque type.
     ///
     /// ```no_run
-    /// # use std::path::Path;
     /// # use bevy_asset::{prelude::*, io::{AssetReader, PathStream, Reader, AssetReaderError}};
     /// # struct MyReader;
     /// impl AssetReader for MyReader {
-    ///     async fn read<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
+    ///     async fn read<'a>(&'a self, path: &'a str) -> Result<impl Reader + 'a, AssetReaderError> {
     ///         // ...
     ///         # let val: Box<dyn Reader> = unimplemented!(); Ok(val)
     ///     }
-    ///     # async fn read_meta<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
+    ///     # async fn read_meta<'a>(&'a self, path: &'a str) -> Result<impl Reader + 'a, AssetReaderError> {
     ///     #     let val: Box<dyn Reader> = unimplemented!(); Ok(val) }
-    ///     # async fn read_directory<'a>(&'a self, path: &'a Path) -> Result<Box<PathStream>, AssetReaderError> { unimplemented!() }
-    ///     # async fn is_directory<'a>(&'a self, path: &'a Path) -> Result<bool, AssetReaderError> { unimplemented!() }
-    ///     # async fn read_meta_bytes<'a>(&'a self, path: &'a Path) -> Result<Vec<u8>, AssetReaderError> { unimplemented!() }
+    ///     # async fn read_directory<'a>(&'a self, path: &'a str) -> Result<Box<PathStream>, AssetReaderError> { unimplemented!() }
+    ///     # async fn is_directory<'a>(&'a self, path: &'a str) -> Result<bool, AssetReaderError> { unimplemented!() }
+    ///     # async fn read_meta_bytes<'a>(&'a self, path: &'a str) -> Result<Vec<u8>, AssetReaderError> { unimplemented!() }
     /// }
     /// ```
-    fn read<'a>(&'a self, path: &'a Path) -> impl AssetReaderFuture<Value: Reader + 'a>;
+    fn read<'a>(&'a self, path: &'a str) -> impl AssetReaderFuture<Value: Reader + 'a>;
     /// Returns a future to load the full file data at the provided path.
-    fn read_meta<'a>(&'a self, path: &'a Path) -> impl AssetReaderFuture<Value: Reader + 'a>;
+    fn read_meta<'a>(&'a self, path: &'a str) -> impl AssetReaderFuture<Value: Reader + 'a>;
     /// Returns an iterator of directory entry names at the provided path.
     fn read_directory<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> impl ConditionalSendFuture<Output = Result<Box<PathStream>, AssetReaderError>>;
     /// Returns true if the provided path points to a directory.
     fn is_directory<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> impl ConditionalSendFuture<Output = Result<bool, AssetReaderError>>;
     /// Reads asset metadata bytes at the given `path` into a [`Vec<u8>`]. This is a convenience
     /// function that wraps [`AssetReader::read_meta`] by default.
     fn read_meta_bytes<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> impl ConditionalSendFuture<Output = Result<Vec<u8>, AssetReaderError>> {
         async {
             let mut meta_reader = self.read_meta(path).await?;
@@ -243,35 +242,33 @@ pub trait ErasedAssetReader: Send + Sync + 'static {
     /// Returns a future to load the full file data at the provided path.
     fn read<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> BoxedFuture<'a, Result<Box<dyn Reader + 'a>, AssetReaderError>>;
     /// Returns a future to load the full file data at the provided path.
     fn read_meta<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> BoxedFuture<'a, Result<Box<dyn Reader + 'a>, AssetReaderError>>;
     /// Returns an iterator of directory entry names at the provided path.
     fn read_directory<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> BoxedFuture<'a, Result<Box<PathStream>, AssetReaderError>>;
     /// Returns true if the provided path points to a directory.
-    fn is_directory<'a>(
-        &'a self,
-        path: &'a Path,
-    ) -> BoxedFuture<'a, Result<bool, AssetReaderError>>;
+    fn is_directory<'a>(&'a self, path: &'a str)
+        -> BoxedFuture<'a, Result<bool, AssetReaderError>>;
     /// Reads asset metadata bytes at the given `path` into a [`Vec<u8>`]. This is a convenience
     /// function that wraps [`ErasedAssetReader::read_meta`] by default.
     fn read_meta_bytes<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> BoxedFuture<'a, Result<Vec<u8>, AssetReaderError>>;
 }
 
 impl<T: AssetReader> ErasedAssetReader for T {
     fn read<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> BoxedFuture<'a, Result<Box<dyn Reader + 'a>, AssetReaderError>> {
         Box::pin(async move {
             let reader = Self::read(self, path).await?;
@@ -280,7 +277,7 @@ impl<T: AssetReader> ErasedAssetReader for T {
     }
     fn read_meta<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> BoxedFuture<'a, Result<Box<dyn Reader + 'a>, AssetReaderError>> {
         Box::pin(async {
             let reader = Self::read_meta(self, path).await?;
@@ -289,19 +286,19 @@ impl<T: AssetReader> ErasedAssetReader for T {
     }
     fn read_directory<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> BoxedFuture<'a, Result<Box<PathStream>, AssetReaderError>> {
         Box::pin(Self::read_directory(self, path))
     }
     fn is_directory<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> BoxedFuture<'a, Result<bool, AssetReaderError>> {
         Box::pin(Self::is_directory(self, path))
     }
     fn read_meta_bytes<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> BoxedFuture<'a, Result<Vec<u8>, AssetReaderError>> {
         Box::pin(Self::read_meta_bytes(self, path))
     }
@@ -309,7 +306,7 @@ impl<T: AssetReader> ErasedAssetReader for T {
 
 pub type Writer = dyn AsyncWrite + Unpin + Send + Sync;
 
-pub type PathStream = dyn Stream<Item = PathBuf> + Unpin + Send;
+pub type PathStream = dyn Stream<Item = String> + Unpin + Send;
 
 /// Errors that occur while loading assets.
 #[derive(Error, Debug)]
@@ -331,64 +328,64 @@ pub trait AssetWriter: Send + Sync + 'static {
     /// Writes the full asset bytes at the provided path.
     fn write<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> impl ConditionalSendFuture<Output = Result<Box<Writer>, AssetWriterError>>;
     /// Writes the full asset meta bytes at the provided path.
     /// This _should not_ include storage specific extensions like `.meta`.
     fn write_meta<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> impl ConditionalSendFuture<Output = Result<Box<Writer>, AssetWriterError>>;
     /// Removes the asset stored at the given path.
     fn remove<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> impl ConditionalSendFuture<Output = Result<(), AssetWriterError>>;
     /// Removes the asset meta stored at the given path.
     /// This _should not_ include storage specific extensions like `.meta`.
     fn remove_meta<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> impl ConditionalSendFuture<Output = Result<(), AssetWriterError>>;
     /// Renames the asset at `old_path` to `new_path`
     fn rename<'a>(
         &'a self,
-        old_path: &'a Path,
-        new_path: &'a Path,
+        old_path: &'a str,
+        new_path: &'a str,
     ) -> impl ConditionalSendFuture<Output = Result<(), AssetWriterError>>;
     /// Renames the asset meta for the asset at `old_path` to `new_path`.
     /// This _should not_ include storage specific extensions like `.meta`.
     fn rename_meta<'a>(
         &'a self,
-        old_path: &'a Path,
-        new_path: &'a Path,
+        old_path: &'a str,
+        new_path: &'a str,
     ) -> impl ConditionalSendFuture<Output = Result<(), AssetWriterError>>;
     /// Creates a directory at the given path, including all parent directories if they do not
     /// already exist.
     fn create_directory<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> impl ConditionalSendFuture<Output = Result<(), AssetWriterError>>;
     /// Removes the directory at the given path, including all assets _and_ directories in that directory.
     fn remove_directory<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> impl ConditionalSendFuture<Output = Result<(), AssetWriterError>>;
     /// Removes the directory at the given path, but only if it is completely empty. This will return an error if the
     /// directory is not empty.
     fn remove_empty_directory<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> impl ConditionalSendFuture<Output = Result<(), AssetWriterError>>;
     /// Removes all assets (and directories) in this directory, resulting in an empty directory.
     fn remove_assets_in_directory<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> impl ConditionalSendFuture<Output = Result<(), AssetWriterError>>;
     /// Writes the asset `bytes` to the given `path`.
     fn write_bytes<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
         bytes: &'a [u8],
     ) -> impl ConditionalSendFuture<Output = Result<(), AssetWriterError>> {
         async {
@@ -401,7 +398,7 @@ pub trait AssetWriter: Send + Sync + 'static {
     /// Writes the asset meta `bytes` to the given `path`.
     fn write_meta_bytes<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
         bytes: &'a [u8],
     ) -> impl ConditionalSendFuture<Output = Result<(), AssetWriterError>> {
         async {
@@ -417,66 +414,64 @@ pub trait AssetWriter: Send + Sync + 'static {
 /// as [`AssetWriter`] isn't currently object safe.
 pub trait ErasedAssetWriter: Send + Sync + 'static {
     /// Writes the full asset bytes at the provided path.
-    fn write<'a>(
-        &'a self,
-        path: &'a Path,
-    ) -> BoxedFuture<'a, Result<Box<Writer>, AssetWriterError>>;
+    fn write<'a>(&'a self, path: &'a str)
+        -> BoxedFuture<'a, Result<Box<Writer>, AssetWriterError>>;
     /// Writes the full asset meta bytes at the provided path.
     /// This _should not_ include storage specific extensions like `.meta`.
     fn write_meta<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> BoxedFuture<'a, Result<Box<Writer>, AssetWriterError>>;
     /// Removes the asset stored at the given path.
-    fn remove<'a>(&'a self, path: &'a Path) -> BoxedFuture<'a, Result<(), AssetWriterError>>;
+    fn remove<'a>(&'a self, path: &'a str) -> BoxedFuture<'a, Result<(), AssetWriterError>>;
     /// Removes the asset meta stored at the given path.
     /// This _should not_ include storage specific extensions like `.meta`.
-    fn remove_meta<'a>(&'a self, path: &'a Path) -> BoxedFuture<'a, Result<(), AssetWriterError>>;
+    fn remove_meta<'a>(&'a self, path: &'a str) -> BoxedFuture<'a, Result<(), AssetWriterError>>;
     /// Renames the asset at `old_path` to `new_path`
     fn rename<'a>(
         &'a self,
-        old_path: &'a Path,
-        new_path: &'a Path,
+        old_path: &'a str,
+        new_path: &'a str,
     ) -> BoxedFuture<'a, Result<(), AssetWriterError>>;
     /// Renames the asset meta for the asset at `old_path` to `new_path`.
     /// This _should not_ include storage specific extensions like `.meta`.
     fn rename_meta<'a>(
         &'a self,
-        old_path: &'a Path,
-        new_path: &'a Path,
+        old_path: &'a str,
+        new_path: &'a str,
     ) -> BoxedFuture<'a, Result<(), AssetWriterError>>;
     /// Creates a directory at the given path, including all parent directories if they do not
     /// already exist.
     fn create_directory<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> BoxedFuture<'a, Result<(), AssetWriterError>>;
     /// Removes the directory at the given path, including all assets _and_ directories in that directory.
     fn remove_directory<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> BoxedFuture<'a, Result<(), AssetWriterError>>;
     /// Removes the directory at the given path, but only if it is completely empty. This will return an error if the
     /// directory is not empty.
     fn remove_empty_directory<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> BoxedFuture<'a, Result<(), AssetWriterError>>;
     /// Removes all assets (and directories) in this directory, resulting in an empty directory.
     fn remove_assets_in_directory<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> BoxedFuture<'a, Result<(), AssetWriterError>>;
     /// Writes the asset `bytes` to the given `path`.
     fn write_bytes<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
         bytes: &'a [u8],
     ) -> BoxedFuture<'a, Result<(), AssetWriterError>>;
     /// Writes the asset meta `bytes` to the given `path`.
     fn write_meta_bytes<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
         bytes: &'a [u8],
     ) -> BoxedFuture<'a, Result<(), AssetWriterError>>;
 }
@@ -484,70 +479,70 @@ pub trait ErasedAssetWriter: Send + Sync + 'static {
 impl<T: AssetWriter> ErasedAssetWriter for T {
     fn write<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> BoxedFuture<'a, Result<Box<Writer>, AssetWriterError>> {
         Box::pin(Self::write(self, path))
     }
     fn write_meta<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> BoxedFuture<'a, Result<Box<Writer>, AssetWriterError>> {
         Box::pin(Self::write_meta(self, path))
     }
-    fn remove<'a>(&'a self, path: &'a Path) -> BoxedFuture<'a, Result<(), AssetWriterError>> {
+    fn remove<'a>(&'a self, path: &'a str) -> BoxedFuture<'a, Result<(), AssetWriterError>> {
         Box::pin(Self::remove(self, path))
     }
-    fn remove_meta<'a>(&'a self, path: &'a Path) -> BoxedFuture<'a, Result<(), AssetWriterError>> {
+    fn remove_meta<'a>(&'a self, path: &'a str) -> BoxedFuture<'a, Result<(), AssetWriterError>> {
         Box::pin(Self::remove_meta(self, path))
     }
     fn rename<'a>(
         &'a self,
-        old_path: &'a Path,
-        new_path: &'a Path,
+        old_path: &'a str,
+        new_path: &'a str,
     ) -> BoxedFuture<'a, Result<(), AssetWriterError>> {
         Box::pin(Self::rename(self, old_path, new_path))
     }
     fn rename_meta<'a>(
         &'a self,
-        old_path: &'a Path,
-        new_path: &'a Path,
+        old_path: &'a str,
+        new_path: &'a str,
     ) -> BoxedFuture<'a, Result<(), AssetWriterError>> {
         Box::pin(Self::rename_meta(self, old_path, new_path))
     }
     fn create_directory<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> BoxedFuture<'a, Result<(), AssetWriterError>> {
         Box::pin(Self::create_directory(self, path))
     }
     fn remove_directory<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> BoxedFuture<'a, Result<(), AssetWriterError>> {
         Box::pin(Self::remove_directory(self, path))
     }
     fn remove_empty_directory<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> BoxedFuture<'a, Result<(), AssetWriterError>> {
         Box::pin(Self::remove_empty_directory(self, path))
     }
     fn remove_assets_in_directory<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> BoxedFuture<'a, Result<(), AssetWriterError>> {
         Box::pin(Self::remove_assets_in_directory(self, path))
     }
     fn write_bytes<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
         bytes: &'a [u8],
     ) -> BoxedFuture<'a, Result<(), AssetWriterError>> {
         Box::pin(Self::write_bytes(self, path, bytes))
     }
     fn write_meta_bytes<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
         bytes: &'a [u8],
     ) -> BoxedFuture<'a, Result<(), AssetWriterError>> {
         Box::pin(Self::write_meta_bytes(self, path, bytes))
@@ -558,33 +553,33 @@ impl<T: AssetWriter> ErasedAssetWriter for T {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum AssetSourceEvent {
     /// An asset at this path was added.
-    AddedAsset(PathBuf),
+    AddedAsset(String),
     /// An asset at this path was modified.
-    ModifiedAsset(PathBuf),
+    ModifiedAsset(String),
     /// An asset at this path was removed.
-    RemovedAsset(PathBuf),
+    RemovedAsset(String),
     /// An asset at this path was renamed.
-    RenamedAsset { old: PathBuf, new: PathBuf },
+    RenamedAsset { old: String, new: String },
     /// Asset metadata at this path was added.
-    AddedMeta(PathBuf),
+    AddedMeta(String),
     /// Asset metadata at this path was modified.
-    ModifiedMeta(PathBuf),
+    ModifiedMeta(String),
     /// Asset metadata at this path was removed.
-    RemovedMeta(PathBuf),
+    RemovedMeta(String),
     /// Asset metadata at this path was renamed.
-    RenamedMeta { old: PathBuf, new: PathBuf },
+    RenamedMeta { old: String, new: String },
     /// A folder at the given path was added.
-    AddedFolder(PathBuf),
+    AddedFolder(String),
     /// A folder at the given path was removed.
-    RemovedFolder(PathBuf),
+    RemovedFolder(String),
     /// A folder at the given path was renamed.
-    RenamedFolder { old: PathBuf, new: PathBuf },
+    RenamedFolder { old: String, new: String },
     /// Something of unknown type was removed. It is the job of the event handler to determine the type.
     /// This exists because notify-rs produces "untyped" rename events without destination paths for unwatched folders, so we can't determine the type of
     /// the rename.
     RemovedUnknown {
         /// The path of the removed asset or folder (undetermined). This could be an asset path or a folder. This will not be a "meta file" path.
-        path: PathBuf,
+        path: String,
         /// This field is only relevant if `path` is determined to be an asset path (and therefore not a folder). If this field is `true`,
         /// then this event corresponds to a meta removal (not an asset removal) . If `false`, then this event corresponds to an asset removal
         /// (not a meta removal).
@@ -781,7 +776,7 @@ struct EmptyPathStream;
 
 #[cfg(any(target_arch = "wasm32", target_os = "android"))]
 impl Stream for EmptyPathStream {
-    type Item = PathBuf;
+    type Item = String;
 
     fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         Poll::Ready(None)

--- a/crates/bevy_asset/src/io/processor_gated.rs
+++ b/crates/bevy_asset/src/io/processor_gated.rs
@@ -6,11 +6,10 @@ use crate::{
     processor::{ProcessStatus, ProcessingState},
     AssetPath,
 };
-use alloc::{borrow::ToOwned, boxed::Box, sync::Arc, vec::Vec};
+use alloc::{boxed::Box, string::ToString, sync::Arc, vec::Vec};
 use async_lock::RwLockReadGuardArc;
 use core::{pin::Pin, task::Poll};
 use futures_io::AsyncRead;
-use std::path::Path;
 use tracing::trace;
 
 use super::ErasedAssetReader;
@@ -41,8 +40,8 @@ impl ProcessorGatedReader {
 }
 
 impl AssetReader for ProcessorGatedReader {
-    async fn read<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
-        let asset_path = AssetPath::from(path.to_path_buf()).with_source(self.source.clone());
+    async fn read<'a>(&'a self, path: &'a str) -> Result<impl Reader + 'a, AssetReaderError> {
+        let asset_path = AssetPath::from(path.to_string()).with_source(self.source.clone());
         trace!("Waiting for processing to finish before reading {asset_path}");
         let process_result = self
             .processing_state
@@ -51,7 +50,7 @@ impl AssetReader for ProcessorGatedReader {
         match process_result {
             ProcessStatus::Processed => {}
             ProcessStatus::Failed | ProcessStatus::NonExistent => {
-                return Err(AssetReaderError::NotFound(path.to_owned()));
+                return Err(AssetReaderError::NotFound(path.to_string()));
             }
         }
         trace!("Processing finished with {asset_path}, reading {process_result:?}",);
@@ -64,8 +63,8 @@ impl AssetReader for ProcessorGatedReader {
         Ok(reader)
     }
 
-    async fn read_meta<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
-        let asset_path = AssetPath::from(path.to_path_buf()).with_source(self.source.clone());
+    async fn read_meta<'a>(&'a self, path: &'a str) -> Result<impl Reader + 'a, AssetReaderError> {
+        let asset_path = AssetPath::from(path.to_string()).with_source(self.source.clone());
         trace!("Waiting for processing to finish before reading meta for {asset_path}",);
         let process_result = self
             .processing_state
@@ -74,7 +73,7 @@ impl AssetReader for ProcessorGatedReader {
         match process_result {
             ProcessStatus::Processed => {}
             ProcessStatus::Failed | ProcessStatus::NonExistent => {
-                return Err(AssetReaderError::NotFound(path.to_owned()));
+                return Err(AssetReaderError::NotFound(path.to_string()));
             }
         }
         trace!("Processing finished with {process_result:?}, reading meta for {asset_path}",);
@@ -89,7 +88,7 @@ impl AssetReader for ProcessorGatedReader {
 
     async fn read_directory<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> Result<Box<PathStream>, AssetReaderError> {
         trace!(
             "Waiting for processing to finish before reading directory {:?}",
@@ -101,7 +100,7 @@ impl AssetReader for ProcessorGatedReader {
         Ok(result)
     }
 
-    async fn is_directory<'a>(&'a self, path: &'a Path) -> Result<bool, AssetReaderError> {
+    async fn is_directory<'a>(&'a self, path: &'a str) -> Result<bool, AssetReaderError> {
         trace!(
             "Waiting for processing to finish before reading directory {:?}",
             path

--- a/crates/bevy_asset/src/io/wasm.rs
+++ b/crates/bevy_asset/src/io/wasm.rs
@@ -1,13 +1,8 @@
 use crate::io::{
     get_meta_path, AssetReader, AssetReaderError, EmptyPathStream, PathStream, Reader, VecReader,
 };
-use alloc::{
-    borrow::{Cow, ToOwned},
-    boxed::Box,
-    format,
-};
+use alloc::{borrow::Cow, boxed::Box, format, string::String};
 use js_sys::{Uint8Array, JSON};
-use std::path::{Path, PathBuf};
 use tracing::error;
 use wasm_bindgen::{prelude::wasm_bindgen, JsCast, JsValue};
 use wasm_bindgen_futures::JsFuture;
@@ -30,15 +25,15 @@ extern "C" {
 
 /// Reader implementation for loading assets via HTTP in Wasm.
 pub struct HttpWasmAssetReader {
-    root_path: PathBuf,
+    root_path: String,
     request_mapper: Option<Box<dyn Fn(&str) -> Cow<str> + Send + Sync + 'static>>,
 }
 
 impl HttpWasmAssetReader {
     /// Creates a new `WasmAssetReader`. The path provided will be used to build URLs to query for assets.
-    pub fn new<P: AsRef<Path>>(path: P) -> Self {
+    pub fn new(path: String) -> Self {
         Self {
-            root_path: path.as_ref().to_owned(),
+            root_path: path,
             request_mapper: None,
         }
     }
@@ -71,9 +66,9 @@ impl HttpWasmAssetReader {
     // Also used by [`WebAssetReader`](crate::web::WebAssetReader)
     pub(crate) async fn fetch_bytes(
         &self,
-        path: PathBuf,
+        path: String,
     ) -> Result<impl Reader + use<>, AssetReaderError> {
-        let path = path.to_str().unwrap();
+        let path = path.as_str();
         let fetch_path = self
             .request_mapper
             .as_ref()
@@ -114,26 +109,32 @@ impl HttpWasmAssetReader {
 }
 
 impl AssetReader for HttpWasmAssetReader {
-    async fn read<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
+    async fn read<'a>(&'a self, path: &'a str) -> Result<impl Reader + 'a, AssetReaderError> {
         let path = self.root_path.join(path);
         self.fetch_bytes(path).await
     }
 
-    async fn read_meta<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
+    async fn read_meta<'a>(&'a self, path: &'a str) -> Result<impl Reader + 'a, AssetReaderError> {
+        let path = if let Some(index) = path.rfind("?") {
+            let (path, query) = path.split_at(index);
+            alloc::format!("{path}.meta{query}")
+        } else {
+            alloc::format!("{path}.meta")
+        };
         let meta_path = get_meta_path(&self.root_path.join(path));
         self.fetch_bytes(meta_path).await
     }
 
     async fn read_directory<'a>(
         &'a self,
-        _path: &'a Path,
+        _path: &'a str,
     ) -> Result<Box<PathStream>, AssetReaderError> {
         let stream: Box<PathStream> = Box::new(EmptyPathStream);
         error!("Reading directories is not supported with the HttpWasmAssetReader");
         Ok(stream)
     }
 
-    async fn is_directory<'a>(&'a self, _path: &'a Path) -> Result<bool, AssetReaderError> {
+    async fn is_directory<'a>(&'a self, _path: &'a str) -> Result<bool, AssetReaderError> {
         error!("Reading directories is not supported with the HttpWasmAssetReader");
         Ok(false)
     }

--- a/crates/bevy_asset/src/io/web.rs
+++ b/crates/bevy_asset/src/io/web.rs
@@ -1,9 +1,8 @@
 use crate::io::{AssetReader, AssetReaderError, AssetSourceBuilder, PathStream, Reader};
-use crate::{AssetApp, AssetPlugin};
-use alloc::boxed::Box;
+use crate::{join_paths, AssetApp, AssetPlugin};
+use alloc::{boxed::Box, string::String};
 use bevy_app::{App, Plugin};
 use bevy_tasks::ConditionalSendFuture;
-use std::path::{Path, PathBuf};
 use tracing::warn;
 
 /// Adds the `http` and `https` asset sources to the app.
@@ -94,23 +93,28 @@ pub enum WebAssetReader {
 }
 
 impl WebAssetReader {
-    fn make_uri(&self, path: &Path) -> PathBuf {
+    fn make_uri(&self, path: &str) -> String {
         let prefix = match self {
             Self::Http => "http://",
             Self::Https => "https://",
         };
-        PathBuf::from(prefix).join(path)
+        join_paths(prefix, path)
     }
 
     /// See [`io::get_meta_path`](`crate::io::get_meta_path`)
-    fn make_meta_uri(&self, path: &Path) -> PathBuf {
-        let meta_path = crate::io::get_meta_path(path);
-        self.make_uri(&meta_path)
+    fn make_meta_uri(&self, path: &str) -> String {
+        let path = if let Some(index) = path.rfind("?") {
+            let (path, query) = path.split_at(index);
+            alloc::format!("{path}.meta{query}")
+        } else {
+            alloc::format!("{path}.meta")
+        };
+        self.make_uri(path.as_ref())
     }
 }
 
 #[cfg(target_arch = "wasm32")]
-async fn get<'a>(path: PathBuf) -> Result<Box<dyn Reader>, AssetReaderError> {
+async fn get<'a>(path: String) -> Result<Box<dyn Reader>, AssetReaderError> {
     use crate::io::wasm::HttpWasmAssetReader;
 
     HttpWasmAssetReader::new("")
@@ -120,24 +124,15 @@ async fn get<'a>(path: PathBuf) -> Result<Box<dyn Reader>, AssetReaderError> {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-async fn get(path: PathBuf) -> Result<Box<dyn Reader>, AssetReaderError> {
+async fn get(path: String) -> Result<Box<dyn Reader>, AssetReaderError> {
     use crate::io::VecReader;
-    use alloc::{borrow::ToOwned, boxed::Box, vec::Vec};
+    use alloc::{boxed::Box, vec::Vec};
     use bevy_platform::sync::LazyLock;
     use blocking::unblock;
     use std::io::{self, BufReader, Read};
 
-    let str_path = path.to_str().ok_or_else(|| {
-        AssetReaderError::Io(
-            io::Error::other(std::format!("non-utf8 path: {}", path.display())).into(),
-        )
-    })?;
-
-    #[cfg(target_os = "windows")]
-    let str_path = &str_path.replace(std::path::MAIN_SEPARATOR, "/");
-
     #[cfg(all(not(target_arch = "wasm32"), feature = "web_asset_cache"))]
-    if let Some(data) = web_asset_cache::try_load_from_cache(str_path).await? {
+    if let Some(data) = web_asset_cache::try_load_from_cache(&path).await? {
         return Ok(Box::new(VecReader::new(data)));
     }
     use ureq::tls::{RootCerts, TlsConfig};
@@ -154,7 +149,7 @@ async fn get(path: PathBuf) -> Result<Box<dyn Reader>, AssetReaderError> {
             .new_agent()
     });
 
-    let uri = str_path.to_owned();
+    let uri = path.clone();
     // Use [`unblock`] to run the http request on a separately spawned thread as to not block bevy's
     // async executor.
     let response = unblock(|| AGENT.get(uri).call()).await;
@@ -167,7 +162,7 @@ async fn get(path: PathBuf) -> Result<Box<dyn Reader>, AssetReaderError> {
             reader.read_to_end(&mut buffer)?;
 
             #[cfg(all(not(target_arch = "wasm32"), feature = "web_asset_cache"))]
-            web_asset_cache::save_to_cache(str_path, &buffer).await?;
+            web_asset_cache::save_to_cache(&path, &buffer).await?;
 
             Ok(Box::new(VecReader::new(buffer)))
         }
@@ -181,9 +176,7 @@ async fn get(path: PathBuf) -> Result<Box<dyn Reader>, AssetReaderError> {
         }
         Err(err) => Err(AssetReaderError::Io(
             io::Error::other(std::format!(
-                "unexpected error while loading asset {}: {}",
-                path.display(),
-                err
+                "unexpected error while loading asset {path}: {err}",
             ))
             .into(),
         )),
@@ -193,23 +186,23 @@ async fn get(path: PathBuf) -> Result<Box<dyn Reader>, AssetReaderError> {
 impl AssetReader for WebAssetReader {
     fn read<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> impl ConditionalSendFuture<Output = Result<Box<dyn Reader>, AssetReaderError>> {
         get(self.make_uri(path))
     }
 
-    async fn read_meta<'a>(&'a self, path: &'a Path) -> Result<Box<dyn Reader>, AssetReaderError> {
+    async fn read_meta<'a>(&'a self, path: &'a str) -> Result<Box<dyn Reader>, AssetReaderError> {
         let uri = self.make_meta_uri(path);
         get(uri).await
     }
 
-    async fn is_directory<'a>(&'a self, _path: &'a Path) -> Result<bool, AssetReaderError> {
+    async fn is_directory<'a>(&'a self, _path: &'a str) -> Result<bool, AssetReaderError> {
         Ok(false)
     }
 
     async fn read_directory<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> Result<Box<PathStream>, AssetReaderError> {
         Err(AssetReaderError::NotFound(self.make_uri(path)))
     }
@@ -277,10 +270,7 @@ mod tests {
     #[test]
     fn make_http_uri() {
         assert_eq!(
-            WebAssetReader::Http
-                .make_uri(Path::new("example.com/favicon.png"))
-                .to_str()
-                .unwrap(),
+            WebAssetReader::Http.make_uri("example.com/favicon.png"),
             "http://example.com/favicon.png"
         );
     }
@@ -288,10 +278,7 @@ mod tests {
     #[test]
     fn make_https_uri() {
         assert_eq!(
-            WebAssetReader::Https
-                .make_uri(Path::new("example.com/favicon.png"))
-                .to_str()
-                .unwrap(),
+            WebAssetReader::Https.make_uri("example.com/favicon.png"),
             "https://example.com/favicon.png"
         );
     }
@@ -299,10 +286,7 @@ mod tests {
     #[test]
     fn make_http_meta_uri() {
         assert_eq!(
-            WebAssetReader::Http
-                .make_meta_uri(Path::new("example.com/favicon.png"))
-                .to_str()
-                .unwrap(),
+            WebAssetReader::Http.make_meta_uri("example.com/favicon.png"),
             "http://example.com/favicon.png.meta"
         );
     }
@@ -310,10 +294,7 @@ mod tests {
     #[test]
     fn make_https_meta_uri() {
         assert_eq!(
-            WebAssetReader::Https
-                .make_meta_uri(Path::new("example.com/favicon.png"))
-                .to_str()
-                .unwrap(),
+            WebAssetReader::Https.make_meta_uri("example.com/favicon.png"),
             "https://example.com/favicon.png.meta"
         );
     }
@@ -321,10 +302,7 @@ mod tests {
     #[test]
     fn make_https_without_extension_meta_uri() {
         assert_eq!(
-            WebAssetReader::Https
-                .make_meta_uri(Path::new("example.com/favicon"))
-                .to_str()
-                .unwrap(),
+            WebAssetReader::Https.make_meta_uri("example.com/favicon"),
             "https://example.com/favicon.meta"
         );
     }

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -752,7 +752,6 @@ mod tests {
     use futures_lite::AsyncReadExt;
     use ron::ser::PrettyConfig;
     use serde::{Deserialize, Serialize};
-    use std::path::{Path, PathBuf};
     use thiserror::Error;
 
     #[derive(Asset, Debug, Default, Reflect)]
@@ -844,7 +843,7 @@ mod tests {
     /// A dummy [`CoolText`] asset reader that only succeeds after `failure_count` times it's read from for each asset.
     #[derive(Default, Clone)]
     pub struct UnstableMemoryAssetReader {
-        pub attempt_counters: Arc<Mutex<HashMap<Box<Path>, usize>>>,
+        pub attempt_counters: Arc<Mutex<HashMap<String, usize>>>,
         pub load_delay: Duration,
         memory_reader: MemoryAssetReader,
         failure_count: usize,
@@ -862,29 +861,29 @@ mod tests {
     }
 
     impl AssetReader for UnstableMemoryAssetReader {
-        async fn is_directory<'a>(&'a self, path: &'a Path) -> Result<bool, AssetReaderError> {
+        async fn is_directory<'a>(&'a self, path: &'a str) -> Result<bool, AssetReaderError> {
             self.memory_reader.is_directory(path).await
         }
         async fn read_directory<'a>(
             &'a self,
-            path: &'a Path,
+            path: &'a str,
         ) -> Result<Box<bevy_asset::io::PathStream>, AssetReaderError> {
             self.memory_reader.read_directory(path).await
         }
         async fn read_meta<'a>(
             &'a self,
-            path: &'a Path,
+            path: &'a str,
         ) -> Result<impl Reader + 'a, AssetReaderError> {
             self.memory_reader.read_meta(path).await
         }
-        async fn read<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
+        async fn read<'a>(&'a self, path: &'a str) -> Result<impl Reader + 'a, AssetReaderError> {
             let attempt_number = {
                 let mut attempt_counters = self.attempt_counters.lock().unwrap();
                 if let Some(existing) = attempt_counters.get_mut(path) {
                     *existing += 1;
                     *existing
                 } else {
-                    attempt_counters.insert(path.into(), 1);
+                    attempt_counters.insert(path.to_string(), 1);
                     1
                 }
             };
@@ -1052,10 +1051,10 @@ mod tests {
     sub_texts: [],
 )"#;
 
-        dir.insert_asset_text(Path::new(a_path), a_ron);
-        dir.insert_asset_text(Path::new(b_path), b_ron);
-        dir.insert_asset_text(Path::new(c_path), c_ron);
-        dir.insert_asset_text(Path::new(d_path), d_ron);
+        dir.insert_asset_text(a_path, a_ron);
+        dir.insert_asset_text(b_path, b_ron);
+        dir.insert_asset_text(c_path, c_ron);
+        dir.insert_asset_text(d_path, d_ron);
 
         #[derive(Resource)]
         struct IdResults {
@@ -1364,10 +1363,10 @@ mod tests {
     sub_texts: []
 )"#;
 
-        dir.insert_asset_text(Path::new(a_path), a_ron);
-        dir.insert_asset_text(Path::new(b_path), b_ron);
-        dir.insert_asset_text(Path::new(c_path), c_ron);
-        dir.insert_asset_text(Path::new(d_path), d_ron);
+        dir.insert_asset_text(a_path, a_ron);
+        dir.insert_asset_text(b_path, b_ron);
+        dir.insert_asset_text(c_path, c_ron);
+        dir.insert_asset_text(d_path, d_ron);
 
         let (mut app, gate_opener) = create_app_with_gate(dir);
         app.init_asset::<CoolText>()
@@ -1490,9 +1489,9 @@ mod tests {
 )"#;
 
         let dir = Dir::default();
-        dir.insert_asset_text(Path::new(a_path), a_ron);
-        dir.insert_asset_text(Path::new(b_path), b_ron);
-        dir.insert_asset_text(Path::new(c_path), c_ron);
+        dir.insert_asset_text(a_path, a_ron);
+        dir.insert_asset_text(b_path, b_ron);
+        dir.insert_asset_text(c_path, c_ron);
 
         let (mut app, gate_opener) = create_app_with_gate(dir);
         app.init_asset::<CoolText>()
@@ -1569,7 +1568,7 @@ mod tests {
     #[test]
     fn keep_gotten_strong_handles() {
         let dir = Dir::default();
-        dir.insert_asset_text(Path::new("dep.cool.ron"), SIMPLE_TEXT);
+        dir.insert_asset_text("dep.cool.ron", SIMPLE_TEXT);
 
         let (mut app, _) = create_app_with_gate(dir);
         app.init_asset::<CoolText>()
@@ -1606,7 +1605,7 @@ mod tests {
         let dir = Dir::default();
         let dep_path = "dep.cool.ron";
 
-        dir.insert_asset_text(Path::new(dep_path), SIMPLE_TEXT);
+        dir.insert_asset_text(dep_path, SIMPLE_TEXT);
 
         let (mut app, gate_opener) = create_app_with_gate(dir);
         app.init_asset::<CoolText>()
@@ -1745,9 +1744,9 @@ mod tests {
     embedded_dependencies: [],
     sub_texts: [],
 )"#;
-        dir.insert_asset_text(Path::new(a_path), a_ron);
-        dir.insert_asset_text(Path::new(b_path), b_ron);
-        dir.insert_asset_text(Path::new(c_path), c_ron);
+        dir.insert_asset_text(a_path, a_ron);
+        dir.insert_asset_text(b_path, b_ron);
+        dir.insert_asset_text(c_path, c_ron);
 
         let (mut app, gate_opener) = create_app_with_gate(dir);
         app.init_asset::<CoolText>()
@@ -1896,7 +1895,7 @@ mod tests {
 )"#;
 
         let dir = Dir::default();
-        dir.insert_asset_text(Path::new(a_path), a_ron);
+        dir.insert_asset_text(a_path, a_ron);
         let unstable_reader = UnstableMemoryAssetReader::new(dir, 2);
 
         let mut app = App::new();
@@ -1974,7 +1973,7 @@ mod tests {
     fn error_on_nested_immediate_load_of_subasset() {
         let (mut app, dir) = create_app();
         dir.insert_asset_text(
-            Path::new("a.cool.ron"),
+            "a.cool.ron",
             r#"(
     text: "b",
     dependencies: [],
@@ -1982,7 +1981,7 @@ mod tests {
     sub_texts: ["A"],
 )"#,
         );
-        dir.insert_asset_text(Path::new("empty.txt"), "");
+        dir.insert_asset_text("empty.txt", "");
 
         app.init_asset::<CoolText>()
             .init_asset::<SubText>()
@@ -2116,7 +2115,7 @@ mod tests {
     sub_texts: [],
 )"#;
 
-        dir.insert_asset_text(Path::new(a_path), a_ron);
+        dir.insert_asset_text(a_path, a_ron);
 
         let mut app = App::new();
         let memory_reader = MemoryAssetReader { root: dir };
@@ -2265,7 +2264,7 @@ mod tests {
                 gate_receiver,
             });
 
-        let path = Path::new("abc.ron");
+        let path = "abc.ron";
         dir.insert_asset_text(path, "blah");
 
         let asset_server = app.world().resource::<AssetServer>().clone();
@@ -2314,7 +2313,7 @@ mod tests {
                 gate_receiver,
             });
 
-        let path = Path::new("abc.ron");
+        let path = "abc.ron";
         dir.insert_asset_text(path, "blah");
 
         let asset_server = app.world().resource::<AssetServer>().clone();
@@ -2410,7 +2409,7 @@ mod tests {
         let asset_server = app.world().resource::<AssetServer>().clone();
 
         dir.insert_asset_text(
-            Path::new("abc.cool.ron"),
+            "abc.cool.ron",
             r#"(
     text: "a",
     dependencies: [],
@@ -2442,9 +2441,7 @@ mod tests {
         // Sending an asset event should result in the asset being reloaded - resulting in a
         // "Modified" message.
         source_events
-            .send_blocking(AssetSourceEvent::ModifiedAsset(PathBuf::from(
-                "abc.cool.ron",
-            )))
+            .send_blocking(AssetSourceEvent::ModifiedAsset("abc.cool.ron".to_string()))
             .unwrap();
 
         run_app_until(&mut app, |world| {
@@ -2488,7 +2485,7 @@ mod tests {
         // The asset has already been considered as failed to load. Now we add the asset data, and
         // send an AddedAsset event.
         dir.insert_asset_text(
-            Path::new("abc.cool.ron"),
+            "abc.cool.ron",
             r#"(
     text: "a",
     dependencies: [],
@@ -2497,7 +2494,7 @@ mod tests {
 )"#,
         );
         source_events
-            .send_blocking(AssetSourceEvent::AddedAsset(PathBuf::from("abc.cool.ron")))
+            .send_blocking(AssetSourceEvent::AddedAsset("abc.cool.ron".to_string()))
             .unwrap();
 
         run_app_until(&mut app, |world| {
@@ -2555,7 +2552,7 @@ mod tests {
         // Create a test asset and setup the app.
 
         let (mut app, dir) = create_app();
-        dir.insert_asset(Path::new("test.u8"), &[]);
+        dir.insert_asset("test.u8", &[]);
 
         app.init_asset::<U8Asset>().register_asset_loader(U8Loader);
 
@@ -2607,7 +2604,7 @@ mod tests {
     #[test]
     fn loading_two_subassets_does_not_start_two_loads() {
         let (mut app, dir) = create_app();
-        dir.insert_asset(Path::new("test.txt"), &[]);
+        dir.insert_asset("test.txt", &[]);
 
         #[derive(TypePath)]
         struct TwoSubassetLoader;
@@ -2675,7 +2672,7 @@ mod tests {
     #[test]
     fn get_strong_handle_prevents_reload_when_asset_still_alive() {
         let (mut app, dir) = create_app();
-        dir.insert_asset(Path::new("test.txt"), &[]);
+        dir.insert_asset("test.txt", &[]);
 
         app.init_asset::<TestAsset>()
             .register_asset_loader(TrivialLoader);
@@ -2794,9 +2791,9 @@ mod tests {
             .register_asset_loader(DeferredNestedLoader)
             .register_asset_loader(ImmediateNestedLoader);
 
-        dir.insert_asset_text(Path::new("a.immediate"), "b.defer");
-        dir.insert_asset_text(Path::new("b.defer"), "c.txt");
-        dir.insert_asset_text(Path::new("c.txt"), "hiya");
+        dir.insert_asset_text("a.immediate", "b.defer");
+        dir.insert_asset_text("b.defer", "c.txt");
+        dir.insert_asset_text("c.txt", "hiya");
 
         let server = app.world().resource::<AssetServer>().clone();
         let immediate_handle: Handle<ImmediateNested> = server.load("a.immediate");
@@ -2816,12 +2813,12 @@ mod tests {
         });
     }
 
-    pub(crate) fn read_asset_as_string(dir: &Dir, path: &Path) -> String {
+    pub(crate) fn read_asset_as_string(dir: &Dir, path: &str) -> String {
         let bytes = dir.get_asset(path).unwrap();
         str::from_utf8(bytes.value()).unwrap().to_string()
     }
 
-    pub(crate) fn read_meta_as_string(dir: &Dir, path: &Path) -> String {
+    pub(crate) fn read_meta_as_string(dir: &Dir, path: &str) -> String {
         let bytes = dir.get_metadata(path).unwrap();
         str::from_utf8(bytes.value()).unwrap().to_string()
     }
@@ -2833,13 +2830,13 @@ mod tests {
         app.register_asset_loader(CoolTextLoader);
 
         const ASSET_PATH: &str = "abc.cool.ron";
-        source.insert_asset_text(Path::new(ASSET_PATH), "blah");
+        source.insert_asset_text(ASSET_PATH, "blah");
 
         let asset_server = app.world().resource::<AssetServer>().clone();
         block_on(asset_server.write_default_loader_meta_file_for_path(ASSET_PATH)).unwrap();
 
         assert_eq!(
-            read_meta_as_string(&source, Path::new(ASSET_PATH)),
+            read_meta_as_string(&source, ASSET_PATH),
             r#"(
     meta_format_version: "1.0",
     asset: Load(
@@ -2857,9 +2854,9 @@ mod tests {
         app.register_asset_loader(CoolTextLoader);
 
         const ASSET_PATH: &str = "abc.cool.ron";
-        source.insert_asset_text(Path::new(ASSET_PATH), "blah");
+        source.insert_asset_text(ASSET_PATH, "blah");
         const META_TEXT: &str = "hey i'm walkin here!";
-        source.insert_meta_text(Path::new(ASSET_PATH), META_TEXT);
+        source.insert_meta_text(ASSET_PATH, META_TEXT);
 
         let asset_server = app.world().resource::<AssetServer>().clone();
         assert!(matches!(
@@ -2867,10 +2864,7 @@ mod tests {
             Err(WriteDefaultMetaError::MetaAlreadyExists)
         ));
 
-        assert_eq!(
-            read_meta_as_string(&source, Path::new(ASSET_PATH)),
-            META_TEXT
-        );
+        assert_eq!(read_meta_as_string(&source, ASSET_PATH), META_TEXT);
     }
 
     #[test]
@@ -2911,8 +2905,8 @@ mod tests {
 
         // Write some data so the loaders have something to load (even though they don't use the
         // data).
-        dir.insert_asset_text(Path::new("abc.ron"), "");
-        dir.insert_asset_text(Path::new("blah.with_deps"), "");
+        dir.insert_asset_text("abc.ron", "");
+        dir.insert_asset_text("blah.with_deps", "");
 
         let (in_loader_sender, in_loader_receiver) = async_channel::bounded(1);
         let (gate_sender, gate_receiver) = async_channel::bounded(1);
@@ -3027,7 +3021,7 @@ mod tests {
             .register_asset_loader(CoolTextLoader);
 
         dir.insert_asset_text(
-            Path::new("test.cool.ron"),
+            "test.cool.ron",
             r#"
 (
     text: "test",
@@ -3037,7 +3031,7 @@ mod tests {
 )"#,
         );
 
-        dir.insert_asset_text(Path::new("malformed.cool.ron"), "MALFORMED");
+        dir.insert_asset_text("malformed.cool.ron", "MALFORMED");
 
         let asset_server = app.world().resource::<AssetServer>().clone();
         let handle = asset_server.load::<A>(path);
@@ -3193,9 +3187,9 @@ mod tests {
     #[test]
     fn resource_are_dependencies_loaded() {
         let (mut app, dir) = create_app();
-        dir.insert_asset_text(Path::new("abc.txt"), "");
-        dir.insert_asset_text(Path::new("def.txt"), "");
-        dir.insert_asset_text(Path::new("ghi.txt"), "");
+        dir.insert_asset_text("abc.txt", "");
+        dir.insert_asset_text("def.txt", "");
+        dir.insert_asset_text("ghi.txt", "");
 
         app.init_asset::<TestAsset>()
             .register_asset_loader(TrivialLoader);
@@ -3241,8 +3235,8 @@ mod tests {
             .init_asset::<SubText>()
             .register_asset_loader(CoolTextLoader);
 
-        let abc_path = Path::new("dir/abc.cool.ron");
-        let def_path = Path::new("dir/def.cool.ron");
+        let abc_path = "dir/abc.cool.ron";
+        let def_path = "dir/def.cool.ron";
         dir.insert_asset_text(abc_path, &serialize_as_cool_text("abc"));
         dir.insert_asset_text(def_path, &serialize_as_cool_text("def"));
 
@@ -3268,7 +3262,7 @@ mod tests {
             .map(UntypedHandle::typed::<CoolText>)
             .collect::<Vec<_>>();
         // Sort the handles so we know abc is first and def is second.
-        handles.sort_by_key(|handle| handle.path().unwrap().path().to_path_buf());
+        handles.sort_by_key(|handle| handle.path().unwrap().path().to_string());
 
         let abc_handle = handles[0].clone();
         let def_handle = handles[1].clone();
@@ -3283,10 +3277,10 @@ mod tests {
             .clear();
 
         // Add a new asset to the folder, and send an event to trigger hot-reloading.
-        let ghi_path = Path::new("dir/ghi.cool.ron");
+        let ghi_path = "dir/ghi.cool.ron";
         dir.insert_asset_text(ghi_path, &serialize_as_cool_text("ghi"));
         event_sender
-            .send_blocking(AssetSourceEvent::AddedAsset(ghi_path.to_path_buf()))
+            .send_blocking(AssetSourceEvent::AddedAsset(ghi_path.to_string()))
             .unwrap();
 
         run_app_until(&mut app, |world| {
@@ -3316,7 +3310,7 @@ mod tests {
             .map(UntypedHandle::typed::<CoolText>)
             .collect::<Vec<_>>();
         // Sort the handles so we know the order is abc, def, and ghi.
-        handles.sort_by_key(|handle| handle.path().unwrap().path().to_path_buf());
+        handles.sort_by_key(|handle| handle.path().unwrap().path().to_string());
 
         let new_abc_handle = handles[0].clone();
         let new_def_handle = handles[1].clone();

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -6,7 +6,11 @@ use crate::{
     Asset, AssetIndex, AssetLoadError, AssetServer, AssetServerMode, Assets, ErasedAssetIndex,
     Handle, UntypedAssetId, UntypedHandle,
 };
-use alloc::{boxed::Box, string::ToString, vec::Vec};
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+    vec::Vec,
+};
 use atomicow::CowArc;
 use bevy_ecs::{error::BevyError, world::World};
 use bevy_platform::collections::{hash_map::Entry, HashMap, HashSet};
@@ -16,7 +20,6 @@ use core::any::{Any, TypeId};
 use downcast_rs::{impl_downcast, Downcast};
 use ron::error::SpannedError;
 use serde::{Deserialize, Serialize};
-use std::path::{Path, PathBuf};
 use thiserror::Error;
 use tracing::error;
 
@@ -569,7 +572,7 @@ impl<'a> LoadContext<'a> {
         path: impl Into<AssetPath<'c>>,
     ) -> Result<Vec<u8>, ReadAssetBytesError> {
         let path = path.into();
-        if path.path() == Path::new("") {
+        if path.path() == "" {
             error!("Attempted to load an asset with an empty path \"{path}\"!");
             return Err(ReadAssetBytesError::EmptyPath(path.into_owned()));
         }
@@ -598,7 +601,7 @@ impl<'a> LoadContext<'a> {
             .read_to_end(&mut bytes)
             .await
             .map_err(|source| ReadAssetBytesError::Io {
-                path: path.path().to_path_buf(),
+                path: path.path().to_string(),
                 source,
             })?;
         self.loader_dependencies.insert(path.clone_owned(), hash);
@@ -698,9 +701,9 @@ pub enum ReadAssetBytesError {
     #[error(transparent)]
     MissingProcessedAssetReaderError(#[from] MissingProcessedAssetReaderError),
     /// Encountered an I/O error while loading an asset.
-    #[error("Encountered an io error while loading asset at `{}`: {source}", path.display())]
+    #[error("Encountered an io error while loading asset at `{path}`: {source}")]
     Io {
-        path: PathBuf,
+        path: String,
         source: std::io::Error,
     },
     #[error("The LoadContext for this read_asset_bytes call requires hash metadata, but it was not provided. This is likely an internal implementation error.")]

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -712,6 +712,230 @@ pub(crate) fn normalize_path(path: &Path) -> PathBuf {
     result_path
 }
 
+pub const PATH_SEPARATOR: char = '/';
+
+/// Splits `path` into its directory and basename.
+///
+/// This assumes the given path uses `/` has its path delimiter. If the path ends in a slash, the
+/// basename will be [`None`]. If the path is absolute (starts with a slash), the directory may be
+/// [`None`].
+///
+/// ```rust
+/// # use bevy_asset::split_path;
+/// assert_eq!(split_path(""), (None, None));
+/// assert_eq!(split_path("foo"), (None, Some("foo")));
+/// assert_eq!(split_path("foo/bar"), (Some("foo"), Some("bar")));
+/// assert_eq!(split_path("/foo/bar"), (Some("/foo"), Some("bar")));
+/// assert_eq!(split_path("/foo/"), (Some("/foo"), None));
+/// ```
+pub fn split_path<'a>(path: &'a str) -> (Option<&'a str>, Option<&'a str>) {
+    let (parent, basename) = match path.rfind(PATH_SEPARATOR) {
+        Some(slash) => (&path[..slash], &path[(slash + 1)..]),
+        None => ("", path),
+    };
+    (
+        (!parent.is_empty()).then_some(parent),
+        (!basename.is_empty()).then_some(basename),
+    )
+}
+
+/// Returns the directory of `path`.
+///
+/// This assumes the given path uses `/` has its path delimiter. If the path ends in a slash, the
+/// basename will be the empty string. If the path is absolute (starts with a slash), and the path
+/// has only one components (e.g., `/blah.txt`), [`None`] is returned.
+///
+/// ```rust
+/// # use bevy_asset::path_parent;
+/// assert_eq!(path_parent(""), None);
+/// assert_eq!(path_parent("foo"), Some(""));
+/// assert_eq!(path_parent("foo/bar"), Some("foo"));
+/// assert_eq!(path_parent("/foo/bar"), Some("/foo"));
+/// assert_eq!(path_parent("/foo/"), Some("/foo"));
+/// ```
+pub fn path_parent<'a>(path: &'a str) -> Option<&'a str> {
+    let (parent, basename) = split_path(path);
+    parent.or_else(|| basename.map(|_| ""))
+}
+
+/// Returns the basename of `path`.
+///
+/// This assumes the given path uses `/` as its path delimiter. If the path ends in a slash,
+/// [`None`] is returned.
+///
+/// ```rust
+/// # use bevy_asset::path_basename;
+/// assert_eq!(path_basename(""), None);
+/// assert_eq!(path_basename("foo"), Some("foo"));
+/// assert_eq!(path_basename("foo/bar"), Some("bar"));
+/// assert_eq!(path_basename("/foo/bar"), Some("bar"));
+/// assert_eq!(path_basename("/foo/"), None);
+/// ```
+pub fn path_basename<'a>(path: &'a str) -> Option<&'a str> {
+    split_path(path).1
+}
+
+/// Returns the individual components of `path`.
+///
+/// This assumes the given path uses `/` as its path delimiter.
+///
+/// ```rust
+/// # use bevy_asset::path_components;
+/// let mut components = path_components("/foo/bar");
+/// assert_eq!(components.next(), Some("foo"));
+/// assert_eq!(components.next(), Some("bar"));
+/// assert_eq!(components.next(), None);
+/// ```
+pub fn path_components<'a>(mut path: &'a str) -> impl Iterator<Item = &'a str> {
+    path = path.strip_prefix(PATH_SEPARATOR).unwrap_or(path);
+    path = path.strip_suffix(PATH_SEPARATOR).unwrap_or(path);
+    path.split(PATH_SEPARATOR)
+        .filter(|component| !component.is_empty())
+}
+
+/// Returns the ancestors of `path` (including `path`).
+///
+/// This assumes the given path uses `/` as its path delimiter.
+///
+/// ```rust
+/// # use bevy_asset::path_ancestors;
+/// let mut ancestors = path_ancestors("/foo/bar");
+/// assert_eq!(ancestors.next(), Some("/foo/bar"));
+/// assert_eq!(ancestors.next(), Some("/foo"));
+/// assert_eq!(ancestors.next(), Some("/"));
+/// assert_eq!(ancestors.next(), None);
+///
+/// let mut ancestors = path_ancestors("../foo/bar");
+/// assert_eq!(ancestors.next(), Some("../foo/bar"));
+/// assert_eq!(ancestors.next(), Some("../foo"));
+/// assert_eq!(ancestors.next(), Some(".."));
+/// assert_eq!(ancestors.next(), None);
+/// ```
+pub fn path_ancestors<'a>(mut path: &'a str) -> impl Iterator<Item = &'a str> {
+    if path != "/" {
+        path = path.strip_suffix(PATH_SEPARATOR).unwrap_or(path);
+    }
+    AncestorIter { path: Some(path) }
+}
+
+/// Cleans the given path into a "platform agnostic" path.
+///
+/// Different platforms have different semantics for their file paths. In particular, Windows allows
+/// users to use `\` as a path separator. To address this, we convert the path to a common
+/// unambiguous representation - paths are separated by `/`. Since we don't know whether a path was
+/// created on Windows or not, we must replace all `\` with `/`. As a consequence, paths on all
+/// platforms cannot include `\`.
+///
+/// ```rust
+/// # use bevy_asset::clean_path;
+/// # use atomicow::CowArc;
+/// assert_eq!(clean_path("/foo/bar"), CowArc::Static("/foo/bar"));
+/// assert_eq!(clean_path("C:\\foo\\bar"), CowArc::Owned("C:/foo/bar".into()));
+/// assert_eq!(clean_path("/foo\\bar"), CowArc::Owned("/foo/bar".into()));
+/// ```
+pub fn clean_path<'a>(raw_path: &'a str) -> CowArc<'a, str> {
+    if raw_path.find('\\').is_none() {
+        return CowArc::Borrowed(raw_path);
+    }
+    CowArc::Owned(raw_path.replace('\\', "/").into())
+}
+
+/// Joins the two paths together into a single path.
+///
+/// If `rpath` is an absolute path, it is used entirely (`lpath` is ignored).
+///
+/// ```rust
+/// # use bevy_asset::join_paths;
+/// assert_eq!(join_paths("foo/bar", "baz/quox"), "foo/bar/baz/quox");
+/// assert_eq!(join_paths("foo/bar/", "baz/quox"), "foo/bar/baz/quox");
+/// assert_eq!(join_paths("foo/bar", "/baz/quox"), "/baz/quox");
+/// assert_eq!(join_paths("", "baz/quox"), "baz/quox");
+/// ```
+pub fn join_paths(lpath: &str, rpath: &str) -> String {
+    if lpath.is_empty() {
+        return rpath.to_string();
+    }
+
+    if rpath.starts_with(PATH_SEPARATOR) {
+        return rpath.to_string();
+    }
+
+    if lpath.ends_with(PATH_SEPARATOR) {
+        format!("{lpath}{rpath}")
+    } else {
+        format!("{lpath}/{rpath}")
+    }
+}
+
+/// Returns whether the path is an absolute path (starts with '/').
+///
+/// ```rust
+/// # use bevy_asset::is_absolute_path;
+/// assert!(!is_absolute_path("foo/bar"));
+/// assert!(is_absolute_path("/foo/bar"));
+/// ```
+pub fn is_absolute_path(path: &str) -> bool {
+    path.starts_with(PATH_SEPARATOR)
+}
+
+/// Returns the file extension for the given path.
+///
+/// The file extension is defined as the string after the last `.` in the last path component.
+/// Returns [`None`] if the last component does not contain a dot (or the dot is at the end of the
+/// path).
+///
+/// ```rust
+/// # use bevy_asset::path_file_extension;
+/// assert_eq!(path_file_extension("foo/bar.png"), Some("png"));
+/// assert_eq!(path_file_extension("foo/bar."), None);
+/// assert_eq!(path_file_extension("foo/.png"), Some("png"));
+/// assert_eq!(path_file_extension("foo.png"), Some("png"));
+/// assert_eq!(path_file_extension("foo.png/ok_thats_odd"), None);
+/// ```
+pub fn path_file_extension(path: &str) -> Option<&str> {
+    let path = path_basename(path).unwrap_or(path);
+    let dot = path.rfind('.')?;
+
+    if dot + 1 == path.len() {
+        // The dot is the last character, so there's nothing in the extension.
+        return None;
+    }
+
+    // TODO: Should we strip off query parameters like `get_full_extension`?
+
+    Some(&path[(dot + 1)..])
+}
+
+/// Iterator for the ancestors of a file path - including the path itself.
+struct AncestorIter<'a> {
+    /// The path for which to get the ancestors.
+    ///
+    /// This is [`None`] if the path has no more ancestors.
+    path: Option<&'a str>,
+}
+
+impl<'a> Iterator for AncestorIter<'a> {
+    type Item = &'a str;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let path = self.path?;
+        if let Some(slash) = path.rfind(PATH_SEPARATOR) {
+            self.path = if slash == 0 {
+                if path == "/" {
+                    None
+                } else {
+                    Some("/")
+                }
+            } else {
+                Some(&path[..slash])
+            };
+        } else {
+            self.path = None;
+        }
+        Some(path)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::AssetPath;

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -1,6 +1,7 @@
 use crate::io::AssetSourceId;
 use alloc::{
     borrow::ToOwned,
+    format,
     string::{String, ToString},
 };
 use atomicow::CowArc;
@@ -11,7 +12,6 @@ use core::{
     ops::Deref,
 };
 use serde::{de::Visitor, Deserialize, Serialize};
-use std::path::{Path, PathBuf};
 use thiserror::Error;
 
 /// Represents a path to an asset in a "virtual filesystem".
@@ -56,7 +56,7 @@ use thiserror::Error;
 #[reflect(Debug, PartialEq, Hash, Clone, Serialize, Deserialize)]
 pub struct AssetPath<'a> {
     source: AssetSourceId<'a>,
-    path: CowArc<'a, Path>,
+    path: CowArc<'a, str>,
     label: Option<CowArc<'a, str>>,
 }
 
@@ -71,7 +71,7 @@ impl<'a> Display for AssetPath<'a> {
         if let AssetSourceId::Name(name) = self.source() {
             write!(f, "{name}://")?;
         }
-        write!(f, "{}", self.path.display())?;
+        write!(f, "{}", self.path)?;
         if let Some(label) = &self.label {
             write!(f, "#{label}")?;
         }
@@ -129,7 +129,7 @@ impl<'a> AssetPath<'a> {
                 Some(source) => AssetSourceId::Name(CowArc::Borrowed(source)),
                 None => AssetSourceId::Default,
             },
-            path: CowArc::Borrowed(path),
+            path: clean_path(path),
             label: label.map(CowArc::Borrowed),
         })
     }
@@ -137,7 +137,7 @@ impl<'a> AssetPath<'a> {
     // Attempts to Parse a &str into an `AssetPath`'s `AssetPath::source`, `AssetPath::path`, and `AssetPath::label` components.
     fn parse_internal(
         asset_path: &str,
-    ) -> Result<(Option<&str>, &Path, Option<&str>), ParseAssetPathError> {
+    ) -> Result<(Option<&str>, &str, Option<&str>), ParseAssetPathError> {
         let chars = asset_path.char_indices();
         let mut source_range = None;
         let mut path_range = 0..asset_path.len();
@@ -158,7 +158,7 @@ impl<'a> AssetPath<'a> {
                 ':' => {
                     source_delimiter_chars_matched = 1;
                 }
-                '/' => {
+                PATH_SEPARATOR => {
                     match source_delimiter_chars_matched {
                         1 => {
                             source_delimiter_chars_matched = 2;
@@ -219,25 +219,31 @@ impl<'a> AssetPath<'a> {
             None => None,
         };
 
-        let path = Path::new(&asset_path[path_range]);
+        let path = &asset_path[path_range];
         Ok((source, path, label))
     }
 
-    /// Creates a new [`AssetPath`] from a [`PathBuf`].
+    /// Creates a new [`AssetPath`] from a [`String`] path.
+    ///
+    /// Unlike [`Self::parse`], this **does not** interpret the string: the string is used as the
+    /// path unconditionally. Prefer [`Self::parse`] where possible.
     #[inline]
-    pub fn from_path_buf(path_buf: PathBuf) -> AssetPath<'a> {
+    pub fn from_string_path(string: String) -> AssetPath<'a> {
         AssetPath {
-            path: CowArc::Owned(path_buf.into()),
+            path: CowArc::Owned(string.into()),
             source: AssetSourceId::Default,
             label: None,
         }
     }
 
-    /// Creates a new [`AssetPath`] from a [`Path`].
+    /// Creates a new [`AssetPath`] from a [`str`] path.
+    ///
+    /// Unlike [`Self::parse`], this **does not** interpret the string: the string is used as the
+    /// path unconditionally. Prefer [`Self::parse`] where possible.
     #[inline]
-    pub fn from_path(path: &'a Path) -> AssetPath<'a> {
+    pub fn from_str_path(s: &'a str) -> AssetPath<'a> {
         AssetPath {
-            path: CowArc::Borrowed(path),
+            path: CowArc::Borrowed(s),
             source: AssetSourceId::Default,
             label: None,
         }
@@ -264,7 +270,7 @@ impl<'a> AssetPath<'a> {
 
     /// Gets the path to the asset in the "virtual filesystem".
     #[inline]
-    pub fn path(&self) -> &Path {
+    pub fn path(&self) -> &str {
         self.path.deref()
     }
 
@@ -314,11 +320,18 @@ impl<'a> AssetPath<'a> {
 
     /// Returns an [`AssetPath`] for the parent folder of this path, if there is a parent folder in the path.
     pub fn parent(&self) -> Option<AssetPath<'a>> {
+        // The root directory doesn't have a parent, so return None.
+        if self.path.as_ref() == "" {
+            return None;
+        }
         let path = match &self.path {
-            CowArc::Borrowed(path) => CowArc::Borrowed(path.parent()?),
-            CowArc::Static(path) => CowArc::Static(path.parent()?),
-            CowArc::Owned(path) => path.parent()?.to_path_buf().into(),
+            CowArc::Borrowed(path) => path_parent(path).map(CowArc::Borrowed),
+            CowArc::Static(path) => path_parent(path).map(CowArc::Static),
+            CowArc::Owned(path) => path_parent(path).map(ToString::to_string).map(Into::into),
         };
+        // If there isn't a parent, then the path refers to an entry in the root directory. So the
+        // parent of that *is* the root directory.
+        let path = path.unwrap_or("".into());
         Some(AssetPath {
             source: self.source.clone(),
             label: None,
@@ -372,7 +385,7 @@ impl<'a> AssetPath<'a> {
     /// See also [`AssetPath::resolve_str`].
     pub fn resolve(&self, path: &AssetPath<'_>) -> AssetPath<'static> {
         let is_label_only = matches!(path.source(), AssetSourceId::Default)
-            && path.path().as_os_str().is_empty()
+            && path.path().is_empty()
             && path.label().is_some();
 
         if is_label_only {
@@ -409,7 +422,7 @@ impl<'a> AssetPath<'a> {
     /// See also [`AssetPath::resolve_embed_str`].
     pub fn resolve_embed(&self, path: &AssetPath<'_>) -> AssetPath<'static> {
         let is_label_only = matches!(path.source(), AssetSourceId::Default)
-            && path.path().as_os_str().is_empty()
+            && path.path().is_empty()
             && path.label().is_some();
 
         if is_label_only {
@@ -448,32 +461,35 @@ impl<'a> AssetPath<'a> {
         &self,
         replace: bool,
         source: Option<&str>,
-        rpath: &Path,
+        rpath: &str,
         rlabel: Option<&str>,
     ) -> AssetPath<'static> {
-        let mut base_path = PathBuf::from(self.path());
-        if replace && !self.path.to_str().unwrap().ends_with('/') {
+        let base_path = if replace
+            && !self.path.ends_with(PATH_SEPARATOR)
+            && let Some(parent) = path_parent(self.path.as_ref())
+        {
             // No error if base is empty (per RFC 1808).
-            base_path.pop();
-        }
+            parent.to_string()
+        } else {
+            self.path.to_string()
+        };
 
         // Strip off leading slash
         let mut is_absolute = false;
-        let rpath = match rpath.strip_prefix("/") {
-            Ok(p) => {
+        let rpath = match rpath.strip_prefix(PATH_SEPARATOR) {
+            Some(p) => {
                 is_absolute = true;
                 p
             }
-            _ => rpath,
+            None => rpath,
         };
 
         let mut result_path = if !is_absolute && source.is_none() {
-            base_path
+            join_paths(&base_path, rpath)
         } else {
-            PathBuf::new()
+            String::from(rpath)
         };
-        result_path.push(rpath);
-        result_path = normalize_path(result_path.as_path());
+        result_path = normalize_path(&result_path);
 
         AssetPath {
             source: match source {
@@ -504,7 +520,7 @@ impl<'a> AssetPath<'a> {
     ///
     /// Also strips out anything following a `?` to handle query parameters in URIs
     pub fn get_full_extension(&self) -> Option<&str> {
-        let file_name = self.path().file_name()?.to_str()?;
+        let file_name = path_basename(self.path())?;
         let index = file_name.find('.')?;
         let mut extension = &file_name[index + 1..];
 
@@ -567,18 +583,22 @@ impl<'a> AssetPath<'a> {
     /// assert!(path.is_unapproved());
     /// ```
     pub fn is_unapproved(&self) -> bool {
-        use std::path::Component;
-        let mut simplified = PathBuf::new();
-        for component in self.path.components() {
+        let mut depth = 0;
+        if self.path.starts_with(PATH_SEPARATOR) {
+            return true;
+        }
+        for component in path_components(self.path.as_ref()) {
             match component {
-                Component::Prefix(_) | Component::RootDir => return true,
-                Component::CurDir => {}
-                Component::ParentDir => {
-                    if !simplified.pop() {
+                "." => {}
+                ".." => {
+                    if depth == 0 {
                         return true;
                     }
+                    depth -= 1;
                 }
-                Component::Normal(os_str) => simplified.push(os_str),
+                _ => {
+                    depth += 1;
+                }
             }
         }
 
@@ -595,7 +615,11 @@ impl From<&'static str> for AssetPath<'static> {
         let (source, path, label) = Self::parse_internal(asset_path).unwrap();
         AssetPath {
             source: source.into(),
-            path: CowArc::Static(path),
+            path: if path.contains('\\') {
+                clean_path(path)
+            } else {
+                CowArc::Static(path)
+            },
             label: label.map(CowArc::Static),
         }
     }
@@ -615,37 +639,9 @@ impl From<String> for AssetPath<'static> {
     }
 }
 
-impl From<&'static Path> for AssetPath<'static> {
-    #[inline]
-    fn from(path: &'static Path) -> Self {
-        Self {
-            source: AssetSourceId::Default,
-            path: CowArc::Static(path),
-            label: None,
-        }
-    }
-}
-
-impl From<PathBuf> for AssetPath<'static> {
-    #[inline]
-    fn from(path: PathBuf) -> Self {
-        Self {
-            source: AssetSourceId::Default,
-            path: path.into(),
-            label: None,
-        }
-    }
-}
-
 impl<'a, 'b> From<&'a AssetPath<'b>> for AssetPath<'b> {
     fn from(value: &'a AssetPath<'b>) -> Self {
         value.clone()
-    }
-}
-
-impl<'a> From<AssetPath<'a>> for PathBuf {
-    fn from(value: AssetPath<'a>) -> Self {
-        value.path().to_path_buf()
     }
 }
 
@@ -689,24 +685,30 @@ impl<'de> Visitor<'de> for AssetPathVisitor {
 
 /// Normalizes the path by collapsing all occurrences of '.' and '..' dot-segments where possible
 /// as per [RFC 1808](https://datatracker.ietf.org/doc/html/rfc1808)
-pub(crate) fn normalize_path(path: &Path) -> PathBuf {
-    let mut result_path = PathBuf::new();
-    for elt in path.iter() {
+pub(crate) fn normalize_path(path: &str) -> String {
+    let mut result_path = String::new();
+    for elt in path_components(path) {
         if elt == "." {
             // Skip
         } else if elt == ".." {
-            // Note: If the result_path ends in `..`, Path::file_name returns None, so we'll end up
-            // preserving it.
-            if result_path.file_name().is_some() {
-                // This assert is just a sanity check - we already know the path has a file_name, so
-                // we know there is something to pop.
-                assert!(result_path.pop());
+            let (index, basename) = match result_path.rfind(PATH_SEPARATOR) {
+                None => (0, result_path.as_str()),
+                Some(index) => (index, &result_path[(index + 1)..]),
+            };
+            if basename != ".." && !basename.is_empty() {
+                result_path.drain(index..);
             } else {
                 // Preserve ".." if insufficient matches (per RFC 1808).
-                result_path.push(elt);
+                if !result_path.is_empty() {
+                    result_path.push(PATH_SEPARATOR);
+                }
+                result_path.push_str(elt);
             }
         } else {
-            result_path.push(elt);
+            if !result_path.is_empty() {
+                result_path.push(PATH_SEPARATOR);
+            }
+            result_path.push_str(elt);
         }
     }
     result_path
@@ -939,35 +941,28 @@ impl<'a> Iterator for AncestorIter<'a> {
 #[cfg(test)]
 mod tests {
     use crate::AssetPath;
-    use std::path::Path;
 
     #[test]
     fn parse_asset_path() {
         let result = AssetPath::parse_internal("a/b.test");
-        assert_eq!(result, Ok((None, Path::new("a/b.test"), None)));
+        assert_eq!(result, Ok((None, "a/b.test", None)));
 
         let result = AssetPath::parse_internal("http://a/b.test");
-        assert_eq!(result, Ok((Some("http"), Path::new("a/b.test"), None)));
+        assert_eq!(result, Ok((Some("http"), "a/b.test", None)));
 
         let result = AssetPath::parse_internal("http://a/b.test#Foo");
-        assert_eq!(
-            result,
-            Ok((Some("http"), Path::new("a/b.test"), Some("Foo")))
-        );
+        assert_eq!(result, Ok((Some("http"), "a/b.test", Some("Foo"))));
 
         let result = AssetPath::parse_internal("localhost:80/b.test");
-        assert_eq!(result, Ok((None, Path::new("localhost:80/b.test"), None)));
+        assert_eq!(result, Ok((None, "localhost:80/b.test", None)));
 
         let result = AssetPath::parse_internal("http://localhost:80/b.test");
-        assert_eq!(
-            result,
-            Ok((Some("http"), Path::new("localhost:80/b.test"), None))
-        );
+        assert_eq!(result, Ok((Some("http"), "localhost:80/b.test", None)));
 
         let result = AssetPath::parse_internal("http://localhost:80/b.test#Foo");
         assert_eq!(
             result,
-            Ok((Some("http"), Path::new("localhost:80/b.test"), Some("Foo")))
+            Ok((Some("http"), "localhost:80/b.test", Some("Foo")))
         );
 
         let result = AssetPath::parse_internal("#insource://a/b.test");
@@ -983,7 +978,7 @@ mod tests {
         );
 
         let result = AssetPath::parse_internal("http://");
-        assert_eq!(result, Ok((Some("http"), Path::new(""), None)));
+        assert_eq!(result, Ok((Some("http"), "", None)));
 
         let result = AssetPath::parse_internal("://x");
         assert_eq!(result, Err(crate::ParseAssetPathError::MissingSource));
@@ -1364,19 +1359,19 @@ mod tests {
         );
         assert_eq!(
             base.resolve_str("/martin/stephan#dave").unwrap(),
-            AssetPath::from("martin/stephan/#dave")
+            AssetPath::from("martin/stephan#dave")
         );
         assert_eq!(
             base.resolve(&AssetPath::parse("/martin/stephan#dave")),
-            AssetPath::from("martin/stephan/#dave")
+            AssetPath::from("martin/stephan#dave")
         );
         assert_eq!(
             base.resolve_embed_str("/martin/stephan#dave").unwrap(),
-            AssetPath::from("martin/stephan/#dave")
+            AssetPath::from("martin/stephan#dave")
         );
         assert_eq!(
             base.resolve_embed(&AssetPath::parse("/martin/stephan#dave")),
-            AssetPath::from("martin/stephan/#dave")
+            AssetPath::from("martin/stephan#dave")
         );
     }
 
@@ -1402,20 +1397,20 @@ mod tests {
         );
         assert_eq!(
             base.resolve_str("source://martin/stephan#dave").unwrap(),
-            AssetPath::from("source://martin/stephan/#dave")
+            AssetPath::from("source://martin/stephan#dave")
         );
         assert_eq!(
             base.resolve(&AssetPath::parse("source://martin/stephan#dave")),
-            AssetPath::from("source://martin/stephan/#dave")
+            AssetPath::from("source://martin/stephan#dave")
         );
         assert_eq!(
             base.resolve_embed_str("source://martin/stephan#dave")
                 .unwrap(),
-            AssetPath::from("source://martin/stephan/#dave")
+            AssetPath::from("source://martin/stephan#dave")
         );
         assert_eq!(
             base.resolve_embed(&AssetPath::parse("source://martin/stephan#dave")),
-            AssetPath::from("source://martin/stephan/#dave")
+            AssetPath::from("source://martin/stephan#dave")
         );
     }
 

--- a/crates/bevy_asset/src/processor/mod.rs
+++ b/crates/bevy_asset/src/processor/mod.rs
@@ -49,12 +49,14 @@ use crate::{
         AssetReaderError, AssetSource, AssetSourceBuilders, AssetSourceEvent, AssetSourceId,
         AssetSources, AssetWriterError, ErasedAssetReader, MissingAssetSourceError,
     },
+    is_absolute_path,
     meta::{
         get_asset_hash, get_full_asset_hash, AssetAction, AssetActionMinimal, AssetHash, AssetMeta,
         AssetMetaDyn, AssetMetaMinimal, ProcessedInfo, ProcessedInfoMinimal,
     },
-    AssetLoadError, AssetMetaCheck, AssetPath, AssetServer, AssetServerMode, DeserializeMetaError,
-    MissingAssetLoaderForExtensionError, UnapprovedPathMode, WriteDefaultMetaError,
+    path_parent, AssetLoadError, AssetMetaCheck, AssetPath, AssetServer, AssetServerMode,
+    DeserializeMetaError, MissingAssetLoaderForExtensionError, UnapprovedPathMode,
+    WriteDefaultMetaError,
 };
 use alloc::{borrow::ToOwned, boxed::Box, string::String, sync::Arc, vec, vec::Vec};
 use bevy_ecs::prelude::*;
@@ -66,10 +68,7 @@ use bevy_tasks::IoTaskPool;
 use futures_io::ErrorKind;
 use futures_lite::{AsyncWriteExt, StreamExt};
 use futures_util::{select_biased, FutureExt};
-use std::{
-    path::{Path, PathBuf},
-    sync::Mutex,
-};
+use std::sync::Mutex;
 use thiserror::Error;
 use tracing::{debug, error, trace, warn};
 
@@ -292,10 +291,10 @@ impl AssetProcessor {
     /// Sends start task events for all assets in all processed sources into `sender`.
     async fn queue_initial_processing_tasks(
         &self,
-        sender: &async_channel::Sender<(AssetSourceId<'static>, PathBuf)>,
+        sender: &async_channel::Sender<(AssetSourceId<'static>, String)>,
     ) {
         for source in self.sources().iter_processed() {
-            self.queue_processing_tasks_for_folder(source, PathBuf::from(""), sender)
+            self.queue_processing_tasks_for_folder(source, String::from(""), sender)
                 .await
                 .unwrap();
         }
@@ -305,7 +304,7 @@ impl AssetProcessor {
     /// response.
     fn spawn_source_change_event_listeners(
         &self,
-        sender: &async_channel::Sender<(AssetSourceId<'static>, PathBuf)>,
+        sender: &async_channel::Sender<(AssetSourceId<'static>, String)>,
     ) {
         for source in self.data.sources.iter_processed() {
             let Some(receiver) = source.event_receiver().cloned() else {
@@ -337,8 +336,8 @@ impl AssetProcessor {
     /// the initial tasks are processed.
     async fn execute_processing_tasks(
         &self,
-        new_task_sender: async_channel::Sender<(AssetSourceId<'static>, PathBuf)>,
-        new_task_receiver: async_channel::Receiver<(AssetSourceId<'static>, PathBuf)>,
+        new_task_sender: async_channel::Sender<(AssetSourceId<'static>, String)>,
+        new_task_receiver: async_channel::Receiver<(AssetSourceId<'static>, String)>,
     ) {
         // Convert the Sender into a WeakSender so that once all task producers terminate (and drop
         // their sender), this task doesn't keep itself alive. We still however need a way to get
@@ -359,7 +358,7 @@ impl AssetProcessor {
                 .await;
         }
         enum ProcessorTaskEvent {
-            Start(AssetSourceId<'static>, PathBuf),
+            Start(AssetSourceId<'static>, String),
             Finished,
         }
         let (task_finished_sender, task_finished_receiver) = async_channel::unbounded::<()>();
@@ -487,7 +486,7 @@ impl AssetProcessor {
         &self,
         source: &AssetSource,
         event: AssetSourceEvent,
-        new_task_sender: &async_channel::Sender<(AssetSourceId<'static>, PathBuf)>,
+        new_task_sender: &async_channel::Sender<(AssetSourceId<'static>, String)>,
     ) {
         trace!("{event:?}");
         match event {
@@ -571,14 +570,14 @@ impl AssetProcessor {
                                 error!(
                                     "Path '{}' was removed, but the destination reader could not determine if it \
                                     was a folder or a file due to the following error: {err}",
-                                    AssetPath::from_path(&path).with_source(source.id())
+                                    AssetPath::from_str_path(&path).with_source(source.id())
                                 );
                             }
                             AssetReaderError::HttpError(status) => {
                                 error!(
                                     "Path '{}' was removed, but the destination reader could not determine if it \
                                     was a folder or a file due to receiving an unexpected HTTP Status {status}",
-                                    AssetPath::from_path(&path).with_source(source.id())
+                                    AssetPath::from_str_path(&path).with_source(source.id())
                                 );
                             }
                         }
@@ -591,12 +590,12 @@ impl AssetProcessor {
     async fn handle_added_folder(
         &self,
         source: &AssetSource,
-        path: PathBuf,
-        new_task_sender: &async_channel::Sender<(AssetSourceId<'static>, PathBuf)>,
+        path: String,
+        new_task_sender: &async_channel::Sender<(AssetSourceId<'static>, String)>,
     ) {
         debug!(
             "Folder {} was added. Attempting to re-process",
-            AssetPath::from_path(&path).with_source(source.id())
+            AssetPath::from_str_path(&path).with_source(source.id())
         );
         self.queue_processing_tasks_for_folder(source, path, new_task_sender)
             .await
@@ -607,8 +606,8 @@ impl AssetProcessor {
     async fn handle_removed_meta(
         &self,
         source: &AssetSource,
-        path: PathBuf,
-        new_task_sender: &async_channel::Sender<(AssetSourceId<'static>, PathBuf)>,
+        path: String,
+        new_task_sender: &async_channel::Sender<(AssetSourceId<'static>, String)>,
     ) {
         // If meta was removed, we might need to regenerate it.
         // Likewise, the user might be manually re-adding the asset.
@@ -616,17 +615,14 @@ impl AssetProcessor {
         // user-initiated action.
         debug!(
             "Meta for asset {} was removed. Attempting to re-process",
-            AssetPath::from_path(&path).with_source(source.id())
+            AssetPath::from_str_path(&path).with_source(source.id())
         );
         let _ = new_task_sender.send((source.id(), path)).await;
     }
 
     /// Removes all processed assets stored at the given path (respecting transactionality), then removes the folder itself.
-    async fn handle_removed_folder(&self, source: &AssetSource, path: &Path) {
-        debug!(
-            "Removing folder {} because source was removed",
-            path.display()
-        );
+    async fn handle_removed_folder(&self, source: &AssetSource, path: &str) {
+        debug!("Removing folder {path} because source was removed",);
         let processed_reader = source.ungated_processed_reader().unwrap();
         match processed_reader.read_directory(path).await {
             Ok(mut path_stream) => {
@@ -661,7 +657,7 @@ impl AssetProcessor {
                     // we can ignore NotFound because if the "final" file in a folder was removed
                     // then we automatically clean up this folder
                     if err.kind() != ErrorKind::NotFound {
-                        let asset_path = AssetPath::from_path(path).with_source(source.id());
+                        let asset_path = AssetPath::from_str_path(path).with_source(source.id());
                         error!("Failed to remove destination folder that no longer exists in {asset_path}: {err}");
                     }
                 }
@@ -671,7 +667,7 @@ impl AssetProcessor {
 
     /// Removes the processed version of an asset and associated in-memory metadata. This will block until all existing reads/writes to the
     /// asset have finished, thanks to the `file_transaction_lock`.
-    async fn handle_removed_asset(&self, source: &AssetSource, path: PathBuf) {
+    async fn handle_removed_asset(&self, source: &AssetSource, path: String) {
         let asset_path = AssetPath::from(path).with_source(source.id());
         debug!("Removing processed {asset_path} because source was removed");
         let lock = {
@@ -695,9 +691,9 @@ impl AssetProcessor {
     async fn handle_renamed_asset(
         &self,
         source: &AssetSource,
-        old: PathBuf,
-        new: PathBuf,
-        new_task_sender: &async_channel::Sender<(AssetSourceId<'static>, PathBuf)>,
+        old: String,
+        new: String,
+        new_task_sender: &async_channel::Sender<(AssetSourceId<'static>, String)>,
     ) {
         let old = AssetPath::from(old).with_source(source.id());
         let new = AssetPath::from(new).with_source(source.id());
@@ -727,8 +723,8 @@ impl AssetProcessor {
     async fn queue_processing_tasks_for_folder(
         &self,
         source: &AssetSource,
-        path: PathBuf,
-        new_task_sender: &async_channel::Sender<(AssetSourceId<'static>, PathBuf)>,
+        path: String,
+        new_task_sender: &async_channel::Sender<(AssetSourceId<'static>, String)>,
     ) -> Result<(), AssetReaderError> {
         if source.reader().is_directory(&path).await? {
             let mut path_stream = source.reader().read_directory(&path).await?;
@@ -842,9 +838,9 @@ impl AssetProcessor {
         /// folders when they are discovered.
         async fn get_asset_paths(
             reader: &dyn ErasedAssetReader,
-            path: PathBuf,
-            paths: &mut Vec<PathBuf>,
-            mut empty_dirs: Option<&mut Vec<PathBuf>>,
+            path: String,
+            paths: &mut Vec<String>,
+            mut empty_dirs: Option<&mut Vec<String>>,
         ) -> Result<bool, AssetReaderError> {
             if reader.is_directory(&path).await? {
                 let mut path_stream = reader.read_directory(&path).await?;
@@ -862,7 +858,7 @@ impl AssetProcessor {
                 // Add the current directory after all its subdirectories so we delete any empty
                 // subdirectories before the current directory.
                 if !contains_files
-                    && path.parent().is_some()
+                    && path_parent(&path).is_some()
                     && let Some(empty_dirs) = empty_dirs
                 {
                     empty_dirs.push(path);
@@ -884,7 +880,7 @@ impl AssetProcessor {
             let mut unprocessed_paths = Vec::new();
             get_asset_paths(
                 source.reader(),
-                PathBuf::from(""),
+                String::from(""),
                 &mut unprocessed_paths,
                 None,
             )
@@ -895,7 +891,7 @@ impl AssetProcessor {
             let mut empty_dirs = Vec::new();
             get_asset_paths(
                 processed_reader,
-                PathBuf::from(""),
+                String::from(""),
                 &mut processed_paths,
                 Some(&mut empty_dirs),
             )
@@ -971,7 +967,7 @@ impl AssetProcessor {
 
     /// Removes the processed version of an asset and its metadata, if it exists. This _is not_ transactional like `remove_processed_asset_transactional`, nor
     /// does it remove existing in-memory metadata.
-    async fn remove_processed_asset_and_meta(&self, source: &AssetSource, path: &Path) {
+    async fn remove_processed_asset_and_meta(&self, source: &AssetSource, path: &str) {
         if let Err(err) = source.processed_writer().unwrap().remove(path).await {
             warn!("Failed to remove non-existent asset {path:?}: {err}");
         }
@@ -984,15 +980,15 @@ impl AssetProcessor {
             .await;
     }
 
-    async fn clean_empty_processed_ancestor_folders(&self, source: &AssetSource, mut path: &Path) {
+    async fn clean_empty_processed_ancestor_folders(&self, source: &AssetSource, mut path: &str) {
         // As a safety precaution don't delete absolute paths to avoid deleting folders outside of the destination folder
-        if path.is_absolute() {
+        if is_absolute_path(path) {
             error!("Attempted to clean up ancestor folders of an absolute path. This is unsafe so the operation was skipped.");
             return;
         }
-        while let Some(parent) = path.parent() {
+        while let Some(parent) = path_parent(path) {
             path = parent;
-            if parent == Path::new("") {
+            if parent.is_empty() {
                 break;
             }
             if source
@@ -1018,8 +1014,8 @@ impl AssetProcessor {
     async fn process_asset(
         &self,
         source: &AssetSource,
-        path: PathBuf,
-        processor_task_event: async_channel::Sender<(AssetSourceId<'static>, PathBuf)>,
+        path: String,
+        processor_task_event: async_channel::Sender<(AssetSourceId<'static>, String)>,
     ) {
         let asset_path = AssetPath::from(path).with_source(source.id());
         let result = self.process_asset_internal(source, &asset_path).await;
@@ -1321,10 +1317,7 @@ impl AssetProcessor {
                     let Ok(processed_writer) = source.processed_writer() else {
                         continue;
                     };
-                    if let Err(err) = processed_writer
-                        .remove_assets_in_directory(Path::new(""))
-                        .await
-                    {
+                    if let Err(err) = processed_writer.remove_assets_in_directory("").await {
                         panic!("Processed assets were in a bad state. To correct this, the asset processor attempted to remove all processed assets and start from scratch. This failed. There is no way to continue. Try restarting, or deleting imported asset folder manually. {err}");
                     }
                 }
@@ -1616,7 +1609,7 @@ impl ProcessorAssetInfos {
         &mut self,
         asset_path: AssetPath<'static>,
         result: Result<ProcessResult, ProcessError>,
-        reprocess_sender: async_channel::Sender<(AssetSourceId<'static>, PathBuf)>,
+        reprocess_sender: async_channel::Sender<(AssetSourceId<'static>, String)>,
     ) {
         match result {
             Ok(ProcessResult::Processed(processed_info)) => {
@@ -1727,7 +1720,7 @@ impl ProcessorAssetInfos {
         &mut self,
         old: &AssetPath<'static>,
         new: &AssetPath<'static>,
-        new_task_sender: &async_channel::Sender<(AssetSourceId<'static>, PathBuf)>,
+        new_task_sender: &async_channel::Sender<(AssetSourceId<'static>, String)>,
     ) -> Option<(Arc<async_lock::RwLock<()>>, Arc<async_lock::RwLock<()>>)> {
         let mut info = self.infos.remove(old)?;
         if !info.dependents.is_empty() {

--- a/crates/bevy_asset/src/processor/tests.rs
+++ b/crates/bevy_asset/src/processor/tests.rs
@@ -16,7 +16,6 @@ use core::marker::PhantomData;
 use futures_lite::AsyncWriteExt;
 use ron::ser::PrettyConfig;
 use serde::{Deserialize, Serialize};
-use std::path::Path;
 
 use bevy_app::{App, TaskPoolPlugin};
 use bevy_ecs::error::BevyError;
@@ -199,25 +198,25 @@ impl<R: AssetReader> LockGatedReader<R> {
 }
 
 impl<R: AssetReader> AssetReader for LockGatedReader<R> {
-    async fn read<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
+    async fn read<'a>(&'a self, path: &'a str) -> Result<impl Reader + 'a, AssetReaderError> {
         let _guard = self.gate.read().await;
         self.reader.read(path).await
     }
 
-    async fn read_meta<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
+    async fn read_meta<'a>(&'a self, path: &'a str) -> Result<impl Reader + 'a, AssetReaderError> {
         let _guard = self.gate.read().await;
         self.reader.read_meta(path).await
     }
 
     async fn read_directory<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> Result<Box<PathStream>, AssetReaderError> {
         let _guard = self.gate.read().await;
         self.reader.read_directory(path).await
     }
 
-    async fn is_directory<'a>(&'a self, path: &'a Path) -> Result<bool, AssetReaderError> {
+    async fn is_directory<'a>(&'a self, path: &'a str) -> Result<bool, AssetReaderError> {
         let _guard = self.gate.read().await;
         self.reader.is_directory(path).await
     }
@@ -475,7 +474,7 @@ fn no_meta_or_default_processor_copies_asset() {
 
     let guard = source_gate.write_blocking();
 
-    let path = Path::new("abc.cool.ron");
+    let path = "abc.cool.ron";
     let source_asset = r#"(
     text: "abc",
     dependencies: [],
@@ -520,7 +519,7 @@ fn asset_processor_transforms_asset_default_processor() {
 
     let guard = source_gate.write_blocking();
 
-    let path = Path::new("abc.cool.ron");
+    let path = "abc.cool.ron";
     source_dir.insert_asset_text(
         path,
         r#"(
@@ -573,7 +572,7 @@ fn asset_processor_transforms_asset_with_meta() {
 
     let guard = source_gate.write_blocking();
 
-    let path = Path::new("abc.cool.ron");
+    let path = "abc.cool.ron";
     source_dir.insert_asset_text(
         path,
         r#"(
@@ -637,7 +636,7 @@ fn asset_processor_transforms_asset_with_short_path_meta() {
 
     let guard = source_gate.write_blocking();
 
-    let path = Path::new("abc.cool.ron");
+    let path = "abc.cool.ron";
     source_dir.insert_asset_text(
         path,
         r#"(
@@ -842,7 +841,7 @@ fn asset_processor_loading_can_read_processed_assets() {
 
     let guard = source_gate.write_blocking();
 
-    let gltf_path = Path::new("abc.gltf");
+    let gltf_path = "abc.gltf";
     source_dir.insert_asset_text(
         gltf_path,
         r#"(
@@ -852,7 +851,7 @@ fn asset_processor_loading_can_read_processed_assets() {
     }
 )"#,
     );
-    let bsn_path = Path::new("def.bsn");
+    let bsn_path = "def.bsn";
     // The bsn tries to load the gltf as a bsn. This only works if the bsn can read processed
     // assets.
     source_dir.insert_asset_text(
@@ -1000,7 +999,7 @@ fn asset_processor_loading_can_read_source_assets() {
 
     let guard = source_gate.write_blocking();
 
-    let gltf_path_1 = Path::new("abc.gltf");
+    let gltf_path_1 = "abc.gltf";
     source_dir.insert_asset_text(
         gltf_path_1,
         r#"(
@@ -1010,7 +1009,7 @@ fn asset_processor_loading_can_read_source_assets() {
     }
 )"#,
     );
-    let gltf_path_2 = Path::new("def.gltf");
+    let gltf_path_2 = "def.gltf";
     source_dir.insert_asset_text(
         gltf_path_2,
         r#"(
@@ -1021,7 +1020,7 @@ fn asset_processor_loading_can_read_source_assets() {
 )"#,
     );
 
-    let gltfx_path = Path::new("xyz.gltfx");
+    let gltfx_path = "xyz.gltfx";
     source_dir.insert_asset_text(
         gltfx_path,
         r#"(
@@ -1122,7 +1121,7 @@ fn asset_processor_processes_all_sources() {
 
     // All the assets will have the same path, but they will still be separately processed since
     // they are in different sources.
-    let path = Path::new("asset.cool.ron");
+    let path = "asset.cool.ron";
     default_source_dir.insert_asset_text(path, &serialize_as_cool_text("default asset"));
     custom_1_source_dir.insert_asset_text(path, &serialize_as_cool_text("custom 1 asset"));
     custom_2_source_dir.insert_asset_text(path, &serialize_as_cool_text("custom 2 asset"));
@@ -1148,7 +1147,7 @@ fn asset_processor_processes_all_sources() {
     // Update the default source asset and notify the watcher.
     default_source_dir.insert_asset_text(path, &serialize_as_cool_text("default asset changed"));
     default_source_events
-        .send_blocking(AssetSourceEvent::ModifiedAsset(path.to_path_buf()))
+        .send_blocking(AssetSourceEvent::ModifiedAsset(path.to_string()))
         .unwrap();
 
     run_app_until_finished_processing(&mut app, guard);
@@ -1173,10 +1172,10 @@ fn asset_processor_processes_all_sources() {
     custom_1_source_dir.insert_asset_text(path, &serialize_as_cool_text("custom 1 asset changed"));
     custom_2_source_dir.insert_asset_text(path, &serialize_as_cool_text("custom 2 asset changed"));
     custom_1_source_events
-        .send_blocking(AssetSourceEvent::ModifiedAsset(path.to_path_buf()))
+        .send_blocking(AssetSourceEvent::ModifiedAsset(path.to_string()))
         .unwrap();
     custom_2_source_events
-        .send_blocking(AssetSourceEvent::ModifiedAsset(path.to_path_buf()))
+        .send_blocking(AssetSourceEvent::ModifiedAsset(path.to_string()))
         .unwrap();
 
     run_app_until_finished_processing(&mut app, guard);
@@ -1314,37 +1313,33 @@ fn nested_loads_of_processed_asset_reprocesses_on_reload() {
 
     // This test also checks that processing of nested assets can occur across asset sources.
     custom_source_dir.insert_asset_text(
-        Path::new("top.nest"),
+        "top.nest",
         &ron::ser::to_string(&NesterSerialized::Path("middle.nest".into())).unwrap(),
     );
     default_source_dir.insert_asset_text(
-        Path::new("middle.nest"),
+        "middle.nest",
         &ron::ser::to_string(&NesterSerialized::Path("custom://bottom.nest".into())).unwrap(),
     );
-    custom_source_dir
-        .insert_asset_text(Path::new("bottom.nest"), &serialize_as_leaf("leaf".into()));
-    default_source_dir.insert_asset_text(
-        Path::new("unrelated.nest"),
-        &serialize_as_leaf("unrelated".into()),
-    );
+    custom_source_dir.insert_asset_text("bottom.nest", &serialize_as_leaf("leaf".into()));
+    default_source_dir.insert_asset_text("unrelated.nest", &serialize_as_leaf("unrelated".into()));
 
     run_app_until_finished_processing(&mut app, guard);
 
     // The initial processing step should have processed all assets.
     assert_eq!(
-        read_asset_as_string(&custom_processed_dir, Path::new("bottom.nest")),
+        read_asset_as_string(&custom_processed_dir, "bottom.nest"),
         serialize_as_leaf("leaf-ref".into())
     );
     assert_eq!(
-        read_asset_as_string(&default_processed_dir, Path::new("middle.nest")),
+        read_asset_as_string(&default_processed_dir, "middle.nest"),
         serialize_as_leaf("leaf-ref-ref".into())
     );
     assert_eq!(
-        read_asset_as_string(&custom_processed_dir, Path::new("top.nest")),
+        read_asset_as_string(&custom_processed_dir, "top.nest"),
         serialize_as_leaf("leaf-ref-ref-ref".into())
     );
     assert_eq!(
-        read_asset_as_string(&default_processed_dir, Path::new("unrelated.nest")),
+        read_asset_as_string(&default_processed_dir, "unrelated.nest"),
         serialize_as_leaf("unrelated-ref".into())
     );
 
@@ -1359,10 +1354,7 @@ fn nested_loads_of_processed_asset_reprocesses_on_reload() {
     // assets being reprocessed.
     let guard = source_gate.write_blocking();
 
-    custom_source_dir.insert_asset_text(
-        Path::new("bottom.nest"),
-        &serialize_as_leaf("leaf changed".into()),
-    );
+    custom_source_dir.insert_asset_text("bottom.nest", &serialize_as_leaf("leaf changed".into()));
     custom_source_events
         .send_blocking(AssetSourceEvent::ModifiedAsset("bottom.nest".into()))
         .unwrap();
@@ -1370,19 +1362,19 @@ fn nested_loads_of_processed_asset_reprocesses_on_reload() {
     run_app_until_finished_processing(&mut app, guard);
 
     assert_eq!(
-        read_asset_as_string(&custom_processed_dir, Path::new("bottom.nest")),
+        read_asset_as_string(&custom_processed_dir, "bottom.nest"),
         serialize_as_leaf("leaf changed-ref".into())
     );
     assert_eq!(
-        read_asset_as_string(&default_processed_dir, Path::new("middle.nest")),
+        read_asset_as_string(&default_processed_dir, "middle.nest"),
         serialize_as_leaf("leaf changed-ref-ref".into())
     );
     assert_eq!(
-        read_asset_as_string(&custom_processed_dir, Path::new("top.nest")),
+        read_asset_as_string(&custom_processed_dir, "top.nest"),
         serialize_as_leaf("leaf changed-ref-ref-ref".into())
     );
     assert_eq!(
-        read_asset_as_string(&default_processed_dir, Path::new("unrelated.nest")),
+        read_asset_as_string(&default_processed_dir, "unrelated.nest"),
         serialize_as_leaf("unrelated-ref".into())
     );
 
@@ -1399,19 +1391,19 @@ fn nested_loads_of_processed_asset_reprocesses_on_reload() {
     run_app_until_finished_processing(&mut app, guard);
 
     assert_eq!(
-        read_asset_as_string(&custom_processed_dir, Path::new("bottom.nest")),
+        read_asset_as_string(&custom_processed_dir, "bottom.nest"),
         serialize_as_leaf("leaf changed-ref".into())
     );
     assert_eq!(
-        read_asset_as_string(&default_processed_dir, Path::new("middle.nest")),
+        read_asset_as_string(&default_processed_dir, "middle.nest"),
         serialize_as_leaf("leaf changed-ref-ref".into())
     );
     assert_eq!(
-        read_asset_as_string(&custom_processed_dir, Path::new("top.nest")),
+        read_asset_as_string(&custom_processed_dir, "top.nest"),
         serialize_as_leaf("leaf changed-ref-ref-ref".into())
     );
     assert_eq!(
-        read_asset_as_string(&default_processed_dir, Path::new("unrelated.nest")),
+        read_asset_as_string(&default_processed_dir, "unrelated.nest"),
         serialize_as_leaf("unrelated-ref".into())
     );
 
@@ -1448,27 +1440,24 @@ fn clears_invalid_data_from_processed_dir() {
 
     let guard = source_gate.write_blocking();
 
-    default_source_dir.insert_asset_text(Path::new("a.cool.ron"), &serialize_as_cool_text("a"));
-    default_source_dir.insert_asset_text(Path::new("dir/b.cool.ron"), &serialize_as_cool_text("b"));
-    default_source_dir.insert_asset_text(
-        Path::new("dir/subdir/c.cool.ron"),
-        &serialize_as_cool_text("c"),
-    );
+    default_source_dir.insert_asset_text("a.cool.ron", &serialize_as_cool_text("a"));
+    default_source_dir.insert_asset_text("dir/b.cool.ron", &serialize_as_cool_text("b"));
+    default_source_dir.insert_asset_text("dir/subdir/c.cool.ron", &serialize_as_cool_text("c"));
 
     // This asset has the right data, but no meta, so it should be reprocessed.
-    let a = Path::new("a.cool.ron");
+    let a = "a.cool.ron";
     default_processed_dir.insert_asset_text(a, &serialize_as_cool_text("a processed"));
     // These assets aren't present in the unprocessed directory, so they should be deleted.
-    let missing1 = Path::new("missing1.cool.ron");
-    let missing2 = Path::new("dir/missing2.cool.ron");
-    let missing3 = Path::new("other_dir/missing3.cool.ron");
+    let missing1 = "missing1.cool.ron";
+    let missing2 = "dir/missing2.cool.ron";
+    let missing3 = "other_dir/missing3.cool.ron";
     default_processed_dir.insert_asset_text(missing1, &serialize_as_cool_text("missing1"));
     default_processed_dir.insert_meta_text(missing1, ""); // This asset has metadata.
     default_processed_dir.insert_asset_text(missing2, &serialize_as_cool_text("missing2"));
     default_processed_dir.insert_asset_text(missing3, &serialize_as_cool_text("missing3"));
     // This directory is empty, so it should be deleted.
-    let empty_dir = Path::new("empty_dir");
-    let empty_dir_subdir = Path::new("empty_dir/empty_subdir");
+    let empty_dir = "empty_dir";
+    let empty_dir_subdir = "empty_dir/empty_subdir";
     default_processed_dir.get_or_insert_dir(empty_dir_subdir);
 
     run_app_until_finished_processing(&mut app, guard);
@@ -1490,10 +1479,10 @@ fn clears_invalid_data_from_processed_dir() {
 
 #[test]
 fn only_reprocesses_wrong_hash_on_startup() {
-    let no_deps_asset = Path::new("no_deps.cool.ron");
-    let source_changed_asset = Path::new("source_changed.cool.ron");
-    let dep_unchanged_asset = Path::new("dep_unchanged.cool.ron");
-    let dep_changed_asset = Path::new("dep_changed.cool.ron");
+    let no_deps_asset = "no_deps.cool.ron";
+    let source_changed_asset = "source_changed.cool.ron";
+    let dep_unchanged_asset = "dep_unchanged.cool.ron";
+    let dep_changed_asset = "dep_changed.cool.ron";
     let default_source_dir;
     let default_processed_dir;
 
@@ -1553,11 +1542,11 @@ fn only_reprocesses_wrong_hash_on_startup() {
 
         let guard = source_gate.write_blocking();
 
-        let cool_text_with_embedded = |text: &str, embedded: &Path| {
+        let cool_text_with_embedded = |text: &str, embedded: &str| {
             let cool_text_ron = CoolTextRon {
                 text: text.into(),
                 dependencies: vec![],
-                embedded_dependencies: vec![embedded.to_string_lossy().into_owned()],
+                embedded_dependencies: vec![embedded.to_string()],
                 sub_texts: vec![],
             };
             ron::ser::to_string_pretty(&cool_text_ron, PrettyConfig::new().new_line("\n")).unwrap()
@@ -1702,13 +1691,13 @@ fn writes_short_default_meta_for_processor() {
     .set_default_asset_processor::<CoolTextProcessor>("cool.ron");
 
     const ASSET_PATH: &str = "abc.cool.ron";
-    source.insert_asset_text(Path::new(ASSET_PATH), &serialize_as_cool_text("blah"));
+    source.insert_asset_text(ASSET_PATH, &serialize_as_cool_text("blah"));
 
     let processor = app.world().resource::<AssetProcessor>().clone();
     bevy_tasks::block_on(processor.write_default_meta_file_for_path(ASSET_PATH)).unwrap();
 
     assert_eq!(
-        read_meta_as_string(&source, Path::new(ASSET_PATH)),
+        read_meta_as_string(&source, ASSET_PATH),
         r#"(
     meta_format_version: "1.0",
     asset: Process(
@@ -1772,13 +1761,13 @@ fn writes_long_default_meta_for_ambiguous_processor() {
     ));
 
     const ASSET_PATH: &str = "abc.cool.ron";
-    source.insert_asset_text(Path::new(ASSET_PATH), &serialize_as_cool_text("blah"));
+    source.insert_asset_text(ASSET_PATH, &serialize_as_cool_text("blah"));
 
     let processor = app.world().resource::<AssetProcessor>().clone();
     bevy_tasks::block_on(processor.write_default_meta_file_for_path(ASSET_PATH)).unwrap();
 
     assert_eq!(
-        read_meta_as_string(&source, Path::new(ASSET_PATH)),
+        read_meta_as_string(&source, ASSET_PATH),
         r#"(
     meta_format_version: "1.0",
     asset: Process(
@@ -1814,9 +1803,9 @@ fn write_default_meta_does_not_overwrite() {
     .set_default_asset_processor::<CoolTextProcessor>("cool.ron");
 
     const ASSET_PATH: &str = "abc.cool.ron";
-    source.insert_asset_text(Path::new(ASSET_PATH), &serialize_as_cool_text("blah"));
+    source.insert_asset_text(ASSET_PATH, &serialize_as_cool_text("blah"));
     const META_TEXT: &str = "hey i'm walkin here!";
-    source.insert_meta_text(Path::new(ASSET_PATH), META_TEXT);
+    source.insert_meta_text(ASSET_PATH, META_TEXT);
 
     let processor = app.world().resource::<AssetProcessor>().clone();
     assert!(matches!(
@@ -1824,8 +1813,5 @@ fn write_default_meta_does_not_overwrite() {
         Err(WriteDefaultMetaError::MetaAlreadyExists)
     ));
 
-    assert_eq!(
-        read_meta_as_string(&source, Path::new(ASSET_PATH)),
-        META_TEXT
-    );
+    assert_eq!(read_meta_as_string(&source, ASSET_PATH), META_TEXT);
 }

--- a/crates/bevy_asset/src/reflect.rs
+++ b/crates/bevy_asset/src/reflect.rs
@@ -517,7 +517,6 @@ mod tests {
     use core::any::TypeId;
     use ron::ser::PrettyConfig;
     use serde::de::DeserializeSeed;
-    use std::path::Path;
     use uuid::Uuid;
 
     use crate::{
@@ -619,8 +618,8 @@ mod tests {
                 .register_type::<Stuff>()
                 .register_asset_loader(CoolTextLoader);
 
-            dir.insert_asset_text(Path::new("abc.cool.ron"), &serialize_as_cool_text("hello"));
-            dir.insert_asset_text(Path::new("def.cool.ron"), &serialize_as_cool_text("world"));
+            dir.insert_asset_text("abc.cool.ron", &serialize_as_cool_text("hello"));
+            dir.insert_asset_text("def.cool.ron", &serialize_as_cool_text("world"));
 
             let type_registry = app.world().resource::<AppTypeRegistry>().0.clone();
             let asset_server = app.world().resource::<AssetServer>().clone();
@@ -664,8 +663,8 @@ mod tests {
             .register_type::<Stuff>()
             .register_asset_loader(CoolTextLoader);
 
-        dir.insert_asset_text(Path::new("abc.cool.ron"), &serialize_as_cool_text("hello"));
-        dir.insert_asset_text(Path::new("def.cool.ron"), &serialize_as_cool_text("world"));
+        dir.insert_asset_text("abc.cool.ron", &serialize_as_cool_text("hello"));
+        dir.insert_asset_text("def.cool.ron", &serialize_as_cool_text("world"));
 
         let type_registry = app.world().resource::<AppTypeRegistry>().0.clone();
         let mut asset_server = app.world().resource::<AssetServer>().clone();

--- a/crates/bevy_asset/src/saver.rs
+++ b/crates/bevy_asset/src/saver.rs
@@ -618,7 +618,7 @@ pub(crate) mod tests {
                     .dependencies
                     .iter()
                     .map(|handle| handle.path().unwrap().path())
-                    .map(|path| path.to_str().unwrap().to_string())
+                    .map(ToString::to_string)
                     .collect(),
                 embedded_dependencies: vec![],
             };

--- a/crates/bevy_asset/src/server/loaders.rs
+++ b/crates/bevy_asset/src/server/loaders.rs
@@ -306,10 +306,7 @@ impl MaybeAssetLoader {
 mod tests {
     use alloc::{format, string::String};
     use core::marker::PhantomData;
-    use std::{
-        path::Path,
-        sync::mpsc::{channel, Receiver, Sender},
-    };
+    use std::sync::mpsc::{channel, Receiver, Sender};
 
     use bevy_reflect::TypePath;
     use bevy_tasks::block_on;
@@ -536,7 +533,7 @@ mod tests {
         assert!(rx_b1.try_recv().is_ok());
         assert!(rx_c1.try_recv().is_ok());
 
-        let path = AssetPath::from_path(Path::new("asset.a"));
+        let path = AssetPath::from_str_path("asset.a");
 
         let loader = block_on(loaders.get_by_path(&path).unwrap().get()).unwrap();
 
@@ -546,7 +543,7 @@ mod tests {
         assert!(rx_b1.try_recv().is_err());
         assert!(rx_c1.try_recv().is_err());
 
-        let path = AssetPath::from_path(Path::new("asset.b"));
+        let path = AssetPath::from_str_path("asset.b");
 
         let loader = block_on(loaders.get_by_path(&path).unwrap().get()).unwrap();
 
@@ -556,7 +553,7 @@ mod tests {
         assert!(rx_b1.try_recv().is_ok());
         assert!(rx_c1.try_recv().is_err());
 
-        let path = AssetPath::from_path(Path::new("asset.c"));
+        let path = AssetPath::from_str_path("asset.c");
 
         let loader = block_on(loaders.get_by_path(&path).unwrap().get()).unwrap();
 
@@ -600,7 +597,7 @@ mod tests {
                     None,
                     Some(TypeId::of::<A>()),
                     None,
-                    Some(&AssetPath::from_path(Path::new("asset.a"))),
+                    Some(&AssetPath::from_str_path("asset.a")),
                 )
                 .unwrap()
                 .get(),
@@ -621,7 +618,7 @@ mod tests {
                     None,
                     Some(TypeId::of::<B>()),
                     None,
-                    Some(&AssetPath::from_path(Path::new("asset.b"))),
+                    Some(&AssetPath::from_str_path("asset.b")),
                 )
                 .unwrap()
                 .get(),
@@ -642,7 +639,7 @@ mod tests {
                     None,
                     Some(TypeId::of::<C>()),
                     None,
-                    Some(&AssetPath::from_path(Path::new("asset.c"))),
+                    Some(&AssetPath::from_str_path("asset.c")),
                 )
                 .unwrap()
                 .get(),
@@ -665,7 +662,7 @@ mod tests {
                     None,
                     Some(TypeId::of::<C>()),
                     None,
-                    Some(&AssetPath::from_path(Path::new("asset.a"))),
+                    Some(&AssetPath::from_str_path("asset.a")),
                 )
                 .unwrap()
                 .get(),
@@ -686,7 +683,7 @@ mod tests {
                     None,
                     Some(TypeId::of::<C>()),
                     None,
-                    Some(&AssetPath::from_path(Path::new("asset.b"))),
+                    Some(&AssetPath::from_str_path("asset.b")),
                 )
                 .unwrap()
                 .get(),
@@ -709,7 +706,7 @@ mod tests {
                     None,
                     Some(TypeId::of::<A>()),
                     None,
-                    Some(&AssetPath::from_path(Path::new("asset.x"))),
+                    Some(&AssetPath::from_str_path("asset.x")),
                 )
                 .unwrap()
                 .get(),
@@ -730,7 +727,7 @@ mod tests {
                     None,
                     Some(TypeId::of::<A>()),
                     None,
-                    Some(&AssetPath::from_path(Path::new("asset"))),
+                    Some(&AssetPath::from_str_path("asset")),
                 )
                 .unwrap()
                 .get(),
@@ -769,7 +766,7 @@ mod tests {
                     None,
                     Some(TypeId::of::<A>()),
                     None,
-                    Some(&AssetPath::from_path(Path::new("asset.a"))),
+                    Some(&AssetPath::from_str_path("asset.a")),
                 )
                 .unwrap()
                 .get(),
@@ -788,7 +785,7 @@ mod tests {
                     None,
                     Some(TypeId::of::<A>()),
                     None,
-                    Some(&AssetPath::from_path(Path::new("asset.x"))),
+                    Some(&AssetPath::from_str_path("asset.x")),
                 )
                 .unwrap()
                 .get(),
@@ -807,7 +804,7 @@ mod tests {
                     None,
                     Some(TypeId::of::<A>()),
                     None,
-                    Some(&AssetPath::from_path(Path::new("asset"))),
+                    Some(&AssetPath::from_str_path("asset")),
                 )
                 .unwrap()
                 .get(),

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -14,10 +14,10 @@ use crate::{
         MetaTransform, Settings,
     },
     path::AssetPath,
-    Asset, AssetEvent, AssetHandleProvider, AssetId, AssetIndex, AssetLoadFailedEvent,
-    AssetMetaCheck, Assets, DeserializeMetaError, ErasedAssetIndex, ErasedLoadedAsset, Handle,
-    LoadedUntypedAsset, UnapprovedPathMode, UntypedAssetId, UntypedAssetLoadFailedEvent,
-    UntypedHandle, VisitAssetDependencies,
+    path_ancestors, Asset, AssetEvent, AssetHandleProvider, AssetId, AssetIndex,
+    AssetLoadFailedEvent, AssetMetaCheck, Assets, DeserializeMetaError, ErasedAssetIndex,
+    ErasedLoadedAsset, Handle, LoadedUntypedAsset, UnapprovedPathMode, UntypedAssetId,
+    UntypedAssetLoadFailedEvent, UntypedHandle, VisitAssetDependencies,
 };
 use alloc::{borrow::ToOwned, boxed::Box, vec, vec::Vec};
 use alloc::{
@@ -43,7 +43,6 @@ use crossbeam_channel::{Receiver, Sender};
 use futures_lite::{FutureExt, StreamExt};
 use info::*;
 use loaders::*;
-use std::path::{Path, PathBuf};
 use thiserror::Error;
 use tracing::{error, info, warn};
 
@@ -324,14 +323,13 @@ impl AssetServer {
     /// Note that if the asset at this path is already loaded, this function will return the existing handle,
     /// and will not waste work spawning a new load task.
     ///
-    /// In case the file path contains a hashtag (`#`), the `path` must be specified using [`Path`]
-    /// or [`AssetPath`] because otherwise the hashtag would be interpreted as separator between
-    /// the file path and the label. For example:
+    /// In case the file path contains a hashtag (`#`), the `path` must be specified using
+    /// [`AssetPath::from_str_path`] because otherwise the hashtag would be interpreted as separator
+    /// between the file path and the label. For example:
     ///
     /// ```no_run
-    /// # use bevy_asset::{AssetServer, Handle, LoadedUntypedAsset};
+    /// # use bevy_asset::{AssetServer, Handle, LoadedUntypedAsset, AssetPath};
     /// # use bevy_ecs::prelude::Res;
-    /// # use std::path::Path;
     /// // `#path` is a label.
     /// # fn setup(asset_server: Res<AssetServer>) {
     /// # let handle: Handle<LoadedUntypedAsset> =
@@ -339,7 +337,7 @@ impl AssetServer {
     ///
     /// // `#path` is part of the file name.
     /// # let handle: Handle<LoadedUntypedAsset> =
-    /// asset_server.load(Path::new("some/file#path"));
+    /// asset_server.load(AssetPath::from_str_path("some/file#path"));
     /// # }
     /// ```
     ///
@@ -349,10 +347,9 @@ impl AssetServer {
     /// ```no_run
     /// # use bevy_asset::{AssetPath, AssetServer, Handle, LoadedUntypedAsset};
     /// # use bevy_ecs::prelude::Res;
-    /// # use std::path::Path;
     /// # fn setup(asset_server: Res<AssetServer>) {
     /// # let handle: Handle<LoadedUntypedAsset> =
-    /// asset_server.load(AssetPath::from_path(Path::new("some/file#path")).with_label("subasset"));
+    /// asset_server.load(AssetPath::from_str_path("some/file#path").with_label("subasset"));
     /// # }
     /// ```
     ///
@@ -554,7 +551,7 @@ impl AssetServer {
         override_unapproved: bool,
     ) -> UntypedHandle {
         let path = path.into().into_owned();
-        if path.path() == Path::new("") {
+        if path.path() == "" {
             error!("Attempted to load an asset with an empty path \"{path}\"!");
             return UntypedHandle::default_for_type(type_id);
         }
@@ -645,7 +642,7 @@ impl AssetServer {
         override_unapproved: bool,
     ) -> Handle<LoadedUntypedAsset> {
         let path = path.into().into_owned();
-        if path.path() == Path::new("") {
+        if path.path() == "" {
             error!("Attempted to load an asset with an empty path \"{path}\"!");
             return Handle::default();
         }
@@ -1151,7 +1148,7 @@ impl AssetServer {
     pub(crate) fn load_folder_internal(&self, index: ErasedAssetIndex, path: AssetPath) {
         async fn load_folder<'a>(
             source: AssetSourceId<'static>,
-            path: &'a Path,
+            path: &'a str,
             reader: &'a dyn ErasedAssetReader,
             server: &'a AssetServer,
             handles: &'a mut Vec<UntypedHandle>,
@@ -1170,8 +1167,7 @@ impl AssetServer {
                         ))
                         .await?;
                     } else {
-                        let path = child_path.to_str().expect("Path should be a valid string.");
-                        let asset_path = AssetPath::parse(path).with_source(source.clone());
+                        let asset_path = AssetPath::parse(&child_path).with_source(source.clone());
                         match server.load_builder().load_untyped_async(asset_path).await {
                             Ok(handle) => handles.push(handle),
                             // skip assets that cannot be loaded
@@ -2049,7 +2045,7 @@ impl<'a> LoadBuilder<'a> {
         asset_path: impl Into<AssetPath<'b>>,
     ) -> Result<UntypedHandle, AssetLoadError> {
         let path: AssetPath = asset_path.into();
-        if path.path() == Path::new("") {
+        if path.path() == "" {
             return Err(AssetLoadError::EmptyPath(path.into_owned()));
         }
 
@@ -2156,11 +2152,11 @@ pub fn handle_internal_asset_events(world: &mut World) {
 
         let mut folders_to_reload = Vec::default();
         let mut reload_parent_folders =
-            |path: &PathBuf, source: &AssetSourceId<'static>, infos: &mut AssetInfos| {
+            |path: &str, source: &AssetSourceId<'static>, infos: &mut AssetInfos| {
                 let mut new_loads = 0;
-                for parent in path.ancestors().skip(1) {
+                for parent in path_ancestors(path).skip(1) {
                     let parent_asset_path =
-                        AssetPath::from(parent.to_path_buf()).with_source(source.clone());
+                        AssetPath::from_string_path(parent.to_string()).with_source(source.clone());
                     for folder_handle in infos.get_path_handles(&parent_asset_path) {
                         info!(
                             "Reloading folder {parent_asset_path} because the content has changed"
@@ -2174,8 +2170,8 @@ pub fn handle_internal_asset_events(world: &mut World) {
 
         let mut paths_to_reload = <HashSet<_>>::default();
         let mut reload_path =
-            |path: PathBuf, source: &AssetSourceId<'static>, infos: &AssetInfos| {
-                let path = AssetPath::from(path).with_source(source);
+            |path: String, source: &AssetSourceId<'static>, infos: &AssetInfos| {
+                let path = AssetPath::from_string_path(path).with_source(source);
                 queue_ancestors(&path, infos, &mut paths_to_reload);
                 paths_to_reload.insert(path);
             };

--- a/crates/bevy_gltf/src/loader/mod.rs
+++ b/crates/bevy_gltf/src/loader/mod.rs
@@ -259,15 +259,6 @@ impl GltfLoader {
             extension.on_root(load_context, &gltf, settings);
         }
 
-        let file_name = load_context
-            .path()
-            .path()
-            .to_str()
-            .ok_or(GltfError::Gltf(gltf::Error::Io(Error::new(
-                std::io::ErrorKind::InvalidInput,
-                "Gltf file name invalid",
-            ))))?
-            .to_string();
         let buffer_data = load_buffers(&gltf, load_context).await?;
 
         let linear_textures = get_linear_textures(&gltf.document);
@@ -840,10 +831,11 @@ impl GltfLoader {
                     && needs_tangents(&primitive.material())
                 {
                     tracing::debug!(
-                        "Missing vertex tangents for {}, computing them using the mikktspace algorithm. Consider using a tool such as Blender to pre-compute the tangents.", file_name
+                        "Missing vertex tangents for {}, computing them using the mikktspace algorithm. Consider using a tool such as Blender to pre-compute the tangents.", load_context.path()
                     );
 
-                    let generate_tangents_span = info_span!("generate_tangents", name = file_name);
+                    let generate_tangents_span =
+                        info_span!("generate_tangents", name = %load_context.path());
 
                     generate_tangents_span.in_scope(|| {
                         if let Err(err) = mesh.generate_tangents() {
@@ -2102,8 +2094,6 @@ pub struct MorphTargetNames {
 
 #[cfg(test)]
 mod test {
-    use std::path::Path;
-
     use crate::{Gltf, GltfAssetLabel, GltfMaterial, GltfNode, GltfSkin};
     use bevy_app::{App, TaskPoolPlugin};
     use bevy_asset::{
@@ -2165,7 +2155,7 @@ mod test {
         struct GltfHandle(Handle<Gltf>);
 
         let dir = Dir::default();
-        dir.insert_asset_text(Path::new(gltf_path), gltf);
+        dir.insert_asset_text(gltf_path, gltf);
         let mut app = test_app(dir);
         app.update();
         let asset_server = app.world().resource::<AssetServer>().clone();
@@ -2397,7 +2387,7 @@ mod test {
 "#;
 
         let dir = Dir::default();
-        dir.insert_asset_text(Path::new(gltf_path), gltf_str);
+        dir.insert_asset_text(gltf_path, gltf_str);
         let mut app = test_app(dir);
         app.update();
         let asset_server = app.world().resource::<AssetServer>().clone();
@@ -2439,7 +2429,7 @@ mod test {
 "#;
 
         let dir = Dir::default();
-        dir.insert_asset_text(Path::new(gltf_path), gltf_str);
+        dir.insert_asset_text(gltf_path, gltf_str);
         let mut app = test_app(dir);
         app.update();
         let asset_server = app.world().resource::<AssetServer>().clone();
@@ -2575,7 +2565,7 @@ mod test {
         let (mut app, dir) = test_app_custom_asset_source();
 
         dir.insert_asset_text(
-            Path::new("abc.gltf"),
+            "abc.gltf",
             r#"
 {
     "asset": {
@@ -2591,7 +2581,7 @@ mod test {
 "#,
         );
         // We don't care that the buffer contains reasonable info since we won't actually use it.
-        dir.insert_asset_text(Path::new("abc.bin"), "Sup");
+        dir.insert_asset_text("abc.bin", "Sup");
 
         let asset_server = app.world().resource::<AssetServer>().clone();
         let handle: Handle<Gltf> = asset_server.load("custom://abc.gltf");
@@ -2615,7 +2605,7 @@ mod test {
         // can result in the image getting dropped leading to the gltf never being loaded with
         // dependencies.
         dir.insert_asset_text(
-            Path::new("abc.gltf"),
+            "abc.gltf",
             r#"
 {
     "asset": {
@@ -2652,7 +2642,7 @@ mod test {
 "#,
         );
         // We don't care that the image contains reasonable info since we won't actually use it.
-        dir.insert_asset_text(Path::new("abc.png"), "Sup");
+        dir.insert_asset_text("abc.png", "Sup");
 
         /// A fake loader to avoid actually loading any image data and just return an image.
         #[derive(TypePath)]
@@ -2696,7 +2686,7 @@ mod test {
         let (mut app, dir) = test_app_custom_asset_source();
 
         dir.insert_asset_text(
-            Path::new("abc.gltf"),
+            "abc.gltf",
             r#"
 {
     "asset": {

--- a/crates/bevy_image/src/image_loader.rs
+++ b/crates/bevy_image/src/image_loader.rs
@@ -2,7 +2,7 @@ use crate::{
     image::{Image, ImageFormat, ImageType, TextureError},
     TextureReinterpretationError,
 };
-use bevy_asset::{io::Reader, AssetLoader, LoadContext, RenderAssetUsages};
+use bevy_asset::{io::Reader, path_file_extension, AssetLoader, LoadContext, RenderAssetUsages};
 use bevy_reflect::TypePath;
 use thiserror::Error;
 
@@ -187,25 +187,19 @@ impl AssetLoader for ImageLoader {
         let image_type = match settings.format {
             ImageFormatSetting::FromExtension => {
                 // use the file extension for the image type
-                let ext = load_context
-                    .path()
-                    .path()
-                    .extension()
-                    .unwrap()
-                    .to_str()
-                    .unwrap();
+                let ext = path_file_extension(load_context.path().path()).unwrap();
                 ImageType::Extension(ext)
             }
             ImageFormatSetting::Format(format) => ImageType::Format(format),
             ImageFormatSetting::Guess => {
                 let format = image::guess_format(&bytes).map_err(|err| FileTextureError {
                     error: err.into(),
-                    path: format!("{}", load_context.path().path().display()),
+                    path: load_context.path().to_string(),
                 })?;
                 ImageType::Format(ImageFormat::from_image_crate_format(format).ok_or_else(
                     || FileTextureError {
                         error: TextureError::UnsupportedTextureFormat(format!("{format:?}")),
-                        path: format!("{}", load_context.path().path().display()),
+                        path: load_context.path().to_string(),
                     },
                 )?)
             }
@@ -221,7 +215,7 @@ impl AssetLoader for ImageLoader {
         )
         .map_err(|err| FileTextureError {
             error: err,
-            path: format!("{}", load_context.path().path().display()),
+            path: load_context.path().to_string(),
         })?;
 
         if let Some(format) = settings.texture_format {

--- a/crates/bevy_image/src/saver.rs
+++ b/crates/bevy_image/src/saver.rs
@@ -153,8 +153,6 @@ pub enum SaveImageError {
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
-
     use bevy_app::{App, TaskPoolPlugin};
     use bevy_asset::{
         io::{
@@ -225,7 +223,7 @@ mod tests {
         let (mut app, dir) = create_app();
         let asset_server = app.world().resource::<AssetServer>().clone();
 
-        let asset_path = AssetPath::from_path(Path::new(file_name));
+        let asset_path = AssetPath::from_str_path(file_name);
 
         const WIDTH: u32 = 5;
         let mut image = Image::new(

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -118,10 +118,8 @@ use bevy_render::{
     RenderSystems,
 };
 
-use std::path::PathBuf;
-
-fn shader_ref(path: PathBuf) -> ShaderRef {
-    ShaderRef::Path(AssetPath::from_path_buf(path).with_source("embedded"))
+fn shader_ref(path: String) -> ShaderRef {
+    ShaderRef::Path(AssetPath::from_string_path(path).with_source("embedded"))
 }
 
 pub const TONEMAPPING_LUT_TEXTURE_BINDING_INDEX: u32 = 19;

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -767,7 +767,7 @@ fn pipeline_error_context(cached_pipeline: &CachedPipeline) -> String {
         shader_defs: &[ShaderDefVal],
     ) -> String {
         let source = match shader.path() {
-            Some(path) => path.path().to_string_lossy().to_string(),
+            Some(path) => path.path().to_string(),
             None => String::new(),
         };
         let entry = match entry {

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -572,7 +572,6 @@ mod tests {
     use bevy_ecs::relationship::Relationship;
     use bevy_ecs::world::DeferredWorld;
     use bevy_reflect::TypePath;
-    use std::path::Path;
     use std::sync::Mutex;
 
     fn test_app() -> App {
@@ -697,7 +696,7 @@ mod tests {
         }
 
         // Insert an asset that the fake loader can fake read.
-        dir.insert_asset_text(Path::new("a.bsn"), "");
+        dir.insert_asset_text("a.bsn", "");
         let asset_server = app.world().resource::<AssetServer>().clone();
         let handle = asset_server.load("a.bsn");
         assert!(app.world().get_resource::<Assets<ScenePatch>>().is_some());

--- a/crates/bevy_shader/src/shader.rs
+++ b/crates/bevy_shader/src/shader.rs
@@ -1,6 +1,8 @@
 use super::ShaderDefVal;
 use alloc::borrow::Cow;
-use bevy_asset::{io::Reader, Asset, AssetLoader, AssetPath, Handle, LoadContext};
+use bevy_asset::{
+    io::Reader, path_file_extension, Asset, AssetLoader, AssetPath, Handle, LoadContext,
+};
 use bevy_reflect::TypePath;
 use bevy_utils::define_atomic_id;
 use thiserror::Error;
@@ -330,17 +332,8 @@ impl AssetLoader for ShaderLoader {
         settings: &Self::Settings,
         load_context: &mut LoadContext<'_>,
     ) -> Result<Shader, Self::Error> {
-        let ext = load_context
-            .path()
-            .path()
-            .extension()
-            .unwrap()
-            .to_str()
-            .unwrap();
+        let ext = path_file_extension(load_context.path().path()).unwrap();
         let path = load_context.path().to_string();
-        // On windows, the path will inconsistently use \ or /.
-        // TODO: remove this once AssetPath forces cross-platform "slash" consistency. See #10511
-        let path = path.replace(std::path::MAIN_SEPARATOR, "/");
         let mut bytes = Vec::new();
         reader.read_to_end(&mut bytes).await?;
         if ext != "wgsl" && !settings.shader_defs.is_empty() {
@@ -350,7 +343,8 @@ impl AssetLoader for ShaderLoader {
             );
         }
         let mut shader = match ext {
-            "spv" => Shader::from_spirv(bytes, load_context.path().path().to_string_lossy()),
+            // TODO: Should this just pass `load_context.path()` instead?
+            "spv" => Shader::from_spirv(bytes, load_context.path().path()),
             "wgsl" => Shader::from_wgsl_with_defs(
                 String::from_utf8(bytes)?,
                 path,

--- a/crates/bevy_sprite_render/src/mesh2d/color_material.rs
+++ b/crates/bevy_sprite_render/src/mesh2d/color_material.rs
@@ -147,7 +147,8 @@ impl AsBindGroupShaderType<ColorMaterialUniform> for ColorMaterial {
 impl Material2d for ColorMaterial {
     fn fragment_shader() -> ShaderRef {
         ShaderRef::Path(
-            AssetPath::from_path_buf(embedded_path!("color_material.wgsl")).with_source("embedded"),
+            AssetPath::from_string_path(embedded_path!("color_material.wgsl"))
+                .with_source("embedded"),
         )
     }
 

--- a/crates/bevy_sprite_render/src/sprite_mesh/sprite_material.rs
+++ b/crates/bevy_sprite_render/src/sprite_mesh/sprite_material.rs
@@ -313,14 +313,14 @@ impl AsBindGroupShaderType<SpriteMaterialUniform> for SpriteMaterial {
 impl Material2d for SpriteMaterial {
     fn vertex_shader() -> ShaderRef {
         ShaderRef::Path(
-            AssetPath::from_path_buf(embedded_path!("sprite_material.wgsl"))
+            AssetPath::from_string_path(embedded_path!("sprite_material.wgsl"))
                 .with_source("embedded"),
         )
     }
 
     fn fragment_shader() -> ShaderRef {
         ShaderRef::Path(
-            AssetPath::from_path_buf(embedded_path!("sprite_material.wgsl"))
+            AssetPath::from_string_path(embedded_path!("sprite_material.wgsl"))
                 .with_source("embedded"),
         )
     }

--- a/crates/bevy_sprite_render/src/tilemap_chunk/tilemap_chunk_material.rs
+++ b/crates/bevy_sprite_render/src/tilemap_chunk/tilemap_chunk_material.rs
@@ -39,7 +39,7 @@ pub struct TilemapChunkMaterial {
 impl Material2d for TilemapChunkMaterial {
     fn fragment_shader() -> ShaderRef {
         ShaderRef::Path(
-            AssetPath::from_path_buf(embedded_path!("tilemap_chunk_material.wgsl"))
+            AssetPath::from_string_path(embedded_path!("tilemap_chunk_material.wgsl"))
                 .with_source("embedded"),
         )
     }

--- a/examples/asset/asset_decompression.rs
+++ b/examples/asset/asset_decompression.rs
@@ -3,7 +3,7 @@
 use bevy::{
     asset::{
         io::{Reader, VecReader},
-        AssetLoader, ErasedLoadedAsset, LoadContext, LoadDirectError,
+        path_basename, AssetLoader, ErasedLoadedAsset, LoadContext, LoadDirectError,
     },
     prelude::*,
     reflect::TypePath,
@@ -47,11 +47,8 @@ impl AssetLoader for GzAssetLoader {
         load_context: &mut LoadContext<'_>,
     ) -> Result<Self::Asset, Self::Error> {
         let compressed_path = load_context.path();
-        let file_name = compressed_path
-            .path()
-            .file_name()
-            .ok_or(GzAssetLoaderError::IndeterminateFilePath)?
-            .to_string_lossy();
+        let file_name = path_basename(compressed_path.path())
+            .ok_or(GzAssetLoaderError::IndeterminateFilePath)?;
         let uncompressed_file_name = file_name
             .strip_suffix(".gz")
             .ok_or(GzAssetLoaderError::IndeterminateFilePath)?;

--- a/examples/asset/custom_asset_reader.rs
+++ b/examples/asset/custom_asset_reader.rs
@@ -9,28 +9,27 @@ use bevy::{
     },
     prelude::*,
 };
-use std::path::Path;
 
 /// A custom asset reader implementation that wraps a given asset reader implementation
 struct CustomAssetReader(Box<dyn ErasedAssetReader>);
 
 impl AssetReader for CustomAssetReader {
-    async fn read<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
-        info!("Reading {}", path.display());
+    async fn read<'a>(&'a self, path: &'a str) -> Result<impl Reader + 'a, AssetReaderError> {
+        info!("Reading {path}");
         self.0.read(path).await
     }
-    async fn read_meta<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
+    async fn read_meta<'a>(&'a self, path: &'a str) -> Result<impl Reader + 'a, AssetReaderError> {
         self.0.read_meta(path).await
     }
 
     async fn read_directory<'a>(
         &'a self,
-        path: &'a Path,
+        path: &'a str,
     ) -> Result<Box<PathStream>, AssetReaderError> {
         self.0.read_directory(path).await
     }
 
-    async fn is_directory<'a>(&'a self, path: &'a Path) -> Result<bool, AssetReaderError> {
+    async fn is_directory<'a>(&'a self, path: &'a str) -> Result<bool, AssetReaderError> {
         self.0.is_directory(path).await
     }
 }

--- a/examples/asset/embedded_asset.rs
+++ b/examples/asset/embedded_asset.rs
@@ -7,10 +7,9 @@
 //! One common use case for embedded assets is including them directly within the executable during its creation. By embedding an asset at build time rather than runtime
 //! the program never needs to go to disk for the asset at all, since it is already located in the program's binary executable.
 use bevy::{
-    asset::{embedded_asset, io::AssetSourceId, AssetPath},
+    asset::{embedded_asset, io::AssetSourceId, join_paths, AssetPath},
     prelude::*,
 };
-use std::path::Path;
 
 fn main() {
     App::new()
@@ -43,9 +42,9 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     //
     // We omit the "examples/asset" from the embedded_asset! call and replace it
     // with the crate name.
-    let path = Path::new(crate_name).join("files/bevy_pixel_light.png");
+    let path = join_paths(crate_name, "files/bevy_pixel_light.png");
     let source = AssetSourceId::from("embedded");
-    let asset_path = AssetPath::from_path(&path).with_source(source);
+    let asset_path = AssetPath::from_string_path(path).with_source(source);
 
     // You could also parse this URL-like string representation for the asset
     // path.

--- a/examples/asset/extra_source.rs
+++ b/examples/asset/extra_source.rs
@@ -8,7 +8,6 @@ use bevy::{
     },
     prelude::*,
 };
-use std::path::Path;
 
 fn main() {
     App::new()
@@ -34,9 +33,9 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     //
     // The actual file path relative to workspace root is
     // "examples/asset/files/bevy_pixel_light.png".
-    let path = Path::new("bevy_pixel_light.png");
+    let path = "bevy_pixel_light.png";
     let source = AssetSourceId::from("example_files");
-    let asset_path = AssetPath::from_path(path).with_source(source);
+    let asset_path = AssetPath::from_str_path(path).with_source(source);
 
     // You could also parse this URL-like string representation for the asset
     // path.


### PR DESCRIPTION
# Objective

- A step towards #23092.
- Fixes #19079.
- A step towards #10511.

## Solution

- Create utilities to replace common Path operations.

## Testing

- Existing tests work.
    - A couple tests within `bevy_asset` needed to be **changed**, since they added spurious `/` to the **end** of a path. This behavior just seems wrong.
- bloom_3d runs.