### PR TITLE
Make the web_asset_cache compile in single-threaded mode.

### DIFF
--- a/crates/bevy_asset/src/io/file/mod.rs
+++ b/crates/bevy_asset/src/io/file/mod.rs
@@ -4,7 +4,7 @@ mod file_watcher;
 #[cfg(feature = "multi_threaded")]
 mod file_asset;
 #[cfg(not(feature = "multi_threaded"))]
-mod sync_file_asset;
+pub(crate) mod sync_file_asset;
 
 #[cfg(feature = "file_watcher")]
 pub use file_watcher::*;

--- a/crates/bevy_asset/src/io/file/sync_file_asset.rs
+++ b/crates/bevy_asset/src/io/file/sync_file_asset.rs
@@ -16,7 +16,7 @@ use std::{
 
 use super::{FileAssetReader, FileAssetWriter};
 
-struct FileReader(File);
+pub(crate) struct FileReader(pub(crate) File);
 
 impl AsyncRead for FileReader {
     fn poll_read(

--- a/crates/bevy_asset/src/io/web.rs
+++ b/crates/bevy_asset/src/io/web.rs
@@ -243,7 +243,11 @@ mod web_asset_cache {
         let cache_path = PathBuf::from(CACHE_DIR).join(&filename);
 
         if cache_path.exists() {
+            #[cfg(feature = "multi_threaded")]
             let mut file = async_fs::File::open(&cache_path).await?;
+            #[cfg(not(feature = "multi_threaded"))]
+            let mut file =
+                crate::io::file::sync_file_asset::FileReader(std::fs::File::open(&cache_path)?);
             let mut buffer = Vec::new();
             file.read_to_end(&mut buffer).await?;
             Ok(Some(buffer))


### PR DESCRIPTION
# Objective

- `cargo t -p bevy_asset --features=http,https,web_asset_cache` fails to compile.
    - This is because we don't want to use `async_fs::File` in single-threaded since that uses a blocking IO thread to read files. We instead just do the blocking on the async thread since we're single-threaded any way.

## Solution

- Use the `FileReader` from our sync_file_asset module if `multi_threaded` is not enabled.

## Testing

- The tests pass without `multi_threaded` enabled.