### PR TITLE
Avoid extra cloning on scene impls

### DIFF
--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -398,7 +398,7 @@ impl Scene for InheritSceneAsset {
             context.inherited = Some(scene_patch);
             Ok(())
         } else {
-            Err(ResolveSceneError::MissingSceneDependency(self.0.clone()))
+            Err(ResolveSceneError::MissingSceneDependency(self.0))
         }
     }
 
@@ -415,7 +415,7 @@ impl<F: (Fn(&mut TemplateContext) -> Result<O>) + Clone + Send + Sync + 'static,
         _context: &mut ResolveContext,
         scene: &mut ResolvedScene,
     ) -> Result<(), ResolveSceneError> {
-        scene.push_template(FnTemplate(self.0.clone()));
+        scene.push_template(FnTemplate(self.0));
         Ok(())
     }
 }
@@ -453,7 +453,7 @@ impl Scene for NameEntityReference {
         }
         scene.entity_indices.push(this_index);
         let name = scene.get_or_insert_template::<Name>(context);
-        *name = self.name.clone();
+        *name = self.name;
         Ok(())
     }
 }
@@ -527,7 +527,7 @@ impl<
         _context: &mut ResolveContext,
         scene: &mut ResolvedScene,
     ) -> Result<(), ResolveSceneError> {
-        scene.push_bundle_template(OnTemplate(self.0.clone(), PhantomData));
+        scene.push_bundle_template(OnTemplate(self.0, PhantomData));
         Ok(())
     }
 }


### PR DESCRIPTION
# Objective

- Some code inside the scene.rs contained unnecessary  `.clone()` calls. Most probably because `Scene::resolve` was not consuming itself before.
- I'm not sure if this improves anything, as the compiler might be intelligent enough to remove this calls already, but I don't see any drawbacks either.

## Solution

- Remove the `.clone()` calls when not necessary.

## Testing

- Local unit tests
