### PR TITLE
Don't skip prepass if there are no opaque objects

### DIFF
--- a/crates/bevy_core_pipeline/src/prepass/node.rs
+++ b/crates/bevy_core_pipeline/src/prepass/node.rs
@@ -160,14 +160,6 @@ fn run_prepass_system(
         return;
     };
 
-    // Skip starting a render pass if there's nothing to draw
-    if opaque_prepass_phase.is_empty()
-        && alpha_mask_prepass_phase.is_empty()
-        && background_motion_vectors_pipeline.is_none()
-    {
-        return;
-    }
-
     #[cfg(feature = "trace")]
     let _prepass_span = info_span!("prepass").entered();
 


### PR DESCRIPTION
# Objective

Fixes #23920

## Solution

Don't skip prepass if there are no opaque objects

## Testing

```
cargo r --example order_independent_transparency
```