### PR TITLE
headless_renderer example overallocates Buffer.

### DIFF
--- a/examples/app/headless_renderer.rs
+++ b/examples/app/headless_renderer.rs
@@ -289,9 +289,7 @@ impl ImageCopier {
         size: Extent3d,
         render_device: &RenderDevice,
     ) -> ImageCopier {
-        let padded_bytes_per_row =
-            RenderDevice::align_copy_bytes_per_row((size.width) as usize) * 4;
-
+        let padded_bytes_per_row = RenderDevice::align_copy_bytes_per_row(size.width as usize * 4);
         let cpu_buffer = render_device.create_buffer(&BufferDescriptor {
             label: None,
             size: padded_bytes_per_row as u64 * size.height as u64,


### PR DESCRIPTION
# Objective

headless_renderer example over allocates the Buffer

`RenderDevice::align_copy_bytes_per_row` takes bytes per row, the example is passing pixels - then multiplying the padded result by bytes per pixel.
So it allocates 8192 bytes per row instead of 7680.

## Solution

Multiply pixels per row by bytes per pixel and pass that to `align_copy_bytes_per_row`

## Testing

- Did you test these changes? If so, how?

Ran the example with various pixel widths.

The over allocation doesn't affect the rendered output because the other call to `align_copy_bytes_per_row` in `update` is correct, so we properly extract the image from the padded buffer.
