### PR TITLE
Fix TypePath derive counting as a usage for deprecated types.

### DIFF
--- a/crates/bevy_reflect/derive/src/impls/typed.rs
+++ b/crates/bevy_reflect/derive/src/impls/typed.rs
@@ -90,6 +90,7 @@ pub(crate) fn impl_type_path(meta: &ReflectMeta) -> TokenStream {
             const _: () = {
                 mod private_scope {
                     // Compiles if it can be named when there are no imports.
+                    #[allow(deprecated, reason = "derives on a deprecated type shouldn't be considered a usage")]
                     type AssertIsPrimitive = #type_path;
                 }
             };
@@ -106,6 +107,7 @@ pub(crate) fn impl_type_path(meta: &ReflectMeta) -> TokenStream {
     quote! {
         #primitive_assert
 
+        #[allow(deprecated, reason = "derives on a deprecated type shouldn't be considered a usage")]
         impl #impl_generics #bevy_reflect_path::TypePath for #type_path #ty_generics #where_reflect_clause {
             fn type_path() -> &'static str {
                 #long_type_path


### PR DESCRIPTION
# Objective

- Deprecating a type deriving `TypePath` would cause **the type itself** to trigger a deprecation lint. You couldn't even set `#[allow(deprecated)]`!

## Solution

- Add `#[allow(deprecated)]` to the generated code of `TypePath`.

## Testing

- The type I was deprecating stopped giving me lint warnings with this.