### PR TITLE
Fallible arithmetic for `Val` and `Val2`

### DIFF
--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -166,22 +166,6 @@ impl Val {
     pub const DEFAULT: Self = Self::Auto;
     pub const ZERO: Self = Self::Px(0.0);
 
-    /// Returns `Val::Px(0.)` if `self` is `Val::Auto`, or `self` otherwise.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use bevy_ui::{Val};
-    /// assert_eq!(Val::Auto.auto_to_zero(), Val::Px(0.));
-    /// assert_eq!(Val::Percent(1.).auto_to_zero(), Val::Percent(1.));
-    /// ```
-    pub const fn auto_to_px_zero(self) -> Val {
-        match self {
-            Val::Auto => Val::Px(0.),
-            _ => self,
-        }
-    }
-
     /// Returns a [`UiRect`] with its `left` equal to this value,
     /// and all other fields set to `Val::ZERO`.
     ///

--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -1286,18 +1286,6 @@ mod tests {
     }
 
     #[test]
-    fn val_arithmetic_error_messages() {
-        assert_eq!(
-            format!("{}", ValArithmeticError::NonEvaluable),
-            "the given variant of Val is not evaluable (non-numeric)"
-        );
-        assert_eq!(
-            format!("{}", ValArithmeticError::IncompatibleUnits),
-            "the given variants of Val have mismatched units"
-        );
-    }
-
-    #[test]
     fn val_str_parse() {
         assert_eq!("auto".parse::<Val>(), Ok(Val::Auto));
         assert_eq!("Auto".parse::<Val>(), Ok(Val::Auto));

--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -166,6 +166,22 @@ impl Val {
     pub const DEFAULT: Self = Self::Auto;
     pub const ZERO: Self = Self::Px(0.0);
 
+    /// Returns `Val::Px(0.)` if `self` is `Val::Auto`, or `self` otherwise.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use bevy_ui::{Val};
+    /// assert_eq!(Val::Auto.auto_to_zero(), Val::Px(0.));
+    /// assert_eq!(Val::Percent(1.).auto_to_zero(), Val::Percent(1.));
+    /// ```
+    pub const fn auto_to_px_zero(self) -> Val {
+        match self {
+            Val::Auto => Val::Px(0.),
+            _ => self,
+        }
+    }
+
     /// Returns a [`UiRect`] with its `left` equal to this value,
     /// and all other fields set to `Val::ZERO`.
     ///
@@ -302,7 +318,7 @@ impl Val {
         UiRect::vertical(self)
     }
 
-    /// Attempts to add two `Val`s.
+    /// Try to add two `Val`s.
     ///
     /// Returns [`ValArithmeticError::IncompatibleUnits`] if the units differ or both are `Val::Auto`.
     ///
@@ -326,7 +342,7 @@ impl Val {
         }
     }
 
-    /// Attempts to subtract one `Val` from another.
+    /// Try to subtract one `Val` from another.
     ///
     /// Returns [`ValArithmeticError::IncompatibleUnits`] if the units differ or both are `Val::Auto`.
     ///

--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -301,6 +301,30 @@ impl Val {
     pub const fn vertical(self) -> UiRect {
         UiRect::vertical(self)
     }
+
+    pub const fn try_add(self, val: Val) -> Result<Val, ValArithmeticError> {
+        match (self, val) {
+            (Val::Px(u), Val::Px(v)) => Ok(Val::Px(u + v)),
+            (Val::Percent(u), Val::Percent(v)) => Ok(Val::Percent(u + v)),
+            (Val::Vw(u), Val::Vw(v)) => Ok(Val::Vw(u + v)),
+            (Val::Vh(u), Val::Vh(v)) => Ok(Val::Vh(u + v)),
+            (Val::VMin(u), Val::VMin(v)) => Ok(Val::VMin(u + v)),
+            (Val::VMax(u), Val::VMax(v)) => Ok(Val::VMax(u + v)),
+            _ => Err(ValArithmeticError::IncompatibleUnits),
+        }
+    }
+
+    pub const fn try_sub(self, val: Val) -> Result<Val, ValArithmeticError> {
+        match (self, val) {
+            (Val::Px(u), Val::Px(v)) => Ok(Val::Px(u - v)),
+            (Val::Percent(u), Val::Percent(v)) => Ok(Val::Percent(u - v)),
+            (Val::Vw(u), Val::Vw(v)) => Ok(Val::Vw(u - v)),
+            (Val::Vh(u), Val::Vh(v)) => Ok(Val::Vh(u - v)),
+            (Val::VMin(u), Val::VMin(v)) => Ok(Val::VMin(u - v)),
+            (Val::VMax(u), Val::VMax(v)) => Ok(Val::VMax(u - v)),
+            _ => Err(ValArithmeticError::IncompatibleUnits),
+        }
+    }
 }
 
 impl Default for Val {
@@ -389,6 +413,8 @@ impl Neg for Val {
 pub enum ValArithmeticError {
     #[error("the given variant of Val is not evaluable (non-numeric)")]
     NonEvaluable,
+    #[error("the given variants of Val have incompatible units")]
+    IncompatibleUnits,
 }
 
 impl Val {
@@ -1178,10 +1204,72 @@ mod tests {
     }
 
     #[test]
+    fn val_try_add_compatible_variants() {
+        assert_eq!(Val::Px(1.).try_add(Val::Px(2.)), Ok(Val::Px(3.)));
+        assert_eq!(
+            Val::Percent(1.).try_add(Val::Percent(2.)),
+            Ok(Val::Percent(3.))
+        );
+        assert_eq!(Val::Vw(1.).try_add(Val::Vw(2.)), Ok(Val::Vw(3.)));
+        assert_eq!(Val::Vh(1.).try_add(Val::Vh(2.)), Ok(Val::Vh(3.)));
+        assert_eq!(Val::VMin(1.).try_add(Val::VMin(2.)), Ok(Val::VMin(3.)));
+        assert_eq!(Val::VMax(1.).try_add(Val::VMax(2.)), Ok(Val::VMax(3.)));
+    }
+
+    #[test]
+    fn val_try_add_incompatible_variants() {
+        assert_eq!(
+            Val::Auto.try_add(Val::Auto),
+            Err(ValArithmeticError::IncompatibleUnits)
+        );
+        assert_eq!(
+            Val::Px(1.).try_add(Val::Percent(2.)),
+            Err(ValArithmeticError::IncompatibleUnits)
+        );
+        assert_eq!(
+            Val::Auto.try_add(Val::Px(1.)),
+            Err(ValArithmeticError::IncompatibleUnits)
+        );
+    }
+
+    #[test]
+    fn val_try_sub_compatible_variants() {
+        assert_eq!(Val::Px(3.).try_sub(Val::Px(2.)), Ok(Val::Px(1.)));
+        assert_eq!(
+            Val::Percent(3.).try_sub(Val::Percent(2.)),
+            Ok(Val::Percent(1.))
+        );
+        assert_eq!(Val::Vw(3.).try_sub(Val::Vw(2.)), Ok(Val::Vw(1.)));
+        assert_eq!(Val::Vh(3.).try_sub(Val::Vh(2.)), Ok(Val::Vh(1.)));
+        assert_eq!(Val::VMin(3.).try_sub(Val::VMin(2.)), Ok(Val::VMin(1.)));
+        assert_eq!(Val::VMax(3.).try_sub(Val::VMax(2.)), Ok(Val::VMax(1.)));
+    }
+
+    #[test]
+    fn val_try_sub_incompatible_variants() {
+        assert_eq!(
+            Val::Auto.try_sub(Val::Auto),
+            Err(ValArithmeticError::IncompatibleUnits)
+        );
+        assert_eq!(
+            Val::Px(1.).try_sub(Val::Percent(2.)),
+            Err(ValArithmeticError::IncompatibleUnits)
+        );
+        assert_eq!(
+            Val::Auto.try_sub(Val::Px(1.)),
+            Err(ValArithmeticError::IncompatibleUnits)
+        );
+    }
+
+    #[test]
     fn val_arithmetic_error_messages() {
         assert_eq!(
             format!("{}", ValArithmeticError::NonEvaluable),
             "the given variant of Val is not evaluable (non-numeric)"
+        );
+        assert_eq!(
+            format!("{}", ValArithmeticError::IncompatibleUnits),
+            "the given variants of Val have mismatched units"
         );
     }
 

--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -302,6 +302,18 @@ impl Val {
         UiRect::vertical(self)
     }
 
+    /// Attempts to add two `Val`s.
+    ///
+    /// Returns [`ValArithmeticError::IncompatibleUnits`] if the units differ or both are `Val::Auto`.
+    ///
+    /// ```
+    /// # use bevy_ui::{Val, ValArithmeticError};
+    /// assert_eq!(Val::Px(1.).try_add(Val::Px(2.)), Ok(Val::Px(3.)));
+    /// assert_eq!(
+    ///     Val::Px(1.).try_add(Val::Percent(2.)),
+    ///     Err(ValArithmeticError::IncompatibleUnits)
+    /// );
+    /// ```
     pub const fn try_add(self, val: Val) -> Result<Val, ValArithmeticError> {
         match (self, val) {
             (Val::Px(u), Val::Px(v)) => Ok(Val::Px(u + v)),
@@ -314,6 +326,18 @@ impl Val {
         }
     }
 
+    /// Attempts to subtract one `Val` from another.
+    ///
+    /// Returns [`ValArithmeticError::IncompatibleUnits`] if the units differ or both are `Val::Auto`.
+    ///
+    /// ```
+    /// # use bevy_ui::{Val, ValArithmeticError};
+    /// assert_eq!(Val::Px(3.).try_sub(Val::Px(2.)), Ok(Val::Px(1.)));
+    /// assert_eq!(
+    ///     Val::Px(1.).try_sub(Val::Percent(2.)),
+    ///     Err(ValArithmeticError::IncompatibleUnits)
+    /// );
+    /// ```
     pub const fn try_sub(self, val: Val) -> Result<Val, ValArithmeticError> {
         match (self, val) {
             (Val::Px(u), Val::Px(v)) => Ok(Val::Px(u - v)),

--- a/crates/bevy_ui/src/ui_transform.rs
+++ b/crates/bevy_ui/src/ui_transform.rs
@@ -84,7 +84,7 @@ impl Val2 {
     /// );
     /// ```
     pub fn try_add(self, other: Val2) -> Result<Self, ValArithmeticError> {
-        let (Ok(x), Ok(y)) = (self.x.try_add(other.x), other.y.try_add(other.y)) else {
+        let (Ok(x), Ok(y)) = (self.x.try_add(other.x), self.y.try_add(other.y)) else {
             return Err(ValArithmeticError::IncompatibleUnits);
         };
         Ok(Self { x, y })

--- a/crates/bevy_ui/src/ui_transform.rs
+++ b/crates/bevy_ui/src/ui_transform.rs
@@ -84,10 +84,7 @@ impl Val2 {
     /// );
     /// ```
     pub fn try_add(self, other: Val2) -> Result<Self, ValArithmeticError> {
-        let (Ok(x), Ok(y)) = (
-            self.x.auto_to_px_zero().try_add(other.x.auto_to_px_zero()),
-            other.y.auto_to_px_zero().try_add(other.y.auto_to_px_zero()),
-        ) else {
+        let (Ok(x), Ok(y)) = (self.x.try_add(other.x), other.y.try_add(other.y)) else {
             return Err(ValArithmeticError::IncompatibleUnits);
         };
         Ok(Self { x, y })
@@ -106,10 +103,7 @@ impl Val2 {
     /// );
     /// ```
     pub fn try_sub(self, other: Val2) -> Result<Self, ValArithmeticError> {
-        let (Ok(x), Ok(y)) = (
-            self.x.auto_to_px_zero().try_sub(other.x.auto_to_px_zero()),
-            other.y.auto_to_px_zero().try_sub(other.y.auto_to_px_zero()),
-        ) else {
+        let (Ok(x), Ok(y)) = (self.x.try_sub(other.x), self.y.try_sub(other.y)) else {
             return Err(ValArithmeticError::IncompatibleUnits);
         };
         Ok(Self { x, y })

--- a/crates/bevy_ui/src/ui_transform.rs
+++ b/crates/bevy_ui/src/ui_transform.rs
@@ -1,4 +1,5 @@
 use crate::Val;
+use crate::ValArithmeticError;
 use bevy_derive::Deref;
 use bevy_ecs::component::Component;
 use bevy_ecs::prelude::ReflectComponent;
@@ -68,6 +69,50 @@ impl Val2 {
                 .resolve(scale_factor, base_size.y, viewport_size)
                 .unwrap_or(0.),
         )
+    }
+
+    /// Try to add two `Val2`s component-wise.
+    ///
+    /// Returns [`ValArithmeticError::IncompatibleUnits`] if either component has mismatched units.
+    ///
+    /// ```
+    /// # use bevy_ui::{Val, Val2, ValArithmeticError};
+    /// assert_eq!(Val2::px(1., 2.).try_add(Val2::px(3., 4.)), Ok(Val2::px(4., 6.)));
+    /// assert_eq!(
+    ///     Val2::new(Val::Px(1.), Val::Px(2.)).try_add(Val2::new(Val::Percent(3.), Val::Px(4.))),
+    ///     Err(ValArithmeticError::IncompatibleUnits)
+    /// );
+    /// ```
+    pub fn try_add(self, other: Val2) -> Result<Self, ValArithmeticError> {
+        let (Ok(x), Ok(y)) = (
+            self.x.auto_to_px_zero().try_add(other.x.auto_to_px_zero()),
+            other.y.auto_to_px_zero().try_add(other.y.auto_to_px_zero()),
+        ) else {
+            return Err(ValArithmeticError::IncompatibleUnits);
+        };
+        Ok(Self { x, y })
+    }
+
+    /// Try to subtract two `Val2`s component-wise.
+    ///
+    /// Returns [`ValArithmeticError::IncompatibleUnits`] if either component has mismatched units.
+    ///
+    /// ```
+    /// # use bevy_ui::{Val, Val2, ValArithmeticError};
+    /// assert_eq!(Val2::px(3., 4.).try_sub(Val2::px(1., 2.)), Ok(Val2::px(2., 2.)));
+    /// assert_eq!(
+    ///     Val2::new(Val::Px(1.), Val::Px(2.)).try_sub(Val2::new(Val::Percent(3.), Val::Px(4.))),
+    ///     Err(ValArithmeticError::IncompatibleUnits)
+    /// );
+    /// ```
+    pub fn try_sub(self, other: Val2) -> Result<Self, ValArithmeticError> {
+        let (Ok(x), Ok(y)) = (
+            self.x.auto_to_px_zero().try_sub(other.x.auto_to_px_zero()),
+            other.y.auto_to_px_zero().try_sub(other.y.auto_to_px_zero()),
+        ) else {
+            return Err(ValArithmeticError::IncompatibleUnits);
+        };
+        Ok(Self { x, y })
     }
 }
 


### PR DESCRIPTION
# Objective

Add fallible arithmetic support for `Val`s.

## Solution

Implement `try_add` and `try_sub` methods for `Val` and `Val2`.

The methods succeed only if the `Val`s are matching variants, and neither is `Val:Auto`.

I considered allowing arithmetric with incompatible zero(s), but it feels potentially confusing as there isn't a clear and natural way to select the units for the result. 

Also removed the `val_arithmetic_error_messages` test, instead of updating it. I don't see any value there.
