### PR TITLE
Fix excessive monomorphization of `Dir::insert_asset`

### DIFF
--- a/crates/bevy_asset/src/io/embedded/mod.rs
+++ b/crates/bevy_asset/src/io/embedded/mod.rs
@@ -40,6 +40,12 @@ impl EmbeddedAssetRegistry {
     /// running in a non-rust file). `asset_path` is the path that will be used to identify the asset in the `embedded`
     /// [`AssetSource`](crate::io::AssetSource). `value` is the bytes that will be returned for the asset. This can be
     /// _either_ a `&'static [u8]` or a [`Vec<u8>`](alloc::vec::Vec).
+    pub fn insert_asset(&self, full_path: PathBuf, asset_path: &Path, value: impl Into<Value>) {
+        self.insert_asset_internal(full_path, asset_path, value.into());
+    }
+
+    // Implements `insert_asset`, but with a non-generic `value` parameter. This
+    // stops the function from being duplicated many times by monomorphization.
     #[cfg_attr(
         not(feature = "embedded_watcher"),
         expect(
@@ -47,7 +53,7 @@ impl EmbeddedAssetRegistry {
             reason = "The `full_path` argument is not used when `embedded_watcher` is disabled."
         )
     )]
-    pub fn insert_asset(&self, full_path: PathBuf, asset_path: &Path, value: impl Into<Value>) {
+    fn insert_asset_internal(&self, full_path: PathBuf, asset_path: &Path, value: Value) {
         #[cfg(feature = "embedded_watcher")]
         self.root_paths
             .write()

--- a/crates/bevy_asset/src/io/memory.rs
+++ b/crates/bevy_asset/src/io/memory.rs
@@ -48,6 +48,12 @@ impl Dir {
     }
 
     pub fn insert_asset(&self, path: &Path, value: impl Into<Value>) {
+        self.insert_asset_internal(path, value.into());
+    }
+
+    // Implements `insert_asset`, but with a non-generic `value` parameter. This
+    // stops the function from being duplicated many times by monomorphization.
+    fn insert_asset_internal(&self, path: &Path, value: Value) {
         let mut dir = self.clone();
         if let Some(parent) = path.parent() {
             dir = self.get_or_insert_dir(parent);
@@ -59,7 +65,7 @@ impl Dir {
             .insert(
                 path.file_name().unwrap().to_string_lossy().into(),
                 Data {
-                    value: value.into(),
+                    value,
                     path: path.to_owned(),
                 },
             );
@@ -82,6 +88,11 @@ impl Dir {
     }
 
     pub fn insert_meta(&self, path: &Path, value: impl Into<Value>) {
+        self.insert_meta_internal(path, value.into());
+    }
+
+    // Implements `insert_meta` - see `insert_asset_internal` for rationale.
+    fn insert_meta_internal(&self, path: &Path, value: Value) {
         let mut dir = self.clone();
         if let Some(parent) = path.parent() {
             dir = self.get_or_insert_dir(parent);
@@ -93,7 +104,7 @@ impl Dir {
             .insert(
                 path.file_name().unwrap().to_string_lossy().into(),
                 Data {
-                    value: value.into(),
+                    value,
                     path: path.to_owned(),
                 },
             );


### PR DESCRIPTION
## Objective

Reduce code bloat caused by excessive monomorphization.

## Background

`bevy_asset::Dir::insert` has the following signature:

```rust
fn insert_asset(&self, path: &Path, value: impl Into<Value>)
```

The `value` parameter is usually a `Vec<u8>` or `&'static [u8; N]`, which is conveniently handled by `Into<Value>`.

`Dir::insert_asset` is called by the `embedded_asset!` macro via `EmbeddedAssetRegistry::insert_asset`:

```rust
embedded.insert_asset(watched_path, &path, include_bytes!($path));
```

`include_bytes!` returns a `&'static [u8; N]`, which goes to the `value` parameter of `insert_asset`. This means that `insert_asset` gets monomorphized many times, since N is part of the generic type via `impl From<&'static [u8; N]> for Value`.

```
> cargo bloat --example 3d_scene --profile release --filter "insert_asset" -n 10

File .text     Size              Crate Name
0.0%  0.0%   1.1KiB    bevy_anti_alias bevy_asset::io::embedded::EmbeddedAssetRegistry::insert_asset
0.0%  0.0%   1.1KiB    bevy_anti_alias bevy_asset::io::embedded::EmbeddedAssetRegistry::insert_asset
0.0%  0.0%   1.1KiB    bevy_anti_alias bevy_asset::io::embedded::EmbeddedAssetRegistry::insert_asset
0.0%  0.0%   1.1KiB    bevy_anti_alias bevy_asset::io::embedded::EmbeddedAssetRegistry::insert_asset
0.0%  0.0%   1.1KiB    bevy_anti_alias bevy_asset::io::embedded::EmbeddedAssetRegistry::insert_asset
0.0%  0.0%   1.1KiB    bevy_anti_alias bevy_asset::io::embedded::EmbeddedAssetRegistry::insert_asset
0.0%  0.0%     983B bevy_core_pipeline bevy_asset::io::memory::Dir::insert_asset
0.0%  0.0%     983B bevy_core_pipeline bevy_asset::io::memory::Dir::insert_asset
0.0%  0.0%     983B bevy_core_pipeline bevy_asset::io::memory::Dir::insert_asset
0.0%  0.0%     983B bevy_core_pipeline bevy_asset::io::memory::Dir::insert_asset
0.1%  0.2% 106.3KiB                    And 111 smaller methods. Use -n N to show more.
0.1%  0.2% 116.5KiB                    filtered data size, the file size is 79.3MiB
```

## Solution

The fix is to split `insert_asset` into a generic front-end and a non-generic back-end:

```rust
pub fn insert_asset(&self, path: &Path, value: impl Into<Value>) {
    self.insert_asset_internal(path, value.into());
}
 
fn insert_asset_internal(&self, path: &Path, value: Value) {
    ...
}
```

This drops a release build of `3d_scene` from 81,190KB to 81,029KB (-161KB, -0.2%).

## Testing

```sh
cargo test -p bevy_asset
cargo run --example 3d_scene
cargo run --example 3d_scene --features "embedded_watcher"
```
