### PR TITLE
Add missing 'trace' feature cfg attributes

### DIFF
--- a/crates/bevy_core_pipeline/src/schedule.rs
+++ b/crates/bevy_core_pipeline/src/schedule.rs
@@ -230,6 +230,7 @@ pub(crate) fn submit_pending_command_buffers(world: &mut World) {
     let buffers = pending.take();
 
     if !buffers.is_empty() {
+        #[cfg(feature = "trace")]
         let _span = info_span!("queue_submit", count = buffer_count).entered();
         let queue = world.resource::<RenderQueue>();
         queue.submit(buffers);

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -2482,6 +2482,7 @@ pub fn collect_meshes_for_gpu_building(
                         let reextract_tx = reextract_tx.clone();
                         let removed_tx = removed_tx.clone();
                         scope.spawn(async move {
+                            #[cfg(feature = "trace")]
                             let _span = info_span!("prepared_mesh_producer").entered();
                             changed
                                 .drain(..)
@@ -2520,6 +2521,7 @@ pub fn collect_meshes_for_gpu_building(
                         let reextract_tx = reextract_tx.clone();
                         let removed_tx = removed_tx.clone();
                         scope.spawn(async move {
+                            #[cfg(feature = "trace")]
                             let _span = info_span!("prepared_mesh_producer").entered();
                             for (entity, mesh_instance_builder, mesh_culling_builder) in
                                 changed_cpu_culling

--- a/crates/bevy_render/src/batching/gpu_preprocessing.rs
+++ b/crates/bevy_render/src/batching/gpu_preprocessing.rs
@@ -2341,12 +2341,14 @@ pub fn write_batched_instance_buffers<GFBD>(
 
     ComputeTaskPool::get().scope(|scope| {
         scope.spawn(async {
+            #[cfg(feature = "trace")]
             let _span = bevy_log::info_span!("write_current_input_buffers").entered();
             current_input_buffer
                 .buffer
                 .write_buffers(render_device, render_queue);
         });
         scope.spawn(async {
+            #[cfg(feature = "trace")]
             let _span = bevy_log::info_span!("write_previous_input_buffers").entered();
             previous_input_buffer.write_buffer(render_device, render_queue);
         });
@@ -2360,6 +2362,7 @@ pub fn write_batched_instance_buffers<GFBD>(
             } = *phase_instance_buffers;
 
             scope.spawn(async {
+                #[cfg(feature = "trace")]
                 let _span = bevy_log::info_span!("write_phase_instance_buffers").entered();
                 data_buffer.write_buffer(render_device);
                 late_indexed_indirect_parameters_buffer.write_buffer(render_device, render_queue);
@@ -2369,6 +2372,7 @@ pub fn write_batched_instance_buffers<GFBD>(
 
             for phase_work_item_buffers in work_item_buffers.values_mut() {
                 scope.spawn(async {
+                    #[cfg(feature = "trace")]
                     let _span = bevy_log::info_span!("write_work_item_buffers").entered();
                     match *phase_work_item_buffers {
                         PreprocessWorkItemBuffers::Direct(ref mut buffer_vec) => {
@@ -2640,6 +2644,7 @@ pub fn write_indirect_parameters_buffers(
     ComputeTaskPool::get().scope(|scope| {
         for phase_indirect_parameters_buffers in indirect_parameters_buffers.values_mut() {
             scope.spawn(async {
+                #[cfg(feature = "trace")]
                 let _span = bevy_log::info_span!("indexed_data").entered();
                 phase_indirect_parameters_buffers
                     .indexed
@@ -2647,6 +2652,7 @@ pub fn write_indirect_parameters_buffers(
                     .write_buffer(render_device);
             });
             scope.spawn(async {
+                #[cfg(feature = "trace")]
                 let _span = bevy_log::info_span!("non_indexed_data").entered();
                 phase_indirect_parameters_buffers
                     .non_indexed
@@ -2655,6 +2661,7 @@ pub fn write_indirect_parameters_buffers(
             });
 
             scope.spawn(async {
+                #[cfg(feature = "trace")]
                 let _span = bevy_log::info_span!("indexed_cpu_metadata").entered();
                 phase_indirect_parameters_buffers
                     .indexed
@@ -2662,6 +2669,7 @@ pub fn write_indirect_parameters_buffers(
                     .write_buffer(render_device, render_queue);
             });
             scope.spawn(async {
+                #[cfg(feature = "trace")]
                 let _span = bevy_log::info_span!("non_indexed_cpu_metadata").entered();
                 phase_indirect_parameters_buffers
                     .non_indexed
@@ -2670,6 +2678,7 @@ pub fn write_indirect_parameters_buffers(
             });
 
             scope.spawn(async {
+                #[cfg(feature = "trace")]
                 let _span = bevy_log::info_span!("non_indexed_gpu_metadata").entered();
                 phase_indirect_parameters_buffers
                     .non_indexed
@@ -2677,6 +2686,7 @@ pub fn write_indirect_parameters_buffers(
                     .write_buffer(render_device);
             });
             scope.spawn(async {
+                #[cfg(feature = "trace")]
                 let _span = bevy_log::info_span!("indexed_gpu_metadata").entered();
                 phase_indirect_parameters_buffers
                     .indexed
@@ -2685,6 +2695,7 @@ pub fn write_indirect_parameters_buffers(
             });
 
             scope.spawn(async {
+                #[cfg(feature = "trace")]
                 let _span = bevy_log::info_span!("indexed_batch_sets").entered();
                 phase_indirect_parameters_buffers
                     .indexed
@@ -2692,6 +2703,7 @@ pub fn write_indirect_parameters_buffers(
                     .write_buffer(render_device, render_queue);
             });
             scope.spawn(async {
+                #[cfg(feature = "trace")]
                 let _span = bevy_log::info_span!("non_indexed_batch_sets").entered();
                 phase_indirect_parameters_buffers
                     .non_indexed

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -19,13 +19,16 @@ use bevy_camera::NormalizedRenderTarget;
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::schedule::ScheduleLabel;
 use bevy_ecs::{prelude::*, system::SystemState};
-use bevy_log::{debug, info, info_span, warn};
+use bevy_log::{debug, info, warn};
 use bevy_render::camera::ExtractedCamera;
 use bevy_window::RawHandleWrapperHolder;
 use wgpu::{
     Adapter, AdapterInfo, Backends, DeviceType, ForceShaderModelToken, Instance, Queue,
     RequestAdapterOptions, Trace,
 };
+
+#[cfg(feature = "trace")]
+use bevy_log::info_span;
 
 /// Schedule label for the root render graph schedule. This schedule runs once per frame
 /// in the [`render_system`] system and is responsible for driving the entire rendering process.

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -87,6 +87,7 @@ pub fn render_system(
     }
 
     {
+        #[cfg(feature = "trace")]
         let _span = info_span!("present_frames").entered();
 
         world.resource_scope(|world, mut windows: Mut<ExtractedWindows>| {

--- a/crates/bevy_render/src/renderer/render_context.rs
+++ b/crates/bevy_render/src/renderer/render_context.rs
@@ -107,7 +107,8 @@ impl RenderContextState {
 impl SystemBuffer for RenderContextState {
     fn queue(&mut self, _system_meta: &SystemMeta, mut world: DeferredWorld) {
         #[cfg(feature = "trace")]
-        let _span = info_span!("RenderContextState::apply", system = %_system_meta.name()).entered();
+        let _span =
+            info_span!("RenderContextState::apply", system = %_system_meta.name()).entered();
 
         let inner = &mut *self.0;
 

--- a/crates/bevy_render/src/renderer/render_context.rs
+++ b/crates/bevy_render/src/renderer/render_context.rs
@@ -104,6 +104,7 @@ impl RenderContextState {
 
 impl SystemBuffer for RenderContextState {
     fn queue(&mut self, system_meta: &SystemMeta, mut world: DeferredWorld) {
+        #[cfg(feature = "trace")]
         let _span = info_span!("RenderContextState::apply", system = %system_meta.name()).entered();
 
         let inner = &mut *self.0;

--- a/crates/bevy_render/src/renderer/render_context.rs
+++ b/crates/bevy_render/src/renderer/render_context.rs
@@ -13,9 +13,11 @@ use bevy_ecs::system::{
 };
 use bevy_ecs::world::unsafe_world_cell::UnsafeWorldCell;
 use bevy_ecs::world::DeferredWorld;
-use bevy_log::info_span;
 use core::marker::PhantomData;
 use wgpu::CommandBuffer;
+
+#[cfg(feature = "trace")]
+use bevy_log::info_span;
 
 #[derive(Default)]
 struct PendingCommandBuffersInner {
@@ -103,9 +105,9 @@ impl RenderContextState {
 }
 
 impl SystemBuffer for RenderContextState {
-    fn queue(&mut self, system_meta: &SystemMeta, mut world: DeferredWorld) {
+    fn queue(&mut self, _system_meta: &SystemMeta, mut world: DeferredWorld) {
         #[cfg(feature = "trace")]
-        let _span = info_span!("RenderContextState::apply", system = %system_meta.name()).entered();
+        let _span = info_span!("RenderContextState::apply", system = %_system_meta.name()).entered();
 
         let inner = &mut *self.0;
 

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -194,6 +194,7 @@ impl RenderVisibleEntitiesClass {
         &mut self,
         visible_mesh_entities_cpu_culling: &[(Entity, MainEntity)],
     ) {
+        #[cfg(feature = "trace")]
         let _update_from = info_span!("update_from", name = "update_from").entered();
 
         let old_entities_cpu_culling = mem::take(&mut self.entities_cpu_culling);
@@ -203,6 +204,7 @@ impl RenderVisibleEntitiesClass {
         // entities. The lists must be sorted.
         let mut old_entity_cpu_culling_iter = old_entities_cpu_culling.iter().peekable();
         {
+            #[cfg(feature = "trace")]
             let _old_entity_cpu_culling_span =
                 info_span!("old_entity_cpu_culling", name = "old_entity_cpu_culling").entered();
             for (render_entity, visible_main_entity) in visible_mesh_entities_cpu_culling {
@@ -236,6 +238,7 @@ impl RenderVisibleEntitiesClass {
         // Any entities that do CPU culling and that we didn't see yet are
         // removed, so drain them.
         {
+            #[cfg(feature = "trace")]
             let _old_entity_cpu_culling_removal_span = info_span!(
                 "old_entity_cpu_culling_removal",
                 name = "old_entity_cpu_culling_removal"

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -10,7 +10,6 @@ use bevy_ecs::{
         Local, Query, SystemParam,
     },
 };
-use bevy_log::info_span;
 use bevy_platform::collections::{HashMap, HashSet};
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_utils::TypeIdMap;
@@ -20,6 +19,9 @@ use crate::{
     view::RetainedViewEntity,
     Extract,
 };
+
+#[cfg(feature = "trace")]
+use bevy_log::info_span;
 
 mod range;
 use bevy_camera::visibility::*;


### PR DESCRIPTION
# Objective

Resolve the memory leak described in #23949.

# Solution

Added `#[cfg(feature = "trace")]` to all `info_span!` calls where the `trace` feature is available. There are some info spans that are included in crates that do not have a `trace` feature. I left these alone but could also add the feature if that's preferrable.

Exiting spans causes `tracing_wasm` to create `PerformanceMark`/`PerformanceMeasure` instances. Most of the spans that were missing this attribute were in `gpu_preprocessing`, which are entered every frame on WebGPU, leading to a steady memory increase. Adding these attributes resolves this issue for non-profiling builds.

# Testing

```bash
CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=wasm-server-runner cargo run -r --example 3d_shapes -F webgpu --target wasm32-unknown-unknown
```

Closes #23949
