### PR TITLE
Detach reattach propagation fix

### DIFF
--- a/crates/bevy_app/src/propagate.rs
+++ b/crates/bevy_app/src/propagate.rs
@@ -263,7 +263,7 @@ pub fn propagate_inherited<C: Component + Clone + PartialEq, F: QueryFilter, R: 
 
     // and removed
     for entity in removed.read() {
-        if let Ok((Some(targets), _, _)) = recurse.get(entity) {
+        if let Ok((Some(targets), None, _)) = recurse.get(entity) {
             to_process.extend(targets.iter().map(|target| (target, None)));
         }
     }

--- a/crates/bevy_app/src/propagate.rs
+++ b/crates/bevy_app/src/propagate.rs
@@ -480,6 +480,45 @@ mod tests {
     }
 
     #[test]
+    fn test_detach_and_reattach_propagates_to_descendants() {
+        let mut app = App::new();
+        app.add_schedule(Schedule::new(Update));
+        app.add_plugins(HierarchyPropagatePlugin::<TestValue>::new(Update));
+
+        let mut query = app.world_mut().query::<&TestValue>();
+
+        let propagator = app.world_mut().spawn(Propagate(TestValue(1))).id();
+        let intermediate = app
+            .world_mut()
+            .spawn_empty()
+            .insert(ChildOf(propagator))
+            .id();
+        let propagatee = app
+            .world_mut()
+            .spawn_empty()
+            .insert(ChildOf(intermediate))
+            .id();
+
+        app.update();
+
+        assert_eq!(
+            query.get_many(app.world(), [intermediate, propagatee]),
+            Ok([&TestValue(1), &TestValue(1)])
+        );
+
+        app.world_mut()
+            .entity_mut(intermediate)
+            .remove::<ChildOf>()
+            .insert(ChildOf(propagator));
+        app.update();
+
+        assert_eq!(
+            query.get_many(app.world(), [intermediate, propagatee]),
+            Ok([&TestValue(1), &TestValue(1)])
+        );
+    }
+
+    #[test]
     fn test_propagate_over() {
         let mut app = App::new();
         app.add_schedule(Schedule::new(Update));


### PR DESCRIPTION
# Objective

Fixes #23893

Chain of events as far as I can follow it:
1. Remove a relationship from an entity E.
2. Immediately restore the relationship.
3. The `on_r_removed<C, R>` observer system triggered by `On<Remove, R>` removes the `Inherited<C>` component from E.
4. The `on_r_inserted<C, R>` observer system  triggered by `On<Insert, R>` inserts `Inherited<C>`  back again on E.
5. `propagated_inherited` queries for changes, adds `(E, Inherited<C>)` to `to_process`.
6. `propagate_inherited` queries for `RemovedComponents<Inherited<C>>`, adds `(F, None)` to `to_process` for each F descended from E.
7. Then `to_process` is processed.
8. The `(F, None)` entries are processed first, recursively removing `Inherited<C>` from E's descendants using deferred commands.
9. Then `(E, Inherited<C>)` is ignored as the defererred commands haven't been applied yet so the current inherited state matches the queued inherited state.

## Solution

If an entity from `RemovedComponents<Inherited<C>>` has `Inherited<C>`, don't add its descendants to the `to_process` stack.

Not super confident in this change, but the new test passes and none of the old tests fail.

## Testing

New test: `test_detach_and_reattach_propagates_to_descendants`


