### PR TITLE
fix(Rect Lights): `rect_lights` should be written out to `GpuLights`

### DIFF
--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -2078,21 +2078,6 @@ pub fn prepare_lights(
             }
         }
 
-        commands.entity(entity).insert((
-            ViewShadowBindings {
-                point_light_depth_texture: point_light_depth_texture.texture.clone(),
-                point_light_depth_texture_view: point_light_depth_texture_view.clone(),
-                directional_light_depth_texture: directional_light_depth_texture.texture.clone(),
-                directional_light_depth_texture_view: directional_light_depth_texture_view.clone(),
-            },
-            ViewLightEntities {
-                lights: view_lights,
-            },
-            ViewLightsUniformOffset {
-                offset: view_gpu_lights_writer.write(&gpu_lights),
-            },
-        ));
-
         // Make a link from the camera to all shadow cascades with occlusion
         // culling enabled.
         if !view_occlusion_culling_lights.is_empty() {
@@ -2125,6 +2110,21 @@ pub fn prepare_lights(
             };
             gpu_lights.n_rect_lights += 1;
         }
+
+        commands.entity(entity).insert((
+            ViewShadowBindings {
+                point_light_depth_texture: point_light_depth_texture.texture.clone(),
+                point_light_depth_texture_view: point_light_depth_texture_view.clone(),
+                directional_light_depth_texture: directional_light_depth_texture.texture.clone(),
+                directional_light_depth_texture_view: directional_light_depth_texture_view.clone(),
+            },
+            ViewLightEntities {
+                lights: view_lights,
+            },
+            ViewLightsUniformOffset {
+                offset: view_gpu_lights_writer.write(&gpu_lights),
+            },
+        ));
     }
 
     // Mark the existing shadow maps as unused this frame so that the first


### PR DESCRIPTION
# Objective

- The `rect_light` half of #23997 

## Solution

- Move the statement that writes `gpu_lights` *after* the code block that sets rect_light information within `gpu_lights`. If only all the rendering bugs were this easy...

## Testing

- `cargo run --example rect_light --features=“free_camera”` works again

<img width="1271" height="744" alt="Screenshot 2026-04-28 at 11 08 32 PM" src="https://github.com/user-attachments/assets/84018902-1f70-4a8c-9e16-982d156fb8b4" />