### PR TITLE
Add a rectangular light to the 3d testbed Light scene

### DIFF
--- a/examples/testbed/3d.rs
+++ b/examples/testbed/3d.rs
@@ -190,6 +190,18 @@ mod light {
         ));
 
         commands.spawn((
+            RectLight {
+                color: Color::srgb(0.5, 0.7, 1.0),
+                intensity: 100_000.0,
+                width: 1.5,
+                height: 4.0,
+                range: 20.0,
+            },
+            Transform::from_xyz(1.0, 2.0, -2.0).looking_at(Vec3::new(-1.0, 0.0, 0.0), Vec3::Y),
+            DespawnOnExit(CURRENT_SCENE),
+        ));
+
+        commands.spawn((
             Camera3d::default(),
             Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
             DespawnOnExit(CURRENT_SCENE),


### PR DESCRIPTION
# Objective

- Regression test for broken Rect Lights

## Solution

- Add a rectangular light to testbed/3d

## Testing

- `cargo run --example testbed_3d` - I can see the new light (well, after #24024 is merged hehe)

Before (w/o rect light)
<img width="1271" height="747" alt="Screenshot 2026-04-28 at 11 28 16 PM" src="https://github.com/user-attachments/assets/aa6b6258-e80d-4a98-861c-bcad6e8db541" />

After (w/ rect light - it’s behind the cube)
<img width="1271" height="750" alt="Screenshot 2026-04-28 at 11 25 33 PM" src="https://github.com/user-attachments/assets/877013f0-843a-43f2-9dbd-96f2fa37d8e2" />

