### PR TITLE
Add `SystemIdTemplate` to allow one-shot system in bsn!

### DIFF
--- a/crates/bevy_ecs/src/template.rs
+++ b/crates/bevy_ecs/src/template.rs
@@ -6,7 +6,10 @@ use bevy_platform::sync::Mutex;
 
 pub use bevy_ecs_macros::FromTemplate;
 
+use crate::lifecycle::HookContext;
+use crate::name::Name;
 use crate::system::SystemId;
+use crate::world::DeferredWorld;
 use crate::{
     component::Mutable,
     entity::Entity,
@@ -485,34 +488,57 @@ impl Default for SystemIdTemplate {
     }
 }
 
+/// These are used to track one-shot systems registered from templates, so that they can be cleaned up when the template is no longer in use and to prevent duplicate registrations.
+///
+/// A template instance will create a linked entity for each holding one-shot system. Each system will create a entity with `SytemIdRecorder` saved in `SceneSystemRegistry`, which counting references to it via `RefToSystem`.
+///
+/// `template_A`: `(CompA(system_1), CompB{..., callback: system_2}, ..., LinkedWith(vec![CompA1_system1_entity, CompB1_system2_entity, ...])`
+///
+/// `template_A_clone`: `(CompA(system_1), CompB{..., callback: system_2}, ..., LinkedWith(vec![CompA2_system1_entity, CompB2_system2_entity, ...])`
+///
+/// `system_1`: `SystemIdRecorder{...}, SystemRefs(vec![CompA1_system1_entity, CompA2_system1_entity, ...])`
+///
+/// `system_2`: `SystemIdRecorder{...}, SystemRefs(vec![CompB1_system2_entity, CompB2_system2_entity, ...])`
+///
+/// When `template_A` and `template_A_clone` are dropped, the linked entities will be despawned, which triggers the cleanup system to check the system entities. Since both `system_1` and `system_2` have no more references, they will be despawned and unregistered.
+
 #[derive(Resource, Default)]
 struct SceneSystemRegistry {
     type_map: bevy_platform::collections::HashMap<core::any::TypeId, Entity>,
     id_map: bevy_platform::collections::HashMap<SystemId<(), ()>, Entity>,
 }
 
-#[derive(Component)]
+#[derive(Component, Clone)]
 struct SystemIdRecorder {
     type_id: core::any::TypeId,
     system_id: SystemId<(), ()>,
 }
 
-// #[derive(Component)]
-// #[relationship(relationship_target = SystemRefs<T>)]
-// struct RefToSystem<T: Component + Send + Sync>(#[relationship] Entity, core::marker::PhantomData<T>);
-
-// #[derive(Component)]
-// #[relationship_target(relationship = RefToSystem<T>)]
-// struct SystemRefs<T: Component + Send + Sync>(#[relationship] Vec<Entity>, core::marker::PhantomData<T>);
-
 #[derive(Component)]
 #[relationship(relationship_target = SystemRefs)]
-struct RefToSystem(#[relationship] Entity);
+#[component(on_remove = on_ref_to_system_remove)]
+struct RefToSystem(Entity);
 
+fn on_ref_to_system_remove(mut world: DeferredWorld, ctx: HookContext) {
+    let entity = ctx.entity;
+    let system_refs_entity = world.get::<RefToSystem>(entity).unwrap().0;
+    let system_refs = &world.get::<SystemRefs>(system_refs_entity).unwrap().0;
+
+    if system_refs.is_empty() { // a system is no more referenced, so we can clean it up.
+        let system_recorder = world.get::<SystemIdRecorder>(system_refs_entity).unwrap().clone();
+
+        let mut registry = world.resource_mut::<SceneSystemRegistry>();
+        registry.type_map.remove(&system_recorder.type_id);
+        registry.id_map.remove(&system_recorder.system_id);
+        
+        let mut commands = world.commands();
+        commands.unregister_system(system_recorder.system_id);
+        commands.entity(system_refs_entity).despawn();
+    }
+}
 #[derive(Component)]
 #[relationship_target(relationship = RefToSystem)]
-struct SystemRefs(#[relationship] Vec<Entity>);
-// TODO: unregister system when ref collection is empty.
+struct SystemRefs(Vec<Entity>);
 
 #[derive(Component)]
 #[relationship(relationship_target = LinkedWith)]
@@ -520,8 +546,19 @@ struct LinkLifetimeWith(Entity);
 
 #[derive(Component)]
 #[relationship_target(relationship = LinkLifetimeWith)]
-// TODO: #[Component(on_remove = remove all linked entities on despawn)]
+#[component(on_remove = on_template_remove)]
 struct LinkedWith(Vec<Entity>);
+
+fn on_template_remove(mut world: DeferredWorld, ctx: HookContext) {
+    let entity = ctx.entity;
+    let linked = world.get::<LinkedWith>(entity).unwrap().0.clone();
+
+    let mut commands = world.commands();
+
+    for linked_entity in linked {
+        commands.entity(linked_entity).despawn();
+    }
+}
 
 impl Template for SystemIdTemplate {
     type Output = SystemId<(), ()>;
@@ -529,26 +566,30 @@ impl Template for SystemIdTemplate {
     fn build_template(&self, _context: &mut TemplateContext) -> Result<Self::Output> {
         let template_item_entity = _context.entity.id();
 
+        // ensure the registry exists.
+        _context.entity.world_scope(|world| {
+            world.init_resource::<SceneSystemRegistry>();
+        });
+
         let mut template_state = self.0.lock().unwrap();
         let template_value = template_state.take().unwrap();
 
         let system_id = match template_value {
             SystemOrId::BoxedSystem(system) => _context.entity.world_scope(|world| {
-                let registry = world.get_resource_or_init::<SceneSystemRegistry>();
+                let registry = world.resource::<SceneSystemRegistry>();
 
                 let type_id = system.system_type();
                 if let Some(&entity) = registry.type_map.get(&type_id) {
                     let recorder = world.entity(entity).get::<SystemIdRecorder>().unwrap();
+
                     recorder.system_id
                 } else {
                     let id = world.register_boxed_system(system);
                     let entity = world
-                        .spawn(
-                            (SystemIdRecorder {
-                                system_id: id,
-                                type_id,
-                            }),
-                        )
+                        .spawn((Name("SystemEntity".into()),SystemIdRecorder {
+                            system_id: id,
+                            type_id,
+                        }))
                         .id();
 
                     let mut registry = world.resource_mut::<SceneSystemRegistry>();
@@ -564,14 +605,8 @@ impl Template for SystemIdTemplate {
 
         *template_state = Some(SystemOrId::SystemId(system_id));
 
-        let system_entity = *_context
-            .entity
-            .resource::<SceneSystemRegistry>()
-            .id_map
-            .get(&system_id)
-            .unwrap();
-
         _context.entity.world_scope(|world| {
+            let system_entity = *world.resource::<SceneSystemRegistry>().id_map.get(&system_id).unwrap();
             world.spawn((
                 RefToSystem(system_entity),
                 LinkLifetimeWith(template_item_entity),
@@ -590,14 +625,17 @@ impl FromTemplate for SystemId<(), ()> {
     type Template = SystemIdTemplate;
 }
 
-pub fn system_value<M>(system: impl IntoSystem<(), (), M>) -> SystemIdTemplate {
+pub fn system_value<M, S: IntoSystem<(), (), M>>(system: S) -> SystemIdTemplate {
+    const {
+        assert!(
+            size_of::<S>() == 0,
+            "Non-ZST systems (e.g. capturing closures, function pointers) cannot be cached.",
+        );
+    }
+    
     SystemIdTemplate(Arc::new(Mutex::new(Some(SystemOrId::BoxedSystem(
         Box::new(IntoSystem::into_system(system)),
     )))))
-}
-
-pub fn system_id_value(system_id: SystemId<(), ()>) -> SystemIdTemplate {
-    SystemIdTemplate(Arc::new(Mutex::new(Some(SystemOrId::SystemId(system_id)))))
 }
 
 /// A [`Template`] driven by a function that returns an output. This is used to create "free floating" templates without

--- a/crates/bevy_ecs/src/template.rs
+++ b/crates/bevy_ecs/src/template.rs
@@ -478,7 +478,7 @@ impl FromTemplate for Entity {
 /// use bevy_ecs::prelude::*;
 /// use bevy_ecs::system::SystemId;
 /// use bevy_scene::prelude::*;
-/// 
+///
 /// #[derive(Component, FromTemplate)]
 /// struct Callback(SystemId);
 ///

--- a/crates/bevy_ecs/src/template.rs
+++ b/crates/bevy_ecs/src/template.rs
@@ -1,8 +1,8 @@
 //! Functionality that relates to the [`Template`] trait.
 
-use alloc::{boxed::Box, sync::Arc};
+use alloc::boxed::Box;
 use bevy_ecs_macros::Component;
-use bevy_platform::sync::Mutex;
+use bevy_platform::sync::{Arc, Mutex};
 
 pub use bevy_ecs_macros::FromTemplate;
 

--- a/crates/bevy_ecs/src/template.rs
+++ b/crates/bevy_ecs/src/template.rs
@@ -1,15 +1,20 @@
 //! Functionality that relates to the [`Template`] trait.
 
-use alloc::{boxed::Box, sync::{Arc}};
+use alloc::{boxed::Box, sync::Arc};
+use bevy_ecs_macros::Component;
 use bevy_platform::sync::Mutex;
 
 pub use bevy_ecs_macros::FromTemplate;
 
-use crate::{
-
-    component::Mutable, entity::Entity, error::{BevyError, Result}, resource::Resource, system::{BoxedSystem, IntoSystem}, world::{EntityWorldMut, Mut, World}
-};
 use crate::system::SystemId;
+use crate::{
+    component::Mutable,
+    entity::Entity,
+    error::{BevyError, Result},
+    resource::Resource,
+    system::{BoxedSystem, IntoSystem},
+    world::{EntityWorldMut, Mut, World},
+};
 use alloc::{vec, vec::Vec};
 use variadics_please::all_tuples;
 
@@ -480,21 +485,98 @@ impl Default for SystemIdTemplate {
     }
 }
 
+#[derive(Resource, Default)]
+struct SceneSystemRegistry {
+    type_map: bevy_platform::collections::HashMap<core::any::TypeId, Entity>,
+    id_map: bevy_platform::collections::HashMap<SystemId<(), ()>, Entity>,
+}
+
+#[derive(Component)]
+struct SystemIdRecorder {
+    type_id: core::any::TypeId,
+    system_id: SystemId<(), ()>,
+}
+
+// #[derive(Component)]
+// #[relationship(relationship_target = SystemRefs<T>)]
+// struct RefToSystem<T: Component + Send + Sync>(#[relationship] Entity, core::marker::PhantomData<T>);
+
+// #[derive(Component)]
+// #[relationship_target(relationship = RefToSystem<T>)]
+// struct SystemRefs<T: Component + Send + Sync>(#[relationship] Vec<Entity>, core::marker::PhantomData<T>);
+
+#[derive(Component)]
+#[relationship(relationship_target = SystemRefs)]
+struct RefToSystem(#[relationship] Entity);
+
+#[derive(Component)]
+#[relationship_target(relationship = RefToSystem)]
+struct SystemRefs(#[relationship] Vec<Entity>);
+// TODO: unregister system when ref collection is empty.
+
+#[derive(Component)]
+#[relationship(relationship_target = LinkedWith)]
+struct LinkLifetimeWith(Entity);
+
+#[derive(Component)]
+#[relationship_target(relationship = LinkLifetimeWith)]
+// TODO: #[Component(on_remove = remove all linked entities on despawn)]
+struct LinkedWith(Vec<Entity>);
+
 impl Template for SystemIdTemplate {
     type Output = SystemId<(), ()>;
 
     fn build_template(&self, _context: &mut TemplateContext) -> Result<Self::Output> {
+        let template_item_entity = _context.entity.id();
+
         let mut template_state = self.0.lock().unwrap();
         let template_value = template_state.take().unwrap();
 
         let system_id = match template_value {
-            SystemOrId::BoxedSystem(system) => {
-                _context.entity.world_scope(|world| world.register_boxed_system(system))
-            },
+            SystemOrId::BoxedSystem(system) => _context.entity.world_scope(|world| {
+                let registry = world.get_resource_or_init::<SceneSystemRegistry>();
+
+                let type_id = system.system_type();
+                if let Some(&entity) = registry.type_map.get(&type_id) {
+                    let recorder = world.entity(entity).get::<SystemIdRecorder>().unwrap();
+                    recorder.system_id
+                } else {
+                    let id = world.register_boxed_system(system);
+                    let entity = world
+                        .spawn(
+                            (SystemIdRecorder {
+                                system_id: id,
+                                type_id,
+                            }),
+                        )
+                        .id();
+
+                    let mut registry = world.resource_mut::<SceneSystemRegistry>();
+
+                    registry.type_map.insert(type_id, entity);
+                    registry.id_map.insert(id, entity);
+
+                    id
+                }
+            }),
             SystemOrId::SystemId(system_id) => system_id,
         };
 
         *template_state = Some(SystemOrId::SystemId(system_id));
+
+        let system_entity = *_context
+            .entity
+            .resource::<SceneSystemRegistry>()
+            .id_map
+            .get(&system_id)
+            .unwrap();
+
+        _context.entity.world_scope(|world| {
+            world.spawn((
+                RefToSystem(system_entity),
+                LinkLifetimeWith(template_item_entity),
+            ));
+        });
 
         Ok(system_id)
     }
@@ -509,7 +591,9 @@ impl FromTemplate for SystemId<(), ()> {
 }
 
 pub fn system_value<M>(system: impl IntoSystem<(), (), M>) -> SystemIdTemplate {
-    SystemIdTemplate(Arc::new(Mutex::new(Some(SystemOrId::BoxedSystem(Box::new(IntoSystem::into_system(system)))))))
+    SystemIdTemplate(Arc::new(Mutex::new(Some(SystemOrId::BoxedSystem(
+        Box::new(IntoSystem::into_system(system)),
+    )))))
 }
 
 pub fn system_id_value(system_id: SystemId<(), ()>) -> SystemIdTemplate {

--- a/crates/bevy_ecs/src/template.rs
+++ b/crates/bevy_ecs/src/template.rs
@@ -6,17 +6,14 @@ use bevy_platform::sync::Mutex;
 
 pub use bevy_ecs_macros::FromTemplate;
 
-use crate::lifecycle::HookContext;
-use crate::name::Name;
-use crate::system::SystemId;
-use crate::world::DeferredWorld;
 use crate::{
     component::Mutable,
     entity::Entity,
     error::{BevyError, Result},
+    lifecycle::HookContext,
     resource::Resource,
-    system::{BoxedSystem, IntoSystem},
-    world::{EntityWorldMut, Mut, World},
+    system::{BoxedSystem, IntoSystem, SystemId},
+    world::{DeferredWorld, EntityWorldMut, Mut, World},
 };
 use alloc::{vec, vec::Vec};
 use variadics_please::all_tuples;
@@ -475,6 +472,29 @@ impl FromTemplate for Entity {
     type Template = EntityTemplate;
 }
 
+/// A [`Template`] that produces a [`SystemId`] for a given system. This is used to create one-shot systems from templates.
+///
+/// ```ignore
+/// use bevy_ecs::prelude::*;
+/// use bevy_ecs::system::SystemId;
+/// use bevy_scene::prelude::*;
+/// 
+/// #[derive(Component, FromTemplate)]
+/// struct Callback(SystemId);
+///
+/// fn scene() -> impl Scene{
+///     bsn! {
+///         Callback(system_value(|| {})),    
+///     }
+/// }
+/// ```
+///
+/// Note that each system will be registered only once.
+/// They share the same [`SystemId`] across all templates referencing it.
+/// And the system will be automatically unregistered when no more referenced.
+///
+/// Therefore the system has same restriction as [`World::register_system_cached`].
+/// You should generally use the [`system_value`] helper function to create this, which enforces that the system is a zero-sized type.
 pub struct SystemIdTemplate(Arc<Mutex<Option<SystemOrId>>>);
 
 enum SystemOrId {
@@ -488,52 +508,59 @@ impl Default for SystemIdTemplate {
     }
 }
 
-/// These are used to track one-shot systems registered from templates, so that they can be cleaned up when the template is no longer in use and to prevent duplicate registrations.
-///
-/// A template instance will create a linked entity for each holding one-shot system. Each system will create a entity with `SytemIdRecorder` saved in `SceneSystemRegistry`, which counting references to it via `RefToSystem`.
-///
-/// `template_A`: `(CompA(system_1), CompB{..., callback: system_2}, ..., LinkedWith(vec![CompA1_system1_entity, CompB1_system2_entity, ...])`
-///
-/// `template_A_clone`: `(CompA(system_1), CompB{..., callback: system_2}, ..., LinkedWith(vec![CompA2_system1_entity, CompB2_system2_entity, ...])`
-///
-/// `system_1`: `SystemIdRecorder{...}, SystemRefs(vec![CompA1_system1_entity, CompA2_system1_entity, ...])`
-///
-/// `system_2`: `SystemIdRecorder{...}, SystemRefs(vec![CompB1_system2_entity, CompB2_system2_entity, ...])`
-///
-/// When `template_A` and `template_A_clone` are dropped, the linked entities will be despawned, which triggers the cleanup system to check the system entities. Since both `system_1` and `system_2` have no more references, they will be despawned and unregistered.
+// These are used to track one-shot systems registered from templates, so that they can be cleaned up when the template is no longer in use and to prevent duplicate registrations.
+//
+// A template instance will create a linked entity for each holding one-shot system. Each system will create a entity with `SystemIdRecorder` saved in `SceneSystemRegistry`, which counting references to it via `RefToSystem`.
+//
+// `template_A`: `(CompA(system_1), CompB{..., callback: system_2}, ..., LinkedWith(vec![CompA1_system1_entity, CompB1_system2_entity, ...])`
+//
+// `template_A_clone`: `(CompA(system_1), CompB{..., callback: system_2}, ..., LinkedWith(vec![CompA2_system1_entity, CompB2_system2_entity, ...])`
+//
+// `system_1`: `SystemIdRecorder{...}, SystemRefs(vec![CompA1_system1_entity, CompA2_system1_entity, ...])`
+//
+// `system_2`: `SystemIdRecorder{...}, SystemRefs(vec![CompB1_system2_entity, CompB2_system2_entity, ...])`
+//
+// When `template_A` and `template_A_clone` are dropped, the linked entities will be despawned, which triggers the cleanup system to check the system entities. Since both `system_1` and `system_2` have no more references, they will be despawned and the system is unregistered.
 
+/// A registry that tracks one-shot systems by their [`core::any::TypeId`], since we don't want it registered multiple times for same system.
 #[derive(Resource, Default)]
 struct SceneSystemRegistry {
     type_map: bevy_platform::collections::HashMap<core::any::TypeId, Entity>,
-    id_map: bevy_platform::collections::HashMap<SystemId<(), ()>, Entity>,
 }
 
 #[derive(Component, Clone)]
-struct SystemIdRecorder {
+struct TypeIdRecorder {
     type_id: core::any::TypeId,
-    system_id: SystemId<(), ()>,
 }
 
+/// These simulate a many-to-many between templates and systems in companion with [`LinkLifetimeWith`].
+/// A template refers to its systems via [`LinkedWith`] and a system refers to its templates via [`SystemRefs`].
 #[derive(Component)]
 #[relationship(relationship_target = SystemRefs)]
 #[component(on_remove = on_ref_to_system_remove)]
 struct RefToSystem(Entity);
 
 fn on_ref_to_system_remove(mut world: DeferredWorld, ctx: HookContext) {
-    let entity = ctx.entity;
-    let system_refs_entity = world.get::<RefToSystem>(entity).unwrap().0;
+    let system_refs_entity = world.get::<RefToSystem>(ctx.entity).unwrap().0;
     let system_refs = &world.get::<SystemRefs>(system_refs_entity).unwrap().0;
 
-    if system_refs.is_empty() { // a system is no more referenced, so we can clean it up.
-        let system_recorder = world.get::<SystemIdRecorder>(system_refs_entity).unwrap().clone();
+    // This hook is called in `on_remove` while relationship is maintained in `on_discard`,
+    // which is ensured to be run before `on_remove` when removing a `Component`.
+    // The collection hereby should be empty if a system is no more referenced.
+    // And we can clean it up.
+    if system_refs.is_empty() {
+        let system_recorder = world
+            .get::<TypeIdRecorder>(system_refs_entity)
+            .unwrap()
+            .clone();
 
         let mut registry = world.resource_mut::<SceneSystemRegistry>();
         registry.type_map.remove(&system_recorder.type_id);
-        registry.id_map.remove(&system_recorder.system_id);
-        
+
         let mut commands = world.commands();
-        commands.unregister_system(system_recorder.system_id);
-        commands.entity(system_refs_entity).despawn();
+
+        // reused the entity spawned by `register_boxed_system`, so we don't need to despawn it again.
+        commands.unregister_system::<(), ()>(SystemId::from_entity(system_refs_entity));
     }
 }
 #[derive(Component)]
@@ -544,28 +571,16 @@ struct SystemRefs(Vec<Entity>);
 #[relationship(relationship_target = LinkedWith)]
 struct LinkLifetimeWith(Entity);
 
+/// When a template entity is despawned, all its relationship with systems will be removed.
+/// Hence the system entities will be notified via `on_ref_to_system_remove` hook to check if they are still referenced by any templates, and clean up if not.
 #[derive(Component)]
-#[relationship_target(relationship = LinkLifetimeWith)]
-#[component(on_remove = on_template_remove)]
+#[relationship_target(relationship = LinkLifetimeWith, linked_spawn)]
 struct LinkedWith(Vec<Entity>);
-
-fn on_template_remove(mut world: DeferredWorld, ctx: HookContext) {
-    let entity = ctx.entity;
-    let linked = world.get::<LinkedWith>(entity).unwrap().0.clone();
-
-    let mut commands = world.commands();
-
-    for linked_entity in linked {
-        commands.entity(linked_entity).despawn();
-    }
-}
 
 impl Template for SystemIdTemplate {
     type Output = SystemId<(), ()>;
 
     fn build_template(&self, _context: &mut TemplateContext) -> Result<Self::Output> {
-        let template_item_entity = _context.entity.id();
-
         // ensure the registry exists.
         _context.entity.world_scope(|world| {
             world.init_resource::<SceneSystemRegistry>();
@@ -579,34 +594,39 @@ impl Template for SystemIdTemplate {
                 let registry = world.resource::<SceneSystemRegistry>();
 
                 let type_id = system.system_type();
-                if let Some(&entity) = registry.type_map.get(&type_id) {
-                    let recorder = world.entity(entity).get::<SystemIdRecorder>().unwrap();
 
-                    recorder.system_id
+                if let Some(&entity) = registry.type_map.get(&type_id) {
+                    // this system has already been registered, so just get a `SystemId` for it.
+                    SystemId::from_entity(entity)
                 } else {
-                    let id = world.register_boxed_system(system);
-                    let entity = world
-                        .spawn((Name("SystemEntity".into()),SystemIdRecorder {
-                            system_id: id,
-                            type_id,
-                        }))
-                        .id();
+                    // otherwise register the system and do associated preparation.
+                    let system_id = world.register_boxed_system(system);
+                    let system_entity = system_id.entity;
+
+                    // link `TypeId` to `SystemId` for future reference.
+                    world
+                        .entity_mut(system_entity)
+                        .insert(TypeIdRecorder { type_id });
 
                     let mut registry = world.resource_mut::<SceneSystemRegistry>();
 
-                    registry.type_map.insert(type_id, entity);
-                    registry.id_map.insert(id, entity);
+                    registry.type_map.insert(type_id, system_entity);
 
-                    id
+                    system_id
                 }
             }),
             SystemOrId::SystemId(system_id) => system_id,
         };
 
+        // replace the system with its `SystemId`, so that next time we can skip registration and just clone the `SystemId`.
         *template_state = Some(SystemOrId::SystemId(system_id));
 
+        // create the relationship between template and system entites.
+        let template_item_entity = _context.entity.id();
+        let system_entity = system_id.entity;
+
+        // a middle entity is needed since we don't have many-to-many relationship yet.
         _context.entity.world_scope(|world| {
-            let system_entity = *world.resource::<SceneSystemRegistry>().id_map.get(&system_id).unwrap();
             world.spawn((
                 RefToSystem(system_entity),
                 LinkLifetimeWith(template_item_entity),
@@ -625,6 +645,8 @@ impl FromTemplate for SystemId<(), ()> {
     type Template = SystemIdTemplate;
 }
 
+/// A helper function to create a [`SystemIdTemplate`] from a given system. This has the same restriction with [`World::register_system_cached`],
+/// as the system of same type will be registered only once.
 pub fn system_value<M, S: IntoSystem<(), (), M>>(system: S) -> SystemIdTemplate {
     const {
         assert!(
@@ -632,7 +654,7 @@ pub fn system_value<M, S: IntoSystem<(), (), M>>(system: S) -> SystemIdTemplate 
             "Non-ZST systems (e.g. capturing closures, function pointers) cannot be cached.",
         );
     }
-    
+
     SystemIdTemplate(Arc::new(Mutex::new(Some(SystemOrId::BoxedSystem(
         Box::new(IntoSystem::into_system(system)),
     )))))

--- a/crates/bevy_ecs/src/template.rs
+++ b/crates/bevy_ecs/src/template.rs
@@ -500,13 +500,7 @@ impl Template for SystemIdTemplate {
     }
 
     fn clone_template(&self) -> Self {
-        let template_state = self.0.lock().unwrap();
-        let template_value = template_state.as_ref().unwrap();
-        
-        match template_value {
-            SystemOrId::BoxedSystem(_) => unreachable!("This variant should only exist during the build_template call, and should be replaced with the SystemId variant after."),
-            SystemOrId::SystemId(system_id) => system_id_value(*system_id),
-        }
+        SystemIdTemplate(self.0.clone())
     }
 }
 

--- a/crates/bevy_ecs/src/template.rs
+++ b/crates/bevy_ecs/src/template.rs
@@ -510,15 +510,15 @@ impl Default for SystemIdTemplate {
 
 // These are used to track one-shot systems registered from templates, so that they can be cleaned up when the template is no longer in use and to prevent duplicate registrations.
 //
-// A template instance will create a linked entity for each holding one-shot system. Each system will create a entity with `SystemIdRecorder` saved in `SceneSystemRegistry`, which counting references to it via `RefToSystem`.
+// A template instance will create a linked entity for each holding one-shot system. Each system will create a entity with `TypeIdRecorder` saved in `SceneSystemRegistry`, which counting references to it via `RefToSystem`.
 //
 // `template_A`: `(CompA(system_1), CompB{..., callback: system_2}, ..., LinkedWith(vec![CompA1_system1_entity, CompB1_system2_entity, ...])`
 //
 // `template_A_clone`: `(CompA(system_1), CompB{..., callback: system_2}, ..., LinkedWith(vec![CompA2_system1_entity, CompB2_system2_entity, ...])`
 //
-// `system_1`: `SystemIdRecorder{...}, SystemRefs(vec![CompA1_system1_entity, CompA2_system1_entity, ...])`
+// `system_1`: `TypeIdRecorder{...}, SystemRefs(vec![CompA1_system1_entity, CompA2_system1_entity, ...])`
 //
-// `system_2`: `SystemIdRecorder{...}, SystemRefs(vec![CompB1_system2_entity, CompB2_system2_entity, ...])`
+// `system_2`: `TypeIdRecorder{...}, SystemRefs(vec![CompB1_system2_entity, CompB2_system2_entity, ...])`
 //
 // When `template_A` and `template_A_clone` are dropped, the linked entities will be despawned, which triggers the cleanup system to check the system entities. Since both `system_1` and `system_2` have no more references, they will be despawned and the system is unregistered.
 

--- a/crates/bevy_ecs/src/template.rs
+++ b/crates/bevy_ecs/src/template.rs
@@ -621,7 +621,7 @@ impl Template for SystemIdTemplate {
         // replace the system with its `SystemId`, so that next time we can skip registration and just clone the `SystemId`.
         *template_state = Some(SystemOrId::SystemId(system_id));
 
-        // create the relationship between template and system entites.
+        // create the relationship between template and system entities.
         let template_item_entity = _context.entity.id();
         let system_entity = system_id.entity;
 

--- a/crates/bevy_ecs/src/template.rs
+++ b/crates/bevy_ecs/src/template.rs
@@ -1,5 +1,7 @@
 //! Functionality that relates to the [`Template`] trait.
 
+use core::marker::PhantomData;
+
 use alloc::boxed::Box;
 use bevy_ecs_macros::Component;
 use bevy_platform::sync::{Arc, Mutex};
@@ -539,36 +541,42 @@ struct TypeIdRecorder {
 /// These simulate a many-to-many between templates and systems in companion with [`LinkLifetimeWith`].
 /// A template refers to its systems via [`LinkedWith`] and a system refers to its templates via [`SystemRefs`].
 #[derive(Component)]
-#[relationship(relationship_target = SystemRefs)]
-#[component(on_remove = on_ref_to_system_remove)]
-struct RefToSystem(Entity);
+#[relationship(relationship_target = SystemRefs<I>)]
+#[component(on_remove)]
+struct RefToSystem<I: SystemInput + Send + Sync + 'static>(#[relationship] Entity, PhantomData<I>);
 
-fn on_ref_to_system_remove(mut world: DeferredWorld, ctx: HookContext) {
-    let system_refs_entity = world.get::<RefToSystem>(ctx.entity).unwrap().0;
-    let system_refs = &world.get::<SystemRefs>(system_refs_entity).unwrap().0;
+impl<I: SystemInput + Send + Sync + 'static> RefToSystem<I> {
+    pub fn on_remove(mut world: DeferredWorld, ctx: HookContext) {
+        let system_refs_entity = world.get::<RefToSystem<I>>(ctx.entity).unwrap().0;
+        let system_refs = &world.get::<SystemRefs<I>>(system_refs_entity).unwrap().0;
 
-    // This hook is called in `on_remove` while relationship is maintained in `on_discard`,
-    // which is ensured to be run before `on_remove` when removing a `Component`.
-    // The collection hereby should be empty if a system is no more referenced.
-    // And we can clean it up.
-    if system_refs.is_empty() {
-        let system_recorder = world
-            .get::<TypeIdRecorder>(system_refs_entity)
-            .unwrap()
-            .clone();
+        // This hook is called in `on_remove` while relationship is maintained in `on_discard`,
+        // which is ensured to be run before `on_remove` when removing a `Component`.
+        // The collection hereby should be empty if a system is no more referenced.
+        // And we can clean it up.
+        if system_refs.is_empty() {
+            let system_recorder = world
+                .get::<TypeIdRecorder>(system_refs_entity)
+                .unwrap()
+                .clone();
 
-        let mut registry = world.resource_mut::<SceneSystemRegistry>();
-        registry.type_map.remove(&system_recorder.type_id);
+            let mut registry = world.resource_mut::<SceneSystemRegistry>();
+            registry.type_map.remove(&system_recorder.type_id);
 
-        let mut commands = world.commands();
+            let mut commands = world.commands();
 
-        // reused the entity spawned by `register_boxed_system`, so we don't need to despawn it again.
-        commands.unregister_system::<(), ()>(SystemId::from_entity(system_refs_entity));
+            // reused the entity spawned by `register_boxed_system`, so we don't need to despawn it again.
+            commands.unregister_system::<I, ()>(SystemId::from_entity(system_refs_entity));
+        }
     }
 }
+
 #[derive(Component)]
-#[relationship_target(relationship = RefToSystem)]
-struct SystemRefs(Vec<Entity>);
+#[relationship_target(relationship = RefToSystem<I>)]
+struct SystemRefs<I: SystemInput + Send + Sync + 'static>(
+    #[relationship] Vec<Entity>,
+    PhantomData<I>,
+);
 
 #[derive(Component)]
 #[relationship(relationship_target = LinkedWith)]
@@ -580,7 +588,7 @@ struct LinkLifetimeWith(Entity);
 #[relationship_target(relationship = LinkLifetimeWith, linked_spawn)]
 struct LinkedWith(Vec<Entity>);
 
-impl<I: SystemInput + 'static> Template for SystemIdTemplate<I> {
+impl<I: SystemInput + Send + Sync + 'static> Template for SystemIdTemplate<I> {
     type Output = SystemId<I, ()>;
 
     fn build_template(&self, _context: &mut TemplateContext) -> Result<Self::Output> {
@@ -635,7 +643,7 @@ impl<I: SystemInput + 'static> Template for SystemIdTemplate<I> {
         // a middle entity is needed since we don't have many-to-many relationship yet.
         _context.entity.world_scope(|world| {
             world.spawn((
-                RefToSystem(system_entity),
+                RefToSystem::<I>(system_entity, PhantomData),
                 LinkLifetimeWith(template_item_entity),
             ));
         });
@@ -648,7 +656,7 @@ impl<I: SystemInput + 'static> Template for SystemIdTemplate<I> {
     }
 }
 
-impl<I: SystemInput + 'static> FromTemplate for SystemId<I, ()> {
+impl<I: SystemInput + Send + Sync + 'static> FromTemplate for SystemId<I, ()> {
     type Template = SystemIdTemplate<I>;
 }
 

--- a/crates/bevy_ecs/src/template.rs
+++ b/crates/bevy_ecs/src/template.rs
@@ -1,14 +1,15 @@
 //! Functionality that relates to the [`Template`] trait.
 
+use alloc::{boxed::Box, sync::{Arc}};
+use bevy_platform::sync::Mutex;
+
 pub use bevy_ecs_macros::FromTemplate;
 
 use crate::{
-    component::Mutable,
-    entity::Entity,
-    error::{BevyError, Result},
-    resource::Resource,
-    world::{EntityWorldMut, Mut, World},
+
+    component::Mutable, entity::Entity, error::{BevyError, Result}, resource::Resource, system::{BoxedSystem, IntoSystem}, world::{EntityWorldMut, Mut, World}
 };
+use crate::system::SystemId;
 use alloc::{vec, vec::Vec};
 use variadics_please::all_tuples;
 
@@ -464,6 +465,50 @@ impl Template for EntityTemplate {
 
 impl FromTemplate for Entity {
     type Template = EntityTemplate;
+}
+
+pub enum SystemIdTemplate {
+    BoxedSystem(Arc<Mutex<Option<BoxedSystem<(), ()>>>>),
+    SystemId(SystemId<(), ()>),
+}
+
+impl Default for SystemIdTemplate {
+    fn default() -> Self {
+        Self::BoxedSystem(Arc::new(Mutex::new(Some(Box::new(IntoSystem::into_system(|| {}))))))
+    }
+}
+
+impl Template for SystemIdTemplate {
+    type Output = SystemId<(), ()>;
+
+    fn build_template(&self, _context: &mut TemplateContext) -> Result<Self::Output> {
+        Ok(match self {
+            Self::BoxedSystem(system) =>{
+                let system = system.lock().unwrap().take().unwrap();
+                
+                // SAFETY: this is ok because only spawning new system entity.?
+                unsafe {
+                    _context.entity.world_mut().register_boxed_system(system)
+                }
+            },
+            Self::SystemId(system_id) => *system_id,
+        })
+    }
+
+    fn clone_template(&self) -> Self {
+        match self {
+            Self::BoxedSystem(system) => Self::BoxedSystem(Arc::clone(system)),
+            Self::SystemId(system_id) => Self::SystemId(*system_id),
+        }
+    }
+}
+
+impl FromTemplate for SystemId<(), ()> {
+    type Template = SystemIdTemplate;
+}
+
+pub fn system_value<M>(system: impl IntoSystem<(), (),M>) -> SystemIdTemplate {
+    SystemIdTemplate::BoxedSystem(Arc::new(Mutex::new(Some(Box::new(IntoSystem::into_system(system))))))
 }
 
 /// A [`Template`] driven by a function that returns an output. This is used to create "free floating" templates without

--- a/crates/bevy_ecs/src/template.rs
+++ b/crates/bevy_ecs/src/template.rs
@@ -467,14 +467,16 @@ impl FromTemplate for Entity {
     type Template = EntityTemplate;
 }
 
-pub enum SystemIdTemplate {
-    BoxedSystem(Arc<Mutex<Option<BoxedSystem<(), ()>>>>),
+pub struct SystemIdTemplate(Arc<Mutex<Option<SystemOrId>>>);
+
+enum SystemOrId {
+    BoxedSystem(BoxedSystem<(), ()>),
     SystemId(SystemId<(), ()>),
 }
 
 impl Default for SystemIdTemplate {
     fn default() -> Self {
-        Self::BoxedSystem(Arc::new(Mutex::new(Some(Box::new(IntoSystem::into_system(|| {}))))))
+        system_value(|| {})
     }
 }
 
@@ -482,23 +484,28 @@ impl Template for SystemIdTemplate {
     type Output = SystemId<(), ()>;
 
     fn build_template(&self, _context: &mut TemplateContext) -> Result<Self::Output> {
-        Ok(match self {
-            Self::BoxedSystem(system) =>{
-                let system = system.lock().unwrap().take().unwrap();
-                
-                // SAFETY: this is ok because only spawning new system entity.?
-                unsafe {
-                    _context.entity.world_mut().register_boxed_system(system)
-                }
+        let mut template_state = self.0.lock().unwrap();
+        let template_value = template_state.take().unwrap();
+
+        let system_id = match template_value {
+            SystemOrId::BoxedSystem(system) => {
+                _context.entity.world_scope(|world| world.register_boxed_system(system))
             },
-            Self::SystemId(system_id) => *system_id,
-        })
+            SystemOrId::SystemId(system_id) => system_id,
+        };
+
+        *template_state = Some(SystemOrId::SystemId(system_id));
+
+        Ok(system_id)
     }
 
     fn clone_template(&self) -> Self {
-        match self {
-            Self::BoxedSystem(system) => Self::BoxedSystem(Arc::clone(system)),
-            Self::SystemId(system_id) => Self::SystemId(*system_id),
+        let template_state = self.0.lock().unwrap();
+        let template_value = template_state.as_ref().unwrap();
+        
+        match template_value {
+            SystemOrId::BoxedSystem(_) => unreachable!("This variant should only exist during the build_template call, and should be replaced with the SystemId variant after."),
+            SystemOrId::SystemId(system_id) => system_id_value(*system_id),
         }
     }
 }
@@ -507,8 +514,12 @@ impl FromTemplate for SystemId<(), ()> {
     type Template = SystemIdTemplate;
 }
 
-pub fn system_value<M>(system: impl IntoSystem<(), (),M>) -> SystemIdTemplate {
-    SystemIdTemplate::BoxedSystem(Arc::new(Mutex::new(Some(Box::new(IntoSystem::into_system(system))))))
+pub fn system_value<M>(system: impl IntoSystem<(), (), M>) -> SystemIdTemplate {
+    SystemIdTemplate(Arc::new(Mutex::new(Some(SystemOrId::BoxedSystem(Box::new(IntoSystem::into_system(system)))))))
+}
+
+pub fn system_id_value(system_id: SystemId<(), ()>) -> SystemIdTemplate {
+    SystemIdTemplate(Arc::new(Mutex::new(Some(SystemOrId::SystemId(system_id)))))
 }
 
 /// A [`Template`] driven by a function that returns an output. This is used to create "free floating" templates without

--- a/crates/bevy_ecs/src/template.rs
+++ b/crates/bevy_ecs/src/template.rs
@@ -12,7 +12,7 @@ use crate::{
     error::{BevyError, Result},
     lifecycle::HookContext,
     resource::Resource,
-    system::{BoxedSystem, IntoSystem, SystemId},
+    system::{BoxedSystem, IntoSystem, SystemId, SystemInput},
     world::{DeferredWorld, EntityWorldMut, Mut, World},
 };
 use alloc::{vec, vec::Vec};
@@ -495,16 +495,19 @@ impl FromTemplate for Entity {
 ///
 /// Therefore the system has same restriction as [`World::register_system_cached`].
 /// You should generally use the [`system_value`] helper function to create this, which enforces that the system is a zero-sized type.
-pub struct SystemIdTemplate(Arc<Mutex<Option<SystemOrId>>>);
+pub struct SystemIdTemplate<I: SystemInput = ()>(Arc<Mutex<Option<SystemOrId<I>>>>);
 
-enum SystemOrId {
-    BoxedSystem(BoxedSystem<(), ()>),
-    SystemId(SystemId<(), ()>),
+enum SystemOrId<I: SystemInput = ()> {
+    BoxedSystem(BoxedSystem<I, ()>),
+    SystemId(SystemId<I, ()>),
 }
 
-impl Default for SystemIdTemplate {
+impl<I> Default for SystemIdTemplate<I>
+where
+    I: SystemInput,
+{
     fn default() -> Self {
-        system_value(|| {})
+        Self(Arc::new(Mutex::new(None)))
     }
 }
 
@@ -577,8 +580,8 @@ struct LinkLifetimeWith(Entity);
 #[relationship_target(relationship = LinkLifetimeWith, linked_spawn)]
 struct LinkedWith(Vec<Entity>);
 
-impl Template for SystemIdTemplate {
-    type Output = SystemId<(), ()>;
+impl<I: SystemInput + 'static> Template for SystemIdTemplate<I> {
+    type Output = SystemId<I, ()>;
 
     fn build_template(&self, _context: &mut TemplateContext) -> Result<Self::Output> {
         // ensure the registry exists.
@@ -587,7 +590,11 @@ impl Template for SystemIdTemplate {
         });
 
         let mut template_state = self.0.lock().unwrap();
-        let template_value = template_state.take().unwrap();
+        let Some(template_value) = template_state.take() else {
+            return Err(BevyError::error(
+                "Failed to build SystemIdTemplate: no system specified",
+            ));
+        };
 
         let system_id = match template_value {
             SystemOrId::BoxedSystem(system) => _context.entity.world_scope(|world| {
@@ -641,13 +648,15 @@ impl Template for SystemIdTemplate {
     }
 }
 
-impl FromTemplate for SystemId<(), ()> {
-    type Template = SystemIdTemplate;
+impl<I: SystemInput + 'static> FromTemplate for SystemId<I, ()> {
+    type Template = SystemIdTemplate<I>;
 }
 
 /// A helper function to create a [`SystemIdTemplate`] from a given system. This has the same restriction with [`World::register_system_cached`],
 /// as the system of same type will be registered only once.
-pub fn system_value<M, S: IntoSystem<(), (), M>>(system: S) -> SystemIdTemplate {
+pub fn system_value<I: SystemInput + 'static, M, S: IntoSystem<I, (), M>>(
+    system: S,
+) -> SystemIdTemplate<I> {
     const {
         assert!(
             size_of::<S>() == 0,

--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -1,18 +1,20 @@
 //! A simple 3D scene with light shining over a cube sitting on a plane.
 
 use bevy::prelude::*;
-use bevy_ecs::template::system_value;
+use bevy_ecs::{template::system_value};
 
 fn main() {
-    fn run_callbacks(mut commands: Commands, callbacks: Query<&Callback>) {
-        callbacks.iter().for_each(|callback| {
+    fn run_callbacks(mut commands: Commands, callbacks: Query<(Entity,&Callback)>) {
+        callbacks.iter().for_each(|(entity, callback)| {
             commands.run_system(callback.0);
+
+            commands.entity(entity).despawn();
         });
     }
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_systems(Startup, scene.spawn().before(run_callbacks))
-        .add_systems(Startup, run_callbacks)
+        .add_systems(Startup, scene.spawn())
+        .add_systems(Startup, (callback_scene.spawn(), run_callbacks, callback_scene.spawn(), run_callbacks).chain())
         .run();
 }
 
@@ -41,7 +43,6 @@ fn scene() -> impl SceneList {
             Camera3d
             template_value(Transform::from_xyz(-2.5, 4.5, 9.0).looking_at(Vec3::ZERO, Vec3::Y))
         ),
-        {callback_scene()}
     ]
 }
 
@@ -49,12 +50,11 @@ fn scene() -> impl SceneList {
 struct Callback(bevy_ecs::system::SystemId);
 fn callback_scene() -> impl SceneList {
     bsn_list! {
-        Callback(system_value(|| {
-            println!("Hello from the callback!");
-        })),
-        Callback(system_value(callback_system)),
+        Name("template1") Callback(system_value(callback_system)),
+        Name("template2") Callback(system_value(callback_system)),
     }
 }
-fn callback_system() {
-    println!("Hello from the system!");
+fn callback_system(mut call_counter:Local<u32>){
+    *call_counter += 1;
+    println!("Hello from the system! Called: {}", *call_counter);
 }

--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -55,6 +55,6 @@ fn callback_scene() -> impl SceneList {
         Callback(system_value(callback_system)),
     }
 }
-fn callback_system(){
+fn callback_system() {
     println!("Hello from the system!");
 }

--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -1,11 +1,18 @@
 //! A simple 3D scene with light shining over a cube sitting on a plane.
 
 use bevy::prelude::*;
+use bevy_ecs::template::system_value;
 
 fn main() {
+    fn run_callbacks(mut commands: Commands, callbacks: Query<&Callback>) {
+        callbacks.iter().for_each(|callback| {
+            commands.run_system(callback.0);
+        });
+    }
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_systems(Startup, scene.spawn())
+        .add_systems(Startup, scene.spawn().before(run_callbacks))
+        .add_systems(Startup, run_callbacks)
         .run();
 }
 
@@ -33,6 +40,21 @@ fn scene() -> impl SceneList {
         (
             Camera3d
             template_value(Transform::from_xyz(-2.5, 4.5, 9.0).looking_at(Vec3::ZERO, Vec3::Y))
-        )
+        ),
+        {callback_scene()}
     ]
+}
+
+#[derive(Component, FromTemplate)]
+struct Callback(bevy_ecs::system::SystemId);
+fn callback_scene() -> impl SceneList {
+    bsn_list! {
+        Callback(system_value(|| {
+            println!("Hello from the callback!");
+        })),
+        Callback(system_value(callback_system)),
+    }
+}
+fn callback_system(){
+    println!("Hello from the system!");
 }

--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -1,20 +1,11 @@
 //! A simple 3D scene with light shining over a cube sitting on a plane.
 
 use bevy::prelude::*;
-use bevy_ecs::{template::system_value};
 
 fn main() {
-    fn run_callbacks(mut commands: Commands, callbacks: Query<(Entity,&Callback)>) {
-        callbacks.iter().for_each(|(entity, callback)| {
-            commands.run_system(callback.0);
-
-            commands.entity(entity).despawn();
-        });
-    }
     App::new()
         .add_plugins(DefaultPlugins)
         .add_systems(Startup, scene.spawn())
-        .add_systems(Startup, (callback_scene.spawn(), run_callbacks, callback_scene.spawn(), run_callbacks).chain())
         .run();
 }
 
@@ -44,17 +35,4 @@ fn scene() -> impl SceneList {
             template_value(Transform::from_xyz(-2.5, 4.5, 9.0).looking_at(Vec3::ZERO, Vec3::Y))
         ),
     ]
-}
-
-#[derive(Component, FromTemplate)]
-struct Callback(bevy_ecs::system::SystemId);
-fn callback_scene() -> impl SceneList {
-    bsn_list! {
-        Name("template1") Callback(system_value(callback_system)),
-        Name("template2") Callback(system_value(callback_system)),
-    }
-}
-fn callback_system(mut call_counter:Local<u32>){
-    *call_counter += 1;
-    println!("Hello from the system! Called: {}", *call_counter);
 }


### PR DESCRIPTION
# Objective

- Fixes #24002 

## Solution

- Add `SystemIdTemplate`
  ```rust
  pub struct SystemIdTemplate(Arc<Mutex<Option<SystemOrId>>>);

  enum SystemOrId {
      BoxedSystem(BoxedSystem<(), ()>),
      SystemId(SystemId<(), ()>),
  }
  ```
- Add a helper function `system_value<M>` to convert a system to `SystemIdTemplate`

- When a `SystemIdTemplate` is built, record its `TypeId` for the `SystemId` in `HashMap` and spawn a "relationship pair" between the template entity and the registered system entity.
- Each cloned template built will get the inserted `SystemId`. 
- Each new built template refers to same system will get the `SystemId` by system type.
- When a template item despawns, despawn all its "relationship pairs" entities, which triggers a hook on the relationship component to check if the system entity is still referenced. If not, unregister it and remove the record.

## Testing

<details>
<summary>codes</summary>

```rust
fn main() {
    fn run_callbacks(mut commands: Commands, callbacks: Query<(Entity,&Callback)>) {
        callbacks.iter().for_each(|(entity, callback)| {
            commands.run_system(callback.0);

            // It will print "1,2,1,2" for the scene entity is despawned after
            // called. The system is unregistered then re-registered.
            // Comment this line you will get "1,2,3,4,5,6".
            commands.entity(entity).despawn();
        });
    }
    App::new()
        .add_plugins(DefaultPlugins)
        .add_systems(Startup, (callback_scene.spawn(), run_callbacks, callback_scene.spawn(), run_callbacks).chain())
        .run();
}

#[derive(Component, FromTemplate)]
struct Callback(bevy_ecs::system::SystemId);

#[derive(Component, FromTemplate)]
struct SomeStruct{
        value: u32,
        callback: bevy_ecs::system::SystemId,
}
fn callback_scene() -> impl SceneList {
    bsn_list! {
        Name("template1") Callback(system_value(callback_system)),
        Name("template2") Callback(system_value(callback_system)) SomeStruct{value: 42, callback: system_value(another_callback_system)},
    }
}
fn callback_system(mut call_counter:Local<u32>){
    *call_counter += 1;
    println!("Hello from the system! Called: {}", *call_counter);
}

fn another_callback_system(mut call_counter:Local<u32>){
    *call_counter += 1;
    println!("Hello from another system! Called: {}", *call_counter);
}
```

</details>

---

## Showcase

```rust
#[derive(Component, FromTemplate)]
struct Callback(SystemId);

fn callback_scene() -> impl SceneList {
    bsn_list! {
        Callback(system_value(|| {
            println!("Hello from the callback!");
        })),
        Callback(system_value(callback_system)),
    }
}

fn callback_system(){
    println!("Hello from the system!");
}
```
