### PR TITLE
Fix `cfg_select!` compile error in panic handler

### DIFF
--- a/crates/bevy_app/src/panic_handler.rs
+++ b/crates/bevy_app/src/panic_handler.rs
@@ -55,6 +55,7 @@ impl Plugin for PanicHandlerPlugin {
                         ));
                     }
                     // Otherwise use the default target panic hook - Do nothing.
+                    _ => ()
                 }
             });
         }


### PR DESCRIPTION
## Objective

Ran into this after #23896:

```sh
> cargo build -p bevy_app --no-default-features --features "std"

error: none of the predicates in this `cfg_select` evaluated to true
  --> crates\bevy_app\src\panic_handler.rs:46:17
   |
46 | /                 cfg_select! {
47 | |                     all(target_arch = "wasm32", feature = "web") => {
48 | |                         // This provides better panic handling in JS engines (displays the panic message and improves the backtrace).
49 | |                         std::panic::set_hook(alloc::boxed::Box::new(console_error_panic_hook::hook));
...  |
58 | |                 }
   | |_________________^
```

## Solution

Add a fallback clause. Also did a quick scan to confirm that other cases of `cfg_select!` were fine.

## Testing

```sh
cargo build -p bevy_app --no-default-features --features "std"
cargo build -p bevy_app --no-default-features
cargo build -p bevy_app
cargo run --example 3d_scene
cargo run --example 3d_scene --target wasm32-unknown-unknown --features "webgpu"
```
