### PR TITLE
Remove Scene/SceneList impls for unit (), replace with unit struct

### DIFF
--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -1266,18 +1266,6 @@ mod tests {
     }
 
     #[test]
-    fn empty_scene_expressions() {
-        let mut app = test_app();
-        let world = app.world_mut();
-        fn a() -> impl Scene {
-            bsn! {
-                {}
-            }
-        }
-        world.spawn_scene(a()).unwrap();
-    }
-
-    #[test]
     fn closures_in_bsn() {
         #[derive(Resource, Default)]
         struct TotalHealed(u32);

--- a/crates/bevy_scene/src/macro_utils.rs
+++ b/crates/bevy_scene/src/macro_utils.rs
@@ -2,6 +2,9 @@
 /// to add IDE support for nested type names, as it allows us to pass the input Ident from the input to the output code.
 pub const fn touch_type<T>() {}
 
+#[doc(hidden)]
+#[derive(Clone, Copy)]
+pub struct EmptyTuple;
 /// Creates a tuple that will be nested after it passes 11 items.
 /// When there is a single item, it is _not_ wrapped in a tuple.
 /// This is implemented in a way that creates the smallest number of trait impls possible.
@@ -9,7 +12,7 @@ pub const fn touch_type<T>() {}
 #[doc(hidden)]
 macro_rules! auto_nest_tuple {
     // direct expansion
-    () => { () };
+    () => { $crate::macro_utils::EmptyTuple };
     ($a:expr) => {
         $a
     };

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -235,7 +235,7 @@ macro_rules! scene_impl {
     }
 }
 
-all_tuples!(scene_impl, 0, 12, P);
+all_tuples!(scene_impl, 1, 12, P);
 
 /// A [`Scene`] that patches a [`Template`] of type `T` with a given function `F`.
 ///

--- a/crates/bevy_scene/src/scene_list.rs
+++ b/crates/bevy_scene/src/scene_list.rs
@@ -1,4 +1,7 @@
-use crate::{ResolveContext, ResolveSceneError, ResolvedScene, Scene, SceneDependencies};
+use crate::{
+    macro_utils::EmptyTuple, ResolveContext, ResolveSceneError, ResolvedScene, Scene,
+    SceneDependencies,
+};
 use variadics_please::all_tuples;
 
 /// This behaves like a list of [`Scene`], where each entry in the list is a new entity (see [`Scene`] for more details).
@@ -134,8 +137,19 @@ macro_rules! scene_list_impl {
     }
 }
 
-all_tuples!(scene_list_impl, 0, 12, P);
+all_tuples!(scene_list_impl, 1, 12, P);
 
+impl SceneList for EmptyTuple {
+    fn resolve_list(
+        self,
+        _context: &mut ResolveContext,
+        _scenes: &mut Vec<ResolvedScene>,
+    ) -> Result<(), ResolveSceneError> {
+        Ok(())
+    }
+
+    fn register_dependencies(&self, _dependencies: &mut SceneDependencies) {}
+}
 impl<S: Scene> SceneList for Vec<S> {
     fn resolve_list(
         self,


### PR DESCRIPTION
# Objective

Having `Scene` and `SceneList` implemented for `()` (unit) can be a source of confusion if users forget a `;`. See this already happening before bsn is released here: https://discord.com/channels/691052431525675048/691052431974465548/1498960812662849637
The intention of this is to cause an error when `;` is accidentally used at the end of a expression which evaluates to `impl Scene`/`impl SceneList`

## Solution

The issue was that `()` is both the value any expression ending in `;` evaluates to, and the value for `empty` the corresponding traits were implemented for by `all_tuples!`

By raising the start of `all_tuples!` to 1 instead of 0, and implementing SceneList for a new unit struct, the implementation for `()` can be avoided. Luckily, everywhere where an empty Scene/SceneList was used in at least Bevy itself, it was done through `bsn_list!()` which ultimately created the `()` by calling out to `bevy_scene::macro_utils::auto_nest_tuple!`, allowing me to replace the `()` there with the new unit struct.

This means, empty BSN scenes and scene lists now consist of the new `EmptyTuple` unit struct instead of `()`, and an accidental `;` now raises "error[E0277]: the trait bound `(): bevy_scene::Scene` is not satisfied"

## Testing

- [x] `cargo test`
- [x] bevy_city example with a `bsn_list!()` changed to empty
- [x] feathers_gallery example with a `bsn_list!()` changed to empty
- [ ] test with crates already using main?