### PR TITLE
Fix: Update the `ExtractedView` & `Frustum` when the `ExtractedPointLight` has changed

### DIFF
--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -439,7 +439,7 @@ impl Plugin for PbrPlugin {
                 shared_shadow_pass::<EARLY_SHADOW_PASS>
                     .after(early_prepass_build_indirect_parameters)
                     .before(early_downsample_depth)
-                    .before(per_view_shadow_pass::<LATE_SHADOW_PASS>),
+                    .before(shared_shadow_pass::<LATE_SHADOW_PASS>),
                 shared_shadow_pass::<LATE_SHADOW_PASS>
                     .after(late_prepass_build_indirect_parameters)
                     .before(main_build_indirect_parameters)

--- a/crates/bevy_pbr/src/meshlet/mod.rs
+++ b/crates/bevy_pbr/src/meshlet/mod.rs
@@ -43,7 +43,7 @@ use self::{
     },
     visibility_buffer_raster_node::meshlet_visibility_buffer_raster,
 };
-use crate::render::{per_view_shadow_pass, EARLY_SHADOW_PASS};
+use crate::render::{per_view_shadow_pass, shared_shadow_pass, EARLY_SHADOW_PASS};
 use crate::{meshlet::meshlet_mesh_manager::init_meshlet_mesh_manager, PreviousGlobalTransform};
 use bevy_app::{App, Plugin};
 use bevy_asset::{embedded_asset, AssetApp, AssetId, Handle};
@@ -199,9 +199,11 @@ impl Plugin for MeshletPlugin {
                 Core3d,
                 (
                     meshlet_visibility_buffer_raster
-                        .before(per_view_shadow_pass::<EARLY_SHADOW_PASS>),
+                        .before(per_view_shadow_pass::<EARLY_SHADOW_PASS>)
+                        .before(shared_shadow_pass::<EARLY_SHADOW_PASS>),
                     meshlet_prepass
                         .after(per_view_shadow_pass::<EARLY_SHADOW_PASS>)
+                        .after(shared_shadow_pass::<EARLY_SHADOW_PASS>)
                         .in_set(Core3dSystems::Prepass),
                     meshlet_deferred_gbuffer_prepass
                         .after(meshlet_prepass)

--- a/crates/bevy_pbr/src/meshlet/mod.rs
+++ b/crates/bevy_pbr/src/meshlet/mod.rs
@@ -43,7 +43,7 @@ use self::{
     },
     visibility_buffer_raster_node::meshlet_visibility_buffer_raster,
 };
-use crate::render::{per_view_shadow_pass, shared_shadow_pass, EARLY_SHADOW_PASS};
+use crate::render::{per_view_shadow_pass, EARLY_SHADOW_PASS};
 use crate::{meshlet::meshlet_mesh_manager::init_meshlet_mesh_manager, PreviousGlobalTransform};
 use bevy_app::{App, Plugin};
 use bevy_asset::{embedded_asset, AssetApp, AssetId, Handle};
@@ -199,11 +199,9 @@ impl Plugin for MeshletPlugin {
                 Core3d,
                 (
                     meshlet_visibility_buffer_raster
-                        .before(per_view_shadow_pass::<EARLY_SHADOW_PASS>)
-                        .before(shared_shadow_pass::<EARLY_SHADOW_PASS>),
+                        .before(per_view_shadow_pass::<EARLY_SHADOW_PASS>),
                     meshlet_prepass
                         .after(per_view_shadow_pass::<EARLY_SHADOW_PASS>)
-                        .after(shared_shadow_pass::<EARLY_SHADOW_PASS>)
                         .in_set(Core3dSystems::Prepass),
                     meshlet_deferred_gbuffer_prepass
                         .after(meshlet_prepass)

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -1702,23 +1702,23 @@ pub fn prepare_lights(
                 [point_light_count..point_light_count + spot_light_shadow_maps_count] are spot lights").1;
             let spot_projection = spot_light_clip_from_view(angle, light.shadow_map_near_z);
 
-            for view_light_entity in point_and_spot_light_view_entities.0.iter() {
-                commands.entity(*view_light_entity).insert(ExtractedView {
-                    retained_view_entity,
-                    viewport: UVec4::new(
-                        0,
-                        0,
-                        directional_light_shadow_map.size as u32,
-                        directional_light_shadow_map.size as u32,
-                    ),
-                    world_from_view: spot_world_from_view,
-                    clip_from_view: spot_projection,
-                    clip_from_world: None,
-                    target_format: CORE_3D_DEPTH_FORMAT,
-                    color_grading: Default::default(),
-                    invert_culling: false,
-                });
-            }
+            // There should be only one `view_light_entity` for spotlights.
+            let view_light_entity = point_and_spot_light_view_entities.0[0];
+            commands.entity(view_light_entity).insert(ExtractedView {
+                retained_view_entity,
+                viewport: UVec4::new(
+                    0,
+                    0,
+                    directional_light_shadow_map.size as u32,
+                    directional_light_shadow_map.size as u32,
+                ),
+                world_from_view: spot_world_from_view,
+                clip_from_view: spot_projection,
+                clip_from_world: None,
+                target_format: CORE_3D_DEPTH_FORMAT,
+                color_grading: Default::default(),
+                invert_culling: false,
+            });
         }
 
         shadow_render_phases.prepare_for_new_frame(

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -1004,7 +1004,13 @@ pub fn prepare_lights(
         Local<bool>,
         Local<HashSet<RetainedViewEntity>>,
     ),
-    (mut point_lights, directional_lights, rect_lights, mut directional_light_view_entities): (
+    (
+        mut point_lights,
+        changed_point_lights,
+        directional_lights,
+        rect_lights,
+        mut directional_light_view_entities,
+    ): (
         Query<(
             Entity,
             &MainEntity,
@@ -1012,6 +1018,7 @@ pub fn prepare_lights(
             &mut PointAndSpotLightViewEntities,
             AnyOf<(&CubemapFrusta, &Frustum)>,
         )>,
+        Query<(), Changed<ExtractedPointLight>>,
         Query<(Entity, &MainEntity, &ExtractedDirectionalLight)>,
         Query<(Entity, &MainEntity, &ExtractedRectLight)>,
         Query<&mut DirectionalLightViewEntities>,
@@ -1548,6 +1555,34 @@ pub fn prepare_lights(
             }
 
             point_and_spot_light_view_entities.0 = light_view_entities;
+        } else if changed_point_lights.get(*light_entity).is_ok() {
+            // If the point light was changed, update the `ExtractedView` only.
+            let view_translation = GlobalTransform::from_translation(light.transform.translation());
+            let cube_face_projection = Mat4::perspective_infinite_reverse_rh(
+                core::f32::consts::FRAC_PI_2,
+                1.0,
+                light.shadow_map_near_z,
+            );
+            for (face_index, view_rotation) in cube_face_rotations.iter().enumerate() {
+                let view_light_entity = point_and_spot_light_view_entities.0[face_index];
+                let retained_view_entity =
+                    RetainedViewEntity::new(*light_main_entity, None, face_index as u32);
+                commands.entity(view_light_entity).insert(ExtractedView {
+                    retained_view_entity,
+                    viewport: UVec4::new(
+                        0,
+                        0,
+                        point_light_shadow_map.size as u32,
+                        point_light_shadow_map.size as u32,
+                    ),
+                    world_from_view: view_translation * *view_rotation,
+                    clip_from_world: None,
+                    clip_from_view: cube_face_projection,
+                    target_format: CORE_3D_DEPTH_FORMAT,
+                    color_grading: Default::default(),
+                    invert_culling: false,
+                });
+            }
         }
 
         // Initialize the shadow render phases. We have to do this even if we've
@@ -1658,6 +1693,32 @@ pub fn prepare_lights(
             }
 
             point_and_spot_light_view_entities.0 = vec![view_light_entity];
+        } else if changed_point_lights.get(*light_entity).is_ok() {
+            // If the spot light was changed, update the `ExtractedView` only.
+            let spot_world_from_view = spot_light_world_from_view(&light.transform);
+            let spot_world_from_view = spot_world_from_view.into();
+
+            let angle = light.spot_light_angles.expect("lights should be sorted so that \
+                [point_light_count..point_light_count + spot_light_shadow_maps_count] are spot lights").1;
+            let spot_projection = spot_light_clip_from_view(angle, light.shadow_map_near_z);
+
+            for view_light_entity in point_and_spot_light_view_entities.0.iter() {
+                commands.entity(*view_light_entity).insert(ExtractedView {
+                    retained_view_entity,
+                    viewport: UVec4::new(
+                        0,
+                        0,
+                        directional_light_shadow_map.size as u32,
+                        directional_light_shadow_map.size as u32,
+                    ),
+                    world_from_view: spot_world_from_view,
+                    clip_from_view: spot_projection,
+                    clip_from_world: None,
+                    target_format: CORE_3D_DEPTH_FORMAT,
+                    color_grading: Default::default(),
+                    invert_culling: false,
+                });
+            }
         }
 
         shadow_render_phases.prepare_for_new_frame(

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -1018,7 +1018,14 @@ pub fn prepare_lights(
             &mut PointAndSpotLightViewEntities,
             AnyOf<(&CubemapFrusta, &Frustum)>,
         )>,
-        Query<(), Changed<ExtractedPointLight>>,
+        Query<
+            (),
+            Or<(
+                Changed<ExtractedPointLight>,
+                Changed<CubemapFrusta>,
+                Changed<Frustum>,
+            )>,
+        >,
         Query<(Entity, &MainEntity, &ExtractedDirectionalLight)>,
         Query<(Entity, &MainEntity, &ExtractedRectLight)>,
         Query<&mut DirectionalLightViewEntities>,
@@ -1563,25 +1570,32 @@ pub fn prepare_lights(
                 1.0,
                 light.shadow_map_near_z,
             );
-            for (face_index, view_rotation) in cube_face_rotations.iter().enumerate() {
+            for (face_index, (view_rotation, frustum)) in cube_face_rotations
+                .iter()
+                .zip(&point_light_frusta.unwrap().frusta)
+                .enumerate()
+            {
                 let view_light_entity = point_and_spot_light_view_entities.0[face_index];
                 let retained_view_entity =
                     RetainedViewEntity::new(*light_main_entity, None, face_index as u32);
-                commands.entity(view_light_entity).insert(ExtractedView {
-                    retained_view_entity,
-                    viewport: UVec4::new(
-                        0,
-                        0,
-                        point_light_shadow_map.size as u32,
-                        point_light_shadow_map.size as u32,
-                    ),
-                    world_from_view: view_translation * *view_rotation,
-                    clip_from_world: None,
-                    clip_from_view: cube_face_projection,
-                    target_format: CORE_3D_DEPTH_FORMAT,
-                    color_grading: Default::default(),
-                    invert_culling: false,
-                });
+                commands.entity(view_light_entity).insert((
+                    ExtractedView {
+                        retained_view_entity,
+                        viewport: UVec4::new(
+                            0,
+                            0,
+                            point_light_shadow_map.size as u32,
+                            point_light_shadow_map.size as u32,
+                        ),
+                        world_from_view: view_translation * *view_rotation,
+                        clip_from_world: None,
+                        clip_from_view: cube_face_projection,
+                        target_format: CORE_3D_DEPTH_FORMAT,
+                        color_grading: Default::default(),
+                        invert_culling: false,
+                    },
+                    *frustum,
+                ));
             }
         }
 
@@ -1704,21 +1718,24 @@ pub fn prepare_lights(
 
             // There should be only one `view_light_entity` for spotlights.
             let view_light_entity = point_and_spot_light_view_entities.0[0];
-            commands.entity(view_light_entity).insert(ExtractedView {
-                retained_view_entity,
-                viewport: UVec4::new(
-                    0,
-                    0,
-                    directional_light_shadow_map.size as u32,
-                    directional_light_shadow_map.size as u32,
-                ),
-                world_from_view: spot_world_from_view,
-                clip_from_view: spot_projection,
-                clip_from_world: None,
-                target_format: CORE_3D_DEPTH_FORMAT,
-                color_grading: Default::default(),
-                invert_culling: false,
-            });
+            commands.entity(view_light_entity).insert((
+                ExtractedView {
+                    retained_view_entity,
+                    viewport: UVec4::new(
+                        0,
+                        0,
+                        directional_light_shadow_map.size as u32,
+                        directional_light_shadow_map.size as u32,
+                    ),
+                    world_from_view: spot_world_from_view,
+                    clip_from_view: spot_projection,
+                    clip_from_world: None,
+                    target_format: CORE_3D_DEPTH_FORMAT,
+                    color_grading: Default::default(),
+                    invert_culling: false,
+                },
+                *spot_light_frustum.unwrap(),
+            ));
         }
 
         shadow_render_phases.prepare_for_new_frame(


### PR DESCRIPTION
# Objective

- Fixes #23997 for `spotlight` (`rect_light` fixed with #24024 already)
- The spotlight example changes the transform of each spotlight, but the `ExtractedView` and the `Frustum` for the spotlight never updates, hence why the light doesn’t look complete for subsequent frames.

## Solution

- For Spot lights (and Point lights since those were also affected), update the `ExtractedView` and the `Frustum` if its corresponding `ExtractedPointLight` has changed.
- AFAIK this isn’t needed for Directional lights because `ExtractedView`s aren’t re-used — they’re made anew in `prepare_lights`

## Testing

- `cargo run --example spotlight` works as desired.
- `cargo run --example async_channel_pattern` works as desired (for PointLight testing)
- @Zeophlite assist with the example runner (was done before the frusta change though)