### PR TITLE
Fix `Component` macro hook composition codegen

### DIFF
--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -762,11 +762,8 @@ fn hook_register_function_call(
         [single] => single.clone(),
         multiple => {
             quote! {
-                {
-                    fn hook(world: #bevy_ecs_path::world::DeferredWorld, context: #bevy_ecs_path::lifecycle::HookContext) {
-                        quote! {#(#multiple(world.reborrow(), context.clone());)*}
-                    }
-                    hook
+                |mut world: #bevy_ecs_path::world::DeferredWorld, context: #bevy_ecs_path::lifecycle::HookContext| {
+                    #(#multiple(world.reborrow(), context.clone());)*
                 }
             }
         }

--- a/crates/bevy_ecs/src/relationship/mod.rs
+++ b/crates/bevy_ecs/src/relationship/mod.rs
@@ -1190,27 +1190,63 @@ mod tests {
     }
 
     #[test]
-    fn component_hooks_compatibility() {
-        static CALLED: AtomicBool = AtomicBool::new(false);
+    pub fn component_hooks_compatibility() {
+        static ADD_CALLED: AtomicBool = AtomicBool::new(false);
+        static INSERT_CALLED: AtomicBool = AtomicBool::new(false);
+        static DISCARD_CALLED: AtomicBool = AtomicBool::new(false);
+        static REMOVE_CALLED: AtomicBool = AtomicBool::new(false);
+        static DESPAWN_CALLED: AtomicBool = AtomicBool::new(false);
 
         #[derive(Component)]
         #[relationship(relationship_target = RelTarget)]
-        #[component(on_add = on_add)]
+        #[component(on_add, on_insert, on_discard, on_remove, on_despawn)]
         struct Rel(Entity);
 
         #[derive(Component)]
         #[relationship_target(relationship = Rel)]
         struct RelTarget(Entity);
 
-        fn on_add(world: DeferredWorld, context: HookContext) {
-            assert!(!world.entity(context.entity).contains::<RelTarget>());
-            CALLED.store(true, core::sync::atomic::Ordering::Relaxed);
+        impl Rel {
+            fn on_add(world: DeferredWorld, context: HookContext) {
+                let &Rel(target) = world.get(context.entity).unwrap();
+                assert!(!world.entity(target).contains::<RelTarget>());
+                ADD_CALLED.store(true, core::sync::atomic::Ordering::Relaxed);
+            }
+
+            fn on_insert(world: DeferredWorld, context: HookContext) {
+                let &Rel(target) = world.get(context.entity).unwrap();
+                assert!(!world.entity(target).contains::<RelTarget>());
+                INSERT_CALLED.store(true, core::sync::atomic::Ordering::Relaxed);
+            }
+
+            fn on_discard(world: DeferredWorld, context: HookContext) {
+                let &Rel(target) = world.get(context.entity).unwrap();
+                assert!(world.entity(target).contains::<RelTarget>());
+                DISCARD_CALLED.store(true, core::sync::atomic::Ordering::Relaxed);
+            }
+
+            fn on_remove(world: DeferredWorld, context: HookContext) {
+                let &Rel(target) = world.get(context.entity).unwrap();
+                assert!(world.entity(target).contains::<RelTarget>());
+                REMOVE_CALLED.store(true, core::sync::atomic::Ordering::Relaxed);
+            }
+
+            fn on_despawn(world: DeferredWorld, context: HookContext) {
+                let &Rel(target) = world.get(context.entity).unwrap();
+                assert!(world.entity(target).contains::<RelTarget>());
+                DESPAWN_CALLED.store(true, core::sync::atomic::Ordering::Relaxed);
+            }
         }
 
         let mut world = World::new();
         let target = world.spawn_empty().id();
-        world.spawn(Rel(target));
+        let source = world.spawn(Rel(target)).id();
         assert!(world.entity(target).contains::<RelTarget>());
-        assert!(CALLED.load(core::sync::atomic::Ordering::Relaxed));
+        assert!(ADD_CALLED.load(core::sync::atomic::Ordering::Relaxed));
+        assert!(INSERT_CALLED.load(core::sync::atomic::Ordering::Relaxed));
+        world.despawn(source);
+        assert!(DISCARD_CALLED.load(core::sync::atomic::Ordering::Relaxed));
+        assert!(REMOVE_CALLED.load(core::sync::atomic::Ordering::Relaxed));
+        assert!(DESPAWN_CALLED.load(core::sync::atomic::Ordering::Relaxed));
     }
 }


### PR DESCRIPTION
# Objective

#24000 introduced the ability to use both relationships and user-provided hooks with `#[derive(Component)]`, but the hook function that is generated when there's a conflict does not compile.

## Solution

Remove an errant nested `quote!`, and change the inline function definition to a closure so that `Self` type references work.

## Testing

Updated the test to check the rest of the hooks, and it passes with this fix.