### PR TITLE
Use irrefutable pattern matching to remove `expect` usage

### DIFF
--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -12,7 +12,10 @@ use bevy_ecs::{error::BevyError, world::World};
 use bevy_platform::collections::{hash_map::Entry, HashMap, HashSet};
 use bevy_reflect::TypePath;
 use bevy_tasks::{BoxedFuture, ConditionalSendFuture};
-use core::any::{Any, TypeId};
+use core::{
+    any::{Any, TypeId},
+    convert::Infallible,
+};
 use downcast_rs::{impl_downcast, Downcast};
 use ron::error::SpannedError;
 use serde::{Deserialize, Serialize};
@@ -475,8 +478,8 @@ impl<'a> LoadContext<'a> {
         label: impl Into<CowArc<'static, str>>,
         asset: A,
     ) -> Handle<A> {
-        self.labeled_asset_scope(label, |_| Ok::<_, ()>(asset))
-            .expect("the closure returns Ok")
+        let Ok(handle) = self.labeled_asset_scope(label, |_| Ok::<_, Infallible>(asset));
+        handle
     }
 
     /// Add a [`LoadedAsset`] that is a "labeled sub asset" of the root path of this load context.


### PR DESCRIPTION
# Objective

Reduce usage of `expect` in the codebase.

## Solution

Use irrefutable pattern matching to statically guarantee the `Ok` variant.