### PR TITLE
Implement a spinbox widget

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5361,6 +5361,17 @@ category = "UI (User Interface)"
 wasm = true
 
 [[example]]
+name = "spinbox_months"
+path = "examples/ui/widgets/spinbox_months.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.spinbox_months]
+name = "Spinbox Months"
+description = "Demonstrates using the headless spinbox with a Month enum and a non-editable text field"
+category = "UI (User Interface)"
+wasm = true
+
+[[example]]
 name = "scrollbars"
 path = "examples/ui/scroll_and_overflow/scrollbars.rs"
 doc-scrape-examples = true

--- a/crates/bevy_feathers/src/controls/mod.rs
+++ b/crates/bevy_feathers/src/controls/mod.rs
@@ -46,6 +46,7 @@ impl Plugin for ControlsPlugin {
             ColorSwatchPlugin,
             DisclosureTogglePlugin,
             MenuPlugin,
+            NumberInputPlugin,
             RadioPlugin,
             SliderPlugin,
             TextInputPlugin,

--- a/crates/bevy_feathers/src/controls/number_input.rs
+++ b/crates/bevy_feathers/src/controls/number_input.rs
@@ -1,51 +1,46 @@
-use bevy_app::PropagateOver;
+use bevy_app::{Plugin, PreUpdate, PropagateOver};
 use bevy_asset::AssetServer;
+use bevy_camera::visibility::Visibility;
 use bevy_ecs::{
     component::Component,
     entity::Entity,
     event::EntityEvent,
-    hierarchy::{ChildOf, Children},
+    hierarchy::Children,
     observer::On,
-    query::With,
-    relationship::Relationship,
-    system::{Commands, Query, Res},
+    query::{Changed, With},
+    schedule::IntoScheduleConfigs,
+    system::Query,
     template::template,
 };
-use bevy_input::keyboard::{KeyCode, KeyboardInput};
-use bevy_input_focus::{FocusLost, FocusedInput, InputFocus};
-use bevy_log::warn;
+use bevy_picking::{hover::Hovered, PickingSystems};
 use bevy_scene::prelude::*;
-use bevy_text::{
-    EditableText, EditableTextFilter, FontSource, FontWeight, TextEdit, TextEditChange, TextFont,
+use bevy_text::{FontSource, FontWeight, TextFont};
+use bevy_ui::{
+    px, widget::Text, AlignItems, AlignSelf, Display, FlexDirection, JustifyContent, Node, UiRect,
 };
-use bevy_ui::{px, widget::Text, AlignItems, AlignSelf, Display, JustifyContent, Node, UiRect};
-use bevy_ui_widgets::{SelectAllOnFocus, ValueChange};
+use bevy_ui_widgets::{
+    NumberInput as CoreNumberInput, NumberSpinBoxValueInput, SelectAllOnFocus,
+    SetNumberSpinBoxValue, SpinBox, SpinBoxDecrementButton, SpinBoxIncrementButton,
+};
 
 use crate::{
     constants::{fonts, size},
-    controls::{text_input, text_input_container, TextInputProps},
-    theme::{ThemeBackgroundColor, ThemeBorderColor, ThemeTextColor, ThemeToken},
+    controls::{
+        button, text_input, text_input_container, ButtonProps, ButtonVariant, TextInputProps,
+    },
+    theme::{ThemeBackgroundColor, ThemeBorderColor, ThemeTextColor, ThemeToken, ThemedText},
     tokens,
 };
+
+pub use bevy_ui_widgets::{NumberFormat, NumberInputValue};
 
 /// Marker to indicate a number input widget with feathers styling.
 #[derive(Component, Default, Clone)]
 struct FeathersNumberInput;
 
-/// Used to indicate what format of numbers we are editing. This primarily affects the type
-/// of [`ValueChange`] event that is emitted.
-#[derive(Component, Default, Clone, Copy)]
-pub enum NumberFormat {
-    /// A 32-bit float
-    #[default]
-    F32,
-    /// A 64-bit float
-    F64,
-    /// A 32-bit integer
-    I32,
-    /// A 64-bit integer
-    I64,
-}
+/// Marker for the spinbox button container that should only be shown while hovered.
+#[derive(Component, Default, Clone)]
+struct FeathersSpinButtons;
 
 /// Parameters for the text input template, passed to [`number_input`] function.
 pub struct NumberInputProps {
@@ -69,65 +64,32 @@ impl Default for NumberInputProps {
     }
 }
 
-/// Represents numbers in different formats.
-#[derive(Debug, PartialEq, Clone, Copy)]
-pub enum NumberInputValue {
-    /// An f32 value
-    F32(f32),
-    /// An f64 value
-    F64(f64),
-    /// An i32 value
-    I32(i32),
-    /// An i64 value
-    I64(i64),
-}
-
-impl core::fmt::Display for NumberInputValue {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            NumberInputValue::F32(v) => write!(f, "{}", v),
-            NumberInputValue::F64(v) => write!(f, "{}", v),
-            NumberInputValue::I32(v) => write!(f, "{}", v),
-            NumberInputValue::I64(v) => write!(f, "{}", v),
-        }
-    }
-}
-
-/// Event which can be sent to the number input widget to update the displayed value.
+/// Event which can be sent to the styled Feathers number input to update the displayed value.
+///
+/// This preserves the existing Feathers API by targeting the outer styled widget entity, and
+/// forwards internally to the wrapped core [`bevy_ui_widgets::SpinBox`].
 #[derive(Clone, EntityEvent)]
 pub struct UpdateNumberInput {
-    /// Target widget
+    /// Target widget.
     pub entity: Entity,
 
-    /// Value to change to
+    /// Value to change to.
     pub value: NumberInputValue,
 }
 
-/// Widget that permits text entry of floating-point numbers. This widget implements two-way
-/// synchronization:
-/// * when the widget has focus, it emits values (via a [`ValueChange<T>`]) event as the user types.
-///   The type of ``T`` will be ``f32``, ``f64``, ``i32``, or ``i64`` depending on the
-///   ``number_format`` parameter.
-/// * when the widget does not have focus, it listens for [`UpdateNumberInput`] events, and replaces
-///   the contents of the text buffer based on the value in that event.
+/// Styled Feathers wrapper around the core [`bevy_ui_widgets::SpinBox`].
 ///
-/// To avoid excessive updating, you should only update the number value when there is an actual
-/// change, that is, when the new value is different from the current value.
-///
-/// In most cases, the actual source of truth for the numeric value will be external, that is,
-/// some property in an app-specific data structure. It's the responsibility of the app to
-/// synchronize this value with the [`number_input`] widget in both directions:
-/// * When a [`ValueChange`] event is received, update the app-specific property.
-/// * When the app-specific property changes - either in response to a [`ValueChange`] event, or
-///   because of some other action, trigger an [`UpdateNumberInput`] entity event to update the
-///   displayed value.
-// TODO: Add text_input field validation when it becomes available.
+/// The Feathers widget keeps only layout, theming, and hover-only button presentation. Numeric
+/// editing, stepping, and typed value-change behavior are handled by the core widgets.
 pub fn number_input(props: NumberInputProps) -> impl Scene {
+    let number_format = props.number_format;
+
     bsn! {
         :text_input_container()
         ThemeBorderColor({props.sigil_color.clone()})
         FeathersNumberInput
-        template_value(props.number_format)
+        SpinBox
+        Hovered
         on(number_input_on_update)
         Children [
             {
@@ -157,199 +119,175 @@ pub fn number_input(props: NumberInputProps) -> impl Scene {
                     )) as Box<dyn SceneList>,
                     None => Box::new(bsn_list!()) as Box<dyn SceneList>
                 }
-            }
-            text_input(TextInputProps {
-                visible_width: None,
-                max_characters: Some(20),
-            })
-            SelectAllOnFocus,
-            on(number_input_on_text_change)
-            on(number_input_on_enter_key)
-            on(number_input_on_focus_loss)
-            EditableTextFilter::new(|c| {
-                c.is_ascii_digit() || matches!(c, '.' | '-' | '+' | 'e' | 'E')
-            }),
+            },
+            (
+                text_input(TextInputProps {
+                    visible_width: None,
+                    max_characters: Some(20),
+                })
+                CoreNumberInput {
+                    format: number_format,
+                }
+                NumberSpinBoxValueInput
+                SelectAllOnFocus
+            ),
+            (
+                Node {
+                    display: Display::Flex,
+                    flex_direction: FlexDirection::Column,
+                    align_self: AlignSelf::Stretch,
+                    justify_content: JustifyContent::Center,
+                    width: px(18),
+                    row_gap: px(1),
+                }
+                template_value(Visibility::Hidden)
+                FeathersSpinButtons
+                Children [
+                    (
+                        button(ButtonProps {
+                            caption: Box::new(bsn_list!((Text("+") ThemedText))),
+                            variant: ButtonVariant::Plain,
+                            ..Default::default()
+                        })
+                        SpinBoxIncrementButton
+                        Node {
+                            min_width: px(18),
+                            height: px(11),
+                            padding: UiRect::axes(px(0), px(0)),
+                        }
+                    ),
+                    (
+                        button(ButtonProps {
+                            caption: Box::new(bsn_list!((Text("-") ThemedText))),
+                            variant: ButtonVariant::Plain,
+                            ..Default::default()
+                        })
+                        SpinBoxDecrementButton
+                        Node {
+                            min_width: px(18),
+                            height: px(11),
+                            padding: UiRect::axes(px(0), px(0)),
+                        }
+                    ),
+                ]
+            ),
         ]
     }
 }
 
-fn number_input_on_text_change(
-    change: On<TextEditChange>,
-    q_parent: Query<&ChildOf>,
-    q_number_input: Query<&NumberFormat, With<FeathersNumberInput>>,
-    q_text_input: Query<&EditableText>,
-    mut commands: Commands,
-) {
-    let Ok(parent) = q_parent.get(change.event_target()) else {
-        return;
-    };
-
-    let Ok(number_format) = q_number_input.get(parent.get()) else {
-        return;
-    };
-
-    let Ok(editable_text) = q_text_input.get(change.event_target()) else {
-        return;
-    };
-
-    let text_value = editable_text.value().to_string();
-    emit_value_change(text_value, *number_format, parent.0, &mut commands, false);
-}
-
 fn number_input_on_update(
     update: On<UpdateNumberInput>,
+    q_feathers: Query<(), With<FeathersNumberInput>>,
+    mut commands: bevy_ecs::system::Commands,
+) {
+    if !q_feathers.contains(update.event_target()) {
+        return;
+    }
+
+    commands.trigger(SetNumberSpinBoxValue {
+        entity: update.event_target(),
+        value: update.value,
+    });
+}
+
+fn update_spinbox_button_visibility(
+    q_spinboxes: Query<(Entity, &Hovered), (With<FeathersNumberInput>, Changed<Hovered>)>,
     q_children: Query<&Children>,
-    q_number_input: Query<(), With<FeathersNumberInput>>,
-    mut q_text_input: Query<&mut EditableText>,
-    focus: Res<InputFocus>,
+    mut q_button_groups: Query<&mut Visibility, With<FeathersSpinButtons>>,
 ) {
-    if !q_number_input.contains(update.event_target()) {
-        return;
-    };
+    for (spinbox, hovered) in q_spinboxes.iter() {
+        let visibility = if hovered.0 {
+            Visibility::Visible
+        } else {
+            Visibility::Hidden
+        };
 
-    let Ok(children) = q_children.get(update.event_target()) else {
-        return;
-    };
-
-    for child_id in children.iter() {
-        if focus.get() != Some(*child_id)
-            && let Ok(mut editable_text) = q_text_input.get_mut(*child_id)
-        {
-            let new_digits = update.value.to_string();
-            let old_digits = editable_text.value().to_string();
-            if old_digits != new_digits {
-                editable_text.queue_edit(TextEdit::SelectAll);
-                editable_text.queue_edit(TextEdit::Insert(new_digits.into()));
+        for child in q_children.iter_descendants(spinbox) {
+            if let Ok(mut button_visibility) = q_button_groups.get_mut(child) {
+                *button_visibility = visibility;
             }
-            break;
         }
     }
 }
 
-fn number_input_on_enter_key(
-    key_input: On<FocusedInput<KeyboardInput>>,
-    q_parent: Query<&ChildOf>,
-    q_number_input: Query<&NumberFormat, With<FeathersNumberInput>>,
-    q_text_input: Query<&EditableText>,
-    mut commands: Commands,
-) {
-    if key_input.input.key_code != KeyCode::Enter {
-        return;
+/// Plugin which registers the systems for updating Feathers number-input styling.
+pub struct NumberInputPlugin;
+
+impl Plugin for NumberInputPlugin {
+    fn build(&self, app: &mut bevy_app::App) {
+        app.add_systems(
+            PreUpdate,
+            update_spinbox_button_visibility.in_set(PickingSystems::Last),
+        );
     }
-
-    let Ok(parent) = q_parent.get(key_input.event_target()) else {
-        return;
-    };
-
-    let Ok(number_format) = q_number_input.get(parent.get()) else {
-        return;
-    };
-
-    let Ok(editable_text) = q_text_input.get(key_input.event_target()) else {
-        return;
-    };
-
-    let text_value = editable_text.value().to_string();
-    emit_value_change(text_value, *number_format, parent.0, &mut commands, true);
 }
 
-fn number_input_on_focus_loss(
-    focus_lost: On<FocusLost>,
-    q_parent: Query<&ChildOf>,
-    q_number_input: Query<&NumberFormat, With<FeathersNumberInput>>,
-    mut q_text_input: Query<&mut EditableText>,
-    mut commands: Commands,
-) {
-    let editable_text_id = focus_lost.event_target();
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy_app::App;
+    use bevy_ecs::{observer::On, prelude::*};
 
-    let Ok(parent) = q_parent.get(editable_text_id) else {
-        return;
-    };
+    #[derive(Resource, Default)]
+    struct ForwardedSpinBoxUpdates(Vec<(Entity, NumberInputValue)>);
 
-    let Ok(number_format) = q_number_input.get(parent.get()) else {
-        return;
-    };
+    #[test]
+    fn update_number_input_forwards_to_core_spinbox_update() {
+        let mut app = App::new();
+        app.init_resource::<ForwardedSpinBoxUpdates>();
 
-    let Ok(editable_text) = q_text_input.get_mut(editable_text_id) else {
-        return;
-    };
+        let root = app
+            .world_mut()
+            .spawn((FeathersNumberInput, SpinBox))
+            .observe(number_input_on_update)
+            .observe(
+                |update: On<SetNumberSpinBoxValue>,
+                 mut forwarded: ResMut<ForwardedSpinBoxUpdates>| {
+                    forwarded.0.push((update.event_target(), update.value));
+                },
+            )
+            .id();
 
-    let text_value = editable_text.value().to_string();
-    emit_value_change(text_value, *number_format, parent.0, &mut commands, true);
-}
+        app.world_mut().commands().trigger(UpdateNumberInput {
+            entity: root,
+            value: NumberInputValue::I32(9),
+        });
+        app.update();
 
-fn emit_value_change(
-    text_value: String,
-    format: NumberFormat,
-    source: Entity,
-    commands: &mut Commands,
-    is_final: bool,
-) {
-    let text_value = text_value.trim();
-    if text_value.is_empty() {
-        return;
+        assert_eq!(
+            app.world().resource::<ForwardedSpinBoxUpdates>().0,
+            vec![(root, NumberInputValue::I32(9))]
+        );
     }
 
-    match format {
-        NumberFormat::F32 => {
-            match text_value.parse::<f32>() {
-                Ok(new_value) => {
-                    commands.trigger(ValueChange {
-                        source,
-                        value: new_value,
-                        is_final,
-                    });
-                }
-                Err(_) => {
-                    // TODO: Emit a validation error once these are defined
-                    warn!("Invalid floating-point number in text edit");
-                }
-            }
-        }
-        NumberFormat::F64 => {
-            match text_value.parse::<f64>() {
-                Ok(new_value) => {
-                    commands.trigger(ValueChange {
-                        source,
-                        value: new_value,
-                        is_final,
-                    });
-                }
-                Err(_) => {
-                    // TODO: Emit a validation error once these are defined
-                    warn!("Invalid floating-point number in text edit");
-                }
-            }
-        }
-        NumberFormat::I32 => {
-            match text_value.parse::<i32>() {
-                Ok(new_value) => {
-                    commands.trigger(ValueChange {
-                        source,
-                        value: new_value,
-                        is_final,
-                    });
-                }
-                Err(_) => {
-                    // TODO: Emit a validation error once these are defined
-                    warn!("Invalid integer number in text edit");
-                }
-            }
-        }
-        NumberFormat::I64 => {
-            match text_value.parse::<i64>() {
-                Ok(new_value) => {
-                    commands.trigger(ValueChange {
-                        source,
-                        value: new_value,
-                        is_final,
-                    });
-                }
-                Err(_) => {
-                    // TODO: Emit a validation error once these are defined
-                    warn!("Invalid integer number in text edit");
-                }
-            }
-        }
+    #[test]
+    fn hover_changes_toggle_spin_button_visibility() {
+        let mut app = App::new();
+        app.add_plugins(NumberInputPlugin);
+
+        let root = app
+            .world_mut()
+            .spawn((FeathersNumberInput, Hovered(false)))
+            .id();
+        let button_group = app
+            .world_mut()
+            .spawn((FeathersSpinButtons, Visibility::Hidden, ChildOf(root)))
+            .id();
+
+        app.world_mut().entity_mut(root).insert(Hovered(true));
+        app.update();
+
+        assert_eq!(
+            app.world().get::<Visibility>(button_group),
+            Some(&Visibility::Visible)
+        );
+
+        app.world_mut().entity_mut(root).insert(Hovered(false));
+        app.update();
+
+        assert_eq!(
+            app.world().get::<Visibility>(button_group),
+            Some(&Visibility::Hidden)
+        );
     }
 }

--- a/crates/bevy_ui_widgets/src/lib.rs
+++ b/crates/bevy_ui_widgets/src/lib.rs
@@ -29,20 +29,26 @@
 mod button;
 mod checkbox;
 mod menu;
+mod number_input;
+mod numeric_spinbox;
 mod observe;
 pub mod popover;
 mod radio;
 mod scrollbar;
 mod slider;
+mod spinbox;
 mod text_input;
 
 pub use button::*;
 pub use checkbox::*;
 pub use menu::*;
+pub use number_input::*;
+pub use numeric_spinbox::*;
 pub use observe::*;
 pub use radio::*;
 pub use scrollbar::*;
 pub use slider::*;
+pub use spinbox::*;
 pub use text_input::*;
 
 use bevy_app::{PluginGroup, PluginGroupBuilder};
@@ -66,6 +72,9 @@ impl PluginGroup for UiWidgetsPlugins {
             .add(ScrollbarPlugin)
             .add(SliderPlugin)
             .add(EditableTextInputPlugin)
+            .add(SpinBoxPlugin)
+            .add(NumberInputPlugin)
+            .add(NumericSpinBoxPlugin)
     }
 }
 

--- a/crates/bevy_ui_widgets/src/number_input.rs
+++ b/crates/bevy_ui_widgets/src/number_input.rs
@@ -1,0 +1,659 @@
+use bevy_app::{App, Plugin};
+use bevy_ecs::{
+    component::Component,
+    entity::Entity,
+    event::EntityEvent,
+    lifecycle::Insert,
+    observer::On,
+    query::{Has, With},
+    system::{Commands, Query, Res},
+    world::DeferredWorld,
+};
+use bevy_input::keyboard::{KeyCode, KeyboardInput};
+use bevy_input::ButtonState;
+use bevy_input_focus::{FocusLost, FocusedInput, InputFocus};
+use bevy_log::warn;
+use bevy_text::{EditableText, EditableTextFilter, TextEdit, TextEditChange};
+
+use crate::ValueChange;
+
+/// Defines what numeric type a [`NumberInput`] edits.
+#[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
+pub enum NumberFormat {
+    /// A 32-bit float.
+    #[default]
+    F32,
+    /// A 64-bit float.
+    F64,
+    /// A 32-bit integer.
+    I32,
+    /// A 64-bit integer.
+    I64,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub(crate) enum NumberInputParseError {
+    Empty,
+    InvalidFloat,
+    InvalidInteger,
+}
+
+impl core::fmt::Display for NumberInputParseError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            NumberInputParseError::Empty => write!(f, "empty numeric input"),
+            NumberInputParseError::InvalidFloat => write!(f, "invalid floating-point number"),
+            NumberInputParseError::InvalidInteger => write!(f, "invalid integer number"),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub(crate) enum NumberInputAdjustError {
+    IntegerStepRequired,
+    StepOutOfRangeForI32,
+    Overflow,
+}
+
+impl core::fmt::Display for NumberInputAdjustError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            NumberInputAdjustError::IntegerStepRequired => {
+                write!(f, "integer number inputs require integer step values")
+            }
+            NumberInputAdjustError::StepOutOfRangeForI32 => {
+                write!(f, "numeric step does not fit in i32")
+            }
+            NumberInputAdjustError::Overflow => {
+                write!(f, "numeric value overflowed during step")
+            }
+        }
+    }
+}
+
+impl NumberFormat {
+    pub(crate) fn parse(self, text: &str) -> Result<NumberInputValue, NumberInputParseError> {
+        let text = text.trim();
+        if text.is_empty() {
+            return Err(NumberInputParseError::Empty);
+        }
+
+        match self {
+            NumberFormat::F32 => text
+                .parse::<f32>()
+                .map(NumberInputValue::F32)
+                .map_err(|_| NumberInputParseError::InvalidFloat),
+            NumberFormat::F64 => text
+                .parse::<f64>()
+                .map(NumberInputValue::F64)
+                .map_err(|_| NumberInputParseError::InvalidFloat),
+            NumberFormat::I32 => text
+                .parse::<i32>()
+                .map(NumberInputValue::I32)
+                .map_err(|_| NumberInputParseError::InvalidInteger),
+            NumberFormat::I64 => text
+                .parse::<i64>()
+                .map(NumberInputValue::I64)
+                .map_err(|_| NumberInputParseError::InvalidInteger),
+        }
+    }
+}
+
+/// Headless numeric text input.
+///
+/// This is the numeric-specialized layer on top of [`EditableText`]. The widget keeps the text
+/// buffer local to the input entity, but emits typed [`ValueChange`] events for external state
+/// management.
+///
+/// Add this component to the same entity as [`EditableText`]. A numeric character filter is
+/// inserted automatically if the entity does not already have an [`EditableTextFilter`].
+///
+/// ```ignore
+/// use bevy_ecs::prelude::*;
+/// use bevy_text::{EditableText, TextCursorStyle};
+/// use bevy_ui_widgets::{NumberFormat, NumberInput, SelectAllOnFocus, ValueChange};
+///
+/// commands.spawn((
+///     NumberInput {
+///         format: NumberFormat::F32,
+///     },
+///     EditableText::new("1.0"),
+///     TextCursorStyle::default(),
+///     SelectAllOnFocus,
+/// )).observe(|change: On<ValueChange<f32>>| {
+///     info!("new number: {}", change.value);
+/// });
+/// ```
+#[derive(Component, Debug, Default, Clone, Copy)]
+#[require(EditableText)]
+pub struct NumberInput {
+    /// The numeric type edited by this input.
+    pub format: NumberFormat,
+}
+
+/// Represents a concrete numeric value for programmatic updates and spinbox stepping.
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum NumberInputValue {
+    /// An `f32` value.
+    F32(f32),
+    /// An `f64` value.
+    F64(f64),
+    /// An `i32` value.
+    I32(i32),
+    /// An `i64` value.
+    I64(i64),
+}
+
+impl NumberInputValue {
+    pub(crate) fn one_for(format: NumberFormat) -> Self {
+        match format {
+            NumberFormat::F32 => Self::F32(1.0),
+            NumberFormat::F64 => Self::F64(1.0),
+            NumberFormat::I32 => Self::I32(1),
+            NumberFormat::I64 => Self::I64(1),
+        }
+    }
+
+    pub(crate) fn emit(self, source: Entity, is_final: bool, commands: &mut Commands) {
+        match self {
+            NumberInputValue::F32(value) => {
+                commands.trigger(ValueChange {
+                    source,
+                    value,
+                    is_final,
+                });
+            }
+            NumberInputValue::F64(value) => {
+                commands.trigger(ValueChange {
+                    source,
+                    value,
+                    is_final,
+                });
+            }
+            NumberInputValue::I32(value) => {
+                commands.trigger(ValueChange {
+                    source,
+                    value,
+                    is_final,
+                });
+            }
+            NumberInputValue::I64(value) => {
+                commands.trigger(ValueChange {
+                    source,
+                    value,
+                    is_final,
+                });
+            }
+        }
+    }
+
+    pub(crate) fn adjust(
+        self,
+        step: Self,
+        increment: bool,
+    ) -> Result<Self, NumberInputAdjustError> {
+        match self {
+            NumberInputValue::F32(value) => Ok(NumberInputValue::F32(if increment {
+                value + step.as_f32()
+            } else {
+                value - step.as_f32()
+            })),
+            NumberInputValue::F64(value) => Ok(NumberInputValue::F64(if increment {
+                value + step.as_f64()
+            } else {
+                value - step.as_f64()
+            })),
+            NumberInputValue::I32(value) => {
+                let step = step.as_i32()?;
+                let next = if increment {
+                    value.checked_add(step)
+                } else {
+                    value.checked_sub(step)
+                };
+                next.map(NumberInputValue::I32)
+                    .ok_or(NumberInputAdjustError::Overflow)
+            }
+            NumberInputValue::I64(value) => {
+                let step = step.as_i64()?;
+                let next = if increment {
+                    value.checked_add(step)
+                } else {
+                    value.checked_sub(step)
+                };
+                next.map(NumberInputValue::I64)
+                    .ok_or(NumberInputAdjustError::Overflow)
+            }
+        }
+    }
+
+    fn as_f32(self) -> f32 {
+        match self {
+            NumberInputValue::F32(value) => value,
+            NumberInputValue::F64(value) => value as f32,
+            NumberInputValue::I32(value) => value as f32,
+            NumberInputValue::I64(value) => value as f32,
+        }
+    }
+
+    fn as_f64(self) -> f64 {
+        match self {
+            NumberInputValue::F32(value) => value.into(),
+            NumberInputValue::F64(value) => value,
+            NumberInputValue::I32(value) => value.into(),
+            NumberInputValue::I64(value) => value as f64,
+        }
+    }
+
+    fn as_i32(self) -> Result<i32, NumberInputAdjustError> {
+        match self {
+            NumberInputValue::I32(value) => Ok(value),
+            NumberInputValue::I64(value) => {
+                i32::try_from(value).map_err(|_| NumberInputAdjustError::StepOutOfRangeForI32)
+            }
+            NumberInputValue::F32(_) | NumberInputValue::F64(_) => {
+                Err(NumberInputAdjustError::IntegerStepRequired)
+            }
+        }
+    }
+
+    fn as_i64(self) -> Result<i64, NumberInputAdjustError> {
+        match self {
+            NumberInputValue::I32(value) => Ok(value.into()),
+            NumberInputValue::I64(value) => Ok(value),
+            NumberInputValue::F32(_) | NumberInputValue::F64(_) => {
+                Err(NumberInputAdjustError::IntegerStepRequired)
+            }
+        }
+    }
+}
+
+impl core::fmt::Display for NumberInputValue {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            NumberInputValue::F32(value) => write!(f, "{value}"),
+            NumberInputValue::F64(value) => write!(f, "{value}"),
+            NumberInputValue::I32(value) => write!(f, "{value}"),
+            NumberInputValue::I64(value) => write!(f, "{value}"),
+        }
+    }
+}
+
+/// Programmatically replace the displayed value of a [`NumberInput`].
+///
+/// If the input currently has focus, the update is ignored so it does not interfere with typing.
+#[derive(Clone, EntityEvent)]
+pub struct SetNumberInputValue {
+    /// The target input.
+    #[event_target]
+    pub entity: Entity,
+    /// The value to display.
+    pub value: NumberInputValue,
+}
+
+// Programmatic text refreshes still trigger `TextEditChange` on the next frame. Mark them so the
+// next change event is ignored instead of echoed back as a user-originated `ValueChange`.
+#[derive(Component, Default)]
+pub(crate) struct IgnoreNextNumberInputChange;
+
+fn number_input_allows_char(c: char) -> bool {
+    c.is_ascii_digit() || matches!(c, '.' | '-' | '+' | 'e' | 'E')
+}
+
+fn number_input_on_insert(insert: On<Insert, NumberInput>, mut world: DeferredWorld) {
+    if !world.entity(insert.entity).contains::<EditableTextFilter>() {
+        world
+            .commands()
+            .entity(insert.entity)
+            .insert(EditableTextFilter::new(number_input_allows_char));
+    }
+}
+
+fn number_input_on_text_change(
+    change: On<TextEditChange>,
+    q_number_input: Query<
+        (
+            &NumberInput,
+            &EditableText,
+            Has<IgnoreNextNumberInputChange>,
+        ),
+        With<NumberInput>,
+    >,
+    mut commands: Commands,
+) {
+    let Ok((number_input, editable_text, suppress)) = q_number_input.get(change.event_target())
+    else {
+        return;
+    };
+
+    if suppress {
+        commands
+            .entity(change.event_target())
+            .remove::<IgnoreNextNumberInputChange>();
+        return;
+    }
+
+    let text_value = editable_text.value().to_string();
+    emit_value_change(
+        &text_value,
+        number_input.format,
+        change.event_target(),
+        false,
+        &mut commands,
+    );
+}
+
+// Single-line numeric inputs do not lose focus on Enter, so treat Enter as an explicit commit.
+fn number_input_on_submit_key(
+    key_input: On<FocusedInput<KeyboardInput>>,
+    q_number_input: Query<(&NumberInput, &EditableText)>,
+    mut commands: Commands,
+) {
+    if key_input.input.key_code != KeyCode::Enter
+        || key_input.input.state != ButtonState::Pressed
+        || key_input.input.repeat
+    {
+        return;
+    }
+
+    let Ok((number_input, editable_text)) = q_number_input.get(key_input.focused_entity) else {
+        return;
+    };
+
+    let text_value = editable_text.value().to_string();
+    emit_value_change(
+        &text_value,
+        number_input.format,
+        key_input.focused_entity,
+        true,
+        &mut commands,
+    );
+}
+
+fn number_input_on_focus_loss(
+    focus_lost: On<FocusLost>,
+    q_number_input: Query<(&NumberInput, &EditableText)>,
+    mut commands: Commands,
+) {
+    let Ok((number_input, editable_text)) = q_number_input.get(focus_lost.event_target()) else {
+        return;
+    };
+
+    let text_value = editable_text.value().to_string();
+    emit_value_change(
+        &text_value,
+        number_input.format,
+        focus_lost.event_target(),
+        true,
+        &mut commands,
+    );
+}
+
+fn number_input_on_set_value(
+    set_value: On<SetNumberInputValue>,
+    mut q_number_input: Query<&mut EditableText, With<NumberInput>>,
+    focus: Option<Res<InputFocus>>,
+    mut commands: Commands,
+) {
+    queue_number_input_value_update_if_unfocused(
+        set_value.event_target(),
+        set_value.value,
+        &mut q_number_input,
+        focus.as_deref(),
+        &mut commands,
+    );
+}
+
+fn emit_value_change(
+    text_value: &str,
+    format: NumberFormat,
+    source: Entity,
+    is_final: bool,
+    commands: &mut Commands,
+) {
+    match format.parse(text_value) {
+        Ok(value) => value.emit(source, is_final, commands),
+        Err(NumberInputParseError::Empty) => {}
+        Err(error) => warn!("{error} in text edit"),
+    }
+}
+
+pub(crate) fn queue_number_input_value_update(
+    entity: Entity,
+    value: NumberInputValue,
+    editable_text: &mut EditableText,
+    commands: &mut Commands,
+) -> bool {
+    let new_digits = value.to_string();
+    let old_digits = editable_text.value().to_string();
+    if old_digits == new_digits {
+        return false;
+    }
+
+    commands.entity(entity).insert(IgnoreNextNumberInputChange);
+    editable_text.queue_edit(TextEdit::SelectAll);
+    editable_text.queue_edit(TextEdit::Insert(new_digits.into()));
+    true
+}
+
+pub(crate) fn queue_number_input_value_update_if_unfocused(
+    entity: Entity,
+    value: NumberInputValue,
+    q_number_input: &mut Query<&mut EditableText, With<NumberInput>>,
+    focus: Option<&InputFocus>,
+    commands: &mut Commands,
+) -> bool {
+    if focus.is_some_and(|focus| focus.get() == Some(entity)) {
+        return false;
+    }
+
+    let Ok(mut editable_text) = q_number_input.get_mut(entity) else {
+        return false;
+    };
+
+    queue_number_input_value_update(entity, value, &mut editable_text, commands)
+}
+
+/// Plugin that adds observers for [`NumberInput`].
+pub struct NumberInputPlugin;
+
+impl Plugin for NumberInputPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_observer(number_input_on_insert)
+            .add_observer(number_input_on_text_change)
+            .add_observer(number_input_on_submit_key)
+            .add_observer(number_input_on_focus_loss)
+            .add_observer(number_input_on_set_value);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy_app::App;
+    use bevy_ecs::{observer::On, prelude::*};
+    use bevy_input::{
+        keyboard::{Key, KeyCode, KeyboardInput},
+        ButtonState, InputPlugin,
+    };
+    use bevy_input_focus::{FocusLost, InputDispatchPlugin, InputFocus, InputFocusPlugin};
+    use bevy_window::{PrimaryWindow, Window};
+
+    #[derive(Resource, Default)]
+    struct NumberInputEvents(Vec<(Entity, f32, bool)>);
+
+    fn keyboard_input(key_code: KeyCode) -> KeyboardInput {
+        KeyboardInput {
+            key_code,
+            logical_key: match key_code {
+                KeyCode::Enter => Key::Enter,
+                _ => unreachable!(),
+            },
+            state: ButtonState::Pressed,
+            text: None,
+            repeat: false,
+            window: Entity::PLACEHOLDER,
+        }
+    }
+
+    #[test]
+    fn number_input_parses_values() {
+        assert_eq!(
+            NumberFormat::F32.parse("1.5"),
+            Ok(NumberInputValue::F32(1.5))
+        );
+        assert_eq!(NumberFormat::I32.parse("-7"), Ok(NumberInputValue::I32(-7)));
+        assert_eq!(
+            NumberFormat::I32.parse("1.5"),
+            Err(NumberInputParseError::InvalidInteger)
+        );
+        assert_eq!(
+            NumberFormat::I32.parse(" "),
+            Err(NumberInputParseError::Empty)
+        );
+    }
+
+    #[test]
+    fn focus_loss_emits_final_value_change() {
+        let mut app = App::new();
+        app.init_resource::<NumberInputEvents>()
+            .add_plugins(NumberInputPlugin)
+            .add_observer(
+                |change: On<ValueChange<f32>>, mut events: ResMut<NumberInputEvents>| {
+                    events
+                        .0
+                        .push((change.source, change.value, change.is_final));
+                },
+            );
+
+        let entity = app
+            .world_mut()
+            .spawn((NumberInput::default(), EditableText::new("12.5")))
+            .id();
+
+        app.world_mut().commands().trigger(FocusLost { entity });
+        app.update();
+
+        assert_eq!(
+            app.world().resource::<NumberInputEvents>().0,
+            vec![(entity, 12.5, true)]
+        );
+    }
+
+    #[test]
+    fn enter_key_emits_final_value_change() {
+        let mut app = App::new();
+        app.init_resource::<NumberInputEvents>()
+            .add_plugins((
+                InputPlugin,
+                InputFocusPlugin,
+                InputDispatchPlugin,
+                NumberInputPlugin,
+            ))
+            .add_observer(
+                |change: On<ValueChange<f32>>, mut events: ResMut<NumberInputEvents>| {
+                    events
+                        .0
+                        .push((change.source, change.value, change.is_final));
+                },
+            );
+        app.world_mut().spawn((Window::default(), PrimaryWindow));
+        app.update();
+
+        let entity = app
+            .world_mut()
+            .spawn((NumberInput::default(), EditableText::new("7.25")))
+            .id();
+        app.world_mut()
+            .insert_resource(InputFocus::from_entity(entity));
+
+        app.world_mut()
+            .write_message(keyboard_input(KeyCode::Enter))
+            .unwrap();
+        app.update();
+
+        assert_eq!(
+            app.world().resource::<NumberInputEvents>().0,
+            vec![(entity, 7.25, true)]
+        );
+    }
+
+    #[test]
+    fn invalid_focus_loss_does_not_emit_value_change() {
+        let mut app = App::new();
+        app.init_resource::<NumberInputEvents>()
+            .add_plugins(NumberInputPlugin)
+            .add_observer(
+                |change: On<ValueChange<f32>>, mut events: ResMut<NumberInputEvents>| {
+                    events
+                        .0
+                        .push((change.source, change.value, change.is_final));
+                },
+            );
+
+        let entity = app
+            .world_mut()
+            .spawn((NumberInput::default(), EditableText::new("abc")))
+            .id();
+
+        app.world_mut().commands().trigger(FocusLost { entity });
+        app.update();
+
+        assert!(app.world().resource::<NumberInputEvents>().0.is_empty());
+    }
+
+    #[test]
+    fn set_number_input_value_marks_unfocused_input_for_refresh() {
+        let mut app = App::new();
+        app.add_plugins(NumberInputPlugin);
+
+        let entity = app
+            .world_mut()
+            .spawn((
+                NumberInput {
+                    format: NumberFormat::I32,
+                },
+                EditableText::new("4"),
+            ))
+            .id();
+
+        app.world_mut().commands().trigger(SetNumberInputValue {
+            entity,
+            value: NumberInputValue::I32(9),
+        });
+        app.update();
+
+        assert!(app
+            .world()
+            .entity(entity)
+            .contains::<IgnoreNextNumberInputChange>());
+    }
+
+    #[test]
+    fn set_number_input_value_ignores_focused_input() {
+        let mut app = App::new();
+        app.add_plugins(NumberInputPlugin);
+
+        let entity = app
+            .world_mut()
+            .spawn((
+                NumberInput {
+                    format: NumberFormat::I32,
+                },
+                EditableText::new("4"),
+            ))
+            .id();
+        app.world_mut()
+            .insert_resource(InputFocus::from_entity(entity));
+
+        app.world_mut().commands().trigger(SetNumberInputValue {
+            entity,
+            value: NumberInputValue::I32(9),
+        });
+        app.update();
+
+        assert!(!app
+            .world()
+            .entity(entity)
+            .contains::<IgnoreNextNumberInputChange>());
+    }
+}

--- a/crates/bevy_ui_widgets/src/numeric_spinbox.rs
+++ b/crates/bevy_ui_widgets/src/numeric_spinbox.rs
@@ -1,0 +1,519 @@
+use bevy_app::{App, Plugin};
+use bevy_ecs::{
+    component::Component,
+    entity::Entity,
+    event::EntityEvent,
+    hierarchy::{ChildOf, Children},
+    observer::On,
+    query::With,
+    system::{Commands, Query, Res},
+};
+use bevy_input_focus::InputFocus;
+use bevy_log::warn;
+use bevy_text::EditableText;
+
+use crate::{
+    number_input::{
+        queue_number_input_value_update, queue_number_input_value_update_if_unfocused, NumberInput,
+        NumberInputParseError, NumberInputValue,
+    },
+    spinbox::find_spinbox_ancestor,
+    SpinBox, SpinBoxButtonPress, SpinBoxDirection, ValueChange,
+};
+
+/// Marks the descendant [`NumberInput`] used as the numeric value field of a [`SpinBox`].
+#[derive(Component, Debug, Default, Clone, Copy)]
+#[require(NumberInput)]
+pub struct NumberSpinBoxValueInput;
+
+/// Optional custom numeric step size for a [`SpinBox`].
+#[derive(Component, Debug, Clone, Copy)]
+pub struct NumberSpinBoxStep(pub NumberInputValue);
+
+/// Programmatically replace the displayed value of a numeric spinbox.
+///
+/// Like [`crate::SetNumberInputValue`], the update is ignored if the embedded number input
+/// currently has focus.
+#[derive(Clone, EntityEvent)]
+pub struct SetNumberSpinBoxValue {
+    /// The target spinbox.
+    #[event_target]
+    pub entity: Entity,
+    /// The value to display.
+    pub value: NumberInputValue,
+}
+
+fn find_number_spinbox_value_input(
+    spinbox: Entity,
+    q_children: &Query<&Children>,
+    mut has_value_input: impl FnMut(Entity) -> bool,
+) -> Option<Entity> {
+    q_children
+        .iter_descendants(spinbox)
+        .find(|child| has_value_input(*child))
+}
+
+fn number_spinbox_on_button_press(
+    press: On<SpinBoxButtonPress>,
+    q_spinbox: Query<Option<&NumberSpinBoxStep>, With<SpinBox>>,
+    q_children: Query<&Children>,
+    mut q_value_input: Query<
+        (Entity, &NumberInput, &mut EditableText),
+        With<NumberSpinBoxValueInput>,
+    >,
+    mut commands: Commands,
+) {
+    let Some(input_entity) = find_number_spinbox_value_input(press.entity, &q_children, |child| {
+        q_value_input.contains(child)
+    }) else {
+        return;
+    };
+
+    let Ok((_, number_input, mut editable_text)) = q_value_input.get_mut(input_entity) else {
+        return;
+    };
+
+    let current_value = match number_input
+        .format
+        .parse(&editable_text.value().to_string())
+    {
+        Ok(value) => value,
+        Err(NumberInputParseError::Empty) => {
+            warn!("SpinBox cannot step an empty numeric input");
+            return;
+        }
+        Err(error) => {
+            warn!("SpinBox cannot step invalid input: {error}");
+            return;
+        }
+    };
+
+    let step = q_spinbox
+        .get(press.entity)
+        .ok()
+        .flatten()
+        .map(|step| step.0)
+        .unwrap_or(NumberInputValue::one_for(number_input.format));
+
+    let next_value =
+        match current_value.adjust(step, press.direction == SpinBoxDirection::Increment) {
+            Ok(value) => value,
+            Err(error) => {
+                warn!("SpinBox step ignored: {error}");
+                return;
+            }
+        };
+
+    queue_number_input_value_update(input_entity, next_value, &mut editable_text, &mut commands);
+    next_value.emit(press.entity, true, &mut commands);
+}
+
+fn number_spinbox_on_set_value(
+    set_value: On<SetNumberSpinBoxValue>,
+    q_spinbox: Query<(), With<SpinBox>>,
+    q_children: Query<&Children>,
+    q_value_input: Query<Entity, With<NumberSpinBoxValueInput>>,
+    mut q_number_input: Query<&mut EditableText, With<NumberInput>>,
+    focus: Option<Res<InputFocus>>,
+    mut commands: Commands,
+) {
+    if !q_spinbox.contains(set_value.event_target()) {
+        return;
+    }
+
+    let Some(input_entity) =
+        find_number_spinbox_value_input(set_value.event_target(), &q_children, |child| {
+            q_value_input.contains(child)
+        })
+    else {
+        return;
+    };
+
+    queue_number_input_value_update_if_unfocused(
+        input_entity,
+        set_value.value,
+        &mut q_number_input,
+        focus.as_deref(),
+        &mut commands,
+    );
+}
+
+macro_rules! number_spinbox_forward_value_change {
+    ($name:ident, $ty:ty) => {
+        fn $name(
+            change: On<ValueChange<$ty>>,
+            q_value_input: Query<(), With<NumberSpinBoxValueInput>>,
+            q_parent: Query<&ChildOf>,
+            q_spinbox: Query<(), With<SpinBox>>,
+            mut commands: Commands,
+        ) {
+            if !q_value_input.contains(change.source) {
+                return;
+            }
+
+            let Some(spinbox) = find_spinbox_ancestor(change.source, &q_parent, &q_spinbox) else {
+                return;
+            };
+
+            commands.trigger(ValueChange {
+                source: spinbox,
+                value: change.value,
+                is_final: change.is_final,
+            });
+        }
+    };
+}
+
+number_spinbox_forward_value_change!(number_spinbox_on_number_change_f32, f32);
+number_spinbox_forward_value_change!(number_spinbox_on_number_change_f64, f64);
+number_spinbox_forward_value_change!(number_spinbox_on_number_change_i32, i32);
+number_spinbox_forward_value_change!(number_spinbox_on_number_change_i64, i64);
+
+/// Plugin that adds observers for the composed numeric [`SpinBox`] behavior.
+pub struct NumericSpinBoxPlugin;
+
+impl Plugin for NumericSpinBoxPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_observer(number_spinbox_on_button_press)
+            .add_observer(number_spinbox_on_set_value)
+            .add_observer(number_spinbox_on_number_change_f32)
+            .add_observer(number_spinbox_on_number_change_f64)
+            .add_observer(number_spinbox_on_number_change_i32)
+            .add_observer(number_spinbox_on_number_change_i64);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy_app::App;
+    use bevy_ecs::{observer::On, prelude::*};
+    use bevy_input::{
+        keyboard::{Key, KeyCode, KeyboardInput},
+        ButtonState, InputPlugin,
+    };
+    use bevy_input_focus::{InputDispatchPlugin, InputFocus, InputFocusPlugin};
+    use bevy_window::{PrimaryWindow, Window};
+
+    use crate::{
+        number_input::{IgnoreNextNumberInputChange, NumberInputAdjustError},
+        NumberFormat,
+    };
+
+    #[derive(Resource, Default)]
+    struct NumberSpinBoxEvents(Vec<(Entity, i32, bool)>);
+
+    fn keyboard_input(key_code: KeyCode) -> KeyboardInput {
+        KeyboardInput {
+            key_code,
+            logical_key: match key_code {
+                KeyCode::ArrowUp => Key::ArrowUp,
+                KeyCode::ArrowDown => Key::ArrowDown,
+                KeyCode::ArrowLeft => Key::ArrowLeft,
+                KeyCode::ArrowRight => Key::ArrowRight,
+                _ => unreachable!(),
+            },
+            state: ButtonState::Pressed,
+            text: None,
+            repeat: false,
+            window: Entity::PLACEHOLDER,
+        }
+    }
+
+    #[test]
+    fn integer_adjust_rejects_float_steps() {
+        assert_eq!(
+            NumberInputValue::I32(3).adjust(NumberInputValue::F32(0.5), true),
+            Err(NumberInputAdjustError::IntegerStepRequired)
+        );
+    }
+
+    #[test]
+    fn set_number_spinbox_value_marks_unfocused_embedded_input() {
+        let mut app = App::new();
+        app.add_plugins((crate::NumberInputPlugin, NumericSpinBoxPlugin));
+
+        let spinbox = app.world_mut().spawn(SpinBox).id();
+        let value_input = app
+            .world_mut()
+            .spawn((
+                NumberInput {
+                    format: NumberFormat::I32,
+                },
+                NumberSpinBoxValueInput,
+                EditableText::new("4"),
+                ChildOf(spinbox),
+            ))
+            .id();
+
+        app.world_mut().commands().trigger(SetNumberSpinBoxValue {
+            entity: spinbox,
+            value: NumberInputValue::I32(8),
+        });
+        app.update();
+
+        assert!(app
+            .world()
+            .entity(value_input)
+            .contains::<IgnoreNextNumberInputChange>());
+    }
+
+    #[test]
+    fn set_number_spinbox_value_ignores_focused_embedded_input() {
+        let mut app = App::new();
+        app.add_plugins((crate::NumberInputPlugin, NumericSpinBoxPlugin));
+
+        let spinbox = app.world_mut().spawn(SpinBox).id();
+        let value_input = app
+            .world_mut()
+            .spawn((
+                NumberInput {
+                    format: NumberFormat::I32,
+                },
+                NumberSpinBoxValueInput,
+                EditableText::new("4"),
+                ChildOf(spinbox),
+            ))
+            .id();
+        app.world_mut()
+            .insert_resource(InputFocus::from_entity(value_input));
+
+        app.world_mut().commands().trigger(SetNumberSpinBoxValue {
+            entity: spinbox,
+            value: NumberInputValue::I32(8),
+        });
+        app.update();
+
+        assert!(!app
+            .world()
+            .entity(value_input)
+            .contains::<IgnoreNextNumberInputChange>());
+    }
+
+    #[test]
+    fn number_spinbox_steps_and_emits_from_root() {
+        let mut app = App::new();
+        app.init_resource::<NumberSpinBoxEvents>()
+            .add_plugins((
+                crate::ButtonPlugin,
+                crate::SpinBoxPlugin,
+                crate::NumberInputPlugin,
+                NumericSpinBoxPlugin,
+            ))
+            .add_observer(
+                |change: On<ValueChange<i32>>, mut events: ResMut<NumberSpinBoxEvents>| {
+                    events
+                        .0
+                        .push((change.source, change.value, change.is_final));
+                },
+            );
+
+        let spinbox = app.world_mut().spawn(SpinBox).id();
+        let value_input = app
+            .world_mut()
+            .spawn((
+                NumberInput {
+                    format: NumberFormat::I32,
+                },
+                NumberSpinBoxValueInput,
+                EditableText::new("4"),
+                ChildOf(spinbox),
+            ))
+            .id();
+        let increment = app
+            .world_mut()
+            .spawn((crate::SpinBoxIncrementButton, ChildOf(spinbox)))
+            .id();
+
+        app.world_mut()
+            .commands()
+            .trigger(crate::Activate { entity: increment });
+        app.update();
+
+        assert_eq!(
+            app.world().resource::<NumberSpinBoxEvents>().0,
+            vec![(spinbox, 5, true)]
+        );
+        assert!(app.world().entity(value_input).contains::<NumberInput>());
+    }
+
+    #[test]
+    fn number_spinbox_forwards_number_input_changes() {
+        let mut app = App::new();
+        app.init_resource::<NumberSpinBoxEvents>()
+            .add_plugins((crate::SpinBoxPlugin, NumericSpinBoxPlugin))
+            .add_observer(
+                |change: On<ValueChange<i32>>, mut events: ResMut<NumberSpinBoxEvents>| {
+                    events
+                        .0
+                        .push((change.source, change.value, change.is_final));
+                },
+            );
+
+        let spinbox = app.world_mut().spawn(SpinBox).id();
+        let value_input = app
+            .world_mut()
+            .spawn((
+                NumberInput {
+                    format: NumberFormat::I32,
+                },
+                NumberSpinBoxValueInput,
+                EditableText::new("7"),
+                ChildOf(spinbox),
+            ))
+            .id();
+
+        app.world_mut().commands().trigger(ValueChange {
+            source: value_input,
+            value: 8_i32,
+            is_final: false,
+        });
+        app.update();
+
+        assert!(app
+            .world()
+            .resource::<NumberSpinBoxEvents>()
+            .0
+            .contains(&(spinbox, 8, false)));
+    }
+
+    #[test]
+    fn number_spinbox_forwards_nested_number_input_changes() {
+        let mut app = App::new();
+        app.init_resource::<NumberSpinBoxEvents>()
+            .add_plugins((crate::SpinBoxPlugin, NumericSpinBoxPlugin))
+            .add_observer(
+                |change: On<ValueChange<i32>>, mut events: ResMut<NumberSpinBoxEvents>| {
+                    events
+                        .0
+                        .push((change.source, change.value, change.is_final));
+                },
+            );
+
+        let spinbox = app.world_mut().spawn(SpinBox).id();
+        let wrapper = app.world_mut().spawn(ChildOf(spinbox)).id();
+        let value_input = app
+            .world_mut()
+            .spawn((
+                NumberInput {
+                    format: NumberFormat::I32,
+                },
+                NumberSpinBoxValueInput,
+                EditableText::new("7"),
+                ChildOf(wrapper),
+            ))
+            .id();
+
+        app.world_mut().commands().trigger(ValueChange {
+            source: value_input,
+            value: 8_i32,
+            is_final: false,
+        });
+        app.update();
+
+        assert!(app
+            .world()
+            .resource::<NumberSpinBoxEvents>()
+            .0
+            .contains(&(spinbox, 8, false)));
+    }
+
+    #[test]
+    fn number_spinbox_uses_custom_step_value() {
+        let mut app = App::new();
+        app.init_resource::<NumberSpinBoxEvents>()
+            .add_plugins((
+                crate::ButtonPlugin,
+                crate::SpinBoxPlugin,
+                crate::NumberInputPlugin,
+                NumericSpinBoxPlugin,
+            ))
+            .add_observer(
+                |change: On<ValueChange<i32>>, mut events: ResMut<NumberSpinBoxEvents>| {
+                    events
+                        .0
+                        .push((change.source, change.value, change.is_final));
+                },
+            );
+
+        let spinbox = app
+            .world_mut()
+            .spawn((SpinBox, NumberSpinBoxStep(NumberInputValue::I32(2))))
+            .id();
+        let _value_input = app.world_mut().spawn((
+            NumberInput {
+                format: NumberFormat::I32,
+            },
+            NumberSpinBoxValueInput,
+            EditableText::new("4"),
+            ChildOf(spinbox),
+        ));
+        let increment = app
+            .world_mut()
+            .spawn((crate::SpinBoxIncrementButton, ChildOf(spinbox)))
+            .id();
+
+        app.world_mut()
+            .commands()
+            .trigger(crate::Activate { entity: increment });
+        app.update();
+
+        assert_eq!(
+            app.world().resource::<NumberSpinBoxEvents>().0,
+            vec![(spinbox, 6, true)]
+        );
+    }
+
+    #[test]
+    fn focused_number_input_arrow_key_steps_spinbox() {
+        let mut app = App::new();
+        app.init_resource::<NumberSpinBoxEvents>()
+            .init_resource::<bevy_ui::UiScale>()
+            .add_message::<bevy_window::Ime>()
+            .add_message::<bevy_picking::events::Pointer<bevy_picking::events::Release>>()
+            .add_plugins((
+                InputPlugin,
+                InputFocusPlugin,
+                InputDispatchPlugin,
+                crate::EditableTextInputPlugin,
+                crate::SpinBoxPlugin,
+                crate::NumberInputPlugin,
+                NumericSpinBoxPlugin,
+            ))
+            .add_observer(
+                |change: On<ValueChange<i32>>, mut events: ResMut<NumberSpinBoxEvents>| {
+                    events
+                        .0
+                        .push((change.source, change.value, change.is_final));
+                },
+            );
+        app.world_mut().spawn((Window::default(), PrimaryWindow));
+        app.update();
+
+        let spinbox = app.world_mut().spawn(SpinBox).id();
+        let value_input = app
+            .world_mut()
+            .spawn((
+                NumberInput {
+                    format: NumberFormat::I32,
+                },
+                NumberSpinBoxValueInput,
+                EditableText::new("4"),
+                ChildOf(spinbox),
+            ))
+            .id();
+        app.world_mut()
+            .insert_resource(InputFocus::from_entity(value_input));
+
+        app.world_mut()
+            .write_message(keyboard_input(KeyCode::ArrowRight))
+            .unwrap();
+        app.update();
+
+        assert!(app
+            .world()
+            .resource::<NumberSpinBoxEvents>()
+            .0
+            .contains(&(spinbox, 5, true)));
+    }
+}

--- a/crates/bevy_ui_widgets/src/spinbox.rs
+++ b/crates/bevy_ui_widgets/src/spinbox.rs
@@ -1,0 +1,289 @@
+use bevy_app::{App, Plugin};
+use bevy_ecs::{
+    component::Component,
+    entity::Entity,
+    event::EntityEvent,
+    hierarchy::ChildOf,
+    observer::On,
+    query::With,
+    relationship::Relationship,
+    system::{Commands, Query},
+};
+use bevy_input::keyboard::{KeyCode, KeyboardInput};
+use bevy_input::ButtonState;
+use bevy_input_focus::FocusedInput;
+
+use crate::{Activate, Button};
+
+/// Headless spinbox container.
+///
+/// A spinbox composes increment and decrement buttons and emits direction intent from the spinbox
+/// root. It does not assume a particular value type or editing surface.
+///
+/// ```ignore
+/// use bevy_ecs::prelude::*;
+/// use bevy_ui_widgets::{
+///     SpinBox, SpinBoxButtonPress, SpinBoxDecrementButton, SpinBoxDirection,
+///     SpinBoxIncrementButton,
+/// };
+///
+/// let spinbox = commands.spawn(SpinBox).id();
+/// commands.spawn((SpinBoxDecrementButton, ChildOf(spinbox)));
+/// commands.spawn((SpinBoxIncrementButton, ChildOf(spinbox)));
+///
+/// commands.entity(spinbox).observe(|press: On<SpinBoxButtonPress>| match press.direction {
+///     SpinBoxDirection::Increment => info!("next"),
+///     SpinBoxDirection::Decrement => info!("previous"),
+/// });
+/// ```
+#[derive(Component, Debug, Default, Clone, Copy)]
+pub struct SpinBox;
+
+/// The direction requested by a spinbox button activation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpinBoxDirection {
+    /// Move to the next value.
+    Increment,
+    /// Move to the previous value.
+    Decrement,
+}
+
+/// Marks the increment button of a [`SpinBox`].
+#[derive(Component, Debug, Default, Clone, Copy)]
+#[require(Button)]
+pub struct SpinBoxIncrementButton;
+
+/// Marks the decrement button of a [`SpinBox`].
+#[derive(Component, Debug, Default, Clone, Copy)]
+#[require(Button)]
+pub struct SpinBoxDecrementButton;
+
+/// Emitted when one of a spinbox's buttons is activated.
+///
+/// This always targets the [`SpinBox`] root entity, so apps can use it for arbitrary value
+/// domains such as enums or wrap it with more specialized adapters.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, EntityEvent)]
+pub struct SpinBoxButtonPress {
+    /// The spinbox entity.
+    #[event_target]
+    pub entity: Entity,
+    /// The requested direction.
+    pub direction: SpinBoxDirection,
+}
+
+pub(crate) fn spinbox_direction_for_key(key_code: KeyCode) -> Option<SpinBoxDirection> {
+    match key_code {
+        KeyCode::ArrowUp | KeyCode::ArrowRight => Some(SpinBoxDirection::Increment),
+        KeyCode::ArrowDown | KeyCode::ArrowLeft => Some(SpinBoxDirection::Decrement),
+        _ => None,
+    }
+}
+
+fn spinbox_on_activate(
+    activate: On<Activate>,
+    q_increment: Query<(), With<SpinBoxIncrementButton>>,
+    q_decrement: Query<(), With<SpinBoxDecrementButton>>,
+    q_parent: Query<&ChildOf>,
+    q_spinbox: Query<(), With<SpinBox>>,
+    mut commands: Commands,
+) {
+    let button = activate.event_target();
+    let direction = if q_increment.contains(button) {
+        SpinBoxDirection::Increment
+    } else if q_decrement.contains(button) {
+        SpinBoxDirection::Decrement
+    } else {
+        return;
+    };
+
+    let Some(spinbox) = find_spinbox_ancestor(button, &q_parent, &q_spinbox) else {
+        return;
+    };
+
+    commands.trigger(SpinBoxButtonPress {
+        entity: spinbox,
+        direction,
+    });
+}
+
+fn spinbox_on_key_input(
+    mut key_input: On<FocusedInput<KeyboardInput>>,
+    q_spinbox: Query<(), With<SpinBox>>,
+    q_parent: Query<&ChildOf>,
+    mut commands: Commands,
+) {
+    let input_event = &key_input.input;
+    if input_event.state != ButtonState::Pressed || input_event.repeat {
+        return;
+    }
+
+    let Some(direction) = spinbox_direction_for_key(input_event.key_code) else {
+        return;
+    };
+
+    let spinbox = if q_spinbox.contains(key_input.focused_entity) {
+        Some(key_input.focused_entity)
+    } else {
+        find_spinbox_ancestor(key_input.focused_entity, &q_parent, &q_spinbox)
+    };
+
+    let Some(spinbox) = spinbox else {
+        return;
+    };
+
+    key_input.propagate(false);
+    commands.trigger(SpinBoxButtonPress {
+        entity: spinbox,
+        direction,
+    });
+}
+
+pub(crate) fn find_spinbox_ancestor(
+    entity: Entity,
+    q_parent: &Query<&ChildOf>,
+    q_spinbox: &Query<(), With<SpinBox>>,
+) -> Option<Entity> {
+    let mut current = entity;
+    while let Ok(parent) = q_parent.get(current) {
+        let parent = parent.get();
+        if q_spinbox.contains(parent) {
+            return Some(parent);
+        }
+        current = parent;
+    }
+    None
+}
+
+/// Plugin that adds observers for [`SpinBox`].
+pub struct SpinBoxPlugin;
+
+impl Plugin for SpinBoxPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_observer(spinbox_on_activate)
+            .add_observer(spinbox_on_key_input);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bevy_app::App;
+    use bevy_ecs::{observer::On, prelude::*};
+    use bevy_input::{
+        keyboard::{Key, KeyboardInput},
+        ButtonState, InputPlugin,
+    };
+    use bevy_input_focus::{InputDispatchPlugin, InputFocus, InputFocusPlugin};
+    use bevy_window::{PrimaryWindow, Window};
+
+    use super::*;
+
+    #[derive(Resource, Default)]
+    struct SpinBoxDirections(Vec<(Entity, SpinBoxDirection)>);
+
+    fn keyboard_input(key_code: KeyCode) -> KeyboardInput {
+        KeyboardInput {
+            key_code,
+            logical_key: match key_code {
+                KeyCode::ArrowUp => Key::ArrowUp,
+                KeyCode::ArrowDown => Key::ArrowDown,
+                KeyCode::ArrowLeft => Key::ArrowLeft,
+                KeyCode::ArrowRight => Key::ArrowRight,
+                _ => unreachable!(),
+            },
+            state: ButtonState::Pressed,
+            text: None,
+            repeat: false,
+            window: Entity::PLACEHOLDER,
+        }
+    }
+
+    #[test]
+    fn spinbox_emits_increment_button_press_from_root() {
+        let mut app = App::new();
+        app.init_resource::<SpinBoxDirections>()
+            .add_plugins((crate::ButtonPlugin, SpinBoxPlugin))
+            .add_observer(
+                |press: On<SpinBoxButtonPress>, mut directions: ResMut<SpinBoxDirections>| {
+                    directions.0.push((press.entity, press.direction));
+                },
+            );
+
+        let spinbox = app.world_mut().spawn(SpinBox).id();
+        let increment = app
+            .world_mut()
+            .spawn((SpinBoxIncrementButton, ChildOf(spinbox)))
+            .id();
+
+        app.world_mut()
+            .commands()
+            .trigger(Activate { entity: increment });
+        app.update();
+
+        assert_eq!(
+            app.world().resource::<SpinBoxDirections>().0,
+            vec![(spinbox, SpinBoxDirection::Increment)]
+        );
+    }
+
+    #[test]
+    fn spinbox_emits_decrement_button_press_without_value_input() {
+        let mut app = App::new();
+        app.init_resource::<SpinBoxDirections>()
+            .add_plugins((crate::ButtonPlugin, SpinBoxPlugin))
+            .add_observer(
+                |press: On<SpinBoxButtonPress>, mut directions: ResMut<SpinBoxDirections>| {
+                    directions.0.push((press.entity, press.direction));
+                },
+            );
+
+        let spinbox = app.world_mut().spawn(SpinBox).id();
+        let decrement = app
+            .world_mut()
+            .spawn((SpinBoxDecrementButton, ChildOf(spinbox)))
+            .id();
+
+        app.world_mut()
+            .commands()
+            .trigger(Activate { entity: decrement });
+        app.update();
+
+        assert_eq!(
+            app.world().resource::<SpinBoxDirections>().0,
+            vec![(spinbox, SpinBoxDirection::Decrement)]
+        );
+    }
+
+    #[test]
+    fn spinbox_emits_button_press_for_focused_descendant_arrow_keys() {
+        let mut app = App::new();
+        app.init_resource::<SpinBoxDirections>()
+            .add_plugins((
+                InputPlugin,
+                InputFocusPlugin,
+                InputDispatchPlugin,
+                SpinBoxPlugin,
+            ))
+            .add_observer(
+                |press: On<SpinBoxButtonPress>, mut directions: ResMut<SpinBoxDirections>| {
+                    directions.0.push((press.entity, press.direction));
+                },
+            );
+        app.world_mut().spawn((Window::default(), PrimaryWindow));
+        app.update();
+
+        let spinbox = app.world_mut().spawn(SpinBox).id();
+        let focused_child = app.world_mut().spawn(ChildOf(spinbox)).id();
+        app.world_mut()
+            .insert_resource(InputFocus::from_entity(focused_child));
+
+        app.world_mut()
+            .write_message(keyboard_input(KeyCode::ArrowRight))
+            .unwrap();
+        app.update();
+
+        assert_eq!(
+            app.world().resource::<SpinBoxDirections>().0,
+            vec![(spinbox, SpinBoxDirection::Increment)]
+        );
+    }
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -622,6 +622,7 @@ Example | Description
 [Scroll](../examples/ui/scroll_and_overflow/scroll.rs) | Demonstrates scrolling UI containers
 [Scrollbars](../examples/ui/scroll_and_overflow/scrollbars.rs) | Demonstrates use of core scrollbar in Bevy UI
 [Size Constraints](../examples/ui/layout/size_constraints.rs) | Demonstrates how the to use the size constraints to control the size of a UI node.
+[Spinbox Months](../examples/ui/widgets/spinbox_months.rs) | Demonstrates using the headless spinbox with a Month enum and a non-editable text field
 [Stacked Gradients](../examples/ui/styling/stacked_gradients.rs) | An example demonstrating stacked gradients
 [Standard Widgets](../examples/ui/widgets/standard_widgets.rs) | Demonstrates use of core (headless) widgets in Bevy UI
 [Standard Widgets (w/Observers)](../examples/ui/widgets/standard_widgets_observers.rs) | Demonstrates use of core (headless) widgets in Bevy UI, with Observers

--- a/examples/ui/widgets/spinbox_months.rs
+++ b/examples/ui/widgets/spinbox_months.rs
@@ -1,0 +1,223 @@
+//! Demonstrates using the headless [`SpinBox`](bevy::ui_widgets::SpinBox) with a non-numeric
+//! value type by cycling through a `Month` enum.
+
+use bevy::{
+    ecs::relationship::Relationship,
+    input_focus::{
+        tab_navigation::{TabGroup, TabIndex, TabNavigationPlugin},
+        InputFocus,
+    },
+    picking::hover::Hovered,
+    prelude::*,
+    ui_widgets::{
+        observe, Button, SpinBox, SpinBoxButtonPress, SpinBoxDecrementButton, SpinBoxDirection,
+        SpinBoxIncrementButton,
+    },
+};
+
+fn main() {
+    App::new()
+        .add_plugins((DefaultPlugins, TabNavigationPlugin))
+        .init_resource::<InputFocus>()
+        .add_systems(Startup, setup)
+        .add_systems(Update, (update_button_style, update_month_display))
+        .run();
+}
+
+const NORMAL_BUTTON: Color = Color::srgb(0.15, 0.15, 0.15);
+const HOVERED_BUTTON: Color = Color::srgb(0.25, 0.25, 0.25);
+
+#[derive(Component)]
+struct MonthSpinBox;
+
+#[derive(Component)]
+struct MonthDisplay;
+
+#[derive(Component)]
+struct DemoButton;
+
+#[derive(Component, Clone, Copy)]
+struct MonthValue(Month);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Month {
+    January,
+    February,
+    March,
+    April,
+    May,
+    June,
+    July,
+    August,
+    September,
+    October,
+    November,
+    December,
+}
+
+impl Month {
+    const ALL: [Self; 12] = [
+        Self::January,
+        Self::February,
+        Self::March,
+        Self::April,
+        Self::May,
+        Self::June,
+        Self::July,
+        Self::August,
+        Self::September,
+        Self::October,
+        Self::November,
+        Self::December,
+    ];
+
+    fn advance(self, direction: SpinBoxDirection) -> Self {
+        let index = Self::ALL.iter().position(|month| *month == self).unwrap();
+        let next = match direction {
+            SpinBoxDirection::Increment => (index + 1) % Self::ALL.len(),
+            SpinBoxDirection::Decrement => (index + Self::ALL.len() - 1) % Self::ALL.len(),
+        };
+        Self::ALL[next]
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::January => "January",
+            Self::February => "February",
+            Self::March => "March",
+            Self::April => "April",
+            Self::May => "May",
+            Self::June => "June",
+            Self::July => "July",
+            Self::August => "August",
+            Self::September => "September",
+            Self::October => "October",
+            Self::November => "November",
+            Self::December => "December",
+        }
+    }
+}
+
+fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    commands.spawn(Camera2d);
+
+    commands.spawn((
+        Node {
+            width: percent(100),
+            height: percent(100),
+            justify_content: JustifyContent::Center,
+            align_items: AlignItems::Center,
+            ..default()
+        },
+        TabGroup::default(),
+        children![(
+            Node {
+                width: px(220),
+                height: px(54),
+                padding: UiRect::all(px(4)),
+                border: UiRect::all(px(2)),
+                column_gap: px(6),
+                justify_content: JustifyContent::SpaceBetween,
+                align_items: AlignItems::Center,
+                ..default()
+            },
+            BorderColor::all(Color::WHITE),
+            BackgroundColor(Color::BLACK),
+            MonthSpinBox,
+            MonthValue(Month::January),
+            SpinBox,
+            TabIndex(0),
+            observe(
+                |press: On<SpinBoxButtonPress>,
+                 mut spinboxes: Query<&mut MonthValue, With<MonthSpinBox>>| {
+                    if let Ok(mut month) = spinboxes.get_mut(press.entity) {
+                        month.0 = month.0.advance(press.direction);
+                    }
+                },
+            ),
+            children![
+                (
+                    Node {
+                        flex_grow: 1.0,
+                        padding: UiRect::horizontal(px(10)),
+                        border: UiRect::all(px(1)),
+                        align_items: AlignItems::Center,
+                        ..default()
+                    },
+                    BorderColor::all(Color::srgb(0.3, 0.3, 0.3)),
+                    BackgroundColor(Color::srgb(0.08, 0.08, 0.08)),
+                    MonthDisplay,
+                    Text::new(Month::January.label()),
+                    TextFont {
+                        font: asset_server.load("fonts/FiraSans-Bold.ttf").into(),
+                        font_size: FontSize::Px(24.0),
+                        ..default()
+                    },
+                    TextColor(Color::WHITE),
+                ),
+                (
+                    Node {
+                        width: px(36),
+                        height: percent(100),
+                        flex_direction: FlexDirection::Column,
+                        row_gap: px(4),
+                        ..default()
+                    },
+                    children![
+                        demo_button("+", SpinBoxIncrementButton),
+                        demo_button("-", SpinBoxDecrementButton),
+                    ],
+                ),
+            ],
+        )],
+    ));
+}
+
+fn demo_button<M: Bundle>(label: &'static str, marker: M) -> impl Bundle {
+    (
+        DemoButton,
+        marker,
+        Button,
+        Hovered::default(),
+        Node {
+            flex_grow: 1.0,
+            justify_content: JustifyContent::Center,
+            align_items: AlignItems::Center,
+            border: UiRect::all(px(1)),
+            ..default()
+        },
+        BorderColor::all(Color::WHITE),
+        BackgroundColor(NORMAL_BUTTON),
+        children![(
+            Text::new(label),
+            TextFont {
+                font_size: FontSize::Px(18.0),
+                ..default()
+            },
+            TextColor(Color::WHITE),
+        )],
+    )
+}
+
+fn update_button_style(
+    mut buttons: Query<(&Hovered, &mut BackgroundColor), (With<DemoButton>, Changed<Hovered>)>,
+) {
+    for (hovered, mut background) in &mut buttons {
+        background.0 = if hovered.0 {
+            HOVERED_BUTTON
+        } else {
+            NORMAL_BUTTON
+        };
+    }
+}
+
+fn update_month_display(
+    spinboxes: Query<&MonthValue, (With<MonthSpinBox>, Changed<MonthValue>)>,
+    mut displays: Query<(&ChildOf, &mut Text), With<MonthDisplay>>,
+) {
+    for (parent, mut text) in &mut displays {
+        if let Ok(month) = spinboxes.get(parent.get()) {
+            **text = month.0.label().to_string();
+        }
+    }
+}


### PR DESCRIPTION
# Objective
- Implement spinboxes! (part of https://github.com/bevyengine/bevy/issues/19236)
  - (dragging not implemented yet)

## Solution

Architecture notes:

- Number input related stuff (NumberFormat etc.) moved from feathers to core. [perhaps worth splitting to a separate PR first?]
  - `NumberInput` is a specialized `TextInput`
- Spinbox is a “base class” for anything with a increment/decrement behavior
  - So a “numeric spinbox” is NumberInput + Spinbox
  - Left/Down key press is decrement, Up/Right is increment
  - Added an example for a non-numeric spinbox 

Questions:

1. Not sure if

```
fn update_spinbox_button_visibility(
    q_spinboxes: Query<(Entity, &Hovered), (With<FeathersNumberInput>, Changed<Hovered>)>,
    q_children: Query<&Children>,
    mut q_button_groups: Query<&mut Visibility, With<FeathersSpinButtons>>,
) {
    [snip]
    for child in q_children.iter_descendants(spinbox) {
            if let Ok(mut button_visibility) = q_button_groups.get_mut(child) {
                *button_visibility = visibility;
            }
    }
    [snip]
}
```
Is the way to go. I mean `q_children.iter_descendants` + `q_button_groups.get_mut(child)`.

2. Similarly - “find_spinbox_ancestor”. I’m not sure what the expected structure is for headless widgets that require a container and some nested parts (increment/decrement buttons in this case). Which components should go where?

3. What’s the general story for textbox input validation? Any previous design docs/tracking issues?


## Testing

Implemented `examples/ui/widgets/spinbox_months.rs` and played around with the numeric input in `examples/ui/widgets/feathers_gallery.rs`. Focusing-unfocusing seems to work, but I'm not at all confident I got this part right.

---

## Showcase

`examples/ui/widgets/spinbox_months.rs`
<img width="409" height="180" alt="image" src="https://github.com/user-attachments/assets/ea84caa6-a13a-4847-814b-b4841ef1bde7" />
(unstyled-ish)

`examples/ui/widgets/feathers_gallery.rs`
<img width="364" height="61" alt="image" src="https://github.com/user-attachments/assets/78ae8167-98d6-4570-b06d-ad2c5a71fe26" />
(+/- buttons are shown only on hover)

</details>
