### PR TITLE
Add hierachy based ui/text rasterization scaling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1043,7 +1043,6 @@ wasm = true
 name = "text_scaling"
 path = "examples/ui/text/text_scaling.rs"
 doc-scrape-examples = true
-required-features = ["experimental_bevy_feathers"]
 
 [package.metadata.example.text_scaling]
 name = "Text Scaling"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3954,6 +3954,12 @@ name = "text_debug"
 path = "examples/ui/text/text_debug.rs"
 doc-scrape-examples = true
 
+[[example]]
+name = "text_scaling"
+path = "examples/ui/text/text_scaling.rs"
+doc-scrape-examples = true
+required-features = ["experimental_bevy_feathers"]
+
 [package.metadata.example.text_debug]
 name = "Text Debug"
 description = "An example for debugging text layout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1040,6 +1040,18 @@ category = "UI (User Interface)"
 wasm = true
 
 [[example]]
+name = "text_scaling"
+path = "examples/ui/text/text_scaling.rs"
+doc-scrape-examples = true
+required-features = ["experimental_bevy_feathers"]
+
+[package.metadata.example.text_scaling]
+name = "Text Scaling"
+description = "Demonstrates increasing text rasterization resolution for zooming"
+category = "UI (User Interface)"
+wasm = true
+
+[[example]]
 name = "editable_text_filter"
 path = "examples/ui/text/editable_text_filter.rs"
 doc-scrape-examples = true
@@ -3953,12 +3965,6 @@ wasm = true
 name = "text_debug"
 path = "examples/ui/text/text_debug.rs"
 doc-scrape-examples = true
-
-[[example]]
-name = "text_scaling"
-path = "examples/ui/text/text_scaling.rs"
-doc-scrape-examples = true
-required-features = ["experimental_bevy_feathers"]
 
 [package.metadata.example.text_debug]
 name = "Text Debug"

--- a/crates/bevy_sprite/src/text2d.rs
+++ b/crates/bevy_sprite/src/text2d.rs
@@ -314,6 +314,7 @@ pub fn update_text2d_layout(
             text_bounds,
             block.justify,
             *hinting,
+            1.0,
         ) {
             Err(TextError::NoSuchFont | TextError::NoSuchFontFamily(_)) => {
                 // There was an error processing the text layout.

--- a/crates/bevy_sprite_render/src/text2d/mod.rs
+++ b/crates/bevy_sprite_render/src/text2d/mod.rs
@@ -115,6 +115,7 @@ pub fn extract_text2d_sprite(
                 i,
                 PositionedGlyph {
                     position,
+                    size,
                     atlas_info,
                     ..
                 },
@@ -123,7 +124,7 @@ pub fn extract_text2d_sprite(
                 extracted_slices.slices.push(ExtractedSlice {
                     offset: *position,
                     rect: atlas_info.rect,
-                    size: atlas_info.rect.size(),
+                    size: *size,
                 });
 
                 if text_layout_info
@@ -213,6 +214,7 @@ pub fn extract_text2d_sprite(
             i,
             PositionedGlyph {
                 position,
+                size,
                 atlas_info,
                 section_index,
                 ..
@@ -235,7 +237,7 @@ pub fn extract_text2d_sprite(
             extracted_slices.slices.push(ExtractedSlice {
                 offset: *position,
                 rect: atlas_info.rect,
-                size: atlas_info.rect.size(),
+                size: *size,
             });
 
             if text_layout_info.glyphs.get(i + 1).is_none_or(|info| {

--- a/crates/bevy_text/src/font_atlas_set.rs
+++ b/crates/bevy_text/src/font_atlas_set.rs
@@ -14,7 +14,7 @@ pub struct FontAtlasKey {
     pub id: u32,
     /// Font data index
     pub index: u32,
-    /// Raster size, which is the font size multiplied by `UiRasterSize`.
+    /// Raster size, which is the font size multiplied by a raster scale.
     pub raster_size: AtlasRasterSize,
     /// Hash of normalized variation coords for this run.
     pub variations_hash: u64,

--- a/crates/bevy_text/src/font_atlas_set.rs
+++ b/crates/bevy_text/src/font_atlas_set.rs
@@ -60,7 +60,7 @@ impl AtlasRasterSize {
         Self((font_size * raster_scale).to_bits())
     }
 
-    /// Converts the `AtlasFontSize` back to an `f32`. This is
+    /// Converts the `AtlasRasterSize` to a `f32`.
     pub fn as_f32(self) -> f32 {
         f32::from_bits(self.0)
     }

--- a/crates/bevy_text/src/font_atlas_set.rs
+++ b/crates/bevy_text/src/font_atlas_set.rs
@@ -14,8 +14,8 @@ pub struct FontAtlasKey {
     pub id: u32,
     /// Font data index
     pub index: u32,
-    /// Font size via `f32::to_bits`
-    pub font_size_bits: u32,
+    /// Raster size, which is the font size multiplied by `UiRasterSize`.
+    pub raster_size: AtlasRasterSize,
     /// Hash of normalized variation coords for this run.
     pub variations_hash: u64,
     /// Hinting
@@ -46,5 +46,22 @@ impl FontAtlasSet {
                     .map_or(0, |data| data.len() as u64)
             })
             .sum()
+    }
+}
+
+/// Wrapping the raster size so it can be used as a key in a `HashMap`.
+#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
+pub struct AtlasRasterSize(u32);
+
+impl AtlasRasterSize {
+    /// Create a new `AtlasRasterSize` from a font size and a raster scale.
+    /// `raster_size = font_size * raster_scale`.
+    pub fn new(font_size: f32, raster_scale: f32) -> Self {
+        Self((font_size * raster_scale).to_bits())
+    }
+
+    /// Converts the `AtlasFontSize` back to an `f32`. This is
+    pub fn as_f32(self) -> f32 {
+        f32::from_bits(self.0)
     }
 }

--- a/crates/bevy_text/src/glyph.rs
+++ b/crates/bevy_text/src/glyph.rs
@@ -15,6 +15,12 @@ use bevy_reflect::Reflect;
 pub struct PositionedGlyph {
     /// The position of the glyph in the text block's bounding box.
     pub position: Vec2,
+    /// The physical pixels size of the glyph in the render target.
+    ///
+    /// This is independent of the rasterization resolution stored in [`GlyphAtlasInfo::rect`],
+    /// allowing the atlas to be rasterized at a different resolution than the display size
+    /// (e.g. supersampled based on `UiRasterScale`).
+    pub size: Vec2,
     /// Information about the glyph's atlas.
     pub atlas_info: GlyphAtlasInfo,
     /// The index of the glyph in the [`ComputedTextBlock`](crate::ComputedTextBlock)'s tracked sections.

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -19,7 +19,6 @@ use parley::{
 };
 use swash::FontRef;
 
-use crate::TextBrush;
 use crate::{
     add_glyph_to_atlas,
     error::TextError,
@@ -29,6 +28,7 @@ use crate::{
     Justify, LetterSpacing, LineBreak, LineHeight, PositionedGlyph, TextBounds, TextEntity,
     TextFont, TextLayout,
 };
+use crate::{AtlasRasterSize, TextBrush};
 
 struct TextSectionView<'a> {
     index: usize,
@@ -298,6 +298,9 @@ impl TextPipeline {
     }
 
     /// Update [`TextLayoutInfo`] with the new [`PositionedGlyph`] layout.
+    ///
+    /// `raster_scale` multiplies the atlas rasterization resolution without affecting
+    /// the position, size or other layout properties of the glyphs.
     pub fn update_text_layout_info(
         &mut self,
         layout_info: &mut TextLayoutInfo,
@@ -308,6 +311,7 @@ impl TextPipeline {
         bounds: TextBounds,
         justify: Justify,
         hinting: FontHinting,
+        raster_scale: f32,
     ) -> Result<(), TextError> {
         computed.needs_rerender = false;
         layout_info.clear();
@@ -323,12 +327,13 @@ impl TextPipeline {
                     let run = glyph_run.run();
                     let font = run.font();
                     let font_size = run.font_size();
+                    let raster_size = AtlasRasterSize::new(font_size, raster_scale);
                     let coords = run.normalized_coords();
                     let variations_hash = FixedHasher.hash_one(coords);
                     let font_atlas_key = FontAtlasKey {
                         id: font.data.id() as u32,
                         index: font.index,
-                        font_size_bits: font_size.to_bits(),
+                        raster_size,
                         variations_hash,
                         hinting,
                         font_smoothing,
@@ -344,7 +349,7 @@ impl TextPipeline {
                     let mut scaler = scale_cx
                         .0
                         .builder(font_ref)
-                        .size(font_size)
+                        .size(raster_size.as_f32())
                         .hint(hint)
                         .normalized_coords(coords)
                         .build();
@@ -369,7 +374,9 @@ impl TextPipeline {
                                 })?;
 
                         let glyph_pos = Vec2::new(glyph.x, glyph.y);
-                        let size = atlas_info.rect.size();
+                        // Convert atlas size and offset from raster space back to layout space.
+                        let size = atlas_info.rect.size() / raster_scale;
+                        let offset = atlas_info.offset / raster_scale;
 
                         layout_info.glyphs.push(PositionedGlyph {
                             position: size / 2.
@@ -378,7 +385,8 @@ impl TextPipeline {
                                 } else {
                                     glyph_pos
                                 }
-                                + atlas_info.offset,
+                                + offset,
+                            size,
                             atlas_info,
                             section_index,
                             line_index,

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -2,6 +2,7 @@
 use crate::experimental::GhostNode;
 use crate::{
     experimental::{UiChildren, UiRootNodes},
+    ui_raster_scale::UiRasterScale,
     ui_transform::{UiGlobalTransform, UiTransform},
     ComputedNode, ComputedUiRenderTargetInfo, ContentSize, Display, IgnoreScroll, LayoutConfig,
     Node, Outline, OverflowAxis, ScrollPosition,
@@ -94,6 +95,7 @@ pub fn ui_layout_system(
         Option<&Outline>,
         Option<&ScrollPosition>,
         Option<&IgnoreScroll>,
+        Option<&UiRasterScale>,
     )>,
     mut buffer_query: Query<&mut ComputedTextBlock>,
     mut font_system: ResMut<FontCx>,
@@ -211,6 +213,7 @@ pub fn ui_layout_system(
             computed_target.scale_factor.recip(),
             Vec2::ZERO,
             Vec2::ZERO,
+            UiRasterScale::DEFAULT,
         );
     }
 
@@ -230,11 +233,13 @@ pub fn ui_layout_system(
             Option<&Outline>,
             Option<&ScrollPosition>,
             Option<&IgnoreScroll>,
+            Option<&UiRasterScale>,
         )>,
         ui_children: &UiChildren,
         inverse_target_scale_factor: f32,
         parent_size: Vec2,
         parent_scroll_position: Vec2,
+        parent_raster_scale: UiRasterScale,
     ) {
         if let Ok((
             mut node,
@@ -245,6 +250,7 @@ pub fn ui_layout_system(
             maybe_outline,
             maybe_scroll_position,
             maybe_scroll_sticky,
+            maybe_raster_scale,
         )) = node_update_query.get_mut(entity)
         {
             let use_rounding = maybe_layout_config
@@ -368,6 +374,13 @@ pub fn ui_layout_system(
 
             node.bypass_change_detection().scroll_position = physical_scroll_position;
 
+            let raster_scale = match maybe_raster_scale {
+                Some(raster_scale) => *raster_scale,
+                None => parent_raster_scale,
+            };
+
+            node.bypass_change_detection().raster_scale = raster_scale;
+
             for child_uinode in ui_children.iter_ui_children(entity) {
                 update_uinode_geometry_recursive(
                     child_uinode,
@@ -380,6 +393,7 @@ pub fn ui_layout_system(
                     inverse_target_scale_factor,
                     layout_size,
                     physical_scroll_position,
+                    raster_scale,
                 );
             }
         }

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -275,14 +275,21 @@ pub fn ui_layout_system(
             let local_center =
                 layout_location - effective_parent_scroll + 0.5 * (layout_size - parent_size);
 
+            let raster_scale = match maybe_raster_scale {
+                Some(raster_scale) => *raster_scale,
+                None => parent_raster_scale,
+            };
+
             // only trigger change detection when the new values are different
             if node.size != layout_size
                 || node.unrounded_size != unrounded_size
                 || node.inverse_scale_factor != inverse_target_scale_factor
+                || node.raster_scale != raster_scale
             {
                 node.size = layout_size;
                 node.unrounded_size = unrounded_size;
                 node.inverse_scale_factor = inverse_target_scale_factor;
+                node.raster_scale = raster_scale;
             }
 
             let content_size = Vec2::new(layout.content_size.width, layout.content_size.height);
@@ -373,13 +380,6 @@ pub fn ui_layout_system(
             let physical_scroll_position = clamped_scroll_position.floor();
 
             node.bypass_change_detection().scroll_position = physical_scroll_position;
-
-            let raster_scale = match maybe_raster_scale {
-                Some(raster_scale) => *raster_scale,
-                None => parent_raster_scale,
-            };
-
-            node.bypass_change_detection().raster_scale = raster_scale;
 
             for child_uinode in ui_children.iter_ui_children(entity) {
                 update_uinode_geometry_recursive(

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -21,6 +21,7 @@ pub mod widget;
 pub mod gradients;
 #[cfg(feature = "bevy_picking")]
 pub mod picking_backend;
+pub mod ui_raster_scale;
 pub mod ui_transform;
 
 use bevy_derive::{Deref, DerefMut};
@@ -45,6 +46,7 @@ pub use interaction_states::{Checkable, Checked, InteractionDisabled, Pressed};
 pub use layout::*;
 pub use measurement::*;
 pub use ui_node::*;
+pub use ui_raster_scale::*;
 pub use ui_transform::*;
 pub use widget::TextNodeFlags;
 

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -1,4 +1,5 @@
 use crate::{
+    ui_raster_scale::UiRasterScale,
     ui_transform::{UiGlobalTransform, UiTransform},
     ComputedStackIndex, ContentSize, FocusPolicy, UiRect, Val,
 };
@@ -78,6 +79,13 @@ pub struct ComputedNode {
     ///
     /// Automatically calculated by [`ui_layout_system`](`super::layout::ui_layout_system`).
     pub inverse_scale_factor: f32,
+    /// Scale factor for rasterizing this Node.
+    /// Multiplies the raster resolution of rasterized parts of this node, such as text.
+    ///
+    /// Does not affect the logical or physical size of the node.
+    ///
+    /// Automatically calculated by [`ui_layout_system`](`super::layout::ui_layout_system`).
+    pub raster_scale: UiRasterScale,
 }
 
 impl ComputedNode {
@@ -392,6 +400,7 @@ impl ComputedNode {
         border: BorderRect::ZERO,
         padding: BorderRect::ZERO,
         inverse_scale_factor: 1.,
+        raster_scale: UiRasterScale::DEFAULT,
     };
 }
 

--- a/crates/bevy_ui/src/ui_raster_scale.rs
+++ b/crates/bevy_ui/src/ui_raster_scale.rs
@@ -3,7 +3,7 @@ use bevy_reflect::prelude::*;
 
 /// Scale factor for ui node rasterization.
 ///
-/// Add it to an entity with [`Node`] to multiply the raster resolution of rasterized parts
+/// Add it to an entity with [`Node`](crate::Node) to multiply the raster resolution of rasterized parts
 /// of the node and it's **descendants**, such as text.
 ///
 /// Does not affect the logical or physical size of the node.

--- a/crates/bevy_ui/src/ui_raster_scale.rs
+++ b/crates/bevy_ui/src/ui_raster_scale.rs
@@ -7,6 +7,10 @@ use bevy_reflect::prelude::*;
 /// of the node and it's **descendants**, such as text.
 ///
 /// Does not affect the logical or physical size of the node.
+///
+/// # Warning
+/// The raster scale should only be set to a small amount of discrete values, because
+/// each scale is likely to rerasterize all affected text glyphs for example.
 #[derive(Component, Debug, Copy, Clone, PartialEq, Reflect)]
 #[reflect(Component, Default, Debug, Clone)]
 pub struct UiRasterScale(pub f32);

--- a/crates/bevy_ui/src/ui_raster_scale.rs
+++ b/crates/bevy_ui/src/ui_raster_scale.rs
@@ -1,0 +1,22 @@
+use bevy_ecs::prelude::*;
+use bevy_reflect::prelude::*;
+
+/// Scale factor for ui node rasterization.
+///
+/// Add it to an entity with [`Node`] to multiply the raster resolution of rasterized parts
+/// of the node and it's **descendants**, such as text.
+///
+/// Does not affect the logical or physical size of the node.
+#[derive(Component, Debug, Copy, Clone, PartialEq, Reflect)]
+#[reflect(Component, Default, Debug, Clone)]
+pub struct UiRasterScale(pub f32);
+
+impl UiRasterScale {
+    pub const DEFAULT: Self = Self(1.0);
+}
+
+impl Default for UiRasterScale {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -1,6 +1,6 @@
 use crate::{
     ComputedNode, ComputedUiRenderTargetInfo, ContentSize, FixedMeasure, Measure, MeasureArgs,
-    Node, NodeMeasure,
+    Node, NodeMeasure, UiGlobalTransform,
 };
 use bevy_asset::Assets;
 use bevy_color::Color;
@@ -23,6 +23,7 @@ use bevy_text::{
     LineHeight, RemSize, ScaleCx, TextBounds, TextColor, TextError, TextFont, TextLayout,
     TextLayoutInfo, TextMeasureInfo, TextPipeline, TextReader, TextSection, TextWriter,
 };
+use bevy_window::{PrimaryWindow, Window};
 use taffy::{style::AvailableSpace, MaybeMath};
 use tracing::error;
 
@@ -377,6 +378,7 @@ pub fn text_system(
                 physical_node_size,
                 block.justify,
                 *hinting,
+                node.raster_scale.0,
             ) {
                 Err(
                     TextError::NoSuchFont

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -1,6 +1,6 @@
 use crate::{
     ComputedNode, ComputedUiRenderTargetInfo, ContentSize, FixedMeasure, Measure, MeasureArgs,
-    Node, NodeMeasure, UiGlobalTransform,
+    Node, NodeMeasure,
 };
 use bevy_asset::Assets;
 use bevy_color::Color;
@@ -23,7 +23,6 @@ use bevy_text::{
     LineHeight, RemSize, ScaleCx, TextBounds, TextColor, TextError, TextFont, TextLayout,
     TextLayoutInfo, TextMeasureInfo, TextPipeline, TextReader, TextSection, TextWriter,
 };
-use bevy_window::{PrimaryWindow, Window};
 use taffy::{style::AvailableSpace, MaybeMath};
 use tracing::error;
 

--- a/crates/bevy_ui/src/widget/text_input_layout.rs
+++ b/crates/bevy_ui/src/widget/text_input_layout.rs
@@ -1,7 +1,9 @@
 use core::hash::BuildHasher;
 use core::time::Duration;
 
-use crate::{ComputedNode, ComputedUiRenderTargetInfo, ContentSize, NodeMeasure};
+use crate::{
+    ComputedNode, ComputedUiRenderTargetInfo, ContentSize, NodeMeasure, UiGlobalTransform,
+};
 use bevy_asset::Assets;
 
 use bevy_ecs::{
@@ -17,7 +19,7 @@ use bevy_input_focus::InputFocus;
 use bevy_math::{Rect, Vec2};
 use bevy_platform::hash::FixedHasher;
 use bevy_text::{
-    add_glyph_to_atlas, get_glyph_atlas_info, resolve_font_source, EditableText,
+    add_glyph_to_atlas, get_glyph_atlas_info, resolve_font_source, AtlasRasterSize, EditableText,
     EditableTextGeneration, Font, FontAtlasKey, FontAtlasSet, FontCx, FontHinting, FontSize,
     GlyphCacheKey, LayoutCx, LineBreak, LineHeight, PositionedGlyph, RemSize, RunGeometry, ScaleCx,
     TextBrush, TextFont, TextLayout, TextLayoutInfo,
@@ -323,12 +325,14 @@ pub fn update_editable_text_layout(
 
                             let font_data = run.font();
                             let font_size = run.font_size();
+                            let raster_scale = computed_node.raster_scale.0;
+                            let raster_size = AtlasRasterSize::new(font_size, raster_scale);
                             let coords = run.normalized_coords();
 
                             let font_atlas_key = FontAtlasKey {
                                 id: font_data.data.id() as u32,
                                 index: font_data.index,
-                                font_size_bits: font_size.to_bits(),
+                                raster_size,
                                 variations_hash: FixedHasher.hash_one(coords),
                                 hinting: *hinting,
                                 font_smoothing: brush.font_smoothing,
@@ -352,7 +356,7 @@ pub fn update_editable_text_layout(
                                     .unwrap();
                                     let mut scaler = scale_cx
                                         .builder(font_ref)
-                                        .size(font_size)
+                                        .size(raster_size.as_f32())
                                         .hint(matches!(*hinting, FontHinting::Enabled))
                                         .normalized_coords(coords)
                                         .build();
@@ -367,10 +371,13 @@ pub fn update_editable_text_layout(
                                     continue;
                                 };
 
+                                let size = atlas_info.rect.size() / raster_scale;
+                                let logical_offset = atlas_info.offset / raster_scale;
                                 info.glyphs.push(PositionedGlyph {
                                     position: Vec2::new(glyph.x, glyph.y)
-                                        + atlas_info.rect.size() / 2.
-                                        + atlas_info.offset,
+                                        + size / 2.
+                                        + logical_offset,
+                                    size,
                                     atlas_info,
                                     section_index: brush.section_index as usize,
                                     line_index,

--- a/crates/bevy_ui/src/widget/text_input_layout.rs
+++ b/crates/bevy_ui/src/widget/text_input_layout.rs
@@ -1,9 +1,7 @@
 use core::hash::BuildHasher;
 use core::time::Duration;
 
-use crate::{
-    ComputedNode, ComputedUiRenderTargetInfo, ContentSize, NodeMeasure, UiGlobalTransform,
-};
+use crate::{ComputedNode, ComputedUiRenderTargetInfo, ContentSize, NodeMeasure};
 use bevy_asset::Assets;
 
 use bevy_ecs::{

--- a/crates/bevy_ui_render/src/lib.rs
+++ b/crates/bevy_ui_render/src/lib.rs
@@ -368,6 +368,8 @@ pub enum ExtractedUiItem {
 pub struct ExtractedGlyph {
     pub color: LinearRgba,
     pub translation: Vec2,
+    /// Physical pixel size of the glyph in the render target.
+    pub size: Vec2,
     pub rect: Rect,
 }
 
@@ -1003,6 +1005,7 @@ pub fn extract_text_sections(
             i,
             PositionedGlyph {
                 position,
+                size,
                 atlas_info,
                 section_index,
                 ..
@@ -1029,7 +1032,7 @@ pub fn extract_text_sections(
                     .selection_rects
                     .iter()
                     .any(|selection_rect| {
-                        let glyph_rect = Rect::from_center_size(*position, atlas_info.rect.size());
+                        let glyph_rect = Rect::from_center_size(*position, *size);
                         selection_rect.contains(glyph_rect.min)
                             && selection_rect.contains(glyph_rect.max)
                     })
@@ -1042,6 +1045,7 @@ pub fn extract_text_sections(
             extracted_uinodes.glyphs.push(ExtractedGlyph {
                 color,
                 translation: *position,
+                size: *size,
                 rect: atlas_info.rect,
             });
 
@@ -1137,6 +1141,7 @@ pub fn extract_text_shadows(
             i,
             PositionedGlyph {
                 position,
+                size,
                 atlas_info,
                 section_index,
                 ..
@@ -1146,6 +1151,7 @@ pub fn extract_text_shadows(
             extracted_uinodes.glyphs.push(ExtractedGlyph {
                 color: shadow.color.into(),
                 translation: *position,
+                size: *size,
                 rect: atlas_info.rect,
             });
 
@@ -1842,14 +1848,13 @@ pub fn prepare_uinodes(
 
                         for glyph in &extracted_uinodes.glyphs[range.clone()] {
                             let color = glyph.color.to_f32_array();
-                            let glyph_rect = glyph.rect;
-                            let rect_size = glyph_rect.size();
+                            let rect_size = glyph.size;
 
                             // Specify the corners of the glyph
                             let positions = QUAD_VERTEX_POSITIONS.map(|pos| {
                                 extracted_uinode
                                     .transform
-                                    .transform_point2(glyph.translation + pos * glyph_rect.size())
+                                    .transform_point2(glyph.translation + pos * glyph.size)
                                     .extend(0.)
                             });
 
@@ -1895,22 +1900,29 @@ pub fn prepare_uinodes(
                                 continue;
                             }
 
+                            // Scale positions_diff from display space to atlas texture space.
+                            // atlas_size / display_size gives atlas pixels per display pixel.
+                            let atlas_scale =
+                                glyph.rect.size() / glyph.size.max(Vec2::splat(f32::EPSILON));
+                            let positions_diff_atlas_space =
+                                positions_diff.map(|diff| diff * atlas_scale);
+
                             let uvs = [
                                 Vec2::new(
-                                    glyph.rect.min.x + positions_diff[0].x,
-                                    glyph.rect.min.y + positions_diff[0].y,
+                                    glyph.rect.min.x + positions_diff_atlas_space[0].x,
+                                    glyph.rect.min.y + positions_diff_atlas_space[0].y,
                                 ),
                                 Vec2::new(
-                                    glyph.rect.max.x + positions_diff[1].x,
-                                    glyph.rect.min.y + positions_diff[1].y,
+                                    glyph.rect.max.x + positions_diff_atlas_space[1].x,
+                                    glyph.rect.min.y + positions_diff_atlas_space[1].y,
                                 ),
                                 Vec2::new(
-                                    glyph.rect.max.x + positions_diff[2].x,
-                                    glyph.rect.max.y + positions_diff[2].y,
+                                    glyph.rect.max.x + positions_diff_atlas_space[2].x,
+                                    glyph.rect.max.y + positions_diff_atlas_space[2].y,
                                 ),
                                 Vec2::new(
-                                    glyph.rect.min.x + positions_diff[3].x,
-                                    glyph.rect.max.y + positions_diff[3].y,
+                                    glyph.rect.min.x + positions_diff_atlas_space[3].x,
+                                    glyph.rect.max.y + positions_diff_atlas_space[3].y,
                                 ),
                             ]
                             .map(|pos| pos / atlas_extent);

--- a/examples/README.md
+++ b/examples/README.md
@@ -632,6 +632,7 @@ Example | Description
 [Text Background Colors](../examples/ui/text/text_background_colors.rs) | Demonstrates text background colors
 [Text Debug](../examples/ui/text/text_debug.rs) | An example for debugging text layout
 [Text Input](../examples/ui/text/text_input.rs) | Demonstrates a simple, unstyled text input widget
+[Text Scaling](../examples/ui/text/text_scaling.rs) | Demonstrates increasing text rasterization resolution for zooming
 [Text Wrap Debug](../examples/ui/text/text_wrap_debug.rs) | Demonstrates text wrapping
 [Transparency UI](../examples/ui/styling/transparency_ui.rs) | Demonstrates transparency for UI
 [UI Drag and Drop](../examples/ui/ui_drag_and_drop.rs) | Demonstrates dragging and dropping UI nodes

--- a/examples/ui/text/text_scaling.rs
+++ b/examples/ui/text/text_scaling.rs
@@ -2,28 +2,14 @@
 //! it stays sharp even when zoomed in.
 
 use bevy::{
-    feathers::{
-        dark_theme::create_dark_theme,
-        theme::{ThemeBackgroundColor, UiTheme},
-        tokens, FeathersPlugins,
-    },
     input::{keyboard::KeyboardInput, mouse::MouseWheel},
     prelude::*,
     ui::UiRasterScale,
-    window::WindowResolution,
 };
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                resolution: WindowResolution::default(),
-                ..default()
-            }),
-            ..default()
-        }))
-        .add_plugins(FeathersPlugins)
-        .insert_resource(UiTheme(create_dark_theme()))
+        .add_plugins(DefaultPlugins)
         .add_systems(Startup, scene.spawn())
         .add_systems(Update, zoom)
         .run();
@@ -54,8 +40,7 @@ fn root() -> impl Scene {
             Text::new("Some Text")
             TextFont {
                 font_size: FontSize::Px(16.),
-            }
-            ThemeBackgroundColor(tokens::PANE_BODY_BG),
+            },
 
             // Simple solution:
             // Scaling by UiRasterScale, which scales up the glyph rasterization resolution
@@ -66,8 +51,7 @@ fn root() -> impl Scene {
             TextFont {
                 font_size: FontSize::Px(16.),
             }
-            UiRasterScale(4.)
-            ThemeBackgroundColor(tokens::PANE_BODY_BG),
+            UiRasterScale(4.),
 
             // More complex, less flexible solution:
             // Increase font size by 4x and scale the node down to 1/4 size.
@@ -82,8 +66,7 @@ fn root() -> impl Scene {
                 // The node size is calculated before the scale is applied,
                 // so we move it down to be next to the other text.
                 top: px(-30.)
-            }
-            ThemeBackgroundColor(tokens::PANE_BODY_BG),
+            },
         ]
     }
 }

--- a/examples/ui/text/text_scaling.rs
+++ b/examples/ui/text/text_scaling.rs
@@ -72,7 +72,7 @@ fn root() -> impl Scene {
             // More complex, less flexible solution:
             // Increase font size by 4x and scale the node down to 1/4 size.
             // This works, but you need to multiply your font sizes everywhere by 4x
-            // and there is extra complexity, because the 1/4 scale needs to happen somwhere.
+            // and there is extra complexity, because the 1/4 scale needs to happen somewhere.
             TextFont {
                 font_size: {FontSize::Px(16. * 4.)},
             }

--- a/examples/ui/text/text_scaling.rs
+++ b/examples/ui/text/text_scaling.rs
@@ -47,8 +47,29 @@ fn root() -> impl Scene {
             align_items: AlignItems::Center,
             flex_direction: FlexDirection::Column
         }
-        // Goal: Render text of font size 16 that stays sharp up to 4x zoom.
+        // Goal: Render text of logical pixel size 16 that stays sharp up to 4x zoom.
         Children [
+            // For comparison non-sharp text.
+            Node
+            Text::new("Some Text")
+            TextFont {
+                font_size: FontSize::Px(16.),
+            }
+            ThemeBackgroundColor(tokens::PANE_BODY_BG),
+
+            // Simple solution:
+            // Scaling by UiRasterScale, which scales up the glyph rasterization resolution
+            // and could be dynamically changed based on zoom level. When zoomed out very far
+            // less raster resolution can look better.
+            Node
+            Text::new("Some Text")
+            TextFont {
+                font_size: FontSize::Px(16.),
+            }
+            UiRasterScale(4.)
+            ThemeBackgroundColor(tokens::PANE_BODY_BG),
+
+            // More complex, less flexible solution:
             // Increase font size by 4x and scale the node down to 1/4 size.
             // This works, but you need to multiply your font sizes everywhere by 4x
             // and there is extra complexity, because the 1/4 scale needs to happen somwhere.
@@ -60,30 +81,9 @@ fn root() -> impl Scene {
             Node {
                 // The node size is calculated before the scale is applied,
                 // so we move it down to be next to the other text.
-                top: px(30.)
+                top: px(-30.)
             }
             ThemeBackgroundColor(tokens::PANE_BODY_BG),
-
-            // Scaling by UiRasterScale, which simply scales up the glyph rasterization resolution
-            // and could even be dynamically changed based on zoom level. When zoomed out very far
-            // less raster resolution can look better.
-            Node
-            Text::new("Some Text")
-            TextFont {
-                font_size: FontSize::Px(16.),
-            }
-            UiRasterScale(4.)
-            ThemeBackgroundColor(tokens::PANE_BODY_BG),
-
-            // For comparison non-sharp text.
-            Node
-            Text::new("Some Text")
-            TextFont {
-                font_size: FontSize::Px(16.),
-            }
-            ThemeBackgroundColor(tokens::PANE_BODY_BG),
-
-
         ]
     }
 }

--- a/examples/ui/text/text_scaling.rs
+++ b/examples/ui/text/text_scaling.rs
@@ -1,0 +1,122 @@
+//! This example shows off how to rasterize text at a higher resolution, so that
+//! it stays sharp even when zoomed in.
+
+use bevy::{
+    feathers::{
+        dark_theme::create_dark_theme,
+        theme::{ThemeBackgroundColor, UiTheme},
+        tokens, FeathersPlugins,
+    },
+    input::{keyboard::KeyboardInput, mouse::MouseWheel},
+    prelude::*,
+    ui::UiRasterScale,
+    window::WindowResolution,
+};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins.set(WindowPlugin {
+            primary_window: Some(Window {
+                resolution: WindowResolution::default(),
+                ..default()
+            }),
+            ..default()
+        }))
+        .add_plugins(FeathersPlugins)
+        .insert_resource(UiTheme(create_dark_theme()))
+        .add_systems(Startup, scene.spawn())
+        .add_systems(Update, zoom)
+        .run();
+}
+
+fn scene() -> impl SceneList {
+    bsn_list![Camera2d, root(), controls()]
+}
+
+#[derive(Component, Clone, Default)]
+struct Root;
+
+fn root() -> impl Scene {
+    bsn! {
+        Root
+        Node {
+            width: percent(100),
+            height: percent(100),
+            display: Display::Flex,
+            justify_content: JustifyContent::Center,
+            align_items: AlignItems::Center,
+            flex_direction: FlexDirection::Column
+        }
+        // Goal: Render text of font size 16 that stays sharp up to 4x zoom.
+        Children [
+            // Increase font size by 4x and scale the node down to 1/4 size.
+            // This works, but you need to multiply your font sizes everywhere by 4x
+            // and there is extra complexity, because the 1/4 scale needs to happen somwhere.
+            TextFont {
+                font_size: {FontSize::Px(16. * 4.)},
+            }
+            template_value(UiTransform::from_scale(Vec2::splat(1./4.)))
+            Text::new("Some Text")
+            Node {
+                // The node size is calculated before the scale is applied,
+                // so we move it down to be next to the other text.
+                top: px(30.)
+            }
+            ThemeBackgroundColor(tokens::PANE_BODY_BG),
+
+            // Scaling by UiRasterScale, which simply scales up the glyph rasterization resolution
+            // and could even be dynamically changed based on zoom level. When zoomed out very far
+            // less raster resolution can look better.
+            Node
+            Text::new("Some Text")
+            TextFont {
+                font_size: FontSize::Px(16.),
+            }
+            UiRasterScale(4.)
+            ThemeBackgroundColor(tokens::PANE_BODY_BG),
+
+            // For comparison non-sharp text.
+            Node
+            Text::new("Some Text")
+            TextFont {
+                font_size: FontSize::Px(16.),
+            }
+            ThemeBackgroundColor(tokens::PANE_BODY_BG),
+
+
+        ]
+    }
+}
+
+fn zoom(
+    mut root_transform: Single<&mut UiTransform, With<Root>>,
+    mut scroll: MessageReader<MouseWheel>,
+    mut keys: MessageReader<KeyboardInput>,
+) {
+    // Use screen-space cursor (top-left origin) directly for UI calculations.
+    for event in scroll.read() {
+        root_transform.scale *= 1.0 + event.y * 0.05;
+    }
+    for key in keys.read() {
+        root_transform.scale = Vec2::splat(match key.key_code {
+            KeyCode::Digit1 => 1.0,
+            KeyCode::Digit2 => 2.0,
+            KeyCode::Digit3 => 4.0,
+            KeyCode::Digit4 => 1. / 1.5,
+            KeyCode::Digit5 => 1. / 2.0,
+            KeyCode::Digit6 => 1. / 2.5,
+            _ => continue,
+        });
+    }
+}
+
+fn controls() -> impl Scene {
+    bsn! {
+        Node {
+            position_type: PositionType::Absolute,
+            top: px(16.),
+            left: px(16.),
+        }
+        Text::new("Scroll to zoom or use 1, 2, 3, 4, 5 for fixed zoom levels")
+    }
+}


### PR DESCRIPTION
# Objective
Bevy currently tightly couples text rasterization size to it's font size, however, font size is also used as a logical unit for ui layout calculations. In practice this means if you want your text to render at a higher resolution you need to increase it's font size, which also increases it's text size. High resolution text is for example required for text staying sharp when zoomed in on.

It's possible to work around this issue by using a large font size and using `UiTransform` to scale down the ui text node so the text is the size you want it to be. However, this is cumbersome, adds extra complexity to handling the scaling correctly everywhere and using `UiTransform` scaling is rather restrictive, because ui layout calculations happen before the scaling is applied and there is no equivalent to `transform_origin` in web.

`UiScale` also exists, but it's a global modifier and suffers from similar issues as the other workaround from above.

## Solution
Introduce a new component `UiRasterScale`, which can be added to a `Node` entity to scale the rasterization size of the rasterized parts of the node and it's **descendants**, such as the glyphs of it's text (currently this is the only thing affected by `UiRasterScale`).

`FontAtlasKey` now takes a `raster_size: AtlasRasterSize` rather than a `font_size`. `AtlasRasterSize` is `font_size * raster_scale`.

## Testing
- Tested on the new `text_scaling` example, which compares this approach to the workaround.
- Also tested it on `feathers_gallery` by adding zooming functionality to it (not in this PR).

## Showcase
The example shows how to make text stay sharp for up to 4x scale
- top: 16px font size
- middle: 16px font size + `UiRasterScale(4)`
- bottom: 64px font size + `UiTransform.scale = 1 / 4`

Middle and bottom look identical, but middle is simpler to use and more flexible.

https://github.com/user-attachments/assets/5b9b6e1b-a217-4e29-b8c7-7220dea6dea8

