### PR TITLE
Fix feathers gallery button info 

### DIFF
--- a/examples/ui/widgets/feathers_gallery.rs
+++ b/examples/ui/widgets/feathers_gallery.rs
@@ -174,7 +174,7 @@ fn demo_column_1() -> impl Scene {
                             flex_grow: 1.0,
                         }
                         on(|_activate: On<Activate>| {
-                            info!("Disabled button clicked!");
+                            info!("Primary button clicked!");
                         })
                     ),
                     (


### PR DESCRIPTION
# Objective

 The `feathers gallery` example logs "Disabled button clicked!" when its "Primary" button is clicked. 

## Solution

Log "Primary button clicked!" instead.