### PR TITLE
Deps: bump up wgpu and related deps to 29.0.3

### DIFF
--- a/crates/bevy_camera/Cargo.toml
+++ b/crates/bevy_camera/Cargo.toml
@@ -28,7 +28,7 @@ bevy_color = { path = "../bevy_color", version = "0.19.0-dev", features = [
 bevy_window = { path = "../bevy_window", version = "0.19.0-dev" }
 
 # other
-wgpu-types = { version = "29.0.2", default-features = false }
+wgpu-types = { version = "29.0.3", default-features = false }
 serde = { version = "1", default-features = false, features = ["derive"] }
 thiserror = { version = "2", default-features = false }
 downcast-rs = { version = "2", default-features = false, features = ["std"] }

--- a/crates/bevy_camera/Cargo.toml
+++ b/crates/bevy_camera/Cargo.toml
@@ -28,7 +28,7 @@ bevy_color = { path = "../bevy_color", version = "0.19.0-dev", features = [
 bevy_window = { path = "../bevy_window", version = "0.19.0-dev" }
 
 # other
-wgpu-types = { version = "29.0.1", default-features = false }
+wgpu-types = { version = "29.0.2", default-features = false }
 serde = { version = "1", default-features = false, features = ["derive"] }
 thiserror = { version = "2", default-features = false }
 downcast-rs = { version = "2", default-features = false, features = ["std"] }

--- a/crates/bevy_clipboard/Cargo.toml
+++ b/crates/bevy_clipboard/Cargo.toml
@@ -29,7 +29,7 @@ bevy_platform = { path = "../bevy_platform", version = "0.19.0-dev", default-fea
 [target.'cfg(any(windows, unix))'.dependencies]
 bevy_asset = { path = "../bevy_asset", version = "0.19.0-dev", default-features = false, optional = true }
 bevy_image = { path = "../bevy_image", version = "0.19.0-dev", default-features = false, optional = true }
-wgpu-types = { version = "29.0.2", default-features = false, optional = true }
+wgpu-types = { version = "29.0.3", default-features = false, optional = true }
 arboard = { version = "3.6.1", default-features = false, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/bevy_clipboard/Cargo.toml
+++ b/crates/bevy_clipboard/Cargo.toml
@@ -29,7 +29,7 @@ bevy_platform = { path = "../bevy_platform", version = "0.19.0-dev", default-fea
 [target.'cfg(any(windows, unix))'.dependencies]
 bevy_asset = { path = "../bevy_asset", version = "0.19.0-dev", default-features = false, optional = true }
 bevy_image = { path = "../bevy_image", version = "0.19.0-dev", default-features = false, optional = true }
-wgpu-types = { version = "29.0.1", default-features = false, optional = true }
+wgpu-types = { version = "29.0.2", default-features = false, optional = true }
 arboard = { version = "3.6.1", default-features = false, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/bevy_color/Cargo.toml
+++ b/crates/bevy_color/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1.0", features = [
 ], default-features = false, optional = true }
 thiserror = { version = "2", default-features = false }
 derive_more = { version = "2", default-features = false, features = ["from"] }
-wgpu-types = { version = "29.0.1", default-features = false, optional = true }
+wgpu-types = { version = "29.0.2", default-features = false, optional = true }
 encase = { version = "0.12", default-features = false, optional = true }
 
 [features]

--- a/crates/bevy_color/Cargo.toml
+++ b/crates/bevy_color/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1.0", features = [
 ], default-features = false, optional = true }
 thiserror = { version = "2", default-features = false }
 derive_more = { version = "2", default-features = false, features = ["from"] }
-wgpu-types = { version = "29.0.2", default-features = false, optional = true }
+wgpu-types = { version = "29.0.3", default-features = false, optional = true }
 encase = { version = "0.12", default-features = false, optional = true }
 
 [features]

--- a/crates/bevy_gltf/Cargo.toml
+++ b/crates/bevy_gltf/Cargo.toml
@@ -65,7 +65,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.140"
 smallvec = { version = "1", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
-wgpu-types = { version = "29.0.1", default-features = false }
+wgpu-types = { version = "29.0.2", default-features = false }
 
 [dev-dependencies]
 bevy_log = { path = "../bevy_log", version = "0.19.0-dev" }

--- a/crates/bevy_gltf/Cargo.toml
+++ b/crates/bevy_gltf/Cargo.toml
@@ -65,7 +65,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.140"
 smallvec = { version = "1", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
-wgpu-types = { version = "29.0.2", default-features = false }
+wgpu-types = { version = "29.0.3", default-features = false }
 
 [dev-dependencies]
 bevy_log = { path = "../bevy_log", version = "0.19.0-dev" }

--- a/crates/bevy_image/Cargo.toml
+++ b/crates/bevy_image/Cargo.toml
@@ -70,7 +70,7 @@ image = { version = "0.25.2", default-features = false }
 # misc
 bitflags = { version = "2.3", features = ["serde"] }
 bytemuck = { version = "1.5" }
-wgpu-types = { version = "29.0.1", default-features = false, features = [
+wgpu-types = { version = "29.0.2", default-features = false, features = [
   "serde",
 ] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/bevy_image/Cargo.toml
+++ b/crates/bevy_image/Cargo.toml
@@ -70,7 +70,7 @@ image = { version = "0.25.2", default-features = false }
 # misc
 bitflags = { version = "2.3", features = ["serde"] }
 bytemuck = { version = "1.5" }
-wgpu-types = { version = "29.0.2", default-features = false, features = [
+wgpu-types = { version = "29.0.3", default-features = false, features = [
   "serde",
 ] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/bevy_light/Cargo.toml
+++ b/crates/bevy_light/Cargo.toml
@@ -28,7 +28,7 @@ bevy_gizmos = { path = "../bevy_gizmos", version = "0.19.0-dev", optional = true
 
 # other
 tracing = { version = "0.1", default-features = false }
-wgpu-types = { version = "29.0.2", default-features = false }
+wgpu-types = { version = "29.0.3", default-features = false }
 half = "2.7.1"
 smallvec = { version = "1", default-features = false }
 

--- a/crates/bevy_light/Cargo.toml
+++ b/crates/bevy_light/Cargo.toml
@@ -28,7 +28,7 @@ bevy_gizmos = { path = "../bevy_gizmos", version = "0.19.0-dev", optional = true
 
 # other
 tracing = { version = "0.1", default-features = false }
-wgpu-types = { version = "29.0.1", default-features = false }
+wgpu-types = { version = "29.0.2", default-features = false }
 half = "2.7.1"
 smallvec = { version = "1", default-features = false }
 

--- a/crates/bevy_material/Cargo.toml
+++ b/crates/bevy_material/Cargo.toml
@@ -23,7 +23,7 @@ bevy_platform = { path = "../bevy_platform", version = "0.19.0-dev" }
 encase = "0.12"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 thiserror = { version = "2", default-features = false }
-wgpu-types = { version = "29.0.1", default-features = false }
+wgpu-types = { version = "29.0.2", default-features = false }
 variadics_please = "1.1"
 smallvec = { version = "1", default-features = false }
 

--- a/crates/bevy_material/Cargo.toml
+++ b/crates/bevy_material/Cargo.toml
@@ -23,7 +23,7 @@ bevy_platform = { path = "../bevy_platform", version = "0.19.0-dev" }
 encase = "0.12"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 thiserror = { version = "2", default-features = false }
-wgpu-types = { version = "29.0.2", default-features = false }
+wgpu-types = { version = "29.0.3", default-features = false }
 variadics_please = "1.1"
 smallvec = { version = "1", default-features = false }
 

--- a/crates/bevy_mesh/Cargo.toml
+++ b/crates/bevy_mesh/Cargo.toml
@@ -27,7 +27,7 @@ bevy_platform = { path = "../bevy_platform", version = "0.19.0-dev", default-fea
 # other
 bitflags = { version = "2.3", features = ["serde"] }
 bytemuck = { version = "1.5" }
-wgpu-types = { version = "29.0.1", default-features = false }
+wgpu-types = { version = "29.0.2", default-features = false }
 serde = { version = "1", default-features = false, features = [
   "derive",
 ], optional = true }

--- a/crates/bevy_mesh/Cargo.toml
+++ b/crates/bevy_mesh/Cargo.toml
@@ -27,7 +27,7 @@ bevy_platform = { path = "../bevy_platform", version = "0.19.0-dev", default-fea
 # other
 bitflags = { version = "2.3", features = ["serde"] }
 bytemuck = { version = "1.5" }
-wgpu-types = { version = "29.0.2", default-features = false }
+wgpu-types = { version = "29.0.3", default-features = false }
 serde = { version = "1", default-features = false, features = [
   "derive",
 ], optional = true }

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -90,7 +90,7 @@ tracing = { version = "0.1", default-features = false, features = ["std"] }
 offset-allocator = "0.2"
 arrayvec = { version = "0.7", default-features = false }
 indexmap = { version = "2" }
-wgpu-types = "29.0.2"
+wgpu-types = "29.0.3"
 
 [lints]
 workspace = true

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -90,7 +90,7 @@ tracing = { version = "0.1", default-features = false, features = ["std"] }
 offset-allocator = "0.2"
 arrayvec = { version = "0.7", default-features = false }
 indexmap = { version = "2" }
-wgpu-types = "29.0.1"
+wgpu-types = "29.0.2"
 
 [lints]
 workspace = true

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -129,7 +129,7 @@ uuid = { version = "1.21.0", default-features = false, optional = true, features
   "serde",
 ] }
 variadics_please = "1.1"
-wgpu-types = { version = "29.0.2", features = [
+wgpu-types = { version = "29.0.3", features = [
   "serde",
 ], optional = true, default-features = false }
 

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -129,7 +129,7 @@ uuid = { version = "1.21.0", default-features = false, optional = true, features
   "serde",
 ] }
 variadics_please = "1.1"
-wgpu-types = { version = "29.0.1", features = [
+wgpu-types = { version = "29.0.2", features = [
   "serde",
 ], optional = true, default-features = false }
 

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -95,7 +95,7 @@ image = { version = "0.25.2", default-features = false }
 # It is enabled for now to avoid having to do a significant overhaul of the renderer just for wasm.
 # When the 'atomics' feature is enabled `fragile-send-sync-non-atomic` does nothing
 # and Bevy instead wraps `wgpu` types to verify they are not used off their origin thread.
-wgpu = { version = "29.0.2", default-features = false, features = [
+wgpu = { version = "29.0.3", default-features = false, features = [
   "wgsl",
   "dx12",
   "metal",
@@ -103,8 +103,8 @@ wgpu = { version = "29.0.2", default-features = false, features = [
   "naga-ir",
   "fragile-send-sync-non-atomic-wasm",
 ] }
-wgpu-types = { version = "29.0.2", default-features = false }
-naga = { version = "29.0.2", features = ["wgsl-in"] }
+wgpu-types = { version = "29.0.3", default-features = false }
+naga = { version = "29.0.3", features = ["wgsl-in"] }
 bytemuck = { version = "1.5", features = ["derive", "must_cast"] }
 downcast-rs = { version = "2", default-features = false, features = ["std"] }
 thiserror = { version = "2", default-features = false }

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -95,7 +95,7 @@ image = { version = "0.25.2", default-features = false }
 # It is enabled for now to avoid having to do a significant overhaul of the renderer just for wasm.
 # When the 'atomics' feature is enabled `fragile-send-sync-non-atomic` does nothing
 # and Bevy instead wraps `wgpu` types to verify they are not used off their origin thread.
-wgpu = { version = "29.0.1", default-features = false, features = [
+wgpu = { version = "29.0.2", default-features = false, features = [
   "wgsl",
   "dx12",
   "metal",
@@ -103,8 +103,8 @@ wgpu = { version = "29.0.1", default-features = false, features = [
   "naga-ir",
   "fragile-send-sync-non-atomic-wasm",
 ] }
-wgpu-types = { version = "29.0.1", default-features = false }
-naga = { version = "29.0.1", features = ["wgsl-in"] }
+wgpu-types = { version = "29.0.2", default-features = false }
+naga = { version = "29.0.2", features = ["wgsl-in"] }
 bytemuck = { version = "1.5", features = ["derive", "must_cast"] }
 downcast-rs = { version = "2", default-features = false, features = ["std"] }
 thiserror = { version = "2", default-features = false }

--- a/crates/bevy_shader/Cargo.toml
+++ b/crates/bevy_shader/Cargo.toml
@@ -16,9 +16,9 @@ bevy_platform = { path = "../bevy_platform", version = "0.19.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.19.0-dev" }
 
 # other
-wgpu-types = { version = "29.0.2", default-features = false }
-naga = { version = "29.0.2", features = ["wgsl-in"] }
-wgpu-naga-bridge = { version = "29.0.2", default-features = false }
+wgpu-types = { version = "29.0.3", default-features = false }
+naga = { version = "29.0.3", features = ["wgsl-in"] }
+wgpu-naga-bridge = { version = "29.0.3", default-features = false }
 serde = { version = "1", features = ["derive"] }
 thiserror = { version = "2", default-features = false }
 wesl = { version = "0.3.1", optional = true }

--- a/crates/bevy_shader/Cargo.toml
+++ b/crates/bevy_shader/Cargo.toml
@@ -16,9 +16,9 @@ bevy_platform = { path = "../bevy_platform", version = "0.19.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.19.0-dev" }
 
 # other
-wgpu-types = { version = "29.0.1", default-features = false }
-naga = { version = "29.0.1", features = ["wgsl-in"] }
-wgpu-naga-bridge = { version = "29.0.1", default-features = false }
+wgpu-types = { version = "29.0.2", default-features = false }
+naga = { version = "29.0.2", features = ["wgsl-in"] }
+wgpu-naga-bridge = { version = "29.0.2", default-features = false }
 serde = { version = "1", features = ["derive"] }
 thiserror = { version = "2", default-features = false }
 wesl = { version = "0.3.1", optional = true }

--- a/crates/bevy_sprite/Cargo.toml
+++ b/crates/bevy_sprite/Cargo.toml
@@ -33,7 +33,7 @@ bevy_log = { path = "../bevy_log", version = "0.19.0-dev" }
 # other
 radsort = "0.1"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
-wgpu-types = { version = "29.0.1", default-features = false }
+wgpu-types = { version = "29.0.2", default-features = false }
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/crates/bevy_sprite/Cargo.toml
+++ b/crates/bevy_sprite/Cargo.toml
@@ -33,7 +33,7 @@ bevy_log = { path = "../bevy_log", version = "0.19.0-dev" }
 # other
 radsort = "0.1"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
-wgpu-types = { version = "29.0.2", default-features = false }
+wgpu-types = { version = "29.0.3", default-features = false }
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/crates/bevy_text/Cargo.toml
+++ b/crates/bevy_text/Cargo.toml
@@ -34,7 +34,7 @@ bevy_platform = { path = "../bevy_platform", version = "0.19.0-dev", default-fea
 ] }
 
 # other
-wgpu-types = { version = "29.0.1", default-features = false }
+wgpu-types = { version = "29.0.2", default-features = false }
 thiserror = { version = "2", default-features = false }
 serde = { version = "1", features = ["derive"] }
 smallvec = { version = "1", default-features = false }

--- a/crates/bevy_text/Cargo.toml
+++ b/crates/bevy_text/Cargo.toml
@@ -34,7 +34,7 @@ bevy_platform = { path = "../bevy_platform", version = "0.19.0-dev", default-fea
 ] }
 
 # other
-wgpu-types = { version = "29.0.2", default-features = false }
+wgpu-types = { version = "29.0.3", default-features = false }
 thiserror = { version = "2", default-features = false }
 serde = { version = "1", features = ["derive"] }
 smallvec = { version = "1", default-features = false }

--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -57,7 +57,7 @@ bevy_asset = { path = "../bevy_asset", version = "0.19.0-dev", optional = true }
 ## used by custom_cursor
 bevy_image = { path = "../bevy_image", version = "0.19.0-dev", optional = true }
 ## used by custom_cursor
-wgpu-types = { version = "29.0.2", optional = true }
+wgpu-types = { version = "29.0.3", optional = true }
 ## used by custom_cursor
 bytemuck = { version = "1.5", optional = true }
 

--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -57,7 +57,7 @@ bevy_asset = { path = "../bevy_asset", version = "0.19.0-dev", optional = true }
 ## used by custom_cursor
 bevy_image = { path = "../bevy_image", version = "0.19.0-dev", optional = true }
 ## used by custom_cursor
-wgpu-types = { version = "29.0.1", optional = true }
+wgpu-types = { version = "29.0.2", optional = true }
 ## used by custom_cursor
 bytemuck = { version = "1.5", optional = true }
 


### PR DESCRIPTION
# Objective

- Should fix #23573 - I don’t have DX-12 so I can’t verify this, just following orders. Someone can verify this is fixed!
## Solution

- Search and replace “29.0.1” with “29.0.3” if it is related to wgpu (and checking that the version is available on crates)

- Fixes #23220.

## Testing

- Leaning on CI for this one personally