### PR TITLE
Remove panic from code gen of an enum's FromReflect derive.

### DIFF
--- a/crates/bevy_reflect/derive/src/from_reflect.rs
+++ b/crates/bevy_reflect/derive/src/from_reflect.rs
@@ -95,7 +95,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
                 {
                     match #bevy_reflect_path::enums::Enum::variant_name(#ref_value) {
                         #match_branches
-                        name => panic!("variant with name `{}` does not exist on enum `{}`", name, <Self as #bevy_reflect_path::TypePath>::type_path()),
+                        name => #FQOption::None,
                     }
                 } else {
                     #FQOption::None

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -1721,6 +1721,29 @@ mod tests {
     }
 
     #[test]
+    fn enum_from_reflect_does_not_panic() {
+        #[derive(Reflect, PartialEq, Eq, Debug)]
+        enum A {
+            Hot,
+            Cold,
+        }
+
+        #[derive(Reflect, PartialEq, Eq, Debug)]
+        enum B {
+            Hot,
+            Cold,
+            Warm,
+        }
+
+        // There's no difference between the reflected data of these enum variants - they are named
+        // the same, so we are able to convert them.
+        assert_eq!(A::from_reflect(&B::Hot), Some(A::Hot));
+        assert_eq!(A::from_reflect(&B::Cold), Some(A::Cold));
+        // This variant doesn't exist in `A`, so it should not be converted.
+        assert_eq!(A::from_reflect(&B::Warm), None);
+    }
+
+    #[test]
     fn reflect_partial_cmp_array_length_difference() {
         use core::cmp::Ordering;
 


### PR DESCRIPTION
# Objective

- I noticed this while reviewing #24048. Our current FromReflect derive macro adds a panic for cases when a PartialReflect-ed enum includes a variant we weren't expecting. This can happen for a few reasons, e.g., a variant of the enum has been removed. In any case, **crashing the program** is not the correct answer, since we already have an appropriate response to a failed conversion: just return None!

## Solution

- Return None instead of panicking.

I also checked if there are any other panics, and it looks like none in the codegen. The only remaining panics have to do with some auto registration file stuff, which seems appropriate to panic on.

## Testing

- Added a unit test.