### PR TITLE
bsn: parse negative numeric literals as Expr

### DIFF
--- a/crates/bevy_scene/macros/src/bsn/parse.rs
+++ b/crates/bevy_scene/macros/src/bsn/parse.rs
@@ -474,7 +474,7 @@ mod tests {
 
     /// Regression for #24050: `MyComponent(-0.1)` previously raised `expected Expr`
     /// when the parser saw `-` and the literal as separate tokens (rust-analyzer's
-    /// behaviour). After the fix the value parses successfully — either as a
+    /// behavior). After the fix the value parses successfully — either as a
     /// folded `Lit` (when syn combines the tokens) or as an `Expr` (when it
     /// doesn't); both downstream codegen paths handle the value correctly.
     #[test]

--- a/crates/bevy_scene/macros/src/bsn/parse.rs
+++ b/crates/bevy_scene/macros/src/bsn/parse.rs
@@ -434,6 +434,10 @@ impl Parse for BsnValue {
             }
         } else if input.peek(Lit) {
             BsnValue::Lit(input.parse::<Lit>()?)
+        } else if input.peek(Token![-]) {
+            // Negative numeric literal: -0.1, -42, etc. Not a syn::Lit, so parse as Expr.
+            let expr: Expr = input.parse()?;
+            BsnValue::Expr(quote! { #expr })
         } else if input.peek(Paren) {
             BsnValue::Tuple(input.parse::<BsnTuple>()?)
         } else if input.peek(Token![#]) {

--- a/crates/bevy_scene/macros/src/bsn/parse.rs
+++ b/crates/bevy_scene/macros/src/bsn/parse.rs
@@ -454,3 +454,47 @@ fn take_last_path_ident(path: &mut Path) -> Option<Ident> {
     path.segments.pop_punct();
     ident
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proc_macro2::{Punct, Spacing, TokenStream, TokenTree};
+    use quote::quote;
+    use syn::parse2;
+
+    /// Build a `-` punct followed by `lit_tokens` so the resulting TokenStream
+    /// has the `-` and the literal as separate tokens. This mirrors the way
+    /// rust-analyzer's tokenizer splits `-0.1` (the path that exposes #24050).
+    fn neg_then(lit_tokens: TokenStream) -> TokenStream {
+        let minus = TokenTree::Punct(Punct::new('-', Spacing::Alone));
+        let mut out = TokenStream::from(minus);
+        out.extend(lit_tokens);
+        out
+    }
+
+    /// Regression for #24050: `MyComponent(-0.1)` previously raised `expected Expr`
+    /// when the parser saw `-` and the literal as separate tokens (rust-analyzer's
+    /// behaviour). After the fix the value parses successfully — either as a
+    /// folded `Lit` (when syn combines the tokens) or as an `Expr` (when it
+    /// doesn't); both downstream codegen paths handle the value correctly.
+    #[test]
+    fn negative_float_value_parses() {
+        let value: BsnValue = parse2(neg_then(quote! { 0.1 })).expect("BsnValue should parse");
+        assert!(matches!(value, BsnValue::Lit(_) | BsnValue::Expr(_)));
+    }
+
+    #[test]
+    fn negative_int_value_parses() {
+        let value: BsnValue = parse2(neg_then(quote! { 42 })).expect("BsnValue should parse");
+        assert!(matches!(value, BsnValue::Lit(_) | BsnValue::Expr(_)));
+    }
+
+    #[test]
+    fn positive_literal_value_parses() {
+        let value: BsnValue = parse2(quote! { 0.1 }).expect("BsnValue should parse");
+        assert!(matches!(value, BsnValue::Lit(_)));
+
+        let value: BsnValue = parse2(quote! { 42 }).expect("BsnValue should parse");
+        assert!(matches!(value, BsnValue::Lit(_)));
+    }
+}


### PR DESCRIPTION
Closes #24050. `MyComponent(-0.1)` fails because `-` is a unary expression, not a syn::Lit. Route the leading-`-` case through `syn::Expr` so negative numerics work without brace-wrapping.