### PR TITLE
Expose MorphIndices::morph_descriptor_index() as public.

### DIFF
--- a/crates/bevy_pbr/src/render/morph.rs
+++ b/crates/bevy_pbr/src/render/morph.rs
@@ -158,10 +158,7 @@ impl MorphIndices {
     /// As morph descriptors are only present if the platform supports storage
     /// buffers, this method returns `None` if the platform doesn't support
     /// them.
-    pub fn morph_descriptor_index(
-        &self,
-        main_entity: MainEntity,
-    ) -> Option<MorphDescriptorIndex> {
+    pub fn morph_descriptor_index(&self, main_entity: MainEntity) -> Option<MorphDescriptorIndex> {
         match *self {
             MorphIndices::Uniform { .. } => None,
             MorphIndices::Storage {

--- a/crates/bevy_pbr/src/render/morph.rs
+++ b/crates/bevy_pbr/src/render/morph.rs
@@ -158,7 +158,7 @@ impl MorphIndices {
     /// As morph descriptors are only present if the platform supports storage
     /// buffers, this method returns `None` if the platform doesn't support
     /// them.
-    pub(crate) fn morph_descriptor_index(
+    pub fn morph_descriptor_index(
         &self,
         main_entity: MainEntity,
     ) -> Option<MorphDescriptorIndex> {


### PR DESCRIPTION
# Objective

My ecosystem crate, bevy_mod_outline, renders the outlines of morphed meshes while reusing the data already bound for this purpose by the regular mesh rendering pipeline. While porting the crate to _0.19-dev_, I found that the new support by #23023 for providing the morph targets in storage buffers requires me to know the morph descriptor index in order to use the prepared data, but this field is not accessible outside of the bevy_pbr crate.

## Solution

- Change `MorphIndices::morph_descriptor_index()` from `pub(crate)` to `pub`.

## Testing

- Check that Bevy compiles and that the function is accessible from a dependent crate.