### PR TITLE
Fix: Add SyncComponents for SSAO, ensuring SSAOResources is synced

### DIFF
--- a/crates/bevy_pbr/src/render/mesh_view_bindings.rs
+++ b/crates/bevy_pbr/src/render/mesh_view_bindings.rs
@@ -58,10 +58,9 @@ use crate::{
     Bluenoise, EnvironmentMapUniformBuffer, ExtractedAtmosphere, FogMeta,
     GlobalClusterableObjectMeta, GpuClusteredLights, GpuFog, GpuLights, LightMeta,
     LightProbesBuffer, LightProbesUniform, MeshPipeline, MeshPipelineKey, RenderViewLightProbes,
-    ScreenSpaceAmbientOcclusion, ScreenSpaceAmbientOcclusionResources,
-    ScreenSpaceReflectionsBuffer, ScreenSpaceReflectionsUniform, ShadowSamplers,
-    ViewClusterBindings, ViewShadowBindings, ViewTransmissionTexture,
-    CLUSTERED_FORWARD_STORAGE_BUFFER_COUNT,
+    ScreenSpaceAmbientOcclusionResources, ScreenSpaceReflectionsBuffer,
+    ScreenSpaceReflectionsUniform, ShadowSamplers, ViewClusterBindings, ViewShadowBindings,
+    ViewTransmissionTexture, CLUSTERED_FORWARD_STORAGE_BUFFER_COUNT,
 };
 
 #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
@@ -638,10 +637,7 @@ pub fn prepare_mesh_view_bind_groups(
         &ViewShadowBindings,
         &ViewClusterBindings,
         &Msaa,
-        (
-            Has<ScreenSpaceAmbientOcclusion>,
-            Option<&ScreenSpaceAmbientOcclusionResources>,
-        ),
+        Option<&ScreenSpaceAmbientOcclusionResources>,
         Option<&ViewPrepassTextures>,
         Option<&ViewTransmissionTexture>,
         Option<&AtmosphereTextures>,
@@ -723,7 +719,7 @@ pub fn prepare_mesh_view_bind_groups(
             shadow_bindings,
             cluster_bindings,
             msaa,
-            (has_ssao, ssao_resources),
+            ssao_resources,
             prepass_textures,
             transmission_texture,
             atmosphere_textures,
@@ -862,7 +858,7 @@ pub fn prepare_mesh_view_bind_groups(
                 entries = entries.extend_with_indices(((19, lut_bindings.0), (20, lut_bindings.1)));
             }
 
-            if has_ssao && let Some(ssao_resources) = ssao_resources {
+            if let Some(ssao_resources) = ssao_resources {
                 layout_key |= MeshPipelineViewLayoutKey::SCREEN_SPACE_AMBIENT_OCCLUSION;
                 let ssao_view = &ssao_resources
                     .screen_space_ambient_occlusion_texture

--- a/crates/bevy_pbr/src/render/mesh_view_bindings.rs
+++ b/crates/bevy_pbr/src/render/mesh_view_bindings.rs
@@ -58,9 +58,10 @@ use crate::{
     Bluenoise, EnvironmentMapUniformBuffer, ExtractedAtmosphere, FogMeta,
     GlobalClusterableObjectMeta, GpuClusteredLights, GpuFog, GpuLights, LightMeta,
     LightProbesBuffer, LightProbesUniform, MeshPipeline, MeshPipelineKey, RenderViewLightProbes,
-    ScreenSpaceAmbientOcclusionResources, ScreenSpaceReflectionsBuffer,
-    ScreenSpaceReflectionsUniform, ShadowSamplers, ViewClusterBindings, ViewShadowBindings,
-    ViewTransmissionTexture, CLUSTERED_FORWARD_STORAGE_BUFFER_COUNT,
+    ScreenSpaceAmbientOcclusion, ScreenSpaceAmbientOcclusionResources,
+    ScreenSpaceReflectionsBuffer, ScreenSpaceReflectionsUniform, ShadowSamplers,
+    ViewClusterBindings, ViewShadowBindings, ViewTransmissionTexture,
+    CLUSTERED_FORWARD_STORAGE_BUFFER_COUNT,
 };
 
 #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
@@ -637,7 +638,10 @@ pub fn prepare_mesh_view_bind_groups(
         &ViewShadowBindings,
         &ViewClusterBindings,
         &Msaa,
-        Option<&ScreenSpaceAmbientOcclusionResources>,
+        (
+            Has<ScreenSpaceAmbientOcclusion>,
+            Option<&ScreenSpaceAmbientOcclusionResources>,
+        ),
         Option<&ViewPrepassTextures>,
         Option<&ViewTransmissionTexture>,
         Option<&AtmosphereTextures>,
@@ -719,7 +723,7 @@ pub fn prepare_mesh_view_bind_groups(
             shadow_bindings,
             cluster_bindings,
             msaa,
-            ssao_resources,
+            (has_ssao, ssao_resources),
             prepass_textures,
             transmission_texture,
             atmosphere_textures,
@@ -858,7 +862,7 @@ pub fn prepare_mesh_view_bind_groups(
                 entries = entries.extend_with_indices(((19, lut_bindings.0), (20, lut_bindings.1)));
             }
 
-            if let Some(ssao_resources) = ssao_resources {
+            if has_ssao && let Some(ssao_resources) = ssao_resources {
                 layout_key |= MeshPipelineViewLayoutKey::SCREEN_SPACE_AMBIENT_OCCLUSION;
                 let ssao_view = &ssao_resources
                     .screen_space_ambient_occlusion_texture

--- a/crates/bevy_pbr/src/ssao/mod.rs
+++ b/crates/bevy_pbr/src/ssao/mod.rs
@@ -111,6 +111,7 @@ impl Plugin for ScreenSpaceAmbientOcclusionPlugin {
 #[derive(Component, ExtractComponent, Reflect, PartialEq, Clone, Debug)]
 #[reflect(Component, Debug, Default, PartialEq, Clone)]
 #[require(DepthPrepass, NormalPrepass)]
+#[extract_component_sync_target((Self, ScreenSpaceAmbientOcclusionResources, SsaoPipelineId, SsaoBindGroups))]
 #[doc(alias = "Ssao")]
 pub struct ScreenSpaceAmbientOcclusion {
     /// Quality of the SSAO effect.
@@ -598,8 +599,9 @@ fn prepare_ssao_textures(
     }
 }
 
+/// A render world component that holds the cached pipeline id for Ssao.
 #[derive(Component)]
-struct SsaoPipelineId(CachedComputePipelineId);
+pub struct SsaoPipelineId(pub CachedComputePipelineId);
 
 fn prepare_ssao_pipelines(
     mut commands: Commands,
@@ -622,12 +624,16 @@ fn prepare_ssao_pipelines(
     }
 }
 
+/// A render world component that stores the bind groups necessary to perform
+/// Screen Space Ambient Occlusion.
+///
+/// This is stored on each view.
 #[derive(Component)]
-struct SsaoBindGroups {
-    common_bind_group: BindGroup,
-    preprocess_depth_bind_group: BindGroup,
-    ssao_bind_group: BindGroup,
-    spatial_denoise_bind_group: BindGroup,
+pub struct SsaoBindGroups {
+    pub common_bind_group: BindGroup,
+    pub preprocess_depth_bind_group: BindGroup,
+    pub ssao_bind_group: BindGroup,
+    pub spatial_denoise_bind_group: BindGroup,
 }
 
 fn prepare_ssao_bind_groups(


### PR DESCRIPTION
# Objective

- The SSAO part of the fix for #24084 

## Solution

- Add SSAOResources (and other related components) to the sync component target for SSAO to ensure that adding/removing SSAO also adds/removes resources. This ensures that checking for SSAOResources later in `mesh_view_bindings` logic is valid.

## Testing

- `cargo run --example ssao` : toggling “Off” no longer crashes.