### PR TITLE
`SystemId` scene templating

### DIFF
--- a/crates/bevy_ecs/src/system/system_registry.rs
+++ b/crates/bevy_ecs/src/system/system_registry.rs
@@ -351,7 +351,7 @@ impl<I: SystemInput + 'static, O: 'static> Template for SystemHandleTemplate<I, 
                 match &mut *value_or_id {
                     SystemHandleOrValue::Handle(handle) => Ok(handle.clone()),
                     SystemHandleOrValue::Value(system) => {
-                        let system = system.take().unwrap_or_else(|| unreachable!());
+                        let system = system.take().unwrap();
                         let id = context
                             .entity
                             .world_scope(|world| world.register_tracked_boxed_system(system));
@@ -382,6 +382,14 @@ impl<I: SystemInput + 'static, O: 'static> Default for SystemHandleTemplate<I, O
 impl<I: SystemInput + 'static, O: 'static> From<SystemHandle<I, O>> for SystemHandleTemplate<I, O> {
     fn from(handle: SystemHandle<I, O>) -> Self {
         Self::Handle(handle)
+    }
+}
+
+impl<I: SystemInput + 'static, O: 'static> From<BoxedSystem<I, O>> for SystemHandleTemplate<I, O> {
+    fn from(system: BoxedSystem<I, O>) -> Self {
+        Self::Value(SystemHandleValue(Arc::new(Mutex::new(
+            SystemHandleOrValue::Value(Some(system)),
+        ))))
     }
 }
 

--- a/crates/bevy_ecs/src/system/system_registry.rs
+++ b/crates/bevy_ecs/src/system/system_registry.rs
@@ -4,15 +4,17 @@ use crate::{
     change_detection::Mut,
     entity::Entity,
     error::BevyError,
+    prelude::{FromTemplate, Template},
     system::{
         input::SystemInput, BoxedSystem, Commands, If, IntoSystem, Res, RunSystemError,
         SystemParamValidationError,
     },
+    template::TemplateContext,
     world::World,
 };
 use alloc::boxed::Box;
 use bevy_ecs_macros::{Component, Resource};
-use bevy_platform::sync::Arc;
+use bevy_platform::sync::{Arc, Mutex};
 use bevy_utils::prelude::DebugName;
 use concurrent_queue::ConcurrentQueue;
 use core::{any::TypeId, marker::PhantomData};
@@ -288,6 +290,114 @@ impl<I: SystemInput, O> core::fmt::Debug for SystemId<I, O> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_tuple("SystemId").field(&self.entity).finish()
     }
+}
+
+impl<I: SystemInput + 'static, O: 'static> FromTemplate for SystemHandle<I, O> {
+    type Template = SystemHandleTemplate<I, O>;
+}
+
+/// A [`Template`] that produces a [`SystemHandle`].
+pub enum SystemHandleTemplate<I: SystemInput + 'static = (), O: 'static = ()> {
+    /// Creates a [`SystemHandle`] by cloning the given [`SystemHandle`] value.
+    Handle(SystemHandle<I, O>),
+    /// Creates a [`SystemHandle`] by registering the given system value using
+    /// [`World::register_tracked_boxed_system`]. This will cache the resulting
+    /// [`SystemHandle`]
+    /// on the template and reuse it for future template builds.
+    ///
+    /// This should generally be constructed using [`SystemHandleTemplate::value`]
+    /// or [`system_value`].
+    Value(SystemHandleValue<I, O>),
+}
+
+/// Stores an [`Arc<Mutex<SystemHandleOrValue<I, O>>>`].
+pub struct SystemHandleValue<I: SystemInput + 'static = (), O: 'static = ()>(
+    Arc<Mutex<SystemHandleOrValue<I, O>>>,
+);
+
+impl<I: SystemInput + 'static, O: 'static> Clone for SystemHandleValue<I, O> {
+    fn clone(&self) -> Self {
+        Self(Arc::clone(&self.0))
+    }
+}
+
+enum SystemHandleOrValue<I: SystemInput + 'static = (), O: 'static = ()> {
+    Handle(SystemHandle<I, O>),
+    Value(Option<BoxedSystem<I, O>>),
+}
+
+impl<I: SystemInput + 'static, O: 'static> SystemHandleTemplate<I, O> {
+    /// This will create a new [`SystemHandleTemplate`] for the given `system` value.
+    /// This makes it possible to define systems "inline" in templates / scenes
+    /// that produce a [`SystemId`].
+    pub fn value<M>(system: impl IntoSystem<I, O, M>) -> Self {
+        Self::Value(SystemHandleValue(Arc::new(Mutex::new(
+            SystemHandleOrValue::Value(Some(Box::new(IntoSystem::into_system(system)))),
+        ))))
+    }
+}
+
+impl<I: SystemInput + 'static, O: 'static> Template for SystemHandleTemplate<I, O> {
+    type Output = SystemHandle<I, O>;
+
+    fn build_template(
+        &self,
+        context: &mut TemplateContext,
+    ) -> crate::prelude::Result<Self::Output> {
+        match self {
+            Self::Handle(handle) => Ok(handle.clone()),
+            Self::Value(value) => {
+                let mut value_or_id = value.0.lock().unwrap();
+                match &mut *value_or_id {
+                    SystemHandleOrValue::Handle(handle) => Ok(handle.clone()),
+                    SystemHandleOrValue::Value(system) => {
+                        let system = system.take().unwrap_or_else(|| unreachable!());
+                        let id = context
+                            .entity
+                            .world_scope(|world| world.register_tracked_boxed_system(system));
+                        *value_or_id = SystemHandleOrValue::Handle(id.clone());
+                        Ok(id)
+                    }
+                }
+            }
+        }
+    }
+
+    fn clone_template(&self) -> Self {
+        match self {
+            Self::Handle(handle) => Self::Handle(handle.clone()),
+            Self::Value(value) => Self::Value(value.clone()),
+        }
+    }
+}
+
+impl<I: SystemInput + 'static, O: 'static> Default for SystemHandleTemplate<I, O> {
+    fn default() -> Self {
+        Self::Handle(SystemHandle::Weak(SystemId::from_entity(
+            Entity::PLACEHOLDER,
+        )))
+    }
+}
+
+impl<I: SystemInput + 'static, O: 'static> From<SystemHandle<I, O>> for SystemHandleTemplate<I, O> {
+    fn from(handle: SystemHandle<I, O>) -> Self {
+        Self::Handle(handle)
+    }
+}
+
+impl<I: SystemInput + 'static, O: 'static> From<SystemId<I, O>> for SystemHandleTemplate<I, O> {
+    fn from(id: SystemId<I, O>) -> Self {
+        Self::Handle(SystemHandle::Weak(id))
+    }
+}
+
+/// This will create a new [`SystemHandleTemplate`] for the given `system` value.
+/// This makes it possible to define systems "inline" in templates / scenes that
+/// produce a [`SystemHandle`].
+pub fn system_value<I: SystemInput + 'static, O: 'static, M>(
+    system: impl IntoSystem<I, O, M>,
+) -> SystemHandleTemplate<I, O> {
+    SystemHandleTemplate::value(system)
 }
 
 /// A cached [`SystemId`] distinguished by the unique function type of its system.
@@ -782,7 +892,10 @@ mod tests {
 
     use crate::{
         prelude::*,
-        system::{despawn_unused_registered_systems, RegisteredSystemError, SystemId},
+        system::{
+            despawn_unused_registered_systems, system_value, RegisteredSystemError, SystemHandle,
+            SystemHandleTemplate, SystemId,
+        },
     };
 
     #[derive(Resource, Default, PartialEq, Debug)]
@@ -1270,5 +1383,33 @@ mod tests {
             .unwrap();
 
         assert!(world.get_entity(entity).is_err());
+    }
+
+    #[test]
+    fn system_handle_template() {
+        fn my_system() {}
+
+        let mut world = World::new();
+
+        {
+            let my_system_handle = world.register_tracked_system(my_system);
+            let system_handle = world
+                .spawn_empty()
+                .build_template(&SystemHandleTemplate::Handle(my_system_handle.clone()))
+                .unwrap();
+            assert_eq!(system_handle, my_system_handle);
+        }
+
+        {
+            let template = system_value(my_system);
+
+            let a = world.spawn_empty().build_template(&template).unwrap();
+            let b = world.spawn_empty().build_template(&template).unwrap();
+
+            assert!(matches!(a, SystemHandle::Strong(_)));
+            assert!(matches!(b, SystemHandle::Strong(_)));
+
+            assert_eq!(a, b);
+        }
     }
 }

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -859,6 +859,7 @@ mod tests {
     use bevy_ecs::lifecycle::HookContext;
     use bevy_ecs::prelude::*;
     use bevy_ecs::relationship::Relationship;
+    use bevy_ecs::system::{system_value, SystemHandle};
     use bevy_ecs::world::DeferredWorld;
     use bevy_reflect::TypePath;
     use bevy_scene_macros::SceneComponent;
@@ -2121,5 +2122,37 @@ mod tests {
         }
 
         func();
+    }
+
+    #[test]
+    fn scene_with_oneshot_system() {
+        #[derive(Component, FromTemplate)]
+        struct Callback {
+            callback: SystemHandle<(), ()>,
+        }
+
+        fn my_system() {}
+
+        let mut app = test_app();
+        let world = app.world_mut();
+
+        let direct = bsn! {
+            Callback {
+                callback: system_value(my_system)
+            }
+        };
+        let direct_ent = world.spawn_scene(direct).unwrap();
+        assert!(direct_ent.get::<Callback>().is_some());
+
+        let id = world.register_tracked_system(my_system);
+        let id2 = id.clone();
+
+        let indirect = bsn! {
+            Callback {
+                callback: id
+            }
+        };
+        let indirect_ent = world.spawn_scene(indirect).unwrap();
+        assert!(indirect_ent.get::<Callback>().unwrap().callback == id2);
     }
 }


### PR DESCRIPTION
# Objective

- Simplified alternative to #24072

I have a bunch of `Bundle`-style code that I want to replace with the new `bsn!` Scene-style macro:

```rust
pub fn rest_ui(/* system params */) {
    // my ui system...
}

// From
pub fn rest(mut commands: Commands) -> impl Bundle {
    (
        Rest,
        Name::new("Rest"),
        Activity {
            render: commands.register_system(rest_ui),
        },
    )
}

// To (ideally)
pub fn rest() -> impl Scene {
    bsn! {
        Rest
        Name("Rest")
        Activity {
            render: rest_ui
        }
    }
}
```

## Solution

This solution is more inspired by how `HandleTemplate` works.

1. Added `SystemIdTemplate`; it stores either a `SystemId` or a `Arc<Mutex<Either<SystemId, Box<dyn System>>>>`
2. Added a `system_value` function for wrapping system functions (see Future Work for potentially removing the need)

## Testing

- Added a unit test for `SystemIdTemplate`.
- Added to the `callbacks` example demonstrating how to spawn `SystemId`s via BSN scenes.

## Future work

- I believe we can remove the need for wrapping with `system_value` by introducing [`SuperFrom`/`SuperInto` traits a la Dioxus](https://docs.rs/dioxus-core/0.7.6/dioxus_core/trait.SuperFrom.html) and using it in the `bsn!` macros in-place of the implicit `.into()`s.

---

## Showcase

You can now spawn components containing `SystemId`s via `bsn!` macros:

```rust
#[derive(Component, FromTemplate)]
struct Callback {
    system_id: SystemId<(), ()>,
}

fn my_scene() -> impl Scene {
    bsn! {
        Callback {
            system_id: system_value(|| {
                println!("This is a callback spawned via a scene.");
            })
        }
    }
}
```