### PR TITLE
Fix: Put back Defaulting of `EnvironmentMapUniform`

### DIFF
--- a/crates/bevy_pbr/src/light_probe/mod.rs
+++ b/crates/bevy_pbr/src/light_probe/mod.rs
@@ -436,14 +436,18 @@ impl Plugin for LightProbePlugin {
 /// Compared to the `ExtractComponentPlugin`, this implementation will create a default instance
 /// if one does not already exist.
 fn gather_environment_map_uniform(
-    view_query: Extract<Query<(RenderEntity, &EnvironmentMapLight), With<Camera3d>>>,
+    view_query: Extract<Query<(RenderEntity, Option<&EnvironmentMapLight>), With<Camera3d>>>,
     mut commands: Commands,
 ) {
     for (view_entity, environment_map_light) in view_query.iter() {
-        let environment_map_uniform = EnvironmentMapUniform {
-            transform: Transform::from_rotation(environment_map_light.rotation)
-                .to_matrix()
-                .inverse(),
+        let environment_map_uniform = if let Some(environment_map_light) = environment_map_light {
+            EnvironmentMapUniform {
+                transform: Transform::from_rotation(environment_map_light.rotation)
+                    .to_matrix()
+                    .inverse(),
+            }
+        } else {
+            EnvironmentMapUniform::default()
         };
         commands
             .get_entity(view_entity)


### PR DESCRIPTION
# Objective

- I think this is the last fix associated with #24084

## Solution

- Some defaulting logic of `EnvironmentMapUniform` was removed — this just puts it back. It seems like it is critical to the rendering the desired mirror-y effects of the `light_probe_blending` and `pcss` examples, and it resolves the rendering strobing that happens for the affected examples.
- I do realize that this probably makes the `ENVIRONMENTAL_MAP` flag useless? Since every camera will then have an `EnvironmentalMap`. I might do that later (have to sleep!)

Alternative solution: add `EnvironmentalMapLight` to the examples’ cameras, but I am second guessing that based on the pre-existing function doc comment. It might be a usability thing to not have to include the `EnvironmentalMapLight` component… albeit I haven’t asked anyone about it. 

This is in draft until I make up my mind about modifying the examples and changing user expectations vs putting back in the defaulting behavior. I do like how the feature gating ensures that we use one less uniform buffer...

## Testing

- `cargo run --example light_probe_blending --features="free_camera https”` looks correct again
- `cargo run --example pcss` also looks correct again