### PR TITLE
Use the shorthand functions to construct Val in examples

### DIFF
--- a/examples/3d/rect_light.rs
+++ b/examples/3d/rect_light.rs
@@ -91,8 +91,8 @@ fn setup(
         TextColor(Color::srgb(0.9, 0.9, 0.9)),
         Node {
             position_type: PositionType::Absolute,
-            top: Val::Px(12.0),
-            left: Val::Px(12.0),
+            top: px(12),
+            left: px(12),
             ..default()
         },
         RoughnessDisplay,

--- a/examples/app/persisting_preferences.rs
+++ b/examples/app/persisting_preferences.rs
@@ -63,8 +63,8 @@ fn setup(mut commands: Commands) {
     commands.spawn((Camera::default(), Camera2d));
     commands
         .spawn(Node {
-            width: Val::Percent(100.0),
-            height: Val::Percent(100.0),
+            width: percent(100),
+            height: percent(100),
             display: Display::Flex,
             flex_direction: FlexDirection::Column,
             align_items: AlignItems::Center,

--- a/examples/asset/asset_saving.rs
+++ b/examples/asset/asset_saving.rs
@@ -146,8 +146,8 @@ F5 - Save image"
     let container = commands
         .spawn((
             Node {
-                width: Val::Percent(100.0),
-                height: Val::Percent(100.0),
+                width: percent(100),
+                height: percent(100),
                 align_items: AlignItems::End,
                 justify_content: JustifyContent::Center,
                 ..Default::default()
@@ -169,9 +169,9 @@ F5 - Save image"
     ] {
         let mut entity = commands.spawn((
             Node {
-                width: Val::Vw(5.0),
-                height: Val::Vh(5.0),
-                border: UiRect::all(Val::Px(5.0)),
+                width: vw(5),
+                height: vh(5),
+                border: UiRect::all(px(5)),
                 ..Default::default()
             },
             SelectableColor,

--- a/examples/asset/asset_saving.rs
+++ b/examples/asset/asset_saving.rs
@@ -171,7 +171,7 @@ F5 - Save image"
             Node {
                 width: vw(5),
                 height: vh(5),
-                border: UiRect::all(px(5)),
+                border: px(5).all(),
                 ..Default::default()
             },
             SelectableColor,

--- a/examples/gizmos/transform_gizmo.rs
+++ b/examples/gizmos/transform_gizmo.rs
@@ -40,8 +40,8 @@ fn setup(
         ),
         Node {
             position_type: PositionType::Absolute,
-            top: Val::Px(12.0),
-            left: Val::Px(12.0),
+            top: px(12),
+            left: px(12),
             ..default()
         },
         InstructionsText,

--- a/examples/large_scenes/bevy_city/src/main.rs
+++ b/examples/large_scenes/bevy_city/src/main.rs
@@ -141,17 +141,17 @@ fn loading_screen() -> impl Scene {
         LoadingScreen
         Node {
             position_type: PositionType::Absolute,
-            width: Val::Percent(100.0),
-            height: Val::Percent(100.0),
+            width: percent(100),
+            height: percent(100),
         }
         BackgroundColor(Color::BLACK)
         Children [
             Node {
                 position_type: PositionType::Absolute,
-                top: Val::Percent(50.0),
-                left: Val::Percent(20.0),
-                right: Val::Percent(20.0),
-                height: Val::Vh(40.0),
+                top: percent(50),
+                left: percent(20),
+                right: percent(20),
+                height: vh(40),
                 flex_direction: FlexDirection::Column,
                 align_items: AlignItems::FlexStart,
                 overflow: Overflow::scroll_y(),

--- a/examples/large_scenes/bevy_city/src/settings.rs
+++ b/examples/large_scenes/bevy_city/src/settings.rs
@@ -41,9 +41,9 @@ pub fn settings_ui() -> impl Scene {
     bsn! {
         Node {
             position_type: PositionType::Absolute,
-            top: Val::Px(10.0),
-            right: Val::Px(10.0),
-            padding: UiRect::all(Val::Px(8.0)),
+            top: px(10),
+            right: px(10),
+            padding: UiRect::all(px(8)),
         }
         ThemeBackgroundColor(feathers::tokens::WINDOW_BG)
         on(|_: On<Pointer<Over>>, mut free_camera_state: Single<&mut FreeCameraState>| {

--- a/examples/window/persisting_window_settings.rs
+++ b/examples/window/persisting_window_settings.rs
@@ -77,8 +77,8 @@ fn init_window_pos(app: &mut App) {
 fn setup(mut commands: Commands) {
     commands.spawn((Camera::default(), Camera2d));
     commands.spawn(Node {
-        width: Val::Percent(100.0),
-        height: Val::Percent(100.0),
+        width: percent(100),
+        height: percent(100),
         display: Display::Flex,
         flex_direction: FlexDirection::Column,
         align_items: AlignItems::Center,


### PR DESCRIPTION
This is my first bevy PR, please tell me if I'm doing anything wrong.

# Objective

Contribute to #22695.
Showcase the preferred coding style in all examples.

## Solution

Replace Val:: constructors with the more ergonomic shorthand functions. Change their float literals to integer literals if they are integral.

Exceptions:
  - const contexts (the shorthand functions are not const)
  - inside bsn! macros (these are new and presumably know what they are doing)
  - in testbed (these are not really examples)
  - Val::ZERO (no helper function)

## Testing

Ran the changed examples before and after, except the library example `widgets` where I just checked that it still builds.

## Context

There was PR #22765 that fixed the same thing but only in the UI examples.