### PR TITLE
Renamed `ToolButton` to `FeathersToolButton` to be consistent

### DIFF
--- a/crates/bevy_feathers/src/controls/button.rs
+++ b/crates/bevy_feathers/src/controls/button.rs
@@ -121,9 +121,9 @@ impl FeathersButton {
 ///  These events can be disabled by adding an [`bevy_ui::InteractionDisabled`] component to the entity
 #[derive(SceneComponent, Default, Clone)]
 #[scene(FeathersButtonProps)]
-pub struct ToolButton;
+pub struct FeathersToolButton;
 
-impl ToolButton {
+impl FeathersToolButton {
     fn scene(props: FeathersButtonProps) -> impl Scene {
         bsn! {
             :FeathersButton {

--- a/examples/ui/widgets/feathers_gallery.rs
+++ b/examples/ui/widgets/feathers_gallery.rs
@@ -15,7 +15,8 @@ use bevy::{
             FeathersColorSwatch, FeathersDisclosureToggle, FeathersMenu, FeathersMenuButton,
             FeathersMenuDivider, FeathersMenuItem, FeathersMenuPopup, FeathersNumberInput,
             FeathersRadio, FeathersSlider, FeathersTextInput, FeathersTextInputContainer,
-            FeathersToggleSwitch, NumberInputValue, SliderBaseColor, ToolButton, UpdateNumberInput,
+            FeathersToggleSwitch, FeathersToolButton, NumberInputValue, SliderBaseColor,
+            UpdateNumberInput,
         },
         cursor::{EntityCursor, OverrideCursor},
         dark_theme::create_dark_theme,
@@ -541,35 +542,35 @@ fn demo_column_2() -> impl Scene {
             (
                 :pane Children [
                     :pane_header Children [
-                        :ToolButton {
+                        :FeathersToolButton {
                             @variant: ButtonVariant::Primary,
                         } Children [
                             (Text("\u{0398}") ThemedText)
                         ],
                         :pane_header_divider,
-                        :ToolButton {
+                        :FeathersToolButton {
                             @variant: ButtonVariant::Plain,
                         } Children [
                             (Text("\u{00BC}") ThemedText)
                         ],
-                        :ToolButton {
+                        :FeathersToolButton {
                             @variant: ButtonVariant::Plain,
                         } Children [
                             (Text("\u{00BD}") ThemedText)
                         ],
-                        :ToolButton {
+                        :FeathersToolButton {
                             @variant: ButtonVariant::Plain,
                         } Children [
                             (Text("\u{00BE}") ThemedText)
                         ],
                         :pane_header_divider,
-                        :ToolButton {
+                        :FeathersToolButton {
                             @variant: ButtonVariant::Plain,
                         } Children [
                             :icon(icons::CHEVRON_DOWN)
                         ],
                         :flex_spacer,
-                        :ToolButton {
+                        :FeathersToolButton {
                             @variant: ButtonVariant::Plain,
                         } Children [
                             :icon(icons::X)


### PR DESCRIPTION
with naming conventions for other widgets.

# Objective

The `ToolButton` widget was not consistently named like the other controls.

## Solution

Renamed.

## Testing

Basic manual testing.

@cart 