### PR TITLE
Limit Pixel 10 to GPU preprocessing without GPU culling

### DIFF
--- a/crates/bevy_render/src/batching/gpu_preprocessing.rs
+++ b/crates/bevy_render/src/batching/gpu_preprocessing.rs
@@ -1328,9 +1328,11 @@ impl FromWorld for GpuPreprocessingSupport {
         // - We filter out Adreno 730 and earlier GPUs (except 720, as it's newer
         //   than 730).
         // - We filter out Mali GPUs with driver versions lower than 48.
+        // - We filter out Pixel 10 GPUs (all versions for now)
         fn is_non_supported_android_device(adapter_info: &RenderAdapterInfo) -> bool {
             crate::get_adreno_model(adapter_info).is_some_and(|model| model != 720 && model <= 730)
                 || crate::get_mali_driver_version(adapter_info).is_some_and(|version| version < 48)
+                || crate::get_pixel10_driver_version(adapter_info).is_some()
         }
 
         let culling_feature_support = device

--- a/crates/bevy_render/src/batching/gpu_preprocessing.rs
+++ b/crates/bevy_render/src/batching/gpu_preprocessing.rs
@@ -1328,11 +1328,13 @@ impl FromWorld for GpuPreprocessingSupport {
         // - We filter out Adreno 730 and earlier GPUs (except 720, as it's newer
         //   than 730).
         // - We filter out Mali GPUs with driver versions lower than 48.
-        // - We filter out Pixel 10 GPUs (all versions for now)
+        // - We limit Pixel 10 GPUs (all versions for now) to preprocessing only (no culling)
         fn is_non_supported_android_device(adapter_info: &RenderAdapterInfo) -> bool {
             crate::get_adreno_model(adapter_info).is_some_and(|model| model != 720 && model <= 730)
                 || crate::get_mali_driver_version(adapter_info).is_some_and(|version| version < 48)
-                || crate::get_pixel10_driver_version(adapter_info).is_some()
+        }
+        fn is_preprocessing_only_android_device(adapter_info: &RenderAdapterInfo) -> bool {
+            crate::get_pixel10_driver_version(&adapter_info).is_some()
         }
 
         let culling_feature_support = device
@@ -1364,7 +1366,9 @@ impl FromWorld for GpuPreprocessingSupport {
                 Falling back to CPU preprocessing.",
             );
             GpuPreprocessingMode::None
-        } else if !(culling_feature_support && limit_support && downlevel_support) {
+        } else if !(culling_feature_support && limit_support && downlevel_support)
+            || is_preprocessing_only_android_device(&adapter_info)
+        {
             info_once!("Some GPU preprocessing are limited on this device.");
             GpuPreprocessingMode::PreprocessingOnly
         } else {

--- a/crates/bevy_render/src/batching/gpu_preprocessing.rs
+++ b/crates/bevy_render/src/batching/gpu_preprocessing.rs
@@ -1334,7 +1334,7 @@ impl FromWorld for GpuPreprocessingSupport {
                 || crate::get_mali_driver_version(adapter_info).is_some_and(|version| version < 48)
         }
         fn is_preprocessing_only_android_device(adapter_info: &RenderAdapterInfo) -> bool {
-            crate::get_pixel10_driver_version(&adapter_info).is_some()
+            crate::get_pixel10_driver_version(adapter_info).is_some()
         }
 
         let culling_feature_support = device

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -566,6 +566,19 @@ pub fn get_mali_driver_version(adapter_info: &RenderAdapterInfo) -> Option<u32> 
     None
 }
 
+pub fn get_pixel10_driver_version(adapter_info: &RenderAdapterInfo) -> Option<u32> {
+    if !cfg!(target_os = "android") {
+        return None;
+    }
+
+    if adapter_info.name != "PowerVR D-Series DXT-48-1536 MC1" {
+        return None;
+    }
+
+    let (_, driver_version) = adapter_info.driver_info.split_once('@')?;
+    driver_version.parse::<u32>().ok()
+}
+
 /// Returns true if storage buffers are unsupported on this platform or false
 /// if they are supported.
 pub fn storage_buffers_are_unsupported(limits: &WgpuLimits) -> bool {


### PR DESCRIPTION
# Objective

- Workaround for #23754 until we find the actual issue or Google fixes its driver

## Solution

- Limit Pixel 10 to GPU preprocessing without GPU culling

## Testing

- Ran the android example on my Pixel 10