### PR TITLE
Increase time allocated to run-examples-on-windows-dx12

### DIFF
--- a/.github/workflows/example-run.yml
+++ b/.github/workflows/example-run.yml
@@ -172,7 +172,8 @@ jobs:
   run-examples-on-windows-dx12:
     if: ${{ github.event_name != 'pull_request' }}
     runs-on: windows-latest
-    timeout-minutes: 30
+    # See https://github.com/bevyengine/bevy/issues/24106 for discussions on speeding this up
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
# Objective

Stopgap solution for #24106 so we can actually merge things.

## Solution

Double the time allocated (we're game-devs here after all).
Leave a comment to the issue tracking this, so when we inevitably get annoyed about how slow this is we have a breadcrumb trail.

## Testing

CI do your thing!
