### PR TITLE
Rename `bevy_experimental_feathers` feature to `bevy_feathers`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -407,7 +407,7 @@ bevy_ui_widgets = ["bevy_internal/bevy_ui_widgets"]
 bevy_settings = ["bevy_internal/bevy_settings"]
 
 # Feathers widget collection.
-experimental_bevy_feathers = ["bevy_internal/bevy_feathers", "bevy_ui_widgets"]
+bevy_feathers = ["bevy_internal/bevy_feathers", "bevy_ui_widgets"]
 
 # Enable passthrough loading for SPIR-V shaders (Only supported on Vulkan, shader capabilities and extensions must agree with the platform implementation)
 spirv_shader_passthrough = ["bevy_internal/spirv_shader_passthrough"]
@@ -4075,7 +4075,7 @@ wasm = true
 name = "virtual_keyboard"
 path = "examples/ui/widgets/virtual_keyboard.rs"
 doc-scrape-examples = true
-required-features = ["experimental_bevy_feathers"]
+required-features = ["bevy_feathers"]
 
 [package.metadata.example.virtual_keyboard]
 name = "Virtual Keyboard"
@@ -5411,7 +5411,7 @@ wasm = true
 name = "feathers_counter"
 path = "examples/ui/widgets/feathers_counter.rs"
 doc-scrape-examples = true
-required-features = ["experimental_bevy_feathers"]
+required-features = ["bevy_feathers"]
 
 [package.metadata.example.feathers_counter]
 name = "Feathers Counter"
@@ -5423,7 +5423,7 @@ wasm = true
 name = "feathers_gallery"
 path = "examples/ui/widgets/feathers_gallery.rs"
 doc-scrape-examples = true
-required-features = ["experimental_bevy_feathers"]
+required-features = ["bevy_feathers"]
 
 [package.metadata.example.feathers_gallery]
 name = "Feathers Widgets"

--- a/_release-content/migration-guides/experimental_bevy_feathers.md
+++ b/_release-content/migration-guides/experimental_bevy_feathers.md
@@ -6,4 +6,4 @@ pull_requests: [TODO]
 The feature flag `experimental_bevy_feathers` is now `bevy_feathers`.
 
 With the introduction of `bsn!` and another cycle of bug fixes and features, the Feathers UI framework is now stable enough for broad use in tooling.
-While it remains incomplete and is subject to breaking changes, it is no longer substantialyl more experimental than the rest of Bevy.
+While it remains incomplete and is subject to breaking changes, it is no longer substantially more experimental than the rest of Bevy.

--- a/_release-content/migration-guides/experimental_bevy_feathers.md
+++ b/_release-content/migration-guides/experimental_bevy_feathers.md
@@ -1,6 +1,6 @@
 ---
 title: "The `experimental_bevy_feathers` feature is no longer experimental"
-pull_requests: [TODO]
+pull_requests: [24108]
 ---
 
 The feature flag `experimental_bevy_feathers` is now `bevy_feathers`.

--- a/_release-content/migration-guides/experimental_bevy_feathers.md
+++ b/_release-content/migration-guides/experimental_bevy_feathers.md
@@ -1,0 +1,9 @@
+---
+title: "The `experimental_bevy_feathers` feature is no longer experimental"
+pull_requests: [TODO]
+---
+
+The feature flag `experimental_bevy_feathers` is now `bevy_feathers`.
+
+With the introduction of `bsn!` and another cycle of bug fixes and features, the Feathers UI framework is now stable enough for broad use in tooling.
+While it remains incomplete and is subject to breaking changes, it is no longer substantialyl more experimental than the rest of Bevy.

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -19,12 +19,12 @@ For example, you can compile only the "2D" Bevy features (without the 3D feature
 bevy = { version = "0.18", default-features = false, features = ["2d"] }
 ```
 
-| Profile | Description                                                                                                  |
-| ------- | ------------------------------------------------------------------------------------------------------------ |
-| default | The full default Bevy experience. This is a combination of the following profiles: 2d, 3d, ui, audio         |
-| 2d      | The default 2D Bevy experience. This includes the core Bevy framework, 2D functionality, scenes and picking. |
-| 3d      | The default 3D Bevy experience. This includes the core Bevy framework, 3D functionality, scenes and picking. |
-| ui      | The default Bevy UI experience. This includes the core Bevy framework, Bevy UI, scenes, and picking.         |
+|Profile|Description|
+|-|-|
+|default|The full default Bevy experience. This is a combination of the following profiles: 2d, 3d, ui, audio|
+|2d|The default 2D Bevy experience. This includes the core Bevy framework, 2D functionality, scenes and picking.|
+|3d|The default 3D Bevy experience. This includes the core Bevy framework, 3D functionality, scenes and picking.|
+|ui|The default Bevy UI experience. This includes the core Bevy framework, Bevy UI, scenes, and picking.|
 
 By default, the `bevy` crate enables the  features.
 
@@ -34,179 +34,179 @@ By default, the `bevy` crate enables the  features.
 suit your use case (ex: you want to use a custom renderer, you want to build a "headless" app, you want to target no_std, etc), then you can use these
 collections to build your own "profile" equivalent, without needing to manually manage _every single_ feature.
 
-| Collection        | Description                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| dev               | Enable this feature during development to improve the development experience. This adds features like asset hot-reloading and debugging tools. This should not be enabled for published apps! **Feature set:** `debug`, `bevy_dev_tools`, `file_watcher`.                                                                                                                                                                                             |
-| audio             | Features used to build audio Bevy apps. **Feature set:** `bevy_audio`, `vorbis`.                                                                                                                                                                                                                                                                                                                                                                      |
-| audio-all-formats | Enables audio features and all supported formats. **Feature set:** `bevy_audio`, `aac`, `flac`, `mp3`, `mp4`, `vorbis`, `wav`.                                                                                                                                                                                                                                                                                                                        |
-| scene             | Features used to compose Bevy scenes. **Feature set:** `bevy_world_serialization`, `bevy_scene`.                                                                                                                                                                                                                                                                                                                                                      |
-| picking           | Enables picking with all backends. **Feature set:** `bevy_picking`, `mesh_picking`, `sprite_picking`, `ui_picking`.                                                                                                                                                                                                                                                                                                                                   |
-| default_app       | The core pieces that most apps need. This serves as a baseline feature set for other higher level feature collections (such as "2d" and "3d"). It is also useful as a baseline feature set for scenarios like headless apps that require no rendering (ex: command line tools, servers, etc). **Feature set:** `async_executor`, `bevy_asset`, `bevy_input_focus`, `bevy_log`, `bevy_state`, `bevy_window`, `custom_cursor`, `reflect_auto_register`. |
-| default_platform  | These are platform support features, such as OS support/features, windowing and input backends, etc. **Feature set:** `std`, `bevy_gilrs`, `bevy_winit`, `bevy_clipboard`, `default_font`, `multi_threaded`, `webgl2`, `x11`, `wayland`, `sysinfo_plugin`.                                                                                                                                                                                            |
-| common_api        | Default scene definition features. Note that this does not include an actual renderer, such as bevy_render (Bevy's default render backend). **Feature set:** `bevy_animation`, `bevy_camera`, `bevy_color`, `bevy_gizmos`, `bevy_image`, `bevy_mesh`, `bevy_shader`, `bevy_material`, `bevy_text`, `hdr`, `png`.                                                                                                                                      |
-| 2d_api            | Features used to build 2D Bevy apps (does not include a render backend). You generally don't need to worry about this unless you are using a custom renderer. **Feature set:** `common_api`, `bevy_sprite`.                                                                                                                                                                                                                                           |
-| 2d_bevy_render    | Bevy's built-in 2D renderer, built on top of `bevy_render`. **Feature set:** `2d_api`, `bevy_render`, `bevy_core_pipeline`, `bevy_post_process`, `bevy_sprite_render`, `bevy_gizmos_render`.                                                                                                                                                                                                                                                          |
-| 3d_api            | Features used to build 3D Bevy apps (does not include a render backend). You generally don't need to worry about this unless you are using a custom renderer. **Feature set:** `common_api`, `bevy_light`, `bevy_mikktspace`, `ktx2`, `morph_animation`, `morph`, `smaa_luts`, `tonemapping_luts`, `zstd_rust`.                                                                                                                                       |
-| 3d_bevy_render    | Bevy's built-in 3D renderer, built on top of `bevy_render`. **Feature set:** `3d_api`, `bevy_render`, `bevy_core_pipeline`, `bevy_gizmos_render`, `bevy_anti_alias`, `bevy_gltf`, `bevy_pbr`, `bevy_post_process`, `gltf_animation`.                                                                                                                                                                                                                  |
-| ui_api            | Features used to build UI Bevy apps (does not include a render backend). You generally don't need to worry about this unless you are using a custom renderer. **Feature set:** `default_app`, `common_api`, `bevy_ui`.                                                                                                                                                                                                                                |
-| ui_bevy_render    | Bevy's built-in UI renderer, built on top of `bevy_render`. **Feature set:** `ui_api`, `bevy_render`, `bevy_core_pipeline`, `bevy_ui_render`.                                                                                                                                                                                                                                                                                                         |
-| default_no_std    | Recommended defaults for no_std applications. **Feature set:** `libm`, `critical-section`, `bevy_color`, `bevy_state`.                                                                                                                                                                                                                                                                                                                                |
+|Collection|Description|
+|-|-|
+|dev|Enable this feature during development to improve the development experience. This adds features like asset hot-reloading and debugging tools. This should not be enabled for published apps! **Feature set:** `debug`, `bevy_dev_tools`, `file_watcher`.|
+|audio|Features used to build audio Bevy apps. **Feature set:** `bevy_audio`, `vorbis`.|
+|audio-all-formats|Enables audio features and all supported formats. **Feature set:** `bevy_audio`, `aac`, `flac`, `mp3`, `mp4`, `vorbis`, `wav`.|
+|scene|Features used to compose Bevy scenes. **Feature set:** `bevy_world_serialization`, `bevy_scene`.|
+|picking|Enables picking with all backends. **Feature set:** `bevy_picking`, `mesh_picking`, `sprite_picking`, `ui_picking`.|
+|default_app|The core pieces that most apps need. This serves as a baseline feature set for other higher level feature collections (such as "2d" and "3d"). It is also useful as a baseline feature set for scenarios like headless apps that require no rendering (ex: command line tools, servers, etc). **Feature set:** `async_executor`, `bevy_asset`, `bevy_input_focus`, `bevy_log`, `bevy_state`, `bevy_window`, `custom_cursor`, `reflect_auto_register`.|
+|default_platform|These are platform support features, such as OS support/features, windowing and input backends, etc. **Feature set:** `std`, `bevy_gilrs`, `bevy_winit`, `bevy_clipboard`, `default_font`, `multi_threaded`, `webgl2`, `x11`, `wayland`, `sysinfo_plugin`.|
+|common_api|Default scene definition features. Note that this does not include an actual renderer, such as bevy_render (Bevy's default render backend). **Feature set:** `bevy_animation`, `bevy_camera`, `bevy_color`, `bevy_gizmos`, `bevy_image`, `bevy_mesh`, `bevy_shader`, `bevy_material`, `bevy_text`, `hdr`, `png`.|
+|2d_api|Features used to build 2D Bevy apps (does not include a render backend). You generally don't need to worry about this unless you are using a custom renderer. **Feature set:** `common_api`, `bevy_sprite`.|
+|2d_bevy_render|Bevy's built-in 2D renderer, built on top of `bevy_render`. **Feature set:** `2d_api`, `bevy_render`, `bevy_core_pipeline`, `bevy_post_process`, `bevy_sprite_render`, `bevy_gizmos_render`.|
+|3d_api|Features used to build 3D Bevy apps (does not include a render backend). You generally don't need to worry about this unless you are using a custom renderer. **Feature set:** `common_api`, `bevy_light`, `bevy_mikktspace`, `ktx2`, `morph_animation`, `morph`, `smaa_luts`, `tonemapping_luts`, `zstd_rust`.|
+|3d_bevy_render|Bevy's built-in 3D renderer, built on top of `bevy_render`. **Feature set:** `3d_api`, `bevy_render`, `bevy_core_pipeline`, `bevy_gizmos_render`, `bevy_anti_alias`, `bevy_gltf`, `bevy_pbr`, `bevy_post_process`, `gltf_animation`.|
+|ui_api|Features used to build UI Bevy apps (does not include a render backend). You generally don't need to worry about this unless you are using a custom renderer. **Feature set:** `default_app`, `common_api`, `bevy_ui`.|
+|ui_bevy_render|Bevy's built-in UI renderer, built on top of `bevy_render`. **Feature set:** `ui_api`, `bevy_render`, `bevy_core_pipeline`, `bevy_ui_render`.|
+|default_no_std|Recommended defaults for no_std applications. **Feature set:** `libm`, `critical-section`, `bevy_color`, `bevy_state`.|
 
 ### Feature List
 
 This is the complete `bevy` cargo feature list, without "profiles" or "collections" (sorted by name):
 
-| Feature                           | Description                                                                                                                                                                                                                                                     |
-| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| aac                               | AAC audio format support (through `symphonia`)                                                                                                                                                                                                                  |
-| accesskit_unix                    | Enable AccessKit on Unix backends (currently only works with experimental screen readers and forks.)                                                                                                                                                            |
-| android-game-activity             | Android GameActivity support. Default, choose between this and `android-native-activity`.                                                                                                                                                                       |
-| android-native-activity           | Android NativeActivity support. Legacy, should be avoided for most new Android games.                                                                                                                                                                           |
-| asset_processor                   | Enables the built-in asset processor for processed assets.                                                                                                                                                                                                      |
-| async-io                          | Use async-io's implementation of block_on instead of futures-lite's implementation. This is preferred if your application uses async-io.                                                                                                                        |
-| async_executor                    | Uses `async-executor` as a task execution backend.                                                                                                                                                                                                              |
-| basis-universal                   | Basis Universal compressed texture support                                                                                                                                                                                                                      |
-| bevy_animation                    | Provides animation functionality                                                                                                                                                                                                                                |
-| bevy_anti_alias                   | Provides various anti aliasing solutions                                                                                                                                                                                                                        |
-| bevy_asset                        | Provides asset functionality                                                                                                                                                                                                                                    |
-| bevy_audio                        | Provides audio functionality                                                                                                                                                                                                                                    |
-| bevy_camera                       | Provides camera and visibility types, as well as culling primitives.                                                                                                                                                                                            |
-| bevy_camera_controller            | Provides a collection of prebuilt camera controllers                                                                                                                                                                                                            |
-| bevy_ci_testing                   | Enable systems that allow for automated testing on CI                                                                                                                                                                                                           |
-| bevy_clipboard                    | Clipboard resource and management. See `system_clipboard` for OS-integrated clipboard support.                                                                                                                                                                  |
-| bevy_color                        | Provides shared color types and operations                                                                                                                                                                                                                      |
-| bevy_core_pipeline                | Provides cameras and other basic render pipeline features                                                                                                                                                                                                       |
-| bevy_debug_stepping               | Enable stepping-based debugging of Bevy systems                                                                                                                                                                                                                 |
-| bevy_dev_tools                    | Provides a collection of developer tools                                                                                                                                                                                                                        |
-| bevy_gilrs                        | Adds gamepad support                                                                                                                                                                                                                                            |
-| bevy_gizmos                       | Adds support for gizmos                                                                                                                                                                                                                                         |
-| bevy_gizmos_render                | Adds support for rendering gizmos                                                                                                                                                                                                                               |
-| bevy_gltf                         | [glTF](https://www.khronos.org/gltf/) support                                                                                                                                                                                                                   |
-| bevy_image                        | Load and access image data. Usually added by an image format                                                                                                                                                                                                    |
-| bevy_input_focus                  | Enable input focus subsystem                                                                                                                                                                                                                                    |
-| bevy_light                        | Provides light types such as point lights, directional lights, spotlights.                                                                                                                                                                                      |
-| bevy_log                          | Enable integration with `tracing` and `log`                                                                                                                                                                                                                     |
-| bevy_material                     | Provides materials.                                                                                                                                                                                                                                             |
-| bevy_mesh                         | Provides a mesh format and some primitive meshing routines.                                                                                                                                                                                                     |
-| bevy_mikktspace                   | Provides vertex tangent generation for use with bevy_mesh.                                                                                                                                                                                                      |
-| bevy_pbr                          | Adds PBR rendering                                                                                                                                                                                                                                              |
-| bevy_picking                      | Provides picking functionality without any backend                                                                                                                                                                                                              |
-| bevy_post_process                 | Provides post process effects such as depth of field, bloom, chromatic aberration.                                                                                                                                                                              |
-| bevy_remote                       | Enable the Bevy Remote Protocol                                                                                                                                                                                                                                 |
-| bevy_render                       | Provides rendering functionality                                                                                                                                                                                                                                |
-| bevy_scene                        | Provides scene functionality                                                                                                                                                                                                                                    |
-| bevy_settings                     | Load and save user preferences                                                                                                                                                                                                                                  |
-| bevy_shader                       | Provides shaders usable through asset handles.                                                                                                                                                                                                                  |
-| bevy_solari                       | Provides raytraced lighting (experimental)                                                                                                                                                                                                                      |
-| bevy_sprite                       | Provides sprite functionality                                                                                                                                                                                                                                   |
-| bevy_sprite_render                | Provides sprite rendering functionality                                                                                                                                                                                                                         |
-| bevy_state                        | Enable built in global state machines                                                                                                                                                                                                                           |
-| bevy_text                         | Provides text functionality                                                                                                                                                                                                                                     |
-| bevy_ui                           | A custom ECS-driven UI framework                                                                                                                                                                                                                                |
-| bevy_ui_debug                     | Provides a debug overlay for bevy UI                                                                                                                                                                                                                            |
-| bevy_ui_render                    | Provides rendering functionality for bevy_ui                                                                                                                                                                                                                    |
-| bevy_ui_widgets                   | Headless widget collection for Bevy UI.                                                                                                                                                                                                                         |
-| bevy_window                       | Windowing layer                                                                                                                                                                                                                                                 |
-| bevy_winit                        | winit window and input backend                                                                                                                                                                                                                                  |
-| bevy_world_serialization          | Provides ECS serialization functionality                                                                                                                                                                                                                        |
-| bluenoise_texture                 | Include spatio-temporal blue noise KTX2 file used by generated environment maps, Solari and atmosphere                                                                                                                                                          |
-| bmp                               | BMP image format support                                                                                                                                                                                                                                        |
-| clipboard_image                   | Enables image copy/paste via the system clipboard. Not supported on WASM.                                                                                                                                                                                       |
-| compressed_image_saver            | Enables compressed KTX2 UASTC texture output on the asset processor                                                                                                                                                                                             |
-| critical-section                  | `critical-section` provides the building blocks for synchronization primitives on all platforms, including `no_std`.                                                                                                                                            |
-| custom_cursor                     | Enable winit custom cursor support                                                                                                                                                                                                                              |
-| dds                               | DDS compressed texture support                                                                                                                                                                                                                                  |
-| debug                             | Enable collecting debug information about systems and components to help with diagnostics                                                                                                                                                                       |
-| debug_glam_assert                 | Enable assertions in debug builds to check the validity of parameters passed to glam                                                                                                                                                                            |
-| default_font                      | Include a default font, containing only ASCII characters, at the cost of a 20kB binary size increase                                                                                                                                                            |
-| detailed_trace                    | Enable detailed trace event logging. These trace events are expensive even when off, thus they require compile time opt-in                                                                                                                                      |
-| dfg_lut                           | Include a preintegrated BRDF Look Up Table for more accurate specular shading.                                                                                                                                                                                  |
-| dlss                              | NVIDIA Deep Learning Super Sampling                                                                                                                                                                                                                             |
-| dynamic_linking                   | Force dynamic linking, which improves iterative compile times                                                                                                                                                                                                   |
-| embedded_watcher                  | Enables watching in memory asset providers for Bevy Asset hot-reloading                                                                                                                                                                                         |
-| bevy_feathers                     | Feathers widget collection.                                                                                                                                                                                                                                     |
-| experimental_pbr_pcss             | Enable support for PCSS, at the risk of blowing past the global, per-shader sampler limit on older/lower-end GPUs                                                                                                                                               |
-| exr                               | EXR image format support                                                                                                                                                                                                                                        |
-| ff                                | Farbfeld image format support                                                                                                                                                                                                                                   |
-| file_watcher                      | Enables watching the filesystem for Bevy Asset hot-reloading                                                                                                                                                                                                    |
-| flac                              | FLAC audio format support (through `claxon`)                                                                                                                                                                                                                    |
-| force_disable_dlss                | Forcibly disable DLSS so that cargo build --all-features works without the DLSS SDK being installed. Not meant for users.                                                                                                                                       |
-| free_camera                       | Enables the free cam from bevy_camera_controller                                                                                                                                                                                                                |
-| gamepad                           | Gamepad support. Automatically enabled by `bevy_gilrs`.                                                                                                                                                                                                         |
-| gestures                          | Gestures support. Automatically enabled by `bevy_window`.                                                                                                                                                                                                       |
-| ghost_nodes                       | Experimental support for nodes that are ignored for UI layouting                                                                                                                                                                                                |
-| gif                               | GIF image format support                                                                                                                                                                                                                                        |
-| glam_assert                       | Enable assertions to check the validity of parameters passed to glam                                                                                                                                                                                            |
-| gltf_animation                    | Enable glTF animation loading                                                                                                                                                                                                                                   |
-| hdr                               | HDR image format support                                                                                                                                                                                                                                        |
-| hotpatching                       | Enable hotpatching of Bevy systems                                                                                                                                                                                                                              |
-| http                              | Enables downloading assets from HTTP sources. Warning: there are security implications. Read the docs on WebAssetPlugin.                                                                                                                                        |
-| https                             | Enables downloading assets from HTTPS sources. Warning: there are security implications. Read the docs on WebAssetPlugin.                                                                                                                                       |
-| ico                               | ICO image format support                                                                                                                                                                                                                                        |
-| jpeg                              | JPEG image format support                                                                                                                                                                                                                                       |
-| keyboard                          | Keyboard support. Automatically enabled by `bevy_window`.                                                                                                                                                                                                       |
-| ktx2                              | KTX2 compressed texture support                                                                                                                                                                                                                                 |
-| libm                              | Uses the `libm` maths library instead of the one provided in `std` and `core`.                                                                                                                                                                                  |
-| mesh_picking                      | Provides an implementation for picking meshes                                                                                                                                                                                                                   |
-| meshlet                           | Enables the meshlet renderer for dense high-poly scenes (experimental)                                                                                                                                                                                          |
-| meshlet_processor                 | Enables processing meshes into meshlet meshes for bevy_pbr                                                                                                                                                                                                      |
-| morph                             | Enables support for morph target weights in bevy_mesh                                                                                                                                                                                                           |
-| morph_animation                   | Enables bevy_mesh and bevy_animation morph weight support                                                                                                                                                                                                       |
-| mouse                             | Mouse support. Automatically enabled by `bevy_window`.                                                                                                                                                                                                          |
-| mp3                               | MP3 audio format support (through `symphonia`)                                                                                                                                                                                                                  |
-| mp4                               | MP4 audio format support (through `symphonia`). It also enables AAC support.                                                                                                                                                                                    |
-| multi_threaded                    | Enables multithreaded parallelism in the engine. Disabling it forces all engine tasks to run on a single thread.                                                                                                                                                |
-| pan_camera                        | Enables the pan camera from bevy_camera_controller                                                                                                                                                                                                              |
-| pbr_anisotropy_texture            | Enable support for anisotropy texture in the `StandardMaterial`, at the risk of blowing past the global, per-shader texture limit on older/lower-end GPUs                                                                                                       |
-| pbr_clustered_decals              | Enable support for Clustered Decals                                                                                                                                                                                                                             |
-| pbr_light_textures                | Enable support for Light Textures                                                                                                                                                                                                                               |
-| pbr_multi_layer_material_textures | Enable support for multi-layer material textures in the `StandardMaterial`, at the risk of blowing past the global, per-shader texture limit on older/lower-end GPUs                                                                                            |
-| pbr_specular_textures             | Enable support for specular textures in the `StandardMaterial`, at the risk of blowing past the global, per-shader texture limit on older/lower-end GPUs                                                                                                        |
-| pbr_transmission_textures         | Enable support for transmission-related textures in the `StandardMaterial`, at the risk of blowing past the global, per-shader texture limit on older/lower-end GPUs                                                                                            |
-| png                               | PNG image format support                                                                                                                                                                                                                                        |
-| pnm                               | PNM image format support, includes pam, pbm, pgm and ppm                                                                                                                                                                                                        |
-| qoi                               | QOI image format support                                                                                                                                                                                                                                        |
-| raw_vulkan_init                   | Forces the wgpu instance to be initialized using the raw Vulkan HAL, enabling additional configuration                                                                                                                                                          |
-| reflect_auto_register             | Enable automatic reflect registration                                                                                                                                                                                                                           |
-| reflect_auto_register_static      | Enable automatic reflect registration without inventory. See `reflect::load_type_registrations` for more info.                                                                                                                                                  |
-| reflect_documentation             | Enables bevy_reflect to access documentation comments of rust code at runtime                                                                                                                                                                                   |
-| reflect_functions                 | Enable function reflection                                                                                                                                                                                                                                      |
-| schedule_data                     | Enable collecting schedule data from the app.                                                                                                                                                                                                                   |
-| serialize                         | Enable serialization support through serde                                                                                                                                                                                                                      |
-| shader_format_glsl                | Enable support for shaders in GLSL                                                                                                                                                                                                                              |
-| shader_format_spirv               | Enable support for shaders in SPIR-V                                                                                                                                                                                                                            |
-| shader_format_wesl                | Enable support for shaders in WESL                                                                                                                                                                                                                              |
-| smaa_luts                         | Include SMAA Look Up Tables KTX2 Files                                                                                                                                                                                                                          |
-| spirv_shader_passthrough          | Enable passthrough loading for SPIR-V shaders (Only supported on Vulkan, shader capabilities and extensions must agree with the platform implementation)                                                                                                        |
-| sprite_picking                    | Provides an implementation for picking sprites                                                                                                                                                                                                                  |
-| statically-linked-dxc             | Statically linked DXC shader compiler for DirectX 12                                                                                                                                                                                                            |
-| std                               | Allows access to the `std` crate.                                                                                                                                                                                                                               |
-| symphonia-flac                    | FLAC audio format support (through `symphonia`)                                                                                                                                                                                                                 |
-| symphonia-vorbis                  | OGG/VORBIS audio format support (through `symphonia`)                                                                                                                                                                                                           |
-| symphonia-wav                     | WAV audio format support (through `symphonia`)                                                                                                                                                                                                                  |
-| sysinfo_plugin                    | Enables system information diagnostic plugin                                                                                                                                                                                                                    |
-| system_clipboard                  | Enables system-level clipboard support.                                                                                                                                                                                                                         |
-| system_font_discovery             | Allows for discovery of preloaded system fonts                                                                                                                                                                                                                  |
-| tga                               | TGA image format support                                                                                                                                                                                                                                        |
-| tiff                              | TIFF image format support                                                                                                                                                                                                                                       |
-| tonemapping_luts                  | Include tonemapping Look Up Tables KTX2 files. If everything is pink, you need to enable this feature or change the `Tonemapping` method for your `Camera2d` or `Camera3d`.                                                                                     |
-| touch                             | Touch support. Automatically enabled by `bevy_window`.                                                                                                                                                                                                          |
-| trace                             | Tracing support                                                                                                                                                                                                                                                 |
-| trace_chrome                      | Tracing support, saving a file in Chrome Tracing format                                                                                                                                                                                                         |
-| trace_tracy                       | Tracing support, exposing a port for Tracy                                                                                                                                                                                                                      |
-| trace_tracy_memory                | Tracing support, with memory profiling, exposing a port for Tracy                                                                                                                                                                                               |
-| track_location                    | Enables source location tracking for change detection and spawning/despawning, which can assist with debugging                                                                                                                                                  |
-| type_label_buffers                | Pre-populate buffer labels with buffer types for debugging.                                                                                                                                                                                                     |
-| ui_picking                        | Provides an implementation for picking UI                                                                                                                                                                                                                       |
-| vorbis                            | OGG/VORBIS audio format support (through `lewton`)                                                                                                                                                                                                              |
-| wav                               | WAV audio format support (through `hound`)                                                                                                                                                                                                                      |
-| wayland                           | Wayland display server support                                                                                                                                                                                                                                  |
-| web                               | Enables use of browser APIs. Note this is currently only applicable on `wasm32` architectures.                                                                                                                                                                  |
-| web_asset_cache                   | Enable caching downloaded assets on the filesystem. NOTE: this cache currently never invalidates entries!                                                                                                                                                       |
-| webgl2                            | Enable some limitations to be able to use WebGL2. Please refer to the [WebGL2 and WebGPU](https://github.com/bevyengine/bevy/tree/latest/examples#webgl2-and-webgpu) section of the examples README for more information on how to run Wasm builds with WebGPU. |
-| webgpu                            | Enable support for WebGPU in Wasm. When enabled, this feature will override the `webgl2` feature and you won't be able to run Wasm builds with WebGL2, only with WebGPU.                                                                                        |
-| webp                              | WebP image format support                                                                                                                                                                                                                                       |
-| x11                               | X11 display server support                                                                                                                                                                                                                                      |
-| zlib                              | For KTX2 supercompression                                                                                                                                                                                                                                       |
-| zstd_c                            | For KTX2 Zstandard decompression using [zstd](https://crates.io/crates/zstd). This is a faster backend, but uses unsafe C bindings. For the safe option, stick to the default backend with "zstd_rust".                                                         |
-| zstd_rust                         | For KTX2 Zstandard decompression using pure rust [ruzstd](https://crates.io/crates/ruzstd). This is the safe default. For maximum performance, use "zstd_c".                                                                                                    |
+|Feature|Description|
+|-|-|
+|aac|AAC audio format support (through `symphonia`)|
+|accesskit_unix|Enable AccessKit on Unix backends (currently only works with experimental screen readers and forks.)|
+|android-game-activity|Android GameActivity support. Default, choose between this and `android-native-activity`.|
+|android-native-activity|Android NativeActivity support. Legacy, should be avoided for most new Android games.|
+|asset_processor|Enables the built-in asset processor for processed assets.|
+|async-io|Use async-io's implementation of block_on instead of futures-lite's implementation. This is preferred if your application uses async-io.|
+|async_executor|Uses `async-executor` as a task execution backend.|
+|basis-universal|Basis Universal compressed texture support|
+|bevy_animation|Provides animation functionality|
+|bevy_anti_alias|Provides various anti aliasing solutions|
+|bevy_asset|Provides asset functionality|
+|bevy_audio|Provides audio functionality|
+|bevy_camera|Provides camera and visibility types, as well as culling primitives.|
+|bevy_camera_controller|Provides a collection of prebuilt camera controllers|
+|bevy_ci_testing|Enable systems that allow for automated testing on CI|
+|bevy_clipboard|Clipboard resource and management. See `system_clipboard` for OS-integrated clipboard support.|
+|bevy_color|Provides shared color types and operations|
+|bevy_core_pipeline|Provides cameras and other basic render pipeline features|
+|bevy_debug_stepping|Enable stepping-based debugging of Bevy systems|
+|bevy_dev_tools|Provides a collection of developer tools|
+|bevy_feathers|Feathers widget collection.|
+|bevy_gilrs|Adds gamepad support|
+|bevy_gizmos|Adds support for gizmos|
+|bevy_gizmos_render|Adds support for rendering gizmos|
+|bevy_gltf|[glTF](https://www.khronos.org/gltf/) support|
+|bevy_image|Load and access image data. Usually added by an image format|
+|bevy_input_focus|Enable input focus subsystem|
+|bevy_light|Provides light types such as point lights, directional lights, spotlights.|
+|bevy_log|Enable integration with `tracing` and `log`|
+|bevy_material|Provides materials.|
+|bevy_mesh|Provides a mesh format and some primitive meshing routines.|
+|bevy_mikktspace|Provides vertex tangent generation for use with bevy_mesh.|
+|bevy_pbr|Adds PBR rendering|
+|bevy_picking|Provides picking functionality without any backend|
+|bevy_post_process|Provides post process effects such as depth of field, bloom, chromatic aberration.|
+|bevy_remote|Enable the Bevy Remote Protocol|
+|bevy_render|Provides rendering functionality|
+|bevy_scene|Provides scene functionality|
+|bevy_settings|Load and save user preferences|
+|bevy_shader|Provides shaders usable through asset handles.|
+|bevy_solari|Provides raytraced lighting (experimental)|
+|bevy_sprite|Provides sprite functionality|
+|bevy_sprite_render|Provides sprite rendering functionality|
+|bevy_state|Enable built in global state machines|
+|bevy_text|Provides text functionality|
+|bevy_ui|A custom ECS-driven UI framework|
+|bevy_ui_debug|Provides a debug overlay for bevy UI|
+|bevy_ui_render|Provides rendering functionality for bevy_ui|
+|bevy_ui_widgets|Headless widget collection for Bevy UI.|
+|bevy_window|Windowing layer|
+|bevy_winit|winit window and input backend|
+|bevy_world_serialization|Provides ECS serialization functionality|
+|bluenoise_texture|Include spatio-temporal blue noise KTX2 file used by generated environment maps, Solari and atmosphere|
+|bmp|BMP image format support|
+|clipboard_image|Enables image copy/paste via the system clipboard. Not supported on WASM.|
+|compressed_image_saver|Enables compressed KTX2 UASTC texture output on the asset processor|
+|critical-section|`critical-section` provides the building blocks for synchronization primitives on all platforms, including `no_std`.|
+|custom_cursor|Enable winit custom cursor support|
+|dds|DDS compressed texture support|
+|debug|Enable collecting debug information about systems and components to help with diagnostics|
+|debug_glam_assert|Enable assertions in debug builds to check the validity of parameters passed to glam|
+|default_font|Include a default font, containing only ASCII characters, at the cost of a 20kB binary size increase|
+|detailed_trace|Enable detailed trace event logging. These trace events are expensive even when off, thus they require compile time opt-in|
+|dfg_lut|Include a preintegrated BRDF Look Up Table for more accurate specular shading.|
+|dlss|NVIDIA Deep Learning Super Sampling|
+|dynamic_linking|Force dynamic linking, which improves iterative compile times|
+|embedded_watcher|Enables watching in memory asset providers for Bevy Asset hot-reloading|
+|experimental_pbr_pcss|Enable support for PCSS, at the risk of blowing past the global, per-shader sampler limit on older/lower-end GPUs|
+|exr|EXR image format support|
+|ff|Farbfeld image format support|
+|file_watcher|Enables watching the filesystem for Bevy Asset hot-reloading|
+|flac|FLAC audio format support (through `claxon`)|
+|force_disable_dlss|Forcibly disable DLSS so that cargo build --all-features works without the DLSS SDK being installed. Not meant for users.|
+|free_camera|Enables the free cam from bevy_camera_controller|
+|gamepad|Gamepad support. Automatically enabled by `bevy_gilrs`.|
+|gestures|Gestures support. Automatically enabled by `bevy_window`.|
+|ghost_nodes|Experimental support for nodes that are ignored for UI layouting|
+|gif|GIF image format support|
+|glam_assert|Enable assertions to check the validity of parameters passed to glam|
+|gltf_animation|Enable glTF animation loading|
+|hdr|HDR image format support|
+|hotpatching|Enable hotpatching of Bevy systems|
+|http|Enables downloading assets from HTTP sources. Warning: there are security implications. Read the docs on WebAssetPlugin.|
+|https|Enables downloading assets from HTTPS sources. Warning: there are security implications. Read the docs on WebAssetPlugin.|
+|ico|ICO image format support|
+|jpeg|JPEG image format support|
+|keyboard|Keyboard support. Automatically enabled by `bevy_window`.|
+|ktx2|KTX2 compressed texture support|
+|libm|Uses the `libm` maths library instead of the one provided in `std` and `core`.|
+|mesh_picking|Provides an implementation for picking meshes|
+|meshlet|Enables the meshlet renderer for dense high-poly scenes (experimental)|
+|meshlet_processor|Enables processing meshes into meshlet meshes for bevy_pbr|
+|morph|Enables support for morph target weights in bevy_mesh|
+|morph_animation|Enables bevy_mesh and bevy_animation morph weight support|
+|mouse|Mouse support. Automatically enabled by `bevy_window`.|
+|mp3|MP3 audio format support (through `symphonia`)|
+|mp4|MP4 audio format support (through `symphonia`). It also enables AAC support.|
+|multi_threaded|Enables multithreaded parallelism in the engine. Disabling it forces all engine tasks to run on a single thread.|
+|pan_camera|Enables the pan camera from bevy_camera_controller|
+|pbr_anisotropy_texture|Enable support for anisotropy texture in the `StandardMaterial`, at the risk of blowing past the global, per-shader texture limit on older/lower-end GPUs|
+|pbr_clustered_decals|Enable support for Clustered Decals|
+|pbr_light_textures|Enable support for Light Textures|
+|pbr_multi_layer_material_textures|Enable support for multi-layer material textures in the `StandardMaterial`, at the risk of blowing past the global, per-shader texture limit on older/lower-end GPUs|
+|pbr_specular_textures|Enable support for specular textures in the `StandardMaterial`, at the risk of blowing past the global, per-shader texture limit on older/lower-end GPUs|
+|pbr_transmission_textures|Enable support for transmission-related textures in the `StandardMaterial`, at the risk of blowing past the global, per-shader texture limit on older/lower-end GPUs|
+|png|PNG image format support|
+|pnm|PNM image format support, includes pam, pbm, pgm and ppm|
+|qoi|QOI image format support|
+|raw_vulkan_init|Forces the wgpu instance to be initialized using the raw Vulkan HAL, enabling additional configuration|
+|reflect_auto_register|Enable automatic reflect registration|
+|reflect_auto_register_static|Enable automatic reflect registration without inventory. See `reflect::load_type_registrations` for more info.|
+|reflect_documentation|Enables bevy_reflect to access documentation comments of rust code at runtime|
+|reflect_functions|Enable function reflection|
+|schedule_data|Enable collecting schedule data from the app.|
+|serialize|Enable serialization support through serde|
+|shader_format_glsl|Enable support for shaders in GLSL|
+|shader_format_spirv|Enable support for shaders in SPIR-V|
+|shader_format_wesl|Enable support for shaders in WESL|
+|smaa_luts|Include SMAA Look Up Tables KTX2 Files|
+|spirv_shader_passthrough|Enable passthrough loading for SPIR-V shaders (Only supported on Vulkan, shader capabilities and extensions must agree with the platform implementation)|
+|sprite_picking|Provides an implementation for picking sprites|
+|statically-linked-dxc|Statically linked DXC shader compiler for DirectX 12|
+|std|Allows access to the `std` crate.|
+|symphonia-flac|FLAC audio format support (through `symphonia`)|
+|symphonia-vorbis|OGG/VORBIS audio format support (through `symphonia`)|
+|symphonia-wav|WAV audio format support (through `symphonia`)|
+|sysinfo_plugin|Enables system information diagnostic plugin|
+|system_clipboard|Enables system-level clipboard support.|
+|system_font_discovery|Allows for discovery of preloaded system fonts|
+|tga|TGA image format support|
+|tiff|TIFF image format support|
+|tonemapping_luts|Include tonemapping Look Up Tables KTX2 files. If everything is pink, you need to enable this feature or change the `Tonemapping` method for your `Camera2d` or `Camera3d`.|
+|touch|Touch support. Automatically enabled by `bevy_window`.|
+|trace|Tracing support|
+|trace_chrome|Tracing support, saving a file in Chrome Tracing format|
+|trace_tracy|Tracing support, exposing a port for Tracy|
+|trace_tracy_memory|Tracing support, with memory profiling, exposing a port for Tracy|
+|track_location|Enables source location tracking for change detection and spawning/despawning, which can assist with debugging|
+|type_label_buffers|Pre-populate buffer labels with buffer types for debugging.|
+|ui_picking|Provides an implementation for picking UI|
+|vorbis|OGG/VORBIS audio format support (through `lewton`)|
+|wav|WAV audio format support (through `hound`)|
+|wayland|Wayland display server support|
+|web|Enables use of browser APIs. Note this is currently only applicable on `wasm32` architectures.|
+|web_asset_cache|Enable caching downloaded assets on the filesystem. NOTE: this cache currently never invalidates entries!|
+|webgl2|Enable some limitations to be able to use WebGL2. Please refer to the [WebGL2 and WebGPU](https://github.com/bevyengine/bevy/tree/latest/examples#webgl2-and-webgpu) section of the examples README for more information on how to run Wasm builds with WebGPU.|
+|webgpu|Enable support for WebGPU in Wasm. When enabled, this feature will override the `webgl2` feature and you won't be able to run Wasm builds with WebGL2, only with WebGPU.|
+|webp|WebP image format support|
+|x11|X11 display server support|
+|zlib|For KTX2 supercompression|
+|zstd_c|For KTX2 Zstandard decompression using [zstd](https://crates.io/crates/zstd). This is a faster backend, but uses unsafe C bindings. For the safe option, stick to the default backend with "zstd_rust".|
+|zstd_rust|For KTX2 Zstandard decompression using pure rust [ruzstd](https://crates.io/crates/ruzstd). This is the safe default. For maximum performance, use "zstd_c".|

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -19,12 +19,12 @@ For example, you can compile only the "2D" Bevy features (without the 3D feature
 bevy = { version = "0.18", default-features = false, features = ["2d"] }
 ```
 
-|Profile|Description|
-|-|-|
-|default|The full default Bevy experience. This is a combination of the following profiles: 2d, 3d, ui, audio|
-|2d|The default 2D Bevy experience. This includes the core Bevy framework, 2D functionality, scenes and picking.|
-|3d|The default 3D Bevy experience. This includes the core Bevy framework, 3D functionality, scenes and picking.|
-|ui|The default Bevy UI experience. This includes the core Bevy framework, Bevy UI, scenes, and picking.|
+| Profile | Description                                                                                                  |
+| ------- | ------------------------------------------------------------------------------------------------------------ |
+| default | The full default Bevy experience. This is a combination of the following profiles: 2d, 3d, ui, audio         |
+| 2d      | The default 2D Bevy experience. This includes the core Bevy framework, 2D functionality, scenes and picking. |
+| 3d      | The default 3D Bevy experience. This includes the core Bevy framework, 3D functionality, scenes and picking. |
+| ui      | The default Bevy UI experience. This includes the core Bevy framework, Bevy UI, scenes, and picking.         |
 
 By default, the `bevy` crate enables the  features.
 
@@ -34,179 +34,179 @@ By default, the `bevy` crate enables the  features.
 suit your use case (ex: you want to use a custom renderer, you want to build a "headless" app, you want to target no_std, etc), then you can use these
 collections to build your own "profile" equivalent, without needing to manually manage _every single_ feature.
 
-|Collection|Description|
-|-|-|
-|dev|Enable this feature during development to improve the development experience. This adds features like asset hot-reloading and debugging tools. This should not be enabled for published apps! **Feature set:** `debug`, `bevy_dev_tools`, `file_watcher`.|
-|audio|Features used to build audio Bevy apps. **Feature set:** `bevy_audio`, `vorbis`.|
-|audio-all-formats|Enables audio features and all supported formats. **Feature set:** `bevy_audio`, `aac`, `flac`, `mp3`, `mp4`, `vorbis`, `wav`.|
-|scene|Features used to compose Bevy scenes. **Feature set:** `bevy_world_serialization`, `bevy_scene`.|
-|picking|Enables picking with all backends. **Feature set:** `bevy_picking`, `mesh_picking`, `sprite_picking`, `ui_picking`.|
-|default_app|The core pieces that most apps need. This serves as a baseline feature set for other higher level feature collections (such as "2d" and "3d"). It is also useful as a baseline feature set for scenarios like headless apps that require no rendering (ex: command line tools, servers, etc). **Feature set:** `async_executor`, `bevy_asset`, `bevy_input_focus`, `bevy_log`, `bevy_state`, `bevy_window`, `custom_cursor`, `reflect_auto_register`.|
-|default_platform|These are platform support features, such as OS support/features, windowing and input backends, etc. **Feature set:** `std`, `bevy_gilrs`, `bevy_winit`, `bevy_clipboard`, `default_font`, `multi_threaded`, `webgl2`, `x11`, `wayland`, `sysinfo_plugin`.|
-|common_api|Default scene definition features. Note that this does not include an actual renderer, such as bevy_render (Bevy's default render backend). **Feature set:** `bevy_animation`, `bevy_camera`, `bevy_color`, `bevy_gizmos`, `bevy_image`, `bevy_mesh`, `bevy_shader`, `bevy_material`, `bevy_text`, `hdr`, `png`.|
-|2d_api|Features used to build 2D Bevy apps (does not include a render backend). You generally don't need to worry about this unless you are using a custom renderer. **Feature set:** `common_api`, `bevy_sprite`.|
-|2d_bevy_render|Bevy's built-in 2D renderer, built on top of `bevy_render`. **Feature set:** `2d_api`, `bevy_render`, `bevy_core_pipeline`, `bevy_post_process`, `bevy_sprite_render`, `bevy_gizmos_render`.|
-|3d_api|Features used to build 3D Bevy apps (does not include a render backend). You generally don't need to worry about this unless you are using a custom renderer. **Feature set:** `common_api`, `bevy_light`, `bevy_mikktspace`, `ktx2`, `morph_animation`, `morph`, `smaa_luts`, `tonemapping_luts`, `zstd_rust`.|
-|3d_bevy_render|Bevy's built-in 3D renderer, built on top of `bevy_render`. **Feature set:** `3d_api`, `bevy_render`, `bevy_core_pipeline`, `bevy_gizmos_render`, `bevy_anti_alias`, `bevy_gltf`, `bevy_pbr`, `bevy_post_process`, `gltf_animation`.|
-|ui_api|Features used to build UI Bevy apps (does not include a render backend). You generally don't need to worry about this unless you are using a custom renderer. **Feature set:** `default_app`, `common_api`, `bevy_ui`.|
-|ui_bevy_render|Bevy's built-in UI renderer, built on top of `bevy_render`. **Feature set:** `ui_api`, `bevy_render`, `bevy_core_pipeline`, `bevy_ui_render`.|
-|default_no_std|Recommended defaults for no_std applications. **Feature set:** `libm`, `critical-section`, `bevy_color`, `bevy_state`.|
+| Collection        | Description                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| dev               | Enable this feature during development to improve the development experience. This adds features like asset hot-reloading and debugging tools. This should not be enabled for published apps! **Feature set:** `debug`, `bevy_dev_tools`, `file_watcher`.                                                                                                                                                                                             |
+| audio             | Features used to build audio Bevy apps. **Feature set:** `bevy_audio`, `vorbis`.                                                                                                                                                                                                                                                                                                                                                                      |
+| audio-all-formats | Enables audio features and all supported formats. **Feature set:** `bevy_audio`, `aac`, `flac`, `mp3`, `mp4`, `vorbis`, `wav`.                                                                                                                                                                                                                                                                                                                        |
+| scene             | Features used to compose Bevy scenes. **Feature set:** `bevy_world_serialization`, `bevy_scene`.                                                                                                                                                                                                                                                                                                                                                      |
+| picking           | Enables picking with all backends. **Feature set:** `bevy_picking`, `mesh_picking`, `sprite_picking`, `ui_picking`.                                                                                                                                                                                                                                                                                                                                   |
+| default_app       | The core pieces that most apps need. This serves as a baseline feature set for other higher level feature collections (such as "2d" and "3d"). It is also useful as a baseline feature set for scenarios like headless apps that require no rendering (ex: command line tools, servers, etc). **Feature set:** `async_executor`, `bevy_asset`, `bevy_input_focus`, `bevy_log`, `bevy_state`, `bevy_window`, `custom_cursor`, `reflect_auto_register`. |
+| default_platform  | These are platform support features, such as OS support/features, windowing and input backends, etc. **Feature set:** `std`, `bevy_gilrs`, `bevy_winit`, `bevy_clipboard`, `default_font`, `multi_threaded`, `webgl2`, `x11`, `wayland`, `sysinfo_plugin`.                                                                                                                                                                                            |
+| common_api        | Default scene definition features. Note that this does not include an actual renderer, such as bevy_render (Bevy's default render backend). **Feature set:** `bevy_animation`, `bevy_camera`, `bevy_color`, `bevy_gizmos`, `bevy_image`, `bevy_mesh`, `bevy_shader`, `bevy_material`, `bevy_text`, `hdr`, `png`.                                                                                                                                      |
+| 2d_api            | Features used to build 2D Bevy apps (does not include a render backend). You generally don't need to worry about this unless you are using a custom renderer. **Feature set:** `common_api`, `bevy_sprite`.                                                                                                                                                                                                                                           |
+| 2d_bevy_render    | Bevy's built-in 2D renderer, built on top of `bevy_render`. **Feature set:** `2d_api`, `bevy_render`, `bevy_core_pipeline`, `bevy_post_process`, `bevy_sprite_render`, `bevy_gizmos_render`.                                                                                                                                                                                                                                                          |
+| 3d_api            | Features used to build 3D Bevy apps (does not include a render backend). You generally don't need to worry about this unless you are using a custom renderer. **Feature set:** `common_api`, `bevy_light`, `bevy_mikktspace`, `ktx2`, `morph_animation`, `morph`, `smaa_luts`, `tonemapping_luts`, `zstd_rust`.                                                                                                                                       |
+| 3d_bevy_render    | Bevy's built-in 3D renderer, built on top of `bevy_render`. **Feature set:** `3d_api`, `bevy_render`, `bevy_core_pipeline`, `bevy_gizmos_render`, `bevy_anti_alias`, `bevy_gltf`, `bevy_pbr`, `bevy_post_process`, `gltf_animation`.                                                                                                                                                                                                                  |
+| ui_api            | Features used to build UI Bevy apps (does not include a render backend). You generally don't need to worry about this unless you are using a custom renderer. **Feature set:** `default_app`, `common_api`, `bevy_ui`.                                                                                                                                                                                                                                |
+| ui_bevy_render    | Bevy's built-in UI renderer, built on top of `bevy_render`. **Feature set:** `ui_api`, `bevy_render`, `bevy_core_pipeline`, `bevy_ui_render`.                                                                                                                                                                                                                                                                                                         |
+| default_no_std    | Recommended defaults for no_std applications. **Feature set:** `libm`, `critical-section`, `bevy_color`, `bevy_state`.                                                                                                                                                                                                                                                                                                                                |
 
 ### Feature List
 
 This is the complete `bevy` cargo feature list, without "profiles" or "collections" (sorted by name):
 
-|Feature|Description|
-|-|-|
-|aac|AAC audio format support (through `symphonia`)|
-|accesskit_unix|Enable AccessKit on Unix backends (currently only works with experimental screen readers and forks.)|
-|android-game-activity|Android GameActivity support. Default, choose between this and `android-native-activity`.|
-|android-native-activity|Android NativeActivity support. Legacy, should be avoided for most new Android games.|
-|asset_processor|Enables the built-in asset processor for processed assets.|
-|async-io|Use async-io's implementation of block_on instead of futures-lite's implementation. This is preferred if your application uses async-io.|
-|async_executor|Uses `async-executor` as a task execution backend.|
-|basis-universal|Basis Universal compressed texture support|
-|bevy_animation|Provides animation functionality|
-|bevy_anti_alias|Provides various anti aliasing solutions|
-|bevy_asset|Provides asset functionality|
-|bevy_audio|Provides audio functionality|
-|bevy_camera|Provides camera and visibility types, as well as culling primitives.|
-|bevy_camera_controller|Provides a collection of prebuilt camera controllers|
-|bevy_ci_testing|Enable systems that allow for automated testing on CI|
-|bevy_clipboard|Clipboard resource and management. See `system_clipboard` for OS-integrated clipboard support.|
-|bevy_color|Provides shared color types and operations|
-|bevy_core_pipeline|Provides cameras and other basic render pipeline features|
-|bevy_debug_stepping|Enable stepping-based debugging of Bevy systems|
-|bevy_dev_tools|Provides a collection of developer tools|
-|bevy_gilrs|Adds gamepad support|
-|bevy_gizmos|Adds support for gizmos|
-|bevy_gizmos_render|Adds support for rendering gizmos|
-|bevy_gltf|[glTF](https://www.khronos.org/gltf/) support|
-|bevy_image|Load and access image data. Usually added by an image format|
-|bevy_input_focus|Enable input focus subsystem|
-|bevy_light|Provides light types such as point lights, directional lights, spotlights.|
-|bevy_log|Enable integration with `tracing` and `log`|
-|bevy_material|Provides materials.|
-|bevy_mesh|Provides a mesh format and some primitive meshing routines.|
-|bevy_mikktspace|Provides vertex tangent generation for use with bevy_mesh.|
-|bevy_pbr|Adds PBR rendering|
-|bevy_picking|Provides picking functionality without any backend|
-|bevy_post_process|Provides post process effects such as depth of field, bloom, chromatic aberration.|
-|bevy_remote|Enable the Bevy Remote Protocol|
-|bevy_render|Provides rendering functionality|
-|bevy_scene|Provides scene functionality|
-|bevy_settings|Load and save user preferences|
-|bevy_shader|Provides shaders usable through asset handles.|
-|bevy_solari|Provides raytraced lighting (experimental)|
-|bevy_sprite|Provides sprite functionality|
-|bevy_sprite_render|Provides sprite rendering functionality|
-|bevy_state|Enable built in global state machines|
-|bevy_text|Provides text functionality|
-|bevy_ui|A custom ECS-driven UI framework|
-|bevy_ui_debug|Provides a debug overlay for bevy UI|
-|bevy_ui_render|Provides rendering functionality for bevy_ui|
-|bevy_ui_widgets|Headless widget collection for Bevy UI.|
-|bevy_window|Windowing layer|
-|bevy_winit|winit window and input backend|
-|bevy_world_serialization|Provides ECS serialization functionality|
-|bluenoise_texture|Include spatio-temporal blue noise KTX2 file used by generated environment maps, Solari and atmosphere|
-|bmp|BMP image format support|
-|clipboard_image|Enables image copy/paste via the system clipboard. Not supported on WASM.|
-|compressed_image_saver|Enables compressed KTX2 UASTC texture output on the asset processor|
-|critical-section|`critical-section` provides the building blocks for synchronization primitives on all platforms, including `no_std`.|
-|custom_cursor|Enable winit custom cursor support|
-|dds|DDS compressed texture support|
-|debug|Enable collecting debug information about systems and components to help with diagnostics|
-|debug_glam_assert|Enable assertions in debug builds to check the validity of parameters passed to glam|
-|default_font|Include a default font, containing only ASCII characters, at the cost of a 20kB binary size increase|
-|detailed_trace|Enable detailed trace event logging. These trace events are expensive even when off, thus they require compile time opt-in|
-|dfg_lut|Include a preintegrated BRDF Look Up Table for more accurate specular shading.|
-|dlss|NVIDIA Deep Learning Super Sampling|
-|dynamic_linking|Force dynamic linking, which improves iterative compile times|
-|embedded_watcher|Enables watching in memory asset providers for Bevy Asset hot-reloading|
-|experimental_bevy_feathers|Feathers widget collection.|
-|experimental_pbr_pcss|Enable support for PCSS, at the risk of blowing past the global, per-shader sampler limit on older/lower-end GPUs|
-|exr|EXR image format support|
-|ff|Farbfeld image format support|
-|file_watcher|Enables watching the filesystem for Bevy Asset hot-reloading|
-|flac|FLAC audio format support (through `claxon`)|
-|force_disable_dlss|Forcibly disable DLSS so that cargo build --all-features works without the DLSS SDK being installed. Not meant for users.|
-|free_camera|Enables the free cam from bevy_camera_controller|
-|gamepad|Gamepad support. Automatically enabled by `bevy_gilrs`.|
-|gestures|Gestures support. Automatically enabled by `bevy_window`.|
-|ghost_nodes|Experimental support for nodes that are ignored for UI layouting|
-|gif|GIF image format support|
-|glam_assert|Enable assertions to check the validity of parameters passed to glam|
-|gltf_animation|Enable glTF animation loading|
-|hdr|HDR image format support|
-|hotpatching|Enable hotpatching of Bevy systems|
-|http|Enables downloading assets from HTTP sources. Warning: there are security implications. Read the docs on WebAssetPlugin.|
-|https|Enables downloading assets from HTTPS sources. Warning: there are security implications. Read the docs on WebAssetPlugin.|
-|ico|ICO image format support|
-|jpeg|JPEG image format support|
-|keyboard|Keyboard support. Automatically enabled by `bevy_window`.|
-|ktx2|KTX2 compressed texture support|
-|libm|Uses the `libm` maths library instead of the one provided in `std` and `core`.|
-|mesh_picking|Provides an implementation for picking meshes|
-|meshlet|Enables the meshlet renderer for dense high-poly scenes (experimental)|
-|meshlet_processor|Enables processing meshes into meshlet meshes for bevy_pbr|
-|morph|Enables support for morph target weights in bevy_mesh|
-|morph_animation|Enables bevy_mesh and bevy_animation morph weight support|
-|mouse|Mouse support. Automatically enabled by `bevy_window`.|
-|mp3|MP3 audio format support (through `symphonia`)|
-|mp4|MP4 audio format support (through `symphonia`). It also enables AAC support.|
-|multi_threaded|Enables multithreaded parallelism in the engine. Disabling it forces all engine tasks to run on a single thread.|
-|pan_camera|Enables the pan camera from bevy_camera_controller|
-|pbr_anisotropy_texture|Enable support for anisotropy texture in the `StandardMaterial`, at the risk of blowing past the global, per-shader texture limit on older/lower-end GPUs|
-|pbr_clustered_decals|Enable support for Clustered Decals|
-|pbr_light_textures|Enable support for Light Textures|
-|pbr_multi_layer_material_textures|Enable support for multi-layer material textures in the `StandardMaterial`, at the risk of blowing past the global, per-shader texture limit on older/lower-end GPUs|
-|pbr_specular_textures|Enable support for specular textures in the `StandardMaterial`, at the risk of blowing past the global, per-shader texture limit on older/lower-end GPUs|
-|pbr_transmission_textures|Enable support for transmission-related textures in the `StandardMaterial`, at the risk of blowing past the global, per-shader texture limit on older/lower-end GPUs|
-|png|PNG image format support|
-|pnm|PNM image format support, includes pam, pbm, pgm and ppm|
-|qoi|QOI image format support|
-|raw_vulkan_init|Forces the wgpu instance to be initialized using the raw Vulkan HAL, enabling additional configuration|
-|reflect_auto_register|Enable automatic reflect registration|
-|reflect_auto_register_static|Enable automatic reflect registration without inventory. See `reflect::load_type_registrations` for more info.|
-|reflect_documentation|Enables bevy_reflect to access documentation comments of rust code at runtime|
-|reflect_functions|Enable function reflection|
-|schedule_data|Enable collecting schedule data from the app.|
-|serialize|Enable serialization support through serde|
-|shader_format_glsl|Enable support for shaders in GLSL|
-|shader_format_spirv|Enable support for shaders in SPIR-V|
-|shader_format_wesl|Enable support for shaders in WESL|
-|smaa_luts|Include SMAA Look Up Tables KTX2 Files|
-|spirv_shader_passthrough|Enable passthrough loading for SPIR-V shaders (Only supported on Vulkan, shader capabilities and extensions must agree with the platform implementation)|
-|sprite_picking|Provides an implementation for picking sprites|
-|statically-linked-dxc|Statically linked DXC shader compiler for DirectX 12|
-|std|Allows access to the `std` crate.|
-|symphonia-flac|FLAC audio format support (through `symphonia`)|
-|symphonia-vorbis|OGG/VORBIS audio format support (through `symphonia`)|
-|symphonia-wav|WAV audio format support (through `symphonia`)|
-|sysinfo_plugin|Enables system information diagnostic plugin|
-|system_clipboard|Enables system-level clipboard support.|
-|system_font_discovery|Allows for discovery of preloaded system fonts|
-|tga|TGA image format support|
-|tiff|TIFF image format support|
-|tonemapping_luts|Include tonemapping Look Up Tables KTX2 files. If everything is pink, you need to enable this feature or change the `Tonemapping` method for your `Camera2d` or `Camera3d`.|
-|touch|Touch support. Automatically enabled by `bevy_window`.|
-|trace|Tracing support|
-|trace_chrome|Tracing support, saving a file in Chrome Tracing format|
-|trace_tracy|Tracing support, exposing a port for Tracy|
-|trace_tracy_memory|Tracing support, with memory profiling, exposing a port for Tracy|
-|track_location|Enables source location tracking for change detection and spawning/despawning, which can assist with debugging|
-|type_label_buffers|Pre-populate buffer labels with buffer types for debugging.|
-|ui_picking|Provides an implementation for picking UI|
-|vorbis|OGG/VORBIS audio format support (through `lewton`)|
-|wav|WAV audio format support (through `hound`)|
-|wayland|Wayland display server support|
-|web|Enables use of browser APIs. Note this is currently only applicable on `wasm32` architectures.|
-|web_asset_cache|Enable caching downloaded assets on the filesystem. NOTE: this cache currently never invalidates entries!|
-|webgl2|Enable some limitations to be able to use WebGL2. Please refer to the [WebGL2 and WebGPU](https://github.com/bevyengine/bevy/tree/latest/examples#webgl2-and-webgpu) section of the examples README for more information on how to run Wasm builds with WebGPU.|
-|webgpu|Enable support for WebGPU in Wasm. When enabled, this feature will override the `webgl2` feature and you won't be able to run Wasm builds with WebGL2, only with WebGPU.|
-|webp|WebP image format support|
-|x11|X11 display server support|
-|zlib|For KTX2 supercompression|
-|zstd_c|For KTX2 Zstandard decompression using [zstd](https://crates.io/crates/zstd). This is a faster backend, but uses unsafe C bindings. For the safe option, stick to the default backend with "zstd_rust".|
-|zstd_rust|For KTX2 Zstandard decompression using pure rust [ruzstd](https://crates.io/crates/ruzstd). This is the safe default. For maximum performance, use "zstd_c".|
+| Feature                           | Description                                                                                                                                                                                                                                                     |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| aac                               | AAC audio format support (through `symphonia`)                                                                                                                                                                                                                  |
+| accesskit_unix                    | Enable AccessKit on Unix backends (currently only works with experimental screen readers and forks.)                                                                                                                                                            |
+| android-game-activity             | Android GameActivity support. Default, choose between this and `android-native-activity`.                                                                                                                                                                       |
+| android-native-activity           | Android NativeActivity support. Legacy, should be avoided for most new Android games.                                                                                                                                                                           |
+| asset_processor                   | Enables the built-in asset processor for processed assets.                                                                                                                                                                                                      |
+| async-io                          | Use async-io's implementation of block_on instead of futures-lite's implementation. This is preferred if your application uses async-io.                                                                                                                        |
+| async_executor                    | Uses `async-executor` as a task execution backend.                                                                                                                                                                                                              |
+| basis-universal                   | Basis Universal compressed texture support                                                                                                                                                                                                                      |
+| bevy_animation                    | Provides animation functionality                                                                                                                                                                                                                                |
+| bevy_anti_alias                   | Provides various anti aliasing solutions                                                                                                                                                                                                                        |
+| bevy_asset                        | Provides asset functionality                                                                                                                                                                                                                                    |
+| bevy_audio                        | Provides audio functionality                                                                                                                                                                                                                                    |
+| bevy_camera                       | Provides camera and visibility types, as well as culling primitives.                                                                                                                                                                                            |
+| bevy_camera_controller            | Provides a collection of prebuilt camera controllers                                                                                                                                                                                                            |
+| bevy_ci_testing                   | Enable systems that allow for automated testing on CI                                                                                                                                                                                                           |
+| bevy_clipboard                    | Clipboard resource and management. See `system_clipboard` for OS-integrated clipboard support.                                                                                                                                                                  |
+| bevy_color                        | Provides shared color types and operations                                                                                                                                                                                                                      |
+| bevy_core_pipeline                | Provides cameras and other basic render pipeline features                                                                                                                                                                                                       |
+| bevy_debug_stepping               | Enable stepping-based debugging of Bevy systems                                                                                                                                                                                                                 |
+| bevy_dev_tools                    | Provides a collection of developer tools                                                                                                                                                                                                                        |
+| bevy_gilrs                        | Adds gamepad support                                                                                                                                                                                                                                            |
+| bevy_gizmos                       | Adds support for gizmos                                                                                                                                                                                                                                         |
+| bevy_gizmos_render                | Adds support for rendering gizmos                                                                                                                                                                                                                               |
+| bevy_gltf                         | [glTF](https://www.khronos.org/gltf/) support                                                                                                                                                                                                                   |
+| bevy_image                        | Load and access image data. Usually added by an image format                                                                                                                                                                                                    |
+| bevy_input_focus                  | Enable input focus subsystem                                                                                                                                                                                                                                    |
+| bevy_light                        | Provides light types such as point lights, directional lights, spotlights.                                                                                                                                                                                      |
+| bevy_log                          | Enable integration with `tracing` and `log`                                                                                                                                                                                                                     |
+| bevy_material                     | Provides materials.                                                                                                                                                                                                                                             |
+| bevy_mesh                         | Provides a mesh format and some primitive meshing routines.                                                                                                                                                                                                     |
+| bevy_mikktspace                   | Provides vertex tangent generation for use with bevy_mesh.                                                                                                                                                                                                      |
+| bevy_pbr                          | Adds PBR rendering                                                                                                                                                                                                                                              |
+| bevy_picking                      | Provides picking functionality without any backend                                                                                                                                                                                                              |
+| bevy_post_process                 | Provides post process effects such as depth of field, bloom, chromatic aberration.                                                                                                                                                                              |
+| bevy_remote                       | Enable the Bevy Remote Protocol                                                                                                                                                                                                                                 |
+| bevy_render                       | Provides rendering functionality                                                                                                                                                                                                                                |
+| bevy_scene                        | Provides scene functionality                                                                                                                                                                                                                                    |
+| bevy_settings                     | Load and save user preferences                                                                                                                                                                                                                                  |
+| bevy_shader                       | Provides shaders usable through asset handles.                                                                                                                                                                                                                  |
+| bevy_solari                       | Provides raytraced lighting (experimental)                                                                                                                                                                                                                      |
+| bevy_sprite                       | Provides sprite functionality                                                                                                                                                                                                                                   |
+| bevy_sprite_render                | Provides sprite rendering functionality                                                                                                                                                                                                                         |
+| bevy_state                        | Enable built in global state machines                                                                                                                                                                                                                           |
+| bevy_text                         | Provides text functionality                                                                                                                                                                                                                                     |
+| bevy_ui                           | A custom ECS-driven UI framework                                                                                                                                                                                                                                |
+| bevy_ui_debug                     | Provides a debug overlay for bevy UI                                                                                                                                                                                                                            |
+| bevy_ui_render                    | Provides rendering functionality for bevy_ui                                                                                                                                                                                                                    |
+| bevy_ui_widgets                   | Headless widget collection for Bevy UI.                                                                                                                                                                                                                         |
+| bevy_window                       | Windowing layer                                                                                                                                                                                                                                                 |
+| bevy_winit                        | winit window and input backend                                                                                                                                                                                                                                  |
+| bevy_world_serialization          | Provides ECS serialization functionality                                                                                                                                                                                                                        |
+| bluenoise_texture                 | Include spatio-temporal blue noise KTX2 file used by generated environment maps, Solari and atmosphere                                                                                                                                                          |
+| bmp                               | BMP image format support                                                                                                                                                                                                                                        |
+| clipboard_image                   | Enables image copy/paste via the system clipboard. Not supported on WASM.                                                                                                                                                                                       |
+| compressed_image_saver            | Enables compressed KTX2 UASTC texture output on the asset processor                                                                                                                                                                                             |
+| critical-section                  | `critical-section` provides the building blocks for synchronization primitives on all platforms, including `no_std`.                                                                                                                                            |
+| custom_cursor                     | Enable winit custom cursor support                                                                                                                                                                                                                              |
+| dds                               | DDS compressed texture support                                                                                                                                                                                                                                  |
+| debug                             | Enable collecting debug information about systems and components to help with diagnostics                                                                                                                                                                       |
+| debug_glam_assert                 | Enable assertions in debug builds to check the validity of parameters passed to glam                                                                                                                                                                            |
+| default_font                      | Include a default font, containing only ASCII characters, at the cost of a 20kB binary size increase                                                                                                                                                            |
+| detailed_trace                    | Enable detailed trace event logging. These trace events are expensive even when off, thus they require compile time opt-in                                                                                                                                      |
+| dfg_lut                           | Include a preintegrated BRDF Look Up Table for more accurate specular shading.                                                                                                                                                                                  |
+| dlss                              | NVIDIA Deep Learning Super Sampling                                                                                                                                                                                                                             |
+| dynamic_linking                   | Force dynamic linking, which improves iterative compile times                                                                                                                                                                                                   |
+| embedded_watcher                  | Enables watching in memory asset providers for Bevy Asset hot-reloading                                                                                                                                                                                         |
+| bevy_feathers                     | Feathers widget collection.                                                                                                                                                                                                                                     |
+| experimental_pbr_pcss             | Enable support for PCSS, at the risk of blowing past the global, per-shader sampler limit on older/lower-end GPUs                                                                                                                                               |
+| exr                               | EXR image format support                                                                                                                                                                                                                                        |
+| ff                                | Farbfeld image format support                                                                                                                                                                                                                                   |
+| file_watcher                      | Enables watching the filesystem for Bevy Asset hot-reloading                                                                                                                                                                                                    |
+| flac                              | FLAC audio format support (through `claxon`)                                                                                                                                                                                                                    |
+| force_disable_dlss                | Forcibly disable DLSS so that cargo build --all-features works without the DLSS SDK being installed. Not meant for users.                                                                                                                                       |
+| free_camera                       | Enables the free cam from bevy_camera_controller                                                                                                                                                                                                                |
+| gamepad                           | Gamepad support. Automatically enabled by `bevy_gilrs`.                                                                                                                                                                                                         |
+| gestures                          | Gestures support. Automatically enabled by `bevy_window`.                                                                                                                                                                                                       |
+| ghost_nodes                       | Experimental support for nodes that are ignored for UI layouting                                                                                                                                                                                                |
+| gif                               | GIF image format support                                                                                                                                                                                                                                        |
+| glam_assert                       | Enable assertions to check the validity of parameters passed to glam                                                                                                                                                                                            |
+| gltf_animation                    | Enable glTF animation loading                                                                                                                                                                                                                                   |
+| hdr                               | HDR image format support                                                                                                                                                                                                                                        |
+| hotpatching                       | Enable hotpatching of Bevy systems                                                                                                                                                                                                                              |
+| http                              | Enables downloading assets from HTTP sources. Warning: there are security implications. Read the docs on WebAssetPlugin.                                                                                                                                        |
+| https                             | Enables downloading assets from HTTPS sources. Warning: there are security implications. Read the docs on WebAssetPlugin.                                                                                                                                       |
+| ico                               | ICO image format support                                                                                                                                                                                                                                        |
+| jpeg                              | JPEG image format support                                                                                                                                                                                                                                       |
+| keyboard                          | Keyboard support. Automatically enabled by `bevy_window`.                                                                                                                                                                                                       |
+| ktx2                              | KTX2 compressed texture support                                                                                                                                                                                                                                 |
+| libm                              | Uses the `libm` maths library instead of the one provided in `std` and `core`.                                                                                                                                                                                  |
+| mesh_picking                      | Provides an implementation for picking meshes                                                                                                                                                                                                                   |
+| meshlet                           | Enables the meshlet renderer for dense high-poly scenes (experimental)                                                                                                                                                                                          |
+| meshlet_processor                 | Enables processing meshes into meshlet meshes for bevy_pbr                                                                                                                                                                                                      |
+| morph                             | Enables support for morph target weights in bevy_mesh                                                                                                                                                                                                           |
+| morph_animation                   | Enables bevy_mesh and bevy_animation morph weight support                                                                                                                                                                                                       |
+| mouse                             | Mouse support. Automatically enabled by `bevy_window`.                                                                                                                                                                                                          |
+| mp3                               | MP3 audio format support (through `symphonia`)                                                                                                                                                                                                                  |
+| mp4                               | MP4 audio format support (through `symphonia`). It also enables AAC support.                                                                                                                                                                                    |
+| multi_threaded                    | Enables multithreaded parallelism in the engine. Disabling it forces all engine tasks to run on a single thread.                                                                                                                                                |
+| pan_camera                        | Enables the pan camera from bevy_camera_controller                                                                                                                                                                                                              |
+| pbr_anisotropy_texture            | Enable support for anisotropy texture in the `StandardMaterial`, at the risk of blowing past the global, per-shader texture limit on older/lower-end GPUs                                                                                                       |
+| pbr_clustered_decals              | Enable support for Clustered Decals                                                                                                                                                                                                                             |
+| pbr_light_textures                | Enable support for Light Textures                                                                                                                                                                                                                               |
+| pbr_multi_layer_material_textures | Enable support for multi-layer material textures in the `StandardMaterial`, at the risk of blowing past the global, per-shader texture limit on older/lower-end GPUs                                                                                            |
+| pbr_specular_textures             | Enable support for specular textures in the `StandardMaterial`, at the risk of blowing past the global, per-shader texture limit on older/lower-end GPUs                                                                                                        |
+| pbr_transmission_textures         | Enable support for transmission-related textures in the `StandardMaterial`, at the risk of blowing past the global, per-shader texture limit on older/lower-end GPUs                                                                                            |
+| png                               | PNG image format support                                                                                                                                                                                                                                        |
+| pnm                               | PNM image format support, includes pam, pbm, pgm and ppm                                                                                                                                                                                                        |
+| qoi                               | QOI image format support                                                                                                                                                                                                                                        |
+| raw_vulkan_init                   | Forces the wgpu instance to be initialized using the raw Vulkan HAL, enabling additional configuration                                                                                                                                                          |
+| reflect_auto_register             | Enable automatic reflect registration                                                                                                                                                                                                                           |
+| reflect_auto_register_static      | Enable automatic reflect registration without inventory. See `reflect::load_type_registrations` for more info.                                                                                                                                                  |
+| reflect_documentation             | Enables bevy_reflect to access documentation comments of rust code at runtime                                                                                                                                                                                   |
+| reflect_functions                 | Enable function reflection                                                                                                                                                                                                                                      |
+| schedule_data                     | Enable collecting schedule data from the app.                                                                                                                                                                                                                   |
+| serialize                         | Enable serialization support through serde                                                                                                                                                                                                                      |
+| shader_format_glsl                | Enable support for shaders in GLSL                                                                                                                                                                                                                              |
+| shader_format_spirv               | Enable support for shaders in SPIR-V                                                                                                                                                                                                                            |
+| shader_format_wesl                | Enable support for shaders in WESL                                                                                                                                                                                                                              |
+| smaa_luts                         | Include SMAA Look Up Tables KTX2 Files                                                                                                                                                                                                                          |
+| spirv_shader_passthrough          | Enable passthrough loading for SPIR-V shaders (Only supported on Vulkan, shader capabilities and extensions must agree with the platform implementation)                                                                                                        |
+| sprite_picking                    | Provides an implementation for picking sprites                                                                                                                                                                                                                  |
+| statically-linked-dxc             | Statically linked DXC shader compiler for DirectX 12                                                                                                                                                                                                            |
+| std                               | Allows access to the `std` crate.                                                                                                                                                                                                                               |
+| symphonia-flac                    | FLAC audio format support (through `symphonia`)                                                                                                                                                                                                                 |
+| symphonia-vorbis                  | OGG/VORBIS audio format support (through `symphonia`)                                                                                                                                                                                                           |
+| symphonia-wav                     | WAV audio format support (through `symphonia`)                                                                                                                                                                                                                  |
+| sysinfo_plugin                    | Enables system information diagnostic plugin                                                                                                                                                                                                                    |
+| system_clipboard                  | Enables system-level clipboard support.                                                                                                                                                                                                                         |
+| system_font_discovery             | Allows for discovery of preloaded system fonts                                                                                                                                                                                                                  |
+| tga                               | TGA image format support                                                                                                                                                                                                                                        |
+| tiff                              | TIFF image format support                                                                                                                                                                                                                                       |
+| tonemapping_luts                  | Include tonemapping Look Up Tables KTX2 files. If everything is pink, you need to enable this feature or change the `Tonemapping` method for your `Camera2d` or `Camera3d`.                                                                                     |
+| touch                             | Touch support. Automatically enabled by `bevy_window`.                                                                                                                                                                                                          |
+| trace                             | Tracing support                                                                                                                                                                                                                                                 |
+| trace_chrome                      | Tracing support, saving a file in Chrome Tracing format                                                                                                                                                                                                         |
+| trace_tracy                       | Tracing support, exposing a port for Tracy                                                                                                                                                                                                                      |
+| trace_tracy_memory                | Tracing support, with memory profiling, exposing a port for Tracy                                                                                                                                                                                               |
+| track_location                    | Enables source location tracking for change detection and spawning/despawning, which can assist with debugging                                                                                                                                                  |
+| type_label_buffers                | Pre-populate buffer labels with buffer types for debugging.                                                                                                                                                                                                     |
+| ui_picking                        | Provides an implementation for picking UI                                                                                                                                                                                                                       |
+| vorbis                            | OGG/VORBIS audio format support (through `lewton`)                                                                                                                                                                                                              |
+| wav                               | WAV audio format support (through `hound`)                                                                                                                                                                                                                      |
+| wayland                           | Wayland display server support                                                                                                                                                                                                                                  |
+| web                               | Enables use of browser APIs. Note this is currently only applicable on `wasm32` architectures.                                                                                                                                                                  |
+| web_asset_cache                   | Enable caching downloaded assets on the filesystem. NOTE: this cache currently never invalidates entries!                                                                                                                                                       |
+| webgl2                            | Enable some limitations to be able to use WebGL2. Please refer to the [WebGL2 and WebGPU](https://github.com/bevyengine/bevy/tree/latest/examples#webgl2-and-webgpu) section of the examples README for more information on how to run Wasm builds with WebGPU. |
+| webgpu                            | Enable support for WebGPU in Wasm. When enabled, this feature will override the `webgl2` feature and you won't be able to run Wasm builds with WebGL2, only with WebGPU.                                                                                        |
+| webp                              | WebP image format support                                                                                                                                                                                                                                       |
+| x11                               | X11 display server support                                                                                                                                                                                                                                      |
+| zlib                              | For KTX2 supercompression                                                                                                                                                                                                                                       |
+| zstd_c                            | For KTX2 Zstandard decompression using [zstd](https://crates.io/crates/zstd). This is a faster backend, but uses unsafe C bindings. For the safe option, stick to the default backend with "zstd_rust".                                                         |
+| zstd_rust                         | For KTX2 Zstandard decompression using pure rust [ruzstd](https://crates.io/crates/ruzstd). This is the safe default. For maximum performance, use "zstd_c".                                                                                                    |

--- a/examples/large_scenes/bevy_city/Cargo.toml
+++ b/examples/large_scenes/bevy_city/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 bevy = { path = "../../../", features = [
   "https",
   "free_camera",
-  "experimental_bevy_feathers",
+  "bevy_feathers",
   "web_asset_cache",
 ] }
 

--- a/examples/ui/widgets/feathers_counter.rs
+++ b/examples/ui/widgets/feathers_counter.rs
@@ -1,6 +1,6 @@
 //! This example shows how to setup a basic counter app using feathers
 //!
-//! To use feathers in your bevy app, you need to use the `experimental_bevy_feathers` feature
+//! To use feathers in your bevy app, you need to use the `bevy_feathers` feature
 
 use bevy::{
     feathers::{


### PR DESCRIPTION
# Objective

> With the introduction of scene components, the feathers API has now reached its final form. This has a number of consequences:
> - There's no longer any reason to keep the experimental flag around
> - The effort of migrating the Bevy examples to feathers widgets is unblocked, however I think we should start with migrating just one example


- @viridia 

## Solution

1. Rename the feature flag.
2. Write a migration guide.

This was previously attempted as part of https://github.com/bevyengine/bevy/pull/22934, but I got pushback there. Now that bsn! is more complete (scene components!) things are better.

I've opted not to change the default features here, even though it makes it much harder to move our examples over, because that's a much more contentious change. While I feel that Bevy's default features should be example-oriented, that's still up for debate!