### PR TITLE
Integrate bevy_world_serialization rename into existing release content

### DIFF
--- a/_release-content/migration-guides/scene_type_registry.md
+++ b/_release-content/migration-guides/scene_type_registry.md
@@ -7,7 +7,10 @@ Previously, `DynamicSceneBuilder` and `DynamicScene` would get the type registry
 being extracted. However, when building a world from scratch just for serialization, this required
 artificially cloning the registry and putting it in the world being saved.
 
-Now, `DynamicSceneBuilder` and `DynamicScene::from_scene` require an existing type registry. For
+In another set of changes, `DynamicSceneBuilder`, `DynamicScene`, and `Scene` were renamed to `DynamicWorldBuilder`,
+`DynamicWorld`, and `WorldAsset` respectively in Bevy 0.19.
+
+Now called `DynamicWorldBuilder` and `DynamicWorld::from_world_asset`, these methods require an existing type registry in Bevy 0.19. For
 example, before:
 
 ```rust
@@ -23,9 +26,9 @@ Becomes:
 
 ```rust
 let world: &World = ...;
-let scene = {
+let dynamic_world = {
     let type_registry = world.resource::<AppTypeRegistry>().read();
-    DynamicSceneBuilder::from_world(world, &type_registry)
+    DynamicWorldBuilder::from_world(world, &type_registry)
         .extract_entity(e1)
         .extract_entity(e2)
         .extract_resources()
@@ -47,7 +50,7 @@ Becomes:
 
 ```rust
 let type_registry: AppTypeRegistry = get_from_main_world();
-let scene: Scene = ...;
-// No need to insert into the scene!
-let dynamic_scene = DynamicScene::from_scene(scene, &type_registry.read());
+let world_asset: WorldAsset = ...;
+// No need to insert into the world asset!
+let dynamic_world = DynamicWorld::from_world_asset(&world_asset, &type_registry.read());
 ```

--- a/_release-content/release-notes/reflect_serde_handles.md
+++ b/_release-content/release-notes/reflect_serde_handles.md
@@ -6,9 +6,9 @@ pull_requests: [23329]
 
 Asset handles are not just data: they are a reference to an asset that also keeps that asset alive.
 This poses a challenge for deserializing handles: there's no asset to keep alive when deserializing!
-In particular, our scene format (writable through `DynamicScene::serialize`) has been unfortunately
+In particular, our world serialization format (writable through `DynamicWorld::serialize`, previously called "scenes") has been unfortunately
 restricted by the fact that handles could not be serialized or deserialized. A lot of things you
-want to put into a scene, like 3D models or even other scenes, need to reference asset handles for
+want to put into a world asset, like 3D models or even other scenes, need to reference asset handles for
 their data.
 
 To resolve this, we've introduced `HandleSerializeProcessor` and `HandleDeserializeProcessor` to
@@ -17,7 +17,7 @@ respectively. These allow the reflection (de)serialization to store and load han
 handle will store its "identifying" information (e.g., asset path), and deserializing the handle
 will load the asset path to produce the handle.
 
-In addition, this now happens automatically for scene loading and saving!
+In addition, this now happens automatically for world asset loading and saving!
 
 While it isn't practical for us to directly support `serde::Serialize` and `serde::Deserialize`
 (since these don't allow passing the `AssetServer` needed to execute loads), reflection allows us to


### PR DESCRIPTION
# Objective

An existing migration guide + release note got clobbered by the `bevy_scene` -> `bevy_ecs_serialization` rename.

Fixes #24007.

## Solution

Carefully integrate the rename into the text to make the migration less confusing.