### PR TITLE
Run `prepass_build_indirect_parameters` if there is any prepass

### DIFF
--- a/crates/bevy_pbr/src/render/gpu_preprocess.rs
+++ b/crates/bevy_pbr/src/render/gpu_preprocess.rs
@@ -15,7 +15,8 @@ use bevy_core_pipeline::{
     mip_generation::experimental::depth::{early_downsample_depth, ViewDepthPyramid},
     prepass::{
         node::{early_prepass, late_prepass},
-        DepthPrepass, PreviousViewData, PreviousViewUniformOffset, PreviousViewUniforms,
+        DeferredPrepass, DepthPrepass, MotionVectorPrepass, NormalPrepass, PreviousViewData,
+        PreviousViewUniformOffset, PreviousViewUniforms,
     },
     schedule::{Core3d, Core3dSystems},
 };
@@ -383,6 +384,13 @@ pub struct ViewPhaseBinUnpackingBindGroup {
 #[derive(Component, Default)]
 pub struct SkipGpuPreprocess;
 
+type WithAnyPrepass = Or<(
+    With<DepthPrepass>,
+    With<NormalPrepass>,
+    With<MotionVectorPrepass>,
+    With<DeferredPrepass>,
+)>;
+
 impl Plugin for GpuMeshPreprocessPlugin {
     fn build(&self, app: &mut App) {
         embedded_asset!(app, "mesh_preprocess.wgsl");
@@ -436,7 +444,7 @@ impl Plugin for GpuMeshPreprocessPlugin {
                             With<PreprocessBindGroups>,
                             Without<SkipGpuPreprocess>,
                             Without<NoIndirectDrawing>,
-                            Or<(With<DepthPrepass>, With<ShadowView>)>,
+                            Or<(WithAnyPrepass, With<ShadowView>)>,
                         )>),
                     )
                         .chain()
@@ -447,7 +455,7 @@ impl Plugin for GpuMeshPreprocessPlugin {
                             With<PreprocessBindGroups>,
                             Without<SkipGpuPreprocess>,
                             Without<NoIndirectDrawing>,
-                            Or<(With<DepthPrepass>, With<ShadowView>)>,
+                            Or<(WithAnyPrepass, With<ShadowView>)>,
                             With<OcclusionCulling>,
                         )>),
                     )


### PR DESCRIPTION
# Objective

Fixes #24097

Indirect parameters are not built in early prepass if depth prepass and shadow map are not enabled:

<img width="1219" height="453" alt="屏幕截图_20260504_123430" src="https://github.com/user-attachments/assets/93854a27-84e5-4918-a167-398ec535e7fc" />


## Solution

Run prepass_build_indirect_parameters if there is any prepass, not only depth prepass.

## Testing

`motion_blur` example without shadow map is fixed:

<img width="1283" height="489" alt="屏幕截图_20260504_140302" src="https://github.com/user-attachments/assets/7454880d-7338-4282-936f-e540824ce7df" />
