### PR TITLE
Add more reflection tests for `Handle`

### DIFF
--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -737,11 +737,11 @@ pub enum UntypedAssetConversionError {
 mod tests {
     use alloc::boxed::Box;
     use bevy_platform::hash::FixedHasher;
-    use bevy_reflect::PartialReflect;
+    use bevy_reflect::{FromReflect, PartialReflect};
     use core::hash::BuildHasher;
     use uuid::Uuid;
 
-    use crate::tests::create_app;
+    use crate::{tests::create_app, AssetApp, Assets, VisitAssetDependencies};
 
     use super::*;
 
@@ -847,9 +847,6 @@ mod tests {
     /// `PartialReflect::reflect_clone`/`PartialReflect::to_dynamic` should increase the strong count of a strong handle
     #[test]
     fn strong_handle_reflect_clone() {
-        use crate::{AssetApp, Assets, VisitAssetDependencies};
-        use bevy_reflect::FromReflect;
-
         #[derive(Reflect)]
         struct MyAsset {
             value: u32,
@@ -904,9 +901,6 @@ mod tests {
 
     #[test]
     fn handle_from_reflect_verifies_type_id() {
-        use crate::{AssetApp, Assets};
-        use bevy_reflect::FromReflect;
-
         #[derive(Reflect, Asset)]
         struct A;
         #[derive(Reflect, Asset)]
@@ -944,8 +938,6 @@ mod tests {
     #[test]
     #[ignore = "blocked by #24111"]
     fn handle_try_apply_verifies_type_id() {
-        use crate::{AssetApp, Assets};
-
         #[derive(Reflect, Asset)]
         struct A;
         #[derive(Reflect, Asset)]
@@ -969,9 +961,6 @@ mod tests {
 
     #[test]
     fn handle_from_reflect_and_try_apply() {
-        use crate::{AssetApp, Assets};
-        use bevy_reflect::FromReflect;
-
         #[derive(Reflect, Asset)]
         struct A(i32);
 

--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -142,8 +142,6 @@ pub enum Handle<A: Asset> {
 
 // `Handle` needs a custom `FromReflect` to do extra type checking - see the
 // `strong_handle.type_id` check below.
-// `Handle` needs a custom `FromReflect` to do extra type checking - see the
-// `strong_handle.type_id` check below.
 impl<A: Asset> FromReflect for Handle<A>
 where
     Handle<A>: Send + Sync,

--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -940,4 +940,55 @@ mod tests {
             "Handle<A> should be constructible from reflected Handle<A>"
         );
     }
+
+    #[test]
+    #[ignore = "blocked by #24111"]
+    fn handle_try_apply_verifies_type_id() {
+        use crate::{AssetApp, Assets};
+
+        #[derive(Reflect, Asset)]
+        struct A;
+        #[derive(Reflect, Asset)]
+        struct B;
+
+        let mut app = create_app().0;
+        app.init_asset::<A>().init_asset::<B>();
+
+        let mut assets_a = app.world_mut().resource_mut::<Assets<A>>();
+        let handle_a = assets_a.add(A);
+
+        let reflected_handle_a = handle_a.as_partial_reflect();
+
+        let mut assets_b = app.world_mut().resource_mut::<Assets<B>>();
+        let mut handle_b = assets_b.add(B);
+        assert!(
+            handle_b.try_apply(reflected_handle_a).is_err(),
+            "Handle<A> should not be applicable to Handle<B>"
+        );
+    }
+
+    #[test]
+    fn handle_from_reflect_and_try_apply() {
+        use crate::{AssetApp, Assets};
+        use bevy_reflect::FromReflect;
+
+        #[derive(Reflect, Asset)]
+        struct A(i32);
+
+        let mut app = create_app().0;
+        app.init_asset::<A>();
+
+        let mut assets = app.world_mut().resource_mut::<Assets<A>>();
+        let handle_1 = assets.add(A(1));
+        let reflected_handle_1 = handle_1.as_partial_reflect();
+
+        let handle_1_from_reflect: Handle<A> =
+            FromReflect::from_reflect(reflected_handle_1).unwrap();
+        assert_eq!(handle_1, handle_1_from_reflect);
+
+        let mut handle_2 = assets.add(A(2));
+        assert_ne!(handle_1, handle_2);
+        handle_2.try_apply(reflected_handle_1).unwrap();
+        assert_eq!(handle_1, handle_2);
+    }
 }

--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -934,7 +934,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "blocked by #24111"]
+    #[ignore = "Known failure tracked in #24111"]
     fn handle_try_apply_verifies_type_id() {
         #[derive(Reflect, Asset)]
         struct A;


### PR DESCRIPTION
## Objective

Build on #24048 to improve test coverage for `Handle` reflection, and also repro #24111.

## Solution

Add various tests. Includes a test for valid cases of `from_reflect` and `try_apply` - this is relevant since `from_reflect` now has a custom implementation.

I've snuck in a few cleanups too:

- Avoid multiple tests repeating the same imports.
- Fix an accidentally duplicated comment.

## Testing

```sh
cargo test -p bevy_asset
```