### PR TITLE
Make 1-to-1 Relationship clearer in docs

### DIFF
--- a/crates/bevy_ecs/src/relationship/mod.rs
+++ b/crates/bevy_ecs/src/relationship/mod.rs
@@ -64,7 +64,7 @@ use log::warn;
 /// pub struct Children(Vec<Entity>);
 /// ```
 ///
-/// A one-to-one relationship can be created by not having a `Vec` in the [`RelationshipTarget`].
+/// A one-to-one relationship can be created by putting a single [`Entity`] in the [`RelationshipTarget`]'s field.
 /// In that case, if another entity is added to the relationship, the original entity is removed.
 ///
 /// ```

--- a/crates/bevy_ecs/src/relationship/mod.rs
+++ b/crates/bevy_ecs/src/relationship/mod.rs
@@ -64,6 +64,21 @@ use log::warn;
 /// pub struct Children(Vec<Entity>);
 /// ```
 ///
+/// A one-to-one relationship can be created by not having a `Vec` in the [`RelationshipTarget`].
+/// In that case, if another entity is added to the relationship, the original entity is removed.
+///
+/// ```
+/// # use bevy_ecs::component::Component;
+/// # use bevy_ecs::entity::Entity;
+/// #[derive(Component)]
+/// #[relationship(relationship_target = View)]
+/// pub struct ViewOf(pub Entity);
+///
+/// #[derive(Component)]
+/// #[relationship_target(relationship = ViewOf)]
+/// pub struct View(Entity);
+/// ```
+///
 /// When deriving [`RelationshipTarget`] you can specify the `#[relationship_target(linked_spawn)]` attribute to
 /// automatically despawn entities stored in an entity's [`RelationshipTarget`] when that entity is despawned:
 ///


### PR DESCRIPTION
# Objective

Make the possibility of 1-to-1 `Relationship` clearer in the docs, so that people know it's an option.
(There's already a passing mention of it at the top, but that doesn't show that it's supported in code.)

## Solution

Added an example to the doc comment to show how it's done, and explained what happens if you try to add another entity anyway.

## Testing

Ran `cargo doc` and looked at the new docs to see if they're ok.

