### PR TITLE
bevy_render: Do not remove VALIDATION_INDIRECT_CALL if Backends contains DX12

### DIFF
--- a/crates/bevy_render/src/error_handler.rs
+++ b/crates/bevy_render/src/error_handler.rs
@@ -171,7 +171,6 @@ pub(crate) fn update_state(main_world: &mut World, render_world: &mut World) {
 
     // Remove the render state so we can provide both worlds to the `RenderErrorHandler`.
     let state = render_world.remove_resource::<RenderState>().unwrap();
-    println!("{state:?}");
 
     match &state {
         RenderState::Initializing => {

--- a/crates/bevy_render/src/error_handler.rs
+++ b/crates/bevy_render/src/error_handler.rs
@@ -171,6 +171,7 @@ pub(crate) fn update_state(main_world: &mut World, render_world: &mut World) {
 
     // Remove the render state so we can provide both worlds to the `RenderErrorHandler`.
     let state = render_world.remove_resource::<RenderState>().unwrap();
+    println!("{state:?}");
 
     match &state {
         RenderState::Initializing => {

--- a/crates/bevy_render/src/settings.rs
+++ b/crates/bevy_render/src/settings.rs
@@ -129,14 +129,16 @@ impl Default for WgpuSettings {
 
         let mut instance_flags = InstanceFlags::default();
         #[cfg(not(debug_assertions))]
-        // wgpu executes additional necessary logic during validation passes for dx-12 backends,
-        // so the `VALIDATION_INDIRECT_CALL` flag should stay for dx-12.
-        if !backends.unwrap().contains(Backends::DX12) {
-            // Removing this flag improves performance.
-            instance_flags.remove(InstanceFlags::VALIDATION_INDIRECT_CALL);
+        {
+            // wgpu executes additional necessary logic during validation passes for the DX12 backend,
+            // so the `VALIDATION_INDIRECT_CALL` flag should stay for DX12.
+            if !backends.is_some_and(|backends| backends.contains(Backends::DX12)) {
+                // Removing this flag improves performance.
+                instance_flags.remove(InstanceFlags::VALIDATION_INDIRECT_CALL);
+            }
         }
         #[cfg(all(not(debug_assertions), feature = "raw_vulkan_init"))]
-        // intending to use vulkan even if backends contains dx-12
+        // intending to use vulkan even if backends contains DX12
         instance_flags.remove(InstanceFlags::VALIDATION_INDIRECT_CALL);
 
         instance_flags = instance_flags.with_env();

--- a/crates/bevy_render/src/settings.rs
+++ b/crates/bevy_render/src/settings.rs
@@ -138,7 +138,7 @@ impl Default for WgpuSettings {
             }
         }
         #[cfg(all(not(debug_assertions), feature = "raw_vulkan_init"))]
-        // intending to use vulkan even if backends contains DX12
+        // intending to use vulkan even if backends may contain DX12
         instance_flags.remove(InstanceFlags::VALIDATION_INDIRECT_CALL);
 
         instance_flags = instance_flags.with_env();

--- a/crates/bevy_render/src/settings.rs
+++ b/crates/bevy_render/src/settings.rs
@@ -129,19 +129,16 @@ impl Default for WgpuSettings {
 
         let mut instance_flags = InstanceFlags::default();
         #[cfg(not(debug_assertions))]
-        {
-            // wgpu executes additional necessary logic during validation passes for dx-12 backends,
-            // so the `VALIDATION_INDIRECT_CALL` flag should stay for dx-12.
-            if !backends.unwrap().contains(Backends::DX12) {
-                // Removing this flag improves performance.
-                instance_flags.remove(InstanceFlags::VALIDATION_INDIRECT_CALL);
-            }
-        }
-        #[cfg(all(not(debug_assertions), feature = "raw_vulkan_init"))]
-        {
-            // intending to use vulkan even if backends contains dx-12
+        // wgpu executes additional necessary logic during validation passes for dx-12 backends,
+        // so the `VALIDATION_INDIRECT_CALL` flag should stay for dx-12.
+        if !backends.unwrap().contains(Backends::DX12) {
+            // Removing this flag improves performance.
             instance_flags.remove(InstanceFlags::VALIDATION_INDIRECT_CALL);
         }
+        #[cfg(all(not(debug_assertions), feature = "raw_vulkan_init"))]
+        // intending to use vulkan even if backends contains dx-12
+        instance_flags.remove(InstanceFlags::VALIDATION_INDIRECT_CALL);
+
         instance_flags = instance_flags.with_env();
 
         Self {

--- a/crates/bevy_render/src/settings.rs
+++ b/crates/bevy_render/src/settings.rs
@@ -128,8 +128,13 @@ impl Default for WgpuSettings {
         let gles3_minor_version = Gles3MinorVersion::from_env().unwrap_or_default();
 
         let mut instance_flags = InstanceFlags::default();
-        #[cfg(not(debug_assertions))]
-        instance_flags.remove(InstanceFlags::VALIDATION_INDIRECT_CALL);
+        #[cfg(all(not(debug_assertions), not(feature = "raw_vulkan_init")))]
+        // wgpu executes additional necessary logic during validation passes for dx-12 backends,
+        // so the `VALIDATION_INDIRECT_CALL` flag should stay for dx-12.
+        if !backends.unwrap().contains(Backends::DX12) {
+            // Removing this flag improves performance.
+            instance_flags.remove(InstanceFlags::VALIDATION_INDIRECT_CALL);
+        }
         instance_flags = instance_flags.with_env();
 
         Self {

--- a/crates/bevy_render/src/settings.rs
+++ b/crates/bevy_render/src/settings.rs
@@ -128,11 +128,18 @@ impl Default for WgpuSettings {
         let gles3_minor_version = Gles3MinorVersion::from_env().unwrap_or_default();
 
         let mut instance_flags = InstanceFlags::default();
-        #[cfg(all(not(debug_assertions), not(feature = "raw_vulkan_init")))]
-        // wgpu executes additional necessary logic during validation passes for dx-12 backends,
-        // so the `VALIDATION_INDIRECT_CALL` flag should stay for dx-12.
-        if !backends.unwrap().contains(Backends::DX12) {
-            // Removing this flag improves performance.
+        #[cfg(not(debug_assertions))]
+        {
+            // wgpu executes additional necessary logic during validation passes for dx-12 backends,
+            // so the `VALIDATION_INDIRECT_CALL` flag should stay for dx-12.
+            if !backends.unwrap().contains(Backends::DX12) {
+                // Removing this flag improves performance.
+                instance_flags.remove(InstanceFlags::VALIDATION_INDIRECT_CALL);
+            }
+        }
+        #[cfg(all(not(debug_assertions), feature = "raw_vulkan_init"))]
+        {
+            // intending to use vulkan even if backends contains dx-12
             instance_flags.remove(InstanceFlags::VALIDATION_INDIRECT_CALL);
         }
         instance_flags = instance_flags.with_env();


### PR DESCRIPTION
# Objective

- Fixes #24117

## Solution

- The flag is supposedly necessary for DX12 in wgpu. Add some additional conditions for removing `VALIDATION_INDIRECT_CALL`, and add a comment about it.

## Testing

- The revert commit in #24122 by itself fixes the issue in Pixel Eagle. It was also confirmed to fix the issue by @meepleek — Thank you for testing locally!
- The additional logic has not been verified in Pixel Eagle but it’s simple enough to only need review.

(Just decided to remake the PR after main was force pushed)