### PR TITLE
Quit Application on any `RenderError`s by default

### DIFF
--- a/_release-content/release-notes/render-recovery.md
+++ b/_release-content/release-notes/render-recovery.md
@@ -1,7 +1,7 @@
 ---
 title: "Render Recovery"
 authors: ["@atlv24"]
-pull_requests: [22761, 23350, 23349, 23433, 23458, 23444, 23459, 23461, 23463, 22714, 22759, 16481]
+pull_requests: [22761, 23350, 23349, 23433, 23458, 23444, 23459, 23461, 23463, 22714, 22759, 16481, 24131]
 --- 
 
 You can now recover from rendering errors such as device loss by reloading the renderer:
@@ -21,4 +21,4 @@ app.insert_resource(RenderErrorHandler(
 
 NOTE: this is just an example showing the different errors and policies available, and not a recommendation for how to handle errors.
 
-The default error handler behaves identically to how Bevy behaved before: validation errors are ignored, and other errors crash/hang the application.
+The default error handler will quit the application on any RenderError.

--- a/_release-content/release-notes/render-recovery.md
+++ b/_release-content/release-notes/render-recovery.md
@@ -21,4 +21,4 @@ app.insert_resource(RenderErrorHandler(
 
 NOTE: this is just an example showing the different errors and policies available, and not a recommendation for how to handle errors.
 
-The default error handler will quit the application on any RenderError.
+The default error handler does not attempt recovery, currently. It behaves similarly to how Bevy behaved before, except the application will exit instead of panicking on any `RenderError`.

--- a/crates/bevy_render/src/error_handler.rs
+++ b/crates/bevy_render/src/error_handler.rs
@@ -20,6 +20,11 @@ use crate::{
 pub enum RenderErrorPolicy {
     /// Pretends nothing happened and continues rendering.
     /// This discards the error after logging it to console.
+    /// WARNING: Using this policy can cause hazardous rapid flashing
+    /// if the conditions causing the error remain unaddressed, since
+    /// rendering will attempt to continue executing.
+    /// When choosing to use this policy, be sure to test that the application
+    /// remains safe to use.
     Ignore,
     /// Keeps the app alive, but stops rendering further.
     /// This keeps the error state, and will continue polling the [`RenderErrorHandler`]
@@ -28,6 +33,8 @@ pub enum RenderErrorPolicy {
     /// Attempt renderer recovery with the given [`RenderCreation`].
     Recover(RenderCreation),
     /// Quits the app.
+    /// This stops rendering and sends an [`AppExit::error`], which will
+    /// immediately terminate the app.
     QuitApplication,
 }
 

--- a/crates/bevy_render/src/error_handler.rs
+++ b/crates/bevy_render/src/error_handler.rs
@@ -81,7 +81,7 @@ impl Default for RenderErrorHandler {
     }
 }
 
-/// An error encountered during rendering. These errors come from the WebGPU API.
+/// An error encountered during rendering. These errors come from wgpu.
 #[derive(Debug)]
 pub struct RenderError {
     pub ty: ErrorType,

--- a/crates/bevy_render/src/error_handler.rs
+++ b/crates/bevy_render/src/error_handler.rs
@@ -68,11 +68,13 @@ impl RenderErrorHandler {
 
 impl Default for RenderErrorHandler {
     fn default() -> Self {
-        // Quit the application for any `RenderError`.
-        // These `RenderError`s originate from wgpu. Ignoring a wgpu OutOfMemory
-        // or wgpu Validation error without addressing the root cause can
-        // create a rendering loop that delivers hazardous strobing effects.
-        // We can choose a new default once recovery works better.
+        // Quit the application for any RenderError. This is overzealous at the moment,
+        // but requires more extensive use of the non-fatal error handling pattern in
+        // upstream wgpu. RenderErrors are issued when wgpu is used incorrectly.
+        // Ignoring a wgpu OutOfMemory or Validation error without addressing the
+        // root cause (via hiding or deleting entities or changing rendering settings) will
+        // likely hit the same error repeatedly, resulting in hazardous strobing effects.
+        // The parameters to this function are (error, main_world, render_world).
         Self(|error, main_world, _| {
             bevy_log::error!("Quitting the application due to {:?} RenderError", error.ty);
             main_world.write_message(AppExit::error());
@@ -81,7 +83,8 @@ impl Default for RenderErrorHandler {
     }
 }
 
-/// An error encountered during rendering. These errors come from wgpu.
+/// An error encountered during rendering. These are errors reported by wgpu validation layers,
+/// and typically indicate problems in the way it is being used.
 #[derive(Debug)]
 pub struct RenderError {
     pub ty: ErrorType,

--- a/crates/bevy_render/src/error_handler.rs
+++ b/crates/bevy_render/src/error_handler.rs
@@ -20,7 +20,7 @@ use crate::{
 pub enum RenderErrorPolicy {
     /// Pretends nothing happened and continues rendering.
     /// This discards the error after logging it to console.
-    /// WARNING: Using this policy can cause hazardous rapid flashing
+    /// WARNING: Using this policy could cause hazardous rapid flashing
     /// if the conditions causing the error remain unaddressed, since
     /// rendering will attempt to continue executing.
     /// When choosing to use this policy, be sure to test that the application
@@ -38,9 +38,11 @@ pub enum RenderErrorPolicy {
 ///
 /// The handler has access to both the main world and the render world in that order.
 /// By the time this is invoked, the error has already been logged. The error is provided
-/// for the decision-making reason of how to appropriately respond to it. Not all errors
-/// are equally severe: validation errors may be ignored for example, while device lost errors
-/// require recovery to continue rendering.
+/// for the decision-making reason of how to appropriately respond to it.
+/// 
+/// Note that failing to address the source of an error and continuing to render may cause rapid flashing.
+/// Be sure to thoroughly test your error handler to ensure you application remains safe
+/// to use.
 #[derive(Resource)]
 pub struct RenderErrorHandler(
     pub for<'a> fn(&'a RenderError, &'a mut World, &'a mut World) -> RenderErrorPolicy,
@@ -67,11 +69,10 @@ impl RenderErrorHandler {
 impl Default for RenderErrorHandler {
     fn default() -> Self {
         // Quit the application for any `RenderError`.
-        // Especially for OOM's and Validation RenderErrors, ignoring the error
-        // and resuming render can cause a loop that can cause hazardous strobing effects.
+        // These `RenderError`s originate from wgpu. Ignoring a wgpu OutOfMemory
+        // or wgpu Validation error without addressing the root cause can
+        // create a rendering loop that delivers hazardous strobing effects.
         // We can choose a new default once recovery works better.
-        Self(|error, _, _| {
-            bevy_log::error!("Quitting the application due to {:?} RenderError", error.ty);
         Self(|error, main_world, _| {
             bevy_log::error!("Quitting the application due to {:?} RenderError", error.ty);
             main_world.write_message(AppExit::error());
@@ -80,7 +81,7 @@ impl Default for RenderErrorHandler {
     }
 }
 
-/// An error encountered during rendering.
+/// An error encountered during rendering. These errors come from the WebGPU API.
 #[derive(Debug)]
 pub struct RenderError {
     pub ty: ErrorType,

--- a/crates/bevy_render/src/error_handler.rs
+++ b/crates/bevy_render/src/error_handler.rs
@@ -39,7 +39,7 @@ pub enum RenderErrorPolicy {
 /// The handler has access to both the main world and the render world in that order.
 /// By the time this is invoked, the error has already been logged. The error is provided
 /// for the decision-making reason of how to appropriately respond to it.
-/// 
+///
 /// Note that failing to address the source of an error and continuing to render may cause rapid flashing.
 /// Be sure to thoroughly test your error handler to ensure you application remains safe
 /// to use.

--- a/crates/bevy_render/src/error_handler.rs
+++ b/crates/bevy_render/src/error_handler.rs
@@ -32,10 +32,6 @@ pub enum RenderErrorPolicy {
     StopRendering,
     /// Attempt renderer recovery with the given [`RenderCreation`].
     Recover(RenderCreation),
-    /// Quits the app.
-    /// This stops rendering and sends an [`AppExit::error`], which will
-    /// immediately terminate the app.
-    QuitApplication,
 }
 
 /// Determines what [`RenderErrorPolicy`] should be used to respond to a given [`RenderError`].
@@ -60,9 +56,6 @@ impl RenderErrorHandler {
             RenderErrorPolicy::StopRendering => {
                 // do nothing
             }
-            RenderErrorPolicy::QuitApplication => {
-                main_world.write_message(AppExit::error());
-            }
             RenderErrorPolicy::Recover(render_creation) => {
                 assert!(insert_future_resources(&render_creation, main_world));
                 render_world.insert_resource(RenderState::Reinitializing);
@@ -79,7 +72,10 @@ impl Default for RenderErrorHandler {
         // We can choose a new default once recovery works better.
         Self(|error, _, _| {
             bevy_log::error!("Quitting the application due to {:?} RenderError", error.ty);
-            RenderErrorPolicy::QuitApplication
+        Self(|error, main_world, _| {
+            bevy_log::error!("Quitting the application due to {:?} RenderError", error.ty);
+            main_world.write_message(AppExit::error());
+            RenderErrorPolicy::StopRendering
         })
     }
 }

--- a/crates/bevy_render/src/error_handler.rs
+++ b/crates/bevy_render/src/error_handler.rs
@@ -1,4 +1,5 @@
 use alloc::sync::Arc;
+use bevy_app::AppExit;
 use bevy_ecs::{
     resource::Resource,
     world::{Mut, World},
@@ -26,6 +27,8 @@ pub enum RenderErrorPolicy {
     StopRendering,
     /// Attempt renderer recovery with the given [`RenderCreation`].
     Recover(RenderCreation),
+    /// Quits the app.
+    QuitApplication,
 }
 
 /// Determines what [`RenderErrorPolicy`] should be used to respond to a given [`RenderError`].
@@ -50,6 +53,9 @@ impl RenderErrorHandler {
             RenderErrorPolicy::StopRendering => {
                 // do nothing
             }
+            RenderErrorPolicy::QuitApplication => {
+                main_world.write_message(AppExit::error());
+            }
             RenderErrorPolicy::Recover(render_creation) => {
                 assert!(insert_future_resources(&render_creation, main_world));
                 render_world.insert_resource(RenderState::Reinitializing);
@@ -60,9 +66,14 @@ impl RenderErrorHandler {
 
 impl Default for RenderErrorHandler {
     fn default() -> Self {
-        // This is what we've always done historically,
-        // but we could choose a new default once recovery works better.
-        Self(|_, _, _| RenderErrorPolicy::Ignore)
+        // Quit the application for any `RenderError`.
+        // Especially for OOM's and Validation RenderErrors, ignoring the error
+        // and resuming render can cause a loop that can cause hazardous strobing effects.
+        // We can choose a new default once recovery works better.
+        Self(|error, _, _| {
+            bevy_log::error!("Quitting the application due to {:?} RenderError", error.ty);
+            RenderErrorPolicy::QuitApplication
+        })
     }
 }
 


### PR DESCRIPTION
# Objective

- Fixes #23183 
- The issue describes strobing that happens on OOM’s (that used to just crash the application). I’ve also seen strobing happen on validation errors while some examples were in a broken state very recently.  I believe it’s cause OOM’s and Validations are ignored, which just leads for rendering to resume and hit those same issues again. The looping is somehow causing the flashing. To protect against this strobing, I think the default render error policy needs to be changed.

## Solution

- Instead of ignoring any errors and continuing to render, this PR changes the default error policy to quit the application upon any error. OOM and Validation error induced strobing will not happen cause the app should just quit. I’m not aware of strobing that could happen on DeviceLost / Internal errors, but I’m leaning towards safety here. You can correct me (within reason) if there are some obvious errors we should handle with a different error policy, but I think this is a better starting point than `Ignore` for all.

- Note: At times, even with this code, I’ve seen the app flash to a magenta/pink color before exiting (not a strobing pink that would happen if the app ignored validation errors, just a single abrupt switch before app exit), so I’m wondering if it’s better to throw a `panic!` rather than try to quit gracefully.

## Testing

- Fortunately, the `pccm` example and `light_probe_blending` examples are still broken on `main`.
- `cargo r --example light_probe_blending --features free_camera,https` correctly closes the app upon Validation error
- `cargo run --example pccm --features="free_camera https”` does the same.

<details>
<summary>Example console logs</summary>

```
cargo r --example light_probe_blending --features free_camera,https
   Compiling bevy v0.19.0-dev (/Users/kchen/CodingProjects/bevy)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 11.24s
     Running `target/debug/examples/light_probe_blending`
2026-05-05T01:04:33.028208Z  INFO bevy_diagnostic::system_information_diagnostics_plugin::internal: SystemInfo { os: "macOS 26.4.1", kernel: "25.4.0", cpu: "Apple M4", core_count: "10", memory: "16.0 GiB" }
2026-05-05T01:04:33.031189Z  WARN bevy_asset::io::web: WebAssetPlugin is potentially insecure! Make sure to verify asset URLs are safe to load before loading them. If you promise you know what you're doing, you can silence this warning by setting silence_startup_warning: true in the WebAssetPlugin construction.
2026-05-05T01:04:33.448175Z  INFO bevy_render::renderer: AdapterInfo { name: "Apple M4", vendor: 0, device: 0, device_type: IntegratedGpu, device_pci_bus_id: "", driver: "", driver_info: "", backend: Metal, subgroup_min_size: 4, subgroup_max_size: 64, transient_saves_memory: true }
2026-05-05T01:04:34.315115Z  INFO bevy_pbr::cluster: GPU clustering is supported on this device.
2026-05-05T01:04:34.315226Z  INFO bevy_render::batching::gpu_preprocessing: GPU preprocessing is fully supported on this device.
2026-05-05T01:04:34.611394Z  INFO bevy_winit::system: Creating new window Bevy Light Probe Blending Example (65v0)
2026-05-05T01:04:37.312262Z ERROR bevy_render::error_handler: Caught rendering error: Validation Error

Caused by:
  In Device::create_bind_group, label = 'mesh_view_bind_group_binding_array'
    Number of bindings in bind group descriptor (3) does not match the number of bindings defined in the bind group layout (0)

2026-05-05T01:04:37.900677Z ERROR bevy_render::error_handler: Quitting the application due to Validation RenderError
2026-05-05T01:04:37.964583Z  WARN bevy_ecs::world::command_queue: CommandQueue has un-applied commands being dropped. Did you forget to call SystemState::apply?
2026-05-05T01:04:37.964628Z  WARN bevy_ecs::world::command_queue: CommandQueue has un-applied commands being dropped. Did you forget to call SystemState::apply?
...
```
</details>

There is some `WARN bevy_ecs::world::command_queue: CommandQueue has un-applied commands being dropped. Did you forget to call SystemState::apply?` spam (like at least 20+ lines of it) after quitting the application; if anyone knows if that could be prevented somehow, I’m keen to learn.