### PR TITLE
`clip_check_recursive` improvements

### DIFF
--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -348,17 +348,19 @@ pub fn clip_check_recursive(
     clipping_query: &Query<'_, '_, (&ComputedNode, &UiGlobalTransform, &Node)>,
     child_of_query: &Query<&ChildOf, Without<OverrideClip>>,
 ) -> bool {
-    if let Ok(child_of) = child_of_query.get(entity) {
-        let parent = child_of.0;
-        if let Ok((computed_node, transform, node)) = clipping_query.get(parent)
-            && !computed_node
+    if let Ok(child_of) = child_of_query.get(entity)
+        && let Ok((computed_node, transform, node)) = clipping_query.get(child_of.0)
+        && !node.overflow.is_visible()
+    {
+        if transform.try_inverse().is_none_or(|affine| {
+            !computed_node
                 .resolve_clip_rect(node.overflow, node.overflow_clip_margin)
-                .contains(transform.inverse().transform_point2(point))
-        {
-            // The point is clipped and should be ignored by picking
+                .contains(affine.transform_point2(point))
+        }) {
+            // The point is clipped (or transform not invertible) → ignore for picking
             return false;
         }
-        return clip_check_recursive(point, parent, clipping_query, child_of_query);
+        return clip_check_recursive(point, child_of.0, clipping_query, child_of_query);
     }
     // Reached root, point unclipped by all ancestors
     true


### PR DESCRIPTION
## Objective

* `clip_check_recursive` can skip the clip containment test in the absence of clipping
* `try_inverse` should be used to avoid invalid results.

## Solution
* Skip the clip containment test, if there's no clipping.
* Use `try_inverse` to reject non-invertible transforms.

## Testing 

Changes are very simple, shouldn't be hard to convince anyone they are correct. Test with:

```
cargo run --example overflow
```