### PR TITLE
`ComputedNode::resolve_clip_rect` margins fix

### DIFF
--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -3233,6 +3233,10 @@ mod tests {
         assert_eq!(content_box.max, Vec2::new(40.0 - 6.0, 20.0 - 8.0));
     }
 
+    fn abs_diff_eq_rect(s: Rect, t: Rect) -> bool {
+        s.min.abs_diff_eq(t.min, 1e-5) && s.max.abs_diff_eq(t.max, 1e-5)
+    }
+
     #[test]
     fn overflow_clip_margin_boxes() {
         let size = 100.;
@@ -3248,7 +3252,7 @@ mod tests {
 
         let r = Rect::from_center_size(Vec2::ZERO, Vec2::splat(size));
 
-        let (s, t) = (
+        assert!(abs_diff_eq_rect(
             computed_node.resolve_clip_rect(
                 Overflow::clip(),
                 OverflowClipMargin {
@@ -3257,10 +3261,9 @@ mod tests {
                 },
             ),
             r.inflate(m),
-        );
-        assert!(s.min.abs_diff_eq(t.min, 1e-5) && s.max.abs_diff_eq(t.max, 1e-5));
+        ));
 
-        let (s, t) = (
+        assert!(abs_diff_eq_rect(
             computed_node.resolve_clip_rect(
                 Overflow::clip(),
                 OverflowClipMargin {
@@ -3269,10 +3272,9 @@ mod tests {
                 },
             ),
             r.inflate(m - b),
-        );
-        assert!(s.min.abs_diff_eq(t.min, 1e-5) && s.max.abs_diff_eq(t.max, 1e-5));
+        ));
 
-        let (s, t) = (
+        assert!(abs_diff_eq_rect(
             computed_node.resolve_clip_rect(
                 Overflow::clip(),
                 OverflowClipMargin {
@@ -3281,8 +3283,7 @@ mod tests {
                 },
             ),
             r.inflate(m - b - p),
-        );
-        assert!(s.min.abs_diff_eq(t.min, 1e-5) && s.max.abs_diff_eq(t.max, 1e-5));
+        ));
     }
 
     #[test]
@@ -3305,7 +3306,6 @@ mod tests {
         );
         let s = Rect::from_center_size(Vec2::ZERO, Vec2::splat(size)).inflate(m * scale_factor);
 
-        assert!(r.min.abs_diff_eq(s.max, 1e-5));
-        assert!(r.max.abs_diff_eq(s.max, 1e-5));
+        assert!(abs_diff_eq_rect(r, s));
     }
 }

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -267,6 +267,9 @@ impl ComputedNode {
             OverflowClipBox::PaddingBox => self.border(),
         };
 
+        clip_rect =
+            clip_rect.inflate(overflow_clip_margin.margin.max(0.) / self.inverse_scale_factor);
+
         clip_rect.min += clip_inset.min_inset;
         clip_rect.max -= clip_inset.max_inset;
 
@@ -3056,6 +3059,9 @@ impl ComputedUiRenderTargetInfo {
 mod tests {
     use crate::ComputedNode;
     use crate::GridPlacement;
+    use crate::Overflow;
+    use crate::OverflowClipBox;
+    use crate::OverflowClipMargin;
     use bevy_math::{Rect, Vec2};
     use bevy_sprite::BorderRect;
 
@@ -3225,5 +3231,77 @@ mod tests {
 
         assert_eq!(content_box.min, Vec2::new(-40.0 + 4.0, -20.0 + 2.0));
         assert_eq!(content_box.max, Vec2::new(40.0 - 6.0, 20.0 - 8.0));
+    }
+
+    #[test]
+    fn overflow_clip_margin_boxes() {
+        let size = 100.;
+        let b = 3.;
+        let p = 5.;
+        let m = 7.;
+        let computed_node = ComputedNode {
+            size: Vec2::splat(size),
+            border: BorderRect::all(b),
+            padding: BorderRect::all(p),
+            ..Default::default()
+        };
+
+        let r = Rect::from_center_size(Vec2::ZERO, Vec2::splat(size));
+
+        assert_eq!(
+            computed_node.resolve_clip_rect(
+                Overflow::clip(),
+                OverflowClipMargin {
+                    visual_box: OverflowClipBox::BorderBox,
+                    margin: m,
+                },
+            ),
+            r.inflate(m)
+        );
+
+        assert_eq!(
+            computed_node.resolve_clip_rect(
+                Overflow::clip(),
+                OverflowClipMargin {
+                    visual_box: OverflowClipBox::PaddingBox,
+                    margin: m,
+                },
+            ),
+            r.inflate(m - b)
+        );
+
+        assert_eq!(
+            computed_node.resolve_clip_rect(
+                Overflow::clip(),
+                OverflowClipMargin {
+                    visual_box: OverflowClipBox::ContentBox,
+                    margin: m,
+                },
+            ),
+            r.inflate(m - b - p)
+        );
+    }
+
+    #[test]
+    fn overflow_clip_margin_is_logical() {
+        let size = 100.;
+        let m = 10.;
+        let scale_factor = 2.;
+        let computed_node = ComputedNode {
+            size: Vec2::splat(size),
+            inverse_scale_factor: 1. / scale_factor,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            computed_node.resolve_clip_rect(
+                Overflow::clip(),
+                OverflowClipMargin {
+                    visual_box: OverflowClipBox::BorderBox,
+                    margin: m,
+                },
+            ),
+            Rect::from_center_size(Vec2::ZERO, Vec2::splat(size)).inflate(m * scale_factor)
+        );
     }
 }

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -3248,7 +3248,7 @@ mod tests {
 
         let r = Rect::from_center_size(Vec2::ZERO, Vec2::splat(size));
 
-        assert_eq!(
+        let (s, t) = (
             computed_node.resolve_clip_rect(
                 Overflow::clip(),
                 OverflowClipMargin {
@@ -3256,10 +3256,11 @@ mod tests {
                     margin: m,
                 },
             ),
-            r.inflate(m)
+            r.inflate(m),
         );
+        assert!(s.min.abs_diff_eq(t.min, 1e-5) && s.max.abs_diff_eq(t.max, 1e-5));
 
-        assert_eq!(
+        let (s, t) = (
             computed_node.resolve_clip_rect(
                 Overflow::clip(),
                 OverflowClipMargin {
@@ -3267,10 +3268,11 @@ mod tests {
                     margin: m,
                 },
             ),
-            r.inflate(m - b)
+            r.inflate(m - b),
         );
+        assert!(s.min.abs_diff_eq(t.min, 1e-5) && s.max.abs_diff_eq(t.max, 1e-5));
 
-        assert_eq!(
+        let (s, t) = (
             computed_node.resolve_clip_rect(
                 Overflow::clip(),
                 OverflowClipMargin {
@@ -3278,8 +3280,9 @@ mod tests {
                     margin: m,
                 },
             ),
-            r.inflate(m - b - p)
+            r.inflate(m - b - p),
         );
+        assert!(s.min.abs_diff_eq(t.min, 1e-5) && s.max.abs_diff_eq(t.max, 1e-5));
     }
 
     #[test]
@@ -3293,15 +3296,16 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(
-            computed_node.resolve_clip_rect(
-                Overflow::clip(),
-                OverflowClipMargin {
-                    visual_box: OverflowClipBox::BorderBox,
-                    margin: m,
-                },
-            ),
-            Rect::from_center_size(Vec2::ZERO, Vec2::splat(size)).inflate(m * scale_factor)
+        let r = computed_node.resolve_clip_rect(
+            Overflow::clip(),
+            OverflowClipMargin {
+                visual_box: OverflowClipBox::BorderBox,
+                margin: m,
+            },
         );
+        let s = Rect::from_center_size(Vec2::ZERO, Vec2::splat(size)).inflate(m * scale_factor);
+
+        assert!(r.min.abs_diff_eq(s.max, 1e-5));
+        assert!(r.max.abs_diff_eq(s.max, 1e-5));
     }
 }

--- a/crates/bevy_ui/src/update.rs
+++ b/crates/bevy_ui/src/update.rs
@@ -4,7 +4,7 @@ use crate::{
     experimental::{UiChildren, UiRootNodes},
     ui_transform::UiGlobalTransform,
     CalculatedClip, ComputedUiRenderTargetInfo, ComputedUiTargetCamera, DefaultUiCamera, Display,
-    Node, OverflowAxis, OverrideClip, UiScale, UiTargetCamera,
+    Node, OverrideClip, UiScale, UiTargetCamera,
 };
 
 use super::ComputedNode;
@@ -16,7 +16,6 @@ use bevy_ecs::{
     system::{Commands, Query, Res},
 };
 use bevy_math::{Rect, UVec2};
-use bevy_sprite::BorderRect;
 
 /// Updates clipping for all nodes
 pub fn update_clipping_system(
@@ -101,7 +100,10 @@ fn update_clipping(
         //
         // `clip_inset` should always fit inside `node_rect`.
         // Even if `clip_inset` were to overflow, we won't return a degenerate result as `Rect::intersect` will clamp the intersection, leaving it empty.
-        let clip_rect = computed_node.resolve_clip_rect(node.overflow, node.overflow_clip_margin);
+        let mut clip_rect =
+            computed_node.resolve_clip_rect(node.overflow, node.overflow_clip_margin);
+        clip_rect.min += transform.translation;
+        clip_rect.max += transform.translation;
         Some(maybe_inherited_clip.map_or(clip_rect, |c| c.intersect(clip_rect)))
     };
 

--- a/crates/bevy_ui/src/update.rs
+++ b/crates/bevy_ui/src/update.rs
@@ -97,32 +97,11 @@ fn update_clipping(
         maybe_inherited_clip
     } else {
         // Find the current node's clipping rect and intersect it with the inherited clipping rect, if one exists
-        let mut clip_rect = Rect::from_center_size(transform.translation, computed_node.size());
-
         // Content isn't clipped at the edges of the node but at the edges of the region specified by [`Node::overflow_clip_margin`].
         //
         // `clip_inset` should always fit inside `node_rect`.
         // Even if `clip_inset` were to overflow, we won't return a degenerate result as `Rect::intersect` will clamp the intersection, leaving it empty.
-        let clip_inset = match node.overflow_clip_margin.visual_box {
-            crate::OverflowClipBox::BorderBox => BorderRect::ZERO,
-            crate::OverflowClipBox::ContentBox => computed_node.content_inset(),
-            crate::OverflowClipBox::PaddingBox => computed_node.border(),
-        };
-
-        clip_rect.min += clip_inset.min_inset;
-        clip_rect.max -= clip_inset.max_inset;
-
-        clip_rect = clip_rect
-            .inflate(node.overflow_clip_margin.margin.max(0.) / computed_node.inverse_scale_factor);
-
-        if node.overflow.x == OverflowAxis::Visible {
-            clip_rect.min.x = -f32::INFINITY;
-            clip_rect.max.x = f32::INFINITY;
-        }
-        if node.overflow.y == OverflowAxis::Visible {
-            clip_rect.min.y = -f32::INFINITY;
-            clip_rect.max.y = f32::INFINITY;
-        }
+        let clip_rect = computed_node.resolve_clip_rect(node.overflow, node.overflow_clip_margin);
         Some(maybe_inherited_clip.map_or(clip_rect, |c| c.intersect(clip_rect)))
     };
 


### PR DESCRIPTION
# Objective

The `resolve_clip_rect` function on `ComputedNode` wasn't adding the margin from `OverflowClipMargin`. This only affected picking, not rendering, as `update_clipping` has its own clipping calculations.

## Solution

* Inflate the clipping rect in `resolve_clip_rect` by the margin value from `OverflowClipMargin` (after scaling as the margin is logical).
* Removed the duplicate calculations from `update_clipping`. 
* Added two basic tests.

## Testing

Added two new tests to the `ui_node` module: `overflow_clip_margin_boxes` and overflow_clip_margin_is_logical`.
