### PR TITLE
Add a `translate` method to `Rect`

### DIFF
--- a/crates/bevy_math/src/rects/rect.rs
+++ b/crates/bevy_math/src/rects/rect.rs
@@ -215,6 +215,25 @@ impl Rect {
         )
     }
 
+    /// Returns the rectangle translated by the given offset.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bevy_math::{Rect, Vec2};
+    /// let r = Rect::new(0., 0., 5., 1.); // w=5 h=1
+    /// let r2 = r.translate(Vec2::new(2., -3.));
+    /// assert!(r2.min.abs_diff_eq(Vec2::new(2., -3.), 1e-5));
+    /// assert!(r2.max.abs_diff_eq(Vec2::new(7., -2.), 1e-5));
+    /// ```
+    #[inline]
+    pub const fn translate(&self, offset: Vec2) -> Self {
+        Self {
+            min: Vec2::new(self.min.x + offset.x, self.min.y + offset.y),
+            max: Vec2::new(self.max.x + offset.x, self.max.y + offset.y),
+        }
+    }
+
     /// Check if a point lies within this rectangle, inclusive of its edges.
     ///
     /// # Examples
@@ -534,5 +553,15 @@ mod tests {
         let r2 = r.inflate(0.3);
         assert!(r2.min.abs_diff_eq(Vec2::new(-0.8, -0.8), 1e-5));
         assert!(r2.max.abs_diff_eq(Vec2::new(0.8, 0.8), 1e-5));
+    }
+
+    #[test]
+    fn rect_translate() {
+        let r = Rect::new(0., 1., 4., 3.);
+        let r2 = r.translate(Vec2::new(2., -5.));
+
+        assert!(r2.min.abs_diff_eq(Vec2::new(2., -4.), 1e-5));
+        assert!(r2.max.abs_diff_eq(Vec2::new(6., -2.), 1e-5));
+        assert!(r2.size().abs_diff_eq(r.size(), 1e-5));
     }
 }


### PR DESCRIPTION
# Objective

Add a `translate` method to `Rect`.

## Solution

Add a `translate` method to `Rect`.

## Testing

Added a `rect_translate` test to the `rect` module.