### PR TITLE
Add Disabled/Enabled state scoped components

### DIFF
--- a/crates/bevy_state/src/app.rs
+++ b/crates/bevy_state/src/app.rs
@@ -11,7 +11,9 @@ use crate::{
     },
     state_scoped::{
         despawn_entities_on_enter_state, despawn_entities_on_exit_state,
-        despawn_entities_when_state,
+        despawn_entities_when_state, disable_entities_on_enter_state,
+        disable_entities_on_exit_state, disable_entities_when_state,
+        enable_entities_on_enter_state, enable_entities_on_exit_state, enable_entities_when_state,
     },
 };
 
@@ -253,18 +255,33 @@ fn enable_state_scoped_entities<S: States>(app: &mut SubApp) {
     // `OnExit` only runs for one specific variant of the state.
     app.add_systems(
         StateTransition,
-        despawn_entities_on_exit_state::<S>.in_set(StateTransitionSystems::ExitSchedules),
+        (
+            despawn_entities_on_exit_state::<S>,
+            disable_entities_on_exit_state::<S>,
+            enable_entities_on_exit_state::<S>,
+        )
+            .in_set(StateTransitionSystems::ExitSchedules),
     )
     // Note: We work with `StateTransition` in set
     // `StateTransitionSystems::EnterSchedules` rather than `OnEnter`, because
     // `OnEnter` only runs for one specific variant of the state.
     .add_systems(
         StateTransition,
-        despawn_entities_on_enter_state::<S>.in_set(StateTransitionSystems::EnterSchedules),
+        (
+            despawn_entities_on_enter_state::<S>,
+            disable_entities_on_enter_state::<S>,
+            enable_entities_on_enter_state::<S>,
+        )
+            .in_set(StateTransitionSystems::EnterSchedules),
     )
     .add_systems(
         StateTransition,
-        despawn_entities_when_state::<S>.in_set(StateTransitionSystems::TransitionSchedules),
+        (
+            despawn_entities_when_state::<S>,
+            disable_entities_when_state::<S>,
+            enable_entities_when_state::<S>,
+        )
+            .in_set(StateTransitionSystems::TransitionSchedules),
     );
 }
 

--- a/crates/bevy_state/src/lib.rs
+++ b/crates/bevy_state/src/lib.rs
@@ -92,7 +92,10 @@ pub mod prelude {
             OnExit, OnTransition, PreviousState, State, StateSet, StateTransition,
             StateTransitionEvent, States, SubStates, TransitionSchedules,
         },
-        state_scoped::{DespawnOnEnter, DespawnOnExit, DespawnWhen},
+        state_scoped::{
+            DespawnOnEnter, DespawnOnExit, DespawnWhen, DisableOnEnter, DisableOnExit, DisableWhen,
+            EnableOnEnter, EnableOnExit, EnableWhen,
+        },
     };
 }
 

--- a/crates/bevy_state/src/state_scoped.rs
+++ b/crates/bevy_state/src/state_scoped.rs
@@ -262,6 +262,488 @@ pub fn despawn_entities_on_enter_state<S: States>(
     }
 }
 
+/// Entities marked with this component will be disabled
+/// when a [`StateTransitionEvent<S>`] matching the given predicate is sent.
+///
+/// If you need to disable this behavior, add the attribute `#[states(scoped_entities = false)]` when deriving [`States`].
+///
+/// ```
+/// use bevy_state::prelude::*;
+/// use bevy_ecs::{prelude::*, system::ScheduleSystem};
+///
+/// #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Default, States)]
+/// enum GameState {
+///     #[default]
+///     MainMenu,
+///     SettingsMenu,
+///     InGame,
+///     GameOver,
+/// }
+///
+/// # #[derive(Component)]
+/// # struct Player;
+///
+/// fn spawn_player(mut commands: Commands) {
+///     commands.spawn((
+///         DisableWhen::new(|transition| {
+///             matches!(
+///                 transition.entered,
+///                 Some(GameState::MainMenu) | Some(GameState::GameOver)
+///             )
+///         }),
+///         Player
+///     ));
+/// }
+///
+/// # struct AppMock;
+/// # impl AppMock {
+/// #     fn init_state<S>(&mut self) {}
+/// #     fn add_systems<S, M>(&mut self, schedule: S, systems: impl IntoScheduleConfigs<ScheduleSystem, M>) {}
+/// # }
+/// # struct Update;
+/// # let mut app = AppMock;
+///
+/// app.init_state::<GameState>();
+/// app.add_systems(OnEnter(GameState::InGame), spawn_player);
+/// ```
+///
+/// See also [`DisableOnExit`] and [`DisableOnEnter`].
+#[derive(Component)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Component))]
+pub struct DisableWhen<S: States> {
+    /// The predicate that is ran when message [`StateTransitionEvent<S>`] is sent.
+    pub state_transition_evaluator:
+        Box<dyn Fn(&StateTransitionEvent<S>) -> bool + Sync + Send + 'static>,
+}
+
+impl<S: States> DisableWhen<S> {
+    /// Creates a [`DisableWhen`] for the given predicate.
+    pub fn new(f: impl Fn(&StateTransitionEvent<S>) -> bool + Sync + Send + 'static) -> Self {
+        Self {
+            state_transition_evaluator: Box::new(f),
+        }
+    }
+}
+
+/// Disable entities marked with [`DisableWhen<S>`] when the state transition message matches their
+/// predicate.
+pub fn disable_entities_when_state<S: States>(
+    mut commands: Commands,
+    mut transitions: MessageReader<StateTransitionEvent<S>>,
+    query: Query<(Entity, &DisableWhen<S>), Allow<Disabled>>,
+) {
+    // We use the latest event, because state machine internals generate at most 1
+    // transition event (per type) each frame. No event means no change happened
+    // and we skip iterating all entities.
+    let Some(transition) = transitions.read().last() else {
+        return;
+    };
+    if transition.entered == transition.exited && !transition.allow_same_state_transitions {
+        return;
+    }
+    for (entity, when) in &query {
+        if (when.state_transition_evaluator)(transition) {
+            commands.entity(entity).try_insert(Disabled);
+        }
+    }
+}
+
+/// Entities marked with this component will be disabled
+/// upon exiting the given state.
+///
+/// If you need to disable this behavior, add the attribute `#[states(scoped_entities = false)]` when deriving [`States`].
+///
+/// ```
+/// use bevy_state::prelude::*;
+/// use bevy_ecs::{prelude::*, system::ScheduleSystem};
+///
+/// #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Default, States)]
+/// enum GameState {
+///     #[default]
+///     MainMenu,
+///     SettingsMenu,
+///     InGame,
+/// }
+///
+/// # #[derive(Component)]
+/// # struct Player;
+///
+/// fn spawn_player(mut commands: Commands) {
+///     commands.spawn((
+///         DisableOnExit(GameState::InGame),
+///         Player
+///     ));
+/// }
+///
+/// # struct AppMock;
+/// # impl AppMock {
+/// #     fn init_state<S>(&mut self) {}
+/// #     fn add_systems<S, M>(&mut self, schedule: S, systems: impl IntoScheduleConfigs<ScheduleSystem, M>) {}
+/// # }
+/// # struct Update;
+/// # let mut app = AppMock;
+///
+/// app.init_state::<GameState>();
+/// app.add_systems(OnEnter(GameState::InGame), spawn_player);
+/// ```
+///
+/// For more advanced usecases see [`DisableWhen`]
+#[derive(Component, Clone)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Component, Clone))]
+pub struct DisableOnExit<S: States>(pub S);
+
+impl<S> Default for DisableOnExit<S>
+where
+    S: States + Default,
+{
+    fn default() -> Self {
+        Self(S::default())
+    }
+}
+
+/// Disables entities marked with [`DisableOnExit<S>`] when their state no
+/// longer matches the world state.
+pub fn disable_entities_on_exit_state<S: States>(
+    mut commands: Commands,
+    mut transitions: MessageReader<StateTransitionEvent<S>>,
+    query: Query<(Entity, &DisableOnExit<S>), Allow<Disabled>>,
+) {
+    // We use the latest event, because state machine internals generate at most 1
+    // transition event (per type) each frame. No event means no change happened
+    // and we skip iterating all entities.
+    let Some(transition) = transitions.read().last() else {
+        return;
+    };
+    if transition.entered == transition.exited && !transition.allow_same_state_transitions {
+        return;
+    }
+    let Some(exited) = &transition.exited else {
+        return;
+    };
+    for (entity, exit) in &query {
+        if exit.0 == *exited {
+            commands.entity(entity).try_insert(Disabled);
+        }
+    }
+}
+
+/// Entities marked with this component will be disabled
+/// upon entering the given state.
+///
+/// If you need to disable this behavior, add the attribute `#[states(scoped_entities = false)]` when deriving [`States`].
+///
+/// ```
+/// use bevy_state::prelude::*;
+/// use bevy_ecs::{prelude::*, system::ScheduleSystem};
+///
+/// #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Default, States)]
+/// enum GameState {
+///     #[default]
+///     MainMenu,
+///     SettingsMenu,
+///     InGame,
+/// }
+///
+/// # #[derive(Component)]
+/// # struct Player;
+///
+/// fn spawn_player(mut commands: Commands) {
+///     commands.spawn((
+///         DisableOnEnter(GameState::MainMenu),
+///         Player
+///     ));
+/// }
+///
+/// # struct AppMock;
+/// # impl AppMock {
+/// #     fn init_state<S>(&mut self) {}
+/// #     fn add_systems<S, M>(&mut self, schedule: S, systems: impl IntoScheduleConfigs<ScheduleSystem, M>) {}
+/// # }
+/// # struct Update;
+/// # let mut app = AppMock;
+///
+/// app.init_state::<GameState>();
+/// app.add_systems(OnEnter(GameState::InGame), spawn_player);
+/// ```
+///
+/// For more advanced usecases see [`DisableWhen`]
+#[derive(Component, Clone)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Component))]
+pub struct DisableOnEnter<S: States>(pub S);
+
+impl<S: States + Default> Default for DisableOnEnter<S> {
+    fn default() -> Self {
+        Self(S::default())
+    }
+}
+
+/// Disables entities marked with [`DisableOnEnter<S>`] when their state
+/// matches the world state.
+pub fn disable_entities_on_enter_state<S: States>(
+    mut commands: Commands,
+    mut transitions: MessageReader<StateTransitionEvent<S>>,
+    query: Query<(Entity, &DisableOnEnter<S>), Allow<Disabled>>,
+) {
+    // We use the latest event, because state machine internals generate at most 1
+    // transition event (per type) each frame. No event means no change happened
+    // and we skip iterating all entities.
+    let Some(transition) = transitions.read().last() else {
+        return;
+    };
+    if transition.entered == transition.exited && !transition.allow_same_state_transitions {
+        return;
+    }
+    let Some(entered) = &transition.entered else {
+        return;
+    };
+    for (entity, enter) in &query {
+        if enter.0 == *entered {
+            commands.entity(entity).try_insert(Disabled);
+        }
+    }
+}
+
+/// Entities marked with this component will be enabled
+/// when a [`StateTransitionEvent<S>`] matching the given predicate is sent.
+///
+/// If you need to disable this behavior, add the attribute `#[states(scoped_entities = false)]` when deriving [`States`].
+///
+/// ```
+/// use bevy_state::prelude::*;
+/// use bevy_ecs::{prelude::*, system::ScheduleSystem};
+///
+/// #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Default, States)]
+/// enum GameState {
+///     #[default]
+///     MainMenu,
+///     SettingsMenu,
+///     InGame,
+///     GameOver,
+/// }
+///
+/// # #[derive(Component)]
+/// # struct Player;
+///
+/// fn spawn_player(mut commands: Commands) {
+///     commands.spawn((
+///         EnableWhen::new(|transition| {
+///             matches!(
+///                 transition.entered,
+///                 Some(GameState::MainMenu) | Some(GameState::GameOver)
+///             )
+///         }),
+///         Player
+///     ));
+/// }
+///
+/// # struct AppMock;
+/// # impl AppMock {
+/// #     fn init_state<S>(&mut self) {}
+/// #     fn add_systems<S, M>(&mut self, schedule: S, systems: impl IntoScheduleConfigs<ScheduleSystem, M>) {}
+/// # }
+/// # struct Update;
+/// # let mut app = AppMock;
+///
+/// app.init_state::<GameState>();
+/// app.add_systems(OnEnter(GameState::InGame), spawn_player);
+/// ```
+///
+/// See also [`EnableOnExit`] and [`EnableOnEnter`].
+#[derive(Component)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Component))]
+pub struct EnableWhen<S: States> {
+    /// The predicate that is ran when message [`StateTransitionEvent<S>`] is sent.
+    pub state_transition_evaluator:
+        Box<dyn Fn(&StateTransitionEvent<S>) -> bool + Sync + Send + 'static>,
+}
+
+impl<S: States> EnableWhen<S> {
+    /// Creates a [`EnableWhen`] for the given predicate.
+    pub fn new(f: impl Fn(&StateTransitionEvent<S>) -> bool + Sync + Send + 'static) -> Self {
+        Self {
+            state_transition_evaluator: Box::new(f),
+        }
+    }
+}
+
+/// Enable entities marked with [`EnableWhen<S>`] when the state transition message matches their
+/// predicate.
+pub fn enable_entities_when_state<S: States>(
+    mut commands: Commands,
+    mut transitions: MessageReader<StateTransitionEvent<S>>,
+    query: Query<(Entity, &EnableWhen<S>), Allow<Disabled>>,
+) {
+    // We use the latest event, because state machine internals generate at most 1
+    // transition event (per type) each frame. No event means no change happened
+    // and we skip iterating all entities.
+    let Some(transition) = transitions.read().last() else {
+        return;
+    };
+    if transition.entered == transition.exited && !transition.allow_same_state_transitions {
+        return;
+    }
+    for (entity, when) in &query {
+        if (when.state_transition_evaluator)(transition) {
+            commands.entity(entity).try_remove::<Disabled>();
+        }
+    }
+}
+
+/// Entities marked with this component will be enabled
+/// upon exiting the given state.
+///
+/// If you need to disable this behavior, add the attribute `#[states(scoped_entities = false)]` when deriving [`States`].
+///
+/// ```
+/// use bevy_state::prelude::*;
+/// use bevy_ecs::{prelude::*, system::ScheduleSystem};
+///
+/// #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Default, States)]
+/// enum GameState {
+///     #[default]
+///     MainMenu,
+///     SettingsMenu,
+///     InGame,
+/// }
+///
+/// # #[derive(Component)]
+/// # struct Player;
+///
+/// fn spawn_player(mut commands: Commands) {
+///     commands.spawn((
+///         EnableOnExit(GameState::InGame),
+///         Player
+///     ));
+/// }
+///
+/// # struct AppMock;
+/// # impl AppMock {
+/// #     fn init_state<S>(&mut self) {}
+/// #     fn add_systems<S, M>(&mut self, schedule: S, systems: impl IntoScheduleConfigs<ScheduleSystem, M>) {}
+/// # }
+/// # struct Update;
+/// # let mut app = AppMock;
+///
+/// app.init_state::<GameState>();
+/// app.add_systems(OnEnter(GameState::InGame), spawn_player);
+/// ```
+///
+/// For more advanced usecases see [`EnableWhen`]
+#[derive(Component, Clone)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Component, Clone))]
+pub struct EnableOnExit<S: States>(pub S);
+
+impl<S> Default for EnableOnExit<S>
+where
+    S: States + Default,
+{
+    fn default() -> Self {
+        Self(S::default())
+    }
+}
+
+/// Disables entities marked with [`DisableOnExit<S>`] when their state no
+/// longer matches the world state.
+pub fn enable_entities_on_exit_state<S: States>(
+    mut commands: Commands,
+    mut transitions: MessageReader<StateTransitionEvent<S>>,
+    query: Query<(Entity, &EnableOnExit<S>), Allow<Disabled>>,
+) {
+    // We use the latest event, because state machine internals generate at most 1
+    // transition event (per type) each frame. No event means no change happened
+    // and we skip iterating all entities.
+    let Some(transition) = transitions.read().last() else {
+        return;
+    };
+    if transition.entered == transition.exited && !transition.allow_same_state_transitions {
+        return;
+    }
+    let Some(exited) = &transition.exited else {
+        return;
+    };
+    for (entity, exit) in &query {
+        if exit.0 == *exited {
+            commands.entity(entity).try_remove::<Disabled>();
+        }
+    }
+}
+
+/// Entities marked with this component will be enabled
+/// upon entering the given state.
+///
+/// If you need to disable this behavior, add the attribute `#[states(scoped_entities = false)]` when deriving [`States`].
+///
+/// ```
+/// use bevy_state::prelude::*;
+/// use bevy_ecs::{prelude::*, system::ScheduleSystem};
+///
+/// #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Default, States)]
+/// enum GameState {
+///     #[default]
+///     MainMenu,
+///     SettingsMenu,
+///     InGame,
+/// }
+///
+/// # #[derive(Component)]
+/// # struct Player;
+///
+/// fn spawn_player(mut commands: Commands) {
+///     commands.spawn((
+///         EnableOnEnter(GameState::MainMenu),
+///         Player
+///     ));
+/// }
+///
+/// # struct AppMock;
+/// # impl AppMock {
+/// #     fn init_state<S>(&mut self) {}
+/// #     fn add_systems<S, M>(&mut self, schedule: S, systems: impl IntoScheduleConfigs<ScheduleSystem, M>) {}
+/// # }
+/// # struct Update;
+/// # let mut app = AppMock;
+///
+/// app.init_state::<GameState>();
+/// app.add_systems(OnEnter(GameState::InGame), spawn_player);
+/// ```
+///
+/// For more advanced usecases see [`EnableWhen`]
+#[derive(Component, Clone)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Component))]
+pub struct EnableOnEnter<S: States>(pub S);
+
+impl<S: States + Default> Default for EnableOnEnter<S> {
+    fn default() -> Self {
+        Self(S::default())
+    }
+}
+
+/// Enables entities marked with [`EnableOnEnter<S>`] when their state
+/// matches the world state.
+pub fn enable_entities_on_enter_state<S: States>(
+    mut commands: Commands,
+    mut transitions: MessageReader<StateTransitionEvent<S>>,
+    query: Query<(Entity, &EnableOnEnter<S>), Allow<Disabled>>,
+) {
+    // We use the latest event, because state machine internals generate at most 1
+    // transition event (per type) each frame. No event means no change happened
+    // and we skip iterating all entities.
+    let Some(transition) = transitions.read().last() else {
+        return;
+    };
+    if transition.entered == transition.exited && !transition.allow_same_state_transitions {
+        return;
+    }
+    let Some(entered) = &transition.entered else {
+        return;
+    };
+    for (entity, enter) in &query {
+        if enter.0 == *entered {
+            commands.entity(entity).try_remove::<Disabled>();
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/bevy_state/src/state_scoped.rs
+++ b/crates/bevy_state/src/state_scoped.rs
@@ -7,7 +7,7 @@ use bevy_ecs::{
     entity::Entity,
     entity_disabling::Disabled,
     message::MessageReader,
-    query::Allow,
+    query::{Allow, With},
     system::{Commands, Query},
 };
 #[cfg(feature = "bevy_reflect")]
@@ -528,7 +528,7 @@ pub fn disable_entities_on_enter_state<S: States>(
 ///     commands.spawn((
 ///         EnableWhen::new(|transition| {
 ///             matches!(
-///                 transition.entered,
+///                 transition.exited,
 ///                 Some(GameState::MainMenu) | Some(GameState::GameOver)
 ///             )
 ///         }),
@@ -571,7 +571,7 @@ impl<S: States> EnableWhen<S> {
 pub fn enable_entities_when_state<S: States>(
     mut commands: Commands,
     mut transitions: MessageReader<StateTransitionEvent<S>>,
-    query: Query<(Entity, &EnableWhen<S>), Allow<Disabled>>,
+    query: Query<(Entity, &EnableWhen<S>), With<Disabled>>,
 ) {
     // We use the latest event, because state machine internals generate at most 1
     // transition event (per type) each frame. No event means no change happened
@@ -611,7 +611,7 @@ pub fn enable_entities_when_state<S: States>(
 ///
 /// fn spawn_player(mut commands: Commands) {
 ///     commands.spawn((
-///         EnableOnExit(GameState::InGame),
+///         EnableOnExit(GameState::MainMenu),
 ///         Player
 ///     ));
 /// }
@@ -642,12 +642,12 @@ where
     }
 }
 
-/// Disables entities marked with [`DisableOnExit<S>`] when their state no
+/// Enables entities marked with [`EnableOnExit<S>`] when their state no
 /// longer matches the world state.
 pub fn enable_entities_on_exit_state<S: States>(
     mut commands: Commands,
     mut transitions: MessageReader<StateTransitionEvent<S>>,
-    query: Query<(Entity, &EnableOnExit<S>), Allow<Disabled>>,
+    query: Query<(Entity, &EnableOnExit<S>), With<Disabled>>,
 ) {
     // We use the latest event, because state machine internals generate at most 1
     // transition event (per type) each frame. No event means no change happened
@@ -690,7 +690,7 @@ pub fn enable_entities_on_exit_state<S: States>(
 ///
 /// fn spawn_player(mut commands: Commands) {
 ///     commands.spawn((
-///         EnableOnEnter(GameState::MainMenu),
+///         EnableOnEnter(GameState::InGame),
 ///         Player
 ///     ));
 /// }
@@ -723,7 +723,7 @@ impl<S: States + Default> Default for EnableOnEnter<S> {
 pub fn enable_entities_on_enter_state<S: States>(
     mut commands: Commands,
     mut transitions: MessageReader<StateTransitionEvent<S>>,
-    query: Query<(Entity, &EnableOnEnter<S>), Allow<Disabled>>,
+    query: Query<(Entity, &EnableOnEnter<S>), With<Disabled>>,
 ) {
     // We use the latest event, because state machine internals generate at most 1
     // transition event (per type) each frame. No event means no change happened


### PR DESCRIPTION
# Objective

Fixes #19087

## Solution

Add 

- `DisableWhen`
- `DisableOnEnter`
- `DisableOnExit`
- `EnableWhen`
- `EnableOnEnter`
- `EnableOnExit`

## Testing

This is the exact same code copied over from `DespawnWhen`/`DespawnOnEnter`/`DespawnOnExit`, so it should work. If tests are needed lmk and I'll add them

## Showcase

```rust
#[derive(Component, Clone, Default)]
pub struct Player;

#[derive(States, Hash, PartialEq, Eq, Clone, Default, Debug)]
pub enum GameState {
    #[default]
    MainMenu,
    Loading,
    InGame
}

fn main() -> AppExit {
    App::new()
        .init_state::<GameState>()
        .add_systems(Startup, player.spawn())
        .run()
}

fn player() -> impl Scene {
    bsn! {
        Disabled
        Player
        EnableOnEnter(GameState::InGame)
        DisableOnExit(GameState::InGame)
    }
}
```