### PR TITLE
cache packages from ppa:kisak/turtle

### DIFF
--- a/.github/workflows/example-run.yml
+++ b/.github/workflows/example-run.yml
@@ -104,11 +104,24 @@ jobs:
           persist-credentials: false
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
+      - uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        continue-on-error: true
+        with:
+          path: |
+            ~/apt-cache/
+          key: ${{ runner.os }}-apt-kisak_turtle-
+          restore-keys: ${{ runner.os }}-apt-kisak_turtle-
       # At some point this may be merged into `install-linux-deps`, but for now it is its own step.
       - name: Install additional Linux dependencies for Vulkan
         run: |
-          sudo add-apt-repository ppa:kisak/turtle -y
-          sudo apt-get install --no-install-recommends libxkbcommon-x11-0 xvfb libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
+          sudo apt-get install --no-install-recommends libxkbcommon-x11-0 xvfb libxcb-xfixes0-dev
+
+          if [ -d ~/apt-cache ] && [ -n "$(ls -A ~/apt-cache 2>/dev/null)" ]; then
+            sudo cp --verbose --force --recursive ~/apt-cache/* /
+          else
+            sudo add-apt-repository ppa:kisak/turtle -y
+            sudo apt-get install --no-install-recommends libgl1-mesa-dri mesa-vulkan-drivers
+          fi
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
           toolchain: stable

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -158,3 +158,34 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-${{ matrix.toolchain }}-${{ matrix.target }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('Cargo.lock') }}-${{ steps.get-date.outputs.date }}
+
+  build-apt-cache:
+    name: Build apt kisak/turtle Cache
+    runs-on: ubuntu-24.04
+
+    steps:
+      # prepare the date - used to rebuild the cache daily to catch new versions
+      - name: Get Date
+        id: get-date
+        run: |
+          echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Install llvmpipe and lavapipe
+        run: |
+          sudo apt-get update -y -qq
+          sudo add-apt-repository ppa:kisak/turtle -y
+          DEBIAN_FRONTEND=noninteractive sudo apt-get install --no-install-recommends -yq \
+            libgl1-mesa-dri mesa-vulkan-drivers
+          rm -rf ~/apt-cache; mkdir ~/apt-cache
+          for package in libgbm1 libgl1-mesa-dri libglx-mesa0 mesa-libgallium mesa-vulkan-drivers; do
+              echo $package
+              dpkg -L $package | while IFS= read -r f; do if test -f "$f"; then echo "$f"; fi; done | xargs -d '\n' cp --parents --target-directory ~/apt-cache/
+          done
+
+      - name: Save cache
+        uses: actions/cache/save@v5
+        with:
+          path: |
+            ~/apt-cache/
+          key: ${{ runner.os }}-apt-kisak_turtle-${{ steps.get-date.outputs.date }}

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -184,7 +184,7 @@ jobs:
           done
 
       - name: Save cache
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: |
             ~/apt-cache/


### PR DESCRIPTION
# Objective

- ppa:kisak/turtle has been unstable lately
- Improve CI stability

## Solution

- Cache the packages in actions cache
- Use the cache if available, otherwise clean install

## Testing

- I did the same changes to the example runner