### PR TITLE
Filter out Tuple fields when generating props

### DIFF
--- a/crates/bevy_scene/macros/src/bsn/codegen.rs
+++ b/crates/bevy_scene/macros/src/bsn/codegen.rs
@@ -449,6 +449,10 @@ impl BsnType {
                 }
             }
             BsnFields::Tuple(fields) => {
+                // Tuple fields can't be props
+                if is_props {
+                    return Ok(());
+                }
                 for (i, field) in fields.iter().enumerate() {
                     if let Err(err) = self.process_field(
                         ctx,

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -1874,6 +1874,33 @@ mod tests {
     }
 
     #[test]
+    fn scene_component_name_reference() {
+        #[derive(SceneComponent, FromTemplate)]
+        struct Widget(pub Entity);
+
+        impl Widget {
+            fn scene() -> impl Scene {
+                bsn! {}
+            }
+        }
+
+        let scene = bsn! {
+          #Name
+          Children [
+              :Widget(#Name)
+          ]
+        };
+
+        let mut app = test_app();
+        let world = app.world_mut();
+        let entity = world.spawn_scene(scene).unwrap().id();
+        let root = world.entity(entity);
+        let children = root.get::<Children>().unwrap();
+        let child_widget = world.entity(children[0]).get::<Widget>().unwrap();
+        assert_eq!(child_widget.0, entity);
+    }
+
+    #[test]
     fn drop_is_called_for_uninserted_components() {
         #[derive(Component, FromTemplate)]
         struct DropTracker(Option<Arc<Mutex<usize>>>);


### PR DESCRIPTION
# Objective

Setting fields on tuple Scene Components breaks down because their fields are improperly considered "props".

## Solution

Properly filter out tuple fields.

## Testing

- Added a test!