### PR TITLE
Expose private fields in ActiveAnimation

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -630,6 +630,16 @@ impl ActiveAnimation {
         self.elapsed
     }
 
+    /// Returns the last seek time of the animation.
+    pub fn last_seek_time(&self) -> Option<f32> {
+        self.last_seek_time
+    }
+
+    /// Returns true if the animation was completed at least once this tick.
+    pub fn just_completed(&self) -> bool {
+        self.just_completed
+    }
+
     /// Returns the seek time of the animation.
     ///
     /// This is nonnegative and no more than the clip duration.


### PR DESCRIPTION
# Objective

Expose `last_seek_time` and `just_completed` in `ActiveAnimation`. This allows detecting loops in animations and compute deltas. This PR implements the second point proposed in #23355.

## Solution

Add `last_seek_time` and `just_completed` methods in `ActiveAnimation`.

## Testing

Regular CI