### PR TITLE
`ImageNode` measure func fixes and allow drawing inside border and padding

### DIFF
--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -262,9 +262,9 @@ impl ComputedNode {
         let mut clip_rect = Rect::from_center_size(Vec2::ZERO, self.size);
 
         let clip_inset = match overflow_clip_margin.visual_box {
-            OverflowClipBox::BorderBox => BorderRect::ZERO,
-            OverflowClipBox::ContentBox => self.content_inset(),
-            OverflowClipBox::PaddingBox => self.border(),
+            VisualBox::BorderBox => BorderRect::ZERO,
+            VisualBox::ContentBox => self.content_inset(),
+            VisualBox::PaddingBox => self.border(),
         };
 
         clip_rect =
@@ -1387,7 +1387,7 @@ impl Default for OverflowAxis {
 )]
 pub struct OverflowClipMargin {
     /// Visible unclipped area
-    pub visual_box: OverflowClipBox,
+    pub visual_box: VisualBox,
     /// Width of the margin on each edge of the visual box in logical pixels.
     /// The width of the margin will be zero if a negative value is set.
     pub margin: f32,
@@ -1395,14 +1395,14 @@ pub struct OverflowClipMargin {
 
 impl OverflowClipMargin {
     pub const DEFAULT: Self = Self {
-        visual_box: OverflowClipBox::PaddingBox,
+        visual_box: VisualBox::PaddingBox,
         margin: 0.,
     };
 
     /// Clip any content that overflows outside the content box
     pub const fn content_box() -> Self {
         Self {
-            visual_box: OverflowClipBox::ContentBox,
+            visual_box: VisualBox::ContentBox,
             ..Self::DEFAULT
         }
     }
@@ -1410,7 +1410,7 @@ impl OverflowClipMargin {
     /// Clip any content that overflows outside the padding box
     pub const fn padding_box() -> Self {
         Self {
-            visual_box: OverflowClipBox::PaddingBox,
+            visual_box: VisualBox::PaddingBox,
             ..Self::DEFAULT
         }
     }
@@ -1418,7 +1418,7 @@ impl OverflowClipMargin {
     /// Clip any content that overflows outside the border box
     pub const fn border_box() -> Self {
         Self {
-            visual_box: OverflowClipBox::BorderBox,
+            visual_box: VisualBox::BorderBox,
             ..Self::DEFAULT
         }
     }
@@ -1431,7 +1431,7 @@ impl OverflowClipMargin {
     }
 }
 
-/// Used to determine the bounds of the visible area when a UI node is clipped.
+/// Used to determine which region of a UI node is used for visual bounds.
 #[derive(Default, Copy, Clone, PartialEq, Eq, Debug, Reflect)]
 #[reflect(Default, PartialEq, Clone)]
 #[cfg_attr(
@@ -1439,13 +1439,13 @@ impl OverflowClipMargin {
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-pub enum OverflowClipBox {
-    /// Clip any content that overflows outside the content box
+pub enum VisualBox {
+    /// Use the content box.
     ContentBox,
-    /// Clip any content that overflows outside the padding box
+    /// Use the padding box.
     #[default]
     PaddingBox,
-    /// Clip any content that overflows outside the border box
+    /// Use the border box.
     BorderBox,
 }
 
@@ -3060,8 +3060,8 @@ mod tests {
     use crate::ComputedNode;
     use crate::GridPlacement;
     use crate::Overflow;
-    use crate::OverflowClipBox;
     use crate::OverflowClipMargin;
+    use crate::VisualBox;
     use bevy_math::{Rect, Vec2};
     use bevy_sprite::BorderRect;
 
@@ -3256,7 +3256,7 @@ mod tests {
             computed_node.resolve_clip_rect(
                 Overflow::clip(),
                 OverflowClipMargin {
-                    visual_box: OverflowClipBox::BorderBox,
+                    visual_box: VisualBox::BorderBox,
                     margin: m,
                 },
             ),
@@ -3267,7 +3267,7 @@ mod tests {
             computed_node.resolve_clip_rect(
                 Overflow::clip(),
                 OverflowClipMargin {
-                    visual_box: OverflowClipBox::PaddingBox,
+                    visual_box: VisualBox::PaddingBox,
                     margin: m,
                 },
             ),
@@ -3278,7 +3278,7 @@ mod tests {
             computed_node.resolve_clip_rect(
                 Overflow::clip(),
                 OverflowClipMargin {
-                    visual_box: OverflowClipBox::ContentBox,
+                    visual_box: VisualBox::ContentBox,
                     margin: m,
                 },
             ),
@@ -3300,7 +3300,7 @@ mod tests {
         let r = computed_node.resolve_clip_rect(
             Overflow::clip(),
             OverflowClipMargin {
-                visual_box: OverflowClipBox::BorderBox,
+                visual_box: VisualBox::BorderBox,
                 margin: m,
             },
         );

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -1,4 +1,6 @@
-use crate::{ComputedUiRenderTargetInfo, ContentSize, Measure, MeasureArgs, Node, NodeMeasure};
+use crate::{
+    ComputedUiRenderTargetInfo, ContentSize, Measure, MeasureArgs, Node, NodeMeasure, VisualBox,
+};
 use bevy_asset::{AsAssetId, AssetId, Assets, Handle};
 use bevy_color::Color;
 use bevy_ecs::prelude::*;
@@ -37,6 +39,8 @@ pub struct ImageNode {
     pub rect: Option<Rect>,
     /// Controls how the image is altered to fit within the layout and how the layout algorithm determines the space to allocate for the image.
     pub image_mode: NodeImageMode,
+    /// Which region of the UI node the image should be drawn within.
+    pub visual_box: VisualBox,
 }
 
 impl Default for ImageNode {
@@ -59,6 +63,7 @@ impl Default for ImageNode {
             flip_y: false,
             rect: None,
             image_mode: NodeImageMode::Auto,
+            visual_box: VisualBox::default(),
         }
     }
 }

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -1,5 +1,6 @@
 use crate::{
-    ComputedUiRenderTargetInfo, ContentSize, Measure, MeasureArgs, Node, NodeMeasure, VisualBox,
+    ComputedUiRenderTargetInfo, ContentSize, Measure, MeasureArgs, Node, NodeMeasure, ResolvedAxis,
+    VisualBox,
 };
 use bevy_asset::{AsAssetId, AssetId, Assets, Handle};
 use bevy_color::Color;
@@ -8,7 +9,7 @@ use bevy_image::{prelude::*, TRANSPARENT_IMAGE_HANDLE};
 use bevy_math::{Rect, UVec2, Vec2};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_sprite::TextureSlicer;
-use taffy::MaybeMath;
+use taffy::{MaybeMath, ResolveOrZero};
 
 /// A UI Node that renders an image.
 #[derive(Component, Clone, Debug, Reflect, FromTemplate)]
@@ -63,7 +64,7 @@ impl Default for ImageNode {
             flip_y: false,
             rect: None,
             image_mode: NodeImageMode::Auto,
-            visual_box: VisualBox::default(),
+            visual_box: VisualBox::ContentBox,
         }
     }
 }
@@ -90,6 +91,7 @@ impl ImageNode {
             texture_atlas: None,
             rect: None,
             image_mode: NodeImageMode::Auto,
+            visual_box: VisualBox::ContentBox,
         }
     }
 
@@ -209,12 +211,79 @@ impl ImageNodeSize {
 pub struct ImageMeasure {
     /// The size of the image's texture
     pub size: Vec2,
+    /// The region of the UI node containing the image
+    pub visual_box: VisualBox,
 }
 
 impl Measure for ImageMeasure {
     fn measure(&mut self, measure_args: MeasureArgs) -> Vec2 {
-        let width = measure_args.resolve_width();
-        let height = measure_args.resolve_height();
+        let mut width = measure_args.resolve_width();
+        let mut height = measure_args.resolve_height();
+
+        let calc = |_, _| 0.;
+        let padding = measure_args.style.padding.resolve_or_zero(
+            taffy::Size {
+                width: width.effective,
+                height: height.effective,
+            },
+            calc,
+        );
+        let border = measure_args.style.border.resolve_or_zero(
+            taffy::Size {
+                width: width.effective,
+                height: height.effective,
+            },
+            calc,
+        );
+        let content_inset = Vec2::new(
+            padding.left + padding.right + border.left + border.right,
+            padding.top + padding.bottom + border.top + border.bottom,
+        );
+
+        if measure_args.style.box_sizing == taffy::style::BoxSizing::BorderBox {
+            if measure_args.known_width.is_none() {
+                width.min = width.min.map(|min| (min - content_inset.x).max(0.));
+                width.preferred = width
+                    .preferred
+                    .map(|preferred| (preferred - content_inset.x).max(0.));
+                width.max = width.max.map(|max| (max - content_inset.x).max(0.));
+                width.effective = width
+                    .effective
+                    .map(|effective| (effective - content_inset.x).max(0.));
+            }
+
+            if measure_args.known_height.is_none() {
+                height.min = height.min.map(|min| (min - content_inset.y).max(0.));
+                height.preferred = height
+                    .preferred
+                    .map(|preferred| (preferred - content_inset.y).max(0.));
+                height.max = height.max.map(|max| (max - content_inset.y).max(0.));
+                height.effective = height
+                    .effective
+                    .map(|effective| (effective - content_inset.y).max(0.));
+            }
+        }
+
+        let inset = match self.visual_box {
+            VisualBox::ContentBox => Vec2::ZERO,
+            VisualBox::PaddingBox => {
+                Vec2::new(padding.left + padding.right, padding.top + padding.bottom)
+            }
+            VisualBox::BorderBox => Vec2::new(content_inset.x, content_inset.y),
+        };
+
+        let width = ResolvedAxis {
+            min: width.min.map(|min| min + inset.x),
+            preferred: width.preferred.map(|preferred| preferred + inset.x),
+            max: width.max.map(|max| max + inset.x),
+            effective: width.effective.map(|effective| effective + inset.x),
+        };
+        let height = ResolvedAxis {
+            min: height.min.map(|min| min + inset.y),
+            preferred: height.preferred.map(|preferred| preferred + inset.y),
+            max: height.max.map(|max| max + inset.y),
+            effective: height.effective.map(|effective| effective + inset.y),
+        };
 
         // Use aspect_ratio from style, fall back to inherent aspect ratio
         let aspect_ratio = measure_args
@@ -230,17 +299,17 @@ impl Measure for ImageMeasure {
         }
         .maybe_apply_aspect_ratio(Some(aspect_ratio));
 
-        // Use computed sizes or fall back to image's inherent size
-        Vec2 {
-            x: taffy_size
+        (Vec2::new(
+            taffy_size
                 .width
                 .unwrap_or(self.size.x)
                 .maybe_clamp(width.min, width.max),
-            y: taffy_size
+            taffy_size
                 .height
                 .unwrap_or(self.size.y)
                 .maybe_clamp(height.min, height.max),
-        }
+        ) - inset)
+            .max(Vec2::ZERO)
     }
 }
 
@@ -281,11 +350,16 @@ pub fn update_image_content_size_system(
                 })
         {
             // Update only if size or scale factor has changed to avoid needless layout calculations
-            if size != image_size.size || computed_target.is_changed() || content_size.is_added() {
+            if size != image_size.size
+                || computed_target.is_changed()
+                || content_size.is_added()
+                || image.is_changed()
+            {
                 image_size.size = size;
                 content_size.set(NodeMeasure::Image(ImageMeasure {
                     // multiply the image size by the scale factor to get the physical size
                     size: size.as_vec2() * computed_target.scale_factor(),
+                    visual_box: image.visual_box,
                 }));
             }
         }

--- a/crates/bevy_ui_render/src/lib.rs
+++ b/crates/bevy_ui_render/src/lib.rs
@@ -26,7 +26,9 @@ use bevy_reflect::Reflect;
 use bevy_render::camera::{extract_cameras, CameraMainPassTextureFormats};
 use bevy_shader::load_shader_library;
 use bevy_sprite_render::SpriteAssetEvents;
-use bevy_ui::widget::{ImageNode, TextScroll, TextShadow, ViewportNode};
+use bevy_ui::widget::{
+    ImageNode, ImageNodeSize, NodeImageMode, TextScroll, TextShadow, ViewportNode,
+};
 use bevy_ui::{
     BackgroundColor, BorderColor, CalculatedClip, ComputedNode, ComputedStackIndex,
     ComputedUiTargetCamera, Display, Node, OuterColor, Outline, ResolvedBorderRadius,
@@ -497,13 +499,23 @@ pub fn extract_uinode_images(
             Option<&CalculatedClip>,
             &ComputedUiTargetCamera,
             &ImageNode,
+            &ImageNodeSize,
         )>,
     >,
     camera_map: Extract<UiCameraMap>,
 ) {
     let mut camera_mapper = camera_map.get_mapper();
-    for (entity, uinode, stack_index, transform, inherited_visibility, clip, camera, image) in
-        &uinode_query
+    for (
+        entity,
+        uinode,
+        stack_index,
+        transform,
+        inherited_visibility,
+        clip,
+        camera,
+        image,
+        image_size,
+    ) in &uinode_query
     {
         let visual_box = match image.visual_box {
             VisualBox::ContentBox => uinode.content_box(),
@@ -524,6 +536,17 @@ pub fn extract_uinode_images(
             continue;
         };
 
+        let size = if matches!(image.image_mode, NodeImageMode::Auto) {
+            let source = image_size.size().as_vec2();
+            if source.cmple(Vec2::ZERO).any() {
+                visual_box.size()
+            } else {
+                source * (visual_box.size() / source).min_element()
+            }
+        } else {
+            visual_box.size()
+        };
+
         let atlas_rect = image
             .texture_atlas
             .as_ref()
@@ -533,7 +556,7 @@ pub fn extract_uinode_images(
         let mut rect = match (atlas_rect, image.rect) {
             (None, None) => Rect {
                 min: Vec2::ZERO,
-                max: visual_box.size(),
+                max: size,
             },
             (None, Some(image_rect)) => image_rect,
             (Some(atlas_rect), None) => atlas_rect,
@@ -545,7 +568,7 @@ pub fn extract_uinode_images(
         };
 
         let atlas_scaling = if atlas_rect.is_some() || image.rect.is_some() {
-            let atlas_scaling = visual_box.size() / rect.size();
+            let atlas_scaling = size / rect.size();
             rect.min *= atlas_scaling;
             rect.max *= atlas_scaling;
             Some(atlas_scaling)

--- a/crates/bevy_ui_render/src/lib.rs
+++ b/crates/bevy_ui_render/src/lib.rs
@@ -30,7 +30,7 @@ use bevy_ui::widget::{ImageNode, TextScroll, TextShadow, ViewportNode};
 use bevy_ui::{
     BackgroundColor, BorderColor, CalculatedClip, ComputedNode, ComputedStackIndex,
     ComputedUiTargetCamera, Display, Node, OuterColor, Outline, ResolvedBorderRadius,
-    UiGlobalTransform,
+    UiGlobalTransform, VisualBox,
 };
 
 use bevy_app::prelude::*;
@@ -505,13 +505,17 @@ pub fn extract_uinode_images(
     for (entity, uinode, stack_index, transform, inherited_visibility, clip, camera, image) in
         &uinode_query
     {
-        let content_box = uinode.content_box();
+        let visual_box = match image.visual_box {
+            VisualBox::ContentBox => uinode.content_box(),
+            VisualBox::PaddingBox => uinode.padding_box(),
+            VisualBox::BorderBox => uinode.border_box(),
+        };
         // Skip invisible images
         if !inherited_visibility.get()
             || image.color.is_fully_transparent()
             || image.image.id() == TRANSPARENT_IMAGE_HANDLE.id()
             || image.image_mode.uses_slices()
-            || content_box.size().cmple(Vec2::ZERO).any()
+            || visual_box.size().cmple(Vec2::ZERO).any()
         {
             continue;
         }
@@ -529,7 +533,7 @@ pub fn extract_uinode_images(
         let mut rect = match (atlas_rect, image.rect) {
             (None, None) => Rect {
                 min: Vec2::ZERO,
-                max: content_box.size(),
+                max: visual_box.size(),
             },
             (None, Some(image_rect)) => image_rect,
             (Some(atlas_rect), None) => atlas_rect,
@@ -541,7 +545,7 @@ pub fn extract_uinode_images(
         };
 
         let atlas_scaling = if atlas_rect.is_some() || image.rect.is_some() {
-            let atlas_scaling = content_box.size() / rect.size();
+            let atlas_scaling = visual_box.size() / rect.size();
             rect.min *= atlas_scaling;
             rect.max *= atlas_scaling;
             Some(atlas_scaling)
@@ -555,7 +559,7 @@ pub fn extract_uinode_images(
             clip: clip.map(|clip| clip.clip),
             image: image.image.id(),
             extracted_camera_entity,
-            transform: Affine2::from(*transform) * Affine2::from_translation(content_box.center()),
+            transform: Affine2::from(*transform) * Affine2::from_translation(visual_box.center()),
             item: ExtractedUiItem::Node {
                 color: image.color.into(),
                 rect,

--- a/crates/bevy_ui_render/src/ui_texture_slice_pipeline.rs
+++ b/crates/bevy_ui_render/src/ui_texture_slice_pipeline.rs
@@ -28,7 +28,7 @@ use bevy_shader::Shader;
 use bevy_sprite::{SliceScaleMode, SpriteImageMode, TextureSlicer};
 use bevy_sprite_render::SpriteAssetEvents;
 use bevy_ui::widget;
-use bevy_ui::ComputedStackIndex;
+use bevy_ui::{ComputedStackIndex, VisualBox};
 use bevy_utils::default;
 use binding_types::{sampler, texture_2d};
 use bytemuck::{Pod, Zeroable};
@@ -235,13 +235,17 @@ pub fn extract_ui_texture_slices(
     for (entity, uinode, stack_index, transform, inherited_visibility, clip, camera, image) in
         &slicers_query
     {
-        let content_box = uinode.content_box();
+        let visual_box = match image.visual_box {
+            VisualBox::ContentBox => uinode.content_box(),
+            VisualBox::PaddingBox => uinode.padding_box(),
+            VisualBox::BorderBox => uinode.border_box(),
+        };
 
         // Skip invisible images
         if !inherited_visibility.get()
             || image.color.is_fully_transparent()
             || image.image.id() == TRANSPARENT_IMAGE_HANDLE.id()
-            || content_box.size().cmple(Vec2::ZERO).any()
+            || visual_box.size().cmple(Vec2::ZERO).any()
         {
             continue;
         }
@@ -286,11 +290,11 @@ pub fn extract_ui_texture_slices(
         extracted_ui_slicers.slices.push(ExtractedUiTextureSlice {
             render_entity: commands.spawn(TemporaryRenderEntity).id(),
             stack_index: stack_index.0,
-            transform: Affine2::from(*transform) * Affine2::from_translation(content_box.center()),
+            transform: Affine2::from(*transform) * Affine2::from_translation(visual_box.center()),
             color: image.color.into(),
             rect: Rect {
                 min: Vec2::ZERO,
-                max: content_box.size(),
+                max: visual_box.size(),
             },
             clip: clip.map(|clip| clip.clip),
             image: image.image.id(),

--- a/crates/bevy_ui_render/src/ui_texture_slice_pipeline.rs
+++ b/crates/bevy_ui_render/src/ui_texture_slice_pipeline.rs
@@ -27,7 +27,7 @@ use bevy_render::{sync_world::MainEntity, GpuResourceAppExt, RenderStartup};
 use bevy_shader::Shader;
 use bevy_sprite::{SliceScaleMode, SpriteImageMode, TextureSlicer};
 use bevy_sprite_render::SpriteAssetEvents;
-use bevy_ui::widget;
+use bevy_ui::widget::NodeImageMode;
 use bevy_ui::{ComputedStackIndex, VisualBox};
 use bevy_utils::default;
 use binding_types::{sampler, texture_2d};
@@ -251,10 +251,8 @@ pub fn extract_ui_texture_slices(
         }
 
         let image_scale_mode = match image.image_mode.clone() {
-            widget::NodeImageMode::Sliced(texture_slicer) => {
-                SpriteImageMode::Sliced(texture_slicer)
-            }
-            widget::NodeImageMode::Tiled {
+            NodeImageMode::Sliced(texture_slicer) => SpriteImageMode::Sliced(texture_slicer),
+            NodeImageMode::Tiled {
                 tile_x,
                 tile_y,
                 stretch_value,

--- a/examples/testbed/ui.rs
+++ b/examples/testbed/ui.rs
@@ -147,14 +147,59 @@ fn switch_scene(
 }
 
 mod image {
+    use bevy::color::palettes::css::DARK_GREY;
     use bevy::prelude::*;
 
     pub fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         commands.spawn((Camera2d, DespawnOnExit(super::Scene::Image)));
-        commands.spawn((
-            ImageNode::new(asset_server.load("branding/bevy_logo_dark.png")),
-            DespawnOnExit(super::Scene::Image),
-        ));
+        commands
+            .spawn(Node {
+                width: percent(100.),
+                height: percent(100.),
+                flex_direction: FlexDirection::Column,
+                justify_content: JustifyContent::SpaceAround,
+                align_items: AlignItems::Stretch,
+                ..default()
+            })
+            .with_children(|parent| {
+                for [b, p] in [[0, 0], [10, 0], [0, 10], [10, 10]] {
+                    for image_path in ["branding/icon.png", "branding/bevy_logo_dark.png"] {
+                        parent
+                            .spawn(Node {
+                                justify_content: JustifyContent::SpaceAround,
+                                align_items: AlignItems::Center,
+                                ..default()
+                            })
+                            .with_children(|parent| {
+                                for visual_box in [
+                                    VisualBox::BorderBox,
+                                    VisualBox::PaddingBox,
+                                    VisualBox::ContentBox,
+                                ] {
+                                    parent.spawn((
+                                        ImageNode {
+                                            image: asset_server.load(image_path),
+                                            visual_box,
+                                            ..default()
+                                        },
+                                        Node {
+                                            border: px(b).all(),
+                                            padding: px(p).all(),
+                                            width: px(100.),
+                                            ..default()
+                                        },
+                                        DespawnOnExit(super::Scene::Image),
+                                        Outline {
+                                            color: DARK_GREY.into(),
+                                            width: px(2.),
+                                            ..default()
+                                        },
+                                    ));
+                                }
+                            });
+                    }
+                }
+            });
     }
 }
 

--- a/examples/testbed/ui.rs
+++ b/examples/testbed/ui.rs
@@ -997,48 +997,77 @@ mod slice {
                 Node {
                     width: percent(100),
                     height: percent(100),
-                    align_items: AlignItems::Center,
+                    flex_direction: FlexDirection::Column,
                     justify_content: JustifyContent::SpaceAround,
+                    align_content: AlignContent::Center,
                     ..default()
                 },
                 DespawnOnExit(super::Scene::Slice),
             ))
             .with_children(|parent| {
-                for [w, h] in [[150.0, 150.0], [300.0, 150.0], [150.0, 300.0]] {
-                    parent.spawn((
-                        Button,
-                        ImageNode {
-                            image: image.clone(),
-                            image_mode: NodeImageMode::Sliced(slicer.clone()),
+                for visual_box in [
+                    VisualBox::BorderBox,
+                    VisualBox::PaddingBox,
+                    VisualBox::ContentBox,
+                ] {
+                    parent
+                        .spawn(Node {
+                            justify_content: JustifyContent::SpaceAround,
                             ..default()
-                        },
-                        Node {
-                            width: px(w),
-                            height: px(h),
-                            ..default()
-                        },
-                    ));
-                }
+                        })
+                        .with_children(|parent| {
+                            for [w, h] in [[200.0, 200.0], [300.0, 200.0], [150., 200.0]] {
+                                parent.spawn((
+                                    Button,
+                                    ImageNode {
+                                        image: image.clone(),
+                                        image_mode: NodeImageMode::Sliced(slicer.clone()),
+                                        visual_box,
+                                        ..default()
+                                    },
+                                    Node {
+                                        width: px(w),
+                                        height: px(h),
+                                        border: px(20.).all(),
+                                        padding: px(20.).all(),
+                                        ..default()
+                                    },
+                                    Outline {
+                                        width: px(2.),
+                                        ..default()
+                                    },
+                                ));
+                            }
 
-                parent.spawn((
-                    ImageNode {
-                        image: asset_server
-                            .load("textures/fantasy_ui_borders/panel-border-010.png"),
-                        image_mode: NodeImageMode::Sliced(TextureSlicer {
-                            border: BorderRect::all(22.0),
-                            center_scale_mode: SliceScaleMode::Stretch,
-                            sides_scale_mode: SliceScaleMode::Stretch,
-                            max_corner_scale: 1.0,
-                        }),
-                        ..Default::default()
-                    },
-                    Node {
-                        width: px(100),
-                        height: px(100),
-                        ..default()
-                    },
-                    BackgroundColor(bevy::color::palettes::css::NAVY.into()),
-                ));
+                            parent.spawn((
+                                ImageNode {
+                                    image: asset_server
+                                        .load("textures/fantasy_ui_borders/panel-border-010.png"),
+                                    image_mode: NodeImageMode::Sliced(TextureSlicer {
+                                        border: BorderRect::all(22.0),
+                                        center_scale_mode: SliceScaleMode::Stretch,
+                                        sides_scale_mode: SliceScaleMode::Stretch,
+                                        max_corner_scale: 1.0,
+                                    }),
+                                    visual_box,
+                                    ..Default::default()
+                                },
+                                Node {
+                                    width: px(200),
+                                    height: px(200),
+                                    border: px(20.).all(),
+                                    padding: px(20.).all(),
+                                    ..default()
+                                },
+                                Outline {
+                                    color: bevy::color::palettes::css::DARK_CYAN.into(),
+                                    width: px(2.),
+                                    ..default()
+                                },
+                                BackgroundColor(bevy::color::palettes::css::NAVY.into()),
+                            ));
+                        });
+                }
             });
     }
 }


### PR DESCRIPTION
# Objective

Allowing drawing with `ImageNode` inside the border and padding boxes of a UI node.
Fix a lot of image measurement and aspect ratio issues.

Fixes #24150

## Solution

Renamed `OverflowClipMarginBox` to `VisualBox`. 
Added a `visual_box: VisualBox` field to `ImageNode`.
Use the size of the selected node region in image rendering.
Fixed the bugs with the `ImageNode` measure func.

## Testing

Added many more cases to `testbed_ui`'s `image` and `slice` scenes:

```
cargo run --example testbed_ui -- --scene image
cargo run --example testbed_ui -- --scene slice
```

## Showcase

<img width="902" height="530" alt="box" src="https://github.com/user-attachments/assets/74f873d4-f00e-47c3-ad3a-3640a39466e4" />
<img width="962" height="563" alt="borderbox" src="https://github.com/user-attachments/assets/3b27c8e1-3b27-4a82-b136-95fed19c28ce" />
<img width="766" height="541" alt="content" src="https://github.com/user-attachments/assets/a4543995-a835-45e1-8ffb-5d671fc7ec05" />
