### PR TITLE
free camera controller add local space Y controls

### DIFF
--- a/crates/bevy_camera_controller/src/free_camera.rs
+++ b/crates/bevy_camera_controller/src/free_camera.rs
@@ -200,7 +200,7 @@ Freecamera Controls:
     }
 }
 
-/// Config to choose camera's vertical movement behaviour.
+/// Config to choose camera's vertical movement behavior.
 #[derive(Debug, Clone, Copy)]
 pub enum VerticalVelocitySpace {
     /// up and down motion will move along the global Y axis regardless of camera orientation.

--- a/crates/bevy_camera_controller/src/free_camera.rs
+++ b/crates/bevy_camera_controller/src/free_camera.rs
@@ -203,10 +203,14 @@ Freecamera Controls:
 /// Whether the vertical inputs translate the camera in world or local space axes.
 #[derive(Debug, Default, Clone, Copy)]
 pub enum VerticalMovementAxis {
-    /// Vertical movement are aligned to the world.
+    /// Vertical movement is aligned to the world.
+    /// 
+    /// This is the default behavior in Bevy, Unreal and Blender.
     #[default]
     World,
-    /// Vertical movement follow the camera's rotation.
+    /// Vertical movement follows the camera's rotation.
+    ///
+    /// This is the default behavior in Unity and Godot.
     Local,
 }
 

--- a/crates/bevy_camera_controller/src/free_camera.rs
+++ b/crates/bevy_camera_controller/src/free_camera.rs
@@ -133,7 +133,7 @@ pub struct FreeCamera {
     /// Speed of camera rotation to snapped axis in radians/second
     pub rotation_speed: f32,
     /// The vertical velocity transformation space for up down controls.
-    pub vertical_velocity_space: VerticalVelocitySpace,
+    pub vertical_movement_axis: VerticalMovementAxis,
 }
 
 impl Default for FreeCamera {
@@ -159,7 +159,7 @@ impl Default for FreeCamera {
             scroll_factor: 0.04879016,
             friction: 40.0,
             rotation_speed: PI / 16.0 * 60.0,
-            vertical_velocity_space: VerticalVelocitySpace::Global,
+            vertical_movement_axis: VerticalMovementAxis::default(),
         }
     }
 }
@@ -201,9 +201,10 @@ Freecamera Controls:
 }
 
 /// Config to choose camera's vertical movement behavior.
-#[derive(Debug, Clone, Copy)]
-pub enum VerticalVelocitySpace {
+#[derive(Debug, Default, Clone, Copy)]
+pub enum VerticalMovementAxis {
     /// up and down motion will move along the global Y axis regardless of camera orientation.
+    #[default]
     Global,
     /// up and down motion will move along the camera orientation's local up and down axis.
     Local,
@@ -365,9 +366,9 @@ pub fn run_freecamera_controller(
     if state.velocity != Vec3::ZERO {
         let forward = *transform.forward();
         let right = *transform.right();
-        let up = match config.vertical_velocity_space {
-            VerticalVelocitySpace::Global => Vec3::Y,
-            VerticalVelocitySpace::Local => *transform.up(),
+        let up = match config.vertical_movement_axis {
+            VerticalMovementAxis::Global => Vec3::Y,
+            VerticalMovementAxis::Local => *transform.up(),
         };
         transform.translation += state.velocity.x * dt * right
             + state.velocity.y * dt * up

--- a/crates/bevy_camera_controller/src/free_camera.rs
+++ b/crates/bevy_camera_controller/src/free_camera.rs
@@ -132,7 +132,7 @@ pub struct FreeCamera {
     pub friction: f32,
     /// Speed of camera rotation to snapped axis in radians/second
     pub rotation_speed: f32,
-    /// The vertical velocity transformation space for up down controls.
+    /// Whether the vertical inputs translate the camera in world or local space axes.
     pub vertical_movement_axis: VerticalMovementAxis,
 }
 
@@ -200,13 +200,13 @@ Freecamera Controls:
     }
 }
 
-/// Config to choose camera's vertical movement behavior.
+/// Whether the vertical inputs translate the camera in world or local space axes.
 #[derive(Debug, Default, Clone, Copy)]
 pub enum VerticalMovementAxis {
-    /// up and down motion will move along the global Y axis regardless of camera orientation.
+    /// Vertical movement are aligned to the world.
     #[default]
-    Global,
-    /// up and down motion will move along the camera orientation's local up and down axis.
+    World,
+    /// Vertical movement follow the camera's rotation.
     Local,
 }
 
@@ -367,7 +367,7 @@ pub fn run_freecamera_controller(
         let forward = *transform.forward();
         let right = *transform.right();
         let up = match config.vertical_movement_axis {
-            VerticalMovementAxis::Global => Vec3::Y,
+            VerticalMovementAxis::World => Vec3::Y,
             VerticalMovementAxis::Local => *transform.up(),
         };
         transform.translation += state.velocity.x * dt * right

--- a/crates/bevy_camera_controller/src/free_camera.rs
+++ b/crates/bevy_camera_controller/src/free_camera.rs
@@ -132,6 +132,8 @@ pub struct FreeCamera {
     pub friction: f32,
     /// Speed of camera rotation to snapped axis in radians/second
     pub rotation_speed: f32,
+    /// The vertical velocity transformation space for up down controls.
+    pub vertical_velocity_space: VerticalVelocitySpace,
 }
 
 impl Default for FreeCamera {
@@ -157,6 +159,7 @@ impl Default for FreeCamera {
             scroll_factor: 0.04879016,
             friction: 40.0,
             rotation_speed: PI / 16.0 * 60.0,
+            vertical_velocity_space: VerticalVelocitySpace::Global,
         }
     }
 }
@@ -195,6 +198,15 @@ Freecamera Controls:
             self.axis_front,
         )
     }
+}
+
+/// Config to choose camera's vertical movement behaviour.
+#[derive(Debug, Clone, Copy)]
+pub enum VerticalVelocitySpace {
+    /// up and down motion will move along the global Y axis regardless of camera orientation.
+    Global,
+    /// up and down motion will move along the camera orientation's local up and down axis.
+    Local,
 }
 
 /// Tracks the runtime state of a [`FreeCamera`] controller.
@@ -353,8 +365,12 @@ pub fn run_freecamera_controller(
     if state.velocity != Vec3::ZERO {
         let forward = *transform.forward();
         let right = *transform.right();
+        let up = match config.vertical_velocity_space {
+            VerticalVelocitySpace::Global => Vec3::Y,
+            VerticalVelocitySpace::Local => *transform.up(),
+        };
         transform.translation += state.velocity.x * dt * right
-            + state.velocity.y * dt * Vec3::Y
+            + state.velocity.y * dt * up
             + state.velocity.z * dt * forward;
     }
 

--- a/crates/bevy_camera_controller/src/free_camera.rs
+++ b/crates/bevy_camera_controller/src/free_camera.rs
@@ -204,7 +204,7 @@ Freecamera Controls:
 #[derive(Debug, Default, Clone, Copy)]
 pub enum VerticalMovementAxis {
     /// Vertical movement is aligned to the world.
-    /// 
+    ///
     /// This is the default behavior in Bevy, Unreal and Blender.
     #[default]
     World,

--- a/examples/camera/free_camera_controller.rs
+++ b/examples/camera/free_camera_controller.rs
@@ -34,16 +34,16 @@
 //! This example also provides a few extra keybinds to change the camera sensitivity, friction (how fast the camera
 //! stops), scroll factor (how much scrolling changes speed) and enabling/disabling the controller.
 //!
-//! | Key Binding | Action                    |
-//! |:------------|:--------------------------|
-//! | Z           | Decrease sensitivity      |
-//! | X           | Increase sensitivity      |
-//! | C           | Decrease friction         |
-//! | V           | Increase friction         |
-//! | F           | Decrease scroll factor    |
-//! | G           | Increase scroll factor    |
-//! | B           | Enable/Disable            |
-//! | T           | Toggle Q/E Global / Local |
+//! | Key Binding | Action                        |
+//! |:------------|:------------------------------|
+//! | Z           | Decrease sensitivity          |
+//! | X           | Increase sensitivity          |
+//! | C           | Decrease friction             |
+//! | V           | Increase friction             |
+//! | F           | Decrease scroll factor        |
+//! | G           | Increase scroll factor        |
+//! | B           | Enable/Disable                |
+//! | T           | World/Local vertical movement |
 
 use std::f32::consts::{FRAC_PI_4, PI};
 
@@ -127,7 +127,7 @@ fn spawn_text(mut commands: Commands, free_camera_query: Query<&FreeCamera>) {
             "C/V: decrease/increase friction\n",
             "F/G: decrease/increase scroll factor\n",
             "B: enable/disable controller\n",
-            "T: toggle Q/E global vs local space"
+            "T: world/local vertical movement"
         ]),],
     ));
 
@@ -172,8 +172,8 @@ fn update_camera_settings(
     }
     if input.just_pressed(KeyCode::KeyT) {
         free_camera.vertical_movement_axis = match free_camera.vertical_movement_axis {
-            VerticalMovementAxis::Global => VerticalMovementAxis::Local,
-            VerticalMovementAxis::Local => VerticalMovementAxis::Global,
+            VerticalMovementAxis::World => VerticalMovementAxis::Local,
+            VerticalMovementAxis::Local => VerticalMovementAxis::World,
         };
     }
 }

--- a/examples/camera/free_camera_controller.rs
+++ b/examples/camera/free_camera_controller.rs
@@ -49,7 +49,7 @@ use std::f32::consts::{FRAC_PI_4, PI};
 
 use bevy::{
     camera_controller::free_camera::{
-        FreeCamera, FreeCameraPlugin, FreeCameraState, VerticalVelocitySpace,
+        FreeCamera, FreeCameraPlugin, FreeCameraState, VerticalMovementAxis,
     },
     color::palettes::tailwind,
     prelude::*,
@@ -171,9 +171,9 @@ fn update_camera_settings(
         free_camera_state.enabled = !free_camera_state.enabled;
     }
     if input.just_pressed(KeyCode::KeyT) {
-        free_camera.vertical_velocity_space = match free_camera.vertical_velocity_space {
-            VerticalVelocitySpace::Global => VerticalVelocitySpace::Local,
-            VerticalVelocitySpace::Local => VerticalVelocitySpace::Global,
+        free_camera.vertical_movement_axis = match free_camera.vertical_movement_axis {
+            VerticalMovementAxis::Global => VerticalMovementAxis::Local,
+            VerticalMovementAxis::Local => VerticalMovementAxis::Global,
         };
     }
 }

--- a/examples/camera/free_camera_controller.rs
+++ b/examples/camera/free_camera_controller.rs
@@ -34,20 +34,23 @@
 //! This example also provides a few extra keybinds to change the camera sensitivity, friction (how fast the camera
 //! stops), scroll factor (how much scrolling changes speed) and enabling/disabling the controller.
 //!
-//! | Key Binding | Action                 |
-//! |:------------|:-----------------------|
-//! | Z           | Decrease sensitivity   |
-//! | X           | Increase sensitivity    |
-//! | C           | Decrease friction      |
-//! | V           | Increase friction      |
-//! | F           | Decrease scroll factor |
-//! | G           | Increase scroll factor |
-//! | B           | Enable/Disable         |
+//! | Key Binding | Action                    |
+//! |:------------|:--------------------------|
+//! | Z           | Decrease sensitivity      |
+//! | X           | Increase sensitivity      |
+//! | C           | Decrease friction         |
+//! | V           | Increase friction         |
+//! | F           | Decrease scroll factor    |
+//! | G           | Increase scroll factor    |
+//! | B           | Enable/Disable            |
+//! | T           | Toggle Q/E Global / Local |
 
 use std::f32::consts::{FRAC_PI_4, PI};
 
 use bevy::{
-    camera_controller::free_camera::{FreeCamera, FreeCameraPlugin, FreeCameraState},
+    camera_controller::free_camera::{
+        FreeCamera, FreeCameraPlugin, FreeCameraState, VerticalVelocitySpace,
+    },
     color::palettes::tailwind,
     prelude::*,
 };
@@ -123,7 +126,8 @@ fn spawn_text(mut commands: Commands, free_camera_query: Query<&FreeCamera>) {
             "Z/X: decrease/increase sensitivity\n",
             "C/V: decrease/increase friction\n",
             "F/G: decrease/increase scroll factor\n",
-            "B: enable/disable controller",
+            "B: enable/disable controller\n",
+            "T: toggle Q/E global vs local space"
         ]),],
     ));
 
@@ -165,6 +169,12 @@ fn update_camera_settings(
     }
     if input.just_pressed(KeyCode::KeyB) {
         free_camera_state.enabled = !free_camera_state.enabled;
+    }
+    if input.just_pressed(KeyCode::KeyT) {
+        free_camera.vertical_velocity_space = match free_camera.vertical_velocity_space {
+            VerticalVelocitySpace::Global => VerticalVelocitySpace::Local,
+            VerticalVelocitySpace::Local => VerticalVelocitySpace::Global,
+        };
     }
 }
 


### PR DESCRIPTION
# Objective

- Fixes https://github.com/bevyengine/bevy/issues/24141

## Solution

- Added Two additional keys (R & F) for local space Y velocity. 
    - following the [Blender Walk/Fly Mode](https://docs.blender.org/manual/en/latest/editors/3dview/navigate/walk_fly.html) controls.
- Added `FreeCamera::invert_world_local_control()` for alternative keybinds where Q/E is local Space instead, and R/F is world Space.
    - Some user probably more familiar with Q/E as local space up.
- Updated Examples to resolve key conflict with scroll factor controls
    - from F/G to G/H 

Note: This is my first contribution. If there's anything I am missing please point it out :)

## Testing

- Did you test these changes? If so, how?
  - I tested with `free_camera_controller` example
- Are there any parts that need more testing?
  - Don't think so.
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
  - Don't think so. Straightforward change.
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?
  - tested on Windows 11. It's not platform specific so should be ok.