### PR TITLE
Resource hooks & immutable resources

### DIFF
--- a/_release-content/migration-guides/resources_as_components.md
+++ b/_release-content/migration-guides/resources_as_components.md
@@ -144,9 +144,16 @@ See the implementation of `WorldQuery` for `AssetChanged` for an example of how 
 
 ## Immutable Resources
 
-Since resources may now be immutable, all methods on `ResMut` that allow mutation as well as `ExtractResourcePlugin`
-now carry a `Mutability = Mutable` bound. If you're calling these in a generic context, you need to add this bound to
-your own type parameters:
+Since resources may now be immutable, the following now carry a `Mutability = Mutable` bound:
+- `World::resource_mut`, `World::get_resource_mut`
+- `UnsafeWorldCell::get_resource_mut`
+- `EntityWorldMut::resource_mut`, `EntityWorldMut::get_resource_mut`
+- `DeferredWorld::resource_mut`, `DeferredWorld::get_resource_mut`
+- `TemplateContext::resource_mut`
+- all methods on `ResMut` that allow mutation
+- as well as `ExtractResourcePlugin`
+
+If you're calling these in a generic context, you need to add this bound to your own type parameters:
 
 ```rust
 // 0.18
@@ -154,7 +161,8 @@ fn my_generic_system<R: Resource>(mut res: ResMut<R>) {
     let res = res.deref_mut();
     …
 }
-// 0.18
+
+// 0.19
 fn my_generic_system<R: Resource<Mutability = Mutable>>(mut res: ResMut<R>) {
     let res = res.deref_mut();
     …

--- a/_release-content/migration-guides/resources_as_components.md
+++ b/_release-content/migration-guides/resources_as_components.md
@@ -146,12 +146,12 @@ See the implementation of `WorldQuery` for `AssetChanged` for an example of how 
 
 Since resources may now be immutable, the following now carry a `Mutability = Mutable` bound:
 
+- `ResMut`
 - `World::resource_mut`, `World::get_resource_mut`
 - `UnsafeWorldCell::get_resource_mut`
 - `EntityWorldMut::resource_mut`, `EntityWorldMut::get_resource_mut`
 - `DeferredWorld::resource_mut`, `DeferredWorld::get_resource_mut`
 - `TemplateContext::resource_mut`
-- all methods on `ResMut` that allow mutation
 - as well as `ExtractResourcePlugin`
 
 If you're calling these in a generic context, you need to add this bound to your own type parameters:
@@ -159,13 +159,11 @@ If you're calling these in a generic context, you need to add this bound to your
 ```rust
 // 0.18
 fn my_generic_system<R: Resource>(mut res: ResMut<R>) {
-    let res = res.deref_mut();
     …
 }
 
 // 0.19
 fn my_generic_system<R: Resource<Mutability = Mutable>>(mut res: ResMut<R>) {
-    let res = res.deref_mut();
     …
 }
 ```

--- a/_release-content/migration-guides/resources_as_components.md
+++ b/_release-content/migration-guides/resources_as_components.md
@@ -145,6 +145,7 @@ See the implementation of `WorldQuery` for `AssetChanged` for an example of how 
 ## Immutable Resources
 
 Since resources may now be immutable, the following now carry a `Mutability = Mutable` bound:
+
 - `World::resource_mut`, `World::get_resource_mut`
 - `UnsafeWorldCell::get_resource_mut`
 - `EntityWorldMut::resource_mut`, `EntityWorldMut::get_resource_mut`

--- a/_release-content/migration-guides/resources_as_components.md
+++ b/_release-content/migration-guides/resources_as_components.md
@@ -142,6 +142,25 @@ Due to the split storage it used to be possible to both access an entity and a r
 This is no longer valid. In order to access multiple different entities for a `WorldQuery` implementation, use `WorldQuery::init_nested_access`.
 See the implementation of `WorldQuery` for `AssetChanged` for an example of how this can be done correctly.
 
+## Immutable Resources
+
+Since resources may now be immutable, all methods on `ResMut` that allow mutation as well as `ExtractResourcePlugin`
+now carry a `Mutability = Mutable` bound. If you're calling these in a generic context, you need to add this bound to
+your own type parameters:
+
+```rust
+// 0.18
+fn my_generic_system<R: Resource>(mut res: ResMut<R>) {
+    let res = res.deref_mut();
+    …
+}
+// 0.18
+fn my_generic_system<R: Resource<Mutability = Mutable>>(mut res: ResMut<R>) {
+    let res = res.deref_mut();
+    …
+}
+```
+
 ## Miscellaneous
 
 Since `MapEntities` is implemented by default for components, it's no longer necessary to add `derive(MapEntities)` to a resource.

--- a/_release-content/release-notes/resources_as_components.md
+++ b/_release-content/release-notes/resources_as_components.md
@@ -1,19 +1,19 @@
 ---
 title: Resources as Components
 authors: ["@Trashtalk", "@cart"]
-pull_requests: [20934, 22910, 22911, 22919, 22930]
+pull_requests: [20934, 22910, 22911, 22919, 22930, 24164]
 ---
 
 Resources are very similar to Components: they are both data that can be stored in the ECS and queried.
 The only real difference between them is that querying a resource will return either one or zero resources, whereas querying for a component can return any number of matching entities.
 
 Even so, resources and components have always been separate concepts within the ECS.
-This leads to some annoying restrictions.
-While components have [`ComponentHooks`](https://docs.rs/bevy/latest/bevy/ecs/component/struct.ComponentHooks.html), it's not possible to add lifecycle hooks to resources.
+This lead to some annoying restrictions.
+While components have [`ComponentHooks`](https://docs.rs/bevy/latest/bevy/ecs/component/struct.ComponentHooks.html), it wasn't possible to add lifecycle hooks to resources.
 The same is true for relations, observers, and a host of other concepts that already exist for components.
-Moreover, the engine internals contain a lot of duplication because of it.
+Moreover, the engine internals contained a lot of duplication because of it.
 
-This first implementation is limited, only enabling observers for resources.
+This first implementation is limited, but lets you define hooks, observers and storage type for resources.
 
 ```rust
 #[derive(Resource)]

--- a/_release-content/release-notes/resources_as_components.md
+++ b/_release-content/release-notes/resources_as_components.md
@@ -1,19 +1,19 @@
 ---
 title: Resources as Components
 authors: ["@Trashtalk", "@cart"]
-pull_requests: [20934, 22910, 22911, 22919, 22930, 24164]
+pull_requests: [20934, 22910, 22911, 22919, 22930]
 ---
 
 Resources are very similar to Components: they are both data that can be stored in the ECS and queried.
 The only real difference between them is that querying a resource will return either one or zero resources, whereas querying for a component can return any number of matching entities.
 
 Even so, resources and components have always been separate concepts within the ECS.
-This lead to some annoying restrictions.
-While components have [`ComponentHooks`](https://docs.rs/bevy/latest/bevy/ecs/component/struct.ComponentHooks.html), it wasn't possible to add lifecycle hooks to resources.
+This leads to some annoying restrictions.
+While components have [`ComponentHooks`](https://docs.rs/bevy/latest/bevy/ecs/component/struct.ComponentHooks.html), it's not possible to add lifecycle hooks to resources.
 The same is true for relations, observers, and a host of other concepts that already exist for components.
-Moreover, the engine internals contained a lot of duplication because of it.
+Moreover, the engine internals contain a lot of duplication because of it.
 
-This first implementation is limited, but lets you define hooks, observers and storage type for resources.
+This first implementation is limited, only enabling observers for resources.
 
 ```rust
 #[derive(Resource)]

--- a/crates/bevy_ecs/macro_logic/src/component.rs
+++ b/crates/bevy_ecs/macro_logic/src/component.rs
@@ -18,7 +18,7 @@ use crate::map_entities::{map_entities, MapEntitiesAttributeKind};
 /// Derived `Component` trait specification, which can be used to generate a component implementation.
 pub struct DeriveComponent {
     /// The storage type of the component.
-    pub storage: StorageTy,
+    pub storage: Option<StorageTy>,
     /// The parsed punctuated list of required components.
     pub requires: Option<Punctuated<Require, Comma>>,
     /// The `on_add` hook.
@@ -49,7 +49,7 @@ impl DeriveComponent {
     /// Parse [`DeriveComponent`] from the given `ast`.
     pub fn parse(ast: &DeriveInput) -> Result<DeriveComponent> {
         let mut attrs = DeriveComponent {
-            storage: StorageTy::Table,
+            storage: None,
             on_add: None,
             on_insert: None,
             on_discard: None,
@@ -69,7 +69,7 @@ impl DeriveComponent {
             if attr.path().is_ident(COMPONENT) {
                 attr.parse_nested_meta(|nested| {
                     if nested.path.is_ident(STORAGE) {
-                        attrs.storage = match nested.value()?.parse::<LitStr>()?.value() {
+                        attrs.storage = Some(match nested.value()?.parse::<LitStr>()?.value() {
                             s if s == TABLE => StorageTy::Table,
                             s if s == SPARSE_SET => StorageTy::SparseSet,
                             s => {
@@ -77,7 +77,7 @@ impl DeriveComponent {
                                 "Invalid storage type `{s}`, expected '{TABLE}' or '{SPARSE_SET}'.",
                             )));
                             }
-                        };
+                        });
                         Ok(())
                     } else if nested.path.is_ident(ON_ADD) {
                         attrs.on_add = Some(HookAttributeKind::parse(nested.input, || {
@@ -156,7 +156,12 @@ impl DeriveComponent {
     /// Generates a new `Component` trait implementation from this specification.
     ///
     /// Note that this will add Send + Sync + 'static to the where clause
-    pub fn impl_component(self, ast: &mut DeriveInput, bevy_ecs: &Path) -> Result<TokenStream> {
+    pub fn impl_component(
+        self,
+        ast: &mut DeriveInput,
+        bevy_ecs: &Path,
+        default_storage: StorageTy,
+    ) -> Result<TokenStream> {
         // We want to raise a compile time error when the generic lifetimes
         // are not bound to 'static lifetime
         let non_static_lifetime_error = ast
@@ -198,7 +203,7 @@ impl DeriveComponent {
             }
         });
 
-        let storage = storage_path(bevy_ecs, self.storage);
+        let storage = storage_path(bevy_ecs, self.storage.unwrap_or(default_storage));
 
         let on_add_path = Vec::from_iter(self.on_add.map(|path| path.to_token_stream(bevy_ecs)));
         let on_remove_path =

--- a/crates/bevy_ecs/macro_logic/src/component.rs
+++ b/crates/bevy_ecs/macro_logic/src/component.rs
@@ -15,6 +15,14 @@ use syn::{
 
 use crate::map_entities::{map_entities, MapEntitiesAttributeKind};
 
+/// Whether the derive macro may contain a `component(storage = "…")` attribute.
+pub enum StorageAttribute {
+    /// User can overwrite the storage type
+    Allowed,
+    /// User cannot overwrite the storage type
+    Disallowed,
+}
+
 /// Derived `Component` trait specification, which can be used to generate a component implementation.
 pub struct DeriveComponent {
     /// The storage type of the component.
@@ -47,7 +55,7 @@ pub struct DeriveComponent {
 
 impl DeriveComponent {
     /// Parse [`DeriveComponent`] from the given `ast`.
-    pub fn parse(ast: &DeriveInput) -> Result<DeriveComponent> {
+    pub fn parse(ast: &DeriveInput, storage_attr: StorageAttribute) -> Result<DeriveComponent> {
         let mut attrs = DeriveComponent {
             storage: None,
             on_add: None,
@@ -68,7 +76,9 @@ impl DeriveComponent {
         for attr in ast.attrs.iter() {
             if attr.path().is_ident(COMPONENT) {
                 attr.parse_nested_meta(|nested| {
-                    if nested.path.is_ident(STORAGE) {
+                    if let StorageAttribute::Allowed = storage_attr
+                        && nested.path.is_ident(STORAGE)
+                    {
                         attrs.storage = Some(match nested.value()?.parse::<LitStr>()?.value() {
                             s if s == TABLE => StorageTy::Table,
                             s if s == SPARSE_SET => StorageTy::SparseSet,

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -563,6 +563,25 @@ pub fn derive_message(input: TokenStream) -> TokenStream {
 }
 
 /// Implement the `Resource` trait.
+/// 
+/// ## Immutability
+/// ```ignore
+/// #[derive(Resource)]
+/// #[component(immutable)]
+/// struct MyResource;
+/// ```
+///
+/// ## Hooks
+/// ```ignore
+/// #[derive(Resource)]
+/// #[component(hook_name = function)]
+/// struct MyResource;
+/// ```
+/// where `hook_name` is `on_add`, `on_insert`, `on_discard` or `on_remove`;
+/// `function` can be either a path, e.g. `some_function::<Self>`,
+/// or a function call that returns a function that can be turned into
+/// a `ComponentHook`, e.g. `get_closure("Hi!")`.
+/// `function` can be elided if the path is `Self::on_add`, `Self::on_insert` etc.
 #[proc_macro_derive(Resource, attributes(component))]
 pub fn derive_resource(input: TokenStream) -> TokenStream {
     let mut ast = parse_macro_input!(input as DeriveInput);

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -15,7 +15,7 @@ mod world_query;
 
 use crate::{query_data::derive_query_data_impl, query_filter::derive_query_filter_impl};
 use bevy_ecs_macro_logic::{
-    component::{DeriveComponent, StorageTy},
+    component::{DeriveComponent, StorageAttribute, StorageTy},
     map_entities::map_entities,
 };
 use bevy_macro_utils::{
@@ -827,7 +827,7 @@ pub fn derive_settings_group(input: TokenStream) -> TokenStream {
 )]
 pub fn derive_component(input: TokenStream) -> TokenStream {
     let mut ast = parse_macro_input!(input as DeriveInput);
-    let derive_component = match DeriveComponent::parse(&ast) {
+    let derive_component = match DeriveComponent::parse(&ast, StorageAttribute::Allowed) {
         Ok(value) => value,
         Err(e) => return e.into_compile_error().into(),
     };

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -14,7 +14,10 @@ mod variant_defaults;
 mod world_query;
 
 use crate::{query_data::derive_query_data_impl, query_filter::derive_query_filter_impl};
-use bevy_ecs_macro_logic::{component::DeriveComponent, map_entities::map_entities};
+use bevy_ecs_macro_logic::{
+    component::{DeriveComponent, StorageTy},
+    map_entities::map_entities,
+};
 use bevy_macro_utils::{
     derive_label, ensure_no_collision,
     fq_std::{FQDefault, FQIterator, FQOption, FQResult},
@@ -810,10 +813,11 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
         Err(e) => return e.into_compile_error().into(),
     };
     let bevy_ecs = bevy_ecs_path();
-    let impl_component = match derive_component.impl_component(&mut ast, &bevy_ecs) {
-        Ok(value) => value,
-        Err(err) => return err.into_compile_error().into(),
-    };
+    let impl_component =
+        match derive_component.impl_component(&mut ast, &bevy_ecs, StorageTy::Table) {
+            Ok(value) => value,
+            Err(err) => return err.into_compile_error().into(),
+        };
     TokenStream::from(impl_component)
 }
 

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -560,7 +560,7 @@ pub fn derive_message(input: TokenStream) -> TokenStream {
 }
 
 /// Implement the `Resource` trait.
-#[proc_macro_derive(Resource)]
+#[proc_macro_derive(Resource, attributes(component))]
 pub fn derive_resource(input: TokenStream) -> TokenStream {
     let mut ast = parse_macro_input!(input as DeriveInput);
     TokenStream::from(resource::derive_resource(&mut ast))

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -563,7 +563,7 @@ pub fn derive_message(input: TokenStream) -> TokenStream {
 }
 
 /// Implement the `Resource` trait.
-/// 
+///
 /// ## Immutability
 /// ```ignore
 /// #[derive(Resource)]

--- a/crates/bevy_ecs/macros/src/resource.rs
+++ b/crates/bevy_ecs/macros/src/resource.rs
@@ -10,7 +10,6 @@ pub fn derive_resource(ast: &mut DeriveInput) -> TokenStream {
         Ok(value) => value,
         Err(e) => return e.into_compile_error(),
     };
-    derive_component.storage = StorageTy::SparseSet;
 
     let struct_name = &ast.ident;
     let (_, type_generics, _) = &ast.generics.split_for_impl();
@@ -25,7 +24,8 @@ pub fn derive_resource(ast: &mut DeriveInput) -> TokenStream {
         required_components.register_required::<#bevy_ecs::resource::IsResource>(move || #bevy_ecs::resource::IsResource::new(resource_component_id));
     });
 
-    let component_impl = match derive_component.impl_component(ast, &bevy_ecs) {
+    let component_impl = match derive_component.impl_component(ast, &bevy_ecs, StorageTy::SparseSet)
+    {
         Ok(value) => value,
         Err(err) => return err.into_compile_error(),
     };

--- a/crates/bevy_ecs/macros/src/resource.rs
+++ b/crates/bevy_ecs/macros/src/resource.rs
@@ -1,4 +1,4 @@
-use bevy_ecs_macro_logic::component::{DeriveComponent, StorageTy};
+use bevy_ecs_macro_logic::component::{DeriveComponent, StorageAttribute, StorageTy};
 use bevy_macro_utils::fq_std::FQOption;
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -6,7 +6,7 @@ use syn::{DeriveInput, Path};
 
 pub fn derive_resource(ast: &mut DeriveInput) -> TokenStream {
     let bevy_ecs: Path = crate::bevy_ecs_path();
-    let mut derive_component = match DeriveComponent::parse(ast) {
+    let mut derive_component = match DeriveComponent::parse(ast, StorageAttribute::Disallowed) {
         Ok(value) => value,
         Err(e) => return e.into_compile_error(),
     };

--- a/crates/bevy_ecs/src/change_detection/params.rs
+++ b/crates/bevy_ecs/src/change_detection/params.rs
@@ -1,5 +1,6 @@
 use crate::{
     change_detection::{traits::*, ComponentTickCells, MaybeLocation, Tick},
+    component::Mutable,
     ptr::PtrMut,
     resource::Resource,
 };
@@ -548,7 +549,7 @@ where
     }
 }
 
-impl<'w, 'a, T: Resource> IntoIterator for &'a mut ResMut<'w, T>
+impl<'w, 'a, T: Resource<Mutability = Mutable>> IntoIterator for &'a mut ResMut<'w, T>
 where
     &'a mut T: IntoIterator,
 {
@@ -562,11 +563,11 @@ where
 }
 
 change_detection_impl!(ResMut<'w, T>, T, Resource);
-change_detection_mut_impl!(ResMut<'w, T>, T, Resource);
-impl_methods!(ResMut<'w, T>, T, Resource);
+change_detection_mut_impl!(ResMut<'w, T>, T, Resource<Mutability = Mutable>);
+impl_methods!(ResMut<'w, T>, T, Resource, Resource<Mutability = Mutable>);
 impl_debug!(ResMut<'w, T>, Resource);
 
-impl<'w, T: Resource> From<ResMut<'w, T>> for Mut<'w, T> {
+impl<'w, T: Resource<Mutability = Mutable>> From<ResMut<'w, T>> for Mut<'w, T> {
     /// Convert this `ResMut` into a `Mut`. This allows keeping the change-detection feature of `Mut`
     /// while losing the specificity of `ResMut` for resources.
     fn from(other: ResMut<'w, T>) -> Mut<'w, T> {

--- a/crates/bevy_ecs/src/change_detection/params.rs
+++ b/crates/bevy_ecs/src/change_detection/params.rs
@@ -488,7 +488,7 @@ impl<'w, T: Resource> Res<'w, T> {
     }
 }
 
-impl<'w, T: Resource> From<ResMut<'w, T>> for Res<'w, T> {
+impl<'w, T: Resource<Mutability = Mutable>> From<ResMut<'w, T>> for Res<'w, T> {
     fn from(res: ResMut<'w, T>) -> Self {
         Self {
             value: res.value,
@@ -532,12 +532,12 @@ impl_debug!(Res<'w, T>, Resource);
 /// This will cause a panic, but can be configured to do nothing or warn once.
 ///
 /// Use [`Option<ResMut<T>>`] instead if the resource might not always exist.
-pub struct ResMut<'w, T: ?Sized + Resource> {
+pub struct ResMut<'w, T: ?Sized + Resource<Mutability = Mutable>> {
     pub(crate) value: &'w mut T,
     pub(crate) ticks: ComponentTicksMut<'w>,
 }
 
-impl<'w, 'a, T: Resource> IntoIterator for &'a ResMut<'w, T>
+impl<'w, 'a, T: Resource<Mutability = Mutable>> IntoIterator for &'a ResMut<'w, T>
 where
     &'a T: IntoIterator,
 {
@@ -562,10 +562,10 @@ where
     }
 }
 
-change_detection_impl!(ResMut<'w, T>, T, Resource);
+change_detection_impl!(ResMut<'w, T>, T, Resource<Mutability = Mutable>);
 change_detection_mut_impl!(ResMut<'w, T>, T, Resource<Mutability = Mutable>);
-impl_methods!(ResMut<'w, T>, T, Resource, Resource<Mutability = Mutable>);
-impl_debug!(ResMut<'w, T>, Resource);
+impl_methods!(ResMut<'w, T>, T, Resource<Mutability = Mutable>);
+impl_debug!(ResMut<'w, T>, Resource<Mutability = Mutable>);
 
 impl<'w, T: Resource<Mutability = Mutable>> From<ResMut<'w, T>> for Mut<'w, T> {
     /// Convert this `ResMut` into a `Mut`. This allows keeping the change-detection feature of `Mut`

--- a/crates/bevy_ecs/src/change_detection/traits.rs
+++ b/crates/bevy_ecs/src/change_detection/traits.rs
@@ -359,7 +359,7 @@ pub trait DetectChangesMut: DetectChanges {
 }
 
 macro_rules! change_detection_impl {
-    ($name:ident < $( $generics:tt ),+ >, $target:ty, $($traits:ident)?) => {
+    ($name:ident < $( $generics:tt ),+ >, $target:ty, $($traits:path)?) => {
         impl<$($generics),* : ?Sized $(+ $traits)?> DetectChanges for $name<$($generics),*> {
             #[inline]
             fn is_added(&self) -> bool {
@@ -484,8 +484,8 @@ macro_rules! change_detection_mut_impl {
 pub(crate) use change_detection_mut_impl;
 
 macro_rules! impl_methods {
-    ($name:ident < $( $generics:tt ),+ >, $target:ty, $($traits:ident)? $(, $mut_traits:path)?) => {
-        impl<$($generics),* : ?Sized $(+ $mut_traits)?> $name<$($generics),*> {
+    ($name:ident < $( $generics:tt ),+ >, $target:ty, $($traits:path)?) => {
+        impl<$($generics),* : ?Sized $(+ $traits)?> $name<$($generics),*> {
             /// Consume `self` and return a mutable reference to the
             /// contained value while marking `self` as "changed".
             #[inline]
@@ -493,9 +493,7 @@ macro_rules! impl_methods {
                 self.set_changed();
                 self.value
             }
-        }
 
-        impl<$($generics),* : ?Sized $(+ $traits)?> $name<$($generics),*> {
             /// Returns a `Mut<>` with a smaller lifetime.
             /// This is useful if you have `&mut
             #[doc = stringify!($name)]
@@ -581,7 +579,7 @@ macro_rules! impl_methods {
 pub(crate) use impl_methods;
 
 macro_rules! impl_debug {
-    ($name:ident < $( $generics:tt ),+ >, $($traits:ident)?) => {
+    ($name:ident < $( $generics:tt ),+ >, $($traits:path)?) => {
         impl<$($generics),* : ?Sized $(+ $traits)?> core::fmt::Debug for $name<$($generics),*>
             where T: core::fmt::Debug
         {

--- a/crates/bevy_ecs/src/change_detection/traits.rs
+++ b/crates/bevy_ecs/src/change_detection/traits.rs
@@ -422,7 +422,7 @@ macro_rules! change_detection_impl {
 pub(crate) use change_detection_impl;
 
 macro_rules! change_detection_mut_impl {
-    ($name:ident < $( $generics:tt ),+ >, $target:ty, $($traits:ident)?) => {
+    ($name:ident < $( $generics:tt ),+ >, $target:ty, $($traits:path)?) => {
         impl<$($generics),* : ?Sized $(+ $traits)?> DetectChangesMut for $name<$($generics),*> {
             type Inner = $target;
 
@@ -484,8 +484,8 @@ macro_rules! change_detection_mut_impl {
 pub(crate) use change_detection_mut_impl;
 
 macro_rules! impl_methods {
-    ($name:ident < $( $generics:tt ),+ >, $target:ty, $($traits:ident)?) => {
-        impl<$($generics),* : ?Sized $(+ $traits)?> $name<$($generics),*> {
+    ($name:ident < $( $generics:tt ),+ >, $target:ty, $($traits:ident)? $(, $mut_traits:path)?) => {
+        impl<$($generics),* : ?Sized $(+ $mut_traits)?> $name<$($generics),*> {
             /// Consume `self` and return a mutable reference to the
             /// contained value while marking `self` as "changed".
             #[inline]
@@ -493,7 +493,9 @@ macro_rules! impl_methods {
                 self.set_changed();
                 self.value
             }
+        }
 
+        impl<$($generics),* : ?Sized $(+ $traits)?> $name<$($generics),*> {
             /// Returns a `Mut<>` with a smaller lifetime.
             /// This is useful if you have `&mut
             #[doc = stringify!($name)]

--- a/crates/bevy_ecs/src/resource.rs
+++ b/crates/bevy_ecs/src/resource.rs
@@ -219,7 +219,6 @@ mod tests {
 
     use crate::{
         change_detection::MaybeLocation,
-        component::StorageType,
         entity::Entity,
         lifecycle::HookContext,
         ptr::OwningPtr,

--- a/crates/bevy_ecs/src/resource.rs
+++ b/crates/bevy_ecs/src/resource.rs
@@ -3,7 +3,7 @@
 use log::warn;
 
 use crate::{
-    component::{Component, ComponentId, Mutable},
+    component::{Component, ComponentId},
     entity::Entity,
     lifecycle::HookContext,
     storage::SparseArray,
@@ -84,7 +84,7 @@ use bevy_platform::cell::SyncUnsafeCell;
     label = "invalid `Resource`",
     note = "consider annotating `{Self}` with `#[derive(Resource)]`"
 )]
-pub trait Resource: Component<Mutability = Mutable> {}
+pub trait Resource: Component {}
 
 /// A cache that links each `ComponentId` from a resource to the corresponding entity.
 #[derive(Default)]
@@ -215,12 +215,16 @@ pub const IS_RESOURCE: ComponentId = ComponentId::new(crate::component::IS_RESOU
 
 #[cfg(test)]
 mod tests {
+    use core::sync::atomic::{AtomicBool, Ordering::Relaxed};
+
     use crate::{
         change_detection::MaybeLocation,
+        component::StorageType,
         entity::Entity,
+        lifecycle::HookContext,
         ptr::OwningPtr,
         resource::{IsResource, Resource},
-        world::World,
+        world::{DeferredWorld, World},
     };
     use alloc::vec::Vec;
     use bevy_platform::prelude::String;
@@ -326,5 +330,34 @@ mod tests {
         assert!(world.entity(id).get::<IsResource>().is_none());
         assert!(world.entity(second_entity).get::<TestResource>().is_some());
         assert!(world.entity(second_entity).get::<IsResource>().is_some());
+    }
+
+    #[test]
+    fn derive_resource_component_features() {
+        static ON_ADD_CALLED: AtomicBool = AtomicBool::new(false);
+
+        #[derive(Resource)]
+        #[component(immutable, on_add, storage = "Table")]
+        struct TestResource;
+        impl TestResource {
+            fn on_add(_: DeferredWorld, _: HookContext) {
+                ON_ADD_CALLED.store(true, Relaxed);
+            }
+        }
+
+        let mut world = World::new();
+        world.insert_resource(TestResource);
+
+        assert!(ON_ADD_CALLED.load(Relaxed));
+        assert!(
+            world
+                .components()
+                .get_descriptor(world.component_id::<TestResource>().unwrap())
+                .unwrap()
+                .storage_type()
+                == StorageType::Table
+        );
+        assert!(world.get_resource::<TestResource>().is_some());
+        assert!(world.get_resource_mut::<TestResource>().is_none());
     }
 }

--- a/crates/bevy_ecs/src/resource.rs
+++ b/crates/bevy_ecs/src/resource.rs
@@ -337,7 +337,7 @@ mod tests {
         static ON_ADD_CALLED: AtomicBool = AtomicBool::new(false);
 
         #[derive(Resource)]
-        #[component(immutable, on_add, storage = "Table")]
+        #[component(immutable, on_add)]
         struct TestResource;
         impl TestResource {
             fn on_add(_: DeferredWorld, _: HookContext) {
@@ -349,14 +349,6 @@ mod tests {
         world.insert_resource(TestResource);
 
         assert!(ON_ADD_CALLED.load(Relaxed));
-        assert!(
-            world
-                .components()
-                .get_descriptor(world.component_id::<TestResource>().unwrap())
-                .unwrap()
-                .storage_type()
-                == StorageType::Table
-        );
         assert!(world.get_resource::<TestResource>().is_some());
         assert!(world.get_resource_mut::<TestResource>().is_none());
     }

--- a/crates/bevy_ecs/src/resource.rs
+++ b/crates/bevy_ecs/src/resource.rs
@@ -349,6 +349,5 @@ mod tests {
 
         assert!(ON_ADD_CALLED.load(Relaxed));
         assert!(world.get_resource::<TestResource>().is_some());
-        assert!(world.get_resource_mut::<TestResource>().is_none());
     }
 }

--- a/crates/bevy_ecs/src/system/builder.rs
+++ b/crates/bevy_ecs/src/system/builder.rs
@@ -5,6 +5,7 @@ use variadics_please::all_tuples;
 
 use crate::{
     change_detection::{CheckChangeTicks, Tick},
+    component::Mutable,
     prelude::QueryBuilder,
     query::{FilteredAccessSet, QueryData, QueryFilter, QueryState},
     resource::Resource,
@@ -226,7 +227,8 @@ impl ParamBuilder {
     }
 
     /// Helper method for mutably accessing a [`Resource`] as a param, equivalent to `of::<ResMut<T>>()`
-    pub fn resource_mut<'w, T: Resource>() -> impl SystemParamBuilder<ResMut<'w, T>> {
+    pub fn resource_mut<'w, T: Resource<Mutability = Mutable>>(
+    ) -> impl SystemParamBuilder<ResMut<'w, T>> {
         Self
     }
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -8,7 +8,7 @@ use crate::{
     archetype::Archetypes,
     bundle::Bundles,
     change_detection::{ComponentTicksMut, ComponentTicksRef, Tick},
-    component::{ComponentId, Components},
+    component::{ComponentId, Components, Mutable},
     entity::{Entities, EntityAllocator},
     query::{
         Access, FilteredAccess, FilteredAccessSet, IterQueryData, QueryData, QueryFilter,
@@ -725,7 +725,7 @@ unsafe impl<'a, T: Resource> SystemParam for Res<'a, T> {
 
 // SAFETY: Res ComponentId access is applied to SystemMeta. If this Res
 // conflicts with any prior access, a panic will occur.
-unsafe impl<'a, T: Resource> SystemParam for ResMut<'a, T> {
+unsafe impl<'a, T: Resource<Mutability = Mutable>> SystemParam for ResMut<'a, T> {
     type State = ComponentId;
     type Item<'w, 's> = ResMut<'w, T>;
 

--- a/crates/bevy_ecs/src/template.rs
+++ b/crates/bevy_ecs/src/template.rs
@@ -3,6 +3,7 @@
 pub use bevy_ecs_macros::FromTemplate;
 
 use crate::{
+    component::Mutable,
     entity::Entity,
     error::{BevyError, Result},
     resource::Resource,
@@ -80,7 +81,7 @@ impl<'a, 'w> TemplateContext<'a, 'w> {
 
     /// Retrieves a mutable reference to the given resource `R`.
     #[inline]
-    pub fn resource_mut<R: Resource>(&mut self) -> Mut<'_, R> {
+    pub fn resource_mut<R: Resource<Mutability = Mutable>>(&mut self) -> Mut<'_, R> {
         self.entity.resource_mut()
     }
 }

--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -472,7 +472,7 @@ impl<'w> DeferredWorld<'w> {
     /// Use [`get_resource_mut`](DeferredWorld::get_resource_mut) instead if you want to handle this case.
     #[inline]
     #[track_caller]
-    pub fn resource_mut<R: Resource>(&mut self) -> Mut<'_, R> {
+    pub fn resource_mut<R: Resource<Mutability = Mutable>>(&mut self) -> Mut<'_, R> {
         match self.get_resource_mut() {
             Some(x) => x,
             None => panic!(
@@ -487,7 +487,7 @@ impl<'w> DeferredWorld<'w> {
 
     /// Gets a mutable reference to the resource of the given type if it exists
     #[inline]
-    pub fn get_resource_mut<R: Resource>(&mut self) -> Option<Mut<'_, R>> {
+    pub fn get_resource_mut<R: Resource<Mutability = Mutable>>(&mut self) -> Option<Mut<'_, R>> {
         // SAFETY: &mut self ensure that there are no outstanding accesses to the resource
         unsafe { self.world.get_resource_mut() }
     }

--- a/crates/bevy_ecs/src/world/entity_access/world_mut.rs
+++ b/crates/bevy_ecs/src/world/entity_access/world_mut.rs
@@ -672,7 +672,7 @@ impl<'w> EntityWorldMut<'w> {
     /// use [`get_resource_or_insert_with`](World::get_resource_or_insert_with).
     #[inline]
     #[track_caller]
-    pub fn resource_mut<R: Resource>(&mut self) -> Mut<'_, R> {
+    pub fn resource_mut<R: Resource<Mutability = Mutable>>(&mut self) -> Mut<'_, R> {
         self.world.resource_mut::<R>()
     }
 
@@ -684,7 +684,7 @@ impl<'w> EntityWorldMut<'w> {
 
     /// Gets a mutable reference to the resource of the given type if it exists
     #[inline]
-    pub fn get_resource_mut<R: Resource>(&mut self) -> Option<Mut<'_, R>> {
+    pub fn get_resource_mut<R: Resource<Mutability = Mutable>>(&mut self) -> Option<Mut<'_, R>> {
         self.world.get_resource_mut()
     }
 

--- a/crates/bevy_ecs/src/world/error.rs
+++ b/crates/bevy_ecs/src/world/error.rs
@@ -73,6 +73,9 @@ pub enum ResourceFetchError {
     /// Cannot get access to the resource with the given [`ComponentId`] in the world as it conflicts with an on going operation.
     #[error("Cannot get access to the resource with ID {0:?} in the world as it conflicts with an on going operation.")]
     NoResourceAccess(ComponentId),
+    /// Tried to mutably fetch an immutable resource.
+    #[error("Tried to mutably fetch resource with ID {0:?}, which is immutable")]
+    Immutable(ComponentId),
 }
 
 #[cfg(test)]

--- a/crates/bevy_ecs/src/world/filtered_resource.rs
+++ b/crates/bevy_ecs/src/world/filtered_resource.rs
@@ -490,6 +490,12 @@ impl<'w, 's> FilteredResourcesMut<'w, 's> {
         let (value, ticks) = unsafe { self.world.get_resource_with_ticks(component_id) }
             .ok_or(ResourceFetchError::DoesNotExist(component_id))?;
 
+        // SAFETY: Resource is present, so its component info exists
+        let mutable = unsafe { self.world.components().get_info_unchecked(component_id) }.mutable();
+        if !mutable {
+            return Err(ResourceFetchError::Immutable(component_id));
+        }
+
         Ok(MutUntyped {
             // SAFETY: We have exclusive access to the underlying storage.
             value: unsafe { value.assert_unique() },

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -2799,7 +2799,7 @@ impl World {
             entity: Entity,
             component_id: ComponentId,
             value: ManuallyDrop<R>,
-            ticks: ComponentTicks,
+            new_tick: Tick,
             caller: MaybeLocation,
         }
         impl<R: Resource> Drop for ReinsertGuard<'_, R> {
@@ -2860,7 +2860,7 @@ impl World {
                     // SAFETY:
                     // - `location.archetype_id` is part of a valid `EntityLocation`.
                     let mut bundle_inserter = unsafe {
-                        BundleInserter::new::<R>(world, location.archetype_id, self.ticks.changed)
+                        BundleInserter::new::<R>(world, location.archetype_id, self.new_tick)
                     };
                     // SAFETY:
                     // - `location` matches current entity and thus must currently exist in the source
@@ -2899,7 +2899,7 @@ impl World {
             entity,
             component_id,
             value: ManuallyDrop::new(value),
-            ticks,
+            new_tick: change_tick,
             caller: changed_by,
         };
 
@@ -3925,7 +3925,7 @@ mod tests {
         component::{ComponentCloneBehavior, ComponentDescriptor, ComponentInfo, StorageType},
         entity::EntityHashSet,
         entity_disabling::{DefaultQueryFilters, Disabled},
-        prelude::{Event, Mut, On, Res},
+        prelude::{DetectChanges, Event, Mut, On, Res},
         ptr::OwningPtr,
         resource::Resource,
         world::{error::EntityMutableFetchError, DeferredWorld},
@@ -4628,5 +4628,26 @@ mod tests {
         world.flush();
 
         assert!(world.get_entity(eid).is_err());
+    }
+
+    #[test]
+    fn resource_scope_ticks() {
+        #[derive(Resource)]
+        struct R;
+
+        let mut world = World::new();
+        world.insert_resource(R);
+        world.increment_change_tick();
+        assert_ne!(world.change_tick(), world.resource_ref::<R>().added());
+        assert_ne!(
+            world.change_tick(),
+            world.resource_ref::<R>().last_changed()
+        );
+        world.resource_scope(|_, _: Mut<R>| ());
+        assert_eq!(world.change_tick(), world.resource_ref::<R>().added());
+        assert_eq!(
+            world.change_tick(),
+            world.resource_ref::<R>().last_changed()
+        );
     }
 }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -2880,12 +2880,6 @@ impl World {
                     });
                     entity_mut.update_location();
 
-                    // Set the added tick to the original.
-                    entity_mut
-                        .get_mut::<R>()
-                        .unwrap()
-                        .set_last_added(self.ticks.added);
-
                     // SAFETY: We update the entity location afterwards.
                     unsafe { entity_mut.world_mut() }.flush();
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -2799,7 +2799,6 @@ impl World {
             entity: Entity,
             component_id: ComponentId,
             value: ManuallyDrop<R>,
-            new_tick: Tick,
             caller: MaybeLocation,
         }
         impl<R: Resource> Drop for ReinsertGuard<'_, R> {
@@ -2857,11 +2856,11 @@ impl World {
                     // SAFETY:
                     // - We update the entity location like in `EntityWorldMut::insert_with_caller`.
                     let world = unsafe { entity_mut.world_mut() };
+                    let tick = world.change_tick();
                     // SAFETY:
                     // - `location.archetype_id` is part of a valid `EntityLocation`.
-                    let mut bundle_inserter = unsafe {
-                        BundleInserter::new::<R>(world, location.archetype_id, self.new_tick)
-                    };
+                    let mut bundle_inserter =
+                        unsafe { BundleInserter::new::<R>(world, location.archetype_id, tick) };
                     // SAFETY:
                     // - `location` matches current entity and thus must currently exist in the source
                     //   archetype for this inserter and its location within the archetype.
@@ -2899,7 +2898,6 @@ impl World {
             entity,
             component_id,
             value: ManuallyDrop::new(value),
-            new_tick: change_tick,
             caller: changed_by,
         };
 
@@ -4637,13 +4635,11 @@ mod tests {
 
         let mut world = World::new();
         world.insert_resource(R);
-        world.increment_change_tick();
-        assert_ne!(world.change_tick(), world.resource_ref::<R>().added());
-        assert_ne!(
-            world.change_tick(),
-            world.resource_ref::<R>().last_changed()
-        );
-        world.resource_scope(|_, _: Mut<R>| ());
+        world.resource_scope(|world, r: Mut<R>| {
+            assert_eq!(world.change_tick(), r.added());
+            assert_eq!(world.change_tick(), r.last_changed());
+            world.increment_change_tick();
+        });
         assert_eq!(world.change_tick(), world.resource_ref::<R>().added());
         assert_eq!(
             world.change_tick(),

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -2193,7 +2193,7 @@ impl World {
     /// use [`get_resource_or_insert_with`](World::get_resource_or_insert_with).
     #[inline]
     #[track_caller]
-    pub fn resource_mut<R: Resource>(&mut self) -> Mut<'_, R> {
+    pub fn resource_mut<R: Resource<Mutability = Mutable>>(&mut self) -> Mut<'_, R> {
         match self.get_resource_mut() {
             Some(x) => x,
             None => panic!(
@@ -2226,7 +2226,7 @@ impl World {
 
     /// Gets a mutable reference to the resource of the given type if it exists
     #[inline]
-    pub fn get_resource_mut<R: Resource>(&mut self) -> Option<Mut<'_, R>> {
+    pub fn get_resource_mut<R: Resource<Mutability = Mutable>>(&mut self) -> Option<Mut<'_, R>> {
         // SAFETY:
         // - `as_unsafe_world_cell` gives permission to access everything mutably
         // - `&mut self` ensures nothing in world is borrowed
@@ -3393,7 +3393,7 @@ impl World {
         }
     }
 
-    /// Gets a pointer to the resource with the id [`ComponentId`] if it exists.
+    /// Gets a pointer to the resource with the id [`ComponentId`] if it exists and is mutable.
     /// The returned pointer may be used to modify the resource, as long as the mutable borrow
     /// of the [`World`] is still valid.
     ///

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -2250,7 +2250,7 @@ impl World {
     /// ```
     #[inline]
     #[track_caller]
-    pub fn get_resource_or_insert_with<R: Resource>(
+    pub fn get_resource_or_insert_with<R: Resource<Mutability = Mutable>>(
         &mut self,
         func: impl FnOnce() -> R,
     ) -> Mut<'_, R> {
@@ -2297,7 +2297,9 @@ impl World {
     /// assert_eq!(my_res.0, 30);
     /// ```
     #[track_caller]
-    pub fn get_resource_or_init<R: Resource + FromWorld>(&mut self) -> Mut<'_, R> {
+    pub fn get_resource_or_init<R: Resource<Mutability = Mutable> + FromWorld>(
+        &mut self,
+    ) -> Mut<'_, R> {
         let caller = MaybeLocation::caller();
         let (resource_id, entity) =
             self.insert_resource_if_not_exists_with_caller(R::from_world, caller);

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -54,7 +54,7 @@ use crate::{
     lifecycle::{ComponentHooks, RemovedComponentMessages, ADD, DESPAWN, DISCARD, INSERT, REMOVE},
     message::{Message, MessageId, Messages, WriteBatchIds},
     observer::Observers,
-    prelude::{Add, Despawn, DetectChangesMut, Discard, Insert, Remove},
+    prelude::{Add, Despawn, Discard, Insert, Remove},
     query::{DebugCheckedUnwrap, QueryData, QueryFilter, QueryState},
     relationship::RelationshipHookMode,
     resource::{IsResource, Resource, ResourceEntities, IS_RESOURCE},

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -1335,7 +1335,7 @@ unsafe fn get_component_and_ticks(
     }
 }
 
-/// Get an untyped pointer to the [`ComponentTicks`] on a particular [`Entity`]
+/// Get the [`ComponentTicks`] on a particular [`Entity`]
 ///
 /// # Safety
 /// - `location` must refer to an archetype that contains `entity`

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -55,6 +55,7 @@ use thiserror::Error;
 /// use bevy_ecs::world::World;
 /// use bevy_ecs::change_detection::Mut;
 /// use bevy_ecs::resource::Resource;
+/// use bevy_ecs::component::Mutable;
 /// use bevy_ecs::world::unsafe_world_cell::UnsafeWorldCell;
 ///
 /// // INVARIANT: existence of this struct means that users of it are the only ones being able to access resources in the world

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -63,7 +63,7 @@ use thiserror::Error;
 /// struct OnlyComponentAccessWorld<'w>(UnsafeWorldCell<'w>);
 ///
 /// impl<'w> OnlyResourceAccessWorld<'w> {
-///     fn get_resource_mut<T: Resource>(&mut self) -> Option<Mut<'_, T>> {
+///     fn get_resource_mut<T: Resource<Mutability = Mutable>>(&mut self) -> Option<Mut<'_, T>> {
 ///         // SAFETY: resource access is allowed through this UnsafeWorldCell
 ///         unsafe { self.0.get_resource_mut::<T>() }
 ///     }
@@ -543,7 +543,7 @@ impl<'w> UnsafeWorldCell<'w> {
     /// - the [`UnsafeWorldCell`] has permission to access the resource mutably
     /// - no other references to the resource exist at the same time
     #[inline]
-    pub unsafe fn get_resource_mut<R: Resource>(self) -> Option<Mut<'w, R>> {
+    pub unsafe fn get_resource_mut<R: Resource<Mutability = Mutable>>(self) -> Option<Mut<'w, R>> {
         self.assert_allows_mutable_access();
         let component_id = self.components().get_valid_id(TypeId::of::<R>())?;
         // SAFETY:
@@ -556,7 +556,7 @@ impl<'w> UnsafeWorldCell<'w> {
         }
     }
 
-    /// Gets a pointer to the resource with the id [`ComponentId`] if it exists.
+    /// Gets a pointer to the resource with the id [`ComponentId`] if it exists and is mutable.
     /// The returned pointer may be used to modify the resource, as long as the mutable borrow
     /// of the [`UnsafeWorldCell`] is still valid.
     ///
@@ -1122,7 +1122,8 @@ impl<'w> UnsafeEntityCell<'w> {
     }
 
     /// Retrieves a mutable untyped reference to the given `entity`'s [`Component`] of the given [`ComponentId`].
-    /// Returns `None` if the `entity` does not have a [`Component`] of the given type.
+    /// Returns `None` if the `entity` does not have a [`Component`] of the given type,
+    /// or if the component is immutable.
     ///
     /// **You should prefer to use the typed API [`UnsafeEntityCell::get_mut`] where possible and only
     /// use this in cases where the actual types are not known at compile time.**

--- a/crates/bevy_render/src/extract_resource.rs
+++ b/crates/bevy_render/src/extract_resource.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 
 use bevy_app::{App, Plugin};
-use bevy_ecs::prelude::*;
+use bevy_ecs::{component::Mutable, prelude::*};
 pub use bevy_render_macros::ExtractResource;
 use bevy_utils::once;
 
@@ -38,7 +38,9 @@ impl<R: ExtractResource<F>, F> Default for ExtractResourcePlugin<R, F> {
     }
 }
 
-impl<R: ExtractResource<F>, F: 'static + Send + Sync> Plugin for ExtractResourcePlugin<R, F> {
+impl<R: ExtractResource<F, Mutability = Mutable>, F: 'static + Send + Sync> Plugin
+    for ExtractResourcePlugin<R, F>
+{
     fn build(&self, app: &mut App) {
         if let Some(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app.add_systems(ExtractSchedule, extract_resource::<R, F>);
@@ -52,7 +54,7 @@ impl<R: ExtractResource<F>, F: 'static + Send + Sync> Plugin for ExtractResource
 }
 
 /// This system extracts the resource of the corresponding [`Resource`] type
-pub fn extract_resource<R: ExtractResource<F>, F>(
+pub fn extract_resource<R: ExtractResource<F, Mutability = Mutable>, F>(
     mut commands: Commands,
     main_resource: Extract<Option<Res<R::Source>>>,
     target_resource: Option<ResMut<R>>,

--- a/crates/bevy_scene/macros/src/scene_component.rs
+++ b/crates/bevy_scene/macros/src/scene_component.rs
@@ -1,4 +1,4 @@
-use bevy_ecs_macro_logic::component::DeriveComponent;
+use bevy_ecs_macro_logic::component::{DeriveComponent, StorageTy};
 use bevy_macro_utils::{fq_std::FQDefault, BevyManifest, PathType};
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -46,7 +46,7 @@ pub(crate) fn derive_scene_component(ast: &mut DeriveInput) -> TokenStream {
     derive_component.additional_requires.push(quote! {
         required_components.register_required(|| #bevy_scene::SceneComponentInfo::new::<#struct_name #type_generics>(false));
     });
-    let component_impl = match derive_component.impl_component(ast, &bevy_ecs) {
+    let component_impl = match derive_component.impl_component(ast, &bevy_ecs, StorageTy::Table) {
         Ok(value) => value,
         Err(err) => return err.into_compile_error(),
     };

--- a/crates/bevy_scene/macros/src/scene_component.rs
+++ b/crates/bevy_scene/macros/src/scene_component.rs
@@ -1,4 +1,4 @@
-use bevy_ecs_macro_logic::component::{DeriveComponent, StorageTy};
+use bevy_ecs_macro_logic::component::{DeriveComponent, StorageAttribute, StorageTy};
 use bevy_macro_utils::{fq_std::FQDefault, BevyManifest, PathType};
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -11,7 +11,7 @@ use syn::{
 };
 
 pub(crate) fn derive_scene_component(ast: &mut DeriveInput) -> TokenStream {
-    let mut derive_component = match DeriveComponent::parse(ast) {
+    let mut derive_component = match DeriveComponent::parse(ast, StorageAttribute::Allowed) {
         Ok(value) => value,
         Err(e) => return e.into_compile_error(),
     };

--- a/examples/showcase/game_menu.rs
+++ b/examples/showcase/game_menu.rs
@@ -228,10 +228,10 @@ mod menu {
     use bevy::{
         app::AppExit,
         color::palettes::css::CRIMSON,
+        ecs::component::Mutable,
         ecs::spawn::{SpawnIter, SpawnWith},
         prelude::*,
     };
-    use bevy_ecs::component::Mutable;
 
     use super::{DisplayQuality, GameState, Setting, Volume, TEXT_COLOR};
 

--- a/examples/showcase/game_menu.rs
+++ b/examples/showcase/game_menu.rs
@@ -231,6 +231,7 @@ mod menu {
         ecs::spawn::{SpawnIter, SpawnWith},
         prelude::*,
     };
+    use bevy_ecs::component::Mutable;
 
     use super::{DisplayQuality, GameState, Setting, Volume, TEXT_COLOR};
 

--- a/examples/showcase/game_menu.rs
+++ b/examples/showcase/game_menu.rs
@@ -338,7 +338,7 @@ mod menu {
 
     // This system updates the settings when a new value for a setting is selected, and marks
     // the button as the one currently selected
-    fn setting_button<T: Resource + Component + PartialEq + Copy>(
+    fn setting_button<T: Resource<Mutability = Mutable> + Component + PartialEq + Copy>(
         interaction_query: Query<
             (&Interaction, &Setting<T>, Entity),
             (Changed<Interaction>, With<Button>),


### PR DESCRIPTION
# Objective

Enables the resource derive macro to specify the attributes for
- hooks (fixes #24159)
- immutability (fixes #24166)

Also fixes `resource_scope` overwriting change ticks and a few related doc comments.

## Showcase

```rust
#[derive(Resource)]
#[component(immutable)]
#[component(on_insert = update_level, on_discard = update_level)]
struct Level(i32);
```