### PR TITLE
bsn: use globally unique indices for entity #Name reference resolution

### DIFF
--- a/benches/benches/bevy_scene/spawn.rs
+++ b/benches/benches/bevy_scene/spawn.rs
@@ -28,6 +28,12 @@ fn spawn(c: &mut Criterion) {
             app.world_mut().spawn_scene(ui()).unwrap();
         });
     });
+    group.bench_function("named_entity_reference", |b| {
+        let mut app = bench_app(|_| {}, |_| {});
+        b.iter(move || {
+            app.world_mut().spawn_scene(named_passing()).unwrap();
+        });
+    });
     group.bench_function("ui_immediate_loaded_scene", |b| {
         let dir = Dir::default();
         let mut app = bench_app(
@@ -126,6 +132,31 @@ fn spawn(c: &mut Criterion) {
         });
     });
     group.finish();
+}
+
+#[derive(Component, FromTemplate)]
+#[expect(
+    unused,
+    reason = "this exists to store the Entity for benchmarking #Name references"
+)]
+struct Reference(Entity);
+
+fn named_passing() -> impl Scene {
+    bsn! {
+        #Name
+        Children [
+            (#Name0 Reference(#Name) Reference(#Name0)),
+            (#Name1 Reference(#Name) Reference(#Name1)),
+            (#Name2 Reference(#Name) Reference(#Name2)),
+            (#Name3 Reference(#Name) Reference(#Name3)),
+            (#Name4 Reference(#Name) Reference(#Name4)),
+            (#Name5 Reference(#Name) Reference(#Name5)),
+            (#Name6 Reference(#Name) Reference(#Name6)),
+            (#Name7 Reference(#Name) Reference(#Name7)),
+            (#Name8 Reference(#Name) Reference(#Name8)),
+            (#Name9 Reference(#Name) Reference(#Name9)),
+        ]
+    }
 }
 
 #[derive(Asset, TypePath)]

--- a/crates/bevy_ecs/src/template.rs
+++ b/crates/bevy_ecs/src/template.rs
@@ -1,14 +1,19 @@
 //! Functionality that relates to the [`Template`] trait.
 
+use core::{hash::Hash, ops::Deref};
+
 pub use bevy_ecs_macros::FromTemplate;
+use bevy_platform::hash::Hashed;
+use bevy_utils::PreHashMap;
+use indexmap::Equivalent;
 
 use crate::{
     entity::Entity,
     error::{BevyError, Result},
     resource::Resource,
-    world::{EntityWorldMut, Mut, World},
+    world::{EntityWorldMut, Mut},
 };
-use alloc::{vec, vec::Vec};
+use alloc::vec::Vec;
 use variadics_please::all_tuples;
 
 /// A [`Template`] is something that, given a spawn context (target [`Entity`], [`World`], etc), can produce a [`Template::Output`].
@@ -40,36 +45,12 @@ pub trait Template {
 pub struct TemplateContext<'a, 'w> {
     /// The current entity the template is being applied to
     pub entity: &'a mut EntityWorldMut<'w>,
-    /// The scoped entities mapping for the current template context
-    pub scoped_entities: &'a mut ScopedEntities,
-    /// The entity scopes for the current template context. This matches
-    /// the `scoped_entities`.
-    pub entity_scopes: &'a EntityScopes,
 }
 
 impl<'a, 'w> TemplateContext<'a, 'w> {
     /// Creates a new [`TemplateContext`].
-    pub fn new(
-        entity: &'a mut EntityWorldMut<'w>,
-        scoped_entities: &'a mut ScopedEntities,
-        entity_scopes: &'a EntityScopes,
-    ) -> Self {
-        Self {
-            entity,
-            scoped_entities,
-            entity_scopes,
-        }
-    }
-
-    /// Retrieves the scoped entity if it has already been spawned, and spawns a new entity if it has not
-    /// yet been spawned.
-    pub fn get_scoped_entity(&mut self, scoped_entity_index: ScopedEntityIndex) -> Entity {
-        self.scoped_entities.get(
-            // SAFETY: this only uses the world to spawn an empty entity
-            unsafe { self.entity.world_mut() },
-            self.entity_scopes,
-            scoped_entity_index,
-        )
+    pub fn new(entity: &'a mut EntityWorldMut<'w>) -> Self {
+        Self { entity }
     }
 
     /// Retrieves a reference to the given resource `R`.
@@ -84,97 +65,121 @@ impl<'a, 'w> TemplateContext<'a, 'w> {
         self.entity.resource_mut()
     }
 }
+mod sealed_world_mut {
+    use crate::world::{EntityWorldMut, World};
 
-/// A mapping from from an entity reference's (scope, index) to a contiguous flat index that uniquely
-/// identifies the entity within a scene.
-#[derive(Default, Debug)]
-pub struct EntityScopes {
-    scopes: Vec<Vec<Option<usize>>>,
-    next_index: usize,
-}
-
-impl EntityScopes {
-    /// The number of entities defined across all scopes.
-    #[inline]
-    pub fn entity_len(&self) -> usize {
-        self.next_index
+    // private trait to hide and disallow _get_world_mut
+    #[doc(hidden)]
+    pub trait SealedWorldMut {
+        #[doc(hidden)]
+        unsafe fn _get_world_mut(&mut self) -> &mut World;
     }
-
-    /// Allocate a new contiguous entity index for the given (scope, index) pair.
-    pub fn alloc(&mut self, scoped_entity_index: ScopedEntityIndex) {
-        *self.get_mut(scoped_entity_index) = Some(self.next_index);
-        self.next_index += 1;
-    }
-
-    /// Assign an existing contiguous entity index for the given (scope, index) pair.
-    /// This is generally used when there are multiple (scope, index) pairs that point
-    /// to the same entity (ex: scene inheritance).
-    pub fn assign(&mut self, scoped_entity_index: ScopedEntityIndex, value: usize) {
-        let option = self.get_mut(scoped_entity_index);
-        *option = Some(value);
-    }
-
-    #[expect(unsafe_code, reason = "Easily verifiable performance optimization")]
-    fn get_mut(&mut self, scoped_entity_index: ScopedEntityIndex) -> &mut Option<usize> {
-        // NOTE: this is ok because PatchContext::new_scope adds scopes as they are created.
-        // this shouldn't panic unless internals are broken.
-        let indices = &mut self.scopes[scoped_entity_index.scope];
-        if scoped_entity_index.index >= indices.len() {
-            indices.resize_with(scoped_entity_index.index + 1, || None);
+    impl<'a> SealedWorldMut for &'a mut World {
+        unsafe fn _get_world_mut(&mut self) -> &mut World {
+            self
         }
-        // SAFETY: just allocated above
-        unsafe { indices.get_unchecked_mut(scoped_entity_index.index) }
     }
-
-    /// Gets the assigned contiguous entity index for the given (scope, index) pair
-    pub fn get(&self, scoped_entity_index: ScopedEntityIndex) -> Option<usize> {
-        *self
-            .scopes
-            .get(scoped_entity_index.scope)?
-            .get(scoped_entity_index.index)?
-    }
-
-    /// Creates a new scope and returns it.
-    pub fn add_scope(&mut self) -> usize {
-        let scope_index = self.scopes.len();
-        self.scopes.push(Vec::default());
-        scope_index
+    impl<'a> SealedWorldMut for &'a mut EntityWorldMut<'_> {
+        unsafe fn _get_world_mut(&mut self) -> &mut World {
+            // SAFETY: is in unsafe
+            unsafe { self.world_mut() }
+        }
     }
 }
-
-/// A contiguous list of entities identified by their index in the list.
-#[derive(Debug)]
-pub struct ScopedEntities(Vec<Option<Entity>>);
-
-impl ScopedEntities {
-    /// Creates a new [`ScopedEntities`] with the given `size`, initialized to [`None`] (no [`Entity`] assigned).
-    pub fn new(size: usize) -> Self {
-        Self(vec![None; size])
-    }
-}
-
-impl ScopedEntities {
-    /// Gets the [`Entity`] assigned to the given (scope, index) pair, if it exists, and spawns a new entity if
-    /// it does not.
-    pub fn get(
+/// Trait to access [`SceneGlobalEntityIds`] from World/EntityWorldMut
+pub trait SceneEntityWorldMutExt: sealed_world_mut::SealedWorldMut {
+    /// Get the [`Entity`] associated with this [`SceneEntityIndex`]
+    /// If the index is unknown, spawn a new empty [`Entity`] and store it
+    fn get_global_entity(
         &mut self,
-        world: &mut World,
-        entity_scopes: &EntityScopes,
-        scoped_entity_index: ScopedEntityIndex,
+        key: impl Deref<Target = Hashed<InnerSceneEntityIndex>>,
     ) -> Entity {
-        let index = entity_scopes.get(scoped_entity_index).unwrap();
-        *self.0[index].get_or_insert_with(|| world.spawn_empty().id())
+        let key: &Hashed<InnerSceneEntityIndex> = &key;
+        // SAFETY: this function takes &mut self which ensures only we have access
+        let entry = unsafe { self._get_world_mut() }
+            .resource::<SceneGlobalEntityIds>()
+            .0
+            .raw_entry()
+            .from_key_hashed_nocheck(key.hash(), key);
+        match entry {
+            Some((_, &entity)) => entity,
+            None => {
+                // SAFETY: Only used to construct a new entity,
+                // and entry is ignored after this point
+                let new_entity = unsafe { self._get_world_mut() }.spawn_empty().id();
+                self.set_global_entity(key, new_entity);
+                new_entity
+            }
+        }
     }
 
-    /// Assigns the given `entity` to the (scope, index) pair.
-    pub fn set(
+    /// Set the [`Entity`] associated with a [`SceneEntityIndex`]
+    ///
+    /// Will panic if the [`SceneEntityIndex`] is already associated with an [`Entity`]
+    fn set_global_entity(
         &mut self,
-        entity_scopes: &EntityScopes,
-        scoped_entity_index: ScopedEntityIndex,
+        key: impl Deref<Target = Hashed<InnerSceneEntityIndex>>,
         entity: Entity,
     ) {
-        let index = entity_scopes.get(scoped_entity_index).unwrap();
-        self.0[index] = Some(entity);
+        use bevy_platform::collections::hash_map::RawEntryMut;
+        let key: &Hashed<InnerSceneEntityIndex> = &key;
+        // SAFETY: this function takes &mut self which ensures only we have access
+        match unsafe { self._get_world_mut() }
+            .resource_mut::<SceneGlobalEntityIds>()
+            .0
+            .raw_entry_mut()
+            .from_key_hashed_nocheck(key.hash(), key)
+        {
+            RawEntryMut::Occupied(_) => {}
+            RawEntryMut::Vacant(view) => {
+                view.insert_hashed_nocheck(key.hash(), *key, entity);
+            }
+        };
+    }
+}
+impl<T> SceneEntityWorldMutExt for T where T: sealed_world_mut::SealedWorldMut {}
+
+/// A resource used to map
+#[derive(Resource, Default, Debug)]
+pub struct SceneGlobalEntityIds(PreHashMap<InnerSceneEntityIndex, Entity>);
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+pub struct SceneEntityIndex(Hashed<InnerSceneEntityIndex>);
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+pub struct InnerSceneEntityIndex {
+    file: &'static str,
+    line: usize,
+    column: usize,
+    local: usize,
+}
+impl SceneEntityIndex {
+    pub fn new((file, line, column): (&'static str, usize, usize), local: usize) -> Self {
+        Self(Hashed::new(InnerSceneEntityIndex {
+            file,
+            line,
+            column,
+            local,
+        }))
+    }
+}
+impl core::fmt::Display for SceneEntityIndex {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_fmt(format_args!(
+            "global={}:{}:{} local={}",
+            self.file, self.line, self.column, self.local
+        ))
+    }
+}
+impl Deref for SceneEntityIndex {
+    type Target = Hashed<InnerSceneEntityIndex>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+impl Equivalent<Hashed<InnerSceneEntityIndex>> for SceneEntityIndex {
+    fn equivalent(&self, key: &Hashed<InnerSceneEntityIndex>) -> bool {
+        &self.0 == key
     }
 }
 
@@ -406,25 +411,11 @@ pub trait SpecializeFromTemplate: Sized {}
 pub enum EntityTemplate {
     /// A reference to a specific [`Entity`]
     Entity(Entity),
-    /// A reference to an entity via a [`ScopedEntityIndex`]
-    ScopedEntityIndex(ScopedEntityIndex),
+    /// A reference to an entity via a global unique reference
+    GlobalEntityIndex(SceneEntityIndex),
     /// An entity has not been specified. Building a template with this variant will result in an error.
     #[default]
     None,
-}
-
-/// An entity index within the current [`TemplateContext`], which is defined by a scope
-/// and an index. This references a specific (and sometimes yet-to-be-spawned) entity defined
-/// within a given scope.
-///
-/// In most cases this is initialized by the scene system and should not be initialized manually.
-/// Scopes must be defined ahead of time on the [`TemplateContext`].
-#[derive(Copy, Clone, Debug)]
-pub struct ScopedEntityIndex {
-    /// The scope of the entity index. This must be defined ahead of time.
-    pub scope: usize,
-    /// The index that uniquely identifies the entity within the current scope.
-    pub index: usize,
 }
 
 impl From<Entity> for EntityTemplate {
@@ -439,8 +430,8 @@ impl Template for EntityTemplate {
     fn build_template(&self, context: &mut TemplateContext) -> Result<Self::Output> {
         Ok(match self {
             Self::Entity(entity) => *entity,
-            Self::ScopedEntityIndex(scoped_entity_index) => {
-                context.get_scoped_entity(*scoped_entity_index)
+            Self::GlobalEntityIndex(global_entity_index) => {
+                context.entity.get_global_entity(*global_entity_index)
             }
             Self::None => {
                 return Err(BevyError::error(
@@ -453,8 +444,8 @@ impl Template for EntityTemplate {
     fn clone_template(&self) -> Self {
         match self {
             Self::Entity(entity) => Self::Entity(*entity),
-            Self::ScopedEntityIndex(scoped_entity_index) => {
-                Self::ScopedEntityIndex(*scoped_entity_index)
+            Self::GlobalEntityIndex(global_entity_index) => {
+                Self::GlobalEntityIndex(*global_entity_index)
             }
             Self::None => Self::None,
         }

--- a/crates/bevy_ecs/src/template.rs
+++ b/crates/bevy_ecs/src/template.rs
@@ -11,7 +11,7 @@ use crate::{
     entity::Entity,
     error::{BevyError, Result},
     resource::Resource,
-    world::{EntityWorldMut, Mut},
+    world::{EntityWorldMut, Mut, World},
 };
 use alloc::vec::Vec;
 use variadics_please::all_tuples;
@@ -45,12 +45,24 @@ pub trait Template {
 pub struct TemplateContext<'a, 'w> {
     /// The current entity the template is being applied to
     pub entity: &'a mut EntityWorldMut<'w>,
+    pub scene_entities: &'a mut SceneEntityIds,
 }
 
 impl<'a, 'w> TemplateContext<'a, 'w> {
     /// Creates a new [`TemplateContext`].
-    pub fn new(entity: &'a mut EntityWorldMut<'w>) -> Self {
-        Self { entity }
+    pub fn new(entity: &'a mut EntityWorldMut<'w>, scene_entities: &'a mut SceneEntityIds) -> Self {
+        Self {
+            entity,
+            scene_entities,
+        }
+    }
+
+    pub fn get_entity(&mut self, index: SceneEntityIndex) -> Entity {
+        self.scene_entities.get_entity(
+            index,
+            // Safety: only used to create a new Entity
+            unsafe { self.entity.world_mut() },
+        )
     }
 
     /// Retrieves a reference to the given resource `R`.
@@ -65,48 +77,29 @@ impl<'a, 'w> TemplateContext<'a, 'w> {
         self.entity.resource_mut()
     }
 }
-mod sealed_world_mut {
-    use crate::world::{EntityWorldMut, World};
-
-    // private trait to hide and disallow _get_world_mut
-    #[doc(hidden)]
-    pub trait SealedWorldMut {
-        #[doc(hidden)]
-        unsafe fn _get_world_mut(&mut self) -> &mut World;
-    }
-    impl<'a> SealedWorldMut for &'a mut World {
-        unsafe fn _get_world_mut(&mut self) -> &mut World {
-            self
-        }
-    }
-    impl<'a> SealedWorldMut for &'a mut EntityWorldMut<'_> {
-        unsafe fn _get_world_mut(&mut self) -> &mut World {
-            // SAFETY: is in unsafe
-            unsafe { self.world_mut() }
-        }
-    }
+#[derive(Default)]
+pub struct SceneEntityIds {
+    map: PreHashMap<InnerSceneEntityIndex, Entity>,
 }
+
 /// Trait to access [`SceneGlobalEntityIds`] from World/EntityWorldMut
-pub trait SceneEntityWorldMutExt: sealed_world_mut::SealedWorldMut {
+impl SceneEntityIds {
     /// Get the [`Entity`] associated with this [`SceneEntityIndex`]
     /// If the index is unknown, spawn a new empty [`Entity`] and store it
-    fn get_global_entity(
+    pub fn get_entity(
         &mut self,
         key: impl Deref<Target = Hashed<InnerSceneEntityIndex>>,
+        world: &mut World,
     ) -> Entity {
         let key: &Hashed<InnerSceneEntityIndex> = &key;
-        // SAFETY: this function takes &mut self which ensures only we have access
-        let entry = unsafe { self._get_world_mut() }
-            .resource::<SceneGlobalEntityIds>()
-            .0
+        let entry = self
+            .map
             .raw_entry()
             .from_key_hashed_nocheck(key.hash(), key);
         match entry {
             Some((_, &entity)) => entity,
             None => {
-                // SAFETY: Only used to construct a new entity,
-                // and entry is ignored after this point
-                let new_entity = unsafe { self._get_world_mut() }.spawn_empty().id();
+                let new_entity = world.spawn_empty().id();
                 self.set_global_entity(key, new_entity);
                 new_entity
             }
@@ -116,17 +109,15 @@ pub trait SceneEntityWorldMutExt: sealed_world_mut::SealedWorldMut {
     /// Set the [`Entity`] associated with a [`SceneEntityIndex`]
     ///
     /// Will panic if the [`SceneEntityIndex`] is already associated with an [`Entity`]
-    fn set_global_entity(
+    pub fn set_global_entity(
         &mut self,
         key: impl Deref<Target = Hashed<InnerSceneEntityIndex>>,
         entity: Entity,
     ) {
         use bevy_platform::collections::hash_map::RawEntryMut;
         let key: &Hashed<InnerSceneEntityIndex> = &key;
-        // SAFETY: this function takes &mut self which ensures only we have access
-        match unsafe { self._get_world_mut() }
-            .resource_mut::<SceneGlobalEntityIds>()
-            .0
+        match self
+            .map
             .raw_entry_mut()
             .from_key_hashed_nocheck(key.hash(), key)
         {
@@ -137,11 +128,6 @@ pub trait SceneEntityWorldMutExt: sealed_world_mut::SealedWorldMut {
         };
     }
 }
-impl<T> SceneEntityWorldMutExt for T where T: sealed_world_mut::SealedWorldMut {}
-
-/// A resource used to map
-#[derive(Resource, Default, Debug)]
-pub struct SceneGlobalEntityIds(PreHashMap<InnerSceneEntityIndex, Entity>);
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 pub struct SceneEntityIndex(Hashed<InnerSceneEntityIndex>);
@@ -431,7 +417,7 @@ impl Template for EntityTemplate {
         Ok(match self {
             Self::Entity(entity) => *entity,
             Self::GlobalEntityIndex(global_entity_index) => {
-                context.entity.get_global_entity(*global_entity_index)
+                context.get_entity(*global_entity_index)
             }
             Self::None => {
                 return Err(BevyError::error(

--- a/crates/bevy_ecs/src/world/entity_access/world_mut.rs
+++ b/crates/bevy_ecs/src/world/entity_access/world_mut.rs
@@ -16,7 +16,7 @@ use crate::{
     relationship::RelationshipHookMode,
     resource::Resource,
     storage::{SparseSets, Table},
-    template::{EntityScopes, ScopedEntities, Template, TemplateContext},
+    template::{Template, TemplateContext},
     world::{
         error::EntityComponentError, unsafe_world_cell::UnsafeEntityCell, ComponentEntry,
         DynamicComponentFetch, EntityMut, EntityRef, FilteredEntityMut, FilteredEntityRef, Mut,
@@ -1600,9 +1600,7 @@ impl<'w> EntityWorldMut<'w> {
         &mut self,
         func: impl FnOnce(&mut TemplateContext) -> crate::error::Result<T>,
     ) -> crate::error::Result<T> {
-        let mut scoped_entities = ScopedEntities::new(0);
-        let entity_scopes = EntityScopes::default();
-        let mut context = TemplateContext::new(self, &mut scoped_entities, &entity_scopes);
+        let mut context = TemplateContext::new(self);
         func(&mut context)
     }
 

--- a/crates/bevy_ecs/src/world/entity_access/world_mut.rs
+++ b/crates/bevy_ecs/src/world/entity_access/world_mut.rs
@@ -16,7 +16,7 @@ use crate::{
     relationship::RelationshipHookMode,
     resource::Resource,
     storage::{SparseSets, Table},
-    template::{Template, TemplateContext},
+    template::{SceneEntityIds, Template, TemplateContext},
     world::{
         error::EntityComponentError, unsafe_world_cell::UnsafeEntityCell, ComponentEntry,
         DynamicComponentFetch, EntityMut, EntityRef, FilteredEntityMut, FilteredEntityRef, Mut,
@@ -1600,7 +1600,8 @@ impl<'w> EntityWorldMut<'w> {
         &mut self,
         func: impl FnOnce(&mut TemplateContext) -> crate::error::Result<T>,
     ) -> crate::error::Result<T> {
-        let mut context = TemplateContext::new(self);
+        let mut scene_entities = SceneEntityIds::default();
+        let mut context = TemplateContext::new(self, &mut scene_entities);
         func(&mut context)
     }
 

--- a/crates/bevy_scene/macros/src/bsn/codegen.rs
+++ b/crates/bevy_scene/macros/src/bsn/codegen.rs
@@ -670,7 +670,6 @@ impl ToTokens for BsnValue {
 mod tests {
     use super::*;
     use crate::bsn::types::*;
-    use proc_macro::Span;
     use syn::parse_quote;
 
     struct TestPaths {

--- a/crates/bevy_scene/macros/src/bsn/codegen.rs
+++ b/crates/bevy_scene/macros/src/bsn/codegen.rs
@@ -6,7 +6,7 @@ use bevy_macro_utils::{fq_std::FQDefault, path_to_string};
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote, ToTokens};
 use std::collections::{hash_map::Entry, HashMap, HashSet};
-use syn::{parse::Parse, Ident, Index, Lit, Member, Path};
+use syn::{parse::Parse, ExprTuple, Ident, Index, Lit, Member, Path};
 
 /// Tracks named entity references and assigns them unique, sequential indices
 /// during the code generation process.
@@ -58,6 +58,7 @@ impl HoistedExpressions {
 pub(crate) struct BsnCodegenCtx<'a> {
     pub bevy_scene: &'a Path,
     pub bevy_ecs: &'a Path,
+    pub invocation_index: ExprTuple,
     pub entity_refs: &'a mut EntityRefs,
     pub hoisted_expressions: &'a mut HoistedExpressions,
     /// Accumulated parsing and validation errors.
@@ -301,8 +302,9 @@ impl BsnEntry {
             }),
             BsnEntry::Name(ident) => {
                 let (name, index) = (ident.to_string(), ctx.entity_refs.get(ident.to_string()));
+                let invocation = ctx.invocation_index.clone();
                 EntryResult::CombinedSceneFunction(quote! {
-                    #bevy_scene::NameEntityReference { name: #bevy_ecs::name::Name(#name.into()), index: #index }.resolve_inline(_context, _scene);
+                    #bevy_scene::NameEntityReference { name: #bevy_ecs::name::Name(#name.into()), index: #bevy_ecs::template::SceneEntityIndex::new(#invocation, #index) }.resolve_inline(_context, _scene);
                 })
             }
             BsnEntry::NameExpression(expr) => EntryResult::CombinedSceneFunction(quote! {
@@ -533,12 +535,9 @@ impl BsnType {
             Some(BsnValue::Name(ident)) => {
                 let index = ctx.entity_refs.get(ident.to_string());
                 let bevy_ecs = ctx.bevy_ecs;
+                let invocation = ctx.invocation_index.clone();
                 assignments.push(quote! {
-                    #(#base_path.)*#member = #bevy_ecs::template::EntityTemplate::ScopedEntityIndex(
-                        #bevy_ecs::template::ScopedEntityIndex {
-                            scope: _context.current_entity_scope(), index: #index
-                        }
-                    );
+                    #(#base_path.)*#member =  #bevy_ecs::template::EntityTemplate::GlobalEntityIndex(#bevy_ecs::template::SceneEntityIndex::new(#invocation, #index));
                 });
             }
             Some(BsnValue::Type(ty)) if ty.enum_variant.is_some() => {
@@ -671,6 +670,7 @@ impl ToTokens for BsnValue {
 mod tests {
     use super::*;
     use crate::bsn::types::*;
+    use proc_macro::Span;
     use syn::parse_quote;
 
     struct TestPaths {
@@ -695,6 +695,7 @@ mod tests {
                 bevy_scene: &self.bevy_scene,
                 bevy_ecs: &self.bevy_ecs,
                 entity_refs: refs,
+                invocation_index: parse_quote!(("", 0, 0)),
                 hoisted_expressions,
                 errors: Vec::new(),
             }

--- a/crates/bevy_scene/macros/src/bsn/mod.rs
+++ b/crates/bevy_scene/macros/src/bsn/mod.rs
@@ -6,8 +6,8 @@ use codegen::*;
 use types::*;
 
 use bevy_macro_utils::BevyManifest;
-use proc_macro::TokenStream;
-use syn::parse_macro_input;
+use proc_macro::{Span, TokenStream};
+use syn::{parse_macro_input, parse_quote};
 
 pub fn bsn(input: TokenStream) -> TokenStream {
     bsn_token_stream::<BsnRoot>(input)
@@ -19,6 +19,7 @@ pub fn bsn_list(input: TokenStream) -> TokenStream {
 
 fn bsn_token_stream<T: BsnTokenStream>(input: TokenStream) -> TokenStream {
     let scene = parse_macro_input!(input as T);
+
     let (bevy_scene, bevy_ecs) = BevyManifest::shared(|manifest| {
         (
             manifest.get_path("bevy_scene"),
@@ -27,10 +28,15 @@ fn bsn_token_stream<T: BsnTokenStream>(input: TokenStream) -> TokenStream {
     });
     let mut entity_refs = EntityRefs::default();
     let mut hoisted_expressions = HoistedExpressions::default();
+    let call_site = Span::call_site();
+    let file = call_site.file();
+    let line = call_site.line();
+    let column = call_site.column();
     let mut ctx = BsnCodegenCtx {
         bevy_scene: &bevy_scene,
         bevy_ecs: &bevy_ecs,
         entity_refs: &mut entity_refs,
+        invocation_index: parse_quote!((#file, #line, #column)),
         hoisted_expressions: &mut hoisted_expressions,
         errors: Vec::new(),
     };

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -824,7 +824,7 @@ pub use spawn_system::*;
 
 use bevy_app::{App, Plugin, SceneSpawnerSystems, SpawnScene};
 use bevy_asset::AssetApp;
-use bevy_ecs::prelude::*;
+use bevy_ecs::{prelude::*, template::SceneGlobalEntityIds};
 
 /// Adds support for spawning Bevy Scenes. See [`Scene`], [`SceneList`], [`ScenePatch`], and the [`bsn!`] macro for more information.
 #[derive(Default)]
@@ -834,6 +834,7 @@ impl Plugin for ScenePlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<QueuedScenes>()
             .init_resource::<WaitingScenes>()
+            .init_resource::<SceneGlobalEntityIds>()
             .init_asset::<ScenePatch>()
             .init_asset::<SceneListPatch>()
             .add_systems(

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -824,7 +824,7 @@ pub use spawn_system::*;
 
 use bevy_app::{App, Plugin, SceneSpawnerSystems, SpawnScene};
 use bevy_asset::AssetApp;
-use bevy_ecs::{prelude::*, template::SceneGlobalEntityIds};
+use bevy_ecs::prelude::*;
 
 /// Adds support for spawning Bevy Scenes. See [`Scene`], [`SceneList`], [`ScenePatch`], and the [`bsn!`] macro for more information.
 #[derive(Default)]
@@ -834,7 +834,6 @@ impl Plugin for ScenePlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<QueuedScenes>()
             .init_resource::<WaitingScenes>()
-            .init_resource::<SceneGlobalEntityIds>()
             .init_asset::<ScenePatch>()
             .init_asset::<SceneListPatch>()
             .add_systems(

--- a/crates/bevy_scene/src/resolved_scene.rs
+++ b/crates/bevy_scene/src/resolved_scene.rs
@@ -246,15 +246,13 @@ impl ResolvedScene {
                 });
             };
             let resolved_inherited = resolved_inherited.clone();
-            let mut inherited_context =
-                TemplateContext::new(context.entity, context.scene_entities);
             // SAFETY: bundle_writer is used with the same World across all template.apply calls,
             // and the next bundle_writer.write call
             unsafe {
                 resolved_inherited
                     .scene
                     .apply_templates_without_bundle_write(
-                        &mut inherited_context,
+                        context,
                         &mut bundle_writer,
                         // this will skip building / inserting templates that
                         // have local copies in the current scene
@@ -283,11 +281,9 @@ impl ResolvedScene {
 
                 bundle_writer.write(context.entity);
 
-                let mut inherited_context =
-                    TemplateContext::new(context.entity, context.scene_entities);
                 resolved_inherited
                     .scene
-                    .apply_related(&mut inherited_context, bundle_scratch)?;
+                    .apply_related(context, bundle_scratch)?;
                 self.apply_related(context, bundle_scratch)?;
             }
         } else {

--- a/crates/bevy_scene/src/resolved_scene.rs
+++ b/crates/bevy_scene/src/resolved_scene.rs
@@ -6,7 +6,7 @@ use bevy_ecs::{
     entity::Entity,
     error::{BevyError, Result},
     relationship::{Relationship, RelationshipTarget},
-    template::{EntityScopes, ScopedEntities, ScopedEntityIndex, Template, TemplateContext},
+    template::{SceneEntityIndex, SceneEntityWorldMutExt, Template, TemplateContext},
     world::{EntityWorldMut, World},
 };
 use bevy_platform::collections::HashSet;
@@ -18,8 +18,6 @@ use thiserror::Error;
 pub struct ResolvedSceneRoot {
     /// The root [`ResolvedScene`].
     pub scene: ResolvedScene,
-    /// The [`EntityScopes`] associated with the `root` [`ResolvedScene`].
-    pub entity_scopes: EntityScopes,
 }
 
 impl ResolvedSceneRoot {
@@ -31,20 +29,16 @@ impl ResolvedSceneRoot {
         patches: &Assets<ScenePatch>,
     ) -> Result<Self, ResolveSceneError> {
         let mut resolved_scene = ResolvedScene::default();
-        let mut entity_scopes = EntityScopes::default();
         scene.resolve_box(
             &mut ResolveContext {
                 assets,
                 patches,
-                current_scope: 0,
-                entity_scopes: &mut entity_scopes,
                 inherited: None,
             },
             &mut resolved_scene,
         )?;
         Ok(ResolvedSceneRoot {
             scene: resolved_scene,
-            entity_scopes,
         })
     }
 
@@ -73,8 +67,7 @@ impl ResolvedSceneRoot {
         entity: &mut EntityWorldMut,
         bundle_scratch: &mut BundleScratch,
     ) -> Result<(), ApplySceneError> {
-        let mut scoped_entities = self.new_scoped_entities();
-        let mut context = TemplateContext::new(entity, &mut scoped_entities, &self.entity_scopes);
+        let mut context = TemplateContext::new(entity);
 
         let result = self.scene.apply(&mut context, bundle_scratch);
         if !bundle_scratch.is_empty() {
@@ -85,18 +78,12 @@ impl ResolvedSceneRoot {
         }
         result
     }
-
-    fn new_scoped_entities(&self) -> ScopedEntities {
-        ScopedEntities::new(self.entity_scopes.entity_len())
-    }
 }
 
 /// A final "spawnable" root list of [`ResolvedScene`]s. This includes the [`EntityScopes`] for the whole graph of entities.
 pub struct ResolvedSceneListRoot {
     /// The root [`ResolvedScene`] list.
     pub scenes: Vec<ResolvedScene>,
-    /// The [`EntityScopes`] associated with the `root` [`ResolvedScene`].
-    pub entity_scopes: EntityScopes,
 }
 
 impl ResolvedSceneListRoot {
@@ -108,20 +95,16 @@ impl ResolvedSceneListRoot {
         patches: &Assets<ScenePatch>,
     ) -> Result<Self, ResolveSceneError> {
         let mut resolved_scenes = Vec::new();
-        let mut entity_scopes = EntityScopes::default();
         scene_list.resolve_list_box(
             &mut ResolveContext {
                 assets,
                 patches,
-                current_scope: 0,
-                entity_scopes: &mut entity_scopes,
                 inherited: None,
             },
             &mut resolved_scenes,
         )?;
         Ok(ResolvedSceneListRoot {
             scenes: resolved_scenes,
-            entity_scopes,
         })
     }
     /// Spawns a new [`Entity`] for each [`ResolvedScene`] in the list, and applies that [`ResolvedScene`] to them.
@@ -131,17 +114,14 @@ impl ResolvedSceneListRoot {
 
     pub(crate) fn spawn_with(
         &self,
-        world: &mut World,
+        mut world: &mut World,
         func: impl Fn(&mut EntityWorldMut),
     ) -> Result<Vec<Entity>, ApplySceneError> {
         let mut entities = Vec::new();
-        let mut scoped_entities = ScopedEntities::new(self.entity_scopes.entity_len());
         let mut bundle_scratch = BundleScratch::default();
         for scene in self.scenes.iter() {
-            let mut entity = if let Some(scoped_entity_index) =
-                scene.entity_indices.first().copied()
-            {
-                let entity = scoped_entities.get(world, &self.entity_scopes, scoped_entity_index);
+            let mut entity = if let Some(entity_index) = scene.entity_indices.first().copied() {
+                let entity = world.get_global_entity(entity_index);
                 world.entity_mut(entity)
             } else {
                 world.spawn_empty()
@@ -149,10 +129,7 @@ impl ResolvedSceneListRoot {
 
             func(&mut entity);
             entities.push(entity.id());
-            let result = scene.apply(
-                &mut TemplateContext::new(&mut entity, &mut scoped_entities, &self.entity_scopes),
-                &mut bundle_scratch,
-            );
+            let result = scene.apply(&mut TemplateContext::new(&mut entity), &mut bundle_scratch);
             if let Err(err) = result {
                 // SAFETY: Components comes from the same world as the `context` passed in to self.scene.apply above
                 unsafe {
@@ -197,7 +174,7 @@ pub struct ResolvedScene {
     template_indices: TypeIdMap<usize>,
     /// A list of all [`ScopedEntityIndex`] values associated with this entity. There can be more than one if this scene uses
     /// "flattened" inheritance.
-    pub entity_indices: Vec<ScopedEntityIndex>,
+    pub entity_indices: Vec<SceneEntityIndex>,
 }
 
 impl core::fmt::Debug for ResolvedScene {
@@ -244,6 +221,11 @@ impl ResolvedScene {
         writer_ops: impl FnOnce(&mut TemplateContext, &mut BundleWriter),
     ) -> Result<(), ApplySceneError> {
         let mut bundle_writer = bundle_scratch.writer();
+        if let Some(entity_index) = self.entity_indices.first().copied() {
+            context
+                .entity
+                .set_global_entity(entity_index, context.entity.id());
+        }
         if let Some(inherited) = &self.inherited {
             let scene_patches = context.resource::<Assets<ScenePatch>>();
             let Some(patch) = scene_patches.get(&inherited.handle) else {
@@ -259,12 +241,7 @@ impl ResolvedScene {
                 });
             };
             let resolved_inherited = resolved_inherited.clone();
-            let mut inherited_scoped_entities = resolved_inherited.new_scoped_entities();
-            let mut inherited_context = TemplateContext::new(
-                context.entity,
-                &mut inherited_scoped_entities,
-                &resolved_inherited.entity_scopes,
-            );
+            let mut inherited_context = TemplateContext::new(context.entity);
             // SAFETY: bundle_writer is used with the same World across all template.apply calls,
             // and the next bundle_writer.write call
             unsafe {
@@ -300,11 +277,7 @@ impl ResolvedScene {
 
                 bundle_writer.write(context.entity);
 
-                let mut inherited_context = TemplateContext::new(
-                    context.entity,
-                    &mut inherited_scoped_entities,
-                    &resolved_inherited.entity_scopes,
-                );
+                let mut inherited_context = TemplateContext::new(context.entity);
                 resolved_inherited
                     .scene
                     .apply_related(&mut inherited_context, bundle_scratch)?;
@@ -335,16 +308,6 @@ impl ResolvedScene {
         Ok(())
     }
 
-    fn set_current_entity_in_scope(&self, context: &mut TemplateContext) {
-        if let Some(scoped_entity_index) = self.entity_indices.first().copied() {
-            context.scoped_entities.set(
-                context.entity_scopes,
-                scoped_entity_index,
-                context.entity.id(),
-            );
-        }
-    }
-
     /// # Safety
     ///
     /// `bundle_writer` must either be empty or only contain components registered with the given
@@ -355,7 +318,6 @@ impl ResolvedScene {
         bundle_writer: &mut BundleWriter,
         skip_templates: impl SkipTemplate,
     ) -> Result<(), ApplySceneError> {
-        self.set_current_entity_in_scope(context);
         for template in &self.component_templates {
             if skip_templates.should_skip((**template).type_id()) {
                 continue;
@@ -390,28 +352,19 @@ impl ResolvedScene {
             let target = context.entity.id();
             context
                 .entity
-                .world_scope(|world| -> Result<(), ApplySceneError> {
+                .world_scope(|mut world| -> Result<(), ApplySceneError> {
                     for (index, scene) in related_resolved_scenes.scenes.iter().enumerate() {
-                        let mut entity = if let Some(scoped_entity_index) =
-                            scene.entity_indices.first().copied()
-                        {
-                            let entity = context.scoped_entities.get(
-                                world,
-                                context.entity_scopes,
-                                scoped_entity_index,
-                            );
-                            world.entity_mut(entity)
-                        } else {
-                            world.spawn_empty()
-                        };
+                        let mut entity =
+                            if let Some(entity_index) = scene.entity_indices.first().copied() {
+                                let entity = world.get_global_entity(entity_index);
+                                world.entity_mut(entity)
+                            } else {
+                                world.spawn_empty()
+                            };
 
                         scene
                             .apply_with(
-                                &mut TemplateContext::new(
-                                    &mut entity,
-                                    context.scoped_entities,
-                                    context.entity_scopes,
-                                ),
+                                &mut TemplateContext::new(&mut entity),
                                 bundle_scratch,
                                 |context, bundle_writer| {
                                     // SAFETY: `context` is used to write all previous `bundle_writer` components

--- a/crates/bevy_scene/src/resolved_scene.rs
+++ b/crates/bevy_scene/src/resolved_scene.rs
@@ -6,7 +6,7 @@ use bevy_ecs::{
     entity::Entity,
     error::{BevyError, Result},
     relationship::{Relationship, RelationshipTarget},
-    template::{SceneEntityIndex, SceneEntityWorldMutExt, Template, TemplateContext},
+    template::{SceneEntityIds, SceneEntityIndex, Template, TemplateContext},
     world::{EntityWorldMut, World},
 };
 use bevy_platform::collections::HashSet;
@@ -67,7 +67,8 @@ impl ResolvedSceneRoot {
         entity: &mut EntityWorldMut,
         bundle_scratch: &mut BundleScratch,
     ) -> Result<(), ApplySceneError> {
-        let mut context = TemplateContext::new(entity);
+        let mut scene_entities = SceneEntityIds::default();
+        let mut context = TemplateContext::new(entity, &mut scene_entities);
 
         let result = self.scene.apply(&mut context, bundle_scratch);
         if !bundle_scratch.is_empty() {
@@ -114,14 +115,15 @@ impl ResolvedSceneListRoot {
 
     pub(crate) fn spawn_with(
         &self,
-        mut world: &mut World,
+        world: &mut World,
         func: impl Fn(&mut EntityWorldMut),
     ) -> Result<Vec<Entity>, ApplySceneError> {
         let mut entities = Vec::new();
+        let mut scene_entities = SceneEntityIds::default();
         let mut bundle_scratch = BundleScratch::default();
         for scene in self.scenes.iter() {
             let mut entity = if let Some(entity_index) = scene.entity_indices.first().copied() {
-                let entity = world.get_global_entity(entity_index);
+                let entity = scene_entities.get_entity(entity_index, world);
                 world.entity_mut(entity)
             } else {
                 world.spawn_empty()
@@ -129,7 +131,10 @@ impl ResolvedSceneListRoot {
 
             func(&mut entity);
             entities.push(entity.id());
-            let result = scene.apply(&mut TemplateContext::new(&mut entity), &mut bundle_scratch);
+            let result = scene.apply(
+                &mut TemplateContext::new(&mut entity, &mut scene_entities),
+                &mut bundle_scratch,
+            );
             if let Err(err) = result {
                 // SAFETY: Components comes from the same world as the `context` passed in to self.scene.apply above
                 unsafe {
@@ -172,7 +177,7 @@ pub struct ResolvedScene {
     /// A [`TypeId`] to `templates` index mapping. If a [`Template`] is intended to be shared / patched across scenes, it should be registered
     /// here.
     template_indices: TypeIdMap<usize>,
-    /// A list of all [`ScopedEntityIndex`] values associated with this entity. There can be more than one if this scene uses
+    /// A list of all [`SceneEntityIndex`] values associated with this entity. There can be more than one if this scene uses
     /// "flattened" inheritance.
     pub entity_indices: Vec<SceneEntityIndex>,
 }
@@ -223,7 +228,7 @@ impl ResolvedScene {
         let mut bundle_writer = bundle_scratch.writer();
         if let Some(entity_index) = self.entity_indices.first().copied() {
             context
-                .entity
+                .scene_entities
                 .set_global_entity(entity_index, context.entity.id());
         }
         if let Some(inherited) = &self.inherited {
@@ -241,7 +246,8 @@ impl ResolvedScene {
                 });
             };
             let resolved_inherited = resolved_inherited.clone();
-            let mut inherited_context = TemplateContext::new(context.entity);
+            let mut inherited_context =
+                TemplateContext::new(context.entity, context.scene_entities);
             // SAFETY: bundle_writer is used with the same World across all template.apply calls,
             // and the next bundle_writer.write call
             unsafe {
@@ -277,7 +283,8 @@ impl ResolvedScene {
 
                 bundle_writer.write(context.entity);
 
-                let mut inherited_context = TemplateContext::new(context.entity);
+                let mut inherited_context =
+                    TemplateContext::new(context.entity, context.scene_entities);
                 resolved_inherited
                     .scene
                     .apply_related(&mut inherited_context, bundle_scratch)?;
@@ -350,47 +357,46 @@ impl ResolvedScene {
     ) -> Result<(), ApplySceneError> {
         for related_resolved_scenes in self.related.values() {
             let target = context.entity.id();
-            context
-                .entity
-                .world_scope(|mut world| -> Result<(), ApplySceneError> {
-                    for (index, scene) in related_resolved_scenes.scenes.iter().enumerate() {
-                        let mut entity =
-                            if let Some(entity_index) = scene.entity_indices.first().copied() {
-                                let entity = world.get_global_entity(entity_index);
-                                world.entity_mut(entity)
-                            } else {
-                                world.spawn_empty()
-                            };
+            let TemplateContext {
+                entity,
+                scene_entities,
+            } = context;
+            entity.world_scope(|world| -> Result<(), ApplySceneError> {
+                for (index, scene) in related_resolved_scenes.scenes.iter().enumerate() {
+                    let mut entity =
+                        if let Some(entity_index) = scene.entity_indices.first().copied() {
+                            let entity = scene_entities.get_entity(entity_index, world);
+                            world.entity_mut(entity)
+                        } else {
+                            world.spawn_empty()
+                        };
 
-                        scene
-                            .apply_with(
-                                &mut TemplateContext::new(&mut entity),
-                                bundle_scratch,
-                                |context, bundle_writer| {
-                                    // SAFETY: `context` is used to write all previous `bundle_writer` components
-                                    // and is also used to write this relationship component
-                                    unsafe {
-                                        (related_resolved_scenes.insert_relationship)(
-                                            bundle_writer,
-                                            // SAFETY: World is only used for component registration, which does not affect
-                                            // the entity location
-                                            &mut context
-                                                .entity
-                                                .world_mut()
-                                                .components_registrator(),
-                                            target,
-                                        );
-                                    }
-                                },
-                            )
-                            .map_err(|e| ApplySceneError::RelatedSceneError {
-                                relationship_type_name: related_resolved_scenes.relationship_name,
-                                index,
-                                error: Box::new(e),
-                            })?;
-                    }
-                    Ok(())
-                })?;
+                    scene
+                        .apply_with(
+                            &mut TemplateContext::new(&mut entity, scene_entities),
+                            bundle_scratch,
+                            |context, bundle_writer| {
+                                // SAFETY: `context` is used to write all previous `bundle_writer` components
+                                // and is also used to write this relationship component
+                                unsafe {
+                                    (related_resolved_scenes.insert_relationship)(
+                                        bundle_writer,
+                                        // SAFETY: World is only used for component registration, which does not affect
+                                        // the entity location
+                                        &mut context.entity.world_mut().components_registrator(),
+                                        target,
+                                    );
+                                }
+                            },
+                        )
+                        .map_err(|e| ApplySceneError::RelatedSceneError {
+                            relationship_type_name: related_resolved_scenes.relationship_name,
+                            index,
+                            error: Box::new(e),
+                        })?;
+                }
+                Ok(())
+            })?;
         }
 
         Ok(())

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -8,9 +8,7 @@ use bevy_ecs::{
     name::Name,
     relationship::Relationship,
     system::IntoObserverSystem,
-    template::{
-        EntityScopes, FnTemplate, FromTemplate, ScopedEntityIndex, Template, TemplateContext,
-    },
+    template::{FnTemplate, FromTemplate, SceneEntityIndex, Template, TemplateContext},
 };
 use core::{any::TypeId, marker::PhantomData};
 use thiserror::Error;
@@ -176,30 +174,6 @@ pub struct ResolveContext<'a> {
     pub patches: &'a Assets<ScenePatch>,
     /// The currently inherited [`ScenePatch`], if there is one.
     pub inherited: Option<&'a ScenePatch>,
-    pub(crate) entity_scopes: &'a mut EntityScopes,
-    pub(crate) current_scope: usize,
-}
-
-impl<'a> ResolveContext<'a> {
-    /// The current entity scope.
-    #[inline]
-    pub fn current_entity_scope(&self) -> usize {
-        self.current_scope
-    }
-
-    /// Creates a new entity scope, which is active for the duration of `func`. When this function returns,
-    /// the original scope will be returned to.
-    pub fn new_entity_scope<T>(&mut self, func: impl FnOnce(&mut ResolveContext) -> T) -> T {
-        let current_scope = self.entity_scopes.add_scope();
-        let mut context = ResolveContext {
-            assets: self.assets,
-            patches: self.patches,
-            inherited: None,
-            entity_scopes: self.entity_scopes,
-            current_scope,
-        };
-        (func)(&mut context)
-    }
 }
 
 macro_rules! scene_impl {
@@ -431,24 +405,14 @@ impl<F: (Fn(&mut TemplateContext) -> Result<O>) + Clone + Send + Sync + 'static,
 pub struct NameEntityReference {
     /// The name to give this entity.
     pub name: Name,
-    /// The index (within the current "entity scope") of this entity reference.
-    pub index: usize,
+    /// The index of this entity reference.
+    pub index: SceneEntityIndex,
 }
 
 impl NameEntityReference {
     /// Resolves this reference "inline" without going through a [`Scene`] impl.
     pub fn resolve_inline(self, context: &mut ResolveContext, scene: &mut ResolvedScene) {
-        let this_index = ScopedEntityIndex {
-            scope: context.current_entity_scope(),
-            index: self.index,
-        };
-        if let Some(first_index) = scene.entity_indices.first().copied() {
-            let consolidated_index = context.entity_scopes.get(first_index).unwrap();
-            context.entity_scopes.assign(this_index, consolidated_index);
-        } else {
-            context.entity_scopes.alloc(this_index);
-        }
-        scene.entity_indices.push(this_index);
+        scene.entity_indices.push(self.index);
         let name = scene.get_or_insert_template::<Name>(context);
         *name = self.name;
     }
@@ -476,7 +440,7 @@ impl<S: Scene> Scene for SceneScope<S> {
         context: &mut ResolveContext,
         scene: &mut ResolvedScene,
     ) -> Result<(), ResolveSceneError> {
-        context.new_entity_scope(|context| self.0.resolve(context, scene))
+        self.0.resolve(context, scene)
     }
 
     fn register_dependencies(&self, dependencies: &mut SceneDependencies) {
@@ -495,7 +459,7 @@ impl<L: SceneList> SceneList for SceneListScope<L> {
         context: &mut ResolveContext,
         scenes: &mut Vec<ResolvedScene>,
     ) -> Result<(), ResolveSceneError> {
-        context.new_entity_scope(|context| self.0.resolve_list(context, scenes))
+        self.0.resolve_list(context, scenes)
     }
 
     fn register_dependencies(&self, dependencies: &mut SceneDependencies) {


### PR DESCRIPTION
# Objective

Currently, `#Name` references are quite limited due to the fact they cannot be passed to `-> impl Scene` functions or SceneComponent Props.

I investigated trying to make it work anyways in this branch: https://github.com/bevyengine/bevy/compare/main...laundmo:bevy:bsn-hacky-name-passing which kept being stuck at the limitations of the scoped nature of how `#Name` references are resolved.

After discussing this with @cart in the Next Generation Scenes working goup thread on discord, I decided to go ahead and see what a basic implementation of this might look like.

## Solution

This PR is a first step towards a more flexible implementation, relying on globally unique entity indices. This should allow for updating the bsn macro(s) to allow passing these indices into `-> impl Scene`/`@props` in the future.

In this initial state, the indices consist of `(filename, line, column, local)` with the first 3 uniquely identifying a `bsn!` call, and `local` being a counter for names within that macro invocation (this was kept from the previous scoped approach).

There is a new resource for storing a mapping from these global indices to the corresponding Entity. One optimization already applied here is to store a `PreHashMap<Hashed<T>>`, a `HashMap` acting on pre-hashed keys. My hope is that this allows most of the hashing to be done at compile time.

TODO:
- [ ] Decide on better names for some of the new types and functions
- [ ] Write comments explaining how the less intuitive parts of this work
- [ ] Write documentation for items missing it
- [ ] Test on more complex applications which repeatedly spawn and despawn scenes
- [x] Come up with some idea on how to clean up the `SceneGlobalEntityIds` resource so it doesn't keep growing continously
  - perhaps by not making it a resource at all. Its not really necessary to persist the map for a scene after that scene is spawned, this was just the first thing i could think of. ~~Reconsidering later: I'm not sure how this interacts with patching a scene after its spawned.~~ cart confirmed its not something to worry about right now, and i misread the code i thought would be doing that
- [ ] Pass CI

## Testing

- [x] `cargo test -p bevy_scene --lib`
- [x] `cargo run --example feathers_gallery --features=bevy_feathers`
- [ ] Benchmark spawn performance of scenes before and after this PR, especially for large scenes with many `#Name` references. Maybe #24057 could work for this.


`## Showcase`: Since this PR should act the same, and the only user-facing changes are related to scene spawning innards, i don't think theres anything to benchmark here.