### PR TITLE
Expose more functionality of RenderVisibleEntitiesClass as public.

### DIFF
--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -100,7 +100,7 @@ pub struct RenderVisibleEntitiesClass {
 
     /// A sorted list of all entities that were invisible last frame (including
     /// ones that didn't exist at all last frame) and became visible this frame.
-    added_entities: Vec<(Entity, MainEntity)>,
+    pub added_entities: Vec<(Entity, MainEntity)>,
 
     /// A sorted list of all entities that were visible last frame and became
     /// invisible this frame, including those that were despawned this frame.
@@ -179,7 +179,7 @@ impl RenderVisibleEntities {
 impl RenderVisibleEntitiesClass {
     /// Clears out the lists of added and removed entities in preparation for a
     /// new frame.
-    fn prepare_for_new_frame(&mut self) {
+    pub fn prepare_for_new_frame(&mut self) {
         self.added_entities.clear();
         self.removed_entities.clear();
     }
@@ -191,7 +191,7 @@ impl RenderVisibleEntitiesClass {
     /// have `NoCpuCulling` components). Entities that use only GPU culling are
     /// instead fetched from the main world and added to the
     /// `RenderGpuCulledEntities` table.
-    fn update_cpu_culled_entities(
+    pub fn update_cpu_culled_entities(
         &mut self,
         visible_mesh_entities_cpu_culling: &[(Entity, MainEntity)],
     ) {


### PR DESCRIPTION
# Objective

Encountered while porting the bevy_mod_outline ecosystem crate to Bevy _0.19_:

The outline effects have a different visual extent to the geometry of the meshes they decorate. Hence, I need to manage outline visibility separate from Bevy's own visibility system. I would like to use `DirtySpecialization` in my custom rendering phase as suggested by the draft migration guide, but its API depends on supplying a `RenderVisibleEntitiesClass`. The methods (and one field) of this type are non-public so my own visibility system cannot manufacture one. 

## Solution

- Expose added_entities, prepare_for_new_frame(), and update_cpu_culled_entities() as public.

## Testing

- Check Bevy builds and members are accessible from a dependent crate.