### PR TITLE
Return `Result` when creating a contiguous iterator

### DIFF
--- a/crates/bevy_ecs/src/query/error.rs
+++ b/crates/bevy_ecs/src/query/error.rs
@@ -36,6 +36,12 @@ pub enum QuerySingleError {
     MultipleEntities(DebugName),
 }
 
+/// An error that occurs when creating a contiguous iterator from a non-dense [`Query`](crate::system::Query) or [`QueryState`](crate::query::QueryState) via
+/// [`contiguous_iter`](crate::system::Query::contiguous_iter) or [`contiguous_iter_mut`](crate::system::Query::contiguous_iter_mut).
+#[derive(Debug, thiserror::Error)]
+#[error("Cannot contiguously iterate non-dense query {0}")]
+pub struct QueryNotDenseError(pub DebugName);
+
 #[cfg(test)]
 mod test {
     use crate::{prelude::World, query::QueryEntityError};

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -4400,7 +4400,7 @@ mod tests {
 
         let mut query = world.query::<&mut S>();
         let iter = query.contiguous_iter_mut(&mut world);
-        assert!(iter.is_none());
+        assert!(iter.is_err());
     }
 
     #[test]

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -7,8 +7,8 @@ use crate::{
     prelude::FromWorld,
     query::{
         ArchetypeFilter, ContiguousQueryData, FilteredAccess, FilteredAccessSet, IterQueryData,
-        QueryCombinationIter, QueryContiguousIter, QueryIter, QueryParIter, SingleEntityQueryData,
-        WorldQuery,
+        QueryCombinationIter, QueryContiguousIter, QueryIter, QueryNotDenseError, QueryParIter,
+        SingleEntityQueryData, WorldQuery,
     },
     storage::TableId,
     system::Query,
@@ -1473,21 +1473,21 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
         self.query_mut(world).par_iter_inner()
     }
 
-    /// Returns a contiguous iterator over the query results for the given [`World`] or [`None`] if
+    /// Returns a contiguous iterator over the query results for the given [`World`] or [`Err`] with [`QueryNotDenseError`] if
     /// the query is not dense hence not contiguously iterable.
     #[inline]
     pub fn contiguous_iter<'w, 's>(
         &'s mut self,
         world: &'w World,
-    ) -> Option<QueryContiguousIter<'w, 's, D::ReadOnly, F>>
+    ) -> Result<QueryContiguousIter<'w, 's, D::ReadOnly, F>, QueryNotDenseError>
     where
         D::ReadOnly: ContiguousQueryData,
         F: ArchetypeFilter,
     {
-        self.query(world).contiguous_iter_inner().ok()
+        self.query(world).contiguous_iter_inner()
     }
 
-    /// Returns a contiguous iterator over the query results for the given [`World`] or [`None`] if
+    /// Returns a contiguous iterator over the query results for the given [`World`] or [`Err`] with [`QueryNotDenseError`] if
     /// the query is not dense hence not contiguously iterable.
     ///
     /// This can only be called for mutable queries, see [`Self::contiguous_iter`] for read-only-queries.
@@ -1495,12 +1495,12 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
     pub fn contiguous_iter_mut<'w, 's>(
         &'s mut self,
         world: &'w mut World,
-    ) -> Option<QueryContiguousIter<'w, 's, D, F>>
+    ) -> Result<QueryContiguousIter<'w, 's, D, F>, QueryNotDenseError>
     where
         D: ContiguousQueryData,
         F: ArchetypeFilter,
     {
-        self.query_mut(world).contiguous_iter_inner().ok()
+        self.query_mut(world).contiguous_iter_inner()
     }
 
     /// Runs `func` on each query result in parallel for the given [`World`], where the last change and

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -7,9 +7,9 @@ use crate::{
     query::{
         ArchetypeFilter, ContiguousQueryData, DebugCheckedUnwrap, IterQueryData, NopWorldQuery,
         QueryCombinationIter, QueryContiguousIter, QueryData, QueryEntityError, QueryFilter,
-        QueryIter, QueryManyIter, QueryManyUniqueIter, QueryParIter, QueryParManyIter,
-        QueryParManyUniqueIter, QuerySingleError, QueryState, ROQueryItem, ReadOnlyQueryData,
-        SingleEntityQueryData,
+        QueryIter, QueryManyIter, QueryManyUniqueIter, QueryNotDenseError, QueryParIter,
+        QueryParManyIter, QueryParManyUniqueIter, QuerySingleError, QueryState, ROQueryItem,
+        ReadOnlyQueryData, SingleEntityQueryData,
     },
     world::unsafe_world_cell::UnsafeWorldCell,
 };
@@ -1438,7 +1438,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     }
 
     /// Returns a contiguous iterator over the query results for the given
-    /// [`World`](crate::world::World) or [`None`] if the query is not dense hence not contiguously
+    /// [`World`](crate::world::World) or [`Err`] with [`QueryNotDenseError`] if the query is not dense hence not contiguously
     /// iterable.
     ///
     /// Contiguous iteration enables getting slices of contiguously lying components (which lie in the same table), which for example
@@ -1469,16 +1469,18 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     /// ```
     ///
     /// A mutable version: [`Self::contiguous_iter_mut`]
-    pub fn contiguous_iter(&self) -> Option<QueryContiguousIter<'_, 's, D::ReadOnly, F>>
+    pub fn contiguous_iter(
+        &self,
+    ) -> Result<QueryContiguousIter<'_, 's, D::ReadOnly, F>, QueryNotDenseError>
     where
         D::ReadOnly: ContiguousQueryData,
         F: ArchetypeFilter,
     {
-        self.as_readonly().contiguous_iter_inner().ok()
+        self.as_readonly().contiguous_iter_inner()
     }
 
     /// Returns a mutable contiguous iterator over the query results for the given
-    /// [`World`](crate::world::World) or [`None`] if the query is not dense hence not contiguously
+    /// [`World`](crate::world::World) or [`Err`] with [`QueryNotDenseError`] if the query is not dense hence not contiguously
     /// iterable.
     ///
     /// Contiguous iteration enables getting slices of contiguously lying components (which lie in the same table), which for example
@@ -1510,19 +1512,23 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     /// }
     /// ```
     /// An immutable version: [`Self::contiguous_iter`]
-    pub fn contiguous_iter_mut(&mut self) -> Option<QueryContiguousIter<'_, 's, D, F>>
+    pub fn contiguous_iter_mut(
+        &mut self,
+    ) -> Result<QueryContiguousIter<'_, 's, D, F>, QueryNotDenseError>
     where
         D: ContiguousQueryData,
         F: ArchetypeFilter,
     {
-        self.reborrow().contiguous_iter_inner().ok()
+        self.reborrow().contiguous_iter_inner()
     }
 
     /// Returns a contiguous iterator over the query results for the given
-    /// [`World`](crate::world::World) or [`Err`] with this [`Query`] if the query is not dense hence not contiguously
+    /// [`World`](crate::world::World) or [`Err`] with [`QueryNotDenseError`] if the query is not dense hence not contiguously
     /// iterable.
     /// This consumes the [`Query`] to return results with the actual "inner" world lifetime.
-    pub fn contiguous_iter_inner(self) -> Result<QueryContiguousIter<'w, 's, D, F>, Self>
+    pub fn contiguous_iter_inner(
+        self,
+    ) -> Result<QueryContiguousIter<'w, 's, D, F>, QueryNotDenseError>
     where
         D: ContiguousQueryData,
         F: ArchetypeFilter,
@@ -1531,7 +1537,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
         // - `self.world` has permission to access the required components
         // - `self.world` was used to initialize `self.state`
         unsafe { QueryContiguousIter::new(self.world, self.state, self.last_run, self.this_run) }
-            .ok_or(self)
+            .ok_or(QueryNotDenseError(DebugName::type_name::<Self>()))
     }
 
     /// Returns the read-only query item for the given [`Entity`].


### PR DESCRIPTION
# Objective

When `contiguous_iter{,_mut}` was introduced in https://github.com/bevyengine/bevy/pull/21984, the API returns an `Option<T>` value. A `Result<T, E>` value should be a more natural choice for this type of fallible API.

This also has the ergonomic benefit of being able to use the `?` operator in fallible systems.

## Solution

Change it so that `contiguous_iter{,_mut}` returns a `Result<_, QueryNotDenseError>`.

## Testing

- Did you test these changes? If so, how?

  I tried to run the tests, but I got the following error:
  ```rust
  fatal runtime error: failed to initiate panic, error 5, aborting
  error: test failed, to rerun pass `-p bevy_ecs --lib`
  ```
  My changes are fairly minimal, so I can't imagine that this was caused by my PR. But I'll have to run the test directly on the CI for now, if you guys don't mind.
- How can other people (reviewers) test your changes? Is there anything specific they need to know?

  `cargo test -p bevy_ecs`