### PR TITLE
Collapse selection on text focus lost

### DIFF
--- a/crates/bevy_ui_widgets/src/text_input.rs
+++ b/crates/bevy_ui_widgets/src/text_input.rs
@@ -443,6 +443,16 @@ fn on_focus_lost_clear_ime(
     }
 }
 
+/// Observer that collapses the selection of [`EditableText`] when it loses focus.
+fn on_focus_lost_collapse_selection(
+    trigger: On<FocusLost>,
+    mut q_text_input: Query<&mut EditableText>,
+) {
+    if let Ok(mut editable_text) = q_text_input.get_mut(trigger.entity) {
+        editable_text.queue_edit(TextEdit::CollapseSelection);
+    }
+}
+
 /// Marker component for [`EditableText`] widgets that should select all text on focus.
 ///
 /// If a pointer press is what caused the focus, the select all is deferred until
@@ -539,6 +549,7 @@ impl Plugin for EditableTextInputPlugin {
             .add_observer(on_pointer_drag)
             .add_observer(on_pointer_press)
             .add_observer(on_focus_lost_clear_ime)
+            .add_observer(on_focus_lost_collapse_selection)
             .add_observer(on_focus_select_all)
             .add_observer(on_pointer_click)
             .add_systems(


### PR DESCRIPTION
# Objective
Currently it can happen that text selection remains when the `EditableText` loses focus, which should not be the case. I say "can", because it's not consistent across bevy builds. I originally included this part in #23969, but after some changes noticed that it wasn't necessary anymore and removed it. However, in my own project it started happening again.

## Solution
Introduce a new observer `on_focus_lost_collapse_selection`.

This does solve it seemingly, but that could be, because it changes the bevy build and not because it's an actual fix. It would be better to find out why on some builds it works without this fix. It could be related to `on_focus_lost_clear_ime`, which is right above the new function `on_focus_lost_collapse_selection`, but I'm not sure.

## Testing
Tested on my own project.