### PR TITLE
Support all text styles for text input

### DIFF
--- a/crates/bevy_ui/src/widget/text_input_layout.rs
+++ b/crates/bevy_ui/src/widget/text_input_layout.rs
@@ -202,6 +202,9 @@ pub fn update_editable_text_styles(
             style_set.insert(StyleProperty::FontFeatures(
                 (&text_font.font_features).into(),
             ));
+            style_set.insert(StyleProperty::FontVariations(
+                (&text_font.font_variations).into(),
+            ));
             style_set.insert(StyleProperty::Brush(TextBrush::new(
                 0,
                 text_font.font_smoothing,

--- a/crates/bevy_ui/src/widget/text_input_layout.rs
+++ b/crates/bevy_ui/src/widget/text_input_layout.rs
@@ -196,6 +196,12 @@ pub fn update_editable_text_styles(
             let family = font_family.into_owned();
             let style_set = editable_text.editor.edit_styles();
             style_set.insert(StyleProperty::FontFamily(family));
+            style_set.insert(StyleProperty::FontWeight(text_font.weight.into()));
+            style_set.insert(StyleProperty::FontWidth(text_font.width.into()));
+            style_set.insert(StyleProperty::FontStyle(text_font.style.into()));
+            style_set.insert(StyleProperty::FontFeatures(
+                (&text_font.font_features).into(),
+            ));
             style_set.insert(StyleProperty::Brush(TextBrush::new(
                 0,
                 text_font.font_smoothing,


### PR DESCRIPTION
# Objective
Current text inputs do not apply all styles set in `TextFont` to their text.

## Solution
Set the missing text styles in `update_editable_text_styles`.

## Testing
Tested in my own non-public project. If desired I can write or extend an existing example to showcase.
