### PR TITLE
bevy_input_focus: gate reflect use by bevy_reflect

### DIFF
--- a/crates/bevy_input_focus/src/gained_and_lost.rs
+++ b/crates/bevy_input_focus/src/gained_and_lost.rs
@@ -3,6 +3,7 @@
 
 use super::InputFocus;
 use bevy_ecs::prelude::*;
+#[cfg(feature = "bevy_reflect")]
 use bevy_reflect::Reflect;
 
 /// The cause for a [`FocusGained`]
@@ -10,7 +11,8 @@ use bevy_reflect::Reflect;
 /// Sometimes widgets would like to know how their focus was gained so they can act accordingly.
 ///
 /// For example, a text input may want to select all text when navigated into, but not when pressed.
-#[derive(Reflect, PartialEq, Eq, Debug, Clone, Copy)]
+#[derive(PartialEq, Eq, Debug, Clone, Copy)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
 pub enum FocusCause {
     /// The input was navigated into by the keyboard, gamepad, or default behavior when unknown.
     Navigated,


### PR DESCRIPTION
# Objective

- bevy_input_focus reflect `FocusCause` without gating it by bevy_reflect

## Solution

- Gate it

## Testing

- CI