### PR TITLE
bevy_clipboard: expect derivable default lint on some platform/feature combinations

### DIFF
--- a/crates/bevy_clipboard/src/lib.rs
+++ b/crates/bevy_clipboard/src/lib.rs
@@ -204,6 +204,13 @@ pub struct Clipboard {
     text: String,
 }
 
+#[cfg_attr(
+    not(all(any(unix, windows), feature = "system_clipboard")),
+    expect(
+        clippy::derivable_impls,
+        reason = "non-derivable on unix/windows with system_clipboard"
+    )
+)]
 impl Default for Clipboard {
     fn default() -> Self {
         Self {


### PR DESCRIPTION
# Objective

- bevy_clipboard triggers a derivable default lint
- `cargo clippy -p bevy_clipboard  --no-deps -- -D warnings`
- this is because `system_clipboard` is gated by platofrms/features

## Solution

- Gate it

## Testing

- CI