### PR TITLE
bevy_asset: don't expect large error in wasm

### DIFF
--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -292,9 +292,12 @@ impl ErasedLoadedAsset {
 
     /// Cast this loaded asset as the given type. If the type does not match,
     /// the original type-erased asset is returned.
-    #[expect(
-        clippy::result_large_err,
-        reason = "Returning the passed in ErasedLoadedAsset"
+    #[cfg_attr(
+        not(target_arch = "wasm32"),
+        expect(
+            clippy::result_large_err,
+            reason = "Returning the passed in ErasedLoadedAsset"
+        )
     )]
     pub fn downcast<A: Asset>(mut self) -> Result<LoadedAsset<A>, ErasedLoadedAsset> {
         match self.value.downcast::<A>() {

--- a/crates/bevy_asset/src/loader_builders.rs
+++ b/crates/bevy_asset/src/loader_builders.rs
@@ -330,9 +330,12 @@ impl<'ctx, 'builder> NestedLoadBuilder<'ctx, 'builder> {
 
     /// Same as [`Self::load_value_internal`], but with a generic to ensure the returned handle type
     /// is correct.
-    #[expect(
-        clippy::result_large_err,
-        reason = "we need to give the user the correct error type"
+    #[cfg_attr(
+        not(target_arch = "wasm32"),
+        expect(
+            clippy::result_large_err,
+            reason = "we need to give the user the correct error type"
+        )
     )]
     async fn load_typed_value_internal<A: Asset>(
         self,


### PR DESCRIPTION
# Objective

- `cargo clippy --target wasm32-unknown-unknown -p bevy_asset --no-deps -- -D warnings`
- `clippy::result_large_err` is not triggered in wasm
- `ErasedLoadedAsset` is not too big in wasm 🤷 

## Solution

- gate the expect

## Testing

- CI