### PR TITLE
bevy_world_serialization: always use TypeRegistry

### DIFF
--- a/crates/bevy_world_serialization/src/dynamic_world.rs
+++ b/crates/bevy_world_serialization/src/dynamic_world.rs
@@ -6,13 +6,13 @@ use bevy_ecs::{
     reflect::{AppTypeRegistry, ReflectComponent},
     world::World,
 };
-use bevy_reflect::{PartialReflect, TypePath};
+use bevy_reflect::{PartialReflect, TypePath, TypeRegistry};
 
 use bevy_ecs::component::ComponentCloneBehavior;
 use bevy_ecs::relationship::RelationshipHookMode;
 
 #[cfg(feature = "serialize")]
-use {crate::serde::DynamicWorldSerializer, bevy_reflect::TypeRegistry, serde::Serialize};
+use {crate::serde::DynamicWorldSerializer, serde::Serialize};
 
 /// A collection of serializable resources and dynamic entities.
 ///


### PR DESCRIPTION
# Objective

- `cargo build -p bevy_world_serialization --no-default-features`
- `TypeRegistry` is used as a parameter to `DynamicWorld::from_world_asset` but its import is gated by `serialize`

## Solution

- Ungate it

## Testing

- CI