### PR TITLE
bevy_input: enable touch mod with the mouse feature

### DIFF
--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -34,7 +34,8 @@ pub mod keyboard;
 #[cfg(feature = "mouse")]
 pub mod mouse;
 
-#[cfg(feature = "touch")]
+// Also enabled with `mouse` because `MouseWheel` reuses `TouchPhase` for trackpad scroll phases.
+#[cfg(any(feature = "touch", feature = "mouse"))]
 pub mod touch;
 
 pub use axis::*;


### PR DESCRIPTION
# Objective

- `cargo build --no-default-features --features mouse`
- mouse use `TouchPhase` from touch, but touch is behind a different feature

## Solution

- Gate it correctly

## Testing

- CI