### PR TITLE
bevy_settings: wasm clippy

### DIFF
--- a/crates/bevy_settings/src/store_wasm.rs
+++ b/crates/bevy_settings/src/store_wasm.rs
@@ -33,7 +33,7 @@ impl PreferencesStore {
         if let Ok(Some(storage)) = window().unwrap().local_storage() {
             let toml_str = contents.to_string();
             storage
-                .set_item(&self.storage_key(filename).as_str(), &toml_str)
+                .set_item(self.storage_key(filename).as_str(), &toml_str)
                 .unwrap();
         }
     }
@@ -49,7 +49,7 @@ impl PreferencesStore {
                 if let Ok(Some(storage)) = window().unwrap().local_storage() {
                     let toml_str = contents.to_string();
                     storage
-                        .set_item(&self.storage_key(filename).as_str(), &toml_str)
+                        .set_item(self.storage_key(filename).as_str(), &toml_str)
                         .unwrap();
                 }
             });


### PR DESCRIPTION
# Objective

- `cargo clippy --target wasm32-unknown-unknown -p bevy_settings --no-deps -- -D warnings`
- Complains about `clippy::needless_borrow`

## Solution

- Fix it

## Testing

- CI