### PR TITLE
`impl Default` for `Outline`

### DIFF
--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -2312,7 +2312,7 @@ impl Default for BorderColor {
     }
 }
 
-#[derive(Component, Copy, Clone, Default, Debug, PartialEq, Reflect)]
+#[derive(Component, Copy, Clone, Debug, PartialEq, Reflect)]
 #[reflect(Component, Default, Debug, PartialEq, Clone)]
 #[cfg_attr(
     feature = "serialize",
@@ -2389,6 +2389,16 @@ impl Outline {
             width,
             offset,
             color,
+        }
+    }
+}
+
+impl Default for Outline {
+    fn default() -> Self {
+        Self {
+            color: Color::WHITE,
+            width: Val::Px(1.),
+            offset: Val::Px(0.),
         }
     }
 }


### PR DESCRIPTION
# Objective

`Outline` derives `Default` which means that outlines added to a UI node aren't visible unless you set an explicit width. Generally, if you don't want `Outline`s to be visible it's better to either set their `color` to `Color::NONE` or remove the `Outline` component completely, not change the width. `Outline`s are often used during debugging, and it's very easy to leave the width unset and convince yourself the missing outline is due to a bug.

## Solution

Remove the `Default` derive, and add an explicit `impl Default` with `width` set to `Val::Px(1.)`.
