### PR TITLE
Fix: Send `CurrentView`/ `PointAndSpotLightShadowPrimaryCamera` ’s world position via Immediates for gpu vis range culling

### DIFF
--- a/crates/bevy_pbr/src/render/gpu_preprocess.rs
+++ b/crates/bevy_pbr/src/render/gpu_preprocess.rs
@@ -1194,6 +1194,9 @@ impl PreprocessPipelines {
             GpuPreprocessingMode::None => false,
             GpuPreprocessingMode::PreprocessingOnly => {
                 self.direct_preprocess.is_loaded(pipeline_cache)
+                    && self
+                        .gpu_frustum_culling_preprocess
+                        .is_loaded(pipeline_cache)
             }
             GpuPreprocessingMode::Culling => {
                 self.direct_preprocess.is_loaded(pipeline_cache)

--- a/crates/bevy_pbr/src/render/gpu_preprocess.rs
+++ b/crates/bevy_pbr/src/render/gpu_preprocess.rs
@@ -961,7 +961,10 @@ pub fn late_gpu_preprocess(
 
         // Transform and cull indexed meshes if there are any.
         if let Some(late_indexed_bind_group) = maybe_late_indexed_bind_group {
-            compute_pass.set_immediates(0, bytemuck::bytes_of(late_indirect_parameters_indexed_offset));
+            compute_pass.set_immediates(
+                0,
+                bytemuck::bytes_of(late_indirect_parameters_indexed_offset),
+            );
 
             compute_pass.set_bind_group(0, late_indexed_bind_group, &dynamic_offsets);
             compute_pass.dispatch_workgroups_indirect(
@@ -973,7 +976,10 @@ pub fn late_gpu_preprocess(
 
         // Transform and cull non-indexed meshes if there are any.
         if let Some(late_non_indexed_bind_group) = maybe_late_non_indexed_bind_group {
-            compute_pass.set_immediates(0, bytemuck::bytes_of(late_indirect_parameters_non_indexed_offset));
+            compute_pass.set_immediates(
+                0,
+                bytemuck::bytes_of(late_indirect_parameters_non_indexed_offset),
+            );
 
             compute_pass.set_bind_group(0, late_non_indexed_bind_group, &dynamic_offsets);
             compute_pass.dispatch_workgroups_indirect(

--- a/crates/bevy_pbr/src/render/gpu_preprocess.rs
+++ b/crates/bevy_pbr/src/render/gpu_preprocess.rs
@@ -961,10 +961,7 @@ pub fn late_gpu_preprocess(
 
         // Transform and cull indexed meshes if there are any.
         if let Some(late_indexed_bind_group) = maybe_late_indexed_bind_group {
-            compute_pass.set_immediates(
-                0,
-                bytemuck::bytes_of(late_indirect_parameters_indexed_offset),
-            );
+            compute_pass.set_immediates(0, bytemuck::bytes_of(late_indirect_parameters_indexed_offset));
 
             compute_pass.set_bind_group(0, late_indexed_bind_group, &dynamic_offsets);
             compute_pass.dispatch_workgroups_indirect(
@@ -976,10 +973,7 @@ pub fn late_gpu_preprocess(
 
         // Transform and cull non-indexed meshes if there are any.
         if let Some(late_non_indexed_bind_group) = maybe_late_non_indexed_bind_group {
-            compute_pass.set_immediates(
-                0,
-                bytemuck::bytes_of(late_indirect_parameters_non_indexed_offset),
-            );
+            compute_pass.set_immediates(0, bytemuck::bytes_of(late_indirect_parameters_non_indexed_offset));
 
             compute_pass.set_bind_group(0, late_non_indexed_bind_group, &dynamic_offsets);
             compute_pass.dispatch_workgroups_indirect(
@@ -1188,9 +1182,6 @@ impl PreprocessPipelines {
             GpuPreprocessingMode::None => false,
             GpuPreprocessingMode::PreprocessingOnly => {
                 self.direct_preprocess.is_loaded(pipeline_cache)
-                    && self
-                        .gpu_frustum_culling_preprocess
-                        .is_loaded(pipeline_cache)
             }
             GpuPreprocessingMode::Culling => {
                 self.direct_preprocess.is_loaded(pipeline_cache)

--- a/crates/bevy_pbr/src/render/gpu_preprocess.rs
+++ b/crates/bevy_pbr/src/render/gpu_preprocess.rs
@@ -660,10 +660,16 @@ pub fn early_gpu_preprocess(
         };
         // Set the camera position that will be used for visibility range culling.
         let cur_view_world_position = if !has_non_root_view {
+            // Directional light shadows are made via cascaded shadow maps.
+            // These cascades are unique to each camera view (see RetainedViewEntity).
+            // For directional light shadows, the world position of the associated camera
+            // should be used for visibility range culling, not the world position of the shadow camera.
+            // The `CurrentView`'s `ExtractedView` contains the associated camera's world position.
             extracted_view.world_from_view.translation().to_array()
         } else {
+            // PointLight and SpotLight shadow views are handled in this else block.
             // TODO: We need to better handle this case.
-            // As written, point and spot lights shadows will just use the first user camera
+            // As written, point and spot lights shadow views will just use the first user camera
             // that is returned by the query.
             // If there is only one user camera, this is fine, but for multiple user cameras,
             // only one of them is randomly used for visibility range culling.

--- a/crates/bevy_pbr/src/render/gpu_preprocess.rs
+++ b/crates/bevy_pbr/src/render/gpu_preprocess.rs
@@ -876,7 +876,6 @@ pub fn late_gpu_preprocess(
 ) {
     let (view, bind_groups, view_uniform_offset) = current_view.into_inner();
 
-    let cur_view_world_position = view.world_from_view.translation().to_array();
     // Fetch the pipeline BEFORE starting diagnostic spans to avoid panic on early return
     let maybe_pipeline_id = preprocess_pipelines
         .late_gpu_occlusion_culling_preprocess
@@ -962,11 +961,10 @@ pub fn late_gpu_preprocess(
 
         // Transform and cull indexed meshes if there are any.
         if let Some(late_indexed_bind_group) = maybe_late_indexed_bind_group {
-            let immediates = PreprocessImmediates {
-                cur_view_world_position,
-                late_preprocess_work_item_indirect_offset: *late_indirect_parameters_indexed_offset,
-            };
-            compute_pass.set_immediates(0, bytemuck::bytes_of(&immediates));
+            compute_pass.set_immediates(
+                0,
+                bytemuck::bytes_of(late_indirect_parameters_indexed_offset),
+            );
 
             compute_pass.set_bind_group(0, late_indexed_bind_group, &dynamic_offsets);
             compute_pass.dispatch_workgroups_indirect(
@@ -978,12 +976,10 @@ pub fn late_gpu_preprocess(
 
         // Transform and cull non-indexed meshes if there are any.
         if let Some(late_non_indexed_bind_group) = maybe_late_non_indexed_bind_group {
-            let immediates = PreprocessImmediates {
-                cur_view_world_position,
-                late_preprocess_work_item_indirect_offset:
-                    *late_indirect_parameters_non_indexed_offset,
-            };
-            compute_pass.set_immediates(0, bytemuck::bytes_of(&immediates));
+            compute_pass.set_immediates(
+                0,
+                bytemuck::bytes_of(late_indirect_parameters_non_indexed_offset),
+            );
 
             compute_pass.set_bind_group(0, late_non_indexed_bind_group, &dynamic_offsets);
             compute_pass.dispatch_workgroups_indirect(

--- a/crates/bevy_pbr/src/render/gpu_preprocess.rs
+++ b/crates/bevy_pbr/src/render/gpu_preprocess.rs
@@ -18,7 +18,7 @@ use bevy_core_pipeline::{
         DeferredPrepass, DepthPrepass, MotionVectorPrepass, NormalPrepass, PreviousViewData,
         PreviousViewUniformOffset, PreviousViewUniforms,
     },
-    schedule::{Core3d, Core3dSystems},
+    schedule::{Core3d, Core3dSystems, RootNonCameraView},
 };
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
@@ -45,6 +45,7 @@ use bevy_render::{
         PreprocessWorkItemBuffers, UntypedPhaseBatchedInstanceBuffers,
         UntypedPhaseIndirectParametersBuffers,
     },
+    camera::ExtractedCamera,
     diagnostic::RecordDiagnostics as _,
     occlusion_culling::OcclusionCulling,
     render_phase::GpuRenderBinnedMeshInstance,
@@ -69,6 +70,7 @@ use bevy_render::{
 use bevy_shader::Shader;
 use bevy_utils::{default, TypeIdMap};
 use bitflags::bitflags;
+use bytemuck::{Pod, Zeroable};
 use smallvec::{smallvec, SmallVec};
 use tracing::warn;
 
@@ -291,7 +293,7 @@ pub enum PhasePreprocessBindGroups {
     },
 
     /// The bind groups used for the compute shader when indirect drawing is
-    /// being used, but occlusion culling isn't being used.
+    /// being used and occlusion culling is being used.
     ///
     /// Because indirect drawing requires splitting the meshes into indexed and
     /// non-indexed meshes, and because occlusion culling requires splitting
@@ -311,6 +313,13 @@ pub enum PhasePreprocessBindGroups {
         /// preprocessing phase.
         late_non_indexed: Option<BindGroup>,
     },
+}
+
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+struct PreprocessImmediates {
+    cur_view_world_position: [f32; 3],
+    late_preprocess_work_item_indirect_offset: u32,
 }
 
 /// The bind groups for the compute shaders that reset indirect draw counts and
@@ -600,7 +609,15 @@ pub fn unpack_bins(
 }
 
 pub fn early_gpu_preprocess(
-    current_view: ViewQuery<Option<&ViewLightEntities>, Without<SkipGpuPreprocess>>,
+    current_view: ViewQuery<
+        (
+            Option<&ViewLightEntities>,
+            &ExtractedView,
+            Has<RootNonCameraView>,
+        ),
+        Without<SkipGpuPreprocess>,
+    >,
+    camera_views: Query<&ExtractedView, (With<ExtractedCamera>, Without<SkipGpuPreprocess>)>,
     view_query: Query<
         (
             &ExtractedView,
@@ -630,7 +647,7 @@ pub fn early_gpu_preprocess(
     let pass_span = diagnostics.pass_span(&mut compute_pass, "early_mesh_preprocessing");
 
     let view_entity = current_view.entity();
-    let shadow_cascade_views = current_view.into_inner();
+    let (shadow_cascade_views, extracted_view, has_non_root_view) = current_view.into_inner();
     let all_views =
         gather_shadow_cascades_for_view(view_entity, shadow_cascade_views, &light_query);
 
@@ -640,6 +657,23 @@ pub fn early_gpu_preprocess(
             view_query.get(view_entity)
         else {
             continue;
+        };
+        // Set the camera position that will be used for visibility range culling.
+        let cur_view_world_position = if !has_non_root_view {
+            extracted_view.world_from_view.translation().to_array()
+        } else {
+            // TODO: We need to better handle this case.
+            // As written, point and spot lights shadows will just use the first user camera
+            // that is returned by the query.
+            // If there is only one user camera, this is fine, but for multiple user cameras,
+            // only one of them is randomly used for visibility range culling.
+            let camera_view: Option<&ExtractedView> = camera_views.iter().next();
+            if let Some(camera_view) = camera_view {
+                camera_view.world_from_view.translation().to_array()
+            } else {
+                // No camera views to render to.
+                continue;
+            }
         };
 
         let Some(bind_groups) = bind_groups else {
@@ -746,10 +780,15 @@ pub fn early_gpu_preprocess(
                             ..
                         } = *work_item_buffers
                         {
-                            compute_pass.set_immediates(
-                                0,
-                                bytemuck::bytes_of(&late_indirect_parameters_indexed_offset),
-                            );
+                            let immediates = PreprocessImmediates {
+                                cur_view_world_position,
+                                late_preprocess_work_item_indirect_offset:
+                                    late_indirect_parameters_indexed_offset,
+                            };
+                            compute_pass.set_immediates(0, bytemuck::bytes_of(&immediates));
+                        } else {
+                            compute_pass
+                                .set_immediates(0, bytemuck::bytes_of(&cur_view_world_position));
                         }
 
                         compute_pass.set_bind_group(0, indexed_bind_group, &dynamic_offsets);
@@ -770,10 +809,15 @@ pub fn early_gpu_preprocess(
                             ..
                         } = *work_item_buffers
                         {
-                            compute_pass.set_immediates(
-                                0,
-                                bytemuck::bytes_of(&late_indirect_parameters_non_indexed_offset),
-                            );
+                            let immediates = PreprocessImmediates {
+                                cur_view_world_position,
+                                late_preprocess_work_item_indirect_offset:
+                                    late_indirect_parameters_non_indexed_offset,
+                            };
+                            compute_pass.set_immediates(0, bytemuck::bytes_of(&immediates));
+                        } else {
+                            compute_pass
+                                .set_immediates(0, bytemuck::bytes_of(&cur_view_world_position));
                         }
 
                         compute_pass.set_bind_group(0, non_indexed_bind_group, &dynamic_offsets);
@@ -832,6 +876,7 @@ pub fn late_gpu_preprocess(
 ) {
     let (view, bind_groups, view_uniform_offset) = current_view.into_inner();
 
+    let cur_view_world_position = view.world_from_view.translation().to_array();
     // Fetch the pipeline BEFORE starting diagnostic spans to avoid panic on early return
     let maybe_pipeline_id = preprocess_pipelines
         .late_gpu_occlusion_culling_preprocess
@@ -917,10 +962,11 @@ pub fn late_gpu_preprocess(
 
         // Transform and cull indexed meshes if there are any.
         if let Some(late_indexed_bind_group) = maybe_late_indexed_bind_group {
-            compute_pass.set_immediates(
-                0,
-                bytemuck::bytes_of(late_indirect_parameters_indexed_offset),
-            );
+            let immediates = PreprocessImmediates {
+                cur_view_world_position,
+                late_preprocess_work_item_indirect_offset: *late_indirect_parameters_indexed_offset,
+            };
+            compute_pass.set_immediates(0, bytemuck::bytes_of(&immediates));
 
             compute_pass.set_bind_group(0, late_indexed_bind_group, &dynamic_offsets);
             compute_pass.dispatch_workgroups_indirect(
@@ -932,10 +978,12 @@ pub fn late_gpu_preprocess(
 
         // Transform and cull non-indexed meshes if there are any.
         if let Some(late_non_indexed_bind_group) = maybe_late_non_indexed_bind_group {
-            compute_pass.set_immediates(
-                0,
-                bytemuck::bytes_of(late_indirect_parameters_non_indexed_offset),
-            );
+            let immediates = PreprocessImmediates {
+                cur_view_world_position,
+                late_preprocess_work_item_indirect_offset:
+                    *late_indirect_parameters_non_indexed_offset,
+            };
+            compute_pass.set_immediates(0, bytemuck::bytes_of(&immediates));
 
             compute_pass.set_bind_group(0, late_non_indexed_bind_group, &dynamic_offsets);
             compute_pass.dispatch_workgroups_indirect(
@@ -1247,7 +1295,9 @@ impl SpecializedComputePipeline for PreprocessPipeline {
             ),
             layout: vec![self.bind_group_layout.clone()],
             immediate_size: if key.contains(PreprocessPipelineKey::OCCLUSION_CULLING) {
-                4
+                16
+            } else if key.contains(PreprocessPipelineKey::FRUSTUM_CULLING) {
+                12
             } else {
                 0
             },

--- a/crates/bevy_pbr/src/render/gpu_preprocess.rs
+++ b/crates/bevy_pbr/src/render/gpu_preprocess.rs
@@ -62,8 +62,8 @@ use bevy_render::{
     renderer::{RenderContext, RenderDevice, RenderQueue, ViewQuery},
     settings::WgpuFeatures,
     view::{
-        ExtractedView, NoIndirectDrawing, RenderVisibilityRanges, RetainedViewEntity, ViewUniform,
-        ViewUniformOffset, ViewUniforms,
+        ExtractedView, NoIndirectDrawing, PointAndSpotLightShadowPrimaryCamera,
+        RenderVisibilityRanges, RetainedViewEntity, ViewUniform, ViewUniformOffset, ViewUniforms,
     },
     GpuResourceAppExt, Render, RenderApp, RenderSystems,
 };
@@ -617,7 +617,13 @@ pub fn early_gpu_preprocess(
         ),
         Without<SkipGpuPreprocess>,
     >,
-    camera_views: Query<&ExtractedView, (With<ExtractedCamera>, Without<SkipGpuPreprocess>)>,
+    point_and_spot_light_shadow_primary_camera: Query<
+        &ExtractedView,
+        (
+            With<ExtractedCamera>,
+            With<PointAndSpotLightShadowPrimaryCamera>,
+        ),
+    >,
     view_query: Query<
         (
             &ExtractedView,
@@ -650,6 +656,8 @@ pub fn early_gpu_preprocess(
     let (shadow_cascade_views, extracted_view, has_non_root_view) = current_view.into_inner();
     let all_views =
         gather_shadow_cascades_for_view(view_entity, shadow_cascade_views, &light_query);
+    let point_and_spot_light_shadow_camera_view =
+        point_and_spot_light_shadow_primary_camera.single();
 
     // Run the compute passes.
     for view_entity in all_views {
@@ -668,16 +676,13 @@ pub fn early_gpu_preprocess(
             extracted_view.world_from_view.translation().to_array()
         } else {
             // PointLight and SpotLight shadow views are handled in this else block.
-            // TODO: We need to better handle this case.
-            // As written, point and spot lights shadow views will just use the first user camera
-            // that is returned by the query.
-            // If there is only one user camera, this is fine, but for multiple user cameras,
-            // only one of them is randomly used for visibility range culling.
-            let camera_view: Option<&ExtractedView> = camera_views.iter().next();
-            if let Some(camera_view) = camera_view {
+            // We could handle this case better if we can specify certain point and spot light shadow
+            // views to different cameras. Right now, it is all centralized to one user specified camera.
+            if let Ok(camera_view) = point_and_spot_light_shadow_camera_view {
                 camera_view.world_from_view.translation().to_array()
             } else {
-                // No camera views to render to.
+                // There is no single designated primary camera to use for vis range culling of the shadows.
+                // Do not render them.
                 continue;
             }
         };

--- a/crates/bevy_pbr/src/render/mesh_preprocess.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_preprocess.wgsl
@@ -73,15 +73,15 @@ struct Immediates {
     // The offset into the `late_preprocess_work_item_indirect_parameters`
     // buffer.
     late_preprocess_work_item_indirect_offset: u32,
-#endif // OCCLUSION_CULLING
+#endif  // OCCLUSION_CULLING
 }
-#else // FRUSTUM_CULLING
+#else  // FRUSTUM_CULLING
 struct Immediates {
     // The offset into the `late_preprocess_work_item_indirect_parameters`
     // buffer.
     late_preprocess_work_item_indirect_offset: u32,
 }
-#endif // FRUSTUM_CULLING
+#endif  // FRUSTUM_CULLING
 
 // The current frame's `MeshInput`.
 @group(0) @binding(3) var<storage> current_input: array<MeshInput>;
@@ -129,6 +129,10 @@ var<immediate> immediates: Immediates;
 @group(0) @binding(13) var<storage, read> late_preprocess_work_item_indirect_parameters:
     array<LatePreprocessWorkItemIndirectParameters>;
 #endif  // LATE_PHASE
+
+#ifndef FRUSTUM_CULLING
+var<immediate> immediates: Immediates;
+#endif  // FRUSTUM_CULLING
 #endif  // OCCLUSION_CULLING
 
 #ifdef FRUSTUM_CULLING

--- a/crates/bevy_pbr/src/render/mesh_preprocess.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_preprocess.wgsl
@@ -67,7 +67,10 @@ struct LatePreprocessWorkItemIndirectParameters {
 #ifdef FRUSTUM_CULLING
 // These have to be in a structure because of Naga limitations on DX12.
 struct Immediates {
-    // The world position of the `CurrentView`
+    // The world position of a camera view.
+    // This is important to distinguish when preprocessing shadow views, 
+    // which is bound to `view`. Visibility range culling must use a camera view's 
+    // position in order to function properly.
     cur_view_world_position: vec3<f32>,
 #ifdef OCCLUSION_CULLING
     // The offset into the `late_preprocess_work_item_indirect_parameters`

--- a/crates/bevy_pbr/src/render/mesh_preprocess.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_preprocess.wgsl
@@ -75,6 +75,12 @@ struct Immediates {
     late_preprocess_work_item_indirect_offset: u32,
 #endif // OCCLUSION_CULLING
 }
+#else // FRUSTUM_CULLING
+struct Immediates {
+    // The offset into the `late_preprocess_work_item_indirect_parameters`
+    // buffer.
+    late_preprocess_work_item_indirect_offset: u32,
+}
 #endif // FRUSTUM_CULLING
 
 // The current frame's `MeshInput`.

--- a/crates/bevy_pbr/src/render/mesh_preprocess.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_preprocess.wgsl
@@ -64,12 +64,18 @@ struct LatePreprocessWorkItemIndirectParameters {
     pad: vec4<u32>,
 }
 
+#ifdef FRUSTUM_CULLING
 // These have to be in a structure because of Naga limitations on DX12.
 struct Immediates {
+    // The world position of the `CurrentView`
+    cur_view_world_position: vec3<f32>,
+#ifdef OCCLUSION_CULLING
     // The offset into the `late_preprocess_work_item_indirect_parameters`
     // buffer.
     late_preprocess_work_item_indirect_offset: u32,
+#endif // OCCLUSION_CULLING
 }
+#endif // FRUSTUM_CULLING
 
 // The current frame's `MeshInput`.
 @group(0) @binding(3) var<storage> current_input: array<MeshInput>;
@@ -98,6 +104,8 @@ struct Immediates {
 @group(0) @binding(9) var<storage> mesh_culling_data: array<MeshCullingData>;
 
 @group(0) @binding(10) var<storage> visibility_ranges: array<vec4<f32>>;
+
+var<immediate> immediates: Immediates;
 #endif  // FRUSTUM_CULLING
 
 #ifdef OCCLUSION_CULLING
@@ -115,8 +123,6 @@ struct Immediates {
 @group(0) @binding(13) var<storage, read> late_preprocess_work_item_indirect_parameters:
     array<LatePreprocessWorkItemIndirectParameters>;
 #endif  // LATE_PHASE
-
-var<immediate> immediates: Immediates;
 #endif  // OCCLUSION_CULLING
 
 #ifdef FRUSTUM_CULLING
@@ -224,7 +230,7 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
             world_pos = world_from_local[3].xyz;
         }
 
-        let camera_distance = length(position_world_to_view(world_pos));
+        let camera_distance = length(immediates.cur_view_world_position - world_pos);
         // `x` is the minimum range; `w` is the largest range.
         if (camera_distance < lod_range.x || camera_distance >= lod_range.w) {
             return;

--- a/crates/bevy_render/src/batching/gpu_preprocessing.rs
+++ b/crates/bevy_render/src/batching/gpu_preprocessing.rs
@@ -1337,6 +1337,7 @@ impl FromWorld for GpuPreprocessingSupport {
             crate::get_pixel10_driver_version(adapter_info).is_some()
         }
 
+        // Includes occlusion culling and frustum culling
         let culling_feature_support = device
             .features()
             .contains(Features::INDIRECT_FIRST_INSTANCE | Features::IMMEDIATES);

--- a/crates/bevy_render/src/batching/gpu_preprocessing.rs
+++ b/crates/bevy_render/src/batching/gpu_preprocessing.rs
@@ -1337,7 +1337,6 @@ impl FromWorld for GpuPreprocessingSupport {
             crate::get_pixel10_driver_version(adapter_info).is_some()
         }
 
-        // Includes occlusion culling
         let culling_feature_support = device
             .features()
             .contains(Features::INDIRECT_FIRST_INSTANCE | Features::IMMEDIATES);

--- a/crates/bevy_render/src/batching/gpu_preprocessing.rs
+++ b/crates/bevy_render/src/batching/gpu_preprocessing.rs
@@ -1337,7 +1337,7 @@ impl FromWorld for GpuPreprocessingSupport {
             crate::get_pixel10_driver_version(adapter_info).is_some()
         }
 
-        // Includes occlusion culling and frustum culling
+        // Includes occlusion culling
         let culling_feature_support = device
             .features()
             .contains(Features::INDIRECT_FIRST_INSTANCE | Features::IMMEDIATES);
@@ -1361,6 +1361,7 @@ impl FromWorld for GpuPreprocessingSupport {
         let max_supported_mode = if device.limits().max_compute_workgroup_size_x == 0
             || is_non_supported_android_device(&adapter_info)
             || adapter_info.backend == wgpu::Backend::Gl
+            || !device.features().contains(Features::IMMEDIATES)
         {
             info_once!(
                 "GPU preprocessing is not supported on this device. \

--- a/crates/bevy_render/src/camera.rs
+++ b/crates/bevy_render/src/camera.rs
@@ -11,8 +11,9 @@ use crate::{
     texture::{GpuImage, ManualTextureViews},
     view::{
         ColorGrading, ExtractedView, ExtractedWindows, Msaa, NoIndirectDrawing,
-        RenderExtractedVisibleEntities, RenderVisibleEntities, RenderVisibleEntitiesClass,
-        RetainedViewEntity, ViewUniformOffset, VisibilityExtractionSystemParam,
+        PointAndSpotLightShadowPrimaryCamera, RenderExtractedVisibleEntities,
+        RenderVisibleEntities, RenderVisibleEntitiesClass, RetainedViewEntity, ViewUniformOffset,
+        VisibilityExtractionSystemParam,
     },
     Extract, ExtractSchedule, Render, RenderApp, RenderSystems,
 };
@@ -492,6 +493,7 @@ pub fn extract_cameras(
                 Option<&MipBias>,
                 Option<&RenderLayers>,
                 Option<&Projection>,
+                Has<PointAndSpotLightShadowPrimaryCamera>,
                 Has<NoIndirectDrawing>,
             ),
         )>,
@@ -517,6 +519,7 @@ pub fn extract_cameras(
         MipBias,
         RenderLayers,
         Projection,
+        PointAndSpotLightShadowPrimaryCamera,
         NoIndirectDrawing,
         ViewUniformOffset,
     );
@@ -538,6 +541,7 @@ pub fn extract_cameras(
             mip_bias,
             render_layers,
             projection,
+            has_pasl_shadow_primary_camera,
             no_indirect_drawing,
         ),
     ) in query.iter()
@@ -680,6 +684,12 @@ pub fn extract_cameras(
                 commands.insert(projection.clone());
             } else {
                 commands.remove::<Projection>();
+            }
+
+            if has_pasl_shadow_primary_camera {
+                commands.insert(PointAndSpotLightShadowPrimaryCamera);
+            } else {
+                commands.remove::<PointAndSpotLightShadowPrimaryCamera>();
             }
 
             if no_indirect_drawing

--- a/crates/bevy_render/src/view/visibility/range.rs
+++ b/crates/bevy_render/src/view/visibility/range.rs
@@ -4,6 +4,7 @@
 use super::VisibilityRange;
 use bevy_app::{App, Plugin};
 use bevy_ecs::{
+    component::Component,
     entity::Entity,
     lifecycle::RemovedComponents,
     query::Changed,
@@ -56,6 +57,23 @@ impl Plugin for RenderVisibilityRangePlugin {
             );
     }
 }
+
+/// A marker component for a `Camera` to denote that this entity should be the primary camera
+/// used for GPU Visibility Range Culling on shadows produced by all `PointLight`s and
+/// `SpotLight`s. There should only be one `Camera` with this marker component
+/// at a given moment in the application. This culling will occur if `GpuPreprocessingMode`
+/// is at least `GpuPreprocessingMode::PreprocessingOnly`.
+///
+/// Unlike `DirectionalLight` shadows, `PointLight` shadows and `SpotLight` shadows are
+/// not associated with any camera. They are only rendered once, regardless of the
+/// number of cameras. In order for these shadows to participate in visibility range culling,
+/// the user camera that distances are calculated relative to must be specified. Use this component
+/// to specify that camera.
+///
+/// If this marker component is not placed on a camera, or if there are multiple cameras
+/// with this component, shadows made by `PointLight`s and `SpotLight`s may not render.
+#[derive(Component, Default)]
+pub struct PointAndSpotLightShadowPrimaryCamera;
 
 /// Stores information related to [`VisibilityRange`]s in the render world.
 #[derive(Resource)]

--- a/examples/testbed/3d.rs
+++ b/examples/testbed/3d.rs
@@ -122,6 +122,7 @@ mod light {
     use bevy::{
         color::palettes::css::{DEEP_PINK, LIME, RED},
         prelude::*,
+        render::view::PointAndSpotLightShadowPrimaryCamera,
     };
 
     const CURRENT_SCENE: super::Scene = super::Scene::Light;
@@ -203,6 +204,7 @@ mod light {
 
         commands.spawn((
             Camera3d::default(),
+            PointAndSpotLightShadowPrimaryCamera,
             Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
             DespawnOnExit(CURRENT_SCENE),
         ));
@@ -732,6 +734,7 @@ mod render_layers {
     use bevy::{
         camera::{visibility::RenderLayers, Viewport},
         prelude::*,
+        render::view::PointAndSpotLightShadowPrimaryCamera,
         window::PrimaryWindow,
     };
 
@@ -805,7 +808,9 @@ mod render_layers {
                 DespawnOnExit(CURRENT_SCENE),
             ));
             match index {
-                0 => {}
+                0 => {
+                    entity_cmds.insert(PointAndSpotLightShadowPrimaryCamera);
+                }
                 1 => {
                     entity_cmds.insert(RenderLayers::layer(1));
                 }


### PR DESCRIPTION
# Objective

- Also fixes #23991
- (Better?) Alternate to #24133 . Decisions made can be mixed and matched between the two, just let me know
- @JMS55 took a look and suggested using `Immediates` to avoid bloating `ViewUniform`s. There was also a concern about using `RetainedViewEntity` to pass information about what camera to use along. This is that alternate implementation path.

## Solution

- Rely on the `CurrentView` mechanism to get the current view’s world position, used when preprocessing directional light shadow views. This will be used for gpu vis range culling dir light shadows.
- For Point/Spot shadow cameras (aka `RootNonCameraView`s), a marker component has been added to denote the camera to use: `PointAndSpotLightShadowPrimaryCamera`. There must only be **one** camera with this component. This camera’s position will be used for gpu vis range culling point/spotlight shadows.
  - This component could probably be expanded later in functionality if desired, but I just went with what’s simplest.
  - If we don’t want to have the `PointAndSpotLightShadowPrimaryCamera` component, we can revert 
ac87f8e — the previous logic just queried for extracted cameras and took the world position of the first one returned by the query.

>[!NOTE]
Copying this comment from @JMS55:
>With this PR, we lose out on PreprocessingOnly support for WebGPU, until immediates are added to the spec and wgpu supports it.

## Testing

- `cargo run --example visibility_range -- --no-cpu-culling` works with a directional light as desired
- I updated the light in the `visibility_range` example to be a Spot or PointLight like so:
```rust
SpotLight {
            intensity: 1_000_000_000.0, // lumens
            range: 110.0,
            color: Color::WHITE,
            shadow_maps_enabled: true,
            radius: 10.0,
            ..default()
        },
        Transform::from_rotation(Quat::from_array([
            0.6539259,
            -0.34646285,
            0.36505926,
            -0.5648683,
        ]))
        .with_translation(vec3(57.693, 34.334, -6.422)),
```
And added the `PointAndSpotLightShadowPrimaryCamera` to the `Camera3d` in the example, and then ran the example. The shadows of spot and point lights also look normal.