### PR TITLE
Store previous_asset in PrepareNextFrameAssets.

### DIFF
--- a/crates/bevy_render/src/render_asset.rs
+++ b/crates/bevy_render/src/render_asset.rs
@@ -364,7 +364,7 @@ pub(crate) fn extract_render_asset<A: RenderAsset>(
 /// All assets that should be prepared next frame.
 #[derive(Resource)]
 pub struct PrepareNextFrameAssets<A: RenderAsset> {
-    assets: Vec<(AssetId<A::SourceAsset>, A::SourceAsset)>,
+    assets: Vec<(AssetId<A::SourceAsset>, A::SourceAsset, Option<A>)>,
 }
 
 impl<A: RenderAsset> Default for PrepareNextFrameAssets<A> {
@@ -388,7 +388,7 @@ pub fn prepare_assets<A: RenderAsset>(
 
     let mut param = param.into_inner();
     let queued_assets = core::mem::take(&mut prepare_next_frame.assets);
-    for (id, extracted_asset) in queued_assets {
+    for (id, extracted_asset, previous_asset) in queued_assets {
         if extracted_assets.removed.contains(&id) || extracted_assets.added.contains(&id) {
             // skip previous frame's assets that have been removed or updated
             continue;
@@ -400,7 +400,9 @@ pub fn prepare_assets<A: RenderAsset>(
             // this way we always write at least one (sized) asset per frame.
             // in future we could also consider partial asset uploads.
             if bpf.exhausted() {
-                prepare_next_frame.assets.push((id, extracted_asset));
+                prepare_next_frame
+                    .assets
+                    .push((id, extracted_asset, previous_asset));
                 continue;
             }
             size
@@ -408,15 +410,16 @@ pub fn prepare_assets<A: RenderAsset>(
             0
         };
 
-        let previous_asset = render_assets.get(id);
-        match A::prepare_asset(extracted_asset, id, &mut param, previous_asset) {
+        match A::prepare_asset(extracted_asset, id, &mut param, previous_asset.as_ref()) {
             Ok(prepared_asset) => {
                 render_assets.insert(id, prepared_asset);
                 bpf.write_bytes(write_bytes);
                 wrote_asset_count += 1;
             }
             Err(PrepareAssetError::RetryNextUpdate(extracted_asset)) => {
-                prepare_next_frame.assets.push((id, extracted_asset));
+                prepare_next_frame
+                    .assets
+                    .push((id, extracted_asset, previous_asset));
             }
             Err(PrepareAssetError::AsBindGroupError(e)) => {
                 error!(
@@ -440,7 +443,9 @@ pub fn prepare_assets<A: RenderAsset>(
 
         let write_bytes = if let Some(size) = A::byte_len(&extracted_asset) {
             if bpf.exhausted() {
-                prepare_next_frame.assets.push((id, extracted_asset));
+                prepare_next_frame
+                    .assets
+                    .push((id, extracted_asset, previous_asset));
                 continue;
             }
             size
@@ -455,7 +460,9 @@ pub fn prepare_assets<A: RenderAsset>(
                 wrote_asset_count += 1;
             }
             Err(PrepareAssetError::RetryNextUpdate(extracted_asset)) => {
-                prepare_next_frame.assets.push((id, extracted_asset));
+                prepare_next_frame
+                    .assets
+                    .push((id, extracted_asset, previous_asset));
             }
             Err(PrepareAssetError::AsBindGroupError(e)) => {
                 error!(


### PR DESCRIPTION
# Issue
In `prepare_assets` the `previous_asset` is passed to `A::prepare_asset` however when an asset is enqueued into the `PrepareNextFrameAssets` it's previous asset is removed from `RenderAssets` and dropped. When consuming the queue is attempts to read the value from the `RenderAssets` which always returns `None`. 

## Solution
This change simply stores the previous_asset in the `PrepareNextFrameAssets` queue. 

## Alternative Solution
I find it dubious that the `RenderAsset` has to be removed from `RenderAssets` in the first place. The reason given is that "we remove previous here to ensure that if we are updating the asset then any users will not see the old asset after a new asset is extracted, even if the new asset is not yet ready or we are out of bytes to write."  However, I would personally expect to keep stale data until the updated data arrives. If we do that then there would be no need to store the previous asset.

## Testing

- I have not tested this... How would I go about testing this?