### PR TITLE
monitor selection fallback has been added on web build

### DIFF
--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -334,25 +334,28 @@ pub(crate) fn changed_windows(
                         ))))
                     }
                     WindowMode::Fullscreen(monitor_selection, video_mode_selection) => {
-                        let monitor = &select_monitor(
+                        match select_monitor(
                             &monitors,
                             winit_window.primary_monitor(),
                             winit_window.current_monitor(),
                             &monitor_selection,
-                        )
-                        .unwrap_or_else(|| {
-                            panic!("Could not find monitor for {monitor_selection:?}")
-                        });
-
-                        if let Some(video_mode) = get_selected_videomode(monitor, &video_mode_selection)
-                        {
-                            Some(Some(winit::window::Fullscreen::Exclusive(video_mode)))
-                        } else {
-                            warn!(
-                                "Could not find valid fullscreen video mode for {:?} {:?}",
-                                monitor_selection, video_mode_selection
-                            );
-                            None
+                        ) {
+                            Some(monitor) => {
+                                if let Some(video_mode) = get_selected_videomode(&monitor, &video_mode_selection)
+                                {
+                                    Some(Some(winit::window::Fullscreen::Exclusive(video_mode)))
+                                } else {
+                                    warn!(
+                                        "Could not find valid fullscreen video mode for {:?} {:?}",
+                                        monitor_selection, video_mode_selection
+                                    );
+                                    None
+                                }
+                            }
+                            None => {
+                                warn!("Could not find monitor for {:?}", monitor_selection);
+                                None
+                            }
                         }
                     }
                     WindowMode::Windowed => Some(None),


### PR DESCRIPTION
# Objective

fix #23649 

## Solution

I have added a warning fallback when monitor selection code is trigerred preventing a panic on unrwap

## Testing

The testing was done by building a web build then pressing SPACEBAR to trigger relevant logic and logs were monitored

### Showcase (Option) A video of testing the functionality
[Screencast from 2026-05-09 17-03-06.webm](https://github.com/user-attachments/assets/9f3f4f8f-f88a-4f12-8afb-10f0a1372a2c)

### AI disclaimer

1. A wget command was used to fetch issues for context for the AI. That was the issue itself
2. The screenshots were taken and put into gemini to be converted into text that were in the issue
3. Some explanations were generated and possible solution approaches in md files
These files were moved out of the directory
4. Approaches were reviewed
5. Logic that I decided for the fix was 
- If the monitor selection fails, then it should not panic instead it should return none with a
warning that indicates the user of this behavior in developer console
7. Then the AI was queried for testing. Which was done by a hosting a local web instance of bevy outside the project directory.
8. The setting up of this instance was done 
9. Instructions to replicate this were also generated via a bash script
10. Finally it was tested by a human where monitor selection logic was triggered manually and confirmed

