### PR TITLE
fixed far plane intersection test for fogvolumes

### DIFF
--- a/crates/bevy_pbr/src/volumetric_fog/render.rs
+++ b/crates/bevy_pbr/src/volumetric_fog/render.rs
@@ -138,7 +138,7 @@ pub struct VolumetricFogUniform {
     /// The vector takes the form V = (N, -N⋅Q), where N is the normal of the
     /// plane and Q is any point in it, in view space. The equation of the plane
     /// for homogeneous point P = (Px, Py, Pz, Pw) is V⋅P = 0.
-    far_planes: [Vec4; 3],
+    far_planes: [Vec4; 6],
 
     fog_color: Vec3,
     light_tint: Vec3,
@@ -695,8 +695,8 @@ pub fn prepare_view_depth_textures_for_volumetric_fog(
     }
 }
 
-fn get_far_planes(view_from_local: &Affine3A) -> [Vec4; 3] {
-    let (mut far_planes, mut next_index) = ([Vec4::ZERO; 3], 0);
+fn get_far_planes(view_from_local: &Affine3A) -> [Vec4; 6] {
+    let (mut far_planes, mut next_index) = ([Vec4::ZERO; 6], 0);
 
     for &local_normal in &[
         Vec3A::X,
@@ -709,18 +709,20 @@ fn get_far_planes(view_from_local: &Affine3A) -> [Vec4; 3] {
         let view_normal = view_from_local
             .transform_vector3a(local_normal)
             .normalize_or_zero();
-        if view_normal.z <= 0.0 {
-            continue;
-        }
 
         let view_position = view_from_local.transform_point3a(-local_normal * 0.5);
         let plane_coords = view_normal.extend(-view_normal.dot(view_position));
 
-        far_planes[next_index] = plane_coords;
-        next_index += 1;
-        if next_index == far_planes.len() {
+        // Filter planes that are facing away from the camera.
+        if plane_coords.w <= 0.0 {
+            // When planes are filtered here, the `far_planes` array will be padded with
+            // one or more "zero" planes: (0.0, 0.0, 0.0, 0.0), these planes will be
+            // correctly ignored by the shader in the plane sorting step.
             continue;
         }
+
+        far_planes[next_index] = plane_coords;
+        next_index += 1;
     }
 
     far_planes

--- a/crates/bevy_pbr/src/volumetric_fog/volumetric_fog.wgsl
+++ b/crates/bevy_pbr/src/volumetric_fog/volumetric_fog.wgsl
@@ -52,7 +52,7 @@
 struct VolumetricFog {
     clip_from_local: mat4x4<f32>,
     uvw_from_world: mat4x4<f32>,
-    far_planes: array<vec4<f32>, 3>,
+    far_planes: array<vec4<f32>, 6>,
     fog_color: vec3<f32>,
     light_tint: vec3<f32>,
     ambient_color: vec3<f32>,
@@ -144,10 +144,13 @@ fn fragment(@builtin(position) position: vec4<f32>) -> @location(0) vec4<f32> {
     // Calculate the end position of the ray. This requires us to raytrace the
     // three back faces of the AABB to find the one that our ray intersects.
     var end_depth_view = 0.0;
-    for (var plane_index = 0; plane_index < 3; plane_index += 1) {
+    for (var plane_index = 0; plane_index < 6; plane_index += 1) {
         let plane = volumetric_fog.far_planes[plane_index];
-        let other_plane_a = volumetric_fog.far_planes[(plane_index + 1) % 3];
-        let other_plane_b = volumetric_fog.far_planes[(plane_index + 2) % 3];
+        let other_plane_a = volumetric_fog.far_planes[(plane_index + 1) % 6];
+        let other_plane_b = volumetric_fog.far_planes[(plane_index + 2) % 6];
+        let other_plane_c = volumetric_fog.far_planes[(plane_index + 3) % 6];
+        let other_plane_d = volumetric_fog.far_planes[(plane_index + 4) % 6];
+        let other_plane_e = volumetric_fog.far_planes[(plane_index + 5) % 6];
 
         // Calculate the intersection of the ray and the plane. The ray must
         // intersect in front of us (t > 0).
@@ -158,13 +161,13 @@ fn fragment(@builtin(position) position: vec4<f32>) -> @location(0) vec4<f32> {
         let hit_pos = view_start_pos.xyz * t;
 
         // The intersection point must be in front of the other backfaces.
-        let other_sides = vec2(
-            dot(vec4(hit_pos, 1.0), other_plane_a) >= 0.0,
-            dot(vec4(hit_pos, 1.0), other_plane_b) >= 0.0
-        );
-
         // If those tests pass, we found our backface.
-        if (all(other_sides)) {
+        if (dot(vec4(hit_pos, 1.0), other_plane_a) >= 0.0 &&
+            dot(vec4(hit_pos, 1.0), other_plane_b) >= 0.0 &&
+            dot(vec4(hit_pos, 1.0), other_plane_c) >= 0.0 &&
+            dot(vec4(hit_pos, 1.0), other_plane_d) >= 0.0 &&
+            dot(vec4(hit_pos, 1.0), other_plane_e) >= 0.0)
+        {
             end_depth_view = -hit_pos.z;
             break;
         }

--- a/crates/bevy_pbr/src/volumetric_fog/volumetric_fog.wgsl
+++ b/crates/bevy_pbr/src/volumetric_fog/volumetric_fog.wgsl
@@ -142,7 +142,7 @@ fn fragment(@builtin(position) position: vec4<f32>) -> @location(0) vec4<f32> {
     let view_start_pos = position_ndc_to_view(frag_coord_to_ndc(frag_coord));
 
     // Calculate the end position of the ray. This requires us to raytrace the
-    // three back faces of the AABB to find the one that our ray intersects.
+    // back faces of the AABB to find the one that our ray intersects.
     var end_depth_view = 0.0;
     for (var plane_index = 0; plane_index < 6; plane_index += 1) {
         let plane = volumetric_fog.far_planes[plane_index];


### PR DESCRIPTION
# Objective

Fixes #22574 

## Solution

The previous code assumed there are only 3 back faces visible at any time for the FogVolume. This assumption is incorrect and breaks in some instances: e.g. when the camera is looking head-on at one of the faces of a cube. Depending on the distance and size of the cube, 5 back faces will be visible. 

The solution is to consider all visible back faces for testing in the shader.

## Testing

Tested with this command and on another test scene without atmospherics (see showcase)
`cargo run -r --example atmosphere --features free_camera`

---

## Showcase

Before:

https://github.com/user-attachments/assets/72381ba3-b85f-4a14-9dab-70d99b205ddd

After:

https://github.com/user-attachments/assets/9438bcf2-0c95-4d44-9341-52114ecd68cd

</details>
