### PR TITLE
resource_scope: Propagate source location tracking

### DIFF
--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -2789,7 +2789,7 @@ impl World {
         let mut entity_mut = self.get_entity_mut(entity).ok()?;
 
         let mut ticks = entity_mut.get_change_ticks::<R>()?;
-        let mut changed_by = entity_mut.get_changed_by::<R>()?;
+        let changed_by = entity_mut.get_changed_by::<R>()?;
         let value = entity_mut.take::<R>()?;
 
         // type used to manage reinserting the resource at the end of the scope. use of a drop impl means that
@@ -2908,16 +2908,13 @@ impl World {
             ticks: ComponentTicksMut {
                 added: &mut ticks.added,
                 changed: &mut ticks.changed,
-                changed_by: changed_by.as_mut(),
+                changed_by: guard.caller.as_mut(),
                 last_run: last_change_tick,
                 this_run: change_tick,
             },
         };
 
         let result = f(guard.world, value_mut);
-
-        // Update source location tracking if f mutably dereferenced the resource
-        guard.caller = changed_by;
 
         Some(result)
     }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -2916,6 +2916,9 @@ impl World {
 
         let result = f(guard.world, value_mut);
 
+        // Update source location tracking if f mutably dereferenced the resource
+        guard.caller = changed_by;
+
         Some(result)
     }
 


### PR DESCRIPTION
# Objective

Part of #16775

If a resource is mutated in `resource_scope`, store the tracked source location.

## Showcase

This used to print the location of the `insert_resource` call; it now prints the location of the `deref_mut` call:
```rust
#[derive(Resource)]
struct A;
let mut world = World::new();
world.insert_resource(A);
world.resource_scope::<A, _>(|_, mut a| {
    a.deref_mut();
});
dbg!(world.resource_ref::<A>().changed_by());
```