### PR TITLE
Added default value to `Name` of `Window`

### DIFF
--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -481,7 +481,7 @@ impl Default for Window {
     fn default() -> Self {
         Self {
             title: DEFAULT_WINDOW_TITLE.to_owned(),
-            name: None,
+            name: Some("bevy_window".into()),
             present_mode: Default::default(),
             mode: Default::default(),
             position: Default::default(),


### PR DESCRIPTION
# Objective

Fixes #24228 
Add a default app_id (wayland) to the bevy window. This should be functionally identical to users that don't care about app_id.

This change is useful as it allows to detect whenever a window has been created by bevy (no matter the crate) and apply custom rules to its behavior through a window manager.

## Solution

Naive implementation. Just changed the default value of name from `None` to `Some("bevy_window")`

## Testing

`cargo run --example 2d_shapes` has the "bevy_window" as app_id.