### PR TITLE
fixed spotlight shadow issue due to incorrect basis reconstruction

### DIFF
--- a/crates/bevy_pbr/src/volumetric_fog/volumetric_fog.wgsl
+++ b/crates/bevy_pbr/src/volumetric_fog/volumetric_fog.wgsl
@@ -44,6 +44,7 @@
     position_ndc_to_world,
     position_view_to_world
 }
+#import bevy_render::maths::orthonormalize
 #import bevy_pbr::clustered_forward as clustering
 #import bevy_pbr::lighting::getDistanceAttenuation;
 
@@ -478,18 +479,7 @@ fn fetch_spot_shadow_without_normal(light_id: u32, frag_position: vec4<f32>, fra
         -surface_to_light
         + ((*light).shadow_depth_bias * normalize(surface_to_light));
 
-    // the construction of the up and right vectors needs to precisely mirror the code
-    // in light/spot_light.rs:orthonormalize
-    var sign = -1.0;
-    if (fwd.z >= 0.0) {
-        sign = 1.0;
-    }
-    let a = -1.0 / (fwd.z + sign);
-    let b = fwd.x * fwd.y * a;
-    let right_dir = vec3<f32>(1.0 + sign * fwd.x * fwd.x * a, sign * b, -sign * fwd.x);
-    let up_dir = vec3<f32>(b, sign + fwd.y * fwd.y * a, -fwd.y);
-
-    let light_inv_rot = mat3x3<f32>(right_dir, up_dir, fwd);
+    let light_inv_rot = orthonormalize(fwd);
 
     // because the matrix is a pure rotation matrix, the inverse is just the transpose, and to calculate
     // the product of the transpose with a vector we can just post-multiply instead of pre-multiplying.

--- a/crates/bevy_pbr/src/volumetric_fog/volumetric_fog.wgsl
+++ b/crates/bevy_pbr/src/volumetric_fog/volumetric_fog.wgsl
@@ -479,15 +479,16 @@ fn fetch_spot_shadow_without_normal(light_id: u32, frag_position: vec4<f32>, fra
         + ((*light).shadow_depth_bias * normalize(surface_to_light));
 
     // the construction of the up and right vectors needs to precisely mirror the code
-    // in render/light.rs:spot_light_view_matrix
+    // in light/spot_light.rs:orthonormalize
     var sign = -1.0;
     if (fwd.z >= 0.0) {
         sign = 1.0;
     }
     let a = -1.0 / (fwd.z + sign);
     let b = fwd.x * fwd.y * a;
-    let up_dir = vec3<f32>(1.0 + sign * fwd.x * fwd.x * a, sign * b, -sign * fwd.x);
-    let right_dir = vec3<f32>(-b, -sign - fwd.y * fwd.y * a, fwd.y);
+    let right_dir = vec3<f32>(1.0 + sign * fwd.x * fwd.x * a, sign * b, -sign * fwd.x);
+    let up_dir = vec3<f32>(b, sign + fwd.y * fwd.y * a, -fwd.y);
+
     let light_inv_rot = mat3x3<f32>(right_dir, up_dir, fwd);
 
     // because the matrix is a pure rotation matrix, the inverse is just the transpose, and to calculate


### PR DESCRIPTION
# Objective

Fixes #24232 

## Solution

The basis vector construction code in the shader was no longer in sync with the rust code. I updated the shader to match the rust code: https://github.com/bevyengine/bevy/blob/2002a188e0e106eacf56b854dfaff4eca8839584/crates/bevy_light/src/spot_light.rs#L172-L183

## Testing

Run the example code posted in #24232 

## Showcase

Before:
<img width="1891" height="2124" alt="screenshot-2026-05-10_17-43-50" src="https://github.com/user-attachments/assets/31f93820-66c6-4ce9-8c4e-ccdfbb89fd3d" />

After:

<img width="1891" height="2085" alt="screenshot-2026-05-10_23-34-33" src="https://github.com/user-attachments/assets/6d400252-2367-400f-a067-bcd944032bad" />
