### PR TITLE
Pass panics to the fallback error handler

### DIFF
--- a/_release-content/release-notes/panics-to-errors.md
+++ b/_release-content/release-notes/panics-to-errors.md
@@ -8,4 +8,4 @@ For long-running programs, crashing can be unacceptable. If, for example, there 
 
 Bevy's systems, commands and observers are able to return errors. You can either set an error handler case-by-case, or let the `FallbackErrorHandler` deal with it. But this used to only work for explicitly returned errors: Panics used to bring down the entire app.
 
-In Bevy 0.xx, these panics now get turned into errors and passed to the fallback error handler. By default this re-panics, but now you can choose to log an error and continue, or whatever else you want!
+In Bevy 0.xx, these panics now get turned into errors and passed to the fallback error handler. By default this re-panics, but now you can choose whether to log an error and continue, or whatever else you want!

--- a/_release-content/release-notes/panics-to-errors.md
+++ b/_release-content/release-notes/panics-to-errors.md
@@ -1,0 +1,11 @@
+---
+title: 
+authors: ["@SpecificProtagonist"]
+pull_requests: [24240]
+---
+
+For long-running programs, crashing can be unacceptable. If, for example, there is a bug in one of your image editor's tools, it's better for that tool to fail or to produce wrong results than to loose all your unsafed work.
+
+Bevy's systems, commands and observers are able to return errors. You can either set an error handler case-by-case, or let the `FallbackErrorHandler` deal with it. But this used to only work for explicity returned errors: Panics used to bring down the entire app.
+
+In Bevy 0.xx, these panics now get turned into errors and passed to the fallback error handler. By default this re-panics, but now you can choose to log an error and continue, or whatever else you want!

--- a/_release-content/release-notes/panics-to-errors.md
+++ b/_release-content/release-notes/panics-to-errors.md
@@ -1,5 +1,5 @@
 ---
-title: 
+title: Catching Panics
 authors: ["@SpecificProtagonist"]
 pull_requests: [24240]
 ---
@@ -8,4 +8,4 @@ For long-running programs, crashing can be unacceptable. If, for example, there 
 
 Bevy's systems, commands and observers are able to return errors. You can either set an error handler case-by-case, or let the `FallbackErrorHandler` deal with it. But this used to only work for explicitly returned errors: Panics used to bring down the entire app.
 
-In Bevy 0.xx, these panics now get turned into errors and passed to the fallback error handler. By default this re-panics, but now you can choose whether to log an error and continue, or whatever else you want!
+In Bevy 0.xx, these panics now get turned into errors and passed to the fallback error handler. By default this re-panics, but now you can choose whether to log an error and continue, or whatever else you want.

--- a/_release-content/release-notes/panics-to-errors.md
+++ b/_release-content/release-notes/panics-to-errors.md
@@ -6,6 +6,6 @@ pull_requests: [24240]
 
 For long-running programs, crashing can be unacceptable. If, for example, there is a bug in one of your image editor's tools, it's better for that tool to fail or to produce wrong results than to loose all your unsafed work.
 
-Bevy's systems, commands and observers are able to return errors. You can either set an error handler case-by-case, or let the `FallbackErrorHandler` deal with it. But this used to only work for explicity returned errors: Panics used to bring down the entire app.
+Bevy's systems, commands and observers are able to return errors. You can either set an error handler case-by-case, or let the `FallbackErrorHandler` deal with it. But this used to only work for explicitly returned errors: Panics used to bring down the entire app.
 
 In Bevy 0.xx, these panics now get turned into errors and passed to the fallback error handler. By default this re-panics, but now you can choose to log an error and continue, or whatever else you want!

--- a/_release-content/release-notes/panics-to-errors.md
+++ b/_release-content/release-notes/panics-to-errors.md
@@ -4,7 +4,7 @@ authors: ["@SpecificProtagonist"]
 pull_requests: [24240]
 ---
 
-For long-running programs, crashing can be unacceptable. If, for example, there is a bug in one of your image editor's tools, it's better for that tool to fail or to produce wrong results than to loose all your unsafed work.
+For long-running programs, crashing can be unacceptable. If, for example, there is a bug in one of your image editor's tools, it's better for that tool to fail or to produce wrong results than to lose all your unsaved work.
 
 Bevy's systems, commands and observers are able to return errors. You can either set an error handler case-by-case, or let the `FallbackErrorHandler` deal with it. But this used to only work for explicitly returned errors: Panics used to bring down the entire app.
 

--- a/crates/bevy_ecs/src/error/bevy_error.rs
+++ b/crates/bevy_ecs/src/error/bevy_error.rs
@@ -86,6 +86,30 @@ impl BevyError {
         Self::from(error).with_severity(severity)
     }
 
+    /// Constructs a new [`BevyError`] with the given [`Severity`].
+    ///
+    /// Like [`BevyError::new`], but if the `backtrace` cargo feature is enabled
+    /// it will use the supplied backtrace instead of capturing a new one.
+    pub fn new_with_backtrace<E>(
+        severity: Severity,
+        error: E,
+        backtrace: std::backtrace::Backtrace,
+    ) -> Self
+    where
+        Box<dyn Error + Sync + Send>: From<E>,
+    {
+        #[cfg(not(feature = "backtrace"))]
+        drop(backtrace);
+        BevyError {
+            inner: Box::new(InnerBevyError {
+                error: error.into(),
+                severity,
+                #[cfg(feature = "backtrace")]
+                backtrace,
+            }),
+        }
+    }
+
     /// Creates a new [`BevyError`] with the [`Severity::Ignore`] severity.
     ///
     /// This is a shorthand for <code>[BevyError::new(Severity::Ignore, error)](BevyError::new)</code>.
@@ -405,9 +429,7 @@ pub fn bevy_error_panic_hook(
 ) -> impl Fn(&std::panic::PanicHookInfo) {
     move |info| {
         if SKIP_NORMAL_BACKTRACE.replace(false) {
-            if let Some(payload) = info.payload().downcast_ref::<&str>() {
-                std::println!("{payload}");
-            } else if let Some(payload) = info.payload().downcast_ref::<alloc::string::String>() {
+            if let Some(payload) = info.payload_as_str() {
                 std::println!("{payload}");
             }
             return;

--- a/crates/bevy_ecs/src/error/bevy_error.rs
+++ b/crates/bevy_ecs/src/error/bevy_error.rs
@@ -90,6 +90,7 @@ impl BevyError {
     ///
     /// Like [`BevyError::new`], but if the `backtrace` cargo feature is enabled
     /// it will use the supplied backtrace instead of capturing a new one.
+    #[cfg(feature = "std")]
     pub fn new_with_backtrace<E>(
         severity: Severity,
         error: E,

--- a/crates/bevy_ecs/src/error/handler.rs
+++ b/crates/bevy_ecs/src/error/handler.rs
@@ -112,6 +112,8 @@ pub type ErrorHandler = fn(BevyError, ErrorContext);
 /// Fallback error handler to call when an error is not handled otherwise.
 /// Defaults to [`match_severity()`].
 ///
+/// Called both for explicitly returned errors, and when a panic occurs.
+///
 /// When updated while a [`Schedule`] is running, it doesn't take effect for
 /// that schedule until it's completed.
 ///

--- a/crates/bevy_ecs/src/error/handler.rs
+++ b/crates/bevy_ecs/src/error/handler.rs
@@ -102,6 +102,11 @@ macro_rules! inner {
 }
 
 /// Defines how Bevy reacts to errors.
+///
+/// When writing an error handler, if you want to thow a panic,
+/// consider setting [`PANIC_ORIGINATES_FROM_ERROR_HANDLER`].
+/// This lets the excecutor know that a panic doesn't need to be
+/// converted back to a [`BevyError`] and passed to the [`FallbackErrorHandler`].
 pub type ErrorHandler = fn(BevyError, ErrorContext);
 
 /// Fallback error handler to call when an error is not handled otherwise.
@@ -124,6 +129,14 @@ impl Default for FallbackErrorHandler {
 #[deprecated(since = "0.19.0", note = "Renamed to `FallbackErrorHandler`.")]
 pub type DefaultErrorHandler = FallbackErrorHandler;
 
+#[cfg(feature = "std")]
+std::thread_local! {
+    /// When deliberately throwing a panic in your [`ErrorHandler`],
+    /// set this to true to indicate to the executor that the panic
+    /// should not be turned back into a [`BevyError`].
+    pub static PANIC_ORIGINATES_FROM_ERROR_HANDLER: core::cell::Cell<bool>  = const {core::cell::Cell::new(false)};
+}
+
 /// Error handler that defers to an error's [`Severity`].
 #[track_caller]
 #[inline]
@@ -143,6 +156,7 @@ pub fn match_severity(err: BevyError, ctx: ErrorContext) {
 #[track_caller]
 #[inline]
 pub fn panic(error: BevyError, ctx: ErrorContext) {
+    PANIC_ORIGINATES_FROM_ERROR_HANDLER.set(true);
     inner!(panic, error, ctx);
 }
 

--- a/crates/bevy_ecs/src/error/handler.rs
+++ b/crates/bevy_ecs/src/error/handler.rs
@@ -103,9 +103,9 @@ macro_rules! inner {
 
 /// Defines how Bevy reacts to errors.
 ///
-/// When writing an error handler, if you want to thow a panic,
+/// When writing an error handler, if you want to throw a panic,
 /// consider setting [`PANIC_ORIGINATES_FROM_ERROR_HANDLER`].
-/// This lets the excecutor know that a panic doesn't need to be
+/// This lets the executor know that a panic doesn't need to be
 /// converted back to a [`BevyError`] and passed to the [`FallbackErrorHandler`].
 pub type ErrorHandler = fn(BevyError, ErrorContext);
 

--- a/crates/bevy_ecs/src/error/handler.rs
+++ b/crates/bevy_ecs/src/error/handler.rs
@@ -156,6 +156,7 @@ pub fn match_severity(err: BevyError, ctx: ErrorContext) {
 #[track_caller]
 #[inline]
 pub fn panic(error: BevyError, ctx: ErrorContext) {
+    #[cfg(feature = "std")]
     PANIC_ORIGINATES_FROM_ERROR_HANDLER.set(true);
     inner!(panic, error, ctx);
 }

--- a/crates/bevy_ecs/src/schedule/executor/mod.rs
+++ b/crates/bevy_ecs/src/schedule/executor/mod.rs
@@ -313,6 +313,7 @@ mod __rust_begin_short_backtrace {
     }
 
     #[inline(never)]
+    #[cfg(feature = "std")]
     pub(super) fn error_handler(
         error_handler: crate::error::ErrorHandler,
         err: crate::error::BevyError,

--- a/crates/bevy_ecs/src/schedule/executor/mod.rs
+++ b/crates/bevy_ecs/src/schedule/executor/mod.rs
@@ -311,6 +311,16 @@ mod __rust_begin_short_backtrace {
         // Call `black_box` to prevent this frame from being tail-call optimized away
         black_box(system.run((), world))
     }
+
+    #[inline(never)]
+    pub(super) fn error_handler(
+        error_handler: crate::error::ErrorHandler,
+        err: crate::error::BevyError,
+        err_context: crate::error::ErrorContext,
+    ) {
+        error_handler(err, err_context);
+        black_box(());
+    }
 }
 
 #[cfg(test)]

--- a/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
@@ -813,24 +813,45 @@ unsafe fn evaluate_and_fold_conditions(
     conditions
         .iter_mut()
         .map(|ConditionWithAccess { condition, .. }| {
-            // SAFETY:
-            // - The caller ensures that `world` has permission to read any data
-            //   required by the condition.
-            unsafe { __rust_begin_short_backtrace::readonly_run_unsafe(&mut **condition, world) }
-                .unwrap_or_else(|err| {
-                    if let RunSystemError::Failed(err) = err {
-                        error_handler(
-                            err,
-                            ErrorContext::RunCondition {
-                                name: condition.name(),
-                                last_run: condition.get_last_run(),
-                                system: for_system.name(),
-                                on_set,
-                            },
-                        );
-                    };
-                    false
-                })
+            let result = std::panic::catch_unwind(AssertUnwindSafe(||
+                // SAFETY:
+                // - The caller ensures that `world` has permission to read any data
+                //   required by the condition.
+                unsafe { __rust_begin_short_backtrace::readonly_run_unsafe(&mut **condition, world) }
+                    .unwrap_or_else(|err| {
+                        if let RunSystemError::Failed(err) = err {
+                            error_handler(
+                                err,
+                                ErrorContext::RunCondition {
+                                    name: condition.name(),
+                                    last_run: condition.get_last_run(),
+                                    system: for_system.name(),
+                                    on_set,
+                                },
+                            );
+                        };
+                        false
+                    })
+            ));
+            match result {
+                Ok(r) => r,
+                Err(_) => {
+                    __rust_begin_short_backtrace::error_handler(
+                        error_handler,
+                        BevyError::new_with_backtrace(
+                            Severity::Panic,
+                            "Encountered panic",
+                            Backtrace::disabled(),
+                        ),
+                        ErrorContext::RunCondition {
+                            name: condition.name(),
+                            last_run: condition.get_last_run(),
+                            system: for_system.name(),
+                            on_set,
+                        },
+                    );false
+                }
+            }
         })
         .fold(true, |acc, res| acc && res)
 }

--- a/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
@@ -813,28 +813,18 @@ unsafe fn evaluate_and_fold_conditions(
     conditions
         .iter_mut()
         .map(|ConditionWithAccess { condition, .. }| {
-            let result = std::panic::catch_unwind(AssertUnwindSafe(||
+            PANIC_ORIGINATES_FROM_ERROR_HANDLER.set(false);
+            let potential_unwind = std::panic::catch_unwind(AssertUnwindSafe(||
                 // SAFETY:
                 // - The caller ensures that `world` has permission to read any data
                 //   required by the condition.
-                unsafe { __rust_begin_short_backtrace::readonly_run_unsafe(&mut **condition, world) }
-                    .unwrap_or_else(|err| {
-                        if let RunSystemError::Failed(err) = err {
-                            error_handler(
-                                err,
-                                ErrorContext::RunCondition {
-                                    name: condition.name(),
-                                    last_run: condition.get_last_run(),
-                                    system: for_system.name(),
-                                    on_set,
-                                },
-                            );
-                        };
-                        false
-                    })
+                unsafe {__rust_begin_short_backtrace::readonly_run_unsafe(&mut **condition, world)}
             ));
-            match result {
-                Ok(r) => r,
+            let panic_originates_from_error_handler = PANIC_ORIGINATES_FROM_ERROR_HANDLER.replace(false);
+            match potential_unwind {
+                // A panic occurred, but it came from an error handler, so rethrow it
+                Err(payload) if panic_originates_from_error_handler => std::panic::resume_unwind(payload),
+                // Let the error handler handle the panic
                 Err(_) => {
                     __rust_begin_short_backtrace::error_handler(
                         error_handler,
@@ -849,8 +839,22 @@ unsafe fn evaluate_and_fold_conditions(
                             system: for_system.name(),
                             on_set,
                         },
-                    );false
-                }
+                    ); false},
+                // Condition returned an error, let the error handler handle it
+                Ok(Err(RunSystemError::Failed(err))) => {
+                    __rust_begin_short_backtrace::error_handler(
+                        error_handler,
+                        err,
+                        ErrorContext::RunCondition {
+                            name: condition.name(),
+                            last_run: condition.get_last_run(),
+                            system: for_system.name(),
+                            on_set,
+                        },
+                    ); false
+                },
+                Ok(Err(RunSystemError::Skipped(_))) => false,
+                Ok(Ok(result)) => result,
             }
         })
         .fold(true, |acc, res| acc && res)
@@ -1030,5 +1034,58 @@ mod tests {
                 .unwrap_or_else(|| payload.downcast_ref::<&str>().unwrap()),
             PANIC_PAYLOAD
         );
+
+        static SYSTEM_RAN: AtomicBool = AtomicBool::new(false);
+        let system = || {
+            SYSTEM_RAN.store(true, Relaxed);
+        };
+        let mut schedule_condition_error = Schedule::default();
+        schedule_condition_error.set_executor(MultiThreadedExecutor::new());
+        schedule_condition_error.add_systems(system.run_if(|| Err(BevyError::ignore(""))));
+
+        let mut schedule_condition_panic = Schedule::default();
+        schedule_condition_panic.set_executor(MultiThreadedExecutor::new());
+        schedule_condition_panic.add_systems(system.run_if(|| {
+            panic!("Condition's panic payload");
+        }));
+
+        world.insert_resource(FallbackErrorHandler(handle));
+
+        // Condition error
+        schedule_error.run(&mut world);
+        assert!(HANDLER_CALLED.load(Relaxed));
+        assert!(!SYSTEM_RAN.load(Relaxed));
+
+        // Condition panic
+        HANDLER_CALLED.store(false, Relaxed);
+        schedule_panic.run(&mut world);
+        assert!(HANDLER_CALLED.load(Relaxed));
+        assert!(!SYSTEM_RAN.load(Relaxed));
+
+        world.insert_resource(FallbackErrorHandler(panic));
+
+        // Condition error, handler panic
+        let result = catch_unwind(AssertUnwindSafe(|| schedule_error.run(&mut world)));
+        let payload = result.unwrap_err();
+        assert_eq!(
+            payload
+                .downcast_ref::<String>()
+                .map(String::as_str)
+                .unwrap_or_else(|| payload.downcast_ref::<&str>().unwrap()),
+            PANIC_PAYLOAD
+        );
+        assert!(!SYSTEM_RAN.load(Relaxed));
+
+        // Condition panic, handler panic
+        let result = catch_unwind(AssertUnwindSafe(|| schedule_panic.run(&mut world)));
+        let payload = result.unwrap_err();
+        assert_eq!(
+            payload
+                .downcast_ref::<String>()
+                .map(String::as_str)
+                .unwrap_or_else(|| payload.downcast_ref::<&str>().unwrap()),
+            PANIC_PAYLOAD
+        );
+        assert!(!SYSTEM_RAN.load(Relaxed));
     }
 }

--- a/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
@@ -907,7 +907,14 @@ impl MainThreadExecutor {
 
 #[cfg(test)]
 mod tests {
+    use core::{
+        panic::AssertUnwindSafe,
+        sync::atomic::{AtomicBool, Ordering::Relaxed},
+    };
+    use std::{panic::catch_unwind, string::String};
+
     use crate::{
+        error::{BevyError, ErrorContext, FallbackErrorHandler},
         prelude::Resource,
         schedule::{IntoScheduleConfigs, MultiThreadedExecutor, Schedule},
         system::Commands,
@@ -946,5 +953,57 @@ mod tests {
         schedule.set_executor(MultiThreadedExecutor::new());
         schedule.add_systems(((|_: Commands| {}), |_: Commands| {}).chain());
         schedule.run(&mut world);
+    }
+
+    #[test]
+    fn panic_to_error() {
+        let mut world = World::new();
+
+        let mut schedule_error = Schedule::default();
+        schedule_error.set_executor(MultiThreadedExecutor::new());
+        schedule_error.add_systems(|| Err(BevyError::ignore("")));
+
+        let mut schedule_panic = Schedule::default();
+        schedule_panic.set_executor(MultiThreadedExecutor::new());
+        schedule_panic.add_systems(|| {
+            panic!();
+        });
+
+        static HANDLER_CALLED: AtomicBool = AtomicBool::new(false);
+        fn handle(_: BevyError, ctx: ErrorContext) {
+            assert!(matches!(ctx, ErrorContext::System { .. }));
+            HANDLER_CALLED.store(true, Relaxed);
+        }
+        world.insert_resource(FallbackErrorHandler(handle));
+
+        // System error
+        schedule_error.run(&mut world);
+        assert!(HANDLER_CALLED.load(Relaxed));
+
+        // System panic
+        HANDLER_CALLED.store(false, Relaxed);
+        schedule_panic.run(&mut world);
+        assert!(HANDLER_CALLED.load(Relaxed));
+
+        const PANIC_PAYLOAD: &str = "UwU";
+        fn panic(_: BevyError, ctx: ErrorContext) {
+            assert!(matches!(ctx, ErrorContext::System { .. }));
+            panic!("{}", PANIC_PAYLOAD);
+        }
+        world.insert_resource(FallbackErrorHandler(panic));
+
+        // System error, handler panic
+        let result = catch_unwind(AssertUnwindSafe(|| schedule_error.run(&mut world)));
+        assert_eq!(
+            *result.unwrap_err().downcast_ref::<String>().unwrap(),
+            PANIC_PAYLOAD
+        );
+
+        // System panic, handler panic
+        let result = catch_unwind(AssertUnwindSafe(|| schedule_panic.run(&mut world)));
+        assert_eq!(
+            *result.unwrap_err().downcast_ref::<String>().unwrap(),
+            PANIC_PAYLOAD
+        );
     }
 }

--- a/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
@@ -24,7 +24,7 @@ use crate::{
     schedule::{
         is_apply_deferred, ConditionWithAccess, SystemExecutor, SystemSchedule, SystemWithAccess,
     },
-    system::{RunSystemError, ScheduleSystem},
+    system::{RunSystemError, ScheduleSystem, System},
     world::{unsafe_world_cell::UnsafeWorldCell, World},
 };
 #[cfg(feature = "hotpatching")]
@@ -671,39 +671,7 @@ impl ExecutorState {
                     __rust_begin_short_backtrace::run_unsafe(system, context.environment.world_cell)
                 }
             }));
-            // If the system returned an unhandled error or panicked,
-            // invoke the fallback error handler. If the error handler decides to panic,
-            // we need to catch this panic and rethrow it on the main thread for proper teardown.
-            let (err, mut res) = match res {
-                // The error has already been handled (by deliberately panicking), so propagate that
-                Err(payload) if PANIC_ORIGINATES_FROM_ERROR_HANDLER.replace(false) => {
-                    (None, Err(payload))
-                }
-                // We can ignore the panic payload here, as it will have already been printed.
-                Err(_) => {
-                    let err = BevyError::new_with_backtrace(
-                        Severity::Panic,
-                        "System panicked",
-                        Backtrace::disabled(),
-                    );
-                    (Some(err), Ok(()))
-                }
-                Ok(Err(RunSystemError::Failed(err))) => (Some(err), Ok(())),
-                _ => (None, Ok(())),
-            };
-            if let Some(err) = err {
-                // An error occurred, handle it and propagate the panic if needed
-                res = std::panic::catch_unwind(AssertUnwindSafe(|| {
-                    __rust_begin_short_backtrace::error_handler(
-                        context.error_handler,
-                        err,
-                        ErrorContext::System {
-                            name: system.name(),
-                            last_run: system.get_last_run(),
-                        },
-                    );
-                }));
-            }
+            let res = handle_errors(res, context.error_handler, &**system, "System panicked");
             context.system_completed(system_index, res, system);
         };
 
@@ -744,30 +712,12 @@ impl ExecutorState {
                 let res = std::panic::catch_unwind(AssertUnwindSafe(|| {
                     __rust_begin_short_backtrace::run(system, world)
                 }));
-                let (err, mut res) = match res {
-                    Err(_) => {
-                        let err = BevyError::new_with_backtrace(
-                            Severity::Panic,
-                            "System panicked",
-                            Backtrace::disabled(),
-                        );
-                        (Some(err), Ok(()))
-                    }
-                    Ok(Err(RunSystemError::Failed(err))) => (Some(err), Ok(())),
-                    _ => (None, Ok(())),
-                };
-                if let Some(err) = err {
-                    res = std::panic::catch_unwind(AssertUnwindSafe(|| {
-                        __rust_begin_short_backtrace::error_handler(
-                            context.error_handler,
-                            err,
-                            ErrorContext::System {
-                                name: system.name(),
-                                last_run: system.get_last_run(),
-                            },
-                        );
-                    }));
-                }
+                let res = handle_errors(
+                    res,
+                    context.error_handler,
+                    &**system,
+                    "Exclusive system panicked",
+                );
                 context.system_completed(system_index, res, system);
             };
 
@@ -826,25 +776,12 @@ fn apply_deferred(
         let res = std::panic::catch_unwind(AssertUnwindSafe(|| {
             system.apply_deferred(world);
         }));
-        if res.is_err() {
-            if PANIC_ORIGINATES_FROM_ERROR_HANDLER.replace(false) {
-                return res;
-            }
-            let err = BevyError::new_with_backtrace(
-                Severity::Panic,
-                "Encountered a panic while applying system buffers",
-                Backtrace::disabled(),
-            );
-            std::panic::catch_unwind(AssertUnwindSafe(|| {
-                world.fallback_error_handler()(
-                    err,
-                    ErrorContext::System {
-                        name: system.name(),
-                        last_run: system.get_last_run(),
-                    },
-                );
-            }))?;
-        }
+        handle_errors(
+            res.map(|()| Ok(())),
+            world.fallback_error_handler(),
+            &**system,
+            "Encountered a panic while applying system buffers",
+        )?;
     }
     Ok(())
 }
@@ -886,6 +823,48 @@ unsafe fn evaluate_and_fold_conditions(
                 })
         })
         .fold(true, |acc, res| acc && res)
+}
+
+/// Handle a potential panic or failed system by invoking the fallback error handler
+/// and/or returning a panic payload with which to resume unwinding.
+fn handle_errors(
+    potential_unwind: Result<Result<(), RunSystemError>, Box<dyn Any + Send>>,
+    error_handler: ErrorHandler,
+    in_system: &dyn System<In = (), Out = ()>,
+    error_message: &str,
+) -> Result<(), Box<dyn Any + Send>> {
+    match potential_unwind {
+        // A panic occurred, but it came from an error handler, so pass it on to be rethrown
+        Err(payload) if PANIC_ORIGINATES_FROM_ERROR_HANDLER.replace(false) => Err(payload),
+        // Let the fallback error handler handle the panic, passing on any panic it throws
+        Err(_) => std::panic::catch_unwind(AssertUnwindSafe(|| {
+            __rust_begin_short_backtrace::error_handler(
+                error_handler,
+                BevyError::new_with_backtrace(
+                    Severity::Panic,
+                    error_message,
+                    Backtrace::disabled(),
+                ),
+                ErrorContext::System {
+                    name: in_system.name(),
+                    last_run: in_system.get_last_run(),
+                },
+            );
+        })),
+        // System returned an error, let the fallback error handler handle it, passing on any panic it throws
+        Ok(Err(RunSystemError::Failed(err))) => std::panic::catch_unwind(AssertUnwindSafe(|| {
+            __rust_begin_short_backtrace::error_handler(
+                error_handler,
+                err,
+                ErrorContext::System {
+                    name: in_system.name(),
+                    last_run: in_system.get_last_run(),
+                },
+            );
+        })),
+        // Success
+        _ => Ok(()),
+    }
 }
 
 /// New-typed [`ThreadExecutor`] [`Resource`] that is used to run systems on the main thread

--- a/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
@@ -845,9 +845,10 @@ fn handle_errors(
 ) -> Result<(), Box<dyn Any + Send>> {
     PANIC_ORIGINATES_FROM_ERROR_HANDLER.set(false);
     let potential_unwind = std::panic::catch_unwind(AssertUnwindSafe(|| f(system)));
+    let panic_originates_from_error_handler = PANIC_ORIGINATES_FROM_ERROR_HANDLER.replace(false);
     match potential_unwind {
         // A panic occurred, but it came from an error handler, so pass it on to be rethrown
-        Err(payload) if PANIC_ORIGINATES_FROM_ERROR_HANDLER.replace(false) => Err(payload),
+        Err(payload) if panic_originates_from_error_handler => Err(payload),
         // Let the error handler handle the panic, passing on any panic it throws
         Err(_) => std::panic::catch_unwind(AssertUnwindSafe(|| {
             __rust_begin_short_backtrace::error_handler(
@@ -874,7 +875,7 @@ fn handle_errors(
                 },
             );
         })),
-        // Success
+        // Success (or skipped system)
         _ => Ok(()),
     }
 }

--- a/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
@@ -24,7 +24,7 @@ use crate::{
     schedule::{
         is_apply_deferred, ConditionWithAccess, SystemExecutor, SystemSchedule, SystemWithAccess,
     },
-    system::{RunSystemError, ScheduleSystem, System},
+    system::{BoxedSystem, RunSystemError, ScheduleSystem, System},
     world::{unsafe_world_cell::UnsafeWorldCell, World},
 };
 #[cfg(feature = "hotpatching")]
@@ -838,8 +838,8 @@ unsafe fn evaluate_and_fold_conditions(
 /// Handle a potential panic or failed system by invoking the error handler
 /// and/or returning a panic payload with which to resume unwinding.
 fn handle_errors(
-    f: impl FnOnce(&mut Box<dyn System<In = (), Out = ()>>) -> Result<(), RunSystemError>,
-    system: &mut Box<dyn System<In = (), Out = ()>>,
+    f: impl FnOnce(&mut BoxedSystem) -> Result<(), RunSystemError>,
+    system: &mut BoxedSystem,
     error_handler: ErrorHandler,
     error_message: &str,
 ) -> Result<(), Box<dyn Any + Send>> {

--- a/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
@@ -300,7 +300,7 @@ impl SystemExecutor for MultiThreadedExecutor {
         if self.apply_final_deferred {
             // Do one final apply buffers after all systems have completed
             // Commands should be applied while on the scope's thread, not the executor's thread
-            let res = apply_deferred(&state.unapplied_systems, systems, world);
+            let res = apply_deferred(&state.unapplied_systems, systems, world, error_handler);
             if let Err(payload) = res {
                 let panic_payload = self.panic_payload.get_mut().unwrap();
                 *panic_payload = Some(payload);
@@ -699,7 +699,12 @@ impl ExecutorState {
                 // SAFETY: `can_run` returned true for this system, which means
                 // that no other systems currently have access to the world.
                 let world = unsafe { context.environment.world_cell.world_mut() };
-                let res = apply_deferred(&unapplied_systems, context.environment.systems, world);
+                let res = apply_deferred(
+                    &unapplied_systems,
+                    context.environment.systems,
+                    world,
+                    context.error_handler,
+                );
                 context.system_completed(system_index, res, system);
             };
 
@@ -769,6 +774,7 @@ fn apply_deferred(
     unapplied_systems: &FixedBitSet,
     systems: &[SyncUnsafeCell<SystemWithAccess>],
     world: &mut World,
+    error_handler: ErrorHandler,
 ) -> Result<(), Box<dyn Any + Send>> {
     for system_index in unapplied_systems.ones() {
         // SAFETY: none of these systems are running, no other references exist
@@ -778,7 +784,7 @@ fn apply_deferred(
         }));
         handle_errors(
             res.map(|()| Ok(())),
-            world.fallback_error_handler(),
+            error_handler,
             &**system,
             "Encountered a panic while applying system buffers",
         )?;
@@ -825,7 +831,7 @@ unsafe fn evaluate_and_fold_conditions(
         .fold(true, |acc, res| acc && res)
 }
 
-/// Handle a potential panic or failed system by invoking the fallback error handler
+/// Handle a potential panic or failed system by invoking the error handler
 /// and/or returning a panic payload with which to resume unwinding.
 fn handle_errors(
     potential_unwind: Result<Result<(), RunSystemError>, Box<dyn Any + Send>>,
@@ -836,7 +842,7 @@ fn handle_errors(
     match potential_unwind {
         // A panic occurred, but it came from an error handler, so pass it on to be rethrown
         Err(payload) if PANIC_ORIGINATES_FROM_ERROR_HANDLER.replace(false) => Err(payload),
-        // Let the fallback error handler handle the panic, passing on any panic it throws
+        // Let the error handler handle the panic, passing on any panic it throws
         Err(_) => std::panic::catch_unwind(AssertUnwindSafe(|| {
             __rust_begin_short_backtrace::error_handler(
                 error_handler,
@@ -851,7 +857,7 @@ fn handle_errors(
                 },
             );
         })),
-        // System returned an error, let the fallback error handler handle it, passing on any panic it throws
+        // System returned an error, let the error handler handle it, passing on any panic it throws
         Ok(Err(RunSystemError::Failed(err))) => std::panic::catch_unwind(AssertUnwindSafe(|| {
             __rust_begin_short_backtrace::error_handler(
                 error_handler,

--- a/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
@@ -892,8 +892,10 @@ impl MainThreadExecutor {
 
 #[cfg(test)]
 mod tests {
+    use alloc::boxed::Box;
     use alloc::string::String;
     use core::{
+        any::Any,
         panic::AssertUnwindSafe,
         sync::atomic::{AtomicBool, Ordering::Relaxed},
     };
@@ -972,6 +974,16 @@ mod tests {
         assert!(HANDLER_CALLED.load(Relaxed));
 
         const PANIC_PAYLOAD: &str = "UwU";
+        fn assert_panic_payload(result: Result<(), Box<dyn Any + Send>>) {
+            let payload = result.unwrap_err();
+            assert_eq!(
+                payload
+                    .downcast_ref::<String>()
+                    .map(String::as_str)
+                    .unwrap_or_else(|| payload.downcast_ref::<&str>().unwrap()),
+                PANIC_PAYLOAD
+            );
+        }
         fn panic(_: BevyError, ctx: ErrorContext) {
             assert!(matches!(ctx, ErrorContext::System { .. }));
             panic!("{}", PANIC_PAYLOAD);
@@ -980,16 +992,10 @@ mod tests {
 
         // System error, handler panic
         let result = catch_unwind(AssertUnwindSafe(|| schedule_error.run(&mut world)));
-        assert_eq!(
-            *result.unwrap_err().downcast_ref::<String>().unwrap(),
-            PANIC_PAYLOAD
-        );
+        assert_panic_payload(result);
 
         // System panic, handler panic
         let result = catch_unwind(AssertUnwindSafe(|| schedule_panic.run(&mut world)));
-        assert_eq!(
-            *result.unwrap_err().downcast_ref::<String>().unwrap(),
-            PANIC_PAYLOAD
-        );
+        assert_panic_payload(result);
     }
 }

--- a/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
@@ -907,11 +907,12 @@ impl MainThreadExecutor {
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::String;
     use core::{
         panic::AssertUnwindSafe,
         sync::atomic::{AtomicBool, Ordering::Relaxed},
     };
-    use std::{alloc::String, panic::catch_unwind};
+    use std::panic::catch_unwind;
 
     use crate::{
         error::{BevyError, ErrorContext, FallbackErrorHandler},

--- a/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
@@ -967,7 +967,7 @@ mod tests {
         let mut schedule_panic = Schedule::default();
         schedule_panic.set_executor(MultiThreadedExecutor::new());
         schedule_panic.add_systems(|| {
-            panic!();
+            panic!("System's panic payload");
         });
 
         static HANDLER_CALLED: AtomicBool = AtomicBool::new(false);

--- a/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
@@ -662,16 +662,23 @@ impl ExecutorState {
         let system_meta = &self.system_task_metadata[system_index];
 
         let task = async move {
-            let res = std::panic::catch_unwind(AssertUnwindSafe(|| {
-                // SAFETY:
-                // - The caller ensures that we have permission to
-                // access the world data used by the system.
-                // - `is_exclusive` returned false
-                unsafe {
-                    __rust_begin_short_backtrace::run_unsafe(system, context.environment.world_cell)
-                }
-            }));
-            let res = handle_errors(res, context.error_handler, &**system, "System panicked");
+            let res = handle_errors(
+                |system| {
+                    // SAFETY:
+                    // - The caller ensures that we have permission to
+                    // access the world data used by the system.
+                    // - `is_exclusive` returned false
+                    unsafe {
+                        __rust_begin_short_backtrace::run_unsafe(
+                            system,
+                            context.environment.world_cell,
+                        )
+                    }
+                },
+                system,
+                context.error_handler,
+                "System panicked",
+            );
             context.system_completed(system_index, res, system);
         };
 
@@ -714,13 +721,10 @@ impl ExecutorState {
                 // SAFETY: `can_run` returned true for this system, which means
                 // that no other systems currently have access to the world.
                 let world = unsafe { context.environment.world_cell.world_mut() };
-                let res = std::panic::catch_unwind(AssertUnwindSafe(|| {
-                    __rust_begin_short_backtrace::run(system, world)
-                }));
                 let res = handle_errors(
-                    res,
+                    |system| __rust_begin_short_backtrace::run(system, world),
+                    system,
                     context.error_handler,
-                    &**system,
                     "Exclusive system panicked",
                 );
                 context.system_completed(system_index, res, system);
@@ -779,13 +783,13 @@ fn apply_deferred(
     for system_index in unapplied_systems.ones() {
         // SAFETY: none of these systems are running, no other references exist
         let system = &mut unsafe { &mut *systems[system_index].get() }.system;
-        let res = std::panic::catch_unwind(AssertUnwindSafe(|| {
-            system.apply_deferred(world);
-        }));
         handle_errors(
-            res.map(|()| Ok(())),
+            |system| {
+                system.apply_deferred(world);
+                Ok(())
+            },
+            system,
             error_handler,
-            &**system,
             "Encountered a panic while applying system buffers",
         )?;
     }
@@ -834,11 +838,13 @@ unsafe fn evaluate_and_fold_conditions(
 /// Handle a potential panic or failed system by invoking the error handler
 /// and/or returning a panic payload with which to resume unwinding.
 fn handle_errors(
-    potential_unwind: Result<Result<(), RunSystemError>, Box<dyn Any + Send>>,
+    f: impl FnOnce(&mut Box<dyn System<In = (), Out = ()>>) -> Result<(), RunSystemError>,
+    system: &mut Box<dyn System<In = (), Out = ()>>,
     error_handler: ErrorHandler,
-    in_system: &dyn System<In = (), Out = ()>,
     error_message: &str,
 ) -> Result<(), Box<dyn Any + Send>> {
+    PANIC_ORIGINATES_FROM_ERROR_HANDLER.set(false);
+    let potential_unwind = std::panic::catch_unwind(AssertUnwindSafe(|| f(system)));
     match potential_unwind {
         // A panic occurred, but it came from an error handler, so pass it on to be rethrown
         Err(payload) if PANIC_ORIGINATES_FROM_ERROR_HANDLER.replace(false) => Err(payload),
@@ -852,8 +858,8 @@ fn handle_errors(
                     Backtrace::disabled(),
                 ),
                 ErrorContext::System {
-                    name: in_system.name(),
-                    last_run: in_system.get_last_run(),
+                    name: system.name(),
+                    last_run: system.get_last_run(),
                 },
             );
         })),
@@ -863,8 +869,8 @@ fn handle_errors(
                 error_handler,
                 err,
                 ErrorContext::System {
-                    name: in_system.name(),
-                    last_run: in_system.get_last_run(),
+                    name: system.name(),
+                    last_run: system.get_last_run(),
                 },
             );
         })),
@@ -892,17 +898,17 @@ impl MainThreadExecutor {
 
 #[cfg(test)]
 mod tests {
-    use alloc::boxed::Box;
     use alloc::string::String;
     use core::{
-        any::Any,
         panic::AssertUnwindSafe,
         sync::atomic::{AtomicBool, Ordering::Relaxed},
     };
     use std::panic::catch_unwind;
 
     use crate::{
-        error::{BevyError, ErrorContext, FallbackErrorHandler},
+        error::{
+            BevyError, ErrorContext, FallbackErrorHandler, PANIC_ORIGINATES_FROM_ERROR_HANDLER,
+        },
         prelude::Resource,
         schedule::{IntoScheduleConfigs, MultiThreadedExecutor, Schedule},
         system::Commands,
@@ -974,28 +980,33 @@ mod tests {
         assert!(HANDLER_CALLED.load(Relaxed));
 
         const PANIC_PAYLOAD: &str = "UwU";
-        fn assert_panic_payload(result: Result<(), Box<dyn Any + Send>>) {
-            let payload = result.unwrap_err();
-            assert_eq!(
-                payload
-                    .downcast_ref::<String>()
-                    .map(String::as_str)
-                    .unwrap_or_else(|| payload.downcast_ref::<&str>().unwrap()),
-                PANIC_PAYLOAD
-            );
-        }
         fn panic(_: BevyError, ctx: ErrorContext) {
             assert!(matches!(ctx, ErrorContext::System { .. }));
+            PANIC_ORIGINATES_FROM_ERROR_HANDLER.set(true);
             panic!("{}", PANIC_PAYLOAD);
         }
         world.insert_resource(FallbackErrorHandler(panic));
 
         // System error, handler panic
         let result = catch_unwind(AssertUnwindSafe(|| schedule_error.run(&mut world)));
-        assert_panic_payload(result);
+        let payload = result.unwrap_err();
+        assert_eq!(
+            payload
+                .downcast_ref::<String>()
+                .map(String::as_str)
+                .unwrap_or_else(|| payload.downcast_ref::<&str>().unwrap()),
+            PANIC_PAYLOAD
+        );
 
         // System panic, handler panic
         let result = catch_unwind(AssertUnwindSafe(|| schedule_panic.run(&mut world)));
-        assert_panic_payload(result);
+        let payload = result.unwrap_err();
+        assert_eq!(
+            payload
+                .downcast_ref::<String>()
+                .map(String::as_str)
+                .unwrap_or_else(|| payload.downcast_ref::<&str>().unwrap()),
+            PANIC_PAYLOAD
+        );
     }
 }

--- a/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
@@ -692,7 +692,7 @@ impl ExecutorState {
                 _ => (None, Ok(())),
             };
             if let Some(err) = err {
-                // An error occured, handle it and propagate the panic if needed
+                // An error occurred, handle it and propagate the panic if needed
                 res = std::panic::catch_unwind(AssertUnwindSafe(|| {
                     __rust_begin_short_backtrace::error_handler(
                         context.error_handler,

--- a/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
@@ -7,13 +7,16 @@ use core::{any::Any, panic::AssertUnwindSafe};
 use fixedbitset::FixedBitSet;
 #[cfg(feature = "std")]
 use std::eprintln;
-use std::sync::{Mutex, MutexGuard};
+use std::{
+    backtrace::Backtrace,
+    sync::{Mutex, MutexGuard},
+};
 
 #[cfg(feature = "trace")]
 use tracing::{info_span, Span};
 
 use crate::{
-    error::{ErrorContext, ErrorHandler, Result},
+    error::{BevyError, ErrorContext, ErrorHandler, Result, Severity},
     prelude::Resource,
     schedule::{
         is_apply_deferred, ConditionWithAccess, SystemExecutor, SystemSchedule, SystemWithAccess,
@@ -662,22 +665,38 @@ impl ExecutorState {
                 // access the world data used by the system.
                 // - `is_exclusive` returned false
                 unsafe {
-                    if let Err(RunSystemError::Failed(err)) =
-                        __rust_begin_short_backtrace::run_unsafe(
-                            system,
-                            context.environment.world_cell,
-                        )
-                    {
-                        (context.error_handler)(
-                            err,
-                            ErrorContext::System {
-                                name: system.name(),
-                                last_run: system.get_last_run(),
-                            },
-                        );
-                    }
-                };
+                    __rust_begin_short_backtrace::run_unsafe(system, context.environment.world_cell)
+                }
             }));
+            // If the system returned an unhandled error or panicked,
+            // invoke the fallback error handler. If the error handler decides to panic,
+            // we need to catch this panic and rethrow it on the main thread for proper teardown.
+            let err = match res {
+                // We can ignore the panic payload here, as it will have already been printed
+                Err(_) => {
+                    let err = BevyError::new_with_backtrace(
+                        Severity::Panic,
+                        "System panicked",
+                        Backtrace::disabled(),
+                    );
+                    Some(err)
+                }
+                Ok(Err(RunSystemError::Failed(err))) => Some(err),
+                _ => None,
+            };
+            let res = if let Some(err) = err {
+                std::panic::catch_unwind(AssertUnwindSafe(|| {
+                    (context.error_handler)(
+                        err,
+                        ErrorContext::System {
+                            name: system.name(),
+                            last_run: system.get_last_run(),
+                        },
+                    );
+                }))
+            } else {
+                Ok(())
+            };
             context.system_completed(system_index, res, system);
         };
 
@@ -716,9 +735,22 @@ impl ExecutorState {
                 // that no other systems currently have access to the world.
                 let world = unsafe { context.environment.world_cell.world_mut() };
                 let res = std::panic::catch_unwind(AssertUnwindSafe(|| {
-                    if let Err(RunSystemError::Failed(err)) =
-                        __rust_begin_short_backtrace::run(system, world)
-                    {
+                    __rust_begin_short_backtrace::run(system, world)
+                }));
+                let err = match res {
+                    Err(_) => {
+                        let err = BevyError::new_with_backtrace(
+                            Severity::Panic,
+                            "System panicked",
+                            Backtrace::disabled(),
+                        );
+                        Some(err)
+                    }
+                    Ok(Err(RunSystemError::Failed(err))) => Some(err),
+                    _ => None,
+                };
+                let res = if let Some(err) = err {
+                    std::panic::catch_unwind(AssertUnwindSafe(|| {
                         (context.error_handler)(
                             err,
                             ErrorContext::System {
@@ -726,8 +758,10 @@ impl ExecutorState {
                                 last_run: system.get_last_run(),
                             },
                         );
-                    }
-                }));
+                    }))
+                } else {
+                    Ok(())
+                };
                 context.system_completed(system_index, res, system);
             };
 
@@ -786,16 +820,22 @@ fn apply_deferred(
         let res = std::panic::catch_unwind(AssertUnwindSafe(|| {
             system.apply_deferred(world);
         }));
-        if let Err(payload) = res {
-            #[cfg(feature = "std")]
-            #[expect(clippy::print_stderr, reason = "Allowed behind `std` feature gate.")]
-            {
-                eprintln!(
-                    "Encountered a panic when applying buffers for system `{}`!",
-                    system.name()
+        if res.is_err() {
+            let name = system.name();
+            let err = BevyError::new_with_backtrace(
+                Severity::Panic,
+                "Encountered a panic while applying system buffers",
+                Backtrace::disabled(),
+            );
+            std::panic::catch_unwind(AssertUnwindSafe(|| {
+                world.fallback_error_handler()(
+                    err,
+                    ErrorContext::System {
+                        name,
+                        last_run: system.get_last_run(),
+                    },
                 );
-            }
-            return Err(payload);
+            }))?;
         }
     }
     Ok(())

--- a/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
@@ -16,7 +16,10 @@ use std::{
 use tracing::{info_span, Span};
 
 use crate::{
-    error::{BevyError, ErrorContext, ErrorHandler, Result, Severity},
+    error::{
+        BevyError, ErrorContext, ErrorHandler, Result, Severity,
+        PANIC_ORIGINATES_FROM_ERROR_HANDLER,
+    },
     prelude::Resource,
     schedule::{
         is_apply_deferred, ConditionWithAccess, SystemExecutor, SystemSchedule, SystemWithAccess,
@@ -671,32 +674,36 @@ impl ExecutorState {
             // If the system returned an unhandled error or panicked,
             // invoke the fallback error handler. If the error handler decides to panic,
             // we need to catch this panic and rethrow it on the main thread for proper teardown.
-            let err = match res {
-                // We can ignore the panic payload here, as it will have already been printed
+            let (err, mut res) = match res {
+                // The error has already been handled (by deliberately panicking), so propagate that
+                Err(payload) if PANIC_ORIGINATES_FROM_ERROR_HANDLER.replace(false) => {
+                    (None, Err(payload))
+                }
+                // We can ignore the panic payload here, as it will have already been printed.
                 Err(_) => {
                     let err = BevyError::new_with_backtrace(
                         Severity::Panic,
                         "System panicked",
                         Backtrace::disabled(),
                     );
-                    Some(err)
+                    (Some(err), Ok(()))
                 }
-                Ok(Err(RunSystemError::Failed(err))) => Some(err),
-                _ => None,
+                Ok(Err(RunSystemError::Failed(err))) => (Some(err), Ok(())),
+                _ => (None, Ok(())),
             };
-            let res = if let Some(err) = err {
-                std::panic::catch_unwind(AssertUnwindSafe(|| {
-                    (context.error_handler)(
+            if let Some(err) = err {
+                // An error occured, handle it and propagate the panic if needed
+                res = std::panic::catch_unwind(AssertUnwindSafe(|| {
+                    __rust_begin_short_backtrace::error_handler(
+                        context.error_handler,
                         err,
                         ErrorContext::System {
                             name: system.name(),
                             last_run: system.get_last_run(),
                         },
                     );
-                }))
-            } else {
-                Ok(())
-            };
+                }));
+            }
             context.system_completed(system_index, res, system);
         };
 
@@ -737,31 +744,30 @@ impl ExecutorState {
                 let res = std::panic::catch_unwind(AssertUnwindSafe(|| {
                     __rust_begin_short_backtrace::run(system, world)
                 }));
-                let err = match res {
+                let (err, mut res) = match res {
                     Err(_) => {
                         let err = BevyError::new_with_backtrace(
                             Severity::Panic,
                             "System panicked",
                             Backtrace::disabled(),
                         );
-                        Some(err)
+                        (Some(err), Ok(()))
                     }
-                    Ok(Err(RunSystemError::Failed(err))) => Some(err),
-                    _ => None,
+                    Ok(Err(RunSystemError::Failed(err))) => (Some(err), Ok(())),
+                    _ => (None, Ok(())),
                 };
-                let res = if let Some(err) = err {
-                    std::panic::catch_unwind(AssertUnwindSafe(|| {
-                        (context.error_handler)(
+                if let Some(err) = err {
+                    res = std::panic::catch_unwind(AssertUnwindSafe(|| {
+                        __rust_begin_short_backtrace::error_handler(
+                            context.error_handler,
                             err,
                             ErrorContext::System {
                                 name: system.name(),
                                 last_run: system.get_last_run(),
                             },
                         );
-                    }))
-                } else {
-                    Ok(())
-                };
+                    }));
+                }
                 context.system_completed(system_index, res, system);
             };
 
@@ -821,7 +827,9 @@ fn apply_deferred(
             system.apply_deferred(world);
         }));
         if res.is_err() {
-            let name = system.name();
+            if PANIC_ORIGINATES_FROM_ERROR_HANDLER.replace(false) {
+                return res;
+            }
             let err = BevyError::new_with_backtrace(
                 Severity::Panic,
                 "Encountered a panic while applying system buffers",
@@ -831,7 +839,7 @@ fn apply_deferred(
                 world.fallback_error_handler()(
                     err,
                     ErrorContext::System {
-                        name,
+                        name: system.name(),
                         last_run: system.get_last_run(),
                     },
                 );

--- a/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
@@ -24,7 +24,7 @@ use crate::{
     schedule::{
         is_apply_deferred, ConditionWithAccess, SystemExecutor, SystemSchedule, SystemWithAccess,
     },
-    system::{BoxedSystem, RunSystemError, ScheduleSystem, System},
+    system::{BoxedSystem, RunSystemError, ScheduleSystem},
     world::{unsafe_world_cell::UnsafeWorldCell, World},
 };
 #[cfg(feature = "hotpatching")]

--- a/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
@@ -911,7 +911,7 @@ mod tests {
         panic::AssertUnwindSafe,
         sync::atomic::{AtomicBool, Ordering::Relaxed},
     };
-    use std::{panic::catch_unwind, string::String};
+    use std::{alloc::String, panic::catch_unwind};
 
     use crate::{
         error::{BevyError, ErrorContext, FallbackErrorHandler},

--- a/crates/bevy_ecs/src/schedule/executor/single_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/single_threaded.rs
@@ -6,9 +6,6 @@ use alloc::string::ToString as _;
 #[cfg(feature = "trace")]
 use tracing::info_span;
 
-#[cfg(feature = "std")]
-use std::eprintln;
-
 use crate::{
     error::{ErrorContext, ErrorHandler},
     schedule::{is_apply_deferred, ConditionWithAccess, SystemExecutor, SystemSchedule},
@@ -146,11 +143,22 @@ impl SystemExecutor for SingleThreadedExecutor {
             });
 
             #[cfg(feature = "std")]
-            #[expect(clippy::print_stderr, reason = "Allowed behind `std` feature gate.")]
             {
-                if let Err(payload) = std::panic::catch_unwind(f) {
-                    eprintln!("Encountered a panic in system `{}`!", system.name());
-                    std::panic::resume_unwind(payload);
+                if std::panic::catch_unwind(f).is_err() {
+                    use crate::error::{BevyError, Severity};
+
+                    let err = BevyError::new_with_backtrace(
+                        Severity::Panic,
+                        "System panicked",
+                        std::backtrace::Backtrace::disabled(),
+                    );
+                    error_handler(
+                        err,
+                        ErrorContext::System {
+                            name: system.name(),
+                            last_run: system.get_last_run(),
+                        },
+                    );
                 }
             }
 

--- a/crates/bevy_ecs/src/schedule/executor/single_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/single_threaded.rs
@@ -124,7 +124,7 @@ impl SystemExecutor for SingleThreadedExecutor {
             }
 
             if is_apply_deferred(&**system) {
-                self.apply_deferred(schedule, world);
+                self.apply_deferred(schedule, world, error_handler);
                 continue;
             }
 
@@ -145,12 +145,7 @@ impl SystemExecutor for SingleThreadedExecutor {
             #[cfg(feature = "std")]
             {
                 let res = std::panic::catch_unwind(f);
-                handle_unwind(
-                    res,
-                    world.fallback_error_handler(),
-                    &**system,
-                    "System panicked",
-                );
+                handle_unwind(res, error_handler, &**system, "System panicked");
             }
 
             #[cfg(not(feature = "std"))]
@@ -162,7 +157,7 @@ impl SystemExecutor for SingleThreadedExecutor {
         }
 
         if self.apply_final_deferred {
-            self.apply_deferred(schedule, world);
+            self.apply_deferred(schedule, world, error_handler);
         }
         self.evaluated_sets.clear();
         self.completed_systems.clear();
@@ -186,7 +181,12 @@ impl SingleThreadedExecutor {
         }
     }
 
-    fn apply_deferred(&mut self, schedule: &mut SystemSchedule, world: &mut World) {
+    fn apply_deferred(
+        &mut self,
+        schedule: &mut SystemSchedule,
+        world: &mut World,
+        error_handler: ErrorHandler,
+    ) {
         for system_index in self.unapplied_systems.ones() {
             let system = &mut schedule.systems[system_index].system;
             #[cfg(not(feature = "std"))]
@@ -198,7 +198,7 @@ impl SingleThreadedExecutor {
                     std::panic::catch_unwind(AssertUnwindSafe(|| system.apply_deferred(world)));
                 handle_unwind(
                     res,
-                    world.fallback_error_handler(),
+                    error_handler,
                     &**system,
                     "Encountered a panic while applying system buffers",
                 );
@@ -253,8 +253,7 @@ fn evaluate_and_fold_conditions(
         .fold(true, |acc, res| acc && res)
 }
 
-/// Handle a potential panic or failed system by invoking the fallback error handler
-/// and/or returning a panic payload with which to resume unwinding.
+/// Handle a potential panic by invoking the error handler
 #[cfg(feature = "std")]
 fn handle_unwind(
     potential_unwind: Result<(), alloc::boxed::Box<dyn core::any::Any + Send>>,

--- a/crates/bevy_ecs/src/schedule/executor/single_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/single_threaded.rs
@@ -197,6 +197,7 @@ impl SingleThreadedExecutor {
 
             #[cfg(feature = "std")]
             {
+                crate::error::PANIC_ORIGINATES_FROM_ERROR_HANDLER.set(false);
                 let res =
                     std::panic::catch_unwind(AssertUnwindSafe(|| system.apply_deferred(world)));
                 handle_unwind(

--- a/crates/bevy_ecs/src/schedule/executor/single_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/single_threaded.rs
@@ -9,7 +9,7 @@ use tracing::info_span;
 use crate::{
     error::{ErrorContext, ErrorHandler},
     schedule::{is_apply_deferred, ConditionWithAccess, SystemExecutor, SystemSchedule},
-    system::{RunSystemError, ScheduleSystem},
+    system::{RunSystemError, ScheduleSystem, System},
     world::World,
 };
 
@@ -144,25 +144,13 @@ impl SystemExecutor for SingleThreadedExecutor {
 
             #[cfg(feature = "std")]
             {
-                if let Err(payload) = std::panic::catch_unwind(f) {
-                    if crate::error::PANIC_ORIGINATES_FROM_ERROR_HANDLER.replace(false) {
-                        std::panic::resume_unwind(payload);
-                    }
-
-                    let err = crate::error::BevyError::new_with_backtrace(
-                        crate::error::Severity::Panic,
-                        "System panicked",
-                        std::backtrace::Backtrace::disabled(),
-                    );
-                    __rust_begin_short_backtrace::error_handler(
-                        error_handler,
-                        err,
-                        ErrorContext::System {
-                            name: system.name(),
-                            last_run: system.get_last_run(),
-                        },
-                    );
-                }
+                let res = std::panic::catch_unwind(f);
+                handle_unwind(
+                    res,
+                    world.fallback_error_handler(),
+                    &**system,
+                    "System panicked",
+                );
             }
 
             #[cfg(not(feature = "std"))]
@@ -208,26 +196,12 @@ impl SingleThreadedExecutor {
             {
                 let res =
                     std::panic::catch_unwind(AssertUnwindSafe(|| system.apply_deferred(world)));
-
-                if let Err(payload) = res {
-                    if crate::error::PANIC_ORIGINATES_FROM_ERROR_HANDLER.replace(false) {
-                        std::panic::resume_unwind(payload);
-                    }
-
-                    let err = crate::error::BevyError::new_with_backtrace(
-                        crate::error::Severity::Panic,
-                        "System panicked",
-                        std::backtrace::Backtrace::disabled(),
-                    );
-                    __rust_begin_short_backtrace::error_handler(
-                        world.fallback_error_handler(),
-                        err,
-                        ErrorContext::System {
-                            name: system.name(),
-                            last_run: system.get_last_run(),
-                        },
-                    );
-                }
+                handle_unwind(
+                    res,
+                    world.fallback_error_handler(),
+                    &**system,
+                    "Encountered a panic while applying system buffers",
+                );
             }
         }
 
@@ -277,4 +251,34 @@ fn evaluate_and_fold_conditions(
             )
         })
         .fold(true, |acc, res| acc && res)
+}
+
+/// Handle a potential panic or failed system by invoking the fallback error handler
+/// and/or returning a panic payload with which to resume unwinding.
+#[cfg(feature = "std")]
+fn handle_unwind(
+    potential_unwind: Result<(), alloc::boxed::Box<dyn core::any::Any + Send>>,
+    error_handler: ErrorHandler,
+    in_system: &dyn System<In = (), Out = ()>,
+    error_message: &str,
+) {
+    if let Err(payload) = potential_unwind {
+        if crate::error::PANIC_ORIGINATES_FROM_ERROR_HANDLER.replace(false) {
+            std::panic::resume_unwind(payload);
+        }
+
+        let err = crate::error::BevyError::new_with_backtrace(
+            crate::error::Severity::Panic,
+            error_message,
+            std::backtrace::Backtrace::disabled(),
+        );
+        __rust_begin_short_backtrace::error_handler(
+            error_handler,
+            err,
+            ErrorContext::System {
+                name: in_system.name(),
+                last_run: in_system.get_last_run(),
+            },
+        );
+    }
 }

--- a/crates/bevy_ecs/src/schedule/executor/single_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/single_threaded.rs
@@ -128,7 +128,7 @@ impl SystemExecutor for SingleThreadedExecutor {
                 continue;
             }
 
-            let f = AssertUnwindSafe(|| {
+            let f = |system: &mut _| {
                 if let Err(RunSystemError::Failed(err)) =
                     __rust_begin_short_backtrace::run_without_applying_deferred(system, world)
                 {
@@ -140,17 +140,16 @@ impl SystemExecutor for SingleThreadedExecutor {
                         },
                     );
                 }
-            });
+            };
 
             #[cfg(feature = "std")]
             {
-                let res = std::panic::catch_unwind(f);
-                handle_unwind(res, error_handler, &**system, "System panicked");
+                handle_unwind(f, system, error_handler, "System panicked");
             }
 
             #[cfg(not(feature = "std"))]
             {
-                (f)();
+                (f)(system);
             }
 
             self.unapplied_systems.insert(system_index);
@@ -197,13 +196,10 @@ impl SingleThreadedExecutor {
 
             #[cfg(feature = "std")]
             {
-                crate::error::PANIC_ORIGINATES_FROM_ERROR_HANDLER.set(false);
-                let res =
-                    std::panic::catch_unwind(AssertUnwindSafe(|| system.apply_deferred(world)));
                 handle_unwind(
-                    res,
+                    |system| system.apply_deferred(world),
+                    system,
                     error_handler,
-                    &**system,
                     "Encountered a panic while applying system buffers",
                 );
             }
@@ -260,13 +256,17 @@ fn evaluate_and_fold_conditions(
 /// Handle a potential panic by invoking the error handler
 #[cfg(feature = "std")]
 fn handle_unwind(
-    potential_unwind: Result<(), alloc::boxed::Box<dyn core::any::Any + Send>>,
+    f: impl FnOnce(&mut alloc::boxed::Box<dyn crate::system::System<In = (), Out = ()>>),
+    system: &mut alloc::boxed::Box<dyn crate::system::System<In = (), Out = ()>>,
     error_handler: ErrorHandler,
-    in_system: &dyn crate::system::System<In = (), Out = ()>,
     error_message: &str,
 ) {
+    crate::error::PANIC_ORIGINATES_FROM_ERROR_HANDLER.set(false);
+    let potential_unwind = std::panic::catch_unwind(AssertUnwindSafe(|| f(system)));
+    let panic_originates_from_error_handler =
+        crate::error::PANIC_ORIGINATES_FROM_ERROR_HANDLER.replace(false);
     if let Err(payload) = potential_unwind {
-        if crate::error::PANIC_ORIGINATES_FROM_ERROR_HANDLER.replace(false) {
+        if panic_originates_from_error_handler {
             std::panic::resume_unwind(payload);
         }
 
@@ -279,8 +279,8 @@ fn handle_unwind(
             error_handler,
             err,
             ErrorContext::System {
-                name: in_system.name(),
-                last_run: in_system.get_last_run(),
+                name: system.name(),
+                last_run: system.get_last_run(),
             },
         );
     }

--- a/crates/bevy_ecs/src/schedule/executor/single_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/single_threaded.rs
@@ -5,6 +5,11 @@ use alloc::string::ToString as _;
 #[cfg(feature = "trace")]
 use tracing::info_span;
 
+#[cfg(feature = "std")]
+use crate::{
+    error::{BevyError, Severity, PANIC_ORIGINATES_FROM_ERROR_HANDLER},
+    system::BoxedSystem,
+};
 use crate::{
     error::{ErrorContext, ErrorHandler},
     schedule::{is_apply_deferred, ConditionWithAccess, SystemExecutor, SystemSchedule},
@@ -256,22 +261,21 @@ fn evaluate_and_fold_conditions(
 /// Handle a potential panic by invoking the error handler
 #[cfg(feature = "std")]
 fn handle_unwind(
-    f: impl FnOnce(&mut alloc::boxed::Box<dyn crate::system::System<In = (), Out = ()>>),
-    system: &mut alloc::boxed::Box<dyn crate::system::System<In = (), Out = ()>>,
+    f: impl FnOnce(&mut BoxedSystem),
+    system: &mut BoxedSystem,
     error_handler: ErrorHandler,
     error_message: &str,
 ) {
-    crate::error::PANIC_ORIGINATES_FROM_ERROR_HANDLER.set(false);
+    PANIC_ORIGINATES_FROM_ERROR_HANDLER.set(false);
     let potential_unwind = std::panic::catch_unwind(core::panic::AssertUnwindSafe(|| f(system)));
-    let panic_originates_from_error_handler =
-        crate::error::PANIC_ORIGINATES_FROM_ERROR_HANDLER.replace(false);
+    let panic_originates_from_error_handler = PANIC_ORIGINATES_FROM_ERROR_HANDLER.replace(false);
     if let Err(payload) = potential_unwind {
         if panic_originates_from_error_handler {
             std::panic::resume_unwind(payload);
         }
 
-        let err = crate::error::BevyError::new_with_backtrace(
-            crate::error::Severity::Panic,
+        let err = BevyError::new_with_backtrace(
+            Severity::Panic,
             error_message,
             std::backtrace::Backtrace::disabled(),
         );

--- a/crates/bevy_ecs/src/schedule/executor/single_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/single_threaded.rs
@@ -144,15 +144,18 @@ impl SystemExecutor for SingleThreadedExecutor {
 
             #[cfg(feature = "std")]
             {
-                if std::panic::catch_unwind(f).is_err() {
-                    use crate::error::{BevyError, Severity};
+                if let Err(payload) = std::panic::catch_unwind(f) {
+                    if crate::error::PANIC_ORIGINATES_FROM_ERROR_HANDLER.replace(false) {
+                        std::panic::resume_unwind(payload);
+                    }
 
-                    let err = BevyError::new_with_backtrace(
-                        Severity::Panic,
+                    let err = crate::error::BevyError::new_with_backtrace(
+                        crate::error::Severity::Panic,
                         "System panicked",
                         std::backtrace::Backtrace::disabled(),
                     );
-                    error_handler(
+                    __rust_begin_short_backtrace::error_handler(
+                        error_handler,
                         err,
                         ErrorContext::System {
                             name: system.name(),
@@ -198,7 +201,34 @@ impl SingleThreadedExecutor {
     fn apply_deferred(&mut self, schedule: &mut SystemSchedule, world: &mut World) {
         for system_index in self.unapplied_systems.ones() {
             let system = &mut schedule.systems[system_index].system;
+            #[cfg(not(feature = "std"))]
             system.apply_deferred(world);
+
+            #[cfg(feature = "std")]
+            {
+                let res =
+                    std::panic::catch_unwind(AssertUnwindSafe(|| system.apply_deferred(world)));
+
+                if let Err(payload) = res {
+                    if crate::error::PANIC_ORIGINATES_FROM_ERROR_HANDLER.replace(false) {
+                        std::panic::resume_unwind(payload);
+                    }
+
+                    let err = crate::error::BevyError::new_with_backtrace(
+                        crate::error::Severity::Panic,
+                        "System panicked",
+                        std::backtrace::Backtrace::disabled(),
+                    );
+                    __rust_begin_short_backtrace::error_handler(
+                        world.fallback_error_handler(),
+                        err,
+                        ErrorContext::System {
+                            name: system.name(),
+                            last_run: system.get_last_run(),
+                        },
+                    );
+                }
+            }
         }
 
         self.unapplied_systems.clear();

--- a/crates/bevy_ecs/src/schedule/executor/single_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/single_threaded.rs
@@ -1,3 +1,8 @@
+#[cfg(feature = "std")]
+use core::panic::AssertUnwindSafe;
+#[cfg(feature = "std")]
+use std::backtrace::Backtrace;
+
 use fixedbitset::FixedBitSet;
 
 #[cfg(feature = "trace")]
@@ -12,7 +17,9 @@ use crate::{
 };
 use crate::{
     error::{ErrorContext, ErrorHandler},
-    schedule::{is_apply_deferred, ConditionWithAccess, SystemExecutor, SystemSchedule},
+    schedule::{
+        is_apply_deferred, BoxedCondition, ConditionWithAccess, SystemExecutor, SystemSchedule,
+    },
     system::{RunSystemError, ScheduleSystem},
     world::World,
 };
@@ -238,22 +245,33 @@ fn evaluate_and_fold_conditions(
             if hotpatch_tick.is_newer_than(condition.get_last_run(), world.change_tick()) {
                 condition.refresh_hotpatch();
             }
-            __rust_begin_short_backtrace::readonly_run(&mut **condition, world).unwrap_or_else(
-                |err| {
-                    if let RunSystemError::Failed(err) = err {
-                        error_handler(
-                            err,
-                            ErrorContext::RunCondition {
-                                name: condition.name(),
-                                last_run: condition.get_last_run(),
-                                system: for_system.name(),
-                                on_set,
-                            },
-                        );
-                    };
-                    false
-                },
-            )
+            let f = |condition: &mut BoxedCondition| {
+                __rust_begin_short_backtrace::readonly_run(&mut **condition, world).unwrap_or_else(
+                    |err| {
+                        if let RunSystemError::Failed(err) = err {
+                            error_handler(
+                                err,
+                                ErrorContext::RunCondition {
+                                    name: condition.name(),
+                                    last_run: condition.get_last_run(),
+                                    system: for_system.name(),
+                                    on_set,
+                                },
+                            );
+                        };
+                        false
+                    },
+                )
+            };
+            #[cfg(not(feature = "std"))]
+            let result = {
+                let mut f = f;
+                f(condition)
+            };
+            #[cfg(feature = "std")]
+            let result =
+                handle_unwind_in_run_condition(f, condition, for_system, on_set, error_handler);
+            result
         })
         .fold(true, |acc, res| acc && res)
 }
@@ -267,18 +285,15 @@ fn handle_unwind(
     error_message: &str,
 ) {
     PANIC_ORIGINATES_FROM_ERROR_HANDLER.set(false);
-    let potential_unwind = std::panic::catch_unwind(core::panic::AssertUnwindSafe(|| f(system)));
+    let potential_unwind = std::panic::catch_unwind(AssertUnwindSafe(|| f(system)));
     let panic_originates_from_error_handler = PANIC_ORIGINATES_FROM_ERROR_HANDLER.replace(false);
     if let Err(payload) = potential_unwind {
         if panic_originates_from_error_handler {
             std::panic::resume_unwind(payload);
         }
 
-        let err = BevyError::new_with_backtrace(
-            Severity::Panic,
-            error_message,
-            std::backtrace::Backtrace::disabled(),
-        );
+        let err =
+            BevyError::new_with_backtrace(Severity::Panic, error_message, Backtrace::disabled());
         __rust_begin_short_backtrace::error_handler(
             error_handler,
             err,
@@ -287,5 +302,44 @@ fn handle_unwind(
                 last_run: system.get_last_run(),
             },
         );
+    }
+}
+
+/// Handle a potential panic by invoking the error handler
+#[cfg(feature = "std")]
+fn handle_unwind_in_run_condition(
+    f: impl FnOnce(&mut BoxedCondition) -> bool,
+    condition: &mut BoxedCondition,
+    for_system: &ScheduleSystem,
+    on_set: bool,
+    error_handler: ErrorHandler,
+) -> bool {
+    PANIC_ORIGINATES_FROM_ERROR_HANDLER.set(false);
+    let potential_unwind = std::panic::catch_unwind(AssertUnwindSafe(|| f(condition)));
+    let panic_originates_from_error_handler = PANIC_ORIGINATES_FROM_ERROR_HANDLER.replace(false);
+    match potential_unwind {
+        Ok(r) => r,
+        Err(payload) => {
+            if panic_originates_from_error_handler {
+                std::panic::resume_unwind(payload);
+            }
+
+            let err = BevyError::new_with_backtrace(
+                Severity::Panic,
+                "Encountered panic",
+                Backtrace::disabled(),
+            );
+            __rust_begin_short_backtrace::error_handler(
+                error_handler,
+                err,
+                ErrorContext::RunCondition {
+                    name: condition.name(),
+                    last_run: condition.get_last_run(),
+                    system: for_system.name(),
+                    on_set,
+                },
+            );
+            false
+        }
     }
 }

--- a/crates/bevy_ecs/src/schedule/executor/single_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/single_threaded.rs
@@ -9,7 +9,7 @@ use tracing::info_span;
 use crate::{
     error::{ErrorContext, ErrorHandler},
     schedule::{is_apply_deferred, ConditionWithAccess, SystemExecutor, SystemSchedule},
-    system::{RunSystemError, ScheduleSystem, System},
+    system::{RunSystemError, ScheduleSystem},
     world::World,
 };
 
@@ -190,7 +190,10 @@ impl SingleThreadedExecutor {
         for system_index in self.unapplied_systems.ones() {
             let system = &mut schedule.systems[system_index].system;
             #[cfg(not(feature = "std"))]
-            system.apply_deferred(world);
+            {
+                system.apply_deferred(world);
+                let _ = error_handler;
+            }
 
             #[cfg(feature = "std")]
             {
@@ -258,7 +261,7 @@ fn evaluate_and_fold_conditions(
 fn handle_unwind(
     potential_unwind: Result<(), alloc::boxed::Box<dyn core::any::Any + Send>>,
     error_handler: ErrorHandler,
-    in_system: &dyn System<In = (), Out = ()>,
+    in_system: &dyn crate::system::System<In = (), Out = ()>,
     error_message: &str,
 ) {
     if let Err(payload) = potential_unwind {

--- a/crates/bevy_ecs/src/schedule/executor/single_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/single_threaded.rs
@@ -1,4 +1,3 @@
-use core::panic::AssertUnwindSafe;
 use fixedbitset::FixedBitSet;
 
 #[cfg(feature = "trace")]
@@ -149,6 +148,7 @@ impl SystemExecutor for SingleThreadedExecutor {
 
             #[cfg(not(feature = "std"))]
             {
+                let mut f = f;
                 (f)(system);
             }
 
@@ -262,7 +262,7 @@ fn handle_unwind(
     error_message: &str,
 ) {
     crate::error::PANIC_ORIGINATES_FROM_ERROR_HANDLER.set(false);
-    let potential_unwind = std::panic::catch_unwind(AssertUnwindSafe(|| f(system)));
+    let potential_unwind = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(system)));
     let panic_originates_from_error_handler =
         crate::error::PANIC_ORIGINATES_FROM_ERROR_HANDLER.replace(false);
     if let Err(payload) = potential_unwind {

--- a/crates/bevy_ecs/src/schedule/executor/single_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/single_threaded.rs
@@ -262,7 +262,7 @@ fn handle_unwind(
     error_message: &str,
 ) {
     crate::error::PANIC_ORIGINATES_FROM_ERROR_HANDLER.set(false);
-    let potential_unwind = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(system)));
+    let potential_unwind = std::panic::catch_unwind(core::panic::AssertUnwindSafe(|| f(system)));
     let panic_originates_from_error_handler =
         crate::error::PANIC_ORIGINATES_FROM_ERROR_HANDLER.replace(false);
     if let Err(payload) = potential_unwind {

--- a/examples/ecs/error_handling.rs
+++ b/examples/ecs/error_handling.rs
@@ -31,7 +31,7 @@ fn main() {
     // types of systems the same way, except for the error handling.
     app.add_systems(Startup, setup);
 
-    // Commands can also return `Result`s, which are automatically handled by the global error handler
+    // Commands can also return `Result`s, which are automatically handled by the fallback error handler
     // if not explicitly handled by the user.
     app.add_systems(Startup, failing_commands);
 
@@ -177,7 +177,7 @@ fn failing_commands(mut commands: Commands) {
         // This entity doesn't exist!
         .entity(Entity::from_raw_u32(12345678).unwrap())
         // Normally, this failed command would panic,
-        // but since we've set the global error handler to `warn`
+        // but since we've set the fallback error handler to `warn`
         // it will log a warning instead.
         .insert(Transform::default());
 


### PR DESCRIPTION
# Objective

Currently, a panic (whether from engine or user code, as there is little distinction) takes down the entire app with it. Instead the user should be able to decide how the error is handled. This is currently not possible except by writing your own executor and setting it for all relevant schedules.

See for comparison Godot's policy on exceptions:

> ### [Why does Godot not use exceptions?](https://docs.godotengine.org/en/stable/about/faq.html#why-does-godot-not-use-exceptions)
> 
> We believe games should not crash, no matter what. If an unexpected situation happens, Godot > will print an error (which can be traced even to script), but then it will try to recover as > gracefully as possible and keep going.

Unity will also log an error and then continue if user code throws an exception. I believe Unreal does too for exceptions coming from Blueprints. Similarly, many web servers will respond with an error to a request that threw an exception, but will not crash the server itself.

This PR does not enable this behavior by default, but makes it user-configurable.

Also fixes #19109
Also (I think) fixes #7434

## Solution

Instead of rethrowing panics, hand them to the `FallbackErrorHandler`.

If the panic was thrown by an error handler in the first place, we don't need to pass it back to a handler again. I've added a way for the error handler to signal that it's the source of the panic.

The constructed error is created without a backtrace, as the default panic handler already prints it when instructed to via `RUST_LIB_BACKTRACE`/`RUST_BACKTRACE`.

Panics will not be turned into errors on `no_std` projects.

Potential work for a future PR:
- if a error handler has been specified with e.g. `queue_handled`, use this error handler instead of the fallback error handler
- if a command panics, still apply the remaining commands in the buffer?

## Testing

See added `panic_to_error` test