### PR TITLE
impl SceneList for Vec<Box<dyn SceneList>>

### DIFF
--- a/crates/bevy_scene/src/scene_list.rs
+++ b/crates/bevy_scene/src/scene_list.rs
@@ -159,6 +159,25 @@ impl<S: Scene> SceneList for Vec<S> {
     }
 }
 
+impl SceneList for Vec<Box<dyn SceneList>> {
+    fn resolve_list(
+        self,
+        context: &mut ResolveContext,
+        scenes: &mut Vec<ResolvedScene>,
+    ) -> Result<(), ResolveSceneError> {
+        for scene_list in self {
+            scene_list.resolve_list(context, scenes)?;
+        }
+        Ok(())
+    }
+
+    fn register_dependencies(&self, dependencies: &mut SceneDependencies) {
+        for scene_list in self {
+            scene_list.register_dependencies(dependencies);
+        }
+    }
+}
+
 impl<S: Scene> SceneList for SceneScope<S> {
     fn resolve_list(
         self,


### PR DESCRIPTION
# Objective
I couldn't figure out a way to spawn a variable amount of `SceneList`s as `Children`.

This came up when trying to make a variable row grid layout, each row being a `SceneList` because it has columns that need to be inserted directly into the grid `Node`:
```rust
let rows: Vec<Box<dyn SceneList>> = ...;
bsn! {
    Node { display: Display::Grid }
    // This doesn't work
    Children [ { rows } ]
}
```

## Solution
```rust
impl SceneList for Vec<Box<dyn SceneList>> { ... }
```
This can be implemented in user land by creating a wrapper type for `Vec<Box<dyn SceneList>>`, so I don't feel strongly about actually merging this PR.

## Testing
None so far.