### PR TITLE
Set `TextLayoutInfo::scale_factor` in `update_text_layout_info`

### DIFF
--- a/crates/bevy_sprite/src/text2d.rs
+++ b/crates/bevy_sprite/src/text2d.rs
@@ -331,10 +331,7 @@ pub fn update_text2d_layout(
             ) => {
                 panic!("Fatal error when processing text: {e}.");
             }
-            Ok(()) => {
-                text_layout_info.scale_factor = scale_factor;
-                text_layout_info.size *= scale_factor.recip();
-            }
+            Ok(()) => {}
         }
     }
 }

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -318,6 +318,7 @@ impl TextPipeline {
 
         let layout = &mut computed.layout;
         layout_with_bounds(layout, bounds, justify);
+        layout_info.scale_factor = layout.scale();
 
         for (line_index, line) in layout.lines().enumerate() {
             for item in line.items() {
@@ -471,7 +472,7 @@ pub struct TextLayoutInfo {
     ///
     /// The coordinates are unscaled and relative to the top left corner of the text layout.
     pub run_geometry: Vec<RunGeometry>,
-    /// The glyphs resulting size
+    /// The size of the text layout in physical pixels
     pub size: Vec2,
     /// Cursor visibility, size and position for editing
     pub cursor: Option<(bool, Rect)>,

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -400,8 +400,6 @@ pub fn text_system(
                     panic!("Fatal error when processing text: {e}.");
                 }
                 Ok(()) => {
-                    text_layout_info.scale_factor = node.inverse_scale_factor().recip();
-                    text_layout_info.size *= node.inverse_scale_factor();
                     text_flags.needs_recompute = false;
                 }
             }


### PR DESCRIPTION
# Objective
* `TextLayoutInfo::scale_factor` should be set during `update_text_layout_info` with the value taken from the parley `Layout`, responsibility should not be with the caller.
* `TextLayoutInfo::size` is scaled to be in logical pixels, this isn't consistant with other UI layout values that are kept in physical pixels.

## Solution

* Update `TextLayoutInfo::scale_factor` in `update_text_layout_info` with the value taken from the parley `Layout`.
* Remove the lines updating `scale_factor` and scaling `size` from the text2d and UI text systems.
