### PR TITLE
`RunGeometry` bounds fix

### DIFF
--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -392,11 +392,9 @@ impl TextPipeline {
                     layout_info.run_geometry.push(RunGeometry {
                         section_index,
                         bounds: Rect::new(
-                            line.metrics().inline_min_coord + glyph_run.offset(),
+                            glyph_run.offset(),
                             line.metrics().block_min_coord,
-                            line.metrics().inline_min_coord
-                                + glyph_run.offset()
-                                + glyph_run.advance(),
+                            glyph_run.offset() + glyph_run.advance(),
                             line.metrics().block_max_coord,
                         ),
                         strikethrough_y: glyph_run.baseline() - run.metrics().strikethrough_offset,

--- a/crates/bevy_ui/src/widget/text_input_layout.rs
+++ b/crates/bevy_ui/src/widget/text_input_layout.rs
@@ -418,13 +418,11 @@ pub fn update_editable_text_layout(
                                 section_index: brush.section_index as usize,
                                 bounds: Rect {
                                     min: Vec2::new(
-                                        line.metrics().inline_min_coord + glyph_run.offset(),
+                                        glyph_run.offset(),
                                         line.metrics().block_min_coord,
                                     ),
                                     max: Vec2::new(
-                                        line.metrics().inline_min_coord
-                                            + glyph_run.offset()
-                                            + glyph_run.advance(),
+                                        glyph_run.offset() + glyph_run.advance(),
                                         line.metrics().block_max_coord,
                                     ),
                                 },


### PR DESCRIPTION
# Objective

We sum `GlyphRun::offset` and `LineMetrics::inline_min_coord` when calculating the run geometry bounding boxes during text layout. But this is incorrect because `GlyphRun::offset` is set equal to `offset + self.line.data.metrics.inline_min_coord + self.line.data.metrics.offset`, so `inline_min_coord` is added twice.

We don't see any errors in layout because  `BreakerState::set_line_x` isn't used anywhere atm, so the value of `inline_min_coord` is always zero, but it's still wrong.

## Solution

Don't add `inline_min_coord` to the run bounds.