### PR TITLE
Don't leave root during `bench-check`.

### DIFF
--- a/tools/ci/src/commands/bench_check.rs
+++ b/tools/ci/src/commands/bench_check.rs
@@ -14,7 +14,7 @@ impl Prepare for BenchCheckCommand {
         vec![PreparedCommand::new::<Self>(
             cmd!(
                 sh,
-                "cargo check --benches {jobs...} --target-dir ../target --manifest-path ./benches/Cargo.toml"
+                "cargo check --benches {jobs...} --target-dir ./target --manifest-path ./benches/Cargo.toml"
             ),
             "Failed to check the benches.",
         )]

--- a/tools/ci/src/commands/bench_check.rs
+++ b/tools/ci/src/commands/bench_check.rs
@@ -12,11 +12,9 @@ impl Prepare for BenchCheckCommand {
         let jobs = args.build_jobs();
 
         vec![PreparedCommand::new::<Self>(
-            cmd!(
-                sh,
-                "cargo check --benches {jobs...} --manifest-path ./benches/Cargo.toml"
-            ),
+            cmd!(sh, "cargo check --benches {jobs...}"),
             "Failed to check the benches.",
-        )]
+        )
+        .with_subdir("benches")]
     }
 }

--- a/tools/ci/src/commands/bench_check.rs
+++ b/tools/ci/src/commands/bench_check.rs
@@ -12,9 +12,8 @@ impl Prepare for BenchCheckCommand {
         let jobs = args.build_jobs();
 
         vec![PreparedCommand::new::<Self>(
-            cmd!(sh, "cargo check --benches {jobs...}"),
+            cmd!(sh, "cargo check -p benches --benches {jobs...}"),
             "Failed to check the benches.",
-        )
-        .with_subdir("benches")]
+        )]
     }
 }

--- a/tools/ci/src/commands/bench_check.rs
+++ b/tools/ci/src/commands/bench_check.rs
@@ -14,7 +14,7 @@ impl Prepare for BenchCheckCommand {
         vec![PreparedCommand::new::<Self>(
             cmd!(
                 sh,
-                "cargo check --benches {jobs...} --target-dir ./target --manifest-path ./benches/Cargo.toml"
+                "cargo check --benches {jobs...} --manifest-path ./benches/Cargo.toml"
             ),
             "Failed to check the benches.",
         )]

--- a/tools/ci/src/commands/compile_fail.rs
+++ b/tools/ci/src/commands/compile_fail.rs
@@ -22,9 +22,10 @@ impl Prepare for CompileFailCommand {
         // - See crates/bevy_macros/compile_fail/README.md
         commands.push(
             PreparedCommand::new::<Self>(
-                cmd!(sh, "cargo test {no_fail_fast...} {jobs_ref...} --manifest-path crates/bevy_derive/compile_fail/Cargo.toml -- {test_threads_ref...}"),
+                cmd!(sh, "cargo test --target-dir ../../../target {no_fail_fast...} {jobs_ref...} -- {test_threads_ref...}"),
                 "Compiler errors of the macros compile fail tests seem to be different than expected! Check locally and compare rust versions.",
-            ),
+            )
+            .with_subdir("crates/bevy_derive/compile_fail"),
         );
 
         // ECS Compile Fail Tests
@@ -32,9 +33,10 @@ impl Prepare for CompileFailCommand {
         // - See crates/bevy_ecs/compile_fail/README.md
         commands.push(
             PreparedCommand::new::<Self>(
-                cmd!(sh, "cargo test {no_fail_fast...} {jobs_ref...} --manifest-path crates/bevy_ecs/compile_fail/Cargo.toml -- {test_threads_ref...}"),
+                cmd!(sh, "cargo test --target-dir ../../../target {no_fail_fast...} {jobs_ref...} -- {test_threads_ref...}"),
                 "Compiler errors of the ECS compile fail tests seem to be different than expected! Check locally and compare rust versions.",
-            ),
+            )
+            .with_subdir("crates/bevy_ecs/compile_fail"),
         );
 
         // Reflect Compile Fail Tests
@@ -42,9 +44,10 @@ impl Prepare for CompileFailCommand {
         // - See crates/bevy_reflect/compile_fail/README.md
         commands.push(
             PreparedCommand::new::<Self>(
-                cmd!(sh, "cargo test {no_fail_fast...} {jobs...} --manifest-path crates/bevy_reflect/compile_fail/Cargo.toml -- {test_threads...}"),
+                cmd!(sh, "cargo test --target-dir ../../../target {no_fail_fast...} {jobs...} -- {test_threads...}"),
                 "Compiler errors of the Reflect compile fail tests seem to be different than expected! Check locally and compare rust versions.",
-            ),
+            )
+            .with_subdir("crates/bevy_reflect/compile_fail"),
         );
 
         commands

--- a/tools/ci/src/commands/compile_fail.rs
+++ b/tools/ci/src/commands/compile_fail.rs
@@ -19,7 +19,7 @@ impl Prepare for CompileFailCommand {
 
         // Macro Compile Fail Tests
         // Run tests (they do not get executed with the workspace tests)
-        // - See crates/bevy_macros/compile_fail/README.md
+        // - See crates/bevy_derive/compile_fail/README.md
         commands.push(
             PreparedCommand::new::<Self>(
                 cmd!(sh, "cargo test {no_fail_fast...} {jobs_ref...} -- {test_threads_ref...}"),

--- a/tools/ci/src/commands/compile_fail.rs
+++ b/tools/ci/src/commands/compile_fail.rs
@@ -19,7 +19,7 @@ impl Prepare for CompileFailCommand {
 
         // Macro Compile Fail Tests
         // Run tests (they do not get executed with the workspace tests)
-        // - See crates/bevy_macros_compile_fail_tests/README.md
+        // - See crates/bevy_macros/compile_fail/README.md
         commands.push(
             PreparedCommand::new::<Self>(
                 cmd!(sh, "cargo test --target-dir ../../../target {no_fail_fast...} {jobs_ref...} -- {test_threads_ref...}"),
@@ -30,7 +30,7 @@ impl Prepare for CompileFailCommand {
 
         // ECS Compile Fail Tests
         // Run UI tests (they do not get executed with the workspace tests)
-        // - See crates/bevy_ecs_compile_fail_tests/README.md
+        // - See crates/bevy_ecs/compile_fail/README.md
         commands.push(
             PreparedCommand::new::<Self>(
                 cmd!(sh, "cargo test --target-dir ../../../target {no_fail_fast...} {jobs_ref...} -- {test_threads_ref...}"),
@@ -41,7 +41,7 @@ impl Prepare for CompileFailCommand {
 
         // Reflect Compile Fail Tests
         // Run tests (they do not get executed with the workspace tests)
-        // - See crates/bevy_reflect_compile_fail_tests/README.md
+        // - See crates/bevy_reflect/compile_fail/README.md
         commands.push(
             PreparedCommand::new::<Self>(
                 cmd!(sh, "cargo test --target-dir ../../../target {no_fail_fast...} {jobs...} -- {test_threads...}"),

--- a/tools/ci/src/commands/compile_fail.rs
+++ b/tools/ci/src/commands/compile_fail.rs
@@ -22,10 +22,9 @@ impl Prepare for CompileFailCommand {
         // - See crates/bevy_macros/compile_fail/README.md
         commands.push(
             PreparedCommand::new::<Self>(
-                cmd!(sh, "cargo test --target-dir ../../../target {no_fail_fast...} {jobs_ref...} -- {test_threads_ref...}"),
+                cmd!(sh, "cargo test {no_fail_fast...} {jobs_ref...} --manifest-path crates/bevy_derive/compile_fail/Cargo.toml -- {test_threads_ref...}"),
                 "Compiler errors of the macros compile fail tests seem to be different than expected! Check locally and compare rust versions.",
-            )
-            .with_subdir("crates/bevy_derive/compile_fail"),
+            ),
         );
 
         // ECS Compile Fail Tests
@@ -33,10 +32,9 @@ impl Prepare for CompileFailCommand {
         // - See crates/bevy_ecs/compile_fail/README.md
         commands.push(
             PreparedCommand::new::<Self>(
-                cmd!(sh, "cargo test --target-dir ../../../target {no_fail_fast...} {jobs_ref...} -- {test_threads_ref...}"),
+                cmd!(sh, "cargo test {no_fail_fast...} {jobs_ref...} --manifest-path crates/bevy_ecs/compile_fail/Cargo.toml -- {test_threads_ref...}"),
                 "Compiler errors of the ECS compile fail tests seem to be different than expected! Check locally and compare rust versions.",
-            )
-            .with_subdir("crates/bevy_ecs/compile_fail"),
+            ),
         );
 
         // Reflect Compile Fail Tests
@@ -44,10 +42,9 @@ impl Prepare for CompileFailCommand {
         // - See crates/bevy_reflect/compile_fail/README.md
         commands.push(
             PreparedCommand::new::<Self>(
-                cmd!(sh, "cargo test --target-dir ../../../target {no_fail_fast...} {jobs...} -- {test_threads...}"),
+                cmd!(sh, "cargo test {no_fail_fast...} {jobs...} --manifest-path crates/bevy_reflect/compile_fail/Cargo.toml -- {test_threads...}"),
                 "Compiler errors of the Reflect compile fail tests seem to be different than expected! Check locally and compare rust versions.",
-            )
-            .with_subdir("crates/bevy_reflect/compile_fail"),
+            ),
         );
 
         commands

--- a/tools/ci/src/commands/compile_fail.rs
+++ b/tools/ci/src/commands/compile_fail.rs
@@ -22,7 +22,7 @@ impl Prepare for CompileFailCommand {
         // - See crates/bevy_macros/compile_fail/README.md
         commands.push(
             PreparedCommand::new::<Self>(
-                cmd!(sh, "cargo test --target-dir ../../../target {no_fail_fast...} {jobs_ref...} -- {test_threads_ref...}"),
+                cmd!(sh, "cargo test {no_fail_fast...} {jobs_ref...} -- {test_threads_ref...}"),
                 "Compiler errors of the macros compile fail tests seem to be different than expected! Check locally and compare rust versions.",
             )
             .with_subdir("crates/bevy_derive/compile_fail"),
@@ -33,7 +33,7 @@ impl Prepare for CompileFailCommand {
         // - See crates/bevy_ecs/compile_fail/README.md
         commands.push(
             PreparedCommand::new::<Self>(
-                cmd!(sh, "cargo test --target-dir ../../../target {no_fail_fast...} {jobs_ref...} -- {test_threads_ref...}"),
+                cmd!(sh, "cargo test {no_fail_fast...} {jobs_ref...} -- {test_threads_ref...}"),
                 "Compiler errors of the ECS compile fail tests seem to be different than expected! Check locally and compare rust versions.",
             )
             .with_subdir("crates/bevy_ecs/compile_fail"),
@@ -44,7 +44,7 @@ impl Prepare for CompileFailCommand {
         // - See crates/bevy_reflect/compile_fail/README.md
         commands.push(
             PreparedCommand::new::<Self>(
-                cmd!(sh, "cargo test --target-dir ../../../target {no_fail_fast...} {jobs...} -- {test_threads...}"),
+                cmd!(sh, "cargo test {no_fail_fast...} {jobs...} -- {test_threads...}"),
                 "Compiler errors of the Reflect compile fail tests seem to be different than expected! Check locally and compare rust versions.",
             )
             .with_subdir("crates/bevy_reflect/compile_fail"),

--- a/tools/ci/src/commands/compile_fail.rs
+++ b/tools/ci/src/commands/compile_fail.rs
@@ -22,10 +22,9 @@ impl Prepare for CompileFailCommand {
         // - See crates/bevy_derive/compile_fail/README.md
         commands.push(
             PreparedCommand::new::<Self>(
-                cmd!(sh, "cargo test {no_fail_fast...} {jobs_ref...} -- {test_threads_ref...}"),
+                cmd!(sh, "cargo test -p bevy_derive_compile_fail {no_fail_fast...} {jobs_ref...} -- {test_threads_ref...}"),
                 "Compiler errors of the macros compile fail tests seem to be different than expected! Check locally and compare rust versions.",
-            )
-            .with_subdir("crates/bevy_derive/compile_fail"),
+            ),
         );
 
         // ECS Compile Fail Tests
@@ -33,10 +32,9 @@ impl Prepare for CompileFailCommand {
         // - See crates/bevy_ecs/compile_fail/README.md
         commands.push(
             PreparedCommand::new::<Self>(
-                cmd!(sh, "cargo test {no_fail_fast...} {jobs_ref...} -- {test_threads_ref...}"),
+                cmd!(sh, "cargo test -p bevy_ecs_compile_fail {no_fail_fast...} {jobs_ref...} -- {test_threads_ref...}"),
                 "Compiler errors of the ECS compile fail tests seem to be different than expected! Check locally and compare rust versions.",
-            )
-            .with_subdir("crates/bevy_ecs/compile_fail"),
+            ),
         );
 
         // Reflect Compile Fail Tests
@@ -44,10 +42,9 @@ impl Prepare for CompileFailCommand {
         // - See crates/bevy_reflect/compile_fail/README.md
         commands.push(
             PreparedCommand::new::<Self>(
-                cmd!(sh, "cargo test {no_fail_fast...} {jobs...} -- {test_threads...}"),
+                cmd!(sh, "cargo test -p bevy_reflect_compile_fail {no_fail_fast...} {jobs_ref...} -- {test_threads_ref...}"),
                 "Compiler errors of the Reflect compile fail tests seem to be different than expected! Check locally and compare rust versions.",
-            )
-            .with_subdir("crates/bevy_reflect/compile_fail"),
+            ),
         );
 
         commands


### PR DESCRIPTION
## Error

During `$ cargo run -p ci -- compile`
 
```text
$ cargo check --benches --target-dir ../target --manifest-path ./benches/Cargo.toml
error: failed to create directory `D:\bevy\..`

Caused by:
  Access is denied. (os error 5)

thread 'main' (16628) panicked at tools\ci\src\ci.rs:62:13:
One or more CI commands failed:
bench-check: Failed to check the benches.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

## Solution

- Instead of accessing ../target access ./target

## Testing

- Now the command works on my device.