### PR TITLE
Minor documentation fixes

### DIFF
--- a/crates/bevy_ecs/src/component/mod.rs
+++ b/crates/bevy_ecs/src/component/mod.rs
@@ -257,7 +257,7 @@ use core::{fmt::Debug, marker::PhantomData, ops::Deref};
 /// Note that cycles in the "component require tree" will result in stack overflows when attempting to
 /// insert a component.
 ///
-/// This "multiple inheritance" pattern does mean that it is possible to have duplicate requires for a given type
+/// This "multiple inheritance" pattern does mean that it is possible to have duplicate `require`s for a given type
 /// at different levels of the inheritance tree:
 ///
 /// ```
@@ -321,7 +321,7 @@ use core::{fmt::Debug, marker::PhantomData, ops::Deref};
 /// assert_eq!(&C(2), world.entity(id).get::<C>().unwrap());
 /// ```
 ///
-/// Similar rules as before apply to duplicate requires fer a given type at different levels
+/// Similar rules as before apply to duplicate `require`s for a given type at different levels
 /// of the inheritance tree. `A` requiring `C` directly would take precedence over indirectly
 /// requiring it through `A` requiring `B` and `B` requiring `C`.
 ///

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -2822,6 +2822,9 @@ impl<'w, 'q, Q: SingleEntityQueryData, F: QueryFilter> From<&'q mut Query<'w, '_
 /// ```
 /// # use bevy_ecs::prelude::*;
 /// #[derive(Component)]
+/// struct Hiding;
+///
+/// #[derive(Component)]
 /// struct Boss {
 ///    health: f32
 /// };
@@ -2831,7 +2834,7 @@ impl<'w, 'q, Q: SingleEntityQueryData, F: QueryFilter> From<&'q mut Query<'w, '_
 ///    height: f32
 /// };
 ///
-/// fn hurt_boss(mut boss: Single<&mut Boss>) {
+/// fn hurt_boss(mut boss: Single<&mut Boss, Without<Hiding>>) {
 ///    boss.health -= 4.0;
 /// }
 ///

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -2826,12 +2826,24 @@ impl<'w, 'q, Q: SingleEntityQueryData, F: QueryFilter> From<&'q mut Query<'w, '_
 ///    health: f32
 /// };
 ///
+/// #[derive(Component)]
+/// struct EnemySize {
+///    height: f32
+/// };
+///
 /// fn hurt_boss(mut boss: Single<&mut Boss>) {
 ///    boss.health -= 4.0;
+/// }
+///
+/// fn hurt_and_shrink_boss(mut boss_and_size: Single<(&mut Boss, &mut EnemySize)>) {
+///    let (mut boss, mut size) = boss_and_size.into_inner();
+///    boss.health -= 4.0;
+///    size.height *= 0.5;
 /// }
 /// ```
 /// Note that because [`Single`] implements [`Deref`] and [`DerefMut`], methods and fields like `health` can be accessed directly.
 /// You can also access the underlying data manually, by calling `.deref`/`.deref_mut`, or by using the `*` operator.
+/// When mutable elements appear in [`Single`], use `.into_inner` to extract the tuple elements to mutate them.
 pub struct Single<'w, 's, D: IterQueryData, F: QueryFilter = ()> {
     pub(crate) item: D::Item<'w, 's>,
     pub(crate) _filter: PhantomData<F>,


### PR DESCRIPTION
# Objective

- Tiny Mwriting Monday contribution.
- Improve `Single` doc example to show `into_inner` and filter usage.
- Fix a typo and formatting for Query `require`s.
