### PR TITLE
Don't remove Handle tracking upon soft-removal of an asset.

### DIFF
--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -483,10 +483,7 @@ impl<A: Asset> Assets<A> {
     pub fn remove_untracked(&mut self, id: impl Into<AssetId<A>>) -> Option<A> {
         let id: AssetId<A> = id.into();
         match id {
-            AssetId::Index { index, .. } => {
-                self.duplicate_handles.remove(&index);
-                self.dense_storage.remove_still_alive(index)
-            }
+            AssetId::Index { index, .. } => self.dense_storage.remove_still_alive(index),
             AssetId::Uuid { uuid } => self.hash_map.remove(&uuid),
         }
     }


### PR DESCRIPTION
## Error

I believe the intended behavior of `remove` and `remove_untracked` is for the backing Id to still be valid until all handles are dropped however the `remove_untracked` (called by `remove`) drops the Handle refcount (called `duplicate_handles`) for that id. 

This is illogically sound because we're still using the refcount to track the handles. But it technically has the same result IF we only have a single live handle (surely like 90% of use cases) because the refcount only gets checked on a dropped Handle.

---

@andriyDev - If you wanted to look into this.