### PR TITLE
Document messagereader being per system basis

### DIFF
--- a/crates/bevy_ecs/src/message/mod.rs
+++ b/crates/bevy_ecs/src/message/mod.rs
@@ -91,7 +91,7 @@ use core::{
 /// ```
 /// [`Event`]: crate::event::Event
 /// [`Observer`]: crate::observer::Observer
-/// [`local<MessageCursor>`]:crate::system::Local
+/// [`local<MessageCursor>`]: crate::system::Local
 #[diagnostic::on_unimplemented(
     message = "`{Self}` is not an `Message`",
     label = "invalid `Message`",

--- a/crates/bevy_ecs/src/message/mod.rs
+++ b/crates/bevy_ecs/src/message/mod.rs
@@ -38,6 +38,9 @@ use core::{
 /// Messages are stored in the [`Messages<M>`] resource, and require periodically polling the world for new messages,
 /// typically in a system that runs as part of a schedule.
 ///
+/// A [`MessageReader`] system parameter tracks the consumption of these events on a per-system basis using a [`Local<MessageCursor>`],
+/// which will guarantee each system an opportunity to read the event once.
+///
 /// While the polling imposes a small overhead, messages are useful for efficiently batch processing
 /// a large number of messages at once. For cases like these, messages can be more efficient than [`Event`]s (which are handled via [`Observer`]s).
 ///
@@ -88,6 +91,7 @@ use core::{
 /// ```
 /// [`Event`]: crate::event::Event
 /// [`Observer`]: crate::observer::Observer
+/// [`local<MessageCursor>`]:crate::system::Local
 #[diagnostic::on_unimplemented(
     message = "`{Self}` is not an `Message`",
     label = "invalid `Message`",


### PR DESCRIPTION
# Objective

- I was looking at documentation to check if MessageReader was per system basis or global.
I did not find the answers in the docs, so 

## Solution

I have copied over the wording from https://taintedcoders.com/bevy/events#reading-messages


## Testing
- CI trivial docs changes


