### PR TITLE
export `resource_entity` in `EntityWorldMut` and `TemplateContext`

### DIFF
--- a/crates/bevy_ecs/src/template.rs
+++ b/crates/bevy_ecs/src/template.rs
@@ -84,6 +84,12 @@ impl<'a, 'w> TemplateContext<'a, 'w> {
     pub fn resource_mut<R: Resource<Mutability = Mutable>>(&mut self) -> Mut<'_, R> {
         self.entity.resource_mut()
     }
+
+    /// Retrieves the entity associated with the given resource `R`, if it exists.
+    #[inline]
+    pub fn resource_entity<R: Resource>(&self) -> Option<Entity> {
+        self.entity.resource_entity::<R>()
+    }
 }
 
 /// A mapping from from an entity reference's (scope, index) to a contiguous flat index that uniquely

--- a/crates/bevy_ecs/src/world/entity_access/world_mut.rs
+++ b/crates/bevy_ecs/src/world/entity_access/world_mut.rs
@@ -14,7 +14,7 @@ use crate::{
         ReleaseStateQueryData, SingleEntityQueryData,
     },
     relationship::RelationshipHookMode,
-    resource::Resource,
+    resource::{Resource, ResourceEntities},
     storage::{SparseSets, Table},
     template::{EntityScopes, ScopedEntities, Template, TemplateContext},
     world::{
@@ -730,6 +730,21 @@ impl<'w> EntityWorldMut<'w> {
                 f(&mut this, res)
             })
         })
+    }
+
+    /// Retrieves this world's [`ResourceEntities`].
+    #[inline]
+    #[track_caller]
+    pub fn resource_entities(&self) -> &ResourceEntities {
+        self.world.resource_entities()
+    }
+
+    /// Retrieves the [`Entity`] associated with the resource of type `R`, if it exists.
+    #[inline]
+    #[track_caller]
+    pub fn resource_entity<R: Resource>(&self) -> Option<Entity> {
+        let component_id = self.world.component_id::<R>()?;
+        self.world.resource_entities().get(component_id)
     }
 
     /// Retrieves the change ticks for the given component. This can be useful for implementing change


### PR DESCRIPTION
# Objective

- Provide a way for accessing resource entities, enabling the use of #19731 .

## Solution

- Add `resource_entity::<R: Resource>` using `World::resource_entities`.
- Not sure if there is needed for accessing `ResourceEntities`. Just exported `resource_entities` in `EntityWorldMut` but not in `TemplateContext`.

