### PR TITLE
Change the letter Q to D in comments

### DIFF
--- a/crates/bevy_ecs/src/query/builder.rs
+++ b/crates/bevy_ecs/src/query/builder.rs
@@ -44,7 +44,7 @@ pub struct QueryBuilder<'w, D: QueryData = (), F: QueryFilter = ()> {
 }
 
 impl<'w, D: QueryData, F: QueryFilter> QueryBuilder<'w, D, F> {
-    /// Creates a new builder with the accesses required for `Q` and `F`
+    /// Creates a new builder with the accesses required for `D` and `F`
     pub fn new(world: &'w mut World) -> Self {
         let fetch_state = D::init_state(world);
         let filter_state = F::init_state(world);


### PR DESCRIPTION
Co-Authored-By: ItsDoot

# Objective

- Comment has a typo

## Solution

- Fixes a typo, Thanks to Doot for the tuition and extensive consultation. 


