### PR TITLE
Extract between non-main sub-apps

### DIFF
--- a/crates/bevy_app/src/sub_app.rs
+++ b/crates/bevy_app/src/sub_app.rs
@@ -78,6 +78,8 @@ pub struct SubApp {
     /// A function that gives mutable access to two app worlds. This is primarily
     /// intended for copying data from the main world to secondary worlds.
     extract: Option<ExtractFn>,
+    /// Functions that give mutable access to two sub_app worlds.
+    labeled_extracts: HashMap<InternedAppLabel, ExtractFn>,
 }
 
 impl Debug for SubApp {
@@ -98,6 +100,7 @@ impl Default for SubApp {
             plugins_state: PluginsState::Adding,
             update_schedule: None,
             extract: None,
+            labeled_extracts: HashMap::new(),
         }
     }
 }
@@ -147,6 +150,48 @@ impl SubApp {
     pub fn update(&mut self) {
         self.run_default_schedule();
         self.world.clear_trackers();
+    }
+
+    /// Sets the method that will be called by [`extract_with_label`](Self::extract_with_label)
+    /// for the given label.
+    ///
+    /// The first argument is the `World` to extract data from, the second argument is the app `World`.
+    pub fn set_extract_with_label<F>(&mut self, label: impl AppLabel, extract: F) -> &mut Self
+    where
+        F: FnMut(&mut World, &mut World) + Send + 'static,
+    {
+        self.labeled_extracts
+            .insert(label.intern(), Box::new(extract));
+        self
+    }
+
+    /// Take the function that will be called by [`extract_with_label`](Self::extract_with_label)
+    /// out of the app, if any was set, and replace it with `None`.
+    pub fn take_extract_with_label(&mut self, label: impl AppLabel) -> Option<ExtractFn> {
+        self.labeled_extracts.remove(&label.intern())
+    }
+
+    /// Extracts data from `sub_apps` into the app's world using the registered labeled
+    /// extract methods.
+    pub fn extract_labeled(&mut self, sub_apps: &mut SubApps) {
+        // Run the extract function on each sub-app pair.
+        for (sub_app_label, f) in &mut self.labeled_extracts {
+            let Some(app) = sub_apps.sub_apps.get_mut(sub_app_label) else {
+                continue;
+            };
+            f(&mut app.world, &mut self.world);
+        }
+    }
+
+    /// Extracts data from `world` into the app's world using the registered extract method
+    /// with the given label.
+    ///
+    /// **Note:** There is no default extract method. Calling `extract_with_label` does nothing if
+    /// [`set_extract_with_label`](Self::set_extract_with_label) has not been called.
+    pub fn extract_with_label(&mut self, label: impl AppLabel, world: &mut World) {
+        if let Some(f) = self.labeled_extracts.get_mut(&label.intern()) {
+            f(world, &mut self.world);
+        }
     }
 
     /// Extracts data from `world` into the app's world using the registered extract method.
@@ -559,11 +604,12 @@ impl SubApps {
             let _bevy_frame_update_span = info_span!("main app").entered();
             self.main.run_default_schedule();
         }
-        for (_label, sub_app) in self.sub_apps.iter_mut() {
+
+        let labels = self.sub_apps.keys().copied().collect::<Vec<_>>();
+        for label in labels {
             #[cfg(feature = "trace")]
-            let _sub_app_span = info_span!("sub app", name = ?_label).entered();
-            sub_app.extract(&mut self.main.world);
-            sub_app.update();
+            let _sub_app_span = info_span!("sub app", name = ?label).entered();
+            self.update_subapp_by_label(label);
         }
 
         self.main.world.clear_trackers();
@@ -581,9 +627,16 @@ impl SubApps {
 
     /// Extract data from the main world into the [`SubApp`] with the given label and perform an update if it exists.
     pub fn update_subapp_by_label(&mut self, label: impl AppLabel) {
-        if let Some(sub_app) = self.sub_apps.get_mut(&label.intern()) {
-            sub_app.extract(&mut self.main.world);
-            sub_app.update();
-        }
+        // Temporarily remove the `sub_app` from the map.
+        let Some((label, mut sub_app)) = self.sub_apps.remove_entry(&label.intern()) else {
+            return;
+        };
+
+        sub_app.extract_labeled(self);
+        sub_app.extract(&mut self.main.world);
+        sub_app.update();
+
+        // Restore the removed `sub_app`.
+        self.sub_apps.insert(label, sub_app);
     }
 }


### PR DESCRIPTION
# Objective

This is work in progress, just intended to show a general approach. It's a small extension on the existing `SubApp::{extract, set_extract, take_extract}` methods to have labelled versions of them. This allows for extraction between SubApps that aren't main.

One issue with this currently is it does not allow a deterministic order between the apps, which may mean you can't construct a DAG of extractions between subapps. This could be solved by storing the labels vector from `SubApps::update`, but that needs further thought.

This is mainly to provide to context when asking whether the general approach of adding more extract methods to SubApps would be accepted, or if it would still be blocked by the greater multi-world work.

Related issues:
- https://github.com/bevyengine/bevy/discussions/17937
- https://github.com/bevyengine/bevy/discussions/7893
- https://github.com/bevyengine/bevy/discussions/2237

## Solution

- Describe the solution used to achieve the objective above.

## Testing

- Did you test these changes? If so, how?
- Are there any parts that need more testing?
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?

---

## Showcase

> This section is optional. If this PR does not include a visual change or does not add a new feature, you can delete this section.

- Help others understand the result of this PR by showcasing your awesome work!
- If this PR adds a new feature or public API, consider adding a brief pseudo-code snippet of it in action
- If this PR includes a visual change, consider adding a screenshot, GIF, or video
  - If you want, you could even include a before/after comparison!
- If the Migration Guide adequately covers the changes, you can delete this section

While a showcase should aim to be brief and digestible, you can use a toggleable section to save space on longer showcases:

<details>
  <summary>Click to view showcase</summary>

```rust
println!("My super cool code.");
```

</details>
