### PR TITLE
Add migration guide for `shadow_pass` split

### DIFF
--- a/_release-content/migration-guides/shadow-pass-split.md
+++ b/_release-content/migration-guides/shadow-pass-split.md
@@ -1,0 +1,7 @@
+---
+title: "`shadow_pass` has been split into `per_view_shadow_pass` and `shared_shadow_pass`"
+pull_requests: [23713]
+---
+
+`shadow_pass` has been split into `per_view_shadow_pass` (for rendering DirectionalLight shadow maps)
+and `shared_shadow_pass` (for rendering PointLight and SpotLight shadow maps).


### PR DESCRIPTION
# Objective

- Fixes #24256 

## Solution

- Adds the migration guide

## Testing

- CI will let me know if it’s formatted incorrectly