### PR TITLE
Specify where `RenderGraph` is in Migration Guide, add it to `bevy_render::prelude`

### DIFF
--- a/_release-content/migration-guides/render_graph_as_systems.md
+++ b/_release-content/migration-guides/render_graph_as_systems.md
@@ -53,5 +53,5 @@ parameter instead of being passed as `&mut`. Use `.before()` / `.after()` with t
 `main_opaque_pass_3d`) rather than `Node3d` labels.
 
 System sets `Core3dSystems::Prepass`, `MainPass`, and `PostProcess` are available for coarse ordering.
-The `RenderGraph` schedule, available as `bevy_render::renderer::RenderGraph`,
+The `RenderGraph` schedule, available as `bevy::render::renderer::RenderGraph`,
 remains as the top-level schedule for non-camera rendering.

--- a/_release-content/migration-guides/render_graph_as_systems.md
+++ b/_release-content/migration-guides/render_graph_as_systems.md
@@ -52,5 +52,6 @@ The `ViewNode` trait is replaced by a regular system using the `ViewQuery` param
 parameter instead of being passed as `&mut`. Use `.before()` / `.after()` with the actual system functions (e.g.,
 `main_opaque_pass_3d`) rather than `Node3d` labels.
 
-System sets `Core3dSystems::Prepass`, `MainPass`, and `PostProcess` are available for coarse ordering. The `RenderGraph`
-schedule remains as the top-level schedule for non-camera rendering.
+System sets `Core3dSystems::Prepass`, `MainPass`, and `PostProcess` are available for coarse ordering.
+The `RenderGraph` schedule, available as `bevy_render::renderer::RenderGraph`,
+remains as the top-level schedule for non-camera rendering.

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -72,8 +72,8 @@ pub mod view;
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
-        camera::NormalizedRenderTargetExt as _, texture::ManualTextureViews, view::Msaa,
-        ExtractSchedule,
+        camera::NormalizedRenderTargetExt as _, renderer::RenderGraph, texture::ManualTextureViews,
+        view::Msaa, ExtractSchedule,
     };
 }
 


### PR DESCRIPTION
# Objective

- Fixes #24257

## Solution

- `RenderGraph` is already pub, but it moved locations. Specify where in the migration guide.
- Added `RenderGraph` to `bevy_render`’s prelude. This can be removed if desired.

## Testing

- ci