### PR TITLE
Add new method `entity_commands` to `EntityWorldMut`

### DIFF
--- a/crates/bevy_ecs/src/world/entity_access/world_mut.rs
+++ b/crates/bevy_ecs/src/world/entity_access/world_mut.rs
@@ -1877,8 +1877,8 @@ impl<'w> EntityWorldMut<'w> {
         f(guard.entity_mut.world)
     }
 
-    /// Creates a new [`EntityCommands`] instance that writes to the world's command queue
-    /// Use [`World::flush`] to apply all queued commands
+    /// Creates a new [`EntityCommands`] instance that writes commands
+    /// Use [`EntityWorldMut::flush`] to apply all queued commands
     #[inline]
     pub fn entity_commands(&mut self) -> EntityCommands<'_> {
         let id = self.id();

--- a/crates/bevy_ecs/src/world/entity_access/world_mut.rs
+++ b/crates/bevy_ecs/src/world/entity_access/world_mut.rs
@@ -16,6 +16,7 @@ use crate::{
     relationship::RelationshipHookMode,
     resource::Resource,
     storage::{SparseSets, Table},
+    system::EntityCommands,
     template::{SceneEntityReferences, Template, TemplateContext},
     world::{
         error::EntityComponentError, unsafe_world_cell::UnsafeEntityCell, ComponentEntry,
@@ -1874,6 +1875,17 @@ impl<'w> EntityWorldMut<'w> {
         // This will run even in case the closure `f` unwinds.
         let guard = Guard { entity_mut: self };
         f(guard.entity_mut.world)
+    }
+
+    /// Creates a new [`EntityCommands`] instance that writes to the world's command queue
+    /// Use [`World::flush`] to apply all queued commands
+    #[inline]
+    pub fn entity_commands(&mut self) -> EntityCommands<'_> {
+        let id = self.id();
+        EntityCommands {
+            entity: id,
+            commands: self.world.commands(),
+        }
     }
 
     /// Updates the internal entity location to match the current location in the internal


### PR DESCRIPTION

# Objective

Fixes https://github.com/bevyengine/bevy/issues/23512
Added a shortcut for getting `EntityCommands`.

Hi, this is my first PR to Bevy, I’m not sure if my approach is developer want.
Thanks for the review!
