### PR TITLE
Added density texture support for volumetric point and spotlights

### DIFF
--- a/crates/bevy_pbr/src/volumetric_fog/volumetric_fog.wgsl
+++ b/crates/bevy_pbr/src/volumetric_fog/volumetric_fog.wgsl
@@ -351,6 +351,20 @@ fn fragment(@builtin(position) position: vec4<f32>) -> @location(0) vec4<f32> {
         let P_view = view_start_pos + Rd_view * f32(step) * step_size_world;
 
         var density = density_factor;
+#ifdef DENSITY_TEXTURE
+            // Take the density texture into account, if there is one.
+            //
+            // The uvs should never go outside the (0, 0, 0) to (1, 1, 1) box,
+            // but sometimes due to floating point error they can. Handle this
+            // case.
+            let P_uvw = Ro_uvw + Rd_step_uvw * f32(step);
+            if (all(P_uvw >= vec3(0.0)) && all(P_uvw <= vec3(1.0))) {
+                density *= textureSampleLevel(density_texture, density_sampler, P_uvw + density_texture_offset, 0.0).r;
+            } else {
+                density = 0.0;
+            }
+#endif  // DENSITY_TEXTURE
+
         var sample_color = vec3(0.0);
 
         let cluster_index = clustering::view_fragment_cluster_index(frag_coord.xy, P_view.z, is_orthographic);


### PR DESCRIPTION
# Objective

Currently density textures are only supported for directional lights, this PR adds the density texture sampling to the spot / point light pass as well.

## Solution

Sample density texture for the point / spotlight volumetric pass.

## Testing

Added a pointlight to the `fog_volumes.rs` example
```
use bevy::{
    color::palettes::css::RED,
    camera::Hdr,
    light::{FogVolume, VolumetricFog, VolumetricLight},
    math::vec3,
    prelude::*,
};

/// Entry point.
fn main() {
    App::new()
        .add_plugins(DefaultPlugins.set(WindowPlugin {
            primary_window: Some(Window {
                title: "Bevy Fog Volumes Example".into(),
                ..default()
            }),
            ..default()
        }))
        .insert_resource(GlobalAmbientLight::NONE)
        .add_systems(Startup, setup)
        .add_systems(Update, rotate_camera)
        .run();
}

/// Spawns all the objects in the scene.
fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
    // Spawn a fog volume with a voxelized version of the Stanford bunny.
    commands.spawn((
        Transform::from_xyz(0.0, 0.5, 0.0),
        FogVolume {
            density_texture: Some(asset_server.load("volumes/bunny.ktx2")),
            density_factor: 1.0,
            // Scatter as much of the light as possible, to brighten the bunny
            // up.
            scattering: 1.0,
            ..default()
        },
    ));

    // Spawn a bright directional light that illuminates the fog well.
    commands.spawn((
        Transform::from_xyz(1.0, 1.0, -0.3).looking_at(vec3(0.0, 0.5, 0.0), Vec3::Y),
        DirectionalLight {
            shadow_maps_enabled: true,
            illuminance: 32000.0,
            ..default()
        },
        // Make sure to add this for the light to interact with the fog.
        VolumetricLight,
    ));

    commands.spawn((
        Transform::from_xyz(0.0, 0.0, 0.0),
        PointLight {
            shadow_maps_enabled: true,
            range: 150.0,
            color: RED.into(),
            intensity: 5_000.0,
            ..default()
        },
        VolumetricLight,
    ));

    // Spawn a camera.
    commands.spawn((
        Camera3d::default(),
        Transform::from_xyz(-0.75, 1.0, 2.0).looking_at(vec3(0.0, 0.0, 0.0), Vec3::Y),
        Hdr,
        VolumetricFog {
            // Make this relatively high in order to increase the fog quality.
            step_count: 64,
            // Disable ambient light.
            ambient_intensity: 0.0,
            ..default()
        },
    ));
}

/// Rotates the camera a bit every frame.
fn rotate_camera(mut cameras: Query<&mut Transform, With<Camera3d>>) {
    for mut camera_transform in cameras.iter_mut() {
        *camera_transform =
            Transform::from_translation(Quat::from_rotation_y(0.01) * camera_transform.translation)
                .looking_at(vec3(0.0, 0.5, 0.0), Vec3::Y);
    }
}
```
---

## Showcase

Before:
<img width="1891" height="2085" alt="screenshot-2026-05-12_22-55-45" src="https://github.com/user-attachments/assets/9e408d5b-d700-47a7-93b2-c51e0b80ee8d" />

After:
<img width="1891" height="2085" alt="screenshot-2026-05-12_23-00-53" src="https://github.com/user-attachments/assets/54d3a389-e9b9-4228-92fd-5710d1bdafbd" />
