### PR TITLE
`bevy_text`: use `u32`s for line and section indices

### DIFF
--- a/crates/bevy_sprite_render/src/text2d/mod.rs
+++ b/crates/bevy_sprite_render/src/text2d/mod.rs
@@ -78,7 +78,7 @@ pub fn extract_text2d_sprite(
         let top_left = (Anchor::TOP_LEFT.0 - anchor.as_vec()) * size;
 
         for run in text_layout_info.run_geometry.iter() {
-            let section_entity = computed_block.entities()[run.section_index].entity;
+            let section_entity = computed_block.entities()[run.section_index as usize].entity;
             let Ok(text_background_color) = text_background_colors_query.get(section_entity) else {
                 continue;
             };
@@ -151,7 +151,7 @@ pub fn extract_text2d_sprite(
             }
 
             for run in text_layout_info.run_geometry.iter() {
-                let section_entity = computed_block.entities()[run.section_index].entity;
+                let section_entity = computed_block.entities()[run.section_index as usize].entity;
                 let Ok((_, has_strikethrough, has_underline, _, _)) =
                     decoration_query.get(section_entity)
                 else {
@@ -207,7 +207,7 @@ pub fn extract_text2d_sprite(
         let transform =
             *global_transform * GlobalTransform::from_translation(top_left.extend(0.)) * scaling;
         let mut color = LinearRgba::WHITE;
-        let mut current_section = usize::MAX;
+        let mut current_section = u32::MAX;
 
         for (
             i,
@@ -224,7 +224,7 @@ pub fn extract_text2d_sprite(
                     .get(
                         computed_block
                             .entities()
-                            .get(*section_index)
+                            .get(*section_index as usize)
                             .map(|t| t.entity)
                             .unwrap_or(Entity::PLACEHOLDER),
                     )
@@ -262,7 +262,7 @@ pub fn extract_text2d_sprite(
         }
 
         for run in text_layout_info.run_geometry.iter() {
-            let section_entity = computed_block.entities()[run.section_index].entity;
+            let section_entity = computed_block.entities()[run.section_index as usize].entity;
             let Ok((
                 text_color,
                 has_strike_through,

--- a/crates/bevy_text/src/glyph.rs
+++ b/crates/bevy_text/src/glyph.rs
@@ -18,9 +18,9 @@ pub struct PositionedGlyph {
     /// Information about the glyph's atlas.
     pub atlas_info: GlyphAtlasInfo,
     /// The index of the glyph in the [`ComputedTextBlock`](crate::ComputedTextBlock)'s tracked sections.
-    pub section_index: usize,
+    pub section_index: u32,
     /// The index of the glyph's line.
-    pub line_index: usize,
+    pub line_index: u32,
 }
 
 /// Information about a glyph in an atlas.

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -322,7 +322,7 @@ impl TextPipeline {
         for (line_index, line) in layout.lines().enumerate() {
             for item in line.items() {
                 if let PositionedLayoutItem::GlyphRun(glyph_run) = item {
-                    let section_index = glyph_run.style().brush.section_index as usize;
+                    let section_index = glyph_run.style().brush.section_index;
                     let font_smoothing = glyph_run.style().brush.font_smoothing;
                     let run = glyph_run.run();
                     let font = run.font();
@@ -385,7 +385,7 @@ impl TextPipeline {
                                 + atlas_info.offset,
                             atlas_info,
                             section_index,
-                            line_index,
+                            line_index: line_index as u32,
                         });
                     }
 
@@ -499,7 +499,7 @@ impl TextLayoutInfo {
 #[derive(Default, Debug, Clone, Reflect)]
 pub struct RunGeometry {
     /// The index of the text entity in [`ComputedTextBlock`] that this run belongs to.
-    pub section_index: usize,
+    pub section_index: u32,
     /// Bounding box around the text run.
     pub bounds: Rect,
     /// Y position of the strikethrough in the text layout.

--- a/crates/bevy_ui/src/picking_backend.rs
+++ b/crates/bevy_ui/src/picking_backend.rs
@@ -294,5 +294,8 @@ fn pick_ui_text_section(
         .iter()
         .find(|run| run.bounds.contains(local_point))
         .map(|run| run.section_index)?;
-    text_block.entities().get(section_index).map(|e| e.entity)
+    text_block
+        .entities()
+        .get(section_index as usize)
+        .map(|e| e.entity)
 }

--- a/crates/bevy_ui/src/widget/text_input_layout.rs
+++ b/crates/bevy_ui/src/widget/text_input_layout.rs
@@ -376,8 +376,8 @@ pub fn update_editable_text_layout(
                                         + atlas_info.rect.size() / 2.
                                         + atlas_info.offset,
                                     atlas_info,
-                                    section_index: brush.section_index as usize,
-                                    line_index,
+                                    section_index: brush.section_index,
+                                    line_index: line_index as u32,
                                 });
                             }
 
@@ -415,7 +415,7 @@ pub fn update_editable_text_layout(
                             }
 
                             info.run_geometry.push(RunGeometry {
-                                section_index: brush.section_index as usize,
+                                section_index: brush.section_index,
                                 bounds: Rect {
                                     min: Vec2::new(
                                         glyph_run.offset(),

--- a/crates/bevy_ui_render/src/lib.rs
+++ b/crates/bevy_ui_render/src/lib.rs
@@ -1039,7 +1039,7 @@ pub fn extract_text_sections(
             if current_section_index != *section_index
                 && let Some(section_entity) = computed_block
                     .entities()
-                    .get(*section_index)
+                    .get(*section_index as usize)
                     .map(|t| t.entity)
             {
                 color = text_styles
@@ -1199,7 +1199,7 @@ pub fn extract_text_shadows(
         for run in text_layout_info.run_geometry.iter() {
             let Some(section_entity) = computed_block
                 .entities()
-                .get(run.section_index)
+                .get(run.section_index as usize)
                 .map(|t| t.entity)
             else {
                 continue;
@@ -1332,7 +1332,7 @@ pub fn extract_text_decorations(
         for run in text_layout_info.run_geometry.iter() {
             let Some(section_entity) = computed_block
                 .entities()
-                .get(run.section_index)
+                .get(run.section_index as usize)
                 .map(|t| t.entity)
             else {
                 continue;


### PR DESCRIPTION
# Objective

Parley uses `u32`s for its section indices, the conversion to `usize` serves no purpose.
Line indices can be `u32`s too, text with more than `u32::MAX` lines is infeasible.

## Solution

Change the section and line indices in `PostionedGlyph` and `RunGeometry` to use `u32`s.