### PR TITLE
Revert #21684, do not reverse the y-axis direction of the tiles in tileset.

### DIFF
--- a/crates/bevy_sprite_render/src/tilemap_chunk/mod.rs
+++ b/crates/bevy_sprite_render/src/tilemap_chunk/mod.rs
@@ -77,14 +77,14 @@ impl TilemapChunk {
             // to place the 0 at left of tilemapchunk
             - self.tile_display_size.x as f32 * self.chunk_size.x as f32 / 2.,
             // tile position
-            position.y as f32
+            -(position.y as f32
             // times display size for a tile
             * self.tile_display_size.y as f32
             // minus 1/2 the tile_display_size to correct the center
             + self.tile_display_size.y as f32 / 2.
             // plus 1/2 the tilechunk size, in terms of the tile_display_size,
-            // to place the 0 at bottom of tilemapchunk
-            - self.tile_display_size.y as f32 * self.chunk_size.y as f32 / 2.,
+            // to place the 0 at top of tilemapchunk
+            - self.tile_display_size.y as f32 * self.chunk_size.y as f32 / 2.),
             0.,
         )
     }

--- a/crates/bevy_sprite_render/src/tilemap_chunk/tilemap_chunk_material.wgsl
+++ b/crates/bevy_sprite_render/src/tilemap_chunk/tilemap_chunk_material.wgsl
@@ -44,8 +44,6 @@ fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
     var tile_coord = clamp(vec2<u32>(floor(tile_uv)), vec2<u32>(0), chunk_size - 1);
     var local_uv = tile_uv - vec2<f32>(tile_coord);
 
-    tile_coord.y = chunk_size.y - 1 - tile_coord.y;
-
     let tile = get_tile_data(tile_coord);
 
     if (tile.tileset_index == 0xffffu || !tile.visible) {


### PR DESCRIPTION
# Objective

- Following convention, do not reverse the y-axis direction of the tiles in the tileset.

> It's okay to depart from common editors to align with bevy's coordinate system imo.
> 
> External editors only have to make the corrections once at export or import, any in engine or real time use cases for tile maps would have to deal with the coordinate change constantly.
> 
> _Originally posted by @jamescarterbell in https://github.com/bevyengine/bevy/issues/21684#issuecomment-3458571143_

I'm not convinced. A tilemap is more of a rendering thing than a logic one, and in the rendering world, almost every 2D thing follows a left-to-right, top-to-bottom order. Breaking this convention only creates friction for collaboration or migration, without bringing much benefit.

In practice, you rarely face many coordinate conversions, i.e., mapping a position between `TilemapChunk` and world. An interaction either occurs in the engine's world coordinate, where all entities are already spawned, or on a separate grid layer, which have its own arbitrary coordinate.

## Solution

- Revert #21684.

