### PR TITLE
Only select all on input focus with `SelectAllOnFocus`

### DIFF
--- a/crates/bevy_ui_widgets/src/text_input.rs
+++ b/crates/bevy_ui_widgets/src/text_input.rs
@@ -465,9 +465,6 @@ fn on_focus_select_all(
                     queued_select_all.0 = Some(target);
                 }
             }
-
-            // Navigating into a text input should always select all even without
-            // the `SelectAllOnFocus` marker, unless it is a multiline input.
             FocusCause::Navigated => {
                 if select_all_on_focus {
                     editable_text.queue_edit(TextEdit::SelectAll);

--- a/crates/bevy_ui_widgets/src/text_input.rs
+++ b/crates/bevy_ui_widgets/src/text_input.rs
@@ -474,7 +474,7 @@ fn on_focus_select_all(
             // Navigating into a text input should always select all even without
             // the `SelectAllOnFocus` marker, unless it is a multiline input.
             FocusCause::Navigated => {
-                if select_all_on_focus || !editable_text.allow_newlines {
+                if select_all_on_focus {
                     editable_text.queue_edit(TextEdit::SelectAll);
                 }
             }

--- a/examples/ui/text/multiline_text_input.rs
+++ b/examples/ui/text/multiline_text_input.rs
@@ -7,6 +7,7 @@ use bevy::input_focus::tab_navigation::{TabGroup, TabIndex, TabNavigationPlugin}
 use bevy::input_focus::{AutoFocus, FocusedInput};
 use bevy::prelude::*;
 use bevy::text::{EditableText, EditableTextFilter, TextCursorStyle};
+use bevy::ui_widgets::SelectAllOnFocus;
 
 fn main() {
     App::new()
@@ -142,8 +143,10 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                     TextCursorStyle {
                                         color: Color::WHITE,
                                         selected_text_color: Some(Color::BLACK),
+                                        unfocused_selection_color: Color::NONE,
                                         ..default()
                                     },
+                                    SelectAllOnFocus,
                                     VisibleLinesInput,
                                     TabIndex(1),
                                 )
@@ -224,8 +227,10 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                     TextCursorStyle {
                                         color: Color::WHITE,
                                         selected_text_color: Some(Color::BLACK),
+                                        unfocused_selection_color: Color::NONE,
                                         ..default()
                                     },
+                                    SelectAllOnFocus,
                                     FontSizeInput,
                                     TabIndex(2),
                                 )


### PR DESCRIPTION
# Objective

Only select all on focus with `SelectAllOnFocus`. 
It should be possible to have single line inputs without automatic select all on focus.

## Solution

Remove the automatic select all on focus for single line inputs from `on_focus_select_all`.
