### PR TITLE
Atmosphere renames missing from migration guides

### DIFF
--- a/_release-content/migration-guides/atmosphere_entity.md
+++ b/_release-content/migration-guides/atmosphere_entity.md
@@ -46,3 +46,9 @@ commands.spawn(Atmosphere::earth(earth_medium));
 The `bottom_radius` and `top_radius` fields on the `Atmosphere` component have been renamed to `inner_radius` and `outer_radius` respectively to reflect their new meaning.
 
 See the [updated atmosphere example](https://bevy.org/examples/3d-rendering/atmosphere/) and documentation for details.
+
+There have been some renames:
+
+- `Atmosphere::earthlike` -> `Atmosphere::earth`
+- `bevy::pbr::Atmosphere` -> `bevy::light::Atmosphere`
+- `bevy::pbr::ScatteringMedium` -> `bevy::light::atmosphere::ScatteringMedium`


### PR DESCRIPTION
# Objective

- Missing some renames during migration to `0.19.0-rc.1`

## Solution

- Add to migration guide
- PR against release branch as expecting https://github.com/bevyengine/bevy/pull/24276 to remove them

## Testing

- N/A