### PR TITLE
Initialize screen-space transmission texture for transparent transmissive materials

### DIFF
--- a/crates/bevy_pbr/src/transmission/node.rs
+++ b/crates/bevy_pbr/src/transmission/node.rs
@@ -66,9 +66,9 @@ pub fn main_transmissive_pass_3d(
         multiview_mask: None,
     };
 
-    if !transmissive_phase.items.is_empty() {
-        let steps = transmission_settings.steps;
-        if steps > 0 {
+    let steps = transmission_settings.steps;
+    if steps > 0 {
+        if !transmissive_phase.items.is_empty() {
             let transmission =
                 transmission.expect("`ViewTransmissionTexture` should exist at this point");
 
@@ -98,22 +98,31 @@ pub fn main_transmissive_pass_3d(
 
                 pass_span.end(&mut render_pass);
             }
-        } else {
-            let mut render_pass = ctx.begin_tracked_render_pass(render_pass_descriptor);
-            let pass_span = diagnostics.pass_span(&mut render_pass, "main_transmissive_pass_3d");
-
-            if let Some(viewport) =
-                Viewport::from_viewport_and_override(camera.viewport.as_ref(), resolution_override)
-            {
-                render_pass.set_camera_viewport(&viewport);
-            }
-
-            if let Err(err) = transmissive_phase.render(&mut render_pass, world, view_entity) {
-                error!("Error encountered while rendering the transmissive phase {err:?}");
-            }
-
-            pass_span.end(&mut render_pass);
+        } else if let Some(transmission) = transmission {
+            // Materials in later phases can still read from `ViewTransmissionTexture`.
+            // If there are no `Transmissive3d` items, initialize it with the color
+            // output from the opaque pass.
+            ctx.command_encoder().copy_texture_to_texture(
+                target.main_texture().as_image_copy(),
+                transmission.texture.as_image_copy(),
+                physical_target_size.to_extents(),
+            );
         }
+    } else if !transmissive_phase.items.is_empty() {
+        let mut render_pass = ctx.begin_tracked_render_pass(render_pass_descriptor);
+        let pass_span = diagnostics.pass_span(&mut render_pass, "main_transmissive_pass_3d");
+
+        if let Some(viewport) =
+            Viewport::from_viewport_and_override(camera.viewport.as_ref(), resolution_override)
+        {
+            render_pass.set_camera_viewport(&viewport);
+        }
+
+        if let Err(err) = transmissive_phase.render(&mut render_pass, world, view_entity) {
+            error!("Error encountered while rendering the transmissive phase {err:?}");
+        }
+
+        pass_span.end(&mut render_pass);
     }
 }
 

--- a/crates/bevy_pbr/src/transmission/texture.rs
+++ b/crates/bevy_pbr/src/transmission/texture.rs
@@ -8,7 +8,8 @@ use bevy_image::ToExtents;
 use bevy_platform::collections::HashMap;
 use bevy_render::{
     camera::ExtractedCamera,
-    render_phase::{ViewBinnedRenderPhases, ViewSortedRenderPhases},
+    erased_render_asset::ErasedRenderAssets,
+    render_phase::{PhaseItem, ViewBinnedRenderPhases, ViewSortedRenderPhases},
     render_resource::{
         FilterMode, Sampler, SamplerDescriptor, Texture, TextureDescriptor, TextureDimension,
         TextureUsages, TextureView,
@@ -18,7 +19,7 @@ use bevy_render::{
     view::ExtractedView,
 };
 
-use crate::{ScreenSpaceTransmission, Transmissive3d};
+use crate::{PreparedMaterial, RenderMaterialInstances, ScreenSpaceTransmission, Transmissive3d};
 
 #[derive(Component)]
 pub struct ViewTransmissionTexture {
@@ -35,6 +36,8 @@ pub fn prepare_core_3d_transmission_textures(
     alpha_mask_3d_phases: Res<ViewBinnedRenderPhases<AlphaMask3d>>,
     transmissive_3d_phases: Res<ViewSortedRenderPhases<Transmissive3d>>,
     transparent_3d_phases: Res<ViewSortedRenderPhases<Transparent3d>>,
+    render_materials: Res<ErasedRenderAssets<PreparedMaterial>>,
+    material_instances: Res<RenderMaterialInstances>,
     views_3d: Query<(
         Entity,
         &ExtractedCamera,
@@ -48,25 +51,47 @@ pub fn prepare_core_3d_transmission_textures(
             || !alpha_mask_3d_phases.contains_key(&view.retained_view_entity)
             || !transparent_3d_phases.contains_key(&view.retained_view_entity)
         {
+            commands.entity(entity).remove::<ViewTransmissionTexture>();
+            continue;
+        };
+
+        let Some(transparent_3d_phase) = transparent_3d_phases.get(&view.retained_view_entity)
+        else {
+            commands.entity(entity).remove::<ViewTransmissionTexture>();
             continue;
         };
 
         let Some(transmissive_3d_phase) = transmissive_3d_phases.get(&view.retained_view_entity)
         else {
+            commands.entity(entity).remove::<ViewTransmissionTexture>();
             continue;
         };
 
         let Some(physical_target_size) = camera.physical_target_size else {
+            commands.entity(entity).remove::<ViewTransmissionTexture>();
             continue;
         };
 
         // Don't prepare a transmission texture if the number of steps is set to 0
         if transmission.steps == 0 {
+            commands.entity(entity).remove::<ViewTransmissionTexture>();
             continue;
         }
 
-        // Don't prepare a transmission texture if there are no transmissive items to render
-        if transmissive_3d_phase.items.is_empty() {
+        let transparent_phase_reads_view_transmission_texture =
+            transparent_3d_phase.items.values().any(|transparent_item| {
+                material_instances
+                    .instances
+                    .get(&transparent_item.main_entity())
+                    .and_then(|material_instance| render_materials.get(material_instance.asset_id))
+                    .is_some_and(|material| material.properties.reads_view_transmission_texture)
+            });
+
+        // Don't prepare a transmission texture if no phase will read from it.
+        if transmissive_3d_phase.items.is_empty()
+            && !transparent_phase_reads_view_transmission_texture
+        {
+            commands.entity(entity).remove::<ViewTransmissionTexture>();
             continue;
         }
 


### PR DESCRIPTION
# Objective

Fix stale or uninitialized screen-space transmission sampling for transparent transmissive materials.

`StandardMaterial` materials with `specular_transmission > 0.0` can read from `ViewTransmissionTexture` even when their `alpha_mode` queues them in the `Transparent3d` phase instead of the `Transmissive3d` phase. Previously, `ViewTransmissionTexture` was only prepared when the `Transmissive3d` phase had items, so transparent transmissive materials could sample an old or missing transmission texture.


https://github.com/user-attachments/assets/d703a689-3e6c-4dc6-8d5b-c72f797a413e



## Solution

Prepare `ViewTransmissionTexture` when it is needed by either:

- items in the `Transmissive3d` phase, or
- items in the `Transparent3d` phase whose prepared material reads `ViewTransmissionTexture`.

When no phase needs the transmission texture, remove `ViewTransmissionTexture` from the view so stale bindings are not reused.

The transmissive pass now also initializes the texture by copying the current main color target when there are no `Transmissive3d` items but later transparent items still need the texture.

https://github.com/user-attachments/assets/f323013f-df09-4023-a30a-0ac3c966db93


## Testing

Tested with:

- `cargo fmt -p bevy_pbr`
- `cargo check -p bevy_pbr`

Also tested manually with a local repro using spheres with:

```rust
alpha_mode: AlphaMode::Blend,
baseColor alpha: 0.8
specular_transmission: 1.0,
