### PR TITLE
Add `TextLayout` constructor rename migration guide, fix `Access` deprecation messages

### DIFF
--- a/_release-content/migration-guides/text_layout_renames.md
+++ b/_release-content/migration-guides/text_layout_renames.md
@@ -1,0 +1,10 @@
+---
+title: "`new_with_` prefix removed from `TextLayout` constuctors"
+pull_requests: [24049]
+---
+
+Constructor functions for the `TextLayout` type were simplified:
+
+- `TextLayout::new_with_justify` -> `TextLayout::justify`
+- `TextLayout::new_with_linebreak` -> `TextLayout::linebreak`
+- `TextLayout::new_with_no_wrap` -> `TextLayout::no_wrap`

--- a/_release-content/migration-guides/text_layout_renames.md
+++ b/_release-content/migration-guides/text_layout_renames.md
@@ -1,5 +1,5 @@
 ---
-title: "`new_with_` prefix removed from `TextLayout` constuctors"
+title: "`new_with_` prefix removed from `TextLayout` constructors"
 pull_requests: [24049]
 ---
 

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -237,25 +237,25 @@ impl Access {
     }
 
     /// Returns `true` if this can access the resource given by `index`.
-    #[deprecated(since = "0.19.0", note = "use Access::has_component_read")]
+    #[deprecated(since = "0.19.0", note = "use Access::has_read")]
     pub fn has_resource_read(&self, index: ComponentId) -> bool {
         self.has_read(index)
     }
 
     /// Returns `true` if this can access any resource.
-    #[deprecated(since = "0.19.0", note = "use Access::has_any_component_read")]
+    #[deprecated(since = "0.19.0", note = "use Access::has_any_read")]
     pub fn has_any_resource_read(&self) -> bool {
         self.has_any_read()
     }
 
     /// Returns `true` if this can exclusively access the resource given by `index`.
-    #[deprecated(since = "0.19.0", note = "use Access::has_component_write")]
+    #[deprecated(since = "0.19.0", note = "use Access::has_write")]
     pub fn has_resource_write(&self, index: ComponentId) -> bool {
         self.has_write(index)
     }
 
     /// Returns `true` if this accesses any resource mutably.
-    #[deprecated(since = "0.19.0", note = "use Access::has_any_component_write")]
+    #[deprecated(since = "0.19.0", note = "use Access::has_any_write")]
     pub fn has_any_resource_write(&self) -> bool {
         self.has_any_write()
     }


### PR DESCRIPTION
Two minor things I noticed during migrating for 0.19-rc1.