### PR TITLE
`multiple_text_input` example layout fixes

### DIFF
--- a/examples/ui/text/multiple_text_inputs.rs
+++ b/examples/ui/text/multiple_text_inputs.rs
@@ -126,7 +126,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     children![(
                         Text::default(),
                         TextLayout::no_wrap(),
-                        Node { ..default() },
                         font.clone(),
                         BackgroundColor(bevy::color::palettes::css::DARK_SLATE_GRAY.into()),
                         BorderColor::all(Color::WHITE),
@@ -152,7 +151,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     children![(
                         Text::default(),
                         TextLayout::no_wrap(),
-                        Node { ..default() },
                         font.clone(),
                         TextInputRow(row),
                         SubmitOutput,

--- a/examples/ui/text/multiple_text_inputs.rs
+++ b/examples/ui/text/multiple_text_inputs.rs
@@ -102,6 +102,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     font.clone(),
                     BackgroundColor(bevy::color::palettes::css::DARK_GREY.into()),
                     TextInputRow(row),
+                    TextLayout::no_wrap(),
                     TabIndex(row as i32),
                     BorderColor::all(SLATE_300),
                 ));
@@ -110,39 +111,52 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 }
 
                 parent.spawn((
-                    Text::default(),
-                    TextLayout {
-                        linebreak: LineBreak::AnyCharacter,
-                        ..default()
-                    },
                     Node {
                         border: px(4.).all(),
                         padding: px(4.).all(),
+                        overflow: Overflow::clip_x(),
+                        overflow_clip_margin: OverflowClipMargin {
+                            visual_box: VisualBox::ContentBox,
+                            ..default()
+                        },
                         ..default()
                     },
-                    font.clone(),
-                    BackgroundColor(bevy::color::palettes::css::DARK_SLATE_GRAY.into()),
+                    BackgroundColor(bevy::color::palettes::css::DARK_SLATE_BLUE.into()),
                     BorderColor::all(Color::WHITE),
-                    TextInputRow(row),
-                    TextOutput,
+                    children![(
+                        Text::default(),
+                        TextLayout::no_wrap(),
+                        Node { ..default() },
+                        font.clone(),
+                        BackgroundColor(bevy::color::palettes::css::DARK_SLATE_GRAY.into()),
+                        BorderColor::all(Color::WHITE),
+                        TextInputRow(row),
+                        TextOutput,
+                    )],
                 ));
 
                 parent.spawn((
-                    Text::default(),
-                    TextLayout {
-                        linebreak: LineBreak::AnyCharacter,
-                        ..default()
-                    },
                     Node {
                         border: px(4.).all(),
                         padding: px(4.).all(),
+                        overflow: Overflow::clip_x(),
+                        overflow_clip_margin: OverflowClipMargin {
+                            visual_box: VisualBox::ContentBox,
+                            ..default()
+                        },
+
                         ..default()
                     },
-                    font.clone(),
                     BackgroundColor(bevy::color::palettes::css::DARK_SLATE_BLUE.into()),
                     BorderColor::all(Color::WHITE),
-                    TextInputRow(row),
-                    SubmitOutput,
+                    children![(
+                        Text::default(),
+                        TextLayout::no_wrap(),
+                        Node { ..default() },
+                        font.clone(),
+                        TextInputRow(row),
+                        SubmitOutput,
+                    )],
                 ));
             }
 


### PR DESCRIPTION
# Objective

These are meant to be single line inputs, but:

<img width="1552" height="954" alt="image" src="https://github.com/user-attachments/assets/5e7ab2c7-9bb2-46cd-9a42-bca36b933837" />

A mess!

## Solution

1. Add `TextLayout::no_wrap()` to each input and their outputs.
2. Add an intermediate node wrapping each output node applying clipping to hide the overflow.

<img width="1608" height="489" alt="fixed-inputs" src="https://github.com/user-attachments/assets/22dc436c-e677-4b1f-a569-d3a9c9effc1c" />

## Testing

```
cargo run --example multiple_text_inputs  --features="system_clipboard"
```

