### PR TITLE
`ime_support` example clean up

### DIFF
--- a/examples/ui/text/ime_support.rs
+++ b/examples/ui/text/ime_support.rs
@@ -37,10 +37,6 @@ fn setup(mut commands: Commands) {
                 font_size: FontSize::Px(20.0),
                 ..default()
             },
-            Node {
-                margin: UiRect::bottom(px(16.0)),
-                ..default()
-            },
         ))
         .id();
 
@@ -48,6 +44,7 @@ fn setup(mut commands: Commands) {
         .spawn((
             Node {
                 width: px(400),
+                height: px(250),
                 border: px(3).all(),
                 padding: px(8).all(),
                 ..default()
@@ -61,7 +58,10 @@ fn setup(mut commands: Commands) {
                 ..default()
             },
             BorderColor::from(Color::from(SLATE_300)),
-            EditableText::default(),
+            EditableText {
+                allow_newlines: true,
+                ..default()
+            },
             TextCursorStyle::default(),
             TabIndex(0),
             BackgroundColor(DARK_GREY.into()),
@@ -77,10 +77,6 @@ fn setup(mut commands: Commands) {
                 ..default()
             },
             TextOutput,
-            Node {
-                margin: UiRect::top(px(16.0)),
-                ..default()
-            },
         ))
         .id();
 
@@ -89,6 +85,7 @@ fn setup(mut commands: Commands) {
             Node {
                 flex_direction: FlexDirection::Column,
                 padding: px(24.0).all(),
+                row_gap: px(16),
                 ..default()
             },
             TabGroup::new(0),


### PR DESCRIPTION
# Objective

Little bit of clean up for the `ime_support` example.

## Solution

* Use `row_gap` on the parent for spacing instead of setting individual margins on the children.
* Give the text input node a fixed height and allow newlines.

## Testing

```
cargo run --example ime_support --features="system_font_discovery"
```