### PR TITLE
docs - modernized nix linux dependencies example

### DIFF
--- a/docs/linux_dependencies.md
+++ b/docs/linux_dependencies.md
@@ -119,8 +119,8 @@ Add a `flake.nix` file to the root of your GitHub repository containing:
   outputs =
     {
       nixpkgs,
-      rust-overlay,
       flake-utils,
+      rust-overlay,
       ...
     }:
     flake-utils.lib.eachDefaultSystem (
@@ -135,38 +135,40 @@ Add a `flake.nix` file to the root of your GitHub repository containing:
         devShells.default =
           with pkgs;
           mkShell {
-            buildInputs =
-              [
-                # Rust dependencies
-                (rust-bin.stable.latest.default.override { extensions = [ "rust-src" ]; })
-                pkg-config
-              ]
-              ++ lib.optionals (lib.strings.hasInfix "linux" system) [
-                # for Linux
-                # Audio (Linux only)
-                alsa-lib
-                # Cross Platform 3D Graphics API
-                vulkan-loader
-                # For debugging around vulkan
-                vulkan-tools
-                # Other dependencies
-                libudev-zero
-                libx11
-                libxcursor
-                libxi
-                libxrandr
-                libxkbcommon
-                wayland
-              ];
-            RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
-            LD_LIBRARY_PATH = lib.makeLibraryPath [
+            nativeBuildInputs = [ pkg-config ];
+            packages = [
+              # Rust dependencies
+              (rust-bin.stable.latest.default.override { extensions = [ "rust-src" "rust-analyzer" ]; })
+            ]
+            ++ lib.optionals stdenv.isLinux [
+              # for Linux
+              # Audio (Linux only)
+              alsa-lib
+              # Cross Platform 3D Graphics API
               vulkan-loader
+              # For debugging around vulkan
+              vulkan-tools
+              # Other dependencies
+              libudev-zero
               libx11
-              libxi
               libxcursor
+              libxi
+              libxrandr
               libxkbcommon
               wayland
             ];
+
+            LD_LIBRARY_PATH = lib.optionalString stdenv.isLinux (
+              lib.makeLibraryPath [
+                libX11
+                libxcursor
+                libxi
+                libxkbcommon
+                libxrandr
+                vulkan-loader
+                wayland
+              ]
+            );
           };
       }
     );


### PR DESCRIPTION
# Objective
- Changed buildInputs to packages (recommended way for mkShell since 22.05)
- Removed outdated RUST_SRC_PATH no longer needed as rust-analyzer added to extension list
- pkg-config moved to nativeBuildInputs because it is a build time tool, not a runtime library (package - buildInput)
- Use stdenv.isLinux instead of (lib.strings.hasInfix "linux" system) as it is cleaner, clearer and safer
- Made LD_LIBRARY_PATH part of platform check

## Solution
- Updates the Nix example in the Linux dependencies documentation to use current best practices: 
- Uses packages instead of the older buildInputs in mkShell 
- Moves pkg-config to its proper place:  nativeBuildInputs 
- Uses stdenv.isLinux for platform checks

## Testing
Test flake: https://gitlab.com/megacron/echo-chamber

- This code was tested in both Nixos and Mac environments using nix develop.
- It made the devshell environments properly for both platforms.
- Successfully ran cargo check and cargo run on both linux and macos with bevy window spawn, no errors.