### PR TITLE
Selection rect gap fix

### DIFF
--- a/crates/bevy_ui/src/widget/text_input_layout.rs
+++ b/crates/bevy_ui/src/widget/text_input_layout.rs
@@ -446,6 +446,15 @@ pub fn update_editable_text_layout(
                 .iter()
                 .map(|&b| bounding_box_to_rect(b.0))
                 .collect();
+
+            for i in 0..info.selection_rects.len().saturating_sub(1) {
+                let [a, b] = &mut info.selection_rects[i..i + 2] else {
+                    unreachable!();
+                };
+                if a.max.y < b.min.y {
+                    a.max.y = b.min.y;
+                }
+            }
         }
 
         if let Some(input_focus) = input_focus.as_ref()


### PR DESCRIPTION

# Objective

Fix the gaps that sometimes occur between vertically adjacent text selection rects:

<img width="486" height="448" alt="gap" src="https://github.com/user-attachments/assets/b8e8d6b3-18fa-4731-9937-72544f1837be" />

Frequency of gaps varies depending on scale factor and font settings.

## Solution

Iterate the selection rects returned from Parley in pairs. If there is a gap, close it by extending the bottom edge downwards.

<img width="489" height="460" alt="no-gaps" src="https://github.com/user-attachments/assets/063b3b93-c6af-459b-a774-a345a22b95b7" />

## Testing
```
cargo run --example multiline_text_input --features="system_clipboard"
```


