### PR TITLE
Change swap to memcopy in Column::initialize_from_unchecked

### DIFF
--- a/crates/bevy_ecs/src/storage/blob_array.rs
+++ b/crates/bevy_ecs/src/storage/blob_array.rs
@@ -333,6 +333,40 @@ impl BlobArray {
         core::ptr::copy::<u8>(value.as_ptr(), dst.as_ptr(), size);
     }
 
+    /// Initializes the value at `dst_index` by swap-removing an element from `src`.
+    ///
+    /// # Safety
+    /// - `src_index` & `dst_index` must be in bounds of their [`BlobArray`]
+    /// - `src_last_element_index` must be the last element in `src`
+    /// - The value [`Layout`] and drop function of `src` and `self` must match
+    #[inline]
+    pub unsafe fn initialize_from_swap_remove_unchecked(
+        &mut self,
+        src: &mut Self,
+        src_last_element_index: usize,
+        src_index: usize,
+        dst_index: usize,
+    ) {
+        #[cfg(debug_assertions)]
+        {
+            debug_assert!(src.capacity > src_last_element_index);
+            debug_assert!(src.capacity > src_index);
+            debug_assert!(self.capacity > dst_index);
+        }
+        core::ptr::copy_nonoverlapping(
+            src.get_unchecked(src_index).as_ptr(),
+            self.get_unchecked_mut(dst_index).as_ptr(),
+            self.item_layout.size(),
+        );
+        if src_index != src_last_element_index {
+            core::ptr::copy_nonoverlapping(
+                src.get_unchecked(src_last_element_index).as_ptr(),
+                src.get_unchecked_mut(src_index).as_ptr(),
+                self.item_layout.size(),
+            );
+        }
+    }
+
     /// Replaces the value at `index` with `value`. This function does not do any bounds checking.
     ///
     /// # Safety
@@ -442,7 +476,6 @@ impl BlobArray {
             debug_assert!(self.capacity > index_to_remove);
             debug_assert_ne!(index_to_keep, index_to_remove);
         }
-        debug_assert_ne!(index_to_keep, index_to_remove);
         core::ptr::swap_nonoverlapping::<u8>(
             self.get_unchecked_mut(index_to_keep).as_ptr(),
             self.get_unchecked_mut(index_to_remove).as_ptr(),

--- a/crates/bevy_ecs/src/storage/blob_array.rs
+++ b/crates/bevy_ecs/src/storage/blob_array.rs
@@ -365,7 +365,7 @@ impl BlobArray {
         }
         if src_index != src_last_element_index {
             // SAFETY:
-            // - indices disjointness
+            // - indices disjoint
             // - in bounds per precondition
             unsafe {
                 core::ptr::copy_nonoverlapping(

--- a/crates/bevy_ecs/src/storage/blob_array.rs
+++ b/crates/bevy_ecs/src/storage/blob_array.rs
@@ -353,17 +353,27 @@ impl BlobArray {
             debug_assert!(src.capacity > src_index);
             debug_assert!(self.capacity > dst_index);
         }
-        core::ptr::copy_nonoverlapping(
-            src.get_unchecked(src_index).as_ptr(),
-            self.get_unchecked_mut(dst_index).as_ptr(),
-            self.item_layout.size(),
-        );
-        if src_index != src_last_element_index {
+        // SAFETY:
+        // - exclusive references guarantee disjointness
+        // - in bounds per precondition
+        unsafe {
             core::ptr::copy_nonoverlapping(
-                src.get_unchecked(src_last_element_index).as_ptr(),
-                src.get_unchecked_mut(src_index).as_ptr(),
+                src.get_unchecked(src_index).as_ptr(),
+                self.get_unchecked_mut(dst_index).as_ptr(),
                 self.item_layout.size(),
             );
+        }
+        if src_index != src_last_element_index {
+            // SAFETY:
+            // - indices disjointness
+            // - in bounds per precondition
+            unsafe {
+                core::ptr::copy_nonoverlapping(
+                    src.get_unchecked(src_last_element_index).as_ptr(),
+                    src.get_unchecked_mut(src_index).as_ptr(),
+                    self.item_layout.size(),
+                );
+            }
         }
     }
 

--- a/crates/bevy_ecs/src/storage/table/column.rs
+++ b/crates/bevy_ecs/src/storage/table/column.rs
@@ -228,7 +228,7 @@ impl Column {
         dst_row: TableRow,
     ) {
         debug_assert!(self.data.layout() == src.data.layout());
-        // SAFETY
+        // SAFETY:
         // In bounds, same layout & correct last element index as per preconditions
         unsafe {
             self.data.initialize_from_swap_remove_unchecked(

--- a/crates/bevy_ecs/src/storage/table/column.rs
+++ b/crates/bevy_ecs/src/storage/table/column.rs
@@ -208,7 +208,7 @@ impl Column {
             .assign(caller);
     }
 
-    /// Removes the element from `other` at `src_row` and inserts it
+    /// Removes the element from `src` at `src_row` and inserts it
     /// into the current column to initialize the values at `dst_row`.
     /// Does not do any bounds checking.
     ///
@@ -221,34 +221,38 @@ impl Column {
     #[inline]
     pub(crate) unsafe fn initialize_from_unchecked(
         &mut self,
-        other: &mut Column,
-        other_last_element_index: usize,
+        src: &mut Column,
+        src_last_element_index: usize,
         src_row: TableRow,
         dst_row: TableRow,
     ) {
-        debug_assert!(self.data.layout() == other.data.layout());
-        // Init the data
-        let src_val = other
-            .data
-            .swap_remove_unchecked(src_row.index(), other_last_element_index);
-        self.data.initialize_unchecked(dst_row.index(), src_val);
-        // Init added_ticks
-        let added_tick = other
-            .added_ticks
-            .swap_remove_unchecked(src_row.index(), other_last_element_index);
-        self.added_ticks
-            .initialize_unchecked(dst_row.index(), added_tick);
-        // Init changed_ticks
-        let changed_tick = other
-            .changed_ticks
-            .swap_remove_unchecked(src_row.index(), other_last_element_index);
-        self.changed_ticks
-            .initialize_unchecked(dst_row.index(), changed_tick);
-        self.changed_by.as_mut().zip(other.changed_by.as_mut()).map(
-            |(self_changed_by, other_changed_by)| {
-                let changed_by = other_changed_by
-                    .swap_remove_unchecked(src_row.index(), other_last_element_index);
-                self_changed_by.initialize_unchecked(dst_row.index(), changed_by);
+        debug_assert!(self.data.layout() == src.data.layout());
+        self.data.initialize_from_swap_remove_unchecked(
+            &mut src.data,
+            src_last_element_index,
+            src_row.index(),
+            dst_row.index(),
+        );
+        self.added_ticks.initialize_from_swap_remove_unchecked(
+            &mut src.added_ticks,
+            src_last_element_index,
+            src_row.index(),
+            dst_row.index(),
+        );
+        self.changed_ticks.initialize_from_swap_remove_unchecked(
+            &mut src.changed_ticks,
+            src_last_element_index,
+            src_row.index(),
+            dst_row.index(),
+        );
+        self.changed_by.as_mut().zip(src.changed_by.as_mut()).map(
+            |(self_changed_by, src_changed_by)| {
+                self_changed_by.initialize_from_swap_remove_unchecked(
+                    src_changed_by,
+                    src_last_element_index,
+                    src_row.index(),
+                    dst_row.index(),
+                );
             },
         );
     }

--- a/crates/bevy_ecs/src/storage/table/column.rs
+++ b/crates/bevy_ecs/src/storage/table/column.rs
@@ -218,6 +218,7 @@ impl Column {
     ///  - `dst_row` must be in bounds for `self`
     ///  - `src[src_row]` must be initialized to a valid value.
     ///  - `self[dst_row]` must not be initialized yet.
+    ///  - `src_last_element_index` must be the last element in `src`
     #[inline]
     pub(crate) unsafe fn initialize_from_unchecked(
         &mut self,
@@ -227,34 +228,38 @@ impl Column {
         dst_row: TableRow,
     ) {
         debug_assert!(self.data.layout() == src.data.layout());
-        self.data.initialize_from_swap_remove_unchecked(
-            &mut src.data,
-            src_last_element_index,
-            src_row.index(),
-            dst_row.index(),
-        );
-        self.added_ticks.initialize_from_swap_remove_unchecked(
-            &mut src.added_ticks,
-            src_last_element_index,
-            src_row.index(),
-            dst_row.index(),
-        );
-        self.changed_ticks.initialize_from_swap_remove_unchecked(
-            &mut src.changed_ticks,
-            src_last_element_index,
-            src_row.index(),
-            dst_row.index(),
-        );
-        self.changed_by.as_mut().zip(src.changed_by.as_mut()).map(
-            |(self_changed_by, src_changed_by)| {
-                self_changed_by.initialize_from_swap_remove_unchecked(
-                    src_changed_by,
-                    src_last_element_index,
-                    src_row.index(),
-                    dst_row.index(),
-                );
-            },
-        );
+        // SAFETY
+        // In bounds, same layout & correct last element index as per preconditions
+        unsafe {
+            self.data.initialize_from_swap_remove_unchecked(
+                &mut src.data,
+                src_last_element_index,
+                src_row.index(),
+                dst_row.index(),
+            );
+            self.added_ticks.initialize_from_swap_remove_unchecked(
+                &mut src.added_ticks,
+                src_last_element_index,
+                src_row.index(),
+                dst_row.index(),
+            );
+            self.changed_ticks.initialize_from_swap_remove_unchecked(
+                &mut src.changed_ticks,
+                src_last_element_index,
+                src_row.index(),
+                dst_row.index(),
+            );
+            self.changed_by.as_mut().zip(src.changed_by.as_mut()).map(
+                |(self_changed_by, src_changed_by)| {
+                    self_changed_by.initialize_from_swap_remove_unchecked(
+                        src_changed_by,
+                        src_last_element_index,
+                        src_row.index(),
+                        dst_row.index(),
+                    );
+                },
+            );
+        }
     }
 
     /// Call [`Tick::check_tick`] on all of the ticks stored in this column.

--- a/crates/bevy_ecs/src/storage/table/column.rs
+++ b/crates/bevy_ecs/src/storage/table/column.rs
@@ -209,14 +209,14 @@ impl Column {
     }
 
     /// Removes the element from `src` at `src_row` and inserts it
-    /// into the current column to initialize the values at `dst_row`.
+    /// into this column to initialize the values at `dst_row`.
     /// Does not do any bounds checking.
     ///
     /// # Safety
-    ///  - `other` must have the same data layout as `self`
-    ///  - `src_row` must be in bounds for `other`
+    ///  - `src` must have the same data layout as `self`
+    ///  - `src_row` must be in bounds for `src`
     ///  - `dst_row` must be in bounds for `self`
-    ///  - `other[src_row]` must be initialized to a valid value.
+    ///  - `src[src_row]` must be initialized to a valid value.
     ///  - `self[dst_row]` must not be initialized yet.
     #[inline]
     pub(crate) unsafe fn initialize_from_unchecked(

--- a/crates/bevy_ecs/src/storage/thin_array_ptr.rs
+++ b/crates/bevy_ecs/src/storage/thin_array_ptr.rs
@@ -126,6 +126,41 @@ impl<T> ThinArrayPtr<T> {
         unsafe { ptr::write(ptr, value) };
     }
 
+    /// Initializes the value at `dst_index` by swap-removing an element from `src`.
+    /// Thus the previous last element of `src` is now at `src_index` (if still in bounds).
+    ///
+    /// # Safety
+    /// - `src_index` & `dst_index` must be in bounds of their [`ThinArrayPtr`]
+    /// - `src_last_element_index` must be the last element in `src`
+    /// - The value [`Layout`] and drop function of `src` and `self` must match
+    #[inline]
+    pub unsafe fn initialize_from_swap_remove_unchecked(
+        &mut self,
+        src: &mut Self,
+        src_last_element_index: usize,
+        src_index: usize,
+        dst_index: usize,
+    ) {
+        #[cfg(debug_assertions)]
+        {
+            debug_assert!(src.capacity > src_last_element_index);
+            debug_assert!(src.capacity > src_index);
+            debug_assert!(self.capacity > dst_index);
+        }
+        ptr::copy_nonoverlapping(
+            src.data.as_ptr().add(src_index),
+            self.data.as_ptr().add(dst_index),
+            1,
+        );
+        if src_index != src_last_element_index {
+            ptr::copy_nonoverlapping(
+                src.data.as_ptr().add(src_last_element_index),
+                src.data.as_ptr().add(src_index),
+                1,
+            );
+        }
+    }
+
     /// Get a reference to the element at `index`. This method doesn't do any bounds checking.
     ///
     /// # Safety

--- a/crates/bevy_ecs/src/storage/thin_array_ptr.rs
+++ b/crates/bevy_ecs/src/storage/thin_array_ptr.rs
@@ -147,17 +147,27 @@ impl<T> ThinArrayPtr<T> {
             debug_assert!(src.capacity > src_index);
             debug_assert!(self.capacity > dst_index);
         }
-        ptr::copy_nonoverlapping(
-            src.data.as_ptr().add(src_index),
-            self.data.as_ptr().add(dst_index),
-            1,
-        );
-        if src_index != src_last_element_index {
+        // SAFETY:
+        // - exclusive references guarantee disjointness
+        // - in bounds per precondition
+        unsafe {
             ptr::copy_nonoverlapping(
-                src.data.as_ptr().add(src_last_element_index),
                 src.data.as_ptr().add(src_index),
+                self.data.as_ptr().add(dst_index),
                 1,
             );
+        }
+        if src_index != src_last_element_index {
+            // SAFETY:
+            // - indices disjoint
+            // - in bounds per precondition
+            unsafe {
+                ptr::copy_nonoverlapping(
+                    src.data.as_ptr().add(src_last_element_index),
+                    src.data.as_ptr().add(src_index),
+                    1,
+                );
+            }
         }
     }
 


### PR DESCRIPTION
# Objective

When moving a component between tables, we move it to the end of the table before moving it to the new table; we can just move them directly to the new table.

## Solution

I don't expect noticeable gains, but it doesn't make the code more complex. I'm not an expert in reading assembly and haven't benched this yet, but `Column::initialize_from_unchecked` now is half as long and calls `memcpy` instead of `memmove`.