### PR TITLE
docs(bevy_ecs): clarify how to configure Res/ResMut validation error …

### DIFF
--- a/crates/bevy_ecs/src/change_detection/params.rs
+++ b/crates/bevy_ecs/src/change_detection/params.rs
@@ -456,9 +456,11 @@ impl<'w> From<ContiguousComponentTicksMut<'w>> for ContiguousComponentTicksRef<'
 /// If you need a unique mutable borrow, use [`ResMut`] instead.
 ///
 /// This [`SystemParam`](crate::system::SystemParam) fails validation if resource doesn't exist.
-/// This will cause a panic, but can be configured to do nothing or warn once.
+/// This will cause a panic. To skip this system without panicking when the resource
+/// is missing, use [`If<Res<T>>`](crate::system::If).
 ///
-/// Use [`Option<Res<T>>`] instead if the resource might not always exist.
+/// Use [`Option<Res<T>>`] instead if the resource might not always exist
+/// and you want to handle that case yourself.
 pub struct Res<'w, T: ?Sized + Resource> {
     pub(crate) value: &'w T,
     pub(crate) ticks: ComponentTicksRef<'w>,
@@ -529,9 +531,11 @@ impl_debug!(Res<'w, T>, Resource);
 /// If you need a shared borrow, use [`Res`] instead.
 ///
 /// This [`SystemParam`](crate::system::SystemParam) fails validation if resource doesn't exist.
-/// This will cause a panic, but can be configured to do nothing or warn once.
+/// This will cause a panic. To skip this system without panicking when the resource
+/// is missing, use [`If<ResMut<T>>`](crate::system::If).
 ///
-/// Use [`Option<ResMut<T>>`] instead if the resource might not always exist.
+/// Use [`Option<ResMut<T>>`] instead if the resource might not always exist
+/// and you want to handle that case yourself.
 pub struct ResMut<'w, T: ?Sized + Resource<Mutability = Mutable>> {
     pub(crate) value: &'w mut T,
     pub(crate) ticks: ComponentTicksMut<'w>,
@@ -586,9 +590,11 @@ impl<'w, T: Resource<Mutability = Mutable>> From<ResMut<'w, T>> for Mut<'w, T> {
 /// over to another thread.
 ///
 /// This [`SystemParam`](crate::system::SystemParam) fails validation if the non-send resource doesn't exist.
-/// This will cause a panic, but can be configured to do nothing or warn once.
+/// This will cause a panic. To skip this system without panicking when the resource
+/// is missing, use [`If<NonSend<T>>`](crate::system::If).
 ///
-/// Use [`Option<NonSend<T>>`] instead if the resource might not always exist.
+/// Use [`Option<NonSend<T>>`] instead if the resource might not always exist
+/// and you want to handle that case yourself.
 pub struct NonSend<'w, T: ?Sized + 'static> {
     pub(crate) value: &'w T,
     pub(crate) ticks: ComponentTicksRef<'w>,
@@ -614,9 +620,11 @@ impl<'w, T> From<NonSendMut<'w, T>> for NonSend<'w, T> {
 /// over to another thread.
 ///
 /// This [`SystemParam`](crate::system::SystemParam) fails validation if non-send resource doesn't exist.
-/// This will cause a panic, but can be configured to do nothing or warn once.
+/// This will cause a panic. To skip this system without panicking when the resource
+/// is missing, use [`If<NonSendMut<T>>`](crate::system::If).
 ///
-/// Use [`Option<NonSendMut<T>>`] instead if the resource might not always exist.
+/// Use [`Option<NonSendMut<T>>`] instead if the resource might not always exist
+/// and you want to handle that case yourself.
 pub struct NonSendMut<'w, T: ?Sized + 'static> {
     pub(crate) value: &'w mut T,
     pub(crate) ticks: ComponentTicksMut<'w>,


### PR DESCRIPTION
# Objective

Fixes #23770

The documentation for `Res`, `ResMut`, `NonSend`, and `NonSendMut` stated
that validation failures "can be configured to do nothing or warn once"
but never explained how to actually configure it.

## Solution

Replaced the misleading sentence with accurate information pointing users
to `If<T>` for silently skipping the system, and clarified that
`Option<T>` is for when you want to handle the missing resource yourself.

## Testing

No testing is required. These are documentation-only changes.