### PR TITLE
transform: Add transform_vector methods

### DIFF
--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -300,9 +300,9 @@ impl GlobalTransform {
     /// # use bevy_transform::prelude::{GlobalTransform};
     /// # use bevy_math::prelude::Vec3;
     /// let global_transform = GlobalTransform::from_xyz(1., 2., 3.);
-    /// let local_point = Vec3::new(1., 2., 3.);
-    /// let global_point = global_transform.transform_vector(local_point);
-    /// assert_eq!(global_point, Vec3::new(1., 2., 3.));
+    /// let local_vector = Vec3::new(1., 2., 3.);
+    /// let global_vector = global_transform.transform_vector(local_vector);
+    /// assert_eq!(global_vector, Vec3::new(1., 2., 3.));
     /// ```
     #[inline]
     pub fn transform_vector(&self, vector: Vec3) -> Vec3 {

--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -281,7 +281,7 @@ impl GlobalTransform {
     /// # use bevy_math::prelude::Vec3;
     /// let global_transform = GlobalTransform::from_xyz(1., 2., 3.);
     /// let local_direction = Vec3::new(1., 2., 3.);
-    /// let global_direction = global_transform.affine().transform_vector3(local_direction);
+    /// let global_direction = global_transform.transform_vector(local_direction);
     /// assert_eq!(global_direction, Vec3::new(1., 2., 3.));
     /// let roundtripped_local_direction = global_transform.affine().inverse().transform_vector3(global_direction);
     /// assert_eq!(roundtripped_local_direction, local_direction);
@@ -289,6 +289,24 @@ impl GlobalTransform {
     #[inline]
     pub fn transform_point(&self, point: Vec3) -> Vec3 {
         self.0.transform_point3(point)
+    }
+
+    /// Transforms the given vector from local space to global space, applying
+    /// shear, scale, rotation but not translation.
+    ///
+    /// It can be used like this:
+    ///
+    /// ```
+    /// # use bevy_transform::prelude::{GlobalTransform};
+    /// # use bevy_math::prelude::Vec3;
+    /// let global_transform = GlobalTransform::from_xyz(1., 2., 3.);
+    /// let local_point = Vec3::new(1., 2., 3.);
+    /// let global_point = global_transform.transform_vector(local_point);
+    /// assert_eq!(global_point, Vec3::new(1., 2., 3.));
+    /// ```
+    #[inline]
+    pub fn transform_vector(&self, vector: Vec3) -> Vec3 {
+        self.0.transform_vector3(vector)
     }
 
     /// Multiplies `self` with `transform` component by component, returning the

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -598,6 +598,38 @@ impl Transform {
         point
     }
 
+    /// Transforms the given `vector`, applying scale, rotation but not translation.
+    ///
+    /// If this [`Transform`] has an ancestor entity with a [`Transform`] component,
+    /// [`Transform::transform_vector`] will transform a point in local space into its
+    /// parent transform's space.
+    ///
+    /// If this [`Transform`] does not have a parent, [`Transform::transform_vector`] will
+    /// transform a point in local space into worldspace coordinates.
+    ///
+    /// If you always want to transform a point in local space to worldspace,
+    /// see [`GlobalTransform::transform_vector()`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bevy_transform::prelude::Transform;
+    /// # use bevy_math::prelude::{Vec3, Quat};
+    /// # use std::f64::consts::PI;
+    /// let transform = Transform::from_xyz(1., 2., 3.)
+    ///    .with_scale(Vec3::splat(2.))
+    ///    .with_rotation(Quat::from_axis_angle(Vec3::Y, PI as f32));
+    /// let local_vector = Vec3::new(1., 2., 3.);
+    /// let global_vector = transform.transform_vector(local_vector);
+    /// assert!(global_vector.abs_diff_eq(Vec3::new(-2., 4., -6.), 1e-5));
+    /// ```
+    #[inline]
+    pub fn transform_vector(&self, mut vector: Vec3) -> Vec3 {
+        vector = self.scale * vector;
+        vector = self.rotation * vector;
+        vector
+    }
+
     /// Returns `true` if, and only if, translation, rotation and scale all are
     /// finite. If any of them contains a `NaN`, positive or negative infinity,
     /// this will return `false`.

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -598,16 +598,16 @@ impl Transform {
         point
     }
 
-    /// Transforms the given `vector`, applying scale, rotation but not translation.
+    /// Transforms the given `vector`, applying scale and rotation only, not translation.
     ///
     /// If this [`Transform`] has an ancestor entity with a [`Transform`] component,
-    /// [`Transform::transform_vector`] will transform a point in local space into its
+    /// [`Transform::transform_vector`] will transform a vector in local space into its
     /// parent transform's space.
     ///
     /// If this [`Transform`] does not have a parent, [`Transform::transform_vector`] will
-    /// transform a point in local space into worldspace coordinates.
+    /// transform a vector in local space into worldspace coordinates.
     ///
-    /// If you always want to transform a point in local space to worldspace,
+    /// If you always want to transform a vector in local space to worldspace,
     /// see [`GlobalTransform::transform_vector()`].
     ///
     /// # Examples


### PR DESCRIPTION
# Objective

There isn't a particularly obvious way to transform a vector using a `Transform` (you have to make an Affine3 first, and then use the matrix)

## Solution

This adds a `transform_vector` method to `Transform` and `GlobalTransform`, paralleling the `transform_point` method.

## Testing

Added doctests.
