### PR TITLE
Re-export everything from the gltf library

### DIFF
--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -165,7 +165,7 @@ pub use {assets::*, label::GltfAssetLabel, loader::*, material::GltfMaterial};
 /// Re-exports for GLTF
 pub mod gltf {
     #[doc(hidden)]
-    pub use gltf::{Animation, Document, Gltf, Material, Mesh, Primitive, Scene, Texture};
+    pub use gltf::*;
 }
 
 // Has to store an Arc<Mutex<...>> as there is no other way to mutate fields of asset loaders.

--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -163,10 +163,7 @@ use crate::{convert_coordinates::GltfConvertCoordinates, extensions::GltfExtensi
 pub use {assets::*, label::GltfAssetLabel, loader::*, material::GltfMaterial};
 
 /// Re-exports for GLTF
-pub mod gltf {
-    #[doc(hidden)]
-    pub use gltf::*;
-}
+pub use gltf;
 
 // Has to store an Arc<Mutex<...>> as there is no other way to mutate fields of asset loaders.
 /// Stores default [`ImageSamplerDescriptor`] in main world.


### PR DESCRIPTION
# Objective

Some traits like `GltfExtensionHandler` depends on items that weren't re-exported from the `gltf` library, such as `gltf::Node`:

https://github.com/bevyengine/bevy/blob/fc292740893c7df0fa640a5e4000270ce57ac83f/crates/bevy_gltf/src/loader/extensions/mod.rs#L227-L232

This means that users won't be able to implement this trait method without manually adding `gltf` to their dependencies (while also making sure that the version matches up).

## Solution

We could just add `Node` to the re-export, but I think it's safer and more future-proof to just re-export everything. Since they're namespaced under `gltf`, there's no risk of collisions there.

## Testing

- Did you test these changes? If so, how?
  ```bash
  $ cargo test -p ci
  ```
- Are there any parts that need more testing?

  I don't think so!
- How can other people (reviewers) test your changes? Is there anything specific they need to know?

  It's just an additional set of re-exports, so if it compiles it's probably fine.
  
