### PR TITLE
Support require attribute in resource derive

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -582,7 +582,7 @@ pub fn derive_message(input: TokenStream) -> TokenStream {
 /// or a function call that returns a function that can be turned into
 /// a `ComponentHook`, e.g. `get_closure("Hi!")`.
 /// `function` can be elided if the path is `Self::on_add`, `Self::on_insert` etc.
-#[proc_macro_derive(Resource, attributes(component))]
+#[proc_macro_derive(Resource, attributes(component, require))]
 pub fn derive_resource(input: TokenStream) -> TokenStream {
     let mut ast = parse_macro_input!(input as DeriveInput);
     TokenStream::from(resource::derive_resource(&mut ast))

--- a/crates/bevy_ecs/src/resource.rs
+++ b/crates/bevy_ecs/src/resource.rs
@@ -226,6 +226,7 @@ mod tests {
         world::{DeferredWorld, World},
     };
     use alloc::vec::Vec;
+    use bevy_ecs_macros::Component;
     use bevy_platform::prelude::String;
 
     #[test]
@@ -349,5 +350,26 @@ mod tests {
 
         assert!(ON_ADD_CALLED.load(Relaxed));
         assert!(world.get_resource::<TestResource>().is_some());
+    }
+
+    #[test]
+    fn derive_resource_require_features() {
+        #[derive(Component, Default)]
+        struct RequiredComponent;
+
+        #[derive(Resource)]
+        #[require(RequiredComponent)]
+        struct TestResource;
+
+        let mut world = World::new();
+        world.insert_resource(TestResource);
+
+        assert_eq!(
+            world
+                .query::<(&TestResource, &RequiredComponent)>()
+                .iter(&world)
+                .count(),
+            1
+        );
     }
 }


### PR DESCRIPTION
# Objective

Resources are now components, which means that they should be capable of requiring other components. But this ability is not accessible in the derive macro.

## Solution

Expose the `require` attribute in the `Resource` derive.

## Testing

- Did you test these changes? If so, how?
  ```bash
  $ cargo test -p ci
  ```

- Are there any parts that need more testing?

  I'm not very familiar with the ecs internals, so additional eyes would be appreciated!