### PR TITLE
`FixedNode`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3985,6 +3985,17 @@ category = "UI (User Interface)"
 wasm = true
 
 [[example]]
+name = "fixed_node"
+path = "examples/ui/layout/fixed_node.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.fixed_node]
+name = "Fixed Node"
+description = "Demonstrates how to use FixedNode to lay out a UI node as a root node"
+category = "UI (User Interface)"
+wasm = true
+
+[[example]]
 name = "text_wrap_debug"
 path = "examples/ui/text/text_wrap_debug.rs"
 doc-scrape-examples = true

--- a/_release-content/release-notes/fixed_node.md
+++ b/_release-content/release-notes/fixed_node.md
@@ -7,3 +7,5 @@ pull_requests: [24323]
 `FixedNode` is a new marker component for Bevy UI.
 
 A UI node entity with the `FixedNode` component is positioned relative to the window rather than its parent element.
+
+In the Taffy layout there is nothing to distinguish `FixedNode`s and root nodes, so they are treated identically during updates.

--- a/_release-content/release-notes/fixed_node.md
+++ b/_release-content/release-notes/fixed_node.md
@@ -6,6 +6,6 @@ pull_requests: [24323]
 
 `FixedNode` is a new marker component for Bevy UI.
 
-A UI node entity with the `FixedNode` component is positioned relative to the window rather than its parent element.
+A UI node entity with the `FixedNode` component is positioned relative to the target camera's viewport rather than its parent element. `FixedNode`s don't inherit their parent's layout or transform context.
 
 In the Taffy layout (stored in `UiSurface`) there is nothing to distinguish `FixedNode`s and root nodes, so they are treated identically during updates.

--- a/_release-content/release-notes/fixed_node.md
+++ b/_release-content/release-notes/fixed_node.md
@@ -8,4 +8,4 @@ pull_requests: [24323]
 
 A UI node entity with the `FixedNode` component is positioned relative to the window rather than its parent element.
 
-In the Taffy layout there is nothing to distinguish `FixedNode`s and root nodes, so they are treated identically during updates.
+In the Taffy layout (stored in `UiSurface`) there is nothing to distinguish `FixedNode`s and root nodes, so they are treated identically during updates.

--- a/_release-content/release-notes/fixed_node.md
+++ b/_release-content/release-notes/fixed_node.md
@@ -6,6 +6,6 @@ pull_requests: [24323]
 
 `FixedNode` is a new marker component for Bevy UI.
 
-A UI node entity with the `FixedNode` component is positioned relative to the target camera's viewport rather than its parent element. `FixedNode`s don't inherit their parent's layout or transform context.
+A UI node entity with the `FixedNode` component is positioned relative to the target camera's viewport rather than its parent element. `FixedNode`s don't inherit their parent's layout, clipping or transform context.
 
 In the Taffy layout (stored in `UiSurface`) there is nothing to distinguish `FixedNode`s and root nodes, so they are treated identically during updates.

--- a/_release-content/release-notes/fixed_node.md
+++ b/_release-content/release-notes/fixed_node.md
@@ -1,0 +1,9 @@
+---
+title: "FixedNode"
+authors: ["@Ickshonpe"]
+pull_requests: [24323]
+---
+
+`FixedNode` is a new marker component for Bevy UI.
+
+A UI node entity with the `FixedNode` component is positioned relative to the window rather than its parent element.

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -1564,7 +1564,7 @@ mod tests {
         assert!(ui_surface.is_root(b));
         assert_eq!(ui_surface.child_count(a).unwrap(), 0);
 
-        world.entity_mut(b).add_child(a);
+        world.entity_mut(b).remove::<ChildOf>().add_child(a);
 
         app.update();
         let world = app.world_mut();

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -3,8 +3,8 @@ use crate::experimental::GhostNode;
 use crate::{
     experimental::{UiChildren, UiRootNodes},
     ui_transform::{UiGlobalTransform, UiTransform},
-    ComputedNode, ComputedUiRenderTargetInfo, ContentSize, Display, IgnoreScroll, LayoutConfig,
-    Node, Outline, OverflowAxis, ScrollPosition,
+    ComputedNode, ComputedUiRenderTargetInfo, ContentSize, Display, FixedNode, IgnoreScroll,
+    LayoutConfig, Node, Outline, OverflowAxis, ScrollPosition,
 };
 #[cfg(feature = "ghost_nodes")]
 use bevy_ecs::query::With;
@@ -13,7 +13,7 @@ use bevy_ecs::{
     entity::Entity,
     hierarchy::Children,
     lifecycle::RemovedComponents,
-    query::Added,
+    query::{Added, Has, With},
     system::{Query, ResMut},
     world::Ref,
 };
@@ -77,6 +77,7 @@ pub enum LayoutError {
 pub fn ui_layout_system(
     mut ui_surface: ResMut<UiSurface>,
     ui_root_node_query: UiRootNodes,
+    fixed_nodes_query: Query<Entity, With<FixedNode>>,
     ui_children: UiChildren,
     mut node_query: Query<(
         Entity,
@@ -94,6 +95,7 @@ pub fn ui_layout_system(
         Option<&Outline>,
         Option<&ScrollPosition>,
         Option<&IgnoreScroll>,
+        Has<FixedNode>,
     )>,
     mut buffer_query: Query<&mut ComputedTextBlock>,
     mut font_system: ResMut<FontCx>,
@@ -158,7 +160,7 @@ pub fn ui_layout_system(
             .filter(|entity| !node_query.contains(*entity)),
     );
 
-    for ui_root_entity in ui_root_node_query.iter() {
+    for ui_root_entity in ui_root_node_query.iter().chain(fixed_nodes_query.iter()) {
         fn update_children_recursively(
             ui_surface: &mut UiSurface,
             ui_children: &UiChildren,
@@ -202,6 +204,7 @@ pub fn ui_layout_system(
 
         update_uinode_geometry_recursive(
             ui_root_entity,
+            ui_root_entity,
             &mut ui_surface,
             true,
             computed_target.physical_size().as_vec2(),
@@ -216,6 +219,7 @@ pub fn ui_layout_system(
 
     // Returns the combined bounding box of the node and any of its overflowing children.
     fn update_uinode_geometry_recursive(
+        root: Entity,
         entity: Entity,
         ui_surface: &mut UiSurface,
         inherited_use_rounding: bool,
@@ -230,6 +234,7 @@ pub fn ui_layout_system(
             Option<&Outline>,
             Option<&ScrollPosition>,
             Option<&IgnoreScroll>,
+            Has<FixedNode>,
         )>,
         ui_children: &UiChildren,
         inverse_target_scale_factor: f32,
@@ -245,8 +250,13 @@ pub fn ui_layout_system(
             maybe_outline,
             maybe_scroll_position,
             maybe_scroll_sticky,
+            is_fixed_node,
         )) = node_update_query.get_mut(entity)
         {
+            if is_fixed_node && root != entity {
+                return;
+            }
+
             let use_rounding = maybe_layout_config
                 .map(|layout_config| layout_config.use_rounding)
                 .unwrap_or(inherited_use_rounding);
@@ -370,6 +380,7 @@ pub fn ui_layout_system(
 
             for child_uinode in ui_children.iter_ui_children(entity) {
                 update_uinode_geometry_recursive(
+                    root,
                     child_uinode,
                     ui_surface,
                     use_rounding,

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -1792,7 +1792,7 @@ mod tests {
         }
 
         #[test]
-        fn ghosts_and_fixed_nodes_attach_and_detatch() {
+        fn ghosts_and_fixed_nodes_attach_and_detach() {
             let mut app = setup_ui_test_app();
             let world = app.world_mut();
 

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -11,7 +11,7 @@ use bevy_ecs::query::With;
 use bevy_ecs::{
     change_detection::{DetectChanges, DetectChangesMut},
     entity::Entity,
-    hierarchy::Children,
+    hierarchy::{ChildOf, Children},
     lifecycle::RemovedComponents,
     query::{Added, Has, With},
     system::{Query, ResMut},
@@ -77,7 +77,7 @@ pub enum LayoutError {
 pub fn ui_layout_system(
     mut ui_surface: ResMut<UiSurface>,
     ui_root_node_query: UiRootNodes,
-    fixed_nodes_query: Query<Entity, With<FixedNode>>,
+    fixed_nodes_query: Query<Entity, (With<FixedNode>, With<ChildOf>)>,
     ui_children: UiChildren,
     mut node_query: Query<(
         Entity,
@@ -165,7 +165,7 @@ pub fn ui_layout_system(
             ui_surface: &mut UiSurface,
             ui_children: &UiChildren,
             added_node_query: &Query<(), Added<Node>>,
-            fixed_nodes_query: &Query<Entity, With<FixedNode>>,
+            fixed_nodes_query: &Query<Entity, (With<FixedNode>, With<ChildOf>)>,
             entity: Entity,
         ) {
             let children_changed = ui_children.is_changed(entity)

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -1790,5 +1790,89 @@ mod tests {
             assert!(compare_taffy_parent(ui_surface, child, None));
             assert!(!ui_surface.root_entity_to_viewport_node.contains_key(&child));
         }
+
+        #[test]
+        fn fixed_ghost() {
+            let mut app = setup_ui_test_app();
+            let world = app.world_mut();
+
+            let fixed = world.spawn((Node::default(), FixedNode)).id();
+            let ghost1 = world.spawn(GhostNode).add_child(fixed).id();
+
+            app.update();
+            let world = app.world_mut();
+
+            let ui_surface = world.resource::<UiSurface>();
+            assert!(ui_surface.is_root(fixed));
+            assert_eq!(ui_surface.total_count(), 2);
+
+            world.spawn(GhostNode).add_child(ghost1);
+
+            app.update();
+            let world = app.world_mut();
+
+            let ui_surface = world.resource::<UiSurface>();
+            assert!(ui_surface.is_root(fixed));
+            assert_eq!(ui_surface.total_count(), 2);
+
+            let fixed2 = world.spawn((Node::default(), FixedNode)).id();
+            let ghost3 = world.spawn(GhostNode).add_child(fixed2).id();
+
+            app.update();
+            let world = app.world_mut();
+
+            let ui_surface = world.resource::<UiSurface>();
+            assert!(ui_surface.is_root(fixed));
+            assert!(ui_surface.is_root(fixed2));
+            assert_eq!(ui_surface.total_count(), 4);
+
+            world.entity_mut(ghost1).detach_all_children();
+            world.entity_mut(ghost3).detach_all_children();
+
+            app.update();
+            let world = app.world_mut();
+
+            let ui_surface = world.resource::<UiSurface>();
+            assert!(ui_surface.is_root(fixed));
+            assert!(ui_surface.is_root(fixed2));
+            assert_eq!(ui_surface.total_count(), 4);
+        }
+
+        #[test]
+        fn fixed_ghost_child_is_a_root_node() {
+            let mut app = setup_ui_test_app();
+            let world = app.world_mut();
+
+            let fixed = world.spawn((Node::default(), FixedNode)).id();
+            let child = world.spawn(Node::default()).id();
+            let ghost = world.spawn(GhostNode).add_children(&[fixed, child]).id();
+            let root = world.spawn(Node::default()).add_child(ghost).id();
+
+            app.update();
+            let world = app.world_mut();
+
+            let ui_surface = world.resource::<UiSurface>();
+            let fixed_node = ui_surface.entity_to_taffy.get(&fixed).unwrap();
+            let child_node = ui_surface.entity_to_taffy.get(&child).unwrap();
+            let root_node = ui_surface.entity_to_taffy.get(&root).unwrap();
+            let fixed_viewport_node = ui_surface.root_entity_to_viewport_node.get(&fixed).copied();
+            let root_viewport_node = ui_surface.root_entity_to_viewport_node.get(&root).copied();
+
+            assert_eq!(ui_surface.root_count(), 2);
+            assert_eq!(ui_surface.total_count(), 5);
+            assert_eq!(fixed_node.viewport_id, fixed_viewport_node);
+            assert_eq!(root_node.viewport_id, root_viewport_node);
+            assert_eq!(ui_surface.parent(fixed), fixed_viewport_node);
+            assert_eq!(ui_surface.parent(child), Some(root_node.id));
+            assert_eq!(ui_surface.child_count(fixed).unwrap(), 0);
+            assert_eq!(ui_surface.child_count(root).unwrap(), 1);
+            assert_eq!(
+                ui_surface
+                    .taffy
+                    .children(ui_surface.entity_to_taffy[&root].id)
+                    .unwrap(),
+                &[child_node.id]
+            );
+        }
     }
 }

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -6,11 +6,9 @@ use crate::{
     ComputedNode, ComputedUiRenderTargetInfo, ContentSize, Display, FixedNode, IgnoreScroll,
     LayoutConfig, Node, Outline, OverflowAxis, ScrollPosition,
 };
-#[cfg(feature = "ghost_nodes")]
-use bevy_ecs::query::With;
 use bevy_ecs::{
     change_detection::{DetectChanges, DetectChangesMut},
-    entity::Entity,
+    entity::{Entity, EntityHashSet},
     hierarchy::{ChildOf, Children},
     lifecycle::RemovedComponents,
     query::{Added, Has, With},
@@ -20,7 +18,6 @@ use bevy_ecs::{
 
 use bevy_math::{Affine2, Vec2};
 use bevy_sprite::BorderRect;
-use thiserror::Error;
 use ui_surface::UiSurface;
 
 use bevy_text::ComputedTextBlock;
@@ -65,14 +62,6 @@ impl Default for LayoutContext {
     }
 }
 
-#[derive(Debug, Error)]
-pub enum LayoutError {
-    #[error("Invalid hierarchy")]
-    InvalidHierarchy,
-    #[error("Taffy error: {0}")]
-    TaffyError(taffy::tree::TaffyError),
-}
-
 /// Updates the UI's layout tree, computes the new layout geometry and then updates the sizes and transforms of all the UI nodes.
 pub fn ui_layout_system(
     mut ui_surface: ResMut<UiSurface>,
@@ -86,6 +75,7 @@ pub fn ui_layout_system(
         Ref<ComputedUiRenderTargetInfo>,
     )>,
     added_node_query: Query<(), Added<Node>>,
+    added_fixed_node_query: Query<Entity, Added<FixedNode>>,
     mut node_update_query: Query<(
         &mut ComputedNode,
         &UiTransform,
@@ -101,6 +91,7 @@ pub fn ui_layout_system(
     mut font_system: ResMut<FontCx>,
     mut removed_children: RemovedComponents<Children>,
     mut removed_nodes: RemovedComponents<Node>,
+    mut removed_fixed_nodes: RemovedComponents<FixedNode>,
     #[cfg(feature = "ghost_nodes")] mut removed_ghost_nodes: RemovedComponents<GhostNode>,
     #[cfg(feature = "ghost_nodes")] added_ghost_node_query: Query<Entity, Added<GhostNode>>,
     #[cfg(feature = "ghost_nodes")] ghost_node_query: Query<(), With<GhostNode>>,
@@ -160,18 +151,24 @@ pub fn ui_layout_system(
             .filter(|entity| !node_query.contains(*entity)),
     );
 
+    let fixed_node_changes = added_fixed_node_query
+        .iter()
+        .chain(removed_fixed_nodes.read())
+        .collect::<EntityHashSet>();
+
     for ui_root_entity in ui_root_node_query.iter().chain(fixed_nodes_query.iter()) {
         fn update_children_recursively(
             ui_surface: &mut UiSurface,
             ui_children: &UiChildren,
             added_node_query: &Query<(), Added<Node>>,
             fixed_nodes_query: &Query<Entity, (With<FixedNode>, With<ChildOf>)>,
+            fixed_node_changes: &EntityHashSet,
             entity: Entity,
         ) {
             let children_changed = ui_children.is_changed(entity)
-                || ui_children
-                    .iter_ui_children(entity)
-                    .any(|child| added_node_query.contains(child));
+                || ui_children.iter_ui_children(entity).any(|child| {
+                    added_node_query.contains(child) || fixed_node_changes.contains(&child)
+                });
             #[cfg(feature = "ghost_nodes")]
             let children_changed =
                 children_changed || ui_surface.dirty_ghost_children_scratch.contains(&entity);
@@ -196,6 +193,7 @@ pub fn ui_layout_system(
                     ui_children,
                     added_node_query,
                     fixed_nodes_query,
+                    fixed_node_changes,
                     child,
                 );
             }
@@ -206,6 +204,7 @@ pub fn ui_layout_system(
             &ui_children,
             &added_node_query,
             &fixed_nodes_query,
+            &fixed_node_changes,
             ui_root_entity,
         );
 
@@ -428,8 +427,6 @@ mod tests {
     use bevy_transform::systems::{propagate_parent_transforms, sync_simple_transforms};
     use bevy_utils::prelude::default;
 
-    use taffy::TraversePartialTree;
-
     // these window dimensions are easy to convert to and from percentage values
     const TARGET_WIDTH: u32 = 1000;
     const TARGET_HEIGHT: u32 = 100;
@@ -591,7 +588,7 @@ mod tests {
         let ui_surface = world.resource::<UiSurface>();
 
         // `ui_node` is removed, attempting to retrieve a style for `ui_node` panics
-        let _ = ui_surface.taffy.style(ui_node.id);
+        let _ = ui_surface.taffy().style(ui_node.id);
     }
 
     #[test]
@@ -609,7 +606,7 @@ mod tests {
         let ui_parent_node = ui_surface.entity_to_taffy[&ui_parent_entity];
 
         // `ui_parent_node` shouldn't have any children yet
-        assert_eq!(ui_surface.taffy.child_count(ui_parent_node.id), 0);
+        assert_eq!(ui_surface.child_count(ui_parent_entity).unwrap(), 0);
 
         let mut ui_child_entities = (0..10)
             .map(|_| {
@@ -629,7 +626,7 @@ mod tests {
             1 + ui_child_entities.len()
         );
         assert_eq!(
-            ui_surface.taffy.child_count(ui_parent_node.id),
+            ui_surface.child_count(ui_parent_entity).unwrap(),
             ui_child_entities.len()
         );
 
@@ -641,7 +638,7 @@ mod tests {
 
         // the children should have a corresponding ui node and that ui node's parent should be `ui_parent_node`
         for node in child_node_map.values() {
-            assert_eq!(ui_surface.taffy.parent(node.id), Some(ui_parent_node.id));
+            assert_eq!(node.id, ui_parent_node.id);
         }
 
         // delete every second child
@@ -661,7 +658,7 @@ mod tests {
             1 + ui_child_entities.len()
         );
         assert_eq!(
-            ui_surface.taffy.child_count(ui_parent_node.id),
+            ui_surface.child_count(ui_parent_entity).unwrap(),
             ui_child_entities.len()
         );
 
@@ -669,10 +666,7 @@ mod tests {
         for child_entity in &ui_child_entities {
             let child_node = child_node_map[child_entity];
             assert_eq!(ui_surface.entity_to_taffy[child_entity], child_node);
-            assert_eq!(
-                ui_surface.taffy.parent(child_node.id),
-                Some(ui_parent_node.id)
-            );
+            assert_eq!(ui_surface.parent(*child_entity), Some(ui_parent_node.id));
             assert!(ui_surface
                 .taffy
                 .children(ui_parent_node.id)
@@ -757,10 +751,9 @@ mod tests {
         let world = app.world_mut();
 
         let ui_surface = world.resource_mut::<UiSurface>();
-        let taffy_root = ui_surface.entity_to_taffy[&root_node];
 
         // There should be one child of the root node after fixing it
-        assert_eq!(ui_surface.taffy.child_count(taffy_root.id), 1);
+        assert_eq!(ui_surface.child_count(root_node).unwrap(), 1);
     }
 
     #[test]
@@ -784,8 +777,7 @@ mod tests {
 
         let ui_surface = world.resource::<UiSurface>();
         for (entity, n) in [(a, 2), (b, 0), (c, 1), (d, 0)] {
-            let taffy_id = ui_surface.entity_to_taffy[&entity].id;
-            assert_eq!(ui_surface.taffy.child_count(taffy_id), n);
+            assert_eq!(ui_surface.child_count(entity).unwrap(), n);
         }
     }
 
@@ -1407,6 +1399,276 @@ mod tests {
             .resource_mut::<UiSurface>()
             .root_entity_to_viewport_node
             .contains_key(&ui_root_entity_1));
+    }
+
+    #[test]
+    fn fixed_root_is_a_root_node() {
+        let mut app = setup_ui_test_app();
+        let world = app.world_mut();
+        let fixed_entity = world.spawn((Node::default(), FixedNode)).id();
+
+        app.update();
+
+        let world = app.world_mut();
+        let ui_surface = world.resource::<UiSurface>();
+        let fixed_node = ui_surface.entity_to_taffy.get(&fixed_entity).unwrap();
+        let viewport_node = ui_surface
+            .root_entity_to_viewport_node
+            .get(&fixed_entity)
+            .copied();
+
+        assert_eq!(fixed_node.viewport_id, viewport_node);
+        assert_eq!(ui_surface.taffy.parent(fixed_node.id), viewport_node);
+    }
+
+    #[test]
+    fn fixed_child_is_a_root_node() {
+        let mut app = setup_ui_test_app();
+        let world = app.world_mut();
+        let parent_entity = world.spawn(Node::default()).id();
+        let fixed_entity = world
+            .spawn((Node::default(), FixedNode, ChildOf(parent_entity)))
+            .id();
+
+        app.update();
+
+        let world = app.world_mut();
+        let ui_surface = world.resource::<UiSurface>();
+
+        let parent_node = ui_surface.entity_to_taffy.get(&parent_entity).unwrap();
+        let fixed_node = ui_surface.entity_to_taffy.get(&fixed_entity).unwrap();
+        let parent_viewport_node = ui_surface
+            .root_entity_to_viewport_node
+            .get(&parent_entity)
+            .copied();
+        let fixed_viewport_node = ui_surface
+            .root_entity_to_viewport_node
+            .get(&fixed_entity)
+            .copied();
+
+        assert_eq!(parent_node.viewport_id, parent_viewport_node);
+        assert_eq!(ui_surface.parent(parent_entity), parent_viewport_node);
+        assert_eq!(fixed_node.viewport_id, fixed_viewport_node);
+        assert_eq!(ui_surface.parent(fixed_entity), fixed_viewport_node);
+        assert_eq!(ui_surface.child_count(parent_entity).unwrap(), 0);
+    }
+
+    #[test]
+    fn fixed_node_reparenting() {
+        let mut app = setup_ui_test_app();
+        let world = app.world_mut();
+
+        let fixed = world.spawn((Node::default(), FixedNode)).id();
+        let root_1 = world.spawn(Node::default()).id();
+        let root_2 = world.spawn(Node::default()).id();
+
+        app.update();
+        let world = app.world_mut();
+        let ui_surface = world.resource::<UiSurface>();
+
+        assert_eq!(ui_surface.count(), 6);
+        assert_eq!(ui_surface.root_count(), 3);
+
+        assert_eq!(ui_surface.child_count(fixed).unwrap(), 0);
+        assert_eq!(ui_surface.child_count(root_1).unwrap(), 0);
+        assert_eq!(ui_surface.child_count(root_2).unwrap(), 0);
+
+        assert_eq!(
+            ui_surface.parent(fixed),
+            ui_surface.get(fixed).unwrap().viewport_id
+        );
+
+        world.entity_mut(root_1).add_child(fixed);
+
+        app.update();
+
+        let world = app.world_mut();
+        let ui_surface = world.resource::<UiSurface>();
+
+        assert_eq!(ui_surface.child_count(fixed).unwrap(), 0);
+        assert_eq!(ui_surface.child_count(root_1).unwrap(), 0);
+        assert_eq!(ui_surface.child_count(root_2).unwrap(), 0);
+
+        assert_eq!(ui_surface.count(), 6);
+        assert_eq!(ui_surface.root_count(), 3);
+
+        world.entity_mut(root_2).add_child(fixed);
+
+        app.update();
+
+        let world = app.world_mut();
+        let ui_surface = world.resource::<UiSurface>();
+
+        assert_eq!(ui_surface.child_count(fixed).unwrap(), 0);
+        assert_eq!(ui_surface.child_count(root_1).unwrap(), 0);
+        assert_eq!(ui_surface.child_count(root_2).unwrap(), 0);
+
+        assert_eq!(ui_surface.count(), 6);
+        assert_eq!(ui_surface.root_count(), 3);
+
+        world.entity_mut(fixed).remove::<FixedNode>();
+
+        app.update();
+
+        let world = app.world_mut();
+        let ui_surface = world.resource::<UiSurface>();
+
+        assert_eq!(ui_surface.child_count(fixed).unwrap(), 0);
+        assert_eq!(ui_surface.child_count(root_1).unwrap(), 0);
+        assert_eq!(ui_surface.child_count(root_2).unwrap(), 1);
+
+        assert_eq!(ui_surface.count(), 5);
+        assert_eq!(ui_surface.root_count(), 2);
+
+        world.entity_mut(root_2).remove::<Children>();
+        let world = app.world_mut();
+        let ui_surface = world.resource::<UiSurface>();
+        assert_eq!(ui_surface.child_count(fixed).unwrap(), 0);
+        assert_eq!(ui_surface.child_count(root_1).unwrap(), 0);
+        assert_eq!(ui_surface.child_count(root_2).unwrap(), 0);
+
+        assert_eq!(ui_surface.count(), 6);
+        assert_eq!(ui_surface.root_count(), 3);
+    }
+
+    #[test]
+    fn swap_fixed_nodes() {
+        let mut app = setup_ui_test_app();
+        let world = app.world_mut();
+
+        let a = world.spawn(Node::default()).id();
+        let b = world.spawn((Node::default(), ChildOf(a))).id();
+
+        app.update();
+        let world = app.world_mut();
+        let ui_surface = world.resource::<UiSurface>();
+
+        assert!(ui_surface.is_root(a));
+        assert!(!ui_surface.is_root(b));
+        assert_eq!(ui_surface.parent(b).unwrap(), ui_surface.get(a).unwrap().id);
+        assert_eq!(ui_surface.child_count(a).unwrap(), 0);
+        assert_eq!(ui_surface.child_count(b).unwrap(), 1);
+        assert_eq!(ui_surface.total_count(), 3);
+
+        world.entity_mut(a).insert(FixedNode);
+
+        app.update();
+        let world = app.world_mut();
+        let ui_surface = world.resource::<UiSurface>();
+
+        assert!(ui_surface.is_root(a));
+        assert!(!ui_surface.is_root(b));
+        assert_eq!(ui_surface.parent(b).unwrap(), ui_surface.get(a).unwrap().id);
+
+        world.entity_mut(b).insert(FixedNode);
+
+        app.update();
+        let world = app.world_mut();
+        let ui_surface = world.resource::<UiSurface>();
+
+        assert!(ui_surface.is_root(a));
+        assert!(ui_surface.is_root(b));
+        assert_eq!(ui_surface.child_count(a).unwrap(), 0);
+
+        world.entity_mut(b).add_child(a);
+
+        app.update();
+        let world = app.world_mut();
+        let ui_surface = world.resource::<UiSurface>();
+
+        assert!(ui_surface.is_root(a));
+        assert!(ui_surface.is_root(b));
+        assert_eq!(ui_surface.child_count(a).unwrap(), 0);
+        assert_eq!(ui_surface.child_count(b).unwrap(), 0);
+        assert_eq!(ui_surface.total_count(), 4);
+
+        world.entity_mut(b).remove::<FixedNode>();
+
+        app.update();
+        let world = app.world_mut();
+        let ui_surface = world.resource::<UiSurface>();
+
+        assert!(ui_surface.is_root(a));
+        assert!(ui_surface.is_root(b));
+        assert_eq!(ui_surface.child_count(a).unwrap(), 0);
+        assert_eq!(ui_surface.child_count(b).unwrap(), 0);
+        assert_eq!(ui_surface.total_count(), 4);
+
+        world.entity_mut(a).remove::<FixedNode>();
+
+        app.update();
+        let world = app.world_mut();
+        let ui_surface = world.resource::<UiSurface>();
+
+        assert!(!ui_surface.is_root(a));
+        assert!(ui_surface.is_root(b));
+        assert_eq!(ui_surface.child_count(a).unwrap(), 0);
+        assert_eq!(ui_surface.child_count(b).unwrap(), 1);
+        assert_eq!(ui_surface.total_count(), 3);
+    }
+
+    #[test]
+    fn fixed_node_children() {
+        let mut app = setup_ui_test_app();
+        let world = app.world_mut();
+
+        let a = world.spawn(Node::default()).id();
+        let b = world.spawn(Node::default()).id();
+        let c = world.spawn(Node::default()).id();
+        let p = world.spawn(Node::default()).add_children(&[a, b, c]).id();
+
+        app.update();
+        let world = app.world_mut();
+        let ui_surface = world.resource::<UiSurface>();
+
+        assert!(ui_surface.is_root(p));
+        assert_eq!(ui_surface.root_count(), 1);
+        assert_eq!(ui_surface.total_count(), 5);
+
+        world.entity_mut(a).insert(FixedNode);
+
+        app.update();
+        let world = app.world_mut();
+        let ui_surface = world.resource::<UiSurface>();
+
+        assert!(ui_surface.is_root(p));
+        assert!(ui_surface.is_root(a));
+        assert_eq!(ui_surface.root_count(), 2);
+        assert_eq!(ui_surface.total_count(), 6);
+        assert_eq!(ui_surface.parent(a), None);
+        assert_eq!(ui_surface.parent(b), ui_surface.get(p).map(|n| n.id));
+        assert_eq!(ui_surface.parent(c), ui_surface.get(p).map(|n| n.id));
+        assert_eq!(ui_surface.root_count(), 2);
+
+        world.entity_mut(c).insert(FixedNode);
+        app.update();
+        let world = app.world_mut();
+        let ui_surface = world.resource::<UiSurface>();
+        assert!(ui_surface.is_root(p));
+        assert!(ui_surface.is_root(a));
+        assert!(ui_surface.is_root(b));
+        assert_eq!(ui_surface.root_count(), 3);
+        assert_eq!(ui_surface.total_count(), 7);
+        assert_eq!(ui_surface.parent(a), None);
+        assert_eq!(ui_surface.parent(b), ui_surface.get(p).map(|n| n.id));
+        assert_eq!(ui_surface.parent(c), None);
+
+        world.entity_mut(p).detach_all_children();
+        world.entity_mut(p).despawn();
+
+        app.update();
+        let world = app.world_mut();
+        let ui_surface = world.resource::<UiSurface>();
+
+        assert!(ui_surface.is_root(a));
+        assert!(ui_surface.is_root(b));
+        assert!(ui_surface.is_root(c));
+        assert_eq!(ui_surface.root_count(), 3);
+        assert_eq!(ui_surface.total_count(), 6);
+
+        assert_eq!(ui_surface.parent(a), None);
+        assert_eq!(ui_surface.parent(b), None);
+        assert_eq!(ui_surface.parent(c), None);
     }
 
     #[cfg(feature = "ghost_nodes")]

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -1479,7 +1479,6 @@ mod tests {
         world.entity_mut(root_1).add_child(fixed);
 
         app.update();
-
         let world = app.world_mut();
         let ui_surface = world.resource::<UiSurface>();
 
@@ -1492,7 +1491,6 @@ mod tests {
         world.entity_mut(root_2).add_child(fixed);
 
         app.update();
-
         let world = app.world_mut();
         let ui_surface = world.resource::<UiSurface>();
 
@@ -1505,7 +1503,6 @@ mod tests {
         world.entity_mut(fixed).remove::<FixedNode>();
 
         app.update();
-
         let world = app.world_mut();
         let ui_surface = world.resource::<UiSurface>();
 
@@ -1516,6 +1513,8 @@ mod tests {
         assert_eq!(ui_surface.root_count(), 2);
 
         world.entity_mut(root_2).remove::<Children>();
+
+        app.update();
         let world = app.world_mut();
         let ui_surface = world.resource::<UiSurface>();
 

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -1792,7 +1792,7 @@ mod tests {
         }
 
         #[test]
-        fn fixed_ghost() {
+        fn ghosts_and_fixed_nodes_attach_and_detatch() {
             let mut app = setup_ui_test_app();
             let world = app.world_mut();
 
@@ -1873,6 +1873,35 @@ mod tests {
                     .unwrap(),
                 &[child_node.id]
             );
+        }
+
+        #[test]
+        fn unghost_ghost_node_with_fixed_and_normal_children() {
+            let mut app = setup_ui_test_app();
+            let world = app.world_mut();
+
+            let fixed = world.spawn((Node::default(), FixedNode)).id();
+            let child = world.spawn(Node::default()).id();
+            let ghost = world.spawn(GhostNode).add_children(&[fixed, child]).id();
+
+            app.update();
+            let world = app.world_mut();
+            let ui_surface = world.resource::<UiSurface>();
+
+            assert!(ui_surface.is_root(fixed));
+            assert!(ui_surface.is_root(child));
+
+            world
+                .entity_mut(ghost)
+                .remove::<GhostNode>()
+                .insert(Node::default());
+
+            app.update();
+            let world = app.world_mut();
+            let ui_surface = world.resource::<UiSurface>();
+
+            assert!(ui_surface.is_root(fixed));
+            assert!(!ui_surface.is_root(child));
         }
     }
 }

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -165,6 +165,7 @@ pub fn ui_layout_system(
             ui_surface: &mut UiSurface,
             ui_children: &UiChildren,
             added_node_query: &Query<(), Added<Node>>,
+            fixed_nodes_query: &Query<Entity, With<FixedNode>>,
             entity: Entity,
         ) {
             let children_changed = ui_children.is_changed(entity)
@@ -178,11 +179,25 @@ pub fn ui_layout_system(
             if ui_surface.entity_to_taffy.contains_key(&entity)
                 && (added_node_query.contains(entity) || children_changed)
             {
-                ui_surface.update_children(entity, ui_children.iter_ui_children(entity));
+                ui_surface.update_children(
+                    entity,
+                    ui_children
+                        .iter_ui_children(entity)
+                        .filter(|entity| !fixed_nodes_query.contains(*entity)),
+                );
             }
 
             for child in ui_children.iter_ui_children(entity) {
-                update_children_recursively(ui_surface, ui_children, added_node_query, child);
+                if fixed_nodes_query.contains(child) {
+                    continue;
+                }
+                update_children_recursively(
+                    ui_surface,
+                    ui_children,
+                    added_node_query,
+                    fixed_nodes_query,
+                    child,
+                );
             }
         }
 
@@ -190,6 +205,7 @@ pub fn ui_layout_system(
             &mut ui_surface,
             &ui_children,
             &added_node_query,
+            &fixed_nodes_query,
             ui_root_entity,
         );
 

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -588,7 +588,7 @@ mod tests {
         let ui_surface = world.resource::<UiSurface>();
 
         // `ui_node` is removed, attempting to retrieve a style for `ui_node` panics
-        let _ = ui_surface.taffy().style(ui_node.id);
+        let _ = ui_surface.taffy.style(ui_node.id);
     }
 
     #[test]
@@ -638,7 +638,7 @@ mod tests {
 
         // the children should have a corresponding ui node and that ui node's parent should be `ui_parent_node`
         for node in child_node_map.values() {
-            assert_eq!(node.id, ui_parent_node.id);
+            assert_eq!(ui_surface.taffy.parent(node.id), Some(ui_parent_node.id));
         }
 
         // delete every second child
@@ -1466,13 +1466,11 @@ mod tests {
         let world = app.world_mut();
         let ui_surface = world.resource::<UiSurface>();
 
-        assert_eq!(ui_surface.count(), 6);
+        assert_eq!(ui_surface.total_count(), 6);
         assert_eq!(ui_surface.root_count(), 3);
-
         assert_eq!(ui_surface.child_count(fixed).unwrap(), 0);
         assert_eq!(ui_surface.child_count(root_1).unwrap(), 0);
         assert_eq!(ui_surface.child_count(root_2).unwrap(), 0);
-
         assert_eq!(
             ui_surface.parent(fixed),
             ui_surface.get(fixed).unwrap().viewport_id
@@ -1488,8 +1486,7 @@ mod tests {
         assert_eq!(ui_surface.child_count(fixed).unwrap(), 0);
         assert_eq!(ui_surface.child_count(root_1).unwrap(), 0);
         assert_eq!(ui_surface.child_count(root_2).unwrap(), 0);
-
-        assert_eq!(ui_surface.count(), 6);
+        assert_eq!(ui_surface.total_count(), 6);
         assert_eq!(ui_surface.root_count(), 3);
 
         world.entity_mut(root_2).add_child(fixed);
@@ -1502,8 +1499,7 @@ mod tests {
         assert_eq!(ui_surface.child_count(fixed).unwrap(), 0);
         assert_eq!(ui_surface.child_count(root_1).unwrap(), 0);
         assert_eq!(ui_surface.child_count(root_2).unwrap(), 0);
-
-        assert_eq!(ui_surface.count(), 6);
+        assert_eq!(ui_surface.total_count(), 6);
         assert_eq!(ui_surface.root_count(), 3);
 
         world.entity_mut(fixed).remove::<FixedNode>();
@@ -1516,18 +1512,17 @@ mod tests {
         assert_eq!(ui_surface.child_count(fixed).unwrap(), 0);
         assert_eq!(ui_surface.child_count(root_1).unwrap(), 0);
         assert_eq!(ui_surface.child_count(root_2).unwrap(), 1);
-
-        assert_eq!(ui_surface.count(), 5);
+        assert_eq!(ui_surface.total_count(), 5);
         assert_eq!(ui_surface.root_count(), 2);
 
         world.entity_mut(root_2).remove::<Children>();
         let world = app.world_mut();
         let ui_surface = world.resource::<UiSurface>();
+
         assert_eq!(ui_surface.child_count(fixed).unwrap(), 0);
         assert_eq!(ui_surface.child_count(root_1).unwrap(), 0);
         assert_eq!(ui_surface.child_count(root_2).unwrap(), 0);
-
-        assert_eq!(ui_surface.count(), 6);
+        assert_eq!(ui_surface.total_count(), 6);
         assert_eq!(ui_surface.root_count(), 3);
     }
 
@@ -1546,8 +1541,8 @@ mod tests {
         assert!(ui_surface.is_root(a));
         assert!(!ui_surface.is_root(b));
         assert_eq!(ui_surface.parent(b).unwrap(), ui_surface.get(a).unwrap().id);
-        assert_eq!(ui_surface.child_count(a).unwrap(), 0);
-        assert_eq!(ui_surface.child_count(b).unwrap(), 1);
+        assert_eq!(ui_surface.child_count(a).unwrap(), 1);
+        assert_eq!(ui_surface.child_count(b).unwrap(), 0);
         assert_eq!(ui_surface.total_count(), 3);
 
         world.entity_mut(a).insert(FixedNode);
@@ -1633,9 +1628,11 @@ mod tests {
 
         assert!(ui_surface.is_root(p));
         assert!(ui_surface.is_root(a));
+        assert!(!ui_surface.is_root(b));
+        assert!(!ui_surface.is_root(c));
         assert_eq!(ui_surface.root_count(), 2);
         assert_eq!(ui_surface.total_count(), 6);
-        assert_eq!(ui_surface.parent(a), None);
+        assert!(ui_surface.child_count(p).is_ok_and(|count| count == 2));
         assert_eq!(ui_surface.parent(b), ui_surface.get(p).map(|n| n.id));
         assert_eq!(ui_surface.parent(c), ui_surface.get(p).map(|n| n.id));
         assert_eq!(ui_surface.root_count(), 2);
@@ -1646,12 +1643,12 @@ mod tests {
         let ui_surface = world.resource::<UiSurface>();
         assert!(ui_surface.is_root(p));
         assert!(ui_surface.is_root(a));
-        assert!(ui_surface.is_root(b));
+        assert!(!ui_surface.is_root(b));
+        assert!(ui_surface.is_root(c));
         assert_eq!(ui_surface.root_count(), 3);
         assert_eq!(ui_surface.total_count(), 7);
-        assert_eq!(ui_surface.parent(a), None);
+        assert!(ui_surface.child_count(p).is_ok_and(|count| count == 1));
         assert_eq!(ui_surface.parent(b), ui_surface.get(p).map(|n| n.id));
-        assert_eq!(ui_surface.parent(c), None);
 
         world.entity_mut(p).detach_all_children();
         world.entity_mut(p).despawn();
@@ -1665,10 +1662,6 @@ mod tests {
         assert!(ui_surface.is_root(c));
         assert_eq!(ui_surface.root_count(), 3);
         assert_eq!(ui_surface.total_count(), 6);
-
-        assert_eq!(ui_surface.parent(a), None);
-        assert_eq!(ui_surface.parent(b), None);
-        assert_eq!(ui_surface.parent(c), None);
     }
 
     #[cfg(feature = "ghost_nodes")]

--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -333,7 +333,7 @@ impl UiSurface {
         Ok(self.taffy.child_count(node.id))
     }
 
-    /// Returns the number of nodes in the taffy tree, inclduding viewport nodes.
+    /// Returns the number of nodes in the taffy tree, including viewport nodes.
     pub fn total_count(&self) -> usize {
         self.taffy.total_node_count()
     }
@@ -374,7 +374,7 @@ impl UiSurface {
             })
     }
 
-    /// Returns the `NodeId` of the parenty of `Entity`, if any.
+    /// Returns the `NodeId` of the parent of `Entity`, if any.
     pub fn parent(&self, entity: Entity) -> Option<NodeId> {
         self.get(entity).and_then(|node| self.taffy.parent(node.id))
     }

--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -363,15 +363,11 @@ impl UiSurface {
         self.entity_to_taffy.get(&entity).copied()
     }
 
-    pub(super) fn taffy(&self) -> &UiTree<NodeMeasure> {
-        &self.taffy
-    }
-
     pub fn get_style(&self, entity: Entity) -> Result<&Style, UiSurfaceError> {
         self.get(entity)
             .ok_or(UiSurfaceError::NoAssociatedTaffyNode)
             .and_then(|node| {
-                self.taffy()
+                self.taffy
                     .style(node.id)
                     .map_err(UiSurfaceError::TaffyError)
             })

--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -363,6 +363,7 @@ impl UiSurface {
         self.entity_to_taffy.get(&entity).copied()
     }
 
+    /// Returns the Taffy `Style` for the given entity.
     pub fn get_style(&self, entity: Entity) -> Result<&Style, UiSurfaceError> {
         self.get(entity)
             .ok_or(UiSurfaceError::NoAssociatedTaffyNode)

--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -343,7 +343,7 @@ impl UiSurface {
         self.root_entity_to_viewport_node.len()
     }
 
-    /// Returns the number of taffy nodes with corresponding entites.
+    /// Returns the number of taffy nodes with an associated entity.
     pub fn count(&self) -> usize {
         self.entity_to_taffy.len()
     }

--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -1,8 +1,9 @@
+use bevy_platform::collections::hash_map::Entry;
 use core::fmt;
 use core::ops::{Deref, DerefMut};
-
-use bevy_platform::collections::hash_map::Entry;
-use taffy::TaffyTree;
+use taffy::NodeId;
+use taffy::{Style, TaffyTree, TraversePartialTree};
+use thiserror::Error;
 
 #[cfg(feature = "ghost_nodes")]
 use bevy_ecs::entity::EntityHashSet;
@@ -13,19 +14,26 @@ use bevy_ecs::{
 use bevy_math::{UVec2, Vec2};
 use bevy_utils::default;
 
-use crate::{layout::convert, LayoutContext, LayoutError, Measure, MeasureArgs, Node, NodeMeasure};
+use crate::{layout::convert, LayoutContext, Measure, MeasureArgs, Node, NodeMeasure};
 use bevy_text::FontCx;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct LayoutNode {
     // Implicit "viewport" node if this `LayoutNode` corresponds to a root UI node entity
-    pub(super) viewport_id: Option<taffy::NodeId>,
+    pub viewport_id: Option<NodeId>,
     // The id of the node in the taffy tree
-    pub(super) id: taffy::NodeId,
+    pub id: NodeId,
 }
 
-impl From<taffy::NodeId> for LayoutNode {
-    fn from(value: taffy::NodeId) -> Self {
+impl LayoutNode {
+    /// Returns true if this is a root node.
+    pub const fn is_root(&self) -> bool {
+        self.viewport_id.is_some()
+    }
+}
+
+impl From<NodeId> for LayoutNode {
+    fn from(value: NodeId) -> Self {
         LayoutNode {
             viewport_id: None,
             id: value,
@@ -58,17 +66,17 @@ impl<T> DerefMut for UiTree<T> {
 
 #[derive(Resource)]
 pub struct UiSurface {
-    pub root_entity_to_viewport_node: EntityHashMap<taffy::NodeId>,
+    pub root_entity_to_viewport_node: EntityHashMap<NodeId>,
     pub(super) entity_to_taffy: EntityHashMap<LayoutNode>,
     pub(super) taffy: UiTree<NodeMeasure>,
-    taffy_children_scratch: Vec<taffy::NodeId>,
+    taffy_children_scratch: Vec<NodeId>,
     #[cfg(feature = "ghost_nodes")]
     pub(super) dirty_ghost_children_scratch: EntityHashSet,
 }
 
 fn _assert_send_sync_ui_surface_impl_safe() {
     fn _assert_send_sync<T: Send + Sync>() {}
-    _assert_send_sync::<EntityHashMap<taffy::NodeId>>();
+    _assert_send_sync::<EntityHashMap<NodeId>>();
     _assert_send_sync::<UiTree<NodeMeasure>>();
     _assert_send_sync::<UiSurface>();
 }
@@ -181,7 +189,7 @@ impl UiSurface {
     }
 
     /// Gets or inserts an implicit taffy viewport node corresponding to the given UI root entity
-    pub fn get_or_insert_taffy_viewport_node(&mut self, ui_root_entity: Entity) -> taffy::NodeId {
+    pub fn get_or_insert_taffy_viewport_node(&mut self, ui_root_entity: Entity) -> NodeId {
         *self
             .root_entity_to_viewport_node
             .entry(ui_root_entity)
@@ -189,7 +197,7 @@ impl UiSurface {
                 let root_node = self.entity_to_taffy.get_mut(&ui_root_entity).unwrap();
                 let implicit_root = self
                     .taffy
-                    .new_leaf(taffy::style::Style {
+                    .new_leaf(Style {
                         display: taffy::style::Display::Grid,
                         // Note: Taffy percentages are floats ranging from 0.0 to 1.0.
                         // So this is setting width:100% and height:100%
@@ -229,9 +237,9 @@ impl UiSurface {
                 available_space,
                 |known_dimensions: taffy::Size<Option<f32>>,
                  available_space: taffy::Size<taffy::AvailableSpace>,
-                 _node_id: taffy::NodeId,
+                 _node_id: NodeId,
                  context: Option<&mut NodeMeasure>,
-                 style: &taffy::Style|
+                 style: &Style|
                  -> taffy::Size<f32> {
                     context
                         .map(|ctx| {
@@ -284,9 +292,9 @@ impl UiSurface {
         &mut self,
         entity: Entity,
         use_rounding: bool,
-    ) -> Result<(taffy::Layout, Vec2), LayoutError> {
+    ) -> Result<(taffy::Layout, Vec2), UiSurfaceError> {
         let Some(taffy_node) = self.entity_to_taffy.get(&entity) else {
-            return Err(LayoutError::InvalidHierarchy);
+            return Err(UiSurfaceError::NoAssociatedTaffyNode);
         };
 
         if use_rounding {
@@ -302,12 +310,85 @@ impl UiSurface {
                 let unrounded_size = Vec2::new(taffy_size.width, taffy_size.height);
                 Ok((layout, unrounded_size))
             }
-            Err(taffy_error) => Err(LayoutError::TaffyError(taffy_error)),
+            Err(taffy_error) => Err(UiSurfaceError::TaffyError(taffy_error)),
         };
 
         self.taffy.enable_rounding();
         out
     }
+
+    /// Returns the number of children belonging to the entity's associated taffy node.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UiSurfaceError::NoAssociatedTaffyNode`] if the entity does not have an associated taffy node.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the associated taffy node is not found in the layout tree.
+    pub fn child_count(&self, entity: Entity) -> Result<usize, UiSurfaceError> {
+        let node = self
+            .get(entity)
+            .ok_or(UiSurfaceError::NoAssociatedTaffyNode)?;
+        Ok(self.taffy.child_count(node.id))
+    }
+
+    /// Returns the number of nodes in the taffy tree, inclduding viewport nodes.
+    pub fn total_count(&self) -> usize {
+        self.taffy.total_node_count()
+    }
+
+    /// Returns the number of root taffy nodes.
+    pub fn root_count(&self) -> usize {
+        self.root_entity_to_viewport_node.len()
+    }
+
+    /// Returns the number of taffy nodes with corresponding entites.
+    pub fn count(&self) -> usize {
+        self.entity_to_taffy.len()
+    }
+
+    /// Returns true if the Entity has a corresponding taffy node.
+    pub fn is_node(&self, entity: Entity) -> bool {
+        self.entity_to_taffy.contains_key(&entity)
+    }
+
+    /// Returns true if the Entity is a root node in `UiSurface`.
+    pub fn is_root(&self, entity: Entity) -> bool {
+        self.root_entity_to_viewport_node.contains_key(&entity)
+    }
+
+    /// Returns the `LayoutNode` corresponding to the given Entity, if any.
+    pub fn get(&self, entity: Entity) -> Option<LayoutNode> {
+        self.entity_to_taffy.get(&entity).copied()
+    }
+
+    pub(super) fn taffy(&self) -> &UiTree<NodeMeasure> {
+        &self.taffy
+    }
+
+    pub fn get_style(&self, entity: Entity) -> Result<&Style, UiSurfaceError> {
+        self.get(entity)
+            .ok_or(UiSurfaceError::NoAssociatedTaffyNode)
+            .and_then(|node| {
+                self.taffy()
+                    .style(node.id)
+                    .map_err(UiSurfaceError::TaffyError)
+            })
+    }
+
+    /// Returns the `NodeId` of the parenty of `Entity`, if any.
+    pub fn parent(&self, entity: Entity) -> Option<NodeId> {
+        self.get(entity).and_then(|node| self.taffy.parent(node.id))
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum UiSurfaceError {
+    #[error("There is no taffy node associated with the given Entity.")]
+    NoAssociatedTaffyNode,
+    #[error("Taffy error: {0}")]
+    TaffyError(taffy::tree::TaffyError),
 }
 
 pub fn get_text_buffer<'a>(

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -3065,12 +3065,13 @@ impl ComputedUiRenderTargetInfo {
     }
 }
 
-/// Treats this UI node as a root node, even when it has a UI node parent.
+/// A UI entity with a `FixedNode` component is treated as a root node, even when it has a UI node parent.
+/// A `FixedNode` UI entity is positioned relative to the target camera's viewport rather that its parent element.
 ///
 /// `FixedNode`s don't inherit their parent's layout or transform context.
 /// They also ignore clipping inherited from ancestors through [`OverrideClip`].
 #[derive(Component, Clone, Default)]
-#[require(OverrideClip, Node)]
+#[require(Node, OverrideClip)]
 pub struct FixedNode;
 
 #[cfg(test)]

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -3065,6 +3065,10 @@ impl ComputedUiRenderTargetInfo {
     }
 }
 
+/// A fixed node is laid out like a root node even if not a root entity.
+#[derive(Component)]
+pub struct FixedNode;
+
 #[cfg(test)]
 mod tests {
     use crate::ComputedNode;

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -3066,6 +3066,7 @@ impl ComputedUiRenderTargetInfo {
 }
 
 /// A fixed node is laid out like a root node even if not a root entity.
+/// Marker component.
 #[derive(Component)]
 pub struct FixedNode;
 

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -3069,7 +3069,6 @@ impl ComputedUiRenderTargetInfo {
 /// A `FixedNode` UI entity is positioned relative to the target camera's viewport rather that its parent element.
 ///
 /// `FixedNode`s don't inherit their parent's layout, clipping or transform context.
-/// They also ignore clipping inherited from ancestors through [`OverrideClip`].
 #[derive(Component, Clone, Default)]
 #[require(Node, OverrideClip)]
 pub struct FixedNode;

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -3068,7 +3068,7 @@ impl ComputedUiRenderTargetInfo {
 /// A UI entity with a `FixedNode` component is treated as a root node, even when it has a UI node parent.
 /// A `FixedNode` UI entity is positioned relative to the target camera's viewport rather that its parent element.
 ///
-/// `FixedNode`s don't inherit their parent's layout or transform context.
+/// `FixedNode`s don't inherit their parent's layout, clipping or transform context.
 /// They also ignore clipping inherited from ancestors through [`OverrideClip`].
 #[derive(Component, Clone, Default)]
 #[require(Node, OverrideClip)]

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -3067,7 +3067,7 @@ impl ComputedUiRenderTargetInfo {
 
 /// Treats this UI node as a root node, even when it has a UI node parent.
 ///
-/// `FixedNode`s don't inherit their parent's layout context or transform.
+/// `FixedNode`s don't inherit their parent's layout or transform context.
 /// They also ignore clipping inherited from ancestors through [`OverrideClip`].
 #[derive(Component, Clone, Default)]
 #[require(OverrideClip, Node)]

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -3065,9 +3065,12 @@ impl ComputedUiRenderTargetInfo {
     }
 }
 
-/// A fixed node is laid out like a root node even if not a root entity.
-/// Marker component.
-#[derive(Component)]
+/// Treats this UI node as a root node, even when it has a UI node parent.
+///
+/// `FixedNode`s don't inherit their parent's layout context or transform.
+/// They also ignore clipping inherited from ancestors through [`OverrideClip`].
+#[derive(Component, Clone, Default)]
+#[require(OverrideClip, Node)]
 pub struct FixedNode;
 
 #[cfg(test)]

--- a/examples/README.md
+++ b/examples/README.md
@@ -601,6 +601,7 @@ Example | Description
 [Editable Text Filter](../examples/ui/text/editable_text_filter.rs) | Demonstrates an 8-character hex input using EditableTextFilter
 [Feathers Counter](../examples/ui/widgets/feathers_counter.rs) | Simple counter using feathers
 [Feathers Widgets](../examples/ui/widgets/feathers_gallery.rs) | Gallery of Feathers Widgets
+[Fixed Node](../examples/ui/layout/fixed_node.rs) | Demonstrates how to use FixedNode to lay out a UI node as a root node
 [Flex Layout](../examples/ui/layout/flex_layout.rs) | Demonstrates how the AlignItems and JustifyContent properties can be composed to layout nodes and position text
 [Font Atlas Debug](../examples/ui/text/font_atlas_debug.rs) | Illustrates how FontAtlases are populated (used to optimize text rendering internally)
 [Font Queries](../examples/ui/text/font_query.rs) | Demonstrates font querying

--- a/examples/ui/layout/fixed_node.rs
+++ b/examples/ui/layout/fixed_node.rs
@@ -1,4 +1,4 @@
-//! Demonstrates how to use FixedNode to lay out a UI node as a root node
+//! Demonstrates how to use `FixedNode` to lay out a UI node as a root node
 
 use bevy::color::palettes::css::BLUE;
 use bevy::color::palettes::css::RED;

--- a/examples/ui/layout/fixed_node.rs
+++ b/examples/ui/layout/fixed_node.rs
@@ -1,16 +1,13 @@
-//! Demonstrates Fixed Node component
+//! Demonstrates UI pointer event bubbling.
 
+use bevy::color::palettes::css::BLUE;
+use bevy::color::palettes::css::RED;
+use bevy::color::palettes::css::YELLOW;
 use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                title: "Bevy Fixed Node Example".to_string(),
-                ..Default::default()
-            }),
-            ..Default::default()
-        }))
+        .add_plugins(DefaultPlugins)
         .add_systems(Startup, setup)
         .run();
 }
@@ -18,5 +15,34 @@ fn main() {
 fn setup(mut commands: Commands) {
     commands.spawn(Camera2d);
 
-    commands.spawn((Node::default(), children![(Node::default(), FixedNode)]));
+    commands
+        .spawn((
+            Node {
+                width: percent(100),
+                height: percent(100),
+                align_items: AlignItems::Center,
+                justify_content: JustifyContent::Center,
+                ..default()
+            },
+            BackgroundColor(BLUE.into()),
+            Pickable::IGNORE,
+            children![(
+                Node {
+                    width: px(100),
+                    height: px(100),
+                    ..default()
+                },
+                BackgroundColor(YELLOW.into()),
+            )],
+        ))
+        .observe(
+            |over: On<Pointer<Over>>, mut colors: Query<&mut BackgroundColor>| {
+                colors.get_mut(over.entity).unwrap().0 = RED.into();
+            },
+        )
+        .observe(
+            |over: On<Pointer<Leave>>, mut colors: Query<&mut BackgroundColor>| {
+                colors.get_mut(over.entity).unwrap().0 = BLUE.into();
+            },
+        );
 }

--- a/examples/ui/layout/fixed_node.rs
+++ b/examples/ui/layout/fixed_node.rs
@@ -1,4 +1,4 @@
-//! Demonstrates UI pointer event bubbling.
+//! Demonstrates how to use FixedNode to lay out a UI node as a root node
 
 use bevy::color::palettes::css::BLUE;
 use bevy::color::palettes::css::RED;

--- a/examples/ui/layout/fixed_node.rs
+++ b/examples/ui/layout/fixed_node.rs
@@ -27,6 +27,7 @@ fn setup(mut commands: Commands) {
             BackgroundColor(BLUE.into()),
             Pickable::IGNORE,
             children![(
+                FixedNode,
                 Node {
                     width: px(100),
                     height: px(100),

--- a/examples/ui/layout/fixed_node.rs
+++ b/examples/ui/layout/fixed_node.rs
@@ -1,5 +1,7 @@
 //! Demonstrates Fixed Node component
 
+use bevy::prelude::*;
+
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(WindowPlugin {
@@ -16,5 +18,5 @@ fn main() {
 fn setup(mut commands: Commands) {
     commands.spawn(Camera2d);
 
-    comands.spawn((Node { ..default() }, children![(Node {}, FixedNode,)]));
+    commands.spawn((Node::default(), children![(Node::default(), FixedNode)]));
 }

--- a/examples/ui/layout/fixed_node.rs
+++ b/examples/ui/layout/fixed_node.rs
@@ -1,0 +1,20 @@
+//! Demonstrates Fixed Node component
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins.set(WindowPlugin {
+            primary_window: Some(Window {
+                title: "Bevy Fixed Node Example".to_string(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }))
+        .add_systems(Startup, setup)
+        .run();
+}
+
+fn setup(mut commands: Commands) {
+    commands.spawn(Camera2d);
+
+    comands.spawn((Node { ..default() }, children![(Node {}, FixedNode,)]));
+}


### PR DESCRIPTION
# Objective

Allow UI elements to be positioned relative to the viewport rather than their parent element.

Fixes #9564

## Solution

- New UI marker component `FixedNode`. Requires `Node` and `OverrideClip`.
- `FixedNode` entities are treated as UI roots in layout, even if they have a parent.
- `FixedNode`s don't inherit their parent's layout, clipping or transform context.
- During the taffy layout updates children with `FixedNode` are skipped.
- Added a couple of basic helper functions to `UiSurface`, mainly there to make the tests a little less painful.
- Added a fairly comprehensive range of new tests, including tests with `GhostNode`s.
- In the Taffy layout (stored in `UiSurface`) there is nothing to distinguish `FixedNode`s and root nodes, so they are treated identically during updates.

--

The original suggestion was to implement it as a `PositionType::Fixed` variant that could used with `Node`, but I think that would be much more complicated without support from Taffy. Being able to just directly query for and filter out `FixedNode` entities directly makes the implementation much simpler and more efficient.

## Testing

Basic example which shows events bubbling up to the parent from the fixed node:

```
cargo run --example fixed_node
```

There are also a number of new tests in the `layout` module.

```
cargo test -p bevy_ui --lib --features ghost_nodes
```