### PR TITLE
Add warning about `Frustum` when using `SpotLight`

### DIFF
--- a/crates/bevy_light/src/spot_light.rs
+++ b/crates/bevy_light/src/spot_light.rs
@@ -23,7 +23,7 @@ use crate::cluster::ClusterVisibilityClass;
 /// **Warning:**
 /// If this component is used on an entity that also has the [`Camera`](`bevy_camera::Camera`)
 /// component, the [`Frustum`](`bevy_camera::primitives::Frustum`) of the
-/// spotlight, will override the frustum of the camera, causing possible
+/// spotlight will override the frustum of the camera, causing possible
 /// rendering artifacts. To fix this, add either the spotlight or the camera
 /// component on a child entity instead.
 #[derive(Component, Debug, Clone, Copy, Reflect)]

--- a/crates/bevy_light/src/spot_light.rs
+++ b/crates/bevy_light/src/spot_light.rs
@@ -18,7 +18,14 @@ use crate::cluster::ClusterVisibilityClass;
 /// shines light only in a given direction. The direction is taken from
 /// the transform, and can be specified with [`Transform::looking_at`](Transform::looking_at).
 ///
-/// To control the resolution of the shadow maps, use the [`DirectionalLightShadowMap`](`crate::DirectionalLightShadowMap`)  resource.
+/// To control the resolution of the shadow maps, use the [`DirectionalLightShadowMap`](`crate::DirectionalLightShadowMap`) resource.
+///
+/// **Warning:**
+/// If this component is used on an entity that also has the [`Camera`](`bevy_camera::Camera`)
+/// component, the [`Frustum`](`bevy_camera::primitives::Frustum`) of the
+/// spotlight, will override the frustum of the camera, causing possible 
+/// rendering artifacts. To fix this, add either the spotlight or the camera
+/// component on a child entity instead.
 #[derive(Component, Debug, Clone, Copy, Reflect)]
 #[reflect(Component, Default, Debug, Clone)]
 #[require(Frustum, VisibleMeshEntities, Transform, Visibility, VisibilityClass)]

--- a/crates/bevy_light/src/spot_light.rs
+++ b/crates/bevy_light/src/spot_light.rs
@@ -23,7 +23,7 @@ use crate::cluster::ClusterVisibilityClass;
 /// **Warning:**
 /// If this component is used on an entity that also has the [`Camera`](`bevy_camera::Camera`)
 /// component, the [`Frustum`](`bevy_camera::primitives::Frustum`) of the
-/// spotlight, will override the frustum of the camera, causing possible 
+/// spotlight, will override the frustum of the camera, causing possible
 /// rendering artifacts. To fix this, add either the spotlight or the camera
 /// component on a child entity instead.
 #[derive(Component, Debug, Clone, Copy, Reflect)]


### PR DESCRIPTION
# Objective
When using the `SpotLight` component on an entity that already has the `Camera` component, the `Frustum` component of the camera will be overriden with the one create from the spotlight. This leads to incorrect frustum culling, if both components are on the same entity. There is no mention of this in the docs. This pr adds that.

I am not sure what the convention is when doing warnings in the docs. I just did \*\*bold\*\*, but I can change that.
 
## Solution
Change docs