### PR TITLE
Document reflection reference limitations

### DIFF
--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -457,6 +457,12 @@
 //! Rust requires fields to define a lifetime for referenced data,
 //! but [`Reflect`] requires all types to have a `'static` lifetime.
 //! This makes it impossible to reflect any type with non-static borrowed data.
+//! Reference support is therefore limited to specific `'static` reference types implemented by this
+//! crate, such as `&'static str` and `&'static Path`.
+//! Arbitrary reference fields like `&'a T`, `&'static T`, or `&'static mut T`
+//! do not automatically implement [`Reflect`] just because `T` does.
+//! If reflected data needs to refer to external values, prefer storing an owned value,
+//! an asset handle, or another stable identifier that can be resolved outside reflection.
 //!
 //! ## Generic Function Reflection
 //!


### PR DESCRIPTION
# Objective

Fixes #24151.

Document the current `bevy_reflect` limitation around reference fields so readers do not assume that arbitrary references can be reflected automatically.

## Solution

- Adds a short note to the crate-level "Non-Static Lifetimes" limitation.
- Calls out that reference support is limited to explicitly implemented `'static` reference types, such as `&'static str` and `&'static Path`.
- Suggests owned values, asset handles, or stable identifiers when reflected data needs to point at external values.

## Testing

- `git diff --check`
- `cargo doc -p bevy_reflect --no-deps` could not run in the sparse checkout because Cargo loads all workspace members, and the sparse clone does not include every crate target file.

This was implemented with Codex assistance, with the final patch reviewed manually and kept to the documented limitation.

---

## Showcase

N/A
