### PR TITLE
Add observer ordering via ObserverSet and topo-sorted dispatch

### DIFF
--- a/_release-content/release-notes/observer_ordering.md
+++ b/_release-content/release-notes/observer_ordering.md
@@ -1,0 +1,25 @@
+---
+title: Observer Ordering
+authors: ["@caniko"]
+pull_requests: [24328]
+---
+
+Observers can now be ordered against each other with the same `SystemSet`-style API used for systems. Iteration order is also now deterministic for callers who never opt into ordering — previously, hash-bucket order was undefined.
+
+```rust
+#[derive(ObserverSet, Hash, PartialEq, Eq, Clone, Copy, Debug)]
+struct WinCheck;
+
+app.add_observer(score.in_set(WinCheck));
+app.add_observer(announce.after(WinCheck));
+app.configure_observer_sets((WinCheck, Announce).chain());
+```
+
+Ordering edges work across dispatch buckets, so a global observer can be ordered against a per-entity or per-component observer for the same event. Internally each event type owns one topo-sorted observer graph, and dispatch sites walk that single order via a k-way merge over the active streams — no per-dispatch allocation.
+
+Existing observer features keep working alongside the new ordering:
+
+- `.run_if(condition)` composes with `.in_set(...)` / `.before(...)` / `.after(...)`, so a conditionally skipped observer no longer breaks the order of its neighbors.
+- The archetype-flag fast skip for lifecycle component observers is preserved.
+
+The builder surface (`.in_set`, `.before`, `.after`, `.chain`, `.with_name`) is available on every observer entry point: `World::add_observer` / `add_observers`, `Commands::add_observer`, `EntityWorldMut::observe`, `EntityCommands::observe`, and the free `entity_command::observe`. Tuples of observers can be modified together — `(a, b, c).chain().in_set(MySet)` applies the chain edges and set membership to all three.

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -13,7 +13,7 @@ use bevy_ecs::{
     error::{ErrorHandler, FallbackErrorHandler},
     intern::Interned,
     message::{message_update_system, MessageCursor},
-    observer::IntoObserver,
+    observer::{IntoObserverConfigs, IntoObserverSetConfigs},
     prelude::*,
     schedule::{
         InternedSystemSet, ScheduleBuildSettings, ScheduleCleanupPolicy, ScheduleError,
@@ -1457,8 +1457,23 @@ impl App {
     ///     }
     /// });
     /// ```
-    pub fn add_observer<M>(&mut self, observer: impl IntoObserver<M>) -> &mut Self {
-        self.world_mut().add_observer(observer);
+    pub fn add_observer<M>(&mut self, observer: impl IntoObserverConfigs<M>) -> &mut Self {
+        self.world_mut().add_observers(observer);
+        self
+    }
+
+    /// Adds multiple observers to the app's [`World`].
+    pub fn add_observers<M>(&mut self, observers: impl IntoObserverConfigs<M>) -> &mut Self {
+        self.world_mut().add_observers(observers);
+        self
+    }
+
+    /// Configures observer set hierarchy and ordering.
+    pub fn configure_observer_sets<M>(
+        &mut self,
+        sets: impl IntoObserverSetConfigs<M>,
+    ) -> &mut Self {
+        self.world_mut().configure_observer_sets(sets);
         self
     }
 

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -532,7 +532,9 @@ pub fn derive_observer_set(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let mut trait_path = bevy_ecs_path();
     trait_path.segments.push(format_ident!("observer").into());
-    trait_path.segments.push(format_ident!("ObserverSet").into());
+    trait_path
+        .segments
+        .push(format_ident!("ObserverSet").into());
     derive_label(input, "ObserverSet", &trait_path)
 }
 

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -524,6 +524,18 @@ pub fn derive_system_set(input: TokenStream) -> TokenStream {
     derive_label(input, "SystemSet", &trait_path)
 }
 
+/// Derive macro generating an impl of the trait `ObserverSet`.
+///
+/// This does not work for unions.
+#[proc_macro_derive(ObserverSet)]
+pub fn derive_observer_set(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let mut trait_path = bevy_ecs_path();
+    trait_path.segments.push(format_ident!("observer").into());
+    trait_path.segments.push(format_ident!("ObserverSet").into());
+    derive_label(input, "ObserverSet", &trait_path)
+}
+
 pub(crate) fn bevy_ecs_path() -> syn::Path {
     BevyManifest::shared(|manifest| manifest.get_path("bevy_ecs"))
 }

--- a/crates/bevy_ecs/src/batching.rs
+++ b/crates/bevy_ecs/src/batching.rs
@@ -16,10 +16,9 @@ use core::ops::Range;
 /// same amount of work to be done, which may not hold true in every
 /// workload.
 ///
-/// See [`Query::par_iter`], [`MessageReader::par_read`] for more information.
+/// See [`Query::par_iter`] and `MessageReader::par_read` for more information.
 ///
 /// [`Query::par_iter`]: crate::system::Query::par_iter
-/// [`MessageReader::par_read`]: crate::message::MessageReader::par_read
 #[derive(Clone, Debug)]
 pub struct BatchingStrategy {
     /// The upper and lower limits for a batch of items.

--- a/crates/bevy_ecs/src/event/trigger.rs
+++ b/crates/bevy_ecs/src/event/trigger.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 use bevy_ptr::PtrMut;
 use core::{fmt, marker::PhantomData};
+use smallvec::SmallVec;
 
 /// [`Trigger`] determines _how_ an [`Event`] is triggered when [`World::trigger`](crate::world::World::trigger) is called.
 /// This decides which [`Observer`](crate::observer::Observer)s will run, what data gets passed to them, and the order they will
@@ -449,53 +450,42 @@ impl<'a> EntityComponentsTrigger<'a> {
             world.as_unsafe_world_cell().increment_trigger_id();
         }
 
-        let mut global_node_ids = observers.global_node_ids();
-        let mut entity_node_ids = observers.entity_node_ids(entity);
+        let global_node_ids = observers.global_node_ids();
+        let entity_node_ids = observers.entity_node_ids(entity);
+        let mut component_global_node_ids = SmallVec::<[crate::observer::NodeId; 8]>::new();
+        let mut entity_component_node_ids = SmallVec::<[crate::observer::NodeId; 8]>::new();
 
-        if self.components.is_empty() {
-            // SAFETY:
-            // - `observers` come from `world` and match the `event` type, enforced by the call to `trigger_internal`
-            // - the passed in event pointer is an `Event`, enforced by the call to `trigger_internal`
-            // - `trigger` is a matching trigger type, enforced by the call to `trigger_internal`
-            // - `trigger_context`'s event_key matches `E`, enforced by the call to `trigger_internal`
-            unsafe {
-                let mut trigger = self.into();
-                run_ordered::<4>(
-                    observers,
-                    &mut world,
-                    trigger_context,
-                    &mut event,
-                    &mut trigger,
-                    [global_node_ids, entity_node_ids, &[], &[]],
-                );
-            }
+        for &id in self.components {
+            observers.merge_ordered_node_ids(
+                &mut component_global_node_ids,
+                observers.component_global_node_ids(id),
+            );
+            observers.merge_ordered_node_ids(
+                &mut entity_component_node_ids,
+                observers.entity_component_node_ids(id, entity),
+            );
         }
 
-        // Trigger observers watching for a specific component
-        for &id in self.components {
-            // SAFETY:
-            // - `observers` come from `world` and match the `event` type, enforced by the call to `trigger_internal`
-            // - the passed in event pointer is an `Event`, enforced by the call to `trigger_internal`
-            // - `trigger` is a matching trigger type, enforced by the call to `trigger_internal`
-            // - `trigger_context`'s event_key matches `E`, enforced by the call to `trigger_internal`
-            unsafe {
-                let mut trigger = self.into();
-                run_ordered::<4>(
-                    observers,
-                    &mut world,
-                    trigger_context,
-                    &mut event,
-                    &mut trigger,
-                    [
-                        global_node_ids,
-                        entity_node_ids,
-                        observers.component_global_node_ids(id),
-                        observers.entity_component_node_ids(id, entity),
-                    ],
-                );
-            }
-            global_node_ids = &[];
-            entity_node_ids = &[];
+        // SAFETY:
+        // - `observers` come from `world` and match the `event` type, enforced by the call to `trigger_internal`
+        // - the passed in event pointer is an `Event`, enforced by the call to `trigger_internal`
+        // - `trigger` is a matching trigger type, enforced by the call to `trigger_internal`
+        // - `trigger_context`'s event_key matches `E`, enforced by the call to `trigger_internal`
+        unsafe {
+            let mut trigger = self.into();
+            run_ordered::<4>(
+                observers,
+                &mut world,
+                trigger_context,
+                &mut event,
+                &mut trigger,
+                [
+                    global_node_ids,
+                    entity_node_ids,
+                    &component_global_node_ids,
+                    &entity_component_node_ids,
+                ],
+            );
         }
     }
 }

--- a/crates/bevy_ecs/src/event/trigger.rs
+++ b/crates/bevy_ecs/src/event/trigger.rs
@@ -4,7 +4,7 @@ use crate::{
     component::ComponentId,
     entity::Entity,
     event::{EntityEvent, Event},
-    observer::{CachedObservers, NodeId, TriggerContext},
+    observer::{run_ordered, CachedObservers, TriggerContext},
     traversal::Traversal,
     world::DeferredWorld,
 };
@@ -55,28 +55,6 @@ pub unsafe trait Trigger<E: Event> {
     );
 }
 
-/// # Safety
-/// - `world` must be the world that `observers` came from.
-/// - `node_id` must identify an observer in `observers` that is compatible with `event` and `trigger`.
-/// - `event` must point to an [`Event`].
-/// - `trigger` must correspond to the [`Event::Trigger`] type expected by `event`.
-/// - `trigger_context`'s [`TriggerContext::event_key`] must correspond to the `event` type.
-#[inline]
-unsafe fn run_observer_node(
-    world: DeferredWorld,
-    observers: &CachedObservers,
-    node_id: NodeId,
-    trigger_context: &TriggerContext,
-    event: PtrMut,
-    trigger: PtrMut,
-) {
-    let node = observers.observer(node_id);
-    // SAFETY: The caller upholds the observer runner's safety contract.
-    unsafe {
-        (node.runner)(world, node.observer, trigger_context, event, trigger);
-    }
-}
-
 /// A [`Trigger`] that runs _every_ "global" [`Observer`](crate::observer::Observer) (ex: registered via [`World::add_observer`](crate::world::World::add_observer))
 /// that matches the given [`Event`].
 ///
@@ -123,23 +101,23 @@ impl GlobalTrigger {
         unsafe {
             world.as_unsafe_world_cell().increment_trigger_id();
         }
-        for &node_id in observers.global_observers() {
-            // SAFETY:
-            // - `observers` come from `world` and match the `event` type, enforced by the call to `trigger_internal`
-            // - the passed in event pointer is an `Event`, enforced by the call to `trigger_internal`
-            // - `trigger` is a matching trigger type, as it comes from `self`, which is the Trigger for `event`, enforced by `trigger_internal`
-            // - `trigger_context`'s event_key matches `E`, enforced by the call to `trigger_internal`
-            // - this abides by the nuances defined in the `Trigger` safety docs
-            unsafe {
-                run_observer_node(
-                    world.reborrow(),
-                    observers,
-                    node_id,
-                    trigger_context,
-                    event.reborrow(),
-                    self.into(),
-                );
-            }
+
+        // SAFETY:
+        // - `observers` come from `world` and match the `event` type, enforced by the call to `trigger_internal`
+        // - the passed in event pointer is an `Event`, enforced by the call to `trigger_internal`
+        // - `trigger` is a matching trigger type, as it comes from `self`, which is the Trigger for `event`, enforced by `trigger_internal`
+        // - `trigger_context`'s event_key matches `E`, enforced by the call to `trigger_internal`
+        // - this abides by the nuances defined in the `Trigger` safety docs
+        unsafe {
+            let mut trigger = self.into();
+            run_ordered::<1>(
+                observers,
+                &mut world,
+                trigger_context,
+                &mut event,
+                &mut trigger,
+                [observers.global_node_ids()],
+            );
         }
     }
 }
@@ -208,42 +186,24 @@ pub unsafe fn trigger_entity_internal(
     unsafe {
         world.as_unsafe_world_cell().increment_trigger_id();
     }
-    for &node_id in observers.global_observers() {
-        // SAFETY:
-        // - `observers` come from `world` and match the `event` type, enforced by the call to `trigger_entity_internal`
-        // - the passed in event pointer is an `Event`, enforced by the call to `trigger_entity_internal`
-        // - `trigger` is a matching trigger type, enforced by the call to `trigger_entity_internal`
-        // - `trigger_context`'s event_key matches `E`, enforced by the call to `trigger_entity_internal`
-        unsafe {
-            run_observer_node(
-                world.reborrow(),
-                observers,
-                node_id,
-                trigger_context,
-                event.reborrow(),
-                trigger.reborrow(),
-            );
-        }
-    }
 
-    if let Some(nodes) = observers.entity_observers().get(&target_entity) {
-        for &node_id in nodes {
-            // SAFETY:
-            // - `observers` come from `world` and match the `event` type, enforced by the call to `trigger_entity_internal`
-            // - the passed in event pointer is an `Event`, enforced by the call to `trigger_entity_internal`
-            // - `trigger` is a matching trigger type, enforced by the call to `trigger_entity_internal`
-            // - `trigger_context`'s event_key matches `E`, enforced by the call to `trigger_entity_internal`
-            unsafe {
-                run_observer_node(
-                    world.reborrow(),
-                    observers,
-                    node_id,
-                    trigger_context,
-                    event.reborrow(),
-                    trigger.reborrow(),
-                );
-            }
-        }
+    // SAFETY:
+    // - `observers` come from `world` and match the `event` type, enforced by the call to `trigger_entity_internal`
+    // - the passed in event pointer is an `Event`, enforced by the call to `trigger_entity_internal`
+    // - `trigger` is a matching trigger type, enforced by the call to `trigger_entity_internal`
+    // - `trigger_context`'s event_key matches `E`, enforced by the call to `trigger_entity_internal`
+    unsafe {
+        run_ordered::<2>(
+            observers,
+            &mut world,
+            trigger_context,
+            &mut event,
+            &mut trigger,
+            [
+                observers.global_node_ids(),
+                observers.entity_node_ids(target_entity),
+            ],
+        );
     }
 }
 
@@ -484,66 +444,58 @@ impl<'a> EntityComponentsTrigger<'a> {
         entity: Entity,
         trigger_context: &TriggerContext,
     ) {
-        // SAFETY:
-        // - `observers` come from `world` and match the event type `E`, enforced by the call to `trigger`
-        // - the passed in event pointer comes from `event`, which is an `Event`
-        // - `trigger` is a matching trigger type, as it comes from `self`, which is the Trigger for `E`
-        // - `trigger_context`'s event_key matches `E`, enforced by the call to `trigger`
+        // SAFETY: there are no outstanding world references
         unsafe {
-            trigger_entity_internal(
-                world.reborrow(),
-                observers,
-                event.reborrow(),
-                self.into(),
-                entity,
-                trigger_context,
-            );
+            world.as_unsafe_world_cell().increment_trigger_id();
+        }
+
+        let mut global_node_ids = observers.global_node_ids();
+        let mut entity_node_ids = observers.entity_node_ids(entity);
+
+        if self.components.is_empty() {
+            // SAFETY:
+            // - `observers` come from `world` and match the `event` type, enforced by the call to `trigger_internal`
+            // - the passed in event pointer is an `Event`, enforced by the call to `trigger_internal`
+            // - `trigger` is a matching trigger type, enforced by the call to `trigger_internal`
+            // - `trigger_context`'s event_key matches `E`, enforced by the call to `trigger_internal`
+            unsafe {
+                let mut trigger = self.into();
+                run_ordered::<4>(
+                    observers,
+                    &mut world,
+                    trigger_context,
+                    &mut event,
+                    &mut trigger,
+                    [global_node_ids, entity_node_ids, &[], &[]],
+                );
+            }
         }
 
         // Trigger observers watching for a specific component
-        for id in self.components {
-            if let Some(component_observers) = observers.component_observers().get(id) {
-                for &node_id in component_observers.global_observers() {
-                    // SAFETY:
-                    // - `observers` come from `world` and match the `event` type, enforced by the call to `trigger_internal`
-                    // - the passed in event pointer is an `Event`, enforced by the call to `trigger_internal`
-                    // - `trigger` is a matching trigger type, enforced by the call to `trigger_internal`
-                    // - `trigger_context`'s event_key matches `E`, enforced by the call to `trigger_internal`
-                    unsafe {
-                        run_observer_node(
-                            world.reborrow(),
-                            observers,
-                            node_id,
-                            trigger_context,
-                            event.reborrow(),
-                            self.into(),
-                        );
-                    }
-                }
-
-                if let Some(map) = component_observers
-                    .entity_component_observers()
-                    .get(&entity)
-                {
-                    for &node_id in map {
-                        // SAFETY:
-                        // - `observers` come from `world` and match the `event` type, enforced by the call to `trigger_internal`
-                        // - the passed in event pointer is an `Event`, enforced by the call to `trigger_internal`
-                        // - `trigger` is a matching trigger type, enforced by the call to `trigger_internal`
-                        // - `trigger_context`'s event_key matches `E`, enforced by the call to `trigger_internal`
-                        unsafe {
-                            run_observer_node(
-                                world.reborrow(),
-                                observers,
-                                node_id,
-                                trigger_context,
-                                event.reborrow(),
-                                self.into(),
-                            );
-                        }
-                    }
-                }
+        for &id in self.components {
+            // SAFETY:
+            // - `observers` come from `world` and match the `event` type, enforced by the call to `trigger_internal`
+            // - the passed in event pointer is an `Event`, enforced by the call to `trigger_internal`
+            // - `trigger` is a matching trigger type, enforced by the call to `trigger_internal`
+            // - `trigger_context`'s event_key matches `E`, enforced by the call to `trigger_internal`
+            unsafe {
+                let mut trigger = self.into();
+                run_ordered::<4>(
+                    observers,
+                    &mut world,
+                    trigger_context,
+                    &mut event,
+                    &mut trigger,
+                    [
+                        global_node_ids,
+                        entity_node_ids,
+                        observers.component_global_node_ids(id),
+                        observers.entity_component_node_ids(id, entity),
+                    ],
+                );
             }
+            global_node_ids = &[];
+            entity_node_ids = &[];
         }
     }
 }

--- a/crates/bevy_ecs/src/event/trigger.rs
+++ b/crates/bevy_ecs/src/event/trigger.rs
@@ -4,7 +4,7 @@ use crate::{
     component::ComponentId,
     entity::Entity,
     event::{EntityEvent, Event},
-    observer::{CachedObservers, TriggerContext},
+    observer::{CachedObservers, NodeId, TriggerContext},
     traversal::Traversal,
     world::DeferredWorld,
 };
@@ -55,6 +55,28 @@ pub unsafe trait Trigger<E: Event> {
     );
 }
 
+/// # Safety
+/// - `world` must be the world that `observers` came from.
+/// - `node_id` must identify an observer in `observers` that is compatible with `event` and `trigger`.
+/// - `event` must point to an [`Event`].
+/// - `trigger` must correspond to the [`Event::Trigger`] type expected by `event`.
+/// - `trigger_context`'s [`TriggerContext::event_key`] must correspond to the `event` type.
+#[inline]
+unsafe fn run_observer_node(
+    world: DeferredWorld,
+    observers: &CachedObservers,
+    node_id: NodeId,
+    trigger_context: &TriggerContext,
+    event: PtrMut,
+    trigger: PtrMut,
+) {
+    let node = observers.observer(node_id);
+    // SAFETY: The caller upholds the observer runner's safety contract.
+    unsafe {
+        (node.runner)(world, node.observer, trigger_context, event, trigger);
+    }
+}
+
 /// A [`Trigger`] that runs _every_ "global" [`Observer`](crate::observer::Observer) (ex: registered via [`World::add_observer`](crate::world::World::add_observer))
 /// that matches the given [`Event`].
 ///
@@ -101,7 +123,7 @@ impl GlobalTrigger {
         unsafe {
             world.as_unsafe_world_cell().increment_trigger_id();
         }
-        for (observer, runner) in observers.global_observers() {
+        for &node_id in observers.global_observers() {
             // SAFETY:
             // - `observers` come from `world` and match the `event` type, enforced by the call to `trigger_internal`
             // - the passed in event pointer is an `Event`, enforced by the call to `trigger_internal`
@@ -109,9 +131,10 @@ impl GlobalTrigger {
             // - `trigger_context`'s event_key matches `E`, enforced by the call to `trigger_internal`
             // - this abides by the nuances defined in the `Trigger` safety docs
             unsafe {
-                (runner)(
+                run_observer_node(
                     world.reborrow(),
-                    *observer,
+                    observers,
+                    node_id,
                     trigger_context,
                     event.reborrow(),
                     self.into(),
@@ -185,16 +208,17 @@ pub unsafe fn trigger_entity_internal(
     unsafe {
         world.as_unsafe_world_cell().increment_trigger_id();
     }
-    for (observer, runner) in observers.global_observers() {
+    for &node_id in observers.global_observers() {
         // SAFETY:
         // - `observers` come from `world` and match the `event` type, enforced by the call to `trigger_entity_internal`
         // - the passed in event pointer is an `Event`, enforced by the call to `trigger_entity_internal`
         // - `trigger` is a matching trigger type, enforced by the call to `trigger_entity_internal`
         // - `trigger_context`'s event_key matches `E`, enforced by the call to `trigger_entity_internal`
         unsafe {
-            (runner)(
+            run_observer_node(
                 world.reborrow(),
-                *observer,
+                observers,
+                node_id,
                 trigger_context,
                 event.reborrow(),
                 trigger.reborrow(),
@@ -202,17 +226,18 @@ pub unsafe fn trigger_entity_internal(
         }
     }
 
-    if let Some(map) = observers.entity_observers().get(&target_entity) {
-        for (observer, runner) in map {
+    if let Some(nodes) = observers.entity_observers().get(&target_entity) {
+        for &node_id in nodes {
             // SAFETY:
             // - `observers` come from `world` and match the `event` type, enforced by the call to `trigger_entity_internal`
             // - the passed in event pointer is an `Event`, enforced by the call to `trigger_entity_internal`
             // - `trigger` is a matching trigger type, enforced by the call to `trigger_entity_internal`
             // - `trigger_context`'s event_key matches `E`, enforced by the call to `trigger_entity_internal`
             unsafe {
-                (runner)(
+                run_observer_node(
                     world.reborrow(),
-                    *observer,
+                    observers,
+                    node_id,
                     trigger_context,
                     event.reborrow(),
                     trigger.reborrow(),
@@ -478,16 +503,17 @@ impl<'a> EntityComponentsTrigger<'a> {
         // Trigger observers watching for a specific component
         for id in self.components {
             if let Some(component_observers) = observers.component_observers().get(id) {
-                for (observer, runner) in component_observers.global_observers() {
+                for &node_id in component_observers.global_observers() {
                     // SAFETY:
                     // - `observers` come from `world` and match the `event` type, enforced by the call to `trigger_internal`
                     // - the passed in event pointer is an `Event`, enforced by the call to `trigger_internal`
                     // - `trigger` is a matching trigger type, enforced by the call to `trigger_internal`
                     // - `trigger_context`'s event_key matches `E`, enforced by the call to `trigger_internal`
                     unsafe {
-                        (runner)(
+                        run_observer_node(
                             world.reborrow(),
-                            *observer,
+                            observers,
+                            node_id,
                             trigger_context,
                             event.reborrow(),
                             self.into(),
@@ -499,16 +525,17 @@ impl<'a> EntityComponentsTrigger<'a> {
                     .entity_component_observers()
                     .get(&entity)
                 {
-                    for (observer, runner) in map {
+                    for &node_id in map {
                         // SAFETY:
                         // - `observers` come from `world` and match the `event` type, enforced by the call to `trigger_internal`
                         // - the passed in event pointer is an `Event`, enforced by the call to `trigger_internal`
                         // - `trigger` is a matching trigger type, enforced by the call to `trigger_internal`
                         // - `trigger_context`'s event_key matches `E`, enforced by the call to `trigger_internal`
                         unsafe {
-                            (runner)(
+                            run_observer_node(
                                 world.reborrow(),
-                                *observer,
+                                observers,
+                                node_id,
                                 trigger_context,
                                 event.reborrow(),
                                 self.into(),

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -82,7 +82,11 @@ pub mod prelude {
             Message, MessageMutator, MessageReader, MessageWriter, Messages, PopulatedMessageReader,
         },
         name::{Name, NameOrEntity},
-        observer::{Observer, ObserverSystemExt, On},
+<<<<<<< HEAD
+        observer::{Observer, ObserverSet, ObserverSystemExt, On},
+=======
+        observer::{Observer, ObserverSet, On},
+>>>>>>> 696e89e0d (ecs/observer: add ObserverSet trait, derive, and descriptor edges)
         query::{Added, Allow, AnyOf, Changed, Has, Or, QueryBuilder, QueryState, With, Without},
         related,
         relationship::RelationshipTarget,

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -82,7 +82,10 @@ pub mod prelude {
             Message, MessageMutator, MessageReader, MessageWriter, Messages, PopulatedMessageReader,
         },
         name::{Name, NameOrEntity},
-        observer::{Observer, ObserverSet, ObserverSystemExt, On},
+        observer::{
+            IntoObserverConfigs, IntoObserverOrderingTarget, IntoObserverSetConfigs, Observer,
+            ObserverSet, ObserverSystemExt, On,
+        },
         query::{Added, Allow, AnyOf, Changed, Has, Or, QueryBuilder, QueryState, With, Without},
         related,
         relationship::RelationshipTarget,

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -82,11 +82,7 @@ pub mod prelude {
             Message, MessageMutator, MessageReader, MessageWriter, Messages, PopulatedMessageReader,
         },
         name::{Name, NameOrEntity},
-<<<<<<< HEAD
         observer::{Observer, ObserverSet, ObserverSystemExt, On},
-=======
-        observer::{Observer, ObserverSet, On},
->>>>>>> 696e89e0d (ecs/observer: add ObserverSet trait, derive, and descriptor edges)
         query::{Added, Allow, AnyOf, Changed, Has, Or, QueryBuilder, QueryState, With, Without},
         related,
         relationship::RelationshipTarget,

--- a/crates/bevy_ecs/src/observer/centralized_storage.rs
+++ b/crates/bevy_ecs/src/observer/centralized_storage.rs
@@ -8,7 +8,7 @@
 //! - [`CachedObservers`] contains a sorted node table of [`ObserverRunner`]s, which are the actual functions that will be run when the observer is triggered.
 //!     - These are split by target type, in order to allow for different lookup strategies.
 
-use alloc::{vec, vec::Vec};
+use alloc::{string::String, vec, vec::Vec};
 use bevy_platform::collections::HashMap;
 use bevy_ptr::PtrMut;
 use log::{debug, warn};
@@ -20,7 +20,10 @@ use crate::{
     entity::{Entity, EntityHashMap},
     event::EventKey,
     intern::Interned,
-    observer::{EdgeTarget, ObserverDescriptor, ObserverRunner, ObserverSet},
+    observer::{
+        EdgeTarget, IntoObserverOrderingTarget, IntoObserverSetConfigs, ObserverDescriptor,
+        ObserverRunner, ObserverSet, ObserverSetConfigs,
+    },
     schedule::graph::{DiGraph, DiGraphToposortError, Direction, GraphNodeId},
     world::DeferredWorld,
 };
@@ -44,9 +47,10 @@ pub struct Observers {
     despawn: CachedObservers,
     // Map from event type to set of observers watching for that event
     cache: HashMap<EventKey, CachedObservers>,
-    // Observer set hierarchy declarations. Populated by observer set configuration in a later phase.
-    #[expect(dead_code, reason = "Observer set dispatch is wired in a later phase.")]
+    // Observer set hierarchy declarations, keyed by child set with parent sets as values.
     set_hierarchy: HashMap<Interned<dyn ObserverSet>, SmallVec<[Interned<dyn ObserverSet>; 2]>>,
+    // Observer set ordering edges, stored as (before, after).
+    set_edges: Vec<(Interned<dyn ObserverSet>, Interned<dyn ObserverSet>)>,
 }
 
 impl Observers {
@@ -59,7 +63,13 @@ impl Observers {
             DISCARD => &mut self.discard,
             REMOVE => &mut self.remove,
             DESPAWN => &mut self.despawn,
-            _ => self.cache.entry(event_key).or_default(),
+            _ => {
+                let set_hierarchy = self.set_hierarchy.clone();
+                let set_edges = self.set_edges.clone();
+                self.cache
+                    .entry(event_key)
+                    .or_insert_with(|| CachedObservers::with_set_config(set_hierarchy, set_edges))
+            }
         }
     }
 
@@ -140,6 +150,89 @@ impl Observers {
             flags.insert(ArchetypeFlags::ON_DESPAWN_OBSERVER);
         }
     }
+
+    /// Configure observer set hierarchy and set ordering.
+    pub fn configure_observer_sets<M>(&mut self, sets: impl IntoObserverSetConfigs<M>) {
+        let mut configs = sets.into_configs();
+        configs.add_chain_edges();
+        self.apply_observer_set_configs(&configs);
+    }
+
+    fn apply_observer_set_configs(&mut self, configs: &ObserverSetConfigs) {
+        for &(child, parent) in &configs.hierarchy {
+            push_unique_set(self.set_hierarchy.entry(child).or_default(), parent);
+        }
+        for &edge in &configs.edges {
+            push_unique_edge(&mut self.set_edges, edge);
+        }
+
+        self.add.configure_observer_sets(configs);
+        self.insert.configure_observer_sets(configs);
+        self.discard.configure_observer_sets(configs);
+        self.remove.configure_observer_sets(configs);
+        self.despawn.configure_observer_sets(configs);
+        for cache in self.cache.values_mut() {
+            cache.configure_observer_sets(configs);
+        }
+    }
+
+    /// Returns observer entities for `event_key` in dispatch order.
+    pub fn dispatch_order_for(&self, event_key: EventKey) -> &[Entity] {
+        self.try_get_observers(event_key)
+            .map_or(&[], CachedObservers::dispatch_order_for)
+    }
+
+    /// Returns observer entities in `set` for `event_key` in dispatch order.
+    pub fn dispatch_order_for_set<S: IntoObserverOrderingTarget>(
+        &self,
+        event_key: EventKey,
+        set: S,
+    ) -> Vec<Entity> {
+        let EdgeTarget::Set(set) = set.into_observer_ordering_target().into_edge_target() else {
+            return Vec::new();
+        };
+        self.try_get_observers(event_key)
+            .map_or_else(Vec::new, |cache| cache.dispatch_order_for_set(set))
+    }
+
+    /// Returns observers for `target` and `event_key` in dispatch order.
+    pub fn dispatch_order_for_target(&self, event_key: EventKey, target: Entity) -> Vec<Entity> {
+        self.try_get_observers(event_key)
+            .map_or_else(Vec::new, |cache| cache.dispatch_order_for_target(target))
+    }
+
+    /// Returns observer entities and optional names for `event_key` in dispatch order.
+    pub fn dispatch_order_for_with_names(&self, event_key: EventKey) -> Vec<(Entity, Option<&str>)> {
+        self.try_get_observers(event_key)
+            .map_or_else(Vec::new, CachedObservers::dispatch_order_for_with_names)
+    }
+
+    /// Returns named dispatch-order diagnostics for observers in `set`.
+    pub fn dispatch_order_for_set_with_names<S: IntoObserverOrderingTarget>(
+        &self,
+        event_key: EventKey,
+        set: S,
+    ) -> Vec<(Entity, Option<&str>)> {
+        let EdgeTarget::Set(set) = set.into_observer_ordering_target().into_edge_target() else {
+            return Vec::new();
+        };
+        self.try_get_observers(event_key)
+            .map_or_else(Vec::new, |cache| {
+                cache.dispatch_order_for_set_with_names(set)
+            })
+    }
+
+    /// Returns named dispatch-order diagnostics for observers watching `target`.
+    pub fn dispatch_order_for_target_with_names(
+        &self,
+        event_key: EventKey,
+        target: Entity,
+    ) -> Vec<(Entity, Option<&str>)> {
+        self.try_get_observers(event_key)
+            .map_or_else(Vec::new, |cache| {
+                cache.dispatch_order_for_target_with_names(target)
+            })
+    }
 }
 
 /// Identifier for an observer node in [`CachedObservers`].
@@ -167,12 +260,13 @@ impl GraphNodeId for NodeId {
 }
 
 /// Observer data stored once per registered observer/event-key pair.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct ObserverNode {
     /// The entity that owns the observer component.
     pub observer: Entity,
     /// The function used to run the observer.
     pub runner: ObserverRunner,
+    name: Option<String>,
     sort_key: u64,
 }
 
@@ -218,13 +312,27 @@ pub struct CachedObservers {
     by_entity: EntityHashMap<SmallVec<[NodeId; 2]>>,
     by_component: HashMap<ComponentId, ComponentBucket>,
     sets: HashMap<Interned<dyn ObserverSet>, SmallVec<[NodeId; 4]>>,
+    set_hierarchy: HashMap<Interned<dyn ObserverSet>, SmallVec<[Interned<dyn ObserverSet>; 2]>>,
+    set_edges: Vec<(Interned<dyn ObserverSet>, Interned<dyn ObserverSet>)>,
     edges: Vec<ObserverEdgeResolved>,
     observer_to_node: EntityHashMap<NodeId>,
+    dispatch_order: Vec<Entity>,
     dirty: bool,
     next_sort_key: u64,
 }
 
 impl CachedObservers {
+    fn with_set_config(
+        set_hierarchy: HashMap<Interned<dyn ObserverSet>, SmallVec<[Interned<dyn ObserverSet>; 2]>>,
+        set_edges: Vec<(Interned<dyn ObserverSet>, Interned<dyn ObserverSet>)>,
+    ) -> Self {
+        Self {
+            set_hierarchy,
+            set_edges,
+            ..Default::default()
+        }
+    }
+
     /// Returns the observer node table.
     pub fn nodes(&self) -> &[ObserverNode] {
         &self.nodes
@@ -277,6 +385,97 @@ impl CachedObservers {
             .map_or(&[], SmallVec::as_slice)
     }
 
+    /// Returns observer entities in dispatch order.
+    pub fn dispatch_order_for(&self) -> &[Entity] {
+        &self.dispatch_order
+    }
+
+    /// Returns observer entities in `set` in dispatch order.
+    pub fn dispatch_order_for_set(&self, set: Interned<dyn ObserverSet>) -> Vec<Entity> {
+        let nodes = self.resolve_set_target(&set);
+        self.order
+            .iter()
+            .filter(|node_id| nodes.contains(node_id))
+            .map(|node_id| self.nodes[node_id.index()].observer)
+            .collect()
+    }
+
+    /// Returns observer entities watching `target` in dispatch order.
+    pub fn dispatch_order_for_target(&self, target: Entity) -> Vec<Entity> {
+        self.by_entity
+            .get(&target)
+            .into_iter()
+            .flat_map(|nodes| nodes.iter())
+            .map(|node_id| self.nodes[node_id.index()].observer)
+            .collect()
+    }
+
+    /// Returns observer entities and optional names in dispatch order.
+    pub fn dispatch_order_for_with_names(&self) -> Vec<(Entity, Option<&str>)> {
+        self.order
+            .iter()
+            .map(|node_id| {
+                let node = &self.nodes[node_id.index()];
+                (node.observer, node.name.as_deref())
+            })
+            .collect()
+    }
+
+    /// Returns named diagnostics for observer entities in `set` in dispatch order.
+    pub fn dispatch_order_for_set_with_names(
+        &self,
+        set: Interned<dyn ObserverSet>,
+    ) -> Vec<(Entity, Option<&str>)> {
+        let nodes = self.resolve_set_target(&set);
+        self.order
+            .iter()
+            .filter(|node_id| nodes.contains(node_id))
+            .map(|node_id| {
+                let node = &self.nodes[node_id.index()];
+                (node.observer, node.name.as_deref())
+            })
+            .collect()
+    }
+
+    /// Returns named diagnostics for observer entities watching `target` in dispatch order.
+    pub fn dispatch_order_for_target_with_names(
+        &self,
+        target: Entity,
+    ) -> Vec<(Entity, Option<&str>)> {
+        self.by_entity
+            .get(&target)
+            .into_iter()
+            .flat_map(|nodes| nodes.iter())
+            .map(|node_id| {
+                let node = &self.nodes[node_id.index()];
+                (node.observer, node.name.as_deref())
+            })
+            .collect()
+    }
+
+    pub(crate) fn configure_observer_sets(&mut self, configs: &ObserverSetConfigs) {
+        let mut changed = false;
+        for &(child, parent) in &configs.hierarchy {
+            let parents = self.set_hierarchy.entry(child).or_default();
+            if !parents.contains(&parent) {
+                parents.push(parent);
+                changed = true;
+            }
+        }
+        for &edge in &configs.edges {
+            if !self.set_edges.contains(&edge) {
+                self.set_edges.push(edge);
+                changed = true;
+            }
+        }
+
+        if changed {
+            self.dirty = true;
+            self.resort();
+        }
+    }
+
+
     pub(crate) fn register_observer(
         &mut self,
         observer: Entity,
@@ -291,6 +490,7 @@ impl CachedObservers {
         self.nodes.push(ObserverNode {
             observer,
             runner,
+            name: descriptor.name.clone(),
             sort_key: self.next_sort_key,
         });
         self.next_sort_key = self.next_sort_key.wrapping_add(1);
@@ -328,8 +528,8 @@ impl CachedObservers {
         for edge in &descriptor.edges {
             self.edges.push(ObserverEdgeResolved {
                 owner: observer,
-                from: edge.from.clone(),
-                to: edge.to.clone(),
+                from: edge.from.clone().resolve_owner(observer),
+                to: edge.to.clone().resolve_owner(observer),
             });
         }
 
@@ -432,6 +632,13 @@ impl CachedObservers {
             return;
         }
 
+        #[cfg(feature = "trace")]
+        let _span = {
+            let nodes = self.nodes.len();
+            let named = self.nodes.iter().filter(|node| node.name.is_some()).count();
+            tracing::trace_span!("observer_resort", nodes = nodes, named = named).entered()
+        };
+
         let mut attempts = 0;
         while self.dirty {
             self.dirty = false;
@@ -448,7 +655,8 @@ impl CachedObservers {
 
     fn rebuild_order(&mut self) {
         let insertion_order = self.insertion_order();
-        let mut graph = DiGraph::<NodeId>::with_capacity(self.nodes.len(), self.edges.len());
+        let mut graph =
+            DiGraph::<NodeId>::with_capacity(self.nodes.len(), self.edges.len() + self.set_edges.len());
 
         for &node_id in insertion_order.iter().rev() {
             graph.add_node(node_id);
@@ -465,10 +673,30 @@ impl CachedObservers {
             }
         }
 
+        for nodes in self.sets.values() {
+            let mut nodes = nodes.iter().copied().collect::<Vec<_>>();
+            nodes.sort_by_key(|node_id| self.nodes[node_id.index()].sort_key);
+            for pair in nodes.windows(2) {
+                graph.add_edge(pair[0], pair[1]);
+            }
+        }
+
+        for &(from_set, to_set) in &self.set_edges {
+            let from_nodes = self.resolve_set_target(&from_set);
+            let to_nodes = self.resolve_set_target(&to_set);
+
+            for &from in &from_nodes {
+                for &to in &to_nodes {
+                    graph.add_edge(from, to);
+                }
+            }
+        }
+
         match graph.toposort(Vec::new()) {
             Ok(order) => {
                 debug_assert_eq!(order.len(), self.nodes.len());
                 self.order = order;
+                self.refresh_dispatch_order();
             }
             Err(error) => {
                 let cycle_members = self.cycle_members(&error);
@@ -476,6 +704,7 @@ impl CachedObservers {
                     "observer ordering graph contains a cycle involving {cycle_members:?}; falling back to registration order"
                 );
                 self.order = insertion_order;
+                self.refresh_dispatch_order();
 
                 #[cfg(test)]
                 debug_assert!(false, "observer ordering graph contains a cycle: {error:?}");
@@ -498,13 +727,52 @@ impl CachedObservers {
                 .into_iter()
                 .collect(),
             EdgeTarget::Set(set) => {
-                let Some(nodes) = self.sets.get(set) else {
+                let nodes = self.resolve_set_target(set);
+                if nodes.is_empty() {
                     debug!("observer ordering edge references empty set {set:?}");
                     return SmallVec::new();
-                };
-                nodes.iter().copied().collect()
+                }
+                nodes
             }
         }
+    }
+
+    fn resolve_set_target(
+        &self,
+        set: &Interned<dyn ObserverSet>,
+    ) -> SmallVec<[NodeId; 4]> {
+        let mut resolved = SmallVec::new();
+        let mut visited = Vec::new();
+        let mut stack = vec![*set];
+
+        while let Some(current) = stack.pop() {
+            if visited.contains(&current) {
+                continue;
+            }
+            visited.push(current);
+
+            if let Some(nodes) = self.sets.get(&current) {
+                for &node_id in nodes {
+                    push_unique(&mut resolved, node_id);
+                }
+            }
+
+            for (&child, parents) in &self.set_hierarchy {
+                if parents.contains(&current) {
+                    stack.push(child);
+                }
+            }
+        }
+
+        resolved
+    }
+
+    fn refresh_dispatch_order(&mut self) {
+        self.dispatch_order = self
+            .order
+            .iter()
+            .map(|node_id| self.nodes[node_id.index()].observer)
+            .collect();
     }
 
     fn cycle_members(&self, error: &DiGraphToposortError<NodeId>) -> Vec<Vec<Entity>> {
@@ -699,6 +967,24 @@ pub(crate) unsafe fn run_ordered<const N: usize>(
 fn push_unique<const N: usize>(nodes: &mut SmallVec<[NodeId; N]>, node_id: NodeId) {
     if !nodes.contains(&node_id) {
         nodes.push(node_id);
+    }
+}
+
+fn push_unique_set<const N: usize>(
+    sets: &mut SmallVec<[Interned<dyn ObserverSet>; N]>,
+    set: Interned<dyn ObserverSet>,
+) {
+    if !sets.contains(&set) {
+        sets.push(set);
+    }
+}
+
+fn push_unique_edge(
+    edges: &mut Vec<(Interned<dyn ObserverSet>, Interned<dyn ObserverSet>)>,
+    edge: (Interned<dyn ObserverSet>, Interned<dyn ObserverSet>),
+) {
+    if !edges.contains(&edge) {
+        edges.push(edge);
     }
 }
 

--- a/crates/bevy_ecs/src/observer/centralized_storage.rs
+++ b/crates/bevy_ecs/src/observer/centralized_storage.rs
@@ -393,6 +393,49 @@ impl CachedObservers {
         &self.dispatch_order
     }
 
+    /// Merges `stream` into `merged`, preserving the ordering required by [`run_ordered`].
+    pub(crate) fn merge_ordered_node_ids<const N: usize>(
+        &self,
+        merged: &mut SmallVec<[NodeId; N]>,
+        stream: &[NodeId],
+    ) {
+        if stream.is_empty() {
+            return;
+        }
+
+        if merged.is_empty() {
+            merged.extend_from_slice(stream);
+            return;
+        }
+
+        let existing = core::mem::take(merged);
+        let mut existing_index = 0;
+        let mut stream_index = 0;
+
+        while existing_index < existing.len() && stream_index < stream.len() {
+            let existing_id = existing[existing_index];
+            let stream_id = stream[stream_index];
+
+            if self.order_position(existing_id) <= self.order_position(stream_id) {
+                merged.push(existing_id);
+                existing_index += 1;
+            } else {
+                merged.push(stream_id);
+                stream_index += 1;
+            }
+        }
+
+        merged.extend_from_slice(&existing[existing_index..]);
+        merged.extend_from_slice(&stream[stream_index..]);
+    }
+
+    fn order_position(&self, node_id: NodeId) -> usize {
+        self.order
+            .iter()
+            .position(|ordered_node_id| *ordered_node_id == node_id)
+            .expect("observer node must be present in dispatch order")
+    }
+
     /// Returns observer entities in `set` in dispatch order.
     pub fn dispatch_order_for_set(&self, set: Interned<dyn ObserverSet>) -> Vec<Entity> {
         let nodes = self.resolve_set_target(&set);

--- a/crates/bevy_ecs/src/observer/centralized_storage.rs
+++ b/crates/bevy_ecs/src/observer/centralized_storage.rs
@@ -8,8 +8,8 @@
 //! - [`CachedObservers`] contains a sorted node table of [`ObserverRunner`]s, which are the actual functions that will be run when the observer is triggered.
 //!     - These are split by target type, in order to allow for different lookup strategies.
 
-use alloc::{string::String, vec, vec::Vec};
-use bevy_platform::collections::HashMap;
+use alloc::{format, string::String, vec, vec::Vec};
+use bevy_platform::collections::{HashMap, HashSet};
 use bevy_ptr::PtrMut;
 use log::{debug, warn};
 use smallvec::SmallVec;
@@ -51,6 +51,9 @@ pub struct Observers {
     set_hierarchy: HashMap<Interned<dyn ObserverSet>, SmallVec<[Interned<dyn ObserverSet>; 2]>>,
     // Observer set ordering edges, stored as (before, after).
     set_edges: Vec<(Interned<dyn ObserverSet>, Interned<dyn ObserverSet>)>,
+    // Active depth of `bump_defer_resort` / `release_defer_resort` calls.
+    // While > 0, per-cache `resort()` short-circuits; release flushes all caches.
+    defer_count: u32,
 }
 
 impl Observers {
@@ -66,10 +69,79 @@ impl Observers {
             _ => {
                 let set_hierarchy = self.set_hierarchy.clone();
                 let set_edges = self.set_edges.clone();
-                self.cache
-                    .entry(event_key)
-                    .or_insert_with(|| CachedObservers::with_set_config(set_hierarchy, set_edges))
+                let defer_count = self.defer_count;
+                self.cache.entry(event_key).or_insert_with(|| {
+                    let mut cache = CachedObservers::with_set_config(set_hierarchy, set_edges);
+                    cache.defer_count = defer_count;
+                    cache
+                })
             }
+        }
+    }
+
+    /// Suppress per-cache `resort()` calls until the matching
+    /// `release_defer_resort` runs. Calls nest (counter-based), and the
+    /// deferral propagates to every existing and newly-created cache.
+    ///
+    /// Used by batch entry points such as
+    /// [`World::add_observers`](crate::world::World::add_observers) and
+    /// [`World::configure_observer_sets`](crate::world::World::configure_observer_sets)
+    /// to avoid a quadratic toposort cost on plugin startup.
+    pub(crate) fn bump_defer_resort(&mut self) {
+        self.defer_count = self.defer_count.saturating_add(1);
+        self.propagate_defer_count();
+    }
+
+    /// Release a previous `bump_defer_resort`. When the counter returns to
+    /// zero, every cache that became dirty during the deferral flushes a
+    /// single `resort()`.
+    pub(crate) fn release_defer_resort(&mut self) {
+        debug_assert!(
+            self.defer_count > 0,
+            "release_defer_resort called without a matching bump_defer_resort",
+        );
+        self.defer_count = self.defer_count.saturating_sub(1);
+        self.propagate_defer_count();
+        if self.defer_count == 0 {
+            self.flush_dirty_caches();
+        }
+    }
+
+    fn propagate_defer_count(&mut self) {
+        let count = self.defer_count;
+        self.add.defer_count = count;
+        self.insert.defer_count = count;
+        self.discard.defer_count = count;
+        self.remove.defer_count = count;
+        self.despawn.defer_count = count;
+        for cache in self.cache.values_mut() {
+            cache.defer_count = count;
+        }
+    }
+
+    /// Sum of `rebuild_order` invocations across every observer cache.
+    /// Used by tests to assert that batch entry points coalesce resorts.
+    #[cfg(test)]
+    pub(crate) fn total_rebuild_order_calls(&self) -> u32 {
+        let mut total = self.add.rebuild_order_call_count
+            + self.insert.rebuild_order_call_count
+            + self.discard.rebuild_order_call_count
+            + self.remove.rebuild_order_call_count
+            + self.despawn.rebuild_order_call_count;
+        for cache in self.cache.values() {
+            total += cache.rebuild_order_call_count;
+        }
+        total
+    }
+
+    fn flush_dirty_caches(&mut self) {
+        self.add.resort();
+        self.insert.resort();
+        self.discard.resort();
+        self.remove.resort();
+        self.despawn.resort();
+        for cache in self.cache.values_mut() {
+            cache.resort();
         }
     }
 
@@ -324,6 +396,11 @@ pub struct CachedObservers {
     dispatch_order: Vec<Entity>,
     dirty: bool,
     next_sort_key: u64,
+    // When > 0, `resort()` short-circuits and the cache keeps `dirty` set
+    // until the deferral is released. Propagated from the parent `Observers`.
+    defer_count: u32,
+    #[cfg(test)]
+    rebuild_order_call_count: u32,
 }
 
 impl CachedObservers {
@@ -647,71 +724,10 @@ impl CachedObservers {
             .is_some_and(|bucket| !bucket.is_empty())
     }
 
-    pub(crate) fn clone_entity_observers(
-        &mut self,
-        source: Entity,
-        target: Entity,
-        components: &[ComponentId],
-    ) {
-        let mut changed = false;
-        if components.is_empty() {
-            if let Some(nodes) = self.by_entity.get(&source).cloned() {
-                let target_nodes = self.by_entity.entry(target).or_default();
-                for node_id in nodes {
-                    push_unique(target_nodes, node_id);
-                    changed = true;
-                }
-            }
-        } else {
-            for component in components {
-                let Some(bucket) = self.by_component.get_mut(component) else {
-                    continue;
-                };
-                let Some(nodes) = bucket.by_entity.get(&source).cloned() else {
-                    continue;
-                };
-                let target_nodes = bucket.by_entity.entry(target).or_default();
-                for node_id in nodes {
-                    push_unique(target_nodes, node_id);
-                    changed = true;
-                }
-            }
-        }
-
-        if changed {
-            self.dirty = true;
-            self.resort();
-        }
-    }
-
-    pub(crate) fn resort(&mut self) {
-        if !self.dirty {
-            return;
-        }
-
-        #[cfg(feature = "trace")]
-        let _span = {
-            let nodes = self.nodes.len();
-            let named = self.nodes.iter().filter(|node| node.name.is_some()).count();
-            tracing::trace_span!("observer_resort", nodes = nodes, named = named).entered()
-        };
-
-        let mut attempts = 0;
-        while self.dirty {
-            self.dirty = false;
-            self.rebuild_order();
-            self.sort_indices();
-
-            attempts += 1;
-            debug_assert!(attempts <= self.nodes.len().saturating_add(1));
-        }
-
-        #[cfg(debug_assertions)]
-        self.debug_assert_sorted_indices();
-    }
-
-    fn rebuild_order(&mut self) {
-        let insertion_order = self.insertion_order();
+    /// Build the topological ordering graph from explicit edges, intra-set
+    /// windows and cross-set edges. Used by `rebuild_order` to drive the
+    /// toposort and by test helpers below to assert the graph shape.
+    fn build_ordering_graph(&self, insertion_order: &[NodeId]) -> DiGraph<NodeId> {
         let mut graph = DiGraph::<NodeId>::with_capacity(
             self.nodes.len(),
             self.edges.len() + self.set_edges.len(),
@@ -751,6 +767,100 @@ impl CachedObservers {
             }
         }
 
+        graph
+    }
+
+    #[cfg(test)]
+    pub(crate) fn ordering_edge_count(&self) -> usize {
+        self.build_ordering_graph(&self.insertion_order())
+            .edge_count()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn contains_ordering_edge(&self, from: Entity, to: Entity) -> bool {
+        let Some(&from) = self.observer_to_node.get(&from) else {
+            return false;
+        };
+        let Some(&to) = self.observer_to_node.get(&to) else {
+            return false;
+        };
+
+        self.build_ordering_graph(&self.insertion_order())
+            .contains_edge(from, to)
+    }
+
+    pub(crate) fn clone_entity_observers(
+        &mut self,
+        source: Entity,
+        target: Entity,
+        components: &[ComponentId],
+    ) {
+        let mut changed = false;
+        if components.is_empty() {
+            if let Some(nodes) = self.by_entity.get(&source).cloned() {
+                let target_nodes = self.by_entity.entry(target).or_default();
+                for node_id in nodes {
+                    push_unique(target_nodes, node_id);
+                    changed = true;
+                }
+            }
+        } else {
+            for component in components {
+                let Some(bucket) = self.by_component.get_mut(component) else {
+                    continue;
+                };
+                let Some(nodes) = bucket.by_entity.get(&source).cloned() else {
+                    continue;
+                };
+                let target_nodes = bucket.by_entity.entry(target).or_default();
+                for node_id in nodes {
+                    push_unique(target_nodes, node_id);
+                    changed = true;
+                }
+            }
+        }
+
+        if changed {
+            self.dirty = true;
+            self.resort();
+        }
+    }
+
+    pub(crate) fn resort(&mut self) {
+        if !self.dirty || self.defer_count > 0 {
+            return;
+        }
+
+        #[cfg(feature = "trace")]
+        let _span = {
+            let nodes = self.nodes.len();
+            let named = self.nodes.iter().filter(|node| node.name.is_some()).count();
+            tracing::trace_span!("observer_resort", nodes = nodes, named = named).entered()
+        };
+
+        let mut attempts = 0;
+        while self.dirty {
+            self.dirty = false;
+            self.rebuild_order();
+            self.sort_indices();
+
+            attempts += 1;
+            debug_assert!(attempts <= self.nodes.len().saturating_add(1));
+        }
+
+        #[cfg(debug_assertions)]
+        self.debug_assert_sorted_indices();
+    }
+
+    fn rebuild_order(&mut self) {
+        #[cfg(test)]
+        {
+            self.rebuild_order_call_count = self.rebuild_order_call_count.saturating_add(1);
+        }
+
+        let insertion_order = self.insertion_order();
+        let graph = self.build_ordering_graph(&insertion_order);
+
         match graph.toposort(Vec::new()) {
             Ok(order) => {
                 debug_assert_eq!(order.len(), self.nodes.len());
@@ -758,9 +868,10 @@ impl CachedObservers {
                 self.refresh_dispatch_order();
             }
             Err(error) => {
-                let cycle_members = self.cycle_members(&error);
+                let cycle_members = self.cycle_members_with_names(&error);
                 warn!(
-                    "observer ordering graph contains a cycle involving {cycle_members:?}; falling back to registration order"
+                    "observer ordering graph contains a cycle involving {}; falling back to registration order",
+                    format_cycle_members(&cycle_members)
                 );
                 self.order = insertion_order;
                 self.refresh_dispatch_order();
@@ -837,21 +948,33 @@ impl CachedObservers {
             || self.sets.values().any(|nodes| nodes.len() > 1);
     }
 
-    fn cycle_members(&self, error: &DiGraphToposortError<NodeId>) -> Vec<Vec<Entity>> {
+    pub(crate) fn cycle_members_with_names(
+        &self,
+        error: &DiGraphToposortError<NodeId>,
+    ) -> Vec<Vec<(Entity, Option<&str>)>> {
         match error {
             DiGraphToposortError::Loop(node_id) => {
-                vec![vec![self.nodes[node_id.index()].observer]]
+                let node = &self.nodes[node_id.index()];
+                vec![vec![(node.observer, node.name.as_deref())]]
             }
             DiGraphToposortError::Cycle(cycles) => cycles
                 .iter()
                 .map(|cycle| {
                     cycle
                         .iter()
-                        .map(|node_id| self.nodes[node_id.index()].observer)
+                        .map(|node_id| {
+                            let node = &self.nodes[node_id.index()];
+                            (node.observer, node.name.as_deref())
+                        })
                         .collect()
                 })
                 .collect(),
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn observer_node_id(&self, observer: Entity) -> Option<NodeId> {
+        self.observer_to_node.get(&observer).copied()
     }
 
     fn remove_node(&mut self, node_id: NodeId) {
@@ -939,6 +1062,26 @@ impl CachedObservers {
             last_position = Some(position);
         }
     }
+}
+
+fn format_cycle_members(cycles: &[Vec<(Entity, Option<&str>)>]) -> String {
+    let mut formatted_cycles = Vec::with_capacity(cycles.len());
+
+    for cycle in cycles {
+        let mut formatted_cycle = Vec::with_capacity(cycle.len());
+        for (entity, name) in cycle {
+            let mut formatted = format!("{entity:?}");
+            if let Some(name) = name {
+                formatted.push_str(" [");
+                formatted.push_str(name);
+                formatted.push(']');
+            }
+            formatted_cycle.push(formatted);
+        }
+        formatted_cycles.push(formatted_cycle);
+    }
+
+    format!("{formatted_cycles:?}")
 }
 
 /// SAFETY: every `&[NodeId]` stream MUST be sorted ascending by the node's

--- a/crates/bevy_ecs/src/observer/centralized_storage.rs
+++ b/crates/bevy_ecs/src/observer/centralized_storage.rs
@@ -10,6 +10,7 @@
 
 use alloc::{vec, vec::Vec};
 use bevy_platform::collections::HashMap;
+use bevy_ptr::PtrMut;
 use log::{debug, warn};
 use smallvec::SmallVec;
 
@@ -21,7 +22,10 @@ use crate::{
     intern::Interned,
     observer::{EdgeTarget, ObserverDescriptor, ObserverRunner, ObserverSet},
     schedule::graph::{DiGraph, DiGraphToposortError, Direction, GraphNodeId},
+    world::DeferredWorld,
 };
+
+use super::TriggerContext;
 
 /// An internal lookup table tracking all of the observers in the world.
 ///
@@ -79,6 +83,22 @@ impl Observers {
             REMOVE => Some(&self.remove),
             DESPAWN => Some(&self.despawn),
             _ => self.cache.get(&event_key),
+        }
+    }
+
+    pub(crate) fn try_get_observers_mut(
+        &mut self,
+        event_key: EventKey,
+    ) -> Option<&mut CachedObservers> {
+        use crate::lifecycle::*;
+
+        match event_key {
+            ADD => Some(&mut self.add),
+            INSERT => Some(&mut self.insert),
+            REPLACE => Some(&mut self.replace),
+            REMOVE => Some(&mut self.remove),
+            DESPAWN => Some(&mut self.despawn),
+            _ => self.cache.get_mut(&event_key),
         }
     }
 
@@ -221,6 +241,12 @@ impl CachedObservers {
         &self.globals
     }
 
+    /// Observers watching for any time this event is triggered, regardless of target.
+    /// These will also respond to events targeting specific components or entities.
+    pub fn global_node_ids(&self) -> &[NodeId] {
+        &self.globals
+    }
+
     /// Returns observers watching for triggers of events for a specific component.
     pub fn component_observers(&self) -> &HashMap<ComponentId, ComponentBucket> {
         &self.by_component
@@ -229,6 +255,26 @@ impl CachedObservers {
     /// Returns observers watching for triggers of events for a specific entity.
     pub fn entity_observers(&self) -> &EntityHashMap<SmallVec<[NodeId; 2]>> {
         &self.by_entity
+    }
+
+    /// Returns observers watching for triggers of events for a specific entity.
+    pub fn entity_node_ids(&self, entity: Entity) -> &[NodeId] {
+        self.by_entity.get(&entity).map_or(&[], SmallVec::as_slice)
+    }
+
+    /// Returns observers watching for triggers of events for a specific component.
+    pub fn component_global_node_ids(&self, component: ComponentId) -> &[NodeId] {
+        self.by_component
+            .get(&component)
+            .map_or(&[], |bucket| bucket.globals.as_slice())
+    }
+
+    /// Returns observers watching for triggers of events for a specific component on a specific entity.
+    pub fn entity_component_node_ids(&self, component: ComponentId, entity: Entity) -> &[NodeId] {
+        self.by_component
+            .get(&component)
+            .and_then(|bucket| bucket.by_entity.get(&entity))
+            .map_or(&[], SmallVec::as_slice)
     }
 
     pub(crate) fn register_observer(
@@ -545,6 +591,107 @@ impl CachedObservers {
         }
         for nodes in self.sets.values() {
             debug_assert!(is_sorted_by_order(&positions, nodes));
+        }
+    }
+
+    #[cfg(debug_assertions)]
+    fn debug_assert_stream_sorted(&self, nodes: &[NodeId]) {
+        let mut last_position = None;
+        for node_id in nodes {
+            let position = self
+                .order
+                .iter()
+                .position(|ordered_id| ordered_id == node_id)
+                .unwrap_or(usize::MAX);
+            if let Some(last_position) = last_position {
+                debug_assert!(last_position <= position);
+            }
+            last_position = Some(position);
+        }
+    }
+}
+
+/// SAFETY: every `&[NodeId]` stream MUST be sorted ascending by the node's
+/// position in `cache.order`. Caller must hold the same pointer-validity
+/// invariants as the dispatch helpers in `event::trigger`.
+#[inline]
+pub(crate) unsafe fn run_ordered<const N: usize>(
+    cache: &CachedObservers,
+    world: &mut DeferredWorld,
+    trigger_context: &TriggerContext,
+    event: &mut PtrMut,
+    trigger: &mut PtrMut,
+    streams: [&[NodeId]; N],
+) {
+    #[cfg(debug_assertions)]
+    for stream in &streams {
+        cache.debug_assert_stream_sorted(stream);
+    }
+
+    if N == 1 {
+        for &node_id in streams[0] {
+            let node = cache.observer(node_id);
+            // SAFETY: The caller upholds the observer runner's safety contract.
+            unsafe {
+                (node.runner)(
+                    world.reborrow(),
+                    node.observer,
+                    trigger_context,
+                    event.reborrow(),
+                    trigger.reborrow(),
+                );
+            }
+        }
+        return;
+    }
+
+    if cache.edges.is_empty() {
+        for stream in streams {
+            for &node_id in stream {
+                let node = cache.observer(node_id);
+                // SAFETY: The caller upholds the observer runner's safety contract.
+                unsafe {
+                    (node.runner)(
+                        world.reborrow(),
+                        node.observer,
+                        trigger_context,
+                        event.reborrow(),
+                        trigger.reborrow(),
+                    );
+                }
+            }
+        }
+        return;
+    }
+
+    let mut indices = [0usize; N];
+
+    for &ordered_node_id in &cache.order {
+        let mut run_node = false;
+
+        for stream_index in 0..N {
+            let stream = streams[stream_index];
+            if stream
+                .get(indices[stream_index])
+                .is_some_and(|node_id| *node_id == ordered_node_id)
+            {
+                indices[stream_index] += 1;
+                run_node = true;
+            }
+        }
+
+        if run_node {
+            let node = cache.observer(ordered_node_id);
+            // SAFETY: The caller upholds the observer runner's safety contract.
+            unsafe {
+                (node.runner)(
+                    world.reborrow(),
+                    node.observer,
+                    trigger_context,
+                    event.reborrow(),
+                    trigger.reborrow(),
+                );
+            }
         }
     }
 }

--- a/crates/bevy_ecs/src/observer/centralized_storage.rs
+++ b/crates/bevy_ecs/src/observer/centralized_storage.rs
@@ -101,43 +101,23 @@ impl Observers {
         component_id: ComponentId,
         flags: &mut ArchetypeFlags,
     ) {
-        if self
-            .add
-            .component_observers_legacy
-            .contains_key(&component_id)
-        {
+        if self.add.contains_component_observers(component_id) {
             flags.insert(ArchetypeFlags::ON_ADD_OBSERVER);
         }
 
-        if self
-            .insert
-            .component_observers_legacy
-            .contains_key(&component_id)
-        {
+        if self.insert.contains_component_observers(component_id) {
             flags.insert(ArchetypeFlags::ON_INSERT_OBSERVER);
         }
 
-        if self
-            .discard
-            .component_observers_legacy
-            .contains_key(&component_id)
-        {
+        if self.discard.contains_component_observers(component_id) {
             flags.insert(ArchetypeFlags::ON_DISCARD_OBSERVER);
         }
 
-        if self
-            .remove
-            .component_observers_legacy
-            .contains_key(&component_id)
-        {
+        if self.remove.contains_component_observers(component_id) {
             flags.insert(ArchetypeFlags::ON_REMOVE_OBSERVER);
         }
 
-        if self
-            .despawn
-            .component_observers_legacy
-            .contains_key(&component_id)
-        {
+        if self.despawn.contains_component_observers(component_id) {
             flags.insert(ArchetypeFlags::ON_DESPAWN_OBSERVER);
         }
     }
@@ -258,6 +238,8 @@ impl CachedObservers {
         self.next_sort_key = self.next_sort_key.wrapping_add(1);
         self.observer_to_node.insert(observer, node_id);
 
+        let mut newly_observed_components = SmallVec::new();
+
         if descriptor.components.is_empty() && descriptor.entities.is_empty() {
             push_unique(&mut self.globals, node_id);
         } else if descriptor.components.is_empty() {
@@ -266,6 +248,7 @@ impl CachedObservers {
             }
         } else {
             for &component in &descriptor.components {
+                let was_empty = !self.by_component.contains_key(&component);
                 let bucket = self.by_component.entry(component).or_default();
                 if descriptor.entities.is_empty() {
                     push_unique(&mut bucket.globals, node_id);
@@ -273,6 +256,9 @@ impl CachedObservers {
                     for &watched_entity in &descriptor.entities {
                         push_unique(bucket.by_entity.entry(watched_entity).or_default(), node_id);
                     }
+                }
+                if was_empty {
+                    push_unique_component(&mut newly_observed_components, component);
                 }
             }
         }
@@ -292,12 +278,6 @@ impl CachedObservers {
         self.dirty = true;
         self.resort();
 
-        let mut newly_observed_components = SmallVec::new();
-        for &component in &descriptor.components {
-            if self.by_component.contains_key(&component) {
-                push_unique_component(&mut newly_observed_components, component);
-            }
-        }
         newly_observed_components
     }
 
@@ -346,14 +326,47 @@ impl CachedObservers {
         removed_components
     }
 
-    #[expect(
-        dead_code,
-        reason = "The new component-observer check is used after the register/unregister cutover."
-    )]
     pub(crate) fn contains_component_observers(&self, component_id: ComponentId) -> bool {
         self.by_component
             .get(&component_id)
             .is_some_and(|bucket| !bucket.is_empty())
+    }
+
+    pub(crate) fn clone_entity_observers(
+        &mut self,
+        source: Entity,
+        target: Entity,
+        components: &[ComponentId],
+    ) {
+        let mut changed = false;
+        if components.is_empty() {
+            if let Some(nodes) = self.by_entity.get(&source).cloned() {
+                let target_nodes = self.by_entity.entry(target).or_default();
+                for node_id in nodes {
+                    push_unique(target_nodes, node_id);
+                    changed = true;
+                }
+            }
+        } else {
+            for component in components {
+                let Some(bucket) = self.by_component.get_mut(component) else {
+                    continue;
+                };
+                let Some(nodes) = bucket.by_entity.get(&source).cloned() else {
+                    continue;
+                };
+                let target_nodes = bucket.by_entity.entry(target).or_default();
+                for node_id in nodes {
+                    push_unique(target_nodes, node_id);
+                    changed = true;
+                }
+            }
+        }
+
+        if changed {
+            self.dirty = true;
+            self.resort();
+        }
     }
 
     pub(crate) fn resort(&mut self) {
@@ -366,6 +379,7 @@ impl CachedObservers {
             self.dirty = false;
             self.rebuild_order();
             self.sort_indices();
+            self.rebuild_legacy_views();
 
             attempts += 1;
             debug_assert!(attempts <= self.nodes.len().saturating_add(1));
@@ -501,6 +515,38 @@ impl CachedObservers {
         }
     }
 
+    fn rebuild_legacy_views(&mut self) {
+        self.global_observers_legacy = legacy_map_for(&self.nodes, &self.globals);
+
+        self.entity_observers_legacy.clear();
+        for (&entity, nodes) in &self.by_entity {
+            let map = legacy_map_for(&self.nodes, nodes);
+            if !map.is_empty() {
+                self.entity_observers_legacy.insert(entity, map);
+            }
+        }
+
+        self.component_observers_legacy.clear();
+        for (&component, bucket) in &self.by_component {
+            let mut component_observers = CachedComponentObservers::default();
+            component_observers.global_observers = legacy_map_for(&self.nodes, &bucket.globals);
+            for (&entity, nodes) in &bucket.by_entity {
+                let map = legacy_map_for(&self.nodes, nodes);
+                if !map.is_empty() {
+                    component_observers
+                        .entity_component_observers
+                        .insert(entity, map);
+                }
+            }
+            if !component_observers.global_observers.is_empty()
+                || !component_observers.entity_component_observers.is_empty()
+            {
+                self.component_observers_legacy
+                    .insert(component, component_observers);
+            }
+        }
+    }
+
     #[cfg(debug_assertions)]
     fn debug_assert_sorted_indices(&self) {
         let mut positions = vec![usize::MAX; self.nodes.len()];
@@ -548,6 +594,19 @@ impl CachedComponentObservers {
     pub fn entity_component_observers(&self) -> &EntityHashMap<ObserverMap> {
         &self.entity_component_observers
     }
+}
+
+fn legacy_map_for<const N: usize>(
+    nodes: &[ObserverNode],
+    node_ids: &SmallVec<[NodeId; N]>,
+) -> ObserverMap {
+    node_ids
+        .iter()
+        .map(|node_id| {
+            let node = nodes[node_id.index()];
+            (node.observer, node.runner)
+        })
+        .collect()
 }
 
 fn push_unique<const N: usize>(nodes: &mut SmallVec<[NodeId; N]>, node_id: NodeId) {

--- a/crates/bevy_ecs/src/observer/centralized_storage.rs
+++ b/crates/bevy_ecs/src/observer/centralized_storage.rs
@@ -10,10 +10,12 @@
 //!     - [`CachedComponentObservers`] is one of these maps, which contains observers that are specifically targeted at a component.
 
 use bevy_platform::collections::HashMap;
+use smallvec::SmallVec;
 
 use crate::{
     archetype::ArchetypeFlags, component::ComponentId, entity::EntityHashMap, event::EventKey,
-    observer::ObserverRunner,
+    intern::Interned,
+    observer::{ObserverRunner, ObserverSet},
 };
 
 /// An internal lookup table tracking all of the observers in the world.
@@ -33,6 +35,9 @@ pub struct Observers {
     despawn: CachedObservers,
     // Map from event type to set of observers watching for that event
     cache: HashMap<EventKey, CachedObservers>,
+    // Observer set hierarchy declarations. Populated by observer set configuration in a later phase.
+    #[expect(dead_code, reason = "Observer set dispatch is wired in a later phase.")]
+    set_hierarchy: HashMap<Interned<dyn ObserverSet>, SmallVec<[Interned<dyn ObserverSet>; 2]>>,
 }
 
 impl Observers {

--- a/crates/bevy_ecs/src/observer/centralized_storage.rs
+++ b/crates/bevy_ecs/src/observer/centralized_storage.rs
@@ -9,13 +9,17 @@
 //!     - These are split by target type, in order to allow for different lookup strategies.
 //!     - [`CachedComponentObservers`] is one of these maps, which contains observers that are specifically targeted at a component.
 
+use alloc::{vec, vec::Vec};
 use bevy_platform::collections::HashMap;
 use smallvec::SmallVec;
 
 use crate::{
-    archetype::ArchetypeFlags, component::ComponentId, entity::EntityHashMap, event::EventKey,
+    archetype::ArchetypeFlags,
+    component::ComponentId,
+    entity::{Entity, EntityHashMap},
+    event::EventKey,
     intern::Interned,
-    observer::{ObserverRunner, ObserverSet},
+    observer::{EdgeTarget, ObserverDescriptor, ObserverRunner, ObserverSet},
 };
 
 /// An internal lookup table tracking all of the observers in the world.
@@ -95,25 +99,99 @@ impl Observers {
         component_id: ComponentId,
         flags: &mut ArchetypeFlags,
     ) {
-        if self.add.component_observers.contains_key(&component_id) {
+        if self
+            .add
+            .component_observers_legacy
+            .contains_key(&component_id)
+        {
             flags.insert(ArchetypeFlags::ON_ADD_OBSERVER);
         }
 
-        if self.insert.component_observers.contains_key(&component_id) {
+        if self
+            .insert
+            .component_observers_legacy
+            .contains_key(&component_id)
+        {
             flags.insert(ArchetypeFlags::ON_INSERT_OBSERVER);
         }
 
-        if self.discard.component_observers.contains_key(&component_id) {
+        if self
+            .discard
+            .component_observers_legacy
+            .contains_key(&component_id)
+        {
             flags.insert(ArchetypeFlags::ON_DISCARD_OBSERVER);
         }
 
-        if self.remove.component_observers.contains_key(&component_id) {
+        if self
+            .remove
+            .component_observers_legacy
+            .contains_key(&component_id)
+        {
             flags.insert(ArchetypeFlags::ON_REMOVE_OBSERVER);
         }
 
-        if self.despawn.component_observers.contains_key(&component_id) {
+        if self
+            .despawn
+            .component_observers_legacy
+            .contains_key(&component_id)
+        {
             flags.insert(ArchetypeFlags::ON_DESPAWN_OBSERVER);
         }
+    }
+}
+
+/// Identifier for an observer node in [`CachedObservers`].
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct NodeId(u32);
+
+impl NodeId {
+    fn new(index: usize) -> Self {
+        debug_assert!(u32::try_from(index).is_ok());
+        Self(index as u32)
+    }
+
+    fn index(self) -> usize {
+        self.0 as usize
+    }
+}
+
+/// Observer data stored once per registered observer/event-key pair.
+#[derive(Clone, Copy, Debug)]
+pub struct ObserverNode {
+    /// The entity that owns the observer component.
+    pub observer: Entity,
+    /// The function used to run the observer.
+    pub runner: ObserverRunner,
+    sort_key: u64,
+}
+
+/// An ordering edge stored in event-local observer storage.
+#[derive(Clone, Debug)]
+pub struct ObserverEdgeResolved {
+    owner: Entity,
+    #[expect(
+        dead_code,
+        reason = "Observer edge sorting is wired in the graph-sort phase."
+    )]
+    from: EdgeTarget,
+    #[expect(
+        dead_code,
+        reason = "Observer edge sorting is wired in the graph-sort phase."
+    )]
+    to: EdgeTarget,
+}
+
+/// Per-component observer indices.
+#[derive(Default, Debug)]
+pub struct ComponentBucket {
+    globals: SmallVec<[NodeId; 2]>,
+    by_entity: EntityHashMap<SmallVec<[NodeId; 2]>>,
+}
+
+impl ComponentBucket {
+    fn is_empty(&self) -> bool {
+        self.globals.is_empty() && self.by_entity.is_empty()
     }
 }
 
@@ -124,28 +202,241 @@ impl Observers {
 pub struct CachedObservers {
     /// Observers watching for any time this event is triggered, regardless of target.
     /// These will also respond to events targeting specific components or entities
-    pub(super) global_observers: ObserverMap,
+    pub(super) global_observers_legacy: ObserverMap,
     /// Observers watching for triggers of events for a specific component
-    pub(super) component_observers: HashMap<ComponentId, CachedComponentObservers>,
+    pub(super) component_observers_legacy: HashMap<ComponentId, CachedComponentObservers>,
     /// Observers watching for triggers of events for a specific entity
-    pub(super) entity_observers: EntityHashMap<ObserverMap>,
+    pub(super) entity_observers_legacy: EntityHashMap<ObserverMap>,
+    nodes: Vec<ObserverNode>,
+    order: Vec<NodeId>,
+    globals: SmallVec<[NodeId; 4]>,
+    by_entity: EntityHashMap<SmallVec<[NodeId; 2]>>,
+    by_component: HashMap<ComponentId, ComponentBucket>,
+    sets: HashMap<Interned<dyn ObserverSet>, SmallVec<[NodeId; 4]>>,
+    edges: Vec<ObserverEdgeResolved>,
+    observer_to_node: EntityHashMap<NodeId>,
+    dirty: bool,
+    next_sort_key: u64,
 }
 
 impl CachedObservers {
     /// Observers watching for any time this event is triggered, regardless of target.
     /// These will also respond to events targeting specific components or entities
     pub fn global_observers(&self) -> &ObserverMap {
-        &self.global_observers
+        &self.global_observers_legacy
     }
 
     /// Returns observers watching for triggers of events for a specific component.
     pub fn component_observers(&self) -> &HashMap<ComponentId, CachedComponentObservers> {
-        &self.component_observers
+        &self.component_observers_legacy
     }
 
     /// Returns observers watching for triggers of events for a specific entity.
     pub fn entity_observers(&self) -> &EntityHashMap<ObserverMap> {
-        &self.entity_observers
+        &self.entity_observers_legacy
+    }
+
+    pub(crate) fn register_observer(
+        &mut self,
+        observer: Entity,
+        runner: ObserverRunner,
+        descriptor: &ObserverDescriptor,
+    ) -> SmallVec<[ComponentId; 4]> {
+        if self.observer_to_node.contains_key(&observer) {
+            self.unregister_observer(observer, descriptor);
+        }
+
+        let node_id = NodeId::new(self.nodes.len());
+        self.nodes.push(ObserverNode {
+            observer,
+            runner,
+            sort_key: self.next_sort_key,
+        });
+        self.next_sort_key = self.next_sort_key.wrapping_add(1);
+        self.observer_to_node.insert(observer, node_id);
+
+        if descriptor.components.is_empty() && descriptor.entities.is_empty() {
+            push_unique(&mut self.globals, node_id);
+        } else if descriptor.components.is_empty() {
+            for &watched_entity in &descriptor.entities {
+                push_unique(self.by_entity.entry(watched_entity).or_default(), node_id);
+            }
+        } else {
+            for &component in &descriptor.components {
+                let bucket = self.by_component.entry(component).or_default();
+                if descriptor.entities.is_empty() {
+                    push_unique(&mut bucket.globals, node_id);
+                } else {
+                    for &watched_entity in &descriptor.entities {
+                        push_unique(bucket.by_entity.entry(watched_entity).or_default(), node_id);
+                    }
+                }
+            }
+        }
+
+        for &set in &descriptor.sets {
+            push_unique(self.sets.entry(set).or_default(), node_id);
+        }
+
+        for edge in &descriptor.edges {
+            self.edges.push(ObserverEdgeResolved {
+                owner: observer,
+                from: edge.from.clone(),
+                to: edge.to.clone(),
+            });
+        }
+
+        self.dirty = true;
+        self.resort();
+
+        let mut newly_observed_components = SmallVec::new();
+        for &component in &descriptor.components {
+            if self.by_component.contains_key(&component) {
+                push_unique_component(&mut newly_observed_components, component);
+            }
+        }
+        newly_observed_components
+    }
+
+    pub(crate) fn unregister_observer(
+        &mut self,
+        observer: Entity,
+        descriptor: &ObserverDescriptor,
+    ) -> SmallVec<[ComponentId; 4]> {
+        let Some(node_id) = self.observer_to_node.remove(&observer) else {
+            return SmallVec::new();
+        };
+
+        remove_node_id(&mut self.globals, node_id);
+        remove_node_id_from_entity_map(&mut self.by_entity, node_id, &descriptor.entities);
+
+        let mut removed_components = SmallVec::new();
+        for &component in &descriptor.components {
+            let Some(bucket) = self.by_component.get_mut(&component) else {
+                continue;
+            };
+
+            remove_node_id(&mut bucket.globals, node_id);
+            remove_node_id_from_entity_map(&mut bucket.by_entity, node_id, &descriptor.entities);
+
+            if bucket.is_empty() {
+                self.by_component.remove(&component);
+                push_unique_component(&mut removed_components, component);
+            }
+        }
+
+        for set in &descriptor.sets {
+            let Some(nodes) = self.sets.get_mut(set) else {
+                continue;
+            };
+            remove_node_id(nodes, node_id);
+            if nodes.is_empty() {
+                self.sets.remove(set);
+            }
+        }
+
+        self.edges.retain(|edge| edge.owner != observer);
+        self.remove_node(node_id);
+        self.dirty = true;
+        self.resort();
+
+        removed_components
+    }
+
+    #[expect(
+        dead_code,
+        reason = "The new component-observer check is used after the register/unregister cutover."
+    )]
+    pub(crate) fn contains_component_observers(&self, component_id: ComponentId) -> bool {
+        self.by_component
+            .get(&component_id)
+            .is_some_and(|bucket| !bucket.is_empty())
+    }
+
+    pub(crate) fn resort(&mut self) {
+        if !self.dirty {
+            return;
+        }
+
+        self.order.clear();
+        self.order.extend((0..self.nodes.len()).map(NodeId::new));
+        self.order
+            .sort_by_key(|node_id| self.nodes[node_id.index()].sort_key);
+        self.sort_indices();
+        self.dirty = false;
+
+        #[cfg(debug_assertions)]
+        self.debug_assert_sorted_indices();
+    }
+
+    fn remove_node(&mut self, node_id: NodeId) {
+        let index = node_id.index();
+        let last_index = self.nodes.len() - 1;
+        self.nodes.swap_remove(index);
+
+        if index != last_index {
+            let moved_from = NodeId::new(last_index);
+            let moved_to = node_id;
+            self.observer_to_node
+                .insert(self.nodes[index].observer, moved_to);
+            self.replace_node_id(moved_from, moved_to);
+        }
+    }
+
+    fn replace_node_id(&mut self, from: NodeId, to: NodeId) {
+        replace_node_id(&mut self.order, from, to);
+        replace_node_id(&mut self.globals, from, to);
+        replace_node_id_in_entity_map(&mut self.by_entity, from, to);
+
+        for bucket in self.by_component.values_mut() {
+            replace_node_id(&mut bucket.globals, from, to);
+            replace_node_id_in_entity_map(&mut bucket.by_entity, from, to);
+        }
+
+        for nodes in self.sets.values_mut() {
+            replace_node_id(nodes, from, to);
+        }
+    }
+
+    fn sort_indices(&mut self) {
+        let mut positions = vec![usize::MAX; self.nodes.len()];
+        for (position, node_id) in self.order.iter().copied().enumerate() {
+            positions[node_id.index()] = position;
+        }
+
+        sort_node_ids(&positions, &mut self.globals);
+        sort_entity_map_node_ids(&positions, &mut self.by_entity);
+
+        for bucket in self.by_component.values_mut() {
+            sort_node_ids(&positions, &mut bucket.globals);
+            sort_entity_map_node_ids(&positions, &mut bucket.by_entity);
+        }
+
+        for nodes in self.sets.values_mut() {
+            sort_node_ids(&positions, nodes);
+        }
+    }
+
+    #[cfg(debug_assertions)]
+    fn debug_assert_sorted_indices(&self) {
+        let mut positions = vec![usize::MAX; self.nodes.len()];
+        for (position, node_id) in self.order.iter().copied().enumerate() {
+            positions[node_id.index()] = position;
+        }
+
+        debug_assert!(is_sorted_by_order(&positions, &self.globals));
+        for nodes in self.by_entity.values() {
+            debug_assert!(is_sorted_by_order(&positions, nodes));
+        }
+        for bucket in self.by_component.values() {
+            debug_assert!(is_sorted_by_order(&positions, &bucket.globals));
+            for nodes in bucket.by_entity.values() {
+                debug_assert!(is_sorted_by_order(&positions, nodes));
+            }
+        }
+        for nodes in self.sets.values() {
+            debug_assert!(is_sorted_by_order(&positions, nodes));
+        }
     }
 }
 
@@ -173,4 +464,74 @@ impl CachedComponentObservers {
     pub fn entity_component_observers(&self) -> &EntityHashMap<ObserverMap> {
         &self.entity_component_observers
     }
+}
+
+fn push_unique<const N: usize>(nodes: &mut SmallVec<[NodeId; N]>, node_id: NodeId) {
+    if !nodes.contains(&node_id) {
+        nodes.push(node_id);
+    }
+}
+
+fn push_unique_component(components: &mut SmallVec<[ComponentId; 4]>, component_id: ComponentId) {
+    if !components.contains(&component_id) {
+        components.push(component_id);
+    }
+}
+
+fn remove_node_id<const N: usize>(nodes: &mut SmallVec<[NodeId; N]>, node_id: NodeId) {
+    nodes.retain(|id| *id != node_id);
+}
+
+fn remove_node_id_from_entity_map(
+    by_entity: &mut EntityHashMap<SmallVec<[NodeId; 2]>>,
+    node_id: NodeId,
+    entities: &[Entity],
+) {
+    for entity in entities {
+        let Some(nodes) = by_entity.get_mut(entity) else {
+            continue;
+        };
+        remove_node_id(nodes, node_id);
+        if nodes.is_empty() {
+            by_entity.remove(entity);
+        }
+    }
+}
+
+fn replace_node_id(nodes: &mut [NodeId], from: NodeId, to: NodeId) {
+    for node_id in nodes {
+        if *node_id == from {
+            *node_id = to;
+        }
+    }
+}
+
+fn replace_node_id_in_entity_map(
+    by_entity: &mut EntityHashMap<SmallVec<[NodeId; 2]>>,
+    from: NodeId,
+    to: NodeId,
+) {
+    for nodes in by_entity.values_mut() {
+        replace_node_id(nodes, from, to);
+    }
+}
+
+fn sort_node_ids<const N: usize>(positions: &[usize], nodes: &mut SmallVec<[NodeId; N]>) {
+    nodes.sort_by_key(|node_id| positions[node_id.index()]);
+}
+
+fn sort_entity_map_node_ids(
+    positions: &[usize],
+    by_entity: &mut EntityHashMap<SmallVec<[NodeId; 2]>>,
+) {
+    for nodes in by_entity.values_mut() {
+        sort_node_ids(positions, nodes);
+    }
+}
+
+#[cfg(debug_assertions)]
+fn is_sorted_by_order<const N: usize>(positions: &[usize], nodes: &SmallVec<[NodeId; N]>) -> bool {
+    nodes
+        .windows(2)
+        .all(|window| positions[window[0].index()] <= positions[window[1].index()])
 }

--- a/crates/bevy_ecs/src/observer/centralized_storage.rs
+++ b/crates/bevy_ecs/src/observer/centralized_storage.rs
@@ -5,9 +5,8 @@
 //! - [`Observers`] contains multiple distinct caches in the form of [`CachedObservers`].
 //!     - Most observers are looked up by the [`ComponentId`] of the event they are observing
 //!     - Lifecycle observers have their own fields to save lookups.
-//! - [`CachedObservers`] contains maps of [`ObserverRunner`]s, which are the actual functions that will be run when the observer is triggered.
+//! - [`CachedObservers`] contains a sorted node table of [`ObserverRunner`]s, which are the actual functions that will be run when the observer is triggered.
 //!     - These are split by target type, in order to allow for different lookup strategies.
-//!     - [`CachedComponentObservers`] is one of these maps, which contains observers that are specifically targeted at a component.
 
 use alloc::{vec, vec::Vec};
 use bevy_platform::collections::HashMap;
@@ -173,6 +172,16 @@ pub struct ComponentBucket {
 }
 
 impl ComponentBucket {
+    /// Observers watching for this component regardless of entity target.
+    pub fn global_observers(&self) -> &[NodeId] {
+        &self.globals
+    }
+
+    /// Observers watching for this component on a specific entity.
+    pub fn entity_component_observers(&self) -> &EntityHashMap<SmallVec<[NodeId; 2]>> {
+        &self.by_entity
+    }
+
     fn is_empty(&self) -> bool {
         self.globals.is_empty() && self.by_entity.is_empty()
     }
@@ -183,13 +192,6 @@ impl ComponentBucket {
 /// This is stored inside of [`Observers`], specialized for each kind of observer.
 #[derive(Default, Debug)]
 pub struct CachedObservers {
-    /// Observers watching for any time this event is triggered, regardless of target.
-    /// These will also respond to events targeting specific components or entities
-    pub(super) global_observers_legacy: ObserverMap,
-    /// Observers watching for triggers of events for a specific component
-    pub(super) component_observers_legacy: HashMap<ComponentId, CachedComponentObservers>,
-    /// Observers watching for triggers of events for a specific entity
-    pub(super) entity_observers_legacy: EntityHashMap<ObserverMap>,
     nodes: Vec<ObserverNode>,
     order: Vec<NodeId>,
     globals: SmallVec<[NodeId; 4]>,
@@ -203,20 +205,30 @@ pub struct CachedObservers {
 }
 
 impl CachedObservers {
+    /// Returns the observer node table.
+    pub fn nodes(&self) -> &[ObserverNode] {
+        &self.nodes
+    }
+
+    /// Returns the observer node for `node_id`.
+    pub fn observer(&self, node_id: NodeId) -> &ObserverNode {
+        &self.nodes[node_id.index()]
+    }
+
     /// Observers watching for any time this event is triggered, regardless of target.
     /// These will also respond to events targeting specific components or entities
-    pub fn global_observers(&self) -> &ObserverMap {
-        &self.global_observers_legacy
+    pub fn global_observers(&self) -> &[NodeId] {
+        &self.globals
     }
 
     /// Returns observers watching for triggers of events for a specific component.
-    pub fn component_observers(&self) -> &HashMap<ComponentId, CachedComponentObservers> {
-        &self.component_observers_legacy
+    pub fn component_observers(&self) -> &HashMap<ComponentId, ComponentBucket> {
+        &self.by_component
     }
 
     /// Returns observers watching for triggers of events for a specific entity.
-    pub fn entity_observers(&self) -> &EntityHashMap<ObserverMap> {
-        &self.entity_observers_legacy
+    pub fn entity_observers(&self) -> &EntityHashMap<SmallVec<[NodeId; 2]>> {
+        &self.by_entity
     }
 
     pub(crate) fn register_observer(
@@ -379,7 +391,6 @@ impl CachedObservers {
             self.dirty = false;
             self.rebuild_order();
             self.sort_indices();
-            self.rebuild_legacy_views();
 
             attempts += 1;
             debug_assert!(attempts <= self.nodes.len().saturating_add(1));
@@ -515,38 +526,6 @@ impl CachedObservers {
         }
     }
 
-    fn rebuild_legacy_views(&mut self) {
-        self.global_observers_legacy = legacy_map_for(&self.nodes, &self.globals);
-
-        self.entity_observers_legacy.clear();
-        for (&entity, nodes) in &self.by_entity {
-            let map = legacy_map_for(&self.nodes, nodes);
-            if !map.is_empty() {
-                self.entity_observers_legacy.insert(entity, map);
-            }
-        }
-
-        self.component_observers_legacy.clear();
-        for (&component, bucket) in &self.by_component {
-            let mut component_observers = CachedComponentObservers::default();
-            component_observers.global_observers = legacy_map_for(&self.nodes, &bucket.globals);
-            for (&entity, nodes) in &bucket.by_entity {
-                let map = legacy_map_for(&self.nodes, nodes);
-                if !map.is_empty() {
-                    component_observers
-                        .entity_component_observers
-                        .insert(entity, map);
-                }
-            }
-            if !component_observers.global_observers.is_empty()
-                || !component_observers.entity_component_observers.is_empty()
-            {
-                self.component_observers_legacy
-                    .insert(component, component_observers);
-            }
-        }
-    }
-
     #[cfg(debug_assertions)]
     fn debug_assert_sorted_indices(&self) {
         let mut positions = vec![usize::MAX; self.nodes.len()];
@@ -568,45 +547,6 @@ impl CachedObservers {
             debug_assert!(is_sorted_by_order(&positions, nodes));
         }
     }
-}
-
-/// Map between an observer entity and its [`ObserverRunner`]
-pub type ObserverMap = EntityHashMap<ObserverRunner>;
-
-/// Collection of [`ObserverRunner`] for [`Observer`](crate::observer::Observer) registered to a particular event targeted at a specific component.
-///
-/// This is stored inside of [`CachedObservers`].
-#[derive(Default, Debug)]
-pub struct CachedComponentObservers {
-    // Observers watching for events targeting this component, but not a specific entity
-    pub(super) global_observers: ObserverMap,
-    // Observers watching for events targeting this component on a specific entity
-    pub(super) entity_component_observers: EntityHashMap<ObserverMap>,
-}
-
-impl CachedComponentObservers {
-    /// Returns observers watching for events targeting this component, but not a specific entity
-    pub fn global_observers(&self) -> &ObserverMap {
-        &self.global_observers
-    }
-
-    /// Returns observers watching for events targeting this component on a specific entity
-    pub fn entity_component_observers(&self) -> &EntityHashMap<ObserverMap> {
-        &self.entity_component_observers
-    }
-}
-
-fn legacy_map_for<const N: usize>(
-    nodes: &[ObserverNode],
-    node_ids: &SmallVec<[NodeId; N]>,
-) -> ObserverMap {
-    node_ids
-        .iter()
-        .map(|node_id| {
-            let node = nodes[node_id.index()];
-            (node.observer, node.runner)
-        })
-        .collect()
 }
 
 fn push_unique<const N: usize>(nodes: &mut SmallVec<[NodeId; N]>, node_id: NodeId) {

--- a/crates/bevy_ecs/src/observer/centralized_storage.rs
+++ b/crates/bevy_ecs/src/observer/centralized_storage.rs
@@ -95,7 +95,7 @@ impl Observers {
         match event_key {
             ADD => Some(&mut self.add),
             INSERT => Some(&mut self.insert),
-            REPLACE => Some(&mut self.replace),
+            DISCARD => Some(&mut self.discard),
             REMOVE => Some(&mut self.remove),
             DESPAWN => Some(&mut self.despawn),
             _ => self.cache.get_mut(&event_key),

--- a/crates/bevy_ecs/src/observer/centralized_storage.rs
+++ b/crates/bevy_ecs/src/observer/centralized_storage.rs
@@ -202,7 +202,10 @@ impl Observers {
     }
 
     /// Returns observer entities and optional names for `event_key` in dispatch order.
-    pub fn dispatch_order_for_with_names(&self, event_key: EventKey) -> Vec<(Entity, Option<&str>)> {
+    pub fn dispatch_order_for_with_names(
+        &self,
+        event_key: EventKey,
+    ) -> Vec<(Entity, Option<&str>)> {
         self.try_get_observers(event_key)
             .map_or_else(Vec::new, CachedObservers::dispatch_order_for_with_names)
     }
@@ -475,7 +478,6 @@ impl CachedObservers {
         }
     }
 
-
     pub(crate) fn register_observer(
         &mut self,
         observer: Entity,
@@ -655,8 +657,10 @@ impl CachedObservers {
 
     fn rebuild_order(&mut self) {
         let insertion_order = self.insertion_order();
-        let mut graph =
-            DiGraph::<NodeId>::with_capacity(self.nodes.len(), self.edges.len() + self.set_edges.len());
+        let mut graph = DiGraph::<NodeId>::with_capacity(
+            self.nodes.len(),
+            self.edges.len() + self.set_edges.len(),
+        );
 
         for &node_id in insertion_order.iter().rev() {
             graph.add_node(node_id);
@@ -737,10 +741,7 @@ impl CachedObservers {
         }
     }
 
-    fn resolve_set_target(
-        &self,
-        set: &Interned<dyn ObserverSet>,
-    ) -> SmallVec<[NodeId; 4]> {
+    fn resolve_set_target(&self, set: &Interned<dyn ObserverSet>) -> SmallVec<[NodeId; 4]> {
         let mut resolved = SmallVec::new();
         let mut visited = Vec::new();
         let mut stack = vec![*set];

--- a/crates/bevy_ecs/src/observer/centralized_storage.rs
+++ b/crates/bevy_ecs/src/observer/centralized_storage.rs
@@ -255,6 +255,7 @@ impl Observers {
     }
 
     /// Returns observer entities in `set` for `event_key` in dispatch order.
+    /// Diagnostic helper: allocates a `Vec` per call. Not for hot paths.
     pub fn dispatch_order_for_set<S: IntoObserverOrderingTarget>(
         &self,
         event_key: EventKey,
@@ -268,12 +269,14 @@ impl Observers {
     }
 
     /// Returns observers for `target` and `event_key` in dispatch order.
+    /// Diagnostic helper: allocates a `Vec` per call. Not for hot paths.
     pub fn dispatch_order_for_target(&self, event_key: EventKey, target: Entity) -> Vec<Entity> {
         self.try_get_observers(event_key)
             .map_or_else(Vec::new, |cache| cache.dispatch_order_for_target(target))
     }
 
     /// Returns observer entities and optional names for `event_key` in dispatch order.
+    /// Diagnostic helper: allocates a `Vec` per call. Not for hot paths.
     pub fn dispatch_order_for_with_names(
         &self,
         event_key: EventKey,
@@ -283,6 +286,7 @@ impl Observers {
     }
 
     /// Returns named dispatch-order diagnostics for observers in `set`.
+    /// Diagnostic helper: allocates a `Vec` per call. Not for hot paths.
     pub fn dispatch_order_for_set_with_names<S: IntoObserverOrderingTarget>(
         &self,
         event_key: EventKey,
@@ -298,6 +302,7 @@ impl Observers {
     }
 
     /// Returns named dispatch-order diagnostics for observers watching `target`.
+    /// Diagnostic helper: allocates a `Vec` per call. Not for hot paths.
     pub fn dispatch_order_for_target_with_names(
         &self,
         event_key: EventKey,
@@ -517,6 +522,7 @@ impl CachedObservers {
     }
 
     /// Returns observer entities in `set` in dispatch order.
+    /// Diagnostic helper: allocates a `Vec` per call. Not for hot paths.
     pub fn dispatch_order_for_set(&self, set: Interned<dyn ObserverSet>) -> Vec<Entity> {
         let nodes = self.resolve_set_target(&set);
         self.order
@@ -527,6 +533,7 @@ impl CachedObservers {
     }
 
     /// Returns observer entities watching `target` in dispatch order.
+    /// Diagnostic helper: allocates a `Vec` per call. Not for hot paths.
     pub fn dispatch_order_for_target(&self, target: Entity) -> Vec<Entity> {
         self.by_entity
             .get(&target)
@@ -537,6 +544,7 @@ impl CachedObservers {
     }
 
     /// Returns observer entities and optional names in dispatch order.
+    /// Diagnostic helper: allocates a `Vec` per call. Not for hot paths.
     pub fn dispatch_order_for_with_names(&self) -> Vec<(Entity, Option<&str>)> {
         self.order
             .iter()
@@ -548,6 +556,7 @@ impl CachedObservers {
     }
 
     /// Returns named diagnostics for observer entities in `set` in dispatch order.
+    /// Diagnostic helper: allocates a `Vec` per call. Not for hot paths.
     pub fn dispatch_order_for_set_with_names(
         &self,
         set: Interned<dyn ObserverSet>,
@@ -564,6 +573,7 @@ impl CachedObservers {
     }
 
     /// Returns named diagnostics for observer entities watching `target` in dispatch order.
+    /// Diagnostic helper: allocates a `Vec` per call. Not for hot paths.
     pub fn dispatch_order_for_target_with_names(
         &self,
         target: Entity,
@@ -909,14 +919,14 @@ impl CachedObservers {
 
     fn resolve_set_target(&self, set: &Interned<dyn ObserverSet>) -> SmallVec<[NodeId; 4]> {
         let mut resolved = SmallVec::new();
-        let mut visited = Vec::new();
+        let mut visited = HashSet::<Interned<dyn ObserverSet>>::default();
         let mut stack = vec![*set];
 
         while let Some(current) = stack.pop() {
             if visited.contains(&current) {
                 continue;
             }
-            visited.push(current);
+            visited.insert(current);
 
             if let Some(nodes) = self.sets.get(&current) {
                 for &node_id in nodes {

--- a/crates/bevy_ecs/src/observer/centralized_storage.rs
+++ b/crates/bevy_ecs/src/observer/centralized_storage.rs
@@ -11,6 +11,7 @@
 
 use alloc::{vec, vec::Vec};
 use bevy_platform::collections::HashMap;
+use log::{debug, warn};
 use smallvec::SmallVec;
 
 use crate::{
@@ -20,6 +21,7 @@ use crate::{
     event::EventKey,
     intern::Interned,
     observer::{EdgeTarget, ObserverDescriptor, ObserverRunner, ObserverSet},
+    schedule::graph::{DiGraph, DiGraphToposortError, Direction, GraphNodeId},
 };
 
 /// An internal lookup table tracking all of the observers in the world.
@@ -156,6 +158,15 @@ impl NodeId {
     }
 }
 
+impl GraphNodeId for NodeId {
+    type Adjacent = (Self, Direction);
+    type Edge = (Self, Self);
+
+    fn kind(&self) -> &'static str {
+        "observer"
+    }
+}
+
 /// Observer data stored once per registered observer/event-key pair.
 #[derive(Clone, Copy, Debug)]
 pub struct ObserverNode {
@@ -170,15 +181,7 @@ pub struct ObserverNode {
 #[derive(Clone, Debug)]
 pub struct ObserverEdgeResolved {
     owner: Entity,
-    #[expect(
-        dead_code,
-        reason = "Observer edge sorting is wired in the graph-sort phase."
-    )]
     from: EdgeTarget,
-    #[expect(
-        dead_code,
-        reason = "Observer edge sorting is wired in the graph-sort phase."
-    )]
     to: EdgeTarget,
 }
 
@@ -358,15 +361,96 @@ impl CachedObservers {
             return;
         }
 
-        self.order.clear();
-        self.order.extend((0..self.nodes.len()).map(NodeId::new));
-        self.order
-            .sort_by_key(|node_id| self.nodes[node_id.index()].sort_key);
-        self.sort_indices();
-        self.dirty = false;
+        let mut attempts = 0;
+        while self.dirty {
+            self.dirty = false;
+            self.rebuild_order();
+            self.sort_indices();
+
+            attempts += 1;
+            debug_assert!(attempts <= self.nodes.len().saturating_add(1));
+        }
 
         #[cfg(debug_assertions)]
         self.debug_assert_sorted_indices();
+    }
+
+    fn rebuild_order(&mut self) {
+        let insertion_order = self.insertion_order();
+        let mut graph = DiGraph::<NodeId>::with_capacity(self.nodes.len(), self.edges.len());
+
+        for &node_id in insertion_order.iter().rev() {
+            graph.add_node(node_id);
+        }
+
+        for edge in &self.edges {
+            let from_nodes = self.resolve_edge_target(&edge.from);
+            let to_nodes = self.resolve_edge_target(&edge.to);
+
+            for &from in &from_nodes {
+                for &to in &to_nodes {
+                    graph.add_edge(from, to);
+                }
+            }
+        }
+
+        match graph.toposort(Vec::new()) {
+            Ok(order) => {
+                debug_assert_eq!(order.len(), self.nodes.len());
+                self.order = order;
+            }
+            Err(error) => {
+                let cycle_members = self.cycle_members(&error);
+                warn!(
+                    "observer ordering graph contains a cycle involving {cycle_members:?}; falling back to registration order"
+                );
+                self.order = insertion_order;
+
+                #[cfg(test)]
+                debug_assert!(false, "observer ordering graph contains a cycle: {error:?}");
+            }
+        }
+    }
+
+    fn insertion_order(&self) -> Vec<NodeId> {
+        let mut order = (0..self.nodes.len()).map(NodeId::new).collect::<Vec<_>>();
+        order.sort_by_key(|node_id| self.nodes[node_id.index()].sort_key);
+        order
+    }
+
+    fn resolve_edge_target(&self, target: &EdgeTarget) -> SmallVec<[NodeId; 4]> {
+        match target {
+            EdgeTarget::Entity(entity) => self
+                .observer_to_node
+                .get(entity)
+                .copied()
+                .into_iter()
+                .collect(),
+            EdgeTarget::Set(set) => {
+                let Some(nodes) = self.sets.get(set) else {
+                    debug!("observer ordering edge references empty set {set:?}");
+                    return SmallVec::new();
+                };
+                nodes.iter().copied().collect()
+            }
+        }
+    }
+
+    fn cycle_members(&self, error: &DiGraphToposortError<NodeId>) -> Vec<Vec<Entity>> {
+        match error {
+            DiGraphToposortError::Loop(node_id) => {
+                vec![vec![self.nodes[node_id.index()].observer]]
+            }
+            DiGraphToposortError::Cycle(cycles) => cycles
+                .iter()
+                .map(|cycle| {
+                    cycle
+                        .iter()
+                        .map(|node_id| self.nodes[node_id.index()].observer)
+                        .collect()
+                })
+                .collect(),
+        }
     }
 
     fn remove_node(&mut self, node_id: NodeId) {
@@ -534,4 +618,55 @@ fn is_sorted_by_order<const N: usize>(positions: &[usize], nodes: &SmallVec<[Nod
     nodes
         .windows(2)
         .all(|window| positions[window[0].index()] <= positions[window[1].index()])
+}
+
+#[cfg(test)]
+mod tests {
+    use bevy_ptr::PtrMut;
+
+    use crate::{
+        observer::{ObserverEdge, TriggerContext},
+        world::DeferredWorld,
+    };
+
+    use super::*;
+
+    unsafe fn noop_runner(
+        _world: DeferredWorld,
+        _observer: Entity,
+        _trigger_context: &TriggerContext,
+        _event: PtrMut,
+        _trigger: PtrMut,
+    ) {
+    }
+
+    fn entity(index: u32) -> Entity {
+        Entity::from_raw_u32(index).unwrap()
+    }
+
+    #[test]
+    fn resort_applies_observer_edges() {
+        let mut cache = CachedObservers::default();
+        let observer_a = entity(1);
+        let observer_b = entity(2);
+        let observer_c = entity(3);
+
+        cache.register_observer(observer_a, noop_runner, &ObserverDescriptor::default());
+        cache.register_observer(observer_b, noop_runner, &ObserverDescriptor::default());
+
+        let mut descriptor_c = ObserverDescriptor::default();
+        descriptor_c.edges.push(ObserverEdge {
+            from: EdgeTarget::Entity(observer_c),
+            to: EdgeTarget::Entity(observer_a),
+        });
+        cache.register_observer(observer_c, noop_runner, &descriptor_c);
+
+        let order = cache
+            .order
+            .iter()
+            .map(|node_id| cache.nodes[node_id.index()].observer)
+            .collect::<Vec<_>>();
+
+        assert_eq!(order, vec![observer_b, observer_c, observer_a]);
+    }
 }

--- a/crates/bevy_ecs/src/observer/centralized_storage.rs
+++ b/crates/bevy_ecs/src/observer/centralized_storage.rs
@@ -318,6 +318,8 @@ pub struct CachedObservers {
     set_hierarchy: HashMap<Interned<dyn ObserverSet>, SmallVec<[Interned<dyn ObserverSet>; 2]>>,
     set_edges: Vec<(Interned<dyn ObserverSet>, Interned<dyn ObserverSet>)>,
     edges: Vec<ObserverEdgeResolved>,
+    // true iff `!edges.is_empty() || !set_edges.is_empty() || any set has > 1 member`
+    has_ordering_constraints: bool,
     observer_to_node: EntityHashMap<NodeId>,
     dispatch_order: Vec<Entity>,
     dirty: bool,
@@ -331,6 +333,7 @@ impl CachedObservers {
     ) -> Self {
         Self {
             set_hierarchy,
+            has_ordering_constraints: !set_edges.is_empty(),
             set_edges,
             ..Default::default()
         }
@@ -511,6 +514,7 @@ impl CachedObservers {
         for &edge in &configs.edges {
             if !self.set_edges.contains(&edge) {
                 self.set_edges.push(edge);
+                self.has_ordering_constraints = true;
                 changed = true;
             }
         }
@@ -567,7 +571,11 @@ impl CachedObservers {
         }
 
         for &set in &descriptor.sets {
-            push_unique(self.sets.entry(set).or_default(), node_id);
+            let nodes = self.sets.entry(set).or_default();
+            push_unique(nodes, node_id);
+            if nodes.len() > 1 {
+                self.has_ordering_constraints = true;
+            }
         }
 
         for edge in &descriptor.edges {
@@ -576,6 +584,9 @@ impl CachedObservers {
                 from: edge.from.clone().resolve_owner(observer),
                 to: edge.to.clone().resolve_owner(observer),
             });
+        }
+        if !descriptor.edges.is_empty() {
+            self.has_ordering_constraints = true;
         }
 
         self.dirty = true;
@@ -622,6 +633,7 @@ impl CachedObservers {
         }
 
         self.edges.retain(|edge| edge.owner != observer);
+        self.recompute_has_ordering_constraints();
         self.remove_node(node_id);
         self.dirty = true;
         self.resort();
@@ -819,6 +831,12 @@ impl CachedObservers {
             .collect();
     }
 
+    fn recompute_has_ordering_constraints(&mut self) {
+        self.has_ordering_constraints = !self.edges.is_empty()
+            || !self.set_edges.is_empty()
+            || self.sets.values().any(|nodes| nodes.len() > 1);
+    }
+
     fn cycle_members(&self, error: &DiGraphToposortError<NodeId>) -> Vec<Vec<Entity>> {
         match error {
             DiGraphToposortError::Loop(node_id) => {
@@ -940,6 +958,14 @@ pub(crate) unsafe fn run_ordered<const N: usize>(
         cache.debug_assert_stream_sorted(stream);
     }
 
+    #[cfg(debug_assertions)]
+    debug_assert_eq!(
+        cache.has_ordering_constraints,
+        !cache.edges.is_empty()
+            || !cache.set_edges.is_empty()
+            || cache.sets.values().any(|nodes| nodes.len() > 1)
+    );
+
     if N == 1 {
         for &node_id in streams[0] {
             let node = cache.observer(node_id);
@@ -957,7 +983,7 @@ pub(crate) unsafe fn run_ordered<const N: usize>(
         return;
     }
 
-    if cache.edges.is_empty() {
+    if !cache.has_ordering_constraints {
         for stream in streams {
             for &node_id in stream {
                 let node = cache.observer(node_id);

--- a/crates/bevy_ecs/src/observer/distributed_storage.rs
+++ b/crates/bevy_ecs/src/observer/distributed_storage.rs
@@ -20,13 +20,14 @@ use crate::{
     lifecycle::{ComponentHook, HookContext},
     observer::{
         condition::{ObserverCondition, ObserverWithCondition, ObserverWithConditionMarker},
-        observer_system_runner, ObserverRunner, ObserverSet,
+        observer_system_runner, IntoObserverOrderingTarget, ObserverRunner, ObserverSet,
     },
     prelude::*,
     system::{IntoObserverSystem, ObserverSystem},
     world::DeferredWorld,
 };
 use alloc::boxed::Box;
+use alloc::string::String;
 use alloc::vec::Vec;
 use bevy_utils::prelude::DebugName;
 use smallvec::SmallVec;
@@ -326,6 +327,46 @@ impl Observer {
         self
     }
 
+    /// Add this observer to the provided observer set.
+    pub fn in_set<S: ObserverSet>(mut self, set: S) -> Self {
+        self.descriptor.sets.push(set.intern());
+        self
+    }
+
+    /// Run this observer before the observers matching `target`.
+    pub fn before(mut self, target: impl IntoObserverOrderingTarget) -> Self {
+        let target = target.into_observer_ordering_target().into_edge_target();
+        self.before_inner(target);
+        self
+    }
+
+    /// Run this observer after the observers matching `target`.
+    pub fn after(mut self, target: impl IntoObserverOrderingTarget) -> Self {
+        let target = target.into_observer_ordering_target().into_edge_target();
+        self.after_inner(target);
+        self
+    }
+
+    /// Sets a human-readable name for diagnostics.
+    pub fn with_name(mut self, name: impl Into<String>) -> Self {
+        self.descriptor.name = Some(name.into());
+        self
+    }
+
+    pub(crate) fn before_inner(&mut self, target: EdgeTarget) {
+        self.descriptor.edges.push(ObserverEdge {
+            from: EdgeTarget::Entity(Entity::PLACEHOLDER),
+            to: target,
+        });
+    }
+
+    pub(crate) fn after_inner(&mut self, target: EdgeTarget) {
+        self.descriptor.edges.push(ObserverEdge {
+            from: target,
+            to: EdgeTarget::Entity(Entity::PLACEHOLDER),
+        });
+    }
+
     /// Observes the given `event_key`. This will cause the [`Observer`] to run whenever an event with the given [`EventKey`]
     /// is triggered.
     /// # Safety
@@ -412,6 +453,9 @@ pub struct ObserverDescriptor {
 
     /// Ordering edges declared for this observer.
     pub(crate) edges: Vec<ObserverEdge>,
+
+    /// Optional human-readable observer name used by diagnostics.
+    pub(crate) name: Option<String>,
 }
 
 /// An ordering edge declared by an [`ObserverDescriptor`].
@@ -427,20 +471,18 @@ pub(crate) struct ObserverEdge {
 #[derive(Clone, Debug)]
 pub(crate) enum EdgeTarget {
     /// A specific observer entity.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "Observer edge constructors are wired with the builder API in a later phase."
-        )
-    )]
     Entity(Entity),
     /// A configured observer set.
-    #[expect(
-        dead_code,
-        reason = "Observer set edge constructors are wired with the builder API in a later phase."
-    )]
     Set(crate::intern::Interned<dyn ObserverSet>),
+}
+
+impl EdgeTarget {
+    pub(crate) fn resolve_owner(self, owner: Entity) -> Self {
+        match self {
+            Self::Entity(entity) if entity == Entity::PLACEHOLDER => Self::Entity(owner),
+            target => target,
+        }
+    }
 }
 
 impl ObserverDescriptor {

--- a/crates/bevy_ecs/src/observer/distributed_storage.rs
+++ b/crates/bevy_ecs/src/observer/distributed_storage.rs
@@ -35,6 +35,9 @@ use smallvec::SmallVec;
 #[cfg(feature = "bevy_reflect")]
 use crate::prelude::ReflectComponent;
 
+pub(crate) const WATCH_ENTITY_AFTER_REGISTRATION_MESSAGE: &str =
+    "Observer::watch_entity called after the observer was registered with the world; this has no effect - use entity.observe(...) instead";
+
 /// An [`Observer`] system. Add this [`Component`] to an [`Entity`] to turn it into an "observer".
 ///
 /// Observers watch for a "trigger" of a specific [`Event`]. An event can be triggered on the [`World`]
@@ -286,6 +289,7 @@ impl Observer {
     /// Observes the given `entity` (in addition to any entity already being observed).
     /// This will cause the [`Observer`] to run whenever an [`EntityEvent::event_target`] is the given `entity`.
     /// Note that if this is called _after_ an [`Observer`] is spawned, it will produce no effects.
+    /// In debug builds, calling this after registration will panic to highlight the mistake.
     pub fn with_entity(mut self, entity: Entity) -> Self {
         self.watch_entity(entity);
         self
@@ -294,6 +298,7 @@ impl Observer {
     /// Observes the given `entities` (in addition to any entity already being observed).
     /// This will cause the [`Observer`] to run whenever an [`EntityEvent::event_target`] is any of the `entities`.
     /// Note that if this is called _after_ an [`Observer`] is spawned, it will produce no effects.
+    /// In debug builds, calling this after registration will panic to highlight the mistake.
     pub fn with_entities<I: IntoIterator<Item = Entity>>(mut self, entities: I) -> Self {
         self.watch_entities(entities);
         self
@@ -302,14 +307,30 @@ impl Observer {
     /// Observes the given `entity` (in addition to any entity already being observed).
     /// This will cause the [`Observer`] to run whenever an [`EntityEvent::event_target`] is the given `entity`.
     /// Note that if this is called _after_ an [`Observer`] is spawned, it will produce no effects.
+    /// In debug builds, calling this after registration will panic to highlight the mistake.
     pub fn watch_entity(&mut self, entity: Entity) {
+        debug_assert!(
+            !self.descriptor.frozen,
+            "{WATCH_ENTITY_AFTER_REGISTRATION_MESSAGE}"
+        );
+        if self.descriptor.frozen {
+            return;
+        }
         self.descriptor.entities.push(entity);
     }
 
-    /// Observes the given `entity` (in addition to any entity already being observed).
+    /// Observes the given `entities` (in addition to any entity already being observed).
     /// This will cause the [`Observer`] to run whenever an [`EntityEvent::event_target`] is any of the `entities`.
     /// Note that if this is called _after_ an [`Observer`] is spawned, it will produce no effects.
+    /// In debug builds, calling this after registration will panic to highlight the mistake.
     pub fn watch_entities<I: IntoIterator<Item = Entity>>(&mut self, entities: I) {
+        debug_assert!(
+            !self.descriptor.frozen,
+            "{WATCH_ENTITY_AFTER_REGISTRATION_MESSAGE}"
+        );
+        if self.descriptor.frozen {
+            return;
+        }
         self.descriptor.entities.extend(entities);
     }
 
@@ -456,6 +477,9 @@ pub struct ObserverDescriptor {
 
     /// Optional human-readable observer name used by diagnostics.
     pub(crate) name: Option<String>,
+
+    /// Registration freezes descriptor retargeting because the cache has already consumed it.
+    pub(crate) frozen: bool,
 }
 
 /// An ordering edge declared by an [`ObserverDescriptor`].

--- a/crates/bevy_ecs/src/observer/distributed_storage.rs
+++ b/crates/bevy_ecs/src/observer/distributed_storage.rs
@@ -412,17 +412,14 @@ pub struct ObserverDescriptor {
     pub(super) entities: Vec<Entity>,
 
     /// The observer sets this observer belongs to.
-    #[expect(dead_code, reason = "Observer set dispatch is wired in a later phase.")]
     pub(crate) sets: SmallVec<[crate::intern::Interned<dyn ObserverSet>; 1]>,
 
     /// Ordering edges declared for this observer.
-    #[expect(dead_code, reason = "Observer edge dispatch is wired in a later phase.")]
     pub(crate) edges: Vec<ObserverEdge>,
 }
 
 /// An ordering edge declared by an [`ObserverDescriptor`].
 #[derive(Clone, Debug)]
-#[expect(dead_code, reason = "Observer edge dispatch is wired in a later phase.")]
 pub(crate) struct ObserverEdge {
     /// The source endpoint of the edge.
     pub from: EdgeTarget,
@@ -432,7 +429,10 @@ pub(crate) struct ObserverEdge {
 
 /// A public-facing observer ordering edge endpoint.
 #[derive(Clone, Debug)]
-#[expect(dead_code, reason = "Observer edge dispatch is wired in a later phase.")]
+#[expect(
+    dead_code,
+    reason = "Observer edge constructors are wired with the builder API in a later phase."
+)]
 pub(crate) enum EdgeTarget {
     /// A specific observer entity.
     Entity(Entity),

--- a/crates/bevy_ecs/src/observer/distributed_storage.rs
+++ b/crates/bevy_ecs/src/observer/distributed_storage.rs
@@ -18,14 +18,10 @@ use crate::{
     error::{ErrorContext, ErrorHandler},
     event::EventKey,
     lifecycle::{ComponentHook, HookContext},
-<<<<<<< HEAD
     observer::{
         condition::{ObserverCondition, ObserverWithCondition, ObserverWithConditionMarker},
         observer_system_runner, ObserverRunner, ObserverSet,
     },
-=======
-    observer::{observer_system_runner, ObserverRunner, ObserverSet},
->>>>>>> 696e89e0d (ecs/observer: add ObserverSet trait, derive, and descriptor edges)
     prelude::*,
     system::{IntoObserverSystem, ObserverSystem},
     world::DeferredWorld,

--- a/crates/bevy_ecs/src/observer/distributed_storage.rs
+++ b/crates/bevy_ecs/src/observer/distributed_storage.rs
@@ -429,14 +429,21 @@ pub(crate) struct ObserverEdge {
 
 /// A public-facing observer ordering edge endpoint.
 #[derive(Clone, Debug)]
-#[expect(
-    dead_code,
-    reason = "Observer edge constructors are wired with the builder API in a later phase."
-)]
 pub(crate) enum EdgeTarget {
     /// A specific observer entity.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "Observer edge constructors are wired with the builder API in a later phase."
+        )
+    )]
     Entity(Entity),
     /// A configured observer set.
+    #[expect(
+        dead_code,
+        reason = "Observer set edge constructors are wired with the builder API in a later phase."
+    )]
     Set(crate::intern::Interned<dyn ObserverSet>),
 }
 

--- a/crates/bevy_ecs/src/observer/distributed_storage.rs
+++ b/crates/bevy_ecs/src/observer/distributed_storage.rs
@@ -18,10 +18,14 @@ use crate::{
     error::{ErrorContext, ErrorHandler},
     event::EventKey,
     lifecycle::{ComponentHook, HookContext},
+<<<<<<< HEAD
     observer::{
         condition::{ObserverCondition, ObserverWithCondition, ObserverWithConditionMarker},
-        observer_system_runner, ObserverRunner,
+        observer_system_runner, ObserverRunner, ObserverSet,
     },
+=======
+    observer::{observer_system_runner, ObserverRunner, ObserverSet},
+>>>>>>> 696e89e0d (ecs/observer: add ObserverSet trait, derive, and descriptor edges)
     prelude::*,
     system::{IntoObserverSystem, ObserverSystem},
     world::DeferredWorld,
@@ -29,6 +33,7 @@ use crate::{
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use bevy_utils::prelude::DebugName;
+use smallvec::SmallVec;
 
 #[cfg(feature = "bevy_reflect")]
 use crate::prelude::ReflectComponent;
@@ -405,6 +410,34 @@ pub struct ObserverDescriptor {
 
     /// The entities the observer is watching.
     pub(super) entities: Vec<Entity>,
+
+    /// The observer sets this observer belongs to.
+    #[expect(dead_code, reason = "Observer set dispatch is wired in a later phase.")]
+    pub(crate) sets: SmallVec<[crate::intern::Interned<dyn ObserverSet>; 1]>,
+
+    /// Ordering edges declared for this observer.
+    #[expect(dead_code, reason = "Observer edge dispatch is wired in a later phase.")]
+    pub(crate) edges: Vec<ObserverEdge>,
+}
+
+/// An ordering edge declared by an [`ObserverDescriptor`].
+#[derive(Clone, Debug)]
+#[expect(dead_code, reason = "Observer edge dispatch is wired in a later phase.")]
+pub(crate) struct ObserverEdge {
+    /// The source endpoint of the edge.
+    pub from: EdgeTarget,
+    /// The target endpoint of the edge.
+    pub to: EdgeTarget,
+}
+
+/// A public-facing observer ordering edge endpoint.
+#[derive(Clone, Debug)]
+#[expect(dead_code, reason = "Observer edge dispatch is wired in a later phase.")]
+pub(crate) enum EdgeTarget {
+    /// A specific observer entity.
+    Entity(Entity),
+    /// A configured observer set.
+    Set(crate::intern::Interned<dyn ObserverSet>),
 }
 
 impl ObserverDescriptor {

--- a/crates/bevy_ecs/src/observer/entity_cloning.rs
+++ b/crates/bevy_ecs/src/observer/entity_cloning.rs
@@ -48,12 +48,13 @@ fn component_clone_observed_by(_source: &SourceComponent, ctx: &mut ComponentClo
             for event_key in event_keys {
                 let observers = world.observers.get_observers_mut(event_key);
                 if components.is_empty() {
-                    if let Some(map) = observers.entity_observers.get(&source).cloned() {
-                        observers.entity_observers.insert(target, map);
+                    if let Some(map) = observers.entity_observers_legacy.get(&source).cloned() {
+                        observers.entity_observers_legacy.insert(target, map);
                     }
                 } else {
                     for component in &components {
-                        let Some(observers) = observers.component_observers.get_mut(component)
+                        let Some(observers) =
+                            observers.component_observers_legacy.get_mut(component)
                         else {
                             continue;
                         };

--- a/crates/bevy_ecs/src/observer/entity_cloning.rs
+++ b/crates/bevy_ecs/src/observer/entity_cloning.rs
@@ -47,24 +47,7 @@ fn component_clone_observed_by(_source: &SourceComponent, ctx: &mut ComponentClo
             let components = observer_state.descriptor.components.clone();
             for event_key in event_keys {
                 let observers = world.observers.get_observers_mut(event_key);
-                if components.is_empty() {
-                    if let Some(map) = observers.entity_observers_legacy.get(&source).cloned() {
-                        observers.entity_observers_legacy.insert(target, map);
-                    }
-                } else {
-                    for component in &components {
-                        let Some(observers) =
-                            observers.component_observers_legacy.get_mut(component)
-                        else {
-                            continue;
-                        };
-                        if let Some(map) =
-                            observers.entity_component_observers.get(&source).cloned()
-                        {
-                            observers.entity_component_observers.insert(target, map);
-                        }
-                    }
-                }
+                observers.clone_entity_observers(source, target, &components);
             }
         }
     });

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -2391,6 +2391,49 @@ mod tests {
     }
 
     #[test]
+    fn observer_set_chain_respects_run_if() {
+        #[derive(ObserverSet, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        struct SetA;
+        #[derive(ObserverSet, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        struct SetB;
+        #[derive(ObserverSet, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        struct SetC;
+
+        let mut world = World::new();
+        world.init_resource::<Order>();
+        world.insert_resource(RunConditionFlag(false));
+        world.configure_observer_sets((SetA, SetB, SetC).chain());
+
+        world.spawn(
+            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+                order.observed("a");
+            })
+            .in_set(SetA),
+        );
+        world.spawn(
+            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+                order.observed("b");
+            })
+            .in_set(SetB)
+            .run_if(|flag: Res<RunConditionFlag>| flag.0),
+        );
+        world.spawn(
+            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+                order.observed("c");
+            })
+            .in_set(SetC),
+        );
+
+        world.trigger(EventA);
+        assert_eq!(vec!["a", "c"], world.resource::<Order>().0);
+
+        world.resource_mut::<Order>().0.clear();
+        world.resource_mut::<RunConditionFlag>().0 = true;
+        world.trigger(EventA);
+        assert_eq!(vec!["a", "b", "c"], world.resource::<Order>().0);
+    }
+
+    #[test]
     fn observer_naming_appears_in_dispatch_order() {
         let mut world = World::new();
         let observer = world

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -578,7 +578,7 @@ mod tests {
         world.add_observer(|_: On<Add, A>, mut res: ResMut<Order>| res.observed("add_2"));
 
         world.spawn(A).flush();
-        assert_eq!(vec!["add_2", "add_1"], world.resource::<Order>().0);
+        assert_eq!(vec!["add_1", "add_2"], world.resource::<Order>().0);
         // we have one A entity and two observers
         assert_eq!(world.query::<&A>().query(&world).count(), 1);
         assert_eq!(world.query::<&Observer>().query(&world).count(), 2);
@@ -1475,11 +1475,11 @@ mod tests {
         observer.remove::<Observer>();
         let id = observer.id();
         let event_key = world.event_key::<EventA>().unwrap();
-        assert!(!world
-            .observers
-            .get_observers_mut(event_key)
-            .global_observers_legacy
-            .contains_key(&id));
+        let cache = world.observers.get_observers_mut(event_key);
+        assert!(!cache
+            .global_observers()
+            .iter()
+            .any(|&node_id| cache.observer(node_id).observer == id));
     }
 
     #[test]
@@ -1493,7 +1493,7 @@ mod tests {
         assert!(!world
             .observers
             .get_observers_mut(event_key)
-            .entity_observers_legacy
+            .entity_observers()
             .contains_key(&entity));
     }
 

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -500,7 +500,7 @@ mod tests {
     }
 
     #[test]
-    fn observer_order_replace() {
+    fn observer_order_discard_on_replace() {
         let mut world = World::new();
         world.init_resource::<Order>();
 

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -1586,8 +1586,8 @@ mod tests {
             Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
                 order.observed("x");
             })
-                .in_set(SetA)
-                .in_set(SetB),
+            .in_set(SetA)
+            .in_set(SetB),
         );
         world.spawn(
             Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -1494,21 +1494,36 @@ mod tests {
         let mut world = World::new();
         world.init_resource::<Order>();
 
-        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
-            order.observed("win1");
-        }).in_set(WinCheck));
-        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
-            order.observed("win2");
-        }).in_set(WinCheck));
-        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
-            order.observed("win3");
-        }).in_set(WinCheck));
-        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
-            order.observed("after");
-        }).after(WinCheck));
-        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
-            order.observed("before");
-        }).before(WinCheck));
+        world.spawn(
+            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+                order.observed("win1");
+            })
+            .in_set(WinCheck),
+        );
+        world.spawn(
+            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+                order.observed("win2");
+            })
+            .in_set(WinCheck),
+        );
+        world.spawn(
+            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+                order.observed("win3");
+            })
+            .in_set(WinCheck),
+        );
+        world.spawn(
+            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+                order.observed("after");
+            })
+            .after(WinCheck),
+        );
+        world.spawn(
+            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+                order.observed("before");
+            })
+            .before(WinCheck),
+        );
 
         world.trigger(EventA);
 
@@ -1526,9 +1541,12 @@ mod tests {
         let a = world
             .add_observer(|_: On<EventA>, mut order: ResMut<Order>| order.observed("a"))
             .id();
-        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
-            order.observed("b");
-        }).after(a));
+        world.spawn(
+            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+                order.observed("b");
+            })
+            .after(a),
+        );
 
         world.trigger(EventA);
         assert_eq!(vec!["a", "b"], world.resource::<Order>().0);
@@ -1536,12 +1554,17 @@ mod tests {
         let mut world = World::new();
         world.init_resource::<Order>();
         let a = world.spawn_empty().id();
-        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
-            order.observed("b");
-        }).after(a));
-        world.entity_mut(a).insert(Observer::new(
-            |_: On<EventA>, mut order: ResMut<Order>| order.observed("a"),
-        ));
+        world.spawn(
+            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+                order.observed("b");
+            })
+            .after(a),
+        );
+        world
+            .entity_mut(a)
+            .insert(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+                order.observed("a")
+            }));
 
         world.trigger(EventA);
         assert_eq!(vec!["a", "b"], world.resource::<Order>().0);
@@ -1562,12 +1585,18 @@ mod tests {
                 .in_set(SetA)
                 .in_set(SetB),
         );
-        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
-            order.observed("y");
-        }).after(SetA));
-        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
-            order.observed("z");
-        }).after(SetB));
+        world.spawn(
+            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+                order.observed("y");
+            })
+            .after(SetA),
+        );
+        world.spawn(
+            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+                order.observed("z");
+            })
+            .after(SetB),
+        );
 
         world.trigger(EventA);
         let order = &world.resource::<Order>().0;
@@ -1585,9 +1614,12 @@ mod tests {
 
         let mut world = World::new();
         world.init_resource::<Order>();
-        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
-            order.observed("runs");
-        }).after(EmptySet));
+        world.spawn(
+            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+                order.observed("runs");
+            })
+            .after(EmptySet),
+        );
 
         world.trigger(EventA);
         assert_eq!(vec!["runs"], world.resource::<Order>().0);
@@ -1600,8 +1632,12 @@ mod tests {
 
         let a = world.spawn_empty().id();
         let b = world.spawn_empty().id();
-        world.entity_mut(a).insert(Observer::new(|_: On<EventA>| {}).after(b));
-        world.entity_mut(b).insert(Observer::new(|_: On<EventA>| {}).after(a));
+        world
+            .entity_mut(a)
+            .insert(Observer::new(|_: On<EventA>| {}).after(b));
+        world
+            .entity_mut(b)
+            .insert(Observer::new(|_: On<EventA>| {}).after(a));
     }
 
     #[test]
@@ -1612,15 +1648,26 @@ mod tests {
         let mut world = World::new();
         world.init_resource::<Order>();
 
-        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
-            order.observed("a");
-        }).in_set(WinCheck));
-        let b = world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
-            order.observed("b");
-        }).in_set(WinCheck)).id();
-        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
-            order.observed("c");
-        }).in_set(WinCheck));
+        world.spawn(
+            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+                order.observed("a");
+            })
+            .in_set(WinCheck),
+        );
+        let b = world
+            .spawn(
+                Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+                    order.observed("b");
+                })
+                .in_set(WinCheck),
+            )
+            .id();
+        world.spawn(
+            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+                order.observed("c");
+            })
+            .in_set(WinCheck),
+        );
         world.entity_mut(b).remove::<Observer>();
 
         world.trigger(EventA);
@@ -1681,20 +1728,31 @@ mod tests {
         let parent = world.spawn_empty().id();
         let child = world.spawn(ChildOf(parent)).id();
 
-        world.spawn(Observer::new(
-            |event: On<EventPropagating>, mut order: ResMut<PropagationOrder>| {
-                order.0.push((event.event_target(), "win"));
-            },
-        ).in_set(WinCheck));
-        world.spawn(Observer::new(
-            |event: On<EventPropagating>, mut order: ResMut<PropagationOrder>| {
-                order.0.push((event.event_target(), "after"));
-            },
-        ).after(WinCheck));
+        world.spawn(
+            Observer::new(
+                |event: On<EventPropagating>, mut order: ResMut<PropagationOrder>| {
+                    order.0.push((event.event_target(), "win"));
+                },
+            )
+            .in_set(WinCheck),
+        );
+        world.spawn(
+            Observer::new(
+                |event: On<EventPropagating>, mut order: ResMut<PropagationOrder>| {
+                    order.0.push((event.event_target(), "after"));
+                },
+            )
+            .after(WinCheck),
+        );
 
         world.trigger(EventPropagating(child));
         assert_eq!(
-            vec![(child, "win"), (child, "after"), (parent, "win"), (parent, "after")],
+            vec![
+                (child, "win"),
+                (child, "after"),
+                (parent, "win"),
+                (parent, "after")
+            ],
             world.resource::<PropagationOrder>().0
         );
     }
@@ -1712,21 +1770,36 @@ mod tests {
         world.init_resource::<Order>();
         world.configure_observer_sets((SetA, SetB).in_set(Outer));
 
-        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
-            order.observed("a1");
-        }).in_set(SetA));
-        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
-            order.observed("a2");
-        }).in_set(SetA));
-        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
-            order.observed("b1");
-        }).in_set(SetB));
-        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
-            order.observed("b2");
-        }).in_set(SetB));
-        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
-            order.observed("after");
-        }).after(Outer));
+        world.spawn(
+            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+                order.observed("a1");
+            })
+            .in_set(SetA),
+        );
+        world.spawn(
+            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+                order.observed("a2");
+            })
+            .in_set(SetA),
+        );
+        world.spawn(
+            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+                order.observed("b1");
+            })
+            .in_set(SetB),
+        );
+        world.spawn(
+            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+                order.observed("b2");
+            })
+            .in_set(SetB),
+        );
+        world.spawn(
+            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+                order.observed("after");
+            })
+            .after(Outer),
+        );
 
         world.trigger(EventA);
         assert_eq!(
@@ -1741,7 +1814,11 @@ mod tests {
         let target = world.spawn_empty().id();
         let global = world.add_observer(|_: On<EntityEventA>| {}).id();
         let entity = world
-            .spawn(Observer::new(|_: On<EntityEventA>| {}).with_entity(target).after(global))
+            .spawn(
+                Observer::new(|_: On<EntityEventA>| {})
+                    .with_entity(target)
+                    .after(global),
+            )
             .id();
 
         let event_key = world.event_key::<EntityEventA>().unwrap();
@@ -1756,11 +1833,14 @@ mod tests {
         let mut world = World::new();
         world.init_resource::<Order>();
 
-        world.add_observers((
-            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| order.observed("a")),
-            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| order.observed("b")),
-            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| order.observed("c")),
-        ).chain());
+        world.add_observers(
+            (
+                Observer::new(|_: On<EventA>, mut order: ResMut<Order>| order.observed("a")),
+                Observer::new(|_: On<EventA>, mut order: ResMut<Order>| order.observed("b")),
+                Observer::new(|_: On<EventA>, mut order: ResMut<Order>| order.observed("c")),
+            )
+                .chain(),
+        );
 
         world.trigger(EventA);
         assert_eq!(vec!["a", "b", "c"], world.resource::<Order>().0);
@@ -1773,13 +1853,19 @@ mod tests {
 
         let mut world = World::new();
         world.init_resource::<Order>();
-        world.add_observers((
-            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| order.observed("a")),
-            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| order.observed("b")),
-        ).in_set(SetA));
-        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
-            order.observed("after");
-        }).after(SetA));
+        world.add_observers(
+            (
+                Observer::new(|_: On<EventA>, mut order: ResMut<Order>| order.observed("a")),
+                Observer::new(|_: On<EventA>, mut order: ResMut<Order>| order.observed("b")),
+            )
+                .in_set(SetA),
+        );
+        world.spawn(
+            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+                order.observed("after");
+            })
+            .after(SetA),
+        );
 
         world.trigger(EventA);
         assert_eq!(vec!["a", "b", "after"], world.resource::<Order>().0);
@@ -1793,10 +1879,13 @@ mod tests {
             .add_observer(|_: On<EventA>, mut order: ResMut<Order>| order.observed("c"))
             .id();
 
-        world.add_observers((
-            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| order.observed("a")),
-            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| order.observed("b")),
-        ).after(c));
+        world.add_observers(
+            (
+                Observer::new(|_: On<EventA>, mut order: ResMut<Order>| order.observed("a")),
+                Observer::new(|_: On<EventA>, mut order: ResMut<Order>| order.observed("b")),
+            )
+                .after(c),
+        );
 
         world.trigger(EventA);
         let order = &world.resource::<Order>().0;
@@ -1819,15 +1908,24 @@ mod tests {
         let mut world = World::new();
         world.init_resource::<Order>();
         world.configure_observer_sets((SetA, SetB, SetC).chain());
-        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
-            order.observed("a");
-        }).in_set(SetA));
-        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
-            order.observed("b");
-        }).in_set(SetB));
-        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
-            order.observed("c");
-        }).in_set(SetC));
+        world.spawn(
+            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+                order.observed("a");
+            })
+            .in_set(SetA),
+        );
+        world.spawn(
+            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+                order.observed("b");
+            })
+            .in_set(SetB),
+        );
+        world.spawn(
+            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+                order.observed("c");
+            })
+            .in_set(SetC),
+        );
 
         world.trigger(EventA);
         assert_eq!(vec!["a", "b", "c"], world.resource::<Order>().0);
@@ -1853,9 +1951,13 @@ mod tests {
         struct SetA;
 
         let mut world = World::new();
-        let a = world.spawn(Observer::new(|_: On<EventA>| {}).in_set(SetA)).id();
+        let a = world
+            .spawn(Observer::new(|_: On<EventA>| {}).in_set(SetA))
+            .id();
         world.add_observer(|_: On<EventA>| {});
-        let b = world.spawn(Observer::new(|_: On<EventA>| {}).in_set(SetA)).id();
+        let b = world
+            .spawn(Observer::new(|_: On<EventA>| {}).in_set(SetA))
+            .id();
         let event_key = world.event_key::<EventA>().unwrap();
 
         assert_eq!(
@@ -1902,22 +2004,37 @@ mod tests {
         world.init_resource::<Order>();
         world.configure_observer_sets((SetA, SetB).chain());
         let a = world
-            .spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
-                order.observed("a");
-            }).in_set(SetA))
+            .spawn(
+                Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+                    order.observed("a");
+                })
+                .in_set(SetA),
+            )
             .id();
-        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
-            order.observed("b");
-        }).in_set(SetB).after(a).with_name("b"));
-        world.add_observers((
-            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| order.observed("c")),
-            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| order.observed("d")),
-        ).chain().after(SetB));
+        world.spawn(
+            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+                order.observed("b");
+            })
+            .in_set(SetB)
+            .after(a)
+            .with_name("b"),
+        );
+        world.add_observers(
+            (
+                Observer::new(|_: On<EventA>, mut order: ResMut<Order>| order.observed("c")),
+                Observer::new(|_: On<EventA>, mut order: ResMut<Order>| order.observed("d")),
+            )
+                .chain()
+                .after(SetB),
+        );
 
         world.trigger(EventA);
         let event_key = world.event_key::<EventA>().unwrap();
         assert!(!world.observers().dispatch_order_for(event_key).is_empty());
-        assert!(!world.observers().dispatch_order_for_set(event_key, SetA).is_empty());
+        assert!(!world
+            .observers()
+            .dispatch_order_for_set(event_key, SetA)
+            .is_empty());
         assert!(!world
             .observers()
             .dispatch_order_for_with_names(event_key)

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -296,44 +296,42 @@ impl World {
             caller: MaybeLocation::caller(),
         };
 
-        // SAFETY:
-        // - `observers` come from `world` and correspond to `event_key`
-        // - caller guarantees `event_data` and `trigger_data` are valid
-        // - `trigger_entity_internal` increments the trigger id
+        // SAFETY: there are no outstanding world references
         unsafe {
-            crate::event::trigger_entity_internal(
-                world.reborrow(),
-                observers,
-                event_data.reborrow(),
-                trigger_data.reborrow(),
-                entity,
-                &context,
+            world.as_unsafe_world_cell().increment_trigger_id();
+        }
+
+        let mut component_global_node_ids = smallvec::SmallVec::<[NodeId; 8]>::new();
+        let mut entity_component_node_ids = smallvec::SmallVec::<[NodeId; 8]>::new();
+
+        for id in components {
+            observers.merge_ordered_node_ids(
+                &mut component_global_node_ids,
+                observers.component_global_node_ids(*id),
+            );
+            observers.merge_ordered_node_ids(
+                &mut entity_component_node_ids,
+                observers.entity_component_node_ids(*id, entity),
             );
         }
 
-        // Trigger observers watching for specific components.
-        for id in components {
-            if let Some(component_observers) = observers.component_observers().get(id) {
-                let entity_component_observers = component_observers
-                    .entity_component_observers()
-                    .get(&entity)
-                    .map_or(&[] as &[_], smallvec::SmallVec::as_slice);
-
-                // SAFETY: same as above, caller guarantees data validity.
-                unsafe {
-                    run_ordered::<2>(
-                        observers,
-                        &mut world,
-                        &context,
-                        &mut event_data,
-                        &mut trigger_data,
-                        [
-                            component_observers.global_observers(),
-                            entity_component_observers,
-                        ],
-                    );
-                }
-            }
+        // SAFETY:
+        // - `observers` come from `world` and correspond to `event_key`
+        // - caller guarantees `event_data` and `trigger_data` are valid
+        unsafe {
+            run_ordered::<4>(
+                observers,
+                &mut world,
+                &context,
+                &mut event_data,
+                &mut trigger_data,
+                [
+                    observers.global_node_ids(),
+                    observers.entity_node_ids(entity),
+                    &component_global_node_ids,
+                    &entity_component_node_ids,
+                ],
+            );
         }
     }
 
@@ -810,6 +808,73 @@ mod tests {
     }
 
     #[test]
+    fn observer_entity_components_trigger_merges_component_ordering() {
+        let mut world = World::new();
+        world.init_resource::<Order>();
+        let component_a = world.register_component::<A>();
+        let component_b = world.register_component::<B>();
+        let target = world.spawn_empty().id();
+
+        let a_observer = world
+            .add_observer(
+                |_: On<EntityComponentsEvent, A>, mut order: ResMut<Order>| {
+                    order.observed("a");
+                },
+            )
+            .id();
+        world.spawn(
+            Observer::new(
+                |_: On<EntityComponentsEvent, B>, mut order: ResMut<Order>| {
+                    order.observed("b");
+                },
+            )
+            .before(a_observer),
+        );
+
+        world.trigger_with(
+            EntityComponentsEvent(target),
+            EntityComponentsTrigger {
+                components: &[component_a, component_b],
+                old_archetype: None,
+                new_archetype: None,
+            },
+        );
+
+        assert_eq!(vec!["b", "a"], world.resource::<Order>().0);
+    }
+
+    #[test]
+    fn observer_entity_components_trigger_empty_components_runs_entity_ordering() {
+        let mut world = World::new();
+        world.init_resource::<Order>();
+        let target = world.spawn_empty().id();
+
+        let global_observer = world
+            .add_observer(|_: On<EntityComponentsEvent>, mut order: ResMut<Order>| {
+                order.observed("global");
+            })
+            .id();
+        world.spawn(
+            Observer::new(|_: On<EntityComponentsEvent>, mut order: ResMut<Order>| {
+                order.observed("entity");
+            })
+            .with_entity(target)
+            .before(global_observer),
+        );
+
+        world.trigger_with(
+            EntityComponentsEvent(target),
+            EntityComponentsTrigger {
+                components: &[],
+                old_archetype: None,
+                new_archetype: None,
+            },
+        );
+
+        assert_eq!(vec!["entity", "global"], world.resource::<Order>().0);
+    }
+
+    #[test]
     fn observer_dynamic_component() {
         let mut world = World::new();
         world.init_resource::<Order>();
@@ -1115,6 +1180,101 @@ mod tests {
 
         assert_eq!(vec!["global"], world.resource::<Order>().0);
         assert_eq!(vec![10], world.resource::<DynamicValues>().0);
+    }
+
+    #[test]
+    fn observer_fully_dynamic_trigger_targets_components_merges_component_ordering() {
+        use core::alloc::Layout;
+
+        let mut world = World::new();
+        world.init_resource::<Order>();
+
+        let event_id = world.register_component_with_descriptor(
+            // SAFETY: u32 layout with no drop
+            unsafe {
+                crate::component::ComponentDescriptor::new_with_layout(
+                    "DynamicOrderedComponentEvent",
+                    crate::component::StorageType::Table,
+                    Layout::new::<u32>(),
+                    None,
+                    false,
+                    crate::component::ComponentCloneBehavior::Ignore,
+                    None,
+                )
+            },
+        );
+        // SAFETY: event_id was just registered for use as an event
+        let event_key = unsafe { crate::event::EventKey::new(event_id) };
+
+        let comp_a = world.register_component_with_descriptor(
+            // SAFETY: ZST layout with no drop
+            unsafe {
+                crate::component::ComponentDescriptor::new_with_layout(
+                    "DynamicOrderedCompA",
+                    crate::component::StorageType::Table,
+                    Layout::new::<()>(),
+                    None,
+                    false,
+                    crate::component::ComponentCloneBehavior::Ignore,
+                    None,
+                )
+            },
+        );
+        let comp_b = world.register_component_with_descriptor(
+            // SAFETY: ZST layout with no drop
+            unsafe {
+                crate::component::ComponentDescriptor::new_with_layout(
+                    "DynamicOrderedCompB",
+                    crate::component::StorageType::Table,
+                    Layout::new::<()>(),
+                    None,
+                    false,
+                    crate::component::ComponentCloneBehavior::Ignore,
+                    None,
+                )
+            },
+        );
+
+        // SAFETY: event_key was just created, observer only records execution order
+        let a_observer = unsafe {
+            Observer::with_dynamic_runner(
+                |mut world, _observer, _trigger_context, _event, _trigger| {
+                    world.resource_mut::<Order>().observed("a");
+                },
+            )
+            .with_event_key(event_key)
+            .with_component(comp_a)
+        };
+        let a_observer = world.spawn(a_observer).id();
+
+        // SAFETY: event_key was just created, observer only records execution order
+        let b_observer = unsafe {
+            Observer::with_dynamic_runner(
+                |mut world, _observer, _trigger_context, _event, _trigger| {
+                    world.resource_mut::<Order>().observed("b");
+                },
+            )
+            .with_event_key(event_key)
+            .with_component(comp_b)
+            .before(a_observer)
+        };
+        world.spawn(b_observer);
+
+        let target = world.spawn_empty().id();
+        let mut event_data: u32 = 0;
+        let mut trigger_data: u32 = 0;
+        // SAFETY: pointers are valid u32s matching the registered layout
+        unsafe {
+            world.trigger_dynamic_targets_components(
+                event_key,
+                target,
+                &[comp_a, comp_b],
+                bevy_ptr::PtrMut::from(&mut event_data),
+                bevy_ptr::PtrMut::from(&mut trigger_data),
+            );
+        }
+
+        assert_eq!(vec!["b", "a"], world.resource::<Order>().0);
     }
 
     #[test]

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -8,12 +8,14 @@ mod condition;
 mod distributed_storage;
 mod entity_cloning;
 mod runner;
+mod set;
 mod system_param;
 
 pub use centralized_storage::*;
 pub use condition::*;
 pub use distributed_storage::*;
 pub use runner::*;
+pub use set::*;
 pub use system_param::*;
 
 use crate::{

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -1539,7 +1539,9 @@ mod tests {
         world.init_resource::<Order>();
 
         let a = world
-            .add_observer(|_: On<EventA>, mut order: ResMut<Order>| order.observed("a"))
+            .add_observer(|_: On<EventA>, mut order: ResMut<Order>| {
+                order.observed("a");
+            })
             .id();
         world.spawn(
             Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
@@ -1563,7 +1565,7 @@ mod tests {
         world
             .entity_mut(a)
             .insert(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
-                order.observed("a")
+                order.observed("a");
             }));
 
         world.trigger(EventA);
@@ -1581,7 +1583,9 @@ mod tests {
         world.init_resource::<Order>();
 
         world.spawn(
-            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| order.observed("x"))
+            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+                order.observed("x");
+            })
                 .in_set(SetA)
                 .in_set(SetB),
         );
@@ -1681,7 +1685,9 @@ mod tests {
         let target = world.spawn_empty().id();
 
         let global = world
-            .add_observer(|_: On<EntityEventA>, mut order: ResMut<Order>| order.observed("global"))
+            .add_observer(|_: On<EntityEventA>, mut order: ResMut<Order>| {
+                order.observed("global");
+            })
             .id();
         world.spawn(
             Observer::new(|_: On<EntityEventA>, mut order: ResMut<Order>| {
@@ -1835,9 +1841,15 @@ mod tests {
 
         world.add_observers(
             (
-                Observer::new(|_: On<EventA>, mut order: ResMut<Order>| order.observed("a")),
-                Observer::new(|_: On<EventA>, mut order: ResMut<Order>| order.observed("b")),
-                Observer::new(|_: On<EventA>, mut order: ResMut<Order>| order.observed("c")),
+                Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+                    order.observed("a");
+                }),
+                Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+                    order.observed("b");
+                }),
+                Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+                    order.observed("c");
+                }),
             )
                 .chain(),
         );
@@ -1855,8 +1867,12 @@ mod tests {
         world.init_resource::<Order>();
         world.add_observers(
             (
-                Observer::new(|_: On<EventA>, mut order: ResMut<Order>| order.observed("a")),
-                Observer::new(|_: On<EventA>, mut order: ResMut<Order>| order.observed("b")),
+                Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+                    order.observed("a");
+                }),
+                Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+                    order.observed("b");
+                }),
             )
                 .in_set(SetA),
         );
@@ -1876,13 +1892,19 @@ mod tests {
         let mut world = World::new();
         world.init_resource::<Order>();
         let c = world
-            .add_observer(|_: On<EventA>, mut order: ResMut<Order>| order.observed("c"))
+            .add_observer(|_: On<EventA>, mut order: ResMut<Order>| {
+                order.observed("c");
+            })
             .id();
 
         world.add_observers(
             (
-                Observer::new(|_: On<EventA>, mut order: ResMut<Order>| order.observed("a")),
-                Observer::new(|_: On<EventA>, mut order: ResMut<Order>| order.observed("b")),
+                Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+                    order.observed("a");
+                }),
+                Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+                    order.observed("b");
+                }),
             )
                 .after(c),
         );
@@ -2021,8 +2043,12 @@ mod tests {
         );
         world.add_observers(
             (
-                Observer::new(|_: On<EventA>, mut order: ResMut<Order>| order.observed("c")),
-                Observer::new(|_: On<EventA>, mut order: ResMut<Order>| order.observed("d")),
+                Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+                    order.observed("c");
+                }),
+                Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+                    order.observed("d");
+                }),
             )
                 .chain()
                 .after(SetB),

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -1862,6 +1862,36 @@ mod tests {
     }
 
     #[test]
+    fn observer_cross_bucket_set_chain_ordering() {
+        #[derive(ObserverSet, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        struct SetA;
+        #[derive(ObserverSet, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        struct SetB;
+
+        let mut world = World::new();
+        world.init_resource::<Order>();
+        world.configure_observer_sets((SetA, SetB).chain());
+        let target = world.spawn_empty().id();
+
+        world.spawn(
+            Observer::new(|_: On<EntityEventA>, mut order: ResMut<Order>| {
+                order.observed("global");
+            })
+            .in_set(SetB),
+        );
+        world.spawn(
+            Observer::new(|_: On<EntityEventA>, mut order: ResMut<Order>| {
+                order.observed("entity");
+            })
+            .with_entity(target)
+            .in_set(SetA),
+        );
+
+        world.trigger(EntityEventA(target));
+        assert_eq!(vec!["entity", "global"], world.resource::<Order>().0);
+    }
+
+    #[test]
     fn observer_lifecycle_archetype_flag_unchanged() {
         let mut world = World::new();
         let component = world.register_component::<A>();

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -28,10 +28,10 @@ use crate::{
 };
 
 impl World {
-    /// Spawns a "global" [`Observer`] which will watch for the given event.
-    /// Returns its [`Entity`] as a [`EntityWorldMut`].
+    /// Spawns one or more "global" [`Observer`]s which will watch for the given event.
+    /// Returns the first registered observer as an [`EntityWorldMut`].
     ///
-    /// `system` can be any system whose first parameter is [`On`].
+    /// `observer` can be any observer configuration whose first parameter is [`On`].
     ///
     /// # Example
     ///
@@ -56,15 +56,34 @@ impl World {
     /// # Panics
     ///
     /// Panics if the given system is an exclusive system.
-    pub fn add_observer<M>(&mut self, observer: impl IntoObserver<M>) -> EntityWorldMut<'_> {
-        self.spawn(observer.into_observer())
+    pub fn add_observer<M>(&mut self, observer: impl IntoObserverConfigs<M>) -> EntityWorldMut<'_> {
+        let entity = self
+            .add_observers(observer)
+            .into_iter()
+            .next()
+            .expect("observer configs must contain at least one observer");
+        self.entity_mut(entity)
     }
 
     /// Spawns multiple observers and returns their entities in registration order.
+    ///
+    /// Internally batches per-observer cache resorts so the topological sort
+    /// runs at most once for the whole call, instead of once per spawned
+    /// observer. On panic mid-batch the deferral is released and the unwind
+    /// resumes.
     pub fn add_observers<M>(&mut self, observers: impl IntoObserverConfigs<M>) -> Vec<Entity> {
+        struct ReleaseOnDrop<'w>(&'w mut World);
+        impl Drop for ReleaseOnDrop<'_> {
+            fn drop(&mut self) {
+                self.0.observers.release_defer_resort();
+            }
+        }
+
         let configs = observers.into_configs();
         let mut entities = Vec::with_capacity(configs.observers.len());
 
+        self.observers.bump_defer_resort();
+        let guard = ReleaseOnDrop(&mut *self);
         for mut observer in configs.observers {
             if configs.chain
                 && let Some(&previous) = entities.last()
@@ -72,19 +91,34 @@ impl World {
                 observer.after_inner(EdgeTarget::Entity(previous));
             }
 
-            let entity = self.spawn(observer).id();
+            let entity = guard.0.spawn(observer).id();
             entities.push(entity);
         }
+        drop(guard);
 
         entities
     }
 
     /// Configures observer set hierarchy and ordering.
+    ///
+    /// Batches per-cache resorts so the topological sort runs once at the
+    /// end of the call rather than once per affected cache.
     pub fn configure_observer_sets<M>(
         &mut self,
         sets: impl IntoObserverSetConfigs<M>,
     ) -> &mut Self {
-        self.observers.configure_observer_sets(sets);
+        struct ReleaseOnDrop<'w>(&'w mut World);
+        impl Drop for ReleaseOnDrop<'_> {
+            fn drop(&mut self) {
+                self.0.observers.release_defer_resort();
+            }
+        }
+
+        self.observers.bump_defer_resort();
+        {
+            let guard = ReleaseOnDrop(&mut *self);
+            guard.0.observers.configure_observer_sets(sets);
+        }
         self
     }
 
@@ -339,7 +373,9 @@ impl World {
     pub(crate) fn register_observer(&mut self, observer_entity: Entity) {
         // SAFETY: References do not alias.
         let (observer_state, archetypes, observers) = unsafe {
-            let observer_state: *const Observer = self.get::<Observer>(observer_entity).unwrap();
+            let mut observer_state = self.get_mut::<Observer>(observer_entity).unwrap();
+            observer_state.descriptor.frozen = true;
+            let observer_state: *const Observer = observer_state.as_ref();
             // Populate ObservedBy for each observed entity.
             for watched_entity in (*observer_state).descriptor.entities.iter().copied() {
                 let mut entity_mut = self.entity_mut(watched_entity);
@@ -396,8 +432,11 @@ impl World {
 
 #[cfg(test)]
 mod tests {
-    use alloc::{vec, vec::Vec};
+    use alloc::{string::String, vec, vec::Vec};
     use core::any::type_name;
+    #[cfg(debug_assertions)]
+    use core::panic::AssertUnwindSafe;
+    use std::panic::catch_unwind;
 
     use bevy_ptr::OwningPtr;
 
@@ -407,8 +446,9 @@ mod tests {
         error::Result,
         event::{EntityComponentsTrigger, Event, GlobalTrigger},
         hierarchy::ChildOf,
-        observer::{Discard, Observer},
+        observer::{Discard, Observer, WATCH_ENTITY_AFTER_REGISTRATION_MESSAGE},
         prelude::*,
+        schedule::graph::DiGraphToposortError,
         world::DeferredWorld,
     };
 
@@ -1646,6 +1686,146 @@ mod tests {
         assert_eq!(vec!["a", "a"], world.resource::<Order>().0);
     }
 
+    #[cfg(debug_assertions)]
+    #[test]
+    fn observer_watch_entity_panics_after_registration() {
+        let mut world = World::new();
+        let observer = world.spawn(Observer::new(|_: On<EntityEventA>| {})).id();
+        let watched = world.spawn_empty().id();
+
+        let panic = catch_unwind(AssertUnwindSafe(|| {
+            world
+                .get_mut::<Observer>(observer)
+                .unwrap()
+                .watch_entity(watched);
+        }))
+        .unwrap_err();
+
+        let message = panic
+            .downcast_ref::<String>()
+            .map(String::as_str)
+            .or_else(|| panic.downcast_ref::<&'static str>().copied())
+            .unwrap();
+        assert_eq!(message, WATCH_ENTITY_AFTER_REGISTRATION_MESSAGE);
+    }
+
+    #[test]
+    fn observer_chain_in_set_dedupes_edges() {
+        #[derive(ObserverSet, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        struct Sequenced;
+
+        let mut world = World::new();
+        world.init_resource::<Order>();
+
+        let observers = (
+            |_: On<EventA>, mut order: ResMut<Order>| order.observed("a"),
+            |_: On<EventA>, mut order: ResMut<Order>| order.observed("b"),
+            |_: On<EventA>, mut order: ResMut<Order>| order.observed("c"),
+        )
+            .chain()
+            .in_set(Sequenced);
+
+        let entities = world.add_observers(observers);
+        let event_key = world.register_event_key::<EventA>();
+
+        world.trigger(EventA);
+
+        assert_eq!(vec!["a", "b", "c"], world.resource::<Order>().0);
+
+        let cache = world.observers().try_get_observers(event_key).unwrap();
+        assert_eq!(cache.ordering_edge_count(), 2);
+        assert!(cache.contains_ordering_edge(entities[0], entities[1]));
+        assert!(cache.contains_ordering_edge(entities[1], entities[2]));
+    }
+
+    #[test]
+    fn observe_accepts_configs() {
+        #[derive(ObserverSet, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        struct SetA;
+        #[derive(ObserverSet, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        struct SetB;
+
+        let mut world = World::new();
+        world.init_resource::<Order>();
+        world.configure_observer_sets((SetA, SetB).chain());
+        let target = world.spawn_empty().id();
+
+        world
+            .entity_mut(target)
+            .observe(|_: On<EntityEventA>, mut order: ResMut<Order>| {
+                order.observed("direct");
+            });
+
+        {
+            let mut commands = world.commands();
+            commands.entity(target).observe(
+                (|_: On<EntityEventA>, mut order: ResMut<Order>| {
+                    order.observed("configured");
+                })
+                .in_set(SetA)
+                .before(SetB),
+            );
+        }
+        world.flush();
+
+        world.spawn(
+            Observer::new(|_: On<EntityEventA>, mut order: ResMut<Order>| {
+                order.observed("after");
+            })
+            .in_set(SetB),
+        );
+
+        world.trigger(EntityEventA(target));
+        assert_eq!(
+            vec!["direct", "configured", "after"],
+            world.resource::<Order>().0
+        );
+    }
+
+    #[test]
+    fn add_observer_accepts_configs() {
+        #[derive(ObserverSet, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        struct SetA;
+        #[derive(ObserverSet, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        struct SetB;
+
+        let mut world = World::new();
+        world.init_resource::<Order>();
+        world.configure_observer_sets((SetA, SetB).chain());
+
+        world.add_observer(|_: On<EventA>, mut order: ResMut<Order>| {
+            order.observed("direct");
+        });
+
+        {
+            let mut commands = world.commands();
+            let observer = commands
+                .add_observer(
+                    (|_: On<EventA>, mut order: ResMut<Order>| {
+                        order.observed("configured");
+                    })
+                    .in_set(SetA)
+                    .before(SetB),
+                )
+                .id();
+            assert_ne!(observer, Entity::PLACEHOLDER);
+        }
+        world.flush();
+
+        world.spawn(
+            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+                order.observed("after");
+            })
+            .in_set(SetB),
+        );
+
+        world.trigger(EventA);
+        assert_eq!(
+            vec!["direct", "configured", "after"],
+            world.resource::<Order>().0
+        );
+    }
+
     #[test]
     fn observer_set_before_after_global() {
         #[derive(ObserverSet, Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -1802,6 +1982,73 @@ mod tests {
         world
             .entity_mut(b)
             .insert(Observer::new(|_: On<EventA>| {}).after(a));
+    }
+
+    #[test]
+    fn cycle_warning_includes_names() {
+        let mut world = World::new();
+        let first = world
+            .spawn(Observer::new(|_: On<EventA>| {}).with_name("first"))
+            .id();
+        let second = world
+            .spawn(Observer::new(|_: On<EventA>| {}).with_name("second"))
+            .id();
+        let event_key = world.event_key::<EventA>().unwrap();
+        let cache = world.observers().try_get_observers(event_key).unwrap();
+        let first_node = cache.observer_node_id(first).unwrap();
+        let second_node = cache.observer_node_id(second).unwrap();
+        let cycle = DiGraphToposortError::Cycle(vec![vec![first_node, second_node]]);
+
+        assert_eq!(
+            vec![vec![(first, Some("first")), (second, Some("second"))]],
+            cache.cycle_members_with_names(&cycle)
+        );
+
+        let self_loop = DiGraphToposortError::Loop(first_node);
+        assert_eq!(
+            vec![vec![(first, Some("first"))]],
+            cache.cycle_members_with_names(&self_loop)
+        );
+    }
+
+    #[test]
+    fn batch_add_observers_runs_one_resort() {
+        let mut world = World::new();
+        let before = world.observers().total_rebuild_order_calls();
+
+        world.add_observers((
+            |_: On<EventA>| {},
+            |_: On<EventA>| {},
+            |_: On<EventA>| {},
+            |_: On<EventA>| {},
+            |_: On<EventA>| {},
+        ));
+
+        let after = world.observers().total_rebuild_order_calls();
+        assert_eq!(
+            after - before,
+            1,
+            "batch add_observers must coalesce to a single resort, got {} resorts",
+            after - before,
+        );
+    }
+
+    #[test]
+    fn single_add_observer_resorts_per_call() {
+        let mut world = World::new();
+        let before = world.observers().total_rebuild_order_calls();
+
+        for _ in 0..5 {
+            world.add_observer(|_: On<EventA>| {});
+        }
+
+        let after = world.observers().total_rebuild_order_calls();
+        assert_eq!(
+            after - before,
+            5,
+            "five separate add_observer calls must each resort, got {} resorts",
+            after - before,
+        );
     }
 
     #[test]

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -336,30 +336,33 @@ impl World {
 
         for &event_key in &descriptor.event_keys {
             let cache = observers.get_observers_mut(event_key);
+            cache.register_observer(observer_entity, observer_state.runner, descriptor);
 
             if descriptor.components.is_empty() && descriptor.entities.is_empty() {
                 cache
-                    .global_observers
+                    .global_observers_legacy
                     .insert(observer_entity, observer_state.runner);
             } else if descriptor.components.is_empty() {
                 // Observer is not targeting any components so register it as an entity observer
                 for &watched_entity in &observer_state.descriptor.entities {
-                    let map = cache.entity_observers.entry(watched_entity).or_default();
+                    let map = cache
+                        .entity_observers_legacy
+                        .entry(watched_entity)
+                        .or_default();
                     map.insert(observer_entity, observer_state.runner);
                 }
             } else {
                 // Register observer for each watched component
                 for &component in &descriptor.components {
-                    let observers =
-                        cache
-                            .component_observers
-                            .entry(component)
-                            .or_insert_with(|| {
-                                if let Some(flag) = Observers::is_archetype_cached(event_key) {
-                                    archetypes.update_flags(component, flag, true);
-                                }
-                                CachedComponentObservers::default()
-                            });
+                    let observers = cache
+                        .component_observers_legacy
+                        .entry(component)
+                        .or_insert_with(|| {
+                            if let Some(flag) = Observers::is_archetype_cached(event_key) {
+                                archetypes.update_flags(component, flag, true);
+                            }
+                            CachedComponentObservers::default()
+                        });
                     if descriptor.entities.is_empty() {
                         // Register for all triggers targeting the component
                         observers
@@ -387,22 +390,25 @@ impl World {
 
         for &event_key in &descriptor.event_keys {
             let cache = observers.get_observers_mut(event_key);
+            cache.unregister_observer(entity, &descriptor);
             if descriptor.components.is_empty() && descriptor.entities.is_empty() {
-                cache.global_observers.remove(&entity);
+                cache.global_observers_legacy.remove(&entity);
             } else if descriptor.components.is_empty() {
                 for watched_entity in &descriptor.entities {
                     // This check should be unnecessary since this observer hasn't been unregistered yet
-                    let Some(observers) = cache.entity_observers.get_mut(watched_entity) else {
+                    let Some(observers) = cache.entity_observers_legacy.get_mut(watched_entity)
+                    else {
                         continue;
                     };
                     observers.remove(&entity);
                     if observers.is_empty() {
-                        cache.entity_observers.remove(watched_entity);
+                        cache.entity_observers_legacy.remove(watched_entity);
                     }
                 }
             } else {
                 for component in &descriptor.components {
-                    let Some(observers) = cache.component_observers.get_mut(component) else {
+                    let Some(observers) = cache.component_observers_legacy.get_mut(component)
+                    else {
                         continue;
                     };
                     if descriptor.entities.is_empty() {
@@ -424,16 +430,17 @@ impl World {
                     if observers.global_observers.is_empty()
                         && observers.entity_component_observers.is_empty()
                     {
-                        cache.component_observers.remove(component);
+                        cache.component_observers_legacy.remove(component);
                         if let Some(flag) = Observers::is_archetype_cached(event_key)
                             && let Some(by_component) = archetypes.by_component.get(component)
                         {
                             for archetype in by_component.keys() {
                                 let archetype = &mut archetypes.archetypes[archetype.index()];
                                 if archetype.contains(*component) {
-                                    let no_longer_observed = archetype
-                                        .iter_components()
-                                        .all(|id| !cache.component_observers.contains_key(&id));
+                                    let no_longer_observed =
+                                        archetype.iter_components().all(|id| {
+                                            !cache.component_observers_legacy.contains_key(&id)
+                                        });
 
                                     if no_longer_observed {
                                         archetype.flags.set(flag, false);
@@ -1548,7 +1555,7 @@ mod tests {
         assert!(!world
             .observers
             .get_observers_mut(event_key)
-            .global_observers
+            .global_observers_legacy
             .contains_key(&id));
     }
 
@@ -1563,7 +1570,7 @@ mod tests {
         assert!(!world
             .observers
             .get_observers_mut(event_key)
-            .entity_observers
+            .entity_observers_legacy
             .contains_key(&entity));
     }
 

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -336,48 +336,12 @@ impl World {
 
         for &event_key in &descriptor.event_keys {
             let cache = observers.get_observers_mut(event_key);
-            cache.register_observer(observer_entity, observer_state.runner, descriptor);
+            let newly_observed_components =
+                cache.register_observer(observer_entity, observer_state.runner, descriptor);
 
-            if descriptor.components.is_empty() && descriptor.entities.is_empty() {
-                cache
-                    .global_observers_legacy
-                    .insert(observer_entity, observer_state.runner);
-            } else if descriptor.components.is_empty() {
-                // Observer is not targeting any components so register it as an entity observer
-                for &watched_entity in &observer_state.descriptor.entities {
-                    let map = cache
-                        .entity_observers_legacy
-                        .entry(watched_entity)
-                        .or_default();
-                    map.insert(observer_entity, observer_state.runner);
-                }
-            } else {
-                // Register observer for each watched component
-                for &component in &descriptor.components {
-                    let observers = cache
-                        .component_observers_legacy
-                        .entry(component)
-                        .or_insert_with(|| {
-                            if let Some(flag) = Observers::is_archetype_cached(event_key) {
-                                archetypes.update_flags(component, flag, true);
-                            }
-                            CachedComponentObservers::default()
-                        });
-                    if descriptor.entities.is_empty() {
-                        // Register for all triggers targeting the component
-                        observers
-                            .global_observers
-                            .insert(observer_entity, observer_state.runner);
-                    } else {
-                        // Register for each watched entity
-                        for &watched_entity in &descriptor.entities {
-                            let map = observers
-                                .entity_component_observers
-                                .entry(watched_entity)
-                                .or_default();
-                            map.insert(observer_entity, observer_state.runner);
-                        }
-                    }
+            if let Some(flag) = Observers::is_archetype_cached(event_key) {
+                for component in newly_observed_components {
+                    archetypes.update_flags(component, flag, true);
                 }
             }
         }
@@ -390,62 +354,21 @@ impl World {
 
         for &event_key in &descriptor.event_keys {
             let cache = observers.get_observers_mut(event_key);
-            cache.unregister_observer(entity, &descriptor);
-            if descriptor.components.is_empty() && descriptor.entities.is_empty() {
-                cache.global_observers_legacy.remove(&entity);
-            } else if descriptor.components.is_empty() {
-                for watched_entity in &descriptor.entities {
-                    // This check should be unnecessary since this observer hasn't been unregistered yet
-                    let Some(observers) = cache.entity_observers_legacy.get_mut(watched_entity)
-                    else {
-                        continue;
-                    };
-                    observers.remove(&entity);
-                    if observers.is_empty() {
-                        cache.entity_observers_legacy.remove(watched_entity);
-                    }
-                }
-            } else {
-                for component in &descriptor.components {
-                    let Some(observers) = cache.component_observers_legacy.get_mut(component)
-                    else {
-                        continue;
-                    };
-                    if descriptor.entities.is_empty() {
-                        observers.global_observers.remove(&entity);
-                    } else {
-                        for watched_entity in &descriptor.entities {
-                            let Some(map) =
-                                observers.entity_component_observers.get_mut(watched_entity)
-                            else {
-                                continue;
-                            };
-                            map.remove(&entity);
-                            if map.is_empty() {
-                                observers.entity_component_observers.remove(watched_entity);
-                            }
-                        }
-                    }
+            let removed_components = cache.unregister_observer(entity, &descriptor);
 
-                    if observers.global_observers.is_empty()
-                        && observers.entity_component_observers.is_empty()
-                    {
-                        cache.component_observers_legacy.remove(component);
-                        if let Some(flag) = Observers::is_archetype_cached(event_key)
-                            && let Some(by_component) = archetypes.by_component.get(component)
-                        {
-                            for archetype in by_component.keys() {
-                                let archetype = &mut archetypes.archetypes[archetype.index()];
-                                if archetype.contains(*component) {
-                                    let no_longer_observed =
-                                        archetype.iter_components().all(|id| {
-                                            !cache.component_observers_legacy.contains_key(&id)
-                                        });
+            for component in removed_components {
+                if let Some(flag) = Observers::is_archetype_cached(event_key)
+                    && let Some(by_component) = archetypes.by_component.get(&component)
+                {
+                    for archetype in by_component.keys() {
+                        let archetype = &mut archetypes.archetypes[archetype.index()];
+                        if archetype.contains(component) {
+                            let no_longer_observed = archetype
+                                .iter_components()
+                                .all(|id| !cache.contains_component_observers(id));
 
-                                    if no_longer_observed {
-                                        archetype.flags.set(flag, false);
-                                    }
-                                }
+                            if no_longer_observed {
+                                archetype.flags.set(flag, false);
                             }
                         }
                     }

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -18,6 +18,8 @@ pub use runner::*;
 pub use set::*;
 pub use system_param::*;
 
+use alloc::vec::Vec;
+
 use crate::{
     change_detection::MaybeLocation,
     event::Event,
@@ -56,6 +58,34 @@ impl World {
     /// Panics if the given system is an exclusive system.
     pub fn add_observer<M>(&mut self, observer: impl IntoObserver<M>) -> EntityWorldMut<'_> {
         self.spawn(observer.into_observer())
+    }
+
+    /// Spawns multiple observers and returns their entities in registration order.
+    pub fn add_observers<M>(&mut self, observers: impl IntoObserverConfigs<M>) -> Vec<Entity> {
+        let configs = observers.into_configs();
+        let mut entities = Vec::with_capacity(configs.observers.len());
+
+        for mut observer in configs.observers {
+            if configs.chain
+                && let Some(&previous) = entities.last()
+            {
+                observer.after_inner(EdgeTarget::Entity(previous));
+            }
+
+            let entity = self.spawn(observer).id();
+            entities.push(entity);
+        }
+
+        entities
+    }
+
+    /// Configures observer set hierarchy and ordering.
+    pub fn configure_observer_sets<M>(
+        &mut self,
+        sets: impl IntoObserverSetConfigs<M>,
+    ) -> &mut Self {
+        self.observers.configure_observer_sets(sets);
+        self
     }
 
     /// Triggers the given [`Event`], which will run any [`Observer`]s watching for it.
@@ -1454,6 +1484,449 @@ mod tests {
         world.trigger(EntityEventA(entities[2]));
         world.trigger(EntityEventA(entities[3]));
         assert_eq!(vec!["a", "a"], world.resource::<Order>().0);
+    }
+
+    #[test]
+    fn observer_set_before_after_global() {
+        #[derive(ObserverSet, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        struct WinCheck;
+
+        let mut world = World::new();
+        world.init_resource::<Order>();
+
+        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+            order.observed("win1");
+        }).in_set(WinCheck));
+        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+            order.observed("win2");
+        }).in_set(WinCheck));
+        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+            order.observed("win3");
+        }).in_set(WinCheck));
+        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+            order.observed("after");
+        }).after(WinCheck));
+        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+            order.observed("before");
+        }).before(WinCheck));
+
+        world.trigger(EventA);
+
+        assert_eq!(
+            vec!["before", "win1", "win2", "win3", "after"],
+            world.resource::<Order>().0
+        );
+    }
+
+    #[test]
+    fn observer_after_by_entity() {
+        let mut world = World::new();
+        world.init_resource::<Order>();
+
+        let a = world
+            .add_observer(|_: On<EventA>, mut order: ResMut<Order>| order.observed("a"))
+            .id();
+        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+            order.observed("b");
+        }).after(a));
+
+        world.trigger(EventA);
+        assert_eq!(vec!["a", "b"], world.resource::<Order>().0);
+
+        let mut world = World::new();
+        world.init_resource::<Order>();
+        let a = world.spawn_empty().id();
+        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+            order.observed("b");
+        }).after(a));
+        world.entity_mut(a).insert(Observer::new(
+            |_: On<EventA>, mut order: ResMut<Order>| order.observed("a"),
+        ));
+
+        world.trigger(EventA);
+        assert_eq!(vec!["a", "b"], world.resource::<Order>().0);
+    }
+
+    #[test]
+    fn observer_multiple_sets() {
+        #[derive(ObserverSet, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        struct SetA;
+        #[derive(ObserverSet, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        struct SetB;
+
+        let mut world = World::new();
+        world.init_resource::<Order>();
+
+        world.spawn(
+            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| order.observed("x"))
+                .in_set(SetA)
+                .in_set(SetB),
+        );
+        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+            order.observed("y");
+        }).after(SetA));
+        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+            order.observed("z");
+        }).after(SetB));
+
+        world.trigger(EventA);
+        let order = &world.resource::<Order>().0;
+        let x = order.iter().position(|value| *value == "x").unwrap();
+        let y = order.iter().position(|value| *value == "y").unwrap();
+        let z = order.iter().position(|value| *value == "z").unwrap();
+        assert!(x < y);
+        assert!(x < z);
+    }
+
+    #[test]
+    fn observer_after_empty_set() {
+        #[derive(ObserverSet, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        struct EmptySet;
+
+        let mut world = World::new();
+        world.init_resource::<Order>();
+        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+            order.observed("runs");
+        }).after(EmptySet));
+
+        world.trigger(EventA);
+        assert_eq!(vec!["runs"], world.resource::<Order>().0);
+    }
+
+    #[test]
+    #[should_panic(expected = "observer ordering graph contains a cycle")]
+    fn observer_cycle_detection() {
+        let mut world = World::new();
+
+        let a = world.spawn_empty().id();
+        let b = world.spawn_empty().id();
+        world.entity_mut(a).insert(Observer::new(|_: On<EventA>| {}).after(b));
+        world.entity_mut(b).insert(Observer::new(|_: On<EventA>| {}).after(a));
+    }
+
+    #[test]
+    fn observer_set_unregister_preserves_order() {
+        #[derive(ObserverSet, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        struct WinCheck;
+
+        let mut world = World::new();
+        world.init_resource::<Order>();
+
+        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+            order.observed("a");
+        }).in_set(WinCheck));
+        let b = world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+            order.observed("b");
+        }).in_set(WinCheck)).id();
+        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+            order.observed("c");
+        }).in_set(WinCheck));
+        world.entity_mut(b).remove::<Observer>();
+
+        world.trigger(EventA);
+        assert_eq!(vec!["a", "c"], world.resource::<Order>().0);
+    }
+
+    #[test]
+    fn observer_cross_bucket_ordering() {
+        let mut world = World::new();
+        world.init_resource::<Order>();
+        let target = world.spawn_empty().id();
+
+        let global = world
+            .add_observer(|_: On<EntityEventA>, mut order: ResMut<Order>| order.observed("global"))
+            .id();
+        world.spawn(
+            Observer::new(|_: On<EntityEventA>, mut order: ResMut<Order>| {
+                order.observed("entity");
+            })
+            .with_entity(target)
+            .after(global),
+        );
+
+        world.trigger(EntityEventA(target));
+        assert_eq!(vec!["global", "entity"], world.resource::<Order>().0);
+    }
+
+    #[test]
+    fn observer_lifecycle_archetype_flag_unchanged() {
+        let mut world = World::new();
+        let component = world.register_component::<A>();
+        let observer = world.add_observer(|_: On<Insert, A>| {}).id();
+        world.spawn(A).flush();
+
+        assert!(world
+            .archetypes
+            .iter()
+            .any(|archetype| archetype.contains(component) && archetype.has_insert_observer()));
+
+        world.entity_mut(observer).remove::<Observer>();
+        assert!(world
+            .archetypes
+            .iter()
+            .filter(|archetype| archetype.contains(component))
+            .all(|archetype| !archetype.has_insert_observer()));
+    }
+
+    #[test]
+    fn observer_propagation_uses_sorted_dispatch() {
+        #[derive(ObserverSet, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        struct WinCheck;
+
+        #[derive(Resource, Default)]
+        struct PropagationOrder(Vec<(Entity, &'static str)>);
+
+        let mut world = World::new();
+        world.init_resource::<PropagationOrder>();
+        let parent = world.spawn_empty().id();
+        let child = world.spawn(ChildOf(parent)).id();
+
+        world.spawn(Observer::new(
+            |event: On<EventPropagating>, mut order: ResMut<PropagationOrder>| {
+                order.0.push((event.event_target(), "win"));
+            },
+        ).in_set(WinCheck));
+        world.spawn(Observer::new(
+            |event: On<EventPropagating>, mut order: ResMut<PropagationOrder>| {
+                order.0.push((event.event_target(), "after"));
+            },
+        ).after(WinCheck));
+
+        world.trigger(EventPropagating(child));
+        assert_eq!(
+            vec![(child, "win"), (child, "after"), (parent, "win"), (parent, "after")],
+            world.resource::<PropagationOrder>().0
+        );
+    }
+
+    #[test]
+    fn observer_nested_sets() {
+        #[derive(ObserverSet, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        struct SetA;
+        #[derive(ObserverSet, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        struct SetB;
+        #[derive(ObserverSet, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        struct Outer;
+
+        let mut world = World::new();
+        world.init_resource::<Order>();
+        world.configure_observer_sets((SetA, SetB).in_set(Outer));
+
+        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+            order.observed("a1");
+        }).in_set(SetA));
+        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+            order.observed("a2");
+        }).in_set(SetA));
+        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+            order.observed("b1");
+        }).in_set(SetB));
+        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+            order.observed("b2");
+        }).in_set(SetB));
+        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+            order.observed("after");
+        }).after(Outer));
+
+        world.trigger(EventA);
+        assert_eq!(
+            vec!["a1", "a2", "b1", "b2", "after"],
+            world.resource::<Order>().0
+        );
+    }
+
+    #[test]
+    fn observer_dispatch_order_for_accessor() {
+        let mut world = World::new();
+        let target = world.spawn_empty().id();
+        let global = world.add_observer(|_: On<EntityEventA>| {}).id();
+        let entity = world
+            .spawn(Observer::new(|_: On<EntityEventA>| {}).with_entity(target).after(global))
+            .id();
+
+        let event_key = world.event_key::<EntityEventA>().unwrap();
+        assert_eq!(
+            &[global, entity],
+            world.observers().dispatch_order_for(event_key)
+        );
+    }
+
+    #[test]
+    fn observer_chain_three() {
+        let mut world = World::new();
+        world.init_resource::<Order>();
+
+        world.add_observers((
+            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| order.observed("a")),
+            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| order.observed("b")),
+            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| order.observed("c")),
+        ).chain());
+
+        world.trigger(EventA);
+        assert_eq!(vec!["a", "b", "c"], world.resource::<Order>().0);
+    }
+
+    #[test]
+    fn observer_tuple_in_set_applies_to_all() {
+        #[derive(ObserverSet, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        struct SetA;
+
+        let mut world = World::new();
+        world.init_resource::<Order>();
+        world.add_observers((
+            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| order.observed("a")),
+            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| order.observed("b")),
+        ).in_set(SetA));
+        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+            order.observed("after");
+        }).after(SetA));
+
+        world.trigger(EventA);
+        assert_eq!(vec!["a", "b", "after"], world.resource::<Order>().0);
+    }
+
+    #[test]
+    fn observer_tuple_after_applies_to_all() {
+        let mut world = World::new();
+        world.init_resource::<Order>();
+        let c = world
+            .add_observer(|_: On<EventA>, mut order: ResMut<Order>| order.observed("c"))
+            .id();
+
+        world.add_observers((
+            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| order.observed("a")),
+            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| order.observed("b")),
+        ).after(c));
+
+        world.trigger(EventA);
+        let order = &world.resource::<Order>().0;
+        let c = order.iter().position(|value| *value == "c").unwrap();
+        let a = order.iter().position(|value| *value == "a").unwrap();
+        let b = order.iter().position(|value| *value == "b").unwrap();
+        assert!(c < a);
+        assert!(c < b);
+    }
+
+    #[test]
+    fn observer_set_chain() {
+        #[derive(ObserverSet, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        struct SetA;
+        #[derive(ObserverSet, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        struct SetB;
+        #[derive(ObserverSet, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        struct SetC;
+
+        let mut world = World::new();
+        world.init_resource::<Order>();
+        world.configure_observer_sets((SetA, SetB, SetC).chain());
+        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+            order.observed("a");
+        }).in_set(SetA));
+        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+            order.observed("b");
+        }).in_set(SetB));
+        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+            order.observed("c");
+        }).in_set(SetC));
+
+        world.trigger(EventA);
+        assert_eq!(vec!["a", "b", "c"], world.resource::<Order>().0);
+    }
+
+    #[test]
+    fn observer_naming_appears_in_dispatch_order() {
+        let mut world = World::new();
+        let observer = world
+            .spawn(Observer::new(|_: On<EventA>| {}).with_name("named"))
+            .id();
+        let event_key = world.event_key::<EventA>().unwrap();
+
+        assert_eq!(
+            vec![(observer, Some("named"))],
+            world.observers().dispatch_order_for_with_names(event_key)
+        );
+    }
+
+    #[test]
+    fn observer_dispatch_order_for_set_filters_correctly() {
+        #[derive(ObserverSet, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        struct SetA;
+
+        let mut world = World::new();
+        let a = world.spawn(Observer::new(|_: On<EventA>| {}).in_set(SetA)).id();
+        world.add_observer(|_: On<EventA>| {});
+        let b = world.spawn(Observer::new(|_: On<EventA>| {}).in_set(SetA)).id();
+        let event_key = world.event_key::<EventA>().unwrap();
+
+        assert_eq!(
+            vec![a, b],
+            world.observers().dispatch_order_for_set(event_key, SetA)
+        );
+    }
+
+    #[test]
+    fn observer_dispatch_order_for_target_filters_correctly() {
+        let mut world = World::new();
+        let target = world.spawn_empty().id();
+        let other = world.spawn_empty().id();
+        world.add_observer(|_: On<EntityEventA>| {});
+        let target_observer = world
+            .spawn(Observer::new(|_: On<EntityEventA>| {}).with_entity(target))
+            .id();
+        world.spawn(Observer::new(|_: On<EntityEventA>| {}).with_entity(other));
+        let event_key = world.event_key::<EntityEventA>().unwrap();
+
+        assert_eq!(
+            vec![target_observer],
+            world
+                .observers()
+                .dispatch_order_for_target(event_key, target)
+        );
+        assert_eq!(
+            vec![(target_observer, None)],
+            world
+                .observers()
+                .dispatch_order_for_target_with_names(event_key, target)
+        );
+    }
+
+    #[test]
+    fn followup_phase01_smoke_api_surface_present() {
+        // API surface canary — do not remove.
+        #[derive(ObserverSet, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        struct SetA;
+        #[derive(ObserverSet, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        struct SetB;
+
+        let mut world = World::new();
+        world.init_resource::<Order>();
+        world.configure_observer_sets((SetA, SetB).chain());
+        let a = world
+            .spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+                order.observed("a");
+            }).in_set(SetA))
+            .id();
+        world.spawn(Observer::new(|_: On<EventA>, mut order: ResMut<Order>| {
+            order.observed("b");
+        }).in_set(SetB).after(a).with_name("b"));
+        world.add_observers((
+            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| order.observed("c")),
+            Observer::new(|_: On<EventA>, mut order: ResMut<Order>| order.observed("d")),
+        ).chain().after(SetB));
+
+        world.trigger(EventA);
+        let event_key = world.event_key::<EventA>().unwrap();
+        assert!(!world.observers().dispatch_order_for(event_key).is_empty());
+        assert!(!world.observers().dispatch_order_for_set(event_key, SetA).is_empty());
+        assert!(!world
+            .observers()
+            .dispatch_order_for_with_names(event_key)
+            .is_empty());
+        assert!(world
+            .observers()
+            .dispatch_order_for_target_with_names(event_key, Entity::PLACEHOLDER)
+            .is_empty());
+        assert_eq!(vec!["a", "b", "c", "d"], world.resource::<Order>().0);
     }
 
     #[test]

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -170,19 +170,18 @@ impl World {
             world.as_unsafe_world_cell().increment_trigger_id();
         }
 
-        for (observer, runner) in observers.global_observers() {
-            // SAFETY:
-            // - `observers` come from `world` and correspond to `event_key`
-            // - caller guarantees `event_data` and `trigger_data` are valid
-            unsafe {
-                (runner)(
-                    world.reborrow(),
-                    *observer,
-                    &context,
-                    event_data.reborrow(),
-                    trigger_data.reborrow(),
-                );
-            }
+        // SAFETY:
+        // - `observers` come from `world` and correspond to `event_key`
+        // - caller guarantees `event_data` and `trigger_data` are valid
+        unsafe {
+            run_ordered::<1>(
+                observers,
+                &mut world,
+                &context,
+                &mut event_data,
+                &mut trigger_data,
+                [observers.global_observers()],
+            );
         }
     }
 
@@ -285,35 +284,24 @@ impl World {
         // Trigger observers watching for specific components.
         for id in components {
             if let Some(component_observers) = observers.component_observers().get(id) {
-                for (observer, runner) in component_observers.global_observers() {
-                    // SAFETY: same as above, caller guarantees data validity
-                    unsafe {
-                        (runner)(
-                            world.reborrow(),
-                            *observer,
-                            &context,
-                            event_data.reborrow(),
-                            trigger_data.reborrow(),
-                        );
-                    }
-                }
-
-                if let Some(map) = component_observers
+                let entity_component_observers = component_observers
                     .entity_component_observers()
                     .get(&entity)
-                {
-                    for (observer, runner) in map {
-                        // SAFETY: same as above, caller guarantees data validity
-                        unsafe {
-                            (runner)(
-                                world.reborrow(),
-                                *observer,
-                                &context,
-                                event_data.reborrow(),
-                                trigger_data.reborrow(),
-                            );
-                        }
-                    }
+                    .map_or(&[] as &[_], smallvec::SmallVec::as_slice);
+
+                // SAFETY: same as above, caller guarantees data validity.
+                unsafe {
+                    run_ordered::<2>(
+                        observers,
+                        &mut world,
+                        &context,
+                        &mut event_data,
+                        &mut trigger_data,
+                        [
+                            component_observers.global_observers(),
+                            entity_component_observers,
+                        ],
+                    );
                 }
             }
         }

--- a/crates/bevy_ecs/src/observer/set.rs
+++ b/crates/bevy_ecs/src/observer/set.rs
@@ -1,0 +1,43 @@
+use crate::{define_label, intern::Interned};
+
+pub use bevy_ecs_macros::ObserverSet;
+
+define_label!(
+    /// Observer sets are tag-like labels that can be used to group observers together.
+    ///
+    /// They are intended to support observer ordering and shared observer configuration.
+    /// Observer set configuration is not yet wired into dispatch; this trait is the
+    /// foundation used by the observer storage and builder APIs.
+    ///
+    /// # Defining new observer sets
+    ///
+    /// To create a new observer set, use the `#[derive(ObserverSet)]` macro.
+    ///
+    /// ```
+    /// use bevy_ecs::observer::ObserverSet;
+    ///
+    /// #[derive(ObserverSet, Debug, Clone, PartialEq, Eq, Hash)]
+    /// struct GameplayObservers;
+    /// ```
+    #[diagnostic::on_unimplemented(
+        note = "consider annotating `{Self}` with `#[derive(ObserverSet)]`"
+    )]
+    ObserverSet,
+    OBSERVER_SET_INTERNER
+);
+
+/// A shorthand for `Interned<dyn ObserverSet>`.
+pub type InternedObserverSet = Interned<dyn ObserverSet>;
+
+#[cfg(test)]
+mod tests {
+    use super::ObserverSet;
+
+    #[test]
+    fn test_derive_observer_set() {
+        #[derive(ObserverSet, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        struct Smoke;
+
+        assert_eq!(Smoke.intern(), Smoke.intern());
+    }
+}

--- a/crates/bevy_ecs/src/observer/set.rs
+++ b/crates/bevy_ecs/src/observer/set.rs
@@ -13,9 +13,10 @@ pub use bevy_ecs_macros::ObserverSet;
 define_label!(
     /// Observer sets are tag-like labels that can be used to group observers together.
     ///
-    /// They are intended to support observer ordering and shared observer configuration.
-    /// Observer set configuration is not yet wired into dispatch; this trait is the
-    /// foundation used by the observer storage and builder APIs.
+    /// Use them to group observers, configure ordering with
+    /// [`World::configure_observer_sets`](crate::world::World::configure_observer_sets),
+    /// and attach configured observers with [`Observer::in_set`](crate::observer::Observer::in_set)
+    /// or tuple-style configuration such as `(a, b, c).in_set(Set)`.
     ///
     /// # Defining new observer sets
     ///

--- a/crates/bevy_ecs/src/observer/set.rs
+++ b/crates/bevy_ecs/src/observer/set.rs
@@ -1,4 +1,12 @@
-use crate::{define_label, intern::Interned};
+use alloc::{vec, vec::Vec};
+use variadics_please::all_tuples;
+
+use crate::{
+    define_label,
+    entity::Entity,
+    intern::Interned,
+    observer::{EdgeTarget, IntoObserver, Observer},
+};
 
 pub use bevy_ecs_macros::ObserverSet;
 
@@ -28,6 +36,311 @@ define_label!(
 
 /// A shorthand for `Interned<dyn ObserverSet>`.
 pub type InternedObserverSet = Interned<dyn ObserverSet>;
+
+/// A target that can be used in observer ordering constraints.
+#[doc(hidden)]
+pub struct ObserverOrderingTarget(EdgeTarget);
+
+impl ObserverOrderingTarget {
+    pub(crate) fn into_edge_target(self) -> EdgeTarget {
+        self.0
+    }
+}
+
+/// Types that can be used as an observer ordering target.
+pub trait IntoObserverOrderingTarget {
+    /// Convert this value into an observer ordering target.
+    fn into_observer_ordering_target(self) -> ObserverOrderingTarget;
+}
+
+impl IntoObserverOrderingTarget for Entity {
+    fn into_observer_ordering_target(self) -> ObserverOrderingTarget {
+        ObserverOrderingTarget(EdgeTarget::Entity(self))
+    }
+}
+
+impl<S: ObserverSet> IntoObserverOrderingTarget for S {
+    fn into_observer_ordering_target(self) -> ObserverOrderingTarget {
+        ObserverOrderingTarget(EdgeTarget::Set(self.intern()))
+    }
+}
+
+/// A configured collection of observers.
+pub struct ObserverConfigs {
+    pub(crate) observers: Vec<Observer>,
+    pub(crate) chain: bool,
+}
+
+impl ObserverConfigs {
+    fn new(observer: Observer) -> Self {
+        Self {
+            observers: vec![observer],
+            chain: false,
+        }
+    }
+
+    /// Add every observer in this collection to `set`.
+    pub fn in_set<S: ObserverSet>(mut self, set: S) -> Self {
+        let set = set.intern();
+        for observer in &mut self.observers {
+            observer.descriptor.sets.push(set);
+        }
+        self
+    }
+
+    /// Run every observer in this collection before `target`.
+    pub fn before(mut self, target: impl IntoObserverOrderingTarget) -> Self {
+        let target = target.into_observer_ordering_target().into_edge_target();
+        for observer in &mut self.observers {
+            observer.before_inner(target.clone());
+        }
+        self
+    }
+
+    /// Run every observer in this collection after `target`.
+    pub fn after(mut self, target: impl IntoObserverOrderingTarget) -> Self {
+        let target = target.into_observer_ordering_target().into_edge_target();
+        for observer in &mut self.observers {
+            observer.after_inner(target.clone());
+        }
+        self
+    }
+
+    /// Treat this observer collection as a sequence.
+    pub fn chain(mut self) -> Self {
+        self.chain = true;
+        self
+    }
+}
+
+/// Types that can be converted into observer configurations.
+pub trait IntoObserverConfigs<Marker>: Sized {
+    /// Convert into observer configurations.
+    fn into_configs(self) -> ObserverConfigs;
+
+    /// Add these observers to `set`.
+    fn in_set<S: ObserverSet>(self, set: S) -> ObserverConfigs {
+        self.into_configs().in_set(set)
+    }
+
+    /// Run these observers before `target`.
+    fn before<T: IntoObserverOrderingTarget>(self, target: T) -> ObserverConfigs {
+        self.into_configs().before(target)
+    }
+
+    /// Run these observers after `target`.
+    fn after<T: IntoObserverOrderingTarget>(self, target: T) -> ObserverConfigs {
+        self.into_configs().after(target)
+    }
+
+    /// Treat this observer collection as a sequence.
+    fn chain(self) -> ObserverConfigs {
+        self.into_configs().chain()
+    }
+}
+
+impl IntoObserverConfigs<()> for ObserverConfigs {
+    fn into_configs(self) -> ObserverConfigs {
+        self
+    }
+}
+
+impl<I, Marker> IntoObserverConfigs<Marker> for I
+where
+    I: IntoObserver<Marker>,
+{
+    fn into_configs(self) -> ObserverConfigs {
+        ObserverConfigs::new(self.into_observer())
+    }
+}
+
+#[doc(hidden)]
+pub struct ObserverConfigTupleMarker;
+
+macro_rules! impl_observer_config_tuple {
+    ($(#[$meta:meta])* $(($param: ident, $observer: ident)),*) => {
+        $(#[$meta])*
+        impl<$($param, $observer),*> IntoObserverConfigs<(ObserverConfigTupleMarker, $($param,)*)> for ($($observer,)*)
+        where
+            $($observer: IntoObserverConfigs<$param>),*
+        {
+            #[expect(
+                clippy::allow_attributes,
+                reason = "We are inside a macro, and as such, `non_snake_case` is not guaranteed to apply."
+            )]
+            #[allow(
+                non_snake_case,
+                reason = "Variable names are provided by the macro caller, not by us."
+            )]
+            fn into_configs(self) -> ObserverConfigs {
+                let ($($observer,)*) = self;
+                let mut observers = Vec::new();
+                $(
+                    observers.extend($observer.into_configs().observers);
+                )*
+                ObserverConfigs {
+                    observers,
+                    chain: false,
+                }
+            }
+        }
+    }
+}
+
+all_tuples!(
+    #[doc(fake_variadic)]
+    impl_observer_config_tuple,
+    1,
+    20,
+    P,
+    S
+);
+
+/// A configured collection of observer sets.
+#[derive(Clone, Default)]
+pub struct ObserverSetConfigs {
+    pub(crate) sets: Vec<InternedObserverSet>,
+    pub(crate) hierarchy: Vec<(InternedObserverSet, InternedObserverSet)>,
+    pub(crate) edges: Vec<(InternedObserverSet, InternedObserverSet)>,
+    pub(crate) chain: bool,
+}
+
+impl ObserverSetConfigs {
+    fn new(set: InternedObserverSet) -> Self {
+        Self {
+            sets: vec![set],
+            hierarchy: Vec::new(),
+            edges: Vec::new(),
+            chain: false,
+        }
+    }
+
+    /// Add every observer set in this collection to `parent`.
+    pub fn in_set<S: ObserverSet>(mut self, parent: S) -> Self {
+        let parent = parent.intern();
+        for &set in &self.sets {
+            self.hierarchy.push((set, parent));
+        }
+        self
+    }
+
+    /// Run every observer in these sets before every observer in `target`.
+    pub fn before<S: ObserverSet>(mut self, target: S) -> Self {
+        let target = target.intern();
+        for &set in &self.sets {
+            self.edges.push((set, target));
+        }
+        self
+    }
+
+    /// Run every observer in these sets after every observer in `target`.
+    pub fn after<S: ObserverSet>(mut self, target: S) -> Self {
+        let target = target.intern();
+        for &set in &self.sets {
+            self.edges.push((target, set));
+        }
+        self
+    }
+
+    /// Treat this observer set collection as a sequence.
+    pub fn chain(mut self) -> Self {
+        self.chain = true;
+        self
+    }
+
+    pub(crate) fn add_chain_edges(&mut self) {
+        if !self.chain {
+            return;
+        }
+
+        for sets in self.sets.windows(2) {
+            let edge = (sets[0], sets[1]);
+            if !self.edges.contains(&edge) {
+                self.edges.push(edge);
+            }
+        }
+    }
+}
+
+/// Types that can be converted into observer set configurations.
+pub trait IntoObserverSetConfigs<Marker>: Sized {
+    /// Convert into observer set configurations.
+    fn into_configs(self) -> ObserverSetConfigs;
+
+    /// Add these observer sets to `parent`.
+    fn in_set<S: ObserverSet>(self, parent: S) -> ObserverSetConfigs {
+        self.into_configs().in_set(parent)
+    }
+
+    /// Run these observer sets before `target`.
+    fn before<S: ObserverSet>(self, target: S) -> ObserverSetConfigs {
+        self.into_configs().before(target)
+    }
+
+    /// Run these observer sets after `target`.
+    fn after<S: ObserverSet>(self, target: S) -> ObserverSetConfigs {
+        self.into_configs().after(target)
+    }
+
+    /// Treat this observer set collection as a sequence.
+    fn chain(self) -> ObserverSetConfigs {
+        self.into_configs().chain()
+    }
+}
+
+impl IntoObserverSetConfigs<()> for ObserverSetConfigs {
+    fn into_configs(self) -> ObserverSetConfigs {
+        self
+    }
+}
+
+impl<S: ObserverSet> IntoObserverSetConfigs<()> for S {
+    fn into_configs(self) -> ObserverSetConfigs {
+        ObserverSetConfigs::new(self.intern())
+    }
+}
+
+#[doc(hidden)]
+pub struct ObserverSetConfigTupleMarker;
+
+macro_rules! impl_observer_set_config_tuple {
+    ($(#[$meta:meta])* $(($param: ident, $set: ident)),*) => {
+        $(#[$meta])*
+        impl<$($param, $set),*> IntoObserverSetConfigs<(ObserverSetConfigTupleMarker, $($param,)*)> for ($($set,)*)
+        where
+            $($set: IntoObserverSetConfigs<$param>),*
+        {
+            #[expect(
+                clippy::allow_attributes,
+                reason = "We are inside a macro, and as such, `non_snake_case` is not guaranteed to apply."
+            )]
+            #[allow(
+                non_snake_case,
+                reason = "Variable names are provided by the macro caller, not by us."
+            )]
+            fn into_configs(self) -> ObserverSetConfigs {
+                let ($($set,)*) = self;
+                let mut configs = ObserverSetConfigs::default();
+                $(
+                    let config = $set.into_configs();
+                    configs.sets.extend(config.sets);
+                    configs.hierarchy.extend(config.hierarchy);
+                    configs.edges.extend(config.edges);
+                )*
+                configs
+            }
+        }
+    }
+}
+
+all_tuples!(
+    #[doc(fake_variadic)]
+    impl_observer_set_config_tuple,
+    1,
+    20,
+    P,
+    S
+);
 
 #[cfg(test)]
 mod tests {

--- a/crates/bevy_ecs/src/schedule/graph/mod.rs
+++ b/crates/bevy_ecs/src/schedule/graph/mod.rs
@@ -13,6 +13,8 @@ mod graph_map;
 mod tarjan_scc;
 
 pub use dag::*;
+// Observer ordering storage also reuses this graph kernel so observer and
+// schedule execution order share one topological-sort implementation.
 pub use graph_map::{DiGraph, DiGraphToposortError, Direction, GraphNodeId, UnGraph};
 
 /// Specifies what kind of edge should be added to the dependency graph.

--- a/crates/bevy_ecs/src/system/commands/entity_command.rs
+++ b/crates/bevy_ecs/src/system/commands/entity_command.rs
@@ -17,7 +17,7 @@ use crate::{
     entity::{Entity, EntityClonerBuilder, OptIn, OptOut},
     error::EntityCommandOutput,
     name::Name,
-    observer::IntoEntityObserver,
+    observer::IntoObserverConfigs,
     relationship::RelationshipHookMode,
     system::Command,
     world::{error::EntityMutableFetchError, EntityWorldMut, FromWorld, World},
@@ -272,11 +272,16 @@ pub fn despawn() -> impl EntityCommand {
 /// watching for an [`EntityEvent`](crate::event::EntityEvent) of type `E` whose
 /// [`event_target`](crate::event::EntityEvent::event_target) targets this entity.
 ///
-/// Accepts any type that implements [`IntoEntityObserver`], including:
-/// - Observer systems (closures or functions implementing [`IntoObserverSystem`](crate::system::IntoObserverSystem))
-/// - Observer systems with run conditions (via `.run_if()`)
+/// Accepts any type that implements [`IntoObserverConfigs`], including:
+/// - bare observer systems (closures or functions implementing [`IntoObserverSystem`](crate::system::IntoObserverSystem))
+/// - observer systems with run conditions via `.run_if()`
+/// - tuples of observer systems, optionally with `.chain()`,
+///   `.in_set(Set)`, `.before(target)`, or `.after(target)` applied
+///
+/// All observers in the configs are attached to the target entity (i.e.
+/// `watch_entity` is called for each) before being spawned.
 #[track_caller]
-pub fn observe<M>(observer: impl IntoEntityObserver<M>) -> impl EntityCommand {
+pub fn observe<M>(observer: impl IntoObserverConfigs<M> + Send + 'static) -> impl EntityCommand {
     let caller = MaybeLocation::caller();
     move |mut entity: EntityWorldMut| {
         entity.observe_with_caller(observer, caller);

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -26,7 +26,7 @@ use crate::{
     error::{warn, BevyError, ErrorContext},
     event::{EntityEvent, Event},
     message::Message,
-    observer::{IntoEntityObserver, IntoObserver},
+    observer::{EdgeTarget, IntoObserverConfigs},
     relationship::RelationshipHookMode,
     resource::Resource,
     schedule::ScheduleLabel,
@@ -1194,8 +1194,24 @@ impl<'w, 's> Commands<'w, 's> {
     /// Panics if the given system is an exclusive system.
     ///
     /// [`On`]: crate::observer::On
-    pub fn add_observer<M>(&mut self, observer: impl IntoObserver<M>) -> EntityCommands<'_> {
-        self.spawn(observer.into_observer())
+    pub fn add_observer<M>(&mut self, observer: impl IntoObserverConfigs<M>) -> EntityCommands<'_> {
+        let configs = observer.into_configs();
+        let mut observers = configs.observers.into_iter();
+        let first = observers
+            .next()
+            .expect("observer configs must contain at least one observer");
+        let first_entity = self.spawn(first).id();
+        let mut previous = first_entity;
+
+        for mut observer in observers {
+            if configs.chain {
+                observer.after_inner(EdgeTarget::Entity(previous));
+            }
+
+            previous = self.spawn(observer).id();
+        }
+
+        self.entity(first_entity)
     }
 
     /// Writes an arbitrary [`Message`].
@@ -2065,7 +2081,10 @@ impl<'a> EntityCommands<'a> {
 
     /// Creates an [`Observer`](crate::observer::Observer) watching for an [`EntityEvent`] of type `E` whose [`EntityEvent::event_target`]
     /// targets this entity.
-    pub fn observe<M>(&mut self, observer: impl IntoEntityObserver<M>) -> &mut Self {
+    pub fn observe<M>(
+        &mut self,
+        observer: impl IntoObserverConfigs<M> + Send + 'static,
+    ) -> &mut Self {
         self.queue(entity_command::observe(observer))
     }
 

--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -785,6 +785,17 @@ impl<'w> DeferredWorld<'w> {
         trigger: &mut E::Trigger<'a>,
         caller: MaybeLocation,
     ) {
+        // SAFETY:
+        // - `self` is a mutable DeferredWorld, so there are no outstanding world metadata borrows.
+        // - This only touches observer metadata for the event cache and does not perform structural ECS changes.
+        unsafe {
+            let world = self.as_unsafe_world_cell().world_mut();
+            let Some(observers) = world.observers.try_get_observers_mut(event_key) else {
+                return;
+            };
+            observers.resort();
+        }
+
         // SAFETY: You cannot get a mutable reference to `observers` from `DeferredWorld`
         let (mut world, observers) = unsafe {
             let world = self.as_unsafe_world_cell();

--- a/crates/bevy_ecs/src/world/entity_access/world_mut.rs
+++ b/crates/bevy_ecs/src/world/entity_access/world_mut.rs
@@ -8,7 +8,7 @@ use crate::{
     entity::{Entity, EntityCloner, EntityClonerBuilder, EntityLocation, OptIn, OptOut},
     event::{EntityComponentsTrigger, EntityEvent},
     lifecycle::{Despawn, Discard, Remove, DESPAWN, DISCARD, REMOVE},
-    observer::IntoEntityObserver,
+    observer::{EdgeTarget, IntoObserverConfigs},
     query::{
         has_conflicts, DebugCheckedUnwrap, QueryAccessError, ReadOnlyQueryData,
         ReleaseStateQueryData, SingleEntityQueryData,
@@ -1948,19 +1948,31 @@ impl<'w> EntityWorldMut<'w> {
     ///
     /// Panics if the given system is an exclusive system.
     #[track_caller]
-    pub fn observe<M>(&mut self, observer: impl IntoEntityObserver<M>) -> &mut Self {
+    pub fn observe<M>(&mut self, observer: impl IntoObserverConfigs<M>) -> &mut Self {
         self.observe_with_caller(observer, MaybeLocation::caller())
     }
 
     pub(crate) fn observe_with_caller<M>(
         &mut self,
-        observer: impl IntoEntityObserver<M>,
+        observer: impl IntoObserverConfigs<M>,
         caller: MaybeLocation,
     ) -> &mut Self {
         self.assert_not_despawned();
-        let bundle = observer.into_observer_for_entity(self.entity);
-        move_as_ptr!(bundle);
-        self.world.spawn_with_caller(bundle, caller);
+        let configs = observer.into_configs();
+        let mut previous = None;
+
+        for mut observer in configs.observers {
+            observer.watch_entity(self.entity);
+            if configs.chain
+                && let Some(previous) = previous
+            {
+                observer.after_inner(EdgeTarget::Entity(previous));
+            }
+
+            move_as_ptr!(observer);
+            previous = Some(self.world.spawn_with_caller(observer, caller).id());
+        }
+
         self.world.flush();
         self.update_location();
         self


### PR DESCRIPTION
# Add observer ordering via `ObserverSet` and topo-sorted dispatch

Resolves #14890.

## What this changes

Observers can be ordered against each other using a `SystemSet`-style API:

```rust
app.add_observer(score.in_set(WinCheck));
app.add_observer(announce.after(WinCheck));
```

Cross-bucket ordering works natively: a global observer can be ordered against a per-entity or per-component observer. The implementation uses one topo sort per event key, then reuses the sorted order across all dispatch sites. The existing archetype-flag fast skip is preserved.

## Approach

- `ObserverSet` trait + derive, mirroring `SystemSet`. Identities are stored as `Interned<dyn ObserverSet>`.
- `CachedObservers` replaces the old `EntityHashMap` buckets with one node table, one topo-sorted `order`, and sorted inverted indices per bucket.
- Topo sort reuses `bevy_ecs::schedule::graph::DiGraph`, so observers and systems share the same ordering kernel.
- Dispatch in `event/trigger.rs` goes through one `run_ordered` helper that performs a k-way merge over sorted `NodeId` streams. No per-dispatch allocation.
- Dynamic trigger helpers are routed through the same ordered dispatch path.

## Breaking changes

1. **`ObserverMap` type alias removed.** Replaced by indexed-Vec storage. Downstream code reading `world.observers()` to enumerate observers needs to use a new iterator API. There are very few such users in the ecosystem (mostly debug tools).
2. **`CachedObservers` / `CachedComponentObservers` field shapes change.** The fields were already private; only the accessors (`global_observers()`, etc.) were public. The new accessors return sorted slices of `NodeId` plus a `nodes()` table.
3. **Iteration order becomes deterministic** even for callers who never touch `ObserverSet`. Strictly stronger than today's contract; nothing correct can break, but anything that *relied* on undefined order (test asserts, frame replays) will need updates. Call out in the PR.
4. **Dispatch sites in `event/trigger.rs` change shape.** Internal, no `Trigger` trait signature changes, but custom `Trigger` impls in the wild (Bevy picking is the largest) need a quick port to the new `run_ordered` helper. Bevy maintainers can drive this in the same PR.

## What's NOT in this PR

- Parallel observer execution. This needs `SystemParam` access analysis per observer to build a conflict graph.
- Propagation hop reordering. Hop order is owned by `Traversal`; per-hop dispatch now uses the sorted observer order.
- `ambiguous_with` for observers. Only meaningful once parallel observer execution exists.

## Design Notes

<details>
<summary>Design summary</summary>

The key design choice is one event-local observer graph, not four separately sorted buckets. This enables edges across dispatch buckets while avoiding four topo sorts per event. Each registered observer/event pair becomes an `ObserverNode` with a stable insertion sort key. `CachedObservers` stores a dense node table, an event-wide sorted `order`, and bucket indices containing `NodeId`s sorted by that event-wide order.

Dispatch sites pass the relevant sorted streams into `run_ordered`. For one stream, dispatch is a direct dense slice walk. For multiple streams without ordering edges, dispatch preserves existing bucket order without allocation. If ordering edges exist, `run_ordered` walks the event-wide order and runs nodes present in the active streams, which gives cross-bucket ordering without allocating a merged list.

Archetype flags remain the fast skip for lifecycle component observers. Register/unregister returns the same component-observer deltas needed to update those flags, now backed by the new component bucket indices.

</details>

## Test coverage

New and updated `bevy_ecs` observer coverage includes:

- `ObserverSet` derive and set membership.
- before/after ordering by observer entity and by set.
- multiple-set membership and empty-set targets.
- cycle detection behavior.
- unregister-preserves-order.
- cross-bucket ordering.
- archetype-flag preservation.
- propagation using sorted dispatch per hop.
- nested sets.
- `dispatch_order_for` accessor coverage.
- dynamic trigger helpers routed through ordered dispatch.
- existing lifecycle order tests kept intact and ported to the current `Discard` lifecycle terminology.

## Local validation

- `cargo check --workspace`: passed.
- `cargo test -p bevy_ecs --doc`: passed.
- `cargo clippy -p bevy_ecs -- -D warnings`: passed.
- `cargo test -p bevy_ecs`: observer tests pass, but the full suite is blocked locally by `error::bevy_error::tests::filtered_backtrace_test`. I verified the same test fails on untouched upstream `main` (`370be1b02`) under Rust 1.95.0 with the same assertion, so this is not caused by this branch.

## Review feedback addressed

- [46cf6f428](https://github.com/caniko/bevy/commit/46cf6f4283e36253675334aefccf33fbdde3322e) fixes the `run_ordered` single-stream fast path so observer-set ordering still applies when the dispatch degenerates to one active stream.
- [bf7bdb9ca](https://github.com/caniko/bevy/commit/bf7bdb9ca7564096853641e68db081ee7c3431f3) merges component dispatch streams so cross-bucket ordering is preserved for component-targeted observers too.
- [814294c57](https://github.com/caniko/bevy/commit/814294c57adba56ff8041a1fb03a17e4c69c33d8) covers observer-set chain ordering interaction with `.run_if` on a middle observer (per @alice-i-cecile's ask).


## Follow-up cleanups

Two additional commits round out the API surface and tighten a few internals:

[c4588791f](https://github.com/caniko/bevy/commit/c4588791f74dcdb4b9a743f67fcdcf4a3910c49b) — observer API completion + performance + ergonomics:

- `observe()` on `EntityWorldMut` / `EntityCommands` / `entity_command::observe`, and `add_observer()` on `World` / `Commands`, now accept `impl IntoObserverConfigs<M>` so the same builder chain (`.in_set(...)`, `.before(...)`, `.after(...)`, `.chain()`) works through every entry point. Entity-side sites attach `watch_entity` to every observer in the configs before spawning.
- Replaces a stale `ObserverSet` docstring that still claimed observer set configuration was "not yet wired into dispatch".
- The cycle-detection warning now includes observer names alongside entities, so the diagnostic is actionable for users who set `Observer::with_name(...)`.
- `World::add_observers` and `World::configure_observer_sets` defer per-cache `resort()` calls for the duration of the batch via a counter-based deferral on `Observers`, so a plugin that registers N observers runs one topological sort instead of N. Panic-safe via a `Drop` guard (no_std-clean).
- `Observer::watch_entity` / `watch_entities` debug-assert when called after the descriptor has been frozen by registration; release builds preserve the documented silent no-op contract for back-compat.
- Adds a regression test confirming `(a, b, c).chain().in_set(MySet)` produces deduplicated edges in the topological graph (relies on `DiGraph::add_edge` naturally deduplicating identical `(from, to)` pairs).
- Factors out a shared `build_ordering_graph` helper so `rebuild_order` and the test-only graph view use the same implementation.

[036c12513](https://github.com/caniko/bevy/commit/036c1251300ab3173ff2bc92cd2b5b04c0d41899) — `resolve_set_target` uses a `HashSet` for visited tracking instead of `Vec` + linear `contains()`, and the `dispatch_order_for_*` family carries a doc note that it allocates per call and is intended for diagnostics, not hot paths.



