### PR TITLE
Include `libdisplay-info1` in update-caches

### DIFF
--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -178,7 +178,7 @@ jobs:
           DEBIAN_FRONTEND=noninteractive sudo apt-get install --no-install-recommends -yq \
             libgl1-mesa-dri mesa-vulkan-drivers
           rm -rf ~/apt-cache; mkdir ~/apt-cache
-          for package in libgbm1 libgl1-mesa-dri libglx-mesa0 mesa-libgallium mesa-vulkan-drivers; do
+          for package in libgbm1 libgl1-mesa-dri libglx-mesa0 mesa-libgallium libdisplay-info1 mesa-vulkan-drivers; do
               echo $package
               dpkg -L $package | while IFS= read -r f; do if test -f "$f"; then echo "$f"; fi; done | xargs -d '\n' cp --parents --target-directory ~/apt-cache/
           done


### PR DESCRIPTION
# Objective

Unbreak linux example tests in merge queue.
Currently `run-examples-linux-vulkan` is failing.

## Solution

At least part of the failure is that it can't find `libdisplay-info.so.1`.
Include the package that provides it in the cached packages.

## Testing

Unfortunately none. I can't reproduce the github environment at home.
We won't see whether this worked until the day after this PR is merged
and the caches get updated again.