### PR TITLE
Solari: Better light leak prevention

### DIFF
--- a/crates/bevy_solari/src/realtime/node.rs
+++ b/crates/bevy_solari/src/realtime/node.rs
@@ -575,7 +575,7 @@ pub fn init_solari_lighting_pipelines(
             "specular_gi",
             load_embedded_asset!(asset_server.as_ref(), "specular_gi.wgsl"),
             None,
-            vec!["NO_JITTER_WORLD_CACHE".into()],
+            vec!["JITTER_WORLD_CACHE".into()],
         ),
         #[cfg(all(feature = "dlss", not(feature = "force_disable_dlss")))]
         specular_gi_with_psr_pipeline: create_pipeline(

--- a/crates/bevy_solari/src/realtime/node.rs
+++ b/crates/bevy_solari/src/realtime/node.rs
@@ -561,7 +561,7 @@ pub fn init_solari_lighting_pipelines(
             "initial_and_temporal",
             load_embedded_asset!(asset_server.as_ref(), "restir_gi.wgsl"),
             None,
-            vec!["WORLD_CACHE_FIRST_BOUNCE_LIGHT_LEAK_PREVENTION".into()],
+            vec![],
         ),
         gi_spatial_and_shade_pipeline: create_pipeline(
             "solari_lighting_gi_spatial_and_shade_pipeline",
@@ -575,7 +575,7 @@ pub fn init_solari_lighting_pipelines(
             "specular_gi",
             load_embedded_asset!(asset_server.as_ref(), "specular_gi.wgsl"),
             None,
-            vec![],
+            vec!["NO_JITTER_WORLD_CACHE".into()],
         ),
         #[cfg(all(feature = "dlss", not(feature = "force_disable_dlss")))]
         specular_gi_with_psr_pipeline: create_pipeline(

--- a/crates/bevy_solari/src/realtime/world_cache_query.wgsl
+++ b/crates/bevy_solari/src/realtime/world_cache_query.wgsl
@@ -44,7 +44,7 @@ fn query_world_cache(world_position_in: vec3<f32>, world_normal: vec3<f32>, view
     var world_position = world_position_in;
     var cell_size = get_cell_size(world_position, view_position, rng);
 
-#ifndef NO_JITTER_WORLD_CACHE
+#ifdef JITTER_WORLD_CACHE
     // Jitter query point, which essentially blurs the cache a bit so it's not so grid-like
     // https://tomclabault.github.io/blog/2025/regir, jitter_world_position_tangent_plane
     let TBN = orthonormalize(world_normal);

--- a/crates/bevy_solari/src/realtime/world_cache_query.wgsl
+++ b/crates/bevy_solari/src/realtime/world_cache_query.wgsl
@@ -54,7 +54,8 @@ fn query_world_cache(world_position_in: vec3<f32>, world_normal: vec3<f32>, view
 #else
     // Reduce light leaks
     if ray_t < cell_size {
-        cell_size = WORLD_CACHE_POSITION_BASE_CELL_SIZE;
+        let lod = max(floor(log2(ray_t / WORLD_CACHE_POSITION_BASE_CELL_SIZE)), 0.0);
+        cell_size = WORLD_CACHE_POSITION_BASE_CELL_SIZE * exp2(lod);
     }
 #endif
 

--- a/crates/bevy_solari/src/realtime/world_cache_query.wgsl
+++ b/crates/bevy_solari/src/realtime/world_cache_query.wgsl
@@ -44,13 +44,6 @@ fn query_world_cache(world_position_in: vec3<f32>, world_normal: vec3<f32>, view
     var world_position = world_position_in;
     var cell_size = get_cell_size(world_position, view_position, rng);
 
-#ifdef WORLD_CACHE_FIRST_BOUNCE_LIGHT_LEAK_PREVENTION
-    if ray_t < cell_size {
-        // Prevent light leaks
-        cell_size = WORLD_CACHE_POSITION_BASE_CELL_SIZE;
-    }
-#endif
-
 #ifndef NO_JITTER_WORLD_CACHE
     // Jitter query point, which essentially blurs the cache a bit so it's not so grid-like
     // https://tomclabault.github.io/blog/2025/regir, jitter_world_position_tangent_plane
@@ -58,6 +51,11 @@ fn query_world_cache(world_position_in: vec3<f32>, world_normal: vec3<f32>, view
     let offset = (rand_vec2f(rng) * 2.0 - 1.0) * cell_size * 0.5;
     world_position += offset.x * TBN[0] + offset.y * TBN[1];
     cell_size = get_cell_size(world_position, view_position, rng);
+#else
+    // Reduce light leaks
+    if ray_t < cell_size {
+        cell_size = WORLD_CACHE_POSITION_BASE_CELL_SIZE;
+    }
 #endif
 
     let world_position_quantized = bitcast<vec3<u32>>(quantize_position(world_position, cell_size));
@@ -111,7 +109,6 @@ fn quantize_normal(world_normal: vec3<f32>) -> vec3<f32> {
     return floor(world_normal * 2.0 + 0.0001);
 }
 
-// TODO: Clustering
 fn compute_key(world_position: vec3<u32>, world_normal: vec3<u32>) -> u32 {
     var key = pcg_hash(world_position.x);
     key = pcg_hash(key + world_position.y);


### PR DESCRIPTION
* Turn jitter off unless using specular GI
* Rather than snap to the base cell size immediately, pick the biggest cell size that's bigger than ray_t