### PR TITLE
Add `const` and `unsafe` block suport to `bsn!` macro

### DIFF
--- a/crates/bevy_scene/macros/src/bsn/parse.rs
+++ b/crates/bevy_scene/macros/src/bsn/parse.rs
@@ -436,17 +436,6 @@ impl Parse for BsnValue {
             let braced = braced_tokens(input)?;
 
             BsnValue::Expr(quote! {#unsafe_token {#braced}})
-        } else if input.peek(Token![async]) && input.peek2(Brace) {
-            let async_token = input.parse::<Token![async]>()?;
-            let braced = braced_tokens(input)?;
-
-            BsnValue::Expr(quote! {#async_token {#braced}})
-        } else if input.peek(Token![async]) && input.peek2(Token![move]) && input.peek3(Brace) {
-            let async_token = input.parse::<Token![async]>()?;
-            let move_token = input.parse::<Token![move]>()?;
-            let braced = braced_tokens(input)?;
-
-            BsnValue::Expr(quote! {#async_token #move_token {#braced}})
         } else if input.peek(Token![|]) {
             let tokens = parse_closure_loose(input)?;
             BsnValue::Closure(tokens)

--- a/crates/bevy_scene/macros/src/bsn/parse.rs
+++ b/crates/bevy_scene/macros/src/bsn/parse.rs
@@ -426,6 +426,27 @@ impl Parse for BsnValue {
     fn parse(input: ParseStream) -> Result<Self> {
         Ok(if input.peek(Brace) {
             BsnValue::Expr(braced_tokens(input)?)
+        } else if input.peek(Token![const]) && input.peek2(Brace) {
+            let const_token = input.parse::<Token![const]>()?;
+            let braced = braced_tokens(input)?;
+
+            BsnValue::Expr(quote! {#const_token {#braced}})
+        } else if input.peek(Token![unsafe]) && input.peek2(Brace) {
+            let unsafe_token = input.parse::<Token![unsafe]>()?;
+            let braced = braced_tokens(input)?;
+
+            BsnValue::Expr(quote! {#unsafe_token {#braced}})
+        } else if input.peek(Token![async]) && input.peek2(Brace) {
+            let async_token = input.parse::<Token![async]>()?;
+            let braced = braced_tokens(input)?;
+
+            BsnValue::Expr(quote! {#async_token {#braced}})
+        } else if input.peek(Token![async]) && input.peek2(Token![move]) && input.peek3(Brace) {
+            let async_token = input.parse::<Token![async]>()?;
+            let move_token = input.parse::<Token![move]>()?;
+            let braced = braced_tokens(input)?;
+
+            BsnValue::Expr(quote! {#async_token #move_token {#braced}})
         } else if input.peek(Token![|]) {
             let tokens = parse_closure_loose(input)?;
             BsnValue::Closure(tokens)

--- a/crates/bevy_scene/macros/src/lib.rs
+++ b/crates/bevy_scene/macros/src/lib.rs
@@ -192,6 +192,20 @@ use syn::{parse_macro_input, DeriveInput};
 /// }
 /// ```
 ///
+/// `{...}` blocks can also be `unsafe` or `const` (but not both at once without nesting):
+///
+/// ```rust, ignore
+/// fn friendly(people: &[&'static str]) -> impl Scene {
+///     bsn! {
+///         Friend {
+///             name: const {"John"}
+///             /// SAFETY: Jesus take the wheel
+///             father: unsafe {people.get_unchecked(0)}
+///         }
+///     }
+/// }
+/// ```
+///
 /// **Note:** `.bsn` asset files will not support arbitrary Rust expressions,
 /// as we do not intend to require Bevy games to ship a Rust compiler.
 ///

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -2123,4 +2123,24 @@ mod tests {
 
         b();
     }
+
+    #[test]
+    fn scene_with_blocks() {
+        #[derive(Component, Clone, Default)]
+        struct Holder {
+            const_block: i32,
+            unsafe_block: i32,
+        }
+
+        fn func() -> impl Scene {
+            bsn! {
+                Holder {
+                    const_block: const {0},
+                    unsafe_block: unsafe {0},
+                }
+            }
+        }
+
+        func();
+    }
 }


### PR DESCRIPTION
# Objective

Closes #24121

## Solution

Add `const`, `unsafe` and `async` block support to bsn expressions.

## Testing

I've added a compile test for `const` and `unsafe` blocks. I couldn't figure out how to test or even use the async blocks. The macro needs to construct a struct that holds a future, but `async` blocks produce voldemort (unnameable) types. Using `Box<dyn Future>` fixes this problem but then you run into the problem that the struct needs to be clone-able and have a default value. `async` block futures have neither of those properties.

---

## Showcase

The `bsn!` macro now supports `const` and `unsafe` blocks.
```rust,
 fn friendly(people: &[&'static str]) -> impl Scene {
     bsn! {
         Friend {
             name: const {"John"}
             // SAFETY: Jesus take the wheel
             father: unsafe {people.get_unchecked(0)}
         }
     }
 }
 ```

