### PR TITLE
Add missing reflect to bevy_picking resources

### DIFF
--- a/crates/bevy_picking/src/backend.rs
+++ b/crates/bevy_picking/src/backend.rs
@@ -236,7 +236,7 @@ pub mod ray {
     use bevy_ecs::prelude::*;
     use bevy_math::Ray3d;
     use bevy_platform::collections::{hash_map::Iter, HashMap};
-    use bevy_reflect::Reflect;
+    use bevy_reflect::{std_traits::ReflectDefault, Reflect};
     use bevy_transform::prelude::GlobalTransform;
     use bevy_window::PrimaryWindow;
 
@@ -279,7 +279,8 @@ pub mod ray {
     ///     }
     /// }
     /// ```
-    #[derive(Clone, Debug, Default, Resource)]
+    #[derive(Clone, Debug, Default, Resource, Reflect)]
+    #[reflect(Clone, Debug, Default, Resource)]
     pub struct RayMap {
         /// Cartesian product of all pointers and all cameras
         /// Add your rays here to support picking through indirections,

--- a/crates/bevy_picking/src/events.rs
+++ b/crates/bevy_picking/src/events.rs
@@ -472,7 +472,8 @@ pub struct Scroll {
 
 /// An entry in the cache that drives the `pointer_events` system, storing additional data
 /// about pointer button presses.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Reflect)]
+#[reflect(Debug, Clone, Default)]
 pub struct PointerButtonState {
     /// Stores the press location and start time for each button currently being pressed by the pointer.
     pub pressing: EntityHashMap<(Location, Instant, HitData)>,
@@ -494,7 +495,8 @@ impl PointerButtonState {
 }
 
 /// A cache map containing the ancestry of hovered entities
-#[derive(Debug, Clone, Default, Deref, DerefMut)]
+#[derive(Debug, Clone, Default, Deref, DerefMut, Reflect)]
+#[reflect(Debug, Clone, Default)]
 pub struct HoveredEntityAncestors(EntityHashMap<EntityHashSet>);
 
 impl HoveredEntityAncestors {
@@ -547,7 +549,8 @@ impl HoveredEntityAncestors {
 }
 
 /// State for all pointers.
-#[derive(Debug, Clone, Default, Resource)]
+#[derive(Debug, Clone, Default, Resource, Reflect)]
+#[reflect(Debug, Clone, Default, Resource)]
 pub struct PointerState {
     /// Pressing and dragging state, organized by pointer and button.
     pub pointer_buttons: HashMap<(PointerId, PointerButton), PointerButtonState>,

--- a/crates/bevy_picking/src/hover.rs
+++ b/crates/bevy_picking/src/hover.rs
@@ -56,11 +56,13 @@ type OverMap = HashMap<PointerId, LayerMap>;
 /// this authoritative hover state, and you can do the same. You can also use the
 /// [`PreviousHoverMap`] as a robust way of determining changes in hover state from the previous
 /// update.
-#[derive(Debug, Deref, DerefMut, Default, Resource)]
+#[derive(Debug, Deref, DerefMut, Default, Resource, Reflect)]
+#[reflect(Debug, Default, Resource)]
 pub struct HoverMap(pub HashMap<PointerId, EntityHashMap<HitData>>);
 
 /// The previous state of the hover map, used to track changes to hover state.
-#[derive(Debug, Deref, DerefMut, Default, Resource)]
+#[derive(Debug, Deref, DerefMut, Default, Resource, Reflect)]
+#[reflect(Debug, Default, Resource)]
 pub struct PreviousHoverMap(pub HashMap<PointerId, EntityHashMap<HitData>>);
 
 /// Gets the hovered entities for a `pointer_id` from a provided `HoverMap` inner map

--- a/crates/bevy_picking/src/pointer.rs
+++ b/crates/bevy_picking/src/pointer.rs
@@ -90,7 +90,8 @@ impl Deref for PointerInteraction {
 }
 
 /// A resource that maps each [`PointerId`] to their [`Entity`] for easy lookups.
-#[derive(Debug, Clone, Default, Resource)]
+#[derive(Debug, Clone, Default, Resource, Reflect)]
+#[reflect(Debug, Clone, Default, Resource)]
 pub struct PointerMap {
     inner: HashMap<PointerId, Entity>,
 }


### PR DESCRIPTION
# Objective

- Be able to inspect these resources when debugging picking.

<img width="968" height="258" alt="image" src="https://github.com/user-attachments/assets/37ce0575-2364-4044-b282-8847f6ec9eff" />

## Solution

- Reflect missing resources in `bevy_picking`.

## Testing

- CI builds it.
