### PR TITLE
Allow plugin functions in `plugin_group!`

### DIFF
--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -983,6 +983,20 @@ mod tests {
     }
     #[test]
     fn construct_nested_plugin_groups_with_plugin_functions() {
-        PluginGroupF {}.build();
+        fn type_id_of<T: Plugin>(_: T) -> TypeId {
+            TypeId::of::<T>()
+        }
+
+        let group = PluginGroupF {}.build();
+
+        assert_eq!(
+            group.order,
+            vec![
+                TypeId::of::<PluginB>(),
+                TypeId::of::<PluginA>(),
+                type_id_of(plugin_d),
+                type_id_of(plugin_e),
+            ]
+        );
     }
 }

--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -37,11 +37,15 @@ use log::{debug, warn};
 /// # pub struct TickratePlugin;
 /// # impl Plugin for TickratePlugin { fn build(&self, _: &mut App) {} }
 /// #
+/// # pub fn bullet_time_plugin(_: &mut App) {}
+/// #
 /// # mod features {
 /// #   use bevy_app::*;
 /// #   #[derive(Default)]
 /// #   pub struct ForcePlugin;
 /// #   impl Plugin for ForcePlugin { fn build(&self, _: &mut App) {} }
+/// #
+/// #   pub fn force_debug_plugin(_: &mut App) {}
 /// # }
 /// #
 /// # mod web {
@@ -67,6 +71,8 @@ use log::{debug, warn};
 /// #   #[derive(Default)]
 /// #   pub struct InternalPlugin;
 /// #   impl Plugin for InternalPlugin { fn build(&self, _: &mut App) {} }
+/// #
+/// #   pub fn internal_plugin(_: &mut App) {}
 /// # }
 /// #
 /// plugin_group! {
@@ -94,9 +100,18 @@ use log::{debug, warn};
 ///         #[plugin_group]
 ///         audio:::AudioPlugins,
 ///         // You can hide plugins from documentation. Due to macro limitations, hidden plugins
-///         // must be last.
+///         // must be after all other plugins.
 ///         #[doc(hidden)]
-///         internal:::InternalPlugin
+///         internal:::InternalPlugin,
+///         // The last thing within the block can be a "fn block", which allows using plugin functions
+///         // within function groups.
+///         fn {
+///             :bullet_time_plugin,
+///             #[cfg(feature = "external_forces")]
+///             features:::force_debug_plugin,
+///             #[doc(hidden)]
+///             internal:::internal_plugin,
+///         }
 ///     }
 ///     /// You may add doc comments after the plugin group as well. They will be appended after
 ///     /// the documented list of plugins.
@@ -127,6 +142,24 @@ macro_rules! plugin_group {
                     $(#[custom($hidden_plugin_meta:meta)])*
                     $($hidden_plugin_path:ident::)* : $hidden_plugin_name:ident
                 ),+
+            )?
+            $(
+                $(,)? fn {
+                    $(
+                        $(#[cfg(feature = $fn_plugin_feature:literal)])?
+                        $(#[custom($fn_plugin_meta:meta)])*
+                        $($fn_plugin_path:ident::)* : $fn_plugin_name:ident
+                    ),*
+                    $(
+                        $(,)?$(
+                            #[doc(hidden)]
+                            $(#[cfg(feature = $fn_hidden_plugin_feature:literal)])?
+                            $(#[custom($fn_hidden_plugin_meta:meta)])*
+                            $($fn_hidden_plugin_path:ident::)* : $fn_hidden_plugin_name:ident
+                        ),+
+                    )?
+                    $(,)?
+                }
             )?
 
             $(,)?
@@ -166,6 +199,13 @@ macro_rules! plugin_group {
                     }
                 )*
                 $($(
+                    $(#[cfg(feature = $fn_plugin_feature)])?
+                    $(#[$fn_plugin_meta])*
+                    {
+                        group = group.add($($fn_plugin_path::)*$fn_plugin_name);
+                    }
+                )*)?
+                $($(
                     $(#[cfg(feature = $plugin_group_feature)])?
                     $(#[$plugin_group_meta])*
                     {
@@ -189,6 +229,13 @@ macro_rules! plugin_group {
                         group = group.add(<$($hidden_plugin_path::)*$hidden_plugin_name>::default());
                     }
                 )+)?
+                $($($(
+                    $(#[cfg(feature = $fn_hidden_plugin_feature)])?
+                    $(#[$fn_hidden_plugin_meta])*
+                    {
+                        group = group.add($($fn_hidden_plugin_path::)*$fn_hidden_plugin_name);
+                    }
+                )+)?)?
 
                 group
             }

--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -103,9 +103,8 @@ use log::{debug, warn};
 ///         // must be after all other plugins.
 ///         #[doc(hidden)]
 ///         internal:::InternalPlugin,
-///         // The last thing within the block can be a "fn block", which allows using plugin functions
-///         // within function groups.
-///         fn {
+///         // Can end with a "fn block" for plugin function members of the group.
+///         @fn {
 ///             :bullet_time_plugin,
 ///             #[cfg(feature = "external_forces")]
 ///             features:::force_debug_plugin,
@@ -144,7 +143,7 @@ macro_rules! plugin_group {
                 ),+
             )?
             $(
-                $(,)? fn {
+                $(,)? @fn {
                     $(
                         $(#[cfg(feature = $fn_plugin_feature:literal)])?
                         $(#[custom($fn_plugin_meta:meta)])*
@@ -176,6 +175,10 @@ macro_rules! plugin_group {
             " - [`", stringify!($plugin_group_name), "`](" $(, stringify!($plugin_group_path), "::")*, stringify!($plugin_group_name), ")"
             $(, " - with feature `", $plugin_group_feature, "`")?
         )])+)?
+        $($(#[doc = concat!(
+            " - [`", stringify!($fn_plugin_name), "`](" $(, stringify!($fn_plugin_path), "::")*, stringify!($fn_plugin_name), ")"
+            $(, " - with feature `", $fn_plugin_feature, "`")?
+        )])*)?
         $(
             ///
             $(#[doc = $post_doc])+
@@ -198,13 +201,6 @@ macro_rules! plugin_group {
                         group = group.add(<$($plugin_path::)*$plugin_name>::default());
                     }
                 )*
-                $($(
-                    $(#[cfg(feature = $fn_plugin_feature)])?
-                    $(#[$fn_plugin_meta])*
-                    {
-                        group = group.add($($fn_plugin_path::)*$fn_plugin_name);
-                    }
-                )*)?
                 $($(
                     $(#[cfg(feature = $plugin_group_feature)])?
                     $(#[$plugin_group_meta])*
@@ -229,6 +225,13 @@ macro_rules! plugin_group {
                         group = group.add(<$($hidden_plugin_path::)*$hidden_plugin_name>::default());
                     }
                 )+)?
+                $($(
+                    $(#[cfg(feature = $fn_plugin_feature)])?
+                    $(#[$fn_plugin_meta])*
+                    {
+                        group = group.add($($fn_plugin_path::)*$fn_plugin_name);
+                    }
+                )*)?
                 $($($(
                     $(#[cfg(feature = $fn_hidden_plugin_feature)])?
                     $(#[$fn_hidden_plugin_meta])*
@@ -625,6 +628,9 @@ mod tests {
         fn build(&self, _: &mut App) {}
     }
 
+    fn plugin_d(_: &mut App) {}
+    fn plugin_e(_: &mut App) {}
+
     #[derive(PartialEq, Debug)]
     struct PluginWithData(u32);
     impl Plugin for PluginWithData {
@@ -947,5 +953,36 @@ mod tests {
     #[test]
     fn construct_nested_plugin_groups() {
         PluginGroupC {}.build();
+    }
+    plugin_group! {
+        #[derive(Default)]
+        struct PluginGroupD {
+            :PluginA
+            @fn {
+                #[doc(hidden)]
+                :plugin_d
+            }
+        }
+    }
+    plugin_group! {
+        #[derive(Default)]
+        struct PluginGroupE {
+            @fn {
+                :plugin_e
+            }
+        }
+    }
+    plugin_group! {
+        struct PluginGroupF {
+            :PluginB
+            #[plugin_group]
+            :PluginGroupD,
+            #[plugin_group]
+            :PluginGroupE,
+        }
+    }
+    #[test]
+    fn construct_nested_plugin_groups_with_plugin_functions() {
+        PluginGroupF {}.build();
     }
 }

--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -175,8 +175,8 @@ macro_rules! plugin_group {
             " - [`", stringify!($plugin_group_name), "`](" $(, stringify!($plugin_group_path), "::")*, stringify!($plugin_group_name), ")"
             $(, " - with feature `", $plugin_group_feature, "`")?
         )])+)?
-        $($(#[doc = concat!(
-            " - [`", stringify!($fn_plugin_name), "`](" $(, stringify!($fn_plugin_path), "::")*, stringify!($fn_plugin_name), ")"
+        $($(#[doc = ::core::concat!(
+            " - [`", ::core::stringify!($fn_plugin_name), "`](" $(, ::core::stringify!($fn_plugin_path), "::")*, ::core::stringify!($fn_plugin_name), ")"
             $(, " - with feature `", $fn_plugin_feature, "`")?
         )])*)?
         $(


### PR DESCRIPTION
# Objective

Allow plugin functions to be used inside `plugin_group!` declarations.

Right now, functions of signature `fn(&mut App)` implement `Plugin`, but cannot be added to plugin groups, due
to how the macro is implemented.

This fixes that.

## Solution

This PR fixes the problem by introducing a block after the top-level members, labeled with `fn`, where the names are considered to be referencing values directly, rather than types. It looks like:

```rust
plugin_group! {
  pub struct MyFnGroup {
     // ... stuff that `impl Plugin` ...
     @fn {
       :local_fn,
       outer:::outer_fn,
       #[doc(hidden)]
       internal:::hidden_fn,
    }
  }
}
```

## Testing

I edited the doctest above the macro implementation, and made sure that passes, and the syntax is non-invasive otherwise, so overall, not much should change.

**EDIT**: update description to include required sigil

---
