### PR TITLE
Fix switching between earth/mars in atmosphere example

### DIFF
--- a/examples/3d/atmosphere.rs
+++ b/examples/3d/atmosphere.rs
@@ -70,7 +70,7 @@ fn print_controls() {
 
 fn atmosphere_controls(
     keyboard_input: Res<ButtonInput<KeyCode>>,
-    mut planet_atmosphere: Query<(&mut Atmosphere, &mut Transform)>,
+    mut planet_atmosphere: Query<(&mut Atmosphere, &mut GlobalTransform)>,
     mut camera_settings: Query<&mut AtmosphereSettings, With<Camera3d>>,
     atmosphere_presets: Res<AtmospherePresets>,
     mut game_state: ResMut<GameState>,
@@ -80,7 +80,7 @@ fn atmosphere_controls(
     if keyboard_input.just_pressed(KeyCode::Digit3) {
         for (mut atmosphere, mut transform) in &mut planet_atmosphere {
             *atmosphere = Atmosphere::earth(atmosphere_presets.earth.clone());
-            transform.translation = -Vec3::Y * atmosphere.inner_radius;
+            *transform = GlobalTransform::from_translation(-Vec3::Y * atmosphere.inner_radius);
             println!("Switched to Earth atmosphere");
         }
     }
@@ -88,7 +88,7 @@ fn atmosphere_controls(
     if keyboard_input.just_pressed(KeyCode::Digit4) {
         for (mut atmosphere, mut transform) in &mut planet_atmosphere {
             *atmosphere = Atmosphere::mars(atmosphere_presets.mars.clone());
-            transform.translation = -Vec3::Y * atmosphere.inner_radius;
+            *transform = GlobalTransform::from_translation(-Vec3::Y * atmosphere.inner_radius);
             println!("Switched to Mars atmosphere");
         }
     }


### PR DESCRIPTION
# Objective

The keys for switching between earth and mars atmospheres in the atmosphere example currently do nothing. This change restores the functionality.

I'm guessing the issue is from the Atmosphere component changing from using `Transform` to `GlobalTransform` directly in `Atmosphere::set_default_transform`. The example is expecting to iterate over a `Transform`, never finds one, and thus never changes the atmosphere.

## Solution

Change the example to modify `GlobalTransform` instead of `Transform`. 

It may be preferable to modify the example to insert a `Transform` in set-up. Let me know if this is the case and i'll update the PR.

## Testing

- Tested by running the atmosphere example, hitting the 3 and 4 keys and seeing sufficiently earth and mars like atmospheres, as well as messages in the console.