### PR TITLE
remove CI badge from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Crates.io](https://img.shields.io/crates/v/bevy.svg)](https://crates.io/crates/bevy)
 [![Downloads](https://img.shields.io/crates/d/bevy.svg)](https://crates.io/crates/bevy)
 [![Docs](https://docs.rs/bevy/badge.svg)](https://docs.rs/bevy/latest/bevy/)
-[![CI](https://github.com/bevyengine/bevy/workflows/CI/badge.svg)](https://github.com/bevyengine/bevy/actions)
 [![Discord](https://img.shields.io/discord/691052431525675048.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/bevy)
 
 ## What is Bevy?


### PR DESCRIPTION
# Objective

- Readme is used on crates.io and shouldn't show information about development
- CI badge is about the current main

## Solution

- Remove the CI badge from the readme
