### PR TITLE
Fix rounding in the `pixel_grid_snap` example

### DIFF
--- a/examples/2d/pixel_grid_snap.rs
+++ b/examples/2d/pixel_grid_snap.rs
@@ -152,6 +152,6 @@ fn fit_canvas(
     for window_resized in resize_messages.read() {
         let h_scale = window_resized.width / RES_WIDTH as f32;
         let v_scale = window_resized.height / RES_HEIGHT as f32;
-        projection.scale = 1. / h_scale.min(v_scale).round();
+        projection.scale = 1. / h_scale.min(v_scale).floor();
     }
 }


### PR DESCRIPTION
# Objective

Fixes #24350 

## Solution

I replaced `round` with `floor` as mentioned in the issue.

## Testing

- Did you test these changes? If so, how?

I ran the program on my computer and observed the change.

- Are there any parts that need more testing?

Perhaps other display sizes need testing, but theoretically the math should be correct. This is my first PR, so I might have missed something.

- How can other people (reviewers) test your changes? Is there anything specific they need to know?

Compare the clipping on window sizes that are a multiple of the canvas's resolution to those that are not.

- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?

I tested on macOS; I cannot test on any other platform.

---

## Showcase

<details>
  <summary>Click to view showcase</summary>

<img width="1728" height="1117" alt="Screenshot 2026-05-19 at 3 14 25 AM" src="https://github.com/user-attachments/assets/1da0b3f1-1f04-4dbe-bbb2-a14a237ff1a7" />
<img width="1728" height="1117" alt="Screenshot 2026-05-19 at 12 50 52 AM" src="https://github.com/user-attachments/assets/a8fc835e-7b32-49ad-916b-a55c4be1d38f" />

</details>
