### PR TITLE
Link to the correct page in SceneComponent docs

### DIFF
--- a/crates/bevy_scene/src/scene_component.rs
+++ b/crates/bevy_scene/src/scene_component.rs
@@ -9,7 +9,7 @@ use crate::Scene;
 /// In general, developers should not implement this manually. Instead, they should derive it,
 /// which also derives [`Component`] and adds additional protections and assurances.
 ///
-/// See the ["Scene Components"](crate#scene-components) sections of the module docs to see how this is used in practice.
+/// See the ["Scene Components"](crate#scene-components) section of the module docs to see how this is used in practice.
 pub trait SceneComponent: Component + FromTemplate<Template: Default> {
     /// The "properties" passed into [`Self::scene`] to build the final scene.
     type Props: Default;

--- a/crates/bevy_scene/src/scene_component.rs
+++ b/crates/bevy_scene/src/scene_component.rs
@@ -9,7 +9,7 @@ use crate::Scene;
 /// In general, developers should not implement this manually. Instead, they should derive it,
 /// which also derives [`Component`] and adds additional protections and assurances.
 ///
-/// See the "Scene Components" sections of the [`Scene`] docs to see how this is used in practice.
+/// See the ["Scene Components"](crate#scene-components) sections of the module docs to see how this is used in practice.
 pub trait SceneComponent: Component + FromTemplate<Template: Default> {
     /// The "properties" passed into [`Self::scene`] to build the final scene.
     type Props: Default;


### PR DESCRIPTION
# Objective

Fix the `SceneComponent` docs directing to a non-existent "Scene Components" section of the `Scene` docs

## Solution

Link to the section in the module docs instead

## Testing

Ran `cargo doc --no-deps` to see if the link was correct