### PR TITLE
Add coord system transform for atmosphere

### DIFF
--- a/crates/bevy_pbr/src/atmosphere/environment.wgsl
+++ b/crates/bevy_pbr/src/atmosphere/environment.wgsl
@@ -1,5 +1,6 @@
 #import bevy_pbr::{
     atmosphere::{
+        bindings::atmosphere_transforms,
         functions::{direction_world_to_atmosphere, sample_sky_view_lut, get_view_position},
     },
     utils::sample_cube_dir
@@ -26,6 +27,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     
     // invert the z direction to account for cubemaps being lefthanded
     ray_dir_ws.z = -ray_dir_ws.z;
+    ray_dir_ws = (atmosphere_transforms.globe_to_plane * vec4(ray_dir_ws, 0.0)).xyz;
 
     let world_pos = get_view_position();
     let r = length(world_pos);

--- a/crates/bevy_pbr/src/atmosphere/functions.wgsl
+++ b/crates/bevy_pbr/src/atmosphere/functions.wgsl
@@ -216,11 +216,13 @@ fn sample_local_inscattering(local_scattering: vec3<f32>, ray_dir: vec3<f32>, wo
     for (var light_i: u32 = 0u; light_i < lights.n_directional_lights; light_i++) {
         let light = &lights.directional_lights[light_i];
 
-        let mu_light = dot((*light).direction_to_light, local_up);
+        let light_dir = (atmosphere_transforms.globe_to_plane * vec4((*light).direction_to_light, 0.0)).xyz;
+
+        let mu_light = dot(light_dir, local_up);
 
         // -(L . V) == (L . -V). -V here is our ray direction, which points away from the view
         // instead of towards it (as is the convention for V)
-        let neg_LdotV = dot((*light).direction_to_light, ray_dir);
+        let neg_LdotV = dot(light_dir, ray_dir);
 
         let transmittance_to_light = sample_transmittance_lut(local_r, mu_light);
         let shadow_factor = transmittance_to_light * f32(!ray_intersects_ground(local_r, mu_light));
@@ -247,7 +249,8 @@ fn sample_sun_radiance(ray_dir_ws: vec3<f32>) -> vec3<f32> {
     var sun_radiance = vec3(0.0);
     for (var light_i: u32 = 0u; light_i < lights.n_directional_lights; light_i++) {
         let light = &lights.directional_lights[light_i];
-        let neg_LdotV = dot((*light).direction_to_light, ray_dir_ws);
+        let light_dir = (atmosphere_transforms.globe_to_plane * vec4((*light).direction_to_light, 0.0)).xyz;
+        let neg_LdotV = dot(light_dir, ray_dir_ws);
         let angle_to_sun = fast_acos(clamp(neg_LdotV, -1.0, 1.0));
         let w = max(0.5 * fwidth(angle_to_sun), 1e-6);
         let sun_angular_size = (*light).sun_disk_angular_size;
@@ -305,8 +308,16 @@ fn max_atmosphere_distance(r: f32, mu: f32) -> f32 {
     return mix(t_top, t_bottom, f32(hits));
 }
 
-/// Returns the observer's position in the atmosphere
+/// Returns the observer's position in the atmosphere.
+/// When `atmosphere_transforms.view_height` is non-zero (ECEF / geospatial mode),
+/// the camera is placed at `(0, inner_radius + view_height, 0)` in atmosphere space.
+/// Otherwise, the camera position is derived from `view.world_position` via the
+/// atmosphere entity's inverse transform.
 fn get_view_position() -> vec3<f32> {
+    if atmosphere_transforms.view_height != 0.0 {
+        var world_pos = vec3(0.0, atmosphere.inner_radius + atmosphere_transforms.view_height, 0.0);
+        return clamp_to_surface(atmosphere, world_pos);
+    }
     let atmo_pos = (atmosphere.world_to_atmosphere * vec4(view.world_position, 1.0)).xyz;
     return clamp_to_surface(atmosphere, atmo_pos);
 }
@@ -368,7 +379,7 @@ fn uv_to_ray_direction(uv: vec2<f32>) -> vec3<f32> {
     // direction to world space. Note that the w element is set to 0.0, as this is a
     // vector direction, not a position, That causes the matrix multiplication to ignore
     // the translations from the view matrix.
-    let ray_direction = (view.world_from_view * vec4(view_ray_direction, 0.0)).xyz;
+    let ray_direction = (atmosphere_transforms.globe_to_plane * view.world_from_view * vec4(view_ray_direction, 0.0)).xyz;
 
     return normalize(ray_direction);
 }
@@ -490,7 +501,7 @@ fn raymarch_atmosphere(
     if ground && ray_intersects_ground(r, mu) {
         for (var light_i: u32 = 0u; light_i < lights.n_directional_lights; light_i++) {
             let light = &lights.directional_lights[light_i];
-            let light_dir = (*light).direction_to_light;
+            let light_dir = (atmosphere_transforms.globe_to_plane * vec4((*light).direction_to_light, 0.0)).xyz;
             let light_color = (*light).color.rgb;
             let transmittance_to_ground = exp(-optical_depth);
             // position on the sphere and get the sphere normal (up)

--- a/crates/bevy_pbr/src/atmosphere/mod.rs
+++ b/crates/bevy_pbr/src/atmosphere/mod.rs
@@ -81,7 +81,7 @@ use environment::{
 use node::{atmosphere_luts, render_sky};
 use resources::{
     prepare_atmosphere_transforms, prepare_atmosphere_uniforms, queue_render_sky_pipelines,
-    AtmosphereTransforms, GpuAtmosphere, RenderSkyBindGroupLayouts,
+    AtmosphereGlobe, AtmosphereTransforms, GpuAtmosphere, RenderSkyBindGroupLayouts,
 };
 use tracing::warn;
 
@@ -111,9 +111,11 @@ impl Plugin for AtmospherePlugin {
 
         app.add_plugins((
             ExtractComponentPlugin::<AtmosphereEnvironmentMap>::default(),
+            ExtractComponentPlugin::<AtmosphereGlobe>::default(),
             SyncComponentPlugin::<AtmosphereSettings>::default(),
             UniformComponentPlugin::<GpuAtmosphere>::default(),
             UniformComponentPlugin::<GpuAtmosphereSettings>::default(),
+            UniformComponentPlugin::<AtmosphereGlobe>::default(),
         ))
         .add_systems(Update, prepare_atmosphere_probe_components);
 

--- a/crates/bevy_pbr/src/atmosphere/node.rs
+++ b/crates/bevy_pbr/src/atmosphere/node.rs
@@ -130,6 +130,7 @@ pub fn atmosphere_luts(
         &[
             atmosphere_uniforms_offset.index(),
             settings_uniforms_offset.index(),
+            atmosphere_transforms_offset.index(),
             view_uniforms_offset.offset,
             lights_uniforms_offset.offset,
         ],

--- a/crates/bevy_pbr/src/atmosphere/resources.rs
+++ b/crates/bevy_pbr/src/atmosphere/resources.rs
@@ -18,7 +18,7 @@ use bevy_image::ToExtents;
 use bevy_light::atmosphere::ScatteringMedium;
 use bevy_math::{Affine3A, Mat4, Vec3, Vec3A};
 use bevy_render::{
-    extract_component::ComponentUniforms,
+    extract_component::{ComponentUniforms, ExtractComponent},
     render_asset::RenderAssets,
     render_resource::{binding_types::*, *},
     renderer::{RenderDevice, RenderQueue},
@@ -134,6 +134,7 @@ impl AtmosphereBindGroupLayouts {
                 (
                     (0, uniform_buffer::<GpuAtmosphere>(true)),
                     (1, uniform_buffer::<GpuAtmosphereSettings>(true)),
+                    (2, uniform_buffer::<AtmosphereTransform>(true)),
                     (3, uniform_buffer::<ViewUniform>(true)),
                     (4, uniform_buffer::<GpuLights>(true)),
                     // scattering medium luts and sampler
@@ -144,7 +145,7 @@ impl AtmosphereBindGroupLayouts {
                     (8, texture_2d(TextureSampleType::default())), // transmittance
                     (9, texture_2d(TextureSampleType::default())), // multiscattering
                     (12, sampler(SamplerBindingType::Filtering)),
-                    // eerial view lut storage texture
+                    // aerial view lut storage texture
                     (
                         13,
                         texture_storage_3d(
@@ -519,6 +520,36 @@ impl AtmosphereTransforms {
 pub struct AtmosphereTransform {
     world_from_atmosphere: Mat4,
     atmosphere_from_world: Mat4,
+    /// Transform from ECEF to standard Y-up coordinates.
+    /// Identity when ECEF is not in use.
+    globe_to_plane: Mat4,
+    /// Camera altitude above the reference ellipsoid in meters.
+    view_height: f32,
+}
+
+/// Provides the ECEF-to-standard transform for geospatial atmosphere rendering.
+///
+/// When attached to the same camera entity as `AtmosphereSettings`, the
+/// [`ecf_to_std`](AtmosphereGlobe::globe_to_plane) matrix and
+/// [`view_height`](AtmosphereGlobe::view_height) altitude are forwarded to the shader
+/// as part of [`AtmosphereTransforms`]. Leave this component unset (or set both
+/// fields to their default identity / 0.0) when not using an ECEF coordinate
+/// system — the atmosphere will behave identically to the original implementation.
+#[derive(Clone, Component, ShaderType, ExtractComponent)]
+pub struct AtmosphereGlobe {
+    /// Transform matrix from ECEF to standard Y-up coordinates.
+    pub globe_to_plane: Mat4,
+    /// Camera altitude above the reference ellipsoid, in meters.
+    pub view_height: f32,
+}
+
+impl Default for AtmosphereGlobe {
+    fn default() -> Self {
+        Self {
+            globe_to_plane: Mat4::IDENTITY,
+            view_height: 0.0,
+        }
+    }
 }
 
 #[derive(Component)]
@@ -535,7 +566,12 @@ impl AtmosphereTransformsOffset {
 
 pub(super) fn prepare_atmosphere_transforms(
     views: Query<
-        (Entity, &ExtractedView, &GpuAtmosphere),
+        (
+            Entity,
+            &ExtractedView,
+            &GpuAtmosphere,
+            Option<&AtmosphereGlobe>,
+        ),
         (With<ExtractedAtmosphere>, With<Camera3d>),
     >,
     render_device: Res<RenderDevice>,
@@ -552,9 +588,14 @@ pub(super) fn prepare_atmosphere_transforms(
         return;
     };
 
-    for (entity, view, gpu_atmosphere) in &views {
+    for (entity, view, gpu_atmosphere, globe) in &views {
         // Camera position in atmosphere space
         let cam_world = view.world_from_view.translation();
+
+        let (globe_to_plane, view_height) = globe
+            .map(|g| (g.globe_to_plane, g.view_height))
+            .unwrap_or((Mat4::IDENTITY, 0.0));
+
         let cam_pos = Vec3A::from(
             gpu_atmosphere
                 .world_to_atmosphere
@@ -584,6 +625,8 @@ pub(super) fn prepare_atmosphere_transforms(
             index: writer.write(&AtmosphereTransform {
                 world_from_atmosphere,
                 atmosphere_from_world,
+                globe_to_plane,
+                view_height,
             }),
         });
     }
@@ -730,12 +773,13 @@ pub(super) fn prepare_atmosphere_bind_groups(
         );
 
         let aerial_view_lut = render_device.create_bind_group(
-            "sky_view_lut_bind_group",
+            "aerial_view_lut_bind_group",
             &pipeline_cache.get_bind_group_layout(&layouts.aerial_view_lut),
             &BindGroupEntries::with_indices((
                 // uniforms
                 (0, atmosphere_binding.clone()),
                 (1, settings_binding.clone()),
+                (2, transforms_binding.clone()),
                 (3, view_binding.clone()),
                 (4, lights_binding.clone()),
                 // scattering medium luts and sampler

--- a/crates/bevy_pbr/src/atmosphere/types.wgsl
+++ b/crates/bevy_pbr/src/atmosphere/types.wgsl
@@ -31,4 +31,6 @@ struct AtmosphereSettings {
 struct AtmosphereTransforms {
     world_from_atmosphere: mat4x4<f32>,
     atmosphere_from_world: mat4x4<f32>,
+    globe_to_plane: mat4x4<f32>,
+    view_height: f32,
 }


### PR DESCRIPTION
To support atmosphere when planet is placed at engine origin.
so I add a interface to pass the coord system transform data
the detail implement is [here](https://github.com/jiangheng90/big_space/tree/coord-system-transform-atmosphere-from-main/examples/earth)
LookupTexture is a bit wired
<img width="1284" height="756" alt="截屏2026-05-21 00 14 36" src="https://github.com/user-attachments/assets/4ee0efe7-6e55-491a-82d5-d914fd2cd1e3" />
Raymarch Looks fine
<img width="1288" height="755" alt="截屏2026-05-21 00 15 46" src="https://github.com/user-attachments/assets/904e5aab-7841-41c4-b086-c12054ffadeb" />

since my implement in issue is base on bevy 0.16 and only merge raymarching and some custimized update. I see a lot of changes in atmosphere. so it can not reach the effect in issue demonstrate. and this pull request is focus on atmosphere works fine when placing in true origin.