### PR TITLE
Add disclaimers to references to the `.bsn` file format

### DIFF
--- a/crates/bevy_scene/src/spawn.rs
+++ b/crates/bevy_scene/src/spawn.rs
@@ -19,7 +19,8 @@ pub trait WorldSceneExt {
     ///
     /// See [`Scene`] for the features of the scene system (and how to use it).
     ///
-    /// If your scene has a dependency that might not be loaded yet (for example, it inherits from a `.bsn` asset file), consider using [`World::queue_spawn_scene`].
+    /// If your scene has a dependency that might not be loaded yet (for example, it inherits from a `.bsn` asset file), consider using [`World::queue_spawn_scene`].  
+    /// DISCLAIMER: The .bsn file format is not yet released!
     ///
     /// ```
     /// # use bevy_app::App;
@@ -85,6 +86,7 @@ pub trait WorldSceneExt {
     ///
     /// // This scene inherits from the "player.bsn" asset. It will be spawned on the frame that "player.bsn"
     /// // is fully loaded.
+    /// // DISCLAIMER: The .bsn file format is not yet released!
     /// world.queue_spawn_scene(bsn! {
     ///     :"player.bsn"
     ///     #Player
@@ -104,7 +106,8 @@ pub trait WorldSceneExt {
     ///
     /// See [`Scene`] for the features of the scene system (and how to use it).
     ///
-    /// If your scene list has a dependency that might not be loaded yet (for example, it inherits from a `.bsn` asset file), consider using [`World::queue_spawn_scene_list`].
+    /// If your scene list has a dependency that might not be loaded yet (for example, it inherits from a `.bsn` asset file), consider using [`World::queue_spawn_scene_list`].  
+    /// DISCLAIMER: The .bsn file format is not yet released!
     ///
     /// ```
     /// # use bevy_app::App;
@@ -166,6 +169,7 @@ pub trait WorldSceneExt {
     /// }
     /// // This scene list inherits from the "player.bsn" asset. It will be spawned on the frame that "player.bsn"
     /// // is loaded.
+    /// // DISCLAIMER: The .bsn file format is not yet released!
     /// world.queue_spawn_scene_list(bsn_list! [
     ///     (
     ///         :"player.bsn"
@@ -226,7 +230,8 @@ pub trait CommandsSceneExt {
     ///
     /// See [`Scene`] for the features of the scene system (and how to use it).
     ///
-    /// If your scene has a dependency that might not be loaded yet (for example, it inherits from a `.bsn` asset file), consider using [`Commands::queue_spawn_scene`].
+    /// If your scene has a dependency that might not be loaded yet (for example, it inherits from a `.bsn` asset file), consider using [`Commands::queue_spawn_scene`].  
+    /// DISCLAIMER: The .bsn file format is not yet released!
     ///
     /// ```
     /// # use bevy_scene::prelude::*;
@@ -276,6 +281,7 @@ pub trait CommandsSceneExt {
     ///
     /// // This scene inherits from the "player.bsn" asset. It will be spawned on the frame that "player.bsn"
     /// // is fully loaded.
+    /// // DISCLAIMER: The .bsn file format is not yet released!
     /// commands.queue_spawn_scene(bsn! {
     ///     :"player.bsn"
     ///     #Player
@@ -309,6 +315,7 @@ pub trait CommandsSceneExt {
     ///     Blue,
     /// }
     ///
+    /// // DISCLAIMER: The .bsn file format is not yet released!
     /// commands.spawn_scene_list(bsn_list! {
     ///     (
     ///         :"player.bsn"
@@ -343,6 +350,7 @@ pub trait CommandsSceneExt {
     ///
     /// // This scene list inherits from the "player.bsn" asset. It will be spawned on the frame that "player.bsn"
     /// // is loaded.
+    /// // DISCLAIMER: The .bsn file format is not yet released!
     /// commands.queue_spawn_scene_list(bsn_list! [
     ///     (
     ///         :"player.bsn"
@@ -450,7 +458,8 @@ pub trait EntityWorldMutSceneExt {
     ///
     /// See [`Scene`] for the features of the scene system (and how to use it).
     ///
-    /// If your scene has a dependency that might not be loaded yet (for example, it inherits from a `.bsn` asset file), consider using [`World::queue_spawn_scene`].
+    /// If your scene has a dependency that might not be loaded yet (for example, it inherits from a `.bsn` asset file), consider using [`World::queue_spawn_scene`].  
+    /// DISCLAIMER: The .bsn file format is not yet released!
     fn apply_scene<S: Scene>(&mut self, scene: S) -> Result<(), SpawnSceneError>;
 
     /// Queues the `scene` to be applied. This will evaluate the `scene`'s dependencies (via [`Scene::register_dependencies`]) and queue it to be resolved and spawned
@@ -549,7 +558,8 @@ pub trait EntityCommandsSceneExt {
     ///
     /// See [`Scene`] for the features of the scene system (and how to use it).
     ///
-    /// If your scene has a dependency that might not be loaded yet (for example, it inherits from a `.bsn` asset file), consider using [`Commands::spawn_scene`].
+    /// If your scene has a dependency that might not be loaded yet (for example, it inherits from a `.bsn` asset file), consider using [`Commands::spawn_scene`].  
+    /// DISCLAIMER: The .bsn file format is not yet released!
     fn apply_scene<S: Scene>(&mut self, scene: S) -> &mut Self;
 
     /// Queues the `scene` to be applied. This will evaluate the `scene`'s dependencies (via [`Scene::register_dependencies`]) and queue it to be resolved and spawned

--- a/crates/bevy_scene/src/spawn.rs
+++ b/crates/bevy_scene/src/spawn.rs
@@ -19,8 +19,8 @@ pub trait WorldSceneExt {
     ///
     /// See [`Scene`] for the features of the scene system (and how to use it).
     ///
-    /// If your scene has a dependency that might not be loaded yet (for example, it inherits from a `.bsn` asset file), consider using [`World::queue_spawn_scene`].  
-    /// DISCLAIMER: The .bsn file format is not yet released!
+    /// If your scene has a dependency that might not be loaded yet (for example, it inherits from a `.bsn` asset file), consider using [`World::queue_spawn_scene`].
+    /// Note that the `.bsn` file format is not yet released.
     ///
     /// ```
     /// # use bevy_app::App;
@@ -84,9 +84,8 @@ pub trait WorldSceneExt {
     /// #[derive(Component, Default, Clone)]
     /// struct Shield;
     ///
-    /// // This scene inherits from the "player.bsn" asset. It will be spawned on the frame that "player.bsn"
+    /// // This scene inherits from the "player.bsn" asset (note that the `.bsn` file format is not yet released). It will be spawned on the frame that "player.bsn"
     /// // is fully loaded.
-    /// // DISCLAIMER: The .bsn file format is not yet released!
     /// world.queue_spawn_scene(bsn! {
     ///     :"player.bsn"
     ///     #Player
@@ -106,8 +105,8 @@ pub trait WorldSceneExt {
     ///
     /// See [`Scene`] for the features of the scene system (and how to use it).
     ///
-    /// If your scene list has a dependency that might not be loaded yet (for example, it inherits from a `.bsn` asset file), consider using [`World::queue_spawn_scene_list`].  
-    /// DISCLAIMER: The .bsn file format is not yet released!
+    /// If your scene list has a dependency that might not be loaded yet (for example, it inherits from a `.bsn` asset file), consider using [`World::queue_spawn_scene_list`].
+    /// Note that the `.bsn` file format is not yet released.
     ///
     /// ```
     /// # use bevy_app::App;
@@ -167,9 +166,8 @@ pub trait WorldSceneExt {
     ///     Red,
     ///     Blue,
     /// }
-    /// // This scene list inherits from the "player.bsn" asset. It will be spawned on the frame that "player.bsn"
+    /// // This scene list inherits from the "player.bsn" asset (note that the `.bsn` file format is not yet released). It will be spawned on the frame that "player.bsn"
     /// // is loaded.
-    /// // DISCLAIMER: The .bsn file format is not yet released!
     /// world.queue_spawn_scene_list(bsn_list! [
     ///     (
     ///         :"player.bsn"
@@ -230,8 +228,8 @@ pub trait CommandsSceneExt {
     ///
     /// See [`Scene`] for the features of the scene system (and how to use it).
     ///
-    /// If your scene has a dependency that might not be loaded yet (for example, it inherits from a `.bsn` asset file), consider using [`Commands::queue_spawn_scene`].  
-    /// DISCLAIMER: The .bsn file format is not yet released!
+    /// If your scene has a dependency that might not be loaded yet (for example, it inherits from a `.bsn` asset file), consider using [`Commands::queue_spawn_scene`].
+    /// Note that the `.bsn` file format is not yet released.
     ///
     /// ```
     /// # use bevy_scene::prelude::*;
@@ -279,9 +277,8 @@ pub trait CommandsSceneExt {
     /// #[derive(Component, Default, Clone)]
     /// struct Shield;
     ///
-    /// // This scene inherits from the "player.bsn" asset. It will be spawned on the frame that "player.bsn"
+    /// // This scene inherits from the "player.bsn" asset (note that the `.bsn` file format is not yet released). It will be spawned on the frame that "player.bsn"
     /// // is fully loaded.
-    /// // DISCLAIMER: The .bsn file format is not yet released!
     /// commands.queue_spawn_scene(bsn! {
     ///     :"player.bsn"
     ///     #Player
@@ -315,7 +312,7 @@ pub trait CommandsSceneExt {
     ///     Blue,
     /// }
     ///
-    /// // DISCLAIMER: The .bsn file format is not yet released!
+    /// // Note that the .bsn file format is not yet released.
     /// commands.spawn_scene_list(bsn_list! {
     ///     (
     ///         :"player.bsn"
@@ -348,9 +345,8 @@ pub trait CommandsSceneExt {
     ///     Blue,
     /// }
     ///
-    /// // This scene list inherits from the "player.bsn" asset. It will be spawned on the frame that "player.bsn"
+    /// // This scene list inherits from the "player.bsn" asset (note that the `.bsn` file format is not yet released). It will be spawned on the frame that "player.bsn"
     /// // is loaded.
-    /// // DISCLAIMER: The .bsn file format is not yet released!
     /// commands.queue_spawn_scene_list(bsn_list! [
     ///     (
     ///         :"player.bsn"
@@ -458,8 +454,8 @@ pub trait EntityWorldMutSceneExt {
     ///
     /// See [`Scene`] for the features of the scene system (and how to use it).
     ///
-    /// If your scene has a dependency that might not be loaded yet (for example, it inherits from a `.bsn` asset file), consider using [`World::queue_spawn_scene`].  
-    /// DISCLAIMER: The .bsn file format is not yet released!
+    /// If your scene has a dependency that might not be loaded yet (for example, it inherits from a `.bsn` asset file), consider using [`World::queue_spawn_scene`].
+    /// Note that the .bsn file format is not yet released.
     fn apply_scene<S: Scene>(&mut self, scene: S) -> Result<(), SpawnSceneError>;
 
     /// Queues the `scene` to be applied. This will evaluate the `scene`'s dependencies (via [`Scene::register_dependencies`]) and queue it to be resolved and spawned
@@ -558,8 +554,8 @@ pub trait EntityCommandsSceneExt {
     ///
     /// See [`Scene`] for the features of the scene system (and how to use it).
     ///
-    /// If your scene has a dependency that might not be loaded yet (for example, it inherits from a `.bsn` asset file), consider using [`Commands::spawn_scene`].  
-    /// DISCLAIMER: The .bsn file format is not yet released!
+    /// If your scene has a dependency that might not be loaded yet (for example, it inherits from a `.bsn` asset file), consider using [`Commands::spawn_scene`].
+    /// Note that the .bsn file format is not yet released.
     fn apply_scene<S: Scene>(&mut self, scene: S) -> &mut Self;
 
     /// Queues the `scene` to be applied. This will evaluate the `scene`'s dependencies (via [`Scene::register_dependencies`]) and queue it to be resolved and spawned


### PR DESCRIPTION
# Objective

Warn readers that the `.bsn` file format does not exist yet, to avoid confusion.
Fixes: #24309

## Solution

Add comments warning about this. This is better than removing all references because we do want `.bsn` to exist in the future.

I used markdown's "double space at the end of the line" to make line breaks, even though I don't like that syntax. Is there a better way?

## Testing

`cargo doc -p bevy_scene` and look at it