### PR TITLE
cherry-pick: rename bevy_settings to bevy-settings (#24317)

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -529,7 +529,7 @@ pub(crate) fn bevy_ecs_path() -> syn::Path {
 }
 
 pub(crate) fn bevy_settings_path() -> syn::Path {
-    BevyManifest::shared(|manifest| manifest.get_path("bevy_settings"))
+    BevyManifest::shared(|manifest| manifest.get_path("bevy-settings"))
 }
 
 /// Implement the `Event` trait.

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -478,6 +478,9 @@ debug = ["bevy_utils/debug", "bevy_ecs/debug", "bevy_render?/debug"]
 screenrecording = ["bevy_dev_tools/screenrecording"]
 schedule_data = ["bevy_dev_tools/schedule_data"]
 
+# Keep feature for bevy-settings as bevy_settings
+bevy_settings = ["bevy-settings"]
+
 [dependencies]
 # bevy (no_std)
 bevy_app = { path = "../bevy_app", version = "0.19.0-rc.1", default-features = false, features = [

--- a/crates/bevy_macro_utils/src/bevy_manifest.rs
+++ b/crates/bevy_macro_utils/src/bevy_manifest.rs
@@ -82,9 +82,11 @@ impl BevyManifest {
     /// Attempt to retrieve the [path](syn::Path) of a particular package in
     /// the [manifest](BevyManifest) by [name](str).
     pub fn maybe_get_path(&self, name: &str) -> Option<syn::Path> {
+        // Cargo normalizes hyphens to underscores when crates are referenced from Rust code.
+        let rust_name = name.replace('-', "_");
         let find_in_deps = |deps: &Item| -> Option<syn::Path> {
             let package = if deps.get(name).is_some() {
-                return Some(Self::parse_str(name));
+                return Some(Self::parse_str(&rust_name));
             } else if deps.get(BEVY).is_some() {
                 BEVY
             } else {
@@ -97,7 +99,7 @@ impl BevyManifest {
             };
 
             let mut path = Self::parse_str::<syn::Path>(&format!("::{package}"));
-            if let Some(module) = name.strip_prefix("bevy_") {
+            if let Some(module) = rust_name.strip_prefix("bevy_") {
                 path.segments.push(Self::parse_str(module));
             }
             Some(path)
@@ -118,7 +120,7 @@ impl BevyManifest {
     /// Returns the path for the crate with the given name.
     pub fn get_path(&self, name: &str) -> syn::Path {
         self.maybe_get_path(name)
-            .unwrap_or_else(|| Self::parse_str(name))
+            .unwrap_or_else(|| Self::parse_str(&name.replace('-', "_")))
     }
 
     /// Attempt to parse provided [path](str) as a [syntax tree node](syn::parse::Parse).

--- a/crates/bevy_settings/Cargo.toml
+++ b/crates/bevy_settings/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+# crate was originally published as bevy-settings and can't be renamed on crates.io
 name = "bevy-settings"
 version = "0.19.0-rc.1"
 edition = "2024"


### PR DESCRIPTION
fixes a warning