### PR TITLE
Fix unsoundness in `MovingPtr::assign_to`

### DIFF
--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -594,18 +594,36 @@ impl<'a, T, A: IsAligned> MovingPtr<'a, T, A> {
     /// The value previously stored at `dst` will be dropped.
     #[inline]
     pub fn assign_to(self, dst: &mut T) {
-        // SAFETY:
-        // - `dst` is a mutable borrow, it must point to a valid instance of `T`.
-        // - `dst` is a mutable borrow, it must point to value that is valid for dropping.
-        // - `dst` is a mutable borrow, it must not alias any other access.
-        unsafe {
-            ptr::drop_in_place(dst);
+        struct DropGuard<'a, 'b, T, A: IsAligned> {
+            src: ManuallyDrop<MovingPtr<'a, T, A>>,
+            dst: &'b mut T,
         }
+
+        impl<'a, 'b, T, A: IsAligned> Drop for DropGuard<'a, 'b, T, A> {
+            fn drop(&mut self) {
+                // SAFETY: `self.src` is always initialized with a valid `MovingPtr` and is only ever taken here
+                // in drop. No other code can observe the invalid `self.src` after this point.
+                let src = unsafe { ManuallyDrop::take(&mut self.src) };
+
+                // SAFETY:
+                // - `dst` is a mutable borrow, it must be valid for writes.
+                // - `dst` is a mutable borrow, it must always be aligned.
+                unsafe { src.write_to(self.dst) };
+            }
+        }
+
+        let guard = DropGuard {
+            src: ManuallyDrop::new(self),
+            dst,
+        };
+
         // SAFETY:
-        // - `dst` is a mutable borrow, it must be valid for writes.
-        // - `dst` is a mutable borrow, it must always be aligned.
+        // - `guard.dst` is a mutable borrow, it must point to a valid instance of `T`.
+        // - `guard.dst` is a mutable borrow, it must point to value that is valid for dropping.
+        // - `guard.dst` is a mutable borrow, it must not alias any other access.
+        // - `guard.dst` will be overwritten when `guard` is dropped, so no other code can observe it being dropped.
         unsafe {
-            self.write_to(dst);
+            ptr::drop_in_place(guard.dst);
         }
     }
 

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -594,37 +594,13 @@ impl<'a, T, A: IsAligned> MovingPtr<'a, T, A> {
     /// The value previously stored at `dst` will be dropped.
     #[inline]
     pub fn assign_to(self, dst: &mut T) {
-        struct DropGuard<'a, 'b, T, A: IsAligned> {
-            src: ManuallyDrop<MovingPtr<'a, T, A>>,
-            dst: &'b mut T,
-        }
-
-        impl<'a, 'b, T, A: IsAligned> Drop for DropGuard<'a, 'b, T, A> {
-            fn drop(&mut self) {
-                // SAFETY: `self.src` is always initialized with a valid `MovingPtr` and is only ever taken here
-                // in drop. No other code can observe the invalid `self.src` after this point.
-                let src = unsafe { ManuallyDrop::take(&mut self.src) };
-
-                // SAFETY:
-                // - `dst` is a mutable borrow, it must be valid for writes.
-                // - `dst` is a mutable borrow, it must always be aligned.
-                unsafe { src.write_to(self.dst) };
-            }
-        }
-
-        let guard = DropGuard {
-            src: ManuallyDrop::new(self),
-            dst,
-        };
-
+        let src = self.0.as_ptr();
+        mem::forget(self);
         // SAFETY:
-        // - `guard.dst` is a mutable borrow, it must point to a valid instance of `T`.
-        // - `guard.dst` is a mutable borrow, it must point to value that is valid for dropping.
-        // - `guard.dst` is a mutable borrow, it must not alias any other access.
-        // - `guard.dst` will be overwritten when `guard` is dropped, so no other code can observe it being dropped.
-        unsafe {
-            ptr::drop_in_place(guard.dst);
-        }
+        //  - `src` must be valid for reads as this pointer is considered to own the value it points to.
+        //  - As `A` is `Aligned`, the caller is required to ensure that `dst` is aligned and `src` must
+        //    be aligned by the type's invariants.
+        *dst = unsafe { A::read_ptr(src) };
     }
 
     /// Creates a [`MovingPtr`] for a specific field within `self`.

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -593,8 +593,19 @@ impl<'a, T, A: IsAligned> MovingPtr<'a, T, A> {
     /// Writes the value pointed to by this pointer into `dst`.
     ///
     /// The value previously stored at `dst` will be dropped.
+    ///
+    /// This has the same semantics as a normal `*dst = ...` assignment.
     #[inline]
     pub fn assign_to(self, dst: &mut T) {
+        // This code has the same semantics as the following:
+        // ```
+        // let src = self.0.as_ptr();
+        // mem::forget(self);
+        // *dst = unsafe { A::read(src) };
+        // ```
+        //
+        // However the above might codegen to multiple `memcpy`s, while the code below will avoid that.
+
         struct DropGuard<'a, 'b, T, A: IsAligned> {
             src: ManuallyDrop<MovingPtr<'a, T, A>>,
             dst: &'b mut T,

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -595,14 +595,37 @@ impl<'a, T, A: IsAligned> MovingPtr<'a, T, A> {
     /// The value previously stored at `dst` will be dropped.
     #[inline]
     pub fn assign_to(self, dst: &mut T) {
-        let src = self.0.as_ptr();
-        mem::forget(self);
+        struct DropGuard<'a, 'b, T, A: IsAligned> {
+            src: ManuallyDrop<MovingPtr<'a, T, A>>,
+            dst: &'b mut T,
+        }
+
+        impl<'a, 'b, T, A: IsAligned> Drop for DropGuard<'a, 'b, T, A> {
+            fn drop(&mut self) {
+                // SAFETY: `self.src` is always initialized with a valid `MovingPtr` and is only ever taken here
+                // in drop. No other code can observe the invalid `self.src` after this point.
+                let src = unsafe { ManuallyDrop::take(&mut self.src) };
+
+                // SAFETY:
+                // - `dst` is a mutable borrow, it must be valid for writes.
+                // - `dst` is a mutable borrow, it must always be aligned.
+                unsafe { src.write_to(self.dst) };
+            }
+        }
+
+        let guard = DropGuard {
+            src: ManuallyDrop::new(self),
+            dst,
+        };
+
         // SAFETY:
-        //  - `src` must be valid for reads as this pointer is considered to own the value it points to.
-        //  - As `A` is `Aligned`, the caller is required to ensure that `dst` is aligned and `src` must
-        //    be aligned by the type's invariants.
-        //  - We took self by move and forgotten it, so nothing else can observe `src` being moved out.
-        *dst = unsafe { A::read_ptr(src) };
+        // - `guard.dst` is a mutable borrow, it must point to a valid instance of `T`.
+        // - `guard.dst` is a mutable borrow, it must point to value that is valid for dropping.
+        // - `guard.dst` is a mutable borrow, it must not alias any other access.
+        // - `guard.dst` will be overwritten when `guard` is dropped, so no other code can observe it being dropped.
+        unsafe {
+            ptr::drop_in_place(guard.dst);
+        }
     }
 
     /// Creates a [`MovingPtr`] for a specific field within `self`.

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -586,6 +586,7 @@ impl<'a, T, A: IsAligned> MovingPtr<'a, T, A> {
         //  - The caller is required to ensure that `dst` must be valid for writes.
         //  - As `A` is `Aligned`, the caller is required to ensure that `dst` is aligned and `src` must
         //    be aligned by the type's invariants.
+        //  - We took self by move and forgotten it, so nothing else can observe `src` being moved out.
         unsafe { A::copy_nonoverlapping(src, dst, 1) };
     }
 
@@ -600,6 +601,7 @@ impl<'a, T, A: IsAligned> MovingPtr<'a, T, A> {
         //  - `src` must be valid for reads as this pointer is considered to own the value it points to.
         //  - As `A` is `Aligned`, the caller is required to ensure that `dst` is aligned and `src` must
         //    be aligned by the type's invariants.
+        //  - We took self by move and forgotten it, so nothing else can observe `src` being moved out.
         *dst = unsafe { A::read_ptr(src) };
     }
 

--- a/crates/bevy_ptr/tests/moving_ptr.rs
+++ b/crates/bevy_ptr/tests/moving_ptr.rs
@@ -1,4 +1,4 @@
-//! Tests for [`bevy_ptr::MovingPtr`] with panic behaviour.
+//! Tests for [`bevy_ptr::MovingPtr`] with panic behavior.
 
 #![allow(unsafe_code, reason = "unsafe is needed to use bevy_ptr::MovingPtr")]
 

--- a/crates/bevy_ptr/tests/moving_ptr.rs
+++ b/crates/bevy_ptr/tests/moving_ptr.rs
@@ -6,6 +6,9 @@ use bevy_ptr::MovingPtr;
 
 use core::cell::Cell;
 use core::mem::MaybeUninit;
+use core::panic::AssertUnwindSafe;
+
+use std::panic::catch_unwind;
 
 #[test]
 fn moving_ptr_assign_drop() {
@@ -27,7 +30,7 @@ fn moving_ptr_assign_drop() {
     let mut value1 = MaybeUninit::new(IncAndPanicOnDrop(&drops1));
     let mut value2 = IncAndPanicOnDrop(&drops2);
 
-    _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+    _ = catch_unwind(AssertUnwindSafe(|| {
         // SAFETY:
         // - value1 is initialized
         // - we're not using value1 after this point.
@@ -42,7 +45,7 @@ fn moving_ptr_assign_drop() {
     assert_eq!(drops2.get(), 1);
 
     // Now drop value2, which should now hold value1. We expect this to drop value1 and increase drops1.
-    _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| drop(value2)));
+    _ = catch_unwind(AssertUnwindSafe(|| drop(value2)));
 
     assert_eq!(drops1.get(), 1);
     assert_eq!(drops2.get(), 1);

--- a/crates/bevy_ptr/tests/moving_ptr.rs
+++ b/crates/bevy_ptr/tests/moving_ptr.rs
@@ -1,0 +1,49 @@
+//! Tests for [`bevy_ptr::MovingPtr`] with panic behaviour.
+
+#![allow(unsafe_code, reason = "unsafe is needed to use bevy_ptr::MovingPtr")]
+
+use bevy_ptr::MovingPtr;
+
+use core::cell::Cell;
+use core::mem::MaybeUninit;
+
+#[test]
+fn moving_ptr_assign_drop() {
+    struct IncAndPanicOnDrop<'a>(&'a Cell<u32>);
+    impl<'a> Drop for IncAndPanicOnDrop<'a> {
+        fn drop(&mut self) {
+            self.0.set(self.0.get() + 1);
+
+            // Panic, but avoid double-panics to avoid aborts.
+            if !std::thread::panicking() {
+                panic!();
+            }
+        }
+    }
+
+    let drops1 = Cell::new(0);
+    let drops2 = Cell::new(0);
+
+    let mut value1 = MaybeUninit::new(IncAndPanicOnDrop(&drops1));
+    let mut value2 = IncAndPanicOnDrop(&drops2);
+
+    _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        // SAFETY:
+        // - value1 is initialized
+        // - we're not using value1 after this point.
+        let moving_ptr = unsafe { MovingPtr::from_value(&mut value1) };
+
+        // This should drop value2 and overwrite it with value1 no matter what happen.
+        // If the overwrite doesn't happen then it is unsound and the second pair of asserts will fail.
+        moving_ptr.assign_to(&mut value2);
+    }));
+
+    assert_eq!(drops1.get(), 0);
+    assert_eq!(drops2.get(), 1);
+
+    // Now drop value2, which should now hold value1. We expect this to drop value1 and increase drops1.
+    _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| drop(value2)));
+
+    assert_eq!(drops1.get(), 1);
+    assert_eq!(drops2.get(), 1);
+}

--- a/crates/bevy_ptr/tests/moving_ptr.rs
+++ b/crates/bevy_ptr/tests/moving_ptr.rs
@@ -11,7 +11,7 @@ use core::panic::AssertUnwindSafe;
 use std::panic::catch_unwind;
 
 #[test]
-fn moving_ptr_assign_drop() {
+fn moving_ptr_assign_drop_is_unwind_safe() {
     struct IncAndPanicOnDrop<'a>(&'a Cell<u32>);
     impl<'a> Drop for IncAndPanicOnDrop<'a> {
         fn drop(&mut self) {


### PR DESCRIPTION
# Objective

- `MovingPtr::assign_to` is currently unsound if the destructor of `*dst` panics because it will leave it populated with the old value whose destructor panicked. When the owner of `*dst` then drops it it will result in a double drop.
- Fix this unsoundness, fixes #23500

## Solution

- Use a drop guard to ensure that no matter what happens when dropping `*dst`, it will be overwritten with the value from `self.` This has the same semantics as normal assignments except it will prevent generating multiple `memcpy`s.
- ~~Rewrite the method to use a normal assignment to the reference so that the language itself takes care of this issue.~~ This ended up making two `memcpy`s

## Testing

- A regression test has been added
