### PR TITLE
Fix multi-line log when inserting a resource multiple times

### DIFF
--- a/crates/bevy_ecs/src/resource.rs
+++ b/crates/bevy_ecs/src/resource.rs
@@ -167,8 +167,8 @@ impl IsResource {
                     .components()
                     .get_name(resource_component_id)
                     .expect("resource is registered");
-                warn!("Tried inserting the resource {} while one already exists.
-                Resources are unique components stored on a single entity.
+                warn!("Tried inserting the resource {} while one already exists. \
+                Resources are unique components stored on a single entity. \
                 Inserting on a different entity, when one already exists, causes the new value to be removed.", name);
             }
         } else {


### PR DESCRIPTION
# Objective

Fixes #24360

## Solution

Flattened the multi-line `warn!()` message in `resource.rs` using the `\` character, preventing literal newlines and indentation from being displayed in log output.

## Testing

Created a small program outside the repo that inserts the same resource twice, which triggered the warning and confirmed that the log output now appears on a single line.

