### PR TITLE
bevy_reflect: Capture generic type info on opaque types

### DIFF
--- a/crates/bevy_reflect/derive/src/impls/opaque.rs
+++ b/crates/bevy_reflect/derive/src/impls/opaque.rs
@@ -1,3 +1,4 @@
+use crate::generics::generate_generics;
 use crate::{
     impls::{common_partial_reflect_methods, impl_full_reflect, impl_type_path, impl_typed},
     where_clause_options::WhereClauseOptions,
@@ -20,11 +21,19 @@ pub(crate) fn impl_opaque(meta: &ReflectMeta) -> proc_macro2::TokenStream {
     let with_docs: Option<proc_macro2::TokenStream> = None;
 
     let where_clause_options = WhereClauseOptions::new(meta);
+    let mut info = quote! {
+        #bevy_reflect_path::OpaqueInfo::new::<Self>() #with_docs
+    };
+    if let Some(generics) = generate_generics(meta) {
+        info.extend(quote! {
+            .with_generics(#generics)
+        });
+    }
     let typed_impl = impl_typed(
         &where_clause_options,
         quote! {
-            let info = #bevy_reflect_path::OpaqueInfo::new::<Self>() #with_docs;
-            #bevy_reflect_path::TypeInfo::Opaque(info)
+            let info = #info;
+            #bevy_reflect_path::TypeInfo::Opaque(#info)
         },
     );
 

--- a/crates/bevy_reflect/src/generics.rs
+++ b/crates/bevy_reflect/src/generics.rs
@@ -336,4 +336,75 @@ mod tests {
         };
         assert_eq!(n.default().unwrap().downcast_ref::<usize>().unwrap(), &10);
     }
+
+    #[test]
+    fn should_not_capture_generics_with_type_path_opt_out() {
+        #[derive(Reflect)]
+        #[reflect(type_path = false)]
+        struct Test<T: Default, const N: usize = 10>(#[reflect(ignore)] T);
+
+        impl<T: Default + 'static, const N: usize> TypePath for Test<T, N> {
+            fn type_path() -> &'static str {
+                ::core::any::type_name::<Self>()
+            }
+
+            fn short_type_path() -> &'static str {
+                "Test<T, N>"
+            }
+        }
+
+        let generics = <Test<f32> as Typed>::type_info()
+            .as_tuple_struct()
+            .unwrap()
+            .generics();
+
+        assert!(generics.is_empty());
+    }
+
+    #[test]
+    fn should_capture_generics_on_opaque_type() {
+        #[derive(Reflect, Clone)]
+        #[reflect(opaque)]
+        struct Test<T: Clone + Default, const N: usize = 10>(#[reflect(ignore)] T);
+
+        let generics = <Test<f32> as Typed>::type_info()
+            .as_opaque()
+            .unwrap()
+            .generics();
+
+        let t = generics.get_named("T").unwrap();
+        assert_eq!(t.name(), "T");
+        assert!(t.is::<f32>());
+        assert!(!t.is_const());
+
+        let n = generics.get_named("N").unwrap();
+        assert_eq!(n.name(), "N");
+        assert!(n.is::<usize>());
+        assert!(n.is_const());
+    }
+
+    #[test]
+    fn should_not_capture_generics_on_opaque_type_with_type_path_opt_out() {
+        #[derive(Reflect, Clone)]
+        #[reflect(opaque)]
+        #[reflect(type_path = false)]
+        struct Test<T: Clone + Default, const N: usize = 10>(#[reflect(ignore)] T);
+
+        impl<T: Clone + Default + 'static, const N: usize> TypePath for Test<T, N> {
+            fn type_path() -> &'static str {
+                ::core::any::type_name::<Self>()
+            }
+
+            fn short_type_path() -> &'static str {
+                "Test<T, N>"
+            }
+        }
+
+        let generics = <Test<f32> as Typed>::type_info()
+            .as_opaque()
+            .unwrap()
+            .generics();
+
+        assert!(generics.is_empty());
+    }
 }

--- a/crates/bevy_reflect/src/impls/bevy_platform/sync.rs
+++ b/crates/bevy_reflect/src/impls/bevy_platform/sync.rs
@@ -2,3 +2,23 @@ use bevy_reflect_derive::{impl_reflect_opaque, impl_type_path};
 
 impl_reflect_opaque!(::bevy_platform::sync::Arc<T: Send + Sync + ?Sized>(Clone));
 impl_type_path!(::bevy_platform::sync::Mutex<T>);
+
+#[cfg(test)]
+mod tests {
+    use crate::Typed;
+
+    #[test]
+    fn should_capture_generic_info() {
+        let generics = <::bevy_platform::sync::Arc<u32>>::type_info()
+            .as_opaque()
+            .unwrap()
+            .generics();
+
+        assert_eq!(generics.len(), 1);
+
+        let t = generics.get_named("T").unwrap();
+        assert_eq!(t.name(), "T");
+        assert!(t.is::<u32>());
+        assert!(!t.is_const());
+    }
+}


### PR DESCRIPTION
# Objective

Resolves #24235

## Solution

This PR makes it so that opaque types (i.e. those marked with `#[reflect(opaque)]` or implemented with `impl_reflect_opaque!`), such as `Arc<T>`, capture generic type information when possible.

Upon reviewing the code, I don't believe this was an intentional limitation. And instead, it was probably just forgotten about.

## Testing

I added new unit tests to ensure this works properly.