### PR TITLE
Make `ComputedNode` documentation clearer

### DIFF
--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -17,66 +17,60 @@ use smallvec::SmallVec;
 use thiserror::Error;
 use tracing::warn;
 
-/// Provides the computed size and layout properties of the node.
+/// Provides the computed size and layout properties of a UI [`Node`].
 ///
-/// Fields in this struct are public but should not be modified under most circumstances.
+/// All of the fields are automatically calculated by [`ui_layout_system`](`super::layout::ui_layout_system`)
+/// during `PostUpdate` in the [`UiSystems::Layout`](super::UiSystems) set..
+///
+/// The fields are measured in physical pixels.
+/// You can multiply by the `inverse_scale_factor` field to convert back to logical pixels.
+///
+/// Fields in this struct are public but should only rarely be directly modified.
 /// For example, in a scrollbar you may want to derive the handle's size from the proportion of
 /// scrollable content in-view. You can directly modify `ComputedNode` after layout to set the
-/// handle size without any delays.
+/// handle size without a frame delay.
 #[derive(Component, Debug, Copy, Clone, PartialEq, Reflect)]
 #[reflect(Component, Default, Debug, Clone)]
 #[require(ComputedStackIndex)]
 pub struct ComputedNode {
     /// The size of the node as width and height in physical pixels.
-    ///
-    /// Automatically calculated by [`ui_layout_system`](`super::layout::ui_layout_system`).
     pub size: Vec2,
-    /// Size of this node's content.
-    ///
-    /// Automatically calculated by [`ui_layout_system`](`super::layout::ui_layout_system`).
+    /// Size of this node's content in physical pixels.
     pub content_size: Vec2,
     /// Space allocated for scrollbars.
-    ///
-    /// Automatically calculated by [`ui_layout_system`](`super::layout::ui_layout_system`).
     pub scrollbar_size: Vec2,
     /// Resolved offset of scrolled content
-    ///
-    /// Automatically calculated by [`ui_layout_system`](`super::layout::ui_layout_system`).
     pub scroll_position: Vec2,
-    /// The width of this node's outline.
-    /// If this value is `Auto`, negative or `0.` then no outline will be rendered.
-    /// Outline updates bypass change detection.
+    /// The width of this node's outline in physical pixels.
+    /// If this value is negative or zero then no outline will be rendered.
     ///
-    /// Automatically calculated by [`ui_layout_system`](`super::layout::ui_layout_system`).
+    /// [`ui_layout_system`](`super::layout::ui_layout_system`) bypasses change detection
+    /// when updating this field.
     pub outline_width: f32,
     /// The amount of space between the outline and the edge of the node.
-    /// Outline updates bypass change detection.
     ///
-    /// Automatically calculated by [`ui_layout_system`](`super::layout::ui_layout_system`).
+    /// [`ui_layout_system`](`super::layout::ui_layout_system`) bypasses change detection
+    /// when updating this field.
     pub outline_offset: f32,
     /// The unrounded size of the node as width and height in physical pixels.
-    ///
-    /// Automatically calculated by [`ui_layout_system`](`super::layout::ui_layout_system`).
     pub unrounded_size: Vec2,
     /// Resolved border values in physical pixels.
-    /// Border updates bypass change detection.
     ///
-    /// Automatically calculated by [`ui_layout_system`](`super::layout::ui_layout_system`).
+    /// [`ui_layout_system`](`super::layout::ui_layout_system`) bypasses change detection
+    /// when updating this field.
     pub border: BorderRect,
     /// Resolved border radius values in physical pixels.
-    /// Border radius updates bypass change detection.
     ///
-    /// Automatically calculated by [`ui_layout_system`](`super::layout::ui_layout_system`).
+    /// [`ui_layout_system`](`super::layout::ui_layout_system`) bypasses change detection
+    /// when updating this field.
     pub border_radius: ResolvedBorderRadius,
     /// Resolved padding values in physical pixels.
-    /// Padding updates bypass change detection.
     ///
-    /// Automatically calculated by [`ui_layout_system`](`super::layout::ui_layout_system`).
+    /// [`ui_layout_system`](`super::layout::ui_layout_system`) bypasses change detection
+    /// when updating this field.
     pub padding: BorderRect,
     /// Inverse scale factor for this Node.
     /// Multiply physical coordinates by the inverse scale factor to give logical coordinates.
-    ///
-    /// Automatically calculated by [`ui_layout_system`](`super::layout::ui_layout_system`).
     pub inverse_scale_factor: f32,
 }
 
@@ -113,7 +107,7 @@ impl ComputedNode {
     }
 
     /// Returns the thickness of the UI node's outline in physical pixels.
-    /// If this value is negative or `0.` then no outline will be rendered.
+    /// If this value is negative or zero then no outline will be rendered.
     ///
     /// Automatically calculated by [`ui_layout_system`](`super::layout::ui_layout_system`).
     #[inline]


### PR DESCRIPTION
# Objective

The ComputedNode docs are a bit confusing to a new reader. Add more information and streamline them.

## Solution

- Linked back to `Node` for context.
- Explained when exactly the values are calculated.
- More consistency about the units used (physical pixels).
- Resolved meaning inversion at "For example" (where it first said don't modify the fields, then gave an example of the opposite)
- Changed `0.` to "zero" because it reads easier (especially with the punctuation)
- Removed mentions of `Auto` for values that are not `Val`.
- Made more specific about when change detection is bypassed. (The original wording sounded like the user's updates to this field would also bypass it)

## Testing

- Did you test these changes? If so, how?

`cargo doc -p bevy_ui` and looked at the result