### PR TITLE
Fix skybox render-world cleanup on component removal

### DIFF
--- a/crates/bevy_core_pipeline/src/skybox/mod.rs
+++ b/crates/bevy_core_pipeline/src/skybox/mod.rs
@@ -19,6 +19,7 @@ use bevy_render::{
         *,
     },
     renderer::RenderDevice,
+    sync_component::{SyncComponent, SyncComponentPlugin},
     sync_world::RenderEntity,
     texture::GpuImage,
     view::{ExtractedView, Msaa, ViewUniform, ViewUniforms},
@@ -36,7 +37,10 @@ impl Plugin for SkyboxPlugin {
     fn build(&self, app: &mut App) {
         embedded_asset!(app, "skybox.wgsl");
 
-        app.add_plugins(UniformComponentPlugin::<SkyboxUniforms>::default());
+        app.add_plugins((
+            SyncComponentPlugin::<Skybox, Self>::default(),
+            UniformComponentPlugin::<SkyboxUniforms>::default(),
+        ));
 
         let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
             return;
@@ -53,6 +57,10 @@ impl Plugin for SkyboxPlugin {
                 ),
             );
     }
+}
+
+impl SyncComponent<SkyboxPlugin> for Skybox {
+    type Target = (Self, SkyboxUniforms, SkyboxPipelineId, SkyboxBindGroup);
 }
 
 // This is needed because of the orphan rule not allowing implementing


### PR DESCRIPTION
# Objective

When `Skybox` was moved to `bevy_light` (#22682), extraction moved from `ExtractComponentPlugin` to a manual extraction implementation due to orphan rules. In the process, the functionality of `SyncComponentPlugin` was lost because it is no longer added automatically.

This manifests as the extracted skybox sticking around in the render world even after removing `Skybox` from the camera.

## Solution

Register `SyncComponentPlugin` manually for `Skybox`.
 
## Testing
 
- Reproduced with `cargo run --example anisotropy  --features="jpeg pbr_anisotropy_texture"`.
- Press `Space` until the example switches from environment map mode back to directional light mode.
- The skybox now disappears correctly.