### PR TITLE
Deprecate `AssetId::invalid()`

### DIFF
--- a/_release-content/migration-guides/deprecate_asset_id_invalid.md
+++ b/_release-content/migration-guides/deprecate_asset_id_invalid.md
@@ -1,10 +1,10 @@
 ---
-title: "`AssetId::invalid()` and `AssetId::INVALID_UUID` have been removed"
+title: "`AssetId::invalid()` and `AssetId::INVALID_UUID` have been deprecated"
 pull_requests: [24392]
 ---
 
-`AssetId::invalid()` and `AssetId::INVALID_UUID` have been removed. This is part
-of an effort to reduce special cases and optimize asset lookups,
+`AssetId::invalid()` and `AssetId::INVALID_UUID` have been deprecated. This is
+part of an effort to reduce special cases and optimize asset lookups.
 
 If you were using `AssetId::invalid()` as a null value, the recommended solution
 is to change your variable to be `Option<AssetId>` and use `None` instead of

--- a/_release-content/migration-guides/remove_asset_id_invalid.md
+++ b/_release-content/migration-guides/remove_asset_id_invalid.md
@@ -1,6 +1,6 @@
 ---
 title: "`AssetId::invalid()` and `AssetId::INVALID_UUID` have been removed"
-pull_requests: [TODO]
+pull_requests: [24392]
 ---
 
 `AssetId::invalid()` and `AssetId::INVALID_UUID` have been removed. This is part

--- a/_release-content/migration-guides/remove_asset_id_invalid.md
+++ b/_release-content/migration-guides/remove_asset_id_invalid.md
@@ -1,0 +1,42 @@
+---
+title: "`AssetId::invalid()` and `AssetId::INVALID_UUID` have been removed"
+pull_requests: [TODO]
+---
+
+`AssetId::invalid()` and `AssetId::INVALID_UUID` have been removed. This is part
+of an effort to reduce special cases and optimize asset lookups,
+
+
+If you were using `AssetId::invalid()` as a null value, the recommended solution
+is to change your variable to be `Option<AssetId>` and use `None` instead of
+`AssetId::invalid()`.
+
+Before:
+
+```rust
+struct MyImageResource(AssetId<Image>);
+
+world.insert_resource(MyImageResource(AssetId::invalid());
+
+...
+
+let resource = world.resource::<MyImageResource>()?;
+let asset = assets.get(resource.0)?;
+```
+
+After:
+
+```rust
+struct MyImageResource(Option<AssetId<Image>>);
+
+world.insert_resource(MyImageResource(None));
+
+...
+
+let resource = world.resource::<MyImageResource>()?;
+let asset = assets.get(resource.0?)?;
+```
+
+In some cases it may be possible to use `AssetId::default()` instead. But note
+that the default ID is *not* guaranteed to be a null value - an asset can be
+registered with the default ID.

--- a/_release-content/migration-guides/remove_asset_id_invalid.md
+++ b/_release-content/migration-guides/remove_asset_id_invalid.md
@@ -6,7 +6,6 @@ pull_requests: [24392]
 `AssetId::invalid()` and `AssetId::INVALID_UUID` have been removed. This is part
 of an effort to reduce special cases and optimize asset lookups,
 
-
 If you were using `AssetId::invalid()` as a null value, the recommended solution
 is to change your variable to be `Option<AssetId>` and use `None` instead of
 `AssetId::invalid()`.

--- a/crates/bevy_asset/src/id.rs
+++ b/crates/bevy_asset/src/id.rs
@@ -48,6 +48,27 @@ impl<A: Asset> AssetId<A> {
     /// and by convention (where appropriate) assets should support this pattern.
     pub const DEFAULT_UUID: Uuid = Uuid::from_u128(200809721996911295814598172825939264631);
 
+    /// This asset id _should_ never be valid. Assigning a value to this in [`Assets`](crate::Assets) will
+    /// produce undefined behavior, so don't do it!
+    #[deprecated(
+        since = "0.20.0",
+        note = "Use `Option<AssetId>` if possible. `AssetId::default` may also work, but note that the default can map to a valid asset."
+    )]
+    pub const INVALID_UUID: Uuid = Uuid::from_u128(108428345662029828789348721013522787528);
+
+    /// Returns an [`AssetId`] with [`Self::INVALID_UUID`], which _should_ never be assigned to.
+    #[deprecated(
+        since = "0.20.0",
+        note = "Use `Option<AssetId>` if possible. `AssetId::default` may also work, but note that the default can map to a valid asset."
+    )]
+    #[inline]
+    pub const fn invalid() -> Self {
+        Self::Uuid {
+            #[expect(deprecated, reason = "deprecated function uses deprecated constant")]
+            uuid: Self::INVALID_UUID,
+        }
+    }
+
     /// Converts this to an "untyped" / "generic-less" [`Asset`] identifier that stores the type information
     /// _inside_ the [`UntypedAssetId`].
     #[inline]

--- a/crates/bevy_asset/src/id.rs
+++ b/crates/bevy_asset/src/id.rs
@@ -48,18 +48,6 @@ impl<A: Asset> AssetId<A> {
     /// and by convention (where appropriate) assets should support this pattern.
     pub const DEFAULT_UUID: Uuid = Uuid::from_u128(200809721996911295814598172825939264631);
 
-    /// This asset id _should_ never be valid. Assigning a value to this in [`Assets`](crate::Assets) will
-    /// produce undefined behavior, so don't do it!
-    pub const INVALID_UUID: Uuid = Uuid::from_u128(108428345662029828789348721013522787528);
-
-    /// Returns an [`AssetId`] with [`Self::INVALID_UUID`], which _should_ never be assigned to.
-    #[inline]
-    pub const fn invalid() -> Self {
-        Self::Uuid {
-            uuid: Self::INVALID_UUID,
-        }
-    }
-
     /// Converts this to an "untyped" / "generic-less" [`Asset`] identifier that stores the type information
     /// _inside_ the [`UntypedAssetId`].
     #[inline]

--- a/examples/shader_advanced/custom_phase_item.rs
+++ b/examples/shader_advanced/custom_phase_item.rs
@@ -288,7 +288,7 @@ fn queue_custom_phase_item(
             // handling that Bevy has for meshes (preprocessing, indirect
             // draws, etc.)
             //
-            // The asset ID is arbitrary; we simply use [`AssetId::invalid`],
+            // The asset ID is arbitrary; we simply use [`AssetId::default`],
             // but you can use anything you like. Note that the asset ID need
             // not be the ID of a [`Mesh`].
             opaque_phase.add(
@@ -300,7 +300,7 @@ fn queue_custom_phase_item(
                     slabs: MeshSlabs::default(),
                 },
                 Opaque3dBinKey {
-                    asset_id: AssetId::<Mesh>::invalid().untyped(),
+                    asset_id: AssetId::<Mesh>::default().untyped(),
                 },
                 (*render_entity, *main_entity),
                 InputUniformIndex::default(),


### PR DESCRIPTION
## Objective

Progress #19024 (removing UUID handles). Even if UUID handles end up sticking around, there's an argument for deprecating `AssetId::invalid()` in the name of simplicity and robustness.

## Solution

Remove the last remaining case of `AssetId::invalid()` in the `custom_phase_item` example. The example only used it as a placeholder value, so `AssetId::default()` is fine.

```diff
 Opaque3dBinKey {
-    asset_id: AssetId::<Mesh>::invalid().untyped(),
+    asset_id: AssetId::<Mesh>::default().untyped(),
 }
```

## Testing

```sh
cargo run --example custom_phase_item
```
