### PR TITLE
Fix double-sided normals for negative scale meshes

### DIFF
--- a/crates/bevy_pbr/src/render/pbr_fragment.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_fragment.wgsl
@@ -55,10 +55,11 @@ fn pbr_input_from_vertex_output(
     pbr_input.material.base_color = in.color;
 #endif
 
+    let is_logically_front = pbr_functions::winding_corrected_front_facing(pbr_input.flags, is_front);
     pbr_input.world_normal = pbr_functions::prepare_world_normal(
         in.world_normal,
         double_sided,
-        is_front,
+        is_logically_front,
     );
 
 #ifdef LOAD_PREPASS_NORMALS
@@ -100,6 +101,7 @@ fn pbr_input_from_standard_material(
     pbr_input.material.flags = flags;
     pbr_input.material.base_color *= base_color;
     pbr_input.material.deferred_lighting_pass_id = deferred_lighting_pass_id;
+    let is_logically_front = pbr_functions::winding_corrected_front_facing(pbr_input.flags, is_front);
 
     // Neubelt and Pettineo 2013, "Crafting a Next-gen Material Pipeline for The Order: 1886"
     let NdotV = max(dot(pbr_input.N, pbr_input.V), 0.0001);
@@ -706,7 +708,13 @@ pbr_input.material.uv_transform = uv_transform;
 #endif  // MESHLET_MESH_MATERIAL_PASS
             ).rgb;
 
-        pbr_input.N = pbr_functions::apply_normal_mapping(flags, TBN, double_sided, is_front, Nt);
+        pbr_input.N = pbr_functions::apply_normal_mapping(
+            flags,
+            TBN,
+            double_sided,
+            is_logically_front,
+            Nt,
+        );
 
 #endif  // STANDARD_MATERIAL_NORMAL_MAP
 
@@ -748,7 +756,7 @@ pbr_input.material.uv_transform = uv_transform;
             flags,
             TBN,
             double_sided,
-            is_front,
+            is_logically_front,
             clearcoat_Nt,
         );
 

--- a/crates/bevy_pbr/src/render/pbr_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_functions.wgsl
@@ -13,7 +13,11 @@
     view_transformations,
     raymarch,
     utils,
-    mesh_types::{MESH_FLAGS_SHADOW_RECEIVER_BIT, MESH_FLAGS_TRANSMITTED_SHADOW_RECEIVER_BIT},
+    mesh_types::{
+        MESH_FLAGS_SHADOW_RECEIVER_BIT,
+        MESH_FLAGS_SIGN_DETERMINANT_MODEL_3X3_BIT,
+        MESH_FLAGS_TRANSMITTED_SHADOW_RECEIVER_BIT,
+    },
 }
 #import bevy_pbr::mesh_view_bindings::globals
 #import bevy_pbr::view_transformations::{position_world_to_ndc}
@@ -145,6 +149,11 @@ fn prepare_world_normal(
 #endif
 #endif
     return output;
+}
+
+fn winding_corrected_front_facing(mesh_flags: u32, is_front: bool) -> bool {
+    let positive_determinant = (mesh_flags & MESH_FLAGS_SIGN_DETERMINANT_MODEL_3X3_BIT) != 0u;
+    return is_front == positive_determinant;
 }
 
 // Calculates the three TBN vectors according to [mikktspace]. Returns a matrix

--- a/crates/bevy_pbr/src/render/pbr_prepass.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_prepass.wgsl
@@ -63,11 +63,17 @@ fn fragment(
     // NOTE: Unlit bit not set means == 0 is true, so the true case is if lit
     if (flags & pbr_types::STANDARD_MATERIAL_FLAGS_UNLIT_BIT) == 0u {
         let double_sided = (flags & pbr_types::STANDARD_MATERIAL_FLAGS_DOUBLE_SIDED_BIT) != 0u;
+#ifdef MESHLET_MESH_MATERIAL_PASS
+        let mesh_flags = in.mesh_flags;
+#else
+        let mesh_flags = mesh[in.instance_index].flags;
+#endif
+        let is_logically_front = pbr_functions::winding_corrected_front_facing(mesh_flags, is_front);
 
         let world_normal = pbr_functions::prepare_world_normal(
             in.world_normal,
             double_sided,
-            is_front,
+            is_logically_front,
         );
 
         var normal = world_normal;
@@ -119,7 +125,7 @@ fn fragment(
             flags,
             TBN,
             double_sided,
-            is_front,
+            is_logically_front,
             Nt,
         );
 


### PR DESCRIPTION
# Objective

Fix incorrect PBR lighting for double-sided meshes with negative-scale transforms.

#8859 fixed culling for single-sided glTF materials by detecting inverted scale in the loader. Double-sided materials still need a shader-side fix, because culling is disabled and raw `front_facing` is reversed by negative-scale winding.

## Solution

Add a winding-corrected front-facing helper in the PBR shader path.

## Testing

Tested with Khronos [NegativeScaleTest](https://github.com/KhronosGroup/glTF-Sample-Models/tree/main/2.0/NegativeScaleTest)

The bottom-right `-1.0` column should match the expected lighting/reflection behavior for double-sided materials.

To validate non-regression for normal/tangent handling, reviewers can also test:

[NormalTangentMirrorTest](https://github.com/KhronosGroup/glTF-Sample-Models/tree/main/2.0/NormalTangentMirrorTest)
[NormalTangentTest](https://github.com/KhronosGroup/glTF-Sample-Models/tree/main/2.0/NormalTangentTest)

## Showcase

Before 
<img width="785" height="670" alt="image" src="https://github.com/user-attachments/assets/23d87e83-92a9-4d08-989b-092f3a6e2527" />

After
<img width="785" height="670" alt="image" src="https://github.com/user-attachments/assets/eb8a47e8-20fe-4b25-b9d2-c09a49a86006" />


