### PR TITLE
Add PointerCaptureMap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5091,6 +5091,17 @@ category = "Picking"
 wasm = true
 
 [[example]]
+name = "draggable_slider"
+path = "examples/picking/draggable_slider.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.draggable_slider]
+name = "Draggable Slider"
+description = "Demonstrates pointer capture using a draggable slider"
+category = "Picking"
+wasm = true
+
+[[example]]
 name = "animation_masks"
 path = "examples/animation/animation_masks.rs"
 doc-scrape-examples = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5194,6 +5194,17 @@ category = "Picking"
 wasm = true
 
 [[example]]
+name = "draggable_slider"
+path = "examples/picking/draggable_slider.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.draggable_slider]
+name = "Draggable Slider"
+description = "Demonstrates pointer capture using a draggable slider"
+category = "Picking"
+wasm = true
+
+[[example]]
 name = "animation_masks"
 path = "examples/animation/animation_masks.rs"
 doc-scrape-examples = true

--- a/crates/bevy_picking/src/hover.rs
+++ b/crates/bevy_picking/src/hover.rs
@@ -65,6 +65,43 @@ pub struct HoverMap(pub HashMap<PointerId, EntityHashMap<HitData>>);
 #[reflect(Debug, Default, Resource)]
 pub struct PreviousHoverMap(pub HashMap<PointerId, EntityHashMap<HitData>>);
 
+/// Overrides the [`HoverMap`] for captured pointers, forcing a single entity to be reported as
+/// hovered regardless of where the pointer physically is.
+///
+/// When a pointer is captured by an entity, that entity is reported as the sole hover target for
+/// that pointer. This keeps interactions (like dragging a slider) working correctly even when the
+/// pointer drifts outside the entity's bounding box while a button is held.
+///
+/// Use [`PointerCaptureMap::capture`] to lock a pointer to an entity, and
+/// [`PointerCaptureMap::release`] to remove the lock. Captures are automatically cleaned up when
+/// the associated pointer entity is removed.
+#[derive(Debug, Default, Resource)]
+pub struct PointerCaptureMap(pub HashMap<PointerId, (Entity, HitData)>);
+
+impl PointerCaptureMap {
+    /// Lock `pointer` to `entity`. The provided `hit` is injected into the [`HoverMap`] for the
+    /// duration of the capture so downstream systems see consistent hit data.
+    pub fn capture(&mut self, pointer: PointerId, entity: Entity, hit: HitData) {
+        self.0.insert(pointer, (entity, hit));
+    }
+
+    /// Remove the capture for `pointer`, returning the previously captured entity and hit data if
+    /// one existed.
+    pub fn release(&mut self, pointer: PointerId) -> Option<(Entity, HitData)> {
+        self.0.remove(&pointer)
+    }
+
+    /// Return the captured `(Entity, &HitData)` for `pointer`, or `None` if not captured.
+    pub fn get(&self, pointer: &PointerId) -> Option<(Entity, &HitData)> {
+        self.0.get(pointer).map(|(e, h)| (*e, h))
+    }
+
+    /// Returns `true` if `pointer` is currently captured.
+    pub fn is_captured(&self, pointer: &PointerId) -> bool {
+        self.0.contains_key(pointer)
+    }
+}
+
 /// Gets the hovered entities for a `pointer_id` from a provided `HoverMap` inner map
 pub(crate) fn get_hovered_entities(
     hover_map: &HashMap<PointerId, EntityHashMap<HitData>>,
@@ -101,6 +138,7 @@ pub fn generate_hovermap(
     pointers: Query<&PointerId>,
     mut pointer_hits_reader: MessageReader<backend::PointerHits>,
     mut pointer_input_reader: MessageReader<PointerInput>,
+    capture_map: Res<PointerCaptureMap>,
     // Local
     mut over_map: Local<OverMap>,
     // Output
@@ -119,6 +157,17 @@ pub fn generate_hovermap(
         &mut pointer_input_reader,
     );
     build_hover_map(&pointers, pickable, &over_map, &mut hover_map);
+    apply_pointer_captures(&capture_map, &mut hover_map);
+}
+
+/// For each captured pointer, replaces its hover set with a single entry pointing to the captured
+/// entity. Pointers not present in `capture_map` are left unchanged.
+fn apply_pointer_captures(capture_map: &PointerCaptureMap, hover_map: &mut HoverMap) {
+    for (pointer_id, (entity, hit_data)) in &capture_map.0 {
+        let entry = hover_map.entry(*pointer_id).or_default();
+        entry.clear();
+        entry.insert(*entity, hit_data.clone());
+    }
 }
 
 /// Clear non-empty local maps, reusing allocated memory.
@@ -599,5 +648,120 @@ mod tests {
             .unwrap();
         assert!(!hover.get());
         assert!(hover.is_changed());
+    }
+
+    fn make_hit(camera: Entity) -> HitData {
+        HitData {
+            depth: 0.0,
+            camera,
+            position: None,
+            normal: None,
+            extra: None,
+        }
+    }
+
+    #[test]
+    fn capture_overrides_hover_map() {
+        let camera = Entity::from_bits(1);
+        let entity_a = Entity::from_bits(2);
+        let entity_b = Entity::from_bits(3);
+        let hit = make_hit(camera);
+
+        let mut hover_map = HoverMap::default();
+        let mut entity_map = EntityHashMap::new();
+        entity_map.insert(entity_a, hit.clone());
+        hover_map.insert(PointerId::Mouse, entity_map);
+
+        let mut capture_map = PointerCaptureMap::default();
+        capture_map.capture(PointerId::Mouse, entity_b, hit.clone());
+
+        apply_pointer_captures(&capture_map, &mut hover_map);
+
+        let mouse_hovered = hover_map.get(&PointerId::Mouse).unwrap();
+        assert!(
+            !mouse_hovered.contains_key(&entity_a),
+            "original hover should be evicted"
+        );
+        assert!(
+            mouse_hovered.contains_key(&entity_b),
+            "captured entity should be sole entry"
+        );
+        assert_eq!(mouse_hovered.len(), 1);
+    }
+
+    #[test]
+    fn capture_does_not_affect_uncaptured_pointers() {
+        let camera = Entity::from_bits(1);
+        let entity_a = Entity::from_bits(2);
+        let entity_b = Entity::from_bits(3);
+        let hit = make_hit(camera);
+
+        let touch_id = PointerId::Touch(0);
+
+        let mut hover_map = HoverMap::default();
+        let mut mouse_map = EntityHashMap::new();
+        mouse_map.insert(entity_a, hit.clone());
+        hover_map.insert(PointerId::Mouse, mouse_map);
+
+        let mut touch_map = EntityHashMap::new();
+        touch_map.insert(entity_b, hit.clone());
+        hover_map.insert(touch_id, touch_map);
+
+        let mut capture_map = PointerCaptureMap::default();
+        capture_map.capture(touch_id, entity_a, hit.clone());
+
+        apply_pointer_captures(&capture_map, &mut hover_map);
+
+        let mouse_hovered = hover_map.get(&PointerId::Mouse).unwrap();
+        assert!(mouse_hovered.contains_key(&entity_a));
+        assert_eq!(mouse_hovered.len(), 1);
+
+        let touch_hovered = hover_map.get(&touch_id).unwrap();
+        assert!(touch_hovered.contains_key(&entity_a));
+        assert!(!touch_hovered.contains_key(&entity_b));
+        assert_eq!(touch_hovered.len(), 1);
+    }
+
+    #[test]
+    fn capture_creates_entry_for_pointer_absent_from_hover_map() {
+        let camera = Entity::from_bits(1);
+        let entity = Entity::from_bits(2);
+        let hit = make_hit(camera);
+
+        let mut hover_map = HoverMap::default();
+
+        let mut capture_map = PointerCaptureMap::default();
+        capture_map.capture(PointerId::Mouse, entity, hit.clone());
+
+        apply_pointer_captures(&capture_map, &mut hover_map);
+
+        let mouse_hovered = hover_map.get(&PointerId::Mouse).unwrap();
+        assert!(mouse_hovered.contains_key(&entity));
+        assert_eq!(mouse_hovered.len(), 1);
+    }
+
+    #[test]
+    fn pointer_capture_map_api() {
+        let camera = Entity::from_bits(1);
+        let entity = Entity::from_bits(2);
+        let hit = make_hit(camera);
+
+        let mut map = PointerCaptureMap::default();
+
+        assert!(!map.is_captured(&PointerId::Mouse));
+        assert!(map.get(&PointerId::Mouse).is_none());
+
+        map.capture(PointerId::Mouse, entity, hit);
+        assert!(map.is_captured(&PointerId::Mouse));
+        let (captured_entity, _) = map.get(&PointerId::Mouse).unwrap();
+        assert_eq!(captured_entity, entity);
+
+        let released = map.release(PointerId::Mouse);
+        assert_eq!(released.unwrap().0, entity);
+        assert!(!map.is_captured(&PointerId::Mouse));
+        assert!(map.get(&PointerId::Mouse).is_none());
+
+        // Double release is a no-op.
+        assert!(map.release(PointerId::Mouse).is_none());
     }
 }

--- a/crates/bevy_picking/src/hover.rs
+++ b/crates/bevy_picking/src/hover.rs
@@ -217,7 +217,9 @@ fn reset_maps(
     let active_pointers: Vec<PointerId> = pointers.iter().copied().collect();
     hover_map.retain(|pointer, _| active_pointers.contains(pointer));
     over_map.retain(|pointer, _| active_pointers.contains(pointer));
-    capture_map.0.retain(|pointer, _| active_pointers.contains(pointer));
+    capture_map
+        .0
+        .retain(|pointer, _| active_pointers.contains(pointer));
 }
 
 /// Build an ordered map of entities that are under each pointer
@@ -848,14 +850,13 @@ mod tests {
 
         let camera = Entity::from_bits(1);
         let captured_entity = app.world_mut().spawn_empty().id();
-        app.world_mut()
-            .resource_mut::<PointerCaptureMap>()
-            .capture(PointerId::Mouse, captured_entity, make_hit(camera));
+        app.world_mut().resource_mut::<PointerCaptureMap>().capture(
+            PointerId::Mouse,
+            captured_entity,
+            make_hit(camera),
+        );
 
-        assert!(app
-            .world_mut()
-            .run_system_cached(generate_hovermap)
-            .is_ok());
+        assert!(app.world_mut().run_system_cached(generate_hovermap).is_ok());
 
         assert!(!app
             .world()

--- a/crates/bevy_picking/src/hover.rs
+++ b/crates/bevy_picking/src/hover.rs
@@ -56,6 +56,9 @@ type OverMap = HashMap<PointerId, LayerMap>;
 /// this authoritative hover state, and you can do the same. You can also use the
 /// [`PreviousHoverMap`] as a robust way of determining changes in hover state from the previous
 /// update.
+///
+/// See [`PointerCaptureMap`] to force a pointer to keep hovering a single entity regardless of
+/// where it physically is.
 #[derive(Debug, Deref, DerefMut, Default, Resource, Reflect)]
 #[reflect(Debug, Default, Resource)]
 pub struct HoverMap(pub HashMap<PointerId, EntityHashMap<HitData>>);
@@ -75,6 +78,9 @@ pub struct PreviousHoverMap(pub HashMap<PointerId, EntityHashMap<HitData>>);
 /// Use [`PointerCaptureMap::capture`] to lock a pointer to an entity, and
 /// [`PointerCaptureMap::release`] to remove the lock. Captures are automatically cleaned up when
 /// the associated pointer entity is removed.
+///
+/// A pointer's capture is also released automatically when that pointer reports a button release
+/// or cancel action.
 #[derive(Debug, Default, Resource)]
 pub struct PointerCaptureMap(pub HashMap<PointerId, (Entity, HitData)>);
 
@@ -138,7 +144,7 @@ pub fn generate_hovermap(
     pointers: Query<&PointerId>,
     mut pointer_hits_reader: MessageReader<backend::PointerHits>,
     mut pointer_input_reader: MessageReader<PointerInput>,
-    capture_map: Res<PointerCaptureMap>,
+    mut capture_map: ResMut<PointerCaptureMap>,
     // Local
     mut over_map: Local<OverMap>,
     // Output
@@ -149,15 +155,32 @@ pub fn generate_hovermap(
         &mut hover_map,
         &mut previous_hover_map,
         &mut over_map,
+        &mut capture_map,
         &pointers,
     );
-    build_over_map(
-        &mut pointer_hits_reader,
-        &mut over_map,
-        &mut pointer_input_reader,
-    );
+    // Read all pointer input events once so both the capture release and hit-testing logic below
+    // can inspect them.
+    let pointer_inputs: Vec<PointerInput> = pointer_input_reader.read().cloned().collect();
+    release_captures_on_release_or_cancel(&pointer_inputs, &mut capture_map);
+    build_over_map(&mut pointer_hits_reader, &mut over_map, &pointer_inputs);
     build_hover_map(&pointers, pickable, &over_map, &mut hover_map);
     apply_pointer_captures(&capture_map, &mut hover_map);
+}
+
+/// Releases a pointer's capture when that pointer reports a button release or cancel
+/// action.
+fn release_captures_on_release_or_cancel(
+    pointer_inputs: &[PointerInput],
+    capture_map: &mut PointerCaptureMap,
+) {
+    for input in pointer_inputs {
+        if matches!(
+            input.action,
+            PointerAction::Release(_) | PointerAction::Cancel
+        ) {
+            capture_map.release(input.pointer_id);
+        }
+    }
 }
 
 /// For each captured pointer, replaces its hover set with a single entry pointing to the captured
@@ -175,6 +198,7 @@ fn reset_maps(
     hover_map: &mut HoverMap,
     previous_hover_map: &mut PreviousHoverMap,
     over_map: &mut OverMap,
+    capture_map: &mut PointerCaptureMap,
     pointers: &Query<&PointerId>,
 ) {
     // Swap the previous and current hover maps. This results in the previous values being stored in
@@ -193,16 +217,17 @@ fn reset_maps(
     let active_pointers: Vec<PointerId> = pointers.iter().copied().collect();
     hover_map.retain(|pointer, _| active_pointers.contains(pointer));
     over_map.retain(|pointer, _| active_pointers.contains(pointer));
+    capture_map.0.retain(|pointer, _| active_pointers.contains(pointer));
 }
 
 /// Build an ordered map of entities that are under each pointer
 fn build_over_map(
     pointer_hit_reader: &mut MessageReader<backend::PointerHits>,
     pointer_over_map: &mut Local<OverMap>,
-    pointer_input_reader: &mut MessageReader<PointerInput>,
+    pointer_inputs: &[PointerInput],
 ) {
-    let cancelled_pointers: HashSet<PointerId> = pointer_input_reader
-        .read()
+    let cancelled_pointers: HashSet<PointerId> = pointer_inputs
+        .iter()
         .filter_map(|p| {
             if let PointerAction::Cancel = p.action {
                 Some(p.pointer_id)
@@ -763,5 +788,78 @@ mod tests {
 
         // Double release is a no-op.
         assert!(map.release(PointerId::Mouse).is_none());
+    }
+
+    fn make_pointer_input(pointer_id: PointerId, action: PointerAction) -> PointerInput {
+        use bevy_camera::{ManualTextureViewHandle, NormalizedRenderTarget};
+        use bevy_math::Vec2;
+        PointerInput::new(
+            pointer_id,
+            crate::pointer::Location {
+                target: NormalizedRenderTarget::TextureView(ManualTextureViewHandle(5)),
+                position: Vec2::ZERO,
+            },
+            action,
+        )
+    }
+
+    #[test]
+    fn release_action_releases_capture() {
+        let camera = Entity::from_bits(1);
+        let entity = Entity::from_bits(2);
+        let hit = make_hit(camera);
+
+        let mut capture_map = PointerCaptureMap::default();
+        capture_map.capture(PointerId::Mouse, entity, hit);
+
+        let inputs = [make_pointer_input(
+            PointerId::Mouse,
+            PointerAction::Release(crate::pointer::PointerButton::Primary),
+        )];
+        release_captures_on_release_or_cancel(&inputs, &mut capture_map);
+
+        assert!(!capture_map.is_captured(&PointerId::Mouse));
+    }
+
+    #[test]
+    fn cancel_action_releases_capture() {
+        let camera = Entity::from_bits(1);
+        let entity = Entity::from_bits(2);
+        let hit = make_hit(camera);
+
+        let mut capture_map = PointerCaptureMap::default();
+        capture_map.capture(PointerId::Mouse, entity, hit);
+
+        let inputs = [make_pointer_input(PointerId::Mouse, PointerAction::Cancel)];
+        release_captures_on_release_or_cancel(&inputs, &mut capture_map);
+
+        assert!(!capture_map.is_captured(&PointerId::Mouse));
+    }
+
+    #[test]
+    fn generate_hovermap_cleans_up_capture_for_removed_pointer() {
+        let mut app = bevy_app::App::new();
+        app.init_resource::<HoverMap>()
+            .init_resource::<PreviousHoverMap>()
+            .init_resource::<PointerCaptureMap>()
+            .add_message::<PointerInput>()
+            .add_message::<backend::PointerHits>();
+        // No pointer entity is spawned, so `PointerId::Mouse` is not active.
+
+        let camera = Entity::from_bits(1);
+        let captured_entity = app.world_mut().spawn_empty().id();
+        app.world_mut()
+            .resource_mut::<PointerCaptureMap>()
+            .capture(PointerId::Mouse, captured_entity, make_hit(camera));
+
+        assert!(app
+            .world_mut()
+            .run_system_cached(generate_hovermap)
+            .is_ok());
+
+        assert!(!app
+            .world()
+            .resource::<PointerCaptureMap>()
+            .is_captured(&PointerId::Mouse));
     }
 }

--- a/crates/bevy_picking/src/lib.rs
+++ b/crates/bevy_picking/src/lib.rs
@@ -182,8 +182,8 @@ pub mod prelude {
     };
     #[doc(hidden)]
     pub use crate::{
-        events::*, input::PointerInputPlugin, pointer::PointerButton, DefaultPickingPlugins,
-        InteractionPlugin, Pickable, PickingPlugin,
+        events::*, hover::PointerCaptureMap, input::PointerInputPlugin, pointer::PointerButton,
+        DefaultPickingPlugins, InteractionPlugin, Pickable, PickingPlugin,
     };
 }
 
@@ -424,6 +424,7 @@ impl Plugin for InteractionPlugin {
         app.init_resource::<hover::HoverMap>()
             .init_resource::<hover::PreviousHoverMap>()
             .init_resource::<PickingSettings>()
+            .init_resource::<hover::PointerCaptureMap>()
             .init_resource::<PointerState>()
             .add_message::<Pointer<Cancel>>()
             .add_message::<Pointer<Click>>()

--- a/crates/bevy_picking/src/lib.rs
+++ b/crates/bevy_picking/src/lib.rs
@@ -183,8 +183,8 @@ pub mod prelude {
     };
     #[doc(hidden)]
     pub use crate::{
-        events::*, input::PointerInputPlugin, pointer::PointerButton, DefaultPickingPlugins,
-        InteractionPlugin, Pickable, PickingPlugin,
+        events::*, hover::PointerCaptureMap, input::PointerInputPlugin, pointer::PointerButton,
+        DefaultPickingPlugins, InteractionPlugin, Pickable, PickingPlugin,
     };
 }
 
@@ -424,6 +424,7 @@ impl Plugin for InteractionPlugin {
         app.init_resource::<hover::HoverMap>()
             .init_resource::<hover::PreviousHoverMap>()
             .init_resource::<PickingSettings>()
+            .init_resource::<hover::PointerCaptureMap>()
             .init_resource::<PointerState>()
             .add_message::<PointerCancel>()
             .add_message::<PointerClick>()

--- a/examples/README.md
+++ b/examples/README.md
@@ -440,6 +440,7 @@ Example | Description
 --- | ---
 [Custom Hit Data](../examples/picking/custom_hit_data.rs) | Demonstrates a custom picking backend with custom hit data.
 [Drag and Drop](../examples/picking/dragdrop_picking.rs) | Demonstrates drag and drop using picking events
+[Draggable Slider](../examples/picking/draggable_slider.rs) | Demonstrates pointer capture using a draggable slider
 [Mesh Picking](../examples/picking/mesh_picking.rs) | Demonstrates picking meshes
 [Picking Debug Tools](../examples/picking/debug_picking.rs) | Demonstrates picking debug overlay
 [Showcases simple picking events and usage](../examples/picking/simple_picking.rs) | Demonstrates how to use picking events to spawn simple objects

--- a/examples/README.md
+++ b/examples/README.md
@@ -438,6 +438,7 @@ Example | Description
 --- | ---
 [Custom Hit Data](../examples/picking/custom_hit_data.rs) | Demonstrates a custom picking backend with custom hit data.
 [Drag and Drop](../examples/picking/dragdrop_picking.rs) | Demonstrates drag and drop using picking events
+[Draggable Slider](../examples/picking/draggable_slider.rs) | Demonstrates pointer capture using a draggable slider
 [Mesh Picking](../examples/picking/mesh_picking.rs) | Demonstrates picking meshes
 [Picking Debug Tools](../examples/picking/debug_picking.rs) | Demonstrates picking debug overlay
 [Showcases simple picking events and usage](../examples/picking/simple_picking.rs) | Demonstrates how to use picking events to spawn simple objects

--- a/examples/picking/draggable_slider.rs
+++ b/examples/picking/draggable_slider.rs
@@ -1,0 +1,383 @@
+//! Demonstrates why pointer capture matters during drag operations.
+//!
+//! A slider sits above a row of buttons. Without [`PointerCaptureMap`], dragging the slider thumb
+//! over the buttons causes them to show a hover highlight — misleading the user into thinking the
+//! button is about to be activated. With capture enabled the slider owns the pointer for the
+//! duration of the drag, so no other widget receives hover state.
+//!
+//! Toggle capture on/off with the button at the bottom to see the difference.
+//!
+//! Additional UI elements showcased:
+//! - A **fill bar** that grows with the slider value.
+//! - **Min / max labels** flanking the track.
+//! - A **Reset button** that snaps the value back to the default.
+
+use bevy::prelude::*;
+
+const TRACK_WIDTH: f32 = 500.0;
+const TRACK_HEIGHT: f32 = 14.0;
+const THUMB_SIZE: f32 = 28.0;
+const THUMB_HALF: f32 = THUMB_SIZE / 2.0;
+const FILL_HEIGHT: f32 = 8.0;
+
+const SLIDER_DEFAULT_VALUE: f32 = 0.5;
+
+const COLOR_TRACK: Color = Color::srgb(0.2, 0.2, 0.2);
+const COLOR_FILL: Color = Color::srgb(0.35, 0.65, 0.35);
+const COLOR_FILL_DRAGGING: Color = Color::srgb(0.45, 0.85, 0.45);
+const COLOR_THUMB_IDLE: Color = Color::srgb(0.85, 0.55, 0.1);
+const COLOR_THUMB_HOVER: Color = Color::srgb(1.0, 0.75, 0.2);
+const COLOR_DECOY_IDLE: Color = Color::srgb(0.2, 0.45, 0.8);
+const COLOR_DECOY_HOVER: Color = Color::srgb(0.9, 0.2, 0.2);
+const COLOR_TOGGLE_ON: Color = Color::srgb(0.15, 0.65, 0.3);
+const COLOR_TOGGLE_OFF: Color = Color::srgb(0.55, 0.15, 0.15);
+const COLOR_RESET_IDLE: Color = Color::srgb(0.3, 0.3, 0.55);
+const COLOR_RESET_HOVER: Color = Color::srgb(0.5, 0.5, 0.75);
+
+/// The normalized (0 – 1) position of the slider thumb.
+#[derive(Resource)]
+struct SliderValue(f32);
+
+impl Default for SliderValue {
+    fn default() -> Self {
+        Self(SLIDER_DEFAULT_VALUE)
+    }
+}
+
+/// Whether [`PointerCaptureMap`] is used while dragging the thumb.
+#[derive(Resource)]
+struct CaptureEnabled(bool);
+
+impl Default for CaptureEnabled {
+    fn default() -> Self {
+        Self(true)
+    }
+}
+
+#[derive(Component)]
+struct SliderThumb;
+
+#[derive(Component)]
+struct SliderFill;
+
+#[derive(Component)]
+struct SliderLabel;
+
+#[derive(Component)]
+struct ToggleLabel;
+
+#[derive(Component)]
+struct ToggleButton;
+
+#[derive(Component)]
+struct ResetButton;
+
+#[derive(Component)]
+struct DecoyButton;
+
+/// X offset of the left edge of the thumb node.
+fn thumb_left(v: f32) -> f32 {
+    v.clamp(0.0, 1.0) * (TRACK_WIDTH - THUMB_SIZE)
+}
+
+/// Width of the fill bar (reaches to the center of the thumb).
+fn fill_width(v: f32) -> f32 {
+    v.clamp(0.0, 1.0) * (TRACK_WIDTH - THUMB_SIZE) + THUMB_HALF
+}
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .init_resource::<SliderValue>()
+        .init_resource::<CaptureEnabled>()
+        .add_systems(Startup, setup)
+        .add_systems(Update, (sync_thumb_and_label, sync_fill))
+        .run();
+}
+
+fn setup(mut commands: Commands) {
+    commands.spawn(Camera2d);
+
+    // Root column – centered, full-screen, non-pickable container.
+    commands
+        .spawn((
+            Node {
+                width: Val::Percent(100.0),
+                height: Val::Percent(100.0),
+                flex_direction: FlexDirection::Column,
+                align_items: AlignItems::Center,
+                justify_content: JustifyContent::Center,
+                row_gap: Val::Px(28.0),
+                ..default()
+            },
+            Pickable::IGNORE,
+        ))
+        .with_children(|root| {
+            root.spawn((
+                Text::new(
+                    "Drag the slider over the blue buttons.\n\
+                     With capture ON they stay blue. With capture OFF they incorrectly turn red.",
+                ),
+                TextFont::from_font_size(15.0),
+                TextColor(Color::srgb(0.75, 0.75, 0.75)),
+            ));
+
+            root.spawn((
+                Node {
+                    flex_direction: FlexDirection::Row,
+                    align_items: AlignItems::Center,
+                    column_gap: Val::Px(10.0),
+                    ..default()
+                },
+                Pickable::IGNORE,
+            ))
+            .with_children(|row| {
+                row.spawn((
+                    Text::new("0.0"),
+                    TextFont::from_font_size(13.0),
+                    TextColor(Color::srgb(0.55, 0.55, 0.55)),
+                ));
+
+                row.spawn((
+                    Node {
+                        width: Val::Px(TRACK_WIDTH),
+                        height: Val::Px(TRACK_HEIGHT),
+                        position_type: PositionType::Relative,
+                        align_items: AlignItems::Center,
+                        ..default()
+                    },
+                    BackgroundColor(COLOR_TRACK),
+                    Pickable::IGNORE,
+                ))
+                .with_children(|track| {
+                    track.spawn((
+                        SliderFill,
+                        Node {
+                            width: Val::Px(fill_width(SLIDER_DEFAULT_VALUE)),
+                            height: Val::Px(FILL_HEIGHT),
+                            position_type: PositionType::Absolute,
+                            left: Val::Px(0.0),
+                            ..default()
+                        },
+                        BackgroundColor(COLOR_FILL),
+                        Pickable::IGNORE,
+                    ));
+
+                    track
+                        .spawn((
+                            SliderThumb,
+                            Node {
+                                width: Val::Px(THUMB_SIZE),
+                                height: Val::Px(THUMB_SIZE),
+                                position_type: PositionType::Absolute,
+                                left: Val::Px(thumb_left(SLIDER_DEFAULT_VALUE)),
+                                border_radius: BorderRadius::all(Val::Px(4.0)),
+                                ..default()
+                            },
+                            BackgroundColor(COLOR_THUMB_IDLE),
+                        ))
+                        .observe(on_drag_start)
+                        .observe(on_drag)
+                        .observe(on_drag_end)
+                        .observe(
+                            |_: On<Pointer<Over>>,
+                             mut q: Single<&mut BackgroundColor, With<SliderThumb>>| {
+                                q.0 = COLOR_THUMB_HOVER;
+                            },
+                        )
+                        .observe(
+                            |_: On<Pointer<Out>>,
+                             mut q: Single<&mut BackgroundColor, With<SliderThumb>>| {
+                                q.0 = COLOR_THUMB_IDLE;
+                            },
+                        );
+                });
+
+                row.spawn((
+                    Text::new("1.0"),
+                    TextFont::from_font_size(13.0),
+                    TextColor(Color::srgb(0.55, 0.55, 0.55)),
+                ));
+            });
+
+            root.spawn((
+                SliderLabel,
+                Text::new(format!("Value: {:.2}", SLIDER_DEFAULT_VALUE)),
+                TextFont::from_font_size(18.0),
+            ));
+
+            root.spawn((
+                Node {
+                    flex_direction: FlexDirection::Row,
+                    column_gap: Val::Px(16.0),
+                    ..default()
+                },
+                Pickable::IGNORE,
+            ))
+            .with_children(|row| {
+                for label in ["Button A", "Button B", "Button C", "Button D", "Button E"] {
+                    spawn_decoy_button(row, label);
+                }
+            });
+
+            root.spawn((
+                Node {
+                    flex_direction: FlexDirection::Row,
+                    column_gap: Val::Px(20.0),
+                    align_items: AlignItems::Center,
+                    ..default()
+                },
+                Pickable::IGNORE,
+            ))
+            .with_children(|row| {
+                row.spawn((
+                    ToggleButton,
+                    Node {
+                        padding: UiRect::axes(Val::Px(20.0), Val::Px(10.0)),
+                        border_radius: BorderRadius::all(Val::Px(6.0)),
+                        ..default()
+                    },
+                    BackgroundColor(COLOR_TOGGLE_ON),
+                ))
+                .with_children(|btn| {
+                    btn.spawn((
+                        ToggleLabel,
+                        Text::new("Capture: ON  (click to toggle)"),
+                        TextFont::from_font_size(16.0),
+                        TextColor(Color::WHITE),
+                        Pickable::IGNORE,
+                    ));
+                })
+                .observe(on_toggle_click);
+
+                row.spawn((
+                    ResetButton,
+                    Node {
+                        padding: UiRect::axes(Val::Px(20.0), Val::Px(10.0)),
+                        border_radius: BorderRadius::all(Val::Px(6.0)),
+                        ..default()
+                    },
+                    BackgroundColor(COLOR_RESET_IDLE),
+                ))
+                .with_children(|btn| {
+                    btn.spawn((
+                        Text::new("Reset"),
+                        TextFont::from_font_size(16.0),
+                        TextColor(Color::WHITE),
+                        Pickable::IGNORE,
+                    ));
+                })
+                .observe(
+                    |_: On<Pointer<Over>>,
+                     mut q: Single<&mut BackgroundColor, With<ResetButton>>| {
+                        q.0 = COLOR_RESET_HOVER;
+                    },
+                )
+                .observe(
+                    |_: On<Pointer<Out>>,
+                     mut q: Single<&mut BackgroundColor, With<ResetButton>>| {
+                        q.0 = COLOR_RESET_IDLE;
+                    },
+                )
+                .observe(on_reset_click);
+            });
+        });
+}
+
+fn spawn_decoy_button(parent: &mut ChildSpawnerCommands, label: &str) {
+    parent
+        .spawn((
+            DecoyButton,
+            Node {
+                padding: UiRect::axes(Val::Px(24.0), Val::Px(14.0)),
+                border_radius: BorderRadius::all(Val::Px(6.0)),
+                justify_content: JustifyContent::Center,
+                align_items: AlignItems::Center,
+                ..default()
+            },
+            BackgroundColor(COLOR_DECOY_IDLE),
+        ))
+        .with_child((
+            Text::new(label),
+            TextFont::from_font_size(15.0),
+            TextColor(Color::WHITE),
+            Pickable::IGNORE,
+        ))
+        .observe(
+            |event: On<Pointer<Over>>,
+             mut colors: Query<&mut BackgroundColor, With<DecoyButton>>| {
+                if let Ok(mut color) = colors.get_mut(event.entity) {
+                    color.0 = COLOR_DECOY_HOVER;
+                }
+            },
+        )
+        .observe(
+            |event: On<Pointer<Out>>,
+             mut colors: Query<&mut BackgroundColor, With<DecoyButton>>| {
+                if let Ok(mut color) = colors.get_mut(event.entity) {
+                    color.0 = COLOR_DECOY_IDLE;
+                }
+            },
+        );
+}
+
+fn on_drag_start(
+    event: On<Pointer<DragStart>>,
+    capture_enabled: Res<CaptureEnabled>,
+    mut capture_map: ResMut<PointerCaptureMap>,
+    mut fill_color: Single<&mut BackgroundColor, With<SliderFill>>,
+) {
+    if capture_enabled.0 {
+        capture_map.capture(event.pointer_id, event.entity, event.hit.clone());
+    }
+    // Signal active drag with a brighter fill color.
+    fill_color.0 = COLOR_FILL_DRAGGING;
+}
+
+fn on_drag(event: On<Pointer<Drag>>, mut value: ResMut<SliderValue>) {
+    value.0 = (value.0 + event.delta.x / (TRACK_WIDTH - THUMB_SIZE)).clamp(0.0, 1.0);
+}
+
+fn on_drag_end(
+    event: On<Pointer<DragEnd>>,
+    mut capture_map: ResMut<PointerCaptureMap>,
+    mut fill_color: Single<&mut BackgroundColor, With<SliderFill>>,
+) {
+    capture_map.release(event.pointer_id);
+    fill_color.0 = COLOR_FILL;
+}
+
+fn on_toggle_click(
+    _: On<Pointer<Click>>,
+    mut capture_enabled: ResMut<CaptureEnabled>,
+    mut label: Single<&mut Text, With<ToggleLabel>>,
+    mut toggle_bg: Single<&mut BackgroundColor, With<ToggleButton>>,
+) {
+    capture_enabled.0 = !capture_enabled.0;
+    if capture_enabled.0 {
+        label.0 = "Capture: ON  (click to toggle)".into();
+        toggle_bg.0 = COLOR_TOGGLE_ON;
+    } else {
+        label.0 = "Capture: OFF  (click to toggle)".into();
+        toggle_bg.0 = COLOR_TOGGLE_OFF;
+    }
+}
+
+fn on_reset_click(_: On<Pointer<Click>>, mut value: ResMut<SliderValue>) {
+    value.0 = SLIDER_DEFAULT_VALUE;
+}
+
+/// Moves the thumb and updates the numeric readout.
+fn sync_thumb_and_label(
+    value: Res<SliderValue>,
+    mut thumb: Single<&mut Node, With<SliderThumb>>,
+    mut value_label: Single<&mut Text, With<SliderLabel>>,
+) {
+    thumb.left = Val::Px(thumb_left(value.0));
+    value_label.0 = format!("Value: {:.2}", value.0);
+}
+
+/// Resizes the fill bar to match the current slider value.
+fn sync_fill(value: Res<SliderValue>, mut fill: Single<&mut Node, With<SliderFill>>) {
+    fill.width = Val::Px(fill_width(value.0));
+}

--- a/examples/picking/draggable_slider.rs
+++ b/examples/picking/draggable_slider.rs
@@ -180,13 +180,13 @@ fn setup(mut commands: Commands) {
                         .observe(on_drag)
                         .observe(on_drag_end)
                         .observe(
-                            |_: On<Pointer<Over>>,
+                            |_: On<PointerOver>,
                              mut q: Single<&mut BackgroundColor, With<SliderThumb>>| {
                                 q.0 = COLOR_THUMB_HOVER;
                             },
                         )
                         .observe(
-                            |_: On<Pointer<Out>>,
+                            |_: On<PointerOut>,
                              mut q: Single<&mut BackgroundColor, With<SliderThumb>>| {
                                 q.0 = COLOR_THUMB_IDLE;
                             },
@@ -268,14 +268,12 @@ fn setup(mut commands: Commands) {
                     ));
                 })
                 .observe(
-                    |_: On<Pointer<Over>>,
-                     mut q: Single<&mut BackgroundColor, With<ResetButton>>| {
+                    |_: On<PointerOver>, mut q: Single<&mut BackgroundColor, With<ResetButton>>| {
                         q.0 = COLOR_RESET_HOVER;
                     },
                 )
                 .observe(
-                    |_: On<Pointer<Out>>,
-                     mut q: Single<&mut BackgroundColor, With<ResetButton>>| {
+                    |_: On<PointerOut>, mut q: Single<&mut BackgroundColor, With<ResetButton>>| {
                         q.0 = COLOR_RESET_IDLE;
                     },
                 )
@@ -304,16 +302,14 @@ fn spawn_decoy_button(parent: &mut ChildSpawnerCommands, label: &str) {
             Pickable::IGNORE,
         ))
         .observe(
-            |event: On<Pointer<Over>>,
-             mut colors: Query<&mut BackgroundColor, With<DecoyButton>>| {
+            |event: On<PointerOver>, mut colors: Query<&mut BackgroundColor, With<DecoyButton>>| {
                 if let Ok(mut color) = colors.get_mut(event.entity) {
                     color.0 = COLOR_DECOY_HOVER;
                 }
             },
         )
         .observe(
-            |event: On<Pointer<Out>>,
-             mut colors: Query<&mut BackgroundColor, With<DecoyButton>>| {
+            |event: On<PointerOut>, mut colors: Query<&mut BackgroundColor, With<DecoyButton>>| {
                 if let Ok(mut color) = colors.get_mut(event.entity) {
                     color.0 = COLOR_DECOY_IDLE;
                 }
@@ -322,33 +318,33 @@ fn spawn_decoy_button(parent: &mut ChildSpawnerCommands, label: &str) {
 }
 
 fn on_drag_start(
-    event: On<Pointer<DragStart>>,
+    event: On<PointerDragStart>,
     capture_enabled: Res<CaptureEnabled>,
     mut capture_map: ResMut<PointerCaptureMap>,
     mut fill_color: Single<&mut BackgroundColor, With<SliderFill>>,
 ) {
     if capture_enabled.0 {
-        capture_map.capture(event.pointer_id, event.entity, event.hit.clone());
+        capture_map.capture(event.pointer.id, event.entity, event.hit.clone());
     }
     // Signal active drag with a brighter fill color.
     fill_color.0 = COLOR_FILL_DRAGGING;
 }
 
-fn on_drag(event: On<Pointer<Drag>>, mut value: ResMut<SliderValue>) {
+fn on_drag(event: On<PointerDrag>, mut value: ResMut<SliderValue>) {
     value.0 = (value.0 + event.delta.x / (TRACK_WIDTH - THUMB_SIZE)).clamp(0.0, 1.0);
 }
 
 fn on_drag_end(
-    event: On<Pointer<DragEnd>>,
+    event: On<PointerDragEnd>,
     mut capture_map: ResMut<PointerCaptureMap>,
     mut fill_color: Single<&mut BackgroundColor, With<SliderFill>>,
 ) {
-    capture_map.release(event.pointer_id);
+    capture_map.release(event.pointer.id);
     fill_color.0 = COLOR_FILL;
 }
 
 fn on_toggle_click(
-    _: On<Pointer<Click>>,
+    _: On<PointerClick>,
     mut capture_enabled: ResMut<CaptureEnabled>,
     mut label: Single<&mut Text, With<ToggleLabel>>,
     mut toggle_bg: Single<&mut BackgroundColor, With<ToggleButton>>,
@@ -363,7 +359,7 @@ fn on_toggle_click(
     }
 }
 
-fn on_reset_click(_: On<Pointer<Click>>, mut value: ResMut<SliderValue>) {
+fn on_reset_click(_: On<PointerClick>, mut value: ResMut<SliderValue>) {
     value.0 = SLIDER_DEFAULT_VALUE;
 }
 


### PR DESCRIPTION
# Objective

Fixes #21754

When dragging widgets like sliders, the pointer often moves faster than the widget can follow. It drifts outside the bounding box while the button is held, breaking the interaction.

## Solution

Added `PointerCaptureMap` resource to lock a pointer's hover state to an entity. The `generate_hovermap` system now applies captures after computing the normal hover map, so captured pointers only report the capturing entity.

Public API:
- `capture(pointer, entity, hit)` — lock pointer
- `release(pointer)` — unlock
- `get(pointer)` — query capture
- `is_captured(pointer)` — check status

Includes unit tests and a `draggable_slider` example demonstrating the feature.
