### PR TITLE
Fix placeholder SMAA LUTs

### DIFF
--- a/crates/bevy_anti_alias/src/smaa/mod.rs
+++ b/crates/bevy_anti_alias/src/smaa/mod.rs
@@ -31,8 +31,6 @@
 //! [SMAA]: https://www.iryoku.com/smaa/
 use bevy_app::{App, Plugin};
 use bevy_asset::{embedded_asset, load_embedded_asset, AssetServer, Handle};
-#[cfg(not(feature = "smaa_luts"))]
-use bevy_core_pipeline::tonemapping::lut_placeholder;
 use bevy_core_pipeline::{
     schedule::{Core2d, Core2dSystems, Core3d, Core3dSystems},
     tonemapping::tonemapping,
@@ -322,8 +320,33 @@ impl Plugin for SmaaPlugin {
         };
         #[cfg(not(feature = "smaa_luts"))]
         let smaa_luts = {
+            use bevy_asset::RenderAssetUsages;
+            use bevy_image::ImageSampler;
+            use bevy_render::render_resource::{Extent3d, TextureDataOrder};
+
             let mut images = app.world_mut().resource_mut::<bevy_asset::Assets<Image>>();
-            let handle = images.add(lut_placeholder());
+
+            let format = TextureFormat::Rgba8Unorm;
+            let data = vec![255, 0, 255, 255];
+            let handle = images.add(Image {
+                data: Some(data),
+                data_order: TextureDataOrder::default(),
+                texture_descriptor: TextureDescriptor {
+                    size: Extent3d::default(),
+                    format,
+                    dimension: TextureDimension::D2,
+                    label: None,
+                    mip_level_count: 1,
+                    sample_count: 1,
+                    usage: TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_DST,
+                    view_formats: &[],
+                },
+                sampler: ImageSampler::Default,
+                texture_view_descriptor: None,
+                asset_usage: RenderAssetUsages::RENDER_WORLD,
+                copy_on_resize: false,
+            });
+
             SmaaLuts {
                 area_lut: handle.clone(),
                 search_lut: handle.clone(),


### PR DESCRIPTION
# Objective

With the placeholder SMAA LUTs in place (for context that's without the `smaa_luts` feature) you couldn't actually use them because backends like Vulkan will scream things like:

```
Texture binding 2 expects dimension = D2, but given a view with dimension = D3
```

This is because the LUTs weren't generated within this crate, but re-uses the LUT placeholder function from the tonemapping crate. While that may work there, the SMAA LUTs aren't 3D (hence the mysterious third dimension entering the picture here.)

## Solution

I moved a copy of this function instead, modifying it to provide a 2D image instead.

## Testing

Enable the `bevy_anti_alias` feature (while NOT enabling the `smaa_luts` one), and then configure your `Camera` to add the `Smaa` type. I tested it on the Vulkan backend (Linux and Android) but I think the other ones fail too.