### PR TITLE
Text2d size fix

### DIFF
--- a/crates/bevy_sprite/src/text2d.rs
+++ b/crates/bevy_sprite/src/text2d.rs
@@ -354,9 +354,14 @@ pub fn calculate_bounds_text2d(
     >,
 ) {
     for (entity, layout_info, anchor, text_bounds, aabb) in &mut text_to_update_aabb {
+        let inverse_scale_factor = layout_info.scale_factor.recip();
         let size = Vec2::new(
-            text_bounds.width.unwrap_or(layout_info.size.x),
-            text_bounds.height.unwrap_or(layout_info.size.y),
+            text_bounds
+                .width
+                .unwrap_or(layout_info.size.x * inverse_scale_factor),
+            text_bounds
+                .height
+                .unwrap_or(layout_info.size.y * inverse_scale_factor),
         );
 
         let x1 = (Anchor::TOP_LEFT.0.x - anchor.as_vec().x) * size.x;
@@ -389,6 +394,10 @@ mod tests {
     const SECOND_TEXT: &str = "Another, longer sample text.";
 
     fn setup() -> (App, Entity) {
+        setup_with_scale_factor(1.)
+    }
+
+    fn setup_with_scale_factor(scale_factor: f32) -> (App, Entity) {
         let mut app = App::new();
         app.init_resource::<Assets<Font>>()
             .init_resource::<Assets<Image>>()
@@ -418,7 +427,7 @@ mod tests {
                 computed: ComputedCameraValues {
                     target_info: Some(RenderTargetInfo {
                         physical_size: UVec2::splat(1000),
-                        scale_factor: 1.,
+                        scale_factor,
                     }),
                     ..Default::default()
                 },
@@ -517,5 +526,30 @@ mod tests {
         approx::assert_abs_diff_eq!(first_aabb.half_extents.y, second_aabb.half_extents.y);
         assert!(FIRST_TEXT.len() < SECOND_TEXT.len());
         assert!(first_aabb.half_extents.x < second_aabb.half_extents.x);
+    }
+
+    #[test]
+    fn calculate_bounds_text2d_uses_logical_size() {
+        let (mut app, entity) = setup_with_scale_factor(2.);
+
+        app.update();
+
+        let entity_ref = app
+            .world()
+            .get_entity(entity)
+            .expect("Could not find entity");
+        let layout_info = entity_ref
+            .get::<TextLayoutInfo>()
+            .expect("Text should have layout info");
+        let aabb = entity_ref.get::<Aabb>().expect("Text should have an AABB");
+
+        approx::assert_abs_diff_eq!(
+            aabb.half_extents.x * 2.,
+            layout_info.size.x / layout_info.scale_factor
+        );
+        approx::assert_abs_diff_eq!(
+            aabb.half_extents.y * 2.,
+            layout_info.size.y / layout_info.scale_factor
+        );
     }
 }

--- a/crates/bevy_sprite_render/src/text2d/mod.rs
+++ b/crates/bevy_sprite_render/src/text2d/mod.rs
@@ -63,16 +63,20 @@ pub fn extract_text2d_sprite(
         global_transform,
     ) in text2d_query.iter()
     {
-        let inverse_scale_factor = text_layout_info.scale_factor.recip();
-        let scaling =
-            GlobalTransform::from_scale(Vec3::new(inverse_scale_factor, -inverse_scale_factor, 1.));
         if !view_visibility.get() {
             continue;
         }
 
+        let inverse_scale_factor = text_layout_info.scale_factor.recip();
+        let scaling =
+            GlobalTransform::from_scale(Vec3::new(inverse_scale_factor, -inverse_scale_factor, 1.));
         let size = Vec2::new(
-            text_bounds.width.unwrap_or(text_layout_info.size.x),
-            text_bounds.height.unwrap_or(text_layout_info.size.y),
+            text_bounds
+                .width
+                .unwrap_or(text_layout_info.size.x * inverse_scale_factor),
+            text_bounds
+                .height
+                .unwrap_or(text_layout_info.size.y * inverse_scale_factor),
         );
 
         let top_left = (Anchor::TOP_LEFT.0 - anchor.as_vec()) * size;


### PR DESCRIPTION
# Objective

Fixes #24384

## Solution

The layout size is stored in physical pixels so it needs to be multiplied by the inverse scale factor when calculating anchor offsets.

## Testing

```
cargo run --example text2d
```