### PR TITLE
Rename SortedRenderPhase add to add_retained

### DIFF
--- a/crates/bevy_dev_tools/src/infinite_grid.rs
+++ b/crates/bevy_dev_tools/src/infinite_grid.rs
@@ -398,7 +398,7 @@ fn queue_infinite_grids(
             if !plane_check(transform, view.world_from_view.translation()) {
                 continue;
             }
-            phase.add(Transparent3d {
+            phase.add_retained(Transparent3d {
                 pipeline: pipeline_id,
                 entity: (*render_entity, *main_entity),
                 draw_function: draw_function_id,

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -1289,7 +1289,7 @@ pub fn queue_material_meshes(
                     else {
                         continue;
                     };
-                    transmissive_phase.add(Transmissive3d {
+                    transmissive_phase.add_retained(Transmissive3d {
                         sorting_info: TransparentSortingInfo3d::Sorted {
                             mesh_center: get_mesh_instance_world_from_local(
                                 *visible_entity,
@@ -1389,7 +1389,7 @@ pub fn queue_material_meshes(
                     else {
                         continue;
                     };
-                    transparent_phase.add(Transparent3d {
+                    transparent_phase.add_retained(Transparent3d {
                         sorting_info: TransparentSortingInfo3d::Sorted {
                             mesh_center: get_mesh_instance_world_from_local(
                                 *visible_entity,

--- a/crates/bevy_render/src/render_phase/mod.rs
+++ b/crates/bevy_render/src/render_phase/mod.rs
@@ -1807,14 +1807,15 @@ impl<I> SortedRenderPhase<I>
 where
     I: SortedPhaseItem,
 {
-    /// Adds a [`PhaseItem`] to this render phase.
+    /// Adds a [`PhaseItem`] to this render phase, which will persist between
+    /// frames until removed.
     #[inline]
     pub fn add_retained(&mut self, item: I) {
         self.items.insert((item.entity(), item.main_entity()), item);
     }
 
-    /// Adds a [`PhaseItem`] which will be automatically removed after this
-    /// frame to this phase.
+    /// Adds a [`PhaseItem`] to this render phase, which will be automatically
+    /// removed after this frame.
     #[inline]
     pub fn add_transient(&mut self, item: I) {
         let key = (item.entity(), item.main_entity());

--- a/crates/bevy_render/src/render_phase/mod.rs
+++ b/crates/bevy_render/src/render_phase/mod.rs
@@ -1809,7 +1809,7 @@ where
 {
     /// Adds a [`PhaseItem`] to this render phase.
     #[inline]
-    pub fn add(&mut self, item: I) {
+    pub fn add_retained(&mut self, item: I) {
         self.items.insert((item.entity(), item.main_entity()), item);
     }
 

--- a/crates/bevy_sprite_render/src/mesh2d/material.rs
+++ b/crates/bevy_sprite_render/src/mesh2d/material.rs
@@ -1037,7 +1037,7 @@ pub fn queue_material2d_meshes<M: Material2d>(
                     // entity field here entirely, but we currently can't do so
                     // because UI creates multiple render entities for each main
                     // entity in its sorted phases.
-                    transparent_phase.add(Transparent2d {
+                    transparent_phase.add_retained(Transparent2d {
                         entity: (Entity::PLACEHOLDER, *visible_entity),
                         draw_function: material_2d.properties.draw_function_id,
                         pipeline: pipeline_id,

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -423,7 +423,7 @@ pub fn queue_colored_mesh2d(
                     pipelines.specialize(&pipeline_cache, &colored_mesh2d_pipeline, mesh2d_key);
 
                 let mesh_z = mesh2d_transforms.world_from_local.translation.z;
-                transparent_phase.add(Transparent2d {
+                transparent_phase.add_retained(Transparent2d {
                     entity: (*render_entity, *visible_entity),
                     draw_function: draw_colored_mesh2d,
                     pipeline: pipeline_id,

--- a/examples/shader_advanced/custom_render_phase.rs
+++ b/examples/shader_advanced/custom_render_phase.rs
@@ -617,7 +617,7 @@ fn queue_custom_meshes(
             };
             // At this point we have all the data we need to create a phase item and add it to our
             // phase
-            custom_phase.add(Stencil3d {
+            custom_phase.add_retained(Stencil3d {
                 sorting_info: TransparentSortingInfo3d::Sorted {
                     mesh_center: pbr::get_mesh_instance_world_from_local(
                         *visible_entity,

--- a/examples/shader_advanced/custom_shader_instancing.rs
+++ b/examples/shader_advanced/custom_shader_instancing.rs
@@ -177,7 +177,7 @@ fn queue_custom(
             let pipeline = pipelines
                 .specialize(&pipeline_cache, &custom_pipeline, key, &mesh.layout)
                 .unwrap();
-            transparent_phase.add(Transparent3d {
+            transparent_phase.add_retained(Transparent3d {
                 sorting_info: TransparentSortingInfo3d::Sorted {
                     mesh_center: pbr::get_mesh_instance_world_from_local(
                         *main_entity,


### PR DESCRIPTION
# Objective

In #22966 the semantics of the `add` method on `SortedRenderPhase` was changed from the items being cleared at the end of the frame, to items being retained until they are removed. A new `add_transient` method was added with the old functionality, but this is a big migration hazard because it's a major semantic change that doesn't give any compiler errors or warnings.

I discovered this after updating `bevy_vector_shapes` to the RC and seeing drawings not being cleared properly.

## Solution

Rename `add` to `add_retained` both for clarity and to make old uses not compile, so the affected users will know to look in the migration guide.

A sentence about this should be added to the migration guide if/when this is backported to the 0.19 release branch.

## Testing

It compiles (hopefully).