### PR TITLE
Implement `SystemParam` for `SmallVec`

### DIFF
--- a/crates/bevy_ecs/src/system/builder.rs
+++ b/crates/bevy_ecs/src/system/builder.rs
@@ -1,6 +1,7 @@
 use alloc::{boxed::Box, vec::Vec};
 use bevy_platform::cell::SyncCell;
 use bevy_utils::prelude::DebugName;
+use smallvec::SmallVec;
 use variadics_please::all_tuples;
 
 use crate::{
@@ -615,6 +616,17 @@ all_tuples!(
 // SAFETY: implementors of each `SystemParamBuilder` in the vec have validated their impls
 unsafe impl<P: SystemParam, B: SystemParamBuilder<P>> SystemParamBuilder<Vec<P>> for Vec<B> {
     fn build(self, world: &mut World) -> <Vec<P> as SystemParam>::State {
+        self.into_iter()
+            .map(|builder| builder.build(world))
+            .collect()
+    }
+}
+
+// SAFETY: implementors of each `SystemParamBuilder` in the vec have validated their impls
+unsafe impl<P: SystemParam, B: SystemParamBuilder<P>, const N: usize>
+    SystemParamBuilder<SmallVec<[P; N]>> for SmallVec<[B; N]>
+{
+    fn build(self, world: &mut World) -> <SmallVec<[P; N]> as SystemParam>::State {
         self.into_iter()
             .map(|builder| builder.build(world))
             .collect()

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -115,7 +115,7 @@
 //! - [`FilteredResourcesMut`](crate::world::FilteredResourcesMut)
 //! - [`DynSystemParam`]
 //! - [`Vec<P>`] and [`SmallVec<[P, N]>`](smallvec::SmallVec) where `P: SystemParam`
-//! - [`ParamSet<Vec<P>>`] and [`ParamSet<SmallVec<[P, N]>>`](ParamSet) where `P: SystemParam`
+//! - [`ParamSet<Vec<P>>`] where `P: SystemParam`
 //!
 //! [`Vec<P>`]: alloc::vec::Vec
 

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -114,8 +114,8 @@
 //! - [`FilteredResources`](crate::world::FilteredResources)
 //! - [`FilteredResourcesMut`](crate::world::FilteredResourcesMut)
 //! - [`DynSystemParam`]
-//! - [`Vec<P>`] where `P: SystemParam`
-//! - [`ParamSet<Vec<P>>`] where `P: SystemParam`
+//! - [`Vec<P>`] and [`SmallVec<[P, N]>`](smallvec::SmallVec) where `P: SystemParam`
+//! - [`ParamSet<Vec<P>>`] and [`ParamSet<SmallVec<[P, N]>>`](ParamSet) where `P: SystemParam`
 //!
 //! [`Vec<P>`]: alloc::vec::Vec
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -32,6 +32,7 @@ use core::{
     marker::PhantomData,
     ops::{Deref, DerefMut},
 };
+use smallvec::SmallVec;
 use thiserror::Error;
 
 use super::Populated;
@@ -1922,6 +1923,91 @@ unsafe impl<T: SystemParam> SystemParam for ParamSet<'_, '_, Vec<T>> {
 }
 
 impl<T: SystemParam> ParamSet<'_, '_, Vec<T>> {
+    /// Accesses the parameter at the given index.
+    /// No other parameters may be accessed while this one is active.
+    pub fn get_mut(&mut self, index: usize) -> T::Item<'_, '_> {
+        // SAFETY:
+        // - We initialized the access for each parameter, so the caller ensures we have access to any world data needed by any param.
+        //   We have mutable access to the ParamSet, so no other params in the set are active.
+        // - The caller of `get_param` ensured that this was the world used to initialize our state, and we used that world to initialize parameter states
+        unsafe {
+            T::get_param(
+                &mut self.param_states[index],
+                &self.system_meta,
+                self.world,
+                self.change_tick,
+            )
+            .unwrap()
+        }
+    }
+
+    /// Calls a closure for each parameter in the set.
+    pub fn for_each(&mut self, mut f: impl FnMut(T::Item<'_, '_>)) {
+        self.param_states.iter_mut().for_each(|state| {
+            f(
+                // SAFETY:
+                // - We initialized the access for each parameter, so the caller ensures we have access to any world data needed by any param.
+                //   We have mutable access to the ParamSet, so no other params in the set are active.
+                // - The caller of `get_param` ensured that this was the world used to initialize our state, and we used that world to initialize parameter states
+                unsafe { T::get_param(state, &self.system_meta, self.world, self.change_tick) }
+                    .unwrap_or_else(|err| panic!("ParamSet parameter validation failed: {err}")),
+            );
+        });
+    }
+}
+
+// SAFETY: Registers access for each element of `state`.
+// If any one conflicts, it will panic.
+unsafe impl<T: SystemParam, const N: usize> SystemParam for SmallVec<[T; N]> {
+    type State = SmallVec<[T::State; N]>;
+
+    type Item<'world, 'state> = SmallVec<[T::Item<'world, 'state>; N]>;
+
+    fn init_state(_world: &mut World) -> Self::State {
+        SmallVec::new()
+    }
+
+    fn init_access(
+        state: &Self::State,
+        system_meta: &mut SystemMeta,
+        component_access_set: &mut FilteredAccessSet,
+        world: &mut World,
+    ) {
+        for state in state {
+            T::init_access(state, system_meta, component_access_set, world);
+        }
+    }
+
+    #[inline]
+    unsafe fn get_param<'world, 'state>(
+        state: &'state mut Self::State,
+        system_meta: &SystemMeta,
+        world: UnsafeWorldCell<'world>,
+        change_tick: Tick,
+    ) -> Result<Self::Item<'world, 'state>, SystemParamValidationError> {
+        state
+            .iter_mut()
+            // SAFETY:
+            // - We initialized the access for each parameter in `init_access`, so the caller ensures we have access to any world data needed by each param.
+            // - The caller ensures this was the world used to initialize our state, and we used that world to initialize parameter states
+            .map(|state| unsafe { T::get_param(state, system_meta, world, change_tick) })
+            .collect()
+    }
+
+    fn apply(state: &mut Self::State, system_meta: &SystemMeta, world: &mut World) {
+        for state in state {
+            T::apply(state, system_meta, world);
+        }
+    }
+
+    fn queue(state: &mut Self::State, system_meta: &SystemMeta, mut world: DeferredWorld) {
+        for state in state {
+            T::queue(state, system_meta, world.reborrow());
+        }
+    }
+}
+
+impl<T: SystemParam, const N: usize> ParamSet<'_, '_, SmallVec<[T; N]>> {
     /// Accesses the parameter at the given index.
     /// No other parameters may be accessed while this one is active.
     pub fn get_mut(&mut self, index: usize) -> T::Item<'_, '_> {

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -2007,40 +2007,6 @@ unsafe impl<T: SystemParam, const N: usize> SystemParam for SmallVec<[T; N]> {
     }
 }
 
-impl<T: SystemParam, const N: usize> ParamSet<'_, '_, SmallVec<[T; N]>> {
-    /// Accesses the parameter at the given index.
-    /// No other parameters may be accessed while this one is active.
-    pub fn get_mut(&mut self, index: usize) -> T::Item<'_, '_> {
-        // SAFETY:
-        // - We initialized the access for each parameter, so the caller ensures we have access to any world data needed by any param.
-        //   We have mutable access to the ParamSet, so no other params in the set are active.
-        // - The caller of `get_param` ensured that this was the world used to initialize our state, and we used that world to initialize parameter states
-        unsafe {
-            T::get_param(
-                &mut self.param_states[index],
-                &self.system_meta,
-                self.world,
-                self.change_tick,
-            )
-            .unwrap()
-        }
-    }
-
-    /// Calls a closure for each parameter in the set.
-    pub fn for_each(&mut self, mut f: impl FnMut(T::Item<'_, '_>)) {
-        self.param_states.iter_mut().for_each(|state| {
-            f(
-                // SAFETY:
-                // - We initialized the access for each parameter, so the caller ensures we have access to any world data needed by any param.
-                //   We have mutable access to the ParamSet, so no other params in the set are active.
-                // - The caller of `get_param` ensured that this was the world used to initialize our state, and we used that world to initialize parameter states
-                unsafe { T::get_param(state, &self.system_meta, self.world, self.change_tick) }
-                    .unwrap_or_else(|err| panic!("ParamSet parameter validation failed: {err}")),
-            );
-        });
-    }
-}
-
 macro_rules! impl_system_param_tuple {
     ($(#[$meta:meta])* $($param: ident),*) => {
         $(#[$meta])*


### PR DESCRIPTION
# Objective

To register a system from a script, I need to support for dynamic number of system parameters (since scripting languages usually don't play well with generics). Right now the only solution is to use `Vec<T>` as a system param which is allocated every time the system runs. But it would be nice to avoid allocations when the number of system parameters is low.

## Solution

Implement `SystemParam` for `SmallVec`. It's already a dependency for `bevy_ecs` and allows to avoid allocations with user-defined number of system parameters.

## Testing

- Did you test these changes? If so, how? I tried creating a system with a `SmallVec<[Local<usize>; 8]>`.
- Are there any parts that need more testing? I don't think so. The code follows `Vec` impl.