### PR TITLE
Remove false positive error log for morph targets

### DIFF
--- a/crates/bevy_render/src/mesh/morph.rs
+++ b/crates/bevy_render/src/mesh/morph.rs
@@ -3,7 +3,6 @@ use bevy_ecs::{
     resource::Resource,
     world::{FromWorld, World},
 };
-use bevy_log::error;
 use bevy_mesh::{
     morph::{MorphAttributes, MorphBuildError, MAX_MORPH_WEIGHTS, MAX_TEXTURE_WIDTH},
     Mesh,
@@ -212,12 +211,7 @@ impl RenderMorphTargetAllocator {
             RenderMorphTargetAllocator::Image {
                 ref mut mesh_id_to_image,
             } => {
-                if mesh_id_to_image.remove(&mesh_id).is_none() {
-                    error!(
-                        "Attempted to free a morph target allocation that wasn't allocated: {:?}",
-                        mesh_id
-                    );
-                }
+                mesh_id_to_image.remove(&mesh_id);
             }
             RenderMorphTargetAllocator::Storage => {
                 // Do nothing. Morph target displacements are managed by the


### PR DESCRIPTION
# Objective

When mesh assets are prepared, an image is allocated only if the mesh has any morph targets. When unloading the asset an error log is always printed if that image cannot be found, even if it was never allocated. This leads to a bunch of error messages that aren't actionable.

## Solution

Remove the error log, as we don't have enough bookkeeping to output it correctly.

## Testing

None