### PR TITLE
Preserve color space on `Saturation` changes (Consistency with `Hue` and `Luminance` traits)

### DIFF
--- a/crates/bevy_color/src/color.rs
+++ b/crates/bevy_color/src/color.rs
@@ -861,8 +861,8 @@ impl Saturation for Color {
         match &mut new {
             Color::Srgba(x) => *x = Hsla::from(*x).with_saturation(saturation).into(),
             Color::LinearRgba(x) => *x = Hsla::from(*x).with_saturation(saturation).into(),
-            Color::Hsla(x) => *x = x.with_saturation(saturation).into(),
-            Color::Hsva(x) => *x = x.with_saturation(saturation).into(),
+            Color::Hsla(x) => *x = x.with_saturation(saturation),
+            Color::Hsva(x) => *x = x.with_saturation(saturation),
             Color::Hwba(x) => *x = Hsla::from(*x).with_saturation(saturation).into(),
             Color::Laba(x) => *x = Hsla::from(*x).with_saturation(saturation).into(),
             Color::Lcha(x) => *x = Hsla::from(*x).with_saturation(saturation).into(),

--- a/crates/bevy_color/src/color.rs
+++ b/crates/bevy_color/src/color.rs
@@ -859,17 +859,19 @@ impl Saturation for Color {
         let mut new = *self;
 
         match &mut new {
-            Color::Srgba(x) => Hsla::from(*x).with_saturation(saturation).into(),
-            Color::LinearRgba(x) => Hsla::from(*x).with_saturation(saturation).into(),
-            Color::Hsla(x) => x.with_saturation(saturation).into(),
-            Color::Hsva(x) => x.with_saturation(saturation).into(),
-            Color::Hwba(x) => Hsla::from(*x).with_saturation(saturation).into(),
-            Color::Laba(x) => Hsla::from(*x).with_saturation(saturation).into(),
-            Color::Lcha(x) => Hsla::from(*x).with_saturation(saturation).into(),
-            Color::Oklaba(x) => Hsla::from(*x).with_saturation(saturation).into(),
-            Color::Oklcha(x) => Hsla::from(*x).with_saturation(saturation).into(),
-            Color::Xyza(x) => Hsla::from(*x).with_saturation(saturation).into(),
+            Color::Srgba(x) => *x = Hsla::from(*x).with_saturation(saturation).into(),
+            Color::LinearRgba(x) => *x = Hsla::from(*x).with_saturation(saturation).into(),
+            Color::Hsla(x) => *x = x.with_saturation(saturation).into(),
+            Color::Hsva(x) => *x = x.with_saturation(saturation).into(),
+            Color::Hwba(x) => *x = Hsla::from(*x).with_saturation(saturation).into(),
+            Color::Laba(x) => *x = Hsla::from(*x).with_saturation(saturation).into(),
+            Color::Lcha(x) => *x = Hsla::from(*x).with_saturation(saturation).into(),
+            Color::Oklaba(x) => *x = Hsla::from(*x).with_saturation(saturation).into(),
+            Color::Oklcha(x) => *x = Hsla::from(*x).with_saturation(saturation).into(),
+            Color::Xyza(x) => *x = Hsla::from(*x).with_saturation(saturation).into(),
         }
+
+        new
     }
 
     fn saturation(&self) -> f32 {


### PR DESCRIPTION
# Objective

- Make the `Saturation` trait match the behavior of `Hue` and `Luminance` traits, by preserving the underlying color space of the modified color

## Solution

- Assign to the interior mutably borrowed value in the underlying color space, instead of just returning a new value in an arbitrary color space (`Color::Hsla()`)

## Testing

- Manual testing. Trivial change, behavior already consistent with existing traits