### PR TITLE
bugfix android activity

### DIFF
--- a/crates/bevy_android/Cargo.toml
+++ b/crates/bevy_android/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [target.'cfg(target_os = "android")'.dependencies]
-android-activity = "0.6"
+android-activity = "0.6.1"
 
 [features]
 default = []


### PR DESCRIPTION
* update android-activity to 0.6.1 from crate bevy_android

Issue: NO-TICKET (not found)

# Objective

The android-activity 0.6.0 is no longer compatible. This makes `android-activity = "0.6"` to less restrictive.

## Solution

I asked in the Discord and it looks like a dedicated version is most practical. `android-activity = "0.6.1"` At least it is now compatible with gamesActivity from here: [libs.versions.toml L8](https://github.com/bevyengine/bevy/blob/3cc7161f5f133cecb8886351691592bc31dfad6f/examples/mobile/android_example/gradle/libs.versions.toml#L8).

## Testing

Created the example on my own system. It is now working on emulator and real devices. I was a long time struggeling with this missing constraint, because I had still the old 0.6.0 on my system.

