### PR TITLE
Generalise `TemporaryRenderEntity` over `AppLabel`

### DIFF
--- a/_release-content/migration-guides/extract-extract-a.md
+++ b/_release-content/migration-guides/extract-extract-a.md
@@ -1,0 +1,10 @@
+---
+title: Extract Extract
+pull_requests: []
+---
+
+Extraction used to be specific of Main World to Render World, but will now be generic
+
+- Use `TemporaryRenderEntity::default()` instead of `TemporaryRenderEntity`
+
+NOTE: more to come

--- a/crates/bevy_gizmos_render/src/lib.rs
+++ b/crates/bevy_gizmos_render/src/lib.rs
@@ -214,7 +214,7 @@ fn extract_gizmo_data(
             // The immediate mode API does not have a main world entity to refer to,
             // but we do need MainEntity on this render entity for the systems to find it.
             MainEntity::from(Entity::PLACEHOLDER),
-            TemporaryRenderEntity,
+            TemporaryRenderEntity::default(),
         ));
     }
 }

--- a/crates/bevy_gizmos_render/src/retained.rs
+++ b/crates/bevy_gizmos_render/src/retained.rs
@@ -75,7 +75,7 @@ pub(crate) fn extract_linegizmos(
                 handle: gizmo.handle.clone(),
             },
             MainEntity::from(entity),
-            TemporaryRenderEntity,
+            TemporaryRenderEntity::default(),
         ));
     }
     *previous_len = values.len();

--- a/crates/bevy_render/src/extract_plugin.rs
+++ b/crates/bevy_render/src/extract_plugin.rs
@@ -1,5 +1,5 @@
 use crate::{
-    sync_world::{despawn_temporary_render_entities, entity_sync_system, SyncWorldPlugin},
+    sync_world::{despawn_temporary_entities, entity_sync_system, SyncWorldPlugin},
     Render, RenderApp, RenderSystems,
 };
 use bevy_app::{App, Plugin, SubApp};
@@ -54,7 +54,7 @@ impl Plugin for ExtractPlugin {
                     // This set applies the commands from the extract schedule while the render schedule
                     // is running in parallel with the main app.
                     apply_extract_commands.in_set(RenderSystems::ExtractCommands),
-                    despawn_temporary_render_entities::<RenderApp>
+                    despawn_temporary_entities::<RenderApp>
                         .in_set(RenderSystems::PostCleanup),
                 ),
             );

--- a/crates/bevy_render/src/extract_plugin.rs
+++ b/crates/bevy_render/src/extract_plugin.rs
@@ -54,8 +54,7 @@ impl Plugin for ExtractPlugin {
                     // This set applies the commands from the extract schedule while the render schedule
                     // is running in parallel with the main app.
                     apply_extract_commands.in_set(RenderSystems::ExtractCommands),
-                    despawn_temporary_entities::<RenderApp>
-                        .in_set(RenderSystems::PostCleanup),
+                    despawn_temporary_entities::<RenderApp>.in_set(RenderSystems::PostCleanup),
                 ),
             );
 

--- a/crates/bevy_render/src/extract_plugin.rs
+++ b/crates/bevy_render/src/extract_plugin.rs
@@ -54,7 +54,8 @@ impl Plugin for ExtractPlugin {
                     // This set applies the commands from the extract schedule while the render schedule
                     // is running in parallel with the main app.
                     apply_extract_commands.in_set(RenderSystems::ExtractCommands),
-                    despawn_temporary_render_entities.in_set(RenderSystems::PostCleanup),
+                    despawn_temporary_render_entities::<RenderApp>
+                        .in_set(RenderSystems::PostCleanup),
                 ),
             );
 

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -342,7 +342,7 @@ impl Render {
 pub(crate) struct FutureRenderResources(Arc<Mutex<Option<RenderResources>>>);
 
 /// A label for the rendering sub-app.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, AppLabel)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, AppLabel, Default)]
 pub struct RenderApp;
 
 impl Plugin for RenderPlugin {

--- a/crates/bevy_render/src/sync_world.rs
+++ b/crates/bevy_render/src/sync_world.rs
@@ -191,9 +191,9 @@ pub type MainEntityHashSet = HashSet<MainEntity, EntityHash>;
 /// Marker component that indicates that its entity needs to be despawned at the end of the frame.
 #[derive(Component, Copy, Clone, Debug, Default, Reflect)]
 #[reflect(Component, Default, Clone)]
-pub struct TemporarySubEntity<L: AppLabel + Clone + Eq + Copy + Default>(PhantomData<L>);
+pub struct TemporaryEntity<L: AppLabel + Clone + Eq + Copy + Default>(PhantomData<L>);
 
-pub type TemporaryRenderEntity = TemporarySubEntity<crate::RenderApp>;
+pub type TemporaryRenderEntity = TemporaryEntity<crate::RenderApp>;
 
 /// A record enum to what entities with [`SyncToRenderWorld`] have been added or removed.
 #[derive(Debug)]
@@ -254,7 +254,7 @@ pub(crate) fn entity_sync_system(main_world: &mut World, render_world: &mut Worl
 
 pub(crate) fn despawn_temporary_render_entities<L: AppLabel + Copy + Default + Eq>(
     world: &mut World,
-    state: &mut SystemState<Query<Entity, With<TemporarySubEntity<L>>>>,
+    state: &mut SystemState<Query<Entity, With<TemporaryEntity<L>>>>,
     mut local: Local<Vec<Entity>>,
 ) {
     let query = state.get(world).unwrap();

--- a/crates/bevy_render/src/sync_world.rs
+++ b/crates/bevy_render/src/sync_world.rs
@@ -252,7 +252,7 @@ pub(crate) fn entity_sync_system(main_world: &mut World, render_world: &mut Worl
     });
 }
 
-pub(crate) fn despawn_temporary_render_entities<L: AppLabel + Copy + Default + Eq>(
+pub(crate) fn despawn_temporary_entities<L: AppLabel + Copy + Default + Eq>(
     world: &mut World,
     state: &mut SystemState<Query<Entity, With<TemporaryEntity<L>>>>,
     mut local: Local<Vec<Entity>>,

--- a/crates/bevy_render/src/sync_world.rs
+++ b/crates/bevy_render/src/sync_world.rs
@@ -1,4 +1,6 @@
-use bevy_app::Plugin;
+use core::marker::PhantomData;
+
+use bevy_app::{AppLabel, Plugin};
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
     component::Component,
@@ -189,7 +191,9 @@ pub type MainEntityHashSet = HashSet<MainEntity, EntityHash>;
 /// Marker component that indicates that its entity needs to be despawned at the end of the frame.
 #[derive(Component, Copy, Clone, Debug, Default, Reflect)]
 #[reflect(Component, Default, Clone)]
-pub struct TemporaryRenderEntity;
+pub struct TemporarySubEntity<L: AppLabel + Clone + Eq + Copy + Default>(PhantomData<L>);
+
+pub type TemporaryRenderEntity = TemporarySubEntity<crate::RenderApp>;
 
 /// A record enum to what entities with [`SyncToRenderWorld`] have been added or removed.
 #[derive(Debug)]
@@ -248,9 +252,9 @@ pub(crate) fn entity_sync_system(main_world: &mut World, render_world: &mut Worl
     });
 }
 
-pub(crate) fn despawn_temporary_render_entities(
+pub(crate) fn despawn_temporary_render_entities<L: AppLabel + Copy + Default + Eq>(
     world: &mut World,
-    state: &mut SystemState<Query<Entity, With<TemporaryRenderEntity>>>,
+    state: &mut SystemState<Query<Entity, With<TemporarySubEntity<L>>>>,
     mut local: Local<Vec<Entity>>,
 ) {
     let query = state.get(world).unwrap();

--- a/crates/bevy_sprite_render/src/text2d/mod.rs
+++ b/crates/bevy_sprite_render/src/text2d/mod.rs
@@ -86,7 +86,7 @@ pub fn extract_text2d_sprite(
             let Ok(text_background_color) = text_background_colors_query.get(section_entity) else {
                 continue;
             };
-            let render_entity = commands.spawn(TemporaryRenderEntity).id();
+            let render_entity = commands.spawn(TemporaryRenderEntity::default()).id();
             let offset = run.bounds.center();
             let transform = *global_transform
                 * GlobalTransform::from_translation(top_left.extend(0.))
@@ -135,7 +135,7 @@ pub fn extract_text2d_sprite(
                     .get(i + 1)
                     .is_none_or(|info| info.atlas_info.texture != atlas_info.texture)
                 {
-                    let render_entity = commands.spawn(TemporaryRenderEntity).id();
+                    let render_entity = commands.spawn(TemporaryRenderEntity::default()).id();
                     extracted_sprites.sprites.push(ExtractedSprite {
                         main_entity,
                         render_entity,
@@ -163,7 +163,7 @@ pub fn extract_text2d_sprite(
                 };
 
                 if has_strikethrough {
-                    let render_entity = commands.spawn(TemporaryRenderEntity).id();
+                    let render_entity = commands.spawn(TemporaryRenderEntity::default()).id();
                     let offset = run.strikethrough_position();
                     let transform =
                         shadow_transform * GlobalTransform::from_translation(offset.extend(0.));
@@ -185,7 +185,7 @@ pub fn extract_text2d_sprite(
                 }
 
                 if has_underline {
-                    let render_entity = commands.spawn(TemporaryRenderEntity).id();
+                    let render_entity = commands.spawn(TemporaryRenderEntity::default()).id();
                     let offset = run.underline_position();
                     let transform =
                         shadow_transform * GlobalTransform::from_translation(offset.extend(0.));
@@ -246,7 +246,7 @@ pub fn extract_text2d_sprite(
                 info.section_index != current_section
                     || info.atlas_info.texture != atlas_info.texture
             }) {
-                let render_entity = commands.spawn(TemporaryRenderEntity).id();
+                let render_entity = commands.spawn(TemporaryRenderEntity::default()).id();
                 extracted_sprites.sprites.push(ExtractedSprite {
                     main_entity,
                     render_entity,
@@ -282,7 +282,7 @@ pub fn extract_text2d_sprite(
                     .map(|c| c.0)
                     .unwrap_or(text_color.0)
                     .to_linear();
-                let render_entity = commands.spawn(TemporaryRenderEntity).id();
+                let render_entity = commands.spawn(TemporaryRenderEntity::default()).id();
                 let offset = run.strikethrough_position();
                 let transform = *global_transform
                     * GlobalTransform::from_translation(top_left.extend(0.))
@@ -310,7 +310,7 @@ pub fn extract_text2d_sprite(
                     .map(|c| c.0)
                     .unwrap_or(text_color.0)
                     .to_linear();
-                let render_entity = commands.spawn(TemporaryRenderEntity).id();
+                let render_entity = commands.spawn(TemporaryRenderEntity::default()).id();
                 let offset = run.underline_position();
                 let transform = *global_transform
                     * GlobalTransform::from_translation(top_left.extend(0.))

--- a/crates/bevy_ui_render/src/box_shadow.rs
+++ b/crates/bevy_ui_render/src/box_shadow.rs
@@ -274,7 +274,7 @@ pub fn extract_shadows(
             };
 
             extracted_box_shadows.box_shadows.push(ExtractedBoxShadow {
-                render_entity: commands.spawn(TemporaryRenderEntity).id(),
+                render_entity: commands.spawn(TemporaryRenderEntity::default()).id(),
                 stack_index: stack_index.0,
                 transform: Affine2::from(transform) * Affine2::from_translation(offset),
                 color: drop_shadow.color.into(),

--- a/crates/bevy_ui_render/src/debug_overlay.rs
+++ b/crates/bevy_ui_render/src/debug_overlay.rs
@@ -218,7 +218,7 @@ pub fn extract_debug_overlay(
             }
 
             extracted_uinodes.uinodes.push(ExtractedUiNode {
-                render_entity: commands.spawn(TemporaryRenderEntity).id(),
+                render_entity: commands.spawn(TemporaryRenderEntity::default()).id(),
                 // Keep all overlays above UI, and nudge each type slightly in Z so ordering is stable.
                 z_order,
                 clip: maybe_clip

--- a/crates/bevy_ui_render/src/gradient.rs
+++ b/crates/bevy_ui_render/src/gradient.rs
@@ -416,7 +416,7 @@ pub fn extract_gradients(
                             node_type,
                         },
                         main_entity: entity.into(),
-                        render_entity: commands.spawn(TemporaryRenderEntity).id(),
+                        render_entity: commands.spawn(TemporaryRenderEntity::default()).id(),
                     });
                     continue;
                 }
@@ -440,7 +440,7 @@ pub fn extract_gradients(
                         );
 
                         extracted_gradients.items.push(ExtractedGradient {
-                            render_entity: commands.spawn(TemporaryRenderEntity).id(),
+                            render_entity: commands.spawn(TemporaryRenderEntity::default()).id(),
                             stack_index: stack_index.0,
                             transform: transform.into(),
                             stops_range: range_start..extracted_color_stops.0.len(),
@@ -490,7 +490,7 @@ pub fn extract_gradients(
                         );
 
                         extracted_gradients.items.push(ExtractedGradient {
-                            render_entity: commands.spawn(TemporaryRenderEntity).id(),
+                            render_entity: commands.spawn(TemporaryRenderEntity::default()).id(),
                             stack_index: stack_index.0,
                             transform: transform.into(),
                             stops_range: range_start..extracted_color_stops.0.len(),
@@ -546,7 +546,7 @@ pub fn extract_gradients(
                         );
 
                         extracted_gradients.items.push(ExtractedGradient {
-                            render_entity: commands.spawn(TemporaryRenderEntity).id(),
+                            render_entity: commands.spawn(TemporaryRenderEntity::default()).id(),
                             stack_index: stack_index.0,
                             transform: transform.into(),
                             stops_range: range_start..extracted_color_stops.0.len(),

--- a/crates/bevy_ui_render/src/lib.rs
+++ b/crates/bevy_ui_render/src/lib.rs
@@ -433,7 +433,7 @@ pub fn extract_uinode_background_colors(
 
         if !background_color.is_fully_transparent() {
             extracted_uinodes.uinodes.push(ExtractedUiNode {
-                render_entity: commands.spawn(TemporaryRenderEntity).id(),
+                render_entity: commands.spawn(TemporaryRenderEntity::default()).id(),
                 z_order: stack_index.0 as f32 + stack_z_offsets::BACKGROUND_COLOR,
                 clip: clip.map(|clip| clip.clip),
                 image: AssetId::default(),
@@ -460,7 +460,7 @@ pub fn extract_uinode_background_colors(
             && !outer_color.0.is_fully_transparent()
         {
             extracted_uinodes.uinodes.push(ExtractedUiNode {
-                render_entity: commands.spawn(TemporaryRenderEntity).id(),
+                render_entity: commands.spawn(TemporaryRenderEntity::default()).id(),
                 z_order: stack_index.0 as f32 + stack_z_offsets::BACKGROUND_COLOR,
                 clip: clip.map(|clip| clip.clip),
                 image: AssetId::default(),
@@ -578,7 +578,7 @@ pub fn extract_uinode_images(
 
         extracted_uinodes.uinodes.push(ExtractedUiNode {
             z_order: stack_index.0 as f32 + stack_z_offsets::IMAGE,
-            render_entity: commands.spawn(TemporaryRenderEntity).id(),
+            render_entity: commands.spawn(TemporaryRenderEntity::default()).id(),
             clip: clip.map(|clip| clip.clip),
             image: image.image.id(),
             extracted_camera_entity,
@@ -697,7 +697,7 @@ pub fn extract_uinode_borders(
                         node_type: NodeType::Border(border_flags),
                     },
                     main_entity: entity.into(),
-                    render_entity: commands.spawn(TemporaryRenderEntity).id(),
+                    render_entity: commands.spawn(TemporaryRenderEntity::default()).id(),
                 });
             }
         }
@@ -711,7 +711,7 @@ pub fn extract_uinode_borders(
             let outline_size = computed_node.outlined_node_size();
             extracted_uinodes.uinodes.push(ExtractedUiNode {
                 z_order: stack_index.0 as f32 + stack_z_offsets::BORDER,
-                render_entity: commands.spawn(TemporaryRenderEntity).id(),
+                render_entity: commands.spawn(TemporaryRenderEntity::default()).id(),
                 image,
                 clip: maybe_clip.map(|clip| clip.clip),
                 extracted_camera_entity,
@@ -853,7 +853,7 @@ pub fn extract_ui_camera_view(
                     },
                     // Link to the main camera view.
                     UiViewTarget(render_entity),
-                    TemporaryRenderEntity,
+                    TemporaryRenderEntity::default(),
                 ))
                 .id();
 
@@ -929,7 +929,7 @@ pub fn extract_viewport_nodes(
 
         extracted_uinodes.uinodes.push(ExtractedUiNode {
             z_order: stack_index.0 as f32 + stack_z_offsets::IMAGE,
-            render_entity: commands.spawn(TemporaryRenderEntity).id(),
+            render_entity: commands.spawn(TemporaryRenderEntity::default()).id(),
             clip: clip.map(|clip| clip.clip),
             image: image.id(),
             extracted_camera_entity,
@@ -1079,7 +1079,7 @@ pub fn extract_text_sections(
             {
                 extracted_uinodes.uinodes.push(ExtractedUiNode {
                     z_order: stack_index.0 as f32 + stack_z_offsets::TEXT,
-                    render_entity: commands.spawn(TemporaryRenderEntity).id(),
+                    render_entity: commands.spawn(TemporaryRenderEntity::default()).id(),
                     image: atlas_info.texture,
                     clip,
                     extracted_camera_entity,
@@ -1183,7 +1183,7 @@ pub fn extract_text_shadows(
                 extracted_uinodes.uinodes.push(ExtractedUiNode {
                     transform: node_transform,
                     z_order: stack_index.0 as f32 + stack_z_offsets::TEXT,
-                    render_entity: commands.spawn(TemporaryRenderEntity).id(),
+                    render_entity: commands.spawn(TemporaryRenderEntity::default()).id(),
                     image: atlas_info.texture,
                     clip,
                     extracted_camera_entity,
@@ -1212,7 +1212,7 @@ pub fn extract_text_shadows(
             if has_strikethrough {
                 extracted_uinodes.uinodes.push(ExtractedUiNode {
                     z_order: stack_index.0 as f32 + stack_z_offsets::TEXT,
-                    render_entity: commands.spawn(TemporaryRenderEntity).id(),
+                    render_entity: commands.spawn(TemporaryRenderEntity::default()).id(),
                     clip,
                     image: AssetId::default(),
                     extracted_camera_entity,
@@ -1238,7 +1238,7 @@ pub fn extract_text_shadows(
             if has_underline {
                 extracted_uinodes.uinodes.push(ExtractedUiNode {
                     z_order: stack_index.0 as f32 + stack_z_offsets::TEXT,
-                    render_entity: commands.spawn(TemporaryRenderEntity).id(),
+                    render_entity: commands.spawn(TemporaryRenderEntity::default()).id(),
                     clip,
                     image: AssetId::default(),
                     extracted_camera_entity,
@@ -1350,7 +1350,7 @@ pub fn extract_text_decorations(
             if let Some(text_background_color) = text_background_color {
                 extracted_uinodes.uinodes.push(ExtractedUiNode {
                     z_order: stack_index.0 as f32 + stack_z_offsets::TEXT,
-                    render_entity: commands.spawn(TemporaryRenderEntity).id(),
+                    render_entity: commands.spawn(TemporaryRenderEntity::default()).id(),
                     clip,
                     image: AssetId::default(),
                     extracted_camera_entity,
@@ -1380,7 +1380,7 @@ pub fn extract_text_decorations(
 
                 extracted_uinodes.uinodes.push(ExtractedUiNode {
                     z_order: stack_index.0 as f32 + stack_z_offsets::TEXT_STRIKETHROUGH,
-                    render_entity: commands.spawn(TemporaryRenderEntity).id(),
+                    render_entity: commands.spawn(TemporaryRenderEntity::default()).id(),
                     clip,
                     image: AssetId::default(),
                     extracted_camera_entity,
@@ -1410,7 +1410,7 @@ pub fn extract_text_decorations(
 
                 extracted_uinodes.uinodes.push(ExtractedUiNode {
                     z_order: stack_index.0 as f32 + stack_z_offsets::TEXT_STRIKETHROUGH,
-                    render_entity: commands.spawn(TemporaryRenderEntity).id(),
+                    render_entity: commands.spawn(TemporaryRenderEntity::default()).id(),
                     clip,
                     image: AssetId::default(),
                     extracted_camera_entity,

--- a/crates/bevy_ui_render/src/text.rs
+++ b/crates/bevy_ui_render/src/text.rs
@@ -137,7 +137,7 @@ pub fn extract_text_cursor(
                 }
 
                 extracted_uinodes.uinodes.push(ExtractedUiNode {
-                    render_entity: commands.spawn(TemporaryRenderEntity).id(),
+                    render_entity: commands.spawn(TemporaryRenderEntity::default()).id(),
                     z_order: stack_index.0 as f32 + stack_z_offsets::TEXT_SELECTION,
                     clip,
                     image: AssetId::default(),
@@ -166,7 +166,7 @@ pub fn extract_text_cursor(
             && !cursor_style.color.is_fully_transparent()
         {
             extracted_uinodes.uinodes.push(ExtractedUiNode {
-                render_entity: commands.spawn(TemporaryRenderEntity).id(),
+                render_entity: commands.spawn(TemporaryRenderEntity::default()).id(),
                 z_order: stack_index.0 as f32 + stack_z_offsets::TEXT_CURSOR,
                 clip,
                 image: AssetId::default(),
@@ -259,7 +259,7 @@ pub fn extract_preedit_underlines(
 
         for rect in text_layout_info.preedit_underline_rects.iter() {
             extracted_uinodes.uinodes.push(ExtractedUiNode {
-                render_entity: commands.spawn(TemporaryRenderEntity).id(),
+                render_entity: commands.spawn(TemporaryRenderEntity::default()).id(),
                 z_order: stack_index.0 as f32 + stack_z_offsets::TEXT_STRIKETHROUGH,
                 clip,
                 image: AssetId::default(),

--- a/crates/bevy_ui_render/src/ui_material_pipeline.rs
+++ b/crates/bevy_ui_render/src/ui_material_pipeline.rs
@@ -364,7 +364,7 @@ pub fn extract_ui_material_nodes<M: UiMaterial>(
         };
 
         extracted_uinodes.uinodes.push(ExtractedUiMaterialNode {
-            render_entity: commands.spawn(TemporaryRenderEntity).id(),
+            render_entity: commands.spawn(TemporaryRenderEntity::default()).id(),
             stack_index: stack_index.0,
             transform: transform.into(),
             material: handle.id(),

--- a/crates/bevy_ui_render/src/ui_texture_slice_pipeline.rs
+++ b/crates/bevy_ui_render/src/ui_texture_slice_pipeline.rs
@@ -286,7 +286,7 @@ pub fn extract_ui_texture_slices(
         };
 
         extracted_ui_slicers.slices.push(ExtractedUiTextureSlice {
-            render_entity: commands.spawn(TemporaryRenderEntity).id(),
+            render_entity: commands.spawn(TemporaryRenderEntity::default()).id(),
             stack_index: stack_index.0,
             transform: Affine2::from(*transform) * Affine2::from_translation(visual_box.center()),
             color: image.color.into(),


### PR DESCRIPTION
# Objective

- Step towards making the extract infra is reusable for non-rendering crates (see https://github.com/bevyengine/bevy/issues/24483 )

## Solution

- Replace `TemporaryRenderEntity` with a generic over `AppLabel`, `TemporaryRenderEntity` becomes an alias over `RenderApp`

## Testing

- CI
- `cargo run --example animated_mesh`