### PR TITLE
Fix IME text input wrapping (#23932)

### DIFF
--- a/examples/ui/text/ime_support.rs
+++ b/examples/ui/text/ime_support.rs
@@ -62,6 +62,7 @@ fn setup(mut commands: Commands) {
                 allow_newlines: true,
                 ..default()
             },
+            TextLayout::no_wrap(),
             TextCursorStyle::default(),
             TabIndex(0),
             BackgroundColor(DARK_GREY.into()),


### PR DESCRIPTION
The IME support example configures its editable text field as a
single visible input, but the text layout still used default soft
wrapping. When the cursor moved through long text, wrapped visual lines
could appear as disconnected text segments.

Set the example input to use `TextLayout::no_wrap()`, matching the
other single-line text input examples while still allowing explicit
newlines.

Fixes https://github.com/bevyengine/bevy/issues/23932.

```sh
cargo check --example ime_support --features system_font_discovery
```