### PR TITLE
Fix: Move DiagnosticsOverlay Setup to PreStartup Schedule

### DIFF
--- a/crates/bevy_dev_tools/src/diagnostics_overlay.rs
+++ b/crates/bevy_dev_tools/src/diagnostics_overlay.rs
@@ -66,8 +66,7 @@ type StandardMaterialAllocator = MaterialAllocatorDiagnosticPlugin<StandardMater
 /// ```
 ///
 /// A [`DiagnosticsOverlay`] entity will be managed by [`DiagnosticsOverlayPlugin`],
-/// and be added as a child of the [`DiagnosticsOverlayPlane`]. To work properly,
-/// the entity must be spawned after [`DiagnosticsOverlaySystems::Setup`].
+/// and be added as a child of the [`DiagnosticsOverlayPlane`].
 ///
 /// If any value is showing as `Missing`, means that the [`DiagnosticPath`] is not registered,
 /// so make sure that the plugin that writes to it is properly set up.
@@ -211,10 +210,6 @@ impl DiagnosticsOverlayStatistic {
 /// System set for the systems of the [`DiagnosticsOverlayPlugin`]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, SystemSet)]
 pub enum DiagnosticsOverlaySystems {
-    /// Runs in the [`Startup`] schedule.
-    /// Sets up the [`DiagnosticsOverlayPlane`] that will parent all [`DiagnosticsOverlay`]s.
-    /// Ensure that any [`DiagnosticsOverlay`]s are spawned after this system.
-    Setup,
     /// Rebuild the contents of the [`DiagnosticsOverlay`] entities
     Rebuild,
 }
@@ -226,12 +221,8 @@ pub struct DiagnosticsOverlayPlugin;
 
 impl Plugin for DiagnosticsOverlayPlugin {
     fn build(&self, app: &mut App) {
-        app.configure_sets(Startup, DiagnosticsOverlaySystems::Setup);
         app.configure_sets(Update, DiagnosticsOverlaySystems::Rebuild);
-        app.add_systems(
-            Startup,
-            build_plane.in_set(DiagnosticsOverlaySystems::Setup),
-        );
+        app.add_systems(PreStartup, build_plane);
         app.add_systems(
             Update,
             rebuild_diagnostics_list

--- a/crates/bevy_dev_tools/src/diagnostics_overlay.rs
+++ b/crates/bevy_dev_tools/src/diagnostics_overlay.rs
@@ -210,6 +210,8 @@ impl DiagnosticsOverlayStatistic {
 /// System set for the systems of the [`DiagnosticsOverlayPlugin`]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, SystemSet)]
 pub enum DiagnosticsOverlaySystems {
+    /// Sets up the [`DiagnosticsOverlayPlane`] that will parent all [`DiagnosticsOverlay`]s.
+    Setup,
     /// Rebuild the contents of the [`DiagnosticsOverlay`] entities
     Rebuild,
 }
@@ -221,8 +223,12 @@ pub struct DiagnosticsOverlayPlugin;
 
 impl Plugin for DiagnosticsOverlayPlugin {
     fn build(&self, app: &mut App) {
+        app.configure_sets(Startup, DiagnosticsOverlaySystems::Setup);
         app.configure_sets(Update, DiagnosticsOverlaySystems::Rebuild);
-        app.add_systems(Startup, build_plane);
+        app.add_systems(
+            Startup,
+            build_plane.in_set(DiagnosticsOverlaySystems::Setup),
+        );
         app.add_systems(
             Update,
             rebuild_diagnostics_list

--- a/crates/bevy_dev_tools/src/diagnostics_overlay.rs
+++ b/crates/bevy_dev_tools/src/diagnostics_overlay.rs
@@ -210,7 +210,10 @@ impl DiagnosticsOverlayStatistic {
 /// System set for the systems of the [`DiagnosticsOverlayPlugin`]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, SystemSet)]
 pub enum DiagnosticsOverlaySystems {
+    /// Runs in the [`Startup`] schedule.
     /// Sets up the [`DiagnosticsOverlayPlane`] that will parent all [`DiagnosticsOverlay`]s.
+    /// Ensure that any [`DiagnosticsOverlay`]s are spawned
+    /// [`after`](bevy_ecs::schedule::IntoScheduleConfigs::after) this system.
     Setup,
     /// Rebuild the contents of the [`DiagnosticsOverlay`] entities
     Rebuild,

--- a/crates/bevy_dev_tools/src/diagnostics_overlay.rs
+++ b/crates/bevy_dev_tools/src/diagnostics_overlay.rs
@@ -66,7 +66,9 @@ type StandardMaterialAllocator = MaterialAllocatorDiagnosticPlugin<StandardMater
 /// ```
 ///
 /// A [`DiagnosticsOverlay`] entity will be managed by [`DiagnosticsOverlayPlugin`],
-/// and be added as a child of the [`DiagnosticsOverlayPlane`].
+/// and be added as a child of the [`DiagnosticsOverlayPlane`]. To work properly,
+/// the entity must be spawned [`after`](bevy_ecs::schedule::IntoScheduleConfigs::after)
+/// [`DiagnosticsOverlaySystems::Setup`].
 ///
 /// If any value is showing as `Missing`, means that the [`DiagnosticPath`] is not registered,
 /// so make sure that the plugin that writes to it is properly set up.

--- a/crates/bevy_dev_tools/src/diagnostics_overlay.rs
+++ b/crates/bevy_dev_tools/src/diagnostics_overlay.rs
@@ -67,8 +67,7 @@ type StandardMaterialAllocator = MaterialAllocatorDiagnosticPlugin<StandardMater
 ///
 /// A [`DiagnosticsOverlay`] entity will be managed by [`DiagnosticsOverlayPlugin`],
 /// and be added as a child of the [`DiagnosticsOverlayPlane`]. To work properly,
-/// the entity must be spawned [`after`](bevy_ecs::schedule::IntoScheduleConfigs::after)
-/// [`DiagnosticsOverlaySystems::Setup`].
+/// the entity must be spawned after [`DiagnosticsOverlaySystems::Setup`].
 ///
 /// If any value is showing as `Missing`, means that the [`DiagnosticPath`] is not registered,
 /// so make sure that the plugin that writes to it is properly set up.
@@ -214,8 +213,7 @@ impl DiagnosticsOverlayStatistic {
 pub enum DiagnosticsOverlaySystems {
     /// Runs in the [`Startup`] schedule.
     /// Sets up the [`DiagnosticsOverlayPlane`] that will parent all [`DiagnosticsOverlay`]s.
-    /// Ensure that any [`DiagnosticsOverlay`]s are spawned
-    /// [`after`](bevy_ecs::schedule::IntoScheduleConfigs::after) this system.
+    /// Ensure that any [`DiagnosticsOverlay`]s are spawned after this system.
     Setup,
     /// Rebuild the contents of the [`DiagnosticsOverlay`] entities
     Rebuild,


### PR DESCRIPTION
# Objective

- Fixes #24377 
- One of the regressions was already fixed by #24019 . The other regression (caused seemingly by merely adding TransformGizmo functionality) revealed a potential system ordering issue when using the `DiagnosticsOverlayPlugin`: If one setups `DiagnosticsOverlay`s in the `Startup` schedule, the `build_overlays` observer could fail silently because the `DiagnosticsOverlayPlane` (which is also created in the `Startup` schedule) may not have been created yet.

## Solution

Move the system that sets up the`DiagnosticsOverlayPlane` into the `PreStartup` schedule.

## Testing

- Copied the “What I did” section in https://github.com/bevyengine/bevy/issues/24377 (`cargo run --release --example scene_viewer --features="free_camera bevy_dev_tools" assets/models/FlightHelmet/FlightHelmet.gltf` after the scene_viewer has been modified as described). The overlay now appears and works correctly.