### PR TITLE
Feature: add AnimationEventView and events_iter for viewing AnimationClip events

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -214,13 +214,46 @@ impl Hash for AnimationTargetId {
 #[reflect(Component, Clone)]
 pub struct AnimatedBy(#[entities] pub Entity);
 
+/// A read-only projection of an animation event.
+///
+/// Use this when you need to manually inspect or trigger animation events
+/// outside of the standard animation playback system.
+pub struct AnimationEventView {
+    /// The target bone or entity associated with the event.
+    /// [`None`] means no specific bone was targeted.
+    pub animation_target_id: Option<AnimationTargetId>,
+    /// The timestamp (in seconds) at which this event is configured to trigger.
+    pub trigger_time: f32,
+    /// The function that this animation event would run
+    pub trigger_fn: Arc<dyn Fn(&mut Commands, Entity, f32, f32) + Send + Sync>,
+}
+
 impl AnimationClip {
     #[inline]
     /// [`VariableCurve`]s for each animation target. Indexed by the [`AnimationTargetId`].
     pub fn curves(&self) -> &AnimationCurves {
         &self.curves
     }
-
+    /// Returns an iterator over all animation events in this clip.
+    ///
+    /// Generally should not be used unless existing animation events need to be manually triggered
+    /// for some reason.
+    ///
+    /// The iterator yields [`AnimationEventView`], which provide access
+    /// to the target, timing, and trigger function of each event.
+    pub fn events_iter(&self) -> impl Iterator<Item = AnimationEventView> + '_ {
+        self.events.iter().flat_map(|(k, events)| {
+            let id = match k {
+                AnimationEventTarget::Root => None,
+                AnimationEventTarget::Node(node) => Some(*node),
+            };
+            events.iter().map(move |event| AnimationEventView {
+                animation_target_id: id,
+                trigger_time: event.time,
+                trigger_fn: event.event.trigger.0.clone(),
+            })
+        })
+    }
     #[inline]
     /// Get mutable references of [`VariableCurve`]s for each animation target. Indexed by the [`AnimationTargetId`].
     pub fn curves_mut(&mut self) -> &mut AnimationCurves {

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -216,7 +216,7 @@ pub struct AnimatedBy(#[entities] pub Entity);
 
 /// A read-only projection of an animation event.
 ///
-/// Use this when you need to manually inspect or trigger animation events
+/// Use this when you need to manually inspect animation events and run their designated functions
 /// outside of the standard animation playback system.
 pub struct AnimationEventView {
     /// The target bone or entity associated with the event.


### PR DESCRIPTION
# Objective
A system needs to play animations starting at a certain time, but sometimes you don't want to skip the animation events that came before.

For example, a sword unsheathing should always play the unsheath sound, but sometimes the animation is played from a bit further into the unsheathing for a different starting pose.

## Solution
This PR gives a "view" into the animation events, so that if someone needs to manually trigger them, they can. It's a bit awkward to use since it copies the internal trigger fn, but it's still useful enough that it seems worth adding.

## Testing

I stuck this code into the animation_events example and it reliably manually triggers both animation events every 0.4 seconds.

```
fn debug_animations(
    animations: Res<Assets<AnimationClip>>,
    mut commands: Commands,
    mut timer: Local<f32>,
    time: Res<Time>,
) {
    *timer += time.delta_secs();
    if *timer > 0.4 {
        *timer = 0.0;
        for (_id, animation_clip) in animations.iter() {
            let views = animation_clip.events_iter();
            for view in views {
                dbg!(view.animation_target_id);
                dbg!(view.trigger_time);
                (view.trigger_fn)(&mut commands, Entity::PLACEHOLDER, view.trigger_time, 1.0);
            }
        }
    }
}
```


I understand this is a bit unwieldy, but this seems like an important thing to be able to access.
