### PR TITLE
Fix cut and paste error in UntypedHandle docs

### DIFF
--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -560,7 +560,7 @@ impl UntypedHandle {
         handle
     }
 
-    /// Converts to a typed Handle. This will panic if the internal [`TypeId`] does not match the given asset type `A`
+    /// Converts to a typed Handle if the internal [`TypeId`] matches the given asset type `A`.
     #[inline]
     pub fn try_typed<A: Asset>(self) -> Result<Handle<A>, UntypedAssetConversionError> {
         Handle::try_from(self)

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -20,7 +20,7 @@ use tracing::warn;
 /// Provides the computed size and layout properties of a UI [`Node`].
 ///
 /// All of the fields are automatically calculated by [`ui_layout_system`](`super::layout::ui_layout_system`)
-/// during `PostUpdate` in the [`UiSystems::Layout`](super::UiSystems) set..
+/// during `PostUpdate` in the [`UiSystems::Layout`](super::UiSystems) set.
 ///
 /// The fields are measured in physical pixels.
 /// You can multiply by the `inverse_scale_factor` field to convert back to logical pixels.


### PR DESCRIPTION
# Objective

`UntypedHandle::try_typed` docs are inaccurate. Fix them.

## Solution

Describe what the method really does.

## Testing

`cargo doc -p bevy_asset` and look at the docs