### PR TITLE
Replace unnecessary `FromTemplate` with `Default + Clone`.

### DIFF
--- a/crates/bevy_sprite_render/src/tilemap_chunk/mod.rs
+++ b/crates/bevy_sprite_render/src/tilemap_chunk/mod.rs
@@ -127,7 +127,7 @@ impl Default for TileData {
 
 /// Component storing the data of tiles within a chunk.
 /// Each index corresponds to a specific tile in the tileset. `None` indicates an empty tile.
-#[derive(Component, Clone, Debug, Deref, DerefMut, Reflect, FromTemplate)]
+#[derive(Component, Clone, Debug, Deref, DerefMut, Reflect, Default)]
 #[reflect(Component, Clone, Debug)]
 pub struct TilemapChunkTileData(pub Vec<Option<TileData>>);
 

--- a/crates/bevy_ui_widgets/src/scrollbar.rs
+++ b/crates/bevy_ui_widgets/src/scrollbar.rs
@@ -74,7 +74,7 @@ pub struct Scrollbar {
 /// A `ScrollbarThumb` UI node does not have a `Node` component. It only has `Border` and `BorderRadius` styling properties.
 /// Its layout is handled after `ui_layout_system` in `update_scroll_thumb` so that its size and position can be set relative to the scrolling area's
 /// size and scroll position.
-#[derive(Component, FromTemplate, Debug, Default)]
+#[derive(Component, Clone, Debug, Default)]
 #[require(
     ScrollbarDragState,
     ComputedNode,


### PR DESCRIPTION
# Objective

- Fixes #24416.
- Deriving `Default + Clone` is preferred over deriving `FromTemplate` when constructing the component doesn't refer to world/spawn context according to the documents of `FromTemplate`.

## Solution

- I searched across repository, `ScrollbarThumb` is another type that derives `FromTemplate` while all its fields are `Default + Clone`.
- Replace `FromTemplate` with `Default + Clone` on those types.

