### PR TITLE
Add missing `#[derive(Reflect)]` to ui crates

### DIFF
--- a/crates/bevy_feathers/src/controls/button.rs
+++ b/crates/bevy_feathers/src/controls/button.rs
@@ -56,6 +56,8 @@ pub enum ButtonVariant {
 ///  These events can be disabled by adding an [`bevy_ui::InteractionDisabled`] component to the entity
 #[derive(SceneComponent, Default, Clone)]
 #[scene(FeathersButtonProps)]
+#[derive(Reflect)]
+#[reflect(Component, Clone, Default)]
 pub struct FeathersButton;
 
 /// Props used to construct a [`FeathersButton`] scene.
@@ -119,8 +121,9 @@ impl FeathersButton {
 ///     * the ENTER or SPACE key is pressed while the button has keyboard focus.
 ///
 ///  These events can be disabled by adding an [`bevy_ui::InteractionDisabled`] component to the entity
-#[derive(SceneComponent, Default, Clone)]
+#[derive(SceneComponent, Default, Clone, Reflect)]
 #[scene(FeathersButtonProps)]
+#[reflect(Component, Clone, Default)]
 pub struct FeathersToolButton;
 
 impl FeathersToolButton {

--- a/crates/bevy_feathers/src/controls/button.rs
+++ b/crates/bevy_feathers/src/controls/button.rs
@@ -121,8 +121,9 @@ impl FeathersButton {
 ///     * the ENTER or SPACE key is pressed while the button has keyboard focus.
 ///
 ///  These events can be disabled by adding an [`bevy_ui::InteractionDisabled`] component to the entity
-#[derive(SceneComponent, Default, Clone, Reflect)]
+#[derive(SceneComponent, Default, Clone)]
 #[scene(FeathersButtonProps)]
+#[derive(Reflect)]
 #[reflect(Component, Clone, Default)]
 pub struct FeathersToolButton;
 

--- a/crates/bevy_feathers/src/controls/checkbox.rs
+++ b/crates/bevy_feathers/src/controls/checkbox.rs
@@ -43,8 +43,9 @@ use crate::{
 /// * [`bevy_ui_widgets::ValueChange<bool>`] with the new value when the checkbox changes state.
 ///
 ///  These events can be disabled by adding an [`bevy_ui::InteractionDisabled`] component to the entity
-#[derive(SceneComponent, FromTemplate, Reflect)]
+#[derive(SceneComponent, FromTemplate)]
 #[scene(FeathersCheckboxProps)]
+#[derive(Reflect)]
 #[reflect(Component)]
 pub struct FeathersCheckbox;
 

--- a/crates/bevy_feathers/src/controls/checkbox.rs
+++ b/crates/bevy_feathers/src/controls/checkbox.rs
@@ -43,8 +43,9 @@ use crate::{
 /// * [`bevy_ui_widgets::ValueChange<bool>`] with the new value when the checkbox changes state.
 ///
 ///  These events can be disabled by adding an [`bevy_ui::InteractionDisabled`] component to the entity
-#[derive(SceneComponent, FromTemplate)]
+#[derive(SceneComponent, FromTemplate, Reflect)]
 #[scene(FeathersCheckboxProps)]
+#[reflect(Component)]
 pub struct FeathersCheckbox;
 
 /// Props used to construct a [`FeathersCheckbox`] scene.

--- a/crates/bevy_feathers/src/controls/color_slider.rs
+++ b/crates/bevy_feathers/src/controls/color_slider.rs
@@ -157,8 +157,9 @@ pub struct SliderBaseColor(pub Color);
 /// * [`bevy_ui_widgets::ValueChange<f32>`] when the slider value is changed.
 ///
 ///  These events can be disabled by adding an [`bevy_ui::InteractionDisabled`] component to the entity
-#[derive(SceneComponent, Default, Clone, Reflect)]
+#[derive(SceneComponent, Default, Clone)]
 #[scene(FeathersColorSliderProps)]
+#[derive(Reflect)]
 #[reflect(Component, Default, Clone)]
 pub struct FeathersColorSlider;
 
@@ -181,8 +182,9 @@ impl Default for FeathersColorSliderProps {
 }
 
 /// A color slider widget.
-#[derive(Component, Default, Clone, Reflect)]
+#[derive(Component, Default, Clone)]
 #[require(Slider, SliderBaseColor(Color::WHITE))]
+#[derive(Reflect)]
 #[reflect(Component, Default, Clone)]
 pub struct ColorSlider {
     /// Which channel is being edited by this slider.

--- a/crates/bevy_feathers/src/controls/color_slider.rs
+++ b/crates/bevy_feathers/src/controls/color_slider.rs
@@ -10,12 +10,15 @@ use bevy_ecs::{
     entity::Entity,
     hierarchy::Children,
     query::{Changed, Or, With},
+    reflect::ReflectComponent,
     schedule::IntoScheduleConfigs,
     system::Query,
 };
 use bevy_input_focus::tab_navigation::TabIndex;
 use bevy_log::warn_once;
 use bevy_picking::PickingSystems;
+use bevy_reflect::std_traits::ReflectDefault;
+use bevy_reflect::Reflect;
 use bevy_scene::prelude::*;
 use bevy_ui::{
     percent, px, AlignItems, BackgroundColor, BackgroundGradient, BorderColor, BorderRadius,
@@ -41,7 +44,8 @@ const TRACK_RADIUS: f32 = SLIDER_HEIGHT * 0.5 - TRACK_PADDING;
 const THUMB_SIZE: f32 = SLIDER_HEIGHT - 2.0;
 
 /// Indicates which color channel we want to edit.
-#[derive(Component, Default, Copy, Clone)]
+#[derive(Component, Default, Copy, Clone, Reflect)]
+#[reflect(Component, Default, Clone)]
 pub enum ColorChannel {
     /// Editing the RGB red channel (0..=1)
     #[default]
@@ -140,7 +144,8 @@ impl ColorChannel {
 
 /// Used to store the color channels that we are not editing: the components of the color
 /// that are constant for this slider.
-#[derive(Component, Default, Clone)]
+#[derive(Component, Default, Clone, Reflect)]
+#[reflect(Component, Default, Clone)]
 pub struct SliderBaseColor(pub Color);
 
 /// A color slider widget.
@@ -152,8 +157,9 @@ pub struct SliderBaseColor(pub Color);
 /// * [`bevy_ui_widgets::ValueChange<f32>`] when the slider value is changed.
 ///
 ///  These events can be disabled by adding an [`bevy_ui::InteractionDisabled`] component to the entity
-#[derive(SceneComponent, Default, Clone)]
+#[derive(SceneComponent, Default, Clone, Reflect)]
 #[scene(FeathersColorSliderProps)]
+#[reflect(Component, Default, Clone)]
 pub struct FeathersColorSlider;
 
 /// Props used to construct a [`FeathersColorSlider`] scene.
@@ -175,19 +181,22 @@ impl Default for FeathersColorSliderProps {
 }
 
 /// A color slider widget.
-#[derive(Component, Default, Clone)]
+#[derive(Component, Default, Clone, Reflect)]
 #[require(Slider, SliderBaseColor(Color::WHITE))]
+#[reflect(Component, Default, Clone)]
 pub struct ColorSlider {
     /// Which channel is being edited by this slider.
     pub channel: ColorChannel,
 }
 
 /// Marker for the track
-#[derive(Component, Default, Clone)]
+#[derive(Component, Default, Clone, Reflect)]
+#[reflect(Component, Default, Clone)]
 struct ColorSliderTrack;
 
 /// Marker for the thumb
-#[derive(Component, Default, Clone)]
+#[derive(Component, Default, Clone, Reflect)]
+#[reflect(Component, Default, Clone)]
 struct ColorSliderThumb;
 
 impl FeathersColorSlider {

--- a/crates/bevy_feathers/src/controls/disclosure_toggle.rs
+++ b/crates/bevy_feathers/src/controls/disclosure_toggle.rs
@@ -3,12 +3,15 @@ use bevy_ecs::{
     hierarchy::Children,
     lifecycle::RemovedComponents,
     query::{Added, Has, Or, With},
+    reflect::ReflectComponent,
     schedule::IntoScheduleConfigs,
     system::{Query, Res},
 };
 use bevy_input_focus::tab_navigation::TabIndex;
 use bevy_math::Rot2;
 use bevy_picking::PickingSystems;
+use bevy_reflect::std_traits::ReflectDefault;
+use bevy_reflect::Reflect;
 use bevy_scene::{bsn, Scene, SceneComponent};
 use bevy_ui::{
     px, widget::ImageNode, AlignItems, Checked, Display, InteractionDisabled, JustifyContent, Node,
@@ -27,7 +30,8 @@ use crate::{
 /// state.
 ///
 /// This is spawnable by inheriting it as a "scene component".
-#[derive(SceneComponent, Default, Clone)]
+#[derive(SceneComponent, Default, Clone, Reflect)]
+#[reflect(Component, Default, Clone)]
 pub struct FeathersDisclosureToggle;
 
 impl FeathersDisclosureToggle {

--- a/crates/bevy_feathers/src/controls/menu.rs
+++ b/crates/bevy_feathers/src/controls/menu.rs
@@ -8,11 +8,14 @@ use bevy_ecs::{
     lifecycle::RemovedComponents,
     observer::On,
     query::{Added, Changed, Has, Or, With},
+    reflect::ReflectComponent,
     schedule::IntoScheduleConfigs,
     system::{Commands, Query, Res, ResMut},
 };
 use bevy_log::warn;
 use bevy_picking::{hover::Hovered, PickingSystems};
+use bevy_reflect::std_traits::ReflectDefault;
+use bevy_reflect::Reflect;
 use bevy_scene::prelude::*;
 use bevy_text::FontWeight;
 use bevy_ui::{
@@ -42,7 +45,8 @@ use bevy_input_focus::{
 /// Top-level menu container. This wraps the menu button and provides an anchor for the popover.
 ///
 /// This is spawnable by inheriting it as a "scene component".
-#[derive(SceneComponent, Clone, Default)]
+#[derive(SceneComponent, Clone, Default, Reflect)]
+#[reflect(Component, Default, Clone)]
 pub struct FeathersMenu;
 
 impl FeathersMenu {
@@ -134,6 +138,8 @@ fn on_menu_event(
 /// This is spawnable by inheriting it as a "scene component" with optional [`FeathersMenuButtonProps`].
 #[derive(SceneComponent, Default, Clone)]
 #[scene(FeathersMenuButtonProps)]
+#[derive(Reflect)]
+#[reflect(Component, Default, Clone)]
 pub struct FeathersMenuButton;
 
 /// Props used to construct a [`FeathersMenuButton`] scene.
@@ -186,7 +192,8 @@ impl FeathersMenuButton {
 }
 
 /// A menu popup widget.
-#[derive(SceneComponent, Default, Clone)]
+#[derive(SceneComponent, Default, Clone, Reflect)]
+#[reflect(Component, Default, Clone)]
 pub struct FeathersMenuPopup;
 
 impl FeathersMenuPopup {
@@ -240,6 +247,8 @@ impl FeathersMenuPopup {
 /// This is spawnable by inheriting it as a "scene component" with optional [`FeathersMenuItemProps`].
 #[derive(SceneComponent, Default, Clone)]
 #[scene(FeathersMenuItemProps)]
+#[derive(Reflect)]
+#[reflect(Component, Default, Clone)]
 pub struct FeathersMenuItem;
 
 /// Props used to construct a [`FeathersMenuItem`] scene.
@@ -427,7 +436,8 @@ fn set_menuitem_colors(
 }
 
 /// A decorative divider between menu items
-#[derive(SceneComponent, Default, Clone)]
+#[derive(SceneComponent, Default, Clone, Reflect)]
+#[reflect(Component, Default, Clone)]
 pub struct FeathersMenuDivider;
 
 impl FeathersMenuDivider {

--- a/crates/bevy_feathers/src/controls/number_input.rs
+++ b/crates/bevy_feathers/src/controls/number_input.rs
@@ -6,12 +6,15 @@ use bevy_ecs::{
     hierarchy::{ChildOf, Children},
     observer::On,
     query::With,
+    reflect::{ReflectComponent, ReflectEvent},
     relationship::Relationship,
     system::{Commands, Query, Res},
 };
 use bevy_input::keyboard::{KeyCode, KeyboardInput};
 use bevy_input_focus::{FocusLost, FocusedInput, InputFocus};
 use bevy_log::warn;
+use bevy_reflect::std_traits::ReflectDefault;
+use bevy_reflect::Reflect;
 use bevy_scene::prelude::*;
 use bevy_text::{
     EditableText, EditableTextFilter, FontSourceTemplate, FontWeight, TextEdit, TextEditChange,
@@ -50,6 +53,8 @@ use crate::{
 // TODO: Add text_input field validation when it becomes available.
 #[derive(SceneComponent, Default, Clone)]
 #[scene(FeathersNumberInputProps)]
+#[derive(Reflect)]
+#[reflect(Component, Default, Clone)]
 pub struct FeathersNumberInput;
 
 /// Props used to construct a [`FeathersNumberInput`] scene.
@@ -125,7 +130,8 @@ impl FeathersNumberInput {
 
 /// Used to indicate what format of numbers we are editing. This primarily affects the type
 /// of [`ValueChange`] event that is emitted.
-#[derive(Component, Default, Clone, Copy)]
+#[derive(Component, Default, Clone, Copy, Reflect)]
+#[reflect(Component, Default, Clone)]
 pub enum NumberFormat {
     /// A 32-bit float
     #[default]
@@ -139,7 +145,7 @@ pub enum NumberFormat {
 }
 
 /// Represents numbers in different formats.
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone, Copy, Reflect)]
 pub enum NumberInputValue {
     /// An f32 value
     F32(f32),
@@ -163,7 +169,8 @@ impl core::fmt::Display for NumberInputValue {
 }
 
 /// Event which can be sent to the number input widget to update the displayed value.
-#[derive(Clone, EntityEvent)]
+#[derive(Clone, EntityEvent, Reflect)]
+#[reflect(Event, Clone)]
 pub struct UpdateNumberInput {
     /// Target widget
     pub entity: Entity,

--- a/crates/bevy_feathers/src/controls/radio.rs
+++ b/crates/bevy_feathers/src/controls/radio.rs
@@ -44,6 +44,8 @@ use crate::{
 ///  These events can be disabled by adding an [`bevy_ui::InteractionDisabled`] component to the entity
 #[derive(SceneComponent, Default, Clone)]
 #[scene(FeathersRadioProps)]
+#[derive(Reflect)]
+#[reflect(Component, Default, Clone)]
 pub struct FeathersRadio;
 
 /// Props used to construct a [`FeathersRadio`] scene.

--- a/crates/bevy_feathers/src/controls/text_input.rs
+++ b/crates/bevy_feathers/src/controls/text_input.rs
@@ -5,12 +5,15 @@ use bevy_ecs::{
     entity::Entity,
     lifecycle::RemovedComponents,
     query::{Added, Has, With},
+    reflect::ReflectComponent,
     schedule::IntoScheduleConfigs,
     system::{Commands, Query, Res},
     template::template,
 };
 use bevy_input_focus::tab_navigation::TabIndex;
 use bevy_picking::PickingSystems;
+use bevy_reflect::std_traits::ReflectDefault;
+use bevy_reflect::Reflect;
 use bevy_scene::prelude::*;
 use bevy_text::{
     EditableText, FontSource, FontWeight, LineBreak, TextCursorStyle, TextFont, TextLayout,
@@ -32,7 +35,8 @@ use crate::{
 /// (such as "search" or "clear") to be inserted adjacent to the input.
 ///
 /// This is spawnable by inheriting it as a "scene component".
-#[derive(SceneComponent, Default, Clone)]
+#[derive(SceneComponent, Default, Clone, Reflect)]
+#[reflect(Component, Default, Clone)]
 pub struct FeathersTextInputContainer;
 
 impl FeathersTextInputContainer {
@@ -78,6 +82,8 @@ impl FeathersTextInputContainer {
 /// ```
 #[derive(SceneComponent, Default, Clone)]
 #[scene(FeathersTextInputProps)]
+#[derive(Reflect)]
+#[reflect(Component, Default, Clone)]
 pub struct FeathersTextInput;
 
 /// Props used to construct the [`FeathersTextInput`] scene.

--- a/crates/bevy_feathers/src/controls/virtual_keyboard.rs
+++ b/crates/bevy_feathers/src/controls/virtual_keyboard.rs
@@ -2,6 +2,7 @@ use core::marker::PhantomData;
 
 use bevy_ecs::prelude::*;
 use bevy_input_focus::tab_navigation::TabGroup;
+use bevy_reflect::Reflect;
 use bevy_scene::prelude::*;
 use bevy_ui::{px, widget::Text, FlexDirection, Node};
 use bevy_ui_widgets::{observe, Activate};
@@ -18,6 +19,8 @@ use crate::controls::{button::ButtonBundleProps, button_bundle, FeathersButton};
 ///  These events can be disabled by adding an [`bevy_ui::InteractionDisabled`] component to the entity
 #[derive(SceneComponent, FromTemplate)]
 #[scene(VirtualKeyboardProps<T>)]
+#[derive(Reflect)]
+#[reflect(Component)]
 pub struct VirtualKeyboard<T: AsRef<str> + Clone + Send + Sync + 'static>(PhantomData<fn() -> T>);
 
 /// Props used to construct the [`VirtualKeyboard`] scene.
@@ -87,7 +90,8 @@ impl<T: AsRef<str> + Clone + Send + Sync + 'static> VirtualKeyboard<T> {
 }
 
 /// Fired whenever a virtual key is pressed.
-#[derive(EntityEvent)]
+#[derive(EntityEvent, Reflect)]
+#[reflect(Event)]
 pub struct VirtualKeyPressed<T> {
     /// The virtual keyboard entity
     pub entity: Entity,

--- a/crates/bevy_feathers/src/cursor.rs
+++ b/crates/bevy_feathers/src/cursor.rs
@@ -45,6 +45,7 @@ pub enum EntityCursor {
 /// This is meant for cases like loading where you don't want the cursor to imply you
 /// can interact with something.
 #[derive(Deref, Resource, Debug, Clone, Default, Reflect)]
+#[reflect(Resource, Default, Clone, Debug)]
 pub struct OverrideCursor(pub Option<EntityCursor>);
 
 impl EntityCursor {

--- a/crates/bevy_input_focus/src/gained_and_lost.rs
+++ b/crates/bevy_input_focus/src/gained_and_lost.rs
@@ -28,6 +28,11 @@ pub enum FocusCause {
 /// This event bubbles up the entity hierarchy, so if a child entity gains focus, its parents will also receive this event.
 #[derive(EntityEvent, Debug, Clone)]
 #[entity_event(auto_propagate)]
+#[cfg_attr(
+    feature = "bevy_reflect",
+    derive(Reflect),
+    reflect(Event, Debug, Clone)
+)]
 pub struct FocusGained {
     /// The entity that gained focus
     pub entity: Entity,
@@ -40,6 +45,11 @@ pub struct FocusGained {
 /// This event bubbles up the entity hierarchy, so if a child entity loses focus, its parents will also receive this event.
 #[derive(EntityEvent, Debug, Clone)]
 #[entity_event(auto_propagate)]
+#[cfg_attr(
+    feature = "bevy_reflect",
+    derive(Reflect),
+    reflect(Event, Debug, Clone)
+)]
 pub struct FocusLost {
     /// The entity that lost focus.
     pub entity: Entity,

--- a/crates/bevy_input_focus/src/lib.rs
+++ b/crates/bevy_input_focus/src/lib.rs
@@ -184,7 +184,11 @@ pub struct InputFocusVisible(pub bool);
 /// in the [`InputFocusSystems::Dispatch`] system set during [`PreUpdate`].
 #[derive(EntityEvent, Clone, Debug, Component)]
 #[entity_event(propagate = WindowTraversal, auto_propagate)]
-#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Component, Clone))]
+#[cfg_attr(
+    feature = "bevy_reflect",
+    derive(Reflect),
+    reflect(Event, Component, Clone)
+)]
 pub struct FocusedInput<M: Message + Clone> {
     /// The entity that has received focused input.
     #[event_target]
@@ -199,6 +203,11 @@ pub struct FocusedInput<M: Message + Clone> {
 /// until it finds a focusable entity, and then set focus to it.
 #[derive(EntityEvent, Debug, Clone)]
 #[entity_event(propagate = WindowTraversal, auto_propagate)]
+#[cfg_attr(
+    feature = "bevy_reflect",
+    derive(Reflect),
+    reflect(Event, Clone, Debug)
+)]
 pub struct AcquireFocus {
     /// The entity that has acquired focus.
     #[event_target]

--- a/crates/bevy_input_focus/src/tab_navigation.rs
+++ b/crates/bevy_input_focus/src/tab_navigation.rs
@@ -102,6 +102,11 @@ impl TabGroup {
 ///
 /// These values are consumed by the [`TabNavigation`] system param.
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(
+    feature = "bevy_reflect",
+    derive(Reflect),
+    reflect(Debug, Clone, PartialEq)
+)]
 pub enum NavAction {
     /// Navigate to the next focusable entity, wrapping around to the beginning if at the end.
     ///

--- a/crates/bevy_ui/src/interaction_states.rs
+++ b/crates/bevy_ui/src/interaction_states.rs
@@ -4,8 +4,11 @@ use bevy_ecs::{
     component::Component,
     lifecycle::{Add, Remove},
     observer::On,
+    reflect::ReflectComponent,
     world::DeferredWorld,
 };
+use bevy_reflect::std_traits::ReflectDefault;
+use bevy_reflect::Reflect;
 
 /// A component indicating that a widget is disabled and should be "grayed out".
 /// This is used to prevent user interaction with the widget. It should not, however, prevent
@@ -15,7 +18,8 @@ use bevy_ecs::{
 /// the `InteractionDisabled` component should be added to the root entity of the widget - the
 /// same entity that contains the `AccessibilityNode` component. This will ensure that
 /// the a11y tree is updated correctly.
-#[derive(Component, Debug, Clone, Copy, Default)]
+#[derive(Component, Debug, Clone, Copy, Default, Reflect)]
+#[reflect(Component, Default, Clone)]
 pub struct InteractionDisabled;
 
 pub(crate) fn on_add_disabled(add: On<Add, InteractionDisabled>, mut world: DeferredWorld) {
@@ -37,15 +41,18 @@ pub(crate) fn on_remove_disabled(
 
 /// Component that indicates whether a button or widget is currently in a pressed or "held down"
 /// state.
-#[derive(Component, Debug, Clone, Copy, Default)]
+#[derive(Component, Debug, Clone, Copy, Default, Reflect)]
+#[reflect(Component, Default, Clone)]
 pub struct Pressed;
 
 /// Component that indicates that a widget can be checked.
-#[derive(Component, Debug, Clone, Copy, Default)]
+#[derive(Component, Debug, Clone, Copy, Default, Reflect)]
+#[reflect(Component, Default, Clone)]
 pub struct Checkable;
 
 /// Component that indicates whether a checkbox or radio button is in a checked state.
-#[derive(Component, Debug, Clone, Copy, Default)]
+#[derive(Component, Debug, Clone, Copy, Default, Reflect)]
+#[reflect(Component, Default, Clone)]
 pub struct Checked;
 
 pub(crate) fn on_add_checkable(add: On<Add, Checkable>, mut world: DeferredWorld) {

--- a/crates/bevy_ui/src/stack.rs
+++ b/crates/bevy_ui/src/stack.rs
@@ -6,20 +6,24 @@ use crate::{
 };
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{entity::EntityHashSet, prelude::*};
+use bevy_reflect::std_traits::ReflectDefault;
+use bevy_reflect::Reflect;
 use core::ops::Range;
 
 /// The order of the node in the UI layout.
 /// Nodes with a higher stack index are drawn on top of and receive interactions before nodes with lower stack indices.
 ///
 /// Automatically calculated in [`UiSystems::Stack`](`super::UiSystems::Stack`).
-#[derive(Component, Default, PartialEq, Eq, Deref, DerefMut)]
+#[derive(Component, Default, PartialEq, Eq, Deref, DerefMut, Reflect)]
+#[reflect(Component, Default)]
 pub struct ComputedStackIndex(pub u32);
 
 /// The current UI stack, which contains all UI nodes ordered by their depth (back-to-front).
 ///
 /// The first entry is the furthest node from the camera and is the first one to get rendered
 /// while the last entry is the first node to receive interactions.
-#[derive(Debug, Resource, Default)]
+#[derive(Debug, Resource, Default, Reflect)]
+#[reflect(Resource, Default)]
 pub struct UiStack {
     /// Partition of the `uinodes` list into disjoint slices of nodes that all share the same camera target.
     pub partition: Vec<Range<usize>>,

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -2408,7 +2408,8 @@ pub struct CalculatedClip {
 
 /// UI node entities with this component will ignore any clipping rect they inherit,
 /// the node will not be clipped regardless of its ancestors' `Overflow` setting.
-#[derive(Component, Clone, Default)]
+#[derive(Component, Clone, Default, Reflect)]
+#[reflect(Component, Default, Clone)]
 pub struct OverrideClip;
 
 #[expect(
@@ -2969,7 +2970,8 @@ impl UiTargetCamera {
 ///     ));
 /// }
 /// ```
-#[derive(Component, Default)]
+#[derive(Component, Default, Reflect)]
+#[reflect(Component, Default)]
 pub struct IsDefaultUiCamera;
 
 #[derive(SystemParam)]
@@ -3064,7 +3066,8 @@ impl ComputedUiRenderTargetInfo {
 /// A `FixedNode` UI entity is positioned relative to the target camera's viewport rather that its parent element.
 ///
 /// `FixedNode`s don't inherit their parent's layout, clipping or transform context.
-#[derive(Component, Clone, Default)]
+#[derive(Component, Clone, Default, Reflect)]
+#[reflect(Component, Default, Clone)]
 #[require(Node, OverrideClip)]
 pub struct FixedNode;
 

--- a/crates/bevy_ui/src/widget/text_input_layout.rs
+++ b/crates/bevy_ui/src/widget/text_input_layout.rs
@@ -8,6 +8,7 @@ use bevy_ecs::{
     change_detection::{DetectChanges, DetectChangesMut},
     component::Component,
     entity::Entity,
+    reflect::ReflectComponent,
     system::{Local, Query, Res, ResMut},
     world::Ref,
 };
@@ -15,6 +16,8 @@ use bevy_image::prelude::*;
 use bevy_input_focus::InputFocus;
 use bevy_math::{Rect, Vec2};
 use bevy_platform::hash::FixedHasher;
+use bevy_reflect::std_traits::ReflectDefault;
+use bevy_reflect::Reflect;
 use bevy_text::{
     add_glyph_to_atlas, get_glyph_atlas_info, resolve_font_source, EditableText,
     EditableTextGeneration, Font, FontAtlasKey, FontAtlasSet, FontCx, FontHinting, FontSize,
@@ -26,7 +29,8 @@ use parley::{BoundingBox, PositionedLayoutItem, StyleProperty};
 use swash::FontRef;
 use taffy::MaybeMath;
 
-#[derive(Component, Clone, Copy, PartialEq, Debug, Default)]
+#[derive(Component, Clone, Copy, PartialEq, Debug, Default, Reflect)]
+#[reflect(Component, Default, Clone)]
 pub struct TextScroll(pub Vec2);
 
 struct TextInputMeasure {

--- a/crates/bevy_ui_widgets/src/button.rs
+++ b/crates/bevy_ui_widgets/src/button.rs
@@ -7,12 +7,14 @@ use bevy_ecs::{
     entity::Entity,
     observer::On,
     query::With,
+    reflect::ReflectComponent,
     system::{Commands, Query},
 };
 use bevy_input::keyboard::{KeyCode, KeyboardInput};
 use bevy_input::ButtonState;
 use bevy_input_focus::FocusedInput;
 use bevy_picking::events::{Cancel, Click, DragEnd, Pointer, Press, Release};
+use bevy_reflect::Reflect;
 use bevy_ui::{InteractionDisabled, Pressed};
 
 use crate::Activate;
@@ -22,11 +24,14 @@ use crate::Activate;
 /// event when the button is un-pressed.
 #[derive(Component, Default, Debug, Clone)]
 #[require(AccessibilityNode(accesskit::Node::new(Role::Button)))]
+#[derive(Reflect)]
+#[reflect(Component)]
 pub struct Button;
 
 /// Optional marker component that indicates we want the button to activate on the pointer down
 /// event, this is used for menu buttons.
-#[derive(Component, Default, Debug, Clone)]
+#[derive(Component, Default, Debug, Clone, Reflect)]
+#[reflect(Component)]
 pub struct ActivateOnPress;
 
 fn button_on_key_event(

--- a/crates/bevy_ui_widgets/src/checkbox.rs
+++ b/crates/bevy_ui_widgets/src/checkbox.rs
@@ -7,12 +7,14 @@ use bevy_ecs::system::ResMut;
 use bevy_ecs::{
     component::Component,
     observer::On,
+    reflect::{ReflectComponent, ReflectEvent},
     system::{Commands, Query},
 };
 use bevy_input::keyboard::{KeyCode, KeyboardInput};
 use bevy_input::ButtonState;
 use bevy_input_focus::{FocusCause, FocusedInput, InputFocus, InputFocusVisible};
 use bevy_picking::events::{Cancel, Click, DragEnd, Pointer, Press, Release};
+use bevy_reflect::Reflect;
 use bevy_ui::{Checkable, Checked, InteractionDisabled, Pressed};
 
 use crate::{ActivateOnPress, ValueChange};
@@ -31,6 +33,8 @@ use bevy_ecs::entity::Entity;
 /// the `Switch` role instead of the `Checkbox` role.
 #[derive(Component, Debug, Default, Clone)]
 #[require(AccessibilityNode(accesskit::Node::new(Role::CheckBox)), Checkable)]
+#[derive(Reflect)]
+#[reflect(Component)]
 pub struct Checkbox;
 
 fn checkbox_on_key_input(
@@ -174,7 +178,8 @@ fn checkbox_on_pointer_cancel(
 ///     commands.trigger(SetChecked { entity, checked: true});
 /// }
 /// ```
-#[derive(EntityEvent)]
+#[derive(EntityEvent, Reflect)]
+#[reflect(Event)]
 pub struct SetChecked {
     /// The [`Checkbox`] entity to set the "checked" state on.
     pub entity: Entity,
@@ -201,7 +206,8 @@ pub struct SetChecked {
 ///     commands.trigger(ToggleChecked { entity });
 /// }
 /// ```
-#[derive(EntityEvent)]
+#[derive(EntityEvent, Reflect)]
+#[reflect(Event)]
 pub struct ToggleChecked {
     /// The [`Entity`] of the toggled [`Checkbox`]
     pub entity: Entity,

--- a/crates/bevy_ui_widgets/src/lib.rs
+++ b/crates/bevy_ui_widgets/src/lib.rs
@@ -46,7 +46,8 @@ pub use slider::*;
 pub use text_input::*;
 
 use bevy_app::{PluginGroup, PluginGroupBuilder};
-use bevy_ecs::{entity::Entity, event::EntityEvent};
+use bevy_ecs::{entity::Entity, event::EntityEvent, reflect::ReflectEvent};
+use bevy_reflect::Reflect;
 
 use crate::popover::PopoverPlugin;
 
@@ -70,14 +71,16 @@ impl PluginGroup for UiWidgetsPlugins {
 }
 
 /// Notification sent by a button or menu item.
-#[derive(Copy, Clone, Debug, PartialEq, EntityEvent)]
+#[derive(Copy, Clone, Debug, PartialEq, EntityEvent, Reflect)]
+#[reflect(Event)]
 pub struct Activate {
     /// The activated entity.
     pub entity: Entity,
 }
 
 /// Notification sent by a widget that edits a scalar value.
-#[derive(Copy, Clone, Debug, PartialEq, EntityEvent)]
+#[derive(Copy, Clone, Debug, PartialEq, EntityEvent, Reflect)]
+#[reflect(Event)]
 pub struct ValueChange<T> {
     /// The id of the widget that produced this value.
     #[event_target]

--- a/crates/bevy_ui_widgets/src/menu.rs
+++ b/crates/bevy_ui_widgets/src/menu.rs
@@ -38,6 +38,7 @@ use bevy_ecs::{
     hierarchy::ChildOf,
     observer::On,
     query::{Has, With},
+    reflect::{ReflectComponent, ReflectEvent},
     schedule::IntoScheduleConfigs,
     system::{Commands, Query, Res, ResMut},
 };
@@ -51,12 +52,13 @@ use bevy_input_focus::{
 };
 use bevy_log::warn;
 use bevy_picking::events::{Cancel, Click, DragEnd, Pointer, Press, Release};
+use bevy_reflect::Reflect;
 use bevy_ui::{widget::Button, InteractionDisabled, Pressed};
 
 use crate::{Activate, ActivateOnPress};
 
 /// Action type for [`MenuEvent`].
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Reflect)]
 pub enum MenuAction {
     /// Indicates we want to open the menu, if it is not already open, and focus the first or
     /// last item depending on the [`NavAction`].
@@ -74,6 +76,8 @@ pub enum MenuAction {
 /// and the menu container, through the portal relation, and to the menu owner entity.
 #[derive(EntityEvent, Clone, Debug)]
 #[entity_event(propagate, auto_propagate)]
+#[derive(Reflect)]
+#[reflect(Event)]
 pub struct MenuEvent {
     /// The [`MenuItem`] or [`MenuPopup`] that triggered this event.
     #[event_target]
@@ -84,7 +88,7 @@ pub struct MenuEvent {
 }
 
 /// Specifies the layout direction of the menu, for keyboard navigation
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, Reflect)]
 pub enum MenuLayout {
     /// A vertical stack. Up and down arrows to move between items.
     #[default]
@@ -116,6 +120,8 @@ pub enum MenuLayout {
     TabGroup::modal()
 )]
 #[require(MenuFocusState::Closed)]
+#[derive(Reflect)]
+#[reflect(Component)]
 pub struct MenuPopup {
     /// The layout orientation of the menu
     pub layout: MenuLayout,
@@ -124,11 +130,14 @@ pub struct MenuPopup {
 /// Component that defines a menu item.
 #[derive(Component, Debug, Clone, Default)]
 #[require(AccessibilityNode(accesskit::Node::new(Role::MenuItem)))]
+#[derive(Reflect)]
+#[reflect(Component)]
 pub struct MenuItem;
 
 /// Component used to manage focus on the popup. Menu popups remain open only so long as they
 /// contain focus.
-#[derive(Component, Debug, Clone, Default, PartialEq)]
+#[derive(Component, Debug, Clone, Default, PartialEq, Reflect)]
+#[reflect(Component)]
 pub enum MenuFocusState {
     /// A newly opened menu, which needs to have focus set to the first or last item depending on
     /// [`NavAction`].
@@ -402,6 +411,8 @@ fn menu_item_on_pointer_cancel(
     Button,
     ActivateOnPress
 )]
+#[derive(Reflect)]
+#[reflect(Component)]
 pub struct MenuButton;
 
 fn menubutton_on_activate(

--- a/crates/bevy_ui_widgets/src/popover.rs
+++ b/crates/bevy_ui_widgets/src/popover.rs
@@ -6,10 +6,12 @@ use bevy_ecs::{
     entity::Entity,
     hierarchy::{ChildOf, Children},
     query::Without,
+    reflect::ReflectComponent,
     schedule::IntoScheduleConfigs,
     system::{ParamSet, Query},
 };
 use bevy_math::{Affine2, Rect, Vec2};
+use bevy_reflect::Reflect;
 use bevy_ui::{
     ui_layout_system, ComputedNode, ComputedUiRenderTargetInfo, Node, PositionType,
     UiGlobalTransform, UiSystems, UiTransform, Val2,
@@ -18,7 +20,7 @@ use bevy_ui::{
 use crate::update_scrollbar_thumb;
 
 /// Which side of the parent element the popover element should be placed.
-#[derive(Debug, Default, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Reflect)]
 pub enum PopoverSide {
     /// The popover element should be placed above the parent.
     Top,
@@ -47,7 +49,7 @@ impl PopoverSide {
 /// axis that is perpendicular to the direction of the popover side. So for example, if the popup is
 /// positioned below the parent, then the [`PopoverAlign`] variant controls the horizontal alignment
 /// of the popup.
-#[derive(Debug, Default, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Reflect)]
 pub enum PopoverAlign {
     /// The starting edge of the popover element should be aligned to the starting edge of the
     /// parent.
@@ -64,7 +66,7 @@ pub enum PopoverAlign {
 /// sufficient space to display the popup without being clipped by the window edge. If any position
 /// has sufficient room, it will pick the first one; if there are none, then it will pick the least
 /// bad one.
-#[derive(Debug, Default, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Reflect)]
 pub struct PopoverPlacement {
     /// The side of the parent entity where the popover element should be placed.
     pub side: PopoverSide,
@@ -79,7 +81,8 @@ pub struct PopoverPlacement {
 
 /// Component which is inserted into a popover element to make it dynamically position relative to
 /// an parent element.
-#[derive(Component, PartialEq, Default)]
+#[derive(Component, PartialEq, Default, Reflect)]
+#[reflect(Component)]
 pub struct Popover {
     /// List of potential positions for the popover element relative to the parent.
     pub positions: Vec<PopoverPlacement>,

--- a/crates/bevy_ui_widgets/src/radio.rs
+++ b/crates/bevy_ui_widgets/src/radio.rs
@@ -37,6 +37,8 @@ use crate::{ActivateOnPress, ValueChange};
 /// within the group, it should never be the case that more than one button is selected at a time.
 #[derive(Component, Debug, Clone, Default)]
 #[require(AccessibilityNode(accesskit::Node::new(Role::RadioGroup)))]
+#[derive(Reflect)]
+#[reflect(Component)]
 pub struct RadioGroup;
 
 /// Headless widget implementation for radio buttons. They can be used independently,

--- a/crates/bevy_ui_widgets/src/slider.rs
+++ b/crates/bevy_ui_widgets/src/slider.rs
@@ -13,7 +13,7 @@ use bevy_ecs::{
     component::Component,
     observer::On,
     query::With,
-    reflect::ReflectComponent,
+    reflect::{ReflectComponent, ReflectEvent},
     system::{Commands, Query},
 };
 use bevy_input::keyboard::{KeyCode, KeyboardInput};
@@ -100,6 +100,8 @@ pub enum TrackClick {
     SliderRange,
     SliderStep
 )]
+#[derive(Reflect)]
+#[reflect(Component)]
 pub struct Slider {
     /// Set the track-clicking behavior for this slider.
     pub track_click: TrackClick,
@@ -108,17 +110,22 @@ pub struct Slider {
 }
 
 /// Marker component that identifies which descendant element is the slider thumb.
-#[derive(Component, Debug, Default, Clone)]
+#[derive(Component, Debug, Default, Clone, Reflect)]
+#[reflect(Component)]
 pub struct SliderThumb;
 
 /// A component which stores the current value of the slider.
 #[derive(Component, Debug, Default, PartialEq, Clone, Copy)]
 #[component(immutable)]
+#[derive(Reflect)]
+#[reflect(Component)]
 pub struct SliderValue(pub f32);
 
 /// A component which represents the allowed range of the slider value. Defaults to 0.0..=1.0.
 #[derive(Component, Debug, PartialEq, Clone, Copy)]
 #[component(immutable)]
+#[derive(Reflect)]
+#[reflect(Component)]
 pub struct SliderRange {
     /// The beginning of the allowed range for the slider value.
     start: f32,
@@ -663,7 +670,8 @@ pub(crate) fn slider_on_insert_step(insert: On<Insert, SliderStep>, mut world: D
 ///     });
 /// }
 /// ```
-#[derive(EntityEvent, Clone)]
+#[derive(EntityEvent, Clone, Reflect)]
+#[reflect(Event)]
 pub struct SetSliderValue {
     /// The slider entity to change.
     pub entity: Entity,
@@ -672,7 +680,7 @@ pub struct SetSliderValue {
 }
 
 /// The type of slider value change to apply in [`SetSliderValue`].
-#[derive(Clone)]
+#[derive(Clone, Reflect)]
 pub enum SliderValueChange {
     /// Set the slider value to a specific value.
     Absolute(f32),

--- a/crates/bevy_ui_widgets/src/text_input.rs
+++ b/crates/bevy_ui_widgets/src/text_input.rs
@@ -17,6 +17,7 @@ use bevy_input_focus::{
 use bevy_math::Vec2;
 use bevy_picking::events::{Drag, Pointer, Press, Release};
 use bevy_picking::pointer::PointerButton;
+use bevy_reflect::Reflect;
 use bevy_text::{EditableText, PreeditCursor, TextEdit};
 use bevy_ui::widget::{scroll_editable_text, update_editable_text_layout, TextScroll};
 use bevy_ui::UiSystems;
@@ -398,12 +399,14 @@ fn on_focus_lost_clear_ime(
 /// pointer release and is only applied if there is no other selection by then.
 /// For example, if pointer dragging caused a selection to be made, we don't want
 /// to replace it with a select all.
-#[derive(Component, Clone, Default)]
+#[derive(Component, Clone, Default, Reflect)]
+#[reflect(Component)]
 pub struct SelectAllOnFocus;
 
 /// Resource to track when a pointer press caused focus on an [`EditableText`].
 /// A corresponding pointer release will select all text if there is no other selection.
-#[derive(Resource, Default)]
+#[derive(Resource, Default, Reflect)]
+#[reflect(Resource)]
 struct QueuedSelectAll(Option<Entity>);
 
 fn on_focus_select_all(


### PR DESCRIPTION
# Objective

Some ui crates are missing `#[derive(Reflect)]` on components, resources and events, making inspecting and inserting/triggering them using reflection cumbersome.

## Solution

Add `#[derive(Reflect)]` to trivially reflectable structs in `bevy_ui`, `bevy_ui_widgets`, `bevy_input_focus` and `bevy_feathers` that were missing. This isn't meant to be a complete solution, just a pass to increase reflection coverage that is useful for future editor work.

## Testing

No new tests
