### PR TITLE
Allow bsn caching syntax for zero-argument function calls

### DIFF
--- a/crates/bevy_scene/macros/src/bsn/parse.rs
+++ b/crates/bevy_scene/macros/src/bsn/parse.rs
@@ -291,8 +291,11 @@ impl BsnScene {
                         path,
                         args: input.parse()?,
                     };
-                    if func.args.0.is_some() {
-                        err_if_cached("Cannot cache Scene function with arguments")?;
+                    if func.args.0.as_ref().is_some_and(|args| !args.is_empty()) {
+                        err_if_cached(&format!(
+                            "Cannot cache Scene function with arguments, {:?}",
+                            func.args.0
+                        ))?;
                     }
                     BsnScene::Fn(func)
                 }

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -1472,7 +1472,7 @@ mod tests {
 
         fn b() -> impl Scene {
             bsn! {
-                a()
+                :a()
                 Foo {
                     y: 2,
                     nested: Bar(2),
@@ -1783,14 +1783,14 @@ mod tests {
 
         let mut app = test_app();
         let world = app.world_mut();
-        let entity = world.spawn_scene(bsn! {@Widget}).unwrap();
+        let entity = world.spawn_scene(bsn! {:@Widget}).unwrap();
         assert_eq!(entity.get::<Name>().unwrap().as_str(), "widget");
         assert!(entity.contains::<Widget>());
 
         #[derive(SceneComponent, Default, Clone)]
         #[scene(Widget::scene)]
         struct OtherWidget;
-        let entity = world.spawn_scene(bsn! {@OtherWidget}).unwrap();
+        let entity = world.spawn_scene(bsn! {:@OtherWidget}).unwrap();
         assert_eq!(entity.get::<Name>().unwrap().as_str(), "widget");
         assert!(entity.contains::<OtherWidget>());
         assert!(
@@ -1869,7 +1869,7 @@ mod tests {
 
         let mut app = test_app();
         let world = app.world_mut();
-        let entity = world.spawn_scene(bsn! {@Widget}).unwrap();
+        let entity = world.spawn_scene(bsn! {:@Widget}).unwrap();
         assert!(entity.contains::<Widget>());
     }
 

--- a/examples/ui/widgets/feathers_gallery.rs
+++ b/examples/ui/widgets/feathers_gallery.rs
@@ -162,7 +162,7 @@ fn demo_column_1() -> impl Scene {
                         })
                     ),
                     (
-                        @FeathersMenu
+                        :@FeathersMenu
                         Children [
                             (
                                 @FeathersMenuButton {
@@ -174,7 +174,7 @@ fn demo_column_1() -> impl Scene {
                                 }
                             ),
                             (
-                                @FeathersMenuPopup
+                                :@FeathersMenuPopup
                                 Children [
                                     (
                                         @FeathersMenuItem {
@@ -259,7 +259,7 @@ fn demo_column_1() -> impl Scene {
                 ]
             ),
             (
-                @FeathersButton
+                :@FeathersButton
                 on(|_activate: On<Activate>, mut ovr: ResMut<OverrideCursor>| {
                     ovr.0 = if ovr.0.is_some() {
                         None


### PR DESCRIPTION
# Objective

In #24367 the caching syntax using the `:` prefix was limited to only being allowed in front of scene functions without arguments. The way this check was implemented meant the following was not valid: `:scene()` even tho `:scene` is converted to `scene()` in the macro anyways. Theres an argument for disallowing `()` call syntax from the start, to make it obvious whats going on, but at least when working in the context of the Rust macro, a function name being converted to a function call seems unintuitive. 

## Solution

Change the check used to allow zero-argument `:scene()` calls as well as `:scene` auto-called functions.

## Testing

- [x] `cargo test --lib bevy_scene`
- [x] `cargo run --example feathers_gallery --features=bevy_feathers`