### PR TITLE
Remove `interner_name` argument from `define_label!` and make the interner private.

### DIFF
--- a/_release-content/migration-guides/define_label.md
+++ b/_release-content/migration-guides/define_label.md
@@ -1,0 +1,27 @@
+---
+title: "`define_label!` no longer defines an `Interner`"
+pull_requests: [24445]
+---
+
+The macro `define_label!()` no longer takes a parameter for the name of an `Interner`,
+and that interner is no longer a public `static` item. Calls like
+
+```rust
+bevy::ecs::define_label!(
+    /// Documentation
+    ThingLabel,
+    THING_LABEL_INTERNER
+);
+```
+
+must be changed to
+
+```rust
+bevy::ecs::define_label!(
+    /// Documentation
+    ThingLabel,
+);
+```
+
+If you were calling `Interner::intern()` on the defined interner, then replace those calls
+with calls to the `.intern()` method of the defined label trait.

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -42,7 +42,6 @@ bevy_ecs::define_label!(
         note = "consider annotating `{Self}` with `#[derive(AppLabel)]`"
     )]
     AppLabel,
-    APP_LABEL_INTERNER
 );
 
 pub use bevy_ecs::label::DynEq;

--- a/crates/bevy_ecs/src/label.rs
+++ b/crates/bevy_ecs/src/label.rs
@@ -72,7 +72,6 @@ where
 /// define_label!(
 ///     /// Documentation of label trait
 ///     MyNewLabelTrait,
-///     MY_NEW_LABEL_TRAIT_INTERNER
 /// );
 ///
 /// /// A new label type implementing the new label trait.
@@ -97,7 +96,6 @@ where
 /// define_label!(
 ///     /// Documentation of another label trait
 ///     MyNewExtendedLabelTrait,
-///     MY_NEW_EXTENDED_LABEL_TRAIT_INTERNER,
 ///     extra_methods: {
 ///         // Extra methods for the trait can be defined here
 ///         fn additional_method(&self) -> i32;
@@ -135,10 +133,7 @@ where
 ///
 /// ```
 /// # use bevy_ecs::define_label;
-/// define_label!(
-///     Team,
-///     TEAM_INTERNER
-/// );
+/// define_label!(Team);
 ///
 /// macro_rules! define_team {
 ///     ($name:ident) => {
@@ -164,13 +159,11 @@ where
 macro_rules! define_label {
     (
         $(#[$label_attr:meta])*
-        $label_trait_name:ident,
-        $interner_name:ident
+        $label_trait_name:ident $(,)?
     ) => {
         $crate::define_label!(
             $(#[$label_attr])*
             $label_trait_name,
-            $interner_name,
             extra_methods: {},
             extra_methods_impl: {}
         );
@@ -178,9 +171,8 @@ macro_rules! define_label {
     (
         $(#[$label_attr:meta])*
         $label_trait_name:ident,
-        $interner_name:ident,
         extra_methods: { $($trait_extra_methods:tt)* },
-        extra_methods_impl: { $($interned_extra_methods_impl:tt)* }
+        extra_methods_impl: { $($interned_extra_methods_impl:tt)* }  $(,)?
     ) => {
 
         $(#[$label_attr])*
@@ -196,7 +188,10 @@ macro_rules! define_label {
             /// Returns an [`Interned`] value corresponding to `self`.
             fn intern(&self) -> $crate::intern::Interned<dyn $label_trait_name>
             where Self: ::core::marker::Sized {
-                $interner_name.intern(self)
+                static INTERNER: $crate::intern::Interner<dyn $label_trait_name> =
+                    $crate::intern::Interner::new();
+
+                INTERNER.intern(self)
             }
         }
 
@@ -252,8 +247,5 @@ macro_rules! define_label {
                 ptr::from_ref::<Self>(self).cast::<()>().hash(state);
             }
         }
-
-        static $interner_name: $crate::intern::Interner<dyn $label_trait_name> =
-            $crate::intern::Interner::new();
     };
 }

--- a/crates/bevy_ecs/src/schedule/set.rs
+++ b/crates/bevy_ecs/src/schedule/set.rs
@@ -57,7 +57,6 @@ define_label!(
         note = "consider annotating `{Self}` with `#[derive(ScheduleLabel)]`"
     )]
     ScheduleLabel,
-    SCHEDULE_LABEL_INTERNER
 );
 
 define_label!(
@@ -152,7 +151,6 @@ define_label!(
         note = "consider annotating `{Self}` with `#[derive(SystemSet)]`"
     )]
     SystemSet,
-    SYSTEM_SET_INTERNER,
     extra_methods: {
         /// Returns `Some` if this system set is a [`SystemTypeSet`].
         fn system_type(&self) -> Option<TypeId> {

--- a/crates/bevy_material/src/labels.rs
+++ b/crates/bevy_material/src/labels.rs
@@ -8,7 +8,6 @@ define_label!(
     )]
     /// Labels used to uniquely identify types of material shaders
     ShaderLabel,
-    SHADER_LABEL_INTERNER
 );
 
 /// A shorthand for `Interned<dyn RenderSubGraph>`.
@@ -22,7 +21,6 @@ define_label!(
     )]
     /// Labels used to uniquely identify types of material shaders
     DrawFunctionLabel,
-    DRAW_FUNCTION_LABEL_INTERNER
 );
 
 pub type InternedDrawFunctionLabel = Interned<dyn DrawFunctionLabel>;


### PR DESCRIPTION
# Objective

Simplify the use of `define_label!()`.

## Solution

- Move the `static` interner inside the `intern()` method, so that it is not visible anywhere else and does not need to have a non-conflicting name. The only operation the interner has is interning, so the `intern()` trait method is all the access that is ever needed.
- Also added support for trailing commas.

This PR will conflict with #24444. I will rebase whichever one doesn’t get merged first.

## Testing

- Ran tests with `cargo run -p ci -- --keep-going test`. There were some failures that I believe are existing/spurious.
