### PR TITLE
chore: remove duplicate "in" in two doc comments

### DIFF
--- a/crates/bevy_pbr/src/render/gpu_preprocess.rs
+++ b/crates/bevy_pbr/src/render/gpu_preprocess.rs
@@ -203,7 +203,7 @@ pub struct BinUnpackingPipeline {
     pub shader: Handle<Shader>,
     /// The pipeline ID for the compute shader.
     ///
-    /// This gets filled in in the [`prepare_preprocess_pipelines`] system.
+    /// This gets filled in the [`prepare_preprocess_pipelines`] system.
     pub pipeline_id: Option<CachedComputePipelineId>,
 }
 

--- a/crates/bevy_render/src/render_phase/mod.rs
+++ b/crates/bevy_render/src/render_phase/mod.rs
@@ -162,7 +162,7 @@ where
     ///
     /// We retain these so that, when the entity changes, the methods that
     /// remove items from bins can quickly find the bin each entity was located
-    /// in in order to remove it.
+    /// in order to remove it.
     cached_entity_bin_keys: MainEntityHashMap<CachedBinnedEntity<BPI>>,
 
     /// The gpu preprocessing mode configured for the view this phase is associated


### PR DESCRIPTION
## Summary

Two near-identical doc comments with "in in":

- `crates/bevy_render/src/render_phase/mod.rs:165` - "in in order to remove it" → "in order to remove it"
- `crates/bevy_pbr/src/render/gpu_preprocess.rs:206` - "filled in in the [\`prepare_preprocess_pipelines\`] system" → "filled in the ..." (link unchanged)

Doc-comment only.