### PR TITLE
Change `CameraOutputMode::Write::blend_state` behavior and default to alpha blending

### DIFF
--- a/_release-content/migration-guides/camera_output_mode_blend_state.md
+++ b/_release-content/migration-guides/camera_output_mode_blend_state.md
@@ -1,0 +1,13 @@
+---
+title: "`CameraOutputMode::Write::blend_state` behavior change"
+pull_requests: [24452]
+---
+
+Previously `CameraOutputMode::Write::blend_state` defaulted to `None`. And when set to `None` the first camera
+for the render target will disable blending (overwrite existing data of the texture) and subsequent cameras will use alpha blending.
+
+Now `CameraOutputMode::Write::blend_state` has been changed to default to `BlendState::ALPHA_BLENDING`, and the `blend_state` is used as-is,
+which means `None` will always disable blending instead of applying the above logic.
+
+If you want the original behavior, you can manually set the `CameraOutputMode::Write::blend_state` of the first camera to `None`
+and subsequent cameras to `BlendState::ALPHA_BLENDING`.

--- a/crates/bevy_camera/src/camera.rs
+++ b/crates/bevy_camera/src/camera.rs
@@ -27,7 +27,7 @@ use wgpu_types::{BlendState, TextureUsages};
 ///
 /// <div class="warning">
 ///
-/// Note that the physical position is in actual screen coordinates and not virtual pixels for window targets.  
+/// Note that the physical position is in actual screen coordinates and not virtual pixels for window targets.
 /// You should use the scaling factor reported by the window, which on some OS's defaults to a value other than 1.
 /// Please see the example code (which assumes a single camera and window)
 ///
@@ -879,7 +879,7 @@ pub enum CameraOutputMode {
 impl Default for CameraOutputMode {
     fn default() -> Self {
         CameraOutputMode::Write {
-            blend_state: None,
+            blend_state: Some(BlendState::ALPHA_BLENDING),
             clear_color: ClearColorConfig::Default,
         }
     }

--- a/crates/bevy_core_pipeline/src/upscaling/mod.rs
+++ b/crates/bevy_core_pipeline/src/upscaling/mod.rs
@@ -61,22 +61,7 @@ fn prepare_view_upscaling_pipelines(
         let blend_state = if let Some(extracted_camera) = camera {
             match extracted_camera.output_mode {
                 CameraOutputMode::Skip => None,
-                CameraOutputMode::Write { blend_state, .. } => {
-                    match blend_state {
-                        None => {
-                            // Auto-detect: the first camera to render to this output
-                            // (sorted_camera_index_for_target == 0) uses replace mode;
-                            // subsequent cameras default to alpha blending so they don't
-                            // accidentally overwrite earlier cameras' output.
-                            if extracted_camera.sorted_camera_index_for_target > 0 {
-                                Some(BlendState::ALPHA_BLENDING)
-                            } else {
-                                None
-                            }
-                        }
-                        _ => blend_state,
-                    }
-                }
+                CameraOutputMode::Write { blend_state, .. } => blend_state,
             }
         } else {
             None


### PR DESCRIPTION

# Objective

Fixes #24263.

## Solution

If `blend_state` is `None`, disable blending instead of setting blend state according to camera order.

Change `CameraOutputMode::Write::blend_state` default to alpha blending to keep the original behavior of multi-cameras.

## Testing
```
cargo r --example split_screen
```