### PR TITLE
Fix rgb_to_hsv returning a negative hue

### DIFF
--- a/crates/bevy_render/src/color_operations.wgsl
+++ b/crates/bevy_render/src/color_operations.wgsl
@@ -316,7 +316,7 @@ fn rgb_to_hsv(rgb: vec3<f32>) -> vec3<f32> {
         swizzle = vec3(rgb.rg, 4.0);
     }
 
-    let h = FRAC_PI_3 * (((swizzle.x - swizzle.y) / c + swizzle.z) % 6.0);
+    let h = FRAC_PI_3 * fract(((swizzle.x - swizzle.y) / c + swizzle.z) / 6.0) * 6.0;
 
     // Avoid division by zero.
     var s = 0.0;


### PR DESCRIPTION
# Objective

While testing #24428, I realized the `rgb_to_hsv` function can return negative hues, eg `rgb_to_hsv(vec3(1.0, 0.0, 1.0))` returns `(-1.0472, 1.0, 1.0)`.

## Solution

For colors where `(swizzle.x - swizzle.y) / c + swizzle.z` is negative, `negative % 6.0` stays negative.
I replaced `x % 6.0` with `fract(x / 6.0) * 6.0`, which is always positive. 

## Testing
- Ran the shader from a test script for a couple colors. 

The function is pretty much unused, it currently only gets called when `ColorGradingGlobal.hue` is set.