### PR TITLE
Expose TAA and CAS nodes as public

### DIFF
--- a/crates/bevy_anti_alias/src/contrast_adaptive_sharpening/mod.rs
+++ b/crates/bevy_anti_alias/src/contrast_adaptive_sharpening/mod.rs
@@ -22,7 +22,7 @@ use bevy_render::{
 
 mod node;
 
-pub(crate) use node::cas;
+pub use node::cas;
 
 /// Applies a contrast adaptive sharpening (CAS) filter to the camera.
 ///

--- a/crates/bevy_anti_alias/src/contrast_adaptive_sharpening/node.rs
+++ b/crates/bevy_anti_alias/src/contrast_adaptive_sharpening/node.rs
@@ -13,7 +13,7 @@ use bevy_render::{
 
 use super::{CasPipeline, CasUniform};
 
-pub(crate) fn cas(
+pub fn cas(
     view: ViewQuery<
         (
             &ViewTarget,

--- a/crates/bevy_anti_alias/src/taa/mod.rs
+++ b/crates/bevy_anti_alias/src/taa/mod.rs
@@ -133,7 +133,7 @@ impl SyncComponent for TemporalAntiAliasing {
     type Target = Self;
 }
 
-fn temporal_anti_alias(
+pub fn temporal_anti_alias(
     view: ViewQuery<(
         &ExtractedCamera,
         &ViewTarget,
@@ -217,7 +217,7 @@ fn temporal_anti_alias(
 }
 
 #[derive(Resource)]
-struct TaaPipeline {
+pub struct TaaPipeline {
     taa_bind_group_layout: BindGroupLayoutDescriptor,
     nearest_sampler: Sampler,
     linear_sampler: Sampler,


### PR DESCRIPTION
# Objective

Fixes #24455.

## Solution

Makes TAA and CAS functions public.

## Testing

Tested that it compiles.
