### PR TITLE
Account for `MouseScrollUnit` in `projection_zoom` example.

### DIFF
--- a/examples/camera/projection_zoom.rs
+++ b/examples/camera/projection_zoom.rs
@@ -141,15 +141,17 @@ fn zoom(
 ) {
     // Usually, you won't need to handle both types of projection,
     // but doing so makes for a more complete example.
+
+    // Get a scroll amount proportional to the kind of input that generated it.
+    let scroll = match mouse_wheel_input.unit {
+        MouseScrollUnit::Line => mouse_wheel_input.delta.y,
+        MouseScrollUnit::Pixel => {
+            mouse_wheel_input.delta.y / MouseScrollUnit::SCROLL_UNIT_CONVERSION_FACTOR
+        }
+    };
+
     match *camera.into_inner() {
         Projection::Orthographic(ref mut orthographic) => {
-            // Get a scroll amount proportional to the kind of input that generated it.
-            let scroll = match mouse_wheel_input.unit {
-                MouseScrollUnit::Line => mouse_wheel_input.delta.y,
-                MouseScrollUnit::Pixel => {
-                    mouse_wheel_input.delta.y / MouseScrollUnit::SCROLL_UNIT_CONVERSION_FACTOR
-                }
-            };
             // We want scrolling up to zoom in, decreasing the scale, so we negate the delta.
             let delta_zoom = -scroll * camera_settings.orthographic_zoom_speed;
             // When changing scales, logarithmic changes are more intuitive.
@@ -165,7 +167,7 @@ fn zoom(
         }
         Projection::Perspective(ref mut perspective) => {
             // We want scrolling up to zoom in, decreasing the scale, so we negate the delta.
-            let delta_zoom = -mouse_wheel_input.delta.y * camera_settings.perspective_zoom_speed;
+            let delta_zoom = -scroll * camera_settings.perspective_zoom_speed;
 
             // Adjust the field of view, but keep it within our stated range.
             perspective.fov = (perspective.fov + delta_zoom).clamp(

--- a/examples/camera/projection_zoom.rs
+++ b/examples/camera/projection_zoom.rs
@@ -2,7 +2,10 @@
 
 use std::{f32::consts::PI, ops::Range};
 
-use bevy::{camera::ScalingMode, input::mouse::AccumulatedMouseScroll, prelude::*};
+use bevy::{
+    camera::ScalingMode, input::mouse::AccumulatedMouseScroll, input::mouse::MouseScrollUnit,
+    prelude::*,
+};
 
 #[derive(Debug, Resource)]
 struct CameraSettings {
@@ -140,8 +143,15 @@ fn zoom(
     // but doing so makes for a more complete example.
     match *camera.into_inner() {
         Projection::Orthographic(ref mut orthographic) => {
+            // Get a scroll amount proportional to the kind of input that generated it.
+            let scroll = match mouse_wheel_input.unit {
+                MouseScrollUnit::Line => mouse_wheel_input.delta.y,
+                MouseScrollUnit::Pixel => {
+                    mouse_wheel_input.delta.y / MouseScrollUnit::SCROLL_UNIT_CONVERSION_FACTOR
+                }
+            };
             // We want scrolling up to zoom in, decreasing the scale, so we negate the delta.
-            let delta_zoom = -mouse_wheel_input.delta.y * camera_settings.orthographic_zoom_speed;
+            let delta_zoom = -scroll * camera_settings.orthographic_zoom_speed;
             // When changing scales, logarithmic changes are more intuitive.
             // To get this effect, we add 1 to the delta, so that a delta of 0
             // results in no multiplicative effect, positive values result in a multiplicative increase,


### PR DESCRIPTION
# Objective

- Fix the feel of the `projection_zoom` example on macOS using a trackpad. Otherwise the zoom is ~100x faster than when using a mouse wheel.
- No bug logged.

## Solution

- Copied logic from from the `free_camera` / `pan_camera` modules to use the conversion to `MouseScrollWheel::SCROLL_UNIT_CONVERSION_FACTOR` when the accumulated mouse wheel input came from `MouseScrollUnit::Lines` rather than `MouseScrollUnit::Pixels`.

## Testing

- Tested on Linux and macOS using a mouse and trackpad.
