### PR TITLE
Fix typo for word glance in `bevy_scene` docs

### DIFF
--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -738,7 +738,7 @@
 //!
 //! ### Scene Components vs Required Components
 //!
-//! At first glace, Scene Components and [Required Components](bevy_ecs::component::Component) solve
+//! At first glance, Scene Components and [Required Components](bevy_ecs::component::Component) solve
 //! similar problems. They both provide a mechanism to initialize components with other components.
 //!
 //! They are functionally quite different however. It is worth understanding the differences and


### PR DESCRIPTION
# Objective

Fixes a very small typo, with the word glace wrongfully used in the expression.

## Solution

Use the right word: _glance_
Bumping the line's width from 100 to 101 characters.

## Testing

No testing was done.
