### PR TITLE
docs: explain morph weight limit

### DIFF
--- a/crates/bevy_mesh/src/morph.rs
+++ b/crates/bevy_mesh/src/morph.rs
@@ -12,6 +12,11 @@ use thiserror::Error;
 pub const MAX_TEXTURE_WIDTH: u32 = 2048;
 
 /// Max target count available for [morph targets](MorphWeights).
+///
+/// This value is used to allocate morph target weight buffers. The current
+/// value is chosen because it is guaranteed to work everywhere. To allow for
+/// larger values, the limit would need to be checked against the GPU at runtime,
+/// which would mean not using a compile-time constant anymore.
 pub const MAX_MORPH_WEIGHTS: usize = 256;
 
 /// The maximum number of morph target components, if morph target textures are

--- a/crates/bevy_pbr/src/render/mesh_bindings.rs
+++ b/crates/bevy_pbr/src/render/mesh_bindings.rs
@@ -13,11 +13,11 @@ use crate::{binding_arrays_are_usable, render::skin::MAX_JOINTS, skin, LightmapS
 
 const MORPH_WEIGHT_SIZE: usize = size_of::<f32>();
 
-/// This is used to allocate buffers.
-/// The correctness of the value depends on the GPU/platform.
-/// The current value is chosen because it is guaranteed to work everywhere.
-/// To allow for bigger values, a check must be made for the limits
-/// of the GPU at runtime, which would mean not using consts anymore.
+/// Buffer size used to store [`MAX_MORPH_WEIGHTS`] morph weights.
+///
+/// The maximum is chosen to work on all supported GPUs. Supporting more morph
+/// weights would require checking GPU/platform limits at runtime instead of
+/// relying on const buffer sizes.
 pub const MORPH_BUFFER_SIZE: usize = MAX_MORPH_WEIGHTS * MORPH_WEIGHT_SIZE;
 
 const JOINT_SIZE: usize = size_of::<Mat4>();


### PR DESCRIPTION
## Objective

Document why `MAX_MORPH_WEIGHTS` is fixed at its current value, matching the existing explanation for `MAX_JOINTS`.

Fixes #15974.

## Solution

- Move the GPU/platform-limit rationale onto the public `MAX_MORPH_WEIGHTS` constant.
- Keep `MORPH_BUFFER_SIZE` documentation focused on the derived buffer size.

## Testing

- `rustfmt +1.93.0-aarch64-apple-darwin --check crates/bevy_mesh/src/morph.rs crates/bevy_pbr/src/render/mesh_bindings.rs`
- `git diff --check`

Note: `cargo +1.93.0-aarch64-apple-darwin check -p bevy_mesh -p bevy_pbr` could not run in this environment because crates.io DNS resolution failed while fetching the index.