### PR TITLE
`bevy_ui_widgets` needs some dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -400,7 +400,11 @@ bevy_input_focus = ["bevy_internal/bevy_input_focus"]
 bevy_clipboard = ["bevy_internal/bevy_clipboard"]
 
 # Headless widget collection for Bevy UI.
-bevy_ui_widgets = ["bevy_internal/bevy_ui_widgets", "bevy_input_focus", "bevy_ui"]
+bevy_ui_widgets = [
+  "bevy_internal/bevy_ui_widgets",
+  "bevy_input_focus",
+  "bevy_ui"
+]
 
 # Load and save user preferences
 bevy_settings = ["bevy_internal/bevy_settings"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -400,7 +400,7 @@ bevy_input_focus = ["bevy_internal/bevy_input_focus"]
 bevy_clipboard = ["bevy_internal/bevy_clipboard"]
 
 # Headless widget collection for Bevy UI.
-bevy_ui_widgets = ["bevy_internal/bevy_ui_widgets"]
+bevy_ui_widgets = ["bevy_internal/bevy_ui_widgets", "bevy_input_focus", "bevy_ui"]
 
 # Load and save user preferences
 bevy_settings = ["bevy_internal/bevy_settings"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -403,7 +403,7 @@ bevy_clipboard = ["bevy_internal/bevy_clipboard"]
 bevy_ui_widgets = [
   "bevy_internal/bevy_ui_widgets",
   "bevy_input_focus",
-  "bevy_ui"
+  "bevy_ui",
 ]
 
 # Load and save user preferences


### PR DESCRIPTION
It panicked if you started the app with DefaultPlugins, because some resources were missing.

# Objective

Fix panic when starting the app with `bevy_ui_widgets` or `bevy_feathers` but no `ui` feature.

Fixes #24369

## Solution

Add the needed features as feature dependencies.

The alternative would be to make `bevy_ui_widgets` work without them, and that could be considered.
One could replace the `Res<...>` with `If<...>` for example. Downside: silently missing capabilities.

## Testing

I compiled and ran the example from the issue.
