### PR TITLE
bsn: throw error when using caching syntax on unsupported scene entries

### DIFF
--- a/benches/benches/bevy_scene/spawn.rs
+++ b/benches/benches/bevy_scene/spawn.rs
@@ -193,16 +193,16 @@ fn ui() -> impl Scene {
     bsn! {
         Node
         Children [
-            (:button Node { width: Val::Px(200.) }),
-            (:button Node { width: Val::Px(200.) }),
-            (:button Node { width: Val::Px(200.) }),
-            (:button Node { width: Val::Px(200.) }),
-            (:button Node { width: Val::Px(200.) }),
-            (:button Node { width: Val::Px(200.) }),
-            (:button Node { width: Val::Px(200.) }),
-            (:button Node { width: Val::Px(200.) }),
-            (:button Node { width: Val::Px(200.) }),
-            (:button Node { width: Val::Px(200.) }),
+            (button() Node { width: Val::Px(200.) }),
+            (button() Node { width: Val::Px(200.) }),
+            (button() Node { width: Val::Px(200.) }),
+            (button() Node { width: Val::Px(200.) }),
+            (button() Node { width: Val::Px(200.) }),
+            (button() Node { width: Val::Px(200.) }),
+            (button() Node { width: Val::Px(200.) }),
+            (button() Node { width: Val::Px(200.) }),
+            (button() Node { width: Val::Px(200.) }),
+            (button() Node { width: Val::Px(200.) }),
         ]
     }
 }

--- a/crates/bevy_feathers/src/controls/number_input.rs
+++ b/crates/bevy_feathers/src/controls/number_input.rs
@@ -77,7 +77,7 @@ impl Default for FeathersNumberInputProps {
 impl FeathersNumberInput {
     fn scene(props: FeathersNumberInputProps) -> impl Scene {
         bsn! {
-            :@FeathersTextInputContainer
+            @FeathersTextInputContainer
             ThemeBorderColor({props.sigil_color})
             FeathersNumberInput
             template_value(props.number_format)

--- a/crates/bevy_feathers/src/controls/virtual_keyboard.rs
+++ b/crates/bevy_feathers/src/controls/virtual_keyboard.rs
@@ -40,7 +40,7 @@ impl<T: AsRef<str> + Clone + Send + Sync + 'static> VirtualKeyboard<T> {
             let key_row = Vec::from_iter(row.into_iter().map(move |key| {
                 let key_clone = key.clone();
                 bsn! {
-                    :@FeathersButton
+                    @FeathersButton
                     Node {
                         flex_grow: 1.0,
                     }

--- a/crates/bevy_scene/macros/src/bsn/parse.rs
+++ b/crates/bevy_scene/macros/src/bsn/parse.rs
@@ -59,22 +59,27 @@ impl Parse for BsnListRoot {
 impl<const ALLOW_FLAT: bool> Parse for Bsn<ALLOW_FLAT> {
     fn parse(input: ParseStream) -> Result<Self> {
         let mut entries = Vec::new();
-        let mut found_cached_scene = false;
         if input.peek(Paren) {
             let content;
             parenthesized![content in input];
             while !content.is_empty() {
-                let entry = BsnEntry::parse(&content, found_cached_scene)?;
-                if matches!(entry, BsnEntry::CachedScene(_)) {
-                    found_cached_scene = true;
+                let entry = BsnEntry::parse(&content)?;
+                if matches!(entry, BsnEntry::CachedScene(_)) && !entries.is_empty() {
+                    return Err(syn::Error::new(
+                        content.span(),
+                        "Caching entries after the first is not supported, remove the ':' prefix or make this the first entry.",
+                    ));
                 }
                 entries.push(entry);
             }
         } else if ALLOW_FLAT {
             while !input.is_empty() {
-                let entry = BsnEntry::parse(input, found_cached_scene)?;
-                if matches!(entry, BsnEntry::CachedScene(_)) {
-                    found_cached_scene = true;
+                let entry = BsnEntry::parse(input)?;
+                if matches!(entry, BsnEntry::CachedScene(_)) && !entries.is_empty() {
+                    return Err(syn::Error::new(
+                        input.span(),
+                        "Caching entries after the first is not supported, remove the ':' prefix or make this the first entry.",
+                    ));
                 }
                 entries.push(entry);
                 if input.peek(Comma) {
@@ -84,7 +89,7 @@ impl<const ALLOW_FLAT: bool> Parse for Bsn<ALLOW_FLAT> {
                 }
             }
         } else {
-            entries.push(BsnEntry::parse(input, found_cached_scene)?);
+            entries.push(BsnEntry::parse(input)?);
         }
 
         Ok(Self { entries })
@@ -92,9 +97,9 @@ impl<const ALLOW_FLAT: bool> Parse for Bsn<ALLOW_FLAT> {
 }
 
 impl BsnEntry {
-    fn parse(input: ParseStream, found_cached_scene: bool) -> Result<Self> {
+    fn parse(input: ParseStream) -> Result<Self> {
         Ok(if input.peek(Token![:]) {
-            BsnEntry::CachedScene(BsnScene::parse(input, found_cached_scene)?)
+            BsnEntry::CachedScene(BsnScene::parse(input)?)
         } else if input.peek(Token![#]) {
             input.parse::<Token![#]>()?;
             if input.peek(Brace) {
@@ -103,7 +108,7 @@ impl BsnEntry {
                 BsnEntry::Name(input.parse::<Ident>()?)
             }
         } else if input.peek(Brace) || input.peek(At) {
-            BsnEntry::UncachedScene(BsnScene::parse(input, found_cached_scene)?)
+            BsnEntry::UncachedScene(BsnScene::parse(input)?)
         } else {
             let is_template = input.peek(Tilde);
             if is_template {
@@ -232,7 +237,7 @@ impl Parse for BsnSceneFnArg {
     }
 }
 impl BsnScene {
-    fn parse(input: ParseStream, found_cached_scene: bool) -> Result<Self> {
+    fn parse(input: ParseStream) -> Result<Self> {
         let cached = if input.peek(Token![:]) {
             Some(input.parse::<Token![:]>()?)
         } else {
@@ -247,8 +252,13 @@ impl BsnScene {
             }
         };
 
-        if found_cached_scene {
-            err_if_cached("Cannot cache scenes more than once")?;
+        // It may seem odd how this is checking LitStr again
+        // and how there doesn't seem to be a need for all the specific `err_if_cached`
+        // in later code. But since caching is planned, and will very likely
+        // have the limitations which are ensured by the other errors below,
+        // this is its own block so its very simple to remove once caching is implemented.
+        if !input.peek(LitStr) {
+            err_if_cached("Currently, caching is only supported for scene assets. Please remove the ':' prefix for now.")?;
         }
 
         Ok(if input.peek(LitStr) {
@@ -256,7 +266,7 @@ impl BsnScene {
             if cached.is_none() {
                 return Err(syn::Error::new(
                     path.span(),
-                    "Cannot use scenes from asset path without caching, please add the ':' prefix.",
+                    "Cannot use scene assets without caching, please add the ':' prefix.",
                 ));
             }
             BsnScene::Asset(path)

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -2070,7 +2070,7 @@ mod tests {
         panic!("Ran out of loops to return `Some` from `predicate`");
     }
 
-    // NOTE: caching is not yet implemented
+    // NOTE: function scene caching is not yet implemented
     // #[test]
     // fn caching_with_generics() {
     //     #[derive(Component, FromTemplate, PartialEq, Eq, Debug)]

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -889,7 +889,7 @@ mod tests {
 
         fn b() -> impl Scene {
             bsn! {
-                :a
+                a()
                 Position { x: 1. }
                 Children [ #Y ]
             }
@@ -1183,12 +1183,11 @@ mod tests {
     fn bsn_name_references() {
         let mut app = test_app();
         let world = app.world_mut();
-
         fn a() -> impl Scene {
             bsn! {
                 #X
                 Children [
-                    (:b Reference(#X))
+                    (b() Reference(#X))
                 ]
             }
         }
@@ -1271,7 +1270,7 @@ mod tests {
                         Reference(#Y)
                     ]
                 ),
-                (:b #Z)
+                (b() #Z)
             ]
         }
 
@@ -2071,37 +2070,38 @@ mod tests {
         panic!("Ran out of loops to return `Some` from `predicate`");
     }
 
-    #[test]
-    fn caching_with_generics() {
-        #[derive(Component, FromTemplate, PartialEq, Eq, Debug)]
-        struct Foo<T: FromTemplate<Template: Default + Template<Output = T>>> {
-            value: T,
-            number: u32,
-        }
+    // NOTE: caching is not yet implemented
+    // #[test]
+    // fn caching_with_generics() {
+    //     #[derive(Component, FromTemplate, PartialEq, Eq, Debug)]
+    //     struct Foo<T: FromTemplate<Template: Default + Template<Output = T>>> {
+    //         value: T,
+    //         number: u32,
+    //     }
 
-        fn b() -> impl Scene {
-            bsn! {
-                :a::<0, i32>
-                Children [ #Y ]
-            }
-        }
+    //     fn b() -> impl Scene {
+    //         bsn! {
+    //             :a::<0, i32>
+    //             Children [ #Y ]
+    //         }
+    //     }
 
-        fn a<
-            const A: u32,
-            T: 'static
-                + Send
-                + Sync
-                + FromTemplate<Template: Send + Sync + Default + Template<Output = T>>,
-        >() -> impl Scene {
-            bsn! {
-                Foo<T>{
-                    number: A
-                }
-            }
-        }
+    //     fn a<
+    //         const A: u32,
+    //         T: 'static
+    //             + Send
+    //             + Sync
+    //             + FromTemplate<Template: Send + Sync + Default + Template<Output = T>>,
+    //     >() -> impl Scene {
+    //         bsn! {
+    //             Foo<T>{
+    //                 number: A
+    //             }
+    //         }
+    //     }
 
-        b();
-    }
+    //     b();
+    // }
 
     #[test]
     fn scene_with_blocks() {

--- a/examples/ui/widgets/feathers_gallery.rs
+++ b/examples/ui/widgets/feathers_gallery.rs
@@ -93,8 +93,8 @@ fn demo_root() -> impl Scene {
         TabGroup
         ThemeBackgroundColor(tokens::WINDOW_BG)
         Children[
-            :demo_column_1,
-            :demo_column_2,
+            demo_column_1(),
+            demo_column_2(),
         ]
     }
 }
@@ -415,7 +415,7 @@ fn demo_column_1() -> impl Scene {
                 Children [
                     label("Srgba"),
                     // Spacer
-                    :flex_spacer,
+                    flex_spacer(),
                     // Text input
                     (
                         @FeathersTextInputContainer
@@ -547,14 +547,14 @@ fn demo_column_2() -> impl Scene {
         }
         Children [
             (
-                :pane Children [
-                    :pane_header Children [
+                pane() Children [
+                    pane_header() Children [
                         @FeathersToolButton {
                             @variant: ButtonVariant::Primary,
                         } Children [
                             (Text("\u{0398}") ThemedText)
                         ],
-                        :pane_header_divider,
+                        pane_header_divider(),
                         @FeathersToolButton {
                             @variant: ButtonVariant::Plain,
                         } Children [
@@ -570,13 +570,13 @@ fn demo_column_2() -> impl Scene {
                         } Children [
                             (Text("\u{00BE}") ThemedText)
                         ],
-                        :pane_header_divider,
+                        pane_header_divider(),
                         @FeathersToolButton {
                             @variant: ButtonVariant::Plain,
                         } Children [
                             icon(icons::CHEVRON_DOWN)
                         ],
-                        :flex_spacer,
+                        flex_spacer(),
                         @FeathersToolButton {
                             @variant: ButtonVariant::Plain,
                         } Children [
@@ -584,27 +584,27 @@ fn demo_column_2() -> impl Scene {
                         ],
                     ],
                     (
-                        :pane_body Children [
+                        pane_body() Children [
                             label_dim("A standard editor pane"),
-                            :subpane Children [
-                                :subpane_header Children [
+                            subpane() Children [
+                                subpane_header() Children [
                                     (Text("Left") ThemedText),
                                     (Text("Center") ThemedText),
                                     (Text("Right") ThemedText)
                                 ],
-                                :subpane_body Children [
+                                subpane_body() Children [
                                     label_dim("A standard sub-pane"),
-                                    :group
+                                    group()
                                     Children [
-                                        :group_header Children [
+                                        group_header() Children [
                                             (Text("Group") ThemedText),
                                         ],
-                                        :group_body
+                                        group_body()
                                         Children [
                                             label("A standard group"),
                                             label_small("Scalar property"),
                                             (
-                                                :@FeathersNumberInput
+                                                @FeathersNumberInput
                                                 DemoScalarField
                                                 Node {
                                                     flex_grow: 1.0,
@@ -620,7 +620,7 @@ fn demo_column_2() -> impl Scene {
                                             ),
                                             label_small("Scalar property (copy)"),
                                             (
-                                                :@FeathersNumberInput
+                                                @FeathersNumberInput
                                                 DemoScalarField
                                                 Node {
                                                     flex_grow: 1.0,


### PR DESCRIPTION
# Objective

Implement changes discussed with cart around erroring when using caching syntax where its not implemented.


## Solution

Throw a compile error, in a way which is easy to remove once caching exists/works for more cases.

Also contains a commit to alleviate trait errors which will (from my experience writing this PR and fixing them in bevy) arise from fixing this for existing bsn code. This commit can be dropped if not desired. This would ideally be fixed upstream so this workaround can be removed: https://github.com/rust-lang/rust/issues/141258#issuecomment-4565897810

Note: The error caused by this workaround is far from ideal. It initially looks like a method call is missing, but ultimately the hint/advice *is* correct
<img width="1982" height="477" alt="image" src="https://github.com/user-attachments/assets/879f7630-ada8-4e63-9c59-80be466f37cf" />


## Testing

- `cargo test -p bevy_scene --lib`
- `cargo check`

