### PR TITLE
Don't use ScenePatchInstance for queued scenes

### DIFF
--- a/crates/bevy_scene/src/spawn.rs
+++ b/crates/bevy_scene/src/spawn.rs
@@ -199,11 +199,9 @@ impl WorldSceneExt for World {
         let mut entity = self.spawn_empty();
         let id = entity.id();
         entity
-            .resource_mut::<WaitingScenes>()
-            .scene_entities
-            .entry(handle)
-            .or_default()
-            .push(id);
+            .resource_mut::<QueuedScenes>()
+            .new_scene_entities
+            .push((id, handle));
         entity
     }
 
@@ -510,11 +508,9 @@ impl EntityWorldMutSceneExt for EntityWorldMut<'_> {
         let patch = ScenePatch::load(assets, scene);
         let handle = assets.add(patch);
         let id = self.id();
-        self.resource_mut::<WaitingScenes>()
-            .scene_entities
-            .entry(handle)
-            .or_default()
-            .push(id);
+        self.resource_mut::<QueuedScenes>()
+            .new_scene_entities
+            .push((id, handle));
     }
 }
 
@@ -673,7 +669,7 @@ pub fn resolve_scene_patches(
 /// A [`Resource`] that tracks entities / scenes that have been queued to spawn.
 #[derive(Resource, Default)]
 pub struct QueuedScenes {
-    new_scene_entities: Vec<Entity>,
+    new_scene_entities: Vec<(Entity, Handle<ScenePatch>)>,
     related_scene_list_spawns: Vec<(RelatedSceneListSpawn, Handle<SceneListPatch>)>,
     scene_list_spawns: Vec<Handle<SceneListPatch>>,
 }
@@ -695,8 +691,13 @@ pub(crate) struct RelatedSceneListSpawn {
 pub fn on_add_scene_patch_instance(
     add: On<Add, ScenePatchInstance>,
     mut queued_scenes: ResMut<QueuedScenes>,
+    instances: Query<&ScenePatchInstance>,
 ) {
-    queued_scenes.new_scene_entities.push(add.entity);
+    if let Ok(instance) = instances.get(add.entity) {
+        queued_scenes
+            .new_scene_entities
+            .push((add.entity, instance.0.clone()));
+    }
 }
 
 /// A system that spawns queued scenes when they are loaded.
@@ -708,22 +709,8 @@ pub fn spawn_queued(
     mut reader: Local<MessageCursor<AssetEvent<ScenePatch>>>,
     mut list_reader: Local<MessageCursor<AssetEvent<SceneListPatch>>>,
 ) {
-    core::mem::swap(&mut *world.resource_mut::<QueuedScenes>(), &mut queued);
     world.resource_scope(|world, mut list_patches: Mut<Assets<SceneListPatch>>| {
         world.resource_scope(|world, mut waiting: Mut<WaitingScenes>| {
-            loop {
-                if queued.is_empty() {
-                    break;
-                }
-                queued.spawn_queued(
-                    world,
-                    &mut waiting,
-                    scene_patch_instances,
-                    &mut bundle_scratch,
-                    &list_patches,
-                );
-            }
-
             world.resource_scope(|world, events: Mut<Messages<AssetEvent<ScenePatch>>>| {
                 for event in reader.read(&events) {
                     let patches = world.resource::<Assets<ScenePatch>>();
@@ -778,6 +765,20 @@ pub fn spawn_queued(
                     }
                 },
             );
+
+            loop {
+                core::mem::swap(&mut *world.resource_mut::<QueuedScenes>(), &mut queued);
+                if queued.is_empty() {
+                    break;
+                }
+                queued.spawn_queued(
+                    world,
+                    &mut waiting,
+                    scene_patch_instances,
+                    &mut bundle_scratch,
+                    &list_patches,
+                );
+            }
         });
     });
 }
@@ -797,12 +798,9 @@ impl QueuedScenes {
         bundle_scratch: &mut BundleScratch,
         list_patches: &Assets<SceneListPatch>,
     ) {
-        for entity in core::mem::take(&mut self.new_scene_entities) {
-            let Ok(handle) = scene_patch_instances.get(world, entity).map(|h| &h.0) else {
-                continue;
-            };
+        for (entity, handle) in core::mem::take(&mut self.new_scene_entities) {
             let patches = world.resource::<Assets<ScenePatch>>();
-            if let Some(resolved) = patches.get(handle).and_then(|p| p.resolved.clone()) {
+            if let Some(resolved) = patches.get(&handle).and_then(|p| p.resolved.clone()) {
                 let mut entity_mut = world.get_entity_mut(entity).unwrap();
                 if let Err(err) = resolved.apply(&mut entity_mut, bundle_scratch) {
                     let scene_patch_instance = scene_patch_instances.get(world, entity).unwrap();

--- a/crates/bevy_scene/src/spawn.rs
+++ b/crates/bevy_scene/src/spawn.rs
@@ -196,7 +196,15 @@ impl WorldSceneExt for World {
         let assets = self.resource::<AssetServer>();
         let patch = ScenePatch::load(assets, scene);
         let handle = assets.add(patch);
-        self.spawn(ScenePatchInstance(handle))
+        let mut entity = self.spawn_empty();
+        let id = entity.id();
+        entity
+            .resource_mut::<WaitingScenes>()
+            .scene_entities
+            .entry(handle)
+            .or_default()
+            .push(id);
+        entity
     }
 
     fn spawn_scene_list<L: SceneList>(
@@ -501,7 +509,12 @@ impl EntityWorldMutSceneExt for EntityWorldMut<'_> {
         let assets = self.resource::<AssetServer>();
         let patch = ScenePatch::load(assets, scene);
         let handle = assets.add(patch);
-        self.insert(ScenePatchInstance(handle));
+        let id = self.id();
+        self.resource_mut::<WaitingScenes>()
+            .scene_entities
+            .entry(handle)
+            .or_default()
+            .push(id);
     }
 }
 


### PR DESCRIPTION
# Objective

Fix #24320

## Solution

Don't use `ScenePatchInstance` for queued scenes. Instead, use QueuedScenes directly.

## Testing

The example in #24320 now works.