### PR TITLE
fix all clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,9 @@ ref_as_ptr = "warn"
 # see: https://github.com/bevyengine/bevy/pull/15375#issuecomment-2366966219
 too_long_first_doc_paragraph = "allow"
 
-std_instead_of_core = "warn"
+# currently falsely fires on std::io, even tho core::io is unstable
+# https://github.com/rust-lang/rust-clippy/issues/13158#issuecomment-4373196346
+std_instead_of_core = "allow"
 std_instead_of_alloc = "warn"
 alloc_instead_of_core = "warn"
 

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -1756,7 +1756,7 @@ mod tests {
                 AnimationTargetId::from_names(name_path.iter()),
                 "{:?} {:?}",
                 str_path,
-                &name_path
+                name_path
             );
         }
     }

--- a/crates/bevy_asset/src/reflect.rs
+++ b/crates/bevy_asset/src/reflect.rs
@@ -463,7 +463,7 @@ impl ReflectDeserializerProcessor for HandleDeserializeProcessor<'_> {
             else {
                 return Err(D::Error::custom(format!(
                     "Could not find asset type by name \"{}\" for UntypedHandle",
-                    &typed_handle_reference.asset_type
+                    typed_handle_reference.asset_type
                 )));
             };
             let type_id = asset_type.type_id();

--- a/crates/bevy_ecs/src/query/mod.rs
+++ b/crates/bevy_ecs/src/query/mod.rs
@@ -303,7 +303,7 @@ mod tests {
             sorted.sort();
             assert!(expected.contains(&sorted),
                     "the results of iter_combinations should contain this combination {:?}. Expected: {:?}, got: {:?}",
-                    &sorted, &expected, &values);
+                    sorted, expected, values);
         });
     }
 

--- a/crates/bevy_feathers/src/controls/text_input.rs
+++ b/crates/bevy_feathers/src/controls/text_input.rs
@@ -95,9 +95,9 @@ impl FeathersTextInput {
             Node {
                 flex_grow: {
                     if props.visible_width.is_some() {
-                        0.
+                        0_f32
                     } else {
-                        1.
+                        1_f32
                     }
                 } ,
             }

--- a/crates/bevy_math/src/bounding/bounded2d/mod.rs
+++ b/crates/bevy_math/src/bounding/bounded2d/mod.rs
@@ -710,7 +710,7 @@ mod bounding_circle_tests {
     #[test]
     fn grow() {
         let a = BoundingCircle::new(Vec2::ONE, 5.);
-        let padded = a.grow(1.25f32);
+        let padded = a.grow(1.25_f32);
         assert!(ops::abs(padded.radius() - 6.25) < f32::EPSILON);
         assert!(padded.contains(&a));
         assert!(!a.contains(&padded));
@@ -719,7 +719,7 @@ mod bounding_circle_tests {
     #[test]
     fn shrink() {
         let a = BoundingCircle::new(Vec2::ONE, 5.);
-        let shrunk = a.shrink(0.5f32);
+        let shrunk = a.shrink(0.5_f32);
         assert!(ops::abs(shrunk.radius() - 4.5) < f32::EPSILON);
         assert!(a.contains(&shrunk));
         assert!(!shrunk.contains(&a));

--- a/crates/bevy_math/src/bounding/bounded2d/mod.rs
+++ b/crates/bevy_math/src/bounding/bounded2d/mod.rs
@@ -710,7 +710,7 @@ mod bounding_circle_tests {
     #[test]
     fn grow() {
         let a = BoundingCircle::new(Vec2::ONE, 5.);
-        let padded = a.grow(1.25);
+        let padded = a.grow(1.25f32);
         assert!(ops::abs(padded.radius() - 6.25) < f32::EPSILON);
         assert!(padded.contains(&a));
         assert!(!a.contains(&padded));
@@ -719,7 +719,7 @@ mod bounding_circle_tests {
     #[test]
     fn shrink() {
         let a = BoundingCircle::new(Vec2::ONE, 5.);
-        let shrunk = a.shrink(0.5);
+        let shrunk = a.shrink(0.5f32);
         assert!(ops::abs(shrunk.radius() - 4.5) < f32::EPSILON);
         assert!(a.contains(&shrunk));
         assert!(!shrunk.contains(&a));
@@ -728,7 +728,7 @@ mod bounding_circle_tests {
     #[test]
     fn scale_around_center() {
         let a = BoundingCircle::new(Vec2::ONE, 5.);
-        let scaled = a.scale_around_center(2.);
+        let scaled = a.scale_around_center(2_f32);
         assert!(ops::abs(scaled.radius() - 10.) < f32::EPSILON);
         assert!(!a.contains(&scaled));
         assert!(scaled.contains(&a));

--- a/crates/bevy_math/src/bounding/bounded3d/mod.rs
+++ b/crates/bevy_math/src/bounding/bounded3d/mod.rs
@@ -762,7 +762,7 @@ mod bounding_sphere_tests {
     #[test]
     fn grow() {
         let a = BoundingSphere::new(Vec3::ONE, 5.);
-        let padded = a.grow(1.25);
+        let padded = a.grow(1.25f32);
         assert!(ops::abs(padded.radius() - 6.25) < f32::EPSILON);
         assert!(padded.contains(&a));
         assert!(!a.contains(&padded));
@@ -771,7 +771,7 @@ mod bounding_sphere_tests {
     #[test]
     fn shrink() {
         let a = BoundingSphere::new(Vec3::ONE, 5.);
-        let shrunk = a.shrink(0.5);
+        let shrunk = a.shrink(0.5f32);
         assert!(ops::abs(shrunk.radius() - 4.5) < f32::EPSILON);
         assert!(a.contains(&shrunk));
         assert!(!shrunk.contains(&a));
@@ -780,7 +780,7 @@ mod bounding_sphere_tests {
     #[test]
     fn scale_around_center() {
         let a = BoundingSphere::new(Vec3::ONE, 5.);
-        let scaled = a.scale_around_center(2.);
+        let scaled = a.scale_around_center(2_f32);
         assert!(ops::abs(scaled.radius() - 10.) < f32::EPSILON);
         assert!(!a.contains(&scaled));
         assert!(scaled.contains(&a));

--- a/crates/bevy_math/src/bounding/bounded3d/mod.rs
+++ b/crates/bevy_math/src/bounding/bounded3d/mod.rs
@@ -762,7 +762,7 @@ mod bounding_sphere_tests {
     #[test]
     fn grow() {
         let a = BoundingSphere::new(Vec3::ONE, 5.);
-        let padded = a.grow(1.25f32);
+        let padded = a.grow(1.25_f32);
         assert!(ops::abs(padded.radius() - 6.25) < f32::EPSILON);
         assert!(padded.contains(&a));
         assert!(!a.contains(&padded));
@@ -771,7 +771,7 @@ mod bounding_sphere_tests {
     #[test]
     fn shrink() {
         let a = BoundingSphere::new(Vec3::ONE, 5.);
-        let shrunk = a.shrink(0.5f32);
+        let shrunk = a.shrink(0.5_f32);
         assert!(ops::abs(shrunk.radius() - 4.5) < f32::EPSILON);
         assert!(a.contains(&shrunk));
         assert!(!shrunk.contains(&a));

--- a/crates/bevy_reflect/src/func/dynamic_function.rs
+++ b/crates/bevy_reflect/src/func/dynamic_function.rs
@@ -456,7 +456,7 @@ impl_type_path!((in bevy_reflect) DynamicFunction<'env>);
 /// [overloaded]: DynamicFunction::with_overload
 impl<'env> Debug for DynamicFunction<'env> {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        write!(f, "DynamicFunction({:?})", &self.internal)
+        write!(f, "DynamicFunction({:?})", self.internal)
     }
 }
 

--- a/crates/bevy_reflect/src/func/dynamic_function_mut.rs
+++ b/crates/bevy_reflect/src/func/dynamic_function_mut.rs
@@ -346,7 +346,7 @@ impl<'env> DynamicFunctionMut<'env> {
 /// [overloaded]: DynamicFunctionMut::with_overload
 impl<'env> Debug for DynamicFunctionMut<'env> {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        write!(f, "DynamicFunctionMut({:?})", &self.internal)
+        write!(f, "DynamicFunctionMut({:?})", self.internal)
     }
 }
 

--- a/crates/bevy_render/src/render_resource/sparse_buffer_vec.rs
+++ b/crates/bevy_render/src/render_resource/sparse_buffer_vec.rs
@@ -243,7 +243,7 @@ fn update_sparse_buffers(
             command_encoder.begin_compute_pass(&ComputePassDescriptor {
                 label: Some(&*format!(
                     "sparse buffer update ({})",
-                    &sparse_buffer_update_job.label
+                    sparse_buffer_update_job.label
                 )),
                 timestamp_writes: None,
             });

--- a/crates/bevy_settings/src/lib.rs
+++ b/crates/bevy_settings/src/lib.rs
@@ -298,7 +298,7 @@ fn save_preferences(world: &mut World, use_async: bool, force: bool) {
 
     // Update timestamps
     let mut registry = world.get_resource_mut::<PreferencesFileRegistry>().unwrap();
-    for (_, manifest) in registry.files.iter_mut() {
+    for manifest in registry.files.values_mut() {
         manifest.last_save = this_run;
     }
 }

--- a/crates/bevy_ui/src/layout/convert.rs
+++ b/crates/bevy_ui/src/layout/convert.rs
@@ -642,18 +642,18 @@ mod tests {
         );
         assert_eq!(
             taffy_style.grid_template_rows,
-            vec![sh::length(10.0_f32), sh::percent(0.5_f32), sh::fr(1.0_f32)]
+            vec![sh::length(10_f32), sh::percent(0.5_f32), sh::fr(1_f32)]
         );
         assert_eq!(
             taffy_style.grid_template_columns,
-            vec![sh::repeat(5, vec![sh::length(10.0_f32)])]
+            vec![sh::repeat(5, vec![sh::length(10_f32)])]
         );
         assert_eq!(
             taffy_style.grid_auto_rows,
             vec![
                 sh::fit_content(taffy::style::LengthPercentage::length(10.0)),
                 sh::fit_content(taffy::style::LengthPercentage::percent(0.25)),
-                sh::minmax(sh::length(0.0_f32), sh::fr(2.0_f32)),
+                sh::minmax(sh::length(0_f32), sh::fr(2_f32)),
             ]
         );
         assert_eq!(

--- a/crates/bevy_ui/src/layout/convert.rs
+++ b/crates/bevy_ui/src/layout/convert.rs
@@ -642,18 +642,18 @@ mod tests {
         );
         assert_eq!(
             taffy_style.grid_template_rows,
-            vec![sh::length(10.0), sh::percent(0.5), sh::fr(1.0)]
+            vec![sh::length(10.0_f32), sh::percent(0.5_f32), sh::fr(1.0_f32)]
         );
         assert_eq!(
             taffy_style.grid_template_columns,
-            vec![sh::repeat(5, vec![sh::length(10.0)])]
+            vec![sh::repeat(5, vec![sh::length(10.0_f32)])]
         );
         assert_eq!(
             taffy_style.grid_auto_rows,
             vec![
                 sh::fit_content(taffy::style::LengthPercentage::length(10.0)),
                 sh::fit_content(taffy::style::LengthPercentage::percent(0.25)),
-                sh::minmax(sh::length(0.0), sh::fr(2.0)),
+                sh::minmax(sh::length(0.0_f32), sh::fr(2.0_f32)),
             ]
         );
         assert_eq!(

--- a/tools/build-templated-pages/src/features.rs
+++ b/tools/build-templated-pages/src/features.rs
@@ -96,7 +96,7 @@ fn parse_features(panic_on_missing: bool) -> Vec<Feature> {
                             .flat_map(|v| v.as_str().map(|s| format!("`{}`", s)))
                             .collect::<Vec<_>>()
                             .join(", ");
-                        description.push_str(&format!(" **Feature set:** {}.", &features));
+                        description.push_str(&format!(" **Feature set:** {}.", features));
                     }
 
                     Some(Feature {

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -613,16 +613,16 @@ required_features = {:?}
                                 WebApi::Webgl2 => "",
                             },
                             to_show.category,
-                            &to_show.technical_name.replace('_', "-"),
-                            &to_show.technical_name.replace('_', "-"),
+                            to_show.technical_name.replace('_', "-"),
+                            to_show.technical_name.replace('_', "-"),
                             match api {
                                 WebApi::Webgpu => "-webgpu",
                                 WebApi::Webgl2 => "",
                             },
-                            &beautified_category,
-                            &to_show.technical_name.replace('_', "-"),
-                            &to_show.category,
-                            &to_show.technical_name,
+                            beautified_category,
+                            to_show.technical_name.replace('_', "-"),
+                            to_show.category,
+                            to_show.technical_name,
                             match api {
                                 WebApi::Webgpu => "-webgpu",
                                 WebApi::Webgl2 => "",
@@ -633,7 +633,7 @@ required_features = {:?}
                                 .collect::<PathBuf>()
                                 .display(),
                             to_show.shader_paths,
-                            &to_show.path,
+                            to_show.path,
                             match api {
                                 WebApi::Webgpu => "WebGPU",
                                 WebApi::Webgl2 => "WebGL2",


### PR DESCRIPTION
# Objective

Resolve all clippy lints currently warning in one way or another. They were annoying me while contributing, especially having to find the lints i caused in the ~50 of them which this PR resolves.

## Solution

Most of them were fixes that were reasonable to apply.

`std_instead_of_core` currently has false hits on `std::io`: because `core::io` is unstable we don't want to apply those. So ive decided to disable this lint for now. This was already "allow" in `[lints.clippy]`, i made it "allow" in `[workspace.lints.clippy]` as well.

## Testing

- [x] `cargo test --all` passes, except for `error::bevy_error::tests::filtered_backtrace_test` which fails on `main` in the same way for me 
- [x] `bevy_city` example works