### PR TITLE
Fix Transform Gizmo: Snapped scale values now have a minimum of `snap_scale`

### DIFF
--- a/crates/bevy_gizmos/src/transform_gizmo.rs
+++ b/crates/bevy_gizmos/src/transform_gizmo.rs
@@ -603,17 +603,17 @@ fn transform_gizmo_drag(
                         let mut snapped = state.start_transform.scale;
                         match axis {
                             TransformGizmoAxis::X => {
-                                snapped.x = snap_value(new_scale.x, inc).max(inc)
+                                snapped.x = snap_value(new_scale.x, inc).max(inc);
                             }
                             TransformGizmoAxis::Y => {
-                                snapped.y = snap_value(new_scale.y, inc).max(inc)
+                                snapped.y = snap_value(new_scale.y, inc).max(inc);
                             }
                             TransformGizmoAxis::Z => {
-                                snapped.z = snap_value(new_scale.z, inc).max(inc)
+                                snapped.z = snap_value(new_scale.z, inc).max(inc);
                             }
                             TransformGizmoAxis::View => {
                                 snapped = Vec3::splat(snap_value(new_scale.x, inc));
-                                snapped = snapped.max(Vec3::splat(inc))
+                                snapped = snapped.max(Vec3::splat(inc));
                             }
                         }
                         snapped

--- a/crates/bevy_gizmos/src/transform_gizmo.rs
+++ b/crates/bevy_gizmos/src/transform_gizmo.rs
@@ -602,11 +602,18 @@ fn transform_gizmo_drag(
                     Some(inc) => {
                         let mut snapped = state.start_transform.scale;
                         match axis {
-                            TransformGizmoAxis::X => snapped.x = snap_value(new_scale.x, inc),
-                            TransformGizmoAxis::Y => snapped.y = snap_value(new_scale.y, inc),
-                            TransformGizmoAxis::Z => snapped.z = snap_value(new_scale.z, inc),
+                            TransformGizmoAxis::X => {
+                                snapped.x = snap_value(new_scale.x, inc).max(inc)
+                            }
+                            TransformGizmoAxis::Y => {
+                                snapped.y = snap_value(new_scale.y, inc).max(inc)
+                            }
+                            TransformGizmoAxis::Z => {
+                                snapped.z = snap_value(new_scale.z, inc).max(inc)
+                            }
                             TransformGizmoAxis::View => {
                                 snapped = Vec3::splat(snap_value(new_scale.x, inc));
+                                snapped = snapped.max(Vec3::splat(inc))
                             }
                         }
                         snapped


### PR DESCRIPTION
# Objective

- Fixes #24429 
- Non snapped scaling uses `MIN_SCALE` to prevent scale from ever reaching 0. However, the same is not applied to snapped scaling, which can reach 0, breaking the Transform Gizmo.

## Solution

- Snapped scale values must be at least `snap_scale` if present. I opted to use `snap_scale` instead of `MIN_SCALE` here so that the increment math stays simple. I also found that if `MIN_SCALE` were used as a min instead and `snap_scale` is a value larger than `MIN_SCALE`, there is some bad ux when you are set to `MIN_SCALE` and try to snap increment out of it: It can get stuck unless you use a lot of scroll.

- As an aside, The issue suggests allowing scale to equal 0, but allowing a mesh transform with scale = 0 makes the transformation degenerate, which means that we are unable to extract rotation data from the `GlobalTransform` (hence why the gizmo stops rendering properly). If we want to pursue allowing scale = 0, there probably needs to be more design to handle that case.

## Testing

- Tested on the reproduction example in the issue. The scale of the mesh never goes below 0.25.