### PR TITLE
Clippy: Allow `bevy_ptr::deconstruct_moving_ptr` to use `core::mem::forget`

### DIFF
--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -1503,6 +1503,7 @@ macro_rules! deconstruct_moving_ptr {
         // - `mem::forget` is called on `self` immediately after these calls
         // - Each field is distinct, since otherwise the block of code above would fail compilation
         $(let $pattern = unsafe { ptr.move_field(|f| &raw mut (*f).$field_index) };)*
+        #[expect(clippy::mem_forget, reason = "`deconstruct_moving_ptr` needs to forget the `MovingPtr` due to its safety requirements.")]
         ::core::mem::forget(ptr);
     };
     ({ let MaybeUninit::<tuple> { $($field_index:tt: $pattern:pat),* $(,)? } = $ptr:expr ;}) => {
@@ -1527,6 +1528,7 @@ macro_rules! deconstruct_moving_ptr {
         // - `mem::forget` is called on `self` immediately after these calls
         // - Each field is distinct, since otherwise the block of code above would fail compilation
         $(let $pattern = unsafe { ptr.move_maybe_uninit_field(|f| &raw mut (*f).$field_index) };)*
+        #[expect(clippy::mem_forget, reason = "`deconstruct_moving_ptr` needs to forget the `MovingPtr` due to its safety requirements.")]
         ::core::mem::forget(ptr);
     };
     ({ let $struct_name:ident { $($field_index:tt$(: $pattern:pat)?),* $(,)? } = $ptr:expr ;}) => {
@@ -1550,6 +1552,7 @@ macro_rules! deconstruct_moving_ptr {
         // - `mem::forget` is called on `self` immediately after these calls
         // - Each field is distinct, since otherwise the block of code above would fail compilation
         $(let $crate::get_pattern!($field_index$(: $pattern)?) = unsafe { ptr.move_field(|f| &raw mut (*f).$field_index) };)*
+        #[expect(clippy::mem_forget, reason = "`deconstruct_moving_ptr` needs to forget the `MovingPtr` due to its safety requirements.")]
         ::core::mem::forget(ptr);
     };
     ({ let MaybeUninit::<$struct_name:ident> { $($field_index:tt$(: $pattern:pat)?),* $(,)? } = $ptr:expr ;}) => {
@@ -1574,6 +1577,7 @@ macro_rules! deconstruct_moving_ptr {
         // - `mem::forget` is called on `self` immediately after these calls
         // - Each field is distinct, since otherwise the block of code above would fail compilation
         $(let $crate::get_pattern!($field_index$(: $pattern)?) = unsafe { ptr.move_maybe_uninit_field(|f| &raw mut (*f).$field_index) };)*
+        #[expect(clippy::mem_forget, reason = "`deconstruct_moving_ptr` needs to forget the `MovingPtr` due to its safety requirements.")]
         ::core::mem::forget(ptr);
     };
 }


### PR DESCRIPTION
# Objective

Currently, when deriving `Bundle`[^1], and using the `clippy::mem_forget` lint from the `clippy::restricted` group, the lint will fire:
```rs
#![warn(clippy::mem_forget)]
#[derive(Bundle);
struct MyStruct;
```
This is because `Bundle` utilizes the [`deconstruct_moving_ptr`](https://docs.rs/bevy/latest/bevy/ecs/ptr/macro.deconstruct_moving_ptr.html) macro from `bevy_ptr`. This macro, in turn, moves the fields from `MovingPtr` out, and needs to call `core::mem::forget` on the original value, in order to avoid the freeing of used memory.

Because this is inside a `derive` macro, the lint is fired in the *calling code*, rather than in the bevy crate.
Additionally, since the code is generated in the *implementation of the trait*, rather than in the struct, it's not simply enough to add an expect attribute for the lint above the derive.

This PR simply allows the macro to be called without firing the lint.

[^1]: There may be other traits that cause the same behavior, but this is the one that motivated this PR.

## Solution

Add an `expect(clippy::mem_forget)` attribute to all `mem::forget` calls in `deconstruct_moving_ptr`.
It needs to be an expect rather than an allow because otherwise `clippy::allow_attributes` might fire.

## Testing

Run the example code above with the modified crate.
