### PR TITLE
Track DeferredWorld::trigger caller

### DIFF
--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -811,6 +811,7 @@ impl<'w> DeferredWorld<'w> {
     /// This will run any [`Observer`] of the given [`Event`] that isn't scoped to specific targets.
     ///
     /// [`Observer`]: crate::observer::Observer
+    #[track_caller]
     pub fn trigger<'a>(&mut self, event: impl Event<Trigger<'a>: Default>) {
         self.commands().trigger(event);
     }


### PR DESCRIPTION
`DeferredWorld::trigger` was missing `#[track_caller]`.

This PR doesn't change `bevy_ecs`'s triggers of the `ArchetypeCreated` event to pass along caller info, but is useful because `trigger` is a public method.