### PR TITLE
Fix transform gizmo local translation snapping

### DIFF
--- a/crates/bevy_gizmos/src/transform_gizmo.rs
+++ b/crates/bevy_gizmos/src/transform_gizmo.rs
@@ -535,12 +535,12 @@ fn transform_gizmo_drag(
                     let new_projected = cursor_vec.dot(axis_norm) * axis_norm + gizmo_origin;
                     let delta = new_projected - state.drag_start_world;
 
-                    let new_pos = state.start_transform.translation + delta;
                     transform.translation = match settings.snap_translate {
                         Some(inc) => {
-                            snap_axis(new_pos, state.start_transform.translation, axis, inc)
+                            state.start_transform.translation
+                                + axis_norm * snap_value(delta.dot(axis_norm), inc)
                         }
-                        None => new_pos,
+                        None => state.start_transform.translation + delta,
                     };
                 }
             }
@@ -744,27 +744,4 @@ pub fn gizmo_rotation(global_tf: &GlobalTransform, space: &TransformGizmoSpace) 
 
 fn snap_value(value: f32, increment: f32) -> f32 {
     (value / increment).round() * increment
-}
-
-/// Snap only the component along the dragged axis, leaving others unchanged.
-fn snap_axis(position: Vec3, original: Vec3, axis: TransformGizmoAxis, increment: f32) -> Vec3 {
-    match axis {
-        TransformGizmoAxis::X => {
-            Vec3::new(snap_value(position.x, increment), original.y, original.z)
-        }
-        TransformGizmoAxis::Y => {
-            Vec3::new(original.x, snap_value(position.y, increment), original.z)
-        }
-        TransformGizmoAxis::Z => {
-            Vec3::new(original.x, original.y, snap_value(position.z, increment))
-        }
-        TransformGizmoAxis::View => {
-            // Snap all axes uniformly
-            Vec3::new(
-                snap_value(position.x, increment),
-                snap_value(position.y, increment),
-                snap_value(position.z, increment),
-            )
-        }
-    }
 }


### PR DESCRIPTION
# Objective

Fixes #24431.

When translation snapping is enabled, the transform gizmo currently snaps world-space position components with `snap_axis`. This works for world-aligned axes, but breaks local-space translation on rotated entities because a local axis can affect multiple world-space components.

## Solution

Snap the scalar drag distance along the selected gizmo axis instead of snapping `x/y/z` position components.
This keeps snapping aligned with the actual drag axis in both world and local space.

## Testing

- `cargo check` in a local example using `TransformGizmoPlugin`
- `cargo fmt -p bevy_gizmos --check`
- I ran the reproduction actions from #24431 and verified the issue before applying the fix: with a rotated object in local space, translation snapping moved the object along world-space components instead of the displayed local gizmo axis. After applying this change, I repeated the same steps and confirmed that snapped translation follows the selected local axis as expected.