### PR TITLE
Activate missing-docs warning for `bevy_sprite`

### DIFF
--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -1,4 +1,3 @@
-#![expect(missing_docs, reason = "Not all docs are written yet, see #3492.")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(unsafe_code)]
 #![doc(
@@ -66,13 +65,6 @@ use bevy_math::Vec2;
 /// Adds support for 2D sprites.
 #[derive(Default)]
 pub struct SpritePlugin;
-
-/// System set for sprite rendering.
-#[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
-pub enum SpriteSystems {
-    ExtractSprites,
-    ComputeSlices,
-}
 
 impl Plugin for SpritePlugin {
     fn build(&self, app: &mut App) {

--- a/crates/bevy_sprite/src/sprite.rs
+++ b/crates/bevy_sprite/src/sprite.rs
@@ -263,6 +263,7 @@ impl Hash for Anchor {
     }
 }
 
+#[expect(missing_docs, reason = "the associated constants are self-documenting")]
 impl Anchor {
     pub const BOTTOM_LEFT: Self = Self(Vec2::new(-0.5, -0.5));
     pub const BOTTOM_CENTER: Self = Self(Vec2::new(0.0, -0.5));
@@ -274,6 +275,7 @@ impl Anchor {
     pub const TOP_CENTER: Self = Self(Vec2::new(0.0, 0.5));
     pub const TOP_RIGHT: Self = Self(Vec2::new(0.5, 0.5));
 
+    /// Returns the Anchor's offset as a [`Vec2`].
     pub fn as_vec(&self) -> Vec2 {
         self.0
     }

--- a/crates/bevy_sprite/src/sprite_mesh.rs
+++ b/crates/bevy_sprite/src/sprite_mesh.rs
@@ -175,6 +175,8 @@ impl SpriteMesh {
 // NOTE: If this is ever replaced by AlphaMode2d, make a custom Default impl for Sprite,
 // because AlphaMode2d defaults to Opaque, but the sprite's alpha mode is most commonly Mask(0.5)
 
+/// An enum describing how a sprite's alpha channel will be handled.
+/// The default is `Mask(0.5)`.
 #[derive(Debug, Reflect, Copy, Clone, PartialEq)]
 #[reflect(Default, Debug, Clone)]
 pub enum SpriteAlphaMode {

--- a/crates/bevy_sprite/src/sprite_mesh.rs
+++ b/crates/bevy_sprite/src/sprite_mesh.rs
@@ -176,6 +176,7 @@ impl SpriteMesh {
 // because AlphaMode2d defaults to Opaque, but the sprite's alpha mode is most commonly Mask(0.5)
 
 /// An enum describing how a sprite's alpha channel will be handled.
+/// The base color being modified is that of the texture after tinting.
 /// The default is `Mask(0.5)`.
 #[derive(Debug, Reflect, Copy, Clone, PartialEq)]
 #[reflect(Default, Debug, Clone)]


### PR DESCRIPTION
# Objective

Enable the lint missing-docs, crate by crate (see #3492)

## Solution

- Add docs where needed
- Add specific exceptions where needed
- In the process, found that `bevy_sprite` and `bevy_sprite_render` have identical but distinct system set enums, but only `bevy_sprite_render` uses its definition. This struck me as a bit of a footgun (users ordering systems against the `bevy_sprite` one will fail to order against any actual systems), so I deleted the one in `bevy_sprite`.

## Testing

Ran `cargo test --doc` for luck.
