### PR TITLE
Add Lens Dirt post-processing effect

### DIFF
--- a/crates/bevy_post_process/src/bloom/bloom.wgsl
+++ b/crates/bevy_post_process/src/bloom/bloom.wgsl
@@ -7,26 +7,23 @@
 // * [PBB] - Physically Based Bloom - https://learnopengl.com/Guest-Articles/2022/Phys.-Based-Bloom
 
 #import bevy_core_pipeline::fullscreen_vertex_shader::FullscreenVertexOutput
+#import bevy_post_process::lens_dirt::LensDirtUniforms
 
 struct BloomUniforms {
     threshold_precomputations: vec4<f32>,
     viewport: vec4<f32>,
     scale: vec2<f32>,
     aspect: f32,
-    lens_dirt_intensity: f32,
-    lens_dirt_tint: vec3<f32>,
-    padding: u32,
 };
 
 @group(0) @binding(0) var input_texture: texture_2d<f32>;
 @group(0) @binding(1) var s: sampler;
-
 @group(0) @binding(2) var<uniform> uniforms: BloomUniforms;
 @group(0) @binding(3) var<storage, read> blend_factor: f32;
-
 #ifdef LENS_DIRT
-@group(0) @binding(4) var dirt_texture: texture_2d<f32>;
-@group(0) @binding(5) var dirt_sampler: sampler;
+@group(1) @binding(0) var lens_dirt_texture: texture_2d<f32>;
+@group(1) @binding(1) var lens_dirt_sampler: sampler;
+@group(1) @binding(2) var<uniform> lens_dirt_uniforms: LensDirtUniforms;
 #endif
 
 #ifdef FIRST_DOWNSAMPLE
@@ -184,22 +181,6 @@ fn downsample_first(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
 }
 #endif
 
-#ifdef LENS_DIRT
-@fragment
-fn upsample_final(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
-    let bloom = sample_input_3x3_tent(in.uv);
-    let bloom_intensity = max(bloom.r, max(bloom.g, bloom.b));
-
-    let dirt = textureSample(dirt_texture, dirt_sampler, in.uv).r;
-    let amount = clamp(dirt * uniforms.lens_dirt_intensity * bloom_intensity, 0.0, 1.0);
-
-    let result_bloom = mix(bloom.rgb, bloom.rgb * uniforms.lens_dirt_tint.rgb, amount);
-    let alpha = mix(blend_factor, 1.0, amount);
-
-    return vec4<f32>(result_bloom, alpha);
-}
-#endif
-
 @fragment
 fn downsample(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
     return vec4<f32>(sample_input_13_tap(in.uv), 1.0);
@@ -207,5 +188,18 @@ fn downsample(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
 
 @fragment
 fn upsample(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
-    return vec4<f32>(sample_input_3x3_tent(in.uv), blend_factor);
+    let bloom = sample_input_3x3_tent(in.uv);
+#ifdef LENS_DIRT
+    let bloom_intensity = max(bloom.r, max(bloom.g, bloom.b));
+
+    let dirt = textureSample(lens_dirt_texture, lens_dirt_sampler, in.uv).r;
+    let amount = clamp(dirt * lens_dirt_uniforms.intensity * bloom_intensity, 0.0, 1.0);
+
+    let result_bloom = mix(bloom.rgb, bloom.rgb * lens_dirt_uniforms.tint.rgb, amount);
+    let alpha = mix(blend_factor, 1.0, amount);
+
+    return vec4<f32>(result_bloom, alpha);
+#else
+    return vec4<f32>(bloom, blend_factor);
+#endif
 }

--- a/crates/bevy_post_process/src/bloom/bloom.wgsl
+++ b/crates/bevy_post_process/src/bloom/bloom.wgsl
@@ -13,13 +13,6 @@ struct BloomUniforms {
     viewport: vec4<f32>,
     scale: vec2<f32>,
     aspect: f32,
-    intensity: f32,
-    low_frequency_boost: f32,
-    low_frequency_boost_curvature: f32,
-    high_pass_frequency: f32,
-    // BloomCompositeMode::EnergyConserving = 0, BloomCompositeMode::Additive = 1.
-    composite_mode: u32,
-    max_mip: f32,
     lens_dirt_intensity: f32,
     lens_dirt_tint: vec3<f32>,
     padding: u32,
@@ -29,25 +22,11 @@ struct BloomUniforms {
 @group(0) @binding(1) var s: sampler;
 
 @group(0) @binding(2) var<uniform> uniforms: BloomUniforms;
+@group(0) @binding(3) var<storage, read> blend_factor: f32;
 
 #ifdef LENS_DIRT
-@group(0) @binding(3) var dirt_texture: texture_2d<f32>;
-@group(0) @binding(4) var dirt_sampler: sampler;
-
-// Shader version of `compute_blend_factor`.
-fn compute_blend_factor_gpu(mip: f32, max_mip: f32) -> f32 {
-    var lf_boost = (1.0 - pow(
-        1.0 - (mip / max_mip),
-        1.0 / (1.0 - uniforms.low_frequency_boost_curvature)
-        )) * uniforms.low_frequency_boost;
-    var high_pass_lq = 1.0 - clamp(
-        ((mip / max_mip) - uniforms.high_pass_frequency) / uniforms.high_pass_frequency,
-        0.0, 1.0);
-    if uniforms.composite_mode == 0u {
-        lf_boost *= 1.0 - uniforms.intensity;
-    }
-    return (uniforms.intensity + lf_boost) * high_pass_lq;
-}
+@group(0) @binding(4) var dirt_texture: texture_2d<f32>;
+@group(0) @binding(5) var dirt_sampler: sampler;
 #endif
 
 #ifdef FIRST_DOWNSAMPLE
@@ -210,13 +189,12 @@ fn downsample_first(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
 fn upsample_final(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
     let bloom = sample_input_3x3_tent(in.uv);
     let bloom_intensity = max(bloom.r, max(bloom.g, bloom.b));
-    let base_alpha = compute_blend_factor_gpu(0.0, uniforms.max_mip);
 
     let dirt = textureSample(dirt_texture, dirt_sampler, in.uv).r;
     let amount = clamp(dirt * uniforms.lens_dirt_intensity * bloom_intensity, 0.0, 1.0);
 
     let result_bloom = mix(bloom.rgb, bloom.rgb * uniforms.lens_dirt_tint.rgb, amount);
-    let alpha = mix(base_alpha, 1.0, amount);
+    let alpha = mix(blend_factor, 1.0, amount);
 
     return vec4<f32>(result_bloom, alpha);
 }
@@ -229,5 +207,5 @@ fn downsample(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
 
 @fragment
 fn upsample(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
-    return vec4<f32>(sample_input_3x3_tent(in.uv), 1.0);
+    return vec4<f32>(sample_input_3x3_tent(in.uv), blend_factor);
 }

--- a/crates/bevy_post_process/src/bloom/bloom.wgsl
+++ b/crates/bevy_post_process/src/bloom/bloom.wgsl
@@ -6,17 +6,49 @@
 // * [COD] - Next Generation Post Processing in Call of Duty - http://www.iryoku.com/next-generation-post-processing-in-call-of-duty-advanced-warfare
 // * [PBB] - Physically Based Bloom - https://learnopengl.com/Guest-Articles/2022/Phys.-Based-Bloom
 
+#import bevy_core_pipeline::fullscreen_vertex_shader::FullscreenVertexOutput
+
 struct BloomUniforms {
     threshold_precomputations: vec4<f32>,
     viewport: vec4<f32>,
     scale: vec2<f32>,
     aspect: f32,
+    intensity: f32,
+    low_frequency_boost: f32,
+    low_frequency_boost_curvature: f32,
+    high_pass_frequency: f32,
+    // BloomCompositeMode::EnergyConserving = 0, BloomCompositeMode::Additive = 1.
+    composite_mode: u32,
+    max_mip: f32,
+    lens_dirt_intensity: f32,
+    lens_dirt_tint: vec3<f32>,
+    padding: u32,
 };
 
 @group(0) @binding(0) var input_texture: texture_2d<f32>;
 @group(0) @binding(1) var s: sampler;
 
 @group(0) @binding(2) var<uniform> uniforms: BloomUniforms;
+
+#ifdef LENS_DIRT
+@group(0) @binding(3) var dirt_texture: texture_2d<f32>;
+@group(0) @binding(4) var dirt_sampler: sampler;
+
+// Shader version of `compute_blend_factor`.
+fn compute_blend_factor_gpu(mip: f32, max_mip: f32) -> f32 {
+    var lf_boost = (1.0 - pow(
+        1.0 - (mip / max_mip),
+        1.0 / (1.0 - uniforms.low_frequency_boost_curvature)
+        )) * uniforms.low_frequency_boost;
+    var high_pass_lq = 1.0 - clamp(
+        ((mip / max_mip) - uniforms.high_pass_frequency) / uniforms.high_pass_frequency,
+        0.0, 1.0);
+    if uniforms.composite_mode == 0u {
+        lf_boost *= 1.0 - uniforms.intensity;
+    }
+    return (uniforms.intensity + lf_boost) * high_pass_lq;
+}
+#endif
 
 #ifdef FIRST_DOWNSAMPLE
 // https://catlikecoding.com/unity/tutorials/advanced-rendering/bloom/#3.4
@@ -155,9 +187,10 @@ fn sample_input_3x3_tent(uv: vec2<f32>) -> vec3<f32> {
 
 #ifdef FIRST_DOWNSAMPLE
 @fragment
-fn downsample_first(@location(0) output_uv: vec2<f32>) -> @location(0) vec4<f32> {
-    let sample_uv = uniforms.viewport.xy + output_uv * uniforms.viewport.zw;
+fn downsample_first(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
+    let sample_uv = uniforms.viewport.xy + in.uv * uniforms.viewport.zw;
     var sample = sample_input_13_tap(sample_uv);
+
     // Lower bound of 0.0001 is to avoid propagating multiplying by 0.0 through the
     // downscaling and upscaling which would result in black boxes.
     // The upper bound is to prevent NaNs.
@@ -172,12 +205,29 @@ fn downsample_first(@location(0) output_uv: vec2<f32>) -> @location(0) vec4<f32>
 }
 #endif
 
+#ifdef LENS_DIRT
 @fragment
-fn downsample(@location(0) uv: vec2<f32>) -> @location(0) vec4<f32> {
-    return vec4<f32>(sample_input_13_tap(uv), 1.0);
+fn upsample_final(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
+    let bloom = sample_input_3x3_tent(in.uv);
+    let bloom_intensity = max(bloom.r, max(bloom.g, bloom.b));
+    let base_alpha = compute_blend_factor_gpu(0.0, uniforms.max_mip);
+
+    let dirt = textureSample(dirt_texture, dirt_sampler, in.uv).r;
+    let amount = clamp(dirt * uniforms.lens_dirt_intensity * bloom_intensity, 0.0, 1.0);
+
+    let result_bloom = mix(bloom.rgb, bloom.rgb * uniforms.lens_dirt_tint.rgb, amount);
+    let alpha = mix(base_alpha, 1.0, amount);
+
+    return vec4<f32>(result_bloom, alpha);
+}
+#endif
+
+@fragment
+fn downsample(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
+    return vec4<f32>(sample_input_13_tap(in.uv), 1.0);
 }
 
 @fragment
-fn upsample(@location(0) uv: vec2<f32>) -> @location(0) vec4<f32> {
-    return vec4<f32>(sample_input_3x3_tent(uv), 1.0);
+fn upsample(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
+    return vec4<f32>(sample_input_3x3_tent(in.uv), 1.0);
 }

--- a/crates/bevy_post_process/src/bloom/bloom.wgsl
+++ b/crates/bevy_post_process/src/bloom/bloom.wgsl
@@ -7,7 +7,10 @@
 // * [PBB] - Physically Based Bloom - https://learnopengl.com/Guest-Articles/2022/Phys.-Based-Bloom
 
 #import bevy_core_pipeline::fullscreen_vertex_shader::FullscreenVertexOutput
-#import bevy_post_process::lens_dirt::LensDirtUniforms
+
+#ifdef LENS_DIRT
+#import bevy_post_process::lens_dirt::{LensDirtUniforms, lens_dirt_texture, lens_dirt_sampler, lens_dirt_uniforms}
+#endif
 
 struct BloomUniforms {
     threshold_precomputations: vec4<f32>,
@@ -20,11 +23,6 @@ struct BloomUniforms {
 @group(0) @binding(1) var s: sampler;
 @group(0) @binding(2) var<uniform> uniforms: BloomUniforms;
 @group(0) @binding(3) var<storage, read> blend_factor: f32;
-#ifdef LENS_DIRT
-@group(1) @binding(0) var lens_dirt_texture: texture_2d<f32>;
-@group(1) @binding(1) var lens_dirt_sampler: sampler;
-@group(1) @binding(2) var<uniform> lens_dirt_uniforms: LensDirtUniforms;
-#endif
 
 #ifdef FIRST_DOWNSAMPLE
 // https://catlikecoding.com/unity/tutorials/advanced-rendering/bloom/#3.4

--- a/crates/bevy_post_process/src/bloom/downsampling_pipeline.rs
+++ b/crates/bevy_post_process/src/bloom/downsampling_pipeline.rs
@@ -1,13 +1,13 @@
-use bevy_core_pipeline::FullscreenShader;
+use super::{settings::BloomUniforms, Bloom, BLOOM_TEXTURE_FORMAT};
 
-use super::{Bloom, BLOOM_TEXTURE_FORMAT};
 use bevy_asset::{load_embedded_asset, AssetServer, Handle};
+use bevy_core_pipeline::FullscreenShader;
 use bevy_ecs::{
     prelude::{Component, Entity},
     resource::Resource,
     system::{Commands, Query, Res, ResMut},
 };
-use bevy_math::{Vec2, Vec4};
+use bevy_math::Vec2;
 use bevy_render::{
     render_resource::{
         binding_types::{sampler, texture_2d, uniform_buffer},
@@ -40,17 +40,6 @@ pub struct BloomDownsamplingPipelineKeys {
     prefilter: bool,
     first_downsample: bool,
     uniform_scale: bool,
-}
-
-/// The uniform struct extracted from [`Bloom`] attached to a Camera.
-/// Will be available for use in the Bloom shader.
-#[derive(Component, ShaderType, Clone)]
-pub struct BloomUniforms {
-    // Precomputed values used when thresholding, see https://catlikecoding.com/unity/tutorials/advanced-rendering/bloom/#3.4
-    pub threshold_precomputations: Vec4,
-    pub viewport: Vec4,
-    pub scale: Vec2,
-    pub aspect: f32,
 }
 
 pub fn init_bloom_downsampling_pipeline(

--- a/crates/bevy_post_process/src/bloom/mod.rs
+++ b/crates/bevy_post_process/src/bloom/mod.rs
@@ -266,7 +266,7 @@ pub fn bloom(
         {
             upsampling_final_pass.set_bind_group(
                 1,
-                &lens_dirt_bind_group.0,
+                &lens_dirt_bind_group.bind_group,
                 &[lens_dirt_uniform_index.index()],
             );
         }

--- a/crates/bevy_post_process/src/bloom/mod.rs
+++ b/crates/bevy_post_process/src/bloom/mod.rs
@@ -2,18 +2,21 @@ mod downsampling_pipeline;
 mod settings;
 mod upsampling_pipeline;
 
-use crate::bloom::{
-    downsampling_pipeline::{
-        init_bloom_downsampling_pipeline, prepare_downsampling_pipeline, BloomDownsamplingPipeline,
-        BloomDownsamplingPipelineIds,
+use crate::{
+    bloom::{
+        downsampling_pipeline::{
+            init_bloom_downsampling_pipeline, prepare_downsampling_pipeline,
+            BloomDownsamplingPipeline, BloomDownsamplingPipelineIds,
+        },
+        settings::BloomUniforms,
+        upsampling_pipeline::{
+            init_bloom_upscaling_pipeline, prepare_upsampling_pipeline, BloomUpsamplingPipeline,
+            UpsamplingPipelineIds,
+        },
     },
-    settings::BloomUniforms,
-    upsampling_pipeline::{
-        init_bloom_upscaling_pipeline, prepare_upsampling_pipeline, BloomUpsamplingPipeline,
-        UpsamplingPipelineIds,
-    },
+    lens_dirt::{LensDirtBindGroup, LensDirtUniforms},
 };
-pub use settings::{Bloom, BloomCompositeMode, BloomPrefilter, LensDirt};
+pub use settings::{Bloom, BloomCompositeMode, BloomPrefilter};
 
 use bevy_app::{App, Plugin};
 use bevy_asset::embedded_asset;
@@ -30,10 +33,9 @@ use bevy_render::{
     extract_component::{
         ComponentUniforms, DynamicUniformIndex, ExtractComponentPlugin, UniformComponentPlugin,
     },
-    render_asset::RenderAssets,
     render_resource::*,
     renderer::{RenderContext, RenderDevice, ViewQuery},
-    texture::{CachedTexture, FallbackImage, GpuImage, TextureCache},
+    texture::{CachedTexture, TextureCache},
     view::ViewTarget,
     GpuResourceAppExt, Render, RenderApp, RenderStartup, RenderSystems,
 };
@@ -41,6 +43,7 @@ use core::num::NonZero;
 
 const BLOOM_TEXTURE_FORMAT: TextureFormat = TextureFormat::Rg11b10Ufloat;
 
+/// A plugin that adds support for the bloom effect to Bevy.
 #[derive(Default)]
 pub struct BloomPlugin;
 
@@ -96,13 +99,12 @@ pub fn bloom(
         &Bloom,
         &UpsamplingPipelineIds,
         &BloomDownsamplingPipelineIds,
+        Option<&LensDirtBindGroup>,
+        Option<&DynamicUniformIndex<LensDirtUniforms>>,
     )>,
     downsampling_pipeline_res: Res<BloomDownsamplingPipeline>,
-    upsampling_pipeline_res: Res<BloomUpsamplingPipeline>,
     pipeline_cache: Res<PipelineCache>,
     uniforms: Res<ComponentUniforms<BloomUniforms>>,
-    gpu_images: Res<RenderAssets<GpuImage>>,
-    fallback: Res<FallbackImage>,
     mut ctx: RenderContext,
 ) {
     let (
@@ -114,11 +116,17 @@ pub fn bloom(
         bloom_settings,
         upsampling_pipeline_ids,
         downsampling_pipeline_ids,
+        maybe_lens_dirt_bind_group,
+        maybe_lens_dirt_uniform_index,
     ) = view.into_inner();
 
     if bloom_settings.intensity == 0.0 || !camera.hdr {
         return;
     }
+
+    let final_pipeline_id = maybe_lens_dirt_bind_group
+        .and_then(|_| upsampling_pipeline_ids.id_final_dirt)
+        .unwrap_or(upsampling_pipeline_ids.id_final);
 
     let (
         Some(uniforms_binding),
@@ -131,7 +139,7 @@ pub fn bloom(
         pipeline_cache.get_render_pipeline(downsampling_pipeline_ids.first),
         pipeline_cache.get_render_pipeline(downsampling_pipeline_ids.main),
         pipeline_cache.get_render_pipeline(upsampling_pipeline_ids.id_main),
-        pipeline_cache.get_render_pipeline(upsampling_pipeline_ids.id_final),
+        pipeline_cache.get_render_pipeline(final_pipeline_id),
     )
     else {
         return;
@@ -150,40 +158,6 @@ pub fn bloom(
             uniforms_binding.clone(),
         )),
     );
-
-    // Use dirt pipeline if ready, otherwise standard final pipeline.
-    let (final_pipeline, use_dirt) = match upsampling_pipeline_ids.id_final_dirt {
-        Some(dirt_id) => match pipeline_cache.get_render_pipeline(dirt_id) {
-            Some(dirt_pipeline) => (dirt_pipeline, true),
-            None => (upsampling_final_pipeline, false),
-        },
-        None => (upsampling_final_pipeline, false),
-    };
-
-    // Choose the appropriate final bind group.
-    let final_bind_group = match (use_dirt, &bloom_settings.lens_dirt.texture) {
-        (true, Some(lens_dirt_texture)) => {
-            let dirt_image = gpu_images.get(lens_dirt_texture).unwrap_or(&fallback.d2);
-            ctx.render_device().create_bind_group(
-                "bloom_final_dirt_bind_group",
-                &pipeline_cache
-                    .get_bind_group_layout(&upsampling_pipeline_res.dirt_bind_group_layout),
-                &BindGroupEntries::sequential((
-                    &bloom_texture.view(0),
-                    &bind_groups.sampler,
-                    uniforms_binding.clone(),
-                    BufferBinding {
-                        buffer: &bind_groups.blend_factor_buffers[0],
-                        offset: 0,
-                        size: NonZero::<u64>::new(4),
-                    },
-                    &dirt_image.texture_view,
-                    &bind_groups.sampler,
-                )),
-            )
-        }
-        _ => bind_groups.upsampling_bind_groups[(bloom_texture.mip_count - 1) as usize].clone(),
-    };
 
     let diagnostics = ctx.diagnostic_recorder();
     let diagnostics = diagnostics.as_deref();
@@ -281,8 +255,21 @@ pub fn bloom(
             occlusion_query_set: None,
             multiview_mask: None,
         });
-        upsampling_final_pass.set_pipeline(final_pipeline);
-        upsampling_final_pass.set_bind_group(0, &final_bind_group, &[uniform_index.index()]);
+        upsampling_final_pass.set_pipeline(upsampling_final_pipeline);
+        upsampling_final_pass.set_bind_group(
+            0,
+            &bind_groups.upsampling_bind_groups[(bloom_texture.mip_count - 1) as usize].clone(),
+            &[uniform_index.index()],
+        );
+        if let (Some(lens_dirt_bind_group), Some(lens_dirt_uniform_index)) =
+            (maybe_lens_dirt_bind_group, maybe_lens_dirt_uniform_index)
+        {
+            upsampling_final_pass.set_bind_group(
+                1,
+                &lens_dirt_bind_group.0,
+                &[lens_dirt_uniform_index.index()],
+            );
+        }
         if let Some(viewport) = camera.viewport.as_ref() {
             upsampling_final_pass.set_viewport(
                 viewport.physical_position.x as f32,
@@ -414,7 +401,6 @@ pub struct BloomBindGroups {
     cache_key: (Vec<TextureId>, BufferId),
     downsampling_bind_groups: Box<[BindGroup]>,
     upsampling_bind_groups: Box<[BindGroup]>,
-    blend_factor_buffers: Box<[Buffer]>,
     sampler: Sampler,
 }
 
@@ -470,20 +456,11 @@ fn prepare_bloom_bind_groups(
             ));
         }
 
-        let mip_count = bloom_texture.mip_count;
-        let blend_factor_buffers: Box<[Buffer]> = (0..mip_count)
-            .map(|mip| {
-                let factor = compute_blend_factor(bloom, mip as f32, (mip_count - 1) as f32);
-                render_device.create_buffer_with_data(&BufferInitDescriptor {
-                    label: Some("bloom_blend_factor"),
-                    contents: &factor.to_ne_bytes(),
-                    usage: BufferUsages::STORAGE,
-                })
-            })
-            .collect();
-
-        let mut upsampling_bind_groups = Vec::with_capacity(bind_group_count);
+        let mut upsampling_bind_groups = Vec::with_capacity(bloom_texture.mip_count as usize);
         for mip in (0..bloom_texture.mip_count).rev() {
+            let blend_factor =
+                compute_blend_factor(bloom, mip as f32, (bloom_texture.mip_count - 1) as f32);
+
             upsampling_bind_groups.push(render_device.create_bind_group(
                 "bloom_upsampling_bind_group",
                 &pipeline_cache.get_bind_group_layout(&upsampling_pipeline.bind_group_layout),
@@ -492,7 +469,11 @@ fn prepare_bloom_bind_groups(
                     sampler,
                     uniforms.binding().unwrap(),
                     BufferBinding {
-                        buffer: &blend_factor_buffers[mip as usize],
+                        buffer: &render_device.create_buffer_with_data(&BufferInitDescriptor {
+                            label: Some("bloom_blend_factor"),
+                            contents: &blend_factor.to_ne_bytes(),
+                            usage: BufferUsages::STORAGE,
+                        }),
                         offset: 0,
                         size: NonZero::<u64>::new(4),
                     },
@@ -504,7 +485,6 @@ fn prepare_bloom_bind_groups(
             cache_key,
             downsampling_bind_groups: downsampling_bind_groups.into_boxed_slice(),
             upsampling_bind_groups: upsampling_bind_groups.into_boxed_slice(),
-            blend_factor_buffers,
             sampler: sampler.clone(),
         });
     }

--- a/crates/bevy_post_process/src/bloom/mod.rs
+++ b/crates/bevy_post_process/src/bloom/mod.rs
@@ -2,13 +2,19 @@ mod downsampling_pipeline;
 mod settings;
 mod upsampling_pipeline;
 
-use bevy_image::ToExtents;
-pub use settings::{Bloom, BloomCompositeMode, BloomPrefilter};
-
 use crate::bloom::{
-    downsampling_pipeline::init_bloom_downsampling_pipeline,
-    upsampling_pipeline::init_bloom_upscaling_pipeline,
+    downsampling_pipeline::{
+        init_bloom_downsampling_pipeline, prepare_downsampling_pipeline, BloomDownsamplingPipeline,
+        BloomDownsamplingPipelineIds,
+    },
+    settings::BloomUniforms,
+    upsampling_pipeline::{
+        init_bloom_upscaling_pipeline, prepare_upsampling_pipeline, BloomUpsamplingPipeline,
+        UpsamplingPipelineIds,
+    },
 };
+pub use settings::{Bloom, BloomCompositeMode, BloomPrefilter, LensDirt};
+
 use bevy_app::{App, Plugin};
 use bevy_asset::embedded_asset;
 use bevy_color::{Gray, LinearRgba};
@@ -17,6 +23,7 @@ use bevy_core_pipeline::{
     tonemapping::tonemapping,
 };
 use bevy_ecs::prelude::*;
+use bevy_image::ToExtents;
 use bevy_math::{ops, UVec2};
 use bevy_render::{
     camera::ExtractedCamera,
@@ -24,18 +31,12 @@ use bevy_render::{
     extract_component::{
         ComponentUniforms, DynamicUniformIndex, ExtractComponentPlugin, UniformComponentPlugin,
     },
+    render_asset::RenderAssets,
     render_resource::*,
     renderer::{RenderContext, RenderDevice, ViewQuery},
-    texture::{CachedTexture, TextureCache},
+    texture::{CachedTexture, FallbackImage, GpuImage, TextureCache},
     view::ViewTarget,
     GpuResourceAppExt, Render, RenderApp, RenderStartup, RenderSystems,
-};
-use downsampling_pipeline::{
-    prepare_downsampling_pipeline, BloomDownsamplingPipeline, BloomDownsamplingPipelineIds,
-    BloomUniforms,
-};
-use upsampling_pipeline::{
-    prepare_upsampling_pipeline, BloomUpsamplingPipeline, UpsamplingPipelineIds,
 };
 
 const BLOOM_TEXTURE_FORMAT: TextureFormat = TextureFormat::Rg11b10Ufloat;
@@ -97,8 +98,11 @@ pub fn bloom(
         &BloomDownsamplingPipelineIds,
     )>,
     downsampling_pipeline_res: Res<BloomDownsamplingPipeline>,
+    upsampling_pipeline_res: Res<BloomUpsamplingPipeline>,
     pipeline_cache: Res<PipelineCache>,
     uniforms: Res<ComponentUniforms<BloomUniforms>>,
+    gpu_images: Res<RenderAssets<GpuImage>>,
+    fallback: Res<FallbackImage>,
     mut ctx: RenderContext,
 ) {
     let (
@@ -146,6 +150,35 @@ pub fn bloom(
             uniforms_binding.clone(),
         )),
     );
+
+    // Use dirt pipeline if ready, otherwise standard final pipeline.
+    let (final_pipeline, use_dirt) = match upsampling_pipeline_ids.id_final_dirt {
+        Some(dirt_id) => match pipeline_cache.get_render_pipeline(dirt_id) {
+            Some(dirt_pipeline) => (dirt_pipeline, true),
+            None => (upsampling_final_pipeline, false),
+        },
+        None => (upsampling_final_pipeline, false),
+    };
+
+    // Choose the appropriate final bind group.
+    let final_bind_group = match (use_dirt, &bloom_settings.lens_dirt.texture) {
+        (true, Some(lens_dirt_texture)) => {
+            let dirt_image = gpu_images.get(lens_dirt_texture).unwrap_or(&fallback.d2);
+            ctx.render_device().create_bind_group(
+                "bloom_final_dirt_bind_group",
+                &pipeline_cache
+                    .get_bind_group_layout(&upsampling_pipeline_res.dirt_bind_group_layout),
+                &BindGroupEntries::sequential((
+                    &bloom_texture.view(0),
+                    &bind_groups.sampler,
+                    uniforms_binding.clone(),
+                    &dirt_image.texture_view,
+                    &bind_groups.sampler,
+                )),
+            )
+        }
+        _ => bind_groups.upsampling_bind_groups[(bloom_texture.mip_count - 1) as usize].clone(),
+    };
 
     let diagnostics = ctx.diagnostic_recorder();
     let diagnostics = diagnostics.as_deref();
@@ -249,12 +282,8 @@ pub fn bloom(
             occlusion_query_set: None,
             multiview_mask: None,
         });
-        upsampling_final_pass.set_pipeline(upsampling_final_pipeline);
-        upsampling_final_pass.set_bind_group(
-            0,
-            &bind_groups.upsampling_bind_groups[(bloom_texture.mip_count - 1) as usize],
-            &[uniform_index.index()],
-        );
+        upsampling_final_pass.set_pipeline(final_pipeline);
+        upsampling_final_pass.set_bind_group(0, &final_bind_group, &[uniform_index.index()]);
         if let Some(viewport) = camera.viewport.as_ref() {
             upsampling_final_pass.set_viewport(
                 viewport.physical_position.x as f32,
@@ -265,8 +294,12 @@ pub fn bloom(
                 viewport.depth.end,
             );
         }
-        let blend = compute_blend_factor(bloom_settings, 0.0, (bloom_texture.mip_count - 1) as f32);
-        upsampling_final_pass.set_blend_constant(LinearRgba::gray(blend).into());
+
+        if !use_dirt {
+            let blend =
+                compute_blend_factor(bloom_settings, 0.0, (bloom_texture.mip_count - 1) as f32);
+            upsampling_final_pass.set_blend_constant(LinearRgba::gray(blend).into());
+        }
         upsampling_final_pass.draw(0..3, 0..1);
     }
 

--- a/crates/bevy_post_process/src/bloom/mod.rs
+++ b/crates/bevy_post_process/src/bloom/mod.rs
@@ -125,7 +125,7 @@ pub fn bloom(
     }
 
     let final_pipeline_id = maybe_lens_dirt_bind_group
-        .and_then(|_| upsampling_pipeline_ids.id_final_dirt)
+        .and(upsampling_pipeline_ids.id_final_dirt)
         .unwrap_or(upsampling_pipeline_ids.id_final);
 
     let (

--- a/crates/bevy_post_process/src/bloom/mod.rs
+++ b/crates/bevy_post_process/src/bloom/mod.rs
@@ -17,7 +17,6 @@ pub use settings::{Bloom, BloomCompositeMode, BloomPrefilter, LensDirt};
 
 use bevy_app::{App, Plugin};
 use bevy_asset::embedded_asset;
-use bevy_color::{Gray, LinearRgba};
 use bevy_core_pipeline::{
     schedule::{Core2d, Core2dSystems, Core3d, Core3dSystems},
     tonemapping::tonemapping,
@@ -38,6 +37,7 @@ use bevy_render::{
     view::ViewTarget,
     GpuResourceAppExt, Render, RenderApp, RenderStartup, RenderSystems,
 };
+use core::num::NonZero;
 
 const BLOOM_TEXTURE_FORMAT: TextureFormat = TextureFormat::Rg11b10Ufloat;
 
@@ -172,6 +172,11 @@ pub fn bloom(
                     &bloom_texture.view(0),
                     &bind_groups.sampler,
                     uniforms_binding.clone(),
+                    BufferBinding {
+                        buffer: &bind_groups.blend_factor_buffers[0],
+                        offset: 0,
+                        size: NonZero::<u64>::new(4),
+                    },
                     &dirt_image.texture_view,
                     &bind_groups.sampler,
                 )),
@@ -263,12 +268,6 @@ pub fn bloom(
             &bind_groups.upsampling_bind_groups[(bloom_texture.mip_count - mip - 1) as usize],
             &[uniform_index.index()],
         );
-        let blend = compute_blend_factor(
-            bloom_settings,
-            mip as f32,
-            (bloom_texture.mip_count - 1) as f32,
-        );
-        upsampling_pass.set_blend_constant(LinearRgba::gray(blend).into());
         upsampling_pass.draw(0..3, 0..1);
     }
 
@@ -293,12 +292,6 @@ pub fn bloom(
                 viewport.depth.start,
                 viewport.depth.end,
             );
-        }
-
-        if !use_dirt {
-            let blend =
-                compute_blend_factor(bloom_settings, 0.0, (bloom_texture.mip_count - 1) as f32);
-            upsampling_final_pass.set_blend_constant(LinearRgba::gray(blend).into());
         }
         upsampling_final_pass.draw(0..3, 0..1);
     }
@@ -421,6 +414,7 @@ pub struct BloomBindGroups {
     cache_key: (Vec<TextureId>, BufferId),
     downsampling_bind_groups: Box<[BindGroup]>,
     upsampling_bind_groups: Box<[BindGroup]>,
+    blend_factor_buffers: Box<[Buffer]>,
     sampler: Sampler,
 }
 
@@ -429,13 +423,13 @@ fn prepare_bloom_bind_groups(
     render_device: Res<RenderDevice>,
     downsampling_pipeline: Res<BloomDownsamplingPipeline>,
     upsampling_pipeline: Res<BloomUpsamplingPipeline>,
-    views: Query<(Entity, &BloomTexture, Option<&BloomBindGroups>)>,
+    views: Query<(Entity, &BloomTexture, &Bloom, Option<&BloomBindGroups>)>,
     uniforms: Res<ComponentUniforms<BloomUniforms>>,
     pipeline_cache: Res<PipelineCache>,
 ) {
     let sampler = &downsampling_pipeline.sampler;
 
-    for (entity, bloom_texture, bloom_bind_groups) in &views {
+    for (entity, bloom_texture, bloom, bloom_bind_groups) in &views {
         #[cfg(any(
             not(feature = "webgl"),
             not(target_arch = "wasm32"),
@@ -476,6 +470,18 @@ fn prepare_bloom_bind_groups(
             ));
         }
 
+        let mip_count = bloom_texture.mip_count;
+        let blend_factor_buffers: Box<[Buffer]> = (0..mip_count)
+            .map(|mip| {
+                let factor = compute_blend_factor(bloom, mip as f32, (mip_count - 1) as f32);
+                render_device.create_buffer_with_data(&BufferInitDescriptor {
+                    label: Some("bloom_blend_factor"),
+                    contents: &factor.to_ne_bytes(),
+                    usage: BufferUsages::STORAGE,
+                })
+            })
+            .collect();
+
         let mut upsampling_bind_groups = Vec::with_capacity(bind_group_count);
         for mip in (0..bloom_texture.mip_count).rev() {
             upsampling_bind_groups.push(render_device.create_bind_group(
@@ -485,6 +491,11 @@ fn prepare_bloom_bind_groups(
                     &bloom_texture.view(mip),
                     sampler,
                     uniforms.binding().unwrap(),
+                    BufferBinding {
+                        buffer: &blend_factor_buffers[mip as usize],
+                        offset: 0,
+                        size: NonZero::<u64>::new(4),
+                    },
                 )),
             ));
         }
@@ -493,6 +504,7 @@ fn prepare_bloom_bind_groups(
             cache_key,
             downsampling_bind_groups: downsampling_bind_groups.into_boxed_slice(),
             upsampling_bind_groups: upsampling_bind_groups.into_boxed_slice(),
+            blend_factor_buffers,
             sampler: sampler.clone(),
         });
     }

--- a/crates/bevy_post_process/src/bloom/settings.rs
+++ b/crates/bevy_post_process/src/bloom/settings.rs
@@ -325,15 +325,6 @@ impl ExtractComponent<RenderApp> for Bloom {
                     aspect: AspectRatio::try_from_pixels(size.x, size.y)
                         .expect("Valid screen size values for Bloom settings")
                         .ratio(),
-                    intensity: bloom.intensity,
-                    low_frequency_boost: bloom.low_frequency_boost,
-                    low_frequency_boost_curvature: bloom.low_frequency_boost_curvature,
-                    high_pass_frequency: bloom.high_pass_frequency,
-                    composite_mode: match bloom.composite_mode {
-                        BloomCompositeMode::EnergyConserving => 0,
-                        BloomCompositeMode::Additive => 1,
-                    },
-                    max_mip: (bloom.max_mip_dimension.ilog2().max(2) - 1).saturating_sub(1) as f32,
                     lens_dirt_intensity: bloom.lens_dirt.intensity,
                     lens_dirt_tint: bloom.lens_dirt.tint.to_linear().to_vec3(),
                     padding: 0,
@@ -355,12 +346,6 @@ pub struct BloomUniforms {
     pub viewport: Vec4,
     pub scale: Vec2,
     pub aspect: f32,
-    pub intensity: f32,
-    pub low_frequency_boost: f32,
-    pub low_frequency_boost_curvature: f32,
-    pub high_pass_frequency: f32,
-    pub composite_mode: u32,
-    pub max_mip: f32,
     pub lens_dirt_intensity: f32,
     pub lens_dirt_tint: Vec3,
     pub padding: u32,

--- a/crates/bevy_post_process/src/bloom/settings.rs
+++ b/crates/bevy_post_process/src/bloom/settings.rs
@@ -1,10 +1,12 @@
-use bevy_asset::Handle;
+use bevy_asset::{Handle, HandleTemplate};
 use bevy_camera::{Camera, Hdr};
 use bevy_color::{Color, ColorToComponents};
 use bevy_ecs::{
+    error::Result as EcsResult,
     prelude::Component,
     query::{QueryItem, With},
     reflect::ReflectComponent,
+    template::{FromTemplate, OptionTemplate, Template, TemplateContext},
 };
 use bevy_image::Image;
 use bevy_math::{AspectRatio, URect, UVec4, Vec2, Vec3, Vec4};
@@ -32,7 +34,7 @@ use bevy_render::{
 /// blurred (lower frequency) images generated from the camera's view.
 /// See <https://starlederer.github.io/bloom/> for a visualization of the parametric curve
 /// used in Bevy as well as a visualization of the curve's respective scattering profile.
-#[derive(Component, Reflect, Clone)]
+#[derive(Component, Reflect, Clone, FromTemplate)]
 #[reflect(Component, Default, Clone)]
 #[require(Hdr)]
 pub struct Bloom {
@@ -217,6 +219,18 @@ impl Default for Bloom {
     }
 }
 
+impl Template for Bloom {
+    type Output = Bloom;
+
+    fn build_template(&self, _context: &mut TemplateContext) -> EcsResult<Self::Output> {
+        Ok(self.clone())
+    }
+
+    fn clone_template(&self) -> Self {
+        self.clone()
+    }
+}
+
 /// Applies a threshold filter to the input image to extract the brightest
 /// regions before blurring them and compositing back onto the original image.
 /// These settings are useful when emulating the 1990s-2000s game look.
@@ -242,9 +256,10 @@ pub struct BloomPrefilter {
     pub threshold_softness: f32,
 }
 
-#[derive(Debug, Clone, Reflect, PartialEq, Eq, Hash, Copy)]
-#[reflect(Clone, Hash, PartialEq)]
+#[derive(Debug, Clone, Reflect, PartialEq, Eq, Hash, Copy, Default)]
+#[reflect(Clone, Hash, PartialEq, Default)]
 pub enum BloomCompositeMode {
+    #[default]
     EnergyConserving,
     Additive,
 }
@@ -253,10 +268,11 @@ pub enum BloomCompositeMode {
 ///
 /// Lens dirt overlays a texture (e.g., dust, smudges) onto bloom regions during final
 /// compositing. This creates a cinematic or stylized look.
-#[derive(Default, Clone, Reflect)]
+#[derive(Default, Clone, Reflect, FromTemplate)]
 #[reflect(Clone, Default)]
 pub struct LensDirt {
     /// The lens dirt texture. Set to `Some` to enable the effect.
+    #[template(OptionTemplate<HandleTemplate<Image>>)]
     pub texture: Option<Handle<Image>>,
 
     /// How strongly the lens dirt appears (default: 1.0).

--- a/crates/bevy_post_process/src/bloom/settings.rs
+++ b/crates/bevy_post_process/src/bloom/settings.rs
@@ -1,15 +1,14 @@
 use bevy_asset::{Handle, HandleTemplate};
 use bevy_camera::{Camera, Hdr};
-use bevy_color::{Color, ColorToComponents};
+use bevy_color::Color;
 use bevy_ecs::{
-    error::Result as EcsResult,
     prelude::Component,
     query::{QueryItem, With},
     reflect::ReflectComponent,
-    template::{FromTemplate, OptionTemplate, Template, TemplateContext},
+    template::{FromTemplate, OptionTemplate},
 };
 use bevy_image::Image;
-use bevy_math::{AspectRatio, URect, UVec4, Vec2, Vec3, Vec4};
+use bevy_math::{AspectRatio, URect, UVec4, Vec2, Vec4};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{
     extract_component::ExtractComponent, render_resource::ShaderType,
@@ -34,7 +33,7 @@ use bevy_render::{
 /// blurred (lower frequency) images generated from the camera's view.
 /// See <https://starlederer.github.io/bloom/> for a visualization of the parametric curve
 /// used in Bevy as well as a visualization of the curve's respective scattering profile.
-#[derive(Component, Reflect, Clone, FromTemplate)]
+#[derive(Component, Reflect, Clone)]
 #[reflect(Component, Default, Clone)]
 #[require(Hdr)]
 pub struct Bloom {
@@ -128,15 +127,6 @@ pub struct Bloom {
     /// anamorphic blur by using a large x-value. For large values, you may need to increase
     /// [`Bloom::max_mip_dimension`] to reduce sampling artifacts.
     pub scale: Vec2,
-
-    /// Controls the lens dirt effect, which overlays a texture onto bloom highlights
-    /// to simulate dust or smudges on the camera lens (default: disabled).
-    ///
-    /// The dirt effect is applied during the final composite stage and only affects
-    /// regions where bloom is present.
-    ///
-    /// See [`LensDirt`] for configuration options.
-    pub lens_dirt: LensDirt,
 }
 
 impl Bloom {
@@ -157,11 +147,6 @@ impl Bloom {
         composite_mode: BloomCompositeMode::EnergyConserving,
         max_mip_dimension: Self::DEFAULT_MAX_MIP_DIMENSION,
         scale: Vec2::ONE,
-        lens_dirt: LensDirt {
-            texture: None,
-            intensity: 0.0,
-            tint: Color::WHITE,
-        },
     };
 
     /// Emulates the look of stylized anamorphic bloom, stretched horizontally.
@@ -185,11 +170,6 @@ impl Bloom {
         composite_mode: BloomCompositeMode::Additive,
         max_mip_dimension: Self::DEFAULT_MAX_MIP_DIMENSION,
         scale: Vec2::ONE,
-        lens_dirt: LensDirt {
-            texture: None,
-            intensity: 0.0,
-            tint: Color::WHITE,
-        },
     };
 
     /// A preset that applies a very strong bloom, and blurs the whole screen.
@@ -205,29 +185,12 @@ impl Bloom {
         composite_mode: BloomCompositeMode::EnergyConserving,
         max_mip_dimension: Self::DEFAULT_MAX_MIP_DIMENSION,
         scale: Vec2::ONE,
-        lens_dirt: LensDirt {
-            texture: None,
-            intensity: 0.0,
-            tint: Color::WHITE,
-        },
     };
 }
 
 impl Default for Bloom {
     fn default() -> Self {
         Self::NATURAL
-    }
-}
-
-impl Template for Bloom {
-    type Output = Bloom;
-
-    fn build_template(&self, _context: &mut TemplateContext) -> EcsResult<Self::Output> {
-        Ok(self.clone())
-    }
-
-    fn clone_template(&self) -> Self {
-        self.clone()
     }
 }
 
@@ -325,9 +288,6 @@ impl ExtractComponent<RenderApp> for Bloom {
                     aspect: AspectRatio::try_from_pixels(size.x, size.y)
                         .expect("Valid screen size values for Bloom settings")
                         .ratio(),
-                    lens_dirt_intensity: bloom.lens_dirt.intensity,
-                    lens_dirt_tint: bloom.lens_dirt.tint.to_linear().to_vec3(),
-                    padding: 0,
                 };
 
                 Some((bloom.clone(), uniform))
@@ -346,7 +306,4 @@ pub struct BloomUniforms {
     pub viewport: Vec4,
     pub scale: Vec2,
     pub aspect: f32,
-    pub lens_dirt_intensity: f32,
-    pub lens_dirt_tint: Vec3,
-    pub padding: u32,
 }

--- a/crates/bevy_post_process/src/bloom/settings.rs
+++ b/crates/bevy_post_process/src/bloom/settings.rs
@@ -1,13 +1,9 @@
-use bevy_asset::{Handle, HandleTemplate};
 use bevy_camera::{Camera, Hdr};
-use bevy_color::Color;
 use bevy_ecs::{
     prelude::Component,
     query::{QueryItem, With},
     reflect::ReflectComponent,
-    template::{FromTemplate, OptionTemplate},
 };
-use bevy_image::Image;
 use bevy_math::{AspectRatio, URect, UVec4, Vec2, Vec4};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{
@@ -225,30 +221,6 @@ pub enum BloomCompositeMode {
     #[default]
     EnergyConserving,
     Additive,
-}
-
-/// Controls a lens dirt effect that simulates physical imperfections on the camera lens.
-///
-/// Lens dirt overlays a texture (e.g., dust, smudges) onto bloom regions during final
-/// compositing. This creates a cinematic or stylized look.
-#[derive(Default, Clone, Reflect, FromTemplate)]
-#[reflect(Clone, Default)]
-pub struct LensDirt {
-    /// The lens dirt texture. Set to `Some` to enable the effect.
-    #[template(OptionTemplate<HandleTemplate<Image>>)]
-    pub texture: Option<Handle<Image>>,
-
-    /// How strongly the lens dirt appears (default: 1.0).
-    ///
-    /// Valid range: 0.0 to 1.0 where:
-    /// * 0.0 - No dirt visible
-    /// * 1.0 - Full dirt intensity
-    pub intensity: f32,
-
-    /// Color tint applied to the lens dirt (default: `Color::WHITE`).
-    ///
-    /// Use this to match the dirt effect to your scene's lighting or mood.
-    pub tint: Color,
 }
 
 impl SyncComponent<RenderApp> for Bloom {

--- a/crates/bevy_post_process/src/bloom/settings.rs
+++ b/crates/bevy_post_process/src/bloom/settings.rs
@@ -1,13 +1,18 @@
-use super::downsampling_pipeline::BloomUniforms;
+use bevy_asset::Handle;
 use bevy_camera::{Camera, Hdr};
+use bevy_color::{Color, ColorToComponents};
 use bevy_ecs::{
     prelude::Component,
     query::{QueryItem, With},
     reflect::ReflectComponent,
 };
-use bevy_math::{AspectRatio, URect, UVec4, Vec2, Vec4};
+use bevy_image::Image;
+use bevy_math::{AspectRatio, URect, UVec4, Vec2, Vec3, Vec4};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
-use bevy_render::{extract_component::ExtractComponent, sync_component::SyncComponent, RenderApp};
+use bevy_render::{
+    extract_component::ExtractComponent, render_resource::ShaderType,
+    sync_component::SyncComponent, RenderApp,
+};
 
 /// Applies a bloom effect to an HDR-enabled 2d or 3d camera.
 ///
@@ -121,6 +126,15 @@ pub struct Bloom {
     /// anamorphic blur by using a large x-value. For large values, you may need to increase
     /// [`Bloom::max_mip_dimension`] to reduce sampling artifacts.
     pub scale: Vec2,
+
+    /// Controls the lens dirt effect, which overlays a texture onto bloom highlights
+    /// to simulate dust or smudges on the camera lens (default: disabled).
+    ///
+    /// The dirt effect is applied during the final composite stage and only affects
+    /// regions where bloom is present.
+    ///
+    /// See [`LensDirt`] for configuration options.
+    pub lens_dirt: LensDirt,
 }
 
 impl Bloom {
@@ -141,6 +155,11 @@ impl Bloom {
         composite_mode: BloomCompositeMode::EnergyConserving,
         max_mip_dimension: Self::DEFAULT_MAX_MIP_DIMENSION,
         scale: Vec2::ONE,
+        lens_dirt: LensDirt {
+            texture: None,
+            intensity: 0.0,
+            tint: Color::WHITE,
+        },
     };
 
     /// Emulates the look of stylized anamorphic bloom, stretched horizontally.
@@ -164,6 +183,11 @@ impl Bloom {
         composite_mode: BloomCompositeMode::Additive,
         max_mip_dimension: Self::DEFAULT_MAX_MIP_DIMENSION,
         scale: Vec2::ONE,
+        lens_dirt: LensDirt {
+            texture: None,
+            intensity: 0.0,
+            tint: Color::WHITE,
+        },
     };
 
     /// A preset that applies a very strong bloom, and blurs the whole screen.
@@ -179,6 +203,11 @@ impl Bloom {
         composite_mode: BloomCompositeMode::EnergyConserving,
         max_mip_dimension: Self::DEFAULT_MAX_MIP_DIMENSION,
         scale: Vec2::ONE,
+        lens_dirt: LensDirt {
+            texture: None,
+            intensity: 0.0,
+            tint: Color::WHITE,
+        },
     };
 }
 
@@ -220,6 +249,29 @@ pub enum BloomCompositeMode {
     Additive,
 }
 
+/// Controls a lens dirt effect that simulates physical imperfections on the camera lens.
+///
+/// Lens dirt overlays a texture (e.g., dust, smudges) onto bloom regions during final
+/// compositing. This creates a cinematic or stylized look.
+#[derive(Default, Clone, Reflect)]
+#[reflect(Clone, Default)]
+pub struct LensDirt {
+    /// The lens dirt texture. Set to `Some` to enable the effect.
+    pub texture: Option<Handle<Image>>,
+
+    /// How strongly the lens dirt appears (default: 1.0).
+    ///
+    /// Valid range: 0.0 to 1.0 where:
+    /// * 0.0 - No dirt visible
+    /// * 1.0 - Full dirt intensity
+    pub intensity: f32,
+
+    /// Color tint applied to the lens dirt (default: `Color::WHITE`).
+    ///
+    /// Use this to match the dirt effect to your scene's lighting or mood.
+    pub tint: Color,
+}
+
 impl SyncComponent<RenderApp> for Bloom {
     type Target = (Self, BloomUniforms);
 }
@@ -253,10 +305,22 @@ impl ExtractComponent<RenderApp> for Bloom {
                     viewport: UVec4::new(origin.x, origin.y, size.x, size.y).as_vec4()
                         / UVec4::new(target_size.x, target_size.y, target_size.x, target_size.y)
                             .as_vec4(),
+                    scale: bloom.scale,
                     aspect: AspectRatio::try_from_pixels(size.x, size.y)
                         .expect("Valid screen size values for Bloom settings")
                         .ratio(),
-                    scale: bloom.scale,
+                    intensity: bloom.intensity,
+                    low_frequency_boost: bloom.low_frequency_boost,
+                    low_frequency_boost_curvature: bloom.low_frequency_boost_curvature,
+                    high_pass_frequency: bloom.high_pass_frequency,
+                    composite_mode: match bloom.composite_mode {
+                        BloomCompositeMode::EnergyConserving => 0,
+                        BloomCompositeMode::Additive => 1,
+                    },
+                    max_mip: (bloom.max_mip_dimension.ilog2().max(2) - 1).saturating_sub(1) as f32,
+                    lens_dirt_intensity: bloom.lens_dirt.intensity,
+                    lens_dirt_tint: bloom.lens_dirt.tint.to_linear().to_vec3(),
+                    padding: 0,
                 };
 
                 Some((bloom.clone(), uniform))
@@ -264,4 +328,24 @@ impl ExtractComponent<RenderApp> for Bloom {
             _ => None,
         }
     }
+}
+
+/// The uniform struct extracted from [`Bloom`] attached to a Camera.
+/// Will be available for use in the Bloom shader.
+#[derive(Component, ShaderType, Clone)]
+pub struct BloomUniforms {
+    // Precomputed values used when thresholding, see https://catlikecoding.com/unity/tutorials/advanced-rendering/bloom/#3.4
+    pub threshold_precomputations: Vec4,
+    pub viewport: Vec4,
+    pub scale: Vec2,
+    pub aspect: f32,
+    pub intensity: f32,
+    pub low_frequency_boost: f32,
+    pub low_frequency_boost_curvature: f32,
+    pub high_pass_frequency: f32,
+    pub composite_mode: u32,
+    pub max_mip: f32,
+    pub lens_dirt_intensity: f32,
+    pub lens_dirt_tint: Vec3,
+    pub padding: u32,
 }

--- a/crates/bevy_post_process/src/bloom/upsampling_pipeline.rs
+++ b/crates/bevy_post_process/src/bloom/upsampling_pipeline.rs
@@ -120,6 +120,7 @@ impl SpecializedRenderPipeline for BloomUpsamplingPipeline {
                     }),
                     write_mask: ColorWrites::ALL,
                 })],
+                ..default()
             }),
             ..default()
         }

--- a/crates/bevy_post_process/src/bloom/upsampling_pipeline.rs
+++ b/crates/bevy_post_process/src/bloom/upsampling_pipeline.rs
@@ -173,7 +173,6 @@ impl SpecializedRenderPipeline for BloomUpsamplingPipeline {
                     }),
                     write_mask: ColorWrites::ALL,
                 })],
-                ..default()
             }),
             ..default()
         }

--- a/crates/bevy_post_process/src/bloom/upsampling_pipeline.rs
+++ b/crates/bevy_post_process/src/bloom/upsampling_pipeline.rs
@@ -1,9 +1,7 @@
-use bevy_core_pipeline::FullscreenShader;
+use super::{settings::BloomUniforms, Bloom, BloomCompositeMode, BLOOM_TEXTURE_FORMAT};
 
-use super::{
-    downsampling_pipeline::BloomUniforms, Bloom, BloomCompositeMode, BLOOM_TEXTURE_FORMAT,
-};
 use bevy_asset::{load_embedded_asset, AssetServer, Handle};
+use bevy_core_pipeline::FullscreenShader;
 use bevy_ecs::{
     prelude::{Component, Entity},
     resource::Resource,
@@ -23,11 +21,13 @@ use bevy_utils::default;
 pub struct UpsamplingPipelineIds {
     pub id_main: CachedRenderPipelineId,
     pub id_final: CachedRenderPipelineId,
+    pub id_final_dirt: Option<CachedRenderPipelineId>,
 }
 
 #[derive(Resource)]
 pub struct BloomUpsamplingPipeline {
     pub bind_group_layout: BindGroupLayoutDescriptor,
+    pub dirt_bind_group_layout: BindGroupLayoutDescriptor,
     /// The asset handle for the fullscreen vertex shader.
     pub fullscreen_shader: FullscreenShader,
     /// The fragment shader asset handle.
@@ -38,6 +38,7 @@ pub struct BloomUpsamplingPipeline {
 pub struct BloomUpsamplingPipelineKeys {
     composite_mode: BloomCompositeMode,
     target_format: TextureFormat,
+    lens_dirt: bool,
 }
 
 pub fn init_bloom_upscaling_pipeline(
@@ -60,8 +61,28 @@ pub fn init_bloom_upscaling_pipeline(
         ),
     );
 
+    let dirt_bind_group_layout = BindGroupLayoutDescriptor::new(
+        "bloom_dirt_upsampling_bind_group_layout",
+        &BindGroupLayoutEntries::sequential(
+            ShaderStages::FRAGMENT,
+            (
+                // Input texture
+                texture_2d(TextureSampleType::Float { filterable: true }),
+                // Sampler
+                sampler(SamplerBindingType::Filtering),
+                // BloomUniforms
+                uniform_buffer::<BloomUniforms>(true),
+                // Lens Dirt texture
+                texture_2d(TextureSampleType::Float { filterable: true }),
+                // Lens Dirt sampler
+                sampler(SamplerBindingType::Filtering),
+            ),
+        ),
+    );
+
     commands.insert_resource(BloomUpsamplingPipeline {
         bind_group_layout,
+        dirt_bind_group_layout,
         fullscreen_shader: fullscreen_shader.clone(),
         fragment_shader: load_embedded_asset!(asset_server.as_ref(), "bloom.wgsl"),
     });
@@ -71,45 +92,75 @@ impl SpecializedRenderPipeline for BloomUpsamplingPipeline {
     type Key = BloomUpsamplingPipelineKeys;
 
     fn specialize(&self, key: Self::Key) -> RenderPipelineDescriptor {
-        let color_blend = match key.composite_mode {
-            BloomCompositeMode::EnergyConserving => {
-                // At the time of developing this we decided to blend our
-                // blur pyramid levels using native WGPU render pass blend
-                // constants. They are set in the bloom node's run function.
-                // This seemed like a good approach at the time which allowed
-                // us to perform complex calculations for blend levels on the CPU,
-                // however, we missed the fact that this prevented us from using
-                // textures to customize bloom appearance on individual parts
-                // of the screen and create effects such as lens dirt or
-                // screen blur behind certain UI elements.
-                //
-                // TODO: Use alpha instead of blend constants and move
-                // compute_blend_factor to the shader. The shader
-                // will likely need to know current mip number or
-                // mip "angle" (original texture is 0deg, max mip is 90deg)
-                // so make sure you give it that as a uniform.
-                // That does have to be provided per each pass unlike other
-                // uniforms that are set once.
-                BlendComponent {
-                    src_factor: BlendFactor::Constant,
-                    dst_factor: BlendFactor::OneMinusConstant,
-                    operation: BlendOperation::Add,
-                }
-            }
-            BloomCompositeMode::Additive => BlendComponent {
+        // At the time of developing this we decided to blend our
+        // blur pyramid levels using native WGPU render pass blend
+        // constants. They are set in the bloom node's run function.
+        // This seemed like a good approach at the time which allowed
+        // us to perform complex calculations for blend levels on the CPU,
+        // however, we missed the fact that this prevented us from using
+        // textures to customize bloom appearance on individual parts
+        // of the screen and create effects such as lens dirt or
+        // screen blur behind certain UI elements.
+        //
+        // Lens dirt has been implemented as a workaround using a separate
+        // final compositing pipeline with alpha blending (see the
+        // `id_final_dirt` pipeline). When the below TODO is completed,
+        // this workaround can be merged back into the main pipeline.
+        //
+        // TODO: Use alpha instead of blend constants and move
+        // compute_blend_factor to the shader. The shader
+        // will likely need to know current mip number or
+        // mip "angle" (original texture is 0deg, max mip is 90deg)
+        // so make sure you give it that as a uniform.
+        // That does have to be provided per each pass unlike other
+        // uniforms that are set once.
+        let color_blend = match (key.composite_mode, key.lens_dirt) {
+            (BloomCompositeMode::EnergyConserving, false) => BlendComponent {
                 src_factor: BlendFactor::Constant,
+                dst_factor: BlendFactor::OneMinusConstant,
+                operation: BlendOperation::Add,
+            },
+            (BloomCompositeMode::Additive, false) => BlendComponent {
+                src_factor: BlendFactor::Constant,
+                dst_factor: BlendFactor::One,
+                operation: BlendOperation::Add,
+            },
+            (BloomCompositeMode::EnergyConserving, true) => BlendComponent {
+                src_factor: BlendFactor::SrcAlpha,
+                dst_factor: BlendFactor::OneMinusSrcAlpha,
+                operation: BlendOperation::Add,
+            },
+            (BloomCompositeMode::Additive, true) => BlendComponent {
+                src_factor: BlendFactor::SrcAlpha,
                 dst_factor: BlendFactor::One,
                 operation: BlendOperation::Add,
             },
         };
 
+        let entry_point = if key.lens_dirt {
+            Some("upsample_final".into())
+        } else {
+            Some("upsample".into())
+        };
+
+        let shader_defs = if key.lens_dirt {
+            vec!["LENS_DIRT".into()]
+        } else {
+            vec![]
+        };
+
         RenderPipelineDescriptor {
             label: Some("bloom_upsampling_pipeline".into()),
-            layout: vec![self.bind_group_layout.clone()],
+            layout: vec![if key.lens_dirt {
+                self.dirt_bind_group_layout.clone()
+            } else {
+                self.bind_group_layout.clone()
+            }],
             vertex: self.fullscreen_shader.to_vertex_state(),
             fragment: Some(FragmentState {
                 shader: self.fragment_shader.clone(),
-                entry_point: Some("upsample".into()),
+                shader_defs,
+                entry_point,
                 targets: vec![Some(ColorTargetState {
                     format: key.target_format,
                     blend: Some(BlendState {
@@ -143,6 +194,7 @@ pub fn prepare_upsampling_pipeline(
             BloomUpsamplingPipelineKeys {
                 composite_mode: bloom.composite_mode,
                 target_format: BLOOM_TEXTURE_FORMAT,
+                lens_dirt: false,
             },
         );
 
@@ -152,12 +204,26 @@ pub fn prepare_upsampling_pipeline(
             BloomUpsamplingPipelineKeys {
                 composite_mode: bloom.composite_mode,
                 target_format: view.target_format,
+                lens_dirt: false,
             },
         );
+
+        let pipeline_final_dirt_id = bloom.lens_dirt.texture.is_some().then(|| {
+            pipelines.specialize(
+                &pipeline_cache,
+                &pipeline,
+                BloomUpsamplingPipelineKeys {
+                    composite_mode: bloom.composite_mode,
+                    target_format: view.target_format,
+                    lens_dirt: true,
+                },
+            )
+        });
 
         commands.entity(entity).insert(UpsamplingPipelineIds {
             id_main: pipeline_id,
             id_final: pipeline_final_id,
+            id_final_dirt: pipeline_final_dirt_id,
         });
     }
 }

--- a/crates/bevy_post_process/src/bloom/upsampling_pipeline.rs
+++ b/crates/bevy_post_process/src/bloom/upsampling_pipeline.rs
@@ -1,5 +1,5 @@
 use super::{settings::BloomUniforms, Bloom, BloomCompositeMode, BLOOM_TEXTURE_FORMAT};
-use crate::lens_dirt::{LensDirt, LensDirtUniforms};
+use crate::lens_dirt::{create_lens_dirt_bind_group_layout, LensDirt};
 
 use bevy_asset::{load_embedded_asset, AssetServer, Handle};
 use bevy_core_pipeline::FullscreenShader;
@@ -61,17 +61,7 @@ pub fn init_bloom_upscaling_pipeline(
         ),
     );
 
-    let lens_dirt_bind_group_layout = BindGroupLayoutDescriptor::new(
-        "lens_dirt_bind_group_layout",
-        &BindGroupLayoutEntries::sequential(
-            ShaderStages::FRAGMENT,
-            (
-                texture_2d(TextureSampleType::Float { filterable: true }),
-                sampler(SamplerBindingType::Filtering),
-                uniform_buffer::<LensDirtUniforms>(true),
-            ),
-        ),
-    );
+    let lens_dirt_bind_group_layout = create_lens_dirt_bind_group_layout();
 
     commands.insert_resource(BloomUpsamplingPipeline {
         bind_group_layout,

--- a/crates/bevy_post_process/src/bloom/upsampling_pipeline.rs
+++ b/crates/bevy_post_process/src/bloom/upsampling_pipeline.rs
@@ -9,13 +9,14 @@ use bevy_ecs::{
 };
 use bevy_render::{
     render_resource::{
-        binding_types::{sampler, texture_2d, uniform_buffer},
+        binding_types::{sampler, storage_buffer_read_only_sized, texture_2d, uniform_buffer},
         *,
     },
     view::ExtractedView,
 };
 use bevy_shader::Shader;
 use bevy_utils::default;
+use core::num::NonZero;
 
 #[derive(Component)]
 pub struct UpsamplingPipelineIds {
@@ -57,6 +58,8 @@ pub fn init_bloom_upscaling_pipeline(
                 sampler(SamplerBindingType::Filtering),
                 // BloomUniforms
                 uniform_buffer::<BloomUniforms>(true),
+                // Blend factor
+                storage_buffer_read_only_sized(false, NonZero::<u64>::new(4)),
             ),
         ),
     );
@@ -72,6 +75,8 @@ pub fn init_bloom_upscaling_pipeline(
                 sampler(SamplerBindingType::Filtering),
                 // BloomUniforms
                 uniform_buffer::<BloomUniforms>(true),
+                // Blend factor
+                storage_buffer_read_only_sized(false, NonZero::<u64>::new(4)),
                 // Lens Dirt texture
                 texture_2d(TextureSampleType::Float { filterable: true }),
                 // Lens Dirt sampler
@@ -92,45 +97,13 @@ impl SpecializedRenderPipeline for BloomUpsamplingPipeline {
     type Key = BloomUpsamplingPipelineKeys;
 
     fn specialize(&self, key: Self::Key) -> RenderPipelineDescriptor {
-        // At the time of developing this we decided to blend our
-        // blur pyramid levels using native WGPU render pass blend
-        // constants. They are set in the bloom node's run function.
-        // This seemed like a good approach at the time which allowed
-        // us to perform complex calculations for blend levels on the CPU,
-        // however, we missed the fact that this prevented us from using
-        // textures to customize bloom appearance on individual parts
-        // of the screen and create effects such as lens dirt or
-        // screen blur behind certain UI elements.
-        //
-        // Lens dirt has been implemented as a workaround using a separate
-        // final compositing pipeline with alpha blending (see the
-        // `id_final_dirt` pipeline). When the below TODO is completed,
-        // this workaround can be merged back into the main pipeline.
-        //
-        // TODO: Use alpha instead of blend constants and move
-        // compute_blend_factor to the shader. The shader
-        // will likely need to know current mip number or
-        // mip "angle" (original texture is 0deg, max mip is 90deg)
-        // so make sure you give it that as a uniform.
-        // That does have to be provided per each pass unlike other
-        // uniforms that are set once.
-        let color_blend = match (key.composite_mode, key.lens_dirt) {
-            (BloomCompositeMode::EnergyConserving, false) => BlendComponent {
-                src_factor: BlendFactor::Constant,
-                dst_factor: BlendFactor::OneMinusConstant,
-                operation: BlendOperation::Add,
-            },
-            (BloomCompositeMode::Additive, false) => BlendComponent {
-                src_factor: BlendFactor::Constant,
-                dst_factor: BlendFactor::One,
-                operation: BlendOperation::Add,
-            },
-            (BloomCompositeMode::EnergyConserving, true) => BlendComponent {
+        let color_blend = match key.composite_mode {
+            BloomCompositeMode::EnergyConserving => BlendComponent {
                 src_factor: BlendFactor::SrcAlpha,
                 dst_factor: BlendFactor::OneMinusSrcAlpha,
                 operation: BlendOperation::Add,
             },
-            (BloomCompositeMode::Additive, true) => BlendComponent {
+            BloomCompositeMode::Additive => BlendComponent {
                 src_factor: BlendFactor::SrcAlpha,
                 dst_factor: BlendFactor::One,
                 operation: BlendOperation::Add,

--- a/crates/bevy_post_process/src/bloom/upsampling_pipeline.rs
+++ b/crates/bevy_post_process/src/bloom/upsampling_pipeline.rs
@@ -1,4 +1,5 @@
 use super::{settings::BloomUniforms, Bloom, BloomCompositeMode, BLOOM_TEXTURE_FORMAT};
+use crate::lens_dirt::{LensDirt, LensDirtUniforms};
 
 use bevy_asset::{load_embedded_asset, AssetServer, Handle};
 use bevy_core_pipeline::FullscreenShader;
@@ -28,7 +29,7 @@ pub struct UpsamplingPipelineIds {
 #[derive(Resource)]
 pub struct BloomUpsamplingPipeline {
     pub bind_group_layout: BindGroupLayoutDescriptor,
-    pub dirt_bind_group_layout: BindGroupLayoutDescriptor,
+    pub lens_dirt_bind_group_layout: BindGroupLayoutDescriptor,
     /// The asset handle for the fullscreen vertex shader.
     pub fullscreen_shader: FullscreenShader,
     /// The fragment shader asset handle.
@@ -52,42 +53,29 @@ pub fn init_bloom_upscaling_pipeline(
         &BindGroupLayoutEntries::sequential(
             ShaderStages::FRAGMENT,
             (
-                // Input texture
                 texture_2d(TextureSampleType::Float { filterable: true }),
-                // Sampler
                 sampler(SamplerBindingType::Filtering),
-                // BloomUniforms
                 uniform_buffer::<BloomUniforms>(true),
-                // Blend factor
                 storage_buffer_read_only_sized(false, NonZero::<u64>::new(4)),
             ),
         ),
     );
 
-    let dirt_bind_group_layout = BindGroupLayoutDescriptor::new(
-        "bloom_dirt_upsampling_bind_group_layout",
+    let lens_dirt_bind_group_layout = BindGroupLayoutDescriptor::new(
+        "lens_dirt_bind_group_layout",
         &BindGroupLayoutEntries::sequential(
             ShaderStages::FRAGMENT,
             (
-                // Input texture
                 texture_2d(TextureSampleType::Float { filterable: true }),
-                // Sampler
                 sampler(SamplerBindingType::Filtering),
-                // BloomUniforms
-                uniform_buffer::<BloomUniforms>(true),
-                // Blend factor
-                storage_buffer_read_only_sized(false, NonZero::<u64>::new(4)),
-                // Lens Dirt texture
-                texture_2d(TextureSampleType::Float { filterable: true }),
-                // Lens Dirt sampler
-                sampler(SamplerBindingType::Filtering),
+                uniform_buffer::<LensDirtUniforms>(true),
             ),
         ),
     );
 
     commands.insert_resource(BloomUpsamplingPipeline {
         bind_group_layout,
-        dirt_bind_group_layout,
+        lens_dirt_bind_group_layout,
         fullscreen_shader: fullscreen_shader.clone(),
         fragment_shader: load_embedded_asset!(asset_server.as_ref(), "bloom.wgsl"),
     });
@@ -110,30 +98,26 @@ impl SpecializedRenderPipeline for BloomUpsamplingPipeline {
             },
         };
 
-        let entry_point = if key.lens_dirt {
-            Some("upsample_final".into())
+        let (layout, shader_defs) = if key.lens_dirt {
+            (
+                vec![
+                    self.bind_group_layout.clone(),
+                    self.lens_dirt_bind_group_layout.clone(),
+                ],
+                vec!["LENS_DIRT".into()],
+            )
         } else {
-            Some("upsample".into())
-        };
-
-        let shader_defs = if key.lens_dirt {
-            vec!["LENS_DIRT".into()]
-        } else {
-            vec![]
+            (vec![self.bind_group_layout.clone()], vec![])
         };
 
         RenderPipelineDescriptor {
             label: Some("bloom_upsampling_pipeline".into()),
-            layout: vec![if key.lens_dirt {
-                self.dirt_bind_group_layout.clone()
-            } else {
-                self.bind_group_layout.clone()
-            }],
+            layout,
             vertex: self.fullscreen_shader.to_vertex_state(),
             fragment: Some(FragmentState {
                 shader: self.fragment_shader.clone(),
                 shader_defs,
-                entry_point,
+                entry_point: Some("upsample".into()),
                 targets: vec![Some(ColorTargetState {
                     format: key.target_format,
                     blend: Some(BlendState {
@@ -157,9 +141,9 @@ pub fn prepare_upsampling_pipeline(
     pipeline_cache: Res<PipelineCache>,
     mut pipelines: ResMut<SpecializedRenderPipelines<BloomUpsamplingPipeline>>,
     pipeline: Res<BloomUpsamplingPipeline>,
-    views: Query<(&ExtractedView, Entity, &Bloom)>,
+    views: Query<(&ExtractedView, Entity, &Bloom, Option<&LensDirt>)>,
 ) {
-    for (view, entity, bloom) in &views {
+    for (view, entity, bloom, maybe_lens_dirt) in &views {
         let pipeline_id = pipelines.specialize(
             &pipeline_cache,
             &pipeline,
@@ -180,7 +164,7 @@ pub fn prepare_upsampling_pipeline(
             },
         );
 
-        let pipeline_final_dirt_id = bloom.lens_dirt.texture.is_some().then(|| {
+        let pipeline_final_dirt_id = maybe_lens_dirt.is_some().then(|| {
             pipelines.specialize(
                 &pipeline_cache,
                 &pipeline,

--- a/crates/bevy_post_process/src/lens_dirt/lens_dirt.wgsl
+++ b/crates/bevy_post_process/src/lens_dirt/lens_dirt.wgsl
@@ -4,3 +4,7 @@ struct LensDirtUniforms {
     intensity: f32,
     tint: vec3<f32>,
 };
+
+@group(1) @binding(0) var lens_dirt_texture: texture_2d<f32>;
+@group(1) @binding(1) var lens_dirt_sampler: sampler;
+@group(1) @binding(2) var<uniform> lens_dirt_uniforms: LensDirtUniforms;

--- a/crates/bevy_post_process/src/lens_dirt/lens_dirt.wgsl
+++ b/crates/bevy_post_process/src/lens_dirt/lens_dirt.wgsl
@@ -1,0 +1,6 @@
+#define_import_path bevy_post_process::lens_dirt
+
+struct LensDirtUniforms {
+    intensity: f32,
+    tint: vec3<f32>,
+};

--- a/crates/bevy_post_process/src/lens_dirt/mod.rs
+++ b/crates/bevy_post_process/src/lens_dirt/mod.rs
@@ -147,11 +147,11 @@ impl Default for LensDirt {
     }
 }
 
-impl SyncComponent for LensDirt {
+impl SyncComponent<RenderApp> for LensDirt {
     type Target = (Self, LensDirt);
 }
 
-impl ExtractComponent for LensDirt {
+impl ExtractComponent<RenderApp> for LensDirt {
     type QueryData = &'static Self;
     type QueryFilter = With<Camera>;
     type Out = (Self, LensDirtUniforms);

--- a/crates/bevy_post_process/src/lens_dirt/mod.rs
+++ b/crates/bevy_post_process/src/lens_dirt/mod.rs
@@ -134,6 +134,7 @@ fn prepare_lens_dirt_bind_group(
 /// Currently, the lens dirt only interacts with the bloom effect.
 #[derive(Component, Reflect, Clone)]
 #[reflect(Component, Default, Clone)]
+#[expect(dead_code, reason = "Bevy component, constructed by downstream users")]
 pub struct LensDirt {
     /// The lens dirt texture. Set to `Some` to enable the effect.
     pub texture: Handle<Image>,

--- a/crates/bevy_post_process/src/lens_dirt/mod.rs
+++ b/crates/bevy_post_process/src/lens_dirt/mod.rs
@@ -62,7 +62,7 @@ pub struct LensDirtBindGroupLayout(pub BindGroupLayout);
 #[derive(Component)]
 pub struct LensDirtBindGroup(pub BindGroup);
 
-pub(crate) fn create_lens_dirt_bind_group_layout() -> BindGroupLayoutDescriptor {
+pub fn create_lens_dirt_bind_group_layout() -> BindGroupLayoutDescriptor {
     BindGroupLayoutDescriptor::new(
         "lens_dirt_bind_group_layout",
         &BindGroupLayoutEntries::sequential(

--- a/crates/bevy_post_process/src/lens_dirt/mod.rs
+++ b/crates/bevy_post_process/src/lens_dirt/mod.rs
@@ -1,0 +1,168 @@
+use bevy_app::Plugin;
+use bevy_asset::Handle;
+use bevy_camera::Camera;
+use bevy_color::{Color, ColorToComponents};
+use bevy_ecs::{
+    component::Component,
+    entity::Entity,
+    prelude::Resource,
+    query::{QueryItem, With},
+    reflect::ReflectComponent,
+    schedule::IntoScheduleConfigs,
+    system::{Commands, Query, Res},
+};
+use bevy_image::Image;
+use bevy_math::Vec3;
+use bevy_reflect::{std_traits::ReflectDefault, Reflect};
+use bevy_render::{
+    extract_component::{ExtractComponent, ExtractComponentPlugin},
+    render_asset::RenderAssets,
+    render_resource::{
+        binding_types::{sampler, texture_2d, uniform_buffer},
+        BindGroup, BindGroupEntries, BindGroupLayout, BindGroupLayoutEntries, SamplerBindingType,
+        ShaderStages, ShaderType, TextureSampleType,
+    },
+    renderer::RenderDevice,
+    sync_component::SyncComponent,
+    texture::{FallbackImage, GpuImage},
+    uniform::{ComponentUniforms, UniformComponentPlugin},
+    Render, RenderApp, RenderStartup, RenderSystems,
+};
+use bevy_shader::load_shader_library;
+
+/// A plugin that adds support for the lens dirt effect to Bevy.
+#[derive(Default)]
+pub struct LensDirtPlugin;
+
+impl Plugin for LensDirtPlugin {
+    fn build(&self, app: &mut bevy_app::App) {
+        load_shader_library!(app, "lens_dirt.wgsl");
+
+        app.add_plugins((
+            ExtractComponentPlugin::<LensDirt>::default(),
+            UniformComponentPlugin::<LensDirtUniforms>::default(),
+        ));
+
+        let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
+        };
+
+        render_app
+            .add_systems(RenderStartup, init_lens_dirt_bind_group)
+            .add_systems(
+                Render,
+                prepare_lens_dirt_bind_group.in_set(RenderSystems::PrepareBindGroups),
+            );
+    }
+}
+
+#[derive(Resource)]
+pub struct LensDirtBindGroupLayout(pub BindGroupLayout);
+
+#[derive(Component)]
+pub struct LensDirtBindGroup(pub BindGroup);
+
+fn init_lens_dirt_bind_group(mut commands: Commands, render_device: Res<RenderDevice>) {
+    let bind_group_layout = render_device.create_bind_group_layout(
+        "lens_dirt_bind_group_layout",
+        &BindGroupLayoutEntries::sequential(
+            ShaderStages::FRAGMENT,
+            (
+                texture_2d(TextureSampleType::Float { filterable: true }),
+                sampler(SamplerBindingType::Filtering),
+                uniform_buffer::<LensDirtUniforms>(true),
+            ),
+        ),
+    );
+
+    commands.insert_resource(LensDirtBindGroupLayout(bind_group_layout));
+}
+
+fn prepare_lens_dirt_bind_group(
+    mut commands: Commands,
+    render_device: Res<RenderDevice>,
+    lens_dirt_layout: Res<LensDirtBindGroupLayout>,
+    gpu_images: Res<RenderAssets<GpuImage>>,
+    uniforms: Res<ComponentUniforms<LensDirtUniforms>>,
+    fallback: Res<FallbackImage>,
+    views: Query<(Entity, &LensDirt)>,
+) {
+    let Some(uniform_binding) = uniforms.binding() else {
+        return;
+    };
+    for (entity, lens_dirt) in &views {
+        let dirt_image = gpu_images.get(&lens_dirt.texture).unwrap_or(&fallback.d2);
+        let bind_group = render_device.create_bind_group(
+            "lens_dirt_bind_group",
+            &lens_dirt_layout.0,
+            &BindGroupEntries::sequential((
+                &dirt_image.texture_view,
+                &dirt_image.sampler,
+                uniform_binding.clone(),
+            )),
+        );
+        commands
+            .entity(entity)
+            .insert(LensDirtBindGroup(bind_group));
+    }
+}
+
+/// A component that enables a lens dirt effect when added to a camera.
+/// Simulates the effect of dirt on the lens.
+///
+/// Currently, the lens dirt only interacts with the bloom effect.
+#[derive(Component, Reflect, Clone)]
+#[reflect(Component, Default, Clone)]
+pub struct LensDirt {
+    /// The lens dirt texture. Set to `Some` to enable the effect.
+    pub texture: Handle<Image>,
+
+    /// How strongly the lens dirt appears (default: 1.0).
+    ///
+    /// Valid range: 0.0 to 1.0 where:
+    /// * 0.0 - No dirt visible
+    /// * 1.0 - Full dirt intensity
+    pub intensity: f32,
+
+    /// Color tint applied to the lens dirt (default: `Color::WHITE`).
+    ///
+    /// Use this to match the dirt effect to your scene's lighting or mood.
+    pub tint: Color,
+}
+
+impl Default for LensDirt {
+    fn default() -> Self {
+        Self {
+            texture: Handle::default(),
+            intensity: 1.0,
+            tint: Color::default(),
+        }
+    }
+}
+
+impl SyncComponent for LensDirt {
+    type Target = (Self, LensDirt);
+}
+
+impl ExtractComponent for LensDirt {
+    type QueryData = &'static Self;
+    type QueryFilter = With<Camera>;
+    type Out = (Self, LensDirtUniforms);
+
+    fn extract_component(lens_dirt: QueryItem<'_, '_, Self::QueryData>) -> Option<Self::Out> {
+        Some((
+            lens_dirt.clone(),
+            LensDirtUniforms {
+                intensity: lens_dirt.intensity,
+                tint: lens_dirt.tint.to_linear().to_vec3(),
+            },
+        ))
+    }
+}
+
+/// The uniform struct extracted from [`LensDirt`] attached to a Camera.
+#[derive(Component, ShaderType, Clone)]
+pub struct LensDirtUniforms {
+    pub intensity: f32,
+    pub tint: Vec3,
+}

--- a/crates/bevy_post_process/src/lens_dirt/mod.rs
+++ b/crates/bevy_post_process/src/lens_dirt/mod.rs
@@ -20,7 +20,8 @@ use bevy_render::{
     render_resource::{
         binding_types::{sampler, texture_2d, uniform_buffer},
         BindGroup, BindGroupEntries, BindGroupLayout, BindGroupLayoutDescriptor,
-        BindGroupLayoutEntries, SamplerBindingType, ShaderStages, ShaderType, TextureSampleType,
+        BindGroupLayoutEntries, BufferId, SamplerBindingType, ShaderStages, ShaderType, TextureId,
+        TextureSampleType,
     },
     renderer::RenderDevice,
     sync_component::SyncComponent,
@@ -60,7 +61,10 @@ impl Plugin for LensDirtPlugin {
 pub struct LensDirtBindGroupLayout(pub BindGroupLayout);
 
 #[derive(Component)]
-pub struct LensDirtBindGroup(pub BindGroup);
+pub struct LensDirtBindGroup {
+    cache_key: (TextureId, BufferId),
+    pub bind_group: BindGroup,
+}
 
 pub fn create_lens_dirt_bind_group_layout() -> BindGroupLayoutDescriptor {
     BindGroupLayoutDescriptor::new(
@@ -92,13 +96,22 @@ fn prepare_lens_dirt_bind_group(
     gpu_images: Res<RenderAssets<GpuImage>>,
     uniforms: Res<ComponentUniforms<LensDirtUniforms>>,
     fallback: Res<FallbackImage>,
-    views: Query<(Entity, &LensDirt)>,
+    views: Query<(Entity, &LensDirt, Option<&LensDirtBindGroup>)>,
 ) {
     let Some(uniform_binding) = uniforms.binding() else {
         return;
     };
-    for (entity, lens_dirt) in &views {
+    for (entity, lens_dirt, existing_bind_group) in &views {
         let dirt_image = gpu_images.get(&lens_dirt.texture).unwrap_or(&fallback.d2);
+
+        let cache_key = (dirt_image.texture.id(), uniforms.buffer().unwrap().id());
+
+        if let Some(bg) = existing_bind_group
+            && bg.cache_key == cache_key
+        {
+            continue;
+        }
+
         let bind_group = render_device.create_bind_group(
             "lens_dirt_bind_group",
             &lens_dirt_layout.0,
@@ -108,9 +121,10 @@ fn prepare_lens_dirt_bind_group(
                 uniform_binding.clone(),
             )),
         );
-        commands
-            .entity(entity)
-            .insert(LensDirtBindGroup(bind_group));
+        commands.entity(entity).insert(LensDirtBindGroup {
+            cache_key,
+            bind_group,
+        });
     }
 }
 
@@ -148,7 +162,7 @@ impl Default for LensDirt {
 }
 
 impl SyncComponent<RenderApp> for LensDirt {
-    type Target = (Self, LensDirt);
+    type Target = (Self, LensDirtUniforms);
 }
 
 impl ExtractComponent<RenderApp> for LensDirt {

--- a/crates/bevy_post_process/src/lens_dirt/mod.rs
+++ b/crates/bevy_post_process/src/lens_dirt/mod.rs
@@ -58,7 +58,7 @@ impl Plugin for LensDirtPlugin {
 }
 
 #[derive(Resource)]
-pub struct LensDirtBindGroupLayout(pub BindGroupLayout);
+struct LensDirtBindGroupLayout(pub BindGroupLayout);
 
 #[derive(Component)]
 pub struct LensDirtBindGroup {
@@ -66,7 +66,7 @@ pub struct LensDirtBindGroup {
     pub bind_group: BindGroup,
 }
 
-pub fn create_lens_dirt_bind_group_layout() -> BindGroupLayoutDescriptor {
+pub(crate) fn create_lens_dirt_bind_group_layout() -> BindGroupLayoutDescriptor {
     BindGroupLayoutDescriptor::new(
         "lens_dirt_bind_group_layout",
         &BindGroupLayoutEntries::sequential(
@@ -134,7 +134,6 @@ fn prepare_lens_dirt_bind_group(
 /// Currently, the lens dirt only interacts with the bloom effect.
 #[derive(Component, Reflect, Clone)]
 #[reflect(Component, Default, Clone)]
-#[expect(dead_code, reason = "Bevy component, constructed by downstream users")]
 pub struct LensDirt {
     /// The lens dirt texture. Set to `Some` to enable the effect.
     pub texture: Handle<Image>,

--- a/crates/bevy_post_process/src/lens_dirt/mod.rs
+++ b/crates/bevy_post_process/src/lens_dirt/mod.rs
@@ -19,8 +19,8 @@ use bevy_render::{
     render_asset::RenderAssets,
     render_resource::{
         binding_types::{sampler, texture_2d, uniform_buffer},
-        BindGroup, BindGroupEntries, BindGroupLayout, BindGroupLayoutEntries, SamplerBindingType,
-        ShaderStages, ShaderType, TextureSampleType,
+        BindGroup, BindGroupEntries, BindGroupLayout, BindGroupLayoutDescriptor,
+        BindGroupLayoutEntries, SamplerBindingType, ShaderStages, ShaderType, TextureSampleType,
     },
     renderer::RenderDevice,
     sync_component::SyncComponent,
@@ -62,8 +62,8 @@ pub struct LensDirtBindGroupLayout(pub BindGroupLayout);
 #[derive(Component)]
 pub struct LensDirtBindGroup(pub BindGroup);
 
-fn init_lens_dirt_bind_group(mut commands: Commands, render_device: Res<RenderDevice>) {
-    let bind_group_layout = render_device.create_bind_group_layout(
+pub(crate) fn create_lens_dirt_bind_group_layout() -> BindGroupLayoutDescriptor {
+    BindGroupLayoutDescriptor::new(
         "lens_dirt_bind_group_layout",
         &BindGroupLayoutEntries::sequential(
             ShaderStages::FRAGMENT,
@@ -73,6 +73,13 @@ fn init_lens_dirt_bind_group(mut commands: Commands, render_device: Res<RenderDe
                 uniform_buffer::<LensDirtUniforms>(true),
             ),
         ),
+    )
+}
+
+fn init_lens_dirt_bind_group(mut commands: Commands, render_device: Res<RenderDevice>) {
+    let bind_group_layout = render_device.create_bind_group_layout(
+        "lens_dirt_bind_group_layout",
+        &create_lens_dirt_bind_group_layout().entries,
     );
 
     commands.insert_resource(LensDirtBindGroupLayout(bind_group_layout));

--- a/crates/bevy_post_process/src/lens_dirt/mod.rs
+++ b/crates/bevy_post_process/src/lens_dirt/mod.rs
@@ -25,7 +25,7 @@ use bevy_render::{
     },
     renderer::RenderDevice,
     sync_component::SyncComponent,
-    texture::{FallbackImage, GpuImage},
+    texture::GpuImage,
     uniform::{ComponentUniforms, UniformComponentPlugin},
     Render, RenderApp, RenderStartup, RenderSystems,
 };
@@ -95,14 +95,18 @@ fn prepare_lens_dirt_bind_group(
     lens_dirt_layout: Res<LensDirtBindGroupLayout>,
     gpu_images: Res<RenderAssets<GpuImage>>,
     uniforms: Res<ComponentUniforms<LensDirtUniforms>>,
-    fallback: Res<FallbackImage>,
     views: Query<(Entity, &LensDirt, Option<&LensDirtBindGroup>)>,
 ) {
     let Some(uniform_binding) = uniforms.binding() else {
         return;
     };
     for (entity, lens_dirt, existing_bind_group) in &views {
-        let dirt_image = gpu_images.get(&lens_dirt.texture).unwrap_or(&fallback.d2);
+        let Some(dirt_image) = gpu_images.get(&lens_dirt.texture) else {
+            if existing_bind_group.is_some() {
+                commands.entity(entity).remove::<LensDirtBindGroup>();
+            }
+            continue;
+        };
 
         let cache_key = (dirt_image.texture.id(), uniforms.buffer().unwrap().id());
 

--- a/crates/bevy_post_process/src/lib.rs
+++ b/crates/bevy_post_process/src/lib.rs
@@ -10,12 +10,13 @@ pub mod auto_exposure;
 pub mod bloom;
 pub mod dof;
 pub mod effect_stack;
+pub mod lens_dirt;
 pub mod motion_blur;
 pub mod msaa_writeback;
 
 use crate::{
     bloom::BloomPlugin, dof::DepthOfFieldPlugin, effect_stack::EffectStackPlugin,
-    motion_blur::MotionBlurPlugin, msaa_writeback::MsaaWritebackPlugin,
+    lens_dirt::LensDirtPlugin, motion_blur::MotionBlurPlugin, msaa_writeback::MsaaWritebackPlugin,
 };
 use bevy_app::{App, Plugin};
 use bevy_shader::load_shader_library;
@@ -34,6 +35,7 @@ impl Plugin for PostProcessPlugin {
             MotionBlurPlugin,
             DepthOfFieldPlugin,
             EffectStackPlugin,
+            LensDirtPlugin,
         ));
     }
 }

--- a/examples/3d/bloom_3d.rs
+++ b/examples/3d/bloom_3d.rs
@@ -3,7 +3,10 @@
 use bevy::{
     core_pipeline::tonemapping::Tonemapping,
     math::ops,
-    post_process::bloom::{Bloom, BloomCompositeMode, LensDirt},
+    post_process::{
+        bloom::{Bloom, BloomCompositeMode},
+        lens_dirt::LensDirt,
+    },
     prelude::*,
 };
 use std::{
@@ -33,15 +36,12 @@ fn setup_scene(
         },
         Tonemapping::TonyMcMapface, // 1. Using a tonemapper that desaturates to white is recommended
         Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-        Bloom {
-            lens_dirt: LensDirt {
-                // https://opengameart.org/content/lens-dirt-texture-pack-3png
-                texture: Some(asset_server.load("textures/lens_dirt_texture.png")),
-                intensity: 1.0,
-                ..default()
-            },
+        Bloom::NATURAL, // 2. Enable bloom for the camera
+        LensDirt {
+            // https://opengameart.org/content/lens-dirt-texture-pack-3png
+            texture: asset_server.load("textures/lens_dirt_texture.png"),
             ..default()
-        }, // 2. Enable bloom for the camera
+        },
     ));
 
     let material_emissive1 = materials.add(StandardMaterial {
@@ -104,7 +104,7 @@ fn setup_scene(
 // ------------------------------------------------------------------------------------------------
 
 fn update_bloom_settings(
-    camera: Single<(Entity, Option<&mut Bloom>), With<Camera>>,
+    camera: Single<(Entity, Option<&mut Bloom>, &mut LensDirt), With<Camera>>,
     mut text: Single<&mut Text>,
     mut commands: Commands,
     keycode: Res<ButtonInput<KeyCode>>,
@@ -113,7 +113,7 @@ fn update_bloom_settings(
     let bloom = camera.into_inner();
 
     match bloom {
-        (entity, Some(mut bloom)) => {
+        (entity, Some(mut bloom), mut lens_dirt) => {
             text.0 = "Bloom (Toggle: Space)\n".to_string();
             text.push_str(&format!("(Q/A) Intensity: {:.2}\n", bloom.intensity));
             text.push_str(&format!(
@@ -147,7 +147,7 @@ fn update_bloom_settings(
 
             text.push_str(&format!(
                 "(O/L) Lens Dirt intensity: {:.2}\n",
-                bloom.lens_dirt.intensity
+                lens_dirt.intensity
             ));
 
             if keycode.just_pressed(KeyCode::Space) {
@@ -221,16 +221,16 @@ fn update_bloom_settings(
             bloom.scale.x = bloom.scale.x.clamp(0.0, 8.0);
 
             if keycode.pressed(KeyCode::KeyL) {
-                bloom.lens_dirt.intensity -= dt / 10.0;
+                lens_dirt.intensity -= dt / 10.0;
             }
             if keycode.pressed(KeyCode::KeyO) {
-                bloom.lens_dirt.intensity += dt / 10.0;
+                lens_dirt.intensity += dt / 10.0;
             }
 
-            bloom.lens_dirt.intensity = bloom.lens_dirt.intensity.clamp(0.0, 1.0);
+            lens_dirt.intensity = lens_dirt.intensity.clamp(0.0, 1.0);
         }
 
-        (entity, None) => {
+        (entity, None, _) => {
             text.0 = "Bloom: Off (Toggle: Space)".to_string();
 
             if keycode.just_pressed(KeyCode::Space) {

--- a/examples/3d/bloom_3d.rs
+++ b/examples/3d/bloom_3d.rs
@@ -3,7 +3,7 @@
 use bevy::{
     core_pipeline::tonemapping::Tonemapping,
     math::ops,
-    post_process::bloom::{Bloom, BloomCompositeMode},
+    post_process::bloom::{Bloom, BloomCompositeMode, LensDirt},
     prelude::*,
 };
 use std::{
@@ -23,6 +23,7 @@ fn setup_scene(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
+    asset_server: Res<AssetServer>,
 ) {
     commands.spawn((
         Camera3d::default(),
@@ -32,7 +33,15 @@ fn setup_scene(
         },
         Tonemapping::TonyMcMapface, // 1. Using a tonemapper that desaturates to white is recommended
         Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-        Bloom::NATURAL, // 2. Enable bloom for the camera
+        Bloom {
+            lens_dirt: LensDirt {
+                // https://opengameart.org/content/lens-dirt-texture-pack-3png
+                texture: Some(asset_server.load("textures/lens_dirt_texture.png")),
+                intensity: 1.0,
+                ..default()
+            },
+            ..default()
+        }, // 2. Enable bloom for the camera
     ));
 
     let material_emissive1 = materials.add(StandardMaterial {
@@ -136,6 +145,11 @@ fn update_bloom_settings(
             ));
             text.push_str(&format!("(I/K) Horizontal Scale: {:.2}\n", bloom.scale.x));
 
+            text.push_str(&format!(
+                "(O/L) Lens Dirt intensity: {:.2}\n",
+                bloom.lens_dirt.intensity
+            ));
+
             if keycode.just_pressed(KeyCode::Space) {
                 commands.entity(entity).remove::<Bloom>();
             }
@@ -205,6 +219,15 @@ fn update_bloom_settings(
                 bloom.scale.x += dt * 2.0;
             }
             bloom.scale.x = bloom.scale.x.clamp(0.0, 8.0);
+
+            if keycode.pressed(KeyCode::KeyL) {
+                bloom.lens_dirt.intensity -= dt / 10.0;
+            }
+            if keycode.pressed(KeyCode::KeyO) {
+                bloom.lens_dirt.intensity += dt / 10.0;
+            }
+
+            bloom.lens_dirt.intensity = bloom.lens_dirt.intensity.clamp(0.0, 1.0);
         }
 
         (entity, None) => {


### PR DESCRIPTION
# Objective

- This PR adds optional lens dirt support to the bloom post-processing pipeline.

## Solution

- The effect is applied during the final upsampling stage and remains fully optional.

- ~~There's a TODO comment in `upsampling_pipeline.rs`, but I didn't follow it exactly for this lens dirt implementation.
It felt like overkill for what I needed, and I just wanted a working lens dirt effect without too much extra complexity.
The TODO approach might make things cleaner in the long run, but this simpler version works well enough for now.~~

- The upsampling process is now calculated on the CPU side and blended on the GPU side, which enables future features such as bloom mask without needing to move `compute_blend_factor()` to the GPU side.

- Now that `LensDirt` has been extracted into a standalone plugin, the Bloom module is noticeably cleaner. ~~However, I’m still reflecting on its design. Ideally, LensDirt should simply provide GPU resources for other post-processing effects to consume. This would allow users to build custom post-processing effects and decide how they interact with the lens dirt. Unfortunately, the current way users utilize the plugin isn’t very elegant, and I haven’t figured out a good design solution to solve this yet.~~   Perhaps this should be left as future work rather than addressed in this PR.

## Testing

- The `bloom_3d` example adds a lens dirt effect and runs as expected.
- The `lens_dirt_texture.png` just for review. This would probably be better placed in `bevy_asset_files`.

---


https://github.com/user-attachments/assets/75223f3f-fffb-44b1-890f-e5eeaf16b1c1

