### PR TITLE
Add this_run and last_run to DetectChanges

### DIFF
--- a/crates/bevy_ecs/src/change_detection/params.rs
+++ b/crates/bevy_ecs/src/change_detection/params.rs
@@ -1363,6 +1363,16 @@ impl<'w> DetectChanges for MutUntyped<'w> {
     fn added(&self) -> Tick {
         *self.ticks.added
     }
+    
+    #[inline]
+    fn this_run(&self) -> Tick {
+        self.ticks.this_run
+    }
+        
+    #[inline]
+    fn last_run(&self) -> Tick {
+        self.ticks.last_run
+    }
 }
 
 impl<'w> DetectChangesMut for MutUntyped<'w> {

--- a/crates/bevy_ecs/src/change_detection/params.rs
+++ b/crates/bevy_ecs/src/change_detection/params.rs
@@ -1363,12 +1363,12 @@ impl<'w> DetectChanges for MutUntyped<'w> {
     fn added(&self) -> Tick {
         *self.ticks.added
     }
-    
+
     #[inline]
     fn this_run(&self) -> Tick {
         self.ticks.this_run
     }
-        
+
     #[inline]
     fn last_run(&self) -> Tick {
         self.ticks.last_run

--- a/crates/bevy_ecs/src/change_detection/traits.rs
+++ b/crates/bevy_ecs/src/change_detection/traits.rs
@@ -82,6 +82,12 @@ pub trait DetectChanges {
     /// Returns the change tick recording the time this data was added.
     fn added(&self) -> Tick;
 
+    /// Returns the change tick of the current run of this system.
+    fn this_run(&self) -> Tick;
+
+    /// Returns the change tick of the last run of this system.
+    fn last_run(&self) -> Tick;
+    
     /// The location that last caused this to change.
     fn changed_by(&self) -> MaybeLocation;
 }
@@ -393,6 +399,16 @@ macro_rules! change_detection_impl {
             #[inline]
             fn added(&self) -> Tick {
                 *self.ticks.added
+            }
+            
+            #[inline]
+            fn this_run(&self) -> Tick {
+                self.ticks.this_run
+            }
+            
+            #[inline]
+            fn last_run(&self) -> Tick {
+                self.ticks.last_run
             }
 
             #[inline]

--- a/crates/bevy_ecs/src/change_detection/traits.rs
+++ b/crates/bevy_ecs/src/change_detection/traits.rs
@@ -87,7 +87,7 @@ pub trait DetectChanges {
 
     /// Returns the change tick of the last run of this system.
     fn last_run(&self) -> Tick;
-    
+
     /// The location that last caused this to change.
     fn changed_by(&self) -> MaybeLocation;
 }
@@ -400,12 +400,12 @@ macro_rules! change_detection_impl {
             fn added(&self) -> Tick {
                 *self.ticks.added
             }
-            
+
             #[inline]
             fn this_run(&self) -> Tick {
                 self.ticks.this_run
             }
-            
+
             #[inline]
             fn last_run(&self) -> Tick {
                 self.ticks.last_run


### PR DESCRIPTION
# Objective

Since the change detecting smart pointers carry around the current and previous system ticks, it would be nice to have access to this information.

For example, I want to detect if a component has changed, but including if it was changed by the last run of this system. Currently I guess the best way would be a marker component state machine kinda like `avian3d::Sleeping`, but with this PR we can do:
```
fn is_awake<T>(thing: Ref<T>) -> bool {
    thing.is_changed() || thing.last_changed() == thing.last_run()
}
```

The other thing I want to do that would require this is to make a component that does internal change detection through extension traits on `Ref<MyComponent>` and `Mut<MyComponent>`. The alternatives would be to create a `SystemParam` with `SystemChangeTick`, implement a new `QueryData`, or break my component into smaller components and put them on child entities (which I'm trying in a separate branch of my project), but these are all heavier solutions.

I suppose the downside is that if we ever switch to u64 ticks, then we'll no longer need `this_run` in order to compare ticks, and so we'd have to remove `this_run()` from `DetectChanges`. But at least for the use cases I have in mind, the user would also no longer need `this_run()`.

## Solution

Added `this_run` and `last_run` methods to `DetectChanges`.

## Testing

I am currently building a plugin where I will try out these methods.