### PR TITLE
update ratatui dependency to 0.30

### DIFF
--- a/tools/export-content/Cargo.toml
+++ b/tools/export-content/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 miette = { version = "7.6.0", features = ["fancy"] }
-ratatui = "0.29.0"
+ratatui = "0.30.0"
 regex = "1.11.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_yml = "0.0.12"

--- a/tools/export-content/src/app.rs
+++ b/tools/export-content/src/app.rs
@@ -77,7 +77,10 @@ impl App {
         })
     }
 
-    pub fn run<B: Backend>(mut self, terminal: &mut Terminal<B>) -> Result<()> {
+    pub fn run<B: Backend>(mut self, terminal: &mut Terminal<B>) -> Result<()>
+    where
+        B::Error: 'static + Send + Sync,
+    {
         while !self.exit {
             terminal
                 .draw(|frame| self.render(frame))

--- a/tools/export-content/src/main.rs
+++ b/tools/export-content/src/main.rs
@@ -11,6 +11,7 @@
 
 use std::{
     io,
+    io::Write,
     panic::{set_hook, take_hook},
 };
 
@@ -43,7 +44,10 @@ fn main() -> Result<()> {
     res
 }
 
-fn run_app<B: Backend>(terminal: &mut Terminal<B>) -> Result<()> {
+fn run_app<B: Backend>(terminal: &mut Terminal<B>) -> Result<()>
+where
+    B::Error: 'static + Send + Sync,
+{
     let app = App::new()?;
     app.run(terminal)
 }
@@ -57,7 +61,7 @@ fn init_panic_hook() {
     }));
 }
 
-fn init_terminal() -> Result<Terminal<impl Backend>> {
+fn init_terminal() -> Result<Terminal<CrosstermBackend<impl Write>>> {
     enable_raw_mode().into_diagnostic()?;
     execute!(io::stdout(), EnterAlternateScreen, EnableMouseCapture).into_diagnostic()?;
     let backend = CrosstermBackend::new(io::stdout());


### PR DESCRIPTION
# Objective

Ratatui is used by the `tools/export-content` crate. Update it to its latest stable version.

This PR supersedes #22351 which is a dependabot PR that got stuck on some breaking changes in ratatui 0.30.

## Solution

Ratatui's `Backend` type now has an associated `Error` type that does not specify `Send + Sync`,
which is a bit awkward because `miette` requires those. Fixed by adding the requirements locally,
and changing `init_terminal()` to return its specific backend type so that the compiler can verify its `Error` type.

## Testing

Ran the tool before and after and it looked the same.