### PR TITLE
No CAS loop EntityAllocator remote freelist.

### DIFF
--- a/benches/benches/bevy_ecs/world/entity_allocator.rs
+++ b/benches/benches/bevy_ecs/world/entity_allocator.rs
@@ -184,7 +184,7 @@ pub fn entity_allocator_benches(criterion: &mut Criterion) {
             bencher.iter_batched_ref(
                 || {
                     let mut world = World::new();
-                    let mut entities =
+                    let entities =
                         Vec::from_iter(world.entity_allocator().alloc_many(entity_count));
                     world.entity_allocator_mut().free_many(&entities);
                     world.entity_allocator_mut().flush();

--- a/benches/benches/bevy_ecs/world/entity_allocator.rs
+++ b/benches/benches/bevy_ecs/world/entity_allocator.rs
@@ -64,6 +64,7 @@ pub fn entity_allocator_benches(criterion: &mut Criterion) {
                     entities
                         .drain(..)
                         .for_each(|e| world.entity_allocator_mut().free(e));
+                    world.entity_allocator_mut().flush();
                 },
                 BatchSize::SmallInput,
             );
@@ -107,6 +108,7 @@ pub fn entity_allocator_benches(criterion: &mut Criterion) {
                     let entities =
                         Vec::from_iter(world.entity_allocator().alloc_many(entity_count));
                     world.entity_allocator_mut().free_many(&entities);
+                    world.entity_allocator_mut().flush();
                     world
                 },
                 |world| {
@@ -134,6 +136,7 @@ pub fn entity_allocator_benches(criterion: &mut Criterion) {
                     let entities =
                         Vec::from_iter(world.entity_allocator().alloc_many(entity_count));
                     world.entity_allocator_mut().free_many(&entities);
+                    world.entity_allocator_mut().flush();
                     world
                 },
                 |world| {
@@ -183,9 +186,8 @@ pub fn entity_allocator_benches(criterion: &mut Criterion) {
                     let mut world = World::new();
                     let mut entities =
                         Vec::from_iter(world.entity_allocator().alloc_many(entity_count));
-                    entities
-                        .drain(..)
-                        .for_each(|e| world.entity_allocator_mut().free(e));
+                    world.entity_allocator_mut().free_many(&entities);
+                    world.entity_allocator_mut().flush();
                     world.entity_allocator().build_remote_allocator()
                 },
                 |remote| {

--- a/benches/benches/bevy_ecs/world/entity_allocator.rs
+++ b/benches/benches/bevy_ecs/world/entity_allocator.rs
@@ -88,6 +88,7 @@ pub fn entity_allocator_benches(criterion: &mut Criterion) {
                 },
                 |(world, entities)| {
                     world.entity_allocator_mut().free_many(entities);
+                    world.entity_allocator_mut().flush();
                 },
                 BatchSize::SmallInput,
             );
@@ -107,7 +108,10 @@ pub fn entity_allocator_benches(criterion: &mut Criterion) {
                     let mut world = World::new();
                     let entities =
                         Vec::from_iter(world.entity_allocator().alloc_many(entity_count));
-                    world.entity_allocator_mut().free_many(&entities);
+                    let half = entity_count as usize / 2;
+                    world.entity_allocator_mut().free_many(&entities[..half]);
+                    world.entity_allocator_mut().flush();
+                    world.entity_allocator_mut().free_many(&entities[half..]);
                     world.entity_allocator_mut().flush();
                     world
                 },
@@ -135,7 +139,10 @@ pub fn entity_allocator_benches(criterion: &mut Criterion) {
                     let mut world = World::new();
                     let entities =
                         Vec::from_iter(world.entity_allocator().alloc_many(entity_count));
-                    world.entity_allocator_mut().free_many(&entities);
+                    let half = entity_count as usize / 2;
+                    world.entity_allocator_mut().free_many(&entities[..half]);
+                    world.entity_allocator_mut().flush();
+                    world.entity_allocator_mut().free_many(&entities[half..]);
                     world.entity_allocator_mut().flush();
                     world
                 },
@@ -186,13 +193,46 @@ pub fn entity_allocator_benches(criterion: &mut Criterion) {
                     let mut world = World::new();
                     let entities =
                         Vec::from_iter(world.entity_allocator().alloc_many(entity_count));
-                    world.entity_allocator_mut().free_many(&entities);
+                    let half = entity_count as usize / 2;
+                    world.entity_allocator_mut().free_many(&entities[..half]);
+                    world.entity_allocator_mut().flush();
+                    world.entity_allocator_mut().free_many(&entities[half..]);
                     world.entity_allocator_mut().flush();
                     world.entity_allocator().build_remote_allocator()
                 },
                 |remote| {
                     for _ in 0..entity_count {
                         let entity = remote.alloc();
+                        black_box(entity);
+                    }
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+
+    group.finish();
+
+    let mut group = criterion.benchmark_group("entity_allocator_allocate_reused_remote_bulk");
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(4));
+
+    for entity_count in ENTITY_COUNTS {
+        group.bench_function(format!("{entity_count}_entities"), |bencher| {
+            bencher.iter_batched_ref(
+                || {
+                    let mut world = World::new();
+                    let entities =
+                        Vec::from_iter(world.entity_allocator().alloc_many(entity_count));
+                    let half = entity_count as usize / 2;
+                    world.entity_allocator_mut().free_many(&entities[..half]);
+                    world.entity_allocator_mut().flush();
+                    world.entity_allocator_mut().free_many(&entities[half..]);
+                    world.entity_allocator_mut().flush();
+                    world.entity_allocator().build_remote_allocator()
+                },
+                |remote| {
+                    for entity in remote.alloc_many(entity_count) {
                         black_box(entity);
                     }
                 },

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -128,6 +128,7 @@ subsecond = { version = "0.7.0-rc.0", optional = true }
 slotmap = { version = "1.0.7", default-features = false }
 
 concurrent-queue = { version = "2.5.0", default-features = false }
+crossbeam-utils = { version = "0.8.21", default-features = false }
 [target.'cfg(not(all(target_has_atomic = "8", target_has_atomic = "16", target_has_atomic = "32", target_has_atomic = "64", target_has_atomic = "ptr")))'.dependencies]
 concurrent-queue = { version = "2.5.0", default-features = false, features = [
   "portable-atomic",

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -729,16 +729,18 @@ impl EntityAllocator {
     /// Freeing an [`Entity`] such that one [`EntityIndex`] is in the allocator in multiple places can cause panics when spawning the allocated entity.
     /// Additionally, to differentiate versions of an [`Entity`], updating the [`EntityGeneration`] before freeing is a good idea
     /// (but not strictly necessary if you don't mind [`Entity`] id aliasing.)
-    pub fn free(&mut self, freed: Entity) {
+    pub fn free(&mut self, freed: Entity) -> &mut Self {
         self.inner.free(freed);
+        self
     }
 
     /// This allows `freed` to be retrieved from [`alloc`](Self::alloc), etc.
     ///
     /// The same caveats of [`free`](Self::free) apply here.
     /// (Eg. the slice should not contain duplicates.)
-    pub fn free_many(&mut self, freed: &[Entity]) {
+    pub fn free_many(&mut self, freed: &[Entity]) -> &mut Self {
         self.inner.free_many(freed);
+        self
     }
 
     /// Allocates some [`Entity`].

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -729,18 +729,16 @@ impl EntityAllocator {
     /// Freeing an [`Entity`] such that one [`EntityIndex`] is in the allocator in multiple places can cause panics when spawning the allocated entity.
     /// Additionally, to differentiate versions of an [`Entity`], updating the [`EntityGeneration`] before freeing is a good idea
     /// (but not strictly necessary if you don't mind [`Entity`] id aliasing.)
-    pub fn free(&mut self, freed: Entity) -> &mut Self {
+    pub fn free(&mut self, freed: Entity) {
         self.inner.free(freed);
-        self
     }
 
     /// This allows `freed` to be retrieved from [`alloc`](Self::alloc), etc.
     ///
     /// The same caveats of [`free`](Self::free) apply here.
     /// (Eg. the slice should not contain duplicates.)
-    pub fn free_many(&mut self, freed: &[Entity]) -> &mut Self {
+    pub fn free_many(&mut self, freed: &[Entity]) {
         self.inner.free_many(freed);
-        self
     }
 
     /// Allocates some [`Entity`].

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -795,6 +795,11 @@ impl EntityAllocator {
             inner: self.inner.alloc_many(count),
         }
     }
+
+    /// Flushes any pending frees to the shared free list.
+    pub fn flush(&mut self) {
+        self.inner.flush();
+    }
 }
 
 /// An [`Iterator`] returning a sequence of unique [`Entity`] values from [`Entities`].

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -710,7 +710,7 @@ pub struct EntityAllocator {
 impl EntityAllocator {
     /// Restarts the allocator.
     pub(crate) fn restart(&mut self) {
-        self.inner = remote_allocator::Allocator::new();
+        self.inner = remote_allocator::Allocator::default();
     }
 
     /// Builds a new remote allocator that hooks into this [`EntityAllocator`].

--- a/crates/bevy_ecs/src/entity/remote_allocator.rs
+++ b/crates/bevy_ecs/src/entity/remote_allocator.rs
@@ -792,7 +792,7 @@ impl FreshAllocator {
 /// These rows have never been given out before.
 ///
 /// **NOTE:** Dropping will leak the remaining entity rows!
-pub(super) struct AllocUniqueEntityIndexIterator(core::ops::Range<u32>);
+pub(super) struct AllocUniqueEntityIndexIterator(Range<u32>);
 
 impl Iterator for AllocUniqueEntityIndexIterator {
     type Item = Entity;

--- a/crates/bevy_ecs/src/entity/remote_allocator.rs
+++ b/crates/bevy_ecs/src/entity/remote_allocator.rs
@@ -402,7 +402,7 @@ impl Metadata {
     }
 
     fn non_empty_count(self) -> u32 {
-        (self.0 & 0b11).count_zeros()
+        (self.0 | !0b11).count_zeros()
     }
 }
 

--- a/crates/bevy_ecs/src/entity/remote_allocator.rs
+++ b/crates/bevy_ecs/src/entity/remote_allocator.rs
@@ -649,15 +649,15 @@ impl SharedFreeList {
         }
         let meta = self.meta.load();
 
-        let wich_priority = meta.which_priority();
+        let which_priority = meta.which_priority();
         let which = match meta.non_empty_count() {
             2 => return,
             // publish to the non-priority buffer which will be (or already has been) swapped to when
             // the current priority buffer empties
-            1 => !wich_priority,
+            1 => !which_priority,
             // publish to the priority buffer which has already been swapped to when the last buffer
             // was emptied
-            0 => wich_priority,
+            0 => which_priority,
             _ => unreachable!(),
         };
 

--- a/crates/bevy_ecs/src/entity/remote_allocator.rs
+++ b/crates/bevy_ecs/src/entity/remote_allocator.rs
@@ -408,8 +408,8 @@ impl<'a> Drop for PopMany<'a> {
 }
 
 /// # Layout
-/// - 0: a_empty
-/// - 1: b_empty
+/// - 0: a_non_empty
+/// - 1: b_non_empty
 /// - 2: priority (true -> b, false -> b) (see [`SharedFreeList::swaps`])
 #[derive(Clone, Copy)]
 struct Metadata(u32);
@@ -422,12 +422,12 @@ impl Metadata {
 
     #[inline]
     fn are_empty(self) -> bool {
-        self.0 & 0b11 == 0b11
+        self.0 & 0b11 == 0b00
     }
 
     #[inline]
     fn non_empty_count(self) -> u32 {
-        (self.0 | !0b11).count_zeros()
+        (self.0 | 0b11).count_ones()
     }
 }
 

--- a/crates/bevy_ecs/src/entity/remote_allocator.rs
+++ b/crates/bevy_ecs/src/entity/remote_allocator.rs
@@ -732,11 +732,11 @@ impl SharedAllocator {
     /// # Safety
     /// - You must be the single producer to call this function.
     #[inline]
-    unsafe fn alloc_many_as_producer(&self, count: u32) -> AllocEntitiesiter<'_> {
+    unsafe fn alloc_many_as_producer(&self, count: u32) -> AllocEntitiesIterator<'_> {
         let reused = unsafe { self.free.pop_many_as_producer(count) };
         let still_need = count - reused.len() as u32;
         let new = self.fresh.alloc_many(still_need);
-        AllocEntitiesiter { new, reused }
+        AllocEntitiesIterator { new, reused }
     }
 
     /// Allocates a new [`Entity`], reusing a freed index if one exists.
@@ -749,11 +749,11 @@ impl SharedAllocator {
 
     /// Allocates a `count` [`Entity`]s, reusing freed indices if they exist.
     #[inline]
-    fn alloc_many_as_consumer(&self, count: u32) -> AllocEntitiesiter<'_> {
+    fn alloc_many_as_consumer(&self, count: u32) -> AllocEntitiesIterator<'_> {
         let reused = unsafe { self.free.pop_many_as_producer(count) };
         let still_need = count - reused.len() as u32;
         let new = self.fresh.alloc_many(still_need);
-        AllocEntitiesiter { new, reused }
+        AllocEntitiesIterator { new, reused }
     }
 
     /// Marks the allocator as closed, but it will still function normally.
@@ -793,7 +793,7 @@ impl Allocator {
 
     /// Allocates `count` entities in an iterator.
     #[inline]
-    pub(super) fn alloc_many(&self, count: u32) -> AllocEntitiesiter<'_> {
+    pub(super) fn alloc_many(&self, count: u32) -> AllocEntitiesIterator<'_> {
         // SAFETY: we have &self, so we are the single producer. also no Clone
         unsafe { self.shared.alloc_many_as_producer(count) }
     }
@@ -849,12 +849,12 @@ impl core::fmt::Debug for Allocator {
 /// An [`Iterator`] returning a sequence of [`Entity`] values from an [`Allocator`].
 ///
 /// **NOTE:** Dropping will leak the remaining entities!
-pub(crate) struct AllocEntitiesiter<'a> {
+pub(crate) struct AllocEntitiesIterator<'a> {
     reused: ChainPopMany<'a>,
     new: AllocUniqueEntityIndexIterator,
 }
 
-impl<'a> Iterator for AllocEntitiesiter<'a> {
+impl<'a> Iterator for AllocEntitiesIterator<'a> {
     type Item = Entity;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -867,13 +867,13 @@ impl<'a> Iterator for AllocEntitiesiter<'a> {
     }
 }
 
-impl<'a> ExactSizeIterator for AllocEntitiesiter<'a> {}
-impl<'a> FusedIterator for AllocEntitiesiter<'a> {}
+impl<'a> ExactSizeIterator for AllocEntitiesIterator<'a> {}
+impl<'a> FusedIterator for AllocEntitiesIterator<'a> {}
 
 // SAFETY: Newly reserved entity values are unique.
-unsafe impl EntitySetIterator for AllocEntitiesiter<'_> {}
+unsafe impl EntitySetIterator for AllocEntitiesIterator<'_> {}
 
-impl Drop for AllocEntitiesiter<'_> {
+impl Drop for AllocEntitiesIterator<'_> {
     fn drop(&mut self) {
         let leaking = self.len();
         if leaking > 0 {
@@ -929,7 +929,7 @@ impl RemoteAllocator {
     /// They will not be unique in the world anymore and you should not spawn them!
     /// Before using the returned values in the world, first check that it is ok with [`EntityAllocator::has_remote_allocator`](super::EntityAllocator::has_remote_allocator).
     #[inline]
-    pub(crate) fn alloc_many(&self, count: u32) -> AllocEntitiesiter<'_> {
+    pub(crate) fn alloc_many(&self, count: u32) -> AllocEntitiesIterator<'_> {
         self.shared.alloc_many_as_consumer(count)
     }
 

--- a/crates/bevy_ecs/src/entity/remote_allocator.rs
+++ b/crates/bevy_ecs/src/entity/remote_allocator.rs
@@ -732,11 +732,11 @@ impl SharedAllocator {
     /// # Safety
     /// - You must be the single producer to call this function.
     #[inline]
-    unsafe fn alloc_many_as_producer(&self, count: u32) -> SharedAllocEntitiesIter<'_> {
+    unsafe fn alloc_many_as_producer(&self, count: u32) -> AllocEntitiesiter<'_> {
         let reused = unsafe { self.free.pop_many_as_producer(count) };
         let still_need = count - reused.len() as u32;
         let new = self.fresh.alloc_many(still_need);
-        SharedAllocEntitiesIter { new, reused }
+        AllocEntitiesiter { new, reused }
     }
 
     /// Allocates a new [`Entity`], reusing a freed index if one exists.
@@ -749,11 +749,11 @@ impl SharedAllocator {
 
     /// Allocates a `count` [`Entity`]s, reusing freed indices if they exist.
     #[inline]
-    fn alloc_many_as_consumer(&self, count: u32) -> SharedAllocEntitiesIter<'_> {
+    fn alloc_many_as_consumer(&self, count: u32) -> AllocEntitiesiter<'_> {
         let reused = unsafe { self.free.pop_many_as_producer(count) };
         let still_need = count - reused.len() as u32;
         let new = self.fresh.alloc_many(still_need);
-        SharedAllocEntitiesIter { new, reused }
+        AllocEntitiesiter { new, reused }
     }
 
     /// Marks the allocator as closed, but it will still function normally.
@@ -793,7 +793,7 @@ impl Allocator {
 
     /// Allocates `count` entities in an iterator.
     #[inline]
-    pub(super) fn alloc_many(&self, count: u32) -> SharedAllocEntitiesIter<'_> {
+    pub(super) fn alloc_many(&self, count: u32) -> AllocEntitiesiter<'_> {
         // SAFETY: we have &self, so we are the single producer. also no Clone
         unsafe { self.shared.alloc_many_as_producer(count) }
     }
@@ -849,12 +849,12 @@ impl core::fmt::Debug for Allocator {
 /// An [`Iterator`] returning a sequence of [`Entity`] values from an [`Allocator`].
 ///
 /// **NOTE:** Dropping will leak the remaining entities!
-pub(crate) struct SharedAllocEntitiesIter<'a> {
+pub(crate) struct AllocEntitiesiter<'a> {
     reused: ChainPopMany<'a>,
     new: AllocUniqueEntityIndexIterator,
 }
 
-impl<'a> Iterator for SharedAllocEntitiesIter<'a> {
+impl<'a> Iterator for AllocEntitiesiter<'a> {
     type Item = Entity;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -867,13 +867,13 @@ impl<'a> Iterator for SharedAllocEntitiesIter<'a> {
     }
 }
 
-impl<'a> ExactSizeIterator for SharedAllocEntitiesIter<'a> {}
-impl<'a> FusedIterator for SharedAllocEntitiesIter<'a> {}
+impl<'a> ExactSizeIterator for AllocEntitiesiter<'a> {}
+impl<'a> FusedIterator for AllocEntitiesiter<'a> {}
 
 // SAFETY: Newly reserved entity values are unique.
-unsafe impl EntitySetIterator for SharedAllocEntitiesIter<'_> {}
+unsafe impl EntitySetIterator for AllocEntitiesiter<'_> {}
 
-impl Drop for SharedAllocEntitiesIter<'_> {
+impl Drop for AllocEntitiesiter<'_> {
     fn drop(&mut self) {
         let leaking = self.len();
         if leaking > 0 {
@@ -929,7 +929,7 @@ impl RemoteAllocator {
     /// They will not be unique in the world anymore and you should not spawn them!
     /// Before using the returned values in the world, first check that it is ok with [`EntityAllocator::has_remote_allocator`](super::EntityAllocator::has_remote_allocator).
     #[inline]
-    pub(crate) fn alloc_many(&self, count: u32) -> SharedAllocEntitiesIter<'_> {
+    pub(crate) fn alloc_many(&self, count: u32) -> AllocEntitiesiter<'_> {
         self.shared.alloc_many_as_consumer(count)
     }
 

--- a/crates/bevy_ecs/src/entity/remote_allocator.rs
+++ b/crates/bevy_ecs/src/entity/remote_allocator.rs
@@ -105,6 +105,12 @@ impl SharedDrain {
 /// Although this is a [`AtomicU64`]. On unsupporting platforms we can easily split this into two [`AtomicI32`] values and
 /// have [`SharedSwapDrain::pop_as_consumer`] update both atomically.
 ///
+/// Keep in mind that the two heads [`Head::head`] and [`Head::consumer_head`] would not be decremented (together) atomically in this case
+/// resulting in [`Head::producer_pop_count`] being incorrect when publishing. However, assuming we decrement the [`Head::consumer_head]
+/// first, we can at least ensure that [`Head::producer_pop_count`] is only ever incorrect in a direction where it won't result in UB.
+/// Additionally, because we use [`Metadata`] to (loosely) avoid polling empty queues, this possible design results in a fallible but
+/// eventually correct [`Head::producer_pop_count`] value.
+///
 /// # Layout
 /// - 0..31 - `i32` head used to reserve indices
 /// - 32..63 - `i32` consumer only head

--- a/crates/bevy_ecs/src/entity/remote_allocator.rs
+++ b/crates/bevy_ecs/src/entity/remote_allocator.rs
@@ -14,21 +14,6 @@
 //! In particular, a concurrent queue must do additional work to handle cases where something is added concurrently with being removed.
 //! But for non-remote allocation, we can guarantee that no free will happen during an allocation since `free` needs mutably access to the world already.
 //! That means, we can skip a lot of those safety checks.
-//! Plus, we know the maximum size of the free list ahead of time, since we can assume there are no duplicates.
-//! That means, we can have a much more efficient allocation scheme, far better than a linked list.
-//!
-//! For the free list, the list needs to be pinned in memory and yet grow-able.
-//! That's quite the pickle, but by splitting the growth over multiple arrays, this isn't so bad.
-//! When the list needs to grow, we just *add* on another array to the buffer (instead of *replacing* the old one with a bigger one).
-//! These arrays are called [`Chunk`]s.
-//! This keeps everything pinned, and since we know the maximum size ahead of time, we can make this mapping very fast.
-//!
-//! Similar to how `Vec` is implemented, the free list is implemented as a [`FreeBuffer`] (handling allocations and implicit capacity)
-//! and the [`FreeCount`] manages the length of the free list.
-//! The free list's item is a [`Slot`], which manages accessing each item concurrently.
-//!
-//! These types are summed up in [`SharedAllocator`], which is highly unsafe.
-//! The interfaces [`Allocator`] and [`RemoteAllocator`] provide safe interfaces to them.
 
 use super::{Entity, EntityIndex, EntitySetIterator};
 use bevy_platform::{
@@ -50,17 +35,25 @@ use crossbeam_utils::CachePadded;
 use log::warn;
 use nonmax::NonMaxU32;
 
+/// A [`SharedDrain`] is a wrapper around a [`Vec`]. It ensures the capacity doesn't overflow `i32::MAX`.
+/// It also facilitates unsafe swapping and reading of elements.
+///
+/// # Note
+/// [`ManuallyDrop`] is not needed here as the capacity is always correct (unlike the len) and
+/// [`Entity`] is [`Copy`] but it is included anyways for correctness.
 #[derive(Default)]
 struct SharedDrain(ManuallyDrop<Vec<Entity>>);
 
 impl SharedDrain {
-    /// Swaps the previous `Vec` as if it had been drained to `0` with the `other` `Vec`.
-    /// Swaps it with an empty `Vec` if this is the first time it's been called.
+    /// Swaps the previous [`Vec`] as if it had been drained to `0` with the `other` [`Vec`].
+    /// Swaps it with an empty [`Vec`] if this is the first time it's been called.
+    ///
+    /// Returns the initial length of the [`SharedDrain`] that should be used as a cursor.
     ///
     /// This function makes sure the length of the vector is bound to `i32::MAX`.
     ///
     /// # Safety
-    /// - The previous `Vec` must have a length of `0`
+    /// - The previous [`Vec`] must have had all items in it [`SharedDrain::read`].
     #[inline]
     unsafe fn swap(&mut self, other: &mut Vec<Entity>) -> i32 {
         const MAX: usize = i32::MAX as usize;
@@ -93,23 +86,34 @@ impl SharedDrain {
 
 /// Reserves items to be drained from a [`SharedDrain`] using [`AtomicHead::claim_as_*`].
 ///
+/// # Producer Optimization
+/// Consumers normally decrement the [`Head::head`] cursor to claim items and decrement the
+/// [`Tail`] counter to release items. However when we are the producer ([`Allocator`]) we
+/// don't need to release items because we would be releasing them to ourself see
+/// [`SharedSwapDrain::pop_as_producer`] vs [`SharedSwapDrain::pop_as_consumer`]. Still,
+/// we need to know how many items we're popped by the producer. In order to achieve this
+/// we have two [`Head`]s: [`Head::head`] and [`Head::consumer_head`]. [`Head::head`] is
+/// decremented by the producer AND the consumer, and [`Head::consumer_head`] is decremented only by the consumer.
+/// We can then recreate the [`Head::producer_pop_count`] by subtracting [`Head::consumer_head`] from [`Head::head`].
+///
+/// To achieve this without significantly slowing down [`SharedSwapDrain::pop_as_consumer`], we pack both counters
+/// into a single `u64` value so that a single RMW operation can be used to update both. (I specifically chose this
+/// over having producer doubly increment so that the performance of [`SharedSwapDrain::pop_as_producer`] is not affected
+/// on unsupported platforms. vvv)
+///
+/// # Compatibility
+/// Although this is a [`AtomicU64`]. On unsupporting platforms we can easily split this into two [`AtomicI32`] values and
+/// have [`SharedSwapDrain::pop_as_consumer`] update both atomically.
+///
 /// # Layout
 /// - 0..31 - `i32` head used to reserve indices
 /// - 32..63 - `i32` consumer only head
 ///
-/// The lower 32 bits freely borrow and carry into the upper 32 bits. We only ever
-/// need to read the upper 32 bits when the lower 32 bits are negative (and also the
-/// lower 32 bits aren't allowed to wrap from negative <-> positive) therefore we can
-/// extract the actual value from the upper 32 bits by adding 1 when the lower 32 bits
-/// are negative.
+/// The lower 32 bits freely borrow and carry into the upper 32 bits. We manually correct
+/// this by adding `1` to the upper 32 bits when the lower 32 bits are negative.
+/// Keep in mind that this _only_ works because [`Head::head`] is not allowed to wrap (`i32::MAX` <-> `i32::MIN`)
 #[derive(Clone, Copy)]
 struct Head(u64);
-
-impl Default for Head {
-    fn default() -> Self {
-        Self::new(0)
-    }
-}
 
 impl Head {
     #[inline]
@@ -118,24 +122,31 @@ impl Head {
         Self(v | (v << 32))
     }
 
+    /// The current cursor position as if only consumers popped values.
+    ///
+    /// Only should be used in [`Head::producer_pop_count`].
     #[inline]
     fn consumer_head(self) -> i32 {
-        let mut consumer_head = ((self.0 as i64) >> 32) as i32;
-        // Note: This only works because `head` is not allowed to wrap
+        let mut consumer_head = (self.0 >> 32) as i32;
+        // Note: This only works because `head` is not allowed to wrap.
         if self.head() < 0 {
             consumer_head += 1;
         }
         consumer_head
     }
 
+    /// The current cursor position
     #[inline]
     fn head(self) -> i32 {
         (self.0 & u32::MAX as u64) as i32
     }
 
+    /// Returns the number of entities popped by the producer since the last [`Head::consumer_head`] update.
     #[inline]
-    fn producer_pop_count(self) -> i32 {
-        self.consumer_head() - self.head()
+    fn producer_pop_count(self) -> u32 {
+        // This could technically wrap which is why we cast to `u32` (besides it being the
+        // semantically correct option).
+        self.consumer_head().wrapping_sub(self.head()) as u32
     }
 }
 
@@ -144,12 +155,14 @@ impl Head {
 struct AtomicHead(AtomicU64);
 
 impl AtomicHead {
+    /// Write a new head value and release any prior written data to consumers.
     #[inline]
     fn publish(&self, head: Head) {
         // release matches with [`AtomicHead::claim_as_consumer`]
         self.0.store(head.0, Ordering::Release);
     }
 
+    /// Claim `n` slots as a consumer and return the old head value.
     #[inline]
     fn claim_as_consumer(&self, n: u32) -> Head {
         let n = n as u64;
@@ -158,6 +171,8 @@ impl AtomicHead {
         Head(self.0.fetch_sub(rhs, Ordering::Acquire))
     }
 
+    /// Claim `n` slots as a producer and return the old head value.
+    ///
     /// # Safety
     /// - must not be called syncronously with [`AtomicHead::publish`]
     #[inline]
@@ -167,13 +182,13 @@ impl AtomicHead {
     }
 }
 
-/// The `Tail` tracks how many remaining slots still need to be drained
-/// in order for the producer to have exclusive access to the buffer.
+/// The [`Tail`] counts how many remaining slots are unread by consumers
 ///
-/// Although this value is an `i32` it is always non-negative.
+/// Although this value is an `i32` it is always non-negative because consumers
+/// don't decrement it past zero.
 ///
 /// When the producer is performing their own reads they elide the decriment to
-/// tail. The actual tail must be reconstructed when publishing.
+/// tail. The actual tail must be reconstructed by adding this value and the [`Head::producer_pop_count`].
 #[derive(Default)]
 struct AtomicTail(AtomicI32);
 
@@ -184,6 +199,9 @@ impl AtomicTail {
         self.0.fetch_sub(n as i32, Ordering::Release);
     }
 
+    /// load the current tail and Acquire any reads the consumers released.
+    ///
+    /// This is used to reconstruct the actual tail value when publishing.
     #[inline]
     fn acquire(&self) -> i32 {
         // acquire matches with [`Tail::release_as_consumer`]
@@ -191,6 +209,14 @@ impl AtomicTail {
     }
 }
 
+/// A "View" of a [`SharedSwapDrain`] because it's internally stored as a SOA (see [`SharedFreeList`]).
+///
+/// This structure facilitates concurrent access to a [`SharedDrain`].
+///
+/// When the `actual_tail` (as summed by [`Head::produer_pop_count`] and [`Tail::acquire`]) is `<= 0`, the drain is considered empty.
+/// This is the only time that the producer is allowed to write data because we know that no consumer are
+/// reading the `drain`.
+/// Otherwise, the `drain` is under shared immutable access to all consumers and producers.
 #[derive(Clone, Copy)]
 struct SharedSwapDrain<'a> {
     drain: &'a SyncUnsafeCell<SharedDrain>,
@@ -199,8 +225,10 @@ struct SharedSwapDrain<'a> {
 }
 
 impl<'a> SharedSwapDrain<'a> {
+    /// Pop an entity from the drain.
+    ///
     /// # Safety
-    /// - must not be called syncronously with [`SharedSwapDrain::publish`]
+    /// - must not be called syncronously with [`SharedSwapDrain::try_publish`]
     #[inline]
     unsafe fn pop_as_producer(self, on_empty: impl Fn()) -> Option<Entity> {
         // SAFETY: [`SharedSwapDrain::publish`] which calls [`Head::publish`] is not being called
@@ -215,7 +243,7 @@ impl<'a> SharedSwapDrain<'a> {
             on_empty()
         }
 
-        // SAFETY: [`SharedSwapDrain::publish`], which mutates this value, is not being called
+        // SAFETY: if `head` returns any positive value then drain is under immutable access
         let drain = unsafe { self.drain.get().as_ref_unchecked() };
         // SAFETY: all indices in ranges returned by head are unique and in-bounds
         let value = unsafe { drain.read(index) };
@@ -223,6 +251,7 @@ impl<'a> SharedSwapDrain<'a> {
         Some(value)
     }
 
+    /// Pop an entity from the drain as a consumer.
     #[inline]
     fn pop_as_consumer(self, on_empty: impl Fn()) -> Option<Entity> {
         let head = self.head.claim_as_consumer(1);
@@ -236,7 +265,7 @@ impl<'a> SharedSwapDrain<'a> {
             on_empty()
         }
 
-        // SAFETY: if `head` returns any positive value then consumers have immutable access to drain
+        // SAFETY: if `head` returns any positive value then drain is under immutable access
         let drain = unsafe { self.drain.get().as_ref_unchecked() };
         // SAFETY: all indices in ranges returned by head are unique and in-bounds
         let value = unsafe { drain.read(index) };
@@ -247,7 +276,7 @@ impl<'a> SharedSwapDrain<'a> {
     }
 
     /// # Safety
-    /// - must not be called syncronously with [`SharedSwapDrain::publish`]
+    /// - must not be called syncronously with [`SharedSwapDrain::try_publish`]
     #[inline]
     unsafe fn pop_many_as_producer(self, n: u32, on_empty: impl Fn()) -> PopMany<'a> {
         if n == 0 {
@@ -284,25 +313,26 @@ impl<'a> SharedSwapDrain<'a> {
     }
 
     /// # Safety
-    /// - must not be called syncronously with any [`SharedSwapDrain::*_as_producer`]
+    /// - must not be called syncronously with any `*_as_producer`
+    /// - must not be called concurrently with itself
     #[inline]
     unsafe fn try_publish(self, data: &mut Vec<Entity>) -> bool {
         let tail = self.tail.acquire();
         // producer_pop_count cannot change while we have exclusive access to the producer
         let producer_pop_count = Head(self.head.0.load(Ordering::Relaxed)).producer_pop_count();
-        let actual_tail = tail - producer_pop_count;
+        let (actual_tail, overflow) = tail.overflowing_sub_unsigned(producer_pop_count);
 
-        if actual_tail > 0 {
+        if actual_tail > 0 || overflow {
             return false;
         }
 
         // SAFETY: Nobody is allowed to read from `drain` when `actual_tail <= 0`.
         let drain = unsafe { self.drain.get().as_mut_unchecked() };
-        // SAFETY: We checked that `actual_tail <= 0` meaning all items have been drained.
+        // SAFETY: We checked that `actual_tail <= 0` meaning all items have been claimed and read.
         let initial_len = unsafe { drain.swap(data) };
 
         // `tail` can be relaxed because `head` fences the publication
-        // `tail` must be stored before `head`
+        // `tail` must be stored before `head` because `head` also fences `tail`.
         self.tail.0.store(initial_len, Ordering::Relaxed);
         self.head.publish(Head::new(initial_len));
 
@@ -312,8 +342,12 @@ impl<'a> SharedSwapDrain<'a> {
 
 #[inline]
 fn clamp_to_positive(range: Range<i32>, on_empty: impl Fn()) -> Range<u32> {
-    // `<=` makes sure we also call `on_empty` on ranges to `0` not just past `0`
-    if range.start <= 0 {
+    if range.start > 0 {
+        Range {
+            start: range.start as u32,
+            end: range.end as u32,
+        }
+    } else {
         if range.end > 0 {
             on_empty();
             Range {
@@ -322,11 +356,6 @@ fn clamp_to_positive(range: Range<i32>, on_empty: impl Fn()) -> Range<u32> {
             }
         } else {
             Range { start: 0, end: 0 }
-        }
-    } else {
-        Range {
-            start: range.start as u32,
-            end: range.end as u32,
         }
     }
 }
@@ -340,6 +369,7 @@ struct PopMany<'a> {
 impl<'a> PopMany<'a> {
     /// # Safety
     /// - if range yields elements `swap.drain` must be under shared access
+    /// - all items yielded by range must be valid indices into `swap.drain`
     #[inline]
     unsafe fn new(
         swap: SharedSwapDrain<'a>,
@@ -374,7 +404,7 @@ impl<'a> Iterator for PopMany<'a> {
         // SAFETY: ensured by construction with either [`PopMany::new`] or [`PopMany::empty`]
         let drain = unsafe { self.swap.drain.get().as_ref_unchecked() };
         let index = index as usize;
-        // SAFETY: all indices in ranges returned by head are unique and in-bounds
+        // SAFETY: ensured by construction with either [`PopMany::new`] or [`PopMany::empty`]
         Some(unsafe { drain.read(index) })
     }
 
@@ -399,6 +429,9 @@ impl<'a> Drop for PopMany<'a> {
     }
 }
 
+/// Determines which [`SharedSwapDrain`] to prioritize when popping elements. Additionally,
+/// stores the empty state of both drains to short-circuit popping elements.
+///
 /// # Layout
 /// - 0: a_non_empty
 /// - 1: b_non_empty
@@ -407,16 +440,19 @@ impl<'a> Drop for PopMany<'a> {
 struct Metadata(u32);
 
 impl Metadata {
+    /// Returns `which` [`SharedSwapDrain`] to prioritize when popping elements.
     #[inline]
-    fn priority(self) -> bool {
+    fn which_priority(self) -> bool {
         self.0 & 0b100 != 0
     }
 
+    /// Returns `true` if both [`SharedSwapDrain`]s are empty.
     #[inline]
     fn are_empty(self) -> bool {
         self.0 & 0b11 == 0b00
     }
 
+    /// Returns the number of non-empty elements in both [`SharedSwapDrain`]s.
     #[inline]
     fn non_empty_count(self) -> u32 {
         (self.0 & 0b11).count_ones()
@@ -431,35 +467,56 @@ impl Metadata {
 struct AtomicMetadata(AtomicU32);
 
 impl AtomicMetadata {
+    /// Loads the metadata value from the atomic variable.
     #[inline]
     fn load(&self) -> Metadata {
         Metadata(self.0.load(Ordering::Relaxed))
     }
 
+    /// Call this when a drain becomes empty.
+    ///
+    /// Swaps the priority bit (see how [`SharedFreeList::try_publish`] handles this)
+    /// and swaps the empty bit for the drain.
+    ///
+    /// It doesn't matter if these operations are reordered, as long as
+    /// they are performed atomically. That's because we simply toggle state
+    /// and n toggles in any order will eventually result in the correct state
+    /// once they are all performed.
+    ///
+    /// What does matter is that these "Event" operations are only called
+    /// once when the event happens.
     #[inline]
-    fn set_empty(&self, which: bool) {
+    fn on_drain_empty(&self, which: bool) {
         let bit_index = if which { 1 } else { 0 };
         let empty_mask = 1 << bit_index;
         let priority_mask = 0b100;
-        // We can do a checkless toggle because we that we only
-        // toggle these flags once on each event therefore even if
-        // we don't check the state, the state will be correct OR
-        // pending correct (correctness influences heuristics but not
-        // soundness so it's only loosely guarded)
         self.0
             .fetch_xor(empty_mask | priority_mask, Ordering::Relaxed);
     }
 
-    // We don't swap the priority in this case. The priority is only swapped
-    // on emptying.
+    /// Called when a drain is swapped.
+    ///
+    /// Swaps the empty bit for the drain being swapped to.
+    ///
+    /// It doesn't matter if these operations are reordered, as long as
+    /// they are performed atomically. That's because we simply toggle state
+    /// and n toggles in any order will eventually result in the correct state
+    /// once they are all performed.
+    ///
+    /// What does matter is that these "Event" operations are only called
+    /// once when the event happens.
     #[inline]
-    fn set_non_empty(&self, which: bool) {
+    fn on_drain_swapped(&self, which: bool) {
         let bit_index = if which { 1 } else { 0 };
         let empty_mask = 1 << bit_index;
         self.0.fetch_xor(empty_mask, Ordering::Relaxed);
     }
 }
 
+/// Stored as an SOA so that I can put the [`SharedDrain`]s and [`AtomicMetadata`]
+/// in the same cache line.
+///
+/// The other fields are hot RMW fields and so are padded to stop false sharing.
 #[derive(Default)]
 pub struct SharedFreeList {
     heads: [CachePadded<AtomicHead>; 2],
@@ -469,27 +526,34 @@ pub struct SharedFreeList {
 }
 
 impl SharedFreeList {
+    /// Returns a [`SharedSwapDrain`] for the given `which`.
     #[inline]
-    fn swaps(&self, priority: bool) -> [SharedSwapDrain<'_>; 2] {
-        let a = SharedSwapDrain {
-            drain: &self.drains[0],
-            head: &self.heads[0],
-            tail: &self.tails[0],
-        };
-        let b = SharedSwapDrain {
-            drain: &self.drains[1],
-            head: &self.heads[1],
-            tail: &self.tails[1],
-        };
-        if priority {
-            [b, a]
+    fn swap(&self, which: bool) -> SharedSwapDrain<'_> {
+        if which {
+            SharedSwapDrain {
+                drain: &self.drains[1],
+                head: &self.heads[1],
+                tail: &self.tails[1],
+            }
         } else {
-            [a, b]
+            SharedSwapDrain {
+                drain: &self.drains[0],
+                head: &self.heads[0],
+                tail: &self.tails[0],
+            }
         }
     }
 
+    /// Returns the [priority, other] array of [`SharedSwapDrain`]s for the given `priority`.
+    #[inline]
+    fn swaps(&self, which_priority: bool) -> [SharedSwapDrain<'_>; 2] {
+        [self.swap(which_priority), self.swap(!which_priority)]
+    }
+
+    /// Pops an entity from the free list as a producer, returning it.
+    ///
     /// # Safety
-    /// - Must
+    /// - must not be called concurrently with [`SharedFreeList::try_publish`]
     #[inline]
     unsafe fn pop_as_producer(&self) -> Option<Entity> {
         let meta = self.meta.load();
@@ -497,17 +561,19 @@ impl SharedFreeList {
             return None;
         }
 
-        let which = meta.priority();
-        let [priority, other] = self.swaps(which);
+        let which_priority = meta.which_priority();
+        let [priority, other] = self.swaps(which_priority);
 
-        // SAFETY: todo
+        // SAFETY: [`SharedSwapDrain::try_publish`] which calls [`SharedSwapDrain::try_publish`]
+        // is not being called right now.
         unsafe {
             priority
-                .pop_as_producer(|| self.meta.set_empty(which))
-                .or_else(|| other.pop_as_producer(|| self.meta.set_empty(!which)))
+                .pop_as_producer(|| self.meta.on_drain_empty(which_priority))
+                .or_else(|| other.pop_as_producer(|| self.meta.on_drain_empty(!which_priority)))
         }
     }
 
+    /// Pops an entity from the free list as a consumer, returning it.
     #[inline]
     fn pop_as_consumer(&self) -> Option<Entity> {
         let meta = self.meta.load();
@@ -515,83 +581,90 @@ impl SharedFreeList {
             return None;
         }
 
-        let which = meta.priority();
-        let [priority, other] = self.swaps(which);
+        let which_priority = meta.which_priority();
+        let [priority, other] = self.swaps(which_priority);
 
         priority
-            .pop_as_consumer(|| self.meta.set_empty(which))
-            .or_else(|| other.pop_as_consumer(|| self.meta.set_empty(!which)))
+            .pop_as_consumer(|| self.meta.on_drain_empty(which_priority))
+            .or_else(|| other.pop_as_consumer(|| self.meta.on_drain_empty(!which_priority)))
     }
 
-    /// # Safety
+    /// Pops `n` entities from the free list as a producer, returning them in a [`FlattenPopMany`].
     ///
+    /// # Safety
+    /// - must not be called concurrently with [`SharedFreeList::try_publish`]
     #[inline]
     unsafe fn pop_many_as_producer(&self, n: u32) -> FlattenPopMany<'_> {
-        let empty = FlattenPopMany::empty(self.swaps(false)[0]);
         if n == 0 {
-            return empty;
+            return FlattenPopMany::empty(self.swap(false));
         }
         let meta = self.meta.load();
         if meta.are_empty() {
-            return empty;
+            return FlattenPopMany::empty(self.swap(false));
         }
 
-        let which = meta.priority();
-        let [priority, other] = self.swaps(which);
+        let which_priority = meta.which_priority();
+        let [priority, other] = self.swaps(which_priority);
 
-        // SAFETY: todo
+        // SAFETY: [`SharedSwapDrain::try_publish`] which calls [`SharedSwapDrain::try_publish`]
+        // is not being called right now.
         unsafe {
-            let a = priority.pop_many_as_producer(n, || self.meta.set_empty(which));
+            let a = priority.pop_many_as_producer(n, || self.meta.on_drain_empty(which_priority));
             let remaining = n - a.len() as u32;
-            let b = other.pop_many_as_producer(remaining, || self.meta.set_empty(!which));
+            let b =
+                other.pop_many_as_producer(remaining, || self.meta.on_drain_empty(!which_priority));
             FlattenPopMany::new([a, b])
         }
     }
 
+    /// Pops `n` entities from the free list as a consumer, returning them in a [`FlattenPopMany`].
     #[inline]
     fn pop_many_as_consumer(&self, n: u32) -> FlattenPopMany<'_> {
-        let empty = FlattenPopMany::empty(self.swaps(false)[0]);
         if n == 0 {
-            return empty;
+            return FlattenPopMany::empty(self.swap(false));
         }
         let meta = self.meta.load();
         if meta.are_empty() {
-            return empty;
+            return FlattenPopMany::empty(self.swap(false));
         }
 
-        let which = meta.priority();
-        let [priority, other] = self.swaps(which);
+        let which_priority = meta.which_priority();
+        let [priority, other] = self.swaps(which_priority);
 
-        let a = priority.pop_many_as_consumer(n, || self.meta.set_empty(which));
+        let a = priority.pop_many_as_consumer(n, || self.meta.on_drain_empty(which_priority));
         let remaining = n - a.len() as u32;
-        let b = other.pop_many_as_consumer(remaining, || self.meta.set_empty(!which));
+        let b = other.pop_many_as_consumer(remaining, || self.meta.on_drain_empty(!which_priority));
         FlattenPopMany::new([a, b])
     }
 
+    /// Trys to pull all of `data` into the free list by trying to swap it with a [`SharedDrain`].
+    ///
     /// # Safety
+    /// - must not be called concurrently with any `*_as_producer` function
+    /// - must not be called concurrently with itself
     #[inline]
-    pub unsafe fn try_publish(&self, data: &mut Vec<Entity>) {
+    unsafe fn try_publish(&self, data: &mut Vec<Entity>) {
         if data.len() == 0 {
             return;
         }
         let meta = self.meta.load();
 
-        let which = meta.priority();
-        let publish_to = match meta.non_empty_count() {
-            // nowhere to publish
+        let wich_priority = meta.which_priority();
+        let which = match meta.non_empty_count() {
             2 => return,
-            // publish to the non-priority buffer which will be (or already has been) swapped to when the current
-            // buffer empties
-            1 => !which,
+            // publish to the non-priority buffer which will be (or already has been) swapped to when
+            // the current priority buffer empties
+            1 => !wich_priority,
             // publish to the priority buffer which has already been swapped to when the last buffer
             // was emptied
-            0 => which,
+            0 => wich_priority,
             _ => unreachable!(),
         };
 
-        let [swap, _] = self.swaps(publish_to);
+        let swap = self.swap(which);
+        // SAFETY: ensured by caller
         if unsafe { swap.try_publish(data) } {
-            self.meta.set_non_empty(publish_to);
+            self.meta.on_drain_swapped(which);
         }
     }
 }
@@ -600,13 +673,10 @@ impl Drop for SharedFreeList {
     #[inline]
     fn drop(&mut self) {
         for i in 0..2 {
-            // Since we have &mut self we know that `head.max(0) == actual_tail` (actual_tail as computed)
             let head = Head(*self.heads[i].0.get_mut());
             let undrained_len = head.head().max(0) as usize;
-
             let drain = self.drains[i].get_mut();
             // SAFETY: `num_undrained_items` is the number of elements in `drain` that are still valid.
-            //
             // Note: Since [`Entity`] is [`Copy`] we don't actually have to do this.
             unsafe {
                 drain.0.set_len(undrained_len);
@@ -642,6 +712,7 @@ impl<'a> FlattenPopMany<'a> {
 impl<'a> Iterator for FlattenPopMany<'a> {
     type Item = Entity;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         while self.index < 1 {
             if let Some(item) = self.pop_manys[self.index].next() {
@@ -652,6 +723,7 @@ impl<'a> Iterator for FlattenPopMany<'a> {
         None
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         let len = self.pop_manys[0].len() + self.pop_manys[1].len();
         (len, Some(len))
@@ -701,6 +773,7 @@ impl FreshAllocator {
     /// Allocates `count` [`EntityIndex`]s.
     /// These rows will be fresh.
     /// They have never been given out before.
+    #[inline]
     fn alloc_many(&self, count: u32) -> AllocUniqueEntityIndexIterator {
         if count == 0 {
             return AllocUniqueEntityIndexIterator(0..0);
@@ -758,9 +831,10 @@ impl SharedAllocator {
     /// Allocates a new [`Entity`], reusing a freed index if one exists.
     ///
     /// # Safety
-    /// - You must be the single producer to call this function.
+    /// - must not be called at the same time as [`SharedAllocator::try_publish`]
     #[inline]
     unsafe fn alloc_as_producer(&self) -> Entity {
+        // SAFETY: ensured by caller
         unsafe {
             self.free
                 .pop_as_producer()
@@ -768,12 +842,13 @@ impl SharedAllocator {
         }
     }
 
-    /// Allocates a `count` [`Entity`]s, reusing freed indices if they exist.
+    /// Allocates `count` [`Entity`]s, reusing freed indices if they exist.
     ///
     /// # Safety
-    /// - You must be the single producer to call this function.
+    /// - must not be called at the same time as [`SharedAllocator::try_publish`]
     #[inline]
     unsafe fn alloc_many_as_producer(&self, count: u32) -> AllocEntitiesIterator<'_> {
+        // SAFETY: ensured by caller
         let reused = unsafe { self.free.pop_many_as_producer(count) };
         let still_need = count - reused.len() as u32;
         let new = self.fresh.alloc_many(still_need);
@@ -795,6 +870,18 @@ impl SharedAllocator {
         let still_need = count - reused.len() as u32;
         let new = self.fresh.alloc_many(still_need);
         AllocEntitiesIterator { new, reused }
+    }
+
+    /// Attempts the publish the contents of `data` to the free list.
+    ///
+    /// # Safety
+    /// - must not be called at the same time as [`Self::alloc_as_producer`] or [`Self::alloc_many_as_producer`]
+    #[inline]
+    unsafe fn try_publish(&self, data: &mut Vec<Entity>) {
+        // SAFETY: ensured by caller
+        unsafe {
+            self.free.try_publish(data);
+        }
     }
 
     /// Marks the allocator as closed, but it will still function normally.
@@ -828,15 +915,22 @@ impl Allocator {
     /// Allocates a new [`Entity`], reusing a freed index if one exists.
     #[inline]
     pub(super) fn alloc(&self) -> Entity {
-        // SAFETY: we have &self, so we are the single producer. also no Clone
+        // SAFETY: we have &self therefore [`Allocator::flush`] cannot be called right now
         unsafe { self.shared.alloc_as_producer() }
     }
 
     /// Allocates `count` entities in an iterator.
     #[inline]
     pub(super) fn alloc_many(&self, count: u32) -> AllocEntitiesIterator<'_> {
-        // SAFETY: we have &self, so we are the single producer. also no Clone
+        // SAFETY: we have &self therefore [`Allocator::flush`] cannot be called right now
         unsafe { self.shared.alloc_many_as_producer(count) }
+    }
+
+    /// Synchronizes the local free list with the shared free list.
+    #[inline]
+    pub(crate) fn flush(&mut self) {
+        // SAFETY: we have &mut self therefore [`Allocator::alloc_many`] and [`Allocator::alloc`] and [`Allocator::try_publish`]cannot be called right now
+        unsafe { self.shared.try_publish(&mut self.local) };
     }
 
     /// The total number of indices given out.
@@ -849,14 +943,6 @@ impl Allocator {
     #[inline]
     fn num_free(&self) -> u32 {
         todo!()
-        // Safety: The `Allocator` is the single producer for `SharedFreeList`.
-        // unsafe { self.shared.free.len() }
-    }
-
-    /// Synchronizes the local free list with the shared free list.
-    pub(crate) fn flush(&mut self) {
-        // Safety: The `Allocator` is the single producer for `SharedFreeList`.
-        unsafe { self.shared.free.try_publish(&mut self.local) };
     }
 
     /// Frees the entity allowing it to be reused.

--- a/crates/bevy_ecs/src/entity/remote_allocator.rs
+++ b/crates/bevy_ecs/src/entity/remote_allocator.rs
@@ -30,710 +30,597 @@
 //! These types are summed up in [`SharedAllocator`], which is highly unsafe.
 //! The interfaces [`Allocator`] and [`RemoteAllocator`] provide safe interfaces to them.
 
-use arrayvec::ArrayVec;
+use super::{Entity, EntityIndex, EntitySetIterator};
 use bevy_platform::{
     cell::SyncUnsafeCell,
-    prelude::{Box, Vec},
+    prelude::Vec,
     sync::{
-        atomic::{AtomicBool, AtomicPtr, AtomicU32, AtomicU64, Ordering},
+        atomic::{AtomicBool, AtomicU32, Ordering},
         Arc,
     },
 };
-use core::mem::ManuallyDrop;
+use core::{
+    iter::FusedIterator,
+    mem::{self, ManuallyDrop},
+    num::NonZeroU32,
+    range::{Range, RangeIter},
+    sync::atomic::{AtomicI32, AtomicU64},
+};
+use crossbeam_utils::CachePadded;
 use log::warn;
 use nonmax::NonMaxU32;
 
-use crate::query::DebugCheckedUnwrap;
+#[derive(Default)]
+struct SharedDrain(ManuallyDrop<Vec<Entity>>);
 
-use super::{Entity, EntityIndex, EntitySetIterator};
-
-/// This is the item we store in the free list.
-/// Effectively, this is a `MaybeUninit<Entity>` where uninit is represented by `Entity::PLACEHOLDER`.
-struct Slot {
-    inner: SyncUnsafeCell<Entity>,
-}
-
-impl Slot {
-    /// Produces a meaningless empty value. This is a valid but incorrect `Entity`.
-    /// It's valid because the bits do represent a valid bit pattern of an `Entity`.
-    /// It's incorrect because this is in the free buffer even though the entity was never freed.
-    /// Importantly, [`FreeCount`] determines which part of the free buffer is the free list.
-    /// An empty slot may be in the free buffer, but should not be in the free list.
-    /// This can be thought of as the `MaybeUninit` uninit in `Vec`'s excess capacity.
-    const fn empty() -> Self {
-        let source = Entity::PLACEHOLDER;
-        Self {
-            inner: SyncUnsafeCell::new(source),
-        }
-    }
-
-    /// Sets the entity at this slot.
+impl SharedDrain {
+    /// Swaps the previous `Vec` as if it had been drained to `0` with the `other` `Vec`.
+    /// Swaps it with an empty `Vec` if this is the first time it's been called.
+    ///
+    /// This function makes sure the length of the vector is bound to `i32::MAX`.
     ///
     /// # Safety
-    ///
-    /// There must be a clear, strict order between this call and the previous uses of this [`Slot`].
-    /// Otherwise, the compiler will make unsound optimizations.
-    #[inline]
-    const unsafe fn set_entity(&self, entity: Entity) {
-        // SAFETY: Ensured by caller.
+    /// - The previous `Vec` must have a length of `0`
+    unsafe fn swap(&mut self, other: &mut Vec<Entity>) {
+        const MAX: usize = i32::MAX as usize;
+        if other.len() > MAX {
+            #[cold]
+            fn drain(to: &mut Vec<Entity>, from: &mut Vec<Entity>) {
+                to.extend(from.drain(MAX..));
+            }
+            drain(&mut *self.0, other);
+        }
+        mem::swap(&mut *self.0, other);
+        // SAFETY: The next time this function is called this length will be correct
         unsafe {
-            self.inner.get().write(entity);
+            self.0.set_len(0);
         }
     }
 
-    /// Gets the stored entity. The result will be [`Entity::PLACEHOLDER`] unless [`set_entity`](Self::set_entity) has been called.
+    /// Returns the value at `index` the `Vec`.
     ///
     /// # Safety
-    ///
-    /// There must be a clear, strict order between this call and the previous uses of this [`Slot`].
-    /// Otherwise, the compiler will make unsound optimizations.
-    #[inline]
-    const unsafe fn get_entity(&self) -> Entity {
-        // SAFETY: Ensured by caller.
-        unsafe { self.inner.get().read() }
+    /// - `index` must be in bounds.
+    /// - each `index` must be called with this function exactly once.
+    unsafe fn read(&self, index: usize) -> Entity {
+        unsafe { self.0.as_ptr().add(index).read() }
+    }
+
+    fn initial_len(&self) -> i32 {
+        // see [`SharedDrain::swap`]
+        self.0.len() as i32
     }
 }
 
-/// Each chunk stores a buffer of [`Slot`]s at a fixed capacity.
-struct Chunk {
-    /// Points to the first slot. If this is null, we need to allocate it.
-    first: AtomicPtr<Slot>,
+/// Reserves items to be drained from a [`SharedDrain`] using [`AtomicHead::claim_as_*`].
+///
+/// # Layout
+/// - 0..31 - `i32` head used to reserve indices
+/// - 32..63 - `i32` consumer only head
+///
+/// The lower 32 bits freely borrow and carry into the upper 32 bits. We only ever
+/// need to read the upper 32 bits when the lower 32 bits are negative (and also the
+/// lower 32 bits aren't allowed to wrap from negative <-> positive) therefore we can
+/// extract the actual value from the upper 32 bits by adding 1 when the lower 32 bits
+/// are negative.
+#[derive(Clone, Copy)]
+struct Head(u64);
+
+impl Default for Head {
+    fn default() -> Self {
+        Self::new(0)
+    }
 }
 
-impl Chunk {
-    /// Constructs a null [`Chunk`].
-    const fn new() -> Self {
-        Self {
-            first: AtomicPtr::new(core::ptr::null_mut()),
+impl Head {
+    fn new(v: i32) -> Self {
+        let v = v as u64;
+        Self(v | (v << 32))
+    }
+
+    fn consumer_head(self) -> i32 {
+        let mut consumer_head = ((self.0 as i64) >> 32) as i32;
+        // Note: This only works because `head` is not allowed to wrap
+        if self.head() < 0 {
+            consumer_head += 1;
         }
+        consumer_head
     }
 
-    /// Gets the entity at the index within this chunk.
-    ///
-    /// # Safety
-    ///
-    /// [`Self::set`] must have been called on this index before, ensuring it is in bounds and the chunk is initialized.
-    /// There must be a clear, strict order between this call and the previous uses of this `index`.
-    /// Otherwise, the compiler will make unsound optimizations.
-    #[inline]
-    unsafe fn get(&self, index: u32) -> Entity {
-        // Relaxed is fine since caller has already assured memory ordering is satisfied.
-        let head = self.first.load(Ordering::Relaxed);
-        // SAFETY: caller ensures we are in bounds and init (because `set` must be in bounds)
-        let target = unsafe { &*head.add(index as usize) };
-        // SAFETY: Caller ensures ordering.
-        unsafe { target.get_entity() }
+    fn head(self) -> i32 {
+        (self.0 & u32::MAX as u64) as i32
     }
 
-    /// Gets a slice of indices.
-    ///
-    /// # Safety
-    ///
-    /// [`Self::set`] must have been called on these indices before, ensuring it is in bounds and the chunk is initialized.
-    #[inline]
-    unsafe fn get_slice(&self, index: u32, ideal_len: u32, chunk_capacity: u32) -> &[Slot] {
-        let after_index_slice_len = chunk_capacity - index;
-        let len = after_index_slice_len.min(ideal_len) as usize;
+    /// We only actually need the value if the head is < 0
+    fn producer_pop_count(self) -> i32 {
+        self.head() - self.consumer_head()
+    }
+}
 
-        // Relaxed is fine since caller ensures we are initialized already.
-        // In order for the caller to guarantee that, they must have an ordering that orders this `get` after the required `set`.
-        let head = self.first.load(Ordering::Relaxed);
+/// [`Head`]
+#[derive(Default)]
+struct AtomicHead(AtomicU64);
 
-        // SAFETY: Caller ensures we are init, so the chunk was allocated via a `Vec` and the index is within the capacity.
-        unsafe { core::slice::from_raw_parts(head.add(index as usize), len) }
+impl AtomicHead {
+    fn publish(&self, head: Head) {
+        // release matches with [`AtomicHead::claim_as_consumer`]
+        self.0.store(head.0, Ordering::Release);
     }
 
-    /// Sets this entity at this index.
-    ///
+    fn claim_as_consumer(&self, n: u32) -> Head {
+        let n = n as u64;
+        let rhs = n | (n << 32);
+        // acquire matches with [`AtomicHead::publish`]
+        Head(self.0.fetch_sub(rhs, Ordering::Acquire))
+    }
+
     /// # Safety
-    ///
-    /// Index must be in bounds.
-    /// There must be a clear, strict order between this call and the previous uses of this `index`.
-    /// Otherwise, the compiler will make unsound optimizations.
-    /// This must not be called on the same chunk concurrently.
-    #[inline]
-    unsafe fn set(&self, index: u32, entity: Entity, chunk_capacity: u32) {
-        // Relaxed is fine here since the caller ensures memory ordering.
-        let ptr = self.first.load(Ordering::Relaxed);
-        let head = if ptr.is_null() {
-            // SAFETY: Ensured by caller.
-            unsafe { self.init(chunk_capacity) }
+    /// - must not be called syncronously with [`AtomicHead::publish`]
+    unsafe fn claim_as_producer(&self, n: u32) -> Head {
+        // relaxed ordering due to safety requirements
+        Head(self.0.fetch_sub(n as u64, Ordering::Relaxed))
+    }
+}
+
+/// The `Tail` tracks how many remaining slots still need to be drained
+/// in order for the producer to have exclusive access to the buffer.
+///
+/// Although this value is an `i32` it is always non-negative.
+///
+/// When the producer is performing their own reads they elide the decriment to
+/// tail. The actual tail must be reconstructed when publishing.
+#[derive(Default)]
+struct AtomicTail(AtomicI32);
+
+impl AtomicTail {
+    fn release_as_consumer(&self, n: u32) {
+        // release matches with [`Tail::acquire`]
+        self.0.fetch_sub(n as i32, Ordering::Release);
+    }
+
+    fn acquire(&self) -> i32 {
+        // acquire matches with [`Tail::release_as_consumer`]
+        self.0.load(Ordering::Acquire)
+    }
+}
+
+#[derive(Clone, Copy)]
+struct SharedSwapDrain<'a> {
+    drain: &'a SyncUnsafeCell<SharedDrain>,
+    head: &'a AtomicHead,
+    tail: &'a AtomicTail,
+}
+
+impl<'a> SharedSwapDrain<'a> {
+    /// # Safety
+    /// - must not be called syncronously with [`SharedSwapDrain::publish`]
+    unsafe fn pop_as_producer(self, on_empty: impl Fn()) -> Option<Entity> {
+        // SAFETY: [`SharedSwapDrain::publish`] which calls [`Head::publish`] is not being called
+        let head = unsafe { self.head.claim_as_producer(1) };
+        if head.head() < 1 {
+            let _ = head.head().strict_sub(1);
+            return None;
+        }
+
+        let index = (head.head() - 1) as usize;
+        if index == 0 {
+            on_empty()
+        }
+
+        // SAFETY: [`SharedSwapDrain::publish`], which mutates this value, is not being called
+        let drain = unsafe { self.drain.get().as_ref_unchecked() };
+        // SAFETY: all indices in ranges returned by head are unique and in-bounds
+        let value = unsafe { drain.read(index) };
+
+        Some(value)
+    }
+
+    fn pop_as_consumer(self, on_empty: impl Fn()) -> Option<Entity> {
+        let head = self.head.claim_as_consumer(1);
+        if head.head() < 1 {
+            let _ = head.head().strict_sub(1);
+            return None;
+        }
+
+        let index = (head.head() - 1) as usize;
+        if index == 0 {
+            on_empty()
+        }
+
+        // SAFETY: if `head` returns any positive value then consumers have immutable access to drain
+        let drain = unsafe { self.drain.get().as_ref_unchecked() };
+        // SAFETY: all indices in ranges returned by head are unique and in-bounds
+        let value = unsafe { drain.read(index) };
+
+        self.tail.release_as_consumer(1);
+
+        Some(value)
+    }
+
+    /// # Safety
+    /// - must not be called syncronously with [`SharedSwapDrain::publish`]
+    unsafe fn pop_many_as_producer(self, n: u32, on_empty: impl Fn()) -> PopMany<'a> {
+        if n == 0 {
+            return PopMany::empty(self);
+        }
+
+        // SAFETY: [`SharedSwapDrain::publish`] which calls [`Head::publish`] is not being called
+        let head = unsafe { self.head.claim_as_producer(n) };
+
+        let end = head.head();
+        let start = end.strict_sub_unsigned(n);
+        let range = clamp_to_positive(Range { start, end }, on_empty);
+
+        // SAFETY: negative ranges will yield zero elements and positive ranges mean that `drain` is under shared access
+        unsafe { PopMany::new(self, range.into_iter(), None) }
+    }
+
+    fn pop_many_as_consumer(self, n: u32, on_empty: impl Fn()) -> PopMany<'a> {
+        if n == 0 {
+            return PopMany::empty(self);
+        }
+
+        let head = self.head.claim_as_consumer(n);
+
+        let end = head.head();
+        let start = end.strict_sub_unsigned(n);
+        let range = clamp_to_positive(Range { start, end }, on_empty);
+
+        let popped_as_consumer = NonZeroU32::new(range.end - range.start);
+
+        // SAFETY: negative ranges will yield zero elements and positive ranges mean that `drain` is under shared access
+        unsafe { PopMany::new(self, range.into_iter(), popped_as_consumer) }
+    }
+
+    /// # Safety
+    /// - must not be called syncronously with any [`SharedSwapDrain::*_as_producer`]
+    unsafe fn try_publish(self, data: &mut Vec<Entity>) -> bool {
+        let tail = self.tail.acquire();
+        // producer_pop_count cannot change while we have exclusive access to the producer
+        let producer_pop_count = Head(self.head.0.load(Ordering::Relaxed)).producer_pop_count();
+        let actual_tail = tail - producer_pop_count;
+
+        if actual_tail <= 0 {
+            return false;
+        }
+
+        // SAFETY: Nobody is allowed to read from `drain` when `actual_tail <= 0`.
+        let drain = unsafe { self.drain.get().as_mut_unchecked() };
+        // SAFETY: We checked that `actual_tail < 0` meaning all items have been drained
+        unsafe {
+            drain.swap(data);
+        }
+
+        let initial_len = drain.initial_len() as i32;
+
+        // `tail` can be relaxed because `head` fences the publication
+        // `tail` must be stored before `head`
+        self.tail.0.store(initial_len, Ordering::Relaxed);
+        self.head.publish(Head::new(initial_len));
+
+        true
+    }
+}
+
+fn clamp_to_positive(range: Range<i32>, on_empty: impl Fn()) -> Range<u32> {
+    // `<=` makes sure we also call `on_empty` on ranges to `0` not just past `0`
+    if range.start <= 0 {
+        if range.end > 0 {
+            on_empty();
+            Range {
+                start: 0,
+                end: range.end as u32,
+            }
         } else {
-            ptr
+            Range { start: 0, end: 0 }
+        }
+    } else {
+        Range {
+            start: range.start as u32,
+            end: range.end as u32,
+        }
+    }
+}
+
+struct PopMany<'a> {
+    swap: SharedSwapDrain<'a>,
+    range: RangeIter<u32>,
+    popped_as_consumer: Option<NonZeroU32>,
+}
+
+impl<'a> PopMany<'a> {
+    /// # Safety
+    /// - if range yields elements `swap.drain` must be under shared access
+    unsafe fn new(
+        swap: SharedSwapDrain<'a>,
+        range: RangeIter<u32>,
+        popped_as_consumer: Option<NonZeroU32>,
+    ) -> Self {
+        Self {
+            swap,
+            range,
+            popped_as_consumer,
+        }
+    }
+
+    fn empty(swap: SharedSwapDrain<'a>) -> Self {
+        Self {
+            swap,
+            range: Range::default().into_iter(),
+            popped_as_consumer: None,
+        }
+    }
+}
+
+impl<'a> Iterator for PopMany<'a> {
+    type Item = Entity;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let Some(index) = self.range.next() else {
+            return None;
+        };
+        // SAFETY: ensured by construction with either [`PopMany::new`] or [`PopMany::empty`]
+        let drain = unsafe { self.swap.drain.get().as_ref_unchecked() };
+        let index = index as usize;
+        // SAFETY: all indices in ranges returned by head are unique and in-bounds
+        Some(unsafe { drain.read(index) })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.range.size_hint()
+    }
+}
+
+impl<'a> ExactSizeIterator for PopMany<'a> {}
+impl<'a> FusedIterator for PopMany<'a> {}
+
+impl<'a> Drop for PopMany<'a> {
+    fn drop(&mut self) {
+        // Note: Since [`Entity`] is [`Copy`] we don't actually have to do this.
+        self.by_ref().for_each(drop);
+
+        if let Some(popped) = self.popped_as_consumer {
+            self.swap.tail.release_as_consumer(popped.get());
+        }
+    }
+}
+
+/// # Layout
+/// - 0: a_empty
+/// - 1: b_empty
+/// - 2: priority (true -> b, false -> b) (see [`SharedFreeList::swaps`])
+#[derive(Clone, Copy)]
+struct Metadata(u32);
+
+impl Metadata {
+    fn priority(self) -> bool {
+        self.0 & 0b100 != 0
+    }
+
+    fn are_empty(self) -> bool {
+        self.0 & 0b11 == 0b11
+    }
+
+    fn non_empty_count(self) -> u32 {
+        (self.0 & 0b11).count_ones()
+    }
+}
+
+/// [`Metadata`]
+///
+/// All operations are [`Ordering::Relaxed`] because metadata only changes
+/// behavior and does not guard data.
+#[derive(Default)]
+struct AtomicMetadata(AtomicU32);
+
+impl AtomicMetadata {
+    fn load(&self) -> Metadata {
+        Metadata(self.0.load(Ordering::Relaxed))
+    }
+
+    fn set_empty(&self, which: bool) {
+        let bit_index = if which { 1 } else { 0 };
+        let empty_mask = 1 << bit_index;
+        let priority_mask = 0b100;
+        // We can do a checkless toggle because we that we only
+        // toggle these flags once on each event therefore even if
+        // we don't check the state, the state will be correct OR
+        // pending correct (correctness influences heuristics but not
+        // soundness so it's only loosely guarded)
+        self.0
+            .fetch_xor(empty_mask | priority_mask, Ordering::Relaxed);
+    }
+
+    // We don't swap the priority in this case. The priority is only swapped
+    // on emptying.
+    fn set_non_empty(&self, which: bool) {
+        let bit_index = if which { 1 } else { 0 };
+        let empty_mask = 1 << bit_index;
+        self.0.fetch_xor(empty_mask, Ordering::Relaxed);
+    }
+}
+
+#[derive(Default)]
+pub struct SharedFreeList {
+    heads: [CachePadded<AtomicHead>; 2],
+    tails: [CachePadded<AtomicTail>; 2],
+    drains: [SyncUnsafeCell<SharedDrain>; 2],
+    meta: AtomicMetadata,
+}
+
+impl SharedFreeList {
+    #[inline]
+    fn swaps(&self, priority: bool) -> [SharedSwapDrain<'_>; 2] {
+        let a = SharedSwapDrain {
+            drain: &self.drains[0],
+            head: &self.heads[0],
+            tail: &self.tails[0],
+        };
+        let b = SharedSwapDrain {
+            drain: &self.drains[1],
+            head: &self.heads[1],
+            tail: &self.tails[1],
+        };
+        if priority {
+            [b, a]
+        } else {
+            [a, b]
+        }
+    }
+
+    /// # Safety
+    /// - Must
+    unsafe fn pop_as_producer(&self) -> Option<Entity> {
+        let meta = self.meta.load();
+        if meta.are_empty() {
+            return None;
+        }
+
+        let which = meta.priority();
+        let [priority, other] = self.swaps(which);
+
+        // SAFETY: todo
+        unsafe {
+            priority
+                .pop_as_producer(|| self.meta.set_empty(which))
+                .or_else(|| other.pop_as_producer(|| self.meta.set_empty(!which)))
+        }
+    }
+
+    fn pop_as_consumer(&self) -> Option<Entity> {
+        let meta = self.meta.load();
+        if meta.are_empty() {
+            return None;
+        }
+
+        let which = meta.priority();
+        let [priority, other] = self.swaps(which);
+
+        priority
+            .pop_as_consumer(|| self.meta.set_empty(which))
+            .or_else(|| other.pop_as_consumer(|| self.meta.set_empty(!which)))
+    }
+
+    /// # Safety
+    ///
+    unsafe fn pop_many_as_producer(&self, n: u32) -> ChainPopMany<'_> {
+        let empty = ChainPopMany::empty(self.swaps(false)[0]);
+        if n == 0 {
+            return empty;
+        }
+        let meta = self.meta.load();
+        if meta.are_empty() {
+            return empty;
+        }
+
+        let which = meta.priority();
+        let [priority, other] = self.swaps(which);
+
+        // SAFETY: todo
+        unsafe {
+            let a = priority.pop_many_as_producer(n, || self.meta.set_empty(which));
+            let remaining = n - a.len() as u32;
+            let b = other.pop_many_as_producer(remaining, || self.meta.set_empty(!which));
+            ChainPopMany { a, b }
+        }
+    }
+
+    fn pop_many_as_consumer(&self, n: u32) -> ChainPopMany<'_> {
+        let empty = ChainPopMany::empty(self.swaps(false)[0]);
+        if n == 0 {
+            return empty;
+        }
+        let meta = self.meta.load();
+        if meta.are_empty() {
+            return empty;
+        }
+
+        let which = meta.priority();
+        let [priority, other] = self.swaps(which);
+
+        let a = priority.pop_many_as_consumer(n, || self.meta.set_empty(which));
+        let remaining = n - a.len() as u32;
+        let b = other.pop_many_as_consumer(remaining, || self.meta.set_empty(!which));
+        ChainPopMany { a, b }
+    }
+
+    /// # Safety
+    pub unsafe fn try_publish(&self, data: &mut Vec<Entity>) {
+        if data.len() == 0 {
+            return;
+        }
+        let meta = self.meta.load();
+
+        let which = meta.priority();
+        let publish_to = match meta.non_empty_count() {
+            // nowhere to publish
+            2 => return,
+            // publish to the non-priority buffer which will be (or already has been) swapped to when the current
+            // buffer empties
+            1 => !which,
+            // publish to the priority buffer which has already been swapped to when the last buffer
+            // was emptied
+            0 => which,
+            _ => unreachable!(),
         };
 
-        // SAFETY: caller ensures it is in bounds and we are not fighting with other `set` calls or `get` calls.
-        // A race condition is therefore impossible.
-        // The address can't wrap or pass isize max since this addition is within an allocation.
-        // For that to happen, you would first run out of memory in practice.
-        let target = unsafe { &*head.add(index as usize) };
-
-        // SAFETY: Ensured by caller.
-        unsafe {
-            target.set_entity(entity);
+        let [swap, _] = self.swaps(publish_to);
+        if unsafe { swap.try_publish(data) } {
+            self.meta.set_non_empty(publish_to);
         }
     }
+}
 
-    /// Initializes the chunk to be valid, returning the pointer.
-    ///
-    /// # Safety
-    ///
-    /// This must not be called concurrently with itself.
-    #[cold]
-    unsafe fn init(&self, chunk_capacity: u32) -> *mut Slot {
-        let mut buff = ManuallyDrop::new(Vec::new());
-        buff.reserve_exact(chunk_capacity as usize);
-        buff.resize_with(chunk_capacity as usize, Slot::empty);
-        let ptr = buff.as_mut_ptr();
-        // Relaxed is fine here since this is not called concurrently.
-        self.first.store(ptr, Ordering::Relaxed);
-        ptr
-    }
+impl Drop for SharedFreeList {
+    fn drop(&mut self) {
+        for i in 0..2 {
+            // Since we have &mut self we know that `head.max(0) == actual_tail` (actual_tail as computed)
+            let head = Head(*self.heads[i].0.get_mut());
+            let undrained_len = head.head().max(0) as usize;
 
-    /// Frees memory
-    ///
-    /// # Safety
-    ///
-    /// `chunk_capacity` must be the same as it was initialized with.
-    unsafe fn dealloc(&mut self, chunk_capacity: u32) {
-        let to_drop = *self.first.get_mut();
-        if !to_drop.is_null() {
-            // SAFETY: This was created in [`Self::init`] from a standard Vec.
+            let drain = self.drains[i].get_mut();
+            // SAFETY: `num_undrained_items` is the number of elements in `drain` that are still valid.
+            //
+            // Note: Since [`Entity`] is [`Copy`] we don't actually have to do this.
             unsafe {
-                Vec::from_raw_parts(to_drop, chunk_capacity as usize, chunk_capacity as usize);
+                drain.0.set_len(undrained_len);
+                ManuallyDrop::drop(&mut drain.0);
             }
         }
     }
 }
 
-/// This is a buffer that has been split into power-of-two sized chunks, so that each chunk is pinned in memory.
-/// Conceptually, each chunk is put end-to-end to form the buffer. This ultimately avoids copying elements on resize,
-/// while allowing it to expand in capacity as needed. A separate system must track the length of the list in the buffer.
-/// Each chunk is twice as large as the last, except for the first two which have a capacity of 512.
-struct FreeBuffer([Chunk; Self::NUM_CHUNKS as usize]);
+pub struct ChainPopMany<'a> {
+    a: PopMany<'a>,
+    b: PopMany<'a>,
+}
 
-impl FreeBuffer {
-    const NUM_CHUNKS: u32 = 24;
-    const NUM_SKIPPED: u32 = u32::BITS - Self::NUM_CHUNKS;
-
-    /// Constructs an empty [`FreeBuffer`].
-    const fn new() -> Self {
-        Self([const { Chunk::new() }; Self::NUM_CHUNKS as usize])
-    }
-
-    /// Computes the capacity of the chunk at this index within [`Self::NUM_CHUNKS`].
-    /// The first 2 have length 512 (2^9) and the last has length (2^31)
-    #[inline]
-    const fn capacity_of_chunk(chunk_index: u32) -> u32 {
-        // We do this because we're skipping the first `NUM_SKIPPED` powers, so we need to make up for them by doubling the first index.
-        // This is why the first 2 indices both have a capacity of 512.
-        let corrected = if chunk_index == 0 { 1 } else { chunk_index };
-        // We add NUM_SKIPPED because the total capacity should be as if [`Self::NUM_CHUNKS`] were 32.
-        // This skips the first NUM_SKIPPED powers.
-        let corrected = corrected + Self::NUM_SKIPPED;
-        // This bit shift is just 2^corrected.
-        1 << corrected
-    }
-
-    /// For this index in the whole buffer, returns the index of the [`Chunk`], the index within that chunk, and the capacity of that chunk.
-    #[inline]
-    const fn index_info(full_index: u32) -> (u32, u32, u32) {
-        // We do a `saturating_sub` because we skip the first `NUM_SKIPPED` powers to make space for the first chunk's entity count.
-        // The -1 is because this is the number of chunks, but we want the index in the end.
-        // We store chunks in smallest to biggest order, so we need to reverse it.
-        let chunk_index = (Self::NUM_CHUNKS - 1).saturating_sub(full_index.leading_zeros());
-        let chunk_capacity = Self::capacity_of_chunk(chunk_index);
-        // We only need to cut off this particular bit.
-        // The capacity is only one bit, and if other bits needed to be dropped, `leading` would have been greater
-        let index_in_chunk = full_index & !chunk_capacity;
-
-        (chunk_index, index_in_chunk, chunk_capacity)
-    }
-
-    /// For this index in the whole buffer, returns the [`Chunk`], the index within that chunk, and the capacity of that chunk.
-    #[inline]
-    fn index_in_chunk(&self, full_index: u32) -> (&Chunk, u32, u32) {
-        let (chunk_index, index_in_chunk, chunk_capacity) = Self::index_info(full_index);
-        // SAFETY: The `index_info` is correct.
-        let chunk = unsafe { self.0.get_unchecked(chunk_index as usize) };
-        (chunk, index_in_chunk, chunk_capacity)
-    }
-
-    /// Gets the entity at an index.
-    ///
-    /// # Safety
-    ///
-    /// [`set`](Self::set) must have been called on this index to initialize its memory.
-    /// There must be a clear, strict order between this call and the previous uses of this `full_index`.
-    /// Otherwise, the compiler will make unsound optimizations.
-    unsafe fn get(&self, full_index: u32) -> Entity {
-        let (chunk, index, _) = self.index_in_chunk(full_index);
-        // SAFETY: Ensured by caller.
-        unsafe { chunk.get(index) }
-    }
-
-    /// Sets an entity at an index.
-    ///
-    /// # Safety
-    ///
-    /// There must be a clear, strict order between this call and the previous uses of this `full_index`.
-    /// Otherwise, the compiler will make unsound optimizations.
-    /// This must not be called on the same buffer concurrently.
-    #[inline]
-    unsafe fn set(&self, full_index: u32, entity: Entity) {
-        let (chunk, index, chunk_capacity) = self.index_in_chunk(full_index);
-        // SAFETY: Ensured by caller and that the index is correct.
-        unsafe { chunk.set(index, entity, chunk_capacity) }
-    }
-
-    /// Iterates the entities in these indices.
-    ///
-    /// # Safety
-    ///
-    /// [`Self::set`] must have been called on these indices before to initialize memory.
-    /// There must be a clear, strict order between this call and the previous uses of these `indices`.
-    /// Note that until the returned value is dropped, these `indices` are still being accessed,
-    /// making safety for other operations afterward need careful justification.
-    /// Otherwise, the compiler will make unsound optimizations.
-    #[inline]
-    unsafe fn iter(&self, indices: core::ops::Range<u32>) -> FreeBufferIterator<'_> {
-        FreeBufferIterator {
-            buffer: self,
-            future_buffer_indices: indices,
-            current_chunk_slice: [].iter(),
+impl<'a> ChainPopMany<'a> {
+    fn empty(swap: SharedSwapDrain<'a>) -> Self {
+        Self {
+            a: PopMany::empty(swap),
+            b: PopMany::empty(swap),
         }
     }
 }
 
-impl Drop for FreeBuffer {
-    fn drop(&mut self) {
-        for index in 0..Self::NUM_CHUNKS {
-            let capacity = Self::capacity_of_chunk(index);
-            // SAFETY: we have `&mut` and the capacity is correct.
-            unsafe { self.0[index as usize].dealloc(capacity) };
-        }
-    }
-}
-
-/// An iterator over a [`FreeBuffer`].
-///
-/// # Safety
-///
-/// [`FreeBuffer::set`] must have been called on these indices beforehand to initialize memory.
-struct FreeBufferIterator<'a> {
-    buffer: &'a FreeBuffer,
-    /// The part of the buffer we are iterating at the moment.
-    current_chunk_slice: core::slice::Iter<'a, Slot>,
-    /// The indices in the buffer that are not yet in `current_chunk_slice`.
-    future_buffer_indices: core::ops::Range<u32>,
-}
-
-impl<'a> Iterator for FreeBufferIterator<'a> {
+impl<'a> Iterator for ChainPopMany<'a> {
     type Item = Entity;
 
-    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        if let Some(found) = self.current_chunk_slice.next() {
-            // SAFETY: We have `&mut self`, so that memory order is certain.
-            // The caller of `FreeBuffer::iter` ensures the memory order of this value's lifetime.
-            return Some(unsafe { found.get_entity() });
-        }
-
-        let still_need = self.future_buffer_indices.len() as u32;
-        if still_need == 0 {
-            return None;
-        }
-        let next_index = self.future_buffer_indices.start;
-        let (chunk, index, chunk_capacity) = self.buffer.index_in_chunk(next_index);
-
-        // SAFETY: Assured by `FreeBuffer::iter`
-        let slice = unsafe { chunk.get_slice(index, still_need, chunk_capacity) };
-        self.future_buffer_indices.start += slice.len() as u32;
-        self.current_chunk_slice = slice.iter();
-
-        // SAFETY: Constructor ensures these indices are valid in the buffer; the buffer is not sparse, and we just got the next slice.
-        // So the only way for the slice to be empty is if the constructor did not uphold safety.
-        let next = unsafe { self.current_chunk_slice.next().debug_checked_unwrap() };
-        // SAFETY: We have `&mut self`, so that memory order is certain.
-        // The caller of `FreeBuffer::iter` ensures the memory order of this value's lifetime.
-        Some(unsafe { next.get_entity() })
+        self.a.next().or_else(|| self.b.next())
     }
 
-    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = self.future_buffer_indices.len() + self.current_chunk_slice.len();
+        let len = self.a.len() + self.b.len();
         (len, Some(len))
     }
 }
 
-impl<'a> ExactSizeIterator for FreeBufferIterator<'a> {}
-impl<'a> core::iter::FusedIterator for FreeBufferIterator<'a> {}
+impl<'a> ExactSizeIterator for ChainPopMany<'a> {}
+impl<'a> FusedIterator for ChainPopMany<'a> {}
 
-/// This tracks the state of a [`FreeCount`], which has lots of information packed into it.
-///
-/// This has three jobs:
-///
-///  - First, obviously, this needs to track the length of the free list.
-///    When the length is 0, we use the [`FreshAllocator`]; otherwise, we pop.
-///    The length also tells us where on the list to push freed entities to.
-///  - Second, we need to be able to "freeze" the length for remote allocations.
-///    This happens when pushing to the list; we need to prevent a push and remote pop from happening at the same time.
-///    We call this "disabling the length".
-///    When it is disabled, only the thing that disabled it is allowed to re-enable it.
-///    This is like a mutex, but it's faster because we pack the mutex into the same bits as the state.
-///    See [`FreeCount::disable_len_for_state`] and [`FreeCount::set_state_risky`] for how this can be done.
-///  - Third, we need to track the generation of the free list.
-///    That is, any two distinct states of the free list, even if they are the same length, must have different [`FreeCount`] values.
-///    This becomes important when a remote allocator needs to know if the information it is working with has been outdated.
-///    See [`FreeList::remote_alloc`] for why this is so important.
-///
-/// As if that isn't hard enough, we need to do all three of these things in the same [`AtomicU64`] for performance.
-/// Not only that, but for memory ordering guarantees, we need to be able to change the length and generation in a single atomic operation.
-/// We do that with a very specific bit layout:
-///
-/// - The least significant 33 bits store a signed 33 bit integer for the length.
-///   This behaves like a u33, but we define `1 << 32` as 0.
-/// - The 34th bit stores a flag that indicates if the length has been disabled.
-/// - The remaining 30 bits are the generation.
-///   The generation helps differentiates different versions of the state that happen to encode the same length.
-///
-/// Why this layout?
-/// A few observations:
-/// First, since the disabling mechanic acts as a mutex, we only need one bit for that, and we can use bit operations to interact with it.
-/// That leaves the length and the generation (which we need to distinguish between two states of the free list that happen to be the same length).
-/// Every change to the length must be/cause a change to the [`FreeCountState`] such that the new state does not equal any previous state.
-/// The second observation is that we only need to change the generation when we move the length in one direction.
-/// Here, we tie popping/allocation to a generation change.
-/// When the length increases, the length part of the state changes, so a generation change is a moot point. (Ex `L0-G0` -> `L1G0`)
-/// When the length decreases, we also need to change the generation to distinguish the states. (Ex `L1-G0` -> `L0G1`)
-///
-/// We need the generation to freely wrap.
-/// In this case, the generation is 30 bits, so after 2 ^ 30 allocations, the generation will wrap.
-/// That is technically a soundness concern,
-/// but it would only cause a problem if the same [`FreeList::remote_alloc`] procedure had been sleeping for all 2 ^ 30 allocations and then when it woke up, all 2 ^ 30 allocations had been freed.
-/// This is impossibly unlikely and is safely ignored in other concurrent queue implementations.
-/// Still, we need the generation to wrap; it must not overflow into the length bits.
-/// As a result, the generation bits *must* be the most significant; this allows them to wrap freely.
-///
-/// It is convenient to put the disabling bit next since that leaves the length bits already aligned to the least significant bits.
-/// That saves us a bit shift!
-///
-/// But now we need to stop the length information from messing with the generation or disabling bits.
-/// Preventing overflow is easy since we can assume the list is unique and there are only `u32::MAX` [`Entity`] values.
-/// We can't prevent underflow with just 32 bits, and performance prevents us from running checks before a subtraction.
-/// But we do know that it can't overflow more than `u32::MAX` times because that would cause the [`FreshAllocator`] to overflow and panic for allocating too many entities.
-/// That means we need to represent "length" values in `±u32::MAX` range, which gives us an `i33` that we then saturatingly cast to `u32`.
-/// As mentioned above, we represent this `i33` as a `u33` where we define `1 << 32` as 0.
-/// This representation works slightly easier for the `saturating_sub` in [`FreeCountState::length`] than a true `i33` representation.
-#[derive(Clone, Copy)]
-struct FreeCountState(u64);
-
-impl FreeCountState {
-    /// When this bit is on, the count is disabled.
-    /// This is used to prevent remote allocations from running at the same time as a free operation.
-    const DISABLING_BIT: u64 = 1 << 33;
-    /// This is the mask for the length bits.
-    const LENGTH_MASK: u64 = (1 << 32) | u32::MAX as u64;
-    /// This is the value of the length mask we consider to be 0.
-    const LENGTH_0: u64 = 1 << 32;
-    /// This is the lowest bit in the u30 generation.
-    const GENERATION_LEAST_BIT: u64 = 1 << 34;
-
-    /// Constructs a length of 0.
-    const fn new_zero_len() -> Self {
-        Self(Self::LENGTH_0)
-    }
-
-    /// Gets the encoded length.
-    #[inline]
-    const fn length(self) -> u32 {
-        let unsigned_length = self.0 & Self::LENGTH_MASK;
-        unsigned_length.saturating_sub(Self::LENGTH_0) as u32
-    }
-
-    /// Returns whether or not the count is disabled.
-    #[inline]
-    const fn is_disabled(self) -> bool {
-        (self.0 & Self::DISABLING_BIT) > 0
-    }
-
-    /// Changes only the length of this count to `length`.
-    #[inline]
-    const fn with_length(self, length: u32) -> Self {
-        // Just turns on the "considered zero" bit since this is non-negative.
-        let length = length as u64 | Self::LENGTH_0;
-        Self(self.0 & !Self::LENGTH_MASK | length)
-    }
-
-    /// For popping `num` off the count, subtract the resulting u64.
-    #[inline]
-    const fn encode_pop(num: u32) -> u64 {
-        let subtract_length = num as u64;
-        // Also subtract one from the generation bit.
-        subtract_length | Self::GENERATION_LEAST_BIT
-    }
-
-    /// Returns the count after popping off `num` elements.
-    #[inline]
-    const fn pop(self, num: u32) -> Self {
-        Self(self.0.wrapping_sub(Self::encode_pop(num)))
-    }
-}
-
-/// This is an atomic interface to [`FreeCountState`].
-struct FreeCount(AtomicU64);
-
-impl FreeCount {
-    /// Constructs a length of 0.
-    const fn new_zero_len() -> Self {
-        Self(AtomicU64::new(FreeCountState::new_zero_len().0))
-    }
-
-    /// Gets the current state of the buffer.
-    #[inline]
-    fn state(&self, order: Ordering) -> FreeCountState {
-        FreeCountState(self.0.load(order))
-    }
-
-    /// Subtracts `num` from the length, returning the previous state.
-    ///
-    /// **NOTE:** Caller should be careful that changing the state is allowed and that the state is not disabled.
-    #[inline]
-    fn pop_for_state(&self, num: u32, order: Ordering) -> FreeCountState {
-        let to_sub = FreeCountState::encode_pop(num);
-        let raw = self.0.fetch_sub(to_sub, order);
-        FreeCountState(raw)
-    }
-
-    /// Marks the state as disabled, returning the previous state
-    /// When the length is disabled, [`try_set_state`](Self::try_set_state) will fail.
-    /// This is used to prevent remote allocation during a free.
-    #[inline]
-    fn disable_len_for_state(&self, order: Ordering) -> FreeCountState {
-        // We don't care about the generation here since this changes the value anyway.
-        FreeCountState(self.0.fetch_or(FreeCountState::DISABLING_BIT, order))
-    }
-
-    /// Sets the state explicitly.
-    /// Caller must be careful that the state has not changed since getting the state and setting it.
-    /// If that happens, the state may not properly reflect the length of the free list or its generation,
-    /// causing entities to be skipped or given out twice.
-    /// This is not a safety concern, but it is a major correctness concern.
-    #[inline]
-    fn set_state_risky(&self, state: FreeCountState, order: Ordering) {
-        self.0.store(state.0, order);
-    }
-
-    /// Attempts to update the state, returning the new [`FreeCountState`] if it fails.
-    #[inline]
-    fn try_set_state(
-        &self,
-        expected_current_state: FreeCountState,
-        target_state: FreeCountState,
-        success: Ordering,
-        failure: Ordering,
-    ) -> Result<(), FreeCountState> {
-        match self
-            .0
-            .compare_exchange(expected_current_state.0, target_state.0, success, failure)
-        {
-            Ok(_) => Ok(()),
-            Err(val) => Err(FreeCountState(val)),
-        }
-    }
-}
-
-/// This is conceptually like a `Vec<Entity>` that stores entities pending reuse.
-struct FreeList {
-    /// The actual buffer of [`Slot`]s.
-    /// Conceptually, this is like the `RawVec` for this `Vec`.
-    buffer: FreeBuffer,
-    /// The length of the free buffer
-    len: FreeCount,
-}
-
-impl FreeList {
-    /// Constructs a empty [`FreeList`].
-    fn new() -> Self {
-        Self {
-            buffer: FreeBuffer::new(),
-            len: FreeCount::new_zero_len(),
-        }
-    }
-
-    /// Gets the number of free entities.
-    ///
-    /// # Risk
-    ///
-    /// For this to be accurate, this must not be called during a [`Self::free`].
-    #[inline]
-    fn num_free(&self) -> u32 {
-        // Relaxed ordering is fine since this doesn't act on the length value in memory.
-        self.len.state(Ordering::Relaxed).length()
-    }
-
-    /// Frees the `entities` allowing them to be reused.
-    ///
-    /// # Safety
-    ///
-    /// There must be a clear, strict order between this call and calls to [`Self::free`], [`Self::alloc_many`], and [`Self::alloc`].
-    /// Otherwise, the compiler will make unsound optimizations.
-    #[inline]
-    unsafe fn free(&self, entities: &[Entity]) {
-        // Disable remote allocation.
-        // We don't need to acquire the most recent memory from remote threads because we never read it.
-        // We do not need to release to remote threads because we only changed the disabled bit,
-        // which the remote allocator would with relaxed ordering.
-        let state = self.len.disable_len_for_state(Ordering::Relaxed);
-
-        // Append onto the buffer
-        let mut len = state.length();
-        // `for_each` is typically faster than `for` here.
-        entities.iter().for_each(|&entity| {
-            // SAFETY: Caller ensures this does not conflict with `free` or `alloc` calls,
-            // and we just disabled remote allocation with a strict memory ordering.
-            // We only call `set` during a free, and the caller ensures that is not called concurrently.
-            unsafe {
-                self.buffer.set(len, entity);
-            }
-            len += 1;
-        });
-
-        // Update length
-        let new_state = state.with_length(len);
-        // This is safe because `alloc` is not being called and `remote_alloc` checks that it is not disabled.
-        // We don't need to change the generation since this will change the length, which changes the value anyway.
-        // If, from a `remote_alloc` perspective, this does not change the length (i.e. this changes it *back* to what it was),
-        // then `alloc` must have been called, which changes the generation.
-        self.len.set_state_risky(new_state, Ordering::Release);
-    }
-
-    /// Allocates an [`Entity`] from the free list if one is available.
-    ///
-    /// # Safety
-    ///
-    /// There must be a clear, strict order between this call and calls to [`Self::free`].
-    /// Otherwise, the compiler will make unsound optimizations.
-    #[inline]
-    unsafe fn alloc(&self) -> Option<Entity> {
-        // SAFETY: This will get a valid index because caller ensures there is no way for `free` to be done at the same time.
-        // Relaxed is ok here since `free` is the only time memory is changed, and relaxed still gets the most recent state.
-        // The memory ordering to ensure we read the most recent value at the index is ensured by the caller.
-        let len = self.len.pop_for_state(1, Ordering::Relaxed).length();
-        let index = len.checked_sub(1)?;
-
-        // SAFETY: This was less then `len`, so it must have been `set` via `free` before.
-        // There is a strict memory ordering of this use of the index because the length is only decreasing.
-        // That means there is only one use of this index since the last call to `free`.
-        // The only time the length increases is during `free`, which the caller ensures has a "happened before" relationship with this call.
-        Some(unsafe { self.buffer.get(index) })
-    }
-
-    /// Allocates as many [`Entity`]s from the free list as are available, up to `count`.
-    ///
-    /// # Safety
-    ///
-    /// There must be a clear, strict order between this call and calls to [`Self::free`].
-    /// Otherwise, the compiler will make unsound optimizations.
-    ///
-    /// Note that this allocation call doesn't end until the returned value is dropped.
-    /// So, calling [`Self::free`] while the returned value is live is unsound.
-    #[inline]
-    unsafe fn alloc_many(&self, count: u32) -> FreeBufferIterator<'_> {
-        // SAFETY: This will get a valid index because there is no way for `free` to be done at the same time.
-        // Relaxed is ok here since `free` is the only time memory is changed, and relaxed still gets the most recent state.
-        // The memory ordering to ensure we read the most recent value at the index is ensured by the caller.
-        let len = self.len.pop_for_state(count, Ordering::Relaxed).length();
-        let index = len.saturating_sub(count);
-
-        // SAFETY: The iterator's items are all less than the length, so they are in bounds and have been previously set.
-        // There is a strict memory ordering of this use of the indices because the length is only decreasing.
-        // That means there is only one use of these indices since the last call to `free`.
-        // The only time it the length increases is during `free`, which the caller ensures has a "happened before" relationship with this call.
-        unsafe { self.buffer.iter(index..len) }
-    }
-
-    /// Allocates an [`Entity`] from the free list if one is available and it is safe to do so.
-    #[inline]
-    fn remote_alloc(&self) -> Option<Entity> {
-        // The goal is the same as `alloc`, so what's the difference?
-        // `alloc` knows `free` is not being called, but this does not.
-        // What if we `len.fetch_sub(1)` but then `free` overwrites the entity before we could read it?
-        // That would mean we would leak an entity and give another entity out twice.
-        // We get around this by only updating `len` after the read is complete.
-        // But that means something else could be trying to allocate the same index!
-        // So we need a `len.compare_exchange` loop to ensure the index is unique.
-        // Because we keep a generation value in the `FreeCount`, if any of these things happen, we simply try again.
-        // We also need to prevent this from conflicting with a `free` call, so we check to ensure the state is not disabled.
-
-        // We keep track of the attempts so we can yield the thread on std after a few fails.
-        #[cfg(feature = "std")]
-        let mut attempts = 1u32;
-        // We need an acquire ordering to acquire the most recent memory of `free` calls.
-        let mut state = self.len.state(Ordering::Acquire);
-        loop {
-            // The state is only disabled when freeing.
-            // If a free is happening, we need to wait for the new entity to be ready on the free buffer.
-            // That means we will also need to re-fetch the state and acquire the new memory.
-            // Then, we can allocate it.
-            if state.is_disabled() {
-                // Spin 64 times before yielding.
-                #[cfg(feature = "std")]
-                {
-                    attempts += 1;
-                    if attempts.is_multiple_of(64) {
-                        // scheduler probably isn't running the thread doing the `free` call, so yield so it can finish.
-                        std::thread::yield_now();
-                    } else {
-                        core::hint::spin_loop();
-                    }
-                }
-
-                #[cfg(not(feature = "std"))]
-                core::hint::spin_loop();
-
-                // Retry with the fresh state and acquired memory order.
-                state = self.len.state(Ordering::Acquire);
-                continue;
-            }
-
-            // At this point, we know a `free` was not happening when we started.
-
-            let len = state.length();
-            let index = len.checked_sub(1)?;
-
-            // SAFETY:
-            //
-            // If no `free` call has started, this safety follows the same logic as in non-remote `alloc`.
-            // That is, the len always counts down, so this is the only use of this index since the last `free`,
-            // and another `free` hasn't happened.
-            //
-            // But if a `free` did start at this point, it would be operating on indices greater than `index`.
-            // We haven't updated the `FreeCount` yet, so the `free` call would be adding to it, while we've been subtracting from it.
-            // That means this is still the only time this index is used since the last `free`!
-            // So, even though we can't guarantee when the concurrent `free` is happening in memory order, it doesn't matter since that `free` doesn't use this index.
-            // We can still establish a clear, strict ordering for this slot because 1) any concurrent `free` doesn't use this index and 2) we have an `Acquire` relationship with the `free` before it.
-            //
-            // So yeah, we could be reading from outdated memory (the free buffer), but the part that we are reading, hasn't changed, so that's ok.
-            // That satisfies safety but not correctness.
-            // We still need to double check that a free didn't happen, and retry if it did.
-            // Otherwise, this entity might be given out twice.
-            let entity = unsafe { self.buffer.get(index) };
-
-            let ideal_state = state.pop(1);
-            // If we fail, we need to acquire the new state.
-            // If we succeed, we are finished, and we haven't changed any memory, so we can used relaxed ordering.
-            match self
-                .len
-                .try_set_state(state, ideal_state, Ordering::Relaxed, Ordering::Acquire)
-            {
-                Ok(_) => return Some(entity),
-                Err(new_state) => state = new_state,
-            }
-        }
-    }
-}
-
+#[derive(Default)]
 struct FreshAllocator {
     /// The next value of [`Entity::index`] to give out if needed.
     next_entity_index: AtomicU32,
@@ -774,6 +661,9 @@ impl FreshAllocator {
     /// These rows will be fresh.
     /// They have never been given out before.
     fn alloc_many(&self, count: u32) -> AllocUniqueEntityIndexIterator {
+        if count == 0 {
+            return AllocUniqueEntityIndexIterator(0..0);
+        }
         let start_new = self.next_entity_index.fetch_add(count, Ordering::Relaxed);
         let new = match start_new
             .checked_add(count)
@@ -811,61 +701,59 @@ impl Iterator for AllocUniqueEntityIndexIterator {
 }
 
 impl ExactSizeIterator for AllocUniqueEntityIndexIterator {}
-impl core::iter::FusedIterator for AllocUniqueEntityIndexIterator {}
+impl FusedIterator for AllocUniqueEntityIndexIterator {}
 
 /// This stores allocation data shared by all entity allocators.
+#[derive(Default)]
 struct SharedAllocator {
     /// The entities pending reuse
-    free: FreeList,
+    free: SharedFreeList,
     fresh: FreshAllocator,
     /// Tracks whether or not the primary [`Allocator`] has been closed or not.
     is_closed: AtomicBool,
 }
 
 impl SharedAllocator {
-    /// Constructs a [`SharedAllocator`]
-    fn new() -> Self {
-        Self {
-            free: FreeList::new(),
-            fresh: FreshAllocator {
-                next_entity_index: AtomicU32::new(0),
-            },
-            is_closed: AtomicBool::new(false),
-        }
-    }
-
     /// Allocates a new [`Entity`], reusing a freed index if one exists.
     ///
     /// # Safety
-    ///
-    /// This must not conflict with [`FreeList::free`] calls.
+    /// - You must be the single producer to call this function.
     #[inline]
-    unsafe fn alloc(&self) -> Entity {
-        // SAFETY: assured by caller
-        unsafe { self.free.alloc() }.unwrap_or_else(|| self.fresh.alloc())
+    unsafe fn alloc_as_producer(&self) -> Entity {
+        unsafe {
+            self.free
+                .pop_as_producer()
+                .unwrap_or_else(|| self.fresh.alloc())
+        }
     }
 
     /// Allocates a `count` [`Entity`]s, reusing freed indices if they exist.
     ///
     /// # Safety
-    ///
-    /// This must not conflict with [`FreeList::free`] calls for the duration of the iterator.
+    /// - You must be the single producer to call this function.
     #[inline]
-    unsafe fn alloc_many(&self, count: u32) -> AllocEntitiesIterator<'_> {
-        // SAFETY: Ensured by caller.
-        let reused = unsafe { self.free.alloc_many(count) };
+    unsafe fn alloc_many_as_producer(&self, count: u32) -> SharedAllocEntitiesIter<'_> {
+        let reused = unsafe { self.free.pop_many_as_producer(count) };
         let still_need = count - reused.len() as u32;
         let new = self.fresh.alloc_many(still_need);
-        AllocEntitiesIterator { new, reused }
+        SharedAllocEntitiesIter { new, reused }
     }
 
-    /// Allocates a new [`Entity`].
-    /// This will only try to reuse a freed index if it is safe to do so.
+    /// Allocates a new [`Entity`], reusing a freed index if one exists.
     #[inline]
-    fn remote_alloc(&self) -> Entity {
+    fn alloc_as_consumer(&self) -> Entity {
         self.free
-            .remote_alloc()
+            .pop_as_consumer()
             .unwrap_or_else(|| self.fresh.alloc())
+    }
+
+    /// Allocates a `count` [`Entity`]s, reusing freed indices if they exist.
+    #[inline]
+    fn alloc_many_as_consumer(&self, count: u32) -> SharedAllocEntitiesIter<'_> {
+        let reused = unsafe { self.free.pop_many_as_producer(count) };
+        let still_need = count - reused.len() as u32;
+        let new = self.fresh.alloc_many(still_need);
+        SharedAllocEntitiesIter { new, reused }
     }
 
     /// Marks the allocator as closed, but it will still function normally.
@@ -885,34 +773,29 @@ impl SharedAllocator {
 /// The allocator assumes that it is the only one with [`FreeList::free`] permissions.
 /// If this were cloned, that assumption would be broken, leading to undefined behavior.
 /// This is in contrast to the [`RemoteAllocator`], which may be cloned freely.
+#[derive(Default)]
 pub(crate) struct Allocator {
     /// The shared allocator state, which we share with any [`RemoteAllocator`]s.
     shared: Arc<SharedAllocator>,
-    /// The local free list.
-    /// We use this to amortize the cost of freeing to the shared allocator since that is expensive.
-    local_free: Box<ArrayVec<Entity, 128>>,
-}
-
-impl Default for Allocator {
-    fn default() -> Self {
-        Self::new()
-    }
+    /// The local free list. All local operations go through this.
+    /// In order to share items with [`RemoteAllocator`]s, we swap this with
+    /// other `Vec`s.
+    local: Vec<Entity>,
 }
 
 impl Allocator {
-    /// Constructs a new [`Allocator`]
-    pub(super) fn new() -> Self {
-        Self {
-            shared: Arc::new(SharedAllocator::new()),
-            local_free: Box::new(ArrayVec::new()),
-        }
-    }
-
     /// Allocates a new [`Entity`], reusing a freed index if one exists.
     #[inline]
     pub(super) fn alloc(&self) -> Entity {
-        // SAFETY: violating safety requires a `&mut self` to exist, but rust does not allow that.
-        unsafe { self.shared.alloc() }
+        // SAFETY: we have &self, so we are the single producer. also no Clone
+        unsafe { self.shared.alloc_as_producer() }
+    }
+
+    /// Allocates `count` entities in an iterator.
+    #[inline]
+    pub(super) fn alloc_many(&self, count: u32) -> SharedAllocEntitiesIter<'_> {
+        // SAFETY: we have &self, so we are the single producer. also no Clone
+        unsafe { self.shared.alloc_many_as_producer(count) }
     }
 
     /// The total number of indices given out.
@@ -924,50 +807,27 @@ impl Allocator {
     /// The number of free entities.
     #[inline]
     fn num_free(&self) -> u32 {
-        // RISK: `free` requires mutable access.
-        self.shared.free.num_free()
+        todo!()
+        // Safety: The `Allocator` is the single producer for `SharedFreeList`.
+        // unsafe { self.shared.free.len() }
     }
 
-    /// Flushes the entities that have been freed locally into the full allocator.
-    /// This is not exposed publicly because it is subject to change.
-    /// It is sometimes useful to call this for tests that depend on the entity allocator behaving more predictably.
-    #[inline]
-    pub(crate) fn flush_freed(&mut self) {
-        // SAFETY: We have `&mut self`.
-        unsafe {
-            self.shared.free.free(self.local_free.as_slice());
-        }
-        self.local_free.clear();
+    /// Synchronizes the local free list with the shared free list.
+    pub(crate) fn flush(&mut self) {
+        // Safety: The `Allocator` is the single producer for `SharedFreeList`.
+        unsafe { self.shared.free.try_publish(&mut self.local) };
     }
 
     /// Frees the entity allowing it to be reused.
     #[inline]
     pub(super) fn free(&mut self, entity: Entity) {
-        if self.local_free.is_full() {
-            self.flush_freed();
-        }
-        // SAFETY: The `ArrayVec` is not full or has just been cleared.
-        unsafe {
-            self.local_free.push_unchecked(entity);
-        }
-    }
-
-    /// Allocates `count` entities in an iterator.
-    #[inline]
-    pub(super) fn alloc_many(&self, count: u32) -> AllocEntitiesIterator<'_> {
-        // SAFETY: `free` takes `&mut self`, and this lifetime is captured by the iterator.
-        unsafe { self.shared.alloc_many(count) }
+        self.local.push(entity);
     }
 
     /// Frees the entities allowing them to be reused.
     #[inline]
     pub(super) fn free_many(&mut self, entities: &[Entity]) {
-        if self.local_free.try_extend_from_slice(entities).is_err() {
-            // SAFETY: We have `&mut self`.
-            unsafe {
-                self.shared.free.free(entities);
-            }
-        }
+        self.local.extend_from_slice(entities)
     }
 }
 
@@ -989,12 +849,12 @@ impl core::fmt::Debug for Allocator {
 /// An [`Iterator`] returning a sequence of [`Entity`] values from an [`Allocator`].
 ///
 /// **NOTE:** Dropping will leak the remaining entities!
-pub(super) struct AllocEntitiesIterator<'a> {
+pub(crate) struct SharedAllocEntitiesIter<'a> {
+    reused: ChainPopMany<'a>,
     new: AllocUniqueEntityIndexIterator,
-    reused: FreeBufferIterator<'a>,
 }
 
-impl<'a> Iterator for AllocEntitiesIterator<'a> {
+impl<'a> Iterator for SharedAllocEntitiesIter<'a> {
     type Item = Entity;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -1007,13 +867,13 @@ impl<'a> Iterator for AllocEntitiesIterator<'a> {
     }
 }
 
-impl<'a> ExactSizeIterator for AllocEntitiesIterator<'a> {}
-impl<'a> core::iter::FusedIterator for AllocEntitiesIterator<'a> {}
+impl<'a> ExactSizeIterator for SharedAllocEntitiesIter<'a> {}
+impl<'a> FusedIterator for SharedAllocEntitiesIter<'a> {}
 
 // SAFETY: Newly reserved entity values are unique.
-unsafe impl EntitySetIterator for AllocEntitiesIterator<'_> {}
+unsafe impl EntitySetIterator for SharedAllocEntitiesIter<'_> {}
 
-impl Drop for AllocEntitiesIterator<'_> {
+impl Drop for SharedAllocEntitiesIter<'_> {
     fn drop(&mut self) {
         let leaking = self.len();
         if leaking > 0 {
@@ -1058,7 +918,19 @@ impl RemoteAllocator {
     /// Before using the returned values in the world, first check that it is ok with [`EntityAllocator::has_remote_allocator`](super::EntityAllocator::has_remote_allocator).
     #[inline]
     pub fn alloc(&self) -> Entity {
-        self.shared.remote_alloc()
+        self.shared.alloc_as_consumer()
+    }
+
+    /// Allocates a batch of entities remotely.
+    ///
+    /// This comes with a major downside:
+    /// Because this does not hold reference to the world, the world may be cleared or destroyed before you get a chance to use the result.
+    /// If that happens, these entities will be garbage!
+    /// They will not be unique in the world anymore and you should not spawn them!
+    /// Before using the returned values in the world, first check that it is ok with [`EntityAllocator::has_remote_allocator`](super::EntityAllocator::has_remote_allocator).
+    #[inline]
+    pub(crate) fn alloc_many(&self, count: u32) -> SharedAllocEntitiesIter<'_> {
+        self.shared.alloc_many_as_consumer(count)
     }
 
     /// Returns whether or not this [`RemoteAllocator`] is still connected to its source [`EntityAllocator`](super::EntityAllocator).
@@ -1077,63 +949,11 @@ impl RemoteAllocator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloc::vec;
-
-    /// Ensure the total capacity of [`OwnedBuffer`] is `u32::MAX + 1`.
-    #[test]
-    fn chunk_capacity_sums() {
-        let total: u64 = (0..FreeBuffer::NUM_CHUNKS)
-            .map(FreeBuffer::capacity_of_chunk)
-            .map(|x| x as u64)
-            .sum();
-        // The last 2 won't be used, but that's ok.
-        // Keeping them powers of 2 makes things faster.
-        let expected = u32::MAX as u64 + 1;
-        assert_eq!(total, expected);
-    }
-
-    /// Ensure [`OwnedBuffer`] can be properly indexed
-    #[test]
-    fn chunk_indexing() {
-        let to_test = vec![
-            (0, (0, 0, 512)), // index 0 cap = 512
-            (1, (0, 1, 512)),
-            (256, (0, 256, 512)),
-            (511, (0, 511, 512)),
-            (512, (1, 0, 512)), // index 1 cap = 512
-            (1023, (1, 511, 512)),
-            (1024, (2, 0, 1024)), // index 2 cap = 1024
-            (1025, (2, 1, 1024)),
-            (2047, (2, 1023, 1024)),
-            (2048, (3, 0, 2048)), // index 3 cap = 2048
-            (4095, (3, 2047, 2048)),
-            (4096, (4, 0, 4096)), // index 3 cap = 4096
-        ];
-
-        for (input, output) in to_test {
-            assert_eq!(FreeBuffer::index_info(input), output);
-        }
-    }
-
-    #[test]
-    fn buffer_len_encoding() {
-        let len = FreeCount::new_zero_len();
-        assert_eq!(len.state(Ordering::Relaxed).length(), 0);
-        assert_eq!(len.pop_for_state(200, Ordering::Relaxed).length(), 0);
-        len.set_state_risky(
-            FreeCountState::new_zero_len().with_length(5),
-            Ordering::Relaxed,
-        );
-        assert_eq!(len.pop_for_state(2, Ordering::Relaxed).length(), 5);
-        assert_eq!(len.pop_for_state(2, Ordering::Relaxed).length(), 3);
-        assert_eq!(len.pop_for_state(2, Ordering::Relaxed).length(), 1);
-        assert_eq!(len.pop_for_state(2, Ordering::Relaxed).length(), 0);
-    }
 
     #[test]
     fn uniqueness() {
         let mut entities = Vec::with_capacity(2000);
-        let mut allocator = Allocator::new();
+        let mut allocator = Allocator::default();
         entities.extend(allocator.alloc_many(1000));
 
         let pre_len = entities.len();
@@ -1159,7 +979,7 @@ mod tests {
     /// This test just exists to make sure allocations don't step on each other's toes.
     #[test]
     fn allocation_order_correctness() {
-        let mut allocator = Allocator::new();
+        let mut allocator = Allocator::default();
         let e0 = allocator.alloc();
         let e1 = allocator.alloc();
         let e2 = allocator.alloc();
@@ -1168,7 +988,7 @@ mod tests {
         allocator.free(e1);
         allocator.free(e2);
         allocator.free(e3);
-        allocator.flush_freed();
+        allocator.flush();
 
         let r0 = allocator.alloc();
         let mut many = allocator.alloc_many(2);

--- a/crates/bevy_ecs/src/entity/remote_allocator.rs
+++ b/crates/bevy_ecs/src/entity/remote_allocator.rs
@@ -194,7 +194,7 @@ impl AtomicHead {
 /// don't decrement it past zero.
 ///
 /// When the producer is performing their own reads they elide the decriment to
-/// tail. The actual tail must be reconstructed by adding this value and the [`Head::producer_pop_count`].
+/// tail. The actual tail must be reconstructed by subtracting the [`Head::producer_pop_count`].
 #[derive(Default)]
 struct AtomicTail(AtomicI32);
 

--- a/crates/bevy_ecs/src/entity/remote_allocator.rs
+++ b/crates/bevy_ecs/src/entity/remote_allocator.rs
@@ -785,7 +785,7 @@ impl SharedAllocator {
     /// Allocates a `count` [`Entity`]s, reusing freed indices if they exist.
     #[inline]
     fn alloc_many_as_consumer(&self, count: u32) -> AllocEntitiesIterator<'_> {
-        let reused = unsafe { self.free.pop_many_as_producer(count) };
+        let reused = self.free.pop_many_as_consumer(count);
         let still_need = count - reused.len() as u32;
         let new = self.fresh.alloc_many(still_need);
         AllocEntitiesIterator { new, reused }
@@ -884,7 +884,7 @@ impl core::fmt::Debug for Allocator {
 /// An [`Iterator`] returning a sequence of [`Entity`] values from an [`Allocator`].
 ///
 /// **NOTE:** Dropping will leak the remaining entities!
-pub(crate) struct AllocEntitiesIterator<'a> {
+pub struct AllocEntitiesIterator<'a> {
     reused: ChainPopMany<'a>,
     new: AllocUniqueEntityIndexIterator,
 }
@@ -964,7 +964,7 @@ impl RemoteAllocator {
     /// They will not be unique in the world anymore and you should not spawn them!
     /// Before using the returned values in the world, first check that it is ok with [`EntityAllocator::has_remote_allocator`](super::EntityAllocator::has_remote_allocator).
     #[inline]
-    pub(crate) fn alloc_many(&self, count: u32) -> AllocEntitiesIterator<'_> {
+    pub fn alloc_many(&self, count: u32) -> AllocEntitiesIterator<'_> {
         self.shared.alloc_many_as_consumer(count)
     }
 

--- a/crates/bevy_ecs/src/entity/remote_allocator.rs
+++ b/crates/bevy_ecs/src/entity/remote_allocator.rs
@@ -61,6 +61,7 @@ impl SharedDrain {
     ///
     /// # Safety
     /// - The previous `Vec` must have a length of `0`
+    #[inline]
     unsafe fn swap(&mut self, other: &mut Vec<Entity>) {
         const MAX: usize = i32::MAX as usize;
         if other.len() > MAX {
@@ -82,10 +83,12 @@ impl SharedDrain {
     /// # Safety
     /// - `index` must be in bounds.
     /// - each `index` must be called with this function exactly once.
+    #[inline]
     unsafe fn read(&self, index: usize) -> Entity {
         unsafe { self.0.as_ptr().add(index).read() }
     }
 
+    #[inline]
     fn initial_len(&self) -> i32 {
         // see [`SharedDrain::swap`]
         self.0.len() as i32
@@ -113,11 +116,13 @@ impl Default for Head {
 }
 
 impl Head {
+    #[inline]
     fn new(v: i32) -> Self {
         let v = v as u64;
         Self(v | (v << 32))
     }
 
+    #[inline]
     fn consumer_head(self) -> i32 {
         let mut consumer_head = ((self.0 as i64) >> 32) as i32;
         // Note: This only works because `head` is not allowed to wrap
@@ -127,11 +132,12 @@ impl Head {
         consumer_head
     }
 
+    #[inline]
     fn head(self) -> i32 {
         (self.0 & u32::MAX as u64) as i32
     }
 
-    /// We only actually need the value if the head is < 0
+    #[inline]
     fn producer_pop_count(self) -> i32 {
         self.head() - self.consumer_head()
     }
@@ -142,11 +148,13 @@ impl Head {
 struct AtomicHead(AtomicU64);
 
 impl AtomicHead {
+    #[inline]
     fn publish(&self, head: Head) {
         // release matches with [`AtomicHead::claim_as_consumer`]
         self.0.store(head.0, Ordering::Release);
     }
 
+    #[inline]
     fn claim_as_consumer(&self, n: u32) -> Head {
         let n = n as u64;
         let rhs = n | (n << 32);
@@ -156,6 +164,7 @@ impl AtomicHead {
 
     /// # Safety
     /// - must not be called syncronously with [`AtomicHead::publish`]
+    #[inline]
     unsafe fn claim_as_producer(&self, n: u32) -> Head {
         // relaxed ordering due to safety requirements
         Head(self.0.fetch_sub(n as u64, Ordering::Relaxed))
@@ -173,11 +182,13 @@ impl AtomicHead {
 struct AtomicTail(AtomicI32);
 
 impl AtomicTail {
+    #[inline]
     fn release_as_consumer(&self, n: u32) {
         // release matches with [`Tail::acquire`]
         self.0.fetch_sub(n as i32, Ordering::Release);
     }
 
+    #[inline]
     fn acquire(&self) -> i32 {
         // acquire matches with [`Tail::release_as_consumer`]
         self.0.load(Ordering::Acquire)
@@ -194,6 +205,7 @@ struct SharedSwapDrain<'a> {
 impl<'a> SharedSwapDrain<'a> {
     /// # Safety
     /// - must not be called syncronously with [`SharedSwapDrain::publish`]
+    #[inline]
     unsafe fn pop_as_producer(self, on_empty: impl Fn()) -> Option<Entity> {
         // SAFETY: [`SharedSwapDrain::publish`] which calls [`Head::publish`] is not being called
         let head = unsafe { self.head.claim_as_producer(1) };
@@ -215,6 +227,7 @@ impl<'a> SharedSwapDrain<'a> {
         Some(value)
     }
 
+    #[inline]
     fn pop_as_consumer(self, on_empty: impl Fn()) -> Option<Entity> {
         let head = self.head.claim_as_consumer(1);
         if head.head() < 1 {
@@ -239,6 +252,7 @@ impl<'a> SharedSwapDrain<'a> {
 
     /// # Safety
     /// - must not be called syncronously with [`SharedSwapDrain::publish`]
+    #[inline]
     unsafe fn pop_many_as_producer(self, n: u32, on_empty: impl Fn()) -> PopMany<'a> {
         if n == 0 {
             return PopMany::empty(self);
@@ -255,6 +269,7 @@ impl<'a> SharedSwapDrain<'a> {
         unsafe { PopMany::new(self, range.into_iter(), None) }
     }
 
+    #[inline]
     fn pop_many_as_consumer(self, n: u32, on_empty: impl Fn()) -> PopMany<'a> {
         if n == 0 {
             return PopMany::empty(self);
@@ -274,6 +289,7 @@ impl<'a> SharedSwapDrain<'a> {
 
     /// # Safety
     /// - must not be called syncronously with any [`SharedSwapDrain::*_as_producer`]
+    #[inline]
     unsafe fn try_publish(self, data: &mut Vec<Entity>) -> bool {
         let tail = self.tail.acquire();
         // producer_pop_count cannot change while we have exclusive access to the producer
@@ -302,6 +318,7 @@ impl<'a> SharedSwapDrain<'a> {
     }
 }
 
+#[inline]
 fn clamp_to_positive(range: Range<i32>, on_empty: impl Fn()) -> Range<u32> {
     // `<=` makes sure we also call `on_empty` on ranges to `0` not just past `0`
     if range.start <= 0 {
@@ -331,6 +348,7 @@ struct PopMany<'a> {
 impl<'a> PopMany<'a> {
     /// # Safety
     /// - if range yields elements `swap.drain` must be under shared access
+    #[inline]
     unsafe fn new(
         swap: SharedSwapDrain<'a>,
         range: RangeIter<u32>,
@@ -343,6 +361,7 @@ impl<'a> PopMany<'a> {
         }
     }
 
+    #[inline]
     fn empty(swap: SharedSwapDrain<'a>) -> Self {
         Self {
             swap,
@@ -355,6 +374,7 @@ impl<'a> PopMany<'a> {
 impl<'a> Iterator for PopMany<'a> {
     type Item = Entity;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         let Some(index) = self.range.next() else {
             return None;
@@ -366,6 +386,7 @@ impl<'a> Iterator for PopMany<'a> {
         Some(unsafe { drain.read(index) })
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.range.size_hint()
     }
@@ -375,6 +396,7 @@ impl<'a> ExactSizeIterator for PopMany<'a> {}
 impl<'a> FusedIterator for PopMany<'a> {}
 
 impl<'a> Drop for PopMany<'a> {
+    #[inline]
     fn drop(&mut self) {
         // Note: Since [`Entity`] is [`Copy`] we don't actually have to do this.
         self.by_ref().for_each(drop);
@@ -393,14 +415,17 @@ impl<'a> Drop for PopMany<'a> {
 struct Metadata(u32);
 
 impl Metadata {
+    #[inline]
     fn priority(self) -> bool {
         self.0 & 0b100 != 0
     }
 
+    #[inline]
     fn are_empty(self) -> bool {
         self.0 & 0b11 == 0b11
     }
 
+    #[inline]
     fn non_empty_count(self) -> u32 {
         (self.0 | !0b11).count_zeros()
     }
@@ -414,10 +439,12 @@ impl Metadata {
 struct AtomicMetadata(AtomicU32);
 
 impl AtomicMetadata {
+    #[inline]
     fn load(&self) -> Metadata {
         Metadata(self.0.load(Ordering::Relaxed))
     }
 
+    #[inline]
     fn set_empty(&self, which: bool) {
         let bit_index = if which { 1 } else { 0 };
         let empty_mask = 1 << bit_index;
@@ -433,6 +460,7 @@ impl AtomicMetadata {
 
     // We don't swap the priority in this case. The priority is only swapped
     // on emptying.
+    #[inline]
     fn set_non_empty(&self, which: bool) {
         let bit_index = if which { 1 } else { 0 };
         let empty_mask = 1 << bit_index;
@@ -470,6 +498,7 @@ impl SharedFreeList {
 
     /// # Safety
     /// - Must
+    #[inline]
     unsafe fn pop_as_producer(&self) -> Option<Entity> {
         let meta = self.meta.load();
         if meta.are_empty() {
@@ -487,6 +516,7 @@ impl SharedFreeList {
         }
     }
 
+    #[inline]
     fn pop_as_consumer(&self) -> Option<Entity> {
         let meta = self.meta.load();
         if meta.are_empty() {
@@ -503,6 +533,7 @@ impl SharedFreeList {
 
     /// # Safety
     ///
+    #[inline]
     unsafe fn pop_many_as_producer(&self, n: u32) -> ChainPopMany<'_> {
         let empty = ChainPopMany::empty(self.swaps(false)[0]);
         if n == 0 {
@@ -525,6 +556,7 @@ impl SharedFreeList {
         }
     }
 
+    #[inline]
     fn pop_many_as_consumer(&self, n: u32) -> ChainPopMany<'_> {
         let empty = ChainPopMany::empty(self.swaps(false)[0]);
         if n == 0 {
@@ -545,6 +577,7 @@ impl SharedFreeList {
     }
 
     /// # Safety
+    #[inline]
     pub unsafe fn try_publish(&self, data: &mut Vec<Entity>) {
         if data.len() == 0 {
             return;
@@ -572,6 +605,7 @@ impl SharedFreeList {
 }
 
 impl Drop for SharedFreeList {
+    #[inline]
     fn drop(&mut self) {
         for i in 0..2 {
             // Since we have &mut self we know that `head.max(0) == actual_tail` (actual_tail as computed)
@@ -596,6 +630,7 @@ pub struct ChainPopMany<'a> {
 }
 
 impl<'a> ChainPopMany<'a> {
+    #[inline]
     fn empty(swap: SharedSwapDrain<'a>) -> Self {
         Self {
             a: PopMany::empty(swap),

--- a/crates/bevy_ecs/src/entity/remote_allocator.rs
+++ b/crates/bevy_ecs/src/entity/remote_allocator.rs
@@ -427,7 +427,7 @@ impl Metadata {
 
     #[inline]
     fn non_empty_count(self) -> u32 {
-        (self.0 | 0b11).count_ones()
+        (self.0 & 0b11).count_ones()
     }
 }
 
@@ -702,7 +702,7 @@ impl FreshAllocator {
         let start_new = self.next_entity_index.fetch_add(count, Ordering::Relaxed);
         let new = match start_new
             .checked_add(count)
-            .filter(|new| *new < Self::MAX_ENTITIES)
+            .filter(|new| *new <= Self::MAX_ENTITIES)
         {
             Some(new_next_entity_index) => start_new..new_next_entity_index,
             None => Self::on_overflow(),

--- a/crates/bevy_ecs/src/entity/remote_allocator.rs
+++ b/crates/bevy_ecs/src/entity/remote_allocator.rs
@@ -714,7 +714,7 @@ impl<'a> Iterator for FlattenPopMany<'a> {
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        while self.index < 1 {
+        while self.index < 2 {
             if let Some(item) = self.pop_manys[self.index].next() {
                 return Some(item);
             }

--- a/crates/bevy_ecs/src/entity/remote_allocator.rs
+++ b/crates/bevy_ecs/src/entity/remote_allocator.rs
@@ -402,7 +402,7 @@ impl Metadata {
     }
 
     fn non_empty_count(self) -> u32 {
-        (self.0 & 0b11).count_ones()
+        (self.0 & 0b11).count_zeros()
     }
 }
 

--- a/crates/bevy_ecs/src/entity/remote_allocator.rs
+++ b/crates/bevy_ecs/src/entity/remote_allocator.rs
@@ -526,8 +526,8 @@ impl SharedFreeList {
     /// # Safety
     ///
     #[inline]
-    unsafe fn pop_many_as_producer(&self, n: u32) -> ChainPopMany<'_> {
-        let empty = ChainPopMany::empty(self.swaps(false)[0]);
+    unsafe fn pop_many_as_producer(&self, n: u32) -> FlattenPopMany<'_> {
+        let empty = FlattenPopMany::empty(self.swaps(false)[0]);
         if n == 0 {
             return empty;
         }
@@ -544,13 +544,13 @@ impl SharedFreeList {
             let a = priority.pop_many_as_producer(n, || self.meta.set_empty(which));
             let remaining = n - a.len() as u32;
             let b = other.pop_many_as_producer(remaining, || self.meta.set_empty(!which));
-            ChainPopMany { a, b }
+            FlattenPopMany::new([a, b])
         }
     }
 
     #[inline]
-    fn pop_many_as_consumer(&self, n: u32) -> ChainPopMany<'_> {
-        let empty = ChainPopMany::empty(self.swaps(false)[0]);
+    fn pop_many_as_consumer(&self, n: u32) -> FlattenPopMany<'_> {
+        let empty = FlattenPopMany::empty(self.swaps(false)[0]);
         if n == 0 {
             return empty;
         }
@@ -565,7 +565,7 @@ impl SharedFreeList {
         let a = priority.pop_many_as_consumer(n, || self.meta.set_empty(which));
         let remaining = n - a.len() as u32;
         let b = other.pop_many_as_consumer(remaining, || self.meta.set_empty(!which));
-        ChainPopMany { a, b }
+        FlattenPopMany::new([a, b])
     }
 
     /// # Safety
@@ -616,36 +616,50 @@ impl Drop for SharedFreeList {
     }
 }
 
-pub struct ChainPopMany<'a> {
-    a: PopMany<'a>,
-    b: PopMany<'a>,
+pub struct FlattenPopMany<'a> {
+    pop_manys: [PopMany<'a>; 2],
+    index: usize,
 }
 
-impl<'a> ChainPopMany<'a> {
+impl<'a> FlattenPopMany<'a> {
+    #[inline]
+    fn new(pop_manys: [PopMany<'a>; 2]) -> Self {
+        Self {
+            pop_manys,
+            index: 0,
+        }
+    }
+
     #[inline]
     fn empty(swap: SharedSwapDrain<'a>) -> Self {
         Self {
-            a: PopMany::empty(swap),
-            b: PopMany::empty(swap),
+            pop_manys: [PopMany::empty(swap), PopMany::empty(swap)],
+            index: 2,
         }
     }
 }
 
-impl<'a> Iterator for ChainPopMany<'a> {
+impl<'a> Iterator for FlattenPopMany<'a> {
     type Item = Entity;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.a.next().or_else(|| self.b.next())
+        while self.index < 1 {
+            if let Some(item) = self.pop_manys[self.index].next() {
+                return Some(item);
+            }
+            self.index += 1;
+        }
+        None
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = self.a.len() + self.b.len();
+        let len = self.pop_manys[0].len() + self.pop_manys[1].len();
         (len, Some(len))
     }
 }
 
-impl<'a> ExactSizeIterator for ChainPopMany<'a> {}
-impl<'a> FusedIterator for ChainPopMany<'a> {}
+impl<'a> ExactSizeIterator for FlattenPopMany<'a> {}
+impl<'a> FusedIterator for FlattenPopMany<'a> {}
 
 #[derive(Default)]
 struct FreshAllocator {
@@ -877,7 +891,7 @@ impl core::fmt::Debug for Allocator {
 ///
 /// **NOTE:** Dropping will leak the remaining entities!
 pub struct AllocEntitiesIterator<'a> {
-    reused: ChainPopMany<'a>,
+    reused: FlattenPopMany<'a>,
     new: AllocUniqueEntityIndexIterator,
 }
 

--- a/crates/bevy_ecs/src/entity/remote_allocator.rs
+++ b/crates/bevy_ecs/src/entity/remote_allocator.rs
@@ -324,8 +324,13 @@ impl<'a> SharedSwapDrain<'a> {
     #[inline]
     unsafe fn try_publish(self, data: &mut Vec<Entity>) -> bool {
         let tail = self.tail.acquire();
-        // producer_pop_count cannot change while we have exclusive access to the producer
-        let producer_pop_count = Head(self.head.0.load(Ordering::Relaxed)).producer_pop_count();
+        let head = Head(self.head.0.load(Ordering::Relaxed));
+        if head.head() > 0 {
+            return false;
+        }
+        // producer_pop_count cannot change while we have exclusive access to the producer (see docs
+        // for [`Head`] for more info about 32 bit targets)
+        let producer_pop_count = head.producer_pop_count();
         let (actual_tail, overflow) = tail.overflowing_sub_unsigned(producer_pop_count);
 
         if actual_tail > 0 || overflow {

--- a/crates/bevy_ecs/src/entity/remote_allocator.rs
+++ b/crates/bevy_ecs/src/entity/remote_allocator.rs
@@ -776,7 +776,10 @@ impl FreshAllocator {
             return AllocUniqueEntityIndexIterator(0..0);
         }
         let start_new = self.next_entity_index.fetch_add(count, Ordering::Relaxed);
-        #[allow(clippy::absurd_extreme_comparisons)]
+        #[expect(
+            clippy::absurd_extreme_comparisons,
+            reason = "Self::MAX_ENTITIES may later be changed to not be equal to u32::MAX n some platforms"
+        )]
         let new = match start_new
             .checked_add(count)
             .filter(|new| *new <= Self::MAX_ENTITIES)

--- a/crates/bevy_ecs/src/entity/remote_allocator.rs
+++ b/crates/bevy_ecs/src/entity/remote_allocator.rs
@@ -28,7 +28,7 @@ use core::{
     iter::FusedIterator,
     mem::{self, ManuallyDrop},
     num::NonZeroU32,
-    range::{Range, RangeIter},
+    ops::Range,
     sync::atomic::{AtomicI32, AtomicU64},
 };
 use crossbeam_utils::CachePadded;
@@ -62,7 +62,7 @@ impl SharedDrain {
             fn drain(to: &mut Vec<Entity>, from: &mut Vec<Entity>) {
                 to.extend(from.drain(MAX..));
             }
-            drain(&mut *self.0, other);
+            drain(&mut self.0, other);
         }
         let initial_len = other.len() as i32;
         mem::swap(&mut *self.0, other);
@@ -80,6 +80,7 @@ impl SharedDrain {
     /// - each `index` must be called with this function exactly once.
     #[inline]
     unsafe fn read(&self, index: usize) -> Entity {
+        // SAFETY: Ensured by caller
         unsafe { self.0.as_ptr().add(index).read() }
     }
 }
@@ -106,7 +107,7 @@ impl SharedDrain {
 /// have [`SharedSwapDrain::pop_as_consumer`] update both atomically.
 ///
 /// Keep in mind that the two heads [`Head::head`] and [`Head::consumer_head`] would not be decremented (together) atomically in this case
-/// resulting in [`Head::producer_pop_count`] being incorrect when publishing. However, assuming we decrement the [`Head::consumer_head]
+/// resulting in [`Head::producer_pop_count`] being incorrect when publishing. However, assuming we decrement the [`Head::consumer_head`]
 /// first, we can at least ensure that [`Head::producer_pop_count`] is only ever incorrect in a direction where it won't result in UB.
 /// Additionally, because we use [`Metadata`] to (loosely) avoid polling empty queues, this possible design results in a fallible but
 /// eventually correct [`Head::producer_pop_count`] value.
@@ -246,7 +247,7 @@ impl<'a> SharedSwapDrain<'a> {
 
         let index = (head.head() - 1) as usize;
         if index == 0 {
-            on_empty()
+            on_empty();
         }
 
         // SAFETY: if `head` returns any positive value then drain is under immutable access
@@ -268,7 +269,7 @@ impl<'a> SharedSwapDrain<'a> {
 
         let index = (head.head() - 1) as usize;
         if index == 0 {
-            on_empty()
+            on_empty();
         }
 
         // SAFETY: if `head` returns any positive value then drain is under immutable access
@@ -354,26 +355,20 @@ impl<'a> SharedSwapDrain<'a> {
 #[inline]
 fn clamp_to_positive(range: Range<i32>, on_empty: impl Fn()) -> Range<u32> {
     if range.start > 0 {
-        Range {
-            start: range.start as u32,
-            end: range.end as u32,
-        }
+        range.start as u32..range.end as u32
     } else {
         if range.end > 0 {
             on_empty();
-            Range {
-                start: 0,
-                end: range.end as u32,
-            }
+            0..range.end as u32
         } else {
-            Range { start: 0, end: 0 }
+            0..0
         }
     }
 }
 
 struct PopMany<'a> {
     swap: SharedSwapDrain<'a>,
-    range: RangeIter<u32>,
+    range: Range<u32>,
     popped_as_consumer: Option<NonZeroU32>,
 }
 
@@ -384,7 +379,7 @@ impl<'a> PopMany<'a> {
     #[inline]
     unsafe fn new(
         swap: SharedSwapDrain<'a>,
-        range: RangeIter<u32>,
+        range: Range<u32>,
         popped_as_consumer: Option<NonZeroU32>,
     ) -> Self {
         Self {
@@ -398,7 +393,7 @@ impl<'a> PopMany<'a> {
     fn empty(swap: SharedSwapDrain<'a>) -> Self {
         Self {
             swap,
-            range: Range::default().into_iter(),
+            range: 0..0,
             popped_as_consumer: None,
         }
     }
@@ -409,9 +404,7 @@ impl<'a> Iterator for PopMany<'a> {
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        let Some(index) = self.range.next() else {
-            return None;
-        };
+        let index = self.range.next()?;
         // SAFETY: ensured by construction with either [`PopMany::new`] or [`PopMany::empty`]
         let drain = unsafe { self.swap.drain.get().as_ref_unchecked() };
         let index = index as usize;
@@ -444,8 +437,8 @@ impl<'a> Drop for PopMany<'a> {
 /// stores the empty state of both drains to short-circuit popping elements.
 ///
 /// # Layout
-/// - 0: a_non_empty
-/// - 1: b_non_empty
+/// - 0: `a_non_empty`
+/// - 1: `b_non_empty`
 /// - 2: priority (true -> b, false -> b) (see [`SharedFreeList::swaps`])
 #[derive(Clone, Copy)]
 struct Metadata(u32);
@@ -648,7 +641,7 @@ impl SharedFreeList {
     /// - must not be called concurrently with itself
     #[inline]
     unsafe fn try_publish(&self, data: &mut Vec<Entity>) {
-        if data.len() == 0 {
+        if data.is_empty() {
             return;
         }
         let meta = self.meta.load();
@@ -783,6 +776,7 @@ impl FreshAllocator {
             return AllocUniqueEntityIndexIterator(0..0);
         }
         let start_new = self.next_entity_index.fetch_add(count, Ordering::Relaxed);
+        #[allow(clippy::absurd_extreme_comparisons)]
         let new = match start_new
             .checked_add(count)
             .filter(|new| *new <= Self::MAX_ENTITIES)
@@ -958,7 +952,7 @@ impl Allocator {
     /// Frees the entities allowing them to be reused.
     #[inline]
     pub(super) fn free_many(&mut self, entities: &[Entity]) {
-        self.local.extend_from_slice(entities)
+        self.local.extend_from_slice(entities);
     }
 }
 

--- a/crates/bevy_ecs/src/entity/remote_allocator.rs
+++ b/crates/bevy_ecs/src/entity/remote_allocator.rs
@@ -540,18 +540,11 @@ impl SharedFreeList {
     /// Returns a [`SharedSwapDrain`] for the given `which`.
     #[inline]
     fn swap(&self, which: bool) -> SharedSwapDrain<'_> {
-        if which {
-            SharedSwapDrain {
-                drain: &self.drains[1],
-                head: &self.heads[1],
-                tail: &self.tails[1],
-            }
-        } else {
-            SharedSwapDrain {
-                drain: &self.drains[0],
-                head: &self.heads[0],
-                tail: &self.tails[0],
-            }
+        let index = if which { 1 } else { 0 };
+        SharedSwapDrain {
+            drain: &self.drains[index],
+            head: &self.heads[index],
+            tail: &self.tails[index],
         }
     }
 

--- a/crates/bevy_ecs/src/entity/remote_allocator.rs
+++ b/crates/bevy_ecs/src/entity/remote_allocator.rs
@@ -85,11 +85,11 @@ impl SharedDrain {
     }
 }
 
-/// Reserves items to be drained from a [`SharedDrain`] using [`AtomicHead::claim_as_*`].
+/// Reserves items to be drained from a [`SharedDrain`] using [`AtomicHead::claim_as_producer`] and [`AtomicHead::claim_as_consumer`].
 ///
 /// # Producer Optimization
 /// Consumers normally decrement the [`Head::head`] cursor to claim items and decrement the
-/// [`Tail`] counter to release items. However when we are the producer ([`Allocator`]) we
+/// tail counter to release items. However when we are the producer ([`Allocator`]) we
 /// don't need to release items because we would be releasing them to ourself see
 /// [`SharedSwapDrain::pop_as_producer`] vs [`SharedSwapDrain::pop_as_consumer`]. Still,
 /// we need to know how many items we're popped by the producer. In order to achieve this
@@ -189,7 +189,7 @@ impl AtomicHead {
     }
 }
 
-/// The [`Tail`] counts how many remaining slots are unread by consumers
+/// The [`AtomicTail`] counts how many remaining slots are unread by consumers
 ///
 /// Although this value is an `i32` it is always non-negative because consumers
 /// don't decrement it past zero.
@@ -220,7 +220,7 @@ impl AtomicTail {
 ///
 /// This structure facilitates concurrent access to a [`SharedDrain`].
 ///
-/// When the `actual_tail` (as summed by [`Head::produer_pop_count`] and [`Tail::acquire`]) is `<= 0`, the drain is considered empty.
+/// When the `actual_tail` (as summed by [`Head::producer_pop_count`] and [`AtomicTail::acquire`]) is `<= 0`, the drain is considered empty.
 /// This is the only time that the producer is allowed to write data because we know that no consumer are
 /// reading the `drain`.
 /// Otherwise, the `drain` is under shared immutable access to all consumers and producers.
@@ -896,7 +896,7 @@ impl SharedAllocator {
 /// This keeps track of freed entities and allows the allocation of new ones.
 ///
 /// Note that this must not implement [`Clone`].
-/// The allocator assumes that it is the only one with [`FreeList::free`] permissions.
+/// The allocator assumes that it is the only one with [`SharedFreeList::free`] permissions.
 /// If this were cloned, that assumption would be broken, leading to undefined behavior.
 /// This is in contrast to the [`RemoteAllocator`], which may be cloned freely.
 #[derive(Default)]

--- a/crates/bevy_ecs/src/entity/remote_allocator.rs
+++ b/crates/bevy_ecs/src/entity/remote_allocator.rs
@@ -139,7 +139,7 @@ impl Head {
 
     #[inline]
     fn producer_pop_count(self) -> i32 {
-        self.head() - self.consumer_head()
+        self.consumer_head() - self.head()
     }
 }
 

--- a/crates/bevy_ecs/src/entity/remote_allocator.rs
+++ b/crates/bevy_ecs/src/entity/remote_allocator.rs
@@ -296,7 +296,7 @@ impl<'a> SharedSwapDrain<'a> {
         let producer_pop_count = Head(self.head.0.load(Ordering::Relaxed)).producer_pop_count();
         let actual_tail = tail - producer_pop_count;
 
-        if actual_tail <= 0 {
+        if actual_tail >= 0 {
             return false;
         }
 

--- a/crates/bevy_ecs/src/entity/remote_allocator.rs
+++ b/crates/bevy_ecs/src/entity/remote_allocator.rs
@@ -896,7 +896,7 @@ impl SharedAllocator {
 /// This keeps track of freed entities and allows the allocation of new ones.
 ///
 /// Note that this must not implement [`Clone`].
-/// The allocator assumes that it is the only one with [`SharedFreeList::free`] permissions.
+/// The allocator assumes that it is the only one with `*_as_producer` and `try_publish` permissions.
 /// If this were cloned, that assumption would be broken, leading to undefined behavior.
 /// This is in contrast to the [`RemoteAllocator`], which may be cloned freely.
 #[derive(Default)]

--- a/crates/bevy_ecs/src/entity/remote_allocator.rs
+++ b/crates/bevy_ecs/src/entity/remote_allocator.rs
@@ -181,7 +181,7 @@ impl AtomicHead {
     /// Claim `n` slots as a producer and return the old head value.
     ///
     /// # Safety
-    /// - must not be called syncronously with [`AtomicHead::publish`]
+    /// - must not be called synchronously with [`AtomicHead::publish`]
     #[inline]
     unsafe fn claim_as_producer(&self, n: u32) -> Head {
         // relaxed ordering due to safety requirements
@@ -194,7 +194,7 @@ impl AtomicHead {
 /// Although this value is an `i32` it is always non-negative because consumers
 /// don't decrement it past zero.
 ///
-/// When the producer is performing their own reads they elide the decriment to
+/// When the producer is performing their own reads they elide the decrement to
 /// tail. The actual tail must be reconstructed by subtracting the [`Head::producer_pop_count`].
 #[derive(Default)]
 struct AtomicTail(AtomicI32);
@@ -235,7 +235,7 @@ impl<'a> SharedSwapDrain<'a> {
     /// Pop an entity from the drain.
     ///
     /// # Safety
-    /// - must not be called syncronously with [`SharedSwapDrain::try_publish`]
+    /// - must not be called synchronously with [`SharedSwapDrain::try_publish`]
     #[inline]
     unsafe fn pop_as_producer(self, on_empty: impl Fn()) -> Option<Entity> {
         // SAFETY: [`SharedSwapDrain::publish`] which calls [`Head::publish`] is not being called
@@ -283,7 +283,7 @@ impl<'a> SharedSwapDrain<'a> {
     }
 
     /// # Safety
-    /// - must not be called syncronously with [`SharedSwapDrain::try_publish`]
+    /// - must not be called synchronously with [`SharedSwapDrain::try_publish`]
     #[inline]
     unsafe fn pop_many_as_producer(self, n: u32, on_empty: impl Fn()) -> PopMany<'a> {
         if n == 0 {
@@ -320,7 +320,7 @@ impl<'a> SharedSwapDrain<'a> {
     }
 
     /// # Safety
-    /// - must not be called syncronously with any `*_as_producer`
+    /// - must not be called synchronously with any `*_as_producer`
     /// - must not be called concurrently with itself
     #[inline]
     unsafe fn try_publish(self, data: &mut Vec<Entity>) -> bool {
@@ -634,7 +634,7 @@ impl SharedFreeList {
         FlattenPopMany::new([a, b])
     }
 
-    /// Trys to pull all of `data` into the free list by trying to swap it with a [`SharedDrain`].
+    /// Tries to pull all of `data` into the free list by trying to swap it with a [`SharedDrain`].
     ///
     /// # Safety
     /// - must not be called concurrently with any `*_as_producer` function

--- a/crates/bevy_ecs/src/entity/remote_allocator.rs
+++ b/crates/bevy_ecs/src/entity/remote_allocator.rs
@@ -62,7 +62,7 @@ impl SharedDrain {
     /// # Safety
     /// - The previous `Vec` must have a length of `0`
     #[inline]
-    unsafe fn swap(&mut self, other: &mut Vec<Entity>) {
+    unsafe fn swap(&mut self, other: &mut Vec<Entity>) -> i32 {
         const MAX: usize = i32::MAX as usize;
         if other.len() > MAX {
             #[cold]
@@ -71,11 +71,13 @@ impl SharedDrain {
             }
             drain(&mut *self.0, other);
         }
+        let initial_len = other.len() as i32;
         mem::swap(&mut *self.0, other);
         // SAFETY: The next time this function is called this length will be correct
         unsafe {
             self.0.set_len(0);
         }
+        initial_len
     }
 
     /// Returns the value at `index` the `Vec`.
@@ -86,12 +88,6 @@ impl SharedDrain {
     #[inline]
     unsafe fn read(&self, index: usize) -> Entity {
         unsafe { self.0.as_ptr().add(index).read() }
-    }
-
-    #[inline]
-    fn initial_len(&self) -> i32 {
-        // see [`SharedDrain::swap`]
-        self.0.len() as i32
     }
 }
 
@@ -296,18 +292,14 @@ impl<'a> SharedSwapDrain<'a> {
         let producer_pop_count = Head(self.head.0.load(Ordering::Relaxed)).producer_pop_count();
         let actual_tail = tail - producer_pop_count;
 
-        if actual_tail >= 0 {
+        if actual_tail > 0 {
             return false;
         }
 
         // SAFETY: Nobody is allowed to read from `drain` when `actual_tail <= 0`.
         let drain = unsafe { self.drain.get().as_mut_unchecked() };
-        // SAFETY: We checked that `actual_tail < 0` meaning all items have been drained
-        unsafe {
-            drain.swap(data);
-        }
-
-        let initial_len = drain.initial_len() as i32;
+        // SAFETY: We checked that `actual_tail <= 0` meaning all items have been drained.
+        let initial_len = unsafe { drain.swap(data) };
 
         // `tail` can be relaxed because `head` fences the publication
         // `tail` must be stored before `head`

--- a/crates/bevy_ecs/src/world/spawn_batch.rs
+++ b/crates/bevy_ecs/src/world/spawn_batch.rs
@@ -134,7 +134,7 @@ mod tests {
         let mut world = World::new();
         world.spawn_batch((0u32..50).filter(|&i| i & 1 > 0).map(|_| ComponentA));
         let total_allocated = world.entity_allocator().inner.total_entity_indices();
-        world.entity_allocator_mut().inner.flush_freed();
+        world.entity_allocator_mut().inner.flush();
         world.entity_allocator_mut().alloc();
         let reused = world.entity_allocator().inner.total_entity_indices() == total_allocated;
         assert!(reused);


### PR DESCRIPTION
# Objective

- A freelist design that doesn't use a CAS loop for remote entities

## Solution

- We double buffer two drain-only vectors and swap in new vectors when they are empty. Draining is just atomic decrementing.

## Testing

I did basic correctness testing but focused mainly on benchmarking. A complete test suite needs to be implimented.

## Benchmarking

<details>
<summary>Criterion Output</summary>
CPU: 16 × 12th Gen Intel® Core™ i5-1250P

<pre>
lars@fedora:~/Workspace/bevy$ cargo bench -p benches --bench ecs entity_allocator -- --baseline main
    Finished `bench` profile [optimized] target(s) in 0.24s
     Running benches/bevy_ecs/main.rs (target/release/deps/ecs-ada68f98dddbfe18)
entity_allocator_allocate_fresh/1_entities
                        time:   [19.423 ns 19.903 ns 20.302 ns]
                        change: [+0.7537% +7.3324% +14.329%] (p = 0.04 < 0.05)
                        Change within noise threshold.
entity_allocator_allocate_fresh/100_entities
                        time:   [608.19 ns 610.63 ns 612.81 ns]
                        change: [−37.009% −36.616% −36.241%] (p = 0.00 < 0.05)
                        Performance has improved.
entity_allocator_allocate_fresh/10000_entities
                        time:   [57.563 µs 57.611 µs 57.665 µs]
                        change: [−36.954% −36.559% −36.294%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe

entity_allocator_allocate_fresh_bulk/1_entities
                        time:   [31.968 ns 32.676 ns 33.283 ns]
                        change: [+5.9950% +15.038% +25.026%] (p = 0.00 < 0.05)
                        Performance has regressed.
entity_allocator_allocate_fresh_bulk/100_entities
                        time:   [183.42 ns 186.63 ns 189.43 ns]
                        change: [+5.8983% +9.1638% +12.400%] (p = 0.00 < 0.05)
                        Performance has regressed.
entity_allocator_allocate_fresh_bulk/10000_entities
                        time:   [11.894 µs 11.908 µs 11.925 µs]
                        change: [+3.0505% +3.9059% +4.9381%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  6 (6.00%) high severe

entity_allocator_free/1_entities
                        time:   [64.417 ns 65.769 ns 66.964 ns]
                        change: [+170.63% +187.74% +206.72%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) low mild
entity_allocator_free/100_entities
                        time:   [382.39 ns 393.61 ns 412.81 ns]
                        change: [+51.774% +56.270% +61.680%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe
entity_allocator_free/10000_entities
                        time:   [19.206 µs 19.356 µs 19.501 µs]
                        change: [−40.164% −39.174% −38.223%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

entity_allocator_free_bulk/1_entities
                        time:   [64.508 ns 65.544 ns 66.434 ns]
                        change: [+217.85% +237.95% +260.37%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) low mild
entity_allocator_free_bulk/100_entities
                        time:   [120.55 ns 124.79 ns 128.35 ns]
                        change: [+16.195% +24.475% +33.712%] (p = 0.00 < 0.05)
                        Performance has regressed.
entity_allocator_free_bulk/10000_entities
                        time:   [8.3743 µs 8.5281 µs 8.6458 µs]
                        change: [−59.310% −56.238% −53.366%] (p = 0.00 < 0.05)
                        Performance has improved.

entity_allocator_allocate_reused/1_entities
                        time:   [38.608 ns 39.484 ns 40.240 ns]
                        change: [+108.81% +121.04% +135.30%] (p = 0.00 < 0.05)
                        Performance has regressed.
entity_allocator_allocate_reused/100_entities
                        time:   [817.19 ns 824.11 ns 829.89 ns]
                        change: [−16.906% −15.971% −15.062%] (p = 0.00 < 0.05)
                        Performance has improved.
entity_allocator_allocate_reused/10000_entities
                        time:   [67.155 µs 67.290 µs 67.404 µs]
                        change: [−27.318% −27.064% −26.822%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

entity_allocator_allocate_reused_bulk/1_entities
                        time:   [54.570 ns 55.767 ns 56.784 ns]
                        change: [+90.857% +104.28% +118.33%] (p = 0.00 < 0.05)
                        Performance has regressed.
entity_allocator_allocate_reused_bulk/100_entities
                        time:   [271.87 ns 277.26 ns 281.80 ns]
                        change: [+36.234% +40.071% +44.356%] (p = 0.00 < 0.05)
                        Performance has regressed.
entity_allocator_allocate_reused_bulk/10000_entities
                        time:   [18.005 µs 18.036 µs 18.070 µs]
                        change: [+21.665% +22.353% +23.053%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low severe
  5 (5.00%) low mild
  2 (2.00%) high mild

entity_allocator_allocate_fresh_remote/1_entities
                        time:   [9.1270 ns 9.2756 ns 9.4035 ns]
                        change: [+3.4827% +7.9894% +11.949%] (p = 0.00 < 0.05)
                        Performance has regressed.
entity_allocator_allocate_fresh_remote/100_entities
                        time:   [576.71 ns 577.32 ns 577.94 ns]
                        change: [−0.3470% −0.0268% +0.2458%] (p = 0.87 > 0.05)
                        No change in performance detected.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
entity_allocator_allocate_fresh_remote/10000_entities
                        time:   [57.514 µs 57.572 µs 57.637 µs]
                        change: [−0.7266% −0.3943% −0.0903%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe

entity_allocator_allocate_reused_remote/1_entities
                        time:   [21.223 ns 21.534 ns 21.796 ns]
                        change: [+158.21% +167.41% +176.36%] (p = 0.00 < 0.05)
                        Performance has regressed.
entity_allocator_allocate_reused_remote/100_entities
                        time:   [1.0413 µs 1.0430 µs 1.0445 µs]
                        change: [+72.384% +72.930% +73.484%] (p = 0.00 < 0.05)
                        Performance has regressed.
entity_allocator_allocate_reused_remote/10000_entities
                        time:   [99.011 µs 99.166 µs 99.313 µs]
                        change: [−15.378% −15.138% −14.871%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
</pre>
</details>

---

In general this implimentation does significantly worse in the 1 entity case and moderately worse in the bulk cases. This is likely because of:
1. Worse cache locality
2. More branches

### Fresh & Fresh Remote
I have a fast path for when both buffers are empty and it's significantly faster or equal.
#### Fresh Bulk
Except for bulk operations, which do have a fast path but still suffer a penalty. 

### Free & Free Bulk
Both versions free to a local buffer. The previous version used a heapless Vec. My version doesn't and pays the allocation cost which is visible in the benchmarks.

#### Flushing
If you notice in the 10k case the new version is significantly faster. That's because I mem::swap::<Vec> buffers while the previous version must flush whenever it reaches capacity and flushing involves copying elements.*

*The semantic meaning of flushing is also very different because we only actually call mem::swap if one of the remote buffers is empty: hence this function should be polled somewhat regularly and shouldn't be tied to the state of the local vector.

### Reused & Reused Bulk
Both implimentations have very similar reused cost. However in the case of 10000 my implimentation is significantly faster. I attribute this to the fact that the previous implimentation has to walk many Blocks while this implementation walks a maximum of 2 Vecs.*  

* This is not the full story: this implementation requires swapping buffers regularly while under normal load. The previous implementation usually doesn't.

### Reused Remote
Although this is what I was mainly optimizing for it was 60% slower in the 100 case (the 10000 case I assume ran into the same memory access pattern as Reused). 

However this test compares uncontested performance. As soon as the CAS loop loops once it would theoretically be slower.

## Remote Bulk
Presumably we didn't support it because it would be an expensive operation we would have to repeat in a CAS loop. This implementation doesn't suffer that problem.