### PR TITLE
Refactor `affects_lightmapped_meshes`, introduce `AmbientLightFlags`

### DIFF
--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -192,6 +192,16 @@ pub struct GpuRectLight {
     range: f32,
 }
 
+// NOTE: These must match the bit flags in bevy_pbr/src/render/mesh_view_types.wgsl!
+bitflags::bitflags! {
+    #[repr(transparent)]
+    struct AmbientLightFlags: u32 {
+        const AFFECTS_LIGHTMAPPED_MESHES        = 1 << 0;
+        const NONE                              = 0;
+        const UNINITIALIZED                     = 0xFFFF;
+    }
+}
+
 #[derive(Copy, Clone, Debug, ShaderType)]
 pub struct GpuLights {
     directional_lights: [GpuDirectionalLight; MAX_DIRECTIONAL_LIGHTS],
@@ -205,7 +215,7 @@ pub struct GpuLights {
     n_directional_lights: u32,
     // offset from spot light's light index to spot light's shadow map index
     spot_light_shadowmap_offset: i32,
-    ambient_light_affects_lightmapped_meshes: u32,
+    ambient_light_flags: u32,
     n_rect_lights: u32,
     rect_lights: [GpuRectLight; MAX_RECT_LIGHTS],
 }
@@ -1879,6 +1889,12 @@ pub fn prepare_lights(
             num_directional_cascades_enabled_for_this_view += num_cascades;
         }
 
+        let mut ambient_light_flags = AmbientLightFlags::NONE;
+
+        if ambient_light.affects_lightmapped_meshes {
+            ambient_light_flags |= AmbientLightFlags::AFFECTS_LIGHTMAPPED_MESHES;
+        }
+
         let mut gpu_lights = GpuLights {
             directional_lights: gpu_directional_lights,
             ambient_color: Vec4::from_slice(&LinearRgba::from(ambient_light.color).to_f32_array())
@@ -1896,8 +1912,7 @@ pub fn prepare_lights(
             // index to shadow map index, we need to subtract point light count and add directional shadowmap count.
             spot_light_shadowmap_offset: num_directional_cascades_enabled as i32
                 - point_light_count as i32,
-            ambient_light_affects_lightmapped_meshes: ambient_light.affects_lightmapped_meshes
-                as u32,
+            ambient_light_flags: ambient_light_flags.bits(),
             n_rect_lights: 0,
             rect_lights: [GpuRectLight::default(); MAX_RECT_LIGHTS],
         };

--- a/crates/bevy_pbr/src/render/mesh_view_types.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_view_types.wgsl
@@ -81,10 +81,12 @@ struct Lights {
     cluster_factors: vec4<f32>,
     n_directional_lights: u32,
     spot_light_shadowmap_offset: i32,
-    ambient_light_affects_lightmapped_meshes: u32,
+    ambient_light_flags: u32,
     n_rect_lights: u32,
     rect_lights: array<RectLight, #{MAX_RECT_LIGHTS}u>,
 };
+
+const AMBIENT_LIGHT_FLAGS_AFFECTS_LIGHTMAPPED_MESHES_BIT: u32           = 1u << 0u;
 
 struct Fog {
     base_color: vec4<f32>,

--- a/crates/bevy_pbr/src/render/pbr_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_functions.wgsl
@@ -754,7 +754,7 @@ fn apply_pbr_lighting(
     // If we are lightmapped, disable the ambient contribution if requested.
     // This is to avoid double-counting ambient light. (It might be part of the lightmap)
 #ifdef LIGHTMAP
-    let enable_ambient = view_bindings::lights.ambient_light_affects_lightmapped_meshes != 0u;
+    let enable_ambient = (view_bindings::lights.ambient_light_flags & mesh_view_types::AMBIENT_LIGHT_FLAGS_AFFECTS_LIGHTMAPPED_MESHES_BIT) != 0u;
 #else   // LIGHTMAP
     let enable_ambient = true;
 #endif  // LIGHTMAP


### PR DESCRIPTION
# Objective

- Make ambient light more consistent with other light sources in the code
- Pave the way for more ambient light boolean flags other than `affects_lightmapped_meshes`
- Make it easier to support `monochromatic` ambient lights as a follow up once #24428 lands

## Solution

- Add `AmbientLightFlags` bitflags struct
- Rename `ambient_light_affects_lightmapped_meshes` to `ambient_light_flags` in `GpuLights` struct and matching WGSL-side `Lights` struct
- Added WGSL `AMBIENT_LIGHT_FLAGS_AFFECTS_LIGHTMAPPED_MESHES_BIT` constant 
- Set up plumbing to both pass and use the new bitfield consistently with other light flags

## Testing

- Did you test these changes? If so, how? Yes, by viewing the `lighting` and `lightmaps` examples
- Are there any parts that need more testing? Not that I know of
- How can other people (reviewers) test your changes? Is there anything specific they need to know? Manually verify ambient light still works
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test? macOS