### PR TITLE
Fixes 24476

### DIFF
--- a/crates/bevy_ecs/src/name.rs
+++ b/crates/bevy_ecs/src/name.rs
@@ -168,7 +168,7 @@ impl<'w, 's> core::fmt::Display for NameOrEntityItem<'w, 's> {
 
 // Conversions from strings
 
-impl From<&str> for Name {
+impl From<&'static str> for Name {
     #[inline(always)]
     fn from(name: &str) -> Self {
         Name::new(name.to_owned())

--- a/crates/bevy_gizmos/src/transform_gizmo.rs
+++ b/crates/bevy_gizmos/src/transform_gizmo.rs
@@ -169,7 +169,7 @@ impl Default for TransformGizmoSettings {
             snap_translate: None,
             snap_rotate: None,
             snap_scale: None,
-            confine_cursor: true,
+            confine_cursor: !cfg!(target_os = "macos"),
             screen_scale_factor: 0.1,
         }
     }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,6 @@
 use_field_init_shorthand = true
 newline_style = "Unix"
-style_edition = "2021"
+style_edition = "2024"
 
 # The following lines may be uncommented on nightly Rust.
 # Once these features have stabilized, they should be added to the always-enabled options above.

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,6 @@
 use_field_init_shorthand = true
 newline_style = "Unix"
-style_edition = "2024"
+style_edition = "2021"
 
 # The following lines may be uncommented on nightly Rust.
 # Once these features have stabilized, they should be added to the always-enabled options above.


### PR DESCRIPTION
# Objective

- Describe the objective or issue this PR addresses.
- Fixes an trivial bug involving TransformGizmosSettings, in which macOS does not support the default constructor values. 
- If you're fixing a specific issue, say "Fixes #X".
Fixes #24476 

## Solution

- Describe the solution used to achieve the objective above.
- The solution achieve is an !cfg!(target_os=macos). The cfg! macro will initially evaluate to true for macos, and then evaluate to false due to the NOT operator.

## Testing

- Did you test these changes? If so, how? I used cargo check to make sure the logic is safe. 
- Are there any parts that need more testing? Probably not. 
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?

---

## Showcase

> This section is optional. If this PR does not include a visual change or does not add a new feature, you can delete this section.

- Help others understand the result of this PR by showcasing your awesome work!
- If this PR adds a new feature or public API, consider adding a brief pseudo-code snippet of it in action
- If this PR includes a visual change, consider adding a screenshot, GIF, or video
  - If you want, you could even include a before/after comparison!
- If the Migration Guide adequately covers the changes, you can delete this section

While a showcase should aim to be brief and digestible, you can use a toggleable section to save space on longer showcases:

<details>
  <summary>Click to view showcase</summary>

```rust
!cfg!(target_os = "macos")
```

</details>
