### PR TITLE
Propagate glTF clearcoat texture to StandardMaterial

### DIFF
--- a/crates/bevy_pbr/src/gltf.rs
+++ b/crates/bevy_pbr/src/gltf.rs
@@ -70,6 +70,10 @@ pub fn standard_material_from_gltf_material(material: &GltfMaterial) -> Standard
         #[cfg(feature = "pbr_specular_textures")]
         specular_tint_texture: material.specular_tint_texture.clone(),
         clearcoat: material.clearcoat,
+        #[cfg(feature = "pbr_multi_layer_material_textures")]
+        clearcoat_channel: material.clearcoat_channel.clone(),
+        #[cfg(feature = "pbr_multi_layer_material_textures")]
+        clearcoat_texture: material.clearcoat_texture.clone(),
         clearcoat_perceptual_roughness: material.clearcoat_perceptual_roughness,
         #[cfg(feature = "pbr_multi_layer_material_textures")]
         clearcoat_roughness_channel: material.clearcoat_roughness_channel.clone(),


### PR DESCRIPTION
# Objective

Fix glTF `KHR_materials_clearcoat` materials where `clearcoatTexture` was ignored when converting to `StandardMaterial`.

This caused assets like [`ClearCoatTest'](https://github.com/KhronosGroup/glTF-Sample-Assets/tree/main/Models/ClearCoatTest) to render the “Partial coating” column as fully coated instead of showing coated and uncoated bands.

## Solution

Propagate glTF clearcoat texture to StandardMaterial

## Testing

Reviewers can test by loading Khronos [`ClearCoatTest'](https://github.com/KhronosGroup/glTF-Sample-Assets/tree/main/Models/ClearCoatTest) and checking that the center [“Partial coating”](https://github.com/KhronosGroup/glTF-Sample-Assets/tree/main/Models/ClearCoatTest#partial-coating) column shows alternating coated and uncoated bands.


