### PR TITLE
Fix anisotropic ibl bend factor

### DIFF
--- a/crates/bevy_pbr/src/render/pbr_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_functions.wgsl
@@ -247,8 +247,9 @@ fn bend_normal_for_anisotropy(lighting_input: ptr<function, lighting::LightingIn
     // The `KHR_materials_anisotropy` spec states:
     //
     // > This heuristic can probably be improved upon
-    let a = pow(2.0, pow(2.0, 1.0 - anisotropy * (1.0 - roughness)));
-    bent_normal = normalize(mix(bent_normal, N, a));
+    let bendFactor = 1.0 - anisotropy * (1.0 - roughness);
+    let bendFactorPow4 = bendFactor * bendFactor * bendFactor * bendFactor;
+    bent_normal = normalize(mix(bent_normal, N, bendFactorPow4));
 
     // The `KHR_materials_anisotropy` spec states:
     //


### PR DESCRIPTION
# Objective

Fix incorrect anisotropic IBL normal bending for `KHR_materials_anisotropy`.

The previous formula computed `2^(2^x)` instead of the `x^4` bend factor described by the [glTF anisotropy reference implementation](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_anisotropy/README.md#image-based-lighting). This caused anisotropy to affect areas where the anisotropy texture strength should be zero, visibly producing square texture bounds in assets such as Khronos [`AnisotropyDiscTest`](https://github.com/KhronosGroup/glTF-Sample-Assets/tree/main/Models/AnisotropyDiscTest).

## Solution

Replace the incorrect nested `pow` expression with the explicit fourth-power bend factor used by the [Khronos glTF Sample Viewer](https://github.com/KhronosGroup/glTF-Sample-Renderer/blob/bec106e53da4a6a398aa3205f0f96563519a657e/source/Renderer/shaders/ibl.glsl#L126-L128)

## Testing

Reviewers can visually test this with the Khronos [`AnisotropyDiscTest`](https://github.com/KhronosGroup/glTF-Sample-Assets/tree/main/Models/AnisotropyDiscTest) and [`CompareAnisotropy`](https://github.com/KhronosGroup/glTF-Sample-Assets/tree/main/Models/CompareAnisotropy). 

## Showcase

Before this PR 

<img width="1188" height="547" alt="image" src="https://github.com/user-attachments/assets/0f5745ac-bf26-4348-b449-c0623f5909cc" />

After

<img width="1151" height="496" alt="image" src="https://github.com/user-attachments/assets/1a77476c-3a0b-4af6-b98f-2cc493e62e69" />

Ref Khronos 

<img width="1695" height="781" alt="image" src="https://github.com/user-attachments/assets/e80315d6-1e32-40c7-8500-522f44cb6921" />


Before 

<img width="927" height="595" alt="image" src="https://github.com/user-attachments/assets/b3632f7c-e2f5-47ad-ad0b-9ee325bda38b" />

After

<img width="932" height="578" alt="image" src="https://github.com/user-attachments/assets/3371fdbd-b847-4f38-8458-0c225fa8b86a" />


Ref Khronos 
(In this asset, KHR_texture_transform is applied to the [normal map](https://github.com/KhronosGroup/glTF-Sample-Assets/blob/main/Models/CompareAnisotropy/glTF/CompareAnisotropy.gltf#L389), so the normal detail may not line up exactly with the Khronos viewer even after the anisotropy bend factor is fixed)

<img width="1296" height="951" alt="image" src="https://github.com/user-attachments/assets/df4de7bd-4c73-4d6a-9a63-3a53924462b4" />



