### PR TITLE
Compute light attenuation using Beer's law

### DIFF
--- a/crates/bevy_gltf/src/loader/gltf_ext/mod.rs
+++ b/crates/bevy_gltf/src/loader/gltf_ext/mod.rs
@@ -64,6 +64,13 @@ pub(crate) fn get_linear_textures(document: &Document) -> HashSet<usize> {
         {
             linear_textures.insert(texture_index);
         }
+        #[cfg(feature = "pbr_transmission_textures")]
+        if let Some(texture) = material
+            .volume()
+            .and_then(|volume| volume.thickness_texture())
+        {
+            linear_textures.insert(texture.texture().index());
+        }
 
         // None of the clearcoat maps should be loaded as sRGB.
         #[cfg(feature = "pbr_multi_layer_material_textures")]

--- a/crates/bevy_pbr/src/render/pbr_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_functions.wgsl
@@ -857,7 +857,8 @@ fn apply_pbr_lighting(
         // and will allow us to eventually hook up subsurface scattering more easily
         var attenuation_fog: mesh_view_types::Fog;
         attenuation_fog.base_color.a = 1.0;
-        attenuation_fog.be = pow(1.0 - in.material.attenuation_color.rgb, vec3<f32>(E)) / in.material.attenuation_distance;
+        let attenuation_color = max(in.material.attenuation_color.rgb, vec3<f32>(1e-6));
+        attenuation_fog.be = -log(attenuation_color) / in.material.attenuation_distance;
         // TODO: Add the subsurface scattering factor below
         // attenuation_fog.bi = /* ... */
         transmitted_light = bevy_pbr::fog::atmospheric_fog(

--- a/crates/bevy_pbr/src/render/pbr_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_functions.wgsl
@@ -851,20 +851,14 @@ fn apply_pbr_lighting(
 #ifdef STANDARD_MATERIAL_SPECULAR_TRANSMISSION
     transmitted_light += transmission::specular_transmissive_light(in.world_position, in.frag_coord.xyz, view_z, in.N, in.V, F0, ior, thickness, perceptual_roughness, specular_transmissive_color, specular_transmitted_environment_light).rgb;
 
-    if (in.material.flags & pbr_types::STANDARD_MATERIAL_FLAGS_ATTENUATION_ENABLED_BIT) != 0u {
-        // We reuse the `atmospheric_fog()` function here, as it's fundamentally
-        // equivalent to the attenuation that takes place inside the material volume,
-        // and will allow us to eventually hook up subsurface scattering more easily
-        var attenuation_fog: mesh_view_types::Fog;
-        attenuation_fog.base_color.a = 1.0;
-        let attenuation_color = max(in.material.attenuation_color.rgb, vec3<f32>(1e-6));
-        attenuation_fog.be = -log(attenuation_color) / in.material.attenuation_distance;
-        // TODO: Add the subsurface scattering factor below
-        // attenuation_fog.bi = /* ... */
-        transmitted_light = bevy_pbr::fog::atmospheric_fog(
-            attenuation_fog, vec4<f32>(transmitted_light, 1.0), thickness,
-            vec3<f32>(0.0) // TODO: Pass in (pre-attenuated) scattered light contribution here
-        ).rgb;
+    if (in.material.flags & pbr_types::STANDARD_MATERIAL_FLAGS_ATTENUATION_ENABLED_BIT) != 0u
+        && in.material.attenuation_distance != 0.0 {
+        // Compute light attenuation using Beer's law.
+        let transmittance = pow(
+            in.material.attenuation_color.rgb,
+            vec3<f32>(thickness / in.material.attenuation_distance),
+        );
+        transmitted_light *= transmittance;
     }
 #endif
 


### PR DESCRIPTION
# Objective

Fix volume attenuation for glTF materials using [`KHR_materials_volume`](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_volume).

Bevy was converting `attenuationColor` with `pow(1.0 - color, E)` to reuse the existing fog math `atmospheric_fog()` , which under-attenuates transmitted light. This makes dark volume materials render too bright.

I first tried to keep the existing structure and only fix the coefficient passed to `atmospheric_fog()` ([first commit](https://github.com/bevyengine/bevy/pull/24516/changes/91894fe33293e44cf839e27b307269d5ca8c1938)). Since that function attenuates with:

```text
transmittance = exp(-be * distance)
```

and `KHR_materials_volume` defines `attenuationColor` as the transmittance after `attenuationDistance`, solving:

```text
attenuationColor = exp(-be * attenuationDistance)
```

gives:

```text
be = -log(attenuationColor) / attenuationDistance
```

After discussing this with @coreh, I switched to applying the volume attenuation directly instead of routing it through the fog abstraction.

## Solution

- Apply the Beer's law for transmittance from the [Khronos Sample Renderer](https://github.com/KhronosGroup/glTF-Sample-Renderer/blob/main/source/Renderer/shaders/punctual.glsl#L116-L130) directly in the transmission path:

```text
transmittance = attenuationColor ^ (transmissionDistance / attenuationDistance)
radiance *= transmittance
```

- `thicknessTexture` is now loaded as a linear data texture, since its G channel stores thickness rather than color.

## Testing

Reviewers can test visually by loading the Khronos [`AttenuationTest`](https://github.com/KhronosGroup/glTF-Sample-Assets/tree/main/Models/AttenuationTest) and [`DragonAttenuation`](https://github.com/KhronosGroup/glTF-Sample-Assets/tree/main/Models/DragonAttenuation) assets

## Showcase
Before PR

<img width="675" height="658" alt="image" src="https://github.com/user-attachments/assets/3b4c0fb3-79b6-4a18-93c9-a578a71a9ad5" />

After
<img width="611" height="601" alt="image" src="https://github.com/user-attachments/assets/e16b39ad-ba15-4769-936b-ea721185959e" />

Ref Khronos 

<img width="1042" height="1042" alt="image" src="https://github.com/user-attachments/assets/2218b840-041b-46a3-a7a4-94dd94fef399" />

Before 

<img width="875" height="685" alt="image" src="https://github.com/user-attachments/assets/ec9184b5-cac3-47bd-af60-6b6f899d8c2e" />

After 

<img width="716" height="608" alt="image" src="https://github.com/user-attachments/assets/a420f80d-d2ac-496e-b6f3-3e65cfff7d91" />

Ref Khronos

<img width="1080" height="881" alt="image" src="https://github.com/user-attachments/assets/0b17b534-2814-4a15-9925-e7dba83a2e7a" />
