### PR TITLE
bevy_reflect: Type data registration callbacks

### DIFF
--- a/_release-content/migration-guides/bevy_reflect_type_data_callbacks.md
+++ b/_release-content/migration-guides/bevy_reflect_type_data_callbacks.md
@@ -1,0 +1,53 @@
+---
+title: "Type data creation and registration changes"
+pull_requests: [24518]
+---
+
+Type data definition and registration have been reworked to enable `on_insert` and `on_register` registration callbacks.
+
+Type data is no longer automatically implemented on types implementing `Clone`.
+Instead, it must be manually implemented or derived:
+
+```rust
+// BEFORE
+#[derive(Clone)]
+struct ReflectSomeTypeData;
+
+// AFTER
+#[derive(TypeData)]
+struct ReflectSomeTypeData;
+
+// or manually:
+// impl TypeData for ReflectSomeTypeData {}
+```
+
+Additionally, type data can no longer be inserted directly onto a `&mut TypeRegistration`.
+Instead, it must be inserted during construction, with an owned `TypeRegistration`.
+This was done to ensure that registration callbacks weren't accidentally missed.
+
+```rust
+// BEFORE
+let mut registration = TypeRegistration::of::<MyType>();
+registration.register_type_data::<SomeTypeData, _>();
+
+// AFTER
+let registration = TypeRegistration::of::<MyType>()
+  .register_type_data::<SomeTypeData, _>();
+});
+```
+
+Methods for registering type data on the `TypeRegistry` remain unchanged.
+However, because of the new restrictions around inserting type data on `TypeRegistration`,
+instances of `TypeRegistry::get_mut` can be replaced with the new `TypeRegistry::registration_scope`
+in order to insert multiple type data without additional lookups.
+
+```rust
+// BEFORE
+let registration = registry.get_mut(TypeId::of::<MyType>());
+registration.register_type_data::<SomeTypeData, _>();
+
+// AFTER
+let registration = registry.registration_scope(TypeId::of::<MyType>(), |mut registration| {
+  registration.register_type_data::<SomeTypeData, _>();
+});
+```

--- a/crates/bevy_asset/src/reflect.rs
+++ b/crates/bevy_asset/src/reflect.rs
@@ -8,7 +8,7 @@ use uuid::Uuid;
 use bevy_ecs::world::{unsafe_world_cell::UnsafeWorldCell, World};
 use bevy_reflect::{
     serde::{ReflectDeserializerProcessor, ReflectSerializerProcessor},
-    CreateTypeData, FromReflect, PartialReflect, Reflect, TypeRegistry,
+    CreateTypeData, FromReflect, PartialReflect, Reflect, TypeData, TypeRegistry,
 };
 
 use crate::{
@@ -23,7 +23,7 @@ use crate::{
 /// until runtime.
 ///
 /// [`ReflectAsset`] can be obtained via [`TypeRegistration::data`](bevy_reflect::TypeRegistration::data) if the asset was registered using [`register_asset_reflect`](crate::AssetApp::register_asset_reflect).
-#[derive(Clone)]
+#[derive(Clone, TypeData)]
 pub struct ReflectAsset {
     handle_type_id: TypeId,
     assets_resource_type_id: TypeId,
@@ -228,7 +228,7 @@ impl<A: Asset + FromReflect> CreateTypeData<A> for ReflectAsset {
 ///     println!("{value:?}");
 /// }
 /// ```
-#[derive(Clone)]
+#[derive(Clone, TypeData)]
 pub struct ReflectHandle {
     asset_type_id: TypeId,
     downcast_handle_untyped: fn(&dyn Any) -> Option<UntypedHandle>,

--- a/crates/bevy_ecs/src/entity/clone_entities.rs
+++ b/crates/bevy_ecs/src/entity/clone_entities.rs
@@ -1476,7 +1476,7 @@ mod tests {
         use super::*;
         use crate::reflect::{AppTypeRegistry, ReflectComponent, ReflectFromWorld};
         use alloc::vec;
-        use bevy_reflect::{std_traits::ReflectDefault, CreateTypeData, Reflect, ReflectFromPtr};
+        use bevy_reflect::{std_traits::ReflectDefault, Reflect, ReflectFromPtr};
 
         #[test]
         fn clone_entity_using_reflect() {
@@ -1614,10 +1614,9 @@ mod tests {
             {
                 let mut registry = registry.write();
                 registry.register::<A>();
-                registry
-                    .get_mut(TypeId::of::<A>())
-                    .unwrap()
-                    .insert(<ReflectFromPtr as CreateTypeData<B>>::create_type_data(()));
+                registry.registration_scope(TypeId::of::<A>(), |mut registration| {
+                    registration.register_type_data::<ReflectFromPtr, B>();
+                });
             }
 
             let e = world.spawn(A).id();

--- a/crates/bevy_ecs/src/reflect/bundle.rs
+++ b/crates/bevy_ecs/src/reflect/bundle.rs
@@ -16,7 +16,8 @@ use crate::{
     world::{EntityMut, EntityWorldMut},
 };
 use bevy_reflect::{
-    CreateTypeData, FromReflect, PartialReflect, Reflect, ReflectRef, TypePath, TypeRegistry,
+    CreateTypeData, FromReflect, PartialReflect, Reflect, ReflectRef, TypeData, TypePath,
+    TypeRegistry,
 };
 
 use super::{from_reflect_with_fallback, ReflectComponent};
@@ -25,7 +26,7 @@ use super::{from_reflect_with_fallback, ReflectComponent};
 ///
 /// A [`ReflectBundle`] for type `T` can be obtained via
 /// [`bevy_reflect::TypeRegistration::data`].
-#[derive(Clone)]
+#[derive(Clone, TypeData)]
 pub struct ReflectBundle(ReflectBundleFns);
 
 /// The raw function pointers needed to make up a [`ReflectBundle`].

--- a/crates/bevy_ecs/src/reflect/component.rs
+++ b/crates/bevy_ecs/src/reflect/component.rs
@@ -70,14 +70,16 @@ use crate::{
     },
 };
 use alloc::boxed::Box;
-use bevy_reflect::{CreateTypeData, FromReflect, PartialReflect, Reflect, TypePath, TypeRegistry};
+use bevy_reflect::{
+    CreateTypeData, FromReflect, PartialReflect, Reflect, TypeData, TypePath, TypeRegistry,
+};
 use bevy_utils::prelude::DebugName;
 
 /// A struct used to operate on reflected [`Component`] trait of a type.
 ///
 /// A [`ReflectComponent`] for type `T` can be obtained via
 /// [`bevy_reflect::TypeRegistration::data`].
-#[derive(Clone)]
+#[derive(Clone, TypeData)]
 pub struct ReflectComponent(ReflectComponentFns);
 
 /// The raw function pointers needed to make up a [`ReflectComponent`].

--- a/crates/bevy_ecs/src/reflect/event.rs
+++ b/crates/bevy_ecs/src/reflect/event.rs
@@ -13,13 +13,15 @@ use crate::{
     reflect::from_reflect_with_fallback,
     world::{DeferredWorld, World},
 };
-use bevy_reflect::{CreateTypeData, FromReflect, PartialReflect, Reflect, TypePath, TypeRegistry};
+use bevy_reflect::{
+    CreateTypeData, FromReflect, PartialReflect, Reflect, TypeData, TypePath, TypeRegistry,
+};
 
 /// A struct used to operate on reflected [`Event`] trait of a type.
 ///
 /// A [`ReflectEvent`] for type `T` can be obtained via
 /// [`bevy_reflect::TypeRegistration::data`].
-#[derive(Clone)]
+#[derive(Clone, TypeData)]
 pub struct ReflectEvent(ReflectEventFns);
 
 /// The raw function pointers needed to make up a [`ReflectEvent`].

--- a/crates/bevy_ecs/src/reflect/from_world.rs
+++ b/crates/bevy_ecs/src/reflect/from_world.rs
@@ -7,7 +7,7 @@
 //! Same as [`component`](`super::component`), but for [`FromWorld`].
 
 use alloc::boxed::Box;
-use bevy_reflect::{CreateTypeData, Reflect};
+use bevy_reflect::{CreateTypeData, Reflect, TypeData};
 
 use crate::world::{FromWorld, World};
 
@@ -15,7 +15,7 @@ use crate::world::{FromWorld, World};
 ///
 /// A [`ReflectFromWorld`] for type `T` can be obtained via
 /// [`bevy_reflect::TypeRegistration::data`].
-#[derive(Clone)]
+#[derive(Clone, TypeData)]
 pub struct ReflectFromWorld(ReflectFromWorldFns);
 
 /// The raw function pointers needed to make up a [`ReflectFromWorld`].

--- a/crates/bevy_ecs/src/reflect/map_entities.rs
+++ b/crates/bevy_ecs/src/reflect/map_entities.rs
@@ -1,5 +1,5 @@
 use crate::entity::{EntityMapper, MapEntities};
-use bevy_reflect::{CreateTypeData, FromReflect, PartialReflect};
+use bevy_reflect::{CreateTypeData, FromReflect, PartialReflect, TypeData};
 
 /// For a specific type of value, this maps any fields with values of type [`Entity`] to a new world.
 ///
@@ -10,7 +10,7 @@ use bevy_reflect::{CreateTypeData, FromReflect, PartialReflect};
 ///
 /// [`Entity`]: crate::entity::Entity
 /// [`EntityMapper`]: crate::entity::EntityMapper
-#[derive(Clone)]
+#[derive(Clone, TypeData)]
 pub struct ReflectMapEntities {
     map_entities: fn(&mut dyn PartialReflect, &mut dyn EntityMapper),
 }

--- a/crates/bevy_ecs/src/reflect/message.rs
+++ b/crates/bevy_ecs/src/reflect/message.rs
@@ -6,13 +6,15 @@
 //! Same as [`component`](`super::component`), but for messages.
 
 use crate::{message::Message, reflect::from_reflect_with_fallback, world::World};
-use bevy_reflect::{CreateTypeData, FromReflect, PartialReflect, Reflect, TypePath, TypeRegistry};
+use bevy_reflect::{
+    CreateTypeData, FromReflect, PartialReflect, Reflect, TypeData, TypePath, TypeRegistry,
+};
 
 /// A struct used to operate on reflected [`Message`] trait of a type.
 ///
 /// A [`ReflectMessage`] for type `T` can be obtained via
 /// [`bevy_reflect::TypeRegistration::data`].
-#[derive(Clone)]
+#[derive(Clone, TypeData)]
 pub struct ReflectMessage(ReflectMessageFns);
 
 /// The raw function pointers needed to make up a [`ReflectMessage`].

--- a/crates/bevy_ecs/src/reflect/resource.rs
+++ b/crates/bevy_ecs/src/reflect/resource.rs
@@ -35,9 +35,9 @@ impl<R: Resource + FromReflect + TypePath> CreateTypeData<R> for ReflectResource
         ReflectResource
     }
 
-    fn on_insert() -> Option<OnInsertTypeData> {
-        Some(|mut registration| {
+    fn on_insert(_: &()) -> Option<OnInsertTypeData> {
+        Some(OnInsertTypeData::new(|mut registration| {
             registration.register_type_data::<ReflectComponent, R>();
-        })
+        }))
     }
 }

--- a/crates/bevy_ecs/src/reflect/resource.rs
+++ b/crates/bevy_ecs/src/reflect/resource.rs
@@ -5,7 +5,7 @@
 //! See the module doc for [`reflect::component`](`crate::reflect::component`).
 
 use crate::{reflect::ReflectComponent, resource::Resource};
-use bevy_reflect::{CreateTypeData, FromReflect, TypePath, TypeRegistration};
+use bevy_reflect::{CreateTypeData, FromReflect, OnInsertTypeData, TypeData, TypePath};
 
 /// A struct that marks a reflected [`Resource`] of a type.
 ///
@@ -27,7 +27,7 @@ use bevy_reflect::{CreateTypeData, FromReflect, TypePath, TypeRegistration};
 ///
 /// A [`ReflectResource`] for type `T` can be obtained via
 /// [`bevy_reflect::TypeRegistration::data`].
-#[derive(Clone)]
+#[derive(Clone, TypeData)]
 pub struct ReflectResource;
 
 impl<R: Resource + FromReflect + TypePath> CreateTypeData<R> for ReflectResource {
@@ -35,7 +35,9 @@ impl<R: Resource + FromReflect + TypePath> CreateTypeData<R> for ReflectResource
         ReflectResource
     }
 
-    fn insert_dependencies(type_registration: &mut TypeRegistration) {
-        type_registration.register_type_data::<ReflectComponent, R>();
+    fn on_insert() -> Option<OnInsertTypeData> {
+        Some(|mut registration| {
+            registration.register_type_data::<ReflectComponent, R>();
+        })
     }
 }

--- a/crates/bevy_reflect/compile_fail/tests/reflect_derive/custom_where_fail.rs
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_derive/custom_where_fail.rs
@@ -1,7 +1,7 @@
-use bevy_reflect::{CreateTypeData, Reflect};
+use bevy_reflect::{CreateTypeData, Reflect, TypeData};
 use core::marker::PhantomData;
 
-#[derive(Clone)]
+#[derive(TypeData)]
 struct ReflectMyTrait;
 
 impl<T> CreateTypeData<T> for ReflectMyTrait {

--- a/crates/bevy_reflect/compile_fail/tests/reflect_derive/custom_where_pass.rs
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_derive/custom_where_pass.rs
@@ -1,8 +1,8 @@
 //@check-pass
-use bevy_reflect::{CreateTypeData, Reflect};
+use bevy_reflect::{CreateTypeData, Reflect, TypeData};
 use core::marker::PhantomData;
 
-#[derive(Clone)]
+#[derive(TypeData)]
 struct ReflectMyTrait;
 
 impl<T> CreateTypeData<T> for ReflectMyTrait {

--- a/crates/bevy_reflect/compile_fail/tests/reflect_derive/type_data_fail.rs
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_derive/type_data_fail.rs
@@ -1,7 +1,7 @@
 //@no-rustfix
-use bevy_reflect::{CreateTypeData, Reflect};
+use bevy_reflect::{CreateTypeData, Reflect, TypeData};
 
-#[derive(Clone)]
+#[derive(TypeData)]
 struct ReflectMyTrait;
 
 impl<T> CreateTypeData<T, f32> for ReflectMyTrait {

--- a/crates/bevy_reflect/compile_fail/tests/reflect_derive/type_data_pass.rs
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_derive/type_data_pass.rs
@@ -1,7 +1,7 @@
 //@check-pass
-use bevy_reflect::{CreateTypeData, Reflect};
+use bevy_reflect::{CreateTypeData, Reflect, TypeData};
 
-#[derive(Clone)]
+#[derive(TypeData)]
 struct ReflectMyTrait;
 
 impl<T> CreateTypeData<T> for ReflectMyTrait {

--- a/crates/bevy_reflect/derive/src/lib.rs
+++ b/crates/bevy_reflect/derive/src/lib.rs
@@ -512,6 +512,21 @@ pub fn derive_type_path(input: TokenStream) -> TokenStream {
     })
 }
 
+/// Derives the `TypePath` trait.
+#[proc_macro_derive(TypeData)]
+pub fn derive_type_data(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    let ident = &ast.ident;
+    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+    let bevy_reflect_path = meta::get_bevy_reflect_path();
+
+    TokenStream::from(quote! {
+        const _: () = {
+            impl #impl_generics #bevy_reflect_path::TypeData for #ident #ty_generics #where_clause {}
+        };
+    })
+}
+
 /// A macro that automatically generates type data for traits, which their implementors can then register.
 ///
 /// The output of this macro is a struct that takes reflected instances of the implementor's type

--- a/crates/bevy_reflect/derive/src/lib.rs
+++ b/crates/bevy_reflect/derive/src/lib.rs
@@ -512,7 +512,7 @@ pub fn derive_type_path(input: TokenStream) -> TokenStream {
     })
 }
 
-/// Derives the `TypePath` trait.
+/// Derives the `TypeData` trait.
 #[proc_macro_derive(TypeData)]
 pub fn derive_type_data(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);

--- a/crates/bevy_reflect/derive/src/lib.rs
+++ b/crates/bevy_reflect/derive/src/lib.rs
@@ -514,6 +514,21 @@ pub fn derive_type_path(input: TokenStream) -> TokenStream {
     })
 }
 
+/// Derives the `TypePath` trait.
+#[proc_macro_derive(TypeData)]
+pub fn derive_type_data(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    let ident = &ast.ident;
+    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+    let bevy_reflect_path = meta::get_bevy_reflect_path();
+
+    TokenStream::from(quote! {
+        const _: () = {
+            impl #impl_generics #bevy_reflect_path::TypeData for #ident #ty_generics #where_clause {}
+        };
+    })
+}
+
 /// A macro that automatically generates type data for traits, which their implementors can then register.
 ///
 /// The output of this macro is a struct that takes reflected instances of the implementor's type

--- a/crates/bevy_reflect/derive/src/lib.rs
+++ b/crates/bevy_reflect/derive/src/lib.rs
@@ -514,7 +514,7 @@ pub fn derive_type_path(input: TokenStream) -> TokenStream {
     })
 }
 
-/// Derives the `TypePath` trait.
+/// Derives the `TypeData` trait.
 #[proc_macro_derive(TypeData)]
 pub fn derive_type_data(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);

--- a/crates/bevy_reflect/derive/src/registration.rs
+++ b/crates/bevy_reflect/derive/src/registration.rs
@@ -28,9 +28,9 @@ pub(crate) fn impl_get_type_registration<'a>(
 
     let from_reflect_data = if meta.from_reflect().should_auto_derive() {
         Some(quote! {
-            registration.insert(
+            .insert_data(
                 <#bevy_reflect_path::ReflectFromReflect as #bevy_reflect_path::CreateTypeData<Self>>::create_type_data(())
-            );
+            )
         })
     } else {
         None
@@ -39,7 +39,7 @@ pub(crate) fn impl_get_type_registration<'a>(
     let serialization_data = serialization_data.map(|data| {
         let serialization_data = data.as_serialization_data(bevy_reflect_path);
         quote! {
-            registration.insert::<#bevy_reflect_path::serde::SerializationData>(#serialization_data);
+            .insert_data::<#bevy_reflect_path::serde::SerializationData>(#serialization_data)
         }
     });
 
@@ -56,21 +56,20 @@ pub(crate) fn impl_get_type_registration<'a>(
         };
 
         quote! {
-            registration.register_type_data_with::<#reflect_ident, Self, _>(#args);
+            .register_type_data_with::<#reflect_ident, Self, _>(#args)
         }
     });
 
     quote! {
         impl #impl_generics #bevy_reflect_path::GetTypeRegistration for #type_path #ty_generics #where_reflect_clause {
             fn get_type_registration() -> #bevy_reflect_path::TypeRegistration {
-                let mut registration = #bevy_reflect_path::TypeRegistration::of::<Self>();
-                registration.insert(
-                    <#bevy_reflect_path::ReflectFromPtr as #bevy_reflect_path::CreateTypeData::<Self>>::create_type_data(())
-                );
+                #bevy_reflect_path::TypeRegistration::of::<Self>()
+                    .insert_data(
+                        <#bevy_reflect_path::ReflectFromPtr as #bevy_reflect_path::CreateTypeData::<Self>>::create_type_data(())
+                    )
                 #from_reflect_data
                 #serialization_data
                 #(#type_data)*
-                registration
             }
 
             #type_deps_fn

--- a/crates/bevy_reflect/derive/src/registration.rs
+++ b/crates/bevy_reflect/derive/src/registration.rs
@@ -29,9 +29,9 @@ pub(crate) fn impl_get_type_registration<'a>(
 
     let from_reflect_data = if meta.from_reflect().should_auto_derive() {
         Some(quote! {
-            registration.insert(
+            .insert_data(
                 <#bevy_reflect_path::ReflectFromReflect as #bevy_reflect_path::CreateTypeData<Self>>::create_type_data(())
-            );
+            )
         })
     } else {
         None
@@ -40,7 +40,7 @@ pub(crate) fn impl_get_type_registration<'a>(
     let serialization_data = serialization_data.map(|data| {
         let serialization_data = data.as_serialization_data(bevy_reflect_path);
         quote! {
-            registration.insert::<#bevy_reflect_path::serde::SerializationData>(#serialization_data);
+            .insert_data::<#bevy_reflect_path::serde::SerializationData>(#serialization_data)
         }
     });
 
@@ -57,21 +57,20 @@ pub(crate) fn impl_get_type_registration<'a>(
         };
 
         quote! {
-            registration.register_type_data_with::<#reflect_path, Self, _>(#args);
+            .register_type_data_with::<#reflect_path, Self, _>(#args)
         }
     });
 
     quote! {
         impl #impl_generics #bevy_reflect_path::GetTypeRegistration for #type_path #ty_generics #where_reflect_clause {
             fn get_type_registration() -> #bevy_reflect_path::TypeRegistration {
-                let mut registration = #bevy_reflect_path::TypeRegistration::of::<Self>();
-                registration.insert(
-                    <#bevy_reflect_path::ReflectFromPtr as #bevy_reflect_path::CreateTypeData::<Self>>::create_type_data(())
-                );
+                #bevy_reflect_path::TypeRegistration::of::<Self>()
+                    .insert_data(
+                        <#bevy_reflect_path::ReflectFromPtr as #bevy_reflect_path::CreateTypeData::<Self>>::create_type_data(())
+                    )
                 #from_reflect_data
                 #serialization_data
                 #(#type_data)*
-                registration
             }
 
             #type_deps_fn

--- a/crates/bevy_reflect/derive/src/trait_reflection.rs
+++ b/crates/bevy_reflect/derive/src/trait_reflection.rs
@@ -74,6 +74,8 @@ pub(crate) fn reflect_trait(_args: &TokenStream, input: TokenStream) -> TokenStr
             }
         }
 
+        impl #bevy_reflect_path::TypeData for #reflect_trait_ident {}
+
         impl<T: #trait_ident + #bevy_reflect_path::Reflect> #bevy_reflect_path::CreateTypeData<T> for #reflect_trait_ident {
             fn create_type_data(_input: ()) -> Self {
                 Self {

--- a/crates/bevy_reflect/src/convert.rs
+++ b/crates/bevy_reflect/src/convert.rs
@@ -32,7 +32,7 @@ use crate::{Reflect, TypeData, TypePath};
 ///     .downcast::<String>()
 ///     .unwrap();
 /// ```
-#[derive(Default)]
+#[derive(Default, TypeData)]
 pub struct ReflectConvert {
     /// A mapping from the type to be converted *from* to its associated
     /// [`Converter`].
@@ -100,8 +100,6 @@ impl ReflectConvert {
         );
     }
 }
-
-impl TypeData for ReflectConvert {}
 
 impl Clone for ReflectConvert {
     fn clone(&self) -> Self {

--- a/crates/bevy_reflect/src/convert.rs
+++ b/crates/bevy_reflect/src/convert.rs
@@ -6,7 +6,7 @@ use core::{any::TypeId, marker::PhantomData};
 
 use bevy_utils::TypeIdMap;
 
-use crate::{Reflect, TypePath};
+use crate::{Reflect, TypeData, TypePath};
 
 /// Provides a mechanism for converting values of one type to another.
 ///
@@ -100,6 +100,8 @@ impl ReflectConvert {
         );
     }
 }
+
+impl TypeData for ReflectConvert {}
 
 impl Clone for ReflectConvert {
     fn clone(&self) -> Self {
@@ -257,10 +259,9 @@ mod tests {
         let mut registry = TypeRegistry::default();
         registry.add_registration(i32::get_type_registration());
         registry.add_registration(String::get_type_registration());
-        registry
-            .get_mut(TypeId::of::<i32>())
-            .unwrap()
-            .insert(ReflectConvert::default());
+        registry.registration_scope(TypeId::of::<i32>(), |mut registration| {
+            registration.insert_data(ReflectConvert::default());
+        });
 
         let reflect_convert = registry
             .get_type_data::<ReflectConvert>(TypeId::of::<i32>())

--- a/crates/bevy_reflect/src/convert.rs
+++ b/crates/bevy_reflect/src/convert.rs
@@ -6,7 +6,7 @@ use core::{any::TypeId, marker::PhantomData};
 
 use bevy_utils::TypeIdHashMap;
 
-use crate::{Reflect, TypePath};
+use crate::{Reflect, TypeData, TypePath};
 
 /// Provides a mechanism for converting values of one type to another.
 ///
@@ -100,6 +100,8 @@ impl ReflectConvert {
         );
     }
 }
+
+impl TypeData for ReflectConvert {}
 
 impl Clone for ReflectConvert {
     fn clone(&self) -> Self {
@@ -257,10 +259,9 @@ mod tests {
         let mut registry = TypeRegistry::default();
         registry.add_registration(i32::get_type_registration());
         registry.add_registration(String::get_type_registration());
-        registry
-            .get_mut(TypeId::of::<i32>())
-            .unwrap()
-            .insert(ReflectConvert::default());
+        registry.registration_scope(TypeId::of::<i32>(), |mut registration| {
+            registration.insert_data(ReflectConvert::default());
+        });
 
         let reflect_convert = registry
             .get_type_data::<ReflectConvert>(TypeId::of::<i32>())

--- a/crates/bevy_reflect/src/from_reflect.rs
+++ b/crates/bevy_reflect/src/from_reflect.rs
@@ -102,7 +102,7 @@ pub trait FromReflect: Reflect + Sized {
 ///
 /// [`DynamicStruct`]: crate::structs::DynamicStruct
 /// [`DynamicEnum`]: crate::enums::DynamicEnum
-#[derive(Clone)]
+#[derive(Clone, TypeData)]
 pub struct ReflectFromReflect {
     from_reflect: fn(&dyn PartialReflect) -> Option<Box<dyn Reflect>>,
 }
@@ -116,8 +116,6 @@ impl ReflectFromReflect {
         (self.from_reflect)(reflect_value)
     }
 }
-
-impl TypeData for ReflectFromReflect {}
 
 impl<T: FromReflect> CreateTypeData<T> for ReflectFromReflect {
     fn create_type_data(_input: ()) -> Self {

--- a/crates/bevy_reflect/src/from_reflect.rs
+++ b/crates/bevy_reflect/src/from_reflect.rs
@@ -1,4 +1,4 @@
-use crate::{CreateTypeData, PartialReflect, Reflect};
+use crate::{CreateTypeData, PartialReflect, Reflect, TypeData};
 use alloc::boxed::Box;
 
 /// A trait that enables types to be dynamically constructed from reflected data.
@@ -116,6 +116,8 @@ impl ReflectFromReflect {
         (self.from_reflect)(reflect_value)
     }
 }
+
+impl TypeData for ReflectFromReflect {}
 
 impl<T: FromReflect> CreateTypeData<T> for ReflectFromReflect {
     fn create_type_data(_input: ()) -> Self {

--- a/crates/bevy_reflect/src/impls/alloc/borrow.rs
+++ b/crates/bevy_reflect/src/impls/alloc/borrow.rs
@@ -123,12 +123,11 @@ impl Typed for Cow<'static, str> {
 
 impl GetTypeRegistration for Cow<'static, str> {
     fn get_type_registration() -> TypeRegistration {
-        let mut registration = TypeRegistration::of::<Cow<'static, str>>();
-        registration.register_type_data::<ReflectDeserialize, Self>();
-        registration.register_type_data::<ReflectFromPtr, Self>();
-        registration.register_type_data::<ReflectFromReflect, Self>();
-        registration.register_type_data::<ReflectSerialize, Self>();
-        registration
+        TypeRegistration::of::<Cow<'static, str>>()
+            .register_type_data::<ReflectDeserialize, Self>()
+            .register_type_data::<ReflectFromPtr, Self>()
+            .register_type_data::<ReflectFromReflect, Self>()
+            .register_type_data::<ReflectSerialize, Self>()
     }
 }
 

--- a/crates/bevy_reflect/src/impls/alloc/collections/btree/map.rs
+++ b/crates/bevy_reflect/src/impls/alloc/collections/btree/map.rs
@@ -199,10 +199,9 @@ where
     V: FromReflect + MaybeTyped + TypePath + GetTypeRegistration,
 {
     fn get_type_registration() -> TypeRegistration {
-        let mut registration = TypeRegistration::of::<Self>();
-        registration.register_type_data::<ReflectFromPtr, Self>();
-        registration.register_type_data::<ReflectFromReflect, Self>();
-        registration
+        TypeRegistration::of::<Self>()
+            .register_type_data::<ReflectFromPtr, Self>()
+            .register_type_data::<ReflectFromReflect, Self>()
     }
 }
 

--- a/crates/bevy_reflect/src/impls/core/panic.rs
+++ b/crates/bevy_reflect/src/impls/core/panic.rs
@@ -149,10 +149,9 @@ impl Typed for &'static Location<'static> {
 
 impl GetTypeRegistration for &'static Location<'static> {
     fn get_type_registration() -> TypeRegistration {
-        let mut registration = TypeRegistration::of::<Self>();
-        registration.register_type_data::<ReflectFromPtr, Self>();
-        registration.register_type_data::<ReflectFromReflect, Self>();
-        registration
+        TypeRegistration::of::<Self>()
+            .register_type_data::<ReflectFromPtr, Self>()
+            .register_type_data::<ReflectFromReflect, Self>()
     }
 }
 

--- a/crates/bevy_reflect/src/impls/core/primitives.rs
+++ b/crates/bevy_reflect/src/impls/core/primitives.rs
@@ -443,11 +443,10 @@ impl Typed for &'static str {
 
 impl GetTypeRegistration for &'static str {
     fn get_type_registration() -> TypeRegistration {
-        let mut registration = TypeRegistration::of::<Self>();
-        registration.register_type_data::<ReflectFromPtr, Self>();
-        registration.register_type_data::<ReflectFromReflect, Self>();
-        registration.register_type_data::<ReflectSerialize, Self>();
-        registration
+        TypeRegistration::of::<Self>()
+            .register_type_data::<ReflectFromPtr, Self>()
+            .register_type_data::<ReflectFromReflect, Self>()
+            .register_type_data::<ReflectSerialize, Self>()
     }
 }
 

--- a/crates/bevy_reflect/src/impls/core/sync.rs
+++ b/crates/bevy_reflect/src/impls/core/sync.rs
@@ -22,17 +22,16 @@ macro_rules! impl_reflect_for_atomic {
 
             impl GetTypeRegistration for $ty {
                 fn get_type_registration() -> TypeRegistration {
-                    let mut registration = TypeRegistration::of::<Self>();
-                    registration.register_type_data::<ReflectFromPtr, Self>();
-                    registration.register_type_data::<ReflectFromReflect, Self>();
-                    registration.register_type_data::<ReflectDefault, Self>();
+                    let registration = TypeRegistration::of::<Self>()
+                        .register_type_data::<ReflectFromPtr, Self>()
+                        .register_type_data::<ReflectFromReflect, Self>()
+                        .register_type_data::<ReflectDefault, Self>();
 
                     // Serde only supports atomic types when the "std" feature is enabled
                     #[cfg(feature = "std")]
-                    {
-                        registration.register_type_data::<crate::type_registry::ReflectSerialize, Self>();
-                        registration.register_type_data::<crate::type_registry::ReflectDeserialize, Self>();
-                    }
+                    let registration = registration
+                        .register_type_data::<crate::type_registry::ReflectSerialize, Self>()
+                        .register_type_data::<crate::type_registry::ReflectDeserialize, Self>();
 
                     registration
                 }

--- a/crates/bevy_reflect/src/impls/indexmap.rs
+++ b/crates/bevy_reflect/src/impls/indexmap.rs
@@ -265,10 +265,9 @@ where
     S: TypePath + BuildHasher + Send + Sync + Default,
 {
     fn get_type_registration() -> TypeRegistration {
-        let mut registration = TypeRegistration::of::<Self>();
-        registration.register_type_data::<ReflectFromPtr, Self>();
-        registration.register_type_data::<ReflectFromReflect, Self>();
-        registration
+        TypeRegistration::of::<Self>()
+            .register_type_data::<ReflectFromPtr, Self>()
+            .register_type_data::<ReflectFromReflect, Self>()
     }
 
     fn register_type_dependencies(registry: &mut TypeRegistry) {
@@ -490,9 +489,7 @@ where
     S: TypePath + BuildHasher + Default + Send + Sync,
 {
     fn get_type_registration() -> TypeRegistration {
-        let mut registration = TypeRegistration::of::<Self>();
-        registration.register_type_data::<ReflectFromPtr, Self>();
-        registration
+        TypeRegistration::of::<Self>().register_type_data::<ReflectFromPtr, Self>()
     }
 }
 

--- a/crates/bevy_reflect/src/impls/macros/list.rs
+++ b/crates/bevy_reflect/src/impls/macros/list.rs
@@ -158,10 +158,9 @@ macro_rules! impl_reflect_for_veclike {
                 for $ty
             {
                 fn get_type_registration() -> $crate::type_registry::TypeRegistration {
-                    let mut registration = $crate::type_registry::TypeRegistration::of::<$ty>();
-                    registration.register_type_data::<$crate::type_registry::ReflectFromPtr, $ty>();
-                    registration.register_type_data::<$crate::from_reflect::ReflectFromReflect, $ty>();
-                    registration
+                    $crate::type_registry::TypeRegistration::of::<$ty>()
+                        .register_type_data::<$crate::type_registry::ReflectFromPtr, $ty>()
+                        .register_type_data::<$crate::from_reflect::ReflectFromReflect, $ty>()
                 }
 
                 fn register_type_dependencies(registry: &mut $crate::type_registry::TypeRegistry) {

--- a/crates/bevy_reflect/src/impls/macros/map.rs
+++ b/crates/bevy_reflect/src/impls/macros/map.rs
@@ -201,10 +201,9 @@ macro_rules! impl_reflect_for_hashmap {
                 S: $crate::type_path::TypePath + core::hash::BuildHasher + Default + Send + Sync + Default,
             {
                 fn get_type_registration() -> $crate::type_registry::TypeRegistration {
-                    let mut registration = $crate::type_registry::TypeRegistration::of::<Self>();
-                    registration.register_type_data::<$crate::type_registry::ReflectFromPtr, Self>();
-                    registration.register_type_data::<$crate::from_reflect::ReflectFromReflect, Self>();
-                    registration
+                    $crate::type_registry::TypeRegistration::of::<Self>()
+                        .register_type_data::<$crate::type_registry::ReflectFromPtr, Self>()
+                        .register_type_data::<$crate::from_reflect::ReflectFromReflect, Self>()
                 }
 
                 fn register_type_dependencies(registry: &mut $crate::type_registry::TypeRegistry) {

--- a/crates/bevy_reflect/src/impls/macros/set.rs
+++ b/crates/bevy_reflect/src/impls/macros/set.rs
@@ -164,10 +164,9 @@ macro_rules! impl_reflect_for_hashset {
                 S: $crate::type_path::TypePath + core::hash::BuildHasher + Default + Send + Sync + Default,
             {
                 fn get_type_registration() -> $crate::type_registry::TypeRegistration {
-                    let mut registration = $crate::type_registry::TypeRegistration::of::<Self>();
-                    registration.register_type_data::<$crate::type_registry::ReflectFromPtr, Self>();
-                    registration.register_type_data::<$crate::from_reflect::ReflectFromReflect, Self>();
-                    registration
+                    $crate::type_registry::TypeRegistration::of::<Self>()
+                        .register_type_data::<$crate::type_registry::ReflectFromPtr, Self>()
+                        .register_type_data::<$crate::from_reflect::ReflectFromReflect, Self>()
                 }
 
                 fn register_type_dependencies(registry: &mut $crate::type_registry::TypeRegistry) {

--- a/crates/bevy_reflect/src/impls/smallvec.rs
+++ b/crates/bevy_reflect/src/impls/smallvec.rs
@@ -229,9 +229,8 @@ where
     T::Item: FromReflect + MaybeTyped + TypePath,
 {
     fn get_type_registration() -> TypeRegistration {
-        let mut registration = TypeRegistration::of::<SmallVec<T>>();
-        registration.register_type_data::<ReflectFromPtr, Self>();
-        registration
+        let registration = TypeRegistration::of::<SmallVec<T>>();
+        registration.register_type_data::<ReflectFromPtr, Self>()
     }
 }
 

--- a/crates/bevy_reflect/src/impls/std/path.rs
+++ b/crates/bevy_reflect/src/impls/std/path.rs
@@ -155,10 +155,9 @@ impl Typed for &'static Path {
 
 impl GetTypeRegistration for &'static Path {
     fn get_type_registration() -> TypeRegistration {
-        let mut registration = TypeRegistration::of::<Self>();
-        registration.register_type_data::<ReflectFromPtr, Self>();
-        registration.register_type_data::<ReflectFromReflect, Self>();
-        registration
+        TypeRegistration::of::<Self>()
+            .register_type_data::<ReflectFromPtr, Self>()
+            .register_type_data::<ReflectFromReflect, Self>()
     }
 }
 
@@ -306,12 +305,11 @@ impl FromReflect for Cow<'static, Path> {
 
 impl GetTypeRegistration for Cow<'static, Path> {
     fn get_type_registration() -> TypeRegistration {
-        let mut registration = TypeRegistration::of::<Self>();
-        registration.register_type_data::<ReflectDeserialize, Self>();
-        registration.register_type_data::<ReflectFromPtr, Self>();
-        registration.register_type_data::<ReflectSerialize, Self>();
-        registration.register_type_data::<ReflectFromReflect, Self>();
-        registration
+        TypeRegistration::of::<Self>()
+            .register_type_data::<ReflectDeserialize, Self>()
+            .register_type_data::<ReflectFromPtr, Self>()
+            .register_type_data::<ReflectSerialize, Self>()
+            .register_type_data::<ReflectFromReflect, Self>()
     }
 }
 

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -4124,9 +4124,9 @@ bevy_reflect::tests::Test {
 
             impl TypeData for ReflectA {
                 fn on_insert(&self) -> Option<OnInsertTypeData> {
-                    Some(|mut registration| {
+                    Some(OnInsertTypeData::new(|mut registration| {
                         registration.insert_data(ReflectB);
-                    })
+                    }))
                 }
             }
 

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -378,8 +378,8 @@
 //! ```
 //!
 //! The generated type data can be used to convert a valid `dyn Reflect` into a `dyn MyTrait`.
-//! See the [dynamic types example](https://github.com/bevyengine/bevy/blob/latest/examples/reflection/dynamic_types.rs)
-//! for more information and usage details.
+//! See the [type_data] module for details or the [dynamic types example](https://github.com/bevyengine/bevy/blob/latest/examples/reflection/type_data.rs)
+//! for additional examples.
 //!
 //! # Serialization
 //!
@@ -613,7 +613,7 @@ pub mod set;
 pub mod structs;
 pub mod tuple;
 pub mod tuple_struct;
-mod type_data;
+pub mod type_data;
 mod type_info;
 mod type_path;
 mod type_registry;
@@ -4121,18 +4121,24 @@ bevy_reflect::tests::Test {
             #[derive(Clone)]
             struct ReflectA;
 
+            impl TypeData for ReflectA {
+                fn on_insert(&self) -> Option<OnInsertTypeData> {
+                    Some(|mut registration| {
+                        registration.insert_data(ReflectB);
+                    })
+                }
+            }
+
             impl<T> CreateTypeData<T> for ReflectA {
                 fn create_type_data(_input: ()) -> Self {
                     ReflectA
-                }
-
-                fn insert_dependencies(type_registration: &mut TypeRegistration) {
-                    type_registration.insert(ReflectB);
                 }
             }
 
             #[derive(Clone)]
             struct ReflectB;
+
+            impl TypeData for ReflectB {}
 
             let mut registry = TypeRegistry::new();
             registry.register::<X>();

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -378,7 +378,8 @@
 //! ```
 //!
 //! The generated type data can be used to convert a valid `dyn Reflect` into a `dyn MyTrait`.
-//! See the [type_data] module for details or the [dynamic types example](https://github.com/bevyengine/bevy/blob/latest/examples/reflection/type_data.rs)
+//!
+//! See the [`type_data`] module for details on type data or the [dynamic types example](https://github.com/bevyengine/bevy/blob/latest/examples/reflection/type_data.rs)
 //! for additional examples.
 //!
 //! # Serialization
@@ -4135,10 +4136,8 @@ bevy_reflect::tests::Test {
                 }
             }
 
-            #[derive(Clone)]
+            #[derive(Clone, TypeData)]
             struct ReflectB;
-
-            impl TypeData for ReflectB {}
 
             let mut registry = TypeRegistry::new();
             registry.register::<X>();

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -4214,9 +4214,9 @@ bevy_reflect::tests::Test {
 
             impl TypeData for ReflectA {
                 fn on_insert(&self) -> Option<OnInsertTypeData> {
-                    Some(|mut registration| {
+                    Some(OnInsertTypeData::new(|mut registration| {
                         registration.insert_data(ReflectB);
-                    })
+                    }))
                 }
             }
 

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -378,7 +378,8 @@
 //! ```
 //!
 //! The generated type data can be used to convert a valid `dyn Reflect` into a `dyn MyTrait`.
-//! See the [type_data] module for details or the [dynamic types example](https://github.com/bevyengine/bevy/blob/latest/examples/reflection/type_data.rs)
+//!
+//! See the [`type_data`] module for details on type data or the [dynamic types example](https://github.com/bevyengine/bevy/blob/latest/examples/reflection/type_data.rs)
 //! for additional examples.
 //!
 //! # Serialization
@@ -4225,10 +4226,8 @@ bevy_reflect::tests::Test {
                 }
             }
 
-            #[derive(Clone)]
+            #[derive(Clone, TypeData)]
             struct ReflectB;
-
-            impl TypeData for ReflectB {}
 
             let mut registry = TypeRegistry::new();
             registry.register::<X>();

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -378,8 +378,8 @@
 //! ```
 //!
 //! The generated type data can be used to convert a valid `dyn Reflect` into a `dyn MyTrait`.
-//! See the [dynamic types example](https://github.com/bevyengine/bevy/blob/latest/examples/reflection/dynamic_types.rs)
-//! for more information and usage details.
+//! See the [type_data] module for details or the [dynamic types example](https://github.com/bevyengine/bevy/blob/latest/examples/reflection/type_data.rs)
+//! for additional examples.
 //!
 //! # Serialization
 //!
@@ -614,7 +614,7 @@ pub mod set;
 pub mod structs;
 pub mod tuple;
 pub mod tuple_struct;
-mod type_data;
+pub mod type_data;
 mod type_path;
 mod type_registry;
 
@@ -4100,10 +4100,10 @@ bevy_reflect::tests::Test {
     fn should_register_fully_qualified_type_data() {
         mod foo {
             pub mod bar {
-                use crate::CreateTypeData;
+                use crate::{CreateTypeData, TypeData};
 
-                #[derive(Clone)]
                 pub struct ReflectBaz;
+                impl TypeData for ReflectBaz {}
 
                 impl<T> CreateTypeData<T> for ReflectBaz {
                     fn create_type_data(_: ()) -> Self {
@@ -4211,18 +4211,24 @@ bevy_reflect::tests::Test {
             #[derive(Clone)]
             struct ReflectA;
 
+            impl TypeData for ReflectA {
+                fn on_insert(&self) -> Option<OnInsertTypeData> {
+                    Some(|mut registration| {
+                        registration.insert_data(ReflectB);
+                    })
+                }
+            }
+
             impl<T> CreateTypeData<T> for ReflectA {
                 fn create_type_data(_input: ()) -> Self {
                     ReflectA
-                }
-
-                fn insert_dependencies(type_registration: &mut TypeRegistration) {
-                    type_registration.insert(ReflectB);
                 }
             }
 
             #[derive(Clone)]
             struct ReflectB;
+
+            impl TypeData for ReflectB {}
 
             let mut registry = TypeRegistry::new();
             registry.register::<X>();

--- a/crates/bevy_reflect/src/serde/de/deserialize_with_registry.rs
+++ b/crates/bevy_reflect/src/serde/de/deserialize_with_registry.rs
@@ -1,5 +1,5 @@
 use crate::serde::de::error_utils::make_custom_error;
-use crate::{CreateTypeData, PartialReflect, TypeRegistry};
+use crate::{CreateTypeData, PartialReflect, TypeData, TypeRegistry};
 use alloc::boxed::Box;
 use serde::Deserializer;
 
@@ -73,6 +73,8 @@ impl ReflectDeserializeWithRegistry {
         (self.deserialize)(&mut erased, registry).map_err(make_custom_error)
     }
 }
+
+impl TypeData for ReflectDeserializeWithRegistry {}
 
 impl<T: PartialReflect + for<'de> DeserializeWithRegistry<'de>> CreateTypeData<T>
     for ReflectDeserializeWithRegistry

--- a/crates/bevy_reflect/src/serde/de/deserialize_with_registry.rs
+++ b/crates/bevy_reflect/src/serde/de/deserialize_with_registry.rs
@@ -51,7 +51,7 @@ pub trait DeserializeWithRegistry<'de>: Sized {
 }
 
 /// Type data used to deserialize a [`PartialReflect`] type with a custom [`DeserializeWithRegistry`] implementation.
-#[derive(Clone)]
+#[derive(Clone, TypeData)]
 pub struct ReflectDeserializeWithRegistry {
     deserialize: fn(
         deserializer: &mut dyn erased_serde::Deserializer,
@@ -73,8 +73,6 @@ impl ReflectDeserializeWithRegistry {
         (self.deserialize)(&mut erased, registry).map_err(make_custom_error)
     }
 }
-
-impl TypeData for ReflectDeserializeWithRegistry {}
 
 impl<T: PartialReflect + for<'de> DeserializeWithRegistry<'de>> CreateTypeData<T>
     for ReflectDeserializeWithRegistry

--- a/crates/bevy_reflect/src/serde/de/processor.rs
+++ b/crates/bevy_reflect/src/serde/de/processor.rs
@@ -62,11 +62,7 @@ use alloc::boxed::Box;
 /// # }
 /// #
 /// # struct ReflectHandle;
-/// # impl TypeData for ReflectHandle {
-/// #     fn clone_type_data(&self) -> Box<dyn TypeData> {
-/// #         unimplemented!()
-/// #     }
-/// # }
+/// # impl TypeData for ReflectHandle {}
 /// # impl ReflectHandle {
 /// #     fn asset_type_id(&self) {
 /// #         unimplemented!()

--- a/crates/bevy_reflect/src/serde/ser/processor.rs
+++ b/crates/bevy_reflect/src/serde/ser/processor.rs
@@ -53,11 +53,7 @@ use crate::{PartialReflect, TypeRegistry};
 /// # struct Mesh;
 /// #
 /// # struct ReflectHandle;
-/// # impl TypeData for ReflectHandle {
-/// #     fn clone_type_data(&self) -> Box<dyn TypeData> {
-/// #         unimplemented!()
-/// #     }
-/// # }
+/// # impl TypeData for ReflectHandle {}
 /// # impl ReflectHandle {
 /// #     fn downcast_handle_untyped(&self, handle: &(dyn Any + 'static)) -> Option<UntypedHandle> {
 /// #         unimplemented!()

--- a/crates/bevy_reflect/src/serde/ser/serialize_with_registry.rs
+++ b/crates/bevy_reflect/src/serde/ser/serialize_with_registry.rs
@@ -1,4 +1,4 @@
-use crate::{CreateTypeData, Reflect, TypeRegistry};
+use crate::{CreateTypeData, Reflect, TypeData, TypeRegistry};
 use alloc::boxed::Box;
 use serde::{Serialize, Serializer};
 
@@ -71,6 +71,8 @@ impl ReflectSerializeWithRegistry {
         ((self.serialize)(value, registry)).serialize(serializer)
     }
 }
+
+impl TypeData for ReflectSerializeWithRegistry {}
 
 impl<T: Reflect + SerializeWithRegistry> CreateTypeData<T> for ReflectSerializeWithRegistry {
     fn create_type_data(_input: ()) -> Self {

--- a/crates/bevy_reflect/src/serde/ser/serialize_with_registry.rs
+++ b/crates/bevy_reflect/src/serde/ser/serialize_with_registry.rs
@@ -49,7 +49,7 @@ pub trait SerializeWithRegistry {
 }
 
 /// Type data used to serialize a [`Reflect`] type with a custom [`SerializeWithRegistry`] implementation.
-#[derive(Clone)]
+#[derive(Clone, TypeData)]
 pub struct ReflectSerializeWithRegistry {
     serialize: for<'a> fn(
         value: &'a dyn Reflect,
@@ -71,8 +71,6 @@ impl ReflectSerializeWithRegistry {
         ((self.serialize)(value, registry)).serialize(serializer)
     }
 }
-
-impl TypeData for ReflectSerializeWithRegistry {}
 
 impl<T: Reflect + SerializeWithRegistry> CreateTypeData<T> for ReflectSerializeWithRegistry {
     fn create_type_data(_input: ()) -> Self {

--- a/crates/bevy_reflect/src/serde/type_data.rs
+++ b/crates/bevy_reflect/src/serde/type_data.rs
@@ -3,7 +3,7 @@ use alloc::boxed::Box;
 use bevy_platform::collections::{hash_map::Iter, HashMap};
 
 /// Contains data relevant to the automatic reflect powered (de)serialization of a type.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, TypeData)]
 pub struct SerializationData {
     skipped_fields: HashMap<usize, SkippedField>,
 }
@@ -112,8 +112,6 @@ impl SerializationData {
         self.skipped_fields.iter()
     }
 }
-
-impl TypeData for SerializationData {}
 
 /// Data needed for (de)serialization of a skipped field.
 #[derive(Debug, Clone)]

--- a/crates/bevy_reflect/src/serde/type_data.rs
+++ b/crates/bevy_reflect/src/serde/type_data.rs
@@ -1,4 +1,4 @@
-use crate::Reflect;
+use crate::{Reflect, TypeData};
 use alloc::boxed::Box;
 use bevy_platform::collections::{hash_map::Iter, HashMap};
 
@@ -112,6 +112,8 @@ impl SerializationData {
         self.skipped_fields.iter()
     }
 }
+
+impl TypeData for SerializationData {}
 
 /// Data needed for (de)serialization of a skipped field.
 #[derive(Debug, Clone)]

--- a/crates/bevy_reflect/src/std_traits.rs
+++ b/crates/bevy_reflect/src/std_traits.rs
@@ -8,7 +8,7 @@ use crate::{CreateTypeData, PartialReflect, Reflect, TypeData};
 /// A struct used to provide the default value of a type.
 ///
 /// A [`ReflectDefault`] for type `T` can be obtained via [`CreateTypeData::create_type_data`].
-#[derive(Clone)]
+#[derive(Clone, TypeData)]
 pub struct ReflectDefault {
     default: fn() -> Box<dyn Reflect>,
 }
@@ -19,8 +19,6 @@ impl ReflectDefault {
         (self.default)()
     }
 }
-
-impl TypeData for ReflectDefault {}
 
 impl<T: Reflect + Default> CreateTypeData<T> for ReflectDefault {
     fn create_type_data(_input: ()) -> Self {
@@ -33,7 +31,7 @@ impl<T: Reflect + Default> CreateTypeData<T> for ReflectDefault {
 /// A struct used to perform addition on reflected values.
 ///
 /// A [`ReflectAdd`] for type `T` can be obtained via [`CreateTypeData::create_type_data`].
-#[derive(Clone)]
+#[derive(Clone, TypeData)]
 pub struct ReflectAdd {
     /// Function pointer implementing [`ReflectAdd::add()`].
     pub add: fn(
@@ -57,8 +55,6 @@ impl ReflectAdd {
         (self.add)(a, b)
     }
 }
-
-impl TypeData for ReflectAdd {}
 
 impl<T: Reflect + Add<Output: Reflect>> CreateTypeData<T> for ReflectAdd {
     fn create_type_data(_input: ()) -> Self {
@@ -85,7 +81,7 @@ impl<T: Reflect + Add<Output: Reflect>> CreateTypeData<T> for ReflectAdd {
 /// A struct used to perform subtraction on reflected values.
 ///
 /// A [`ReflectSub`] for type `T` can be obtained via [`CreateTypeData::create_type_data`].
-#[derive(Clone)]
+#[derive(Clone, TypeData)]
 pub struct ReflectSub {
     /// Function pointer implementing [`ReflectSub::sub()`].
     pub sub: fn(
@@ -109,8 +105,6 @@ impl ReflectSub {
         (self.sub)(a, b)
     }
 }
-
-impl TypeData for ReflectSub {}
 
 impl<T: Reflect + Sub<Output: Reflect>> CreateTypeData<T> for ReflectSub {
     fn create_type_data(_input: ()) -> Self {
@@ -137,7 +131,7 @@ impl<T: Reflect + Sub<Output: Reflect>> CreateTypeData<T> for ReflectSub {
 /// A struct used to perform multiplication on reflected values.
 ///
 /// A [`ReflectMul`] for type `T` can be obtained via [`CreateTypeData::create_type_data`].
-#[derive(Clone)]
+#[derive(Clone, TypeData)]
 pub struct ReflectMul {
     /// Function pointer implementing [`ReflectMul::mul()`].
     pub mul: fn(
@@ -161,8 +155,6 @@ impl ReflectMul {
         (self.mul)(a, b)
     }
 }
-
-impl TypeData for ReflectMul {}
 
 impl<T: Reflect + Mul<Output: Reflect>> CreateTypeData<T> for ReflectMul {
     fn create_type_data(_input: ()) -> Self {
@@ -189,7 +181,7 @@ impl<T: Reflect + Mul<Output: Reflect>> CreateTypeData<T> for ReflectMul {
 /// A struct used to perform division on reflected values.
 ///
 /// A [`ReflectDiv`] for type `T` can be obtained via [`CreateTypeData::create_type_data`].
-#[derive(Clone)]
+#[derive(Clone, TypeData)]
 pub struct ReflectDiv {
     /// Function pointer implementing [`ReflectDiv::div()`].
     pub div: fn(
@@ -213,8 +205,6 @@ impl ReflectDiv {
         (self.div)(a, b)
     }
 }
-
-impl TypeData for ReflectDiv {}
 
 impl<T: Reflect + Div<Output: Reflect>> CreateTypeData<T> for ReflectDiv {
     fn create_type_data(_input: ()) -> Self {
@@ -241,7 +231,7 @@ impl<T: Reflect + Div<Output: Reflect>> CreateTypeData<T> for ReflectDiv {
 /// A struct used to perform remainder on reflected values.
 ///
 /// A [`ReflectRem`] for type `T` can be obtained via [`CreateTypeData::create_type_data`].
-#[derive(Clone)]
+#[derive(Clone, TypeData)]
 pub struct ReflectRem {
     /// Function pointer implementing [`ReflectRem::rem()`].
     pub rem: fn(
@@ -266,8 +256,6 @@ impl ReflectRem {
         (self.rem)(a, b)
     }
 }
-
-impl TypeData for ReflectRem {}
 
 impl<T: Reflect + Rem<Output: Reflect>> CreateTypeData<T> for ReflectRem {
     fn create_type_data(_input: ()) -> Self {
@@ -294,7 +282,7 @@ impl<T: Reflect + Rem<Output: Reflect>> CreateTypeData<T> for ReflectRem {
 /// A struct used to perform addition assignment on reflected values.
 ///
 /// A [`ReflectAddAssign`] for type `T` can be obtained via [`CreateTypeData::create_type_data`].
-#[derive(Clone)]
+#[derive(Clone, TypeData)]
 pub struct ReflectAddAssign {
     /// Function pointer implementing [`ReflectAddAssign::add_assign()`].
     pub add_assign: fn(
@@ -319,8 +307,6 @@ impl ReflectAddAssign {
     }
 }
 
-impl TypeData for ReflectAddAssign {}
-
 impl<T: Reflect + AddAssign> CreateTypeData<T> for ReflectAddAssign {
     fn create_type_data(_input: ()) -> Self {
         ReflectAddAssign {
@@ -342,7 +328,7 @@ impl<T: Reflect + AddAssign> CreateTypeData<T> for ReflectAddAssign {
 /// A struct used to perform subtraction assignment on reflected values.
 ///
 /// A [`ReflectSubAssign`] for type `T` can be obtained via [`CreateTypeData::create_type_data`].
-#[derive(Clone)]
+#[derive(Clone, TypeData)]
 pub struct ReflectSubAssign {
     /// Function pointer implementing [`ReflectSubAssign::sub_assign()`].
     pub sub_assign: fn(
@@ -367,8 +353,6 @@ impl ReflectSubAssign {
     }
 }
 
-impl TypeData for ReflectSubAssign {}
-
 impl<T: Reflect + SubAssign> CreateTypeData<T> for ReflectSubAssign {
     fn create_type_data(_input: ()) -> Self {
         ReflectSubAssign {
@@ -390,7 +374,7 @@ impl<T: Reflect + SubAssign> CreateTypeData<T> for ReflectSubAssign {
 /// A struct used to perform multiplication assignment on reflected values.
 ///
 /// A [`ReflectMulAssign`] for type `T` can be obtained via [`CreateTypeData::create_type_data`].
-#[derive(Clone)]
+#[derive(Clone, TypeData)]
 pub struct ReflectMulAssign {
     /// Function pointer implementing [`ReflectMulAssign::mul_assign()`].
     pub mul_assign: fn(
@@ -415,8 +399,6 @@ impl ReflectMulAssign {
     }
 }
 
-impl TypeData for ReflectMulAssign {}
-
 impl<T: Reflect + MulAssign> CreateTypeData<T> for ReflectMulAssign {
     fn create_type_data(_input: ()) -> Self {
         ReflectMulAssign {
@@ -438,7 +420,7 @@ impl<T: Reflect + MulAssign> CreateTypeData<T> for ReflectMulAssign {
 /// A struct used to perform division assignment on reflected values.
 ///
 /// A [`ReflectDivAssign`] for type `T` can be obtained via [`CreateTypeData::create_type_data`].
-#[derive(Clone)]
+#[derive(Clone, TypeData)]
 pub struct ReflectDivAssign {
     /// Function pointer implementing [`ReflectDivAssign::div_assign()`].
     pub div_assign: fn(
@@ -463,8 +445,6 @@ impl ReflectDivAssign {
     }
 }
 
-impl TypeData for ReflectDivAssign {}
-
 impl<T: Reflect + DivAssign> CreateTypeData<T> for ReflectDivAssign {
     fn create_type_data(_input: ()) -> Self {
         ReflectDivAssign {
@@ -486,7 +466,7 @@ impl<T: Reflect + DivAssign> CreateTypeData<T> for ReflectDivAssign {
 /// A struct used to perform remainder assignment on reflected values.
 ///
 /// A [`ReflectRemAssign`] for type `T` can be obtained via [`CreateTypeData::create_type_data`].
-#[derive(Clone)]
+#[derive(Clone, TypeData)]
 pub struct ReflectRemAssign {
     /// Function pointer implementing [`ReflectRemAssign::rem_assign()`].
     pub rem_assign: fn(
@@ -510,8 +490,6 @@ impl ReflectRemAssign {
         (self.rem_assign)(a, b)
     }
 }
-
-impl TypeData for ReflectRemAssign {}
 
 impl<T: Reflect + RemAssign> CreateTypeData<T> for ReflectRemAssign {
     fn create_type_data(_input: ()) -> Self {

--- a/crates/bevy_reflect/src/std_traits.rs
+++ b/crates/bevy_reflect/src/std_traits.rs
@@ -3,7 +3,7 @@
 use alloc::boxed::Box;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Rem, RemAssign, Sub, SubAssign};
 
-use crate::{CreateTypeData, PartialReflect, Reflect};
+use crate::{CreateTypeData, PartialReflect, Reflect, TypeData};
 
 /// A struct used to provide the default value of a type.
 ///
@@ -19,6 +19,8 @@ impl ReflectDefault {
         (self.default)()
     }
 }
+
+impl TypeData for ReflectDefault {}
 
 impl<T: Reflect + Default> CreateTypeData<T> for ReflectDefault {
     fn create_type_data(_input: ()) -> Self {
@@ -55,6 +57,8 @@ impl ReflectAdd {
         (self.add)(a, b)
     }
 }
+
+impl TypeData for ReflectAdd {}
 
 impl<T: Reflect + Add<Output: Reflect>> CreateTypeData<T> for ReflectAdd {
     fn create_type_data(_input: ()) -> Self {
@@ -106,6 +110,8 @@ impl ReflectSub {
     }
 }
 
+impl TypeData for ReflectSub {}
+
 impl<T: Reflect + Sub<Output: Reflect>> CreateTypeData<T> for ReflectSub {
     fn create_type_data(_input: ()) -> Self {
         ReflectSub {
@@ -156,6 +162,8 @@ impl ReflectMul {
     }
 }
 
+impl TypeData for ReflectMul {}
+
 impl<T: Reflect + Mul<Output: Reflect>> CreateTypeData<T> for ReflectMul {
     fn create_type_data(_input: ()) -> Self {
         ReflectMul {
@@ -205,6 +213,8 @@ impl ReflectDiv {
         (self.div)(a, b)
     }
 }
+
+impl TypeData for ReflectDiv {}
 
 impl<T: Reflect + Div<Output: Reflect>> CreateTypeData<T> for ReflectDiv {
     fn create_type_data(_input: ()) -> Self {
@@ -257,6 +267,8 @@ impl ReflectRem {
     }
 }
 
+impl TypeData for ReflectRem {}
+
 impl<T: Reflect + Rem<Output: Reflect>> CreateTypeData<T> for ReflectRem {
     fn create_type_data(_input: ()) -> Self {
         ReflectRem {
@@ -307,6 +319,8 @@ impl ReflectAddAssign {
     }
 }
 
+impl TypeData for ReflectAddAssign {}
+
 impl<T: Reflect + AddAssign> CreateTypeData<T> for ReflectAddAssign {
     fn create_type_data(_input: ()) -> Self {
         ReflectAddAssign {
@@ -352,6 +366,8 @@ impl ReflectSubAssign {
         (self.sub_assign)(a, b)
     }
 }
+
+impl TypeData for ReflectSubAssign {}
 
 impl<T: Reflect + SubAssign> CreateTypeData<T> for ReflectSubAssign {
     fn create_type_data(_input: ()) -> Self {
@@ -399,6 +415,8 @@ impl ReflectMulAssign {
     }
 }
 
+impl TypeData for ReflectMulAssign {}
+
 impl<T: Reflect + MulAssign> CreateTypeData<T> for ReflectMulAssign {
     fn create_type_data(_input: ()) -> Self {
         ReflectMulAssign {
@@ -445,6 +463,8 @@ impl ReflectDivAssign {
     }
 }
 
+impl TypeData for ReflectDivAssign {}
+
 impl<T: Reflect + DivAssign> CreateTypeData<T> for ReflectDivAssign {
     fn create_type_data(_input: ()) -> Self {
         ReflectDivAssign {
@@ -490,6 +510,8 @@ impl ReflectRemAssign {
         (self.rem_assign)(a, b)
     }
 }
+
+impl TypeData for ReflectRemAssign {}
 
 impl<T: Reflect + RemAssign> CreateTypeData<T> for ReflectRemAssign {
     fn create_type_data(_input: ()) -> Self {

--- a/crates/bevy_reflect/src/type_data.rs
+++ b/crates/bevy_reflect/src/type_data.rs
@@ -310,7 +310,7 @@ pub trait CreateTypeData<T, Input = ()>: TypeData {
 mod tests {
     use super::*;
     use crate as bevy_reflect;
-    use crate::{Reflect, TypeRegistration};
+    use crate::{Reflect, TypeData, TypeRegistration};
     use core::any::TypeId;
     use core::marker::PhantomData;
 
@@ -328,8 +328,8 @@ mod tests {
             }
         }
 
+        #[derive(TypeData)]
         struct ReflectB;
-        impl TypeData for ReflectB {}
 
         let registration = TypeRegistration::of::<Foo>().insert_data(ReflectA);
         assert!(registration.contains::<ReflectA>());
@@ -391,8 +391,8 @@ mod tests {
             }
         }
 
+        #[derive(TypeData)]
         struct ReflectB;
-        impl TypeData for ReflectB {}
 
         let mut registry = TypeRegistry::empty();
         registry.register::<Foo>();
@@ -574,8 +574,8 @@ mod tests {
         #[derive(Reflect)]
         struct Bar;
 
+        #[derive(TypeData)]
         struct ReflectA;
-        impl TypeData for ReflectA {}
 
         impl<T> CreateTypeData<T> for ReflectA {
             fn create_type_data(_: ()) -> Self {
@@ -631,8 +631,8 @@ mod tests {
         #[derive(Reflect)]
         struct Bar;
 
+        #[derive(TypeData)]
         struct ReflectA;
-        impl TypeData for ReflectA {}
 
         impl<T> CreateTypeData<T> for ReflectA {
             fn create_type_data(_: ()) -> Self {

--- a/crates/bevy_reflect/src/type_data.rs
+++ b/crates/bevy_reflect/src/type_data.rs
@@ -1,46 +1,191 @@
-use ::alloc::boxed::Box;
-use bevy_reflect::TypeRegistration;
+//! Type data for type registrations.
+//!
+//! Type data is extra metadata that can be added to a type's [`TypeRegistration`].
+//! Most often this is used to provide information about a type's trait implementation dynamically,
+//! but it may be used for other things such as specifying configuration values, opt-ins, and more.
+//!
+//! # Manual Type Data Creation
+//!
+//! Any type can be used as type data so long as it implements [`TypeData`].
+//! The following code demonstrates how we might define type data that marks a type as "debuggable"
+//! (note that this would probably be better handled through [custom attributes],
+//! so this is just for demonstration purposes).
+//!
+//! It's customary to prefix all type data with `Reflect` as this allows it to be used with
+//! the [derive macro](derive@crate::Reflect).
+//!
+//! ```rust
+//! # use bevy_reflect::TypeData;
+//! struct ReflectDebuggable;
+//! impl TypeData for ReflectDebuggable {}
+//!
+//! ```
+//!
+//! We can then register our type data on any type we want:
+//!
+//! ```
+//! # use bevy_reflect::{TypeData, TypeRegistration, TypeRegistry};
+//! # struct ReflectDebuggable;
+//! # impl TypeData for ReflectDebuggable {}
+//! # let mut registry = TypeRegistry::empty();
+//! let registration = TypeRegistration::of::<String>()
+//!     .insert_data(ReflectDebuggable);
+//! registry.add_registration(registration);
+//! ```
+//!
+//! ## Using `CreateTypeData`
+//!
+//! In order to be compatible with [`TypeRegistry::register_type_data`],
+//! we will also want to implement [`CreateTypeData`] for our struct.
+//! This is usually done through a blanket implementation,
+//! and allows us to add other requirements for usage.
+//! For example, we can adjust out `ReflectDebuggable` to actually make use of [`Debug`].
+//!
+//! ```
+//! # use core::fmt::Debug;
+//! # use core::any::TypeId;
+//! # use bevy_reflect::{CreateTypeData, Reflect, TypeData, TypeRegistration, TypeRegistry};
+//! struct ReflectDebuggable {
+//!   debug: fn(&dyn Reflect) -> String,
+//! }
+//! impl TypeData for ReflectDebuggable {}
+//!
+//! impl ReflectDebuggable {
+//!   // Helper method for calling our `debug` function.
+//!   fn debug<T: Reflect>(&self, value: &T) -> String {
+//!     (self.debug)(value)
+//!   }
+//! }
+//!
+//! impl<T: Reflect + Debug> CreateTypeData<T> for ReflectDebuggable {
+//!   fn create_type_data(input: ()) -> Self {
+//!     Self {
+//!       debug: |value| {
+//!         let value = value .downcast_ref::<T>().unwrap();
+//!         format!("{:?}", value)
+//!       }
+//!     }
+//!   }
+//! }
+//!
+//! # let mut registry = TypeRegistry::empty();
+//! # registry.register::<Vec<i32>>();
+//! // ...
+//!
+//! registry.register_type_data::<Vec<i32>, ReflectDebuggable>();
+//! let data = registry.get_type_data::<ReflectDebuggable>(TypeId::of::<Vec<i32>>()).unwrap();
+//! assert_eq!(data.debug(&vec![1, 2, 3]), "[1, 2, 3]");
+//! ```
+//!
+//! [`CreateTypeData`] can also be created with input if needed.
+//! Here, we didn't need input so we used the default input type of `()`.
+//!
+//! # Automatic Trait Reflection
+//!
+//! Because it's so commonplace to want to transform trait implementations into type data,
+//! this crate provides a macro for doing just that called [`reflect_trait`].
+//!
+//! It can be used on any [dyn-compatible] trait and generates a `Reflect`-prefixed type data struct
+//! that allows a reflected type to be cast into its trait object.
+//!
+//! ```
+//! # use core::any::TypeId;
+//! # use bevy_reflect::{Reflect, TypeRegistry, reflect_trait};
+//! // This will generate a type data struct called `ReflectShout`.
+//! #[reflect_trait]
+//! trait Shout {
+//!   fn shout(&self) -> String;
+//! }
+//!
+//! impl Shout for String {
+//!   fn shout(&self) -> String {
+//!     format!("{}!!!", self)
+//!   }
+//! }
+//!
+//! # let mut registry = TypeRegistry::new();
+//! // ...
+//!  registry.register_type_data::<String, ReflectShout>();
+//! let data = registry.get_type_data::<ReflectShout>(TypeId::of::<String>()).unwrap();
+//!
+//! let value: Box<dyn Reflect> = Box::new(String::from("Hello, world"));
+//! let obj: &dyn Shout = data.get(&*value).unwrap();
+//! assert_eq!(obj.shout(), "Hello, world!!!");
+//! ```
+//!
+//! # Callbacks
+//!
+//! Both [`TypeData`] and [`CreateTypeData`] provide mechanisms for specifying registration callbacks.
+//! The possible callbacks are:
+//!
+//! - `on_insert`: Triggered when the type data is inserted into a [`TypeRegistration`].
+//! - `on_register`: Triggered when a [`TypeRegistration`] containing the type data is registered into a [`TypeRegistry`].
+//!   If the [`TypeRegistration`] is already registered, then it will be triggered immediately.
+//!
+//! Callbacks are defined on both traits to provide as much flexibility as possible.
+//! The callbacks on [`TypeData`] are always run and are intrinsic to the type itself.
+//! Define your callback here if it doesn't rely on knowledge of the type it's being registered on.
+//! The callbacks also have access to `&self`, which allows function pointers to be stored on the type data
+//! and returned by these methods.
+//!
+//! The callbacks on [`CreateTypeData`] are associated functions that have access to the type they're
+//! being registered on.
+//! Note that these callbacks are only invoked when registered directly on a [`TypeRegistration`] or [`TypeRegistry`].
+//! Calling [`CreateTypeData::create_type_data`] and inserting the return value will result in these
+//! callbacks not being triggered.
+//!
+//! [`reflect_trait`]: bevy_reflect_derive::reflect_trait
+//! [dyn-compatible]: https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility
+
+use crate::{TypeRegistration, TypeRegistrationMut, TypeRegistry};
 use downcast_rs::{impl_downcast, Downcast};
+
+/// Type alias representing the callback function for when [`TypeData`] is inserted into a [`TypeRegistration`].
+pub type OnInsertTypeData = fn(registration: TypeRegistrationMut<'_>);
+
+/// Type alias representing the callback function for when a [`TypeRegistration`] is registered into a [`TypeRegistry`].
+pub type OnRegisterTypeData = fn(registry: &mut TypeRegistry);
 
 /// A trait for representing type metadata.
 ///
 /// Type data can be registered to the [`TypeRegistry`] and stored on a type's [`TypeRegistration`].
 ///
 /// While type data is often generated using the [`#[reflect_trait]`](crate::reflect_trait) macro,
-/// almost any type that implements [`Clone`] can be considered "type data".
-/// This is because it has a blanket implementation over all `T` where `T: Clone + Send + Sync + 'static`.
+/// any type that implements this trait can be considered "type data".
 ///
-/// For creating your own type data, see the [`CreateTypeData`] trait.
+/// For creating your own type data generically or based on a specific type,
+/// see the [`CreateTypeData`] trait.
 ///
-/// See the [crate-level documentation] for more information on type data and type registration.
+/// See the [module-level documentation] for more information on type data.
 ///
 /// [`TypeRegistry`]: crate::TypeRegistry
 /// [`TypeRegistration`]: crate::TypeRegistration
-/// [crate-level documentation]: crate
+/// [module-level documentation]: crate::type_data
 pub trait TypeData: Downcast + Send + Sync {
-    /// Creates a type-erased clone of `self`.
-    fn clone_type_data(&self) -> Box<dyn TypeData>;
+    /// Optional callback for when this type data is inserted into a [`TypeRegistration`].
+    fn on_insert(&self) -> Option<OnInsertTypeData> {
+        None
+    }
+
+    /// Optional callback for when the [`TypeRegistration`] this type data belongs to is
+    /// registered into a [`TypeRegistry`].
+    ///
+    /// Note that if this type data is inserted into a [`TypeRegistration`] that already belongs to a [`TypeRegistry`],
+    /// then this should trigger immediately.
+    fn on_register(&self) -> Option<OnRegisterTypeData> {
+        None
+    }
 }
 impl_downcast!(TypeData);
 
-impl<T: 'static + Send + Sync> TypeData for T
-where
-    T: Clone,
-{
-    fn clone_type_data(&self) -> Box<dyn TypeData> {
-        Box::new(self.clone())
-    }
-}
-
 /// A trait for creating [`TypeData`].
 ///
-/// Normally any type that is `Clone + Send + Sync + 'static` can be used as type data
-/// and inserted into a [`TypeRegistration`] using [`TypeRegistration::insert`]
-/// However, only types that implement this trait may be registered using [`TypeRegistry::register_type_data`],
-/// [`TypeRegistry::register_type_data_with`], or via the `#[reflect(MyTrait)]` attribute with the [`Reflect` derive macro].
+/// Normally any type that implements [`TypeData`] can be inserted into a [`TypeRegistration`] using [`TypeRegistration::insert_data`].
+/// However, only types that implement this trait may be registered using [`TypeRegistration::register_type_data`],
+/// [`TypeRegistration::register_type_data_with`], or via the `#[reflect(MyTrait)]` attribute with the [`Reflect` derive macro].
 ///
 /// Note that in order to work with the `#[reflect(MyTrait)]` attribute,
-/// implementors must be named with the `Reflect` prefix (e.g. `ReflectMyTrait`).
+/// implementors must be named with the `Reflect` prefix (e.g., `ReflectMyTrait`).
 ///
 /// # Input
 ///
@@ -48,7 +193,7 @@ where
 /// (the `Input` type parameter defaults to `()`).
 ///
 /// However, implementors may choose to implement this trait with other input types.
-/// As long as the implementations don't conflict, multiple different input types can be specified.
+/// As long as the implementations don't conflict, multiple different input types may be specified.
 ///
 /// # Example
 ///
@@ -140,5 +285,373 @@ pub trait CreateTypeData<T, Input = ()>: TypeData {
         unused_variables,
         reason = "default implementation does not have any dependencies"
     )]
+    #[deprecated(
+        since = "0.21.0",
+        note = "This function will be removed in a future release. Use either `CreateTypeData::on_insert` or `TypeData::on_insert` instead."
+    )]
     fn insert_dependencies(type_registration: &mut TypeRegistration) {}
+
+    /// Optional callback for when this type data is created and inserted into a [`TypeRegistration`].
+    fn on_insert() -> Option<OnInsertTypeData> {
+        None
+    }
+
+    /// Optional callback for when the [`TypeRegistration`] the created type data belongs to is
+    /// registered into a [`TypeRegistry`].
+    ///
+    /// Note that if this type data is inserted into a [`TypeRegistration`] that already belongs to a [`TypeRegistry`],
+    /// then this should trigger immediately.
+    fn on_register() -> Option<OnRegisterTypeData> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate as bevy_reflect;
+    use crate::{Reflect, TypeRegistration};
+    use core::any::TypeId;
+    use core::marker::PhantomData;
+
+    #[test]
+    fn should_register_dependencies_on_insert() {
+        #[derive(Reflect)]
+        struct Foo;
+
+        struct ReflectA;
+        impl TypeData for ReflectA {
+            fn on_insert(&self) -> Option<OnInsertTypeData> {
+                Some(|mut registration| {
+                    registration.insert_data(ReflectB);
+                })
+            }
+        }
+
+        struct ReflectB;
+        impl TypeData for ReflectB {}
+
+        let registration = TypeRegistration::of::<Foo>().insert_data(ReflectA);
+        assert!(registration.contains::<ReflectA>());
+        assert!(registration.contains::<ReflectB>());
+    }
+
+    #[test]
+    fn should_register_dependencies_on_create_type_data_insert() {
+        #[derive(Reflect)]
+        struct Foo;
+
+        struct ReflectA<T>(PhantomData<T>);
+        impl<T: Send + Sync + 'static> TypeData for ReflectA<T> {}
+
+        impl<T: Send + Sync + 'static> CreateTypeData<T> for ReflectA<T> {
+            fn create_type_data(_: ()) -> Self {
+                Self(PhantomData)
+            }
+
+            fn on_insert() -> Option<OnInsertTypeData> {
+                Some(|mut registration| {
+                    registration.register_type_data::<ReflectB<T>, _>();
+                })
+            }
+        }
+
+        struct ReflectB<T>(PhantomData<T>);
+        impl<T: Send + Sync + 'static> TypeData for ReflectB<T> {}
+
+        impl<T: Send + Sync + 'static> CreateTypeData<T> for ReflectB<T> {
+            fn create_type_data(_: ()) -> Self {
+                Self(PhantomData)
+            }
+        }
+
+        let registration = TypeRegistration::of::<Foo>().register_type_data::<ReflectA<Foo>, _>();
+        assert_eq!(registration.len(), 2);
+        assert!(registration.contains::<ReflectA<Foo>>());
+        assert!(registration.contains::<ReflectB<Foo>>());
+    }
+
+    #[test]
+    fn should_register_dependencies_on_insert_from_registry() {
+        #[derive(Reflect)]
+        struct Foo;
+
+        struct ReflectA;
+        impl TypeData for ReflectA {
+            fn on_insert(&self) -> Option<OnInsertTypeData> {
+                Some(|mut registration| {
+                    registration.insert_data(ReflectB);
+                })
+            }
+        }
+
+        impl<T> CreateTypeData<T> for ReflectA {
+            fn create_type_data(_: ()) -> Self {
+                Self
+            }
+        }
+
+        struct ReflectB;
+        impl TypeData for ReflectB {}
+
+        let mut registry = TypeRegistry::empty();
+        registry.register::<Foo>();
+        registry.register_type_data::<Foo, ReflectA>();
+
+        let registration = registry.get(TypeId::of::<Foo>()).unwrap();
+        assert!(registration.contains::<ReflectA>());
+        assert!(registration.contains::<ReflectB>());
+    }
+
+    #[test]
+    fn should_register_dependencies_on_create_type_data_insert_from_registry() {
+        #[derive(Reflect)]
+        struct Foo;
+
+        struct ReflectA<T>(PhantomData<T>);
+        impl<T: Send + Sync + 'static> TypeData for ReflectA<T> {}
+
+        impl<T: Send + Sync + 'static> CreateTypeData<T> for ReflectA<T> {
+            fn create_type_data(_: ()) -> Self {
+                Self(PhantomData)
+            }
+
+            fn on_insert() -> Option<OnInsertTypeData> {
+                Some(|mut registration| {
+                    registration.register_type_data::<ReflectB<T>, _>();
+                })
+            }
+        }
+
+        struct ReflectB<T>(PhantomData<T>);
+        impl<T: Send + Sync + 'static> TypeData for ReflectB<T> {}
+
+        impl<T: Send + Sync + 'static> CreateTypeData<T> for ReflectB<T> {
+            fn create_type_data(_: ()) -> Self {
+                Self(PhantomData)
+            }
+        }
+
+        let mut registry = TypeRegistry::empty();
+        registry.register::<Foo>();
+        registry.register_type_data::<Foo, ReflectA<Foo>>();
+
+        let registration = registry.get(TypeId::of::<Foo>()).unwrap();
+        assert!(registration.contains::<ReflectA<Foo>>());
+        assert!(registration.contains::<ReflectB<Foo>>());
+    }
+
+    #[test]
+    fn should_handle_dependency_cycles_on_insert() {
+        #[derive(Reflect)]
+        struct Foo;
+
+        struct ReflectA;
+        impl TypeData for ReflectA {
+            fn on_insert(&self) -> Option<OnInsertTypeData> {
+                Some(|mut registration| {
+                    registration.insert_data(ReflectB);
+                })
+            }
+        }
+
+        struct ReflectB;
+        impl TypeData for ReflectB {
+            fn on_insert(&self) -> Option<OnInsertTypeData> {
+                Some(|mut registration| {
+                    registration.insert_data(ReflectC);
+                })
+            }
+        }
+
+        struct ReflectC;
+        impl TypeData for ReflectC {
+            fn on_insert(&self) -> Option<OnInsertTypeData> {
+                Some(|mut registration| {
+                    registration.insert_data(ReflectA);
+                })
+            }
+        }
+
+        let registration = TypeRegistration::of::<Foo>().insert_data(ReflectA);
+        assert!(registration.contains::<ReflectA>());
+        assert!(registration.contains::<ReflectB>());
+        assert!(registration.contains::<ReflectC>());
+    }
+
+    #[test]
+    fn should_handle_dependency_cycles_on_create_type_data_insert() {
+        #[derive(Reflect)]
+        struct Foo;
+
+        struct ReflectA<T>(PhantomData<T>);
+        impl<T: Send + Sync + 'static> TypeData for ReflectA<T> {}
+
+        impl<T: Send + Sync + 'static> CreateTypeData<T> for ReflectA<T> {
+            fn create_type_data(_: ()) -> Self {
+                Self(PhantomData)
+            }
+
+            fn on_insert() -> Option<OnInsertTypeData> {
+                Some(|mut registration| {
+                    registration.register_type_data::<ReflectB<T>, _>();
+                })
+            }
+        }
+
+        struct ReflectB<T>(PhantomData<T>);
+        impl<T: Send + Sync + 'static> TypeData for ReflectB<T> {}
+
+        impl<T: Send + Sync + 'static> CreateTypeData<T> for ReflectB<T> {
+            fn create_type_data(_: ()) -> Self {
+                Self(PhantomData)
+            }
+
+            fn on_insert() -> Option<OnInsertTypeData> {
+                Some(|mut registration| {
+                    registration.register_type_data::<ReflectC<T>, _>();
+                })
+            }
+        }
+
+        struct ReflectC<T>(PhantomData<T>);
+        impl<T: Send + Sync + 'static> TypeData for ReflectC<T> {}
+
+        impl<T: Send + Sync + 'static> CreateTypeData<T> for ReflectC<T> {
+            fn create_type_data(_: ()) -> Self {
+                Self(PhantomData)
+            }
+
+            fn on_insert() -> Option<OnInsertTypeData> {
+                Some(|mut registration| {
+                    registration.register_type_data::<ReflectA<T>, _>();
+                })
+            }
+        }
+
+        let registration = TypeRegistration::of::<Foo>().register_type_data::<ReflectA<Foo>, _>();
+        assert!(registration.contains::<ReflectA<Foo>>());
+        assert!(registration.contains::<ReflectB<Foo>>());
+        assert!(registration.contains::<ReflectC<Foo>>());
+    }
+
+    #[test]
+    fn should_register_dependencies_on_register() {
+        #[derive(Reflect)]
+        struct Foo;
+
+        #[derive(Reflect)]
+        struct Bar;
+
+        struct ReflectA;
+        impl TypeData for ReflectA {
+            fn on_register(&self) -> Option<OnRegisterTypeData> {
+                Some(|registry| {
+                    registry.register::<Bar>();
+                })
+            }
+        }
+
+        impl<T> CreateTypeData<T> for ReflectA {
+            fn create_type_data(_: ()) -> Self {
+                Self
+            }
+        }
+
+        let mut registry = TypeRegistry::empty();
+        registry.register::<Foo>();
+        registry.register_type_data::<Foo, ReflectA>();
+
+        assert!(registry.contains(TypeId::of::<Foo>()));
+        assert!(registry.contains(TypeId::of::<Bar>()));
+    }
+
+    #[test]
+    fn should_register_dependencies_on_create_type_data_register() {
+        #[derive(Reflect)]
+        struct Foo;
+
+        #[derive(Reflect)]
+        struct Bar;
+
+        struct ReflectA;
+        impl TypeData for ReflectA {}
+
+        impl<T> CreateTypeData<T> for ReflectA {
+            fn create_type_data(_: ()) -> Self {
+                Self
+            }
+
+            fn on_register() -> Option<OnRegisterTypeData> {
+                Some(|registry| {
+                    registry.register::<Bar>();
+                })
+            }
+        }
+
+        let mut registry = TypeRegistry::empty();
+        registry.register::<Foo>();
+        registry.register_type_data::<Foo, ReflectA>();
+
+        assert!(registry.contains(TypeId::of::<Foo>()));
+        assert!(registry.contains(TypeId::of::<Bar>()));
+    }
+
+    #[test]
+    fn should_register_dependencies_on_deferred_register() {
+        #[derive(Reflect)]
+        struct Foo;
+
+        #[derive(Reflect)]
+        struct Bar;
+
+        struct ReflectA;
+        impl TypeData for ReflectA {
+            fn on_register(&self) -> Option<OnRegisterTypeData> {
+                Some(|registry| {
+                    registry.register::<Bar>();
+                })
+            }
+        }
+
+        let registration = TypeRegistration::of::<Foo>().insert_data(ReflectA);
+
+        let mut registry = TypeRegistry::empty();
+        registry.add_registration(registration);
+
+        assert!(registry.contains(TypeId::of::<Foo>()));
+        assert!(registry.contains(TypeId::of::<Bar>()));
+    }
+
+    #[test]
+    fn should_register_dependencies_on_deferred_create_type_data_register() {
+        #[derive(Reflect)]
+        struct Foo;
+
+        #[derive(Reflect)]
+        struct Bar;
+
+        struct ReflectA;
+        impl TypeData for ReflectA {}
+
+        impl<T> CreateTypeData<T> for ReflectA {
+            fn create_type_data(_: ()) -> Self {
+                Self
+            }
+
+            fn on_register() -> Option<OnRegisterTypeData> {
+                Some(|registry| {
+                    registry.register::<Bar>();
+                })
+            }
+        }
+
+        let registration = TypeRegistration::of::<Foo>().register_type_data::<ReflectA, Foo>();
+
+        let mut registry = TypeRegistry::empty();
+        registry.add_registration(registration);
+
+        assert!(registry.contains(TypeId::of::<Foo>()));
+        assert!(registry.contains(TypeId::of::<Bar>()));
+    }
 }

--- a/crates/bevy_reflect/src/type_data.rs
+++ b/crates/bevy_reflect/src/type_data.rs
@@ -138,13 +138,87 @@
 //! [dyn-compatible]: https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility
 
 use crate::{TypeRegistration, TypeRegistrationMut, TypeRegistry};
+use alloc::boxed::Box;
 use downcast_rs::{impl_downcast, Downcast};
 
-/// Type alias representing the callback function for when [`TypeData`] is inserted into a [`TypeRegistration`].
-pub type OnInsertTypeData = fn(registration: TypeRegistrationMut<'_>);
+/// Callback object for when [`TypeData`] is inserted into a [`TypeRegistration`].
+///
+/// # Example
+///
+/// ```
+/// # use bevy_reflect::{OnInsertTypeData, TypeData, TypeRegistration};
+/// #
+/// #[derive(TypeData)]
+/// struct ReflectSomeOtherData;
+///
+/// struct ReflectSomeData;
+///
+/// impl TypeData for ReflectSomeData {
+///   fn on_insert(&self) -> Option<OnInsertTypeData> {
+///     Some(OnInsertTypeData::new(|mut registration| {
+///       registration.insert_data(ReflectSomeOtherData);
+///     }))
+///   }
+/// }
+///
+/// // ...
+/// let registration = TypeRegistration::of::<String>().insert_data(ReflectSomeData);
+/// assert!(registration.contains::<ReflectSomeOtherData>());
+/// ```
+pub struct OnInsertTypeData(Box<dyn FnOnce(TypeRegistrationMut<'_>) + Send + Sync + 'static>);
 
-/// Type alias representing the callback function for when a [`TypeRegistration`] is registered into a [`TypeRegistry`].
-pub type OnRegisterTypeData = fn(registry: &mut TypeRegistry);
+impl OnInsertTypeData {
+    /// Create a new instance of [`OnInsertTypeData`] with the given callback function.
+    pub fn new<F: FnOnce(TypeRegistrationMut<'_>) + Send + Sync + 'static>(f: F) -> Self {
+        Self(Box::new(f))
+    }
+
+    pub(crate) fn call(self, registration: TypeRegistrationMut<'_>) {
+        self.0(registration);
+    }
+}
+
+/// Callback object for when a [`TypeRegistration`] is registered into a [`TypeRegistry`].
+///
+/// # Example
+///
+/// ```
+/// # use core::any::TypeId;
+/// # use bevy_reflect::{OnRegisterTypeData, Reflect, TypeData, TypeRegistration, TypeRegistry};
+/// #
+/// #[derive(Reflect)]
+/// struct SomeType;
+///
+/// struct ReflectSomeData;
+///
+/// impl TypeData for ReflectSomeData {
+///   fn on_register(&self) -> Option<OnRegisterTypeData> {
+///     Some(OnRegisterTypeData::new(|registry| {
+///       registry.register::<SomeType>();
+///     }))
+///   }
+/// }
+///
+/// // ...
+/// let mut registry = TypeRegistry::empty();
+/// let registration = TypeRegistration::of::<String>().insert_data(ReflectSomeData);
+///
+/// assert!(!registry.contains(TypeId::of::<SomeType>()));
+/// registry.add_registration(registration);
+/// assert!(registry.contains(TypeId::of::<SomeType>()));
+/// ```
+pub struct OnRegisterTypeData(Box<dyn FnOnce(&mut TypeRegistry) + Send + Sync + 'static>);
+
+impl OnRegisterTypeData {
+    /// Create a new instance of [`OnRegisterTypeData`] with the given callback function.
+    pub fn new<F: FnOnce(&mut TypeRegistry) + Send + Sync + 'static>(f: F) -> Self {
+        Self(Box::new(f))
+    }
+
+    pub(crate) fn call(self, registry: &mut TypeRegistry) {
+        self.0(registry);
+    }
+}
 
 /// A trait for representing type metadata.
 ///
@@ -198,12 +272,13 @@ impl_downcast!(TypeData);
 /// # Example
 ///
 /// ```
-/// # use bevy_reflect::{CreateTypeData, Reflect};
+/// # use bevy_reflect::{CreateTypeData, Reflect, TypeData};
+///
 /// trait Combine {
 ///   fn combine(a: f32, b: f32) -> f32;
 /// }
 ///
-/// #[derive(Clone)]
+/// #[derive(TypeData)]
 /// struct ReflectCombine {
 ///   multiplier: f32,
 ///   additional: f32,
@@ -292,7 +367,11 @@ pub trait CreateTypeData<T, Input = ()>: TypeData {
     fn insert_dependencies(type_registration: &mut TypeRegistration) {}
 
     /// Optional callback for when this type data is created and inserted into a [`TypeRegistration`].
-    fn on_insert() -> Option<OnInsertTypeData> {
+    #[expect(
+        unused_variables,
+        reason = "default implementation does not need input"
+    )]
+    fn on_insert(input: &Input) -> Option<OnInsertTypeData> {
         None
     }
 
@@ -301,7 +380,11 @@ pub trait CreateTypeData<T, Input = ()>: TypeData {
     ///
     /// Note that if this type data is inserted into a [`TypeRegistration`] that already belongs to a [`TypeRegistry`],
     /// then this should trigger immediately.
-    fn on_register() -> Option<OnRegisterTypeData> {
+    #[expect(
+        unused_variables,
+        reason = "default implementation does not need input"
+    )]
+    fn on_register(input: &Input) -> Option<OnRegisterTypeData> {
         None
     }
 }
@@ -311,6 +394,7 @@ mod tests {
     use super::*;
     use crate as bevy_reflect;
     use crate::{Reflect, TypeData, TypeRegistration};
+    use alloc::string::String;
     use core::any::TypeId;
     use core::marker::PhantomData;
 
@@ -322,9 +406,9 @@ mod tests {
         struct ReflectA;
         impl TypeData for ReflectA {
             fn on_insert(&self) -> Option<OnInsertTypeData> {
-                Some(|mut registration| {
+                Some(OnInsertTypeData::new(|mut registration| {
                     registration.insert_data(ReflectB);
-                })
+                }))
             }
         }
 
@@ -349,10 +433,10 @@ mod tests {
                 Self(PhantomData)
             }
 
-            fn on_insert() -> Option<OnInsertTypeData> {
-                Some(|mut registration| {
+            fn on_insert(_: &()) -> Option<OnInsertTypeData> {
+                Some(OnInsertTypeData::new(|mut registration| {
                     registration.register_type_data::<ReflectB<T>, _>();
-                })
+                }))
             }
         }
 
@@ -379,9 +463,9 @@ mod tests {
         struct ReflectA;
         impl TypeData for ReflectA {
             fn on_insert(&self) -> Option<OnInsertTypeData> {
-                Some(|mut registration| {
+                Some(OnInsertTypeData::new(|mut registration| {
                     registration.insert_data(ReflectB);
-                })
+                }))
             }
         }
 
@@ -416,10 +500,10 @@ mod tests {
                 Self(PhantomData)
             }
 
-            fn on_insert() -> Option<OnInsertTypeData> {
-                Some(|mut registration| {
+            fn on_insert(_: &()) -> Option<OnInsertTypeData> {
+                Some(OnInsertTypeData::new(|mut registration| {
                     registration.register_type_data::<ReflectB<T>, _>();
-                })
+                }))
             }
         }
 
@@ -449,27 +533,27 @@ mod tests {
         struct ReflectA;
         impl TypeData for ReflectA {
             fn on_insert(&self) -> Option<OnInsertTypeData> {
-                Some(|mut registration| {
+                Some(OnInsertTypeData::new(|mut registration| {
                     registration.insert_data(ReflectB);
-                })
+                }))
             }
         }
 
         struct ReflectB;
         impl TypeData for ReflectB {
             fn on_insert(&self) -> Option<OnInsertTypeData> {
-                Some(|mut registration| {
+                Some(OnInsertTypeData::new(|mut registration| {
                     registration.insert_data(ReflectC);
-                })
+                }))
             }
         }
 
         struct ReflectC;
         impl TypeData for ReflectC {
             fn on_insert(&self) -> Option<OnInsertTypeData> {
-                Some(|mut registration| {
+                Some(OnInsertTypeData::new(|mut registration| {
                     registration.insert_data(ReflectA);
-                })
+                }))
             }
         }
 
@@ -492,10 +576,10 @@ mod tests {
                 Self(PhantomData)
             }
 
-            fn on_insert() -> Option<OnInsertTypeData> {
-                Some(|mut registration| {
+            fn on_insert(_: &()) -> Option<OnInsertTypeData> {
+                Some(OnInsertTypeData::new(|mut registration| {
                     registration.register_type_data::<ReflectB<T>, _>();
-                })
+                }))
             }
         }
 
@@ -507,10 +591,10 @@ mod tests {
                 Self(PhantomData)
             }
 
-            fn on_insert() -> Option<OnInsertTypeData> {
-                Some(|mut registration| {
+            fn on_insert(_: &()) -> Option<OnInsertTypeData> {
+                Some(OnInsertTypeData::new(|mut registration| {
                     registration.register_type_data::<ReflectC<T>, _>();
-                })
+                }))
             }
         }
 
@@ -522,10 +606,10 @@ mod tests {
                 Self(PhantomData)
             }
 
-            fn on_insert() -> Option<OnInsertTypeData> {
-                Some(|mut registration| {
+            fn on_insert(_: &()) -> Option<OnInsertTypeData> {
+                Some(OnInsertTypeData::new(|mut registration| {
                     registration.register_type_data::<ReflectA<T>, _>();
-                })
+                }))
             }
         }
 
@@ -546,9 +630,9 @@ mod tests {
         struct ReflectA;
         impl TypeData for ReflectA {
             fn on_register(&self) -> Option<OnRegisterTypeData> {
-                Some(|registry| {
+                Some(OnRegisterTypeData::new(|registry| {
                     registry.register::<Bar>();
-                })
+                }))
             }
         }
 
@@ -582,10 +666,10 @@ mod tests {
                 Self
             }
 
-            fn on_register() -> Option<OnRegisterTypeData> {
-                Some(|registry| {
+            fn on_register(_: &()) -> Option<OnRegisterTypeData> {
+                Some(OnRegisterTypeData::new(|registry| {
                     registry.register::<Bar>();
-                })
+                }))
             }
         }
 
@@ -608,9 +692,9 @@ mod tests {
         struct ReflectA;
         impl TypeData for ReflectA {
             fn on_register(&self) -> Option<OnRegisterTypeData> {
-                Some(|registry| {
+                Some(OnRegisterTypeData::new(|registry| {
                     registry.register::<Bar>();
-                })
+                }))
             }
         }
 
@@ -639,10 +723,10 @@ mod tests {
                 Self
             }
 
-            fn on_register() -> Option<OnRegisterTypeData> {
-                Some(|registry| {
+            fn on_register(_: &()) -> Option<OnRegisterTypeData> {
+                Some(OnRegisterTypeData::new(|registry| {
                     registry.register::<Bar>();
-                })
+                }))
             }
         }
 
@@ -653,5 +737,52 @@ mod tests {
 
         assert!(registry.contains(TypeId::of::<Foo>()));
         assert!(registry.contains(TypeId::of::<Bar>()));
+    }
+
+    #[test]
+    fn should_invoke_callbacks_with_input() {
+        #[derive(Reflect)]
+        struct Foo;
+
+        #[derive(TypeData)]
+        struct ReflectA;
+
+        #[derive(TypeData, PartialEq, Debug)]
+        struct InsertedData(String);
+
+        #[derive(TypeData, PartialEq, Debug)]
+        struct RegisteredData(String);
+
+        impl<T> CreateTypeData<T, String> for ReflectA {
+            fn create_type_data(_: String) -> Self {
+                Self
+            }
+
+            fn on_insert(input: &String) -> Option<OnInsertTypeData> {
+                let data = input.clone();
+                Some(OnInsertTypeData::new(move |mut registration| {
+                    registration.insert_data(InsertedData(data));
+                }))
+            }
+
+            fn on_register(input: &String) -> Option<OnRegisterTypeData> {
+                let data = input.clone();
+                Some(OnRegisterTypeData::new(move |registry| {
+                    registry.registration_scope(TypeId::of::<Foo>(), |mut registration| {
+                        registration.insert_data(RegisteredData(data));
+                    });
+                }))
+            }
+        }
+
+        let mut registry = TypeRegistry::empty();
+        registry.register::<Foo>();
+        registry.register_type_data_with::<Foo, ReflectA, _>(String::from("test"));
+
+        let data = registry.get_type_data::<InsertedData>(TypeId::of::<Foo>());
+        assert_eq!(data, Some(&InsertedData(String::from("test"))));
+
+        let data = registry.get_type_data::<RegisteredData>(TypeId::of::<Foo>());
+        assert_eq!(data, Some(&RegisteredData(String::from("test"))));
     }
 }

--- a/crates/bevy_reflect/src/type_data.rs
+++ b/crates/bevy_reflect/src/type_data.rs
@@ -18,7 +18,6 @@
 //! # use bevy_reflect::TypeData;
 //! struct ReflectDebuggable;
 //! impl TypeData for ReflectDebuggable {}
-//!
 //! ```
 //!
 //! We can then register our type data on any type we want:

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -883,12 +883,12 @@ macro_rules! type_data_insertion_methods {
 ///
 /// ```
 /// # use bevy_reflect::{TypeRegistration, std_traits::ReflectDefault, CreateTypeData};
-/// let mut registration = TypeRegistration::of::<Option<String>>();
+/// let registration = TypeRegistration::of::<Option<String>>();
 ///
 /// assert_eq!("core::option::Option<alloc::string::String>", registration.type_info().type_path());
 /// assert_eq!("Option<String>", registration.type_info().type_path_table().short_path());
 ///
-/// registration.insert_data::<ReflectDefault>(CreateTypeData::<Option<String>>::create_type_data(()));
+/// let registration = registration.insert_data::<ReflectDefault>(CreateTypeData::<Option<String>>::create_type_data(()));
 /// assert!(registration.data::<ReflectDefault>().is_some())
 /// ```
 ///
@@ -1043,12 +1043,10 @@ impl<'a> TypeRegistrationMut<'a> {
 ///
 /// A `ReflectSerialize` for type `T` can be obtained via
 /// [`CreateTypeData::create_type_data`].
-#[derive(Clone)]
+#[derive(Clone, TypeData)]
 pub struct ReflectSerialize {
     get_serializable: fn(value: &dyn Reflect) -> Serializable,
 }
-
-impl TypeData for ReflectSerialize {}
 
 impl<T: TypePath + FromReflect + erased_serde::Serialize> CreateTypeData<T> for ReflectSerialize {
     fn create_type_data(_input: ()) -> Self {
@@ -1088,7 +1086,7 @@ impl ReflectSerialize {
 ///
 /// A `ReflectDeserialize` for type `T` can be obtained via
 /// [`CreateTypeData::create_type_data`].
-#[derive(Clone)]
+#[derive(Clone, TypeData)]
 pub struct ReflectDeserialize {
     /// Function used by [`ReflectDeserialize::deserialize`] to
     /// perform deserialization.
@@ -1112,8 +1110,6 @@ impl ReflectDeserialize {
             .map_err(<<D as serde::Deserializer<'de>>::Error as serde::de::Error>::custom)
     }
 }
-
-impl TypeData for ReflectDeserialize {}
 
 impl<T: for<'a> Deserialize<'a> + Reflect> CreateTypeData<T> for ReflectDeserialize {
     fn create_type_data(_input: ()) -> Self {
@@ -1153,7 +1149,7 @@ impl<T: for<'a> Deserialize<'a> + Reflect> CreateTypeData<T> for ReflectDeserial
 ///
 /// assert_eq!(value.downcast_ref::<Reflected>().unwrap().0, "Hello world!");
 /// ```
-#[derive(Clone)]
+#[derive(Clone, TypeData)]
 pub struct ReflectFromPtr {
     type_id: TypeId,
     from_ptr: unsafe fn(Ptr) -> &dyn Reflect,
@@ -1214,8 +1210,6 @@ impl ReflectFromPtr {
         self.from_ptr_mut
     }
 }
-
-impl TypeData for ReflectFromPtr {}
 
 #[expect(
     unsafe_code,
@@ -1297,9 +1291,8 @@ mod test {
         #[derive(Reflect)]
         struct Foo;
 
-        #[derive(Clone)]
+        #[derive(Clone, TypeData)]
         struct DataA(i32);
-        impl TypeData for DataA {}
 
         let registration = TypeRegistration::of::<Foo>().insert_data(DataA(123));
 
@@ -1317,9 +1310,8 @@ mod test {
         #[derive(Reflect)]
         struct Foo;
 
-        #[derive(Clone)]
+        #[derive(Clone, TypeData)]
         struct DataA(i32);
-        impl TypeData for DataA {}
 
         let mut registration = TypeRegistration::of::<Foo>().insert_data(DataA(123));
 

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -939,7 +939,7 @@ impl TypeRegistration {
     ///
     /// [type data]: TypeData
     #[deprecated(
-        since = "0.21.0",
+        since = "0.20.0",
         note = "This method will be removed in a future release. Use `TypeRegistry::insert_data` or `TypeRegistry::register_type_data` instead."
     )]
     pub fn insert<T: TypeData>(&mut self, data: T) {
@@ -951,7 +951,7 @@ impl TypeRegistration {
     ///
     /// [type data]: TypeData
     #[deprecated(
-        since = "0.21.0",
+        since = "0.20.0",
         note = "This method will be removed in a future release. Use `TypeRegistry::contains` in conjunction with either `TypeRegistry::insert_data` or `TypeRegistry::register_type_data` instead."
     )]
     pub fn get_or_insert_data_with<T: TypeData>(&mut self, get_data: impl FnOnce() -> T) -> &mut T {

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -1,8 +1,9 @@
+use crate::type_data::{OnInsertTypeData, OnRegisterTypeData};
 use crate::{
     convert::ReflectConvert, serde::Serializable, FromReflect, Reflect, TypeData, TypeInfo,
     TypePath, Typed,
 };
-use alloc::{boxed::Box, string::String};
+use alloc::{boxed::Box, string::String, vec::Vec};
 use bevy_platform::{
     collections::{HashMap, HashSet},
     sync::{Arc, PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard},
@@ -203,7 +204,7 @@ impl TypeRegistry {
     where
         T: GetTypeRegistration,
     {
-        if self.register_internal(TypeId::of::<T>(), T::get_type_registration) {
+        if self.register_internal(TypeId::of::<T>(), T::get_type_registration, false) {
             T::register_type_dependencies(self);
         }
     }
@@ -258,7 +259,7 @@ impl TypeRegistry {
     /// Returns `true` if the registration was added and `false` if it already exists.
     pub fn add_registration(&mut self, registration: TypeRegistration) -> bool {
         let type_id = registration.type_id();
-        self.register_internal(type_id, || registration)
+        self.register_internal(type_id, || registration, false)
     }
 
     /// Registers the type described by `registration`.
@@ -271,14 +272,7 @@ impl TypeRegistry {
     /// This method will _not_ register type dependencies.
     /// Use [`register`](Self::register) to register a type with its dependencies.
     pub fn overwrite_registration(&mut self, registration: TypeRegistration) {
-        Self::update_registration_indices(
-            &registration,
-            &mut self.short_path_to_id,
-            &mut self.type_path_to_id,
-            &mut self.ambiguous_names,
-        );
-        self.registrations
-            .insert(registration.type_id(), registration);
+        self.register_internal(registration.type_id(), || registration, true);
     }
 
     /// Internal method to register a type with a given [`TypeId`] and [`TypeRegistration`].
@@ -292,18 +286,29 @@ impl TypeRegistry {
         &mut self,
         type_id: TypeId,
         get_registration: impl FnOnce() -> TypeRegistration,
+        overwrite: bool,
     ) -> bool {
-        if self.registrations.contains_key(&type_id) {
+        if !overwrite && self.registrations.contains_key(&type_id) {
             return false;
         }
-        let registration = get_registration();
+
+        let mut registration = get_registration();
+
         Self::update_registration_indices(
             &registration,
             &mut self.short_path_to_id,
             &mut self.type_path_to_id,
             &mut self.ambiguous_names,
         );
+
+        let callbacks = registration.flush_on_register_callbacks();
+
         self.registrations.insert(type_id, registration);
+
+        for callback in callbacks {
+            callback(self);
+        }
+
         true
     }
 
@@ -342,14 +347,7 @@ impl TypeRegistry {
     /// type_registry.register_type_data::<Option<String>, ReflectDeserialize>();
     /// ```
     pub fn register_type_data<T: Reflect + TypePath, D: CreateTypeData<T>>(&mut self) {
-        let data = self.get_mut(TypeId::of::<T>()).unwrap_or_else(|| {
-            panic!(
-                "attempted to call `TypeRegistry::register_type_data` for type `{T}` with data `{D}` without registering `{T}` first",
-                T = T::type_path(),
-                D = core::any::type_name::<D>(),
-            )
-        });
-        data.insert(D::create_type_data(()));
+        self.register_type_data_with::<T, D, ()>(());
     }
 
     /// Registers the type data `D` with parameter `P` for type `T`.
@@ -365,15 +363,35 @@ impl TypeRegistry {
         &mut self,
         params: P,
     ) {
-        let data = self.get_mut(TypeId::of::<T>()).unwrap_or_else(|| {
+        let registration = self.get_mut(TypeId::of::<T>()).unwrap_or_else(|| {
             panic!(
-                "attempted to call `TypeRegistry::register_type_data_with` for type `{T}` with data `{D}` and params `{P}` without registering `{T}` first",
+                "attempted to register type data `{D}` with params `{P}` for type `{T}` without registering `{T}` first",
                 T = T::type_path(),
                 D = ::core::any::type_name::<D>(),
                 P = ::core::any::type_name::<P>(),
             )
         });
-        data.insert(D::create_type_data(params));
+
+        let data = D::create_type_data(params);
+
+        let on_register = data.on_register();
+
+        registration.insert_internal(
+            TypeId::of::<D>(),
+            Box::new(data),
+            <D as CreateTypeData<T, P>>::on_insert(),
+            // Set to `None` since we already handle the `on_register` callback in this method
+            None,
+            true,
+        );
+
+        if let Some(on_register) = on_register {
+            on_register(self);
+        }
+
+        if let Some(on_register) = <D as CreateTypeData<T, P>>::on_register() {
+            on_register(self);
+        }
     }
 
     /// Registers a fallible conversion from type T to U with the reflection
@@ -398,13 +416,21 @@ impl TypeRegistry {
         U: Reflect + TypePath,
         F: Fn(T) -> Result<U, T> + Clone + Send + Sync + 'static,
     {
-        let data = self.get_mut(TypeId::of::<U>()).unwrap_or_else(|| {
+        let registration = self.get_mut(TypeId::of::<U>()).unwrap_or_else(|| {
             panic!(
                 "attempted to call `TypeRegistry::register_type_conversion` for type `{U}` without registering `{U}` first",
                 U = U::type_path(),
             )
         });
-        data.get_or_insert_data_with(ReflectConvert::default)
+
+        // We know `ReflectConvert` doesn't have any type data callbacks,
+        // so we're safe to register it directly like this
+        registration
+            .data
+            .entry(TypeId::of::<ReflectConvert>())
+            .or_insert_with(|| Box::new(ReflectConvert::default()))
+            .downcast_mut::<ReflectConvert>()
+            .expect("ReflectConvert is always registered")
             .register_type_conversion(function);
     }
 
@@ -425,13 +451,21 @@ impl TypeRegistry {
         T: Reflect + TypePath,
         U: Reflect + TypePath + From<T>,
     {
-        let data = self.get_mut(TypeId::of::<U>()).unwrap_or_else(|| {
+        let registration = self.get_mut(TypeId::of::<U>()).unwrap_or_else(|| {
             panic!(
                 "attempted to call `TypeRegistry::register_type_conversion` for type `{U}` without registering `{U}` first",
                 U = U::type_path(),
             )
         });
-        data.get_or_insert_data_with(ReflectConvert::default)
+
+        // We know `ReflectConvert` doesn't have any type data callbacks,
+        // so we're safe to register it directly like this
+        registration
+            .data
+            .entry(TypeId::of::<ReflectConvert>())
+            .or_insert_with(|| Box::new(ReflectConvert::default()))
+            .downcast_mut::<ReflectConvert>()
+            .expect("ReflectConvert is always registered")
             .register_type_conversion::<T, U, _>(|input| Ok(input.into()));
     }
 
@@ -453,8 +487,39 @@ impl TypeRegistry {
     /// the given [`TypeId`].
     ///
     /// If the specified type has not been registered, returns `None`.
+    ///
+    /// If you need to insert new type data into this [`TypeRegistration`],
+    /// use [`Self::registration_scope`] instead.
     pub fn get_mut(&mut self, type_id: TypeId) -> Option<&mut TypeRegistration> {
         self.registrations.get_mut(&type_id)
+    }
+
+    /// Provides scoped access to the [`TypeRegistration`] of the type with
+    /// the given [`TypeId`] as a [`TypeRegistrationMut`].
+    ///
+    /// This allows for [`TypeData`] to be inserted into the [`TypeRegistration`],
+    /// and for any registration callbacks associated with that type data to take effect afterwards.
+    ///
+    /// If you do not need to insert any new type data, [`Self::get_mut`] is preferred.
+    ///
+    /// Returns true if the registration was found, false otherwise.
+    pub fn registration_scope(
+        &mut self,
+        type_id: TypeId,
+        mut f: impl FnMut(TypeRegistrationMut<'_>),
+    ) -> bool {
+        let Some(registration) = self.registrations.get_mut(&type_id) else {
+            return false;
+        };
+
+        f(TypeRegistrationMut::new(registration));
+
+        let callbacks = registration.flush_on_register_callbacks();
+        for callback in callbacks {
+            callback(self);
+        }
+
+        true
     }
 
     /// Returns a reference to the [`TypeRegistration`] of the type with the
@@ -603,6 +668,206 @@ impl TypeRegistryArc {
     }
 }
 
+macro_rules! type_registration_methods {
+    ($self:ident => $registration:expr) => {
+        /// Returns the [`TypeId`] of the type.
+        #[inline]
+        pub fn type_id(&$self) -> TypeId {
+            $registration.type_info.type_id()
+        }
+
+        /// Returns a reference to the registration's [`TypeInfo`]
+        pub fn type_info(&$self) -> &'static TypeInfo {
+            $registration.type_info
+        }
+
+        /// Returns a reference to the value of type `T` in this registration's
+        /// [type data].
+        ///
+        /// Returns `None` if no such value exists.
+        ///
+        /// For a dynamic version of this method, see [`data_by_id`].
+        ///
+        /// [type data]: TypeData
+        /// [`data_by_id`]: Self::data_by_id
+        pub fn data<T: TypeData>(&$self) -> Option<&T> {
+            $registration.data
+                .get(&TypeId::of::<T>())
+                .and_then(|value| value.downcast_ref())
+        }
+
+        /// Returns a reference to the value with the given [`TypeId`] in this registration's
+        /// [type data].
+        ///
+        /// Returns `None` if no such value exists.
+        ///
+        /// For a static version of this method, see [`data`].
+        ///
+        /// [type data]: TypeData
+        /// [`data`]: Self::data
+        pub fn data_by_id(&$self, type_id: TypeId) -> Option<&dyn TypeData> {
+            $registration.data.get(&type_id).map(Deref::deref)
+        }
+
+        /// Returns a mutable reference to the value of type `T` in this registration's
+        /// [type data].
+        ///
+        /// Returns `None` if no such value exists.
+        ///
+        /// For a dynamic version of this method, see [`data_mut_by_id`].
+        ///
+        /// [type data]: TypeData
+        /// [`data_mut_by_id`]: Self::data_mut_by_id
+        pub fn data_mut<T: TypeData>(&mut $self) -> Option<&mut T> {
+            $registration.data
+                .get_mut(&TypeId::of::<T>())
+                .and_then(|value| value.downcast_mut())
+        }
+
+        /// Returns a mutable reference to the value with the given [`TypeId`] in this registration's
+        /// [type data].
+        ///
+        /// Returns `None` if no such value exists.
+        ///
+        /// For a static version of this method, see [`data_mut`].
+        ///
+        /// [type data]: TypeData
+        /// [`data_mut`]: Self::data_mut
+        pub fn data_mut_by_id(&mut $self, type_id: TypeId) -> Option<&mut dyn TypeData> {
+            $registration.data.get_mut(&type_id).map(DerefMut::deref_mut)
+        }
+
+        /// Returns true if this registration contains the given [type data].
+        ///
+        /// For a dynamic version of this method, see [`contains_by_id`].
+        ///
+        /// [type data]: TypeData
+        /// [`contains_by_id`]: Self::contains_by_id
+        pub fn contains<T: TypeData>(&$self) -> bool {
+            $registration.data.contains_key(&TypeId::of::<T>())
+        }
+
+        /// Returns true if this registration contains the given [type data] with [`TypeId`].
+        ///
+        /// For a static version of this method, see [`contains`].
+        ///
+        /// [type data]: TypeData
+        /// [`contains`]: Self::contains
+        pub fn contains_by_id(&$self, type_id: TypeId) -> bool {
+            $registration.data.contains_key(&type_id)
+        }
+
+        /// The total count of [type data] in this registration.
+        ///
+        /// [type data]: TypeData
+        pub fn len(&$self) -> usize {
+            $registration.data.len()
+        }
+
+        /// Returns true if this registration has no [type data].
+        ///
+        /// [type data]: TypeData
+        pub fn is_empty(&$self) -> bool {
+            $registration.data.is_empty()
+        }
+
+        /// Returns an iterator over all [type data] in this registration.
+        ///
+        /// The iterator yields a tuple of the [`TypeId`] and its corresponding type data.
+        ///
+        /// [type data]: TypeData
+        pub fn iter(&$self) -> impl ExactSizeIterator<Item = (TypeId, &dyn TypeData)> {
+            $registration.data.iter().map(|(id, data)| (*id, data.deref()))
+        }
+
+        /// Returns a mutable iterator over all [type data] in this registration.
+        ///
+        /// The iterator yields a tuple of the [`TypeId`] and its corresponding type data.
+        ///
+        /// [type data]: TypeData
+        pub fn iter_mut(&mut $self) -> impl ExactSizeIterator<Item = (TypeId, &mut dyn TypeData)> {
+            $registration.data
+                .iter_mut()
+                .map(|(id, data)| (*id, data.deref_mut()))
+        }
+    };
+}
+
+macro_rules! type_data_insertion_methods {
+    ($self:ident => $registration:expr; [$($mut:tt)?] $self_ty:ty => $return_ty:ty) => {
+        /// Inserts an instance of `T` into this registration's [type data] map.
+        /// If another instance of `T` was previously inserted, it is replaced.
+        ///
+        /// If this is the first time `T` is being inserted,
+        /// this method will also trigger the [`TypeData::on_insert`] callbacks for `T`,
+        /// as well as queue up its [`TypeData::on_register`] callback.
+        ///
+        /// See also [`Self::register_type_data`] for type data that can be instantiated
+        /// automatically using [`CreateTypeData`].
+        ///
+        /// [type data]: TypeData
+        pub fn insert_data<T: TypeData>($($mut)? $self: $self_ty, data: T) -> $return_ty {
+            $registration.insert_internal(TypeId::of::<T>(), Box::new(data), None, None, true);
+            $self
+        }
+
+        /// Inserts the [`TypeData`] instance of `T` created for `V`.
+        /// If another instance of `T` was previously inserted, it is replaced.
+        ///
+        /// If this is the first time `T` is being inserted,
+        /// this method will also trigger the [`TypeData::on_insert`] and [`CreateTypeData::on_insert`] callbacks for `T`,
+        /// as well as queue up its [`TypeData::on_register`] and [`CreateTypeData::on_register`] callbacks.
+        ///
+        /// To register [`TypeData`] that requires input (i.e. it doesn't take `()` as its input),
+        /// see [`Self::register_type_data_with`].
+        #[inline]
+        pub fn register_type_data<T: CreateTypeData<V>, V>($self: $self_ty) -> $return_ty {
+            $self.register_type_data_with::<T, V, ()>(())
+        }
+
+        /// Inserts the [`TypeData`] instance of `T` created for `V` with some input `I`.
+        /// If another instance of `T` was previously inserted, it is replaced.
+        ///
+        /// If this is the first time `T` is being inserted,
+        /// this method will also trigger the [`TypeData::on_insert`] and [`CreateTypeData::on_insert`] callbacks for `T`,
+        /// as well as queue up its [`TypeData::on_register`] and [`CreateTypeData::on_register`] callbacks.
+        ///
+        /// To register [`TypeData`] that doesn't require input (i.e. it expects `()`),
+        /// see [`Self::register_type_data`].
+        #[inline]
+        pub fn register_type_data_with<T: CreateTypeData<V, I>, V, I>(
+            $($mut)? $self: $self_ty,
+            input: I,
+        ) -> $return_ty {
+            let data = T::create_type_data(input);
+            let on_insert = <T as CreateTypeData<V, I>>::on_insert();
+            let on_register = <T as CreateTypeData<V, I>>::on_register();
+
+            let has_deps = on_insert.is_some() || data.on_insert().is_some();
+
+            if !$registration.insert_internal(
+                TypeId::of::<T>(),
+                Box::new(data),
+                on_insert,
+                on_register,
+                true,
+            ) {
+                return $self;
+            }
+
+            if !has_deps {
+                #[expect(
+                    deprecated,
+                    reason = "Will continue to call function until fully removed"
+                )]
+                <T as CreateTypeData<V, I>>::insert_dependencies(&mut $registration);
+            }
+
+            $self
+        }
+    };
+}
+
 /// Runtime storage for type metadata, registered into the [`TypeRegistry`].
 ///
 /// An instance of `TypeRegistration` can be created using the [`TypeRegistration::of`] method,
@@ -623,7 +888,7 @@ impl TypeRegistryArc {
 /// assert_eq!("core::option::Option<alloc::string::String>", registration.type_info().type_path());
 /// assert_eq!("Option<String>", registration.type_info().type_path_table().short_path());
 ///
-/// registration.insert::<ReflectDefault>(CreateTypeData::<Option<String>>::create_type_data(()));
+/// registration.insert_data::<ReflectDefault>(CreateTypeData::<Option<String>>::create_type_data(()));
 /// assert!(registration.data::<ReflectDefault>().is_some())
 /// ```
 ///
@@ -631,6 +896,17 @@ impl TypeRegistryArc {
 pub struct TypeRegistration {
     data: TypeIdMap<Box<dyn TypeData>>,
     type_info: &'static TypeInfo,
+    /// The `on_register` callbacks waiting to be applied.
+    ///
+    /// These are generally the ones from [`CreateTypeData::on_register`]
+    /// since the [`TypeData::on_register`] callbacks can be accessed dynamically from `data`.
+    #[expect(
+        clippy::box_collection,
+        reason = "We intentionally box the `Vec` to save 16 bytes per registration. \
+        And since these don't need to be accessed as often or in performance-sensitive code, \
+        we can spare the extra layer of indirection"
+    )]
+    pending_callbacks: Option<Box<Vec<fn(&mut TypeRegistry)>>>,
 }
 
 impl Debug for TypeRegistration {
@@ -647,18 +923,8 @@ impl TypeRegistration {
         Self {
             data: Default::default(),
             type_info: T::type_info(),
+            pending_callbacks: None,
         }
-    }
-
-    /// Returns the [`TypeId`] of the type.
-    #[inline]
-    pub fn type_id(&self) -> TypeId {
-        self.type_info.type_id()
-    }
-
-    /// Returns a reference to the registration's [`TypeInfo`]
-    pub fn type_info(&self) -> &'static TypeInfo {
-        self.type_info
     }
 
     /// Inserts an instance of `T` into this registration's [type data].
@@ -670,6 +936,10 @@ impl TypeRegistration {
     /// That will need to be done manually using [`CreateTypeData::insert_dependencies`].
     ///
     /// [type data]: TypeData
+    #[deprecated(
+        since = "0.21.0",
+        note = "This method will be removed in a future release. Use `TypeRegistry::insert_data` or `TypeRegistry::register_type_data` instead."
+    )]
     pub fn insert<T: TypeData>(&mut self, data: T) {
         self.data.insert(TypeId::of::<T>(), Box::new(data));
     }
@@ -678,159 +948,95 @@ impl TypeRegistration {
     /// exist, it will insert a new instance using `get_data` and then return it.
     ///
     /// [type data]: TypeData
+    #[deprecated(
+        since = "0.21.0",
+        note = "This method will be removed in a future release. Use `TypeRegistry::contains` in conjunction with either `TypeRegistry::insert_data` or `TypeRegistry::register_type_data` instead."
+    )]
     pub fn get_or_insert_data_with<T: TypeData>(&mut self, get_data: impl FnOnce() -> T) -> &mut T {
-        let boxed_data = self
-            .data
-            .entry(TypeId::of::<T>())
-            .or_insert_with(|| Box::new(get_data()));
-        boxed_data.downcast_mut::<T>().unwrap()
+        self.insert_internal(TypeId::of::<T>(), Box::new(get_data()), None, None, false);
+        self.data_mut::<T>().expect("data was just inserted")
     }
 
-    /// Inserts the [`TypeData`] instance of `T` created for `V`, and inserts any
-    /// [`TypeData`] dependencies for that combination of `T` and `V`.
+    /// Internal method for inserting type data.
     ///
-    /// To register [`TypeData`] that requires input (i.e. it doesn't take `()` as its input),
-    /// see [`TypeRegistration::register_type_data_with`].
-    #[inline]
-    pub fn register_type_data<T: CreateTypeData<V>, V>(&mut self) {
-        self.insert(T::create_type_data(()));
-        T::insert_dependencies(self);
+    /// Avoids generics in an effort to reduce binary size costs due to monomorphization.
+    ///
+    /// # Arguments
+    ///
+    /// * `type_id`: The `TypeId` of the type data
+    /// * `data`: The type data itself
+    /// * `on_insert`: An optional `CreateTypeData::on_insert` callback
+    /// * `on_register`: An optional `CreateTypeData::on_register` callback
+    /// * `overwrite`: Indicates whether overwrites are allowed (but does not re-trigger callbacks)
+    fn insert_internal(
+        &mut self,
+        type_id: TypeId,
+        data: Box<dyn TypeData>,
+        on_insert: Option<OnInsertTypeData>,
+        on_register: Option<OnRegisterTypeData>,
+        overwrite: bool,
+    ) -> bool {
+        let entry = self.data.entry(type_id);
+        match entry {
+            indexmap::map::Entry::Vacant(entry) => {
+                if let Some(on_insert) = entry.insert(data).on_insert() {
+                    on_insert(TypeRegistrationMut::new(self));
+                }
+                if let Some(on_insert) = on_insert {
+                    on_insert(TypeRegistrationMut::new(self));
+                }
+                if let Some(on_register) = on_register {
+                    self.pending_callbacks
+                        .get_or_insert_default()
+                        .push(on_register);
+                }
+                true
+            }
+            indexmap::map::Entry::Occupied(mut entry) => {
+                if overwrite {
+                    entry.insert(data);
+                }
+                // We don't handle callbacks here to avoid cycles and since in most cases
+                // doing so would simply be unnecessarily duplicated effort
+                false
+            }
+        }
     }
 
-    /// Inserts the [`TypeData`] instance of `T` created for `V` with some input `I`,
-    /// and inserts any [`TypeData`] dependencies for that combination of `T`, `V`, and `I`.
+    /// Collects all `on_register` callbacks from registered [`TypeData`].
     ///
-    /// To register [`TypeData`] that doesn't require input (i.e. it expects `()`),
-    /// see [`TypeRegistration::register_type_data`].
-    #[inline]
-    pub fn register_type_data_with<T: CreateTypeData<V, I>, V, I>(&mut self, input: I) {
-        self.insert(T::create_type_data(input));
-        T::insert_dependencies(self);
+    /// This includes all pending callbacks and callbacks from inserted type data.
+    /// It should therefore only be used when the this [`TypeRegistration`] is first registered into a [`TypeRegistry`].
+    fn flush_on_register_callbacks(&mut self) -> Vec<fn(&mut TypeRegistry)> {
+        let pending_callbacks = self.pending_callbacks.take();
+
+        self.iter()
+            .filter_map(|(_, data)| data.on_register())
+            .chain(pending_callbacks.as_deref().into_iter().flatten().copied())
+            .collect()
     }
 
-    /// Returns a reference to the value of type `T` in this registration's
-    /// [type data].
-    ///
-    /// Returns `None` if no such value exists.
-    ///
-    /// For a dynamic version of this method, see [`data_by_id`].
-    ///
-    /// [type data]: TypeData
-    /// [`data_by_id`]: Self::data_by_id
-    pub fn data<T: TypeData>(&self) -> Option<&T> {
-        self.data
-            .get(&TypeId::of::<T>())
-            .and_then(|value| value.downcast_ref())
-    }
-
-    /// Returns a reference to the value with the given [`TypeId`] in this registration's
-    /// [type data].
-    ///
-    /// Returns `None` if no such value exists.
-    ///
-    /// For a static version of this method, see [`data`].
-    ///
-    /// [type data]: TypeData
-    /// [`data`]: Self::data
-    pub fn data_by_id(&self, type_id: TypeId) -> Option<&dyn TypeData> {
-        self.data.get(&type_id).map(Deref::deref)
-    }
-
-    /// Returns a mutable reference to the value of type `T` in this registration's
-    /// [type data].
-    ///
-    /// Returns `None` if no such value exists.
-    ///
-    /// For a dynamic version of this method, see [`data_mut_by_id`].
-    ///
-    /// [type data]: TypeData
-    /// [`data_mut_by_id`]: Self::data_mut_by_id
-    pub fn data_mut<T: TypeData>(&mut self) -> Option<&mut T> {
-        self.data
-            .get_mut(&TypeId::of::<T>())
-            .and_then(|value| value.downcast_mut())
-    }
-
-    /// Returns a mutable reference to the value with the given [`TypeId`] in this registration's
-    /// [type data].
-    ///
-    /// Returns `None` if no such value exists.
-    ///
-    /// For a static version of this method, see [`data_mut`].
-    ///
-    /// [type data]: TypeData
-    /// [`data_mut`]: Self::data_mut
-    pub fn data_mut_by_id(&mut self, type_id: TypeId) -> Option<&mut dyn TypeData> {
-        self.data.get_mut(&type_id).map(DerefMut::deref_mut)
-    }
-
-    /// Returns true if this registration contains the given [type data].
-    ///
-    /// For a dynamic version of this method, see [`contains_by_id`].
-    ///
-    /// [type data]: TypeData
-    /// [`contains_by_id`]: Self::contains_by_id
-    pub fn contains<T: TypeData>(&self) -> bool {
-        self.data.contains_key(&TypeId::of::<T>())
-    }
-
-    /// Returns true if this registration contains the given [type data] with [`TypeId`].
-    ///
-    /// For a static version of this method, see [`contains`].
-    ///
-    /// [type data]: TypeData
-    /// [`contains`]: Self::contains
-    pub fn contains_by_id(&self, type_id: TypeId) -> bool {
-        self.data.contains_key(&type_id)
-    }
-
-    /// The total count of [type data] in this registration.
-    ///
-    /// [type data]: TypeData
-    pub fn len(&self) -> usize {
-        self.data.len()
-    }
-
-    /// Returns true if this registration has no [type data].
-    ///
-    /// [type data]: TypeData
-    pub fn is_empty(&self) -> bool {
-        self.data.is_empty()
-    }
-
-    /// Returns an iterator over all [type data] in this registration.
-    ///
-    /// The iterator yields a tuple of the [`TypeId`] and its corresponding type data.
-    ///
-    /// [type data]: TypeData
-    pub fn iter(&self) -> impl ExactSizeIterator<Item = (TypeId, &dyn TypeData)> {
-        self.data.iter().map(|(id, data)| (*id, data.deref()))
-    }
-
-    /// Returns a mutable iterator over all [type data] in this registration.
-    ///
-    /// The iterator yields a tuple of the [`TypeId`] and its corresponding type data.
-    ///
-    /// [type data]: TypeData
-    pub fn iter_mut(&mut self) -> impl ExactSizeIterator<Item = (TypeId, &mut dyn TypeData)> {
-        self.data
-            .iter_mut()
-            .map(|(id, data)| (*id, data.deref_mut()))
-    }
+    type_data_insertion_methods!(self => self; [mut] Self => Self);
+    type_registration_methods!(self => self);
 }
 
-impl Clone for TypeRegistration {
-    fn clone(&self) -> Self {
-        let mut data = TypeIdMap::default();
-        for (id, type_data) in &self.data {
-            data.insert(*id, (*type_data).clone_type_data());
-        }
+/// A wrapper around a mutable reference to a [`TypeRegistration`] that allows for type data
+/// to be inserted mutably.
+///
+/// See [`TypeRegistry::registration_scope`] for how to access this.
+pub struct TypeRegistrationMut<'a> {
+    registration: &'a mut TypeRegistration,
+}
 
-        TypeRegistration {
-            data,
-            type_info: self.type_info,
-        }
+impl<'a> TypeRegistrationMut<'a> {
+    // Private to prevent users from side-stepping the insertion-restrictions,
+    // and thus potentially forgetting to trigger all the relevant type data callbacks.
+    fn new(registration: &'a mut TypeRegistration) -> Self {
+        Self { registration }
     }
+
+    type_data_insertion_methods!(self => self.registration; [] &mut Self => &mut Self);
+    type_registration_methods!(self => self.registration);
 }
 
 /// A struct used to serialize reflected instances of a type.
@@ -841,6 +1047,8 @@ impl Clone for TypeRegistration {
 pub struct ReflectSerialize {
     get_serializable: fn(value: &dyn Reflect) -> Serializable,
 }
+
+impl TypeData for ReflectSerialize {}
 
 impl<T: TypePath + FromReflect + erased_serde::Serialize> CreateTypeData<T> for ReflectSerialize {
     fn create_type_data(_input: ()) -> Self {
@@ -904,6 +1112,8 @@ impl ReflectDeserialize {
             .map_err(<<D as serde::Deserializer<'de>>::Error as serde::de::Error>::custom)
     }
 }
+
+impl TypeData for ReflectDeserialize {}
 
 impl<T: for<'a> Deserialize<'a> + Reflect> CreateTypeData<T> for ReflectDeserialize {
     fn create_type_data(_input: ()) -> Self {
@@ -1005,6 +1215,8 @@ impl ReflectFromPtr {
     }
 }
 
+impl TypeData for ReflectFromPtr {}
+
 #[expect(
     unsafe_code,
     reason = "We must interact with pointers here, which are inherently unsafe."
@@ -1087,9 +1299,9 @@ mod test {
 
         #[derive(Clone)]
         struct DataA(i32);
+        impl TypeData for DataA {}
 
-        let mut registration = TypeRegistration::of::<Foo>();
-        registration.insert(DataA(123));
+        let registration = TypeRegistration::of::<Foo>().insert_data(DataA(123));
 
         let mut iter = registration.iter();
 
@@ -1107,9 +1319,9 @@ mod test {
 
         #[derive(Clone)]
         struct DataA(i32);
+        impl TypeData for DataA {}
 
-        let mut registration = TypeRegistration::of::<Foo>();
-        registration.insert(DataA(123));
+        let mut registration = TypeRegistration::of::<Foo>().insert_data(DataA(123));
 
         {
             let mut iter = registration.iter_mut();

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -306,7 +306,7 @@ impl TypeRegistry {
         self.registrations.insert(type_id, registration);
 
         for callback in callbacks {
-            callback(self);
+            callback.call(self);
         }
 
         true
@@ -372,6 +372,8 @@ impl TypeRegistry {
             )
         });
 
+        let on_create_data_insert = <D as CreateTypeData<T, P>>::on_insert(&params);
+        let on_create_data_register = <D as CreateTypeData<T, P>>::on_register(&params);
         let data = D::create_type_data(params);
 
         let on_register = data.on_register();
@@ -379,18 +381,18 @@ impl TypeRegistry {
         registration.insert_internal(
             TypeId::of::<D>(),
             Box::new(data),
-            <D as CreateTypeData<T, P>>::on_insert(),
+            on_create_data_insert,
             // Set to `None` since we already handle the `on_register` callback in this method
             None,
             true,
         );
 
         if let Some(on_register) = on_register {
-            on_register(self);
+            on_register.call(self);
         }
 
-        if let Some(on_register) = <D as CreateTypeData<T, P>>::on_register() {
-            on_register(self);
+        if let Some(on_register) = on_create_data_register {
+            on_register.call(self);
         }
     }
 
@@ -506,7 +508,7 @@ impl TypeRegistry {
     pub fn registration_scope(
         &mut self,
         type_id: TypeId,
-        mut f: impl FnMut(TypeRegistrationMut<'_>),
+        f: impl FnOnce(TypeRegistrationMut<'_>),
     ) -> bool {
         let Some(registration) = self.registrations.get_mut(&type_id) else {
             return false;
@@ -516,7 +518,7 @@ impl TypeRegistry {
 
         let callbacks = registration.flush_on_register_callbacks();
         for callback in callbacks {
-            callback(self);
+            callback.call(self);
         }
 
         true
@@ -839,9 +841,9 @@ macro_rules! type_data_insertion_methods {
             $($mut)? $self: $self_ty,
             input: I,
         ) -> $return_ty {
+            let on_insert = <T as CreateTypeData<V, I>>::on_insert(&input);
+            let on_register = <T as CreateTypeData<V, I>>::on_register(&input);
             let data = T::create_type_data(input);
-            let on_insert = <T as CreateTypeData<V, I>>::on_insert();
-            let on_register = <T as CreateTypeData<V, I>>::on_register();
 
             let has_deps = on_insert.is_some() || data.on_insert().is_some();
 
@@ -906,7 +908,7 @@ pub struct TypeRegistration {
         And since these don't need to be accessed as often or in performance-sensitive code, \
         we can spare the extra layer of indirection"
     )]
-    pending_callbacks: Option<Box<Vec<fn(&mut TypeRegistry)>>>,
+    pending_callbacks: Option<Box<Vec<OnRegisterTypeData>>>,
 }
 
 impl Debug for TypeRegistration {
@@ -980,10 +982,10 @@ impl TypeRegistration {
         match entry {
             indexmap::map::Entry::Vacant(entry) => {
                 if let Some(on_insert) = entry.insert(data).on_insert() {
-                    on_insert(TypeRegistrationMut::new(self));
+                    on_insert.call(TypeRegistrationMut::new(self));
                 }
                 if let Some(on_insert) = on_insert {
-                    on_insert(TypeRegistrationMut::new(self));
+                    on_insert.call(TypeRegistrationMut::new(self));
                 }
                 if let Some(on_register) = on_register {
                     self.pending_callbacks
@@ -1007,12 +1009,16 @@ impl TypeRegistration {
     ///
     /// This includes all pending callbacks and callbacks from inserted type data.
     /// It should therefore only be used when the this [`TypeRegistration`] is first registered into a [`TypeRegistry`].
-    fn flush_on_register_callbacks(&mut self) -> Vec<fn(&mut TypeRegistry)> {
+    fn flush_on_register_callbacks(&mut self) -> Vec<OnRegisterTypeData> {
         let pending_callbacks = self.pending_callbacks.take();
 
         self.iter()
             .filter_map(|(_, data)| data.on_register())
-            .chain(pending_callbacks.as_deref().into_iter().flatten().copied())
+            .chain(
+                pending_callbacks
+                    .into_iter()
+                    .flat_map(|callbacks| callbacks.into_iter()),
+            )
             .collect()
     }
 

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -306,7 +306,7 @@ impl TypeRegistry {
         self.registrations.insert(type_id, registration);
 
         for callback in callbacks {
-            callback(self);
+            callback.call(self);
         }
 
         true
@@ -372,6 +372,8 @@ impl TypeRegistry {
             )
         });
 
+        let on_create_data_insert = <D as CreateTypeData<T, P>>::on_insert(&params);
+        let on_create_data_register = <D as CreateTypeData<T, P>>::on_register(&params);
         let data = D::create_type_data(params);
 
         let on_register = data.on_register();
@@ -379,18 +381,18 @@ impl TypeRegistry {
         registration.insert_internal(
             TypeId::of::<D>(),
             Box::new(data),
-            <D as CreateTypeData<T, P>>::on_insert(),
+            on_create_data_insert,
             // Set to `None` since we already handle the `on_register` callback in this method
             None,
             true,
         );
 
         if let Some(on_register) = on_register {
-            on_register(self);
+            on_register.call(self);
         }
 
-        if let Some(on_register) = <D as CreateTypeData<T, P>>::on_register() {
-            on_register(self);
+        if let Some(on_register) = on_create_data_register {
+            on_register.call(self);
         }
     }
 
@@ -506,7 +508,7 @@ impl TypeRegistry {
     pub fn registration_scope(
         &mut self,
         type_id: TypeId,
-        mut f: impl FnMut(TypeRegistrationMut<'_>),
+        f: impl FnOnce(TypeRegistrationMut<'_>),
     ) -> bool {
         let Some(registration) = self.registrations.get_mut(&type_id) else {
             return false;
@@ -516,7 +518,7 @@ impl TypeRegistry {
 
         let callbacks = registration.flush_on_register_callbacks();
         for callback in callbacks {
-            callback(self);
+            callback.call(self);
         }
 
         true
@@ -839,9 +841,9 @@ macro_rules! type_data_insertion_methods {
             $($mut)? $self: $self_ty,
             input: I,
         ) -> $return_ty {
+            let on_insert = <T as CreateTypeData<V, I>>::on_insert(&input);
+            let on_register = <T as CreateTypeData<V, I>>::on_register(&input);
             let data = T::create_type_data(input);
-            let on_insert = <T as CreateTypeData<V, I>>::on_insert();
-            let on_register = <T as CreateTypeData<V, I>>::on_register();
 
             let has_deps = on_insert.is_some() || data.on_insert().is_some();
 
@@ -906,7 +908,7 @@ pub struct TypeRegistration {
         And since these don't need to be accessed as often or in performance-sensitive code, \
         we can spare the extra layer of indirection"
     )]
-    pending_callbacks: Option<Box<Vec<fn(&mut TypeRegistry)>>>,
+    pending_callbacks: Option<Box<Vec<OnRegisterTypeData>>>,
 }
 
 impl Debug for TypeRegistration {
@@ -980,10 +982,10 @@ impl TypeRegistration {
         match entry {
             ::bevy_utils::TypeIdHashMapEntry::Vacant(entry) => {
                 if let Some(on_insert) = entry.insert(data).on_insert() {
-                    on_insert(TypeRegistrationMut::new(self));
+                    on_insert.call(TypeRegistrationMut::new(self));
                 }
                 if let Some(on_insert) = on_insert {
-                    on_insert(TypeRegistrationMut::new(self));
+                    on_insert.call(TypeRegistrationMut::new(self));
                 }
                 if let Some(on_register) = on_register {
                     self.pending_callbacks
@@ -1007,12 +1009,16 @@ impl TypeRegistration {
     ///
     /// This includes all pending callbacks and callbacks from inserted type data.
     /// It should therefore only be used when the this [`TypeRegistration`] is first registered into a [`TypeRegistry`].
-    fn flush_on_register_callbacks(&mut self) -> Vec<fn(&mut TypeRegistry)> {
+    fn flush_on_register_callbacks(&mut self) -> Vec<OnRegisterTypeData> {
         let pending_callbacks = self.pending_callbacks.take();
 
         self.iter()
             .filter_map(|(_, data)| data.on_register())
-            .chain(pending_callbacks.as_deref().into_iter().flatten().copied())
+            .chain(
+                pending_callbacks
+                    .into_iter()
+                    .flat_map(|callbacks| callbacks.into_iter()),
+            )
             .collect()
     }
 

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -1,8 +1,9 @@
+use crate::type_data::{OnInsertTypeData, OnRegisterTypeData};
 use crate::{
     convert::ReflectConvert, serde::Serializable, FromReflect, Reflect, TypeData, TypeInfo,
     TypePath, Typed,
 };
-use alloc::{boxed::Box, string::String};
+use alloc::{boxed::Box, string::String, vec::Vec};
 use bevy_platform::{
     collections::{HashMap, HashSet},
     sync::{Arc, PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard},
@@ -203,7 +204,7 @@ impl TypeRegistry {
     where
         T: GetTypeRegistration,
     {
-        if self.register_internal(TypeId::of::<T>(), T::get_type_registration) {
+        if self.register_internal(TypeId::of::<T>(), T::get_type_registration, false) {
             T::register_type_dependencies(self);
         }
     }
@@ -258,7 +259,7 @@ impl TypeRegistry {
     /// Returns `true` if the registration was added and `false` if it already exists.
     pub fn add_registration(&mut self, registration: TypeRegistration) -> bool {
         let type_id = registration.type_id();
-        self.register_internal(type_id, || registration)
+        self.register_internal(type_id, || registration, false)
     }
 
     /// Registers the type described by `registration`.
@@ -271,14 +272,7 @@ impl TypeRegistry {
     /// This method will _not_ register type dependencies.
     /// Use [`register`](Self::register) to register a type with its dependencies.
     pub fn overwrite_registration(&mut self, registration: TypeRegistration) {
-        Self::update_registration_indices(
-            &registration,
-            &mut self.short_path_to_id,
-            &mut self.type_path_to_id,
-            &mut self.ambiguous_names,
-        );
-        self.registrations
-            .insert(registration.type_id(), registration);
+        self.register_internal(registration.type_id(), || registration, true);
     }
 
     /// Internal method to register a type with a given [`TypeId`] and [`TypeRegistration`].
@@ -292,18 +286,29 @@ impl TypeRegistry {
         &mut self,
         type_id: TypeId,
         get_registration: impl FnOnce() -> TypeRegistration,
+        overwrite: bool,
     ) -> bool {
-        if self.registrations.contains_key(&type_id) {
+        if !overwrite && self.registrations.contains_key(&type_id) {
             return false;
         }
-        let registration = get_registration();
+
+        let mut registration = get_registration();
+
         Self::update_registration_indices(
             &registration,
             &mut self.short_path_to_id,
             &mut self.type_path_to_id,
             &mut self.ambiguous_names,
         );
+
+        let callbacks = registration.flush_on_register_callbacks();
+
         self.registrations.insert(type_id, registration);
+
+        for callback in callbacks {
+            callback(self);
+        }
+
         true
     }
 
@@ -342,14 +347,7 @@ impl TypeRegistry {
     /// type_registry.register_type_data::<Option<String>, ReflectDeserialize>();
     /// ```
     pub fn register_type_data<T: Reflect + TypePath, D: CreateTypeData<T>>(&mut self) {
-        let data = self.get_mut(TypeId::of::<T>()).unwrap_or_else(|| {
-            panic!(
-                "attempted to call `TypeRegistry::register_type_data` for type `{T}` with data `{D}` without registering `{T}` first",
-                T = T::type_path(),
-                D = core::any::type_name::<D>(),
-            )
-        });
-        data.insert(D::create_type_data(()));
+        self.register_type_data_with::<T, D, ()>(());
     }
 
     /// Registers the type data `D` with parameter `P` for type `T`.
@@ -365,15 +363,35 @@ impl TypeRegistry {
         &mut self,
         params: P,
     ) {
-        let data = self.get_mut(TypeId::of::<T>()).unwrap_or_else(|| {
+        let registration = self.get_mut(TypeId::of::<T>()).unwrap_or_else(|| {
             panic!(
-                "attempted to call `TypeRegistry::register_type_data_with` for type `{T}` with data `{D}` and params `{P}` without registering `{T}` first",
+                "attempted to register type data `{D}` with params `{P}` for type `{T}` without registering `{T}` first",
                 T = T::type_path(),
                 D = ::core::any::type_name::<D>(),
                 P = ::core::any::type_name::<P>(),
             )
         });
-        data.insert(D::create_type_data(params));
+
+        let data = D::create_type_data(params);
+
+        let on_register = data.on_register();
+
+        registration.insert_internal(
+            TypeId::of::<D>(),
+            Box::new(data),
+            <D as CreateTypeData<T, P>>::on_insert(),
+            // Set to `None` since we already handle the `on_register` callback in this method
+            None,
+            true,
+        );
+
+        if let Some(on_register) = on_register {
+            on_register(self);
+        }
+
+        if let Some(on_register) = <D as CreateTypeData<T, P>>::on_register() {
+            on_register(self);
+        }
     }
 
     /// Registers a fallible conversion from type T to U with the reflection
@@ -398,13 +416,21 @@ impl TypeRegistry {
         U: Reflect + TypePath,
         F: Fn(T) -> Result<U, T> + Clone + Send + Sync + 'static,
     {
-        let data = self.get_mut(TypeId::of::<U>()).unwrap_or_else(|| {
+        let registration = self.get_mut(TypeId::of::<U>()).unwrap_or_else(|| {
             panic!(
                 "attempted to call `TypeRegistry::register_type_conversion` for type `{U}` without registering `{U}` first",
                 U = U::type_path(),
             )
         });
-        data.get_or_insert_data_with(ReflectConvert::default)
+
+        // We know `ReflectConvert` doesn't have any type data callbacks,
+        // so we're safe to register it directly like this
+        registration
+            .data
+            .entry(TypeId::of::<ReflectConvert>())
+            .or_insert_with(|| Box::new(ReflectConvert::default()))
+            .downcast_mut::<ReflectConvert>()
+            .expect("ReflectConvert is always registered")
             .register_type_conversion(function);
     }
 
@@ -425,13 +451,21 @@ impl TypeRegistry {
         T: Reflect + TypePath,
         U: Reflect + TypePath + From<T>,
     {
-        let data = self.get_mut(TypeId::of::<U>()).unwrap_or_else(|| {
+        let registration = self.get_mut(TypeId::of::<U>()).unwrap_or_else(|| {
             panic!(
                 "attempted to call `TypeRegistry::register_type_conversion` for type `{U}` without registering `{U}` first",
                 U = U::type_path(),
             )
         });
-        data.get_or_insert_data_with(ReflectConvert::default)
+
+        // We know `ReflectConvert` doesn't have any type data callbacks,
+        // so we're safe to register it directly like this
+        registration
+            .data
+            .entry(TypeId::of::<ReflectConvert>())
+            .or_insert_with(|| Box::new(ReflectConvert::default()))
+            .downcast_mut::<ReflectConvert>()
+            .expect("ReflectConvert is always registered")
             .register_type_conversion::<T, U, _>(|input| Ok(input.into()));
     }
 
@@ -453,8 +487,39 @@ impl TypeRegistry {
     /// the given [`TypeId`].
     ///
     /// If the specified type has not been registered, returns `None`.
+    ///
+    /// If you need to insert new type data into this [`TypeRegistration`],
+    /// use [`Self::registration_scope`] instead.
     pub fn get_mut(&mut self, type_id: TypeId) -> Option<&mut TypeRegistration> {
         self.registrations.get_mut(&type_id)
+    }
+
+    /// Provides scoped access to the [`TypeRegistration`] of the type with
+    /// the given [`TypeId`] as a [`TypeRegistrationMut`].
+    ///
+    /// This allows for [`TypeData`] to be inserted into the [`TypeRegistration`],
+    /// and for any registration callbacks associated with that type data to take effect afterwards.
+    ///
+    /// If you do not need to insert any new type data, [`Self::get_mut`] is preferred.
+    ///
+    /// Returns true if the registration was found, false otherwise.
+    pub fn registration_scope(
+        &mut self,
+        type_id: TypeId,
+        mut f: impl FnMut(TypeRegistrationMut<'_>),
+    ) -> bool {
+        let Some(registration) = self.registrations.get_mut(&type_id) else {
+            return false;
+        };
+
+        f(TypeRegistrationMut::new(registration));
+
+        let callbacks = registration.flush_on_register_callbacks();
+        for callback in callbacks {
+            callback(self);
+        }
+
+        true
     }
 
     /// Returns a reference to the [`TypeRegistration`] of the type with the
@@ -603,6 +668,206 @@ impl TypeRegistryArc {
     }
 }
 
+macro_rules! type_registration_methods {
+    ($self:ident => $registration:expr) => {
+        /// Returns the [`TypeId`] of the type.
+        #[inline]
+        pub fn type_id(&$self) -> TypeId {
+            $registration.type_info.type_id()
+        }
+
+        /// Returns a reference to the registration's [`TypeInfo`]
+        pub fn type_info(&$self) -> &'static TypeInfo {
+            $registration.type_info
+        }
+
+        /// Returns a reference to the value of type `T` in this registration's
+        /// [type data].
+        ///
+        /// Returns `None` if no such value exists.
+        ///
+        /// For a dynamic version of this method, see [`data_by_id`].
+        ///
+        /// [type data]: TypeData
+        /// [`data_by_id`]: Self::data_by_id
+        pub fn data<T: TypeData>(&$self) -> Option<&T> {
+            $registration.data
+                .get(&TypeId::of::<T>())
+                .and_then(|value| value.downcast_ref())
+        }
+
+        /// Returns a reference to the value with the given [`TypeId`] in this registration's
+        /// [type data].
+        ///
+        /// Returns `None` if no such value exists.
+        ///
+        /// For a static version of this method, see [`data`].
+        ///
+        /// [type data]: TypeData
+        /// [`data`]: Self::data
+        pub fn data_by_id(&$self, type_id: TypeId) -> Option<&dyn TypeData> {
+            $registration.data.get(&type_id).map(Deref::deref)
+        }
+
+        /// Returns a mutable reference to the value of type `T` in this registration's
+        /// [type data].
+        ///
+        /// Returns `None` if no such value exists.
+        ///
+        /// For a dynamic version of this method, see [`data_mut_by_id`].
+        ///
+        /// [type data]: TypeData
+        /// [`data_mut_by_id`]: Self::data_mut_by_id
+        pub fn data_mut<T: TypeData>(&mut $self) -> Option<&mut T> {
+            $registration.data
+                .get_mut(&TypeId::of::<T>())
+                .and_then(|value| value.downcast_mut())
+        }
+
+        /// Returns a mutable reference to the value with the given [`TypeId`] in this registration's
+        /// [type data].
+        ///
+        /// Returns `None` if no such value exists.
+        ///
+        /// For a static version of this method, see [`data_mut`].
+        ///
+        /// [type data]: TypeData
+        /// [`data_mut`]: Self::data_mut
+        pub fn data_mut_by_id(&mut $self, type_id: TypeId) -> Option<&mut dyn TypeData> {
+            $registration.data.get_mut(&type_id).map(DerefMut::deref_mut)
+        }
+
+        /// Returns true if this registration contains the given [type data].
+        ///
+        /// For a dynamic version of this method, see [`contains_by_id`].
+        ///
+        /// [type data]: TypeData
+        /// [`contains_by_id`]: Self::contains_by_id
+        pub fn contains<T: TypeData>(&$self) -> bool {
+            $registration.data.contains_key(&TypeId::of::<T>())
+        }
+
+        /// Returns true if this registration contains the given [type data] with [`TypeId`].
+        ///
+        /// For a static version of this method, see [`contains`].
+        ///
+        /// [type data]: TypeData
+        /// [`contains`]: Self::contains
+        pub fn contains_by_id(&$self, type_id: TypeId) -> bool {
+            $registration.data.contains_key(&type_id)
+        }
+
+        /// The total count of [type data] in this registration.
+        ///
+        /// [type data]: TypeData
+        pub fn len(&$self) -> usize {
+            $registration.data.len()
+        }
+
+        /// Returns true if this registration has no [type data].
+        ///
+        /// [type data]: TypeData
+        pub fn is_empty(&$self) -> bool {
+            $registration.data.is_empty()
+        }
+
+        /// Returns an iterator over all [type data] in this registration.
+        ///
+        /// The iterator yields a tuple of the [`TypeId`] and its corresponding type data.
+        ///
+        /// [type data]: TypeData
+        pub fn iter(&$self) -> impl ExactSizeIterator<Item = (TypeId, &dyn TypeData)> {
+            $registration.data.iter().map(|(id, data)| (*id, data.deref()))
+        }
+
+        /// Returns a mutable iterator over all [type data] in this registration.
+        ///
+        /// The iterator yields a tuple of the [`TypeId`] and its corresponding type data.
+        ///
+        /// [type data]: TypeData
+        pub fn iter_mut(&mut $self) -> impl ExactSizeIterator<Item = (TypeId, &mut dyn TypeData)> {
+            $registration.data
+                .iter_mut()
+                .map(|(id, data)| (*id, data.deref_mut()))
+        }
+    };
+}
+
+macro_rules! type_data_insertion_methods {
+    ($self:ident => $registration:expr; [$($mut:tt)?] $self_ty:ty => $return_ty:ty) => {
+        /// Inserts an instance of `T` into this registration's [type data] map.
+        /// If another instance of `T` was previously inserted, it is replaced.
+        ///
+        /// If this is the first time `T` is being inserted,
+        /// this method will also trigger the [`TypeData::on_insert`] callbacks for `T`,
+        /// as well as queue up its [`TypeData::on_register`] callback.
+        ///
+        /// See also [`Self::register_type_data`] for type data that can be instantiated
+        /// automatically using [`CreateTypeData`].
+        ///
+        /// [type data]: TypeData
+        pub fn insert_data<T: TypeData>($($mut)? $self: $self_ty, data: T) -> $return_ty {
+            $registration.insert_internal(TypeId::of::<T>(), Box::new(data), None, None, true);
+            $self
+        }
+
+        /// Inserts the [`TypeData`] instance of `T` created for `V`.
+        /// If another instance of `T` was previously inserted, it is replaced.
+        ///
+        /// If this is the first time `T` is being inserted,
+        /// this method will also trigger the [`TypeData::on_insert`] and [`CreateTypeData::on_insert`] callbacks for `T`,
+        /// as well as queue up its [`TypeData::on_register`] and [`CreateTypeData::on_register`] callbacks.
+        ///
+        /// To register [`TypeData`] that requires input (i.e. it doesn't take `()` as its input),
+        /// see [`Self::register_type_data_with`].
+        #[inline]
+        pub fn register_type_data<T: CreateTypeData<V>, V>($self: $self_ty) -> $return_ty {
+            $self.register_type_data_with::<T, V, ()>(())
+        }
+
+        /// Inserts the [`TypeData`] instance of `T` created for `V` with some input `I`.
+        /// If another instance of `T` was previously inserted, it is replaced.
+        ///
+        /// If this is the first time `T` is being inserted,
+        /// this method will also trigger the [`TypeData::on_insert`] and [`CreateTypeData::on_insert`] callbacks for `T`,
+        /// as well as queue up its [`TypeData::on_register`] and [`CreateTypeData::on_register`] callbacks.
+        ///
+        /// To register [`TypeData`] that doesn't require input (i.e. it expects `()`),
+        /// see [`Self::register_type_data`].
+        #[inline]
+        pub fn register_type_data_with<T: CreateTypeData<V, I>, V, I>(
+            $($mut)? $self: $self_ty,
+            input: I,
+        ) -> $return_ty {
+            let data = T::create_type_data(input);
+            let on_insert = <T as CreateTypeData<V, I>>::on_insert();
+            let on_register = <T as CreateTypeData<V, I>>::on_register();
+
+            let has_deps = on_insert.is_some() || data.on_insert().is_some();
+
+            if !$registration.insert_internal(
+                TypeId::of::<T>(),
+                Box::new(data),
+                on_insert,
+                on_register,
+                true,
+            ) {
+                return $self;
+            }
+
+            if !has_deps {
+                #[expect(
+                    deprecated,
+                    reason = "Will continue to call function until fully removed"
+                )]
+                <T as CreateTypeData<V, I>>::insert_dependencies(&mut $registration);
+            }
+
+            $self
+        }
+    };
+}
+
 /// Runtime storage for type metadata, registered into the [`TypeRegistry`].
 ///
 /// An instance of `TypeRegistration` can be created using the [`TypeRegistration::of`] method,
@@ -623,7 +888,7 @@ impl TypeRegistryArc {
 /// assert_eq!("core::option::Option<alloc::string::String>", registration.type_info().type_path());
 /// assert_eq!("Option<String>", registration.type_info().type_path_table().short_path());
 ///
-/// registration.insert::<ReflectDefault>(CreateTypeData::<Option<String>>::create_type_data(()));
+/// registration.insert_data::<ReflectDefault>(CreateTypeData::<Option<String>>::create_type_data(()));
 /// assert!(registration.data::<ReflectDefault>().is_some())
 /// ```
 ///
@@ -631,6 +896,17 @@ impl TypeRegistryArc {
 pub struct TypeRegistration {
     data: TypeIdHashMap<Box<dyn TypeData>>,
     type_info: &'static TypeInfo,
+    /// The `on_register` callbacks waiting to be applied.
+    ///
+    /// These are generally the ones from [`CreateTypeData::on_register`]
+    /// since the [`TypeData::on_register`] callbacks can be accessed dynamically from `data`.
+    #[expect(
+        clippy::box_collection,
+        reason = "We intentionally box the `Vec` to save 16 bytes per registration. \
+        And since these don't need to be accessed as often or in performance-sensitive code, \
+        we can spare the extra layer of indirection"
+    )]
+    pending_callbacks: Option<Box<Vec<fn(&mut TypeRegistry)>>>,
 }
 
 impl Debug for TypeRegistration {
@@ -647,18 +923,8 @@ impl TypeRegistration {
         Self {
             data: Default::default(),
             type_info: T::type_info(),
+            pending_callbacks: None,
         }
-    }
-
-    /// Returns the [`TypeId`] of the type.
-    #[inline]
-    pub fn type_id(&self) -> TypeId {
-        self.type_info.type_id()
-    }
-
-    /// Returns a reference to the registration's [`TypeInfo`]
-    pub fn type_info(&self) -> &'static TypeInfo {
-        self.type_info
     }
 
     /// Inserts an instance of `T` into this registration's [type data].
@@ -670,6 +936,10 @@ impl TypeRegistration {
     /// That will need to be done manually using [`CreateTypeData::insert_dependencies`].
     ///
     /// [type data]: TypeData
+    #[deprecated(
+        since = "0.21.0",
+        note = "This method will be removed in a future release. Use `TypeRegistry::insert_data` or `TypeRegistry::register_type_data` instead."
+    )]
     pub fn insert<T: TypeData>(&mut self, data: T) {
         self.data.insert(TypeId::of::<T>(), Box::new(data));
     }
@@ -678,159 +948,95 @@ impl TypeRegistration {
     /// exist, it will insert a new instance using `get_data` and then return it.
     ///
     /// [type data]: TypeData
+    #[deprecated(
+        since = "0.21.0",
+        note = "This method will be removed in a future release. Use `TypeRegistry::contains` in conjunction with either `TypeRegistry::insert_data` or `TypeRegistry::register_type_data` instead."
+    )]
     pub fn get_or_insert_data_with<T: TypeData>(&mut self, get_data: impl FnOnce() -> T) -> &mut T {
-        let boxed_data = self
-            .data
-            .entry(TypeId::of::<T>())
-            .or_insert_with(|| Box::new(get_data()));
-        boxed_data.downcast_mut::<T>().unwrap()
+        self.insert_internal(TypeId::of::<T>(), Box::new(get_data()), None, None, false);
+        self.data_mut::<T>().expect("data was just inserted")
     }
 
-    /// Inserts the [`TypeData`] instance of `T` created for `V`, and inserts any
-    /// [`TypeData`] dependencies for that combination of `T` and `V`.
+    /// Internal method for inserting type data.
     ///
-    /// To register [`TypeData`] that requires input (i.e. it doesn't take `()` as its input),
-    /// see [`TypeRegistration::register_type_data_with`].
-    #[inline]
-    pub fn register_type_data<T: CreateTypeData<V>, V>(&mut self) {
-        self.insert(T::create_type_data(()));
-        T::insert_dependencies(self);
+    /// Avoids generics in an effort to reduce binary size costs due to monomorphization.
+    ///
+    /// # Arguments
+    ///
+    /// * `type_id`: The `TypeId` of the type data
+    /// * `data`: The type data itself
+    /// * `on_insert`: An optional `CreateTypeData::on_insert` callback
+    /// * `on_register`: An optional `CreateTypeData::on_register` callback
+    /// * `overwrite`: Indicates whether overwrites are allowed (but does not re-trigger callbacks)
+    fn insert_internal(
+        &mut self,
+        type_id: TypeId,
+        data: Box<dyn TypeData>,
+        on_insert: Option<OnInsertTypeData>,
+        on_register: Option<OnRegisterTypeData>,
+        overwrite: bool,
+    ) -> bool {
+        let entry = self.data.entry(type_id);
+        match entry {
+            ::bevy_utils::TypeIdHashMapEntry::Vacant(entry) => {
+                if let Some(on_insert) = entry.insert(data).on_insert() {
+                    on_insert(TypeRegistrationMut::new(self));
+                }
+                if let Some(on_insert) = on_insert {
+                    on_insert(TypeRegistrationMut::new(self));
+                }
+                if let Some(on_register) = on_register {
+                    self.pending_callbacks
+                        .get_or_insert_default()
+                        .push(on_register);
+                }
+                true
+            }
+            ::bevy_utils::TypeIdHashMapEntry::Occupied(mut entry) => {
+                if overwrite {
+                    entry.insert(data);
+                }
+                // We don't handle callbacks here to avoid cycles and since in most cases
+                // doing so would simply be unnecessarily duplicated effort
+                false
+            }
+        }
     }
 
-    /// Inserts the [`TypeData`] instance of `T` created for `V` with some input `I`,
-    /// and inserts any [`TypeData`] dependencies for that combination of `T`, `V`, and `I`.
+    /// Collects all `on_register` callbacks from registered [`TypeData`].
     ///
-    /// To register [`TypeData`] that doesn't require input (i.e. it expects `()`),
-    /// see [`TypeRegistration::register_type_data`].
-    #[inline]
-    pub fn register_type_data_with<T: CreateTypeData<V, I>, V, I>(&mut self, input: I) {
-        self.insert(T::create_type_data(input));
-        T::insert_dependencies(self);
+    /// This includes all pending callbacks and callbacks from inserted type data.
+    /// It should therefore only be used when the this [`TypeRegistration`] is first registered into a [`TypeRegistry`].
+    fn flush_on_register_callbacks(&mut self) -> Vec<fn(&mut TypeRegistry)> {
+        let pending_callbacks = self.pending_callbacks.take();
+
+        self.iter()
+            .filter_map(|(_, data)| data.on_register())
+            .chain(pending_callbacks.as_deref().into_iter().flatten().copied())
+            .collect()
     }
 
-    /// Returns a reference to the value of type `T` in this registration's
-    /// [type data].
-    ///
-    /// Returns `None` if no such value exists.
-    ///
-    /// For a dynamic version of this method, see [`data_by_id`].
-    ///
-    /// [type data]: TypeData
-    /// [`data_by_id`]: Self::data_by_id
-    pub fn data<T: TypeData>(&self) -> Option<&T> {
-        self.data
-            .get(&TypeId::of::<T>())
-            .and_then(|value| value.downcast_ref())
-    }
-
-    /// Returns a reference to the value with the given [`TypeId`] in this registration's
-    /// [type data].
-    ///
-    /// Returns `None` if no such value exists.
-    ///
-    /// For a static version of this method, see [`data`].
-    ///
-    /// [type data]: TypeData
-    /// [`data`]: Self::data
-    pub fn data_by_id(&self, type_id: TypeId) -> Option<&dyn TypeData> {
-        self.data.get(&type_id).map(Deref::deref)
-    }
-
-    /// Returns a mutable reference to the value of type `T` in this registration's
-    /// [type data].
-    ///
-    /// Returns `None` if no such value exists.
-    ///
-    /// For a dynamic version of this method, see [`data_mut_by_id`].
-    ///
-    /// [type data]: TypeData
-    /// [`data_mut_by_id`]: Self::data_mut_by_id
-    pub fn data_mut<T: TypeData>(&mut self) -> Option<&mut T> {
-        self.data
-            .get_mut(&TypeId::of::<T>())
-            .and_then(|value| value.downcast_mut())
-    }
-
-    /// Returns a mutable reference to the value with the given [`TypeId`] in this registration's
-    /// [type data].
-    ///
-    /// Returns `None` if no such value exists.
-    ///
-    /// For a static version of this method, see [`data_mut`].
-    ///
-    /// [type data]: TypeData
-    /// [`data_mut`]: Self::data_mut
-    pub fn data_mut_by_id(&mut self, type_id: TypeId) -> Option<&mut dyn TypeData> {
-        self.data.get_mut(&type_id).map(DerefMut::deref_mut)
-    }
-
-    /// Returns true if this registration contains the given [type data].
-    ///
-    /// For a dynamic version of this method, see [`contains_by_id`].
-    ///
-    /// [type data]: TypeData
-    /// [`contains_by_id`]: Self::contains_by_id
-    pub fn contains<T: TypeData>(&self) -> bool {
-        self.data.contains_key(&TypeId::of::<T>())
-    }
-
-    /// Returns true if this registration contains the given [type data] with [`TypeId`].
-    ///
-    /// For a static version of this method, see [`contains`].
-    ///
-    /// [type data]: TypeData
-    /// [`contains`]: Self::contains
-    pub fn contains_by_id(&self, type_id: TypeId) -> bool {
-        self.data.contains_key(&type_id)
-    }
-
-    /// The total count of [type data] in this registration.
-    ///
-    /// [type data]: TypeData
-    pub fn len(&self) -> usize {
-        self.data.len()
-    }
-
-    /// Returns true if this registration has no [type data].
-    ///
-    /// [type data]: TypeData
-    pub fn is_empty(&self) -> bool {
-        self.data.is_empty()
-    }
-
-    /// Returns an iterator over all [type data] in this registration.
-    ///
-    /// The iterator yields a tuple of the [`TypeId`] and its corresponding type data.
-    ///
-    /// [type data]: TypeData
-    pub fn iter(&self) -> impl ExactSizeIterator<Item = (TypeId, &dyn TypeData)> {
-        self.data.iter().map(|(id, data)| (*id, data.deref()))
-    }
-
-    /// Returns a mutable iterator over all [type data] in this registration.
-    ///
-    /// The iterator yields a tuple of the [`TypeId`] and its corresponding type data.
-    ///
-    /// [type data]: TypeData
-    pub fn iter_mut(&mut self) -> impl ExactSizeIterator<Item = (TypeId, &mut dyn TypeData)> {
-        self.data
-            .iter_mut()
-            .map(|(id, data)| (*id, data.deref_mut()))
-    }
+    type_data_insertion_methods!(self => self; [mut] Self => Self);
+    type_registration_methods!(self => self);
 }
 
-impl Clone for TypeRegistration {
-    fn clone(&self) -> Self {
-        let mut data = TypeIdHashMap::default();
-        for (id, type_data) in &self.data {
-            data.insert(*id, (*type_data).clone_type_data());
-        }
+/// A wrapper around a mutable reference to a [`TypeRegistration`] that allows for type data
+/// to be inserted mutably.
+///
+/// See [`TypeRegistry::registration_scope`] for how to access this.
+pub struct TypeRegistrationMut<'a> {
+    registration: &'a mut TypeRegistration,
+}
 
-        TypeRegistration {
-            data,
-            type_info: self.type_info,
-        }
+impl<'a> TypeRegistrationMut<'a> {
+    // Private to prevent users from side-stepping the insertion-restrictions,
+    // and thus potentially forgetting to trigger all the relevant type data callbacks.
+    fn new(registration: &'a mut TypeRegistration) -> Self {
+        Self { registration }
     }
+
+    type_data_insertion_methods!(self => self.registration; [] &mut Self => &mut Self);
+    type_registration_methods!(self => self.registration);
 }
 
 /// A struct used to serialize reflected instances of a type.
@@ -841,6 +1047,8 @@ impl Clone for TypeRegistration {
 pub struct ReflectSerialize {
     get_serializable: fn(value: &dyn Reflect) -> Serializable,
 }
+
+impl TypeData for ReflectSerialize {}
 
 impl<T: TypePath + FromReflect + erased_serde::Serialize> CreateTypeData<T> for ReflectSerialize {
     fn create_type_data(_input: ()) -> Self {
@@ -904,6 +1112,8 @@ impl ReflectDeserialize {
             .map_err(<<D as serde::Deserializer<'de>>::Error as serde::de::Error>::custom)
     }
 }
+
+impl TypeData for ReflectDeserialize {}
 
 impl<T: for<'a> Deserialize<'a> + Reflect> CreateTypeData<T> for ReflectDeserialize {
     fn create_type_data(_input: ()) -> Self {
@@ -1005,6 +1215,8 @@ impl ReflectFromPtr {
     }
 }
 
+impl TypeData for ReflectFromPtr {}
+
 #[expect(
     unsafe_code,
     reason = "We must interact with pointers here, which are inherently unsafe."
@@ -1087,9 +1299,9 @@ mod test {
 
         #[derive(Clone)]
         struct DataA(i32);
+        impl TypeData for DataA {}
 
-        let mut registration = TypeRegistration::of::<Foo>();
-        registration.insert(DataA(123));
+        let registration = TypeRegistration::of::<Foo>().insert_data(DataA(123));
 
         let mut iter = registration.iter();
 
@@ -1107,9 +1319,9 @@ mod test {
 
         #[derive(Clone)]
         struct DataA(i32);
+        impl TypeData for DataA {}
 
-        let mut registration = TypeRegistration::of::<Foo>();
-        registration.insert(DataA(123));
+        let mut registration = TypeRegistration::of::<Foo>().insert_data(DataA(123));
 
         {
             let mut iter = registration.iter_mut();

--- a/crates/bevy_remote/src/schemas/json_schema.rs
+++ b/crates/bevy_remote/src/schemas/json_schema.rs
@@ -463,7 +463,7 @@ mod tests {
 
     use bevy_ecs::{component::Component, reflect::AppTypeRegistry, resource::Resource};
     use bevy_reflect::prelude::ReflectDefault;
-    use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize};
+    use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize, TypeData};
 
     #[test]
     fn reflect_export_struct() {
@@ -482,10 +482,9 @@ mod tests {
         let type_registry = atr.read();
         let foo_registration = type_registry
             .get(TypeId::of::<Foo>())
-            .expect("SHOULD BE REGISTERED")
-            .clone();
+            .expect("SHOULD BE REGISTERED");
         let (_, schema) = export_type(
-            &foo_registration,
+            foo_registration,
             &SchemaTypesMetadata::default(),
             &Components::default(),
         );
@@ -527,10 +526,9 @@ mod tests {
         let type_registry = atr.read();
         let foo_registration = type_registry
             .get(TypeId::of::<EnumComponent>())
-            .expect("SHOULD BE REGISTERED")
-            .clone();
+            .expect("SHOULD BE REGISTERED");
         let (_, schema) = export_type(
-            &foo_registration,
+            foo_registration,
             &SchemaTypesMetadata::default(),
             &Components::default(),
         );
@@ -566,10 +564,9 @@ mod tests {
         let type_registry = atr.read();
         let foo_registration = type_registry
             .get(TypeId::of::<EnumComponent>())
-            .expect("SHOULD BE REGISTERED")
-            .clone();
+            .expect("SHOULD BE REGISTERED");
         let (_, schema) = export_type(
-            &foo_registration,
+            foo_registration,
             &SchemaTypesMetadata::default(),
             &Components::default(),
         );
@@ -598,7 +595,7 @@ mod tests {
             NoValue,
         }
 
-        #[derive(Clone)]
+        #[derive(Clone, TypeData)]
         pub struct ReflectCustomData;
 
         impl<T: Reflect> bevy_reflect::CreateTypeData<T> for ReflectCustomData {
@@ -618,9 +615,8 @@ mod tests {
         let type_registry = atr.read();
         let foo_registration = type_registry
             .get(TypeId::of::<EnumComponent>())
-            .expect("SHOULD BE REGISTERED")
-            .clone();
-        let (_, schema) = export_type(&foo_registration, &metadata, &Components::default());
+            .expect("SHOULD BE REGISTERED");
+        let (_, schema) = export_type(foo_registration, &metadata, &Components::default());
         assert!(
             !metadata.has_type_data::<ReflectComponent>(&schema.reflect_types),
             "Should not be a component"
@@ -655,10 +651,9 @@ mod tests {
         let type_registry = atr.read();
         let foo_registration = type_registry
             .get(TypeId::of::<TupleStructType>())
-            .expect("SHOULD BE REGISTERED")
-            .clone();
+            .expect("SHOULD BE REGISTERED");
         let (_, schema) = export_type(
-            &foo_registration,
+            foo_registration,
             &SchemaTypesMetadata::default(),
             &Components::default(),
         );
@@ -690,10 +685,9 @@ mod tests {
         let type_registry = atr.read();
         let foo_registration = type_registry
             .get(TypeId::of::<Foo>())
-            .expect("SHOULD BE REGISTERED")
-            .clone();
+            .expect("SHOULD BE REGISTERED");
         let (_, schema) = export_type(
-            &foo_registration,
+            foo_registration,
             &SchemaTypesMetadata::default(),
             &Components::default(),
         );

--- a/crates/bevy_settings/src/lib.rs
+++ b/crates/bevy_settings/src/lib.rs
@@ -181,10 +181,10 @@ impl<T: SettingsGroup + FromReflect + TypePath> CreateTypeData<T> for ReflectSet
         }
     }
 
-    fn on_insert() -> Option<OnInsertTypeData> {
-        Some(|mut registration| {
+    fn on_insert(_: &()) -> Option<OnInsertTypeData> {
+        Some(OnInsertTypeData::new(|mut registration| {
             registration.register_type_data::<ReflectResource, T>();
-        })
+        }))
     }
 }
 

--- a/crates/bevy_settings/src/lib.rs
+++ b/crates/bevy_settings/src/lib.rs
@@ -30,8 +30,8 @@ use bevy_log::warn;
 use bevy_reflect::{
     prelude::ReflectDefault,
     serde::{TypedReflectDeserializer, TypedReflectSerializer},
-    CreateTypeData, FromReflect, PartialReflect, ReflectMut, TypeInfo, TypePath, TypeRegistration,
-    TypeRegistry,
+    CreateTypeData, FromReflect, OnInsertTypeData, PartialReflect, ReflectMut, TypeData, TypeInfo,
+    TypePath, TypeRegistry,
 };
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -162,7 +162,7 @@ pub trait SettingsGroup: Resource {
 }
 
 /// Reflected data from a [`SettingsGroup`].
-#[derive(Clone)]
+#[derive(Clone, TypeData)]
 pub struct ReflectSettingsGroup {
     /// The name of the logical section within the settings file.
     settings_group_name: &'static str,
@@ -181,8 +181,10 @@ impl<T: SettingsGroup + FromReflect + TypePath> CreateTypeData<T> for ReflectSet
         }
     }
 
-    fn insert_dependencies(type_registration: &mut TypeRegistration) {
-        type_registration.register_type_data::<ReflectResource, T>();
+    fn on_insert() -> Option<OnInsertTypeData> {
+        Some(|mut registration| {
+            registration.register_type_data::<ReflectResource, T>();
+        })
     }
 }
 

--- a/crates/bevy_settings/src/lib.rs
+++ b/crates/bevy_settings/src/lib.rs
@@ -199,10 +199,10 @@ impl<T: SettingsGroup + FromReflect + TypePath> CreateTypeData<T> for ReflectSet
         }
     }
 
-    fn on_insert() -> Option<OnInsertTypeData> {
-        Some(|mut registration| {
+    fn on_insert(_: &()) -> Option<OnInsertTypeData> {
+        Some(OnInsertTypeData::new(|mut registration| {
             registration.register_type_data::<ReflectResource, T>();
-        })
+        }))
     }
 }
 

--- a/crates/bevy_settings/src/lib.rs
+++ b/crates/bevy_settings/src/lib.rs
@@ -20,8 +20,8 @@ use bevy_log::warn;
 use bevy_reflect::{
     prelude::ReflectDefault,
     serde::{TypedReflectDeserializer, TypedReflectSerializer},
-    CreateTypeData, FromReflect, PartialReflect, ReflectMut, TypeInfo, TypePath, TypeRegistration,
-    TypeRegistry,
+    CreateTypeData, FromReflect, OnInsertTypeData, PartialReflect, ReflectMut, TypeData, TypeInfo,
+    TypePath, TypeRegistry,
 };
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -180,7 +180,7 @@ pub trait SettingsGroup: Resource {
 }
 
 /// Reflected data from a [`SettingsGroup`].
-#[derive(Clone)]
+#[derive(Clone, TypeData)]
 pub struct ReflectSettingsGroup {
     /// The name of the logical section within the settings file.
     settings_group_name: &'static str,
@@ -199,8 +199,10 @@ impl<T: SettingsGroup + FromReflect + TypePath> CreateTypeData<T> for ReflectSet
         }
     }
 
-    fn insert_dependencies(type_registration: &mut TypeRegistration) {
-        type_registration.register_type_data::<ReflectResource, T>();
+    fn on_insert() -> Option<OnInsertTypeData> {
+        Some(|mut registration| {
+            registration.register_type_data::<ReflectResource, T>();
+        })
     }
 }
 

--- a/crates/bevy_state/src/reflect.rs
+++ b/crates/bevy_state/src/reflect.rs
@@ -1,13 +1,13 @@
 use crate::state::{FreelyMutableState, NextState, State, States};
 
 use bevy_ecs::{reflect::from_reflect_with_fallback, world::World};
-use bevy_reflect::{CreateTypeData, Reflect, TypePath, TypeRegistry};
+use bevy_reflect::{CreateTypeData, Reflect, TypeData, TypePath, TypeRegistry};
 
 /// A struct used to operate on the reflected [`States`] trait of a type.
 ///
 /// A [`ReflectState`] for type `T` can be obtained via
 /// [`bevy_reflect::TypeRegistration::data`].
-#[derive(Clone)]
+#[derive(Clone, TypeData)]
 pub struct ReflectState(ReflectStateFns);
 
 /// The raw function pointers needed to make up a [`ReflectState`].
@@ -51,7 +51,7 @@ impl<S: States + Reflect> CreateTypeData<S> for ReflectState {
 ///
 /// A [`ReflectFreelyMutableState`] for type `T` can be obtained via
 /// [`bevy_reflect::TypeRegistration::data`].
-#[derive(Clone)]
+#[derive(Clone, TypeData)]
 pub struct ReflectFreelyMutableState(ReflectFreelyMutableStateFns);
 
 /// The raw function pointers needed to make up a [`ReflectFreelyMutableState`].

--- a/examples/reflection/type_data.rs
+++ b/examples/reflection/type_data.rs
@@ -2,7 +2,10 @@
 
 use bevy::{
     prelude::*,
-    reflect::{CreateTypeData, TypeRegistry},
+    reflect::{
+        CreateTypeData, OnInsertTypeData, OnRegisterTypeData, TypeData, TypeRegistration,
+        TypeRegistry,
+    },
 };
 
 // It's recommended to read this example from top to bottom.
@@ -40,8 +43,8 @@ fn main() {
 
     // Let's create a type data struct for `Damageable` that we can associate with `Zombie`!
 
-    // Firstly, type data must be cloneable.
-    #[derive(Clone)]
+    // Firstly, the simplest way to create type data is to derive `TypeData`.
+    #[derive(TypeData)]
     // Next, they are usually named with the `Reflect` prefix (we'll see why in a bit).
     struct ReflectDamageable {
         // Type data can contain whatever you want, but it's common to include function pointers
@@ -196,6 +199,80 @@ fn main() {
     // and `Box<dyn Reflect>` into `Box<dyn MyTrait>`, respectively.
     let value: &dyn Health = reflect_health.get(value.as_reflect()).unwrap();
     assert_eq!(value.health(), 50);
+
+    // One final thing you can do with type data is define callbacks for when they are inserted or registered.
+    // We'll create a new type data struct and give it a set of callbacks to see what this looks like.
+    struct MyTypeData;
+
+    // We can add callbacks directly to type data, which will always be invoked.
+    impl TypeData for MyTypeData {
+        // This callback runs when the type data is inserted into a `TypeRegistration`.
+        // We can use it to insert other type data into the same registration.
+        fn on_insert(&self) -> Option<OnInsertTypeData> {
+            Some(OnInsertTypeData::new(|_registration| {
+                println!("called TypeData::on_insert");
+            }))
+        }
+
+        // This callback runs when the `TypeRegistration` is registered (or is already registered).
+        // We can use it to register other types we know we'll need.
+        fn on_register(&self) -> Option<OnRegisterTypeData> {
+            Some(OnRegisterTypeData::new(|_registry| {
+                println!("called TypeData::on_register");
+            }))
+        }
+    }
+
+    // We can also register callbacks on `CreateTypeData`.
+    // These will only be run when using a method like `TypeRegistry::register_type_data`
+    // or `TypeRegistration::register_type_data`.
+    // However, it has the benefit of providing access to the type we're registering, `T`, as well as any input.
+    impl<T: Reflect> CreateTypeData<T, String> for MyTypeData {
+        fn create_type_data(_: String) -> Self {
+            Self
+        }
+
+        // This callback runs when the type data is inserted into a `TypeRegistration`.
+        // We can use it to insert other type data into the same registration.
+        fn on_insert(input: &String) -> Option<OnInsertTypeData> {
+            let input = input.clone();
+            Some(OnInsertTypeData::new(move |_registration| {
+                println!("called CreateTypeData::on_insert with input: {input}");
+            }))
+        }
+
+        // This callback runs when the `TypeRegistration` is registered (or is already registered).
+        // We can use it to register other types we know we'll need.
+        fn on_register(input: &String) -> Option<OnRegisterTypeData> {
+            let input = input.clone();
+            Some(OnRegisterTypeData::new(move |_registry| {
+                println!("called CreateTypeData::on_register with input: {input}");
+            }))
+        }
+    }
+
+    println!("i32:");
+    let registration = TypeRegistration::of::<i32>();
+    // This should invoke `TypeData::on_insert`:
+    let registration = registration.insert_data(MyTypeData);
+
+    let mut registry = TypeRegistry::empty();
+    // This should invoke `TypeData::on_register`:
+    registry.add_registration(registration);
+
+    println!("u32:");
+    registry.register::<u32>();
+    // This should invoke both `TypeData` and `CreateTypeData` callbacks:
+    registry.register_type_data_with::<u32, MyTypeData, _>(String::from("HELLO!"));
+
+    println!("f32:");
+    // But again, note that `CreateTypeData` callbacks are not automatically invoked when used directly
+    let data =
+        <MyTypeData as CreateTypeData<f32, String>>::create_type_data(String::from("HELLO!"));
+    let registration = TypeRegistration::of::<f32>().insert_data(data);
+    registry.add_registration(registration);
+
+    // ========================================================================================== //
 
     // Lastly, here's a list of some useful type data provided by Bevy that you might want to register for your types:
     // - `ReflectDefault` for types that implement `Default`

--- a/examples/reflection/type_data.rs
+++ b/examples/reflection/type_data.rs
@@ -2,7 +2,10 @@
 
 use bevy::{
     prelude::*,
-    reflect::{CreateTypeData, TypeRegistry},
+    reflect::{
+        CreateTypeData, OnInsertTypeData, OnRegisterTypeData, TypeData, TypeRegistration,
+        TypeRegistry,
+    },
 };
 
 // It's recommended to read this example from top to bottom.
@@ -40,8 +43,8 @@ fn main() {
 
     // Let's create a type data struct for `Damageable` that we can associate with `Zombie`!
 
-    // Firstly, type data must be cloneable.
-    #[derive(Clone)]
+    // Firstly, the simplest way to create type data is to derive `TypeData`.
+    #[derive(TypeData)]
     // Next, they are usually named with the `Reflect` prefix (we'll see why in a bit).
     struct ReflectDamageable {
         // Type data can contain whatever you want, but it's common to include function pointers
@@ -198,6 +201,80 @@ fn main() {
     // and `Box<dyn Reflect>` into `Box<dyn MyTrait>`, respectively.
     let value: &dyn Health = reflect_health.get(value.as_reflect()).unwrap();
     assert_eq!(value.health(), 50);
+
+    // One final thing you can do with type data is define callbacks for when they are inserted or registered.
+    // We'll create a new type data struct and give it a set of callbacks to see what this looks like.
+    struct MyTypeData;
+
+    // We can add callbacks directly to type data, which will always be invoked.
+    impl TypeData for MyTypeData {
+        // This callback runs when the type data is inserted into a `TypeRegistration`.
+        // We can use it to insert other type data into the same registration.
+        fn on_insert(&self) -> Option<OnInsertTypeData> {
+            Some(OnInsertTypeData::new(|_registration| {
+                println!("called TypeData::on_insert");
+            }))
+        }
+
+        // This callback runs when the `TypeRegistration` is registered (or is already registered).
+        // We can use it to register other types we know we'll need.
+        fn on_register(&self) -> Option<OnRegisterTypeData> {
+            Some(OnRegisterTypeData::new(|_registry| {
+                println!("called TypeData::on_register");
+            }))
+        }
+    }
+
+    // We can also register callbacks on `CreateTypeData`.
+    // These will only be run when using a method like `TypeRegistry::register_type_data`
+    // or `TypeRegistration::register_type_data`.
+    // However, it has the benefit of providing access to the type we're registering, `T`, as well as any input.
+    impl<T: Reflect> CreateTypeData<T, String> for MyTypeData {
+        fn create_type_data(_: String) -> Self {
+            Self
+        }
+
+        // This callback runs when the type data is inserted into a `TypeRegistration`.
+        // We can use it to insert other type data into the same registration.
+        fn on_insert(input: &String) -> Option<OnInsertTypeData> {
+            let input = input.clone();
+            Some(OnInsertTypeData::new(move |_registration| {
+                println!("called CreateTypeData::on_insert with input: {input}");
+            }))
+        }
+
+        // This callback runs when the `TypeRegistration` is registered (or is already registered).
+        // We can use it to register other types we know we'll need.
+        fn on_register(input: &String) -> Option<OnRegisterTypeData> {
+            let input = input.clone();
+            Some(OnRegisterTypeData::new(move |_registry| {
+                println!("called CreateTypeData::on_register with input: {input}");
+            }))
+        }
+    }
+
+    println!("i32:");
+    let registration = TypeRegistration::of::<i32>();
+    // This should invoke `TypeData::on_insert`:
+    let registration = registration.insert_data(MyTypeData);
+
+    let mut registry = TypeRegistry::empty();
+    // This should invoke `TypeData::on_register`:
+    registry.add_registration(registration);
+
+    println!("u32:");
+    registry.register::<u32>();
+    // This should invoke both `TypeData` and `CreateTypeData` callbacks:
+    registry.register_type_data_with::<u32, MyTypeData, _>(String::from("HELLO!"));
+
+    println!("f32:");
+    // But again, note that `CreateTypeData` callbacks are not automatically invoked when used directly
+    let data =
+        <MyTypeData as CreateTypeData<f32, String>>::create_type_data(String::from("HELLO!"));
+    let registration = TypeRegistration::of::<f32>().insert_data(data);
+    registry.add_registration(registration);
+
+    // ========================================================================================== //
 
     // Lastly, here's a list of some useful type data provided by Bevy that you might want to register for your types:
     // - `ReflectDefault` for types that implement `Default`


### PR DESCRIPTION
# Objective

This is a rework of #9777.

I'll give the TL;DR of the objective from that PR here.

Many times we'll define type data that relies on other types and type data being registered.

An example in our codebase might be `ReflectAsset`. This type data wants to work with other types and type data. So to ensure these are available in the registry, we define an extension method on `App` specifically for their registration: https://github.com/bevyengine/bevy/blob/7517c61ecdc610465416813668e106f27f5def49/crates/bevy_asset/src/lib.rs#L673-L691

This method registers other types like `Handle<A>` and type data like `ReflectHandle`. But users need to know to use it. Not only that, but it means that other libraries with similar needs will likely want to follow in the same footsteps, meaning more work for library authors and more mental burden for library users.

Registering such a type should be as simple as this:

```rust
#[derive(Reflect, Asset)]
#[reflect(Asset)]
struct MyAsset;

app.register::<MyAsset>();
```

Done. No special app extension methods. Just a simple registration like every other type.

## Solution

#### Callbacks

To achieve this, this PR adds a more comprehensive set of registration callbacks. The following callbacks have been added:

- `TypeData::on_insert`
- `TypeData::on_register`
- `CreateTypeData::on_insert` (`CreateTypeData::insert_dependencies` has been deprecated)
- `CreateTypeData::on_register`

The `on_insert` callbacks are invoked when the type data is inserted into a `TypeRegistration`. The `on_register` callbacks are invoked when that `TypeRegistration` is registered into a `TypeRegistration` (or immediately if already registered—more on how we do that later).

I chose to allow callbacks on both traits for maximum flexibility. Here is a list of their pros/cons:
- `TypeData` callbacks
  - Work for all type data, regardless of whether `CreateTypeData` is also implemented
  - Always invoked no matter which method on `TypeRegistration`/`TypeRegistry` is used
  - Access to `&self` for runtime-defined callbacks
  - No compile-time information for the type the type data is being registered to
- `CreateTypeData` callbacks
  - Only invoked when registered through specific methods on `TypeRegistration` and `TypeRegistry`
  - Provide full compile-time information for the type the type data is being registered to
  - Ability to pass in input directly from the derive macro
  - No access to `&self` (though, we certainly could add that if we think it would be beneficial)

Below is how we might redefine `ReflectAsset` to make use of these callbacks:

```rust
impl<A: Asset + FromReflect> CreateTypeData<A> for ReflectAsset {
  // ...

  fn on_register(_: &()) -> Option<OnRegisterTypeData> {
    Some(OnRegisterTypeData::new(|registry| {
      registry.register::<A>();
      registry.register::<Handle<A>>();
      registry.register::<HandleTemplate<A>>();
      registry.register_type_data::<Handle<A>, ReflectHandle>();
      registry.register_type_conversion::<String, HandleTemplate<A>, _>(|s| Ok(s.into()));
    }))
  }
}
```

#### Removed Clone

Additionally, I removed the restriction that `TypeRegistration: Clone`. It's really not needed for any of our internal machinery and it doesn't appear to be useful for users in most cases.

This also means that type data no longer needs to be `Clone`. So now the only real requirements are `Self: Send + Sync + 'static`, allowing for much more flexibility in defining type data.

#### Derive Macro

We also introduce a derive macro to quickly derive `TypeData` without any callbacks. This macro was kept very barebones for this PR. We can explore improvements and helper attributes for it in a followup PR (such as a way to easily define callbacks or dependencies).

#### Restricted Type Data Insertions

To ensure that callbacks are almost always properly invoked, we had to change how type data is inserted into a `TypeRegistration`. The main change is that type data can no longer be inserted directly onto a `&mut TypeRegistration`. Instead, type data must be inserted onto an owned instance of `TypeRegistration`.

Additionally, the `on_insert` callbacks are provided a `TypeRegistrationMut<'_>` in order to mutably insert type data onto an existing registration. This type is also used by the new `TypeRegistry::registration_scope` method to provide users with a way of inserting multiple type data without incurring the cost of multiple registration lookups).

By adding these restrictions, we can ensure that `on_register` callbacks are always invoked.

#### Documentation Improvements

I also went ahead and added a new set of docs for the `type_data` module (which is now public). I figured since things were getting somewhat complicated, it made sense to have a central place explaining how everything works together.

I also updated the `type_data` example to account for the new changes. 

## Testing

I added extensive unit tests to `bevy_reflect` and also updated the `type_data` example.

## Followup Work

After working on this PR, I think I've determined the following work as good for followup:

- Reorganizing all type data and registry code into a new `registry` directory module
- Improving the derive macro with additional helper attributes (possibly similar to how hooks are defined for `Component` derives)
- Identify existing type data, like `ReflectAsset`, that could benefit from these changes
- Doing a cleanup pass to ensure consistency in naming, parameter ordering, etc. (e.g., we use both `input` and `params` for talking about `CreateTypeData` input)

~~Additionally, we could consider adding the ability to queue additional `on_register` callbacks onto a `TypeRegistration` apart from type data (potentially removing the need for `GetTypeRegistration::register_type_dependencies`). This is actually trivial to implement with this PR, but I was worried there was already too much happening in a single diff. Of course, if we'd definitely like to do that, I can do that!~~ Drafted a PR: https://github.com/MrGVSV/bevy/pull/2

## AI Usage Disclaimer

As per the AI usage policy, I did not have LLMs generate any code, assets, examples, or documentation—including this PR's description. Nor did I use LLMs to make design decisions for me.

My AI usage was limited to using ChatGPT for rubberducking, evaluating solutions, and suggesting type names.

---

## Showcase

Type data can now be defined with a comprehensive set of registration callbacks, including `on_insert` and `on_register`.

Additionally, type data no longer needs to be `Clone` and instead only needs to implement or derive `TypeData`.

Below is a snippet from our newly updated [type data example](https://github.com/bevyengine/bevy/blob/latest/examples/reflection/type_data.rs):

<details>
  <summary>Click to view showcase</summary>

```rust
struct MyTypeData;

// We can add callbacks directly to type data, which will always be invoked.
impl TypeData for MyTypeData {
    // This callback runs when the type data is inserted into a `TypeRegistration`.
    // We can use it to insert other type data into the same registration.
    fn on_insert(&self) -> Option<OnInsertTypeData> {
        Some(OnInsertTypeData::new(|_registration| {
            println!("called TypeData::on_insert");
        }))
    }

    // This callback runs when the `TypeRegistration` is registered (or is already registered).
    // We can use it to register other types we know we'll need.
    fn on_register(&self) -> Option<OnRegisterTypeData> {
        Some(OnRegisterTypeData::new(|_registry| {
            println!("called TypeData::on_register");
        }))
    }
}

// We can also register callbacks on `CreateTypeData`.
// These will only be run when using a method like `TypeRegistry::register_type_data`
// or `TypeRegistration::register_type_data`.
// However, it has the benefit of providing access to the type we're registering, `T`, as well as any input.
impl<T: Reflect> CreateTypeData<T, String> for MyTypeData {
    fn create_type_data(_: String) -> Self {
        Self
    }

    // This callback runs when the type data is inserted into a `TypeRegistration`.
    // We can use it to insert other type data into the same registration.
    fn on_insert(input: &String) -> Option<OnInsertTypeData> {
        let input = input.clone();
        Some(OnInsertTypeData::new(move |_registration| {
            println!("called CreateTypeData::on_insert with input: {input}");
        }))
    }

    // This callback runs when the `TypeRegistration` is registered (or is already registered).
    // We can use it to register other types we know we'll need.
    fn on_register(input: &String) -> Option<OnRegisterTypeData> {
        let input = input.clone();
        Some(OnRegisterTypeData::new(move |_registry| {
            println!("called CreateTypeData::on_register with input: {input}");
        }))
    }
}

println!("i32:");
let registration = TypeRegistration::of::<i32>();
// This should invoke `TypeData::on_insert`:
let registration = registration.insert_data(MyTypeData);

let mut registry = TypeRegistry::empty();
// This should invoke `TypeData::on_register`:
registry.add_registration(registration);

println!("u32:");
registry.register::<u32>();
// This should invoke both `TypeData` and `CreateTypeData` callbacks:
registry.register_type_data_with::<u32, MyTypeData, _>(String::from("HELLO!"));

println!("f32:");
// But again, note that `CreateTypeData` callbacks are not automatically invoked when used directly
let data =
    <MyTypeData as CreateTypeData<f32, String>>::create_type_data(String::from("HELLO!"));
let registration = TypeRegistration::of::<f32>().insert_data(data);
registry.add_registration(registration);
```

Output:

```
i32:
called TypeData::on_insert
called TypeData::on_register
u32:
called TypeData::on_insert
called CreateTypeData::on_insert with input: HELLO!
called TypeData::on_register
called CreateTypeData::on_register with input: HELLO!
f32:
called TypeData::on_insert
called TypeData::on_register
```

</details>
