### PR TITLE
Fix bsn! autocomplete in function arguments by using loose parsing

### DIFF
--- a/crates/bevy_scene/macros/src/bsn/codegen.rs
+++ b/crates/bevy_scene/macros/src/bsn/codegen.rs
@@ -1,13 +1,13 @@
 use crate::bsn::types::{
-    Bsn, BsnConstructor, BsnEntry, BsnFields, BsnListRoot, BsnRelatedSceneList, BsnRoot, BsnScene,
-    BsnSceneFn, BsnSceneFnArg, BsnSceneFnArgs, BsnSceneListItem, BsnSceneListItems, BsnType,
-    BsnValue,
+    Bsn, BsnConstructor, BsnEntry, BsnFields, BsnFnArg, BsnFnArgs, BsnListRoot,
+    BsnRelatedSceneList, BsnRoot, BsnScene, BsnSceneFn, BsnSceneListItem, BsnSceneListItems,
+    BsnType, BsnValue,
 };
 use bevy_macro_utils::{fq_std::FQDefault, path_to_string};
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote, ToTokens};
 use std::collections::{hash_map::Entry, HashMap, HashSet};
-use syn::{parse::Parse, punctuated::Punctuated, ExprTuple, Ident, Index, Lit, Member, Path};
+use syn::{parse::Parse, ExprTuple, Ident, Index, Lit, Member, Path};
 
 /// Tracks named entity references and assigns them unique, sequential indices
 /// during the code generation process.
@@ -260,7 +260,7 @@ impl BsnEntry {
                 let args = args.to_tokens(ctx);
                 quote! {
                     let value = _scene.get_or_insert_template::<#type_path>(_context);
-                    *value = #type_path::#function(#args);
+                    *value = #type_path::#function #args;
                 }
             }),
             BsnEntry::FromTemplateConstructor(BsnConstructor {
@@ -271,7 +271,7 @@ impl BsnEntry {
                 let args = args.to_tokens(ctx);
                 quote! {
                     let value = _scene.get_or_insert_template::<<#type_path as #bevy_ecs::template::FromTemplate>::Template>(_context);
-                    *value = <#type_path as #bevy_ecs::template::FromTemplate>::Template::#function(#args);
+                    *value = <#type_path as #bevy_ecs::template::FromTemplate>::Template::#function #args;
                 }
             }),
             BsnEntry::RelatedSceneList(BsnRelatedSceneList {
@@ -648,40 +648,12 @@ impl BsnTokenStream for BsnSceneListItems {
     }
 }
 
-impl BsnTokenStream for BsnSceneFnArg {
-    fn to_tokens(&self, ctx: &mut BsnCodegenCtx) -> TokenStream {
-        let bevy_ecs = ctx.bevy_ecs;
-        match self {
-            BsnSceneFnArg::Expr(expr) => quote! {#expr},
-            BsnSceneFnArg::Name(ident) => {
-                let index = ctx.entity_refs.get(ident.to_string());
-                let invocation = ctx.invocation_index.clone();
-                quote! {
-                    #bevy_ecs::template::EntityTemplate::SceneEntityReference(
-                        #bevy_ecs::template::SceneEntityReference::new(#invocation, #index, _call_id)
-                    )
-                }
-            }
-        }
-    }
-}
-
-impl BsnTokenStream for BsnSceneFnArgs {
-    fn to_tokens(&self, ctx: &mut BsnCodegenCtx) -> TokenStream {
-        let mut args: Punctuated<_, syn::Token![,]> = Punctuated::new();
-        // rebuilding the punctuated is required because ctx needs to be passed
-        for arg in self.0.iter().flatten() {
-            args.push(arg.to_tokens(ctx));
-        }
-        quote! {#args}
-    }
-}
 impl BsnSceneFn {
     fn to_tokens(&self, ctx: &mut BsnCodegenCtx) -> TokenStream {
         let bevy_scene = ctx.bevy_scene;
         let args = self.args.to_tokens(ctx);
-        let path = self.path.clone();
-        quote! {#bevy_scene::SceneScope(#path(#args))}
+        let path = &self.path;
+        quote! {#bevy_scene::SceneScope(#path #args)}
     }
 }
 
@@ -708,6 +680,30 @@ impl ToTokens for BsnType {
     }
 }
 
+impl BsnTokenStream for BsnFnArgs {
+    fn to_tokens(&self, ctx: &mut BsnCodegenCtx) -> TokenStream {
+        let args = self.0.iter().map(|a| a.to_tokens(ctx));
+        quote! { (#(#args),*) }
+    }
+}
+
+impl BsnTokenStream for BsnFnArg {
+    fn to_tokens(&self, ctx: &mut BsnCodegenCtx) -> TokenStream {
+        let bevy_ecs = ctx.bevy_ecs;
+        match self {
+            BsnFnArg::EntityName(ident) => {
+                let index = ctx.entity_refs.get(ident.to_string());
+                let invocation = ctx.invocation_index.clone();
+                quote! {
+                    #bevy_ecs::template::EntityTemplate::SceneEntityReference(
+                        #bevy_ecs::template::SceneEntityReference::new(#invocation, #index, _call_id)
+                    )
+                }
+            }
+            BsnFnArg::Tokens(token_stream) => token_stream.clone(),
+        }
+    }
+}
 impl ToTokens for BsnValue {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         match self {

--- a/crates/bevy_scene/macros/src/bsn/parse.rs
+++ b/crates/bevy_scene/macros/src/bsn/parse.rs
@@ -1,6 +1,6 @@
 use crate::bsn::types::{
-    Bsn, BsnConstructor, BsnEntry, BsnFields, BsnListRoot, BsnNamedField, BsnRelatedSceneList,
-    BsnRoot, BsnScene, BsnSceneFn, BsnSceneFnArg, BsnSceneFnArgs, BsnSceneList, BsnSceneListItem,
+    Bsn, BsnConstructor, BsnEntry, BsnFields, BsnFnArg, BsnFnArgs, BsnListRoot, BsnNamedField,
+    BsnRelatedSceneList, BsnRoot, BsnScene, BsnSceneFn, BsnSceneList, BsnSceneListItem,
     BsnSceneListItems, BsnTuple, BsnType, BsnUnnamedField, BsnValue,
 };
 use bevy_macro_utils::{path_to_string, PathType};
@@ -10,10 +10,10 @@ use syn::{
     braced, bracketed,
     buffer::Cursor,
     parenthesized,
-    parse::{Parse, ParseBuffer, ParseStream},
+    parse::{discouraged::Speculative, Parse, ParseBuffer, ParseStream},
     spanned::Spanned,
     token::{At, Brace, Bracket, Colon, Comma, Paren, Tilde},
-    Block, Expr, Ident, Lit, LitStr, Path, Result, Token,
+    Block, Ident, Lit, LitStr, Path, Result, Token,
 };
 
 /// Functionally identical to [`Punctuated`](syn::punctuated::Punctuated), but fills the given `$list` Vec instead
@@ -154,11 +154,11 @@ impl BsnEntry {
                 }
                 PathType::TypeFunction => {
                     let function = take_last_path_ident(&mut path).unwrap();
-
+                    let args = input.parse::<BsnFnArgs>()?;
                     let bsn_constructor = BsnConstructor {
                         type_path: path,
                         function,
-                        args: input.parse()?,
+                        args,
                     };
                     if is_template {
                         BsnEntry::TemplateConstructor(bsn_constructor)
@@ -168,7 +168,7 @@ impl BsnEntry {
                 }
                 PathType::Function => {
                     if input.peek(Paren) {
-                        let args = input.parse()?;
+                        let args = input.parse::<BsnFnArgs>()?;
                         BsnEntry::UncachedScene(BsnScene::Fn(BsnSceneFn { path, args }))
                     } else {
                         BsnEntry::UncachedScene(BsnScene::Expression(quote! {#path}))
@@ -205,29 +205,6 @@ impl Parse for BsnSceneListItem {
     }
 }
 
-impl Parse for BsnSceneFnArgs {
-    fn parse(input: ParseStream) -> Result<Self> {
-        let args = if input.peek(Paren) {
-            let content;
-            parenthesized!(content in input);
-            Some(content.parse_terminated(BsnSceneFnArg::parse, Token![,])?)
-        } else {
-            None
-        };
-        Ok(Self(args))
-    }
-}
-
-impl Parse for BsnSceneFnArg {
-    fn parse(input: ParseStream) -> Result<Self> {
-        if input.peek(Token![#]) {
-            input.parse::<Token![#]>()?;
-            Ok(Self::Name(input.parse::<Ident>()?))
-        } else {
-            Ok(Self::Expr(Expr::parse(input)?))
-        }
-    }
-}
 impl BsnScene {
     fn parse(input: ParseStream) -> Result<Self> {
         let cached = if input.peek(Token![:]) {
@@ -289,14 +266,11 @@ impl BsnScene {
                 }
                 PathType::Function | PathType::TypeFunction => {
                     let path = input.parse::<Path>()?;
-                    let func = BsnSceneFn {
-                        path,
-                        args: input.parse()?,
-                    };
-                    if func.args.0.is_some() {
+                    let args = input.parse::<BsnFnArgs>()?;
+                    if !args.0.is_empty() {
                         err_if_cached("Cannot cache Scene function with arguments")?;
                     }
-                    BsnScene::Fn(func)
+                    BsnScene::Fn(BsnSceneFn { path, args })
                 }
                 path_type => {
                     return Err(syn::Error::new(
@@ -410,6 +384,47 @@ impl Parse for BsnUnnamedField {
     }
 }
 
+/// Parses tuple arguments into a list of [`TokenStream`]s. This avoids
+/// fully parsing Rust expressions, which makes this less strict and cheaper to parse.
+/// This also allows autocomplete to work, even if the tokens aren't a valid rust expression.
+fn parse_tuple_loose(input: &ParseBuffer) -> Result<Vec<TokenStream>> {
+    let content;
+    parenthesized!(content in input);
+    let mut args = Vec::new();
+    let mut current_tokens = Vec::new();
+    let mut in_closure_args = false;
+    let mut generic_scope = 0;
+    while !content.is_empty() {
+        let tt = content.parse::<TokenTree>()?;
+        match &tt {
+            TokenTree::Punct(punct) => match punct.as_char() {
+                ',' if !in_closure_args && generic_scope == 0 => {
+                    args.push(TokenStream::from_iter(current_tokens.drain(..)));
+                }
+                '|' => {
+                    in_closure_args = !in_closure_args;
+                    current_tokens.push(tt);
+                }
+                '<' => {
+                    generic_scope += 1;
+                    current_tokens.push(tt);
+                }
+                '>' => {
+                    generic_scope -= 1;
+                    current_tokens.push(tt);
+                }
+                _ => current_tokens.push(tt),
+            },
+            _ => current_tokens.push(tt),
+        }
+    }
+
+    if !current_tokens.is_empty() {
+        args.push(TokenStream::from_iter(current_tokens));
+    }
+    Ok(args)
+}
+
 /// Parse a closure "loosely" without caring about the tokens between `|...|` and `{...}`. This ensures autocomplete works.
 fn parse_closure_loose(input: &ParseBuffer) -> Result<TokenStream> {
     let start = input.cursor();
@@ -506,6 +521,41 @@ impl Parse for BsnValue {
         } else {
             return Err(input.error("Unexpected input: Invalid BsnValue. This does not match any expected BSN value type."));
         })
+    }
+}
+
+impl Parse for BsnFnArgs {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let mut fn_args = Vec::new();
+        for tokens in parse_tuple_loose(input)? {
+            fn_args.push(syn::parse2::<BsnFnArg>(tokens)?)
+        }
+        Ok(BsnFnArgs(fn_args))
+    }
+}
+
+impl Parse for BsnFnArg {
+    fn parse(input: ParseStream) -> Result<Self> {
+        Ok(if input.peek(Token![#]) {
+            let forked = input.fork();
+            if let Ok(ident) = forked.parse::<EntityNameIdent>() {
+                input.advance_to(&forked);
+                BsnFnArg::EntityName(ident.0)
+            } else {
+                BsnFnArg::Tokens(input.parse::<TokenStream>()?)
+            }
+        } else {
+            BsnFnArg::Tokens(input.parse::<TokenStream>()?)
+        })
+    }
+}
+
+struct EntityNameIdent(Ident);
+
+impl Parse for EntityNameIdent {
+    fn parse(input: ParseStream) -> Result<Self> {
+        input.parse::<Token![#]>()?;
+        Ok(EntityNameIdent(input.parse::<Ident>()?))
     }
 }
 

--- a/crates/bevy_scene/macros/src/bsn/parse.rs
+++ b/crates/bevy_scene/macros/src/bsn/parse.rs
@@ -387,6 +387,8 @@ impl Parse for BsnUnnamedField {
 /// Parses tuple arguments into a list of [`TokenStream`]s. This avoids
 /// fully parsing Rust expressions, which makes this less strict and cheaper to parse.
 /// This also allows autocomplete to work, even if the tokens aren't a valid rust expression.
+///
+/// This will accept anything "tuple-like" in the form (X1, ..., XY), where XY is a TokenStream.
 fn parse_tuple_loose(input: &ParseBuffer) -> Result<Vec<TokenStream>> {
     let content;
     parenthesized!(content in input);

--- a/crates/bevy_scene/macros/src/bsn/types.rs
+++ b/crates/bevy_scene/macros/src/bsn/types.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream;
-use syn::{punctuated::Punctuated, Expr, Ident, Lit, LitStr, Path, Stmt, Token};
+use syn::{Ident, Lit, LitStr, Path, Stmt};
 
 #[derive(Debug)]
 pub struct BsnRoot(pub Bsn<true>);
@@ -51,18 +51,9 @@ pub enum BsnSceneListItem {
 }
 
 #[derive(Debug)]
-pub enum BsnSceneFnArg {
-    Expr(Expr),
-    Name(Ident),
-}
-
-#[derive(Debug)]
-pub struct BsnSceneFnArgs(pub Option<Punctuated<BsnSceneFnArg, Token![,]>>);
-
-#[derive(Debug)]
 pub struct BsnSceneFn {
     pub path: Path,
-    pub args: BsnSceneFnArgs,
+    pub args: BsnFnArgs,
 }
 
 #[derive(Debug)]
@@ -77,7 +68,7 @@ pub enum BsnScene {
 pub struct BsnConstructor {
     pub type_path: Path,
     pub function: Ident,
-    pub args: BsnSceneFnArgs,
+    pub args: BsnFnArgs,
 }
 
 #[derive(Debug)]
@@ -121,3 +112,12 @@ pub enum BsnValue {
     Tuple(BsnTuple),
     Name(Ident),
 }
+
+#[derive(Debug)]
+pub enum BsnFnArg {
+    EntityName(Ident),
+    Tokens(TokenStream),
+}
+
+#[derive(Debug)]
+pub struct BsnFnArgs(pub Vec<BsnFnArg>);


### PR DESCRIPTION
# Objective

https://github.com/bevyengine/bevy/pull/24174 (which adds support for `#Name` in "function argument position) broke `bsn!` autocomplete in function arguments by using `Expr` parsing for them, which will fail to parse (and therefore fail to produce macro outputs) when an expression isn't _currently_ valid rust. This breaks down when your are typing something that isn't _yet_ perfectly valid rust (ex: missing a semicolon, incomplete struct syntax, etc).

`Expr` parsing in this context is also slower, as it requires enforcing exact Rust syntax. This is redundant because rust will do that later when it compiles the final outputs.

## Solution

Stop using `Expr` parsing and instead implement a looser approach to parsing tuple arguments (which we already do elsewhere for things like closures). This requires a degree of "scope awareness", because we only want to split the TokenStream on top-level `,` separators, not on commas contained in things like `(a,b,c)`,  `[a,b,c]`, or `|a,b,c|`.   `#Name` expression parsing is then built on top of that, once we have separated the arguments into individual streams.