### PR TITLE
add missing run support for `SystemHandle`

### DIFF
--- a/crates/bevy_ecs/src/system/commands/command.rs
+++ b/crates/bevy_ecs/src/system/commands/command.rs
@@ -182,7 +182,8 @@ pub fn remove_resource<R: Resource>() -> impl Command {
 }
 
 /// A [`Command`] that runs the system corresponding to the given [`SystemId`].
-pub fn run_system<O: 'static>(id: SystemId<(), O>) -> impl Command {
+pub fn run_system<O: 'static>(id: impl Into<SystemId<(), O>> + Send) -> impl Command {
+    let id = id.into();
     move |world: &mut World| -> Result {
         world.run_system(id)?;
         Ok(())
@@ -191,10 +192,14 @@ pub fn run_system<O: 'static>(id: SystemId<(), O>) -> impl Command {
 
 /// A [`Command`] that runs the system corresponding to the given [`SystemId`]
 /// and provides the given input value.
-pub fn run_system_with<I>(id: SystemId<I>, input: I::Inner<'static>) -> impl Command
+pub fn run_system_with<I>(
+    id: impl Into<SystemId<I>> + Send,
+    input: I::Inner<'static>,
+) -> impl Command
 where
     I: SystemInput<Inner<'static>: Send> + 'static,
 {
+    let id = id.into();
     move |world: &mut World| -> Result {
         world.run_system_with(id, input)?;
         Ok(())

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -952,7 +952,7 @@ impl<'w, 's> Commands<'w, 's> {
     ///
     /// It will internally return a [`RegisteredSystemError`](crate::system::system_registry::RegisteredSystemError),
     /// which will be handled by [logging the error at the `warn` level](warn).
-    pub fn run_system(&mut self, id: SystemId) {
+    pub fn run_system(&mut self, id: impl Into<SystemId> + Send) {
         self.queue(command::run_system(id).handle_error_with(warn));
     }
 
@@ -974,8 +974,11 @@ impl<'w, 's> Commands<'w, 's> {
     ///
     /// It will internally return a [`RegisteredSystemError`](crate::system::system_registry::RegisteredSystemError),
     /// which will be handled by [logging the error at the `warn` level](warn).
-    pub fn run_system_with<I>(&mut self, id: SystemId<I>, input: I::Inner<'static>)
-    where
+    pub fn run_system_with<I>(
+        &mut self,
+        id: impl Into<SystemId<I>> + Send,
+        input: I::Inner<'static>,
+    ) where
         I: SystemInput<Inner<'static>: Send> + 'static,
     {
         self.queue(command::run_system_with(id, input).handle_error_with(warn));

--- a/crates/bevy_ecs/src/system/system_registry.rs
+++ b/crates/bevy_ecs/src/system/system_registry.rs
@@ -292,6 +292,18 @@ impl<I: SystemInput, O> core::fmt::Debug for SystemId<I, O> {
     }
 }
 
+impl<I: SystemInput, O> From<&SystemHandle<I, O>> for SystemId<I, O> {
+    fn from(handle: &SystemHandle<I, O>) -> Self {
+        Self::from_entity(handle.entity())
+    }
+}
+
+impl<I: SystemInput, O> From<SystemHandle<I, O>> for SystemId<I, O> {
+    fn from(handle: SystemHandle<I, O>) -> Self {
+        (&handle).into()
+    }
+}
+
 impl<I: SystemInput + 'static, O: 'static> FromTemplate for SystemHandle<I, O> {
     type Template = SystemHandleTemplate<I, O>;
 }
@@ -1419,5 +1431,20 @@ mod tests {
 
             assert_eq!(a, b);
         }
+    }
+
+    #[test]
+    fn run_system_with_owned_system_handle() {
+        fn increment(mut counter: ResMut<Counter>) {
+            counter.0 += 1;
+        }
+
+        let mut world = World::new();
+        world.insert_resource(Counter(0));
+
+        let handle = world.register_tracked_system(increment);
+        world.run_system(handle).expect("system runs successfully");
+
+        assert_eq!(*world.resource::<Counter>(), Counter(1));
     }
 }


### PR DESCRIPTION
# Objective

- The `SystemHandle` was introduced in #24165. But it didn't come with full `run_system` support.

## Solution

- Implement `From<SystemHandle<I, O>>` and `From<&SystemHandle<I, O>>` for `SystemId<I, O>` to make it available for `run_system`. Using `SystemHandle::entity()` and `SystemId::from_entity()`.
- Let `Commands::run_system*` and `commands::command::run_system*` to accept `impl Into<SystemId>`

## Testing

- Add a test `system::system_registry::tests::run_system_with_owned_system_handle`, to run a `SystemHandle`.

---

## Showcase

```rust
world.run_system(handle)

// or borrowing from a reference
world.run_system(&handle)
```