### PR TITLE
Add some whitespace to custom_phase_item docs

### DIFF
--- a/examples/shader_advanced/custom_phase_item.rs
+++ b/examples/shader_advanced/custom_phase_item.rs
@@ -4,7 +4,7 @@
 //! [`bevy_render::render_phase::BinnedRenderPhase`] functionality with a
 //! custom [`RenderCommand`] to allow inserting arbitrary GPU drawing logic
 //! into Bevy's pipeline. This is not the only way to add custom rendering code
-//! into Bevy—render nodes are another, lower-level method—but it does allow
+//! into Bevy — render nodes are another, lower-level method — but it does allow
 //! for better reuse of parts of Bevy's built-in mesh rendering logic.
 
 use bevy::{


### PR DESCRIPTION
# Objective
Tried reading the custom_phase_item docs and it took me a solid 10s to figure out what it was saying. I think the monospace-ness + no whitespace + em dash just tripped me up

## Solution
Just add whitespace around it.

## Testing
Eyeballs perceived the subpixel rendered font and gave more dopamine with a lack of subpixels between characters.