### PR TITLE
Rename the `PbrNeutral` tonemapper to `KhronosPbrNeutral` and improve the docs.

### DIFF
--- a/crates/bevy_core_pipeline/src/tonemapping/mod.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/mod.rs
@@ -162,8 +162,8 @@ pub enum Tonemapping {
     BlenderFilmic,
     /// Despite its name, it is not considered to be neutral.
     /// Highly saturated colors and tends to produce a very high contrast image.
-    /// Tends to crush dark colors which can make it harder to see details in dark areas.
-    /// Designed for e-commerce to faithfully reproduce the colors of brand's logos when used with low brightness lights.
+    /// Suffers from significant [Abney shifting](https://en.wikipedia.org/wiki/Abney_effect), and tends to crush grays and desaturated colors.
+    /// Designed for e-commerce to faithfully reproduce the colors of brand's logos when used with low brightness grayscale lighting.
     /// See [the KhronosGroup spec](https://github.com/KhronosGroup/ToneMapping/tree/main/PBR_Neutral) for more information.
     KhronosPbrNeutral,
 }

--- a/crates/bevy_core_pipeline/src/tonemapping/mod.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/mod.rs
@@ -162,7 +162,7 @@ pub enum Tonemapping {
     BlenderFilmic,
     /// Designed to faithfully reproduce base color under neutral lighting. Suitable for e-commerce, architecture and CAD applications.
     /// See [the KhronosGroup spec](https://github.com/KhronosGroup/ToneMapping/tree/main/PBR_Neutral) for more information.
-    PbrNeutral,
+    KhronosPbrNeutral,
 }
 
 impl Tonemapping {
@@ -268,7 +268,7 @@ impl SpecializedRenderPipeline for TonemappingPipeline {
                 );
                 shader_defs.push("TONEMAP_METHOD_BLENDER_FILMIC".into());
             }
-            Tonemapping::PbrNeutral => shader_defs.push("TONEMAP_METHOD_PBR_NEUTRAL".into()),
+            Tonemapping::KhronosPbrNeutral => shader_defs.push("TONEMAP_METHOD_PBR_NEUTRAL".into()),
         }
         RenderPipelineDescriptor {
             label: Some("tonemapping pipeline".into()),
@@ -396,7 +396,7 @@ pub fn get_lut_bindings<'a>(
         | Tonemapping::ReinhardLuminance
         | Tonemapping::AcesFitted
         | Tonemapping::AgX
-        | Tonemapping::PbrNeutral
+        | Tonemapping::KhronosPbrNeutral
         | Tonemapping::SomewhatBoringDisplayTransform => &tonemapping_luts.agx,
         Tonemapping::TonyMcMapface => &tonemapping_luts.tony_mc_mapface,
         Tonemapping::BlenderFilmic => &tonemapping_luts.blender_filmic,

--- a/crates/bevy_core_pipeline/src/tonemapping/mod.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/mod.rs
@@ -160,7 +160,8 @@ pub enum Tonemapping {
     /// Somewhat neutral. Suffers from hue shifting. Brights desaturate across the spectrum.
     /// NOTE: Requires the `tonemapping_luts` cargo feature.
     BlenderFilmic,
-    /// Not neutral. Highly saturated colors and tends to produce a very high contrast image.
+    /// Despite its name, it is not considered to be neutral.
+    /// Highly saturated colors and tends to produce a very high contrast image.
     /// Tends to crush dark colors which can make it harder to see details in dark areas.
     /// Designed for e-commerce to faithfully reproduce the colors of brand's logos when used with low brightness lights.
     /// See [the KhronosGroup spec](https://github.com/KhronosGroup/ToneMapping/tree/main/PBR_Neutral) for more information.

--- a/crates/bevy_core_pipeline/src/tonemapping/mod.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/mod.rs
@@ -160,9 +160,9 @@ pub enum Tonemapping {
     /// Somewhat neutral. Suffers from hue shifting. Brights desaturate across the spectrum.
     /// NOTE: Requires the `tonemapping_luts` cargo feature.
     BlenderFilmic,
-    /// Not neutral. Highly saturated colours and tends to produce a very high contrast image.
-    /// Tends to crush dark colours which can make it harder to see details in dark areas.
-    /// Designed for e-commerce to faithfully reproduce the colours of brand's logos when used with low brightness lights.
+    /// Not neutral. Highly saturated colors and tends to produce a very high contrast image.
+    /// Tends to crush dark colors which can make it harder to see details in dark areas.
+    /// Designed for e-commerce to faithfully reproduce the colors of brand's logos when used with low brightness lights.
     /// See [the KhronosGroup spec](https://github.com/KhronosGroup/ToneMapping/tree/main/PBR_Neutral) for more information.
     KhronosPbrNeutral,
 }

--- a/crates/bevy_core_pipeline/src/tonemapping/mod.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/mod.rs
@@ -160,7 +160,9 @@ pub enum Tonemapping {
     /// Somewhat neutral. Suffers from hue shifting. Brights desaturate across the spectrum.
     /// NOTE: Requires the `tonemapping_luts` cargo feature.
     BlenderFilmic,
-    /// Designed to faithfully reproduce base color under neutral lighting. Suitable for e-commerce, architecture and CAD applications.
+    /// Not neutral. Highly saturated colours and tends to produce a very high contrast image.
+    /// Tends to crush dark colours which can make it harder to see details in dark areas.
+    /// Designed for e-commerce to faithfully reproduce the colours of brand's logos when used with low brightness lights.
     /// See [the KhronosGroup spec](https://github.com/KhronosGroup/ToneMapping/tree/main/PBR_Neutral) for more information.
     KhronosPbrNeutral,
 }

--- a/crates/bevy_pbr/src/deferred/mod.rs
+++ b/crates/bevy_pbr/src/deferred/mod.rs
@@ -494,7 +494,7 @@ pub fn prepare_deferred_lighting_pipelines(
                     }
                     Tonemapping::TonyMcMapface => MeshPipelineKey::TONEMAP_METHOD_TONY_MC_MAPFACE,
                     Tonemapping::BlenderFilmic => MeshPipelineKey::TONEMAP_METHOD_BLENDER_FILMIC,
-                    Tonemapping::PbrNeutral => MeshPipelineKey::TONEMAP_METHOD_PBR_NEUTRAL,
+                    Tonemapping::KhronosPbrNeutral => MeshPipelineKey::TONEMAP_METHOD_PBR_NEUTRAL,
                 };
             }
             if let Some(DebandDither::Enabled) = dither {

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -703,7 +703,7 @@ pub const fn tonemapping_pipeline_key(tonemapping: Tonemapping) -> MeshPipelineK
         }
         Tonemapping::TonyMcMapface => MeshPipelineKey::TONEMAP_METHOD_TONY_MC_MAPFACE,
         Tonemapping::BlenderFilmic => MeshPipelineKey::TONEMAP_METHOD_BLENDER_FILMIC,
-        Tonemapping::PbrNeutral => MeshPipelineKey::TONEMAP_METHOD_PBR_NEUTRAL,
+        Tonemapping::KhronosPbrNeutral => MeshPipelineKey::TONEMAP_METHOD_PBR_NEUTRAL,
     }
 }
 

--- a/crates/bevy_sprite_render/src/mesh2d/material.rs
+++ b/crates/bevy_sprite_render/src/mesh2d/material.rs
@@ -579,7 +579,7 @@ pub const fn tonemapping_pipeline_key(tonemapping: Tonemapping) -> Mesh2dPipelin
         }
         Tonemapping::TonyMcMapface => Mesh2dPipelineKey::TONEMAP_METHOD_TONY_MC_MAPFACE,
         Tonemapping::BlenderFilmic => Mesh2dPipelineKey::TONEMAP_METHOD_BLENDER_FILMIC,
-        Tonemapping::PbrNeutral => Mesh2dPipelineKey::TONEMAP_METHOD_PBR_NEUTRAL,
+        Tonemapping::KhronosPbrNeutral => Mesh2dPipelineKey::TONEMAP_METHOD_PBR_NEUTRAL,
     }
 }
 

--- a/crates/bevy_sprite_render/src/render/mod.rs
+++ b/crates/bevy_sprite_render/src/render/mod.rs
@@ -553,7 +553,7 @@ pub fn queue_sprites(
                     }
                     Tonemapping::TonyMcMapface => SpritePipelineKey::TONEMAP_METHOD_TONY_MC_MAPFACE,
                     Tonemapping::BlenderFilmic => SpritePipelineKey::TONEMAP_METHOD_BLENDER_FILMIC,
-                    Tonemapping::PbrNeutral => SpritePipelineKey::TONEMAP_METHOD_PBR_NEUTRAL,
+                    Tonemapping::KhronosPbrNeutral => SpritePipelineKey::TONEMAP_METHOD_PBR_NEUTRAL,
                 };
             }
             if let Some(DebandDither::Enabled) = dither {

--- a/examples/2d/bloom_2d.rs
+++ b/examples/2d/bloom_2d.rs
@@ -209,7 +209,7 @@ fn next_tonemap(tonemapping: &Tonemapping) -> Tonemapping {
         Tonemapping::Reinhard => Tonemapping::ReinhardLuminance,
         Tonemapping::ReinhardLuminance => Tonemapping::SomewhatBoringDisplayTransform,
         Tonemapping::SomewhatBoringDisplayTransform => Tonemapping::TonyMcMapface,
-        Tonemapping::TonyMcMapface => Tonemapping::PbrNeutral,
-        Tonemapping::PbrNeutral => Tonemapping::None,
+        Tonemapping::TonyMcMapface => Tonemapping::KhronosPbrNeutral,
+        Tonemapping::KhronosPbrNeutral => Tonemapping::None,
     }
 }

--- a/examples/3d/tonemapping.rs
+++ b/examples/3d/tonemapping.rs
@@ -311,7 +311,7 @@ fn toggle_tonemapping_method(
     } else if keys.just_pressed(KeyCode::Digit8) {
         **tonemapping = Tonemapping::BlenderFilmic;
     } else if keys.just_pressed(KeyCode::Digit9) {
-        **tonemapping = Tonemapping::PbrNeutral;
+        **tonemapping = Tonemapping::KhronosPbrNeutral;
     }
 
     **color_grading = (*per_method_settings
@@ -500,8 +500,8 @@ fn update_ui(
         }
     ));
     text.push_str(&format!(
-        "(9) {} PBR Neutral\n",
-        if tonemapping == Tonemapping::PbrNeutral {
+        "(9) {} Khronos PBR Neutral\n",
+        if tonemapping == Tonemapping::KhronosPbrNeutral {
             ">"
         } else {
             ""
@@ -598,7 +598,7 @@ impl Default for PerMethodSettings {
             Tonemapping::SomewhatBoringDisplayTransform,
             Tonemapping::TonyMcMapface,
             Tonemapping::BlenderFilmic,
-            Tonemapping::PbrNeutral,
+            Tonemapping::KhronosPbrNeutral,
         ] {
             settings.insert(
                 method,


### PR DESCRIPTION
# Objective

`PbrNeutral` is poorly named as it implies it's a good default neutral tonemapper when it really isn't. The docs also don't really describe how it looks visually unlike the doc comments on the other tonemappers.

## Solution

Rename `PbrNeutral` to `KhronosPbrNeutral` to make it more clear that it's specifically the Khronos Pbr Neutral tonemapper and not a generic neutral pbr tonemapper, and improve the docs to better describe it and essentially recommend against it.