### PR TITLE
Fix large scene mip map generator material change detection trigger

### DIFF
--- a/examples/large_scenes/mipmap_generator/src/lib.rs
+++ b/examples/large_scenes/mipmap_generator/src/lib.rs
@@ -327,7 +327,7 @@ pub fn generate_mipmaps<M: Material + GetImages>(
                     }
                     // Touch material to trigger change detection
                     for material_h in material_handles.iter() {
-                        let _ = materials.get_mut(*material_h);
+                        let _ = materials.get_mut(*material_h).as_deref_mut();
                     }
                 }
                 false


### PR DESCRIPTION
https://github.com/bevyengine/bevy/pull/22460  broke the material change detection trigger in the large scenes mip map generator plugin.

## Testing

Ran the test_image example in mipmap_generator and the bistro scene and textures with mip maps were shown as expected after this fix.