### PR TITLE
Fix typo in `bevy_scene` docs

### DIFF
--- a/crates/bevy_scene/macros/src/lib.rs
+++ b/crates/bevy_scene/macros/src/lib.rs
@@ -356,7 +356,7 @@ use syn::{parse_macro_input, DeriveInput};
 /// small scenes that are shared across contexts (like styles),
 /// or one-off scenes that do not require reuse.
 ///
-/// /// ## Formatting BSN
+/// ## Formatting BSN
 ///
 /// Whitespace, parentheses, and comments have no effect on the generated scene —
 /// they exist purely to help you organize and read your code.


### PR DESCRIPTION
# Objective

- Extra `///`, noticed while I was reading:

<img width="946" height="182" alt="image" src="https://github.com/user-attachments/assets/5489e837-2309-443d-a1f1-a2847040d860" />


## Solution

- Remove extra comment.