### PR TITLE
Impl `SceneList` for `SmallVec`

### DIFF
--- a/crates/bevy_scene/Cargo.toml
+++ b/crates/bevy_scene/Cargo.toml
@@ -20,6 +20,7 @@ bevy_platform = { path = "../bevy_platform", version = "0.19.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.19.0-dev" }
 
+smallvec = { version = "1", default-features = false }
 thiserror = { version = "2", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 variadics_please = "1.0"

--- a/crates/bevy_scene/src/scene_list.rs
+++ b/crates/bevy_scene/src/scene_list.rs
@@ -1,6 +1,7 @@
 use crate::{
     ResolveContext, ResolveSceneError, ResolvedScene, Scene, SceneDependencies, SceneScope,
 };
+use smallvec::SmallVec;
 use variadics_please::all_tuples;
 
 /// This behaves like a list of [`Scene`], where each entry in the list is a new entity (see [`Scene`] for more details).
@@ -137,6 +138,46 @@ macro_rules! scene_list_impl {
 }
 
 all_tuples!(scene_list_impl, 0, 12, P);
+
+impl<S: Scene, const N: usize> SceneList for SmallVec<[S; N]> {
+    fn resolve_list(
+        self,
+        context: &mut ResolveContext,
+        scenes: &mut Vec<ResolvedScene>,
+    ) -> Result<(), ResolveSceneError> {
+        for scene in self {
+            let mut resolved_scene = ResolvedScene::default();
+            scene.resolve(context, &mut resolved_scene)?;
+            scenes.push(resolved_scene);
+        }
+        Ok(())
+    }
+
+    fn register_dependencies(&self, dependencies: &mut SceneDependencies) {
+        for scene in self {
+            scene.register_dependencies(dependencies);
+        }
+    }
+}
+
+impl<const N: usize> SceneList for SmallVec<[Box<dyn SceneList>; N]> {
+    fn resolve_list(
+        self,
+        context: &mut ResolveContext,
+        scenes: &mut Vec<ResolvedScene>,
+    ) -> Result<(), ResolveSceneError> {
+        for scene_list in self {
+            scene_list.resolve_list(context, scenes)?;
+        }
+        Ok(())
+    }
+
+    fn register_dependencies(&self, dependencies: &mut SceneDependencies) {
+        for scene_list in self {
+            scene_list.register_dependencies(dependencies);
+        }
+    }
+}
 
 impl<S: Scene> SceneList for Vec<S> {
     fn resolve_list(


### PR DESCRIPTION
# Objective

- Sometimes it's useful to store a list of components in a `SmallVec` without converting it into a Vec to pass into `bsn!`.

## Solution

- Implement `SceneList` for `SmallVec`. It's already in the Bevy dependency tree anyway.

Alternatively we can implement it for anything that is `IntoIterator`, but this might conflict with other impls?