### PR TITLE
Fill in some doc strings for `bevy_asset`

### DIFF
--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -733,11 +733,16 @@ impl<'a, A: Asset> Iterator for AssetsMutIterator<'a, A> {
 /// An error returned when an [`AssetIndex`] has an invalid generation.
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum InvalidGenerationError {
+    /// The generation of this [`AssetIndex`] does not match the current generation.
+    /// That means its index entry has been replaced.
     #[error("AssetIndex {index:?} has an invalid generation. The current generation is: '{current_generation}'.")]
     Occupied {
+        /// The index being looked up.
         index: AssetIndex,
+        /// The generation currently at that index.
         current_generation: u32,
     },
+    /// This index entry has been removed.
     #[error("AssetIndex {index:?} has been removed")]
     Removed { index: AssetIndex },
 }

--- a/crates/bevy_asset/src/io/android.rs
+++ b/crates/bevy_asset/src/io/android.rs
@@ -1,3 +1,6 @@
+//! Asset reader for Android devices.
+//! See [`AndroidAssetReader`] for details.
+
 use crate::io::{get_meta_path, AssetReader, AssetReaderError, PathStream, Reader, VecReader};
 use alloc::{borrow::ToOwned, boxed::Box, ffi::CString, vec::Vec};
 use futures_lite::stream;

--- a/crates/bevy_asset/src/io/embedded/mod.rs
+++ b/crates/bevy_asset/src/io/embedded/mod.rs
@@ -1,3 +1,10 @@
+//! Support for embedded assets, which are assets that are included inside the application executable
+//! instead of being deployed alongside it.
+//!
+//! See the [`embedded_asset!`] macro for details.
+//!
+//! [`embedded_asset!`]: crate::embedded_asset
+
 #[cfg(feature = "embedded_watcher")]
 mod embedded_watcher;
 
@@ -25,9 +32,9 @@ pub const EMBEDDED: &str = "embedded";
 
 /// A [`Resource`] that manages "rust source files" in a virtual in memory [`Dir`], which is intended
 /// to be shared with a [`MemoryAssetReader`].
-/// Generally this should not be interacted with directly. The [`embedded_asset`] will populate this.
+/// Generally this should not be interacted with directly. The [`embedded_asset!`] macro will populate this.
 ///
-/// [`embedded_asset`]: crate::embedded_asset
+/// [`embedded_asset!`]: crate::embedded_asset
 #[derive(Resource, Default)]
 pub struct EmbeddedAssetRegistry {
     dir: Dir,
@@ -147,6 +154,7 @@ impl EmbeddedAssetRegistry {
 ///
 /// [`load_embedded_asset!`]: crate::load_embedded_asset
 pub trait GetAssetServer {
+    /// Return a reference to the relevant [`AssetServer`].
     fn get_asset_server(&self) -> &AssetServer;
 }
 
@@ -212,10 +220,10 @@ macro_rules! load_embedded_asset {
 }
 
 /// Returns the [`Path`] for a given `embedded` asset.
-/// This is used internally by [`embedded_asset`] and can be used to get a [`Path`]
+/// This is used internally by [`embedded_asset!`] and can be used to get a [`Path`]
 /// that matches the [`AssetPath`](crate::AssetPath) used by that asset.
 ///
-/// [`embedded_asset`]: crate::embedded_asset
+/// [`embedded_asset!`]: crate::embedded_asset
 #[macro_export]
 macro_rules! embedded_path {
     ($path_str: expr) => {{
@@ -317,11 +325,11 @@ pub fn _embedded_asset_path(
 /// 2. `src` is trimmed from the path
 ///
 /// The default behavior also works for cargo workspaces. Pretend the `bevy_rock` crate now exists in a larger workspace in
-/// `$SOME_WORKSPACE/crates/bevy_rock`. The asset path would remain the same, because [`embedded_asset`] searches for the
+/// `$SOME_WORKSPACE/crates/bevy_rock`. The asset path would remain the same, because [`embedded_asset!`] searches for the
 /// _first instance_ of `bevy_rock/src` in the path.
 ///
 /// For most "standard crate structures" the default works just fine. But for some niche cases (such as cargo examples),
-/// the `src` path will not be present. You can override this behavior by adding it as the second argument to [`embedded_asset`]:
+/// the `src` path will not be present. You can override this behavior by adding it as the second argument to [`embedded_asset!`]:
 ///
 /// `embedded_asset!(app, "/examples/rock_stuff/", "rock.wgsl")`
 ///
@@ -333,13 +341,13 @@ pub fn _embedded_asset_path(
 ///
 /// This macro uses the [`include_bytes`] macro internally and _will not_ reallocate the bytes.
 /// Generally the [`AssetPath`] generated will be predictable, but if your asset isn't
-/// available for some reason, you can use the [`embedded_path`] macro to debug.
+/// available for some reason, you can use the [`embedded_path!`] macro to debug.
 ///
 /// Hot-reloading `embedded` assets is supported. Just enable the `embedded_watcher` cargo feature.
 ///
 /// [`AssetPath`]: crate::AssetPath
-/// [`embedded_asset`]: crate::embedded_asset
-/// [`embedded_path`]: crate::embedded_path
+/// [`embedded_asset!`]: crate::embedded_asset
+/// [`embedded_path!`]: crate::embedded_path
 #[macro_export]
 macro_rules! embedded_asset {
     ($app: expr, $path: expr) => {{

--- a/crates/bevy_asset/src/io/file/mod.rs
+++ b/crates/bevy_asset/src/io/file/mod.rs
@@ -1,3 +1,9 @@
+//! A backend for [`Asset`] storage in the local filesystem.
+//!
+//! It can watch for changed assets and hotload them if the `file_watcher` feature is enabled.
+//!
+//! [`Asset`]: crate::Asset
+
 #[cfg(feature = "file_watcher")]
 mod file_watcher;
 

--- a/crates/bevy_asset/src/io/memory.rs
+++ b/crates/bevy_asset/src/io/memory.rs
@@ -1,3 +1,9 @@
+//! In-memory [`Asset`] storage backend.
+//!
+//! See [`Dir`] for details.
+//!
+//! [`Asset`]: crate::Asset
+
 use crate::io::{
     AssetReader, AssetReaderError, AssetWriter, AssetWriterError, PathStream, Reader,
     ReaderNotSeekableError, SeekableReader,
@@ -25,8 +31,12 @@ struct DirInternal {
     path: PathBuf,
 }
 
-/// A clone-able (internally Arc-ed) / thread-safe "in memory" filesystem.
-/// This is built for [`MemoryAssetReader`] and is primarily intended for unit tests.
+/// A clone-able (internally [`Arc`]-ed), thread-safe in-memory filesystem.
+///
+/// This was built for [`MemoryAssetReader`] and is primarily used by unit tests
+/// and by the [`embedded`] backend.
+///
+/// [`embedded`]: crate::io::embedded
 #[derive(Default, Clone, Debug)]
 pub struct Dir(Arc<RwLock<DirInternal>>);
 
@@ -39,14 +49,18 @@ impl Dir {
         })))
     }
 
+    /// Inserts textual data as an asset, at the `path` relative to this `Dir`.
     pub fn insert_asset_text(&self, path: &Path, asset: &str) {
         self.insert_asset(path, asset.as_bytes().to_vec());
     }
 
+    /// Inserts textual data as asset metadata, at the `path` relative to this `Dir`.
     pub fn insert_meta_text(&self, path: &Path, asset: &str) {
         self.insert_meta(path, asset.as_bytes().to_vec());
     }
 
+    /// Inserts a [`Vec`] of bytes or a `'static` array of bytes as an asset,
+    /// at the `path` relative to this `Dir`.
     pub fn insert_asset(&self, path: &Path, value: impl Into<Value>) {
         self.insert_asset_internal(path, value.into());
     }
@@ -87,6 +101,8 @@ impl Dir {
             .remove(&key)
     }
 
+    /// Inserts a [`Vec`] of bytes or a `'static` array of bytes as asset metadata,
+    /// at the `path` relative to this `Dir`.
     pub fn insert_meta(&self, path: &Path, value: impl Into<Value>) {
         self.insert_meta_internal(path, value.into());
     }
@@ -126,6 +142,8 @@ impl Dir {
             .remove(&key)
     }
 
+    /// Returns the `Dir` representing `path` relative to this `Dir`,
+    /// creating a new one for it if necessary.
     pub fn get_or_insert_dir(&self, path: &Path) -> Dir {
         let mut dir = self.clone();
         let mut full_path = PathBuf::new();
@@ -159,6 +177,7 @@ impl Dir {
             .remove(&key)
     }
 
+    /// Returns the `Dir` representing `path` relative to this `Dir`, if it exists.
     pub fn get_dir(&self, path: &Path) -> Option<Dir> {
         let mut dir = self.clone();
         for p in path.components() {
@@ -175,6 +194,7 @@ impl Dir {
         Some(dir)
     }
 
+    /// Returns the asset stored at `path` relative to this `Dir`, if it exists.
     pub fn get_asset(&self, path: &Path) -> Option<Data> {
         let mut dir = self.clone();
         if let Some(parent) = path.parent() {
@@ -191,6 +211,7 @@ impl Dir {
         })
     }
 
+    /// Returns the asset metadata stored at `path` relative to this `Dir`, if it exists.
     pub fn get_metadata(&self, path: &Path) -> Option<Data> {
         let mut dir = self.clone();
         if let Some(parent) = path.parent() {
@@ -207,6 +228,7 @@ impl Dir {
         })
     }
 
+    /// Returns the path represented by this `Dir`.
     pub fn path(&self) -> PathBuf {
         self.0
             .read()
@@ -260,17 +282,20 @@ impl Stream for DirStream {
 }
 
 /// In-memory [`AssetReader`] implementation.
-/// This is primarily intended for unit tests.
+///
+/// This is primarily used by unit tests and the [`embedded`](super::embedded) backend.
 #[derive(Default, Clone)]
 pub struct MemoryAssetReader {
+    /// The root of the in-memory filesystem backing this asset reader.
     pub root: Dir,
 }
 
 /// In-memory [`AssetWriter`] implementation.
 ///
-/// This is primarily intended for unit tests.
+/// This is primarily used by unit tests and the [`embedded`](super::embedded) backend.
 #[derive(Default, Clone)]
 pub struct MemoryAssetWriter {
+    /// The root of the in-memory filesystem backing this asset writer.
     pub root: Dir,
 }
 

--- a/crates/bevy_asset/src/io/memory.rs
+++ b/crates/bevy_asset/src/io/memory.rs
@@ -238,6 +238,8 @@ impl Dir {
     }
 }
 
+/// A struct for iteration over subdirectory and asset paths of a [`Dir`].
+/// It will return full pathnames.
 pub struct DirStream {
     dir: Dir,
     index: usize,
@@ -613,7 +615,7 @@ impl AssetWriter for MemoryAssetWriter {
 }
 
 #[cfg(test)]
-pub mod test {
+mod test {
     use super::Dir;
     use std::path::Path;
 

--- a/crates/bevy_asset/src/io/mod.rs
+++ b/crates/bevy_asset/src/io/mod.rs
@@ -1,3 +1,8 @@
+//! Readers and writers for byte streams that represent assets.
+//!
+//! These are implemented for a variety of backends.
+//! See the submodules for details on those.
+
 #[cfg(all(feature = "file_watcher", target_arch = "wasm32"))]
 compile_error!(
     "The \"file_watcher\" feature for hot reloading does not work \
@@ -564,6 +569,7 @@ pub enum AssetSourceEvent {
     /// An asset at this path was removed.
     RemovedAsset(PathBuf),
     /// An asset at this path was renamed.
+    #[expect(missing_docs, reason = "the names are self documenting")]
     RenamedAsset { old: PathBuf, new: PathBuf },
     /// Asset metadata at this path was added.
     AddedMeta(PathBuf),
@@ -572,12 +578,14 @@ pub enum AssetSourceEvent {
     /// Asset metadata at this path was removed.
     RemovedMeta(PathBuf),
     /// Asset metadata at this path was renamed.
+    #[expect(missing_docs, reason = "the names are self documenting")]
     RenamedMeta { old: PathBuf, new: PathBuf },
     /// A folder at the given path was added.
     AddedFolder(PathBuf),
     /// A folder at the given path was removed.
     RemovedFolder(PathBuf),
     /// A folder at the given path was renamed.
+    #[expect(missing_docs, reason = "the names are self documenting")]
     RenamedFolder { old: PathBuf, new: PathBuf },
     /// Something of unknown type was removed. It is the job of the event handler to determine the type.
     /// This exists because notify-rs produces "untyped" rename events without destination paths for unwatched folders, so we can't determine the type of

--- a/crates/bevy_asset/src/io/mod.rs
+++ b/crates/bevy_asset/src/io/mod.rs
@@ -312,8 +312,10 @@ impl<T: AssetReader> ErasedAssetReader for T {
     }
 }
 
+/// A convenience type for an [`AsyncWrite`] object plus the traits it needs to satisfy.
 pub type Writer = dyn AsyncWrite + Unpin + Send + Sync;
 
+/// A convenience type for a stream of pathnames plus the traits it needs to satisfy.
 pub type PathStream = dyn Stream<Item = PathBuf> + Unpin + Send;
 
 /// Errors that occur while loading assets.

--- a/crates/bevy_asset/src/io/processor_gated.rs
+++ b/crates/bevy_asset/src/io/processor_gated.rs
@@ -1,3 +1,8 @@
+//! Tools for waiting for the [`AssetProcessor`] before loading an [`Asset`].
+//!
+//! [`AssetProcessor`]: crate::processor::AssetProcessor
+//! [`Asset`]: crate::Asset
+
 use crate::{
     io::{
         AssetReader, AssetReaderError, AssetSourceId, PathStream, Reader, ReaderNotSeekableError,

--- a/crates/bevy_asset/src/io/web.rs
+++ b/crates/bevy_asset/src/io/web.rs
@@ -56,6 +56,7 @@ use tracing::warn;
 /// ```
 #[derive(Default)]
 pub struct WebAssetPlugin {
+    /// Set this if you have seen the warning about URL safety enough times.
     pub silence_startup_warning: bool,
 }
 

--- a/crates/bevy_asset/src/io/web.rs
+++ b/crates/bevy_asset/src/io/web.rs
@@ -1,3 +1,7 @@
+//! Adds the `http` and `https` asset sources to the app.
+//!
+//! See [`WebAssetPlugin`] for details.
+
 use crate::io::{AssetReader, AssetReaderError, AssetSourceBuilder, PathStream, Reader};
 use crate::{AssetApp, AssetPlugin};
 use alloc::boxed::Box;

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -465,6 +465,7 @@ pub trait AsAssetId: Component {
 ///
 /// Note that this trait is automatically implemented when deriving [`Asset`].
 pub trait VisitAssetDependencies {
+    /// Apply the `visit` closure to every asset dependency.
     fn visit_dependencies(&self, visit: &mut impl FnMut(UntypedAssetId));
 }
 

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -342,13 +342,20 @@ impl<A: Asset> AssetContainer for A {
 /// An error that occurs when attempting an async load using [`NestedLoadBuilder`].
 #[derive(Error, Debug)]
 pub enum LoadDirectError {
+    /// The asset path was empty.
     #[error("Attempted to load an asset with an empty path \"{0}\"")]
     EmptyPath(AssetPath<'static>),
+    /// Loading an asset path with a subasset at the end is unsupported. See issue [#18291].
+    ///
+    /// [#18291]: https://github.com/bevyengine/bevy/issues/18291
     #[error("Requested to load an asset path ({0:?}) with a subasset, but this is unsupported. See issue #18291")]
     RequestedSubasset(AssetPath<'static>),
+    /// A general [`AssetLoadError`] for an asset dependency.
     #[error("Failed to load dependency {dependency:?} {error}")]
     LoadError {
+        /// Which dependency failed.
         dependency: AssetPath<'static>,
+        /// The original error for that dependency.
         error: Box<AssetLoadError>,
     },
 }
@@ -356,8 +363,10 @@ pub enum LoadDirectError {
 /// An error that occurs while deserializing [`AssetMeta`].
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum DeserializeMetaError {
+    /// Failed to deserialize the asset metadata.
     #[error("Failed to deserialize asset meta: {0:?}")]
     DeserializeSettings(#[from] SpannedError),
+    /// Failed to deserialize the minimal asset metadata.
     #[error("Failed to deserialize minimal asset meta: {0:?}")]
     DeserializeMinimal(SpannedError),
 }

--- a/crates/bevy_asset/src/meta.rs
+++ b/crates/bevy_asset/src/meta.rs
@@ -1,3 +1,11 @@
+//! Handle asset metadata.
+//! Asset metadata informs how an [`Asset`] should be handled by the asset system.
+//!
+//! It is primarily used by [asset processing](crate::processor).
+//!
+//! Asset metadata is generally stored as a `.meta` file next to the asset,
+//! but this may differ per asset storage backend.
+
 use alloc::{
     boxed::Box,
     string::{String, ToString},
@@ -16,6 +24,10 @@ use ron::ser::PrettyConfig;
 use serde::{Deserialize, Serialize};
 use tracing::error;
 
+/// The version of the metadata format being used.
+/// It is included in every metadata entry.
+///
+/// This constant will be updated whenever a breaking change is made to the format.
 pub const META_FORMAT_VERSION: &str = "1.0";
 pub type MetaTransform = Box<dyn Fn(&mut dyn AssetMetaDyn) + Send + Sync>;
 
@@ -80,7 +92,7 @@ pub enum AssetAction<LoaderSettings, ProcessSettings> {
 /// [`AssetProcessor`]: crate::processor::AssetProcessor
 #[derive(Serialize, Deserialize, Default, Debug, Clone)]
 pub struct ProcessedInfo {
-    /// A hash of the asset bytes and the asset .meta data
+    /// A hash of the asset bytes and the asset `.meta` data
     pub hash: AssetHash,
     /// A hash of the asset bytes, the asset .meta data, and the `full_hash` of every `process_dependency`
     pub full_hash: AssetHash,
@@ -92,6 +104,7 @@ pub struct ProcessedInfo {
 /// has changed.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ProcessDependencyInfo {
+    /// A hash of the dependency's `.meta` data and [`ProcessedInfo`] information.
     pub full_hash: AssetHash,
     pub path: AssetPath<'static>,
 }
@@ -111,8 +124,15 @@ pub struct AssetMetaMinimal {
 /// isn't necessary.
 #[derive(Serialize, Deserialize)]
 pub enum AssetActionMinimal {
+    /// Load the asset with the given loader.
+    /// See [`AssetLoader`].
     Load { loader: String },
+    /// Process the asset with the given processor.
+    /// See [`Process`] and [`AssetProcessor`].
+    ///
+    /// [`AssetProcessor`]: crate::processor::AssetProcessor
     Process { processor: String },
+    /// Do nothing with the asset
     Ignore,
 }
 
@@ -120,6 +140,9 @@ pub enum AssetActionMinimal {
 /// necessary.
 #[derive(Serialize, Deserialize)]
 pub struct ProcessedInfoMinimal {
+    /// Info produced by the [`AssetProcessor`] for a given processed asset.
+    ///
+    /// [`AssetProcessor`]: crate::processor::AssetProcessor
     pub processed_info: Option<ProcessedInfo>,
 }
 
@@ -255,6 +278,7 @@ pub(crate) fn loader_settings_meta_transform<S: Settings>(
     Box::new(move |meta| meta_transform_settings(meta, &settings))
 }
 
+/// This type alias records the size of an asset hash.
 pub type AssetHash = [u8; 32];
 
 /// NOTE: changing the hashing logic here is a _breaking change_ that requires a [`META_FORMAT_VERSION`] bump.

--- a/crates/bevy_asset/src/processor/mod.rs
+++ b/crates/bevy_asset/src/processor/mod.rs
@@ -203,6 +203,7 @@ impl AssetProcessor {
         self.data.sources.get(id.into())
     }
 
+    /// Retrieves all the [`AssetSource`]s for this processor.
     #[inline]
     pub fn sources(&self) -> &AssetSources {
         &self.data.sources
@@ -1830,6 +1831,7 @@ pub enum InitializeError {
 /// An error when attempting to set the transaction log factory.
 #[derive(Error, Debug)]
 pub enum SetTransactionLogFactoryError {
+    /// The transaction log is already in use, so setting the factory does nothing.
     #[error("Transaction log is already in use so setting the factory does nothing")]
     AlreadyInUse,
 }
@@ -1837,11 +1839,15 @@ pub enum SetTransactionLogFactoryError {
 /// An error when retrieving an asset processor.
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum GetProcessorError {
+    /// The processor of that name does not exist.
     #[error("The processor '{0}' does not exist")]
     Missing(String),
+    /// The given short name is ambiguous between several processors.
     #[error("The processor '{processor_short_name}' is ambiguous between several processors: {ambiguous_processor_names:?}")]
     Ambiguous {
+        /// The given string for the processor name.
         processor_short_name: String,
+        /// The list of processors that might match it.
         ambiguous_processor_names: Vec<&'static str>,
     },
 }

--- a/crates/bevy_asset/src/processor/process.rs
+++ b/crates/bevy_asset/src/processor/process.rs
@@ -121,20 +121,26 @@ pub enum ProcessError {
     MissingAssetLoaderForExtension(#[from] MissingAssetLoaderForExtensionError),
     #[error(transparent)]
     MissingAssetLoaderForTypeName(#[from] MissingAssetLoaderForTypeNameError),
+    /// No processor with that name is registered..
     #[error("The processor '{0}' does not exist")]
     #[from(ignore)]
     MissingProcessor(String),
+    /// The given short name is ambiguous between several processors.
     #[error("The processor '{processor_short_name}' is ambiguous between several processors: {ambiguous_processor_names:?}")]
     AmbiguousProcessor {
+        /// The given string for the processor name.
         processor_short_name: String,
+        /// The list of processors that might match it.
         ambiguous_processor_names: Vec<&'static str>,
     },
+    /// Encountered an [`AssetReaderError`] for this path.
     #[error("Encountered an AssetReader error for '{path}': {err}")]
     #[from(ignore)]
     AssetReaderError {
         path: AssetPath<'static>,
         err: AssetReaderError,
     },
+    /// Encountered an [`AssetWriterError`] for this path.
     #[error("Encountered an AssetWriter error for '{path}': {err}")]
     #[from(ignore)]
     AssetWriterError {
@@ -147,6 +153,7 @@ pub enum ProcessError {
     MissingProcessedAssetReaderError(#[from] MissingProcessedAssetReaderError),
     #[error(transparent)]
     MissingProcessedAssetWriterError(#[from] MissingProcessedAssetWriterError),
+    /// Encountered an [`AssetReaderError`] when reading the asset metadata for this path.
     #[error("Failed to read asset metadata for {path}: {err}")]
     #[from(ignore)]
     ReadAssetMetaError {
@@ -157,14 +164,19 @@ pub enum ProcessError {
     DeserializeMetaError(#[from] DeserializeMetaError),
     #[error(transparent)]
     AssetLoadError(#[from] AssetLoadError),
+    /// The wrong meta type was passed into a processor.
+    /// This is probably an internal implementation error.
     #[error("The wrong meta type was passed into a processor. This is probably an internal implementation error.")]
     WrongMetaType,
+    /// Encountered an error while saving the asset.
     #[error("Encountered an error while saving the asset: {0}")]
     #[from(ignore)]
     AssetSaveError(BevyError),
+    /// Encountered an error while transforming the asset.
     #[error("Encountered an error while transforming the asset: {0}")]
     #[from(ignore)]
     AssetTransformError(Box<dyn core::error::Error + Send + Sync + 'static>),
+    /// Assets without extensions are not supported.
     #[error("Assets without extensions are not supported.")]
     ExtensionRequired,
 }

--- a/crates/bevy_asset/src/saver.rs
+++ b/crates/bevy_asset/src/saver.rs
@@ -569,8 +569,10 @@ pub enum SaveAssetError {
     MissingSource(#[from] MissingAssetSourceError),
     #[error(transparent)]
     MissingWriter(#[from] MissingAssetWriterError),
+    /// Encountered an [`AssetWriterError`] while saving the asset.
     #[error(transparent)]
     WriterError(#[from] AssetWriterError),
+    /// Failed to save the asset due to an error from the saver.
     #[error("Failed to save asset due to error from saver: {0}")]
     SaverError(Arc<BevyError>),
 }

--- a/crates/bevy_asset/src/saver.rs
+++ b/crates/bevy_asset/src/saver.rs
@@ -1,3 +1,9 @@
+//! Tools to save processed [`Asset`]s to a byte format that can then be written with [`AssetWriter`].
+//!
+//! See [`AssetSaver`] for details.
+//!
+//! [`AssetWriter`]: crate::io::AssetWriter
+
 use crate::{
     io::{AssetWriterError, MissingAssetSourceError, MissingAssetWriterError, Writer},
     meta::{AssetAction, AssetMeta, AssetMetaDyn, Settings},

--- a/crates/bevy_asset/src/transformer.rs
+++ b/crates/bevy_asset/src/transformer.rs
@@ -1,3 +1,9 @@
+//! Tools to transform an [`Asset`] into an asset of a different type.
+//!
+//! This module is generally used in conjunction with [`asset processing`](crate::processor).
+//!
+//! See [`AssetTransformer`] for details.
+
 use crate::{
     meta::Settings, Asset, AssetId, ErasedLoadedAsset, Handle, LabeledAsset, UntypedAssetId,
     UntypedHandle,


### PR DESCRIPTION
# Objective

Make progress on #3492

## Solution

Added doc strings to some of `bevy_asset`.
This is taking a long time, so I'll do the rest in future PRs.

## Testing

Generated the docs locally and looked at them.

Couldn't look at the docs for `io::android` because they are not generated.
