### PR TITLE
Change From<&str> to From<&'static str> for Name

### DIFF
--- a/_release-content/migration-guides/name_from_specialization.md
+++ b/_release-content/migration-guides/name_from_specialization.md
@@ -1,0 +1,9 @@
+---
+title: Feature that broke
+pull_requests: [24544]
+---
+
+* Removed `From<&str>` implementation for `Name` 
+* Added `From<&'static str>` implementation for `Name`
+
+`Name` is internally `Cow<'static, str>`, meaning we need to `.to_owned()`, thus heap-allocating new space in memory. By changing the implementation to `&'static str`, we do not need to `.to_owned()` anymore.

--- a/_release-content/migration-guides/name_from_specialization.md
+++ b/_release-content/migration-guides/name_from_specialization.md
@@ -1,9 +1,8 @@
 ---
-title: "`Name::from<&str>` always heap-allocates"
+title: "`&str`s must now have a static lifetime to be converted to `Name`"
 pull_requests: [24544]
 ---
 
-* Removed `From<&str>` implementation for `Name` 
-* Added `From<&'static str>` implementation for `Name`
+A `From<&str>` implementation for `Name` has been replaced with a `From<&'static str>` implementation for `Name`. This was done to avoid unexpected allocations.
 
-`Name` is internally `Cow<'static, str>`, meaning we need to `.to_owned()`, thus heap-allocating new space in memory. By changing the implementation to `&'static str`, we do not need to `.to_owned()` anymore.
+If you do not mind the extra allocation, you can use `Name::new(non_static_str.to_owned())` for previous behavior.

--- a/_release-content/migration-guides/name_from_specialization.md
+++ b/_release-content/migration-guides/name_from_specialization.md
@@ -1,5 +1,5 @@
 ---
-title: Feature that broke
+title: Name::from<&str> always heap-allocates
 pull_requests: [24544]
 ---
 

--- a/_release-content/migration-guides/name_from_specialization.md
+++ b/_release-content/migration-guides/name_from_specialization.md
@@ -1,5 +1,5 @@
 ---
-title: Name::from<&str> always heap-allocates
+title: "`Name::from<&str>` always heap-allocates"
 pull_requests: [24544]
 ---
 

--- a/crates/bevy_ecs/src/name.rs
+++ b/crates/bevy_ecs/src/name.rs
@@ -173,10 +173,10 @@ impl<'w, 's> core::fmt::Display for NameOrEntityItem<'w, 's> {
 
 // Conversions from strings
 
-impl From<&str> for Name {
+impl From<&'static str> for Name {
     #[inline(always)]
-    fn from(name: &str) -> Self {
-        Name::new(name.to_owned())
+    fn from(name: &'static str) -> Self {
+        Name::new(name)
     }
 }
 


### PR DESCRIPTION
# Objective

- Fixes #24465

## Solution

- Changed `impl From<&str> for Name` to `impl From<&'static str> for Name`

## Testing

- The only place it is (the From<&str> implementation) used is on this test, line 1752, which still passes: https://github.com/bevyengine/bevy/blob/5d5e3f9551ca57a228cf49912df1663f05a037c2/crates/bevy_animation/src/lib.rs#L1722-L1762