### PR TITLE
use sort_unstable if you're deduplicating anyways

### DIFF
--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -1506,7 +1506,7 @@ mod tests {
         }
 
         let pre_len = entities.len();
-        entities.sort();
+        entities.sort_unstable();
         entities.dedup();
         assert_eq!(pre_len, entities.len());
 
@@ -1516,7 +1516,7 @@ mod tests {
 
         entities.extend(allocator.alloc_many(5000));
         let pre_len = entities.len();
-        entities.sort();
+        entities.sort_unstable();
         entities.dedup();
         assert_eq!(pre_len, entities.len());
     }

--- a/crates/bevy_math/src/curve/cores.rs
+++ b/crates/bevy_math/src/curve/cores.rs
@@ -658,7 +658,7 @@ impl<T> ChunkedUnevenCore<T> {
 fn filter_sort_dedup_times(times: impl IntoIterator<Item = f32>) -> Vec<f32> {
     // Filter before sorting/deduplication so that NAN doesn't interfere with them.
     let mut times = times.into_iter().filter(|t| t.is_finite()).collect_vec();
-    times.sort_by(f32::total_cmp);
+    times.sort_unstable_by(f32::total_cmp);
     times.dedup();
     times
 }

--- a/crates/bevy_math/src/curve/mod.rs
+++ b/crates/bevy_math/src/curve/mod.rs
@@ -873,7 +873,7 @@ pub trait CurveResampleExt<T>: Curve<T> {
             .into_iter()
             .filter(|t| t.is_finite() && domain.contains(*t))
             .collect_vec();
-        times.sort_by(f32::total_cmp);
+        times.sort_unstable_by(f32::total_cmp);
         times.dedup();
         if times.len() < 2 {
             return Err(ResamplingError::NotEnoughSamples(times.len()));
@@ -914,7 +914,7 @@ pub trait CurveResampleExt<T>: Curve<T> {
             .into_iter()
             .filter(|t| t.is_finite() && domain.contains(*t))
             .collect_vec();
-        times.sort_by(f32::total_cmp);
+        times.sort_unstable_by(f32::total_cmp);
         times.dedup();
         if times.len() < 2 {
             return Err(ResamplingError::NotEnoughSamples(times.len()));


### PR DESCRIPTION
# Objective

- To make bevy_math faster 🚀 

## Solution

- Unstable sorts are potentially destructive, but if you're deduplicating anyways, there's no risk of that, so you might as well use a faster version.

It also helps that it makes less allocations than the normal `.sort()`.

The changes to `bevy_ecs`'s unit tests and `examples/ui/text` aren't on any critical path, so most of the gains (if any) are for `bevy_math`.

## Testing

- Did you test these changes? If so, how?

I did `cargo test -p bevy_math` and got all tests passing:

```
test result: ok. 117 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.06s
```

Likewise for `cargo test -p bevy_ecs`:

```
test result: ok. 478 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 163.98s

```

- Are there any parts that need more testing? 

No.

- How can other people (reviewers) test your changes? Is there anything specific they need to know?

Nope.

- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?

Windows 11, not important.

---

## Showcase


I'd be happy to add a local `criterion` benchmark if someone points me towards a small representative example to do the before/after comparison - this is my first Bevy PR so I don't know what would be a decent stress test for this code path.

