### PR TITLE
Remove unwrap from layout/mod.rs

### DIFF
--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -211,7 +211,7 @@ pub fn ui_layout_system(
         );
 
         let Ok((_, _, _, computed_target)) = node_query.get(ui_root_entity) else {
-            warn!("UI root not found");
+            warn!("UI root {ui_root_entity} not found");
             continue;
         };
 

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -24,6 +24,8 @@ use bevy_text::ComputedTextBlock;
 
 use bevy_text::FontCx;
 
+use bevy_log::warn;
+
 mod convert;
 pub mod debug;
 pub mod ui_surface;
@@ -208,7 +210,10 @@ pub fn ui_layout_system(
             ui_root_entity,
         );
 
-        let (_, _, _, computed_target) = node_query.get(ui_root_entity).unwrap();
+        let Ok((_, _, _, computed_target)) = node_query.get(ui_root_entity) else {
+            warn!("UI root not found");
+            continue;
+        };
 
         ui_surface.compute_layout(
             ui_root_entity,


### PR DESCRIPTION
# Objective
There's a bug in github.com/Lommix/bevy_hui; the game crashes during hot reload because of an unwrap.

## Solution

removed the unwrap and replaced it with a let-else

## Testing

- Did you test these changes? If so, how? 
  I tested it on my own project
- Are there any parts that need more testing?
  No