### PR TITLE
even more .sort_unstable + .dedup() combos

### DIFF
--- a/crates/bevy_math/src/curve/cores.rs
+++ b/crates/bevy_math/src/curve/cores.rs
@@ -367,7 +367,7 @@ impl<T> UnevenCore<T> {
         timed_samples
             // Using `total_cmp` is fine because no NANs remain and because deduplication uses
             // `PartialEq` anyway (so -0.0 and 0.0 will be considered equal later regardless).
-            .sort_by(|(t0, _), (t1, _)| t0.total_cmp(t1));
+            .sort_unstable_by(|(t0, _), (t1, _)| t0.total_cmp(t1));
         timed_samples.dedup_by_key(|(t, _)| *t);
 
         if timed_samples.len() < 2 {
@@ -448,7 +448,7 @@ impl<T> UnevenCore<T> {
             .map(f)
             .zip(self.samples)
             .collect_vec();
-        timed_samples.sort_by(|(t1, _), (t2, _)| t1.total_cmp(t2));
+        timed_samples.sort_unstable_by(|(t1, _), (t2, _)| t1.total_cmp(t2));
         timed_samples.dedup_by_key(|(t, _)| *t);
         (self.times, self.samples) = timed_samples.into_iter().unzip();
         self


### PR DESCRIPTION
# Objective

- Follow up PR to https://github.com/bevyengine/bevy/pull/24545, since I just learned of `.dedup_by()` and `.dedup_by_key()`.

## Solution

- If you're deduplicating anyways, might as well use the non-allocating unstable sort.

## Testing

- Did you test these changes? `cargo test -p bevy_math`, it passed!

---

## Showcase

I think I'll benchmark both of these PRs together since they both improve on the `curve` crate of `bevy_math`.