### PR TITLE
Make asset_changed import path public

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -150,6 +150,7 @@ extern crate std;
 // Required to make proc macros work in bevy itself.
 extern crate self as bevy_asset;
 
+pub mod asset_changed;
 pub mod io;
 pub mod meta;
 pub mod processor;
@@ -170,7 +171,6 @@ pub mod prelude {
     };
 }
 
-mod asset_changed;
 mod assets;
 mod direct_access_ext;
 mod event;


### PR DESCRIPTION
## Objective

Fixes #24501.

Allow users to import `AssetChanged` from `bevy_asset::asset_changed::AssetChanged`, rather than only through `bevy_asset::prelude::AssetChanged`.

## Solution

Make the existing `asset_changed` module public without moving the implementation around. The internal `AssetChanges` resource remains crate-private, and the existing hidden `WorldQuery` fetch/state types stay unchanged.

## Testing

- `git diff --check`
- `rustup run 1.95.0-aarch64-apple-darwin cargo check -p bevy_asset`
- `rustup run 1.95.0-aarch64-apple-darwin cargo test -p bevy_asset asset_changed`
- `RUSTDOCFLAGS="-D warnings" rustup run 1.95.0-aarch64-apple-darwin cargo doc -p bevy_asset --no-deps`