### PR TITLE
`HierarchyPropagatePlugin` remove insert fix

### DIFF
--- a/crates/bevy_app/src/propagate.rs
+++ b/crates/bevy_app/src/propagate.rs
@@ -407,14 +407,14 @@ mod tests {
         app.world_mut()
             .entity_mut(parent)
             .remove::<Propagate<TestValue>>()
-            .insert(Propagate(TestValue(1)));
+            .insert(Propagate(TestValue(2)));
         app.update();
 
         assert_eq!(
             app.world_mut()
                 .query::<&TestValue>()
                 .get_many(app.world(), [parent, child]),
-            Ok([&TestValue(1), &TestValue(1)])
+            Ok([&TestValue(2), &TestValue(2)])
         );
     }
 

--- a/crates/bevy_app/src/propagate.rs
+++ b/crates/bevy_app/src/propagate.rs
@@ -402,7 +402,6 @@ mod tests {
         app.add_plugins(HierarchyPropagatePlugin::<TestValue>::new(Update));
 
         let parent = app.world_mut().spawn(Propagate(TestValue(1))).id();
-
         let child = app.world_mut().spawn_empty().insert(ChildOf(parent)).id();
 
         app.update();
@@ -411,6 +410,7 @@ mod tests {
             .entity_mut(parent)
             .remove::<Propagate<TestValue>>()
             .insert(Propagate(TestValue(2)));
+
         app.update();
 
         assert_eq!(

--- a/crates/bevy_app/src/propagate.rs
+++ b/crates/bevy_app/src/propagate.rs
@@ -393,6 +393,32 @@ mod tests {
     }
 
     #[test]
+    fn test_remove_and_reinsert_propagate() {
+        let mut app = App::new();
+        app.add_schedule(Schedule::new(Update));
+        app.add_plugins(HierarchyPropagatePlugin::<TestValue>::new(Update));
+
+        let parent = app.world_mut().spawn(Propagate(TestValue(1))).id();
+
+        let child = app.world_mut().spawn_empty().insert(ChildOf(parent)).id();
+
+        app.update();
+
+        app.world_mut()
+            .entity_mut(parent)
+            .remove::<Propagate<TestValue>>()
+            .insert(Propagate(TestValue(1)));
+        app.update();
+
+        assert_eq!(
+            app.world_mut()
+                .query::<&TestValue>()
+                .get_many(app.world(), [parent, child]),
+            Ok([&TestValue(1), &TestValue(1)])
+        );
+    }
+
+    #[test]
     fn test_remove_orphan() {
         let mut app = App::new();
         app.add_schedule(Schedule::new(Update));

--- a/crates/bevy_app/src/propagate.rs
+++ b/crates/bevy_app/src/propagate.rs
@@ -161,6 +161,7 @@ pub fn update_source<C: Component + Clone + PartialEq, F: QueryFilter, R: Relati
     mut removed: RemovedComponents<Propagate<C>>,
     relationship: Query<&R>,
     relations: Query<&Inherited<C>, Without<PropagateStop<C>>>,
+    sources: Query<(), With<Propagate<C>>>,
 ) {
     for (entity, source) in &changed {
         commands
@@ -170,7 +171,9 @@ pub fn update_source<C: Component + Clone + PartialEq, F: QueryFilter, R: Relati
 
     // set `Inherited::<C>` based on ancestry when `Propagate::<C>` is removed
     for removed in removed.read() {
-        if let Ok(mut commands) = commands.get_entity(removed) {
+        if !sources.contains(removed)
+            && let Ok(mut commands) = commands.get_entity(removed)
+        {
             if let Some(inherited) = relationship
                 .get(removed)
                 .ok()


### PR DESCRIPTION
# Objective

Fixes #24549

## Solution

 In `update_source`, add a `With<Propagate<C>>` query to avoid removing `Inherited<C>` when `Propagate<C>` is removed and reinserted in the same frame.

## Testing

Added a new test: `test_remove_and_reinsert_propagate`