### PR TITLE
bevy_reflect: Register type data by path in `reflect` macro attribute

### DIFF
--- a/crates/bevy_reflect/derive/src/container_attributes.rs
+++ b/crates/bevy_reflect/derive/src/container_attributes.rs
@@ -267,10 +267,10 @@ impl ContainerAttributes {
         if self
             .type_data
             .iter()
-            .any(|existing| existing.ident() == type_data.ident())
+            .any(|existing| existing.path() == type_data.path())
         {
             return Err(syn::Error::new(
-                type_data.ident().span(),
+                type_data.path().span(),
                 CONFLICTING_TYPE_DATA_MESSAGE,
             ));
         }
@@ -495,7 +495,7 @@ impl ContainerAttributes {
     pub fn contains(&self, name: &str) -> bool {
         self.type_data
             .iter()
-            .any(|data| data.reflect_ident() == name)
+            .any(|data| data.reflect_path().is_ident(name))
     }
 
     /// The list of type data registrations.

--- a/crates/bevy_reflect/derive/src/ident.rs
+++ b/crates/bevy_reflect/derive/src/ident.rs
@@ -1,4 +1,5 @@
 use proc_macro2::Ident;
+use syn::Path;
 
 /// Returns the "reflected" ident for a given string.
 ///
@@ -17,4 +18,21 @@ use proc_macro2::Ident;
 pub(crate) fn get_reflect_ident(base_ident: &Ident) -> Ident {
     let reflected = format!("Reflect{base_ident}");
     Ident::new(&reflected, base_ident.span())
+}
+
+pub(crate) fn get_reflect_path(path: &Path) -> Path {
+    let mut path = path.clone();
+
+    match path.segments.last_mut() {
+        Some(segment) if !is_reflected_ident(&segment.ident) => {
+            segment.ident = get_reflect_ident(&segment.ident);
+        }
+        _ => {}
+    }
+    path
+}
+
+fn is_reflected_ident(ident: &Ident) -> bool {
+    let ident_str = ident.to_string();
+    ident_str.starts_with("Reflect")
 }

--- a/crates/bevy_reflect/derive/src/lib.rs
+++ b/crates/bevy_reflect/derive/src/lib.rs
@@ -134,14 +134,14 @@ fn match_reflect_impls(ast: DeriveInput, source: ReflectImplSource) -> TokenStre
 ///
 /// In addition to those listed, this macro can also use the attributes for [`TypePath`] derives.
 ///
-/// ## `#[reflect(Ident)]`
+/// ## `#[reflect(TypeData)]`
 ///
-/// The `#[reflect(Ident)]` attribute is used to add type data registrations to the `GetTypeRegistration`
-/// implementation corresponding to the given identifier, prepended by `Reflect`.
+/// The `#[reflect(TypeData)]` attribute is used to add type data registrations to the `GetTypeRegistration`
+/// implementation corresponding to the given type, prepended by `Reflect`.
 ///
-/// For example, `#[reflect(Foo, Bar)]` would add two registrations:
-/// one for `ReflectFoo` and another for `ReflectBar`.
-/// This assumes these types are indeed in-scope wherever this macro is called.
+/// For example, `#[reflect(Foo, path::to::Bar)]` would add two registrations:
+/// one for `ReflectFoo` and another for `path::to::ReflectBar`.
+/// This assumes these types are indeed accessible from their given paths.
 ///
 /// This is often used with traits that have been marked by the [`#[reflect_trait]`](macro@reflect_trait)
 /// macro in order to register the type's implementation of that trait.
@@ -168,7 +168,9 @@ fn match_reflect_impls(ast: DeriveInput, source: ReflectImplSource) -> TokenStre
 ///
 /// ### Special Identifiers
 ///
-/// There are a few "special" identifiers that work a bit differently:
+/// There are a few "special" identifiers that work a bit differently.
+/// It's important that you define these with just the identifier alone
+/// (not their equivalent path nor an alias) to ensure they work as intended.
 ///
 /// * `#[reflect(Clone)]` will force the implementation of `Reflect::reflect_clone` to rely on
 ///   the type's [`Clone`] implementation.

--- a/crates/bevy_reflect/derive/src/registration.rs
+++ b/crates/bevy_reflect/derive/src/registration.rs
@@ -2,6 +2,7 @@
 
 use crate::{serialization::SerializationDataDef, where_clause_options::WhereClauseOptions};
 use quote::{quote, quote_spanned};
+use syn::spanned::Spanned;
 use syn::Type;
 
 /// Creates the `GetTypeRegistration` impl for the given type data.
@@ -44,19 +45,19 @@ pub(crate) fn impl_get_type_registration<'a>(
     });
 
     let type_data = meta.attrs().type_data().iter().map(|data| {
-        let reflect_ident = data.reflect_ident();
+        let reflect_path = data.reflect_path();
         let args = data.args();
 
         let args = if args.is_empty() {
             // Set the span so that we get pointed to the correct identifier even when there are no type data arguments
-            let span = reflect_ident.span();
+            let span = reflect_path.span();
             quote_spanned!(span => ())
         } else {
             quote!((#args))
         };
 
         quote! {
-            registration.register_type_data_with::<#reflect_ident, Self, _>(#args);
+            registration.register_type_data_with::<#reflect_path, Self, _>(#args);
         }
     });
 

--- a/crates/bevy_reflect/derive/src/type_data.rs
+++ b/crates/bevy_reflect/derive/src/type_data.rs
@@ -1,7 +1,6 @@
-use proc_macro2::Ident;
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
-use syn::{parenthesized, token, Expr, Token};
+use syn::{parenthesized, token, Expr, Path, Token};
 
 /// A `TypeData` registration.
 ///
@@ -9,24 +8,38 @@ use syn::{parenthesized, token, Expr, Token};
 /// `#[reflect(Default, Hash(custom_hash_fn))]`.
 #[derive(Clone)]
 pub(crate) struct TypeDataRegistration {
-    ident: Ident,
-    reflect_ident: Ident,
+    path: Path,
+    reflect_path: Path,
     args: Punctuated<Expr, Token![,]>,
 }
 
 impl TypeDataRegistration {
-    /// The shortened ident of the registration.
+    /// The original path of the registration.
     ///
-    /// This would be `Default` in `#[reflect(Default)]`.
-    pub fn ident(&self) -> &Ident {
-        &self.ident
+    /// If the last ident in the path is already prefixed with `Reflect`,
+    /// then this should be the same as the path returned by [`Self::reflect_path`].
+    ///
+    /// Examples:
+    /// - `#[reflect(Foo)]` would give `Foo`
+    /// - `#[reflect(ReflectFoo)]` would give `ReflectFoo`
+    /// - `#[reflect(crate::foo::Foo)]` would give `crate::foo::Foo`
+    /// - `#[reflect(crate::foo::ReflectFoo)]` would give `crate::foo::ReflectFoo`
+    pub fn path(&self) -> &Path {
+        &self.path
     }
 
-    /// The full reflection ident of the registration.
+    /// The reflected type data path of the registration.
     ///
-    /// This would be `ReflectDefault` in `#[reflect(Default)]`.
-    pub fn reflect_ident(&self) -> &Ident {
-        &self.reflect_ident
+    /// If the last ident in the path is already prefixed with `Reflect`,
+    /// then this should be the same as the path returned by [`Self::path`].
+    ///
+    /// Examples:
+    /// - `#[reflect(Foo)]` would give `ReflectFoo`
+    /// - `#[reflect(ReflectFoo)]` would give `ReflectFoo`
+    /// - `#[reflect(crate::foo::Foo)]` would give `crate::foo::ReflectFoo`
+    /// - `#[reflect(crate::foo::ReflectFoo)]` would give `crate::foo::ReflectFoo`
+    pub fn reflect_path(&self) -> &Path {
+        &self.reflect_path
     }
 
     /// The optional arguments of the type data.
@@ -37,8 +50,8 @@ impl TypeDataRegistration {
 
 impl Parse for TypeDataRegistration {
     fn parse(input: ParseStream) -> syn::Result<Self> {
-        let ident = input.parse::<Ident>()?;
-        let reflect_ident = crate::ident::get_reflect_ident(&ident);
+        let path = input.parse::<Path>()?;
+        let reflect_path = crate::ident::get_reflect_path(&path);
 
         let args = if input.peek(token::Paren) {
             let content;
@@ -49,8 +62,8 @@ impl Parse for TypeDataRegistration {
         };
 
         Ok(Self {
-            ident,
-            reflect_ident,
+            path,
+            reflect_path,
             args,
         })
     }

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -4043,6 +4043,43 @@ bevy_reflect::tests::Test {
         assert_eq!(point, Point(external_crate::Vector2([1, 2])));
     }
 
+    #[test]
+    fn should_register_fully_qualified_type_data() {
+        mod foo {
+            pub mod bar {
+                use crate::CreateTypeData;
+
+                #[derive(Clone)]
+                pub struct ReflectBaz;
+
+                impl<T> CreateTypeData<T> for ReflectBaz {
+                    fn create_type_data(_: ()) -> Self {
+                        Self
+                    }
+                }
+            }
+        }
+
+        #[derive(Reflect)]
+        #[reflect(foo::bar::Baz)]
+        struct AutoPrefix;
+
+        #[derive(Reflect)]
+        #[reflect(foo::bar::ReflectBaz)]
+        struct ManualPrefix;
+
+        let mut registry = TypeRegistry::empty();
+        registry.register::<AutoPrefix>();
+        registry.register::<ManualPrefix>();
+
+        assert!(registry
+            .get_type_data::<foo::bar::ReflectBaz>(TypeId::of::<AutoPrefix>())
+            .is_some());
+        assert!(registry
+            .get_type_data::<foo::bar::ReflectBaz>(TypeId::of::<ManualPrefix>())
+            .is_some());
+    }
+
     #[cfg(feature = "auto_register")]
     mod auto_register_reflect {
         use super::*;

--- a/examples/reflection/type_data.rs
+++ b/examples/reflection/type_data.rs
@@ -103,6 +103,8 @@ fn main() {
     // This is why we named it with the `Reflect` prefix:
     // the derive macro will automatically look for a type named `ReflectDamageable` in the current scope.
     #[reflect(Damageable)]
+    // We can also specify the path to type data if it isn't currently in-scope:
+    // #[reflect(path::to::MyTypeData)]
     struct Skeleton {
         health: i32,
     }


### PR DESCRIPTION
# Objective

Currently, type data needs to be in-scope when using `#[reflect(SomeType)]`. This can be mildly annoying when reflection is behind a feature since you need to duplicate the check at both the import and the usage:

```rust
#[cfg(feature = "reflection")]
use bevy_reflect::Reflect;
#[cfg(feature = "reflection")]
use crate::reflect::ReflectSomeType;

#[cfg_attr(feature = "reflection", derive(Reflect), reflect(SomeType))]
struct MyType;
```

You may also notice that it can be somewhat confusing that we import `ReflectSomeType` but write `reflect(SomeType)`. This is unfortunately due to a limitation in Rust, but it would be nice if users had the option at least of writing `reflect(ReflectSomeType)`—if only for consistency.

## Solution

This PR enables registering type data via path rather than just identifier.

```rust
#[cfg(feature = "reflection")]
use bevy_reflect::Reflect;

#[cfg_attr(feature = "reflection", derive(Reflect), reflect(crate::reflect::SomeType))]
struct MyType;
```

Additionally, type data can now also be given by their `Reflect`-prefixed name.

```rust
// Will register `super::reflect::ReflectSomeData` for `MyType`
#[derive(Reflect)]
#[reflect(super::reflect::SomeData)]
struct MyType;

// Will register `super::reflect::ReflectSomeData` for `MyOtherType`
#[derive(Reflect)]
#[reflect(super::reflect::ReflectSomeData)]
struct MyOtherType;
```

## Testing

I added a unit test to ensure things compile correctly and both register the same data.

---

## Showcase

Registering type data via the reflection derive macro can now be done by path:

```rust
#[derive(Reflect)]
// Will register `crate::equipment::ReflectEquippable` for `Sword`
#[reflect(crate::equipment::Equippable)]
struct Sword(i32);
```

Additionally, you may optionally used the `Reflect`-prefixed type name that the macro normally generates automatically:

```rust
#[derive(Reflect)]
// Will still register `crate::equipment::ReflectEquippable` for `Sword`
#[reflect(crate::equipment::ReflectEquippable)]
struct Sword(i32);
```