### PR TITLE
Add additional generic impls of `VisitAssetDependencies`.

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -221,7 +221,10 @@ use bevy_ecs::{
 use bevy_platform::collections::{HashMap, HashSet};
 use bevy_reflect::{FromReflect, GetTypeRegistration, Reflect, TypePath};
 use core::any::TypeId;
-use std::{boxed::Box, collections::{BTreeMap, BTreeSet, VecDeque}};
+use std::{
+    boxed::Box,
+    collections::{BTreeMap, BTreeSet, VecDeque},
+};
 use tracing::error;
 
 /// Provides "asset" loading and processing functionality. An [`Asset`] is a "runtime value" that is loaded from an [`AssetSource`],

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -207,6 +207,8 @@ use crate::{
     processor::{AssetProcessor, Process},
 };
 use alloc::{
+    boxed::Box,
+    collections::{BTreeMap, BTreeSet, VecDeque},
     string::{String, ToString},
     sync::Arc,
     vec::Vec,
@@ -221,10 +223,6 @@ use bevy_ecs::{
 use bevy_platform::collections::{HashMap, HashSet};
 use bevy_reflect::{FromReflect, GetTypeRegistration, Reflect, TypePath};
 use core::any::TypeId;
-use std::{
-    boxed::Box,
-    collections::{BTreeMap, BTreeSet, VecDeque},
-};
 use tracing::error;
 
 /// Provides "asset" loading and processing functionality. An [`Asset`] is a "runtime value" that is loaded from an [`AssetSource`],

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -221,6 +221,7 @@ use bevy_ecs::{
 use bevy_platform::collections::{HashMap, HashSet};
 use bevy_reflect::{FromReflect, GetTypeRegistration, Reflect, TypePath};
 use core::any::TypeId;
+use std::{boxed::Box, collections::{BTreeMap, BTreeSet, VecDeque}};
 use tracing::error;
 
 /// Provides "asset" loading and processing functionality. An [`Asset`] is a "runtime value" that is loaded from an [`AssetSource`],
@@ -474,25 +475,9 @@ impl<A: Asset> VisitAssetDependencies for Handle<A> {
     }
 }
 
-impl<A: Asset> VisitAssetDependencies for Option<Handle<A>> {
-    fn visit_dependencies(&self, visit: &mut impl FnMut(UntypedAssetId)) {
-        if let Some(handle) = self {
-            visit(handle.id().untyped());
-        }
-    }
-}
-
 impl VisitAssetDependencies for UntypedHandle {
     fn visit_dependencies(&self, visit: &mut impl FnMut(UntypedAssetId)) {
         visit(self.id());
-    }
-}
-
-impl VisitAssetDependencies for Option<UntypedHandle> {
-    fn visit_dependencies(&self, visit: &mut impl FnMut(UntypedAssetId)) {
-        if let Some(handle) = self {
-            visit(handle.id());
-        }
     }
 }
 
@@ -502,23 +487,45 @@ impl VisitAssetDependencies for UntypedAssetId {
     }
 }
 
-impl<A: Asset, const N: usize> VisitAssetDependencies for [Handle<A>; N] {
+impl<V: VisitAssetDependencies> VisitAssetDependencies for Option<V> {
     fn visit_dependencies(&self, visit: &mut impl FnMut(UntypedAssetId)) {
-        for dependency in self {
-            visit(dependency.id().untyped());
+        if let Some(dependency) = self {
+            dependency.visit_dependencies(visit);
         }
     }
 }
 
-impl<const N: usize> VisitAssetDependencies for [UntypedHandle; N] {
+impl<V: VisitAssetDependencies, const N: usize> VisitAssetDependencies for [V; N] {
     fn visit_dependencies(&self, visit: &mut impl FnMut(UntypedAssetId)) {
         for dependency in self {
-            visit(dependency.id());
+            dependency.visit_dependencies(visit);
         }
+    }
+}
+
+impl<V: VisitAssetDependencies> VisitAssetDependencies for [V] {
+    fn visit_dependencies(&self, visit: &mut impl FnMut(UntypedAssetId)) {
+        for dependency in self {
+            dependency.visit_dependencies(visit);
+        }
+    }
+}
+
+impl<V: VisitAssetDependencies> VisitAssetDependencies for Box<V> {
+    fn visit_dependencies(&self, visit: &mut impl FnMut(UntypedAssetId)) {
+        self.as_ref().visit_dependencies(visit);
     }
 }
 
 impl<V: VisitAssetDependencies> VisitAssetDependencies for Vec<V> {
+    fn visit_dependencies(&self, visit: &mut impl FnMut(UntypedAssetId)) {
+        for dependency in self {
+            dependency.visit_dependencies(visit);
+        }
+    }
+}
+
+impl<V: VisitAssetDependencies> VisitAssetDependencies for VecDeque<V> {
     fn visit_dependencies(&self, visit: &mut impl FnMut(UntypedAssetId)) {
         for dependency in self {
             dependency.visit_dependencies(visit);
@@ -534,18 +541,26 @@ impl<V: VisitAssetDependencies> VisitAssetDependencies for HashSet<V> {
     }
 }
 
-impl<A: Asset, K> VisitAssetDependencies for HashMap<K, Handle<A>> {
+impl<V: VisitAssetDependencies, K> VisitAssetDependencies for HashMap<K, V> {
     fn visit_dependencies(&self, visit: &mut impl FnMut(UntypedAssetId)) {
         for dependency in self.values() {
-            visit(dependency.id().untyped());
+            dependency.visit_dependencies(visit);
         }
     }
 }
 
-impl<K> VisitAssetDependencies for HashMap<K, UntypedHandle> {
+impl<V: VisitAssetDependencies> VisitAssetDependencies for BTreeSet<V> {
+    fn visit_dependencies(&self, visit: &mut impl FnMut(UntypedAssetId)) {
+        for dependency in self {
+            dependency.visit_dependencies(visit);
+        }
+    }
+}
+
+impl<V: VisitAssetDependencies, K> VisitAssetDependencies for BTreeMap<K, V> {
     fn visit_dependencies(&self, visit: &mut impl FnMut(UntypedAssetId)) {
         for dependency in self.values() {
-            visit(dependency.id());
+            dependency.visit_dependencies(visit);
         }
     }
 }


### PR DESCRIPTION
# Objective

Some implementations of `VisitAssetDependencies` were tied specifically to types directly containing asset handles and IDs such as `Option<Handle<A>>`. This prevents marking many types as `#[dependency]` even though they contain types which implement `VisitAssetDependencies`.

## Solution

Replaced implemenations of `VisitAssetDependencies` that were specifically to asset handles and IDs with ones generic across `V: VisitAssetDependencies`. Added additional implementations for various `std` types and collections.

## Testing

No tests were added or modified.