### PR TITLE
Document gizmos axes colors

### DIFF
--- a/crates/bevy_gizmos/src/arrows.rs
+++ b/crates/bevy_gizmos/src/arrows.rs
@@ -165,6 +165,10 @@ where
     /// Draw a set of axes local to the given transform (`transform`), with length scaled by a factor
     /// of `base_length`.
     ///
+    /// X is red
+    /// Y is green
+    /// Z is blue
+    ///
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;


### PR DESCRIPTION
# Objective

Colors of axes aren't obvious.

## Solution

Added documentation to avoid single "go to definition" hop.

## Testing

Didn't test.