### PR TITLE
bsn: Expand support for optional scenes and scene lists

### DIFF
--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -211,9 +211,9 @@ macro_rules! scene_impl {
 
 all_tuples!(scene_impl, 0, 12, P);
 
-impl<P> Scene for Option<P>
+impl<S> Scene for Option<S>
 where
-    P: Scene,
+    S: Scene,
 {
     #[inline]
     fn resolve(
@@ -221,8 +221,37 @@ where
         context: &mut ResolveContext,
         scene: &mut ResolvedScene,
     ) -> Result<(), ResolveSceneError> {
-        self.map(|optional_scene| optional_scene.resolve(context, scene))
+        self.map(|value| value.resolve(context, scene))
             .unwrap_or(Ok(()))
+    }
+
+    #[inline]
+    fn register_dependencies(&self, dependencies: &mut SceneDependencies) {
+        if let Some(value) = &self {
+            value.register_dependencies(dependencies);
+        }
+    }
+}
+
+impl<L: SceneList> SceneList for Option<L>
+where
+    L: SceneList,
+{
+    #[inline]
+    fn resolve_list(
+        self,
+        context: &mut ResolveContext,
+        scenes: &mut Vec<ResolvedScene>,
+    ) -> std::prelude::v1::Result<(), ResolveSceneError> {
+        self.map(|scene_list| scene_list.resolve_list(context, scenes))
+            .unwrap_or(Ok(()))
+    }
+
+    #[inline]
+    fn register_dependencies(&self, dependencies: &mut SceneDependencies) {
+        if let Some(scene_list) = &self {
+            scene_list.register_dependencies(dependencies);
+        }
     }
 }
 
@@ -534,6 +563,12 @@ impl<S: Scene> From<SceneScope<S>> for Box<dyn Scene> {
     }
 }
 
+impl<S: Scene> From<SceneScope<S>> for Option<Box<dyn Scene>> {
+    fn from(value: SceneScope<S>) -> Self {
+        Some(Box::new(value))
+    }
+}
+
 impl<S: SceneList> From<SceneListScope<S>> for Box<dyn SceneList> {
     fn from(value: SceneListScope<S>) -> Self {
         Box::new(value)
@@ -543,6 +578,18 @@ impl<S: SceneList> From<SceneListScope<S>> for Box<dyn SceneList> {
 impl<S: Scene> From<SceneScope<S>> for Box<dyn SceneList> {
     fn from(value: SceneScope<S>) -> Self {
         Box::new(value)
+    }
+}
+
+impl<S: Scene> From<SceneScope<S>> for Option<Box<dyn SceneList>> {
+    fn from(value: SceneScope<S>) -> Self {
+        Some(Box::new(value))
+    }
+}
+
+impl<S: SceneList> From<SceneListScope<S>> for Option<Box<dyn SceneList>> {
+    fn from(value: SceneListScope<S>) -> Self {
+        Some(Box::new(value))
     }
 }
 


### PR DESCRIPTION
# Objective

It should be possible to support `Option` wrapped scenes and scene lists in Bevy. https://github.com/bevyengine/bevy/pull/24536 got us part of the way there, but it didn't support SceneList. It also didn't add nice support for `Option<Box<dyn SceneList>>`  in cases like "scene props".

#24536 also introduces a bug, as it doesn't register the dependencies of the wrapped scene.

## Solution

Add more thorough support for optional scenes. This is now possible:

```rust
#[derive(SceneComponent, Default, Clone)]
#[scene(FeathersButtonProps)]
pub struct FeathersButton;

pub struct FeathersButtonProps {
    pub caption: Option<Box<dyn SceneList>>,
}

impl FeathersButton {
    fn scene(props: FeathersButtonProps) -> impl Scene {
        bsn! {
            Children [
                {props.caption}
            ]
        }
    }
}

// Later
bsn! {
    @FeathersButton {
        @caption: bsn! { Node }
    }
}
```

This also fixes the bug introduced in #24536