### PR TITLE
Add glTF KHR_materials_dispersion support

### DIFF
--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -1,4 +1,4 @@
-﻿#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://bevy.org/assets/icon.png",

--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(docsrs, feature(doc_cfg))]
+﻿#![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://bevy.org/assets/icon.png",
@@ -103,7 +103,7 @@
 //! | `KHR_lights_punctual`             | ✅        |                                     |
 //! | `KHR_materials_anisotropy`        | ✅        | `pbr_anisotropy_texture`            |
 //! | `KHR_materials_clearcoat`         | ✅        | `pbr_multi_layer_material_textures` |
-//! | `KHR_materials_dispersion`        | ❌        |                                     |
+//! | `KHR_materials_dispersion`        | ✅        |                                     |
 //! | `KHR_materials_emissive_strength` | ✅        |                                     |
 //! | `KHR_materials_ior`               | ✅        |                                     |
 //! | `KHR_materials_iridescence`       | ❌        |                                     |

--- a/crates/bevy_gltf/src/loader/extensions/khr_materials_dispersion.rs
+++ b/crates/bevy_gltf/src/loader/extensions/khr_materials_dispersion.rs
@@ -1,0 +1,28 @@
+use gltf::Material;
+use serde_json::Value;
+
+/// Parsed data from the `KHR_materials_dispersion` extension.
+///
+/// See the specification:
+/// <https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_dispersion/README.md>
+#[derive(Default)]
+pub(crate) struct DispersionExtension {
+    /// The strength of the chromatic dispersion effect. Defaults to `0.0` (no dispersion).
+    pub(crate) dispersion: f32,
+}
+
+impl DispersionExtension {
+    pub(crate) fn parse(material: &Material) -> Option<Self> {
+        let extension = material
+            .extensions()?
+            .get("KHR_materials_dispersion")?
+            .as_object()?;
+
+        let dispersion = extension
+            .get("dispersion")
+            .and_then(Value::as_f64)
+            .unwrap_or(0.0) as f32;
+
+        Some(DispersionExtension { dispersion })
+    }
+}

--- a/crates/bevy_gltf/src/loader/extensions/mod.rs
+++ b/crates/bevy_gltf/src/loader/extensions/mod.rs
@@ -2,6 +2,7 @@
 
 mod khr_materials_anisotropy;
 mod khr_materials_clearcoat;
+mod khr_materials_dispersion;
 mod khr_materials_specular;
 
 use alloc::sync::Arc;
@@ -24,7 +25,9 @@ use {bevy_animation::AnimationClip, bevy_platform::collections::HashSet};
 use crate::{GltfLoaderSettings, GltfMaterial, GltfMesh};
 
 pub(crate) use self::{
-    khr_materials_anisotropy::AnisotropyExtension, khr_materials_clearcoat::ClearcoatExtension,
+    khr_materials_anisotropy::AnisotropyExtension,
+    khr_materials_clearcoat::ClearcoatExtension,
+    khr_materials_dispersion::DispersionExtension,
     khr_materials_specular::SpecularExtension,
 };
 

--- a/crates/bevy_gltf/src/loader/extensions/mod.rs
+++ b/crates/bevy_gltf/src/loader/extensions/mod.rs
@@ -25,10 +25,8 @@ use {bevy_animation::AnimationClip, bevy_platform::collections::HashSet};
 use crate::{GltfLoaderSettings, GltfMaterial, GltfMesh};
 
 pub(crate) use self::{
-    khr_materials_anisotropy::AnisotropyExtension,
-    khr_materials_clearcoat::ClearcoatExtension,
-    khr_materials_dispersion::DispersionExtension,
-    khr_materials_specular::SpecularExtension,
+    khr_materials_anisotropy::AnisotropyExtension, khr_materials_clearcoat::ClearcoatExtension,
+    khr_materials_dispersion::DispersionExtension, khr_materials_specular::SpecularExtension,
 };
 
 /// Stores the `ErasedGltfExtensionHandler` implementations so that they

--- a/crates/bevy_gltf/src/loader/mod.rs
+++ b/crates/bevy_gltf/src/loader/mod.rs
@@ -63,7 +63,7 @@ use crate::{
 #[cfg(feature = "bevy_animation")]
 use self::gltf_ext::scene::collect_path;
 use self::{
-    extensions::{AnisotropyExtension, ClearcoatExtension, SpecularExtension},
+    extensions::{AnisotropyExtension, ClearcoatExtension, DispersionExtension, SpecularExtension},
     gltf_ext::{
         check_for_cycles, get_linear_textures,
         material::{
@@ -1432,6 +1432,9 @@ fn load_material(
     let specular =
         SpecularExtension::parse(material, textures, asset_path.clone()).unwrap_or_default();
 
+    // Parse the `KHR_materials_dispersion` extension data if necessary.
+    let dispersion = DispersionExtension::parse(material).unwrap_or_default();
+
     // We need to operate in the Linear color space and be willing to exceed 1.0 in our channels
     let base_emissive = LinearRgba::rgb(emissive[0], emissive[1], emissive[2]);
     let emissive = base_emissive * material.emissive_strength().unwrap_or(1.0);
@@ -1470,6 +1473,7 @@ fn load_material(
         #[cfg(feature = "pbr_transmission_textures")]
         thickness_texture,
         ior,
+        dispersion: dispersion.dispersion,
         attenuation_distance,
         attenuation_color: Color::linear_rgb(
             attenuation_color[0],

--- a/crates/bevy_gltf/src/material.rs
+++ b/crates/bevy_gltf/src/material.rs
@@ -95,6 +95,9 @@ pub struct GltfMaterial {
     /// The [index of refraction](https://en.wikipedia.org/wiki/Refractive_index) of the material.
     pub ior: f32,
 
+    /// The strength of chromatic dispersion. Corresponds to `KHR_materials_dispersion`.
+    pub dispersion: f32,
+
     /// How far, on average, light travels through the volume beneath the material's
     /// surface before being absorbed.
     pub attenuation_distance: f32,
@@ -221,6 +224,7 @@ impl Default for GltfMaterial {
             #[cfg(feature = "pbr_transmission_textures")]
             thickness_texture: None,
             ior: 1.5,
+            dispersion: 0.0,
             attenuation_color: Color::WHITE,
             attenuation_distance: f32::INFINITY,
             occlusion_channel: UvChannel::Uv0,

--- a/crates/bevy_pbr/src/gltf.rs
+++ b/crates/bevy_pbr/src/gltf.rs
@@ -55,6 +55,7 @@ pub fn standard_material_from_gltf_material(material: &GltfMaterial) -> Standard
         #[cfg(feature = "pbr_transmission_textures")]
         thickness_texture: material.thickness_texture.clone(),
         ior: material.ior,
+        dispersion: material.dispersion,
         attenuation_distance: material.attenuation_distance,
         attenuation_color: material.attenuation_color,
         normal_map_channel: material.normal_map_channel.clone(),

--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -337,6 +337,16 @@ pub struct StandardMaterial {
     #[doc(alias = "refractive_index")]
     pub ior: f32,
 
+    /// The strength of chromatic dispersion, which causes different wavelengths of light to
+    /// refract at slightly different angles when passing through the material.
+    ///
+    /// - When set to `0.0` (the default) there is no dispersion (all wavelengths refract equally).
+    /// - Higher values produce a stronger rainbow/prism effect.
+    ///
+    /// **Note:** Requires [`StandardMaterial::specular_transmission`] to be greater than `0.0` to
+    /// have any visible effect. Corresponds to the `KHR_materials_dispersion` glTF extension.
+    pub dispersion: f32,
+
     /// How far, on average, light travels through the volume beneath the material's
     /// surface before being absorbed.
     ///
@@ -886,6 +896,7 @@ impl Default for StandardMaterial {
             #[cfg(feature = "pbr_transmission_textures")]
             thickness_texture: None,
             ior: 1.5,
+            dispersion: 0.0,
             attenuation_color: Color::WHITE,
             attenuation_distance: f32::INFINITY,
             occlusion_channel: UvChannel::Uv0,
@@ -1036,6 +1047,8 @@ pub struct StandardMaterialUniform {
     pub thickness: f32,
     /// Index of Refraction
     pub ior: f32,
+    /// Dispersion strength
+    pub dispersion: f32,
     /// How far light travels through the volume underneath the material surface before being absorbed
     pub attenuation_distance: f32,
     pub clearcoat: f32,
@@ -1196,6 +1209,7 @@ impl AsBindGroupShaderType<StandardMaterialUniform> for StandardMaterial {
             specular_transmission: self.specular_transmission,
             thickness: self.thickness,
             ior: self.ior,
+            dispersion: self.dispersion,
             attenuation_distance: self.attenuation_distance,
             attenuation_color: LinearRgba::from(self.attenuation_color)
                 .to_f32_array()

--- a/crates/bevy_pbr/src/render/pbr_fragment.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_fragment.wgsl
@@ -247,12 +247,15 @@ pbr_input.material.uv_transform = uv_transform;
     if ((flags & pbr_types::STANDARD_MATERIAL_FLAGS_UNLIT_BIT) == 0u) {
 #ifdef BINDLESS
         pbr_input.material.ior = pbr_bindings::material_array[material_indices[slot].material].ior;
+        pbr_input.material.dispersion =
+                pbr_bindings::material_array[material_indices[slot].material].dispersion;
         pbr_input.material.attenuation_color =
                 pbr_bindings::material_array[material_indices[slot].material].attenuation_color;
         pbr_input.material.attenuation_distance =
                 pbr_bindings::material_array[material_indices[slot].material].attenuation_distance;
 #else   // BINDLESS
         pbr_input.material.ior = pbr_bindings::material.ior;
+        pbr_input.material.dispersion = pbr_bindings::material.dispersion;
         pbr_input.material.attenuation_color = pbr_bindings::material.attenuation_color;
         pbr_input.material.attenuation_distance = pbr_bindings::material.attenuation_distance;
 #endif  // BINDLESS

--- a/crates/bevy_pbr/src/render/pbr_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_functions.wgsl
@@ -850,7 +850,7 @@ fn apply_pbr_lighting(
     emissive_light = emissive_light * mix(1.0, view_bindings::view.exposure, emissive.a);
 
 #ifdef STANDARD_MATERIAL_SPECULAR_TRANSMISSION
-    transmitted_light += transmission::specular_transmissive_light(in.world_position, in.frag_coord.xyz, view_z, in.N, in.V, F0, ior, thickness, perceptual_roughness, specular_transmissive_color, specular_transmitted_environment_light).rgb;
+    transmitted_light += transmission::specular_transmissive_light(in.world_position, in.frag_coord.xyz, view_z, in.N, in.V, F0, ior, thickness, perceptual_roughness, in.material.dispersion, specular_transmissive_color, specular_transmitted_environment_light).rgb;
 
     if (in.material.flags & pbr_types::STANDARD_MATERIAL_FLAGS_ATTENUATION_ENABLED_BIT) != 0u
         && in.material.attenuation_distance != 0.0 {

--- a/crates/bevy_pbr/src/render/pbr_types.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_types.wgsl
@@ -14,6 +14,7 @@ struct StandardMaterial {
     specular_transmission: f32,
     thickness: f32,
     ior: f32,
+    dispersion: f32,
     attenuation_distance: f32,
     clearcoat: f32,
     clearcoat_perceptual_roughness: f32,
@@ -78,6 +79,7 @@ fn standard_material_new() -> StandardMaterial {
     material.specular_transmission = 0.0;
     material.thickness = 0.0;
     material.ior = 1.5;
+    material.dispersion = 0.0;
     material.attenuation_distance = 1.0;
     material.attenuation_color = vec4<f32>(1.0, 1.0, 1.0, 1.0);
     material.clearcoat = 0.0;

--- a/crates/bevy_pbr/src/transmission/transmission.wgsl
+++ b/crates/bevy_pbr/src/transmission/transmission.wgsl
@@ -23,7 +23,13 @@ fn ior_corrected_roughness(roughness: f32, ior: f32) -> f32 {
     return roughness * clamp(ior * 2.0 - 2.0, 0.0, 1.0);
 }
 
-fn specular_transmissive_light(world_position: vec4<f32>, frag_coord: vec3<f32>, view_z: f32, N: vec3<f32>, V: vec3<f32>, F0: vec3<f32>, ior: f32, thickness: f32, perceptual_roughness: f32, specular_transmissive_color: vec3<f32>, transmitted_environment_light_specular: vec3<f32>) -> vec3<f32> {
+struct RefractedRay {
+    direction: vec3<f32>,
+    offset_position: vec2<f32>,
+}
+
+// Compute the refracted direction and matching screen-space UV offset for a given IOR.
+fn refracted_ray(world_position: vec4<f32>, N: vec3<f32>, V: vec3<f32>, ior: f32, thickness: f32) -> RefractedRay {
     // Calculate the ratio between refraction indexes. Assume air/vacuum for the space outside the mesh
     let eta = 1.0 / ior;
 
@@ -43,12 +49,39 @@ fn specular_transmissive_light(world_position: vec4<f32>, frag_coord: vec3<f32>,
 
     // Scale / offset position so that coordinate is in right space for sampling transmissive background texture
     let offset_position = (clip_exit_position.xy / clip_exit_position.w) * vec2<f32>(0.5, -0.5) + 0.5;
+    return RefractedRay(T, offset_position);
+}
+
+fn specular_transmissive_light(world_position: vec4<f32>, frag_coord: vec3<f32>, view_z: f32, N: vec3<f32>, V: vec3<f32>, F0: vec3<f32>, ior: f32, thickness: f32, perceptual_roughness: f32, dispersion: f32, specular_transmissive_color: vec3<f32>, transmitted_environment_light_specular: vec3<f32>) -> vec3<f32> {
+    let refracted = refracted_ray(world_position, N, V, ior, thickness);
+    let T = refracted.direction;
+    let offset_position = refracted.offset_position;
 
     // Fetch background color
     var background_color: vec4<f32>;
     let transmission_roughness = ior_corrected_roughness(perceptual_roughness, ior);
-    if transmission_roughness == 0.0 {
-        // If transmission roughness is zero, we can use a faster approach without the blur.
+    if dispersion > 0.0 {
+        // Dispersion will spread out the ior values for each r,g,b channel
+        let half_spread = (ior - 1.0) * 0.025 * dispersion;
+        let offset_r = refracted_ray(world_position, N, V, ior - half_spread, thickness).offset_position;
+        let offset_b = refracted_ray(world_position, N, V, ior + half_spread, thickness).offset_position;
+
+        var r: vec4<f32>;
+        var g: vec4<f32>;
+        var b: vec4<f32>;
+        if transmission_roughness == 0.0 {
+             // If transmission roughness is zero, we can use a faster approach without the blur.
+            r = fetch_transmissive_background_non_rough(offset_r, frag_coord);
+            g = fetch_transmissive_background_non_rough(offset_position, frag_coord);
+            b = fetch_transmissive_background_non_rough(offset_b, frag_coord);
+        } else {
+            r = fetch_transmissive_background(offset_r, frag_coord, view_z, transmission_roughness);
+            g = fetch_transmissive_background(offset_position, frag_coord, view_z, transmission_roughness);
+            b = fetch_transmissive_background(offset_b, frag_coord, view_z, transmission_roughness);
+        }
+        background_color = vec4<f32>(r.r, g.g, b.b, g.a);
+    } else if transmission_roughness == 0.0 {
+         // If transmission roughness is zero, we can use a faster approach without the blur.
         background_color = fetch_transmissive_background_non_rough(offset_position, frag_coord);
     } else {
         background_color = fetch_transmissive_background(offset_position, frag_coord, view_z, transmission_roughness);


### PR DESCRIPTION
# Objective

- Add support for [`KHR_materials_dispersion`](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_dispersion) in glTF materials.

## Solution

- Parse the `dispersion` factor from glTF materials, pass it to the PBR shader and apply RGB-specific refraction offsets for specular transmission using the formulas described in the `KHR_materials_dispersion` [implementation notes](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_dispersion#implementation).

## Testing

Reviewers can test visually by loading the Khronos [DispersionTest](https://github.com/KhronosGroup/glTF-Sample-Assets/tree/main/Models/DispersionTest), [CompareDispersion](https://github.com/KhronosGroup/glTF-Sample-Assets/tree/main/Models/CompareDispersion) and [DragonDispersion](https://github.com/KhronosGroup/glTF-Sample-Assets/tree/main/Models/DragonDispersion) assets.

## Showcase

<img width="887" height="475" alt="image" src="https://github.com/user-attachments/assets/7ee253ba-1e03-4706-95de-9b5bb049eb18" />

<img width="992" height="517" alt="image" src="https://github.com/user-attachments/assets/deb9e089-78cf-47e9-be68-18e6efe61677" />

<img width="887" height="691" alt="image" src="https://github.com/user-attachments/assets/aca9e57b-f5ff-43e8-915f-0dd3f3512690" />
