### PR TITLE
Add mesh compression and motion blur to scene viewer

### DIFF
--- a/examples/tools/scene_viewer/main.rs
+++ b/examples/tools/scene_viewer/main.rs
@@ -18,6 +18,7 @@ use bevy::{
     gltf::{convert_coordinates::GltfConvertCoordinates, GltfPlugin},
     mesh::MeshAttributeCompressionFlags,
     pbr::DefaultOpaqueRendererMethod,
+    post_process::motion_blur::MotionBlur,
     prelude::*,
     render::occlusion_culling::OcclusionCulling,
 };
@@ -66,6 +67,12 @@ struct Args {
     /// enable mesh index compression
     #[argh(switch)]
     mesh_index_compression: bool,
+    /// enable motion blur
+    #[argh(switch)]
+    motion_blur: bool,
+    /// set the motion blur shutter angle
+    #[argh(option)]
+    motion_blur_shutter_angle: Option<f32>,
 }
 
 impl Args {
@@ -253,6 +260,20 @@ fn setup_scene_after_load(
                 .insert(Msaa::Off)
                 .insert(DepthPrepass)
                 .insert(DeferredPrepass);
+        }
+
+        if args.motion_blur {
+            camera.insert((
+                MotionBlur {
+                    shutter_angle: args
+                        .motion_blur_shutter_angle
+                        .unwrap_or_else(|| MotionBlur::default().shutter_angle),
+                    ..Default::default()
+                },
+                // MSAA and MotionBlur are not compatible on WebGL.
+                #[cfg(all(feature = "webgl2", target_arch = "wasm32", not(feature = "webgpu")))]
+                Msaa::Off,
+            ));
         }
 
         // Spawn a default light if the scene does not have one

--- a/examples/tools/scene_viewer/main.rs
+++ b/examples/tools/scene_viewer/main.rs
@@ -16,6 +16,7 @@ use bevy::{
     core_pipeline::prepass::{DeferredPrepass, DepthPrepass},
     dev_tools::infinite_grid::{InfiniteGrid, InfiniteGridPlugin},
     gltf::{convert_coordinates::GltfConvertCoordinates, GltfPlugin},
+    mesh::MeshAttributeCompressionFlags,
     pbr::DefaultOpaqueRendererMethod,
     prelude::*,
     render::occlusion_culling::OcclusionCulling,
@@ -59,6 +60,12 @@ struct Args {
     /// disables the infinite grid
     #[argh(switch)]
     no_infinite_grid: bool,
+    /// enable mesh attribute compression
+    #[argh(switch)]
+    mesh_attribute_compression: bool,
+    /// enable mesh index compression
+    #[argh(switch)]
+    mesh_index_compression: bool,
 }
 
 impl Args {
@@ -99,6 +106,13 @@ fn main() {
                 ..default()
             })
             .set(GltfPlugin {
+                mesh_attribute_compression: if args.mesh_attribute_compression {
+                    MeshAttributeCompressionFlags::all()
+                        .with_color(MeshAttributeCompressionFlags::COMPRESS_COLOR_UNORM8)
+                } else {
+                    MeshAttributeCompressionFlags::empty()
+                },
+                mesh_index_compression: args.mesh_index_compression,
                 convert_coordinates: GltfConvertCoordinates {
                     rotate_scene_entity: args.convert_scene_coordinates == Some(true),
                     rotate_meshes: args.convert_mesh_coordinates == Some(true),


### PR DESCRIPTION
## Objective

Allow testing more features in the `scene_viewer` example. 

## Solution

Add mesh compression and motion blur options to the command line. Ideally the mesh compression would allow control over individual attributes, but this is enough for basic smoke testing.

```rust
/// enable mesh attribute compression
#[argh(switch)]
mesh_attribute_compression: bool,
/// enable mesh index compression
#[argh(switch)]
mesh_index_compression: bool,
/// enable motion blur
#[argh(switch)]
motion_blur: bool,
/// set the motion blur shutter angle
#[argh(option)]
motion_blur_shutter_angle: Option<f32>,
```

## Testing

```sh
# Mesh compression
cargo run --example scene_viewer --features "free_camera bevy_dev_tools" -- --mesh-attribute-compression --mesh-index-compression

# Motion blur
cargo run --example scene_viewer --features "free_camera bevy_dev_tools" -- "assets//models/animated/Fox.glb" --motion-blur --motion-blur-shutter-angle 10
```
