### PR TITLE
Enable glTF validation for KHR_materials_specular

### DIFF
--- a/crates/bevy_gltf/Cargo.toml
+++ b/crates/bevy_gltf/Cargo.toml
@@ -47,6 +47,7 @@ gltf = { version = "1.4.0", default-features = false, features = [
   "KHR_lights_punctual",
   "KHR_materials_transmission",
   "KHR_materials_ior",
+  "KHR_materials_specular",
   "KHR_materials_volume",
   "KHR_materials_unlit",
   "KHR_materials_emissive_strength",


### PR DESCRIPTION
# Objective

Fix glTF validation for assets that declare `KHR_materials_specular` in `extensionsRequired`.
While testing assets using `KHR_materials_specular` as a required extension, I hit this error:

```text
Failed to load asset '...\xxx.glb' with asset loader 'bevy_gltf::loader::GltfLoader': invalid glTF file: invalid glTF: extensionsRequired[0] = "KHR_materials_specular": Unsupported extension
```

`KHR_materials_specular` is already supported by Bevy, and assets that only list it in `extensionsUsed` load correctly. The failure only happened when the extension was declared as required, because the upstream `gltf` crate feature was not enabled for validation.

I also checked other Bevy-supported material extensions, including `KHR_materials_clearcoat`, `KHR_materials_dispersion` (Soon #24569), and `KHR_materials_anisotropy`. Unlike `KHR_materials_specular`, these extensions do not currently have matching feature flags exposed by the upstream `gltf` crate, so there is no equivalent dependency feature to enable for them in this PR. Bevy handles those extensions through raw extension data parsing.

## Solution

- Enable the `KHR_materials_specular` feature on the `gltf` dependency in `bevy_gltf`.

## Testing

- Reviewers can test by loading a `.gltf` or `.glb` that declares `KHR_materials_specular` in `extensionsRequired`.