### PR TITLE
Fix bindless specular transmission material lookup

### DIFF
--- a/crates/bevy_pbr/src/render/pbr_fragment.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_fragment.wgsl
@@ -498,7 +498,8 @@ pbr_input.material.uv_transform = uv_transform;
 #endif  // VERTEX_UVS
 
 #ifdef BINDLESS
-        var specular_transmission: f32 = pbr_bindings::material_array[slot].specular_transmission;
+        var specular_transmission: f32 =
+                pbr_bindings::material_array[material_indices[slot].material].specular_transmission;
 #else   // BINDLESS
         var specular_transmission: f32 = pbr_bindings::material.specular_transmission;
 #endif  // BINDLESS


### PR DESCRIPTION
# Objective

- Fix a typo in the bindless material lookup for `specular_transmission`.
- I noticed this while reading the transmission shader path for the `KHR_materials_dispersion` work. Since it is unrelated to dispersion itself, I preferred to keep it out of that PR and fix it separately here.

## Solution

- In the bindless path, read `specular_transmission` through the material index stored in `material_indices[slot].material`.
