### PR TITLE
bsn: fix name docs

### DIFF
--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -193,10 +193,8 @@
 //! their descendants:
 //!
 //! ```ignore
-//! let i=0;
 //! bsn! {
 //!     #Root
-//!     Name({format!("Entity {i}")})
 //!     Children [
 //!         Reference(#Root)
 //!     ]


### PR DESCRIPTION
# Objective

Fix #24567 

## Solution

Remove the confusing bits that were wrongly copied from a different example.