### PR TITLE
Rename variable in `custom_loop` example

### DIFF
--- a/examples/app/custom_loop.rs
+++ b/examples/app/custom_loop.rs
@@ -33,9 +33,9 @@ fn print_system(input: Res<Input>) {
     println!("You typed: {}", input.0);
 }
 
-fn exit_system(input: Res<Input>, mut app_exit_reader: MessageWriter<AppExit>) {
+fn exit_system(input: Res<Input>, mut app_exit_writer: MessageWriter<AppExit>) {
     if input.0 == "exit" {
-        app_exit_reader.write(AppExit::Success);
+        app_exit_writer.write(AppExit::Success);
     }
 }
 


### PR DESCRIPTION
# Objective

Rename `app_exit_reader` to `app_exit_writer` for clarity.