### PR TITLE
Fix glTF specular extension parsing

### DIFF
--- a/crates/bevy_gltf/src/loader/extensions/khr_materials_specular.rs
+++ b/crates/bevy_gltf/src/loader/extensions/khr_materials_specular.rs
@@ -3,10 +3,8 @@ use bevy_image::Image;
 
 use gltf::Material;
 
-use serde_json::Value;
-
 #[cfg(feature = "pbr_specular_textures")]
-use {crate::loader::gltf_ext::material::parse_material_extension_texture, bevy_mesh::UvChannel};
+use {crate::loader::gltf_ext::material::uv_channel, bevy_mesh::UvChannel};
 
 /// Parsed data from the `KHR_materials_specular` extension.
 ///
@@ -24,18 +22,34 @@ use {crate::loader::gltf_ext::material::parse_material_extension_texture, bevy_m
 ///
 /// See the specification:
 /// <https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_specular/README.md>
-#[derive(Default)]
 pub(crate) struct SpecularExtension {
-    pub(crate) specular_factor: Option<f64>,
+    pub(crate) specular_factor: f32,
     #[cfg(feature = "pbr_specular_textures")]
     pub(crate) specular_channel: UvChannel,
     #[cfg(feature = "pbr_specular_textures")]
     pub(crate) specular_texture: Option<Handle<Image>>,
-    pub(crate) specular_color_factor: Option<[f64; 3]>,
+    pub(crate) specular_color_factor: [f32; 3],
     #[cfg(feature = "pbr_specular_textures")]
     pub(crate) specular_color_channel: UvChannel,
     #[cfg(feature = "pbr_specular_textures")]
     pub(crate) specular_color_texture: Option<Handle<Image>>,
+}
+
+impl Default for SpecularExtension {
+    fn default() -> Self {
+        Self {
+            specular_factor: 1.0,
+            #[cfg(feature = "pbr_specular_textures")]
+            specular_channel: UvChannel::default(),
+            #[cfg(feature = "pbr_specular_textures")]
+            specular_texture: None,
+            specular_color_factor: [1.0, 1.0, 1.0],
+            #[cfg(feature = "pbr_specular_textures")]
+            specular_color_channel: UvChannel::default(),
+            #[cfg(feature = "pbr_specular_textures")]
+            specular_color_texture: None,
+        }
+    }
 }
 
 impl SpecularExtension {
@@ -52,51 +66,41 @@ impl SpecularExtension {
         textures: &[Handle<Image>],
         asset_path: AssetPath<'_>,
     ) -> Option<Self> {
-        let extension = material
-            .extensions()?
-            .get("KHR_materials_specular")?
-            .as_object()?;
+        let specular = material.specular()?;
 
         #[cfg(feature = "pbr_specular_textures")]
-        let (_specular_channel, _specular_texture) = parse_material_extension_texture(
-            material,
-            extension,
-            "specularTexture",
-            "specular",
-            textures,
-            asset_path.clone(),
-        );
+        let _specular_channel = specular
+            .specular_texture()
+            .map(|info| uv_channel(material, "specular", info.tex_coord()))
+            .unwrap_or_default();
+        #[cfg(feature = "pbr_specular_textures")]
+        let _specular_texture = specular.specular_texture().map(|info| {
+            textures
+                .get(info.texture().index())
+                .cloned()
+                .unwrap_or_default()
+        });
 
         #[cfg(feature = "pbr_specular_textures")]
-        let (_specular_color_channel, _specular_color_texture) = parse_material_extension_texture(
-            material,
-            extension,
-            "specularColorTexture",
-            "specular color",
-            textures,
-            asset_path,
-        );
+        let _specular_color_channel = specular
+            .specular_color_texture()
+            .map(|info| uv_channel(material, "specular color", info.tex_coord()))
+            .unwrap_or_default();
+        #[cfg(feature = "pbr_specular_textures")]
+        let _specular_color_texture = specular.specular_color_texture().map(|info| {
+            textures
+                .get(info.texture().index())
+                .cloned()
+                .unwrap_or_default()
+        });
 
         Some(SpecularExtension {
-            specular_factor: extension.get("specularFactor").and_then(Value::as_f64),
+            specular_factor: specular.specular_factor(),
             #[cfg(feature = "pbr_specular_textures")]
             specular_channel: _specular_channel,
             #[cfg(feature = "pbr_specular_textures")]
             specular_texture: _specular_texture,
-            specular_color_factor: extension
-                .get("specularColorFactor")
-                .and_then(Value::as_array)
-                .and_then(|json_array| {
-                    if json_array.len() < 3 {
-                        None
-                    } else {
-                        Some([
-                            json_array[0].as_f64()?,
-                            json_array[1].as_f64()?,
-                            json_array[2].as_f64()?,
-                        ])
-                    }
-                }),
+            specular_color_factor: specular.specular_color_factor(),
             #[cfg(feature = "pbr_specular_textures")]
             specular_color_channel: _specular_color_channel,
             #[cfg(feature = "pbr_specular_textures")]

--- a/crates/bevy_gltf/src/loader/gltf_ext/material.rs
+++ b/crates/bevy_gltf/src/loader/gltf_ext/material.rs
@@ -12,7 +12,6 @@ use super::texture::texture_transform_to_affine2;
 
 #[cfg(any(
     feature = "pbr_anisotropy_texture",
-    feature = "pbr_specular_textures",
     feature = "pbr_multi_layer_material_textures"
 ))]
 use {
@@ -25,7 +24,6 @@ use {
 /// UV channel and image reference.
 #[cfg(any(
     feature = "pbr_anisotropy_texture",
-    feature = "pbr_specular_textures",
     feature = "pbr_multi_layer_material_textures"
 ))]
 pub(crate) fn parse_material_extension_texture(

--- a/crates/bevy_gltf/src/loader/mod.rs
+++ b/crates/bevy_gltf/src/loader/mod.rs
@@ -1502,15 +1502,16 @@ fn load_material(
         anisotropy_texture: anisotropy.anisotropy_texture,
         // From the `KHR_materials_specular` spec:
         // <https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_specular#materials-with-reflectance-parameter>
-        reflectance: specular.specular_factor.unwrap_or(1.0) as f32 * 0.5,
+        reflectance: specular.specular_factor * 0.5,
         #[cfg(feature = "pbr_specular_textures")]
         specular_channel: specular.specular_channel,
         #[cfg(feature = "pbr_specular_textures")]
         specular_texture: specular.specular_texture,
-        specular_tint: match specular.specular_color_factor {
-            Some(color) => Color::linear_rgb(color[0] as f32, color[1] as f32, color[2] as f32),
-            None => Color::WHITE,
-        },
+        specular_tint: Color::linear_rgb(
+            specular.specular_color_factor[0],
+            specular.specular_color_factor[1],
+            specular.specular_color_factor[2],
+        ),
         #[cfg(feature = "pbr_specular_textures")]
         specular_tint_channel: specular.specular_color_channel,
         #[cfg(feature = "pbr_specular_textures")]


### PR DESCRIPTION
# Objective

- Fix a regression introduced by #24571 where `KHR_materials_specular` was added to the enabled `gltf` crate features. This was missed because the asset i used for testing did not make the specular parsing regression visually obvious.
- After enabling this feature, the `gltf` crate parses `KHR_materials_specular` as a known typed extension, so it is no longer returned by `material.extensions()`, which only exposes unknown extension data.

## Solution

Read `KHR_materials_specular` through the typed [`material.specular()`](https://docs.rs/gltf/latest/gltf/material/struct.Specular.html) API exposed by the `gltf` crate.

## Testing

Reviewers can test visually by loading the Khronos [SpecularTest](https://github.com/KhronosGroup/glTF-Sample-Assets/tree/main/Models/SpecularTest) 