### PR TITLE
Justify the inputs in the `multiple_text_inputs` example

### DIFF
--- a/examples/ui/text/multiple_text_inputs.rs
+++ b/examples/ui/text/multiple_text_inputs.rs
@@ -1,8 +1,9 @@
 //! Demonstrates multiple text inputs
 //!
-//! This example arranges three text inputs in a 3x3 grid layout.  The first column of each row is an [`EditableText`] text input node, the second column is a `Text` node
-//! that is kept synchronized with the [`EditableText`]'s contents by the [`synchronize_output_text`] system, and the third column is updated
-//! by the [`submit_text`] system when the user submits the [`EditableText`]'s text by pressing `Enter`.
+//! This example arranges text inputs in a four-column grid layout. The first column shows the text justification, the second column is an
+//! [`EditableText`] text input node, the third column is a `Text` node that is kept synchronized with the [`EditableText`]'s contents by the
+//! [`synchronize_output_text`] system, and the fourth column is updated by the [`submit_text`] system when the user submits the
+//! [`EditableText`]'s text by pressing `Enter`.
 
 use bevy::color::palettes::tailwind::SLATE_300;
 use bevy::input::keyboard::Key;
@@ -57,8 +58,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 display: Display::Grid,
                 justify_content: JustifyContent::Center,
                 align_content: AlignContent::Center,
-                grid_template_columns: RepeatedGridTrack::px(3, 320.),
-                grid_template_rows: RepeatedGridTrack::auto(6),
+                grid_template_columns: vec![GridTrack::px(160.), RepeatedGridTrack::px(3, 320.)],
                 row_gap: px(8.),
                 column_gap: px(8.),
                 ..default()
@@ -69,7 +69,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             parent.spawn((
                 Text::new("Multiple Text Inputs Example"),
                 Node {
-                    grid_column: GridPlacement::span(3),
+                    grid_column: GridPlacement::span(4),
                     justify_self: JustifySelf::Center,
                     margin: px(16).bottom(),
                     ..default()
@@ -79,7 +79,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             ));
 
             let label_font = font.clone().with_font_size(14.);
-            for label in ["EditableText", "value", "submission"] {
+            for label in ["Justify", "EditableText", "value", "submission"] {
                 parent.spawn((
                     Text::new(label),
                     label_font.clone(),
@@ -91,7 +91,28 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 ));
             }
 
-            for row in 0..3 {
+            for (row, justify) in [
+                Justify::Left,
+                Justify::Center,
+                Justify::Right,
+                Justify::Justified,
+                Justify::Start,
+                Justify::End,
+            ]
+            .into_iter()
+            .enumerate()
+            {
+                parent.spawn((
+                    Node {
+                        border: px(4).all(),
+                        justify_content: JustifyContent::Center,
+                        align_items: AlignItems::Center,
+                        ..default()
+                    },
+                    BorderColor::all(Color::WHITE),
+                    children![(Text::new(format!("{justify:?}")), font.clone(),)],
+                ));
+
                 let mut input = parent.spawn((
                     Node {
                         border: px(4.).all(),
@@ -103,7 +124,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     font.clone(),
                     BackgroundColor(bevy::color::palettes::css::DARK_GREY.into()),
                     TextInputRow(row),
-                    TextLayout::no_wrap(),
+                    TextLayout::no_wrap().with_justify(justify),
                     TabIndex(row as i32),
                     BorderColor::all(SLATE_300),
                 ));
@@ -162,7 +183,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             parent.spawn((
                 Text::new("Press Enter to submit"),
                 Node {
-                    grid_column: GridPlacement::span(3),
+                    grid_column: GridPlacement::span(4),
                     justify_self: JustifySelf::Center,
                     margin: px(16).top(),
                     ..default()


### PR DESCRIPTION
# Objective

Make the `multiple_text_inputs` example a bit more useful by giving each text input a different justification, which should help with debugging cursor behaviour. 

## Solution

Add an input for each `Justify` variant along with a column on the left labelling the justification it is using.

## Showcase

<img width="1798" height="750" alt="inputs-justified" src="https://github.com/user-attachments/assets/324c1cd4-b6a1-4c0f-ad1a-38cd28867704" />
