### PR TITLE
Make resources usable as components by moving `IsResource` off of the required components path

### DIFF
--- a/crates/bevy_ecs/macros/src/resource.rs
+++ b/crates/bevy_ecs/macros/src/resource.rs
@@ -1,28 +1,18 @@
 use bevy_ecs_macro_logic::component::{DeriveComponent, StorageAttribute, StorageTy};
-use bevy_macro_utils::fq_std::FQOption;
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{DeriveInput, Path};
 
 pub fn derive_resource(ast: &mut DeriveInput) -> TokenStream {
     let bevy_ecs: Path = crate::bevy_ecs_path();
-    let mut derive_component = match DeriveComponent::parse(ast, StorageAttribute::Disallowed) {
+    // A resource is just a `Component` that can also be stored as a singleton and registered in resource storage.
+    // The `IsResource` marker that makes it visible to the resource APIs is added by the
+    // `insert_resource`/`init_resource` pathways, *not* as a required component here, so
+    // that the same type can still be used as an ordinary component (see #24591, #24592).
+    let derive_component = match DeriveComponent::parse(ast, StorageAttribute::Disallowed) {
         Ok(value) => value,
         Err(e) => return e.into_compile_error(),
     };
-
-    let struct_name = &ast.ident;
-    let (_, type_generics, _) = &ast.generics.split_for_impl();
-
-    // We add the component_id existence check here to avoid recursive init during required components initialization.
-    derive_component.additional_requires.push(quote! {
-        let resource_component_id = if let #FQOption::Some(id) = required_components.components_registrator().component_id::<#struct_name #type_generics>() {
-            id
-        } else {
-            required_components.components_registrator().register_component::<#struct_name #type_generics>()
-        };
-        required_components.register_required::<#bevy_ecs::resource::IsResource>(move || #bevy_ecs::resource::IsResource::new(resource_component_id));
-    });
 
     let component_impl = match derive_component.impl_component(ast, &bevy_ecs, StorageTy::SparseSet)
     {

--- a/crates/bevy_ecs/src/component/register.rs
+++ b/crates/bevy_ecs/src/component/register.rs
@@ -275,9 +275,15 @@ impl<'w> ComponentsRegistrator<'w> {
     ///
     /// This can also be used to register resources and non-send data.
     ///
-    /// # Warning
+    /// # Note
     ///
-    /// When registering a custom resource be sure to add [`crate::resource::IsResource`] as a required component,
+    /// This only registers the type as a component, even if it is also a resource.
+    ///
+    /// To use it as a resource, insert it through
+    /// the resource APIs (such as [`World::insert_resource_by_id`](crate::world::World::insert_resource_by_id)),
+    /// which mark the backing entity with [`IsResource`](crate::resource::IsResource).
+    ///
+    /// You should not add that marker manually.
     ///
     /// # See also
     ///
@@ -560,10 +566,12 @@ impl<'w> ComponentsQueuedRegistrator<'w> {
     /// Technically speaking, the returned [`ComponentId`] is not valid, but it will become valid later.
     /// See type level docs for details.
     ///
-    /// # Warning
+    /// # Note
     ///
-    /// When registering a custom resource be sure to add [`crate::resource::IsResource`] as a required component,
-    /// Otherwise it will not function as a resource.
+    /// This only makes the type known as a component. To use it as a resource, insert it through
+    /// the resource APIs (such as [`World::insert_resource_by_id`](crate::world::World::insert_resource_by_id)),
+    /// which mark the backing entity with [`IsResource`](crate::resource::IsResource). You should not
+    /// add that marker yourself.
     #[inline]
     pub fn queue_register_component_with_descriptor(
         &self,

--- a/crates/bevy_ecs/src/resource.rs
+++ b/crates/bevy_ecs/src/resource.rs
@@ -216,6 +216,7 @@ pub const IS_RESOURCE: ComponentId = ComponentId::new(crate::component::IS_RESOU
 #[cfg(test)]
 mod tests {
     use core::sync::atomic::{AtomicBool, Ordering::Relaxed};
+    use std::println;
 
     use crate::{
         change_detection::MaybeLocation,
@@ -370,6 +371,48 @@ mod tests {
                 .iter(&world)
                 .count(),
             1
+        );
+    }
+
+    #[test]
+    fn resources_inserted_as_components_are_not_resources() {
+        #[derive(Resource)]
+        struct TestResource;
+
+        let mut world = World::new();
+
+        world.spawn(TestResource);
+        assert!(
+            !world.contains_resource::<TestResource>(),
+            "Spawning a resource as a component should not make it available as a resource"
+        );
+
+        let e1 = world.spawn(()).id();
+        world.entity_mut(e1).insert(TestResource);
+
+        assert!(
+            !world.contains_resource::<TestResource>(),
+            "Inserting a resource as a component should not make it available as a resource"
+        );
+    }
+
+    #[test]
+    fn resources_inserted_as_a_component_do_not_replace_each_other() {
+        #[derive(Resource)]
+        struct TestResource;
+
+        let mut world = World::new();
+
+        let e1 = world.spawn(TestResource).id();
+        let e2 = world.spawn(TestResource).id();
+
+        assert!(
+            world.entity(e1).contains::<TestResource>(),
+            "e1 should have its TestResource component"
+        );
+        assert!(
+            world.entity(e2).contains::<TestResource>(),
+            "e2 should have its TestResource component"
         );
     }
 }

--- a/crates/bevy_ecs/src/resource.rs
+++ b/crates/bevy_ecs/src/resource.rs
@@ -118,6 +118,14 @@ impl ResourceEntities {
 }
 
 /// A marker component for entities that have a Resource component.
+///
+/// This type is automatically inserted during resource insertion,
+/// via the [`World::insert_resource_by_id`] method and
+/// the more common methods which call it.
+///
+/// You should never have to manually insert this component.
+///
+/// [`World::insert_resource_by_id`]: crate::world::World::insert_resource_by_id
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Component, Debug))]
 #[derive(Component, Debug)]
 #[component(on_insert, on_discard, on_despawn)]
@@ -216,7 +224,6 @@ pub const IS_RESOURCE: ComponentId = ComponentId::new(crate::component::IS_RESOU
 #[cfg(test)]
 mod tests {
     use core::sync::atomic::{AtomicBool, Ordering::Relaxed};
-    use std::println;
 
     use crate::{
         change_detection::MaybeLocation,
@@ -326,8 +333,9 @@ mod tests {
         );
 
         let id = world.spawn(TestResource).id();
-        // This spawned resource conflicts with the canonical resource, so it was cleaned up.
-        assert!(world.entity(id).get::<TestResource>().is_none());
+        // Spawning a resource type as a plain component is allowed: the entity keeps its own
+        // `TestResource`, is not marked with `IsResource`, and the canonical resource is untouched.
+        assert!(world.entity(id).get::<TestResource>().is_some());
         assert!(world.entity(id).get::<IsResource>().is_none());
         assert!(world.entity(second_entity).get::<TestResource>().is_some());
         assert!(world.entity(second_entity).get::<IsResource>().is_some());

--- a/crates/bevy_ecs/src/resource.rs
+++ b/crates/bevy_ecs/src/resource.rs
@@ -87,6 +87,11 @@ use bevy_platform::cell::SyncUnsafeCell;
 pub trait Resource: Component {}
 
 /// A cache that links each `ComponentId` from a resource to the corresponding entity.
+///
+/// To initialize a new resource entity, call [`World::get_or_spawn_resource_entity`]
+/// with the resource's `ComponentId`.
+///
+/// [`World::get_or_spawn_resource_entity`]: crate::world::World::get_or_spawn_resource_entity
 #[derive(Default)]
 pub struct ResourceEntities(SyncUnsafeCell<SparseArray<ComponentId, Entity>>);
 
@@ -101,6 +106,12 @@ impl ResourceEntities {
     }
 
     /// Returns the entity for the given resource component, or `None` if there is no entity.
+    ///
+    /// # Warning
+    ///
+    /// When attempting to initialize resource entities, do not call this method directly.
+    /// Instead, use [`World::get_or_spawn_resource_entity`](crate::world::World::get_or_spawn_resource_entity),
+    /// which will ensure that the entity is properly initialized and marked with [`IsResource`].
     #[inline]
     pub fn get(&self, id: ComponentId) -> Option<Entity> {
         self.deref().get(id).copied()
@@ -117,15 +128,33 @@ impl ResourceEntities {
     }
 }
 
-/// A marker component for entities that have a Resource component.
+/// A marker component for entities that have a component which is being used as a [`Resource`].
+///
+/// While [`Resource`], as a trait, indicates that a component *may* be used as a resource,
+/// [`IsResource`] indicates that a component *is* being used as a resource on that entity,
+/// and can be accessed via [`ResourceEntities`], ordinary [`Res`] / [`ResMut`] system parameters,
+/// or [`World::resource`] calls.
+///
+/// Components which implement [`Resource`] are not necessarily resources:
+/// they only become resources when they are inserted via resource insertion paths
+/// such as [`World::insert_resource`].
 ///
 /// This type is automatically inserted during resource insertion,
-/// via the [`World::insert_resource_by_id`] method and
-/// the more common methods which call it.
+/// via the [`World::insert_resource`] method and
+/// related methods.
+/// All of these paths ultimately rely on [`World::get_or_spawn_resource_entity`] to initialize the resource entity,
+/// inserting this component.
+/// As part of that insertion, the resource is registered in [`ResourceEntities`]
+/// via the `on_insert` hook for this component.
 ///
-/// You should never have to manually insert this component.
+/// You should never have to manually insert, remove or edit this component,
+/// and doing so can lead to very surprising bugs.
 ///
-/// [`World::insert_resource_by_id`]: crate::world::World::insert_resource_by_id
+/// [`Res`]: crate::system::Res
+/// [`ResMut`]: crate::system::ResMut
+/// [`World::resource`]: crate::world::World::resource
+/// [`World::insert_resource`]: crate::world::World::insert_resource
+/// [`World::get_or_spawn_resource_entity`]: crate::world::World::get_or_spawn_resource_entity
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Component, Debug))]
 #[derive(Component, Debug)]
 #[component(on_insert, on_discard, on_despawn)]

--- a/crates/bevy_ecs/src/world/entity_access/world_mut.rs
+++ b/crates/bevy_ecs/src/world/entity_access/world_mut.rs
@@ -743,6 +743,14 @@ impl<'w> EntityWorldMut<'w> {
     }
 
     /// Retrieves the [`Entity`] associated with the resource of type `R`, if it exists.
+    ///
+    /// # Warning
+    ///
+    /// Do not use this method when initializing new resources.
+    /// Most of the time, you can just call [`World::insert_resource`](World::insert_resource) or a similar method
+    /// to ensure the resource is properly registered and its entity is properly initialized.
+    ///
+    /// If you need something lower level, reach for [`World::get_or_spawn_resource_entity`] instead.
     #[inline]
     #[track_caller]
     pub fn resource_entity<R: Resource>(&self) -> Option<Entity> {

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1963,7 +1963,13 @@ impl World {
 
         let resource = func(self);
         move_as_ptr!(resource);
-        let entity_mut = self.spawn_with_caller(resource, caller); // ResourceCache is updated automatically
+        let mut entity_mut = self.spawn_with_caller(resource, caller);
+        // Mark this entity as holding a resource so it is registered in the resource cache
+        // and reachable through the resource APIs.
+        // This is added here, rather than as a required component of the resource type,
+        // so that the same type can still be inserted as an ordinary component on other entities
+        // See #24591, #24592 for the regressions that approach caused.
+        entity_mut.insert(IsResource::new(resource_id));
         (resource_id, entity_mut)
     }
 
@@ -3053,22 +3059,38 @@ impl World {
         caller: MaybeLocation,
     ) {
         // if the resource already exists, we replace it on the same entity
-        let mut entity_mut = if let Some(entity) = self.resource_entities.get(component_id) {
-            self.get_entity_mut(entity)
-                .expect("ResourceCache is in sync")
+        if let Some(entity) = self.resource_entities.get(component_id) {
+            let mut entity_mut = self
+                .get_entity_mut(entity)
+                .expect("ResourceCache is in sync");
+            // SAFETY: pointer valid for this component id per precondition
+            unsafe {
+                entity_mut.insert_by_id_with_caller(
+                    component_id,
+                    value,
+                    InsertMode::Replace,
+                    caller,
+                    RelationshipHookMode::Run,
+                )
+            };
         } else {
-            self.spawn_empty()
-        };
-        // SAFETY: pointer valid for this component id per precondition
-        unsafe {
-            entity_mut.insert_by_id_with_caller(
-                component_id,
-                value,
-                InsertMode::Replace,
-                caller,
-                RelationshipHookMode::Run,
-            )
-        };
+            let mut entity_mut = self.spawn_empty();
+            // SAFETY: pointer valid for this component id per precondition
+            unsafe {
+                entity_mut.insert_by_id_with_caller(
+                    component_id,
+                    value,
+                    InsertMode::Replace,
+                    caller,
+                    RelationshipHookMode::Run,
+                )
+            };
+            // Mark this entity as holding a resource so it is registered in the resource
+            // cache and reachable through the resource APIs. This is added here, rather
+            // than as a required component of the resource type, so that the same type can
+            // still be inserted as an ordinary component on other entities (see #24591, #24592).
+            entity_mut.insert(IsResource::new(component_id));
+        }
     }
 
     /// Inserts new `!Send` data with the given `value`. Will replace the value if it already

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1939,6 +1939,24 @@ impl World {
             .register_component_with_descriptor(descriptor)
     }
 
+    /// Returns the [`Entity`] that stores the resource identified by `resource_id`, spawning and
+    /// registering a fresh one if the resource does not exist yet.
+    ///
+    /// This method must be used whenever you are attempting to access a resource entity by id
+    /// that may not have been initialized yet, in order to ensure appropriate initialization.
+    ///
+    /// When a resource entity is spawned, it is marked with [`IsResource`],
+    /// which allows for it to be accessed through the resource APIs (such as [`get_resource`](World::get_resource)).
+    /// When a resource entity already exists, it is expected to already be marked with [`IsResource`];
+    /// failure to do so may result in surprising downstream bugs.
+    pub fn get_or_spawn_resource_entity(&mut self, resource_id: ComponentId) -> Entity {
+        if let Some(entity) = self.resource_entities.get(resource_id) {
+            entity
+        } else {
+            self.spawn(IsResource::new(resource_id)).id()
+        }
+    }
+
     fn insert_resource_if_not_exists_with_caller<R: Resource>(
         &mut self,
         func: impl FnOnce(&mut World) -> R,
@@ -1963,13 +1981,14 @@ impl World {
 
         let resource = func(self);
         move_as_ptr!(resource);
-        let mut entity_mut = self.spawn_with_caller(resource, caller);
-        // Mark this entity as holding a resource so it is registered in the resource cache
-        // and reachable through the resource APIs.
-        // This is added here, rather than as a required component of the resource type,
-        // so that the same type can still be inserted as an ordinary component on other entities
-        // See #24591, #24592 for the regressions that approach caused.
-        entity_mut.insert(IsResource::new(resource_id));
+        let entity = self.get_or_spawn_resource_entity(resource_id);
+        let mut entity_mut = self.entity_mut(entity);
+        entity_mut.insert_with_caller(
+            resource,
+            InsertMode::Replace,
+            caller,
+            RelationshipHookMode::Run,
+        );
         (resource_id, entity_mut)
     }
 
@@ -3058,39 +3077,22 @@ impl World {
         value: OwningPtr<'_>,
         caller: MaybeLocation,
     ) {
-        // if the resource already exists, we replace it on the same entity
-        if let Some(entity) = self.resource_entities.get(component_id) {
-            let mut entity_mut = self
-                .get_entity_mut(entity)
-                .expect("ResourceCache is in sync");
-            // SAFETY: pointer valid for this component id per precondition
-            unsafe {
-                entity_mut.insert_by_id_with_caller(
-                    component_id,
-                    value,
-                    InsertMode::Replace,
-                    caller,
-                    RelationshipHookMode::Run,
-                )
-            };
-        } else {
-            let mut entity_mut = self.spawn_empty();
-            // SAFETY: pointer valid for this component id per precondition
-            unsafe {
-                entity_mut.insert_by_id_with_caller(
-                    component_id,
-                    value,
-                    InsertMode::Replace,
-                    caller,
-                    RelationshipHookMode::Run,
-                )
-            };
-            // Mark this entity as holding a resource so it is registered in the resource
-            // cache and reachable through the resource APIs. This is added here, rather
-            // than as a required component of the resource type, so that the same type can
-            // still be inserted as an ordinary component on other entities (see #24591, #24592).
-            entity_mut.insert(IsResource::new(component_id));
-        }
+        // Reuse the existing resource entity if there is one, otherwise spawn a fresh one
+        // (already marked with `IsResource`) so the type is registered as a resource.
+        let entity = self.get_or_spawn_resource_entity(component_id);
+        let mut entity_mut = self
+            .get_entity_mut(entity)
+            .expect("ResourceCache is in sync");
+        // SAFETY: pointer valid for this component id per precondition
+        unsafe {
+            entity_mut.insert_by_id_with_caller(
+                component_id,
+                value,
+                InsertMode::Replace,
+                caller,
+                RelationshipHookMode::Run,
+            )
+        };
     }
 
     /// Inserts new `!Send` data with the given `value`. Will replace the value if it already

--- a/crates/bevy_ecs/src/world/reflect.rs
+++ b/crates/bevy_ecs/src/world/reflect.rs
@@ -199,11 +199,8 @@ impl World {
         resource_id: ComponentId,
         reflected_resource: Box<dyn PartialReflect>,
     ) {
-        if let Some(entity) = self.resource_entities().get(resource_id) {
-            self.entity_mut(entity).insert_reflect(reflected_resource);
-        } else {
-            self.spawn_empty().insert_reflect(reflected_resource);
-        }
+        let entity = self.get_or_spawn_resource_entity(resource_id);
+        self.entity_mut(entity).insert_reflect(reflected_resource);
     }
 }
 

--- a/crates/bevy_settings/src/lib.rs
+++ b/crates/bevy_settings/src/lib.rs
@@ -497,7 +497,6 @@ fn apply_settings_to_world(
             // The resource does not exist, so create a default.
             let reflect_default = ty.data::<ReflectDefault>().unwrap();
             let mut default_value = reflect_default.default();
-            let mut res_entity = world.spawn_empty();
 
             if let Some(toml) = toml
                 && let Some(value) = toml.get(settings_group)
@@ -515,7 +514,13 @@ fn apply_settings_to_world(
             }
 
             // Now add the new resource to the world.
-            reflect_component.insert(&mut res_entity, default_value.as_partial_reflect(), types);
+            let resource_id = reflect_component.register_component(world);
+            let res_entity = world.get_or_spawn_resource_entity(resource_id);
+            reflect_component.insert(
+                &mut world.entity_mut(res_entity),
+                default_value.as_partial_reflect(),
+                types,
+            );
         }
     }
 }

--- a/crates/bevy_world_serialization/src/dynamic_world.rs
+++ b/crates/bevy_world_serialization/src/dynamic_world.rs
@@ -183,11 +183,7 @@ impl DynamicWorld {
             let resource_id = reflect_component.register_component(world);
 
             // check if the resource already exists, if not spawn it, otherwise override the value
-            let entity = if let Some(entity) = world.resource_entities().get(resource_id) {
-                entity
-            } else {
-                world.spawn_empty().id()
-            };
+            let entity = world.get_or_spawn_resource_entity(resource_id);
 
             SceneEntityMapper::world_scope(entity_map, world, |world, mapper| {
                 reflect_component.apply_or_insert_mapped(

--- a/crates/bevy_world_serialization/src/world_asset.rs
+++ b/crates/bevy_world_serialization/src/world_asset.rs
@@ -113,12 +113,7 @@ impl WorldAsset {
                 .expect("ReflectComponent is depended on ReflectResource");
 
             // check if the resource already exists in the other world, if not spawn it
-            let destination_entity =
-                if let Some(entity) = world.resource_entities().get(component_id) {
-                    entity
-                } else {
-                    world.spawn_empty().id()
-                };
+            let destination_entity = world.get_or_spawn_resource_entity(component_id);
 
             reflect_component.copy(
                 &self.world,


### PR DESCRIPTION
# Objective

One of my goals with resources-as-components (#20934) was to support patterns where data can be used as either a resource or a component fluidly.
Query for the component type *once*, and hit it everywhere.

This is prominently used in `leafwing-input-manager`, where many users asked for the ability to register `InputMap`s and `ActionState`s globally, for games where there's no natural "player" entity to store them.

Unfortunately (as I discovered during upgrading this crate), resources-as-components broke this pattern badly.
There were two bugs:

1. Components inserted onto ordinary entities that happen to be resources are registered as resources (#24591). This is surprising!
2. Inserting a second copy of an entity that happens to be a resource removes

Fixes #24591. Fixes #24592.

## Solution

Both of these problems stem from the strategy used to enforce uniqueness: `IsResource`'s `on_insert` hook, which is inserted as a required component via the `Resource` derive macro.

This meant that *every* usage of the resource type was subject to the resource uniqueness constraints, even if it was not being used as a resource.
And at the same time, it meant that every usage of that type was recording as the canonical resource location.

To fix this, there are basically two steps:

1. Stop inserting `IsResource` as a required component.
2. Add `IsResource` during initialization via another approach.

I opted to achieve 2 by adding a `World::get_or_insert_resource_entity` helper,
and warning extensively that it must be used at all of the attractive nuisance methods where you might bypass it.
Initially this was just a bit of boilerplate copied around, but that managed to miss the reflection paths and I decided to make it Enterprise Grade.

This fixes both bugs above, since the whole `IsResource` path is only exercised when you're using the type as, you know,
a component.
As a bonus, the uniqueness guarantees are now robust to manual `Resource` impls. I don't know *why* you would do that, but hey!

This results in a single extra archetype move on a very cold path (resource insertion).
I think that's well worth it to avoid regressing semantics and to allow resources-as-components to actually live up to its promise here.

We *could* decide that this is an intended breakage and close this PR.
If we do so, I will be sad, and also we need to extend the migration guide for resources-as-components to clearly note this limitation.

## Testing

Two new tests: checking for both regressions reported.
