### PR TITLE
Add -Zcache-proc-macros flag to config_fast_builds.toml

### DIFF
--- a/.cargo/config_fast_builds.toml
+++ b/.cargo/config_fast_builds.toml
@@ -65,6 +65,13 @@
 #
 # For more information, see the blog post at <https://blog.rust-lang.org/2023/11/09/parallel-rustc.html>.
 #
+# ## `cache-proc-macros`
+#
+# This option instructs rustc to cache (derive) proc-macro invocations using the incremental system. This can lead
+# to a 5-10% decrease of incremental compilation times.
+#
+# For more information, see https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/cache-proc-macros.html
+#
 # ## `no-embed-metadata`
 #
 # This options avoids unnecessary metadata duplication and can reduce the size of the `target` directory by
@@ -89,6 +96,7 @@ rustflags = [
   # Nightly
   # "-Zshare-generics=y",
   # "-Zthreads=0",
+  # "-Zcache-proc-macros",
 ]
 # Some systems may experience linker performance issues when running doc tests.
 # See https://github.com/bevyengine/bevy/issues/12207 for details.
@@ -112,6 +120,7 @@ rustflags = [
   # Nightly
   # "-Zshare-generics=y",
   # "-Zthreads=0",
+  # "-Zcache-proc-macros",
 ]
 
 [target.aarch64-apple-darwin]
@@ -129,6 +138,7 @@ rustflags = [
   # Nightly
   # "-Zshare-generics=y",
   # "-Zthreads=0",
+  # "-Zcache-proc-macros",
 ]
 
 [target.x86_64-pc-windows-msvc]
@@ -146,6 +156,7 @@ rustflags = [
   # Nightly
   # "-Zshare-generics=n", # This needs to be off if you use dynamic linking on Windows.
   # "-Zthreads=0",
+  # "-Zcache-proc-macros",
 ]
 
 # Optional: Uncommenting the following improves compile times, but reduces the amount of debug info to 'line number tables only'.


### PR DESCRIPTION
# Objective
Add flag to improve incremental build times.

## Solution
Add the flag `-Zcache-proc-macros` to config_fast_build_times.config so that a user can easily enable it if they want to.

## Testing

I did a few tests back and forth with and without this on Linux. I saw consistent incremental build time gains, maybe around 5%. I've also been running with this on aarch64 Mac so it compiles there as well. I haven't tested this on Windows.

I unfortunately did not save the run results I gathered.

---
Another thing to note is that this might _slightly_ increase clean compilation times but only by a small fraction (maybe a couple of percent, not sure). I'm guessing this might be a hot path in the compiler so branching on this condition every time could possibly make it slightly slower? Or it might have just been noise.

The claim that it improves incremental by 5-10% is based on my own experiments and the original rust [PR](https://github.com/rust-lang/rust/pull/145354) that states
> On a no-op change re-check of octocrab 0.49 (which has a ton of serde derive proc macro invocations), this saves ~0.6s out of ~6s (so a ~10% win) on my PC.

Maybe we shouldn't give a number at all? It might even be the case that a user doesn't notice this a lot of the time. My suspicion is that this would make more of a difference if a crate has many and large derive macros, relative to the rest of the code size.

Also I asked about this in the Discord server, but this will probably return stale results if a proc macro if there are side effects. Does Bevy have any side effects in proc macros?