### PR TITLE
Clean up background motion vectors when prepass is disabled

### DIFF
--- a/crates/bevy_core_pipeline/src/prepass/background_motion_vectors.rs
+++ b/crates/bevy_core_pipeline/src/prepass/background_motion_vectors.rs
@@ -12,7 +12,7 @@ use bevy_asset::{embedded_asset, load_embedded_asset, AssetServer, Handle};
 use bevy_ecs::{
     component::Component,
     entity::Entity,
-    query::{Has, QueryItem, With, Without},
+    query::{Has, Or, QueryItem, With, Without},
     reflect::ReflectComponent,
     resource::Resource,
     schedule::IntoScheduleConfigs,
@@ -125,6 +125,7 @@ impl Plugin for BackgroundMotionVectorsPlugin {
             .add_systems(
                 Render,
                 (
+                    cleanup_background_motion_vectors.in_set(RenderSystems::Prepare),
                     prepare_background_motion_vectors_pipelines.in_set(RenderSystems::Prepare),
                     prepare_background_motion_vectors_bind_groups
                         .in_set(RenderSystems::PrepareBindGroups),
@@ -209,6 +210,27 @@ impl SpecializedRenderPipeline for BackgroundMotionVectorsPipeline {
             }),
             ..default()
         }
+    }
+}
+
+fn cleanup_background_motion_vectors(
+    mut commands: Commands,
+    views: Query<
+        Entity,
+        (
+            With<BackgroundMotionVectorsPipelineId>,
+            Or<(
+                Without<MotionVectorPrepass>,
+                With<NoBackgroundMotionVectors>,
+            )>,
+        ),
+    >,
+) {
+    for entity in &views {
+        commands.entity(entity).remove::<(
+            BackgroundMotionVectorsPipelineId,
+            BackgroundMotionVectorsBindGroup,
+        )>();
     }
 }
 


### PR DESCRIPTION
# Objective

- Fix a render validation error when `TemporalAntiAliasing` is removed from a camera while `DepthPrepass` remains enabled.
- The background motion vectors pipeline state could remain on the render-world view after `MotionVectorPrepass` was removed, causing the prepass node to try to render background motion vectors without a motion vector target.

## Solution

Add a cleanup system for background motion vector state.

## Testing

Press Space to disable TAA while keeping DepthPrepass on the camera. Before this PR, it crash  with:

```text
Render pipeline targets are incompatible with render pass
Incompatible color attachments at indices []: the RenderPass uses textures with formats [] but the RenderPipeline with 'background_motion_vectors_pipeline' label uses attachments with formats [None, Some(Rg16Float), None, None]
```

Minimal repro example: 

```
use bevy::anti_alias::taa::TemporalAntiAliasing;
use bevy::core_pipeline::prepass::{DepthPrepass, MotionVectorPrepass};
use bevy::prelude::*;
use bevy::render::camera::{MipBias, TemporalJitter};

fn main() {
    App::new()
        .add_plugins(DefaultPlugins)
        .add_systems(Startup, setup)
        .add_systems(Update, toggle_taa)
        .run();
}

fn setup(mut commands: Commands) {
    commands.spawn((
        Camera3d::default(),
        Msaa::Off,
        DepthPrepass,
        TemporalAntiAliasing::default(),
        Transform::from_xyz(0.0, 0.0, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
    ));
}

fn toggle_taa(
    keys: Res<ButtonInput<KeyCode>>,
    camera: Single<Entity, With<Camera3d>>,
    mut commands: Commands,
) {
    if keys.just_pressed(KeyCode::Space) {
        commands.entity(*camera).remove::<(
            TemporalAntiAliasing,
            TemporalJitter,
            MipBias,
            MotionVectorPrepass,
        )>();
    }
}