### PR TITLE
Rename Preferences to Settings in the appropriate places

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5432,9 +5432,9 @@ path = "examples/app/settings.rs"
 doc-scrape-examples = true
 required-features = ["bevy_settings"]
 
-[package.metadata.example.persisting_preferences]
-name = "User Preferences"
-description = "Demonstrates persistence of user preferences"
+[package.metadata.example.settings]
+name = "Settings"
+description = "Demonstrates persistence of settings"
 category = "Application"
 wasm = true
 
@@ -5446,7 +5446,7 @@ required-features = ["bevy_settings"]
 
 [package.metadata.example.persisting_window_settings]
 name = "Save Window Position"
-description = "Demonstrates saving window position in preferences"
+description = "Demonstrates saving window position settings"
 category = "Application"
 wasm = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -408,7 +408,7 @@ bevy_ui_widgets = [
   "bevy_ui",
 ]
 
-# Load and save user preferences
+# Load and save settings
 bevy_settings = ["bevy_internal/bevy_settings"]
 
 # Feathers widget collection.
@@ -5427,8 +5427,8 @@ category = "UI (User Interface)"
 wasm = true
 
 [[example]]
-name = "persisting_preferences"
-path = "examples/app/persisting_preferences.rs"
+name = "settings"
+path = "examples/app/settings.rs"
 doc-scrape-examples = true
 required-features = ["bevy_settings"]
 

--- a/crates/bevy_settings/src/lib.rs
+++ b/crates/bevy_settings/src/lib.rs
@@ -1,4 +1,4 @@
-//! Framework for saving and loading user settings files (e.g. user settings) in Bevy
+//! Framework for saving and loading user settings files in Bevy
 //! applications.
 //!
 //! Refer to [`SettingsPlugin`] for detailed usage information.

--- a/crates/bevy_settings/src/lib.rs
+++ b/crates/bevy_settings/src/lib.rs
@@ -265,7 +265,7 @@ impl Command for SaveSettingsDeferred {
 fn save_settings(world: &mut World, use_async: bool, force: bool) {
     let this_run = world.change_tick();
     let Some(registry) = world.get_resource::<SettingsFileRegistry>() else {
-        warn!(“Settings registry not found - did you forget to install the SettingsPlugin?");
+        warn!("Settings registry not found - did you forget to install the SettingsPlugin?");
         return;
     };
     let Some(app_types) = world.get_resource::<AppTypeRegistry>() else {

--- a/crates/bevy_settings/src/lib.rs
+++ b/crates/bevy_settings/src/lib.rs
@@ -265,7 +265,7 @@ impl Command for SaveSettingsDeferred {
 fn save_settings(world: &mut World, use_async: bool, force: bool) {
     let this_run = world.change_tick();
     let Some(registry) = world.get_resource::<SettingsFileRegistry>() else {
-        warn!("Preferences registry not found - did you forget to install the SettingsPlugin?");
+        warn!(“Settings registry not found - did you forget to install the SettingsPlugin?");
         return;
     };
     let Some(app_types) = world.get_resource::<AppTypeRegistry>() else {

--- a/crates/bevy_settings/src/lib.rs
+++ b/crates/bevy_settings/src/lib.rs
@@ -71,7 +71,7 @@ use store_wasm::SettingsStore;
 /// Saving of settings is not automatic; the recommended practice is to issue a
 /// [`SaveSettingsDeferred`] command after modifying a settings resource. This will wait for
 /// a short interval and then spawn an i/o task to write out the changed settings file. You can
-/// also issue a [`SavePreferencesSync::IfChanged`] command immediately before exiting the app.
+/// also issue a [`SaveSettingsSync::IfChanged`] command immediately before exiting the app.
 /// Note that on some platforms, depending on how the user exits (such as invoking Command-Q on
 /// ``MacOS``) there may be no opportunity to intercept the app exit event, so the most reliable
 /// approach is to use both techniques: deferred save and save-on-exit.

--- a/crates/bevy_settings/src/lib.rs
+++ b/crates/bevy_settings/src/lib.rs
@@ -376,7 +376,7 @@ fn resources_to_toml(
 /// Builds the settings file registry by scanning the type registry for settings resources.
 /// This is separated from loading to enable testing without file I/O.
 ///
-/// Returns the [`PreferencesFileRegistry`] that tracks which resources are associated with
+/// Returns the [`SettingsFileRegistry`] that tracks which resources are associated with
 /// which settings files.
 fn build_settings_registry(
     app_name: &str,

--- a/crates/bevy_settings/src/lib.rs
+++ b/crates/bevy_settings/src/lib.rs
@@ -1,17 +1,7 @@
-//! Framework for saving and loading user settings files (e.g. user preferences) in Bevy
+//! Framework for saving and loading user settings files (e.g. user settings) in Bevy
 //! applications.
 //!
-//! For purposes of this crate, the term "preferences" and "settings" are defined as:
-//! * **Preferences** are configuration files that store persistent choices made by the end user
-//!   while the app is running. Examples are audio volume, window position, or "show the tutorial".
-//!   A key distinction is that these configuration files are consumed and produced by the same app.
-//! * **Settings** is a more general term, which also includes configuration files produced by a
-//!   different application, such as a text editor or external settings app.
-//!
-//! Refer to [`PreferencesPlugin`] for detailed usage information.
-
-// Required to make proc macros work in bevy itself.
-extern crate self as bevy_settings;
+//! Refer to [`SettingsPlugin`] for detailed usage information.
 
 use core::any::TypeId;
 use core::time::Duration;
@@ -43,59 +33,59 @@ mod store_wasm;
 use bevy_time::{Time, Timer, TimerMode};
 use serde::de::DeserializeSeed;
 #[cfg(not(target_arch = "wasm32"))]
-use store_fs::PreferencesStore;
+use store_fs::SettingsStore;
 
 #[cfg(target_arch = "wasm32")]
-use store_wasm::PreferencesStore;
+use store_wasm::SettingsStore;
 
-/// Plugin to orchestrate loading and saving of user preferences.
+/// Plugin to orchestrate loading and saving settings.
 ///
-/// You are required to provide a unique application name, so that your preferences don't overwrite
+/// You are required to provide a unique application name, so that your settings don't overwrite
 /// those of other apps. To ensure global uniqueness, it is recommended to use a
 /// [reverse domain name](https://en.wikipedia.org/wiki/Reverse_domain_name_notation),
 /// e.g. "com.example.myapp". The plugin will create a directory with that name in the
-/// appropriate filesystem location (depending on platform) for app preferences. For platforms
+/// appropriate filesystem location (depending on platform) for app settings. For platforms
 /// without filesystems, other storage mechanisms will be used.
 ///
 /// If you are do not have a domain name and cannot
 /// afford one, use a reverse domain based on the URL of your repo (GitHub, GitLab, Codeberg
 /// and so on).
 ///
-/// Adding this plugin causes an immediate load of preferences (from either the filesystem or
+/// Adding this plugin causes an immediate load of settings (from either the filesystem or
 /// browser local storage, depending on platform).
 ///
 /// When using this plugin, care must be taken to ensure that plugins execute in the proper order.
-/// Loading preferences causes registered settings to be inserted into the world as bevy resources.
+/// Loading settings causes registered settings to be inserted into the world as bevy resources.
 /// You cannot access these values before they are loaded, but you may want to use the loaded values
 /// when configuring other plugins. For this reason, it's generally a good idea to initialize and
-/// load preferences before other plugins. The preferences plugin does not depend on any other
+/// load settings before other plugins. The settings plugin does not depend on any other
 /// plugins.
 ///
-/// In many cases, you may want to introduce additional "glue" plugins that copy preference
+/// In many cases, you may want to introduce additional "glue" plugins that copy setting
 /// properties after they are loaded. For example, the
 /// [`WindowPlugin`](https://docs.rs/bevy/latest/bevy/prelude/struct.WindowPlugin.html) plugin knows
-/// nothing about preferences, but if you want the window size and position to persist between runs
+/// nothing about settings, but if you want the window size and position to persist between runs
 /// you can add an additional plugin which copies the window settings from the resource to the
 /// actual window entity.
 ///
-/// Saving of preferences is not automatic; the recommended practice is to issue a
-/// [`SavePreferencesDeferred`] command after modifying a settings resource. This will wait for
+/// Saving of settings is not automatic; the recommended practice is to issue a
+/// [`SaveSettingsDeferred`] command after modifying a settings resource. This will wait for
 /// a short interval and then spawn an i/o task to write out the changed settings file. You can
 /// also issue a [`SavePreferencesSync::IfChanged`] command immediately before exiting the app.
 /// Note that on some platforms, depending on how the user exits (such as invoking Command-Q on
 /// ``MacOS``) there may be no opportunity to intercept the app exit event, so the most reliable
 /// approach is to use both techniques: deferred save and save-on-exit.
 ///
-/// Saving is crash-resistant: if the app crashes in the middle of a save, the preferences file
+/// Saving is crash-resistant: if the app crashes in the middle of a save, the settings file
 /// will not be corrupted (it writes to a temporary file first, then uses atomic operations to
 /// replace the previous file).
-pub struct PreferencesPlugin {
+pub struct SettingsPlugin {
     /// The unique name of the application.
     pub app_name: String,
 }
 
-impl PreferencesPlugin {
-    /// Construct a new `PreferencesPlugin` for the given application name.
+impl SettingsPlugin {
+    /// Construct a new `SettingsPlugin` for the given application name.
     pub fn new(app_name: &str) -> Self {
         Self {
             app_name: app_name.to_string(),
@@ -103,7 +93,7 @@ impl PreferencesPlugin {
     }
 }
 
-impl Plugin for PreferencesPlugin {
+impl Plugin for SettingsPlugin {
     fn build(&self, app: &mut App) {
         let app_name = self.app_name.clone();
         let world = app.world();
@@ -117,7 +107,7 @@ impl Plugin for PreferencesPlugin {
         let types = app_types.read();
 
         let world = app.world_mut();
-        let file_index = build_preferences_registry(&app_name, &types, last_save);
+        let file_index = build_settings_registry(&app_name, &types, last_save);
 
         // Now load each of the toml files we discovered, and apply their properties to
         // the resources in the world.
@@ -128,7 +118,7 @@ impl Plugin for PreferencesPlugin {
         // Cache the index so that we don't have to do it again when saving (and also makes
         // saving more deterministic).
         drop(types);
-        world.insert_resource::<PreferencesFileRegistry>(file_index);
+        world.insert_resource::<SettingsFileRegistry>(file_index);
 
         app.add_systems(PostUpdate, handle_delayed_save);
     }
@@ -144,8 +134,8 @@ impl Plugin for PreferencesPlugin {
 ///
 /// You can also control which file the type gets saved to via
 /// `settings_group(file = "<filename>")`. This should be the base name of the file without the
-/// extension. The default name is `settings`, which will cause the preferences to be written out
-/// to `settings.toml` in the app's preferences directory.
+/// extension. The default name is `settings`, which will cause the settings to be written out
+/// to `settings.toml` in the app's settings directory.
 pub trait SettingsGroup: Resource {
     /// The name of the logical section within the settings file.
     fn settings_group_name() -> &'static str;
@@ -186,83 +176,83 @@ impl<T: SettingsGroup + FromReflect + TypePath> CreateTypeData<T> for ReflectSet
     }
 }
 
-/// List of resource types that will be associated with a specific preferences file.
+/// List of resource types that will be associated with a specific settings file.
 /// Also tracks when that file was last written or read.
 #[derive(Default)]
-struct PreferenceFileManifest {
+struct SettingsFileManifest {
     last_save: Tick,
     resource_types: Vec<TypeId>,
 }
 
-/// Records the game tick when preferences were last loaded or saved. This is used to determine
-/// which preferences files have changed and need to be saved. Also tracks which settings files
+/// Records the game tick when settings were last loaded or saved. This is used to determine
+/// which settings files have changed and need to be saved. Also tracks which settings files
 /// are associated with which resource types.
 #[derive(Resource)]
-struct PreferencesFileRegistry {
+struct SettingsFileRegistry {
     /// App name (from plugin)
     app_name: String,
 
-    /// List of known preferences files, determined by scanning reflection registry.
-    files: HashMap<&'static str, PreferenceFileManifest>,
+    /// List of known settings files, determined by scanning reflection registry.
+    files: HashMap<&'static str, SettingsFileManifest>,
 
     /// Timer used for batched saving.
     save_timer: Timer,
 }
 
-/// A Command which saves preferences to disk. This blocks the command queue until saving
+/// A Command which saves settings to disk. This blocks the command queue until saving
 /// is complete.
 #[derive(Default, PartialEq)]
-pub enum SavePreferencesSync {
-    /// Save preferences only if they have changed since the most recent load or save.
+pub enum SaveSettingsSync {
+    /// Save settings only if they have changed since the most recent load or save.
     #[default]
     IfChanged,
-    /// Save preferences unconditionally.
+    /// Save settings unconditionally.
     Always,
 }
 
-impl Command for SavePreferencesSync {
+impl Command for SaveSettingsSync {
     type Out = ();
 
     fn apply(self, world: &mut World) {
-        save_preferences(world, false, self == SavePreferencesSync::Always);
+        save_settings(world, false, self == SaveSettingsSync::Always);
     }
 }
 
-/// A [`Command`] which saves preferences to disk. Actual file system operations happen in another thread.
+/// A [`Command`] which saves settings to disk. Actual file system operations happen in another thread.
 #[derive(Default, PartialEq)]
-pub enum SavePreferences {
-    /// Save preferences only if they have changed since the most recent load or save.
+pub enum SaveSettings {
+    /// Save settings only if they have changed since the most recent load or save.
     #[default]
     IfChanged,
-    /// Save preferences unconditionally.
+    /// Save settings unconditionally.
     Always,
 }
 
-impl Command for SavePreferences {
+impl Command for SaveSettings {
     type Out = ();
 
     fn apply(self, world: &mut World) {
-        save_preferences(world, true, self == SavePreferences::Always);
+        save_settings(world, true, self == SaveSettings::Always);
     }
 }
 
-/// A Command which saves changed preferences after a delay. This is debounced: issuing this
+/// A Command which saves changed settings after a delay. This is debounced: issuing this
 /// command multiple times resets the delay timer each time. This is meant to be used for settings
 /// which change at a high frequency, such as dragging a slider which controls the game's audio
 /// volume. The default delay is 1.0 seconds.
-pub struct SavePreferencesDeferred(pub Duration);
+pub struct SaveSettingsDeferred(pub Duration);
 
-impl Default for SavePreferencesDeferred {
+impl Default for SaveSettingsDeferred {
     fn default() -> Self {
         Self(Duration::from_secs(1))
     }
 }
 
-impl Command for SavePreferencesDeferred {
+impl Command for SaveSettingsDeferred {
     type Out = ();
 
     fn apply(self, world: &mut World) {
-        let Some(mut registry) = world.get_resource_mut::<PreferencesFileRegistry>() else {
+        let Some(mut registry) = world.get_resource_mut::<SettingsFileRegistry>() else {
             return;
         };
 
@@ -272,10 +262,10 @@ impl Command for SavePreferencesDeferred {
     }
 }
 
-fn save_preferences(world: &mut World, use_async: bool, force: bool) {
+fn save_settings(world: &mut World, use_async: bool, force: bool) {
     let this_run = world.change_tick();
-    let Some(registry) = world.get_resource::<PreferencesFileRegistry>() else {
-        warn!("Preferences registry not found - did you forget to install the PreferencesPlugin?");
+    let Some(registry) = world.get_resource::<SettingsFileRegistry>() else {
+        warn!("Preferences registry not found - did you forget to install the SettingsPlugin?");
         return;
     };
     let Some(app_types) = world.get_resource::<AppTypeRegistry>() else {
@@ -285,9 +275,9 @@ fn save_preferences(world: &mut World, use_async: bool, force: bool) {
     let types = app_types.read();
 
     for (filename, manifest) in registry.files.iter() {
-        if force || has_preferences_changed(world, manifest) {
+        if force || has_settings_changed(world, manifest) {
             let table = resources_to_toml(world, &types, manifest);
-            let store = PreferencesStore::new(&registry.app_name);
+            let store = SettingsStore::new(&registry.app_name);
             if use_async {
                 store.save_async(filename, table);
             } else {
@@ -297,13 +287,13 @@ fn save_preferences(world: &mut World, use_async: bool, force: bool) {
     }
 
     // Update timestamps
-    let mut registry = world.get_resource_mut::<PreferencesFileRegistry>().unwrap();
+    let mut registry = world.get_resource_mut::<SettingsFileRegistry>().unwrap();
     for manifest in registry.files.values_mut() {
         manifest.last_save = this_run;
     }
 }
 
-fn has_preferences_changed(world: &World, manifest: &PreferenceFileManifest) -> bool {
+fn has_settings_changed(world: &World, manifest: &SettingsFileManifest) -> bool {
     let this_run = world.read_change_tick();
     manifest.resource_types.iter().any(|r| {
         let Some(component_id) = world.components().get_id(*r) else {
@@ -319,7 +309,7 @@ fn has_preferences_changed(world: &World, manifest: &PreferenceFileManifest) -> 
 fn resources_to_toml(
     world: &World,
     types: &TypeRegistry,
-    manifest: &PreferenceFileManifest,
+    manifest: &SettingsFileManifest,
 ) -> toml::map::Map<String, toml::Value> {
     let mut table = toml::Table::new();
 
@@ -383,19 +373,19 @@ fn resources_to_toml(
     table
 }
 
-/// Builds the preferences file registry by scanning the type registry for settings resources.
+/// Builds the settings file registry by scanning the type registry for settings resources.
 /// This is separated from loading to enable testing without file I/O.
 ///
 /// Returns the [`PreferencesFileRegistry`] that tracks which resources are associated with
 /// which settings files.
-fn build_preferences_registry(
+fn build_settings_registry(
     app_name: &str,
     types: &TypeRegistry,
     last_save: Tick,
-) -> PreferencesFileRegistry {
+) -> SettingsFileRegistry {
     // Build an index that remembers all of the resource types that are to be saved to
     // each individual settings file.
-    let mut file_index = PreferencesFileRegistry {
+    let mut file_index = SettingsFileRegistry {
         app_name: app_name.to_string(),
         files: HashMap::new(),
         save_timer: Timer::new(Duration::from_secs(1), TimerMode::Once),
@@ -418,7 +408,7 @@ fn build_preferences_registry(
         let pending_file = file_index
             .files
             .entry(filename)
-            .or_insert(PreferenceFileManifest {
+            .or_insert(SettingsFileManifest {
                 last_save,
                 resource_types: Vec::new(),
             });
@@ -434,11 +424,11 @@ fn load_settings_file(
     world: &mut World,
     app_name: &str,
     filename: &str,
-    manifest: &PreferenceFileManifest,
+    manifest: &SettingsFileManifest,
     types: &TypeRegistry,
 ) {
     // Load the TOML file
-    let store = PreferencesStore::new(app_name);
+    let store = SettingsStore::new(app_name);
     let toml = store.load(filename);
     if toml.is_none() {
         warn!("Filename {filename}.toml not found");
@@ -456,7 +446,7 @@ fn load_settings_file(
 fn apply_settings_to_world(
     world: &mut World,
     toml: Option<&toml::Table>,
-    manifest: &PreferenceFileManifest,
+    manifest: &SettingsFileManifest,
     types: &TypeRegistry,
 ) {
     for tid in manifest.resource_types.iter() {
@@ -593,13 +583,13 @@ fn load_properties(value: &toml::Value, resource: &mut dyn PartialReflect, types
 }
 
 fn handle_delayed_save(
-    mut preferences: ResMut<PreferencesFileRegistry>,
+    mut settings: ResMut<SettingsFileRegistry>,
     time: Res<Time>,
     mut commands: Commands,
 ) {
-    preferences.save_timer.tick(time.delta());
-    if preferences.save_timer.just_finished() {
-        commands.queue(SavePreferences::IfChanged);
+    settings.save_timer.tick(time.delta());
+    if settings.save_timer.just_finished() {
+        commands.queue(SaveSettings::IfChanged);
     }
 }
 
@@ -608,6 +598,8 @@ mod tests {
     use super::*;
     use bevy_ecs::change_detection::Tick;
     use bevy_reflect::Reflect;
+    // Required to make proc macros work in bevy itself.
+    extern crate self as bevy_settings;
 
     /// Test resource that uses default settings group name (derived from type name)
     #[derive(Resource, SettingsGroup, Reflect, Default)]
@@ -646,7 +638,7 @@ mod tests {
         let mut types = TypeRegistry::default();
         types.register::<CounterSettings>();
 
-        let registry = build_preferences_registry("test_app", &types, Tick::new(0));
+        let registry = build_settings_registry("test_app", &types, Tick::new(0));
 
         assert_eq!(registry.app_name, "test_app");
         assert_eq!(registry.files.len(), 1);
@@ -661,7 +653,7 @@ mod tests {
         let mut types = TypeRegistry::default();
         types.register::<CounterRefreshRateSettings>();
 
-        let registry = build_preferences_registry("test_app", &types, Tick::new(0));
+        let registry = build_settings_registry("test_app", &types, Tick::new(0));
 
         assert_eq!(registry.app_name, "test_app");
         assert_eq!(registry.files.len(), 1);
@@ -677,7 +669,7 @@ mod tests {
         types.register::<CounterSettings>();
         types.register::<ExtraCounterSettings>();
 
-        let registry = build_preferences_registry("test_app", &types, Tick::new(0));
+        let registry = build_settings_registry("test_app", &types, Tick::new(0));
 
         // Both resources should be in the same file
         assert_eq!(registry.files.len(), 1);
@@ -694,7 +686,7 @@ mod tests {
         types.register::<CounterSettings>();
         types.register::<AudioSettings>();
 
-        let registry = build_preferences_registry("test_app", &types, Tick::new(0));
+        let registry = build_settings_registry("test_app", &types, Tick::new(0));
 
         // Resources should be in different files
         assert_eq!(registry.files.len(), 2);
@@ -722,7 +714,7 @@ mod tests {
         world.insert_resource(CounterRefreshRateSettings::Fast);
 
         // Build a manifest with both resource types
-        let manifest = PreferenceFileManifest {
+        let manifest = SettingsFileManifest {
             last_save: Tick::new(0),
             resource_types: vec![
                 TypeId::of::<CounterSettings>(),
@@ -887,7 +879,7 @@ mod tests {
         ));
 
         // Build a manifest with both resource types
-        let manifest = PreferenceFileManifest {
+        let manifest = SettingsFileManifest {
             last_save: Tick::new(0),
             resource_types: vec![
                 TypeId::of::<CounterSettings>(),
@@ -987,7 +979,7 @@ mod tests {
         world.insert_resource(CounterSettings { count: 100 });
         world.insert_resource(CounterRefreshRateSettings::Fast);
 
-        let manifest = PreferenceFileManifest {
+        let manifest = SettingsFileManifest {
             last_save: Tick::new(0),
             resource_types: vec![
                 TypeId::of::<CounterSettings>(),
@@ -1034,7 +1026,7 @@ mod tests {
         );
         // Note: "enabled" field is missing from the TOML
 
-        let manifest = PreferenceFileManifest {
+        let manifest = SettingsFileManifest {
             last_save: Tick::new(0),
             resource_types: vec![
                 TypeId::of::<CounterSettings>(),

--- a/crates/bevy_settings/src/store_fs.rs
+++ b/crates/bevy_settings/src/store_fs.rs
@@ -48,7 +48,7 @@ impl SettingsStore {
                 error!("Error saving settings file: {}", e);
             }
 
-            // Replace old prefs file with new one.
+            // Replace old settings file with new one.
             let file_path = base_path.join(format!("{filename}.toml"));
             if let Err(e) = fs::rename(&temp_path, file_path) {
                 warn!("Could not save settings file: {:?}", e);
@@ -79,7 +79,7 @@ impl SettingsStore {
                         error!("Error saving settings file: {}", e);
                     }
 
-                    // Replace old prefs file with new one.
+                    // Replace old settings file with new one.
                     let file_path = base_path.join(format!("{filename}.toml"));
                     if let Err(e) = fs::rename(&temp_path, file_path) {
                         warn!("Could not save settings file: {:?}", e);
@@ -107,8 +107,8 @@ impl SettingsStore {
 /// Load a settings file from disk in TOML format.
 pub(crate) fn decode_toml_file(file: &PathBuf) -> Option<toml::Table> {
     if file.exists() && file.is_file() {
-        let prefs_str = match fs::read_to_string(file) {
-            Ok(prefs_str) => prefs_str,
+        let settings_str = match fs::read_to_string(file) {
+            Ok(settings_str) => settings_str,
             Err(e) => {
                 error!("Error reading settings file: {}", e);
                 return None;

--- a/crates/bevy_settings/src/store_fs.rs
+++ b/crates/bevy_settings/src/store_fs.rs
@@ -115,7 +115,7 @@ pub(crate) fn decode_toml_file(file: &PathBuf) -> Option<toml::Table> {
             }
         };
 
-        let table_value = match toml::from_str::<toml::Value>(&prefs_str) {
+        let table_value = match toml::from_str::<toml::Value>(&settings_str) {
             Ok(table_value) => table_value,
             Err(e) => {
                 error!("Error parsing settings file: {}", e);

--- a/crates/bevy_settings/src/store_fs.rs
+++ b/crates/bevy_settings/src/store_fs.rs
@@ -3,22 +3,22 @@ use bevy_platform::dirs::preferences_dir;
 use bevy_tasks::IoTaskPool;
 use std::{fs, path::PathBuf};
 
-/// Persistent storage which uses the local filesystem. Preferences will be located in the
-/// OS-specific directory for user preferences.
-pub(crate) struct PreferencesStore {
+/// Persistent storage which uses the local filesystem. Settings will be located in the
+/// OS-specific directory for user settings.
+pub(crate) struct SettingsStore {
     base_path: Option<PathBuf>,
 }
 
-impl PreferencesStore {
-    /// Construct a new filesystem preferences store.
+impl SettingsStore {
+    /// Construct a new filesystem settings store.
     ///
     /// # Arguments
-    /// * `app_name` - The name of the application. See [`crate::PreferencesPlugin`] for usage.
+    /// * `app_name` - The name of the application. See [`crate::SettingsPlugin`] for usage.
     pub(crate) fn new(app_name: &str) -> Self {
         Self {
             base_path: if let Some(base_dir) = preferences_dir() {
                 let prefs_path = base_dir.join(app_name);
-                debug!("Preferences path: {:?}", prefs_path);
+                debug!("Settings path: {:?}", prefs_path);
                 Some(prefs_path)
             } else {
                 warn!("Could not find user configuration directories");
@@ -34,24 +34,24 @@ impl PreferencesStore {
     /// * `contents` - the contents of the file
     pub(crate) fn save(&self, filename: &str, contents: toml::Table) {
         if let Some(base_path) = &self.base_path {
-            // Recursively create the preferences directory if it doesn't exist.
+            // Recursively create the settings directory if it doesn't exist.
             let mut dir_builder = fs::DirBuilder::new();
             dir_builder.recursive(true);
             if let Err(e) = dir_builder.create(base_path.clone()) {
-                warn!("Could not create preferences directory: {:?}", e);
+                warn!("Could not create settings directory: {:?}", e);
                 return;
             }
 
-            // Save preferences to temp file
+            // Save settings to temp file
             let temp_path = base_path.join(format!("{filename}.toml.new"));
             if let Err(e) = fs::write(&temp_path, contents.to_string()) {
-                error!("Error saving preferences file: {}", e);
+                error!("Error saving settings file: {}", e);
             }
 
             // Replace old prefs file with new one.
             let file_path = base_path.join(format!("{filename}.toml"));
             if let Err(e) = fs::rename(&temp_path, file_path) {
-                warn!("Could not save preferences file: {:?}", e);
+                warn!("Could not save settings file: {:?}", e);
             }
         }
     }
@@ -65,24 +65,24 @@ impl PreferencesStore {
         if let Some(base_path) = &self.base_path {
             IoTaskPool::get().scope(|scope| {
                 scope.spawn(async {
-                    // Recursively create the preferences directory if it doesn't exist.
+                    // Recursively create the settings directory if it doesn't exist.
                     let mut dir_builder = fs::DirBuilder::new();
                     dir_builder.recursive(true);
                     if let Err(e) = dir_builder.create(base_path.clone()) {
-                        warn!("Could not create preferences directory: {:?}", e);
+                        warn!("Could not create settings directory: {:?}", e);
                         return;
                     }
 
-                    // Save preferences to temp file
+                    // Save settings to temp file
                     let temp_path = base_path.join(format!("{filename}.toml.new"));
                     if let Err(e) = fs::write(&temp_path, contents.to_string()) {
-                        error!("Error saving preferences file: {}", e);
+                        error!("Error saving settings file: {}", e);
                     }
 
                     // Replace old prefs file with new one.
                     let file_path = base_path.join(format!("{filename}.toml"));
                     if let Err(e) = fs::rename(&temp_path, file_path) {
-                        warn!("Could not save preferences file: {:?}", e);
+                        warn!("Could not save settings file: {:?}", e);
                     }
                 });
             });
@@ -93,7 +93,7 @@ impl PreferencesStore {
     /// be returned.
     ///
     /// # Arguments
-    /// * `filename` - The name of the preferences file, without the file extension.
+    /// * `filename` - The name of the settings file, without the file extension.
     pub(crate) fn load(&self, filename: &str) -> Option<toml::Table> {
         let Some(base_path) = &self.base_path else {
             return None;
@@ -104,13 +104,13 @@ impl PreferencesStore {
     }
 }
 
-/// Load a preferences file from disk in TOML format.
+/// Load a settings file from disk in TOML format.
 pub(crate) fn decode_toml_file(file: &PathBuf) -> Option<toml::Table> {
     if file.exists() && file.is_file() {
         let prefs_str = match fs::read_to_string(file) {
             Ok(prefs_str) => prefs_str,
             Err(e) => {
-                error!("Error reading preferences file: {}", e);
+                error!("Error reading settings file: {}", e);
                 return None;
             }
         };
@@ -118,7 +118,7 @@ pub(crate) fn decode_toml_file(file: &PathBuf) -> Option<toml::Table> {
         let table_value = match toml::from_str::<toml::Value>(&prefs_str) {
             Ok(table_value) => table_value,
             Err(e) => {
-                error!("Error parsing preferences file: {}", e);
+                error!("Error parsing settings file: {}", e);
                 return None;
             }
         };
@@ -126,12 +126,12 @@ pub(crate) fn decode_toml_file(file: &PathBuf) -> Option<toml::Table> {
         match table_value {
             toml::Value::Table(table) => Some(table),
             _ => {
-                error!("Preferences file must be a table");
+                error!("Settings file must be a table");
                 None
             }
         }
     } else {
-        // Preferences file does not exist yet.
+        // Settings file does not exist yet.
         None
     }
 }

--- a/crates/bevy_settings/src/store_wasm.rs
+++ b/crates/bevy_settings/src/store_wasm.rs
@@ -8,7 +8,7 @@ pub(crate) struct SettingsStore {
 }
 
 impl SettingsStore {
-    /// Construct a new preferences store for browser local storage.
+    /// Construct a new settings store for browser local storage.
     ///
     /// # Arguments
     /// * `app_name` - The name of the application. See [`crate::SettingsPlugin`] for usage.

--- a/crates/bevy_settings/src/store_wasm.rs
+++ b/crates/bevy_settings/src/store_wasm.rs
@@ -60,7 +60,7 @@ impl SettingsStore {
     /// be returned.
     ///
     /// # Arguments
-    /// * `filename` - The name of the preferences file, without the file extension.
+    /// * `filename` - The name of the settings file, without the file extension.
     pub(crate) fn load(&self, filename: &str) -> Option<toml::Table> {
         if let Ok(Some(storage)) = window().unwrap().local_storage() {
             let storage_key = self.storage_key(filename);

--- a/crates/bevy_settings/src/store_wasm.rs
+++ b/crates/bevy_settings/src/store_wasm.rs
@@ -71,7 +71,7 @@ impl SettingsStore {
             let table_value = match toml::from_str::<toml::Value>(&toml_str) {
                 Ok(table_value) => table_value,
                 Err(e) => {
-                    error!("Error parsing preferences file: {}", e);
+                    error!("Error parsing settings file: {}", e);
                     return None;
                 }
             };

--- a/crates/bevy_settings/src/store_wasm.rs
+++ b/crates/bevy_settings/src/store_wasm.rs
@@ -3,15 +3,15 @@ use bevy_tasks::IoTaskPool;
 use web_sys::window;
 
 /// Persistent storage which uses browser local storage.
-pub(crate) struct PreferencesStore {
+pub(crate) struct SettingsStore {
     app_name: String,
 }
 
-impl PreferencesStore {
+impl SettingsStore {
     /// Construct a new preferences store for browser local storage.
     ///
     /// # Arguments
-    /// * `app_name` - The name of the application. See [`crate::PreferencesPlugin`] for usage.
+    /// * `app_name` - The name of the application. See [`crate::SettingsPlugin`] for usage.
     pub fn new(app_name: &str) -> Self {
         Self {
             app_name: app_name.to_owned(),
@@ -79,7 +79,7 @@ impl PreferencesStore {
             match table_value {
                 toml::Value::Table(table) => Some(table),
                 _ => {
-                    error!("Preferences file must be a table");
+                    error!("Settings file must be a table");
                     None
                 }
             }

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -97,7 +97,7 @@ This is the complete `bevy` cargo feature list, without "profiles" or "collectio
 |bevy_remote|Enable the Bevy Remote Protocol|
 |bevy_render|Provides rendering functionality|
 |bevy_scene|Provides scene functionality|
-|bevy_settings|Load and save user preferences|
+|bevy_settings|Load and save settings|
 |bevy_shader|Provides shaders usable through asset handles.|
 |bevy_solari|Provides raytraced lighting (experimental)|
 |bevy_sprite|Provides sprite functionality|

--- a/examples/README.md
+++ b/examples/README.md
@@ -245,9 +245,9 @@ Example | Description
 [Plugin Group](../examples/app/plugin_group.rs) | Demonstrates the creation and registration of a custom plugin group
 [Render Recovery](../examples/app/render_recovery.rs) | Demonstrates how bevy can recover from rendering failures.
 [Return after Run](../examples/app/return_after_run.rs) | Show how to return to main after the Bevy app has exited
-[Save Window Position](../examples/window/persisting_window_settings.rs) | Demonstrates saving window position in preferences
+[Save Window Position](../examples/window/persisting_window_settings.rs) | Demonstrates saving window position settings
 [Thread Pool Resources](../examples/app/thread_pool_resources.rs) | Creates and customizes the internal thread pool
-[User Preferences](../examples/app/persisting_preferences.rs) | Demonstrates persistence of user preferences
+[Settings](../examples/app/settings.rs) | Demonstrates persistence of settings
 [Without Winit](../examples/app/without_winit.rs) | Create an application without winit (runs single time, no event loop)
 
 ### Assets

--- a/examples/README.md
+++ b/examples/README.md
@@ -246,8 +246,8 @@ Example | Description
 [Render Recovery](../examples/app/render_recovery.rs) | Demonstrates how bevy can recover from rendering failures.
 [Return after Run](../examples/app/return_after_run.rs) | Show how to return to main after the Bevy app has exited
 [Save Window Position](../examples/window/persisting_window_settings.rs) | Demonstrates saving window position settings
-[Thread Pool Resources](../examples/app/thread_pool_resources.rs) | Creates and customizes the internal thread pool
 [Settings](../examples/app/settings.rs) | Demonstrates persistence of settings
+[Thread Pool Resources](../examples/app/thread_pool_resources.rs) | Creates and customizes the internal thread pool
 [Without Winit](../examples/app/without_winit.rs) | Create an application without winit (runs single time, no event loop)
 
 ### Assets

--- a/examples/app/settings.rs
+++ b/examples/app/settings.rs
@@ -42,11 +42,17 @@ struct Counter {
 
 /// A different settings group which has the name group name as the previous. The two groups will be
 /// merged into a single section in the config file.
-#[derive(Resource, SettingsGroup, Reflect, Default)]
+#[derive(Resource, SettingsGroup, Reflect)]
 #[reflect(Resource, SettingsGroup, Default)]
 #[settings_group(group = "counter")]
 struct OtherSettings {
     enabled: bool,
+}
+
+impl Default for OtherSettings {
+    fn default() -> Self {
+        Self { enabled: true }
+    }
 }
 
 #[derive(Component)]
@@ -84,10 +90,20 @@ fn setup(mut commands: Commands) {
         });
 }
 
-fn show_count(mut query: Query<&mut Text, With<CounterDisplay>>, counter: Res<Counter>) {
-    if counter.is_changed() {
+fn show_count(
+    mut query: Query<&mut Text, With<CounterDisplay>>,
+    counter: Res<Counter>,
+    other: Res<OtherSettings>,
+) {
+    if other.enabled {
+        if counter.is_changed() {
+            for mut text in query.iter_mut() {
+                text.0 = format!("Count: {}", counter.count);
+            }
+        }
+    } else {
         for mut text in query.iter_mut() {
-            text.0 = format!("Count: {}", counter.count);
+            text.0 = "Disabled".into();
         }
     }
 }

--- a/examples/app/settings.rs
+++ b/examples/app/settings.rs
@@ -23,7 +23,7 @@ fn main() {
             // We want to intercept the exit so that we can save settings.
             exit_condition: ExitCondition::DontExit,
             primary_window: Some(Window {
-                title: "Prefs Counter".into(),
+                title: “Settings Counter".into(),
                 ..default()
             }),
             ..default()

--- a/examples/app/settings.rs
+++ b/examples/app/settings.rs
@@ -23,7 +23,7 @@ fn main() {
             // We want to intercept the exit so that we can save settings.
             exit_condition: ExitCondition::DontExit,
             primary_window: Some(Window {
-                title: “Settings Counter".into(),
+                title: "Settings Counter".into(),
                 ..default()
             }),
             ..default()

--- a/examples/app/settings.rs
+++ b/examples/app/settings.rs
@@ -1,7 +1,7 @@
-//! Demonstrates persistence of user preferences.
+//! Demonstrates persistence of settings.
 //!
 //! A counter is shown in the window. It can be incremented and decremented via input press.
-//! Its value persists between app sessions via user preferences.
+//! Its value persists between app sessions via settings.
 //!
 //! On desktop, if you quit the app and then restart it, the counter value should display
 //! the most recent value the app had before exiting.
@@ -12,8 +12,7 @@ use std::time::Duration;
 use bevy::{
     prelude::*,
     settings::{
-        PreferencesPlugin, ReflectSettingsGroup, SavePreferencesDeferred, SavePreferencesSync,
-        SettingsGroup,
+        ReflectSettingsGroup, SaveSettingsDeferred, SaveSettingsSync, SettingsGroup, SettingsPlugin,
     },
     window::{ExitCondition, WindowCloseRequested},
 };
@@ -21,7 +20,7 @@ use bevy::{
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(WindowPlugin {
-            // We want to intercept the exit so that we can save prefs.
+            // We want to intercept the exit so that we can save settings.
             exit_condition: ExitCondition::DontExit,
             primary_window: Some(Window {
                 title: "Prefs Counter".into(),
@@ -29,9 +28,7 @@ fn main() {
             }),
             ..default()
         }))
-        .add_plugins(PreferencesPlugin::new(
-            "org.bevy.examples.persisting_preferences",
-        ))
+        .add_plugins(SettingsPlugin::new("org.bevy.examples.settings"))
         .add_systems(Startup, setup)
         .add_systems(Update, (show_count, change_count, on_window_close))
         .run();
@@ -48,10 +45,6 @@ struct Counter {
 #[derive(Resource, SettingsGroup, Reflect, Default)]
 #[reflect(Resource, SettingsGroup, Default)]
 #[settings_group(group = "counter")]
-#[expect(
-    dead_code,
-    reason = "Example showing additional settings in the same group"
-)]
 struct OtherSettings {
     enabled: bool,
 }
@@ -115,24 +108,14 @@ fn change_count(
     }
 
     if changed {
-        commands.queue(SavePreferencesDeferred(Duration::from_secs_f32(0.1)));
+        commands.queue(SaveSettingsDeferred(Duration::from_secs_f32(0.1)));
     }
 }
 
 fn on_window_close(mut close: MessageReader<WindowCloseRequested>, mut commands: Commands) {
-    // Save preferences immediately, then quit.
+    // Save settings immediately, then quit.
     if let Some(_close_event) = close.read().next() {
-        commands.queue(SavePreferencesSync::IfChanged);
-        commands.queue(ExitAfterSave);
-    }
-}
-
-struct ExitAfterSave;
-
-impl Command for ExitAfterSave {
-    type Out = ();
-
-    fn apply(self, world: &mut World) {
-        world.write_message(AppExit::Success);
+        commands.queue(SaveSettingsSync::IfChanged);
+        commands.write_message(AppExit::Success);
     }
 }

--- a/examples/window/persisting_window_settings.rs
+++ b/examples/window/persisting_window_settings.rs
@@ -21,7 +21,7 @@ fn main() {
             // We want to intercept the exit so that we can save settings.
             exit_condition: ExitCondition::DontExit,
             primary_window: Some(Window {
-                title: "Prefs Window".into(),
+                title: “Settings Window".into(),
                 ..default()
             }),
             ..default()

--- a/examples/window/persisting_window_settings.rs
+++ b/examples/window/persisting_window_settings.rs
@@ -21,7 +21,7 @@ fn main() {
             // We want to intercept the exit so that we can save settings.
             exit_condition: ExitCondition::DontExit,
             primary_window: Some(Window {
-                title: “Settings Window".into(),
+                title: "Settings Window".into(),
                 ..default()
             }),
             ..default()

--- a/examples/window/persisting_window_settings.rs
+++ b/examples/window/persisting_window_settings.rs
@@ -18,7 +18,7 @@ use bevy::{
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(WindowPlugin {
-            // We want to intercept the exit so that we can save prefs.
+            // We want to intercept the exit so that we can save settings.
             exit_condition: ExitCondition::DontExit,
             primary_window: Some(Window {
                 title: "Prefs Window".into(),

--- a/examples/window/persisting_window_settings.rs
+++ b/examples/window/persisting_window_settings.rs
@@ -1,6 +1,6 @@
-//! Demonstrates persistence of user preferences for saving window position.
+//! Demonstrates persistence of window position settings.
 //!
-//! This app saves the app window’s settings to preferences. You may resize the window, move it
+//! This app saves the app window’s settings. You may resize the window, move it
 //! around, and make it full screen; this example will remember those settings.
 //!
 //! If you close the app and restart it, the app should initialize back to the previous window position,
@@ -10,8 +10,7 @@ use std::time::Duration;
 use bevy::{
     prelude::*,
     settings::{
-        PreferencesPlugin, ReflectSettingsGroup, SavePreferencesDeferred, SavePreferencesSync,
-        SettingsGroup,
+        ReflectSettingsGroup, SaveSettingsDeferred, SaveSettingsSync, SettingsGroup, SettingsPlugin,
     },
     window::{ExitCondition, WindowCloseRequested, WindowMode, WindowResized, WindowResolution},
 };
@@ -27,7 +26,7 @@ fn main() {
             }),
             ..default()
         }))
-        .add_plugins(PreferencesPlugin::new(
+        .add_plugins(SettingsPlugin::new(
             "org.bevy.examples.persisting_window_settings",
         ))
         .add_systems(Startup, setup)
@@ -109,7 +108,7 @@ fn update_window_settings(
     }
 
     if window_changed && store_window_settings(window_settings, window) {
-        commands.queue(SavePreferencesDeferred(Duration::from_secs_f32(0.5)));
+        commands.queue(SaveSettingsDeferred(Duration::from_secs_f32(0.5)));
     }
 }
 
@@ -128,19 +127,9 @@ fn store_window_settings(mut window_settings: ResMut<WindowSettings>, window: &W
 }
 
 fn on_window_close(mut close: MessageReader<WindowCloseRequested>, mut commands: Commands) {
-    // Save preferences immediately, then quit.
+    // Save settings immediately, then quit.
     if let Some(_close_event) = close.read().next() {
-        commands.queue(SavePreferencesSync::IfChanged);
-        commands.queue(ExitAfterSave);
-    }
-}
-
-struct ExitAfterSave;
-
-impl Command for ExitAfterSave {
-    type Out = ();
-
-    fn apply(self, world: &mut World) {
-        world.write_message(AppExit::Success);
+        commands.queue(SaveSettingsSync::IfChanged);
+        commands.write_message(AppExit::Success);
     }
 }


### PR DESCRIPTION
# Objective

`bevy_settings` currently conflates "settings" and "preferences" in a number of places. The name of the framework itself is Bevy Settings, so anything that drives general "settings" behaviors should use "settings" terminology. For example, `PreferencesPlugin` should be `SettingsPlugin` because it handles _all_ `SettingsGroup` types (regardless of their "scope" such as "preferences.toml").

## Solution

Use "settings" instead of "preferences" in the appropriate places. I've also removed the custom `ExitAfterSave` commands in the examples as they are unnecessary.

This should land in 0.19 because we haven't published this API yet and getting naming right is important.