### PR TITLE
light: add SunDisk::MARS preset for Mars atmosphere

### DIFF
--- a/crates/bevy_light/src/directional_light.rs
+++ b/crates/bevy_light/src/directional_light.rs
@@ -258,7 +258,7 @@ pub fn update_directional_light_frusta(
 ///
 /// By default, the atmosphere is rendered with [`SunDisk::EARTH`], which approximates the
 /// apparent size and brightness of the Sun as seen from Earth. Use [`SunDisk::MARS`] for the
-/// smaller apparent sun size from Mars (~1.52 AU). You can also disable the sun disk entirely
+/// smaller apparent sun size from Mars. You can also disable the sun disk entirely
 /// with [`SunDisk::OFF`].
 ///
 /// In order to cause the sun to "glow" and light up the surrounding sky, enable bloom

--- a/crates/bevy_light/src/directional_light.rs
+++ b/crates/bevy_light/src/directional_light.rs
@@ -257,8 +257,9 @@ pub fn update_directional_light_frusta(
 /// Requires a `bevy::pbr::Atmosphere` component on a [`Camera3d`](bevy_camera::Camera3d) to have any effect.
 ///
 /// By default, the atmosphere is rendered with [`SunDisk::EARTH`], which approximates the
-/// apparent size and brightness of the Sun as seen from Earth. You can also disable the sun
-/// disk entirely with [`SunDisk::OFF`].
+/// apparent size and brightness of the Sun as seen from Earth. Use [`SunDisk::MARS`] for the
+/// smaller apparent sun size from Mars (~1.52 AU). You can also disable the sun disk entirely
+/// with [`SunDisk::OFF`].
 ///
 /// In order to cause the sun to "glow" and light up the surrounding sky, enable bloom
 /// in your post-processing pipeline by adding a `Bloom` component to your camera.
@@ -281,6 +282,15 @@ impl SunDisk {
     /// with default intensity.
     pub const EARTH: SunDisk = SunDisk {
         angular_size: 0.00930842,
+        intensity: 1.0,
+    };
+
+    /// Mars-like parameters for the sun disk.
+    ///
+    /// Uses the mean apparent size (~21 arcminutes) of the Sun from Mars
+    /// at ~1.52 AU distance with default intensity.
+    pub const MARS: SunDisk = SunDisk {
+        angular_size: 0.00615,
         intensity: 1.0,
     };
 

--- a/examples/3d/atmosphere.rs
+++ b/examples/3d/atmosphere.rs
@@ -15,7 +15,7 @@ use bevy::{
     input::keyboard::KeyCode,
     light::{
         atmosphere::ScatteringMedium, light_consts::lux, Atmosphere, AtmosphereEnvironmentMapLight,
-        FogVolume, VolumetricFog, VolumetricLight,
+        FogVolume, SunDisk, VolumetricFog, VolumetricLight,
     },
     pbr::{
         AtmosphereMode, AtmosphereSettings, DefaultOpaqueRendererMethod, ExtendedMaterial,
@@ -72,6 +72,7 @@ fn atmosphere_controls(
     keyboard_input: Res<ButtonInput<KeyCode>>,
     mut planet_atmosphere: Query<(&mut Atmosphere, &mut GlobalTransform)>,
     mut camera_settings: Query<&mut AtmosphereSettings, With<Camera3d>>,
+    mut sun_disks: Query<&mut SunDisk, With<DirectionalLight>>,
     atmosphere_presets: Res<AtmospherePresets>,
     mut game_state: ResMut<GameState>,
     mut camera_exposure: Query<&mut Exposure, With<Camera3d>>,
@@ -81,16 +82,22 @@ fn atmosphere_controls(
         for (mut atmosphere, mut transform) in &mut planet_atmosphere {
             *atmosphere = Atmosphere::earth(atmosphere_presets.earth.clone());
             *transform = GlobalTransform::from_translation(-Vec3::Y * atmosphere.inner_radius);
-            println!("Switched to Earth atmosphere");
         }
+        for mut sun_disk in &mut sun_disks {
+            sun_disk.angular_size = SunDisk::EARTH.angular_size;
+        }
+        println!("Switched to Earth atmosphere");
     }
 
     if keyboard_input.just_pressed(KeyCode::Digit4) {
         for (mut atmosphere, mut transform) in &mut planet_atmosphere {
             *atmosphere = Atmosphere::mars(atmosphere_presets.mars.clone());
             *transform = GlobalTransform::from_translation(-Vec3::Y * atmosphere.inner_radius);
-            println!("Switched to Mars atmosphere");
         }
+        for mut sun_disk in &mut sun_disks {
+            sun_disk.angular_size = SunDisk::MARS.angular_size;
+        }
+        println!("Switched to Mars atmosphere");
     }
 
     if keyboard_input.just_pressed(KeyCode::Digit1) {
@@ -229,6 +236,7 @@ fn setup_terrain_scene(
         },
         Transform::from_xyz(1.0, 0.4, 0.0).looking_at(Vec3::ZERO, Vec3::Y),
         VolumetricLight,
+        SunDisk::EARTH,
     ));
 
     // spawn the fog volume


### PR DESCRIPTION
In the atmosphere example we can change between Earth and Mars, but the size of the sun does not change. This somewhat bothered me from an astronomical accuarcy.

This commit introduces a new `SunDisk::MARS` constant to accurately represent the sun’s apparent size when viewed from Mars. The implementation updates the documentation and adds the corresponding constant with an angular size of ~21 arcminutes (0.00615 radians).

Key modifications:

- Added `SunDisk::MARS` constant in `directional_light.rs`
- Updated documentation to reference the new Mars preset
- Modified `atmosphere` example to switch sun disk alongside atmosphere presets

I tested this manually.