### PR TITLE
fix: text selection collapse on focus loss

### DIFF
--- a/crates/bevy_ui_widgets/src/text_input.rs
+++ b/crates/bevy_ui_widgets/src/text_input.rs
@@ -390,6 +390,7 @@ fn on_focus_lost_clear_ime(
 ) {
     if let Ok(mut editable_text) = editable_text_query.get_mut(trigger.entity) {
         editable_text.queue_edit(TextEdit::clear_ime_compose());
+        editable_text.queue_edit(TextEdit::CollapseSelection);
     }
 }
 

--- a/crates/bevy_ui_widgets/src/text_input.rs
+++ b/crates/bevy_ui_widgets/src/text_input.rs
@@ -390,6 +390,14 @@ fn on_focus_lost_clear_ime(
 ) {
     if let Ok(mut editable_text) = editable_text_query.get_mut(trigger.entity) {
         editable_text.queue_edit(TextEdit::clear_ime_compose());
+    }
+}
+
+fn on_focus_lost_collapse_selection(
+    trigger: On<FocusLost>,
+    mut editable_text_query: Query<&mut EditableText>,
+) {
+    if let Ok(mut editable_text) = editable_text_query.get_mut(trigger.entity) {
         editable_text.queue_edit(TextEdit::CollapseSelection);
     }
 }
@@ -489,6 +497,7 @@ impl Plugin for EditableTextInputPlugin {
             .add_observer(on_pointer_drag)
             .add_observer(on_pointer_press)
             .add_observer(on_focus_lost_clear_ime)
+            .add_observer(on_focus_lost_collapse_selection)
             .add_observer(on_focus_select_all)
             .add_systems(
                 PreUpdate,

--- a/crates/bevy_ui_widgets/src/text_input.rs
+++ b/crates/bevy_ui_widgets/src/text_input.rs
@@ -375,29 +375,24 @@ fn listen_for_ime_input_when_text_input_focused(
     window.ime_enabled = editable_text_focused;
 }
 
-/// Observer that clears in-progress IME composition when an [`EditableText`] loses focus.
+/// Observer that clears in-progress IME composition and
+/// collapses the current selection to a caret when an [`EditableText`] loses focus .
 ///
 /// We need to clear the composition on focus loss because IME composition state is not automatically tied to widget focus;
-/// the IME remains active until explicitly disabled, even if the focused widget changes to another `EditableText` or to a non-`EditableText`.
+/// the IME remains active until explicitly disabled,
+/// even if the focused widget changes to another `EditableText` or to a non-`EditableText`.
 ///
 /// Without this, switching focus between two text inputs leaves stale preedit state on the
 /// previous input.
 /// The IME stays enabled because both entities are [`EditableText`],
 /// and no [`Ime::Disabled`] event is ever fired to trigger the cleanup in [`on_ime_input`].
-fn on_focus_lost_clear_ime(
-    trigger: On<FocusLost>,
-    mut editable_text_query: Query<&mut EditableText>,
-) {
+///
+/// A [`TextEdit::CollapseSelection`] is also fired to collapse any active highlighted text
+/// selection back to the caret cursor position, preventing text styles from getting stuck in a
+/// focused color state.
+fn on_focus_lost(trigger: On<FocusLost>, mut editable_text_query: Query<&mut EditableText>) {
     if let Ok(mut editable_text) = editable_text_query.get_mut(trigger.entity) {
         editable_text.queue_edit(TextEdit::clear_ime_compose());
-    }
-}
-
-fn on_focus_lost_collapse_selection(
-    trigger: On<FocusLost>,
-    mut editable_text_query: Query<&mut EditableText>,
-) {
-    if let Ok(mut editable_text) = editable_text_query.get_mut(trigger.entity) {
         editable_text.queue_edit(TextEdit::CollapseSelection);
     }
 }
@@ -496,8 +491,7 @@ impl Plugin for EditableTextInputPlugin {
             .add_observer(on_focused_keyboard_input)
             .add_observer(on_pointer_drag)
             .add_observer(on_pointer_press)
-            .add_observer(on_focus_lost_clear_ime)
-            .add_observer(on_focus_lost_collapse_selection)
+            .add_observer(on_focus_lost)
             .add_observer(on_focus_select_all)
             .add_systems(
                 PreUpdate,


### PR DESCRIPTION
# Objective

- Fixes #24579.
- Earlier, when an `EditableText` widget lost focus when pressing `Tab`, the text selection was preserved internally. This left the text permanently in the selection styling (black). This PR ensures it reverts to the default styling once focus is lost.

## Solution

- Added a new `on_focus_lost_collapse_selection` observer to the `EditableTextInputPlugin`.
- When a `FocusLost` event is triggered, it queues an `TextEdit::CollapseSelection` action on the widget as well.

## Testing

- Tested it on the example mentioned in the issue (`multiline_text_input`).

### Before:
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/f6293add-cdbb-4982-a4a4-28f014611aa1" />

### After:
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/f00523ee-17fa-4af6-ad9b-01052e073dc9" />
