### PR TITLE
Fix ScrollArea scroll speed

### DIFF
--- a/crates/bevy_ui_widgets/src/scrollarea.rs
+++ b/crates/bevy_ui_widgets/src/scrollarea.rs
@@ -35,7 +35,7 @@ fn scrollarea_on_scroll(
         let can_scroll_x = node.overflow.x == OverflowAxis::Scroll;
         let can_scroll_y = node.overflow.y == OverflowAxis::Scroll;
 
-        let scroll_delta = scroll.to_lines(&scroll_conversion_ratio);
+        let scroll_delta = scroll.to_pixels(&scroll_conversion_ratio);
         let scroll_delta = Vec2::new(scroll_delta.x, scroll_delta.y);
 
         let max_range = (content_size - visible_size).max(Vec2::ZERO);


### PR DESCRIPTION
When scrolling a ScrollArea, the scroll delta (in lines) was added to the scroll position
(in logical pixels).
This unit error made scrolling extremely slow when `scroll.unit == Line`.

## Testing

- Did you test these changes? If so, how?

I scrolled the lists in the demo with a touchpad (emits scroll.unit == Line), but unfortunately did not find a device that emits the scroll delta in pixels.

- How can other people (reviewers) test your changes?

1. `cargo run --release --example feathers_gallery
 --features=bevy_feathers`
2. Scroll the list
