### PR TITLE
Reuse RenderContextState and PendingCommandBuffers heap allocations

### DIFF
--- a/crates/bevy_core_pipeline/src/schedule.rs
+++ b/crates/bevy_core_pipeline/src/schedule.rs
@@ -16,6 +16,7 @@ use bevy_ecs::{
     entity::EntityHashSet,
     prelude::*,
     schedule::{InternedScheduleLabel, IntoScheduleConfigs, Schedule, ScheduleLabel, SystemSet},
+    system::SystemState,
 };
 #[cfg(feature = "trace")]
 use bevy_log::info_span;
@@ -225,16 +226,18 @@ impl Display for RootView {
     }
 }
 
-pub(crate) fn submit_pending_command_buffers(world: &mut World) {
-    let mut pending = world.resource_mut::<PendingCommandBuffers>();
+pub(crate) fn submit_pending_command_buffers(
+    world: &mut World,
+    state: &mut SystemState<(ResMut<PendingCommandBuffers>, Res<RenderQueue>)>,
+) {
+    let (mut pending, queue) = state.get_mut(world).unwrap();
     #[cfg(feature = "trace")]
     let buffer_count = pending.len();
-    let buffers = pending.take();
+    let mut buffers = pending.take().peekable();
 
-    if !buffers.is_empty() {
+    if buffers.peek().is_some() {
         #[cfg(feature = "trace")]
         let _span = info_span!("queue_submit", count = buffer_count).entered();
-        let queue = world.resource::<RenderQueue>();
         queue.submit(buffers);
     }
 }

--- a/crates/bevy_render/src/renderer/render_context.rs
+++ b/crates/bevy_render/src/renderer/render_context.rs
@@ -43,12 +43,12 @@ impl PendingCommandBuffers {
         self.0.encoders.push(encoder);
     }
 
-    pub fn take(&mut self) -> Vec<CommandBuffer> {
-        let encoders: Vec<_> = self.0.encoders.drain(..).collect();
-        for encoder in encoders {
-            self.0.buffers.push(encoder.finish());
-        }
-        core::mem::take(&mut self.0.buffers)
+    pub fn take(&mut self) -> impl Iterator<Item = CommandBuffer> {
+        let inner = &mut *self.0;
+        inner
+            .buffers
+            .drain(..)
+            .chain(inner.encoders.drain(..).map(|encoder| encoder.finish()))
     }
 
     pub fn is_empty(&self) -> bool {
@@ -67,6 +67,14 @@ struct RenderContextStateInner {
     render_device: Option<RenderDevice>,
 }
 
+impl RenderContextStateInner {
+    fn flush_encoder(&mut self) {
+        if let Some(encoder) = self.command_encoder.take() {
+            self.command_buffers.push(encoder.finish());
+        }
+    }
+}
+
 /// A resource that holds the current render context state, including command encoder and command buffers.
 /// This is used internally by the [`RenderContext`] system parameter. Implements [`SystemBuffer`] to flush
 /// command buffers at the end of each render system in topological system order.
@@ -80,9 +88,7 @@ impl Default for RenderContextState {
 
 impl RenderContextState {
     fn flush_encoder(&mut self) {
-        if let Some(encoder) = self.0.command_encoder.take() {
-            self.0.command_buffers.push(encoder.finish());
-        }
+        self.0.flush_encoder();
     }
 
     fn command_encoder(&mut self) -> &mut CommandEncoder {
@@ -97,9 +103,9 @@ impl RenderContextState {
         })
     }
 
-    pub fn finish(&mut self) -> Vec<CommandBuffer> {
+    pub fn finish(&mut self) -> impl Iterator<Item = CommandBuffer> {
         self.flush_encoder();
-        core::mem::take(&mut self.0.command_buffers)
+        self.0.command_buffers.drain(..)
     }
 }
 
@@ -112,13 +118,11 @@ impl SystemBuffer for RenderContextState {
         let inner = &mut *self.0;
 
         // flush to ensure correct submission order
-        if let Some(encoder) = inner.command_encoder.take() {
-            inner.command_buffers.push(encoder.finish());
-        }
+        inner.flush_encoder();
 
         if !inner.command_buffers.is_empty() {
             let mut pending = world.resource_mut::<PendingCommandBuffers>();
-            pending.push(core::mem::take(&mut inner.command_buffers));
+            pending.push(inner.command_buffers.drain(..));
         }
 
         inner.render_device = None;
@@ -193,8 +197,8 @@ pub struct FlushCommands<'w> {
 impl<'w> FlushCommands<'w> {
     /// Flushes all pending command buffers to the render queue.
     pub fn flush(&mut self) {
-        let buffers = self.pending.take();
-        if !buffers.is_empty() {
+        let mut buffers = self.pending.take().peekable();
+        if buffers.peek().is_some() {
             self.queue.submit(buffers);
         }
     }

--- a/crates/bevy_render/src/renderer/render_context.rs
+++ b/crates/bevy_render/src/renderer/render_context.rs
@@ -39,6 +39,10 @@ impl PendingCommandBuffers {
         self.0.buffers.extend(buffers);
     }
 
+    pub fn append(&mut self, buffers: &mut Vec<CommandBuffer>) {
+        self.0.buffers.append(buffers);
+    }
+
     pub fn push_encoder(&mut self, encoder: CommandEncoder) {
         self.0.encoders.push(encoder);
     }
@@ -122,7 +126,7 @@ impl SystemBuffer for RenderContextState {
 
         if !inner.command_buffers.is_empty() {
             let mut pending = world.resource_mut::<PendingCommandBuffers>();
-            pending.push(inner.command_buffers.drain(..));
+            pending.append(&mut inner.command_buffers);
         }
 
         inner.render_device = None;

--- a/crates/bevy_render/src/renderer/render_context.rs
+++ b/crates/bevy_render/src/renderer/render_context.rs
@@ -48,7 +48,7 @@ impl PendingCommandBuffers {
         inner
             .buffers
             .drain(..)
-            .chain(inner.encoders.drain(..).map(|encoder| encoder.finish()))
+            .chain(inner.encoders.drain(..).map(CommandEncoder::finish))
     }
 
     pub fn is_empty(&self) -> bool {


### PR DESCRIPTION
# Objective

Reuse heap allocations in RenderContext. Address https://github.com/bevyengine/bevy/pull/22144#discussion_r2729894429

## Solution

Replace `core::mem::take` with `drain(..)`. Change `PendingCommandBuffers::take` to return an Iterator and use `peek()` to check if it's empty.

## Testing

Examples still work