### PR TITLE
Fix nightly clippy and `clippy::result_large_err` again

### DIFF
--- a/_release-content/migration-guides/error_variants_boxed.md
+++ b/_release-content/migration-guides/error_variants_boxed.md
@@ -1,7 +1,0 @@
----
-title: "Some variants in `GltfError` and `LoadDirectError` are boxed"
-pull_requests: [24206]
----
-
-The values in `GltfError::ReadAssetBytesError`, `GltfError::AssetLoadError`
-and `LoadDirectError::LoadError::error` are boxed now.

--- a/_release-content/migration-guides/large_error_variants_boxed.md
+++ b/_release-content/migration-guides/large_error_variants_boxed.md
@@ -1,6 +1,6 @@
 ---
 title: "Some large error variants are boxed"
-pull_requests: [24206]
+pull_requests: [24206, 24624]
 ---
 
 Some large error variants are boxed to avoid `clippy::result_large_err`:

--- a/_release-content/migration-guides/large_error_variants_boxed.md
+++ b/_release-content/migration-guides/large_error_variants_boxed.md
@@ -1,0 +1,9 @@
+---
+title: "Some large error variants are boxed"
+pull_requests: [24206]
+---
+
+Some large error variants are boxed to avoid `clippy::result_large_err`:
+
+- `AssetLoadError::RequestedHandleTypeMismatch` now is a `Box<RequestedHandleTypeMismatchError>`
+- `LoadDirectError::LoadError::error` now is a `Box<AssetLoadError>`

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -3001,13 +3001,9 @@ mod tests {
     impl From<&AssetLoadError> for TestAssetLoadError {
         fn from(value: &AssetLoadError) -> TestAssetLoadError {
             match value {
-                AssetLoadError::RequestedHandleTypeMismatch {
-                    requested,
-                    actual_asset_name,
-                    ..
-                } => Self::RequestedHandleTypeMismatch {
-                    requested: *requested,
-                    actual_asset_name,
+                AssetLoadError::RequestedHandleTypeMismatch (err) => Self::RequestedHandleTypeMismatch {
+                    requested: err.requested,
+                    actual_asset_name: err.actual_asset_name,
                 },
                 AssetLoadError::MissingAssetLoader { .. } => Self::MissingAssetLoader,
                 AssetLoadError::AssetReaderError(AssetReaderError::NotFound(_)) => {

--- a/crates/bevy_asset/src/loader_builders.rs
+++ b/crates/bevy_asset/src/loader_builders.rs
@@ -4,8 +4,8 @@
 use crate::{
     io::Reader,
     meta::{loader_settings_meta_transform, MetaTransform, Settings},
-    Asset, AssetLoadError, AssetPath, ErasedAssetLoader, ErasedLoadedAsset, Handle, LoadContext,
-    LoadDirectError, LoadedAsset, LoadedUntypedAsset, UntypedHandle,
+    Asset, AssetPath, ErasedAssetLoader, ErasedLoadedAsset, Handle, LoadContext, LoadDirectError,
+    LoadedAsset, LoadedUntypedAsset, RequestedHandleTypeMismatchError, UntypedHandle,
 };
 use alloc::{borrow::ToOwned, boxed::Box, sync::Arc};
 use core::any::{type_name, TypeId};
@@ -342,12 +342,15 @@ impl<'ctx, 'builder> NestedLoadBuilder<'ctx, 'builder> {
                     .downcast::<A>()
                     .map_err(|_| LoadDirectError::LoadError {
                         dependency: path.clone(),
-                        error: Box::new(AssetLoadError::RequestedHandleTypeMismatch {
-                            path,
-                            requested: TypeId::of::<A>(),
-                            actual_asset_name: loader.asset_type_name(),
-                            loader_name: loader.type_path(),
-                        }),
+                        error: Box::new(
+                            Box::new(RequestedHandleTypeMismatchError {
+                                path,
+                                requested: TypeId::of::<A>(),
+                                actual_asset_name: loader.asset_type_name(),
+                                loader_name: loader.type_path(),
+                            })
+                            .into(),
+                        ),
                     })
             })
     }

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -828,12 +828,13 @@ impl AssetServer {
                     asset_type_id,
                     loader.asset_type_id()
                 );
-                return Err(AssetLoadError::RequestedHandleTypeMismatch {
+                return Err(Box::new(RequestedHandleTypeMismatchError {
                     path: path.into_owned(),
                     requested: asset_type_id,
                     actual_asset_name: loader.asset_type_name(),
                     loader_name: loader.type_path(),
-                });
+                })
+                .into());
             }
         }
         // Bail out earlier if we don't need to load the asset.
@@ -888,12 +889,17 @@ impl AssetServer {
                             if let Some(asset_id) = asset_id
                                 && asset_id.type_id != labeled_asset.handle.type_id()
                             {
-                                let error = AssetLoadError::RequestedHandleTypeMismatch {
-                                    path: path.clone(),
-                                    requested: asset_id.type_id,
-                                    actual_asset_name: labeled_asset.asset.value.asset_type_name(),
-                                    loader_name: loader.type_path(),
-                                };
+                                let error: AssetLoadError =
+                                    Box::new(RequestedHandleTypeMismatchError {
+                                        path: path.clone(),
+                                        requested: asset_id.type_id,
+                                        actual_asset_name: labeled_asset
+                                            .asset
+                                            .value
+                                            .asset_type_name(),
+                                        loader_name: loader.type_path(),
+                                    })
+                                    .into();
                                 self.send_asset_event(InternalAssetEvent::Failed {
                                     index: asset_id,
                                     error: error.clone(),
@@ -2349,6 +2355,20 @@ impl RecursiveDependencyLoadState {
     }
 }
 
+/// An error that occurs when the requested handle type doesn't match the actual loaded asset type.
+#[derive(Error, Debug, Clone)]
+#[error("Requested handle of type {requested:?} for asset '{path}' does not match actual asset type '{actual_asset_name}', which used loader '{loader_name}'")]
+pub struct RequestedHandleTypeMismatchError {
+    /// The path of the asset.
+    pub path: AssetPath<'static>,
+    /// The requested type id of handle.
+    pub requested: TypeId,
+    /// The actual loaded asset type name.
+    pub actual_asset_name: &'static str,
+    /// The loader name used to load the asset.
+    pub loader_name: &'static str,
+}
+
 /// An error that occurs during an [`Asset`] load.
 #[derive(Error, Debug, Clone)]
 #[expect(
@@ -2358,13 +2378,8 @@ impl RecursiveDependencyLoadState {
 pub enum AssetLoadError {
     #[error("Attempted to load an asset with an empty path \"{0}\"")]
     EmptyPath(AssetPath<'static>),
-    #[error("Requested handle of type {requested:?} for asset '{path}' does not match actual asset type '{actual_asset_name}', which used loader '{loader_name}'")]
-    RequestedHandleTypeMismatch {
-        path: AssetPath<'static>,
-        requested: TypeId,
-        actual_asset_name: &'static str,
-        loader_name: &'static str,
-    },
+    #[error(transparent)]
+    RequestedHandleTypeMismatch(#[from] Box<RequestedHandleTypeMismatchError>),
     #[error("Could not find an asset loader matching: Asset Type: {asset_type_id:?}; Path: {asset_path:?};")]
     MissingAssetLoader {
         asset_type_id: Option<TypeId>,

--- a/crates/bevy_gltf/src/loader/mod.rs
+++ b/crates/bevy_gltf/src/loader/mod.rs
@@ -116,10 +116,10 @@ pub enum GltfError {
     InvalidImageUri(String, ParseAssetPathError),
     /// Failed to read bytes from an asset path.
     #[error("failed to read bytes from an asset path: {0}")]
-    ReadAssetBytesError(#[from] Box<ReadAssetBytesError>),
+    ReadAssetBytesError(#[from] ReadAssetBytesError),
     /// Failed to load asset from an asset path.
     #[error("failed to load asset from an asset path: {0}")]
-    AssetLoadError(#[from] Box<AssetLoadError>),
+    AssetLoadError(#[from] AssetLoadError),
     /// Missing sampler for an animation.
     #[error("Missing sampler for animation {0}")]
     #[from(ignore)]
@@ -1944,10 +1944,7 @@ async fn load_buffers(
                             .path()
                             .resolve_embed_str(uri)
                             .map_err(|err| GltfError::InvalidBufferUri(uri.to_owned(), err))?;
-                        load_context
-                            .read_asset_bytes(buffer_path)
-                            .await
-                            .map_err(Box::new)?
+                        load_context.read_asset_bytes(buffer_path).await?
                     }
                 };
                 buffer_data.push(buffer_bytes);

--- a/crates/bevy_reflect/src/func/reflect_fn.rs
+++ b/crates/bevy_reflect/src/func/reflect_fn.rs
@@ -79,8 +79,8 @@ pub trait ReflectFn<'env, Marker>: ReflectFnMut<'env, Marker> {
 macro_rules! impl_reflect_fn {
     ($(($Arg:ident, $arg:ident)),*) => {
         // === (...) -> ReturnType === //
-        #[expect(clippy::allow_attributes, reason = "`Arg` is optional")]
-        #[allow(clippy::extra_unused_lifetimes, reason = "lifetime may be unused because `Arg` is optional")]
+        #[expect(clippy::allow_attributes, reason = "This lint is part of a macro, which may not always trigger the `extra_unused_lifetimes` lint")]
+        #[allow(clippy::extra_unused_lifetimes, reason = "lifetime `a` may be unused because `Arg` is optional")]
         impl<'env, $($Arg,)* ReturnType, Function> ReflectFn<'env, fn($($Arg),*) -> [ReturnType]> for Function
         where
             $($Arg: FromArg,)*

--- a/crates/bevy_reflect/src/func/reflect_fn.rs
+++ b/crates/bevy_reflect/src/func/reflect_fn.rs
@@ -79,6 +79,8 @@ pub trait ReflectFn<'env, Marker>: ReflectFnMut<'env, Marker> {
 macro_rules! impl_reflect_fn {
     ($(($Arg:ident, $arg:ident)),*) => {
         // === (...) -> ReturnType === //
+        #[expect(clippy::allow_attributes, reason = "`Arg` is optional")]
+        #[allow(clippy::extra_unused_lifetimes, reason = "lifetime may be unused because `Arg` is optional")]
         impl<'env, $($Arg,)* ReturnType, Function> ReflectFn<'env, fn($($Arg),*) -> [ReturnType]> for Function
         where
             $($Arg: FromArg,)*

--- a/crates/bevy_reflect/src/func/reflect_fn_mut.rs
+++ b/crates/bevy_reflect/src/func/reflect_fn_mut.rs
@@ -86,8 +86,8 @@ pub trait ReflectFnMut<'env, Marker> {
 macro_rules! impl_reflect_fn_mut {
     ($(($Arg:ident, $arg:ident)),*) => {
         // === (...) -> ReturnType === //
-        #[expect(clippy::allow_attributes, reason = "`Arg` is optional")]
-        #[allow(clippy::extra_unused_lifetimes, reason = "lifetime may be unused because `Arg` is optional")]
+        #[expect(clippy::allow_attributes, reason = "This lint is part of a macro, which may not always trigger the `extra_unused_lifetimes` lint")]
+        #[allow(clippy::extra_unused_lifetimes, reason = "lifetime `a` may be unused because `Arg` is optional")]
         impl<'env, $($Arg,)* ReturnType, Function> ReflectFnMut<'env, fn($($Arg),*) -> [ReturnType]> for Function
         where
             $($Arg: FromArg,)*

--- a/crates/bevy_reflect/src/func/reflect_fn_mut.rs
+++ b/crates/bevy_reflect/src/func/reflect_fn_mut.rs
@@ -86,6 +86,8 @@ pub trait ReflectFnMut<'env, Marker> {
 macro_rules! impl_reflect_fn_mut {
     ($(($Arg:ident, $arg:ident)),*) => {
         // === (...) -> ReturnType === //
+        #[expect(clippy::allow_attributes, reason = "`Arg` is optional")]
+        #[allow(clippy::extra_unused_lifetimes, reason = "lifetime may be unused because `Arg` is optional")]
         impl<'env, $($Arg,)* ReturnType, Function> ReflectFnMut<'env, fn($($Arg),*) -> [ReturnType]> for Function
         where
             $($Arg: FromArg,)*

--- a/crates/bevy_transform/src/systems.rs
+++ b/crates/bevy_transform/src/systems.rs
@@ -816,7 +816,7 @@ mod parallel {
 mod test {
     use alloc::{vec, vec::Vec};
     use bevy_app::prelude::*;
-    use bevy_ecs::{prelude::*, world::CommandQueue};
+    use bevy_ecs::world::CommandQueue;
     use bevy_math::{vec3, Vec3};
     use bevy_tasks::{ComputeTaskPool, TaskPool};
 

--- a/examples/stress_tests/many_components.rs
+++ b/examples/stress_tests/many_components.rs
@@ -185,7 +185,7 @@ fn main() {
     let num_components = std::env::args()
         .nth(2)
         .and_then(|string| string.parse::<u32>().ok())
-        .and_then(|n| if n >= 10 { Some(n) } else { None })
+        .filter(|&n| n >= 10)
         .unwrap_or_else(|| {
             println!(
                 "No valid number of components provided (>= 10), using default {DEFAULT_NUM_COMPONENTS}"


### PR DESCRIPTION
# Objective

#24206 boxes the large error in `GltfError` but it's not sufficient after https://github.com/rust-lang/rust-clippy/issues/17070 is fixed.

## Solution

Box `AssetLoadError::RequestedHandleTypeMismatch` so that it is reduced to 120 bytes which is below 128 bytes.

Also fix some other trivial clippy warnings.

## Testing

Use the latest nightly clippy which has https://github.com/rust-lang/rust-clippy/issues/17070 fixed:
```
cargo +nightly clippy --workspace --all-features --all-targets -- -D warnings
```
