### PR TITLE
Extract `sprite_material` functions, bindings, and types to separate shader modules

### DIFF
--- a/crates/bevy_sprite_render/src/sprite_mesh/mod.rs
+++ b/crates/bevy_sprite_render/src/sprite_mesh/mod.rs
@@ -13,6 +13,7 @@ use bevy_math::{primitives::Rectangle, vec2};
 use bevy_mesh::{Mesh, Mesh2d, MeshAttributeCompressionFlags, MeshBuilder, Meshable};
 
 use bevy_platform::collections::HashMap;
+use bevy_shader::load_shader_library;
 use bevy_sprite::{prelude::SpriteMesh, Anchor};
 
 mod sprite_material;
@@ -24,6 +25,10 @@ pub struct SpriteMeshPlugin;
 
 impl Plugin for SpriteMeshPlugin {
     fn build(&self, app: &mut bevy_app::App) {
+        load_shader_library!(app, "sprite_bindings.wgsl");
+        load_shader_library!(app, "sprite_functions.wgsl");
+        load_shader_library!(app, "sprite_types.wgsl");
+
         app.add_plugins(SpriteMaterialPlugin);
 
         app.add_systems(

--- a/crates/bevy_sprite_render/src/sprite_mesh/sprite_bindings.wgsl
+++ b/crates/bevy_sprite_render/src/sprite_mesh/sprite_bindings.wgsl
@@ -1,0 +1,7 @@
+#define_import_path bevy_sprite::sprite_bindings
+
+#import bevy_sprite::sprite_types::SpriteMaterial
+
+@group(#{MATERIAL_BIND_GROUP}) @binding(0) var<uniform> material: SpriteMaterial;
+@group(#{MATERIAL_BIND_GROUP}) @binding(1) var texture: texture_2d<f32>;
+@group(#{MATERIAL_BIND_GROUP}) @binding(2) var texture_sampler: sampler;

--- a/crates/bevy_sprite_render/src/sprite_mesh/sprite_functions.wgsl
+++ b/crates/bevy_sprite_render/src/sprite_mesh/sprite_functions.wgsl
@@ -55,7 +55,7 @@ fn apply_flip(uv: vec2<f32>) -> vec2<f32> {
     return out;
 }
 
-// Applies tiling to the UV based on the sprite's tiling propeties when `image_mode` is `Tiled`.
+// Applies tiling to the UV based on the sprite's tiling properties when `image_mode` is `Tiled`.
 fn apply_tiling(uv: vec2<f32>) -> vec2<f32> {
     var out = uv;
     if (material.flags & SPRITE_MATERIAL_FLAGS_TILE_X) != 0u {

--- a/crates/bevy_sprite_render/src/sprite_mesh/sprite_functions.wgsl
+++ b/crates/bevy_sprite_render/src/sprite_mesh/sprite_functions.wgsl
@@ -1,0 +1,206 @@
+#define_import_path bevy_sprite::sprite_functions
+
+#import bevy_sprite::{
+    sprite_types::{
+        SPRITE_MATERIAL_FLAGS_ALPHA_MODE_RESERVED_BITS,
+        SPRITE_MATERIAL_FLAGS_ALPHA_MODE_OPAQUE,
+        SPRITE_MATERIAL_FLAGS_ALPHA_MODE_MASK,
+        SPRITE_MATERIAL_FLAGS_FLIP_X,
+        SPRITE_MATERIAL_FLAGS_FLIP_Y,
+        SPRITE_MATERIAL_FLAGS_TILE_X,
+        SPRITE_MATERIAL_FLAGS_TILE_Y,
+    },
+    sprite_bindings::{material, texture, texture_sampler},
+}
+
+// Applies all the transformations to the UV and samples the sprite's final color.
+fn sample_final_color(uv: vec2<f32>) -> vec4<f32> {
+    let sprite_color = sample_sprite_texture(uv);
+    return get_final_color(sprite_color);
+}
+
+// Applies all the necessary transformations to the UV and samples the sprite's texture.
+fn sample_sprite_texture(uv: vec2<f32>) -> vec4<f32> {
+    let final_uv = get_final_uv(uv);
+    return textureSample(texture, texture_sampler, final_uv);
+}
+
+// Applies the tint and alpha discard on the sprite color.
+fn get_final_color(sprite_color: vec4<f32>) -> vec4<f32> {
+    var output_color = apply_tint(sprite_color);
+    output_color = alpha_discard(output_color);
+    return output_color;
+}
+
+// Applies all the necessary transformations to get the final UV that the texture should be sampled from.
+fn get_final_uv(uv: vec2<f32>) -> vec2<f32> {
+    var out = uv;
+    out = apply_flip(out);
+    out = apply_tiling(out);
+    out = apply_slicing(out);
+    out = apply_uv_transform(out);
+    return out;
+}
+
+// Flips the UV based on the sprite's flip X and Y properties.
+fn apply_flip(uv: vec2<f32>) -> vec2<f32> {
+    var out = uv;
+    if (material.flags & SPRITE_MATERIAL_FLAGS_FLIP_X) != 0u {
+        out.x = 1.0 - out.x;
+    }
+    if (material.flags & SPRITE_MATERIAL_FLAGS_FLIP_Y) != 0u {
+        out.y = 1.0 - out.y;
+    }
+
+    return out;
+}
+
+// Applies tiling to the UV based on the sprite's tiling propeties when `image_mode` is `Tiled`.
+fn apply_tiling(uv: vec2<f32>) -> vec2<f32> {
+    var out = uv;
+    if (material.flags & SPRITE_MATERIAL_FLAGS_TILE_X) != 0u {
+        out.x = (out.x - material.tile_stretch_value.x * floor(out.x / material.tile_stretch_value.x)) / material.tile_stretch_value.x;
+    }
+    if (material.flags & SPRITE_MATERIAL_FLAGS_TILE_Y) != 0u {
+        out.y = (out.y - material.tile_stretch_value.y * floor(out.y / material.tile_stretch_value.y)) / material.tile_stretch_value.y;
+    }
+
+    return out;
+}
+
+// Applies the sprite's UV transform,
+// which is used for sampling the correct region from a texture atlas
+// and scaling the sprite when `image_mode` is `Scaled`.
+fn apply_uv_transform(uv: vec2<f32>) -> vec2<f32> { 
+    return (material.uv_transform * vec3(uv, 1.0)).xy;
+}
+
+// Applies UV slicing based on the sprite's slicing properties when `image_mode` is `Sliced`.
+fn apply_slicing(uv: vec2<f32>) -> vec2<f32> {
+    // using this as a temp check for slicing
+    if material.scale.x == 0.0 {
+        return uv;
+    }
+
+    let min_inset_scaled = material.min_inset / material.scale;
+    let max_inset_scaled = material.max_inset / material.scale;
+
+    let left = uv.x < min_inset_scaled.x;
+    let right = uv.x > 1.0 - max_inset_scaled.x;
+    let top = uv.y < min_inset_scaled.y;
+    let bottom = uv.y > 1.0 - max_inset_scaled.y;
+
+    // top-left corner
+    if top && left {
+        return uv * material.scale;
+    }
+
+    // top-right corner
+    if top && right {
+        return vec2<f32>(
+            1.0 - (1.0 - uv.x) * material.scale.x,
+            uv.y * material.scale.y,
+        );
+    }
+
+    // bottom-left corner
+    if bottom && left {
+        return vec2<f32>(
+            uv.x * material.scale.x,
+            1.0 - (1.0 - uv.y) * material.scale.y
+        );
+    }
+
+    // bottom-right corner
+    if bottom && right {
+        return vec2<f32>(1.0) - (vec2<f32>(1.0) - uv) * material.scale;
+    }
+
+    // top edge
+    if top {
+        return vec2<f32>(
+            tile_or_stretch(uv.x, min_inset_scaled.x, 1.0 - max_inset_scaled.x, material.min_inset.x, 1.0 - material.max_inset.x, material.side_stretch_value.x),
+            uv.y * material.scale.y
+        );
+    }
+
+    // bottom edge
+    if bottom {
+        return vec2<f32>(
+            tile_or_stretch(uv.x, min_inset_scaled.x, 1.0 - max_inset_scaled.x, material.min_inset.x, 1.0 - material.max_inset.x, material.side_stretch_value.x),
+            1.0 - (1.0 - uv.y) * material.scale.y
+        );
+    }
+
+    // left edge
+    if left {
+        return vec2<f32>(
+            uv.x * material.scale.x,
+            tile_or_stretch(uv.y, min_inset_scaled.y, 1.0 - max_inset_scaled.y, material.min_inset.y, 1.0 - material.max_inset.y, material.side_stretch_value.y)
+        );
+    }
+
+    // right edge
+    if right {
+        return vec2<f32>(
+            1.0 - (1.0 - uv.x) * material.scale.x,
+            tile_or_stretch(uv.y, min_inset_scaled.y, 1.0 - max_inset_scaled.y, material.min_inset.y, 1.0 - material.max_inset.y, material.side_stretch_value.y)
+        );
+    }
+
+    // center
+    return vec2<f32>(
+        tile_or_stretch(uv.x, min_inset_scaled.x, 1.0 - max_inset_scaled.x, material.min_inset.x, 1.0 - material.max_inset.x, material.center_stretch_value.x),
+        tile_or_stretch(uv.y, min_inset_scaled.y, 1.0 - max_inset_scaled.y, material.min_inset.y, 1.0 - material.max_inset.y, material.center_stretch_value.y)
+    );
+}
+
+// Applies the tint from the sprite's `color` property.
+fn apply_tint(sprite_color: vec4<f32>) -> vec4<f32> {
+    return sprite_color * material.color;
+}
+
+// Discards fragments based on the sprite's `alpha_cutoff` and `alpha_mode`.
+fn alpha_discard(output_color: vec4<f32>) -> vec4<f32> {
+    var color = output_color;
+    let alpha_mode = material.flags & SPRITE_MATERIAL_FLAGS_ALPHA_MODE_RESERVED_BITS;
+
+    if alpha_mode == SPRITE_MATERIAL_FLAGS_ALPHA_MODE_OPAQUE {
+        // NOTE: If rendering as opaque, alpha should be ignored so set to 1.0
+        color.a = 1.0;
+    }
+
+#ifdef MAY_DISCARD
+    else if alpha_mode == SPRITE_MATERIAL_FLAGS_ALPHA_MODE_MASK {
+        if color.a >= material.alpha_cutoff {
+            // NOTE: If rendering as masked alpha and >= the cutoff, render as fully opaque
+            color.a = 1.0;
+        } else {
+            // NOTE: output_color.a < in.material.alpha_cutoff should not be rendered
+            discard;
+        }
+    }
+#endif // MAY_DISCARD
+
+    return color;
+}
+
+// Maps a point p from [a, b] to [c, d], tiling it if stretch_value is not 0.
+fn tile_or_stretch(p: f32, a: f32, b: f32, c: f32, d: f32, stretch_value: f32) -> f32 {
+    if stretch_value == 0.0 {
+        return stretch_interval(p, a, b, c, d);
+    }
+    return tile_interval(p, a, b, c, d, stretch_value);
+}
+
+// Takes a point p from an interval [a, b] and maps it to a portion of the tile [c, d]
+fn tile_interval(p: f32, a: f32, b: f32, c: f32, d: f32, stretch_value: f32) -> f32 {
+    let value = (p - a) / (b - a);
+    let tile_value = (value - stretch_value * floor(value / stretch_value)) / stretch_value;
+    return tile_value * (d - c) + c;
+}
+
+// Takes a point p from an interval [a, b] and translates it to the interval [c, d]
+fn stretch_interval(p: f32, a: f32, b: f32, c: f32, d: f32) -> f32 {
+    return (p - a) / (b - a) * (d - c) + c;
+}

--- a/crates/bevy_sprite_render/src/sprite_mesh/sprite_material.wgsl
+++ b/crates/bevy_sprite_render/src/sprite_mesh/sprite_material.wgsl
@@ -2,7 +2,9 @@
     mesh2d_functions as mesh_functions,
     mesh2d_vertex_output::VertexOutput,
     mesh2d_view_bindings::view,
-    mesh2d_vertex_input::{Vertex, decompress_vertex}
+    mesh2d_vertex_input::{Vertex, decompress_vertex},
+    sprite_bindings::material,
+    sprite_functions,
 }
 
 #ifdef TONEMAP_IN_SHADER
@@ -51,67 +53,11 @@ fn vertex(vertex: Vertex) -> VertexOutput {
     return out;
 }
 
-struct SpriteMaterial {
-    color: vec4<f32>,
-    flags: u32,
-    alpha_cutoff: f32,
-    vertex_scale: vec2<f32>,
-    vertex_offset: vec2<f32>,
-    uv_transform: mat3x3<f32>,
-
-    tile_stretch_value: vec2<f32>,
-
-    scale: vec2<f32>,
-    min_inset: vec2<f32>,
-    max_inset: vec2<f32>,
-    side_stretch_value: vec2<f32>,
-    center_stretch_value: vec2<f32>,
-};
-
-const SPRITE_MATERIAL_FLAGS_ALPHA_MODE_RESERVED_BITS: u32 = 3221225472u; // (0b11u32 << 30)
-const SPRITE_MATERIAL_FLAGS_ALPHA_MODE_OPAQUE: u32        = 0u;          // (0u32 << 30)
-const SPRITE_MATERIAL_FLAGS_ALPHA_MODE_MASK: u32          = 1073741824u; // (1u32 << 30)
-const SPRITE_MATERIAL_FLAGS_ALPHA_MODE_BLEND: u32         = 2147483648u; // (2u32 << 30)
-
-const SPRITE_MATERIAL_FLAGS_FLIP_X: u32                   = 1u;
-const SPRITE_MATERIAL_FLAGS_FLIP_Y: u32                   = 2u;
-const SPRITE_MATERIAL_FLAGS_TILE_X: u32                   = 4u;
-const SPRITE_MATERIAL_FLAGS_TILE_Y: u32                   = 8u;
-
-@group(#{MATERIAL_BIND_GROUP}) @binding(0) var<uniform> material: SpriteMaterial;
-@group(#{MATERIAL_BIND_GROUP}) @binding(1) var texture: texture_2d<f32>;
-@group(#{MATERIAL_BIND_GROUP}) @binding(2) var texture_sampler: sampler;
-
 @fragment
 fn fragment(
     mesh: VertexOutput,
 ) -> @location(0) vec4<f32> {
-
-    var uv = mesh.uv;
-
-    if (material.flags & SPRITE_MATERIAL_FLAGS_FLIP_X) != 0u {
-        uv.x = 1.0 - uv.x;
-    }
-    if (material.flags & SPRITE_MATERIAL_FLAGS_FLIP_Y) != 0u {
-        uv.y = 1.0 - uv.y;
-    }
-
-    if (material.flags & SPRITE_MATERIAL_FLAGS_TILE_X) != 0u {
-        uv.x = (uv.x - material.tile_stretch_value.x * floor(uv.x / material.tile_stretch_value.x)) / material.tile_stretch_value.x;
-    }
-    if (material.flags & SPRITE_MATERIAL_FLAGS_TILE_Y) != 0u {
-        uv.y = (uv.y - material.tile_stretch_value.y * floor(uv.y / material.tile_stretch_value.y)) / material.tile_stretch_value.y;
-    }
-
-    // using this as a temp check for slicing
-    if material.scale.x != 0.0 {
-        uv = apply_slicing(uv);
-    }
-
-    uv = (material.uv_transform * vec3(uv, 1.0)).xy;
-
-    let sprite_color = textureSample(texture, texture_sampler, uv);
-    var output_color = alpha_discard(sprite_color * material.color);
+    var output_color = sprite_functions::sample_final_color(mesh.uv);
 
 #ifdef TONEMAP_IN_SHADER
     output_color = tonemapping::tone_mapping(output_color, view.color_grading);
@@ -126,122 +72,4 @@ fn fragment(
 #endif
 
     return output_color;
-}
-
-fn apply_slicing(uv: vec2<f32>) -> vec2<f32> {
-    let min_inset_scaled = material.min_inset / material.scale;
-    let max_inset_scaled = material.max_inset / material.scale;
-
-    let left = uv.x < min_inset_scaled.x;
-    let right = uv.x > 1.0 - max_inset_scaled.x;
-    let top = uv.y < min_inset_scaled.y;
-    let bottom = uv.y > 1.0 - max_inset_scaled.y;
-
-    // top-left corner
-    if top && left {
-        return uv * material.scale;
-    }
-
-    // top-right corner
-    if top && right {
-        return vec2<f32>(
-            1.0 - (1.0 - uv.x) * material.scale.x,
-            uv.y * material.scale.y,
-        );
-    }
-
-    // bottom-left corner
-    if bottom && left {
-        return vec2<f32>(
-            uv.x * material.scale.x,
-            1.0 - (1.0 - uv.y) * material.scale.y
-        );
-    }
-
-    // bottom-right corner
-    if bottom && right {
-        return vec2<f32>(1.0) - (vec2<f32>(1.0) - uv) * material.scale;
-    }
-
-    // top edge
-    if top {
-        return vec2<f32>(
-            tile_or_stretch(uv.x, min_inset_scaled.x, 1.0 - max_inset_scaled.x, material.min_inset.x, 1.0 - material.max_inset.x, material.side_stretch_value.x),
-            uv.y * material.scale.y
-        );
-    }
-
-    // bottom edge
-    if bottom {
-        return vec2<f32>(
-            tile_or_stretch(uv.x, min_inset_scaled.x, 1.0 - max_inset_scaled.x, material.min_inset.x, 1.0 - material.max_inset.x, material.side_stretch_value.x),
-            1.0 - (1.0 - uv.y) * material.scale.y
-        );
-    }
-
-    // left edge
-    if left {
-        return vec2<f32>(
-            uv.x * material.scale.x,
-            tile_or_stretch(uv.y, min_inset_scaled.y, 1.0 - max_inset_scaled.y, material.min_inset.y, 1.0 - material.max_inset.y, material.side_stretch_value.y)
-        );
-    }
-
-    // right edge
-    if right {
-        return vec2<f32>(
-            1.0 - (1.0 - uv.x) * material.scale.x,
-            tile_or_stretch(uv.y, min_inset_scaled.y, 1.0 - max_inset_scaled.y, material.min_inset.y, 1.0 - material.max_inset.y, material.side_stretch_value.y)
-        );
-    }
-
-    // center
-    return vec2<f32>(
-        tile_or_stretch(uv.x, min_inset_scaled.x, 1.0 - max_inset_scaled.x, material.min_inset.x, 1.0 - material.max_inset.x, material.center_stretch_value.x),
-        tile_or_stretch(uv.y, min_inset_scaled.y, 1.0 - max_inset_scaled.y, material.min_inset.y, 1.0 - material.max_inset.y, material.center_stretch_value.y)
-    );
-}
-
-// Maps a point p from [a, b] to [c, d], tiling it if stretch_value is not 0.
-fn tile_or_stretch(p: f32, a: f32, b: f32, c: f32, d: f32, stretch_value: f32) -> f32 {
-    if stretch_value == 0.0 {
-        return stretch_interval(p, a, b, c, d);
-    }
-    return tile_interval(p, a, b, c, d, stretch_value);
-}
-
-// Takes a point p from an interval [a, b] and maps it to a portion of the tile [c, d]
-fn tile_interval(p: f32, a: f32, b: f32, c: f32, d: f32, stretch_value: f32) -> f32 {
-    let value = (p - a) / (b - a);
-    let tile_value = (value - stretch_value * floor(value / stretch_value)) / stretch_value;
-    return tile_value * (d - c) + c;
-}
-
-// Takes a point p from an interval [a, b] and translates it to the interval [c, d]
-fn stretch_interval(p: f32, a: f32, b: f32, c: f32, d: f32) -> f32 {
-    return (p - a) / (b - a) * (d - c) + c;
-}
-
-fn alpha_discard(output_color: vec4<f32>) -> vec4<f32> {
-    var color = output_color;
-    let alpha_mode = material.flags & SPRITE_MATERIAL_FLAGS_ALPHA_MODE_RESERVED_BITS;
-
-    if alpha_mode == SPRITE_MATERIAL_FLAGS_ALPHA_MODE_OPAQUE {
-        // NOTE: If rendering as opaque, alpha should be ignored so set to 1.0
-        color.a = 1.0;
-    }
-
-#ifdef MAY_DISCARD
-    else if alpha_mode == SPRITE_MATERIAL_FLAGS_ALPHA_MODE_MASK {
-    if color.a >= material.alpha_cutoff {
-            // NOTE: If rendering as masked alpha and >= the cutoff, render as fully opaque
-            color.a = 1.0;
-        } else {
-            // NOTE: output_color.a < in.material.alpha_cutoff should not be rendered
-            discard;
-        }
-    }
-#endif // MAY_DISCARD
-
-    return color;
 }

--- a/crates/bevy_sprite_render/src/sprite_mesh/sprite_types.wgsl
+++ b/crates/bevy_sprite_render/src/sprite_mesh/sprite_types.wgsl
@@ -1,0 +1,28 @@
+#define_import_path bevy_sprite::sprite_types
+
+struct SpriteMaterial {
+    color: vec4<f32>,
+    flags: u32,
+    alpha_cutoff: f32,
+    vertex_scale: vec2<f32>,
+    vertex_offset: vec2<f32>,
+    uv_transform: mat3x3<f32>,
+
+    tile_stretch_value: vec2<f32>,
+
+    scale: vec2<f32>,
+    min_inset: vec2<f32>,
+    max_inset: vec2<f32>,
+    side_stretch_value: vec2<f32>,
+    center_stretch_value: vec2<f32>,
+};
+
+const SPRITE_MATERIAL_FLAGS_ALPHA_MODE_RESERVED_BITS: u32 = 3221225472u; // (0b11u32 << 30)
+const SPRITE_MATERIAL_FLAGS_ALPHA_MODE_OPAQUE: u32        = 0u;          // (0u32 << 30)
+const SPRITE_MATERIAL_FLAGS_ALPHA_MODE_MASK: u32          = 1073741824u; // (1u32 << 30)
+const SPRITE_MATERIAL_FLAGS_ALPHA_MODE_BLEND: u32         = 2147483648u; // (2u32 << 30)
+
+const SPRITE_MATERIAL_FLAGS_FLIP_X: u32                   = 1u;
+const SPRITE_MATERIAL_FLAGS_FLIP_Y: u32                   = 2u;
+const SPRITE_MATERIAL_FLAGS_TILE_X: u32                   = 4u;
+const SPRITE_MATERIAL_FLAGS_TILE_Y: u32                   = 8u;


### PR DESCRIPTION
# Objective

Make it easier to make sprite shaders by extracting the functions, bindings, and types from the `SpriteMesh`'s  `sprite_material.wgsl` shader to exported modules

## Solution

Move the `SpriteMaterial` type and flags from `sprite_material.wgsl` to the `bevy_sprite::sprite_types` module

Move the sprite material bindings to the `bevy_sprite::sprite_bindings` module

Move the uv flipping, tiling, transforming, and slicing logic along with some utility functions to the `bevy_sprite::sprite_functions` module

## Testing

Ran the `sprite_*` examples using `SpriteMesh` and manually verified that the shaders compiled and the behaviour matched