### PR TITLE
`bevy::math::Rect::clamp_point` function

### DIFF
--- a/crates/bevy_math/src/rects/rect.rs
+++ b/crates/bevy_math/src/rects/rect.rs
@@ -253,6 +253,20 @@ impl Rect {
             && point.y <= self.max.y
     }
 
+    /// Clamps a point to lie within this rectangle.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bevy_math::{Rect, Vec2};
+    /// let r = Rect::new(0., 0., 4., 5.);
+    /// assert_eq!(r.clamp_point(Vec2::new(-1., 6.)), Vec2::new(0., 5.));
+    /// assert_eq!(r.clamp_point(Vec2::ONE), Vec2::ONE);
+    #[inline]
+    pub fn clamp_point(&self, point: Vec2) -> Vec2 {
+        point.clamp(self.min, self.max)
+    }
+
     /// Build a new rectangle formed of the union of this rectangle and another rectangle.
     ///
     /// The union is the smallest rectangle enclosing both rectangles.
@@ -563,5 +577,13 @@ mod tests {
         assert!(r2.min.abs_diff_eq(Vec2::new(2., -4.), 1e-5));
         assert!(r2.max.abs_diff_eq(Vec2::new(6., -2.), 1e-5));
         assert!(r2.size().abs_diff_eq(r.size(), 1e-5));
+    }
+
+    #[test]
+    fn rect_clamp_point() {
+        let r = Rect::new(0., 1., 4., 3.);
+
+        assert_eq!(r.clamp_point(Vec2::new(2., 2.)), Vec2::new(2., 2.));
+        assert_eq!(r.clamp_point(Vec2::new(-1., 5.)), Vec2::new(0., 3.));
     }
 }

--- a/crates/bevy_math/src/rects/rect.rs
+++ b/crates/bevy_math/src/rects/rect.rs
@@ -262,6 +262,7 @@ impl Rect {
     /// let r = Rect::new(0., 0., 4., 5.);
     /// assert_eq!(r.clamp_point(Vec2::new(-1., 6.)), Vec2::new(0., 5.));
     /// assert_eq!(r.clamp_point(Vec2::ONE), Vec2::ONE);
+    /// ```
     #[inline]
     pub fn clamp_point(&self, point: Vec2) -> Vec2 {
         point.clamp(self.min, self.max)


### PR DESCRIPTION
# Objective

`Vec2` has a clamp function but there are two minor annoyances when using it with a `Rect`:

```rust
let r = computed_node.content_box();
let p = Vec2::new(x, y).clamp(r.min, r.max);
```

1. You have to bind the `Rect` value to a variable.
2. You have to manually pass the rectangle bounds in the correct order.

## Solution

Add a `clamp_point` function to `Rect`, then we have:

```rust
let p = computed_node.content_box().clamp_point(Vec2::new(x, y));
```

## Testing

Includes some trivial tests.