### PR TITLE
Entitymut doc changes for #24596

### DIFF
--- a/crates/bevy_ecs/src/world/entity_access/entity_mut.rs
+++ b/crates/bevy_ecs/src/world/entity_access/entity_mut.rs
@@ -176,7 +176,7 @@ impl<'w> EntityMut<'w> {
     }
 
     /// Returns read-only components for the current entity that match the query `Q`,
-    /// or `None` if the entity does not have the components required by the query `Q`.
+    /// or [`QueryAccessError`] if the entity does not have the components required by the query `Q`.
     pub fn get_components<Q: ReadOnlyQueryData + ReleaseStateQueryData + SingleEntityQueryData>(
         &self,
     ) -> Result<Q::Item<'_, 'static>, QueryAccessError> {
@@ -184,7 +184,7 @@ impl<'w> EntityMut<'w> {
     }
 
     /// Returns components for the current entity that match the query `Q`,
-    /// or `None` if the entity does not have the components required by the query `Q`.
+    /// or [`QueryAccessError`] if the entity does not have the components required by the query `Q`.
     ///
     /// # Example
     ///
@@ -252,7 +252,7 @@ impl<'w> EntityMut<'w> {
     }
 
     /// Consumes self and returns components for the current entity that match the query `Q` for the world lifetime `'w`,
-    /// or `None` if the entity does not have the components required by the query `Q`.
+    /// or [`QueryAccessError`] if the entity does not have the components required by the query `Q`.
     ///
     /// # Example
     ///
@@ -295,7 +295,7 @@ impl<'w> EntityMut<'w> {
     }
 
     /// Consumes self and returns components for the current entity that match the query `Q` for the world lifetime `'w`,
-    /// or `None` if the entity does not have the components required by the query `Q`.
+    /// or [`QueryAccessError`] if the entity does not have the components required by the query `Q`.
     ///
     /// The checks for aliasing mutable references may be expensive.
     /// If performance is a concern, consider making multiple calls to [`Self::get_mut`].

--- a/crates/bevy_ecs/src/world/entity_access/entity_mut.rs
+++ b/crates/bevy_ecs/src/world/entity_access/entity_mut.rs
@@ -186,6 +186,10 @@ impl<'w> EntityMut<'w> {
     /// Returns components for the current entity that match the query `Q`,
     /// or [`QueryAccessError`] if the entity does not have the components required by the query `Q`.
     ///
+    /// # Safety
+    /// It is the caller's responsibility to ensure that
+    /// the `QueryData` does not provide aliasing mutable references to the same component.
+    ///
     /// # Example
     ///
     /// ```
@@ -207,10 +211,6 @@ impl<'w> EntityMut<'w> {
     /// // This would trigger undefined behavior, as the `&mut X`s would alias:
     /// // entity.get_components_mut_unchecked::<(&mut X, &mut X)>();
     /// ```
-    ///
-    /// # Safety
-    /// It is the caller's responsibility to ensure that
-    /// the `QueryData` does not provide aliasing mutable references to the same component.
     ///
     /// # See also
     ///
@@ -254,6 +254,10 @@ impl<'w> EntityMut<'w> {
     /// Consumes self and returns components for the current entity that match the query `Q` for the world lifetime `'w`,
     /// or [`QueryAccessError`] if the entity does not have the components required by the query `Q`.
     ///
+    /// # Safety
+    /// It is the caller's responsibility to ensure that
+    /// the `QueryData` does not provide aliasing mutable references to the same component.
+    ///
     /// # Example
     ///
     /// ```
@@ -275,10 +279,6 @@ impl<'w> EntityMut<'w> {
     /// // This would trigger undefined behavior, as the `&mut X`s would alias:
     /// // entity.into_components_mut_unchecked::<(&mut X, &mut X)>();
     /// ```
-    ///
-    /// # Safety
-    /// It is the caller's responsibility to ensure that
-    /// the `QueryData` does not provide aliasing mutable references to the same component.
     ///
     /// # See also
     ///


### PR DESCRIPTION
# Objective

- Describe the objective or issue this PR addresses.
- Fixes #24596 

## Solution

- Describe the solution used to achieve the objective above.
- Changed get_components methods that use result instead of option to return the correct type instead of None.
- Moved safety above example for get/into_components_mut 

## Testing

- Did you test these changes? If so, how? Yes, ran "cargo run -p ci -- doc" and tests came back ok
- Are there any parts that need more testing? Not that I'm aware of.
- How can other people (reviewers) test your changes? Is there anything specific they need to know? Read the comments and check they are correct. there shouldn't be a fn returning type result that returns None on the fail.
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test? N/A

---

