### PR TITLE
Optionally allow `FeathersColorSwatch` to partially display opaque value

### DIFF
--- a/crates/bevy_feathers/src/controls/color_swatch.rs
+++ b/crates/bevy_feathers/src/controls/color_swatch.rs
@@ -12,7 +12,7 @@ use bevy_ecs::{
 };
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_scene::prelude::*;
-use bevy_ui::{px, BackgroundColor, BorderRadius, Node, PositionType};
+use bevy_ui::{percent, px, BackgroundColor, BorderRadius, Node, PositionType, ZIndex};
 use bevy_ui_render::ui_material::MaterialNode;
 
 use crate::{
@@ -23,10 +23,20 @@ use crate::{
 
 /// A color swatch widget.
 ///
-/// This is spawnable by inheriting it as a "scene component".
+/// This is spawnable by inheriting it as a "scene component" with optional
+/// [`FeathersColorSwatchProps`].
 #[derive(SceneComponent, Default, Clone, Reflect)]
 #[reflect(Component, Clone, Default)]
+#[scene(FeathersColorSwatchProps)]
 pub struct FeathersColorSwatch;
+
+/// Props used to construct a [`FeathersColorSwatch`] scene.
+#[derive(Default)]
+pub struct FeathersColorSwatchProps {
+    /// Set a percentage of the swatch to display the opaque version of the
+    /// current color.
+    pub opaque_color_percentage: f32,
+}
 
 /// Component that contains the value of the color swatch. This is copied to the child element
 /// background.
@@ -42,7 +52,23 @@ pub struct ColorSwatchValue(pub Color);
 pub struct ColorSwatchFg;
 
 impl FeathersColorSwatch {
-    fn scene() -> impl Scene {
+    fn scene(props: FeathersColorSwatchProps) -> impl Scene {
+        let non_alpha_fg = (props.opaque_color_percentage > 0.0).then(|| {
+            bsn! {
+                Node {
+                    position_type: PositionType::Absolute,
+                    left: percent(100.0 - props.opaque_color_percentage.clamp(0.0, 100.0)),
+                    top: px(0),
+                    bottom: px(0),
+                    right: px(0),
+                    border_radius: BorderRadius::right(px(5)),
+                }
+                ColorSwatchFg
+                BackgroundColor({palette::ACCENT})
+                ZIndex(1)
+            }
+        });
+
         bsn! {
             Node {
                 height: size::ROW_HEIGHT,
@@ -53,18 +79,21 @@ impl FeathersColorSwatch {
             ColorSwatchValue
             AlphaPattern
             MaterialNode::<AlphaPatternMaterial>
-            Children [(
-                Node {
-                    position_type: PositionType::Absolute,
-                    left: px(0),
-                    top: px(0),
-                    bottom: px(0),
-                    right: px(0),
-                    border_radius: px(5),
-                }
-                ColorSwatchFg
-                BackgroundColor({palette::ACCENT.with_alpha(0.5)})
-            )]
+            Children [
+                (
+                    Node {
+                        position_type: PositionType::Absolute,
+                        left: px(0),
+                        top: px(0),
+                        bottom: px(0),
+                        right: px(0),
+                        border_radius: px(5),
+                    }
+                    ColorSwatchFg
+                    BackgroundColor({palette::ACCENT.with_alpha(0.5)})
+                ),
+                non_alpha_fg
+            ]
         }
     }
 }
@@ -112,6 +141,12 @@ fn update_swatch_color(
             commands
                 .entity(*first_child)
                 .insert(BackgroundColor(value.0));
+        }
+
+        if let Some(second_child) = children.get(1) {
+            commands
+                .entity(*second_child)
+                .insert(BackgroundColor(value.0.with_alpha(1.0)));
         }
     }
 }

--- a/examples/ui/widgets/feathers_gallery.rs
+++ b/examples/ui/widgets/feathers_gallery.rs
@@ -462,7 +462,9 @@ fn demo_column_1() -> impl Scene {
                             )
                         ]
                     )
-                    (@FeathersColorSwatch SwatchType::Rgb),
+                    (@FeathersColorSwatch {
+                        @opaque_color_percentage: 30.0,
+                    } SwatchType::Rgb),
                 ]
             ),
             (


### PR DESCRIPTION
This adds properties to the `FeathersColorSwatch` SceneComponent to allow specifying a percentage of the swatch to remain opaque. This is useful for color-pickers and generally handling colors with alpha channels.

The property value will default to 0% so no migration guide is needed.

# Objective

- Allow a single `FeathersColorSwatch` to display the selected color with and without its alpha channel.

## Solution

- Adds `FeathersColorSwatchProps` to allow dedicating a percentage of the swatch area to the opaque color value

## Testing

Updated the `feathers_gallery` example to display the `rgba` color swatch with 30% dedicated to the opaque color.

---

## Showcase

<img width="1280" height="720" alt="Screenshot_2026-06-15_21-09-53" src="https://github.com/user-attachments/assets/1b3405f5-973b-42fb-abd5-b08c39c59cb6" />

