### PR TITLE
Update variadics_please requirement from 1.1 to 2.0

### DIFF
--- a/crates/bevy_app/Cargo.toml
+++ b/crates/bevy_app/Cargo.toml
@@ -91,7 +91,7 @@ bevy_platform = { path = "../bevy_platform", version = "0.19.0-dev", default-fea
 # other
 downcast-rs = { version = "2", default-features = false }
 thiserror = { version = "2", default-features = false }
-variadics_please = "1.1"
+variadics_please = "2.0"
 tracing = { version = "0.1", default-features = false, optional = true }
 log = { version = "0.4", default-features = false }
 dioxus-devtools = { version = "0.7.0-alpha.1", optional = true }

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -120,7 +120,7 @@ smallvec = { version = "1", default-features = false, features = [
   "const_generics",
 ] }
 indexmap = { version = "2.5.0", default-features = false }
-variadics_please = { version = "1.1", default-features = false }
+variadics_please = { version = "2.0", default-features = false }
 tracing = { version = "0.1", default-features = false, optional = true }
 log = { version = "0.4", default-features = false }
 bumpalo = "3"

--- a/crates/bevy_material/Cargo.toml
+++ b/crates/bevy_material/Cargo.toml
@@ -24,7 +24,7 @@ encase = "0.12"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 thiserror = { version = "2", default-features = false }
 wgpu-types = { version = "29.0.3", default-features = false }
-variadics_please = "1.1"
+variadics_please = "2.0"
 smallvec = { version = "1", default-features = false }
 
 [lints]

--- a/crates/bevy_math/Cargo.toml
+++ b/crates/bevy_math/Cargo.toml
@@ -28,7 +28,7 @@ arrayvec = { version = "0.7", default-features = false }
 bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev", default-features = false, features = [
   "glam",
 ], optional = true }
-variadics_please = "1.1"
+variadics_please = "2.0"
 
 [dev-dependencies]
 approx = "0.5"

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -128,7 +128,7 @@ uuid = { version = "1.21.0", default-features = false, optional = true, features
   "v4",
   "serde",
 ] }
-variadics_please = "1.1"
+variadics_please = "2.0"
 wgpu-types = { version = "29.0.3", features = [
   "serde",
 ], optional = true, default-features = false }

--- a/crates/bevy_reflect/derive/src/type_path.rs
+++ b/crates/bevy_reflect/derive/src/type_path.rs
@@ -70,7 +70,7 @@ impl CustomPathDef {
 pub(crate) enum NamedTypePathDef {
     External {
         path: Path,
-        generics: Generics,
+        generics: Box<Generics>,
         custom_path: Option<CustomPathDef>,
     },
     Primitive(Ident),
@@ -94,7 +94,7 @@ impl Parse for NamedTypePathDef {
         } else {
             Ok(NamedTypePathDef::External {
                 path,
-                generics,
+                generics: Box::new(generics),
                 custom_path,
             })
         }

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -122,7 +122,7 @@ async-channel = "2.3.0"
 nonmax = "0.5"
 smallvec = { version = "1", default-features = false, features = ["const_new"] }
 offset-allocator = "0.2"
-variadics_please = "1.1"
+variadics_please = "2.0"
 tracy-client = { version = "0.18.3", optional = true }
 indexmap = { version = "2" }
 bitflags = "2"

--- a/crates/bevy_render/macros/src/specializer.rs
+++ b/crates/bevy_render/macros/src/specializer.rs
@@ -44,7 +44,7 @@ enum Key {
     Whole,
     Default,
     Index(Index),
-    Custom(Expr),
+    Custom(Box<Expr>),
 }
 
 impl Key {
@@ -56,7 +56,7 @@ impl Key {
                 let member = Member::Unnamed(index.clone());
                 parse_quote!(key.#member)
             }
-            Key::Custom(expr) => expr.clone(),
+            Key::Custom(expr) => *expr.clone(),
         }
     }
 }
@@ -72,10 +72,14 @@ impl Parse for Key {
                 Err(syn::Error::new_spanned(ident, KEY_ERROR_MSG))
             }
         } else {
-            input.parse::<Expr>().map(Key::Custom).map_err(|mut err| {
-                err.extend(syn::Error::new(err.span(), KEY_ERROR_MSG));
-                err
-            })
+            input
+                .parse::<Expr>()
+                .map(Box::new)
+                .map(Key::Custom)
+                .map_err(|mut err| {
+                    err.extend(syn::Error::new(err.span(), KEY_ERROR_MSG));
+                    err
+                })
         }
     }
 }

--- a/crates/bevy_scene/Cargo.toml
+++ b/crates/bevy_scene/Cargo.toml
@@ -22,7 +22,7 @@ bevy_utils = { path = "../bevy_utils", version = "0.19.0-dev" }
 
 thiserror = { version = "2", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
-variadics_please = "1.0"
+variadics_please = "2.0"
 
 [lints]
 workspace = true

--- a/crates/bevy_state/Cargo.toml
+++ b/crates/bevy_state/Cargo.toml
@@ -52,7 +52,7 @@ bevy_utils = { path = "../bevy_utils", version = "0.19.0-dev", default-features 
 bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev", default-features = false, optional = true }
 bevy_app = { path = "../bevy_app", version = "0.19.0-dev", default-features = false, optional = true }
 bevy_platform = { path = "../bevy_platform", version = "0.19.0-dev", default-features = false }
-variadics_please = "1.1"
+variadics_please = "2.0"
 
 # other
 log = { version = "0.4", default-features = false }


### PR DESCRIPTION
# Objective

- Adopts #24304 

## Solution

- Upgrading caused some `large_enum_variant` warnings. I box’ed the affected variants.
- From the original Dependabot PR:
 
Updates the requirements on [variadics_please](https://github.com/bevyengine/variadics_please) to permit the latest version.
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/bevyengine/variadics_please/blob/main/RELEASES.md">variadics_please's changelog</a>.</em></p>
<blockquote>
<h2>Version 2.0.0</h2>
<ul>
<li>Switch from <code>syn</code> to <code>unsynn</code>
<ul>
<li><a href="https://fasterthanli.me/articles/the-virtue-of-unsynn"><code>syn</code> is known to be a major compile time bottleneck</a>. To improve the situation for users of <code>variadics_please</code>, we switched to <code>unsynn</code>, which is the alternative used by <a href="https://fasterthanli.me/articles/introducing-facet-reflection-for-rust"><code>facet</code></a>.</li>
<li>The compile time speedup depends on your local setup and the complexity of the macro invocation,
but on one test setup, the cold compilation time went from about 2.16 seconds to 0.56 seconds.</li>
<li>The code generated by <code>variadics_please</code> should be identical to before.
Our Error messages may look a bit different now, but they should be just as readable.
If you encounter any weird behavior or diagnostics, let us know.</li>
</ul>
</li>
<li>Use Rust 2024, which bumps the MSRV to <code>1.85.0</code></li>
</ul>
<h2>Version 1.1</h2>
<ul>
<li>added <code>all_tuples_enumerated</code>, which provides the index of each item in the tuple</li>
</ul>
<h2>Version 1.0.0</h2>
<ul>
<li>initial release
<ul>
<li>code was taken directly from <code>bevy_utils 0.15-rc2</code>, under a MIT + Apache dual license</li>
</ul>
</li>
</ul>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li>See full diff in <a href="https://github.com/bevyengine/variadics_please/commits">compare view</a></li>
</ul>
</details>
<br /> 

I’m assuming the changelog doesn’t look concerning

## Testing

- ci