### PR TITLE
give immutable access to `SystemWithAccess::system`

### DIFF
--- a/crates/bevy_ecs/src/schedule/node.rs
+++ b/crates/bevy_ecs/src/schedule/node.rs
@@ -50,6 +50,11 @@ impl SystemWithAccess {
             access: FilteredAccessSet::new(),
         }
     }
+
+    /// Returns the underlying [`ScheduleSystem`]
+    pub fn system(&self) -> &ScheduleSystem {
+        &self.system
+    }
 }
 
 impl System for SystemWithAccess {


### PR DESCRIPTION
 This change adds a `SystemWithAccess::system` method to give back access to the ScheduleSystem without exposing it to mutation.

# Objective

To prevent mutation, [this PR][thePR] made all fields of `SystemWithAccess` private.

However, external crates (in my case, `bevy_mod_debugdump`) need access to `&ScheduleSystem`, which the PR made impossible.

## Solution

Add `SystemWithAccess::system` to allow accessing the contained `ScheduleSystem` immutably

## Testing

- Did you test these changes? If so, how?
No
- Are there any parts that need more testing?
No
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
N/A
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?'
N/A

[thePR]: https://github.com/bevyengine/bevy/pull/23443
