### PR TITLE
Increase build workflow timeout to 40 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:


### PR DESCRIPTION
# Objective

- [The Windows runner has been timing out building and testing Bevy in CI](https://github.com/bevyengine/bevy/actions/runs/27773562913/job/82179726455)

## Solution

- Increase the timeout from 30 to 40 minutes

## Alternative

Ideally we could use reduce compilation / testing time instead of increasing the timeout, but I'm not sure how that would be achieved.

cc @mockersf