### PR TITLE
Fix PanCamera mouse button check

### DIFF
--- a/crates/bevy_camera_controller/src/pan_camera.rs
+++ b/crates/bevy_camera_controller/src/pan_camera.rs
@@ -9,10 +9,10 @@ use bevy_app::{App, Plugin, RunFixedMainLoop, RunFixedMainLoopSystems};
 use bevy_camera::{Camera, RenderTarget};
 use bevy_ecs::prelude::*;
 use bevy_input::keyboard::KeyCode;
-use bevy_input::mouse::{AccumulatedMouseScroll, MouseButton, MouseScrollPixelsPerLine};
+use bevy_input::mouse::{AccumulatedMouseScroll, MouseScrollPixelsPerLine};
 use bevy_input::ButtonInput;
 use bevy_math::{Vec2, Vec3};
-use bevy_picking::events::{Drag, DragEnd, DragStart, Pointer};
+use bevy_picking::{pointer::PointerButton, events::{Drag, DragEnd, DragStart, Pointer}};
 use bevy_time::{Real, Time};
 use bevy_transform::components::GlobalTransform;
 use bevy_transform::prelude::Transform;
@@ -121,7 +121,7 @@ impl Default for PanCamera {
             key_rotate_cw: Some(KeyCode::KeyE),
             mouse_pan_settings: MousePanSettings {
                 enabled: true,
-                button: MouseButton::Left,
+                button: PointerButton::Middle,
             },
         }
     }
@@ -311,7 +311,7 @@ fn handle_mouse_pan(
     mut pan_cameras: Query<(&Camera, &GlobalTransform, &mut Transform, &PanCamera)>,
 ) {
     for (camera, global_transform, mut transform, pan_camera_controller) in pan_cameras.iter_mut() {
-        if !pan_camera_controller.enabled || !pan_camera_controller.mouse_pan_settings.enabled {
+        if !pan_camera_controller.enabled || !pan_camera_controller.mouse_pan_settings.enabled || drag.button != pan_camera_controller.mouse_pan_settings.button{
             return;
         }
 

--- a/crates/bevy_camera_controller/src/pan_camera.rs
+++ b/crates/bevy_camera_controller/src/pan_camera.rs
@@ -81,7 +81,7 @@ pub struct MousePanSettings {
     /// Whether the mouse panning is enabled.
     pub enabled: bool,
     /// The mouse button to use for panning.
-    pub button: MouseButton,
+    pub button: PointerButton,
 }
 
 /// Provides the default values for the `PanCamera` controller.

--- a/crates/bevy_camera_controller/src/pan_camera.rs
+++ b/crates/bevy_camera_controller/src/pan_camera.rs
@@ -124,7 +124,7 @@ impl Default for PanCamera {
             key_rotate_cw: Some(KeyCode::KeyE),
             mouse_pan_settings: MousePanSettings {
                 enabled: true,
-                button: PointerButton::Middle,
+                button: PointerButton::Primary,
             },
         }
     }

--- a/crates/bevy_camera_controller/src/pan_camera.rs
+++ b/crates/bevy_camera_controller/src/pan_camera.rs
@@ -12,7 +12,10 @@ use bevy_input::keyboard::KeyCode;
 use bevy_input::mouse::{AccumulatedMouseScroll, MouseScrollPixelsPerLine};
 use bevy_input::ButtonInput;
 use bevy_math::{Vec2, Vec3};
-use bevy_picking::{pointer::PointerButton, events::{Drag, DragEnd, DragStart, Pointer}};
+use bevy_picking::{
+    events::{Drag, DragEnd, DragStart, Pointer},
+    pointer::PointerButton,
+};
 use bevy_time::{Real, Time};
 use bevy_transform::components::GlobalTransform;
 use bevy_transform::prelude::Transform;
@@ -311,7 +314,10 @@ fn handle_mouse_pan(
     mut pan_cameras: Query<(&Camera, &GlobalTransform, &mut Transform, &PanCamera)>,
 ) {
     for (camera, global_transform, mut transform, pan_camera_controller) in pan_cameras.iter_mut() {
-        if !pan_camera_controller.enabled || !pan_camera_controller.mouse_pan_settings.enabled || drag.button != pan_camera_controller.mouse_pan_settings.button{
+        if !pan_camera_controller.enabled
+            || !pan_camera_controller.mouse_pan_settings.enabled
+            || drag.button != pan_camera_controller.mouse_pan_settings.button
+        {
             return;
         }
 


### PR DESCRIPTION
# Objective

Fix PanCamera to check which that the correct mouse button is used, not just any.
Change default pan mouse button to middle mouse button.

## Solution

Add check.

## Testing

- Did you test these changes? If so, how?
- Tested in local test environment, then like a cave man, copy & pasted the changes into github's text editor of the fork.