### PR TITLE
Render optional `bevy_dev_tools`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -570,6 +570,9 @@ android-game-activity = ["bevy_internal/android-game-activity"]
 # Enable systems that allow for automated testing on CI
 bevy_ci_testing = ["bevy_internal/bevy_ci_testing"]
 
+# Enable systems that allow for renderable dev tools
+render_dev_tools = ["bevy_internal/render_dev_tools"]
+
 # Enable glTF animation loading
 gltf_animation = ["bevy_internal/gltf_animation"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,8 +154,9 @@ ui = [
 
 # COLLECTION: Enable this feature during development to improve the development experience. This adds features like asset hot-reloading and debugging tools. This should not be enabled for published apps!
 dev = [
-  "debug",          # TODO: rename this to something more specific ... this is a "debug ECS names" feature
+  "debug",            # TODO: rename this to something more specific ... this is a "debug ECS names" feature
   "bevy_dev_tools",
+  "render_dev_tools",
   "file_watcher",
 ]
 

--- a/crates/bevy_dev_tools/Cargo.toml
+++ b/crates/bevy_dev_tools/Cargo.toml
@@ -11,8 +11,9 @@ keywords = ["bevy"]
 [features]
 bevy_ci_testing = ["dep:serde", "dep:ron"]
 screenrecording = ["dep:x264"]
-webgl = ["bevy_render/webgl"]
-webgpu = ["bevy_render/webgpu"]
+render = ["dep:bevy_render", "dep:bevy_core_pipeline", "dep:bevy_pbr", "dep:bevy_ui_render"]
+webgl = ["dep:bevy_render", "bevy_render?/webgl"]
+webgpu = ["dep:bevy_render", "bevy_render?/webgpu"]
 schedule_data = [
   "dep:serde",
   "dep:ron",
@@ -27,23 +28,23 @@ bevy_app = { path = "../bevy_app", version = "0.19.0-dev" }
 bevy_asset = { path = "../bevy_asset", version = "0.19.0-dev" }
 bevy_camera = { path = "../bevy_camera", version = "0.19.0-dev" }
 bevy_color = { path = "../bevy_color", version = "0.19.0-dev" }
-bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.19.0-dev" }
+bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.19.0-dev", optional = true }
 bevy_diagnostic = { path = "../bevy_diagnostic", version = "0.19.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.19.0-dev" }
 bevy_image = { path = "../bevy_image", version = "0.19.0-dev" }
 bevy_input = { path = "../bevy_input", version = "0.19.0-dev" }
 bevy_log = { path = "../bevy_log", version = "0.19.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.19.0-dev" }
-bevy_pbr = { path = "../bevy_pbr", version = "0.19.0-dev" }
+bevy_pbr = { path = "../bevy_pbr", version = "0.19.0-dev", optional = true }
 bevy_picking = { path = "../bevy_picking", version = "0.19.0-dev" }
-bevy_render = { path = "../bevy_render", version = "0.19.0-dev" }
+bevy_render = { path = "../bevy_render", version = "0.19.0-dev", optional = true}
 bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev" }
 bevy_time = { path = "../bevy_time", version = "0.19.0-dev" }
 bevy_text = { path = "../bevy_text", version = "0.19.0-dev" }
 bevy_transform = { path = "../bevy_transform", version = "0.19.0-dev" }
 bevy_shader = { path = "../bevy_shader", version = "0.19.0-dev" }
 bevy_ui = { path = "../bevy_ui", version = "0.19.0-dev" }
-bevy_ui_render = { path = "../bevy_ui_render", version = "0.19.0-dev" }
+bevy_ui_render = { path = "../bevy_ui_render", version = "0.19.0-dev", optional = true }
 bevy_utils = { path = "../bevy_utils", version = "0.19.0-dev", optional = true }
 bevy_window = { path = "../bevy_window", version = "0.19.0-dev" }
 bevy_state = { path = "../bevy_state", version = "0.19.0-dev" }

--- a/crates/bevy_dev_tools/Cargo.toml
+++ b/crates/bevy_dev_tools/Cargo.toml
@@ -11,7 +11,12 @@ keywords = ["bevy"]
 [features]
 bevy_ci_testing = ["dep:serde", "dep:ron"]
 screenrecording = ["dep:x264"]
-render = ["dep:bevy_render", "dep:bevy_core_pipeline", "dep:bevy_pbr", "dep:bevy_ui_render"]
+render = [
+  "dep:bevy_render",
+  "dep:bevy_core_pipeline",
+  "dep:bevy_pbr",
+  "dep:bevy_ui_render",
+]
 webgl = ["dep:bevy_render", "bevy_render?/webgl"]
 webgpu = ["dep:bevy_render", "bevy_render?/webgpu"]
 schedule_data = [
@@ -37,7 +42,7 @@ bevy_log = { path = "../bevy_log", version = "0.19.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.19.0-dev" }
 bevy_pbr = { path = "../bevy_pbr", version = "0.19.0-dev", optional = true }
 bevy_picking = { path = "../bevy_picking", version = "0.19.0-dev" }
-bevy_render = { path = "../bevy_render", version = "0.19.0-dev", optional = true}
+bevy_render = { path = "../bevy_render", version = "0.19.0-dev", optional = true }
 bevy_reflect = { path = "../bevy_reflect", version = "0.19.0-dev" }
 bevy_time = { path = "../bevy_time", version = "0.19.0-dev" }
 bevy_text = { path = "../bevy_text", version = "0.19.0-dev" }

--- a/crates/bevy_dev_tools/Cargo.toml
+++ b/crates/bevy_dev_tools/Cargo.toml
@@ -11,8 +11,14 @@ keywords = ["bevy"]
 [features]
 bevy_ci_testing = ["dep:serde", "dep:ron"]
 screenrecording = ["dep:x264"]
-webgl = ["bevy_render/webgl"]
-webgpu = ["bevy_render/webgpu"]
+render = [
+  "dep:bevy_render",
+  "dep:bevy_core_pipeline",
+  "dep:bevy_pbr",
+  "dep:bevy_ui_render",
+]
+webgl = ["dep:bevy_render", "bevy_render?/webgl"]
+webgpu = ["dep:bevy_render", "bevy_render?/webgpu"]
 schedule_data = ["dep:serde", "dep:ron", "dep:bevy_utils", "dep:thiserror"]
 serialize = ["dep:serde"]
 
@@ -24,7 +30,7 @@ bevy_audio = { path = "../bevy_audio", version = "0.20.0-dev" }
 bevy_asset = { path = "../bevy_asset", version = "0.20.0-dev" }
 bevy_camera = { path = "../bevy_camera", version = "0.20.0-dev" }
 bevy_color = { path = "../bevy_color", version = "0.20.0-dev" }
-bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.20.0-dev" }
+bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.20.0-dev", optional = true }
 bevy_diagnostic = { path = "../bevy_diagnostic", version = "0.20.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.20.0-dev" }
 bevy_extract = { path = "../bevy_extract", version = "0.20.0-dev" }
@@ -33,9 +39,9 @@ bevy_input = { path = "../bevy_input", version = "0.20.0-dev" }
 bevy_light = { path = "../bevy_light", version = "0.20.0-dev" }
 bevy_log = { path = "../bevy_log", version = "0.20.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.20.0-dev" }
-bevy_pbr = { path = "../bevy_pbr", version = "0.20.0-dev" }
+bevy_pbr = { path = "../bevy_pbr", version = "0.20.0-dev", optional = true }
 bevy_picking = { path = "../bevy_picking", version = "0.20.0-dev" }
-bevy_render = { path = "../bevy_render", version = "0.20.0-dev" }
+bevy_render = { path = "../bevy_render", version = "0.20.0-dev", optional = true }
 bevy_reflect = { path = "../bevy_reflect", version = "0.20.0-dev" }
 bevy_time = { path = "../bevy_time", version = "0.20.0-dev" }
 bevy_text = { path = "../bevy_text", version = "0.20.0-dev" }
@@ -43,7 +49,7 @@ bevy_transform = { path = "../bevy_transform", version = "0.20.0-dev" }
 bevy_shader = { path = "../bevy_shader", version = "0.20.0-dev" }
 bevy_sprite = { path = "../bevy_sprite", version = "0.20.0-dev" }
 bevy_ui = { path = "../bevy_ui", version = "0.20.0-dev" }
-bevy_ui_render = { path = "../bevy_ui_render", version = "0.20.0-dev" }
+bevy_ui_render = { path = "../bevy_ui_render", version = "0.20.0-dev", optional = true }
 bevy_ui_widgets = { path = "../bevy_ui_widgets", version = "0.20.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.20.0-dev", optional = true }
 bevy_window = { path = "../bevy_window", version = "0.20.0-dev" }

--- a/crates/bevy_dev_tools/src/easy_camera.rs
+++ b/crates/bevy_dev_tools/src/easy_camera.rs
@@ -1,0 +1,55 @@
+use bevy_app::{App, Plugin, PostUpdate};
+use bevy_camera::Camera;
+use bevy_ecs::prelude::*;
+use bevy_math::{Quat, StableInterpolate, Vec3};
+use bevy_time::Time;
+use bevy_transform::{components::Transform, TransformSystems};
+
+/// Plugin to move the camera smoothly according to the current time
+pub struct EasyCameraMovementPlugin {
+    /// Decay rate for the camera movement
+    pub decay_rate: f32,
+}
+
+impl Default for EasyCameraMovementPlugin {
+    fn default() -> Self {
+        Self { decay_rate: 1.0 }
+    }
+}
+
+/// Move the camera to the given position
+#[derive(Component)]
+pub struct CameraMovement {
+    /// Target position for the camera movement
+    pub translation: Vec3,
+    /// Target rotation for the camera movement
+    pub rotation: Quat,
+}
+
+impl Plugin for EasyCameraMovementPlugin {
+    fn build(&self, app: &mut App) {
+        let decay_rate = self.decay_rate;
+        app.add_systems(
+            PostUpdate,
+            (move |mut query: Single<(&mut Transform, &CameraMovement), With<Camera>>,
+                   time: Res<Time>| {
+                {
+                    {
+                        let target = query.1;
+                        query.0.translation.smooth_nudge(
+                            &target.translation,
+                            decay_rate,
+                            time.delta_secs(),
+                        );
+                        query.0.rotation.smooth_nudge(
+                            &target.rotation,
+                            decay_rate,
+                            time.delta_secs(),
+                        );
+                    }
+                }
+            })
+            .before(TransformSystems::Propagate),
+        );
+    }
+}

--- a/crates/bevy_dev_tools/src/easy_screenshot.rs
+++ b/crates/bevy_dev_tools/src/easy_screenshot.rs
@@ -2,14 +2,10 @@
 use core::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use bevy_app::{App, Plugin, PostUpdate, Update};
-use bevy_camera::Camera;
+use bevy_app::{App, Plugin, Update};
 use bevy_ecs::prelude::*;
 use bevy_input::{common_conditions::input_just_pressed, keyboard::KeyCode};
-use bevy_math::{Quat, StableInterpolate, Vec3};
 use bevy_render::view::screenshot::{save_to_disk, Screenshot};
-use bevy_time::Time;
-use bevy_transform::{components::Transform, TransformSystems};
 use bevy_window::{PrimaryWindow, Window};
 #[cfg(all(not(target_os = "windows"), feature = "screenrecording"))]
 pub use x264::{Preset, Tune};
@@ -342,54 +338,5 @@ impl Plugin for EasyScreenRecordPlugin {
                     .in_set(EasyScreenRecordSystems),
             );
         }
-    }
-}
-
-/// Plugin to move the camera smoothly according to the current time
-pub struct EasyCameraMovementPlugin {
-    /// Decay rate for the camera movement
-    pub decay_rate: f32,
-}
-
-impl Default for EasyCameraMovementPlugin {
-    fn default() -> Self {
-        Self { decay_rate: 1.0 }
-    }
-}
-
-/// Move the camera to the given position
-#[derive(Component)]
-pub struct CameraMovement {
-    /// Target position for the camera movement
-    pub translation: Vec3,
-    /// Target rotation for the camera movement
-    pub rotation: Quat,
-}
-
-impl Plugin for EasyCameraMovementPlugin {
-    fn build(&self, app: &mut App) {
-        let decay_rate = self.decay_rate;
-        app.add_systems(
-            PostUpdate,
-            (move |mut query: Single<(&mut Transform, &CameraMovement), With<Camera>>,
-                   time: Res<Time>| {
-                {
-                    {
-                        let target = query.1;
-                        query.0.translation.smooth_nudge(
-                            &target.translation,
-                            decay_rate,
-                            time.delta_secs(),
-                        );
-                        query.0.rotation.smooth_nudge(
-                            &target.rotation,
-                            decay_rate,
-                            time.delta_secs(),
-                        );
-                    }
-                }
-            })
-            .before(TransformSystems::Propagate),
-        );
     }
 }

--- a/crates/bevy_dev_tools/src/inspection/label_resolution.rs
+++ b/crates/bevy_dev_tools/src/inspection/label_resolution.rs
@@ -4,6 +4,7 @@ use bevy_animation::AnimationPlayer;
 use bevy_app::{App, Plugin};
 use bevy_audio::{AudioPlayer, AudioSink};
 use bevy_camera::{Camera, Camera2d};
+#[cfg(feature = "render")]
 use bevy_core_pipeline::Skybox;
 use bevy_ecs::{
     component::ComponentId, entity::Entity, name::Name, observer::Observer, resource::Resource,
@@ -15,6 +16,7 @@ use bevy_light::{
     PointLight, SpotLight, SunDisk,
 };
 use bevy_mesh::{Mesh2d, Mesh3d};
+#[cfg(feature = "render")]
 use bevy_pbr::{wireframe::Wireframe, DistanceFog, Lightmap};
 use bevy_picking::pointer::PointerId;
 use bevy_platform::collections::HashMap;
@@ -326,6 +328,7 @@ impl Plugin for LabelResolutionPlugin {
             .register_label_defining_type::<IrradianceVolume>(LabelDefinitionPriority::LIBRARY);
         label_resolution_registry
             .register_label_defining_type::<SunDisk>(LabelDefinitionPriority::LIBRARY);
+        #[cfg(feature = "render")]
         label_resolution_registry
             .register_label_defining_type::<Lightmap>(LabelDefinitionPriority::LIBRARY);
 
@@ -336,16 +339,19 @@ impl Plugin for LabelResolutionPlugin {
             .register_label_defining_type::<Mesh2d>(LabelDefinitionPriority::LIBRARY);
         label_resolution_registry
             .register_label_defining_type::<Mesh3d>(LabelDefinitionPriority::LIBRARY);
+        #[cfg(feature = "render")]
         label_resolution_registry
             .register_label_defining_type::<Wireframe>(LabelDefinitionPriority::LIBRARY);
 
         // Atmospherics
+        #[cfg(feature = "render")]
         label_resolution_registry
             .register_label_defining_type::<Skybox>(LabelDefinitionPriority::LIBRARY);
         label_resolution_registry
             .register_label_defining_type::<FogVolume>(LabelDefinitionPriority::LIBRARY);
         label_resolution_registry
             .register_label_defining_type::<Atmosphere>(LabelDefinitionPriority::LIBRARY);
+        #[cfg(feature = "render")]
         label_resolution_registry
             .register_label_defining_type::<DistanceFog>(LabelDefinitionPriority::LIBRARY);
 

--- a/crates/bevy_dev_tools/src/lib.rs
+++ b/crates/bevy_dev_tools/src/lib.rs
@@ -13,9 +13,16 @@ extern crate alloc;
 #[cfg(feature = "bevy_ci_testing")]
 pub mod ci_testing;
 
+#[cfg(feature = "render")]
 pub mod diagnostics_overlay;
+
+#[cfg(feature = "render")]
 mod easy_screenshot;
+
+#[cfg(feature = "render")]
 pub mod fps_overlay;
+
+#[cfg(feature = "render")]
 pub mod frame_time_graph;
 
 pub mod picking_debug;
@@ -25,10 +32,13 @@ pub mod schedule_data;
 
 pub mod states;
 
+#[cfg(feature = "render")]
 pub use easy_screenshot::*;
 
+#[cfg(feature = "render")]
 pub mod render_debug;
 
+#[cfg(feature = "render")]
 pub mod infinite_grid;
 
 pub mod world_asset_helpers;

--- a/crates/bevy_dev_tools/src/lib.rs
+++ b/crates/bevy_dev_tools/src/lib.rs
@@ -16,6 +16,8 @@ pub mod ci_testing;
 #[cfg(feature = "render")]
 pub mod diagnostics_overlay;
 
+mod easy_camera;
+
 #[cfg(feature = "render")]
 mod easy_screenshot;
 
@@ -33,6 +35,8 @@ pub mod picking_debug;
 pub mod schedule_data;
 
 pub mod states;
+
+pub use easy_camera::*;
 
 #[cfg(feature = "render")]
 pub use easy_screenshot::*;

--- a/crates/bevy_dev_tools/src/lib.rs
+++ b/crates/bevy_dev_tools/src/lib.rs
@@ -13,9 +13,16 @@ extern crate alloc;
 #[cfg(feature = "bevy_ci_testing")]
 pub mod ci_testing;
 
+#[cfg(feature = "render")]
 pub mod diagnostics_overlay;
+
+#[cfg(feature = "render")]
 mod easy_screenshot;
+
+#[cfg(feature = "render")]
 pub mod fps_overlay;
+
+#[cfg(feature = "render")]
 pub mod frame_time_graph;
 
 pub mod inspection;
@@ -27,10 +34,13 @@ pub mod schedule_data;
 
 pub mod states;
 
+#[cfg(feature = "render")]
 pub use easy_screenshot::*;
 
+#[cfg(feature = "render")]
 pub mod render_debug;
 
+#[cfg(feature = "render")]
 pub mod infinite_grid;
 
 pub mod world_asset_helpers;

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -220,6 +220,8 @@ webgpu = [
 # Enable systems that allow for automated testing on CI
 bevy_ci_testing = ["bevy_dev_tools/bevy_ci_testing", "bevy_render?/ci_limits"]
 
+render_dev_tools = ["bevy_dev_tools/render"]
+
 # Enable glTF animation loading
 gltf_animation = ["bevy_animation", "bevy_gltf?/bevy_animation"]
 

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -91,7 +91,7 @@ plugin_group! {
         bevy_state::app:::StatesPlugin,
         #[cfg(feature = "bevy_ci_testing")]
         bevy_dev_tools::ci_testing:::CiTestingPlugin,
-        #[custom(cfg(all(feature = "bevy_dev_tools", feature = "bevy_pbr")))]
+        #[cfg(feature = "render_dev_tools")]
         bevy_dev_tools::render_debug:::RenderDebugOverlayPlugin,
         #[cfg(feature = "hotpatching")]
         bevy_app::hotpatch:::HotPatchPlugin,

--- a/crates/bevy_remote/Cargo.toml
+++ b/crates/bevy_remote/Cargo.toml
@@ -18,7 +18,7 @@ http = [
   "bevy_tasks/async-io",
 ]
 bevy_asset = ["dep:bevy_asset"]
-bevy_render = ["dep:bevy_render"]
+bevy_render = ["dep:bevy_render", "bevy_dev_tools/render"]
 
 [dependencies]
 # bevy

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -36,7 +36,7 @@ collections to build your own "profile" equivalent, without needing to manually 
 
 |Collection|Description|
 |-|-|
-|dev|Enable this feature during development to improve the development experience. This adds features like asset hot-reloading and debugging tools. This should not be enabled for published apps! **Feature set:** `debug`, `bevy_dev_tools`, `file_watcher`.|
+|dev|Enable this feature during development to improve the development experience. This adds features like asset hot-reloading and debugging tools. This should not be enabled for published apps! **Feature set:** `debug`, `bevy_dev_tools`, `render_dev_tools`, `file_watcher`.|
 |audio|Features used to build audio Bevy apps. **Feature set:** `bevy_audio`, `vorbis`.|
 |audio-all-formats|Enables audio features and all supported formats. **Feature set:** `bevy_audio`, `aac`, `flac`, `mp3`, `mp4`, `vorbis`, `wav`.|
 |scene|Features used to compose Bevy scenes. **Feature set:** `bevy_world_serialization`, `bevy_scene`.|

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -176,6 +176,7 @@ This is the complete `bevy` cargo feature list, without "profiles" or "collectio
 |reflect_auto_register_static|Enable automatic reflect registration without inventory. See `reflect::load_type_registrations` for more info.|
 |reflect_documentation|Enables `bevy_reflect` to access documentation comments of Rust code at runtime|
 |reflect_functions|Enable function reflection|
+|render_dev_tools|Enable systems that allow for renderable dev tools|
 |schedule_data|Enable collecting schedule data from the app.|
 |serialize|Enable serialization support through serde|
 |shader_format_spirv|Enable support for shaders in SPIR-V|


### PR DESCRIPTION
# Objective

- Fixes #24617

## Solution

- Feature flagging the rendering crates
  - `bevy_dev_tools` has a `render` feature
  - `bevy` and `bevy_internal` have `render_dev_tools` feature that enables the above
- Split `easy_camera` out of `easy_screenshot` in `bevy_dev_tools`

## Testing

- CI and various examples and build combinations