### PR TITLE
Text performance regression fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3591,6 +3591,17 @@ category = "Stress Tests"
 wasm = true
 
 [[example]]
+name = "many_text"
+path = "examples/stress_tests/many_text.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.many_text]
+name = "Many Text"
+description = "Displays many UI Text nodes. Used for performance testing."
+category = "Stress Tests"
+wasm = true
+
+[[example]]
 name = "many_meshlet_materials"
 path = "examples/stress_tests/many_meshlet_materials.rs"
 doc-scrape-examples = true

--- a/crates/bevy_text/src/font_atlas_set.rs
+++ b/crates/bevy_text/src/font_atlas_set.rs
@@ -47,4 +47,9 @@ impl FontAtlasSet {
             })
             .sum()
     }
+
+    /// Clear all font atlases
+    pub fn clear(&mut self) {
+        self.0.clear()
+    }
 }

--- a/crates/bevy_text/src/font_atlas_set.rs
+++ b/crates/bevy_text/src/font_atlas_set.rs
@@ -50,6 +50,6 @@ impl FontAtlasSet {
 
     /// Clear all font atlases
     pub fn clear(&mut self) {
-        self.0.clear()
+        self.0.clear();
     }
 }

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -364,7 +364,10 @@ impl TextPipeline {
                                         .0
                                         .builder(font_ref)
                                         .size(font_size)
-                                        .hint(hinting.is_enabled())
+                                        .hint(
+                                            hinting.is_enabled()
+                                                && font_smoothing == FontSmoothing::AntiAliased,
+                                        )
                                         .normalized_coords(coords)
                                         .build(),
                                 );

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -344,7 +344,7 @@ impl TextPipeline {
                         return Err(TextError::NoSuchFont);
                     };
 
-                    let mut scaler = None;
+                    let mut maybe_scaler = None;
 
                     for glyph in glyph_run.positioned_glyphs() {
                         let Ok(glyph_id) = u16::try_from(glyph.id) else {
@@ -353,32 +353,34 @@ impl TextPipeline {
 
                         let font_atlases = font_atlas_set.entry(font_atlas_key).or_default();
 
-                        let atlas_info = if let Some(info) =
-                            get_glyph_atlas_info(font_atlases, crate::GlyphCacheKey { glyph_id })
-                        {
-                            info
-                        } else {
-                            if scaler.is_none() {
-                                scaler = Some(
-                                    scale_cx
-                                        .0
-                                        .builder(font_ref)
-                                        .size(font_size)
-                                        .hint(
-                                            hinting.is_enabled()
-                                                && font_smoothing == FontSmoothing::AntiAliased,
-                                        )
-                                        .normalized_coords(coords)
-                                        .build(),
-                                );
+                        let atlas_info = match get_glyph_atlas_info(
+                            font_atlases,
+                            crate::GlyphCacheKey { glyph_id },
+                        ) {
+                            Some(info) => info,
+                            None => {
+                                if maybe_scaler.is_none() {
+                                    maybe_scaler = Some(
+                                        scale_cx
+                                            .0
+                                            .builder(font_ref)
+                                            .size(font_size)
+                                            .hint(
+                                                hinting.is_enabled()
+                                                    && font_smoothing == FontSmoothing::AntiAliased,
+                                            )
+                                            .normalized_coords(coords)
+                                            .build(),
+                                    );
+                                }
+                                add_glyph_to_atlas(
+                                    font_atlases,
+                                    textures,
+                                    maybe_scaler.as_mut().unwrap(),
+                                    font_smoothing,
+                                    glyph_id,
+                                )?
                             }
-                            add_glyph_to_atlas(
-                                font_atlases,
-                                textures,
-                                scaler.as_mut().unwrap(),
-                                font_smoothing,
-                                glyph_id,
-                            )?
                         };
 
                         let glyph_pos = Vec2::new(glyph.x, glyph.y);

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -344,14 +344,7 @@ impl TextPipeline {
                         return Err(TextError::NoSuchFont);
                     };
 
-                    let hint = hinting.is_enabled() && font_smoothing == FontSmoothing::AntiAliased;
-                    let mut scaler = scale_cx
-                        .0
-                        .builder(font_ref)
-                        .size(font_size)
-                        .hint(hint)
-                        .normalized_coords(coords)
-                        .build();
+                    let mut scaler = None;
 
                     for glyph in glyph_run.positioned_glyphs() {
                         let Ok(glyph_id) = u16::try_from(glyph.id) else {
@@ -359,18 +352,31 @@ impl TextPipeline {
                         };
 
                         let font_atlases = font_atlas_set.entry(font_atlas_key).or_default();
-                        let atlas_info =
+
+                        let atlas_info = if let Some(info) =
                             get_glyph_atlas_info(font_atlases, crate::GlyphCacheKey { glyph_id })
-                                .map(Ok)
-                                .unwrap_or_else(|| {
-                                    add_glyph_to_atlas(
-                                        font_atlases,
-                                        textures,
-                                        &mut scaler,
-                                        font_smoothing,
-                                        glyph_id,
-                                    )
-                                })?;
+                        {
+                            info
+                        } else {
+                            if scaler.is_none() {
+                                scaler = Some(
+                                    scale_cx
+                                        .0
+                                        .builder(font_ref)
+                                        .size(font_size)
+                                        .hint(hinting.is_enabled())
+                                        .normalized_coords(coords)
+                                        .build(),
+                                );
+                            }
+                            add_glyph_to_atlas(
+                                font_atlases,
+                                textures,
+                                scaler.as_mut().unwrap(),
+                                font_smoothing,
+                                glyph_id,
+                            )?
+                        };
 
                         let glyph_pos = Vec2::new(glyph.x, glyph.y);
                         let size = atlas_info.rect.size();

--- a/examples/README.md
+++ b/examples/README.md
@@ -558,6 +558,7 @@ Example | Description
 [Many Morph Targets](../examples/stress_tests/many_morph_targets.rs) | Simple benchmark to test rendering many meshes with animated morph targets.
 [Many Sprite Meshes](../examples/stress_tests/many_sprite_meshes.rs) | Displays many sprite meshes in a grid arrangement! Used for performance testing. Use `--colored` to enable color tinted sprites.
 [Many Sprites](../examples/stress_tests/many_sprites.rs) | Displays many sprites in a grid arrangement! Used for performance testing. Use `--colored` to enable color tinted sprites.
+[Many Text](../examples/stress_tests/many_text.rs) | Displays many UI Text nodes. Used for performance testing.
 [Many Text2d](../examples/stress_tests/many_text2d.rs) | Displays many Text2d! Used for performance testing.
 [Text Pipeline](../examples/stress_tests/text_pipeline.rs) | Text Pipeline benchmark
 [Transform Hierarchy](../examples/stress_tests/transform_hierarchy.rs) | Various test cases for hierarchy and transform propagation performance

--- a/examples/stress_tests/many_text.rs
+++ b/examples/stress_tests/many_text.rs
@@ -67,7 +67,7 @@ fn setup_camera(mut commands: Commands) {
     commands.spawn(Camera2d);
 }
 
-fn setup_text(mut commands: Commands, asset_server: Res<AssetServer>, args: Res<Args>) {
+fn setup_text(mut commands: Commands, asset_server: Res<AssetServer>, _args: Res<Args>) {
     commands
         .spawn((
             Node {
@@ -102,34 +102,34 @@ fn setup_text(mut commands: Commands, asset_server: Res<AssetServer>, args: Res<
                         ..default()
                     })
                     .with_children(|parent| {
-                        parent.spawn((Text(format!("font_path")),text_font.clone()));                            
-                        for (justify, linebreak) in [
+                        parent.spawn((Text(format!("{font_path}")),text_font.clone()));                            
+                        for justify in [
                             Justify::Left,
                             Justify::Center,
                             Justify::Right,
                             Justify::Justified,
-                        ].into_iter().zip([LineBreak::AnyCharacter, LineBreak::WordBoundary]) {
-
-                            parent.spawn((Text(format!("Justify::{justify:?}\n LineBreak::{linebreak:?}")),text_font.clone(), TextColor::from(bevy::color::palettes::css::YELLOW)));                            
-                            let layout =  TextLayout {
-                                justify,
-                                linebreak,
-                            };
-                            parent.spawn((
-                                Text::new("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."),
-                                layout,
-                                text_font.clone(),
-                                TextColor::from(bevy::color::palettes::css::NAVY),
-                            ));
-                             parent.spawn((
-                                Text::new("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."),
-                                layout,
-                                text_font.clone().with_font_size(12.),
-                                TextColor::from(bevy::color::palettes::css::PALE_GREEN),
-                            ));
-
+                        ]{
+                            for linebreak in [LineBreak::AnyCharacter, LineBreak::WordBoundary] {
+                                parent.spawn((Text(format!("Justify::{justify:?}\n LineBreak::{linebreak:?}")),text_font.clone(), TextColor::from(bevy::color::palettes::css::YELLOW)));                            
+                                let layout =  TextLayout {
+                                    justify,
+                                    linebreak,
+                                };
+                                parent.spawn((
+                                    Text::new("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."),
+                                    layout,
+                                    text_font.clone(),
+                                    TextColor::from(bevy::color::palettes::css::NAVY),
+                                ));
+                                parent.spawn((
+                                    Text::new("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."),
+                                    layout,
+                                    text_font.clone().with_font_size(12.),
+                                    TextColor::from(bevy::color::palettes::css::PALE_GREEN),
+                                ));
                         }
-                    });
+                    }
+                });
             }
         });
 }

--- a/examples/stress_tests/many_text.rs
+++ b/examples/stress_tests/many_text.rs
@@ -12,7 +12,7 @@ use bevy::{
 const LOREM_TEXT_1: &str = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do \
 eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis \
 nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.";
-const _LOREM_TEXT_2: &str = "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+const LOREM_TEXT_2: &str = "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
 Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
 
 #[derive(FromArgs, Resource)]
@@ -64,7 +64,7 @@ fn main() {
     }
 
     if args.respawn {
-        app.add_systems(Update, (despawn_text, setup_text).chain());
+        app.add_systems(Update, (despawn_layout, setup_text).chain());
     }
 
     app.run();
@@ -82,11 +82,11 @@ fn setup_text(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands
         .spawn((
             Node {
-                display: Display::Flex,
                 flex_direction: FlexDirection::Row,
                 width: percent(100),
                 height: percent(100),
                 overflow: Overflow::clip(),
+                column_gap: px(2.),
                 ..default()
             },
             ManyTextRoot,
@@ -105,13 +105,18 @@ fn setup_text(mut commands: Commands, asset_server: Res<AssetServer>) {
                     ..default()
                 };
                 parent
-                    .spawn(Node {
-                        display: Display::Flex,
-                        flex_direction: FlexDirection::Column,
-                        flex_grow: 1.0,
-                        overflow: Overflow::clip(),
-                        ..default()
-                    })
+                    .spawn((
+                        Node {
+                            flex_direction: FlexDirection::Column,
+                            flex_grow: 1.0,
+                            overflow: Overflow::clip(),
+                            border: px(2.).all(),
+                            padding: px(2.).all(),
+                            row_gap: px(3.),
+                            ..default()
+                        },
+                        BorderColor::all(Color::WHITE),
+                    ))
                     .with_children(|parent| {
                         parent.spawn((Text(format!("{font_path}")), text_font.clone()));
                         for justify in [
@@ -122,9 +127,7 @@ fn setup_text(mut commands: Commands, asset_server: Res<AssetServer>) {
                         ] {
                             for linebreak in [LineBreak::AnyCharacter, LineBreak::WordBoundary] {
                                 parent.spawn((
-                                    Text(format!(
-                                        "Justify::{justify:?}\n LineBreak::{linebreak:?}"
-                                    )),
+                                    Text(format!("Justify::{justify:?}, LineBreak::{linebreak:?}")),
                                     text_font.clone(),
                                     TextColor::from(bevy::color::palettes::css::YELLOW),
                                 ));
@@ -143,6 +146,46 @@ fn setup_text(mut commands: Commands, asset_server: Res<AssetServer>) {
                                 ));
                             }
                         }
+
+                        parent
+                            .spawn((
+                                Text::new(LOREM_TEXT_1),
+                                text_font.clone().with_font_size(13.),
+                                TextColor::from(bevy::color::palettes::css::MISTY_ROSE),
+                            ))
+                            .with_child((TextSpan::new(" "), text_font.clone().with_font_size(13.)))
+                            .with_child((
+                                TextSpan::new(LOREM_TEXT_2),
+                                text_font.clone().with_font_size(14.),
+                                TextColor::from(bevy::color::palettes::css::MAROON),
+                            ));
+
+                        parent
+                            .spawn((
+                                Text::default(),
+                                TextLayout::linebreak(LineBreak::AnyCharacter),
+                            ))
+                            .with_children(|parent| {
+                                for i in (0..10).into_iter().cycle().take(100) {
+                                    parent.spawn((
+                                        TextSpan(i.to_string()),
+                                        text_font.clone().with_font_size((7 + i) as f32),
+                                    ));
+                                }
+                            });
+                        parent
+                            .spawn((
+                                Text::default(),
+                                TextLayout::linebreak(LineBreak::AnyCharacter),
+                            ))
+                            .with_children(|parent| {
+                                for i in (0..10).into_iter() {
+                                    parent.spawn((
+                                        TextSpan::new("0123456789"),
+                                        text_font.clone().with_font_size((7 + i) as f32),
+                                    ));
+                                }
+                            });
                     });
             }
         });
@@ -154,6 +197,6 @@ fn set_changed<C: Component<Mutability = Mutable>>(mut component_query: Query<&m
     }
 }
 
-fn despawn_text(mut commands: Commands, root_node: Single<Entity, With<ManyTextRoot>>) {
+fn despawn_layout(mut commands: Commands, root_node: Single<Entity, With<ManyTextRoot>>) {
     commands.entity(*root_node).despawn();
 }

--- a/examples/stress_tests/many_text.rs
+++ b/examples/stress_tests/many_text.rs
@@ -179,7 +179,7 @@ fn setup_text(mut commands: Commands, asset_server: Res<AssetServer>) {
                                 TextLayout::linebreak(LineBreak::AnyCharacter),
                             ))
                             .with_children(|parent| {
-                                for i in (0..10).into_iter().cycle().take(100) {
+                                for i in (0..10).cycle().take(100) {
                                     parent.spawn((
                                         TextSpan(i.to_string()),
                                         text_font.clone().with_font_size((6 + i) as f32),

--- a/examples/stress_tests/many_text.rs
+++ b/examples/stress_tests/many_text.rs
@@ -8,7 +8,11 @@ use bevy::{
     winit::WinitSettings,
 };
 
-const LOREM_TEXT: &str = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
+const LOREM_TEXT: &str = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do \
+eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis \
+nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure \
+dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur \
+sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
 
 #[derive(FromArgs, Resource)]
 /// `many_text` UI text stress test

--- a/examples/stress_tests/many_text.rs
+++ b/examples/stress_tests/many_text.rs
@@ -127,7 +127,7 @@ fn setup_text(mut commands: Commands, asset_server: Res<AssetServer>) {
                         BorderColor::all(Color::WHITE),
                     ))
                     .with_children(|parent| {
-                        parent.spawn((Text(format!("{font_path}")), text_font.clone()));
+                        parent.spawn((font_path.to_string(), text_font.clone()));
                         for justify in [
                             Justify::Left,
                             Justify::Center,

--- a/examples/stress_tests/many_text.rs
+++ b/examples/stress_tests/many_text.rs
@@ -1,0 +1,68 @@
+//! UI text benchmark
+
+use argh::FromArgs;
+use bevy::{
+    color::palettes::css::ORANGE_RED,
+    diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
+    prelude::*,
+    text::TextColor,
+    window::{PresentMode, WindowResolution},
+    winit::WinitSettings,
+};
+
+const FONT_SIZE: FontSize = FontSize::Px(7.0);
+
+#[derive(FromArgs, Resource)]
+struct Args {
+    /// At the start of each frame despawn any existing UI nodes and spawn a new UI tree
+    #[argh(switch)]
+    respawn: bool,
+}
+
+/// This example shows what happens when there is a lot of buttons on screen.
+fn main() {
+    // `from_env` panics on the web
+    #[cfg(not(target_arch = "wasm32"))]
+    let args: Args = argh::from_env();
+    #[cfg(target_arch = "wasm32")]
+    let args = Args::from_args(&[], &[]).unwrap();
+
+    let mut app = App::new();
+
+    app.add_plugins((
+        DefaultPlugins.set(WindowPlugin {
+            primary_window: Some(Window {
+                present_mode: PresentMode::AutoNoVsync,
+                resolution: WindowResolution::new(1920, 1080).with_scale_factor_override(1.0),
+                ..default()
+            }),
+            ..default()
+        }),
+        FrameTimeDiagnosticsPlugin::default(),
+        LogDiagnosticsPlugin::default(),
+    ))
+    .insert_resource(WinitSettings::continuous())
+    .add_systems(Startup, setup)
+    .add_systems(Update, update);
+}
+
+fn column() -> Bundle {}
+
+fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    commands.spawn(Camera2d);
+
+    let root = commands
+        .spawn((Node {
+            display: Display::Grid,
+        },))
+        .id();
+
+    for font_path in [
+        "EBGaramond12-Regular.otf",
+        "FiraMono-Medium.ttf",
+        "FiraSans-Bold.ttf",
+        "MonaSans-VariableFont.ttf",
+    ] {
+        let font = asset_server.load(format!("fonts/{font_path}"));
+    }
+}

--- a/examples/stress_tests/many_text.rs
+++ b/examples/stress_tests/many_text.rs
@@ -10,9 +10,7 @@ use bevy::{
 
 const LOREM_TEXT: &str = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do \
 eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis \
-nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure \
-dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur \
-sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
+nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.";
 
 #[derive(FromArgs, Resource)]
 /// `many_text` UI text stress test

--- a/examples/stress_tests/many_text.rs
+++ b/examples/stress_tests/many_text.rs
@@ -127,7 +127,7 @@ fn setup_text(mut commands: Commands, asset_server: Res<AssetServer>) {
                         BorderColor::all(Color::WHITE),
                     ))
                     .with_children(|parent| {
-                        parent.spawn((font_path.to_string(), text_font.clone()));
+                        parent.spawn((Text(font_path.to_string()), text_font.clone()));
                         for justify in [
                             Justify::Left,
                             Justify::Center,

--- a/examples/stress_tests/many_text.rs
+++ b/examples/stress_tests/many_text.rs
@@ -84,10 +84,10 @@ fn setup_text(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands
         .spawn((
             Node {
-                flex_direction: FlexDirection::Row,
+                display: Display::Grid,
+                grid_template_columns: RepeatedGridTrack::flex(4, 1.0),
                 width: percent(100),
                 height: percent(100),
-                overflow: Overflow::clip(),
                 column_gap: px(2.),
                 ..default()
             },
@@ -110,10 +110,8 @@ fn setup_text(mut commands: Commands, asset_server: Res<AssetServer>) {
                     .spawn((
                         Node {
                             flex_direction: FlexDirection::Column,
-                            flex_grow: 1.0,
-                            overflow: Overflow::clip(),
-                            border: px(2.).all(),
-                            padding: px(2.).all(),
+                            border: px(1.).all(),
+                            padding: px(1.).all(),
                             row_gap: px(2.),
                             ..default()
                         },
@@ -138,14 +136,14 @@ fn setup_text(mut commands: Commands, asset_server: Res<AssetServer>) {
                                     Text::new(LOREM_TEXT_1),
                                     Lorem(false),
                                     layout,
-                                    text_font.clone().with_font_size(11.),
+                                    text_font.clone().with_font_size(10.),
                                     TextColor::from(bevy::color::palettes::css::NAVY),
                                 ));
                                 parent.spawn((
                                     Text::new(LOREM_TEXT_2),
                                     Lorem(true),
                                     layout,
-                                    text_font.clone().with_font_size(12.),
+                                    text_font.clone().with_font_size(11.),
                                     TextColor::from(bevy::color::palettes::css::PALE_GREEN),
                                 ));
                             }
@@ -155,14 +153,14 @@ fn setup_text(mut commands: Commands, asset_server: Res<AssetServer>) {
                             .spawn((
                                 Text::new(LOREM_TEXT_1),
                                 Lorem(false),
-                                text_font.clone().with_font_size(13.),
+                                text_font.clone().with_font_size(12.),
                                 TextColor::from(bevy::color::palettes::css::MISTY_ROSE),
                             ))
                             .with_child((TextSpan::new(" "), text_font.clone().with_font_size(13.)))
                             .with_child((
                                 TextSpan::new(LOREM_TEXT_2),
                                 Lorem(true),
-                                text_font.clone().with_font_size(14.),
+                                text_font.clone().with_font_size(13.),
                                 TextColor::from(bevy::color::palettes::css::MAROON),
                             ));
 
@@ -175,21 +173,8 @@ fn setup_text(mut commands: Commands, asset_server: Res<AssetServer>) {
                                 for i in (0..10).into_iter().cycle().take(100) {
                                     parent.spawn((
                                         TextSpan(i.to_string()),
-                                        text_font.clone().with_font_size((7 + i) as f32),
+                                        text_font.clone().with_font_size((6 + i) as f32),
                                         NumberSpan,
-                                    ));
-                                }
-                            });
-                        parent
-                            .spawn((
-                                Text::default(),
-                                TextLayout::linebreak(LineBreak::AnyCharacter),
-                            ))
-                            .with_children(|parent| {
-                                for i in (0..10).into_iter() {
-                                    parent.spawn((
-                                        TextSpan::new("0123456789"),
-                                        text_font.clone().with_font_size((7 + i) as f32),
                                     ));
                                 }
                             });

--- a/examples/stress_tests/many_text.rs
+++ b/examples/stress_tests/many_text.rs
@@ -12,16 +12,18 @@ use bevy::{
 const LOREM_TEXT_1: &str = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do \
 eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis \
 nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.";
-const LOREM_TEXT_2: &str = "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+const LOREM_TEXT_2: &str = "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. \
 Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
+
+#[derive(Component)]
+struct Lorem(bool);
+
+#[derive(Component)]
+struct NumberSpan;
 
 #[derive(FromArgs, Resource)]
 /// `many_text` UI text stress test
 struct Args {
-    /// whether to set the text changed each frame
-    #[argh(switch)]
-    set_text_changed: bool,
-
     /// whether to set the font changed each frame
     #[argh(switch)]
     set_font_changed: bool,
@@ -55,10 +57,6 @@ fn main() {
     #[cfg(target_arch = "wasm32")]
     let args = Args::from_args(&[], &[]).unwrap();
 
-    if args.set_text_changed {
-        app.add_systems(Update, set_changed::<Text>);
-    }
-
     if args.set_font_changed {
         app.add_systems(Update, set_changed::<TextFont>);
     }
@@ -66,6 +64,10 @@ fn main() {
     if args.respawn {
         app.add_systems(Update, (despawn_layout, setup_text).chain());
     }
+
+    app.add_systems(Update, update_lorem_text);
+
+    app.add_systems(Update, update_number_text);
 
     app.run();
 }
@@ -112,7 +114,7 @@ fn setup_text(mut commands: Commands, asset_server: Res<AssetServer>) {
                             overflow: Overflow::clip(),
                             border: px(2.).all(),
                             padding: px(2.).all(),
-                            row_gap: px(3.),
+                            row_gap: px(2.),
                             ..default()
                         },
                         BorderColor::all(Color::WHITE),
@@ -134,12 +136,14 @@ fn setup_text(mut commands: Commands, asset_server: Res<AssetServer>) {
                                 let layout = TextLayout { justify, linebreak };
                                 parent.spawn((
                                     Text::new(LOREM_TEXT_1),
+                                    Lorem(false),
                                     layout,
                                     text_font.clone().with_font_size(11.),
                                     TextColor::from(bevy::color::palettes::css::NAVY),
                                 ));
                                 parent.spawn((
-                                    Text::new(LOREM_TEXT_1),
+                                    Text::new(LOREM_TEXT_2),
+                                    Lorem(true),
                                     layout,
                                     text_font.clone().with_font_size(12.),
                                     TextColor::from(bevy::color::palettes::css::PALE_GREEN),
@@ -150,12 +154,14 @@ fn setup_text(mut commands: Commands, asset_server: Res<AssetServer>) {
                         parent
                             .spawn((
                                 Text::new(LOREM_TEXT_1),
+                                Lorem(false),
                                 text_font.clone().with_font_size(13.),
                                 TextColor::from(bevy::color::palettes::css::MISTY_ROSE),
                             ))
                             .with_child((TextSpan::new(" "), text_font.clone().with_font_size(13.)))
                             .with_child((
                                 TextSpan::new(LOREM_TEXT_2),
+                                Lorem(true),
                                 text_font.clone().with_font_size(14.),
                                 TextColor::from(bevy::color::palettes::css::MAROON),
                             ));
@@ -170,6 +176,7 @@ fn setup_text(mut commands: Commands, asset_server: Res<AssetServer>) {
                                     parent.spawn((
                                         TextSpan(i.to_string()),
                                         text_font.clone().with_font_size((7 + i) as f32),
+                                        NumberSpan,
                                     ));
                                 }
                             });
@@ -199,4 +206,26 @@ fn set_changed<C: Component<Mutability = Mutable>>(mut component_query: Query<&m
 
 fn despawn_layout(mut commands: Commands, root_node: Single<Entity, With<ManyTextRoot>>) {
     commands.entity(*root_node).despawn();
+}
+
+fn update_lorem_text(mut lorem_text_query: Query<(&mut Text, &mut Lorem)>) {
+    for (mut text, mut lorem) in &mut lorem_text_query {
+        if lorem.0 {
+            text.0.clear();
+            text.0.push_str(LOREM_TEXT_1);
+        } else {
+            text.0.clear();
+            text.0.push_str(LOREM_TEXT_2);
+        }
+
+        lorem.0 = !lorem.0;
+    }
+}
+
+fn update_number_text(mut n: Local<u32>, mut number_spans: Query<&mut TextSpan, With<NumberSpan>>) {
+    for mut text in &mut number_spans {
+        text.0 = format!("{}", (text.0.parse::<u32>().unwrap() + *n) % 10);
+    }
+
+    *n = (*n + 1) % 10;
 }

--- a/examples/stress_tests/many_text.rs
+++ b/examples/stress_tests/many_text.rs
@@ -3,21 +3,28 @@
 use argh::FromArgs;
 use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
+    ecs::component::Mutable,
     prelude::*,
     window::{PresentMode, WindowResolution},
     winit::WinitSettings,
 };
 
-const LOREM_TEXT: &str = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do \
+const LOREM_TEXT_1: &str = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do \
 eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis \
 nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.";
+const _LOREM_TEXT_2: &str = "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
 
 #[derive(FromArgs, Resource)]
 /// `many_text` UI text stress test
 struct Args {
-    /// whether to force the text to recompute every frame by triggering change detection.
+    /// whether to set the text changed each frame
     #[argh(switch)]
-    recompute_text: bool,
+    set_text_changed: bool,
+
+    /// whether to set the font changed each frame
+    #[argh(switch)]
+    set_font_changed: bool,
 
     /// at the start of each frame despawn any existing UI nodes and spawn a new UI tree
     #[argh(switch)]
@@ -25,15 +32,6 @@ struct Args {
 }
 
 fn main() {
-    // `from_env` panics on the web
-    #[cfg(not(target_arch = "wasm32"))]
-    let args: Args = argh::from_env();
-    #[cfg(target_arch = "wasm32")]
-    let args = Args::from_args(&[], &[]).unwrap();
-
-    let recompute_text = args.recompute_text;
-    let respawn = args.respawn;
-
     let mut app = App::new();
 
     app.add_plugins((
@@ -49,14 +47,23 @@ fn main() {
         LogDiagnosticsPlugin::default(),
     ))
     .insert_resource(WinitSettings::continuous())
-    .insert_resource(args)
     .add_systems(Startup, (setup_camera, setup_text));
 
-    if recompute_text {
-        app.add_systems(Update, recompute_texts);
+    // `from_env` panics on the web
+    #[cfg(not(target_arch = "wasm32"))]
+    let args: Args = argh::from_env();
+    #[cfg(target_arch = "wasm32")]
+    let args = Args::from_args(&[], &[]).unwrap();
+
+    if args.set_text_changed {
+        app.add_systems(Update, set_changed::<Text>);
     }
 
-    if respawn {
+    if args.set_font_changed {
+        app.add_systems(Update, set_changed::<TextFont>);
+    }
+
+    if args.respawn {
         app.add_systems(Update, (despawn_text, setup_text).chain());
     }
 
@@ -123,13 +130,13 @@ fn setup_text(mut commands: Commands, asset_server: Res<AssetServer>, _args: Res
                                 ));
                                 let layout = TextLayout { justify, linebreak };
                                 parent.spawn((
-                                    Text::new(LOREM_TEXT),
+                                    Text::new(LOREM_TEXT_1),
                                     layout,
                                     text_font.clone().with_font_size(11.),
                                     TextColor::from(bevy::color::palettes::css::NAVY),
                                 ));
                                 parent.spawn((
-                                    Text::new(LOREM_TEXT),
+                                    Text::new(LOREM_TEXT_1),
                                     layout,
                                     text_font.clone().with_font_size(12.),
                                     TextColor::from(bevy::color::palettes::css::PALE_GREEN),
@@ -141,9 +148,9 @@ fn setup_text(mut commands: Commands, asset_server: Res<AssetServer>, _args: Res
         });
 }
 
-fn recompute_texts(mut text_query: Query<&mut Text>) {
-    for mut text in &mut text_query {
-        text.set_changed();
+fn set_changed<C: Component<Mutability = Mutable>>(mut component_query: Query<&mut C>) {
+    for mut component in &mut component_query {
+        component.set_changed();
     }
 }
 

--- a/examples/stress_tests/many_text.rs
+++ b/examples/stress_tests/many_text.rs
@@ -8,6 +8,8 @@ use bevy::{
     winit::WinitSettings,
 };
 
+const LOREM_TEXT: &str = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
+
 #[derive(FromArgs, Resource)]
 /// `many_text` UI text stress test
 struct Args {
@@ -88,7 +90,7 @@ fn setup_text(mut commands: Commands, asset_server: Res<AssetServer>, _args: Res
                 "fonts/MonaSans-VariableFont.ttf",
             ] {
                 let font = asset_server.load(font_path);
-                let text_font =  TextFont {
+                let text_font = TextFont {
                     font: font.into(),
                     font_size: px(10).into(),
                     ..default()
@@ -102,34 +104,37 @@ fn setup_text(mut commands: Commands, asset_server: Res<AssetServer>, _args: Res
                         ..default()
                     })
                     .with_children(|parent| {
-                        parent.spawn((Text(format!("{font_path}")),text_font.clone()));                            
+                        parent.spawn((Text(format!("{font_path}")), text_font.clone()));
                         for justify in [
                             Justify::Left,
                             Justify::Center,
                             Justify::Right,
                             Justify::Justified,
-                        ]{
+                        ] {
                             for linebreak in [LineBreak::AnyCharacter, LineBreak::WordBoundary] {
-                                parent.spawn((Text(format!("Justify::{justify:?}\n LineBreak::{linebreak:?}")),text_font.clone(), TextColor::from(bevy::color::palettes::css::YELLOW)));                            
-                                let layout =  TextLayout {
-                                    justify,
-                                    linebreak,
-                                };
                                 parent.spawn((
-                                    Text::new("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."),
-                                    layout,
+                                    Text(format!(
+                                        "Justify::{justify:?}\n LineBreak::{linebreak:?}"
+                                    )),
                                     text_font.clone(),
+                                    TextColor::from(bevy::color::palettes::css::YELLOW),
+                                ));
+                                let layout = TextLayout { justify, linebreak };
+                                parent.spawn((
+                                    Text::new(LOREM_TEXT),
+                                    layout,
+                                    text_font.clone().with_font_size(11.),
                                     TextColor::from(bevy::color::palettes::css::NAVY),
                                 ));
                                 parent.spawn((
-                                    Text::new("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."),
+                                    Text::new(LOREM_TEXT),
                                     layout,
                                     text_font.clone().with_font_size(12.),
                                     TextColor::from(bevy::color::palettes::css::PALE_GREEN),
                                 ));
+                            }
                         }
-                    }
-                });
+                    });
             }
         });
 }

--- a/examples/stress_tests/many_text.rs
+++ b/examples/stress_tests/many_text.rs
@@ -78,7 +78,7 @@ fn setup_camera(mut commands: Commands) {
     commands.spawn(Camera2d);
 }
 
-fn setup_text(mut commands: Commands, asset_server: Res<AssetServer>, _args: Res<Args>) {
+fn setup_text(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands
         .spawn((
             Node {

--- a/examples/stress_tests/many_text.rs
+++ b/examples/stress_tests/many_text.rs
@@ -5,6 +5,7 @@ use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     ecs::component::Mutable,
     prelude::*,
+    text::FontAtlasSet,
     window::{PresentMode, WindowResolution},
     winit::WinitSettings,
 };
@@ -31,6 +32,10 @@ struct Args {
     /// at the start of each frame despawn any existing UI nodes and spawn a new UI tree
     #[argh(switch)]
     respawn: bool,
+
+    /// at the start of each frame clear all font atlases
+    #[argh(switch)]
+    clear_font_atlases: bool,
 }
 
 fn main() {
@@ -63,6 +68,10 @@ fn main() {
 
     if args.respawn {
         app.add_systems(Update, (despawn_layout, setup_text).chain());
+    }
+
+    if args.clear_font_atlases {
+        app.add_systems(Update, clear_all_font_atlases);
     }
 
     app.add_systems(Update, update_lorem_text);
@@ -191,6 +200,10 @@ fn set_changed<C: Component<Mutability = Mutable>>(mut component_query: Query<&m
 
 fn despawn_layout(mut commands: Commands, root_node: Single<Entity, With<ManyTextRoot>>) {
     commands.entity(*root_node).despawn();
+}
+
+fn clear_all_font_atlases(mut font_atlases: ResMut<FontAtlasSet>) {
+    font_atlases.clear();
 }
 
 fn update_lorem_text(mut lorem_text_query: Query<(&mut Text, &mut Lorem)>) {

--- a/examples/stress_tests/many_text.rs
+++ b/examples/stress_tests/many_text.rs
@@ -2,30 +2,33 @@
 
 use argh::FromArgs;
 use bevy::{
-    color::palettes::css::ORANGE_RED,
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     prelude::*,
-    text::TextColor,
     window::{PresentMode, WindowResolution},
     winit::WinitSettings,
 };
 
-const FONT_SIZE: FontSize = FontSize::Px(7.0);
-
 #[derive(FromArgs, Resource)]
+/// `many_text` UI text stress test
 struct Args {
-    /// At the start of each frame despawn any existing UI nodes and spawn a new UI tree
+    /// whether to force the text to recompute every frame by triggering change detection.
+    #[argh(switch)]
+    recompute_text: bool,
+
+    /// at the start of each frame despawn any existing UI nodes and spawn a new UI tree
     #[argh(switch)]
     respawn: bool,
 }
 
-/// This example shows what happens when there is a lot of buttons on screen.
 fn main() {
     // `from_env` panics on the web
     #[cfg(not(target_arch = "wasm32"))]
     let args: Args = argh::from_env();
     #[cfg(target_arch = "wasm32")]
     let args = Args::from_args(&[], &[]).unwrap();
+
+    let recompute_text = args.recompute_text;
+    let respawn = args.respawn;
 
     let mut app = App::new();
 
@@ -42,27 +45,101 @@ fn main() {
         LogDiagnosticsPlugin::default(),
     ))
     .insert_resource(WinitSettings::continuous())
-    .add_systems(Startup, setup)
-    .add_systems(Update, update);
+    .insert_resource(args)
+    .add_systems(Startup, (setup_camera, setup_text));
+
+    if recompute_text {
+        app.add_systems(Update, recompute_texts);
+    }
+
+    if respawn {
+        app.add_systems(Update, (despawn_text, setup_text).chain());
+    }
+
+    app.run();
 }
 
-fn column() -> Bundle {}
+#[derive(Component)]
+struct ManyTextRoot;
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn setup_camera(mut commands: Commands) {
+    warn!(include_str!("warning_string.txt"));
     commands.spawn(Camera2d);
+}
 
-    let root = commands
-        .spawn((Node {
-            display: Display::Grid,
-        },))
-        .id();
+fn setup_text(mut commands: Commands, asset_server: Res<AssetServer>, args: Res<Args>) {
+    commands
+        .spawn((
+            Node {
+                display: Display::Flex,
+                flex_direction: FlexDirection::Row,
+                width: percent(100),
+                height: percent(100),
+                overflow: Overflow::clip(),
+                ..default()
+            },
+            ManyTextRoot,
+        ))
+        .with_children(|parent| {
+            for font_path in [
+                "fonts/EBGaramond12-Regular.otf",
+                "fonts/FiraMono-Medium.ttf",
+                "fonts/FiraSans-Bold.ttf",
+                "fonts/MonaSans-VariableFont.ttf",
+            ] {
+                let font = asset_server.load(font_path);
+                let text_font =  TextFont {
+                    font: font.into(),
+                    font_size: px(10).into(),
+                    ..default()
+                };
+                parent
+                    .spawn(Node {
+                        display: Display::Flex,
+                        flex_direction: FlexDirection::Column,
+                        flex_grow: 1.0,
+                        overflow: Overflow::clip(),
+                        ..default()
+                    })
+                    .with_children(|parent| {
+                        parent.spawn((Text(format!("font_path")),text_font.clone()));                            
+                        for (justify, linebreak) in [
+                            Justify::Left,
+                            Justify::Center,
+                            Justify::Right,
+                            Justify::Justified,
+                        ].into_iter().zip([LineBreak::AnyCharacter, LineBreak::WordBoundary]) {
 
-    for font_path in [
-        "EBGaramond12-Regular.otf",
-        "FiraMono-Medium.ttf",
-        "FiraSans-Bold.ttf",
-        "MonaSans-VariableFont.ttf",
-    ] {
-        let font = asset_server.load(format!("fonts/{font_path}"));
+                            parent.spawn((Text(format!("Justify::{justify:?}\n LineBreak::{linebreak:?}")),text_font.clone(), TextColor::from(bevy::color::palettes::css::YELLOW)));                            
+                            let layout =  TextLayout {
+                                justify,
+                                linebreak,
+                            };
+                            parent.spawn((
+                                Text::new("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."),
+                                layout,
+                                text_font.clone(),
+                                TextColor::from(bevy::color::palettes::css::NAVY),
+                            ));
+                             parent.spawn((
+                                Text::new("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."),
+                                layout,
+                                text_font.clone().with_font_size(12.),
+                                TextColor::from(bevy::color::palettes::css::PALE_GREEN),
+                            ));
+
+                        }
+                    });
+            }
+        });
+}
+
+fn recompute_texts(mut text_query: Query<&mut Text>) {
+    for mut text in &mut text_query {
+        text.set_changed();
     }
+}
+
+fn despawn_text(mut commands: Commands, root_node: Single<Entity, With<ManyTextRoot>>) {
+    commands.entity(*root_node).despawn();
 }


### PR DESCRIPTION
# Objective

Text layout updates take much longer than in 0.18.

## Solution

`update_text_layout_info` was building a new Swash `Scaler` for every run.

Instead, only build a new `Scaler` when it is needed to rasterize new glyphs.

Also added a `clear` method to `FontAtlasSets`. This is used by the `many_text` example with the `--clear-font-atlases` arg to bench glyph rasterization.

## Testing

Includes a new text benchmark `many_text`:

```
cargo run --example many_text --release
```

On my computer on main it reports ~35fps, with this branch ~130fps.
