### PR TITLE
bevy_scene: don't use std Result

### DIFF
--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -242,7 +242,7 @@ where
         self,
         context: &mut ResolveContext,
         scenes: &mut Vec<ResolvedScene>,
-    ) -> std::prelude::v1::Result<(), ResolveSceneError> {
+    ) -> Result<(), ResolveSceneError> {
         self.map(|scene_list| scene_list.resolve_list(context, scenes))
             .unwrap_or(Ok(()))
     }


### PR DESCRIPTION
# Objective

- bevy_scene doesn't build in non std

```
error: used import from `std` instead of `core`
   --> crates/bevy_scene/src/scene.rs:245:10
    |
245 |     ) -> std::prelude::v1::Result<(), ResolveSceneError> {
    |          ^^^ help: consider importing the item from `core`: `core`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.96.0/index.html#std_instead_of_core
    = note: `-D clippy::std-instead-of-core` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::std_instead_of_core)]`

error: could not compile `bevy_scene` (lib) due to 1 previous error
```

- triggered on 0.19 CI: https://github.com/bevyengine/bevy/actions/runs/27730550478/job/82036465625

## Solution

- don't use std `Result`

## Testing

- Built locally
